### PR TITLE
feat(orchestra): start agent slot schema migration

### DIFF
--- a/.winsmux.yaml
+++ b/.winsmux.yaml
@@ -1,7 +1,6 @@
 agent: codex
 model: gpt-5.4
 external-commander: true
-worker-count: 6
 agent-slots:
   - slot-id: worker-1
     runtime-role: worker

--- a/.winsmux.yaml
+++ b/.winsmux.yaml
@@ -2,5 +2,36 @@ agent: codex
 model: gpt-5.4
 external-commander: true
 worker-count: 6
+agent-slots:
+  - slot-id: worker-1
+    runtime-role: worker
+    agent: codex
+    model: gpt-5.4
+    worktree-mode: managed
+  - slot-id: worker-2
+    runtime-role: worker
+    agent: codex
+    model: gpt-5.4
+    worktree-mode: managed
+  - slot-id: worker-3
+    runtime-role: worker
+    agent: codex
+    model: gpt-5.4
+    worktree-mode: managed
+  - slot-id: worker-4
+    runtime-role: worker
+    agent: codex
+    model: gpt-5.4
+    worktree-mode: managed
+  - slot-id: worker-5
+    runtime-role: worker
+    agent: codex
+    model: gpt-5.4
+    worktree-mode: managed
+  - slot-id: worker-6
+    runtime-role: worker
+    agent: codex
+    model: gpt-5.4
+    worktree-mode: managed
 
 roles: {}

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -1,6 +1,6 @@
 # Handoff
 
-> Updated: 2026-04-10T22:10:00+09:00
+> Updated: 2026-04-10T23:35:00+09:00
 > Source of truth: this file
 
 ## Current state
@@ -8,7 +8,8 @@
 - `v0.19.5`, `v0.19.6`, and `v0.19.7` are released.
 - `v0.19.6 hardening` is implemented, merged, released, and tracked as `100% (6/6)` in the external planning backlog/roadmap.
 - `v0.19.7 visible orchestration` is implemented, merged, released, and tracked as `100% (7/7)` in the external planning backlog/roadmap.
