### PR TITLE
feat(orchestra): generalize review targets

### DIFF
--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -8,7 +8,7 @@
 - `v0.19.5`, `v0.19.6`, and `v0.19.7` are released.
 - `v0.19.6 hardening` is implemented, merged, released, and tracked as `100% (6/6)` in the external planning backlog/roadmap.
 - `v0.19.7 visible orchestration` is implemented, merged, released, and tracked as `100% (7/7)` in the external planning backlog/roadmap.
-- `v0.19.8 External Operator & Agent Slots` is started in order; private planning now tracks `TASK-259`, `TASK-261`, and `TASK-262` as done, with `TASK-263` as the next repo-side slice.
+- `v0.19.8 External Operator & Agent Slots` is started in order; private planning now tracks `TASK-259`, `TASK-261`, `TASK-262`, and `TASK-263` as done, and the repo-side `TASK-264` starter slice is in progress.
 - PR [#370](https://github.com/Sora-bluesky/winsmux/pull/370), PR [#371](https://github.com/Sora-bluesky/winsmux/pull/371), PR [#372](https://github.com/Sora-bluesky/winsmux/pull/372), PR [#374](https://github.com/Sora-bluesky/winsmux/pull/374), PR [#375](https://github.com/Sora-bluesky/winsmux/pull/375), PR [#376](https://github.com/Sora-bluesky/winsmux/pull/376), PR [#379](https://github.com/Sora-bluesky/winsmux/pull/379), and PR [#380](https://github.com/Sora-bluesky/winsmux/pull/380) are merged into `main`.
 - Planning source of truth is externalized outside the public repository and syncs automatically into the private planning root.
 - `v0.21.x` private planning is aligned to a conversation-first Tauri operator shell, with Codex-App-like shell rules reflected in Figma and backlog notes.
@@ -31,7 +31,8 @@
 - Merged the repo-side `TASK-261` slice via PR [#381](https://github.com/Sora-bluesky/winsmux/pull/381), making `agent_slots[]` the project settings source of truth, rejecting malformed slot definitions fail-closed, and binding setup-wizard / orchestra-start to the canonical project root.
 - Started the repo-side `TASK-262` slice on `codex/task262-slot-provider-model-20260410`, wiring slot-level `agent/model` selection into orchestra startup, restart plans, monitor cycles, and pane scaling paths.
 - Merged the repo-side `TASK-262` slice via PR [#382](https://github.com/Sora-bluesky/winsmux/pull/382), wiring slot-level `agent/model` selection through startup, restart, monitor, and scale paths.
-- Started the repo-side `TASK-263` slice, changing legacy role layout handling from implicit count-based activation to explicit `legacy_role_layout=true` opt-in only.
+- Merged the repo-side `TASK-263` slice via PR [#383](https://github.com/Sora-bluesky/winsmux/pull/383), changing legacy role layout handling from implicit count-based activation to explicit `legacy_role_layout=true` opt-in only.
+- Started the repo-side `TASK-264` starter slice, moving review-state and pipeline wording from dedicated `reviewer` targets toward generic `review target` semantics while keeping legacy `target_reviewer_*` keys readable.
 - Reworked the Tauri prototype toward `TASK-285`: `winsmux-app` now renders an operator workspace shell scaffold with conversation timeline, sticky composer with inline attachments, context toggle, and a terminal utility drawer instead of a PTY-first full-window layout.
 - Added Figma high-fi anchors for `Operator Home / Inbox`, `Run Explain / Evidence`, and `Editor Secondary Surface`, and clarified how Explorer/Editor/Pane map into the new shell.
 
@@ -47,11 +48,12 @@
 - Composer scaffold matches the intended keyboard contract (`Enter` sends, `Shift+Enter` inserts newline, IME composition Enter does not send), and Context/Terminal toggles expose disclosure semantics via `aria-controls` plus `aria-expanded`.
 - `TASK-261` settings/layout regression passed before merge: `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `110/110 PASS`.
 - Current `TASK-262` slot wiring regression passes locally: `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `113/113 PASS`.
-- Current `TASK-263` explicit legacy opt-in regression passes locally: `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `115/115 PASS`.
+- `TASK-263` explicit legacy opt-in regression passed before merge: `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `115/115 PASS`.
+- Current `TASK-264` starter regression passes locally: `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `116/116 PASS`.
 
 ## Next actions
 
-1. Land the repo-side `TASK-263` slice (legacy role layout explicit opt-in only) and then continue `v0.19.8` with `TASK-264`.
+1. Land the repo-side `TASK-264` starter slice and then continue `v0.19.8` with capability-aware review target selection.
 2. Continue `v0.21.0` with `TASK-292/293/294`, then align `TASK-107` implementation to the explicit secondary editor surface and workspace sidebar model.
 3. Preserve the private planning sync flow: user/agent visible, auto-synced, but not committed to the public repo.
 4. Track GitHub Actions Node runtime warnings and update workflows before the Node 24 switch becomes mandatory.

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -366,6 +366,23 @@ function Get-ReviewStatePropertyValue {
     return $null
 }
 
+function Get-ReviewRequestTargetValue {
+    param(
+        [AllowNull()]$Request,
+        [Parameter(Mandatory = $true)][string]$Name
+    )
+
+    $primaryName = "target_review_$Name"
+    $legacyName = "target_reviewer_$Name"
+
+    $primaryValue = Get-ReviewStatePropertyValue -InputObject $Request -Name $primaryName
+    if ($null -ne $primaryValue -and -not [string]::IsNullOrWhiteSpace([string]$primaryValue)) {
+        return $primaryValue
+    }
+
+    return Get-ReviewStatePropertyValue -InputObject $Request -Name $legacyName
+}
+
 function Get-ReviewState {
     param([string]$ProjectDir = (Get-Location).Path)
 
@@ -3986,6 +4003,9 @@ function Invoke-ReviewRequest {
         id                      = New-ReviewRequestId
         branch                  = $branch
         head_sha                = $headSha
+        target_review_pane_id   = $context.PaneId
+        target_review_label     = $context.Label
+        target_review_role      = $context.Role
         target_reviewer_pane_id = $context.PaneId
         target_reviewer_label   = $context.Label
         target_reviewer_role    = $context.Role
@@ -4037,7 +4057,7 @@ function Invoke-ReviewApprove {
         Stop-WithError "review request pending for $branch was not found. Run: winsmux review-request"
     }
 
-    $requestPaneId = [string](Get-ReviewStatePropertyValue -InputObject $request -Name 'target_reviewer_pane_id')
+    $requestPaneId = [string](Get-ReviewRequestTargetValue -Request $request -Name 'pane_id')
     $requestBranch = [string](Get-ReviewStatePropertyValue -InputObject $request -Name 'branch')
     $requestHeadSha = [string](Get-ReviewStatePropertyValue -InputObject $request -Name 'head_sha')
 
@@ -4103,7 +4123,7 @@ function Invoke-ReviewFail {
         Stop-WithError "review request pending for $branch was not found. Run: winsmux review-request"
     }
 
-    $requestPaneId = [string](Get-ReviewStatePropertyValue -InputObject $request -Name 'target_reviewer_pane_id')
+    $requestPaneId = [string](Get-ReviewRequestTargetValue -Request $request -Name 'pane_id')
     $requestBranch = [string](Get-ReviewStatePropertyValue -InputObject $request -Name 'branch')
     $requestHeadSha = [string](Get-ReviewStatePropertyValue -InputObject $request -Name 'head_sha')
 

--- a/tests/psmux-bridge.Tests.ps1
+++ b/tests/psmux-bridge.Tests.ps1
@@ -1671,8 +1671,8 @@ tasks:
   "worktree-builder-1": {
     "status": "PENDING",
     "request": {
-      "target_reviewer_label": "reviewer",
-      "target_reviewer_pane_id": "%3"
+      "target_review_label": "reviewer",
+      "target_review_pane_id": "%3"
     }
   }
 }
@@ -4283,6 +4283,37 @@ panes:
         $reviewPane.PaneId | Should -Be '%2'
         $reviewPane.Label | Should -Be 'worker-1'
         $reviewPane.Role | Should -Be 'Worker'
+    }
+
+    It 'matches review-state records that use generic review target keys' {
+@"
+version: 1
+saved_at: 2026-04-09T11:00:00+09:00
+session:
+  name: winsmux-orchestra
+  project_dir: $script:commanderPollTempRoot
+panes:
+  worker-1:
+    pane_id: %2
+    role: Worker
+    launch_dir: $script:commanderPollTempRoot
+"@ | Set-Content -Path $script:commanderPollManifestPath -Encoding UTF8
+
+        . (Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\orchestra-state.ps1')
+
+        $reviewState = @{
+            'feature/test' = @{
+                status = 'PENDING'
+                request = @{
+                    target_review_label = 'worker-1'
+                    target_review_pane_id = '%2'
+                }
+            }
+        }
+
+        $record = Get-OrchestraPaneReviewRecord -ReviewState $reviewState -Branch '' -Label 'worker-1' -PaneId '%2' -Role 'Worker'
+
+        $record.status | Should -Be 'PENDING'
     }
 
     It 'appends commander poll log records as jsonl' {

--- a/winsmux-core/scripts/commander-poll.ps1
+++ b/winsmux-core/scripts/commander-poll.ps1
@@ -900,9 +900,13 @@ function Invoke-CommanderStateMachine {
                         $sha = [string]$e['head_sha']
                         $rsRequest = $null
                         if ($e.Contains('request')) { $rsRequest = $e['request'] }
-                        $rsReviewerPaneId = ''
-                        if ($null -ne $rsRequest -and $rsRequest -is [System.Collections.IDictionary] -and $rsRequest.Contains('target_reviewer_pane_id')) {
-                            $rsReviewerPaneId = [string]$rsRequest['target_reviewer_pane_id']
+                        $rsReviewPaneId = ''
+                        if ($null -ne $rsRequest -and $rsRequest -is [System.Collections.IDictionary]) {
+                            if ($rsRequest.Contains('target_review_pane_id')) {
+                                $rsReviewPaneId = [string]$rsRequest['target_review_pane_id']
+                            } elseif ($rsRequest.Contains('target_reviewer_pane_id')) {
+                                $rsReviewPaneId = [string]$rsRequest['target_reviewer_pane_id']
+                            }
                         }
                         $manifestReviewPaneId = ''
                         $manifest2 = Read-CommanderPollManifest -Path $ManifestPath
@@ -910,13 +914,13 @@ function Invoke-CommanderStateMachine {
                         if ($null -ne $reviewPane) {
                             $manifestReviewPaneId = [string]$reviewPane.PaneId
                         }
-                        $reviewerMatch = [string]::IsNullOrWhiteSpace($rsReviewerPaneId) -or $rsReviewerPaneId -eq $manifestReviewPaneId
-                        if ($st -eq 'PASS' -and $sha -eq $headSha -and $reviewerMatch) {
+                        $reviewTargetMatch = [string]::IsNullOrWhiteSpace($rsReviewPaneId) -or $rsReviewPaneId -eq $manifestReviewPaneId
+                        if ($st -eq 'PASS' -and $sha -eq $headSha -and $reviewTargetMatch) {
                             Send-CommanderTelegramNotification -ProjectDir $ProjectDir -SessionName $SessionName `
                                 -Event 'commander.review_passed' -Message "レビュー PASS。" -Branch $branch -HeadSha $headSha
                             $nextState = 'review_passed'
-                        } elseif ($st -eq 'PASS' -and $sha -eq $headSha -and -not $reviewerMatch) {
-                            Write-Warning "TASK-238: review PASS pane_id mismatch: review-state=$rsReviewerPaneId manifest=$manifestReviewPaneId"
+                        } elseif ($st -eq 'PASS' -and $sha -eq $headSha -and -not $reviewTargetMatch) {
+                            Write-Warning "TASK-238: review PASS pane_id mismatch: review-state=$rsReviewPaneId manifest=$manifestReviewPaneId"
                         } elseif ($st -eq 'FAIL') {
                             Send-CommanderTelegramNotification -ProjectDir $ProjectDir -SessionName $SessionName `
                                 -Event 'commander.review_failed' -Message "レビュー FAIL。修正が必要。" -Branch $branch -HeadSha $headSha

--- a/winsmux-core/scripts/orchestra-state.ps1
+++ b/winsmux-core/scripts/orchestra-state.ps1
@@ -263,8 +263,14 @@ function Get-OrchestraPaneReviewRecord {
             continue
         }
 
-        $targetLabel = [string](Get-OrchestraStateValue -InputObject $request -Name 'target_reviewer_label' -Default '')
-        $targetPaneId = [string](Get-OrchestraStateValue -InputObject $request -Name 'target_reviewer_pane_id' -Default '')
+        $targetLabel = [string](Get-OrchestraStateValue -InputObject $request -Name 'target_review_label' -Default '')
+        if ([string]::IsNullOrWhiteSpace($targetLabel)) {
+            $targetLabel = [string](Get-OrchestraStateValue -InputObject $request -Name 'target_reviewer_label' -Default '')
+        }
+        $targetPaneId = [string](Get-OrchestraStateValue -InputObject $request -Name 'target_review_pane_id' -Default '')
+        if ([string]::IsNullOrWhiteSpace($targetPaneId)) {
+            $targetPaneId = [string](Get-OrchestraStateValue -InputObject $request -Name 'target_reviewer_pane_id' -Default '')
+        }
         if ($targetLabel -eq $Label -or $targetPaneId -eq $PaneId) {
             return $entry
         }

--- a/winsmux-core/scripts/team-pipeline.ps1
+++ b/winsmux-core/scripts/team-pipeline.ps1
@@ -708,11 +708,12 @@ function Invoke-TeamPipeline {
             $verifyRole = 'Researcher'
         }
 
-        Write-TeamPipelineEvent -ProjectDir $builderContext.ProjectDir -SessionName $sessionName -Event 'pipeline.reviewer.dispatched' -Message "Auto-dispatched review to $($targets.VerifyTarget) after builder completion." -Role $verifyRole -Target $targets.VerifyTarget -Data ([ordered]@{
+        Write-TeamPipelineEvent -ProjectDir $builderContext.ProjectDir -SessionName $sessionName -Event 'pipeline.review.dispatched' -Message "Auto-dispatched review to $($targets.VerifyTarget) after builder completion." -Role $verifyRole -Target $targets.VerifyTarget -Data ([ordered]@{
             attempt              = $attemptIndex
             task                 = $Task
             builder              = $Builder
             builder_worktree_path = $builderContext.BuilderWorktreePath
+            verify_role          = $verifyRole
             summary              = $buildNotification.Summary
         }) | Out-Null
         Invoke-TeamPipelineBridge -Arguments @('send', $targets.VerifyTarget, $verifyPrompt) | Out-Null


### PR DESCRIPTION
## Summary
- start TASK-264 by moving review-state and pipeline surfaces from dedicated reviewer terminology toward generic review targets
- keep legacy 	arget_reviewer_* keys readable for backward compatibility while writing the new 	arget_review_* keys
- refresh handoff to reflect TASK-263 merged and TASK-264 starter in progress

## Validation
- Invoke-Pester tests/psmux-bridge.Tests.ps1
  - 116/116 PASS
- focused manual diff review
