### PR TITLE
feat(tauri): adopt workspace sidebar shell

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,3 +83,14 @@ When generating or editing a release:
 1. Use English section headings and bullets for the public GitHub Release body.
 2. Keep the GitHub Release body aligned with the `/release-notes` structure, but in English.
 3. Local or private post drafts may be Japanese if the task explicitly asks for them, but the public GitHub Release stays English.
+
+## Third-Party UI Attribution
+
+When winsmux directly reuses or closely adapts UI assets, style definitions, menu/footer behavior, wrapping logic, or component code from external OSS projects, Codex must:
+
+1. keep `THIRD_PARTY_NOTICES.md` updated,
+2. record the upstream repository and source file paths,
+3. preserve the original OSS license attribution in-repo,
+4. mention the provenance in `docs/handoff.md` when the change is active in the current session.
+
+For Codex-derived UI work, use `openai/codex` as the upstream reference and track the exact source areas being reused.

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,38 @@
+# Third-Party Notices
+
+This repository may reuse selected UI/UX assets and implementation patterns from external open-source projects.
+
+## openai/codex
+
+- Upstream: https://github.com/openai/codex
+- License: Apache-2.0
+- Copyright: OpenAI
+
+### winsmux usage policy
+
+winsmux may directly reuse or adapt selected Codex UI assets for the Tauri operator shell, including:
+
+- typography and color/style direction
+- wrapping and footer/status-lane behavior
+- settings/menu display affordances
+- conversation-shell interaction patterns
+
+When code or UI definitions are directly copied or closely adapted from `openai/codex`, the implementing change must:
+
+1. keep this notice file updated,
+2. record the upstream source path(s) in the pull request or handoff,
+3. preserve Apache-2.0 attribution in the repository.
+
+### Current tracked source references
+
+These upstream areas are the current reference set for Codex-derived UI work:
+
+- `codex-rs/tui/`
+- `codex-rs/tui/src/wrapping.rs`
+- `codex-rs/tui/src/bottom_pane/footer.rs`
+- `codex-rs/tui/src/bottom_pane/slash_command.rs`
+- `codex-rs/tui/src/bottom_pane/history_search.rs`
+- `codex-rs/tui/styles.md`
+- `codex-rs/AGENTS.md`
+
+This notice covers attribution and provenance tracking. It does not imply that winsmux reproduces Codex verbatim end-to-end.

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -10,7 +10,7 @@ This repository may reuse selected UI/UX assets and implementation patterns from
 
 ### winsmux usage policy
 
-winsmux retains selected legacy compatibility surfaces that still expose or reference `psmux`, `pmux`, or `tmux` names through the MIT-licensed core upstream.
+winsmux currently retains selected legacy compatibility surfaces that still expose or reference `psmux`, `pmux`, or `tmux` names through the MIT-licensed core upstream.
 
 This includes:
 
@@ -19,6 +19,18 @@ This includes:
 - legacy data-path and terminal-multiplexer compatibility behavior
 
 MIT does not require a separate NOTICE file in the same way Apache-2.0 often does, but winsmux keeps this entry anyway for provenance, auditability, and rename-debt tracking.
+
+### Sunset policy
+
+This section is tied to the active compatibility contract.
+
+- While legacy `psmux` compatibility remains in the public product surface, keep this notice entry and keep the tracked source references current.
+- When the compatibility sunset is completed before `v1.0.0`, update this section to reflect the post-sunset reality:
+  - remove references that no longer ship in the public surface,
+  - keep attribution only for code or assets that still remain in-repo,
+  - or remove this section entirely if no MIT-derived `psmux` compatibility surface remains.
+
+In other words, this entry is not permanent. It should evolve with the compatibility contract and be reduced or removed once the sunset work is complete.
 
 ### Current tracked source references
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -2,6 +2,30 @@
 
 This repository may reuse selected UI/UX assets and implementation patterns from external open-source projects.
 
+## winsmux core / legacy psmux compatibility surface
+
+- Upstream: https://github.com/winsmux/winsmux
+- License: MIT
+- Copyright: Josh
+
+### winsmux usage policy
+
+winsmux retains selected legacy compatibility surfaces that still expose or reference `psmux`, `pmux`, or `tmux` names through the MIT-licensed core upstream.
+
+This includes:
+
+- legacy binary aliases
+- legacy CLI/help compatibility
+- legacy data-path and terminal-multiplexer compatibility behavior
+
+MIT does not require a separate NOTICE file in the same way Apache-2.0 often does, but winsmux keeps this entry anyway for provenance, auditability, and rename-debt tracking.
+
+### Current tracked source references
+
+- `core/Cargo.toml`
+- `core/src/main.rs`
+- `core/src/cli.rs`
+
 ## openai/codex
 
 - Upstream: https://github.com/openai/codex

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -1,6 +1,6 @@
 # Handoff
 
-> Updated: 2026-04-10T23:59:00+09:00
+> Updated: 2026-04-10T17:33:35+09:00
 > Source of truth: this file
 
 ## Current state
