### PR TITLE
feat(tauri): wire editor secondary surface

### DIFF
--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -1,6 +1,6 @@
 # Handoff
 
-> Updated: 2026-04-10T18:18:00+09:00
+> Updated: 2026-04-10T19:00:00+09:00
 > Source of truth: this file
 
 ## Current state
@@ -43,6 +43,8 @@
 - Added [THIRD_PARTY_NOTICES.md](../THIRD_PARTY_NOTICES.md) and a matching `AGENTS.md` rule so direct Codex OSS UI reuse keeps Apache-2.0 attribution plus upstream source-path tracking in-repo, and documented the MIT-licensed legacy `psmux` compatibility surface from the core upstream for provenance.
 - Merged the `TASK-285` workspace-sidebar shell slice via PR [#385](https://github.com/Sora-bluesky/winsmux/pull/385), replacing the generic left-nav with a workspace sidebar and landing in-repo third-party UI provenance tracking.
 - Started the next `v0.21.0` UI slice on `codex/task297-sidebar-composer-responsive-20260410`, adding workspace-sidebar responsive behavior, composer mode chips, log semantics, and a settings/menu surface to advance `TASK-297`, `TASK-292`, `TASK-293`, and `TASK-294`.
+- Merged the `TASK-297/292/293/294` starter slice via PR [#386](https://github.com/Sora-bluesky/winsmux/pull/386), adding a responsive workspace sidebar overlay, composer mode chips, settings/menu sheet, and conversation log semantics.
+- Started the next `TASK-107` editor slice on `codex/task107-editor-secondary-surface-20260410`, wiring changed files and source context into the secondary editor surface.
 
 ## Validation
 
@@ -61,10 +63,11 @@
 - `TASK-264` starter regression passed before merge: `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `116/116 PASS`.
 - Current Tauri workspace-sidebar slice passes frontend build: `npm run build` in `winsmux-app`.
 - Current `TASK-297/292/293/294` starter slice passes frontend build: `npm run build` in `winsmux-app`.
+- Current `TASK-107` editor slice is in progress on `codex/task107-editor-secondary-surface-20260410`.
 
 ## Next actions
 
-1. Review and publish the active `codex/task297-sidebar-composer-responsive-20260410` slice, then continue `v0.21.0` with `TASK-107` aligned to the explicit secondary editor surface model.
+1. Review and publish the active `codex/task107-editor-secondary-surface-20260410` slice, continuing `v0.21.0` toward the explicit secondary editor surface model.
 2. Preserve the private planning sync flow: user/agent visible, auto-synced, but not committed to the public repo.
 3. Track GitHub Actions Node runtime warnings and update workflows before the Node 24 switch becomes mandatory.
 4. Run the next retro-review tranche over recent merged PRs after each milestone-close sequence.

--- a/winsmux-app/index.html
+++ b/winsmux-app/index.html
@@ -104,6 +104,7 @@
               <button class="ghost-btn ghost-btn-small" id="close-editor-btn" type="button">Close</button>
             </div>
             <div id="editor-file-path">winsmux-app/src/main.ts</div>
+            <div id="editor-meta-row"></div>
             <div id="editor-tabs"></div>
             <pre id="editor-code"></pre>
             <div id="editor-statusbar">Secondary work surface: opened from conversation, changed files, or explorer.</div>
@@ -111,22 +112,9 @@
 
           <aside id="context-panel">
             <div class="panel-title">Context</div>
-            <div class="context-section">
-              <div class="context-label">slot</div>
-              <div class="context-value">worker-2</div>
-            </div>
-            <div class="context-section">
-              <div class="context-label">branch</div>
-              <div class="context-value">codex/task245-run-inbox</div>
-            </div>
-            <div class="context-section">
-              <div class="context-label">review</div>
-              <div class="context-value">pending</div>
-            </div>
-            <div class="context-section">
-              <div class="context-label">next</div>
-              <div class="context-value">Open Explain</div>
-            </div>
+            <div id="context-sections"></div>
+            <div class="panel-title secondary-title">Changed files</div>
+            <div id="context-file-list"></div>
           </aside>
         </section>
 

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -47,10 +47,19 @@ interface EditorFile {
   path: string;
   summary: string;
   content: string;
+  language: string;
+  lineCount: number;
+  modified?: boolean;
+  origin: "explorer" | "context";
   active?: boolean;
 }
 
 interface SourceSummaryItem {
+  label: string;
+  value: string;
+}
+
+interface ContextSection {
   label: string;
   value: string;
 }
@@ -122,6 +131,10 @@ const editorFiles: EditorFile[] = [
   {
     path: "winsmux-app/src/main.ts",
     summary: "Conversation shell scaffold",
+    language: "TypeScript",
+    lineCount: 138,
+    modified: true,
+    origin: "context",
     active: true,
     content:
       "const summaryStream = [\n  'blocked',\n  'review_requested',\n  'commit_ready',\n];\n\nfunction openEditorSurface() {\n  // Secondary work surface opened from conversation or source context.\n}\n",
@@ -129,8 +142,21 @@ const editorFiles: EditorFile[] = [
   {
     path: "winsmux-app/src/styles.css",
     summary: "Workspace sidebar and responsive shell",
+    language: "CSS",
+    lineCount: 74,
+    modified: true,
+    origin: "context",
     content:
       ".workspace-sidebar {\n  width: var(--sidebar-width);\n}\n\n.editor-secondary-surface {\n  border-left: 1px solid var(--border-muted);\n}\n",
+  },
+  {
+    path: "winsmux-app/index.html",
+    summary: "Operator shell structure and panel hierarchy",
+    language: "HTML",
+    lineCount: 67,
+    origin: "explorer",
+    content:
+      "<section id=\"conversation-panel\">\n  <div id=\"conversation-timeline\"></div>\n  <form id=\"composer\"></form>\n</section>\n\n<aside id=\"editor-surface\" hidden></aside>\n",
   },
 ];
 
@@ -139,6 +165,13 @@ const sourceSummaryItems: SourceSummaryItem[] = [
   { label: "Changed", value: "3 files" },
   { label: "Review", value: "passed · branch mismatch" },
   { label: "Worktree", value: ".worktrees/builder-2" },
+];
+
+const contextSections: ContextSection[] = [
+  { label: "slot", value: "worker-2" },
+  { label: "branch", value: "codex/task245-run-inbox" },
+  { label: "review", value: "pending" },
+  { label: "next", value: "Open Explain" },
 ];
 
 const footerLeftItems: FooterStatusItem[] = [
@@ -325,6 +358,36 @@ function renderSourceSummary() {
   }
 }
 
+function renderContextPanel() {
+  const sectionRoot = document.getElementById("context-sections");
+  const fileRoot = document.getElementById("context-file-list");
+  if (!sectionRoot || !fileRoot) {
+    return;
+  }
+
+  sectionRoot.innerHTML = "";
+  for (const item of contextSections) {
+    const row = document.createElement("div");
+    row.className = "context-section";
+    row.innerHTML = `<div class="context-label">${item.label}</div><div class="context-value">${item.value}</div>`;
+    sectionRoot.appendChild(row);
+  }
+
+  fileRoot.innerHTML = "";
+  for (const file of editorFiles.filter((item) => item.origin === "context")) {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = `context-file-row ${file.path === selectedEditorPath && editorSurfaceOpen ? "is-active" : ""}`;
+    button.innerHTML =
+      `<span class="context-file-name">${file.path.split("/").pop() ?? file.path}</span><span class="context-file-meta">${file.summary}</span>`;
+    button.addEventListener("click", () => {
+      selectedEditorPath = file.path;
+      setEditorSurface(true);
+    });
+    fileRoot.appendChild(button);
+  }
+}
+
 function renderFooterLane() {
   const left = document.getElementById("footer-left");
   const right = document.getElementById("footer-right");
@@ -451,9 +514,11 @@ function handleChipAction(action: ChipAction) {
 
 function renderEditorSurface() {
   const path = document.getElementById("editor-file-path");
+  const meta = document.getElementById("editor-meta-row");
   const tabs = document.getElementById("editor-tabs");
   const code = document.getElementById("editor-code");
-  if (!path || !tabs || !code) {
+  const statusbar = document.getElementById("editor-statusbar");
+  if (!path || !meta || !tabs || !code || !statusbar) {
     return;
   }
 
@@ -461,7 +526,20 @@ function renderEditorSurface() {
   selectedEditorPath = selected.path;
 
   path.textContent = selected.path;
+  meta.innerHTML = "";
+  for (const item of [
+    selected.language,
+    `${selected.lineCount} lines`,
+    selected.modified ? "Modified" : "Saved",
+    selected.origin === "context" ? "Opened from context" : "Opened from explorer",
+  ]) {
+    const chip = document.createElement("span");
+    chip.className = `editor-meta-chip ${item === "Modified" ? "is-modified" : ""}`;
+    chip.textContent = item;
+    meta.appendChild(chip);
+  }
   code.textContent = selected.content;
+  statusbar.textContent = `Secondary work surface: ${selected.origin === "context" ? "run context" : "explorer"} -> ${selected.path}`;
   tabs.innerHTML = "";
 
   for (const editor of editorFiles) {
@@ -473,6 +551,7 @@ function renderEditorSurface() {
       selectedEditorPath = editor.path;
       renderEditorSurface();
       renderOpenEditors();
+      renderContextPanel();
     });
     tabs.appendChild(tab);
   }
@@ -526,6 +605,7 @@ function setEditorSurface(open: boolean) {
   body.classList.toggle("editor-open", open);
   renderEditorSurface();
   renderOpenEditors();
+  renderContextPanel();
 }
 
 function isNarrowLayout() {
@@ -624,6 +704,7 @@ window.addEventListener("DOMContentLoaded", async () => {
   renderExplorer();
   renderOpenEditors();
   renderSourceSummary();
+  renderContextPanel();
   renderFooterLane();
   renderConversation(seedConversation);
   renderComposerModes();

--- a/winsmux-app/src/styles.css
+++ b/winsmux-app/src/styles.css
@@ -553,10 +553,36 @@ textarea {
   color: #f4f6ff;
 }
 
+.secondary-title {
+  margin-top: 8px;
+}
+
 #editor-file-path {
   font-size: 12px;
   color: #8c96b4;
   font-family: "Cascadia Code", "Consolas", monospace;
+}
+
+#editor-meta-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.editor-meta-chip {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  padding: 5px 9px;
+  background: #171c29;
+  border: 1px solid #2b3146;
+  color: #d5dcf3;
+  font-size: 11px;
+}
+
+.editor-meta-chip.is-modified {
+  border-color: rgba(77, 118, 240, 0.45);
+  color: #eef2ff;
 }
 
 #editor-tabs {
@@ -617,6 +643,43 @@ textarea {
 .context-value {
   font-size: 13px;
   color: #e5e9f8;
+}
+
+#context-file-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.context-file-row {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+  width: 100%;
+  border: 1px solid #22283b;
+  border-radius: 14px;
+  background: #141927;
+  color: #dbe2f8;
+  padding: 10px 12px;
+  text-align: left;
+  cursor: pointer;
+}
+
+.context-file-row:hover,
+.context-file-row.is-active {
+  background: #1c2233;
+  border-color: #3d4d78;
+}
+
+.context-file-name {
+  font-size: 13px;
+  color: #f4f6ff;
+}
+
+.context-file-meta {
+  font-size: 11px;
+  color: #8d97b7;
 }
 
 #terminal-drawer {


### PR DESCRIPTION
## Summary
- connect the secondary editor surface to source-context changed files and explorer selections
- add editor metadata chips and a more explicit editor status/read path
- update handoff for the active TASK-107 slice

## Validation
- npm run build (winsmux-app)
- git diff --check

## Review gate
- reviewer subagents timed out
- fallback used: manual diff review + validation above