### PR TITLE
fix: replace circuit-breaker with session-end checklist (#282)

### DIFF
--- a/.claude/hooks/sh-circuit-breaker.js
+++ b/.claude/hooks/sh-circuit-breaker.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
-// sh-circuit-breaker.js — Retry loop before agent stops
-// Spec: DETAILED_DESIGN.md §5.2
+// sh-circuit-breaker.js — Session end checklist (Stop hook)
+// Displays a checklist on Stop, then allows the stop immediately.
+// Ref: PROPOSAL-29 (TASK-104)
 // Event: Stop
 // Target response time: < 50ms
 "use strict";
@@ -8,14 +9,12 @@
 const {
   readHookInput,
   allow,
-  deny,
   readSession,
   writeSession,
   appendEvidence,
 } = require("./lib/sh-utils");
 
 const HOOK_NAME = "sh-circuit-breaker";
-const MAX_RETRIES = 3;
 
 // ---------------------------------------------------------------------------
 // Main
@@ -23,107 +22,39 @@ const MAX_RETRIES = 3;
 
 try {
   const input = readHookInput();
-  const toolName = input.tool_name || input.toolName || "";
-  const toolInput = input.tool_input || input.toolInput || {};
   const sessionId = input.session_id || input.sessionId || "";
-  void toolName;
-  void toolInput;
   const session = readSession();
-  const isRapidStop = Date.now() - (session.last_stop_at || 0) < 5000;
 
-  if (!isRapidStop) {
-    session.stop_hook_active = false;
-    session.retry_count = 0;
-    session.last_stop_at = 0;
-    writeSession(session);
-  }
-
-  // Step 1: Check stop_hook_active flag (infinite loop prevention)
-  if (session.stop_hook_active === true) {
-    session.stop_hook_active = false;
-    writeSession(session);
-
-    try {
-      appendEvidence({
-        hook: HOOK_NAME,
-        event: "Stop",
-        decision: "allow",
-        reason:
-          "stop_hook_active flag was set — allowing to prevent infinite loop",
-        retry_count: session.retry_count || 0,
-        session_id: sessionId,
-      });
-    } catch {
-      // Evidence failure is non-blocking
-    }
-
-    allow(
-      "[sh-circuit-breaker] stop_hook_active detected — allowing stop to prevent loop.",
-    );
-    return;
-  }
-
-  // Step 2: Read and evaluate retry count
-  const currentRetry = (session.retry_count || 0) + 1;
-
-  if (currentRetry > MAX_RETRIES) {
-    // Retry limit reached — allow the stop
-    session.retry_count = 0;
-    session.stop_hook_active = false;
-    writeSession(session);
-
-    try {
-      appendEvidence({
-        hook: HOOK_NAME,
-        event: "Stop",
-        decision: "allow",
-        reason: `Retry limit reached (${MAX_RETRIES}/${MAX_RETRIES})`,
-        retry_count: MAX_RETRIES,
-        session_id: sessionId,
-      });
-    } catch {
-      // Evidence failure is non-blocking
-    }
-
-    allow(
-      `[sh-circuit-breaker] リトライ上限（${MAX_RETRIES}回）に到達しました。停止を許可します。`,
-    );
-    return;
-  }
-
-  // Step 3: Retry — deny the stop request
-  session.retry_count = currentRetry;
-  session.stop_hook_active = true;
-  session.last_stop_at = Date.now();
+  // Reset session state
+  session.stop_hook_active = false;
+  session.retry_count = 0;
+  session.last_stop_at = 0;
   writeSession(session);
 
   try {
     appendEvidence({
       hook: HOOK_NAME,
       event: "Stop",
-      decision: "deny",
-      reason: `Retry ${currentRetry}/${MAX_RETRIES}`,
-      retry_count: currentRetry,
+      decision: "allow",
+      reason: "Session end checklist displayed",
       session_id: sessionId,
     });
   } catch {
     // Evidence failure is non-blocking
   }
 
-  // Stop hooks use "block"/"approve", not "deny"/"allow"
-  process.stdout.write(
-    `${JSON.stringify({ decision: "block", reason: `[sh-circuit-breaker] リトライ ${currentRetry}/${MAX_RETRIES}。まだ停止しないでください。別のアプローチを試してください。` })}\n`,
+  // Show checklist and allow stop
+  allow(
+    [
+      "[session-end] チェックリスト:",
+      "  □ Worktree 未コミット変更はないか？ (git worktree list)",
+      "  □ PR 提出済み / Builder への差し戻し完了？",
+      "  □ backlog.yaml のタスクステータスは最新か？",
+      "  □ ROADMAP.md の再 sync が必要か？ (sync-roadmap.ps1)",
+      "  □ HANDOFF.md は更新済みか？",
+    ].join("\n"),
   );
-  process.exit(2);
 } catch (_err) {
   // Control hook — fail-open (allow stop on error)
   allow();
 }
-
-// ---------------------------------------------------------------------------
-// Exports (for testing)
-// ---------------------------------------------------------------------------
-
-module.exports = {
-  MAX_RETRIES,
-};


### PR DESCRIPTION
## Summary

- Replace retry-based Stop blocking with session-end checklist
- Stop is allowed immediately (no more 3-retry loop)
- Checklist reminds: worktree, PR, backlog, ROADMAP, HANDOFF

## Test plan

- [x] Pester 61/61 passed
- [x] Stop test: exit 0 + checklist displayed

🤖 Generated with [Claude Code](https://claude.com/claude-code)