### PR TITLE
feat(orchestra): add session board surface

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,3 +45,31 @@ cmd /c "echo content > path\to\file.txt"
 
 winsmux is a Windows-native AI agent orchestration platform.
 Builders operate in isolated git worktrees under `.worktrees/builder-N/`.
+
+## Handoff Maintenance
+
+`docs/handoff.md` is the only active handoff source of truth for this repo.
+Treat repository-root `HANDOFF.md` files as historical unless the task is explicitly about consolidation.
+
+Codex must update `docs/handoff.md` at these points:
+
+1. After any milestone-level state change.
+   - Examples: release completion, PR merge, roadmap/backlog progress shift, version closure, planning externalization.
+2. Before autonomous `commit -> push -> PR -> merge -> cleanup`, if the task materially changes current state.
+3. Before ending a session when there are material code, planning, test, or release changes.
+4. When the user asks for current status / handoff / continuation context and the file is stale.
+
+`docs/handoff.md` should stay concise and always include these sections:
+
+- `Current state`
+- `This session`
+- `Validation`
+- `Next actions`
+- `Notes`
+
+When updating handoff:
+
+- Replace stale “next actions” that have already completed. Do not leave merged PR steps in place.
+- If work is still in progress, record the active task, branch, changed files scope, and latest validation status.
+- Reflect external planning truth when version progress changes.
+- Prefer exact identifiers: version, task IDs, PR numbers, release status.

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -40,6 +40,5 @@
 
 - `HANDOFF.md` at the repository root is historical context and no longer authoritative.
 - Public tracked files must not contain personal paths or private planning roots.
-- External planning source of truth:
-  - `C:\Users\komei\iCloudDrive\iCloud~md~obsidian\MainVault\Projects\winsmux\planning\backlog.yaml`
-  - `C:\Users\komei\iCloudDrive\iCloud~md~obsidian\MainVault\Projects\winsmux\planning\ROADMAP.md`
+- External planning source of truth stays outside the public repository and is resolved via the configured planning root.
+- Public docs may refer to the external planning contract, but must not embed machine-specific absolute paths.

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -1,39 +1,45 @@
 # Handoff
 
-> Updated: 2026-04-10T10:15+09:00
+> Updated: 2026-04-10T10:05:33+09:00
 > Source of truth: this file
 
 ## Current state
 
 - `v0.19.5` is released.
