### PR TITLE
feat: exec-per-task mode for Builder panes (#229)

### DIFF
--- a/psmux-bridge/scripts/agent-monitor.ps1
+++ b/psmux-bridge/scripts/agent-monitor.ps1
@@ -389,6 +389,7 @@ function Get-PaneAgentStatus {
     param(
         [Parameter(Mandatory = $true)][string]$PaneId,
         [string]$Agent = 'codex',
+        [string]$Role = '',
         [int]$HungThreshold = $script:AgentMonitorDefaultHungThreshold
     )
 
@@ -463,6 +464,16 @@ function Get-PaneAgentStatus {
 
     # crashed: PowerShell prompt visible (PS C:\) - Codex exited
     if ($trimmed -match '^PS [A-Z]:\\') {
+        if ($Role -eq 'Builder') {
+            Save-MonitorSnapshot -PaneId $PaneId -Hash (Get-ContentHash -Text $text) -Timestamp (Get-Date -Format o)
+            return [PSCustomObject]@{
+                Status       = 'ready'
+                PaneId       = $PaneId
+                SnapshotTail = $tail
+                ExitReason   = 'exec_completed'
+            }
+        }
+
         return [PSCustomObject]@{
             Status       = 'crashed'
             PaneId       = $PaneId
@@ -666,7 +677,7 @@ function Invoke-AgentMonitorCycle {
         $modelName = [string]$roleAgentConfig.Model
 
         $checkedCount++
-        $status = Get-PaneAgentStatus -PaneId $paneId -Agent $agentName -HungThreshold $IdleThreshold
+        $status = Get-PaneAgentStatus -PaneId $paneId -Agent $agentName -Role $role -HungThreshold $IdleThreshold
         $statusName = [string](Get-MonitorPropertyValue -InputObject $status -Name 'Status' -Default '')
         $statusExitReason = [string](Get-MonitorPropertyValue -InputObject $status -Name 'ExitReason' -Default '')
         $statusSnapshotTail = [string](Get-MonitorPropertyValue -InputObject $status -Name 'SnapshotTail' -Default '')

--- a/psmux-bridge/scripts/orchestra-start.ps1
+++ b/psmux-bridge/scripts/orchestra-start.ps1
@@ -211,11 +211,16 @@ function Get-AgentLaunchCommand {
         [Parameter(Mandatory = $true)][string]$Agent,
         [Parameter(Mandatory = $true)][string]$Model,
         [Parameter(Mandatory = $true)][string]$ProjectDir,
-        [Parameter(Mandatory = $true)][string]$GitWorktreeDir
+        [Parameter(Mandatory = $true)][string]$GitWorktreeDir,
+        [bool]$ExecMode = $false
     )
 
     switch ($Agent.Trim().ToLowerInvariant()) {
         'codex' {
+            if ($ExecMode) {
+                return ''
+            }
+
             return "codex -c model=$Model --full-auto -C $(ConvertTo-PowerShellLiteral -Value $ProjectDir) --add-dir $(ConvertTo-PowerShellLiteral -Value $GitWorktreeDir)"
         }
         'claude' {
@@ -520,6 +525,7 @@ function Save-OrchestraSessionState {
         $lines.Add(('  - label: {0}' -f (ConvertTo-YamlScalar -Value $paneSummary.Label))) | Out-Null
         $lines.Add(('    pane_id: {0}' -f (ConvertTo-YamlScalar -Value $paneSummary.PaneId))) | Out-Null
         $lines.Add(('    role: {0}' -f (ConvertTo-YamlScalar -Value $paneSummary.Role))) | Out-Null
+        $lines.Add(('    exec_mode: {0}' -f (ConvertTo-YamlScalar -Value $paneSummary.ExecMode))) | Out-Null
         $lines.Add(('    launch_dir: {0}' -f (ConvertTo-YamlScalar -Value $paneSummary.LaunchDir))) | Out-Null
         $lines.Add(('    builder_branch: {0}' -f (ConvertTo-YamlScalar -Value $paneSummary.BuilderBranch))) | Out-Null
         $lines.Add(('    builder_worktree_path: {0}' -f (ConvertTo-YamlScalar -Value $paneSummary.BuilderWorktreePath))) | Out-Null
@@ -710,6 +716,7 @@ try {
         $launchGitWorktreeDir = $gitWorktreeDir
         $builderBranch = $null
         $builderWorktreePath = $null
+        $execMode = ($canonicalRole -eq 'Builder')
 
         if ($canonicalRole -eq 'Builder') {
             $builderIndex++
@@ -721,7 +728,7 @@ try {
         }
 
         $roleAgentConfig = Get-RoleAgentConfig -Role $canonicalRole -Settings $settings
-        $launchCommand = Get-AgentLaunchCommand -Agent $roleAgentConfig.Agent -Model $roleAgentConfig.Model -ProjectDir $launchDir -GitWorktreeDir $launchGitWorktreeDir
+        $launchCommand = Get-AgentLaunchCommand -Agent $roleAgentConfig.Agent -Model $roleAgentConfig.Model -ProjectDir $launchDir -GitWorktreeDir $launchGitWorktreeDir -ExecMode $execMode
 
         Invoke-Bridge -Arguments @('name', $paneId, $label)
         try {
@@ -729,7 +736,9 @@ try {
             Set-OrchestraSessionEnvironment -SessionName $sessionName -Name 'WINSMUX_PANE_ID' -Value $paneId
             Invoke-Psmux -Arguments @('respawn-pane', '-k', '-t', $paneId, '-c', $launchDir)
             Wait-PaneShellReady -PaneId $paneId
-            Send-OrchestraBridgeCommand -Target $paneId -Text $launchCommand
+            if (-not [string]::IsNullOrWhiteSpace($launchCommand)) {
+                Send-OrchestraBridgeCommand -Target $paneId -Text $launchCommand
+            }
         } finally {
             foreach ($envName in @('WINSMUX_ROLE', 'WINSMUX_PANE_ID')) {
                 try {
@@ -743,6 +752,7 @@ try {
             Label = $label
             PaneId = $paneId
             Role = $canonicalRole
+            ExecMode = $execMode
             LaunchDir = $launchDir
             BuilderBranch = $builderBranch
             BuilderWorktreePath = $builderWorktreePath
@@ -750,6 +760,10 @@ try {
     }
 
     foreach ($paneSummary in $paneSummaries) {
+        if ($paneSummary.ExecMode) {
+            continue
+        }
+
         try {
             $roleAgentConfig = Get-RoleAgentConfig -Role $paneSummary.Role -Settings $settings
             Wait-AgentReady -PaneId $paneSummary.PaneId -Agent $roleAgentConfig.Agent -TimeoutSeconds 60


### PR DESCRIPTION
## Summary
- Builder ペインでインタラクティブ Codex を起動しない（exec-per-task モード）
- `Get-AgentLaunchCommand` に `-ExecMode` パラメータ追加
- Builder の PS プロンプトを `ready` (ExitReason: `exec_completed`) として扱う
- Researcher/Reviewer は従来通りインタラクティブモード

## Changes
- `orchestra-start.ps1`: Builder 起動時に Codex を起動せず shell で待機
- `agent-monitor.ps1`: Builder の PowerShell プロンプト = ready（crashed ではない）

## Test plan
- [x] Pester 51/51 通過
- [ ] Orchestra 起動で Builder が shell 待機することを確認
- [ ] `codex exec` でタスク投入→完了→shell 復帰を確認

Closes #229

🤖 Generated with [Claude Code](https://claude.com/claude-code)