### PR TITLE
fix: workaround pane-border-status rendering (v0.5.2)

### DIFF
--- a/.psmux.conf
+++ b/.psmux.conf
@@ -15,15 +15,20 @@ set -g default-command pwsh
 # --- Status bar ---
 set -g status-style "bg=colour235,fg=colour4"
 set -g status-left "[#S] "
-set -g status-right "%H:%M"
+set -g status-right "← #{pane_title} → %H:%M"
 set -g status-left-length 20
+set -g status-right-length 50
+
+# --- Terminal title (shows active pane role in tab) ---
+set -g set-titles on
+set -g set-titles-string "#{pane_title} - #{session_name}"
 
 # --- Pane borders ---
 set -g pane-border-style "fg=colour240"
 set -g pane-active-border-style "fg=colour4"
 set -g pane-border-lines heavy
-set -g pane-border-status top
-set -g pane-border-format " #{?#{pane_title},#{pane_title},#{b:pane_current_path}} "
+# pane-border-status: accepted but not rendered in psmux v3.x (Issue #22)
+# Workaround: pane labels shown in status-right and terminal tab title
 
 # --- Alt keybindings (smux compatible) ---
 

--- a/install.ps1
+++ b/install.ps1
@@ -10,7 +10,7 @@ param(
 $ErrorActionPreference = 'Stop'
 [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
 
-$VERSION      = "0.5.1"
+$VERSION      = "0.5.2"
 $WINSMUX_DIR  = Join-Path $HOME ".winsmux"
 $BIN_DIR      = Join-Path $WINSMUX_DIR "bin"
 $BACKUP_DIR   = Join-Path $WINSMUX_DIR "backups"

--- a/scripts/psmux-bridge.ps1
+++ b/scripts/psmux-bridge.ps1
@@ -6,7 +6,7 @@ param(
 )
 
 # --- Config ---
-$VERSION = "0.5.1"
+$VERSION = "0.5.2"
 [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
 $ErrorActionPreference = 'Stop'
 
@@ -301,14 +301,18 @@ function Invoke-Send {
     Write-Output "sent to $paneId"
 }
 
-function Enable-PaneBorderLabels {
-    # Auto-enable pane border labels if not already set
+function Enable-PaneLabels {
+    # Auto-enable pane label display in status bar and terminal tab title.
+    # pane-border-status is accepted but not rendered in psmux v3.x (Issue #22),
+    # so we use status-right and set-titles as a workaround.
     try {
-        $current = (& psmux show-options -g -v pane-border-status 2>&1 | Out-String).Trim()
-        if ($current -ne 'top' -and $current -ne 'bottom') {
-            & psmux set-option -g pane-border-status top 2>$null
-            & psmux set-option -g pane-border-format ' #{?#{pane_title},#{pane_title},#{b:pane_current_path}} ' 2>$null
+        $currentRight = (& psmux show-options -g -v status-right 2>&1 | Out-String).Trim()
+        if ($currentRight -notmatch 'pane_title') {
+            & psmux set-option -g status-right '← #{pane_title} → %H:%M' 2>$null
+            & psmux set-option -g status-right-length 50 2>$null
         }
+        & psmux set-option -g set-titles on 2>$null
+        & psmux set-option -g set-titles-string '#{pane_title} - #{session_name}' 2>$null
     } catch { }
 }
 
@@ -324,8 +328,8 @@ function Invoke-Name {
     $labels[$label] = $paneId
     Save-Labels $labels
 
-    # Enable border labels and set pane title
-    Enable-PaneBorderLabels
+    # Enable pane label display and set pane title
+    Enable-PaneLabels
     try {
         & psmux select-pane -t $paneId -T "$label" 2>$null
     } catch { }


### PR DESCRIPTION
## Summary
Closes #22

`pane-border-status top` is accepted but not rendered in psmux v3.x.
Workaround: show pane labels via `status-right` and `set-titles` instead.

- `psmux-bridge name %1 builder` → status bar shows `← builder →`, terminal tab shows `builder - session`
- Works with any pane configuration (Orchestra, custom, etc.)
- `Enable-PaneBorderLabels` → `Enable-PaneLabels` (status bar + tab title)
- Remove broken `pane-border-status`/`pane-border-format` from `.psmux.conf`
- Version 0.5.2

## Test plan
- [ ] `psmux-bridge name %1 test` → status bar shows `← test →`
- [ ] Switch panes → status bar updates to show active pane's label
- [ ] Windows Terminal tab shows pane label
- [ ] `psmux-bridge list` → labels displayed

🤖 Generated with [Claude Code](https://claude.com/claude-code)