### PR TITLE
feat: settings system, mailbox router, and README platform rewrite

### DIFF
--- a/.psmux-bridge.yaml.example
+++ b/.psmux-bridge.yaml.example
@@ -1,0 +1,11 @@
+# Project-level psmux-bridge settings.
+# Priority: project (.psmux-bridge.yaml) > global (@bridge-*) > built-in defaults.
+
+agent: codex
+model: gpt-5.4
+builders: 4
+researchers: 1
+reviewers: 1
+vault_keys:
+  - GH_TOKEN
+terminal: background

--- a/README.md
+++ b/README.md
@@ -6,18 +6,55 @@
 
 # winsmux
 
-Native Windows terminal multiplexer with cross-pane AI agent communication — no WSL2 required.
+**winsmux is the runtime and orchestration layer that Claude Code provides, minus the model lock-in.**
 
-- **For you** — keyboard-driven pane management with Alt-key bindings on PowerShell
-- **For agents** — `psmux-bridge` CLI lets any agent read, type, and send keys to any pane
-- **Agent-to-agent** — Claude Code can prompt Codex in the next pane, and Codex replies back. Any agent that can run shell commands can participate.
-- **Platform** — the runtime and orchestration layer that Claude Code provides, minus the model lock-in. Vendor-agnostic by design.
+winsmux is a multi-vendor agent orchestration platform for Windows. It gives you a Windows-native runtime for running Claude, Codex, Gemini, and your own CLI agents side by side, with live pane-level visibility, enforced read-before-act control, and enterprise-grade governance.
+
+- **Multi-vendor orchestration**: run Claude, Codex, and Gemini simultaneously in one coordinated workspace
+- **Visual real-time orchestration**: supervise agents through live `psmux` panes with `Read Guard` enforcing observe-before-act
+- **Enterprise-grade security governance**: combine Shield Harness, Credential Vault, and Evidence Ledger patterns for controlled, auditable execution
 
 ```powershell
-psmux-bridge read codex 20              # read the pane
-psmux-bridge type codex "review src/auth.ts"  # type into it
-psmux-bridge keys codex Enter           # press Enter
+psmux-bridge read codex 20                    # inspect the pane state
+psmux-bridge type codex "review src/auth.ts" # type into it
+psmux-bridge keys codex Enter                # press Enter
 ```
+
+## Why winsmux
+
+Most agent tooling gives you one vendor's runtime with one vendor's operating model. winsmux gives you the runtime and orchestration layer itself:
+
+- **Windows-native**: no WSL2, no Linux detour, no hidden tmux dependency
+- **Vendor-neutral**: Claude Code, Codex CLI, Gemini CLI, and custom shell-based agents can share the same workflow
+- **Operator-visible**: every agent runs in a real pane you can read, inspect, interrupt, and redirect in real time
+- **Governable**: safety hooks, read-before-act controls, DPAPI-backed secret handling, and audit-oriented workflows fit enterprise teams
+
+## Platform Architecture
+
+```text
+winsmux (platform)
+├── psmux-bridge CLI
+├── Shield Harness (22 hooks)
+├── Orchestra (Commander/Builder/Reviewer)
+├── Credential Vault (DPAPI)
+└── MCP Server (planned)
+```
+
+- **`psmux-bridge` CLI**: pane targeting, pane I/O, signaling, health checks, and operator controls
+- **Shield Harness**: policy hooks and guarded approval-free execution
+- **Orchestra**: Commander/Builder/Reviewer coordination across multiple agents
+- **Credential Vault**: machine-local secret storage and pane injection via Windows DPAPI
+- **MCP Server (planned)**: expose winsmux as a vendor-neutral orchestration substrate for external agent runtimes
+
+## Competitive Positioning
+
+| Product | Core position | Vendor model | Orchestration model | Visual supervision | Governance posture |
+| ------- | ------------- | ------------ | ------------------- | ------------------ | ------------------ |
+| **winsmux** | Multi-vendor orchestration platform for Windows | Claude + Codex + Gemini + custom CLIs | Pane-native Commander/Builder/Reviewer orchestration | Live `psmux` panes + `Read Guard` | Shield Harness + Evidence Ledger + DPAPI vault |
+| **Codex App** | OpenAI-native coding surface | OpenAI-centric | OpenAI agent workflows | App-level task UI | OpenAI-native controls |
+| **Claude Code** | Anthropic-native terminal coding runtime | Anthropic-centric | Strong single-vendor terminal workflow | Terminal-native, but not a Windows pane orchestration platform | Anthropic-native controls |
+
+winsmux is not trying to replace model-specific coding tools. It sits underneath them as the Windows runtime, coordination fabric, and governance layer when you need multiple vendors to work together in one operator-controlled environment.
 
 ## Install
 
@@ -94,7 +131,7 @@ All keybindings use **Alt** with no prefix required.
 
 ## psmux-bridge
 
-A CLI for cross-pane communication on Windows. Any tool that can run shell commands can use it — Claude Code, Codex, Gemini CLI, or a plain PowerShell script.
+A CLI for cross-pane communication on Windows. Any tool that can run shell commands can use it: Claude Code, Codex, Gemini CLI, or a plain PowerShell script.
 
 | Command                                 | Description                                    |
 | --------------------------------------- | ---------------------------------------------- |
@@ -126,14 +163,14 @@ A CLI for cross-pane communication on Windows. Any tool that can run shell comma
 
 ### Read Guard
 
-The CLI enforces a **read-before-act** rule. You cannot `type` or `keys` to a pane unless you have read it first. After each `type`/`keys`, the mark clears and you must read again.
+`Read Guard` is the core operator safety rule behind winsmux's visual orchestration model. You cannot `type` or `keys` to a pane unless you have read it first. After each `type` or `keys`, the mark clears and you must read again.
 
 ```powershell
 psmux-bridge type codex "hello"
 # error: must read the pane before interacting. Run: psmux-bridge read codex
 ```
 
