### PR TITLE
feat: agent-watchdog background daemon (#245)

### DIFF
--- a/psmux-bridge/scripts/agent-watchdog.ps1
+++ b/psmux-bridge/scripts/agent-watchdog.ps1
@@ -1,0 +1,53 @@
+[CmdletBinding()]
+param(
+    [string]$ManifestPath = '',
+    [string]$SessionName = 'winsmux-orchestra',
+    [int]$IdleThreshold = 120,
+    [int]$PollInterval = 30
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+
+$scriptDir = $PSScriptRoot
+. (Join-Path $scriptDir 'agent-monitor.ps1')
+
+function Invoke-AgentWatchdogCycle {
+    param(
+        [Parameter(Mandatory = $true)][string]$ManifestPath,
+        [Parameter(Mandatory = $true)][string]$SessionName,
+        [Parameter(Mandatory = $true)][int]$IdleThreshold
+    )
+
+    $settings = Get-BridgeSettings
+    return (Invoke-AgentMonitorCycle -Settings $settings -ManifestPath $ManifestPath -SessionName $SessionName -IdleThreshold $IdleThreshold)
+}
+
+function Start-AgentWatchdogLoop {
+    param(
+        [Parameter(Mandatory = $true)][string]$ManifestPath,
+        [Parameter(Mandatory = $true)][string]$SessionName,
+        [int]$IdleThreshold = 120,
+        [int]$PollInterval = 30
+    )
+
+    while ($true) {
+        try {
+            $result = Invoke-AgentWatchdogCycle -ManifestPath $ManifestPath -SessionName $SessionName -IdleThreshold $IdleThreshold
+            Write-Output ($result | ConvertTo-Json -Depth 8 -Compress)
+        } catch {
+            Write-Warning ("Watchdog cycle failed for session {0}: {1}" -f $SessionName, $_.Exception.Message)
+        }
+
+        Start-Sleep -Seconds $PollInterval
+    }
+}
+
+if ($MyInvocation.InvocationName -ne '.') {
+    if ([string]::IsNullOrWhiteSpace($ManifestPath)) {
+        throw 'ManifestPath is required.'
+    }
+
+    Start-AgentWatchdogLoop -ManifestPath $ManifestPath -SessionName $SessionName -IdleThreshold $IdleThreshold -PollInterval $PollInterval
+}

--- a/psmux-bridge/scripts/orchestra-start.ps1
+++ b/psmux-bridge/scripts/orchestra-start.ps1
@@ -559,6 +559,21 @@ function Wait-AgentReady {
     throw "Timed out waiting for pane $PaneId to become ready. Last output:`n$(Get-TailPreview -Text $finalText)"
 }
 
+function Start-AgentWatchdogJob {
+    param(
+        [Parameter(Mandatory = $true)][string]$WatchdogScriptPath,
+        [Parameter(Mandatory = $true)][string]$ManifestPath,
+        [Parameter(Mandatory = $true)][string]$SessionName,
+        [int]$IdleThreshold = 120,
+        [int]$PollInterval = 30
+    )
+
+    return (Start-Job -Name ("winsmux-watchdog-{0}" -f $SessionName) -ScriptBlock {
+        param($ScriptPath, $ManifestFile, $OrchestraSession, $Threshold, $Interval)
+        & $ScriptPath -ManifestPath $ManifestFile -SessionName $OrchestraSession -IdleThreshold $Threshold -PollInterval $Interval
+    } -ArgumentList $WatchdogScriptPath, $ManifestPath, $SessionName, $IdleThreshold, $PollInterval)
+}
+
 try {
     $settings = Get-BridgeSettings
     $projectDir = Get-ProjectDir
@@ -773,6 +788,11 @@ try {
         }
     }
 
+    $manifestPath = Save-OrchestraSessionState -ProjectDir $projectDir -SessionName $sessionName -Settings $settings -GitWorktreeDir $gitWorktreeDir -PaneSummaries $paneSummaries
+    $watchdogScriptPath = Join-Path $scriptDir 'agent-watchdog.ps1'
+    $watchdogJob = Start-AgentWatchdogJob -WatchdogScriptPath $watchdogScriptPath -ManifestPath $manifestPath -SessionName $sessionName
+    Write-WinsmuxLog -Level INFO -Event 'preflight.watchdog.started' -Message "Started agent watchdog for session $sessionName." -Data @{ session_name = $sessionName; manifest_path = $manifestPath; job_id = $watchdogJob.Id; job_name = $watchdogJob.Name } | Out-Null
+
     Write-Output "Orchestra session: $sessionName"
     Write-Output "Agent: $($settings.agent)"
     Write-Output "Model: $($settings.model)"
@@ -794,7 +814,6 @@ try {
         }
     }
 
-    $manifestPath = Save-OrchestraSessionState -ProjectDir $projectDir -SessionName $sessionName -Settings $settings -GitWorktreeDir $gitWorktreeDir -PaneSummaries $paneSummaries
     Write-Output ''
     Write-Output "Manifest: $manifestPath"
 } catch {

--- a/tests/psmux-bridge.Tests.ps1
+++ b/tests/psmux-bridge.Tests.ps1
@@ -506,3 +506,38 @@ Describe 'agent-monitor helpers' {
         (Test-BuilderStall -PaneId '%2' -Role 'Builder' -Status 'busy' -SnapshotHash 'hash-1') | Should -Be $false
     }
 }
+
+Describe 'agent-watchdog helpers' {
+    BeforeAll {
+        . (Join-Path (Split-Path -Parent $PSScriptRoot) 'psmux-bridge\scripts\agent-watchdog.ps1')
+    }
+
+    It 'runs a watchdog cycle through Invoke-AgentMonitorCycle with the requested thresholds' {
+        Mock Get-BridgeSettings {
+            [ordered]@{
+                agent = 'codex'
+                model = 'gpt-5.4'
+                roles = [ordered]@{}
+            }
+        }
+        Mock Invoke-AgentMonitorCycle {
+            [PSCustomObject]@{
+                Checked   = 1
+                Crashed   = 0
+                Respawned = 0
+                IdleAlerts = 0
+                Stalls    = 0
+                Results   = @()
+            }
+        }
+
+        $result = Invoke-AgentWatchdogCycle -ManifestPath 'C:\repo\.winsmux\manifest.yaml' -SessionName 'winsmux-orchestra' -IdleThreshold 120
+
+        $result.Checked | Should -Be 1
+        Should -Invoke Invoke-AgentMonitorCycle -Times 1 -Exactly -ParameterFilter {
+            $ManifestPath -eq 'C:\repo\.winsmux\manifest.yaml' -and
+            $SessionName -eq 'winsmux-orchestra' -and
+            $IdleThreshold -eq 120
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- agent-watchdog.ps1 新規作成: 30秒間隔で Invoke-AgentMonitorCycle を実行
- orchestra-start.ps1: 起動完了後にwatchdogを自動起動
- idle/stall/approval検出が実際に動作するようになった
- Pester 56/56 通過

Closes #245
🤖 Generated with [Claude Code](https://claude.com/claude-code)