### PR TITLE
Rewrite SKILL.md to official guidelines, add bilingual README

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,185 @@
+[English](README.md) | [日本語](README.ja.md)
+
+# winsmux
+
+Windows ネイティブのターミナルマルチプレクサ。AI エージェント間のクロスペイン通信を実現する。WSL2 不要。
+
+- **ユーザー向け** — PowerShell 上で Alt キーバインドによるペイン操作
+- **エージェント向け** — `psmux-bridge` CLI で任意のペインの読み取り・入力・キー送信が可能
+- **エージェント間通信** — Claude Code が隣のペインの Codex に指示を送り、Codex が返答する。シェルコマンドを実行できるエージェントなら何でも参加できる。
+
+```powershell
+psmux-bridge read codex 20              # ペインを読む
+psmux-bridge type codex "review src/auth.ts"  # テキストを入力
+psmux-bridge keys codex Enter           # Enter を押す
+```
+
+## インストール
+
+```powershell
+irm https://raw.githubusercontent.com/Sora-bluesky/winsmux/main/install.ps1 | iex
+```
+
+インストールされるもの:
+- **psmux** — 未インストールの場合は自動インストール（winget, scoop, cargo, chocolatey のいずれか）
+- **psmux-bridge** — クロスペイン通信用 CLI
+- **.psmux.conf** — Alt キーバインド、マウスサポート、ペインラベルの設定
+
+すべて `~\.winsmux\` に配置される。
+
+## クイックスタート
+
+```powershell
+# 1. セッションを作成
+psmux new-session -s work
+
+# 2. ペインを分割（Alt+n でも可）
+psmux split-window -h
+
+# 3. ペインにラベルを付ける
+psmux-bridge name %1 claude
+psmux-bridge name %2 codex
+
+# 4. メッセージを送信
+psmux-bridge read codex 20
+psmux-bridge message codex "review src/auth.ts"
+psmux-bridge read codex 20
+psmux-bridge keys codex Enter
+```
+
+## キーバインド
+
+すべてのキーバインドは **Alt** キーを使用する。プレフィックス不要。
+
+### ペイン
+
+| キー | 動作 |
+|---|---|
+| `Alt+i/k/j/l` | 上/下/左/右に移動 |
+| `Alt+n` | 新しいペイン（分割 + 自動タイル） |
+| `Alt+w` | ペインを閉じる |
+| `Alt+o` | レイアウトを切り替え |
+| `Alt+g` | ペインをマーク |
+| `Alt+y` | マークしたペインと入れ替え |
+
+### ウィンドウ
+
+| キー | 動作 |
+|---|---|
+| `Alt+m` | 新しいウィンドウ |
+| `Alt+u` | 次のウィンドウ |
+| `Alt+h` | 前のウィンドウ |
+
+### スクロール
+
+| キー | 動作 |
+|---|---|
+| `Alt+Tab` | スクロールモードの切り替え |
+| `i/k` | 上/下にスクロール |
+| `Shift+I/K` | 半ページ上/下 |
+| `q` または `Escape` | スクロールモード終了 |
+
+### マウス
+
+- クリックでペインを選択
+- ドラッグでテキスト選択（自動でクリップボードにコピー）
+- スクロールホイールでスクロール
+
+## psmux-bridge
+
+Windows 向けのクロスペイン通信 CLI。シェルコマンドを実行できるツールなら何でも使える — Claude Code、Codex、Gemini CLI、PowerShell スクリプトなど。
+
+| コマンド | 説明 |
+|---|---|
+| `psmux-bridge list` | 全ペインをターゲット・プロセス・ラベル付きで表示 |
+| `psmux-bridge read <target> [lines]` | ペインの末尾 N 行を読み取り（デフォルト 50） |
+| `psmux-bridge type <target> <text>` | ペインにテキストを入力（Enter なし） |
+| `psmux-bridge keys <target> <key>...` | キーを送信（Enter, Escape, C-c 等） |
+| `psmux-bridge message <target> <text>` | 送信者情報付きのタグ付きメッセージを送信 |
+| `psmux-bridge name <target> <label>` | ペインにラベルを付ける |
+| `psmux-bridge resolve <label>` | ラベルからペインを検索 |
+| `psmux-bridge id` | 自分のペイン ID を表示 |
+| `psmux-bridge doctor` | 環境チェックと診断 |
+| `psmux-bridge version` | バージョンを表示 |
+
+### Read Guard
+
+CLI は **read-before-act** ルールを強制する。ペインを `read` しない限り `type` や `keys` は実行できない。`type`/`keys` 実行後はマークがクリアされ、再度 `read` が必要になる。
+
+```powershell
+psmux-bridge type codex "hello"
+# error: must read the pane before interacting. Run: psmux-bridge read codex
+```
+
+エージェントが誤ったペインに盲目的に入力するのを防ぐ仕組みだ。
+
+### ターゲット指定
+
+ペインは以下の方法で指定できる:
+- **ペイン ID** — `%3`, `%5`（psmux ネイティブ ID）
+- **ラベル** — `psmux-bridge name` で設定した任意の名前
+
+ラベルはすべてのコマンドで自動解決される。保存先は `$env:APPDATA\winsmux\labels.json`。
+
+## Commander Orchestration
+
+Commander ワークフローは 4 ペイン構成で、Claude Code が builder/reviewer エージェントを指揮する:
+
+```
+┌──────────────┬──────────────┐
+│  commander   │   builder    │
+│ (Claude Code)│  (Codex CLI) │
+├──────────────┼──────────────┤
+│  reviewer    │   monitor    │
+│  (Codex CLI) │  (shell)     │
+└──────────────┴──────────────┘
+```
+
+| ペイン | 役割 | 担当 |
+|---|---|---|
+| commander | 設計・指揮 | タスク分解、指示送信、git 操作 |
+| builder | 実装 | コード実装、reviewer の指摘を修正 |
+| reviewer | レビュー | セキュリティ・アーキテクチャ・品質のレビュー |
+| monitor | 監視 | テスト実行、dev server、ビルドログ |
+
+ワークフローの流れ: **Plan → Build → Poll → Review → Poll → Judge → Commit → Next**
+
+Commander はコードを直接書かない。実装は builder に委任し、reviewer の指摘も builder に修正指示を送る。
+
+詳細は [SKILL.md](skills/winsmux/SKILL.md) を参照。Commander ワークフローの全手順、Poll パターン、自動承認ルールが記載されている。
+
+## AI Agent Skills
+
+winsmux スキルをインストールすると、エージェントが psmux-bridge の使い方を学習する:
+
+```powershell
+npx skills add Sora-bluesky/winsmux
+```
+
+Claude Code、Codex、Cursor、Copilot、[その他のエージェント](https://skills.sh)で動作する。
+
+## アップデート
+
+```powershell
+winsmux update
+```
+
+## アンインストール
+
+```powershell
+winsmux uninstall
+```
+
+## 動作要件
+
+- Windows 10/11
+- PowerShell 7+（pwsh）
+- [psmux](https://github.com/psmux/psmux)（自動インストール）
+
+## 謝辞
+
+winsmux は [smux](https://github.com/ShawnPana/smux)（[@ShawnPana](https://github.com/ShawnPana) 作）の Windows ネイティブ版だ。smux は macOS/Linux 向けに tmux を使った同様のターミナルマルチプレクサ + AI エージェント通信ワークフローを提供している。winsmux はその体験を psmux 経由で Windows にネイティブに持ち込む。WSL2 は不要。
+
+## ライセンス
+
+MIT

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[English](README.md) | [日本語](README.ja.md)
+
 # winsmux
 
 Native Windows terminal multiplexer with cross-pane AI agent communication — no WSL2 required.
@@ -9,7 +11,7 @@ Native Windows terminal multiplexer with cross-pane AI agent communication — n
 ```powershell
 psmux-bridge read codex 20              # read the pane
 psmux-bridge type codex "review src/auth.ts"  # type into it
