### PR TITLE
fix: add null guards to 5 crashing hooks

### DIFF
--- a/.claude/hooks/lib/openshell-detect.js
+++ b/.claude/hooks/lib/openshell-detect.js
@@ -5,11 +5,13 @@
 "use strict";
 
 const fs = require("fs");
+const os = require("os");
 const path = require("path");
 const { execSync } = require("child_process");
 const { commandExists, SH_DIR } = require("./sh-utils");
 
-const CACHE_DIR = path.join(SH_DIR, "state");
+const SAFE_SH_DIR = typeof SH_DIR === "string" && SH_DIR ? SH_DIR : os.tmpdir();
+const CACHE_DIR = path.join(SAFE_SH_DIR, "state");
 const CACHE_FILE = path.join(CACHE_DIR, "openshell-version-cache.json");
 const CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
 const CMD_TIMEOUT = 3000; // 3 seconds

--- a/.claude/hooks/sh-elicitation.js
+++ b/.claude/hooks/sh-elicitation.js
@@ -6,6 +6,7 @@
 "use strict";
 
 const fs = require("fs");
+const os = require("os");
 const path = require("path");
 const {
   readHookInput,
@@ -17,8 +18,9 @@ const {
 } = require("./lib/sh-utils");
 
 const HOOK_NAME = "sh-elicitation";
+const SAFE_SH_DIR = typeof SH_DIR === "string" && SH_DIR ? SH_DIR : os.tmpdir();
 const ALLOWED_MCP_FILE = path.join(
-  SH_DIR,
+  SAFE_SH_DIR,
   "config",
   "allowed-mcp-servers.json",
 );

--- a/.claude/hooks/sh-pipeline.js
+++ b/.claude/hooks/sh-pipeline.js
@@ -7,6 +7,7 @@
 "use strict";
 
 const fs = require("fs");
+const os = require("os");
 const path = require("path");
 const { execSync } = require("child_process");
 const {
@@ -22,7 +23,12 @@ const {
 } = require("./lib/sh-utils");
 
 const HOOK_NAME = "sh-pipeline";
-const PIPELINE_CONFIG = path.join(SH_DIR, "config", "pipeline-config.json");
+const SAFE_SH_DIR = typeof SH_DIR === "string" && SH_DIR ? SH_DIR : os.tmpdir();
+const PIPELINE_CONFIG = path.join(
+  SAFE_SH_DIR,
+  "config",
+  "pipeline-config.json",
+);
 const BACKLOG_FILE = path.join("tasks", "backlog.yaml");
 
 // ---------------------------------------------------------------------------

--- a/.claude/hooks/sh-postcompact.js
+++ b/.claude/hooks/sh-postcompact.js
@@ -7,6 +7,7 @@
 "use strict";
 
 const fs = require("fs");
+const os = require("os");
 const path = require("path");
 const {
   readHookInput,
@@ -19,7 +20,8 @@ const {
 } = require("./lib/sh-utils");
 
 const HOOK_NAME = "sh-postcompact";
-const BACKUP_DIR = path.join(SH_DIR, "compact-backup");
+const SAFE_SH_DIR = typeof SH_DIR === "string" && SH_DIR ? SH_DIR : os.tmpdir();
+const BACKUP_DIR = path.join(SAFE_SH_DIR, "compact-backup");
 const CLAUDE_MD = "CLAUDE.md";
 
 // ---------------------------------------------------------------------------

--- a/.claude/hooks/sh-precompact.js
+++ b/.claude/hooks/sh-precompact.js
@@ -7,6 +7,7 @@
 "use strict";
 
 const fs = require("fs");
+const os = require("os");
 const path = require("path");
 const {
   readHookInput,
@@ -18,7 +19,8 @@ const {
 } = require("./lib/sh-utils");
 
 const HOOK_NAME = "sh-precompact";
-const BACKUP_DIR = path.join(SH_DIR, "compact-backup");
+const SAFE_SH_DIR = typeof SH_DIR === "string" && SH_DIR ? SH_DIR : os.tmpdir();
+const BACKUP_DIR = path.join(SAFE_SH_DIR, "compact-backup");
 
 // ---------------------------------------------------------------------------
 // Backup Logic


### PR DESCRIPTION
Fixes path.join undefined crashes in elicitation, pipeline, postcompact, precompact, openshell-detect.