### PR TITLE
fix: close v0.19.6 hardening

### DIFF
--- a/.claude/hooks/sh-orchestra-gate.js
+++ b/.claude/hooks/sh-orchestra-gate.js
@@ -40,6 +40,14 @@ try {
     }
   }
 
+  // Rule 2b: Operator shell wrappers must not write code-bearing files outside managed worker panes
+  if (toolName === "Bash") {
+    const currentRole = normalizeAgentValue(process.env.WINSMUX_ROLE);
+    if (currentRole !== "builder" && currentRole !== "worker" && isDirectCodeWriteBypassCommand(bashCommand)) {
+      deny("Operator shell write bypass blocked. Delegate implementation to managed worker panes.");
+    }
+  }
+
   // Rule 3: Protect review state from direct edits
   if (toolName === "Bash") {
     if (isDirectReviewStateWriteCommand(bashCommand)) {
@@ -97,7 +105,7 @@ try {
 
     const isAllowedAgentUse = agentMode === "plan" || subagentType === "explore";
     if (!isAllowedAgentUse) {
-      deny("Commander delegated write bypass blocked. Delegate implementation to Builder panes. Allowed: plan mode, Explore subagents.");
+      deny("Operator delegated write bypass blocked. Delegate implementation to managed worker panes. Allowed: plan mode, Explore subagents.");
     }
   }
 
@@ -440,6 +448,50 @@ function isProtectedReviewStatePath(filePath) {
   return normalized === ".winsmux/review-state.json" || normalized.endsWith("/.winsmux/review-state.json");
 }
 
+function isDirectCodeWriteBypassCommand(command) {
+  const normalized = normalizePathValue(command);
+  if (!/\.(ps1|psm1|js|ts|rs|py)\b/.test(normalized)) {
+    return false;
+  }
+
+  const codePathPattern = /[^"'|\r\n]*\.(?:ps1|psm1|js|ts|rs|py)\b/i;
+  const directWritePattern = /(?:>|>>)\s*["']?[^"'|\r\n]*\.(?:ps1|psm1|js|ts|rs|py)\b|(?:set-content|add-content|out-file|copy-item|move-item|rename-item|new-item|ni)\b[^|&\r\n]*\.(?:ps1|psm1|js|ts|rs|py)\b/i;
+  if (directWritePattern.test(normalized)) {
+    return true;
+  }
+
+  const segments = splitCommandSegments(command);
+  for (const segment of segments) {
+    const tokens = tokenizeCommandLine(segment);
+    if (tokens.length === 0) {
+      continue;
+    }
+
+    const executable = getExecutableBasename(tokens[0]);
+    if (isPowerShellExecutable(executable)) {
+      const commandArgument = getOptionValue(tokens, ["-command", "-c"]);
+      if (commandArgument && codePathPattern.test(commandArgument) && directWritePattern.test(normalizePathValue(commandArgument))) {
+        return true;
+      }
+    }
+
+    if (executable === "cmd" || executable === "cmd.exe") {
+      const shellArgument = getCmdShellArgument(tokens);
+      if (shellArgument && codePathPattern.test(shellArgument) && directWritePattern.test(normalizePathValue(shellArgument))) {
+        return true;
+      }
+    }
+
+    if ((executable === "python" || executable === "python.exe" || executable === "python3" || executable === "py") &&
+        /(?:open|write_text|write_bytes|Path\()/i.test(segment) &&
+        codePathPattern.test(segment)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 function isSettingsLocalHookMutation(command) {
   if (!/settings\.local\.json/i.test(command)) {
     return false;
@@ -556,6 +608,7 @@ module.exports = {
   hasStandaloneCommandToken,
   hasValidReviewerPass,
   isDirectCodexDispatch,
+  isDirectCodeWriteBypassCommand,
   isDirectReviewStateWriteCommand,
   isGhPrMergeCommand,
   isGitCommitCommand,

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -1,0 +1,39 @@
+# Handoff
+
+> Updated: 2026-04-10T10:15+09:00
+> Source of truth: this file
+
+## Current state
+
+- `v0.19.5` is released.
+- `v0.19.6 hardening` is implemented and tracked as `100% (6/6)` in the external planning backlog/roadmap.
+- PR [#370](https://github.com/Sora-bluesky/winsmux/pull/370) carries the repo-side hardening closure.
+- Planning source of truth is externalized outside the public repository and syncs automatically into the private planning root.
+
+## This session
+
+- Closed the remaining `v0.19.6` hardening implementation in the repo.
+- Added strict orchestra server health waiting and watchdog restart handling.
+- Hardened `winsmux send` so redraw-only pane changes do not report false success.
+- Added operator shell write-bypass blocking for direct code-file writes from non-worker panes.
+- Updated external planning so `v0.19.6` is complete and `v0.19.8` exists in the roadmap.
+
+## Validation
+
+- Full local Pester suite passed: `171/171 PASS`
+- Targeted hardening suite passed earlier: `133/133 PASS`
+- CI on PR `#370` initially failed only because `Reset-OrchestraServerSession` called the `winsmux` binary directly in a test environment where the binary is unavailable.
+- The repo now uses `Test-OrchestraServerSession` for that check so CI can be rerun cleanly.
+
+## Next actions
+
+1. Push the CI-only fix for PR `#370`.
+2. Confirm GitHub Actions is green.
+3. Merge PR `#370`.
+4. Delete the merged feature branch.
+5. Start `v0.19.7` or `v0.19.8` depending on orchestration priorities.
+
+## Notes
+
+- `HANDOFF.md` at the repository root is historical context and no longer authoritative.
+- Public tracked files must not contain personal paths or private planning roots.

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -622,6 +622,48 @@ function Invoke-WinsmuxSendKeys {
     }
 }
 
+function Split-SendKeysLiteralChunks {
+    param(
+        [Parameter(Mandatory = $true)][AllowEmptyString()][string]$Text,
+        [ValidateRange(1, 4000)][int]$ChunkSize = 900
+    )
+
+    if ($Text.Length -le $ChunkSize) {
+        return @($Text)
+    }
+
+    $chunks = [System.Collections.Generic.List[string]]::new()
+    for ($index = 0; $index -lt $Text.Length; $index += $ChunkSize) {
+        $remaining = $Text.Length - $index
+        $length = [System.Math]::Min($ChunkSize, $remaining)
+        $chunks.Add($Text.Substring($index, $length)) | Out-Null
+    }
+
+    return @($chunks)
+}
+
+function Test-PaneContainsCommandFragment {
+    param(
+        [AllowEmptyString()][string]$PaneText,
+        [AllowEmptyString()][string]$CommandText,
+        [ValidateRange(8, 256)][int]$FragmentLength = 64
+    )
+
+    if ([string]::IsNullOrWhiteSpace($PaneText) -or [string]::IsNullOrWhiteSpace($CommandText)) {
+        return $false
+    }
+
+    $normalizedPaneText = (($PaneText -replace '\s+', '')).ToLowerInvariant()
+    $normalizedCommandText = (($CommandText -replace '\s+', '')).ToLowerInvariant()
+    if ([string]::IsNullOrWhiteSpace($normalizedPaneText) -or [string]::IsNullOrWhiteSpace($normalizedCommandText)) {
+        return $false
+    }
+
+    $effectiveLength = [Math]::Min($FragmentLength, $normalizedCommandText.Length)
+    $fragment = $normalizedCommandText.Substring([Math]::Max(0, $normalizedCommandText.Length - $effectiveLength))
+    return $normalizedPaneText.Contains($fragment)
+}
+
 function Send-TextToPane {
     param(
         [Parameter(Mandatory = $true)][string]$PaneId,
@@ -633,19 +675,26 @@ function Send-TextToPane {
 
     foreach ($sendTarget in $targetCandidates) {
         $preSendText = Get-PaneSnapshotText -PaneId $PaneId -Lines 200
+        $literalChunks = @(Split-SendKeysLiteralChunks -Text $CommandText)
 
         # Type text directly (no header; headers break TUI agents like Claude Code)
-        $literalResult = Invoke-WinsmuxSendKeys -Target $sendTarget -Keys @($CommandText) -Literal
-        if ($literalResult.ExitCode -ne 0) {
-            $detail = if ([string]::IsNullOrWhiteSpace($literalResult.Output)) { 'send-keys literal failed' } else { $literalResult.Output }
-            $attemptFailures.Add("target ${sendTarget}: $detail") | Out-Null
-            continue
+        for ($chunkIndex = 0; $chunkIndex -lt $literalChunks.Count; $chunkIndex++) {
+            $literalResult = Invoke-WinsmuxSendKeys -Target $sendTarget -Keys @($literalChunks[$chunkIndex]) -Literal
+            if ($literalResult.ExitCode -ne 0) {
+                $detail = if ([string]::IsNullOrWhiteSpace($literalResult.Output)) { 'send-keys literal failed' } else { $literalResult.Output }
+                $attemptFailures.Add("target ${sendTarget}: chunk $($chunkIndex + 1)/$($literalChunks.Count) $detail") | Out-Null
+                continue 2
+            }
         }
 
         Start-Sleep -Milliseconds 300
         $typedText = Get-PaneSnapshotText -PaneId $PaneId -Lines 200
         if ($typedText -eq $preSendText) {
             $attemptFailures.Add("target ${sendTarget}: pane buffer did not change after typing") | Out-Null
+            continue
+        }
+        if (-not (Test-PaneContainsCommandFragment -PaneText $typedText -CommandText $CommandText)) {
+            $attemptFailures.Add("target ${sendTarget}: pane buffer changed but typed command fragment was not observed") | Out-Null
             continue
         }
 

--- a/tests/Integration.GateEnforcement.Tests.ps1
+++ b/tests/Integration.GateEnforcement.Tests.ps1
@@ -400,6 +400,39 @@ EOF
         $result.StdErr | Should -Be ''
     }
 
+    It 'denies pwsh -Command writing a code file from the operator pane' {
+        $result = & $script:InvokeOrchestraGate -ToolName 'Bash' -ToolInput ([ordered]@{
+            command = 'pwsh -Command "Set-Content -LiteralPath scripts/demo.ps1 -Value ''Write-Host hi''"'
+        }) -Environment ([ordered]@{
+            WINSMUX_ROLE = 'Commander'
+        })
+
+        & $script:AssertDenyResult -Result $result
+        $result.ErrorObject.systemMessage | Should -Match 'Operator shell write bypass blocked'
+    }
+
+    It 'denies cmd /c writing a code file from the operator pane' {
+        $result = & $script:InvokeOrchestraGate -ToolName 'Bash' -ToolInput ([ordered]@{
+            command = 'cmd /c "echo Write-Host hi > scripts\\demo.ps1"'
+        }) -Environment ([ordered]@{
+            WINSMUX_ROLE = 'Commander'
+        })
+
+        & $script:AssertDenyResult -Result $result
+        $result.ErrorObject.systemMessage | Should -Match 'Operator shell write bypass blocked'
+    }
+
+    It 'denies python -c writing a code file from the operator pane' {
+        $result = & $script:InvokeOrchestraGate -ToolName 'Bash' -ToolInput ([ordered]@{
+            command = 'python -c "from pathlib import Path; Path(''scripts/demo.py'').write_text(''print(1)'', encoding=''utf-8'')"'
+        }) -Environment ([ordered]@{
+            WINSMUX_ROLE = 'Commander'
+        })
+
+        & $script:AssertDenyResult -Result $result
+        $result.ErrorObject.systemMessage | Should -Match 'Operator shell write bypass blocked'
+    }
+
     It 'denies Agent acceptEdits mode' {
         $result = & $script:InvokeOrchestraGate -ToolName 'Agent' -ToolInput ([ordered]@{
             mode = 'acceptEdits'

--- a/tests/OrchestraPreflight.Tests.ps1
+++ b/tests/OrchestraPreflight.Tests.ps1
@@ -145,6 +145,35 @@ Describe 'orchestra preflight server health' {
         . (Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\orchestra-preflight.ps1')
     }
 
+    It 'requires session-info output in addition to AUTH OK' {
+        Mock Get-OrchestraSessionKeyFilePath { 'C:\Users\test\.psmux\winsmux-orchestra.key' }
+        Mock Test-Path { $true } -ParameterFilter { $LiteralPath -eq 'C:\Users\test\.psmux\winsmux-orchestra.key' }
+        Mock Get-Content { 'test-key' } -ParameterFilter { $LiteralPath -eq 'C:\Users\test\.psmux\winsmux-orchestra.key' }
+
+        $stream = New-Object PSObject
+        Add-Member -InputObject $stream -MemberType ScriptMethod -Name Write -Value { param($Buffer, $Offset, $Count) }
+        Add-Member -InputObject $stream -MemberType ScriptMethod -Name Flush -Value { }
+        Add-Member -InputObject $stream -MemberType ScriptMethod -Name Read -Value {
+            param($Buffer, $Offset, $Count)
+            $bytes = [System.Text.Encoding]::UTF8.GetBytes("OK`n")
+            [Array]::Copy($bytes, 0, $Buffer, 0, $bytes.Length)
+            return $bytes.Length
+        }
+        Add-Member -InputObject $stream -MemberType ScriptMethod -Name Dispose -Value { }
+
+        $client = [PSCustomObject]@{
+            SendTimeout    = 0
+            ReceiveTimeout = 0
+        }
+        Add-Member -InputObject $client -MemberType ScriptMethod -Name ConnectAsync -Value { param($Host, $Port) [System.Threading.Tasks.Task]::FromResult($null) }
+        Add-Member -InputObject $client -MemberType ScriptMethod -Name GetStream -Value { $stream }
+        Add-Member -InputObject $client -MemberType ScriptMethod -Name Dispose -Value { }
+
+        Mock New-OrchestraTcpClient { $client }
+
+        Test-OrchestraSessionAuthResponse -SessionName 'winsmux-orchestra' -Port 49200 | Should -Be $false
+    }
+
     It 'returns Healthy when session exists' {
         Mock Get-OrchestraSessionPortFilePath { 'C:\Users\test\.psmux\winsmux-orchestra.port' }
         Mock Test-Path { $true } -ParameterFilter { $LiteralPath -eq 'C:\Users\test\.psmux\winsmux-orchestra.port' }
@@ -176,5 +205,31 @@ Describe 'orchestra preflight server health' {
         $health = Test-OrchestraServerHealth -SessionName 'winsmux-orchestra' -WinsmuxBin 'winsmux'
 
         $health | Should -Be 'Unhealthy'
+    }
+}
+
+Describe 'orchestra preflight healthy wait' {
+    BeforeAll {
+        . (Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\orchestra-preflight.ps1')
+    }
+
+    It 'waits until strict server health becomes Healthy' {
+        $script:healthProbeCount = 0
+
+        Mock Test-OrchestraServerHealth {
+            $script:healthProbeCount++
+            if ($script:healthProbeCount -lt 3) {
+                return 'Unhealthy'
+            }
+
+            return 'Healthy'
+        }
+
+        Mock Start-Sleep {}
+
+        $result = Wait-OrchestraServerHealthy -SessionName 'winsmux-orchestra' -WinsmuxBin 'winsmux' -TimeoutSeconds 5 -PollIntervalMilliseconds 100
+
+        $result.Health | Should -Be 'Healthy'
+        $result.Attempts | Should -Be 3
     }
 }

--- a/tests/psmux-bridge.Tests.ps1
+++ b/tests/psmux-bridge.Tests.ps1
@@ -1543,17 +1543,7 @@ session:
     It 'detects a missing session and restarts it' {
         $state = New-ServerWatchdogState
 
-        Mock Invoke-ServerWatchdogWinsmux {
-            [ordered]@{
-                ExitCode = 1
-                Output   = @('missing')
-            }
-        } -ParameterFilter {
-            $AllowFailure -and
-            $Arguments[0] -eq 'has-session' -and
-            $Arguments[1] -eq '-t' -and
-            $Arguments[2] -eq 'winsmux-orchestra'
-        }
+        Mock Get-ServerWatchdogHealthStatus { 'Missing' }
 
         Mock Invoke-ServerWatchdogWinsmux {
             [ordered]@{
@@ -1582,19 +1572,13 @@ session:
         $events[0].event | Should -Be 'server.restarted'
         $events[0].status | Should -Be 'restarted'
         $events[0].exit_reason | Should -Be 'session_missing'
+        $events[0].data.health_status | Should -Be 'Missing'
     }
 
     It 'logs restart failures when restart attempt fails' {
         $state = New-ServerWatchdogState
 
-        Mock Invoke-ServerWatchdogWinsmux {
-            [ordered]@{
-                ExitCode = 1
-                Output   = @('missing')
-            }
-        } -ParameterFilter {
-            $AllowFailure -and $Arguments[0] -eq 'has-session'
-        }
+        Mock Get-ServerWatchdogHealthStatus { 'Missing' }
 
         Mock Invoke-ServerWatchdogWinsmux {
             [ordered]@{
@@ -1618,6 +1602,32 @@ session:
         $events[0].event | Should -Be 'server.restart_failed'
         $events[0].exit_reason | Should -Be 'restart_failed'
         $events[0].data.restart_output | Should -Be 'cannot start'
+        $events[0].data.health_status | Should -Be 'Missing'
+    }
+
+    It 'treats unhealthy strict health as a restartable server failure' {
+        $state = New-ServerWatchdogState
+
+        Mock Get-ServerWatchdogHealthStatus { 'Unhealthy' }
+        Mock Invoke-ServerWatchdogWinsmux {
+            [ordered]@{
+                ExitCode = 0
+                Output   = @()
+            }
+        } -ParameterFilter {
+            $AllowFailure -and $Arguments[0] -eq 'new-session'
+        }
+
+        $result = Invoke-ServerWatchdogCycle -ManifestPath $script:serverWatchdogManifestPath -SessionName 'winsmux-orchestra' -State $state
+
+        $result.RestartAttempted | Should -Be $true
+        $result.RestartSucceeded | Should -Be $true
+        $result.HealthStatus | Should -Be 'Unhealthy'
+
+        $eventsPath = Join-Path $script:serverWatchdogTempRoot '.winsmux\events.jsonl'
+        $events = @(Get-Content -Path $eventsPath -Encoding UTF8 | Where-Object { $_ } | ForEach-Object { $_ | ConvertFrom-Json })
+        $events[0].exit_reason | Should -Be 'healthcheck_failed'
+        $events[0].data.health_status | Should -Be 'Unhealthy'
     }
 
     It 'enters degraded state after three restart attempts in ten minutes' {
@@ -1629,13 +1639,11 @@ session:
             $now.AddMinutes(-1).ToString('o')
         )
 
+        Mock Get-ServerWatchdogHealthStatus { 'Missing' }
         Mock Invoke-ServerWatchdogWinsmux {
-            [ordered]@{
-                ExitCode = 1
-                Output   = @('missing')
-            }
+            throw 'restart should not be attempted while degraded'
         } -ParameterFilter {
-            $AllowFailure -and $Arguments[0] -eq 'has-session'
+            $Arguments[0] -eq 'new-session'
         }
 
         $result = Invoke-ServerWatchdogCycle -ManifestPath $script:serverWatchdogManifestPath -SessionName 'winsmux-orchestra' -State $state
@@ -1655,6 +1663,7 @@ session:
         $events[0].status | Should -Be 'degraded'
         $events[0].exit_reason | Should -Be 'crash_loop_protection'
         $events[0].data.attempt_count | Should -Be 3
+        $events[0].data.health_status | Should -Be 'Missing'
     }
 }
 
@@ -1739,6 +1748,7 @@ Describe 'orchestra-start server bootstrap' {
         $script:startProcessArgumentList = @()
         $script:listPanesCallCount = 0
         $script:sleepCallCount = 0
+        $script:waitHealthyCount = 0
 
         function Test-OrchestraServerSession {
             param([string]$SessionName)
@@ -1783,6 +1793,12 @@ Describe 'orchestra-start server bootstrap' {
             }
         }
 
+        function Wait-OrchestraServerHealthy {
+            param([string]$SessionName, [string]$WinsmuxBin, [int]$TimeoutSeconds, [int]$PollIntervalMilliseconds)
+            $script:waitHealthyCount++
+            return [ordered]@{ SessionName = $SessionName; Health = 'Healthy'; Attempts = 1 }
+        }
+
         $result = Ensure-OrchestraServer -SessionName 'winsmux-orchestra'
 
         $result.SessionName | Should -Be 'winsmux-orchestra'
@@ -1790,6 +1806,7 @@ Describe 'orchestra-start server bootstrap' {
         $script:probeCount | Should -Be 3
         $script:sleepCallCount | Should -Be 1
         $script:listPanesCallCount | Should -Be 1
+        $script:waitHealthyCount | Should -Be 1
         $script:startProcessFilePath | Should -Be 'C:\Windows\System32\wt.exe'
         $script:startProcessArgumentList | Should -Be @(
             '--size', '200,70',
@@ -1797,6 +1814,67 @@ Describe 'orchestra-start server bootstrap' {
             '--',
             'winsmux', 'new-session', '-s', 'winsmux-orchestra'
         )
+    }
+
+    It 'resets a stale session by killing it, clearing registration, and recreating it' {
+        $script:killCalls = 0
+        $script:clearCalls = 0
+        $script:ensureCalls = 0
+        $script:waitCalls = 0
+
+        function Invoke-Winsmux {
+            param([string[]]$Arguments, [switch]$CaptureOutput)
+            if ($Arguments[0] -eq 'kill-session') {
+                $script:killCalls++
+                return
+            }
+
+            throw "unexpected winsmux call: $($Arguments -join ' ')"
+        }
+
+        function Clear-OrchestraSessionRegistration {
+            param([string]$SessionName)
+            $script:clearCalls++
+        }
+
+        function Ensure-OrchestraServer {
+            param([string]$SessionName, [int]$TimeoutSeconds = 30)
+            $script:ensureCalls++
+            return [ordered]@{
+                SessionName    = $SessionName
+                SessionCreated = $true
+            }
+        }
+
+        function Wait-OrchestraServerHealthy {
+            param([string]$SessionName, [string]$WinsmuxBin, [int]$TimeoutSeconds = 15, [int]$PollIntervalMilliseconds = 500)
+            $script:waitCalls++
+            return [ordered]@{
+                SessionName = $SessionName
+                Health      = 'Healthy'
+                Attempts    = 1
+            }
+        }
+
+        Mock Test-OrchestraServerSession { $true }
+
+        $result = Reset-OrchestraServerSession -SessionName 'winsmux-orchestra' -WinsmuxBin 'winsmux' -Reason 'test'
+
+        $result.SessionCreated | Should -Be $true
+        $result.Health | Should -Be 'Healthy'
+        $script:killCalls | Should -Be 1
+        $script:clearCalls | Should -Be 1
+        $script:ensureCalls | Should -Be 1
+        $script:waitCalls | Should -Be 1
+    }
+
+    It 'fails closed when a background watchdog process exits immediately' {
+        $process = [PSCustomObject]@{
+            HasExited = $true
+            ExitCode  = 23
+        }
+
+        { Assert-OrchestraBackgroundProcessStarted -Process $process -Name 'Server watchdog job' -StartupDelayMilliseconds 1 } | Should -Throw '*exited immediately*'
     }
 
     It 'fails closed when Windows Terminal is unavailable' {
@@ -2694,6 +2772,129 @@ Describe 'winsmux send fallback' {
         $result | Should -Be 'sent to %7 via default:0.3'
         $script:sendBuffer | Should -Be "> echo test`nresult"
         $script:sendAttempts | Should -Be @('%7 literal', 'default:0.3 literal', 'default:0.3 Enter')
+    }
+
+    It 'falls back when direct pane id delivery redraws the buffer but does not contain the typed command' {
+        $script:sendAttempts = [System.Collections.Generic.List[string]]::new()
+        $script:sendBuffer = '> '
+        $script:sendCommandText = 'claude research --topic winsmux'
+
+        Mock Invoke-WinsmuxRaw {
+            param([string[]]$Arguments)
+
+            switch ($Arguments[0]) {
+                'list-panes' {
+                    $format = $Arguments[-1]
+                    if ($format -eq '#{pane_id}') {
+                        return '%7'
+                    }
+
+                    if ($format -eq "#{pane_id}`t#{session_name}:#{window_index}.#{pane_index}") {
+                        return '%7' + "`t" + 'default:0.3'
+                    }
+
+                    return @()
+                }
+                'capture-pane' {
+                    return $script:sendBuffer
+                }
+                'send-keys' {
+                    $targetIndex = [Array]::IndexOf($Arguments, '-t')
+                    $target = if ($targetIndex -ge 0 -and $targetIndex + 1 -lt $Arguments.Count) {
+                        $Arguments[$targetIndex + 1]
+                    } else {
+                        ''
+                    }
+
+                    if ($Arguments -contains '-l') {
+                        $script:sendAttempts.Add("$target literal") | Out-Null
+                        if ($target -eq '%7') {
+                            $script:sendBuffer = "> [status redraw only]"
+                        } elseif ($target -eq 'default:0.3') {
+                            $script:sendBuffer = "> $script:sendCommandText"
+                        }
+
+                        return
+                    }
+
+                    $script:sendAttempts.Add("$target Enter") | Out-Null
+                    if ($target -eq 'default:0.3') {
+                        $script:sendBuffer += "`nresult"
+                    }
+                    return
+                }
+                default {
+                    throw "Unexpected winsmux command: $($Arguments -join ' ')"
+                }
+            }
+        }
+
+        $result = Send-TextToPane -PaneId '%7' -CommandText $script:sendCommandText
+
+        $result | Should -Be 'sent to %7 via default:0.3'
+        $script:sendBuffer | Should -Be "> $script:sendCommandText`nresult"
+        $script:sendAttempts | Should -Be @('%7 literal', 'default:0.3 literal', 'default:0.3 Enter')
+    }
+
+    It 'chunks long literal sends before pressing Enter' {
+        $script:sendAttempts = [System.Collections.Generic.List[string]]::new()
+        $script:sendBuffer = '> '
+        $script:longCommandText = ('a' * 1200) + 'UNIQUE-TAIL-1234567890'
+
+        Mock Invoke-WinsmuxRaw {
+            param([string[]]$Arguments)
+
+            switch ($Arguments[0]) {
+                'list-panes' {
+                    $format = $Arguments[-1]
+                    if ($format -eq '#{pane_id}') {
+                        return '%7'
+                    }
+
+                    if ($format -eq "#{pane_id}`t#{session_name}:#{window_index}.#{pane_index}") {
+                        return '%7' + "`t" + 'default:0.3'
+                    }
+
+                    return @()
+                }
+                'capture-pane' {
+                    return $script:sendBuffer
+                }
+                'send-keys' {
+                    $targetIndex = [Array]::IndexOf($Arguments, '-t')
+                    $target = if ($targetIndex -ge 0 -and $targetIndex + 1 -lt $Arguments.Count) {
+                        $Arguments[$targetIndex + 1]
+                    } else {
+                        ''
+                    }
+
+                    if ($Arguments -contains '-l') {
+                        $literalText = $Arguments[-1]
+                        $script:sendAttempts.Add("$target literal:$($literalText.Length)") | Out-Null
+                        if ($target -eq 'default:0.3') {
+                            $script:sendBuffer += $literalText
+                        }
+
+                        return
+                    }
+
+                    $script:sendAttempts.Add("$target Enter") | Out-Null
+                    if ($target -eq 'default:0.3') {
+                        $script:sendBuffer += "`nresult"
+                    }
+                    return
+                }
+                default {
+                    throw "Unexpected winsmux command: $($Arguments -join ' ')"
+                }
+            }
+        }
+
+        $result = Send-TextToPane -PaneId '%7' -CommandText $script:longCommandText
+
+        $result | Should -Be 'sent to %7 via default:0.3'
+        (@($script:sendAttempts | Where-Object { $_ -like '* literal*' })).Count | Should -Be 4
+        $script:sendAttempts[-1] | Should -Be 'default:0.3 Enter'
     }
 
 }

--- a/winsmux-core/scripts/orchestra-preflight.ps1
+++ b/winsmux-core/scripts/orchestra-preflight.ps1
@@ -335,13 +335,17 @@ function Get-OrchestraSessionPort {
     return $port
 }
 
+function New-OrchestraTcpClient {
+    return [System.Net.Sockets.TcpClient]::new()
+}
+
 function Test-OrchestraTcpConnection {
     param(
         [Parameter(Mandatory = $true)][int]$Port,
         [int]$TimeoutMs = 500
     )
 
-    $client = [System.Net.Sockets.TcpClient]::new()
+    $client = New-OrchestraTcpClient
     try {
         $connectTask = $client.ConnectAsync('127.0.0.1', $Port)
         if (-not $connectTask.Wait($TimeoutMs)) {
@@ -369,7 +373,7 @@ function Test-OrchestraSessionAuthResponse {
         $sessionKey = (Get-Content -LiteralPath $keyFilePath -Raw -Encoding UTF8).Trim()
     }
 
-    $client = [System.Net.Sockets.TcpClient]::new()
+    $client = New-OrchestraTcpClient
     $stream = $null
 
     try {
@@ -392,7 +396,14 @@ function Test-OrchestraSessionAuthResponse {
         }
 
         $response = [System.Text.Encoding]::UTF8.GetString($buffer, 0, $bytesRead)
-        return $response.Contains('OK')
+        $lines = @($response -split "\r?\n" | ForEach-Object { $_.Trim() } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+        if ($lines.Count -eq 0) {
+            return $false
+        }
+
+        $authOk = $lines[0] -match '^(?i)OK\b'
+        $sessionInfoLines = @($lines | Select-Object -Skip 1 | Where-Object { $_ -notmatch '^(?i)OK\b' })
+        return ($authOk -and $sessionInfoLines.Count -gt 0)
     } catch {
         return $false
     } finally {
@@ -444,6 +455,34 @@ function Test-OrchestraServerHealth {
     }
 
     return 'Healthy'
+}
+
+function Wait-OrchestraServerHealthy {
+    param(
+        [Parameter(Mandatory = $true)][string]$SessionName,
+        [Parameter(Mandatory = $true)][string]$WinsmuxBin,
+        [ValidateRange(1, 120)][int]$TimeoutSeconds = 15,
+        [ValidateRange(100, 5000)][int]$PollIntervalMilliseconds = 500
+    )
+
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    $attempt = 0
+    $lastHealth = 'Unknown'
+    while ((Get-Date) -lt $deadline) {
+        $attempt++
+        $lastHealth = Test-OrchestraServerHealth -SessionName $SessionName -WinsmuxBin $WinsmuxBin -TimeoutMs ([Math]::Max($PollIntervalMilliseconds, 500))
+        if ($lastHealth -eq 'Healthy') {
+            return [ordered]@{
+                SessionName = $SessionName
+                Health      = $lastHealth
+                Attempts    = $attempt
+            }
+        }
+
+        Start-Sleep -Milliseconds $PollIntervalMilliseconds
+    }
+
+    throw "Orchestra session '$SessionName' did not reach Healthy state within $TimeoutSeconds seconds (last health: $lastHealth)."
 }
 
 function Clear-OrchestraSessionRegistration {

--- a/winsmux-core/scripts/orchestra-start.ps1
+++ b/winsmux-core/scripts/orchestra-start.ps1
@@ -133,8 +133,7 @@ function Reset-OrchestraServerSession {
         [string]$Reason = 'reset'
     )
 
-    & $WinsmuxBin has-session -t $SessionName 1>$null 2>$null
-    if ($LASTEXITCODE -eq 0) {
+    if (Test-OrchestraServerSession -SessionName $SessionName) {
         try {
             Invoke-Winsmux -Arguments @('kill-session', '-t', $SessionName)
         } catch {

--- a/winsmux-core/scripts/orchestra-start.ps1
+++ b/winsmux-core/scripts/orchestra-start.ps1
@@ -105,6 +105,7 @@ function Ensure-OrchestraServer {
                 $paneOutput = Invoke-Winsmux -Arguments @('list-panes', '-t', $SessionName, '-F', '#{pane_id}') -CaptureOutput
                 $paneText = ($paneOutput | Out-String).Trim()
                 if (-not [string]::IsNullOrWhiteSpace($paneText)) {
+                    $null = Wait-OrchestraServerHealthy -SessionName $SessionName -WinsmuxBin $script:winsmuxBin -TimeoutSeconds ([Math]::Min($TimeoutSeconds, 15))
                     Write-Host "Ensure-OrchestraServer: ready after $pollAttempt polls"
                     return [ordered]@{
                         SessionName    = $SessionName
@@ -123,6 +124,33 @@ function Ensure-OrchestraServer {
     }
 
     throw "Orchestra session '$SessionName' did not become ready within $TimeoutSeconds seconds. Verify Windows Terminal launched correctly."
+}
+
+function Reset-OrchestraServerSession {
+    param(
+        [Parameter(Mandatory = $true)][string]$SessionName,
+        [Parameter(Mandatory = $true)][string]$WinsmuxBin,
+        [string]$Reason = 'reset'
+    )
+
+    & $WinsmuxBin has-session -t $SessionName 1>$null 2>$null
+    if ($LASTEXITCODE -eq 0) {
+        try {
+            Invoke-Winsmux -Arguments @('kill-session', '-t', $SessionName)
+        } catch {
+            Write-Warning "Reset-OrchestraServerSession: failed to kill $SessionName during ${Reason}: $($_.Exception.Message)"
+        }
+    }
+
+    Clear-OrchestraSessionRegistration -SessionName $SessionName
+    $server = Ensure-OrchestraServer -SessionName $SessionName
+    $health = Wait-OrchestraServerHealthy -SessionName $SessionName -WinsmuxBin $WinsmuxBin
+
+    return [ordered]@{
+        SessionName    = $server.SessionName
+        SessionCreated = $server.SessionCreated
+        Health         = $health.Health
+    }
 }
 
 function Invoke-Bridge {
@@ -761,6 +789,34 @@ function Start-ServerWatchdogJob {
         ) -WindowStyle Hidden -PassThru)
 }
 
+function Assert-OrchestraBackgroundProcessStarted {
+    param(
+        [Parameter(Mandatory = $true)]$Process,
+        [Parameter(Mandatory = $true)][string]$Name,
+        [int]$StartupDelayMilliseconds = 300
+    )
+
+    if ($null -eq $Process) {
+        throw "$Name did not start."
+    }
+
+    Start-Sleep -Milliseconds $StartupDelayMilliseconds
+    try {
+        if ($Process.HasExited) {
+            $exitCode = 'unknown'
+            try {
+                $exitCode = [string]$Process.ExitCode
+            } catch {
+            }
+            throw "$Name exited immediately (exit code $exitCode)."
+        }
+    } catch {
+        if ($_.Exception.Message -like '*exited immediately*') {
+            throw
+        }
+    }
+}
+
 function Get-OrchestraEventsPath {
     param([Parameter(Mandatory = $true)][string]$ProjectDir)
 
@@ -1096,16 +1152,22 @@ if ($MyInvocation.InvocationName -ne '.') {
         Write-WinsmuxLog -Level INFO -Event 'preflight.session.health' -Message "Session health for ${sessionName}: $sessionHealth." -Data @{ session_name = $sessionName; health = $sessionHealth } | Out-Null
         switch ($sessionHealth) {
             'Healthy' {
-                Write-WinsmuxLog -Level INFO -Event 'preflight.session.kill' -Message "Removing existing session $sessionName." -Data @{ session_name = $sessionName } | Out-Null
-                Invoke-Winsmux -Arguments @('kill-session', '-t', $sessionName)
+                Write-WinsmuxLog -Level INFO -Event 'preflight.session.reset' -Message "Resetting existing healthy session $sessionName before startup." -Data @{ session_name = $sessionName; health = $sessionHealth } | Out-Null
+                $orchestraServer = Reset-OrchestraServerSession -SessionName $sessionName -WinsmuxBin $winsmuxBin -Reason 'healthy_existing_session'
             }
             'Unhealthy' {
                 Write-Warning "Preflight: removing stale session registration for $sessionName"
                 Write-WinsmuxLog -Level WARN -Event 'preflight.session.registration_cleared' -Message "Cleared stale session registration for $sessionName." -Data @{ session_name = $sessionName } | Out-Null
-                Clear-OrchestraSessionRegistration -SessionName $sessionName
+                $orchestraServer = Reset-OrchestraServerSession -SessionName $sessionName -WinsmuxBin $winsmuxBin -Reason 'unhealthy_existing_session'
+            }
+            default {
+                Write-Warning "Preflight: session $sessionName is missing strict health metadata; recreating it"
+                Write-WinsmuxLog -Level WARN -Event 'preflight.session.reset' -Message "Resetting session $sessionName after missing strict health metadata." -Data @{ session_name = $sessionName; health = $sessionHealth } | Out-Null
+                $orchestraServer = Reset-OrchestraServerSession -SessionName $sessionName -WinsmuxBin $winsmuxBin -Reason 'missing_strict_health'
             }
         }
     } else {
+        $null = Wait-OrchestraServerHealthy -SessionName $sessionName -WinsmuxBin $winsmuxBin
         Write-WinsmuxLog -Level INFO -Event 'preflight.session.reuse' -Message "Reusing server-created session $sessionName." -Data ([ordered]@{
             session_name    = $sessionName
             session_created = $true
@@ -1354,6 +1416,9 @@ if ($MyInvocation.InvocationName -ne '.') {
     $watchdogProcess = Start-AgentWatchdogJob -WatchdogScriptPath $watchdogScriptPath -ManifestPath $manifestPath -SessionName $sessionName
     $serverWatchdogScriptPath = Join-Path $scriptDir 'server-watchdog.ps1'
     $serverWatchdogProcess = Start-ServerWatchdogJob -WatchdogScriptPath $serverWatchdogScriptPath -ManifestPath $manifestPath -SessionName $sessionName
+    Assert-OrchestraBackgroundProcessStarted -Process $commanderPollProcess -Name 'Commander poll job'
+    Assert-OrchestraBackgroundProcessStarted -Process $watchdogProcess -Name 'Agent watchdog job'
+    Assert-OrchestraBackgroundProcessStarted -Process $serverWatchdogProcess -Name 'Server watchdog job'
     $manifestPath = Save-OrchestraSessionState -ProjectDir $projectDir -SessionName $sessionName -Settings $settings -GitWorktreeDir $gitWorktreeDir -PaneSummaries $validPaneSummaries -CommanderPollPid $commanderPollProcess.Id -WatchdogPid $watchdogProcess.Id -ServerWatchdogPid $serverWatchdogProcess.Id
     Write-WinsmuxLog -Level INFO -Event 'preflight.watchdog.started' -Message "Started agent watchdog for session $sessionName." -Data @{ session_name = $sessionName; manifest_path = $manifestPath; watchdog_pid = $watchdogProcess.Id; process_name = $watchdogProcess.ProcessName } | Out-Null
     Write-WinsmuxLog -Level INFO -Event 'preflight.server_watchdog.started' -Message "Started server watchdog for session $sessionName." -Data @{ session_name = $sessionName; manifest_path = $manifestPath; server_watchdog_pid = $serverWatchdogProcess.Id; process_name = $serverWatchdogProcess.ProcessName } | Out-Null

--- a/winsmux-core/scripts/server-watchdog.ps1
+++ b/winsmux-core/scripts/server-watchdog.ps1
@@ -12,6 +12,7 @@ Set-StrictMode -Version Latest
 [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
 
 $scriptDir = $PSScriptRoot
+. (Join-Path $scriptDir 'orchestra-preflight.ps1')
 . (Join-Path $scriptDir 'settings.ps1')
 
 function Write-ServerWatchdogTextFile {
@@ -152,6 +153,16 @@ function Invoke-ServerWatchdogRestart {
     return (Invoke-ServerWatchdogWinsmux -Arguments @('new-session', '-d', '-s', $SessionName) -AllowFailure)
 }
 
+function Get-ServerWatchdogHealthStatus {
+    param([Parameter(Mandatory = $true)][string]$SessionName)
+
+    try {
+        return [string](Test-OrchestraServerHealth -SessionName $SessionName -WinsmuxBin (Get-WinsmuxBin))
+    } catch {
+        return 'Unknown'
+    }
+}
+
 function Get-ServerWatchdogActiveAttempts {
     param(
         [Parameter(Mandatory = $true)]$State,
@@ -217,11 +228,15 @@ function Invoke-ServerWatchdogCycle {
         return $result
     }
 
-    if (Test-ServerWatchdogSessionAlive -SessionName $SessionName) {
+    $healthStatus = Get-ServerWatchdogHealthStatus -SessionName $SessionName
+    $result['HealthStatus'] = $healthStatus
+
+    if ($healthStatus -eq 'Healthy') {
         return $result
     }
 
     $result['SessionAlive'] = $false
+    $exitReason = if ($healthStatus -eq 'Unhealthy') { 'healthcheck_failed' } else { 'session_missing' }
 
     if ($activeAttempts.Count -ge [int]$State.MaxRestartAttempts) {
         $State['Degraded'] = $true
@@ -239,6 +254,7 @@ function Invoke-ServerWatchdogCycle {
                     attempt_count          = $activeAttempts.Count
                     max_restart_attempts   = [int]$State.MaxRestartAttempts
                     restart_window_minutes = [int]$State.RestartWindowMinutes
+                    health_status          = $healthStatus
                 }) | Out-Null
             $State['DegradedLogged'] = $true
         }
@@ -263,11 +279,12 @@ function Invoke-ServerWatchdogCycle {
             -Event 'server.restarted' `
             -Message $result.Message `
             -Status 'restarted' `
-            -ExitReason 'session_missing' `
+            -ExitReason $exitReason `
             -Data ([ordered]@{
                 attempt_count          = $result.AttemptCount
                 max_restart_attempts   = [int]$State.MaxRestartAttempts
                 restart_window_minutes = [int]$State.RestartWindowMinutes
+                health_status          = $healthStatus
             }) | Out-Null
 
         return $result
@@ -288,6 +305,7 @@ function Invoke-ServerWatchdogCycle {
             max_restart_attempts   = [int]$State.MaxRestartAttempts
             restart_window_minutes = [int]$State.RestartWindowMinutes
             restart_output         = $restartOutput
+            health_status          = $healthStatus
         }) | Out-Null
 
     return $result


### PR DESCRIPTION
## Summary
- close the remaining v0.19.6 hardening work in the repo implementation
- harden `winsmux send` so Researcher/Claude-style panes do not report false success on redraw-only buffer changes
- tighten orchestra server health, watchdog restart handling, and operator shell write-bypass blocking

## Included tasks
- TASK-174 send-keys buffer overflow protection
- TASK-175 Researcher pane send delivery fix
- TASK-222 strict server health probe
- TASK-223 external server watchdog
- TASK-224 Ensure-OrchestraServer auto-start integration
- TASK-247 operator shell write bypass

## Validation
- `Invoke-Pester tests/psmux-bridge.Tests.ps1, tests/OrchestraPreflight.Tests.ps1, tests/Integration.GateEnforcement.Tests.ps1 -Output Normal`
- result: `133/133 PASS`

## Notes
- external planning source of truth was synced outside the repo: v0.19.6 is now 100% complete in the external roadmap/backlog
- residual future work remains in slot/provider routing design, but there are no blocking findings for this hardening bundle