### PR TITLE
feat: SHA256 checksum verification in install.ps1

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -57,6 +57,44 @@ function Install-Psmux {
         Write-Status "Downloading $($asset.name) from $($release.tag_name)..."
         Invoke-RestMethod -Uri $asset.browser_download_url -Headers $headers -OutFile $psmuxExe -ErrorAction Stop
 
+        $sha256Asset = $release.assets | Where-Object { $_.name -eq "SHA256SUMS" } | Select-Object -First 1
+        if (-not $sha256Asset) {
+            Write-Warning "[winsmux] SHA256SUMS asset not found in release $($release.tag_name). Skipping checksum verification."
+        } else {
+            $checksumsPath = Join-Path ([System.IO.Path]::GetTempPath()) ("winsmux-" + [System.Guid]::NewGuid().ToString() + "-SHA256SUMS")
+            try {
+                Write-Status "Downloading $($sha256Asset.name) from $($release.tag_name)..."
+                Invoke-RestMethod -Uri $sha256Asset.browser_download_url -Headers $headers -OutFile $checksumsPath -ErrorAction Stop
+
+                $expectedHash = $null
+                foreach ($line in Get-Content $checksumsPath) {
+                    if ($line -match '^(?<hash>[A-Fa-f0-9]{64})\s+\*?(?<name>.+)$') {
+                        if ($Matches.name -eq $asset.name) {
+                            $expectedHash = $Matches.hash.ToUpperInvariant()
+                            break
+                        }
+                    }
+                }
+
+                if (-not $expectedHash) {
+                    Write-Warning "[winsmux] SHA256SUMS does not contain an entry for $($asset.name). Skipping checksum verification."
+                } else {
+                    $actualHash = (Get-FileHash $psmuxExe -Algorithm SHA256).Hash.ToUpperInvariant()
+                    if ($actualHash -ne $expectedHash) {
+                        throw "Checksum verification failed for $($asset.name)."
+                    }
+                    Write-Status "Checksum verified"
+                }
+            } catch {
+                if ($_.Exception.Message -like "Checksum verification failed*") {
+                    throw
+                }
+                Write-Warning "[winsmux] Failed to verify checksum for $($asset.name): $_. Skipping checksum verification."
+            } finally {
+                Remove-Item $checksumsPath -Force -ErrorAction SilentlyContinue
+            }
+        }
+
         $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
         $userPaths = @()
         if ($userPath) {


### PR DESCRIPTION
## Summary
- Download SHA256SUMS from GitHub Release after psmux.exe download
- Verify binary hash matches expected value
- Graceful fallback: warning-only if SHA256SUMS unavailable
- Checksum mismatch blocks installation for security

## Test plan
- [ ] Install with SHA256SUMS present → checksum verified
- [ ] Install from old release without SHA256SUMS → warning, install continues
- [ ] Tampered binary → checksum mismatch error, install blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)