### PR TITLE
feat(orchestra): require explicit legacy layout opt-in

### DIFF
--- a/.winsmux.yaml.example
+++ b/.winsmux.yaml.example
@@ -1,11 +1,21 @@
-# Project-level psmux-bridge settings.
-# Priority: project (.psmux-bridge.yaml) > global (@bridge-*) > built-in defaults.
+# Project-level winsmux settings.
+# Default mode is external operator + managed worker slots.
+# Set legacy_role_layout: true only if you explicitly want Commander/Builder/Researcher/Reviewer panes.
 
 agent: codex
 model: gpt-5.4
-builders: 4
-researchers: 1
-reviewers: 1
+external-commander: true
+agent-slots:
+  - slot-id: worker-1
+    runtime-role: worker
+    agent: codex
+    model: gpt-5.4
+    worktree-mode: managed
+  - slot-id: worker-2
+    runtime-role: worker
+    agent: codex
+    model: gpt-5.4
+    worktree-mode: managed
 vault_keys:
   - GH_TOKEN
 terminal: background

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -8,7 +8,7 @@
 - `v0.19.5`, `v0.19.6`, and `v0.19.7` are released.
 - `v0.19.6 hardening` is implemented, merged, released, and tracked as `100% (6/6)` in the external planning backlog/roadmap.
 - `v0.19.7 visible orchestration` is implemented, merged, released, and tracked as `100% (7/7)` in the external planning backlog/roadmap.
