### PR TITLE
feat: Commander approval gate + backlog sync (#215)

### DIFF
--- a/psmux-bridge/scripts/agent-monitor.ps1
+++ b/psmux-bridge/scripts/agent-monitor.ps1
@@ -431,7 +431,7 @@ function Get-PaneAgentStatus {
     Captures pane output and returns the agent status.
 
     .OUTPUTS
-    PSCustomObject with: Status (ready|busy|crashed|hung|empty), PaneId, SnapshotTail, ExitReason
+    PSCustomObject with: Status (ready|busy|approval_waiting|crashed|hung|empty), PaneId, SnapshotTail, ExitReason
     #>
     param(
         [Parameter(Mandatory = $true)][string]$PaneId,
@@ -488,7 +488,7 @@ function Get-PaneAgentStatus {
 
     if (Test-CodexApprovalPromptText -Text $text) {
         return [PSCustomObject]@{
-            Status       = 'busy'
+            Status       = 'approval_waiting'
             PaneId       = $PaneId
             SnapshotTail = $tail
             SnapshotHash = $snapshotHash
@@ -684,6 +684,7 @@ function Invoke-AgentMonitorCycle {
             Checked   = 0
             Crashed   = 0
             Respawned = 0
+            ApprovalWaiting = 0
             Results   = @()
         }
     }
@@ -703,6 +704,7 @@ function Invoke-AgentMonitorCycle {
     $checkedCount = 0
     $crashedCount = 0
     $respawnedCount = 0
+    $approvalWaitingCount = 0
     $idleAlertCount = 0
     $stallCount = 0
     $cycleNow = Get-Date
@@ -748,6 +750,17 @@ function Invoke-AgentMonitorCycle {
             IdleAlerted = $false
             StallDetected = $false
             Message    = ''
+        }
+
+        if ($statusName -eq 'approval_waiting') {
+            $approvalWaitingCount++
+            $approvalMessage = "Commander alert: $label ($paneId) awaiting approval"
+            $result.Message = $approvalMessage
+            Write-Output $approvalMessage
+            try {
+                Send-MonitorTelegramAlert -Message $approvalMessage | Out-Null
+            } catch {
+            }
         }
 
         $idleAlert = Update-MonitorIdleAlertState `
@@ -877,8 +890,8 @@ function Invoke-AgentMonitorCycle {
         try {
                 Write-OrchestraLog -ProjectDir $projectDir -SessionName $SessionName `
                     -Event 'monitor.cycle' -Level 'info' `
-                -Message "Monitor cycle: checked=$checkedCount crashed=$crashedCount respawned=$respawnedCount idle_alerts=$idleAlertCount stalls=$stallCount" `
-                -Data ([ordered]@{ checked = $checkedCount; crashed = $crashedCount; respawned = $respawnedCount; idle_alerts = $idleAlertCount; stalls = $stallCount }) | Out-Null
+                -Message "Monitor cycle: checked=$checkedCount crashed=$crashedCount respawned=$respawnedCount approval_waiting=$approvalWaitingCount idle_alerts=$idleAlertCount stalls=$stallCount" `
+                -Data ([ordered]@{ checked = $checkedCount; crashed = $crashedCount; respawned = $respawnedCount; approval_waiting = $approvalWaitingCount; idle_alerts = $idleAlertCount; stalls = $stallCount }) | Out-Null
         } catch {
         }
     }
@@ -887,6 +900,7 @@ function Invoke-AgentMonitorCycle {
         Checked   = $checkedCount
         Crashed   = $crashedCount
         Respawned = $respawnedCount
+        ApprovalWaiting = $approvalWaitingCount
         IdleAlerts = $idleAlertCount
         Stalls = $stallCount
         Results   = @($results)

--- a/tasks/backlog.yaml
+++ b/tasks/backlog.yaml
@@ -1199,7 +1199,7 @@ tasks:
 
   - id: TASK-130
     title: "Commander auto-detect Builder stall and alert"
-    status: backlog
+    status: done
     priority: P1
     target_version: "v0.18.2"
     repo: winsmux
@@ -1669,7 +1669,7 @@ tasks:
 
   - id: TASK-141
     title: "Dispatch-router file-level task boundary enforcement"
-    status: backlog
+    status: done
     priority: P0
     target_version: "v0.18.2"
     repo: winsmux
@@ -1739,6 +1739,20 @@ tasks:
     notes: >
       #240. Builder が git rebase --continue で vim にスタックする。
       orchestra-start.ps1 のセッション環境に GIT_EDITOR=true を追加。
+
+  - id: TASK-149
+    title: "Agent-monitor background daemon for continuous pane monitoring"
+    status: backlog
+    priority: P0
+    target_version: "v0.18.2"
+    repo: winsmux
+    labels: [feat, monitor, daemon]
+    depends_on: ["TASK-130", "TASK-136"]
+    created: "2026-04-05"
+    updated: "2026-04-05"
+    notes: >
+      #245. idle検出/stall検出/approval gate検出は実装済みだが常駐ループが未実装。
+      orchestra-start完了後にagent-monitorを30秒間隔でバックグラウンド実行する。
 
   # === Cline powerup proposals (2026-04-05) ===
 

--- a/tests/Integration.MultiAgent.Tests.ps1
+++ b/tests/Integration.MultiAgent.Tests.ps1
@@ -319,6 +319,48 @@ panes:
         Should -Invoke Send-MonitorTelegramAlert -Times 1 -Exactly
     }
 
+    It 'emits approval waiting alerts and counts them during a monitor cycle' {
+        $manifestDir = Join-Path $script:agentMonitorTempRoot '.winsmux'
+        New-Item -ItemType Directory -Path $manifestDir -Force | Out-Null
+        @"
+version: 1
+session:
+  name: winsmux-orchestra
+  project_dir: $script:agentMonitorTempRoot
+panes:
+  - label: builder-1
+    pane_id: %2
+    role: Builder
+    launch_dir: $script:agentMonitorTempRoot
+"@ | Set-Content -Path (Join-Path $manifestDir 'manifest.yaml') -Encoding UTF8
+
+        Mock Get-PaneAgentStatus {
+            [PSCustomObject]@{
+                Status       = 'approval_waiting'
+                PaneId       = '%2'
+                SnapshotTail = 'Do you want to allow this command?'
+                SnapshotHash = 'approval-hash'
+                ExitReason   = ''
+            }
+        }
+        Mock Send-MonitorTelegramAlert { return $true }
+
+        $settings = [ordered]@{
+            agent = 'codex'
+            model = 'gpt-5.4'
+            roles = [ordered]@{}
+        }
+
+        $output = @(Invoke-AgentMonitorCycle -Settings $settings -ManifestPath (Join-Path $manifestDir 'manifest.yaml') -SessionName 'winsmux-orchestra' -IdleThreshold 120)
+
+        $output.Count | Should -Be 2
+        $output[0] | Should -Be 'Commander alert: builder-1 (%2) awaiting approval'
+        $output[1].ApprovalWaiting | Should -Be 1
+        $output[1].Results[0].Status | Should -Be 'approval_waiting'
+        $output[1].Results[0].Message | Should -Be 'Commander alert: builder-1 (%2) awaiting approval'
+        Should -Invoke Send-MonitorTelegramAlert -Times 1 -Exactly
+    }
+
     It 'emits commander alerts when a Builder stays busy with the same snapshot for three cycles' {
         $script:BuilderStallHistory = @{}
         $manifestDir = Join-Path $script:agentMonitorTempRoot '.winsmux'


### PR DESCRIPTION
## Summary
- agent-monitor に approval_waiting 状態検出を追加
- Builder が sandbox 承認待ちの時に Commander へ自動通知
- backlog: TASK-130/140/141 done、TASK-149 (#245) 追加
- Pester 55/55 通過

Closes #215
🤖 Generated with [Claude Code](https://claude.com/claude-code)