-psmux-bridge keys codex Enter           # press enter
+psmux-bridge keys codex Enter           # press Enter
 ```
 
 ## Install
@@ -24,6 +26,26 @@ This installs:
 - **.psmux.conf** with Alt-key bindings, mouse support, and pane labels
 
 Everything lives in `~\.winsmux\`.
+
+## Quick Start
+
+```powershell
+# 1. Start a session
+psmux new-session -s work
+
+# 2. Split a pane (Alt+n also works)
+psmux split-window -h
+
+# 3. Label the panes
+psmux-bridge name %1 claude
+psmux-bridge name %2 codex
+
+# 4. Send a message
+psmux-bridge read codex 20
+psmux-bridge message codex "review src/auth.ts"
+psmux-bridge read codex 20
+psmux-bridge keys codex Enter
+```
 
 ## Keybindings
 
@@ -57,6 +79,12 @@ All keybindings use **Alt** with no prefix required.
 | `Shift+I/K` | Half-page up/down |
 | `q` or `Escape` | Exit scroll mode |
 
+### Mouse
+
+- Click to select panes
+- Drag to select text (auto-copies to clipboard)
+- Scroll wheel to scroll
+
 ## psmux-bridge
 
 A CLI for cross-pane communication on Windows. Any tool that can run shell commands can use it — Claude Code, Codex, Gemini CLI, or a plain PowerShell script.
@@ -72,6 +100,53 @@ A CLI for cross-pane communication on Windows. Any tool that can run shell comma
 | `psmux-bridge resolve <label>` | Look up a pane by label |
 | `psmux-bridge id` | Print this pane's ID |
 | `psmux-bridge doctor` | Check environment and diagnostics |
+| `psmux-bridge version` | Show version |
+
+### Read Guard
+
+The CLI enforces a **read-before-act** rule. You cannot `type` or `keys` to a pane unless you have read it first. After each `type`/`keys`, the mark clears and you must read again.
+
+```powershell
+psmux-bridge type codex "hello"
+# error: must read the pane before interacting. Run: psmux-bridge read codex
+```
+
+This prevents agents from blindly typing into the wrong pane.
+
+### Targeting
+
+Panes can be addressed by:
+- **Pane ID** — `%3`, `%5` (psmux native IDs)
+- **Label** — any name set via `psmux-bridge name`
+
+Labels are resolved automatically in every command. Stored in `$env:APPDATA\winsmux\labels.json`.
+
+## Commander Orchestration
+
+The Commander workflow uses a 4-pane layout where Claude Code orchestrates builder/reviewer agents:
+
+```
+┌──────────────┬──────────────┐
+│  commander   │   builder    │
+│ (Claude Code)│  (Codex CLI) │
+├──────────────┼──────────────┤
+│  reviewer    │   monitor    │
+│  (Codex CLI) │  (shell)     │
+└──────────────┴──────────────┘
+```
+
+| Pane | Role | Responsibility |
+|---|---|---|
+| commander | Design & orchestrate | Task decomposition, instructions, git operations |
+| builder | Implement | Code implementation, fix reviewer findings |
+| reviewer | Review | Security, architecture, and quality review |
+| monitor | Observe | Test runner, dev server, build logs |
+
+The workflow cycle: **Plan → Build → Poll → Review → Poll → Judge → Commit → Next**.
+
+Commander never writes code directly — it delegates to builder and sends reviewer findings back to builder for fixes.
+
+See [SKILL.md](skills/winsmux/SKILL.md) for the full Commander workflow, poll patterns, and auto-approval rules.
 
 ## AI Agent Skills
 
@@ -80,6 +155,8 @@ Install the winsmux skill to teach your agents how to use psmux-bridge:
 ```powershell
 npx skills add Sora-bluesky/winsmux
 ```
+
+Works with Claude Code, Codex, Cursor, Copilot, and [other agents](https://skills.sh).
 
 ## Update
 
@@ -101,7 +178,7 @@ winsmux uninstall
 
 ## Acknowledgments
 
-This project is the Windows-native counterpart of [smux](https://github.com/ShawnPana/smux) by [@ShawnPana](https://github.com/ShawnPana). smux provides the same terminal multiplexer + AI agent communication workflow for macOS/Linux using tmux. winsmux brings that experience to Windows natively via psmux, without requiring WSL2.
+winsmux is the Windows-native counterpart of [smux](https://github.com/ShawnPana/smux) by [@ShawnPana](https://github.com/ShawnPana). smux provides the same terminal multiplexer + AI agent communication workflow for macOS/Linux using tmux. winsmux brings that experience to Windows natively via psmux, without requiring WSL2.
 
 ## License
 

--- a/skills/winsmux/SKILL.md
+++ b/skills/winsmux/SKILL.md
@@ -1,380 +1,341 @@
 ---
 name: winsmux
 description: |
-  Control psmux panes and communicate between AI agents on Windows.
-  Use this skill whenever the user mentions pane control, cross-pane communication,
-  sending messages to other agents, reading other panes, or managing psmux sessions on Windows.
+  Cross-pane AI agent communication on Windows via psmux-bridge CLI.
+  Use when the user mentions pane control, cross-pane communication,
+  sending messages to other agents, reading other panes, managing
+  psmux sessions, or multi-agent orchestration on Windows.
+  Triggered by "psmux-bridge", "cross-pane", "pane communication",
+  "winsmux", "agent orchestration", "multi-pane", "commander workflow",
+  or "pane read/type/keys".
+  Key capabilities: read-guard-enforced pane I/O, labeled pane targeting,
+  structured inter-agent messaging, commander orchestration workflow
+  with builder/reviewer/monitor roles, POLL loop with auto-approve,
+  and dangerous-command protection.
+metadata:
+  author: Sora-bluesky
+  version: "1.1.0"
+  os: win32
+  requires: psmux, psmux-bridge
 ---
 
 # winsmux
 
-Psmux pane control and cross-pane agent communication on Windows. Use `psmux-bridge` (the high-level CLI) for all cross-pane interactions. Fall back to raw psmux commands only when you need low-level control.
+Cross-pane AI agent communication on Windows. Use `psmux-bridge` for all pane interactions.
 
-## psmux-bridge — Cross-Pane Communication
+## Communication Modes
 
-A CLI that lets any AI agent interact with any other psmux pane. Works via PowerShell. Every command is **atomic**: `type` types text (no Enter), `keys` sends special keys, `read` captures pane content.
-
-### Communication Modes
-
-Panes fall into two categories. **Identify the mode before communicating.**
+Identify the mode **before** communicating with a pane.
 
 | Mode | Condition | Rule |
 |------|-----------|------|
-| **Agent Mode** | Peer has winsmux skill installed (Claude Code, skill-enabled Codex) | DO NOT POLL. Reply arrives in YOUR pane via `[psmux-bridge from:...]` |
-| **Non-Agent Mode** | Codex CLI (no skill), plain shell, dev server | POLL REQUIRED. Commander must `read` periodically to check status |
+| **Agent Mode** | Peer has winsmux skill (Claude Code, skill-enabled Codex) | DO NOT POLL. Reply arrives in YOUR pane via `[psmux-bridge from:...]` |
+| **Non-Agent Mode** | Codex CLI (no skill), plain shell, dev server | POLL REQUIRED. You must `read` periodically to check status |
 
-**Agent Mode** — do not sleep, poll, or loop. Send your message, press Enter, and move on. The reply appears directly in your pane.
+**Agent Mode** -- send your message, press Enter, and move on. The reply appears directly in your pane. Do not sleep, poll, or loop.
 
-**Non-Agent Mode** — after sending a task, enter the POLL loop (see Commander Workflow below). Read the target pane at intervals to detect completion, approval prompts, or errors.
+**Non-Agent Mode** -- after sending a task, enter the POLL loop (see Commander Orchestration below). Read the target pane at intervals to detect completion, approval prompts, or errors.
 
-The ONLY time you read a target pane in Agent Mode is:
-- **Before** interacting with it (enforced by the read guard)
-- **After typing** to verify your text landed before pressing Enter
+The ONLY reasons to read a target pane in Agent Mode:
+- **Before** interacting (enforced by Read Guard)
+- **After typing** to verify text landed before pressing Enter
 
-### Read Guard
+## Core Commands
 
-The CLI enforces read-before-act. You cannot `type` or `keys` to a pane unless you have read it first.
+| Command | Description | Example |
+|---------|-------------|---------|
+| `psmux-bridge list` | Show all panes with target, pid, command, size, label | `psmux-bridge list` |
+| `psmux-bridge read <target> [lines]` | Read last N lines (default 50), sets Read Guard mark | `psmux-bridge read codex 100` |
+| `psmux-bridge type <target> <text>` | Type literal text (no Enter), requires Read Guard | `psmux-bridge type codex "hello"` |
+| `psmux-bridge message <target> <text>` | Type text with auto sender header and reply target | `psmux-bridge message codex "review src/auth.ts"` |
+| `psmux-bridge keys <target> <key>...` | Send special keys, requires Read Guard | `psmux-bridge keys codex Enter` |
+| `psmux-bridge name <target> <label>` | Label a pane | `psmux-bridge name %3 codex` |
+| `psmux-bridge resolve <label>` | Print pane ID for a label | `psmux-bridge resolve codex` |
+| `psmux-bridge id` | Print this pane's ID | `psmux-bridge id` |
+| `psmux-bridge doctor` | Run environment diagnostics | `psmux-bridge doctor` |
 
-1. `psmux-bridge read <target>` marks the pane as "read"
-2. `psmux-bridge type/keys <target>` checks for that mark — errors if you haven't read
-3. After a successful `type`/`keys`, the mark is cleared — you must read again before the next interaction
+For full parameter details, see [psmux-bridge CLI Reference](references/psmux-bridge.md).
 
-Read marks are stored in `$env:TEMP\winsmux\read_marks\`.
+## Read Guard
+
+The CLI enforces **read-before-act**. You cannot `type`, `keys`, or `message` to a pane unless you have read it first.
+
+1. `psmux-bridge read <target>` -- sets the mark
+2. `psmux-bridge type/keys/message <target>` -- checks the mark; errors if missing
+3. After a successful write, the mark is **cleared** -- you must read again before the next interaction
+
+If you skip the read:
 
 ```
 PS> psmux-bridge type codex "hello"
 error: must read the pane before interacting. Run: psmux-bridge read codex
 ```
 
-### Command Reference
+## Read-Act-Read Cycle
 
-| Command | Description | Example |
-|---|---|---|
-| `psmux-bridge list` | Show all panes with target, pid, command, size, label | `psmux-bridge list` |
-| `psmux-bridge type <target> <text>` | Type text without pressing Enter | `psmux-bridge type codex "hello"` |
-| `psmux-bridge message <target> <text>` | Type text with auto sender info and reply target | `psmux-bridge message codex "review src/auth.ts"` |
-| `psmux-bridge read <target> [lines]` | Read last N lines (default 50) | `psmux-bridge read codex 100` |
-| `psmux-bridge keys <target> <key>...` | Send special keys | `psmux-bridge keys codex Enter` |
-| `psmux-bridge name <target> <label>` | Label a pane | `psmux-bridge name %3 codex` |
-| `psmux-bridge resolve <label>` | Print pane target for a label | `psmux-bridge resolve codex` |
-| `psmux-bridge id` | Print this pane's ID | `psmux-bridge id` |
+Every interaction follows **read -> act -> read**.
 
-### Target Resolution
+**Sending a message to an agent (Agent Mode):**
 
-Targets can be:
-- **psmux native**: pane ID (`%3`), or window index (`0`)
-- **label**: Any string set via `psmux-bridge name` — resolved automatically
-
-Labels are stored in `$env:APPDATA\winsmux\labels.json`.
-
-### Read-Act-Read Cycle
-
-Every interaction follows **read → act → read**. The CLI enforces this.
-
-**Sending a message to an agent:**
 ```powershell
