### PR TITLE
feat: add opt-in shield-harness for approval-free Orchestra

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -179,6 +179,19 @@ pwsh scripts/start-orchestra.ps1 `
 | `-Researcher` | `claude --model sonnet` |
 | `-Builder` | `codex` |
 | `-Reviewer` | `codex` |
+| `-ShieldHarness` | Off（スイッチ） |
+
+### 承認レスモード（Shield Harness）
+
+`-ShieldHarness` を追加すると Commander と Researcher が承認ダイアログなしで動作する。[Shield Harness](https://github.com/Sora-bluesky/shield-harness) が 22 のセキュリティフック、deny ルール、エビデンス記録を提供するため、危険な操作は自動でブロックされる。
+
+```powershell
+pwsh scripts/start-orchestra.ps1 -ProjectDir C:\my\project -ShieldHarness
+```
+
+- 初回: プロジェクトに shield-harness を自動初期化（`npx shield-harness init --profile standard`）
+- 2回目以降: 既存のインストールを検出してスキップ
+- `-ShieldHarness` なし: 従来通り（手動承認モード）
 
 ワークフローの流れ: **Plan → Build → Poll → Review → Poll → Judge → Commit → Next**
 

--- a/README.md
+++ b/README.md
@@ -179,6 +179,19 @@ pwsh scripts/start-orchestra.ps1 `
 | `-Researcher` | `claude --model sonnet` |
 | `-Builder` | `codex` |
 | `-Reviewer` | `codex` |
+| `-ShieldHarness` | Off (switch) |
+
+### Approval-Free Mode (Shield Harness)
+
+Add `-ShieldHarness` to enable approval-free operation for Commander and Researcher. [Shield Harness](https://github.com/Sora-bluesky/shield-harness) provides 22 security hooks, deny rules, and evidence recording — so agents operate without approval dialogs while dangerous operations are automatically blocked.
+
+```powershell
+pwsh scripts/start-orchestra.ps1 -ProjectDir C:\my\project -ShieldHarness
+```
+
+- First run: auto-initializes shield-harness in the project (`npx shield-harness init --profile standard`)
+- Subsequent runs: detects existing installation and skips init
+- Without `-ShieldHarness`: works exactly as before (manual approval mode)
 
 The workflow cycle: **Plan → Build → Poll → Review → Poll → Judge → Commit → Next**.
 

--- a/scripts/start-orchestra.ps1
+++ b/scripts/start-orchestra.ps1
@@ -10,12 +10,38 @@ param(
     [string]$Commander  = "claude --model opus --channels plugin:telegram@claude-plugins-official",
     [string]$Researcher = "claude --model sonnet",
     [string]$Builder    = "codex",
-    [string]$Reviewer   = "codex"
+    [string]$Reviewer   = "codex",
+    [switch]$ShieldHarness
 )
 
 [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
 
-# Detect running session
+# --- Shield Harness (opt-in) ---
+$shieldActive = $false
+if ($ShieldHarness) {
+    $markerFile = Join-Path $ProjectDir ".claude\hooks\sh-gate.js"
+    if (Test-Path $markerFile) {
+        Write-Output "[shield-harness] Detected in $ProjectDir"
+        $shieldActive = $true
+    } else {
+        Write-Output "[shield-harness] Initializing in $ProjectDir ..."
+        Push-Location $ProjectDir
+        try {
+            npx shield-harness init --profile standard
+            if ($LASTEXITCODE -eq 0) {
+                Write-Output "[shield-harness] Initialized successfully"
+                $shieldActive = $true
+            } else {
+                Write-Warning "[shield-harness] Init failed (exit code $LASTEXITCODE). Continuing without shield-harness."
+            }
+        } catch {
+            Write-Warning "[shield-harness] Init failed: $_. Continuing without shield-harness."
+        }
+        Pop-Location
+    }
+}
+
+# --- Detect running session ---
 $session = (psmux list-sessions -F '#{session_name}' 2>$null | Select-Object -First 1)
 if (-not $session) {
     Write-Error "No psmux session found. Start psmux first, then run this script."
@@ -23,14 +49,14 @@ if (-not $session) {
 }
 $session = $session.Trim()
 
-# Create 2x2 grid
+# --- Create 2x2 grid ---
 psmux split-window -h -t $session -c $ProjectDir
 psmux split-window -v -t "${session}:0.0" -c $ProjectDir
 psmux split-window -v -t "${session}:0.2" -c $ProjectDir
 
 Start-Sleep -Milliseconds 500
 
-# Get pane IDs
+# --- Get pane IDs ---
 $panes = psmux list-panes -t $session -F '#{pane_id}' 2>$null
 $paneIds = ($panes | Out-String).Trim() -split "`n" | ForEach-Object { $_.Trim() }
 
@@ -39,7 +65,7 @@ $resPane  = $paneIds[1]  # Bottom-left
 $bldPane  = $paneIds[2]  # Top-right
 $revPane  = $paneIds[3]  # Bottom-right
 
-# Commander system prompt with dynamic pane assignments
+# --- Commander system prompt ---
 $commanderPrompt = @"
 You are the COMMANDER in a 4-pane winsmux Orchestra. Load the winsmux skill immediately.
 
@@ -60,14 +86,21 @@ You are the COMMANDER in a 4-pane winsmux Orchestra. Load the winsmux skill imme
 
 $escapedPrompt = $commanderPrompt -replace "'","''"
 
-# Start agents
+# --- Start agents ---
 psmux send-keys -t $cmdPane "cd $ProjectDir && $Commander --append-system-prompt '$escapedPrompt'" Enter
 psmux send-keys -t $resPane "cd $ProjectDir && $Researcher" Enter
 psmux send-keys -t $bldPane "cd $ProjectDir && $Builder" Enter
 psmux send-keys -t $revPane "cd $ProjectDir && $Reviewer" Enter
 
+# --- Summary ---
+Write-Output ""
 Write-Output "Orchestra started in session '$session'"
 Write-Output "  Commander:  $cmdPane  ($Commander)"
 Write-Output "  Researcher: $resPane  ($Researcher)"
 Write-Output "  Builder:    $bldPane  ($Builder)"
 Write-Output "  Reviewer:   $revPane  ($Reviewer)"
+if ($shieldActive) {
+    Write-Output "  Shield:     ACTIVE (approval-free mode with 22 security hooks)"
+} else {
+    Write-Output "  Shield:     OFF (manual approval mode)"
+}


### PR DESCRIPTION
## Summary
- Add `-ShieldHarness` switch to `start-orchestra.ps1` (opt-in, off by default)
- Auto-initializes [shield-harness](https://github.com/Sora-bluesky/shield-harness) in target project on first use
- Detects existing installation on subsequent runs
- Commander/Researcher operate approval-free with 22 security hooks as safety net
- Without the switch: behavior unchanged (manual approval mode)
- Update both READMEs with approval-free mode documentation

## Test plan
- [ ] Without `-ShieldHarness`: agents start in manual approval mode (no change)
- [ ] With `-ShieldHarness` (first run): `npx shield-harness init` executes, `.claude/hooks/` populated
- [ ] With `-ShieldHarness` (second run): "Detected" message, no re-init
- [ ] Commander/Researcher execute safe ops without approval dialogs
- [ ] Dangerous ops (`rm -rf`, `curl`) blocked by hooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)