### PR TITLE
feat: v0.14.0 Tier 1 Hook activation + layout fix

### DIFF
--- a/.claude/hooks/lib/sh-utils.js
+++ b/.claude/hooks/lib/sh-utils.js
@@ -22,7 +22,12 @@ function deny(reason) {
   process.exit(2);
 }
 
-function allow() {
+function allow(additionalContext) {
+  if (additionalContext) {
+    process.stderr.write(
+      `${JSON.stringify({ hookSpecificOutput: { additionalContext } })}\n`,
+    );
+  }
   process.exit(0);
 }
 

--- a/.claude/hooks/sh-session-start.js
+++ b/.claude/hooks/sh-session-start.js
@@ -15,10 +15,15 @@ const {
   writeSession,
   appendEvidence,
 } = require("./lib/sh-utils");
-const { detectOpenShell } = require("./lib/openshell-detect");
-const { checkPolicyCompatibility } = require("./lib/policy-compat");
-const { checkPolicyDrift } = require("./lib/policy-drift");
-const { detectAutoMode } = require("./lib/automode-detect");
+// Enterprise libs — soft-disable with try-catch (Tier 3, not yet validated)
+let detectOpenShell = () => ({ available: false, reason: "module_not_loaded" });
+let checkPolicyCompatibility = () => ({ compatible: null, reason: "module_not_loaded" });
+let checkPolicyDrift = () => ({ has_drift: false, warnings: [] });
+let detectAutoMode = () => ({ detected: false, danger_level: "none", soft_deny_count: 0, soft_allow_count: 0 });
+try { detectOpenShell = require("./lib/openshell-detect").detectOpenShell; } catch {}
+try { checkPolicyCompatibility = require("./lib/policy-compat").checkPolicyCompatibility; } catch {}
+try { checkPolicyDrift = require("./lib/policy-drift").checkPolicyDrift; } catch {}
+try { detectAutoMode = require("./lib/automode-detect").detectAutoMode; } catch {}
 
 const HOOK_NAME = "sh-session-start";
 const CLAUDE_MD = "CLAUDE.md";

--- a/.claude/patterns/injection-patterns.json
+++ b/.claude/patterns/injection-patterns.json
@@ -1,0 +1,51 @@
+{
+  "categories": {
+    "instruction_override": {
+      "severity": "high",
+      "description": "Attempts to discard or override the active instruction hierarchy.",
+      "patterns": [
+        "ignore\\s+previous\\s+instructions",
+        "disregard.*(?:above|prior|previous)",
+        "forget.*(?:rules|instructions|guidelines)"
+      ]
+    },
+    "role_hijack": {
+      "severity": "high",
+      "description": "Attempts to redefine the assistant's role or identity.",
+      "patterns": [
+        "you\\s+are\\s+now",
+        "act\\s+as",
+        "pretend\\s+(?:to\\s+be|you(?:'re|\\s+are))",
+        "roleplay\\s+as"
+      ]
+    },
+    "prompt_extraction": {
+      "severity": "critical",
+      "description": "Attempts to extract system prompt, hidden instructions, or internal state.",
+      "patterns": [
+        "system\\s+prompt",
+        "reveal\\s+your",
+        "show\\s+(?:me\\s+)?your\\s+(?:instructions|prompt|rules)",
+        "what\\s+(?:are|were)\\s+your\\s+(?:instructions|rules)"
+      ]
+    },
+    "context_manipulation": {
+      "severity": "medium",
+      "description": "Indirect manipulation via fabricated context or authority claims.",
+      "patterns": [
+        "(?:previous|earlier)\\s+(?:context|conversation)\\s+(?:said|stated|indicated)",
+        "(?:user|admin|developer)\\s+(?:said|wants|requested)\\s+(?:you|to)"
+      ]
+    },
+    "encoding_evasion": {
+      "severity": "high",
+      "description": "Attempts to use encoding or eval to bypass security patterns.",
+      "patterns": [
+        "base64\\s+decode",
+        "eval\\s*\\(",
+        "\\\\x[0-9a-f]{2}",
+        "\\\\u[0-9a-f]{4}"
+      ]
+    }
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,60 @@
 {
   "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .claude/hooks/sh-session-start.js"
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .claude/hooks/sh-session-end.js"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .claude/hooks/sh-gate.js"
+          },
+          {
+            "type": "command",
+            "command": "node .claude/hooks/sh-injection-guard.js"
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|Write|Read|WebFetch",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .claude/hooks/sh-injection-guard.js"
+          }
+        ]
+      },
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .claude/hooks/sh-permission.js"
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "",
@@ -7,6 +62,10 @@
           {
             "type": "command",
             "command": "node .claude/hooks/sh-evidence.js"
+          },
+          {
+            "type": "command",
+            "command": "node .claude/hooks/sh-output-control.js"
           }
         ]
       }

--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ CLAUDE.md
 !.claude/CLAUDE.md
 !.claude/hooks/
 !.claude/settings.json
+!.claude/patterns/
 .codex/
 .gemini/
 *.local

--- a/psmux-bridge/scripts/orchestra-layout.ps1
+++ b/psmux-bridge/scripts/orchestra-layout.ps1
@@ -65,7 +65,7 @@ function Split-Equal {
 
     for ($i = 0; $i -lt ($PaneCount - 1); $i++) {
         $remaining = $PaneCount - $i
-        $percent = [int](100 * ($remaining - 1) / $remaining)
+        $percent = [int](100 / $remaining)
         & psmux split-window -t $Target $Direction -p $percent | Out-Null
         if ($LASTEXITCODE -ne 0) {
             throw "psmux split-window failed while creating $PaneCount panes in direction $Direction."


### PR DESCRIPTION
## Summary
- **TASK-092**: Tier 1 Hook 8本を settings.json に登録して稼働（session-start/end, gate, injection-guard, permission, output-control + 既存の evidence, orchestra-gate）
- **TASK-093**: injection-patterns.json を Array → Object with 5 categories (17 patterns) に変換
- **#151**: orchestra-layout.ps1 Split-Equal の割合計算式を修正（不均等ペイン解消）
- **Bug fix**: sh-utils.js `allow()` が additionalContext を無視していた問題を修正
- **Bug fix**: sh-session-start.js の enterprise lib 4本を try-catch で soft-disable

## Test plan
- [x] sh-gate: allow (ls) + deny (rm -rf /)
- [x] sh-injection-guard: allow (ls) + deny critical (system prompt) + deny high (ignore instructions)
- [x] sh-permission: category classification
- [x] sh-output-control: truncation + budget tracking
- [x] sh-session-start: context output via additionalContext
- [x] sh-session-end: session stats output
- [x] injection-patterns.json: 5 categories, 17 patterns loaded
- [x] orchestra-gate: restored and deny verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)