-psmux-bridge read codex 20                    # 1. READ — satisfy read guard
-psmux-bridge message codex 'Please review src/auth.ts'
-                                              # 2. MESSAGE — auto-prepends sender info, no Enter
-psmux-bridge read codex 20                    # 3. READ — verify text landed
-psmux-bridge keys codex Enter                 # 4. KEYS — submit
-# STOP. Do NOT read codex for a reply. The agent replies into YOUR pane.
+psmux-bridge read codex 20                    # 1. READ -- satisfy Read Guard
+psmux-bridge message codex "Please review src/auth.ts"
+                                              # 2. MESSAGE -- auto-prepends sender info
+psmux-bridge read codex 20                    # 3. READ -- verify text landed
+psmux-bridge keys codex Enter                 # 4. KEYS -- submit
+# STOP. Do NOT poll. The agent replies into YOUR pane.
 ```
 
-**Approving a prompt (non-agent pane):**
+**Approving a prompt (Non-Agent pane):**
+
 ```powershell
-psmux-bridge read worker 10                   # 1. READ — see the prompt
+psmux-bridge read worker 10                   # 1. READ -- see the prompt
 psmux-bridge type worker "y"                  # 2. TYPE
-psmux-bridge read worker 10                   # 3. READ — verify
-psmux-bridge keys worker Enter                # 4. KEYS — submit
-psmux-bridge read worker 20                   # 5. READ — see the result
+psmux-bridge read worker 10                   # 3. READ -- verify
+psmux-bridge keys worker Enter                # 4. KEYS -- submit
+psmux-bridge read worker 20                   # 5. READ -- see the result
 ```
 
-### Messaging Convention
+## Message Protocol
 
-The `message` command auto-prepends sender info and location:
+The `message` command auto-prepends a structured header:
 
 ```
 [psmux-bridge from:claude pane:%4 at:s:w.p -- load the winsmux skill to reply]
 ```
 
-The receiver gets: who sent it (`from`), the exact pane to reply to (`pane`), and the session/window location (`at`). When you see this header, reply using psmux-bridge to the pane ID from the header.
+Fields: who sent it (`from`), reply-to pane (`pane`), session/window/pane coordinates (`at`).
 
-### Agent-to-Agent Workflow
+When you receive this header, reply using `psmux-bridge message` to the pane ID from the header.
 
-```powershell
-# 1. Label yourself
-psmux-bridge name (psmux-bridge id) claude
+## Commander Orchestration
 
