### PR TITLE
feat: dispatch infrastructure — exec-per-task model (#286, #288)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ docs/ROLE-DEFINITIONS.md
 docs/REQUIREMENTS.md
 .references/
 .tmp-hook-*
+.review-*
 tasks/
 /skills/
 tests/

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -798,31 +798,104 @@ function Invoke-Send {
     $paneId = Resolve-Target $Target
     $paneId = Confirm-Target $paneId
 
-    # Step 1: Type text directly (no header — headers break TUI agents like Claude Code)
-    & winsmux send-keys -t $paneId -l -- "$text"
+    $sendCommandToPane = {
+        param([Parameter(Mandatory = $true)][string]$CommandText)
 
-    # Step 2: Verify text landed
-    Start-Sleep -Milliseconds 300
+        # Type text directly (no header; headers break TUI agents like Claude Code)
+        & winsmux send-keys -t $paneId -l -- "$CommandText"
 
-    # Step 3: Submit with Enter
-    & winsmux send-keys -t $paneId Enter
-    Start-Sleep -Milliseconds 500
-    $postEnterSnapshot = & winsmux capture-pane -t $paneId -p -J -S "-200"
-    $postEnterText = ($postEnterSnapshot | Out-String).TrimEnd()
-    if ($postEnterText -match '\[Pasted Content') {
+        Start-Sleep -Milliseconds 300
+
         & winsmux send-keys -t $paneId Enter
+        Start-Sleep -Milliseconds 500
+        $postEnterSnapshot = & winsmux capture-pane -t $paneId -p -J -S "-200"
+        $postEnterText = ($postEnterSnapshot | Out-String).TrimEnd()
+        if ($postEnterText -match '\[Pasted Content') {
+            & winsmux send-keys -t $paneId Enter
+        }
+
+        Start-Sleep -Milliseconds 800
+        $snapshot = & winsmux capture-pane -t $paneId -p -J -S "-200"
+        $snapshotText = ($snapshot | Out-String).TrimEnd()
+        Save-Watermark $paneId $snapshotText
+
+        Set-ReadMark $paneId
+
+        Write-Output "sent to $paneId"
     }
 
-    # Step 4: Save watermark for change detection in subsequent read calls
-    Start-Sleep -Milliseconds 800
-    $snapshot = & winsmux capture-pane -t $paneId -p -J -S "-200"
-    $snapshotText = ($snapshot | Out-String).TrimEnd()
-    Save-Watermark $paneId $snapshotText
+    try {
+        if (Test-Path $PaneControlScript -PathType Leaf) {
+            . $PaneControlScript
+        }
 
-    # Reset read mark so next read works without guard error
-    Set-ReadMark $paneId
+        if (Test-Path $BridgeSettingsScript -PathType Leaf) {
+            . $BridgeSettingsScript
+        }
 
-    Write-Output "sent to $paneId"
+        $hasManifestHelper = Get-Command Get-PaneControlManifestContext -ErrorAction SilentlyContinue
+        $hasRoleConfigHelper = Get-Command Get-RoleAgentConfig -ErrorAction SilentlyContinue
+        if ($null -ne $hasManifestHelper -and $null -ne $hasRoleConfigHelper) {
+            $projectDir = (Get-Location).Path
+            $context = Get-PaneControlManifestContext -ProjectDir $projectDir -PaneId $paneId
+            if ($null -ne $context -and -not [string]::IsNullOrWhiteSpace([string]$context.ManifestPath)) {
+                $manifestContent = Get-Content -LiteralPath $context.ManifestPath -Raw -Encoding UTF8
+                $manifest = ConvertFrom-PaneControlManifestContent -Content $manifestContent
+                $manifestPane = $null
+                if ($null -ne $manifest -and $null -ne $manifest.Panes -and $manifest.Panes.Contains([string]$context.Label)) {
+                    $manifestPane = $manifest.Panes[[string]$context.Label]
+                }
+
+                $execModeValue = ''
+                if ($null -ne $manifestPane) {
+                    if ($manifestPane -is [System.Collections.IDictionary] -and $manifestPane.Contains('exec_mode')) {
+                        $execModeValue = [string]$manifestPane['exec_mode']
+                    } elseif ($null -ne $manifestPane.PSObject -and $manifestPane.PSObject.Properties.Name -contains 'exec_mode') {
+                        $execModeValue = [string]$manifestPane.exec_mode
+                    }
+                }
+
+                $roleAgentConfig = Get-RoleAgentConfig -Role $context.Role
+                $agent = [string]$roleAgentConfig.Agent
+                if ($execModeValue.Trim().ToLowerInvariant() -eq 'true' -and $agent.Trim().ToLowerInvariant() -eq 'codex') {
+                    $quotePowerShellLiteral = {
+                        param([Parameter(Mandatory = $true)][AllowEmptyString()][string]$Value)
+
+                        $paneControlLiteralHelper = Get-Command ConvertTo-PaneControlPowerShellLiteral -ErrorAction SilentlyContinue
+                        if ($null -ne $paneControlLiteralHelper) {
+                            return ConvertTo-PaneControlPowerShellLiteral -Value $Value
+                        }
+
+                        $genericLiteralHelper = Get-Command ConvertTo-PowerShellLiteral -ErrorAction SilentlyContinue
+                        if ($null -ne $genericLiteralHelper) {
+                            return ConvertTo-PowerShellLiteral -Value $Value
+                        }
+
+                        throw 'No PowerShell literal helper is available.'
+                    }
+
+                    $promptPath = New-DispatchPromptFile -Content $text -ProjectDir $projectDir
+                    $outputPath = '{0}.last-message.txt' -f $promptPath
+                    $launchDir = [string]$context.LaunchDir
+                    $gitWorktreeDir = [string]$context.GitWorktreeDir
+                    $model = [string]$roleAgentConfig.Model
+                    $promptInstruction = 'Read the prompt file at {0} and follow its instructions' -f $promptPath
+                    $dispatchCommand = 'codex exec --full-auto -C {0} --add-dir {1} -o {2} -m {3} {4}' -f `
+                        (& $quotePowerShellLiteral $launchDir), `
+                        (& $quotePowerShellLiteral $gitWorktreeDir), `
+                        (& $quotePowerShellLiteral $outputPath), `
+                        (& $quotePowerShellLiteral $model), `
+                        (& $quotePowerShellLiteral $promptInstruction)
+
+                    & $sendCommandToPane $dispatchCommand
+                    return
+                }
+            }
+        }
+    } catch {
+    }
+
+    & $sendCommandToPane $text
 }
 
 function Invoke-Name {

--- a/winsmux-core/scripts/agent-monitor.ps1
+++ b/winsmux-core/scripts/agent-monitor.ps1
@@ -415,6 +415,21 @@ function Test-CodexContextExhaustionText {
     return $false
 }
 
+function Test-PowerShellPromptText {
+    param([AllowNull()][string]$Text)
+
+    if ([string]::IsNullOrWhiteSpace($Text)) {
+        return $false
+    }
+
+    $lastLine = Get-LastNonEmptyLine -Text $Text
+    if ($null -eq $lastLine) {
+        return $false
+    }
+
+    return $lastLine.TrimStart() -match '^PS [A-Z]:\\'
+}
+
 function Wait-MonitorPaneShellReady {
     param(
         [Parameter(Mandatory = $true)][string]$PaneId,
@@ -540,12 +555,13 @@ function Get-PaneAgentStatus {
     Captures pane output and returns the agent status.
 
     .OUTPUTS
-    PSCustomObject with: Status (ready|busy|approval_waiting|crashed|hung|empty), PaneId, SnapshotTail, ExitReason
+    PSCustomObject with: Status (ready|waiting_for_dispatch|busy|approval_waiting|crashed|hung|empty), PaneId, SnapshotTail, ExitReason
     #>
     param(
         [Parameter(Mandatory = $true)][string]$PaneId,
         [string]$Agent = 'codex',
         [string]$Role = '',
+        [bool]$ExecMode = $false,
         [int]$HungThreshold = $script:AgentMonitorDefaultHungThreshold
     )
 
@@ -622,7 +638,18 @@ function Get-PaneAgentStatus {
     }
 
     # crashed: PowerShell prompt visible (PS C:\) - Codex exited
-    if ($trimmed -match '^PS [A-Z]:\\') {
+    if (Test-PowerShellPromptText -Text $text) {
+        if ($ExecMode) {
+            Save-MonitorSnapshot -PaneId $PaneId -Hash (Get-ContentHash -Text $text) -Timestamp (Get-Date -Format o)
+            return [PSCustomObject]@{
+                Status       = 'waiting_for_dispatch'
+                PaneId       = $PaneId
+                SnapshotTail = $tail
+                SnapshotHash = $snapshotHash
+                ExitReason   = ''
+            }
+        }
+
         if ($Role -eq 'Builder') {
             Save-MonitorSnapshot -PaneId $PaneId -Hash (Get-ContentHash -Text $text) -Timestamp (Get-Date -Format o)
             return [PSCustomObject]@{
@@ -743,6 +770,17 @@ function Invoke-AgentRespawn {
         }
     }
 
+    if ($paneExecMode) {
+        $currentStatus = Get-PaneAgentStatus -PaneId $PaneId -Agent $Agent -Role $paneRole -ExecMode $true
+        if ($currentStatus.Status -eq 'waiting_for_dispatch') {
+            return [PSCustomObject]@{
+                Success = $true
+                PaneId  = $PaneId
+                Message = "Pane $PaneId is waiting for dispatch in exec_mode; skipping respawn"
+            }
+        }
+    }
+
     try {
         Invoke-MonitorWinsmux -Arguments @('respawn-pane', '-k', '-t', $PaneId, '-c', $ProjectDir)
         Wait-MonitorPaneShellReady -PaneId $PaneId
@@ -761,7 +799,7 @@ function Invoke-AgentRespawn {
     $deadline = (Get-Date).AddSeconds($ReadyTimeoutSeconds)
     while ((Get-Date) -lt $deadline) {
         Start-Sleep -Seconds 3
-        $status = Get-PaneAgentStatus -PaneId $PaneId -Agent $Agent -Role $paneRole
+        $status = Get-PaneAgentStatus -PaneId $PaneId -Agent $Agent -Role $paneRole -ExecMode $paneExecMode
         if ($status.Status -eq 'ready') {
             $successMessage = if ($paneExecMode) {
                 "Pane respawned successfully in exec_mode for pane $PaneId"
@@ -852,6 +890,7 @@ function Invoke-AgentMonitorCycle {
         $pane = $manifest.Panes[$label]
         $paneId = [string](Get-MonitorPropertyValue -InputObject $pane -Name 'pane_id' -Default '')
         $role = [string](Get-MonitorPropertyValue -InputObject $pane -Name 'role' -Default '')
+        $paneExecMode = [string](Get-MonitorPropertyValue -InputObject $pane -Name 'exec_mode' -Default '').Trim().ToLowerInvariant() -eq 'true'
 
         if ([string]::IsNullOrWhiteSpace($paneId)) {
             continue
@@ -873,7 +912,7 @@ function Invoke-AgentMonitorCycle {
         $modelName = [string]$roleAgentConfig.Model
 
         $checkedCount++
-        $status = Get-PaneAgentStatus -PaneId $paneId -Agent $agentName -Role $role -HungThreshold $IdleThreshold
+        $status = Get-PaneAgentStatus -PaneId $paneId -Agent $agentName -Role $role -ExecMode $paneExecMode -HungThreshold $IdleThreshold
         $statusName = [string](Get-MonitorPropertyValue -InputObject $status -Name 'Status' -Default '')
         $statusExitReason = [string](Get-MonitorPropertyValue -InputObject $status -Name 'ExitReason' -Default '')
         $statusSnapshotTail = [string](Get-MonitorPropertyValue -InputObject $status -Name 'SnapshotTail' -Default '')
@@ -896,10 +935,6 @@ function Invoke-AgentMonitorCycle {
             $approvalMessage = "Commander alert: $label ($paneId) awaiting approval"
             $result.Message = $approvalMessage
             Write-Output $approvalMessage
-            try {
-                Send-MonitorTelegramAlert -Message $approvalMessage | Out-Null
-            } catch {
-            }
         }
 
         $idleAlert = Update-MonitorIdleAlertState `
@@ -916,10 +951,6 @@ function Invoke-AgentMonitorCycle {
             $result.IdleAlerted = $true
             $result.Message = $idleAlert.Message
             Write-Output $idleAlert.Message
-            try {
-                Send-MonitorTelegramAlert -Message $idleAlert.Message -AlertType 'idle' -ProjectDir $projectDir | Out-Null
-            } catch {
-            }
         }
 
         $stallDetected = Test-BuilderStall -PaneId $paneId -Role $role -Status $statusName -SnapshotHash $statusSnapshotHash
@@ -929,10 +960,6 @@ function Invoke-AgentMonitorCycle {
             $stallMessage = "Commander alert: stalled Builder pane $label ($paneId)"
             $result.Message = $stallMessage
             Write-Output $stallMessage
-            try {
-                Send-MonitorTelegramAlert -Message $stallMessage | Out-Null
-            } catch {
-            }
         }
 
         # Log the status check
@@ -947,7 +974,12 @@ function Invoke-AgentMonitorCycle {
             }
         }
 
-        if ($statusName -eq 'crashed' -or ($statusName -eq 'ready' -and $statusExitReason -eq 'exec_completed')) {
+        $shouldRespawn = $statusName -eq 'crashed' -or ($statusName -eq 'ready' -and $statusExitReason -eq 'exec_completed')
+        if ($paneExecMode -and $statusName -eq 'waiting_for_dispatch') {
+            $shouldRespawn = $false
+        }
+
+        if ($shouldRespawn) {
             $crashedCount++
 
             # Determine launch directory and git worktree dir

--- a/winsmux-core/scripts/orchestra-start.ps1
+++ b/winsmux-core/scripts/orchestra-start.ps1
@@ -758,8 +758,8 @@ try {
             $builderWorktreePath = $builderWorktree.WorktreePath
         }
 
-        $roleAgentConfig = Get-RoleAgentConfig -Role $canonicalRole -Settings $settings
-        $launchCommand = Get-AgentLaunchCommand -Agent $roleAgentConfig.Agent -Model $roleAgentConfig.Model -ProjectDir $launchDir -GitWorktreeDir $launchGitWorktreeDir -ExecMode $execMode
+        # TASK-186: Removed agent launch — panes stay at pwsh prompt
+
 
         Invoke-Bridge -Arguments @('name', $paneId, $label)
         try {
@@ -767,9 +767,8 @@ try {
             Set-OrchestraSessionEnvironment -SessionName $sessionName -Name 'WINSMUX_PANE_ID' -Value $paneId
             Invoke-Winsmux -Arguments @('respawn-pane', '-k', '-t', $paneId, '-c', $launchDir)
             Wait-PaneShellReady -PaneId $paneId
-            if (-not [string]::IsNullOrWhiteSpace($launchCommand)) {
-                Send-OrchestraBridgeCommand -Target $paneId -Text $launchCommand
-            }
+            # TASK-186: No agent launch. Dispatch per-task via codex exec.
+
         } finally {
             foreach ($envName in @('WINSMUX_ROLE', 'WINSMUX_PANE_ID')) {
                 try {
@@ -790,19 +789,7 @@ try {
         })
     }
 
-    foreach ($paneSummary in $paneSummaries) {
-        if ($paneSummary.ExecMode) {
-            continue
-        }
-
-        try {
-            $roleAgentConfig = Get-RoleAgentConfig -Role $paneSummary.Role -Settings $settings
-            Wait-AgentReady -PaneId $paneSummary.PaneId -Agent $roleAgentConfig.Agent -TimeoutSeconds 60
-        } catch {
-            Write-Error "Agent readiness timeout for $($paneSummary.Label) [$($paneSummary.PaneId)]: $($_.Exception.Message)"
-            exit 1
-        }
-    }
+    # TASK-186: Skip agent readiness check — panes are plain pwsh prompts.
 
     $manifestPath = Save-OrchestraSessionState -ProjectDir $projectDir -SessionName $sessionName -Settings $settings -GitWorktreeDir $gitWorktreeDir -PaneSummaries $paneSummaries
     $watchdogScriptPath = Join-Path $scriptDir 'agent-watchdog.ps1'


### PR DESCRIPTION
## Summary
- **TASK-186**: orchestra-start leaves panes at pwsh prompt, agent-monitor treats pwsh-idle as normal for exec_mode panes, removes Telegram from Commander alerts
- **TASK-184**: Invoke-Send detects exec_mode panes from manifest, uses prompt file pattern (New-DispatchPromptFile), proper escaping via ConvertTo-PowerShellLiteral
- Adds .review-* to .gitignore

## Codex Reviewer
- TASK-186: PASS
- TASK-184: PASS

## Test plan
- [x] Syntax check passed (orchestra-start.ps1, agent-monitor.ps1, winsmux-core.ps1)
- [x] 1-pane smoke test: builder-1 completed task via dispatch
- [ ] Full 6-pane dispatch cycle
- [ ] Watchdog restart with new agent-monitor

Closes #286, closes #288

🤖 Generated with [Claude Code](https://claude.com/claude-code)