### PR TITLE
feat(orchestra): stream evidence digest updates

### DIFF
--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -1,6 +1,6 @@
 # Handoff
 
-> Updated: 2026-04-10T12:21:30+09:00
+> Updated: 2026-04-10T15:10:00+09:00
 > Source of truth: this file
 
 ## Current state
@@ -21,6 +21,7 @@
 - Merged `TASK-257` via PR [#375](https://github.com/Sora-bluesky/winsmux/pull/375), tightening notification profiles so Telegram defaults to external-facing events only.
 - Merged `TASK-246` via PR [#376](https://github.com/Sora-bluesky/winsmux/pull/376), adding `winsmux digest [--json]` and evidence digest fields for `explain`.
 - Updated external planning so `v0.19.8` remains visible, `v0.20.1` contains `TASK-272/273/274`, and `v0.24.0` keeps the Rust runtime convergence plan.
+- Added the next stream-first UX slice locally: `winsmux digest --stream` now tails event deltas and emits high-signal digest updates only for materially affected runs.
 
 ## Validation
 
@@ -31,11 +32,12 @@
 - `TASK-257` focused regression passed before merge: `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `98/98 PASS`
 - `TASK-246` focused regression passed before merge: `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `101/101 PASS`
 - PR [#376](https://github.com/Sora-bluesky/winsmux/pull/376) CI passed before merge
+- Current local stream UX regression passes: `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `103/103 PASS`
 
 ## Next actions
 
-1. Continue `v0.19.7` with stream-facing summary UX (`watch --stream / inbox --stream / explain --follow`) after `TASK-246`.
-2. Decide whether to close `v0.19.7` with `TASK-253` deferred or implement the delegation-contract slice next.
+1. Land the local `digest --stream` stream-first UX slice and then decide whether `watch --stream` is still necessary or should wrap digest/inbox instead of pane silence polling.
+2. Decide whether to close `v0.19.7` with `TASK-253` deferred or implement the minimal first-class `run_id` slice next.
 3. Keep future backlog aligned with the `Operator / slot / provider / verification / security monitor` model.
 4. Preserve the private planning sync flow: user/agent visible, auto-synced, but not committed to the public repo.
 5. Track GitHub Actions Node runtime warnings and update workflows before the Node 24 switch becomes mandatory.

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -2883,25 +2883,122 @@ function Write-ExplainFollowItem {
     Write-Output ("[{0}] {1} {2}: {3}" -f [string]$Item.timestamp, [string]$Item.event, [string]$Item.label, [string]$Item.message)
 }
 
+function Get-DigestDeltaItems {
+    param(
+        [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [Parameter(Mandatory = $true)][object[]]$EventRecords
+    )
+
+    $records = @($EventRecords)
+    if ($records.Count -eq 0) {
+        return @()
+    }
+
+    $runsPayload = Get-RunsPayload -ProjectDir $ProjectDir
+    $matchedRunIds = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+
+    foreach ($run in @($runsPayload.runs)) {
+        foreach ($eventRecord in $records) {
+            if (Test-RunMatchesEventRecord -Run $run -EventRecord $eventRecord) {
+                $matchedRunIds.Add([string]$run.run_id) | Out-Null
+                break
+            }
+        }
+    }
+
+    if ($matchedRunIds.Count -eq 0) {
+        return @()
+    }
+
+    return @(
+        foreach ($run in @($runsPayload.runs | Sort-Object @{ Expression = { [string]$_.last_event_at }; Descending = $true }, @{ Expression = { [string]$_.run_id } })) {
+            if ($matchedRunIds.Contains([string]$run.run_id)) {
+                $item = ConvertTo-EvidenceDigestItem -Run $run
+                if (
+                    [int]$item.changed_file_count -gt 0 -or
+                    (
+                        [int]$item.action_item_count -gt 0 -and
+                        [string]$item.next_action -notin @('', 'backlog', 'dispatch_needed')
+                    ) -or
+                    (-not [string]::IsNullOrWhiteSpace([string]$item.review_state))
+                ) {
+                    $item
+                }
+            }
+        }
+    )
+}
+
+function Write-DigestStreamItem {
+    param(
+        [Parameter(Mandatory = $true)]$Item,
+        [switch]$Json
+    )
+
+    if ($Json) {
+        $Item | ConvertTo-Json -Compress -Depth 10 | Write-Output
+        return
+    }
+
+    $updatedAt = [string]$Item.last_event_at
+    if ([string]::IsNullOrWhiteSpace($updatedAt)) {
+        $updatedAt = (Get-Date).ToString('o')
+    }
+
+    Write-Output ("[{0}] digest {1} {2} ({3}) next={4} files={5}" -f `
+        $updatedAt, `
+        [string]$Item.run_id, `
+        [string]$Item.label, `
+        [string]$Item.pane_id, `
+        [string]$Item.next_action, `
+        [int]$Item.changed_file_count)
+}
+
 function Invoke-Digest {
     param(
         [AllowNull()][string]$DigestTarget = $Target,
         [AllowNull()][string[]]$DigestRest = $Rest
     )
 
-    $jsonOutput = $false
+    $tokens = @()
+    if (-not [string]::IsNullOrWhiteSpace($DigestTarget)) {
+        $tokens += $DigestTarget
+    }
+    if ($DigestRest) {
+        $tokens += @($DigestRest)
+    }
 
-    if ($DigestTarget) {
-        if ($DigestTarget -eq '--json' -and (-not $DigestRest -or $DigestRest.Count -eq 0)) {
-            $jsonOutput = $true
-        } else {
-            Stop-WithError "usage: winsmux digest [--json]"
+    $jsonOutput = $false
+    $streamOutput = $false
+
+    foreach ($token in $tokens) {
+        switch ($token) {
+            '--json'   { $jsonOutput = $true }
+            '--stream' { $streamOutput = $true }
+            default    { Stop-WithError "usage: winsmux digest [--json] [--stream]" }
         }
-    } elseif ($DigestRest -and $DigestRest.Count -gt 0) {
-        Stop-WithError "usage: winsmux digest [--json]"
     }
 
     $projectDir = (Get-Location).Path
+    if ($streamOutput) {
+        $snapshot = Get-DigestPayload -ProjectDir $projectDir
+        foreach ($item in @($snapshot.items)) {
+            Write-DigestStreamItem -Item $item -Json:$jsonOutput
+        }
+
+        $cursor = @(Get-BridgeEventRecords -ProjectDir $projectDir).Count
+        while ($true) {
+            $delta = Get-BridgeEventDelta -ProjectDir $projectDir -Cursor $cursor
+            $cursor = [int]$delta.cursor
+            $items = Get-DigestDeltaItems -ProjectDir $projectDir -EventRecords @($delta.events)
+            foreach ($item in @($items)) {
+                Write-DigestStreamItem -Item $item -Json:$jsonOutput
+            }
+
+            Start-Sleep -Seconds 2
+        }
+    }
+
     $payload = Get-DigestPayload -ProjectDir $projectDir
 
     if ($jsonOutput) {
@@ -3902,7 +3999,7 @@ Commands:
   board [--json]            Report pane/task/review/git session board
 inbox [--json] [--stream] Report actionable approvals/review/blockers
 runs [--json]             Report run-oriented session view
-digest [--json]           Report high-signal evidence digest per run
+digest [--json] [--stream] Report high-signal evidence digest per run
 explain <run_id> [--json] [--follow]  Explain one run and optionally follow new events
   poll-events [cursor]      Return new monitor events from .winsmux/events.jsonl
   signal <channel>          Send signal to unblock a waiting process

--- a/tests/psmux-bridge.Tests.ps1
+++ b/tests/psmux-bridge.Tests.ps1
@@ -3261,6 +3261,132 @@ panes:
         $result.items[0].changed_files | Should -Be @('scripts/winsmux-core.ps1')
     }
 
+    It 'returns digest delta items only for runs affected after the current cursor' {
+@"
+version: 1
+session:
+  name: winsmux-orchestra
+  project_dir: $script:digestTempRoot
+panes:
+  builder-1:
+    pane_id: %2
+    role: Builder
+    task_id: task-246
+    task: Build evidence digest
+    task_state: in_progress
+    task_owner: builder-1
+    review_state: PENDING
+    branch: worktree-builder-1
+    head_sha: abc1234def5678
+    changed_file_count: 2
+    changed_files: '["scripts/winsmux-core.ps1","tests/psmux-bridge.Tests.ps1"]'
+    last_event: commander.review_requested
+    last_event_at: 2026-04-10T14:00:00+09:00
+  worker-1:
+    pane_id: %6
+    role: Worker
+    task_id: ''
+    task: ''
+    task_state: backlog
+    task_owner: ''
+    review_state: ''
+    branch: ''
+    head_sha: ''
+    changed_file_count: 0
+    changed_files: '[]'
+    last_event: pane.idle
+    last_event_at: 2026-04-10T14:00:30+09:00
+"@ | Set-Content -Path $script:digestManifestPath -Encoding UTF8
+
+        ([ordered]@{
+            timestamp = '2026-04-10T14:01:00+09:00'
+            session   = 'winsmux-orchestra'
+            event     = 'commander.review_requested'
+            message   = 'review requested'
+            label     = 'reviewer-1'
+            pane_id   = '%3'
+            role      = 'Reviewer'
+            branch    = 'worktree-builder-1'
+            head_sha  = 'abc1234def5678'
+            data      = [ordered]@{
+                task_id = 'task-246'
+            }
+        } | ConvertTo-Json -Compress) | Set-Content -Path $script:digestEventsPath -Encoding UTF8
+
+        function global:winsmux {
+            $commandLine = ($args | ForEach-Object { [string]$_ }) -join ' '
+            switch -Regex ($commandLine) {
+                '^capture-pane .*%2' { return @('gpt-5.4   64% context left', '? send   Ctrl+J newline', '>') }
+                '^capture-pane .*%6' { return @('gpt-5.4   52% context left', 'thinking', 'Esc to interrupt') }
+                default { throw "unexpected winsmux call: $commandLine" }
+            }
+        }
+
+        $cursor = @(Get-BridgeEventRecords -ProjectDir $script:digestTempRoot).Count
+
+        @(
+            ([ordered]@{
+                timestamp = '2026-04-10T14:02:00+09:00'
+                session   = 'winsmux-orchestra'
+                event     = 'pane.idle'
+                message   = 'idle pane'
+                label     = 'worker-1'
+                pane_id   = '%6'
+                role      = 'Worker'
+                status    = 'ready'
+            } | ConvertTo-Json -Compress),
+            ([ordered]@{
+                timestamp = '2026-04-10T14:03:00+09:00'
+                session   = 'winsmux-orchestra'
+                event     = 'commander.commit_ready'
+                message   = 'commit ready'
+                label     = ''
+                pane_id   = ''
+                role      = 'Operator'
+                branch    = 'worktree-builder-1'
+                head_sha  = 'abc1234def5678'
+                status    = 'commit_ready'
+                data      = [ordered]@{
+                    task_id = 'task-246'
+                }
+            } | ConvertTo-Json -Compress),
+            ([ordered]@{
+                timestamp = '2026-04-10T14:04:00+09:00'
+                session   = 'winsmux-orchestra'
+                event     = 'pane.approval_waiting'
+                message   = 'approval prompt detected'
+                label     = 'builder-1'
+                pane_id   = '%2'
+                role      = 'Builder'
+                status    = 'approval_waiting'
+            } | ConvertTo-Json -Compress)
+        ) | Add-Content -Path $script:digestEventsPath -Encoding UTF8
+
+        $delta = Get-BridgeEventDelta -ProjectDir $script:digestTempRoot -Cursor $cursor
+        $items = @(Get-DigestDeltaItems -ProjectDir $script:digestTempRoot -EventRecords @($delta.events))
+
+        $delta.cursor | Should -Be 4
+        $items.Count | Should -Be 1
+        $items[0].run_id | Should -Be 'task:task-246'
+        $items[0].next_action | Should -Be 'approval_waiting'
+        $items[0].changed_file_count | Should -Be 2
+    }
+
+    It 'writes digest stream items as one-line summary records' {
+        $item = [ordered]@{
+            run_id             = 'task:task-246'
+            label              = 'builder-1'
+            pane_id            = '%2'
+            next_action        = 'commit_ready'
+            changed_file_count = 2
+            last_event_at      = '2026-04-10T14:03:00+09:00'
+        }
+
+        $output = Write-DigestStreamItem -Item $item | Out-String
+
+        $output | Should -Match 'digest task:task-246 builder-1 \(%2\) next=commit_ready files=2'
+    }
+
     It 'supports winsmux digest --json through the top-level CLI entrypoint' {
 @"
 version: 1


### PR DESCRIPTION
## Summary
- add `winsmux digest --stream` for summary-first run updates
- filter digest stream output down to materially affected runs instead of replaying idle noise
- refresh handoff with the new stream-first UX state

## Validation
- `Invoke-Pester tests/psmux-bridge.Tests.ps1` (`103/103 PASS`)
- PowerShell parser check for `scripts/winsmux-core.ps1` and `tests/psmux-bridge.Tests.ps1`

## Notes
- this extends the stream-first UX after `TASK-246/257` without forcing the legacy `watch` silence poller into a stream mode yet
- `TASK-253` remains the only open item in `v0.19.7`; this PR focuses on the next high-signal summary surface