-This prevents agents from blindly typing into the wrong pane.
+This prevents agents from blindly typing into the wrong pane and gives human operators a clear inspection point before every action.
 
 ### Targeting
 
@@ -164,9 +201,18 @@ select-pane -T claude
 psmux-bridge name %2 codex
 ```
 
-## Credential Vault
+## Security Governance
 
-Store secrets securely and inject them into agent panes — no `.env` files in your repo.
+winsmux is designed for environments where agent execution has to be observable, controllable, and defensible.
+
+- **Shield Harness (22 hooks)** adds policy enforcement around approval-free execution paths
+- **Read Guard** forces read-before-act interactions on every pane
+- **Credential Vault** stores secrets with Windows DPAPI and injects them into target panes without writing `.env` files into the repo
+- **Evidence Ledger** is the governance pattern for capturing prompts, approvals, outputs, and review evidence around agent work
+
+### Credential Vault
+
+Store secrets securely and inject them into agent panes with no `.env` files in your repo.
 
 ```powershell
 # Store credentials (DPAPI-encrypted, Windows Credential Manager)
@@ -192,13 +238,13 @@ psmux-bridge profile mysetup builder:codex reviewer:claude
 
 ## Orchestra
 
-Orchestra lets one Commander manage multiple AI agents in parallel. The Commander runs in your terminal (full keyboard access); background agents run in psmux panes. You tell the Commander what to build — it splits the work across builders, polls for completion, sends finished work to reviewers, and checks for conflicts before committing.
+Orchestra is winsmux's role-based coordination layer. One Commander manages multiple AI agents in parallel while builders and reviewers run in visible `psmux` panes. You tell the Commander what to build; Orchestra splits the work, tracks progress, routes finished work to review, and checks for conflicts before committing.
 
 ### What the Commander does for you
 
-1. **Splits work** — Assigns independent file sets to each builder so they don't step on each other
+1. **Splits work** — Assigns independent file sets to each builder so they do not step on each other
 2. **Polls progress** — Cycles `psmux-bridge read` across all agents to detect completion
-3. **Reviews incrementally** — Sends completed work to the reviewer as each builder finishes (no waiting for all)
+3. **Reviews incrementally** — Sends completed work to the reviewer as each builder finishes instead of waiting for the whole batch
 4. **Detects conflicts** — Runs `git diff --name-only` before merging to catch overlapping changes
 5. **Commits safely** — Only after review passes and no conflicts
 
@@ -206,13 +252,13 @@ Orchestra lets one Commander manage multiple AI agents in parallel. The Commande
 
 Mix different CLI agents in the same Orchestra. The script auto-detects each CLI and handles their differences:
 
-| CLI         | Approval-free flag (with `-ShieldHarness`) |
-| ----------- | ------------------------------------------ |
-| Claude Code | `--permission-mode bypassPermissions`      |
-| Codex CLI   | `--full-auto`                              |
-| Gemini CLI  | `--yolo`                                   |
+| CLI | Approval-free flag (with `-ShieldHarness`) |
+| --- | ------------------------------------------ |
+| Claude Code | `--permission-mode bypassPermissions` |
+| Codex CLI | `--full-auto` |
+| Gemini CLI | `--yolo` |
 
-Without `-ShieldHarness`: no approval-free flags are added.
+Without `-ShieldHarness`, no approval-free flags are added.
 
 ### Quick start
 
@@ -228,7 +274,7 @@ cd C:\path\to\project
 claude --model claude-opus-4-6 --append-system-prompt-file .commander-prompt.txt
 ```
 
-### Scaling up (e.g. 4 builders + researcher + reviewer)
+### Scaling up (for example, 4 builders + researcher + reviewer)
 
 ```powershell
 pwsh scripts/start-orchestra.ps1 -ProjectDir C:\my\project -Rows 2 -Cols 3 -Agents @(
@@ -241,7 +287,7 @@ pwsh scripts/start-orchestra.ps1 -ProjectDir C:\my\project -Rows 2 -Cols 3 -Agen
 ) -ShieldHarness
 ```
 
-```
+```text
 ┌──────────┬──────────┬──────────┐
 │builder-1 │builder-2 │builder-3 │
 ├──────────┼──────────┼──────────┤
@@ -249,21 +295,21 @@ pwsh scripts/start-orchestra.ps1 -ProjectDir C:\my\project -Rows 2 -Cols 3 -Agen
 └──────────┴──────────┴──────────┘
 ```
 
-The `.commander-prompt.txt` is auto-generated with actual pane IDs, agent labels, and the coordination protocol — the Commander always knows exactly who to talk to.
+The `.commander-prompt.txt` is auto-generated with actual pane IDs, agent labels, and the coordination protocol so the Commander always knows exactly who to talk to.
 
