### PR TITLE
chore: bump version to 0.2.0

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -10,7 +10,7 @@ param(
 $ErrorActionPreference = 'Stop'
 [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
 
-$VERSION      = "1.0.0"
+$VERSION      = "0.2.0"
 $WINSMUX_DIR  = Join-Path $HOME ".winsmux"
 $BIN_DIR      = Join-Path $WINSMUX_DIR "bin"
 $BACKUP_DIR   = Join-Path $WINSMUX_DIR "backups"

--- a/scripts/psmux-bridge.ps1
+++ b/scripts/psmux-bridge.ps1
@@ -6,7 +6,7 @@ param(
 )
 
 # --- Config ---
-$VERSION = "1.1.0"
+$VERSION = "0.2.0"
 [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
 $ErrorActionPreference = 'Stop'
 


### PR DESCRIPTION
## Summary
- Align `install.ps1` and `psmux-bridge.ps1` versions to `0.2.0`
- Matches semver tag scheme (v0.1.0 → v0.2.0)

## Test plan
- [ ] `psmux-bridge version` → `psmux-bridge 0.2.0`
- [ ] `pwsh install.ps1 version` → `winsmux 0.2.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)