### PR TITLE
feat: add orchestra-layout skill for deterministic pane grids

### DIFF
--- a/.claude/rules/binding-governance.md
+++ b/.claude/rules/binding-governance.md
@@ -1,0 +1,62 @@
+# Binding Governance Rules
+
+Binding is the governance control layer for shield-harness. It is NOT an LLM — it is a set of rules, gates, and contracts enforced by Claude Code (Orchestra).
+
+## Operating Profiles
+
+| Profile      | Gate Density                     | Use When                                    |
+| ------------ | -------------------------------- | ------------------------------------------- |
+| **Lite**     | STG0 + STG6 only                 | Low-risk tasks (docs, minor edits)          |
+| **Standard** | All STG gates                    | Normal development tasks                    |
+| **Strict**   | All STG gates + mandatory review | Security-sensitive or public-facing changes |
+
+Profile is selected at `/startproject` time based on task risk level.
+
+## STG Gates (Stage Gates)
+
+| Gate | Name           | Purpose                            |
+| ---- | -------------- | ---------------------------------- |
+| STG0 | Requirements   | Task acceptance criteria confirmed |
+| STG1 | Design         | Architecture/approach reviewed     |
+| STG2 | Implementation | Code written and self-reviewed     |
+| STG3 | Verification   | Tests pass, lint clean             |
+| STG4 | Automation     | CI/CD checks pass                  |
+| STG5 | Commit/Push    | Changes committed and pushed       |
+| STG6 | PR/Merge       | Pull request created and merged    |
+
+## fail-close Principle
+
+- When safety conditions are NOT met, Binding STOPS execution
+- On stop: output reason and recovery steps in Japanese
+- Never skip a gate — always fail-close
+
+## Layer Contract
+
+### Orchestra -> Binding (Input)
+
+| Field      | Type   | Description                    |
+| ---------- | ------ | ------------------------------ |
+| profile    | string | "lite" / "standard" / "strict" |
+| task_id    | string | e.g., "TASK-001"               |
+| intent     | string | What the task aims to achieve  |
+| risk_level | string | "low" / "medium" / "high"      |
+| request_id | string | Unique request identifier      |
+
+### Binding -> Orchestra (Output)
+
+| Field               | Type   | Description                                                      |
+| ------------------- | ------ | ---------------------------------------------------------------- |
+| decision            | string | "allow" / "stop"                                                 |
+| failed_steps        | array  | List of failed gate checks                                       |
+| required_actions    | array  | Steps needed to proceed                                          |
+| evidence_paths      | array  | Paths to evidence files                                          |
+| next_state          | string | backlog/STG update result                                        |
+| quality_gate_source | string | Source of blocking/high judgments (CI results, review summaries) |
+| quality_gate_counts | object | { blocking: number, high: number }                               |
+
+## Single Source of Truth
+
+- **Task state**: `tasks/backlog.yaml` is the ONLY authoritative source
+- **Stage status**: Tracked in `stage_status` field within backlog.yaml
+- **Evidence**: Recorded in `evidence` array within each task
+- **Decision log**: Decision log is maintained per-project.

