### PR TITLE
fix: update Telegram alert test assertions

### DIFF
--- a/tests/Integration.MultiAgent.Tests.ps1
+++ b/tests/Integration.MultiAgent.Tests.ps1
@@ -316,7 +316,7 @@ panes:
         $output[1].IdleAlerts | Should -Be 1
         $output[1].Results[0].IdleAlerted | Should -Be $true
         $output[1].Results[0].Message | Should -Match 'Commander alert: idle pane builder-1'
-        Should -Invoke Send-MonitorTelegramAlert -Times 1 -Exactly
+        Should -Invoke Send-MonitorTelegramAlert -Times 0 -Exactly
     }
 
     It 'emits approval waiting alerts and counts them during a monitor cycle' {
@@ -358,7 +358,7 @@ panes:
         $output[1].ApprovalWaiting | Should -Be 1
         $output[1].Results[0].Status | Should -Be 'approval_waiting'
         $output[1].Results[0].Message | Should -Be 'Commander alert: builder-1 (%2) awaiting approval'
-        Should -Invoke Send-MonitorTelegramAlert -Times 1 -Exactly
+        Should -Invoke Send-MonitorTelegramAlert -Times 0 -Exactly
     }
 
     It 'emits commander alerts when a Builder stays busy with the same snapshot for three cycles' {
@@ -403,6 +403,6 @@ panes:
         $output[1].Stalls | Should -Be 1
         $output[1].Results[0].StallDetected | Should -Be $true
         $output[1].Results[0].Message | Should -Match 'Commander alert: stalled Builder pane builder-1'
-        Should -Invoke Send-MonitorTelegramAlert -Times 1 -Exactly
+        Should -Invoke Send-MonitorTelegramAlert -Times 0 -Exactly
     }
 }


### PR DESCRIPTION
## Summary
- `Send-MonitorTelegramAlert` is no longer called from agent-monitor after PR #307/#312 removed Telegram notifications
- Updated 3 test assertions from `-Times 1` to `-Times 0` in `Integration.MultiAgent.Tests.ps1` (lines 319, 361, 406)
- Fixes CI failures that have been blocking all PRs since #307

## Test plan
- [x] Integration.MultiAgent.Tests.ps1: 14/14 passed
- [x] Full test suite: 61/61 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)