### PR TITLE
Phase 1: psmux-bridge CLI with Read Guard and label management

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,64 @@
+# winsmux
+
+## Mission
+smux の Windows ネイティブ版を実装する。psmux をバックエンドに使い、
+WSL2 不要で PowerShell 上で AI エージェント間のクロスペイン通信を実現する。
+
+## Architecture
+```
+winsmux/
+├── scripts/psmux-bridge.ps1    ← 核心。psmux の高レベル CLI ラッパー
+├── install.ps1                 ← ワンコマンドインストーラー
+├── .psmux.conf                 ← psmux 設定（smux の .tmux.conf ベース）
+├── skills/winsmux/SKILL.md     ← エージェント向けスキル定義
+├── tests/test-bridge.ps1       ← 手動テストスクリプト
+├── CLAUDE.md                   ← このファイル
+└── README.md
+```
+
+## Design Docs
+- `.references/winsmux-design.md` — 詳細設計書
+- `.references/winsmux-handoff.md` — 引き継ぎ指示書
+- `.references/winsmux-implementation-plan.md` — 実装計画
+
+## Rules
+
+### 共通
+1. psmux コマンドは `psmux` を使う（`tmux` エイリアスは使わない）
+2. PowerShell 7（pwsh）必須。5.1 構文は使わない
+3. UTF-8: スクリプト先頭で `[Console]::OutputEncoding = [System.Text.Encoding]::UTF8`
+
+### psmux-bridge
+4. Read Guard: type/keys の前に必ず read が必要。マーク管理は `$env:TEMP\winsmux\read_marks\`
+5. ラベル管理: `$env:APPDATA\winsmux\labels.json`（psmux の @name オプションはペイン単位で動かないため）
+6. ターゲット検証: 操作前に `psmux display-message -t $target -p '#{pane_id}'` で存在確認
+7. message ヘッダー: `[psmux-bridge from:<name> pane:<id> at:<s:w.p> -- load the winsmux skill to reply]`
+8. ファイル名エスケープ: ペインID の `%` と `:` は `_` に置換
+
+### Git
+9. コミットメッセージは英語
+10. フェーズごとにブランチ → PR → squash merge
+
+## Phases
+
+| Phase | 内容 | 状態 |
+|-------|------|------|
+| 0 | psmux インストール・検証 | ✅ 完了 |
+| 1 | psmux-bridge.ps1 + CLAUDE.md + tests | 🔄 進行中 |
+| 2 | install.ps1 + .psmux.conf | ⬜ 未着手 |
+| 3 | SKILL.md + references | ⬜ 未着手 |
+
+## Testing
+psmux セッション内で `tests/test-bridge.ps1` を実行。
+手動で 2 ペイン以上のセッションを作成してからテストする。
+
+```powershell
+psmux new-session -d -s test
+psmux split-window -h -t test
+pwsh tests/test-bridge.ps1
+```
+
+## References
+- smux: https://github.com/ShawnPana/smux
+- psmux: https://github.com/psmux/psmux
+- smux SKILL.md: https://github.com/ShawnPana/smux/blob/main/skills/smux/SKILL.md

--- a/scripts/psmux-bridge.ps1
+++ b/scripts/psmux-bridge.ps1
@@ -1,0 +1,335 @@
+[CmdletBinding()]
+param(
+    [Parameter(Position=0)][string]$Command,
+    [Parameter(Position=1)][string]$Target,
+    [Parameter(Position=2, ValueFromRemainingArguments=$true)][string[]]$Rest
+)
+
+# --- Config ---
+$VERSION = "1.0.0"
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+$ErrorActionPreference = 'Stop'
+
+$ReadMarkDir = Join-Path $env:TEMP "winsmux\read_marks"
+$LabelsFile  = Join-Path $env:APPDATA "winsmux\labels.json"
+
+# --- Helper: Stop-WithError ---
+function Stop-WithError {
+    param([string]$Message)
+    Write-Error $Message
+    exit 1
+}
+
+# --- Helper: Labels ---
+function Get-Labels {
+    if (Test-Path $LabelsFile) {
+        $raw = Get-Content -Path $LabelsFile -Raw -Encoding UTF8
+        if ([string]::IsNullOrWhiteSpace($raw)) { return @{} }
+        $obj = $raw | ConvertFrom-Json
+        $ht = @{}
+        $obj.PSObject.Properties | ForEach-Object { $ht[$_.Name] = $_.Value }
+        return $ht
+    }
+    return @{}
+}
+
+function Save-Labels {
+    param([hashtable]$Labels)
+    $dir = Split-Path $LabelsFile -Parent
+    if (-not (Test-Path $dir)) {
+        New-Item -ItemType Directory -Path $dir -Force | Out-Null
+    }
+    $Labels | ConvertTo-Json | Set-Content -Path $LabelsFile -Encoding UTF8
+}
+
+# --- Helper: Resolve-Target ---
+function Resolve-Target {
+    param([string]$RawTarget)
+    $labels = Get-Labels
+    if ($labels.ContainsKey($RawTarget)) {
+        return $labels[$RawTarget]
+    }
+    return $RawTarget
+}
+
+# --- Helper: Confirm-Target ---
+function Confirm-Target {
+    param([string]$PaneId)
+    try {
+        $result = & psmux display-message -t $PaneId -p '#{pane_id}' 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            Stop-WithError "invalid target: $PaneId"
+        }
+        return ($result | Out-String).Trim()
+    } catch {
+        Stop-WithError "invalid target: $PaneId"
+    }
+}
+
+# --- Helper: Read Mark ---
+function Get-ReadMarkPath {
+    param([string]$PaneId)
+    $safe = $PaneId -replace '[%:]', '_'
+    return Join-Path $ReadMarkDir $safe
+}
+
+function Set-ReadMark {
+    param([string]$PaneId)
+    $path = Get-ReadMarkPath $PaneId
+    if (-not (Test-Path $ReadMarkDir)) {
+        New-Item -ItemType Directory -Path $ReadMarkDir -Force | Out-Null
+    }
+    New-Item -ItemType File -Path $path -Force | Out-Null
+}
+
+function Assert-ReadMark {
+    param([string]$PaneId)
+    $path = Get-ReadMarkPath $PaneId
+    if (-not (Test-Path $path)) {
+        Stop-WithError "error: must read the pane before interacting. Run: psmux-bridge read $PaneId"
+    }
+}
+
+function Clear-ReadMark {
+    param([string]$PaneId)
+    $path = Get-ReadMarkPath $PaneId
+    if (Test-Path $path) {
+        Remove-Item -Path $path -Force
+    }
+}
+
+# --- Commands ---
+
+function Invoke-Id {
+    if ($env:TMUX_PANE) {
+        Write-Output $env:TMUX_PANE
+    } else {
+        $id = & psmux display-message -p '#{pane_id}'
+        Write-Output ($id | Out-String).Trim()
+    }
+}
+
+function Invoke-List {
+    $raw = & psmux list-panes -a -F '#{pane_id} #{pane_pid} #{pane_current_command} #{pane_width}x#{pane_height} #{pane_title}'
+    $labels = Get-Labels
+    # Build reverse lookup: paneId -> label
+    $reverseLabels = @{}
+    foreach ($key in $labels.Keys) {
+        $reverseLabels[$labels[$key]] = $key
+    }
+
+    $lines = ($raw | Out-String).Trim() -split "`n"
+    foreach ($line in $lines) {
+        $trimmed = $line.Trim()
+        if ([string]::IsNullOrWhiteSpace($trimmed)) { continue }
+
+        # Parse pane_id and pane_pid from the line
+        $parts = $trimmed -split '\s+', 5
+        $paneId  = $parts[0]
+        $panePid = $parts[1]
+
+        # Detect child process name
+        $childCmd = ""
+        try {
+            $children = Get-CimInstance Win32_Process -Filter "ParentProcessId = $panePid" -ErrorAction SilentlyContinue
+            if ($children) {
+                $child = $children | Select-Object -First 1
+                $childCmd = $child.Name
+            }
+        } catch { }
+
+        # Build output line
+        $output = $trimmed
+        if ($childCmd) {
+            $output += " ($childCmd)"
+        }
+        if ($reverseLabels.ContainsKey($paneId)) {
+            $output += " [$($reverseLabels[$paneId])]"
+        }
+        Write-Output $output
+    }
+}
+
+function Invoke-Read {
+    if (-not $Target) { Stop-WithError "usage: psmux-bridge read <target> [lines]" }
+
+    $lines = 50
+    if ($Rest -and $Rest.Count -gt 0) {
+        $lines = [int]$Rest[0]
+    }
+
+    $paneId = Resolve-Target $Target
+    $paneId = Confirm-Target $paneId
+
+    $output = & psmux capture-pane -t $paneId -p -J -S "-$lines"
+    Write-Output ($output | Out-String).TrimEnd()
+
+    Set-ReadMark $paneId
+}
+
+function Invoke-Type {
+    if (-not $Target) { Stop-WithError "usage: psmux-bridge type <target> <text>" }
+    if (-not $Rest -or $Rest.Count -eq 0) { Stop-WithError "usage: psmux-bridge type <target> <text>" }
+
+    $text = $Rest -join ' '
+    $paneId = Resolve-Target $Target
+    $paneId = Confirm-Target $paneId
+
+    Assert-ReadMark $paneId
+
+    & psmux send-keys -t $paneId -l -- "$text"
+
+    Clear-ReadMark $paneId
+}
+
+function Invoke-Keys {
+    if (-not $Target) { Stop-WithError "usage: psmux-bridge keys <target> <key>..." }
+    if (-not $Rest -or $Rest.Count -eq 0) { Stop-WithError "usage: psmux-bridge keys <target> <key>..." }
+
+    $paneId = Resolve-Target $Target
+    $paneId = Confirm-Target $paneId
+
+    Assert-ReadMark $paneId
+
+    foreach ($key in $Rest) {
+        & psmux send-keys -t $paneId $key
+    }
+
+    Clear-ReadMark $paneId
+}
+
+function Invoke-Message {
+    if (-not $Target) { Stop-WithError "usage: psmux-bridge message <target> <text>" }
+    if (-not $Rest -or $Rest.Count -eq 0) { Stop-WithError "usage: psmux-bridge message <target> <text>" }
+
+    $text = $Rest -join ' '
+    $paneId = Resolve-Target $Target
+    $paneId = Confirm-Target $paneId
+
+    Assert-ReadMark $paneId
+
+    $myId = (& psmux display-message -p '#{pane_id}' | Out-String).Trim()
+    $myCoord = (& psmux display-message -p '#{session_name}:#{window_index}.#{pane_index}' | Out-String).Trim()
+    $agentName = if ($env:WINSMUX_AGENT_NAME) { $env:WINSMUX_AGENT_NAME } else { "unknown" }
+
+    $header = "[psmux-bridge from:$agentName pane:$myId at:$myCoord -- load the winsmux skill to reply]"
+    & psmux send-keys -t $paneId -l -- "$header $text"
+
+    Clear-ReadMark $paneId
+}
+
+function Invoke-Name {
+    if (-not $Target) { Stop-WithError "usage: psmux-bridge name <target> <label>" }
+    if (-not $Rest -or $Rest.Count -eq 0) { Stop-WithError "usage: psmux-bridge name <target> <label>" }
+
+    $label = $Rest[0]
+    $paneId = Resolve-Target $Target
+    $paneId = Confirm-Target $paneId
+
+    $labels = Get-Labels
+    $labels[$label] = $paneId
+    Save-Labels $labels
+
+    # Also set pane title (best-effort)
+    try {
+        & psmux select-pane -t $paneId -T "$label" 2>$null
+    } catch { }
+
+    Write-Output "Labeled pane $paneId as '$label'"
+}
+
+function Invoke-Resolve {
+    if (-not $Target) { Stop-WithError "usage: psmux-bridge resolve <label>" }
+
+    $labels = Get-Labels
+    if ($labels.ContainsKey($Target)) {
+        Write-Output $labels[$Target]
+    } else {
+        Stop-WithError "label not found: $Target"
+    }
+}
+
+function Invoke-Doctor {
+    Write-Output "=== psmux-bridge doctor ==="
+
+    # psmux install check
+    try {
+        $ver = & psmux -V 2>&1
+        Write-Output "psmux: $($ver | Out-String)".Trim()
+    } catch {
+        Write-Output "psmux: NOT FOUND"
+    }
+
+    # TMUX_PANE
+    if ($env:TMUX_PANE) {
+        Write-Output "TMUX_PANE: $env:TMUX_PANE"
+    } else {
+        Write-Output "TMUX_PANE: (not set)"
+    }
+
+    # WINSMUX_AGENT_NAME
+    if ($env:WINSMUX_AGENT_NAME) {
+        Write-Output "WINSMUX_AGENT_NAME: $env:WINSMUX_AGENT_NAME"
+    } else {
+        Write-Output "WINSMUX_AGENT_NAME: (not set)"
+    }
+
+    # Pane count
+    try {
+        $panes = & psmux list-panes -a -F '#{pane_id}'
+        $count = (($panes | Out-String).Trim() -split "`n" | Where-Object { $_.Trim() }).Count
+        Write-Output "Panes: $count"
+    } catch {
+        Write-Output "Panes: (error listing)"
+    }
+
+    # Labels
+    $labels = Get-Labels
+    Write-Output "Labels: $($labels.Count) in $LabelsFile"
+
+    # Read marks
+    if (Test-Path $ReadMarkDir) {
+        $marks = (Get-ChildItem -Path $ReadMarkDir -File).Count
+        Write-Output "Read marks: $marks in $ReadMarkDir"
+    } else {
+        Write-Output "Read marks: 0 (directory not created yet)"
+    }
+}
+
+function Invoke-Version {
+    Write-Output "psmux-bridge $VERSION"
+}
+
+function Show-Usage {
+    Write-Output @"
+psmux-bridge $VERSION - psmux bridge for winsmux
+
+Commands:
+  id                        Show current pane ID
+  list                      List all panes
+  read <target> [lines]     Capture pane output (default 50 lines)
+  type <target> <text>      Send literal text to pane
+  keys <target> <key>...    Send key sequences to pane
+  message <target> <text>   Send a tagged message to pane
+  name <target> <label>     Label a pane
+  resolve <label>           Resolve label to pane ID
+  doctor                    Check environment
+  version                   Show version
+"@
+}
+
+# --- Dispatch ---
+switch ($Command) {
+    'id'       { Invoke-Id }
+    'list'     { Invoke-List }
+    'read'     { Invoke-Read }
+    'type'     { Invoke-Type }
+    'keys'     { Invoke-Keys }
+    'message'  { Invoke-Message }
+    'name'     { Invoke-Name }
+    'resolve'  { Invoke-Resolve }
+    'doctor'   { Invoke-Doctor }
+    'version'  { Invoke-Version }
+    ''         { Show-Usage }
+    default    { Stop-WithError "unknown command: $Command. Run without arguments for usage." }
+}

