### PR TITLE
feat(orchestra): add actionable inbox surface

### DIFF
--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -1,40 +1,40 @@
 # Handoff
 
-> Updated: 2026-04-10T10:05:33+09:00
+> Updated: 2026-04-10T11:05:00+09:00
 > Source of truth: this file
 
 ## Current state
 
-- `v0.19.5` is released.
-- `v0.19.6 hardening` is implemented, merged, and tracked as `100% (6/6)` in the external planning backlog/roadmap.
-- PR [#370](https://github.com/Sora-bluesky/winsmux/pull/370) is merged into `main`.
+- `v0.19.5` and `v0.19.6` are released.
+- `v0.19.6 hardening` is implemented, merged, released, and tracked as `100% (6/6)` in the external planning backlog/roadmap.
+- PR [#370](https://github.com/Sora-bluesky/winsmux/pull/370) and PR [#371](https://github.com/Sora-bluesky/winsmux/pull/371) are merged into `main`.
 - Planning source of truth is externalized outside the public repository and syncs automatically into the private planning root.
-- `v0.19.7 visible orchestration` is now `2/7` complete. `TASK-243` and `TASK-244` are done in external planning.
+- `v0.19.7 visible orchestration` is now `2/7` complete. `TASK-243` and `TASK-244` are done in external planning, and repo-side work has started on `TASK-245`.
 - `v0.24.0: Rust runtime convergence` exists in external planning as the pre-`v1.0.0` Rust unification milestone.
 
 ## This session
 
-- Merged the repo-side `v0.19.6` hardening closure.
-- Added a durable handoff maintenance rule to `AGENTS.md` so new sessions must refresh `docs/handoff.md` at milestone boundaries and before autonomous git progression.
-- Implemented `winsmux board` as the first visible orchestration surface for `TASK-244`.
-- Updated external planning so `TASK-244` is `done`, `v0.19.7` is `2/7`, and `v0.24.0` contains the Rust runtime convergence plan.
+- Merged the repo-side `TASK-244` session board surface via PR [#371](https://github.com/Sora-bluesky/winsmux/pull/371).
+- Released `v0.19.6` from tag `eac8615` and updated the public GitHub Release body to `/release-notes` format.
+- Added `winsmux inbox` as the first `TASK-245` surface: snapshot/json/stream for actionable approvals, review requests, failures, and blockers.
+- Updated external planning so `v0.19.8` remains visible, `v0.20.1` contains `TASK-272/273/274`, and `v0.24.0` keeps the Rust runtime convergence plan.
 
 ## Validation
 
-- Full local Pester suite passed: `171/171 PASS`
-- Targeted hardening suite passed earlier: `133/133 PASS`
-- `TASK-244` focused regression passed: `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `82/82 PASS`
-- Current uncommitted board surface touches:
+- Release workflow passed: `Release Core Binary` for `v0.19.6`
+- `TASK-244` PR CI passed before merge
+- Current `TASK-245` focused regression passed: `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `88/88 PASS`
+- Current uncommitted `TASK-245` touches:
   - `scripts/winsmux-core.ps1`
   - `winsmux-core/scripts/role-gate.ps1`
   - `tests/psmux-bridge.Tests.ps1`
 
 ## Next actions
 
-1. Commit and PR the repo-side `TASK-244` board surface.
-2. Release `v0.19.6` and prepare the release post draft.
-3. Continue `v0.19.7` with `TASK-245` or `TASK-256` after the board surface lands.
-4. Keep future backlog aligned with the `Operator / slot / provider` model and the new `v0.24.0` Rust convergence plan.
+1. Commit and PR the repo-side `TASK-245` inbox surface.
+2. Continue `v0.19.7` with `TASK-256` explain/run-ledger follow-up after inbox lands.
+3. Keep future backlog aligned with the `Operator / slot / provider / verification / security monitor` model.
+4. Preserve the private planning sync flow: user/agent visible, auto-synced, but not committed to the public repo.
 
 ## Notes
 

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -2236,6 +2236,474 @@ function Get-BridgeEventsPath {
     return Join-Path (Join-Path $ProjectDir '.winsmux') 'events.jsonl'
 }
 
+function Get-BridgeEventRecords {
+    param([string]$ProjectDir = (Get-Location).Path)
+
+    $eventsPath = Get-BridgeEventsPath -ProjectDir $ProjectDir
+    if (-not (Test-Path -LiteralPath $eventsPath -PathType Leaf)) {
+        return @()
+    }
+
+    try {
+        $lines = @(Get-Content -LiteralPath $eventsPath -Encoding UTF8)
+    } catch {
+        Stop-WithError "failed to read event log: $($_.Exception.Message)"
+    }
+
+    $records = [System.Collections.Generic.List[object]]::new()
+    for ($i = 0; $i -lt $lines.Count; $i++) {
+        $line = [string]$lines[$i]
+        if ([string]::IsNullOrWhiteSpace($line)) {
+            continue
+        }
+
+        try {
+            $record = $line | ConvertFrom-Json -AsHashtable -ErrorAction Stop
+            if ($null -eq $record) {
+                continue
+            }
+
+            $record['line_number'] = $i + 1
+            $records.Add($record) | Out-Null
+        } catch {
+            Stop-WithError "failed to parse event log line $($i + 1): $($_.Exception.Message)"
+        }
+    }
+
+    return @($records)
+}
+
+function Get-BridgeEventDelta {
+    param(
+        [string]$ProjectDir = (Get-Location).Path,
+        [int]$Cursor = 0
+    )
+
+    $records = @(Get-BridgeEventRecords -ProjectDir $ProjectDir)
+    if ($Cursor -gt $records.Count) {
+        $Cursor = $records.Count
+    }
+
+    return [ordered]@{
+        cursor = $records.Count
+        events  = @($records | Select-Object -Skip $Cursor)
+    }
+}
+
+function Get-InboxPriority {
+    param([string]$Kind)
+
+    switch ([string]$Kind) {
+        'blocked'          { return 0 }
+        'task_blocked'     { return 0 }
+        'review_failed'    { return 0 }
+        'bootstrap_invalid' { return 0 }
+        'crashed'          { return 0 }
+        'hung'             { return 0 }
+        'stalled'          { return 0 }
+        'approval_waiting' { return 1 }
+        'review_requested' { return 1 }
+        'review_pending'   { return 1 }
+        'dispatch_needed'  { return 2 }
+        'task_completed'   { return 2 }
+        'commit_ready'     { return 2 }
+        default            { return 3 }
+    }
+}
+
+function New-InboxItem {
+    param(
+        [Parameter(Mandatory = $true)][string]$Kind,
+        [Parameter(Mandatory = $true)][string]$Message,
+        [string]$Label = '',
+        [string]$PaneId = '',
+        [string]$Role = '',
+        [string]$TaskId = '',
+        [string]$Task = '',
+        [string]$TaskState = '',
+        [string]$ReviewState = '',
+        [string]$Branch = '',
+        [string]$HeadSha = '',
+        [string]$Event = '',
+        [string]$Timestamp = '',
+        [string]$Source = '',
+        [int]$ChangedFileCount = 0
+    )
+
+    return [ordered]@{
+        kind               = $Kind
+        priority           = Get-InboxPriority -Kind $Kind
+        message            = $Message
+        label              = $Label
+        pane_id            = $PaneId
+        role               = $Role
+        task_id            = $TaskId
+        task               = $Task
+        task_state         = $TaskState
+        review_state       = $ReviewState
+        branch             = $Branch
+        head_sha           = $HeadSha
+        changed_file_count = $ChangedFileCount
+        event              = $Event
+        timestamp          = $Timestamp
+        source             = $Source
+    }
+}
+
+function Get-InboxActionableEventKind {
+    param([Parameter(Mandatory = $true)]$EventRecord)
+
+    $eventName = [string]$EventRecord['event']
+    $status = [string]$EventRecord['status']
+    $data = $null
+    if ($EventRecord.Contains('data')) {
+        $data = $EventRecord['data']
+    }
+
+    $dataStatus = ''
+    if ($null -ne $data -and $data -is [System.Collections.IDictionary] -and $data.Contains('status')) {
+        $dataStatus = [string]$data['status']
+    }
+
+    if ($eventName -eq 'approval_waiting' -or $eventName -eq 'pane.approval_waiting' -or $status -eq 'approval_waiting' -or ($eventName -eq 'monitor.status' -and $dataStatus -eq 'approval_waiting')) {
+        return 'approval_waiting'
+    }
+
+    switch ($eventName) {
+        'pane.idle'              { return 'dispatch_needed' }
+        'pane.completed'         { return 'task_completed' }
+        'pane.bootstrap_invalid' { return 'bootstrap_invalid' }
+        'pane.crashed'           { return 'crashed' }
+        'pane.hung'              { return 'hung' }
+        'pane.stalled'           { return 'stalled' }
+    }
+
+    if ($eventName -eq 'commander.state_transition') {
+        switch ($status) {
+            'blocked_no_review_target' { return 'blocked' }
+            'blocked_review_failed'    { return 'review_failed' }
+            'commit_ready'             { return 'commit_ready' }
+        }
+
+        switch ($dataStatus) {
+            'blocked_no_review_target' { return 'blocked' }
+            'blocked_review_failed'    { return 'review_failed' }
+            'commit_ready'             { return 'commit_ready' }
+        }
+    }
+
+    switch ($eventName) {
+        'commander.review_requested' { return 'review_requested' }
+        'commander.review_failed'    { return 'review_failed' }
+        'commander.blocked'          { return 'blocked' }
+        'commander.commit_ready'     { return 'commit_ready' }
+        default                      { return '' }
+    }
+}
+
+function ConvertTo-InboxEventItem {
+    param([Parameter(Mandatory = $true)]$EventRecord)
+
+    $kind = Get-InboxActionableEventKind -EventRecord $EventRecord
+    if ([string]::IsNullOrWhiteSpace($kind)) {
+        return $null
+    }
+
+    $data = $null
+    if ($EventRecord.Contains('data')) {
+        $data = $EventRecord['data']
+    }
+
+    $taskId = ''
+    $branch = [string]$EventRecord['branch']
+    $headSha = [string]$EventRecord['head_sha']
+    $eventStatus = [string]$EventRecord['status']
+    if ($null -ne $data -and $data -is [System.Collections.IDictionary]) {
+        if ($data.Contains('task_id')) { $taskId = [string]$data['task_id'] }
+        if ([string]::IsNullOrWhiteSpace($branch) -and $data.Contains('branch')) { $branch = [string]$data['branch'] }
+        if ([string]::IsNullOrWhiteSpace($headSha) -and $data.Contains('head_sha')) { $headSha = [string]$data['head_sha'] }
+        if ([string]::IsNullOrWhiteSpace($eventStatus) -and $data.Contains('to')) { $eventStatus = [string]$data['to'] }
+    }
+
+    $eventLabel = [string]$EventRecord['event']
+    if (-not [string]::IsNullOrWhiteSpace($eventStatus)) {
+        $eventLabel = $eventStatus
+    }
+
+    return New-InboxItem `
+        -Kind $kind `
+        -Message ([string]$EventRecord['message']) `
+        -Label ([string]$EventRecord['label']) `
+        -PaneId ([string]$EventRecord['pane_id']) `
+        -Role ([string]$EventRecord['role']) `
+        -TaskId $taskId `
+        -Branch $branch `
+        -HeadSha $headSha `
+        -Event $eventLabel `
+        -Timestamp ([string]$EventRecord['timestamp']) `
+        -Source 'events'
+}
+
+function Get-InboxEventEntityKey {
+    param([Parameter(Mandatory = $true)]$EventRecord)
+
+    $eventName = [string]$EventRecord['event']
+    if ($eventName -like 'commander.*') {
+        return 'commander'
+    }
+
+    $paneId = [string]$EventRecord['pane_id']
+    if (-not [string]::IsNullOrWhiteSpace($paneId)) {
+        return "pane:$paneId"
+    }
+
+    $label = [string]$EventRecord['label']
+    if (-not [string]::IsNullOrWhiteSpace($label)) {
+        return "label:$label"
+    }
+
+    return "event:$eventName"
+}
+
+function Get-InboxActiveEventRecords {
+    param([Parameter(Mandatory = $true)][string]$ProjectDir)
+
+    $records = @(Get-BridgeEventRecords -ProjectDir $ProjectDir)
+    $latestByEntity = [ordered]@{}
+    foreach ($record in $records) {
+        $key = Get-InboxEventEntityKey -EventRecord $record
+        $latestByEntity[$key] = $record
+    }
+
+    return @($latestByEntity.Values)
+}
+
+function Get-InboxStreamStartCursor {
+    param([Parameter(Mandatory = $true)][string]$ProjectDir)
+
+    return @(Get-BridgeEventRecords -ProjectDir $ProjectDir).Count
+}
+
+function Get-InboxPayload {
+    param([Parameter(Mandatory = $true)][string]$ProjectDir)
+
+    $boardPayload = Get-BoardPayload -ProjectDir $ProjectDir
+    $itemsByKey = [ordered]@{}
+
+    foreach ($pane in @($boardPayload.panes)) {
+        $paneKeyBase = if (-not [string]::IsNullOrWhiteSpace([string]$pane.pane_id)) { [string]$pane.pane_id } else { [string]$pane.label }
+        $reviewState = [string]$pane.review_state
+        $taskState = [string]$pane.task_state
+
+        if ($reviewState -eq 'PENDING') {
+            $key = "manifest:review_pending:$paneKeyBase"
+            $itemsByKey[$key] = New-InboxItem `
+                -Kind 'review_pending' `
+                -Message ("{0} が review 待機中。" -f [string]$pane.label) `
+                -Label ([string]$pane.label) `
+                -PaneId ([string]$pane.pane_id) `
+                -Role ([string]$pane.role) `
+                -TaskId ([string]$pane.task_id) `
+                -Task ([string]$pane.task) `
+                -TaskState $taskState `
+                -ReviewState $reviewState `
+                -Branch ([string]$pane.branch) `
+                -HeadSha ([string]$pane.head_sha) `
+                -Event ([string]$pane.last_event) `
+                -Timestamp ([string]$pane.last_event_at) `
+                -Source 'manifest' `
+                -ChangedFileCount ([int]$pane.changed_file_count)
+        }
+
+        if ($reviewState -in @('FAIL', 'FAILED')) {
+            $key = "manifest:review_failed:$paneKeyBase"
+            $itemsByKey[$key] = New-InboxItem `
+                -Kind 'review_failed' `
+                -Message ("{0} の review が FAIL。" -f [string]$pane.label) `
+                -Label ([string]$pane.label) `
+                -PaneId ([string]$pane.pane_id) `
+                -Role ([string]$pane.role) `
+                -TaskId ([string]$pane.task_id) `
+                -Task ([string]$pane.task) `
+                -TaskState $taskState `
+                -ReviewState $reviewState `
+                -Branch ([string]$pane.branch) `
+                -HeadSha ([string]$pane.head_sha) `
+                -Event ([string]$pane.last_event) `
+                -Timestamp ([string]$pane.last_event_at) `
+                -Source 'manifest' `
+                -ChangedFileCount ([int]$pane.changed_file_count)
+        }
+
+        if ($taskState -eq 'blocked') {
+            $key = "manifest:task_blocked:$paneKeyBase"
+            $itemsByKey[$key] = New-InboxItem `
+                -Kind 'task_blocked' `
+                -Message ("{0} が blocked。" -f [string]$pane.label) `
+                -Label ([string]$pane.label) `
+                -PaneId ([string]$pane.pane_id) `
+                -Role ([string]$pane.role) `
+                -TaskId ([string]$pane.task_id) `
+                -Task ([string]$pane.task) `
+                -TaskState $taskState `
+                -ReviewState $reviewState `
+                -Branch ([string]$pane.branch) `
+                -HeadSha ([string]$pane.head_sha) `
+                -Event ([string]$pane.last_event) `
+                -Timestamp ([string]$pane.last_event_at) `
+                -Source 'manifest' `
+                -ChangedFileCount ([int]$pane.changed_file_count)
+        }
+    }
+
+    $eventRecords = @(Get-InboxActiveEventRecords -ProjectDir $ProjectDir)
+    foreach ($eventRecord in $eventRecords) {
+        $item = ConvertTo-InboxEventItem -EventRecord $eventRecord
+        if ($null -eq $item) {
+            continue
+        }
+
+        $paneKeyBase = if (-not [string]::IsNullOrWhiteSpace([string]$item.pane_id)) { [string]$item.pane_id } else { [string]$item.label }
+        $key = "events:{0}:{1}" -f [string]$item.kind, $paneKeyBase
+        $itemsByKey[$key] = $item
+    }
+
+    $items = @($itemsByKey.Values | Sort-Object @{ Expression = { [int]$_.priority } }, @{ Expression = { [string]$_.timestamp } ; Descending = $true }, @{ Expression = { [string]$_.label } })
+    $byKind = [ordered]@{}
+    foreach ($item in $items) {
+        $kind = [string]$item.kind
+        if ([string]::IsNullOrWhiteSpace($kind)) {
+            $kind = 'unknown'
+        }
+
+        if ($byKind.Contains($kind)) {
+            $byKind[$kind] = [int]$byKind[$kind] + 1
+        } else {
+            $byKind[$kind] = 1
+        }
+    }
+
+    return [ordered]@{
+        generated_at = (Get-Date).ToString('o')
+        project_dir  = $ProjectDir
+        summary      = [ordered]@{
+            item_count = $items.Count
+            by_kind    = $byKind
+        }
+        items        = $items
+    }
+}
+
+function Write-InboxStreamItem {
+    param(
+        [Parameter(Mandatory = $true)]$Item,
+        [switch]$Json
+    )
+
+    if ($Json) {
+        $Item | ConvertTo-Json -Compress -Depth 10 | Write-Output
+        return
+    }
+
+    $timestamp = [string]$Item.timestamp
+    if ([string]::IsNullOrWhiteSpace($timestamp)) {
+        $timestamp = (Get-Date).ToString('o')
+    }
+
+    $label = [string]$Item.label
+    $paneId = [string]$Item.pane_id
+    $prefix = if (-not [string]::IsNullOrWhiteSpace($label) -and -not [string]::IsNullOrWhiteSpace($paneId)) {
+        '{0} ({1})' -f $label, $paneId
+    } elseif (-not [string]::IsNullOrWhiteSpace($label)) {
+        $label
+    } else {
+        $paneId
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($prefix)) {
+        Write-Output ("[{0}] {1} {2}: {3}" -f $timestamp, [string]$Item.kind, $prefix, [string]$Item.message)
+    } else {
+        Write-Output ("[{0}] {1}: {2}" -f $timestamp, [string]$Item.kind, [string]$Item.message)
+    }
+}
+
+function Invoke-Inbox {
+    param(
+        [AllowNull()][string]$InboxTarget = $Target,
+        [AllowNull()][string[]]$InboxRest = $Rest
+    )
+
+    $tokens = @()
+    if (-not [string]::IsNullOrWhiteSpace($InboxTarget)) {
+        $tokens += $InboxTarget
+    }
+    if ($InboxRest) {
+        $tokens += @($InboxRest)
+    }
+
+    $jsonOutput = $false
+    $streamOutput = $false
+
+    foreach ($token in $tokens) {
+        switch ($token) {
+            '--json'   { $jsonOutput = $true }
+            '--stream' { $streamOutput = $true }
+            default    { Stop-WithError "usage: winsmux inbox [--json] [--stream]" }
+        }
+    }
+
+    $projectDir = (Get-Location).Path
+    if ($streamOutput) {
+        $snapshot = Get-InboxPayload -ProjectDir $projectDir
+        foreach ($item in @($snapshot.items)) {
+            Write-InboxStreamItem -Item $item -Json:$jsonOutput
+        }
+
+        $cursor = Get-InboxStreamStartCursor -ProjectDir $projectDir
+        while ($true) {
+            $delta = Get-BridgeEventDelta -ProjectDir $projectDir -Cursor $cursor
+            $cursor = [int]$delta.cursor
+            foreach ($eventRecord in @($delta.events)) {
+                $item = ConvertTo-InboxEventItem -EventRecord $eventRecord
+                if ($null -eq $item) {
+                    continue
+                }
+
+                Write-InboxStreamItem -Item $item -Json:$jsonOutput
+            }
+
+            Start-Sleep -Seconds 2
+        }
+    }
+
+    $payload = Get-InboxPayload -ProjectDir $projectDir
+    if ($jsonOutput) {
+        $payload | ConvertTo-Json -Compress -Depth 10 | Write-Output
+        return
+    }
+
+    $items = @($payload.items)
+    if ($items.Count -eq 0) {
+        Write-Output "(no inbox items)"
+        return
+    }
+
+    $table = $items |
+        Select-Object `
+            @{ Name = 'Kind'; Expression = { $_.kind } }, `
+            @{ Name = 'Label'; Expression = { $_.label } }, `
+            @{ Name = 'PaneId'; Expression = { $_.pane_id } }, `
+            @{ Name = 'Role'; Expression = { $_.role } }, `
+            @{ Name = 'TaskState'; Expression = { $_.task_state } }, `
+            @{ Name = 'Review'; Expression = { $_.review_state } }, `
+            @{ Name = 'Branch'; Expression = { $_.branch } }, `
+            @{ Name = 'Message'; Expression = { $_.message } } |
+        Format-Table -AutoSize |
+        Out-String -Width 4096
+
+    Write-Output ($table.TrimEnd())
+}
+
 function Invoke-PollEvents {
     if ($Rest -and $Rest.Count -gt 0) {
         Stop-WithError "usage: winsmux poll-events [cursor]"
@@ -2818,6 +3286,7 @@ Commands:
   health-check              Report READY/BUSY/HUNG/DEAD for labeled panes
   status                    Report manifest pane states via capture-pane
   board [--json]            Report pane/task/review/git session board
+  inbox [--json] [--stream] Report actionable approvals/review/blockers
   poll-events [cursor]      Return new monitor events from .winsmux/events.jsonl
   signal <channel>          Send signal to unblock a waiting process
   watch <label> [silence_s] [timeout_s]  Block until pane output is silent
@@ -3151,6 +3620,7 @@ switch ($Command) {
     'health-check'    { Invoke-HealthCheck }
     'status'          { Invoke-Status }
     'board'           { Invoke-Board }
+    'inbox'           { Invoke-Inbox }
     'poll-events'     { Invoke-PollEvents }
     'signal'          { Invoke-Signal }
     'mailbox-create'  { Invoke-MailboxCreate }

--- a/tests/psmux-bridge.Tests.ps1
+++ b/tests/psmux-bridge.Tests.ps1
@@ -70,6 +70,7 @@ Describe 'Assert-Role' {
         (Assert-Role -Command 'send' -TargetPane 'reviewer') | Should -Be $true
         (Assert-Role -Command 'status') | Should -Be $true
         (Assert-Role -Command 'board') | Should -Be $true
+        (Assert-Role -Command 'inbox') | Should -Be $true
         (Assert-Role -Command 'context-reset' -TargetPane 'reviewer') | Should -Be $true
         (Assert-Role -Command 'poll-events') | Should -Be $true
         (Assert-Role -Command 'vault') | Should -Be $true
@@ -83,6 +84,7 @@ Describe 'Assert-Role' {
         (Assert-Role -Command 'send' -TargetPane 'commander') | Should -Be $true
         (Assert-Role -Command 'status') | Should -Be $true
         (Assert-Role -Command 'board') | Should -Be $true
+        (Assert-Role -Command 'inbox') | Should -Be $true
         (Assert-Role -Command 'type' -TargetPane 'self') | Should -Be $true
         (Assert-Role -Command 'context-reset' -TargetPane 'commander') | Should -Be $false
         (Assert-Role -Command 'send' -TargetPane 'reviewer') | Should -Be $false
@@ -2624,6 +2626,287 @@ Invoke-Board -BoardTarget '--json'
         $result.summary.pane_count | Should -Be 1
         $result.panes[0].label | Should -Be 'builder-1'
         $result.panes[0].task_state | Should -Be 'in_progress'
+    }
+}
+
+Describe 'winsmux inbox command' {
+    BeforeAll {
+        $script:winsmuxCorePath = Join-Path (Split-Path -Parent $PSScriptRoot) 'scripts\winsmux-core.ps1'
+        . $script:winsmuxCorePath 'version' *> $null
+    }
+
+    BeforeEach {
+        $script:inboxTempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('winsmux-inbox-tests-' + [guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $script:inboxTempRoot -Force | Out-Null
+        $script:inboxManifestDir = Join-Path $script:inboxTempRoot '.winsmux'
+        New-Item -ItemType Directory -Path $script:inboxManifestDir -Force | Out-Null
+        $script:inboxManifestPath = Join-Path $script:inboxManifestDir 'manifest.yaml'
+        $script:inboxEventsPath = Join-Path $script:inboxManifestDir 'events.jsonl'
+
+        Push-Location $script:inboxTempRoot
+    }
+
+    AfterEach {
+        Pop-Location
+        if ($script:inboxTempRoot -and (Test-Path $script:inboxTempRoot)) {
+            Remove-Item -Path $script:inboxTempRoot -Recurse -Force
+        }
+
+        $global:Target = $null
+        $global:Rest = @()
+        Remove-Item function:\winsmux -ErrorAction SilentlyContinue
+    }
+
+    It 'renders actionable inbox items from manifest review and blocked state' {
+@"
+version: 1
+session:
+  name: winsmux-orchestra
+  project_dir: $script:inboxTempRoot
+panes:
+  builder-1:
+    pane_id: %2
+    role: Builder
+    task_id: task-245
+    task: Build inbox surface
+    task_state: in_progress
+    task_owner: builder-1
+    review_state: PENDING
+    branch: worktree-builder-1
+    head_sha: abc1234def5678
+    changed_file_count: 1
+    changed_files: '["scripts/winsmux-core.ps1"]'
+    last_event: review.requested
+    last_event_at: 2026-04-10T11:00:00+09:00
+  worker-1:
+    pane_id: %6
+    role: Worker
+    task_id: task-999
+    task: Fix blocker
+    task_state: blocked
+    task_owner: worker-1
+    review_state: ''
+    branch: worktree-worker-1
+    head_sha: def5678abc1234
+    changed_file_count: 0
+    changed_files: '[]'
+    last_event: commander.state_transition
+    last_event_at: 2026-04-10T11:05:00+09:00
+"@ | Set-Content -Path $script:inboxManifestPath -Encoding UTF8
+
+        @(
+            ([ordered]@{
+                timestamp = '2026-04-10T11:02:00+09:00'
+                session   = 'winsmux-orchestra'
+                event     = 'pane.approval_waiting'
+                message   = 'approval prompt detected'
+                label     = 'builder-1'
+                pane_id   = '%2'
+                role      = 'Builder'
+                status    = 'approval_waiting'
+            } | ConvertTo-Json -Compress),
+            ([ordered]@{
+                timestamp = '2026-04-10T11:06:00+09:00'
+                session   = 'winsmux-orchestra'
+                event     = 'commander.state_transition'
+                message   = 'State: review_requested -> blocked_no_review_target'
+                label     = ''
+                pane_id   = ''
+                role      = 'Commander'
+                status    = 'blocked_no_review_target'
+                data      = [ordered]@{
+                    from = 'review_requested'
+                    to   = 'blocked_no_review_target'
+                }
+            } | ConvertTo-Json -Compress)
+        ) | Set-Content -Path $script:inboxEventsPath -Encoding UTF8
+
+        function global:winsmux {
+            $commandLine = ($args | ForEach-Object { [string]$_ }) -join ' '
+            switch -Regex ($commandLine) {
+                '^capture-pane .*%2' { return @('gpt-5.4   64% context left', '? send   Ctrl+J newline', '>') }
+                '^capture-pane .*%6' { return @('gpt-5.4   52% context left', 'thinking', 'Esc to interrupt') }
+                default { throw "unexpected winsmux call: $commandLine" }
+            }
+        }
+
+        $output = Invoke-Inbox | Out-String
+
+        $output | Should -Match 'review_pending'
+        $output | Should -Match 'approval_waiting'
+        $output | Should -Match 'task_blocked'
+        $output | Should -Match 'blocked'
+        $output | Should -Match 'builder-1'
+        $output | Should -Match 'worker-1'
+    }
+
+    It 'returns actionable inbox items as json' {
+@"
+version: 1
+session:
+  name: winsmux-orchestra
+  project_dir: $script:inboxTempRoot
+panes:
+  builder-1:
+    pane_id: %2
+    role: Builder
+    task_id: task-245
+    task: Build inbox surface
+    task_state: in_progress
+    task_owner: builder-1
+    review_state: PENDING
+    branch: worktree-builder-1
+    head_sha: abc1234def5678
+    changed_file_count: 1
+    changed_files: '["scripts/winsmux-core.ps1"]'
+    last_event: review.requested
+    last_event_at: 2026-04-10T11:00:00+09:00
+"@ | Set-Content -Path $script:inboxManifestPath -Encoding UTF8
+
+        @(
+            ([ordered]@{
+                timestamp = '2026-04-10T11:02:00+09:00'
+                session   = 'winsmux-orchestra'
+                event     = 'pane.approval_waiting'
+                message   = 'approval prompt detected'
+                label     = 'builder-1'
+                pane_id   = '%2'
+                role      = 'Builder'
+                status    = 'approval_waiting'
+            } | ConvertTo-Json -Compress),
+            ([ordered]@{
+                timestamp = '2026-04-10T11:07:00+09:00'
+                session   = 'winsmux-orchestra'
+                event     = 'commander.commit_ready'
+                message   = 'コミット準備完了。'
+                label     = ''
+                pane_id   = ''
+                role      = 'Commander'
+                status    = 'commit_ready'
+                head_sha  = 'abc1234def5678'
+            } | ConvertTo-Json -Compress)
+        ) | Set-Content -Path $script:inboxEventsPath -Encoding UTF8
+
+        function global:winsmux {
+            $commandLine = ($args | ForEach-Object { [string]$_ }) -join ' '
+            switch -Regex ($commandLine) {
+                '^capture-pane .*%2' { return @('gpt-5.4   64% context left', '? send   Ctrl+J newline', '>') }
+                default { throw "unexpected winsmux call: $commandLine" }
+            }
+        }
+
+        $result = (Invoke-Inbox -InboxTarget '--json' | Out-String | ConvertFrom-Json -AsHashtable)
+
+        $result.project_dir | Should -Be $script:inboxTempRoot
+        $result.summary.item_count | Should -Be 3
+        $result.summary.by_kind.review_pending | Should -Be 1
+        $result.summary.by_kind.approval_waiting | Should -Be 1
+        $result.summary.by_kind.commit_ready | Should -Be 1
+        @($result.items | ForEach-Object { $_.kind }) | Should -Contain 'review_pending'
+        @($result.items | ForEach-Object { $_.kind }) | Should -Contain 'approval_waiting'
+        @($result.items | ForEach-Object { $_.kind }) | Should -Contain 'commit_ready'
+    }
+
+    It 'supports winsmux inbox --json through the top-level CLI entrypoint' {
+@"
+version: 1
+session:
+  name: winsmux-orchestra
+  project_dir: $script:inboxTempRoot
+panes:
+  builder-1:
+    pane_id: %2
+    role: Builder
+    task_id: task-245
+    task: Build inbox surface
+    task_state: in_progress
+    task_owner: builder-1
+    review_state: PENDING
+    branch: worktree-builder-1
+    head_sha: abc1234def5678
+    changed_file_count: 1
+    changed_files: '["scripts/winsmux-core.ps1"]'
+    last_event: review.requested
+    last_event_at: 2026-04-10T11:00:00+09:00
+"@ | Set-Content -Path $script:inboxManifestPath -Encoding UTF8
+
+        ([ordered]@{
+            timestamp = '2026-04-10T11:02:00+09:00'
+            session   = 'winsmux-orchestra'
+            event     = 'pane.approval_waiting'
+            message   = 'approval prompt detected'
+            label     = 'builder-1'
+            pane_id   = '%2'
+            role      = 'Builder'
+            status    = 'approval_waiting'
+        } | ConvertTo-Json -Compress) | Set-Content -Path $script:inboxEventsPath -Encoding UTF8
+
+        $bridgeScript = Join-Path (Split-Path -Parent $PSScriptRoot) 'scripts\winsmux-core.ps1'
+        $childScript = @'
+Set-Item -Path function:winsmux -Value {
+    param([Parameter(ValueFromRemainingArguments = $true)][object[]]$args)
+    $commandLine = ($args | ForEach-Object { [string]$_ }) -join ' '
+    switch -Regex ($commandLine) {
+        '^capture-pane .*%2' { @('gpt-5.4   64% context left', '? send   Ctrl+J newline', '>'); break }
+        default { throw "unexpected winsmux call: $commandLine" }
+    }
+}
+Set-Location '__INBOX_TEMP_ROOT__'
+. '__BRIDGE_SCRIPT__' version *> $null
+Invoke-Inbox -InboxTarget '--json'
+'@
+        $childScript = $childScript.Replace('__INBOX_TEMP_ROOT__', $script:inboxTempRoot).Replace('__BRIDGE_SCRIPT__', $bridgeScript)
+        $output = & pwsh -NoProfile -Command $childScript
+
+        $result = ($output | Out-String | ConvertFrom-Json -AsHashtable)
+
+        $result.summary.item_count | Should -Be 2
+        @($result.items | ForEach-Object { $_.kind }) | Should -Contain 'review_pending'
+        @($result.items | ForEach-Object { $_.kind }) | Should -Contain 'approval_waiting'
+    }
+
+    It 'classifies the actionable inbox event taxonomy' {
+        (Get-InboxActionableEventKind -EventRecord ([ordered]@{ event = 'pane.approval_waiting'; status = 'approval_waiting' })) | Should -Be 'approval_waiting'
+        (Get-InboxActionableEventKind -EventRecord ([ordered]@{ event = 'pane.idle'; status = 'ready' })) | Should -Be 'dispatch_needed'
+        (Get-InboxActionableEventKind -EventRecord ([ordered]@{ event = 'pane.completed'; status = 'waiting_for_dispatch' })) | Should -Be 'task_completed'
+        (Get-InboxActionableEventKind -EventRecord ([ordered]@{ event = 'pane.bootstrap_invalid'; status = 'bootstrap_invalid' })) | Should -Be 'bootstrap_invalid'
+        (Get-InboxActionableEventKind -EventRecord ([ordered]@{ event = 'pane.crashed'; status = 'crashed' })) | Should -Be 'crashed'
+        (Get-InboxActionableEventKind -EventRecord ([ordered]@{ event = 'pane.hung'; status = 'hung' })) | Should -Be 'hung'
+        (Get-InboxActionableEventKind -EventRecord ([ordered]@{ event = 'pane.stalled'; status = 'stalled' })) | Should -Be 'stalled'
+        (Get-InboxActionableEventKind -EventRecord ([ordered]@{ event = 'commander.state_transition'; status = 'blocked_no_review_target'; data = [ordered]@{ to = 'blocked_no_review_target' } })) | Should -Be 'blocked'
+        (Get-InboxActionableEventKind -EventRecord ([ordered]@{ event = 'commander.commit_ready'; status = 'commit_ready' })) | Should -Be 'commit_ready'
+    }
+
+    It 'starts inbox stream after the current event cursor instead of replaying full history' {
+        @(
+            ([ordered]@{
+                timestamp = '2026-04-10T11:02:00+09:00'
+                session   = 'winsmux-orchestra'
+                event     = 'pane.approval_waiting'
+                message   = 'approval prompt detected'
+                label     = 'builder-1'
+                pane_id   = '%2'
+                role      = 'Builder'
+                status    = 'approval_waiting'
+            } | ConvertTo-Json -Compress),
+            ([ordered]@{
+                timestamp = '2026-04-10T11:03:00+09:00'
+                session   = 'winsmux-orchestra'
+                event     = 'pane.ready'
+                message   = 'ready'
+                label     = 'builder-1'
+                pane_id   = '%2'
+                role      = 'Builder'
+                status    = 'ready'
+            } | ConvertTo-Json -Compress)
+        ) | Set-Content -Path $script:inboxEventsPath -Encoding UTF8
+
+        $cursor = Get-InboxStreamStartCursor -ProjectDir $script:inboxTempRoot
+
+        $cursor | Should -Be 2
+        $delta = Get-BridgeEventDelta -ProjectDir $script:inboxTempRoot -Cursor $cursor
+        $delta.cursor | Should -Be 2
+        @($delta.events).Count | Should -Be 0
     }
 }
 

--- a/winsmux-core/scripts/role-gate.ps1
+++ b/winsmux-core/scripts/role-gate.ps1
@@ -465,6 +465,10 @@ function Assert-Role {
             if ($permissions.Status) { return $true }
             return Deny-RoleCommand -Role $role -Command $normalizedCommand
         }
+        'inbox' {
+            if ($permissions.Status) { return $true }
+            return Deny-RoleCommand -Role $role -Command $normalizedCommand
+        }
         'name' {
             if ($permissions.Name) { return $true }
             return Deny-RoleCommand -Role $role -Command $normalizedCommand


### PR DESCRIPTION
## Summary
- add `winsmux inbox` as the first TASK-245 surface
- derive actionable items from manifest state plus selected event transitions
- support snapshot, `--json`, and `--stream` output modes

## Details
- primary source of truth is manifest task/review state
- `events.jsonl` supplements approval, blocked, commit-ready, and runtime intervention signals
- `--stream` now emits current actionable snapshot first, then tails only new events
- role-gate now allows `inbox` anywhere `status`/`board` is permitted

## Validation
- `Invoke-Pester tests/psmux-bridge.Tests.ps1`
  - `88/88 PASS`
- PowerShell parser check
  - `scripts/winsmux-core.ps1`
  - `winsmux-core/scripts/role-gate.ps1`

## Notes
- handoff updated for merged `v0.19.6` / `TASK-244` and active `TASK-245`
- private planning already reflects `TASK-245` as the next `v0.19.7` implementation focus