### PR TITLE
feat(tauri): refine workspace sidebar shell

### DIFF
--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -1,6 +1,6 @@
 # Handoff
 
-> Updated: 2026-04-10T18:02:00+09:00
+> Updated: 2026-04-10T18:18:00+09:00
 > Source of truth: this file
 
 ## Current state
@@ -42,6 +42,7 @@
 - Updated the Figma `winsmux Tauri Operator Workspace` file so the high-fi home screen shows the workspace sidebar, sticky composer, and footer/status lane together.
 - Added [THIRD_PARTY_NOTICES.md](../THIRD_PARTY_NOTICES.md) and a matching `AGENTS.md` rule so direct Codex OSS UI reuse keeps Apache-2.0 attribution plus upstream source-path tracking in-repo, and documented the MIT-licensed legacy `psmux` compatibility surface from the core upstream for provenance.
 - Merged the `TASK-285` workspace-sidebar shell slice via PR [#385](https://github.com/Sora-bluesky/winsmux/pull/385), replacing the generic left-nav with a workspace sidebar and landing in-repo third-party UI provenance tracking.
+- Started the next `v0.21.0` UI slice on `codex/task297-sidebar-composer-responsive-20260410`, adding workspace-sidebar responsive behavior, composer mode chips, log semantics, and a settings/menu surface to advance `TASK-297`, `TASK-292`, `TASK-293`, and `TASK-294`.
 
 ## Validation
 
@@ -59,11 +60,11 @@
 - `TASK-263` explicit legacy opt-in regression passed before merge: `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `115/115 PASS`.
 - `TASK-264` starter regression passed before merge: `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `116/116 PASS`.
 - Current Tauri workspace-sidebar slice passes frontend build: `npm run build` in `winsmux-app`.
-- Repository is currently clean on `main`: `git status --short --branch` -> `## main...origin/main`.
+- Current `TASK-297/292/293/294` starter slice passes frontend build: `npm run build` in `winsmux-app`.
 
 ## Next actions
 
-1. Continue `v0.21.0` with `TASK-297` plus `TASK-292/293/294`, then align `TASK-107` implementation to the explicit secondary editor surface and workspace sidebar model.
+1. Review and publish the active `codex/task297-sidebar-composer-responsive-20260410` slice, then continue `v0.21.0` with `TASK-107` aligned to the explicit secondary editor surface model.
 2. Preserve the private planning sync flow: user/agent visible, auto-synced, but not committed to the public repo.
 3. Track GitHub Actions Node runtime warnings and update workflows before the Node 24 switch becomes mandatory.
 4. Run the next retro-review tranche over recent merged PRs after each milestone-close sequence.

--- a/winsmux-app/index.html
+++ b/winsmux-app/index.html
@@ -9,6 +9,7 @@
   </head>
   <body>
     <div id="app-shell">
+      <div id="sidebar-overlay" hidden></div>
       <aside id="left-rail">
         <div class="brand-block">
           <div class="brand">winsmux</div>
@@ -44,6 +45,15 @@
           <div id="header-actions">
             <button
               class="ghost-btn"
+              id="toggle-sidebar-btn"
+              type="button"
+              aria-controls="left-rail"
+              aria-expanded="true"
+            >
+              Workspace
+            </button>
+            <button
+              class="ghost-btn"
               id="toggle-context-btn"
               type="button"
               aria-controls="context-panel"
@@ -69,10 +79,11 @@
               <span>winsmux session</span>
               <span>conversation shell</span>
             </div>
-            <div id="conversation-timeline"></div>
+            <div id="conversation-timeline" role="log" aria-live="polite" aria-relevant="additions text"></div>
             <form id="composer" autocomplete="off">
               <label class="sr-only" for="composer-input">Message the Operator</label>
               <textarea id="composer-input" rows="2" placeholder="Message the Operator... Dispatch, ask, review, or explain"></textarea>
+              <div id="composer-mode-row" aria-label="Composer modes"></div>
               <div id="composer-footer">
                 <div id="attachment-tray">
                   <button type="button" class="attachment-chip">Screen 1.png</button>
@@ -130,6 +141,25 @@
             <button id="add-pane-btn">+ Pane</button>
           </div>
           <div id="panes-container"></div>
+        </section>
+
+        <section id="settings-sheet" hidden role="dialog" aria-modal="false" aria-labelledby="settings-sheet-title">
+          <div class="panel-title-row">
+            <div class="panel-title" id="settings-sheet-title">Settings</div>
+            <button class="ghost-btn ghost-btn-small" id="close-settings-btn" type="button">Close</button>
+          </div>
+          <div class="settings-section">
+            <div class="context-label">Profile</div>
+            <div class="context-value">Local environment · GPT-5.4 · High reasoning</div>
+          </div>
+          <div class="settings-section">
+            <div class="context-label">Workspace</div>
+            <div class="context-value">Sidebar width, context collapse, terminal drawer behavior</div>
+          </div>
+          <div class="settings-section">
+            <div class="context-label">Input</div>
+            <div class="context-value">Enter sends, Shift+Enter inserts newline, IME composition is protected</div>
+          </div>
         </section>
       </main>
     </div>

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -61,14 +61,26 @@ interface FooterStatusItem {
   tone?: "default" | "accent";
 }
 
+type ComposerMode = "ask" | "dispatch" | "review" | "explain";
+
 const panes = new Map<string, PaneEntry>();
 let paneCounter = 0;
 let terminalDrawerOpen = false;
 let contextPanelOpen = true;
 let editorSurfaceOpen = false;
+let settingsSheetOpen = false;
+let sidebarOpen = true;
 let composerImeActive = false;
 let sidebarWidth = 292;
 let selectedEditorPath = "winsmux-app/src/main.ts";
+let activeComposerMode: ComposerMode = "dispatch";
+
+const composerModes: Array<{ mode: ComposerMode; label: string; placeholder: string }> = [
+  { mode: "ask", label: "Ask", placeholder: "Ask the Operator for clarification, status, or guidance" },
+  { mode: "dispatch", label: "Dispatch", placeholder: "Dispatch the next task to the Operator" },
+  { mode: "review", label: "Review", placeholder: "Request review, approval, or audit from the Operator" },
+  { mode: "explain", label: "Explain", placeholder: "Ask the Operator to explain the current run state" },
+];
 
 const seedConversation: ConversationItem[] = [
   {
@@ -327,6 +339,9 @@ function renderFooterLane() {
     button.innerHTML = item.value
       ? `<span class="footer-pill-label">${item.label}</span><span class="footer-pill-value">${item.value}</span>`
       : `<span class="footer-pill-value">${item.label}</span>`;
+    if (item.label === "Settings" || item.value === "Settings") {
+      button.addEventListener("click", () => setSettingsSheet(true));
+    }
     return button;
   };
 
@@ -339,6 +354,34 @@ function renderFooterLane() {
 
   for (const item of footerRightItems) {
     right.appendChild(buildPill(item));
+  }
+}
+
+function renderComposerModes() {
+  const root = document.getElementById("composer-mode-row");
+  const composerInput = document.getElementById("composer-input") as HTMLTextAreaElement | null;
+  if (!root || !composerInput) {
+    return;
+  }
+
+  root.innerHTML = "";
+  for (const item of composerModes) {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = `mode-chip ${item.mode === activeComposerMode ? "is-active" : ""}`;
+    button.textContent = item.label;
+    button.setAttribute("aria-pressed", item.mode === activeComposerMode ? "true" : "false");
+    button.addEventListener("click", () => {
+      activeComposerMode = item.mode;
+      composerInput.placeholder = item.placeholder;
+      renderComposerModes();
+    });
+    root.appendChild(button);
+  }
+
+  const selected = composerModes.find((item) => item.mode === activeComposerMode);
+  if (selected) {
+    composerInput.placeholder = selected.placeholder;
   }
 }
 
@@ -485,6 +528,46 @@ function setEditorSurface(open: boolean) {
   renderOpenEditors();
 }
 
+function isNarrowLayout() {
+  return window.matchMedia("(max-width: 1180px)").matches;
+}
+
+function setSidebarOpen(open: boolean) {
+  sidebarOpen = open;
+  const shell = document.getElementById("app-shell");
+  const overlay = document.getElementById("sidebar-overlay");
+  const button = document.getElementById("toggle-sidebar-btn");
+  if (!shell || !overlay || !button) {
+    return;
+  }
+
+  shell.classList.toggle("sidebar-open", open);
+  overlay.hidden = !(open && isNarrowLayout());
+  button.setAttribute("aria-expanded", open ? "true" : "false");
+}
+
+function setSettingsSheet(open: boolean) {
+  settingsSheetOpen = open;
+  const sheet = document.getElementById("settings-sheet");
+  if (!sheet) {
+    return;
+  }
+
+  sheet.hidden = !open;
+}
+
+function syncResponsiveShell() {
+  if (isNarrowLayout()) {
+    setSidebarOpen(false);
+    setContextPanel(false);
+  } else {
+    setSidebarOpen(true);
+    if (!contextPanelOpen) {
+      setContextPanel(true);
+    }
+  }
+}
+
 function appendUserMessage(message: string) {
   seedConversation.push({ type: "user", body: message });
   seedConversation.push({
@@ -543,11 +626,16 @@ window.addEventListener("DOMContentLoaded", async () => {
   renderSourceSummary();
   renderFooterLane();
   renderConversation(seedConversation);
+  renderComposerModes();
   renderEditorSurface();
-  setContextPanel(true);
+  syncResponsiveShell();
   setEditorSurface(false);
   setTerminalDrawer(false);
   initializeSidebarResize();
+
+  document.getElementById("toggle-sidebar-btn")?.addEventListener("click", () => {
+    setSidebarOpen(!sidebarOpen);
+  });
 
   document.getElementById("toggle-terminal-btn")?.addEventListener("click", () => {
     setTerminalDrawer(!terminalDrawerOpen);
@@ -559,6 +647,18 @@ window.addEventListener("DOMContentLoaded", async () => {
 
   document.getElementById("close-editor-btn")?.addEventListener("click", () => {
     setEditorSurface(false);
+  });
+
+  document.getElementById("settings-btn")?.addEventListener("click", () => {
+    setSettingsSheet(true);
+  });
+
+  document.getElementById("close-settings-btn")?.addEventListener("click", () => {
+    setSettingsSheet(false);
+  });
+
+  document.getElementById("sidebar-overlay")?.addEventListener("click", () => {
+    setSidebarOpen(false);
   });
 
   document.getElementById("add-pane-btn")?.addEventListener("click", () => {
@@ -603,7 +703,21 @@ window.addEventListener("DOMContentLoaded", async () => {
     });
   }
 
+  window.addEventListener("keydown", (event) => {
+    if (event.key === "Escape" && settingsSheetOpen) {
+      event.preventDefault();
+      setSettingsSheet(false);
+      return;
+    }
+
+    if ((event.ctrlKey || event.metaKey) && event.key === ",") {
+      event.preventDefault();
+      setSettingsSheet(!settingsSheetOpen);
+    }
+  });
+
   window.addEventListener("resize", () => {
+    syncResponsiveShell();
     panes.forEach((pane) => pane.fitAddon.fit());
   });
 });

--- a/winsmux-app/src/styles.css
+++ b/winsmux-app/src/styles.css
@@ -64,6 +64,10 @@ textarea {
     linear-gradient(180deg, var(--bg-canvas) 0%, #121521 100%);
 }
 
+#sidebar-overlay {
+  display: none;
+}
+
 #left-rail {
   position: relative;
   border-right: 1px solid #232737;
@@ -236,6 +240,10 @@ textarea {
   gap: 8px;
 }
 
+#toggle-sidebar-btn {
+  display: none;
+}
+
 .ghost-btn {
   border: 1px solid #31374d;
   background: #1a1f2f;
@@ -391,6 +399,29 @@ textarea {
 #composer-input:focus {
   border-color: var(--accent-blue-hover);
   box-shadow: 0 0 0 3px rgba(90, 132, 245, 0.18);
+}
+
+#composer-mode-row {
+  margin-top: 10px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.mode-chip {
+  border: 1px solid #31374d;
+  border-radius: 999px;
+  background: #171c29;
+  color: #d4daf0;
+  padding: 7px 11px;
+  cursor: pointer;
+}
+
+.mode-chip.is-active,
+.mode-chip:hover {
+  background: #242b3f;
+  border-color: rgba(77, 118, 240, 0.45);
+  color: #eef2ff;
 }
 
 #composer-footer {
@@ -595,6 +626,30 @@ textarea {
   min-height: 240px;
 }
 
+#settings-sheet {
+  position: fixed;
+  top: 76px;
+  right: 24px;
+  width: min(360px, calc(100vw - 48px));
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  border: 1px solid var(--border-muted);
+  border-radius: 20px;
+  background: rgba(18, 21, 33, 0.98);
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.34);
+  z-index: 50;
+}
+
+.settings-section {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid #23283a;
+}
+
 #terminal-toolbar {
   display: flex;
   align-items: center;
@@ -695,7 +750,34 @@ textarea {
 
 @media (max-width: 1180px) {
   #app-shell {
-    grid-template-columns: minmax(240px, 36vw) minmax(0, 1fr);
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  #sidebar-overlay {
+    position: fixed;
+    inset: 0;
+    display: block;
+    background: rgba(8, 10, 16, 0.48);
+    z-index: 24;
+  }
+
+  #left-rail {
+    position: fixed;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    width: min(86vw, 340px);
+    z-index: 30;
+    transform: translateX(-100%);
+    transition: transform 160ms ease;
+  }
+
+  #app-shell.sidebar-open #left-rail {
+    transform: translateX(0);
+  }
+
+  #toggle-sidebar-btn {
+    display: inline-flex;
   }
 
   #workspace-body,
@@ -743,5 +825,10 @@ textarea {
     z-index: 20;
     max-height: 42vh;
     box-shadow: 0 16px 48px rgba(0, 0, 0, 0.32);
+  }
+
+  #settings-sheet {
+    top: auto;
+    bottom: 84px;
   }
 }


### PR DESCRIPTION
## Summary
- turn the workspace sidebar into a responsive overlay-capable surface on narrow widths
- add composer mode chips and a small settings/menu sheet to the operator shell
- update handoff for the active v0.21.0 TASK-297/292/293/294 slice

## Validation
- npm run build (winsmux-app)
- git diff --check

## Review gate
- reviewer subagent timed out
- fallback used: manual diff review + validation above