### PR TITLE
revert: undo direct push 5c1a02e (branch protection violation)

### DIFF
--- a/scripts/psmux-bridge.ps1
+++ b/scripts/psmux-bridge.ps1
@@ -6,13 +6,12 @@ param(
 )
 
 # --- Config ---
-$VERSION = "0.5.0"
+$VERSION = "0.4.0"
 [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
 $ErrorActionPreference = 'Stop'
 
-$ReadMarkDir    = Join-Path $env:TEMP "winsmux\read_marks"
-$WatermarkDir   = Join-Path $env:TEMP "winsmux\watermarks"
-$LabelsFile     = Join-Path $env:APPDATA "winsmux\labels.json"
+$ReadMarkDir = Join-Path $env:TEMP "winsmux\read_marks"
+$LabelsFile  = Join-Path $env:APPDATA "winsmux\labels.json"
 
 # --- Helper: Stop-WithError ---
 function Stop-WithError {
@@ -96,48 +95,6 @@ function Clear-ReadMark {
     }
 }
 
-# --- Helper: Watermark (change detection for read-after-send) ---
-function Get-WatermarkPath {
-    param([string]$PaneId)
-    $safe = $PaneId -replace '[%:]', '_'
-    return Join-Path $WatermarkDir $safe
-}
-
-function Save-Watermark {
-    param([string]$PaneId, [string]$Content)
-    if (-not (Test-Path $WatermarkDir)) {
-        New-Item -ItemType Directory -Path $WatermarkDir -Force | Out-Null
-    }
-    $hash = [System.BitConverter]::ToString(
-        [System.Security.Cryptography.SHA256]::Create().ComputeHash(
-            [System.Text.Encoding]::UTF8.GetBytes($Content)
-        )
-    ) -replace '-', ''
-    $path = Get-WatermarkPath $PaneId
-    Set-Content -Path $path -Value $hash -Encoding UTF8 -NoNewline
-}
-
-function Test-WatermarkChanged {
-    param([string]$PaneId, [string]$CurrentContent)
-    $path = Get-WatermarkPath $PaneId
-    if (-not (Test-Path $path)) { return $true }
-    $savedHash = Get-Content -Path $path -Raw -Encoding UTF8
-    $currentHash = [System.BitConverter]::ToString(
-        [System.Security.Cryptography.SHA256]::Create().ComputeHash(
-            [System.Text.Encoding]::UTF8.GetBytes($CurrentContent)
-        )
-    ) -replace '-', ''
-    return $currentHash -ne $savedHash
-}
-
-function Clear-Watermark {
-    param([string]$PaneId)
-    $path = Get-WatermarkPath $PaneId
-    if (Test-Path $path) {
-        Remove-Item -Path $path -Force
-    }
-}
-
 # --- Commands ---
 
 function Invoke-Id {
@@ -193,7 +150,7 @@ function Invoke-List {
 function Invoke-Read {
     if (-not $Target) { Stop-WithError "usage: psmux-bridge read <target> [lines]" }
 
-    $lines = 200
+    $lines = 50
     if ($Rest -and $Rest.Count -gt 0) {
         $lines = [int]$Rest[0]
     }
@@ -202,22 +159,8 @@ function Invoke-Read {
     $paneId = Confirm-Target $paneId
 
     $output = & psmux capture-pane -t $paneId -p -J -S "-$lines"
-    $currentText = ($output | Out-String).TrimEnd()
+    Write-Output ($output | Out-String).TrimEnd()
 
-    # Watermark-based change detection: if a watermark exists (set by send),
-    # only return content when the pane buffer has actually changed.
-    $wmPath = Get-WatermarkPath $paneId
-    if (Test-Path $wmPath) {
-        if (-not (Test-WatermarkChanged $paneId $currentText)) {
-            Write-Output "[psmux-bridge] waiting for response..."
-            Set-ReadMark $paneId
-            return
-        }
-        # Buffer changed — agent has produced new output
-        Clear-Watermark $paneId
-    }
-
-    Write-Output $currentText
     Set-ReadMark $paneId
 }
 
@@ -280,23 +223,27 @@ function Invoke-Send {
     $paneId = Resolve-Target $Target
     $paneId = Confirm-Target $paneId
 
-    # Step 1: Type text directly (no header — headers break TUI agents like Claude Code)
-    & psmux send-keys -t $paneId -l -- "$text"
-
-    # Step 2: Verify text landed
-    Start-Sleep -Milliseconds 300
-
-    # Step 3: Submit with Enter
-    & psmux send-keys -t $paneId Enter
-
-    # Step 4: Save watermark for change detection in subsequent read calls
-    Start-Sleep -Milliseconds 800
-    $snapshot = & psmux capture-pane -t $paneId -p -J -S "-200"
-    $snapshotText = ($snapshot | Out-String).TrimEnd()
-    Save-Watermark $paneId $snapshotText
-
-    # Reset read mark so next read works without guard error
+    # Step 1: READ (satisfy read guard)
+    $output = & psmux capture-pane -t $paneId -p -J -S "-5"
     Set-ReadMark $paneId
+
+    # Step 2: MESSAGE (type header + text)
+    $myId = (& psmux display-message -p '#{pane_id}' | Out-String).Trim()
+    $myCoord = (& psmux display-message -p '#{session_name}:#{window_index}.#{pane_index}' | Out-String).Trim()
+    $agentName = if ($env:WINSMUX_AGENT_NAME) { $env:WINSMUX_AGENT_NAME } else { "unknown" }
+
+    $header = "[psmux-bridge from:$agentName pane:$myId at:$myCoord -- load the winsmux skill to reply]"
+    & psmux send-keys -t $paneId -l -- "$header $text"
+    Clear-ReadMark $paneId
+
+    # Step 3: READ (verify text landed)
+    Start-Sleep -Milliseconds 200
+    $verify = & psmux capture-pane -t $paneId -p -J -S "-3"
+    Set-ReadMark $paneId
+
+    # Step 4: KEYS Enter (submit)
+    & psmux send-keys -t $paneId Enter
+    Clear-ReadMark $paneId
 
     Write-Output "sent to $paneId"
 }
@@ -506,16 +453,6 @@ function Invoke-ClipboardPaste {
     Write-Output "sent to $paneId"
 }
 
-function Invoke-Focus {
-    if (-not $Target) { Stop-WithError "usage: psmux-bridge focus <label|target>" }
-
-    $paneId = Resolve-Target $Target
-    $paneId = Confirm-Target $paneId
-
-    & psmux select-pane -t $paneId
-    Write-Output "Focused pane $paneId ($Target)"
-}
-
 function Invoke-Version {
     Write-Output "psmux-bridge $VERSION"
 }
@@ -537,7 +474,6 @@ Commands:
   ime-input <target>        Open GUI dialog for Japanese IME input
   image-paste <target>      Save clipboard image and send path to pane
   clipboard-paste <target>  Send clipboard text to pane
-  focus <label|target>      Switch active pane (use from outside psmux)
   doctor                    Check environment and IME diagnostics
   version                   Show version
 "@
@@ -557,7 +493,6 @@ switch ($Command) {
     'ime-input'       { Invoke-ImeInput }
     'image-paste'     { Invoke-ImagePaste }
     'clipboard-paste' { Invoke-ClipboardPaste }
-    'focus'           { Invoke-Focus }
     'doctor'          { Invoke-Doctor }
     'version'         { Invoke-Version }
     ''                { Show-Usage }

--- a/scripts/start-orchestra.ps1
+++ b/scripts/start-orchestra.ps1
@@ -86,52 +86,11 @@ You are the COMMANDER in a 4-pane winsmux Orchestra. Load the winsmux skill imme
 
 $escapedPrompt = $commanderPrompt -replace "'","''"
 
-# --- Codex MCP URL quarantine (workaround: v0.117.0 "url not supported for stdio") ---
-# HTTP (non-HTTPS) URL-based MCP servers cause Codex startup failure.
-# HTTPS URLs (stitch, vercel etc.) work fine — only quarantine HTTP ones.
-$codexConfigPath = Join-Path $HOME ".codex" "config.toml"
-$codexConfigBackup = $null
-
-if (($Builder -match 'codex' -or $Reviewer -match 'codex') -and (Test-Path $codexConfigPath)) {
-    $codexConfigBackup = Get-Content $codexConfigPath -Raw
-    $quarantined = @()
-    $currentSection = $null
-
-    foreach ($line in (Get-Content $codexConfigPath)) {
-        if ($line -match '^\[mcp_servers\.([^\]]+)\]') {
-            $currentSection = $Matches[1]
-        }
-        elseif ($currentSection -and $line -match '^\s*url\s*=\s*"http://') {
-            $quarantined += $currentSection
-            $currentSection = $null
-        }
-        elseif ($line -match '^\[' -and $line -notmatch '\.env_http_headers') {
-            $currentSection = $null
-        }
-    }
-
-    if ($quarantined.Count -gt 0) {
-        foreach ($s in $quarantined) {
-            codex mcp remove $s 2>$null | Out-Null
-            Write-Output "[codex-mcp] Quarantined '$s' (http:// URL not supported for stdio)"
-        }
-    } else {
-        $codexConfigBackup = $null
-    }
-}
-
 # --- Start agents ---
 psmux send-keys -t $cmdPane "cd $ProjectDir && $Commander --append-system-prompt '$escapedPrompt'" Enter
 psmux send-keys -t $resPane "cd $ProjectDir && $Researcher" Enter
 psmux send-keys -t $bldPane "cd $ProjectDir && $Builder" Enter
 psmux send-keys -t $revPane "cd $ProjectDir && $Reviewer" Enter
-
-# --- Restore Codex MCP config ---
-if ($codexConfigBackup) {
-    Start-Sleep -Seconds 3  # Allow Codex to read config before restoring
-    Set-Content -Path $codexConfigPath -Value $codexConfigBackup -Encoding UTF8 -NoNewline
-    Write-Output "[codex-mcp] Config restored (quarantined servers back in place)"
-}
 
 # --- Summary ---
 Write-Output ""
@@ -145,11 +104,3 @@ if ($shieldActive) {
 } else {
     Write-Output "  Shield:     OFF (manual approval mode)"
 }
-
-$bridgePath = Join-Path $PSScriptRoot "psmux-bridge.ps1"
-Write-Output ""
-Write-Output "Navigation (pane switching from outside psmux):"
-Write-Output "  pwsh $bridgePath focus commander"
-Write-Output "  pwsh $bridgePath focus researcher"
-Write-Output "  pwsh $bridgePath focus builder"
-Write-Output "  pwsh $bridgePath focus reviewer"


### PR DESCRIPTION
## Summary
- Revert commit `5c1a02e` which was pushed directly to main without PR
- Content will be re-applied via proper PR after this revert merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)