### PR TITLE
feat: agent shell templates + watchdog Start-Process fix (#229, #250)

### DIFF
--- a/docs/project/ROADMAP.md
+++ b/docs/project/ROADMAP.md
@@ -1,7 +1,7 @@
 # ロードマップ
 
 > `tasks/backlog.yaml` から自動生成 — 手動編集禁止
-> 最終同期: 2026-04-05 17:51 (+09:00)
+> 最終同期: 2026-04-05 18:09 (+09:00)
 
 ## バージョン概要
 
@@ -25,7 +25,7 @@
 | v0.17.4 | 2 | [====================] 100% (2/2) |
 | v0.18.0 | 1 | [====================] 100% (1/1) |
 | v0.18.1 | 15 | [====================] 100% (15/15) |
-| v0.18.2 | 9 | [==================--] 89% (8/9) |
+| v0.18.2 | 10 | [================----] 80% (8/10) |
 | v0.19.0 | 6 | [--------------------] 0% (0/6) |
 | v0.19.1 | 2 | [--------------------] 0% (0/2) |
 | v0.19.2 | 2 | [--------------------] 0% (0/2) |
@@ -216,6 +216,7 @@
 | [x] | TASK-142 | Fix orchestra-start crash when zombie processes are killed (Write-Output pipeline pollution) | P0 | winsmux | done |
 | [x] | TASK-148 | Set GIT_EDITOR=true in orchestra session to prevent vim stall | P0 | winsmux | done |
 | [x] | TASK-149 | Agent-monitor background daemon for continuous pane monitoring | P0 | winsmux | done |
+| [ ] | TASK-150 | Fix agent-watchdog: Start-Job dies with parent process → Start-Process | P0 | winsmux | wip |
 | [x] | TASK-110 | Automatic task splitting for parallel Builder dispatch | P1 | winsmux | done |
 | [x] | TASK-113 | Dynamic pane scaling — auto add/remove panes based on workload | P1 | winsmux | done |
 | [x] | TASK-130 | Commander auto-detect Builder stall and alert | P1 | winsmux | done |

--- a/psmux-bridge/agents/AGENTS.md
+++ b/psmux-bridge/agents/AGENTS.md
@@ -1,0 +1,54 @@
+# psmux-bridge Agent Templates
+
+This directory contains bash wrappers that generate fixed user prompts for winsmux orchestration roles.
+
+## Files
+
+- `builder.sh`
+  - Purpose: emit a Builder prompt for implementation work in a dedicated worktree.
+  - Guardrails: requires `WORKTREE`, tells the agent to `cd` into it, mirrors the current `New-BuilderQueueDispatchPrompt` format from `psmux-bridge/scripts/builder-queue.ps1`, requires tests or checks before finishing, and requires Conventional Commits if a commit is created.
+  - Completion markers: `STATUS: EXEC_DONE` or `STATUS: BLOCKED`
+
+- `reviewer.sh`
+  - Purpose: emit a Reviewer prompt for diff-based review without editing code.
+  - Guardrails: requires `WORKTREE`, tells the agent to `cd` into it, review `git diff`, and explicitly check for security issues.
+  - Completion markers: `REVIEW_PASS` or `REVIEW_FAIL`
+  - Optional env var: `DIFF_BASE` to override the diff target. Defaults to `HEAD`.
+  - Safety contract for `DIFF_BASE`: it must be a trusted, single-line Git diff target such as `HEAD`, `HEAD~1`, or `origin/main...HEAD`. Do not pass shell fragments, command substitutions, or newline-delimited content. The script renders `DIFF_BASE` as shell-escaped display text only.
+
+- `researcher.sh`
+  - Purpose: emit a Researcher prompt for codebase or task investigation.
+  - Guardrails: requires `WORKTREE`, tells the agent to `cd` into it, asks for structured findings, separates confirmed facts from assumptions, and pushes toward actionable output for builders or reviewers.
+  - Completion markers: `STATUS: RESEARCH_DONE` or `STATUS: BLOCKED`
+
+## Usage
+
+Builder:
+
+```bash
+WORKTREE=/path/to/worktree ./builder.sh "Implement TASK-140"
+```
+
+Reviewer:
+
+```bash
+WORKTREE=/path/to/worktree DIFF_BASE=HEAD ./reviewer.sh "Review TASK-140"
+```
+
+Researcher:
+
+```bash
+WORKTREE=/path/to/worktree ./researcher.sh "Investigate TASK-140 prompt format"
+```
+
+All three scripts also accept input from stdin:
+
+```bash
+printf '%s\n' "Implement TASK-140" | WORKTREE=/path/to/worktree ./builder.sh
+```
+
+## Notes
+
+- `WORKTREE` is required for all three roles. Dispatchers must provide a trusted, single-line workspace path.
+- These scripts generate prompts only. They do not dispatch panes on their own.
+- `builder.sh` attempts to source `psmux-bridge/scripts/builder-queue.ps1` through `pwsh` to stay aligned with the current Builder queue prompt. If that is not available, it falls back to an embedded prompt with the same structure.

--- a/psmux-bridge/agents/builder.sh
+++ b/psmux-bridge/agents/builder.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  WORKTREE=/path/to/worktree ./builder.sh "Implement TASK-140"
+  printf '%s\n' "Implement TASK-140" | WORKTREE=/path/to/worktree ./builder.sh
+
+Outputs a Builder agent prompt with fixed guardrails embedded.
+EOF
+}
+
+read_task() {
+  if (($# > 0)); then
+    printf '%s' "$*"
+    return 0
+  fi
+
+  if [[ ! -t 0 ]]; then
+    cat
+    return 0
+  fi
+
+  return 1
+}
+
+pick_pwsh() {
+  if command -v pwsh >/dev/null 2>&1; then
+    printf '%s' "pwsh"
+    return 0
+  fi
+
+  if command -v pwsh.exe >/dev/null 2>&1; then
+    printf '%s' "pwsh.exe"
+    return 0
+  fi
+
+  return 1
+}
+
+to_native_path() {
+  local path="$1"
+
+  if command -v cygpath >/dev/null 2>&1; then
+    cygpath -w "$path"
+    return 0
+  fi
+
+  printf '%s' "$path"
+}
+
+default_builder_prompt() {
+  local task="$1"
+
+  cat <<EOF
+Implement the next queued Builder task in your assigned workspace.
+
+Task:
+$task
+
+Before finishing:
+- run the relevant checks or tests
+- summarize changed files
+- summarize the verification you performed
+
+End with exactly one line:
+STATUS: EXEC_DONE
+
+If blocked, end with:
+STATUS: BLOCKED
+EOF
+}
+
+base_builder_prompt() {
+  local task="$1"
+  local script_dir repo_root builder_queue_ps1 builder_queue_ps1_native pwsh_bin
+
+  script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+  repo_root="$(cd -- "$script_dir/../.." && pwd -P)"
+  builder_queue_ps1="$repo_root/psmux-bridge/scripts/builder-queue.ps1"
+
+  if [[ ! -f "$builder_queue_ps1" ]]; then
+    default_builder_prompt "$task"
+    return 0
+  fi
+
+  if ! pwsh_bin="$(pick_pwsh)"; then
+    default_builder_prompt "$task"
+    return 0
+  fi
+
+  builder_queue_ps1_native="$(to_native_path "$builder_queue_ps1")"
+
+  if ! BRIDGE_BUILDER_QUEUE_PS1="$builder_queue_ps1_native" TASK_PAYLOAD="$task" "$pwsh_bin" -NoProfile -Command '
+    $script = $env:BRIDGE_BUILDER_QUEUE_PS1
+    if (-not (Test-Path -LiteralPath $script -PathType Leaf)) {
+        exit 11
+    }
+
+    . $script
+    [Console]::Out.Write((New-BuilderQueueDispatchPrompt -Task $env:TASK_PAYLOAD))
+  ' 2>/dev/null; then
+    default_builder_prompt "$task"
+  fi
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  usage
+  exit 0
+fi
+
+task="$(read_task "$@")" || {
+  usage >&2
+  exit 1
+}
+
+if [[ -z "${WORKTREE:-}" ]]; then
+  echo "builder.sh requires WORKTREE to be set." >&2
+  exit 1
+fi
+
+base_prompt="$(base_builder_prompt "$task")"
+
+cat <<EOF
+$base_prompt
+
+Additional fixed guardrails for this builder run:
+- Start by running: cd "$WORKTREE"
+- Treat WORKTREE as the only workspace you may modify for this task.
+- Do not finish until you have run the relevant tests or checks from that workspace, unless you are blocked.
+- In the verification summary, include the exact commands you ran and whether they passed or failed.
+- If you create a commit, use a Conventional Commits message.
+
+Respond with:
+- implementation summary
+- changed files
+- verification summary
+
+The final line must be exactly one of:
+STATUS: EXEC_DONE
+STATUS: BLOCKED
+EOF

--- a/psmux-bridge/agents/researcher.sh
+++ b/psmux-bridge/agents/researcher.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  WORKTREE=/path/to/worktree ./researcher.sh "Investigate TASK-140 agent template conventions"
+  printf '%s\n' "Investigate TASK-140 agent template conventions" | WORKTREE=/path/to/worktree ./researcher.sh
+
+Outputs a Researcher agent prompt with fixed structured-findings guardrails embedded.
+EOF
+}
+
+read_topic() {
+  if (($# > 0)); then
+    printf '%s' "$*"
+    return 0
+  fi
+
+  if [[ ! -t 0 ]]; then
+    cat
+    return 0
+  fi
+
+  return 1
+}
+
+require_single_line_env() {
+  local name="$1"
+  local value="$2"
+
+  if [[ -z "$value" ]]; then
+    printf '%s\n' "researcher.sh requires $name to be set." >&2
+    exit 1
+  fi
+
+  case "$value" in
+    *$'\n'*|*$'\r'*)
+      printf '%s\n' "researcher.sh requires $name to be a single-line value." >&2
+      exit 1
+      ;;
+  esac
+}
+
+shell_quote() {
+  printf '%q' "$1"
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  usage
+  exit 0
+fi
+
+topic="$(read_topic "$@")" || {
+  usage >&2
+  exit 1
+}
+
+require_single_line_env "WORKTREE" "${WORKTREE:-}"
+worktree_display="$(shell_quote "$WORKTREE")"
+
+cat <<'PROMPT'
+Investigate the following topic and return structured findings.
+
+Topic:
+PROMPT
+printf '%s\n\n' "$topic"
+cat <<'PROMPT'
+Working context:
+PROMPT
+printf '%s\n\n' "- workspace: $worktree_display"
+cat <<'PROMPT'
+Instructions:
+PROMPT
+printf '%s\n' "- Start by running: cd $worktree_display"
+cat <<'PROMPT'
+- Investigate the codebase and the provided task context before making assumptions.
+- Separate confirmed facts from assumptions or open questions.
+- Prefer findings that a builder or reviewer can act on immediately.
+- Cite relevant files, commands, or artifacts when useful.
+
+Reply with these sections:
+- summary
+- key findings
+- evidence
+- risks or open questions
+- recommended next steps
+
+End with exactly one line:
+STATUS: RESEARCH_DONE
+
+If blocked, end with:
+STATUS: BLOCKED
+PROMPT

--- a/psmux-bridge/agents/reviewer.sh
+++ b/psmux-bridge/agents/reviewer.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  WORKTREE=/path/to/worktree ./reviewer.sh "Review TASK-140"
+  printf '%s\n' "Review TASK-140" | WORKTREE=/path/to/worktree ./reviewer.sh
+
+Outputs a Reviewer agent prompt with fixed diff-review guardrails embedded.
+EOF
+}
+
+read_task() {
+  if (($# > 0)); then
+    printf '%s' "$*"
+    return 0
+  fi
+
+  if [[ ! -t 0 ]]; then
+    cat
+    return 0
+  fi
+
+  return 1
+}
+
+require_single_line_env() {
+  local name="$1"
+  local value="$2"
+
+  if [[ -z "$value" ]]; then
+    printf '%s\n' "reviewer.sh requires $name to be set." >&2
+    exit 1
+  fi
+
+  case "$value" in
+    *$'\n'*|*$'\r'*)
+      printf '%s\n' "reviewer.sh requires $name to be a single-line value." >&2
+      exit 1
+      ;;
+  esac
+}
+
+shell_quote() {
+  printf '%q' "$1"
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  usage
+  exit 0
+fi
+
+task="$(read_task "$@")" || {
+  usage >&2
+  exit 1
+}
+
+require_single_line_env "WORKTREE" "${WORKTREE:-}"
+diff_base="${DIFF_BASE:-HEAD}"
+require_single_line_env "DIFF_BASE" "$diff_base"
+
+worktree_display="$(shell_quote "$WORKTREE")"
+diff_base_display="$(shell_quote "$diff_base")"
+
+cat <<'PROMPT'
+Review the latest builder result without editing code.
+
+Task:
+PROMPT
+printf '%s\n\n' "$task"
+cat <<'PROMPT'
+Workspace:
+PROMPT
+printf '%s\n\n' "$worktree_display"
+cat <<'PROMPT'
+Required review steps:
+PROMPT
+printf '%s\n' "- Start by running: cd $worktree_display"
+printf '%s\n' "- Inspect the current diff with: git diff $diff_base_display"
+cat <<'PROMPT'
+- Review for correctness, regressions, missing verification, and security issues.
+- Call out any credential exposure, injection risks, auth or authz mistakes, path handling issues, or unsafe shell usage.
+- Do not edit code during this review.
+
+Respond with:
+- verdict
+- findings
+- security review
+- recommended follow-ups
+
+If there are no blocking findings, end with exactly:
+REVIEW_PASS
+
+If there are blocking findings, end with exactly:
+REVIEW_FAIL
+PROMPT

--- a/psmux-bridge/scripts/orchestra-start.ps1
+++ b/psmux-bridge/scripts/orchestra-start.ps1
@@ -502,7 +502,8 @@ function Save-OrchestraSessionState {
         [Parameter(Mandatory = $true)][string]$SessionName,
         [Parameter(Mandatory = $true)]$Settings,
         [Parameter(Mandatory = $true)][string]$GitWorktreeDir,
-        [Parameter(Mandatory = $true)][System.Collections.IEnumerable]$PaneSummaries
+        [Parameter(Mandatory = $true)][System.Collections.IEnumerable]$PaneSummaries,
+        [Nullable[int]]$WatchdogPid = $null
     )
 
     $manifestPath = Get-OrchestraManifestPath -ProjectDir $ProjectDir
@@ -519,6 +520,11 @@ function Save-OrchestraSessionState {
     $lines.Add(('  model: {0}' -f (ConvertTo-YamlScalar -Value $Settings.model))) | Out-Null
     $lines.Add(('  project_dir: {0}' -f (ConvertTo-YamlScalar -Value $ProjectDir))) | Out-Null
     $lines.Add(('  git_worktree_dir: {0}' -f (ConvertTo-YamlScalar -Value $GitWorktreeDir))) | Out-Null
+    if ($null -ne $WatchdogPid) {
+        $lines.Add(('  watchdog_pid: {0}' -f $WatchdogPid)) | Out-Null
+    } else {
+        $lines.Add('  watchdog_pid: null') | Out-Null
+    }
     $lines.Add('panes:') | Out-Null
 
     foreach ($paneSummary in @($PaneSummaries)) {
@@ -568,12 +574,22 @@ function Start-AgentWatchdogJob {
         [int]$PollInterval = 30
     )
 
-    return (Start-Job -Name ("winsmux-watchdog-{0}" -f $SessionName) -ScriptBlock {
-        param($ScriptPath, $ManifestFile, $OrchestraSession, $Threshold, $Interval)
-        & $ScriptPath -ManifestPath $ManifestFile -SessionName $OrchestraSession -IdleThreshold $Threshold -PollInterval $Interval
-    } -ArgumentList $WatchdogScriptPath, $ManifestPath, $SessionName, $IdleThreshold, $PollInterval)
+    return (Start-Process -FilePath 'pwsh' -ArgumentList @(
+            '-NoProfile',
+            '-File',
+            $WatchdogScriptPath,
+            '-ManifestPath',
+            $ManifestPath,
+            '-SessionName',
+            $SessionName,
+            '-IdleThreshold',
+            $IdleThreshold,
+            '-PollInterval',
+            $PollInterval
+        ) -WindowStyle Hidden -PassThru)
 }
 
+$watchdogProcess = $null
 try {
     $settings = Get-BridgeSettings
     $projectDir = Get-ProjectDir
@@ -790,8 +806,9 @@ try {
 
     $manifestPath = Save-OrchestraSessionState -ProjectDir $projectDir -SessionName $sessionName -Settings $settings -GitWorktreeDir $gitWorktreeDir -PaneSummaries $paneSummaries
     $watchdogScriptPath = Join-Path $scriptDir 'agent-watchdog.ps1'
-    $watchdogJob = Start-AgentWatchdogJob -WatchdogScriptPath $watchdogScriptPath -ManifestPath $manifestPath -SessionName $sessionName
-    Write-WinsmuxLog -Level INFO -Event 'preflight.watchdog.started' -Message "Started agent watchdog for session $sessionName." -Data @{ session_name = $sessionName; manifest_path = $manifestPath; job_id = $watchdogJob.Id; job_name = $watchdogJob.Name } | Out-Null
+    $watchdogProcess = Start-AgentWatchdogJob -WatchdogScriptPath $watchdogScriptPath -ManifestPath $manifestPath -SessionName $sessionName
+    $manifestPath = Save-OrchestraSessionState -ProjectDir $projectDir -SessionName $sessionName -Settings $settings -GitWorktreeDir $gitWorktreeDir -PaneSummaries $paneSummaries -WatchdogPid $watchdogProcess.Id
+    Write-WinsmuxLog -Level INFO -Event 'preflight.watchdog.started' -Message "Started agent watchdog for session $sessionName." -Data @{ session_name = $sessionName; manifest_path = $manifestPath; watchdog_pid = $watchdogProcess.Id; process_name = $watchdogProcess.ProcessName } | Out-Null
 
     Write-Output "Orchestra session: $sessionName"
     Write-Output "Agent: $($settings.agent)"
@@ -816,7 +833,14 @@ try {
 
     Write-Output ''
     Write-Output "Manifest: $manifestPath"
+    Write-Output "Watchdog PID: $($watchdogProcess.Id)"
+    Write-Output 'Cleanup: stop the watchdog after the session ends.'
+    Write-Output ("  Stop-Process -Id {0}" -f $watchdogProcess.Id)
 } catch {
+    if ($null -ne $watchdogProcess) {
+        try { Stop-Process -Id $watchdogProcess.Id -Force -ErrorAction SilentlyContinue } catch {}
+    }
+
     # TASK-118: Rollback on failure
     $journalPath = Join-Path $projectDir '.winsmux' 'startup-journal.log'
     $journalDir = Split-Path $journalPath -Parent

--- a/tests/psmux-bridge.Tests.ps1
+++ b/tests/psmux-bridge.Tests.ps1
@@ -542,6 +542,29 @@ Describe 'agent-watchdog helpers' {
     }
 }
 
+Describe 'orchestra-start watchdog contract' {
+    BeforeAll {
+        $script:orchestraStartPath = Join-Path (Split-Path -Parent $PSScriptRoot) 'psmux-bridge\scripts\orchestra-start.ps1'
+        $script:orchestraStartContent = Get-Content -Path $script:orchestraStartPath -Raw -Encoding UTF8
+    }
+
+    It 'launches the watchdog with Start-Process so it survives script exit' {
+        $script:orchestraStartContent | Should -Match 'function Start-AgentWatchdogJob \{'
+        $script:orchestraStartContent | Should -Match 'Start-Process\s+-FilePath\s+''pwsh'''
+        $script:orchestraStartContent | Should -Match "'-NoProfile'"
+        $script:orchestraStartContent | Should -Match "'-File'"
+        $script:orchestraStartContent | Should -Match '-WindowStyle\s+Hidden\s+-PassThru'
+        $script:orchestraStartContent | Should -Not -Match 'Start-Job\s+-Name\s+\("winsmux-watchdog-'
+    }
+
+    It 'persists watchdog_pid and prints watchdog cleanup guidance' {
+        $script:orchestraStartContent | Should -Match 'watchdog_pid:'
+        $script:orchestraStartContent | Should -Match '-WatchdogPid \$watchdogProcess\.Id'
+        $script:orchestraStartContent | Should -Match 'Watchdog PID: \$\(\$watchdogProcess\.Id\)'
+        $script:orchestraStartContent | Should -Match 'Stop-Process -Id'
+    }
+}
+
 Describe 'pane scaler helpers' {
     BeforeAll {
         . (Join-Path (Split-Path -Parent $PSScriptRoot) 'psmux-bridge\scripts\pane-scaler.ps1')


### PR DESCRIPTION
## Summary
- **TASK-140**: Add `psmux-bridge/agents/{builder,reviewer,researcher}.sh` shell templates with embedded guardrails (WORKTREE mandatory, test enforcement, conventional commits, STATUS markers). Includes `AGENTS.md` documentation. `reviewer.sh` uses single-quoted heredocs + `printf` to prevent prompt injection (review finding fix).
- **TASK-150**: Replace `Start-Job` with `Start-Process` in `Start-AgentWatchdogJob` so the watchdog daemon survives `orchestra-start.ps1` exit. Watchdog PID persisted in `manifest.yaml`, cleaned up on failure.

Closes #250

## Test plan
- [x] Pester 61/61 pass (includes 2 new watchdog contract tests)
- [x] Reviewer PASS on injection fix (single-quoted heredocs + shell_quote)
- [ ] Manual: run `orchestra-start.ps1`, verify watchdog process persists after script exit
- [ ] Manual: verify `manifest.yaml` contains `watchdog_pid` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)