-- `v0.19.6 hardening` is implemented and tracked as `100% (6/6)` in the external planning backlog/roadmap.
-- PR [#370](https://github.com/Sora-bluesky/winsmux/pull/370) carries the repo-side hardening closure.
+- `v0.19.6 hardening` is implemented, merged, and tracked as `100% (6/6)` in the external planning backlog/roadmap.
+- PR [#370](https://github.com/Sora-bluesky/winsmux/pull/370) is merged into `main`.
 - Planning source of truth is externalized outside the public repository and syncs automatically into the private planning root.
+- `v0.19.7 visible orchestration` is now `2/7` complete. `TASK-243` and `TASK-244` are done in external planning.
+- `v0.24.0: Rust runtime convergence` exists in external planning as the pre-`v1.0.0` Rust unification milestone.
 
 ## This session
 
-- Closed the remaining `v0.19.6` hardening implementation in the repo.
-- Added strict orchestra server health waiting and watchdog restart handling.
-- Hardened `winsmux send` so redraw-only pane changes do not report false success.
-- Added operator shell write-bypass blocking for direct code-file writes from non-worker panes.
-- Updated external planning so `v0.19.6` is complete and `v0.19.8` exists in the roadmap.
+- Merged the repo-side `v0.19.6` hardening closure.
+- Added a durable handoff maintenance rule to `AGENTS.md` so new sessions must refresh `docs/handoff.md` at milestone boundaries and before autonomous git progression.
+- Implemented `winsmux board` as the first visible orchestration surface for `TASK-244`.
+- Updated external planning so `TASK-244` is `done`, `v0.19.7` is `2/7`, and `v0.24.0` contains the Rust runtime convergence plan.
 
 ## Validation
 
 - Full local Pester suite passed: `171/171 PASS`
 - Targeted hardening suite passed earlier: `133/133 PASS`
-- CI on PR `#370` initially failed only because `Reset-OrchestraServerSession` called the `winsmux` binary directly in a test environment where the binary is unavailable.
-- The repo now uses `Test-OrchestraServerSession` for that check so CI can be rerun cleanly.
+- `TASK-244` focused regression passed: `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `82/82 PASS`
+- Current uncommitted board surface touches:
+  - `scripts/winsmux-core.ps1`
+  - `winsmux-core/scripts/role-gate.ps1`
+  - `tests/psmux-bridge.Tests.ps1`
 
 ## Next actions
 
-1. Push the CI-only fix for PR `#370`.
-2. Confirm GitHub Actions is green.
-3. Merge PR `#370`.
-4. Delete the merged feature branch.
-5. Start `v0.19.7` or `v0.19.8` depending on orchestration priorities.
+1. Commit and PR the repo-side `TASK-244` board surface.
+2. Release `v0.19.6` and prepare the release post draft.
+3. Continue `v0.19.7` with `TASK-245` or `TASK-256` after the board surface lands.
+4. Keep future backlog aligned with the `Operator / slot / provider` model and the new `v0.24.0` Rust convergence plan.
 
 ## Notes
 
 - `HANDOFF.md` at the repository root is historical context and no longer authoritative.
 - Public tracked files must not contain personal paths or private planning roots.
+- External planning source of truth:
+  - `C:\Users\komei\iCloudDrive\iCloud~md~obsidian\MainVault\Projects\winsmux\planning\backlog.yaml`
+  - `C:\Users\komei\iCloudDrive\iCloud~md~obsidian\MainVault\Projects\winsmux\planning\ROADMAP.md`

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -2104,6 +2104,132 @@ function Invoke-Status {
     Write-Output ($table.TrimEnd())
 }
 
+function Get-BoardStateCounts {
+    param(
+        [Parameter(Mandatory = $true)][object[]]$Records,
+        [Parameter(Mandatory = $true)][scriptblock]$Selector
+    )
+
+    $counts = [ordered]@{}
+    foreach ($record in $Records) {
+        $value = [string](& $Selector $record)
+        if ([string]::IsNullOrWhiteSpace($value)) {
+            $value = 'unknown'
+        }
+
+        if ($counts.Contains($value)) {
+            $counts[$value] = [int]$counts[$value] + 1
+        } else {
+            $counts[$value] = 1
+        }
+    }
+
+    return $counts
+}
+
+function Get-BoardPayload {
+    param([Parameter(Mandatory = $true)][string]$ProjectDir)
+
+    $records = @(Get-PaneStatusRecords -ProjectDir $ProjectDir | Sort-Object Label)
+    $summary = [ordered]@{
+        pane_count        = $records.Count
+        dirty_panes       = @($records | Where-Object { [int]$_.ChangedFileCount -gt 0 }).Count
+        review_pending    = @($records | Where-Object { [string]$_.ReviewState -eq 'PENDING' }).Count
+        review_failed     = @($records | Where-Object { [string]$_.ReviewState -in @('FAIL', 'FAILED') }).Count
+        review_passed     = @($records | Where-Object { [string]$_.ReviewState -eq 'PASS' }).Count
+        tasks_in_progress = @($records | Where-Object { [string]$_.TaskState -eq 'in_progress' }).Count
+        tasks_blocked     = @($records | Where-Object { [string]$_.TaskState -eq 'blocked' }).Count
+        by_state          = Get-BoardStateCounts -Records $records -Selector { param($Record) $Record.State }
+        by_review         = Get-BoardStateCounts -Records $records -Selector { param($Record) $Record.ReviewState }
+        by_task_state     = Get-BoardStateCounts -Records $records -Selector { param($Record) $Record.TaskState }
+    }
+
+    $panes = @(
+        $records | ForEach-Object {
+            [ordered]@{
+                label              = $_.Label
+                role               = $_.Role
+                pane_id            = $_.PaneId
+                state              = $_.State
+                tokens_remaining   = $_.TokensRemaining
+                task_id            = $_.TaskId
+                task               = $_.Task
+                task_state         = $_.TaskState
+                task_owner         = $_.TaskOwner
+                review_state       = $_.ReviewState
+                branch             = $_.Branch
+                head_sha           = $_.HeadSha
+                changed_file_count = $_.ChangedFileCount
+                changed_files      = @($_.ChangedFiles)
+                last_event         = $_.LastEvent
+                last_event_at      = $_.LastEventAt
+            }
+        }
+    )
+
+    return [ordered]@{
+        generated_at = (Get-Date).ToString('o')
+        project_dir  = $ProjectDir
+        summary      = $summary
+        panes        = $panes
+    }
+}
+
+function Invoke-Board {
+    param(
+        [AllowNull()][string]$BoardTarget = $Target,
+        [AllowNull()][string[]]$BoardRest = $Rest
+    )
+
+    $jsonOutput = $false
+
+    if ($BoardTarget) {
+        if ($BoardTarget -eq '--json' -and (-not $BoardRest -or $BoardRest.Count -eq 0)) {
+            $jsonOutput = $true
+        } else {
+            Stop-WithError "usage: winsmux board [--json]"
+        }
+    } elseif ($BoardRest -and $BoardRest.Count -gt 0) {
+        Stop-WithError "usage: winsmux board [--json]"
+    }
+
+    $projectDir = (Get-Location).Path
+
+    try {
+        $payload = Get-BoardPayload -ProjectDir $projectDir
+    } catch {
+        Stop-WithError $_.Exception.Message
+    }
+
+    if ($jsonOutput) {
+        $payload | ConvertTo-Json -Compress -Depth 10 | Write-Output
+        return
+    }
+
+    $records = @($payload.panes)
+    if ($records.Count -eq 0) {
+        Write-Output "(no panes)"
+        return
+    }
+
+    $table = $records |
+        Select-Object `
+            @{ Name = 'Label'; Expression = { $_.label } }, `
+            @{ Name = 'Role'; Expression = { $_.role } }, `
+            @{ Name = 'PaneId'; Expression = { $_.pane_id } }, `
+            @{ Name = 'State'; Expression = { $_.state } }, `
+            @{ Name = 'Tokens'; Expression = { $_.tokens_remaining } }, `
+            @{ Name = 'TaskState'; Expression = { $_.task_state } }, `
+            @{ Name = 'Review'; Expression = { $_.review_state } }, `
+            @{ Name = 'Changed'; Expression = { $_.changed_file_count } }, `
+            @{ Name = 'Branch'; Expression = { $_.branch } }, `
+            @{ Name = 'Head'; Expression = { if ([string]::IsNullOrWhiteSpace($_.head_sha)) { '' } elseif ($_.head_sha.Length -le 7) { $_.head_sha } else { $_.head_sha.Substring(0, 7) } } } |
+        Format-Table -AutoSize |
+        Out-String -Width 4096
+
+    Write-Output ($table.TrimEnd())
+}
+
 function Get-BridgeEventsPath {
     param([string]$ProjectDir = (Get-Location).Path)
 
@@ -2691,6 +2817,7 @@ Commands:
   wait-ready <target> [timeout_seconds]  Wait for Codex prompt in pane
   health-check              Report READY/BUSY/HUNG/DEAD for labeled panes
   status                    Report manifest pane states via capture-pane
+  board [--json]            Report pane/task/review/git session board
   poll-events [cursor]      Return new monitor events from .winsmux/events.jsonl
   signal <channel>          Send signal to unblock a waiting process
   watch <label> [silence_s] [timeout_s]  Block until pane output is silent
@@ -3023,6 +3150,7 @@ switch ($Command) {
     'wait-ready'      { Invoke-WaitReady }
     'health-check'    { Invoke-HealthCheck }
     'status'          { Invoke-Status }
+    'board'           { Invoke-Board }
     'poll-events'     { Invoke-PollEvents }
     'signal'          { Invoke-Signal }
     'mailbox-create'  { Invoke-MailboxCreate }

--- a/tests/psmux-bridge.Tests.ps1
+++ b/tests/psmux-bridge.Tests.ps1
@@ -2578,6 +2578,53 @@ panes:
         $result.panes[1].label | Should -Be 'worker-1'
         $result.panes[1].state | Should -Be 'busy'
     }
+
+    It 'supports winsmux board --json through the top-level CLI entrypoint' {
+@"
+version: 1
+session:
+  name: winsmux-orchestra
+  project_dir: $script:boardTempRoot
+panes:
+  builder-1:
+    pane_id: %2
+    role: Builder
+    task_id: task-244
+    task: Implement session board
+    task_state: in_progress
+    task_owner: builder-1
+    review_state: PENDING
+    branch: worktree-builder-1
+    head_sha: abc1234def5678
+    changed_file_count: 1
+    changed_files: '["scripts/winsmux-core.ps1"]'
+    last_event: pane.ready
+    last_event_at: 2026-04-10T10:00:00+09:00
+"@ | Set-Content -Path $script:boardManifestPath -Encoding UTF8
+
+        $bridgeScript = Join-Path (Split-Path -Parent $PSScriptRoot) 'scripts\winsmux-core.ps1'
+        $childScript = @'
+Set-Item -Path function:winsmux -Value {
+    param([Parameter(ValueFromRemainingArguments = $true)][object[]]$args)
+    $commandLine = ($args | ForEach-Object { [string]$_ }) -join ' '
+    switch -Regex ($commandLine) {
+        '^capture-pane .*%2' { @('gpt-5.4   64% context left', '? send   Ctrl+J newline', '>'); break }
+        default { throw "unexpected winsmux call: $commandLine" }
+    }
+}
+Set-Location '__BOARD_TEMP_ROOT__'
+. '__BRIDGE_SCRIPT__' version *> $null
+Invoke-Board -BoardTarget '--json'
+'@
+        $childScript = $childScript.Replace('__BOARD_TEMP_ROOT__', $script:boardTempRoot).Replace('__BRIDGE_SCRIPT__', $bridgeScript)
+        $output = & pwsh -NoProfile -Command $childScript
+
+        $result = ($output | Out-String | ConvertFrom-Json -AsHashtable)
+
+        $result.summary.pane_count | Should -Be 1
+        $result.panes[0].label | Should -Be 'builder-1'
+        $result.panes[0].task_state | Should -Be 'in_progress'
+    }
 }
 
 Describe 'winsmux send dispatch payload' {

--- a/tests/psmux-bridge.Tests.ps1
+++ b/tests/psmux-bridge.Tests.ps1
@@ -69,6 +69,7 @@ Describe 'Assert-Role' {
 
         (Assert-Role -Command 'send' -TargetPane 'reviewer') | Should -Be $true
         (Assert-Role -Command 'status') | Should -Be $true
+        (Assert-Role -Command 'board') | Should -Be $true
         (Assert-Role -Command 'context-reset' -TargetPane 'reviewer') | Should -Be $true
         (Assert-Role -Command 'poll-events') | Should -Be $true
         (Assert-Role -Command 'vault') | Should -Be $true
@@ -81,6 +82,7 @@ Describe 'Assert-Role' {
 
         (Assert-Role -Command 'send' -TargetPane 'commander') | Should -Be $true
         (Assert-Role -Command 'status') | Should -Be $true
+        (Assert-Role -Command 'board') | Should -Be $true
         (Assert-Role -Command 'type' -TargetPane 'self') | Should -Be $true
         (Assert-Role -Command 'context-reset' -TargetPane 'commander') | Should -Be $false
         (Assert-Role -Command 'send' -TargetPane 'reviewer') | Should -Be $false
@@ -2428,6 +2430,153 @@ panes:
         $output | Should -Match 'idle'
         $output | Should -Match 'busy'
         $output | Should -Match 'unknown'
+    }
+}
+
+Describe 'winsmux board command' {
+    BeforeAll {
+        $script:winsmuxCorePath = Join-Path (Split-Path -Parent $PSScriptRoot) 'scripts\winsmux-core.ps1'
+        . $script:winsmuxCorePath 'version' *> $null
+    }
+
+    BeforeEach {
+        $script:boardTempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('winsmux-board-tests-' + [guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $script:boardTempRoot -Force | Out-Null
+        $script:boardManifestDir = Join-Path $script:boardTempRoot '.winsmux'
+        New-Item -ItemType Directory -Path $script:boardManifestDir -Force | Out-Null
+        $script:boardManifestPath = Join-Path $script:boardManifestDir 'manifest.yaml'
+
+        Push-Location $script:boardTempRoot
+    }
+
+    AfterEach {
+        Pop-Location
+        if ($script:boardTempRoot -and (Test-Path $script:boardTempRoot)) {
+            Remove-Item -Path $script:boardTempRoot -Recurse -Force
+        }
+
+        $global:Target = $null
+        $global:Rest = @()
+        Remove-Item function:\winsmux -ErrorAction SilentlyContinue
+    }
+
+    It 'renders a session board with task, review, and git state columns' {
+@"
+version: 1
+session:
+  name: winsmux-orchestra
+  project_dir: $script:boardTempRoot
+panes:
+  builder-1:
+    pane_id: %2
+    role: Builder
+    task_id: task-244
+    task: Implement session board
+    task_state: in_progress
+    task_owner: builder-1
+    review_state: PENDING
+    branch: worktree-builder-1
+    head_sha: abc1234def5678
+    changed_file_count: 2
+    changed_files: '["scripts/winsmux-core.ps1","tests/psmux-bridge.Tests.ps1"]'
+    last_event: pane.ready
+    last_event_at: 2026-04-10T10:00:00+09:00
+  worker-1:
+    pane_id: %6
+    role: Worker
+    task_id: ''
+    task: ''
+    task_state: backlog
+    task_owner: ''
+    review_state: ''
+    branch: ''
+    head_sha: ''
+    changed_file_count: 0
+    changed_files: '[]'
+    last_event: pane.idle
+    last_event_at: 2026-04-10T10:05:00+09:00
+"@ | Set-Content -Path $script:boardManifestPath -Encoding UTF8
+
+        function global:winsmux {
+            $commandLine = ($args | ForEach-Object { [string]$_ }) -join ' '
+            switch -Regex ($commandLine) {
+                '^capture-pane .*%2' { return @('gpt-5.4   64% context left', '? send   Ctrl+J newline', '>') }
+                '^capture-pane .*%6' { return @('gpt-5.4   52% context left', 'thinking', 'Esc to interrupt') }
+                default { throw "unexpected winsmux call: $commandLine" }
+            }
+        }
+
+        $output = Invoke-Board | Out-String
+
+        $output | Should -Match 'builder-1'
+        $output | Should -Match 'worker-1'
+        $output | Should -Match 'in_progress'
+        $output | Should -Match 'PENDING'
+        $output | Should -Match 'worktree-builder-1'
+        $output | Should -Match 'abc1234'
+    }
+
+    It 'returns full session board data as json' {
+@"
+version: 1
+session:
+  name: winsmux-orchestra
+  project_dir: $script:boardTempRoot
+panes:
+  builder-1:
+    pane_id: %2
+    role: Builder
+    task_id: task-244
+    task: Implement session board
+    task_state: in_progress
+    task_owner: builder-1
+    review_state: PENDING
+    branch: worktree-builder-1
+    head_sha: abc1234def5678
+    changed_file_count: 2
+    changed_files: '["scripts/winsmux-core.ps1","tests/psmux-bridge.Tests.ps1"]'
+    last_event: pane.ready
+    last_event_at: 2026-04-10T10:00:00+09:00
+  worker-1:
+    pane_id: %6
+    role: Worker
+    task_id: ''
+    task: ''
+    task_state: backlog
+    task_owner: ''
+    review_state: ''
+    branch: ''
+    head_sha: ''
+    changed_file_count: 0
+    changed_files: '[]'
+    last_event: pane.idle
+    last_event_at: 2026-04-10T10:05:00+09:00
+"@ | Set-Content -Path $script:boardManifestPath -Encoding UTF8
+
+        function global:winsmux {
+            $commandLine = ($args | ForEach-Object { [string]$_ }) -join ' '
+            switch -Regex ($commandLine) {
+                '^capture-pane .*%2' { return @('gpt-5.4   64% context left', '? send   Ctrl+J newline', '>') }
+                '^capture-pane .*%6' { return @('gpt-5.4   52% context left', 'thinking', 'Esc to interrupt') }
+                default { throw "unexpected winsmux call: $commandLine" }
+            }
+        }
+
+        $result = (Invoke-Board -BoardTarget '--json' | Out-String | ConvertFrom-Json -AsHashtable)
+
+        $result.project_dir | Should -Be $script:boardTempRoot
+        $result.summary.pane_count | Should -Be 2
+        $result.summary.dirty_panes | Should -Be 1
+        $result.summary.review_pending | Should -Be 1
+        $result.summary.tasks_in_progress | Should -Be 1
+        $result.summary.by_state.idle | Should -Be 1
+        $result.summary.by_state.busy | Should -Be 1
+        $result.panes.Count | Should -Be 2
+        $result.panes[0].label | Should -Be 'builder-1'
+        $result.panes[0].changed_files | Should -Be @('scripts/winsmux-core.ps1', 'tests/psmux-bridge.Tests.ps1')
+        $result.panes[0].last_event | Should -Be 'pane.ready'
+        $result.panes[1].label | Should -Be 'worker-1'
+        $result.panes[1].state | Should -Be 'busy'
     }
 }
 

--- a/winsmux-core/scripts/role-gate.ps1
+++ b/winsmux-core/scripts/role-gate.ps1
@@ -461,6 +461,10 @@ function Assert-Role {
             if ($permissions.Status) { return $true }
             return Deny-RoleCommand -Role $role -Command $normalizedCommand
         }
+        'board' {
+            if ($permissions.Status) { return $true }
+            return Deny-RoleCommand -Role $role -Command $normalizedCommand
+        }
         'name' {
             if ($permissions.Name) { return $true }
             return Deny-RoleCommand -Role $role -Command $normalizedCommand


### PR DESCRIPTION
## Summary
- add the first visible orchestration `winsmux board` surface
- cover `winsmux board --json` through the top-level CLI entrypoint
- refresh `docs/handoff.md` to remove private planning root paths and keep handoff current

## Validation
- `Invoke-Pester tests/psmux-bridge.Tests.ps1`
- result: `83/83 PASS`

## Notes
- this lands `TASK-244` repo-side work
- external planning already tracks `TASK-244` as done and `v0.19.7` as `2/7`
- handoff keeps `docs/handoff.md` as the only active source of truth