### PR TITLE
feat: task engine, orchestra automation, lifecycle, and unit tests

### DIFF
--- a/psmux-bridge/scripts/agent-lifecycle.ps1
+++ b/psmux-bridge/scripts/agent-lifecycle.ps1
@@ -1,0 +1,690 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$script:AgentMonitorJobName = 'winsmux-agent-monitor'
+$script:AgentLifecycleState = @{}
+$script:AgentConfigCache = @{}
+$script:AgentLifecycleScriptPath = $PSCommandPath
+$script:WorkspaceRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\..'))
+$script:LifecycleDir = Join-Path $script:WorkspaceRoot '.winsmux'
+$script:LifecycleLog = Join-Path $script:LifecycleDir 'lifecycle.log'
+
+function Get-AgentLifecyclePsmuxBin {
+    foreach ($candidate in @('psmux', 'pmux', 'tmux')) {
+        $command = Get-Command $candidate -ErrorAction SilentlyContinue | Select-Object -First 1
+        if ($null -ne $command) {
+            if ($command.Path) {
+                return $command.Path
+            }
+
+            return $command.Name
+        }
+    }
+
+    throw 'Could not find a psmux binary. Tried: psmux, pmux, tmux.'
+}
+
+function Initialize-AgentLifecycleLog {
+    if (-not (Test-Path $script:LifecycleDir)) {
+        New-Item -ItemType Directory -Path $script:LifecycleDir -Force | Out-Null
+    }
+}
+
+function Write-AgentLifecycleLog {
+    param(
+        [Parameter(Mandatory)][string]$Event,
+        [string]$PaneId,
+        [string]$Label,
+        [string]$State,
+        [string]$Details
+    )
+
+    Initialize-AgentLifecycleLog
+
+    $parts = [System.Collections.Generic.List[string]]::new()
+    $parts.Add((Get-Date).ToString('o'))
+    $parts.Add($Event)
+
+    if (-not [string]::IsNullOrWhiteSpace($PaneId)) {
+        $parts.Add("pane=$PaneId")
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($Label)) {
+        $parts.Add("label=$Label")
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($State)) {
+        $parts.Add("state=$State")
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($Details)) {
+        $singleLineDetails = $Details -replace '\r?\n', ' '
+        $parts.Add("details=$singleLineDetails")
+    }
+
+    Add-Content -Path $script:LifecycleLog -Value ($parts -join ' ') -Encoding UTF8
+}
+
+function Get-AgentLabelsFilePath {
+    return Join-Path $env:APPDATA 'winsmux\labels.json'
+}
+
+function Get-AgentLabels {
+    $labelsFile = Get-AgentLabelsFilePath
+    if (-not (Test-Path $labelsFile)) {
+        return @{}
+    }
+
+    $raw = Get-Content -Path $labelsFile -Raw -Encoding UTF8
+    if ([string]::IsNullOrWhiteSpace($raw)) {
+        return @{}
+    }
+
+    try {
+        $parsed = $raw | ConvertFrom-Json -ErrorAction Stop
+    } catch {
+        Write-AgentLifecycleLog -Event 'warn' -Details "Invalid labels file: $labelsFile"
+        return @{}
+    }
+
+    $labels = @{}
+    foreach ($property in $parsed.PSObject.Properties) {
+        $labels[$property.Name] = [string]$property.Value
+    }
+
+    return $labels
+}
+
+function Get-AgentLabelByPaneId {
+    param([Parameter(Mandatory)][string]$PaneId)
+
+    foreach ($entry in (Get-AgentLabels).GetEnumerator()) {
+        if ([string]$entry.Value -eq $PaneId) {
+            return [string]$entry.Key
+        }
+    }
+
+    return $null
+}
+
+function Get-LabeledPaneAssignments {
+    $labels = Get-AgentLabels
+
+    return @(
+        $labels.Keys |
+            Sort-Object |
+            ForEach-Object {
+                [PSCustomObject]@{
+                    Label  = [string]$_
+                    PaneId = [string]$labels[$_]
+                }
+            } |
+            Where-Object { -not [string]::IsNullOrWhiteSpace($_.PaneId) }
+    )
+}
+
+function Get-PaneRuntimeMap {
+    $psmux = Get-AgentLifecyclePsmuxBin
+    $runtimeMap = @{}
+    $raw = & $psmux list-panes -a -F '#{pane_id}|#{pane_pid}|#{pane_current_command}|#{pane_current_path}|#{pane_title}' 2>$null
+    $lines = @($raw | ForEach-Object { "$_".Trim() } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+
+    foreach ($line in $lines) {
+        $parts = $line -split '\|', 5
+        if ($parts.Count -lt 5) {
+            continue
+        }
+
+        $paneId = [string]$parts[0]
+        $panePid = [string]$parts[1]
+        $isRunning = $false
+
+        if ($panePid -match '^\d+$') {
+            try {
+                $null = Get-Process -Id ([int]$panePid) -ErrorAction Stop
+                $isRunning = $true
+            } catch {
+                $isRunning = $false
+            }
+        }
+
+        $runtimeMap[$paneId] = [PSCustomObject]@{
+            PaneId         = $paneId
+            PanePid        = $panePid
+            CurrentCommand = [string]$parts[2]
+            CurrentPath    = [string]$parts[3]
+            Title          = [string]$parts[4]
+            IsRunning      = $isRunning
+        }
+    }
+
+    return $runtimeMap
+}
+
+function Get-PaneRuntimeRecord {
+    param([Parameter(Mandatory)][string]$PaneId)
+
+    $runtimeMap = Get-PaneRuntimeMap
+    if ($runtimeMap.ContainsKey($PaneId)) {
+        return $runtimeMap[$PaneId]
+    }
+
+    return $null
+}
+
+function Get-PaneOutputLines {
+    param(
+        [Parameter(Mandatory)][string]$PaneId,
+        [int]$Lines = 5
+    )
+
+    $psmux = Get-AgentLifecyclePsmuxBin
+    $output = & $psmux capture-pane -t $PaneId -p -J -S "-$Lines" 2>$null
+    return @($output | ForEach-Object { [string]$_ })
+}
+
+function Get-AgentOutputHash {
+    param([string[]]$Lines)
+
+    $text = if ($Lines) { $Lines -join "`n" } else { '' }
+    return [System.BitConverter]::ToString(
+        [System.Security.Cryptography.SHA256]::Create().ComputeHash(
+            [System.Text.Encoding]::UTF8.GetBytes($text)
+        )
+    ) -replace '-', ''
+}
+
+function Get-LastNonEmptyAgentLine {
+    param([string[]]$Lines)
+
+    if ($null -eq $Lines) {
+        return $null
+    }
+
+    for ($index = $Lines.Count - 1; $index -ge 0; $index--) {
+        $line = [string]$Lines[$index]
+        if (-not [string]::IsNullOrWhiteSpace($line)) {
+            return $line
+        }
+    }
+
+    return $null
+}
+
+function Test-AgentReadyLine {
+    param([AllowNull()][string]$Line)
+
+    if ([string]::IsNullOrWhiteSpace($Line)) {
+        return $false
+    }
+
+    $trimmed = $Line.TrimEnd()
+    $normalized = $trimmed.Trim()
+
+    if ($trimmed -match 'codex>\s*$') { return $true }
+    if ($trimmed -match '(?i)tokens used') { return $true }
+    if ($trimmed -match 'claude>\s*$') { return $true }
+    if ($normalized -eq '$') { return $true }
+    if ($trimmed -match 'gemini>\s*$') { return $true }
+    if ($normalized -eq '>') { return $true }
+    if ($trimmed -match '^PS .+>\s*$') { return $true }
+
+    return $false
+}
+
+function Test-AgentReadySnapshot {
+    param([string[]]$Lines)
+
+    foreach ($line in $Lines) {
+        if (Test-AgentReadyLine -Line $line) {
+            return $true
+        }
+    }
+
+    return $false
+}
+
+function Get-ProcessCommandArguments {
+    param([AllowNull()][string]$CommandLine)
+
+    if ([string]::IsNullOrWhiteSpace($CommandLine)) {
+        return ''
+    }
+
+    $trimmed = $CommandLine.Trim()
+    if ($trimmed.StartsWith('"')) {
+        $quotedMatch = [regex]::Match($trimmed, '^"[^"]+"\s*(?<args>.*)$')
+        if ($quotedMatch.Success) {
+            return $quotedMatch.Groups['args'].Value
+        }
+    }
+
+    $plainMatch = [regex]::Match($trimmed, '^\S+\s*(?<args>.*)$')
+    if ($plainMatch.Success) {
+        return $plainMatch.Groups['args'].Value
+    }
+
+    return ''
+}
+
+function Get-AgentChildProcess {
+    param([Parameter(Mandatory)][int]$ParentProcessId)
+
+    try {
+        $children = @(Get-CimInstance Win32_Process -Filter "ParentProcessId = $ParentProcessId" -ErrorAction Stop)
+    } catch {
+        return $null
+    }
+
+    if (-not $children -or $children.Count -eq 0) {
+        return $null
+    }
+
+    $scored = foreach ($child in $children) {
+        $commandLine = [string]$child.CommandLine
+        $name = [string]$child.Name
+        $score = 0
+
+        if ($commandLine -match '(?i)\bcodex\b' -or $name -match '(?i)^codex') { $score += 30 }
+        if ($commandLine -match '(?i)\bclaude\b' -or $name -match '(?i)^claude') { $score += 30 }
+        if ($commandLine -match '(?i)\bgemini\b') { $score += 30 }
+        if ($name -match '(?i)^(pwsh|powershell|conhost|cmd)(\.exe)?$') { $score -= 20 }
+        if (-not [string]::IsNullOrWhiteSpace($commandLine)) { $score += 5 }
+
+        [PSCustomObject]@{
+            Score   = $score
+            Process = $child
+        }
+    }
+
+    return ($scored | Sort-Object -Property @{ Expression = 'Score'; Descending = $true } | Select-Object -First 1).Process
+}
+
+function ConvertTo-AgentLaunchCommand {
+    param($ProcessInfo)
+
+    if ($null -eq $ProcessInfo) {
+        return $null
+    }
+
+    $commandLine = [string]$ProcessInfo.CommandLine
+    $executablePath = [string]$ProcessInfo.ExecutablePath
+    $processName = [System.IO.Path]::GetFileNameWithoutExtension([string]$ProcessInfo.Name)
+
+    if (-not [string]::IsNullOrWhiteSpace($executablePath)) {
+        $escapedExecutable = $executablePath -replace "'", "''"
+        $arguments = Get-ProcessCommandArguments -CommandLine $commandLine
+        if ([string]::IsNullOrWhiteSpace($arguments)) {
+            return "& '$escapedExecutable'"
+        }
+
+        return ("& '{0}' {1}" -f $escapedExecutable, $arguments.Trim()).Trim()
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($commandLine)) {
+        return $commandLine.Trim()
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($processName)) {
+        return $processName
+    }
+
+    return $null
+}
+
+function Get-AgentLaunchFallback {
+    param(
+        [string]$Label,
+        [string[]]$Lines
+    )
+
+    $labelText = if ($Label) { $Label.ToLowerInvariant() } else { '' }
+    $joined = if ($Lines) { ($Lines -join "`n").ToLowerInvariant() } else { '' }
+
+    if ($labelText -match 'codex' -or $joined -match 'codex>' -or $joined -match 'tokens used') {
+        return 'codex'
+    }
+
+    if ($labelText -match 'claude' -or $joined -match 'claude>' -or $joined -match '(?m)^\$\s*$') {
+        return 'claude'
+    }
+
+    if ($labelText -match 'gemini' -or $joined -match 'gemini>' -or $joined -match '(?m)^>\s*$') {
+        return 'gemini'
+    }
+
+    return $null
+}
+
+function Get-AgentConfig {
+    param([Parameter(Mandatory)][string]$PaneId)
+
+    $label = Get-AgentLabelByPaneId -PaneId $PaneId
+    $record = Get-PaneRuntimeRecord -PaneId $PaneId
+    $knownConfig = if ($script:AgentConfigCache.ContainsKey($PaneId)) { $script:AgentConfigCache[$PaneId] } else { $null }
+    $lines = @()
+    $launchCommand = $null
+
+    if ($record -and $record.IsRunning -and $record.PanePid -match '^\d+$') {
+        $processInfo = Get-AgentChildProcess -ParentProcessId ([int]$record.PanePid)
+        $launchCommand = ConvertTo-AgentLaunchCommand -ProcessInfo $processInfo
+    }
+
+    if ([string]::IsNullOrWhiteSpace($launchCommand)) {
+        try {
+            $lines = Get-PaneOutputLines -PaneId $PaneId -Lines 5
+        } catch {
+            $lines = @()
+        }
+
+        $launchCommand = Get-AgentLaunchFallback -Label $label -Lines $lines
+    }
+
+    $config = [PSCustomObject]@{
+        PaneId           = $PaneId
+        Label            = $label
+        LaunchCommand    = if (-not [string]::IsNullOrWhiteSpace($launchCommand)) { $launchCommand } elseif ($knownConfig) { $knownConfig.LaunchCommand } else { $null }
+        WorkingDirectory = if ($record -and -not [string]::IsNullOrWhiteSpace($record.CurrentPath)) { $record.CurrentPath } elseif ($knownConfig) { $knownConfig.WorkingDirectory } else { $null }
+        CapturedAt       = (Get-Date).ToString('o')
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace([string]$config.LaunchCommand)) {
+        $script:AgentConfigCache[$PaneId] = $config
+    }
+
+    return $config
+}
+
+function Reset-AgentHealthState {
+    param([Parameter(Mandatory)][string]$PaneId)
+
+    $script:AgentLifecycleState[$PaneId] = [PSCustomObject]@{
+        LastHash        = $null
+        StableIntervals = 0
+        LastState       = 'UNKNOWN'
+        UpdatedAt       = (Get-Date).ToString('o')
+    }
+}
+
+function Get-AgentHealth {
+    [CmdletBinding()]
+    param([Parameter(Mandatory)][string]$PaneId)
+
+    $record = Get-PaneRuntimeRecord -PaneId $PaneId
+    $label = Get-AgentLabelByPaneId -PaneId $PaneId
+
+    if ($null -eq $record -or [string]::IsNullOrWhiteSpace($record.PanePid) -or -not $record.IsRunning) {
+        Reset-AgentHealthState -PaneId $PaneId
+
+        return [PSCustomObject]@{
+            PaneId          = $PaneId
+            Label           = $label
+            State           = 'DEAD'
+            StableIntervals = 0
+            LastLine        = $null
+            Lines           = @()
+            CheckedAt       = (Get-Date).ToString('o')
+        }
+    }
+
+    $firstCapture = Get-PaneOutputLines -PaneId $PaneId -Lines 5
+    if (Test-AgentReadySnapshot -Lines $firstCapture) {
+        $firstHash = Get-AgentOutputHash -Lines $firstCapture
+        $script:AgentLifecycleState[$PaneId] = [PSCustomObject]@{
+            LastHash        = $firstHash
+            StableIntervals = 0
+            LastState       = 'READY'
+            UpdatedAt       = (Get-Date).ToString('o')
+        }
+
+        return [PSCustomObject]@{
+            PaneId          = $PaneId
+            Label           = $label
+            State           = 'READY'
+            StableIntervals = 0
+            LastLine        = Get-LastNonEmptyAgentLine -Lines $firstCapture
+            Lines           = $firstCapture
+            CheckedAt       = (Get-Date).ToString('o')
+        }
+    }
+
+    Start-Sleep -Seconds 2
+
+    $secondCapture = Get-PaneOutputLines -PaneId $PaneId -Lines 5
+    $secondHash = Get-AgentOutputHash -Lines $secondCapture
+
+    if (Test-AgentReadySnapshot -Lines $secondCapture) {
+        $script:AgentLifecycleState[$PaneId] = [PSCustomObject]@{
+            LastHash        = $secondHash
+            StableIntervals = 0
+            LastState       = 'READY'
+            UpdatedAt       = (Get-Date).ToString('o')
+        }
+
+        return [PSCustomObject]@{
+            PaneId          = $PaneId
+            Label           = $label
+            State           = 'READY'
+            StableIntervals = 0
+            LastLine        = Get-LastNonEmptyAgentLine -Lines $secondCapture
+            Lines           = $secondCapture
+            CheckedAt       = (Get-Date).ToString('o')
+        }
+    }
+
+    $firstHash = Get-AgentOutputHash -Lines $firstCapture
+    if ($firstHash -ne $secondHash) {
+        $script:AgentLifecycleState[$PaneId] = [PSCustomObject]@{
+            LastHash        = $secondHash
+            StableIntervals = 0
+            LastState       = 'BUSY'
+            UpdatedAt       = (Get-Date).ToString('o')
+        }
+
+        return [PSCustomObject]@{
+            PaneId          = $PaneId
+            Label           = $label
+            State           = 'BUSY'
+            StableIntervals = 0
+            LastLine        = Get-LastNonEmptyAgentLine -Lines $secondCapture
+            Lines           = $secondCapture
+            CheckedAt       = (Get-Date).ToString('o')
+        }
+    }
+
+    $stableIntervals = 1
+    if ($script:AgentLifecycleState.ContainsKey($PaneId)) {
+        $previousState = $script:AgentLifecycleState[$PaneId]
+        if ($previousState -and $previousState.LastHash -eq $secondHash) {
+            $stableIntervals = [int]$previousState.StableIntervals + 1
+        }
+    }
+
+    $state = if ($stableIntervals -ge 3) { 'HUNG' } else { 'BUSY' }
+    $script:AgentLifecycleState[$PaneId] = [PSCustomObject]@{
+        LastHash        = $secondHash
+        StableIntervals = $stableIntervals
+        LastState       = $state
+        UpdatedAt       = (Get-Date).ToString('o')
+    }
+
+    return [PSCustomObject]@{
+        PaneId          = $PaneId
+        Label           = $label
+        State           = $state
+        StableIntervals = $stableIntervals
+        LastLine        = Get-LastNonEmptyAgentLine -Lines $secondCapture
+        Lines           = $secondCapture
+        CheckedAt       = (Get-Date).ToString('o')
+    }
+}
+
+function Restart-Agent {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$PaneId,
+        [Parameter(Mandatory)]$AgentConfig
+    )
+
+    $launchCommand = [string]$AgentConfig.LaunchCommand
+    if ([string]::IsNullOrWhiteSpace($launchCommand)) {
+        throw "Cannot restart pane $PaneId because LaunchCommand is empty."
+    }
+
+    $psmux = Get-AgentLifecyclePsmuxBin
+    $label = if ($AgentConfig.PSObject.Properties.Match('Label').Count -gt 0) { [string]$AgentConfig.Label } else { (Get-AgentLabelByPaneId -PaneId $PaneId) }
+
+    try {
+        & $psmux send-keys -t $PaneId C-c | Out-Null
+    } catch {
+    }
+
+    Start-Sleep -Seconds 2
+
+    $record = Get-PaneRuntimeRecord -PaneId $PaneId
+    if ($null -eq $record -or [string]::IsNullOrWhiteSpace($record.PanePid) -or -not $record.IsRunning) {
+        try {
+            & $psmux respawn-pane -k -t $PaneId | Out-Null
+            Start-Sleep -Seconds 1
+        } catch {
+            Write-AgentLifecycleLog -Event 'restart-failed' -PaneId $PaneId -Label $label -Details $_.Exception.Message
+            throw
+        }
+    }
+
+    $workingDirectory = if ($AgentConfig.PSObject.Properties.Match('WorkingDirectory').Count -gt 0) { [string]$AgentConfig.WorkingDirectory } else { $null }
+    if (-not [string]::IsNullOrWhiteSpace($workingDirectory)) {
+        $escapedWorkingDirectory = $workingDirectory -replace "'", "''"
+        & $psmux send-keys -t $PaneId -l -- "Set-Location -LiteralPath '$escapedWorkingDirectory'" | Out-Null
+        & $psmux send-keys -t $PaneId Enter | Out-Null
+        Start-Sleep -Milliseconds 300
+    }
+
+    & $psmux send-keys -t $PaneId -l -- $launchCommand | Out-Null
+    & $psmux send-keys -t $PaneId Enter | Out-Null
+
+    Reset-AgentHealthState -PaneId $PaneId
+    $script:AgentConfigCache[$PaneId] = $AgentConfig
+
+    Write-AgentLifecycleLog -Event 'restart' -PaneId $PaneId -Label $label -State 'RESTARTED' -Details $launchCommand
+
+    return [PSCustomObject]@{
+        PaneId        = $PaneId
+        Label         = $label
+        LaunchCommand = $launchCommand
+        RestartedAt   = (Get-Date).ToString('o')
+    }
+}
+
+function Invoke-AgentMonitorPass {
+    param([Parameter(Mandatory)][int]$IntervalSeconds)
+
+    $assignments = Get-LabeledPaneAssignments
+    foreach ($assignment in $assignments) {
+        $paneId = [string]$assignment.PaneId
+        $label = [string]$assignment.Label
+
+        try {
+            $agentConfig = Get-AgentConfig -PaneId $paneId
+            $health = Get-AgentHealth -PaneId $paneId
+
+            if ($health.State -in @('HUNG', 'DEAD')) {
+                if ($null -eq $agentConfig -or [string]::IsNullOrWhiteSpace([string]$agentConfig.LaunchCommand)) {
+                    Write-AgentLifecycleLog -Event 'restart-skipped' -PaneId $paneId -Label $label -State $health.State -Details 'LaunchCommand could not be determined.'
+                    continue
+                }
+
+                Restart-Agent -PaneId $paneId -AgentConfig $agentConfig | Out-Null
+            }
+        } catch {
+            Write-AgentLifecycleLog -Event 'monitor-error' -PaneId $paneId -Label $label -Details $_.Exception.Message
+        }
+    }
+
+    Start-Sleep -Seconds $IntervalSeconds
+}
+
+function Invoke-AgentMonitorLoop {
+    param([Parameter(Mandatory)][int]$IntervalSeconds)
+
+    while ($true) {
+        try {
+            Invoke-AgentMonitorPass -IntervalSeconds $IntervalSeconds
+        } catch {
+            Write-AgentLifecycleLog -Event 'monitor-loop-error' -Details $_.Exception.Message
+            Start-Sleep -Seconds $IntervalSeconds
+        }
+    }
+}
+
+function Start-AgentMonitor {
+    [CmdletBinding()]
+    param([int]$IntervalSeconds = 30)
+
+    if ($IntervalSeconds -lt 1) {
+        throw 'IntervalSeconds must be 1 or greater.'
+    }
+
+    $existingJob = Get-Job -Name $script:AgentMonitorJobName -ErrorAction SilentlyContinue
+    if ($existingJob) {
+        if ($existingJob.State -eq 'Running') {
+            return $existingJob
+        }
+
+        Remove-Job -Job $existingJob -Force -ErrorAction SilentlyContinue
+    }
+
+    Initialize-AgentLifecycleLog
+    Write-AgentLifecycleLog -Event 'monitor-start' -Details "interval=${IntervalSeconds}s"
+
+    return Start-Job -Name $script:AgentMonitorJobName -ArgumentList @(
+        $script:AgentLifecycleScriptPath,
+        $IntervalSeconds,
+        $env:APPDATA,
+        $env:PATH,
+        $env:USERPROFILE
+    ) -ScriptBlock {
+        param(
+            [string]$ScriptPath,
+            [int]$JobIntervalSeconds,
+            [string]$AppDataPath,
+            [string]$PathValue,
+            [string]$UserProfilePath
+        )
+
+        if (-not [string]::IsNullOrWhiteSpace($AppDataPath)) {
+            $env:APPDATA = $AppDataPath
+        }
+
+        if (-not [string]::IsNullOrWhiteSpace($PathValue)) {
+            $env:PATH = $PathValue
+        }
+
+        if (-not [string]::IsNullOrWhiteSpace($UserProfilePath)) {
+            $env:USERPROFILE = $UserProfilePath
+        }
+
+        . $ScriptPath
+        Invoke-AgentMonitorLoop -IntervalSeconds $JobIntervalSeconds
+    }
+}
+
+function Stop-AgentMonitor {
+    [CmdletBinding()]
+    param()
+
+    $job = Get-Job -Name $script:AgentMonitorJobName -ErrorAction SilentlyContinue
+    if (-not $job) {
+        return $null
+    }
+
+    if ($job.State -eq 'Running') {
+        Stop-Job -Job $job | Out-Null
+    }
+
+    $finalState = $job.State
+    Remove-Job -Job $job -Force -ErrorAction SilentlyContinue
+    Write-AgentLifecycleLog -Event 'monitor-stop' -Details "state=$finalState"
+
+    return $finalState
+}

