### PR TITLE
feat(orchestra): add notification profiles

### DIFF
--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -1,6 +1,6 @@
 # Handoff
 
-> Updated: 2026-04-10T13:10:00+09:00
+> Updated: 2026-04-10T13:45:00+09:00
 > Source of truth: this file
 
 ## Current state
@@ -9,7 +9,7 @@
 - `v0.19.6 hardening` is implemented, merged, released, and tracked as `100% (6/6)` in the external planning backlog/roadmap.
 - PR [#370](https://github.com/Sora-bluesky/winsmux/pull/370) and PR [#371](https://github.com/Sora-bluesky/winsmux/pull/371) are merged into `main`.
 - Planning source of truth is externalized outside the public repository and syncs automatically into the private planning root.
-- `v0.19.7 visible orchestration` is now `3/7` complete. `TASK-243`, `TASK-244`, and `TASK-245` are done in external planning.
+- `v0.19.7 visible orchestration` is now `4/7` complete in repo progress. `TASK-243`, `TASK-244`, `TASK-245`, and `TASK-256` are implemented/merged; external planning still needs a final `TASK-256` done sync after branch landing.
 - `v0.24.0: Rust runtime convergence` exists in external planning as the pre-`v1.0.0` Rust unification milestone.
 
 ## This session
@@ -17,7 +17,8 @@
 - Merged the repo-side `TASK-244` session board surface via PR [#371](https://github.com/Sora-bluesky/winsmux/pull/371).
 - Released `v0.19.6` from tag `eac8615` and updated the public GitHub Release body to `/release-notes` format.
 - Merged `TASK-245` via PR [#372](https://github.com/Sora-bluesky/winsmux/pull/372), adding `winsmux inbox` as the first actionable approval/review/blocker surface.
-- Implemented the repo-side `TASK-256` primitives: `winsmux runs [--json]` and `winsmux explain <run_id> [--json] [--follow]`.
+- Merged the repo-side `TASK-256` primitives via PR [#374](https://github.com/Sora-bluesky/winsmux/pull/374): `winsmux runs [--json]` and `winsmux explain <run_id> [--json] [--follow]`.
+- Started `TASK-257` notification boundary tightening so Telegram defaults to external-facing events only, with optional verbose/internal override profiles.
 - Updated external planning so `v0.19.8` remains visible, `v0.20.1` contains `TASK-272/273/274`, and `v0.24.0` keeps the Rust runtime convergence plan.
 
 ## Validation
@@ -25,18 +26,19 @@
 - Release workflow passed: `Release Core Binary` for `v0.19.6`
 - `TASK-244` PR CI passed before merge
 - `TASK-245` PR CI passed before merge
-- Current `TASK-256` focused regression passed: `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `93/93 PASS`
-- Current uncommitted `TASK-256` touches:
-  - `scripts/winsmux-core.ps1`
-  - `winsmux-core/scripts/role-gate.ps1`
+- `TASK-256` focused regression passed before merge: `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `93/93 PASS`
+- Current `TASK-257` focused regression passed: `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `98/98 PASS`
+- Current uncommitted `TASK-257` touches:
+  - `winsmux-core/scripts/commander-poll.ps1`
   - `tests/psmux-bridge.Tests.ps1`
 
 ## Next actions
 
-1. Review and land the repo-side `TASK-256` runs/explain surface.
-2. Continue `v0.19.7` with `TASK-257` notification boundary tightening after `TASK-256`.
-3. Keep future backlog aligned with the `Operator / slot / provider / verification / security monitor` model.
-4. Preserve the private planning sync flow: user/agent visible, auto-synced, but not committed to the public repo.
+1. Review and land the repo-side `TASK-257` notification profile boundary.
+2. Sync external planning so `TASK-256` becomes `done` and `v0.19.7` progress is refreshed.
+3. Continue `v0.19.7` with stream-facing summary UX (`watch --stream / inbox --stream / explain --follow`) after `TASK-257`.
+4. Keep future backlog aligned with the `Operator / slot / provider / verification / security monitor` model.
+5. Preserve the private planning sync flow: user/agent visible, auto-synced, but not committed to the public repo.
 
 ## Notes
 

--- a/tests/psmux-bridge.Tests.ps1
+++ b/tests/psmux-bridge.Tests.ps1
@@ -3575,6 +3575,83 @@ panes:
         Should -Not -Invoke Invoke-RestMethod
     }
 
+    It 'does not forward auto-approved alerts to Telegram by default' {
+        Mock Test-Path { $true }
+        Mock Get-Content { 'TELEGRAM_BOT_TOKEN=test-token' }
+        Mock Invoke-RestMethod { }
+
+        Send-CommanderTelegramNotification -ProjectDir $script:commanderPollTempRoot -SessionName 'winsmux-orchestra' `
+            -Event 'commander.auto_approved' -Message 'approved' -PaneId '%2' -Label 'builder-1' -Role 'Builder'
+
+        Should -Not -Invoke Invoke-RestMethod
+    }
+
+    It 'sends external review-requested alerts to Telegram by default' {
+        Mock Test-Path { $true }
+        Mock Get-Content { 'TELEGRAM_BOT_TOKEN=test-token' }
+        Mock Invoke-RestMethod { }
+
+        Send-CommanderTelegramNotification -ProjectDir $script:commanderPollTempRoot -SessionName 'winsmux-orchestra' `
+            -Event 'commander.review_requested' -Message 'review requested' -PaneId '%4' -Label 'worker-1' -Role 'Worker'
+
+        Should -Invoke Invoke-RestMethod -Times 1 -Exactly
+    }
+
+    It 'sends commit-ready alerts to Telegram by default' {
+        Mock Test-Path { $true }
+        Mock Get-Content { 'TELEGRAM_BOT_TOKEN=test-token' }
+        Mock Invoke-RestMethod { }
+
+        Send-CommanderTelegramNotification -ProjectDir $script:commanderPollTempRoot -SessionName 'winsmux-orchestra' `
+            -Event 'commander.commit_ready' -Message 'ready to commit' -HeadSha 'abc1234def5678'
+
+        Should -Invoke Invoke-RestMethod -Times 1 -Exactly
+    }
+
+    It 'allows all commander Telegram alerts when verbose profile is enabled' {
+        $previousProfile = $env:WINSMUX_TELEGRAM_PROFILE
+        $env:WINSMUX_TELEGRAM_PROFILE = 'verbose'
+
+        try {
+            Mock Test-Path { $true }
+            Mock Get-Content { 'TELEGRAM_BOT_TOKEN=test-token' }
+            Mock Invoke-RestMethod { }
+
+            Send-CommanderTelegramNotification -ProjectDir $script:commanderPollTempRoot -SessionName 'winsmux-orchestra' `
+                -Event 'commander.dispatch_needed' -Message 'idle' -PaneId '%2' -Label 'builder-1' -Role 'Builder'
+
+            Should -Invoke Invoke-RestMethod -Times 1 -Exactly
+        } finally {
+            if ($null -eq $previousProfile) {
+                Remove-Item Env:WINSMUX_TELEGRAM_PROFILE -ErrorAction SilentlyContinue
+            } else {
+                $env:WINSMUX_TELEGRAM_PROFILE = $previousProfile
+            }
+        }
+    }
+
+    It 'suppresses all Telegram alerts when profile is none' {
+        $previousProfile = $env:WINSMUX_TELEGRAM_PROFILE
+        $env:WINSMUX_TELEGRAM_PROFILE = 'none'
+
+        try {
+            Mock Test-Path { $true }
+            Mock Get-Content { 'TELEGRAM_BOT_TOKEN=test-token' }
+            Mock Invoke-RestMethod { }
+
+            Send-CommanderTelegramNotification -ProjectDir $script:commanderPollTempRoot -SessionName 'winsmux-orchestra' `
+                -Event 'commander.review_failed' -Message 'review failed' -HeadSha 'abc1234def5678'
+
+            Should -Not -Invoke Invoke-RestMethod
+        } finally {
+            if ($null -eq $previousProfile) {
+                Remove-Item Env:WINSMUX_TELEGRAM_PROFILE -ErrorAction SilentlyContinue
+            } else {
+                $env:WINSMUX_TELEGRAM_PROFILE = $previousProfile
+            }
+        }
+    }
+
     It 'allows internal commander Telegram alerts only when explicitly overridden' {
         $previousOverride = $env:WINSMUX_TELEGRAM_INCLUDE_INTERNAL_EVENTS
         $env:WINSMUX_TELEGRAM_INCLUDE_INTERNAL_EVENTS = 'true'

--- a/winsmux-core/scripts/commander-poll.ps1
+++ b/winsmux-core/scripts/commander-poll.ps1
@@ -501,23 +501,59 @@ function Get-CommanderPollEventSignature {
         ([string](Get-CommanderPollValue -InputObject $EventRecord -Name 'message' -Default ''))
 }
 
-function Test-CommanderTelegramNotificationEnabled {
-    param([Parameter(Mandatory = $true)][string]$Event)
-
-    $internalOnlyEvents = @(
-        'commander.dispatch_needed'
-    )
-
-    if ($Event -notin $internalOnlyEvents) {
-        return $true
+function Get-CommanderTelegramNotificationProfile {
+    $profile = [string]$env:WINSMUX_TELEGRAM_PROFILE
+    if (-not [string]::IsNullOrWhiteSpace($profile)) {
+        switch ($profile.Trim().ToLowerInvariant()) {
+            { $_ -in @('external', 'default', 'public') } { return 'external' }
+            { $_ -in @('verbose', 'all', 'internal') } { return 'verbose' }
+            { $_ -in @('none', 'off', 'disabled') } { return 'none' }
+        }
     }
 
     $override = [string]$env:WINSMUX_TELEGRAM_INCLUDE_INTERNAL_EVENTS
-    if ([string]::IsNullOrWhiteSpace($override)) {
-        return $false
+    if (-not [string]::IsNullOrWhiteSpace($override) -and $override.Trim().ToLowerInvariant() -in @('1', 'true', 'yes', 'on')) {
+        return 'verbose'
     }
 
-    return $override.Trim().ToLowerInvariant() -in @('1', 'true', 'yes', 'on')
+    return 'external'
+}
+
+function Test-CommanderTelegramNotificationEnabled {
+    param([Parameter(Mandatory = $true)][string]$Event)
+
+    $externalFacingEvents = @(
+        'commander.review_requested',
+        'commander.review_passed',
+        'commander.review_failed',
+        'commander.blocked',
+        'commander.commit_ready',
+        'commander.commit_done'
+    )
+
+    $internalOnlyEvents = @(
+        'commander.dispatch_needed',
+        'commander.auto_approved',
+        'commander.started',
+        'pane.completed',
+        'pane.exec_completed'
+    )
+
+    switch (Get-CommanderTelegramNotificationProfile) {
+        'none' { return $false }
+        'verbose' { return $true }
+        default {
+            if ($Event -in $externalFacingEvents) {
+                return $true
+            }
+
+            if ($Event -in $internalOnlyEvents) {
+                return $false
+            }
+
+            return $false
+        }
+    }
 }
 
 function Send-CommanderTelegramNotification {


### PR DESCRIPTION
## Summary
- add explicit Telegram notification profiles for external vs internal commander events
- default notifications to external-facing state changes only
- update handoff after TASK-256 merge and TASK-257 implementation start

## Details
- add `WINSMUX_TELEGRAM_PROFILE` with `external` (default), `verbose`, and `none`
- keep the legacy `WINSMUX_TELEGRAM_INCLUDE_INTERNAL_EVENTS` override as a compatibility path to verbose mode
- allowlist external-facing notifications: `review_requested`, `review_passed`, `review_failed`, `blocked`, `commit_ready`, `commit_done`
- suppress internal/noisy notifications by default: `dispatch_needed`, `auto_approved`, `started`, and raw pane completion events

## Validation
- `Invoke-Pester tests/psmux-bridge.Tests.ps1`
  - `98/98 PASS`
- focused PowerShell parser check
  - `winsmux-core/scripts/commander-poll.ps1`
  - `tests/psmux-bridge.Tests.ps1`

## Notes
- private planning has been synced separately: `TASK-256` is now `done` and `v0.19.7` is `4/7`
- TASK-257 remains the notification-boundary tightening step before the stream-facing summary surfaces are expanded further