### PR TITLE
fix: handle detached HEAD worktrees in orchestra-start (TASK-214)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ tests/*
 !tests/OrchestraPreflight.Tests.ps1
 !tests/PaneBorder.Tests.ps1
 !tests/Integration.WorktreeHook.Tests.ps1
+!tests/BuilderWorktree.Tests.ps1
 !tests/README.md
 /hooks/
 .githooks/

--- a/tests/BuilderWorktree.Tests.ps1
+++ b/tests/BuilderWorktree.Tests.ps1
@@ -1,0 +1,65 @@
+$ErrorActionPreference = 'Stop'
+
+Describe 'ConvertFrom-GitWorktreeList' {
+    BeforeAll {
+        . (Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\builder-worktree.ps1')
+    }
+
+    It 'parses a normal worktree entry with a branch name' {
+        $content = @'
+worktree C:/repo
+HEAD abcdef1234567890
+branch refs/heads/main
+
+'@
+
+        $entries = ConvertFrom-GitWorktreeList -Content $content
+
+        $entries.Count | Should -Be 1
+        $entries[0].WorktreePath | Should -Be 'C:/repo'
+        $entries[0].BranchName | Should -Be 'main'
+    }
+
+    It 'parses a detached HEAD entry without throwing and leaves BranchName empty' {
+        $content = @'
+worktree C:/repo/.worktrees/builder-1
+HEAD abcdef1234567890
+detached
+
+'@
+
+        { ConvertFrom-GitWorktreeList -Content $content } | Should -Not -Throw
+
+        $entries = ConvertFrom-GitWorktreeList -Content $content
+
+        $entries.Count | Should -Be 1
+        $entries[0].WorktreePath | Should -Be 'C:/repo/.worktrees/builder-1'
+        $entries[0].BranchName | Should -Be ''
+    }
+
+    It 'parses mixed branch and detached worktree entries' {
+        $content = @'
+worktree C:/repo
+HEAD 1111111111111111
+branch refs/heads/main
+
+worktree C:/repo/.worktrees/builder-1
+HEAD 2222222222222222
+detached
+
+worktree C:/repo/.worktrees/builder-2
+HEAD 3333333333333333
+branch refs/heads/worktree-builder-2
+'@
+
+        $entries = ConvertFrom-GitWorktreeList -Content $content
+
+        $entries.Count | Should -Be 3
+        @($entries | ForEach-Object BranchName) | Should -Be @('main', '', 'worktree-builder-2')
+        @($entries | ForEach-Object WorktreePath) | Should -Be @(
+            'C:/repo',
+            'C:/repo/.worktrees/builder-1',
+            'C:/repo/.worktrees/builder-2'
+        )
+    }
+}

--- a/winsmux-core/scripts/builder-worktree.ps1
+++ b/winsmux-core/scripts/builder-worktree.ps1
@@ -59,7 +59,7 @@ function ConvertFrom-GitWorktreeList {
             if ($current.Contains('worktree')) {
                 $entries.Add([PSCustomObject]@{
                     WorktreePath = [string]$current.worktree
-                    BranchName   = [string]$current.branch
+                    BranchName   = if ($current.Contains('branch')) { [string]$current['branch'] } else { '' }
                 }) | Out-Null
             }
 
@@ -76,12 +76,16 @@ function ConvertFrom-GitWorktreeList {
             $current.branch = $Matches[1]
             continue
         }
+
+        if ($line -eq 'detached') {
+            continue
+        }
     }
 
     if ($current.Contains('worktree')) {
         $entries.Add([PSCustomObject]@{
             WorktreePath = [string]$current.worktree
-            BranchName   = [string]$current.branch
+            BranchName   = if ($current.Contains('branch')) { [string]$current['branch'] } else { '' }
         }) | Out-Null
     }
 


### PR DESCRIPTION
## Summary
- Fix PropertyNotFoundException when `git worktree list` returns detached HEAD entries
- `ConvertFrom-GitWorktreeList` now handles missing `branch` key gracefully
- New test coverage: normal, detached, and mixed worktree scenarios

## Test plan
- [x] 94/94 Pester tests pass (3 new)
- [x] Detached HEAD worktree parsed with empty BranchName

🤖 Generated with [Claude Code](https://claude.com/claude-code)