### PR TITLE
feat: watchdog → events.jsonl for idle/approval/stall (#317)

### DIFF
--- a/tests/psmux-bridge.Tests.ps1
+++ b/tests/psmux-bridge.Tests.ps1
@@ -718,6 +718,156 @@ panes:
         }
     }
 
+    It 'writes state, idle, and stalled events for detected pane states during a monitor cycle' {
+        $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('winsmux-agent-monitor-tests-' + [guid]::NewGuid().ToString('N'))
+        $manifestDir = Join-Path $tempRoot '.winsmux'
+        $manifestPath = Join-Path $manifestDir 'manifest.yaml'
+        $eventsPath = Join-Path $manifestDir 'events.jsonl'
+
+        try {
+            New-Item -ItemType Directory -Path $manifestDir -Force | Out-Null
+@"
+version: 1
+session:
+  name: winsmux-orchestra
+  project_dir: $tempRoot
+panes:
+  - label: builder-1
+    pane_id: %2
+    role: Builder
+  - label: reviewer-1
+    pane_id: %3
+    role: Reviewer
+  - label: builder-2
+    pane_id: %4
+    role: Builder
+  - label: researcher-1
+    pane_id: %5
+    role: Researcher
+  - label: reviewer-2
+    pane_id: %6
+    role: Reviewer
+  - label: builder-3
+    pane_id: %7
+    role: Builder
+"@ | Set-Content -Path $manifestPath -Encoding UTF8
+
+            Mock Get-PaneAgentStatus {
+                switch ($PaneId) {
+                    '%2' {
+                        return [ordered]@{
+                            Status       = 'ready'
+                            PaneId       = '%2'
+                            SnapshotTail = '> '
+                            SnapshotHash = 'hash-ready'
+                            ExitReason   = ''
+                        }
+                    }
+                    '%3' {
+                        return [ordered]@{
+                            Status       = 'approval_waiting'
+                            PaneId       = '%3'
+                            SnapshotTail = 'approval'
+                            SnapshotHash = 'hash-approval'
+                            ExitReason   = ''
+                        }
+                    }
+                    '%4' {
+                        return [ordered]@{
+                            Status       = 'busy'
+                            PaneId       = '%4'
+                            SnapshotTail = 'working'
+                            SnapshotHash = 'hash-busy'
+                            ExitReason   = ''
+                        }
+                    }
+                    '%5' {
+                        return [ordered]@{
+                            Status       = 'waiting_for_dispatch'
+                            PaneId       = '%5'
+                            SnapshotTail = 'PS C:\repo>'
+                            SnapshotHash = 'hash-dispatch'
+                            ExitReason   = ''
+                        }
+                    }
+                    '%6' {
+                        return [ordered]@{
+                            Status       = 'hung'
+                            PaneId       = '%6'
+                            SnapshotTail = 'same output'
+                            SnapshotHash = 'hash-hung'
+                            ExitReason   = ''
+                        }
+                    }
+                    '%7' {
+                        return [ordered]@{
+                            Status       = 'empty'
+                            PaneId       = '%7'
+                            SnapshotTail = ''
+                            SnapshotHash = ''
+                            ExitReason   = ''
+                        }
+                    }
+                    default {
+                        throw "unexpected pane id: $PaneId"
+                    }
+                }
+            }
+            Mock Update-MonitorIdleAlertState {
+                if ($PaneId -eq '%2') {
+                    return [ordered]@{
+                        ShouldAlert = $true
+                        Message     = 'Commander alert: idle pane builder-1 (%2, role=Builder)'
+                    }
+                }
+
+                return [ordered]@{
+                    ShouldAlert = $false
+                    Message     = ''
+                }
+            }
+            Mock Test-BuilderStall {
+                return $PaneId -eq '%4'
+            }
+            Mock Send-MonitorTelegramAlert { $true }
+
+            $output = @(Invoke-AgentMonitorCycle -Settings ([ordered]@{
+                agent = 'codex'
+                model = 'gpt-5.4'
+                roles = [ordered]@{}
+            }) -ManifestPath $manifestPath -SessionName 'winsmux-orchestra' -IdleThreshold 120)
+            $result = $output[-1]
+
+            $result.Checked | Should -Be 6
+            $result.Crashed | Should -Be 0
+            $result.ApprovalWaiting | Should -Be 1
+            $result.IdleAlerts | Should -Be 1
+            $result.Stalls | Should -Be 1
+
+            $events = @(Get-Content -Path $eventsPath -Encoding UTF8 | Where-Object { $_ } | ForEach-Object { $_ | ConvertFrom-Json })
+            $eventNames = @($events | ForEach-Object { $_.event })
+
+            $eventNames.Count | Should -Be 8
+            $eventNames | Should -Be @(
+                'pane.ready',
+                'pane.idle',
+                'pane.approval_waiting',
+                'pane.busy',
+                'pane.stalled',
+                'pane.waiting_for_dispatch',
+                'pane.hung',
+                'pane.empty'
+            )
+            $events[1].data.idle_threshold_seconds | Should -Be 120
+            $events[4].data.required_cycles | Should -Be 3
+            Should -Invoke Send-MonitorTelegramAlert -Times 1 -Exactly
+        } finally {
+            if (Test-Path $tempRoot) {
+                Remove-Item -Path $tempRoot -Recurse -Force
+            }
+        }
+    }
+
     It 'skips relaunch dispatch for exec_mode Researcher panes' {
         $manifestRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('winsmux-agent-monitor-tests-' + [guid]::NewGuid().ToString('N'))
         $manifestPath = Join-Path $manifestRoot 'manifest.yaml'
@@ -824,6 +974,36 @@ Describe 'agent-watchdog helpers' {
             $SessionName -eq 'winsmux-orchestra' -and
             $IdleThreshold -eq 120
         }
+    }
+
+    It 'builds a stdout summary that points to events.jsonl' {
+        $summary = Get-AgentWatchdogSummary -CycleResult ([ordered]@{
+            Checked         = 2
+            Crashed         = 1
+            Respawned       = 1
+            ApprovalWaiting = 1
+            IdleAlerts      = 1
+            Stalls          = 1
+            Results         = @(
+                [ordered]@{
+                    Label      = 'builder-1'
+                    PaneId     = '%2'
+                    Status     = 'busy'
+                    ExitReason = ''
+                    Respawned  = $false
+                    Message    = ''
+                }
+            )
+        }) -ManifestPath 'C:\repo\.winsmux\manifest.yaml' -SessionName 'winsmux-orchestra'
+
+        $summary.session | Should -Be 'winsmux-orchestra'
+        $summary.events_path | Should -Be 'C:\repo\.winsmux\events.jsonl'
+        $summary.checked | Should -Be 2
+        $summary.approval_waiting | Should -Be 1
+        $summary.idle_alerts | Should -Be 1
+        $summary.stalls | Should -Be 1
+        $summary.results.Count | Should -Be 1
+        $summary.results[0].Label | Should -Be 'builder-1'
     }
 }
 