@@ -8,8 +8,8 @@
 - `v0.19.5`, `v0.19.6`, and `v0.19.7` are released.
 - `v0.19.6 hardening` is implemented, merged, released, and tracked as `100% (6/6)` in the external planning backlog/roadmap.
 - `v0.19.7 visible orchestration` is implemented, merged, released, and tracked as `100% (7/7)` in the external planning backlog/roadmap.
-- `v0.19.8 External Operator & Agent Slots` is started in order; private planning now tracks `TASK-259`, `TASK-261`, `TASK-262`, and `TASK-263` as done, and the repo-side `TASK-264` starter slice is in progress.
-- PR [#370](https://github.com/Sora-bluesky/winsmux/pull/370), PR [#371](https://github.com/Sora-bluesky/winsmux/pull/371), PR [#372](https://github.com/Sora-bluesky/winsmux/pull/372), PR [#374](https://github.com/Sora-bluesky/winsmux/pull/374), PR [#375](https://github.com/Sora-bluesky/winsmux/pull/375), PR [#376](https://github.com/Sora-bluesky/winsmux/pull/376), PR [#379](https://github.com/Sora-bluesky/winsmux/pull/379), and PR [#380](https://github.com/Sora-bluesky/winsmux/pull/380) are merged into `main`.
+- `v0.19.8 External Operator & Agent Slots` is implemented in order; private planning now tracks `TASK-259`, `TASK-261`, `TASK-262`, `TASK-263`, and `TASK-264` as done, and the external roadmap is synced accordingly.
+- PR [#370](https://github.com/Sora-bluesky/winsmux/pull/370), PR [#371](https://github.com/Sora-bluesky/winsmux/pull/371), PR [#372](https://github.com/Sora-bluesky/winsmux/pull/372), PR [#374](https://github.com/Sora-bluesky/winsmux/pull/374), PR [#375](https://github.com/Sora-bluesky/winsmux/pull/375), PR [#376](https://github.com/Sora-bluesky/winsmux/pull/376), PR [#379](https://github.com/Sora-bluesky/winsmux/pull/379), PR [#380](https://github.com/Sora-bluesky/winsmux/pull/380), PR [#381](https://github.com/Sora-bluesky/winsmux/pull/381), PR [#382](https://github.com/Sora-bluesky/winsmux/pull/382), PR [#383](https://github.com/Sora-bluesky/winsmux/pull/383), and PR [#384](https://github.com/Sora-bluesky/winsmux/pull/384) are merged into `main`.
 - Planning source of truth is externalized outside the public repository and syncs automatically into the private planning root.
 - `v0.21.x` private planning is aligned to a conversation-first Tauri operator shell, with Codex-App-like shell rules reflected in Figma and backlog notes.
 - `v0.24.x` private planning is split into schema, ledger, machine contract, cutover, and canary phases for Rust runtime convergence before `v1.0.0`.
@@ -32,9 +32,13 @@
 - Started the repo-side `TASK-262` slice on `codex/task262-slot-provider-model-20260410`, wiring slot-level `agent/model` selection into orchestra startup, restart plans, monitor cycles, and pane scaling paths.
 - Merged the repo-side `TASK-262` slice via PR [#382](https://github.com/Sora-bluesky/winsmux/pull/382), wiring slot-level `agent/model` selection through startup, restart, monitor, and scale paths.
 - Merged the repo-side `TASK-263` slice via PR [#383](https://github.com/Sora-bluesky/winsmux/pull/383), changing legacy role layout handling from implicit count-based activation to explicit `legacy_role_layout=true` opt-in only.
-- Started the repo-side `TASK-264` starter slice, moving review-state and pipeline wording from dedicated `reviewer` targets toward generic `review target` semantics while keeping legacy `target_reviewer_*` keys readable.
+- Merged the repo-side `TASK-264` starter slice via PR [#384](https://github.com/Sora-bluesky/winsmux/pull/384), moving review-state and pipeline wording from dedicated `reviewer` targets toward generic `review target` semantics while keeping legacy `target_reviewer_*` keys readable.
 - Reworked the Tauri prototype toward `TASK-285`: `winsmux-app` now renders an operator workspace shell scaffold with conversation timeline, sticky composer with inline attachments, context toggle, and a terminal utility drawer instead of a PTY-first full-window layout.
 - Added Figma high-fi anchors for `Operator Home / Inbox`, `Run Explain / Evidence`, and `Editor Secondary Surface`, and clarified how Explorer/Editor/Pane map into the new shell.
+- Tightened the `TASK-285` shell slice locally: `winsmux-app` now uses a workspace sidebar instead of generic nav, adds a Codex-style footer/status lane, keeps wrapping summary-first, and separates sidebar / conversation / editor surface / context side sheet / terminal drawer more explicitly.
+- Updated private planning notes so `TASK-101`, `TASK-285`, `TASK-287`, `TASK-292`, `TASK-294`, `TASK-297`, `TASK-107`, `TASK-138`, `TASK-286`, and `TASK-288` reflect the Codex-TUI-plus-cmux synthesis, then re-synced the external roadmap.
+- Updated the Figma `winsmux Tauri Operator Workspace` file so the high-fi home screen shows the workspace sidebar, sticky composer, and footer/status lane together.
+- Added [THIRD_PARTY_NOTICES.md](../THIRD_PARTY_NOTICES.md) and a matching `AGENTS.md` rule so direct Codex OSS UI reuse keeps Apache-2.0 attribution plus upstream source-path tracking in-repo.
 
 ## Validation
 
@@ -49,12 +53,13 @@
 - `TASK-261` settings/layout regression passed before merge: `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `110/110 PASS`.
 - Current `TASK-262` slot wiring regression passes locally: `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `113/113 PASS`.
 - `TASK-263` explicit legacy opt-in regression passed before merge: `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `115/115 PASS`.
-- Current `TASK-264` starter regression passes locally: `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `116/116 PASS`.
+- `TASK-264` starter regression passed before merge: `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `116/116 PASS`.
+- Current Tauri workspace-sidebar slice passes frontend build: `npm run build` in `winsmux-app`.
 
 ## Next actions
 
-1. Land the repo-side `TASK-264` starter slice and then continue `v0.19.8` with capability-aware review target selection.
-2. Continue `v0.21.0` with `TASK-292/293/294`, then align `TASK-107` implementation to the explicit secondary editor surface and workspace sidebar model.
+1. Release `v0.19.8` now that `TASK-259/261/262/263/264` are tracked as done and synced in the external roadmap.
+2. Continue `v0.21.0` with `TASK-297` plus `TASK-292/293/294`, then align `TASK-107` implementation to the explicit secondary editor surface and workspace sidebar model.
 3. Preserve the private planning sync flow: user/agent visible, auto-synced, but not committed to the public repo.
 4. Track GitHub Actions Node runtime warnings and update workflows before the Node 24 switch becomes mandatory.
 5. Run the next retro-review tranche over recent merged PRs after each milestone-close sequence.

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -38,7 +38,7 @@
 - Tightened the `TASK-285` shell slice locally: `winsmux-app` now uses a workspace sidebar instead of generic nav, adds a Codex-style footer/status lane, keeps wrapping summary-first, and separates sidebar / conversation / editor surface / context side sheet / terminal drawer more explicitly.
 - Updated private planning notes so `TASK-101`, `TASK-285`, `TASK-287`, `TASK-292`, `TASK-294`, `TASK-297`, `TASK-107`, `TASK-138`, `TASK-286`, and `TASK-288` reflect the Codex-TUI-plus-cmux synthesis, then re-synced the external roadmap.
 - Updated the Figma `winsmux Tauri Operator Workspace` file so the high-fi home screen shows the workspace sidebar, sticky composer, and footer/status lane together.
-- Added [THIRD_PARTY_NOTICES.md](../THIRD_PARTY_NOTICES.md) and a matching `AGENTS.md` rule so direct Codex OSS UI reuse keeps Apache-2.0 attribution plus upstream source-path tracking in-repo.
+- Added [THIRD_PARTY_NOTICES.md](../THIRD_PARTY_NOTICES.md) and a matching `AGENTS.md` rule so direct Codex OSS UI reuse keeps Apache-2.0 attribution plus upstream source-path tracking in-repo, and documented the MIT-licensed legacy `psmux` compatibility surface from the core upstream for provenance.
 
 ## Validation
 

--- a/winsmux-app/index.html
+++ b/winsmux-app/index.html
@@ -10,14 +10,29 @@
   <body>
     <div id="app-shell">
       <aside id="left-rail">
-        <div class="brand">winsmux</div>
-        <nav id="nav-list">
-          <button class="nav-item is-active" data-view="inbox">Inbox</button>
-          <button class="nav-item" data-view="runs">Runs</button>
-          <button class="nav-item" data-view="digest">Digest</button>
-          <button class="nav-item" data-view="source">Source</button>
-          <button class="nav-item" data-view="settings">Settings</button>
-        </nav>
+        <div class="brand-block">
+          <div class="brand">winsmux</div>
+          <div class="sidebar-caption">Workspace sidebar</div>
+        </div>
+        <section class="sidebar-section">
+          <div class="sidebar-section-title">Sessions</div>
+          <div id="session-list" class="sidebar-list"></div>
+        </section>
+        <section class="sidebar-section">
+          <div class="sidebar-section-title">Explorer</div>
+          <div id="explorer-list" class="sidebar-list"></div>
+        </section>
+        <section class="sidebar-section">
+          <div class="sidebar-section-title">Open Editors</div>
+          <div id="open-editors-list" class="sidebar-list"></div>
+        </section>
+        <section class="sidebar-section">
+          <div class="sidebar-section-title">Source Control</div>
+          <div id="source-summary-list" class="sidebar-list"></div>
+        </section>
+        <div class="sidebar-spacer"></div>
+        <button id="settings-btn" class="sidebar-settings-btn" type="button">Settings</button>
+        <div id="sidebar-resizer" aria-hidden="true"></div>
       </aside>
       <main id="workspace">
         <header id="workspace-header">
@@ -52,7 +67,7 @@
           <section id="conversation-panel">
             <div id="thread-meta">
               <span>winsmux session</span>
-              <span>active operator thread</span>
+              <span>conversation shell</span>
             </div>
             <div id="conversation-timeline"></div>
             <form id="composer" autocomplete="off">
@@ -71,6 +86,17 @@
               </div>
             </form>
           </section>
+
+          <aside id="editor-surface" hidden>
+            <div class="panel-title-row">
+              <div class="panel-title">Editor</div>
+              <button class="ghost-btn ghost-btn-small" id="close-editor-btn" type="button">Close</button>
+            </div>
+            <div id="editor-file-path">winsmux-app/src/main.ts</div>
+            <div id="editor-tabs"></div>
+            <pre id="editor-code"></pre>
+            <div id="editor-statusbar">Secondary work surface: opened from conversation, changed files, or explorer.</div>
+          </aside>
 
           <aside id="context-panel">
             <div class="panel-title">Context</div>
@@ -92,6 +118,11 @@
             </div>
           </aside>
         </section>
+
+        <footer id="workspace-footer">
+          <div id="footer-left"></div>
+          <div id="footer-right"></div>
+        </footer>
 
         <section id="terminal-drawer" hidden>
           <div id="terminal-toolbar">

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -10,18 +10,65 @@ interface PaneEntry {
   container: HTMLElement;
 }
 
+type ChipAction =
+  | "open-explain"
+  | "open-editor"
+  | "open-source-context"
+  | "toggle-context"
+  | "open-terminal";
+
+interface ConversationChip {
+  label: string;
+  action: ChipAction;
+}
+
 interface ConversationItem {
   type: "user" | "operator" | "system";
   title?: string;
   body: string;
-  chips?: string[];
+  chips?: ConversationChip[];
+}
+
+interface SessionItem {
+  name: string;
+  meta: string;
+  active?: boolean;
+}
+
+interface ExplorerItem {
+  label: string;
+  depth: number;
+  kind: "folder" | "file";
+  open?: boolean;
+  active?: boolean;
+}
+
+interface EditorFile {
+  path: string;
+  summary: string;
+  content: string;
+  active?: boolean;
+}
+
+interface SourceSummaryItem {
+  label: string;
+  value: string;
+}
+
+interface FooterStatusItem {
+  label: string;
+  value?: string;
+  tone?: "default" | "accent";
 }
 
 const panes = new Map<string, PaneEntry>();
 let paneCounter = 0;
 let terminalDrawerOpen = false;
 let contextPanelOpen = true;
+let editorSurfaceOpen = false;
 let composerImeActive = false;
+let sidebarWidth = 292;
+let selectedEditorPath = "winsmux-app/src/main.ts";
 
 const seedConversation: ConversationItem[] = [
   {
@@ -34,10 +81,65 @@ const seedConversation: ConversationItem[] = [
   },
   {
     type: "system",
-    title: "Review requested",
-    body: "worker-2 changed 3 files. Branch/head mismatch is blocking commit. Open Explain to inspect.",
-    chips: ["Open Explain", "Review", "Commit Ready"],
+    title: "Commit blocked",
+    body: "worker-2 changed 3 files. Review passed, but branch/head mismatch still blocks commit. Open Explain or inspect the edited files.",
+    chips: [
+      { label: "Open Explain", action: "open-explain" },
+      { label: "Open in Editor", action: "open-editor" },
+      { label: "Source Context", action: "open-source-context" },
+      { label: "Terminal", action: "open-terminal" },
+    ],
   },
+];
+
+const sessionItems: SessionItem[] = [
+  { name: "winsmux", meta: "operator active · 2 runs blocked", active: true },
+  { name: "release-check", meta: "digest clean · no review waits" },
+];
+
+const explorerItems: ExplorerItem[] = [
+  { label: "winsmux-app", depth: 0, kind: "folder", open: true },
+  { label: "src", depth: 1, kind: "folder", open: true },
+  { label: "main.ts", depth: 2, kind: "file", active: true },
+  { label: "styles.css", depth: 2, kind: "file" },
+  { label: "index.html", depth: 1, kind: "file" },
+  { label: "winsmux-core", depth: 0, kind: "folder" },
+];
+
+const editorFiles: EditorFile[] = [
+  {
+    path: "winsmux-app/src/main.ts",
+    summary: "Conversation shell scaffold",
+    active: true,
+    content:
+      "const summaryStream = [\n  'blocked',\n  'review_requested',\n  'commit_ready',\n];\n\nfunction openEditorSurface() {\n  // Secondary work surface opened from conversation or source context.\n}\n",
+  },
+  {
+    path: "winsmux-app/src/styles.css",
+    summary: "Workspace sidebar and responsive shell",
+    content:
+      ".workspace-sidebar {\n  width: var(--sidebar-width);\n}\n\n.editor-secondary-surface {\n  border-left: 1px solid var(--border-muted);\n}\n",
+  },
+];
+
+const sourceSummaryItems: SourceSummaryItem[] = [
+  { label: "Branch", value: "codex/task264-review-capable-slot" },
+  { label: "Changed", value: "3 files" },
+  { label: "Review", value: "passed · branch mismatch" },
+  { label: "Worktree", value: ".worktrees/builder-2" },
+];
+
+const footerLeftItems: FooterStatusItem[] = [
+  { label: "Local environment" },
+  { label: "GPT-5.4" },
+  { label: "High" },
+  { label: "Settings", tone: "accent" },
+];
+
+const footerRightItems: FooterStatusItem[] = [
+  { label: "config.toml" },
+  { label: "main" },
+  { label: "Operator ready", tone: "accent" },
 ];
 
 function createPane(paneId?: string): string {
@@ -136,6 +238,110 @@ function closePane(id: string) {
   panes.forEach((pane) => pane.fitAddon.fit());
 }
 
+function renderSessions() {
+  const root = document.getElementById("session-list");
+  if (!root) {
+    return;
+  }
+
+  root.innerHTML = "";
+  for (const session of sessionItems) {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = `sidebar-row ${session.active ? "is-active" : ""}`;
+    button.innerHTML = `<span class="sidebar-row-title">${session.name}</span><span class="sidebar-row-meta">${session.meta}</span>`;
+    root.appendChild(button);
+  }
+}
+
+function renderExplorer() {
+  const root = document.getElementById("explorer-list");
+  if (!root) {
+    return;
+  }
+
+  root.innerHTML = "";
+  for (const item of explorerItems) {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = `sidebar-row sidebar-tree-row ${item.active ? "is-active" : ""}`;
+    button.style.paddingLeft = `${12 + item.depth * 16}px`;
+    button.innerHTML =
+      `<span class="sidebar-row-title">${item.kind === "folder" ? (item.open ? "▾ " : "▸ ") : "• "}${item.label}</span>`;
+    if (item.kind === "file") {
+      button.addEventListener("click", () => {
+        selectedEditorPath = findEditorFile(item.label)?.path || selectedEditorPath;
+        setEditorSurface(true);
+      });
+    }
+    root.appendChild(button);
+  }
+}
+
+function renderOpenEditors() {
+  const root = document.getElementById("open-editors-list");
+  if (!root) {
+    return;
+  }
+
+  root.innerHTML = "";
+  for (const editor of editorFiles) {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = `sidebar-row ${editor.path === selectedEditorPath && editorSurfaceOpen ? "is-active" : ""}`;
+    button.innerHTML = `<span class="sidebar-row-title">${editor.path.split("/").pop() ?? editor.path}</span><span class="sidebar-row-meta">${editor.summary}</span>`;
+    button.addEventListener("click", () => {
+      selectedEditorPath = editor.path;
+      setEditorSurface(true);
+    });
+    root.appendChild(button);
+  }
+}
+
+function renderSourceSummary() {
+  const root = document.getElementById("source-summary-list");
+  if (!root) {
+    return;
+  }
+
+  root.innerHTML = "";
+  for (const item of sourceSummaryItems) {
+    const row = document.createElement("div");
+    row.className = "sidebar-summary-row";
+    row.innerHTML = `<span class="sidebar-summary-label">${item.label}</span><span class="sidebar-summary-value">${item.value}</span>`;
+    root.appendChild(row);
+  }
+}
+
+function renderFooterLane() {
+  const left = document.getElementById("footer-left");
+  const right = document.getElementById("footer-right");
+  if (!left || !right) {
+    return;
+  }
+
+  const buildPill = (item: FooterStatusItem) => {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = `footer-pill ${item.tone === "accent" ? "is-accent" : ""}`;
+    button.innerHTML = item.value
+      ? `<span class="footer-pill-label">${item.label}</span><span class="footer-pill-value">${item.value}</span>`
+      : `<span class="footer-pill-value">${item.label}</span>`;
+    return button;
+  };
+
+  left.innerHTML = "";
+  right.innerHTML = "";
+
+  for (const item of footerLeftItems) {
+    left.appendChild(buildPill(item));
+  }
+
+  for (const item of footerRightItems) {
+    right.appendChild(buildPill(item));
+  }
+}
+
 function renderConversation(items: ConversationItem[]) {
   const timeline = document.getElementById("conversation-timeline");
   if (!timeline) {
@@ -163,16 +369,69 @@ function renderConversation(items: ConversationItem[]) {
     if (item.chips?.length) {
       const chipRow = document.createElement("div");
       chipRow.className = "timeline-chip-row";
-      for (const chipText of item.chips) {
-        const chip = document.createElement("span");
+      for (const chipInfo of item.chips) {
+        const chip = document.createElement("button");
+        chip.type = "button";
         chip.className = "timeline-chip";
-        chip.textContent = chipText;
+        chip.textContent = chipInfo.label;
+        chip.addEventListener("click", () => handleChipAction(chipInfo.action));
         chipRow.appendChild(chip);
       }
       article.appendChild(chipRow);
     }
 
     timeline.appendChild(article);
+  }
+}
+
+function handleChipAction(action: ChipAction) {
+  switch (action) {
+    case "open-editor":
+      setEditorSurface(true);
+      break;
+    case "open-source-context":
+    case "toggle-context":
+      setContextPanel(true);
+      break;
+    case "open-terminal":
+      setTerminalDrawer(true);
+      break;
+    case "open-explain":
+      seedConversation.push({
+        type: "operator",
+        body: "Explain opened: this run is blocked on branch/head alignment after review passed. Changed files and commit readiness are available in the context sheet.",
+      });
+      renderConversation(seedConversation);
+      break;
+  }
+}
+
+function renderEditorSurface() {
+  const path = document.getElementById("editor-file-path");
+  const tabs = document.getElementById("editor-tabs");
+  const code = document.getElementById("editor-code");
+  if (!path || !tabs || !code) {
+    return;
+  }
+
+  const selected = findEditorFile(selectedEditorPath) || editorFiles[0];
+  selectedEditorPath = selected.path;
+
+  path.textContent = selected.path;
+  code.textContent = selected.content;
+  tabs.innerHTML = "";
+
+  for (const editor of editorFiles) {
+    const tab = document.createElement("button");
+    tab.type = "button";
+    tab.className = `editor-tab ${editor.path === selected.path ? "is-active" : ""}`;
+    tab.textContent = editor.path.split("/").pop() ?? editor.path;
+    tab.addEventListener("click", () => {
+      selectedEditorPath = editor.path;
+      renderEditorSurface();
+      renderOpenEditors();
+    });
+    tabs.appendChild(tab);
   }
 }
 
@@ -212,13 +471,54 @@ function setContextPanel(open: boolean) {
   button.setAttribute("aria-expanded", open ? "true" : "false");
 }
 
+function setEditorSurface(open: boolean) {
+  editorSurfaceOpen = open;
+  const panel = document.getElementById("editor-surface");
+  const body = document.getElementById("workspace-body");
+  if (!panel || !body) {
+    return;
+  }
+
+  panel.toggleAttribute("hidden", !open);
+  body.classList.toggle("editor-open", open);
+  renderEditorSurface();
+  renderOpenEditors();
+}
+
 function appendUserMessage(message: string) {
   seedConversation.push({ type: "user", body: message });
   seedConversation.push({
     type: "operator",
-    body: "Operator update: queued for dispatch. Open Explain or Digest after the next material event.",
+    body: "Operator update: queued for dispatch. Open Explain, inspect changed files, or use the terminal drawer if raw PTY detail becomes necessary.",
   });
   renderConversation(seedConversation);
+}
+
+function findEditorFile(label: string) {
+  return editorFiles.find((editor) => editor.path.endsWith(label));
+}
+
+function initializeSidebarResize() {
+  const appShell = document.getElementById("app-shell");
+  const handle = document.getElementById("sidebar-resizer");
+  if (!appShell || !handle) {
+    return;
+  }
+
+  handle.addEventListener("pointerdown", (event) => {
+    const startX = event.clientX;
+    const startWidth = sidebarWidth;
+    const onMove = (moveEvent: PointerEvent) => {
+      sidebarWidth = Math.max(240, Math.min(380, startWidth + (moveEvent.clientX - startX)));
+      appShell.style.setProperty("--sidebar-width", `${sidebarWidth}px`);
+    };
+    const onUp = () => {
+      window.removeEventListener("pointermove", onMove);
+      window.removeEventListener("pointerup", onUp);
+    };
+    window.addEventListener("pointermove", onMove);
+    window.addEventListener("pointerup", onUp);
+  });
 }
 
 window.addEventListener("DOMContentLoaded", async () => {
@@ -237,9 +537,17 @@ window.addEventListener("DOMContentLoaded", async () => {
     }
   });
 
+  renderSessions();
+  renderExplorer();
+  renderOpenEditors();
+  renderSourceSummary();
+  renderFooterLane();
   renderConversation(seedConversation);
+  renderEditorSurface();
   setContextPanel(true);
+  setEditorSurface(false);
   setTerminalDrawer(false);
+  initializeSidebarResize();
 
   document.getElementById("toggle-terminal-btn")?.addEventListener("click", () => {
     setTerminalDrawer(!terminalDrawerOpen);
@@ -247,6 +555,10 @@ window.addEventListener("DOMContentLoaded", async () => {
 
   document.getElementById("toggle-context-btn")?.addEventListener("click", () => {
     setContextPanel(!contextPanelOpen);
+  });
+
+  document.getElementById("close-editor-btn")?.addEventListener("click", () => {
+    setEditorSurface(false);
   });
 
   document.getElementById("add-pane-btn")?.addEventListener("click", () => {

--- a/winsmux-app/src/styles.css
+++ b/winsmux-app/src/styles.css
@@ -1,12 +1,26 @@
+:root {
+  --bg-canvas: #0f1117;
+  --bg-surface: #151926;
+  --bg-surface-raised: #171c29;
+  --bg-panel: #1b2030;
+  --border-muted: #252b3e;
+  --text-primary: #eef2ff;
+  --text-secondary: #d4daf0;
+  --text-muted: #8d97b7;
+  --accent-blue: #4d76f0;
+  --accent-blue-hover: #5d84f5;
+}
+
 html,
 body {
   margin: 0;
   padding: 0;
   width: 100%;
   height: 100%;
-  background: #0f1117;
-  color: #eef2ff;
+  background: var(--bg-canvas);
+  color: var(--text-primary);
   font-family:
+    "OpenAI Sans",
     "Inter",
     "Segoe UI",
     "Noto Sans JP",
@@ -38,22 +52,33 @@ textarea {
 }
 
 #app-shell {
+  --sidebar-width: 292px;
+  --editor-width: 360px;
+  --context-width: 292px;
   display: grid;
-  grid-template-columns: 76px minmax(0, 1fr);
+  grid-template-columns: var(--sidebar-width) minmax(0, 1fr);
   width: 100%;
   height: 100%;
   background:
     radial-gradient(circle at top left, rgba(64, 88, 160, 0.14), transparent 32%),
-    linear-gradient(180deg, #0f1117 0%, #121521 100%);
+    linear-gradient(180deg, var(--bg-canvas) 0%, #121521 100%);
 }
 
 #left-rail {
+  position: relative;
   border-right: 1px solid #232737;
-  background: rgba(10, 12, 18, 0.85);
-  padding: 18px 12px;
+  background: rgba(10, 12, 18, 0.88);
+  padding: 18px 16px 18px 18px;
   display: flex;
   flex-direction: column;
-  gap: 20px;
+  gap: 14px;
+  min-width: 240px;
+}
+
+.brand-block {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
 }
 
 .brand {
@@ -63,32 +88,117 @@ textarea {
   letter-spacing: 0.02em;
 }
 
-#nav-list {
+.sidebar-caption {
+  font-size: 12px;
+  color: #8c96b4;
+}
+
+.sidebar-section {
   display: flex;
   flex-direction: column;
   gap: 8px;
 }
 
-.nav-item {
-  border: 0;
-  border-radius: 12px;
-  background: transparent;
-  color: #97a0bd;
-  padding: 10px 8px;
+.sidebar-section-title {
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #7d88a9;
+}
+
+.sidebar-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.sidebar-row {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+  width: 100%;
+  border: 1px solid #22283b;
+  border-radius: 14px;
+  background: #141927;
+  color: #dbe2f8;
+  padding: 10px 12px;
   text-align: left;
   cursor: pointer;
 }
 
-.nav-item.is-active,
-.nav-item:hover {
-  background: #1a1f2f;
+.sidebar-row:hover,
+.sidebar-row.is-active {
+  background: #1c2233;
+  border-color: #3d4d78;
+}
+
+.sidebar-row-title {
+  font-size: 13px;
   color: #f4f6ff;
+}
+
+.sidebar-row-meta {
+  font-size: 11px;
+  color: #8d97b7;
+}
+
+.sidebar-tree-row {
+  gap: 0;
+}
+
+.sidebar-summary-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  border-radius: 12px;
+  padding: 8px 10px;
+  background: #141927;
+  border: 1px solid #22283b;
+}
+
+.sidebar-summary-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #7d88a9;
+}
+
+.sidebar-summary-value {
+  font-size: 12px;
+  color: #edf1ff;
+  text-align: right;
+}
+
+.sidebar-spacer {
+  flex: 1;
+}
+
+.sidebar-settings-btn {
+  border: 1px solid #31374d;
+  background: #171c29;
+  color: #d4daf0;
+  border-radius: 12px;
+  padding: 10px 12px;
+  text-align: left;
+  cursor: pointer;
+}
+
+#sidebar-resizer {
+  position: absolute;
+  top: 0;
+  right: -3px;
+  width: 8px;
+  height: 100%;
+  cursor: col-resize;
 }
 
 #workspace {
   min-width: 0;
   display: grid;
-  grid-template-rows: auto minmax(0, 1fr) auto;
+  grid-template-rows: auto minmax(0, 1fr) auto auto;
   padding: 20px;
   gap: 16px;
 }
@@ -139,23 +249,37 @@ textarea {
   background: #22283c;
 }
 
+.ghost-btn-small {
+  padding: 7px 10px;
+  border-radius: 10px;
+}
+
 #workspace-body {
   min-height: 0;
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 292px;
+  grid-template-columns: minmax(0, 1fr) var(--context-width);
   gap: 16px;
+}
+
+#workspace-body.editor-open {
+  grid-template-columns: minmax(0, 1fr) var(--editor-width) var(--context-width);
 }
 
 #workspace-body.context-collapsed {
   grid-template-columns: minmax(0, 1fr);
 }
 
+#workspace-body.editor-open.context-collapsed {
+  grid-template-columns: minmax(0, 1fr) var(--editor-width);
+}
+
 #conversation-panel,
+#editor-surface,
 #context-panel,
 #terminal-drawer {
-  border: 1px solid #252b3e;
+  border: 1px solid var(--border-muted);
   border-radius: 20px;
-  background: #151926;
+  background: var(--bg-surface);
 }
 
 #conversation-panel {
@@ -220,6 +344,7 @@ textarea {
   font-size: 13px;
   line-height: 1.55;
   white-space: pre-wrap;
+  overflow-wrap: anywhere;
 }
 
 .timeline-chip-row {
@@ -235,12 +360,18 @@ textarea {
   padding: 5px 10px;
   font-size: 11px;
   font-weight: 600;
+  border: 0;
   background: #1f2640;
   color: #e8ecff;
+  cursor: pointer;
+}
+
+.timeline-chip:hover {
+  background: #2b3864;
 }
 
 #composer {
-  border-top: 1px solid #252b3e;
+  border-top: 1px solid var(--border-muted);
   padding: 16px 18px 18px;
   background: #131722;
 }
@@ -251,14 +382,14 @@ textarea {
   resize: vertical;
   border: 1px solid #343c56;
   border-radius: 18px;
-  background: #1b2030;
+  background: var(--bg-panel);
   color: #f3f5ff;
   padding: 16px 18px;
   outline: none;
 }
 
 #composer-input:focus {
-  border-color: #5a84f5;
+  border-color: var(--accent-blue-hover);
   box-shadow: 0 0 0 3px rgba(90, 132, 245, 0.18);
 }
 
@@ -305,26 +436,136 @@ textarea {
   border: 0;
   border-radius: 999px;
   padding: 9px 16px;
-  background: #4d76f0;
+  background: var(--accent-blue);
   color: #fff;
   cursor: pointer;
 }
 
 #send-btn:hover {
-  background: #5d84f5;
+  background: var(--accent-blue-hover);
 }
 
+#workspace-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  min-width: 0;
+}
+
+#footer-left,
+#footer-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  flex-wrap: wrap;
+}
+
+#footer-right {
+  justify-content: flex-end;
+}
+
+.footer-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  border: 1px solid var(--border-muted);
+  border-radius: 999px;
+  background: rgba(18, 21, 33, 0.9);
+  color: var(--text-secondary);
+  padding: 8px 12px;
+  cursor: pointer;
+}
+
+.footer-pill:hover {
+  background: rgba(25, 31, 47, 0.96);
+}
+
+.footer-pill.is-accent {
+  border-color: rgba(77, 118, 240, 0.45);
+  color: var(--text-primary);
+}
+
+.footer-pill-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+}
+
+.footer-pill-value {
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+#editor-surface,
 #context-panel {
+  min-width: 0;
   padding: 18px;
   display: flex;
   flex-direction: column;
   gap: 14px;
+  overflow: hidden;
+}
+
+.panel-title-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
 }
 
 .panel-title {
   font-size: 13px;
   font-weight: 700;
   color: #f4f6ff;
+}
+
+#editor-file-path {
+  font-size: 12px;
+  color: #8c96b4;
+  font-family: "Cascadia Code", "Consolas", monospace;
+}
+
+#editor-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.editor-tab {
+  border: 1px solid #2b3146;
+  border-radius: 999px;
+  background: #171c29;
+  color: #d5dcf3;
+  padding: 6px 10px;
+  cursor: pointer;
+}
+
+.editor-tab.is-active,
+.editor-tab:hover {
+  background: #242b3f;
+}
+
+#editor-code {
+  margin: 0;
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  border-radius: 16px;
+  background: #111624;
+  border: 1px solid var(--border-muted);
+  padding: 16px;
+  color: #d9dff1;
+  font-family: "Cascadia Code", "Consolas", monospace;
+  font-size: 12px;
+  line-height: 1.55;
+}
+
+#editor-statusbar {
+  font-size: 11px;
+  color: #8c96b4;
 }
 
 .context-section {
@@ -360,7 +601,7 @@ textarea {
   justify-content: space-between;
   gap: 16px;
   padding: 12px 16px;
-  border-bottom: 1px solid #252b3e;
+  border-bottom: 1px solid var(--border-muted);
   font-size: 12px;
   color: #8f99ba;
 }
@@ -437,11 +678,34 @@ textarea {
   background: #5d84f5;
 }
 
+@media (max-width: 1360px) {
+  #app-shell {
+    --sidebar-width: 260px;
+    --editor-width: 320px;
+  }
+
+  #workspace-body.editor-open {
+    grid-template-columns: minmax(0, 1fr) 320px;
+  }
+
+  #workspace-body.editor-open #context-panel {
+    display: none;
+  }
+}
+
 @media (max-width: 1180px) {
-  #workspace-body {
+  #app-shell {
+    grid-template-columns: minmax(240px, 36vw) minmax(0, 1fr);
+  }
+
+  #workspace-body,
+  #workspace-body.editor-open,
+  #workspace-body.context-collapsed,
+  #workspace-body.editor-open.context-collapsed {
     grid-template-columns: minmax(0, 1fr);
   }
 
+  #editor-surface,
   #context-panel {
     order: -1;
   }
@@ -455,6 +719,15 @@ textarea {
     width: 100%;
     justify-content: space-between;
   }
+
+  #workspace-footer {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  #footer-right {
+    justify-content: flex-start;
+  }
 }
 
 @media (max-height: 760px) {
@@ -464,7 +737,7 @@ textarea {
 
   #terminal-drawer {
     position: fixed;
-    left: 96px;
+    left: calc(var(--sidebar-width) + 24px);
     right: 20px;
     bottom: 20px;
     z-index: 20;


### PR DESCRIPTION
## Summary
- replace the generic Tauri left rail with a workspace sidebar for sessions, explorer, open editors, source summary, and settings
- add a secondary editor surface plus a Codex-style footer/status lane while keeping the conversation shell primary
- track direct Codex OSS UI reuse with in-repo Apache-2.0 attribution and refreshed handoff/planning notes

## Validation
- npm run build (winsmux-app)
- git diff --check
- manual diff review (Codex CLI review attempt timed out, so fallback review gate used)