--- a/.claude/rules/channel-security.md
+++ b/.claude/rules/channel-security.md
@@ -1,0 +1,90 @@
+# Channel Security Rules
+
+## Approval-Free Mode (ADR-032)
+
+When `approval_free: true` in pipeline-config.json:
+
+- All security decisions are delegated to hooks (no human approval dialogs)
+- `permissions.deny` rules remain absolute — hooks cannot override them
+- `permissions.ask` rules are promoted to `allow` at SessionStart
+- All hook-based defenses (gate, injection-guard, permission) run at 100%
+
+## Security Invariants
+
+These guarantees hold regardless of approval_free setting:
+
+1. **deny is absolute**: No hook, agent, or automation can override a deny rule
+2. **fail-close**: If a hook cannot determine safety, it denies (exit 2)
+3. **evidence required**: All allow/deny decisions are recorded in evidence-ledger
+4. **no silent bypass**: Hook errors result in deny, not silent allow
+
+## Claude Code Channels Security Harness (ADR-036 §D4)
+
+Claude Code Channels (2026-03-20 公式リリース) は MCP ベースの Telegram/Discord 連携。
+Shield Harness は独自のチャンネル実装を持たず、公式 Channels のセキュリティハーネスとして機能する。
+
+### 対応方針
+
+- 公式 Channels のみサポート（Telegram, Discord）
+- 独自チャンネル実装は行わない（公式 Channels の `--channels` が唯一のプッシュ手段）
+- VS Code パネルモードでの `--channels` 対応は公式の対応を待つ
+- Shield Harness hooks はタグ検知方式で自動追従（環境固有コード不要）
+
+### チャンネルイベント検知
+
+Channel messages arrive as `<channel source="telegram|discord">` events.
+Shield Harness hooks detect this tag automatically on any hook event:
+
+- `UserPromptSubmit`: channel source tag detection → NFKC normalization → injection scan
+- `PreToolUse`: normal gate/permission checks apply to channel-originated commands
+- `PostToolUse`: evidence recording with `source: channel` metadata
+
+### 自動適応保証
+
+以下の理由により、Shield Harness は公式 Channels の環境拡大に自動追従する:
+
+1. hooks は `<channel source="...">` タグの有無で判定（環境非依存）
+2. settings.json の hook 登録は CLI / VS Code 共通
+3. `--channels` が VS Code で有効化された瞬間から Shield Harness のセキュリティゲートが発火
+4. チャンネル無効環境ではイベント自体が到着しないため、誤検知なし（fail-safe）
+
+### チャンネル固有の脅威緩和
+
+- **Injection via channel message**: NFKC normalization + injection-patterns.json scan
+- **Unauthorized sender**: 公式 allowlist（第一防衛線）+ Shield Harness 二重検証
+- **Privilege escalation**: channel messages cannot modify deny rules or hook configuration
+- **Task creation via channel**: requires STG0 gate validation before acceptance
+
+### Implementation Mapping
+
+Hook implementations that handle channel-related security:
+
+| Threat                | Hook                | Function                                                                | Spec       |
+| --------------------- | ------------------- | ----------------------------------------------------------------------- | ---------- |
+| Injection via channel | sh-user-prompt.js   | `scanPatterns()` with `isChannel` flag                                  | §5.4, §8.6 |
+| Severity boost        | sh-user-prompt.js   | `boostSeverity()` — elevates severity by one level for channel messages | §8.6.2     |
+| Channel detection     | sh-user-prompt.js   | `session.source === "channel"` check via `readSession()`                | §8.6.1     |
+| Evidence metadata     | sh-evidence.js      | `is_channel` field in evidence-ledger.jsonl entries                     | §8.6.3     |
+| Data boundary         | sh-data-boundary.js | Jurisdiction tracking applies to channel-originated commands            | §3.4       |
+| Config protection     | sh-config-guard.js  | deny rules and hook config immutable regardless of source               | §5.3       |
+| Task gate             | sh-pipeline.js      | STG0 validation required for channel-originated task creation           | §8.1       |
+
+### Severity Boost Table
+
+Channel messages automatically boost pattern severity by one level:
+
+| Original | Boosted  | Action     |
+| -------- | -------- | ---------- |
+| low      | medium   | warn       |
+| medium   | high     | deny       |
+| high     | critical | deny       |
+| critical | critical | deny (cap) |
+
+### Phase 2 Migration
+
+When `--channels` becomes available in VS Code panel mode:
+
+1. `sh-session-start.js` version-check detects the new capability
+2. additionalContext suggests migration via `npx shield-harness channels migrate`
+3. No hook code changes required — tag-based detection is environment-agnostic
+4. New channel providers (beyond Telegram/Discord) are automatically covered

--- a/.claude/rules/coding-principles.md
+++ b/.claude/rules/coding-principles.md
@@ -1,0 +1,79 @@
+# Coding Principles
+
+Core coding rules to always follow.
+
+## Simplicity First
+
+- Choose readable code over complex code
+- Avoid over-abstraction
+- Prioritize "understandable" over "working"
+
+## Single Responsibility
+
+- One function does one thing only
+- One class has one responsibility only
+- Target 200-400 lines per file (max 800)
+
+## Early Return
+
+```python
+# Bad: Deep nesting
+def process(value):
+    if value is not None:
+        if value > 0:
+            return do_something(value)
+    return None
+
+# Good: Early return
+def process(value):
+    if value is None:
+        return None
+    if value <= 0:
+        return None
+    return do_something(value)
+```
+
+## Type Hints Required
+
+All functions must have type annotations:
+
+```python
+def call_llm(
+    prompt: str,
+    model: str = "gpt-4",
+    max_tokens: int = 1000
+) -> str:
+    ...
+```
+
+## Immutability
+
+Create new objects instead of mutating existing ones:
+
+```python
+# Bad: Mutating existing object
+data["new_key"] = value
+
+# Good: Creating new object
+new_data = {**data, "new_key": value}
+```
+
+## Naming Conventions
+
+- **Variables/Functions**: snake_case (English)
+- **Classes**: PascalCase (English)
+- **Constants**: UPPER_SNAKE_CASE (English)
+- **Meaningful names**: `user_count` over `x`
+
+## No Magic Numbers
+
+```python
+# Bad
+if retry_count > 3:
+    ...
+
+# Good
+MAX_RETRIES = 3
+if retry_count > MAX_RETRIES:
+    ...
+```

