### PR TITLE
feat: Builder stall auto-detection (#210)

### DIFF
--- a/psmux-bridge/scripts/agent-monitor.ps1
+++ b/psmux-bridge/scripts/agent-monitor.ps1
@@ -37,6 +37,8 @@ $scriptDir = $PSScriptRoot
 $script:HungSnapshotDir = Join-Path $env:TEMP 'winsmux\monitor_snapshots'
 $script:IdleStateDir = Join-Path $env:TEMP 'winsmux\monitor_idle'
 $script:AgentMonitorDefaultHungThreshold = 60
+$script:BuilderStallHistory = @{}
+$script:BuilderStallThresholdCycles = 3
 
 # ---------------------------------------------------------------------------
 # Psmux wrapper (same pattern as orchestra-start.ps1)
@@ -238,6 +240,51 @@ function Update-MonitorIdleAlertState {
     return $result
 }
 
+function Clear-BuilderStallState {
+    param([Parameter(Mandatory = $true)][string]$PaneId)
+
+    if ($script:BuilderStallHistory.ContainsKey($PaneId)) {
+        $script:BuilderStallHistory.Remove($PaneId)
+    }
+}
+
+function Test-BuilderStall {
+    param(
+        [Parameter(Mandatory = $true)][string]$PaneId,
+        [Parameter(Mandatory = $true)][string]$Role,
+        [Parameter(Mandatory = $true)][string]$Status,
+        [AllowNull()][string]$SnapshotHash,
+        [int]$RequiredCycles = $script:BuilderStallThresholdCycles
+    )
+
+    if ($Role -ne 'Builder' -or $Status -ne 'busy' -or [string]::IsNullOrWhiteSpace($SnapshotHash)) {
+        Clear-BuilderStallState -PaneId $PaneId
+        return $false
+    }
+
+    if (-not $script:BuilderStallHistory.ContainsKey($PaneId)) {
+        $script:BuilderStallHistory[$PaneId] = [System.Collections.Generic.List[string]]::new()
+    }
+
+    $hashHistory = [System.Collections.Generic.List[string]]$script:BuilderStallHistory[$PaneId]
+    $hashHistory.Add($SnapshotHash)
+    while ($hashHistory.Count -gt $RequiredCycles) {
+        $hashHistory.RemoveAt(0)
+    }
+
+    if ($hashHistory.Count -lt $RequiredCycles) {
+        return $false
+    }
+
+    foreach ($hash in $hashHistory) {
+        if ($hash -ne $SnapshotHash) {
+            return $false
+        }
+    }
+
+    return $true
+}
+
 function Get-ContentHash {
     param([AllowNull()][string]$Text)
 
@@ -437,12 +484,14 @@ function Get-PaneAgentStatus {
         ($lines[($lines.Length - 12)..($lines.Length - 1)] -join [Environment]::NewLine)
     }
     $exitReason = ''
+    $snapshotHash = Get-ContentHash -Text $text
 
     if (Test-CodexApprovalPromptText -Text $text) {
         return [PSCustomObject]@{
             Status       = 'busy'
             PaneId       = $PaneId
             SnapshotTail = $tail
+            SnapshotHash = $snapshotHash
             ExitReason   = ''
         }
     }
@@ -458,6 +507,7 @@ function Get-PaneAgentStatus {
             Status       = 'ready'
             PaneId       = $PaneId
             SnapshotTail = $tail
+            SnapshotHash = $snapshotHash
             ExitReason   = ''
         }
     }
@@ -470,6 +520,7 @@ function Get-PaneAgentStatus {
                 Status       = 'ready'
                 PaneId       = $PaneId
                 SnapshotTail = $tail
+                SnapshotHash = $snapshotHash
                 ExitReason   = 'exec_completed'
             }
         }
@@ -478,12 +529,13 @@ function Get-PaneAgentStatus {
             Status       = 'crashed'
             PaneId       = $PaneId
             SnapshotTail = $tail
+            SnapshotHash = $snapshotHash
             ExitReason   = $exitReason
         }
     }
 
     # hung: no output change for threshold seconds
-    $currentHash = Get-ContentHash -Text $text
+    $currentHash = $snapshotHash
     $now = Get-Date
     $previous = Get-MonitorSnapshot -PaneId $PaneId
 
@@ -496,6 +548,7 @@ function Get-PaneAgentStatus {
                     Status       = 'hung'
                     PaneId       = $PaneId
                     SnapshotTail = $tail
+                    SnapshotHash = $snapshotHash
                     ExitReason   = ''
                 }
             }