--- a/tests/test-bridge.ps1
+++ b/tests/test-bridge.ps1
@@ -1,0 +1,137 @@
+# test-bridge.ps1 — psmux-bridge manual test runner
+# Usage: Run inside a psmux session with 2+ panes
+#   psmux new-session -d -s test
+#   psmux split-window -h -t test
+#   pwsh tests/test-bridge.ps1
+
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+$ErrorActionPreference = 'Stop'
+
+$BRIDGE = Join-Path $PSScriptRoot "..\scripts\psmux-bridge.ps1"
+$passed = 0
+$failed = 0
+
+function Test-Case {
+    param([string]$Name, [scriptblock]$Block)
+    try {
+        & $Block
+        Write-Host "[PASS] $Name" -ForegroundColor Green
+        $script:passed++
+    } catch {
+        Write-Host "[FAIL] $Name — $($_.Exception.Message)" -ForegroundColor Red
+        $script:failed++
+    }
+}
+
+# Get pane list to find targets
+$panes = & pwsh $BRIDGE list
+$allPanes = $panes -split "`n" | Where-Object { $_ -match '^%\d+' } | ForEach-Object { ($_ -split ' ')[0] }
+if ($allPanes.Count -lt 2) {
+    Write-Error "Need at least 2 panes. Run: psmux split-window -h"
+    exit 1
+}
+$pane1 = $allPanes[0]
+$pane2 = $allPanes[1]
+Write-Host "Testing with panes: $pane1, $pane2`n"
+
+# --- Test 1: version ---
+Test-Case "version command" {
+    $out = & pwsh $BRIDGE version
+    if ($out -notmatch 'psmux-bridge') { throw "unexpected output: $out" }
+}
+
+# --- Test 2: list ---
+Test-Case "list shows panes" {
+    $out = & pwsh $BRIDGE list
+    if ($out -notmatch '%\d+') { throw "no pane IDs in output" }
+}
+
+# --- Test 3: id ---
+Test-Case "id returns pane ID" {
+    $out = & pwsh $BRIDGE id
+    if ($out -notmatch '%?\d+') { throw "unexpected id: $out" }
+}
+
+# --- Test 4: read ---
+Test-Case "read captures pane content" {
+    $out = & pwsh $BRIDGE read $pane1 5
+    # read should succeed (may return empty lines for new pane)
+}
+
+# --- Test 5: Read Guard blocks type without read ---
+Test-Case "Read Guard blocks type without prior read" {
+    # Clear any existing read marks
+    $markDir = Join-Path $env:TEMP "winsmux\read_marks"
+    if (Test-Path $markDir) { Remove-Item "$markDir\*" -Force -ErrorAction SilentlyContinue }
+
+    try {
+        & pwsh $BRIDGE type $pane1 "should fail" 2>&1
+        throw "type should have been blocked"
+    } catch {
+        if ($_.Exception.Message -notmatch 'must read') {
+            # If it's our "should have been blocked" error, re-throw
+            if ($_.Exception.Message -match 'should have been blocked') { throw }
+            # Otherwise the error message is about read guard - that's expected
+        }
+    }
+}
+
+# --- Test 6: read → type → keys flow ---
+Test-Case "read-type-keys normal flow" {
+    & pwsh $BRIDGE read $pane1 10 | Out-Null
+    & pwsh $BRIDGE type $pane1 "echo winsmux-test"
+    & pwsh $BRIDGE read $pane1 10 | Out-Null
+    & pwsh $BRIDGE keys $pane1 Enter
+}
+
+# --- Test 7: name and resolve ---
+Test-Case "name and resolve label" {
+    & pwsh $BRIDGE name $pane1 "testpane"
+    $resolved = & pwsh $BRIDGE resolve "testpane"
+    $resolved = $resolved.Trim()
+    if ($resolved -ne $pane1) { throw "resolve returned '$resolved', expected '$pane1'" }
+}
+
+# --- Test 8: label-based operations ---
+Test-Case "operations via label" {
+    & pwsh $BRIDGE read "testpane" 5 | Out-Null
+    & pwsh $BRIDGE type "testpane" "echo via-label"
+    & pwsh $BRIDGE read "testpane" 5 | Out-Null
+    & pwsh $BRIDGE keys "testpane" Enter
+}
+
+# --- Test 9: message with header ---
+Test-Case "message sends with header" {
+    $env:WINSMUX_AGENT_NAME = "test-agent"
+    & pwsh $BRIDGE read $pane2 10 | Out-Null
+    & pwsh $BRIDGE message $pane2 "hello from test"
+    # Verify by reading the pane - should contain the header
+    Start-Sleep -Milliseconds 500
+    $content = & pwsh $BRIDGE read $pane2 10
+    $env:WINSMUX_AGENT_NAME = $null
+    if ($content -notmatch 'psmux-bridge from:test-agent') {
+        throw "message header not found in pane content"
+    }
+}
+
+# --- Test 10: doctor ---
+Test-Case "doctor runs without error" {
+    $out = & pwsh $BRIDGE doctor
+    if ($out -notmatch 'psmux') { throw "doctor output missing psmux info" }
+}
+
+# --- Cleanup ---
+$labelFile = Join-Path $env:APPDATA "winsmux\labels.json"
+if (Test-Path $labelFile) {
+    $labels = Get-Content $labelFile | ConvertFrom-Json
+    $labels.PSObject.Properties.Remove("testpane")
+    $labels | ConvertTo-Json | Set-Content $labelFile -Encoding UTF8
+}
+$markDir = Join-Path $env:TEMP "winsmux\read_marks"
+if (Test-Path $markDir) { Remove-Item "$markDir\*" -Force -ErrorAction SilentlyContinue }
+
+# --- Summary ---
+Write-Host "`n========================"
+Write-Host "Results: $passed passed, $failed failed" -ForegroundColor $(if ($failed -eq 0) { 'Green' } else { 'Red' })
+Write-Host "========================"
+exit $failed


### PR DESCRIPTION
## Summary
- Add `scripts/psmux-bridge.ps1` — core CLI with 10 commands (list, read, type, keys, message, name, resolve, id, doctor, version)
- Add `CLAUDE.md` — project instructions for Claude Code
- Add `tests/test-bridge.ps1` — manual test suite (10 test cases)

### Key features
- **Read Guard**: type/keys require prior read to prevent blind pane interaction
- **Label management**: JSON-based pane labeling (`$env:APPDATA\winsmux\labels.json`)
- **Target validation**: validates pane existence before operations
- **Message protocol**: `[psmux-bridge from:<name> pane:<id> at:<s:w.p>]` header format
- **UTF-8**: explicit encoding setup for Windows compatibility

## Test plan
- [ ] `psmux-bridge list` shows panes with process info
- [ ] `psmux-bridge read %0 20` captures content and sets read mark
- [ ] `psmux-bridge type %0 "text"` blocked without prior read (Read Guard)
- [ ] read → type → keys flow works end-to-end
- [ ] `psmux-bridge name/resolve` label roundtrip
- [ ] `psmux-bridge message` sends with correct header
- [ ] `psmux-bridge doctor` reports environment status

🤖 Generated with [Claude Code](https://claude.com/claude-code)