### PR TITLE
feat: role-based command gate and Pester test framework

### DIFF
--- a/psmux-bridge/scripts/role-gate.ps1
+++ b/psmux-bridge/scripts/role-gate.ps1
@@ -1,0 +1,330 @@
+$RolePermissions = @{
+    Commander = @{
+        ReadOwn      = $true
+        ReadOther    = $true
+        SendAny      = $true
+        SendCommander = $true
+        HealthCheck  = $true
+        Watch        = $true
+        WaitReady    = $true
+        Vault        = $true
+        Dispatch     = $true
+        TypeOwn      = $true
+        TypeOther    = $false
+        KeysOwn      = $true
+        KeysOther    = $false
+        List         = $true
+        Id           = $true
+        Version      = $true
+        Doctor       = $true
+    }
+    Builder = @{
+        ReadOwn      = $true
+        ReadOther    = $false
+        SendAny      = $false
+        SendCommander = $true
+        HealthCheck  = $false
+        Watch        = $false
+        WaitReady    = $false
+        Vault        = $false
+        Dispatch     = $false
+        TypeOwn      = $true
+        TypeOther    = $false
+        KeysOwn      = $true
+        KeysOther    = $false
+        List         = $true
+        Id           = $true
+        Version      = $true
+        Doctor       = $true
+    }
+    Researcher = @{
+        ReadOwn      = $true
+        ReadOther    = $false
+        SendAny      = $false
+        SendCommander = $true
+        HealthCheck  = $false
+        Watch        = $false
+        WaitReady    = $false
+        Vault        = $false
+        Dispatch     = $false
+        TypeOwn      = $true
+        TypeOther    = $false
+        KeysOwn      = $true
+        KeysOther    = $false
+        List         = $true
+        Id           = $true
+        Version      = $true
+        Doctor       = $true
+    }
+    Reviewer = @{
+        ReadOwn      = $true
+        ReadOther    = $false
+        SendAny      = $false
+        SendCommander = $true
+        HealthCheck  = $false
+        Watch        = $false
+        WaitReady    = $false
+        Vault        = $false
+        Dispatch     = $false
+        TypeOwn      = $true
+        TypeOther    = $false
+        KeysOwn      = $true
+        KeysOther    = $false
+        List         = $true
+        Id           = $true
+        Version      = $true
+        Doctor       = $true
+    }
+}
+
+$script:RoleGateLabelsFile = Join-Path $env:APPDATA "winsmux\labels.json"
+
+function ConvertTo-CanonicalWinsmuxRole {
+    param([AllowNull()][string]$RoleName)
+
+    if ([string]::IsNullOrWhiteSpace($RoleName)) {
+        return $null
+    }
+
+    switch -Regex ($RoleName.Trim()) {
+        '^(?i)Commander$' { return 'Commander' }
+        '^(?i)Builder$' { return 'Builder' }
+        '^(?i)Researcher$' { return 'Researcher' }
+        '^(?i)Reviewer$' { return 'Reviewer' }
+        default { return $null }
+    }
+}
+
+function ConvertTo-InferredWinsmuxRole {
+    param([AllowNull()][string]$Value)
+
+    if ([string]::IsNullOrWhiteSpace($Value)) {
+        return $null
+    }
+
+    switch -Regex ($Value.Trim()) {
+        '^(?i)Commander(?:$|[-_:/\s])' { return 'Commander' }
+        '^(?i)Builder(?:$|[-_:/\s])' { return 'Builder' }
+        '^(?i)Researcher(?:$|[-_:/\s])' { return 'Researcher' }
+        '^(?i)Reviewer(?:$|[-_:/\s])' { return 'Reviewer' }
+        default { return $null }
+    }
+}
+
+function Get-RoleGateLabels {
+    if (-not (Test-Path $script:RoleGateLabelsFile)) {
+        return @{}
+    }
+
+    $raw = Get-Content -Path $script:RoleGateLabelsFile -Raw -Encoding UTF8
+    if ([string]::IsNullOrWhiteSpace($raw)) {
+        return @{}
+    }
+
+    $obj = $raw | ConvertFrom-Json
+    $ht = @{}
+    $obj.PSObject.Properties | ForEach-Object { $ht[$_.Name] = $_.Value }
+    return $ht
+}
+
+function Resolve-RoleGateTargetPane {
+    param([AllowNull()][string]$TargetPane)
+
+    if ([string]::IsNullOrWhiteSpace($TargetPane)) {
+        return $null
+    }
+
+    $labels = Get-RoleGateLabels
+    if ($labels.ContainsKey($TargetPane)) {
+        return $labels[$TargetPane]
+    }
+
+    return $TargetPane
+}
+
+function Get-RoleGatePaneLabel {
+    param([AllowNull()][string]$TargetPane)
+
+    if ([string]::IsNullOrWhiteSpace($TargetPane)) {
+        return $null
+    }
+
+    $resolvedPane = Resolve-RoleGateTargetPane $TargetPane
+    $labels = Get-RoleGateLabels
+
+    foreach ($label in $labels.Keys) {
+        if ($labels[$label] -eq $resolvedPane) {
+            return $label
+        }
+    }
+
+    return $null
+}
+
+function Get-RoleGatePaneTitle {
+    param([AllowNull()][string]$TargetPane)
+
+    if ([string]::IsNullOrWhiteSpace($TargetPane)) {
+        return $null
+    }
+
+    $resolvedPane = Resolve-RoleGateTargetPane $TargetPane
+
+    try {
+        $title = & psmux display-message -p -t $resolvedPane '#{pane_title}' 2>$null
+        return ($title | Out-String).Trim()
+    } catch {
+        return $null
+    }
+}
+
+function Test-RoleGateOwnPane {
+    param([AllowNull()][string]$TargetPane)
+
+    if ([string]::IsNullOrWhiteSpace($TargetPane)) {
+        return $false
+    }
+
+    $resolvedPane = Resolve-RoleGateTargetPane $TargetPane
+    $ownPane = $env:WINSMUX_PANE_ID
+
+    if ([string]::IsNullOrWhiteSpace($ownPane)) {
+        return $false
+    }
+
+    return $resolvedPane -eq $ownPane
+}
+
+function Test-RoleGateCommanderTarget {
+    param([AllowNull()][string]$TargetPane)
+
+    if ([string]::IsNullOrWhiteSpace($TargetPane)) {
+        return $false
+    }
+
+    $candidates = @(
+        $TargetPane
+        (Get-RoleGatePaneLabel $TargetPane)
+        (Get-RoleGatePaneTitle $TargetPane)
+    ) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique
+
+    foreach ($candidate in $candidates) {
+        if ((ConvertTo-InferredWinsmuxRole $candidate) -eq 'Commander') {
+            return $true
+        }
+    }
+
+    return $false
+}
+
+function Deny-RoleCommand {
+    param(
+        [string]$Role,
+        [string]$Command
+    )
+
+    Write-Error "DENIED: [$Role] cannot execute [$Command]" -ErrorAction Continue
+    return $false
+}
+
+function Assert-Role {
+    param(
+        [Parameter(Mandatory)][string]$Command,
+        [string]$TargetPane
+    )
+
+    $role = ConvertTo-CanonicalWinsmuxRole $env:WINSMUX_ROLE
+    if ([string]::IsNullOrWhiteSpace($env:WINSMUX_ROLE)) {
+        Write-Error "WINSMUX_ROLE not set" -ErrorAction Continue
+        return $false
+    }
+    if ($null -eq $role) {
+        Write-Error "Invalid WINSMUX_ROLE: $($env:WINSMUX_ROLE)" -ErrorAction Continue
+        return $false
+    }
+
+    $permissions = $RolePermissions[$role]
+    $normalizedCommand = if ($null -eq $Command) { '' } else { $Command.Trim().ToLowerInvariant() }
+    $isOwnPane = Test-RoleGateOwnPane $TargetPane
+
+    switch ($normalizedCommand) {
+        '' { return $true }
+        'read' {
+            if ($isOwnPane -and $permissions.ReadOwn) { return $true }
+            if ((-not $isOwnPane) -and $permissions.ReadOther) { return $true }
+            return Deny-RoleCommand -Role $role -Command $normalizedCommand
+        }
+        'send' {
+            if ($permissions.SendAny) { return $true }
+            if ($permissions.SendCommander -and (Test-RoleGateCommanderTarget $TargetPane)) { return $true }
+            return Deny-RoleCommand -Role $role -Command $normalizedCommand
+        }
+        'message' {
+            if ($permissions.SendAny) { return $true }
+            if ($permissions.SendCommander -and (Test-RoleGateCommanderTarget $TargetPane)) { return $true }
+            return Deny-RoleCommand -Role $role -Command $normalizedCommand
+        }
+        'health-check' {
+            if ($permissions.HealthCheck) { return $true }
+            return Deny-RoleCommand -Role $role -Command $normalizedCommand
+        }
+        'watch' {
+            if ($permissions.Watch) { return $true }
+            return Deny-RoleCommand -Role $role -Command $normalizedCommand
+        }
+        'wait-ready' {
+            if ($permissions.WaitReady) { return $true }
+            return Deny-RoleCommand -Role $role -Command $normalizedCommand
+        }
+        'vault' {
+            if ($permissions.Vault) { return $true }
+            return Deny-RoleCommand -Role $role -Command $normalizedCommand
+        }
+        'dispatch' {
+            if ($permissions.Dispatch) { return $true }
+            return Deny-RoleCommand -Role $role -Command $normalizedCommand
+        }
+        'type' {
+            if ($isOwnPane -and $permissions.TypeOwn) { return $true }
+            if ((-not $isOwnPane) -and $permissions.TypeOther) { return $true }
+            return Deny-RoleCommand -Role $role -Command $normalizedCommand
+        }
+        'clipboard-paste' {
+            if ($isOwnPane -and $permissions.TypeOwn) { return $true }
+            if ((-not $isOwnPane) -and $permissions.TypeOther) { return $true }
+            return Deny-RoleCommand -Role $role -Command $normalizedCommand
+        }
+        'image-paste' {
+            if ($isOwnPane -and $permissions.TypeOwn) { return $true }
+            if ((-not $isOwnPane) -and $permissions.TypeOther) { return $true }
+            return Deny-RoleCommand -Role $role -Command $normalizedCommand
+        }
+        'ime-input' {
+            if ($isOwnPane -and $permissions.TypeOwn) { return $true }
+            if ((-not $isOwnPane) -and $permissions.TypeOther) { return $true }
+            return Deny-RoleCommand -Role $role -Command $normalizedCommand
+        }
+        'keys' {
+            if ($isOwnPane -and $permissions.KeysOwn) { return $true }
+            if ((-not $isOwnPane) -and $permissions.KeysOther) { return $true }
+            return Deny-RoleCommand -Role $role -Command $normalizedCommand
+        }
+        'list' {
+            if ($permissions.List) { return $true }
+            return Deny-RoleCommand -Role $role -Command $normalizedCommand
+        }
+        'id' {
+            if ($permissions.Id) { return $true }
+            return Deny-RoleCommand -Role $role -Command $normalizedCommand
+        }
+        'version' {
+            if ($permissions.Version) { return $true }
+            return Deny-RoleCommand -Role $role -Command $normalizedCommand
+        }
+        'doctor' {
+            if ($permissions.Doctor) { return $true }
+            return Deny-RoleCommand -Role $role -Command $normalizedCommand
+        }
+        default { return $true }
+    }
+}