-# 2. Discover other panes
-psmux-bridge list
+When you are the **commander** orchestrating builder/reviewer/monitor panes, follow this workflow. Builder and reviewer are Non-Agent Mode (Codex CLI without winsmux skill).
 
-# 3. Send a message (read-act-read)
-psmux-bridge read codex 20
-psmux-bridge message codex 'Please review the changes in src/auth.ts'
-psmux-bridge read codex 20
-psmux-bridge keys codex Enter
-```
-
-### Example Conversation
-
-**Agent A (claude) sends:**
-```powershell
-psmux-bridge read codex 20
-psmux-bridge message codex 'What is the test coverage for src/auth.ts?'
-psmux-bridge read codex 20
-psmux-bridge keys codex Enter
-```
-
-**Agent B (codex) sees in their prompt:**
-```
-[psmux-bridge from:claude pane:%4 at:s:w.p -- load the winsmux skill to reply] What is the test coverage for src/auth.ts?
-```
-
-**Agent B replies using the pane ID from the header:**
-```powershell
-psmux-bridge read %4 20
-psmux-bridge message %4 '87% line coverage. Missing the OAuth refresh token path (lines 142-168).'
-psmux-bridge read %4 20
-psmux-bridge keys %4 Enter
-```
-
----
-
-## Commander Orchestration Workflow
-
-When you are the **commander** (Claude Code orchestrating builder/reviewer Codex panes), follow this workflow. Builder and reviewer are **Non-Agent Mode** (Codex CLI without winsmux skill).
-
-### Roles — Strict Separation (CRITICAL)
+### Roles -- Strict Separation (CRITICAL)
 
 | Pane | Role | Responsibility | Prohibited |
 |------|------|---------------|------------|
-| commander | 指揮・設計・コミット | タスク分解、指示送信、結果判断、git 操作 | **コードを直接書く・修正する** |
-| builder | 実装・修正 | コード実装、reviewer 指摘への修正対応 | レビュー、コミット |
-| reviewer | コードレビュー | 品質・セキュリティ・アーキテクチャ観点のレビュー | 修正、コミット |
-| monitor | テスト実行・ログ監視 | dev server、pytest、ビルドログ | エージェントは走らない |
+| commander | Design, orchestrate, commit | Task decomposition, send instructions, judge results, git ops | **Writing or modifying code directly** |
+| builder | Implement, fix | Code implementation, fix reviewer findings | Review, commit |
+| reviewer | Code review | Quality, security, architecture review | Fix code, commit |
+| monitor | Test, observe | Dev server, test runner, build logs | Not an agent -- plain shell only |
 
-**Commander はコードを書かない。** reviewer が指摘を出したら、commander はその指摘を読んで **builder に修正指示を送る**。commander 自身が修正してはならない。
+**Commander does NOT write code.** When the reviewer reports findings, the commander reads them and sends fix instructions to the **builder**. The commander never fixes code itself.
 
 ### Workflow Cycle
 
 ```
