### PR TITLE
revert: PR #110 and fixes — restore working orchestra-start

### DIFF
--- a/.claude/hooks/sh-orchestra-gate.js
+++ b/.claude/hooks/sh-orchestra-gate.js
@@ -17,6 +17,8 @@ try {
   const toolInput = event.tool_input || {};
   const rawCommand = typeof toolInput.command === "string" ? toolInput.command : "";
 
+  logCommand(toolName, rawCommand);
+
   // Rule 1: Commander cannot write/edit code files
   if (toolName === "Write" || toolName === "Edit") {
     const filePath = toolInput.file_path || toolInput.file || "";
@@ -61,7 +63,6 @@ try {
     }
   }
 
-  logCommand(toolName, rawCommand);
   process.exit(0);
 } catch (e) {
   deny("Hook parse error: " + e.message);

--- a/psmux-bridge/scripts/orchestra-layout.ps1
+++ b/psmux-bridge/scripts/orchestra-layout.ps1
@@ -147,7 +147,7 @@ if ($rows -gt 1) {
     Split-Equal -Target $newPaneId -PaneCount $rows -Direction '-v'
 }
 
-$rowIds = @(Get-PaneIds -Target $newWindowId)
+$rowIds = Get-PaneIds -Target $newWindowId
 if ($rowIds.Count -lt $rows) {
     throw "Expected at least $rows row panes but found $($rowIds.Count)."
 }
@@ -165,7 +165,7 @@ if ($cols -gt 1) {
 
 Start-Sleep -Milliseconds 300
 
-$allIds = @(Get-PaneIds -Target $newWindowId)
+$allIds = Get-PaneIds -Target $newWindowId
 if ($allIds.Count -lt $total) {
     throw "Expected at least $total panes but found $($allIds.Count)."
 }

--- a/psmux-bridge/scripts/orchestra-start.ps1
+++ b/psmux-bridge/scripts/orchestra-start.ps1
@@ -222,7 +222,7 @@ function Remove-OrchestraZombieProcesses {
                 ForEach-Object { [int]$_ }
         )
 
-        if (@($paneRootIds).Count -gt 0) {
+        if ($paneRootIds.Count -gt 0) {
             $descendantIds = Get-DescendantProcessIds -Snapshot $snapshot -RootProcessIds $paneRootIds
             foreach ($descendantId in $descendantIds) {
                 if (-not $snapshot.ById.ContainsKey($descendantId)) {
@@ -309,43 +309,6 @@ function New-BuilderWorktree {
         BranchName     = $branchName
         WorktreePath   = $worktreePath
         GitWorktreeDir = Get-GitWorktreeDir -ProjectDir $worktreePath
-    }
-}
-
-function Remove-BuilderWorktree {
-    param(
-        [Parameter(Mandatory = $true)][string]$ProjectDir,
-        [Parameter(Mandatory = $true)][string]$WorktreePath,
-        [Parameter(Mandatory = $true)][string]$BranchName
-    )
-
-    $errors = [System.Collections.Generic.List[string]]::new()
-
-    if (Test-Path -LiteralPath $WorktreePath) {
-        $output = (& git -C $ProjectDir worktree remove --force $WorktreePath 2>&1 | Out-String).Trim()
-        if ($LASTEXITCODE -ne 0) {
-            if ([string]::IsNullOrWhiteSpace($output)) {
-                $output = 'unknown git worktree remove error'
-            }
-
-            $errors.Add("worktree remove failed for ${WorktreePath}: $output")
-        }
-    }
-
-    $existingBranch = (& git -C $ProjectDir branch --list --format '%(refname:short)' $BranchName 2>$null | Out-String).Trim()
-    if (-not [string]::IsNullOrWhiteSpace($existingBranch)) {
-        $output = (& git -C $ProjectDir branch -D $BranchName 2>&1 | Out-String).Trim()
-        if ($LASTEXITCODE -ne 0) {
-            if ([string]::IsNullOrWhiteSpace($output)) {
-                $output = 'unknown git branch delete error'
-            }
-
-            $errors.Add("branch delete failed for ${BranchName}: $output")
-        }
-    }
-
-    if ($errors.Count -gt 0) {
-        throw ($errors -join '; ')
     }
 }
 
@@ -607,10 +570,6 @@ try {
 
     Invoke-VaultPreflight -Settings $settings
     Invoke-CodexTrustPreflight -ProjectDir $projectDir
-    $syncScript = Join-Path $PSScriptRoot 'sync-roadmap.ps1'
-    if (Test-Path $syncScript) {
-        & $syncScript
-    }
 
     $vaultValues = [ordered]@{}
 
@@ -657,7 +616,7 @@ try {
         }
     }
 
-    if ($null -eq $layout -or $null -eq $layout.Panes -or @($layout.Panes).Count -lt 1) {
+    if ($null -eq $layout -or $null -eq $layout.Panes -or $layout.Panes.Count -lt 1) {
         Write-Error 'orchestra-layout did not return any panes.'
         exit 1
     }
@@ -669,110 +628,82 @@ try {
     Set-OrchestraSessionEnvironment -SessionName $sessionName -Name 'WINSMUX_ROLE_MAP' -Value (($sessionRoleMap | ConvertTo-Json -Compress))
 
     $paneSummaries = [System.Collections.Generic.List[object]]::new()
-    $createdBuilderWorktrees = [System.Collections.Generic.List[object]]::new()
     $builderIndex = 0
-    $startupSucceeded = $false
 
-    try {
-        foreach ($pane in @($layout.Panes)) {
-            $assignmentLabel = [string]$pane.Role
-            $canonicalRole = Get-CanonicalRole -AssignmentRole $assignmentLabel
-            $label = $assignmentLabel.ToLowerInvariant()
-            $paneId = [string]$pane.PaneId
-            $launchDir = $projectDir
-            $launchGitWorktreeDir = $gitWorktreeDir
-            $builderBranch = $null
-            $builderWorktreePath = $null
+    foreach ($pane in @($layout.Panes)) {
+        $assignmentLabel = [string]$pane.Role
+        $canonicalRole = Get-CanonicalRole -AssignmentRole $assignmentLabel
+        $label = $assignmentLabel.ToLowerInvariant()
+        $paneId = [string]$pane.PaneId
+        $launchDir = $projectDir
+        $launchGitWorktreeDir = $gitWorktreeDir
+        $builderBranch = $null
+        $builderWorktreePath = $null
 
-            if ($canonicalRole -eq 'Builder') {
-                $builderIndex++
-                $builderWorktree = New-BuilderWorktree -ProjectDir $projectDir -BuilderIndex $builderIndex
-                $launchDir = $builderWorktree.WorktreePath
-                $launchGitWorktreeDir = $builderWorktree.GitWorktreeDir
-                $builderBranch = $builderWorktree.BranchName
-                $builderWorktreePath = $builderWorktree.WorktreePath
-                $createdBuilderWorktrees.Add($builderWorktree)
-            }
+        if ($canonicalRole -eq 'Builder') {
+            $builderIndex++
+            $builderWorktree = New-BuilderWorktree -ProjectDir $projectDir -BuilderIndex $builderIndex
+            $launchDir = $builderWorktree.WorktreePath
+            $launchGitWorktreeDir = $builderWorktree.GitWorktreeDir
+            $builderBranch = $builderWorktree.BranchName
+            $builderWorktreePath = $builderWorktree.WorktreePath
+        }
 
-            $launchCommand = Get-AgentLaunchCommand -Agent $settings.agent -Model $settings.model -ProjectDir $launchDir -GitWorktreeDir $launchGitWorktreeDir
+        $launchCommand = Get-AgentLaunchCommand -Agent $settings.agent -Model $settings.model -ProjectDir $launchDir -GitWorktreeDir $launchGitWorktreeDir
 
-            Invoke-Bridge -Arguments @('name', $paneId, $label)
-            try {
-                Set-OrchestraSessionEnvironment -SessionName $sessionName -Name 'WINSMUX_ROLE' -Value $canonicalRole
-                Set-OrchestraSessionEnvironment -SessionName $sessionName -Name 'WINSMUX_PANE_ID' -Value $paneId
-                Invoke-Psmux -Arguments @('respawn-pane', '-k', '-t', $paneId, '-c', $launchDir)
-                Start-Sleep -Seconds 1
-                Send-OrchestraBridgeCommand -Target $paneId -Text $launchCommand
-            } finally {
-                foreach ($envName in @('WINSMUX_ROLE', 'WINSMUX_PANE_ID')) {
-                    try {
-                        Clear-OrchestraSessionEnvironment -SessionName $sessionName -Name $envName
-                    } catch {
-                    }
+        Invoke-Bridge -Arguments @('name', $paneId, $label)
+        try {
+            Set-OrchestraSessionEnvironment -SessionName $sessionName -Name 'WINSMUX_ROLE' -Value $canonicalRole
+            Set-OrchestraSessionEnvironment -SessionName $sessionName -Name 'WINSMUX_PANE_ID' -Value $paneId
+            Invoke-Psmux -Arguments @('respawn-pane', '-k', '-t', $paneId, '-c', $launchDir)
+            Start-Sleep -Seconds 1
+            Send-OrchestraBridgeCommand -Target $paneId -Text $launchCommand
+        } finally {
+            foreach ($envName in @('WINSMUX_ROLE', 'WINSMUX_PANE_ID')) {
+                try {
+                    Clear-OrchestraSessionEnvironment -SessionName $sessionName -Name $envName
+                } catch {
                 }
             }
-
-            $paneSummaries.Add([PSCustomObject]@{
-                Label = $label
-                PaneId = $paneId
-                Role = $canonicalRole
-                LaunchDir = $launchDir
-                BuilderBranch = $builderBranch
-                BuilderWorktreePath = $builderWorktreePath
-            })
         }
 
-        foreach ($paneSummary in $paneSummaries) {
-            try {
-                Wait-AgentReady -PaneId $paneSummary.PaneId -Agent $settings.agent -TimeoutSeconds 60
-            } catch {
-                Write-Error "Agent readiness timeout for $($paneSummary.Label) [$($paneSummary.PaneId)]: $($_.Exception.Message)"
-                exit 1
-            }
-        }
+        $paneSummaries.Add([PSCustomObject]@{
+            Label = $label
+            PaneId = $paneId
+            Role = $canonicalRole
+            LaunchDir = $launchDir
+            BuilderBranch = $builderBranch
+            BuilderWorktreePath = $builderWorktreePath
+        })
+    }
 
-        Write-Output "Orchestra session: $sessionName"
-        Write-Output "Agent: $($settings.agent)"
-        Write-Output "Model: $($settings.model)"
-        Write-Output "ProjectDir: $projectDir"
-        Write-Output "GitWorktreeDir: $gitWorktreeDir"
+    foreach ($paneSummary in $paneSummaries) {
+        try {
+            Wait-AgentReady -PaneId $paneSummary.PaneId -Agent $settings.agent -TimeoutSeconds 60
+        } catch {
+            Write-Error "Agent readiness timeout for $($paneSummary.Label) [$($paneSummary.PaneId)]: $($_.Exception.Message)"
+            exit 1
+        }
+    }
+
+    Write-Output "Orchestra session: $sessionName"
+    Write-Output "Agent: $($settings.agent)"
+    Write-Output "Model: $($settings.model)"
+    Write-Output "ProjectDir: $projectDir"
+    Write-Output "GitWorktreeDir: $gitWorktreeDir"
+    Write-Output ''
+    Write-Output 'Panes:'
+    foreach ($paneSummary in $paneSummaries) {
+        Write-Output ("  {0,-14} {1,-8} {2}" -f $paneSummary.Label, $paneSummary.PaneId, $paneSummary.Role)
+    }
+
+    $builderPaneSummaries = @($paneSummaries | Where-Object { $_.Role -eq 'Builder' -and -not [string]::IsNullOrWhiteSpace($_.BuilderWorktreePath) })
+    if ($builderPaneSummaries.Count -gt 0) {
         Write-Output ''
-        Write-Output 'Panes:'
-        foreach ($paneSummary in $paneSummaries) {
-            Write-Output ("  {0,-14} {1,-8} {2}" -f $paneSummary.Label, $paneSummary.PaneId, $paneSummary.Role)
-        }
-
-        $builderPaneSummaries = @($paneSummaries | Where-Object { $_.Role -eq 'Builder' -and -not [string]::IsNullOrWhiteSpace($_.BuilderWorktreePath) })
-        if (@($builderPaneSummaries).Count -gt 0) {
-            Write-Output ''
-            Write-Output 'Cleanup: remove Builder worktrees after the session ends.'
-            foreach ($paneSummary in $builderPaneSummaries) {
-                $relativeWorktree = [System.IO.Path]::GetRelativePath($projectDir, $paneSummary.BuilderWorktreePath)
-                Write-Output ("  git -C {0} worktree remove {1} ; git -C {0} branch -D {2}" -f $projectDir, $relativeWorktree, $paneSummary.BuilderBranch)
-            }
-        }
-
-        $startupSucceeded = $true
-    } finally {
-        if (-not $startupSucceeded) {
-            & $psmuxBin has-session -t $sessionName 1>$null 2>$null
-            if ($LASTEXITCODE -eq 0) {
-                try {
-                    Invoke-Psmux -Arguments @('kill-session', '-t', $sessionName)
-                } catch {
-                    Write-Warning "Cleanup: failed to kill session ${sessionName}: $($_.Exception.Message)"
-                }
-            }
-
-            for ($index = $createdBuilderWorktrees.Count - 1; $index -ge 0; $index--) {
-                $builderWorktree = $createdBuilderWorktrees[$index]
-                try {
-                    Remove-BuilderWorktree -ProjectDir $projectDir -WorktreePath $builderWorktree.WorktreePath -BranchName $builderWorktree.BranchName
-                    Write-Warning "Cleanup: removed stale Builder worktree $($builderWorktree.WorktreePath)"
-                } catch {
-                    Write-Warning "Cleanup: failed to remove stale Builder worktree $($builderWorktree.WorktreePath): $($_.Exception.Message)"
-                }
-            }
+        Write-Output 'Cleanup: remove Builder worktrees after the session ends.'
+        foreach ($paneSummary in $builderPaneSummaries) {
+            $relativeWorktree = [System.IO.Path]::GetRelativePath($projectDir, $paneSummary.BuilderWorktreePath)
+            Write-Output ("  git -C {0} worktree remove {1} ; git -C {0} branch -D {2}" -f $projectDir, $relativeWorktree, $paneSummary.BuilderBranch)
         }
     }
 } catch {

--- a/scripts/psmux-bridge.ps1
+++ b/scripts/psmux-bridge.ps1
@@ -1185,135 +1185,57 @@ function Invoke-VaultList {
     }
 }
 
-function Invoke-PsmuxCommand {
-    param(
-        [Parameter(Mandatory = $true)]
-        [string[]]$Arguments
-    )
-
-    $global:LASTEXITCODE = 0
-    try {
-        $output = & psmux @Arguments 2>&1
-    } catch {
-        return [PSCustomObject]@{
-            Success  = $false
-            ExitCode = if ($null -eq $LASTEXITCODE) { 1 } else { $LASTEXITCODE }
-            Output   = $_.Exception.Message
-        }
-    }
-
-    $exitCode = if ($null -eq $LASTEXITCODE) { 0 } else { $LASTEXITCODE }
-    return [PSCustomObject]@{
-        Success  = ($exitCode -eq 0)
-        ExitCode = $exitCode
-        Output   = ($output | Out-String).Trim()
-    }
-}
-
-function ConvertTo-PsmuxConfigString {
-    param([Parameter(Mandatory = $true)][AllowEmptyString()][string]$Value)
-
-    $escaped = $Value.Replace('\', '\\').Replace('"', '\"')
-    return '"' + $escaped + '"'
-}
-
-function Get-PsmuxSessionNameForPane {
-    param([Parameter(Mandatory = $true)][string]$PaneId)
-
-    $result = Invoke-PsmuxCommand -Arguments @('display-message', '-p', '-t', $PaneId, '#{session_name}')
-    if (-not $result.Success) {
-        Stop-WithError "Unable to resolve the psmux session for pane $PaneId."
-    }
-
-    $sessionName = $result.Output.Trim()
-    if ([string]::IsNullOrWhiteSpace($sessionName)) {
-        Stop-WithError "psmux returned an empty session name for pane $PaneId."
-    }
-
-    return $sessionName
-}
-
-function Invoke-PsmuxSourceFile {
-    param([Parameter(Mandatory = $true)][string[]]$Commands)
-
-    $tempConf = [System.IO.Path]::GetTempFileName()
-    try {
-        Set-Content -Path $tempConf -Value ($Commands -join [Environment]::NewLine) -NoNewline -Encoding utf8
-        return Invoke-PsmuxCommand -Arguments @('source-file', $tempConf)
-    } finally {
-        Remove-Item -LiteralPath $tempConf -Force -ErrorAction SilentlyContinue
-    }
-}
-
 function Invoke-VaultInject {
     if (-not $Target) { Stop-WithError "usage: psmux-bridge vault inject <pane>" }
 
     $paneId = Resolve-Target $Target
     $paneId = Confirm-Target $paneId
     Assert-ReadMark $paneId
-    try {
-        # Enumerate all winsmux:* credentials
-        $filter = "winsmux:*"
-        $count = 0
-        $credsPtr = [IntPtr]::Zero
 
-        $ok = [WinCred]::CredEnumerate($filter, 0, [ref]$count, [ref]$credsPtr)
-        if (-not $ok) {
-            $errCode = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
-            if ($errCode -eq 1168) {
-                Write-Output "no credentials to inject"
-                return
-            }
-            Stop-WithError "CredEnumerate failed (error $errCode)"
+    # Enumerate all winsmux:* credentials
+    $filter = "winsmux:*"
+    $count = 0
+    $credsPtr = [IntPtr]::Zero
+
+    $ok = [WinCred]::CredEnumerate($filter, 0, [ref]$count, [ref]$credsPtr)
+    if (-not $ok) {
+        $errCode = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
+        if ($errCode -eq 1168) {
+            Write-Output "no credentials to inject"
+            return
         }
-
-        $entries = [System.Collections.Generic.List[object]]::new()
-        try {
-            $ptrSize = [Runtime.InteropServices.Marshal]::SizeOf([Type][IntPtr])
-            for ($i = 0; $i -lt $count; $i++) {
-                $entryPtr = [Runtime.InteropServices.Marshal]::ReadIntPtr($credsPtr, $i * $ptrSize)
-                $cred = [Runtime.InteropServices.Marshal]::PtrToStructure($entryPtr, [Type][WinCred+CREDENTIAL])
-                $envName = $cred.TargetName -replace '^winsmux:', ''
-
-                $value = ''
-                if ($cred.CredentialBlobSize -gt 0) {
-                    $bytes = New-Object byte[] $cred.CredentialBlobSize
-                    [Runtime.InteropServices.Marshal]::Copy($cred.CredentialBlob, $bytes, 0, $cred.CredentialBlobSize)
-                    $value = [System.Text.Encoding]::Unicode.GetString($bytes)
-                }
-
-                $entries.Add([PSCustomObject]@{
-                    Name  = $envName
-                    Value = $value
-                }) | Out-Null
-            }
-        } finally {
-            [WinCred]::CredFree($credsPtr) | Out-Null
-        }
-
-        $sessionName = Get-PsmuxSessionNameForPane -PaneId $paneId
-        $commands = foreach ($entry in $entries) {
-            'set-environment -t {0} {1} {2}' -f `
-                (ConvertTo-PsmuxConfigString -Value $sessionName), `
-                (ConvertTo-PsmuxConfigString -Value $entry.Name), `
-                (ConvertTo-PsmuxConfigString -Value $entry.Value)
-        }
-
-        $sourceResult = Invoke-PsmuxSourceFile -Commands $commands
-        if (-not $sourceResult.Success) {
-            # source-file keeps secrets out of argv; direct set-environment remains a last-resort fallback.
-            foreach ($entry in $entries) {
-                $setResult = Invoke-PsmuxCommand -Arguments @('set-environment', '-t', $sessionName, $entry.Name, $entry.Value)
-                if (-not $setResult.Success) {
-                    Stop-WithError "psmux set-environment failed while injecting credentials into $paneId."
-                }
-            }
-        }
-
-        Write-Output "injected $($entries.Count) credential(s) into $paneId"
-    } finally {
-        Clear-ReadMark $paneId
+        Stop-WithError "CredEnumerate failed (error $errCode)"
     }
+
+    $injected = 0
+    try {
+        $ptrSize = [Runtime.InteropServices.Marshal]::SizeOf([Type][IntPtr])
+        for ($i = 0; $i -lt $count; $i++) {
+            $entryPtr = [Runtime.InteropServices.Marshal]::ReadIntPtr($credsPtr, $i * $ptrSize)
+            $cred = [Runtime.InteropServices.Marshal]::PtrToStructure($entryPtr, [Type][WinCred+CREDENTIAL])
+            $envName = $cred.TargetName -replace '^winsmux:', ''
+
+            $value = ''
+            if ($cred.CredentialBlobSize -gt 0) {
+                $bytes = New-Object byte[] $cred.CredentialBlobSize
+                [Runtime.InteropServices.Marshal]::Copy($cred.CredentialBlob, $bytes, 0, $cred.CredentialBlobSize)
+                $value = [System.Text.Encoding]::Unicode.GetString($bytes)
+            }
+
+            # Escape single quotes in value for safe injection
+            $escapedValue = $value -replace "'", "''"
+            $setCmd = "`$env:$envName = '$escapedValue'"
+            & psmux send-keys -t $paneId -l -- "$setCmd"
+            & psmux send-keys -t $paneId Enter
+            Start-Sleep -Milliseconds 100
+            $injected++
+        }
+    } finally {
+        [WinCred]::CredFree($credsPtr) | Out-Null
+    }
+
+    Clear-ReadMark $paneId
+    Write-Output "injected $injected credential(s) into $paneId"
 }
 
 function Invoke-Version {


### PR DESCRIPTION
Reverts #110 #115 #116 #117. Orchestra-start was broken by untested Builder changes. Restoring to last known working state (v0.10.0 tag).