### PR TITLE
security: add Rule 6 for safe file untracking (#108)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -66,6 +66,11 @@ Hooks are in `.claude/hooks/` (git-tracked). Registration:
 
 `orchestra-start.ps1` auto-registers Commander hooks in settings.local.json.
 
+## Git Rules
+
+- **`git rm` 禁止。`git rm --cached` を使う。** bare `git rm` はローカルファイルも削除する（PR #79, #101 で2回事故）
+- ブランチは feature branch で作業、main 直コミットは pre-commit hook がブロック
+
 ## Conventions
 
 - Commit messages: English, conventional commits (`feat:`, `fix:`, `chore:`)

--- a/.claude/hooks/sh-orchestra-gate.js
+++ b/.claude/hooks/sh-orchestra-gate.js
@@ -56,6 +56,13 @@ try {
     }
   }
 
+  // Rule 6: Block bare git rm (allow only git rm --cached)
+  if (toolName === "Bash") {
+    if (/git\s+rm\s/.test(rawCommand) && !/--cached/.test(rawCommand)) {
+      deny("Use git rm --cached to untrack files. Bare git rm deletes local files.");
+    }
+  }
+
   process.exit(0);
 } catch (e) {
   deny("Hook parse error: " + e.message);


### PR DESCRIPTION
Closes #108. Adds hook rule blocking bare git rm. Also adds git rules to CLAUDE.md.