### PR TITLE
feat: add Codex agent skills + gitignore scope fix (#284)

### DIFF
--- a/.agents/skills/builder-worktree/SKILL.md
+++ b/.agents/skills/builder-worktree/SKILL.md
@@ -1,0 +1,25 @@
+# builder-worktree
+
+## Purpose
+
+Guidance for Builder agents working inside isolated git worktrees.
+
+## Scope
+
+- Implement requested code changes inside the assigned worktree only.
+- Avoid edits outside the scoped task.
+- Do not run git add, commit, push, merge, or cleanup unless explicitly directed.
+
+## Workflow
+
+1. Read the local task prompt and relevant project instructions.
+2. Inspect the target files before editing.
+3. Make the smallest correct change.
+4. Verify the changed area with lightweight checks when possible.
+5. Report what changed, what was verified, and any blockers.
+
+## Constraints
+
+- Stay inside the assigned worktree.
+- Prefer maintainable, direct solutions over clever ones.
+- Use the file editing tool for manual edits.

--- a/.agents/skills/researcher-source-search/SKILL.md
+++ b/.agents/skills/researcher-source-search/SKILL.md
@@ -1,0 +1,25 @@
+# Researcher Source Search
+
+Use this skill when acting as the Researcher for winsmux tasks.
+
+## Goal
+- Gather source-backed findings before implementation or review.
+- Prefer local repository evidence over assumptions.
+- Report concise findings that the Commander or Builder can act on immediately.
+
+## Workflow
+1. Search the repo for the exact symbols, file paths, commands, and config keys named in the task.
+2. Read the smallest relevant set of files needed to confirm behavior.
+3. Cross-check tests, docs, and scripts when behavior might differ from comments or prompts.
+4. Return only verified findings, with file paths and short evidence excerpts or summaries.
+
+## Rules
+- Do not implement code changes.
+- Do not guess missing behavior when the repo can answer it.
+- Prefer primary sources in this repo: scripts, tests, config, and docs.
+- Call out dead references, deleted files, and drift between prompts and code.
+
+## Output
+- State what you verified.
+- State what is missing or inconsistent.
+- Include actionable next steps for Builder or Reviewer.

--- a/.agents/skills/reviewer-diff-audit/SKILL.md
+++ b/.agents/skills/reviewer-diff-audit/SKILL.md
@@ -1,0 +1,26 @@
+# reviewer-diff-audit
+
+## Purpose
+
+Guidance for Reviewer agents auditing code diffs for correctness and risk.
+
+## Scope
+
+- Review changes with a bug-finding mindset.
+- Prioritize behavioral regressions, security issues, and missing validation.
+- Keep summaries brief and put findings first.
+
+## Workflow
+
+1. Read the changed files and surrounding context.
+2. Identify concrete defects, risks, and test gaps.
+3. Cite exact files and lines when possible.
+4. State clearly when no findings are present.
+
+## Review Focus
+
+- Broken logic or edge cases
+- Incorrect assumptions about state or timing
+- Missing error handling
+- Incomplete or misleading documentation changes
+- Gaps in verification

--- a/.agents/skills/reviewer-pass-fail/SKILL.md
+++ b/.agents/skills/reviewer-pass-fail/SKILL.md
@@ -1,0 +1,28 @@
+# Reviewer Pass Fail
+
+Use this skill when acting as the Reviewer for winsmux tasks.
+
+## Goal
+- Produce a clear PASS or FAIL decision on the requested change.
+- Focus on correctness, regressions, dead references, and missing test coverage.
+
+## Review Workflow
+1. Inspect the changed files and the directly affected tests, scripts, or docs.
+2. Check whether the change matches the request exactly.
+3. Identify regressions, stale references, unsafe assumptions, or missing updates.
+4. Return a final PASS or FAIL with the concrete reason.
+
+## PASS Criteria
+- Requested files were updated correctly.
+- No broken references remain in the touched area.
+- Behavior and tests stay coherent.
+
+## FAIL Criteria
+- Requested edits are incomplete or incorrect.
+- Deleted or renamed files are still referenced.
+- Tests or supporting docs need updates and were missed.
+
+## Output
+- Start with `PASS` or `FAIL`.
+- List findings in severity order with file paths.
+- If FAIL, state the minimum fix needed to pass.

--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,7 @@ docs/REQUIREMENTS.md
 .references/
 .tmp-hook-*
 tasks/
-skills/
+/skills/
 tests/
 !tests/
 tests/*


### PR DESCRIPTION
## Summary

- Add 4 role-based Codex skills in `.agents/skills/`
- Scope `/skills/` gitignore to root only

## Test plan

- [x] Pester 61/61 passed
- [x] Reviewer audit: Codex skills over hooks for role enforcement

🤖 Generated with [Claude Code](https://claude.com/claude-code)