--- a/tasks/backlog.yaml
+++ b/tasks/backlog.yaml
@@ -116,7 +116,7 @@ tasks:
   # Phase A: Foundation
   - id: TASK-025
     title: "Extract psmux-bridge CLI as PPM plugin (winsmux remains as platform)"
-    status: backlog
+    status: done
     priority: P1
     target_version: "v0.10.0"
     repo: winsmux

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,13 @@
+# Pester Tests
+
+Requires `Pester` 5.0 or later.
+
+## Run
+
+```powershell
+Invoke-Pester -Configuration (Import-PowerShellDataFile tests/.pester.ps1)
+```
+
+## Naming Convention
+
+Use `test_{subject}_{condition}_{expected_result}` for test names.

--- a/tests/psmux-bridge.Tests.ps1
+++ b/tests/psmux-bridge.Tests.ps1
@@ -1,0 +1,82 @@
+BeforeAll {
+    $script:BridgeScript = Join-Path $PSScriptRoot '..\scripts\psmux-bridge.ps1'
+    . $script:BridgeScript
+
+    function Stop-WithError {
+        param([string]$Message)
+        throw $Message
+    }
+}
+
+BeforeEach {
+    $script:OriginalWinsmuxRole = $env:WINSMUX_ROLE
+}
+
+AfterEach {
+    if ($null -eq $script:OriginalWinsmuxRole) {
+        Remove-Item Env:WINSMUX_ROLE -ErrorAction SilentlyContinue
+    } else {
+        $env:WINSMUX_ROLE = $script:OriginalWinsmuxRole
+    }
+}
+
+Describe 'psmux-bridge' {
+    Context 'version command' {
+        It 'test_version_when_invoked_returns_version_string' {
+            # Arrange
+            $commandOutput = $null
+
+            # Act
+            $commandOutput = & pwsh -NoProfile -File $script:BridgeScript version
+
+            # Assert
+            $commandOutput | Should -Match '^psmux-bridge \d+\.\d+\.\d+$'
+        }
+    }
+
+    Context 'Assert-Role' {
+        It 'test_assert_role_when_role_missing_denies_access' {
+            # Arrange
+            Remove-Item Env:WINSMUX_ROLE -ErrorAction SilentlyContinue
+
+            # Act
+            $action = { Assert-Role -CommandName 'read' }
+
+            # Assert
+            $action | Should -Throw '*WINSMUX_ROLE is not set*'
+        }
+
+        It 'test_assert_role_when_commander_reads_allows_access' {
+            # Arrange
+            $env:WINSMUX_ROLE = 'Commander'
+
+            # Act
+            $action = { Assert-Role -CommandName 'read' }
+
+            # Assert
+            $action | Should -Not -Throw
+        }
+
+        It 'test_assert_role_when_builder_uses_vault_denies_access' {
+            # Arrange
+            $env:WINSMUX_ROLE = 'Builder'
+
+            # Act
+            $action = { Assert-Role -CommandName 'vault' }
+
+            # Assert
+            $action | Should -Throw "*cannot use 'vault'*"
+        }
+
+        It 'test_assert_role_when_role_unknown_denies_access' {
+            # Arrange
+            $env:WINSMUX_ROLE = 'UnknownRole'
+
+            # Act
+            $action = { Assert-Role -CommandName 'read' }
+
+            # Assert
+            $action | Should -Throw '*unknown WINSMUX_ROLE*'
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- **TASK-027 (P0)**: Assert-Role permission matrix — Commander/Builder/Researcher/Reviewer enforcement at code level
- **TASK-037 (P1)**: Pester 5 test framework with initial Assert-Role test cases
- **TASK-025**: Marked done (plugin skeleton)
- TASK-030/031 hooks created locally (.claude/ gitignored)

## Test plan

- [ ] Assert-Role denies Builder from vault commands
- [ ] Assert-Role allows Commander for all management commands
- [ ] Assert-Role denies when WINSMUX_ROLE unset
- [ ] Pester tests pass: `Invoke-Pester tests/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)