### PR TITLE
chore: add TASK-142..147 to backlog + sync ROADMAP

### DIFF
--- a/docs/project/ROADMAP.md
+++ b/docs/project/ROADMAP.md
@@ -1,7 +1,7 @@
 # ロードマップ
 
 > `tasks/backlog.yaml` から自動生成 — 手動編集禁止
-> 最終同期: 2026-04-05 14:43 (+09:00)
+> 最終同期: 2026-04-05 15:13 (+09:00)
 
 ## バージョン概要
 
@@ -25,13 +25,13 @@
 | v0.17.4 | 2 | [====================] 100% (2/2) |
 | v0.18.0 | 1 | [====================] 100% (1/1) |
 | v0.18.1 | 15 | [====================] 100% (15/15) |
-| v0.18.2 | 6 | [--------------------] 0% (0/6) |
+| v0.18.2 | 7 | [--------------------] 0% (0/7) |
 | v0.19.0 | 6 | [--------------------] 0% (0/6) |
 | v0.19.1 | 2 | [--------------------] 0% (0/2) |
 | v0.19.2 | 2 | [--------------------] 0% (0/2) |
-| v0.20.0 | 1 | [--------------------] 0% (0/1) |
+| v0.20.0 | 5 | [--------------------] 0% (0/5) |
 | v0.20.1 | 1 | [--------------------] 0% (0/1) |
-| v0.21.0 | 1 | [--------------------] 0% (0/1) |
+| v0.21.0 | 2 | [--------------------] 0% (0/2) |
 | v0.21.1 | 1 | [--------------------] 0% (0/1) |
 | v0.21.2 | 1 | [--------------------] 0% (0/1) |
 | cancelled | 22 | [--------------------] 0% (0/22) |
@@ -213,6 +213,7 @@
 |-|-----|-------|----------|------|--------|
 | [ ] | TASK-140 | Switch Builder agents from persistent session to codex exec per task + shell templates | P0 | winsmux | backlog |
 | [ ] | TASK-141 | Dispatch-router file-level task boundary enforcement | P0 | winsmux | backlog |
+| [ ] | TASK-142 | Fix orchestra-start crash when zombie processes are killed (Write-Output pipeline pollution) | P0 | winsmux | backlog |
 | [ ] | TASK-110 | Automatic task splitting for parallel Builder dispatch | P1 | winsmux | backlog |
 | [ ] | TASK-113 | Dynamic pane scaling — auto add/remove panes based on workload | P1 | winsmux | backlog |
 | [ ] | TASK-130 | Commander auto-detect Builder stall and alert | P1 | winsmux | backlog |
@@ -248,6 +249,10 @@
 | | ID | Title | Priority | Repo | Status |
 |-|-----|-------|----------|------|--------|
 | [ ] | TASK-105 | JSON-RPC backend + SDK integration in Tauri | P0 | winsmux | backlog |
+| [ ] | TASK-143 | Shadow Git checkpoint for Builder worktrees | P1 | winsmux | backlog |
+| [ ] | TASK-145 | TaskResume hook × manifest.yaml integration | P1 | winsmux | backlog |
+| [ ] | TASK-144 | Hook parallel execution + Notification hook | P2 | winsmux | backlog |
+| [ ] | TASK-146 | PreCompact hook × context usage monitoring | P2 | winsmux | backlog |
 
 ### v0.20.1 — インストーラプロファイル
 
@@ -260,6 +265,7 @@
 | | ID | Title | Priority | Repo | Status |
 |-|-----|-------|----------|------|--------|
 | [ ] | TASK-106 | Relay Auth + remote pane support in Tauri | P1 | winsmux | backlog |
+| [ ] | TASK-147 | ACP (Agent Communication Protocol) server support | P1 | winsmux | backlog |
 
 ### v0.21.1 — Editor パネル
 