--- a/.claude/rules/dev-environment.md
+++ b/.claude/rules/dev-environment.md
@@ -1,0 +1,40 @@
+# Development Environment
+
+## Script Execution
+
+- **PowerShell 7** (`pwsh`) for all automation scripts
+- Scripts are located in `scripts/` directory
+
+## Pre-commit Security
+
+- Git hooks in `.githooks/` (pre-commit)
+- Pre-commit hook blocks internal files (tasks/, scripts/, HANDOFF, INSTRUCTIONS) from being committed
+- Configured via `git config core.hooksPath .githooks`
+
+## Linting (Future)
+
+- PowerShell: PSScriptAnalyzer (`Invoke-ScriptAnalyzer`)
+- Markdown: markdownlint (optional)
+- Currently: manual review + git-guard-scan
+
+## Testing (Future)
+
+- PowerShell: Pester 5.0+ (`Invoke-Pester -Verbose`)
+- Currently: manual verification + git-guard checks
+
+## Task Management
+
+- **SoT**: `tasks/backlog.yaml`
+
+## Important Commands
+
+```powershell
+# Sync project views (backlog → docs/project/)
+pwsh ./scripts/sync-project-views.ps1
+
+# Sync bilingual README
+pwsh ./scripts/sync-readme.ps1
+
+# Pre-commit hook (manual run)
+bash .githooks/pre-commit
+```

