### PR TITLE
chore: consolidate .gitignore wildcards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,7 +54,7 @@ package-lock.json
 # =========================
 # Orchestra runtime (generated)
 # =========================
-.commander-prompt.txt
+.commander-prompt*.txt
 .orchestra-prompts/
 
 # =========================
@@ -112,4 +112,4 @@ coverage/
 *.swo
 *~
 .shield-harness/
-.research-fork-verdict.md
+.research-*.md


### PR DESCRIPTION
## Summary
- `.commander-prompt.txt` → `.commander-prompt*.txt` (covers all prompt variants)
- `.research-fork-verdict.md` → `.research-*.md` (covers all research outputs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)