### PR TITLE
Phase 3: agent skill, CLI reference, and final docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,9 +44,9 @@ winsmux/
 | Phase | 内容 | 状態 |
 |-------|------|------|
 | 0 | psmux インストール・検証 | ✅ 完了 |
-| 1 | psmux-bridge.ps1 + CLAUDE.md + tests | 🔄 進行中 |
-| 2 | install.ps1 + .psmux.conf | ⬜ 未着手 |
-| 3 | SKILL.md + references | ⬜ 未着手 |
+| 1 | psmux-bridge.ps1 + CLAUDE.md + tests | ✅ 完了 |
+| 2 | install.ps1 + .psmux.conf | ✅ 完了 |
+| 3 | SKILL.md + references | ✅ 完了 |
 
 ## Testing
 psmux セッション内で `tests/test-bridge.ps1` を実行。

--- a/README.md
+++ b/README.md
@@ -15,8 +15,15 @@ psmux-bridge keys codex Enter           # press enter
 ## Install
 
 ```powershell
-# TODO: installer
+irm https://raw.githubusercontent.com/Sora-bluesky/winsmux/main/install.ps1 | iex
 ```
+
+This installs:
+- **psmux** if not already installed (via winget, scoop, cargo, or chocolatey)
+- **psmux-bridge** CLI for cross-pane agent communication
+- **.psmux.conf** with Alt-key bindings, mouse support, and pane labels
+
+Everything lives in `~\.winsmux\`.
 
 ## Keybindings
 
@@ -30,6 +37,8 @@ All keybindings use **Alt** with no prefix required.
 | `Alt+n` | New pane (split + auto-tile) |
 | `Alt+w` | Close pane |
 | `Alt+o` | Cycle layouts |
+| `Alt+g` | Mark pane |
+| `Alt+y` | Swap with marked pane |
 
 ### Windows
 
@@ -39,6 +48,15 @@ All keybindings use **Alt** with no prefix required.
 | `Alt+u` | Next window |
 | `Alt+h` | Previous window |
 
+### Scrolling
+
+| Key | Action |
+|---|---|
+| `Alt+Tab` | Toggle scroll mode |
+| `i/k` | Scroll up/down |
+| `Shift+I/K` | Half-page up/down |
+| `q` or `Escape` | Exit scroll mode |
+
 ## psmux-bridge
 
 A CLI for cross-pane communication on Windows. Any tool that can run shell commands can use it — Claude Code, Codex, Gemini CLI, or a plain PowerShell script.
@@ -46,18 +64,40 @@ A CLI for cross-pane communication on Windows. Any tool that can run shell comma
 | Command | Description |
 |---|---|
 | `psmux-bridge list` | Show all panes with target, process, label |
-| `psmux-bridge read <target> [lines]` | Read last N lines from a pane |
+| `psmux-bridge read <target> [lines]` | Read last N lines from a pane (default 50) |
 | `psmux-bridge type <target> <text>` | Type text into a pane (no Enter) |
-| `psmux-bridge keys <target> <key>...` | Send keys (Enter, Escape, Ctrl+C, etc.) |
+| `psmux-bridge keys <target> <key>...` | Send keys (Enter, Escape, C-c, etc.) |
+| `psmux-bridge message <target> <text>` | Send tagged message with sender info |
 | `psmux-bridge name <target> <label>` | Label a pane for easy addressing |
 | `psmux-bridge resolve <label>` | Look up a pane by label |
 | `psmux-bridge id` | Print this pane's ID |
+| `psmux-bridge doctor` | Check environment and diagnostics |
+
+## AI Agent Skills
+
+Install the winsmux skill to teach your agents how to use psmux-bridge:
+
+```powershell
+npx skills add Sora-bluesky/winsmux
+```
+
+## Update
+
+```powershell
+winsmux update
+```
+
+## Uninstall
+
+```powershell
+winsmux uninstall
+```
 
 ## Requirements
 
 - Windows 10/11
-- PowerShell 5.1+ or PowerShell 7+
-- [psmux](https://github.com/nickcox/psmux) (installed automatically)
+- PowerShell 7+ (pwsh)
+- [psmux](https://github.com/psmux/psmux) (installed automatically)
 
 ## Acknowledgments
 

--- a/skills/winsmux/SKILL.md
+++ b/skills/winsmux/SKILL.md
@@ -1,0 +1,218 @@
+---
+name: winsmux
+description: |
+  Control psmux panes and communicate between AI agents on Windows.
+  Use this skill whenever the user mentions pane control, cross-pane communication,
+  sending messages to other agents, reading other panes, or managing psmux sessions on Windows.
+---
+
+# winsmux
+
+Psmux pane control and cross-pane agent communication on Windows. Use `psmux-bridge` (the high-level CLI) for all cross-pane interactions. Fall back to raw psmux commands only when you need low-level control.
+
+## psmux-bridge — Cross-Pane Communication
+
+A CLI that lets any AI agent interact with any other psmux pane. Works via PowerShell. Every command is **atomic**: `type` types text (no Enter), `keys` sends special keys, `read` captures pane content.
+
+### DO NOT WAIT OR POLL
+
+Other panes have agents that will reply to you via psmux-bridge. Their reply appears directly in YOUR pane as a `[psmux-bridge from:...]` message. Do not sleep, poll, read the target pane for a response, or loop. Type your message, press Enter, and move on.
+
+The ONLY time you read a target pane is:
+- **Before** interacting with it (enforced by the read guard)
+- **After typing** to verify your text landed before pressing Enter
+- When interacting with a **non-agent pane** (plain shell, running process)
+
+### Read Guard
+
+The CLI enforces read-before-act. You cannot `type` or `keys` to a pane unless you have read it first.
+
+1. `psmux-bridge read <target>` marks the pane as "read"
+2. `psmux-bridge type/keys <target>` checks for that mark — errors if you haven't read
+3. After a successful `type`/`keys`, the mark is cleared — you must read again before the next interaction
+
+Read marks are stored in `$env:TEMP\winsmux\read_marks\`.
+
+```
+PS> psmux-bridge type codex "hello"
+error: must read the pane before interacting. Run: psmux-bridge read codex
+```
+
+### Command Reference
+
+| Command | Description | Example |
+|---|---|---|
+| `psmux-bridge list` | Show all panes with target, pid, command, size, label | `psmux-bridge list` |
+| `psmux-bridge type <target> <text>` | Type text without pressing Enter | `psmux-bridge type codex "hello"` |
+| `psmux-bridge message <target> <text>` | Type text with auto sender info and reply target | `psmux-bridge message codex "review src/auth.ts"` |
+| `psmux-bridge read <target> [lines]` | Read last N lines (default 50) | `psmux-bridge read codex 100` |
+| `psmux-bridge keys <target> <key>...` | Send special keys | `psmux-bridge keys codex Enter` |
+| `psmux-bridge name <target> <label>` | Label a pane | `psmux-bridge name %3 codex` |
+| `psmux-bridge resolve <label>` | Print pane target for a label | `psmux-bridge resolve codex` |
+| `psmux-bridge id` | Print this pane's ID | `psmux-bridge id` |
+
+### Target Resolution
+
+Targets can be:
+- **psmux native**: pane ID (`%3`), or window index (`0`)
+- **label**: Any string set via `psmux-bridge name` — resolved automatically
+
+Labels are stored in `$env:APPDATA\winsmux\labels.json`.
+
+### Read-Act-Read Cycle
+
+Every interaction follows **read → act → read**. The CLI enforces this.
+
+**Sending a message to an agent:**
+```powershell
+psmux-bridge read codex 20                    # 1. READ — satisfy read guard
+psmux-bridge message codex 'Please review src/auth.ts'
+                                              # 2. MESSAGE — auto-prepends sender info, no Enter
+psmux-bridge read codex 20                    # 3. READ — verify text landed
+psmux-bridge keys codex Enter                 # 4. KEYS — submit
+# STOP. Do NOT read codex for a reply. The agent replies into YOUR pane.
+```
+
+**Approving a prompt (non-agent pane):**
+```powershell
+psmux-bridge read worker 10                   # 1. READ — see the prompt
+psmux-bridge type worker "y"                  # 2. TYPE
+psmux-bridge read worker 10                   # 3. READ — verify
+psmux-bridge keys worker Enter                # 4. KEYS — submit
+psmux-bridge read worker 20                   # 5. READ — see the result
+```
+
+### Messaging Convention
+
+The `message` command auto-prepends sender info and location:
+
+```
+[psmux-bridge from:claude pane:%4 at:s:w.p -- load the winsmux skill to reply]
+```
+
+The receiver gets: who sent it (`from`), the exact pane to reply to (`pane`), and the session/window location (`at`). When you see this header, reply using psmux-bridge to the pane ID from the header.
+
+### Agent-to-Agent Workflow
+
+```powershell
+# 1. Label yourself
+psmux-bridge name (psmux-bridge id) claude
+
+# 2. Discover other panes
+psmux-bridge list
+
+# 3. Send a message (read-act-read)
+psmux-bridge read codex 20
+psmux-bridge message codex 'Please review the changes in src/auth.ts'
+psmux-bridge read codex 20
+psmux-bridge keys codex Enter
+```
+
+### Example Conversation
+
+**Agent A (claude) sends:**
+```powershell
+psmux-bridge read codex 20
+psmux-bridge message codex 'What is the test coverage for src/auth.ts?'
+psmux-bridge read codex 20
+psmux-bridge keys codex Enter
+```
+
+**Agent B (codex) sees in their prompt:**
+```
+[psmux-bridge from:claude pane:%4 at:s:w.p -- load the winsmux skill to reply] What is the test coverage for src/auth.ts?
+```
+
+**Agent B replies using the pane ID from the header:**
+```powershell
+psmux-bridge read %4 20
+psmux-bridge message %4 '87% line coverage. Missing the OAuth refresh token path (lines 142-168).'
+psmux-bridge read %4 20
+psmux-bridge keys %4 Enter
+```
+
+---
+
+## Raw psmux Commands
+
+Use these when you need direct psmux control beyond what psmux-bridge provides — session management, window navigation, creating panes, or low-level scripting.
+
+### Capture Output
+
+```powershell
+psmux capture-pane -t shared | Select-Object -Last 20    # Last 20 lines
+psmux capture-pane -t shared                              # Entire scrollback
+psmux capture-pane -t 'shared:0.0'                        # Specific pane
+```
+
+### Send Keys
+
+```powershell
+psmux send-keys -t shared -l "text here"     # Type text (literal mode)
+psmux send-keys -t shared Enter              # Press Enter
+psmux send-keys -t shared Escape             # Press Escape
+psmux send-keys -t shared C-c                # Ctrl+C
+psmux send-keys -t shared C-d               # Ctrl+D (EOF)
+```
+
+For interactive TUIs, split text and Enter into separate sends:
+```powershell
+psmux send-keys -t shared -l "Please apply the patch"
+Start-Sleep -Milliseconds 100
+psmux send-keys -t shared Enter
+```
+
+### Panes and Windows
+
+```powershell
+# Create panes (prefer over new windows)
+psmux split-window -h -t SESSION              # Horizontal split
+psmux split-window -v -t SESSION              # Vertical split
+psmux select-layout -t SESSION tiled          # Re-balance
+
+# Navigate
+psmux select-window -t shared:0
+psmux select-pane -t 'shared:0.1'
+psmux list-windows -t shared
+```
+
+### Session Management
+
+```powershell
+psmux list-sessions
+psmux new-session -d -s newsession
+psmux kill-session -t sessionname
+psmux rename-session -t old new
+```
+
+### Claude Code Patterns
+
+```powershell
+# Check if session needs input
+psmux capture-pane -t worker-3 | Select-Object -Last 10 |
+  Select-String -Pattern '❯|Yes.*No|proceed|permission'
+
+# Approve a prompt
+psmux send-keys -t worker-3 -l 'y'
+psmux send-keys -t worker-3 Enter
+
+# Check all sessions
+foreach ($s in @('shared','worker-2','worker-3','worker-4')) {
+    Write-Host "=== $s ==="
+    psmux capture-pane -t $s 2>$null | Select-Object -Last 5
+}
+```
+
+## Tips
+
+- **Read guard is enforced** — you MUST read before every `type`/`keys`
+- **Every action clears the read mark** — after `type`, read again before `keys`
+- **Never wait or poll** — agent panes reply via psmux-bridge into YOUR pane
+- **Label panes early** — easier than using `%N` IDs
+- **`type` uses literal mode** — special characters are typed as-is
+- **`read` defaults to 50 lines** — pass a higher number for more context
+- **Non-agent panes** are the exception — you DO need to read them to see output
+- **Labels** are stored in `$env:APPDATA\winsmux\labels.json` — persistent across sessions
+- **Read marks** are stored in `$env:TEMP\winsmux\read_marks\` — cleared on reboot
+- Use `capture-pane` to get output as strings (essential for scripting)
+- Use **Alt** key combinations for psmux shortcuts (e.g., `Alt+1` to select window 1)

--- a/skills/winsmux/references/psmux-bridge.md
+++ b/skills/winsmux/references/psmux-bridge.md
@@ -1,0 +1,299 @@
+# psmux-bridge reference
+
+> Version: 1.0.0
+
+psmux-bridge is a PowerShell CLI that wraps psmux (tmux-compatible multiplexer) with label resolution, Read Guard safety, and inter-agent messaging.
+
+## Commands
+
+### id
+
+Show the current pane ID.
+
+```powershell
+psmux-bridge id
+```
+
+If `$env:TMUX_PANE` is set, returns it directly. Otherwise queries psmux for the active pane ID.
+
+**Output:**
+
+```
+%0
+```
+
+---
+
+### list
+
+List all panes with their ID, PID, current command, dimensions, title, child process, and label.
+
+```powershell
+psmux-bridge list
+```
+
+For each pane, the command also detects the first child process (via `Win32_Process` parent PID lookup) and appends it in parentheses. If a label is assigned, it is appended in brackets.
+
+**Output format:**
+
+```
+%0 12345 pwsh 120x30 pane %0 (claude.exe) [claude]
+%1 67890 pwsh 120x30 pane %1
+```
+
+Fields: `pane_id pane_pid pane_current_command pane_widthxpane_height pane_title (child_process) [label]`
+
+---
+
+### read
+
+Capture recent output from a pane. Sets the Read Guard mark for that pane.
+
+```powershell
+psmux-bridge read <target> [lines]
+```
+
+| Parameter | Required | Default | Description |
+|-----------|----------|---------|-------------|
+| `target`  | Yes      | --      | Pane ID, label, or coordinate |
+| `lines`   | No       | `50`    | Number of lines to capture |
+
+**Examples:**
+
+```powershell
+psmux-bridge read %1           # Last 50 lines from pane %1
+psmux-bridge read %1 100       # Last 100 lines from pane %1
+psmux-bridge read claude       # Read from pane labeled "claude"
+```
+
+Uses `psmux capture-pane -t <paneId> -p -J -S -<lines>` internally.
+
+---
+
+### type
+
+Send literal text to a pane. Requires Read Guard.
+
+```powershell
+psmux-bridge type <target> <text>
+```
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `target`  | Yes      | Pane ID, label, or coordinate |
+| `text`    | Yes      | Literal text to send (all remaining args joined by space) |
+
+**Examples:**
+
+```powershell
+psmux-bridge type %1 echo hello world
+psmux-bridge type claude ls -la
+```
+
+Uses `psmux send-keys -t <paneId> -l -- "<text>"` internally. The `-l` flag sends the text literally (no key name interpretation). Clears the Read Guard mark after sending.
+
+---
+
+### keys
+
+Send key sequences (named keys) to a pane. Requires Read Guard.
+
+```powershell
+psmux-bridge keys <target> <key>...
+```
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `target`  | Yes      | Pane ID, label, or coordinate |
+| `key`     | Yes      | One or more key names (e.g. `Enter`, `C-c`, `Tab`) |
+
+**Examples:**
+
+```powershell
+psmux-bridge keys %1 Enter                  # Press Enter
+psmux-bridge keys %1 C-c                    # Send Ctrl+C
+psmux-bridge keys %1 C-c Enter              # Ctrl+C then Enter
+psmux-bridge keys claude Up Up Enter         # Arrow up twice, then Enter
+```
+
+Each key argument is sent as a separate `psmux send-keys` call (without `-l`, so key names are interpreted). Clears the Read Guard mark after sending.
+
+---
+
+### message
+
+Send a tagged inter-agent message to a pane. Requires Read Guard.
+
+```powershell
+psmux-bridge message <target> <text>
+```
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `target`  | Yes      | Pane ID, label, or coordinate |
+| `text`    | Yes      | Message body (all remaining args joined by space) |
+
+**Examples:**
+
+```powershell
+psmux-bridge message %2 please run the tests
+psmux-bridge message claude check the build output
+```
+
+The message is prefixed with a structured header:
+
+```
+[psmux-bridge from:<agent_name> pane:<my_pane_id> at:<session>:<window>.<pane> -- load the winsmux skill to reply] <text>
+```
+
+- `agent_name` is taken from `$env:WINSMUX_AGENT_NAME` (defaults to `"unknown"`)
+- `my_pane_id` and coordinates are resolved from the sender's current pane
+
+Clears the Read Guard mark after sending.
+
+---
+
+### name
+
+Assign a label to a pane. Also sets the pane title (best-effort).
+
+```powershell
+psmux-bridge name <target> <label>
+```
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `target`  | Yes      | Pane ID or coordinate to label |
+| `label`   | Yes      | Label string (first extra arg only) |
+
+**Examples:**
+
+```powershell
+psmux-bridge name %0 claude
+psmux-bridge name %1 codex
+```
+
+**Output:**
+
+```
+Labeled pane %0 as 'claude'
+```
+
+Labels are persisted to `labels.json`. Also calls `psmux select-pane -t <paneId> -T "<label>"` to set the pane title (errors are silently ignored).
+
+---
+
+### resolve
+
+Resolve a label to its pane ID.
+
+```powershell
+psmux-bridge resolve <label>
+```
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `label`   | Yes      | Label to look up |
+
+**Examples:**
+
+```powershell
+psmux-bridge resolve claude    # Output: %0
+psmux-bridge resolve codex     # Output: %1
+```
+
+Exits with error if the label is not found.
+
+---
+
+### doctor
+
+Run environment diagnostics.
+
+```powershell
+psmux-bridge doctor
+```
+
+**Output example:**
+
+```
+=== psmux-bridge doctor ===
+psmux: psmux 0.5.0
+TMUX_PANE: %0
+WINSMUX_AGENT_NAME: claude
+Panes: 3
+Labels: 2 in C:\Users\komei\AppData\Roaming\winsmux\labels.json
+Read marks: 1 in C:\Users\komei\AppData\Local\Temp\winsmux\read_marks
+```
+
+Checks performed:
+- psmux installation and version
+- `TMUX_PANE` environment variable
+- `WINSMUX_AGENT_NAME` environment variable
+- Total pane count
+- Label count and file path
+- Read mark count and directory path
+
+---
+
+### version
+
+Show the bridge version.
+
+```powershell
+psmux-bridge version
+```
+
+**Output:**
+
+```
+psmux-bridge 1.0.0
+```
+
+---
+
+## Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `WINSMUX_AGENT_NAME` | Agent name used in `message` command headers. Defaults to `"unknown"` if not set. |
+| `TMUX_PANE` | Current pane ID. If set, `id` command returns this value directly without querying psmux. Set by psmux on pane creation. |
+
+## File Locations
+
+| Path | Purpose |
+|------|---------|
+| `$env:APPDATA\winsmux\labels.json` | Pane label-to-ID mappings (JSON object). Created on first `name` command. |
+| `$env:TEMP\winsmux\read_marks\` | Read Guard state files. One empty file per pane (with `%` and `:` replaced by `_`). |
+
+## Read Guard
+
+Read Guard is a safety mechanism that prevents blind interaction with panes. It enforces a **read-before-write** discipline:
+
+1. **`read`** sets a mark file in `$env:TEMP\winsmux\read_marks\` for the target pane.
+2. **`type`**, **`keys`**, and **`message`** require the mark to exist (via `Assert-ReadMark`). If the mark is missing, the command fails with:
+   ```
+   error: must read the pane before interacting. Run: psmux-bridge read <paneId>
+   ```
+3. After a successful write operation (`type`, `keys`, `message`), the mark is **cleared**, requiring another `read` before the next interaction.
+
+This ensures agents always observe the current pane state before sending input, preventing stale-state mistakes.
+
+**Mark file naming:** The pane ID has `%` and `:` characters replaced with `_` to form a safe filename (e.g., `%0` becomes `_0`).
+
+## Target Resolution
+
+The `<target>` parameter in commands supports 4 formats, resolved in order:
+
+| Format | Example | Description |
+|--------|---------|-------------|
+| **Label** | `claude` | Looked up in `labels.json`. If a matching key exists, its value (pane ID) is used. |
+| **Pane ID** | `%0` | Direct psmux pane identifier. |
+| **Coordinate** | `main:0.1` | psmux target format: `session:window.pane`. |
+| **Window.Pane** | `0.1` | Short coordinate within the current session. |
+
+Resolution flow:
+1. Check if the target string is a key in `labels.json` (via `Resolve-Target`).
+2. If found, substitute with the mapped pane ID.
+3. If not found, pass the string through as-is (assumed to be a pane ID or coordinate).
+4. Validate the resolved target by calling `psmux display-message -t <target> -p '#{pane_id}'` (via `Confirm-Target`). If this fails, exit with `"invalid target"` error.


### PR DESCRIPTION
## Summary
- Add `skills/winsmux/SKILL.md` — agent skill definition adapted from smux
- Add `skills/winsmux/references/psmux-bridge.md` — full CLI reference
- Update `README.md` — install instructions, keybindings, skills section, update/uninstall
- Update `CLAUDE.md` — mark all phases complete

### SKILL.md highlights
- Read-act-read cycle enforcement
- Read Guard explanation with error examples
- Message protocol with sender header format
- Target resolution (4 forms: label, %N, session:win.pane, numeric)
- Agent-to-agent workflow examples in PowerShell

## Test plan
- [ ] `npx skills add Sora-bluesky/winsmux` loads the skill
- [ ] SKILL.md renders correctly on GitHub
- [ ] README install command works: `irm .../install.ps1 | iex`
- [ ] All keybindings documented match `.psmux.conf`

🤖 Generated with [Claude Code](https://claude.com/claude-code)