### PR TITLE
feat(tauri): scaffold operator workspace shell

### DIFF
--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -1,6 +1,6 @@
 # Handoff
 
-> Updated: 2026-04-10T15:10:00+09:00
+> Updated: 2026-04-10T16:45:00+09:00
 > Source of truth: this file
 
 ## Current state
@@ -11,6 +11,7 @@
 - Planning source of truth is externalized outside the public repository and syncs automatically into the private planning root.
 - `v0.19.7 visible orchestration` has `TASK-243`, `TASK-244`, `TASK-245`, `TASK-246`, `TASK-256`, and `TASK-257` merged into `main`, and private planning is now `86% (6/7)`.
 - `v0.24.0: Rust runtime convergence` exists in external planning as the pre-`v1.0.0` Rust unification milestone.
+- `v0.21.x` private planning is now aligned to a conversation-first Tauri operator shell, with Codex-App-like shell rules reflected in Figma and backlog notes.
 
 ## This session
 
@@ -22,6 +23,8 @@
 - Merged `TASK-246` via PR [#376](https://github.com/Sora-bluesky/winsmux/pull/376), adding `winsmux digest [--json]` and evidence digest fields for `explain`.
 - Updated external planning so `v0.19.8` remains visible, `v0.20.1` contains `TASK-272/273/274`, and `v0.24.0` keeps the Rust runtime convergence plan.
 - Added the next stream-first UX slice locally: `winsmux digest --stream` now tails event deltas and emits high-signal digest updates only for materially affected runs.
+- Reworked the Tauri prototype toward `TASK-285`: `winsmux-app` now renders an operator workspace shell scaffold with left nav, conversation timeline, sticky composer with inline attachments, context panel toggle, and a terminal utility drawer instead of a PTY-first full-window layout.
+- Added Figma high-fi anchors for `Operator Home / Inbox`, `Run Explain / Evidence`, and `Editor Secondary Surface`, and clarified how Explorer/Editor/Pane map into the new shell.
 
 ## Validation
 
@@ -33,12 +36,14 @@
 - `TASK-246` focused regression passed before merge: `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `101/101 PASS`
 - PR [#376](https://github.com/Sora-bluesky/winsmux/pull/376) CI passed before merge
 - Current local stream UX regression passes: `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `103/103 PASS`
+- Current Tauri shell scaffold passes frontend build: `npm run build` in `winsmux-app`
+- Composer scaffold now matches the advertised keyboard contract (`Enter` sends, `Shift+Enter` inserts newline, IME composition Enter does not send), and Context/Terminal toggles expose disclosure semantics via `aria-controls` + `aria-expanded`
 
 ## Next actions
 
-1. Land the local `digest --stream` stream-first UX slice and then decide whether `watch --stream` is still necessary or should wrap digest/inbox instead of pane silence polling.
-2. Decide whether to close `v0.19.7` with `TASK-253` deferred or implement the minimal first-class `run_id` slice next.
-3. Keep future backlog aligned with the `Operator / slot / provider / verification / security monitor` model.
+1. Land the repo-side `TASK-285` starter (`winsmux-app` conversation shell scaffold) via branch/PR if the current build-only validation is acceptable.
+2. Decide whether `v0.19.7` should close with `TASK-253` deferred or whether to implement the minimal first-class `run_id` slice next.
+3. Continue `v0.21.0` with `TASK-292/293/294`, then align `TASK-107` implementation to the now-explicit secondary editor surface.
 4. Preserve the private planning sync flow: user/agent visible, auto-synced, but not committed to the public repo.
 5. Track GitHub Actions Node runtime warnings and update workflows before the Node 24 switch becomes mandatory.
 

--- a/winsmux-app/index.html
+++ b/winsmux-app/index.html
@@ -8,10 +8,99 @@
     <script type="module" src="/src/main.ts" defer></script>
   </head>
   <body>
-    <div id="toolbar">
-      <span class="toolbar-title">winsmux</span>
-      <button id="add-pane-btn">+ Pane</button>
+    <div id="app-shell">
+      <aside id="left-rail">
+        <div class="brand">winsmux</div>
+        <nav id="nav-list">
+          <button class="nav-item is-active" data-view="inbox">Inbox</button>
+          <button class="nav-item" data-view="runs">Runs</button>
+          <button class="nav-item" data-view="digest">Digest</button>
+          <button class="nav-item" data-view="source">Source</button>
+          <button class="nav-item" data-view="settings">Settings</button>
+        </nav>
+      </aside>
+      <main id="workspace">
+        <header id="workspace-header">
+          <div>
+            <div class="eyebrow">Operator workspace</div>
+            <h1 id="workspace-title">Inbox</h1>
+            <p id="workspace-subtitle">Conversation-first shell for operator judgment, evidence, and action.</p>
+          </div>
+          <div id="header-actions">
+            <button
+              class="ghost-btn"
+              id="toggle-context-btn"
+              type="button"
+              aria-controls="context-panel"
+              aria-expanded="true"
+            >
+              Context
+            </button>
+            <button
+              class="ghost-btn"
+              id="toggle-terminal-btn"
+              type="button"
+              aria-controls="terminal-drawer"
+              aria-expanded="false"
+            >
+              Terminal
+            </button>
+          </div>
+        </header>
+
+        <section id="workspace-body">
+          <section id="conversation-panel">
+            <div id="thread-meta">
+              <span>winsmux session</span>
+              <span>active operator thread</span>
+            </div>
+            <div id="conversation-timeline"></div>
+            <form id="composer" autocomplete="off">
+              <label class="sr-only" for="composer-input">Message the Operator</label>
+              <textarea id="composer-input" rows="2" placeholder="Message the Operator... Dispatch, ask, review, or explain"></textarea>
+              <div id="composer-footer">
+                <div id="attachment-tray">
+                  <button type="button" class="attachment-chip">Screen 1.png</button>
+                  <button type="button" class="attachment-chip">Trace.txt</button>
+                  <button type="button" class="attachment-chip attachment-chip-muted">+1</button>
+                </div>
+                <div id="composer-actions">
+                  <span id="ime-hint">IME-safe: Enter sends, Shift+Enter inserts newline, composing Enter never sends.</span>
+                  <button type="submit" id="send-btn">Send</button>
+                </div>
+              </div>
+            </form>
+          </section>
+
+          <aside id="context-panel">
+            <div class="panel-title">Context</div>
+            <div class="context-section">
+              <div class="context-label">slot</div>
+              <div class="context-value">worker-2</div>
+            </div>
+            <div class="context-section">
+              <div class="context-label">branch</div>
+              <div class="context-value">codex/task245-run-inbox</div>
+            </div>
+            <div class="context-section">
+              <div class="context-label">review</div>
+              <div class="context-value">pending</div>
+            </div>
+            <div class="context-section">
+              <div class="context-label">next</div>
+              <div class="context-value">Open Explain</div>
+            </div>
+          </aside>
+        </section>
+
+        <section id="terminal-drawer" hidden>
+          <div id="terminal-toolbar">
+            <span>Utility drawer: terminal / raw logs / diagnostics only</span>
+            <button id="add-pane-btn">+ Pane</button>
+          </div>
+          <div id="panes-container"></div>
+        </section>
+      </main>
     </div>
-    <div id="panes-container"></div>
   </body>
 </html>

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -10,39 +10,68 @@ interface PaneEntry {
   container: HTMLElement;
 }
 
+interface ConversationItem {
+  type: "user" | "operator" | "system";
+  title?: string;
+  body: string;
+  chips?: string[];
+}
+
 const panes = new Map<string, PaneEntry>();
 let paneCounter = 0;
+let terminalDrawerOpen = false;
+let contextPanelOpen = true;
+let composerImeActive = false;
+
+const seedConversation: ConversationItem[] = [
+  {
+    type: "user",
+    body: "Please tighten the notification boundary and show why this run is blocked.",
+  },
+  {
+    type: "operator",
+    body: "Operator update: inbox shows 2 approval waits. I am checking run ledger and evidence digest now.",
+  },
+  {
+    type: "system",
+    title: "Review requested",
+    body: "worker-2 changed 3 files. Branch/head mismatch is blocking commit. Open Explain to inspect.",
+    chips: ["Open Explain", "Review", "Commit Ready"],
+  },
+];
 
 function createPane(paneId?: string): string {
   const id = paneId || `pane-${++paneCounter}`;
-  const container = document.getElementById("panes-container")!;
+  const container = document.getElementById("panes-container");
+  if (!container) {
+    return id;
+  }
 
-  // Create pane wrapper
   const paneDiv = document.createElement("div");
   paneDiv.className = "pane";
   paneDiv.id = `pane-${id}`;
 
-  // Header
   const header = document.createElement("div");
   header.className = "pane-header";
+
   const label = document.createElement("span");
   label.className = "pane-label";
   label.textContent = id;
+
   const closeBtn = document.createElement("button");
   closeBtn.className = "pane-close";
   closeBtn.textContent = "×";
   closeBtn.onclick = () => closePane(id);
+
   header.appendChild(label);
   header.appendChild(closeBtn);
 
-  // Terminal container
   const termDiv = document.createElement("div");
   termDiv.className = "pane-terminal";
 
   paneDiv.appendChild(header);
   paneDiv.appendChild(termDiv);
 
-  // Add splitter if not first pane
   if (panes.size > 0) {
     const splitter = document.createElement("div");
     splitter.className = "splitter";
@@ -51,15 +80,14 @@ function createPane(paneId?: string): string {
 
   container.appendChild(paneDiv);
 
-  // Initialize xterm
   const terminal = new Terminal({
     cursorBlink: true,
-    fontSize: 14,
+    fontSize: 13,
     fontFamily: "'Cascadia Code', 'Consolas', monospace",
     theme: {
-      background: "#1a1b26",
-      foreground: "#c0caf5",
-      cursor: "#c0caf5",
+      background: "#131722",
+      foreground: "#c7d2e6",
+      cursor: "#c7d2e6",
     },
   });
 
@@ -69,32 +97,33 @@ function createPane(paneId?: string): string {
   fitAddon.fit();
 
   terminal.onData((data: string) => {
-    invoke("pty_write", { paneId: id, data });
+    void invoke("pty_write", { paneId: id, data });
   });
 
   terminal.onResize(({ cols, rows }) => {
-    invoke("pty_resize", { paneId: id, cols, rows });
+    void invoke("pty_resize", { paneId: id, cols, rows });
   });
 
   panes.set(id, { terminal, fitAddon, container: paneDiv });
 
-  // Spawn PTY
   const { cols, rows } = { cols: terminal.cols, rows: terminal.rows };
-  invoke("pty_spawn", { paneId: id, cols, rows });
+  void invoke("pty_spawn", { paneId: id, cols, rows });
 
   return id;
 }
 
 function closePane(id: string) {
   const entry = panes.get(id);
-  if (!entry) return;
+  if (!entry) {
+    return;
+  }
 
-  // Don't close last pane
-  if (panes.size <= 1) return;
+  if (panes.size <= 1) {
+    return;
+  }
 
   entry.terminal.dispose();
 
-  // Remove splitter before this pane if exists
   const prev = entry.container.previousElementSibling;
   if (prev && prev.classList.contains("splitter")) {
     prev.remove();
@@ -102,14 +131,97 @@ function closePane(id: string) {
 
   entry.container.remove();
   panes.delete(id);
-  invoke("pty_close", { paneId: id });
+  void invoke("pty_close", { paneId: id });
 
-  // Refit remaining panes
-  panes.forEach((p) => p.fitAddon.fit());
+  panes.forEach((pane) => pane.fitAddon.fit());
+}
+
+function renderConversation(items: ConversationItem[]) {
+  const timeline = document.getElementById("conversation-timeline");
+  if (!timeline) {
+    return;
+  }
+
+  timeline.innerHTML = "";
+
+  for (const item of items) {
+    const article = document.createElement("article");
+    article.className = `timeline-item timeline-${item.type}`;
+
+    if (item.title) {
+      const title = document.createElement("div");
+      title.className = "timeline-title";
+      title.textContent = item.title;
+      article.appendChild(title);
+    }
+
+    const body = document.createElement("div");
+    body.className = "timeline-body";
+    body.textContent = item.body;
+    article.appendChild(body);
+
+    if (item.chips?.length) {
+      const chipRow = document.createElement("div");
+      chipRow.className = "timeline-chip-row";
+      for (const chipText of item.chips) {
+        const chip = document.createElement("span");
+        chip.className = "timeline-chip";
+        chip.textContent = chipText;
+        chipRow.appendChild(chip);
+      }
+      article.appendChild(chipRow);
+    }
+
+    timeline.appendChild(article);
+  }
+}
+
+function setTerminalDrawer(open: boolean) {
+  terminalDrawerOpen = open;
+  const drawer = document.getElementById("terminal-drawer");
+  const button = document.getElementById("toggle-terminal-btn");
+  if (!drawer || !button) {
+    return;
+  }
+
+  drawer.hidden = !open;
+  button.textContent = open ? "Hide Terminal" : "Terminal";
+  button.setAttribute("aria-expanded", open ? "true" : "false");
+
+  if (open && panes.size === 0) {
+    createPane("main");
+  }
+
+  requestAnimationFrame(() => {
+    panes.forEach((pane) => pane.fitAddon.fit());
+  });
+}
+
+function setContextPanel(open: boolean) {
+  contextPanelOpen = open;
+  const panel = document.getElementById("context-panel");
+  const button = document.getElementById("toggle-context-btn");
+  const body = document.getElementById("workspace-body");
+  if (!panel || !button || !body) {
+    return;
+  }
+
+  panel.toggleAttribute("hidden", !open);
+  body.classList.toggle("context-collapsed", !open);
+  button.textContent = open ? "Hide Context" : "Context";
+  button.setAttribute("aria-expanded", open ? "true" : "false");
+}
+
+function appendUserMessage(message: string) {
+  seedConversation.push({ type: "user", body: message });
+  seedConversation.push({
+    type: "operator",
+    body: "Operator update: queued for dispatch. Open Explain or Digest after the next material event.",
+  });
+  renderConversation(seedConversation);
 }
 
 window.addEventListener("DOMContentLoaded", async () => {
-  // Listen for PTY output (JSON payload with pane_id and data)
   await listen<string>("pty-output", (event) => {
     try {
       const payload = JSON.parse(event.payload);
@@ -118,20 +230,68 @@ window.addEventListener("DOMContentLoaded", async () => {
         entry.terminal.write(payload.data);
       }
     } catch {
-      // Fallback: write to first pane if not JSON
-      const first = panes.values().next().value;
-      if (first) first.terminal.write(event.payload);
+      const first = panes.values().next().value as PaneEntry | undefined;
+      if (first) {
+        first.terminal.write(event.payload);
+      }
     }
   });
 
-  // Create default pane
-  createPane("main");
+  renderConversation(seedConversation);
+  setContextPanel(true);
+  setTerminalDrawer(false);
 
-  // Wire add pane button
-  document.getElementById("add-pane-btn")!.onclick = () => createPane();
+  document.getElementById("toggle-terminal-btn")?.addEventListener("click", () => {
+    setTerminalDrawer(!terminalDrawerOpen);
+  });
 
-  // Global resize
+  document.getElementById("toggle-context-btn")?.addEventListener("click", () => {
+    setContextPanel(!contextPanelOpen);
+  });
+
+  document.getElementById("add-pane-btn")?.addEventListener("click", () => {
+    if (!terminalDrawerOpen) {
+      setTerminalDrawer(true);
+    }
+    createPane();
+  });
+
+  const composer = document.getElementById("composer") as HTMLFormElement | null;
+  const composerInput = document.getElementById("composer-input") as HTMLTextAreaElement | null;
+  if (composer && composerInput) {
+    composerInput.addEventListener("compositionstart", () => {
+      composerImeActive = true;
+    });
+
+    composerInput.addEventListener("compositionend", () => {
+      composerImeActive = false;
+    });
+
+    composerInput.addEventListener("keydown", (event) => {
+      if (event.key !== "Enter") {
+        return;
+      }
+
+      if (event.shiftKey || composerImeActive || event.isComposing) {
+        return;
+      }
+
+      event.preventDefault();
+      composer.requestSubmit();
+    });
+
+    composer.addEventListener("submit", (event) => {
+      event.preventDefault();
+      const value = composerInput.value.trim();
+      if (!value) {
+        return;
+      }
+      appendUserMessage(value);
+      composerInput.value = "";
+    });
+  }
+
   window.addEventListener("resize", () => {
-    panes.forEach((p) => p.fitAddon.fit());
+    panes.forEach((pane) => pane.fitAddon.fit());
   });
 });

--- a/winsmux-app/src/styles.css
+++ b/winsmux-app/src/styles.css
@@ -1,48 +1,385 @@
-html, body {
+html,
+body {
   margin: 0;
   padding: 0;
   width: 100%;
   height: 100%;
+  background: #0f1117;
+  color: #eef2ff;
+  font-family:
+    "Inter",
+    "Segoe UI",
+    "Noto Sans JP",
+    "Noto Sans KR",
+    "Apple SD Gothic Neo",
+    sans-serif;
   overflow: hidden;
-  background: #1a1b26;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+button,
+textarea {
+  font: inherit;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+#app-shell {
+  display: grid;
+  grid-template-columns: 76px minmax(0, 1fr);
+  width: 100%;
+  height: 100%;
+  background:
+    radial-gradient(circle at top left, rgba(64, 88, 160, 0.14), transparent 32%),
+    linear-gradient(180deg, #0f1117 0%, #121521 100%);
+}
+
+#left-rail {
+  border-right: 1px solid #232737;
+  background: rgba(10, 12, 18, 0.85);
+  padding: 18px 12px;
   display: flex;
   flex-direction: column;
+  gap: 20px;
 }
 
-#toolbar {
-  height: 32px;
-  background: #16161e;
+.brand {
+  font-size: 13px;
+  font-weight: 700;
+  color: #f3f4f6;
+  letter-spacing: 0.02em;
+}
+
+#nav-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.nav-item {
+  border: 0;
+  border-radius: 12px;
+  background: transparent;
+  color: #97a0bd;
+  padding: 10px 8px;
+  text-align: left;
+  cursor: pointer;
+}
+
+.nav-item.is-active,
+.nav-item:hover {
+  background: #1a1f2f;
+  color: #f4f6ff;
+}
+
+#workspace {
+  min-width: 0;
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr) auto;
+  padding: 20px;
+  gap: 16px;
+}
+
+#workspace-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.eyebrow {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #7d88a9;
+  margin-bottom: 6px;
+}
+
+#workspace-title {
+  margin: 0;
+  font-size: 28px;
+  line-height: 1.1;
+}
+
+#workspace-subtitle {
+  margin: 8px 0 0;
+  color: #9aa3bf;
+  font-size: 14px;
+}
+
+#header-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.ghost-btn {
+  border: 1px solid #31374d;
+  background: #1a1f2f;
+  color: #d4daf0;
+  border-radius: 12px;
+  padding: 10px 14px;
+  cursor: pointer;
+}
+
+.ghost-btn:hover {
+  background: #22283c;
+}
+
+#workspace-body {
+  min-height: 0;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 292px;
+  gap: 16px;
+}
+
+#workspace-body.context-collapsed {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+#conversation-panel,
+#context-panel,
+#terminal-drawer {
+  border: 1px solid #252b3e;
+  border-radius: 20px;
+  background: #151926;
+}
+
+#conversation-panel {
+  min-height: 0;
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr) auto;
+  overflow: hidden;
+}
+
+#thread-meta {
+  display: flex;
+  justify-content: space-between;
+  padding: 16px 20px 8px;
+  color: #7e88a8;
+  font-size: 12px;
+}
+
+#conversation-timeline {
+  min-height: 0;
+  overflow: auto;
+  padding: 8px 20px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.timeline-item {
+  max-width: min(78ch, 82%);
+  border-radius: 18px;
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.03);
+}
+
+.timeline-user {
+  align-self: flex-start;
+  background: #202637;
+}
+
+.timeline-operator {
+  align-self: flex-end;
+  background: #162234;
+}
+
+.timeline-system {
+  align-self: flex-start;
+  width: min(82ch, 100%);
+  background: #121723;
+  border: 1px solid #3b65d8;
+}
+
+.timeline-title {
+  font-size: 12px;
+  font-weight: 700;
+  color: #f7f8ff;
+}
+
+.timeline-body {
+  color: #d9dff1;
+  font-size: 13px;
+  line-height: 1.55;
+  white-space: pre-wrap;
+}
+
+.timeline-chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.timeline-chip {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  padding: 5px 10px;
+  font-size: 11px;
+  font-weight: 600;
+  background: #1f2640;
+  color: #e8ecff;
+}
+
+#composer {
+  border-top: 1px solid #252b3e;
+  padding: 16px 18px 18px;
+  background: #131722;
+}
+
+#composer-input {
+  width: 100%;
+  min-height: 72px;
+  resize: vertical;
+  border: 1px solid #343c56;
+  border-radius: 18px;
+  background: #1b2030;
+  color: #f3f5ff;
+  padding: 16px 18px;
+  outline: none;
+}
+
+#composer-input:focus {
+  border-color: #5a84f5;
+  box-shadow: 0 0 0 3px rgba(90, 132, 245, 0.18);
+}
+
+#composer-footer {
+  margin-top: 10px;
   display: flex;
   align-items: center;
