### PR TITLE
feat: backlog sync script for automated status updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,8 @@ tasks/
 skills/
 tests/
 hooks/
+!psmux-bridge/hooks/
+!psmux-bridge/hooks/**
 .githooks/
 .worktrees/
 scripts/sync-*.ps1

--- a/psmux-bridge/scripts/sync-backlog-status.ps1
+++ b/psmux-bridge/scripts/sync-backlog-status.ps1
@@ -1,0 +1,57 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$TaskId,
+
+    [Parameter(Mandatory = $true)]
+    [string]$Status,
+
+    [string]$BacklogPath = 'tasks/backlog.yaml'
+)
+
+$resolvedBacklogPath = if ([System.IO.Path]::IsPathRooted($BacklogPath)) {
+    $BacklogPath
+} else {
+    Join-Path (Get-Location).Path $BacklogPath
+}
+
+if (-not (Test-Path -LiteralPath $resolvedBacklogPath)) {
+    Write-Warning "Backlog not found: $resolvedBacklogPath"
+    exit 0
+}
+
+$utf8NoBom = [System.Text.UTF8Encoding]::new($false)
+$content = [System.IO.File]::ReadAllText($resolvedBacklogPath, $utf8NoBom)
+
+$taskPattern = '(?m)^[ \t]*-[ \t]+id:[ \t]*' + [regex]::Escape($TaskId) + '[ \t]*$'
+$taskMatch = [regex]::Match($content, $taskPattern)
+
+if (-not $taskMatch.Success) {
+    Write-Warning "TaskId not found in backlog: $TaskId"
+    exit 0
+}
+
+$searchStart = $taskMatch.Index + $taskMatch.Length
+$remainingContent = $content.Substring($searchStart)
+$nextTaskMatch = [regex]::Match($remainingContent, '(?m)^[ \t]*-[ \t]+id:[ \t]*')
+$taskBlockLength = if ($nextTaskMatch.Success) { $nextTaskMatch.Index } else { $remainingContent.Length }
+$taskBlock = $remainingContent.Substring(0, $taskBlockLength)
+
+$statusPattern = '(?m)^(?<indent>[ \t]*)status:[ \t]*(?<value>[^#\r\n]*?)(?<suffix>[ \t]*(?:#.*)?)$'
+$statusMatch = [regex]::Match($taskBlock, $statusPattern)
+
+if (-not $statusMatch.Success) {
+    Write-Warning "status line not found for task: $TaskId"
+    exit 0
+}
+
+$newStatusLine = '{0}status: {1}{2}' -f $statusMatch.Groups['indent'].Value, $Status, $statusMatch.Groups['suffix'].Value
+$updatedTaskBlock = [regex]::Replace($taskBlock, $statusPattern, [System.Text.RegularExpressions.MatchEvaluator]{
+    param($match)
+    $newStatusLine
+}, 1)
+
+$updatedContent = $content.Substring(0, $searchStart) + $updatedTaskBlock + $remainingContent.Substring($taskBlockLength)
+[System.IO.File]::WriteAllText($resolvedBacklogPath, $updatedContent, $utf8NoBom)
+
+Write-Output ("Updated {0}: backlog → {1}" -f $TaskId, $Status)


### PR DESCRIPTION
## Summary
- Add `psmux-bridge/scripts/sync-backlog-status.ps1`
- Updates backlog.yaml task status via regex replacement
- Idempotent: re-running with same status is a no-op
- Designed for PostToolUse hook integration

## Test plan
- [ ] Update existing task status
- [ ] Task not found → warning only
- [ ] Idempotent re-run

🤖 Generated with [Claude Code](https://claude.com/claude-code)