### PR TITLE
feat: land TASK-205 and orchestra state tracking updates

### DIFF
--- a/core/src/app.rs
+++ b/core/src/app.rs
@@ -296,15 +296,39 @@ pub fn run(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> io::Result<
                     if let Some(pid) = target_pane {
                         if is_focus_cmd {
                             if pane_is_id {
-                                let _ = tx.send(CtrlReq::FocusPane(pid));
+                                let (rtx, rrx) = mpsc::channel();
+                                let _ = tx.send(CtrlReq::FocusPaneChecked(pid, rtx));
+                                if !rrx.recv_timeout(Duration::from_millis(2000)).unwrap_or(false) {
+                                    let _ = write!(stream, "can't find pane: {}\n", pid);
+                                    let _ = stream.flush();
+                                    return;
+                                }
                             } else {
-                                let _ = tx.send(CtrlReq::FocusPaneByIndex(pid));
+                                let (rtx, rrx) = mpsc::channel();
+                                let _ = tx.send(CtrlReq::FocusPaneByIndexChecked(pid, rtx));
+                                if !rrx.recv_timeout(Duration::from_millis(2000)).unwrap_or(false) {
+                                    let _ = write!(stream, "can't find pane index: {}\n", pid);
+                                    let _ = stream.flush();
+                                    return;
+                                }
                             }
                         } else {
                             if pane_is_id {
-                                let _ = tx.send(CtrlReq::FocusPaneTemp(pid));
+                                let (rtx, rrx) = mpsc::channel();
+                                let _ = tx.send(CtrlReq::FocusPaneTemp(pid, rtx));
+                                if !rrx.recv_timeout(Duration::from_millis(2000)).unwrap_or(false) {
+                                    let _ = write!(stream, "can't find pane: {}\n", pid);
+                                    let _ = stream.flush();
+                                    return;
+                                }
                             } else {
-                                let _ = tx.send(CtrlReq::FocusPaneByIndexTemp(pid));
+                                let (rtx, rrx) = mpsc::channel();
+                                let _ = tx.send(CtrlReq::FocusPaneByIndexTemp(pid, rtx));
+                                if !rrx.recv_timeout(Duration::from_millis(2000)).unwrap_or(false) {
+                                    let _ = write!(stream, "can't find pane index: {}\n", pid);
+                                    let _ = stream.flush();
+                                    return;
+                                }
                             }
                         }
                     }
@@ -979,10 +1003,12 @@ pub fn run(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> io::Result<
                 }
                 CtrlReq::FocusWindow(wid) => { if let Some(idx) = find_window_index_by_id(&app, wid) { app.active_idx = idx; } }
                 CtrlReq::FocusWindowTemp(wid) => { if let Some(idx) = find_window_index_by_id(&app, wid) { app.active_idx = idx; } }
-                CtrlReq::FocusPane(pid) => { focus_pane_by_id(&mut app, pid); }
-                CtrlReq::FocusPaneByIndex(idx) => { focus_pane_by_index(&mut app, idx); }
-                CtrlReq::FocusPaneTemp(pid) => { focus_pane_by_id(&mut app, pid); }
-                CtrlReq::FocusPaneByIndexTemp(idx) => { focus_pane_by_index(&mut app, idx); }
+                CtrlReq::FocusPane(pid) => { let _ = focus_pane_by_id(&mut app, pid); }
+                CtrlReq::FocusPaneByIndex(idx) => { let _ = focus_pane_by_index(&mut app, idx); }
+                CtrlReq::FocusPaneChecked(pid, resp) => { let _ = resp.send(focus_pane_by_id(&mut app, pid)); }
+                CtrlReq::FocusPaneByIndexChecked(idx, resp) => { let _ = resp.send(focus_pane_by_index(&mut app, idx)); }
+                CtrlReq::FocusPaneTemp(pid, resp) => { let _ = resp.send(focus_pane_by_id(&mut app, pid)); }
+                CtrlReq::FocusPaneByIndexTemp(idx, resp) => { let _ = resp.send(focus_pane_by_index(&mut app, idx)); }
                 CtrlReq::SessionInfo(resp) => {
                     let attached = if app.attached_clients > 0 { "(attached)" } else { "(detached)" };
                     let windows = app.windows.len();
@@ -1022,7 +1048,7 @@ pub fn run(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> io::Result<
                     app.last_window_area = Rect { x: 0, y: 0, width: w, height: h }; 
                     resize_all_panes(&mut app);
                 }
-                CtrlReq::FocusPaneCmd(pid) => { focus_pane_by_id(&mut app, pid); }
+                CtrlReq::FocusPaneCmd(pid) => { let _ = focus_pane_by_id(&mut app, pid); }
                 CtrlReq::FocusWindowCmd(wid) => { if let Some(idx) = find_window_index_by_id(&app, wid) { app.active_idx = idx; } }
                 CtrlReq::MouseDown(_,x,y) => { remote_mouse_down(&mut app, x, y); }
                 CtrlReq::MouseDownRight(_,x,y) => { remote_mouse_button(&mut app, x, y, 2, true); }

--- a/core/src/server/connection.rs
+++ b/core/src/server/connection.rs
@@ -271,15 +271,43 @@ if control_echo || control_noecho {
         if let Some(pid) = ctrl_target_pane {
             if is_focus_cmd {
                 if ctrl_pane_is_id {
-                    let _ = tx_ctrl.send(CtrlReq::FocusPane(pid));
+                    let (rtx, rrx) = mpsc::channel::<bool>();
+                    let _ = tx_ctrl.send(CtrlReq::FocusPaneChecked(pid, rtx));
+                    if !rrx.recv_timeout(Duration::from_millis(2000)).unwrap_or(false) {
+                        let _ = writeln!(write_stream, "can't find pane: {}", pid);
+                        let _ = writeln!(write_stream, "{}", control::format_error(ts, cmd_counter));
+                        let _ = write_stream.flush();
+                        continue;
+                    }
                 } else {
-                    let _ = tx_ctrl.send(CtrlReq::FocusPaneByIndex(pid));
+                    let (rtx, rrx) = mpsc::channel::<bool>();
+                    let _ = tx_ctrl.send(CtrlReq::FocusPaneByIndexChecked(pid, rtx));
+                    if !rrx.recv_timeout(Duration::from_millis(2000)).unwrap_or(false) {
+                        let _ = writeln!(write_stream, "can't find pane index: {}", pid);
+                        let _ = writeln!(write_stream, "{}", control::format_error(ts, cmd_counter));
+                        let _ = write_stream.flush();
+                        continue;
+                    }
                 }
             } else {
                 if ctrl_pane_is_id {
-                    let _ = tx_ctrl.send(CtrlReq::FocusPaneTemp(pid));
+                    let (rtx, rrx) = mpsc::channel::<bool>();
+                    let _ = tx_ctrl.send(CtrlReq::FocusPaneTemp(pid, rtx));
+                    if !rrx.recv_timeout(Duration::from_millis(2000)).unwrap_or(false) {
+                        let _ = writeln!(write_stream, "can't find pane: {}", pid);
+                        let _ = writeln!(write_stream, "{}", control::format_error(ts, cmd_counter));
+                        let _ = write_stream.flush();
+                        continue;
+                    }
                 } else {
-                    let _ = tx_ctrl.send(CtrlReq::FocusPaneByIndexTemp(pid));
+                    let (rtx, rrx) = mpsc::channel::<bool>();
+                    let _ = tx_ctrl.send(CtrlReq::FocusPaneByIndexTemp(pid, rtx));
+                    if !rrx.recv_timeout(Duration::from_millis(2000)).unwrap_or(false) {
+                        let _ = writeln!(write_stream, "can't find pane index: {}", pid);
+                        let _ = writeln!(write_stream, "{}", control::format_error(ts, cmd_counter));
+                        let _ = write_stream.flush();
+                        continue;
+                    }
                 }
             }
         }
@@ -440,22 +468,50 @@ let targeted_kill_pane_id = if matches!(cmd, "kill-pane" | "killp") && pane_is_i
 };
 let skip_pane_focus = matches!(cmd, "display-message" | "display");
 if !skip_pane_focus && targeted_kill_pane_id.is_none() {
-    if let Some(pid) = target_pane {
-        if is_focus_cmd {
-            if pane_is_id {
-                let _ = tx.send(CtrlReq::FocusPane(pid));
+        if let Some(pid) = target_pane {
+            if is_focus_cmd {
+                if pane_is_id {
+                    let (rtx, rrx) = mpsc::channel::<bool>();
+                    let _ = tx.send(CtrlReq::FocusPaneChecked(pid, rtx));
+                    if !rrx.recv_timeout(Duration::from_millis(2000)).unwrap_or(false) {
+                        let _ = write!(write_stream, "can't find pane: {}\n", pid);
+                        let _ = write_stream.flush();
+                        if !persistent { break; }
+                        continue;
+                    }
+                } else {
+                    let (rtx, rrx) = mpsc::channel::<bool>();
+                    let _ = tx.send(CtrlReq::FocusPaneByIndexChecked(pid, rtx));
+                    if !rrx.recv_timeout(Duration::from_millis(2000)).unwrap_or(false) {
+                        let _ = write!(write_stream, "can't find pane index: {}\n", pid);
+                        let _ = write_stream.flush();
+                        if !persistent { break; }
+                        continue;
+                    }
+                }
             } else {
-                let _ = tx.send(CtrlReq::FocusPaneByIndex(pid));
-            }
-        } else {
-            if pane_is_id {
-                let _ = tx.send(CtrlReq::FocusPaneTemp(pid));
-            } else {
-                let _ = tx.send(CtrlReq::FocusPaneByIndexTemp(pid));
+                if pane_is_id {
+                    let (rtx, rrx) = mpsc::channel::<bool>();
+                    let _ = tx.send(CtrlReq::FocusPaneTemp(pid, rtx));
+                    if !rrx.recv_timeout(Duration::from_millis(2000)).unwrap_or(false) {
+                        let _ = write!(write_stream, "can't find pane: {}\n", pid);
+                        let _ = write_stream.flush();
+                        if !persistent { break; }
+                        continue;
+                    }
+                } else {
+                    let (rtx, rrx) = mpsc::channel::<bool>();
+                    let _ = tx.send(CtrlReq::FocusPaneByIndexTemp(pid, rtx));
+                    if !rrx.recv_timeout(Duration::from_millis(2000)).unwrap_or(false) {
+                        let _ = write!(write_stream, "can't find pane index: {}\n", pid);
+                        let _ = write_stream.flush();
+                        if !persistent { break; }
+                        continue;
+                    }
+                }
             }
         }
     }
-}
 match cmd {
     "new-window" | "neww" => {
         let name: Option<String> = args.windows(2).find(|w| w[0] == "-n").map(|w| w[1].trim_matches('"').to_string());

--- a/core/src/server/mod.rs
+++ b/core/src/server/mod.rs
@@ -695,7 +695,7 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                         | CtrlReq::SendPaste(_)
                     );
                     let is_temp_focus = matches!(&req,
-                        CtrlReq::FocusWindowTemp(_) | CtrlReq::FocusPaneTemp(_) | CtrlReq::FocusPaneByIndexTemp(_));
+                        CtrlReq::FocusWindowTemp(_) | CtrlReq::FocusPaneTemp(..) | CtrlReq::FocusPaneByIndexTemp(..));
                     let mut hook_event: Option<&str> = None;
                     // Track active_idx changes for debugging window-switch issues
                     let _prev_active_idx = app.active_idx;
@@ -711,7 +711,9 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                         CtrlReq::MouseDownRight(..) => "MouseDownRight",
                         CtrlReq::MouseDownMiddle(..) => "MouseDownMiddle",
                         CtrlReq::FocusPane(_) => "FocusPane",
-                        CtrlReq::FocusPaneTemp(_) => "FocusPaneTemp",
+                        CtrlReq::FocusPaneChecked(..) => "FocusPaneChecked",
+                        CtrlReq::FocusPaneByIndexChecked(..) => "FocusPaneByIndexChecked",
+                        CtrlReq::FocusPaneTemp(..) => "FocusPaneTemp",
                         CtrlReq::NewWindow(..) => "NewWindow",
                         CtrlReq::KillWindow => "KillWindow",
                         CtrlReq::KillPane => "KillPane",
@@ -947,19 +949,41 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                 }
                 CtrlReq::FocusPane(pid) => {
                     let old_path = app.windows[app.active_idx].active_path.clone();
-                    switch_with_copy_save(&mut app, |app| { focus_pane_by_id(app, pid); });
+                    switch_with_copy_save(&mut app, |app| { let _ = focus_pane_by_id(app, pid); });
                     if app.windows[app.active_idx].active_path != old_path { unzoom_if_zoomed(&mut app); }
                     meta_dirty = true;
                 }
                 CtrlReq::FocusPaneByIndex(idx) => {
                     let old_path = app.windows[app.active_idx].active_path.clone();
-                    switch_with_copy_save(&mut app, |app| { focus_pane_by_index(app, idx); });
+                    switch_with_copy_save(&mut app, |app| { let _ = focus_pane_by_index(app, idx); });
                     if app.windows[app.active_idx].active_path != old_path { unzoom_if_zoomed(&mut app); }
                     // Update MRU so directional navigation remembers this focus change
                     let win = &mut app.windows[app.active_idx];
                     if let Some(pid) = crate::tree::get_active_pane_id(&win.root, &win.active_path) {
                         crate::tree::touch_mru(&mut win.pane_mru, pid);
                     }
+                    meta_dirty = true;
+                }
+                CtrlReq::FocusPaneChecked(pid, resp) => {
+                    let old_path = app.windows[app.active_idx].active_path.clone();
+                    let mut focused = false;
+                    switch_with_copy_save(&mut app, |app| { focused = focus_pane_by_id(app, pid); });
+                    if focused && app.windows[app.active_idx].active_path != old_path { unzoom_if_zoomed(&mut app); }
+                    let _ = resp.send(focused);
+                    meta_dirty = true;
+                }
+                CtrlReq::FocusPaneByIndexChecked(idx, resp) => {
+                    let old_path = app.windows[app.active_idx].active_path.clone();
+                    let mut focused = false;
+                    switch_with_copy_save(&mut app, |app| { focused = focus_pane_by_index(app, idx); });
+                    if focused && app.windows[app.active_idx].active_path != old_path { unzoom_if_zoomed(&mut app); }
+                    if focused {
+                        let win = &mut app.windows[app.active_idx];
+                        if let Some(pid) = crate::tree::get_active_pane_id(&win.root, &win.active_path) {
+                            crate::tree::touch_mru(&mut win.pane_mru, pid);
+                        }
+                    }
+                    let _ = resp.send(focused);
                     meta_dirty = true;
                 }
                 // ── Temporary focus variants for -t targeting ────────────
@@ -982,25 +1006,41 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                         }
                     }
                 }