-  padding: 0 12px;
-  gap: 12px;
-  flex-shrink: 0;
+  justify-content: space-between;
+  gap: 14px;
 }
 
-.toolbar-title {
-  color: #565f89;
-  font-family: 'Cascadia Code', monospace;
+#attachment-tray {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.attachment-chip {
+  border: 0;
+  border-radius: 999px;
+  padding: 7px 11px;
+  background: #f4f5f3;
+  color: #161922;
+  cursor: pointer;
+}
+
+.attachment-chip-muted {
+  background: #323851;
+  color: #eef2ff;
+}
+
+#composer-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+#ime-hint {
+  font-size: 11px;
+  color: #8d97b7;
+}
+
+#send-btn {
+  border: 0;
+  border-radius: 999px;
+  padding: 9px 16px;
+  background: #4d76f0;
+  color: #fff;
+  cursor: pointer;
+}
+
+#send-btn:hover {
+  background: #5d84f5;
+}
+
+#context-panel {
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.panel-title {
   font-size: 13px;
-  font-weight: bold;
+  font-weight: 700;
+  color: #f4f6ff;
+}
+
+.context-section {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid #23283a;
+}
+
+.context-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #7e88a8;
+}
+
+.context-value {
+  font-size: 13px;
+  color: #e5e9f8;
+}
+
+#terminal-drawer {
+  overflow: hidden;
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  min-height: 240px;
+}
+
+#terminal-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 12px 16px;
+  border-bottom: 1px solid #252b3e;
+  font-size: 12px;
+  color: #8f99ba;
 }
 
 #add-pane-btn {
