### PR TITLE
Phase 2: installer and psmux configuration

### DIFF
--- a/.psmux.conf
+++ b/.psmux.conf
@@ -1,0 +1,52 @@
+# winsmux — psmux configuration for Windows
+# Based on smux .tmux.conf (https://github.com/ShawnPana/smux)
+
+# --- General ---
+set -g mouse on
+set -g history-limit 10000
+set -g base-index 1
+set -g pane-base-index 1
+set -g default-shell pwsh
+set -g default-command pwsh
+
+# --- Status bar ---
+set -g status-style "bg=#1e1e2e,fg=#cdd6f4"
+set -g status-left "[#S] "
+set -g status-right "%H:%M"
+set -g status-left-length 20
+
+# --- Pane borders ---
+set -g pane-border-style "fg=#45475a"
+set -g pane-active-border-style "fg=#89b4fa"
+set -g pane-border-lines heavy
+set -g pane-border-status top
+set -g pane-border-format " #{?#{pane_title},#{pane_title},#{b:pane_current_path}} "
+
+# --- Alt keybindings (smux compatible) ---
+
+# Pane navigation (no wrap)
+bind-key -n M-i select-pane -U
+bind-key -n M-k select-pane -D
+bind-key -n M-j select-pane -L
+bind-key -n M-l select-pane -R
+
+# Pane management
+bind-key -n M-n split-window -h \; select-layout tiled
+bind-key -n M-w kill-pane
+bind-key -n M-o next-layout
+
+# Pane mark and swap
+bind-key -n M-g select-pane -m
+bind-key -n M-y swap-pane
+
+# Window management
+bind-key -n M-m new-window
+bind-key -n M-u next-window
+bind-key -n M-h previous-window
+
+# Scroll mode (copy mode)
+bind-key -n M-Tab copy-mode
+bind-key -T copy-mode i send-keys -X scroll-up
+bind-key -T copy-mode k send-keys -X scroll-down
+bind-key -T copy-mode I send-keys -X halfpage-up
+bind-key -T copy-mode K send-keys -X halfpage-down

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,265 @@
+# install.ps1 — winsmux one-command installer
+# Usage: irm https://raw.githubusercontent.com/Sora-bluesky/winsmux/main/install.ps1 | iex
+# Or: pwsh install.ps1 [install|update|uninstall|version|help]
+
+[CmdletBinding()]
+param(
+    [Parameter(Position=0)][string]$Action = "install"
+)
+
+$ErrorActionPreference = 'Stop'
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+
+$VERSION      = "1.0.0"
+$WINSMUX_DIR  = Join-Path $HOME ".winsmux"
+$BIN_DIR      = Join-Path $WINSMUX_DIR "bin"
+$BACKUP_DIR   = Join-Path $WINSMUX_DIR "backups"
+$VERSION_FILE = Join-Path $WINSMUX_DIR "version"
+$BASE_URL     = "https://raw.githubusercontent.com/Sora-bluesky/winsmux/main"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+function Write-Status($msg) { Write-Host "[winsmux] $msg" }
+
+function Test-Administrator {
+    $identity  = [Security.Principal.WindowsIdentity]::GetCurrent()
+    $principal = New-Object Security.Principal.WindowsPrincipal($identity)
+    return $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+}
+
+function Install-Psmux {
+    if (Get-Command psmux -ErrorAction SilentlyContinue) {
+        $ver = (psmux -V 2>&1 | Out-String).Trim()
+        Write-Status "psmux found: $ver"
+        return
+    }
+    Write-Status "psmux not found. Attempting auto-install..."
+
+    if (Get-Command winget -ErrorAction SilentlyContinue) {
+        Write-Status "Installing via winget..."
+        winget install psmux --accept-package-agreements --accept-source-agreements
+        return
+    }
+    if (Get-Command scoop -ErrorAction SilentlyContinue) {
+        Write-Status "Installing via scoop..."
+        scoop bucket add psmux https://github.com/psmux/scoop-psmux 2>$null
+        scoop install psmux
+        return
+    }
+    if (Get-Command cargo -ErrorAction SilentlyContinue) {
+        Write-Status "Installing via cargo..."
+        cargo install psmux
+        return
+    }
+    if (Get-Command choco -ErrorAction SilentlyContinue) {
+        Write-Status "Installing via chocolatey..."
+        choco install psmux -y
+        return
+    }
+    Write-Error "[winsmux] Could not install psmux. Install manually: https://github.com/psmux/psmux"
+    exit 1
+}
+
+function Backup-File($path) {
+    if (Test-Path $path) {
+        $ts   = Get-Date -Format "yyyyMMdd-HHmmss"
+        $name = (Split-Path $path -Leaf) + ".$ts.bak"
+        $dest = Join-Path $BACKUP_DIR $name
+        Copy-Item $path $dest -Force
+        Write-Status "Backed up $(Split-Path $path -Leaf) -> $dest"
+    }
+}
+
+function Download-File($relativeUrl, $destPath) {
+    $url = "$BASE_URL/$relativeUrl"
+    Write-Status "Downloading $relativeUrl ..."
+    try {
+        Invoke-RestMethod -Uri $url -OutFile $destPath -ErrorAction Stop
+    } catch {
+        Write-Error "[winsmux] Failed to download $url : $_"
+        exit 1
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Actions
+# ---------------------------------------------------------------------------
+
+function Invoke-Install {
+    param([switch]$IsUpdate)
+    $label = if ($IsUpdate) { "Updating" } else { "Installing" }
+    Write-Status "$label winsmux v$VERSION ..."
+
+    # 1. PowerShell version check
+    if ($PSVersionTable.PSVersion.Major -lt 7) {
+        Write-Warning "[winsmux] PowerShell 7+ is recommended. You are running $($PSVersionTable.PSVersion). Some features may not work correctly."
+    }
+
+    # 2. Administrator check
+    if (Test-Administrator) {
+        Write-Warning "[winsmux] Running as Administrator is not recommended. Consider running as a normal user."
+    }
+
+    # 3. psmux detection / install
+    Install-Psmux
+
+    # 4. Create directories
+    foreach ($dir in @($WINSMUX_DIR, $BIN_DIR, $BACKUP_DIR, (Join-Path $env:APPDATA "winsmux"))) {
+        if (-not (Test-Path $dir)) {
+            New-Item -ItemType Directory -Path $dir -Force | Out-Null
+        }
+    }
+
+    # 5. Download & place files
+    # psmux-bridge.ps1
+    Download-File "scripts/psmux-bridge.ps1" (Join-Path $BIN_DIR "psmux-bridge.ps1")
+
+    # .psmux.conf (backup existing)
+    $confDest = Join-Path $HOME ".psmux.conf"
+    Backup-File $confDest
+    Download-File ".psmux.conf" $confDest
+
+    # 6. Create .cmd wrappers
+    $bridgeCmd = Join-Path $BIN_DIR "psmux-bridge.cmd"
+    @"
+@echo off
+pwsh -NoProfile -File "%USERPROFILE%\.winsmux\bin\psmux-bridge.ps1" %*
+"@ | Set-Content -Path $bridgeCmd -Encoding ASCII
+
+    $winsmuxCmd = Join-Path $BIN_DIR "winsmux.cmd"
+    @"
+@echo off
+pwsh -NoProfile -File "%USERPROFILE%\.winsmux\bin\winsmux.ps1" %*
+"@ | Set-Content -Path $winsmuxCmd -Encoding ASCII
+
+    # 7. Create winsmux.ps1 CLI wrapper
+    $winsmuxPs1 = Join-Path $BIN_DIR "winsmux.ps1"
+    @'
+# winsmux.ps1 — winsmux CLI wrapper
+param([Parameter(Position=0)][string]$Action = "help")
+$installer = "https://raw.githubusercontent.com/Sora-bluesky/winsmux/main/install.ps1"
+switch ($Action) {
+    "update"    { Invoke-RestMethod $installer | Invoke-Expression }
+    "uninstall" { & pwsh -Command "& { $(Invoke-RestMethod $installer) } uninstall" }
+    "version"   { Get-Content "$HOME\.winsmux\version" -ErrorAction SilentlyContinue }
+    default     {
+        Write-Host "winsmux — Windows terminal multiplexer for AI agents"
+        Write-Host ""
+        Write-Host "Commands:"
+        Write-Host "  winsmux update      Update winsmux to latest"
+        Write-Host "  winsmux uninstall   Remove winsmux"
+        Write-Host "  winsmux version     Show version"
+    }
+}
+'@ | Set-Content -Path $winsmuxPs1 -Encoding UTF8
+
+    # 8. Add to PATH via $PROFILE
+    $profileLine = "`$env:PATH = `"$BIN_DIR;`$env:PATH`""
+    $profilePath = $PROFILE.CurrentUserAllHosts
+    if (-not (Test-Path $profilePath)) {
+        $profileDir = Split-Path $profilePath -Parent
+        if (-not (Test-Path $profileDir)) {
+            New-Item -ItemType Directory -Path $profileDir -Force | Out-Null
+        }
+        New-Item -Path $profilePath -Force | Out-Null
+    }
+    $content = Get-Content $profilePath -Raw -ErrorAction SilentlyContinue
+    if (-not $content -or $content -notmatch 'winsmux') {
+        Add-Content $profilePath "`n# winsmux`n$profileLine"
+    }
+    $env:PATH = "$BIN_DIR;$env:PATH"
+
+    # 9. Record version
+    $VERSION | Set-Content $VERSION_FILE
+
+    # 10. Completion message
+    if ($IsUpdate) {
+        Write-Host ""
+        Write-Status "Updated to v$VERSION!"
+        Write-Host "  psmux-bridge: $(Join-Path $BIN_DIR 'psmux-bridge.ps1')"
+        Write-Host "  psmux config:  $confDest"
+    } else {
+        Write-Host ""
+        Write-Status "Installed successfully! (v$VERSION)"
+        Write-Host "  psmux-bridge: $(Join-Path $BIN_DIR 'psmux-bridge.ps1')"
+        Write-Host "  psmux config:  $confDest"
+        Write-Host ""
+        Write-Host "Next steps:"
+        Write-Host "  1. Start a psmux session:  psmux new-session -s work"
+        Write-Host "  2. Set your agent name:    `$env:WINSMUX_AGENT_NAME = 'claude'"
+        Write-Host "  3. Try it out:             psmux-bridge list"
+    }
+}
+
+function Invoke-Uninstall {
+    Write-Status "Uninstalling winsmux..."
+
+    # 1. Remove ~/.winsmux
+    if (Test-Path $WINSMUX_DIR) {
+        Remove-Item $WINSMUX_DIR -Recurse -Force
+        Write-Status "Removed $WINSMUX_DIR"
+    }
+
+    # 2. Remove ~/.psmux.conf
+    $confPath = Join-Path $HOME ".psmux.conf"
+    if (Test-Path $confPath) {
+        Write-Host "[winsmux] Remove $confPath ? (psmux config file)" -NoNewline
+        Write-Host " [Y/n] " -NoNewline
+        $answer = Read-Host
+        if ($answer -eq '' -or $answer -match '^[Yy]') {
+            Remove-Item $confPath -Force
+            Write-Status "Removed $confPath"
+        } else {
+            Write-Status "Kept $confPath"
+        }
+    }
+
+    # 3. Remove winsmux lines from $PROFILE
+    $profilePath = $PROFILE.CurrentUserAllHosts
+    if (Test-Path $profilePath) {
+        $lines = Get-Content $profilePath
+        $filtered = $lines | Where-Object { $_ -notmatch 'winsmux' }
+        $filtered | Set-Content $profilePath
+        Write-Status "Cleaned $profilePath"
+    }
+
+    # 4. Remove %APPDATA%\winsmux
+    $appDataDir = Join-Path $env:APPDATA "winsmux"
+    if (Test-Path $appDataDir) {
+        Remove-Item $appDataDir -Recurse -Force
+        Write-Status "Removed $appDataDir"
+    }
+
+    # 5. Done (psmux itself is NOT uninstalled)
+    Write-Host ""
+    Write-Status "Uninstalled."
+    Write-Host "  Note: psmux itself was NOT removed. Manage it separately if needed."
+}
+
+function Show-Help {
+    Write-Host @"
+Usage: install.ps1 [action]
+
+Actions:
+  install     Install winsmux (default)
+  update      Update to latest version
+  uninstall   Remove winsmux
+  version     Show version
+  help        Show this help
+"@
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+switch ($Action.ToLower()) {
+    "install"   { Invoke-Install }
+    "update"    { Invoke-Install -IsUpdate }
+    "uninstall" { Invoke-Uninstall }
+    "version"   { Write-Output "winsmux $VERSION" }
+    "help"      { Show-Help }
+    default     { Show-Help }
+}


### PR DESCRIPTION
## Summary
- Add `install.ps1` — one-command installer with auto psmux detection (winget→scoop→cargo→choco)
- Add `.psmux.conf` — smux-compatible psmux configuration with Alt keybindings

### install.ps1 features
- `irm .../install.ps1 | iex` for one-command install
- Auto psmux detection and installation via 4 package managers
- `.cmd` wrapper generation for `psmux-bridge` command
- PATH configuration via `$PROFILE`
- `update` / `uninstall` / `version` subcommands

### .psmux.conf features
- Alt+i/k/j/l pane navigation (smux compatible)
- Alt+n split + auto-tile, Alt+w close, Alt+o cycle layouts
- Mouse support, heavy pane borders, title/path display
- pwsh as default shell

## Test plan
- [ ] `pwsh install.ps1 help` shows usage
- [ ] `pwsh install.ps1 version` shows version
- [ ] Fresh install creates `~/.winsmux/bin/` with scripts and wrappers
- [ ] `.psmux.conf` loads correctly in psmux session

🤖 Generated with [Claude Code](https://claude.com/claude-code)