### PR TITLE
Fix Confirm-Target: use list-panes instead of display-message

### DIFF
--- a/scripts/psmux-bridge.ps1
+++ b/scripts/psmux-bridge.ps1
@@ -55,15 +55,12 @@ function Resolve-Target {
 # --- Helper: Confirm-Target ---
 function Confirm-Target {
     param([string]$PaneId)
-    try {
-        $result = & psmux display-message -t $PaneId -p '#{pane_id}' 2>&1
-        if ($LASTEXITCODE -ne 0) {
-            Stop-WithError "invalid target: $PaneId"
-        }
-        return ($result | Out-String).Trim()
-    } catch {
+    # display-message -t ignores the -t flag in psmux v3.3.1, so validate via list-panes
+    $allPanes = (& psmux list-panes -a -F '#{pane_id}' | Out-String).Trim() -split "`n" | ForEach-Object { $_.Trim() }
+    if ($PaneId -notin $allPanes) {
         Stop-WithError "invalid target: $PaneId"
     }
+    return $PaneId
 }
 
 # --- Helper: Read Mark ---


### PR DESCRIPTION
## Summary
- Fix `Confirm-Target` to use `list-panes` for pane validation instead of `display-message -t`
- psmux v3.3.1 ignores the `-t` flag on `display-message`, always returning the active pane ID
- This caused all label operations to target the wrong pane

## Root cause
Discovered during live testing with togu project: `psmux display-message -t %1 -p '#{pane_id}'` always returns `%3` regardless of the `-t` target.

## Test plan
- [x] `psmux-bridge name %1 claude` correctly labels %1 (not the active pane)
- [x] `psmux-bridge name %3 codex` correctly labels %3
- [x] `psmux-bridge list` shows correct labels per pane

🤖 Generated with [Claude Code](https://claude.com/claude-code)