-  background: #292e42;
-  color: #7aa2f7;
-  border: 1px solid #3b4261;
-  border-radius: 4px;
-  padding: 2px 10px;
-  font-size: 12px;
+  border: 1px solid #31374d;
+  background: #1a1f2f;
+  color: #d4daf0;
+  border-radius: 10px;
+  padding: 8px 12px;
   cursor: pointer;
-  font-family: 'Cascadia Code', monospace;
 }
 
 #add-pane-btn:hover {
-  background: #3b4261;
+  background: #22283c;
 }
 
 #panes-container {
-  flex: 1;
+  min-height: 0;
   display: flex;
   flex-direction: row;
   overflow: hidden;
@@ -52,33 +389,32 @@ html, body {
   flex: 1;
   display: flex;
   flex-direction: column;
-  min-width: 200px;
+  min-width: 220px;
   overflow: hidden;
 }
 
 .pane-header {
-  height: 24px;
-  background: #1f2335;
+  height: 28px;
+  background: #171c29;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0 8px;
+  padding: 0 10px;
   flex-shrink: 0;
 }
 
 .pane-label {
-  color: #565f89;
+  color: #8b95b8;
   font-size: 11px;
-  font-family: 'Cascadia Code', monospace;
+  font-family: "Cascadia Code", "Consolas", monospace;
 }
 
 .pane-close {
   background: none;
   border: none;
-  color: #565f89;
+  color: #8b95b8;
   font-size: 14px;
   cursor: pointer;
-  padding: 0 4px;
 }
 
 .pane-close:hover {
@@ -92,11 +428,47 @@ html, body {
 
 .splitter {
   width: 4px;
-  background: #292e42;
+  background: #252b3e;
   cursor: col-resize;
   flex-shrink: 0;
 }
 
 .splitter:hover {
-  background: #7aa2f7;
+  background: #5d84f5;
+}
+
+@media (max-width: 1180px) {
+  #workspace-body {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  #context-panel {
+    order: -1;
+  }
+
+  #composer-footer {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  #composer-actions {
+    width: 100%;
+    justify-content: space-between;
+  }
+}
+
+@media (max-height: 760px) {
+  #workspace {
+    grid-template-rows: auto minmax(0, 1fr);
+  }
+
+  #terminal-drawer {
+    position: fixed;
+    left: 96px;
+    right: 20px;
+    bottom: 20px;
+    z-index: 20;
+    max-height: 42vh;
+    box-shadow: 0 16px 48px rgba(0, 0, 0, 0.32);
+  }
 }


### PR DESCRIPTION
## Summary
- replace the PTY-first `winsmux-app` shell with an operator-first workspace scaffold
- add a conversation timeline, sticky composer with inline attachments, context toggle, and terminal utility drawer
- update handoff with the current TASK-285 state and validation details

## Validation
- `npm run build` in `winsmux-app`
- reviewer follow-up on the current diff reported no blocking findings

## Notes
- this is the TASK-285 starter slice only; it keeps PTY support for the utility drawer and does not yet wire the Tauri shell to `board/inbox/runs/explain/digest` projections
- composer keyboard behavior now matches the UI hint (`Enter` sends, `Shift+Enter` inserts newline, IME composition Enter does not send)
- Context and Terminal toggles now expose disclosure semantics via `aria-controls` and `aria-expanded`