### PR TITLE
chore: gitignore .winsmux/, .tmp-appdata/, .tmp-settings/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,9 @@ package-lock.json
 # =========================
 .commander-prompt*.txt
 .orchestra-prompts/
+.winsmux/
+.tmp-appdata/
+.tmp-settings/
 
 # =========================
 # Claude Code / AI agent config


### PR DESCRIPTION
## Summary
- Add runtime directories to .gitignore to prevent accidental commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)