-1. PLAN    — ロードマップ/タスクを読み、実装方針を決める
-2. BUILD   — builder に実装指示を送る
-3. POLL    — builder の完了を待つ（POLL 必須。省略禁止）
-4. REVIEW  — reviewer にレビュー依頼を送る
-5. POLL    — reviewer の完了を待つ（POLL 必須。省略禁止）
-6. JUDGE   — レビュー結果を判断
-             OK → COMMIT へ
-             NG → builder に修正指示（Step 2 に戻る）
-7. COMMIT  — commander 自身でコミットする
-8. NEXT    — 次のタスクへ（Step 1 に戻る）
+1. PLAN    -- Read roadmap/task, decide implementation approach
+2. BUILD   -- Send implementation instructions to builder
+3. POLL    -- Wait for builder completion (MANDATORY, never skip)
+4. REVIEW  -- Send review request to reviewer
+5. POLL    -- Wait for reviewer completion (MANDATORY, never skip)
+6. JUDGE   -- Evaluate review results
+             OK  -> proceed to COMMIT
+             NG  -> send fix instructions to builder (back to step 2)
+7. COMMIT  -- Commander commits via git
+8. NEXT    -- Move to next task (back to step 1)
 ```
 
-### Step 2: BUILD — builder に実装指示を送る
+### BUILD -- Send Instructions
 
 ```powershell
 psmux-bridge read builder 20
