### PR TITLE
feat(orchestra): wire slot-level provider and model selection

### DIFF
--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -1,6 +1,6 @@
 # Handoff
 
-> Updated: 2026-04-10T23:35:00+09:00
+> Updated: 2026-04-10T23:59:00+09:00
 > Source of truth: this file
 
 ## Current state
@@ -8,7 +8,7 @@
 - `v0.19.5`, `v0.19.6`, and `v0.19.7` are released.
 - `v0.19.6 hardening` is implemented, merged, released, and tracked as `100% (6/6)` in the external planning backlog/roadmap.
 - `v0.19.7 visible orchestration` is implemented, merged, released, and tracked as `100% (7/7)` in the external planning backlog/roadmap.
-- `v0.19.8 External Operator & Agent Slots` is started in order; private planning now tracks `TASK-259` as done and `TASK-261` as the active repo-side slice.
+- `v0.19.8 External Operator & Agent Slots` is started in order; private planning now tracks `TASK-259` and `TASK-261` as done, with `TASK-262` as the next repo-side slice.
 - PR [#370](https://github.com/Sora-bluesky/winsmux/pull/370), PR [#371](https://github.com/Sora-bluesky/winsmux/pull/371), PR [#372](https://github.com/Sora-bluesky/winsmux/pull/372), PR [#374](https://github.com/Sora-bluesky/winsmux/pull/374), PR [#375](https://github.com/Sora-bluesky/winsmux/pull/375), PR [#376](https://github.com/Sora-bluesky/winsmux/pull/376), PR [#379](https://github.com/Sora-bluesky/winsmux/pull/379), and PR [#380](https://github.com/Sora-bluesky/winsmux/pull/380) are merged into `main`.
 - Planning source of truth is externalized outside the public repository and syncs automatically into the private planning root.
 - `v0.21.x` private planning is aligned to a conversation-first Tauri operator shell, with Codex-App-like shell rules reflected in Figma and backlog notes.
@@ -28,6 +28,8 @@
 - Updated the private planning backlog/roadmap so `v0.19.8`, `v0.20.x`, `v0.21.x`, `v0.22.x`, and `v0.24.x` follow the `Operator / slot / provider / verification / security monitor / Tauri shell` model.
 - Updated `TASK-257` planning notes to be channel-agnostic (`external channel` instead of `Telegram` as the design anchor) and documented the Claude Code channels abstraction in `.references`.
 - Started the repo-side `TASK-261` slice on `codex/task261-agent-slots-20260410`, adding `agent_slots[]` parsing, worker-count synthesis, setup-wizard emission, and the default project slot array.
+- Merged the repo-side `TASK-261` slice via PR [#381](https://github.com/Sora-bluesky/winsmux/pull/381), making `agent_slots[]` the project settings source of truth, rejecting malformed slot definitions fail-closed, and binding setup-wizard / orchestra-start to the canonical project root.
+- Started the repo-side `TASK-262` slice on `codex/task262-slot-provider-model-20260410`, wiring slot-level `agent/model` selection into orchestra startup, restart plans, monitor cycles, and pane scaling paths.
 - Reworked the Tauri prototype toward `TASK-285`: `winsmux-app` now renders an operator workspace shell scaffold with conversation timeline, sticky composer with inline attachments, context toggle, and a terminal utility drawer instead of a PTY-first full-window layout.
 - Added Figma high-fi anchors for `Operator Home / Inbox`, `Run Explain / Evidence`, and `Editor Secondary Surface`, and clarified how Explorer/Editor/Pane map into the new shell.
 
@@ -41,15 +43,17 @@
 - `TASK-253` focused regression passed before merge: `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `103/103 PASS`.
 - Current Tauri shell scaffold passes frontend build: `npm run build` in `winsmux-app`.
 - Composer scaffold matches the intended keyboard contract (`Enter` sends, `Shift+Enter` inserts newline, IME composition Enter does not send), and Context/Terminal toggles expose disclosure semantics via `aria-controls` plus `aria-expanded`.
-- Current `TASK-261` settings/layout regression passes locally: `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `105/105 PASS`.
+- `TASK-261` settings/layout regression passed before merge: `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `110/110 PASS`.
+- Current `TASK-262` slot wiring regression passes locally: `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `113/113 PASS`.
 
 ## Next actions
 
-1. Land the repo-side `TASK-261` starter (`agent_slots[]` settings migration) from `codex/task261-agent-slots-20260410`.
-2. Continue `v0.19.8` in order with `TASK-262`, then `TASK-263/264` once slot schema is stable.
+1. Land the repo-side `TASK-262` slice (`slot-level provider/model wiring`) from `codex/task262-slot-provider-model-20260410`.
+2. Continue `v0.19.8` in order with `TASK-263/264` once slot schema and slot-level wiring are stable.
 3. Continue `v0.21.0` with `TASK-292/293/294`, then align `TASK-107` implementation to the explicit secondary editor surface and workspace sidebar model.
 4. Preserve the private planning sync flow: user/agent visible, auto-synced, but not committed to the public repo.
 5. Track GitHub Actions Node runtime warnings and update workflows before the Node 24 switch becomes mandatory.
+6. Run the next retro-review tranche over recent merged PRs after each milestone-close sequence.
 
 ## Notes
 

--- a/tests/psmux-bridge.Tests.ps1
+++ b/tests/psmux-bridge.Tests.ps1
@@ -302,6 +302,40 @@ roles:
         $commanderConfig.Model | Should -Be 'gpt-5.4'
     }
 
+    It 'prefers slot-level agent and model overrides when a matching slot id is provided' {
+@'
+agent: codex
+model: gpt-5.4
+roles:
+  worker:
+    agent: codex
+    model: gpt-5.4
+agent-slots:
+  - slot-id: worker-1
+    runtime-role: worker
+    agent: claude
+    model: sonnet
+  - slot-id: worker-2
+    runtime-role: worker
+    agent: gemini
+    model: gemini-2.5-pro
+'@ | Set-Content -Path (Join-Path $script:settingsTempRoot '.winsmux.yaml') -Encoding UTF8
+
+        Mock Get-WinsmuxOption { param($Name, $Default) return $null }
+
+        $settings = Get-BridgeSettings
+
+        $workerOneConfig = Get-SlotAgentConfig -Role 'Worker' -SlotId 'worker-1' -Settings $settings
+        $workerOneConfig.Agent | Should -Be 'claude'
+        $workerOneConfig.Model | Should -Be 'sonnet'
+        $workerOneConfig.Source | Should -Be 'slot'
+
+        $workerThreeConfig = Get-SlotAgentConfig -Role 'Worker' -SlotId 'worker-3' -Settings $settings
+        $workerThreeConfig.Agent | Should -Be 'codex'
+        $workerThreeConfig.Model | Should -Be 'gpt-5.4'
+        $workerThreeConfig.Source | Should -Be 'role'
+    }
+
     It 'fails closed when explicit agent slot entries are malformed' {
 @'
 agent: codex
@@ -419,14 +453,14 @@ Describe 'Get-OrchestraLayoutSettings' {
         $layout.Workers | Should -Be 3
     }
 
-    It 'rejects unsupported per-slot runtime overrides until slot runtime wiring exists' {
+    It 'rejects unsupported non-worker runtime_role overrides until slot runtime wiring expands' {
         {
             Get-OrchestraLayoutSettings -Settings ([ordered]@{
                 external_commander = $true
                 worker_count       = 2
                 agent_slots        = @(
                     [ordered]@{ slot_id = 'worker-1'; runtime_role = 'worker'; agent = 'codex'; model = 'gpt-5.4'; worktree_mode = 'managed' },
-                    [ordered]@{ slot_id = 'worker-2'; runtime_role = 'worker'; agent = 'claude'; model = 'sonnet'; worktree_mode = 'managed' }
+                    [ordered]@{ slot_id = 'review-1'; runtime_role = 'reviewer'; agent = 'claude'; model = 'sonnet'; worktree_mode = 'managed' }
                 )
                 agent              = 'codex'
                 model              = 'gpt-5.4'
@@ -436,7 +470,7 @@ Describe 'Get-OrchestraLayoutSettings' {
                 researchers        = 0
                 reviewers          = 0
             })
-        } | Should -Throw '*per-slot agent overrides are not supported yet at runtime*'
+        } | Should -Throw '*runtime_role overrides are not supported yet at runtime*'
     }
 
     It 'writes project settings to an explicit root path and omits worker_count when agent slots are present' {
@@ -704,6 +738,49 @@ panes:
         $plan.LaunchDir | Should -Be 'C:\repo\.worktrees\builder-2'
         $plan.GitWorktreeDir | Should -Be 'C:\repo\.worktrees\builder-2'
         $plan.LaunchCommand | Should -Match $([regex]::Escape("-C 'C:\repo\.worktrees\builder-2'"))
+    }
+
+    It 'uses slot-level agent and model overrides when building a restart plan' {
+@'
+version: 1
+saved_at: '2026-04-07T00:00:00+09:00'
+session:
+  name: 'winsmux-orchestra'
+  project_dir: 'C:\repo'
+  git_worktree_dir: 'C:\repo\.git'
+panes:
+  - label: 'worker-1'
+    pane_id: '%2'
+    role: 'Worker'
+    exec_mode: false
+    launch_dir: 'C:\repo'
+    task: null
+'@ | Set-Content -Path (Join-Path $script:paneControlManifestDir 'manifest.yaml') -Encoding UTF8
+
+        $settings = [ordered]@{
+            agent = 'codex'
+            model = 'gpt-5.4'
+            roles = [ordered]@{
+                worker = [ordered]@{
+                    agent = 'codex'
+                    model = 'gpt-5.4'
+                }
+            }
+            agent_slots = @(
+                [ordered]@{
+                    slot_id = 'worker-1'
+                    runtime_role = 'worker'
+                    agent = 'claude'
+                    model = 'sonnet'
+                }
+            )
+        }
+
+        $plan = Get-PaneControlRestartPlan -ProjectDir $script:paneControlTempRoot -PaneId '%2' -Settings $settings
+
+        $plan.Agent | Should -Be 'claude'
+        $plan.Model | Should -Be 'sonnet'
+        $plan.LaunchCommand | Should -Be 'claude --permission-mode bypassPermissions'
     }
 
     It 'updates launch_dir and builder_worktree_path together for builder panes' {
@@ -1091,6 +1168,78 @@ panes:
             $events[1].event | Should -Be 'pane.crashed'
             $events[1].pane_id | Should -Be '%4'
             $events[1].exit_reason | Should -Be 'context_exhausted'
+        } finally {
+            if (Test-Path $tempRoot) {
+                Remove-Item -Path $tempRoot -Recurse -Force
+            }
+        }
+    }
+
+    It 'uses slot-level agent and model overrides during a monitor cycle' {
+        $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('winsmux-agent-monitor-tests-' + [guid]::NewGuid().ToString('N'))
+        $manifestDir = Join-Path $tempRoot '.winsmux'
+        $manifestPath = Join-Path $manifestDir 'manifest.yaml'
+
+        try {
+            New-Item -ItemType Directory -Path $manifestDir -Force | Out-Null
+@"
+version: 1
+session:
+  name: winsmux-orchestra
+  project_dir: $tempRoot
+panes:
+  worker-2:
+    pane_id: %4
+    role: Worker
+    launch_dir: $tempRoot
+"@ | Set-Content -Path $manifestPath -Encoding UTF8
+
+            Mock Get-PaneAgentStatus {
+                [PSCustomObject]@{
+                    Status       = 'ready'
+                    PaneId       = '%4'
+                    SnapshotTail = ''
+                    SnapshotHash = 'hash-worker'
+                    ExitReason   = ''
+                }
+            }
+            Mock Update-MonitorIdleAlertState {
+                [ordered]@{
+                    ShouldAlert = $false
+                    Message     = ''
+                }
+            }
+            Mock Test-BuilderStall { $false }
+            Mock Invoke-AgentRespawn {
+                [PSCustomObject]@{
+                    Success = $true
+                    PaneId  = '%4'
+                    Message = 'respawned'
+                }
+            }
+
+            Invoke-AgentMonitorCycle -Settings ([ordered]@{
+                agent = 'codex'
+                model = 'gpt-5.4'
+                roles = [ordered]@{
+                    worker = [ordered]@{
+                        agent = 'codex'
+                        model = 'gpt-5.4'
+                    }
+                }
+                agent_slots = @(
+                    [ordered]@{
+                        slot_id = 'worker-2'
+                        runtime_role = 'worker'
+                        agent = 'claude'
+                        model = 'sonnet'
+                    }
+                )
+            }) -ManifestPath $manifestPath -SessionName 'winsmux-orchestra' | Out-Null
+
+            Should -Invoke Get-PaneAgentStatus -Times 1 -Exactly -ParameterFilter {
+                $PaneId -eq '%4' -and $Agent -eq 'claude' -and $Role -eq 'Worker'
+            }
         } finally {
             if (Test-Path $tempRoot) {
                 Remove-Item -Path $tempRoot -Recurse -Force

--- a/winsmux-core/scripts/agent-monitor.ps1
+++ b/winsmux-core/scripts/agent-monitor.ps1
@@ -1155,7 +1155,11 @@ function Invoke-AgentMonitorCycle {
         # Determine agent config for this role
         $roleAgentConfig = $null
         try {
-            $roleAgentConfig = Get-RoleAgentConfig -Role $role -Settings $Settings
+            if (Get-Command Get-SlotAgentConfig -ErrorAction SilentlyContinue) {
+                $roleAgentConfig = Get-SlotAgentConfig -Role $role -SlotId $label -Settings $Settings
+            } else {
+                $roleAgentConfig = Get-RoleAgentConfig -Role $role -Settings $Settings
+            }
         } catch {
             # Fallback to default settings
             $roleAgentConfig = [ordered]@{

--- a/winsmux-core/scripts/orchestra-start.ps1
+++ b/winsmux-core/scripts/orchestra-start.ps1
@@ -316,13 +316,6 @@ function Get-OrchestraLayoutSettings {
                 throw "agent_slots worktree_mode overrides are not supported yet at runtime (slot '$slotId' requested '$slotWorktreeMode')."
             }
 
-            if (-not [string]::IsNullOrWhiteSpace($slotAgent) -and $slotAgent -ne [string]$Settings.agent) {
-                throw "agent_slots per-slot agent overrides are not supported yet at runtime (slot '$slotId' requested '$slotAgent')."
-            }
-
-            if (-not [string]::IsNullOrWhiteSpace($slotModel) -and $slotModel -ne [string]$Settings.model) {
-                throw "agent_slots per-slot model overrides are not supported yet at runtime (slot '$slotId' requested '$slotModel')."
-            }
         }
     }
 
@@ -1346,9 +1339,9 @@ if ($MyInvocation.InvocationName -ne '.') {
             $builderWorktreePath = $builderWorktree.WorktreePath
         }
 
-        $roleAgentConfig = Get-RoleAgentConfig -Role $canonicalRole -Settings $settings
-        $execMode = ([string]$roleAgentConfig.Agent).Trim().ToLowerInvariant() -eq 'codex'
-        $launchCommand = Get-AgentLaunchCommand -Agent $roleAgentConfig.Agent -Model $roleAgentConfig.Model -ProjectDir $launchDir -GitWorktreeDir $launchGitWorktreeDir -ExecMode $false
+        $slotAgentConfig = Get-SlotAgentConfig -Role $canonicalRole -SlotId $label -Settings $settings
+        $execMode = ([string]$slotAgentConfig.Agent).Trim().ToLowerInvariant() -eq 'codex'
+        $launchCommand = Get-AgentLaunchCommand -Agent $slotAgentConfig.Agent -Model $slotAgentConfig.Model -ProjectDir $launchDir -GitWorktreeDir $launchGitWorktreeDir -ExecMode $false
 
         Invoke-Bridge -Arguments @('name', $paneId, $label)
         try {
@@ -1391,6 +1384,8 @@ if ($MyInvocation.InvocationName -ne '.') {
             Label = $label
             PaneId = $paneId
             Role = $canonicalRole
+            Agent = [string]$slotAgentConfig.Agent
+            Model = [string]$slotAgentConfig.Model
             ExecMode = $false
             LaunchDir = $launchDir
             BuilderBranch = $builderBranch
@@ -1401,8 +1396,7 @@ if ($MyInvocation.InvocationName -ne '.') {
 
     foreach ($paneSummary in $paneSummaries) {
         try {
-            $roleAgentConfig = Get-RoleAgentConfig -Role $paneSummary.Role -Settings $settings
-            Wait-AgentReady -PaneId $paneSummary.PaneId -Agent $roleAgentConfig.Agent -TimeoutSeconds 60
+            Wait-AgentReady -PaneId $paneSummary.PaneId -Agent $paneSummary.Agent -TimeoutSeconds 60
         } catch {
             Write-Error "Agent readiness timeout for $($paneSummary.Label) [$($paneSummary.PaneId)]: $($_.Exception.Message)"
             exit 1

--- a/winsmux-core/scripts/pane-control.ps1
+++ b/winsmux-core/scripts/pane-control.ps1
@@ -1,3 +1,4 @@
+ . (Join-Path $PSScriptRoot 'settings.ps1')
  . (Join-Path $PSScriptRoot 'manifest.ps1')
 
 function ConvertFrom-PaneControlYamlScalar {
@@ -482,17 +483,19 @@ function Get-PaneControlRestartPlan {
     }
 
     $context = Get-PaneControlManifestContext -ProjectDir $ProjectDir -PaneId $PaneId
-    $roleAgentConfig = $null
-    if (Get-Command Get-RoleAgentConfig -ErrorAction SilentlyContinue) {
-        $roleAgentConfig = Get-RoleAgentConfig -Role $context.Role -Settings $Settings
+    $agentConfig = $null
+    if (Get-Command Get-SlotAgentConfig -ErrorAction SilentlyContinue) {
+        $agentConfig = Get-SlotAgentConfig -Role $context.Role -SlotId $context.Label -Settings $Settings
+    } elseif (Get-Command Get-RoleAgentConfig -ErrorAction SilentlyContinue) {
+        $agentConfig = Get-RoleAgentConfig -Role $context.Role -Settings $Settings
     } else {
-        $roleAgentConfig = [ordered]@{
+        $agentConfig = [ordered]@{
             Agent = [string]$Settings.agent
             Model = [string]$Settings.model
         }
     }
 
-    $launchCommand = Get-PaneControlLaunchCommand -Agent $roleAgentConfig.Agent -Model $roleAgentConfig.Model -ProjectDir $context.LaunchDir -GitWorktreeDir $context.GitWorktreeDir
+    $launchCommand = Get-PaneControlLaunchCommand -Agent $agentConfig.Agent -Model $agentConfig.Model -ProjectDir $context.LaunchDir -GitWorktreeDir $context.GitWorktreeDir
 
     return [ordered]@{
         PaneId         = $context.PaneId
@@ -501,8 +504,8 @@ function Get-PaneControlRestartPlan {
         ProjectDir     = $context.ProjectDir
         LaunchDir      = $context.LaunchDir
         GitWorktreeDir = $context.GitWorktreeDir
-        Agent          = [string]$roleAgentConfig.Agent
-        Model          = [string]$roleAgentConfig.Model
+        Agent          = [string]$agentConfig.Agent
+        Model          = [string]$agentConfig.Model
         LaunchCommand  = $launchCommand
     }
 }

--- a/winsmux-core/scripts/pane-scaler.ps1
+++ b/winsmux-core/scripts/pane-scaler.ps1
@@ -299,7 +299,11 @@ function Get-PaneWorkload {
 
         $roleAgentConfig = $null
         try {
-            $roleAgentConfig = Get-RoleAgentConfig -Role 'Builder' -Settings $Settings
+            if (Get-Command Get-SlotAgentConfig -ErrorAction SilentlyContinue) {
+                $roleAgentConfig = Get-SlotAgentConfig -Role 'Builder' -SlotId $label -Settings $Settings
+            } else {
+                $roleAgentConfig = Get-RoleAgentConfig -Role 'Builder' -Settings $Settings
+            }
         } catch {
             $roleAgentConfig = [PSCustomObject]@{
                 Agent = [string]$Settings.agent
@@ -383,7 +387,11 @@ function Add-OrchestraPane {
 
         $roleAgentConfig = $null
         try {
-            $roleAgentConfig = Get-RoleAgentConfig -Role 'Builder' -Settings $Settings
+            if (Get-Command Get-SlotAgentConfig -ErrorAction SilentlyContinue) {
+                $roleAgentConfig = Get-SlotAgentConfig -Role 'Builder' -SlotId $newLabel -Settings $Settings
+            } else {
+                $roleAgentConfig = Get-RoleAgentConfig -Role 'Builder' -Settings $Settings
+            }
         } catch {
             $roleAgentConfig = [PSCustomObject]@{
                 Agent = [string]$Settings.agent

--- a/winsmux-core/scripts/settings.ps1
+++ b/winsmux-core/scripts/settings.ps1
@@ -749,6 +749,89 @@ function Get-RoleAgentConfig {
     }
 }
 
+function Get-SlotAgentConfig {
+    param(
+        [Parameter(Mandatory = $true)][string]$Role,
+        [string]$SlotId,
+        $Settings = (Get-BridgeSettings)
+    )
+
+    if ($null -eq $Settings) {
+        throw 'Settings cannot be null.'
+    }
+
+    $roleAgentConfig = Get-RoleAgentConfig -Role $Role -Settings $Settings
+    $agent = [string]$roleAgentConfig.Agent
+    $model = [string]$roleAgentConfig.Model
+    $source = 'role'
+
+    if (-not [string]::IsNullOrWhiteSpace($SlotId)) {
+        $configuredSlots = @()
+        if ($Settings -is [System.Collections.IDictionary]) {
+            if ($Settings.Contains('agent_slots')) {
+                $configuredSlots = @($Settings['agent_slots'])
+            }
+        } elseif ($null -ne $Settings.PSObject -and ($Settings.PSObject.Properties.Name -contains 'agent_slots')) {
+            $configuredSlots = @($Settings.agent_slots)
+        }
+
+        foreach ($slot in $configuredSlots) {
+            if ($null -eq $slot) {
+                continue
+            }
+
+            $candidateSlotId = ''
+            $slotAgent = ''
+            $slotModel = ''
+
+            if ($slot -is [System.Collections.IDictionary]) {
+                if ($slot.Contains('slot_id')) {
+                    $candidateSlotId = [string]$slot['slot_id']
+                }
+                if ($slot.Contains('agent')) {
+                    $slotAgent = [string]$slot['agent']
+                }
+                if ($slot.Contains('model')) {
+                    $slotModel = [string]$slot['model']
+                }
+            } elseif ($null -ne $slot.PSObject) {
+                if ($slot.PSObject.Properties.Name -contains 'slot_id') {
+                    $candidateSlotId = [string]$slot.slot_id
+                }
+                if ($slot.PSObject.Properties.Name -contains 'agent') {
+                    $slotAgent = [string]$slot.agent
+                }
+                if ($slot.PSObject.Properties.Name -contains 'model') {
+                    $slotModel = [string]$slot.model
+                }
+            }
+
+            if (-not [string]::Equals($candidateSlotId, $SlotId, [System.StringComparison]::OrdinalIgnoreCase)) {
+                continue
+            }
+
+            if (-not [string]::IsNullOrWhiteSpace($slotAgent)) {
+                $agent = $slotAgent
+                $source = 'slot'
+            }
+
+            if (-not [string]::IsNullOrWhiteSpace($slotModel)) {
+                $model = $slotModel
+                $source = 'slot'
+            }
+
+            break
+        }
+    }
+
+    return [PSCustomObject]@{
+        SlotId = [string]$SlotId
+        Agent  = [string]$agent
+        Model  = [string]$model
+        Source = [string]$source
+    }
+}
+
 function Get-BridgeSetting {
     param(
         [Parameter(Mandatory = $true)][string]$Name,


### PR DESCRIPTION
## Summary
- wire slot-level `agent` / `model` selection into orchestra startup and restart paths
- use `agent_slots[]` when building restart plans, monitor cycles, and pane scaling decisions
- add focused regression coverage for settings, restart plans, and monitor slot resolution

## Validation
- `[System.Management.Automation.Language.Parser]::ParseFile(...)` on updated PowerShell scripts and tests
- `Invoke-Pester tests/psmux-bridge.Tests.ps1`
  - `113/113 PASS`

## Notes
- `runtime_role` and `worktree_mode` overrides remain fail-closed; this slice only lands per-slot provider/model wiring
- handoff updated to reflect `TASK-262` in progress