--- a/winsmux-core/scripts/agent-monitor.ps1
+++ b/winsmux-core/scripts/agent-monitor.ps1
@@ -529,6 +529,51 @@ function Write-MonitorEvent {
     }
 }
 
+function Get-MonitorStateEventName {
+    param(
+        [Parameter(Mandatory = $true)][string]$Status,
+        [string]$ExitReason = ''
+    )
+
+    switch ($Status) {
+        'approval_waiting' { return 'pane.approval_waiting' }
+        'busy' { return 'pane.busy' }
+        'crashed' { return 'pane.crashed' }
+        'empty' { return 'pane.empty' }
+        'hung' { return 'pane.hung' }
+        'ready' {
+            if ($ExitReason -eq 'exec_completed') {
+                return 'pane.completed'
+            }
+
+            return 'pane.ready'
+        }
+        'waiting_for_dispatch' { return 'pane.waiting_for_dispatch' }
+        default { return '' }
+    }
+}
+
+function Get-MonitorStateEventMessage {
+    param(
+        [Parameter(Mandatory = $true)][string]$Event,
+        [Parameter(Mandatory = $true)][string]$Label,
+        [Parameter(Mandatory = $true)][string]$PaneId,
+        [Parameter(Mandatory = $true)][string]$Status
+    )
+
+    switch ($Event) {
+        'pane.approval_waiting' { return "Pane $Label ($PaneId) awaiting approval." }
+        'pane.busy' { return "Pane $Label ($PaneId) is busy." }
+        'pane.completed' { return "Pane $Label ($PaneId) completed." }
+        'pane.crashed' { return "Pane $Label ($PaneId) crashed." }
+        'pane.empty' { return "Pane $Label ($PaneId) is empty." }
+        'pane.hung' { return "Pane $Label ($PaneId) is hung." }
+        'pane.ready' { return "Pane $Label ($PaneId) is ready." }
+        'pane.waiting_for_dispatch' { return "Pane $Label ($PaneId) is waiting for dispatch." }
+        default { return "Pane $Label ($PaneId) detected as $Status." }
+    }
+}
+
 function Write-MonitorIdleAlertLog {
     param(
         [Parameter(Mandatory = $true)][string]$Message,
@@ -1087,6 +1132,8 @@ function Invoke-AgentMonitorCycle {
             Crashed   = 0
             Respawned = 0
             ApprovalWaiting = 0
+            IdleAlerts = 0
+            Stalls = 0
             Results   = @()
         }
     }
@@ -1139,6 +1186,8 @@ function Invoke-AgentMonitorCycle {
 
         $agentName = [string]$roleAgentConfig.Agent
         $modelName = [string]$roleAgentConfig.Model
+        $launchDirFromManifest = [string](Get-MonitorPropertyValue -InputObject $pane -Name 'launch_dir' -Default '')
+        $builderWorktreePath = [string](Get-MonitorPropertyValue -InputObject $pane -Name 'builder_worktree_path' -Default '')
 
         $checkedCount++
         $status = Get-PaneAgentStatus -PaneId $paneId -Agent $agentName -Role $role -ExecMode $paneExecMode -HungThreshold $IdleThreshold
@@ -1157,6 +1206,28 @@ function Invoke-AgentMonitorCycle {
             IdleAlerted = $false
             StallDetected = $false
             Message    = ''
+        }
+
+        $stateEventName = Get-MonitorStateEventName -Status $statusName -ExitReason $statusExitReason
+        if (-not [string]::IsNullOrWhiteSpace($stateEventName)) {
+            $stateEventData = [ordered]@{
+                agent         = $agentName
+                model         = $modelName
+                exec_mode     = $paneExecMode
+                snapshot_hash = $statusSnapshotHash
+            }
+            if (-not [string]::IsNullOrWhiteSpace($launchDirFromManifest)) {
+                $stateEventData['launch_dir'] = $launchDirFromManifest
+            }
+            if (-not [string]::IsNullOrWhiteSpace($builderWorktreePath)) {
+                $stateEventData['builder_worktree_path'] = $builderWorktreePath
+            }
+
+            $stateEventMessage = Get-MonitorStateEventMessage -Event $stateEventName -Label $label -PaneId $paneId -Status $statusName
+            Write-MonitorEvent -ProjectDir $projectDir -SessionName $SessionName `
+                -Event $stateEventName -Message $stateEventMessage `
+                -Label $label -PaneId $paneId -Role $role -Status $statusName -ExitReason $statusExitReason `
+                -Data $stateEventData | Out-Null
         }
 
         if ($statusName -eq 'approval_waiting') {
@@ -1180,6 +1251,15 @@ function Invoke-AgentMonitorCycle {
             $result['IdleAlerted'] = $true
             $result['Message'] = $idleAlert.Message
             Write-Output $idleAlert.Message
+            Write-MonitorEvent -ProjectDir $projectDir -SessionName $SessionName `
+                -Event 'pane.idle' -Message $idleAlert.Message `
+                -Label $label -PaneId $paneId -Role $role -Status $statusName -ExitReason $statusExitReason `
+                -Data ([ordered]@{
+                    agent                  = $agentName
+                    model                  = $modelName
+                    idle_threshold_seconds = $IdleThreshold
+                    snapshot_hash          = $statusSnapshotHash
+                }) | Out-Null
             try {
                 Send-MonitorTelegramAlert -Message $idleAlert.Message -AlertType 'idle' -ProjectDir $projectDir | Out-Null
             } catch {
@@ -1193,6 +1273,15 @@ function Invoke-AgentMonitorCycle {
             $stallMessage = "Commander alert: stalled Builder pane $label ($paneId)"
             $result['Message'] = $stallMessage
             Write-Output $stallMessage
+            Write-MonitorEvent -ProjectDir $projectDir -SessionName $SessionName `
+                -Event 'pane.stalled' -Message $stallMessage `
+                -Label $label -PaneId $paneId -Role $role -Status $statusName -ExitReason $statusExitReason `
+                -Data ([ordered]@{
+                    agent            = $agentName
+                    model            = $modelName
+                    required_cycles  = $script:BuilderStallThresholdCycles
+                    snapshot_hash    = $statusSnapshotHash
+                }) | Out-Null
         }
 
         # Log the status check
@@ -1220,9 +1309,6 @@ function Invoke-AgentMonitorCycle {
             $launchGitWorktreeDir = $null
             $launchGitWorktreeDir = [string](Get-MonitorPropertyValue -InputObject $manifest.Session -Name 'git_worktree_dir' -Default '')
 
-            # Builder panes use their worktree path
-            $builderWorktreePath = [string](Get-MonitorPropertyValue -InputObject $pane -Name 'builder_worktree_path' -Default '')
-
             if (-not [string]::IsNullOrWhiteSpace($builderWorktreePath) -and (Test-Path $builderWorktreePath -PathType Container)) {
                 $launchDir = $builderWorktreePath
                 # Derive git worktree dir for the builder worktree
@@ -1240,26 +1326,6 @@ function Invoke-AgentMonitorCycle {
             if ([string]::IsNullOrWhiteSpace($launchGitWorktreeDir)) {
                 $launchGitWorktreeDir = $launchDir
             }
-
-            $monitorEventName = if ($statusName -eq 'ready' -and $statusExitReason -eq 'exec_completed') {
-                'pane.completed'
-            } else {
-                'pane.crashed'
-            }
-            $monitorEventMessage = if ($monitorEventName -eq 'pane.completed') {
-                "Pane $label ($paneId) completed."
-            } else {
-                "Pane $label ($paneId) crashed."
-            }
-            Write-MonitorEvent -ProjectDir $projectDir -SessionName $SessionName `
-                -Event $monitorEventName -Message $monitorEventMessage `
-                -Label $label -PaneId $paneId -Role $role -Status $statusName -ExitReason $statusExitReason `
-                -Data ([ordered]@{
-                    agent            = $agentName
-                    model            = $modelName
-                    launch_dir       = $launchDir
-                    git_worktree_dir = $launchGitWorktreeDir
-                }) | Out-Null
 
             # Log respawn attempt
             if ($loggerAvailable) {

--- a/winsmux-core/scripts/agent-watchdog.ps1
+++ b/winsmux-core/scripts/agent-watchdog.ps1
@@ -24,6 +24,27 @@ function Invoke-AgentWatchdogCycle {
     return (Invoke-AgentMonitorCycle -Settings $settings -ManifestPath $ManifestPath -SessionName $SessionName -IdleThreshold $IdleThreshold)
 }
 
+function Get-AgentWatchdogSummary {
+    param(
+        [Parameter(Mandatory = $true)]$CycleResult,
+        [Parameter(Mandatory = $true)][string]$ManifestPath,
+        [Parameter(Mandatory = $true)][string]$SessionName
+    )
+
+    return [ordered]@{
+        session          = $SessionName
+        manifest_path    = $ManifestPath
+        events_path      = Join-Path (Split-Path -Parent $ManifestPath) 'events.jsonl'
+        checked          = [int]$CycleResult.Checked
+        crashed          = [int]$CycleResult.Crashed
+        respawned        = [int]$CycleResult.Respawned
+        approval_waiting = [int]$CycleResult.ApprovalWaiting
+        idle_alerts      = [int]$CycleResult.IdleAlerts
+        stalls           = [int]$CycleResult.Stalls
+        results          = @($CycleResult.Results)
+    }
+}
+
 function Start-AgentWatchdogLoop {
     param(
         [Parameter(Mandatory = $true)][string]$ManifestPath,
@@ -35,7 +56,9 @@ function Start-AgentWatchdogLoop {
     while ($true) {
         try {
             $result = Invoke-AgentWatchdogCycle -ManifestPath $ManifestPath -SessionName $SessionName -IdleThreshold $IdleThreshold
-            Write-Output ($result | ConvertTo-Json -Depth 8 -Compress)
+            # Invoke-AgentMonitorCycle persists pane events into events.jsonl; the watchdog publishes only the cycle summary.
+            $summary = Get-AgentWatchdogSummary -CycleResult $result -ManifestPath $ManifestPath -SessionName $SessionName
+            Write-Output ($summary | ConvertTo-Json -Depth 8 -Compress)
         } catch {
             Write-Warning ("Watchdog cycle failed for session {0}: {1}" -f $SessionName, $_.Exception.Message)
         }


### PR DESCRIPTION
## Summary
- Write-MonitorEvent calls for pane.idle, pane.approval_waiting, pane.stalled
- Watchdog writes all detected states to events.jsonl
- Commander can poll via poll-events command (merged in #320)

## Test plan
- [x] 82/82 Pester tests pass
- [x] Event write tests for new event types

Closes #317

🤖 Generated with [Claude Code](https://claude.com/claude-code)