### PR TITLE
feat: Commander subagent edit gate (#324)

### DIFF
--- a/.claude/hooks/sh-orchestra-gate.js
+++ b/.claude/hooks/sh-orchestra-gate.js
@@ -65,11 +65,14 @@ try {
     }
   }
 
-  // Rule 9: Block Commander from using bypassPermissions on Agent subagents
+  // Rule 9: Block Commander from using write-capable Agent modes outside isolated worktrees
   if (toolName === "Agent") {
-    const mode = toolInput.mode || "";
-    if (mode === "bypassPermissions") {
-      deny("Commander cannot use bypassPermissions mode. Use default or plan mode for subagents.");
+    const agentMode = normalizeAgentValue(toolInput.mode);
+    const subagentType = normalizeAgentValue(toolInput.subagent_type);
+    const isolation = normalizeAgentValue(toolInput.isolation);
+
+    if (isolation !== "worktree" && agentMode !== "plan" && subagentType !== "explore" && isWriteCapableAgentMode(agentMode)) {
+      deny("Commander cannot use write-capable Agent modes outside worktree isolation. Use plan mode, Explore subagents, or worktree isolation.");
     }
   }
 
@@ -140,6 +143,14 @@ function stripHeredocBodies(command) {
   return output.join("\n");
 }
 
+function normalizeAgentValue(value) {
+  return typeof value === "string" ? value.trim().toLowerCase() : "";
+}
+
+function isWriteCapableAgentMode(mode) {
+  return mode === "acceptedits" || mode === "auto" || mode === "bypasspermissions" || mode === "dontask";
+}
+
 function getCurrentBranch(repoRoot) {
   const gitDir = resolveGitDir(repoRoot);
   const headPath = path.join(gitDir, "HEAD");
@@ -175,5 +186,7 @@ function deny(reason) {
 module.exports = {
   DEBUG_LOG_PATH,
   SECRET_PATTERN,
+  isWriteCapableAgentMode,
+  normalizeAgentValue,
   stripHeredocBodies,
 };

--- a/tests/Integration.GateEnforcement.Tests.ps1
+++ b/tests/Integration.GateEnforcement.Tests.ps1
@@ -205,6 +205,68 @@ Describe 'sh-orchestra-gate integration' {
         $result.StdErr | Should -Be ''
     }
 
+    It 'denies Agent acceptEdits mode outside worktree isolation' {
+        $result = & $script:InvokeOrchestraGate -ToolName 'Agent' -ToolInput ([ordered]@{
+            mode = 'acceptEdits'
+        })
+
+        & $script:AssertDenyResult -Result $result
+        $result.ErrorObject.systemMessage | Should -Match 'write-capable Agent modes'
+    }
+
+    It 'denies Agent auto mode outside worktree isolation' {
+        $result = & $script:InvokeOrchestraGate -ToolName 'Agent' -ToolInput ([ordered]@{
+            mode = 'auto'
+        })
+
+        & $script:AssertDenyResult -Result $result
+    }
+
+    It 'denies Agent dontAsk mode outside worktree isolation' {
+        $result = & $script:InvokeOrchestraGate -ToolName 'Agent' -ToolInput ([ordered]@{
+            mode = 'dontAsk'
+        })
+
+        & $script:AssertDenyResult -Result $result
+    }
+
+    It 'denies Agent bypassPermissions mode outside worktree isolation' {
+        $result = & $script:InvokeOrchestraGate -ToolName 'Agent' -ToolInput ([ordered]@{
+            mode = 'bypassPermissions'
+        })
+
+        & $script:AssertDenyResult -Result $result
+    }
+
+    It 'allows Agent plan mode' {
+        $result = & $script:InvokeOrchestraGate -ToolName 'Agent' -ToolInput ([ordered]@{
+            mode = 'plan'
+        })
+
+        $result.ExitCode | Should -Be 0
+        $result.StdErr | Should -Be ''
+    }
+
+    It 'allows Explore subagents even when mode is write-capable' {
+        $result = & $script:InvokeOrchestraGate -ToolName 'Agent' -ToolInput ([ordered]@{
+            mode          = 'acceptEdits'
+            subagent_type = 'Explore'
+        })
+
+        $result.ExitCode | Should -Be 0
+        $result.StdErr | Should -Be ''
+    }
+
+    It 'allows Agent write-capable modes when isolation is worktree' {
+        $result = & $script:InvokeOrchestraGate -ToolName 'Agent' -ToolInput ([ordered]@{
+            mode      = 'auto'
+            isolation = 'worktree'
+        })
+
+        $result.ExitCode | Should -Be 0
+        $result.StdErr | Should -Be ''
+    }
+
     It 'Rule 7 removed verify command not yet implemented' {
         $result = & $script:InvokeOrchestraGate -ToolName 'Bash' -ToolInput @{
             command = 'gh pr merge 112 --squash --delete-branch'


### PR DESCRIPTION
## Summary
- Block Agent tool calls with write-capable modes (acceptEdits, auto, dontAsk) from Commander
- Allow: plan mode, Explore subagent type, worktree-isolated agents
- Extends sh-orchestra-gate.js Rule 5 (Agent permissions)

## Test plan
- [x] 80/80 Pester tests pass
- [x] Integration tests for Agent mode deny/allow scenarios

Closes #324

🤖 Generated with [Claude Code](https://claude.com/claude-code)