### PR TITLE
feat: auto-clear at 10% context + /new reset (#303, #309)

### DIFF
--- a/tests/psmux-bridge.Tests.ps1
+++ b/tests/psmux-bridge.Tests.ps1
@@ -535,6 +535,12 @@ Describe 'agent-monitor helpers' {
         $status.ExitReason | Should -Be ''
     }
 
+    It 'parses Codex context percentages from monitor capture text' {
+        (Get-MonitorContextRemainingPercent -Text 'gpt-5.4   10% context left') | Should -Be 10
+        (Get-MonitorContextRemainingPercent -Text 'gpt-5.4   · 8% left') | Should -Be 8
+        (Get-MonitorContextRemainingPercent -Text '') | Should -BeNullOrEmpty
+    }
+
     It 'respawns the pane in the launch directory before sending the agent command' {
         Mock Invoke-MonitorWinsmux { } -ParameterFilter {
             $Arguments[0] -eq 'respawn-pane'
@@ -940,6 +946,78 @@ panes:
         Test-BuilderStall -PaneId '%2' -Role 'Builder' -Status 'busy' -SnapshotHash 'hash-1' | Out-Null
         (Test-BuilderStall -PaneId '%2' -Role 'Builder' -Status 'ready' -SnapshotHash 'hash-1') | Should -Be $false
         (Test-BuilderStall -PaneId '%2' -Role 'Builder' -Status 'busy' -SnapshotHash 'hash-1') | Should -Be $false
+    }
+
+    It 'resets Codex context at the configured threshold using /new' {
+        $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('winsmux-agent-monitor-tests-' + [guid]::NewGuid().ToString('N'))
+        $manifestDir = Join-Path $tempRoot '.winsmux'
+        $manifestPath = Join-Path $manifestDir 'manifest.yaml'
+        $eventsPath = Join-Path $manifestDir 'events.jsonl'
+
+        try {
+            New-Item -ItemType Directory -Path $manifestDir -Force | Out-Null
+@"
+version: 1
+session:
+  name: winsmux-orchestra
+  project_dir: $tempRoot
+panes:
+  - label: builder-1
+    pane_id: %2
+    role: Builder
+    launch_dir: $tempRoot
+"@ | Set-Content -Path $manifestPath -Encoding UTF8
+
+            Mock Get-PaneAgentStatus {
+                [ordered]@{
+                    Status       = 'ready'
+                    PaneId       = '%2'
+                    SnapshotTail = @"
+gpt-5.4   10% context left
+>
+"@
+                    SnapshotHash = 'hash-builder'
+                    ExitReason   = ''
+                }
+            }
+            Mock Send-MonitorBridgeCommand { }
+            Mock Update-MonitorIdleAlertState {
+                [ordered]@{
+                    ShouldAlert = $false
+                    Message     = ''
+                }
+            }
+            Mock Test-BuilderStall { $false }
+
+            $result = Invoke-AgentMonitorCycle -Settings ([ordered]@{
+                agent = 'codex'
+                model = 'gpt-5.4'
+                roles = [ordered]@{}
+            }) -ManifestPath $manifestPath -SessionName 'winsmux-orchestra'
+
+            $result.ContextResets | Should -Be 1
+            $result.Results.Count | Should -Be 1
+            $result.Results[0].ContextReset | Should -Be $true
+            $result.Results[0].ContextRemainingPercent | Should -Be 10
+            Should -Invoke Send-MonitorBridgeCommand -Times 1 -Exactly -ParameterFilter {
+                $PaneId -eq '%2' -and $Text -eq '/new'
+            }
+            Should -Invoke Send-MonitorBridgeCommand -Times 0 -Exactly -ParameterFilter {
+                $Text -eq '/clear'
+            }
+
+            $events = @(Get-Content -Path $eventsPath -Encoding UTF8 | Where-Object { $_ } | ForEach-Object { $_ | ConvertFrom-Json })
+            $events.Count | Should -Be 2
+            $events[0].event | Should -Be 'pane.ready'
+            $events[1].event | Should -Be 'pane.context_reset'
+            $events[1].data.command | Should -Be '/new'
+            $events[1].data.context_remaining_percent | Should -Be 10
+            $events[1].data.threshold_percent | Should -Be 10
+        } finally {
+            if (Test-Path $tempRoot) {
+                Remove-Item -Path $tempRoot -Recurse -Force
+            }
+        }
     }
 }
 

--- a/winsmux-core/scripts/agent-monitor.ps1
+++ b/winsmux-core/scripts/agent-monitor.ps1
@@ -19,7 +19,8 @@ Or run directly for a single monitoring cycle:
 param(
     [string]$ProjectDir,
     [string]$SessionName = 'winsmux-orchestra',
-    [int]$HungThresholdSeconds = 60
+    [int]$HungThresholdSeconds = 60,
+    [int]$ContextResetThresholdPercent = 10
 )
 
 $ErrorActionPreference = 'Stop'
@@ -438,6 +439,32 @@ function Test-CodexContextExhaustionText {
     }
 
     return $false
+}
+
+function Get-MonitorContextRemainingPercent {
+    param([AllowNull()][string]$Text)
+
+    if ([string]::IsNullOrWhiteSpace($Text)) {
+        return $null
+    }
+
+    $patterns = @(
+        '(?im)(?<value>\d+(?:\.\d+)?)%\s+(?:context\s+)?left\b',
+        '(?im)\b(?:context\s+left|tokens?\s+remaining)\s*[:=]\s*(?<value>\d+(?:\.\d+)?)%\b'
+    )
+
+    foreach ($pattern in $patterns) {
+        $matches = [regex]::Matches($Text, $pattern)
+        if ($matches.Count -gt 0) {
+            $rawValue = $matches[$matches.Count - 1].Groups['value'].Value
+            $parsedValue = 0.0
+            if ([double]::TryParse($rawValue, [System.Globalization.NumberStyles]::Float, [System.Globalization.CultureInfo]::InvariantCulture, [ref]$parsedValue)) {
+                return $parsedValue
+            }
+        }
+    }
+
+    return $null
 }
 
 function Test-PowerShellPromptText {
@@ -1074,7 +1101,8 @@ function Invoke-AgentMonitorCycle {
         [Parameter(Mandatory = $true)][string]$ManifestPath,
         [string]$SessionName = 'winsmux-orchestra',
         [Alias('HungThreshold')]
-        [int]$IdleThreshold = $script:AgentMonitorDefaultHungThreshold
+        [int]$IdleThreshold = $script:AgentMonitorDefaultHungThreshold,
+        [int]$ContextResetThresholdPercent = 10
     )
 
     # Read manifest to get pane assignments
@@ -1096,6 +1124,7 @@ function Invoke-AgentMonitorCycle {
             Crashed   = 0
             Respawned = 0
             ApprovalWaiting = 0
+            ContextResets = 0
             IdleAlerts = 0
             Stalls = 0
             Results   = @()
@@ -1122,6 +1151,7 @@ function Invoke-AgentMonitorCycle {
     $crashedCount = 0
     $respawnedCount = 0
     $approvalWaitingCount = 0
+    $contextResetCount = 0
     $idleAlertCount = 0
     $stallCount = 0
     $cycleNow = Get-Date
@@ -1168,6 +1198,8 @@ function Invoke-AgentMonitorCycle {
             Status     = $statusName
             ExitReason = $statusExitReason
             Respawned  = $false
+            ContextReset = $false
+            ContextRemainingPercent = $null
             IdleAlerted = $false
             StallDetected = $false
             Message    = ''
@@ -1211,6 +1243,34 @@ function Invoke-AgentMonitorCycle {
                 $approvalMessage = "Commander alert: $label ($paneId) awaiting approval"
                 $result['Message'] = $approvalMessage
                 Write-Output $approvalMessage
+            }
+        }
+
+        $contextRemainingPercent = Get-MonitorContextRemainingPercent -Text $statusSnapshotTail
+        if ($agentName -eq 'codex' -and $statusName -eq 'ready' -and $null -ne $contextRemainingPercent) {
+            $result['ContextRemainingPercent'] = $contextRemainingPercent
+            if ($contextRemainingPercent -le $ContextResetThresholdPercent) {
+                try {
+                    Send-MonitorBridgeCommand -PaneId $paneId -Text '/new'
+                    $contextResetCount++
+                    $result['ContextReset'] = $true
+                    Write-MonitorEvent -ProjectDir $projectDir -SessionName $SessionName `
+                        -Event 'pane.context_reset' -Message "Reset Codex context in pane $label ($paneId)." `
+                        -Label $label -PaneId $paneId -Role $role -Status $statusName -ExitReason $statusExitReason `
+                        -Data ([ordered]@{
+                            agent                     = $agentName
+                            model                     = $modelName
+                            command                   = '/new'
+                            context_remaining_percent = $contextRemainingPercent
+                            threshold_percent         = $ContextResetThresholdPercent
+                            snapshot_hash             = $statusSnapshotHash
+                        }) | Out-Null
+
+                    $results.Add($result)
+                    continue
+                } catch {
+                    $result['Message'] = "Failed to reset context for pane $label ($paneId): $($_.Exception.Message)"
+                }
             }
         }
 
@@ -1367,6 +1427,7 @@ function Invoke-AgentMonitorCycle {
         Crashed   = $crashedCount
         Respawned = $respawnedCount
         ApprovalWaiting = $approvalWaitingCount
+        ContextResets = $contextResetCount
         IdleAlerts = $idleAlertCount
         Stalls = $stallCount
         Results   = @($results)
@@ -1514,7 +1575,8 @@ if ($MyInvocation.InvocationName -ne '.') {
         -Settings $settings `
         -ManifestPath $manifestPath `
         -SessionName $SessionName `
-        -HungThreshold $HungThresholdSeconds
+        -HungThreshold $HungThresholdSeconds `
+        -ContextResetThresholdPercent $ContextResetThresholdPercent
 
     Write-Output "Monitor cycle complete: checked=$($result.Checked) crashed=$($result.Crashed) respawned=$($result.Respawned)"
     foreach ($r in $result.Results) {


### PR DESCRIPTION
## Summary
- Auto-detect context below 10% and send /new to reset
- Log pane.context_reset events to events.jsonl
- Configurable threshold

## Test plan
- [x] 89/89 Pester tests pass

Closes #303, closes #309

🤖 Generated with [Claude Code](https://claude.com/claude-code)