-- PR [#370](https://github.com/Sora-bluesky/winsmux/pull/370), PR [#371](https://github.com/Sora-bluesky/winsmux/pull/371), PR [#372](https://github.com/Sora-bluesky/winsmux/pull/372), PR [#374](https://github.com/Sora-bluesky/winsmux/pull/374), PR [#375](https://github.com/Sora-bluesky/winsmux/pull/375), PR [#376](https://github.com/Sora-bluesky/winsmux/pull/376), and PR [#380](https://github.com/Sora-bluesky/winsmux/pull/380) are merged into `main`.
+- `v0.19.8 External Operator & Agent Slots` is started in order; private planning now tracks `TASK-259` as done and `TASK-261` as the active repo-side slice.
+- PR [#370](https://github.com/Sora-bluesky/winsmux/pull/370), PR [#371](https://github.com/Sora-bluesky/winsmux/pull/371), PR [#372](https://github.com/Sora-bluesky/winsmux/pull/372), PR [#374](https://github.com/Sora-bluesky/winsmux/pull/374), PR [#375](https://github.com/Sora-bluesky/winsmux/pull/375), PR [#376](https://github.com/Sora-bluesky/winsmux/pull/376), PR [#379](https://github.com/Sora-bluesky/winsmux/pull/379), and PR [#380](https://github.com/Sora-bluesky/winsmux/pull/380) are merged into `main`.
 - Planning source of truth is externalized outside the public repository and syncs automatically into the private planning root.
 - `v0.21.x` private planning is aligned to a conversation-first Tauri operator shell, with Codex-App-like shell rules reflected in Figma and backlog notes.
 - `v0.24.x` private planning is split into schema, ledger, machine contract, cutover, and canary phases for Rust runtime convergence before `v1.0.0`.
@@ -23,7 +24,10 @@
 - Merged `TASK-246` via PR [#376](https://github.com/Sora-bluesky/winsmux/pull/376), adding `winsmux digest [--json]` and evidence digest fields for `explain`.
 - Merged `TASK-253` via PR [#380](https://github.com/Sora-bluesky/winsmux/pull/380), extending manifest/status/board aggregation into first-class `run_packet` and `result_packet` surfaces for `winsmux runs --json` and `winsmux explain --json`.
 - Released `v0.19.7` from tag `833249a` and updated the public GitHub Release body to the standardized English `/release-notes` format.
+- Merged `TASK-285` via PR [#379](https://github.com/Sora-bluesky/winsmux/pull/379), landing the first Tauri operator workspace shell scaffold on `main`.
 - Updated the private planning backlog/roadmap so `v0.19.8`, `v0.20.x`, `v0.21.x`, `v0.22.x`, and `v0.24.x` follow the `Operator / slot / provider / verification / security monitor / Tauri shell` model.
+- Updated `TASK-257` planning notes to be channel-agnostic (`external channel` instead of `Telegram` as the design anchor) and documented the Claude Code channels abstraction in `.references`.
+- Started the repo-side `TASK-261` slice on `codex/task261-agent-slots-20260410`, adding `agent_slots[]` parsing, worker-count synthesis, setup-wizard emission, and the default project slot array.
 - Reworked the Tauri prototype toward `TASK-285`: `winsmux-app` now renders an operator workspace shell scaffold with conversation timeline, sticky composer with inline attachments, context toggle, and a terminal utility drawer instead of a PTY-first full-window layout.
 - Added Figma high-fi anchors for `Operator Home / Inbox`, `Run Explain / Evidence`, and `Editor Secondary Surface`, and clarified how Explorer/Editor/Pane map into the new shell.
 
@@ -37,11 +41,12 @@
 - `TASK-253` focused regression passed before merge: `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `103/103 PASS`.
 - Current Tauri shell scaffold passes frontend build: `npm run build` in `winsmux-app`.
 - Composer scaffold matches the intended keyboard contract (`Enter` sends, `Shift+Enter` inserts newline, IME composition Enter does not send), and Context/Terminal toggles expose disclosure semantics via `aria-controls` plus `aria-expanded`.
+- Current `TASK-261` settings/layout regression passes locally: `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `105/105 PASS`.
 
 ## Next actions
 
-1. Land the repo-side `TASK-285` starter via PR [#379](https://github.com/Sora-bluesky/winsmux/pull/379) after rebasing it onto the now-released `v0.19.7` state.
-2. Start `v0.19.8` in order once the current Tauri starter branch is settled.
+1. Land the repo-side `TASK-261` starter (`agent_slots[]` settings migration) from `codex/task261-agent-slots-20260410`.
+2. Continue `v0.19.8` in order with `TASK-262`, then `TASK-263/264` once slot schema is stable.
 3. Continue `v0.21.0` with `TASK-292/293/294`, then align `TASK-107` implementation to the explicit secondary editor surface and workspace sidebar model.
 4. Preserve the private planning sync flow: user/agent visible, auto-synced, but not committed to the public repo.
 5. Track GitHub Actions Node runtime warnings and update workflows before the Node 24 switch becomes mandatory.

--- a/tests/psmux-bridge.Tests.ps1
+++ b/tests/psmux-bridge.Tests.ps1
@@ -232,7 +232,6 @@ terminal: tab
 agent: codex
 model: gpt-5.4
 external-commander: true
-worker-count: 2
 agent-slots:
   - slot-id: worker-1
     runtime-role: worker
@@ -302,6 +301,73 @@ roles:
         $commanderConfig.Agent | Should -Be 'codex'
         $commanderConfig.Model | Should -Be 'gpt-5.4'
     }
+
+    It 'fails closed when explicit agent slot entries are malformed' {
+@'
+agent: codex
+model: gpt-5.4
+external-commander: true
+agent-slots:
+  - runtime-role: worker
+    agent: codex
+'@ | Set-Content -Path (Join-Path $script:settingsTempRoot '.winsmux.yaml') -Encoding UTF8
+
+        Mock Get-WinsmuxOption { param($Name, $Default) return $null }
+
+        { Get-BridgeSettings } | Should -Throw '*Invalid agent_slots configuration*'
+    }
+
+    It 'fails closed when explicit agent slots contain duplicate slot ids' {
+@'
+agent: codex
+model: gpt-5.4
+external-commander: true
+agent-slots:
+  - slot-id: worker-1
+    runtime-role: worker
+    agent: codex
+    model: gpt-5.4
+  - slot-id: worker-1
+    runtime-role: worker
+    agent: codex
+    model: gpt-5.4
+'@ | Set-Content -Path (Join-Path $script:settingsTempRoot '.winsmux.yaml') -Encoding UTF8
+
+        Mock Get-WinsmuxOption { param($Name, $Default) return $null }
+
+        { Get-BridgeSettings } | Should -Throw '*duplicate slot_id*'
+    }
+
+    It 'reads project settings from an explicit root path even when the current location differs' {
+        $projectRoot = Join-Path $script:settingsTempRoot 'repo-root'
+        $otherRoot = Join-Path $script:settingsTempRoot 'other-root'
+        New-Item -ItemType Directory -Path $projectRoot -Force | Out-Null
+        New-Item -ItemType Directory -Path $otherRoot -Force | Out-Null
+
+@'
+agent: claude
+model: sonnet
+external-commander: true
+agent-slots:
+  - slot-id: worker-1
+    runtime-role: worker
+    agent: claude
+    model: sonnet
+'@ | Set-Content -Path (Join-Path $projectRoot '.winsmux.yaml') -Encoding UTF8
+
+        Mock Get-WinsmuxOption { param($Name, $Default) return $null }
+
+        Push-Location $otherRoot
+        try {
+            $settings = Get-BridgeSettings -RootPath $projectRoot
+        } finally {
+            Pop-Location
+        }
+
+        $settings.agent | Should -Be 'claude'
+        $settings.model | Should -Be 'sonnet'
+        $settings.agent_slots.Count | Should -Be 1
+    }
 }
 
 Describe 'Get-OrchestraLayoutSettings' {
@@ -335,9 +401,11 @@ Describe 'Get-OrchestraLayoutSettings' {
             worker_count       = 2
             agent_slots        = @(
                 [ordered]@{ slot_id = 'worker-1'; runtime_role = 'worker'; agent = 'codex'; model = 'gpt-5.4'; worktree_mode = 'managed' },
-                [ordered]@{ slot_id = 'worker-2'; runtime_role = 'worker'; agent = 'claude'; model = 'sonnet'; worktree_mode = 'managed' },
-                [ordered]@{ slot_id = 'worker-3'; runtime_role = 'worker'; agent = 'gemini'; model = 'gemini-2.5-pro'; worktree_mode = 'managed' }
+                [ordered]@{ slot_id = 'worker-2'; runtime_role = 'worker'; agent = 'codex'; model = 'gpt-5.4'; worktree_mode = 'managed' },
+                [ordered]@{ slot_id = 'worker-3'; runtime_role = 'worker'; agent = 'codex'; model = 'gpt-5.4'; worktree_mode = 'managed' }
             )
+            agent             = 'codex'
+            model             = 'gpt-5.4'
             legacy_role_layout = $false
             commanders         = 0
             builders           = 0
@@ -349,6 +417,49 @@ Describe 'Get-OrchestraLayoutSettings' {
         $layout.LegacyRoleLayout | Should -Be $false
         $layout.Commanders | Should -Be 0
         $layout.Workers | Should -Be 3
+    }
+
+    It 'rejects unsupported per-slot runtime overrides until slot runtime wiring exists' {
+        {
+            Get-OrchestraLayoutSettings -Settings ([ordered]@{
+                external_commander = $true
+                worker_count       = 2
+                agent_slots        = @(
+                    [ordered]@{ slot_id = 'worker-1'; runtime_role = 'worker'; agent = 'codex'; model = 'gpt-5.4'; worktree_mode = 'managed' },
+                    [ordered]@{ slot_id = 'worker-2'; runtime_role = 'worker'; agent = 'claude'; model = 'sonnet'; worktree_mode = 'managed' }
+                )
+                agent              = 'codex'
+                model              = 'gpt-5.4'
+                legacy_role_layout = $false
+                commanders         = 0
+                builders           = 0
+                researchers        = 0
+                reviewers          = 0
+            })
+        } | Should -Throw '*per-slot agent overrides are not supported yet at runtime*'
+    }
+
+    It 'writes project settings to an explicit root path and omits worker_count when agent slots are present' {
+        $projectRoot = Join-Path $script:settingsTempRoot 'repo-root'
+        New-Item -ItemType Directory -Path $projectRoot -Force | Out-Null
+
+        Save-BridgeSettings -Scope project -RootPath $projectRoot -Settings ([ordered]@{
+            agent              = 'codex'
+            model              = 'gpt-5.4'
+            external_commander = $true
+            worker_count       = 2
+            agent_slots        = @(
+                [ordered]@{ slot_id = 'worker-1'; runtime_role = 'worker'; agent = 'codex'; model = 'gpt-5.4'; worktree_mode = 'managed' },
+                [ordered]@{ slot_id = 'worker-2'; runtime_role = 'worker'; agent = 'codex'; model = 'gpt-5.4'; worktree_mode = 'managed' }
+            )
+            vault_keys         = @('GH_TOKEN')
+        })
+
+        $projectConfigPath = Join-Path $projectRoot '.winsmux.yaml'
+        Test-Path $projectConfigPath | Should -Be $true
+        $projectConfig = Get-Content -Raw -Path $projectConfigPath -Encoding UTF8
+        $projectConfig | Should -Match 'agent_slots:'
+        $projectConfig | Should -Not -Match 'worker_count:'
     }
 
     It 'preserves legacy role layouts when explicit legacy counts are configured' {

--- a/tests/psmux-bridge.Tests.ps1
+++ b/tests/psmux-bridge.Tests.ps1
@@ -174,6 +174,9 @@ Describe 'Get-BridgeSettings' {
         $settings.legacy_role_layout | Should -Be $false
         $settings.commanders | Should -Be 0
         $settings.worker_count | Should -Be 6
+        $settings.agent_slots.Count | Should -Be 6
+        $settings.agent_slots[0].slot_id | Should -Be 'worker-1'
+        $settings.agent_slots[0].runtime_role | Should -Be 'worker'
         $settings.builders | Should -Be 0
         $settings.researchers | Should -Be 0
         $settings.reviewers | Should -Be 0
@@ -222,6 +225,41 @@ terminal: tab
         $settings.reviewers | Should -Be 3
         $settings.terminal | Should -Be 'tab'
         $settings.vault_keys | Should -Be @('GH_TOKEN', 'OPENAI_API_KEY')
+    }
+
+    It 'parses agent slot arrays and treats them as the source of truth for managed slot count' {
+@'
+agent: codex
+model: gpt-5.4
+external-commander: true
+worker-count: 2
+agent-slots:
+  - slot-id: worker-1
+    runtime-role: worker
+    agent: codex
+    model: gpt-5.4
+    worktree-mode: managed
+  - slot-id: worker-2
+    runtime-role: worker
+    agent: claude
+    model: sonnet
+    worktree-mode: managed
+  - slot-id: worker-3
+    runtime-role: worker
+    agent: gemini
+    model: gemini-2.5-pro
+    worktree-mode: managed
+'@ | Set-Content -Path (Join-Path $script:settingsTempRoot '.winsmux.yaml') -Encoding UTF8
+
+        Mock Get-WinsmuxOption { param($Name, $Default) return $null }
+
+        $settings = Get-BridgeSettings
+
+        $settings.worker_count | Should -Be 3
+        $settings.agent_slots.Count | Should -Be 3
+        $settings.agent_slots[0].slot_id | Should -Be 'worker-1'
+        $settings.agent_slots[1].agent | Should -Be 'claude'
+        $settings.agent_slots[2].model | Should -Be 'gemini-2.5-pro'
     }
 
     It 'parses per-role agent and model overrides and falls back to global settings' {
@@ -289,6 +327,28 @@ Describe 'Get-OrchestraLayoutSettings' {
         $layout.Builders | Should -Be 0
         $layout.Researchers | Should -Be 0
         $layout.Reviewers | Should -Be 0
+    }
+
+    It 'prefers explicit agent slots over worker_count when deriving managed slot count' {
+        $layout = Get-OrchestraLayoutSettings -Settings ([ordered]@{
+            external_commander = $true
+            worker_count       = 2
+            agent_slots        = @(
+                [ordered]@{ slot_id = 'worker-1'; runtime_role = 'worker'; agent = 'codex'; model = 'gpt-5.4'; worktree_mode = 'managed' },
+                [ordered]@{ slot_id = 'worker-2'; runtime_role = 'worker'; agent = 'claude'; model = 'sonnet'; worktree_mode = 'managed' },
+                [ordered]@{ slot_id = 'worker-3'; runtime_role = 'worker'; agent = 'gemini'; model = 'gemini-2.5-pro'; worktree_mode = 'managed' }
+            )
+            legacy_role_layout = $false
+            commanders         = 0
+            builders           = 0
+            researchers        = 0
+            reviewers          = 0
+        })
+
+        $layout.ExternalCommander | Should -Be $true
+        $layout.LegacyRoleLayout | Should -Be $false
+        $layout.Commanders | Should -Be 0
+        $layout.Workers | Should -Be 3
     }
 
     It 'preserves legacy role layouts when explicit legacy counts are configured' {

--- a/winsmux-core/scripts/orchestra-start.ps1
+++ b/winsmux-core/scripts/orchestra-start.ps1
@@ -283,6 +283,14 @@ function Get-OrchestraLayoutSettings {
 
     $commanders = [int]$Settings.commanders
     $workers = [int]$Settings.worker_count
+    $agentSlots = @()
+    if ($Settings -is [System.Collections.IDictionary]) {
+        if ($Settings.Contains('agent_slots')) {
+            $agentSlots = @($Settings.agent_slots)
+        }
+    } elseif ($null -ne $Settings -and $null -ne $Settings.PSObject -and ($Settings.PSObject.Properties.Name -contains 'agent_slots')) {
+        $agentSlots = @($Settings.agent_slots)
+    }
     $builders = [int]$Settings.builders
     $researchers = [int]$Settings.researchers
     $reviewers = [int]$Settings.reviewers
@@ -305,6 +313,9 @@ function Get-OrchestraLayoutSettings {
     }
 
     $managedCommanders = if ($externalCommander) { 0 } else { 1 }
+    if ($agentSlots.Count -gt 0) {
+        $workers = $agentSlots.Count
+    }
     if ($workers -lt 1) {
         throw "worker_count must be 1 or greater in external commander mode (got $workers)."
     }

--- a/winsmux-core/scripts/orchestra-start.ps1
+++ b/winsmux-core/scripts/orchestra-start.ps1
@@ -300,6 +300,32 @@ function Get-OrchestraLayoutSettings {
     $legacyCount = $commanders + $builders + $researchers + $reviewers
     $useLegacyLayout = $legacyRoleLayout -or $legacyCount -gt 0
 
+    if (-not $useLegacyLayout -and $agentSlots.Count -gt 0) {
+        foreach ($slot in $agentSlots) {
+            $slotId = [string]$slot.slot_id
+            $slotRole = [string]$slot.runtime_role
+            $slotAgent = [string]$slot.agent
+            $slotModel = [string]$slot.model
+            $slotWorktreeMode = [string]$slot.worktree_mode
+
+            if (-not [string]::IsNullOrWhiteSpace($slotRole) -and $slotRole -ne 'worker') {
+                throw "agent_slots runtime_role overrides are not supported yet at runtime (slot '$slotId' requested '$slotRole')."
+            }
+
+            if (-not [string]::IsNullOrWhiteSpace($slotWorktreeMode) -and $slotWorktreeMode -ne 'managed') {
+                throw "agent_slots worktree_mode overrides are not supported yet at runtime (slot '$slotId' requested '$slotWorktreeMode')."
+            }
+
+            if (-not [string]::IsNullOrWhiteSpace($slotAgent) -and $slotAgent -ne [string]$Settings.agent) {
+                throw "agent_slots per-slot agent overrides are not supported yet at runtime (slot '$slotId' requested '$slotAgent')."
+            }
+
+            if (-not [string]::IsNullOrWhiteSpace($slotModel) -and $slotModel -ne [string]$Settings.model) {
+                throw "agent_slots per-slot model overrides are not supported yet at runtime (slot '$slotId' requested '$slotModel')."
+            }
+        }
+    }
+
     if ($useLegacyLayout) {
         return [ordered]@{
             ExternalCommander = $false
@@ -1086,9 +1112,9 @@ if ($MyInvocation.InvocationName -ne '.') {
             exit 1
         }
 
-        $settings = Get-BridgeSettings
-        $layoutSettings = Get-OrchestraLayoutSettings -Settings $settings
         $projectDir = Get-ProjectDir
+        $settings = Get-BridgeSettings -RootPath $projectDir
+        $layoutSettings = Get-OrchestraLayoutSettings -Settings $settings
         Initialize-WinsmuxLog -ProjectDir $projectDir -SessionName $sessionName | Out-Null
         Write-WinsmuxLog -Level INFO -Event 'preflight.settings.loaded' -Message 'Loaded orchestra settings.' -Data @{
             agent              = $settings.agent

--- a/winsmux-core/scripts/settings.ps1
+++ b/winsmux-core/scripts/settings.ps1
@@ -103,7 +103,13 @@ function Get-BridgeSettingsDefaults {
 }
 
 function Get-BridgeProjectSettingsPath {
-    return Join-Path (Get-Location).Path $script:BridgeSettingsFileName
+    param([string]$RootPath)
+
+    if ([string]::IsNullOrWhiteSpace($RootPath)) {
+        $RootPath = (Get-Location).Path
+    }
+
+    return Join-Path $RootPath $script:BridgeSettingsFileName
 }
 
 function Remove-BridgeYamlComment {
@@ -348,7 +354,9 @@ function ConvertFrom-BridgeManualYaml {
 }
 
 function Read-BridgeProjectSettings {
-    $path = Get-BridgeProjectSettingsPath
+    param([string]$RootPath)
+
+    $path = Get-BridgeProjectSettingsPath -RootPath $RootPath
     if (-not (Test-Path $path)) {
         return @{}
     }
@@ -608,6 +616,8 @@ function Read-BridgeGlobalSettings {
 }
 
 function Get-BridgeSettings {
+    param([string]$RootPath)
+
     $defaults = Get-BridgeSettingsDefaults
     $settings = [ordered]@{}
 
@@ -630,7 +640,26 @@ function Get-BridgeSettings {
         }
     }
 
-    $projectSettings = ConvertTo-BridgeSettingsSource (Read-BridgeProjectSettings)
+    $rawProjectSettings = Read-BridgeProjectSettings -RootPath $RootPath
+    $projectSettings = ConvertTo-BridgeSettingsSource $rawProjectSettings
+
+    if ($rawProjectSettings -is [System.Collections.IDictionary] -and $rawProjectSettings.Contains('agent_slots')) {
+        $rawSlotEntries = @()
+        $rawSlotValue = $rawProjectSettings['agent_slots']
+        if ($rawSlotValue -is [System.Collections.IEnumerable] -and $rawSlotValue -isnot [string]) {
+            $rawSlotEntries = @($rawSlotValue)
+        }
+
+        if (-not $projectSettings.Contains('agent_slots')) {
+            throw 'Invalid agent_slots configuration: every slot entry must include at least slot_id.'
+        }
+
+        $normalizedSlotEntries = @($projectSettings['agent_slots'])
+        if ($rawSlotEntries.Count -gt 0 -and $normalizedSlotEntries.Count -ne $rawSlotEntries.Count) {
+            throw 'Invalid agent_slots configuration: every slot entry must include at least slot_id.'
+        }
+    }
+
     foreach ($key in $projectSettings.Keys) {
         $value = $projectSettings[$key]
         if ($value -is [System.Array]) {
@@ -642,6 +671,20 @@ function Get-BridgeSettings {
 
     if ($settings.agent_slots -isnot [System.Array]) {
         $settings.agent_slots = @()
+    }
+
+    $slotIds = @{}
+    foreach ($slot in @($settings.agent_slots)) {
+        if ([string]::IsNullOrWhiteSpace([string]$slot.slot_id)) {
+            throw 'Invalid agent_slots configuration: slot_id must not be empty.'
+        }
+
+        $slotId = [string]$slot.slot_id
+        if ($slotIds.ContainsKey($slotId)) {
+            throw "Invalid agent_slots configuration: duplicate slot_id '$slotId'."
+        }
+
+        $slotIds[$slotId] = $true
     }
 
     $legacyCount = [int]$settings.commanders + [int]$settings.builders + [int]$settings.researchers + [int]$settings.reviewers
@@ -707,14 +750,17 @@ function Get-RoleAgentConfig {
 }
 
 function Get-BridgeSetting {
-    param([Parameter(Mandatory = $true)][string]$Name)
+    param(
+        [Parameter(Mandatory = $true)][string]$Name,
+        [string]$RootPath
+    )
 
     $key = $Name -replace '-', '_'
     if (-not $script:BridgeSettingsSchema.Contains($key)) {
         throw "Unknown bridge setting: $Name"
     }
 
-    return (Get-BridgeSettings)[$key]
+    return (Get-BridgeSettings -RootPath $RootPath)[$key]
 }
 
 function ConvertTo-BridgeYamlScalar {
@@ -735,17 +781,23 @@ function ConvertTo-BridgeYamlScalar {
 function Save-BridgeSettings {
     param(
         [Parameter(Mandatory = $true)][ValidateSet('project', 'global')][string]$Scope,
-        [Parameter(Mandatory = $true)][hashtable]$Settings
+        [Parameter(Mandatory = $true)][hashtable]$Settings,
+        [string]$RootPath
     )
 
     $normalized = ConvertTo-BridgeSettingsSource $Settings
 
     if ($Scope -eq 'project') {
-        $path = Get-BridgeProjectSettingsPath
+        $path = Get-BridgeProjectSettingsPath -RootPath $RootPath
         $lines = [System.Collections.Generic.List[string]]::new()
+        $hasAgentSlots = @($normalized.agent_slots).Count -gt 0
 
         foreach ($key in $script:BridgeSettingsSchema.Keys) {
             if (-not $normalized.Contains($key)) {
+                continue
+            }
+
+            if ($key -eq 'worker_count' -and $hasAgentSlots) {
                 continue
             }
 

--- a/winsmux-core/scripts/settings.ps1
+++ b/winsmux-core/scripts/settings.ps1
@@ -19,6 +19,7 @@ $script:BridgeSettingsSchema = [ordered]@{
     model               = @{ Type = 'string';   Default = 'gpt-5.4';     Option = '@bridge-model' }
     external_commander  = @{ Type = 'bool';     Default = $true;         Option = '@bridge-external-commander' }
     worker_count        = @{ Type = 'int';      Default = 6;             Option = '@bridge-worker-count' }
+    agent_slots         = @{ Type = 'slotlist'; Default = @();           Option = $null }
     legacy_role_layout  = @{ Type = 'bool';     Default = $false;        Option = '@bridge-legacy-role-layout' }
     commanders          = @{ Type = 'int';      Default = 0;             Option = '@bridge-commanders' }
     builders            = @{ Type = 'int';      Default = 0;             Option = '@bridge-builders' }
@@ -176,11 +177,81 @@ function ConvertFrom-BridgeInlineList {
     )
 }
 
+function ConvertTo-BridgeSlotEntry {
+    param([AllowNull()]$Value)
+
+    if ($null -eq $Value) {
+        return $null
+    }
+
+    $pairs = @()
+    if ($Value -is [System.Collections.IDictionary]) {
+        $pairs = $Value.GetEnumerator()
+    } elseif ($null -ne $Value -and $null -ne $Value.PSObject) {
+        $pairs = $Value.PSObject.Properties | ForEach-Object {
+            [PSCustomObject]@{
+                Key = $_.Name
+                Value = $_.Value
+            }
+        }
+    } else {
+        return $null
+    }
+
+    $slot = [ordered]@{}
+    foreach ($pair in $pairs) {
+        $key = $pair.Key.ToString() -replace '-', '_'
+        if ($key -notin @('slot_id', 'runtime_role', 'agent', 'model', 'worktree_mode')) {
+            continue
+        }
+
+        $text = ConvertFrom-BridgeYamlScalar $pair.Value
+        if ([string]::IsNullOrWhiteSpace($text)) {
+            continue
+        }
+
+        $slot[$key] = $text
+    }
+
+    if (-not $slot.Contains('slot_id')) {
+        return $null
+    }
+
+    if (-not $slot.Contains('runtime_role')) {
+        $slot.runtime_role = 'worker'
+    }
+
+    return $slot
+}
+
+function New-BridgeManagedAgentSlots {
+    param(
+        [Parameter(Mandatory = $true)][int]$Count,
+        [Parameter(Mandatory = $true)][string]$Agent,
+        [Parameter(Mandatory = $true)][string]$Model
+    )
+
+    $slots = @()
+    for ($index = 1; $index -le $Count; $index++) {
+        $slots += [ordered]@{
+            slot_id       = "worker-$index"
+            runtime_role  = 'worker'
+            agent         = $Agent
+            model         = $Model
+            worktree_mode = 'managed'
+        }
+    }
+
+    return @($slots)
+}
+
 function ConvertFrom-BridgeManualYaml {
     param([Parameter(Mandatory = $true)][string]$Content)
 
     $settings = [ordered]@{}
     $currentListKey = $null
+    $currentSlotListKey = $null
+    $currentSlotEntry = $null
     $currentMapKey = $null
     $currentMapEntryKey = $null
     $lineNumber = 0
@@ -189,6 +260,21 @@ function ConvertFrom-BridgeManualYaml {
         $lineNumber++
         $line = Remove-BridgeYamlComment $rawLine
         if ([string]::IsNullOrWhiteSpace($line)) {
+            continue
+        }
+
+        if ($null -ne $currentSlotListKey -and $line -match '^\s*-\s*([A-Za-z_][A-Za-z0-9_-]*)\s*:\s*(.*?)\s*$') {
+            $slotEntry = [ordered]@{}
+            $slotKey = $Matches[1] -replace '-', '_'
+            $slotEntry[$slotKey] = ConvertFrom-BridgeYamlScalar $Matches[2]
+            $settings[$currentSlotListKey] += @($slotEntry)
+            $currentSlotEntry = $slotEntry
+            continue
+        }
+
+        if ($null -ne $currentSlotListKey -and $null -ne $currentSlotEntry -and $line -match '^\s{4}([A-Za-z_][A-Za-z0-9_-]*)\s*:\s*(.*?)\s*$') {
+            $slotKey = $Matches[1] -replace '-', '_'
+            $currentSlotEntry[$slotKey] = ConvertFrom-BridgeYamlScalar $Matches[2]
             continue
         }
 
@@ -202,6 +288,8 @@ function ConvertFrom-BridgeManualYaml {
         }
 
         $currentListKey = $null
+        $currentSlotListKey = $null
+        $currentSlotEntry = $null
         if ($null -ne $currentMapKey -and $line -match '^\s{2}([A-Za-z_][A-Za-z0-9_-]*)\s*:\s*$') {
             $currentMapEntryKey = $Matches[1] -replace '-', '_'
             if (-not $settings[$currentMapKey].Contains($currentMapEntryKey)) {
@@ -230,12 +318,19 @@ function ConvertFrom-BridgeManualYaml {
         }
 
         if ([string]::IsNullOrWhiteSpace($value)) {
-            if ($script:BridgeSettingsSchema[$key].Type -eq 'map') {
-                $settings[$key] = [ordered]@{}
-                $currentMapKey = $key
-            } else {
-                $settings[$key] = @()
-                $currentListKey = $key
+            switch ($script:BridgeSettingsSchema[$key].Type) {
+                'map' {
+                    $settings[$key] = [ordered]@{}
+                    $currentMapKey = $key
+                }
+                'slotlist' {
+                    $settings[$key] = @()
+                    $currentSlotListKey = $key
+                }
+                default {
+                    $settings[$key] = @()
+                    $currentListKey = $key
+                }
             }
             continue
         }
@@ -426,6 +521,23 @@ function Test-BridgeSettingValue {
             $NormalizedValue.Value = $map
             return $true
         }
+        'slotlist' {
+            $slots = @()
+
+            if ($Value -isnot [System.Collections.IEnumerable] -or $Value -is [string]) {
+                return $false
+            }
+
+            foreach ($slotValue in $Value) {
+                $slot = ConvertTo-BridgeSlotEntry $slotValue
+                if ($null -ne $slot) {
+                    $slots += $slot
+                }
+            }
+
+            $NormalizedValue.Value = @($slots)
+            return $true
+        }
         default {
             return $false
         }
@@ -528,6 +640,21 @@ function Get-BridgeSettings {
         }
     }
 
+    if ($settings.agent_slots -isnot [System.Array]) {
+        $settings.agent_slots = @()
+    }
+
+    $legacyCount = [int]$settings.commanders + [int]$settings.builders + [int]$settings.researchers + [int]$settings.reviewers
+    $useLegacyLayout = [bool]$settings.legacy_role_layout -or $legacyCount -gt 0
+
+    if (@($settings.agent_slots).Count -eq 0 -and -not $useLegacyLayout -and [bool]$settings.external_commander -and [int]$settings.worker_count -gt 0) {
+        $settings.agent_slots = New-BridgeManagedAgentSlots -Count ([int]$settings.worker_count) -Agent ([string]$settings.agent) -Model ([string]$settings.model)
+    }
+
+    if (@($settings.agent_slots).Count -gt 0 -and -not $useLegacyLayout) {
+        $settings.worker_count = @($settings.agent_slots).Count
+    }
+
     return $settings
 }
 
@@ -625,8 +752,28 @@ function Save-BridgeSettings {
             $value = $normalized[$key]
             if ($value -is [System.Array]) {
                 $lines.Add("${key}:")
-                foreach ($item in $value) {
-                    $lines.Add("  - $(ConvertTo-BridgeYamlScalar $item)")
+                if ($script:BridgeSettingsSchema[$key].Type -eq 'slotlist') {
+                    foreach ($item in $value) {
+                        $slot = ConvertTo-BridgeSlotEntry $item
+                        if ($null -eq $slot) {
+                            continue
+                        }
+
+                        $firstProperty = $true
+                        foreach ($slotEntry in $slot.GetEnumerator()) {
+                            if ($firstProperty) {
+                                $lines.Add("  - $($slotEntry.Key): $(ConvertTo-BridgeYamlScalar $slotEntry.Value)")
+                                $firstProperty = $false
+                                continue
+                            }
+
+                            $lines.Add("    $($slotEntry.Key): $(ConvertTo-BridgeYamlScalar $slotEntry.Value)")
+                        }
+                    }
+                } else {
+                    foreach ($item in $value) {
+                        $lines.Add("  - $(ConvertTo-BridgeYamlScalar $item)")
+                    }
                 }
             } elseif ($value -is [System.Collections.IDictionary]) {
                 $lines.Add("${key}:")

--- a/winsmux-core/scripts/setup-wizard.ps1
+++ b/winsmux-core/scripts/setup-wizard.ps1
@@ -5,6 +5,8 @@ param()
 
 $ErrorActionPreference = 'Stop'
 
+. (Join-Path $PSScriptRoot 'settings.ps1')
+
 function Get-WinsmuxBin {
     foreach ($candidate in @('winsmux', 'pmux', 'tmux')) {
         $command = Get-Command $candidate -ErrorAction SilentlyContinue | Select-Object -First 1
@@ -172,16 +174,18 @@ Write-Host ''
 
 $agentCli = Read-AgentCli -Default 'codex'
 $model = Read-DefaultValue -Prompt 'Model' -Default 'gpt-5.4'
-$externalCommander = Read-YesNo -Prompt 'Use an external Commander terminal?' -Default $true
+$externalCommander = Read-YesNo -Prompt 'Use an external Operator terminal?' -Default $true
 $legacyRoleLayout = $false
 $commanders = 0
 $workerCount = 6
+$agentSlots = @()
 $builders = 0
 $researchers = 0
 $reviewers = 0
 
 if ($externalCommander) {
     $workerCount = Read-PositiveInt -Prompt 'Managed worker pane count' -Default 6
+    $agentSlots = New-BridgeManagedAgentSlots -Count $workerCount -Agent $agentCli -Model $model
 } else {
     $legacyRoleLayout = Read-YesNo -Prompt 'Use legacy role layout (Commander/Builder/Researcher/Reviewer panes)?' -Default $true
     if ($legacyRoleLayout) {
@@ -190,8 +194,9 @@ if ($externalCommander) {
         $researchers = Read-PositiveInt -Prompt 'Researchers count' -Default 1
         $reviewers = Read-PositiveInt -Prompt 'Reviewers count' -Default 1
     } else {
-        $commanders = Read-PositiveInt -Prompt 'Embedded commander count' -Default 1
+        $commanders = Read-PositiveInt -Prompt 'Embedded operator count' -Default 1
         $workerCount = Read-PositiveInt -Prompt 'Managed worker pane count' -Default 6
+        $agentSlots = New-BridgeManagedAgentSlots -Count $workerCount -Agent $agentCli -Model $model
     }
 }
 $storeVault = Read-YesNo -Prompt 'Store GH_TOKEN in the winsmux vault?' -Default $false
@@ -205,6 +210,20 @@ Set-WinsmuxOption -WinsmuxBin $winsmuxBin -OptionName '@bridge-worker-count' -Op
 Set-WinsmuxOption -WinsmuxBin $winsmuxBin -OptionName '@bridge-builders' -OptionValue $builders.ToString()
 Set-WinsmuxOption -WinsmuxBin $winsmuxBin -OptionName '@bridge-researchers' -OptionValue $researchers.ToString()
 Set-WinsmuxOption -WinsmuxBin $winsmuxBin -OptionName '@bridge-reviewers' -OptionValue $reviewers.ToString()
+
+Save-BridgeSettings -Scope project -Settings ([ordered]@{
+    agent               = $agentCli
+    model               = $model
+    external_commander  = $externalCommander
+    worker_count        = $workerCount
+    agent_slots         = @($agentSlots)
+    legacy_role_layout  = $legacyRoleLayout
+    commanders          = $commanders
+    builders            = $builders
+    researchers         = $researchers
+    reviewers           = $reviewers
+    vault_keys          = @('GH_TOKEN')
+})
 
 $vaultStored = $false
 if ($storeVault) {
@@ -228,4 +247,5 @@ Write-Host "  @bridge-worker-count: $workerCount"
 Write-Host "  @bridge-builders:     $builders"
 Write-Host "  @bridge-researchers:  $researchers"
 Write-Host "  @bridge-reviewers:    $reviewers"
+Write-Host "  project agent_slots:  $(@($agentSlots).Count)"
 Write-Host "  GH_TOKEN stored:      $(if ($vaultStored) { 'yes' } else { 'no' })"

--- a/winsmux-core/scripts/setup-wizard.ps1
+++ b/winsmux-core/scripts/setup-wizard.ps1
@@ -199,6 +199,10 @@ if ($externalCommander) {
         $agentSlots = New-BridgeManagedAgentSlots -Count $workerCount -Agent $agentCli -Model $model
     }
 }
+
+function Get-SetupWizardProjectRoot {
+    return [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\..'))
+}
 $storeVault = Read-YesNo -Prompt 'Store GH_TOKEN in the winsmux vault?' -Default $false
 
 Set-WinsmuxOption -WinsmuxBin $winsmuxBin -OptionName '@bridge-agent' -OptionValue $agentCli
@@ -223,7 +227,7 @@ Save-BridgeSettings -Scope project -Settings ([ordered]@{
     researchers         = $researchers
     reviewers           = $reviewers
     vault_keys          = @('GH_TOKEN')
-})
+}) -RootPath (Get-SetupWizardProjectRoot)
 
 $vaultStored = $false
 if ($storeVault) {


### PR DESCRIPTION
## Summary
- add `agent_slots[]` parsing and synthesis as the first TASK-261 settings migration slice
- derive managed slot count from explicit slot arrays while preserving `worker_count` as compatibility sugar
- update the setup wizard to emit project-level slot arrays for external operator mode

## Validation
- `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `105/105 PASS`
- PowerShell parser checks for `settings.ps1`, `orchestra-start.ps1`, `setup-wizard.ps1`, and `psmux-bridge.Tests.ps1`

## Notes
- private planning was updated separately: `TASK-259` is now done and `v0.19.8` is `20% (1/5)`
- `TASK-257` notes were made channel-agnostic (`external channel` instead of Telegram as the design anchor)
- reference added locally: `2026-04-10-claude-code-channels-abstraction-for-winsmux.md`