-psmux-bridge message builder '○○を実装してください。要件: ...'
+psmux-bridge message builder "Implement the auth middleware. Requirements: ..."
 psmux-bridge read builder 20
 psmux-bridge keys builder Enter
-# → 直ちに Step 3 (POLL) に遷移する。他の作業に移らない。
+# Immediately proceed to POLL. Do not context-switch.
 ```
 
-### Step 3: POLL & AUTO-APPROVE
+### POLL and Auto-Approve
 
-builder/reviewer は Non-Agent Mode。**指示送信後、必ずこの POLL ループに入る。省略禁止。**
+After BUILD or REVIEW instructions, enter this POLL loop. **Never skip POLL.**
 
-10秒間隔で read → 状態判断 → 対応。最大12回（約120秒）で打ち切る。
+Read at 10-second intervals. Maximum 12 rounds (about 120 seconds).
 
-#### 状態判断パターン
+#### State Detection Patterns
 
-| 出力に含まれる文字列 | 状態 | commander の対応 |
-|---------------------|------|-----------------|
-| `Do you want to proceed?` / `1. Yes` | **承認待ち** | 自動承認（下記手順） |
-| `2. Yes, and don't ask again` | **承認待ち（永続選択肢あり）** | `type "2"` で以降の同種承認をスキップ |
-| `> Implement` / `> Write` / `> Improve` | **完了（プロンプト待ち）** | POLL 終了 → 次ステップ |
-| `gpt-5.4 high · 100% left` | **完了（アイドル状態）** | POLL 終了 → 次ステップ |
-| `Editing...` / `Running...` / `Reading...` | **作業中** | 何もしない → 次 POLL |
-| `"type": "error"` / `API error` / `rate limit` | **API エラー** | ユーザーに報告。モデル変更を提案 |
-| `error` / `failed` / `Error` | **実行エラー** | エラー内容を読み取り対処判断 |
-| `Esc to cancel` | **承認待ち** | 内容確認後 `keys Enter` で承認 |
-| `[Y/n]` / `[y/N]` | **シェル確認** | `type "y"` + `keys Enter` |
-| `Sandbox` | **サンドボックス承認** | `type "1"` + `keys Enter` |
+| Output contains | State | Commander action |
+|----------------|-------|-----------------|
+| `Do you want to proceed?` / `1. Yes` | Approval needed | Auto-approve (see below) |
+| `2. Yes, and don't ask again` | Approval needed (persistent option) | `type "2"` to skip future prompts of same kind |
+| `> Implement` / `> Write` / `> Improve` | Complete (prompt idle) | End POLL, next step |
+| `gpt-5.4 high` / `100% left` | Complete (idle) | End POLL, next step |
+| `Editing...` / `Running...` / `Reading...` | Working | Do nothing, next POLL |
+| `"type": "error"` / `API error` / `rate limit` | API error | Report to user. Suggest model change |
+| `error` / `failed` / `Error` | Execution error | Read error details, decide action |
+| `Esc to cancel` | Approval needed | Verify content, then `keys Enter` |
+| `[Y/n]` / `[y/N]` | Shell confirmation | `type "y"` + `keys Enter` |
+| `Sandbox` | Sandbox approval | `type "1"` + `keys Enter` |
 
-#### 自動承認の手順
+#### Auto-Approve Procedure
 
 ```powershell
-# 通常の承認
+# Standard approval
 psmux-bridge read builder 10
 psmux-bridge type builder "1"
 psmux-bridge read builder 5
 psmux-bridge keys builder Enter
 
-# 永続承認（初回のみ、以降の同種承認をスキップ）
+# Persistent approval (skip future prompts of same kind)
 psmux-bridge read builder 10
 psmux-bridge type builder "2"
 psmux-bridge read builder 5
 psmux-bridge keys builder Enter
 ```
 
-#### 危険コマンドの自動承認禁止
+#### Dangerous Commands -- Never Auto-Approve
 
-以下のパターンが承認内容に含まれる場合は**自動承認せず、ユーザーに報告する**:
+If approval content contains any of these patterns, **do NOT auto-approve**. Report to the user instead:
+
 - `rm -rf` / `Remove-Item -Recurse -Force`
 - `git push --force` / `git reset --hard`
 - `DROP TABLE` / `DELETE FROM`
-- 不明な外部スクリプトの実行
+- Execution of unknown external scripts
 
-#### POLL 打ち切り
+#### POLL Timeout
 
-12回（約120秒）で完了しない場合:
-- builder/reviewer の最後の20行を読み取って提示
-- 「承認待ち / 作業中 / エラー」の状態判断をユーザーに報告
-- ユーザーの指示を待つ
+After 12 rounds (about 120 seconds) with no completion:
 
-### Step 4: REVIEW — reviewer にレビュー依頼を送る
+1. Read the last 20 lines of the target pane
+2. Report state (approval-waiting / working / error) to the user
+3. Wait for user instructions
+
+### REVIEW -- Send Review Request
 
 ```powershell
 psmux-bridge read reviewer 20
-psmux-bridge message reviewer 'git diff HEAD で未コミット変更を確認し、コードレビューしてください。観点: (1) セキュリティ (2) アーキテクチャ (3) テスト'
+psmux-bridge message reviewer "Review uncommitted changes via git diff HEAD. Focus: (1) security (2) architecture (3) tests"
 psmux-bridge read reviewer 20
 psmux-bridge keys reviewer Enter
-# → 直ちに Step 5 (POLL) に遷移する
+# Immediately proceed to POLL for reviewer.
 ```
 
