### PR TITLE
feat(orchestra): add evidence digest surface

### DIFF
--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -1,6 +1,6 @@
 # Handoff
 
-> Updated: 2026-04-10T13:45:00+09:00
+> Updated: 2026-04-10T12:16:50+09:00
 > Source of truth: this file
 
 ## Current state
@@ -9,7 +9,7 @@
 - `v0.19.6 hardening` is implemented, merged, released, and tracked as `100% (6/6)` in the external planning backlog/roadmap.
 - PR [#370](https://github.com/Sora-bluesky/winsmux/pull/370) and PR [#371](https://github.com/Sora-bluesky/winsmux/pull/371) are merged into `main`.
 - Planning source of truth is externalized outside the public repository and syncs automatically into the private planning root.
-- `v0.19.7 visible orchestration` is now `4/7` complete in repo progress. `TASK-243`, `TASK-244`, `TASK-245`, and `TASK-256` are implemented/merged; external planning still needs a final `TASK-256` done sync after branch landing.
+- `v0.19.7 visible orchestration` has `TASK-243`, `TASK-244`, `TASK-245`, `TASK-256`, and `TASK-257` merged into `main`.
 - `v0.24.0: Rust runtime convergence` exists in external planning as the pre-`v1.0.0` Rust unification milestone.
 
 ## This session
@@ -18,7 +18,8 @@
 - Released `v0.19.6` from tag `eac8615` and updated the public GitHub Release body to `/release-notes` format.
 - Merged `TASK-245` via PR [#372](https://github.com/Sora-bluesky/winsmux/pull/372), adding `winsmux inbox` as the first actionable approval/review/blocker surface.
 - Merged the repo-side `TASK-256` primitives via PR [#374](https://github.com/Sora-bluesky/winsmux/pull/374): `winsmux runs [--json]` and `winsmux explain <run_id> [--json] [--follow]`.
-- Started `TASK-257` notification boundary tightening so Telegram defaults to external-facing events only, with optional verbose/internal override profiles.
+- Merged `TASK-257` via PR [#375](https://github.com/Sora-bluesky/winsmux/pull/375), tightening notification profiles so Telegram defaults to external-facing events only.
+- Implemented repo-side `TASK-246` on branch `codex/task246-evidence-digest-20260410`, adding `winsmux digest [--json]` and evidence digest fields for `explain`.
 - Updated external planning so `v0.19.8` remains visible, `v0.20.1` contains `TASK-272/273/274`, and `v0.24.0` keeps the Rust runtime convergence plan.
 
 ## Validation
@@ -27,16 +28,18 @@
 - `TASK-244` PR CI passed before merge
 - `TASK-245` PR CI passed before merge
 - `TASK-256` focused regression passed before merge: `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `93/93 PASS`
-- Current `TASK-257` focused regression passed: `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `98/98 PASS`
-- Current uncommitted `TASK-257` touches:
-  - `winsmux-core/scripts/commander-poll.ps1`
+- `TASK-257` focused regression passed before merge: `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `98/98 PASS`
+- Current `TASK-246` focused regression: `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `101/101 PASS`
+- Current `TASK-246` touches:
+  - `scripts/winsmux-core.ps1`
+  - `winsmux-core/scripts/role-gate.ps1`
   - `tests/psmux-bridge.Tests.ps1`
 
 ## Next actions
 
-1. Review and land the repo-side `TASK-257` notification profile boundary.
-2. Sync external planning so `TASK-256` becomes `done` and `v0.19.7` progress is refreshed.
-3. Continue `v0.19.7` with stream-facing summary UX (`watch --stream / inbox --stream / explain --follow`) after `TASK-257`.
+1. Review and land the repo-side `TASK-246` evidence digest surface from `codex/task246-evidence-digest-20260410`.
+2. Sync external planning so `TASK-257` is `done` and `TASK-246` progress is reflected after branch landing.
+3. Continue `v0.19.7` with stream-facing summary UX (`watch --stream / inbox --stream / explain --follow`) after `TASK-246`.
 4. Keep future backlog aligned with the `Operator / slot / provider / verification / security monitor` model.
 5. Preserve the private planning sync flow: user/agent visible, auto-synced, but not committed to the public repo.
 

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -2712,6 +2712,100 @@ function Get-RunsPayload {
     }
 }
 
+function Get-ShortHeadSha {
+    param([AllowNull()][string]$HeadSha)
+
+    if ([string]::IsNullOrWhiteSpace($HeadSha)) {
+        return ''
+    }
+
+    if ($HeadSha.Length -le 7) {
+        return $HeadSha
+    }
+
+    return $HeadSha.Substring(0, 7)
+}
+
+function Get-RunNextAction {
+    param([Parameter(Mandatory = $true)]$Run)
+
+    $priorityOrder = @(
+        'approval_waiting',
+        'review_failed',
+        'task_blocked',
+        'blocked',
+        'commit_ready',
+        'task_completed',
+        'review_pending',
+        'dispatch_needed'
+    )
+    foreach ($priorityKind in $priorityOrder) {
+        $match = $Run.action_items | Where-Object { [string]$_.kind -eq $priorityKind } | Select-Object -First 1
+        if ($null -ne $match) {
+            return [string]$match.kind
+        }
+    }
+
+    $firstActionItem = $Run.action_items | Select-Object -First 1
+    if ($null -ne $firstActionItem -and -not [string]::IsNullOrWhiteSpace([string]$firstActionItem.kind)) {
+        return [string]$firstActionItem.kind
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace([string]$Run.review_state)) {
+        return [string]$Run.review_state
+    }
+
+    return [string]$Run.task_state
+}
+
+function ConvertTo-EvidenceDigestItem {
+    param([Parameter(Mandatory = $true)]$Run)
+
+    return [ordered]@{
+        run_id             = [string]$Run.run_id
+        task_id            = [string]$Run.task_id
+        task               = [string]$Run.task
+        label              = [string]$Run.primary_label
+        pane_id            = [string]$Run.primary_pane_id
+        role               = [string]$Run.primary_role
+        task_state         = [string]$Run.task_state
+        review_state       = [string]$Run.review_state
+        next_action        = Get-RunNextAction -Run $Run
+        branch             = [string]$Run.branch
+        head_sha           = [string]$Run.head_sha
+        head_short         = Get-ShortHeadSha -HeadSha ([string]$Run.head_sha)
+        changed_file_count = [int]$Run.changed_file_count
+        changed_files      = @($Run.changed_files)
+        action_item_count  = @($Run.action_items).Count
+        last_event         = [string]$Run.last_event
+        last_event_at      = [string]$Run.last_event_at
+    }
+}
+
+function Get-DigestPayload {
+    param([Parameter(Mandatory = $true)][string]$ProjectDir)
+
+    $runsPayload = Get-RunsPayload -ProjectDir $ProjectDir
+    $items = @(
+        foreach ($run in @($runsPayload.runs)) {
+            ConvertTo-EvidenceDigestItem -Run $run
+        }
+    )
+
+    return [ordered]@{
+        generated_at = (Get-Date).ToString('o')
+        project_dir  = $ProjectDir
+        summary      = [ordered]@{
+            item_count         = @($items).Count
+            dirty_items        = @($items | Where-Object { [int]$_.changed_file_count -gt 0 }).Count
+            review_pending     = @($items | Where-Object { [string]$_.review_state -eq 'PENDING' }).Count
+            review_failed      = @($items | Where-Object { [string]$_.review_state -in @('FAIL', 'FAILED') }).Count
+            actionable_items   = @($items | Where-Object { -not [string]::IsNullOrWhiteSpace([string]$_.next_action) }).Count
+        }
+        items        = @($items | Sort-Object @{ Expression = { [string]$_.last_event_at }; Descending = $true }, @{ Expression = { [string]$_.run_id } })
+    }
+}
+
 function Get-ExplainPayload {
     param(
         [Parameter(Mandatory = $true)][string]$ProjectDir,
@@ -2758,6 +2852,7 @@ function Get-ExplainPayload {
         generated_at  = (Get-Date).ToString('o')
         project_dir   = $ProjectDir
         run           = $run
+        evidence_digest = ConvertTo-EvidenceDigestItem -Run $run
         explanation   = [ordered]@{
             summary       = if (-not [string]::IsNullOrWhiteSpace([string]$run.task)) { [string]$run.task } else { [string]$run.primary_label }
             reasons       = @($reasons)
@@ -2786,6 +2881,61 @@ function Write-ExplainFollowItem {
     }
 
     Write-Output ("[{0}] {1} {2}: {3}" -f [string]$Item.timestamp, [string]$Item.event, [string]$Item.label, [string]$Item.message)
+}
+
+function Invoke-Digest {
+    param(
+        [AllowNull()][string]$DigestTarget = $Target,
+        [AllowNull()][string[]]$DigestRest = $Rest
+    )
+
+    $jsonOutput = $false
+
+    if ($DigestTarget) {
+        if ($DigestTarget -eq '--json' -and (-not $DigestRest -or $DigestRest.Count -eq 0)) {
+            $jsonOutput = $true
+        } else {
+            Stop-WithError "usage: winsmux digest [--json]"
+        }
+    } elseif ($DigestRest -and $DigestRest.Count -gt 0) {
+        Stop-WithError "usage: winsmux digest [--json]"
+    }
+
+    $projectDir = (Get-Location).Path
+    $payload = Get-DigestPayload -ProjectDir $projectDir
+
+    if ($jsonOutput) {
+        $payload | ConvertTo-Json -Compress -Depth 10 | Write-Output
+        return
+    }
+
+    $items = @($payload.items)
+    if ($items.Count -eq 0) {
+        Write-Output "(no digest items)"
+        return
+    }
+
+    foreach ($item in $items) {
+        Write-Output ("Run: {0}" -f [string]$item.run_id)
+        Write-Output ("Primary: {0} ({1})" -f [string]$item.label, [string]$item.pane_id)
+        if (-not [string]::IsNullOrWhiteSpace([string]$item.task)) {
+            Write-Output ("Task: {0}" -f [string]$item.task)
+        }
+        Write-Output ("State: {0} / {1}" -f [string]$item.task_state, [string]$item.review_state)
+        Write-Output ("Next: {0}" -f [string]$item.next_action)
+        if (-not [string]::IsNullOrWhiteSpace([string]$item.branch)) {
+            Write-Output ("Git: {0} @ {1}" -f [string]$item.branch, [string]$item.head_short)
+        }
+        if ([int]$item.changed_file_count -gt 0) {
+            Write-Output ("Changed files ({0}):" -f [int]$item.changed_file_count)
+            foreach ($changedFile in @($item.changed_files)) {
+                Write-Output ("- {0}" -f [string]$changedFile)
+            }
+        } else {
+            Write-Output "Changed files: (none)"
+        }
+        Write-Output ""
+    }
 }
 
 function Get-InboxPayload {
@@ -3049,7 +3199,7 @@ function Invoke-Runs {
             @{ Name = 'Review'; Expression = { $_.review_state } }, `
             @{ Name = 'State'; Expression = { $_.state } }, `
             @{ Name = 'Branch'; Expression = { $_.branch } }, `
-            @{ Name = 'Head'; Expression = { if ([string]::IsNullOrWhiteSpace($_.head_sha)) { '' } elseif ($_.head_sha.Length -le 7) { $_.head_sha } else { $_.head_sha.Substring(0, 7) } } }, `
+            @{ Name = 'Head'; Expression = { Get-ShortHeadSha -HeadSha ([string]$_.head_sha) } }, `
             @{ Name = 'ActionItems'; Expression = { @($_.action_items).Count } } |
         Format-Table -AutoSize |
         Out-String -Width 4096
@@ -3141,11 +3291,18 @@ function Invoke-Explain {
     Write-Output ("Task: {0}" -f [string]$payload.explanation.summary)
     Write-Output ("Primary: {0} ({1})" -f [string]$payload.run.primary_label, [string]$payload.run.primary_pane_id)
     Write-Output ("State: {0} / {1} / {2}" -f [string]$payload.run.state, [string]$payload.run.task_state, [string]$payload.run.review_state)
+    Write-Output ("Next: {0}" -f [string]$payload.evidence_digest.next_action)
     if (-not [string]::IsNullOrWhiteSpace([string]$payload.run.branch)) {
         Write-Output ("Branch: {0}" -f [string]$payload.run.branch)
     }
     if (-not [string]::IsNullOrWhiteSpace([string]$payload.run.head_sha)) {
         Write-Output ("Head: {0}" -f [string]$payload.run.head_sha)
+    }
+    if ([int]$payload.evidence_digest.changed_file_count -gt 0) {
+        Write-Output "Changed files:"
+        foreach ($changedFile in @($payload.evidence_digest.changed_files)) {
+            Write-Output ("- {0}" -f [string]$changedFile)
+        }
     }
     if (@($payload.explanation.reasons).Count -gt 0) {
         Write-Output "Reasons:"
@@ -3743,9 +3900,10 @@ Commands:
   health-check              Report READY/BUSY/HUNG/DEAD for labeled panes
   status                    Report manifest pane states via capture-pane
   board [--json]            Report pane/task/review/git session board
-  inbox [--json] [--stream] Report actionable approvals/review/blockers
-  runs [--json]             Report run-oriented session view
-  explain <run_id> [--json] [--follow]  Explain one run and optionally follow new events
+inbox [--json] [--stream] Report actionable approvals/review/blockers
+runs [--json]             Report run-oriented session view
+digest [--json]           Report high-signal evidence digest per run
+explain <run_id> [--json] [--follow]  Explain one run and optionally follow new events
   poll-events [cursor]      Return new monitor events from .winsmux/events.jsonl
   signal <channel>          Send signal to unblock a waiting process
   watch <label> [silence_s] [timeout_s]  Block until pane output is silent
@@ -4079,9 +4237,10 @@ switch ($Command) {
     'health-check'    { Invoke-HealthCheck }
     'status'          { Invoke-Status }
     'board'           { Invoke-Board }
-    'inbox'           { Invoke-Inbox }
-    'runs'            { Invoke-Runs }
-    'explain'         { Invoke-Explain }
+        'inbox'           { Invoke-Inbox }
+        'runs'            { Invoke-Runs }
+        'digest'          { Invoke-Digest }
+        'explain'         { Invoke-Explain }
     'poll-events'     { Invoke-PollEvents }
     'signal'          { Invoke-Signal }
     'mailbox-create'  { Invoke-MailboxCreate }

--- a/tests/psmux-bridge.Tests.ps1
+++ b/tests/psmux-bridge.Tests.ps1
@@ -72,6 +72,7 @@ Describe 'Assert-Role' {
         (Assert-Role -Command 'board') | Should -Be $true
         (Assert-Role -Command 'inbox') | Should -Be $true
         (Assert-Role -Command 'runs') | Should -Be $true
+        (Assert-Role -Command 'digest') | Should -Be $true
         (Assert-Role -Command 'explain') | Should -Be $true
         (Assert-Role -Command 'context-reset' -TargetPane 'reviewer') | Should -Be $true
         (Assert-Role -Command 'poll-events') | Should -Be $true
@@ -88,6 +89,7 @@ Describe 'Assert-Role' {
         (Assert-Role -Command 'board') | Should -Be $true
         (Assert-Role -Command 'inbox') | Should -Be $true
         (Assert-Role -Command 'runs') | Should -Be $true
+        (Assert-Role -Command 'digest') | Should -Be $true
         (Assert-Role -Command 'explain') | Should -Be $true
         (Assert-Role -Command 'type' -TargetPane 'self') | Should -Be $true
         (Assert-Role -Command 'context-reset' -TargetPane 'commander') | Should -Be $false
@@ -101,6 +103,7 @@ Describe 'Assert-Role' {
 
         (Assert-Role -Command 'message' -TargetPane 'commander') | Should -Be $true
         (Assert-Role -Command 'read' -TargetPane 'self') | Should -Be $true
+        (Assert-Role -Command 'digest') | Should -Be $true
         (Assert-Role -Command 'poll-events') | Should -Be $false
         (Assert-Role -Command 'signal') | Should -Be $false
         (Assert-Role -Command 'wait') | Should -Be $false
@@ -114,6 +117,7 @@ Describe 'Assert-Role' {
         (Assert-Role -Command 'review-request') | Should -Be $true
         (Assert-Role -Command 'review-approve') | Should -Be $true
         (Assert-Role -Command 'status') | Should -Be $true
+        (Assert-Role -Command 'digest') | Should -Be $true
         (Assert-Role -Command 'list') | Should -Be $true
         (Assert-Role -Command 'vault') | Should -Be $false
         (Assert-Role -Command 'focus') | Should -Be $false
@@ -127,6 +131,7 @@ Describe 'Assert-Role' {
         (Assert-Role -Command 'review-request') | Should -Be $true
         (Assert-Role -Command 'review-approve') | Should -Be $true
         (Assert-Role -Command 'review-fail') | Should -Be $true
+        (Assert-Role -Command 'digest') | Should -Be $true
         (Assert-Role -Command 'vault') | Should -Be $false
         (Assert-Role -Command 'focus') | Should -Be $false
     }
@@ -3119,6 +3124,189 @@ Set-Location '__RUNS_TEMP_ROOT__'
     }
 }
 
+Describe 'winsmux digest command' {
+    BeforeAll {
+        $script:winsmuxCorePath = Join-Path (Split-Path -Parent $PSScriptRoot) 'scripts\winsmux-core.ps1'
+        . $script:winsmuxCorePath 'version' *> $null
+    }
+
+    BeforeEach {
+        $script:digestTempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('winsmux-digest-tests-' + [guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $script:digestTempRoot -Force | Out-Null
+        $script:digestManifestDir = Join-Path $script:digestTempRoot '.winsmux'
+        New-Item -ItemType Directory -Path $script:digestManifestDir -Force | Out-Null
+        $script:digestManifestPath = Join-Path $script:digestManifestDir 'manifest.yaml'
+        $script:digestEventsPath = Join-Path $script:digestManifestDir 'events.jsonl'
+
+        Push-Location $script:digestTempRoot
+    }
+
+    AfterEach {
+        Pop-Location
+        if ($script:digestTempRoot -and (Test-Path $script:digestTempRoot)) {
+            Remove-Item -Path $script:digestTempRoot -Recurse -Force
+        }
+
+        $global:Target = $null
+        $global:Rest = @()
+        Remove-Item function:\winsmux -ErrorAction SilentlyContinue
+    }
+
+    It 'renders a high-signal evidence digest per run' {
+@"
+version: 1
+session:
+  name: winsmux-orchestra
+  project_dir: $script:digestTempRoot
+panes:
+  builder-1:
+    pane_id: %2
+    role: Builder
+    task_id: task-246
+    task: Build evidence digest
+    task_state: in_progress
+    task_owner: builder-1
+    review_state: PENDING
+    branch: worktree-builder-1
+    head_sha: abc1234def5678
+    changed_file_count: 2
+    changed_files: '["scripts/winsmux-core.ps1","tests/psmux-bridge.Tests.ps1"]'
+    last_event: commander.review_requested
+    last_event_at: 2026-04-10T14:00:00+09:00
+"@ | Set-Content -Path $script:digestManifestPath -Encoding UTF8
+
+        @(
+            ([ordered]@{
+                timestamp = '2026-04-10T14:01:00+09:00'
+                session   = 'winsmux-orchestra'
+                event     = 'pane.approval_waiting'
+                message   = 'approval prompt detected'
+                label     = 'builder-1'
+                pane_id   = '%2'
+                role      = 'Builder'
+                status    = 'approval_waiting'
+            } | ConvertTo-Json -Compress)
+        ) | Set-Content -Path $script:digestEventsPath -Encoding UTF8
+
+        function global:winsmux {
+            $commandLine = ($args | ForEach-Object { [string]$_ }) -join ' '
+            switch -Regex ($commandLine) {
+                '^capture-pane .*%2' { return @('gpt-5.4   64% context left', '? send   Ctrl+J newline', '>') }
+                default { throw "unexpected winsmux call: $commandLine" }
+            }
+        }
+
+        $output = Invoke-Digest | Out-String
+
+        $output | Should -Match 'Run: task:task-246'
+        $output | Should -Match 'Next: approval_waiting'
+        $output | Should -Match 'Git: worktree-builder-1 @ abc1234'
+        $output | Should -Match 'Changed files \(2\):'
+        $output | Should -Match 'scripts/winsmux-core.ps1'
+    }
+
+    It 'returns digest items as json' {
+@"
+version: 1
+session:
+  name: winsmux-orchestra
+  project_dir: $script:digestTempRoot
+panes:
+  builder-1:
+    pane_id: %2
+    role: Builder
+    task_id: task-246
+    task: Build evidence digest
+    task_state: blocked
+    task_owner: builder-1
+    review_state: FAIL
+    branch: worktree-builder-1
+    head_sha: abc1234def5678
+    changed_file_count: 1
+    changed_files: '["scripts/winsmux-core.ps1"]'
+    last_event: commander.review_failed
+    last_event_at: 2026-04-10T14:00:00+09:00
+"@ | Set-Content -Path $script:digestManifestPath -Encoding UTF8
+
+        ([ordered]@{
+            timestamp = '2026-04-10T14:01:00+09:00'
+            session   = 'winsmux-orchestra'
+            event     = 'commander.review_failed'
+            message   = 'review failed'
+            label     = 'reviewer-1'
+            pane_id   = '%3'
+            role      = 'Reviewer'
+            branch    = 'worktree-builder-1'
+            head_sha  = 'abc1234def5678'
+            data      = [ordered]@{
+                task_id = 'task-246'
+            }
+        } | ConvertTo-Json -Compress) | Set-Content -Path $script:digestEventsPath -Encoding UTF8
+
+        function global:winsmux {
+            $commandLine = ($args | ForEach-Object { [string]$_ }) -join ' '
+            switch -Regex ($commandLine) {
+                '^capture-pane .*%2' { return @('gpt-5.4   64% context left', '? send   Ctrl+J newline', '>') }
+                default { throw "unexpected winsmux call: $commandLine" }
+            }
+        }
+
+        $result = (Invoke-Digest -DigestTarget '--json' | Out-String | ConvertFrom-Json -AsHashtable)
+
+        $result.summary.item_count | Should -Be 1
+        $result.summary.review_failed | Should -Be 1
+        $result.items[0].run_id | Should -Be 'task:task-246'
+        $result.items[0].next_action | Should -Be 'review_failed'
+        $result.items[0].head_short | Should -Be 'abc1234'
+        $result.items[0].changed_files | Should -Be @('scripts/winsmux-core.ps1')
+    }
+
+    It 'supports winsmux digest --json through the top-level CLI entrypoint' {
+@"
+version: 1
+session:
+  name: winsmux-orchestra
+  project_dir: $script:digestTempRoot
+panes:
+  builder-1:
+    pane_id: %2
+    role: Builder
+    task_id: task-246
+    task: Build evidence digest
+    task_state: in_progress
+    task_owner: builder-1
+    review_state: PENDING
+    branch: worktree-builder-1
+    head_sha: abc1234def5678
+    changed_file_count: 1
+    changed_files: '["scripts/winsmux-core.ps1"]'
+    last_event: commander.review_requested
+    last_event_at: 2026-04-10T14:00:00+09:00
+"@ | Set-Content -Path $script:digestManifestPath -Encoding UTF8
+
+        $bridgeScript = Join-Path (Split-Path -Parent $PSScriptRoot) 'scripts\winsmux-core.ps1'
+        $childScript = @'
+Set-Item -Path function:winsmux -Value {
+    param([Parameter(ValueFromRemainingArguments = $true)][object[]]$args)
+    $commandLine = ($args | ForEach-Object { [string]$_ }) -join ' '
+    switch -Regex ($commandLine) {
+        '^capture-pane .*%2' { @('gpt-5.4   64% context left', '? send   Ctrl+J newline', '>'); break }
+        default { throw "unexpected winsmux call: $commandLine" }
+    }
+}
+Set-Location '__DIGEST_TEMP_ROOT__'
+& '__BRIDGE_SCRIPT__' digest --json
+'@
+        $childScript = $childScript.Replace('__DIGEST_TEMP_ROOT__', $script:digestTempRoot).Replace('__BRIDGE_SCRIPT__', $bridgeScript)
+        $output = & pwsh -NoProfile -Command $childScript
+
+        $result = ($output | Out-String | ConvertFrom-Json -AsHashtable)
+
+        $result.summary.item_count | Should -Be 1
+        $result.items[0].run_id | Should -Be 'task:task-246'
+    }
+}
+
 Describe 'winsmux explain command' {
     BeforeAll {
         $script:winsmuxCorePath = Join-Path (Split-Path -Parent $PSScriptRoot) 'scripts\winsmux-core.ps1'
@@ -3235,6 +3423,9 @@ panes:
 
         $result.run.run_id | Should -Be 'task:task-256'
         $result.run.task | Should -Be 'Implement run ledger'
+        $result.evidence_digest.run_id | Should -Be 'task:task-256'
+        $result.evidence_digest.next_action | Should -Be 'approval_waiting'
+        $result.evidence_digest.changed_files | Should -Be @('scripts/winsmux-core.ps1')
         $result.explanation.current_state.review_state | Should -Be 'PENDING'
         $result.explanation.reasons | Should -Contain 'task_state=in_progress'
         $result.explanation.reasons | Should -Contain 'review_state=PENDING'

--- a/winsmux-core/scripts/role-gate.ps1
+++ b/winsmux-core/scripts/role-gate.ps1
@@ -473,6 +473,10 @@ function Assert-Role {
             if ($permissions.Status) { return $true }
             return Deny-RoleCommand -Role $role -Command $normalizedCommand
         }
+        'digest' {
+            if ($permissions.Status) { return $true }
+            return Deny-RoleCommand -Role $role -Command $normalizedCommand
+        }
         'explain' {
             if ($permissions.Status) { return $true }
             return Deny-RoleCommand -Role $role -Command $normalizedCommand


### PR DESCRIPTION
## Summary
- add a first-class `winsmux digest [--json]` surface for high-signal run evidence
- enrich `winsmux explain` with evidence digest fields and visible next action / changed files
- update handoff for the merged TASK-257 state and current TASK-246 branch

## Details
- add `Get-DigestPayload`, `ConvertTo-EvidenceDigestItem`, and next-action prioritization helpers
- allow `digest` through the role gate as a status-class command
- add focused Pester coverage for `winsmux digest` plain output, JSON output, and top-level CLI entrypoint
- extend explain JSON coverage so evidence digest fields remain stable

## Validation
- `Invoke-Pester tests/psmux-bridge.Tests.ps1`
  - `101/101 PASS`
- PowerShell parser check
  - `scripts/winsmux-core.ps1`
  - `winsmux-core/scripts/role-gate.ps1`
  - `tests/psmux-bridge.Tests.ps1`

## Notes
- `TASK-257` is already merged into `main`; this PR builds on that by adding the high-signal evidence surface for `v0.19.7`
- external planning sync remains private and should be refreshed after this branch lands