--- a/.claude/rules/implementation-context.md
+++ b/.claude/rules/implementation-context.md
@@ -1,0 +1,132 @@
+# Shield Harness Implementation Context
+
+> Shield Harness = Claude Code の `.claude/` ディレクトリ構造によるセキュリティハーネス（hooks + rules + skills + settings.json）
+
+## Design Documents（実装時に必ず参照）
+
+| #   | ドキュメント       | 層        | パス                                               | 用途                                     |
+| --- | ------------------ | --------- | -------------------------------------------------- | ---------------------------------------- |
+| ①   | REQUIREMENTS.md    | Why       | docs/REQUIREMENTS.md                               | 機能要件・受入基準                       |
+| ②   | THREAT_MODEL.md    | Why→What  | docs/THREAT_MODEL.md                               | 脅威 ID・攻撃ベクトル                    |
+| ③   | ARCHITECTURE.md    | What      | docs/ARCHITECTURE.md                               | 22 フック一覧・ディレクトリ構造          |
+| ④   | CLAUDE_MD_SPEC.md  | What      | docs/CLAUDE_MD_SPEC.md                             | 28 ルール仕様・トレーサビリティ          |
+| ⑤   | DETAILED_DESIGN.md | How       | docs/DETAILED_DESIGN.md                            | 各フックの入出力・正規表現・分岐ロジック |
+| ADR | ADR 設計提案       | Reference | .reference/SHIELD_HARNESS_ADR_REDESIGN_PROPOSAL.md | 35 ADR の設計判断根拠                    |
+
+## Implementation Order（依存関係グラフに基づく）
+
+```
+Phase A（基盤 — 最初に実装）:
+  ADR-033: backlog.yaml スキーマ + sync-project-views.ps1
+  ↓ 他 ADR の前提
+
+Phase B（パイプライン）:
+  ADR-031: sh-pipeline.js（STG ゲート駆動）
+  ADR-032: 承認レスモード（approval_free） ← 並列可
+  ADR-035: バイリンガル README + sync-readme.ps1 ← 並列可
+  ↓
+
+Phase C（自律ループ）:
+  ADR-034: auto-pickup + チャンネル連携 + ブロック通知
+```
+
+## Technical Constraints
+
+- **Hook language**: Node.js CommonJS（ミリ秒応答必須）。共通ユーティリティは lib/sh-utils.js
+- **Hook protocol**: exit 0 = allow, exit 2 = deny（stdout に JSON）。deny() は sh-utils.js 経由
+- **Target**: 23 hook scripts (22 sh-\* + lint-on-save) + lib/sh-utils.js + injection-patterns.json
+- **External deps**: node 18+ (CommonJS hooks), pwsh (sync scripts, bash fallback あり), gh (optional)
+- **OS**: Windows ネイティブファースト（Git Bash 環境）。WSL2/Linux 互換
+- **Trusted Operation**: pipeline の git 操作は bash 子プロセスとして直接実行（フックエンジン非経由）
+- **fail-close**: 安全条件を確認できない場合は exit 2 で停止
+
+## Directory Structure（生成対象の全量）
+
+```
+.claude/
+├─ settings.json
+├─ settings.local.json
+├─ agents/
+│   └─ general-purpose.md
+├─ hooks/
+│   ├─ sh-permission.js
+│   ├─ sh-permission-learn.js
+│   ├─ sh-gate.js
+│   ├─ sh-injection-guard.js
+│   ├─ sh-user-prompt.js
+│   ├─ sh-evidence.js
+│   ├─ sh-output-control.js
+│   ├─ sh-quiet-inject.js
+│   ├─ sh-circuit-breaker.js
+│   ├─ sh-task-gate.js
+│   ├─ sh-precompact.js
+│   ├─ sh-postcompact.js
+│   ├─ sh-instructions.js
+│   ├─ sh-session-start.js
+│   ├─ sh-session-end.js
+│   ├─ sh-config-guard.js
+│   ├─ sh-subagent.js
+│   ├─ sh-dep-audit.js
+│   ├─ sh-elicitation.js
+│   ├─ sh-worktree.js
+│   ├─ sh-data-boundary.js
+│   ├─ sh-pipeline.js
+│   ├─ lint-on-save.js
+│   └─ lib/
+│       └─ sh-utils.js
+├─ patterns/
+│   └─ injection-patterns.json
+├─ rules/
+│   ├─ binding-governance.md
+│   ├─ channel-security.md
+│   ├─ coding-principles.md
+│   ├─ dev-environment.md
+│   ├─ implementation-context.md
+│   ├─ language.md
+│   ├─ security.md
+│   └─ testing.md
+├─ skills/
+│   ├─ checkpointing/
+│   ├─ docs-sync/
+│   ├─ handoff/
+│   ├─ init/
+│   ├─ plan/
+│   ├─ simplify/
+│   ├─ startproject/
+│   ├─ tdd/
+│   ├─ team-implement/
+│   ├─ team-review/
+│   └─ test-coverage-improver/
+└─ logs/
+    ├─ evidence-ledger.jsonl
+    └─ instructions-hashes.json
+
+.shield-harness/
+├─ session.json
+├─ config/
+│   └─ pipeline-config.json
+└─ logs/
+
+tasks/
+└─ backlog.yaml
+
+docs/project/
+├─ ROADMAP.md
+├─ WBS.md
+├─ GANTT.md
+└─ MILESTONES.md
+
+scripts/
+├─ sync-project-views.ps1
+└─ sync-readme.ps1
+```
+
+## Coding Rules for Hook Scripts
+
+- **DETAILED_DESIGN.md が唯一の実装仕様書** — 各フックの §番号を参照して実装すること
+- deny() は stdout に JSON を出力 + exit 2（stderr ではない）
+- NFKC 正規化: Node.js 不在時は fail-close（deny）
+- Hash chain: flock ベースロック（Windows Git Bash では mkdir フォールバック）
+- READONLY_PATTERNS から sed を除外（sed -i は書込操作）
+- permissions.allow: standard プロファイルで 40 操作
+- Circuit breaker: stop_hook_active フラグは allow 後にリセット

--- a/.claude/rules/language.md
+++ b/.claude/rules/language.md
@@ -1,0 +1,26 @@
+# Language Rules
+
+## Thinking and Reasoning
+
+- **Always think and reason in English**
+- Internal analysis, planning, and problem-solving should be in English
+- Code comments, variable names, function names, and docstrings should be in English
+
+## User Communication
+
+- **Always respond to users in Japanese**
+- Explanations, questions, and status updates should be in Japanese
+- Error messages shown to users should be in Japanese
+
+## Code
+
+- All code should be written in English:
+  - Variable names: `user_count`, not `ユーザー数`
+  - Function names: `calculate_total()`, not `合計計算()`
+  - Comments: `# Check if valid`, not `# 有効かチェック`
+  - Docstrings: English descriptions
+
+## Documentation
+
+- Technical documentation: English
+- User-facing documentation (README, etc.): Japanese is acceptable