-### Step 5: POLL — reviewer の完了を待つ
+### JUDGE -- Evaluate Review Results
 
-Step 3 と同じ POLL ループを reviewer に対して実行する。
+Read reviewer output with `psmux-bridge read reviewer 50`:
 
-### Step 6: JUDGE — レビュー結果の判断
+- **LGTM / APPROVE / no issues** -- proceed to COMMIT
+- **REQUEST_CHANGES / findings reported** -- read findings, send fix instructions to **builder** (back to BUILD step). Commander does NOT fix code itself
+- **Critical issue** -- report to user and await guidance
 
-reviewer の出力を `psmux-bridge read reviewer 50` で読み取り判断:
+### COMMIT
 
-- **LGTM / APPROVE / 問題なし** → Step 7 (COMMIT) に進む
-- **REQUEST_CHANGES / 指摘あり**:
-  1. 指摘内容を読み取る
-  2. **builder に修正指示を送る（Step 2 に戻る）**
-  3. ❌ commander が自分で修正してはならない
-- **重大な問題** → ユーザーに報告して判断を仰ぐ
+Commander performs git operations directly:
 
-### Step 7: COMMIT
-
-commander 自身で git 操作を行う:
 ```powershell
 git add <files>
 git commit -m "feat: ..."
 ```
 
-### Monitor ペインの使い方
+### Monitor Pane
 
-monitor は Non-Agent のプレーンシェル。テスト実行やログ監視に使う。
+Monitor is a Non-Agent plain shell for test execution and log observation.
 
 ```powershell
-# テスト実行
 psmux-bridge read monitor 3
 psmux-bridge type monitor "pytest tests/ -q"
 psmux-bridge read monitor 3
 psmux-bridge keys monitor Enter
 
-# 10秒後に結果確認
+# Wait, then check results
 Start-Sleep 10
 psmux-bridge read monitor 30
-# → "passed" / "failed" を判断
+# Evaluate: "passed" / "failed"
 ```
 
-### Commander の禁止事項
+### Commander Prohibitions
 
-1. **コードを直接書かない・修正しない** — 実装は builder に任せる。reviewer の指摘も builder に修正指示を送る
-2. **POLL を省略しない** — BUILD/REVIEW 指示後は必ず POLL ループに遷移する
-3. **reviewer を飛ばしてコミットしない** — 必ずレビューを通す
-4. **複数ペインに同時に指示を送らない** — 1つずつ順番に
-5. **危険コマンドを自動承認しない** — rm -rf, force push 等はユーザーに報告
-6. **POLL を120秒以上続けない** — 12回で打ち切りユーザーに報告
+1. **Never write or modify code directly** -- all implementation goes through builder
+2. **Never skip POLL** -- always POLL after BUILD and REVIEW instructions
+3. **Never commit without review** -- always run REVIEW before COMMIT
+4. **Never send instructions to multiple panes simultaneously** -- one at a time
+5. **Never auto-approve dangerous commands** -- report to user
+6. **Never POLL beyond 120 seconds** -- timeout after 12 rounds, report to user
 
----
+## Examples
 
-## Raw psmux Commands
-
-Use these when you need direct psmux control beyond what psmux-bridge provides — session management, window navigation, creating panes, or low-level scripting.
-
-### Capture Output
+### Example 1: Agent-to-Agent Communication
 
 ```powershell
-psmux capture-pane -t shared | Select-Object -Last 20    # Last 20 lines
-psmux capture-pane -t shared                              # Entire scrollback
-psmux capture-pane -t 'shared:0.0'                        # Specific pane
+# Label yourself
+psmux-bridge name (psmux-bridge id) claude
+
+# Discover panes
+psmux-bridge list
+
+# Send a message (Read-Act-Read)
+psmux-bridge read codex 20
+psmux-bridge message codex "What is the test coverage for src/auth.ts?"
+psmux-bridge read codex 20
+psmux-bridge keys codex Enter
+# STOP -- reply arrives in your pane (Agent Mode)
 ```
 
-### Send Keys
+The receiving agent sees:
+
+```
+[psmux-bridge from:claude pane:%4 at:s:w.p -- load the winsmux skill to reply] What is the test coverage for src/auth.ts?
+```
+
+And replies:
 
 ```powershell
-psmux send-keys -t shared -l "text here"     # Type text (literal mode)
-psmux send-keys -t shared Enter              # Press Enter
-psmux send-keys -t shared Escape             # Press Escape
-psmux send-keys -t shared C-c                # Ctrl+C
-psmux send-keys -t shared C-d               # Ctrl+D (EOF)
+psmux-bridge read %4 20
+psmux-bridge message %4 "87% line coverage. Missing OAuth refresh path (lines 142-168)."
+psmux-bridge read %4 20
+psmux-bridge keys %4 Enter
 ```
 
