### PR TITLE
feat: default winsmux-start to external operator and managed workers

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -19,14 +19,16 @@ winsmux must be running before orchestra-start. If not running, user starts it m
 
 ## Roles (Orchestra)
 
+The default model is now **external Commander + background workers**.
+
 | Role | Agent | Allowed | Forbidden |
 |------|-------|---------|-----------|
-| Commander | Claude Code | plan, dispatch, git ops, backlog | write/edit code, review code |
-| Builder | Codex | implement in worktree | git add/commit/push, merge, direct main repo work |
-| Reviewer | Codex | review diffs | implement |
-| Researcher | Codex | investigate, report, git add/commit/push | implement |
+| Commander | Claude Code / Codex outside the managed window | plan, dispatch, git ops, backlog, final judgement | background pane execution as the sole control plane |
+| Worker | Codex in managed panes | implement, investigate, verify, review when assigned | direct ownership of the main repo lifecycle |
 
-Roles are advisory. Hard enforcement is via hooks (`sh-orchestra-gate.js` for Commander). Other roles need per-role gate hooks (#284).
+Legacy `Builder / Researcher / Reviewer` pane layouts remain available only for explicit compatibility mode.
+
+Roles are advisory. Hard enforcement is via hooks (`sh-orchestra-gate.js` for Commander) and winsmux role gates inside managed panes.
 
 **Enforcement**: CLAUDE.md is advisory, not enforced. Use hooks for deterministic enforcement. See GUARDRAILS.md for recurring failures.
 

--- a/.claude/hooks/lib/sh-utils.js
+++ b/.claude/hooks/lib/sh-utils.js
@@ -21,15 +21,13 @@ const ZERO_WIDTH_RE =
 const DEFAULT_PATTERNS = { categories: {} };
 const DEFAULT_PREVIOUS_HASH = "genesis";
 const DENY_THRESHOLD = 3;
-const DEFAULT_PLANNING_ROOT = path.join(
-  os.homedir(),
-  "iCloudDrive",
-  "iCloud~md~obsidian",
-  "MainVault",
-  "Projects",
+const DEFAULT_PLANNING_ROOT = path.join(os.homedir(), ".winsmux", "planning");
+const PLANNING_ROOT_MARKER = path.join(
+  process.env.LOCALAPPDATA || path.join(os.homedir(), "AppData", "Local"),
   "winsmux",
-  "planning",
+  "planning-root.txt",
 );
+let cachedPlanningRoot = null;
 
 function deny(reason) {
   process.stdout.write(`${JSON.stringify({ decision: "deny", reason })}\n`);
@@ -394,8 +392,92 @@ function commandExists(cmd) {
   }
 }
 
+function readPlanningRootMarker() {
+  try {
+    if (!fs.existsSync(PLANNING_ROOT_MARKER)) {
+      return "";
+    }
+
+    return fs.readFileSync(PLANNING_ROOT_MARKER, "utf8").trim();
+  } catch {
+    return "";
+  }
+}
+
+function findPlanningRoot(startDir, depth = 0, maxDepth = 8) {
+  if (depth > maxDepth) {
+    return "";
+  }
+
+  let entries;
+  try {
+    entries = fs.readdirSync(startDir, { withFileTypes: true });
+  } catch {
+    return "";
+  }
+
+  const hasBacklog = entries.some(
+    (entry) => entry.isFile() && entry.name === "backlog.yaml",
+  );
+  const hasRoadmap = entries.some(
+    (entry) => entry.isFile() && entry.name === "ROADMAP.md",
+  );
+
+  if (
+    hasBacklog &&
+    hasRoadmap &&
+    normalizePath(startDir).replace(/\\/g, "/").endsWith("/winsmux/planning")
+  ) {
+    return startDir;
+  }
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+    if (entry.name === ".git" || entry.name === "node_modules") {
+      continue;
+    }
+
+    const candidate = findPlanningRoot(
+      path.join(startDir, entry.name),
+      depth + 1,
+      maxDepth,
+    );
+    if (candidate) {
+      return candidate;
+    }
+  }
+
+  return "";
+}
+
 function getPlanningRoot() {
-  return process.env.WINSMUX_PLANNING_ROOT || DEFAULT_PLANNING_ROOT;
+  if (
+    typeof process.env.WINSMUX_PLANNING_ROOT === "string" &&
+    process.env.WINSMUX_PLANNING_ROOT.trim() !== ""
+  ) {
+    return process.env.WINSMUX_PLANNING_ROOT;
+  }
+
+  if (cachedPlanningRoot) {
+    return cachedPlanningRoot;
+  }
+
+  const markerRoot = readPlanningRootMarker();
+  if (markerRoot) {
+    cachedPlanningRoot = markerRoot;
+    return cachedPlanningRoot;
+  }
+
+  const discoveredRoot = findPlanningRoot(os.homedir());
+  if (discoveredRoot) {
+    cachedPlanningRoot = discoveredRoot;
+    return cachedPlanningRoot;
+  }
+
+  cachedPlanningRoot = DEFAULT_PLANNING_ROOT;
+  return cachedPlanningRoot;
 }
 
 function resolvePlanningFile(localRelativePath, envKey, fileName) {

--- a/.claude/hooks/sh-orchestra-gate.js
+++ b/.claude/hooks/sh-orchestra-gate.js
@@ -47,10 +47,11 @@ try {
     }
   }
 
-  // Rule 4: review-approve and review-fail may only run from a Reviewer pane
+  // Rule 4: review-approve and review-fail may only run from a review-capable pane
   if (toolName === "Bash") {
-    if (isReviewerOnlyCommand(bashCommand) && normalizeAgentValue(process.env.WINSMUX_ROLE) !== "reviewer") {
-      deny("review-approve and review-fail can only be run from a Reviewer pane.");
+    const currentRole = normalizeAgentValue(process.env.WINSMUX_ROLE);
+    if (isReviewerOnlyCommand(bashCommand) && currentRole !== "reviewer" && currentRole !== "worker") {
+      deny("review-approve and review-fail can only be run from a review-capable pane.");
     }
   }
 
@@ -121,7 +122,7 @@ try {
   if (toolName === "Bash") {
     if (isReviewGatedCommand(bashCommand) && !/bump-version|chore:\s*bump/.test(bashCommand)) {
       const reviewStatePath = path.join(process.cwd(), ".winsmux", "review-state.json");
-      const denyMessage = "Review required. Flow: 1) Reviewer runs winsmux review-request, 2) Reviewer reviews, 3) Reviewer runs winsmux review-approve or winsmux review-fail from Reviewer pane.";
+      const denyMessage = "Review required. Flow: 1) a review-capable pane runs winsmux review-request, 2) that pane reviews, 3) it runs winsmux review-approve or winsmux review-fail.";
       try {
         const currentBranch = getCurrentBranch(process.cwd());
         const currentHeadSha = getCurrentHeadSha(process.cwd());
@@ -487,7 +488,8 @@ function hasValidReviewerPass(reviewStateEntry, currentHeadSha) {
   }
 
   const reviewer = reviewStateEntry.reviewer;
-  if (!reviewer || normalizeAgentValue(reviewer.role) !== "reviewer") {
+  const reviewerRole = normalizeAgentValue(reviewer?.role);
+  if (!reviewer || (reviewerRole !== "reviewer" && reviewerRole !== "worker")) {
     return false;
   }
 

--- a/.winsmux.yaml
+++ b/.winsmux.yaml
@@ -1,7 +1,6 @@
 agent: codex
 model: gpt-5.4
-builders: 4
-researchers: 1
-reviewers: 1
+external-commander: true
+worker-count: 6
 
 roles: {}

--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ It provides the runtime and coordination layer for running multiple agent CLIs i
 
 - **Multi-vendor support**: run Codex, Claude, Gemini, and other CLI agents side by side in the same session
 - **Real-time visibility**: supervise every agent through live `winsmux` panes instead of waiting for post-hoc summaries
-- **Enterprise governance**: enforce role gates, isolate Builder work in git worktrees, and preserve an evidence trail for review and audit
+- **Enterprise governance**: keep one external Commander in control, isolate managed worker panes in git worktrees, and preserve an evidence trail for review and audit
 
 ```powershell
-winsmux read builder-1 20
-winsmux send reviewer "Review the latest auth changes."
+winsmux read worker-1 20
+winsmux send worker-2 "Review the latest auth changes."
 winsmux health-check
 ```
 
@@ -26,9 +26,9 @@ winsmux health-check
 
 Most agent tooling is optimized for a single vendor and a single execution model. winsmux is designed for teams that need to coordinate multiple agents on Windows while keeping the system observable and governable.
 
-- **Vendor-neutral orchestration**: mix Codex for implementation, Claude for review, and Gemini for research in one session
+- **Vendor-neutral orchestration**: mix Codex, Claude, Gemini, and future local models behind one Commander control loop
 - **Pane-native operations**: inspect, interrupt, redirect, and relabel live panes through `winsmux`
-- **Controlled execution**: combine read-before-act interaction, role-aware command gates, and isolated Builder workspaces
+- **Controlled execution**: combine read-before-act interaction, review-capable worker gates, and isolated worker workspaces
 - **Windows-first deployment**: no WSL2 dependency, no Linux detour, no hidden tmux requirement
 
 ## Platform model
@@ -38,15 +38,15 @@ winsmux
 ├── winsmux CLI
 ├── Orchestra
 ├── Role Gates
-├── Builder Worktree Isolation
+├── Worker Worktree Isolation
 ├── Credential Vault (DPAPI)
 └── Evidence Ledger
 ```
 
 - **`winsmux`** handles pane targeting, messaging, health checks, vault injection, and operator controls
-- **Orchestra** coordinates Commander, Builder, Researcher, and Reviewer panes
-- **Role gates** restrict which actions each role can perform
-- **Builder worktree isolation** gives each Builder pane a separate git worktree to reduce cross-agent collisions
+- **Orchestra** defaults to one external Commander plus managed worker panes
+- **Role gates** restrict which actions Commander and managed panes can perform
+- **Worker worktree isolation** gives each managed worker pane a separate git worktree to reduce cross-agent collisions
 - **Evidence Ledger** supports audit-oriented capture of agent activity and review outcomes
 
 ## Core runtime
@@ -105,19 +105,25 @@ winsmux new-session -s orchestra
 pwsh winsmux-core/scripts/orchestra-start.ps1
 ```
 
+The default layout is now:
+
+- external Commander terminal outside the managed window
+- 6 managed `worker-*` panes inside the orchestra window
+- legacy `Commander / Builder / Researcher / Reviewer` pane layouts only when explicitly enabled
+
 Inside the session, label and inspect panes:
 
 ```powershell
 winsmux list
-winsmux read builder-1 30
-winsmux send researcher "Summarize the upstream issue."
+winsmux read worker-1 30
+winsmux send worker-3 "Summarize the upstream issue."
 ```
 
 ## Governance highlights
 
-- **Role gates**: builders, researchers, reviewers, and commanders do not all get the same command surface
+- **Role gates**: the external Commander and managed worker panes do not get the same command surface
 - **Read Guard**: panes must be read before interaction, reducing blind input into the wrong target
-- **Worktree isolation**: each Builder pane can run in its own git worktree branch and directory
+- **Worktree isolation**: each managed worker pane can run in its own git worktree branch and directory
 - **Credential Vault**: secrets are stored with Windows DPAPI and injected into panes without writing repo `.env` files
 - **Evidence Ledger**: prompts, actions, and review evidence can be captured for audit and compliance workflows
 

--- a/docs/project/README.md
+++ b/docs/project/README.md
@@ -2,9 +2,11 @@
 
 `ROADMAP.md` is maintained outside this repository and is generated from the external planning backlog.
 
-Default local path:
+Default resolution order:
 
-- `C:\Users\komei\iCloudDrive\iCloud~md~obsidian\MainVault\Projects\winsmux\planning\ROADMAP.md`
+- `WINSMUX_ROADMAP_PATH`
+- `WINSMUX_PLANNING_ROOT\ROADMAP.md`
+- the user-profile-relative default returned by `winsmux-core/scripts/planning-paths.ps1`
 
 Override with:
 

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -431,7 +431,7 @@ function Assert-WinsmuxRolePermission {
     }
 }
 
-function Get-CurrentReviewerManifestContext {
+function Get-CurrentReviewPaneManifestContext {
     param([string]$ProjectDir = (Get-Location).Path)
 
     if ([string]::IsNullOrWhiteSpace($env:WINSMUX_PANE_ID)) {
@@ -444,8 +444,8 @@ function Get-CurrentReviewerManifestContext {
         Stop-WithError $_.Exception.Message
     }
 
-    if ([string]$context.Role -ne 'Reviewer') {
-        Stop-WithError "pane $($env:WINSMUX_PANE_ID) is not registered as Reviewer in .winsmux/manifest.yaml"
+    if ([string]$context.Role -notin @('Reviewer', 'Worker')) {
+        Stop-WithError "pane $($env:WINSMUX_PANE_ID) is not registered as a review-capable pane in .winsmux/manifest.yaml"
     }
 
     return [ordered]@{
@@ -460,7 +460,7 @@ function Get-CurrentReviewerManifestContext {
     }
 }
 
-function Update-ReviewerManifestState {
+function Update-ReviewPaneManifestState {
     param(
         [Parameter(Mandatory = $true)][string]$ProjectDir,
         [Parameter(Mandatory = $true)][System.Collections.IDictionary]$Properties
@@ -471,11 +471,26 @@ function Update-ReviewerManifestState {
     }
 
     try {
-        $context = Get-CurrentReviewerManifestContext -ProjectDir $ProjectDir
+        $context = Get-CurrentReviewPaneManifestContext -ProjectDir $ProjectDir
         Set-PaneControlManifestPaneProperties -ManifestPath $context.ManifestPath -PaneId $context.PaneId -Properties $Properties
     } catch {
         # Review-state persistence remains the source of truth. Manifest sync is best-effort.
     }
+}
+
+function Get-PreferredReviewPaneEntry {
+    param([Parameter(Mandatory = $true)][string]$ProjectDir)
+
+    $entries = @(Get-PaneControlManifestEntries -ProjectDir $ProjectDir)
+    foreach ($preferredRole in @('Reviewer', 'Worker')) {
+        foreach ($entry in $entries) {
+            if ([string]$entry.Role -eq $preferredRole) {
+                return $entry
+            }
+        }
+    }
+
+    return $null
 }
 
 function New-ReviewRequestId {
@@ -1431,7 +1446,7 @@ function Invoke-AutoRebalance {
     } catch {}
 
     $suggestion = if ($queueDepth -gt 0) { "キューにタスクあり — Builder 維持" }
-                  elseif ($idleBuilders.Count -gt 0) { "アイドル $($idleBuilders.Count) 台を Researcher に切替可能" }
+                  elseif ($idleBuilders.Count -gt 0) { "アイドル $($idleBuilders.Count) 台を Worker に切替可能" }
                   else { "全 Builder 稼働中" }
 
     Write-Output "アイドル Builder: $($idleBuilders.Count)/$($builderLabels.Count)"
@@ -1442,12 +1457,12 @@ function Invoke-AutoRebalance {
 
 function Invoke-Role {
     if (-not $Target -or -not $Rest -or $Rest.Count -lt 1) {
-        Stop-WithError "usage: winsmux role <pane_label_or_id> <new_role>`n  roles: builder, researcher, reviewer"
+        Stop-WithError "usage: winsmux role <pane_label_or_id> <new_role>`n  roles: worker, builder, researcher, reviewer"
     }
 
     $newRole = $Rest[0].Trim().ToLowerInvariant()
-    if ($newRole -notin @('builder', 'researcher', 'reviewer')) {
-        Stop-WithError "invalid role: $newRole. Must be builder, researcher, or reviewer."
+    if ($newRole -notin @('worker', 'builder', 'researcher', 'reviewer')) {
+        Stop-WithError "invalid role: $newRole. Must be worker, builder, researcher, or reviewer."
     }
 
     # Resolve pane ID
@@ -2358,28 +2373,19 @@ function Invoke-DispatchReview {
     $branch = Get-CurrentGitBranch -ProjectDir $projectDir
     $headSha = Get-CurrentGitHead -ProjectDir $projectDir
 
-    # Find Reviewer pane from manifest
-    $entries = Get-PaneControlManifestEntries -ProjectDir $projectDir
-    $reviewerEntry = $null
-    foreach ($entry in $entries) {
-        if ([string]$entry.Role -eq 'Reviewer') {
-            $reviewerEntry = $entry
-            break
-        }
+    $reviewPaneEntry = Get-PreferredReviewPaneEntry -ProjectDir $projectDir
+    if ($null -eq $reviewPaneEntry) {
+        Stop-WithError "No review-capable pane found in manifest."
     }
 
-    if ($null -eq $reviewerEntry) {
-        Stop-WithError "No Reviewer pane found in manifest."
-    }
+    $reviewPaneId = [string]$reviewPaneEntry.PaneId
+    $reviewLabel = [string]$reviewPaneEntry.Label
+    $reviewRole = [string]$reviewPaneEntry.Role
+    Write-Output "Dispatching review to $reviewLabel [$reviewPaneId] for branch $branch ($($headSha.Substring(0,7)))"
 
-    $reviewerPaneId = [string]$reviewerEntry.PaneId
-    $reviewerLabel = [string]$reviewerEntry.Label
-    Write-Output "Dispatching review to $reviewerLabel [$reviewerPaneId] for branch $branch ($($headSha.Substring(0,7)))"
+    Send-TextToPane -PaneId $reviewPaneId -CommandText "winsmux review-request"
 
-    # Send review-request to Reviewer pane
-    Send-TextToPane -PaneId $reviewerPaneId -CommandText "winsmux review-request"
-
-    Write-Output "review-request sent to $reviewerLabel. Waiting for PENDING state..."
+    Write-Output "review-request sent to $reviewLabel. Waiting for PENDING state..."
 
     # Poll for PENDING state (up to 30 seconds)
     $maxAttempts = 10
@@ -2398,10 +2404,10 @@ function Invoke-DispatchReview {
     }
 
     if (-not $pending) {
-        Stop-WithError "review-request was not recorded after ${maxAttempts} attempts. Check Reviewer pane $reviewerPaneId."
+        Stop-WithError "review-request was not recorded after ${maxAttempts} attempts. Check review pane $reviewPaneId."
     }
 
-    Write-Output "PENDING confirmed. Reviewer will run review-approve or review-fail. Monitor review-state.json for result."
+    Write-Output "PENDING confirmed. $reviewRole pane will run review-approve or review-fail. Monitor review-state.json for result."
 }
 
 function Invoke-ReviewRequest {
@@ -2414,7 +2420,7 @@ function Invoke-ReviewRequest {
     $projectDir = (Get-Location).Path
     $branch = Get-CurrentGitBranch -ProjectDir $projectDir
     $headSha = Get-CurrentGitHead -ProjectDir $projectDir
-    $context = Get-CurrentReviewerManifestContext -ProjectDir $projectDir
+    $context = Get-CurrentReviewPaneManifestContext -ProjectDir $projectDir
     $timestamp = (Get-Date).ToString('o')
     $state = Get-ReviewState -ProjectDir $projectDir
 
@@ -2437,9 +2443,9 @@ function Invoke-ReviewRequest {
 
     $state[$branch] = New-ReviewerStateRecord -Status 'PENDING' -Request $request -Reviewer $reviewer -Evidence $null -UpdatedAt $timestamp
     Save-ReviewState -ProjectDir $projectDir -State $state
-    Update-ReviewerManifestState -ProjectDir $projectDir -Properties ([ordered]@{
+    Update-ReviewPaneManifestState -ProjectDir $projectDir -Properties ([ordered]@{
         review_state = 'pending'
-        task_owner   = 'Reviewer'
+        task_owner   = $context.Role
         branch       = $branch
         head_sha     = $headSha
         last_event   = 'review.requested'
@@ -2458,7 +2464,7 @@ function Invoke-ReviewApprove {
     $projectDir = (Get-Location).Path
     $branch = Get-CurrentGitBranch -ProjectDir $projectDir
     $headSha = Get-CurrentGitHead -ProjectDir $projectDir
-    $context = Get-CurrentReviewerManifestContext -ProjectDir $projectDir
+    $context = Get-CurrentReviewPaneManifestContext -ProjectDir $projectDir
     $state = Get-ReviewState -ProjectDir $projectDir
 
     if (-not $state.Contains($branch)) {
@@ -2503,7 +2509,7 @@ function Invoke-ReviewApprove {
 
     $state[$branch] = New-ReviewerStateRecord -Status 'PASS' -Request $request -Reviewer $reviewer -Evidence $evidence -UpdatedAt $timestamp
     Save-ReviewState -ProjectDir $projectDir -State $state
-    Update-ReviewerManifestState -ProjectDir $projectDir -Properties ([ordered]@{
+    Update-ReviewPaneManifestState -ProjectDir $projectDir -Properties ([ordered]@{
         review_state = 'pass'
         task_owner   = 'Commander'
         branch       = $branch
@@ -2524,7 +2530,7 @@ function Invoke-ReviewFail {
     $projectDir = (Get-Location).Path
     $branch = Get-CurrentGitBranch -ProjectDir $projectDir
     $headSha = Get-CurrentGitHead -ProjectDir $projectDir
-    $context = Get-CurrentReviewerManifestContext -ProjectDir $projectDir
+    $context = Get-CurrentReviewPaneManifestContext -ProjectDir $projectDir
     $state = Get-ReviewState -ProjectDir $projectDir
 
     if (-not $state.Contains($branch)) {
@@ -2569,7 +2575,7 @@ function Invoke-ReviewFail {
 
     $state[$branch] = New-ReviewerStateRecord -Status 'FAIL' -Request $request -Reviewer $reviewer -Evidence $evidence -UpdatedAt $timestamp
     Save-ReviewState -ProjectDir $projectDir -State $state
-    Update-ReviewerManifestState -ProjectDir $projectDir -Properties ([ordered]@{
+    Update-ReviewPaneManifestState -ProjectDir $projectDir -Properties ([ordered]@{
         review_state = 'fail'
         task_owner   = 'Commander'
         branch       = $branch
@@ -2593,7 +2599,7 @@ function Invoke-ReviewReset {
     }
 
     Save-ReviewState -ProjectDir $projectDir -State $state
-    Update-ReviewerManifestState -ProjectDir $projectDir -Properties ([ordered]@{
+    Update-ReviewPaneManifestState -ProjectDir $projectDir -Properties ([ordered]@{
         review_state = ''
         branch       = ''
         head_sha     = ''
@@ -2625,11 +2631,11 @@ Commands:
   focus-unlock              Pop the latest focus lock
   lock <label> <file>...    Acquire file lock(s) for a label
   unlock <label> <file>...  Release file lock(s) for a label
-  review-request            Record a pending Reviewer request for the current branch
-  review-approve            Record Reviewer PASS for the current branch
-  review-fail               Record Reviewer FAIL for the current branch
-  review-reset              Clear Reviewer PASS for the current branch
-  dispatch-review            Dispatch review-request to Reviewer pane (Reviewer judges PASS/FAIL)
+  review-request            Record a pending review request for the current branch
+  review-approve            Record review PASS for the current branch
+  review-fail               Record review FAIL for the current branch
+  review-reset              Clear review PASS for the current branch
+  dispatch-review           Dispatch review-request to a review-capable pane (Reviewer/Worker)
   locks                     List active file locks
   verify <pr-number>        Run Pester in tests/ and merge PR only on PASS
   wait <channel> [timeout]  Block until signal received (replaces polling)
@@ -2652,7 +2658,7 @@ Commands:
   mailbox-listen <ch>       Alias for mailbox-create
   kill <target>             Stop pane process and respawn its shell
   restart <target>          Restart the pane agent using manifest context
-  rebind-worktree <target> <path>  Update a Builder pane to use a new worktree path
+  rebind-worktree <target> <path>  Update a Builder/Worker pane to use a new worktree path
   doctor                    Check environment and IME diagnostics
   version                   Show version
 "@
@@ -2862,8 +2868,8 @@ function Invoke-RebindWorktree {
     $resolvedWorktreePath = (Get-Item -LiteralPath $newWorktreePath -Force).FullName
     $context = Get-PaneControlManifestContext -ProjectDir $projectDir -PaneId $paneId
 
-    if ($context.Role -ne 'Builder') {
-        Stop-WithError "rebind-worktree is only supported for Builder panes: $paneId ($($context.Label))"
+    if ($context.Role -notin @('Builder', 'Worker')) {
+        Stop-WithError "rebind-worktree is only supported for Builder/Worker panes: $paneId ($($context.Label))"
     }
 
     Set-PaneControlManifestPanePaths -ProjectDir $projectDir -PaneId $paneId -LaunchDir $resolvedWorktreePath -BuilderWorktreePath $resolvedWorktreePath

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -2,9 +2,11 @@
 
 `backlog.yaml` is maintained outside this repository.
 
-Default local path:
+Default resolution order:
 
-- `C:\Users\komei\iCloudDrive\iCloud~md~obsidian\MainVault\Projects\winsmux\planning\backlog.yaml`
+- `WINSMUX_BACKLOG_PATH`
+- `WINSMUX_PLANNING_ROOT\backlog.yaml`
+- the user-profile-relative default returned by `winsmux-core/scripts/planning-paths.ps1`
 
 Override with:
 

--- a/tests/Integration.GateEnforcement.Tests.ps1
+++ b/tests/Integration.GateEnforcement.Tests.ps1
@@ -345,7 +345,7 @@ EOF
         $result.StdErr | Should -Be ''
     }
 
-    It 'denies review-approve unless WINSMUX_ROLE is Reviewer' {
+    It 'denies review-approve unless WINSMUX_ROLE is review-capable' {
         $result = & $script:InvokeOrchestraGate -ToolName 'Bash' -ToolInput ([ordered]@{
             command = 'pwsh scripts/winsmux-core.ps1 review-approve'
         }) -Environment ([ordered]@{
@@ -353,7 +353,7 @@ EOF
         })
 
         & $script:AssertDenyResult -Result $result
-        $result.ErrorObject.systemMessage | Should -Match 'Reviewer pane'
+        $result.ErrorObject.systemMessage | Should -Match 'review-capable pane'
     }
 
     It 'allows review-approve when WINSMUX_ROLE is Reviewer' {
@@ -361,6 +361,17 @@ EOF
             command = 'pwsh scripts/winsmux-core.ps1 review-approve'
         }) -Environment ([ordered]@{
             WINSMUX_ROLE = 'Reviewer'
+        })
+
+        $result.ExitCode | Should -Be 0
+        $result.StdErr | Should -Be ''
+    }
+
+    It 'allows review-approve when WINSMUX_ROLE is Worker' {
+        $result = & $script:InvokeOrchestraGate -ToolName 'Bash' -ToolInput ([ordered]@{
+            command = 'pwsh scripts/winsmux-core.ps1 review-approve'
+        }) -Environment ([ordered]@{
+            WINSMUX_ROLE = 'Worker'
         })
 
         $result.ExitCode | Should -Be 0
@@ -553,7 +564,7 @@ EOF
         $result.ErrorObject.systemMessage | Should -Match 'review-request'
     }
 
-    It 'denies git commit when reviewer role is not Reviewer' {
+    It 'denies git commit when reviewer role is not review-capable' {
         $fixture = New-GateFixture
         $script:FixtureRoot = $fixture.Root
         $currentHeadSha = Get-GateFixtureHeadSha -RepoRoot $fixture.RepoRoot

--- a/tests/Integration.MultiAgent.Tests.ps1
+++ b/tests/Integration.MultiAgent.Tests.ps1
@@ -7,6 +7,7 @@ Describe 'orchestra cleanup helpers' {
 
     It 'matches orchestra-managed pane titles only' {
         (Test-OrchestraManagedPaneTitle -Title 'Builder-1') | Should -Be $true
+        (Test-OrchestraManagedPaneTitle -Title 'worker-1') | Should -Be $true
         (Test-OrchestraManagedPaneTitle -Title 'researcher-2') | Should -Be $true
         (Test-OrchestraManagedPaneTitle -Title 'Reviewer-3') | Should -Be $true
         (Test-OrchestraManagedPaneTitle -Title 'Commander') | Should -Be $false
@@ -57,9 +58,13 @@ Describe 'Get-BridgeSettings defaults' {
 
         $settings.agent | Should -Be 'codex'
         $settings.model | Should -Be 'gpt-5.4'
-        $settings.builders | Should -Be 1
-        $settings.researchers | Should -Be 1
-        $settings.reviewers | Should -Be 1
+        $settings.external_commander | Should -Be $true
+        $settings.legacy_role_layout | Should -Be $false
+        $settings.commanders | Should -Be 0
+        $settings.worker_count | Should -Be 6
+        $settings.builders | Should -Be 0
+        $settings.researchers | Should -Be 0
+        $settings.reviewers | Should -Be 0
         $settings.terminal | Should -Be 'background'
         $settings.vault_keys | Should -Be @('GH_TOKEN')
         $settings.roles | Should -BeOfType [System.Collections.Specialized.OrderedDictionary]
@@ -125,12 +130,14 @@ Describe 'agent launch helpers' {
         $command | Should -Be "codex -c model=gpt-5.4 --sandbox danger-full-access -C 'C:\repo path\builder-1' --add-dir 'C:\repo path\.git'"
     }
 
-    It 'returns a CLM workaround bootstrap only for Codex builders' {
+    It 'returns a CLM workaround bootstrap for Codex worktree workers' {
         $builderPrompt = Get-AgentBootstrapPrompt -Agent 'codex' -Role 'Builder'
         $builderPrompt | Should -Match 'ConstrainedLanguageMode'
         $builderPrompt | Should -Match 'apply_patch'
         $builderPrompt | Should -Match 'cmd /c'
 
+        $workerPrompt = Get-AgentBootstrapPrompt -Agent 'codex' -Role 'Worker'
+        $workerPrompt | Should -Match 'ConstrainedLanguageMode'
         (Get-AgentBootstrapPrompt -Agent 'codex' -Role 'Reviewer') | Should -BeNullOrEmpty
         (Get-AgentBootstrapPrompt -Agent 'claude' -Role 'Builder') | Should -BeNullOrEmpty
     }

--- a/tests/psmux-bridge.Tests.ps1
+++ b/tests/psmux-bridge.Tests.ps1
@@ -42,6 +42,7 @@ Describe 'Assert-Role' {
             self       = 'pane-self'
             commander  = 'pane-commander'
             builder    = 'pane-builder'
+            worker     = 'pane-worker'
             researcher = 'pane-researcher'
             reviewer   = 'pane-reviewer'
         } | ConvertTo-Json | Set-Content -Path $labelsPath -Encoding UTF8
@@ -49,7 +50,7 @@ Describe 'Assert-Role' {
         $script:roleGateTempRoot = $tempRoot
         $script:RoleGateLabelsFile = $labelsPath
         $env:WINSMUX_PANE_ID = 'pane-self'
-        $env:WINSMUX_ROLE_MAP = '{"pane-self":"Commander","pane-commander":"Commander","pane-builder":"Builder","pane-researcher":"Researcher","pane-reviewer":"Reviewer"}'
+        $env:WINSMUX_ROLE_MAP = '{"pane-self":"Commander","pane-commander":"Commander","pane-builder":"Builder","pane-worker":"Worker","pane-researcher":"Researcher","pane-reviewer":"Reviewer"}'
     }
 
     AfterEach {
@@ -99,13 +100,25 @@ Describe 'Assert-Role' {
 
     It 'allows Reviewer to message Commander and denies privileged commands' {
         $env:WINSMUX_ROLE = 'Reviewer'
-        $env:WINSMUX_ROLE_MAP = '{"pane-self":"Reviewer","pane-commander":"Commander","pane-builder":"Builder","pane-researcher":"Researcher","pane-reviewer":"Reviewer"}'
+        $env:WINSMUX_ROLE_MAP = '{"pane-self":"Reviewer","pane-commander":"Commander","pane-builder":"Builder","pane-worker":"Worker","pane-researcher":"Researcher","pane-reviewer":"Reviewer"}'
 
         (Assert-Role -Command 'message' -TargetPane 'commander') | Should -Be $true
         (Assert-Role -Command 'review-request') | Should -Be $true
         (Assert-Role -Command 'review-approve') | Should -Be $true
         (Assert-Role -Command 'status') | Should -Be $true
         (Assert-Role -Command 'list') | Should -Be $true
+        (Assert-Role -Command 'vault') | Should -Be $false
+        (Assert-Role -Command 'focus') | Should -Be $false
+    }
+
+    It 'allows Worker to act as a review-capable pane while staying non-privileged' {
+        $env:WINSMUX_ROLE = 'Worker'
+        $env:WINSMUX_ROLE_MAP = '{"pane-self":"Worker","pane-commander":"Commander","pane-builder":"Builder","pane-worker":"Worker","pane-researcher":"Researcher","pane-reviewer":"Reviewer"}'
+
+        (Assert-Role -Command 'message' -TargetPane 'commander') | Should -Be $true
+        (Assert-Role -Command 'review-request') | Should -Be $true
+        (Assert-Role -Command 'review-approve') | Should -Be $true
+        (Assert-Role -Command 'review-fail') | Should -Be $true
         (Assert-Role -Command 'vault') | Should -Be $false
         (Assert-Role -Command 'focus') | Should -Be $false
     }
@@ -144,17 +157,23 @@ Describe 'Get-BridgeSettings' {
 
         $settings.agent | Should -Be 'codex'
         $settings.model | Should -Be 'gpt-5.4'
-        $settings.builders | Should -Be 1
-        $settings.researchers | Should -Be 1
-        $settings.reviewers | Should -Be 1
+        $settings.external_commander | Should -Be $true
+        $settings.legacy_role_layout | Should -Be $false
+        $settings.commanders | Should -Be 0
+        $settings.worker_count | Should -Be 6
+        $settings.builders | Should -Be 0
+        $settings.researchers | Should -Be 0
+        $settings.reviewers | Should -Be 0
         $settings.terminal | Should -Be 'background'
         $settings.vault_keys | Should -Be @('GH_TOKEN')
     }
 
     It 'applies global overrides and lets project settings take precedence per key' {
-        @'
+@'
 agent: claude
 reviewers: 3
+external-commander: false
+legacy-role-layout: true
 vault-keys:
   - GH_TOKEN
   - OPENAI_API_KEY
@@ -167,6 +186,8 @@ terminal: tab
             switch ($Name) {
                 '@bridge-agent' { 'gemini' }
                 '@bridge-model' { 'gpt-5.5-mini' }
+                '@bridge-external-commander' { 'on' }
+                '@bridge-worker-count' { '9' }
                 '@bridge-builders' { '7' }
                 '@bridge-researchers' { '2' }
                 '@bridge-reviewers' { '5' }
@@ -180,6 +201,9 @@ terminal: tab
 
         $settings.agent | Should -Be 'claude'
         $settings.model | Should -Be 'gpt-5.5-mini'
+        $settings.external_commander | Should -Be $false
+        $settings.legacy_role_layout | Should -Be $true
+        $settings.worker_count | Should -Be 9
         $settings.builders | Should -Be 7
         $settings.researchers | Should -Be 2
         $settings.reviewers | Should -Be 3
@@ -226,6 +250,52 @@ roles:
         $commanderConfig = Get-RoleAgentConfig -Role 'Commander' -Settings $settings
         $commanderConfig.Agent | Should -Be 'codex'
         $commanderConfig.Model | Should -Be 'gpt-5.4'
+    }
+}
+
+Describe 'Get-OrchestraLayoutSettings' {
+    BeforeAll {
+        . (Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\orchestra-start.ps1')
+    }
+
+    It 'uses external commander mode by default' {
+        $layout = Get-OrchestraLayoutSettings -Settings ([ordered]@{
+            external_commander = $true
+            worker_count       = 6
+            legacy_role_layout = $false
+            commanders         = 0
+            builders           = 0
+            researchers        = 0
+            reviewers          = 0
+        })
+
+        $layout.ExternalCommander | Should -Be $true
+        $layout.LegacyRoleLayout | Should -Be $false
+        $layout.Commanders | Should -Be 0
+        $layout.Workers | Should -Be 6
+        $layout.Builders | Should -Be 0
+        $layout.Researchers | Should -Be 0
+        $layout.Reviewers | Should -Be 0
+    }
+
+    It 'preserves legacy role layouts when explicit legacy counts are configured' {
+        $layout = Get-OrchestraLayoutSettings -Settings ([ordered]@{
+            external_commander = $true
+            worker_count       = 6
+            legacy_role_layout = $false
+            commanders         = 0
+            builders           = 4
+            researchers        = 1
+            reviewers          = 1
+        })
+
+        $layout.ExternalCommander | Should -Be $false
+        $layout.LegacyRoleLayout | Should -Be $true
+        $layout.Commanders | Should -Be 0
+        $layout.Workers | Should -Be 0
+        $layout.Builders | Should -Be 4
+        $layout.Researchers | Should -Be 1
+        $layout.Reviewers | Should -Be 1
     }
 }
 
@@ -393,9 +463,9 @@ STATUS: VERIFY_PASS
         $defaultTargets.BuildTarget | Should -Be 'builder-1'
         $defaultTargets.VerifyTarget | Should -Be 'reviewer'
 
-        $fallbackTargets = Get-TeamPipelineStageTargets -BuilderLabel 'builder-1' -ResearcherLabel '' -ReviewerLabel ''
-        $fallbackTargets.PlanTarget | Should -Be 'builder-1'
-        $fallbackTargets.VerifyTarget | Should -Be 'builder-1'
+        $workerTargets = Get-TeamPipelineStageTargets -BuilderLabel 'worker-1' -ResearcherLabel '' -ReviewerLabel ''
+        $workerTargets.PlanTarget | Should -Be 'worker-1'
+        $workerTargets.VerifyTarget | Should -Be 'worker-1'
 
         $skipTargets = Get-TeamPipelineStageTargets -BuilderLabel 'builder-1' -ResearcherLabel 'researcher' -ReviewerLabel 'reviewer' -SkipPlan -SkipVerify
         $skipTargets.PlanTarget | Should -BeNullOrEmpty
@@ -2477,6 +2547,28 @@ panes:
         $summary.new_events | Should -Be 1
         $summary.dispatches | Should -Be 1
         $summary.messages[0] | Should -Be 'builder-1 (%2) がアイドル。次タスクのディスパッチが必要'
+    }
+
+    It 'prefers a worker as the review target when no reviewer pane exists' {
+@"
+version: 1
+saved_at: 2026-04-09T11:00:00+09:00
+session:
+  name: winsmux-orchestra
+  project_dir: $script:commanderPollTempRoot
+panes:
+  worker-1:
+    pane_id: %2
+    role: Worker
+    launch_dir: $script:commanderPollTempRoot
+"@ | Set-Content -Path $script:commanderPollManifestPath -Encoding UTF8
+
+        $manifest = Read-CommanderPollManifest -Path $script:commanderPollManifestPath
+        $reviewPane = Get-CommanderPollPreferredReviewPane -Manifest $manifest
+
+        $reviewPane.PaneId | Should -Be '%2'
+        $reviewPane.Label | Should -Be 'worker-1'
+        $reviewPane.Role | Should -Be 'Worker'
     }
 
     It 'appends commander poll log records as jsonl' {

--- a/winsmux-core/scripts/agent-launch.ps1
+++ b/winsmux-core/scripts/agent-launch.ps1
@@ -38,7 +38,7 @@ function Get-AgentBootstrapPrompt {
         return $null
     }
 
-    if ($Role.Trim().ToLowerInvariant() -ne 'builder') {
+    if ($Role.Trim().ToLowerInvariant() -notin @('builder', 'worker')) {
         return $null
     }
 

--- a/winsmux-core/scripts/commander-poll.ps1
+++ b/winsmux-core/scripts/commander-poll.ps1
@@ -781,6 +781,31 @@ function Invoke-CommanderPollCycle {
     }
 }
 
+function Get-CommanderPollPreferredReviewPane {
+    param([AllowNull()]$Manifest)
+
+    if ($null -eq $Manifest -or $null -eq $Manifest.Panes) {
+        return $null
+    }
+
+    foreach ($preferredRole in @('Reviewer', 'Worker')) {
+        foreach ($label in $Manifest.Panes.Keys) {
+            $pane = $Manifest.Panes[$label]
+            $role = [string](Get-CommanderPollValue -InputObject $pane -Name 'role' -Default '')
+            $status = [string](Get-CommanderPollValue -InputObject $pane -Name 'status' -Default '')
+            if ($role -eq $preferredRole -and $status -ne 'bootstrap_invalid') {
+                return [ordered]@{
+                    PaneId = [string](Get-CommanderPollValue -InputObject $pane -Name 'pane_id' -Default '')
+                    Label  = [string]$label
+                    Role   = $role
+                }
+            }
+        }
+    }
+
+    return $null
+}
+
 function Invoke-CommanderStateMachine {
     param(
         [Parameter(Mandatory = $true)][string]$CurrentState,
@@ -807,31 +832,18 @@ function Invoke-CommanderStateMachine {
                 $branch = (git -C $ProjectDir rev-parse --abbrev-ref HEAD 2>$null)
                 $headSha = (git -C $ProjectDir rev-parse HEAD 2>$null)
                 $manifest = Read-CommanderPollManifest -Path $ManifestPath
-                $reviewerPaneId = $null
-                $reviewerLabel = $null
-                if ($manifest.Panes) {
-                    foreach ($lbl in $manifest.Panes.Keys) {
-                        $p = $manifest.Panes[$lbl]
-                        $r = [string](Get-CommanderPollValue -InputObject $p -Name 'role' -Default '')
-                        $s = [string](Get-CommanderPollValue -InputObject $p -Name 'status' -Default '')
-                        if ($r -eq 'Reviewer' -and $s -ne 'bootstrap_invalid') {
-                            $reviewerPaneId = [string](Get-CommanderPollValue -InputObject $p -Name 'pane_id' -Default '')
-                            $reviewerLabel = $lbl
-                            break
-                        }
-                    }
-                }
-                if ([string]::IsNullOrWhiteSpace($reviewerPaneId)) {
+                $reviewPane = Get-CommanderPollPreferredReviewPane -Manifest $manifest
+                if ($null -eq $reviewPane -or [string]::IsNullOrWhiteSpace([string]$reviewPane.PaneId)) {
                     Send-CommanderTelegramNotification -ProjectDir $ProjectDir -SessionName $SessionName `
-                        -Event 'commander.blocked' -Message "Reviewer ペインが見つかりません。" -Branch $branch -HeadSha $headSha
-                    $nextState = 'blocked_no_reviewer'
+                        -Event 'commander.blocked' -Message "Review 可能なペインが見つかりません。" -Branch $branch -HeadSha $headSha
+                    $nextState = 'blocked_no_review_target'
                 } else {
                     $wb = Get-WinsmuxBin
-                    & $wb send-keys -t $reviewerPaneId -l 'winsmux review-request' 2>$null | Out-Null
-                    & $wb send-keys -t $reviewerPaneId Enter 2>$null | Out-Null
+                    & $wb send-keys -t $reviewPane.PaneId -l 'winsmux review-request' 2>$null | Out-Null
+                    & $wb send-keys -t $reviewPane.PaneId Enter 2>$null | Out-Null
                     Send-CommanderTelegramNotification -ProjectDir $ProjectDir -SessionName $SessionName `
-                        -Event 'commander.review_requested' -Message "$reviewerLabel ($reviewerPaneId) にレビュー依頼送信。PASS/FAIL 待機中。" `
-                        -PaneId $reviewerPaneId -Label $reviewerLabel -Role 'Reviewer' -Branch $branch -HeadSha $headSha
+                        -Event 'commander.review_requested' -Message "$($reviewPane.Label) ($($reviewPane.PaneId)) にレビュー依頼送信。PASS/FAIL 待機中。" `
+                        -PaneId $reviewPane.PaneId -Label $reviewPane.Label -Role $reviewPane.Role -Branch $branch -HeadSha $headSha
                     $nextState = 'review_requested'
                 }
             } catch {
@@ -856,26 +868,19 @@ function Invoke-CommanderStateMachine {
                         if ($null -ne $rsRequest -and $rsRequest -is [System.Collections.IDictionary] -and $rsRequest.Contains('target_reviewer_pane_id')) {
                             $rsReviewerPaneId = [string]$rsRequest['target_reviewer_pane_id']
                         }
-                        $manifestReviewerPaneId = ''
+                        $manifestReviewPaneId = ''
                         $manifest2 = Read-CommanderPollManifest -Path $ManifestPath
-                        if ($manifest2.Panes) {
-                            foreach ($lbl2 in $manifest2.Panes.Keys) {
-                                $p2 = $manifest2.Panes[$lbl2]
-                                $r2 = [string](Get-CommanderPollValue -InputObject $p2 -Name 'role' -Default '')
-                                $s2 = [string](Get-CommanderPollValue -InputObject $p2 -Name 'status' -Default '')
-                                if ($r2 -eq 'Reviewer' -and $s2 -ne 'bootstrap_invalid') {
-                                    $manifestReviewerPaneId = [string](Get-CommanderPollValue -InputObject $p2 -Name 'pane_id' -Default '')
-                                    break
-                                }
-                            }
+                        $reviewPane = Get-CommanderPollPreferredReviewPane -Manifest $manifest2
+                        if ($null -ne $reviewPane) {
+                            $manifestReviewPaneId = [string]$reviewPane.PaneId
                         }
-                        $reviewerMatch = [string]::IsNullOrWhiteSpace($rsReviewerPaneId) -or $rsReviewerPaneId -eq $manifestReviewerPaneId
+                        $reviewerMatch = [string]::IsNullOrWhiteSpace($rsReviewerPaneId) -or $rsReviewerPaneId -eq $manifestReviewPaneId
                         if ($st -eq 'PASS' -and $sha -eq $headSha -and $reviewerMatch) {
                             Send-CommanderTelegramNotification -ProjectDir $ProjectDir -SessionName $SessionName `
                                 -Event 'commander.review_passed' -Message "レビュー PASS。" -Branch $branch -HeadSha $headSha
                             $nextState = 'review_passed'
                         } elseif ($st -eq 'PASS' -and $sha -eq $headSha -and -not $reviewerMatch) {
-                            Write-Warning "TASK-238: review PASS pane_id mismatch: review-state=$rsReviewerPaneId manifest=$manifestReviewerPaneId"
+                            Write-Warning "TASK-238: review PASS pane_id mismatch: review-state=$rsReviewerPaneId manifest=$manifestReviewPaneId"
                         } elseif ($st -eq 'FAIL') {
                             Send-CommanderTelegramNotification -ProjectDir $ProjectDir -SessionName $SessionName `
                                 -Event 'commander.review_failed' -Message "レビュー FAIL。修正が必要。" -Branch $branch -HeadSha $headSha
@@ -904,19 +909,11 @@ function Invoke-CommanderStateMachine {
         'blocked_review_failed' {
             if ([int]$CycleSummary['completions'] -gt 0) { $nextState = 'waiting_for_review' }
         }
-        'blocked_no_reviewer' {
+        'blocked_no_review_target' {
             try {
                 $manifest = Read-CommanderPollManifest -Path $ManifestPath
-                if ($manifest.Panes) {
-                    foreach ($lbl in $manifest.Panes.Keys) {
-                        $p = $manifest.Panes[$lbl]
-                        $r = [string](Get-CommanderPollValue -InputObject $p -Name 'role' -Default '')
-                        $s = [string](Get-CommanderPollValue -InputObject $p -Name 'status' -Default '')
-                        if ($r -eq 'Reviewer' -and $s -ne 'bootstrap_invalid') {
-                            $nextState = 'waiting_for_review'
-                            break
-                        }
-                    }
+                if ($null -ne (Get-CommanderPollPreferredReviewPane -Manifest $manifest)) {
+                    $nextState = 'waiting_for_review'
                 }
             } catch { }
         }

--- a/winsmux-core/scripts/dispatch-router.ps1
+++ b/winsmux-core/scripts/dispatch-router.ps1
@@ -2,8 +2,8 @@
 param(
     [string]$Text,
     [string[]]$AvailableTargets = @(),
-    [ValidateSet('Builder', 'Reviewer', 'Researcher', 'Commander')]
-    [string]$DefaultRole = 'Builder',
+    [ValidateSet('Worker', 'Builder', 'Reviewer', 'Researcher', 'Commander')]
+    [string]$DefaultRole = 'Worker',
     [switch]$AsJson
 )
 
@@ -13,6 +13,7 @@ Set-StrictMode -Version Latest
 
 function Get-DispatchRouterKeywordMap {
     return [ordered]@{
+        Worker = @('worker', 'worker-1', 'worker-2', 'worker-3', 'worker-4', 'worker-5', 'worker-6')
         Builder = @(
             'implement', 'implementation', 'build', 'builder', 'fix', 'bug', 'patch',
             'code', 'coding', 'refactor', 'write', 'edit', 'change', 'feature',
@@ -42,6 +43,7 @@ function Get-DispatchRouterCanonicalRole {
     param([Parameter(Mandatory = $true)][string]$RoleOrLabel)
 
     switch -Regex ($RoleOrLabel) {
+        '^(?i)worker(?:$|[-_:/\s])' { return 'Worker' }
         '^(?i)builder(?:$|[-_:/\s])' { return 'Builder' }
         '^(?i)reviewer(?:$|[-_:/\s])' { return 'Reviewer' }
         '^(?i)researcher(?:$|[-_:/\s])' { return 'Researcher' }
@@ -108,8 +110,8 @@ function Get-DispatchRoute {
     param(
         [Parameter(Mandatory = $true)][AllowEmptyString()][string]$Text,
         [string[]]$AvailableTargets = @(),
-        [ValidateSet('Builder', 'Reviewer', 'Researcher', 'Commander')]
-        [string]$DefaultRole = 'Builder'
+        [ValidateSet('Worker', 'Builder', 'Reviewer', 'Researcher', 'Commander')]
+        [string]$DefaultRole = 'Worker'
     )
 
     $keywordMap = Get-DispatchRouterKeywordMap
@@ -144,6 +146,10 @@ function Get-DispatchRoute {
     }
 
     $selectedTarget = Get-DispatchRouterPreferredLabel -Role $bestRole -AvailableTargets $AvailableTargets
+    if ($bestRole -ne 'Commander' -and $null -eq $selectedTarget) {
+        $selectedTarget = Get-DispatchRouterPreferredLabel -Role 'Worker' -AvailableTargets $AvailableTargets
+    }
+
     $handleLocally = $bestRole -eq 'Commander' -or $null -eq $selectedTarget
 
     $reason = if ($bestScore -gt 0) {
@@ -154,6 +160,8 @@ function Get-DispatchRoute {
 
     if ($bestRole -ne 'Commander' -and $null -eq $selectedTarget) {
         $reason = "$reason No '$bestRole' target is available."
+    } elseif ($bestRole -ne 'Commander' -and $null -ne $selectedTarget -and (Get-DispatchRouterCanonicalRole $selectedTarget) -eq 'Worker') {
+        $reason = "$reason Routed to generic worker target '$selectedTarget'."
     }
 
     if ($bestRole -eq 'Commander') {

--- a/winsmux-core/scripts/orchestra-cleanup.ps1
+++ b/winsmux-core/scripts/orchestra-cleanup.ps1
@@ -1,7 +1,7 @@
 function Test-OrchestraManagedPaneTitle {
     param([AllowEmptyString()][string]$Title)
 
-    return $Title -match '^(?i)(builder|researcher|reviewer)-\d+$'
+    return $Title -match '^(?i)(worker|builder|researcher|reviewer)-\d+$'
 }
 
 function Get-StaleOrchestraPaneTargets {

--- a/winsmux-core/scripts/orchestra-layout.ps1
+++ b/winsmux-core/scripts/orchestra-layout.ps1
@@ -5,10 +5,11 @@
 [CmdletBinding()]
 param(
     [string]$SessionName = $env:WINSMUX_ORCHESTRA_SESSION,
-    [int]$Commanders = 1,
-    [int]$Builders = 1,
-    [int]$Researchers = 1,
-[int]$Reviewers = 1
+    [int]$Commanders = 0,
+    [int]$Workers = 0,
+    [int]$Builders = 0,
+    [int]$Researchers = 0,
+    [int]$Reviewers = 0
 )
 
 $ErrorActionPreference = 'Stop'
@@ -95,6 +96,7 @@ function Split-Equal {
 function Get-RoleLabels {
     param(
         [int]$CommanderCount = 0,
+        [int]$WorkerCount = 0,
         [int]$BuilderCount,
         [int]$ResearcherCount,
         [int]$ReviewerCount
@@ -104,6 +106,10 @@ function Get-RoleLabels {
 
     for ($i = 1; $i -le $CommanderCount; $i++) {
         $labels.Add("Commander-$i")
+    }
+
+    for ($i = 1; $i -le $WorkerCount; $i++) {
+        $labels.Add("Worker-$i")
     }
 
     for ($i = 1; $i -le $BuilderCount; $i++) {
@@ -122,6 +128,7 @@ function Get-RoleLabels {
 }
 
 Test-PositiveCount -Name 'Commanders' -Value $Commanders
+Test-PositiveCount -Name 'Workers' -Value $Workers
 Test-PositiveCount -Name 'Builders' -Value $Builders
 Test-PositiveCount -Name 'Researchers' -Value $Researchers
 Test-PositiveCount -Name 'Reviewers' -Value $Reviewers
@@ -130,7 +137,7 @@ if ([string]::IsNullOrWhiteSpace($SessionName)) {
     throw 'SessionName is required. Pass -SessionName or set WINSMUX_ORCHESTRA_SESSION.'
 }
 
-$total = $Commanders + $Builders + $Researchers + $Reviewers
+$total = $Commanders + $Workers + $Builders + $Researchers + $Reviewers
 if ($total -lt 1 -or $total -gt 12) {
     throw "Total panes must be 1-12 (got $total)."
 }
@@ -199,7 +206,7 @@ if ($allIds.Count -lt $total) {
     throw "Expected at least $total panes but found $($allIds.Count)."
 }
 
-$labels = Get-RoleLabels -CommanderCount $Commanders -BuilderCount $Builders -ResearcherCount $Researchers -ReviewerCount $Reviewers
+$labels = Get-RoleLabels -CommanderCount $Commanders -WorkerCount $Workers -BuilderCount $Builders -ResearcherCount $Researchers -ReviewerCount $Reviewers
 $assignments = [System.Collections.Generic.List[object]]::new()
 
 for ($index = 0; $index -lt $total; $index++) {
@@ -224,6 +231,7 @@ if ($LASTEXITCODE -ne 0) {
 
 [PSCustomObject]@{
     Builders    = $Builders
+    Workers     = $Workers
     Researchers = $Researchers
     Reviewers   = $Reviewers
     Total       = $total

--- a/winsmux-core/scripts/orchestra-start.ps1
+++ b/winsmux-core/scripts/orchestra-start.ps1
@@ -242,11 +242,54 @@ function Get-CanonicalRole {
     param([Parameter(Mandatory = $true)][string]$AssignmentRole)
 
     switch -Regex ($AssignmentRole) {
+        '^(?i)worker(?:$|[-_:/\s])' { return 'Worker' }
         '^(?i)builder(?:$|[-_:/\s])' { return 'Builder' }
         '^(?i)researcher(?:$|[-_:/\s])' { return 'Researcher' }
         '^(?i)reviewer(?:$|[-_:/\s])' { return 'Reviewer' }
         '^(?i)commander(?:$|[-_:/\s])' { return 'Commander' }
         default { throw "Unsupported pane role label: $AssignmentRole" }
+    }
+}
+
+function Get-OrchestraLayoutSettings {
+    param([Parameter(Mandatory = $true)]$Settings)
+
+    $commanders = [int]$Settings.commanders
+    $workers = [int]$Settings.worker_count
+    $builders = [int]$Settings.builders
+    $researchers = [int]$Settings.researchers
+    $reviewers = [int]$Settings.reviewers
+    $externalCommander = [bool]$Settings.external_commander
+    $legacyRoleLayout = [bool]$Settings.legacy_role_layout
+
+    $legacyCount = $commanders + $builders + $researchers + $reviewers
+    $useLegacyLayout = $legacyRoleLayout -or $legacyCount -gt 0
+
+    if ($useLegacyLayout) {
+        return [ordered]@{
+            ExternalCommander = $false
+            LegacyRoleLayout  = $true
+            Commanders        = $commanders
+            Workers           = 0
+            Builders          = $builders
+            Researchers       = $researchers
+            Reviewers         = $reviewers
+        }
+    }
+
+    $managedCommanders = if ($externalCommander) { 0 } else { 1 }
+    if ($workers -lt 1) {
+        throw "worker_count must be 1 or greater in external commander mode (got $workers)."
+    }
+
+    return [ordered]@{
+        ExternalCommander = $externalCommander
+        LegacyRoleLayout  = $false
+        Commanders        = $managedCommanders
+        Workers           = $workers
+        Builders          = 0
+        Researchers       = 0
+        Reviewers         = 0
     }
 }
 
@@ -978,9 +1021,20 @@ if ($MyInvocation.InvocationName -ne '.') {
         }
 
         $settings = Get-BridgeSettings
+        $layoutSettings = Get-OrchestraLayoutSettings -Settings $settings
         $projectDir = Get-ProjectDir
         Initialize-WinsmuxLog -ProjectDir $projectDir -SessionName $sessionName | Out-Null
-        Write-WinsmuxLog -Level INFO -Event 'preflight.settings.loaded' -Message 'Loaded orchestra settings.' -Data @{ agent = $settings.agent; model = $settings.model } | Out-Null
+        Write-WinsmuxLog -Level INFO -Event 'preflight.settings.loaded' -Message 'Loaded orchestra settings.' -Data @{
+            agent              = $settings.agent
+            model              = $settings.model
+            external_commander = $layoutSettings.ExternalCommander
+            legacy_role_layout = $layoutSettings.LegacyRoleLayout
+            workers            = $layoutSettings.Workers
+            commanders         = $layoutSettings.Commanders
+            builders           = $layoutSettings.Builders
+            researchers        = $layoutSettings.Researchers
+            reviewers          = $layoutSettings.Reviewers
+        } | Out-Null
         Write-WinsmuxLog -Level INFO -Event 'preflight.winsmux_bin.ready' -Message "Using winsmux binary: $winsmuxBin." -Data @{ winsmux_bin = $winsmuxBin } | Out-Null
         Write-WinsmuxLog -Level INFO -Event 'preflight.bridge_script.ready' -Message "Using bridge script: $bridgeScript." -Data @{ bridge_script = $bridgeScript } | Out-Null
         Write-WinsmuxLog -Level INFO -Event 'preflight.project_dir.resolved' -Message "Resolved project directory: $projectDir." -Data @{ project_dir = $projectDir } | Out-Null
@@ -1018,7 +1072,7 @@ if ($MyInvocation.InvocationName -ne '.') {
     try {
         $existingPanes = & $winsmuxBin list-panes -F '#{pane_id} #{pane_title}' 2>$null
         if ($LASTEXITCODE -eq 0 -and $existingPanes) {
-            $orchestraLabels = @('builder-', 'researcher-', 'reviewer-')
+                    $orchestraLabels = @('worker-', 'builder-', 'researcher-', 'reviewer-')
             foreach ($line in ($existingPanes -split "`n")) {
                 $parts = $line.Trim() -split '\s+', 2
                 if ($parts.Count -ge 2) {
@@ -1124,8 +1178,8 @@ if ($MyInvocation.InvocationName -ne '.') {
 
         try {
             try {
-                Write-Warning "DEBUG: layout start session=$sessionName C=$($settings.commanders) B=$($settings.builders) R=$($settings.researchers) Rev=$($settings.reviewers)"
-                $layout = . $layoutScript -SessionName $sessionName -Commanders $settings.commanders -Builders $settings.builders -Researchers $settings.researchers -Reviewers $settings.reviewers
+                Write-Warning "DEBUG: layout start session=$sessionName external=$($layoutSettings.ExternalCommander) legacy=$($layoutSettings.LegacyRoleLayout) C=$($layoutSettings.Commanders) W=$($layoutSettings.Workers) B=$($layoutSettings.Builders) R=$($layoutSettings.Researchers) Rev=$($layoutSettings.Reviewers)"
+                $layout = . $layoutScript -SessionName $sessionName -Commanders $layoutSettings.Commanders -Workers $layoutSettings.Workers -Builders $layoutSettings.Builders -Researchers $layoutSettings.Researchers -Reviewers $layoutSettings.Reviewers
                 Write-Warning "DEBUG: layout done, panes=$($layout.Panes.Count)"
                 foreach ($sessionPaneId in @(Get-OrchestraSessionPaneIds -SessionName $sessionName)) {
                     if ($createdPaneIds -notcontains $sessionPaneId) {
@@ -1181,7 +1235,7 @@ if ($MyInvocation.InvocationName -ne '.') {
         $builderBranch = $null
         $builderWorktreePath = $null
 
-        if ($canonicalRole -eq 'Builder') {
+        if ($canonicalRole -in @('Builder', 'Worker')) {
             $builderIndex++
             $builderWorktree = New-BuilderWorktree -ProjectDir $projectDir -BuilderIndex $builderIndex
             $createdWorktrees += [ordered]@{
@@ -1210,8 +1264,8 @@ if ($MyInvocation.InvocationName -ne '.') {
             # TASK-236: inject role and pane_id into pane process
             Send-OrchestraBridgeCommand -Target $paneId -Text "`$env:WINSMUX_ROLE = '$canonicalRole'"
             Send-OrchestraBridgeCommand -Target $paneId -Text "`$env:WINSMUX_PANE_ID = '$paneId'"
-            # TASK-234: inject worktree path for Builder isolation (#347)
-            if ($canonicalRole -eq 'Builder' -and -not [string]::IsNullOrWhiteSpace($builderWorktreePath)) {
+            # Workers currently share the Builder-style isolated worktree model.
+            if ($canonicalRole -in @('Builder', 'Worker') -and -not [string]::IsNullOrWhiteSpace($builderWorktreePath)) {
                 Send-OrchestraBridgeCommand -Target $paneId -Text "`$env:WINSMUX_BUILDER_WORKTREE = '$builderWorktreePath'"
             }
             Start-Sleep -Milliseconds 300
@@ -1307,6 +1361,13 @@ if ($MyInvocation.InvocationName -ne '.') {
     Write-Output "Orchestra session: $sessionName"
     Write-Output "Agent: $($settings.agent)"
     Write-Output "Model: $($settings.model)"
+    if ($layoutSettings.LegacyRoleLayout) {
+        Write-Output "Mode: legacy role layout"
+    } elseif ($layoutSettings.ExternalCommander) {
+        Write-Output "Mode: external commander + $($layoutSettings.Workers) workers"
+    } else {
+        Write-Output "Mode: managed commander + $($layoutSettings.Workers) workers"
+    }
     Write-Output "ProjectDir: $projectDir"
     Write-Output "GitWorktreeDir: $gitWorktreeDir"
     Write-Output ''
@@ -1315,10 +1376,10 @@ if ($MyInvocation.InvocationName -ne '.') {
         Write-Output ("  {0,-14} {1,-8} {2}" -f $paneSummary.Label, $paneSummary.PaneId, $paneSummary.Role)
     }
 
-    $builderPaneSummaries = @($paneSummaries | Where-Object { $_.Role -eq 'Builder' -and -not [string]::IsNullOrWhiteSpace($_.BuilderWorktreePath) })
+    $builderPaneSummaries = @($paneSummaries | Where-Object { $_.Role -in @('Builder', 'Worker') -and -not [string]::IsNullOrWhiteSpace($_.BuilderWorktreePath) })
     if ($builderPaneSummaries.Count -gt 0) {
         Write-Output ''
-        Write-Output 'Cleanup: remove Builder worktrees after the session ends.'
+        Write-Output 'Cleanup: remove managed worktrees after the session ends.'
         foreach ($paneSummary in $builderPaneSummaries) {
             $relativeWorktree = [System.IO.Path]::GetRelativePath($projectDir, $paneSummary.BuilderWorktreePath)
             Write-Output ("  git -C {0} worktree remove {1} ; git -C {0} branch -D {2}" -f $projectDir, $relativeWorktree, $paneSummary.BuilderBranch)

--- a/winsmux-core/scripts/orchestra-state.ps1
+++ b/winsmux-core/scripts/orchestra-state.ps1
@@ -252,7 +252,7 @@ function Get-OrchestraPaneReviewRecord {
         return $ReviewState[$Branch]
     }
 
-    if ($Role -ne 'Reviewer') {
+    if ($Role -notin @('Reviewer', 'Worker')) {
         return $null
     }
 

--- a/winsmux-core/scripts/pane-control.ps1
+++ b/winsmux-core/scripts/pane-control.ps1
@@ -113,6 +113,7 @@ function Get-PaneControlCanonicalRole {
     }
 
     switch -Regex ($candidate.Trim()) {
+        '^(?i)worker(?:$|[-_:/\s])' { return 'Worker' }
         '^(?i)builder(?:$|[-_:/\s])' { return 'Builder' }
         '^(?i)researcher(?:$|[-_:/\s])' { return 'Researcher' }
         '^(?i)reviewer(?:$|[-_:/\s])' { return 'Reviewer' }
@@ -216,7 +217,7 @@ function Get-PaneControlManifestEntries {
         }
 
         $gitWorktreeDir = $sessionGitWorktreeDir
-        if ($role -eq 'Builder' -or [string]::IsNullOrWhiteSpace($gitWorktreeDir)) {
+        if ($role -in @('Builder', 'Worker') -or [string]::IsNullOrWhiteSpace($gitWorktreeDir)) {
             $gitWorktreeDir = Get-PaneControlGitWorktreeDir -ProjectDir $launchDir
         }
 

--- a/winsmux-core/scripts/pane-scaler.ps1
+++ b/winsmux-core/scripts/pane-scaler.ps1
@@ -62,6 +62,7 @@ function Get-PaneScalerCanonicalRole {
     }
 
     switch -Regex ($candidate.Trim()) {
+        '^(?i)worker(?:$|[-_:/\s])' { return 'Worker' }
         '^(?i)builder(?:$|[-_:/\s])' { return 'Builder' }
         '^(?i)researcher(?:$|[-_:/\s])' { return 'Researcher' }
         '^(?i)reviewer(?:$|[-_:/\s])' { return 'Reviewer' }

--- a/winsmux-core/scripts/planning-paths.ps1
+++ b/winsmux-core/scripts/planning-paths.ps1
@@ -1,9 +1,81 @@
 [CmdletBinding()]
 param()
 
+function Get-WinsmuxPlanningRootMarkerPath {
+    $localAppData = if ($env:LOCALAPPDATA) { $env:LOCALAPPDATA } else { [Environment]::GetFolderPath('LocalApplicationData') }
+    return Join-Path $localAppData 'winsmux\planning-root.txt'
+}
+
+function Get-WinsmuxPlanningRootFromMarker {
+    $markerPath = Get-WinsmuxPlanningRootMarkerPath
+    if (-not (Test-Path -LiteralPath $markerPath)) {
+        return $null
+    }
+
+    try {
+        $markerValue = (Get-Content -LiteralPath $markerPath -Raw -ErrorAction Stop).Trim()
+        if (-not [string]::IsNullOrWhiteSpace($markerValue)) {
+            return $markerValue
+        }
+    } catch {
+        return $null
+    }
+
+    return $null
+}
+
+function Find-WinsmuxPlanningRoot {
+    param([Parameter(Mandatory = $true)][string]$UserProfile)
+
+    try {
+        $backlogFiles = Get-ChildItem -LiteralPath $UserProfile -Filter 'backlog.yaml' -File -Recurse -Depth 8 -ErrorAction SilentlyContinue
+        foreach ($file in $backlogFiles) {
+            $directory = $file.DirectoryName
+            if ([string]::IsNullOrWhiteSpace($directory)) {
+                continue
+            }
+
+            if ($directory -notmatch '[\\/]winsmux[\\/]planning$') {
+                continue
+            }
+
+            if (Test-Path -LiteralPath (Join-Path $directory 'ROADMAP.md')) {
+                return $directory
+            }
+        }
+    } catch {
+        return $null
+    }
+
+    return $null
+}
+
 function Get-WinsmuxDefaultPlanningRoot {
+    $cachedPlanningRoot = $null
+    $cachedVariable = Get-Variable -Scope Script -Name WinsmuxDefaultPlanningRoot -ErrorAction SilentlyContinue
+    if ($cachedVariable) {
+        $cachedPlanningRoot = [string]$cachedVariable.Value
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($cachedPlanningRoot)) {
+        return $cachedPlanningRoot
+    }
+
     $userProfile = if ($env:USERPROFILE) { $env:USERPROFILE } else { [Environment]::GetFolderPath('UserProfile') }
-    return Join-Path $userProfile 'iCloudDrive\iCloud~md~obsidian\MainVault\Projects\winsmux\planning'
+    $markerRoot = Get-WinsmuxPlanningRootFromMarker
+    if (-not [string]::IsNullOrWhiteSpace($markerRoot)) {
+        $script:WinsmuxDefaultPlanningRoot = $markerRoot
+        return $script:WinsmuxDefaultPlanningRoot
+    }
+
+    $discoveredRoot = Find-WinsmuxPlanningRoot -UserProfile $userProfile
+    if (-not [string]::IsNullOrWhiteSpace($discoveredRoot)) {
+        $script:WinsmuxDefaultPlanningRoot = $discoveredRoot
+        return $script:WinsmuxDefaultPlanningRoot
+    }
+
+    $script:WinsmuxDefaultPlanningRoot = Join-Path $userProfile '.winsmux\planning'
+    return $script:WinsmuxDefaultPlanningRoot
 }
 
 function Get-WinsmuxPlanningRoot {

--- a/winsmux-core/scripts/role-gate.ps1
+++ b/winsmux-core/scripts/role-gate.ps1
@@ -75,6 +75,44 @@ $RolePermissions = @{
         Version       = $true
         Doctor        = $true
     }
+    Worker = @{
+        ReadOwn       = $true
+        ReadOther     = $false
+        SendAny       = $false
+        SendCommander = $true
+        HealthCheck   = $false
+        Watch         = $false
+        WaitReady     = $false
+        PollEvents    = $false
+        Vault         = $false
+        Dispatch      = $false
+        DispatchReview = $false
+        TypeOwn       = $true
+        TypeOther     = $false
+        KeysOwn       = $true
+        KeysOther     = $false
+        List          = $true
+        Status        = $true
+        Name          = $true
+        Resolve       = $true
+        Focus         = $false
+        Signal        = $true
+        Wait          = $true
+        Profile       = $false
+        Lock          = $false
+        Unlock        = $false
+        Locks         = $true
+        MailboxCreate = $false
+        MailboxSend   = $true
+        MailboxListen = $false
+        Kill          = $false
+        Restart       = $false
+        ContextReset  = $false
+        ReviewApprove = $true
+        Id            = $true
+        Version       = $true
+        Doctor        = $true
+    }
     Researcher = @{
         ReadOwn       = $true
         ReadOther     = $false
@@ -164,6 +202,7 @@ function ConvertTo-CanonicalWinsmuxRole {
 
     switch -Regex ($RoleName.Trim()) {
         '^(?i)Commander$' { return 'Commander' }
+        '^(?i)Worker$' { return 'Worker' }
         '^(?i)Builder$' { return 'Builder' }
         '^(?i)Researcher$' { return 'Researcher' }
         '^(?i)Reviewer$' { return 'Reviewer' }

--- a/winsmux-core/scripts/settings.ps1
+++ b/winsmux-core/scripts/settings.ps1
@@ -15,15 +15,18 @@ Dot-source this script to load the helpers:
 
 $script:BridgeSettingsFileName = '.winsmux.yaml'
 $script:BridgeSettingsSchema = [ordered]@{
-    agent       = @{ Type = 'string';   Default = 'codex';      Option = '@bridge-agent' }
-    model       = @{ Type = 'string';   Default = 'gpt-5.4';    Option = '@bridge-model' }
-    commanders  = @{ Type = 'int';      Default = 1;            Option = '@bridge-commanders' }
-    builders    = @{ Type = 'int';      Default = 1;            Option = '@bridge-builders' }
-    researchers = @{ Type = 'int';      Default = 1;            Option = '@bridge-researchers' }
-    reviewers   = @{ Type = 'int';      Default = 1;            Option = '@bridge-reviewers' }
-    vault_keys  = @{ Type = 'string[]'; Default = @('GH_TOKEN'); Option = '@bridge-vault-keys' }
-    terminal    = @{ Type = 'string';   Default = 'background'; Option = '@bridge-terminal' }
-    roles       = @{ Type = 'map';      Default = [ordered]@{}; Option = $null }
+    agent               = @{ Type = 'string';   Default = 'codex';       Option = '@bridge-agent' }
+    model               = @{ Type = 'string';   Default = 'gpt-5.4';     Option = '@bridge-model' }
+    external_commander  = @{ Type = 'bool';     Default = $true;         Option = '@bridge-external-commander' }
+    worker_count        = @{ Type = 'int';      Default = 6;             Option = '@bridge-worker-count' }
+    legacy_role_layout  = @{ Type = 'bool';     Default = $false;        Option = '@bridge-legacy-role-layout' }
+    commanders          = @{ Type = 'int';      Default = 0;             Option = '@bridge-commanders' }
+    builders            = @{ Type = 'int';      Default = 0;             Option = '@bridge-builders' }
+    researchers         = @{ Type = 'int';      Default = 0;             Option = '@bridge-researchers' }
+    reviewers           = @{ Type = 'int';      Default = 0;             Option = '@bridge-reviewers' }
+    vault_keys          = @{ Type = 'string[]'; Default = @('GH_TOKEN'); Option = '@bridge-vault-keys' }
+    terminal            = @{ Type = 'string';   Default = 'background';  Option = '@bridge-terminal' }
+    roles               = @{ Type = 'map';      Default = [ordered]@{};  Option = $null }
 }
 
 if (-not (Get-Command Get-WinsmuxBin -ErrorAction SilentlyContinue)) {
@@ -319,6 +322,26 @@ function Test-BridgeSettingValue {
 
             $NormalizedValue.Value = $parsed
             return $true
+        }
+        'bool' {
+            $text = ConvertFrom-BridgeYamlScalar $Value
+            if ([string]::IsNullOrWhiteSpace($text)) {
+                return $false
+            }
+
+            switch -Regex ($text.Trim()) {
+                '^(?i:true|1|yes|on)$' {
+                    $NormalizedValue.Value = $true
+                    return $true
+                }
+                '^(?i:false|0|no|off)$' {
+                    $NormalizedValue.Value = $false
+                    return $true
+                }
+                default {
+                    return $false
+                }
+            }
         }
         'string[]' {
             $items = @()

--- a/winsmux-core/scripts/setup-wizard.ps1
+++ b/winsmux-core/scripts/setup-wizard.ps1
@@ -172,13 +172,36 @@ Write-Host ''
 
 $agentCli = Read-AgentCli -Default 'codex'
 $model = Read-DefaultValue -Prompt 'Model' -Default 'gpt-5.4'
-$builders = Read-PositiveInt -Prompt 'Builders count' -Default 4
-$researchers = Read-PositiveInt -Prompt 'Researchers count' -Default 1
-$reviewers = Read-PositiveInt -Prompt 'Reviewers count' -Default 1
+$externalCommander = Read-YesNo -Prompt 'Use an external Commander terminal?' -Default $true
+$legacyRoleLayout = $false
+$commanders = 0
+$workerCount = 6
+$builders = 0
+$researchers = 0
+$reviewers = 0
+
+if ($externalCommander) {
+    $workerCount = Read-PositiveInt -Prompt 'Managed worker pane count' -Default 6
+} else {
+    $legacyRoleLayout = Read-YesNo -Prompt 'Use legacy role layout (Commander/Builder/Researcher/Reviewer panes)?' -Default $true
+    if ($legacyRoleLayout) {
+        $commanders = Read-PositiveInt -Prompt 'Commanders count' -Default 1
+        $builders = Read-PositiveInt -Prompt 'Builders count' -Default 4
+        $researchers = Read-PositiveInt -Prompt 'Researchers count' -Default 1
+        $reviewers = Read-PositiveInt -Prompt 'Reviewers count' -Default 1
+    } else {
+        $commanders = Read-PositiveInt -Prompt 'Embedded commander count' -Default 1
+        $workerCount = Read-PositiveInt -Prompt 'Managed worker pane count' -Default 6
+    }
+}
 $storeVault = Read-YesNo -Prompt 'Store GH_TOKEN in the winsmux vault?' -Default $false
 
 Set-WinsmuxOption -WinsmuxBin $winsmuxBin -OptionName '@bridge-agent' -OptionValue $agentCli
 Set-WinsmuxOption -WinsmuxBin $winsmuxBin -OptionName '@bridge-model' -OptionValue $model
+Set-WinsmuxOption -WinsmuxBin $winsmuxBin -OptionName '@bridge-external-commander' -OptionValue $(if ($externalCommander) { 'on' } else { 'off' })
+Set-WinsmuxOption -WinsmuxBin $winsmuxBin -OptionName '@bridge-legacy-role-layout' -OptionValue $(if ($legacyRoleLayout) { 'on' } else { 'off' })
+Set-WinsmuxOption -WinsmuxBin $winsmuxBin -OptionName '@bridge-commanders' -OptionValue $commanders.ToString()
+Set-WinsmuxOption -WinsmuxBin $winsmuxBin -OptionName '@bridge-worker-count' -OptionValue $workerCount.ToString()
 Set-WinsmuxOption -WinsmuxBin $winsmuxBin -OptionName '@bridge-builders' -OptionValue $builders.ToString()
 Set-WinsmuxOption -WinsmuxBin $winsmuxBin -OptionName '@bridge-researchers' -OptionValue $researchers.ToString()
 Set-WinsmuxOption -WinsmuxBin $winsmuxBin -OptionName '@bridge-reviewers' -OptionValue $reviewers.ToString()
@@ -198,6 +221,10 @@ Write-Host 'Saved settings:'
 Write-Host "  winsmux binary:         $winsmuxBin"
 Write-Host "  @bridge-agent:        $agentCli"
 Write-Host "  @bridge-model:        $model"
+Write-Host "  @bridge-external-commander: $externalCommander"
+Write-Host "  @bridge-legacy-role-layout: $legacyRoleLayout"
+Write-Host "  @bridge-commanders:   $commanders"
+Write-Host "  @bridge-worker-count: $workerCount"
 Write-Host "  @bridge-builders:     $builders"
 Write-Host "  @bridge-researchers:  $researchers"
 Write-Host "  @bridge-reviewers:    $reviewers"

--- a/winsmux-core/scripts/team-pipeline.ps1
+++ b/winsmux-core/scripts/team-pipeline.ps1
@@ -2,9 +2,9 @@
 param(
     [Parameter(Position = 0)]
     [string]$Task,
-    [string]$Builder = 'builder-1',
-    [string]$Researcher = 'researcher-1',
-    [string]$Reviewer = 'reviewer-1',
+    [string]$Builder = 'worker-1',
+    [string]$Researcher = '',
+    [string]$Reviewer = '',
     [string]$ManifestPath,
     [string]$BuilderWorktreePath,
     [int]$PollIntervalSeconds = 10,
@@ -200,6 +200,22 @@ function Get-TeamPipelineStageTargets {
         PlanTarget   = $planTarget
         BuildTarget  = $BuilderLabel
         VerifyTarget = $verifyTarget
+    }
+}
+
+function Get-TeamPipelineCanonicalRole {
+    param([AllowNull()][string]$Label)
+
+    if ([string]::IsNullOrWhiteSpace($Label)) {
+        return ''
+    }
+
+    switch -Regex ($Label.Trim()) {
+        '^(?i)worker(?:$|[-_:/\s])' { return 'Worker' }
+        '^(?i)builder(?:$|[-_:/\s])' { return 'Builder' }
+        '^(?i)researcher(?:$|[-_:/\s])' { return 'Researcher' }
+        '^(?i)reviewer(?:$|[-_:/\s])' { return 'Reviewer' }
+        default { return '' }
     }
 }
 
@@ -685,7 +701,14 @@ function Invoke-TeamPipeline {
             Prompt            = $verifyPrompt
             Notification      = $buildNotification.Message
         }
-        Write-TeamPipelineEvent -ProjectDir $builderContext.ProjectDir -SessionName $sessionName -Event 'pipeline.reviewer.dispatched' -Message "Auto-dispatched review to $($targets.VerifyTarget) after builder completion." -Role 'Reviewer' -Target $targets.VerifyTarget -Data ([ordered]@{
+        $verifyRole = 'Worker'
+        if (-not [string]::IsNullOrWhiteSpace($Reviewer) -and $targets.VerifyTarget -eq $Reviewer) {
+            $verifyRole = 'Reviewer'
+        } elseif (-not [string]::IsNullOrWhiteSpace($Researcher) -and $targets.VerifyTarget -eq $Researcher) {
+            $verifyRole = 'Researcher'
+        }
+
+        Write-TeamPipelineEvent -ProjectDir $builderContext.ProjectDir -SessionName $sessionName -Event 'pipeline.reviewer.dispatched' -Message "Auto-dispatched review to $($targets.VerifyTarget) after builder completion." -Role $verifyRole -Target $targets.VerifyTarget -Data ([ordered]@{
             attempt              = $attemptIndex
             task                 = $Task
             builder              = $Builder


### PR DESCRIPTION
## Summary
- switch orchestra startup defaults to one external operator plus managed worker panes
- allow review-capable workers in review and gate flows while keeping legacy role layout as explicit compatibility mode
- remove public path leaks from planning docs and make planning root discovery generic instead of user-specific

## Validation
- `Invoke-Pester tests/Integration.MultiAgent.Tests.ps1 -Output Detailed`
- `Invoke-Pester tests/Integration.GateEnforcement.Tests.ps1 -Output Detailed`
- `Invoke-Pester tests/psmux-bridge.Tests.ps1 -Output Detailed`
- `pwsh winsmux-core/scripts/doctor.ps1`
- `node --check .claude/hooks/lib/sh-utils.js`

## Notes
- local hook delegation now forwards to the global git-guard hooks
- untracked `release/` output is intentionally excluded from this PR