-| Parameter        | Default           | Description                                                                                     |
-| ---------------- | ----------------- | ----------------------------------------------------------------------------------------------- |
-| `-ProjectDir`    | Current directory | Working directory for all panes                                                                 |
-| `-Rows`          | 2                 | Grid rows                                                                                       |
-| `-Cols`          | 2                 | Grid columns                                                                                    |
-| `-Agents`        | 4-pane default    | Array of `@{label; command}` maps                                                               |
-| `-ShieldHarness` | Off               | Enable approval-free mode with [Shield Harness](https://github.com/Sora-bluesky/shield-harness) |
+| Parameter | Default | Description |
+| --------- | ------- | ----------- |
+| `-ProjectDir` | Current directory | Working directory for all panes |
+| `-Rows` | 2 | Grid rows |
+| `-Cols` | 2 | Grid columns |
+| `-Agents` | 4-pane default | Array of `@{label; command}` maps |
+| `-ShieldHarness` | Off | Enable approval-free mode with [Shield Harness](https://github.com/Sora-bluesky/shield-harness) |
 
-See [SKILL.md](skills/winsmux/SKILL.md) for the full Commander workflow. Management protocols (pipeline operation, researcher recon, reviewer batching, agent selection) are bundled as skill references and loaded on-demand by agents.
+See [SKILL.md](skills/winsmux/SKILL.md) for the full Commander workflow. Management protocols such as pipeline operation, researcher recon, reviewer batching, and agent selection are bundled as skill references and loaded on demand by agents.
 
 ## AI Agent Skills
 
-Install the winsmux skill to teach your agents how to use psmux-bridge:
+Install the winsmux skill to teach your agents how to use `psmux-bridge`:
 
 ```powershell
 npx skills add Sora-bluesky/winsmux
@@ -271,7 +317,7 @@ npx skills add Sora-bluesky/winsmux
 
 The skill includes:
 
-- Core psmux-bridge usage ([SKILL.md](skills/winsmux/SKILL.md))
+- Core `psmux-bridge` usage ([SKILL.md](skills/winsmux/SKILL.md))
 - Orchestra management protocol ([references/orchestra-management.md](skills/winsmux/references/orchestra-management.md))
 - Agent selection guide ([references/agent-selection.md](skills/winsmux/references/agent-selection.md))
 
@@ -279,7 +325,7 @@ Works with Claude Code, Codex, Cursor, Copilot, and [other agents](https://skill
 
 ### Orchestra Layout Skill
 
-For Claude Code users, the `orchestra-layout` skill creates deterministic psmux grid layouts in one command, eliminating manual split-window trial-and-error:
+For Claude Code users, the `orchestra-layout` skill creates deterministic `psmux` grid layouts in one command, eliminating manual split-window trial and error:
 
 ```bash
 bash .claude/skills/orchestra-layout/scripts/orchestra-layout.sh 4b1r1v
@@ -301,12 +347,12 @@ winsmux uninstall
 ## Requirements
 
 - Windows 10/11
-- PowerShell 7+ (pwsh)
+- PowerShell 7+ (`pwsh`)
 - [psmux](https://github.com/psmux/psmux) (installed automatically)
 
 ## Acknowledgments
 
-winsmux is the Windows-native counterpart of [smux](https://github.com/ShawnPana/smux) by [@ShawnPana](https://github.com/ShawnPana). smux provides the same terminal multiplexer + AI agent communication workflow for macOS/Linux using tmux. winsmux brings that experience to Windows natively via psmux, without requiring WSL2.
+winsmux is the Windows-native counterpart of [smux](https://github.com/ShawnPana/smux) by [@ShawnPana](https://github.com/ShawnPana). smux provides the same terminal multiplexer and AI agent communication workflow for macOS and Linux using tmux. winsmux brings that experience to Windows natively via psmux, without requiring WSL2.
 
 Terminal banner powered by [oh-my-logo](https://github.com/shinshin86/oh-my-logo) (MIT AND CC0-1.0).
 

--- a/psmux-bridge/scripts/mailbox-router.ps1
+++ b/psmux-bridge/scripts/mailbox-router.ps1
@@ -1,0 +1,427 @@
+Set-StrictMode -Version Latest
+
+$script:MailboxRouterJobPrefix = 'winsmux-mailbox-router'
+
+function Test-MailboxRouterChannel {
+    param([Parameter(Mandatory)][string]$Channel)
+
+    if ([string]::IsNullOrWhiteSpace($Channel)) {
+        throw 'Channel must not be empty.'
+    }
+
+    if ($Channel -notmatch '^[a-zA-Z0-9_-]+$') {
+        throw 'Channel must be alphanumeric with optional hyphen/underscore.'
+    }
+}
+
+function Get-MailboxRouterJobName {
+    param([Parameter(Mandatory)][string]$Channel)
+
+    Test-MailboxRouterChannel -Channel $Channel
+    return "${script:MailboxRouterJobPrefix}-$Channel"
+}
+
+function Get-MailboxRouterPipeNames {
+    param([Parameter(Mandatory)][string]$Channel)
+
+    Test-MailboxRouterChannel -Channel $Channel
+
+    @(
+        "winsmux-$Channel"
+        "winsmux-mailbox-$Channel"
+    ) | Select-Object -Unique
+}
+
+function Get-MailboxRouterConnectPipeNames {
+    param([Parameter(Mandatory)][string]$Channel)
+
+    Test-MailboxRouterChannel -Channel $Channel
+
+    @(
+        "winsmux-$Channel"
+        "winsmux-mailbox-$Channel"
+    ) | Select-Object -Unique
+}
+
+function Test-MailboxRouterMessage {
+    param([Parameter(Mandatory)][hashtable]$Message)
+
+    foreach ($requiredKey in @('from', 'to', 'type', 'payload')) {
+        if (-not $Message.ContainsKey($requiredKey)) {
+            throw "Message must contain key '$requiredKey'."
+        }
+    }
+}
+
+function Start-MailboxRouter {
+    [CmdletBinding()]
+    param([Parameter(Mandatory)][string]$Channel)
+
+    Test-MailboxRouterChannel -Channel $Channel
+
+    $jobName = Get-MailboxRouterJobName -Channel $Channel
+    $existingJob = Get-Job -Name $jobName -ErrorAction SilentlyContinue
+    if ($existingJob) {
+        if ($existingJob.State -eq 'Running') {
+            return $existingJob
+        }
+
+        Remove-Job -Job $existingJob -Force -ErrorAction SilentlyContinue
+    }
+
+    $pipeNames = Get-MailboxRouterPipeNames -Channel $Channel
+
+    $jobParameters = @{
+        Name         = $jobName
+        ArgumentList = @(
+            $Channel,
+            $pipeNames,
+            $env:APPDATA,
+            $env:PATH
+        )
+        ScriptBlock  = {
+        param(
+            [string]$JobChannel,
+            [string[]]$JobPipeNames,
+            [string]$AppDataPath,
+            [string]$PathValue
+        )
+
+        Set-StrictMode -Version Latest
+
+        if (-not [string]::IsNullOrWhiteSpace($AppDataPath)) {
+            $env:APPDATA = $AppDataPath
+        }
+        if (-not [string]::IsNullOrWhiteSpace($PathValue)) {
+            $env:PATH = $PathValue
+        }
+
+        function Get-JobPsmuxBinary {
+            foreach ($name in @('psmux', 'pmux', 'tmux')) {
+                $command = Get-Command $name -ErrorAction SilentlyContinue
+                if ($command) {
+                    return $command.Source
+                }
+            }
+
+            return 'psmux'
+        }
+
+        function Get-LabelsFilePath {
+            Join-Path $env:APPDATA 'winsmux\labels.json'
+        }
+
+        function Get-LabelMap {
+            $labelsFile = Get-LabelsFilePath
+            if (-not (Test-Path $labelsFile)) {
+                return @{}
+            }
+
+            $raw = Get-Content -Path $labelsFile -Raw -Encoding UTF8
+            if ([string]::IsNullOrWhiteSpace($raw)) {
+                return @{}
+            }
+
+            try {
+                $parsed = $raw | ConvertFrom-Json -ErrorAction Stop
+            } catch {
+                Write-Warning "mailbox-router: invalid labels.json payload at $labelsFile"
+                return @{}
+            }
+
+            $map = @{}
+            foreach ($property in $parsed.PSObject.Properties) {
+                $map[$property.Name] = [string]$property.Value
+            }
+
+            return $map
+        }
+
+        function Get-PaneIds {
+            try {
+                @(
+                    & $script:PsmuxBin list-panes -a -F '#{pane_id}' 2>$null |
+                        ForEach-Object { "$_".Trim() } |
+                        Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+                )
+            } catch {
+                @()
+            }
+        }
+
+        function Convert-PayloadToText {
+            param($Payload)
+
+            if ($null -eq $Payload) {
+                return ''
+            }
+
+            if ($Payload -is [string]) {
+                return $Payload
+            }
+
+            return ($Payload | ConvertTo-Json -Compress -Depth 10)
+        }
+
+        function Enqueue-Retry {
+            param(
+                [Parameter(Mandatory)][System.Collections.ArrayList]$Queue,
+                [Parameter(Mandatory)]$Message,
+                [Parameter(Mandatory)][string]$Target,
+                [Parameter(Mandatory)][int]$Attempt
+            )
+
+            if ($Attempt -ge 3) {
+                Write-Warning "mailbox-router: dropping message for '$Target' after 3 retries"
+                return
+            }
+
+            $retryAttempt = $Attempt + 1
+            $retryMessage = [pscustomobject]@{
+                from    = $Message.from
+                to      = $Target
+                type    = $Message.type
+                payload = $Message.payload
+            }
+            [void]$Queue.Add([pscustomobject]@{
+                Message     = $retryMessage
+                Attempt     = $retryAttempt
+                NextAttempt = (Get-Date).AddSeconds([Math]::Max(1, $retryAttempt))
+            })
+        }
+
+        function Resolve-Recipients {
+            param([Parameter(Mandatory)]$Message)
+
+            $labels = Get-LabelMap
+            $target = [string]$Message.to
+            $sender = [string]$Message.from
+
+            if ($target -eq 'broadcast') {
+                $senderPane = if ($labels.ContainsKey($sender)) { [string]$labels[$sender] } else { $sender }
+
+                return @(
+                    $labels.GetEnumerator() |
+                        ForEach-Object {
+                            [pscustomobject]@{
+                                TargetKey = $_.Key
+                                PaneId    = [string]$_.Value
+                            }
+                        } |
+                        Where-Object {
+                            -not [string]::IsNullOrWhiteSpace($_.PaneId) -and
+                            $_.PaneId -ne $senderPane -and
+                            $_.TargetKey -ne $sender
+                        } |
+                        Sort-Object PaneId -Unique
+                )
+            }
+
+            if ($labels.ContainsKey($target)) {
+                return @(
+                    [pscustomobject]@{
+                        TargetKey = $target
+                        PaneId    = [string]$labels[$target]
+                    }
+                )
+            }
+
+            return @(
+                [pscustomobject]@{
+                    TargetKey = $target
+                    PaneId    = $target
+                }
+            )
+        }
+
+        function Send-ToPane {
+            param(
+                [Parameter(Mandatory)][string]$PaneId,
+                [Parameter(Mandatory)][string]$Text
+            )
+
+            & $script:PsmuxBin send-keys -t $PaneId -l -- $Text | Out-Null
+            & $script:PsmuxBin send-keys -t $PaneId Enter | Out-Null
+        }
+
+        function Route-Message {
+            param(
+                [Parameter(Mandatory)]$Message,
+                [Parameter(Mandatory)][System.Collections.ArrayList]$RetryQueue,
+                [Parameter(Mandatory)][int]$Attempt
+            )
+
+            if ($null -eq $Message -or [string]::IsNullOrWhiteSpace([string]$Message.to)) {
+                return
+            }
+
+            $paneIds = Get-PaneIds
+            $payloadText = Convert-PayloadToText -Payload $Message.payload
+            $recipients = Resolve-Recipients -Message $Message
+
+            if ($recipients.Count -eq 0) {
+                if ([string]$Message.to -ne 'broadcast') {
+                    Enqueue-Retry -Queue $RetryQueue -Message $Message -Target ([string]$Message.to) -Attempt $Attempt
+                }
+                return
+            }
+
+            foreach ($recipient in $recipients) {
+                $paneId = [string]$recipient.PaneId
+                if ([string]::IsNullOrWhiteSpace($paneId) -or ($paneIds -notcontains $paneId)) {
+                    Enqueue-Retry -Queue $RetryQueue -Message $Message -Target ([string]$recipient.TargetKey) -Attempt $Attempt
+                    continue
+                }
+
+                try {
+                    Send-ToPane -PaneId $paneId -Text $payloadText
+                } catch {
+                    Write-Warning "mailbox-router: failed to deliver to ${paneId}: $($_.Exception.Message)"
+                }
+            }
+        }
+
+        function Read-PipeMessage {
+            param([Parameter(Mandatory)][System.IO.Pipes.NamedPipeServerStream]$Server)
+
+            $reader = [System.IO.StreamReader]::new($Server, [System.Text.Encoding]::UTF8, $false, 1024, $true)
+            try {
+                $payload = $reader.ReadToEnd()
+            } finally {
+                $reader.Dispose()
+            }
+
+            if ([string]::IsNullOrWhiteSpace($payload)) {
+                return $null
+            }
+
+            try {
+                return $payload | ConvertFrom-Json -ErrorAction Stop
+            } catch {
+                Write-Warning 'mailbox-router: invalid JSON payload received'
+                return $null
+            }
+        }
+
+        function New-ListenerState {
+            param([Parameter(Mandatory)][string]$PipeName)
+
+            $server = [System.IO.Pipes.NamedPipeServerStream]::new(
+                $PipeName,
+                [System.IO.Pipes.PipeDirection]::In,
+                [System.IO.Pipes.NamedPipeServerStream]::MaxAllowedServerInstances,
+                [System.IO.Pipes.PipeTransmissionMode]::Byte,
+                [System.IO.Pipes.PipeOptions]::Asynchronous
+            )
+
+            [pscustomobject]@{
+                PipeName = $PipeName
+                Server   = $server
+                WaitTask = $server.WaitForConnectionAsync()
+            }
+        }
+
+        $script:PsmuxBin = Get-JobPsmuxBinary
+        $retryQueue = [System.Collections.ArrayList]::new()
+        $states = @($JobPipeNames | ForEach-Object { New-ListenerState -PipeName $_ })
+
+        while ($true) {
+            $dueItems = @($retryQueue | Where-Object { $_.NextAttempt -le (Get-Date) })
+            foreach ($item in $dueItems) {
+                [void]$retryQueue.Remove($item)
+                Route-Message -Message $item.Message -RetryQueue $retryQueue -Attempt $item.Attempt
+            }
+
+            $tasks = @($states | ForEach-Object { $_.WaitTask })
+            $completedIndex = [System.Threading.Tasks.Task]::WaitAny($tasks, 1000)
+            if ($completedIndex -lt 0 -or $completedIndex -ge $states.Count) {
+                continue
+            }
+
+            $state = $states[$completedIndex]
+            try {
+                $state.WaitTask.GetAwaiter().GetResult()
+                if ($state.Server.IsConnected) {
+                    $message = Read-PipeMessage -Server $state.Server
+                    if ($message) {
+                        Route-Message -Message $message -RetryQueue $retryQueue -Attempt 0
+                    }
+                }
+            } catch {
+                Write-Warning "mailbox-router: pipe error on $($state.PipeName): $($_.Exception.Message)"
+            } finally {
+                $state.Server.Dispose()
+                $states[$completedIndex] = New-ListenerState -PipeName $state.PipeName
+            }
+        }
+    }
+    }
+
+    $startThreadJob = Get-Command Start-ThreadJob -ErrorAction SilentlyContinue
+    if ($startThreadJob) {
+        return Start-ThreadJob @jobParameters
+    }
+
+    return Start-Job @jobParameters
+}
+
+function Send-MailboxMessage {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Channel,
+        [Parameter(Mandatory)][hashtable]$Message
+    )
+
+    Test-MailboxRouterChannel -Channel $Channel
+    Test-MailboxRouterMessage -Message $Message
+
+    $payload = $Message | ConvertTo-Json -Compress -Depth 10
+    $lastError = $null
+
+    foreach ($pipeName in (Get-MailboxRouterConnectPipeNames -Channel $Channel)) {
+        $client = [System.IO.Pipes.NamedPipeClientStream]::new(
+            '.',
+            $pipeName,
+            [System.IO.Pipes.PipeDirection]::Out
+        )
+
+        try {
+            $client.Connect(1500)
+            $writer = [System.IO.StreamWriter]::new($client, [System.Text.Encoding]::UTF8)
+            try {
+                $writer.AutoFlush = $true
+                $writer.Write($payload)
+            } finally {
+                $writer.Dispose()
+            }
+
+            return [pscustomobject]@{
+                Channel = $Channel
+                Pipe    = "\\.\pipe\$pipeName"
+                Sent    = $true
+            }
+        } catch {
+            $lastError = $_
+        } finally {
+            $client.Dispose()
+        }
+    }
+
+    throw "Failed to send mailbox message on channel '$Channel': $($lastError.Exception.Message)"
+}
+
+function Stop-MailboxRouter {
+    [CmdletBinding()]
+    param([Parameter(Mandatory)][string]$Channel)
+
+    Test-MailboxRouterChannel -Channel $Channel
+
+    $jobName = Get-MailboxRouterJobName -Channel $Channel
+    $job = Get-Job -Name $jobName -ErrorAction SilentlyContinue
+    if (-not $job) {
+        return
+    }
+
+    Stop-Job -Job $job -ErrorAction SilentlyContinue
+    Remove-Job -Job $job -Force -ErrorAction SilentlyContinue
+}

--- a/psmux-bridge/scripts/settings.ps1
+++ b/psmux-bridge/scripts/settings.ps1
@@ -1,0 +1,489 @@
+<#
+.SYNOPSIS
+Hierarchical settings loader for psmux-bridge.
+
+.DESCRIPTION
+Settings are resolved with per-key precedence:
+1. .psmux-bridge.yaml in the current directory
+2. Global psmux options (@bridge-*)
+3. Built-in defaults
+
+Dot-source this script to load the helpers:
+
+    . "$PSScriptRoot/settings.ps1"
+#>
+
+$script:BridgeSettingsFileName = '.psmux-bridge.yaml'
+$script:BridgeSettingsSchema = [ordered]@{
+    agent       = @{ Type = 'string';   Default = 'codex';      Option = '@bridge-agent' }
+    model       = @{ Type = 'string';   Default = 'gpt-5.4';    Option = '@bridge-model' }
+    builders    = @{ Type = 'int';      Default = 4;            Option = '@bridge-builders' }
+    researchers = @{ Type = 'int';      Default = 1;            Option = '@bridge-researchers' }
+    reviewers   = @{ Type = 'int';      Default = 1;            Option = '@bridge-reviewers' }
+    vault_keys  = @{ Type = 'string[]'; Default = @('GH_TOKEN'); Option = '@bridge-vault-keys' }
+    terminal    = @{ Type = 'string';   Default = 'background'; Option = '@bridge-terminal' }
+}
+
+if (-not (Get-Command Get-PsmuxBin -ErrorAction SilentlyContinue)) {
+    function Get-PsmuxBin {
+        foreach ($candidate in @('psmux', 'pmux', 'tmux')) {
+            $command = Get-Command $candidate -ErrorAction SilentlyContinue | Select-Object -First 1
+            if ($null -ne $command) {
+                if ($command.Path) {
+                    return $command.Path
+                }
+
+                return $command.Name
+            }
+        }
+
+        return $null
+    }
+}
+
+if (-not (Get-Command Get-PsmuxOption -ErrorAction SilentlyContinue)) {
+    function Get-PsmuxOption {
+        param(
+            [Parameter(Mandatory = $true)][string]$Name,
+            [string]$Default
+        )
+
+        $psmuxBin = Get-PsmuxBin
+        if (-not $psmuxBin) {
+            return $Default
+        }
+
+        try {
+            $value = (& $psmuxBin show-options -g -v $Name 2>&1 | Out-String).Trim()
+            if ($value -and $value -notmatch 'unknown|error|invalid') {
+                return $value
+            }
+        } catch {
+        }
+
+        return $Default
+    }
+}
+
+if (-not (Get-Command Set-PsmuxOption -ErrorAction SilentlyContinue)) {
+    function Set-PsmuxOption {
+        param(
+            [Parameter(Mandatory = $true)][string]$PsmuxBin,
+            [Parameter(Mandatory = $true)][string]$OptionName,
+            [Parameter(Mandatory = $true)][string]$OptionValue
+        )
+
+        & $PsmuxBin set-option -g $OptionName $OptionValue | Out-Null
+    }
+}
+
+function Get-BridgeSettingsDefaults {
+    $defaults = [ordered]@{}
+    foreach ($key in $script:BridgeSettingsSchema.Keys) {
+        $defaultValue = $script:BridgeSettingsSchema[$key].Default
+        if ($defaultValue -is [System.Array]) {
+            $defaults[$key] = @($defaultValue)
+        } else {
+            $defaults[$key] = $defaultValue
+        }
+    }
+
+    return $defaults
+}
+
+function Get-BridgeProjectSettingsPath {
+    return Join-Path (Get-Location).Path $script:BridgeSettingsFileName
+}
+
+function Remove-BridgeYamlComment {
+    param([string]$Line)
+
+    if ($null -eq $Line) {
+        return ''
+    }
+
+    $builder = [System.Text.StringBuilder]::new()
+    $inSingleQuote = $false
+    $inDoubleQuote = $false
+
+    foreach ($character in $Line.ToCharArray()) {
+        if ($character -eq "'" -and -not $inDoubleQuote) {
+            $inSingleQuote = -not $inSingleQuote
+            [void]$builder.Append($character)
+            continue
+        }
+
+        if ($character -eq '"' -and -not $inSingleQuote) {
+            $inDoubleQuote = -not $inDoubleQuote
+            [void]$builder.Append($character)
+            continue
+        }
+
+        if ($character -eq '#' -and -not $inSingleQuote -and -not $inDoubleQuote) {
+            break
+        }
+
+        [void]$builder.Append($character)
+    }
+
+    return $builder.ToString().TrimEnd()
+}
+
+function ConvertFrom-BridgeYamlScalar {
+    param([AllowNull()]$Value)
+
+    if ($null -eq $Value) {
+        return $null
+    }
+
+    $text = $Value.ToString().Trim()
+    if ($text.Length -ge 2) {
+        if (($text.StartsWith("'") -and $text.EndsWith("'")) -or ($text.StartsWith('"') -and $text.EndsWith('"'))) {
+            $text = $text.Substring(1, $text.Length - 2)
+        }
+    }
+
+    return $text
+}
+
+function ConvertFrom-BridgeInlineList {
+    param([string]$Value)
+
+    $trimmed = $Value.Trim()
+    if (-not ($trimmed.StartsWith('[') -and $trimmed.EndsWith(']'))) {
+        return $null
+    }
+
+    $inner = $trimmed.Substring(1, $trimmed.Length - 2).Trim()
+    if ([string]::IsNullOrWhiteSpace($inner)) {
+        return @()
+    }
+
+    return @(
+        $inner -split ',' |
+        ForEach-Object { ConvertFrom-BridgeYamlScalar $_ } |
+        Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+    )
+}
+
+function ConvertFrom-BridgeManualYaml {
+    param([Parameter(Mandatory = $true)][string]$Content)
+
+    $settings = [ordered]@{}
+    $currentListKey = $null
+    $lineNumber = 0
+
+    foreach ($rawLine in ($Content -split "\r?\n")) {
+        $lineNumber++
+        $line = Remove-BridgeYamlComment $rawLine
+        if ([string]::IsNullOrWhiteSpace($line)) {
+            continue
+        }
+
+        if ($line -match '^\s*-\s*(.+?)\s*$') {
+            if ($null -eq $currentListKey) {
+                continue
+            }
+
+            $settings[$currentListKey] += @(ConvertFrom-BridgeYamlScalar $Matches[1])
+            continue
+        }
+
+        $currentListKey = $null
+        if ($line -notmatch '^\s*([A-Za-z_][A-Za-z0-9_-]*)\s*:\s*(.*?)\s*$') {
+            continue
+        }
+
+        $key = $Matches[1] -replace '-', '_'
+        $value = $Matches[2]
+        if (-not $script:BridgeSettingsSchema.Contains($key)) {
+            continue
+        }
+
+        if ([string]::IsNullOrWhiteSpace($value)) {
+            $settings[$key] = @()
+            $currentListKey = $key
+            continue
+        }
+
+        $inlineList = ConvertFrom-BridgeInlineList $value
+        if ($null -ne $inlineList) {
+            $settings[$key] = @($inlineList)
+            continue
+        }
+
+        $settings[$key] = ConvertFrom-BridgeYamlScalar $value
+    }
+
+    return $settings
+}
+
+function Read-BridgeProjectSettings {
+    $path = Get-BridgeProjectSettingsPath
+    if (-not (Test-Path $path)) {
+        return @{}
+    }
+
+    $raw = Get-Content -Raw -Path $path -Encoding UTF8
+    if ([string]::IsNullOrWhiteSpace($raw)) {
+        return @{}
+    }
+
+    $yamlCommand = Get-Command ConvertFrom-Yaml -ErrorAction SilentlyContinue
+    if ($yamlCommand) {
+        try {
+            $parsed = $raw | ConvertFrom-Yaml -ErrorAction Stop
+            if ($parsed -is [System.Collections.IDictionary]) {
+                $settings = [ordered]@{}
+                foreach ($entry in $parsed.GetEnumerator()) {
+                    $settings[$entry.Key] = $entry.Value
+                }
+
+                return $settings
+            }
+
+            if ($null -ne $parsed) {
+                $settings = [ordered]@{}
+                foreach ($property in $parsed.PSObject.Properties) {
+                    $settings[$property.Name] = $property.Value
+                }
+
+                return $settings
+            }
+        } catch {
+        }
+    }
+
+    return ConvertFrom-BridgeManualYaml -Content $raw
+}
+
+function Test-BridgeSettingValue {
+    param(
+        [Parameter(Mandatory = $true)][string]$Name,
+        [AllowNull()]$Value,
+        [ref]$NormalizedValue
+    )
+
+    $schema = $script:BridgeSettingsSchema[$Name]
+    if ($null -eq $schema) {
+        return $false
+    }
+
+    switch ($schema.Type) {
+        'string' {
+            $text = ConvertFrom-BridgeYamlScalar $Value
+            if ([string]::IsNullOrWhiteSpace($text)) {
+                return $false
+            }
+
+            $NormalizedValue.Value = $text
+            return $true
+        }
+        'int' {
+            $text = ConvertFrom-BridgeYamlScalar $Value
+            $parsed = 0
+            if (-not [int]::TryParse($text, [ref]$parsed)) {
+                return $false
+            }
+
+            $NormalizedValue.Value = $parsed
+            return $true
+        }
+        'string[]' {
+            $items = @()
+
+            if ($Value -is [System.Collections.IEnumerable] -and $Value -isnot [string]) {
+                foreach ($item in $Value) {
+                    $text = ConvertFrom-BridgeYamlScalar $item
+                    if (-not [string]::IsNullOrWhiteSpace($text)) {
+                        $items += $text
+                    }
+                }
+            } else {
+                $text = ConvertFrom-BridgeYamlScalar $Value
+                if ([string]::IsNullOrWhiteSpace($text)) {
+                    $items = @()
+                } else {
+                    $items = @(
+                        $text -split '[,;]' |
+                        ForEach-Object { ConvertFrom-BridgeYamlScalar $_ } |
+                        Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+                    )
+                }
+            }
+
+            $NormalizedValue.Value = @($items)
+            return $true
+        }
+        default {
+            return $false
+        }
+    }
+}
+
+function ConvertTo-BridgeSettingsSource {
+    param([AllowNull()]$Settings)
+
+    $normalized = [ordered]@{}
+    if ($null -eq $Settings) {
+        return $normalized
+    }
+
+    $pairs = @()
+    if ($Settings -is [System.Collections.IDictionary]) {
+        $pairs = $Settings.GetEnumerator()
+    } else {
+        $pairs = $Settings.PSObject.Properties | ForEach-Object {
+            [PSCustomObject]@{ Key = $_.Name; Value = $_.Value }
+        }
+    }
+
+    foreach ($pair in $pairs) {
+        $key = $pair.Key.ToString() -replace '-', '_'
+        if (-not $script:BridgeSettingsSchema.Contains($key)) {
+            continue
+        }
+
+        $normalizedValue = $null
+        if (Test-BridgeSettingValue -Name $key -Value $pair.Value -NormalizedValue ([ref]$normalizedValue)) {
+            if ($normalizedValue -is [System.Array]) {
+                $normalized[$key] = @($normalizedValue)
+            } else {
+                $normalized[$key] = $normalizedValue
+            }
+        }
+    }
+
+    return $normalized
+}
+
+function Read-BridgeGlobalSettings {
+    $settings = [ordered]@{}
+
+    foreach ($key in $script:BridgeSettingsSchema.Keys) {
+        $optionName = $script:BridgeSettingsSchema[$key].Option
+        $rawValue = Get-PsmuxOption -Name $optionName -Default $null
+        if ($null -eq $rawValue -or [string]::IsNullOrWhiteSpace($rawValue)) {
+            continue
+        }
+
+        $normalizedValue = $null
+        if (Test-BridgeSettingValue -Name $key -Value $rawValue -NormalizedValue ([ref]$normalizedValue)) {
+            if ($normalizedValue -is [System.Array]) {
+                $settings[$key] = @($normalizedValue)
+            } else {
+                $settings[$key] = $normalizedValue
+            }
+        }
+    }
+
+    return $settings
+}
+
+function Get-BridgeSettings {
+    $defaults = Get-BridgeSettingsDefaults
+    $settings = [ordered]@{}
+
+    foreach ($key in $script:BridgeSettingsSchema.Keys) {
+        $defaultValue = $defaults[$key]
+        if ($defaultValue -is [System.Array]) {
+            $settings[$key] = @($defaultValue)
+        } else {
+            $settings[$key] = $defaultValue
+        }
+    }
+
+    $globalSettings = Read-BridgeGlobalSettings
+    foreach ($key in $globalSettings.Keys) {
+        $value = $globalSettings[$key]
+        if ($value -is [System.Array]) {
+            $settings[$key] = @($value)
+        } else {
+            $settings[$key] = $value
+        }
+    }
+
+    $projectSettings = ConvertTo-BridgeSettingsSource (Read-BridgeProjectSettings)
+    foreach ($key in $projectSettings.Keys) {
+        $value = $projectSettings[$key]
+        if ($value -is [System.Array]) {
+            $settings[$key] = @($value)
+        } else {
+            $settings[$key] = $value
+        }
+    }
+
+    return $settings
+}
+
+function Get-BridgeSetting {
+    param([Parameter(Mandatory = $true)][string]$Name)
+
+    $key = $Name -replace '-', '_'
+    if (-not $script:BridgeSettingsSchema.Contains($key)) {
+        throw "Unknown bridge setting: $Name"
+    }
+
+    return (Get-BridgeSettings)[$key]
+}
+
+function ConvertTo-BridgeYamlScalar {
+    param([AllowNull()]$Value)
+
+    if ($null -eq $Value) {
+        return "''"
+    }
+
+    $text = $Value.ToString()
+    if ($text -match '^[A-Za-z0-9._/-]+$') {
+        return $text
+    }
+
+    return "'" + ($text -replace "'", "''") + "'"
+}
+
+function Save-BridgeSettings {
+    param(
+        [Parameter(Mandatory = $true)][ValidateSet('project', 'global')][string]$Scope,
+        [Parameter(Mandatory = $true)][hashtable]$Settings
+    )
+
+    $normalized = ConvertTo-BridgeSettingsSource $Settings
+
+    if ($Scope -eq 'project') {
+        $path = Get-BridgeProjectSettingsPath
+        $lines = [System.Collections.Generic.List[string]]::new()
+
+        foreach ($key in $script:BridgeSettingsSchema.Keys) {
+            if (-not $normalized.Contains($key)) {
+                continue
+            }
+
+            $value = $normalized[$key]
+            if ($value -is [System.Array]) {
+                $lines.Add("${key}:")
+                foreach ($item in $value) {
+                    $lines.Add("  - $(ConvertTo-BridgeYamlScalar $item)")
+                }
+            } else {
+                $lines.Add("${key}: $(ConvertTo-BridgeYamlScalar $value)")
+            }
+        }
+
+        $content = if ($lines.Count -gt 0) { ($lines -join [Environment]::NewLine) + [Environment]::NewLine } else { '' }
+        Set-Content -Path $path -Value $content -Encoding UTF8
+        return
+    }
+
+    $psmuxBin = Get-PsmuxBin
+    if (-not $psmuxBin) {
+        throw 'Could not find a psmux binary. Tried: psmux, pmux, tmux.'
+    }
+
+    foreach ($key in $normalized.Keys) {
+        $optionName = $script:BridgeSettingsSchema[$key].Option
+        $value = $normalized[$key]
+        $serializedValue = if ($value -is [System.Array]) { $value -join ',' } else { $value.ToString() }
+        Set-PsmuxOption -PsmuxBin $psmuxBin -OptionName $optionName -OptionValue $serializedValue
+    }
+}


### PR DESCRIPTION
## Summary

- **TASK-026**: Hierarchical settings (project .yaml > global @bridge-* > defaults)
- **TASK-028**: Commander-side PreToolUse hook (sh-orchestra-gate.js, local .claude/)
- **TASK-032 (P0)**: Mailbox-compatible async message router for inter-agent communication
- **TASK-052**: README rewritten — winsmux as multi-vendor agent orchestration platform

## Test plan

- [ ] Get-BridgeSettings loads from .psmux-bridge.yaml when present
- [ ] Get-BridgeSettings falls back to psmux options then defaults
- [ ] Mailbox router routes messages to correct panes by role
- [ ] README reflects platform positioning with 3 unique strengths

🤖 Generated with [Claude Code](https://claude.com/claude-code)