### PR TITLE
feat: v0.16.0 — channel boost, evidence trace, readiness, role fix

### DIFF
--- a/.claude/hooks/sh-evidence.js
+++ b/.claude/hooks/sh-evidence.js
@@ -1,11 +1,18 @@
+#!/usr/bin/env node
+"use strict";
+
 const fs = require("fs");
 const path = require("path");
 
 const { allow, readStdin, sha256 } = require("./lib/sh-utils");
 
 const ROOT_DIR = path.resolve(__dirname, "..", "..");
-const LEDGER_PATH = path.join(ROOT_DIR, ".claude", "logs", "evidence-ledger.jsonl");
-const SESSION_PATH = path.join(ROOT_DIR, ".shield-harness", "session.json");
+const DEFAULT_LEDGER_PATH = path.join(ROOT_DIR, ".claude", "logs", "evidence-ledger.jsonl");
+const DEFAULT_SESSION_PATH = path.join(ROOT_DIR, ".shield-harness", "session.json");
+const LEDGER_PATH = process.env.SH_EVIDENCE_LEDGER_PATH || DEFAULT_LEDGER_PATH;
+const SESSION_PATH = process.env.SH_EVIDENCE_SESSION_PATH || DEFAULT_SESSION_PATH;
+const HOOK_NAME = "sh-evidence";
+const MAX_TRACE_SEGMENTS = 5;
 const SECRET_PATTERNS = [/\bgho_[A-Za-z0-9_]+\b/g, /\bghp_[A-Za-z0-9_]+\b/g, /\bsk-[A-Za-z0-9_-]+\b/g];
 
 function sanitizeValue(value) {
@@ -29,10 +36,34 @@ function sanitizeValue(value) {
   return value;
 }
 
+function pickField(payload, camelKey, snakeKey, fallback = null) {
+  if (!payload || typeof payload !== "object") {
+    return fallback;
+  }
+
+  if (payload[camelKey] !== undefined) {
+    return payload[camelKey];
+  }
+
+  if (payload[snakeKey] !== undefined) {
+    return payload[snakeKey];
+  }
+
+  return fallback;
+}
+
+function normalizeText(value, limit = 200) {
+  return String(value || "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, limit);
+}
+
 function summarizeResult(payload) {
+  const toolResult = pickField(payload, "toolResult", "tool_result");
   const candidate =
-    payload.tool_result ??
-    payload.tool_output ??
+    toolResult ??
+    pickField(payload, "toolOutput", "tool_output") ??
     payload.result ??
     payload.output ??
     payload.stdout ??
@@ -44,7 +75,7 @@ function summarizeResult(payload) {
       ? candidate
       : JSON.stringify(candidate);
 
-  return (text || "").replace(/\s+/g, " ").slice(0, 200);
+  return normalizeText(text, 200);
 }
 
 function readSession() {
@@ -59,45 +90,239 @@ function readSession() {
   }
 }
 
-function getPreviousHash() {
-  if (!fs.existsSync(LEDGER_PATH)) {
-    return "genesis";
+function splitCommandSegments(command) {
+  if (typeof command !== "string" || command.trim() === "") {
+    return [];
   }
 
-  try {
-    const lines = fs
-      .readFileSync(LEDGER_PATH, "utf8")
-      .split(/\r?\n/)
-      .map((line) => line.trim())
-      .filter(Boolean);
+  const segments = [];
+  let current = "";
+  let quote = null;
+  let escapeNext = false;
 
-    if (lines.length === 0) {
-      return "genesis";
+  const pushCurrent = () => {
+    const trimmed = current.trim();
+    if (trimmed) {
+      segments.push(trimmed);
+    }
+    current = "";
+  };
+
+  for (let index = 0; index < command.length; index += 1) {
+    const char = command[index];
+    const pair = command.slice(index, index + 2);
+
+    if (escapeNext) {
+      current += char;
+      escapeNext = false;
+      continue;
     }
 
-    const lastEntry = JSON.parse(lines.at(-1));
-    return typeof lastEntry.hash === "string" && lastEntry.hash ? lastEntry.hash : "genesis";
-  } catch {
-    return "genesis";
+    if (char === "\\" && quote !== "'") {
+      current += char;
+      escapeNext = true;
+      continue;
+    }
+
+    if (quote) {
+      current += char;
+      if (char === quote) {
+        quote = null;
+      }
+      continue;
+    }
+
+    if (char === "'" || char === '"' || char === "`") {
+      quote = char;
+      current += char;
+      continue;
+    }
+
+    if (pair === "&&" || pair === "||") {
+      pushCurrent();
+      index += 1;
+      continue;
+    }
+
+    if (char === "|" || char === ";") {
+      pushCurrent();
+      continue;
+    }
+
+    current += char;
   }
+
+  pushCurrent();
+
+  return segments;
+}
+
+function resolveExitCode(payload, toolResult) {
+  const directExitCode = pickField(payload, "exitCode", "exit_code");
+  if (typeof directExitCode === "number") {
+    return directExitCode;
+  }
+
+  if (toolResult && typeof toolResult === "object") {
+    const nestedExitCode = pickField(toolResult, "exitCode", "exit_code");
+    if (typeof nestedExitCode === "number") {
+      return nestedExitCode;
+    }
+
+    const status = pickField(toolResult, "status", "status");
+    if (typeof status === "number") {
+      return status;
+    }
+  }
+
+  return null;
+}
+
+function extractCommandTrace(toolName, toolInput, payload) {
+  if (toolName !== "Bash" || !toolInput || typeof toolInput !== "object") {
+    return null;
+  }
+
+  const rawCommand =
+    typeof toolInput.command === "string" ? toolInput.command.trim() : "";
+  if (!rawCommand) {
+    return null;
+  }
+
+  const command = sanitizeValue(rawCommand);
+  const segments = splitCommandSegments(command);
+  const toolResult = pickField(payload, "toolResult", "tool_result");
+
+  return {
+    shell: "Bash",
+    command_hash: sha256(command),
+    command_preview: normalizeText(command, 200),
+    segment_count: segments.length,
+    segments: segments
+      .slice(0, MAX_TRACE_SEGMENTS)
+      .map((segment) => normalizeText(segment, 160)),
+    truncated: segments.length > MAX_TRACE_SEGMENTS,
+    working_directory: sanitizeValue(toolInput.cwd ?? toolInput.workdir ?? null),
+    exit_code: resolveExitCode(payload, toolResult),
+  };
+}
+
+function computeEntryHash(entry, impliedPreviousHash = "genesis") {
+  const candidate =
+    entry && typeof entry === "object" && !Array.isArray(entry) ? { ...entry } : {};
+  const previousHash =
+    typeof candidate.previous_hash === "string" && candidate.previous_hash
+      ? candidate.previous_hash
+      : impliedPreviousHash;
+
+  delete candidate.hash;
+  return sha256(previousHash + JSON.stringify(candidate));
+}
+
+function readLedgerLines() {
+  if (!fs.existsSync(LEDGER_PATH)) {
+    return [];
+  }
+
+  return fs
+    .readFileSync(LEDGER_PATH, "utf8")
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+function verifyLedgerIntegrity() {
+  const lines = readLedgerLines();
+  if (lines.length === 0) {
+    return { valid: true, entries_checked: 0, last_hash: "genesis", issue: null };
+  }
+
+  let previousHash = "genesis";
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const lineNumber = index + 1;
+    let entry;
+
+    try {
+      entry = JSON.parse(lines[index]);
+    } catch {
+      return {
+        valid: false,
+        entries_checked: index,
+        last_hash: previousHash,
+        issue: `Malformed JSON at line ${lineNumber}`,
+      };
+    }
+
+    const declaredPreviousHash =
+      typeof entry.previous_hash === "string" && entry.previous_hash
+        ? entry.previous_hash
+        : previousHash;
+
+    if (declaredPreviousHash !== previousHash) {
+      return {
+        valid: false,
+        entries_checked: index,
+        last_hash: previousHash,
+        issue: `previous_hash mismatch at line ${lineNumber}`,
+      };
+    }
+
+    const expectedHash = computeEntryHash(entry, previousHash);
+    if (entry.hash !== expectedHash) {
+      return {
+        valid: false,
+        entries_checked: index,
+        last_hash: previousHash,
+        issue: `hash mismatch at line ${lineNumber}`,
+      };
+    }
+
+    previousHash = entry.hash;
+  }
+
+  return {
+    valid: true,
+    entries_checked: lines.length,
+    last_hash: previousHash,
+    issue: null,
+  };
 }
 
 function buildEntry(payload) {
   const session = readSession();
+  const toolName = pickField(payload, "toolName", "tool_name");
+  const toolInput = sanitizeValue(pickField(payload, "toolInput", "tool_input", {}));
+  const integrityCheck = verifyLedgerIntegrity();
+  const recordedAt = new Date().toISOString();
   const entry = {
-    timestamp: new Date().toISOString(),
-    tool_name: payload.tool_name ?? null,
-    tool_input: sanitizeValue(payload.tool_input ?? {}),
+    hook: HOOK_NAME,
+    event: "PostToolUse",
+    decision: "allow",
+    recorded_at: recordedAt,
+    timestamp: recordedAt,
+    tool: toolName ?? null,
+    tool_name: toolName ?? null,
+    tool_input: toolInput,
     result_summary: summarizeResult(payload),
     session_id: session.session_id ?? session.id ?? null,
     is_channel: session.source === "channel",
+    command_trace: extractCommandTrace(toolName, toolInput, payload),
+    integrity_check: {
+      valid: integrityCheck.valid,
+      entries_checked: integrityCheck.entries_checked,
+      issue: integrityCheck.issue,
+    },
   };
-  const previousHash = getPreviousHash();
-  const entryJson = JSON.stringify(entry);
+  const previousHash = integrityCheck.last_hash || "genesis";
+  const entryWithPreviousHash = {
+    ...entry,
+    previous_hash: previousHash,
+  };
 
   return {
-    ...entry,
-    hash: sha256(previousHash + entryJson),
+    ...entryWithPreviousHash,
+    hash: computeEntryHash(entryWithPreviousHash, previousHash),
   };
 }
 
@@ -118,4 +343,19 @@ function main() {
   allow();
 }
 
-main();
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  DEFAULT_LEDGER_PATH,
+  DEFAULT_SESSION_PATH,
+  HOOK_NAME,
+  sanitizeValue,
+  summarizeResult,
+  splitCommandSegments,
+  extractCommandTrace,
+  computeEntryHash,
+  verifyLedgerIntegrity,
+  buildEntry,
+};

--- a/.claude/hooks/sh-user-prompt.js
+++ b/.claude/hooks/sh-user-prompt.js
@@ -1,48 +1,39 @@
-const fs = require('fs');
-const path = require('path');
+#!/usr/bin/env node
+"use strict";
 
-const SEVERITY_ORDER = ['low', 'medium', 'high', 'critical'];
-const CHANNEL_TAG_RE = /<channel\s+source="(telegram|discord)">/i;
-const PATTERNS_PATH = path.join(__dirname, '..', 'patterns', 'injection-patterns.json');
+const {
+  readHookInput,
+  allow,
+  loadPatterns,
+  nfkcNormalize,
+} = require("./lib/sh-utils");
 
-function readStdin() {
-  return new Promise((resolve, reject) => {
-    let data = '';
-    process.stdin.setEncoding('utf8');
-    process.stdin.on('data', (chunk) => {
-      data += chunk;
-    });
-    process.stdin.on('end', () => resolve(data));
-    process.stdin.on('error', reject);
-  });
-}
-
-function loadPatterns(filePath) {
-  if (!fs.existsSync(filePath)) {
-    return [];
-  }
-
-  try {
-    const raw = fs.readFileSync(filePath, 'utf8');
-    const parsed = JSON.parse(raw);
-    return Array.isArray(parsed) ? parsed : [];
-  } catch {
-    return [];
-  }
-}
+const SEVERITY_ORDER = ["low", "medium", "high", "critical"];
+const CHANNEL_MARKERS = [
+  /<channel\b[^>]*\bsource\s*=\s*["']?(telegram|discord|channel)["']?[^>]*>/i,
+  /\b(?:chat_id|message_id|thread_id|server_id)\b/i,
+  /\b(?:telegram|discord)\b/i,
+  /\bsource\s*[:=]\s*["']?(telegram|discord|channel)\b/i,
+  /"source"\s*:\s*"(telegram|discord|channel)"/i,
+];
+const EVENT_MARKERS = [
+  /<event\b/i,
+  /\bevent(?:_type)?\b\s*[:=]/i,
+  /"event(?:_type)?"\s*:\s*"/i,
+];
 
 function toSeverityIndex(severity) {
   const index = SEVERITY_ORDER.indexOf(String(severity).toLowerCase());
-  return index === -1 ? SEVERITY_ORDER.indexOf('medium') : index;
+  return index === -1 ? SEVERITY_ORDER.indexOf("medium") : index;
 }
 
-function boostSeverity(severity) {
+function boostSeverity(severity, levels = 1) {
   const index = toSeverityIndex(severity);
-  return SEVERITY_ORDER[Math.min(index + 1, SEVERITY_ORDER.length - 1)];
+  return SEVERITY_ORDER[Math.min(index + Math.max(levels, 0), SEVERITY_ORDER.length - 1)];
 }
 
 function compilePattern(pattern) {
-  if (typeof pattern !== 'string' || pattern.length === 0) {
+  if (typeof pattern !== "string" || pattern.length === 0) {
     return null;
   }
 
@@ -56,19 +47,66 @@ function compilePattern(pattern) {
   }
 
   try {
-    return new RegExp(pattern, 'i');
+    return new RegExp(pattern, "i");
   } catch {
     return null;
   }
 }
 
-async function main() {
-  const rawInput = await readStdin();
-  const parsedInput = rawInput ? JSON.parse(rawInput) : {};
-  const prompt = typeof parsedInput.prompt === 'string' ? parsedInput.prompt : '';
-  const normalizedPrompt = prompt.normalize('NFKC');
-  const isChannel = CHANNEL_TAG_RE.test(prompt);
-  const patterns = loadPatterns(PATTERNS_PATH);
+function flattenPatterns(patternConfig) {
+  if (!patternConfig || typeof patternConfig !== "object" || !patternConfig.categories) {
+    return [];
+  }
+
+  const entries = [];
+  for (const [categoryName, category] of Object.entries(patternConfig.categories)) {
+    const patterns = Array.isArray(category.patterns) ? category.patterns : [];
+    const severity = String(category.severity || "medium").toLowerCase();
+    for (const pattern of patterns) {
+      entries.push({
+        category: categoryName,
+        severity,
+        pattern,
+      });
+    }
+  }
+  return entries;
+}
+
+function hasMarker(text, patterns) {
+  return patterns.some((pattern) => pattern.test(text));
+}
+
+function detectPromptContext(input, prompt) {
+  const normalizedPrompt = nfkcNormalize(prompt || "");
+  const metadata = nfkcNormalize(JSON.stringify(input || {}));
+  const combined = [normalizedPrompt, metadata].filter(Boolean).join("\n");
+  const isChannel = hasMarker(combined, CHANNEL_MARKERS);
+  const isChannelEvent = isChannel && hasMarker(combined, EVENT_MARKERS);
+  return { normalizedPrompt, isChannel, isChannelEvent };
+}
+
+function resolveSeverity(baseSeverity, promptContext) {
+  let boostCount = 0;
+  if (promptContext.isChannel) {
+    boostCount += 1;
+  }
+  if (promptContext.isChannelEvent) {
+    boostCount += 1;
+  }
+  return boostSeverity(baseSeverity, boostCount);
+}
+
+function writeDeny(decision) {
+  process.stdout.write(`${JSON.stringify(decision)}\n`);
+  process.exit(2);
+}
+
+function main() {
+  const input = readHookInput();
+  const prompt = typeof input.prompt === "string" ? input.prompt : "";
+  const { normalizedPrompt, isChannel, isChannelEvent } = detectPromptContext(input, prompt);
+  const patterns = flattenPatterns(loadPatterns());
 
   let matchedDecision = null;
 
@@ -78,30 +116,48 @@ async function main() {
       continue;
     }
 
-    const baseSeverity = String(entry.severity || 'medium').toLowerCase();
-    const severity = isChannel ? boostSeverity(baseSeverity) : SEVERITY_ORDER[toSeverityIndex(baseSeverity)];
-
+    const severity = resolveSeverity(entry.severity, { isChannel, isChannelEvent });
     if (!matchedDecision || toSeverityIndex(severity) > toSeverityIndex(matchedDecision.severity)) {
       matchedDecision = {
+        category: entry.category,
         pattern: entry.pattern,
         severity,
       };
     }
   }
 
-  if (matchedDecision && toSeverityIndex(matchedDecision.severity) >= toSeverityIndex('high')) {
-    process.stdout.write(
-      JSON.stringify({
-        result: 'deny',
-        reason: 'Injection pattern detected',
-        pattern: matchedDecision.pattern,
-        severity: matchedDecision.severity,
-      })
-    );
-    process.exit(2);
+  if (matchedDecision && toSeverityIndex(matchedDecision.severity) >= toSeverityIndex("high")) {
+    writeDeny({
+      decision: "deny",
+      result: "deny",
+      reason: "Injection pattern detected",
+      category: matchedDecision.category,
+      pattern: matchedDecision.pattern,
+      severity: matchedDecision.severity,
+    });
+    return;
+  }
+
+  allow();
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch {
+    allow();
   }
 }
 
-main().catch(() => {
-  process.exit(0);
-});
+module.exports = {
+  CHANNEL_MARKERS,
+  EVENT_MARKERS,
+  SEVERITY_ORDER,
+  toSeverityIndex,
+  boostSeverity,
+  compilePattern,
+  flattenPatterns,
+  detectPromptContext,
+  resolveSeverity,
+  writeDeny,
+};

--- a/psmux-bridge/scripts/agent-readiness.ps1
+++ b/psmux-bridge/scripts/agent-readiness.ps1
@@ -1,0 +1,126 @@
+$script:AgentReadinessPromptMarkers = @(
+    '>',
+    ([string][char]8250),
+    ([string][char]0x258C)
+)
+
+function Get-LastNonEmptyLine {
+    param([AllowNull()][string]$Text)
+
+    if ([string]::IsNullOrWhiteSpace($Text)) {
+        return $null
+    }
+
+    $lines = $Text -split "\r?\n"
+    for ($index = $lines.Length - 1; $index -ge 0; $index--) {
+        $line = $lines[$index]
+        if (-not [string]::IsNullOrWhiteSpace($line)) {
+            return $line
+        }
+    }
+
+    return $null
+}
+
+function Get-RecentNonEmptyLines {
+    param(
+        [AllowNull()][string]$Text,
+        [int]$MaxCount = 8
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Text) -or $MaxCount -lt 1) {
+        return @()
+    }
+
+    $lines = $Text -split "\r?\n"
+    $recent = [System.Collections.Generic.List[string]]::new()
+
+    for ($index = $lines.Length - 1; $index -ge 0 -and $recent.Count -lt $MaxCount; $index--) {
+        $line = $lines[$index]
+        if (-not [string]::IsNullOrWhiteSpace($line)) {
+            $recent.Insert(0, $line)
+        }
+    }
+
+    return @($recent)
+}
+
+function Test-AgentPromptText {
+    param(
+        [AllowNull()][string]$Text,
+        [Parameter(Mandatory = $true)][string]$Agent
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Text)) {
+        return $false
+    }
+
+    $agentName = $Agent.Trim().ToLowerInvariant()
+    $recentLines = @(Get-RecentNonEmptyLines -Text $Text -MaxCount 8)
+    if ($recentLines.Count -eq 0) {
+        return $false
+    }
+
+    $tailText = $recentLines -join [Environment]::NewLine
+    $blockedPatterns = @(
+        '(?im)\bmissing api key\b',
+        '(?im)\brun /login\b',
+        '(?im)\bunable to connect\b',
+        '(?im)\bfailed to connect\b'
+    )
+
+    foreach ($pattern in $blockedPatterns) {
+        if ($tailText -match $pattern) {
+            return $false
+        }
+    }
+
+    foreach ($line in $recentLines) {
+        $trimmed = $line.TrimStart()
+        foreach ($marker in $script:AgentReadinessPromptMarkers) {
+            if ($trimmed.StartsWith($marker)) {
+                return $true
+            }
+        }
+    }
+
+    switch ($agentName) {
+        'codex' {
+            if ($tailText -match '(?im)\b(?:gpt|codex|gpt-oss|o[0-9])[A-Za-z0-9._/-]*\b.*\b\d+%\s+(?:context\s+)?left\b') {
+                return $true
+            }
+
+            if ($tailText -match '(?im)\b(?:tokens used|context left)\b' -and $tailText -match '⏎\s*send') {
+                return $true
+            }
+        }
+        'claude' {
+            if ($tailText -match '(?im)\bWelcome to Claude Code!?') {
+                return $true
+            }
+
+            if ($tailText -match '(?im)/help for help,\s*/status for your current setup') {
+                return $true
+            }
+
+            if ($tailText -match '(?im)\?\s+for shortcuts\b') {
+                return $true
+            }
+        }
+        'gemini' {
+            if ($tailText -match '(?im)\bType your message(?:\s+or\s+@path/to/file)?\b') {
+                return $true
+            }
+
+            if ($tailText -match '(?im)\bUsing:\s+\d+\s+GEMINI\.md\s+file') {
+                return $true
+            }
+
+            if ($tailText -match '(?im)\bgemini-[A-Za-z0-9._-]+\b.*\b\d+%\s+context\s+left\b') {
+                return $true
+            }
+        }
+    }
+
+    return $false
+}

--- a/psmux-bridge/scripts/orchestra-start.ps1
+++ b/psmux-bridge/scripts/orchestra-start.ps1
@@ -4,6 +4,7 @@ $scriptDir = $PSScriptRoot
 . "$scriptDir/vault.ps1"
 . "$scriptDir/builder-worktree.ps1"
 . "$scriptDir/logger.ps1"
+. "$scriptDir/agent-readiness.ps1"
 
 Set-StrictMode -Version Latest
 [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
@@ -526,23 +527,6 @@ function Invoke-ShieldHarnessInit {
     Write-WinsmuxLog -Level INFO -Event 'preflight.shield_harness.init' -Message "Shield-Harness initialized at $shDir." -Data @{ shield_dir = $shDir } | Out-Null
 }
 
-function Get-LastNonEmptyLine {
-    param([AllowNull()][string]$Text)
-
-    if ([string]::IsNullOrWhiteSpace($Text)) {
-        return $null
-    }
-
-    $lines = $Text -split "\r?\n"
-    for ($index = $lines.Length - 1; $index -ge 0; $index--) {
-        if (-not [string]::IsNullOrWhiteSpace($lines[$index])) {
-            return $lines[$index]
-        }
-    }
-
-    return $null
-}
-
 function Get-TailPreview {
     param([AllowNull()][string]$Text, [int]$LineCount = 12)
 
@@ -653,30 +637,6 @@ function Save-OrchestraSessionState {
 
     Set-Content -Path $manifestPath -Value ($lines -join [Environment]::NewLine) -Encoding UTF8 -NoNewline
     return $manifestPath
-}
-
-function Test-AgentPromptText {
-    param(
-        [AllowNull()][string]$Text,
-        [Parameter(Mandatory = $true)][string]$Agent
-    )
-
-    $lastLine = Get-LastNonEmptyLine -Text $Text
-    if ($null -eq $lastLine) {
-        return $false
-    }
-
-    $trimmed = $lastLine.TrimStart()
-    $rightChevron = [string][char]8250
-    if ($trimmed.StartsWith('>') -or $trimmed.StartsWith($rightChevron)) {
-        return $true
-    }
-
-    if ($Agent.Trim().ToLowerInvariant() -eq 'codex' -and $Text -match '(?im)\bgpt-[A-Za-z0-9._-]+\b.*\b\d+% left\b') {
-        return $true
-    }
-
-    return $false
 }
 
 function Wait-AgentReady {

--- a/scripts/psmux-bridge.ps1
+++ b/scripts/psmux-bridge.ps1
@@ -791,15 +791,7 @@ function Invoke-Role {
     while ("$newRole-$nextNum" -in $existingLabels) { $nextNum++ }
     $newLabel = "$newRole-$nextNum"
 
-    # Kill current agent (Ctrl+C twice, then exit)
-    & psmux send-keys -t $paneId C-c
-    Start-Sleep -Milliseconds 300
-    & psmux send-keys -t $paneId C-c
-    Start-Sleep -Milliseconds 500
-    & psmux send-keys -t $paneId 'exit' Enter
-    Start-Sleep -Seconds 2
-
-    # Rename pane
+    # Rename pane first (before respawn)
     & psmux select-pane -t $paneId -T $newLabel
 
     # Update labels
@@ -807,7 +799,7 @@ function Invoke-Role {
     if ($labels.ContainsKey($oldLabel)) { $labels.Remove($oldLabel) }
     Save-Labels $labels
 
-    # Respawn pane
+    # Respawn pane (kills current process + restarts shell in one step, #174)
     & psmux respawn-pane -k -t $paneId
 
     # Wait for shell ready (poll for PS prompt)


### PR DESCRIPTION
## Summary
- TASK-030: sh-user-prompt channel severity boost
- TASK-031: evidence-ledger command_trace recording
- TASK-036: agent-readiness拡張 (Claude/Gemini/generic)
- #174: role switch respawn-pane -k直接使用 (Ctrl+C/exit race解消)

## Reviewer指摘 (後続対応)
- TASK-030: channel警告メッセージ未出力、変更が最小でない

## Test plan
- [x] sh-user-prompt exit 0
- [x] sh-evidence command_trace=True
- [x] orchestra-start.ps1 構文OK
- [x] psmux-bridge.ps1 #174修正

🤖 Generated with [Claude Code](https://claude.com/claude-code)