### PR TITLE
fix: pane alerts Commander-only, remove Telegram (#306, #290)

### DIFF
--- a/tests/Integration.MultiAgent.Tests.ps1
+++ b/tests/Integration.MultiAgent.Tests.ps1
@@ -278,7 +278,7 @@ Describe 'agent monitor idle alerts' {
         $stateAfterBusy | Should -BeNullOrEmpty
     }
 
-    It 'emits commander alerts to stdout and telegram during a monitor cycle' {
+    It 'emits commander alerts to stdout and monitor events during a monitor cycle' {
         $manifestDir = Join-Path $script:agentMonitorTempRoot '.winsmux'
         New-Item -ItemType Directory -Path $manifestDir -Force | Out-Null
         @"
@@ -295,13 +295,18 @@ panes:
 
         Save-MonitorIdleState -PaneId '%2' -ReadySince '2026-04-05T09:57:00+09:00' -AlertSent $false
         Mock Get-PaneAgentStatus {
-            [PSCustomObject]@{
+            [ordered]@{
                 Status       = 'ready'
                 PaneId       = '%2'
                 SnapshotTail = '> '
             }
         }
-        Mock Send-MonitorTelegramAlert { return $true }
+        Mock Write-MonitorEvent {
+            return [ordered]@{
+                event   = $Event
+                message = $Message
+            }
+        }
 
         $settings = [ordered]@{
             agent = 'codex'
@@ -316,7 +321,12 @@ panes:
         $output[1].IdleAlerts | Should -Be 1
         $output[1].Results[0].IdleAlerted | Should -Be $true
         $output[1].Results[0].Message | Should -Match 'Commander alert: idle pane builder-1'
-        Should -Invoke Send-MonitorTelegramAlert -Times 1 -Exactly
+        Should -Invoke Write-MonitorEvent -Times 1 -Exactly -ParameterFilter {
+            $Event -eq 'pane.idle' -and
+            $PaneId -eq '%2' -and
+            $Role -eq 'Builder' -and
+            $Message -match 'Commander alert: idle pane builder-1'
+        }
     }
 
     It 'emits approval waiting alerts and counts them during a monitor cycle' {
@@ -343,7 +353,12 @@ panes:
                 ExitReason   = ''
             }
         }
-        Mock Send-MonitorTelegramAlert { return $true }
+        Mock Write-MonitorEvent {
+            return [ordered]@{
+                event   = $Event
+                message = $Message
+            }
+        }
 
         $settings = [ordered]@{
             agent = 'codex'
@@ -358,7 +373,12 @@ panes:
         $output[1].ApprovalWaiting | Should -Be 1
         $output[1].Results[0].Status | Should -Be 'approval_waiting'
         $output[1].Results[0].Message | Should -Be 'Commander alert: builder-1 (%2) awaiting approval'
-        Should -Invoke Send-MonitorTelegramAlert -Times 0 -Exactly
+        Should -Invoke Write-MonitorEvent -Times 1 -Exactly -ParameterFilter {
+            $Event -eq 'pane.approval_waiting' -and
+            $PaneId -eq '%2' -and
+            $Role -eq 'Builder' -and
+            $Message -eq 'Pane builder-1 (%2) awaiting approval.'
+        }
     }
 
     It 'auto-approves trust prompts during a monitor cycle' {
@@ -393,7 +413,12 @@ panes:
                 Message = 'Auto-approved trust prompt in pane %2'
             }
         }
-        Mock Send-MonitorTelegramAlert { return $true }
+        Mock Write-MonitorEvent {
+            return [ordered]@{
+                event   = $Event
+                message = $Message
+            }
+        }
 
         $settings = [ordered]@{
             agent = 'codex'
@@ -409,7 +434,12 @@ panes:
         $output[1].Results[0].Status | Should -Be 'approval_waiting'
         $output[1].Results[0].Message | Should -Be 'Auto-approved trust prompt in pane %2'
         Should -Invoke Invoke-MonitorAutoApprovePrompt -Times 1 -Exactly
-        Should -Invoke Send-MonitorTelegramAlert -Times 0 -Exactly
+        Should -Invoke Write-MonitorEvent -Times 1 -Exactly -ParameterFilter {
+            $Event -eq 'pane.approval_waiting' -and
+            $PaneId -eq '%2' -and
+            $Role -eq 'Builder' -and
+            $Message -eq 'Pane builder-1 (%2) awaiting approval.'
+        }
     }
 
     It 'emits commander alerts when a Builder stays busy with the same snapshot for three cycles' {
@@ -429,7 +459,7 @@ panes:
 "@ | Set-Content -Path (Join-Path $manifestDir 'manifest.yaml') -Encoding UTF8
 
         Mock Get-PaneAgentStatus {
-            [PSCustomObject]@{
+            [ordered]@{
                 Status       = 'busy'
                 PaneId       = '%2'
                 SnapshotTail = 'working'
@@ -437,7 +467,12 @@ panes:
                 ExitReason   = ''
             }
         }
-        Mock Send-MonitorTelegramAlert { return $true }
+        Mock Write-MonitorEvent {
+            return [ordered]@{
+                event   = $Event
+                message = $Message
+            }
+        }
 
         $settings = [ordered]@{
             agent = 'codex'
@@ -454,6 +489,11 @@ panes:
         $output[1].Stalls | Should -Be 1
         $output[1].Results[0].StallDetected | Should -Be $true
         $output[1].Results[0].Message | Should -Match 'Commander alert: stalled Builder pane builder-1'
-        Should -Invoke Send-MonitorTelegramAlert -Times 0 -Exactly
+        Should -Invoke Write-MonitorEvent -Times 1 -Exactly -ParameterFilter {
+            $Event -eq 'pane.stalled' -and
+            $PaneId -eq '%2' -and
+            $Role -eq 'Builder' -and
+            $Message -match 'Commander alert: stalled Builder pane builder-1'
+        }
     }
 }

--- a/tests/psmux-bridge.Tests.ps1
+++ b/tests/psmux-bridge.Tests.ps1
@@ -688,7 +688,6 @@ panes:
                 }
             }
             Mock Test-BuilderStall { $false }
-            Mock Send-MonitorTelegramAlert { $true }
             Mock Invoke-AgentRespawn {
                 param($PaneId, $Agent, $Model, $ProjectDir, $GitWorktreeDir, $ManifestPath)
 
@@ -834,8 +833,6 @@ panes:
             Mock Test-BuilderStall {
                 return $PaneId -eq '%4'
             }
-            Mock Send-MonitorTelegramAlert { $true }
-
             $output = @(Invoke-AgentMonitorCycle -Settings ([ordered]@{
                 agent = 'codex'
                 model = 'gpt-5.4'
@@ -865,7 +862,6 @@ panes:
             )
             $events[1].data.idle_threshold_seconds | Should -Be 120
             $events[4].data.required_cycles | Should -Be 3
-            Should -Invoke Send-MonitorTelegramAlert -Times 1 -Exactly
         } finally {
             if (Test-Path $tempRoot) {
                 Remove-Item -Path $tempRoot -Recurse -Force

--- a/winsmux-core/scripts/agent-monitor.ps1
+++ b/winsmux-core/scripts/agent-monitor.ps1
@@ -38,8 +38,6 @@ $script:HungSnapshotDir = Join-Path $env:TEMP 'winsmux\monitor_snapshots'
 $script:IdleStateDir = Join-Path $env:TEMP 'winsmux\monitor_idle'
 $script:AgentMonitorDefaultHungThreshold = 60
 $script:IdleAlertRepeatSeconds = 300
-$script:MonitorTelegramEnvPath = 'C:\Users\komei\.claude\channels\telegram\.env'
-$script:MonitorTelegramChatId = '8642321094'
 $script:BuilderStallHistory = @{}
 $script:BuilderStallThresholdCycles = 3
 
@@ -610,85 +608,6 @@ function Get-MonitorStateEventMessage {
         'pane.ready' { return "Pane $Label ($PaneId) is ready." }
         'pane.waiting_for_dispatch' { return "Pane $Label ($PaneId) is waiting for dispatch." }
         default { return "Pane $Label ($PaneId) detected as $Status." }
-    }
-}
-
-function Write-MonitorIdleAlertLog {
-    param(
-        [Parameter(Mandatory = $true)][string]$Message,
-        [Parameter(Mandatory = $true)][string]$ProjectDir
-    )
-
-    if ([string]::IsNullOrWhiteSpace($Message) -or [string]::IsNullOrWhiteSpace($ProjectDir)) {
-        return $false
-    }
-
-    try {
-        $logDir = Join-Path $ProjectDir '.winsmux\logs'
-        [System.IO.Directory]::CreateDirectory($logDir) | Out-Null
-
-        $timestamp = (Get-Date).ToString('o')
-        $logLine = "[{0}] {1}{2}" -f $timestamp, $Message, [System.Environment]::NewLine
-        $logPath = Join-Path $logDir 'idle-alerts.log'
-        [System.IO.File]::AppendAllText($logPath, $logLine, [System.Text.Encoding]::UTF8)
-        return $true
-    } catch {
-        return $false
-    }
-}
-
-function Send-MonitorTelegramAlert {
-    param(
-        [Parameter(Mandatory = $true)][string]$Message,
-        [ValidateSet('commander', 'idle')][string]$AlertType = 'commander',
-        [string]$ProjectDir = ''
-    )
-
-    if ([string]::IsNullOrWhiteSpace($Message)) {
-        return $false
-    }
-
-    if ($AlertType -eq 'idle') {
-        return Write-MonitorIdleAlertLog -Message $Message -ProjectDir $ProjectDir
-    }
-
-    if (-not (Test-Path -LiteralPath $script:MonitorTelegramEnvPath -PathType Leaf)) {
-        return $false
-    }
-
-    try {
-        $envLines = Get-Content -LiteralPath $script:MonitorTelegramEnvPath -Encoding UTF8
-    } catch {
-        return $false
-    }
-
-    $token = $null
-    foreach ($line in $envLines) {
-        if ($line -match '^\s*TELEGRAM_BOT_TOKEN\s*=\s*(.+?)\s*$') {
-            $token = $Matches[1].Trim()
-            break
-        }
-    }
-
-    if ([string]::IsNullOrWhiteSpace($token)) {
-        return $false
-    }
-
-    if (($token.StartsWith('"') -and $token.EndsWith('"')) -or ($token.StartsWith("'") -and $token.EndsWith("'"))) {
-        $token = $token.Substring(1, $token.Length - 2)
-    }
-
-    $uri = "https://api.telegram.org/bot$token/sendMessage"
-    $body = @{
-        chat_id = $script:MonitorTelegramChatId
-        text    = $Message
-    }
-
-    try {
-        $response = Invoke-RestMethod -Method Post -Uri $uri -Body $body -ErrorAction Stop
-        return [bool](Get-MonitorPropertyValue -InputObject $response -Name 'ok' -Default $true)
-    } catch {
-        return $false
     }
 }
 
@@ -1318,10 +1237,6 @@ function Invoke-AgentMonitorCycle {
                     idle_threshold_seconds = $IdleThreshold
                     snapshot_hash          = $statusSnapshotHash
                 }) | Out-Null
-            try {
-                Send-MonitorTelegramAlert -Message $idleAlert.Message -AlertType 'idle' -ProjectDir $projectDir | Out-Null
-            } catch {
-            }
         }
 
         $stallDetected = Test-BuilderStall -PaneId $paneId -Role $role -Status $statusName -SnapshotHash $statusSnapshotHash


### PR DESCRIPTION
## Summary
- Remove Send-MonitorTelegramAlert function entirely
- All pane alerts → Commander stdout + events.jsonl
- Telegram reserved for user milestones only

## Test plan
- [x] 87/87 Pester tests pass

Closes #306, closes #290

🤖 Generated with [Claude Code](https://claude.com/claude-code)