### PR TITLE
chore: sync ROADMAP after v0.14.0 release

### DIFF
--- a/docs/project/ROADMAP.md
+++ b/docs/project/ROADMAP.md
@@ -1,7 +1,7 @@
 # Roadmap
 
 > Auto-generated from `tasks/backlog.yaml` — do not edit manually.
-> Last sync: 2026-04-04 16:16 (+09:00)
+> Last sync: 2026-04-04 17:00 (+09:00)
 
 ## Version Summary
 


### PR DESCRIPTION
ROADMAP.md を v0.14.0 リリースに合わせて同期。