### PR TITLE
fix: restore review-gate CI and fixture temp hygiene

### DIFF
--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -87,6 +87,14 @@ function Stop-WithError {
     exit 1
 }
 
+function Get-SafeLastExitCode {
+    if (Test-Path Variable:\LASTEXITCODE) {
+        return $LASTEXITCODE
+    }
+
+    return $null
+}
+
 function Invoke-WinsmuxRaw {
     param([Parameter(Mandatory = $true)][string[]]$Arguments)
 
@@ -119,7 +127,8 @@ function Write-ClmSafeTextFile {
         $Content | cmd /d /c $writeCommand | Out-Null
     }
 
-    if ($LASTEXITCODE -ne 0) {
+    $nativeExitCode = Get-SafeLastExitCode
+    if ($null -ne $nativeExitCode -and $nativeExitCode -ne 0) {
         Stop-WithError "failed to write file via cmd.exe: $Path"
     }
 }
@@ -257,7 +266,8 @@ function Get-CurrentGitBranch {
     param([string]$ProjectDir = (Get-Location).Path)
 
     $branch = (git -C $ProjectDir rev-parse --abbrev-ref HEAD 2>$null | Select-Object -First 1)
-    if (($null -ne $LASTEXITCODE -and $LASTEXITCODE -ne 0) -or [string]::IsNullOrWhiteSpace($branch) -or $branch -eq 'HEAD') {
+    $nativeExitCode = Get-SafeLastExitCode
+    if (($null -ne $nativeExitCode -and $nativeExitCode -ne 0) -or [string]::IsNullOrWhiteSpace($branch) -or $branch -eq 'HEAD') {
         Stop-WithError "unable to determine current git branch in $ProjectDir"
     }
 
@@ -268,7 +278,8 @@ function Get-CurrentGitHead {
     param([string]$ProjectDir = (Get-Location).Path)
 
     $head = (git -C $ProjectDir rev-parse HEAD 2>$null | Select-Object -First 1)
-    if (($null -ne $LASTEXITCODE -and $LASTEXITCODE -ne 0) -or [string]::IsNullOrWhiteSpace($head)) {
+    $nativeExitCode = Get-SafeLastExitCode
+    if (($null -ne $nativeExitCode -and $nativeExitCode -ne 0) -or [string]::IsNullOrWhiteSpace($head)) {
         Stop-WithError "unable to determine current git HEAD in $ProjectDir"
     }
 
@@ -313,9 +324,14 @@ function ConvertTo-ReviewStateValue {
         return $items
     }
 
-    if ($null -ne $Value.PSObject -and $Value.PSObject.Properties.Count -gt 0) {
+    $psProperties = @()
+    if ($null -ne $Value.PSObject) {
+        $psProperties = @($Value.PSObject.Properties)
+    }
+
+    if ($psProperties.Count -gt 0) {
         $ordered = [ordered]@{}
-        foreach ($property in $Value.PSObject.Properties) {
+        foreach ($property in $psProperties) {
             $ordered[$property.Name] = ConvertTo-ReviewStateValue -Value $property.Value
         }
 
@@ -1576,8 +1592,9 @@ function Invoke-Verify {
 
     Write-Output "Pester PASS. Merging PR #$prNumber"
     & gh pr merge $prNumber --squash --delete-branch
-    if ($LASTEXITCODE -ne 0) {
-        exit $LASTEXITCODE
+    $nativeExitCode = Get-SafeLastExitCode
+    if ($null -ne $nativeExitCode -and $nativeExitCode -ne 0) {
+        exit $nativeExitCode
     }
 }
 
@@ -2758,7 +2775,8 @@ function Invoke-Kill {
     $paneId = Confirm-Target $paneId
 
     & winsmux respawn-pane -k -t $paneId
-    if ($LASTEXITCODE -ne 0) {
+    $nativeExitCode = Get-SafeLastExitCode
+    if ($null -ne $nativeExitCode -and $nativeExitCode -ne 0) {
         Stop-WithError "failed to kill pane process: $paneId"
     }
 
@@ -2783,7 +2801,8 @@ function Invoke-Restart {
     $plan = Get-PaneControlRestartPlan -ProjectDir $projectDir -PaneId $paneId -Settings $settings
 
     & winsmux respawn-pane -k -t $paneId -c $plan.LaunchDir
-    if ($LASTEXITCODE -ne 0) {
+    $nativeExitCode = Get-SafeLastExitCode
+    if ($null -ne $nativeExitCode -and $nativeExitCode -ne 0) {
         Stop-WithError "failed to restart pane shell: $paneId"
     }
 
@@ -2794,11 +2813,13 @@ function Invoke-Restart {
     }
 
     & winsmux send-keys -t $paneId -l -- "$($plan.LaunchCommand)"
-    if ($LASTEXITCODE -ne 0) {
+    $nativeExitCode = Get-SafeLastExitCode
+    if ($null -ne $nativeExitCode -and $nativeExitCode -ne 0) {
         Stop-WithError "failed to send launch command to $paneId"
     }
     & winsmux send-keys -t $paneId Enter
-    if ($LASTEXITCODE -ne 0) {
+    $nativeExitCode = Get-SafeLastExitCode
+    if ($null -ne $nativeExitCode -and $nativeExitCode -ne 0) {
         Stop-WithError "failed to submit launch command to $paneId"
     }
 

--- a/tests/Integration.GateEnforcement.Tests.ps1
+++ b/tests/Integration.GateEnforcement.Tests.ps1
@@ -2,6 +2,8 @@ $ErrorActionPreference = 'Stop'
 
 Describe 'sh-orchestra-gate integration' {
     BeforeAll {
+        $script:FixtureBaseRoot = Join-Path ([System.IO.Path]::GetTempPath()) 'winsmux-tests\gate-enforcement'
+
         function Write-GateTestFile {
             param(
                 [Parameter(Mandatory = $true)][string]$Path,
@@ -150,7 +152,7 @@ Describe 'sh-orchestra-gate integration' {
         }
 
         function New-GateFixture {
-            $fixtureRoot = Join-Path $script:RepoRoot '.tmp-gate-enforcement-tests' ([guid]::NewGuid().ToString('N'))
+            $fixtureRoot = Join-Path $script:FixtureBaseRoot ([guid]::NewGuid().ToString('N'))
             $repoRoot = Join-Path $fixtureRoot 'repo'
 
             New-Item -ItemType Directory -Path (Join-Path $repoRoot '.claude\hooks') -Force | Out-Null

--- a/tests/Integration.PaneMonitorHook.Tests.ps1
+++ b/tests/Integration.PaneMonitorHook.Tests.ps1
@@ -2,6 +2,7 @@ $ErrorActionPreference = 'Stop'
 
 Describe 'sh-pane-monitor integration' {
     BeforeAll {
+        $script:FixtureBaseRoot = Join-Path ([System.IO.Path]::GetTempPath()) 'winsmux-tests\pane-monitor'
         $script:RepoRoot = Split-Path -Parent $PSScriptRoot
         $script:SourceHookRoot = Join-Path $script:RepoRoot '.claude\hooks'
         $nodeCommand = Get-Command node -ErrorAction SilentlyContinue | Select-Object -First 1
@@ -60,7 +61,7 @@ Describe 'sh-pane-monitor integration' {
         }
 
         function New-PaneMonitorFixture {
-            $fixtureRoot = Join-Path $script:RepoRoot '.tmp-pane-monitor-tests' ([guid]::NewGuid().ToString('N'))
+            $fixtureRoot = Join-Path $script:FixtureBaseRoot ([guid]::NewGuid().ToString('N'))
             $projectRoot = Join-Path $fixtureRoot 'project'
             $repoRoot = Join-Path $projectRoot '.worktrees\builder-1'
             $winsmuxDir = Join-Path $projectRoot '.winsmux'

--- a/tests/Integration.WorktreeHook.Tests.ps1
+++ b/tests/Integration.WorktreeHook.Tests.ps1
@@ -2,6 +2,7 @@ $ErrorActionPreference = 'Stop'
 
 Describe 'sh-worktree integration' {
     BeforeAll {
+        $script:FixtureBaseRoot = Join-Path ([System.IO.Path]::GetTempPath()) 'winsmux-tests\worktree-hook'
         $script:RepoRoot = Split-Path -Parent $PSScriptRoot
         $script:SourceHookRoot = Join-Path $script:RepoRoot '.claude\hooks'
         $nodeCommand = Get-Command node -ErrorAction SilentlyContinue | Select-Object -First 1
@@ -50,7 +51,7 @@ Describe 'sh-worktree integration' {
         }
 
         function New-WorktreeHookFixture {
-            $fixtureRoot = Join-Path $script:RepoRoot '.tmp-worktree-hook-tests' ([guid]::NewGuid().ToString('N'))
+            $fixtureRoot = Join-Path $script:FixtureBaseRoot ([guid]::NewGuid().ToString('N'))
             $repoRoot = Join-Path $fixtureRoot 'repo'
             $worktreeTarget = Join-Path $repoRoot '.worktrees\feature-auth'
 


### PR DESCRIPTION
## Summary
- harden `scripts/winsmux-core.ps1` against PowerShell 7 native-command exit-code edge cases that broke the review gate flow in CI
- fix review-state normalization so `review-approve` no longer crashes on object property enumeration
- move integration test fixture temp directories out of the repo root so test runs stop scattering `.tmp-*` directories

## Validation
- full Pester suite: `156/156 PASS`
- focused gate regression reproduction confirmed the original CI failure and the fix

## Notes
- this addresses the failed `Tests` workflow runs on `main` (#310) and `codex/release-v0.19.5` (#309)
- no product behavior change beyond the broken review gate path and test fixture cleanup
