### PR TITLE
feat(orchestra): add runs and explain surfaces

### DIFF
--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -1,6 +1,6 @@
 # Handoff
 
-> Updated: 2026-04-10T12:30:00+09:00
+> Updated: 2026-04-10T13:10:00+09:00
 > Source of truth: this file
 
 ## Current state
@@ -9,30 +9,32 @@
 - `v0.19.6 hardening` is implemented, merged, released, and tracked as `100% (6/6)` in the external planning backlog/roadmap.
 - PR [#370](https://github.com/Sora-bluesky/winsmux/pull/370) and PR [#371](https://github.com/Sora-bluesky/winsmux/pull/371) are merged into `main`.
 - Planning source of truth is externalized outside the public repository and syncs automatically into the private planning root.
-- `v0.19.7 visible orchestration` is now `2/7` complete. `TASK-243` and `TASK-244` are done in external planning, and repo-side work has started on `TASK-245`.
+- `v0.19.7 visible orchestration` is now `3/7` complete. `TASK-243`, `TASK-244`, and `TASK-245` are done in external planning.
 - `v0.24.0: Rust runtime convergence` exists in external planning as the pre-`v1.0.0` Rust unification milestone.
 
 ## This session
 
 - Merged the repo-side `TASK-244` session board surface via PR [#371](https://github.com/Sora-bluesky/winsmux/pull/371).
 - Released `v0.19.6` from tag `eac8615` and updated the public GitHub Release body to `/release-notes` format.
-- Added `winsmux inbox` as the first `TASK-245` surface: snapshot/json/stream for actionable approvals, review requests, failures, and blockers.
+- Merged `TASK-245` via PR [#372](https://github.com/Sora-bluesky/winsmux/pull/372), adding `winsmux inbox` as the first actionable approval/review/blocker surface.
+- Implemented the repo-side `TASK-256` primitives: `winsmux runs [--json]` and `winsmux explain <run_id> [--json] [--follow]`.
 - Updated external planning so `v0.19.8` remains visible, `v0.20.1` contains `TASK-272/273/274`, and `v0.24.0` keeps the Rust runtime convergence plan.
 
 ## Validation
 
 - Release workflow passed: `Release Core Binary` for `v0.19.6`
 - `TASK-244` PR CI passed before merge
-- Current `TASK-245` focused regression passed: `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `88/88 PASS`
-- Current uncommitted `TASK-245` touches:
+- `TASK-245` PR CI passed before merge
+- Current `TASK-256` focused regression passed: `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `93/93 PASS`
+- Current uncommitted `TASK-256` touches:
   - `scripts/winsmux-core.ps1`
   - `winsmux-core/scripts/role-gate.ps1`
   - `tests/psmux-bridge.Tests.ps1`
 
 ## Next actions
 
-1. Commit and PR the repo-side `TASK-245` inbox surface.
-2. Continue `v0.19.7` with `TASK-256` explain/run-ledger follow-up after inbox lands.
+1. Review and land the repo-side `TASK-256` runs/explain surface.
+2. Continue `v0.19.7` with `TASK-257` notification boundary tightening after `TASK-256`.
 3. Keep future backlog aligned with the `Operator / slot / provider / verification / security monitor` model.
 4. Preserve the private planning sync flow: user/agent visible, auto-synced, but not committed to the public repo.
 

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -2484,6 +2484,310 @@ function Get-InboxStreamStartCursor {
     return @(Get-BridgeEventRecords -ProjectDir $ProjectDir).Count
 }
 
+function Get-RunIdFromPaneRecord {
+    param([Parameter(Mandatory = $true)]$PaneRecord)
+
+    $taskId = [string]$PaneRecord.task_id
+    if (-not [string]::IsNullOrWhiteSpace($taskId)) {
+        return "task:$taskId"
+    }
+
+    $branch = [string]$PaneRecord.branch
+    if (-not [string]::IsNullOrWhiteSpace($branch)) {
+        return "branch:$branch"
+    }
+
+    $paneId = [string]$PaneRecord.pane_id
+    if (-not [string]::IsNullOrWhiteSpace($paneId)) {
+        return "pane:$paneId"
+    }
+
+    return "label:{0}" -f [string]$PaneRecord.label
+}
+
+function Test-RunMatchesEventRecord {
+    param(
+        [Parameter(Mandatory = $true)]$Run,
+        [Parameter(Mandatory = $true)]$EventRecord
+    )
+
+    $runTaskId = [string]$Run.task_id
+    $runBranch = [string]$Run.branch
+    $runHeadSha = [string]$Run.head_sha
+    $runLabels = @($Run.labels)
+    $runPaneIds = @($Run.pane_ids)
+
+    $eventTaskId = ''
+    $eventBranch = [string]$EventRecord['branch']
+    $eventHeadSha = [string]$EventRecord['head_sha']
+    $eventLabel = [string]$EventRecord['label']
+    $eventPaneId = [string]$EventRecord['pane_id']
+
+    $data = $null
+    if ($EventRecord.Contains('data')) {
+        $data = $EventRecord['data']
+    }
+
+    if ($null -ne $data -and $data -is [System.Collections.IDictionary]) {
+        if ($data.Contains('task_id')) { $eventTaskId = [string]$data['task_id'] }
+        if ([string]::IsNullOrWhiteSpace($eventBranch) -and $data.Contains('branch')) { $eventBranch = [string]$data['branch'] }
+        if ([string]::IsNullOrWhiteSpace($eventHeadSha) -and $data.Contains('head_sha')) { $eventHeadSha = [string]$data['head_sha'] }
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($runTaskId) -and $runTaskId -eq $eventTaskId) {
+        return $true
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($runBranch) -and $runBranch -eq $eventBranch) {
+        return $true
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($runHeadSha) -and $runHeadSha -eq $eventHeadSha) {
+        return $true
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($eventLabel) -and $runLabels -contains $eventLabel) {
+        return $true
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($eventPaneId) -and $runPaneIds -contains $eventPaneId) {
+        return $true
+    }
+
+    return $false
+}
+
+function ConvertTo-RunEventRecord {
+    param([Parameter(Mandatory = $true)]$EventRecord)
+
+    $taskId = ''
+    $branch = [string]$EventRecord['branch']
+    $headSha = [string]$EventRecord['head_sha']
+    $data = $null
+    if ($EventRecord.Contains('data')) {
+        $data = $EventRecord['data']
+    }
+
+    if ($null -ne $data -and $data -is [System.Collections.IDictionary]) {
+        if ($data.Contains('task_id')) { $taskId = [string]$data['task_id'] }
+        if ([string]::IsNullOrWhiteSpace($branch) -and $data.Contains('branch')) { $branch = [string]$data['branch'] }
+        if ([string]::IsNullOrWhiteSpace($headSha) -and $data.Contains('head_sha')) { $headSha = [string]$data['head_sha'] }
+    }
+
+    return [ordered]@{
+        line_number = [int]$EventRecord['line_number']
+        timestamp   = [string]$EventRecord['timestamp']
+        event       = [string]$EventRecord['event']
+        status      = [string]$EventRecord['status']
+        message     = [string]$EventRecord['message']
+        label       = [string]$EventRecord['label']
+        pane_id     = [string]$EventRecord['pane_id']
+        role        = [string]$EventRecord['role']
+        task_id     = $taskId
+        branch      = $branch
+        head_sha    = $headSha
+        source      = [string]$EventRecord['source']
+    }
+}
+
+function Get-RunsPayload {
+    param([Parameter(Mandatory = $true)][string]$ProjectDir)
+
+    $boardPayload = Get-BoardPayload -ProjectDir $ProjectDir
+    $inboxPayload = Get-InboxPayload -ProjectDir $ProjectDir
+    $runsById = [ordered]@{}
+
+    foreach ($pane in @($boardPayload.panes)) {
+        $runId = Get-RunIdFromPaneRecord -PaneRecord $pane
+        if (-not $runsById.Contains($runId)) {
+            $runsById[$runId] = [ordered]@{
+                run_id             = $runId
+                task_id            = [string]$pane.task_id
+                task               = [string]$pane.task
+                task_state         = [string]$pane.task_state
+                review_state       = [string]$pane.review_state
+                branch             = [string]$pane.branch
+                head_sha           = [string]$pane.head_sha
+                primary_label      = [string]$pane.label
+                primary_pane_id    = [string]$pane.pane_id
+                primary_role       = [string]$pane.role
+                state              = [string]$pane.state
+                tokens_remaining   = [string]$pane.tokens_remaining
+                last_event         = [string]$pane.last_event
+                last_event_at      = [string]$pane.last_event_at
+                pane_count         = 0
+                changed_file_count = 0
+                labels             = [System.Collections.Generic.List[string]]::new()
+                pane_ids           = [System.Collections.Generic.List[string]]::new()
+                roles              = [System.Collections.Generic.List[string]]::new()
+                changed_files      = [System.Collections.Generic.List[string]]::new()
+                action_items       = [System.Collections.Generic.List[object]]::new()
+            }
+        }
+
+        $run = $runsById[$runId]
+        $run.pane_count = [int]$run.pane_count + 1
+        $run.changed_file_count = [int]$run.changed_file_count + [int]$pane.changed_file_count
+
+        if (-not [string]::IsNullOrWhiteSpace([string]$pane.label) -and -not $run.labels.Contains([string]$pane.label)) {
+            $run.labels.Add([string]$pane.label) | Out-Null
+        }
+        if (-not [string]::IsNullOrWhiteSpace([string]$pane.pane_id) -and -not $run.pane_ids.Contains([string]$pane.pane_id)) {
+            $run.pane_ids.Add([string]$pane.pane_id) | Out-Null
+        }
+        if (-not [string]::IsNullOrWhiteSpace([string]$pane.role) -and -not $run.roles.Contains([string]$pane.role)) {
+            $run.roles.Add([string]$pane.role) | Out-Null
+        }
+
+        foreach ($changedFile in @($pane.changed_files)) {
+            $changedFileText = [string]$changedFile
+            if (-not [string]::IsNullOrWhiteSpace($changedFileText) -and -not $run.changed_files.Contains($changedFileText)) {
+                $run.changed_files.Add($changedFileText) | Out-Null
+            }
+        }
+    }
+
+    foreach ($item in @($inboxPayload.items)) {
+        foreach ($runId in @($runsById.Keys)) {
+            $run = $runsById[$runId]
+            if (
+                ((-not [string]::IsNullOrWhiteSpace([string]$item.task_id)) -and ([string]$item.task_id -eq [string]$run.task_id)) -or
+                ((-not [string]::IsNullOrWhiteSpace([string]$item.branch)) -and ([string]$item.branch -eq [string]$run.branch)) -or
+                ((-not [string]::IsNullOrWhiteSpace([string]$item.head_sha)) -and ([string]$item.head_sha -eq [string]$run.head_sha)) -or
+                ((-not [string]::IsNullOrWhiteSpace([string]$item.label)) -and ($run.labels -contains [string]$item.label)) -or
+                ((-not [string]::IsNullOrWhiteSpace([string]$item.pane_id)) -and ($run.pane_ids -contains [string]$item.pane_id))
+            ) {
+                $run.action_items.Add([ordered]@{
+                    kind      = [string]$item.kind
+                    message   = [string]$item.message
+                    event     = [string]$item.event
+                    timestamp = [string]$item.timestamp
+                    source    = [string]$item.source
+                }) | Out-Null
+                break
+            }
+        }
+    }
+
+    $runs = @(
+        foreach ($runId in @($runsById.Keys)) {
+            $run = $runsById[$runId]
+            [ordered]@{
+                run_id             = [string]$run.run_id
+                task_id            = [string]$run.task_id
+                task               = [string]$run.task
+                task_state         = [string]$run.task_state
+                review_state       = [string]$run.review_state
+                branch             = [string]$run.branch
+                head_sha           = [string]$run.head_sha
+                primary_label      = [string]$run.primary_label
+                primary_pane_id    = [string]$run.primary_pane_id
+                primary_role       = [string]$run.primary_role
+                state              = [string]$run.state
+                tokens_remaining   = [string]$run.tokens_remaining
+                last_event         = [string]$run.last_event
+                last_event_at      = [string]$run.last_event_at
+                pane_count         = [int]$run.pane_count
+                changed_file_count = [int]$run.changed_file_count
+                labels             = @($run.labels)
+                pane_ids           = @($run.pane_ids)
+                roles              = @($run.roles)
+                changed_files      = @($run.changed_files)
+                action_items       = @($run.action_items | Sort-Object @{ Expression = { [string]$_.timestamp }; Descending = $true }, @{ Expression = { [string]$_.kind } })
+            }
+        }
+    )
+
+    return [ordered]@{
+        generated_at = (Get-Date).ToString('o')
+        project_dir  = $ProjectDir
+        summary      = [ordered]@{
+            run_count          = $runs.Count
+            blocked_runs       = @($runs | Where-Object { [string]$_.task_state -eq 'blocked' }).Count
+            review_pending     = @($runs | Where-Object { [string]$_.review_state -eq 'PENDING' }).Count
+            dirty_runs         = @($runs | Where-Object { [int]$_.changed_file_count -gt 0 }).Count
+            action_item_count  = @($runs | ForEach-Object { @($_.action_items).Count } | Measure-Object -Sum).Sum
+        }
+        runs         = @($runs | Sort-Object @{ Expression = { [string]$_.last_event_at }; Descending = $true }, @{ Expression = { [string]$_.run_id } })
+    }
+}
+
+function Get-ExplainPayload {
+    param(
+        [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [Parameter(Mandatory = $true)][string]$RunId
+    )
+
+    $runsPayload = Get-RunsPayload -ProjectDir $ProjectDir
+    $run = @($runsPayload.runs | Where-Object { [string]$_.run_id -eq $RunId } | Select-Object -First 1)[0]
+    if ($null -eq $run) {
+        Stop-WithError "run not found: $RunId"
+    }
+
+    $events = @(
+        Get-BridgeEventRecords -ProjectDir $ProjectDir |
+            Where-Object { Test-RunMatchesEventRecord -Run $run -EventRecord $_ } |
+            ForEach-Object { ConvertTo-RunEventRecord -EventRecord $_ } |
+            Sort-Object @{ Expression = { [string]$_.timestamp }; Descending = $true }, @{ Expression = { [int]$_.line_number }; Descending = $true }
+    )
+
+    $reviewState = $null
+    $branch = [string]$run.branch
+    if (-not [string]::IsNullOrWhiteSpace($branch)) {
+        $state = Get-ReviewState -ProjectDir $ProjectDir
+        if ($state.Contains($branch)) {
+            $reviewState = ConvertTo-ReviewStateValue -Value $state[$branch]
+        }
+    }
+
+    $reasons = [System.Collections.Generic.List[string]]::new()
+    if (-not [string]::IsNullOrWhiteSpace([string]$run.task_state)) {
+        $reasons.Add("task_state=$([string]$run.task_state)") | Out-Null
+    }
+    if (-not [string]::IsNullOrWhiteSpace([string]$run.review_state)) {
+        $reasons.Add("review_state=$([string]$run.review_state)") | Out-Null
+    }
+    if (-not [string]::IsNullOrWhiteSpace([string]$run.last_event)) {
+        $reasons.Add("last_event=$([string]$run.last_event)") | Out-Null
+    }
+    foreach ($actionItem in @($run.action_items | Select-Object -First 3)) {
+        $reasons.Add("action:$([string]$actionItem.kind)") | Out-Null
+    }
+
+    return [ordered]@{
+        generated_at  = (Get-Date).ToString('o')
+        project_dir   = $ProjectDir
+        run           = $run
+        explanation   = [ordered]@{
+            summary       = if (-not [string]::IsNullOrWhiteSpace([string]$run.task)) { [string]$run.task } else { [string]$run.primary_label }
+            reasons       = @($reasons)
+            next_action   = if (@($run.action_items).Count -gt 0) { [string]$run.action_items[0].kind } else { [string]$run.task_state }
+            current_state = [ordered]@{
+                state        = [string]$run.state
+                task_state   = [string]$run.task_state
+                review_state = [string]$run.review_state
+                last_event   = [string]$run.last_event
+            }
+        }
+        review_state  = $reviewState
+        recent_events = @($events | Select-Object -First 20)
+    }
+}
+
+function Write-ExplainFollowItem {
+    param(
+        [Parameter(Mandatory = $true)]$Item,
+        [switch]$Json
+    )
+
+    if ($Json) {
+        $Item | ConvertTo-Json -Compress -Depth 10 | Write-Output
+        return
+    }
+
+    Write-Output ("[{0}] {1} {2}: {3}" -f [string]$Item.timestamp, [string]$Item.event, [string]$Item.label, [string]$Item.message)
+}
+
 function Get-InboxPayload {
     param([Parameter(Mandatory = $true)][string]$ProjectDir)
 
@@ -2702,6 +3006,159 @@ function Invoke-Inbox {
         Out-String -Width 4096
 
     Write-Output ($table.TrimEnd())
+}
+
+function Invoke-Runs {
+    param(
+        [AllowNull()][string]$RunsTarget = $Target,
+        [AllowNull()][string[]]$RunsRest = $Rest
+    )
+
+    $jsonOutput = $false
+
+    if ($RunsTarget) {
+        if ($RunsTarget -eq '--json' -and (-not $RunsRest -or $RunsRest.Count -eq 0)) {
+            $jsonOutput = $true
+        } else {
+            Stop-WithError "usage: winsmux runs [--json]"
+        }
+    } elseif ($RunsRest -and $RunsRest.Count -gt 0) {
+        Stop-WithError "usage: winsmux runs [--json]"
+    }
+
+    $projectDir = (Get-Location).Path
+    $payload = Get-RunsPayload -ProjectDir $projectDir
+
+    if ($jsonOutput) {
+        $payload | ConvertTo-Json -Compress -Depth 10 | Write-Output
+        return
+    }
+
+    $runs = @($payload.runs)
+    if ($runs.Count -eq 0) {
+        Write-Output "(no runs)"
+        return
+    }
+
+    $table = $runs |
+        Select-Object `
+            @{ Name = 'RunId'; Expression = { $_.run_id } }, `
+            @{ Name = 'Label'; Expression = { $_.primary_label } }, `
+            @{ Name = 'Task'; Expression = { $_.task } }, `
+            @{ Name = 'TaskState'; Expression = { $_.task_state } }, `
+            @{ Name = 'Review'; Expression = { $_.review_state } }, `
+            @{ Name = 'State'; Expression = { $_.state } }, `
+            @{ Name = 'Branch'; Expression = { $_.branch } }, `
+            @{ Name = 'Head'; Expression = { if ([string]::IsNullOrWhiteSpace($_.head_sha)) { '' } elseif ($_.head_sha.Length -le 7) { $_.head_sha } else { $_.head_sha.Substring(0, 7) } } }, `
+            @{ Name = 'ActionItems'; Expression = { @($_.action_items).Count } } |
+        Format-Table -AutoSize |
+        Out-String -Width 4096
+
+    Write-Output ($table.TrimEnd())
+}
+
+function Invoke-Explain {
+    param(
+        [AllowNull()][string]$ExplainTarget = $Target,
+        [AllowNull()][string[]]$ExplainRest = $Rest
+    )
+
+    $tokens = @()
+    if (-not [string]::IsNullOrWhiteSpace($ExplainTarget)) {
+        $tokens += $ExplainTarget
+    }
+    if ($ExplainRest) {
+        $tokens += @($ExplainRest)
+    }
+
+    if ($tokens.Count -eq 0) {
+        Stop-WithError "usage: winsmux explain <run_id> [--json] [--follow]"
+    }
+
+    $runId = ''
+    $jsonOutput = $false
+    $followOutput = $false
+
+    foreach ($token in $tokens) {
+        switch ($token) {
+            '--json'   { $jsonOutput = $true }
+            '--follow' { $followOutput = $true }
+            default {
+                if ([string]::IsNullOrWhiteSpace($runId)) {
+                    $runId = [string]$token
+                } else {
+                    Stop-WithError "usage: winsmux explain <run_id> [--json] [--follow]"
+                }
+            }
+        }
+    }
+
+    if ([string]::IsNullOrWhiteSpace($runId)) {
+        Stop-WithError "usage: winsmux explain <run_id> [--json] [--follow]"
+    }
+
+    $projectDir = (Get-Location).Path
+    $payload = Get-ExplainPayload -ProjectDir $projectDir -RunId $runId
+
+    if ($followOutput) {
+        if ($jsonOutput) {
+            $payload | ConvertTo-Json -Compress -Depth 10 | Write-Output
+        } else {
+            Write-Output ("Run: {0}" -f [string]$payload.run.run_id)
+            Write-Output ("Task: {0}" -f [string]$payload.explanation.summary)
+            Write-Output ("State: {0} / {1} / {2}" -f [string]$payload.run.state, [string]$payload.run.task_state, [string]$payload.run.review_state)
+            if (-not [string]::IsNullOrWhiteSpace([string]$payload.run.branch)) {
+                Write-Output ("Branch: {0}" -f [string]$payload.run.branch)
+            }
+            if (-not [string]::IsNullOrWhiteSpace([string]$payload.run.head_sha)) {
+                Write-Output ("Head: {0}" -f [string]$payload.run.head_sha)
+            }
+        }
+
+        $cursor = @(Get-BridgeEventRecords -ProjectDir $projectDir).Count
+        while ($true) {
+            $delta = Get-BridgeEventDelta -ProjectDir $projectDir -Cursor $cursor
+            $cursor = [int]$delta.cursor
+            foreach ($eventRecord in @($delta.events)) {
+                if (-not (Test-RunMatchesEventRecord -Run $payload.run -EventRecord $eventRecord)) {
+                    continue
+                }
+
+                $item = ConvertTo-RunEventRecord -EventRecord $eventRecord
+                Write-ExplainFollowItem -Item $item -Json:$jsonOutput
+            }
+
+            Start-Sleep -Seconds 2
+        }
+    }
+
+    if ($jsonOutput) {
+        $payload | ConvertTo-Json -Compress -Depth 10 | Write-Output
+        return
+    }
+
+    Write-Output ("Run: {0}" -f [string]$payload.run.run_id)
+    Write-Output ("Task: {0}" -f [string]$payload.explanation.summary)
+    Write-Output ("Primary: {0} ({1})" -f [string]$payload.run.primary_label, [string]$payload.run.primary_pane_id)
+    Write-Output ("State: {0} / {1} / {2}" -f [string]$payload.run.state, [string]$payload.run.task_state, [string]$payload.run.review_state)
+    if (-not [string]::IsNullOrWhiteSpace([string]$payload.run.branch)) {
+        Write-Output ("Branch: {0}" -f [string]$payload.run.branch)
+    }
+    if (-not [string]::IsNullOrWhiteSpace([string]$payload.run.head_sha)) {
+        Write-Output ("Head: {0}" -f [string]$payload.run.head_sha)
+    }
+    if (@($payload.explanation.reasons).Count -gt 0) {
+        Write-Output "Reasons:"
+        foreach ($reason in @($payload.explanation.reasons)) {
+            Write-Output ("- {0}" -f [string]$reason)
+        }
+    }
+    if (@($payload.recent_events).Count -gt 0) {
+        Write-Output "Recent events:"
+        foreach ($eventRecord in @($payload.recent_events | Select-Object -First 10)) {
+            Write-Output ("- [{0}] {1} {2}: {3}" -f [string]$eventRecord.timestamp, [string]$eventRecord.event, [string]$eventRecord.label, [string]$eventRecord.message)
+        }
+    }
 }
 
 function Invoke-PollEvents {
@@ -3287,6 +3744,8 @@ Commands:
   status                    Report manifest pane states via capture-pane
   board [--json]            Report pane/task/review/git session board
   inbox [--json] [--stream] Report actionable approvals/review/blockers
+  runs [--json]             Report run-oriented session view
+  explain <run_id> [--json] [--follow]  Explain one run and optionally follow new events
   poll-events [cursor]      Return new monitor events from .winsmux/events.jsonl
   signal <channel>          Send signal to unblock a waiting process
   watch <label> [silence_s] [timeout_s]  Block until pane output is silent
@@ -3621,6 +4080,8 @@ switch ($Command) {
     'status'          { Invoke-Status }
     'board'           { Invoke-Board }
     'inbox'           { Invoke-Inbox }
+    'runs'            { Invoke-Runs }
+    'explain'         { Invoke-Explain }
     'poll-events'     { Invoke-PollEvents }
     'signal'          { Invoke-Signal }
     'mailbox-create'  { Invoke-MailboxCreate }

--- a/tests/psmux-bridge.Tests.ps1
+++ b/tests/psmux-bridge.Tests.ps1
@@ -71,6 +71,8 @@ Describe 'Assert-Role' {
         (Assert-Role -Command 'status') | Should -Be $true
         (Assert-Role -Command 'board') | Should -Be $true
         (Assert-Role -Command 'inbox') | Should -Be $true
+        (Assert-Role -Command 'runs') | Should -Be $true
+        (Assert-Role -Command 'explain') | Should -Be $true
         (Assert-Role -Command 'context-reset' -TargetPane 'reviewer') | Should -Be $true
         (Assert-Role -Command 'poll-events') | Should -Be $true
         (Assert-Role -Command 'vault') | Should -Be $true
@@ -85,6 +87,8 @@ Describe 'Assert-Role' {
         (Assert-Role -Command 'status') | Should -Be $true
         (Assert-Role -Command 'board') | Should -Be $true
         (Assert-Role -Command 'inbox') | Should -Be $true
+        (Assert-Role -Command 'runs') | Should -Be $true
+        (Assert-Role -Command 'explain') | Should -Be $true
         (Assert-Role -Command 'type' -TargetPane 'self') | Should -Be $true
         (Assert-Role -Command 'context-reset' -TargetPane 'commander') | Should -Be $false
         (Assert-Role -Command 'send' -TargetPane 'reviewer') | Should -Be $false
@@ -2907,6 +2911,426 @@ Invoke-Inbox -InboxTarget '--json'
         $delta = Get-BridgeEventDelta -ProjectDir $script:inboxTempRoot -Cursor $cursor
         $delta.cursor | Should -Be 2
         @($delta.events).Count | Should -Be 0
+    }
+}
+
+Describe 'winsmux runs command' {
+    BeforeAll {
+        $script:winsmuxCorePath = Join-Path (Split-Path -Parent $PSScriptRoot) 'scripts\winsmux-core.ps1'
+        . $script:winsmuxCorePath 'version' *> $null
+    }
+
+    BeforeEach {
+        $script:runsTempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('winsmux-runs-tests-' + [guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $script:runsTempRoot -Force | Out-Null
+        $script:runsManifestDir = Join-Path $script:runsTempRoot '.winsmux'
+        New-Item -ItemType Directory -Path $script:runsManifestDir -Force | Out-Null
+        $script:runsManifestPath = Join-Path $script:runsManifestDir 'manifest.yaml'
+        $script:runsEventsPath = Join-Path $script:runsManifestDir 'events.jsonl'
+
+        Push-Location $script:runsTempRoot
+    }
+
+    AfterEach {
+        Pop-Location
+        if ($script:runsTempRoot -and (Test-Path $script:runsTempRoot)) {
+            Remove-Item -Path $script:runsTempRoot -Recurse -Force
+        }
+
+        $global:Target = $null
+        $global:Rest = @()
+        Remove-Item function:\winsmux -ErrorAction SilentlyContinue
+    }
+
+    It 'renders run-oriented grouped output from manifest and actionable items' {
+@"
+version: 1
+session:
+  name: winsmux-orchestra
+  project_dir: $script:runsTempRoot
+panes:
+  builder-1:
+    pane_id: %2
+    role: Builder
+    task_id: task-256
+    task: Implement run ledger
+    task_state: in_progress
+    task_owner: builder-1
+    review_state: PENDING
+    branch: worktree-builder-1
+    head_sha: abc1234def5678
+    changed_file_count: 2
+    changed_files: '["scripts/winsmux-core.ps1","tests/psmux-bridge.Tests.ps1"]'
+    last_event: commander.review_requested
+    last_event_at: 2026-04-10T12:00:00+09:00
+  worker-1:
+    pane_id: %6
+    role: Worker
+    task_id: ''
+    task: ''
+    task_state: backlog
+    task_owner: ''
+    review_state: ''
+    branch: ''
+    head_sha: ''
+    changed_file_count: 0
+    changed_files: '[]'
+    last_event: pane.idle
+    last_event_at: 2026-04-10T12:05:00+09:00
+"@ | Set-Content -Path $script:runsManifestPath -Encoding UTF8
+
+        @(
+            ([ordered]@{
+                timestamp = '2026-04-10T12:01:00+09:00'
+                session   = 'winsmux-orchestra'
+                event     = 'pane.approval_waiting'
+                message   = 'approval prompt detected'
+                label     = 'builder-1'
+                pane_id   = '%2'
+                role      = 'Builder'
+                status    = 'approval_waiting'
+            } | ConvertTo-Json -Compress),
+            ([ordered]@{
+                timestamp = '2026-04-10T12:06:00+09:00'
+                session   = 'winsmux-orchestra'
+                event     = 'pane.idle'
+                message   = 'idle pane'
+                label     = 'worker-1'
+                pane_id   = '%6'
+                role      = 'Worker'
+                status    = 'ready'
+            } | ConvertTo-Json -Compress)
+        ) | Set-Content -Path $script:runsEventsPath -Encoding UTF8
+
+        function global:winsmux {
+            $commandLine = ($args | ForEach-Object { [string]$_ }) -join ' '
+            switch -Regex ($commandLine) {
+                '^capture-pane .*%2' { return @('gpt-5.4   64% context left', '? send   Ctrl+J newline', '>') }
+                '^capture-pane .*%6' { return @('gpt-5.4   52% context left', 'thinking', 'Esc to interrupt') }
+                default { throw "unexpected winsmux call: $commandLine" }
+            }
+        }
+
+        $output = Invoke-Runs | Out-String
+
+        $output | Should -Match 'task:task-256'
+        $output | Should -Match 'builder-1'
+        $output | Should -Match 'Implement run ledger'
+        $output | Should -Match 'PENDING'
+        $output | Should -Match '\s2\s*$'
+    }
+
+    It 'returns runs as json' {
+@"
+version: 1
+session:
+  name: winsmux-orchestra
+  project_dir: $script:runsTempRoot
+panes:
+  builder-1:
+    pane_id: %2
+    role: Builder
+    task_id: task-256
+    task: Implement run ledger
+    task_state: in_progress
+    task_owner: builder-1
+    review_state: PENDING
+    branch: worktree-builder-1
+    head_sha: abc1234def5678
+    changed_file_count: 1
+    changed_files: '["scripts/winsmux-core.ps1"]'
+    last_event: commander.review_requested
+    last_event_at: 2026-04-10T12:00:00+09:00
+"@ | Set-Content -Path $script:runsManifestPath -Encoding UTF8
+
+        ([ordered]@{
+            timestamp = '2026-04-10T12:01:00+09:00'
+            session   = 'winsmux-orchestra'
+            event     = 'pane.approval_waiting'
+            message   = 'approval prompt detected'
+            label     = 'builder-1'
+            pane_id   = '%2'
+            role      = 'Builder'
+            status    = 'approval_waiting'
+        } | ConvertTo-Json -Compress) | Set-Content -Path $script:runsEventsPath -Encoding UTF8
+
+        function global:winsmux {
+            $commandLine = ($args | ForEach-Object { [string]$_ }) -join ' '
+            switch -Regex ($commandLine) {
+                '^capture-pane .*%2' { return @('gpt-5.4   64% context left', '? send   Ctrl+J newline', '>') }
+                default { throw "unexpected winsmux call: $commandLine" }
+            }
+        }
+
+        $result = (Invoke-Runs -RunsTarget '--json' | Out-String | ConvertFrom-Json -AsHashtable)
+
+        $result.summary.run_count | Should -Be 1
+        $result.summary.review_pending | Should -Be 1
+        $result.summary.dirty_runs | Should -Be 1
+        $result.runs[0].run_id | Should -Be 'task:task-256'
+        @($result.runs[0].action_items | ForEach-Object { $_.kind }) | Should -Contain 'approval_waiting'
+        @($result.runs[0].action_items | ForEach-Object { $_.kind }) | Should -Contain 'review_pending'
+        $result.runs[0].changed_files | Should -Be @('scripts/winsmux-core.ps1')
+    }
+
+    It 'supports winsmux runs --json through the top-level CLI entrypoint' {
+@"
+version: 1
+session:
+  name: winsmux-orchestra
+  project_dir: $script:runsTempRoot
+panes:
+  builder-1:
+    pane_id: %2
+    role: Builder
+    task_id: task-256
+    task: Implement run ledger
+    task_state: in_progress
+    task_owner: builder-1
+    review_state: PENDING
+    branch: worktree-builder-1
+    head_sha: abc1234def5678
+    changed_file_count: 1
+    changed_files: '["scripts/winsmux-core.ps1"]'
+    last_event: commander.review_requested
+    last_event_at: 2026-04-10T12:00:00+09:00
+"@ | Set-Content -Path $script:runsManifestPath -Encoding UTF8
+
+        $bridgeScript = Join-Path (Split-Path -Parent $PSScriptRoot) 'scripts\winsmux-core.ps1'
+        $childScript = @'
+Set-Item -Path function:winsmux -Value {
+    param([Parameter(ValueFromRemainingArguments = $true)][object[]]$args)
+    $commandLine = ($args | ForEach-Object { [string]$_ }) -join ' '
+    switch -Regex ($commandLine) {
+        '^capture-pane .*%2' { @('gpt-5.4   64% context left', '? send   Ctrl+J newline', '>'); break }
+        default { throw "unexpected winsmux call: $commandLine" }
+    }
+}
+Set-Location '__RUNS_TEMP_ROOT__'
+& '__BRIDGE_SCRIPT__' runs --json
+'@
+        $childScript = $childScript.Replace('__RUNS_TEMP_ROOT__', $script:runsTempRoot).Replace('__BRIDGE_SCRIPT__', $bridgeScript)
+        $output = & pwsh -NoProfile -Command $childScript
+
+        $result = ($output | Out-String | ConvertFrom-Json -AsHashtable)
+
+        $result.summary.run_count | Should -Be 1
+        $result.runs[0].run_id | Should -Be 'task:task-256'
+    }
+}
+
+Describe 'winsmux explain command' {
+    BeforeAll {
+        $script:winsmuxCorePath = Join-Path (Split-Path -Parent $PSScriptRoot) 'scripts\winsmux-core.ps1'
+        . $script:winsmuxCorePath 'version' *> $null
+    }
+
+    BeforeEach {
+        $script:explainTempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('winsmux-explain-tests-' + [guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $script:explainTempRoot -Force | Out-Null
+        $script:explainManifestDir = Join-Path $script:explainTempRoot '.winsmux'
+        New-Item -ItemType Directory -Path $script:explainManifestDir -Force | Out-Null
+        $script:explainManifestPath = Join-Path $script:explainManifestDir 'manifest.yaml'
+        $script:explainEventsPath = Join-Path $script:explainManifestDir 'events.jsonl'
+        $script:explainReviewStatePath = Join-Path $script:explainManifestDir 'review-state.json'
+
+        Push-Location $script:explainTempRoot
+    }
+
+    AfterEach {
+        Pop-Location
+        if ($script:explainTempRoot -and (Test-Path $script:explainTempRoot)) {
+            Remove-Item -Path $script:explainTempRoot -Recurse -Force
+        }
+
+        $global:Target = $null
+        $global:Rest = @()
+        Remove-Item function:\winsmux -ErrorAction SilentlyContinue
+    }
+
+    It 'returns a json explanation with related events and review state' {
+@"
+version: 1
+session:
+  name: winsmux-orchestra
+  project_dir: $script:explainTempRoot
+panes:
+  builder-1:
+    pane_id: %2
+    role: Builder
+    task_id: task-256
+    task: Implement run ledger
+    task_state: in_progress
+    task_owner: builder-1
+    review_state: PENDING
+    branch: worktree-builder-1
+    head_sha: abc1234def5678
+    changed_file_count: 1
+    changed_files: '["scripts/winsmux-core.ps1"]'
+    last_event: commander.review_requested
+    last_event_at: 2026-04-10T12:00:00+09:00
+"@ | Set-Content -Path $script:explainManifestPath -Encoding UTF8
+
+        @(
+            ([ordered]@{
+                timestamp = '2026-04-10T12:01:00+09:00'
+                session   = 'winsmux-orchestra'
+                event     = 'commander.review_requested'
+                message   = 'review requested'
+                label     = 'reviewer-1'
+                pane_id   = '%3'
+                role      = 'Reviewer'
+                branch    = 'worktree-builder-1'
+                head_sha  = 'abc1234def5678'
+                data      = [ordered]@{
+                    task_id = 'task-256'
+                }
+            } | ConvertTo-Json -Compress),
+            ([ordered]@{
+                timestamp = '2026-04-10T12:02:00+09:00'
+                session   = 'winsmux-orchestra'
+                event     = 'pane.approval_waiting'
+                message   = 'approval prompt detected'
+                label     = 'builder-1'
+                pane_id   = '%2'
+                role      = 'Builder'
+                status    = 'approval_waiting'
+            } | ConvertTo-Json -Compress),
+            ([ordered]@{
+                timestamp = '2026-04-10T12:03:00+09:00'
+                session   = 'winsmux-orchestra'
+                event     = 'pane.idle'
+                message   = 'idle pane'
+                label     = 'worker-1'
+                pane_id   = '%6'
+                role      = 'Worker'
+                status    = 'ready'
+            } | ConvertTo-Json -Compress)
+        ) | Set-Content -Path $script:explainEventsPath -Encoding UTF8
+
+@'
+{
+  "worktree-builder-1": {
+    "status": "PENDING",
+    "head_sha": "abc1234def5678",
+    "request": {
+      "branch": "worktree-builder-1",
+      "head_sha": "abc1234def5678",
+      "target_reviewer_label": "reviewer-1",
+      "target_reviewer_pane_id": "%3"
+    }
+  }
+}
+'@ | Set-Content -Path $script:explainReviewStatePath -Encoding UTF8
+
+        function global:winsmux {
+            $commandLine = ($args | ForEach-Object { [string]$_ }) -join ' '
+            switch -Regex ($commandLine) {
+                '^capture-pane .*%2' { return @('gpt-5.4   64% context left', '? send   Ctrl+J newline', '>') }
+                default { throw "unexpected winsmux call: $commandLine" }
+            }
+        }
+
+        $result = (Invoke-Explain -ExplainTarget 'task:task-256' -ExplainRest @('--json') | Out-String | ConvertFrom-Json -AsHashtable)
+
+        $result.run.run_id | Should -Be 'task:task-256'
+        $result.run.task | Should -Be 'Implement run ledger'
+        $result.explanation.current_state.review_state | Should -Be 'PENDING'
+        $result.explanation.reasons | Should -Contain 'task_state=in_progress'
+        $result.explanation.reasons | Should -Contain 'review_state=PENDING'
+        $result.review_state.status | Should -Be 'PENDING'
+        $result.recent_events.Count | Should -Be 2
+        @($result.recent_events | ForEach-Object { $_.event }) | Should -Contain 'commander.review_requested'
+        @($result.recent_events | ForEach-Object { $_.event }) | Should -Contain 'pane.approval_waiting'
+    }
+
+    It 'filters explain follow events from the current cursor forward' {
+@"
+version: 1
+session:
+  name: winsmux-orchestra
+  project_dir: $script:explainTempRoot
+panes:
+  builder-1:
+    pane_id: %2
+    role: Builder
+    task_id: task-256
+    task: Implement run ledger
+    task_state: in_progress
+    task_owner: builder-1
+    review_state: PENDING
+    branch: worktree-builder-1
+    head_sha: abc1234def5678
+    changed_file_count: 1
+    changed_files: '["scripts/winsmux-core.ps1"]'
+    last_event: commander.review_requested
+    last_event_at: 2026-04-10T12:00:00+09:00
+"@ | Set-Content -Path $script:explainManifestPath -Encoding UTF8
+
+        ([ordered]@{
+            timestamp = '2026-04-10T12:01:00+09:00'
+            session   = 'winsmux-orchestra'
+            event     = 'commander.review_requested'
+            message   = 'review requested'
+            label     = 'reviewer-1'
+            pane_id   = '%3'
+            role      = 'Reviewer'
+            branch    = 'worktree-builder-1'
+            head_sha  = 'abc1234def5678'
+            data      = [ordered]@{
+                task_id = 'task-256'
+            }
+        } | ConvertTo-Json -Compress) | Set-Content -Path $script:explainEventsPath -Encoding UTF8
+
+        function global:winsmux {
+            $commandLine = ($args | ForEach-Object { [string]$_ }) -join ' '
+            switch -Regex ($commandLine) {
+                '^capture-pane .*%2' { return @('gpt-5.4   64% context left', '? send   Ctrl+J newline', '>') }
+                default { throw "unexpected winsmux call: $commandLine" }
+            }
+        }
+
+        $payload = Get-ExplainPayload -ProjectDir $script:explainTempRoot -RunId 'task:task-256'
+        $cursor = @(Get-BridgeEventRecords -ProjectDir $script:explainTempRoot).Count
+
+        @(
+            ([ordered]@{
+                timestamp = '2026-04-10T12:02:00+09:00'
+                session   = 'winsmux-orchestra'
+                event     = 'pane.idle'
+                message   = 'idle pane'
+                label     = 'worker-1'
+                pane_id   = '%6'
+                role      = 'Worker'
+                status    = 'ready'
+            } | ConvertTo-Json -Compress),
+            ([ordered]@{
+                timestamp = '2026-04-10T12:03:00+09:00'
+                session   = 'winsmux-orchestra'
+                event     = 'commander.commit_ready'
+                message   = 'commit ready'
+                label     = ''
+                pane_id   = ''
+                role      = 'Commander'
+                branch    = 'worktree-builder-1'
+                head_sha  = 'abc1234def5678'
+                status    = 'commit_ready'
+                data      = [ordered]@{
+                    task_id = 'task-256'
+                }
+            } | ConvertTo-Json -Compress)
+        ) | Add-Content -Path $script:explainEventsPath -Encoding UTF8
+
+        $delta = Get-BridgeEventDelta -ProjectDir $script:explainTempRoot -Cursor $cursor
+        $matching = @(
+            $delta.events |
+                Where-Object { Test-RunMatchesEventRecord -Run $payload.run -EventRecord $_ } |
+                ForEach-Object { ConvertTo-RunEventRecord -EventRecord $_ }
+        )
+
+        $delta.cursor | Should -Be 3
+        $matching.Count | Should -Be 1
+        $matching[0].event | Should -Be 'commander.commit_ready'
     }
 }
 

--- a/winsmux-core/scripts/role-gate.ps1
+++ b/winsmux-core/scripts/role-gate.ps1
@@ -469,6 +469,14 @@ function Assert-Role {
             if ($permissions.Status) { return $true }
             return Deny-RoleCommand -Role $role -Command $normalizedCommand
         }
+        'runs' {
+            if ($permissions.Status) { return $true }
+            return Deny-RoleCommand -Role $role -Command $normalizedCommand
+        }
+        'explain' {
+            if ($permissions.Status) { return $true }
+            return Deny-RoleCommand -Role $role -Command $normalizedCommand
+        }
         'name' {
             if ($permissions.Name) { return $true }
             return Deny-RoleCommand -Role $role -Command $normalizedCommand


### PR DESCRIPTION
## Summary
- add `winsmux runs` as the first run-ledger surface for TASK-256
- add `winsmux explain <run_id>` with JSON output and follow-mode event filtering
- allow `runs` and `explain` through the read-only status role-gate path

## Details
- synthesize `run_id` from existing manifest/event state without waiting for TASK-253
- derive run-oriented payloads from the current board/inbox sources of truth
- include related review-state and recent event context in `explain`
- update handoff after TASK-245 merge and TASK-256 repo-side implementation start

## Validation
- `Invoke-Pester tests/psmux-bridge.Tests.ps1`
  - `93/93 PASS`
- PowerShell parser check
  - `scripts/winsmux-core.ps1`
  - `winsmux-core/scripts/role-gate.ps1`
  - `tests/psmux-bridge.Tests.ps1`

## Notes
- private planning has been synced separately: `TASK-245` is `done` and `v0.19.7` is now `3/7`
- this keeps `run_id` synthetic for now; TASK-253 remains the future durable delegation-contract work