### PR TITLE
feat(orchestra): add first-class run packet contract

### DIFF
--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -1,6 +1,6 @@
 # Handoff
 
-> Updated: 2026-04-10T15:10:00+09:00
+> Updated: 2026-04-10T16:05:00+09:00
 > Source of truth: this file
 
 ## Current state
@@ -9,7 +9,7 @@
 - `v0.19.6 hardening` is implemented, merged, released, and tracked as `100% (6/6)` in the external planning backlog/roadmap.
 - PR [#370](https://github.com/Sora-bluesky/winsmux/pull/370) and PR [#371](https://github.com/Sora-bluesky/winsmux/pull/371) are merged into `main`.
 - Planning source of truth is externalized outside the public repository and syncs automatically into the private planning root.
-- `v0.19.7 visible orchestration` has `TASK-243`, `TASK-244`, `TASK-245`, `TASK-246`, `TASK-256`, and `TASK-257` merged into `main`, and private planning is now `86% (6/7)`.
+- `v0.19.7 visible orchestration` is now closed at `100% (7/7)`, with `TASK-253` implemented locally as the first-class run packet/result packet contract.
 - `v0.24.0: Rust runtime convergence` exists in external planning as the pre-`v1.0.0` Rust unification milestone.
 
 ## This session
@@ -20,6 +20,7 @@
 - Merged the repo-side `TASK-256` primitives via PR [#374](https://github.com/Sora-bluesky/winsmux/pull/374): `winsmux runs [--json]` and `winsmux explain <run_id> [--json] [--follow]`.
 - Merged `TASK-257` via PR [#375](https://github.com/Sora-bluesky/winsmux/pull/375), tightening notification profiles so Telegram defaults to external-facing events only.
 - Merged `TASK-246` via PR [#376](https://github.com/Sora-bluesky/winsmux/pull/376), adding `winsmux digest [--json]` and evidence digest fields for `explain`.
+- Implemented `TASK-253` locally on `codex/task253-run-packets-20260410`, extending manifest/status/board aggregation into first-class `run_packet` and `result_packet` surfaces for `winsmux runs --json` and `winsmux explain --json`.
 - Updated external planning so `v0.19.8` remains visible, `v0.20.1` contains `TASK-272/273/274`, and `v0.24.0` keeps the Rust runtime convergence plan.
 - Added the next stream-first UX slice locally: `winsmux digest --stream` now tails event deltas and emits high-signal digest updates only for materially affected runs.
 
@@ -32,15 +33,14 @@
 - `TASK-257` focused regression passed before merge: `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `98/98 PASS`
 - `TASK-246` focused regression passed before merge: `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `101/101 PASS`
 - PR [#376](https://github.com/Sora-bluesky/winsmux/pull/376) CI passed before merge
-- Current local stream UX regression passes: `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `103/103 PASS`
+- `TASK-253` focused regression passes locally: `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `103/103 PASS`
 
 ## Next actions
 
-1. Land the local `digest --stream` stream-first UX slice and then decide whether `watch --stream` is still necessary or should wrap digest/inbox instead of pane silence polling.
-2. Decide whether to close `v0.19.7` with `TASK-253` deferred or implement the minimal first-class `run_id` slice next.
-3. Keep future backlog aligned with the `Operator / slot / provider / verification / security monitor` model.
-4. Preserve the private planning sync flow: user/agent visible, auto-synced, but not committed to the public repo.
-5. Track GitHub Actions Node runtime warnings and update workflows before the Node 24 switch becomes mandatory.
+1. Land `TASK-253` via PR and formally close `v0.19.7`.
+2. Start `v0.19.8` in order, while keeping future backlog aligned with the `Operator / slot / provider / verification / security monitor` model.
+3. Preserve the private planning sync flow: user/agent visible, auto-synced, but not committed to the public repo.
+4. Track GitHub Actions Node runtime warnings and update workflows before the Node 24 switch becomes mandatory.
 
 ## Notes
 

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -2163,6 +2163,21 @@ function Get-BoardPayload {
                 changed_files      = @($_.ChangedFiles)
                 last_event         = $_.LastEvent
                 last_event_at      = $_.LastEventAt
+                parent_run_id      = [string]$_.ParentRunId
+                goal               = [string]$_.Goal
+                task_type          = [string]$_.TaskType
+                priority           = [string]$_.Priority
+                blocking           = [bool]$_.Blocking
+                write_scope        = @($_.WriteScope)
+                read_scope         = @($_.ReadScope)
+                constraints        = @($_.Constraints)
+                expected_output    = [string]$_.ExpectedOutput
+                verification_plan  = @($_.VerificationPlan)
+                review_required    = [bool]$_.ReviewRequired
+                provider_target    = [string]$_.ProviderTarget
+                agent_role         = [string]$_.AgentRole
+                timeout_policy     = [string]$_.TimeoutPolicy
+                handoff_refs       = @($_.HandoffRefs)
             }
         }
     )
@@ -2505,6 +2520,95 @@ function Get-RunIdFromPaneRecord {
     return "label:{0}" -f [string]$PaneRecord.label
 }
 
+function New-RunPacketFromRun {
+    param([Parameter(Mandatory = $true)]$Run)
+
+    return [ordered]@{
+        run_id            = [string]$Run.run_id
+        task_id           = [string]$Run.task_id
+        parent_run_id     = [string]$Run.parent_run_id
+        goal              = [string]$Run.goal
+        task              = [string]$Run.task
+        task_type         = [string]$Run.task_type
+        priority          = [string]$Run.priority
+        blocking          = [bool]$Run.blocking
+        write_scope       = @($Run.write_scope)
+        read_scope        = @($Run.read_scope)
+        constraints       = @($Run.constraints)
+        expected_output   = [string]$Run.expected_output
+        verification_plan = @($Run.verification_plan)
+        review_required   = [bool]$Run.review_required
+        provider_target   = [string]$Run.provider_target
+        agent_role        = if (-not [string]::IsNullOrWhiteSpace([string]$Run.agent_role)) { [string]$Run.agent_role } else { [string]$Run.primary_role }
+        timeout_policy    = [string]$Run.timeout_policy
+        handoff_refs      = @($Run.handoff_refs)
+        branch            = [string]$Run.branch
+        head_sha          = [string]$Run.head_sha
+        primary_label     = [string]$Run.primary_label
+        primary_pane_id   = [string]$Run.primary_pane_id
+        primary_role      = [string]$Run.primary_role
+        labels            = @($Run.labels)
+        pane_ids          = @($Run.pane_ids)
+        roles             = @($Run.roles)
+        changed_files     = @($Run.changed_files)
+        last_event        = [string]$Run.last_event
+        last_event_at     = [string]$Run.last_event_at
+    }
+}
+
+function New-RunResultPacket {
+    param(
+        [Parameter(Mandatory = $true)]$Run,
+        [Parameter(Mandatory = $true)]$EvidenceDigest,
+        [AllowNull()]$ReviewState = $null,
+        [Parameter(Mandatory = $true)][object[]]$RecentEvents
+    )
+
+    $status = ''
+    if ([string]$Run.review_state -in @('FAIL', 'FAILED')) {
+        $status = 'failed'
+    } elseif ([string]$Run.review_state -eq 'PASS' -or [string]$Run.task_state -eq 'done') {
+        $status = 'completed'
+    } elseif ([string]$Run.task_state -eq 'blocked') {
+        $status = 'blocked'
+    } elseif ([string]$Run.task_state -eq 'in_progress') {
+        $status = 'in_progress'
+    } elseif (-not [string]::IsNullOrWhiteSpace([string]$Run.task_state)) {
+        $status = [string]$Run.task_state
+    }
+
+    $summary = if (-not [string]::IsNullOrWhiteSpace([string]$EvidenceDigest.last_event)) {
+        [string]$EvidenceDigest.last_event
+    } elseif (-not [string]::IsNullOrWhiteSpace([string]$Run.task)) {
+        [string]$Run.task
+    } else {
+        [string]$Run.primary_label
+    }
+
+    $reviewRecommendation = ''
+    if ($ReviewState -is [System.Collections.IDictionary] -and $ReviewState.Contains('status')) {
+        $reviewRecommendation = [string]$ReviewState['status']
+    } elseif ([string]$Run.review_state -in @('FAIL', 'FAILED', 'PENDING', 'PASS')) {
+        $reviewRecommendation = [string]$Run.review_state
+    }
+
+    return [ordered]@{
+        run_id                = [string]$Run.run_id
+        status                = $status
+        summary               = $summary
+        artifacts             = @()
+        changed_files         = @($EvidenceDigest.changed_files)
+        head_sha              = [string]$EvidenceDigest.head_sha
+        branch                = [string]$EvidenceDigest.branch
+        next_action_hint      = [string]$EvidenceDigest.next_action
+        review_recommendation = $reviewRecommendation
+        evidence_refs         = @($EvidenceDigest.changed_files)
+        action_items          = @($Run.action_items)
+        review_state          = $ReviewState
+        recent_events         = @($RecentEvents)
+    }
+}
+
 function Test-RunMatchesEventRecord {
     param(
         [Parameter(Mandatory = $true)]$Run,
@@ -2622,12 +2726,58 @@ function Get-RunsPayload {
                 roles              = [System.Collections.Generic.List[string]]::new()
                 changed_files      = [System.Collections.Generic.List[string]]::new()
                 action_items       = [System.Collections.Generic.List[object]]::new()
+                parent_run_id      = [string]$pane.parent_run_id
+                goal               = [string]$pane.goal
+                task_type          = [string]$pane.task_type
+                priority           = [string]$pane.priority
+                blocking           = [bool]$pane.blocking
+                write_scope        = [System.Collections.Generic.List[string]]::new()
+                read_scope         = [System.Collections.Generic.List[string]]::new()
+                constraints        = [System.Collections.Generic.List[string]]::new()
+                expected_output    = [string]$pane.expected_output
+                verification_plan  = [System.Collections.Generic.List[string]]::new()
+                review_required    = [bool]$pane.review_required
+                provider_target    = [string]$pane.provider_target
+                agent_role         = [string]$pane.agent_role
+                timeout_policy     = [string]$pane.timeout_policy
+                handoff_refs       = [System.Collections.Generic.List[string]]::new()
             }
         }
 
         $run = $runsById[$runId]
         $run.pane_count = [int]$run.pane_count + 1
         $run.changed_file_count = [int]$run.changed_file_count + [int]$pane.changed_file_count
+
+        if ([string]::IsNullOrWhiteSpace([string]$run.parent_run_id) -and -not [string]::IsNullOrWhiteSpace([string]$pane.parent_run_id)) {
+            $run.parent_run_id = [string]$pane.parent_run_id
+        }
+        if ([string]::IsNullOrWhiteSpace([string]$run.goal) -and -not [string]::IsNullOrWhiteSpace([string]$pane.goal)) {
+            $run.goal = [string]$pane.goal
+        }
+        if ([string]::IsNullOrWhiteSpace([string]$run.task_type) -and -not [string]::IsNullOrWhiteSpace([string]$pane.task_type)) {
+            $run.task_type = [string]$pane.task_type
+        }
+        if ([string]::IsNullOrWhiteSpace([string]$run.priority) -and -not [string]::IsNullOrWhiteSpace([string]$pane.priority)) {
+            $run.priority = [string]$pane.priority
+        }
+        if (-not [bool]$run.blocking -and [bool]$pane.blocking) {
+            $run.blocking = $true
+        }
+        if ([string]::IsNullOrWhiteSpace([string]$run.expected_output) -and -not [string]::IsNullOrWhiteSpace([string]$pane.expected_output)) {
+            $run.expected_output = [string]$pane.expected_output
+        }
+        if (-not [bool]$run.review_required -and [bool]$pane.review_required) {
+            $run.review_required = $true
+        }
+        if ([string]::IsNullOrWhiteSpace([string]$run.provider_target) -and -not [string]::IsNullOrWhiteSpace([string]$pane.provider_target)) {
+            $run.provider_target = [string]$pane.provider_target
+        }
+        if ([string]::IsNullOrWhiteSpace([string]$run.agent_role) -and -not [string]::IsNullOrWhiteSpace([string]$pane.agent_role)) {
+            $run.agent_role = [string]$pane.agent_role
+        }
+        if ([string]::IsNullOrWhiteSpace([string]$run.timeout_policy) -and -not [string]::IsNullOrWhiteSpace([string]$pane.timeout_policy)) {
+            $run.timeout_policy = [string]$pane.timeout_policy
+        }
 
         if (-not [string]::IsNullOrWhiteSpace([string]$pane.label) -and -not $run.labels.Contains([string]$pane.label)) {
             $run.labels.Add([string]$pane.label) | Out-Null
@@ -2643,6 +2793,36 @@ function Get-RunsPayload {
             $changedFileText = [string]$changedFile
             if (-not [string]::IsNullOrWhiteSpace($changedFileText) -and -not $run.changed_files.Contains($changedFileText)) {
                 $run.changed_files.Add($changedFileText) | Out-Null
+            }
+        }
+        foreach ($writeScopePath in @($pane.write_scope)) {
+            $writeScopeText = [string]$writeScopePath
+            if (-not [string]::IsNullOrWhiteSpace($writeScopeText) -and -not $run.write_scope.Contains($writeScopeText)) {
+                $run.write_scope.Add($writeScopeText) | Out-Null
+            }
+        }
+        foreach ($readScopePath in @($pane.read_scope)) {
+            $readScopeText = [string]$readScopePath
+            if (-not [string]::IsNullOrWhiteSpace($readScopeText) -and -not $run.read_scope.Contains($readScopeText)) {
+                $run.read_scope.Add($readScopeText) | Out-Null
+            }
+        }
+        foreach ($constraint in @($pane.constraints)) {
+            $constraintText = [string]$constraint
+            if (-not [string]::IsNullOrWhiteSpace($constraintText) -and -not $run.constraints.Contains($constraintText)) {
+                $run.constraints.Add($constraintText) | Out-Null
+            }
+        }
+        foreach ($verificationStep in @($pane.verification_plan)) {
+            $verificationText = [string]$verificationStep
+            if (-not [string]::IsNullOrWhiteSpace($verificationText) -and -not $run.verification_plan.Contains($verificationText)) {
+                $run.verification_plan.Add($verificationText) | Out-Null
+            }
+        }
+        foreach ($handoffRef in @($pane.handoff_refs)) {
+            $handoffRefText = [string]$handoffRef
+            if (-not [string]::IsNullOrWhiteSpace($handoffRefText) -and -not $run.handoff_refs.Contains($handoffRefText)) {
+                $run.handoff_refs.Add($handoffRefText) | Out-Null
             }
         }
     }
@@ -2694,9 +2874,28 @@ function Get-RunsPayload {
                 roles              = @($run.roles)
                 changed_files      = @($run.changed_files)
                 action_items       = @($run.action_items | Sort-Object @{ Expression = { [string]$_.timestamp }; Descending = $true }, @{ Expression = { [string]$_.kind } })
+                parent_run_id      = [string]$run.parent_run_id
+                goal               = [string]$run.goal
+                task_type          = [string]$run.task_type
+                priority           = [string]$run.priority
+                blocking           = [bool]$run.blocking
+                write_scope        = @($run.write_scope)
+                read_scope         = @($run.read_scope)
+                constraints        = @($run.constraints)
+                expected_output    = [string]$run.expected_output
+                verification_plan  = @($run.verification_plan)
+                review_required    = [bool]$run.review_required
+                provider_target    = [string]$run.provider_target
+                agent_role         = if (-not [string]::IsNullOrWhiteSpace([string]$run.agent_role)) { [string]$run.agent_role } else { [string]$run.primary_role }
+                timeout_policy     = [string]$run.timeout_policy
+                handoff_refs       = @($run.handoff_refs)
             }
         }
     )
+
+    foreach ($run in @($runs)) {
+        $run['run_packet'] = New-RunPacketFromRun -Run $run
+    }
 
     return [ordered]@{
         generated_at = (Get-Date).ToString('o')
@@ -2848,11 +3047,15 @@ function Get-ExplainPayload {
         $reasons.Add("action:$([string]$actionItem.kind)") | Out-Null
     }
 
+    $evidenceDigest = ConvertTo-EvidenceDigestItem -Run $run
+    $recentEvents = @($events | Select-Object -First 20)
+
     return [ordered]@{
-        generated_at  = (Get-Date).ToString('o')
-        project_dir   = $ProjectDir
-        run           = $run
-        evidence_digest = ConvertTo-EvidenceDigestItem -Run $run
+        generated_at    = (Get-Date).ToString('o')
+        project_dir     = $ProjectDir
+        run             = $run
+        run_packet      = New-RunPacketFromRun -Run $run
+        evidence_digest = $evidenceDigest
         explanation   = [ordered]@{
             summary       = if (-not [string]::IsNullOrWhiteSpace([string]$run.task)) { [string]$run.task } else { [string]$run.primary_label }
             reasons       = @($reasons)
@@ -2864,8 +3067,9 @@ function Get-ExplainPayload {
                 last_event   = [string]$run.last_event
             }
         }
-        review_state  = $reviewState
-        recent_events = @($events | Select-Object -First 20)
+        review_state    = $reviewState
+        recent_events   = $recentEvents
+        result_packet   = New-RunResultPacket -Run $run -EvidenceDigest $evidenceDigest -ReviewState $reviewState -RecentEvents $recentEvents
     }
 }
 

--- a/tests/psmux-bridge.Tests.ps1
+++ b/tests/psmux-bridge.Tests.ps1
@@ -3036,14 +3036,29 @@ panes:
     pane_id: %2
     role: Builder
     task_id: task-256
+    parent_run_id: operator:session-1
+    goal: Ship run contract primitives
     task: Implement run ledger
+    task_type: implementation
     task_state: in_progress
     task_owner: builder-1
     review_state: PENDING
+    priority: P0
+    blocking: true
     branch: worktree-builder-1
     head_sha: abc1234def5678
     changed_file_count: 1
     changed_files: '["scripts/winsmux-core.ps1"]'
+    write_scope: '["scripts/winsmux-core.ps1","tests/psmux-bridge.Tests.ps1"]'
+    read_scope: '["winsmux-core/scripts/pane-status.ps1"]'
+    constraints: '["preserve existing board schema"]'
+    expected_output: Stable run_packet JSON
+    verification_plan: '["Invoke-Pester tests/psmux-bridge.Tests.ps1","verify runs --json contract"]'
+    review_required: true
+    provider_target: codex:gpt-5.4
+    agent_role: worker
+    timeout_policy: standard
+    handoff_refs: '["docs/handoff.md"]'
     last_event: commander.review_requested
     last_event_at: 2026-04-10T12:00:00+09:00
 "@ | Set-Content -Path $script:runsManifestPath -Encoding UTF8
@@ -3076,6 +3091,21 @@ panes:
         @($result.runs[0].action_items | ForEach-Object { $_.kind }) | Should -Contain 'approval_waiting'
         @($result.runs[0].action_items | ForEach-Object { $_.kind }) | Should -Contain 'review_pending'
         $result.runs[0].changed_files | Should -Be @('scripts/winsmux-core.ps1')
+        $result.runs[0].run_packet.parent_run_id | Should -Be 'operator:session-1'
+        $result.runs[0].run_packet.goal | Should -Be 'Ship run contract primitives'
+        $result.runs[0].run_packet.task_type | Should -Be 'implementation'
+        $result.runs[0].run_packet.priority | Should -Be 'P0'
+        $result.runs[0].run_packet.blocking | Should -Be $true
+        $result.runs[0].run_packet.write_scope | Should -Be @('scripts/winsmux-core.ps1', 'tests/psmux-bridge.Tests.ps1')
+        $result.runs[0].run_packet.read_scope | Should -Be @('winsmux-core/scripts/pane-status.ps1')
+        $result.runs[0].run_packet.constraints | Should -Be @('preserve existing board schema')
+        $result.runs[0].run_packet.expected_output | Should -Be 'Stable run_packet JSON'
+        $result.runs[0].run_packet.verification_plan | Should -Be @('Invoke-Pester tests/psmux-bridge.Tests.ps1', 'verify runs --json contract')
+        $result.runs[0].run_packet.review_required | Should -Be $true
+        $result.runs[0].run_packet.provider_target | Should -Be 'codex:gpt-5.4'
+        $result.runs[0].run_packet.agent_role | Should -Be 'worker'
+        $result.runs[0].run_packet.timeout_policy | Should -Be 'standard'
+        $result.runs[0].run_packet.handoff_refs | Should -Be @('docs/handoff.md')
     }
 
     It 'supports winsmux runs --json through the top-level CLI entrypoint' {
@@ -3473,14 +3503,29 @@ panes:
     pane_id: %2
     role: Builder
     task_id: task-256
+    parent_run_id: operator:session-1
+    goal: Ship run contract primitives
     task: Implement run ledger
+    task_type: implementation
     task_state: in_progress
     task_owner: builder-1
     review_state: PENDING
+    priority: P0
+    blocking: true
     branch: worktree-builder-1
     head_sha: abc1234def5678
     changed_file_count: 1
     changed_files: '["scripts/winsmux-core.ps1"]'
+    write_scope: '["scripts/winsmux-core.ps1","tests/psmux-bridge.Tests.ps1"]'
+    read_scope: '["winsmux-core/scripts/pane-status.ps1"]'
+    constraints: '["preserve existing board schema"]'
+    expected_output: Stable run_packet JSON
+    verification_plan: '["Invoke-Pester tests/psmux-bridge.Tests.ps1","verify explain --json contract"]'
+    review_required: true
+    provider_target: codex:gpt-5.4
+    agent_role: worker
+    timeout_policy: standard
+    handoff_refs: '["docs/handoff.md"]'
     last_event: commander.review_requested
     last_event_at: 2026-04-10T12:00:00+09:00
 "@ | Set-Content -Path $script:explainManifestPath -Encoding UTF8
@@ -3549,6 +3594,21 @@ panes:
 
         $result.run.run_id | Should -Be 'task:task-256'
         $result.run.task | Should -Be 'Implement run ledger'
+        $result.run_packet.parent_run_id | Should -Be 'operator:session-1'
+        $result.run_packet.goal | Should -Be 'Ship run contract primitives'
+        $result.run_packet.task_type | Should -Be 'implementation'
+        $result.run_packet.priority | Should -Be 'P0'
+        $result.run_packet.blocking | Should -Be $true
+        $result.run_packet.write_scope | Should -Be @('scripts/winsmux-core.ps1', 'tests/psmux-bridge.Tests.ps1')
+        $result.run_packet.read_scope | Should -Be @('winsmux-core/scripts/pane-status.ps1')
+        $result.run_packet.constraints | Should -Be @('preserve existing board schema')
+        $result.run_packet.expected_output | Should -Be 'Stable run_packet JSON'
+        $result.run_packet.verification_plan | Should -Be @('Invoke-Pester tests/psmux-bridge.Tests.ps1', 'verify explain --json contract')
+        $result.run_packet.review_required | Should -Be $true
+        $result.run_packet.provider_target | Should -Be 'codex:gpt-5.4'
+        $result.run_packet.agent_role | Should -Be 'worker'
+        $result.run_packet.timeout_policy | Should -Be 'standard'
+        $result.run_packet.handoff_refs | Should -Be @('docs/handoff.md')
         $result.evidence_digest.run_id | Should -Be 'task:task-256'
         $result.evidence_digest.next_action | Should -Be 'approval_waiting'
         $result.evidence_digest.changed_files | Should -Be @('scripts/winsmux-core.ps1')
@@ -3556,6 +3616,14 @@ panes:
         $result.explanation.reasons | Should -Contain 'task_state=in_progress'
         $result.explanation.reasons | Should -Contain 'review_state=PENDING'
         $result.review_state.status | Should -Be 'PENDING'
+        $result.result_packet.status | Should -Be 'in_progress'
+        $result.result_packet.summary | Should -Be 'commander.review_requested'
+        $result.result_packet.changed_files | Should -Be @('scripts/winsmux-core.ps1')
+        $result.result_packet.branch | Should -Be 'worktree-builder-1'
+        $result.result_packet.head_sha | Should -Be 'abc1234def5678'
+        $result.result_packet.next_action_hint | Should -Be 'approval_waiting'
+        $result.result_packet.review_recommendation | Should -Be 'PENDING'
+        $result.result_packet.evidence_refs | Should -Be @('scripts/winsmux-core.ps1')
         $result.recent_events.Count | Should -Be 2
         @($result.recent_events | ForEach-Object { $_.event }) | Should -Contain 'commander.review_requested'
         @($result.recent_events | ForEach-Object { $_.event }) | Should -Contain 'pane.approval_waiting'

--- a/winsmux-core/scripts/pane-control.ps1
+++ b/winsmux-core/scripts/pane-control.ps1
@@ -104,6 +104,73 @@ function ConvertFrom-PaneControlChangedFiles {
     }
 }
 
+function ConvertFrom-PaneControlStringArray {
+    param([AllowNull()]$Value)
+
+    $normalize = {
+        param($Items)
+
+        return @(
+            @($Items) |
+                Where-Object { $null -ne $_ -and -not [string]::IsNullOrWhiteSpace([string]$_) } |
+                ForEach-Object { [string]$_ }
+        )
+    }
+
+    if ($null -eq $Value) {
+        return @()
+    }
+
+    if ($Value -is [System.Array]) {
+        return & $normalize $Value
+    }
+
+    $text = [string]$Value
+    if ([string]::IsNullOrWhiteSpace($text)) {
+        return @()
+    }
+
+    try {
+        $parsed = $text | ConvertFrom-Json -ErrorAction Stop
+        if ($parsed -is [System.Array]) {
+            return & $normalize $parsed
+        }
+
+        return & $normalize @($parsed)
+    } catch {
+        return & $normalize @($text)
+    }
+}
+
+function ConvertFrom-PaneControlBoolean {
+    param([AllowNull()]$Value, [bool]$Default = $false)
+
+    if ($null -eq $Value) {
+        return $Default
+    }
+
+    if ($Value -is [bool]) {
+        return [bool]$Value
+    }
+
+    $text = [string]$Value
+    if ([string]::IsNullOrWhiteSpace($text)) {
+        return $Default
+    }
+
+    switch ($text.Trim().ToLowerInvariant()) {
+        'true' { return $true }
+        '1' { return $true }
+        'yes' { return $true }
+        'y' { return $true }
+        'false' { return $false }
+        '0' { return $false }
+        'no' { return $false }
+        'n' { return $false }
+        default { return $Default }
+    }
+}
+
 function Get-PaneControlCanonicalRole {
     param([AllowNull()][string]$Role, [AllowNull()][string]$Label)
 
@@ -241,6 +308,21 @@ function Get-PaneControlManifestEntries {
             ChangedFiles        = @(ConvertFrom-PaneControlChangedFiles -Value (Get-PaneControlValue -InputObject $pane -Name 'changed_files' -Default @()))
             LastEvent           = [string](Get-PaneControlValue -InputObject $pane -Name 'last_event' -Default '')
             LastEventAt         = [string](Get-PaneControlValue -InputObject $pane -Name 'last_event_at' -Default '')
+            ParentRunId         = [string](Get-PaneControlValue -InputObject $pane -Name 'parent_run_id' -Default '')
+            Goal                = [string](Get-PaneControlValue -InputObject $pane -Name 'goal' -Default '')
+            TaskType            = [string](Get-PaneControlValue -InputObject $pane -Name 'task_type' -Default '')
+            Priority            = [string](Get-PaneControlValue -InputObject $pane -Name 'priority' -Default '')
+            Blocking            = ConvertFrom-PaneControlBoolean -Value (Get-PaneControlValue -InputObject $pane -Name 'blocking' -Default $false) -Default $false
+            WriteScope          = @(ConvertFrom-PaneControlStringArray -Value (Get-PaneControlValue -InputObject $pane -Name 'write_scope' -Default @()))
+            ReadScope           = @(ConvertFrom-PaneControlStringArray -Value (Get-PaneControlValue -InputObject $pane -Name 'read_scope' -Default @()))
+            Constraints         = @(ConvertFrom-PaneControlStringArray -Value (Get-PaneControlValue -InputObject $pane -Name 'constraints' -Default @()))
+            ExpectedOutput      = [string](Get-PaneControlValue -InputObject $pane -Name 'expected_output' -Default '')
+            VerificationPlan    = @(ConvertFrom-PaneControlStringArray -Value (Get-PaneControlValue -InputObject $pane -Name 'verification_plan' -Default @()))
+            ReviewRequired      = ConvertFrom-PaneControlBoolean -Value (Get-PaneControlValue -InputObject $pane -Name 'review_required' -Default $false) -Default $false
+            ProviderTarget      = [string](Get-PaneControlValue -InputObject $pane -Name 'provider_target' -Default '')
+            AgentRole           = [string](Get-PaneControlValue -InputObject $pane -Name 'agent_role' -Default '')
+            TimeoutPolicy       = [string](Get-PaneControlValue -InputObject $pane -Name 'timeout_policy' -Default '')
+            HandoffRefs         = @(ConvertFrom-PaneControlStringArray -Value (Get-PaneControlValue -InputObject $pane -Name 'handoff_refs' -Default @()))
         }
     }
 

--- a/winsmux-core/scripts/pane-status.ps1
+++ b/winsmux-core/scripts/pane-status.ps1
@@ -171,6 +171,21 @@ function Get-PaneStatusRecords {
             ChangedFiles    = @($entry.ChangedFiles)
             LastEvent       = $entry.LastEvent
             LastEventAt     = $entry.LastEventAt
+            ParentRunId     = $entry.ParentRunId
+            Goal            = $entry.Goal
+            TaskType        = $entry.TaskType
+            Priority        = $entry.Priority
+            Blocking        = $entry.Blocking
+            WriteScope      = @($entry.WriteScope)
+            ReadScope       = @($entry.ReadScope)
+            Constraints     = @($entry.Constraints)
+            ExpectedOutput  = $entry.ExpectedOutput
+            VerificationPlan = @($entry.VerificationPlan)
+            ReviewRequired  = $entry.ReviewRequired
+            ProviderTarget  = $entry.ProviderTarget
+            AgentRole       = $entry.AgentRole
+            TimeoutPolicy   = $entry.TimeoutPolicy
+            HandoffRefs     = @($entry.HandoffRefs)
         }
     }
 


### PR DESCRIPTION
## Summary
- add first-class `run_packet` and `result_packet` projections to `winsmux runs --json` and `winsmux explain --json`
- extend manifest/status aggregation so run contract fields flow from pane metadata into run-centric surfaces
- update handoff and private planning so `v0.19.7` is tracked as complete

## Scope
- `scripts/winsmux-core.ps1`
- `winsmux-core/scripts/pane-control.ps1`
- `winsmux-core/scripts/pane-status.ps1`
- `tests/psmux-bridge.Tests.ps1`
- `docs/handoff.md`

## Validation
- `Invoke-Pester tests/psmux-bridge.Tests.ps1`
  - `103/103 PASS`
- PowerShell parser check for `scripts/winsmux-core.ps1`
- PowerShell parser check for `tests/psmux-bridge.Tests.ps1`

## Notes
- this slice keeps the contract minimal and focused on existing `runs` / `explain` surfaces rather than refactoring digest/inbox schemas
- private planning was synced outside the public repo after marking `TASK-253` done