--- a/psmux-bridge/scripts/orchestra-start.ps1
+++ b/psmux-bridge/scripts/orchestra-start.ps1
@@ -1,0 +1,364 @@
+$ErrorActionPreference = 'Stop'
+$scriptDir = $PSScriptRoot
+. "$scriptDir/settings.ps1"
+. "$scriptDir/vault.ps1"
+
+Set-StrictMode -Version Latest
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+
+$sessionName = 'winsmux-orchestra'
+$bridgeScript = [System.IO.Path]::GetFullPath((Join-Path $scriptDir '..\..\scripts\psmux-bridge.ps1'))
+$layoutScript = [System.IO.Path]::GetFullPath((Join-Path $scriptDir 'orchestra-layout.ps1'))
+$psmuxBin = Get-PsmuxBin
+
+if (-not $psmuxBin) {
+    Write-Error 'Could not find a psmux binary. Tried: psmux, pmux, tmux.'
+    exit 1
+}
+
+if (-not (Test-Path $bridgeScript)) {
+    Write-Error "Bridge CLI not found: $bridgeScript"
+    exit 1
+}
+
+function Invoke-Psmux {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string[]]$Arguments,
+        [switch]$CaptureOutput
+    )
+
+    if ($CaptureOutput) {
+        $output = & $script:psmuxBin @Arguments 2>&1
+        $exitCode = $LASTEXITCODE
+        if ($exitCode -ne 0) {
+            $message = ($output | Out-String).Trim()
+            if ([string]::IsNullOrWhiteSpace($message)) {
+                $message = 'unknown psmux error'
+            }
+
+            throw "psmux $($Arguments -join ' ') failed: $message"
+        }
+
+        return $output
+    }
+
+    & $script:psmuxBin @Arguments | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        throw "psmux $($Arguments -join ' ') failed with exit code $LASTEXITCODE."
+    }
+}
+
+function Invoke-Bridge {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string[]]$Arguments,
+        [switch]$CaptureOutput,
+        [switch]$AllowFailure
+    )
+
+    if ($CaptureOutput -or $AllowFailure) {
+        $output = & pwsh -NoProfile -File $script:bridgeScript @Arguments 2>&1
+        $exitCode = $LASTEXITCODE
+        if ($exitCode -ne 0 -and -not $AllowFailure) {
+            $message = ($output | Out-String).Trim()
+            if ([string]::IsNullOrWhiteSpace($message)) {
+                $message = 'unknown bridge error'
+            }
+
+            throw "psmux-bridge $($Arguments -join ' ') failed: $message"
+        }
+
+        return [PSCustomObject]@{
+            ExitCode = $exitCode
+            Output   = $output
+        }
+    }
+
+    & pwsh -NoProfile -File $script:bridgeScript @Arguments | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        throw "psmux-bridge $($Arguments -join ' ') failed with exit code $LASTEXITCODE."
+    }
+}
+
+function ConvertTo-PowerShellLiteral {
+    param([Parameter(Mandatory = $true)][AllowEmptyString()][string]$Value)
+
+    return "'" + ($Value -replace "'", "''") + "'"
+}
+
+function Get-ProjectDir {
+    try {
+        $currentPath = Invoke-Psmux -Arguments @('display-message', '-p', '#{pane_current_path}') -CaptureOutput
+        $resolved = ($currentPath | Out-String).Trim()
+        if (-not [string]::IsNullOrWhiteSpace($resolved)) {
+            return $resolved
+        }
+    } catch {
+    }
+
+    return (Get-Location).Path
+}
+
+function Get-GitWorktreeDir {
+    param([Parameter(Mandatory = $true)][string]$ProjectDir)
+
+    $dotGitPath = Join-Path $ProjectDir '.git'
+
+    if (Test-Path $dotGitPath -PathType Leaf) {
+        $raw = (Get-Content -Path $dotGitPath -Raw -Encoding UTF8).Trim()
+        if ($raw -match '^gitdir:\s*(.+)$') {
+            return [System.IO.Path]::GetFullPath($Matches[1].Trim())
+        }
+    }
+
+    if (Test-Path $dotGitPath -PathType Container) {
+        return (Get-Item -LiteralPath $dotGitPath).FullName
+    }
+
+    return $ProjectDir
+}
+
+function Get-CanonicalRole {
+    param([Parameter(Mandatory = $true)][string]$AssignmentRole)
+
+    switch -Regex ($AssignmentRole) {
+        '^(?i)builder(?:$|[-_:/\s])' { return 'Builder' }
+        '^(?i)researcher(?:$|[-_:/\s])' { return 'Researcher' }
+        '^(?i)reviewer(?:$|[-_:/\s])' { return 'Reviewer' }
+        '^(?i)commander(?:$|[-_:/\s])' { return 'Commander' }
+        default { throw "Unsupported pane role label: $AssignmentRole" }
+    }
+}
+
+function New-PaneEnvCommand {
+    param(
+        [Parameter(Mandatory = $true)][string]$Name,
+        [Parameter(Mandatory = $true)][string]$Value
+    )
+
+    return "`$env:${Name}=$(ConvertTo-PowerShellLiteral -Value $Value)"
+}
+
+function Invoke-PaneCommand {
+    param(
+        [Parameter(Mandatory = $true)][string]$PaneId,
+        [Parameter(Mandatory = $true)][string]$CommandText
+    )
+
+    Invoke-Psmux -Arguments @('send-keys', '-t', $PaneId, '-l', '--', $CommandText)
+    Invoke-Psmux -Arguments @('send-keys', '-t', $PaneId, 'Enter')
+}
+
+function Get-AgentLaunchCommand {
+    param(
+        [Parameter(Mandatory = $true)][string]$Agent,
+        [Parameter(Mandatory = $true)][string]$Model,
+        [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [Parameter(Mandatory = $true)][string]$GitWorktreeDir
+    )
+
+    switch ($Agent.Trim().ToLowerInvariant()) {
+        'codex' {
+            return "codex -c model=$Model --full-auto -C $(ConvertTo-PowerShellLiteral -Value $ProjectDir) --add-dir $(ConvertTo-PowerShellLiteral -Value $GitWorktreeDir)"
+        }
+        'claude' {
+            return 'claude --permission-mode bypassPermissions'
+        }
+        default {
+            throw "Unsupported agent setting: $Agent"
+        }
+    }
+}
+
+function Get-VaultValue {
+    param([Parameter(Mandatory = $true)][string]$Key)
+
+    $result = Invoke-Bridge -Arguments @('vault', 'get', $Key) -CaptureOutput -AllowFailure
+    if ($result.ExitCode -ne 0) {
+        $message = ($result.Output | Out-String).Trim()
+        if ([string]::IsNullOrWhiteSpace($message)) {
+            $message = "credential not found: $Key"
+        }
+
+        throw $message
+    }
+
+    return ($result.Output | Out-String).TrimEnd()
+}
+
+function Get-LastNonEmptyLine {
+    param([AllowNull()][string]$Text)
+
+    if ([string]::IsNullOrWhiteSpace($Text)) {
+        return $null
+    }
+
+    $lines = $Text -split "\r?\n"
+    for ($index = $lines.Length - 1; $index -ge 0; $index--) {
+        if (-not [string]::IsNullOrWhiteSpace($lines[$index])) {
+            return $lines[$index]
+        }
+    }
+
+    return $null
+}
+
+function Get-TailPreview {
+    param([AllowNull()][string]$Text, [int]$LineCount = 12)
+
+    if ([string]::IsNullOrWhiteSpace($Text)) {
+        return '(no output)'
+    }
+
+    $lines = $Text -split "\r?\n"
+    if ($lines.Length -le $LineCount) {
+        return ($lines -join [Environment]::NewLine)
+    }
+
+    return ($lines[($lines.Length - $LineCount)..($lines.Length - 1)] -join [Environment]::NewLine)
+}
+
+function Test-AgentPromptText {
+    param(
+        [AllowNull()][string]$Text,
+        [Parameter(Mandatory = $true)][string]$Agent
+    )
+
+    $lastLine = Get-LastNonEmptyLine -Text $Text
+    if ($null -eq $lastLine) {
+        return $false
+    }
+
+    $trimmed = $lastLine.TrimStart()
+    $rightChevron = [string][char]8250
+    if ($trimmed.StartsWith('>') -or $trimmed.StartsWith($rightChevron)) {
+        return $true
+    }
+
+    if ($Agent.Trim().ToLowerInvariant() -eq 'codex' -and $Text -match '(?im)\bgpt-[A-Za-z0-9._-]+\b.*\b\d+% left\b') {
+        return $true
+    }
+
+    return $false
+}
+
+function Wait-AgentReady {
+    param(
+        [Parameter(Mandatory = $true)][string]$PaneId,
+        [Parameter(Mandatory = $true)][string]$Agent,
+        [int]$TimeoutSeconds = 60
+    )
+
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    while ((Get-Date) -lt $deadline) {
+        $snapshot = Invoke-Psmux -Arguments @('capture-pane', '-t', $PaneId, '-p', '-J', '-S', '-80') -CaptureOutput
+        $text = ($snapshot | Out-String).TrimEnd()
+        if (Test-AgentPromptText -Text $text -Agent $Agent) {
+            return
+        }
+
+        Start-Sleep -Seconds 2
+    }
+
+    $finalSnapshot = Invoke-Psmux -Arguments @('capture-pane', '-t', $PaneId, '-p', '-J', '-S', '-80') -CaptureOutput
+    $finalText = ($finalSnapshot | Out-String).TrimEnd()
+    throw "Timed out waiting for pane $PaneId to become ready. Last output:`n$(Get-TailPreview -Text $finalText)"
+}
+
+try {
+    $settings = Get-BridgeSettings
+    $projectDir = Get-ProjectDir
+    $gitWorktreeDir = Get-GitWorktreeDir -ProjectDir $projectDir
+    $vaultValues = [ordered]@{}
+
+    foreach ($key in @($settings.vault_keys)) {
+        try {
+            $vaultValues[$key] = Get-VaultValue -Key $key
+        } catch {
+            Write-Error "Missing required vault key '$key': $($_.Exception.Message)"
+            exit 1
+        }
+    }
+
+    & $psmuxBin has-session -t $sessionName 1>$null 2>$null
+    if ($LASTEXITCODE -eq 0) {
+        Invoke-Psmux -Arguments @('kill-session', '-t', $sessionName)
+    }
+
+    Invoke-Psmux -Arguments @('new-session', '-d', '-s', $sessionName)
+
+    foreach ($entry in $vaultValues.GetEnumerator()) {
+        Invoke-Psmux -Arguments @('set-environment', '-t', $sessionName, $entry.Key, $entry.Value)
+    }
+
+    $previousTargetSession = $env:WINSMUX_ORCHESTRA_SESSION
+    $previousProjectDir = $env:WINSMUX_ORCHESTRA_PROJECT_DIR
+    $env:WINSMUX_ORCHESTRA_SESSION = $sessionName
+    $env:WINSMUX_ORCHESTRA_PROJECT_DIR = $projectDir
+
+    try {
+        $layout = . $layoutScript -Builders $settings.builders -Researchers $settings.researchers -Reviewers $settings.reviewers
+    } finally {
+        if ($null -eq $previousTargetSession) {
+            Remove-Item Env:WINSMUX_ORCHESTRA_SESSION -ErrorAction SilentlyContinue
+        } else {
+            $env:WINSMUX_ORCHESTRA_SESSION = $previousTargetSession
+        }
+
+        if ($null -eq $previousProjectDir) {
+            Remove-Item Env:WINSMUX_ORCHESTRA_PROJECT_DIR -ErrorAction SilentlyContinue
+        } else {
+            $env:WINSMUX_ORCHESTRA_PROJECT_DIR = $previousProjectDir
+        }
+    }
+
+    if ($null -eq $layout -or $null -eq $layout.Panes -or $layout.Panes.Count -lt 1) {
+        Write-Error 'orchestra-layout did not return any panes.'
+        exit 1
+    }
+
+    $launchCommand = Get-AgentLaunchCommand -Agent $settings.agent -Model $settings.model -ProjectDir $projectDir -GitWorktreeDir $gitWorktreeDir
+    $paneSummaries = [System.Collections.Generic.List[object]]::new()
+
+    foreach ($pane in @($layout.Panes)) {
+        $assignmentLabel = [string]$pane.Role
+        $canonicalRole = Get-CanonicalRole -AssignmentRole $assignmentLabel
+        $label = $assignmentLabel.ToLowerInvariant()
+        $paneId = [string]$pane.PaneId
+
+        Invoke-Bridge -Arguments @('name', $paneId, $label)
+        Invoke-PaneCommand -PaneId $paneId -CommandText (New-PaneEnvCommand -Name 'WINSMUX_ROLE' -Value $canonicalRole)
+        Invoke-PaneCommand -PaneId $paneId -CommandText (New-PaneEnvCommand -Name 'WINSMUX_PANE_ID' -Value $paneId)
+        Invoke-PaneCommand -PaneId $paneId -CommandText $launchCommand
+
+        $paneSummaries.Add([PSCustomObject]@{
+            Label = $label
+            PaneId = $paneId
+            Role = $canonicalRole
+        })
+    }
+
+    foreach ($paneSummary in $paneSummaries) {
+        try {
+            Wait-AgentReady -PaneId $paneSummary.PaneId -Agent $settings.agent -TimeoutSeconds 60
+        } catch {
+            Write-Error "Agent readiness timeout for $($paneSummary.Label) [$($paneSummary.PaneId)]: $($_.Exception.Message)"
+            exit 1
+        }
+    }
+
+    Write-Output "Orchestra session: $sessionName"
+    Write-Output "Agent: $($settings.agent)"
+    Write-Output "Model: $($settings.model)"
+    Write-Output "ProjectDir: $projectDir"
+    Write-Output "GitWorktreeDir: $gitWorktreeDir"
+    Write-Output ''
+    Write-Output 'Panes:'
+    foreach ($paneSummary in $paneSummaries) {
+        Write-Output ("  {0,-14} {1,-8} {2}" -f $paneSummary.Label, $paneSummary.PaneId, $paneSummary.Role)
+    }
+} catch {
+    Write-Error $_.Exception.Message
+    exit 1
+}

--- a/psmux-bridge/scripts/shared-task-list.ps1
+++ b/psmux-bridge/scripts/shared-task-list.ps1
@@ -1,0 +1,336 @@
+<#
+.SYNOPSIS
+Shared task list helpers for winsmux agents.
+
+.DESCRIPTION
+Dot-source this script to load the task functions:
+
+    . "$PSScriptRoot/shared-task-list.ps1"
+#>
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Get-SharedTasksDirectoryPath {
+    return Join-Path (Get-Location).Path '.winsmux'
+}
+
+function Get-SharedTasksFilePath {
+    return Join-Path (Get-SharedTasksDirectoryPath) 'tasks.json'
+}
+
+function Get-SharedTasksLockPath {
+    return Join-Path (Get-SharedTasksDirectoryPath) 'tasks.lock'
+}
+
+function Initialize-SharedTaskStore {
+    $tasksDir = Get-SharedTasksDirectoryPath
+    if (-not (Test-Path -LiteralPath $tasksDir)) {
+        New-Item -ItemType Directory -Path $tasksDir -Force | Out-Null
+    }
+
+    $tasksFile = Get-SharedTasksFilePath
+    if (-not (Test-Path -LiteralPath $tasksFile)) {
+        Set-Content -LiteralPath $tasksFile -Value '[]' -Encoding UTF8
+    }
+}
+
+function Invoke-SharedTaskLock {
+    param(
+        [Parameter(Mandatory = $true)][scriptblock]$ScriptBlock
+    )
+
+    Initialize-SharedTaskStore
+    $lockDir = Get-SharedTasksLockPath
+
+    while ($true) {
+        if (Test-Path -LiteralPath $lockDir) {
+            Start-Sleep -Milliseconds 50
+            continue
+        }
+
+        try {
+            New-Item -ItemType Directory -Path $lockDir -ErrorAction Stop | Out-Null
+            break
+        } catch {
+            Start-Sleep -Milliseconds 50
+        }
+    }
+
+    try {
+        return & $ScriptBlock
+    } finally {
+        if (Test-Path -LiteralPath $lockDir) {
+            Remove-Item -LiteralPath $lockDir -Force -Recurse
+        }
+    }
+}
+
+function Read-SharedTasksInternal {
+    $tasksFile = Get-SharedTasksFilePath
+    Initialize-SharedTaskStore
+
+    $raw = Get-Content -LiteralPath $tasksFile -Raw -Encoding UTF8
+    if ([string]::IsNullOrWhiteSpace($raw)) {
+        return @()
+    }
+
+    $parsed = $raw | ConvertFrom-Json
+    if ($null -eq $parsed) {
+        return @()
+    }
+
+    return @($parsed)
+}
+
+function Read-SharedTasksFromStream {
+    param(
+        [Parameter(Mandatory = $true)][System.IO.FileStream]$Stream
+    )
+
+    if ($Stream.Length -eq 0) {
+        return @()
+    }
+
+    $Stream.Seek(0, [System.IO.SeekOrigin]::Begin) | Out-Null
+    $reader = [System.IO.StreamReader]::new($Stream, [System.Text.Encoding]::UTF8, $true, 1024, $true)
+    try {
+        $raw = $reader.ReadToEnd()
+    } finally {
+        $reader.Dispose()
+    }
+
+    if ([string]::IsNullOrWhiteSpace($raw)) {
+        return @()
+    }
+
+    $parsed = $raw | ConvertFrom-Json
+    if ($null -eq $parsed) {
+        return @()
+    }
+
+    return @($parsed)
+}
+
+function Write-SharedTasksInternal {
+    param(
+        [Parameter(Mandatory = $true)][AllowEmptyCollection()][object[]]$Tasks
+    )
+
+    $tasksFile = Get-SharedTasksFilePath
+    $json = @($Tasks) | ConvertTo-Json -Depth 6
+    Set-Content -LiteralPath $tasksFile -Value $json -Encoding UTF8
+}
+
+function Write-SharedTasksToStream {
+    param(
+        [Parameter(Mandatory = $true)][System.IO.FileStream]$Stream,
+        [Parameter(Mandatory = $true)][AllowEmptyCollection()][object[]]$Tasks
+    )
+
+    $json = @($Tasks) | ConvertTo-Json -Depth 6
+    $bytes = [System.Text.Encoding]::UTF8.GetBytes($json)
+
+    $Stream.SetLength(0)
+    $Stream.Seek(0, [System.IO.SeekOrigin]::Begin) | Out-Null
+    $Stream.Write($bytes, 0, $bytes.Length)
+    $Stream.Flush()
+}
+
+function Get-NextSharedTaskId {
+    param(
+        [Parameter(Mandatory = $true)][AllowEmptyCollection()][object[]]$Tasks
+    )
+
+    $maxId = 0
+    foreach ($task in $Tasks) {
+        if ($null -ne $task.id -and $task.id -match '^T-(\d+)$') {
+            $numericId = [int]$Matches[1]
+            if ($numericId -gt $maxId) {
+                $maxId = $numericId
+            }
+        }
+    }
+
+    return 'T-{0:D3}' -f ($maxId + 1)
+}
+
+function Test-SharedTaskDependenciesSatisfied {
+    param(
+        [Parameter(Mandatory = $true)][AllowEmptyCollection()][object[]]$Tasks,
+        [Parameter(Mandatory = $true)]$Task
+    )
+
+    $dependencies = @($Task.depends_on)
+    if ($dependencies.Count -eq 0) {
+        return $true
+    }
+
+    foreach ($dependencyId in $dependencies) {
+        $dependency = $Tasks | Where-Object { $_.id -eq $dependencyId } | Select-Object -First 1
+        if ($null -eq $dependency -or $dependency.status -ne 'done') {
+            return $false
+        }
+    }
+
+    return $true
+}
+
+function Update-SharedTaskBlockingStates {
+    param(
+        [Parameter(Mandatory = $true)][AllowEmptyCollection()][object[]]$Tasks
+    )
+
+    foreach ($task in $Tasks) {
+        if ($task.status -eq 'blocked' -and (Test-SharedTaskDependenciesSatisfied -Tasks $Tasks -Task $task)) {
+            $task.status = 'open'
+        }
+    }
+}
+
+function New-SharedTaskRecord {
+    param(
+        [Parameter(Mandatory = $true)][string]$Id,
+        [Parameter(Mandatory = $true)][string]$Title,
+        [string[]]$DependsOn = @(),
+        [Parameter(Mandatory = $true)][string]$Status
+    )
+
+    return [PSCustomObject][ordered]@{
+        id         = $Id
+        title      = $Title
+        status     = $Status
+        claimed_by = $null
+        depends_on = @($DependsOn)
+        created    = [DateTime]::UtcNow.ToString('o')
+    }
+}
+
+function Get-SharedTasks {
+    return Invoke-SharedTaskLock {
+        return @(Read-SharedTasksInternal)
+    }
+}
+
+function Add-SharedTask {
+    param(
+        [Parameter(Mandatory = $true)][string]$Title,
+        [string[]]$DependsOn = @()
+    )
+
+    return Invoke-SharedTaskLock {
+        $tasks = @(Read-SharedTasksInternal)
+        $taskId = Get-NextSharedTaskId -Tasks $tasks
+        $candidate = [PSCustomObject]@{ depends_on = @($DependsOn) }
+        $status = if (Test-SharedTaskDependenciesSatisfied -Tasks $tasks -Task $candidate) { 'open' } else { 'blocked' }
+        $task = New-SharedTaskRecord -Id $taskId -Title $Title -DependsOn $DependsOn -Status $status
+        $tasks += $task
+        Write-SharedTasksInternal -Tasks $tasks
+        return $task
+    }
+}
+
+function Claim-SharedTask {
+    param(
+        [Parameter(Mandatory = $true)][string]$TaskId,
+        [Parameter(Mandatory = $true)][string]$AgentName
+    )
+
+    return Invoke-SharedTaskLock {
+        Initialize-SharedTaskStore
+        $tasksFile = Get-SharedTasksFilePath
+        $fileStream = [System.IO.File]::Open(
+            $tasksFile,
+            [System.IO.FileMode]::OpenOrCreate,
+            [System.IO.FileAccess]::ReadWrite,
+            [System.IO.FileShare]::None
+        )
+
+        try {
+            $tasks = @(Read-SharedTasksFromStream -Stream $fileStream)
+            $task = $tasks | Where-Object { $_.id -eq $TaskId } | Select-Object -First 1
+
+            if ($null -eq $task) {
+                throw "Shared task not found: $TaskId"
+            }
+
+            if (-not (Test-SharedTaskDependenciesSatisfied -Tasks $tasks -Task $task)) {
+                $task.status = 'blocked'
+                $task.claimed_by = $null
+                Write-SharedTasksToStream -Stream $fileStream -Tasks $tasks
+                return 'blocked'
+            }
+
+            if ($task.status -eq 'done') {
+                return $task
+            }
+
+            if ($task.status -eq 'claimed' -and $task.claimed_by -ne $AgentName) {
+                return $task
+            }
+
+            $task.status = 'claimed'
+            $task.claimed_by = $AgentName
+            Write-SharedTasksToStream -Stream $fileStream -Tasks $tasks
+            return $task
+        } finally {
+            $fileStream.Dispose()
+        }
+    }
+}
+
+function Complete-SharedTask {
+    param(
+        [Parameter(Mandatory = $true)][string]$TaskId
+    )
+
+    return Invoke-SharedTaskLock {
+        $tasks = @(Read-SharedTasksInternal)
+        $task = $tasks | Where-Object { $_.id -eq $TaskId } | Select-Object -First 1
+
+        if ($null -eq $task) {
+            throw "Shared task not found: $TaskId"
+        }
+
+        $task.status = 'done'
+        $task.claimed_by = $null
+
+        foreach ($dependentTask in $tasks) {
+            if ($dependentTask.status -ne 'blocked') {
+                continue
+            }
+
+            if (@($dependentTask.depends_on) -contains $TaskId -and (Test-SharedTaskDependenciesSatisfied -Tasks $tasks -Task $dependentTask)) {
+                $dependentTask.status = 'open'
+            }
+        }
+
+        Write-SharedTasksInternal -Tasks $tasks
+        return $task
+    }
+}
+
+function Get-NextAvailableTask {
+    param(
+        [Parameter(Mandatory = $true)][string]$AgentName
+    )
+
+    return Invoke-SharedTaskLock {
+        $tasks = @(Read-SharedTasksInternal)
+        Update-SharedTaskBlockingStates -Tasks $tasks
+
+        $task = $tasks |
+            Where-Object { $_.status -eq 'open' -and (Test-SharedTaskDependenciesSatisfied -Tasks $tasks -Task $_) } |
+            Select-Object -First 1
+
+        if ($null -eq $task) {
+            Write-SharedTasksInternal -Tasks $tasks
+            return $null
+        }
+
+        $task.status = 'claimed'
+        $task.claimed_by = $AgentName
+        Write-SharedTasksInternal -Tasks $tasks
+        return $task
+    }
+}

--- a/tests/psmux-bridge.Tests.ps1
+++ b/tests/psmux-bridge.Tests.ps1
@@ -1,82 +1,778 @@
-BeforeAll {
-    $script:BridgeScript = Join-Path $PSScriptRoot '..\scripts\psmux-bridge.ps1'
-    . $script:BridgeScript
+$script:BridgeScript = Join-Path $PSScriptRoot '..\scripts\psmux-bridge.ps1'
+$script:RoleGateScript = Join-Path $PSScriptRoot '..\psmux-bridge\scripts\role-gate.ps1'
+$script:SettingsScript = Join-Path $PSScriptRoot '..\psmux-bridge\scripts\settings.ps1'
+$script:VaultScript = Join-Path $PSScriptRoot '..\psmux-bridge\scripts\vault.ps1'
+$script:VersionFile = Join-Path $PSScriptRoot '..\VERSION'
 
-    function Stop-WithError {
-        param([string]$Message)
-        throw $Message
+function Stop-WithError {
+    param([string]$Message)
+    throw $Message
+}
+
+function Resolve-Target {
+    param([string]$RawTarget)
+    return $RawTarget
+}
+
+function Confirm-Target {
+    param([string]$PaneId)
+    return $PaneId
+}
+
+function Assert-ReadMark {
+    param([string]$PaneId)
+}
+
+function Clear-ReadMark {
+    param([string]$PaneId)
+}
+
+if (-not ('WinCred' -as [type])) {
+    Add-Type -TypeDefinition @'
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+
+public static class WinCred {
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    public struct CREDENTIAL {
+        public uint Flags;
+        public uint Type;
+        public string TargetName;
+        public string Comment;
+        public System.Runtime.InteropServices.ComTypes.FILETIME LastWritten;
+        public int CredentialBlobSize;
+        public IntPtr CredentialBlob;
+        public uint Persist;
+        public int AttributeCount;
+        public IntPtr Attributes;
+        public string TargetAlias;
+        public string UserName;
+    }
+
+    public const uint CRED_TYPE_GENERIC = 1;
+    public const uint CRED_PERSIST_LOCAL_MACHINE = 2;
+
+    private static readonly Dictionary<string, string> Store = new Dictionary<string, string>(StringComparer.Ordinal);
+
+    private static string ReadBlob(CREDENTIAL credential) {
+        if (credential.CredentialBlob == IntPtr.Zero || credential.CredentialBlobSize <= 0) {
+            return string.Empty;
+        }
+
+        var bytes = new byte[credential.CredentialBlobSize];
+        Marshal.Copy(credential.CredentialBlob, bytes, 0, credential.CredentialBlobSize);
+        return Encoding.Unicode.GetString(bytes);
+    }
+
+    private static IntPtr BuildCredentialPointer(string target, string value) {
+        var bytes = Encoding.Unicode.GetBytes(value ?? string.Empty);
+        var blobPtr = Marshal.AllocHGlobal(bytes.Length);
+        if (bytes.Length > 0) {
+            Marshal.Copy(bytes, 0, blobPtr, bytes.Length);
+        }
+
+        var credential = new CREDENTIAL {
+            Type = CRED_TYPE_GENERIC,
+            TargetName = target,
+            UserName = "winsmux",
+            CredentialBlobSize = bytes.Length,
+            CredentialBlob = blobPtr,
+            Persist = CRED_PERSIST_LOCAL_MACHINE
+        };
+
+        var credPtr = Marshal.AllocHGlobal(Marshal.SizeOf(typeof(CREDENTIAL)));
+        Marshal.StructureToPtr(credential, credPtr, false);
+        return credPtr;
+    }
+
+    public static bool CredWrite(ref CREDENTIAL credential, uint flags) {
+        Store[credential.TargetName] = ReadBlob(credential);
+        Marshal.SetLastPInvokeError(0);
+        return true;
+    }
+
+    public static bool CredRead(string target, uint type, uint flags, out IntPtr credential) {
+        if (!Store.TryGetValue(target, out var value)) {
+            credential = IntPtr.Zero;
+            Marshal.SetLastPInvokeError(1168);
+            return false;
+        }
+
+        credential = BuildCredentialPointer(target, value);
+        Marshal.SetLastPInvokeError(0);
+        return true;
+    }
+
+    public static bool CredEnumerate(string filter, uint flags, out int count, out IntPtr credentials) {
+        var matches = Store
+            .Where(entry => entry.Key.StartsWith("winsmux:", StringComparison.Ordinal))
+            .OrderBy(entry => entry.Key, StringComparer.Ordinal)
+            .ToArray();
+
+        if (matches.Length == 0) {
+            count = 0;
+            credentials = IntPtr.Zero;
+            Marshal.SetLastPInvokeError(1168);
+            return false;
+        }
+
+        count = matches.Length;
+        credentials = Marshal.AllocHGlobal(IntPtr.Size * count);
+
+        for (var i = 0; i < matches.Length; i++) {
+            var credPtr = BuildCredentialPointer(matches[i].Key, matches[i].Value);
+            Marshal.WriteIntPtr(credentials, i * IntPtr.Size, credPtr);
+        }
+
+        Marshal.SetLastPInvokeError(0);
+        return true;
+    }
+
+    public static bool CredFree(IntPtr credential) {
+        Marshal.SetLastPInvokeError(0);
+        return true;
+    }
+
+    public static void Reset() {
+        Store.Clear();
+    }
+
+    public static string GetValue(string target) {
+        return Store.TryGetValue(target, out var value) ? value : null;
     }
 }
-
-BeforeEach {
-    $script:OriginalWinsmuxRole = $env:WINSMUX_ROLE
+'@ -ErrorAction Stop
 }
 
-AfterEach {
-    if ($null -eq $script:OriginalWinsmuxRole) {
+. $script:RoleGateScript
+. $script:SettingsScript
+. $script:VaultScript
+
+function Invoke-RoleGate {
+    param(
+        [string]$Role,
+        [string]$Command,
+        [string]$TargetPane
+    )
+
+    if ($null -eq $Role) {
         Remove-Item Env:WINSMUX_ROLE -ErrorAction SilentlyContinue
     } else {
-        $env:WINSMUX_ROLE = $script:OriginalWinsmuxRole
+        $env:WINSMUX_ROLE = $Role
     }
+
+    return (& { Assert-Role -Command $Command -TargetPane $TargetPane }) 2>$null
 }
 
 Describe 'psmux-bridge' {
-    Context 'version command' {
-        It 'test_version_when_invoked_returns_version_string' {
-            # Arrange
-            $commandOutput = $null
+    BeforeEach {
+        $script:OriginalWinsmuxRole = $env:WINSMUX_ROLE
+        $script:OriginalWinsmuxPaneId = $env:WINSMUX_PANE_ID
+        $script:OriginalAppData = $env:APPDATA
+        $script:OriginalLocation = Get-Location
 
-            # Act
-            $commandOutput = & pwsh -NoProfile -File $script:BridgeScript version
+        $env:WINSMUX_PANE_ID = '%1'
+        $env:APPDATA = Join-Path $TestDrive 'appdata'
+        New-Item -ItemType Directory -Path $env:APPDATA -Force | Out-Null
 
-            # Assert
-            $commandOutput | Should -Match '^psmux-bridge \d+\.\d+\.\d+$'
+        [WinCred]::Reset()
+        $script:Target = $null
+        $script:Rest = @()
+    }
+
+    AfterEach {
+        Set-Location $script:OriginalLocation
+
+        if ($null -eq $script:OriginalWinsmuxRole) {
+            Remove-Item Env:WINSMUX_ROLE -ErrorAction SilentlyContinue
+        } else {
+            $env:WINSMUX_ROLE = $script:OriginalWinsmuxRole
+        }
+
+        if ($null -eq $script:OriginalWinsmuxPaneId) {
+            Remove-Item Env:WINSMUX_PANE_ID -ErrorAction SilentlyContinue
+        } else {
+            $env:WINSMUX_PANE_ID = $script:OriginalWinsmuxPaneId
+        }
+
+        if ($null -eq $script:OriginalAppData) {
+            Remove-Item Env:APPDATA -ErrorAction SilentlyContinue
+        } else {
+            $env:APPDATA = $script:OriginalAppData
         }
     }
 
     Context 'Assert-Role' {
-        It 'test_assert_role_when_role_missing_denies_access' {
+        It 'allows Commander to read other panes' {
             # Arrange
-            Remove-Item Env:WINSMUX_ROLE -ErrorAction SilentlyContinue
+            $role = 'Commander'
+            $command = 'read'
+            $targetPane = '%9'
 
             # Act
-            $action = { Assert-Role -CommandName 'read' }
+            $result = Invoke-RoleGate -Role $role -Command $command -TargetPane $targetPane
 
             # Assert
-            $action | Should -Throw '*WINSMUX_ROLE is not set*'
+            $result | Should Be $true
         }
 
-        It 'test_assert_role_when_commander_reads_allows_access' {
+        It 'allows Commander to send to other panes' {
             # Arrange
-            $env:WINSMUX_ROLE = 'Commander'
+            $role = 'Commander'
+            $command = 'send'
+            $targetPane = '%9'
 
             # Act
-            $action = { Assert-Role -CommandName 'read' }
+            $result = Invoke-RoleGate -Role $role -Command $command -TargetPane $targetPane
 
             # Assert
-            $action | Should -Not -Throw
+            $result | Should Be $true
         }
 
-        It 'test_assert_role_when_builder_uses_vault_denies_access' {
+        It 'allows Commander to run health-check' {
             # Arrange
-            $env:WINSMUX_ROLE = 'Builder'
+            $role = 'Commander'
+            $command = 'health-check'
 
             # Act
-            $action = { Assert-Role -CommandName 'vault' }
+            $result = Invoke-RoleGate -Role $role -Command $command
 
             # Assert
-            $action | Should -Throw "*cannot use 'vault'*"
+            $result | Should Be $true
         }
 
-        It 'test_assert_role_when_role_unknown_denies_access' {
+        It 'allows Commander to use vault commands' {
             # Arrange
-            $env:WINSMUX_ROLE = 'UnknownRole'
+            $role = 'Commander'
+            $command = 'vault'
 
             # Act
-            $action = { Assert-Role -CommandName 'read' }
+            $result = Invoke-RoleGate -Role $role -Command $command
 
             # Assert
-            $action | Should -Throw '*unknown WINSMUX_ROLE*'
+            $result | Should Be $true
+        }
+
+        It 'allows Commander to watch panes' {
+            # Arrange
+            $role = 'Commander'
+            $command = 'watch'
+            $targetPane = '%9'
+
+            # Act
+            $result = Invoke-RoleGate -Role $role -Command $command -TargetPane $targetPane
+
+            # Assert
+            $result | Should Be $true
+        }
+
+        It 'allows Commander to dispatch work' {
+            # Arrange
+            $role = 'Commander'
+            $command = 'dispatch'
+
+            # Act
+            $result = Invoke-RoleGate -Role $role -Command $command
+
+            # Assert
+            $result | Should Be $true
+        }
+
+        It 'allows Builder to read its own pane' {
+            # Arrange
+            $role = 'Builder'
+            $command = 'read'
+            $targetPane = '%1'
+
+            # Act
+            $result = Invoke-RoleGate -Role $role -Command $command -TargetPane $targetPane
+
+            # Assert
+            $result | Should Be $true
+        }
+
+        It 'allows Builder to send to Commander' {
+            # Arrange
+            $role = 'Builder'
+            $command = 'send'
+            $targetPane = 'Commander'
+
+            # Act
+            $result = Invoke-RoleGate -Role $role -Command $command -TargetPane $targetPane
+
+            # Assert
+            $result | Should Be $true
+        }
+
+        It 'denies Builder from reading other panes' {
+            # Arrange
+            $role = 'Builder'
+            $command = 'read'
+            $targetPane = '%9'
+
+            # Act
+            $result = Invoke-RoleGate -Role $role -Command $command -TargetPane $targetPane
+
+            # Assert
+            $result | Should Be $false
+        }
+
+        It 'denies Builder from using vault commands' {
+            # Arrange
+            $role = 'Builder'
+            $command = 'vault'
+
+            # Act
+            $result = Invoke-RoleGate -Role $role -Command $command
+
+            # Assert
+            $result | Should Be $false
+        }
+
+        It 'denies Builder from dispatching work' {
+            # Arrange
+            $role = 'Builder'
+            $command = 'dispatch'
+
+            # Act
+            $result = Invoke-RoleGate -Role $role -Command $command
+
+            # Assert
+            $result | Should Be $false
+        }
+
+        It 'allows Researcher to read its own pane' {
+            # Arrange
+            $role = 'Researcher'
+            $command = 'read'
+            $targetPane = '%1'
+
+            # Act
+            $result = Invoke-RoleGate -Role $role -Command $command -TargetPane $targetPane
+
+            # Assert
+            $result | Should Be $true
+        }
+
+        It 'allows Researcher to send to Commander' {
+            # Arrange
+            $role = 'Researcher'
+            $command = 'send'
+            $targetPane = 'Commander'
+
+            # Act
+            $result = Invoke-RoleGate -Role $role -Command $command -TargetPane $targetPane
+
+            # Assert
+            $result | Should Be $true
+        }
+
+        It 'denies Researcher from reading other panes' {
+            # Arrange
+            $role = 'Researcher'
+            $command = 'read'
+            $targetPane = '%9'
+
+            # Act
+            $result = Invoke-RoleGate -Role $role -Command $command -TargetPane $targetPane
+
+            # Assert
+            $result | Should Be $false
+        }
+
+        It 'denies Researcher from using vault commands' {
+            # Arrange
+            $role = 'Researcher'
+            $command = 'vault'
+
+            # Act
+            $result = Invoke-RoleGate -Role $role -Command $command
+
+            # Assert
+            $result | Should Be $false
+        }
+
+        It 'denies Researcher from dispatching work' {
+            # Arrange
+            $role = 'Researcher'
+            $command = 'dispatch'
+
+            # Act
+            $result = Invoke-RoleGate -Role $role -Command $command
+
+            # Assert
+            $result | Should Be $false
+        }
+
+        It 'allows Reviewer to read its own pane' {
+            # Arrange
+            $role = 'Reviewer'
+            $command = 'read'
+            $targetPane = '%1'
+
+            # Act
+            $result = Invoke-RoleGate -Role $role -Command $command -TargetPane $targetPane
+
+            # Assert
+            $result | Should Be $true
+        }
+
+        It 'allows Reviewer to send to Commander' {
+            # Arrange
+            $role = 'Reviewer'
+            $command = 'send'
+            $targetPane = 'Commander'
+
+            # Act
+            $result = Invoke-RoleGate -Role $role -Command $command -TargetPane $targetPane
+
+            # Assert
+            $result | Should Be $true
+        }
+
+        It 'denies Reviewer from reading other panes' {
+            # Arrange
+            $role = 'Reviewer'
+            $command = 'read'
+            $targetPane = '%9'
+
+            # Act
+            $result = Invoke-RoleGate -Role $role -Command $command -TargetPane $targetPane
+
+            # Assert
+            $result | Should Be $false
+        }
+
+        It 'denies Reviewer from using vault commands' {
+            # Arrange
+            $role = 'Reviewer'
+            $command = 'vault'
+
+            # Act
+            $result = Invoke-RoleGate -Role $role -Command $command
+
+            # Assert
+            $result | Should Be $false
+        }
+
+        It 'denies Reviewer from dispatching work' {
+            # Arrange
+            $role = 'Reviewer'
+            $command = 'dispatch'
+
+            # Act
+            $result = Invoke-RoleGate -Role $role -Command $command
+
+            # Assert
+            $result | Should Be $false
+        }
+
+        It 'denies read when WINSMUX_ROLE is unset' {
+            # Arrange
+            $command = 'read'
+            $targetPane = '%1'
+
+            # Act
+            $result = Invoke-RoleGate -Role $null -Command $command -TargetPane $targetPane
+
+            # Assert
+            $result | Should Be $false
+        }
+
+        It 'denies read when WINSMUX_ROLE is unknown' {
+            # Arrange
+            $role = 'admin'
+            $command = 'read'
+            $targetPane = '%1'
+
+            # Act
+            $result = Invoke-RoleGate -Role $role -Command $command -TargetPane $targetPane
+
+            # Assert
+            $result | Should Be $false
+        }
+
+        It 'denies read when WINSMUX_ROLE is an empty string' {
+            # Arrange
+            $role = ''
+            $command = 'read'
+            $targetPane = '%1'
+
+            # Act
+            $result = Invoke-RoleGate -Role $role -Command $command -TargetPane $targetPane
+
+            # Assert
+            $result | Should Be $false
+        }
+    }
+
+    Context 'Get-BridgeSettings' {
+        BeforeEach {
+            Set-Location $TestDrive
+            Remove-Item -Path '.psmux-bridge.yaml' -Force -ErrorAction SilentlyContinue
+        }
+
+        It 'returns defaults when no config exists' {
+            # Arrange
+            Mock Get-PsmuxOption { param($Name, $Default) return $Default }
+
+            # Act
+            $settings = Get-BridgeSettings
+
+            # Assert
+            $settings.agent | Should Be 'codex'
+            $settings.model | Should Be 'gpt-5.4'
+            $settings.builders | Should Be 4
+            $settings.researchers | Should Be 1
+            $settings.reviewers | Should Be 1
+            ($settings.vault_keys -join ',') | Should Be 'GH_TOKEN'
+            $settings.terminal | Should Be 'background'
+        }
+
+        It 'reads scalar values from .psmux-bridge.yaml when present' {
+            # Arrange
+            Set-Content -Path '.psmux-bridge.yaml' -Encoding UTF8 -Value @"
+agent: claude
+model: sonnet
+terminal: new-tab
+"@
+            Mock Get-PsmuxOption { param($Name, $Default) return $Default }
+
+            # Act
+            $settings = Get-BridgeSettings
+
+            # Assert
+            $settings.agent | Should Be 'claude'
+            $settings.model | Should Be 'sonnet'
+            $settings.terminal | Should Be 'new-tab'
+        }
+
+        It 'reads numeric values from .psmux-bridge.yaml when present' {
+            # Arrange
+            Set-Content -Path '.psmux-bridge.yaml' -Encoding UTF8 -Value @"
+builders: 7
+researchers: 2
+reviewers: 3
+"@
+            Mock Get-PsmuxOption { param($Name, $Default) return $Default }
+
+            # Act
+            $settings = Get-BridgeSettings
+
+            # Assert
+            $settings.builders | Should Be 7
+            $settings.researchers | Should Be 2
+            $settings.reviewers | Should Be 3
+        }
+
+        It 'reads list values from .psmux-bridge.yaml when present' {
+            # Arrange
+            Set-Content -Path '.psmux-bridge.yaml' -Encoding UTF8 -Value @"
+vault_keys:
+  - GH_TOKEN
+  - OPENAI_API_KEY
+"@
+            Mock Get-PsmuxOption { param($Name, $Default) return $Default }
+
+            # Act
+            $settings = Get-BridgeSettings
+
+            # Assert
+            ($settings.vault_keys -join ',') | Should Be 'GH_TOKEN,OPENAI_API_KEY'
+        }
+
+        It 'falls back to psmux options for scalar values' {
+            # Arrange
+            Mock Get-PsmuxOption {
+                param($Name, $Default)
+                switch ($Name) {
+                    '@bridge-agent' { return 'cursor' }
+                    '@bridge-model' { return 'gpt-5.5-mini' }
+                    '@bridge-terminal' { return 'split-pane' }
+                    default { return $Default }
+                }
+            }
+
+            # Act
+            $settings = Get-BridgeSettings
+
+            # Assert
+            $settings.agent | Should Be 'cursor'
+            $settings.model | Should Be 'gpt-5.5-mini'
+            $settings.terminal | Should Be 'split-pane'
+        }
+
+        It 'falls back to psmux options for list values' {
+            # Arrange
+            Mock Get-PsmuxOption {
+                param($Name, $Default)
+                if ($Name -eq '@bridge-vault-keys') {
+                    return 'GH_TOKEN,OPENAI_API_KEY'
+                }
+
+                return $Default
+            }
+
+            # Act
+            $settings = Get-BridgeSettings
+
+            # Assert
+            ($settings.vault_keys -join ',') | Should Be 'GH_TOKEN,OPENAI_API_KEY'
+        }
+
+        It 'uses project values before global values and defaults' {
+            # Arrange
+            Set-Content -Path '.psmux-bridge.yaml' -Encoding UTF8 -Value @"
+agent: local-agent
+builders: 9
+"@
+            Mock Get-PsmuxOption {
+                param($Name, $Default)
+                switch ($Name) {
+                    '@bridge-agent' { return 'global-agent' }
+                    '@bridge-builders' { return '6' }
+                    default { return $Default }
+                }
+            }
+
+            # Act
+            $settings = Get-BridgeSettings
+
+            # Assert
+            $settings.agent | Should Be 'local-agent'
+            $settings.builders | Should Be 9
+        }
+
+        It 'uses global values before defaults when project values are absent' {
+            # Arrange
+            Mock Get-PsmuxOption {
+                param($Name, $Default)
+                switch ($Name) {
+                    '@bridge-researchers' { return '4' }
+                    '@bridge-reviewers' { return '2' }
+                    default { return $Default }
+                }
+            }
+
+            # Act
+            $settings = Get-BridgeSettings
+
+            # Assert
+            $settings.researchers | Should Be 4
+            $settings.reviewers | Should Be 2
+            $settings.builders | Should Be 4
+        }
+    }
+
+    Context 'version command' {
+        It 'returns version string matching VERSION file' {
+            # Arrange
+            $expectedVersion = (Get-Content -Path $script:VersionFile -Raw -Encoding UTF8).Trim()
+
+            # Act
+            $commandOutput = (& pwsh -NoProfile -File $script:BridgeScript version).Trim()
+
+            # Assert
+            $commandOutput | Should Be "psmux-bridge $expectedVersion"
+        }
+
+        It 'returns a semver version string' {
+            # Arrange
+            $semverPattern = '^psmux-bridge \d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$'
+
+            # Act
+            $commandOutput = (& pwsh -NoProfile -File $script:BridgeScript version).Trim()
+
+            # Assert
+            $commandOutput | Should Match $semverPattern
+        }
+    }
+
+    Context 'Vault functions' {
+        It 'VaultSet stores a credential' {
+            # Arrange
+            $script:Target = 'OPENAI_API_KEY'
+            $script:Rest = @('secret-value')
+
+            # Act
+            Invoke-VaultSet | Out-Null
+            $storedValue = [WinCred]::GetValue('winsmux:OPENAI_API_KEY')
+
+            # Assert
+            $storedValue | Should Be 'secret-value'
+        }
+
+        It 'VaultGet retrieves a stored credential' {
+            # Arrange
+            $script:Target = 'GH_TOKEN'
+            $script:Rest = @('ghs_test_token')
+            Invoke-VaultSet | Out-Null
+            $script:Target = 'GH_TOKEN'
+            $script:Rest = @()
+
+            # Act
+            $value = Invoke-VaultGet
+
+            # Assert
+            $value | Should Be 'ghs_test_token'
+        }
+
+        It 'VaultGet errors when the key is missing' {
+            # Arrange
+            $script:Target = 'MISSING_KEY'
+            $script:Rest = @()
+
+            # Act
+            $action = { Invoke-VaultGet }
+
+            # Assert
+            $action | Should Throw 'credential not found: MISSING_KEY'
+        }
+
+        It 'VaultList returns empty when no credentials exist' {
+            # Arrange
+            $script:Target = $null
+            $script:Rest = @()
+
+            # Act
+            $list = Invoke-VaultList
+
+            # Assert
+            $list | Should Be '(no credentials stored)'
+        }
+
+        It 'VaultList returns stored keys after credentials are set' {
+            # Arrange
+            $script:Target = 'GH_TOKEN'
+            $script:Rest = @('ghs_example')
+            Invoke-VaultSet | Out-Null
+            $script:Target = 'OPENAI_API_KEY'
+            $script:Rest = @('sk-example')
+            Invoke-VaultSet | Out-Null
+            $script:Target = $null
+            $script:Rest = @()
+
+            # Act
+            $list = @(Invoke-VaultList)
+
+            # Assert
+            ($list -join ',') | Should Be 'GH_TOKEN,OPENAI_API_KEY'
+        }
+
+        It 'VaultInject errors when the target pane is invalid' {
+            # Arrange
+            $script:Target = '%99'
+            $script:Rest = @()
+            Mock Confirm-Target { throw 'invalid target: %99' }
+
+            # Act
+            $action = { Invoke-VaultInject }
+
+            # Assert
+            $action | Should Throw 'invalid target: %99'
         }
     }
 }


### PR DESCRIPTION
## Summary

- **TASK-033 (P0)**: Shared Task List — file-lock self-claiming, dependency auto-resolve
- **TASK-029**: Orchestra start automation — Prefix+O full lifecycle (10 steps)
- **TASK-035**: Agent idle/crash detection with auto-respawn (READY/BUSY/HUNG/DEAD)
- **TASK-038**: 36+ Pester unit tests (778 lines)

## Test plan

- [ ] Pester tests pass: `Invoke-Pester tests/`
- [ ] Shared task list: claim/complete/auto-unblock cycle
- [ ] Orchestra start: settings → vault → layout → agents → ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)