--- a/tasks/backlog.yaml
+++ b/tasks/backlog.yaml
@@ -1706,3 +1706,92 @@ tasks:
     updated: "2026-04-05"
     notes: >
       #170. Explorer サイドバーに Git ソースコントロールパネル追加。worktree 表示対応。
+
+  # === v0.18.2: orchestra-start bug (2026-04-05) ===
+
+  - id: TASK-142
+    title: "Fix orchestra-start crash when zombie processes are killed (Write-Output pipeline pollution)"
+    status: backlog
+    priority: P0
+    target_version: "v0.18.2"
+    repo: winsmux
+    labels: [fix, orchestra, preflight]
+    depends_on: []
+    created: "2026-04-05"
+    updated: "2026-04-05"
+    notes: >
+      #235. Remove-OrchestraZombieProcesses の Write-Output がパイプラインを汚染し、
+      戻り値が [string, PSCustomObject] 配列になる。.Killed プロパティアクセスが StrictMode で失敗。
+      Fix: Write-Output → Write-Host に変更。
+
+  # === Cline powerup proposals (2026-04-05) ===
+
+  - id: TASK-143
+    title: "Shadow Git checkpoint for Builder worktrees"
+    status: backlog
+    priority: P1
+    target_version: "v0.20.0"
+    repo: winsmux
+    labels: [feat, checkpoint, safety]
+    depends_on: []
+    created: "2026-04-05"
+    updated: "2026-04-05"
+    notes: >
+      P21 (cline-powerup-proposals). shadow git でエージェント作業のスナップショットを取り、
+      Reviewer reject 時に即座にロールバック可能にする。25h見積。
+
+  - id: TASK-144
+    title: "Hook parallel execution + Notification hook"
+    status: backlog
+    priority: P2
+    target_version: "v0.20.0"
+    repo: winsmux
+    labels: [feat, hooks, notification]
+    depends_on: []
+    created: "2026-04-05"
+    updated: "2026-04-05"
+    notes: >
+      P22 (cline-powerup-proposals). 25本の hook を Promise.all で並列実行 + Notification hook で
+      Builder 入力待ちを Commander に自動通知。15h見積。
+
+  - id: TASK-145
+    title: "TaskResume hook × manifest.yaml integration"
+    status: backlog
+    priority: P1
+    target_version: "v0.20.0"
+    repo: winsmux
+    labels: [feat, hooks, manifest]
+    depends_on: []
+    created: "2026-04-05"
+    updated: "2026-04-05"
+    notes: >
+      P23 (cline-powerup-proposals). セッション再開時に manifest.yaml から前回の状態を各エージェントに
+      自動注入する TaskResume hook。8h見積。
+
+  - id: TASK-146
+    title: "PreCompact hook × context usage monitoring"
+    status: backlog
+    priority: P2
+    target_version: "v0.20.0"
+    repo: winsmux
+    labels: [feat, hooks, context]
+    depends_on: []
+    created: "2026-04-05"
+    updated: "2026-04-05"
+    notes: >
+      P24 (cline-powerup-proposals). エージェントのコンテキスト使用率を監視し、80%超で
+      自動圧縮戦略を適用。12h見積。
+
+  - id: TASK-147
+    title: "ACP (Agent Communication Protocol) server support"
+    status: backlog
+    priority: P1
+    target_version: "v0.21.0"
+    repo: winsmux
+    labels: [feat, acp, protocol]
+    depends_on: []
+    created: "2026-04-05"
+    updated: "2026-04-05"
+    notes: >
+      P25 (cline-powerup-proposals). ACP サーバーとして任意のエディタから Orchestra を操作可能にする。
+      JetBrains/Neovim/Zed 対応。30h見積。


### PR DESCRIPTION
## Summary
- TASK-142: #235 zombie cleanup pipeline pollution (v0.18.2)
- TASK-143..147: Cline powerup proposals (shadow checkpoint, hook parallel, TaskResume, PreCompact, ACP server)
- ROADMAP synced via sync-roadmap.ps1

🤖 Generated with [Claude Code](https://claude.com/claude-code)