### PR TITLE
fix: git add -f for gitignored backlog/ROADMAP (#185)

### DIFF
--- a/scripts/bump-version.ps1
+++ b/scripts/bump-version.ps1
@@ -297,7 +297,7 @@ try {
         }
         Write-Host "[release] ROADMAP refreshed after backlog update"
 
-        git add -- "tasks/backlog.yaml" "docs/project/ROADMAP.md"
+        git add -f -- "tasks/backlog.yaml" "docs/project/ROADMAP.md"
         git diff --cached --quiet -- "tasks/backlog.yaml" "docs/project/ROADMAP.md"
         if ($LASTEXITCODE -ne 0) {
             git commit -m "chore: close release task for $Version"


### PR DESCRIPTION
gitignoreされたファイルのgit addに-fフラグ追加。Closes #185