### PR TITLE
fix: set GIT_EDITOR=true in orchestra session (#240)

### DIFF
--- a/docs/project/ROADMAP.md
+++ b/docs/project/ROADMAP.md
@@ -1,7 +1,7 @@
 # ロードマップ
 
 > `tasks/backlog.yaml` から自動生成 — 手動編集禁止
-> 最終同期: 2026-04-05 15:53 (+09:00)
+> 最終同期: 2026-04-05 16:13 (+09:00)
 
 ## バージョン概要
 
@@ -25,7 +25,7 @@
 | v0.17.4 | 2 | [====================] 100% (2/2) |
 | v0.18.0 | 1 | [====================] 100% (1/1) |
 | v0.18.1 | 15 | [====================] 100% (15/15) |
-| v0.18.2 | 7 | [===-----------------] 14% (1/7) |
+| v0.18.2 | 8 | [===-----------------] 13% (1/8) |
 | v0.19.0 | 6 | [--------------------] 0% (0/6) |
 | v0.19.1 | 2 | [--------------------] 0% (0/2) |
 | v0.19.2 | 2 | [--------------------] 0% (0/2) |
@@ -214,6 +214,7 @@
 | [ ] | TASK-140 | Switch Builder agents from persistent session to codex exec per task + shell templates | P0 | winsmux | backlog |
 | [ ] | TASK-141 | Dispatch-router file-level task boundary enforcement | P0 | winsmux | backlog |
 | [x] | TASK-142 | Fix orchestra-start crash when zombie processes are killed (Write-Output pipeline pollution) | P0 | winsmux | done |
+| [R] | TASK-148 | Set GIT_EDITOR=true in orchestra session to prevent vim stall | P0 | winsmux | review |
 | [ ] | TASK-110 | Automatic task splitting for parallel Builder dispatch | P1 | winsmux | backlog |
 | [ ] | TASK-113 | Dynamic pane scaling — auto add/remove panes based on workload | P1 | winsmux | backlog |
 | [ ] | TASK-130 | Commander auto-detect Builder stall and alert | P1 | winsmux | backlog |

--- a/psmux-bridge/scripts/orchestra-start.ps1
+++ b/psmux-bridge/scripts/orchestra-start.ps1
@@ -663,6 +663,8 @@ try {
     foreach ($entry in $vaultValues.GetEnumerator()) {
         Invoke-Psmux -Arguments @('set-environment', '-t', $sessionName, $entry.Key, $entry.Value)
     }
+    Invoke-Psmux -Arguments @('set-environment', '-t', $sessionName, 'GIT_EDITOR', 'true')
+    Write-WinsmuxLog -Level INFO -Event 'preflight.session_env.git_editor_set' -Message 'Set GIT_EDITOR=true for orchestra session.' -Data @{ session_name = $sessionName; key = 'GIT_EDITOR'; value = 'true' } | Out-Null
 
     $previousTargetSession = $env:WINSMUX_ORCHESTRA_SESSION
     $previousProjectDir = $env:WINSMUX_ORCHESTRA_PROJECT_DIR

--- a/tasks/backlog.yaml
+++ b/tasks/backlog.yaml
@@ -1726,6 +1726,20 @@ tasks:
       戻り値が [string, PSCustomObject] 配列になる。.Killed プロパティアクセスが StrictMode で失敗。
       Fix: Write-Output → Write-Host に変更。
 
+  - id: TASK-148
+    title: "Set GIT_EDITOR=true in orchestra session to prevent vim stall"
+    status: review
+    priority: P0
+    target_version: "v0.18.2"
+    repo: winsmux
+    labels: [fix, orchestra, builder]
+    depends_on: []
+    created: "2026-04-05"
+    updated: "2026-04-05"
+    notes: >
+      #240. Builder が git rebase --continue で vim にスタックする。
+      orchestra-start.ps1 のセッション環境に GIT_EDITOR=true を追加。
+
   # === Cline powerup proposals (2026-04-05) ===
 
   - id: TASK-143


### PR DESCRIPTION
## Summary
- orchestra-start.ps1: セッション環境に `GIT_EDITOR=true` を設定
- Builder が `git rebase --continue` で vim にスタックする問題を解消
- TASK-148 追加 + ROADMAP 同期

## Test plan
- [x] Pester 51/51 通過
- [ ] Builder で `git rebase --continue` が vim なしで完了することを確認

Closes #240

🤖 Generated with [Claude Code](https://claude.com/claude-code)