-                CtrlReq::FocusPaneTemp(pid) => {
-                    if temp_focus_restore.is_none() {
-                        let pane_id = crate::tree::get_active_pane_id(
-                            &app.windows[app.active_idx].root,
-                            &app.windows[app.active_idx].active_path,
-                        ).unwrap_or(usize::MAX);
-                        temp_focus_restore = Some((app.active_idx, pane_id));
+                CtrlReq::FocusPaneTemp(pid, resp) => {
+                    let saved_focus = if temp_focus_restore.is_none() {
+                        Some((
+                            app.active_idx,
+                            crate::tree::get_active_pane_id(
+                                &app.windows[app.active_idx].root,
+                                &app.windows[app.active_idx].active_path,
+                            ).unwrap_or(usize::MAX),
+                        ))
+                    } else {
+                        None
+                    };
+                    let focused = focus_pane_by_id(&mut app, pid);
+                    if focused && temp_focus_restore.is_none() {
+                        temp_focus_restore = saved_focus;
                     }
-                    focus_pane_by_id(&mut app, pid);
+                    let _ = resp.send(focused);
                 }
-                CtrlReq::FocusPaneByIndexTemp(idx) => {
-                    if temp_focus_restore.is_none() {
-                        let pane_id = crate::tree::get_active_pane_id(
-                            &app.windows[app.active_idx].root,
-                            &app.windows[app.active_idx].active_path,
-                        ).unwrap_or(usize::MAX);
-                        temp_focus_restore = Some((app.active_idx, pane_id));
+                CtrlReq::FocusPaneByIndexTemp(idx, resp) => {
+                    let saved_focus = if temp_focus_restore.is_none() {
+                        Some((
+                            app.active_idx,
+                            crate::tree::get_active_pane_id(
+                                &app.windows[app.active_idx].root,
+                                &app.windows[app.active_idx].active_path,
+                            ).unwrap_or(usize::MAX),
+                        ))
+                    } else {
+                        None
+                    };
+                    let focused = focus_pane_by_index(&mut app, idx);
+                    if focused && temp_focus_restore.is_none() {
+                        temp_focus_restore = saved_focus;
                     }
-                    focus_pane_by_index(&mut app, idx);
+                    let _ = resp.send(focused);
                 }
                 CtrlReq::SessionInfo(resp) => {
                     let num_attached = app.client_registry.len();
@@ -1354,7 +1394,7 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                 }
                 CtrlReq::FocusPaneCmd(pid) => {
                     let old_path = app.windows[app.active_idx].active_path.clone();
-                    switch_with_copy_save(&mut app, |app| { focus_pane_by_id(app, pid); });
+                    switch_with_copy_save(&mut app, |app| { let _ = focus_pane_by_id(app, pid); });
                     if app.windows[app.active_idx].active_path != old_path { unzoom_if_zoomed(&mut app); }
                     meta_dirty = true;
                 }

--- a/core/src/tree.rs
+++ b/core/src/tree.rs
@@ -585,7 +585,7 @@ pub fn find_window_index_by_id(app: &AppState, wid: usize) -> Option<usize> {
     app.windows.iter().position(|w| w.id == wid)
 }
 
-pub fn focus_pane_by_id(app: &mut AppState, pid: usize) {
+pub fn focus_pane_by_id(app: &mut AppState, pid: usize) -> bool {
     fn rec(node: &Node, path: &mut Vec<usize>, found: &mut Option<Vec<usize>>, pid: usize) {
         match node {
             Node::Leaf(p) => { if p.id == pid { *found = Some(path.clone()); } }
@@ -598,11 +598,19 @@ pub fn focus_pane_by_id(app: &mut AppState, pid: usize) {
         let mut path = Vec::new();
         let mut found = None;
         rec(&w.root, &mut path, &mut found, pid);
-        if let Some(p) = found { app.active_idx = wi; let win = &mut app.windows[wi]; win.active_path = p; touch_mru(&mut win.pane_mru, pid); return; }
+        if let Some(p) = found {
+            app.active_idx = wi;
+            let win = &mut app.windows[wi];
+            win.active_path = p;
+            touch_mru(&mut win.pane_mru, pid);
+            return true;
+        }
     }
+
+    false
 }
 
-pub fn focus_pane_by_index(app: &mut AppState, idx: usize) {
+pub fn focus_pane_by_index(app: &mut AppState, idx: usize) -> bool {
     fn collect_pane_paths(node: &Node, path: &mut Vec<usize>, panes: &mut Vec<Vec<usize>>) {
         match node {
             Node::Leaf(_) => { panes.push(path.clone()); }
@@ -621,7 +629,10 @@ pub fn focus_pane_by_index(app: &mut AppState, idx: usize) {
     collect_pane_paths(&win.root, &mut path, &mut pane_paths);
     if let Some(path) = pane_paths.get(idx) {
         win.active_path = path.clone();
+        return true;
     }
+
+    false
 }
 
 /// Count the number of leaf (pane) nodes in a tree.
@@ -759,3 +770,7 @@ pub fn collect_leaves(node: Node) -> Vec<Node> {
 #[cfg(test)]
 #[path = "../tests-rs/test_issue171_layout_bugs.rs"]
 mod test_issue171_layout_bugs;
+
+#[cfg(test)]
+#[path = "../tests-rs/test_task205_focus.rs"]
+mod test_task205_focus;

--- a/core/src/types.rs
+++ b/core/src/types.rs
@@ -817,9 +817,12 @@ pub enum CtrlReq {
     FocusWindowTemp(usize),
     FocusPane(usize),
     FocusPaneByIndex(usize),
+    /// Checked permanent focus for -t targeting on focus-changing commands.
+    FocusPaneChecked(usize, mpsc::Sender<bool>),
+    FocusPaneByIndexChecked(usize, mpsc::Sender<bool>),
     /// Temporary pane focus for -t targeting
-    FocusPaneTemp(usize),
-    FocusPaneByIndexTemp(usize),
+    FocusPaneTemp(usize, mpsc::Sender<bool>),
+    FocusPaneByIndexTemp(usize, mpsc::Sender<bool>),
     SessionInfo(mpsc::Sender<String>),
     CapturePaneRange(mpsc::Sender<String>, Option<i32>, Option<i32>),
     ClientAttach(u64),

--- a/core/tests-rs/test_task205_focus.rs
+++ b/core/tests-rs/test_task205_focus.rs
@@ -1,0 +1,30 @@
+use portable_pty::native_pty_system;
+
+#[test]
+fn focus_pane_by_id_returns_false_and_preserves_focus_when_target_is_missing() {
+    let pty = native_pty_system();
+    let mut app = crate::types::AppState::new("task205-focus".to_string());
+
+    crate::pane::create_window(&*pty, &mut app, Some("cmd /c pause"), None).expect("first pane should spawn");
+    crate::pane::create_window(&*pty, &mut app, Some("cmd /c pause"), None).expect("second pane should spawn");
+
+    let original_window_idx = app.active_idx;
+    let original_pane_id = crate::tree::get_active_pane_id(
+        &app.windows[app.active_idx].root,
+        &app.windows[app.active_idx].active_path,
+    )
+    .expect("active pane should exist");
+
+    let missing_pane_id = original_pane_id + 9999;
+    let focused = crate::tree::focus_pane_by_id(&mut app, missing_pane_id);
+
+    assert!(!focused, "missing pane ids must report failure");
+    assert_eq!(app.active_idx, original_window_idx, "missing targets must not change the active window");
+
+    let current_pane_id = crate::tree::get_active_pane_id(
+        &app.windows[app.active_idx].root,
+        &app.windows[app.active_idx].active_path,
+    )
+    .expect("active pane should still exist");
+    assert_eq!(current_pane_id, original_pane_id, "missing targets must preserve the active pane");
+}

--- a/docs/project/ROADMAP.md
+++ b/docs/project/ROADMAP.md
@@ -1,7 +1,7 @@
 # ロードマップ
 
 > `tasks/backlog.yaml` から自動生成 — 手動編集禁止
-> 最終同期: 2026-04-07 22:36 (+09:00)
+> 最終同期: 2026-04-09 21:21 (+09:00)
 
 ## バージョン概要
 
@@ -30,13 +30,17 @@
 | v0.19.1 | 3 | [====================] 100% (3/3) |
 | v0.19.2 | 1 | [====================] 100% (1/1) |
 | v0.19.3 | 3 | [====================] 100% (3/3) |
-| v0.19.4 | 27 | [==========----------] 48% (13/27) |
-| v0.19.5 | 6 | [--------------------] 0% (0/6) |
-| v0.20.0 | 8 | [--------------------] 0% (0/8) |
-| v0.20.1 | 8 | [--------------------] 0% (0/8) |
-| v0.21.0 | 6 | [--------------------] 0% (0/6) |
+| v0.19.4 | 23 | [====================] 100% (23/23) |
+| v0.19.5 | 27 | [====================] 100% (27/27) |
+| v0.19.6 | 6 | [--------------------] 0% (0/6) |
+| v0.19.7 | 7 | [===-----------------] 14% (1/7) |
+| v0.20.0 | 15 | [--------------------] 0% (0/15) |
+| v0.20.1 | 9 | [==------------------] 11% (1/9) |
+| v0.21.0 | 7 | [--------------------] 0% (0/7) |
 | v0.21.1 | 7 | [--------------------] 0% (0/7) |
-| v0.22.0 | 3 | [--------------------] 0% (0/3) |
+| v0.22.0 | 13 | [--------------------] 0% (0/13) |
+| v0.23.0 | 2 | [--------------------] 0% (0/2) |
+| v1.0.0 | 1 | [--------------------] 0% (0/1) |
 | cancelled | 24 | [--------------------] 0% (0/24) |
 | post-v1.0.0 | 7 | [--------------------] 0% (0/7) |
 
@@ -260,53 +264,100 @@
 | | ID | Title | Priority | Repo | Status |
 |-|-----|-------|----------|------|--------|
 | [x] | TASK-176 | Integrate builder-queue auto-dispatch into agent-monitor respawn loop (#275) | P0 | winsmux | done |
-| [ ] | TASK-179 | Gate: block Commander git commit until Reviewer PASS confirmed (#279) | P0 | winsmux | backlog |
-| [ ] | TASK-182 | Builder pane Codex cannot access new worktrees (#283) | P0 | winsmux | backlog |
+| [x] | TASK-179 | Gate: block Commander git commit until Reviewer PASS confirmed (#279) | P0 | winsmux | done |
+| [x] | TASK-182 | Builder pane Codex cannot access new worktrees (#283) | P0 | winsmux | done |
 | [x] | TASK-184 | winsmux send dispatches raw text instead of codex exec (#286) | P0 | winsmux | done |
 | [x] | TASK-185 | Create .claude/rules/dispatch.md Commander dispatch procedure (#287) | P0 | winsmux | done |
 | [x] | TASK-186 | orchestra-start should leave panes at pwsh prompt, not launch Codex interactive (#288) | P0 | winsmux | done |
 | [x] | TASK-193 | agent-monitor respawn ignores exec_mode, launches persistent Codex (#289) | P0 | winsmux | done |
 | [x] | TASK-199 | Dispatch workflow 3 structural failures — agent-type, send+Enter, target validation (#301) | P0 | winsmux | done |
 | [x] | TASK-203 | Watchdog does not notify Commander — add events.jsonl polling (#308) | P0 | winsmux | done |
-| [ ] | TASK-174 | Add send-keys buffer overflow protection to winsmux send (#265) | P1 | winsmux | backlog |
-| [ ] | TASK-175 | Fix Researcher pane not receiving commands via winsmux send (#271) | P1 | winsmux | backlog |
-| [ ] | TASK-177 | Prevent Agent subagent from bypassing sh-orchestra-gate hook (#273) | P1 | winsmux | backlog |
+| [x] | TASK-177 | Prevent Agent subagent from bypassing sh-orchestra-gate hook (#273) | P1 | winsmux | done |
 | [x] | TASK-178 | Implement winsmux verify command or remove Gate Rule 7 (#277) | P1 | winsmux | done |
-| [ ] | TASK-180 | Gate: Commander status reports verified against actual pane state (#280) | P1 | winsmux | backlog |
+| [x] | TASK-180 | Gate: Commander status reports verified against actual pane state (#280) | P1 | winsmux | done |
 | [x] | TASK-181 | Fix sh-circuit-breaker.js false positives (#282, #295) | P1 | winsmux | done |
 | [x] | TASK-183 | Researcher role-gate does not block code editing (#284) | P1 | winsmux | done |
-| [ ] | TASK-187 | PromptTransport abstraction — argv/stdin/file unified interface | P1 | winsmux | backlog |
-| [ ] | TASK-188 | Task Prompt File pattern — .winsmux/task-{slug}.md file-backed handoff | P1 | winsmux | backlog |
-| [ ] | TASK-194 | agent-monitor idle alerts go to user Telegram instead of Commander (#290) | P1 | winsmux | backlog |
-| [ ] | TASK-195 | respawn-pane does not update pane label in manifest.yaml (#291) | P1 | winsmux | backlog |
+| [x] | TASK-194 | agent-monitor idle alerts go to user Telegram instead of Commander (#290) | P1 | winsmux | done |
+| [x] | TASK-195 | respawn-pane does not update pane label in manifest.yaml (#291) | P1 | winsmux | done |
 | [x] | TASK-196 | Fix hooks/scripts referencing files deleted in PR #79 (#292) | P1 | winsmux | done |
 | [x] | TASK-197 | Audit and resolve 8 orphan scripts in winsmux-core/scripts/ (#293) | P1 | winsmux | done |
 | [x] | TASK-198 | Hook Rule 2 scans heredoc body, blocks unrelated commands (#300) | P1 | winsmux | done |
-| [ ] | TASK-200 | agent-monitor bidirectional communication + idle recovery (#302) | P1 | winsmux | backlog |
-| [ ] | TASK-201 | Auto-clear Codex panes at 10% context remaining (#303) | P1 | winsmux | backlog |
-| [ ] | TASK-202 | Remove pane-level alerts from Telegram — Commander-only (#306) | P1 | winsmux | backlog |
-| [ ] | TASK-204 | Codex pane context reset uses /new not /clear (#309) | P1 | winsmux | backlog |
+| [x] | TASK-200 | agent-monitor bidirectional communication + idle recovery (#302) | P1 | winsmux | done |
+| [x] | TASK-201 | Auto-clear Codex panes at 10% context remaining (#303) | P1 | winsmux | done |
+| [x] | TASK-202 | Remove pane-level alerts from Telegram — Commander-only (#306) | P1 | winsmux | done |
+| [x] | TASK-204 | Codex pane context reset uses /new not /clear (#309) | P1 | winsmux | done |
 
 ### v0.19.5: monitoring stack + process gates
 
 | | ID | Title | Priority | Repo | Status |
 |-|-----|-------|----------|------|--------|
-| [ ] | TASK-205 | winsmux send silent failure — focus_pane_by_id returns without error (#316) | P0 | winsmux | backlog |
-| [ ] | TASK-206 | Monitoring stack non-functional — watchdog→Commander delivery path missing (#317) | P0 | winsmux | backlog |
-| [ ] | TASK-209 | Commander Reviewer bypass — process gate enforcement (#314) | P0 | winsmux | backlog |
-| [ ] | TASK-207 | Reviewer audit checklist — design-impact scope mandatory (#318) | P1 | winsmux | backlog |
-| [ ] | TASK-208 | Codex CLM blocks Pester test execution in builder panes (#319) | P1 | winsmux | backlog |
-| [ ] | TASK-210 | Reviewer audit scope too narrow (#315) | P1 | winsmux | backlog |
+| [x] | TASK-205 | winsmux send silent failure — focus_pane_by_id returns without error (#316) | P0 | winsmux | done |
+| [x] | TASK-206 | Monitoring stack non-functional — watchdog→Commander delivery path missing (#317) | P0 | winsmux | done |
+| [x] | TASK-209 | Commander Reviewer bypass — process gate enforcement (#314) | P0 | winsmux | done |
+| [x] | TASK-211 | Commander subagent edit gate — block Agent write permissions (#324) | P0 | winsmux | done |
+| [x] | TASK-214 | Fix orchestra-start crash on detached HEAD worktrees | P0 | winsmux | done |
+| [x] | TASK-221 | Non-destructive rollback — stop kill-session in orchestra-start (#334) | P0 | winsmux | done |
+| [x] | TASK-225 | Guard settings.local.json — block hook disable without approval (#338) | P0 | winsmux | done |
+| [x] | TASK-227 | Fix pane.completed event never fires — add previous-state tracking | P0 | winsmux | done |
+| [x] | TASK-228 | Launch commander-poll.ps1 from orchestra-start (#311 integration) | P0 | winsmux | done |
+| [x] | TASK-229 | Enforce review-approve from Reviewer pane only (#338 enforcement) | P0 | winsmux | done |
+| [x] | TASK-231 | Orchestra startup debug instrumentation — preserve failure evidence for Commander unresolved startup (#344) | P0 | winsmux | done |
+| [x] | TASK-232 | orchestra-start false success — Codex/Commander launch path succeeds without verified agent startup (#345) | P0 | winsmux | done |
+| [x] | TASK-233 | Detached orchestra layout reliability — fail fast when pane creation does not actually occur (#346) | P0 | winsmux | done |
+| [x] | TASK-235 | Direct Commander↔Reviewer review flow — remove user relay from review-request/review-approve (#348) | P0 | winsmux | done |
+| [x] | TASK-236 | Pane bootstrap invariants — guarantee repo cwd and WINSMUX_ROLE for all panes (#349) | P0 | winsmux | done |
+| [x] | TASK-238 | Commander runtime state machine — integrate dispatch/review/commit loop into commander-poll (#348) | P0 | winsmux | done |
+| [x] | TASK-239 | Commander first-class defaults — add commanders setting and default Commander pane (#345) | P0 | winsmux | done |
+| [x] | TASK-240 | Pane bootstrap verification — fail closed on cwd/role/pane_id mismatch and invalidate stale manifest (#349) | P0 | winsmux | done |
+| [x] | TASK-241 | Commander delegated write bypass — fail closed for write-capable Agent modes under worktree isolation (#347) | P0 | winsmux | done |
+| [x] | TASK-208 | Codex CLM blocks Pester test execution in builder panes (#319) | P1 | winsmux | done |
+| [x] | TASK-212 | Complete psmux→winsmux rename in scripts/ (TASK-139 follow-up, #329) | P1 | winsmux | done |
+| [x] | TASK-215 | orchestra-gate hook blocks gh issue close (false positive) | P1 | winsmux | done |
+| [x] | TASK-218 | Remove core/README.md — consolidate to root README | P1 | winsmux | done |
+| [x] | TASK-230 | sync-roadmap.ps1 — include Japanese version titles from backlog comments | P1 | winsmux | done |
+| [x] | TASK-234 | Builder isolation bypass — block direct main repo writes from Builder panes (#347) | P1 | winsmux | done |
+| [x] | TASK-237 | Commander Telegram dense notifications — approval requests and status reports (#350) | P1 | winsmux | done |
+| [x] | TASK-242 | Manifest convergence and CLM-safe writes — remove split-brain schema (#348, #349) | P1 | winsmux | done |
 
-### v0.20.0: Tauri Desktop (2026-04-05)
+### v0.19.6: hardening
 
 | | ID | Title | Priority | Repo | Status |
 |-|-----|-------|----------|------|--------|
+| [ ] | TASK-247 | Commander shell write bypass — block direct code writes from Commander terminal/pane outside Builder-role pane workflow (#364) | P0 | winsmux | backlog |
+| [ ] | TASK-174 | Add send-keys buffer overflow protection to winsmux send (#265) | P1 | winsmux | backlog |
+| [ ] | TASK-175 | Fix Researcher pane not receiving commands via winsmux send (#271) | P1 | winsmux | backlog |
+| [ ] | TASK-222 | Strict server health probe — Test-OrchestraServerHealth (#334) | P1 | winsmux | backlog |
+| [ ] | TASK-223 | External server watchdog — crash detection + auto-restart (#334) | P1 | winsmux | backlog |
+| [ ] | TASK-224 | Ensure-OrchestraServer auto-start integration (#334) | P2 | winsmux | backlog |
+
+### v0.19.7: visible orchestration
+
+| | ID | Title | Priority | Repo | Status |
+|-|-----|-------|----------|------|--------|
+| [ ] | TASK-253 | Commander delegation contract — first-class run packet/result packet | P0 | winsmux | backlog |
+| [x] | TASK-243 | First-class task and review state model — extend manifest/events with task, review, owner, branch, changed-files (#348) | P1 | winsmux | done |
+| [ ] | TASK-244 | Session board — add winsmux orchestra status view for pane/task/review state (#348) | P1 | winsmux | backlog |
+| [ ] | TASK-245 | Approval and review inbox — surface pending approvals, review requests, failures, and blocked panes (#348) | P1 | winsmux | backlog |
+| [ ] | TASK-256 | Run ledger and inbox surface — board/runs/explain primitives | P1 | winsmux | backlog |
+| [ ] | TASK-257 | Notification profiles — external vs internal event boundary | P1 | winsmux | backlog |
+| [ ] | TASK-246 | Evidence digest surface — show changed files, review result, branch/head, and next action per pane (#348) | P2 | winsmux | backlog |
+
+### v0.20.0: Unified Worker Architecture
+
+| | ID | Title | Priority | Repo | Status |
+|-|-----|-------|----------|------|--------|
+| [ ] | TASK-213 | Unified Worker architecture — Commander + Worker 2-layer migration | P0 | winsmux | backlog |
+| [ ] | TASK-255 | Autonomous dispatch policy — blocker/sidecar scheduling with fail-closed gates | P0 | winsmux | backlog |
 | [ ] | TASK-070 | Implement Event Stream (pub/sub event bus for Orchestra) | P1 | winsmux | backlog |
 | [ ] | TASK-100 | Explorer + Dashboard panels in Tauri | P1 | winsmux | backlog |
 | [ ] | TASK-101 | Theme engine + Nerd Font + TrueColor in Tauri | P1 | winsmux | backlog |
 | [ ] | TASK-114 | Orchestra event capture + SQLite FTS5 search layer | P1 | winsmux | backlog |
 | [ ] | TASK-138 | Source control panel in Tauri UI Explorer (worktree-aware) | P1 | winsmux | backlog |
+| [ ] | TASK-187 | PromptTransport abstraction — argv/stdin/file unified interface | P1 | winsmux | backlog |
+| [ ] | TASK-188 | Task Prompt File pattern — .winsmux/task-{slug}.md file-backed handoff | P1 | winsmux | backlog |
+| [ ] | TASK-207 | Reviewer audit checklist — design-impact scope mandatory (#318) | P1 | winsmux | backlog |
+| [ ] | TASK-210 | Reviewer audit scope too narrow (#315) | P1 | winsmux | backlog |
+| [ ] | TASK-254 | Provider capability registry — Codex/Claude/Gemini adapter abstraction | P1 | winsmux | backlog |
 | [ ] | TASK-078 | Pane border metadata display (git branch, timestamp, idle time) | P2 | winsmux | backlog |
 | [ ] | TASK-115 | Installer profile design (core/orchestra/security/full) | P2 | winsmux | backlog |
 | [~] | TASK-146 | PreCompact hook × context usage monitoring | P2 | winsmux | cancelled |
@@ -320,14 +371,16 @@
 | [ ] | TASK-165 | Agent-Model Tier Matching (role-based model selection) | P1 | winsmux | backlog |
 | [ ] | TASK-189 | Formal WINSMUX_* environment variable contract | P1 | winsmux | backlog |
 | [ ] | TASK-166 | 4-Step Model Resolution Chain (override→category→fallback→default) | P2 | winsmux | backlog |
-| [ ] | TASK-171 | Agent-monitor auto-approve trust prompt for Claude Code panes | P2 | winsmux | backlog |
+| [x] | TASK-171 | Agent-monitor auto-approve trust prompt for Claude Code panes | P2 | winsmux | done |
 | [ ] | TASK-172 | Document Codex worktree git ops sandbox limitation | P2 | winsmux | backlog |
 | [ ] | TASK-190 | ConPTY clean environment variable boundary — Get-CleanPtyEnv | P2 | winsmux | backlog |
+| [ ] | TASK-248 | Agent config versioning + migration metadata | P2 | winsmux | backlog |
 
-### v0.21.0
+### v0.21.0: psmux CLI 呼び出し集約
 
 | | ID | Title | Priority | Repo | Status |
 |-|-----|-------|----------|------|--------|
+| [ ] | TASK-216 | Consolidate psmux CLI calls into Invoke-Terminal* functions | P0 | winsmux | backlog |
 | [ ] | TASK-107 | Editor panel + drag-and-drop layout + polish | P1 | winsmux | backlog |
 | [ ] | TASK-108 | Pane pop-out and multi-display support | P1 | winsmux | backlog |
 | [ ] | TASK-143 | Shadow Git checkpoint for Builder worktrees | P1 | winsmux | backlog |
@@ -347,13 +400,36 @@
 | [ ] | TASK-191 | /task-run one-shot orchestration command | P2 | winsmux | backlog |
 | [ ] | TASK-192 | .agents/commands/ single-source command structure | P3 | winsmux | backlog |
 
-### v0.22.0
+### v0.22.0: Tauri PTY 実装
 
 | | ID | Title | Priority | Repo | Status |
 |-|-----|-------|----------|------|--------|
 | [ ] | TASK-105 | JSON-RPC backend + SDK integration in Tauri | P0 | winsmux | backlog |
+| [ ] | TASK-217a | Design PowerShell→Tauri external control plane | P0 | winsmux | backlog |
+| [ ] | TASK-217b | Bootstrap Cargo workspace + converge winsmux-app prototype | P0 | winsmux | backlog |
+| [ ] | TASK-217c | Extract winsmux-terminal headless engine from core/src/server | P0 | winsmux | backlog |
+| [ ] | TASK-217d | Tauri frontend integration + pane lifecycle parity validation | P0 | winsmux | backlog |
+| [ ] | TASK-217e | Invoke-Terminal* WINSMUX_BACKEND switch (cli|tauri) | P0 | winsmux | backlog |
 | [ ] | TASK-106 | Relay Auth + remote pane support in Tauri | P1 | winsmux | backlog |
 | [ ] | TASK-147 | ACP (Agent Communication Protocol) server support | P1 | winsmux | backlog |
+| [ ] | TASK-226 | Revise Tauri plan — backend-first, Named Pipe control plane (#339) | P1 | winsmux | backlog |
+| [ ] | TASK-249 | Cross-platform CI matrix for Windows/Linux/macOS | P1 | winsmux | backlog |
+| [ ] | TASK-250 | Cross-platform secret vault abstraction (DPAPI -> keyring backends) | P1 | winsmux | backlog |
+| [ ] | TASK-251 | PowerShell portability layer for PowerShell Core on Linux/macOS | P1 | winsmux | backlog |
+| [ ] | TASK-258 | Local LLM provider compatibility layer — read-only analysis-first integration | P2 | winsmux | backlog |
+
+### v0.23.0: cross-platform PTY portability
+
+| | ID | Title | Priority | Repo | Status |
+|-|-----|-------|----------|------|--------|
+| [ ] | TASK-219 | Phase 5 dogfooding gate — 2-week validation without psmux | P0 | winsmux | backlog |
+| [ ] | TASK-252 | PTY backend portability enablement (portable-pty non-Windows paths) | P0 | winsmux | backlog |
+
+### v1.0.0: winsmux GA Release
+
+| | ID | Title | Priority | Repo | Status |
+|-|-----|-------|----------|------|--------|
+| [ ] | TASK-220 | Phase 6 release gate — packaging, signing, docs for v1.0.0 | P0 | winsmux | backlog |
 
 ### cancelled
 

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -19,6 +19,7 @@ $BridgeSettingsScript = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '
 $PaneControlScript = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\winsmux-core\scripts\pane-control.ps1'))
 $PaneStatusScript = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\winsmux-core\scripts\pane-status.ps1'))
 $RoleGateScript = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\winsmux-core\scripts\role-gate.ps1'))
+$ClmSafeIoScript = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\winsmux-core\scripts\clm-safe-io.ps1'))
 
 if (Test-Path $BridgeSettingsScript -PathType Leaf) {
     . $BridgeSettingsScript
@@ -34,6 +35,10 @@ if (Test-Path $PaneStatusScript -PathType Leaf) {
 
 if (Test-Path $RoleGateScript -PathType Leaf) {
     . $RoleGateScript
+}
+
+if (Test-Path $ClmSafeIoScript -PathType Leaf) {
+    . $ClmSafeIoScript
 }
 
 # --- Windows Credential Manager P/Invoke ---
@@ -439,6 +444,24 @@ function Get-CurrentReviewerManifestContext {
     }
 }
 
+function Update-ReviewerManifestState {
+    param(
+        [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [Parameter(Mandatory = $true)][System.Collections.IDictionary]$Properties
+    )
+
+    if (-not (Get-Command Set-PaneControlManifestPaneProperties -ErrorAction SilentlyContinue)) {
+        return
+    }
+
+    try {
+        $context = Get-CurrentReviewerManifestContext -ProjectDir $ProjectDir
+        Set-PaneControlManifestPaneProperties -ManifestPath $context.ManifestPath -PaneId $context.PaneId -Properties $Properties
+    } catch {
+        # Review-state persistence remains the source of truth. Manifest sync is best-effort.
+    }
+}
+
 function New-ReviewRequestId {
     $timestamp = Get-Date -Format 'yyyyMMddHHmmss'
     $suffix = ([guid]::NewGuid().ToString('N')).Substring(0, 8)
@@ -680,14 +703,14 @@ function Save-Watermark {
         )
     ) -replace '-', ''
     $path = Get-WatermarkPath $PaneId
-    Set-Content -Path $path -Value $hash -Encoding UTF8 -NoNewline
+    Write-WinsmuxTextFile -Path $path -Content $hash
 }
 
 function Test-WatermarkChanged {
     param([string]$PaneId, [string]$CurrentContent)
     $path = Get-WatermarkPath $PaneId
     if (-not (Test-Path $path)) { return $true }
-    $savedHash = Get-Content -Path $path -Raw -Encoding UTF8
+    $savedHash = (Get-Content -Path $path -Raw -Encoding UTF8).Trim()
     $currentHash = [System.BitConverter]::ToString(
         [System.Security.Cryptography.SHA256]::Create().ComputeHash(
             [System.Text.Encoding]::UTF8.GetBytes($CurrentContent)
@@ -1428,8 +1451,20 @@ function Invoke-Role {
     # Count existing panes with new role to generate label number
     $existingLabels = @()
     if (Test-Path $manifestPath) {
-        $manifestContent = Get-Content $manifestPath -Raw
-        $existingLabels = @([regex]::Matches($manifestContent, "label:\s*'($newRole-\d+)'") | ForEach-Object { $_.Groups[1].Value })
+        try {
+            $manifest = Get-WinsmuxManifest -ProjectDir $projectDir
+            if ($null -ne $manifest -and $null -ne $manifest.panes) {
+                $existingLabels = @(
+                    foreach ($label in $manifest.panes.Keys) {
+                        if ([string]$label -match ("^{0}-\d+$" -f [regex]::Escape($newRole))) {
+                            [string]$label
+                        }
+                    }
+                )
+            }
+        } catch {
+            $existingLabels = @()
+        }
     }
     $nextNum = 1
     while ("$newRole-$nextNum" -in $existingLabels) { $nextNum++ }
@@ -2385,6 +2420,14 @@ function Invoke-ReviewRequest {
 
     $state[$branch] = New-ReviewerStateRecord -Status 'PENDING' -Request $request -Reviewer $reviewer -Evidence $null -UpdatedAt $timestamp
     Save-ReviewState -ProjectDir $projectDir -State $state
+    Update-ReviewerManifestState -ProjectDir $projectDir -Properties ([ordered]@{
+        review_state = 'pending'
+        task_owner   = 'Reviewer'
+        branch       = $branch
+        head_sha     = $headSha
+        last_event   = 'review.requested'
+        last_event_at = $timestamp
+    })
     Write-Output "review request recorded for $branch"
 }
 
@@ -2443,6 +2486,14 @@ function Invoke-ReviewApprove {
 
     $state[$branch] = New-ReviewerStateRecord -Status 'PASS' -Request $request -Reviewer $reviewer -Evidence $evidence -UpdatedAt $timestamp
     Save-ReviewState -ProjectDir $projectDir -State $state
+    Update-ReviewerManifestState -ProjectDir $projectDir -Properties ([ordered]@{
+        review_state = 'pass'
+        task_owner   = 'Commander'
+        branch       = $branch
+        head_sha     = $headSha
+        last_event   = 'review.pass'
+        last_event_at = $timestamp
+    })
     Write-Output "review PASS recorded for $branch"
 }
 
@@ -2501,6 +2552,14 @@ function Invoke-ReviewFail {
 
     $state[$branch] = New-ReviewerStateRecord -Status 'FAIL' -Request $request -Reviewer $reviewer -Evidence $evidence -UpdatedAt $timestamp
     Save-ReviewState -ProjectDir $projectDir -State $state
+    Update-ReviewerManifestState -ProjectDir $projectDir -Properties ([ordered]@{
+        review_state = 'fail'
+        task_owner   = 'Commander'
+        branch       = $branch
+        head_sha     = $headSha
+        last_event   = 'review.fail'
+        last_event_at = $timestamp
+    })
     Write-Output "review FAIL recorded for $branch"
 }
 
@@ -2517,6 +2576,13 @@ function Invoke-ReviewReset {
     }
 
     Save-ReviewState -ProjectDir $projectDir -State $state
+    Update-ReviewerManifestState -ProjectDir $projectDir -Properties ([ordered]@{
+        review_state = ''
+        branch       = ''
+        head_sha     = ''
+        last_event   = 'review.reset'
+        last_event_at = (Get-Date).ToString('o')
+    })
     Write-Output "review PASS cleared for $branch"
 }
 

--- a/tasks/backlog.yaml
+++ b/tasks/backlog.yaml
@@ -1981,6 +1981,21 @@ tasks:
       CLI引数→ロール別設定→環境変数FALLBACK→デフォルトの4段階解決。
       TASK-087 multi-vendor の実装骨格として使用。
 
+  - id: TASK-248
+    title: "Agent config versioning + migration metadata"
+    status: backlog
+    priority: P2
+    target_version: "v0.20.1"
+    repo: winsmux
+    labels: [feat, orchestra, config]
+    depends_on: ["TASK-166"]
+    created: "2026-04-09"
+    updated: "2026-04-09"
+    notes: >
+      managed-agents-improvement-plan 由来の純新規項目。agent 設定に version,
+      schema, migration metadata を持たせ、breaking change を明示的に昇格する。
+      provider hot-swap と role-based model selection の前提となる config 進化契約を定義する。
+
   # === v0.21.1: Orchestra Workflow Evolution (2026-04-05) ===
 
   - id: TASK-163
@@ -2027,7 +2042,6 @@ tasks:
     notes: >
       haasonsaas/agent-harness の設計パターンを移植。
       ProviderRegistry + Switch-AgentProvider でランタイム中のエージェント動的切替。
-      TASK-087 multi-vendor の拡張として、稼働中ペインのプロバイダ変更を実現。
 
   - id: TASK-168
     title: "Plugin Hook Extension Loader (modular hook architecture)"
@@ -2093,7 +2107,7 @@ tasks:
 
   - id: TASK-171
     title: "Agent-monitor auto-approve trust prompt for Claude Code panes"
-    status: backlog
+    status: done
     priority: P2
     target_version: "v0.20.1"
     repo: winsmux
@@ -2135,11 +2149,13 @@ tasks:
       winsmux リポの core/ に git subtree で統合。CI統一、フォーク関係解消。
       v0.19.2でリリース済み。winsmux-coreリポ削除完了。
 
+  # === v0.19.6: hardening ===
+
   - id: TASK-174
     title: "Add send-keys buffer overflow protection to winsmux send (#265)"
     status: backlog
     priority: P1
-    target_version: "v0.19.4"
+    target_version: "v0.19.6"
     repo: winsmux
     labels: [bug, orchestration]
     depends_on: []
@@ -2153,7 +2169,7 @@ tasks:
     title: "Fix Researcher pane not receiving commands via winsmux send (#271)"
     status: backlog
     priority: P1
-    target_version: "v0.19.4"
+    target_version: "v0.19.6"
     repo: winsmux
     labels: [bug, orchestration]
     depends_on: []
@@ -2167,7 +2183,7 @@ tasks:
 
   - id: TASK-182
     title: "Builder pane Codex cannot access new worktrees (#283)"
-    status: backlog
+    status: done
     priority: P0
     target_version: "v0.19.4"
     repo: winsmux
@@ -2226,7 +2242,7 @@ tasks:
 
   - id: TASK-177
     title: "Prevent Agent subagent from bypassing sh-orchestra-gate hook (#273)"
-    status: backlog
+    status: done
     priority: P1
     target_version: "v0.19.4"
     repo: winsmux
@@ -2240,7 +2256,7 @@ tasks:
 
   - id: TASK-179
     title: "Gate: block Commander git commit until Reviewer PASS confirmed (#279)"
-    status: backlog
+    status: done
     priority: P0
     target_version: "v0.19.4"
     repo: winsmux
@@ -2257,7 +2273,7 @@ tasks:
 
   - id: TASK-180
     title: "Gate: Commander status reports verified against actual pane state (#280)"
-    status: backlog
+    status: done
     priority: P1
     target_version: "v0.19.4"
     repo: winsmux
@@ -2331,7 +2347,7 @@ tasks:
 
   - id: TASK-194
     title: "agent-monitor idle alerts go to user Telegram instead of Commander (#290)"
-    status: backlog
+    status: done
     priority: P1
     target_version: "v0.19.4"
     repo: winsmux
@@ -2345,7 +2361,7 @@ tasks:
 
   - id: TASK-195
     title: "respawn-pane does not update pane label in manifest.yaml (#291)"
-    status: backlog
+    status: done
     priority: P1
     target_version: "v0.19.4"
     repo: winsmux
@@ -2393,7 +2409,7 @@ tasks:
     title: "PromptTransport abstraction — argv/stdin/file unified interface"
     status: backlog
     priority: P1
-    target_version: "v0.19.4"
+    target_version: "v0.20.0"
     repo: winsmux
     labels: [feat, orchestra]
     depends_on: ["TASK-186"]
@@ -2407,7 +2423,7 @@ tasks:
     title: "Task Prompt File pattern — .winsmux/task-{slug}.md file-backed handoff"
     status: backlog
     priority: P1
-    target_version: "v0.19.4"
+    target_version: "v0.20.0"
     repo: winsmux
     labels: [feat, orchestra]
     depends_on: ["TASK-187"]
@@ -2519,7 +2535,7 @@ tasks:
 
   - id: TASK-200
     title: "agent-monitor bidirectional communication + idle recovery (#302)"
-    status: backlog
+    status: done
     priority: P1
     target_version: "v0.19.4"
     repo: winsmux
@@ -2533,7 +2549,7 @@ tasks:
 
   - id: TASK-201
     title: "Auto-clear Codex panes at 10% context remaining (#303)"
-    status: backlog
+    status: done
     priority: P1
     target_version: "v0.19.4"
     repo: winsmux
@@ -2561,7 +2577,7 @@ tasks:
 
   - id: TASK-202
     title: "Remove pane-level alerts from Telegram — Commander-only (#306)"
-    status: backlog
+    status: done
     priority: P1
     target_version: "v0.19.4"
     repo: winsmux
@@ -2589,7 +2605,7 @@ tasks:
 
   - id: TASK-204
     title: "Codex pane context reset uses /new not /clear (#309)"
-    status: backlog
+    status: done
     priority: P1
     target_version: "v0.19.4"
     repo: winsmux
@@ -2604,22 +2620,349 @@ tasks:
   # === v0.19.5: monitoring stack + process gates ===
   - id: TASK-205
     title: "winsmux send silent failure — focus_pane_by_id returns without error (#316)"
-    status: backlog
+    status: done
     priority: P0
     target_version: "v0.19.5"
     repo: winsmux
     labels: [bug]
     depends_on: []
     created: "2026-04-07"
-    updated: "2026-04-07"
+    updated: "2026-04-09"
     notes: >
       #316. core/src/tree.rs:588-602 focus_pane_by_id() silently returns when pane not found.
       connection.rs:442-457 FocusPaneTemp does not validate result.
       Commander dispatch to arbitrary panes is broken.
 
+  - id: TASK-231
+    title: "Orchestra startup debug instrumentation — preserve failure evidence for Commander unresolved startup (#344)"
+    status: done
+    priority: P0
+    target_version: "v0.19.5"
+    repo: winsmux
+    labels: [bug, orchestration, debug]
+    depends_on: []
+    created: "2026-04-08"
+    updated: "2026-04-08"
+    notes: >
+      #344. Instrumentation only — does not fix startup.
+      Commander unresolved: initial orchestra-start lacks evidence capture.
+      Add pane count, pane ID, launch command, readiness verification after each startup step.
+      Preserve failed panes (remain-on-exit on for debug). Log pane.empty events in watchdog.
+      Verify pane existence after split-window/new-window, not just exit code.
+      Non-garbled evidence only: command output, manifest, events.jsonl, source.
+
+  - id: TASK-232
+    title: "orchestra-start false success — Codex/Commander launch path succeeds without verified agent startup (#345)"
+    status: done
+    priority: P0
+    target_version: "v0.19.5"
+    repo: winsmux
+    labels: [bug, orchestration]
+    depends_on: [TASK-231]
+    created: "2026-04-08"
+    updated: "2026-04-08"
+    notes: >
+      #345. Scope: false success path + Commander launch verification.
+      ExecMode causes Get-AgentLaunchCommand to return empty string (line 286-287).
+      Readiness wait skipped for ExecMode panes (line 1185-1186).
+      Commander not generated as first-class pane by orchestra-layout.ps1.
+      Fix: all roles must have verified launch. Commander as first-class pane.
+      Eliminate readiness skip. Log launch command/role/readiness per pane.
+
+  - id: TASK-233
+    title: "Detached orchestra layout reliability — fail fast when pane creation does not actually occur (#346)"
+    status: done
+    priority: P0
+    target_version: "v0.19.5"
+    repo: winsmux
+    labels: [bug, orchestration, debug]
+    depends_on: [TASK-231]
+    created: "2026-04-08"
+    updated: "2026-04-08"
+    notes: >
+      #346. Observed during detached startup path (not root cause assertion).
+      split-window exit 0 but pane not created observed in some conditions.
+      stderr: "pane too small to split horizontally (20 cols, need 21)".
+      display-message reports 30x7 while list-panes reports 120x30 for same pane.
+      Fix: verify pane count increase after each split. Do not rely on exit code alone.
+      Investigate display-message vs list-panes size discrepancy.
+
+  - id: TASK-234
+    title: "Builder isolation bypass — block direct main repo writes from Builder panes (#347)"
+    status: done
+    priority: P1
+    target_version: "v0.19.5"
+    repo: winsmux
+    labels: [bug, security]
+    depends_on: [TASK-232]
+    created: "2026-04-08"
+    updated: "2026-04-08"
+    notes: >
+      #347. Prevent Builder panes from writing to main repo.
+      All Builder work must happen in worktree isolation.
+      Violation attempts must be logged.
+
+  - id: TASK-235
+    title: "Direct Commander↔Reviewer review flow — remove user relay from review-request/review-approve (#348)"
+    status: done
+    priority: P0
+    target_version: "v0.19.5"
+    repo: winsmux
+    labels: [bug, orchestration, review]
+    depends_on: [TASK-232, TASK-236]
+    created: "2026-04-08"
+    updated: "2026-04-08"
+    notes: >
+      #348. Commander dispatches review request directly to Reviewer pane.
+      Reviewer returns PASS/FAIL via review-state.json + events.
+      No user relay in the loop. Commander does not run review-approve itself.
+
+  - id: TASK-236
+    title: "Pane bootstrap invariants — guarantee repo cwd and WINSMUX_ROLE for all panes (#349)"
+    status: done
+    priority: P0
+    target_version: "v0.19.5"
+    repo: winsmux
+    labels: [bug, orchestration]
+    depends_on: [TASK-232]
+    created: "2026-04-08"
+    updated: "2026-04-08"
+    notes: >
+      #349. Every pane must start with cwd=repo root, WINSMUX_ROLE set,
+      manifest pane_id matching actual pane. Stale manifest entries detected
+      and invalidated. respawn-pane -c fails on Windows — need alternative.
+      pane_id collision (builder-2 vs reviewer-1 both %5) must be prevented.
+
+  - id: TASK-237
+    title: "Commander Telegram dense notifications — approval requests and status reports (#350)"
+    status: done
+    priority: P1
+    target_version: "v0.19.5"
+    repo: winsmux
+    labels: [enhancement, orchestration]
+    depends_on: [TASK-235, TASK-236]
+    created: "2026-04-08"
+    updated: "2026-04-08"
+    notes: >
+      #350. Dense Telegram notifications at each state transition.
+      Telegram is notification mirror, not control path. Includes session,
+      role, pane label, task, branch, head sha, state, next action, block reason.
+
+  # === v0.19.5 second-pass: closed-loop follow-up ===
+
+  - id: TASK-238
+    title: "Commander runtime state machine — integrate dispatch/review/commit loop into commander-poll (#348)"
+    status: done
+    priority: P0
+    target_version: "v0.19.5"
+    repo: winsmux
+    labels: [bug, orchestration]
+    depends_on: [TASK-235, TASK-236]
+    created: "2026-04-08"
+    updated: "2026-04-08"
+    notes: >
+      Second-pass follow-up for #348. commander-poll is logger+notifier only.
+      Integrate closed-loop state machine: starting, waiting_for_dispatch,
+      builder_running, waiting_for_review, review_requested, review_passed,
+      review_failed, blocked. pane.idle triggers dispatch, pane.completed
+      triggers review request, review-state.json drives commit decision.
+      User relay must not be required.
+
+  - id: TASK-239
+    title: "Commander first-class defaults — add commanders setting and default Commander pane (#345)"
+    status: done
+    priority: P0
+    target_version: "v0.19.5"
+    repo: winsmux
+    labels: [bug, orchestration]
+    depends_on: [TASK-232]
+    created: "2026-04-08"
+    updated: "2026-04-08"
+    notes: >
+      Second-pass follow-up for #345. Commander pane param exists in layout
+      but defaults to 0 and settings.ps1 has no commanders key. Add commanders
+      to settings, default to 1, pass from orchestra-start to layout.
+      Commander pane must appear in manifest with role and status.
+
+  - id: TASK-240
+    title: "Pane bootstrap verification — fail closed on cwd/role/pane_id mismatch and invalidate stale manifest (#349)"
+    status: done
+    priority: P0
+    target_version: "v0.19.5"
+    repo: winsmux
+    labels: [bug, orchestration]
+    depends_on: [TASK-236]
+    created: "2026-04-08"
+    updated: "2026-04-08"
+    notes: >
+      Second-pass follow-up for #349. cwd/role injection exists but
+      bootstrap_invalid state is not implemented. Panes with failed
+      invariants must not be marked ready. Stale manifest entries need
+      runtime detection, not just startup exclusion.
+
+  - id: TASK-241
+    title: "Commander delegated write bypass — fail closed for write-capable Agent modes under worktree isolation (#347)"
+    status: done
+    priority: P0
+    target_version: "v0.19.5"
+    repo: winsmux
+    labels: [bug, security, orchestration]
+    depends_on: [TASK-234]
+    created: "2026-04-08"
+    updated: "2026-04-08"
+    notes: >
+      Second-pass follow-up for #347 scope extension. Builder main-repo
+      write is blocked, but Commander can still use Agent(worktree isolation)
+      as write-capable Builder bypass. Close this path: delegated writes
+      must go through Builder role only. Deny and audit log violations.
+
+  - id: TASK-242
+    title: "Manifest convergence and CLM-safe writes — remove split-brain schema (#348, #349)"
+    status: done
+    priority: P1
+    target_version: "v0.19.5"
+    repo: winsmux
+    labels: [bug, orchestration]
+    depends_on: [TASK-240]
+    created: "2026-04-08"
+    updated: "2026-04-09"
+    notes: >
+      Second-pass follow-up for #348 and #349. manifest.ps1 and
+      orchestra-start.ps1 schema are split-brain. CLM unsafe file writes
+      (Set-Content/Add-Content) remain in logger/manifest/monitor.
+      Converge to single schema, remove unsafe write paths.
+
+  # === v0.19.7: visible orchestration ===
+
+  - id: TASK-243
+    title: "First-class task and review state model — extend manifest/events with task, review, owner, branch, changed-files (#348)"
+    status: done
+    priority: P1
+    target_version: "v0.19.7"
+    repo: winsmux
+    labels: [enhancement, orchestration]
+    depends_on: [TASK-238, TASK-242]
+    created: "2026-04-08"
+    updated: "2026-04-09"
+    notes: >
+      Visible orchestration foundation. Pane state alone is insufficient
+      for operator visibility. Extend manifest/events with task assignment,
+      review state, owner, branch, changed files per pane.
+
+  - id: TASK-253
+    title: "Commander delegation contract — first-class run packet/result packet"
+    status: backlog
+    priority: P0
+    target_version: "v0.19.7"
+    repo: winsmux
+    labels: [enhancement, orchestration]
+    depends_on: [TASK-243]
+    created: "2026-04-09"
+    updated: "2026-04-09"
+    notes: >
+      Codex 型の subagent orchestration を winsmux Commander に取り込むための
+      first-class delegation contract。run_id / task_id / parent_run_id /
+      write_scope / expected_output / verification_plan / review_required /
+      provider_target / status / artifacts / evidence_refs を標準 packet として定義する。
+
+  - id: TASK-244
+    title: "Session board — add winsmux orchestra status view for pane/task/review state (#348)"
+    status: backlog
+    priority: P1
+    target_version: "v0.19.7"
+    repo: winsmux
+    labels: [enhancement, orchestration]
+    depends_on: [TASK-243]
+    created: "2026-04-08"
+    updated: "2026-04-08"
+    notes: >
+      Minimal visible orchestration surface. CLI/JSON view of session-wide
+      pane, task, and review state. Prerequisite for Tauri panel.
+      No Tauri/GUI in this task — CLI/TUI/JSON only.
+
+  - id: TASK-245
+    title: "Approval and review inbox — surface pending approvals, review requests, failures, and blocked panes (#348)"
+    status: backlog
+    priority: P1
+    target_version: "v0.19.7"
+    repo: winsmux
+    labels: [enhancement, orchestration]
+    depends_on: [TASK-238, TASK-243]
+    created: "2026-04-08"
+    updated: "2026-04-08"
+    notes: >
+      Operator can instantly see what needs intervention. Pending approvals,
+      review requests, failures, blocked panes as first-class output.
+
+  - id: TASK-246
+    title: "Evidence digest surface — show changed files, review result, branch/head, and next action per pane (#348)"
+    status: backlog
+    priority: P2
+    target_version: "v0.19.7"
+    repo: winsmux
+    labels: [enhancement, orchestration]
+    depends_on: [TASK-243, TASK-244]
+    created: "2026-04-08"
+    updated: "2026-04-08"
+    notes: >
+      Evidence from primary session data, not Telegram summaries.
+      Changed files, review result, branch/HEAD, next action per pane.
+
+  - id: TASK-256
+    title: "Run ledger and inbox surface — board/runs/explain primitives"
+    status: backlog
+    priority: P1
+    target_version: "v0.19.7"
+    repo: winsmux
+    labels: [enhancement, orchestration]
+    depends_on: [TASK-243, TASK-253]
+    created: "2026-04-09"
+    updated: "2026-04-09"
+    notes: >
+      pane state に加えて run-centric visible orchestration を導入する。
+      board --json, inbox, runs, explain <run_id> を追加し、
+      pane state / task state / run ledger / review state を統合可視化する。
+
+  - id: TASK-257
+    title: "Notification profiles — external vs internal event boundary"
+    status: backlog
+    priority: P1
+    target_version: "v0.19.7"
+    repo: winsmux
+    labels: [enhancement, orchestration]
+    depends_on: [TASK-245, TASK-246, TASK-256]
+    created: "2026-04-09"
+    updated: "2026-04-09"
+    notes: >
+      Telegram 通知を external-facing event に限定し、 internal control signal を
+      既定で非通知にする。review_requested / review_passed / review_failed /
+      blocked / commit_ready / commit_done を主対象とし、 dispatch_needed や
+      state_transition は profile/verbosity 下でのみ出せるよう整理する。
+
+  # === v0.19.6: hardening ===
+
+  - id: TASK-247
+    title: "Commander shell write bypass — block direct code writes from Commander terminal/pane outside Builder-role pane workflow (#364)"
+    status: backlog
+    priority: P0
+    target_version: "v0.19.6"
+    repo: winsmux
+    labels: [bug, security, orchestration]
+    depends_on: [TASK-241]
+    created: "2026-04-08"
+    updated: "2026-04-08"
+    notes: >
+      TASK-241 blocked Agent(worktree isolation) delegated-write bypass, but
+      Commander can still write implementation directly via shell wrappers such
+      as python -c, pwsh -Command, powershell -Command, and cmd /c. Close this
+      governance hole: Commander terminal/pane must not write code-bearing files
+      through shell execution paths. Within winsmux Orchestra governance,
+      implementation writes are allowed only through explicitly designated
+      Builder-role panes and their isolated Builder worktrees.
+
   - id: TASK-206
     title: "Monitoring stack non-functional — watchdog→Commander delivery path missing (#317)"
-    status: backlog
+    status: done
     priority: P0
     target_version: "v0.19.5"
     repo: winsmux
@@ -2636,7 +2979,7 @@ tasks:
     title: "Reviewer audit checklist — design-impact scope mandatory (#318)"
     status: backlog
     priority: P1
-    target_version: "v0.19.5"
+    target_version: "v0.20.0"
     repo: winsmux
     labels: [bug, review]
     depends_on: []
@@ -2648,7 +2991,7 @@ tasks:
 
   - id: TASK-208
     title: "Codex CLM blocks Pester test execution in builder panes (#319)"
-    status: backlog
+    status: done
     priority: P1
     target_version: "v0.19.5"
     repo: winsmux
@@ -2663,7 +3006,7 @@ tasks:
 
   - id: TASK-209
     title: "Commander Reviewer bypass — process gate enforcement (#314)"
-    status: backlog
+    status: done
     priority: P0
     target_version: "v0.19.5"
     repo: winsmux
@@ -2679,7 +3022,7 @@ tasks:
     title: "Reviewer audit scope too narrow (#315)"
     status: backlog
     priority: P1
-    target_version: "v0.19.5"
+    target_version: "v0.20.0"
     repo: winsmux
     labels: [bug, review]
     depends_on: [TASK-207]
@@ -2687,3 +3030,464 @@ tasks:
     updated: "2026-04-07"
     notes: >
       #315. 設計影響を見ずPASS判定。TASK-207のチェックリスト実装で対策。
+
+  - id: TASK-211
+    title: "Commander subagent edit gate — block Agent write permissions (#324)"
+    status: done
+    priority: P0
+    target_version: "v0.19.5"
+    repo: winsmux
+    labels: [enhancement, security]
+    depends_on: []
+    created: "2026-04-07"
+    updated: "2026-04-07"
+    notes: >
+      #324. Commander Agent サブエージェントが write/edit 権限を持つ。
+      sh-orchestra-gate.js を拡張して Agent ツールの書き込みモードをブロック。
+
+  - id: TASK-212
+    title: "Complete psmux→winsmux rename in scripts/ (TASK-139 follow-up, #329)"
+    status: done
+    priority: P1
+    target_version: "v0.19.5"
+    repo: winsmux
+    labels: [chore]
+    depends_on: []
+    created: "2026-04-07"
+    updated: "2026-04-07"
+    notes: >
+      #329. TASK-139で漏れた関数名~50件。settings.ps1, vault.ps1, setup-wizard.ps1,
+      psmux-bridge.ps1内のSet-PsmuxOption等。core/と.references/はスコープ外。
+      Issue #329にgrep手順と全ファイルリストを記載済み。
+
+  # === v0.20.0: Unified Worker Architecture ===
+  - id: TASK-213
+    title: "Unified Worker architecture — Commander + Worker 2-layer migration"
+    status: backlog
+    priority: P0
+    target_version: "v0.20.0"
+    repo: winsmux
+    labels: [enhancement]
+    depends_on: []
+    created: "2026-04-07"
+    updated: "2026-04-07"
+    notes: >
+      3ロール(Builder/Researcher/Reviewer)→2層(Commander+Worker)に移行。
+      13フェーズ。メタ認知提言: 自己レビュー防止ガード、フェーズ独立マージ、
+      team-pipeline→Commanderキューモデル(YAGNI)、成功基準定義。
+
+  - id: TASK-254
+    title: "Provider capability registry — Codex/Claude/Gemini adapter abstraction"
+    status: backlog
+    priority: P1
+    target_version: "v0.20.0"
+    repo: winsmux
+    labels: [enhancement, orchestration, providers]
+    depends_on: [TASK-253]
+    created: "2026-04-09"
+    updated: "2026-04-09"
+    notes: >
+      provider 名分岐をやめ、 supports_parallel_runs / supports_interrupt /
+      supports_structured_result / supports_file_edit / supports_subagents などの
+      capability で dispatch する adapter 抽象を導入する。
+
+  - id: TASK-255
+    title: "Autonomous dispatch policy — blocker/sidecar scheduling with fail-closed gates"
+    status: backlog
+    priority: P0
+    target_version: "v0.20.0"
+    repo: winsmux
+    labels: [enhancement, orchestration, governance]
+    depends_on: [TASK-238, TASK-243, TASK-253, TASK-254]
+    created: "2026-04-09"
+    updated: "2026-04-09"
+    notes: >
+      Codex 型の高自律 orchestrator policy を Commander に導入する。
+      blocker は Commander が保持し、 sidecar だけを並列化する。
+      同一 write_scope 並列禁止、 review insertion 必須、 wait policy 明文化、
+      危険境界は fail-close を既定にする。
+
+  # === v0.21.0: psmux CLI 呼び出し集約 ===
+  - id: TASK-216
+    title: "Consolidate psmux CLI calls into Invoke-Terminal* functions"
+    status: backlog
+    priority: P0
+    target_version: "v0.21.0"
+    repo: winsmux
+    labels: [enhancement]
+    depends_on: [TASK-213]
+    created: "2026-04-07"
+    updated: "2026-04-07"
+    notes: >
+      散在する psmux CLI 呼び出し (capture-pane, send, send-keys, list-panes,
+      respawn-pane, split-window) を Invoke-Terminal* 薄ラッパー関数に集約。
+      抽象化ではなく DRY。成功基準: grep で直接呼び出し 0 件。
+      戦略文書: .references/strategy-psmux-to-tauri-migration.md
+
+  # === v0.22.0: Tauri PTY 実装 ===
+  - id: TASK-217a
+    title: "Design PowerShell→Tauri external control plane"
+    status: backlog
+    priority: P0
+    target_version: "v0.22.0"
+    repo: winsmux
+    labels: [enhancement]
+    depends_on: [TASK-216]
+    created: "2026-04-07"
+    updated: "2026-04-07"
+    notes: >
+      Codex レビュー指摘 #1。PowerShell→Tauri IPC の通信経路設計。
+      候補: localhost HTTP/Named Pipe/JSON-RPC。
+      Invoke-Terminal* が Tauri backend を呼ぶ具体的メカニズム。
+
+  - id: TASK-217b
+    title: "Bootstrap Cargo workspace + converge winsmux-app prototype"
+    status: backlog
+    priority: P0
+    target_version: "v0.22.0"
+    repo: winsmux
+    labels: [enhancement]
+    depends_on: [TASK-217a]
+    created: "2026-04-07"
+    updated: "2026-04-07"
+    notes: >
+      Codex レビュー指摘 #3。既存 winsmux-app/ プロトタイプを再利用。
+      root Cargo.toml workspace 作成。cli/ + crates/ + src-tauri/ 配置。
+
+  - id: TASK-217c
+    title: "Extract winsmux-terminal headless engine from core/src/server"
+    status: backlog
+    priority: P0
+    target_version: "v0.22.0"
+    repo: winsmux
+    labels: [enhancement]
+    depends_on: [TASK-217b]
+    created: "2026-04-07"
+    updated: "2026-04-07"
+    notes: >
+      Codex レビュー指摘 #2。core/src/server/ を丸ごと移植ではなく
+      headless engine crate として再設計。CLI/Tauri 両方が使う。
+
+  - id: TASK-217d
+    title: "Tauri frontend integration + pane lifecycle parity validation"
+    status: backlog
+    priority: P0
+    target_version: "v0.22.0"
+    repo: winsmux
+    labels: [enhancement]
+    depends_on: [TASK-217c]
+    created: "2026-04-07"
+    updated: "2026-04-07"
+    notes: >
+      create/capture/send/respawn/resize の CLI/Tauri parity 検証。
+      xterm.js フロントエンド統合。マルチペイン対応。
+
+  - id: TASK-217e
+    title: "Invoke-Terminal* WINSMUX_BACKEND switch (cli|tauri)"
+    status: backlog
+    priority: P0
+    target_version: "v0.22.0"
+    repo: winsmux
+    labels: [enhancement]
+    depends_on: [TASK-217d]
+    created: "2026-04-07"
+    updated: "2026-04-07"
+    notes: >
+      Codex レビュー指摘 #5。Phase 4 で導入 (Phase 3 ではない)。
+      Tauri backend が存在してから切替を実装。環境変数 or セッション検出。
+
+  - id: TASK-225
+    title: "Guard settings.local.json — block hook disable without approval (#338)"
+    status: done
+    priority: P0
+    target_version: "v0.19.5"
+    repo: winsmux
+    labels: [security, bug]
+    depends_on: []
+    created: "2026-04-07"
+    updated: "2026-04-07"
+    notes: >
+      #338. sh-config-guard を settings.local.json に拡張。hook 削除ブロック。
+      secondary codex exec deny を tracked settings.json に追加。
+      python -c の .claude/ 書き込みを sh-gate.js でブロック。
+
+  - id: TASK-226
+    title: "Revise Tauri plan — backend-first, Named Pipe control plane (#339)"
+    status: backlog
+    priority: P1
+    target_version: "v0.22.0"
+    repo: winsmux
+    labels: [enhancement]
+    depends_on: []
+    created: "2026-04-07"
+    updated: "2026-04-07"
+    notes: >
+      #339. 制御プレーンを Named Pipe に統一。backend state model + typed events
+      + stable pane ID を UI より先に実装。winsmux-app は PoC、本番は再構築。
+
+  - id: TASK-249
+    title: "Cross-platform CI matrix for Windows/Linux/macOS"
+    status: backlog
+    priority: P1
+    target_version: "v0.22.0"
+    repo: winsmux
+    labels: [ci, infrastructure]
+    depends_on: ["TASK-040", "TASK-226"]
+    created: "2026-04-09"
+    updated: "2026-04-09"
+    notes: >
+      managed-agents-improvement-plan 由来の純新規項目。Windows 専用前提を外すため、
+      backend/control-plane の smoke と unit test を 3 OS matrix で常時回す。
+      portability task の回帰検出基盤として先に CI を整える。
+
+  - id: TASK-250
+    title: "Cross-platform secret vault abstraction (DPAPI -> keyring backends)"
+    status: backlog
+    priority: P1
+    target_version: "v0.22.0"
+    repo: winsmux
+    labels: [enhancement, security]
+    depends_on: ["TASK-226"]
+    created: "2026-04-09"
+    updated: "2026-04-09"
+    notes: >
+      managed-agents-improvement-plan 由来の純新規項目。Windows DPAPI 固定をやめ、
+      OS ごとに keyring backend を差し替えられる vault abstraction を定義する。
+      secret storage の contract test を追加し、Telegram/Commander 運用と分離する。
+
+  - id: TASK-251
+    title: "PowerShell portability layer for PowerShell Core on Linux/macOS"
+    status: backlog
+    priority: P1
+    target_version: "v0.22.0"
+    repo: winsmux
+    labels: [enhancement, orchestration]
+    depends_on: ["TASK-226", "TASK-249"]
+    created: "2026-04-09"
+    updated: "2026-04-09"
+    notes: >
+      managed-agents-improvement-plan 由来の純新規項目。Windows/CLM 前提の script 群に
+      portability layer を入れ、pwsh 7 on Linux/macOS でも動く I/O, path, env,
+      process launch 契約に整理する。既存 PowerShell orchestration の移植基盤。
+
+  - id: TASK-258
+    title: "Local LLM provider compatibility layer — read-only analysis-first integration"
+    status: backlog
+    priority: P2
+    target_version: "v0.22.0"
+    repo: winsmux
+    labels: [enhancement, orchestration, local-llm]
+    depends_on: [TASK-254]
+    created: "2026-04-09"
+    updated: "2026-04-09"
+    notes: >
+      Gemma / Llama などの local LLM を provider adapter に追加するが、
+      初期 capability は read-only / analysis-first に制限する。
+      write / review / git は既定 deny とし、 provider capability registry 上で
+      安全に段階導入できるようにする。
+
+  - id: TASK-230
+    title: "sync-roadmap.ps1 — include Japanese version titles from backlog comments"
+    status: done
+    priority: P1
+    target_version: "v0.19.5"
+    repo: winsmux
+    labels: [enhancement]
+    depends_on: []
+    created: "2026-04-07"
+    updated: "2026-04-07"
+    notes: >
+      backlog.yaml の見出しコメント (例: "# === v0.19.5: monitoring stack + process gates ===")
+      を ROADMAP.md のバージョンセクション見出しに反映する。
+      現状はバージョン番号のみ出力。sync-roadmap.ps1 のパーサー修正。
+
+  - id: TASK-227
+    title: "Fix pane.completed event never fires — add previous-state tracking"
+    status: done
+    priority: P0
+    target_version: "v0.19.5"
+    repo: winsmux
+    labels: [bug]
+    depends_on: []
+    created: "2026-04-07"
+    updated: "2026-04-07"
+    notes: >
+      exec_mode ペインは前回状態を保持しないため busy→completed 遷移が不可能。
+      agent-monitor に $PreviousResults パラメータ追加、agent-watchdog でサイクル間保持。
+      PR#320 の時点から到達不能だった (#326 が壊したのではない)。
+
+  - id: TASK-228
+    title: "Launch commander-poll.ps1 from orchestra-start (#311 integration)"
+    status: done
+    priority: P0
+    target_version: "v0.19.5"
+    repo: winsmux
+    labels: [enhancement]
+    depends_on: [TASK-227]
+    created: "2026-04-07"
+    updated: "2026-04-07"
+    notes: >
+      PR#328 でマージ済みだが orchestra-start が起動していない。
+      watchdog と同様に Start-Process で background 起動。
+      commander-poll を watchdog より先に起動 (events.jsonl cursor 問題)。
+
+  - id: TASK-229
+    title: "Enforce review-approve from Reviewer pane only (#338 enforcement)"
+    status: done
+    priority: P0
+    target_version: "v0.19.5"
+    repo: winsmux
+    labels: [security]
+    depends_on: [TASK-225]
+    created: "2026-04-07"
+    updated: "2026-04-07"
+    notes: >
+      Commander が review-approve を自己実行するプロセス違反を3回繰り返し。
+      role-gate に ReviewApprove 権限追加 (Reviewer のみ)。
+      review-state.json に reviewer identity + head_sha を記録。
+      sh-orchestra-gate.js で非 Reviewer からの実行を Hook でブロック。
+
+  # === v0.23.0: cross-platform PTY portability ===
+  - id: TASK-252
+    title: "PTY backend portability enablement (portable-pty non-Windows paths)"
+    status: backlog
+    priority: P0
+    target_version: "v0.23.0"
+    repo: winsmux
+    labels: [enhancement, tauri, pty]
+    depends_on: [TASK-217e, TASK-249, TASK-251]
+    created: "2026-04-09"
+    updated: "2026-04-09"
+    notes: >
+      managed-agents-improvement-plan 由来の純新規項目。portable-pty / non-Windows backend
+      の実装を有効化し、pane spawn, resize, capture, focus, lifecycle を Linux/macOS で成立させる。
+      Tauri backend-first 方針の最終 portability マイルストーン。
+
+  # === v0.23.0-rc: 安定化 ===
+  - id: TASK-219
+    title: "Phase 5 dogfooding gate — 2-week validation without psmux"
+    status: backlog
+    priority: P0
+    target_version: "v0.23.0"
+    repo: winsmux
+    labels: [enhancement]
+    depends_on: [TASK-217e]
+    created: "2026-04-07"
+    updated: "2026-04-07"
+    notes: >
+      Codex レビュー指摘 #4。2週間のドッグフーディングで致命的バグなし。
+      psmux バイナリ完全除去。同時セッション管理、IME、コピーモード検証。
+
+  - id: TASK-220
+    title: "Phase 6 release gate — packaging, signing, docs for v1.0.0"
+    status: backlog
+    priority: P0
+    target_version: "v1.0.0"
+    repo: winsmux
+    labels: [enhancement]
+    depends_on: [TASK-219]
+    created: "2026-04-07"
+    updated: "2026-04-07"
+    notes: >
+      Codex レビュー指摘 #4。Tauri built-in updater + MSI/NSIS パッケージング。
+      README 全面更新。CLI + Desktop 両方のインストールガイド。
+      セッションロック、制御プレーンセキュリティの最終検証。
+
+  - id: TASK-221
+    title: "Non-destructive rollback — stop kill-session in orchestra-start (#334)"
+    status: done
+    priority: P0
+    target_version: "v0.19.5"
+    repo: winsmux
+    labels: [bug]
+    depends_on: [TASK-214]
+    created: "2026-04-07"
+    updated: "2026-04-07"
+    notes: >
+      #334 Phase 1. ロールバックで kill-session を呼ばない。bootstrap ペイン保持。
+      作成済みペインのみ個別 kill。exit-empty 対策。
+
+  - id: TASK-222
+    title: "Strict server health probe — Test-OrchestraServerHealth (#334)"
+    status: backlog
+    priority: P1
+    target_version: "v0.19.6"
+    repo: winsmux
+    labels: [enhancement]
+    depends_on: [TASK-221]
+    created: "2026-04-07"
+    updated: "2026-04-07"
+    notes: >
+      #334 Phase 2. port + TCP + AUTH + session-info の厳密チェック。
+      has-session は TCP 接続成功だけで OK を返すため不十分。
+
+  - id: TASK-223
+    title: "External server watchdog — crash detection + auto-restart (#334)"
+    status: backlog
+    priority: P1
+    target_version: "v0.19.6"
+    repo: winsmux
+    labels: [enhancement]
+    depends_on: [TASK-222]
+    created: "2026-04-07"
+    updated: "2026-04-07"
+    notes: >
+      #334 Phase 3. server-watchdog.ps1 (5-10秒間隔)。
+      max 3回/10分のクラッシュループ保護。Scheduled Task でログオン時自動起動。
+
+  - id: TASK-224
+    title: "Ensure-OrchestraServer auto-start integration (#334)"
+    status: backlog
+    priority: P2
+    target_version: "v0.19.6"
+    repo: winsmux
+    labels: [enhancement]
+    depends_on: [TASK-223]
+    created: "2026-04-07"
+    updated: "2026-04-07"
+    notes: >
+      #334 Phase 4. orchestra-start が Ensure-OrchestraServer を呼び、
+      サーバー不在時に自動 new-session。失敗時は構造化エラー + 修復手順。
+
+  - id: TASK-218
+    title: "Remove core/README.md — consolidate to root README"
+    status: done
+    priority: P1
+    target_version: "v0.19.5"
+    repo: winsmux
+    labels: [chore]
+    depends_on: []
+    created: "2026-04-07"
+    updated: "2026-04-07"
+    notes: >
+      core/ は完全フォーク (upstream sync なし)。独自 README は不要。
+      ルート README.ja.md に統一。
+
+  - id: TASK-214
+    title: "Fix orchestra-start crash on detached HEAD worktrees"
+    status: done
+    priority: P0
+    target_version: "v0.19.5"
+    repo: winsmux
+    labels: [bug]
+    depends_on: []
+    created: "2026-04-07"
+    updated: "2026-04-07"
+    notes: >
+      builder-worktree.ps1:62,84 — $current.branch dot access under StrictMode
+      fails on detached HEAD worktrees (agent-* isolation worktrees).
+      Fix: Contains() guard + empty string default. 2行変更。
+
+  - id: TASK-215
+    title: "orchestra-gate hook blocks gh issue close (false positive)"
+    status: done
+    priority: P1
+    target_version: "v0.19.5"
+    repo: winsmux
+    labels: [bug]
+    depends_on: []
+    created: "2026-04-07"
+    updated: "2026-04-07"
+    notes: >
+      gh issue close 314 が review gate Rule 8 に引っかかった。
+      git commit 以外のコマンドが誤検出されている。パターンマッチの精度向上が必要。

--- a/tests/Integration.MultiAgent.Tests.ps1
+++ b/tests/Integration.MultiAgent.Tests.ps1
@@ -156,6 +156,7 @@ Describe 'manifest round-trip' {
         $manifest = New-WinsmuxManifest -ProjectDir $script:manifestTempRoot
         $manifest.version | Should -Be 1
         $manifest.panes.Count | Should -Be 0
+        $manifest.saved_at | Should -Not -BeNullOrEmpty
         $manifest.session.started | Should -Not -BeNullOrEmpty
 
         $loaded = Get-WinsmuxManifest -ProjectDir $script:manifestTempRoot
@@ -175,6 +176,156 @@ Describe 'manifest round-trip' {
         $updated.panes['builder-1'].role | Should -Be 'Builder'
         $updated.panes['builder-1'].builder_worktree_path | Should -Be 'C:\repo\.worktrees\builder-1'
         $updated.panes['reviewer'].role | Should -Be 'Reviewer'
+    }
+
+    It 'parses legacy list-style pane entries and preserves extended session metadata' {
+        New-Item -ItemType Directory -Path (Join-Path $script:manifestTempRoot '.winsmux') -Force | Out-Null
+
+        Write-ManifestTextFile -Path (Get-ManifestPath -ProjectDir $script:manifestTempRoot) -Content @"
+version: 1
+saved_at: 2026-04-09T11:00:00+09:00
+session:
+  name: winsmux-orchestra
+  status: running
+  project_dir: $script:manifestTempRoot
+panes:
+  - label: builder-1
+    pane_id: %2
+    role: Builder
+    exec_mode: true
+    launch_dir: C:\repo\.worktrees\builder-1
+"@
+
+        $loaded = Get-WinsmuxManifest -ProjectDir $script:manifestTempRoot
+
+        $loaded.saved_at | Should -Be '2026-04-09T11:00:00+09:00'
+        $loaded.session.name | Should -Be 'winsmux-orchestra'
+        $loaded.session.status | Should -Be 'running'
+        $loaded.panes['builder-1'].pane_id | Should -Be '%2'
+        $loaded.panes['builder-1'].exec_mode | Should -Be 'true'
+        $loaded.panes['builder-1'].launch_dir | Should -Be 'C:\repo\.worktrees\builder-1'
+    }
+}
+
+Describe 'orchestra state model' {
+    BeforeAll {
+        . (Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\manifest.ps1')
+        . (Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\orchestra-state.ps1')
+    }
+
+    BeforeEach {
+        $script:orchestraStateTempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('winsmux-orchestra-state-tests-' + [guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $script:orchestraStateTempRoot -Force | Out-Null
+        New-Item -ItemType Directory -Path (Join-Path $script:orchestraStateTempRoot '.winsmux') -Force | Out-Null
+
+        $manifest = [PSCustomObject]@{
+            version  = 1
+            saved_at = '2026-04-09T12:00:00+09:00'
+            session  = [PSCustomObject]@{
+                name        = 'winsmux-orchestra'
+                project_dir = $script:orchestraStateTempRoot
+            }
+            panes = [ordered]@{
+                'builder-1' = [ordered]@{
+                    pane_id               = '%2'
+                    role                  = 'Builder'
+                    launch_dir            = $script:orchestraStateTempRoot
+                    builder_worktree_path = $script:orchestraStateTempRoot
+                    builder_branch        = 'codex/task-243'
+                }
+                'reviewer-1' = [ordered]@{
+                    pane_id    = '%4'
+                    role       = 'Reviewer'
+                    launch_dir = $script:orchestraStateTempRoot
+                }
+            }
+            tasks = [PSCustomObject]@{
+                queued      = @()
+                in_progress = @('id=task-243;builder=builder-1;task=Implement%20state%20model')
+                completed   = @()
+            }
+            worktrees = [ordered]@{}
+        }
+
+        Save-WinsmuxManifest -ProjectDir $script:orchestraStateTempRoot -Manifest $manifest
+        Write-WinsmuxTextFile -Path (Join-Path $script:orchestraStateTempRoot '.winsmux\review-state.json') -Content @"
+{
+  "codex/task-243": {
+    "status": "PENDING",
+    "request": {
+      "branch": "codex/task-243",
+      "head_sha": "abcdef1234567",
+      "target_reviewer_pane_id": "%4",
+      "target_reviewer_label": "reviewer-1"
+    }
+  }
+}
+"@
+    }
+
+    AfterEach {
+        if ($script:orchestraStateTempRoot -and (Test-Path $script:orchestraStateTempRoot)) {
+            Remove-Item -Path $script:orchestraStateTempRoot -Recurse -Force
+        }
+    }
+
+    It 'merges task, review, branch, and changed files into pane state models and persists them to manifest' {
+        Mock Get-OrchestraGitSnapshot {
+            [ordered]@{
+                branch             = 'codex/task-243'
+                head_sha           = 'abcdef1234567'
+                changed_file_count = 2
+                changed_files      = @('winsmux-core/scripts/commander-poll.ps1', 'scripts/winsmux-core.ps1')
+            }
+        }
+
+        $manifest = Get-WinsmuxManifest -ProjectDir $script:orchestraStateTempRoot
+        $models = Sync-OrchestraPaneStateModels -ProjectDir $script:orchestraStateTempRoot -Manifest $manifest
+        $builderModel = $models['builder-1']
+
+        $builderModel.task_id | Should -Be 'task-243'
+        $builderModel.task | Should -Be 'Implement state model'
+        $builderModel.task_state | Should -Be 'in_progress'
+        $builderModel.review_state | Should -Be 'PENDING'
+        $builderModel.branch | Should -Be 'codex/task-243'
+        $builderModel.head_sha | Should -Be 'abcdef1234567'
+        $builderModel.changed_file_count | Should -Be 2
+        $builderModel.changed_files | Should -Be @('winsmux-core/scripts/commander-poll.ps1', 'scripts/winsmux-core.ps1')
+
+        $saved = Get-WinsmuxManifest -ProjectDir $script:orchestraStateTempRoot
+        $saved.panes['builder-1'].task_id | Should -Be 'task-243'
+        $saved.panes['builder-1'].task_state | Should -Be 'in_progress'
+        $saved.panes['builder-1'].review_state | Should -Be 'PENDING'
+        $saved.panes['builder-1'].branch | Should -Be 'codex/task-243'
+        $saved.panes['builder-1'].head_sha | Should -Be 'abcdef1234567'
+        $saved.panes['builder-1'].changed_file_count | Should -Be '2'
+        $saved.panes['builder-1'].changed_files | Should -Be @('winsmux-core/scripts/commander-poll.ps1', 'scripts/winsmux-core.ps1')
+    }
+
+    It 'embeds first-class task, git, and review state in emitted event payloads' {
+        $stateModel = [ordered]@{
+            task_id            = 'task-243'
+            task               = 'Implement state model'
+            task_state         = 'in_progress'
+            task_owner         = 'builder-1'
+            branch             = 'codex/task-243'
+            head_sha           = 'abcdef1234567'
+            changed_file_count = 1
+            changed_files      = @('winsmux-core/scripts/manifest.ps1')
+            review_state       = 'PENDING'
+        }
+
+        $payload = Merge-OrchestraPaneEventData -StateModel $stateModel -Data ([ordered]@{ event_kind = 'pane.completed' })
+
+        $payload.event_kind | Should -Be 'pane.completed'
+        $payload.task.id | Should -Be 'task-243'
+        $payload.task.text | Should -Be 'Implement state model'
+        $payload.task.state | Should -Be 'in_progress'
+        $payload.task.owner | Should -Be 'builder-1'
+        $payload.git.branch | Should -Be 'codex/task-243'
+        $payload.git.head_sha | Should -Be 'abcdef1234567'
+        $payload.git.changed_files | Should -Be @('winsmux-core/scripts/manifest.ps1')
+        $payload.review.state | Should -Be 'PENDING'
     }
 }
 
@@ -329,6 +480,57 @@ panes:
             $Message -match 'Commander alert: idle pane builder-1'
         }
         Should -Invoke Send-MonitorCommanderMailboxMessage -Times 1 -Exactly -ParameterFilter {
+            $Event -eq 'pane.idle' -and
+            $Label -eq 'builder-1' -and
+            $PaneId -eq '%2'
+        }
+    }
+
+    It 'reads dict-style pane manifests during a monitor cycle' {
+        $manifestDir = Join-Path $script:agentMonitorTempRoot '.winsmux'
+        $manifestPath = Join-Path $manifestDir 'manifest.yaml'
+        New-Item -ItemType Directory -Path $manifestDir -Force | Out-Null
+        Write-WinsmuxTextFile -Path $manifestPath -Content @"
+version: 1
+saved_at: 2026-04-09T11:00:00+09:00
+session:
+  name: winsmux-orchestra
+  project_dir: $script:agentMonitorTempRoot
+panes:
+  builder-1:
+    pane_id: %2
+    role: Builder
+    launch_dir: $script:agentMonitorTempRoot
+"@
+
+        Save-MonitorIdleState -PaneId '%2' -ReadySince '2026-04-05T09:57:00+09:00' -AlertSent $false
+        Mock Get-PaneAgentStatus {
+            [ordered]@{
+                Status       = 'ready'
+                PaneId       = '%2'
+                SnapshotTail = '> '
+            }
+        }
+        Mock Write-MonitorEvent {
+            return [ordered]@{
+                event   = $Event
+                message = $Message
+            }
+        }
+
+        $settings = [ordered]@{
+            agent = 'codex'
+            model = 'gpt-5.4'
+            roles = [ordered]@{}
+        }
+
+        $output = @(Invoke-AgentMonitorCycle -Settings $settings -ManifestPath $manifestPath -SessionName 'winsmux-orchestra' -IdleThreshold 120)
+
+        $output.Count | Should -Be 2
+        $output[0] | Should -Match 'Commander alert: idle pane builder-1 \(%2, role=Builder\)'
+        $output[1].IdleAlerts | Should -Be 1
+        $output[1].Results[0].Label | Should -Be 'builder-1'
+        Should -Invoke Write-MonitorEvent -Times 1 -Exactly -ParameterFilter {
             $Event -eq 'pane.idle' -and
             $Label -eq 'builder-1' -and
             $PaneId -eq '%2'
@@ -501,5 +703,23 @@ panes:
             $Role -eq 'Builder' -and
             $Message -match 'Commander alert: stalled Builder pane builder-1'
         }
+    }
+
+    It 'appends monitor events as jsonl records' {
+        $eventsPath = Get-MonitorEventsPath -ProjectDir $script:agentMonitorTempRoot
+
+        Write-MonitorEvent -ProjectDir $script:agentMonitorTempRoot -SessionName 'winsmux-orchestra' -Event 'pane.idle' -Message 'idle alert' -Label 'builder-1' -PaneId '%2' -Role 'Builder' -Status 'ready' | Out-Null
+        Write-MonitorEvent -ProjectDir $script:agentMonitorTempRoot -SessionName 'winsmux-orchestra' -Event 'pane.stalled' -Message 'stall alert' -Label 'builder-1' -PaneId '%2' -Role 'Builder' -Status 'busy' | Out-Null
+
+        $lines = @(Get-Content -Path $eventsPath -Encoding UTF8 | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+        $lines.Count | Should -Be 2
+
+        $first = $lines[0] | ConvertFrom-Json
+        $second = $lines[1] | ConvertFrom-Json
+
+        $first.event | Should -Be 'pane.idle'
+        $first.label | Should -Be 'builder-1'
+        $second.event | Should -Be 'pane.stalled'
+        $second.status | Should -Be 'busy'
     }
 }

--- a/tests/OrchestraPreflight.Tests.ps1
+++ b/tests/OrchestraPreflight.Tests.ps1
@@ -110,6 +110,34 @@ Describe 'orchestra preflight zombie detection' {
 
         @($victims | ForEach-Object { [int]$_.ProcessId } | Sort-Object) | Should -Be @(402, 403)
     }
+
+    It 'does not treat pane root pwsh as a zombie when only descendants should be cleaned' {
+        $snapshot = & $script:NewPreflightSnapshot -Processes @(
+            [PSCustomObject]@{
+                ProcessId       = 501
+                ParentProcessId = 0
+                Name            = 'pwsh.exe'
+                CommandLine     = 'pwsh -NoProfile'
+            }
+            [PSCustomObject]@{
+                ProcessId       = 502
+                ParentProcessId = 501
+                Name            = 'codex.exe'
+                CommandLine     = 'codex'
+            }
+        )
+
+        $victims = Get-OrchestraZombieVictims `
+            -Snapshot $snapshot `
+            -ProtectedIds ([System.Collections.Generic.HashSet[int]]::new()) `
+            -ProjectDir 'C:\repo' `
+            -GitWorktreeDir 'C:\repo\.git' `
+            -BridgeScript 'C:\repo\scripts\winsmux-core.ps1' `
+            -SessionName 'winsmux-orchestra' `
+            -PaneRootIds @(501)
+
+        @($victims | ForEach-Object { [int]$_.ProcessId } | Sort-Object) | Should -Be @(502)
+    }
 }
 
 Describe 'orchestra preflight server health' {

--- a/tests/psmux-bridge.Tests.ps1
+++ b/tests/psmux-bridge.Tests.ps1
@@ -506,8 +506,59 @@ panes:
 
         $updated | Should -Be $true
         $context.Label | Should -Be 'builder-2'
-        $manifestContent | Should -Match $([regex]::Escape("- label: 'builder-2'"))
+        $manifestContent | Should -Match $([regex]::Escape("'builder-2':"))
     }
+
+    It 'updates the manifest label when panes are stored in dictionary format' {
+@'
+version: 1
+saved_at: '2026-04-07T00:00:00+09:00'
+session:
+  name: 'winsmux-orchestra'
+  project_dir: 'C:\repo'
+  git_worktree_dir: 'C:\repo\.git'
+panes:
+  builder-1:
+    pane_id: '%2'
+    role: 'Builder'
+    exec_mode: true
+    launch_dir: 'C:\repo\.worktrees\builder-1'
+'@ | Set-Content -Path (Join-Path $script:paneControlManifestDir 'manifest.yaml') -Encoding UTF8
+
+        Mock Get-PaneControlPaneTitle { 'builder-2' }
+
+        $updated = Update-PaneControlManifestPaneLabel -ProjectDir $script:paneControlTempRoot -PaneId '%2'
+
+        $context = Get-PaneControlManifestContext -ProjectDir $script:paneControlTempRoot -PaneId '%2'
+        $manifestContent = Get-Content -Path (Join-Path $script:paneControlManifestDir 'manifest.yaml') -Raw -Encoding UTF8
+
+        $updated | Should -Be $true
+        $context.Label | Should -Be 'builder-2'
+        $manifestContent | Should -Match $([regex]::Escape("'builder-2':"))
+    }
+
+    It 'keeps changed_files empty when the manifest stores an empty array' {
+@'
+version: 1
+saved_at: '2026-04-09T00:00:00+09:00'
+session:
+  name: 'winsmux-orchestra'
+  project_dir: 'C:\repo'
+panes:
+  builder-1:
+    pane_id: '%2'
+    role: 'Builder'
+    changed_file_count: '0'
+    changed_files: '[]'
+'@ | Set-Content -Path (Join-Path $script:paneControlManifestDir 'manifest.yaml') -Encoding UTF8
+
+        $entries = @(Get-PaneControlManifestEntries -ProjectDir $script:paneControlTempRoot)
+
+        $entries.Count | Should -Be 1
+        $entries[0].ChangedFileCount | Should -Be 0
+        $entries[0].ChangedFiles | Should -Be @()
+    }
+
 }
 
 Describe 'logger helpers' {
@@ -541,7 +592,7 @@ Describe 'logger helpers' {
         $record.role | Should -Be 'Builder'
         $record.data.agent | Should -Be 'codex'
 
-        $lines = @(Get-Content -Path $logPath -Encoding UTF8)
+        $lines = @(Get-Content -Path $logPath -Encoding UTF8 | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
         $lines.Count | Should -Be 1
         $parsed = $lines[0] | ConvertFrom-Json
         $parsed.message | Should -Be 'builder booted'
@@ -692,8 +743,8 @@ panes:
 
             $result.Success | Should -Be $true
             $manifestContent = Get-Content -Path $manifestPath -Raw -Encoding UTF8
-            $manifestContent | Should -Match '(?m)^  - label: builder-2$'
-            $manifestContent | Should -Not -Match '(?m)^  - label: builder-1$'
+        $manifestContent | Should -Match $([regex]::Escape("'builder-2':"))
+            $manifestContent | Should -Not -Match $([regex]::Escape("  - label: 'builder-1'"))
             Should -Invoke Invoke-MonitorWinsmux -Times 1 -Exactly -ParameterFilter {
                 $Arguments[0] -eq 'display-message' -and
                 $Arguments[1] -eq '-p' -and
@@ -1155,6 +1206,118 @@ gpt-5.4   10% context left
             }
         }
     }
+
+    It 'syncs task review git state into manifest and monitor events' {
+        $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('winsmux-agent-monitor-tests-' + [guid]::NewGuid().ToString('N'))
+        $manifestDir = Join-Path $tempRoot '.winsmux'
+        $manifestPath = Join-Path $manifestDir 'manifest.yaml'
+        $eventsPath = Join-Path $manifestDir 'events.jsonl'
+        $reviewStatePath = Join-Path $manifestDir 'review-state.json'
+
+        try {
+            New-Item -ItemType Directory -Path $manifestDir -Force | Out-Null
+@"
+version: 1
+session:
+  name: winsmux-orchestra
+  project_dir: $tempRoot
+panes:
+  - label: builder-1
+    pane_id: %2
+    role: Builder
+    exec_mode: true
+    builder_branch: worktree-builder-1
+    builder_worktree_path: $tempRoot
+tasks:
+  queued: []
+  in_progress:
+    - 'id=task-243;builder=builder-1;task=Implement%20TASK-243'
+  completed: []
+"@ | Set-Content -Path $manifestPath -Encoding UTF8
+
+@'
+{
+  "worktree-builder-1": {
+    "status": "PENDING",
+    "request": {
+      "target_reviewer_label": "reviewer",
+      "target_reviewer_pane_id": "%3"
+    }
+  }
+}
+'@ | Set-Content -Path $reviewStatePath -Encoding UTF8
+
+            Mock Get-OrchestraGitSnapshot {
+                [ordered]@{
+                    branch             = 'worktree-builder-1'
+                    head_sha           = 'abc1234def5678'
+                    changed_file_count = 2
+                    changed_files      = @(
+                        'winsmux-core/scripts/orchestra-state.ps1',
+                        'winsmux-core/scripts/agent-monitor.ps1'
+                    )
+                }
+            }
+            Mock Get-PaneAgentStatus {
+                [ordered]@{
+                    Status       = 'ready'
+                    PaneId       = '%2'
+                    SnapshotTail = 'gpt-5.4   74% context left'
+                    SnapshotHash = 'hash-ready'
+                    ExitReason   = ''
+                }
+            }
+            Mock Update-MonitorIdleAlertState {
+                [ordered]@{
+                    ShouldAlert = $false
+                    Message     = ''
+                }
+            }
+            Mock Test-BuilderStall { $false }
+
+            $result = Invoke-AgentMonitorCycle -Settings ([ordered]@{
+                agent = 'codex'
+                model = 'gpt-5.4'
+                roles = [ordered]@{}
+            }) -ManifestPath $manifestPath -SessionName 'winsmux-orchestra'
+
+            $result.Checked | Should -Be 1
+            $entries = @(Get-PaneControlManifestEntries -ProjectDir $tempRoot)
+            $entries.Count | Should -Be 1
+            $entries[0].TaskId | Should -Be 'task-243'
+            $entries[0].Task | Should -Be 'Implement TASK-243'
+            $entries[0].TaskState | Should -Be 'in_progress'
+            $entries[0].TaskOwner | Should -Be 'builder-1'
+            $entries[0].ReviewState | Should -Be 'PENDING'
+            $entries[0].Branch | Should -Be 'worktree-builder-1'
+            $entries[0].HeadSha | Should -Be 'abc1234def5678'
+            $entries[0].ChangedFileCount | Should -Be 2
+            $entries[0].ChangedFiles | Should -Be @(
+                'winsmux-core/scripts/orchestra-state.ps1',
+                'winsmux-core/scripts/agent-monitor.ps1'
+            )
+
+            $events = @(Get-Content -Path $eventsPath -Encoding UTF8 | Where-Object { $_ } | ForEach-Object { $_ | ConvertFrom-Json })
+            $events.Count | Should -Be 1
+            $events[0].event | Should -Be 'pane.ready'
+            $events[0].data.task.id | Should -Be 'task-243'
+            $events[0].data.task.text | Should -Be 'Implement TASK-243'
+            $events[0].data.task.state | Should -Be 'in_progress'
+            $events[0].data.task.owner | Should -Be 'builder-1'
+            $events[0].data.git.branch | Should -Be 'worktree-builder-1'
+            $events[0].data.git.head_sha | Should -Be 'abc1234def5678'
+            $events[0].data.git.changed_file_count | Should -Be 2
+            $events[0].data.git.changed_files | Should -Be @(
+                'winsmux-core/scripts/orchestra-state.ps1',
+                'winsmux-core/scripts/agent-monitor.ps1'
+            )
+            $events[0].data.review.state | Should -Be 'PENDING'
+        } finally {
+            if (Test-Path $tempRoot) {
+                Remove-Item -Path $tempRoot -Recurse -Force
+            }
+        }
+    }
 }
 
 Describe 'agent-watchdog helpers' {
@@ -1456,10 +1619,10 @@ Describe 'orchestra-start watchdog contract' {
     }
 
     It 'persists both process pids and prints cleanup guidance' {
-        $script:orchestraStartContent | Should -Match 'commander_poll_pid:'
+        $script:orchestraStartContent | Should -Match 'commander_poll_pid\s*=\s*\$CommanderPollPid'
         $script:orchestraStartContent | Should -Match 'Commander Poll PID: \$\(\$commanderPollProcess\.Id\)'
-        $script:orchestraStartContent | Should -Match 'watchdog_pid:'
-        $script:orchestraStartContent | Should -Match 'server_watchdog_pid:'
+        $script:orchestraStartContent | Should -Match 'watchdog_pid\s*=\s*\$WatchdogPid'
+        $script:orchestraStartContent | Should -Match 'server_watchdog_pid\s*=\s*\$ServerWatchdogPid'
         $script:orchestraStartContent | Should -Match '-WatchdogPid \$watchdogProcess\.Id'
         $script:orchestraStartContent | Should -Match '-ServerWatchdogPid \$serverWatchdogProcess\.Id'
         $script:orchestraStartContent | Should -Match 'Watchdog PID: \$\(\$watchdogProcess\.Id\)'
@@ -1496,14 +1659,15 @@ Describe 'orchestra-start server bootstrap' {
 
         $result.SessionName | Should -Be 'winsmux-orchestra'
         $result.SessionCreated | Should -Be $false
-        $result.ReadyChecks | Should -Be 1
         $script:probeCount | Should -Be 1
         $script:newSessionCallCount | Should -Be 0
     }
 
-    It 'auto-creates the server session when missing' {
+    It 'launches Windows Terminal and polls until panes are available when the session is missing' {
         $script:probeCount = 0
-        $script:newSessionArguments = @()
+        $script:startProcessFilePath = $null
+        $script:startProcessArgumentList = @()
+        $script:listPanesCallCount = 0
         $script:sleepCallCount = 0
 
         function Test-OrchestraServerSession {
@@ -1512,14 +1676,39 @@ Describe 'orchestra-start server bootstrap' {
             return ($script:probeCount -ge 3)
         }
 
+        function Get-Command {
+            param([string]$Name)
+            if ($Name -eq 'wt.exe') {
+                return [PSCustomObject]@{ Source = 'C:\Windows\System32\wt.exe' }
+            }
+
+            throw "unexpected command lookup: $Name"
+        }
+
+        function Start-Process {
+            param(
+                [string]$FilePath,
+                [object[]]$ArgumentList
+            )
+
+            $script:startProcessFilePath = $FilePath
+            $script:startProcessArgumentList = @($ArgumentList)
+        }
+
         function Invoke-Winsmux {
             param([string[]]$Arguments, [switch]$CaptureOutput)
-            $script:newSessionArguments = @($Arguments)
+
+            if ($Arguments[0] -eq 'list-panes') {
+                $script:listPanesCallCount++
+                return @('%1')
+            }
+
+            throw "unexpected winsmux call: $($Arguments -join ' ')"
         }
 
         function Start-Sleep {
-            param([int]$Seconds)
-            if ($Seconds -eq 2) {
+            param([int]$Milliseconds)
+            if ($Milliseconds -eq 500) {
                 $script:sleepCallCount++
             }
         }
@@ -1528,10 +1717,30 @@ Describe 'orchestra-start server bootstrap' {
 
         $result.SessionName | Should -Be 'winsmux-orchestra'
         $result.SessionCreated | Should -Be $true
-        $result.ReadyChecks | Should -Be 2
-        $script:newSessionArguments | Should -Be @('new-session', '-d', '-s', 'winsmux-orchestra')
         $script:probeCount | Should -Be 3
         $script:sleepCallCount | Should -Be 1
+        $script:listPanesCallCount | Should -Be 1
+        $script:startProcessFilePath | Should -Be 'C:\Windows\System32\wt.exe'
+        $script:startProcessArgumentList | Should -Be @(
+            '--size', '200,70',
+            '--title', 'winsmux-orchestra',
+            '--',
+            'winsmux', 'new-session', '-s', 'winsmux-orchestra'
+        )
+    }
+
+    It 'fails closed when Windows Terminal is unavailable' {
+        function Test-OrchestraServerSession {
+            param([string]$SessionName)
+            return $false
+        }
+
+        function Get-Command {
+            param([string]$Name)
+            return $null
+        }
+
+        { Ensure-OrchestraServer -SessionName 'winsmux-orchestra' } | Should -Throw '*wt.exe*'
     }
 }
 
@@ -1543,10 +1752,10 @@ Describe 'orchestra-start session reuse contract' {
 
     It 'reuses the session Ensure-OrchestraServer just created' {
         $script:orchestraStartContent | Should -Match '\$orchestraServer\s*=\s*Ensure-OrchestraServer -SessionName \$sessionName'
-        $script:orchestraStartContent | Should -Match 'if \(-not \[bool\]\$orchestraServer\.SessionCreated\) \{'
-        $script:orchestraStartContent | Should -Match "preflight\.session\.reuse"
-        $script:orchestraStartContent | Should -Match 'if \(\[bool\]\$orchestraServer\.SessionCreated\) \{'
-        $script:orchestraStartContent | Should -Match 'Session \$sessionName was already created by Ensure-OrchestraServer\.'
+        $script:orchestraStartContent | Should -Match "preflight\.session\.ready"
+        $script:orchestraStartContent | Should -Match 'Session \$sessionName created by Ensure-OrchestraServer\.'
+        $script:orchestraStartContent | Should -Not -Match "preflight\.session\.create"
+        $script:orchestraStartContent | Should -Not -Match "new-session', '-d'"
     }
 }
 
@@ -1706,6 +1915,60 @@ panes:
         $workload.BuilderCount | Should -Be 3
         $workload.BusyRatio | Should -BeGreaterThan 0.66
         $workload.BusyRatio | Should -BeLessThan 0.67
+    }
+
+    It 'reads dictionary-style pane manifests written by orchestra-start' {
+        @"
+version: 1
+saved_at: 2026-04-05T10:00:00+09:00
+session:
+  name: winsmux-orchestra
+  project_dir: $script:paneScalerTempRoot
+panes:
+  builder-1:
+    pane_id: %2
+    role: Builder
+  builder-2:
+    pane_id: %3
+    role: Builder
+"@ | Set-Content -Path $script:paneScalerManifestPath -Encoding UTF8
+
+        $manifest = Read-PaneScalerManifest -ManifestPath $script:paneScalerManifestPath
+
+        $manifest.Panes.Keys | Should -Be @('builder-1', 'builder-2')
+        $manifest.Panes['builder-1'].pane_id | Should -Be '%2'
+        $manifest.Panes['builder-2'].role | Should -Be 'Builder'
+    }
+
+    It 'writes canonical dictionary-style panes when saving the manifest' {
+        $manifest = [PSCustomObject]@{
+            Version = 1
+            SavedAt = '2026-04-09T11:00:00+09:00'
+            Session = [ordered]@{
+                name = 'winsmux-orchestra'
+                project_dir = $script:paneScalerTempRoot
+            }
+            Panes = [ordered]@{
+                'builder-1' = [ordered]@{
+                    pane_id = '%2'
+                    role = 'Builder'
+                    launch_dir = $script:paneScalerTempRoot
+                }
+            }
+            Tasks = [PSCustomObject]@{
+                queued = @()
+                in_progress = @()
+                completed = @()
+            }
+            Worktrees = [ordered]@{}
+        }
+
+        Save-PaneScalerManifest -ManifestPath $script:paneScalerManifestPath -Manifest $manifest
+
+        $content = Get-Content -Path $script:paneScalerManifestPath -Raw -Encoding UTF8
+        $content | Should -Match "panes:\r?\n  'builder-1':"
+        $content | Should -Not -Match "panes:\r?\n  - label:"
+        $content | Should -Match "saved_at: '2026-04-09T11:00:00\+09:00'"
     }
 
     It 'scales up when workload exceeds the threshold' {
@@ -1876,6 +2139,52 @@ Esc to interrupt
         $records[2].Label | Should -Be 'commander'
         $records[2].State | Should -Be 'busy'
         $records[2].TokensRemaining | Should -Be '61% context left'
+    }
+
+    It 'includes task review git fields from the manifest state model' {
+        @'
+version: 1
+session:
+  name: winsmux-orchestra
+  project_dir: C:\repo
+panes:
+  - label: builder-1
+    pane_id: %2
+    role: Builder
+    launch_dir: C:\repo\.worktrees\builder-1
+    task_id: task-243
+    task: Implement TASK-243
+    task_state: in_progress
+    task_owner: builder-1
+    review_state: PENDING
+    branch: worktree-builder-1
+    head_sha: abc1234def5678
+    changed_file_count: 2
+    changed_files: '["winsmux-core/scripts/orchestra-state.ps1","winsmux-core/scripts/agent-monitor.ps1"]'
+    last_event: pane.ready
+    last_event_at: 2026-04-09T12:00:00+09:00
+'@ | Set-Content -Path (Join-Path (Join-Path $script:paneStatusTempRoot '.winsmux') 'manifest.yaml') -Encoding UTF8
+
+        $records = Get-PaneStatusRecords -ProjectDir $script:paneStatusTempRoot -SnapshotProvider {
+            param($PaneId)
+            'gpt-5.4   74% context left'
+        }
+
+        $records.Count | Should -Be 1
+        $records[0].TaskId | Should -Be 'task-243'
+        $records[0].Task | Should -Be 'Implement TASK-243'
+        $records[0].TaskState | Should -Be 'in_progress'
+        $records[0].TaskOwner | Should -Be 'builder-1'
+        $records[0].ReviewState | Should -Be 'PENDING'
+        $records[0].Branch | Should -Be 'worktree-builder-1'
+        $records[0].HeadSha | Should -Be 'abc1234def5678'
+        $records[0].ChangedFileCount | Should -Be 2
+        $records[0].ChangedFiles | Should -Be @(
+            'winsmux-core/scripts/orchestra-state.ps1',
+            'winsmux-core/scripts/agent-monitor.ps1'
+        )
+        $records[0].LastEvent | Should -Be 'pane.ready'
+        $records[0].LastEventAt | Should -Be '2026-04-09T12:00:00+09:00'
     }
 }
 
@@ -2125,6 +2434,95 @@ panes:
             $Message -eq 'builder-1 (%2) がアイドル。次タスクのディスパッチが必要'
         }
     }
+
+    It 'processes mailbox idle messages when panes are stored in dictionary format' {
+        @"
+version: 1
+saved_at: 2026-04-09T11:00:00+09:00
+session:
+  name: winsmux-orchestra
+  project_dir: $script:commanderPollTempRoot
+panes:
+  builder-1:
+    pane_id: %2
+    role: Builder
+    launch_dir: $script:commanderPollTempRoot
+"@ | Set-Content -Path $script:commanderPollManifestPath -Encoding UTF8
+
+        Mock Receive-CommanderPollMailboxMessages {
+            @(
+                [ordered]@{
+                    timestamp   = '2026-04-07T09:00:00.0000000+09:00'
+                    session     = 'winsmux-orchestra'
+                    event       = 'pane.idle'
+                    message     = 'Commander alert: idle pane builder-1 (%2, role=Builder)'
+                    label       = 'builder-1'
+                    pane_id     = '%2'
+                    role        = 'Builder'
+                    status      = 'ready'
+                    exit_reason = ''
+                    data        = [ordered]@{
+                        idle_threshold_seconds = 120
+                    }
+                    source      = 'mailbox'
+                }
+            )
+        }
+        Mock Write-CommanderPollLog { }
+
+        $cycle = Invoke-CommanderPollCycle -ManifestPath $script:commanderPollManifestPath -ProcessedLineCount 0 -ProcessedEventSignatures ([ordered]@{})
+        $summary = $cycle['Summary']
+
+        $summary.mailbox_events | Should -Be 1
+        $summary.new_events | Should -Be 1
+        $summary.dispatches | Should -Be 1
+        $summary.messages[0] | Should -Be 'builder-1 (%2) がアイドル。次タスクのディスパッチが必要'
+    }
+
+    It 'appends commander poll log records as jsonl' {
+        Write-CommanderPollLog -ProjectDir $script:commanderPollTempRoot -SessionName 'winsmux-orchestra' -EventName 'commander.poll.idle_dispatch_needed' -Message 'idle' -PaneId '%2'
+        Write-CommanderPollLog -ProjectDir $script:commanderPollTempRoot -SessionName 'winsmux-orchestra' -EventName 'commander.poll.auto_approved' -Message 'approved' -PaneId '%2'
+
+        $logPath = Get-CommanderPollLogPath -ProjectDir $script:commanderPollTempRoot
+        $lines = @(Get-Content -Path $logPath -Encoding UTF8 | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+
+        $lines.Count | Should -Be 2
+        ($lines[0] | ConvertFrom-Json).event | Should -Be 'commander.poll.idle_dispatch_needed'
+        ($lines[1] | ConvertFrom-Json).event | Should -Be 'commander.poll.auto_approved'
+    }
+
+    It 'does not forward commander dispatch-needed alerts to Telegram by default' {
+        Mock Test-Path { $true }
+        Mock Get-Content { 'TELEGRAM_BOT_TOKEN=test-token' }
+        Mock Invoke-RestMethod { }
+
+        Send-CommanderTelegramNotification -ProjectDir $script:commanderPollTempRoot -SessionName 'winsmux-orchestra' `
+            -Event 'commander.dispatch_needed' -Message 'idle' -PaneId '%2' -Label 'builder-1' -Role 'Builder'
+
+        Should -Not -Invoke Invoke-RestMethod
+    }
+
+    It 'allows internal commander Telegram alerts only when explicitly overridden' {
+        $previousOverride = $env:WINSMUX_TELEGRAM_INCLUDE_INTERNAL_EVENTS
+        $env:WINSMUX_TELEGRAM_INCLUDE_INTERNAL_EVENTS = 'true'
+
+        try {
+            Mock Test-Path { $true }
+            Mock Get-Content { 'TELEGRAM_BOT_TOKEN=test-token' }
+            Mock Invoke-RestMethod { }
+
+            Send-CommanderTelegramNotification -ProjectDir $script:commanderPollTempRoot -SessionName 'winsmux-orchestra' `
+                -Event 'commander.dispatch_needed' -Message 'idle' -PaneId '%2' -Label 'builder-1' -Role 'Builder'
+
+            Should -Invoke Invoke-RestMethod -Times 1 -Exactly
+        } finally {
+            if ($null -eq $previousOverride) {
+                Remove-Item Env:WINSMUX_TELEGRAM_INCLUDE_INTERNAL_EVENTS -ErrorAction SilentlyContinue
+            } else {
+                $env:WINSMUX_TELEGRAM_INCLUDE_INTERNAL_EVENTS = $previousOverride
+            }
+        }
+    }
 }
 
 Describe 'winsmux send fallback' {
@@ -2206,4 +2604,35 @@ Describe 'winsmux send fallback' {
         $script:sendAttempts | Should -Be @('%7 literal', 'default:0.3 literal', 'default:0.3 Enter')
     }
 
+}
+
+Describe 'watermark helpers' {
+    BeforeAll {
+        $bridgePath = Join-Path (Split-Path -Parent $PSScriptRoot) 'scripts\winsmux-core.ps1'
+        $null = . $bridgePath version
+    }
+
+    BeforeEach {
+        $script:watermarkTempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('winsmux-watermark-tests-' + [guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $script:watermarkTempRoot -Force | Out-Null
+        $WatermarkDir = $script:watermarkTempRoot
+    }
+
+    AfterEach {
+        if ($script:watermarkTempRoot -and (Test-Path $script:watermarkTempRoot)) {
+            Remove-Item -Path $script:watermarkTempRoot -Recurse -Force
+        }
+    }
+
+    It 'writes and reuses watermark hashes via the CLM-safe helper' {
+        Save-Watermark -PaneId '%7' -Content 'hello'
+
+        $path = Get-WatermarkPath -PaneId '%7'
+        $savedHash = Get-Content -Path $path -Raw -Encoding UTF8
+
+        Test-Path $path | Should -Be $true
+        $savedHash | Should -Not -BeNullOrEmpty
+        (Test-WatermarkChanged -PaneId '%7' -CurrentContent 'hello') | Should -Be $false
+        (Test-WatermarkChanged -PaneId '%7' -CurrentContent 'updated') | Should -Be $true
+    }
 }

--- a/winsmux-core/scripts/agent-monitor.ps1
+++ b/winsmux-core/scripts/agent-monitor.ps1
@@ -30,6 +30,9 @@ Set-StrictMode -Version Latest
 $scriptDir = $PSScriptRoot
 . "$scriptDir/settings.ps1"
 . "$scriptDir/agent-readiness.ps1"
+. "$scriptDir/pane-control.ps1"
+. "$scriptDir/orchestra-state.ps1"
+. "$scriptDir/clm-safe-io.ps1"
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -125,7 +128,7 @@ function Save-MonitorSnapshot {
         timestamp = $Timestamp
     }
 
-    ($record | ConvertTo-Json -Compress) | Set-Content -Path $path -Encoding UTF8 -NoNewline
+    Write-WinsmuxTextFile -Path $path -Content ($record | ConvertTo-Json -Compress)
 }
 
 function Get-MonitorIdleStatePath {
@@ -196,7 +199,7 @@ function Save-MonitorIdleState {
     }
 
     $path = Get-MonitorIdleStatePath -PaneId $PaneId
-    ($record | ConvertTo-Json -Compress) | Set-Content -LiteralPath $path -Encoding UTF8 -NoNewline
+    Write-WinsmuxTextFile -Path $path -Content ($record | ConvertTo-Json -Compress)
 }
 
 function Update-MonitorIdleAlertState {
@@ -570,7 +573,6 @@ function Write-MonitorEvent {
 
     try {
         $eventsPath = Get-MonitorEventsPath -ProjectDir $ProjectDir
-        [System.IO.Directory]::CreateDirectory((Split-Path -Parent $eventsPath)) | Out-Null
 
         $record = [ordered]@{
             timestamp   = (Get-Date).ToString('o')
@@ -586,7 +588,7 @@ function Write-MonitorEvent {
         }
 
         $line = ($record | ConvertTo-Json -Compress -Depth 10)
-        [System.IO.File]::AppendAllText($eventsPath, $line + [System.Environment]::NewLine, [System.Text.Encoding]::UTF8)
+        Write-WinsmuxTextFile -Path $eventsPath -Content $line -Append
         return $record
     } catch {
         return $null
@@ -1050,99 +1052,12 @@ function Update-MonitorManifestPaneLabel {
         return $false
     }
 
-    $content = Get-Content -LiteralPath $ManifestPath -Raw -Encoding UTF8
-    if ([string]::IsNullOrWhiteSpace($content)) {
+    try {
+        Set-PaneControlManifestPaneProperties -ManifestPath $ManifestPath -PaneId $PaneId -Properties ([ordered]@{ label = $Label })
+        return $true
+    } catch {
         return $false
     }
-
-    $newline = "`n"
-
-    $lines = [string[]]($content -split "\r?\n")
-    $section = ''
-    $currentPaneStart = -1
-    $currentPaneId = ''
-    $changed = $false
-
-    for ($i = 0; $i -lt $lines.Length; $i++) {
-        $line = $lines[$i]
-
-        if ($line -match '^(session|panes):\s*$') {
-            if ($section -eq 'panes') {
-                if ($currentPaneStart -ge 0 -and $currentPaneId -eq $PaneId) {
-                    $match = [regex]::Match($lines[$currentPaneStart], '^\s{2}-\s+label:\s*(.*?)\s*$')
-                    if ($match.Success) {
-                        $currentLabel = ConvertFrom-MonitorYamlScalar -Value $match.Groups[1].Value
-                        if ($currentLabel -ne $Label) {
-                            $lines[$currentPaneStart] = ('  - label: {0}' -f (ConvertTo-MonitorYamlScalar -Value $Label))
-                            $changed = $true
-                        }
-                    }
-                }
-                $currentPaneStart = -1
-                $currentPaneId = ''
-            }
-
-            $section = $Matches[1]
-            continue
-        }
-
-        if ($section -eq 'panes' -and $line -match '^\s{2}-\s+label:\s*(.*?)\s*$') {
-            if ($currentPaneStart -ge 0 -and $currentPaneId -eq $PaneId) {
-                $match = [regex]::Match($lines[$currentPaneStart], '^\s{2}-\s+label:\s*(.*?)\s*$')
-                if ($match.Success) {
-                    $currentLabel = ConvertFrom-MonitorYamlScalar -Value $match.Groups[1].Value
-                    if ($currentLabel -ne $Label) {
-                        $lines[$currentPaneStart] = ('  - label: {0}' -f (ConvertTo-MonitorYamlScalar -Value $Label))
-                        $changed = $true
-                    }
-                }
-            }
-            $currentPaneStart = $i
-            $currentPaneId = ''
-            continue
-        }
-
-        if ($section -eq 'panes' -and $currentPaneStart -ge 0 -and $line -match '^\s{4}pane_id:\s*(.*?)\s*$') {
-            $currentPaneId = ConvertFrom-MonitorYamlScalar -Value $Matches[1]
-            continue
-        }
-
-        if ($section -eq 'panes' -and $line -match '^[^\s]') {
-            if ($currentPaneStart -ge 0 -and $currentPaneId -eq $PaneId) {
-                $match = [regex]::Match($lines[$currentPaneStart], '^\s{2}-\s+label:\s*(.*?)\s*$')
-                if ($match.Success) {
-                    $currentLabel = ConvertFrom-MonitorYamlScalar -Value $match.Groups[1].Value
-                    if ($currentLabel -ne $Label) {
-                        $lines[$currentPaneStart] = ('  - label: {0}' -f (ConvertTo-MonitorYamlScalar -Value $Label))
-                        $changed = $true
-                    }
-                }
-            }
-            $currentPaneStart = -1
-            $currentPaneId = ''
-            $section = ''
-        }
-    }
-
-    if ($section -eq 'panes') {
-        if ($currentPaneStart -ge 0 -and $currentPaneId -eq $PaneId) {
-            $match = [regex]::Match($lines[$currentPaneStart], '^\s{2}-\s+label:\s*(.*?)\s*$')
-            if ($match.Success) {
-                $currentLabel = ConvertFrom-MonitorYamlScalar -Value $match.Groups[1].Value
-                if ($currentLabel -ne $Label) {
-                    $lines[$currentPaneStart] = ('  - label: {0}' -f (ConvertTo-MonitorYamlScalar -Value $Label))
-                    $changed = $true
-                }
-            }
-        }
-    }
-
-    if (-not $changed) {
-        return $false
-    }
-
-    Set-Content -LiteralPath $ManifestPath -Value ($lines -join $newline) -Encoding UTF8 -NoNewline
-    return $true
 }
 
 # ---------------------------------------------------------------------------
@@ -1208,6 +1123,12 @@ function Invoke-AgentMonitorCycle {
     }
 
     $projectDir = Get-MonitorProjectDir -Manifest $manifest -ManifestPath $ManifestPath
+    $paneStateModels = [ordered]@{}
+    try {
+        $paneStateModels = Sync-OrchestraPaneStateModels -ProjectDir $projectDir -Manifest $manifest
+    } catch {
+        $paneStateModels = [ordered]@{}
+    }
 
     $results = [System.Collections.Generic.List[object]]::new()
     $currentResults = [ordered]@{}
@@ -1225,6 +1146,7 @@ function Invoke-AgentMonitorCycle {
         $paneId = [string](Get-MonitorPropertyValue -InputObject $pane -Name 'pane_id' -Default '')
         $role = [string](Get-MonitorPropertyValue -InputObject $pane -Name 'role' -Default '')
         $paneExecMode = [string](Get-MonitorPropertyValue -InputObject $pane -Name 'exec_mode' -Default '').Trim().ToLowerInvariant() -eq 'true'
+        $paneStateModel = Get-OrchestraPaneStateModelFromCollection -StateModels $paneStateModels -Label $label -PaneId $paneId
 
         if ([string]::IsNullOrWhiteSpace($paneId)) {
             continue
@@ -1303,7 +1225,7 @@ function Invoke-AgentMonitorCycle {
             Write-MonitorEvent -ProjectDir $projectDir -SessionName $SessionName `
                 -Event 'pane.completed' -Message $transitionEventMessage `
                 -Label $label -PaneId $paneId -Role $role -Status $statusName -ExitReason $statusExitReason `
-                -Data $transitionEventData | Out-Null
+                -Data (Merge-OrchestraPaneEventData -StateModel $paneStateModel -Data $transitionEventData) | Out-Null
         }
 
         $stateEventName = Get-MonitorStateEventName -Status $statusName -ExitReason $statusExitReason
@@ -1325,7 +1247,7 @@ function Invoke-AgentMonitorCycle {
             Write-MonitorEvent -ProjectDir $projectDir -SessionName $SessionName `
                 -Event $stateEventName -Message $stateEventMessage `
                 -Label $label -PaneId $paneId -Role $role -Status $statusName -ExitReason $statusExitReason `
-                -Data $stateEventData | Out-Null
+                -Data (Merge-OrchestraPaneEventData -StateModel $paneStateModel -Data $stateEventData) | Out-Null
         }
 
         if ($statusName -eq 'approval_waiting') {
@@ -1350,7 +1272,7 @@ function Invoke-AgentMonitorCycle {
                 Send-MonitorCommanderMailboxMessage -SessionName $SessionName `
                     -Event 'pane.approval_waiting' -Message $result['Message'] `
                     -Label $label -PaneId $paneId -Role $role -Status $statusName -ExitReason $statusExitReason `
-                    -Data $stateEventData | Out-Null
+                    -Data (Merge-OrchestraPaneEventData -StateModel $paneStateModel -Data $stateEventData) | Out-Null
             } catch {
             }
         }
@@ -1366,14 +1288,14 @@ function Invoke-AgentMonitorCycle {
                     Write-MonitorEvent -ProjectDir $projectDir -SessionName $SessionName `
                         -Event 'pane.context_reset' -Message "Reset Codex context in pane $label ($paneId)." `
                         -Label $label -PaneId $paneId -Role $role -Status $statusName -ExitReason $statusExitReason `
-                        -Data ([ordered]@{
+                        -Data (Merge-OrchestraPaneEventData -StateModel $paneStateModel -Data ([ordered]@{
                             agent                     = $agentName
                             model                     = $modelName
                             command                   = '/new'
                             context_remaining_percent = $contextRemainingPercent
                             threshold_percent         = $ContextResetThresholdPercent
                             snapshot_hash             = $statusSnapshotHash
-                        }) | Out-Null
+                        })) | Out-Null
 
                     $results.Add($result)
                     continue
@@ -1400,22 +1322,22 @@ function Invoke-AgentMonitorCycle {
             Write-MonitorEvent -ProjectDir $projectDir -SessionName $SessionName `
                 -Event 'pane.idle' -Message $idleAlert.Message `
                 -Label $label -PaneId $paneId -Role $role -Status $statusName -ExitReason $statusExitReason `
-                -Data ([ordered]@{
+                -Data (Merge-OrchestraPaneEventData -StateModel $paneStateModel -Data ([ordered]@{
                     agent                  = $agentName
                     model                  = $modelName
                     idle_threshold_seconds = $IdleThreshold
                     snapshot_hash          = $statusSnapshotHash
-                }) | Out-Null
+                })) | Out-Null
             try {
                 Send-MonitorCommanderMailboxMessage -SessionName $SessionName `
                     -Event 'pane.idle' -Message $idleAlert.Message `
                     -Label $label -PaneId $paneId -Role $role -Status $statusName -ExitReason $statusExitReason `
-                    -Data ([ordered]@{
+                    -Data (Merge-OrchestraPaneEventData -StateModel $paneStateModel -Data ([ordered]@{
                         agent                  = $agentName
                         model                  = $modelName
                         idle_threshold_seconds = $IdleThreshold
                         snapshot_hash          = $statusSnapshotHash
-                    }) | Out-Null
+                    })) | Out-Null
             } catch {
             }
         }
@@ -1430,22 +1352,22 @@ function Invoke-AgentMonitorCycle {
             Write-MonitorEvent -ProjectDir $projectDir -SessionName $SessionName `
                 -Event 'pane.stalled' -Message $stallMessage `
                 -Label $label -PaneId $paneId -Role $role -Status $statusName -ExitReason $statusExitReason `
-                -Data ([ordered]@{
+                -Data (Merge-OrchestraPaneEventData -StateModel $paneStateModel -Data ([ordered]@{
                     agent            = $agentName
                     model            = $modelName
                     required_cycles  = $script:BuilderStallThresholdCycles
                     snapshot_hash    = $statusSnapshotHash
-                }) | Out-Null
+                })) | Out-Null
             try {
                 Send-MonitorCommanderMailboxMessage -SessionName $SessionName `
                     -Event 'pane.stalled' -Message $stallMessage `
                     -Label $label -PaneId $paneId -Role $role -Status $statusName -ExitReason $statusExitReason `
-                    -Data ([ordered]@{
+                    -Data (Merge-OrchestraPaneEventData -StateModel $paneStateModel -Data ([ordered]@{
                         agent            = $agentName
                         model            = $modelName
                         required_cycles  = $script:BuilderStallThresholdCycles
                         snapshot_hash    = $statusSnapshotHash
-                    }) | Out-Null
+                    })) | Out-Null
             } catch {
             }
         }
@@ -1457,7 +1379,7 @@ function Invoke-AgentMonitorCycle {
                     -Event 'monitor.status' -Level 'debug' `
                     -Message "Pane $label ($paneId): $statusName" `
                     -Role $role -PaneId $paneId `
-                    -Data ([ordered]@{ status = $statusName; exit_reason = $statusExitReason }) | Out-Null
+                    -Data (Merge-OrchestraPaneEventData -StateModel $paneStateModel -Data ([ordered]@{ status = $statusName; exit_reason = $statusExitReason })) | Out-Null
             } catch {
             }
         }
@@ -1581,117 +1503,11 @@ function Invoke-AgentMonitorCycle {
 function ConvertFrom-MonitorManifest {
     <#
     .SYNOPSIS
-    Parses the orchestra-start manifest format (session metadata + panes list).
+    Parses the orchestra manifest using the shared pane-control reader.
     #>
     param([Parameter(Mandatory = $true)][string]$Content)
 
-    $manifest = [ordered]@{
-        Session = [ordered]@{}
-        Panes   = [ordered]@{}
-    }
-
-    $section = $null
-    $currentPane = $null
-
-    function Save-MonitorManifestPane {
-        param($Pane)
-
-        if ($null -eq $Pane) {
-            return
-        }
-
-        $label = [string]$Pane.label
-        if ([string]::IsNullOrWhiteSpace($label)) {
-            return
-        }
-
-        $paneObj = [ordered]@{}
-        foreach ($entry in $Pane.GetEnumerator()) {
-            $paneObj[$entry.Key] = $entry.Value
-        }
-
-        $manifest.Panes[$label] = $paneObj
-    }
-
-    foreach ($rawLine in ($Content -split "\r?\n")) {
-        $line = $rawLine.TrimEnd()
-        if ([string]::IsNullOrWhiteSpace($line) -or $line -match '^\s*#') {
-            continue
-        }
-
-        # Top-level key
-        if ($line -match '^version:\s*') {
-            continue
-        }
-
-        if ($line -match '^(session|panes):\s*$') {
-            if ($section -eq 'panes' -and $null -ne $currentPane) {
-                Save-MonitorManifestPane -Pane $currentPane
-                $currentPane = $null
-            }
-
-            $section = $Matches[1]
-            continue
-        }
-
-        # Session properties (2-space indent)
-        if ($section -eq 'session' -and $line -match '^\s{2}([A-Za-z0-9_.-]+):\s*(.*?)\s*$') {
-            $value = $Matches[2]
-            # Strip surrounding quotes
-            if ($value.Length -ge 2) {
-                if (($value.StartsWith("'") -and $value.EndsWith("'")) -or
-                    ($value.StartsWith('"') -and $value.EndsWith('"'))) {
-                    $value = $value.Substring(1, $value.Length - 2)
-                }
-            }
-            $manifest.Session[$Matches[1]] = $value
-            continue
-        }
-
-        # Pane list item start
-        if ($section -eq 'panes' -and $line -match '^\s{2}-\s+label:\s*(.*?)\s*$') {
-            if ($null -ne $currentPane) {
-                Save-MonitorManifestPane -Pane $currentPane
-            }
-
-            $value = $Matches[1]
-            if ($value.Length -ge 2) {
-                if (($value.StartsWith("'") -and $value.EndsWith("'")) -or
-                    ($value.StartsWith('"') -and $value.EndsWith('"'))) {
-                    $value = $value.Substring(1, $value.Length - 2)
-                }
-            }
-            $currentPane = [ordered]@{ label = $value }
-            continue
-        }
-
-        # Pane properties (4-space indent)
-        if ($section -eq 'panes' -and $line -match '^\s{4}([A-Za-z0-9_.-]+):\s*(.*?)\s*$') {
-            if ($null -eq $currentPane) {
-                continue
-            }
-
-            $value = $Matches[2]
-            if ($value.Length -ge 2) {
-                if (($value.StartsWith("'") -and $value.EndsWith("'")) -or
-                    ($value.StartsWith('"') -and $value.EndsWith('"'))) {
-                    $value = $value.Substring(1, $value.Length - 2)
-                }
-            }
-            if ($value -eq 'null') {
-                $value = ''
-            }
-            $currentPane[$Matches[1]] = $value
-            continue
-        }
-    }
-
-    # Save last pane
-    if ($section -eq 'panes' -and $null -ne $currentPane) {
-        Save-MonitorManifestPane -Pane $currentPane
-    }
-
-    return $manifest
+    return ConvertFrom-PaneControlManifestContent -Content $Content
 }
 
 # ---------------------------------------------------------------------------

--- a/winsmux-core/scripts/builder-queue.ps1
+++ b/winsmux-core/scripts/builder-queue.ps1
@@ -13,6 +13,11 @@ Set-StrictMode -Version Latest
 [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
 
 . (Join-Path $PSScriptRoot 'manifest.ps1')
+. (Join-Path $PSScriptRoot 'clm-safe-io.ps1')
+$script:BuilderQueuePaneControlScript = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot 'pane-control.ps1'))
+if (Test-Path $script:BuilderQueuePaneControlScript -PathType Leaf) {
+    . $script:BuilderQueuePaneControlScript
+}
 
 $script:BuilderQueueBridgeScript = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\..\scripts\winsmux-core.ps1'))
 $script:DispatchLedgerRelativePath = '.winsmux\dispatch-ledger.json'
@@ -149,6 +154,30 @@ function Remove-BuilderQueueRawEntry {
     return @($remaining)
 }
 
+function Update-BuilderQueuePaneState {
+    param(
+        [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [Parameter(Mandatory = $true)][string]$BuilderLabel,
+        [Parameter(Mandatory = $true)][System.Collections.IDictionary]$Properties
+    )
+
+    if (-not (Get-Command Get-PaneControlManifestEntries -ErrorAction SilentlyContinue) -or
+        -not (Get-Command Set-PaneControlManifestPaneProperties -ErrorAction SilentlyContinue)) {
+        return
+    }
+
+    try {
+        $entry = @(Get-PaneControlManifestEntries -ProjectDir $ProjectDir | Where-Object { $_.Label -eq $BuilderLabel } | Select-Object -First 1)[0]
+        if ($null -eq $entry -or [string]::IsNullOrWhiteSpace([string]$entry.PaneId)) {
+            return
+        }
+
+        Set-PaneControlManifestPaneProperties -ManifestPath ([string]$entry.ManifestPath) -PaneId ([string]$entry.PaneId) -Properties $Properties
+    } catch {
+        # Pane state enrichment is best-effort and must not break queue operation.
+    }
+}
+
 function Get-BuilderQueueSnapshot {
     param(
         [Parameter(Mandatory = $true)][string]$ProjectDir,
@@ -214,11 +243,11 @@ function Save-DispatchLedger {
     }
 
     if (@($Entries).Count -eq 0) {
-        '[]' | Set-Content -LiteralPath $path -Encoding UTF8
+        Write-WinsmuxTextFile -Path $path -Content '[]'
         return
     }
 
-    @($Entries) | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $path -Encoding UTF8
+    Write-WinsmuxTextFile -Path $path -Content (@($Entries) | ConvertTo-Json -Depth 8)
 }
 
 function ConvertTo-DispatchLockPath {
@@ -488,6 +517,16 @@ function Dispatch-NextBuilderQueueTask {
     $manifest.tasks.queued = (Remove-BuilderQueueRawEntry -Entries $manifest.tasks.queued -RawEntry $nextEntry.RawEntry)
     $manifest.tasks.in_progress = (@($manifest.tasks.in_progress) + @($nextEntry.RawEntry))
     Save-BuilderQueueManifest -ProjectDir $ProjectDir -Manifest $manifest
+    Update-BuilderQueuePaneState -ProjectDir $ProjectDir -BuilderLabel $BuilderLabel -Properties ([ordered]@{
+        task_id            = $nextEntry.TaskId
+        task               = $nextEntry.Task
+        task_state         = 'in_progress'
+        task_owner         = 'Builder'
+        changed_file_count = 0
+        changed_files      = @()
+        last_event         = 'builder.queue.dispatched'
+        last_event_at      = (Get-Date).ToString('o')
+    })
 
     return [PSCustomObject]@{
         BuilderLabel   = $BuilderLabel
@@ -526,6 +565,14 @@ function Complete-BuilderQueueTask {
     }
     Save-BuilderQueueManifest -ProjectDir $ProjectDir -Manifest $manifest
     Unlock-DispatchFiles -TaskId $completedEntry.TaskId -ProjectDir $ProjectDir | Out-Null
+    Update-BuilderQueuePaneState -ProjectDir $ProjectDir -BuilderLabel $BuilderLabel -Properties ([ordered]@{
+        task_id       = $completedEntry.TaskId
+        task          = $completedEntry.Task
+        task_state    = 'completed'
+        task_owner    = 'Commander'
+        last_event    = 'builder.queue.completed'
+        last_event_at = (Get-Date).ToString('o')
+    })
 
     $dispatchOutcome = Dispatch-NextBuilderQueueTask -ProjectDir $ProjectDir -BuilderLabel $BuilderLabel -DispatchAction $DispatchAction
 

--- a/winsmux-core/scripts/clm-safe-io.ps1
+++ b/winsmux-core/scripts/clm-safe-io.ps1
@@ -1,0 +1,31 @@
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+function Write-WinsmuxTextFile {
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [AllowEmptyString()][string]$Content = '',
+        [switch]$Append
+    )
+
+    $parent = Split-Path -Parent $Path
+    if (-not [string]::IsNullOrWhiteSpace($parent) -and -not (Test-Path -LiteralPath $parent -PathType Container)) {
+        New-Item -ItemType Directory -Path $parent -Force | Out-Null
+    }
+
+    $escapedPath = $Path -replace '"', '""'
+    if ([string]::IsNullOrEmpty($Content)) {
+        if ($Append) {
+            return
+        }
+
+        cmd /d /c ('type nul > "{0}"' -f $escapedPath) | Out-Null
+    } else {
+        $redirect = if ($Append) { '>>' } else { '>' }
+        $Content | cmd /d /c ('more {0} "{1}"' -f $redirect, $escapedPath) | Out-Null
+    }
+
+    if ($LASTEXITCODE -ne 0) {
+        throw "cmd.exe failed to write $Path"
+    }
+}

--- a/winsmux-core/scripts/commander-poll.ps1
+++ b/winsmux-core/scripts/commander-poll.ps1
@@ -7,6 +7,9 @@ param(
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
 [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+. (Join-Path $PSScriptRoot 'manifest.ps1')
+. (Join-Path $PSScriptRoot 'clm-safe-io.ps1')
+. (Join-Path $PSScriptRoot 'pane-control.ps1')
 
 if (-not (Get-Command Get-WinsmuxBin -ErrorAction SilentlyContinue)) {
     function Get-WinsmuxBin {
@@ -73,85 +76,11 @@ function ConvertFrom-CommanderPollYamlScalar {
 function ConvertFrom-CommanderPollManifestContent {
     param([Parameter(Mandatory = $true)][string]$Content)
 
-    $manifest = [ordered]@{
-        Session = [ordered]@{}
-        Panes   = [ordered]@{}
+    $parsed = ConvertFrom-ManifestYaml -Content $Content
+    return [ordered]@{
+        Session = $parsed.session
+        Panes   = $parsed.panes
     }
-
-    $section = ''
-    $currentPane = $null
-
-    function Save-CommanderPollPane {
-        param([AllowNull()]$Pane)
-
-        if ($null -eq $Pane) {
-            return
-        }
-
-        $label = [string](Get-CommanderPollValue -InputObject $Pane -Name 'label' -Default '')
-        if ([string]::IsNullOrWhiteSpace($label)) {
-            return
-        }
-
-        $savedPane = [ordered]@{}
-        foreach ($entry in $Pane.GetEnumerator()) {
-            $savedPane[[string]$entry.Key] = $entry.Value
-        }
-
-        $manifest['Panes'][$label] = $savedPane
-    }
-
-    foreach ($rawLine in ($Content -split "\r?\n")) {
-        $line = $rawLine.TrimEnd()
-        if ([string]::IsNullOrWhiteSpace($line) -or $line -match '^\s*#') {
-            continue
-        }
-
-        if ($line -match '^(session|panes):\s*$') {
-            if ($section -eq 'panes') {
-                Save-CommanderPollPane -Pane $currentPane
-                $currentPane = $null
-            }
-
-            $section = $Matches[1]
-            continue
-        }
-
-        if ($section -eq 'session' -and $line -match '^\s{2}([A-Za-z0-9_.-]+):\s*(.*?)\s*$') {
-            $manifest['Session'][$Matches[1]] = ConvertFrom-CommanderPollYamlScalar $Matches[2]
-            continue
-        }
-
-        if ($section -ne 'panes') {
-            continue
-        }
-
-        if ($line -match '^\s{2}-\s+label:\s*(.*?)\s*$') {
-            Save-CommanderPollPane -Pane $currentPane
-            $currentPane = [ordered]@{
-                label = ConvertFrom-CommanderPollYamlScalar $Matches[1]
-            }
-            continue
-        }
-
-        if ($line -match '^\s{2}(.+?):\s*$') {
-            Save-CommanderPollPane -Pane $currentPane
-            $currentPane = [ordered]@{
-                label = ConvertFrom-CommanderPollYamlScalar $Matches[1]
-            }
-            continue
-        }
-
-        if ($null -ne $currentPane -and $line -match '^\s{4}([A-Za-z0-9_.-]+):\s*(.*?)\s*$') {
-            $currentPane[$Matches[1]] = ConvertFrom-CommanderPollYamlScalar $Matches[2]
-        }
-    }
-
-    if ($section -eq 'panes') {
-        Save-CommanderPollPane -Pane $currentPane
-    }
-
-    return $manifest
 }
 
 function Read-CommanderPollManifest {
@@ -229,9 +158,8 @@ function Write-CommanderPollLog {
         data      = if ($null -eq $Data) { [ordered]@{} } else { $Data }
     }
 
-    $line = ($record | ConvertTo-Json -Compress -Depth 10) + [System.Environment]::NewLine
-    $encoding = [System.Text.UTF8Encoding]::new($false)
-    [System.IO.File]::AppendAllText((Get-CommanderPollLogPath -ProjectDir $ProjectDir), $line, $encoding)
+    $line = ($record | ConvertTo-Json -Compress -Depth 10)
+    Write-WinsmuxTextFile -Path (Get-CommanderPollLogPath -ProjectDir $ProjectDir) -Content $line -Append
 }
 
 function Get-CommanderPollPaneContext {
@@ -301,7 +229,62 @@ function Get-CommanderPollPaneContext {
         label         = $matchedLabel
         role          = $role
         worktree_path = $worktreePath
+        task_id       = if ($null -ne $matchedPane) { [string](Get-CommanderPollValue -InputObject $matchedPane -Name 'task_id' -Default '') } else { '' }
+        task          = if ($null -ne $matchedPane) { [string](Get-CommanderPollValue -InputObject $matchedPane -Name 'task' -Default '') } else { '' }
+        task_state    = if ($null -ne $matchedPane) { [string](Get-CommanderPollValue -InputObject $matchedPane -Name 'task_state' -Default '') } else { '' }
+        task_owner    = if ($null -ne $matchedPane) { [string](Get-CommanderPollValue -InputObject $matchedPane -Name 'task_owner' -Default '') } else { '' }
+        review_state  = if ($null -ne $matchedPane) { [string](Get-CommanderPollValue -InputObject $matchedPane -Name 'review_state' -Default '') } else { '' }
+        branch        = if ($null -ne $matchedPane) { [string](Get-CommanderPollValue -InputObject $matchedPane -Name 'branch' -Default '') } else { '' }
+        head_sha      = if ($null -ne $matchedPane) { [string](Get-CommanderPollValue -InputObject $matchedPane -Name 'head_sha' -Default '') } else { '' }
     }
+}
+
+function Update-CommanderPollPaneState {
+    param(
+        [Parameter(Mandatory = $true)]$PaneContext,
+        [Parameter(Mandatory = $true)][System.Collections.IDictionary]$Properties
+    )
+
+    if ([string]::IsNullOrWhiteSpace([string]$PaneContext['pane_id'])) {
+        return
+    }
+
+    try {
+        $entry = @(Get-PaneControlManifestEntries -ProjectDir ([string]$PaneContext['project_dir']) | Where-Object { $_.PaneId -eq [string]$PaneContext['pane_id'] } | Select-Object -First 1)[0]
+        if ($null -eq $entry) {
+            return
+        }
+
+        Set-PaneControlManifestPaneProperties -ManifestPath ([string]$entry.ManifestPath) -PaneId ([string]$entry.PaneId) -Properties $Properties
+    } catch {
+        # Pane state enrichment is best-effort.
+    }
+}
+
+function New-CommanderPollStateData {
+    param(
+        [Parameter(Mandatory = $true)]$PaneContext,
+        [AllowNull()]$Data = $null
+    )
+
+    $stateData = [ordered]@{
+        task_id      = [string]$PaneContext['task_id']
+        task         = [string]$PaneContext['task']
+        task_state   = [string]$PaneContext['task_state']
+        task_owner   = [string]$PaneContext['task_owner']
+        review_state = [string]$PaneContext['review_state']
+        branch       = [string]$PaneContext['branch']
+        head_sha     = [string]$PaneContext['head_sha']
+    }
+
+    if ($null -ne $Data) {
+        $dataMap = ConvertTo-ManifestPropertyMap -Value $Data
+        foreach ($key in $dataMap.Keys) {
+            $stateData[$key] = $dataMap[$key]
+        }
+    }
+
+    return $stateData
 }
 
 function Invoke-CommanderPollWinsmux {
@@ -355,6 +338,8 @@ function Get-CommanderPollDiffData {
     $statusLines = Get-CommanderPollGitOutput -WorktreePath $WorktreePath -Arguments @('status', '--short', '--untracked-files=all')
     $unstagedDiff = Get-CommanderPollGitOutput -WorktreePath $WorktreePath -Arguments @('diff', '--stat', '--no-ext-diff')
     $stagedDiff = Get-CommanderPollGitOutput -WorktreePath $WorktreePath -Arguments @('diff', '--cached', '--stat', '--no-ext-diff')
+    $branchLines = Get-CommanderPollGitOutput -WorktreePath $WorktreePath -Arguments @('rev-parse', '--abbrev-ref', 'HEAD')
+    $headShaLines = Get-CommanderPollGitOutput -WorktreePath $WorktreePath -Arguments @('rev-parse', 'HEAD')
 
     $changedFiles = @()
     foreach ($statusLine in $statusLines) {
@@ -369,6 +354,8 @@ function Get-CommanderPollDiffData {
 
     return [ordered]@{
         worktree_path        = $WorktreePath
+        branch               = @($branchLines | Select-Object -First 1)[0]
+        head_sha             = @($headShaLines | Select-Object -First 1)[0]
         changed_file_count   = $changedFiles.Count
         changed_files        = @($changedFiles)
         status_lines         = @($statusLines)
@@ -514,6 +501,25 @@ function Get-CommanderPollEventSignature {
         ([string](Get-CommanderPollValue -InputObject $EventRecord -Name 'message' -Default ''))
 }
 
+function Test-CommanderTelegramNotificationEnabled {
+    param([Parameter(Mandatory = $true)][string]$Event)
+
+    $internalOnlyEvents = @(
+        'commander.dispatch_needed'
+    )
+
+    if ($Event -notin $internalOnlyEvents) {
+        return $true
+    }
+
+    $override = [string]$env:WINSMUX_TELEGRAM_INCLUDE_INTERNAL_EVENTS
+    if ([string]::IsNullOrWhiteSpace($override)) {
+        return $false
+    }
+
+    return $override.Trim().ToLowerInvariant() -in @('1', 'true', 'yes', 'on')
+}
+
 function Send-CommanderTelegramNotification {
     param(
         [Parameter(Mandatory = $true)][string]$ProjectDir,
@@ -526,6 +532,10 @@ function Send-CommanderTelegramNotification {
         [string]$Branch = '',
         [string]$HeadSha = ''
     )
+
+    if (-not (Test-CommanderTelegramNotificationEnabled -Event $Event)) {
+        return
+    }
 
     try {
         $chatId = $env:WINSMUX_TELEGRAM_CHAT_ID
@@ -587,16 +597,26 @@ function Invoke-CommanderPollEventRecord {
             -EventName 'commander.poll.exec_completed' `
             -Message $message `
             -PaneId $paneId `
-            -Data ([ordered]@{
-                label     = $paneContext['label']
-                role      = $paneContext['role']
-                diff      = $diffData
-                source    = $sourceName
-                source_id = $sourceId
-            })
+            -Data (New-CommanderPollStateData -PaneContext $paneContext -Data ([ordered]@{
+                    label     = $paneContext['label']
+                    role      = $paneContext['role']
+                    diff      = $diffData
+                    source    = $sourceName
+                    source_id = $sourceId
+                }))
 
         $Summary['completions'] = [int]$Summary['completions'] + 1
         $Summary['messages'] += @($message)
+        Update-CommanderPollPaneState -PaneContext $paneContext -Properties ([ordered]@{
+                task_state         = 'completed'
+                task_owner         = 'Commander'
+                branch             = [string](Get-CommanderPollValue -InputObject $diffData -Name 'branch' -Default '')
+                head_sha           = [string](Get-CommanderPollValue -InputObject $diffData -Name 'head_sha' -Default '')
+                changed_file_count = [int](Get-CommanderPollValue -InputObject $diffData -Name 'changed_file_count' -Default 0)
+                changed_files      = @(Get-CommanderPollValue -InputObject $diffData -Name 'changed_files' -Default @())
+                last_event         = 'commander.poll.exec_completed'
+                last_event_at      = (Get-Date).ToString('o')
+            })
 
         Send-CommanderTelegramNotification -ProjectDir $projectDir -SessionName $sessionName `
             -Event $eventName -Message $message -PaneId $paneId `
@@ -615,17 +635,23 @@ function Invoke-CommanderPollEventRecord {
             -EventName 'commander.poll.idle_dispatch_needed' `
             -Message $message `
             -PaneId $paneId `
-            -Data ([ordered]@{
-                label      = $paneContext['label']
-                role       = $paneContext['role']
-                status     = [string](Get-CommanderPollValue -InputObject $EventRecord -Name 'status' -Default '')
-                event      = $eventName
-                source     = $sourceName
-                source_id  = $sourceId
-            })
+            -Data (New-CommanderPollStateData -PaneContext $paneContext -Data ([ordered]@{
+                    label      = $paneContext['label']
+                    role       = $paneContext['role']
+                    status     = [string](Get-CommanderPollValue -InputObject $EventRecord -Name 'status' -Default '')
+                    event      = $eventName
+                    source     = $sourceName
+                    source_id  = $sourceId
+                }))
 
         $Summary['dispatches'] = [int]$Summary['dispatches'] + 1
         $Summary['messages'] += @($message)
+        Update-CommanderPollPaneState -PaneContext $paneContext -Properties ([ordered]@{
+                task_state    = 'waiting_for_dispatch'
+                task_owner    = 'Commander'
+                last_event    = 'commander.poll.idle_dispatch_needed'
+                last_event_at = (Get-Date).ToString('o')
+            })
 
         Send-CommanderTelegramNotification -ProjectDir $projectDir -SessionName $sessionName `
             -Event 'commander.dispatch_needed' -Message $message -PaneId $paneId `
@@ -649,15 +675,20 @@ function Invoke-CommanderPollEventRecord {
             -EventName 'commander.poll.auto_approved' `
             -Message $message `
             -PaneId $paneId `
-            -Data ([ordered]@{
-                label     = $paneContext['label']
-                role      = $paneContext['role']
-                source    = $sourceName
-                source_id = $sourceId
-            })
+            -Data (New-CommanderPollStateData -PaneContext $paneContext -Data ([ordered]@{
+                    label     = $paneContext['label']
+                    role      = $paneContext['role']
+                    source    = $sourceName
+                    source_id = $sourceId
+                }))
 
         $Summary['approvals'] = [int]$Summary['approvals'] + 1
         $Summary['messages'] += @($message)
+        Update-CommanderPollPaneState -PaneContext $paneContext -Properties ([ordered]@{
+                task_owner    = 'Commander'
+                last_event    = 'commander.poll.auto_approved'
+                last_event_at = (Get-Date).ToString('o')
+            })
 
         Send-CommanderTelegramNotification -ProjectDir $projectDir -SessionName $sessionName `
             -Event 'commander.auto_approved' -Message $message -PaneId $paneId `
@@ -904,7 +935,7 @@ function Invoke-CommanderStateMachine {
                 label = ''; pane_id = ''; role = 'Commander'; status = $nextState
                 exit_reason = ''; data = [ordered]@{ from = $CurrentState; to = $nextState }
             }
-            [System.IO.File]::AppendAllText($ep, (($rec | ConvertTo-Json -Compress -Depth 10) + "`n"), [System.Text.Encoding]::UTF8)
+            Write-WinsmuxTextFile -Path $ep -Content ($rec | ConvertTo-Json -Compress -Depth 10) -Append
         } catch { }
     }
 

--- a/winsmux-core/scripts/logger.ps1
+++ b/winsmux-core/scripts/logger.ps1
@@ -18,6 +18,7 @@ param(
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
 [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+. "$PSScriptRoot/clm-safe-io.ps1"
 
 $script:OrchestraLogDirName = '.winsmux\logs'
 $script:OrchestraLogExtension = '.jsonl'
@@ -58,7 +59,7 @@ function Initialize-OrchestraLogger {
 
     $logPath = Get-OrchestraLogPath -ProjectDir $ProjectDir -SessionName $SessionName
     if (-not (Test-Path $logPath)) {
-        Set-Content -Path $logPath -Value '' -Encoding UTF8 -NoNewline
+        Write-WinsmuxTextFile -Path $logPath -Content ''
     }
 
     return $logPath
@@ -149,7 +150,7 @@ function Write-OrchestraLog {
     $logPath = Initialize-OrchestraLogger -ProjectDir $ProjectDir -SessionName $SessionName
     $record = New-OrchestraLogRecord -SessionName $SessionName -Event $Event -Level $Level -Message $Message -Role $Role -PaneId $PaneId -Target $Target -Data $Data
     $line = ($record | ConvertTo-Json -Compress -Depth 10)
-    Add-Content -Path $logPath -Value $line -Encoding UTF8
+    Write-WinsmuxTextFile -Path $logPath -Content $line -Append
     return [PSCustomObject]$record
 }
 

--- a/winsmux-core/scripts/manifest.ps1
+++ b/winsmux-core/scripts/manifest.ps1
@@ -3,43 +3,107 @@
 Session manifest reader/writer for winsmux Orchestra.
 
 .DESCRIPTION
-Manages .winsmux/manifest.yaml — the single source of truth for a running
-Orchestra session (panes, tasks, worktrees).
-
-Uses simple line-by-line YAML serialization; no external modules required.
-
-Dot-source this script to load the helpers:
-
-    . "$PSScriptRoot/manifest.ps1"
+Manages .winsmux/manifest.yaml as the single source of truth for a running
+Orchestra session. Supports both the legacy list-style pane schema and the
+current dictionary-style pane schema used by orchestra-start.ps1.
 #>
 
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
+. (Join-Path $PSScriptRoot 'clm-safe-io.ps1')
 
 $script:ManifestFileName = 'manifest.yaml'
-$script:ManifestDirName  = '.winsmux'
-
-# ---------------------------------------------------------------------------
-# YAML helpers (minimal, project-local)
-# ---------------------------------------------------------------------------
+$script:ManifestDirName = '.winsmux'
 
 function ConvertTo-ManifestYamlScalar {
     param([AllowNull()]$Value)
 
     if ($null -eq $Value) {
-        return '""'
+        return 'null'
     }
 
-    $text = $Value.ToString()
-    if ($text -eq '') {
-        return '""'
+    if ($Value -is [bool]) {
+        return $(if ($Value) { 'true' } else { 'false' })
     }
 
-    if ($text -match '^[A-Za-z0-9._/\\:-]+$') {
-        return $text
+    $text = [string]$Value
+    if ($text.Length -eq 0) {
+        return "''"
     }
 
-    return '"' + ($text -replace '"', '\"') + '"'
+    return "'" + $text.Replace("'", "''") + "'"
+}
+
+function Split-ManifestYamlInlineList {
+    param([Parameter(Mandatory = $true)][string]$Value)
+
+    $items = [System.Collections.Generic.List[string]]::new()
+    $builder = New-Object System.Text.StringBuilder
+    $quote = [char]0
+
+    for ($index = 0; $index -lt $Value.Length; $index++) {
+        $char = $Value[$index]
+
+        if ($quote -ne [char]0) {
+            [void]$builder.Append($char)
+
+            if ($char -eq $quote) {
+                if ($quote -eq "'" -and $index + 1 -lt $Value.Length -and $Value[$index + 1] -eq "'") {
+                    $index++
+                    [void]$builder.Append($Value[$index])
+                    continue
+                }
+
+                $quote = [char]0
+            }
+
+            continue
+        }
+
+        if ($char -eq "'" -or $char -eq '"') {
+            $quote = $char
+            [void]$builder.Append($char)
+            continue
+        }
+
+        if ($char -eq ',') {
+            $items.Add($builder.ToString().Trim()) | Out-Null
+            [void]$builder.Clear()
+            continue
+        }
+
+        [void]$builder.Append($char)
+    }
+
+    $items.Add($builder.ToString().Trim()) | Out-Null
+    return @($items)
+}
+
+function ConvertTo-ManifestYamlValue {
+    param([AllowNull()]$Value)
+
+    if ($null -eq $Value) {
+        return 'null'
+    }
+
+    if ($Value -is [string] -or $Value -is [bool]) {
+        return ConvertTo-ManifestYamlScalar -Value $Value
+    }
+
+    if ($Value -is [System.Collections.IEnumerable] -and -not ($Value -is [System.Collections.IDictionary])) {
+        $items = @($Value)
+        if ($items.Count -eq 0) {
+            return '[]'
+        }
+
+        $encodedItems = foreach ($item in $items) {
+            ConvertTo-ManifestYamlScalar -Value $item
+        }
+
+        return '[' + ($encodedItems -join ', ') + ']'
+    }
+
+    return ConvertTo-ManifestYamlScalar -Value $Value
 }
 
 function ConvertFrom-ManifestYamlScalar {
@@ -57,12 +121,100 @@ function ConvertFrom-ManifestYamlScalar {
         }
     }
 
+    if ($text -eq 'null') {
+        return $null
+    }
+
     return $text
 }
 
-# ---------------------------------------------------------------------------
-# Path helpers
-# ---------------------------------------------------------------------------
+function ConvertFrom-ManifestYamlValue {
+    param([AllowNull()]$Value)
+
+    if ($null -eq $Value) {
+        return $null
+    }
+
+    $text = $Value.ToString().Trim()
+    if ($text -eq '[]') {
+        return @()
+    }
+
+    if ($text.Length -ge 2 -and $text.StartsWith('[') -and $text.EndsWith(']')) {
+        $inner = $text.Substring(1, $text.Length - 2).Trim()
+        if ([string]::IsNullOrWhiteSpace($inner)) {
+            return @()
+        }
+
+        return @((Split-ManifestYamlInlineList -Value $inner | ForEach-Object {
+            ConvertFrom-ManifestYamlScalar -Value $_
+        }))
+    }
+
+    return ConvertFrom-ManifestYamlScalar -Value $Value
+}
+
+function ConvertTo-ManifestPropertyMap {
+    param([AllowNull()]$Value)
+
+    $result = [ordered]@{}
+    if ($null -eq $Value) {
+        return $result
+    }
+
+    if ($Value -is [System.Collections.Specialized.OrderedDictionary]) {
+        foreach ($key in $Value.Keys) {
+            $result[[string]$key] = $Value[$key]
+        }
+
+        return $result
+    }
+
+    if ($Value -is [System.Collections.IDictionary]) {
+        foreach ($entry in $Value.GetEnumerator()) {
+            $result[[string]$entry.Key] = $entry.Value
+        }
+
+        return $result
+    }
+
+    if ($null -ne $Value.PSObject) {
+        foreach ($property in $Value.PSObject.Properties) {
+            $result[$property.Name] = $property.Value
+        }
+    }
+
+    return $result
+}
+
+function ConvertTo-ManifestKeyName {
+    param([Parameter(Mandatory = $true)][string]$Name)
+
+    switch ($Name) {
+        'PaneId' { return 'pane_id' }
+        'Role' { return 'role' }
+        'ExecMode' { return 'exec_mode' }
+        'LaunchDir' { return 'launch_dir' }
+        'BuilderBranch' { return 'builder_branch' }
+        'BuilderWorktreePath' { return 'builder_worktree_path' }
+        'Task' { return 'task' }
+        'Status' { return 'status' }
+        'BootstrapFailures' { return 'bootstrap_failures' }
+        default {
+            $snake = [regex]::Replace($Name, '([a-z0-9])([A-Z])', '$1_$2')
+            return $snake.ToLowerInvariant()
+        }
+    }
+}
+
+function Write-ManifestTextFile {
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [AllowEmptyString()][string]$Content = ''
+    )
+
+    Write-WinsmuxTextFile -Path $Path -Content $Content
+}
 
 function Get-ManifestDir {
     param([Parameter(Mandatory = $true)][string]$ProjectDir)
@@ -76,27 +228,14 @@ function Get-ManifestPath {
     return Join-Path (Get-ManifestDir -ProjectDir $ProjectDir) $script:ManifestFileName
 }
 
-# ---------------------------------------------------------------------------
-# Public API
-# ---------------------------------------------------------------------------
-
 function New-WinsmuxManifest {
-    <#
-    .SYNOPSIS
-    Creates a fresh .winsmux/manifest.yaml for a new Orchestra session.
-    #>
     param([Parameter(Mandatory = $true)][string]$ProjectDir)
 
-    $dir = Get-ManifestDir -ProjectDir $ProjectDir
-    if (-not (Test-Path $dir)) {
-        New-Item -ItemType Directory -Path $dir -Force | Out-Null
-    }
-
-    $now = [System.DateTimeOffset]::Now.ToString('yyyy-MM-ddTHH:mm:sszzz')
-
+    $now = [System.DateTimeOffset]::Now.ToString('o')
     $manifest = [PSCustomObject]@{
-        version   = 1
-        session   = [PSCustomObject]@{
+        version  = 1
+        saved_at = $now
+        session  = [PSCustomObject]@{
             started = $now
             ended   = ''
         }
@@ -110,23 +249,18 @@ function New-WinsmuxManifest {
     }
 
     Save-WinsmuxManifest -ProjectDir $ProjectDir -Manifest $manifest
-
     return $manifest
 }
 
 function Get-WinsmuxManifest {
-    <#
-    .SYNOPSIS
-    Reads .winsmux/manifest.yaml and returns a PSCustomObject, or $null if absent.
-    #>
     param([Parameter(Mandatory = $true)][string]$ProjectDir)
 
     $path = Get-ManifestPath -ProjectDir $ProjectDir
-    if (-not (Test-Path $path)) {
+    if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
         return $null
     }
 
-    $raw = Get-Content -Raw -Path $path -Encoding UTF8
+    $raw = Get-Content -LiteralPath $path -Raw -Encoding UTF8
     if ([string]::IsNullOrWhiteSpace($raw)) {
         return $null
     }
@@ -135,33 +269,33 @@ function Get-WinsmuxManifest {
 }
 
 function Save-WinsmuxManifest {
-    <#
-    .SYNOPSIS
-    Writes a manifest PSCustomObject back to .winsmux/manifest.yaml.
-    #>
     param(
         [Parameter(Mandatory = $true)][string]$ProjectDir,
         [Parameter(Mandatory = $true)]$Manifest
     )
 
-    $dir = Get-ManifestDir -ProjectDir $ProjectDir
-    if (-not (Test-Path $dir)) {
-        New-Item -ItemType Directory -Path $dir -Force | Out-Null
-    }
-
     $path = Get-ManifestPath -ProjectDir $ProjectDir
     $yaml = ConvertTo-ManifestYaml -Manifest $Manifest
-    Set-Content -Path $path -Value $yaml -Encoding UTF8 -NoNewline
+    Write-ManifestTextFile -Path $path -Content $yaml
+}
+
+function ConvertTo-ManifestPaneEntry {
+    param([Parameter(Mandatory = $true)]$PaneSummary)
+
+    $entry = [ordered]@{}
+    $paneMap = ConvertTo-ManifestPropertyMap -Value $PaneSummary
+    foreach ($key in $paneMap.Keys) {
+        if ($key -eq 'Label') {
+            continue
+        }
+
+        $entry[(ConvertTo-ManifestKeyName -Name $key)] = $paneMap[$key]
+    }
+
+    return $entry
 }
 
 function Update-ManifestPanes {
-    <#
-    .SYNOPSIS
-    Replaces the panes section of the manifest.
-
-    .PARAMETER PaneSummaries
-    Array of objects with: Label, PaneId, Role, BuilderWorktreePath
-    #>
     param(
         [Parameter(Mandatory = $true)][string]$ManifestPath,
         [Parameter(Mandatory = $true)][array]$PaneSummaries
@@ -175,12 +309,7 @@ function Update-ManifestPanes {
 
     $panes = [ordered]@{}
     foreach ($pane in $PaneSummaries) {
-        $label = $pane.Label
-        $panes[$label] = [PSCustomObject]@{
-            pane_id               = $pane.PaneId
-            role                  = $pane.Role
-            builder_worktree_path = if ($pane.BuilderWorktreePath) { $pane.BuilderWorktreePath } else { '' }
-        }
+        $panes[[string]$pane.Label] = ConvertTo-ManifestPaneEntry -PaneSummary $pane
     }
 
     $manifest.panes = $panes
@@ -188,10 +317,6 @@ function Update-ManifestPanes {
 }
 
 function Update-ManifestTasks {
-    <#
-    .SYNOPSIS
-    Replaces the tasks section of the manifest.
-    #>
     param(
         [Parameter(Mandatory = $true)][string]$ManifestPath,
         [Parameter(Mandatory = $true)][AllowEmptyCollection()][array]$InProgress,
@@ -204,7 +329,13 @@ function Update-ManifestTasks {
         throw "Manifest not found at: $ManifestPath"
     }
 
+    $queued = @()
+    if ($null -ne $manifest.tasks -and $null -ne $manifest.tasks.queued) {
+        $queued = @($manifest.tasks.queued)
+    }
+
     $manifest.tasks = [PSCustomObject]@{
+        queued      = @($queued)
         in_progress = @($InProgress)
         completed   = @($Completed)
     }
@@ -212,230 +343,176 @@ function Update-ManifestTasks {
     Save-WinsmuxManifest -ProjectDir $projectDir -Manifest $manifest
 }
 
-# ---------------------------------------------------------------------------
-# YAML serializer
-# ---------------------------------------------------------------------------
-
 function ConvertTo-ManifestYaml {
     param([Parameter(Mandatory = $true)]$Manifest)
 
+    $manifestMap = ConvertTo-ManifestPropertyMap -Value $Manifest
+    $sessionMap = ConvertTo-ManifestPropertyMap -Value $manifestMap['session']
+    $panesMap = ConvertTo-ManifestPropertyMap -Value $manifestMap['panes']
+    $tasksMap = ConvertTo-ManifestPropertyMap -Value $manifestMap['tasks']
+    $worktreesMap = ConvertTo-ManifestPropertyMap -Value $manifestMap['worktrees']
+
     $lines = [System.Collections.Generic.List[string]]::new()
-
-    $lines.Add("version: $($Manifest.version)")
-    $lines.Add('session:')
-    $lines.Add("  started: $(ConvertTo-ManifestYamlScalar $Manifest.session.started)")
-    $lines.Add("  ended: $(ConvertTo-ManifestYamlScalar $Manifest.session.ended)")
-
-    # panes
-    $lines.Add('panes:')
-    $paneEntries = $null
-    if ($Manifest.panes -is [System.Collections.IDictionary]) {
-        $paneEntries = $Manifest.panes
+    $lines.Add(('version: {0}' -f (ConvertTo-ManifestYamlScalar -Value $(if ($manifestMap.Contains('version')) { $manifestMap['version'] } else { 1 })))) | Out-Null
+    $lines.Add(('saved_at: {0}' -f (ConvertTo-ManifestYamlScalar -Value $(if ($manifestMap.Contains('saved_at')) { $manifestMap['saved_at'] } else { [System.DateTimeOffset]::Now.ToString('o') })))) | Out-Null
+    $lines.Add('session:') | Out-Null
+    foreach ($key in $sessionMap.Keys) {
+        $lines.Add(('  {0}: {1}' -f $key, (ConvertTo-ManifestYamlScalar -Value $sessionMap[$key]))) | Out-Null
     }
 
-    if ($null -ne $paneEntries -and $paneEntries.Count -gt 0) {
-        foreach ($label in $paneEntries.Keys) {
-            $pane = $paneEntries[$label]
-            $lines.Add("  $(ConvertTo-ManifestYamlScalar $label):")
-            $lines.Add("    pane_id: $(ConvertTo-ManifestYamlScalar $pane.pane_id)")
-            $lines.Add("    role: $(ConvertTo-ManifestYamlScalar $pane.role)")
-            $lines.Add("    builder_worktree_path: $(ConvertTo-ManifestYamlScalar $pane.builder_worktree_path)")
-        }
-    } else {
+    $lines.Add('panes:') | Out-Null
+    if ($panesMap.Count -eq 0) {
         $lines[$lines.Count - 1] = 'panes: {}'
-    }
-
-    # tasks
-    $lines.Add('tasks:')
-
-    $lines.Add('  queued:')
-    $queued = @()
-    if ($null -ne $Manifest.tasks -and $null -ne $Manifest.tasks.queued) {
-        $queued = @($Manifest.tasks.queued)
-    }
-
-    if ($queued.Count -gt 0) {
-        foreach ($task in $queued) {
-            $lines.Add("    - $(ConvertTo-ManifestYamlScalar $task)")
-        }
     } else {
-        $lines[$lines.Count - 1] = '  queued: []'
-    }
-
-    $lines.Add('  in_progress:')
-    $inProgress = @()
-    if ($null -ne $Manifest.tasks -and $null -ne $Manifest.tasks.in_progress) {
-        $inProgress = @($Manifest.tasks.in_progress)
-    }
-
-    if ($inProgress.Count -gt 0) {
-        foreach ($task in $inProgress) {
-            $lines.Add("    - $(ConvertTo-ManifestYamlScalar $task)")
-        }
-    } else {
-        $lines[$lines.Count - 1] = '  in_progress: []'
-    }
-
-    $lines.Add('  completed:')
-    $completed = @()
-    if ($null -ne $Manifest.tasks -and $null -ne $Manifest.tasks.completed) {
-        $completed = @($Manifest.tasks.completed)
-    }
-
-    if ($completed.Count -gt 0) {
-        foreach ($task in $completed) {
-            $lines.Add("    - $(ConvertTo-ManifestYamlScalar $task)")
-        }
-    } else {
-        $lines[$lines.Count - 1] = '  completed: []'
-    }
-
-    # worktrees
-    $lines.Add('worktrees:')
-    $wtEntries = $null
-    if ($Manifest.worktrees -is [System.Collections.IDictionary]) {
-        $wtEntries = $Manifest.worktrees
-    }
-
-    if ($null -ne $wtEntries -and $wtEntries.Count -gt 0) {
-        foreach ($label in $wtEntries.Keys) {
-            $wt = $wtEntries[$label]
-            $lines.Add("  $(ConvertTo-ManifestYamlScalar $label):")
-            if ($wt -is [System.Collections.IDictionary]) {
-                foreach ($key in $wt.Keys) {
-                    $lines.Add("    ${key}: $(ConvertTo-ManifestYamlScalar $wt[$key])")
-                }
-            } elseif ($null -ne $wt -and $null -ne $wt.PSObject) {
-                foreach ($prop in $wt.PSObject.Properties) {
-                    $lines.Add("    $($prop.Name): $(ConvertTo-ManifestYamlScalar $prop.Value)")
-                }
+        foreach ($label in $panesMap.Keys) {
+            $lines.Add(('  {0}:' -f (ConvertTo-ManifestYamlScalar -Value $label))) | Out-Null
+            $paneMap = ConvertTo-ManifestPropertyMap -Value $panesMap[$label]
+            foreach ($key in $paneMap.Keys) {
+                $lines.Add(('    {0}: {1}' -f $key, (ConvertTo-ManifestYamlValue -Value $paneMap[$key]))) | Out-Null
             }
         }
-    } else {
+    }
+
+    $lines.Add('tasks:') | Out-Null
+    foreach ($taskKey in @('queued', 'in_progress', 'completed')) {
+        $lines.Add(('  {0}:' -f $taskKey)) | Out-Null
+        $items = @()
+        if ($tasksMap.Contains($taskKey) -and $null -ne $tasksMap[$taskKey]) {
+            $items = @($tasksMap[$taskKey])
+        }
+
+        if ($items.Count -eq 0) {
+            $lines[$lines.Count - 1] = ('  {0}: []' -f $taskKey)
+        } else {
+            foreach ($item in $items) {
+                $lines.Add(('    - {0}' -f (ConvertTo-ManifestYamlScalar -Value $item))) | Out-Null
+            }
+        }
+    }
+
+    $lines.Add('worktrees:') | Out-Null
+    if ($worktreesMap.Count -eq 0) {
         $lines[$lines.Count - 1] = 'worktrees: {}'
+    } else {
+        foreach ($label in $worktreesMap.Keys) {
+            $lines.Add(('  {0}:' -f (ConvertTo-ManifestYamlScalar -Value $label))) | Out-Null
+            $worktreeEntry = ConvertTo-ManifestPropertyMap -Value $worktreesMap[$label]
+            foreach ($key in $worktreeEntry.Keys) {
+                $lines.Add(('    {0}: {1}' -f $key, (ConvertTo-ManifestYamlValue -Value $worktreeEntry[$key]))) | Out-Null
+            }
+        }
     }
 
     return ($lines -join "`n") + "`n"
 }
 
-# ---------------------------------------------------------------------------
-# YAML deserializer
-# ---------------------------------------------------------------------------
-
 function ConvertFrom-ManifestYaml {
     param([Parameter(Mandatory = $true)][string]$Content)
 
     $manifest = [PSCustomObject]@{
-        version   = 1
-        session   = [PSCustomObject]@{ started = ''; ended = '' }
-        panes     = [ordered]@{}
-        tasks     = [PSCustomObject]@{ queued = @(); in_progress = @(); completed = @() }
+        version  = 1
+        saved_at = ''
+        session  = [PSCustomObject]@{}
+        panes    = [ordered]@{}
+        tasks    = [PSCustomObject]@{
+            queued      = @()
+            in_progress = @()
+            completed   = @()
+        }
         worktrees = [ordered]@{}
     }
 
-    $section      = ''
-    $subSection   = ''
+    $section = ''
     $currentLabel = ''
-    $taskListKey  = ''
+    $currentMode = ''
+    $taskListKey = ''
 
     foreach ($rawLine in ($Content -split "\r?\n")) {
-        # Skip comments and blank lines
-        $line = $rawLine
-        if ($line -match '^\s*#') { continue }
-        if ([string]::IsNullOrWhiteSpace($line)) { continue }
+        $line = $rawLine.TrimEnd()
+        if ([string]::IsNullOrWhiteSpace($line) -or $line -match '^\s*#') {
+            continue
+        }
 
-        # Top-level scalar: version
-        if ($line -match '^version:\s*(.+?)\s*$') {
+        if ($line -match '^version:\s*(.*?)\s*$') {
             $manifest.version = [int](ConvertFrom-ManifestYamlScalar $Matches[1])
-            $section = ''
             continue
         }
 
-        # Section headers (0-indent)
-        if ($line -match '^(session|panes|tasks|worktrees):\s*(\{?\}?)\s*$') {
-            $section      = $Matches[1]
-            $subSection   = ''
+        if ($line -match '^saved_at:\s*(.*?)\s*$') {
+            $manifest.saved_at = [string](ConvertFrom-ManifestYamlScalar $Matches[1])
+            continue
+        }
+
+        if ($line -match '^(session|panes|tasks|worktrees):\s*(\{\})?\s*$') {
+            $section = $Matches[1]
             $currentLabel = ''
-            $taskListKey  = ''
+            $currentMode = ''
+            $taskListKey = ''
             continue
         }
 
-        # 2-space indent
-        if ($line -match '^  (\S.*)$') {
-            $inner = $Matches[1]
-
-            switch ($section) {
-                'session' {
-                    if ($inner -match '^(started|ended):\s*(.*?)\s*$') {
-                        $manifest.session.($Matches[1]) = ConvertFrom-ManifestYamlScalar $Matches[2]
-                    }
-                }
-                'panes' {
-                    if ($inner -match '^(.+?):\s*$') {
-                        # Pane label header
-                        $currentLabel = ConvertFrom-ManifestYamlScalar $Matches[1]
-                        $manifest.panes[$currentLabel] = [PSCustomObject]@{
-                            pane_id               = ''
-                            role                  = ''
-                            builder_worktree_path = ''
-                        }
-                    }
-                }
-                'tasks' {
-                    if ($inner -match '^(queued|in_progress|completed):\s*(\[?\]?)\s*$') {
-                        $taskListKey = $Matches[1]
-                    } elseif ($inner -match '^-\s+(.+?)\s*$' -and $taskListKey) {
-                        $value = ConvertFrom-ManifestYamlScalar $Matches[1]
-                        if ($taskListKey -eq 'queued') {
-                            $manifest.tasks.queued = @($manifest.tasks.queued) + @($value)
-                        } elseif ($taskListKey -eq 'in_progress') {
-                            $manifest.tasks.in_progress = @($manifest.tasks.in_progress) + @($value)
-                        } else {
-                            $manifest.tasks.completed = @($manifest.tasks.completed) + @($value)
-                        }
-                    }
-                }
-                'worktrees' {
-                    if ($inner -match '^(.+?):\s*$') {
-                        $currentLabel = ConvertFrom-ManifestYamlScalar $Matches[1]
-                        $manifest.worktrees[$currentLabel] = [ordered]@{}
-                    }
-                }
-            }
-
+        if ($section -eq 'session' -and $line -match '^\s{2}([A-Za-z0-9_.-]+):\s*(.*?)\s*$') {
+            $manifest.session | Add-Member -NotePropertyName $Matches[1] -NotePropertyValue (ConvertFrom-ManifestYamlValue $Matches[2]) -Force
             continue
         }
 
-        # 4-space indent
-        if ($line -match '^    (\S.*)$') {
-            $inner = $Matches[1]
-
-            if ($section -eq 'panes' -and $currentLabel -and $manifest.panes.Contains($currentLabel)) {
-                if ($inner -match '^(pane_id|role|builder_worktree_path):\s*(.*?)\s*$') {
-                    $manifest.panes[$currentLabel].($Matches[1]) = ConvertFrom-ManifestYamlScalar $Matches[2]
+        if ($section -eq 'panes') {
+            if ($line -match '^\s{2}-\s+label:\s*(.*?)\s*$') {
+                $currentLabel = [string](ConvertFrom-ManifestYamlScalar $Matches[1])
+                if (-not $manifest.panes.Contains($currentLabel)) {
+                    $manifest.panes[$currentLabel] = [ordered]@{ label = $currentLabel }
                 }
+                $currentMode = 'list'
+                continue
             }
 
-            if ($section -eq 'tasks' -and $taskListKey) {
-                if ($inner -match '^-\s+(.+?)\s*$') {
-                    $value = ConvertFrom-ManifestYamlScalar $Matches[1]
-                    if ($taskListKey -eq 'queued') {
-                        $manifest.tasks.queued = @($manifest.tasks.queued) + @($value)
-                    } elseif ($taskListKey -eq 'in_progress') {
-                        $manifest.tasks.in_progress = @($manifest.tasks.in_progress) + @($value)
-                    } else {
-                        $manifest.tasks.completed = @($manifest.tasks.completed) + @($value)
-                    }
+            if ($line -match '^\s{2}(.+?):\s*$') {
+                $currentLabel = [string](ConvertFrom-ManifestYamlScalar $Matches[1])
+                if (-not $manifest.panes.Contains($currentLabel)) {
+                    $manifest.panes[$currentLabel] = [ordered]@{}
                 }
+                $currentMode = 'dict'
+                continue
             }
 
-            if ($section -eq 'worktrees' -and $currentLabel -and $manifest.worktrees.Contains($currentLabel)) {
-                if ($inner -match '^(\S+?):\s*(.*?)\s*$') {
-                    $manifest.worktrees[$currentLabel][$Matches[1]] = ConvertFrom-ManifestYamlScalar $Matches[2]
-                }
+            if (-not [string]::IsNullOrWhiteSpace($currentLabel) -and $line -match '^\s{4}([A-Za-z0-9_.-]+):\s*(.*?)\s*$') {
+                $manifest.panes[$currentLabel][$Matches[1]] = ConvertFrom-ManifestYamlValue $Matches[2]
+                continue
+            }
+        }
+
+        if ($section -eq 'tasks') {
+            if ($line -match '^\s{2}(queued|in_progress|completed):\s*(\[\])?\s*$') {
+                $taskListKey = $Matches[1]
+                continue
             }
 
-            continue
+            if (-not [string]::IsNullOrWhiteSpace($taskListKey) -and $line -match '^\s{4}-\s*(.*?)\s*$') {
+                $items = @($manifest.tasks.$taskListKey)
+                $manifest.tasks.$taskListKey = @($items + (ConvertFrom-ManifestYamlScalar $Matches[1]))
+                continue
+            }
+        }
+
+        if ($section -eq 'worktrees') {
+            if ($line -match '^\s{2}(.+?):\s*$') {
+                $currentLabel = [string](ConvertFrom-ManifestYamlScalar $Matches[1])
+                if (-not $manifest.worktrees.Contains($currentLabel)) {
+                    $manifest.worktrees[$currentLabel] = [ordered]@{}
+                }
+                continue
+            }
+
+            if (-not [string]::IsNullOrWhiteSpace($currentLabel) -and $line -match '^\s{4}([A-Za-z0-9_.-]+):\s*(.*?)\s*$') {
+                $manifest.worktrees[$currentLabel][$Matches[1]] = ConvertFrom-ManifestYamlValue $Matches[2]
+                continue
+            }
+        }
+    }
+
+    foreach ($label in @($manifest.panes.Keys)) {
+        if ($manifest.panes[$label].Contains('label')) {
+            $manifest.panes[$label].Remove('label')
         }
     }
 

--- a/winsmux-core/scripts/orchestra-preflight.ps1
+++ b/winsmux-core/scripts/orchestra-preflight.ps1
@@ -188,7 +188,12 @@ function Get-OrchestraZombieVictims {
 
     if (@($PaneRootIds).Count -gt 0) {
         $descendantIds = Get-DescendantProcessIds -Snapshot $Snapshot -RootProcessIds $PaneRootIds
+        $paneRootIdSet = [System.Collections.Generic.HashSet[int]]::new()
+        foreach ($rid in @($PaneRootIds)) { [void]$paneRootIdSet.Add([int]$rid) }
         foreach ($descendantId in $descendantIds) {
+            if ($paneRootIdSet.Contains([int]$descendantId)) {
+                continue
+            }
             if (-not $Snapshot.ById.ContainsKey($descendantId)) {
                 continue
             }

--- a/winsmux-core/scripts/orchestra-start.ps1
+++ b/winsmux-core/scripts/orchestra-start.ps1
@@ -6,6 +6,7 @@ $scriptDir = $PSScriptRoot
 . "$scriptDir/logger.ps1"
 . "$scriptDir/agent-readiness.ps1"
 . "$scriptDir/orchestra-preflight.ps1"
+. "$scriptDir/manifest.ps1"
 
 Set-StrictMode -Version Latest
 [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
@@ -22,28 +23,7 @@ function Write-OrchestraTextFile {
         [switch]$Append
     )
 
-    $parent = Split-Path -Parent $Path
-    if (-not [string]::IsNullOrWhiteSpace($parent) -and -not (Test-Path -LiteralPath $parent)) {
-        New-Item -ItemType Directory -Path $parent -Force | Out-Null
-    }
-
-    $escapedPath = $Path -replace '"', '""'
-    if ([string]::IsNullOrEmpty($Content)) {
-        if ($Append) {
-            return
-        }
-
-        $writeCommand = 'type nul > "{0}"' -f $escapedPath
-        cmd /d /c $writeCommand | Out-Null
-    } else {
-        $redirect = if ($Append) { '>>' } else { '>' }
-        $writeCommand = 'more {0} "{1}"' -f $redirect, $escapedPath
-        $Content | cmd /d /c $writeCommand | Out-Null
-    }
-
-    if ($LASTEXITCODE -ne 0) {
-        throw "cmd.exe failed to write $Path"
-    }
+    Write-WinsmuxTextFile -Path $Path -Content $Content -Append:$Append
 }
 
 function Invoke-Winsmux {
@@ -88,35 +68,61 @@ function Ensure-OrchestraServer {
     param(
         [Parameter(Mandatory = $true)]
         [string]$SessionName,
-        [int]$RetryCount = 3,
-        [int]$RetryDelaySeconds = 2
+        [int]$TimeoutSeconds = 30
     )
 
     if (Test-OrchestraServerSession -SessionName $SessionName) {
         return [ordered]@{
             SessionName    = $SessionName
             SessionCreated = $false
-            ReadyChecks    = 1
         }
     }
 
-    Invoke-Winsmux -Arguments @('new-session', '-d', '-s', $SessionName)
+    # Launch in separate Windows Terminal window (attached session gets real terminal size).
+    # Detached sessions are fixed at 120x30 in the Rust core (resize-window is a no-op on Windows).
+    $wtWidth = 200
+    $wtHeight = 70
+    $wtExe = Get-Command 'wt.exe' -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source -ErrorAction SilentlyContinue
+    if ([string]::IsNullOrWhiteSpace($wtExe)) {
+        throw "Windows Terminal (wt.exe) is required to create the orchestra session with a usable window size. Install Windows Terminal or ensure wt.exe is in PATH."
+    }
 
-    for ($attempt = 1; $attempt -le $RetryCount; $attempt++) {
-        if (Test-OrchestraServerSession -SessionName $SessionName) {
-            return [ordered]@{
-                SessionName    = $SessionName
-                SessionCreated = $true
-                ReadyChecks    = $attempt
+    Start-Process -FilePath $wtExe -ArgumentList @(
+        '--size', "$wtWidth,$wtHeight",
+        '--title', $SessionName,
+        '--',
+        $script:winsmuxBin, 'new-session', '-s', $SessionName
+    )
+
+    # Poll for readiness: has-session + list-panes must both succeed.
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    $pollAttempt = 0
+    while ((Get-Date) -lt $deadline) {
+        $pollAttempt++
+        $hasSession = Test-OrchestraServerSession -SessionName $SessionName
+        if ($hasSession) {
+            try {
+                $paneOutput = Invoke-Winsmux -Arguments @('list-panes', '-t', $SessionName, '-F', '#{pane_id}') -CaptureOutput
+                $paneText = ($paneOutput | Out-String).Trim()
+                if (-not [string]::IsNullOrWhiteSpace($paneText)) {
+                    Write-Host "Ensure-OrchestraServer: ready after $pollAttempt polls"
+                    return [ordered]@{
+                        SessionName    = $SessionName
+                        SessionCreated = $true
+                    }
+                }
+            } catch {
+                Write-Warning "Ensure-OrchestraServer: poll $pollAttempt list-panes error: $($_.Exception.Message)"
+            }
+        } else {
+            if ($pollAttempt -le 5 -or $pollAttempt % 10 -eq 0) {
+                Write-Warning "Ensure-OrchestraServer: poll $pollAttempt has-session=false"
             }
         }
-
-        if ($attempt -lt $RetryCount) {
-            Start-Sleep -Seconds $RetryDelaySeconds
-        }
+        Start-Sleep -Milliseconds 500
     }
 
-    throw "Orchestra server session '$SessionName' did not become ready after $RetryCount attempts. Verify the winsmux server can create sessions, then rerun orchestra-start.ps1."
+    throw "Orchestra session '$SessionName' did not become ready within $TimeoutSeconds seconds. Verify Windows Terminal launched correctly."
 }
 
 function Invoke-Bridge {
@@ -507,7 +513,7 @@ function Get-TailPreview {
 function Wait-PaneShellReady {
     param(
         [Parameter(Mandatory = $true)][string]$PaneId,
-        [int]$TimeoutSeconds = 15
+        [int]$TimeoutSeconds = 30
     )
 
     $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
@@ -575,53 +581,48 @@ function Save-OrchestraSessionState {
     )
 
     $manifestPath = Get-OrchestraManifestPath -ProjectDir $ProjectDir
-    $manifestDir = Split-Path -Parent $manifestPath
-    New-Item -ItemType Directory -Path $manifestDir -Force | Out-Null
-
-    $lines = [System.Collections.Generic.List[string]]::new()
-    $lines.Add('version: 1') | Out-Null
-    $lines.Add(('saved_at: {0}' -f (ConvertTo-YamlScalar -Value (Get-Date -Format o)))) | Out-Null
-    $lines.Add('session:') | Out-Null
-    $lines.Add(('  name: {0}' -f (ConvertTo-YamlScalar -Value $SessionName))) | Out-Null
-    $lines.Add("  status: 'running'") | Out-Null
-    $lines.Add(('  agent: {0}' -f (ConvertTo-YamlScalar -Value $Settings.agent))) | Out-Null
-    $lines.Add(('  model: {0}' -f (ConvertTo-YamlScalar -Value $Settings.model))) | Out-Null
-    $lines.Add(('  project_dir: {0}' -f (ConvertTo-YamlScalar -Value $ProjectDir))) | Out-Null
-    $lines.Add(('  git_worktree_dir: {0}' -f (ConvertTo-YamlScalar -Value $GitWorktreeDir))) | Out-Null
-    if ($null -ne $CommanderPollPid) {
-        $lines.Add(('  commander_poll_pid: {0}' -f $CommanderPollPid)) | Out-Null
-    } else {
-        $lines.Add('  commander_poll_pid: null') | Out-Null
-    }
-    if ($null -ne $WatchdogPid) {
-        $lines.Add(('  watchdog_pid: {0}' -f $WatchdogPid)) | Out-Null
-    } else {
-        $lines.Add('  watchdog_pid: null') | Out-Null
-    }
-    if ($null -ne $ServerWatchdogPid) {
-        $lines.Add(('  server_watchdog_pid: {0}' -f $ServerWatchdogPid)) | Out-Null
-    } else {
-        $lines.Add('  server_watchdog_pid: null') | Out-Null
-    }
-    $lines.Add('panes:') | Out-Null
-
+    $paneMap = [ordered]@{}
     foreach ($paneSummary in @($PaneSummaries)) {
-        $lines.Add(('  - label: {0}' -f (ConvertTo-YamlScalar -Value $paneSummary.Label))) | Out-Null
-        $lines.Add(('    pane_id: {0}' -f (ConvertTo-YamlScalar -Value $paneSummary.PaneId))) | Out-Null
-        $lines.Add(('    role: {0}' -f (ConvertTo-YamlScalar -Value $paneSummary.Role))) | Out-Null
-        $lines.Add(('    exec_mode: {0}' -f (ConvertTo-YamlScalar -Value $paneSummary.ExecMode))) | Out-Null
-        $lines.Add(('    launch_dir: {0}' -f (ConvertTo-YamlScalar -Value $paneSummary.LaunchDir))) | Out-Null
-        $lines.Add(('    builder_branch: {0}' -f (ConvertTo-YamlScalar -Value $paneSummary.BuilderBranch))) | Out-Null
-        $lines.Add(('    builder_worktree_path: {0}' -f (ConvertTo-YamlScalar -Value $paneSummary.BuilderWorktreePath))) | Out-Null
-        $lines.Add("    task: null") | Out-Null
-        $paneStatus = if ($paneSummary.Status) { $paneSummary.Status } else { 'ready' }
-        $lines.Add(('    status: {0}' -f (ConvertTo-YamlScalar -Value $paneStatus))) | Out-Null
-        if ($paneSummary.BootstrapFailures) {
-            $lines.Add(('    bootstrap_failures: {0}' -f (ConvertTo-YamlScalar -Value $paneSummary.BootstrapFailures))) | Out-Null
+        $paneEntry = [PSCustomObject]@{
+            pane_id               = $paneSummary.PaneId
+            role                  = $paneSummary.Role
+            exec_mode             = [bool]$paneSummary.ExecMode
+            launch_dir            = $paneSummary.LaunchDir
+            builder_branch        = $paneSummary.BuilderBranch
+            builder_worktree_path = $paneSummary.BuilderWorktreePath
+            task                  = $null
+            status                = if ($paneSummary.Status) { $paneSummary.Status } else { 'ready' }
         }
+        if ($paneSummary.Contains('BootstrapFailures') -and $paneSummary['BootstrapFailures']) {
+            $paneEntry | Add-Member -NotePropertyName 'bootstrap_failures' -NotePropertyValue $paneSummary['BootstrapFailures']
+        }
+        $paneMap[[string]$paneSummary.Label] = $paneEntry
     }
 
-    Write-OrchestraTextFile -Path $manifestPath -Content ($lines -join [Environment]::NewLine)
+    $manifest = [PSCustomObject]@{
+        version  = 1
+        saved_at = (Get-Date -Format o)
+        session  = [PSCustomObject]@{
+            name                = $SessionName
+            status              = 'running'
+            agent               = $Settings.agent
+            model               = $Settings.model
+            project_dir         = $ProjectDir
+            git_worktree_dir    = $GitWorktreeDir
+            commander_poll_pid  = $CommanderPollPid
+            watchdog_pid        = $WatchdogPid
+            server_watchdog_pid = $ServerWatchdogPid
+        }
+        panes     = $paneMap
+        tasks     = [PSCustomObject]@{
+            queued      = @()
+            in_progress = @()
+            completed   = @()
+        }
+        worktrees = [ordered]@{}
+    }
+
+    Save-WinsmuxManifest -ProjectDir $ProjectDir -Manifest $manifest
     return $manifestPath
 }
 
@@ -969,6 +970,7 @@ if ($MyInvocation.InvocationName -ne '.') {
         }
 
         $orchestraServer = Ensure-OrchestraServer -SessionName $sessionName
+        Write-Warning ("Ensure result type: " + $orchestraServer.GetType().FullName + " SessionCreated=" + $orchestraServer.SessionCreated)
 
         if (-not (Test-Path $bridgeScript)) {
             Write-Error "Bridge CLI not found: $bridgeScript"
@@ -1092,16 +1094,12 @@ if ($MyInvocation.InvocationName -ne '.') {
         Write-WinsmuxLog -Level INFO -Event 'preflight.builder_worktree_cleanup.branch_removed' -Message "Removed stale Builder branch $removedBranch." -Data ([ordered]@{ branch_name = $removedBranch }) | Out-Null
     }
 
-        # Ensure-OrchestraServer may already have created the detached session.
-        if ([bool]$orchestraServer.SessionCreated) {
-            Write-WinsmuxLog -Level INFO -Event 'preflight.session.ready' -Message "Session $sessionName was already created by Ensure-OrchestraServer." -Data ([ordered]@{
-                session_name    = $sessionName
-                session_created = $true
-            }) | Out-Null
-        } else {
-            Write-WinsmuxLog -Level INFO -Event 'preflight.session.create' -Message "Creating session $sessionName." -Data ([ordered]@{ session_name = $sessionName }) | Out-Null
-            Invoke-Winsmux -Arguments @('new-session', '-d', '-s', $sessionName)
-        }
+        # Session is created by Ensure-OrchestraServer (wt.exe attached window).
+        # No fallback detached creation — wt.exe is required.
+        Write-WinsmuxLog -Level INFO -Event 'preflight.session.ready' -Message "Session $sessionName created by Ensure-OrchestraServer." -Data ([ordered]@{
+            session_name    = $sessionName
+            session_created = [bool]$orchestraServer.SessionCreated
+        }) | Out-Null
         $bootstrapPaneId = Get-OrchestraBootstrapPaneId -SessionName $sessionName
         $createdPaneIds = @($bootstrapPaneId)
 
@@ -1126,7 +1124,9 @@ if ($MyInvocation.InvocationName -ne '.') {
 
         try {
             try {
+                Write-Warning "DEBUG: layout start session=$sessionName C=$($settings.commanders) B=$($settings.builders) R=$($settings.researchers) Rev=$($settings.reviewers)"
                 $layout = . $layoutScript -SessionName $sessionName -Commanders $settings.commanders -Builders $settings.builders -Researchers $settings.researchers -Reviewers $settings.reviewers
+                Write-Warning "DEBUG: layout done, panes=$($layout.Panes.Count)"
                 foreach ($sessionPaneId in @(Get-OrchestraSessionPaneIds -SessionName $sessionName)) {
                     if ($createdPaneIds -notcontains $sessionPaneId) {
                         $createdPaneIds += $sessionPaneId
@@ -1261,12 +1261,12 @@ if ($MyInvocation.InvocationName -ne '.') {
     $validPaneSummaries = [System.Collections.Generic.List[object]]::new()
     $invalidCount = 0
     foreach ($paneSummary in $paneSummaries) {
-        $failures = Test-PaneBootstrapInvariants `
+        $failures = @(Test-PaneBootstrapInvariants `
             -PaneId $paneSummary.PaneId `
             -Label $paneSummary.Label `
             -ExpectedRole $paneSummary.Role `
             -ExpectedLaunchDir $paneSummary.LaunchDir `
-            -ExpectedWorktreePath ([string]$paneSummary.BuilderWorktreePath)
+            -ExpectedWorktreePath ([string]$paneSummary.BuilderWorktreePath))
 
         if ($failures.Count -gt 0) {
             $failureText = $failures -join '; '
@@ -1334,6 +1334,8 @@ if ($MyInvocation.InvocationName -ne '.') {
     Write-Output ("  Stop-Process -Id {0}" -f $commanderPollProcess.Id)
     Write-Output ("  Stop-Process -Id {0},{1}" -f $watchdogProcess.Id, $serverWatchdogProcess.Id)
 } catch {
+    Write-Warning "STARTUP ERROR: $($_.Exception.Message)"
+    Write-Warning "AT: $($_.ScriptStackTrace)"
     if ($null -ne $commanderPollProcess) {
         try { Stop-Process -Id $commanderPollProcess.Id -Force -ErrorAction SilentlyContinue } catch {}
     }

--- a/winsmux-core/scripts/orchestra-state.ps1
+++ b/winsmux-core/scripts/orchestra-state.ps1
@@ -1,0 +1,493 @@
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+. (Join-Path $PSScriptRoot 'manifest.ps1')
+
+function Get-OrchestraStateValue {
+    param(
+        [AllowNull()]$InputObject,
+        [Parameter(Mandatory = $true)][string]$Name,
+        $Default = $null
+    )
+
+    if ($null -eq $InputObject) {
+        return $Default
+    }
+
+    if ($InputObject -is [System.Collections.IDictionary] -and $InputObject.Contains($Name)) {
+        return $InputObject[$Name]
+    }
+
+    if ($null -ne $InputObject.PSObject -and $InputObject.PSObject.Properties.Name -contains $Name) {
+        return $InputObject.$Name
+    }
+
+    return $Default
+}
+
+function ConvertTo-OrchestraStatePropertyMap {
+    param([AllowNull()]$Value)
+
+    $result = [ordered]@{}
+    if ($null -eq $Value) {
+        return $result
+    }
+
+    if ($Value -is [System.Collections.Specialized.OrderedDictionary]) {
+        foreach ($key in $Value.Keys) {
+            $result[[string]$key] = $Value[$key]
+        }
+
+        return $result
+    }
+
+    if ($Value -is [System.Collections.IDictionary]) {
+        foreach ($entry in $Value.GetEnumerator()) {
+            $result[[string]$entry.Key] = $entry.Value
+        }
+
+        return $result
+    }
+
+    if ($null -ne $Value.PSObject) {
+        foreach ($property in $Value.PSObject.Properties) {
+            $result[$property.Name] = $property.Value
+        }
+    }
+
+    return $result
+}
+
+function ConvertTo-OrchestraStringArray {
+    param([AllowNull()]$Value)
+
+    if ($null -eq $Value) {
+        return @()
+    }
+
+    if ($Value -is [string]) {
+        if ([string]::IsNullOrWhiteSpace($Value)) {
+            return @()
+        }
+
+        return @($Value)
+    }
+
+    if ($Value -is [System.Collections.IEnumerable] -and -not ($Value -is [System.Collections.IDictionary])) {
+        return @($Value | ForEach-Object {
+            if ($null -ne $_ -and -not [string]::IsNullOrWhiteSpace([string]$_)) {
+                [string]$_
+            }
+        })
+    }
+
+    return @([string]$Value)
+}
+
+function ConvertFrom-OrchestraQueueEntry {
+    param([Parameter(Mandatory = $true)][string]$Entry)
+
+    if ($Entry -match '^id=(.*?);builder=(.*?);task=(.*)$') {
+        return [ordered]@{
+            task_id       = $Matches[1]
+            builder_label = $Matches[2]
+            task_text     = [System.Uri]::UnescapeDataString($Matches[3])
+            raw_entry     = $Entry
+        }
+    }
+
+    if ($Entry -match '^builder=(.*?);task=(.*)$') {
+        return [ordered]@{
+            task_id       = ''
+            builder_label = $Matches[1]
+            task_text     = [System.Uri]::UnescapeDataString($Matches[2])
+            raw_entry     = $Entry
+        }
+    }
+
+    return [ordered]@{
+        task_id       = ''
+        builder_label = ''
+        task_text     = $Entry
+        raw_entry     = $Entry
+    }
+}
+
+function Get-OrchestraTaskAssignments {
+    param([AllowNull()]$Manifest)
+
+    $assignments = [ordered]@{}
+    if ($null -eq $Manifest) {
+        return $assignments
+    }
+
+    $tasks = Get-OrchestraStateValue -InputObject $Manifest -Name 'tasks' -Default $null
+    if ($null -eq $tasks) {
+        return $assignments
+    }
+
+    foreach ($stateName in @('queued', 'in_progress', 'completed')) {
+        $entries = @(Get-OrchestraStateValue -InputObject $tasks -Name $stateName -Default @())
+        foreach ($entry in $entries) {
+            $parsed = ConvertFrom-OrchestraQueueEntry -Entry ([string]$entry)
+            $builderLabel = [string](Get-OrchestraStateValue -InputObject $parsed -Name 'builder_label' -Default '')
+            if ([string]::IsNullOrWhiteSpace($builderLabel)) {
+                continue
+            }
+
+            if (-not $assignments.Contains($builderLabel)) {
+                $assignments[$builderLabel] = [ordered]@{
+                    queued      = @()
+                    in_progress = @()
+                    completed   = @()
+                }
+            }
+
+            $bucket = $assignments[$builderLabel]
+            $bucket[$stateName] = @($bucket[$stateName]) + @($parsed)
+        }
+    }
+
+    return $assignments
+}
+
+function Get-OrchestraReviewStatePath {
+    param([string]$ProjectDir = (Get-Location).Path)
+
+    return Join-Path (Join-Path $ProjectDir '.winsmux') 'review-state.json'
+}
+
+function Get-OrchestraReviewState {
+    param([string]$ProjectDir = (Get-Location).Path)
+
+    $path = Get-OrchestraReviewStatePath -ProjectDir $ProjectDir
+    if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
+        return [ordered]@{}
+    }
+
+    $raw = Get-Content -LiteralPath $path -Raw -Encoding UTF8
+    if ([string]::IsNullOrWhiteSpace($raw)) {
+        return [ordered]@{}
+    }
+
+    try {
+        $parsed = $raw | ConvertFrom-Json -AsHashtable -ErrorAction Stop
+        $ordered = [ordered]@{}
+        foreach ($key in $parsed.Keys) {
+            $ordered[[string]$key] = $parsed[$key]
+        }
+
+        return $ordered
+    } catch {
+        return [ordered]@{}
+    }
+}
+
+function Get-OrchestraGitOutput {
+    param(
+        [Parameter(Mandatory = $true)][string]$WorktreePath,
+        [Parameter(Mandatory = $true)][string[]]$Arguments
+    )
+
+    if ([string]::IsNullOrWhiteSpace($WorktreePath) -or -not (Test-Path -LiteralPath $WorktreePath -PathType Container)) {
+        return @()
+    }
+
+    $output = & git -C $WorktreePath @Arguments 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        return @()
+    }
+
+    return @($output | ForEach-Object { [string]$_ } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+}
+
+function Get-OrchestraGitSnapshot {
+    param([string]$WorktreePath)
+
+    $branch = ''
+    $headSha = ''
+    $changedFiles = @()
+
+    $branchLines = @(Get-OrchestraGitOutput -WorktreePath $WorktreePath -Arguments @('rev-parse', '--abbrev-ref', 'HEAD'))
+    if ($branchLines.Count -gt 0) {
+        $branch = [string]$branchLines[0]
+        if ($branch -eq 'HEAD') {
+            $branch = ''
+        }
+    }
+
+    $headLines = @(Get-OrchestraGitOutput -WorktreePath $WorktreePath -Arguments @('rev-parse', 'HEAD'))
+    if ($headLines.Count -gt 0) {
+        $headSha = [string]$headLines[0]
+    }
+
+    $statusLines = @(Get-OrchestraGitOutput -WorktreePath $WorktreePath -Arguments @('status', '--short', '--untracked-files=all'))
+    foreach ($statusLine in $statusLines) {
+        $trimmed = $statusLine.Trim()
+        if ($trimmed -match '^[A-Z\?\! ]{1,2}\s+(.+)$') {
+            $changedFiles += @($Matches[1].Trim())
+        } elseif (-not [string]::IsNullOrWhiteSpace($trimmed)) {
+            $changedFiles += @($trimmed)
+        }
+    }
+
+    return [ordered]@{
+        branch             = $branch
+        head_sha           = $headSha
+        changed_file_count = @($changedFiles).Count
+        changed_files      = @($changedFiles)
+    }
+}
+
+function Get-OrchestraPaneReviewRecord {
+    param(
+        [Parameter(Mandatory = $true)][System.Collections.IDictionary]$ReviewState,
+        [string]$Branch,
+        [string]$Label,
+        [string]$PaneId,
+        [string]$Role
+    )
+
+    if (-not [string]::IsNullOrWhiteSpace($Branch) -and $ReviewState.Contains($Branch)) {
+        return $ReviewState[$Branch]
+    }
+
+    if ($Role -ne 'Reviewer') {
+        return $null
+    }
+
+    foreach ($branchKey in $ReviewState.Keys) {
+        $entry = $ReviewState[$branchKey]
+        $request = Get-OrchestraStateValue -InputObject $entry -Name 'request' -Default $null
+        if ($null -eq $request) {
+            continue
+        }
+
+        $targetLabel = [string](Get-OrchestraStateValue -InputObject $request -Name 'target_reviewer_label' -Default '')
+        $targetPaneId = [string](Get-OrchestraStateValue -InputObject $request -Name 'target_reviewer_pane_id' -Default '')
+        if ($targetLabel -eq $Label -or $targetPaneId -eq $PaneId) {
+            return $entry
+        }
+    }
+
+    return $null
+}
+
+function Get-OrchestraPaneStateModel {
+    param(
+        [Parameter(Mandatory = $true)][string]$Label,
+        [Parameter(Mandatory = $true)]$Pane,
+        [Parameter(Mandatory = $true)][System.Collections.IDictionary]$TaskAssignments,
+        [Parameter(Mandatory = $true)][System.Collections.IDictionary]$ReviewState
+    )
+
+    $role = [string](Get-OrchestraStateValue -InputObject $Pane -Name 'role' -Default '')
+    $paneId = [string](Get-OrchestraStateValue -InputObject $Pane -Name 'pane_id' -Default '')
+    $builderBranch = [string](Get-OrchestraStateValue -InputObject $Pane -Name 'builder_branch' -Default '')
+    $worktreePath = [string](Get-OrchestraStateValue -InputObject $Pane -Name 'builder_worktree_path' -Default '')
+    if ([string]::IsNullOrWhiteSpace($worktreePath)) {
+        $worktreePath = [string](Get-OrchestraStateValue -InputObject $Pane -Name 'launch_dir' -Default '')
+    }
+
+    $gitSnapshot = Get-OrchestraGitSnapshot -WorktreePath $worktreePath
+    $branch = if ([string]::IsNullOrWhiteSpace($builderBranch)) {
+        [string](Get-OrchestraStateValue -InputObject $gitSnapshot -Name 'branch' -Default '')
+    } else {
+        $builderBranch
+    }
+
+    $taskId = ''
+    $taskText = ''
+    $taskState = ''
+    $taskQueueDepth = 0
+
+    if ($TaskAssignments.Contains($Label)) {
+        $taskBucket = $TaskAssignments[$Label]
+        $queuedEntries = @($taskBucket['queued'])
+        $inProgressEntries = @($taskBucket['in_progress'])
+        $completedEntries = @($taskBucket['completed'])
+        $taskQueueDepth = $queuedEntries.Count
+
+        $selectedTask = $null
+        if ($inProgressEntries.Count -gt 0) {
+            $taskState = 'in_progress'
+            $selectedTask = $inProgressEntries[0]
+        } elseif ($queuedEntries.Count -gt 0) {
+            $taskState = 'queued'
+            $selectedTask = $queuedEntries[0]
+        } elseif ($completedEntries.Count -gt 0) {
+            $taskState = 'completed'
+            $selectedTask = $completedEntries[$completedEntries.Count - 1]
+        }
+
+        if ($null -ne $selectedTask) {
+            $taskId = [string](Get-OrchestraStateValue -InputObject $selectedTask -Name 'task_id' -Default '')
+            $taskText = [string](Get-OrchestraStateValue -InputObject $selectedTask -Name 'task_text' -Default '')
+        }
+    }
+
+    $reviewRecord = Get-OrchestraPaneReviewRecord -ReviewState $ReviewState -Branch $branch -Label $Label -PaneId $paneId -Role $role
+    $reviewStateName = ''
+    if ($null -ne $reviewRecord) {
+        $reviewStateName = [string](Get-OrchestraStateValue -InputObject $reviewRecord -Name 'status' -Default '')
+    }
+
+    $changedFiles = ConvertTo-OrchestraStringArray -Value (Get-OrchestraStateValue -InputObject $gitSnapshot -Name 'changed_files' -Default @())
+
+    return [ordered]@{
+        label          = $Label
+        pane_id        = $paneId
+        role           = $role
+        task_id        = $taskId
+        task           = $taskText
+        task_state     = $taskState
+        task_owner     = $Label
+        branch         = $branch
+        head_sha       = [string](Get-OrchestraStateValue -InputObject $gitSnapshot -Name 'head_sha' -Default '')
+        changed_file_count = [int](Get-OrchestraStateValue -InputObject $gitSnapshot -Name 'changed_file_count' -Default 0)
+        changed_files  = $changedFiles
+        review_state   = $reviewStateName
+        last_event     = [string](Get-OrchestraStateValue -InputObject $Pane -Name 'last_event' -Default '')
+        last_event_at  = [string](Get-OrchestraStateValue -InputObject $Pane -Name 'last_event_at' -Default '')
+        task_queue_depth = $taskQueueDepth
+    }
+}
+
+function Get-OrchestraPaneStateModels {
+    param(
+        [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [AllowNull()]$Manifest = $null
+    )
+
+    if ($null -eq $Manifest) {
+        $Manifest = Get-WinsmuxManifest -ProjectDir $ProjectDir
+    }
+
+    $models = [ordered]@{}
+    if ($null -eq $Manifest) {
+        return $models
+    }
+
+    $taskAssignments = Get-OrchestraTaskAssignments -Manifest $Manifest
+    $reviewState = Get-OrchestraReviewState -ProjectDir $ProjectDir
+    $panes = ConvertTo-OrchestraStatePropertyMap -Value (Get-OrchestraStateValue -InputObject $Manifest -Name 'panes' -Default ([ordered]@{}))
+
+    foreach ($label in $panes.Keys) {
+        $models[$label] = Get-OrchestraPaneStateModel -Label ([string]$label) -Pane $panes[$label] -TaskAssignments $taskAssignments -ReviewState $reviewState
+    }
+
+    return $models
+}
+
+function Get-OrchestraPaneStateModelFromCollection {
+    param(
+        [AllowNull()][System.Collections.IDictionary]$StateModels,
+        [string]$Label,
+        [string]$PaneId
+    )
+
+    if ($null -eq $StateModels) {
+        return $null
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($Label) -and $StateModels.Contains($Label)) {
+        return $StateModels[$Label]
+    }
+
+    foreach ($key in $StateModels.Keys) {
+        $candidate = $StateModels[$key]
+        if ([string](Get-OrchestraStateValue -InputObject $candidate -Name 'pane_id' -Default '') -eq $PaneId) {
+            return $candidate
+        }
+    }
+
+    return $null
+}
+
+function ConvertTo-OrchestraPaneManifestProperties {
+    param([Parameter(Mandatory = $true)]$StateModel)
+
+    $changedFiles = ConvertTo-OrchestraStringArray -Value (Get-OrchestraStateValue -InputObject $StateModel -Name 'changed_files' -Default @())
+
+    return [ordered]@{
+        task_id            = [string](Get-OrchestraStateValue -InputObject $StateModel -Name 'task_id' -Default '')
+        task               = [string](Get-OrchestraStateValue -InputObject $StateModel -Name 'task' -Default '')
+        task_state         = [string](Get-OrchestraStateValue -InputObject $StateModel -Name 'task_state' -Default '')
+        task_owner         = [string](Get-OrchestraStateValue -InputObject $StateModel -Name 'task_owner' -Default '')
+        review_state       = [string](Get-OrchestraStateValue -InputObject $StateModel -Name 'review_state' -Default '')
+        branch             = [string](Get-OrchestraStateValue -InputObject $StateModel -Name 'branch' -Default '')
+        head_sha           = [string](Get-OrchestraStateValue -InputObject $StateModel -Name 'head_sha' -Default '')
+        changed_file_count = [string](Get-OrchestraStateValue -InputObject $StateModel -Name 'changed_file_count' -Default 0)
+        changed_files      = $changedFiles
+        last_event         = [string](Get-OrchestraStateValue -InputObject $StateModel -Name 'last_event' -Default '')
+        last_event_at      = [string](Get-OrchestraStateValue -InputObject $StateModel -Name 'last_event_at' -Default '')
+    }
+}
+
+function Merge-OrchestraPaneEventData {
+    param(
+        [AllowNull()]$StateModel,
+        [AllowNull()]$Data = $null
+    )
+
+    $merged = ConvertTo-OrchestraStatePropertyMap -Value $Data
+    if ($null -eq $StateModel) {
+        return $merged
+    }
+
+    $merged['task'] = [ordered]@{
+        id    = [string](Get-OrchestraStateValue -InputObject $StateModel -Name 'task_id' -Default '')
+        text  = [string](Get-OrchestraStateValue -InputObject $StateModel -Name 'task' -Default '')
+        state = [string](Get-OrchestraStateValue -InputObject $StateModel -Name 'task_state' -Default '')
+        owner = [string](Get-OrchestraStateValue -InputObject $StateModel -Name 'task_owner' -Default '')
+    }
+    $merged['git'] = [ordered]@{
+        branch             = [string](Get-OrchestraStateValue -InputObject $StateModel -Name 'branch' -Default '')
+        head_sha           = [string](Get-OrchestraStateValue -InputObject $StateModel -Name 'head_sha' -Default '')
+        changed_file_count = [int](Get-OrchestraStateValue -InputObject $StateModel -Name 'changed_file_count' -Default 0)
+        changed_files      = ConvertTo-OrchestraStringArray -Value (Get-OrchestraStateValue -InputObject $StateModel -Name 'changed_files' -Default @())
+    }
+    $merged['review'] = [ordered]@{
+        state = [string](Get-OrchestraStateValue -InputObject $StateModel -Name 'review_state' -Default '')
+    }
+
+    return $merged
+}
+
+function Sync-OrchestraPaneStateModels {
+    param(
+        [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [AllowNull()]$Manifest = $null
+    )
+
+    if ($null -eq $Manifest) {
+        $Manifest = Get-WinsmuxManifest -ProjectDir $ProjectDir
+    }
+
+    $models = Get-OrchestraPaneStateModels -ProjectDir $ProjectDir -Manifest $Manifest
+    if ($null -eq $Manifest) {
+        return $models
+    }
+
+    $panes = ConvertTo-OrchestraStatePropertyMap -Value (Get-OrchestraStateValue -InputObject $Manifest -Name 'panes' -Default ([ordered]@{}))
+    foreach ($label in $panes.Keys) {
+        $paneMap = ConvertTo-ManifestPropertyMap -Value $panes[$label]
+        $stateModel = Get-OrchestraPaneStateModelFromCollection -StateModels $models -Label ([string]$label)
+        if ($null -eq $stateModel) {
+            continue
+        }
+
+        $properties = ConvertTo-OrchestraPaneManifestProperties -StateModel $stateModel
+        foreach ($propertyName in $properties.Keys) {
+            $paneMap[$propertyName] = $properties[$propertyName]
+        }
+
+        $Manifest.panes[$label] = [ordered]@{}
+        foreach ($propertyName in $paneMap.Keys) {
+            $Manifest.panes[$label][$propertyName] = $paneMap[$propertyName]
+        }
+    }
+
+    Save-WinsmuxManifest -ProjectDir $ProjectDir -Manifest $Manifest
+    return $models
+}

--- a/winsmux-core/scripts/pane-control.ps1
+++ b/winsmux-core/scripts/pane-control.ps1
@@ -1,3 +1,5 @@
+ . (Join-Path $PSScriptRoot 'manifest.ps1')
+
 function ConvertFrom-PaneControlYamlScalar {
     param([AllowNull()]$Value)
 
@@ -40,6 +42,66 @@ function ConvertTo-PaneControlYamlScalar {
     }
 
     return "'" + $text.Replace("'", "''") + "'"
+}
+
+function Get-PaneControlValue {
+    param(
+        [AllowNull()]$InputObject,
+        [Parameter(Mandatory = $true)][string]$Name,
+        $Default = $null
+    )
+
+    if ($null -eq $InputObject) {
+        return $Default
+    }
+
+    if ($InputObject -is [System.Collections.IDictionary] -and $InputObject.Contains($Name)) {
+        return $InputObject[$Name]
+    }
+
+    if ($null -ne $InputObject.PSObject -and $InputObject.PSObject.Properties.Name -contains $Name) {
+        return $InputObject.$Name
+    }
+
+    return $Default
+}
+
+function ConvertFrom-PaneControlChangedFiles {
+    param([AllowNull()]$Value)
+
+    $normalize = {
+        param($Items)
+
+        return @(
+            @($Items) |
+                Where-Object { $null -ne $_ -and -not [string]::IsNullOrWhiteSpace([string]$_) } |
+                ForEach-Object { [string]$_ }
+        )
+    }
+
+    if ($null -eq $Value) {
+        return @()
+    }
+
+    if ($Value -is [System.Array]) {
+        return & $normalize $Value
+    }
+
+    $text = [string]$Value
+    if ([string]::IsNullOrWhiteSpace($text)) {
+        return @()
+    }
+
+    try {
+        $parsed = $text | ConvertFrom-Json -ErrorAction Stop
+        if ($parsed -is [System.Array]) {
+            return & $normalize $parsed
+        }
+
+        return & $normalize @($parsed)
+    } catch {
+        return & $normalize @($text)
+    }
 }
 
 function Get-PaneControlCanonicalRole {
@@ -108,82 +170,13 @@ function Get-PaneControlLaunchCommand {
 function ConvertFrom-PaneControlManifestContent {
     param([Parameter(Mandatory = $true)][string]$Content)
 
-    $manifest = [ordered]@{
-        Session = [ordered]@{}
-        Panes   = [ordered]@{}
+    $parsed = ConvertFrom-ManifestYaml -Content $Content
+    return [ordered]@{
+        Session = $parsed.session
+        Panes   = $parsed.panes
+        Tasks   = $parsed.tasks
+        Worktrees = $parsed.worktrees
     }
-
-    $section = $null
-    $currentPane = $null
-
-    function Save-PaneControlPane {
-        param($Pane)
-
-        if ($null -eq $Pane) {
-            return
-        }
-
-        $label = [string]$Pane.label
-        if ([string]::IsNullOrWhiteSpace($label)) {
-            return
-        }
-
-        $paneObject = [ordered]@{}
-        foreach ($property in $Pane.GetEnumerator()) {
-            $paneObject[[string]$property.Key] = $property.Value
-        }
-
-        $manifest.Panes[$label] = $paneObject
-    }
-
-    foreach ($rawLine in ($Content -split "\r?\n")) {
-        $line = $rawLine.TrimEnd()
-        if ([string]::IsNullOrWhiteSpace($line) -or $line -match '^\s*#') {
-            continue
-        }
-
-        if ($line -match '^(session|panes):\s*$') {
-            if ($section -eq 'panes') {
-                Save-PaneControlPane -Pane $currentPane
-                $currentPane = $null
-            }
-
-            $section = $Matches[1]
-            continue
-        }
-
-        if ($section -eq 'session' -and $line -match '^\s{2}([A-Za-z0-9_.-]+):\s*(.*?)\s*$') {
-            $manifest.Session[$Matches[1]] = ConvertFrom-PaneControlYamlScalar $Matches[2]
-            continue
-        }
-
-        if ($section -ne 'panes') {
-            continue
-        }
-
-        if ($line -match '^\s{2}-\s+label:\s*(.*?)\s*$') {
-            Save-PaneControlPane -Pane $currentPane
-            $currentPane = [ordered]@{
-                label = ConvertFrom-PaneControlYamlScalar $Matches[1]
-            }
-            continue
-        }
-
-        if ($line -match '^\s{2}(.+?):\s*$') {
-            Save-PaneControlPane -Pane $currentPane
-            $currentPane = [ordered]@{
-                label = ConvertFrom-PaneControlYamlScalar $Matches[1]
-            }
-            continue
-        }
-
-        if ($null -ne $currentPane -and $line -match '^\s{4}([A-Za-z0-9_.-]+):\s*(.*?)\s*$') {
-            $currentPane[$Matches[1]] = ConvertFrom-PaneControlYamlScalar $Matches[2]
-        }
-    }
-
-    Save-PaneControlPane -Pane $currentPane
-    return $manifest
 }
 
 function Get-PaneControlManifestEntries {
@@ -200,19 +193,19 @@ function Get-PaneControlManifestEntries {
     }
 
     $manifest = ConvertFrom-PaneControlManifestContent -Content $content
-    $projectRoot = [string]$manifest.Session.project_dir
+    $projectRoot = [string](Get-PaneControlValue -InputObject $manifest.Session -Name 'project_dir' -Default '')
     if ([string]::IsNullOrWhiteSpace($projectRoot)) {
         $projectRoot = $ProjectDir
     }
 
-    $sessionGitWorktreeDir = [string]$manifest.Session.git_worktree_dir
+    $sessionGitWorktreeDir = [string](Get-PaneControlValue -InputObject $manifest.Session -Name 'git_worktree_dir' -Default '')
     $entries = @()
 
     foreach ($label in $manifest.Panes.Keys) {
         $pane = $manifest.Panes[$label]
-        $role = Get-PaneControlCanonicalRole -Role ([string]$pane.role) -Label $label
-        $launchDir = [string]$pane.launch_dir
-        $builderWorktreePath = [string]$pane.builder_worktree_path
+        $role = Get-PaneControlCanonicalRole -Role ([string](Get-PaneControlValue -InputObject $pane -Name 'role' -Default '')) -Label $label
+        $launchDir = [string](Get-PaneControlValue -InputObject $pane -Name 'launch_dir' -Default '')
+        $builderWorktreePath = [string](Get-PaneControlValue -InputObject $pane -Name 'builder_worktree_path' -Default '')
 
         if ([string]::IsNullOrWhiteSpace($launchDir) -and -not [string]::IsNullOrWhiteSpace($builderWorktreePath)) {
             $launchDir = $builderWorktreePath
@@ -231,11 +224,22 @@ function Get-PaneControlManifestEntries {
             ManifestPath        = $manifestPath
             ProjectDir          = $projectRoot
             Label               = $label
-            PaneId              = [string]$pane.pane_id
+            PaneId              = [string](Get-PaneControlValue -InputObject $pane -Name 'pane_id' -Default '')
             Role                = $role
             LaunchDir           = $launchDir
             BuilderWorktreePath = $builderWorktreePath
             GitWorktreeDir      = $gitWorktreeDir
+            TaskId              = [string](Get-PaneControlValue -InputObject $pane -Name 'task_id' -Default '')
+            Task                = [string](Get-PaneControlValue -InputObject $pane -Name 'task' -Default '')
+            TaskState           = [string](Get-PaneControlValue -InputObject $pane -Name 'task_state' -Default '')
+            TaskOwner           = [string](Get-PaneControlValue -InputObject $pane -Name 'task_owner' -Default '')
+            ReviewState         = [string](Get-PaneControlValue -InputObject $pane -Name 'review_state' -Default '')
+            Branch              = [string](Get-PaneControlValue -InputObject $pane -Name 'branch' -Default '')
+            HeadSha             = [string](Get-PaneControlValue -InputObject $pane -Name 'head_sha' -Default '')
+            ChangedFileCount    = [int](Get-PaneControlValue -InputObject $pane -Name 'changed_file_count' -Default 0)
+            ChangedFiles        = @(ConvertFrom-PaneControlChangedFiles -Value (Get-PaneControlValue -InputObject $pane -Name 'changed_files' -Default @()))
+            LastEvent           = [string](Get-PaneControlValue -InputObject $pane -Name 'last_event' -Default '')
+            LastEventAt         = [string](Get-PaneControlValue -InputObject $pane -Name 'last_event_at' -Default '')
         }
     }
 
@@ -272,147 +276,47 @@ function Set-PaneControlManifestPaneProperties {
         throw "Manifest not found: $ManifestPath"
     }
 
-    $lines = @(Get-Content -Path $ManifestPath -Encoding UTF8)
-    $inPanesSection = $false
-    $currentPane = $null
-    $paneBlocks = [System.Collections.Generic.List[object]]::new()
-
-    function Add-PaneControlPaneBlock {
-        param($PaneBlock)
-
-        if ($null -eq $PaneBlock) {
-            return
-        }
-
-        if ([string]::IsNullOrWhiteSpace([string]$PaneBlock.PaneId) -and [string]::IsNullOrWhiteSpace([string]$PaneBlock.Label)) {
-            return
-        }
-
-        $paneBlocks.Add([ordered]@{
-            Label  = [string]$PaneBlock.Label
-            PaneId = [string]$PaneBlock.PaneId
-            Start  = [int]$PaneBlock.Start
-            End    = [int]$PaneBlock.End
-            IsList = [bool]$PaneBlock.IsList
-        }) | Out-Null
-    }
-
-    for ($index = 0; $index -lt $lines.Count; $index++) {
-        $line = $lines[$index]
-
-        if (-not $inPanesSection) {
-            if ($line -match '^panes:\s*$') {
-                $inPanesSection = $true
-            }
-
-            continue
-        }
-
-        if ($line -match '^[A-Za-z0-9_.-]+:\s*$') {
-            if ($null -ne $currentPane) {
-                $currentPane['End'] = $index - 1
-                Add-PaneControlPaneBlock -PaneBlock $currentPane
-                $currentPane = $null
-            }
-
-            break
-        }
-
-        if ($line -match '^\s{2}-\s+label:\s*(.*?)\s*$') {
-            if ($null -ne $currentPane) {
-                $currentPane['End'] = $index - 1
-                Add-PaneControlPaneBlock -PaneBlock $currentPane
-            }
-
-            $currentPane = [ordered]@{
-                Label  = ConvertFrom-PaneControlYamlScalar $Matches[1]
-                PaneId = ''
-                Start  = $index
-                End    = $index
-                IsList = $true
-            }
-            continue
-        }
-
-        if ($line -match '^\s{2}([^:\s][^:]*):\s*$') {
-            if ($null -ne $currentPane) {
-                $currentPane['End'] = $index - 1
-                Add-PaneControlPaneBlock -PaneBlock $currentPane
-            }
-
-            $currentPane = [ordered]@{
-                Label  = ConvertFrom-PaneControlYamlScalar $Matches[1]
-                PaneId = ''
-                Start  = $index
-                End    = $index
-                IsList = $false
-            }
-            continue
-        }
-
-        if ($null -ne $currentPane -and $line -match '^\s{4}pane_id:\s*(.*?)\s*$') {
-            $currentPane['PaneId'] = ConvertFrom-PaneControlYamlScalar $Matches[1]
-            continue
-        }
-    }
-
-    if ($null -ne $currentPane) {
-        $currentPane['End'] = $lines.Count - 1
-        Add-PaneControlPaneBlock -PaneBlock $currentPane
-    }
-
-    $paneBlock = $paneBlocks | Where-Object { $_.PaneId -eq $PaneId } | Select-Object -First 1
-    if ($null -eq $paneBlock) {
+    $projectDir = Split-Path (Split-Path $ManifestPath -Parent) -Parent
+    $manifest = Get-WinsmuxManifest -ProjectDir $projectDir
+    if ($null -eq $manifest) {
         throw "Pane $PaneId was not found in manifest: $ManifestPath"
     }
 
-    $updatedBlockLines = [System.Collections.Generic.List[string]]::new()
-    $pendingProperties = [ordered]@{}
-    foreach ($entry in $Properties.GetEnumerator()) {
-        $pendingProperties[[string]$entry.Key] = $entry.Value
-    }
-
-    foreach ($blockLine in @($lines[$paneBlock.Start..$paneBlock.End])) {
-        if ($pendingProperties.Contains('label')) {
-            if ($blockLine -match '^\s{2}-\s+label:\s*(.*?)\s*$') {
-                $updatedValue = ConvertTo-PaneControlYamlScalar -Value $pendingProperties['label']
-                $updatedBlockLines.Add("  - label: $updatedValue") | Out-Null
-                $pendingProperties.Remove('label')
-                continue
-            }
-
-            if (-not $paneBlock.IsList -and $blockLine -match '^\s{2}([^:\s][^:]*):\s*$') {
-                $updatedValue = ConvertTo-PaneControlYamlScalar -Value $pendingProperties['label']
-                $updatedBlockLines.Add("  ${updatedValue}:") | Out-Null
-                $pendingProperties.Remove('label')
-                continue
-            }
+    $originalLabel = $null
+    $updatedPanes = [ordered]@{}
+    foreach ($label in $manifest.panes.Keys) {
+        $pane = $manifest.panes[$label]
+        if ([string]$pane.pane_id -ne $PaneId) {
+            $updatedPanes[$label] = $pane
+            continue
         }
 
-        if ($blockLine -match '^\s{4}([A-Za-z0-9_.-]+):\s*(.*?)\s*$') {
-            $propertyName = $Matches[1]
-            if ($pendingProperties.Contains($propertyName)) {
-                $updatedValue = ConvertTo-PaneControlYamlScalar -Value $pendingProperties[$propertyName]
-                $updatedBlockLines.Add("    ${propertyName}: $updatedValue") | Out-Null
-                $pendingProperties.Remove($propertyName)
-                continue
-            }
+        $originalLabel = $label
+        $newLabel = if ($Properties.Contains('label')) { [string]$Properties['label'] } else { $label }
+        $updatedPane = [ordered]@{}
+        $paneMap = ConvertTo-ManifestPropertyMap -Value $pane
+        foreach ($propertyName in $paneMap.Keys) {
+            $updatedPane[$propertyName] = $paneMap[$propertyName]
         }
 
-        $updatedBlockLines.Add($blockLine) | Out-Null
+        foreach ($entry in $Properties.GetEnumerator()) {
+            $propertyName = [string]$entry.Key
+            if ($propertyName -eq 'label') {
+                continue
+            }
+
+            $updatedPane[$propertyName] = $entry.Value
+        }
+
+        $updatedPanes[$newLabel] = [PSCustomObject]$updatedPane
     }
 
-    foreach ($propertyName in $pendingProperties.Keys) {
-        $updatedValue = ConvertTo-PaneControlYamlScalar -Value $pendingProperties[$propertyName]
-        $updatedBlockLines.Add("    ${propertyName}: $updatedValue") | Out-Null
+    if ($null -eq $originalLabel) {
+        throw "Pane $PaneId was not found in manifest: $ManifestPath"
     }
 
-    $before = if ($paneBlock.Start -gt 0) { @($lines[0..($paneBlock.Start - 1)]) } else { @() }
-    $after = if ($paneBlock.End + 1 -lt $lines.Count) { @($lines[($paneBlock.End + 1)..($lines.Count - 1)]) } else { @() }
-    $updatedLines = @($before + @($updatedBlockLines) + $after)
-    $updatedContent = ($updatedLines -join [Environment]::NewLine)
-    $quotedManifestPath = '"' + $ManifestPath.Replace('"', '""') + '"'
-    $updatedContent | cmd /d /c "more > $quotedManifestPath" | Out-Null
+    $manifest.panes = $updatedPanes
+    Save-WinsmuxManifest -ProjectDir $projectDir -Manifest $manifest
 }
 
 function Get-PaneControlPaneTitle {

--- a/winsmux-core/scripts/pane-scaler.ps1
+++ b/winsmux-core/scripts/pane-scaler.ps1
@@ -5,6 +5,8 @@ $scriptDir = $PSScriptRoot
 . (Join-Path $scriptDir 'settings.ps1')
 . (Join-Path $scriptDir 'agent-monitor.ps1')
 . (Join-Path $scriptDir 'builder-worktree.ps1')
+. (Join-Path $scriptDir 'clm-safe-io.ps1')
+. (Join-Path $scriptDir 'manifest.ps1')
 
 function ConvertFrom-PaneScalerYamlScalar {
     param([AllowNull()]$Value)
@@ -80,85 +82,21 @@ function Read-PaneScalerManifest {
         throw "Manifest is empty: $ManifestPath"
     }
 
+    $parsed = ConvertFrom-ManifestYaml -Content $content
     $manifest = [PSCustomObject]@{
-        Version = 1
-        SavedAt = ''
-        Session = [ordered]@{}
-        Panes   = [ordered]@{}
+        version   = $parsed.version
+        saved_at  = $parsed.saved_at
+        session   = $parsed.session
+        panes     = $parsed.panes
+        tasks     = $parsed.tasks
+        worktrees = $parsed.worktrees
     }
-
-    $section = ''
-    $currentPane = $null
-
-    function Save-PaneScalerPane {
-        param($Pane)
-
-        if ($null -eq $Pane) {
-            return
-        }
-
-        $label = [string]$Pane.label
-        if ([string]::IsNullOrWhiteSpace($label)) {
-            return
-        }
-
-        $paneObject = [PSCustomObject]@{}
-        foreach ($entry in $Pane.GetEnumerator()) {
-            Add-Member -InputObject $paneObject -MemberType NoteProperty -Name $entry.Key -Value $entry.Value
-        }
-
-        $manifest.Panes[$label] = $paneObject
-    }
-
-    foreach ($rawLine in ($content -split "\r?\n")) {
-        $line = $rawLine.TrimEnd()
-        if ([string]::IsNullOrWhiteSpace($line) -or $line -match '^\s*#') {
-            continue
-        }
-
-        if ($line -match '^version:\s*(.+?)\s*$') {
-            $manifest.Version = [int](ConvertFrom-PaneScalerYamlScalar $Matches[1])
-            continue
-        }
-
-        if ($line -match '^saved_at:\s*(.*?)\s*$') {
-            $manifest.SavedAt = [string](ConvertFrom-PaneScalerYamlScalar $Matches[1])
-            continue
-        }
-
-        if ($line -match '^(session|panes):\s*$') {
-            if ($section -eq 'panes') {
-                Save-PaneScalerPane -Pane $currentPane
-                $currentPane = $null
-            }
-
-            $section = $Matches[1]
-            continue
-        }
-
-        if ($section -eq 'session' -and $line -match '^\s{2}([A-Za-z0-9_.-]+):\s*(.*?)\s*$') {
-            $manifest.Session[$Matches[1]] = ConvertFrom-PaneScalerYamlScalar $Matches[2]
-            continue
-        }
-
-        if ($section -ne 'panes') {
-            continue
-        }
-
-        if ($line -match '^\s{2}-\s+label:\s*(.*?)\s*$') {
-            Save-PaneScalerPane -Pane $currentPane
-            $currentPane = [ordered]@{
-                label = ConvertFrom-PaneScalerYamlScalar $Matches[1]
-            }
-            continue
-        }
-
-        if ($null -ne $currentPane -and $line -match '^\s{4}([A-Za-z0-9_.-]+):\s*(.*?)\s*$') {
-            $currentPane[$Matches[1]] = ConvertFrom-PaneScalerYamlScalar $Matches[2]
-        }
-    }
-
-    Save-PaneScalerPane -Pane $currentPane
+    $manifest | Add-Member -NotePropertyName 'Version' -NotePropertyValue $parsed.version -Force
+    $manifest | Add-Member -NotePropertyName 'SavedAt' -NotePropertyValue $parsed.saved_at -Force
+    $manifest | Add-Member -NotePropertyName 'Session' -NotePropertyValue $parsed.session -Force
+    $manifest | Add-Member -NotePropertyName 'Panes' -NotePropertyValue $parsed.panes -Force
+    $manifest | Add-Member -NotePropertyName 'Tasks' -NotePropertyValue $parsed.tasks -Force
+    $manifest | Add-Member -NotePropertyName 'Worktrees' -NotePropertyValue $parsed.worktrees -Force
     return $manifest
 }
 
@@ -168,42 +106,23 @@ function Save-PaneScalerManifest {
         [Parameter(Mandatory = $true)]$Manifest
     )
 
-    $lines = [System.Collections.Generic.List[string]]::new()
-    $lines.Add("version: $($Manifest.Version)") | Out-Null
-
-    $savedAt = if ([string]::IsNullOrWhiteSpace([string]$Manifest.SavedAt)) {
-        Get-Date -Format o
-    } else {
-        [string]$Manifest.SavedAt
-    }
-    $lines.Add(("saved_at: {0}" -f (ConvertTo-PaneScalerYamlScalar -Value $savedAt))) | Out-Null
-
-    $lines.Add('session:') | Out-Null
-    foreach ($entry in $Manifest.Session.GetEnumerator()) {
-        $lines.Add(("  {0}: {1}" -f $entry.Key, (ConvertTo-PaneScalerYamlScalar -Value $entry.Value))) | Out-Null
+    $projectDir = Split-Path (Split-Path $ManifestPath -Parent) -Parent
+    $version = Get-MonitorPropertyValue -InputObject $Manifest -Name 'Version' -Default (Get-MonitorPropertyValue -InputObject $Manifest -Name 'version' -Default 1)
+    $savedAt = Get-MonitorPropertyValue -InputObject $Manifest -Name 'SavedAt' -Default (Get-MonitorPropertyValue -InputObject $Manifest -Name 'saved_at' -Default '')
+    if ([string]::IsNullOrWhiteSpace([string]$savedAt)) {
+        $savedAt = Get-Date -Format o
     }
 
-    $lines.Add('panes:') | Out-Null
-    foreach ($label in $Manifest.Panes.Keys) {
-        $pane = $Manifest.Panes[$label]
-        $lines.Add(("  - label: {0}" -f (ConvertTo-PaneScalerYamlScalar -Value $label))) | Out-Null
-
-        $properties = if ($pane -is [System.Collections.IDictionary]) {
-            @($pane.GetEnumerator() | ForEach-Object { [PSCustomObject]@{ Name = $_.Key; Value = $_.Value } })
-        } else {
-            @($pane.PSObject.Properties | ForEach-Object { [PSCustomObject]@{ Name = $_.Name; Value = $_.Value } })
-        }
-
-        foreach ($property in $properties) {
-            if ($property.Name -eq 'label') {
-                continue
-            }
-
-            $lines.Add(("    {0}: {1}" -f $property.Name, (ConvertTo-PaneScalerYamlScalar -Value $property.Value))) | Out-Null
-        }
+    $canonicalManifest = [PSCustomObject]@{
+        version   = $version
+        saved_at  = [string]$savedAt
+        session   = Get-MonitorPropertyValue -InputObject $Manifest -Name 'Session' -Default (Get-MonitorPropertyValue -InputObject $Manifest -Name 'session' -Default ([PSCustomObject]@{}))
+        panes     = Get-MonitorPropertyValue -InputObject $Manifest -Name 'Panes' -Default (Get-MonitorPropertyValue -InputObject $Manifest -Name 'panes' -Default ([ordered]@{}))
+        tasks     = Get-MonitorPropertyValue -InputObject $Manifest -Name 'Tasks' -Default (Get-MonitorPropertyValue -InputObject $Manifest -Name 'tasks' -Default ([PSCustomObject]@{ queued = @(); in_progress = @(); completed = @() }))
+        worktrees = Get-MonitorPropertyValue -InputObject $Manifest -Name 'Worktrees' -Default (Get-MonitorPropertyValue -InputObject $Manifest -Name 'worktrees' -Default ([ordered]@{}))
     }
 
-    Set-Content -Path $ManifestPath -Value ($lines -join [Environment]::NewLine) -Encoding UTF8 -NoNewline
+    Save-WinsmuxManifest -ProjectDir $projectDir -Manifest $canonicalManifest
 }
 
 function Get-PaneScalerProjectDir {

--- a/winsmux-core/scripts/pane-status.ps1
+++ b/winsmux-core/scripts/pane-status.ps1
@@ -160,6 +160,17 @@ function Get-PaneStatusRecords {
             PaneId          = $entry.PaneId
             State           = $state
             TokensRemaining = Get-PaneTokensRemainingText -Text $snapshot
+            TaskId          = $entry.TaskId
+            Task            = $entry.Task
+            TaskState       = $entry.TaskState
+            TaskOwner       = $entry.TaskOwner
+            ReviewState     = $entry.ReviewState
+            Branch          = $entry.Branch
+            HeadSha         = $entry.HeadSha
+            ChangedFileCount = $entry.ChangedFileCount
+            ChangedFiles    = @($entry.ChangedFiles)
+            LastEvent       = $entry.LastEvent
+            LastEventAt     = $entry.LastEventAt
         }
     }
 

--- a/winsmux-core/scripts/team-pipeline.ps1
+++ b/winsmux-core/scripts/team-pipeline.ps1
@@ -23,8 +23,31 @@ $script:TeamPipelineBridgeScript = [System.IO.Path]::GetFullPath((Join-Path $PSS
 $script:TeamPipelineLoggerScript = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot 'logger.ps1'))
 $script:TeamPipelineDangerousApprovalPattern = '(?im)(rm\s+-rf|Remove-Item\s+.+-Recurse.+-Force|git\s+push\s+--force|git\s+reset\s+--hard|DROP\s+TABLE|DELETE\s+FROM)'
 
+. (Join-Path $PSScriptRoot 'manifest.ps1')
 if (Test-Path $script:TeamPipelineLoggerScript -PathType Leaf) {
     . $script:TeamPipelineLoggerScript
+}
+
+function Get-TeamPipelineValue {
+    param(
+        [AllowNull()]$InputObject,
+        [Parameter(Mandatory = $true)][string]$Name,
+        $Default = $null
+    )
+
+    if ($null -eq $InputObject) {
+        return $Default
+    }
+
+    if ($InputObject -is [System.Collections.IDictionary] -and $InputObject.Contains($Name)) {
+        return $InputObject[$Name]
+    }
+
+    if ($null -ne $InputObject.PSObject -and $InputObject.PSObject.Properties.Name -contains $Name) {
+        return $InputObject.$Name
+    }
+
+    return $Default
 }
 
 function ConvertFrom-TeamPipelineYamlScalar {
@@ -57,89 +80,11 @@ function Get-TeamPipelineManifestPath {
 function ConvertFrom-TeamPipelineManifestContent {
     param([Parameter(Mandatory = $true)][string]$Content)
 
-    $manifest = [PSCustomObject]@{
-        Session = [ordered]@{}
-        Panes   = [ordered]@{}
+    $parsed = ConvertFrom-ManifestYaml -Content $Content
+    return [PSCustomObject]@{
+        Session = $parsed.session
+        Panes   = $parsed.panes
     }
-
-    $section = $null
-    $currentPane = $null
-
-    function Save-CurrentPane {
-        param($Pane)
-
-        if ($null -eq $Pane) {
-            return
-        }
-
-        $label = [string]$Pane.label
-        if ([string]::IsNullOrWhiteSpace($label)) {
-            return
-        }
-
-        $paneObject = [PSCustomObject]@{}
-        foreach ($property in $Pane.GetEnumerator()) {
-            Add-Member -InputObject $paneObject -MemberType NoteProperty -Name $property.Key -Value $property.Value
-        }
-
-        $manifest.Panes[$label] = $paneObject
-    }
-
-    foreach ($rawLine in ($Content -split "\r?\n")) {
-        $line = $rawLine.TrimEnd()
-        if ([string]::IsNullOrWhiteSpace($line) -or $line -match '^\s*#') {
-            continue
-        }
-
-        if ($line -match '^(session|panes):\s*$') {
-            if ($section -eq 'panes') {
-                Save-CurrentPane -Pane $currentPane
-                $currentPane = $null
-            }
-
-            $section = $Matches[1]
-            continue
-        }
-
-        if ($section -eq 'session' -and $line -match '^\s{2}([A-Za-z0-9_.-]+):\s*(.*?)\s*$') {
-            $manifest.Session[$Matches[1]] = ConvertFrom-TeamPipelineYamlScalar $Matches[2]
-            continue
-        }
-
-        if ($section -ne 'panes') {
-            continue
-        }
-
-        if ($line -match '^\s{2}-\s+label:\s*(.*?)\s*$') {
-            Save-CurrentPane -Pane $currentPane
-            $currentPane = [ordered]@{
-                label = ConvertFrom-TeamPipelineYamlScalar $Matches[1]
-            }
-            continue
-        }
-
-        if ($line -match '^\s{2}(.+?):\s*$') {
-            Save-CurrentPane -Pane $currentPane
-            $currentPane = [ordered]@{
-                label = ConvertFrom-TeamPipelineYamlScalar $Matches[1]
-            }
-            continue
-        }
-
-        if ($line -match '^\s{4}([A-Za-z0-9_.-]+):\s*(.*?)\s*$') {
-            if ($null -eq $currentPane) {
-                continue
-            }
-
-            $currentPane[$Matches[1]] = ConvertFrom-TeamPipelineYamlScalar $Matches[2]
-        }
-    }
-
-    if ($section -eq 'panes') {
-        Save-CurrentPane -Pane $currentPane
-    }
-
-    return $manifest
 }
 
 function Read-TeamPipelineManifest {
@@ -182,10 +127,7 @@ function Resolve-TeamPipelineBuilderContext {
     )
 
     $pane = Get-TeamPipelinePaneInfo -Manifest $Manifest -Label $BuilderLabel
-    $projectDir = $null
-    if ($null -ne $Manifest -and $null -ne $Manifest.Session -and $Manifest.Session.Contains('project_dir')) {
-        $projectDir = [string]$Manifest.Session.project_dir
-    }
+    $projectDir = [string](Get-TeamPipelineValue -InputObject $Manifest.Session -Name 'project_dir' -Default '')
 
     if ([string]::IsNullOrWhiteSpace($projectDir)) {
         $projectDir = (Get-Location).Path
@@ -194,12 +136,10 @@ function Resolve-TeamPipelineBuilderContext {
     $worktreePath = $OverrideWorktreePath
     if ([string]::IsNullOrWhiteSpace($worktreePath) -and $null -ne $pane) {
         foreach ($candidateKey in @('builder_worktree_path', 'launch_dir')) {
-            if ($pane.PSObject.Properties.Name -contains $candidateKey) {
-                $candidate = [string]$pane.$candidateKey
-                if (-not [string]::IsNullOrWhiteSpace($candidate)) {
-                    $worktreePath = $candidate
-                    break
-                }
+            $candidate = [string](Get-TeamPipelineValue -InputObject $pane -Name $candidateKey -Default '')
+            if (-not [string]::IsNullOrWhiteSpace($candidate)) {
+                $worktreePath = $candidate
+                break
             }
         }
     }
@@ -210,7 +150,7 @@ function Resolve-TeamPipelineBuilderContext {
 
     return [PSCustomObject]@{
         BuilderLabel      = $BuilderLabel
-        BuilderPaneId     = if ($null -ne $pane -and ($pane.PSObject.Properties.Name -contains 'pane_id')) { [string]$pane.pane_id } else { $null }
+        BuilderPaneId     = if ($null -ne $pane) { [string](Get-TeamPipelineValue -InputObject $pane -Name 'pane_id' -Default $null) } else { $null }
         ProjectDir        = $projectDir
         BuilderWorktreePath = $worktreePath
     }
@@ -219,11 +159,9 @@ function Resolve-TeamPipelineBuilderContext {
 function Get-TeamPipelineSessionName {
     param([AllowNull()]$Manifest)
 
-    if ($null -ne $Manifest -and $null -ne $Manifest.Session -and $Manifest.Session.Contains('name')) {
-        $sessionName = [string]$Manifest.Session.name
-        if (-not [string]::IsNullOrWhiteSpace($sessionName)) {
-            return $sessionName
-        }
+    $sessionName = [string](Get-TeamPipelineValue -InputObject $Manifest.Session -Name 'name' -Default '')
+    if (-not [string]::IsNullOrWhiteSpace($sessionName)) {
+        return $sessionName
     }
 
     return 'winsmux-orchestra'


### PR DESCRIPTION
## Summary
- land the TASK-205 fail-close fix so pane targeting reports missing panes explicitly
- add first-class orchestra pane/task/review/git state tracking and internal Telegram boundary cleanup
- sync planning artifacts in `tasks/backlog.yaml` and `docs/project/ROADMAP.md`

## Commit Structure
- `829225a` `fix(core): fail when target pane is missing`
- `f1c3d8b` `feat(orchestra): add first-class pane state model`
- `9fde704` `docs(planning): sync backlog and roadmap`

## Validation
- `cargo test task205_focus`
- `Invoke-Pester -Path .\\tests\\psmux-bridge.Tests.ps1,.\\tests\\Integration.MultiAgent.Tests.ps1,.\\tests\\OrchestraPreflight.Tests.ps1 -Output Minimal`
- PR-B focused suite passed `98/98`

## Notes
- `review-state.json` is local-only and excluded from the PR
- merge method requested for this PR is merge commit (not squash)