--- a/.claude/rules/security.md
+++ b/.claude/rules/security.md
@@ -1,0 +1,109 @@
+# Security Rules
+
+Security checklist to always verify when writing code.
+
+## Secrets Management
+
+### Never Do
+
+- Hardcode API keys or passwords
+- Log sensitive information
+- Commit `.env` files
+
+### Required
+
+```python
+# Good: Get from environment variables
+import os
+API_KEY = os.environ["API_KEY"]
+
+# Good: With existence check
+API_KEY = os.environ.get("API_KEY")
+if not API_KEY:
+    raise ValueError("API_KEY environment variable is required")
+```
+
+## Input Validation
+
+Always validate external input:
+
+```python
+from pydantic import BaseModel, EmailStr, Field
+
+class UserInput(BaseModel):
+    email: EmailStr
+    age: int = Field(ge=0, le=150)
+    name: str = Field(min_length=1, max_length=100)
+```
+
+## SQL Injection Prevention
+
+```python
+# Bad: String concatenation
+cursor.execute(f"SELECT * FROM users WHERE id = {user_id}")
+
+# Good: Parameterized query
+cursor.execute("SELECT * FROM users WHERE id = ?", (user_id,))
+```
+
+## XSS Prevention
+
+- Escape user input before embedding in HTML
+- Enable template engine auto-escaping
+
+## Error Messages
+
+```python
+# Bad: Too detailed (gives attackers information)
+raise Exception(f"Database connection failed: {connection_string}")
+
+# Good: Minimal information
+raise Exception("Database connection failed")
+# Details go to logs (logs are private)
+logger.error(f"Database connection failed: {connection_string}")
+```
+
+## Dependencies
+
+- Regular vulnerability checks: `pip-audit`, `safety`
+- Remove unused dependencies
+- Pin versions (`==` over `>=`)
+
+## Code Review Checklist
+
+- [ ] No hardcoded secrets
+- [ ] External input is validated
+- [ ] SQL queries are parameterized
+- [ ] Error messages are not too detailed
+- [ ] Logs don't contain sensitive information
+
+## Git Operations Safety
+
+git rm --cached is a prohibited operation.
+Locally it appears to only remove files from the index,
+but after committing, it propagates as physical deletion
+when others pull/merge from the remote.
+
+Prohibited commands:
+
+- git rm --cached (single files or directories)
+- git rm -r --cached (recursive untrack)
+
+When managing files that should not be tracked via .gitignore,
+the principle is to never commit them in the first place.
+Simply adding an already-committed file to .gitignore does not
+remove it from tracking, which tempts the use of git rm --cached,
+but it is prohibited for the reasons stated above.
+
+Alternative: When you need to remove already-committed files from tracking,
+consult the human (project owner) and determine the approach
+after confirming the impact scope.
+
+## Line Ending Management
+
+Line ending normalization is managed by `.gitattributes` only.
+Do not set `core.autocrlf=true` in this repository.
+
+When restoring files from old commits (`git checkout <commit> -- <path>`),
+always run `git add --renormalize .` afterward to re-apply `.gitattributes` rules.
+Otherwise, phantom diffs will appear in `git status` due to EOL mismatch.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,0 +1,43 @@
+# Testing Rules
+
+## Principles (Language-Agnostic)
+
+- **TDD when possible**: Write tests before implementation (Red-Green-Refactor)
+- **AAA Pattern**: Arrange / Act / Assert
+- **Naming**: `test_{subject}_{condition}_{expected_result}`
+- **Coverage target**: 80%+ for source code
+
+## Test Categories
+
+1. **Happy path**: Normal input, expected output
+2. **Boundary values**: Min, max, empty, zero
+3. **Error cases**: Invalid input, error conditions
+4. **Edge cases**: Null, empty string, special characters
+
+## PowerShell Testing (Pester)
+
+When Pester is available:
+
+```powershell
+# Run tests
+Invoke-Pester -Verbose
+
+# Run with coverage
+Invoke-Pester -CodeCoverage ./scripts/*.ps1
+
+# Test file naming: {Module}.Tests.ps1
+# Test structure: Describe / Context / It
+```
+
+## Current Testing Approach
+
+Until a formal test framework is adopted:
+
+- **Git guard**: Pre-commit hooks catch secrets and sensitive data
+- **Manual verification**: Review output before committing
+
+## Mocking
+
+- Isolate external dependencies (file I/O, network, CLI tools)
+- Use `unittest.mock` (Python hooks) or Pester `Mock` (PowerShell)
+- Test fixtures in dedicated `tests/` directory when available