-For interactive TUIs, split text and Enter into separate sends:
-```powershell
-psmux send-keys -t shared -l "Please apply the patch"
-Start-Sleep -Milliseconds 100
-psmux send-keys -t shared Enter
-```
-
-### Panes and Windows
+### Example 2: Commander Orchestration Cycle
 
 ```powershell
-# Create panes (prefer over new windows)
-psmux split-window -h -t SESSION              # Horizontal split
-psmux split-window -v -t SESSION              # Vertical split
-psmux select-layout -t SESSION tiled          # Re-balance
+# 1. PLAN -- decide task
+# "Implement rate limiting middleware"
 
-# Navigate
-psmux select-window -t shared:0
-psmux select-pane -t 'shared:0.1'
-psmux list-windows -t shared
+# 2. BUILD -- instruct builder
+psmux-bridge read builder 20
+psmux-bridge message builder "Implement rate limiting middleware in src/middleware/rate-limit.ts. Use sliding window, 100 req/min per IP."
+psmux-bridge read builder 20
+psmux-bridge keys builder Enter
+
+# 3. POLL -- wait for builder (10s intervals, max 12 rounds)
+Start-Sleep 10
+psmux-bridge read builder 20
+# ... repeat until completion detected ...
+
+# 4. REVIEW -- send to reviewer
+psmux-bridge read reviewer 20
+psmux-bridge message reviewer "Review uncommitted changes via git diff HEAD. Focus: security, performance, tests."
+psmux-bridge read reviewer 20
+psmux-bridge keys reviewer Enter
+
+# 5. POLL -- wait for reviewer
+Start-Sleep 10
+psmux-bridge read reviewer 50
+# ... repeat until completion detected ...
+
+# 6. JUDGE -- LGTM received
+# 7. COMMIT
+git add src/middleware/rate-limit.ts
+git commit -m "feat: add rate limiting middleware"
+
+# 8. NEXT -- proceed to next task
 ```
 
-### Session Management
+## Troubleshooting
 
-```powershell
-psmux list-sessions
-psmux new-session -d -s newsession
-psmux kill-session -t sessionname
-psmux rename-session -t old new
-```
+| Problem | Cause | Solution |
+|---------|-------|----------|
+| `error: must read the pane before interacting` | Read Guard not satisfied | Run `psmux-bridge read <target>` first |
+| `invalid target` | Label not found or pane ID wrong | Run `psmux-bridge list` to verify panes; re-label with `psmux-bridge name` |
+| `psmux: command not found` | psmux not installed or not in PATH | Install psmux; verify with `psmux -V` |
+| Message sent but no reply (Agent Mode) | Peer does not have winsmux skill loaded | Switch to Non-Agent Mode with POLL |
+| POLL times out after 120 seconds | Builder/reviewer stuck or errored | Read last 20 lines, report state to user |
+| Auto-approve triggered on dangerous command | Pattern not caught | Add pattern to dangerous-command list; report to user |
+| `psmux-bridge doctor` shows warnings | Environment misconfigured | Fix reported issues (TMUX_PANE, WINSMUX_AGENT_NAME, etc.) |
 
-### Claude Code Patterns
+## References
 
-```powershell
-# Check if session needs input
-psmux capture-pane -t worker-3 | Select-Object -Last 10 |
-  Select-String -Pattern '❯|Yes.*No|proceed|permission'
-
-# Approve a prompt
-psmux send-keys -t worker-3 -l 'y'
-psmux send-keys -t worker-3 Enter
-
-# Check all sessions
-foreach ($s in @('shared','worker-2','worker-3','worker-4')) {
-    Write-Host "=== $s ==="
-    psmux capture-pane -t $s 2>$null | Select-Object -Last 5
-}
-```
-
-## Tips
-
-- **Read guard is enforced** — you MUST read before every `type`/`keys`
-- **Every action clears the read mark** — after `type`, read again before `keys`
-- **Agent Mode: never poll** — skill-enabled agents reply via psmux-bridge into YOUR pane
-- **Non-Agent Mode: always poll** — Codex CLI and plain shells require periodic `read` to check status
-- **Label panes early** — easier than using `%N` IDs
-- **`type` uses literal mode** — special characters are typed as-is
-- **`read` defaults to 50 lines** — pass a higher number for more context
-- **Non-agent panes** are the exception — you DO need to read them to see output
-- **Labels** are stored in `$env:APPDATA\winsmux\labels.json` — persistent across sessions
-- **Read marks** are stored in `$env:TEMP\winsmux\read_marks\` — cleared on reboot
-- Use `capture-pane` to get output as strings (essential for scripting)
-- Use **Alt** key combinations for psmux shortcuts (e.g., `Alt+1` to select window 1)
+- [psmux-bridge CLI Reference](references/psmux-bridge.md) -- full command parameters, environment variables, file locations, target resolution details


### PR DESCRIPTION
## Summary
- Rewrite `SKILL.md` to comply with official skill building guidelines
- Unify language to English (resolve Japanese/English mix)
- Add `README.ja.md` (Japanese version) with language switcher header

### SKILL.md changes
- Official frontmatter with WHAT + WHEN + triggers + metadata
- Progressive Disclosure: raw psmux commands moved to references/
- 381 → 341 lines (under 500 line limit)
- Troubleshooting section with 7 common error patterns
- All content preserved: Communication Modes, POLL workflow, Role Separation, Auto-Approve

### README changes
- Language switcher: `[English](README.md) | [日本語](README.ja.md)`
- New sections: Quick Start, Commander Orchestration, Read Guard
- ASCII architecture diagram for 4-pane setup

## Test plan
- [ ] SKILL.md triggers correctly on "psmux-bridge", "cross-pane", "winsmux"
- [ ] README.md renders correctly on GitHub
- [ ] README.ja.md language switcher links work
- [ ] All checklist items pass (kebab-case, no XML, under 500 lines, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)