### PR TITLE
feat: progressive disclosure for orchestra management protocols

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -197,7 +197,7 @@ pwsh scripts/start-orchestra.ps1 -ProjectDir C:\my\project -Rows 2 -Cols 3 -Agen
 | `-Agents`        | 4ペインデフォルト | `@{label; command}` の配列                                                                  |
 | `-ShieldHarness` | Off               | [Shield Harness](https://github.com/Sora-bluesky/shield-harness) による承認レスモード有効化 |
 
-詳細は [SKILL.md](skills/winsmux/SKILL.md) を参照。
+詳細は [SKILL.md](skills/winsmux/SKILL.md) を参照。管理プロトコル（パイプライン運用、researcher 偵察、reviewer 小分け、エージェント選定）はスキルの references/ に同梱され、エージェントがオンデマンドで読み込む。
 
 ## AI Agent Skills
 
@@ -206,6 +206,12 @@ winsmux スキルをインストールすると、エージェントが psmux-br
 ```powershell
 npx skills add Sora-bluesky/winsmux
 ```
+
+スキルに含まれるもの:
+
+- psmux-bridge の使い方（[SKILL.md](skills/winsmux/SKILL.md)）
+- Orchestra 管理プロトコル（[references/orchestra-management.md](skills/winsmux/references/orchestra-management.md)）
+- エージェント選定ガイド（[references/agent-selection.md](skills/winsmux/references/agent-selection.md)）
 
 Claude Code、Codex、Cursor、Copilot、[その他のエージェント](https://skills.sh)で動作する。
 

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ The `.commander-prompt.txt` is auto-generated with actual pane IDs, agent labels
 | `-Agents`        | 4-pane default    | Array of `@{label; command}` maps                                                               |
 | `-ShieldHarness` | Off               | Enable approval-free mode with [Shield Harness](https://github.com/Sora-bluesky/shield-harness) |
 
-See [SKILL.md](skills/winsmux/SKILL.md) for the full Commander workflow.
+See [SKILL.md](skills/winsmux/SKILL.md) for the full Commander workflow. Management protocols (pipeline operation, researcher recon, reviewer batching, agent selection) are bundled as skill references and loaded on-demand by agents.
 
 ## AI Agent Skills
 
@@ -206,6 +206,12 @@ Install the winsmux skill to teach your agents how to use psmux-bridge:
 ```powershell
 npx skills add Sora-bluesky/winsmux
 ```
+
+The skill includes:
+
+- Core psmux-bridge usage ([SKILL.md](skills/winsmux/SKILL.md))
+- Orchestra management protocol ([references/orchestra-management.md](skills/winsmux/references/orchestra-management.md))
+- Agent selection guide ([references/agent-selection.md](skills/winsmux/references/agent-selection.md))
 
 Works with Claude Code, Codex, Cursor, Copilot, and [other agents](https://skills.sh).
 

--- a/install.ps1
+++ b/install.ps1
@@ -10,7 +10,7 @@ param(
 $ErrorActionPreference = 'Stop'
 [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
 
-$VERSION      = "0.6.0"
+$VERSION      = "0.7.0"
 $WINSMUX_DIR  = Join-Path $HOME ".winsmux"
 $BIN_DIR      = Join-Path $WINSMUX_DIR "bin"
 $BACKUP_DIR   = Join-Path $WINSMUX_DIR "backups"

--- a/scripts/psmux-bridge.ps1
+++ b/scripts/psmux-bridge.ps1
@@ -6,7 +6,7 @@ param(
 )
 
 # --- Config ---
-$VERSION = "0.6.0"
+$VERSION = "0.7.0"
 [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
 $ErrorActionPreference = 'Stop'
 

--- a/skills/winsmux/SKILL.md
+++ b/skills/winsmux/SKILL.md
@@ -27,33 +27,34 @@ Cross-pane AI agent communication on Windows. Use `psmux-bridge` for all pane in
 
 Identify the mode **before** communicating with a pane.
 
-| Mode | Condition | Rule |
-|------|-----------|------|
-| **Agent Mode** | Peer has winsmux skill (Claude Code, skill-enabled Codex) | DO NOT POLL. Reply arrives in YOUR pane via `[psmux-bridge from:...]` |
-| **Non-Agent Mode** | Codex CLI (no skill), plain shell, dev server | POLL REQUIRED. You must `read` periodically to check status |
+| Mode               | Condition                                                 | Rule                                                                  |
+| ------------------ | --------------------------------------------------------- | --------------------------------------------------------------------- |
+| **Agent Mode**     | Peer has winsmux skill (Claude Code, skill-enabled Codex) | DO NOT POLL. Reply arrives in YOUR pane via `[psmux-bridge from:...]` |
+| **Non-Agent Mode** | Codex CLI (no skill), plain shell, dev server             | POLL REQUIRED. You must `read` periodically to check status           |
 
 **Agent Mode** -- send your message, press Enter, and move on. The reply appears directly in your pane. Do not sleep, poll, or loop.
 
 **Non-Agent Mode** -- after sending a task, enter the POLL loop (see Commander Orchestration below). Read the target pane at intervals to detect completion, approval prompts, or errors.
 
 The ONLY reasons to read a target pane in Agent Mode:
+
 - **Before** interacting (enforced by Read Guard)
 - **After typing** to verify text landed before pressing Enter
 
 ## Core Commands
 
-| Command | Description | Example |
-|---------|-------------|---------|
-| `psmux-bridge list` | Show all panes with target, pid, command, size, label | `psmux-bridge list` |
-| `psmux-bridge read <target> [lines]` | Read last N lines (default 50), sets Read Guard mark | `psmux-bridge read codex 100` |
-| `psmux-bridge type <target> <text>` | Type literal text (no Enter), requires Read Guard | `psmux-bridge type codex "hello"` |
-| `psmux-bridge send <target> <text>` | **Recommended.** Send tagged message + auto Enter in one step | `psmux-bridge send codex "review src/auth.ts"` |
+| Command                                | Description                                                   | Example                                           |
+| -------------------------------------- | ------------------------------------------------------------- | ------------------------------------------------- |
+| `psmux-bridge list`                    | Show all panes with target, pid, command, size, label         | `psmux-bridge list`                               |
+| `psmux-bridge read <target> [lines]`   | Read last N lines (default 50), sets Read Guard mark          | `psmux-bridge read codex 100`                     |
+| `psmux-bridge type <target> <text>`    | Type literal text (no Enter), requires Read Guard             | `psmux-bridge type codex "hello"`                 |
+| `psmux-bridge send <target> <text>`    | **Recommended.** Send tagged message + auto Enter in one step | `psmux-bridge send codex "review src/auth.ts"`    |
 | `psmux-bridge message <target> <text>` | Type text with sender header (no Enter -- use `send` instead) | `psmux-bridge message codex "review src/auth.ts"` |
-| `psmux-bridge keys <target> <key>...` | Send special keys, requires Read Guard | `psmux-bridge keys codex Enter` |
-| `psmux-bridge name <target> <label>` | Label a pane | `psmux-bridge name %3 codex` |
-| `psmux-bridge resolve <label>` | Print pane ID for a label | `psmux-bridge resolve codex` |
-| `psmux-bridge id` | Print this pane's ID | `psmux-bridge id` |
-| `psmux-bridge doctor` | Run environment diagnostics | `psmux-bridge doctor` |
+| `psmux-bridge keys <target> <key>...`  | Send special keys, requires Read Guard                        | `psmux-bridge keys codex Enter`                   |
+| `psmux-bridge name <target> <label>`   | Label a pane                                                  | `psmux-bridge name %3 codex`                      |
+| `psmux-bridge resolve <label>`         | Print pane ID for a label                                     | `psmux-bridge resolve codex`                      |
+| `psmux-bridge id`                      | Print this pane's ID                                          | `psmux-bridge id`                                 |
+| `psmux-bridge doctor`                  | Run environment diagnostics                                   | `psmux-bridge doctor`                             |
 
 For full parameter details, see [psmux-bridge CLI Reference](references/psmux-bridge.md).
 
@@ -111,149 +112,18 @@ When you receive this header, reply using `psmux-bridge message` to the pane ID 
 
 ## Commander Orchestration
 
-When you are the **commander** orchestrating builder/reviewer/monitor panes, follow this workflow. Builder and reviewer are Non-Agent Mode (Codex CLI without winsmux skill).
+When you are the **commander** orchestrating builder/reviewer/researcher/monitor panes, load the management protocol:
 
-### Roles -- Strict Separation (CRITICAL)
+- [Orchestra Management Protocol](references/orchestra-management.md) -- roles, workflow cycle, pipeline operation, multi-builder coordination, POLL/auto-approve, researcher/reviewer protocols, prohibitions
+- [Agent Selection Guide](references/agent-selection.md) -- which CLI to assign for each task type, approval-free flags, known limitations
 
-| Pane | Role | Responsibility | Prohibited |
-|------|------|---------------|------------|
-| commander | Design, orchestrate, commit | Task decomposition, send instructions, judge results, git ops | **Writing or modifying code directly** |
-| builder | Implement, fix | Code implementation, fix reviewer findings | Review, commit |
-| reviewer | Code review | Quality, security, architecture review | Fix code, commit |
-| monitor | Test, observe | Dev server, test runner, build logs | Not an agent -- plain shell only |
+**Key rules (read the full protocol for details):**
 
-**Commander does NOT write code.** When the reviewer reports findings, the commander reads them and sends fix instructions to the **builder**. The commander never fixes code itself.
-
-### Workflow Cycle
-
-```
-1. PLAN    -- Read roadmap/task, decide implementation approach
-2. BUILD   -- Send implementation instructions to builder
-3. POLL    -- Wait for builder completion (MANDATORY, never skip)
-4. REVIEW  -- Send review request to reviewer
-5. POLL    -- Wait for reviewer completion (MANDATORY, never skip)
-6. JUDGE   -- Evaluate review results
-             OK  -> proceed to COMMIT
-             NG  -> send fix instructions to builder (back to step 2)
-7. COMMIT  -- Commander commits via git
-8. NEXT    -- Move to next task (back to step 1)
-```
-
-### BUILD -- Send Instructions
-
-```powershell
-psmux-bridge read builder 20
-psmux-bridge message builder "Implement the auth middleware. Requirements: ..."
-psmux-bridge read builder 20
-psmux-bridge keys builder Enter
-# Immediately proceed to POLL. Do not context-switch.
-```
-
-### POLL and Auto-Approve
-
-After BUILD or REVIEW instructions, enter this POLL loop. **Never skip POLL.**
-
-Read at 10-second intervals. Maximum 12 rounds (about 120 seconds).
-
-#### State Detection Patterns
-
-| Output contains | State | Commander action |
-|----------------|-------|-----------------|
-| `Do you want to proceed?` / `1. Yes` | Approval needed | Auto-approve (see below) |
-| `2. Yes, and don't ask again` | Approval needed (persistent option) | `type "2"` to skip future prompts of same kind |
-| `> Implement` / `> Write` / `> Improve` | Complete (prompt idle) | End POLL, next step |
-| `gpt-5.4 high` / `100% left` | Complete (idle) | End POLL, next step |
-| `Editing...` / `Running...` / `Reading...` | Working | Do nothing, next POLL |
-| `"type": "error"` / `API error` / `rate limit` | API error | Report to user. Suggest model change |
-| `error` / `failed` / `Error` | Execution error | Read error details, decide action |
-| `Esc to cancel` | Approval needed | Verify content, then `keys Enter` |
-| `[Y/n]` / `[y/N]` | Shell confirmation | `type "y"` + `keys Enter` |
-| `Sandbox` | Sandbox approval | `type "1"` + `keys Enter` |
-
-#### Auto-Approve Procedure
-
-```powershell
-# Standard approval
-psmux-bridge read builder 10
-psmux-bridge type builder "1"
-psmux-bridge read builder 5
-psmux-bridge keys builder Enter
-
-# Persistent approval (skip future prompts of same kind)
-psmux-bridge read builder 10
-psmux-bridge type builder "2"
-psmux-bridge read builder 5
-psmux-bridge keys builder Enter
-```
-
-#### Dangerous Commands -- Never Auto-Approve
-
-If approval content contains any of these patterns, **do NOT auto-approve**. Report to the user instead:
-
-- `rm -rf` / `Remove-Item -Recurse -Force`
-- `git push --force` / `git reset --hard`
-- `DROP TABLE` / `DELETE FROM`
-- Execution of unknown external scripts
-
-#### POLL Timeout
-
-After 12 rounds (about 120 seconds) with no completion:
-
-1. Read the last 20 lines of the target pane
-2. Report state (approval-waiting / working / error) to the user
-3. Wait for user instructions
-
-### REVIEW -- Send Review Request
-
-```powershell
-psmux-bridge read reviewer 20
-psmux-bridge message reviewer "Review uncommitted changes via git diff HEAD. Focus: (1) security (2) architecture (3) tests"
-psmux-bridge read reviewer 20
-psmux-bridge keys reviewer Enter
-# Immediately proceed to POLL for reviewer.
-```
-
-### JUDGE -- Evaluate Review Results
-
-Read reviewer output with `psmux-bridge read reviewer 50`:
-
-- **LGTM / APPROVE / no issues** -- proceed to COMMIT
-- **REQUEST_CHANGES / findings reported** -- read findings, send fix instructions to **builder** (back to BUILD step). Commander does NOT fix code itself
-- **Critical issue** -- report to user and await guidance
-
-### COMMIT
-
-Commander performs git operations directly:
-
-```powershell
-git add <files>
-git commit -m "feat: ..."
-```
-
-### Monitor Pane
-
-Monitor is a Non-Agent plain shell for test execution and log observation.
-
-```powershell
-psmux-bridge read monitor 3
-psmux-bridge type monitor "pytest tests/ -q"
-psmux-bridge read monitor 3
-psmux-bridge keys monitor Enter
-
-# Wait, then check results
-Start-Sleep 10
-psmux-bridge read monitor 30
-# Evaluate: "passed" / "failed"
-```
-
-### Commander Prohibitions
-
-1. **Never write or modify code directly** -- all implementation goes through builder
-2. **Never skip POLL** -- always POLL after BUILD and REVIEW instructions
-3. **Never commit without review** -- always run REVIEW before COMMIT
-4. **Never send instructions to multiple panes simultaneously** -- one at a time
-5. **Never auto-approve dangerous commands** -- report to user
-6. **Never POLL beyond 120 seconds** -- timeout after 12 rounds, report to user
+1. **Never write code yourself** -- delegate to builders
+2. **Never skip reconnaissance** -- send researcher before builders
+3. **Never let agents idle** -- pipeline operation, assign next task within 10 seconds
+4. **Never skip POLL** -- always poll after BUILD and REVIEW
+5. **Split by file boundary** -- each builder gets explicit, non-overlapping files
 
 ## Examples
 
@@ -327,16 +197,18 @@ git commit -m "feat: add rate limiting middleware"
 
 ## Troubleshooting
 
-| Problem | Cause | Solution |
-|---------|-------|----------|
-| `error: must read the pane before interacting` | Read Guard not satisfied | Run `psmux-bridge read <target>` first |
-| `invalid target` | Label not found or pane ID wrong | Run `psmux-bridge list` to verify panes; re-label with `psmux-bridge name` |
-| `psmux: command not found` | psmux not installed or not in PATH | Install psmux; verify with `psmux -V` |
-| Message sent but no reply (Agent Mode) | Peer does not have winsmux skill loaded | Switch to Non-Agent Mode with POLL |
-| POLL times out after 120 seconds | Builder/reviewer stuck or errored | Read last 20 lines, report state to user |
-| Auto-approve triggered on dangerous command | Pattern not caught | Add pattern to dangerous-command list; report to user |
-| `psmux-bridge doctor` shows warnings | Environment misconfigured | Fix reported issues (TMUX_PANE, WINSMUX_AGENT_NAME, etc.) |
+| Problem                                        | Cause                                   | Solution                                                                   |
+| ---------------------------------------------- | --------------------------------------- | -------------------------------------------------------------------------- |
+| `error: must read the pane before interacting` | Read Guard not satisfied                | Run `psmux-bridge read <target>` first                                     |
+| `invalid target`                               | Label not found or pane ID wrong        | Run `psmux-bridge list` to verify panes; re-label with `psmux-bridge name` |
+| `psmux: command not found`                     | psmux not installed or not in PATH      | Install psmux; verify with `psmux -V`                                      |
+| Message sent but no reply (Agent Mode)         | Peer does not have winsmux skill loaded | Switch to Non-Agent Mode with POLL                                         |
+| POLL times out after 120 seconds               | Builder/reviewer stuck or errored       | Read last 20 lines, report state to user                                   |
+| Auto-approve triggered on dangerous command    | Pattern not caught                      | Add pattern to dangerous-command list; report to user                      |
+| `psmux-bridge doctor` shows warnings           | Environment misconfigured               | Fix reported issues (TMUX_PANE, WINSMUX_AGENT_NAME, etc.)                  |
 
 ## References
 
 - [psmux-bridge CLI Reference](references/psmux-bridge.md) -- full command parameters, environment variables, file locations, target resolution details
+- [Orchestra Management Protocol](references/orchestra-management.md) -- roles, workflow, pipeline operation, multi-builder coordination, POLL patterns
+- [Agent Selection Guide](references/agent-selection.md) -- CLI-to-task mapping, approval-free flags, known limitations

--- a/skills/winsmux/references/agent-selection.md
+++ b/skills/winsmux/references/agent-selection.md
@@ -1,0 +1,29 @@
+# Agent Selection Guide
+
+Guidelines for choosing which CLI agent to assign each task type in a multi-vendor Orchestra.
+
+## Task-to-CLI Mapping
+
+| Task Type                     | Recommended CLI       | Reason                                                       |
+| ----------------------------- | --------------------- | ------------------------------------------------------------ |
+| Large file structure analysis | Codex                 | Gemini Pro took 2+ min for 191 files; Codex completed in 20s |
+| Single file summary           | Any                   | No significant difference                                    |
+| Code review                   | Codex                 | Fast response (~90s for multi-builder review)                |
+| Investigation / analysis      | Claude Sonnet         | Best balance of accuracy and speed (~30s)                    |
+| Parallel implementation       | Codex or Gemini Flash | Both respond quickly; assign independent file sets           |
+
+## Approval-Free Flags (with Shield Harness)
+
+| CLI         | Flag                                  | Notes                                   |
+| ----------- | ------------------------------------- | --------------------------------------- |
+| Claude Code | `--permission-mode bypassPermissions` | Shield Harness hooks provide safety net |
+| Codex CLI   | `--full-auto`                         | Sandboxed automatic execution           |
+| Gemini CLI  | `--yolo`                              | All tool calls auto-approved            |
+
+Without Shield Harness: no flags are added (manual approval mode).
+
+## Known Limitations
+
+- **Gemini Pro**: Slow on large-scale file processing. Use for focused tasks, not bulk analysis.
+- **Codex (gpt-5.3-codex-spark)**: Smaller context window. Send reviewer diffs in small batches (max 3 files/message).
+- **Gemini CLI**: Orphaned processes after session end. Run cleanup: `taskkill /F /IM node.exe /FI "WINDOWTITLE eq gemini*"`

--- a/skills/winsmux/references/orchestra-management.md
+++ b/skills/winsmux/references/orchestra-management.md
@@ -1,0 +1,226 @@
+# Orchestra Management Protocol
+
+Management protocols for the Commander orchestrating multiple agents in psmux panes.
+
+## Roles -- Strict Separation (CRITICAL)
+
+| Pane       | Role                        | Responsibility                                                | Prohibited                                |
+| ---------- | --------------------------- | ------------------------------------------------------------- | ----------------------------------------- |
+| commander  | Design, orchestrate, commit | Task decomposition, send instructions, judge results, git ops | **Writing or modifying code directly**    |
+| builder    | Implement, fix              | Code implementation, fix reviewer findings                    | Review, commit                            |
+| builder-N  | Implement (parallel)        | Same as builder, assigned independent file set                | Touching files assigned to other builders |
+| researcher | Investigate, verify         | Code analysis, testing, linting, docs                         | Implementation, commit                    |
+| reviewer   | Code review                 | Quality, security, architecture review                        | Fix code, commit                          |
+| monitor    | Test, observe               | Dev server, test runner, build logs                           | Not an agent -- plain shell only          |
+
+**Commander does NOT write code.** All implementation goes through builders.
+
+## Pipeline Operation (No Serial Processing)
+
+Run all agents concurrently. Idle agents are wasted resources.
+
+```
+BAD (serial):
+  researcher -> wait -> all builders -> wait -> reviewer
+
+GOOD (pipeline):
+  researcher: task A investigation -> task B investigation -> task C investigation
+  builder-1:  wait -> task A implementation -> task B implementation
+  builder-2:  wait -> wait -> task A' implementation (different files)
+  reviewer:   wait -> wait -> task A review -> task B review
+```
+
+### Rules
+
+1. **Task complete -> assign next within 10 seconds**: Poll for completion, then immediately send next task
+2. **Researcher always works 1 step ahead**: While builders implement, researcher investigates the next task
+3. **Review completed work immediately**: Don't wait for all builders. Send each to reviewer as it finishes
+4. **Idle builders get new tasks**: If waiting for review, assign independent work
+5. **All agents idle = planning failure**: Re-examine task decomposition
+
+### Polling Frequency
+
+- Builders: every 30 seconds, cycle through all
+- Reviewer: first check 60s after request, then every 30s
+- Researcher: first check 30s after request, then every 30s
+
+### Forbidden Patterns
+
+- Waiting for one agent before instructing another (serialization)
+- Waiting for all builders before sending to reviewer (batching)
+- Telling researcher to "stand by" (idling)
+
+## Researcher Protocol (Intelligence Officer)
+
+Researcher quality determines Commander decision quality. **Never skip reconnaissance.**
+
+### Three Roles
+
+1. **Reconnaissance**: Before assigning builders, investigate target code structure, dependencies, and impact
+   - Provides the data Commander needs for task splitting decisions
+   - Skipping recon = high conflict risk between builders
+2. **Verification**: After builder implementation, run tests/lint/type-checks
+   - Different from reviewer (code review): researcher verifies it _works_
+3. **Advance investigation**: While builders implement, research the next task ahead of time
+
+### Required Flow
+
+```
+BAD (no recon):
+  commander -> builder-1 "fix src/auth/"
+
+GOOD (recon first):
+  commander -> researcher "analyze src/auth/ structure, dependencies, and test coverage"
+  researcher -> commander "auth.ts depends on api.ts and db.ts. 3 test files exist"
+  commander -> builder-1 "fix src/auth/auth.ts. Do NOT touch api.ts"
+```
+
+### Forbidden Patterns
+
+- Assigning builders without researcher recon first (blind charge)
+- Telling researcher to wait
+- Ignoring researcher findings when splitting tasks
+
+## Multi-Builder Coordination
+
+### Task Splitting
+
+1. **Split by file boundary**: Each builder gets explicit files/directories. No overlap.
+2. **Dependent tasks go to same builder**: If A's output feeds B, assign both to one builder
+3. **When split is unclear, ask researcher first**: Don't guess
+4. **Prefer fewer splits over forced parallelism**: 2 well-scoped tasks > 4 vague tasks
+
+### Instruction Template
+
+```powershell
+psmux-bridge send builder-1 "Implement feature A. Your files: src/auth/ only. Do NOT touch src/api/"
+psmux-bridge send builder-2 "Implement feature B. Your files: src/api/ only. Do NOT touch src/auth/"
+```
+
+### Completion Detection
+
+```powershell
+# Cycle through all builders
+psmux-bridge read builder-1  # output returned -> complete
+psmux-bridge read builder-2  # "waiting for response..." -> still working
+psmux-bridge read builder-3  # output returned -> complete
+# Send completed work to reviewer immediately
+psmux-bridge send reviewer "Review builder-1 changes: git diff"
+```
+
+### Conflict Detection (before commit)
+
+```powershell
+# After ALL builders complete, check for file overlap
+git diff --name-only
+# Same file modified by multiple builders -> manual merge required
+# No overlap -> proceed to commit
+```
+
+## Reviewer Protocol (Context Overflow Prevention)
+
+Reviewer agents (especially smaller models) overflow on large diffs.
+
+### Rules
+
+1. **Send overview first**: `git diff --stat` result to show scope
+2. **Send files individually**: 1-2 files per message via `git diff <file>`
+3. **Never exceed 3 files per message**
+4. **Specify review focus**: "Check type safety" / "Verify i18n consistency"
+
+### Bad Example
+
+```
+send reviewer "Review these 2 files. Check git diff for issues."
+-> reviewer runs git diff itself -> full diff floods context -> overflow
+```
+
+### Good Example
+
+```powershell
+# Step 1: overview
+psmux-bridge send reviewer "git diff --stat: 3 files changed, 10 insertions, 5 deletions"
+
+# Step 2: individual file
+psmux-bridge send reviewer "src/auth.ts diff: [paste diff here]. Check: is the token validation correct?"
+```
+
+## Workflow Cycle
+
+```
+1. PLAN    -- Read task, decide approach
+2. RECON   -- Send researcher to investigate target code (MANDATORY)
+3. SPLIT   -- Based on recon, assign independent file sets to builders
+4. BUILD   -- Send instructions to all builders (parallel)
+5. POLL    -- Cycle through builders (30s intervals)
+6. REVIEW  -- Send each completed builder's work to reviewer
+7. POLL    -- Wait for reviewer (30s intervals)
+8. JUDGE   -- OK -> COMMIT. NG -> send fix to builder (back to 4)
+9. CONFLICT CHECK -- git diff --name-only for overlapping changes
+10. COMMIT -- git add + git commit
+11. NEXT   -- Back to step 1
+```
+
+## POLL and Auto-Approve
+
+After BUILD or REVIEW instructions, enter the POLL loop. **Never skip POLL.**
+
+Read at 10-second intervals. Maximum 12 rounds (about 120 seconds).
+
+### State Detection Patterns
+
+| Output contains                                | State            | Commander action                               |
+| ---------------------------------------------- | ---------------- | ---------------------------------------------- |
+| `Do you want to proceed?` / `1. Yes`           | Approval needed  | Auto-approve (see below)                       |
+| `2. Yes, and don't ask again`                  | Approval needed  | `type "2"` to skip future prompts of same kind |
+| `> Implement` / `> Write` / `> Improve`        | Complete (idle)  | End POLL, next step                            |
+| `gpt-5.4 high` / `100% left`                   | Complete (idle)  | End POLL, next step                            |
+| `Editing...` / `Running...` / `Reading...`     | Working          | Do nothing, next POLL                          |
+| `"type": "error"` / `API error` / `rate limit` | API error        | Report to user. Suggest model change           |
+| `error` / `failed` / `Error`                   | Execution error  | Read error details, decide action              |
+| `Esc to cancel`                                | Approval needed  | Verify content, then `keys Enter`              |
+| `[Y/n]` / `[y/N]`                              | Shell confirm    | `type "y"` + `keys Enter`                      |
+| `Sandbox`                                      | Sandbox approval | `type "1"` + `keys Enter`                      |
+
+### Auto-Approve Procedure
+
+```powershell
+# Standard approval
+psmux-bridge read builder 10
+psmux-bridge type builder "1"
+psmux-bridge read builder 5
+psmux-bridge keys builder Enter
+
+# Persistent approval (skip future prompts)
+psmux-bridge read builder 10
+psmux-bridge type builder "2"
+psmux-bridge read builder 5
+psmux-bridge keys builder Enter
+```
+
+### Dangerous Commands -- Never Auto-Approve
+
+If approval content contains any of these, **do NOT auto-approve**. Report to user:
+
+- `rm -rf` / `Remove-Item -Recurse -Force`
+- `git push --force` / `git reset --hard`
+- `DROP TABLE` / `DELETE FROM`
+- Execution of unknown external scripts
+
+### POLL Timeout
+
+After 12 rounds (~120 seconds) with no completion:
+
+1. Read last 20 lines of target pane
+2. Report state (approval-waiting / working / error) to user
+3. Wait for user instructions
+
+## Commander Prohibitions
+
+1. **Never write or modify code directly** -- all implementation through builders
+2. **Never skip POLL** -- always POLL after BUILD and REVIEW
+3. **Never commit without review** -- always REVIEW before COMMIT
+4. **Never skip reconnaissance** -- always send researcher before builders
+5. **Never auto-approve dangerous commands** -- report to user
+6. **Never POLL beyond 120 seconds** -- timeout, report to user
+7. **Never let agents idle** -- assign next task within 10 seconds of completion


### PR DESCRIPTION
## Summary

- Move orchestra management protocols from SKILL.md body to `references/` for on-demand loading
- Add `references/orchestra-management.md`: pipeline operation, researcher recon, reviewer batching, multi-builder coordination
- Add `references/agent-selection.md`: CLI-to-task mapping, approval-free flags, vendor limitations
- Slim SKILL.md from 343 to 214 lines (core psmux-bridge usage only)
- Bump version to 0.7.0

Follows Agent Skills specification (agentskills.io): SKILL.md for core instructions (<500 lines), references/ for detailed protocols loaded on-demand.

## Test plan

- [ ] SKILL.md is under 300 lines
- [ ] References linked from SKILL.md are accessible
- [ ] README documents skill-bundled management protocols
- [ ] Agents loading the skill can discover and read orchestra-management.md when needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)