### PR TITLE
feat: harden against GlassWorm-style invisible Unicode attacks

### DIFF
--- a/.claude/hooks/lib/sh-utils.js
+++ b/.claude/hooks/lib/sh-utils.js
@@ -11,8 +11,12 @@ const PATTERNS_FILE = path.join(
   "patterns",
   "injection-patterns.json",
 );
+// Zero-width and invisible Unicode ranges removed during normalization:
+// U+00AD, U+034F, U+061C, U+180E, U+200A-U+200F, U+2028-U+2029, U+202A-U+202E,
+// U+205F, U+2060-U+2064, U+2066-U+2069, U+115F-U+1160, U+17B4-U+17B5, U+3000,
+// U+3164, U+FE00-U+FE0F, U+FEFF, U+FFA0, U+E0001-U+E007F, U+E0100-U+E01EF
 const ZERO_WIDTH_RE =
-  /[\u00ad\u034f\u180e\u200a-\u200f\u2028\u2029\u205f\u2060-\u2064\u3000\ufeff]/g;
+  /(?:[\u00ad\u034f\u061c\u180e\u200a-\u200f\u2028\u2029\u202a-\u202e\u205f\u2060-\u2064\u2066-\u2069\u115f-\u1160\u17b4-\u17b5\u3000\u3164\ufe00-\ufe0f\ufeff\uffa0]|\udb40[\udc01-\udc7f\udd00-\uddef])/g;
 const DEFAULT_PATTERNS = { categories: {} };
 const DEFAULT_PREVIOUS_HASH = "genesis";
 const DENY_THRESHOLD = 3;

--- a/.claude/hooks/sh-injection-guard.js
+++ b/.claude/hooks/sh-injection-guard.js
@@ -16,18 +16,13 @@ const {
   trackDeny,
 } = require("./lib/sh-utils");
 
-// Zero-width character regex (checked BEFORE pattern matching to prevent bypass)
-// U+00AD: soft hyphen
-// U+034F: combining grapheme joiner
-// U+180E: Mongolian vowel separator
-// U+200A-200F: hair space, zero-width space, non-joiner, joiner, LTR mark, RTL mark
-// U+2028-2029: line separator, paragraph separator
-// U+205F: medium mathematical space
-// U+2060-2064: word joiner, invisible operators
-// U+3000: ideographic space
-// U+FEFF: byte order mark
+// Zero-width and invisible Unicode regex (checked BEFORE pattern matching to prevent bypass)
+// Covered ranges: U+00AD, U+034F, U+061C, U+180E, U+200A-U+200F, U+2028-U+2029,
+// U+202A-U+202E, U+205F, U+2060-U+2064, U+2066-U+2069, U+115F-U+1160,
+// U+17B4-U+17B5, U+3000, U+3164, U+FE00-U+FE0F, U+FEFF, U+FFA0,
+// U+E0001-U+E007F, U+E0100-U+E01EF
 const ZERO_WIDTH_RE =
