### PR TITLE
fix: bypass CLM by replacing --full-auto with --sandbox danger-full-access (#319)

### DIFF
--- a/GUARDRAILS.md
+++ b/GUARDRAILS.md
@@ -83,4 +83,4 @@
 ### 16. Codex sandbox git operations
 - **Trigger**: Builder (Codex) needs to commit changes
 - **Instruction**: Builder edits only. Git operations delegated to Researcher (Sonnet) or Commander.
-- **Reason**: Codex --full-auto sandbox blocks .git/worktrees/*/index.lock creation.
+- **Reason**: Codex --sandbox danger-full-access bypasses CLM; previously --full-auto blocked .git/worktrees/*/index.lock creation.

--- a/README.ja.md
+++ b/README.ja.md
@@ -209,7 +209,7 @@ Orchestra は1人の Commander が複数の AI エージェントを並列管理
 | CLI         | 承認レスフラグ（`-ShieldHarness` 有効時） |
 | ----------- | ----------------------------------------- |
 | Claude Code | `--permission-mode bypassPermissions`     |
-| Codex CLI   | `--full-auto`                             |
+| Codex CLI   | `--sandbox danger-full-access`             |
 | Gemini CLI  | `--yolo`                                  |
 
 `-ShieldHarness` なし: フラグは付与されない（手動承認モード）。

--- a/scripts/start-orchestra.ps1
+++ b/scripts/start-orchestra.ps1
@@ -5,12 +5,12 @@
 #
 #   # Custom 3x2 with mixed agents:
 #   pwsh scripts/start-orchestra.ps1 -Rows 2 -Cols 3 -Agents @(
-#     @{label="builder-1"; command="codex --full-auto"},
-#     @{label="builder-2"; command="codex --full-auto"},
+#     @{label="builder-1"; command="codex --sandbox danger-full-access"},
+#     @{label="builder-2"; command="codex --sandbox danger-full-access"},
 #     @{label="builder-3"; command="gemini --model gemini-3.1-pro-preview --yolo"},
 #     @{label="researcher"; command="claude --model sonnet"},
 #     @{label="builder-4"; command="gemini --model gemini-3-flash-preview --yolo"},
-#     @{label="reviewer"; command="codex --full-auto"}
+#     @{label="reviewer"; command="codex --sandbox danger-full-access"}
 #   ) -ShieldHarness
 #
 # Prerequisite: user has already started winsmux in their terminal.
@@ -114,8 +114,8 @@ function Get-ApprovalFreeCommand {
     if ($Cmd -match '^claude\b' -and $Cmd -notmatch '--permission-mode') {
         return "$Cmd --permission-mode bypassPermissions"
     }
-    if ($Cmd -match '^codex\b' -and $Cmd -notmatch '--full-auto') {
-        return "$Cmd --full-auto"
+    if ($Cmd -match '^codex\b' -and $Cmd -notmatch '--sandbox') {
+        return "$Cmd --sandbox danger-full-access"
     }
     if ($Cmd -match '^gemini\b' -and $Cmd -notmatch '--yolo') {
         return "$Cmd --yolo"

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -978,7 +978,7 @@ function Invoke-Send {
                     $gitWorktreeDir = [string]$context.GitWorktreeDir
                     $model = [string]$roleAgentConfig.Model
                     $promptInstruction = 'Read the prompt file at {0} and follow its instructions' -f $promptPath
-                    $dispatchCommand = 'codex exec --full-auto -C {0} --add-dir {1} -o {2} -m {3} {4}' -f `
+                    $dispatchCommand = 'codex exec --sandbox danger-full-access -C {0} --add-dir {1} -o {2} -m {3} {4}' -f `
                         (& $quotePowerShellLiteral $launchDir), `
                         (& $quotePowerShellLiteral $gitWorktreeDir), `
                         (& $quotePowerShellLiteral $outputPath), `
@@ -1121,7 +1121,7 @@ function Invoke-Role {
 
     # Launch Codex agent
     $gitDir = Join-Path $projectDir ".git"
-    $launchCmd = "codex --full-auto -C '$projectDir' --add-dir '$gitDir'"
+    $launchCmd = "codex --sandbox danger-full-access -C '$projectDir' --add-dir '$gitDir'"
     & winsmux send-keys -t $paneId -l $launchCmd
     & winsmux send-keys -t $paneId Enter
 
@@ -1312,7 +1312,7 @@ function Invoke-Doctor {
         if ($sandbox) {
             $val = $sandbox.Matches[0].Groups[1].Value
             if ($val -eq 'elevated') {
-                Write-Output "Codex sandbox: $val [WARNING: use 'unelevated' to fix --full-auto]"
+                Write-Output "Codex sandbox: $val [WARNING: use 'unelevated' to fix --sandbox danger-full-access]"
             } else {
                 Write-Output "Codex sandbox: $val [OK]"
             }

--- a/tests/Integration.MultiAgent.Tests.ps1
+++ b/tests/Integration.MultiAgent.Tests.ps1
@@ -122,7 +122,7 @@ Describe 'agent launch helpers' {
     It 'builds the Codex launch command with quoted project and worktree paths' {
         $command = Get-AgentLaunchCommand -Agent 'codex' -Model 'gpt-5.4' -ProjectDir "C:\repo path\builder-1" -GitWorktreeDir "C:\repo path\.git"
 
-        $command | Should -Be "codex -c model=gpt-5.4 --full-auto -C 'C:\repo path\builder-1' --add-dir 'C:\repo path\.git'"
+        $command | Should -Be "codex -c model=gpt-5.4 --sandbox danger-full-access -C 'C:\repo path\builder-1' --add-dir 'C:\repo path\.git'"
     }
 
     It 'returns a CLM workaround bootstrap only for Codex builders' {

--- a/tests/psmux-bridge.Tests.ps1
+++ b/tests/psmux-bridge.Tests.ps1
@@ -566,7 +566,7 @@ Describe 'agent-monitor helpers' {
         }
         Should -Invoke Send-MonitorBridgeCommand -Times 1 -Exactly -ParameterFilter {
             $PaneId -eq '%2' -and
-            $Text -eq "codex -c model=gpt-5.4 --full-auto -C 'C:\repo\.worktrees\builder-1' --add-dir 'C:\repo\.git\worktrees\builder-1'"
+            $Text -eq "codex -c model=gpt-5.4 --sandbox danger-full-access -C 'C:\repo\.worktrees\builder-1' --add-dir 'C:\repo\.git\worktrees\builder-1'"
         }
     }
 
@@ -1032,7 +1032,7 @@ gpt-5.4   82% context left
 "@) | Should -Be 'idle'
         (Get-PaneActualStateFromText -Text @"
 Launching codex...
-codex --full-auto -C C:\repo
+codex --sandbox danger-full-access -C C:\repo
 "@) | Should -Be 'codex'
         (Get-PaneActualStateFromText -Text @"
 gpt-5.4   61% context left

--- a/winsmux-core/scripts/agent-launch.ps1
+++ b/winsmux-core/scripts/agent-launch.ps1
@@ -17,7 +17,7 @@ function Get-AgentLaunchCommand {
 
     switch ($Agent.Trim().ToLowerInvariant()) {
         'codex' {
-            return "codex -c model=$Model --full-auto -C $(ConvertTo-PowerShellLiteral -Value $ProjectDir) --add-dir $(ConvertTo-PowerShellLiteral -Value $GitWorktreeDir)"
+            return "codex -c model=$Model --sandbox danger-full-access -C $(ConvertTo-PowerShellLiteral -Value $ProjectDir) --add-dir $(ConvertTo-PowerShellLiteral -Value $GitWorktreeDir)"
         }
         'claude' {
             return 'claude --permission-mode bypassPermissions'

--- a/winsmux-core/scripts/agent-monitor.ps1
+++ b/winsmux-core/scripts/agent-monitor.ps1
@@ -799,7 +799,7 @@ function Invoke-AgentRespawn {
         'codex' {
             $escapedProject = "'" + ($ProjectDir -replace "'", "''") + "'"
             $escapedWorktree = "'" + ($GitWorktreeDir -replace "'", "''") + "'"
-            $launchCommand = "codex -c model=$Model --full-auto -C $escapedProject --add-dir $escapedWorktree"
+            $launchCommand = "codex -c model=$Model --sandbox danger-full-access -C $escapedProject --add-dir $escapedWorktree"
         }
         'claude' {
             $launchCommand = 'claude --permission-mode bypassPermissions'

--- a/winsmux-core/scripts/orchestra-start.ps1
+++ b/winsmux-core/scripts/orchestra-start.ps1
@@ -221,7 +221,7 @@ function Get-AgentLaunchCommand {
                 return ''
             }
 
-            return "codex -c model=$Model --full-auto -C $(ConvertTo-PowerShellLiteral -Value $ProjectDir) --add-dir $(ConvertTo-PowerShellLiteral -Value $GitWorktreeDir)"
+            return "codex -c model=$Model --sandbox danger-full-access -C $(ConvertTo-PowerShellLiteral -Value $ProjectDir) --add-dir $(ConvertTo-PowerShellLiteral -Value $GitWorktreeDir)"
         }
         'claude' {
             return "claude --model $Model --permission-mode bypassPermissions"

--- a/winsmux-core/scripts/pane-control.ps1
+++ b/winsmux-core/scripts/pane-control.ps1
@@ -94,7 +94,7 @@ function Get-PaneControlLaunchCommand {
 
     switch ($Agent.Trim().ToLowerInvariant()) {
         'codex' {
-            return "codex -c model=$Model --full-auto -C $(ConvertTo-PaneControlPowerShellLiteral -Value $ProjectDir) --add-dir $(ConvertTo-PaneControlPowerShellLiteral -Value $GitWorktreeDir)"
+            return "codex -c model=$Model --sandbox danger-full-access -C $(ConvertTo-PaneControlPowerShellLiteral -Value $ProjectDir) --add-dir $(ConvertTo-PaneControlPowerShellLiteral -Value $GitWorktreeDir)"
         }
         'claude' {
             return 'claude --permission-mode bypassPermissions'

--- a/winsmux-core/scripts/pane-scaler.ps1
+++ b/winsmux-core/scripts/pane-scaler.ps1
@@ -254,7 +254,7 @@ function Get-PaneScalerLaunchCommand {
 
     switch ($Agent.Trim().ToLowerInvariant()) {
         'codex' {
-            return "codex -c model=$Model --full-auto -C $(ConvertTo-PaneScalerPowerShellLiteral -Value $ProjectDir) --add-dir $(ConvertTo-PaneScalerPowerShellLiteral -Value $GitWorktreeDir)"
+            return "codex -c model=$Model --sandbox danger-full-access -C $(ConvertTo-PaneScalerPowerShellLiteral -Value $ProjectDir) --add-dir $(ConvertTo-PaneScalerPowerShellLiteral -Value $GitWorktreeDir)"
         }
         'claude' {
             return 'claude --permission-mode bypassPermissions'


### PR DESCRIPTION
## Summary
- Replace `--full-auto` (forces `workspace-write` → CLM) with `--sandbox danger-full-access` across all Codex launch points
- 13 occurrences in 10 files (source, tests, docs)
- Builder/Reviewer panes can now execute Pester tests directly

## Root cause
Codex `--full-auto` → `workspace-write` sandbox → Windows `CreateRestrictedToken` → PowerShell CLM. `--full-auto` overrides explicit `--sandbox` flag, so it must be fully removed.

## Test plan
- [x] 73/73 Pester tests pass
- [x] Verified: `codex exec --sandbox danger-full-access` → LanguageMode = FullLanguage
- [x] Verified: Pester runs inside Codex sandbox with danger-full-access

Closes #319

🤖 Generated with [Claude Code](https://claude.com/claude-code)