-- `v0.19.8 External Operator & Agent Slots` is started in order; private planning now tracks `TASK-259` and `TASK-261` as done, with `TASK-262` as the next repo-side slice.
+- `v0.19.8 External Operator & Agent Slots` is started in order; private planning now tracks `TASK-259`, `TASK-261`, and `TASK-262` as done, with `TASK-263` as the next repo-side slice.
 - PR [#370](https://github.com/Sora-bluesky/winsmux/pull/370), PR [#371](https://github.com/Sora-bluesky/winsmux/pull/371), PR [#372](https://github.com/Sora-bluesky/winsmux/pull/372), PR [#374](https://github.com/Sora-bluesky/winsmux/pull/374), PR [#375](https://github.com/Sora-bluesky/winsmux/pull/375), PR [#376](https://github.com/Sora-bluesky/winsmux/pull/376), PR [#379](https://github.com/Sora-bluesky/winsmux/pull/379), and PR [#380](https://github.com/Sora-bluesky/winsmux/pull/380) are merged into `main`.
 - Planning source of truth is externalized outside the public repository and syncs automatically into the private planning root.
 - `v0.21.x` private planning is aligned to a conversation-first Tauri operator shell, with Codex-App-like shell rules reflected in Figma and backlog notes.
@@ -30,6 +30,8 @@
 - Started the repo-side `TASK-261` slice on `codex/task261-agent-slots-20260410`, adding `agent_slots[]` parsing, worker-count synthesis, setup-wizard emission, and the default project slot array.
 - Merged the repo-side `TASK-261` slice via PR [#381](https://github.com/Sora-bluesky/winsmux/pull/381), making `agent_slots[]` the project settings source of truth, rejecting malformed slot definitions fail-closed, and binding setup-wizard / orchestra-start to the canonical project root.
 - Started the repo-side `TASK-262` slice on `codex/task262-slot-provider-model-20260410`, wiring slot-level `agent/model` selection into orchestra startup, restart plans, monitor cycles, and pane scaling paths.
+- Merged the repo-side `TASK-262` slice via PR [#382](https://github.com/Sora-bluesky/winsmux/pull/382), wiring slot-level `agent/model` selection through startup, restart, monitor, and scale paths.
+- Started the repo-side `TASK-263` slice, changing legacy role layout handling from implicit count-based activation to explicit `legacy_role_layout=true` opt-in only.
 - Reworked the Tauri prototype toward `TASK-285`: `winsmux-app` now renders an operator workspace shell scaffold with conversation timeline, sticky composer with inline attachments, context toggle, and a terminal utility drawer instead of a PTY-first full-window layout.
 - Added Figma high-fi anchors for `Operator Home / Inbox`, `Run Explain / Evidence`, and `Editor Secondary Surface`, and clarified how Explorer/Editor/Pane map into the new shell.
 
@@ -45,15 +47,15 @@
 - Composer scaffold matches the intended keyboard contract (`Enter` sends, `Shift+Enter` inserts newline, IME composition Enter does not send), and Context/Terminal toggles expose disclosure semantics via `aria-controls` plus `aria-expanded`.
 - `TASK-261` settings/layout regression passed before merge: `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `110/110 PASS`.
 - Current `TASK-262` slot wiring regression passes locally: `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `113/113 PASS`.
+- Current `TASK-263` explicit legacy opt-in regression passes locally: `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `115/115 PASS`.
 
 ## Next actions
 
-1. Land the repo-side `TASK-262` slice (`slot-level provider/model wiring`) from `codex/task262-slot-provider-model-20260410`.
-2. Continue `v0.19.8` in order with `TASK-263/264` once slot schema and slot-level wiring are stable.
-3. Continue `v0.21.0` with `TASK-292/293/294`, then align `TASK-107` implementation to the explicit secondary editor surface and workspace sidebar model.
-4. Preserve the private planning sync flow: user/agent visible, auto-synced, but not committed to the public repo.
-5. Track GitHub Actions Node runtime warnings and update workflows before the Node 24 switch becomes mandatory.
-6. Run the next retro-review tranche over recent merged PRs after each milestone-close sequence.
+1. Land the repo-side `TASK-263` slice (legacy role layout explicit opt-in only) and then continue `v0.19.8` with `TASK-264`.
+2. Continue `v0.21.0` with `TASK-292/293/294`, then align `TASK-107` implementation to the explicit secondary editor surface and workspace sidebar model.
+3. Preserve the private planning sync flow: user/agent visible, auto-synced, but not committed to the public repo.
+4. Track GitHub Actions Node runtime warnings and update workflows before the Node 24 switch becomes mandatory.
+5. Run the next retro-review tranche over recent merged PRs after each milestone-close sequence.
 
 ## Notes
 

--- a/tests/psmux-bridge.Tests.ps1
+++ b/tests/psmux-bridge.Tests.ps1
@@ -372,6 +372,20 @@ agent-slots:
         { Get-BridgeSettings } | Should -Throw '*duplicate slot_id*'
     }
 
+    It 'rejects legacy role counts unless legacy_role_layout is explicitly enabled' {
+@'
+agent: codex
+model: gpt-5.4
+external-commander: true
+builders: 4
+reviewers: 1
+'@ | Set-Content -Path (Join-Path $script:settingsTempRoot '.winsmux.yaml') -Encoding UTF8
+
+        Mock Get-WinsmuxOption { param($Name, $Default) return $null }
+
+        { Get-BridgeSettings } | Should -Throw '*legacy_role_layout=true*'
+    }
+
     It 'reads project settings from an explicit root path even when the current location differs' {
         $projectRoot = Join-Path $script:settingsTempRoot 'repo-root'
         $otherRoot = Join-Path $script:settingsTempRoot 'other-root'
@@ -496,12 +510,12 @@ Describe 'Get-OrchestraLayoutSettings' {
         $projectConfig | Should -Not -Match 'worker_count:'
     }
 
-    It 'preserves legacy role layouts when explicit legacy counts are configured' {
+    It 'preserves legacy role layouts only when explicit opt-in is enabled' {
         $layout = Get-OrchestraLayoutSettings -Settings ([ordered]@{
-            external_commander = $true
-            worker_count       = 6
-            legacy_role_layout = $false
-            commanders         = 0
+            external_commander = $false
+            worker_count       = 0
+            legacy_role_layout = $true
+            commanders         = 1
             builders           = 4
             researchers        = 1
             reviewers          = 1
@@ -509,11 +523,25 @@ Describe 'Get-OrchestraLayoutSettings' {
 
         $layout.ExternalCommander | Should -Be $false
         $layout.LegacyRoleLayout | Should -Be $true
-        $layout.Commanders | Should -Be 0
+        $layout.Commanders | Should -Be 1
         $layout.Workers | Should -Be 0
         $layout.Builders | Should -Be 4
         $layout.Researchers | Should -Be 1
         $layout.Reviewers | Should -Be 1
+    }
+
+    It 'rejects implicit legacy role counts when legacy_role_layout is false' {
+        {
+            Get-OrchestraLayoutSettings -Settings ([ordered]@{
+                external_commander = $true
+                worker_count       = 6
+                legacy_role_layout = $false
+                commanders         = 0
+                builders           = 4
+                researchers        = 1
+                reviewers          = 1
+            })
+        } | Should -Throw '*legacy_role_layout=true*'
     }
 }
 

--- a/winsmux-core/scripts/orchestra-start.ps1
+++ b/winsmux-core/scripts/orchestra-start.ps1
@@ -298,7 +298,11 @@ function Get-OrchestraLayoutSettings {
     $legacyRoleLayout = [bool]$Settings.legacy_role_layout
 
     $legacyCount = $commanders + $builders + $researchers + $reviewers
-    $useLegacyLayout = $legacyRoleLayout -or $legacyCount -gt 0
+    $useLegacyLayout = $legacyRoleLayout
+
+    if ($legacyCount -gt 0 -and -not $useLegacyLayout) {
+        throw 'Legacy role counts require legacy_role_layout=true. Set legacy_role_layout explicitly to opt into Commander/Builder/Researcher/Reviewer panes.'
+    }
 
     if (-not $useLegacyLayout -and $agentSlots.Count -gt 0) {
         foreach ($slot in $agentSlots) {

--- a/winsmux-core/scripts/settings.ps1
+++ b/winsmux-core/scripts/settings.ps1
@@ -688,7 +688,11 @@ function Get-BridgeSettings {
     }
 
     $legacyCount = [int]$settings.commanders + [int]$settings.builders + [int]$settings.researchers + [int]$settings.reviewers
-    $useLegacyLayout = [bool]$settings.legacy_role_layout -or $legacyCount -gt 0
+    $useLegacyLayout = [bool]$settings.legacy_role_layout
+
+    if ($legacyCount -gt 0 -and -not $useLegacyLayout) {
+        throw 'Legacy role counts require legacy_role_layout=true. Set legacy_role_layout explicitly to opt into Commander/Builder/Researcher/Reviewer panes.'
+    }
 
     if (@($settings.agent_slots).Count -eq 0 -and -not $useLegacyLayout -and [bool]$settings.external_commander -and [int]$settings.worker_count -gt 0) {
         $settings.agent_slots = New-BridgeManagedAgentSlots -Count ([int]$settings.worker_count) -Agent ([string]$settings.agent) -Model ([string]$settings.model)

--- a/winsmux-core/scripts/setup-wizard.ps1
+++ b/winsmux-core/scripts/setup-wizard.ps1
@@ -187,14 +187,14 @@ if ($externalCommander) {
     $workerCount = Read-PositiveInt -Prompt 'Managed worker pane count' -Default 6
     $agentSlots = New-BridgeManagedAgentSlots -Count $workerCount -Agent $agentCli -Model $model
 } else {
-    $legacyRoleLayout = Read-YesNo -Prompt 'Use legacy role layout (Commander/Builder/Researcher/Reviewer panes)?' -Default $true
+    $legacyRoleLayout = Read-YesNo -Prompt 'Use legacy role layout (Commander/Builder/Researcher/Reviewer panes)?' -Default $false
     if ($legacyRoleLayout) {
         $commanders = Read-PositiveInt -Prompt 'Commanders count' -Default 1
         $builders = Read-PositiveInt -Prompt 'Builders count' -Default 4
         $researchers = Read-PositiveInt -Prompt 'Researchers count' -Default 1
         $reviewers = Read-PositiveInt -Prompt 'Reviewers count' -Default 1
     } else {
-        $commanders = Read-PositiveInt -Prompt 'Embedded operator count' -Default 1
+        $commanders = 0
         $workerCount = Read-PositiveInt -Prompt 'Managed worker pane count' -Default 6
         $agentSlots = New-BridgeManagedAgentSlots -Count $workerCount -Agent $agentCli -Model $model
     }


### PR DESCRIPTION
## Summary
- require `legacy_role_layout=true` before using Commander/Builder/Researcher/Reviewer counts
- stop implicit legacy activation from stale count values alone
- update setup wizard and example config to default to external operator + managed slots

## Validation
- `Invoke-Pester tests/psmux-bridge.Tests.ps1` (`115/115 PASS`)
- PowerShell parser check for updated scripts and tests

## Notes
- legacy compatibility mode remains supported, but only as explicit opt-in
- `.winsmux.yaml.example` now documents external operator + managed worker slots as the default project shape