### PR TITLE
feat: v0.15.0 Tier 2 Hooks + Focus Policy + worktree cleanup

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -33,6 +33,14 @@
           {
             "type": "command",
             "command": "node .claude/hooks/sh-injection-guard.js"
+          },
+          {
+            "type": "command",
+            "command": "node .claude/hooks/sh-channel-detect.js"
+          },
+          {
+            "type": "command",
+            "command": "node .claude/hooks/sh-quiet-inject.js"
           }
         ]
       },
@@ -66,6 +74,81 @@
           {
             "type": "command",
             "command": "node .claude/hooks/sh-output-control.js"
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .claude/hooks/lint-on-save.js"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .claude/hooks/sh-user-prompt.js"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .claude/hooks/sh-circuit-breaker.js"
+          }
+        ]
+      }
+    ],
+    "SubagentStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .claude/hooks/sh-subagent.js"
+          }
+        ]
+      }
+    ],
+    "WorktreeCreate": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .claude/hooks/sh-worktree.js"
+          }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .claude/hooks/sh-precompact.js"
+          }
+        ]
+      }
+    ],
+    "PostCompact": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .claude/hooks/sh-postcompact.js"
           }
         ]
       }

--- a/psmux-bridge/scripts/orchestra-start.ps1
+++ b/psmux-bridge/scripts/orchestra-start.ps1
@@ -2,6 +2,7 @@ $ErrorActionPreference = 'Stop'
 $scriptDir = $PSScriptRoot
 . "$scriptDir/settings.ps1"
 . "$scriptDir/vault.ps1"
+. "$scriptDir/builder-worktree.ps1"
 . "$scriptDir/logger.ps1"
 
 Set-StrictMode -Version Latest