-  /[\u00ad\u034f\u180e\u200a-\u200f\u2028\u2029\u205f\u2060-\u2064\u3000\ufeff]/;
+  /(?:[\u00ad\u034f\u061c\u180e\u200a-\u200f\u2028\u2029\u202a-\u202e\u205f\u2060-\u2064\u2066-\u2069\u115f-\u1160\u17b4-\u17b5\u3000\u3164\ufe00-\ufe0f\ufeff\uffa0]|\udb40[\udc01-\udc7f\udd00-\uddef])/;
 
 /**
  * Extract the text to scan from tool_input based on tool_name.
@@ -67,7 +62,9 @@ function extractText(toolName, toolInput) {
 if (require.main === module) {
   try {
     const input = readHookInput();
-    const { toolName, toolInput, sessionId } = input;
+    const toolName = input.tool_name || input.toolName || "";
+    const toolInput = input.tool_input || input.toolInput || {};
+    const sessionId = input.session_id || input.sessionId || "";
 
     // Step 0: Extract text to scan
     const rawText = extractText(toolName, toolInput);
@@ -90,7 +87,8 @@ if (require.main === module) {
         tool: toolName,
         category: "zero_width",
         severity: "high",
-        detail: "Zero-width character detected in raw input",
+        detail:
+          "Zero-width or invisible Unicode control detected in raw input",
         session_id: sessionId,
       });
       const zwTracker = trackDeny("injection:zero_width");
@@ -102,8 +100,8 @@ if (require.main === module) {
         );
       } else {
         deny(
-          "[sh-injection-guard] Zero-width character detected. " +
-            "Invisible characters can be used to bypass security patterns. " +
+          "[sh-injection-guard] Zero-width or invisible Unicode character detected. " +
+            "Invisible characters, bidi controls, variation selectors, tag characters, and fillers can be used to bypass security patterns. " +
             "Category: zero_width (severity: high)",
         );
       }

--- a/.claude/hooks/sh-invisible-char-scan.js
+++ b/.claude/hooks/sh-invisible-char-scan.js
@@ -1,0 +1,301 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const { ZERO_WIDTH_RE } = require("./sh-injection-guard");
+
+const HOOK_NAME = "sh-invisible-char-scan";
+const BLOCKED_EXTENSIONS = new Set([
+  ".js",
+  ".ts",
+  ".ps1",
+  ".sh",
+  ".py",
+  ".yaml",
+  ".json",
+  ".md",
+]);
+
+function readInputPayload() {
+  const raw = fs.readFileSync(0, "utf8");
+
+  if (!raw.trim()) {
+    return {
+      payload: {},
+      rawInput: "",
+      rawTextMode: false,
+    };
+  }
+
+  try {
+    return {
+      payload: JSON.parse(raw),
+      rawInput: raw,
+      rawTextMode: false,
+    };
+  } catch {
+    return {
+      payload: {},
+      rawInput: raw,
+      rawTextMode: true,
+    };
+  }
+}
+
+function getToolInput(payload) {
+  if (payload && typeof payload === "object" && !Array.isArray(payload)) {
+    if (payload.tool_input && typeof payload.tool_input === "object") {
+      return payload.tool_input;
+    }
+    if (payload.toolInput && typeof payload.toolInput === "object") {
+      return payload.toolInput;
+    }
+  }
+  return {};
+}
+
+function inferToolName(payload, toolInput) {
+  const directName =
+    (payload && (payload.tool_name || payload.toolName)) || "";
+  if (directName) {
+    return String(directName);
+  }
+  if (typeof toolInput.content === "string") {
+    return "Write";
+  }
+  if (typeof toolInput.new_string === "string") {
+    return "Edit";
+  }
+  return "";
+}
+
+function extractTargets(payload, rawInput, rawTextMode) {
+  const toolInput = getToolInput(payload);
+  const toolName = inferToolName(payload, toolInput);
+  const filePath =
+    toolInput.file_path ||
+    toolInput.file ||
+    payload.file_path ||
+    payload.file ||
+    "";
+
+  if (toolName !== "Write" && toolName !== "Edit") {
+    return [];
+  }
+
+  const targets = [];
+  if (toolName === "Write" && typeof toolInput.content === "string") {
+    targets.push({ filePath, source: "content", text: toolInput.content });
+  }
+  if (toolName === "Edit" && typeof toolInput.new_string === "string") {
+    targets.push({ filePath, source: "new_string", text: toolInput.new_string });
+  }
+
+  if (typeof toolInput.stdin === "string") {
+    targets.push({ filePath, source: "stdin", text: toolInput.stdin });
+  }
+
+  if (typeof payload.stdin === "string") {
+    targets.push({ filePath, source: "stdin", text: payload.stdin });
+  }
+
+  if (targets.length === 0 && rawTextMode) {
+    targets.push({ filePath, source: "stdin", text: rawInput });
+  }
+
+  return dedupeTargets(targets);
+}
+
+function dedupeTargets(targets) {
+  const seen = new Set();
+  return targets.filter((target) => {
+    const key = `${target.filePath}\u0000${target.source}\u0000${target.text}`;
+    if (seen.has(key)) {
+      return false;
+    }
+    seen.add(key);
+    return true;
+  });
+}
+
+function createZeroWidthScanner() {
+  return new RegExp(ZERO_WIDTH_RE.source, "u");
+}
+
+function isBlockedFile(filePath) {
+  const extension = path.extname(String(filePath || "")).toLowerCase();
+  return BLOCKED_EXTENSIONS.has(extension);
+}
+
+function codePointLabel(char) {
+  return `U+${char.codePointAt(0).toString(16).toUpperCase().padStart(4, "0")}`;
+}
+
+function escapedChar(char) {
+  return Array.from(char)
+    .map((part) => {
+      const value = part.codePointAt(0).toString(16).toUpperCase();
+      return value.length <= 4
+        ? `\\u${value.padStart(4, "0")}`
+        : `\\u{${value}}`;
+    })
+    .join("");
+}
+
+function findInvisibleChars(text) {
+  const findings = [];
+  const matcher = createZeroWidthScanner();
+  let line = 1;
+  let column = 1;
+  let offset = 0;
+  let previousWasCarriageReturn = false;
+
+  for (const char of String(text || "")) {
+    if (matcher.test(char)) {
+      findings.push({
+        char,
+        codePoint: codePointLabel(char),
+        escaped: escapedChar(char),
+        offset,
+        line,
+        column,
+      });
+    }
+
+    if (char === "\r") {
+      line += 1;
+      column = 1;
+      previousWasCarriageReturn = true;
+    } else if (char === "\n") {
+      if (!previousWasCarriageReturn) {
+        line += 1;
+      }
+      column = 1;
+      previousWasCarriageReturn = false;
+    } else if (char === "\u2028" || char === "\u2029") {
+      line += 1;
+      column = 1;
+      previousWasCarriageReturn = false;
+    } else {
+      column += 1;
+      previousWasCarriageReturn = false;
+    }
+
+    offset += char.length;
+  }
+
+  return findings;
+}
+
+function scanTargets(targets) {
+  const results = [];
+
+  for (const target of targets) {
+    const findings = findInvisibleChars(target.text);
+    if (findings.length === 0) {
+      continue;
+    }
+
+    results.push({
+      filePath: target.filePath || "<unknown file>",
+      source: target.source,
+      blocked: !target.filePath || isBlockedFile(target.filePath),
+      findings,
+    });
+  }
+
+  return results;
+}
+
+function formatFinding(result, finding) {
+  return [
+    `${result.filePath}`,
+    `${result.source}`,
+    `${finding.codePoint}`,
+    `${finding.escaped}`,
+    `line ${finding.line}`,
+    `column ${finding.column}`,
+    `offset ${finding.offset}`,
+    `literal "${finding.char}"`,
+  ].join(" | ");
+}
+
+function buildMessage(results) {
+  const lines = [
+    `[${HOOK_NAME}] Invisible Unicode characters detected in tool input.`,
+    "Each entry is: file | source | code point | escaped | line | column | offset | literal",
+  ];
+
+  for (const result of results) {
+    for (const finding of result.findings) {
+      lines.push(`- ${formatFinding(result, finding)}`);
+    }
+  }
+
+  return lines.join("\n");
+}
+
+function writeHookMessage(message, permissionDecision) {
+  const output = { hookSpecificOutput: {} };
+  if (permissionDecision) {
+    output.hookSpecificOutput.permissionDecision = permissionDecision;
+  }
+  output.systemMessage = message;
+  process.stderr.write(JSON.stringify(output) + "\n");
+}
+
+function main() {
+  const { payload, rawInput, rawTextMode } = readInputPayload();
+  const targets = extractTargets(payload, rawInput, rawTextMode);
+
+  if (targets.length === 0) {
+    process.exit(0);
+    return;
+  }
+
+  const results = scanTargets(targets);
+  if (results.length === 0) {
+    process.exit(0);
+    return;
+  }
+
+  const message = buildMessage(results);
+  if (results.some((result) => result.blocked)) {
+    writeHookMessage(message, "deny");
+    process.exit(2);
+    return;
+  }
+
+  writeHookMessage(message);
+  process.exit(0);
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    writeHookMessage(
+      `[${HOOK_NAME}] Hook error: ${error.message}`,
+      "deny",
+    );
+    process.exit(2);
+  }
+}
+
+module.exports = {
+  BLOCKED_EXTENSIONS,
+  readInputPayload,
+  getToolInput,
+  inferToolName,
+  extractTargets,
+  dedupeTargets,
+  createZeroWidthScanner,
+  isBlockedFile,
+  codePointLabel,
+  escapedChar,
+  findInvisibleChars,
+  scanTargets,
+  formatFinding,
+  buildMessage,
+};

--- a/.claude/hooks/sh-output-control.js
+++ b/.claude/hooks/sh-output-control.js
@@ -13,6 +13,7 @@ const {
   readSession,
   writeSession,
 } = require("./lib/sh-utils");
+const { ZERO_WIDTH_RE } = require("./sh-injection-guard");
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -50,6 +51,8 @@ const DANGEROUS_TAGS_RE = new RegExp(
   "gi",
 );
 
+const INVISIBLE_UNICODE_GLOBAL_RE = new RegExp(ZERO_WIDTH_RE.source, "g");
+
 // ---------------------------------------------------------------------------
 // Helper Functions
 // ---------------------------------------------------------------------------
@@ -73,6 +76,43 @@ function getLimits(toolName) {
 function stripDangerousTags(text) {
   if (!text || typeof text !== "string") return text;
   return text.replace(DANGEROUS_TAGS_RE, "[REDACTED]");
+}
+
+/**
+ * Detect invisible Unicode characters and capture their raw positions.
+ * @param {string} text
+ * @returns {Array<{ index: number, codePoint: string }>}
+ */
+function detectInvisibleUnicode(text) {
+  if (!text || typeof text !== "string") return [];
+  INVISIBLE_UNICODE_GLOBAL_RE.lastIndex = 0;
+
+  return Array.from(text.matchAll(INVISIBLE_UNICODE_GLOBAL_RE), (match) => ({
+    index: match.index,
+    codePoint: `U+${match[0].codePointAt(0).toString(16).toUpperCase().padStart(4, "0")}`,
+  }));
+}
+
+/**
+ * Build a warning marker for invisible Unicode characters found in output.
+ * @param {Array<{ index: number, codePoint: string }>} matches
+ * @returns {string|null}
+ */
+function buildInvisibleUnicodeWarning(matches) {
+  if (!Array.isArray(matches) || matches.length === 0) return null;
+
+  const maxReported = 8;
+  const summary = matches
+    .slice(0, maxReported)
+    .map(({ index, codePoint }) => `${index}:${codePoint}`)
+    .join(", ");
+  const remaining = matches.length - Math.min(matches.length, maxReported);
+  const extra = remaining > 0 ? `, +${remaining} more` : "";
+
+  return (
+    `[INVISIBLE_CHAR_DETECTED] raw_offsets(0-based)=${summary}${extra}. ` +
+    "Invisible Unicode characters were detected in Builder output."
+  );
 }
 
 /**
@@ -162,6 +202,10 @@ if (require.main === module) {
     const resultStr =
       typeof toolResult === "string" ? toolResult : JSON.stringify(toolResult);
 
+    // Detect invisible Unicode in raw output before sanitization so positions
+    // still refer to the original Builder output.
+    const invisibleMatches = detectInvisibleUnicode(resultStr);
+
     // Strip dangerous system tags before any further processing
     const sanitized = stripDangerousTags(resultStr);
 
@@ -173,6 +217,10 @@ if (require.main === module) {
 
     // Build context messages
     const context = [];
+    const invisibleWarning = buildInvisibleUnicodeWarning(invisibleMatches);
+    if (invisibleWarning) {
+      context.push(invisibleWarning);
+    }
     if (truncated) {
       context.push(
         `[${HOOK_NAME}] ${toolName} の出力を切り詰めました（制限超過）。`,
@@ -183,7 +231,7 @@ if (require.main === module) {
     }
 
     // Output result
-    if (truncated) {
+    if (truncated || invisibleWarning) {
       // Must use allowWithResult to replace the tool output
       if (context.length > 0) {
         // allowWithResult doesn't support additionalContext, so prepend warnings to the result
@@ -210,6 +258,9 @@ if (require.main === module) {
 module.exports = {
   TRUNCATION_LIMITS,
   stripDangerousTags,
+  INVISIBLE_UNICODE_GLOBAL_RE,
+  detectInvisibleUnicode,
+  buildInvisibleUnicodeWarning,
   truncateOutput,
   estimateTokens,
   getLimits,

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -70,6 +70,10 @@
         "hooks": [
           {
             "type": "command",
+            "command": "node .claude/hooks/sh-invisible-char-scan.js"
+          },
+          {
+            "type": "command",
             "command": "node .claude/hooks/sh-injection-guard.js"
           }
         ]

--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,8 @@ coverage/
 *~
 .shield-harness/
 .research-*.md
+
+# Runtime agent output files
+*-output.txt
+*-prompt.txt
+.commander-prompt.txt


### PR DESCRIPTION
## Summary
- Expand ZERO_WIDTH_RE to cover variant selectors, bidi overrides, tag characters, and supplementary variant selectors
- Add `sh-invisible-char-scan.js` PreToolUse hook with detailed position reporting for Write/Edit
- Enhance `sh-output-control.js` with `[INVISIBLE_CHAR_DETECTED]` warning markers
- Fix snake_case/camelCase input parsing mismatch that caused detection bypass
- Import shared `ZERO_WIDTH_RE` in output-control to keep ranges aligned

Closes #253

## Test plan
- [x] `node --check` all modified hooks
- [x] U+200B (zero-width space): exit 2 deny
- [x] U+FE00 (variant selector): exit 2 deny
- [x] U+202A (bidi override): exit 2 deny
- [x] Clean input: exit 0 allow
- [x] sh-invisible-char-scan.js: deny on .js with U+200B, allow on clean
- [x] Pester 61/61 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)