@@ -512,6 +565,7 @@ function Get-PaneAgentStatus {
         Status       = 'busy'
         PaneId       = $PaneId
         SnapshotTail = $tail
+        SnapshotHash = $snapshotHash
         ExitReason   = ''
     }
 }
@@ -600,7 +654,7 @@ function Invoke-AgentMonitorCycle {
     Runs one monitoring cycle: check all panes, respawn crashed ones.
 
     .OUTPUTS
-    PSCustomObject with: Checked (int), Crashed (int), Respawned (int), Results (array)
+    PSCustomObject with: Checked (int), Crashed (int), Respawned (int), IdleAlerts (int), Stalls (int), Results (array)
     #>
     param(
         [Parameter(Mandatory = $true)]$Settings,
@@ -650,6 +704,7 @@ function Invoke-AgentMonitorCycle {
     $crashedCount = 0
     $respawnedCount = 0
     $idleAlertCount = 0
+    $stallCount = 0
     $cycleNow = Get-Date
 
     foreach ($label in $manifest.Panes.Keys) {
@@ -681,6 +736,7 @@ function Invoke-AgentMonitorCycle {
         $statusName = [string](Get-MonitorPropertyValue -InputObject $status -Name 'Status' -Default '')
         $statusExitReason = [string](Get-MonitorPropertyValue -InputObject $status -Name 'ExitReason' -Default '')
         $statusSnapshotTail = [string](Get-MonitorPropertyValue -InputObject $status -Name 'SnapshotTail' -Default '')
+        $statusSnapshotHash = [string](Get-MonitorPropertyValue -InputObject $status -Name 'SnapshotHash' -Default '')
 
         $result = [PSCustomObject]@{
             Label      = $label
@@ -690,6 +746,7 @@ function Invoke-AgentMonitorCycle {
             ExitReason = $statusExitReason
             Respawned  = $false
             IdleAlerted = $false
+            StallDetected = $false
             Message    = ''
         }
 
@@ -709,6 +766,19 @@ function Invoke-AgentMonitorCycle {
             Write-Output $idleAlert.Message
             try {
                 Send-MonitorTelegramAlert -Message $idleAlert.Message | Out-Null
+            } catch {
+            }
+        }
+
+        $stallDetected = Test-BuilderStall -PaneId $paneId -Role $role -Status $statusName -SnapshotHash $statusSnapshotHash
+        if ($stallDetected) {
+            $stallCount++
+            $result.StallDetected = $true
+            $stallMessage = "Commander alert: stalled Builder pane $label ($paneId)"
+            $result.Message = $stallMessage
+            Write-Output $stallMessage
+            try {
+                Send-MonitorTelegramAlert -Message $stallMessage | Out-Null
             } catch {
             }
         }
@@ -807,8 +877,8 @@ function Invoke-AgentMonitorCycle {
         try {
                 Write-OrchestraLog -ProjectDir $projectDir -SessionName $SessionName `
                     -Event 'monitor.cycle' -Level 'info' `
-                -Message "Monitor cycle: checked=$checkedCount crashed=$crashedCount respawned=$respawnedCount idle_alerts=$idleAlertCount" `
-                -Data ([ordered]@{ checked = $checkedCount; crashed = $crashedCount; respawned = $respawnedCount; idle_alerts = $idleAlertCount }) | Out-Null
+                -Message "Monitor cycle: checked=$checkedCount crashed=$crashedCount respawned=$respawnedCount idle_alerts=$idleAlertCount stalls=$stallCount" `
+                -Data ([ordered]@{ checked = $checkedCount; crashed = $crashedCount; respawned = $respawnedCount; idle_alerts = $idleAlertCount; stalls = $stallCount }) | Out-Null
         } catch {
         }
     }
@@ -818,6 +888,7 @@ function Invoke-AgentMonitorCycle {
         Crashed   = $crashedCount
         Respawned = $respawnedCount
         IdleAlerts = $idleAlertCount
+        Stalls = $stallCount
         Results   = @($results)
     }
 }

--- a/tests/Integration.MultiAgent.Tests.ps1
+++ b/tests/Integration.MultiAgent.Tests.ps1
@@ -318,4 +318,49 @@ panes:
         $output[1].Results[0].Message | Should -Match 'Commander alert: idle pane builder-1'
         Should -Invoke Send-MonitorTelegramAlert -Times 1 -Exactly
     }
+
+    It 'emits commander alerts when a Builder stays busy with the same snapshot for three cycles' {
+        $script:BuilderStallHistory = @{}
+        $manifestDir = Join-Path $script:agentMonitorTempRoot '.winsmux'
+        New-Item -ItemType Directory -Path $manifestDir -Force | Out-Null
+        @"
+version: 1
+session:
+  name: winsmux-orchestra
+  project_dir: $script:agentMonitorTempRoot
+panes:
+  - label: builder-1
+    pane_id: %2
+    role: Builder
+    launch_dir: $script:agentMonitorTempRoot
+"@ | Set-Content -Path (Join-Path $manifestDir 'manifest.yaml') -Encoding UTF8
+
+        Mock Get-PaneAgentStatus {
+            [PSCustomObject]@{
+                Status       = 'busy'
+                PaneId       = '%2'
+                SnapshotTail = 'working'
+                SnapshotHash = 'stall-hash'
+                ExitReason   = ''
+            }
+        }
+        Mock Send-MonitorTelegramAlert { return $true }
+
+        $settings = [ordered]@{
+            agent = 'codex'
+            model = 'gpt-5.4'
+            roles = [ordered]@{}
+        }
+
+        @(Invoke-AgentMonitorCycle -Settings $settings -ManifestPath (Join-Path $manifestDir 'manifest.yaml') -SessionName 'winsmux-orchestra' -IdleThreshold 120) | Out-Null
+        @(Invoke-AgentMonitorCycle -Settings $settings -ManifestPath (Join-Path $manifestDir 'manifest.yaml') -SessionName 'winsmux-orchestra' -IdleThreshold 120) | Out-Null
+        $output = @(Invoke-AgentMonitorCycle -Settings $settings -ManifestPath (Join-Path $manifestDir 'manifest.yaml') -SessionName 'winsmux-orchestra' -IdleThreshold 120)
+
+        $output.Count | Should -Be 2
+        $output[0] | Should -Match 'Commander alert: stalled Builder pane builder-1 \(%2\)'
+        $output[1].Stalls | Should -Be 1
+        $output[1].Results[0].StallDetected | Should -Be $true
+        $output[1].Results[0].Message | Should -Match 'Commander alert: stalled Builder pane builder-1'
+        Should -Invoke Send-MonitorTelegramAlert -Times 1 -Exactly
+    }
 }

--- a/tests/psmux-bridge.Tests.ps1
+++ b/tests/psmux-bridge.Tests.ps1
@@ -488,4 +488,21 @@ Describe 'agent-monitor helpers' {
             $Text -eq "codex -c model=gpt-5.4 --full-auto -C 'C:\repo\.worktrees\builder-1' --add-dir 'C:\repo\.git\worktrees\builder-1'"
         }
     }
+
+    It 'detects a stalled Builder after three busy cycles with the same snapshot hash' {
+        $script:BuilderStallHistory = @{}
+
+        (Test-BuilderStall -PaneId '%2' -Role 'Builder' -Status 'busy' -SnapshotHash 'hash-1') | Should -Be $false
+        (Test-BuilderStall -PaneId '%2' -Role 'Builder' -Status 'busy' -SnapshotHash 'hash-1') | Should -Be $false
+        (Test-BuilderStall -PaneId '%2' -Role 'Builder' -Status 'busy' -SnapshotHash 'hash-1') | Should -Be $true
+    }
+
+    It 'resets Builder stall history when the pane is no longer busy' {
+        $script:BuilderStallHistory = @{}
+
+        Test-BuilderStall -PaneId '%2' -Role 'Builder' -Status 'busy' -SnapshotHash 'hash-1' | Out-Null
+        Test-BuilderStall -PaneId '%2' -Role 'Builder' -Status 'busy' -SnapshotHash 'hash-1' | Out-Null
+        (Test-BuilderStall -PaneId '%2' -Role 'Builder' -Status 'ready' -SnapshotHash 'hash-1') | Should -Be $false
+        (Test-BuilderStall -PaneId '%2' -Role 'Builder' -Status 'busy' -SnapshotHash 'hash-1') | Should -Be $false
+    }
 }


### PR DESCRIPTION
## Summary
- agent-monitor にスナップショットハッシュベースのスタル検出を追加
- 3連続サイクルでハッシュ変化なし → stall アラート + Telegram 通知
- Pester テスト 54/54 通過 (3テスト追加)

Closes #210
🤖 Generated with [Claude Code](https://claude.com/claude-code)