### PR TITLE
feat: bidi communication + commander-poll mailbox (#302)

### DIFF
--- a/tests/Integration.MultiAgent.Tests.ps1
+++ b/tests/Integration.MultiAgent.Tests.ps1
@@ -164,8 +164,8 @@ Describe 'manifest round-trip' {
 
         $manifestPath = Get-ManifestPath -ProjectDir $script:manifestTempRoot
         $paneSummaries = @(
-            [PSCustomObject]@{ Label = 'builder-1'; PaneId = '%2'; Role = 'Builder'; BuilderWorktreePath = 'C:\repo\.worktrees\builder-1' }
-            [PSCustomObject]@{ Label = 'reviewer'; PaneId = '%4'; Role = 'Reviewer'; BuilderWorktreePath = '' }
+            [ordered]@{ Label = 'builder-1'; PaneId = '%2'; Role = 'Builder'; BuilderWorktreePath = 'C:\repo\.worktrees\builder-1' }
+            [ordered]@{ Label = 'reviewer'; PaneId = '%4'; Role = 'Reviewer'; BuilderWorktreePath = '' }
         )
         Update-ManifestPanes -ManifestPath $manifestPath -PaneSummaries $paneSummaries
 
@@ -246,6 +246,7 @@ Describe 'agent monitor idle alerts' {
         $script:agentMonitorIdleStateDir = Join-Path $script:agentMonitorTempRoot 'idle'
         New-Item -ItemType Directory -Path $script:agentMonitorTempRoot -Force | Out-Null
         $script:IdleStateDir = $script:agentMonitorIdleStateDir
+        Mock Send-MonitorCommanderMailboxMessage { return $true }
     }
 
     AfterEach {
@@ -327,6 +328,11 @@ panes:
             $Role -eq 'Builder' -and
             $Message -match 'Commander alert: idle pane builder-1'
         }
+        Should -Invoke Send-MonitorCommanderMailboxMessage -Times 1 -Exactly -ParameterFilter {
+            $Event -eq 'pane.idle' -and
+            $Label -eq 'builder-1' -and
+            $PaneId -eq '%2'
+        }
     }
 
     It 'emits approval waiting alerts and counts them during a monitor cycle' {
@@ -345,7 +351,7 @@ panes:
 "@ | Set-Content -Path (Join-Path $manifestDir 'manifest.yaml') -Encoding UTF8
 
         Mock Get-PaneAgentStatus {
-            [PSCustomObject]@{
+            [ordered]@{
                 Status       = 'approval_waiting'
                 PaneId       = '%2'
                 SnapshotTail = 'Do you want to allow this command?'

--- a/tests/psmux-bridge.Tests.ps1
+++ b/tests/psmux-bridge.Tests.ps1
@@ -534,6 +534,10 @@ Describe 'agent-monitor helpers' {
         . (Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\agent-monitor.ps1')
     }
 
+    BeforeEach {
+        Mock Send-MonitorCommanderMailboxMessage { return $true }
+    }
+
     It 'treats Codex context exhaustion followed by a PowerShell prompt as a crash reason' {
         Mock Invoke-MonitorWinsmux {
             @(
@@ -1504,5 +1508,74 @@ Describe 'winsmux poll-events command' {
         $result.events[0].pane_id | Should -Be '%4'
         $result.events[1].event | Should -Be 'pane.completed'
         $result.events[1].pane_id | Should -Be '%5'
+    }
+}
+
+Describe 'commander-poll helpers' {
+    BeforeAll {
+        $script:commanderPollScriptPath = Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\commander-poll.ps1'
+    }
+
+    BeforeEach {
+        $script:commanderPollTempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('winsmux-commander-poll-tests-' + [guid]::NewGuid().ToString('N'))
+        $script:commanderPollManifestDir = Join-Path $script:commanderPollTempRoot '.winsmux'
+        $script:commanderPollManifestPath = Join-Path $script:commanderPollManifestDir 'manifest.yaml'
+        New-Item -ItemType Directory -Path $script:commanderPollManifestDir -Force | Out-Null
+
+@"
+version: 1
+session:
+  name: winsmux-orchestra
+  project_dir: $script:commanderPollTempRoot
+panes:
+  - label: builder-1
+    pane_id: %2
+    role: Builder
+    launch_dir: $script:commanderPollTempRoot
+"@ | Set-Content -Path $script:commanderPollManifestPath -Encoding UTF8
+
+        . $script:commanderPollScriptPath -ManifestPath $script:commanderPollManifestPath
+    }
+
+    AfterEach {
+        if ($script:commanderPollTempRoot -and (Test-Path $script:commanderPollTempRoot)) {
+            Remove-Item -Path $script:commanderPollTempRoot -Recurse -Force
+        }
+    }
+
+    It 'processes mailbox idle messages and logs dispatch-needed guidance' {
+        Mock Receive-CommanderPollMailboxMessages {
+            @(
+                [ordered]@{
+                    timestamp   = '2026-04-07T09:00:00.0000000+09:00'
+                    session     = 'winsmux-orchestra'
+                    event       = 'pane.idle'
+                    message     = 'Commander alert: idle pane builder-1 (%2, role=Builder)'
+                    label       = 'builder-1'
+                    pane_id     = '%2'
+                    role        = 'Builder'
+                    status      = 'ready'
+                    exit_reason = ''
+                    data        = [ordered]@{
+                        idle_threshold_seconds = 120
+                    }
+                    source      = 'mailbox'
+                }
+            )
+        }
+        Mock Write-CommanderPollLog { }
+
+        $cycle = Invoke-CommanderPollCycle -ManifestPath $script:commanderPollManifestPath -ProcessedLineCount 0 -ProcessedEventSignatures ([ordered]@{})
+        $summary = $cycle['Summary']
+
+        $summary.mailbox_events | Should -Be 1
+        $summary.new_events | Should -Be 1
+        $summary.dispatches | Should -Be 1
+        $summary.messages[0] | Should -Be 'Commander should dispatch next task to builder-1 (%2)'
+        Should -Invoke Write-CommanderPollLog -Times 1 -Exactly -ParameterFilter {
+            $EventName -eq 'commander.poll.idle_dispatch_needed' -and
+            $PaneId -eq '%2' -and
+            $Message -eq 'Commander should dispatch next task to builder-1 (%2)'
+        }
     }
 }

--- a/winsmux-core/scripts/agent-monitor.ps1
+++ b/winsmux-core/scripts/agent-monitor.ps1
@@ -593,6 +593,64 @@ function Write-MonitorEvent {
     }
 }
 
+function Get-MonitorCommanderMailboxChannel {
+    param([string]$SessionName = 'winsmux-orchestra')
+
+    $resolvedSessionName = if ([string]::IsNullOrWhiteSpace($SessionName)) {
+        'winsmux-orchestra'
+    } else {
+        $SessionName.Trim()
+    }
+
+    $safeSessionName = [regex]::Replace($resolvedSessionName, '[^A-Za-z0-9_-]', '-')
+    return "$safeSessionName-commander"
+}
+
+function Send-MonitorCommanderMailboxMessage {
+    param(
+        [string]$SessionName = 'winsmux-orchestra',
+        [Parameter(Mandatory = $true)][string]$Event,
+        [string]$Message = '',
+        [string]$Label = '',
+        [string]$PaneId = '',
+        [string]$Role = '',
+        [string]$Status = '',
+        [string]$ExitReason = '',
+        [AllowNull()]$Data = $null
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Event)) {
+        return $false
+    }
+
+    $bridgeScript = [System.IO.Path]::GetFullPath((Join-Path $scriptDir '..\..\scripts\winsmux-core.ps1'))
+    $channel = Get-MonitorCommanderMailboxChannel -SessionName $SessionName
+    $payload = [ordered]@{
+        from      = if ([string]::IsNullOrWhiteSpace($Label)) { 'agent-monitor' } else { $Label }
+        to        = 'Commander'
+        content   = [ordered]@{
+            session     = if ([string]::IsNullOrWhiteSpace($SessionName)) { 'winsmux-orchestra' } else { $SessionName }
+            event       = $Event
+            message     = if ($null -eq $Message) { '' } else { $Message }
+            label       = if ($null -eq $Label) { '' } else { $Label }
+            pane_id     = if ($null -eq $PaneId) { '' } else { $PaneId }
+            role        = if ($null -eq $Role) { '' } else { $Role }
+            status      = if ($null -eq $Status) { '' } else { $Status }
+            exit_reason = if ($null -eq $ExitReason) { '' } else { $ExitReason }
+            data        = if ($null -eq $Data) { [ordered]@{} } else { $Data }
+        }
+        timestamp = (Get-Date).ToString('o')
+    }
+
+    $payloadJson = $payload | ConvertTo-Json -Compress -Depth 10
+    & pwsh -NoProfile -File $bridgeScript 'mailbox-send' $channel $payloadJson 2>&1 | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to send mailbox message on channel $channel."
+    }
+
+    return $true
+}
+
 function Get-MonitorStateEventName {
     param(
         [Parameter(Mandatory = $true)][string]$Status,
@@ -1244,6 +1302,14 @@ function Invoke-AgentMonitorCycle {
                 $result['Message'] = $approvalMessage
                 Write-Output $approvalMessage
             }
+
+            try {
+                Send-MonitorCommanderMailboxMessage -SessionName $SessionName `
+                    -Event 'pane.approval_waiting' -Message $result['Message'] `
+                    -Label $label -PaneId $paneId -Role $role -Status $statusName -ExitReason $statusExitReason `
+                    -Data $stateEventData | Out-Null
+            } catch {
+            }
         }
 
         $contextRemainingPercent = Get-MonitorContextRemainingPercent -Text $statusSnapshotTail
@@ -1297,6 +1363,18 @@ function Invoke-AgentMonitorCycle {
                     idle_threshold_seconds = $IdleThreshold
                     snapshot_hash          = $statusSnapshotHash
                 }) | Out-Null
+            try {
+                Send-MonitorCommanderMailboxMessage -SessionName $SessionName `
+                    -Event 'pane.idle' -Message $idleAlert.Message `
+                    -Label $label -PaneId $paneId -Role $role -Status $statusName -ExitReason $statusExitReason `
+                    -Data ([ordered]@{
+                        agent                  = $agentName
+                        model                  = $modelName
+                        idle_threshold_seconds = $IdleThreshold
+                        snapshot_hash          = $statusSnapshotHash
+                    }) | Out-Null
+            } catch {
+            }
         }
 
         $stallDetected = Test-BuilderStall -PaneId $paneId -Role $role -Status $statusName -SnapshotHash $statusSnapshotHash
@@ -1315,6 +1393,18 @@ function Invoke-AgentMonitorCycle {
                     required_cycles  = $script:BuilderStallThresholdCycles
                     snapshot_hash    = $statusSnapshotHash
                 }) | Out-Null
+            try {
+                Send-MonitorCommanderMailboxMessage -SessionName $SessionName `
+                    -Event 'pane.stalled' -Message $stallMessage `
+                    -Label $label -PaneId $paneId -Role $role -Status $statusName -ExitReason $statusExitReason `
+                    -Data ([ordered]@{
+                        agent            = $agentName
+                        model            = $modelName
+                        required_cycles  = $script:BuilderStallThresholdCycles
+                        snapshot_hash    = $statusSnapshotHash
+                    }) | Out-Null
+            } catch {
+            }
         }
 
         # Log the status check

--- a/winsmux-core/scripts/commander-poll.ps1
+++ b/winsmux-core/scripts/commander-poll.ps1
@@ -402,31 +402,224 @@ function New-CommanderPollCycleSummary {
     )
 
     return [ordered]@{
-        timestamp   = [System.DateTimeOffset]::Now.ToString('o')
-        manifest    = $ManifestPath
-        events      = $EventsPath
-        new_events  = 0
-        completions = 0
-        approvals   = 0
-        errors      = 0
-        messages    = @()
+        timestamp      = [System.DateTimeOffset]::Now.ToString('o')
+        manifest       = $ManifestPath
+        events         = $EventsPath
+        new_events     = 0
+        mailbox_events = 0
+        completions    = 0
+        approvals      = 0
+        dispatches     = 0
+        errors         = 0
+        messages       = @()
     }
 }
 
-if (-not (Test-Path -LiteralPath $ManifestPath -PathType Leaf)) {
-    throw "Manifest not found: $ManifestPath"
+function Get-CommanderPollMailboxChannel {
+    param([string]$SessionName = 'winsmux-orchestra')
+
+    $resolvedSessionName = if ([string]::IsNullOrWhiteSpace($SessionName)) {
+        'winsmux-orchestra'
+    } else {
+        $SessionName.Trim()
+    }
+
+    $safeSessionName = [regex]::Replace($resolvedSessionName, '[^A-Za-z0-9_-]', '-')
+    return "$safeSessionName-commander"
 }
 
-$initialManifest = Read-CommanderPollManifest -Path $ManifestPath
-$initialProjectDir = Get-CommanderPollProjectDir -Manifest $initialManifest -ManifestPath $ManifestPath
-$eventsPath = Get-CommanderPollEventsPath -ProjectDir $initialProjectDir
-$processedLineCount = 0
+function Receive-CommanderPollMailboxMessages {
+    param(
+        [string]$SessionName = 'winsmux-orchestra',
+        [int]$TimeoutMilliseconds = 25,
+        [int]$MaxMessages = 20
+    )
 
-if (Test-Path -LiteralPath $eventsPath -PathType Leaf) {
-    $processedLineCount = @(Get-Content -LiteralPath $eventsPath -Encoding UTF8).Count
+    $messages = [System.Collections.Generic.List[object]]::new()
+    $pipeName = "winsmux-mailbox-$(Get-CommanderPollMailboxChannel -SessionName $SessionName)"
+
+    for ($messageIndex = 0; $messageIndex -lt $MaxMessages; $messageIndex++) {
+        $server = $null
+        try {
+            $server = [System.IO.Pipes.NamedPipeServerStream]::new(
+                $pipeName,
+                [System.IO.Pipes.PipeDirection]::In,
+                1,
+                [System.IO.Pipes.PipeTransmissionMode]::Byte,
+                [System.IO.Pipes.PipeOptions]::Asynchronous
+            )
+            $waitTask = $server.WaitForConnectionAsync()
+            if (-not $waitTask.Wait($TimeoutMilliseconds)) {
+                break
+            }
+
+            $reader = [System.IO.StreamReader]::new($server, [System.Text.Encoding]::UTF8)
+            try {
+                $payload = $reader.ReadToEnd()
+            } finally {
+                $reader.Dispose()
+            }
+
+            if ([string]::IsNullOrWhiteSpace($payload)) {
+                continue
+            }
+
+            $mailboxMessage = $null
+            try {
+                $mailboxMessage = $payload | ConvertFrom-Json -AsHashtable -ErrorAction Stop
+            } catch {
+                continue
+            }
+
+            $content = Get-CommanderPollValue -InputObject $mailboxMessage -Name 'content' -Default $null
+            $eventName = [string](Get-CommanderPollValue -InputObject $content -Name 'event' -Default '')
+            if ([string]::IsNullOrWhiteSpace($eventName)) {
+                continue
+            }
+
+            $messages.Add([ordered]@{
+                timestamp   = [string](Get-CommanderPollValue -InputObject $mailboxMessage -Name 'timestamp' -Default ([System.DateTimeOffset]::Now.ToString('o')))
+                session     = [string](Get-CommanderPollValue -InputObject $content -Name 'session' -Default $SessionName)
+                event       = $eventName
+                message     = [string](Get-CommanderPollValue -InputObject $content -Name 'message' -Default '')
+                label       = [string](Get-CommanderPollValue -InputObject $content -Name 'label' -Default '')
+                pane_id     = [string](Get-CommanderPollValue -InputObject $content -Name 'pane_id' -Default '')
+                role        = [string](Get-CommanderPollValue -InputObject $content -Name 'role' -Default '')
+                status      = [string](Get-CommanderPollValue -InputObject $content -Name 'status' -Default '')
+                exit_reason = [string](Get-CommanderPollValue -InputObject $content -Name 'exit_reason' -Default '')
+                data        = Get-CommanderPollValue -InputObject $content -Name 'data' -Default ([ordered]@{})
+                source      = 'mailbox'
+                mailbox_from = [string](Get-CommanderPollValue -InputObject $mailboxMessage -Name 'from' -Default '')
+            })
+        } catch {
+            break
+        } finally {
+            if ($server) {
+                $server.Dispose()
+            }
+        }
+    }
+
+    return @($messages)
 }
 
-while ($true) {
+function Get-CommanderPollEventSignature {
+    param([Parameter(Mandatory = $true)]$EventRecord)
+
+    return '{0}|{1}|{2}|{3}|{4}' -f `
+        ([string](Get-CommanderPollValue -InputObject $EventRecord -Name 'event' -Default '')), `
+        ([string](Get-CommanderPollValue -InputObject $EventRecord -Name 'pane_id' -Default '')), `
+        ([string](Get-CommanderPollValue -InputObject $EventRecord -Name 'label' -Default '')), `
+        ([string](Get-CommanderPollValue -InputObject $EventRecord -Name 'status' -Default '')), `
+        ([string](Get-CommanderPollValue -InputObject $EventRecord -Name 'message' -Default ''))
+}
+
+function Invoke-CommanderPollEventRecord {
+    param(
+        [Parameter(Mandatory = $true)]$Manifest,
+        [Parameter(Mandatory = $true)][string]$ManifestPath,
+        [Parameter(Mandatory = $true)]$EventRecord,
+        [Parameter(Mandatory = $true)]$Summary
+    )
+
+    $projectDir = Get-CommanderPollProjectDir -Manifest $Manifest -ManifestPath $ManifestPath
+    $sessionName = Get-CommanderPollSessionName -Manifest $Manifest
+    $eventName = [string](Get-CommanderPollValue -InputObject $EventRecord -Name 'event' -Default '')
+    $paneContext = Get-CommanderPollPaneContext -Manifest $Manifest -ManifestPath $ManifestPath -EventRecord $EventRecord
+    $paneId = [string]$paneContext['pane_id']
+    $sourceName = [string](Get-CommanderPollValue -InputObject $EventRecord -Name 'source' -Default 'events_jsonl')
+    $sourceId = [string](Get-CommanderPollValue -InputObject $EventRecord -Name 'id' -Default '')
+    $Summary['new_events'] = [int]$Summary['new_events'] + 1
+
+    if ($eventName -in @('pane.exec_completed', 'pane.completed')) {
+        $diffData = Get-CommanderPollDiffData -WorktreePath ([string]$paneContext['worktree_path'])
+        $message = "Completion detected for $($paneContext['label']) ($paneId) with $($diffData['changed_file_count']) changed file(s)"
+
+        Write-CommanderPollLog `
+            -ProjectDir $projectDir `
+            -SessionName $sessionName `
+            -EventName 'commander.poll.exec_completed' `
+            -Message $message `
+            -PaneId $paneId `
+            -Data ([ordered]@{
+                label     = $paneContext['label']
+                role      = $paneContext['role']
+                diff      = $diffData
+                source    = $sourceName
+                source_id = $sourceId
+            })
+
+        $Summary['completions'] = [int]$Summary['completions'] + 1
+        $Summary['messages'] += @($message)
+        return
+    }
+
+    if ($eventName -eq 'pane.idle') {
+        $message = "Commander should dispatch next task to $($paneContext['label']) ($paneId)"
+
+        Write-CommanderPollLog `
+            -ProjectDir $projectDir `
+            -SessionName $sessionName `
+            -EventName 'commander.poll.idle_dispatch_needed' `
+            -Message $message `
+            -PaneId $paneId `
+            -Data ([ordered]@{
+                label      = $paneContext['label']
+                role       = $paneContext['role']
+                status     = [string](Get-CommanderPollValue -InputObject $EventRecord -Name 'status' -Default '')
+                event      = $eventName
+                source     = $sourceName
+                source_id  = $sourceId
+            })
+
+        $Summary['dispatches'] = [int]$Summary['dispatches'] + 1
+        $Summary['messages'] += @($message)
+        return
+    }
+
+    if (Test-CommanderPollApprovalEvent -EventRecord $EventRecord) {
+        if ([string]::IsNullOrWhiteSpace($paneId)) {
+            $Summary['errors'] = [int]$Summary['errors'] + 1
+            $Summary['messages'] += @('approval_waiting event is missing pane_id')
+            return
+        }
+
+        Approve-CommanderPollPane -PaneId $paneId
+        $message = "Approved pane $($paneContext['label']) ($paneId) with Enter"
+
+        Write-CommanderPollLog `
+            -ProjectDir $projectDir `
+            -SessionName $sessionName `
+            -EventName 'commander.poll.auto_approved' `
+            -Message $message `
+            -PaneId $paneId `
+            -Data ([ordered]@{
+                label     = $paneContext['label']
+                role      = $paneContext['role']
+                source    = $sourceName
+                source_id = $sourceId
+            })
+
+        $Summary['approvals'] = [int]$Summary['approvals'] + 1
+        $Summary['messages'] += @($message)
+    }
+}
+
+function Invoke-CommanderPollCycle {
+    param(
+        [Parameter(Mandatory = $true)][string]$ManifestPath,
+        [int]$ProcessedLineCount = 0,
+        [AllowNull()]$ProcessedEventSignatures = $null
+    )
+
+    if (-not (Test-Path -LiteralPath $ManifestPath -PathType Leaf)) {
+        throw "Manifest not found: $ManifestPath"
+    }
+
+    if ($null -eq $ProcessedEventSignatures) {
+        $ProcessedEventSignatures = [ordered]@{}
+    }
+
     $manifest = Read-CommanderPollManifest -Path $ManifestPath
     $projectDir = Get-CommanderPollProjectDir -Manifest $manifest -ManifestPath $ManifestPath
     $sessionName = Get-CommanderPollSessionName -Manifest $manifest
@@ -434,87 +627,49 @@ while ($true) {
     $summary = New-CommanderPollCycleSummary -ManifestPath $ManifestPath -EventsPath $eventsPath
 
     try {
+        $eventRecords = [System.Collections.Generic.List[object]]::new()
         $lines = @()
         if (Test-Path -LiteralPath $eventsPath -PathType Leaf) {
             $lines = @(Get-Content -LiteralPath $eventsPath -Encoding UTF8)
         }
 
-        if ($lines.Count -lt $processedLineCount) {
-            $processedLineCount = 0
+        if ($lines.Count -lt $ProcessedLineCount) {
+            $ProcessedLineCount = 0
         }
 
-        for ($index = $processedLineCount; $index -lt $lines.Count; $index++) {
+        for ($index = $ProcessedLineCount; $index -lt $lines.Count; $index++) {
             $line = [string]$lines[$index]
             if ([string]::IsNullOrWhiteSpace($line)) {
                 continue
             }
 
-            $eventRecord = $null
             try {
                 $eventRecord = $line | ConvertFrom-Json -AsHashtable -ErrorAction Stop
+                $eventRecord['source'] = 'events_jsonl'
+                $eventRecords.Add($eventRecord)
             } catch {
                 $summary['errors'] = [int]$summary['errors'] + 1
                 $summary['messages'] += @("Failed to parse event line $($index + 1): $($_.Exception.Message)")
-                continue
-            }
-
-            $summary['new_events'] = [int]$summary['new_events'] + 1
-            $eventName = [string](Get-CommanderPollValue -InputObject $eventRecord -Name 'event' -Default '')
-
-            if ($eventName -eq 'pane.exec_completed') {
-                $paneContext = Get-CommanderPollPaneContext -Manifest $manifest -ManifestPath $ManifestPath -EventRecord $eventRecord
-                $diffData = Get-CommanderPollDiffData -WorktreePath ([string]$paneContext['worktree_path'])
-                $message = "Completion detected for $($paneContext['label']) ($($paneContext['pane_id'])) with $($diffData['changed_file_count']) changed file(s)"
-
-                Write-CommanderPollLog `
-                    -ProjectDir $projectDir `
-                    -SessionName $sessionName `
-                    -EventName 'commander.poll.exec_completed' `
-                    -Message $message `
-                    -PaneId ([string]$paneContext['pane_id']) `
-                    -Data ([ordered]@{
-                        label      = $paneContext['label']
-                        role       = $paneContext['role']
-                        diff       = $diffData
-                        source_id  = Get-CommanderPollValue -InputObject $eventRecord -Name 'id' -Default ''
-                    })
-
-                $summary['completions'] = [int]$summary['completions'] + 1
-                $summary['messages'] += @($message)
-                continue
-            }
-
-            if (Test-CommanderPollApprovalEvent -EventRecord $eventRecord) {
-                $paneContext = Get-CommanderPollPaneContext -Manifest $manifest -ManifestPath $ManifestPath -EventRecord $eventRecord
-                $paneId = [string]$paneContext['pane_id']
-
-                if ([string]::IsNullOrWhiteSpace($paneId)) {
-                    $summary['errors'] = [int]$summary['errors'] + 1
-                    $summary['messages'] += @('approval_waiting event is missing pane_id')
-                    continue
-                }
-
-                Approve-CommanderPollPane -PaneId $paneId
-                $message = "Approved pane $($paneContext['label']) ($paneId) with Enter"
-
-                Write-CommanderPollLog `
-                    -ProjectDir $projectDir `
-                    -SessionName $sessionName `
-                    -EventName 'commander.poll.auto_approved' `
-                    -Message $message `
-                    -PaneId $paneId `
-                    -Data ([ordered]@{
-                        label     = $paneContext['label']
-                        role      = $paneContext['role']
-                        source_id = Get-CommanderPollValue -InputObject $eventRecord -Name 'id' -Default ''
-                    })
-
-                $summary['approvals'] = [int]$summary['approvals'] + 1
-                $summary['messages'] += @($message)
             }
         }
 
-        $processedLineCount = $lines.Count
+        $ProcessedLineCount = $lines.Count
+
+        $mailboxRecords = @(Receive-CommanderPollMailboxMessages -SessionName $sessionName)
+        $summary['mailbox_events'] = $mailboxRecords.Count
+        foreach ($mailboxRecord in $mailboxRecords) {
+            $eventRecords.Add($mailboxRecord)
+        }
+
+        foreach ($eventRecord in $eventRecords) {
+            $signature = Get-CommanderPollEventSignature -EventRecord $eventRecord
+            if ($ProcessedEventSignatures.Contains($signature)) {
+                continue
+            }
+
+            $ProcessedEventSignatures[$signature] = [string](Get-CommanderPollValue -InputObject $eventRecord -Name 'timestamp' -Default ([System.DateTimeOffset]::Now.ToString('o')))
+            Invoke-CommanderPollEventRecord -Manifest $manifest -ManifestPath $ManifestPath -EventRecord $eventRecord -Summary $summary
+        }
     } catch {
         $summary['errors'] = [int]$summary['errors'] + 1
         $errorMessage = "commander-poll cycle failed: $($_.Exception.Message)"
@@ -528,6 +683,37 @@ while ($true) {
             -Level 'error'
     }
 
-    Write-Output ($summary | ConvertTo-Json -Compress -Depth 10)
-    Start-Sleep -Seconds $Interval
+    return [ordered]@{
+        Summary                  = $summary
+        ProcessedLineCount       = $ProcessedLineCount
+        ProcessedEventSignatures = $ProcessedEventSignatures
+    }
+}
+
+if ($MyInvocation.InvocationName -ne '.') {
+    if (-not (Test-Path -LiteralPath $ManifestPath -PathType Leaf)) {
+        throw "Manifest not found: $ManifestPath"
+    }
+
+    $initialManifest = Read-CommanderPollManifest -Path $ManifestPath
+    $initialProjectDir = Get-CommanderPollProjectDir -Manifest $initialManifest -ManifestPath $ManifestPath
+    $eventsPath = Get-CommanderPollEventsPath -ProjectDir $initialProjectDir
+    $processedLineCount = 0
+    $processedEventSignatures = [ordered]@{}
+
+    if (Test-Path -LiteralPath $eventsPath -PathType Leaf) {
+        $processedLineCount = @(Get-Content -LiteralPath $eventsPath -Encoding UTF8).Count
+    }
+
+    while ($true) {
+        $cycleResult = Invoke-CommanderPollCycle `
+            -ManifestPath $ManifestPath `
+            -ProcessedLineCount $processedLineCount `
+            -ProcessedEventSignatures $processedEventSignatures
+
+        $processedLineCount = [int]$cycleResult['ProcessedLineCount']
+        $processedEventSignatures = $cycleResult['ProcessedEventSignatures']
+        Write-Output (($cycleResult['Summary']) | ConvertTo-Json -Compress -Depth 10)
+        Start-Sleep -Seconds $Interval
+    }
 }


### PR DESCRIPTION
## Summary
- Mailbox notifications on idle/approval/stall detection
- commander-poll.ps1 processes both events.jsonl and mailbox
- Enables Commander autonomous idle recovery

## Test plan
- [x] 91/91 Pester tests pass

Closes #302

🤖 Generated with [Claude Code](https://claude.com/claude-code)