### PR TITLE
chore: pre-v0.19.4 release cleanup

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -80,6 +80,7 @@ pwsh scripts/bump-version.ps1 -Version X.Y.Z
 - Use `[ordered]@{}` instead of `[PSCustomObject]@{}`
 - Use hashtable assignment (`$obj['key'] = val`) instead of `Add-Member`
 - Codex context reset: `/new` (not `/clear`). `/compact` for context shrink.
+- Sandbox uses `--sandbox danger-full-access` to bypass CLM (#319). Builders can run Pester directly.
 
 ## Task Status Rules
 

--- a/.claude/rules/dispatch.md
+++ b/.claude/rules/dispatch.md
@@ -10,6 +10,7 @@ paths: ["winsmux-core/scripts/**", ".claude/**"]
 3. Send: `winsmux send -t <pane> "Read .builder-prompt.txt and implement"` + Enter via `pwsh -NoProfile -File scripts/winsmux-core.ps1 keys <pane> Enter`
 4. Monitor: `winsmux capture-pane -t <pane> -p | tail -15`
 5. Verify: `git -C <worktree> diff --stat HEAD`
+6. **Commander runs tests** (Builder cannot — CLM #319): `NO_COLOR=1 pwsh -Command "Invoke-Pester <worktree>/tests/ -Output Minimal"`
 
 ## Reviewer Dispatch
 1. Send review request: `winsmux send -t reviewer-1 "Review diffs in .worktrees/builder-N"` + Enter

--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,8 @@ CLAUDE.md
 .claude/logs/
 .claude/worktrees/
 # .codex/ and .gemini/ are tracked (agent project config)
+# Exclude sandbox config (local-only, contains danger-full-access for CLM bypass #319)
+.codex/config.toml
 # Exclude only runtime/local files if they appear
 *.local
 .vscode/settings.json


### PR DESCRIPTION
## Summary
- CLAUDE.md: CLM sandbox note
- dispatch.md: Commander test step
- .gitignore: .codex/config.toml exclusion

## Test plan
- [x] Config-only, no code impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)