### PR TITLE
feat: auto-enable pane border labels on name command

### DIFF
--- a/scripts/psmux-bridge.ps1
+++ b/scripts/psmux-bridge.ps1
@@ -301,6 +301,17 @@ function Invoke-Send {
     Write-Output "sent to $paneId"
 }
 
+function Enable-PaneBorderLabels {
+    # Auto-enable pane border labels if not already set
+    try {
+        $current = (& psmux show-options -g -v pane-border-status 2>&1 | Out-String).Trim()
+        if ($current -ne 'top' -and $current -ne 'bottom') {
+            & psmux set-option -g pane-border-status top 2>$null
+            & psmux set-option -g pane-border-format ' #{?#{pane_title},#{pane_title},#{b:pane_current_path}} ' 2>$null
+        }
+    } catch { }
+}
+
 function Invoke-Name {
     if (-not $Target) { Stop-WithError "usage: psmux-bridge name <target> <label>" }
     if (-not $Rest -or $Rest.Count -eq 0) { Stop-WithError "usage: psmux-bridge name <target> <label>" }
@@ -313,7 +324,8 @@ function Invoke-Name {
     $labels[$label] = $paneId
     Save-Labels $labels
 
-    # Also set pane title (best-effort)
+    # Enable border labels and set pane title
+    Enable-PaneBorderLabels
     try {
         & psmux select-pane -t $paneId -T "$label" 2>$null
     } catch { }

--- a/scripts/start-orchestra.ps1
+++ b/scripts/start-orchestra.ps1
@@ -65,6 +65,13 @@ $resPane  = $paneIds[1]  # Bottom-left
 $bldPane  = $paneIds[2]  # Top-right
 $revPane  = $paneIds[3]  # Bottom-right
 
+# --- Label panes (auto-enables border display) ---
+$bridgePath = Join-Path $PSScriptRoot "psmux-bridge.ps1"
+& pwsh $bridgePath name $cmdPane commander
+& pwsh $bridgePath name $resPane researcher
+& pwsh $bridgePath name $bldPane builder
+& pwsh $bridgePath name $revPane reviewer
+
 # --- Commander system prompt ---
 $commanderPrompt = @"
 You are the COMMANDER in a 4-pane winsmux Orchestra. Load the winsmux skill immediately.
@@ -81,7 +88,6 @@ You are the COMMANDER in a 4-pane winsmux Orchestra. Load the winsmux skill imme
 3. Use Reviewer ($revPane) for code review after Builder completes.
 4. Follow the Commander workflow: Plan -> Build -> Poll -> Review -> Poll -> Judge -> Commit -> Next.
 5. Use psmux-bridge commands for all cross-pane communication.
-6. Label panes on first use: psmux-bridge name $resPane researcher && psmux-bridge name $bldPane builder && psmux-bridge name $revPane reviewer
 "@
 
 $escapedPrompt = $commanderPrompt -replace "'","''"


### PR DESCRIPTION
## Summary
- `psmux-bridge name` now auto-enables `pane-border-status top` and `pane-border-format` on first use
- Labels appear immediately on pane border lines — no manual psmux config needed
- `start-orchestra.ps1` labels all 4 panes at setup time (Commander, Researcher, Builder, Reviewer)
- Removed labeling instruction from Commander's system prompt (no longer needed)

## Test plan
- [ ] Fresh psmux session → `psmux-bridge name %1 test` → border label appears on top border
- [ ] `start-orchestra.ps1` → all 4 panes show role names on borders immediately
- [ ] `psmux-bridge list` → labels displayed
- [ ] `psmux-bridge send researcher "hello"` → label resolution works

🤖 Generated with [Claude Code](https://claude.com/claude-code)