--- a/.claude/skills/orchestra-layout/SKILL.md
+++ b/.claude/skills/orchestra-layout/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: orchestra-layout
+description: |
+  Deterministic psmux grid layout creation for Orchestra multi-agent configurations.
+  Creates Builder/Researcher/Reviewer pane grids in one command using percentage-based
+  splits. Use this skill whenever setting up Orchestra panes, creating multi-agent
+  layouts, configuring builder/researcher/reviewer grids, or any request involving
+  "pane layout", "Orchestra setup", "split panes", "create grid", or specifying agent
+  counts like "4 builders 1 researcher 1 reviewer". Always use this instead of manually
+  running split-window commands — manual pane creation wastes tokens and is unreliable
+  due to psmux resize bugs (psmux/psmux#171).
+user-invocable: false
+allowed-tools: Bash
+---
+
+# Orchestra Layout
+
+Create deterministic psmux pane grids for Orchestra multi-agent configurations.
+Replaces manual split-window trial-and-error with a single script invocation.
+
+## Why This Skill Exists
+
+Manual pane creation via split-window/resize-pane commands is unreliable because:
+- `resize-pane -x/-y` silently fails (CLI parses flags but server ignores them)
+- `split-window -l` is aliased as percentage (not cell count)
+- `split-window -t` is silently ignored (always splits active pane)
+
+The script works around all three bugs using `split-window -p` (percentage-based) splits
+with a chained formula that produces equal partitions: `pct[i] = 100*(N-1-i)/(N-i)`.
+
+## Step 1: Run the Layout Script
+
+```bash
+bash "${CLAUDE_SKILL_DIR}/scripts/orchestra-layout.sh" <PRESET>
+```
+
+### Preset Format
+
+`NbNrNv` — N = count, b = builder, r = researcher, v = reviewer.
+
+| Preset | Agents | Grid |
+|--------|--------|------|
+| `4b1r1v` | 4 builders + 1 researcher + 1 reviewer | 2x3 |
+| `3b1r1v` | 3 builders + 1 researcher + 1 reviewer | 2x3 |
+| `2b1r1v` | 2 builders + 1 researcher + 1 reviewer | 2x2 |
+| `2b1r` | 2 builders + 1 researcher | 1x3 |
+| `1b1r` | 1 builder + 1 researcher | 1x2 |
+
+Default preset: `4b1r1v`
+
+## Step 2: Use Pane IDs for Agent Dispatch
+
+The script outputs pane IDs and role labels:
+
+```
+=== Orchestra Layout: 4b1r1v → 2x3 grid ===
+Panes:
+  %1 → Builder-1
+  %4 → Builder-2
+  %5 → Builder-3
+  %3 → Builder-4
+  %6 → Researcher-1
+  %7 → Reviewer-1
+Done.
+```
+
+Use these IDs to send commands to each pane:
+
+```bash
+psmux send-keys -t %1 "codex exec --model gpt-5.3-codex-spark --full-auto 'task'" Enter
+```
+
+## Examples
+
+### Example 1: Standard Orchestra (4 builders + 1 researcher + 1 reviewer)
+
+Commander receives: "4ビルダー、1リサーチャー、1レビュアーでペインを構成して"
+
+Action:
+```bash
+bash "${CLAUDE_SKILL_DIR}/scripts/orchestra-layout.sh" 4b1r1v
+```
+
+Result: 2x3 grid with labeled panes, ready for agent dispatch.
+
+### Example 2: Minimal Setup (2 builders + 1 reviewer)
+
+Commander receives: "2ビルダー1レビュアーで"
+
+Action:
+```bash
+bash "${CLAUDE_SKILL_DIR}/scripts/orchestra-layout.sh" 2b1v
+```
+
+Result: 1x3 grid (3 panes in one row).
+
+## Troubleshooting
+
+### Error: "psmux: no server running"
+
+**Cause**: psmux server not started or was killed.
+
+**Solution**: The script auto-starts a new session via `psmux new-session -d`.
+If this fails, verify psmux binary is in PATH.
+
+### Pane sizes are unequal
+
+**Cause**: The percentage formula produces near-equal splits (±0.5%), not pixel-perfect.
+For 3 columns: 33% | 33.5% | 33.5%. This is expected and acceptable.
+
+### select-pane -T labels not showing
+
+**Cause**: pane-border-status may not be enabled.
+
+**Solution**: Ensure psmux is configured with `pane-border-status top` or `bottom`.
+
+## Constraints
+
+- The script creates a new window in the existing psmux session (does not kill other windows)
+- Maximum 12 panes (3x4 grid)
+- Grid cells beyond total pane count remain as empty shells
+- Pane IDs are auto-assigned; use the script output to map IDs to roles
+
+## Reference Files
+
+- [psmux workarounds](references/psmux-workarounds.md) — Known psmux bugs and workaround details

--- a/.claude/skills/orchestra-layout/references/psmux-workarounds.md
+++ b/.claude/skills/orchestra-layout/references/psmux-workarounds.md
@@ -1,0 +1,57 @@
+# psmux Layout Workarounds
+
+Documented workarounds for psmux layout bugs tracked in psmux/psmux#171.
+
+## Bug 1: resize-pane -x/-y Silent Fail
+
+**Symptom**: `psmux resize-pane -t %1 -x 91` returns no error but pane size unchanged.
+
+**Root cause**: `main.rs` parses `-x`/`-y` flags and appends to command string, but server
+handler does not route to `CtrlReq::ResizePaneAbsolute`. The handler exists in `server/mod.rs`
+but is unreachable from CLI.
+
+**Workaround**: Do not use `-x`/`-y`. Use percentage-based splits during creation instead.
+
+## Bug 2: split-window -l Aliased as Percentage
+
+**Symptom**: `psmux split-window -h -l 91` creates a 91% split, not 91-cell split.
+
+**Root cause**: `main.rs:829` maps both `-l` and `-p` to the same `size_pct` variable:
+```rust
+"-p" | "-l" => { size_pct = Some(cmd_args[i].to_string()); }
+```
+
+**Workaround**: Always use `-p` (percentage). Calculate cell-based sizes as percentages
+relative to the parent pane.
+
+## Bug 3: split-window -t Silently Ignored
+
+**Symptom**: `psmux split-window -h -t %5` always splits the active pane, not %5.
+
+**Root cause**: `main.rs` parses `-t` but skips its value:
+```rust
+"-t" | "-e" => { i += 1; /* skip value */ }
+```
+
+**Workaround**: Use `psmux select-pane -t %ID` before `split-window` to change the active
+pane. The script captures pane IDs via `list-panes` and iterates with select-pane.
+
+## Equal N-way Split Algorithm
+
+To split a pane into N equal parts using only percentage-based 2-way splits:
+
+```
+For split i (0-indexed, 0 to N-2):
+  percentage = 100 * (N - 1 - i) / (N - i)
+```
+
+Each split divides the active pane. The NEW pane receives the percentage and becomes active.
+
+Example for 3 equal parts:
+1. `split-window -p 67` → [33% original][67% new (active)]
+2. `split-window -p 50` → [33%][33.5%][33.5%]
+
+Example for 4 equal parts:
+1. `split-window -p 75` → [25%][75% active]
+2. `split-window -p 67` → [25%][25%][50% active]
+3. `split-window -p 50` → [25%][25%][25%][25%]

--- a/.claude/skills/orchestra-layout/scripts/orchestra-layout.sh
+++ b/.claude/skills/orchestra-layout/scripts/orchestra-layout.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# orchestra-layout.sh — Deterministic psmux grid layout for Orchestra
+#
+# Usage: bash orchestra-layout.sh [PRESET]
+#   PRESET format: NbNrNv (e.g., 4b1r1v = 4 builders, 1 researcher, 1 reviewer)
+#   Default: 4b1r1v
+#
+# Workaround: Uses split-window -p (percentage) to avoid psmux bugs:
+#   - resize-pane -x/-y silently fails (psmux/psmux#171)
+#   - split-window -l is aliased as percentage
+#   - split-window -t is silently ignored
+set -euo pipefail
+
+PRESET="${1:-4b1r1v}"
+
+# --- Parse preset (NbNrNv) ---
+parse_preset() {
+    local p="$1"
+    BUILDERS=0; RESEARCHERS=0; REVIEWERS=0
+    while [[ -n "$p" ]]; do
+        if [[ "$p" =~ ^([0-9]+)([brv]) ]]; then
+            local num="${BASH_REMATCH[1]}"
+            local role="${BASH_REMATCH[2]}"
+            case "$role" in
+                b) BUILDERS=$num ;;
+                r) RESEARCHERS=$num ;;
+                v) REVIEWERS=$num ;;
+            esac
+            p="${p:${#BASH_REMATCH[0]}}"
+        else
+            echo "Error: Invalid preset: $1 (expected format: NbNrNv, e.g. 4b1r1v)" >&2
+            exit 1
+        fi
+    done
+    TOTAL=$((BUILDERS + RESEARCHERS + REVIEWERS))
+    if (( TOTAL < 1 || TOTAL > 12 )); then
+        echo "Error: Total panes must be 1-12 (got $TOTAL)" >&2
+        exit 1
+    fi
+}
+
+# --- Grid dimensions for N panes ---
+calc_grid() {
+    local n=$1
+    case $n in
+        1)     ROWS=1; COLS=1 ;;
+        2)     ROWS=1; COLS=2 ;;
+        3)     ROWS=1; COLS=3 ;;
+        4)     ROWS=2; COLS=2 ;;
+        5|6)   ROWS=2; COLS=3 ;;
+        7|8)   ROWS=2; COLS=4 ;;
+        9)     ROWS=3; COLS=3 ;;
+        10|12) ROWS=3; COLS=4 ;;
+        11)    ROWS=3; COLS=4 ;;
+    esac
+}
+
+# --- Helpers ---
+get_pane_ids() {
+    psmux list-panes 2>/dev/null | grep -o '%[0-9]*'
+}
+
+# Split active pane into N equal parts.
+# Uses chained percentage splits: pct[i] = 100*(N-1-i)/(N-i)
+# Each split creates a new pane (right/bottom) which becomes active.
+split_equal() {
+    local n=$1 dir=$2
+    for (( i=0; i<n-1; i++ )); do
+        local remaining=$((n - i))
+        local pct=$(( 100 * (remaining - 1) / remaining ))
+        psmux split-window "$dir" -p "$pct"
+    done
+}
+
+# --- Main ---
+parse_preset "$PRESET"
+calc_grid "$TOTAL"
+
+echo "=== Orchestra Layout: ${BUILDERS}b${RESEARCHERS}r${REVIEWERS}v → ${ROWS}x${COLS} grid ==="
+
+# Ensure psmux is running, then create a clean window
+if ! psmux list-sessions &>/dev/null; then
+    psmux new-session -d
+    sleep 0.5
+fi
+
+# Kill all existing panes in current window, start fresh in a new window
+psmux new-window
+
+# Step 1: Create rows (vertical splits on the initial pane)
+if (( ROWS > 1 )); then
+    split_equal "$ROWS" -v
+fi
+
+# Capture row pane IDs (ordered top-to-bottom by list-panes)
+mapfile -t ROW_IDS < <(get_pane_ids)
+
+# Step 2: For each row, select it and split into columns
+if (( COLS > 1 )); then
+    for (( r=0; r<ROWS; r++ )); do
+        psmux select-pane -t "${ROW_IDS[$r]}"
+        split_equal "$COLS" -h
+    done
+fi
+
+sleep 0.3
+
+# Step 3: Collect all pane IDs in screen order
+mapfile -t ALL_IDS < <(get_pane_ids)
+
+# Step 4: Build role labels
+LABELS=()
+for (( i=1; i<=BUILDERS; i++ ));    do LABELS+=("Builder-$i");    done
+for (( i=1; i<=RESEARCHERS; i++ )); do LABELS+=("Researcher-$i"); done
+for (( i=1; i<=REVIEWERS; i++ ));   do LABELS+=("Reviewer-$i");   done
+
+# Step 5: Label panes via select-pane -T
+for (( i=0; i<${#ALL_IDS[@]} && i<TOTAL; i++ )); do
+    psmux select-pane -t "${ALL_IDS[$i]}" -T "${LABELS[$i]}"
+done
+
+# Select first pane
+psmux select-pane -t "${ALL_IDS[0]}"
+
+# Report
+echo "Panes:"
+for (( i=0; i<${#ALL_IDS[@]} && i<TOTAL; i++ )); do
+    echo "  ${ALL_IDS[$i]} → ${LABELS[$i]}"
+done
+echo "Done."

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,10 @@ DEV-NOTES*.md
 # =========================
 CLAUDE.md
 .claude/
+!.claude/rules/
+!.claude/rules/**
+!.claude/skills/
+!.claude/skills/**
 .codex/
 .gemini/
 *.local


### PR DESCRIPTION
## Summary
- Add `orchestra-layout` skill: deterministic psmux grid layout creation for Orchestra multi-agent configurations
- Uses percentage-based splits (`split-window -p`) to work around psmux resize bugs (psmux/psmux#171)
- Un-ignore `.claude/rules/` and `.claude/skills/` so project-level instructions and skills are version-controlled

## Details
- **Skill**: `.claude/skills/orchestra-layout/` — SKILL.md + script + reference docs
- **Script**: `scripts/orchestra-layout.sh` — accepts preset string (e.g., `4b1r1v`) and creates labeled grid
- **Rules**: 8 existing `.claude/rules/*.md` files now tracked (were local-only before)
- **Tested**: 4b1r1v preset creates 2x3 grid with ~equal column widths (92|89|90 cols)

## Motivation
Every Orchestra session wasted 10-20 commands on pane layout trial-and-error due to psmux bugs:
- `resize-pane -x/-y` silently fails
- `split-window -l` aliased as percentage
- `split-window -t` silently ignored

Now: `bash orchestra-layout.sh 4b1r1v` → done in 1 command.

## Test plan
- [x] `4b1r1v` preset: verified 2x3 grid, pane labels, near-equal sizing
- [x] Existing psmux session preserved (new-window, not kill-server)
- [x] Script handles psmux not running (auto-starts session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)