@@ -739,6 +740,21 @@ try {
     if ($LASTEXITCODE -eq 0) {
         Write-WinsmuxLog -Level INFO -Event 'preflight.session.kill' -Message "Removing existing session $sessionName." -Data @{ session_name = $sessionName } | Out-Null
         Invoke-Psmux -Arguments @('kill-session', '-t', $sessionName)
+    }
+
+    Write-WinsmuxLog -Level INFO -Event 'preflight.builder_worktree_cleanup.start' -Message 'Cleaning stale Builder worktrees.' | Out-Null
+    $builderCleanup = Invoke-StaleBuilderWorktreeCleanup -ProjectDir $projectDir
+    foreach ($removedWorktreePath in @($builderCleanup.RemovedWorktreePaths)) {
+        Write-Output "Preflight: removed stale Builder worktree $removedWorktreePath"
+        Write-WinsmuxLog -Level INFO -Event 'preflight.builder_worktree_cleanup.worktree_removed' -Message "Removed stale Builder worktree $removedWorktreePath." -Data @{ worktree_path = $removedWorktreePath } | Out-Null
+    }
+    foreach ($removedDirectoryPath in @($builderCleanup.RemovedDirectoryPaths)) {
+        Write-Output "Preflight: removed stale Builder directory $removedDirectoryPath"
+        Write-WinsmuxLog -Level INFO -Event 'preflight.builder_worktree_cleanup.directory_removed' -Message "Removed stale Builder directory $removedDirectoryPath." -Data @{ directory_path = $removedDirectoryPath } | Out-Null
+    }
+    foreach ($removedBranch in @($builderCleanup.RemovedBranches)) {
+        Write-Output "Preflight: removed stale Builder branch $removedBranch"
+        Write-WinsmuxLog -Level INFO -Event 'preflight.builder_worktree_cleanup.branch_removed' -Message "Removed stale Builder branch $removedBranch." -Data @{ branch_name = $removedBranch } | Out-Null
     }
 
     Write-WinsmuxLog -Level INFO -Event 'preflight.session.create' -Message "Creating session $sessionName." -Data @{ session_name = $sessionName } | Out-Null

--- a/scripts/psmux-bridge.ps1
+++ b/scripts/psmux-bridge.ps1
@@ -13,6 +13,7 @@ $ErrorActionPreference = 'Stop'
 $ReadMarkDir    = Join-Path $env:TEMP "winsmux\read_marks"
 $WatermarkDir   = Join-Path $env:TEMP "winsmux\watermarks"
 $LockDir        = Join-Path $env:TEMP "winsmux\locks"
+$FocusPolicyFile = Join-Path $env:TEMP "winsmux\focus-policy-stack.json"
 $LabelsFile     = Join-Path $env:APPDATA "winsmux\labels.json"
 
 # --- Windows Credential Manager P/Invoke ---
@@ -268,6 +269,108 @@ function Get-PaneSnapshotText {
 
     $output = & psmux capture-pane -t $PaneId -p -J -S "-$Lines"
     return ($output | Out-String).TrimEnd()
+}
+
+# --- Helper: Focus Policy Stack ---
+function Get-FocusPolicyStack {
+    if (-not (Test-Path $FocusPolicyFile)) {
+        return @()
+    }
+
+    $raw = Get-Content -Path $FocusPolicyFile -Raw -Encoding UTF8
+    if ([string]::IsNullOrWhiteSpace($raw)) {
+        return @()
+    }
+
+    try {
+        $parsed = $raw | ConvertFrom-Json -ErrorAction Stop
+    } catch {
+        Stop-WithError "invalid focus policy stack: $FocusPolicyFile"
+    }
+
+    if ($parsed -is [System.Array]) {
+        return @($parsed)
+    }
+
+    return @($parsed)
+}
+
+function Save-FocusPolicyStack {
+    param([object[]]$Stack)
+
+    $dir = Split-Path $FocusPolicyFile -Parent
+    if (-not (Test-Path $dir)) {
+        New-Item -ItemType Directory -Path $dir -Force | Out-Null
+    }
+
+    if ($null -eq $Stack -or $Stack.Count -eq 0) {
+        if (Test-Path $FocusPolicyFile) {
+            Remove-Item -Path $FocusPolicyFile -Force
+        }
+        return
+    }
+
+    $Stack | ConvertTo-Json -Depth 4 | Set-Content -Path $FocusPolicyFile -Encoding UTF8
+}
+
+function Get-ActiveFocusPolicy {
+    $stack = Get-FocusPolicyStack
+    if (-not $stack -or $stack.Count -eq 0) {
+        return $null
+    }
+
+    return $stack[$stack.Count - 1]
+}
+
+function Push-FocusPolicy {
+    param(
+        [string]$PaneId,
+        [string]$TargetName
+    )
+
+    $stack = @(Get-FocusPolicyStack)
+    $entry = [PSCustomObject]@{
+        paneId      = $PaneId
+        target      = $TargetName
+        lockedBy    = $env:WINSMUX_PANE_ID
+        lockedAt    = (Get-Date).ToString("o")
+    }
+
+    $stack += $entry
+    Save-FocusPolicyStack -Stack $stack
+    return $entry
+}
+
+function Pop-FocusPolicy {
+    $stack = @(Get-FocusPolicyStack)
+    if (-not $stack -or $stack.Count -eq 0) {
+        return $null
+    }
+
+    $entry = $stack[$stack.Count - 1]
+    if ($stack.Count -eq 1) {
+        Save-FocusPolicyStack -Stack @()
+    } else {
+        Save-FocusPolicyStack -Stack $stack[0..($stack.Count - 2)]
+    }
+
+    return $entry
+}
+
+function Assert-FocusAllowed {
+    param(
+        [string]$PaneId,
+        [string]$RawTarget
+    )
+
+    $policy = Get-ActiveFocusPolicy
+    if ($null -eq $policy) {
+        return
+    }
+
+    if ($policy.paneId -ne $PaneId) {
+        Stop-WithError "focus denied: locked to $($policy.paneId) ($($policy.target)). Run: psmux-bridge focus-unlock"
+    }
 }
 
 # --- Helper: File Locks ---
@@ -1176,13 +1279,47 @@ function Invoke-HealthCheck {
 }
 
 function Invoke-Focus {
-    if (-not $Target) { Stop-WithError "usage: psmux-bridge focus <label|target>" }
+    param([string]$FocusTarget = $Target)
 
-    $paneId = Resolve-Target $Target
+    if (-not $FocusTarget) { Stop-WithError "usage: psmux-bridge focus <label|target>" }
+
+    $paneId = Resolve-Target $FocusTarget
     $paneId = Confirm-Target $paneId
+    Assert-FocusAllowed -PaneId $paneId -RawTarget $FocusTarget
 
     & psmux select-pane -t $paneId
-    Write-Output "Focused pane $paneId ($Target)"
+    Write-Output "Focused pane $paneId ($FocusTarget)"
+}
+
+function Invoke-FocusLock {
+    param([string]$FocusTarget = $Target)
+
+    if (-not $FocusTarget) { Stop-WithError "usage: psmux-bridge focus-lock <label|target>" }
+
+    $paneId = Resolve-Target $FocusTarget
+    $paneId = Confirm-Target $paneId
+    $entry = Push-FocusPolicy -PaneId $paneId -TargetName $FocusTarget
+
+    Write-Output "Focus locked to $($entry.paneId) ($($entry.target))"
+}
+
+function Invoke-FocusUnlock {
+    param(
+        [string]$FocusTarget = $Target,
+        [string[]]$ExtraArgs = $Rest
+    )
+
+    if ($FocusTarget -or ($ExtraArgs -and $ExtraArgs.Count -gt 0)) {
+        Stop-WithError "usage: psmux-bridge focus-unlock"
+    }
+
+    $entry = Pop-FocusPolicy
+    if ($null -eq $entry) {
+        Write-Output "(no focus lock)"
+        return
+    }
+
+    Write-Output "Focus unlocked $($entry.paneId) ($($entry.target))"
 }
 
 function Invoke-Profile {
@@ -1408,6 +1545,8 @@ Commands:
   image-paste <target>      Save clipboard image and send path to pane
   clipboard-paste <target>  Send clipboard text to pane
   focus <label|target>      Switch active pane (use from outside psmux)
+  focus-lock <target>       Push a focus lock for a pane target
+  focus-unlock              Pop the latest focus lock
   lock <label> <file>...    Acquire file lock(s) for a label
   unlock <label> <file>...  Release file lock(s) for a label
   locks                     List active file locks
@@ -1555,6 +1694,8 @@ switch ($Command) {
     'image-paste'     { Invoke-ImagePaste }
     'clipboard-paste' { Invoke-ClipboardPaste }
     'focus'           { Invoke-Focus }
+    'focus-lock'      { Invoke-FocusLock }
+    'focus-unlock'    { Invoke-FocusUnlock }
     'lock'            { Invoke-Lock }
     'unlock'          { Invoke-Unlock }
     'locks'           { Invoke-Locks }


### PR DESCRIPTION
## Summary
- **TASK-094**: Tier 2 Hook 9本を settings.json に登録（全17本稼働）
- **TASK-095**: Focus Policy Stack (focus-lock/focus-unlock) 実装
- **TASK-096**: stale worktree 自動クリーンアップを orchestra-start preflight に追加

## Test plan
- [x] 9本の Hook 個別テスト通過（allow/deny/context出力確認）
- [x] settings.json JSON バリデーション
- [x] orchestra-start.ps1 構文チェック
- [x] psmux-bridge.ps1 構文チェック
- [ ] Pester 33 テスト

🤖 Generated with [Claude Code](https://claude.com/claude-code)