### PR TITLE
fix: normalize MSYS /tmp paths in dispatch text for pwsh panes (#254)

### DIFF
--- a/scripts/psmux-bridge.ps1
+++ b/scripts/psmux-bridge.ps1
@@ -72,6 +72,69 @@ function Stop-WithError {
     exit 1
 }
 
+# --- Helper: Dispatch prompt paths ---
+function Get-DispatchPromptDirectory {
+    param([string]$ProjectDir = (Get-Location).Path)
+
+    return Join-Path $ProjectDir '.winsmux\dispatch-prompts'
+}
+
+function New-DispatchPromptFile {
+    param(
+        [Parameter(Mandatory = $true)][string]$Content,
+        [string]$ProjectDir = (Get-Location).Path,
+        [string]$Prefix = 'dispatch-prompt'
+    )
+
+    $promptDir = Get-DispatchPromptDirectory -ProjectDir $ProjectDir
+    if (-not (Test-Path $promptDir)) {
+        New-Item -ItemType Directory -Path $promptDir -Force | Out-Null
+    }
+
+    $fileName = '{0}-{1}.txt' -f $Prefix, ([guid]::NewGuid().ToString('N'))
+    $path = Join-Path $promptDir $fileName
+    $Content | Set-Content -LiteralPath $path -Encoding UTF8
+    return $path
+}
+
+function Convert-MsysTmpPathToWindowsPath {
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    if ($Path -notmatch '^/tmp(?:/|$)') {
+        return $Path
+    }
+
+    $tempRoot = [System.IO.Path]::GetTempPath().TrimEnd('\')
+    $relative = $Path.Substring(4).TrimStart('/')
+    if ([string]::IsNullOrWhiteSpace($relative)) {
+        return $tempRoot
+    }
+
+    return Join-Path $tempRoot ($relative -replace '/', '\')
+}
+
+function Normalize-DispatchText {
+    param([AllowEmptyString()][string]$Text)
+
+    if ([string]::IsNullOrWhiteSpace($Text)) {
+        return $Text
+    }
+
+    if ($Text -notmatch '/tmp(?:/|$)') {
+        return $Text
+    }
+
+    return [regex]::Replace($Text, '(?<quote>["''])(?<path>/tmp(?:/|$)(?:(?!\k<quote>).)*)\k<quote>|(?<path>/tmp(?:/[^''"`\s|;,)]*)?)', {
+        param($match)
+        $normalizedPath = Convert-MsysTmpPathToWindowsPath -Path $match.Groups['path'].Value
+        if ($match.Groups['quote'].Success) {
+            return $match.Groups['quote'].Value + $normalizedPath + $match.Groups['quote'].Value
+        }
+
+        return $normalizedPath
+    })
+}
+
 # --- Helper: Labels ---
 function Get-Labels {
     if (Test-Path $LabelsFile) {
@@ -730,7 +793,8 @@ function Invoke-Send {
     if (-not $Target) { Stop-WithError "usage: psmux-bridge send <target> <text>" }
     if (-not $Rest -or $Rest.Count -eq 0) { Stop-WithError "usage: psmux-bridge send <target> <text>" }
 
-    $text = $Rest -join ' '
+    # Normalize Git Bash /tmp paths before dispatching PowerShell-oriented commands.
+    $text = Normalize-DispatchText -Text ($Rest -join ' ')
     $paneId = Resolve-Target $Target
     $paneId = Confirm-Target $paneId
 


### PR DESCRIPTION
## Summary
- Commander (Git Bash) の `/tmp/` MSYS パスを pwsh ペインが認識できる Windows パス (`%TEMP%\`) に自動変換
- `Invoke-Send` 実行時に `Normalize-DispatchText` で `/tmp` パスを検出・正規化
- `.winsmux/dispatch-prompts/` にプロンプトファイルを生成するヘルパー関数追加

## Changes
- `Convert-MsysTmpPathToWindowsPath`: `/tmp/foo` → `$env:TEMP\foo` 変換
- `Normalize-DispatchText`: テキスト内の `/tmp` パスを自動正規化
- `New-DispatchPromptFile` / `Get-DispatchPromptDirectory`: プロジェクト内パス生成

## Test plan
- [ ] PowerShell 構文チェック通過済み
- [ ] `/tmp/foo.txt` を含むテキストが `C:\Users\...\AppData\Local\Temp\foo.txt` に変換されることを確認
- [ ] `/tmp` を含まないテキストは変更されないことを確認

Closes #254

🤖 Generated with [Claude Code](https://claude.com/claude-code)