### PR TITLE
fix: dispatch-route JP keywords + session fix (#129)

### DIFF
--- a/psmux-bridge/scripts/dispatch-router.ps1
+++ b/psmux-bridge/scripts/dispatch-router.ps1
@@ -16,20 +16,24 @@ function Get-DispatchRouterKeywordMap {
         Builder = @(
             'implement', 'implementation', 'build', 'builder', 'fix', 'bug', 'patch',
             'code', 'coding', 'refactor', 'write', 'edit', 'change', 'feature',
-            'script', 'function', 'test', 'tests'
+            'script', 'function', 'test', 'tests',
+            '実装', '作って', '書いて', '修正', 'バグ', 'ビルド', 'コード', 'リファクタ', '機能'
         )
         Reviewer = @(
             'review', 'reviewer', 'audit', 'verify', 'verification', 'regression',
-            'security review', 'inspect', 'check', 'qa'
+            'security review', 'inspect', 'check', 'qa',
+            'レビュー', '確認', 'チェック', '検査', '監査'
         )
         Researcher = @(
             'research', 'researcher', 'investigate', 'investigation', 'analyze',
             'analysis', 'summarize', 'summary', 'explore', 'compare', 'find',
-            'lookup', 'document', 'docs'
+            'lookup', 'document', 'docs',
+            '調査', 'リサーチ', '分析', '探して', '比較', '要約', '検索'
         )
         Commander = @(
             'plan', 'planner', 'backlog', 'triage', 'coordinate', 'orchestrate',
-            'dispatch', 'assign', 'commit', 'merge', 'branch', 'release', 'session'
+            'dispatch', 'assign', 'commit', 'merge', 'branch', 'release', 'session',
+            'マージ', 'デプロイ', 'リリース', '承認', '計画'
         )
     }
 }
@@ -52,20 +56,21 @@ function Get-DispatchRouterKeywordMatches {
         [Parameter(Mandatory = $true)][string[]]$Keywords
     )
 
-    $matches = [System.Collections.Generic.List[string]]::new()
+    $foundKeywords = [System.Collections.Generic.List[string]]::new()
     foreach ($keyword in $Keywords) {
-        $pattern = if ($keyword.Contains(' ')) {
-            [regex]::Escape($keyword)
+        $escaped = [regex]::Escape($keyword)
+        $pattern = if ($keyword.Contains(' ') -or $keyword -match '[^\x00-\x7F]') {
+            $escaped
         } else {
-            '\b' + [regex]::Escape($keyword) + '\b'
+            '\b' + $escaped + '\b'
         }
 
         if ([regex]::IsMatch($Text, $pattern, [System.Text.RegularExpressions.RegexOptions]::IgnoreCase)) {
-            $matches.Add($keyword) | Out-Null
+            $foundKeywords.Add($keyword) | Out-Null
         }
     }
 
-    return @($matches)
+    return @($foundKeywords)
 }
 
 function Get-DispatchRouterPreferredLabel {

--- a/psmux-bridge/scripts/orchestra-start.ps1
+++ b/psmux-bridge/scripts/orchestra-start.ps1
@@ -657,7 +657,13 @@ try {
         Invoke-Psmux -Arguments @('kill-session', '-t', $sessionName)
     }
 
-    Invoke-Psmux -Arguments @('new-session', '-d', '-s', $sessionName)
+    $currentSessionOutput = Invoke-Psmux -Arguments @('display-message', '-p', '#{session_name}') -CaptureOutput
+    $currentSession = ($currentSessionOutput | Out-String).Trim()
+    if ([string]::IsNullOrWhiteSpace($currentSession)) {
+        Invoke-Psmux -Arguments @('new-session', '-d', '-s', $sessionName)
+    } else {
+        $sessionName = $currentSession
+    }
 
     foreach ($entry in $vaultValues.GetEnumerator()) {
         Invoke-Psmux -Arguments @('set-environment', '-t', $sessionName, $entry.Key, $entry.Value)

--- a/scripts/psmux-bridge.ps1
+++ b/scripts/psmux-bridge.ps1
@@ -1489,7 +1489,8 @@ switch ($Command) {
     'verify'          { Invoke-Verify }
     'dispatch-route'  {
         $routerScript = Join-Path $PSScriptRoot '..\psmux-bridge\scripts\dispatch-router.ps1'
-        & $routerScript -Text ($Rest -join ' ')
+        $fullText = @($Target) + @($Rest) | Where-Object { $_ } | ForEach-Object { $_.Trim() } | Where-Object { $_ }
+        & $routerScript -Text ($fullText -join ' ')
     }
     'vault'           {
         switch ($Target) {


### PR DESCRIPTION
Closes #129. Adds Japanese keywords, fixes word boundary for non-ASCII, fixes variable collision, re-applies session fix.