### PR TITLE
fix: zombie cleanup pipeline pollution (#235)

### DIFF
--- a/psmux-bridge/scripts/orchestra-preflight.ps1
+++ b/psmux-bridge/scripts/orchestra-preflight.ps1
@@ -250,7 +250,7 @@ function Remove-OrchestraZombieProcesses {
         try {
             Stop-Process -Id ([int]$victim.ProcessId) -Force -ErrorAction Stop
             $killed.Add($victim) | Out-Null
-            Write-Output ("Preflight: killed zombie process {0} ({1})" -f $victim.Name, $victim.ProcessId)
+            Write-Host ("Preflight: killed zombie process {0} ({1})" -f $victim.Name, $victim.ProcessId)
             Write-WinsmuxLog -Level INFO -Event 'preflight.zombie_process.killed' -Message ("Killed zombie process {0} ({1})." -f $victim.Name, $victim.ProcessId) -Data @{ process_name = $victim.Name; process_id = [int]$victim.ProcessId } | Out-Null
         } catch {
             Write-Warning ("Preflight: failed to kill zombie process {0} ({1}): {2}" -f $victim.Name, $victim.ProcessId, $_.Exception.Message)


### PR DESCRIPTION
## Summary
- `Remove-OrchestraZombieProcesses` の `Write-Output` を `Write-Host` に変更
- `Write-Output` がパイプラインを汚染し、戻り値が `[string, PSCustomObject]` 配列になっていた
- `StrictMode -Version Latest` 下で `.Killed` プロパティアクセスが失敗 → orchestra-start クラッシュ

## Test plan
- [ ] ゾンビプロセスがある状態で `orchestra-start.ps1` を実行し、クラッシュしないことを確認
- [ ] ゾンビがない状態でも正常に起動することを確認

Closes #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)