### PR TITLE
fix: apply stripHeredocBodies to Rule 2 in orchestra-gate hook (#300)

### DIFF
--- a/.claude/hooks/sh-orchestra-gate.js
+++ b/.claude/hooks/sh-orchestra-gate.js
@@ -29,7 +29,8 @@ try {
 
   // Rule 2: No direct winsmux send-keys (use winsmux send)
   if (toolName === "Bash") {
-    if (/winsmux\s+send-keys/.test(rawCommand) && !/winsmux-core/.test(rawCommand)) {
+    const commandForRule2 = stripHeredocBodies(rawCommand);
+    if (/winsmux\s+send-keys/.test(commandForRule2) && !/winsmux-core/.test(commandForRule2)) {
       deny("Use winsmux send instead of direct winsmux send-keys.");
     }
   }


### PR DESCRIPTION
## Summary
- Rule 2 in sh-orchestra-gate.js now uses `stripHeredocBodies()` before regex matching
- Prevents false positives when heredoc body text contains blocked patterns (e.g. `gh issue create` with body mentioning the pattern)
- Consistent with Rule 3 which already uses this approach

## Codex Reviewer
PASS — correct, minimal, consistent with Rule 3. Residual edge cases are in the shared helper, not this change.

## Test plan
- [x] 9/9 existing gate enforcement tests pass
- [x] 2/2 new heredoc-specific tests pass (in worktree, gitignored)
- [ ] Verify `gh issue create` with pattern in body is no longer blocked

Closes #300

🤖 Generated with [Claude Code](https://claude.com/claude-code)