### PR TITLE
feat(tauri): add worktree-aware source control context

### DIFF
--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -1,6 +1,6 @@
 # Handoff
 
-> Updated: 2026-04-10T19:12:00+09:00
+> Updated: 2026-04-10T20:02:00+09:00
 > Source of truth: this file
 
 ## Current state
@@ -9,6 +9,7 @@
 - `v0.19.6 hardening` is implemented, merged, released, and tracked as `100% (6/6)` in the external planning backlog/roadmap.
 - `v0.19.7 visible orchestration` is implemented, merged, released, and tracked as `100% (7/7)` in the external planning backlog/roadmap.
 - `v0.19.8 External Operator & Agent Slots` is implemented in order; private planning now tracks `TASK-259`, `TASK-261`, `TASK-262`, `TASK-263`, and `TASK-264` as done, and the external roadmap is synced accordingly.
+- Private planning now swaps `v0.20.0` and `v0.21.0` to match actual implementation order: `v0.20.0` is `Desktop UX Foundation`, and `v0.21.0` is `Operator Core & Slot Dispatch`.
 - PR [#370](https://github.com/Sora-bluesky/winsmux/pull/370), PR [#371](https://github.com/Sora-bluesky/winsmux/pull/371), PR [#372](https://github.com/Sora-bluesky/winsmux/pull/372), PR [#374](https://github.com/Sora-bluesky/winsmux/pull/374), PR [#375](https://github.com/Sora-bluesky/winsmux/pull/375), PR [#376](https://github.com/Sora-bluesky/winsmux/pull/376), PR [#379](https://github.com/Sora-bluesky/winsmux/pull/379), PR [#380](https://github.com/Sora-bluesky/winsmux/pull/380), PR [#381](https://github.com/Sora-bluesky/winsmux/pull/381), PR [#382](https://github.com/Sora-bluesky/winsmux/pull/382), PR [#383](https://github.com/Sora-bluesky/winsmux/pull/383), PR [#384](https://github.com/Sora-bluesky/winsmux/pull/384), and PR [#385](https://github.com/Sora-bluesky/winsmux/pull/385) are merged into `main`.
 - Planning source of truth is externalized outside the public repository and syncs automatically into the private planning root.
 - `v0.21.x` private planning is aligned to a conversation-first Tauri operator shell, with Codex-App-like shell rules reflected in Figma and backlog notes.
@@ -48,6 +49,9 @@
 - Merged the `TASK-107` editor slice via PR [#387](https://github.com/Sora-bluesky/winsmux/pull/387), connecting the secondary editor surface to explorer selections and source-context changed files.
 - Started the workflow maintenance slice on `codex/node24-workflow-actions-20260410`, upgrading GitHub Actions core actions to Node-24-capable majors to remove runner deprecation warnings.
 - Added a durable subagent review-gate rule to [AGENTS.md](../AGENTS.md): close completed review agents promptly, prefer fresh agents per PR slice, wait longer before declaring timeout, and record fallback review grounds explicitly when timeouts persist.
+- Merged the workflow maintenance slice via PR [#388](https://github.com/Sora-bluesky/winsmux/pull/388), upgrading core GitHub Actions dependencies to Node-24-capable majors and landing the durable subagent review-gate workflow rule in [AGENTS.md](../AGENTS.md).
+- Swapped `v0.20.0` and `v0.21.0` in the private planning backlog/roadmap so release numbering matches actual implementation order, then re-synced [ROADMAP.md](C:\Users\komei\iCloudDrive\iCloud~md~obsidian\MainVault\Projects\winsmux\planning\ROADMAP.md).
+- Started the next `v0.20.0` desktop UX slice on top of `TASK-138`, unifying source-control/worktree mock data into a single `sourceControlState` view model and wiring sidebar source summary, source-entry filters, context overview cards, and changed-file rows to the same state.
 
 ## Validation
 
@@ -67,10 +71,12 @@
 - Current Tauri workspace-sidebar slice passes frontend build: `npm run build` in `winsmux-app`.
 - Current `TASK-297/292/293/294` starter slice passes frontend build: `npm run build` in `winsmux-app`.
 - Current `TASK-107` editor slice is merged via PR [#387](https://github.com/Sora-bluesky/winsmux/pull/387).
+- PR [#388](https://github.com/Sora-bluesky/winsmux/pull/388) merged cleanly and the repo is back to `main == origin/main`.
+- Current `TASK-138` source-control slice passes frontend build: `npm run build` in `winsmux-app`.
 
 ## Next actions
 
-1. Publish the active `codex/node24-workflow-actions-20260410` workflow maintenance slice, then continue `v0.21.0` toward richer editor/context integration.
+1. Publish the active `TASK-138` source-control/worktree-aware desktop UX slice, then continue `v0.20.0: Desktop UX Foundation` toward richer editor/context integration and menu/settings polish.
 2. Preserve the private planning sync flow: user/agent visible, auto-synced, but not committed to the public repo.
 3. Run the next retro-review tranche over recent merged PRs after each milestone-close sequence.
 

--- a/winsmux-app/index.html
+++ b/winsmux-app/index.html
@@ -30,6 +30,7 @@
         <section class="sidebar-section">
           <div class="sidebar-section-title">Source Control</div>
           <div id="source-summary-list" class="sidebar-list"></div>
+          <div id="source-entry-list" class="sidebar-list"></div>
         </section>
         <div class="sidebar-spacer"></div>
         <button id="settings-btn" class="sidebar-settings-btn" type="button">Settings</button>
@@ -113,6 +114,8 @@
           <aside id="context-panel">
             <div class="panel-title">Context</div>
             <div id="context-sections"></div>
+            <div class="panel-title secondary-title">Source control</div>
+            <div id="source-overview-cards"></div>
             <div class="panel-title secondary-title">Changed files</div>
             <div id="context-file-list"></div>
           </aside>

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -63,6 +63,7 @@ type ChangeRisk = "low" | "medium" | "high";
 interface SourceChange {
   path: string;
   summary: string;
+  slot: string;
   status: ChangeStatus;
   risk: ChangeRisk;
   worktree: string;
@@ -195,6 +196,7 @@ const sourceControlState: SourceControlState = {
   {
     path: "winsmux-app/src/main.ts",
     summary: "Conversation shell source-control actions and worktree metadata",
+    slot: "worker-2",
     status: "modified",
     risk: "medium",
     worktree: "builder-2",
@@ -208,6 +210,7 @@ const sourceControlState: SourceControlState = {
   {
     path: "winsmux-app/src/styles.css",
     summary: "Sidebar/context badges and source-control overview cards",
+    slot: "worker-2",
     status: "modified",
     risk: "low",
     worktree: "builder-2",
@@ -221,6 +224,7 @@ const sourceControlState: SourceControlState = {
   {
     path: "winsmux-core/scripts/team-pipeline.ps1",
     summary: "Branch mismatch still blocks commit despite review PASS",
+    slot: "worker-3",
     status: "modified",
     risk: "high",
     worktree: "builder-3",
@@ -235,7 +239,6 @@ const sourceControlState: SourceControlState = {
 };
 
 const baseContextSections: ContextSection[] = [
-  { label: "slot", value: "worker-2" },
   { label: "next", value: "Open Explain" },
 ];
 
@@ -464,6 +467,12 @@ function renderSourceEntries() {
     button.addEventListener("click", () => {
       activeSourceFilter = item.filter;
       setContextPanel(true);
+      const primaryChange = getPrimarySourceChange(getVisibleSourceChanges());
+      if (editorSurfaceOpen && primaryChange) {
+        selectedEditorPath = primaryChange.path;
+        renderEditorSurface();
+        renderOpenEditors();
+      }
       renderSourceSummary();
       renderSourceEntries();
       renderContextPanel();
@@ -505,6 +514,7 @@ function renderContextPanel() {
   sectionRoot.innerHTML = "";
   const resolvedContextSections = [
     ...baseContextSections,
+    { label: "slot", value: primaryChange?.slot ?? "No slot" },
     { label: "branch", value: primaryChange?.branch ?? "No branch" },
     { label: "review", value: primaryChange?.review ?? "No review state" },
     { label: "worktree", value: primaryChange ? `.worktrees/${primaryChange.worktree}` : "No worktree" },
@@ -825,7 +835,44 @@ function appendUserMessage(message: string) {
 }
 
 function findEditorFile(label: string) {
-  return editorFiles.find((editor) => editor.path === label);
+  const existing = editorFiles.find((editor) => editor.path === label);
+  if (existing) {
+    return existing;
+  }
+
+  const sourceChange = sourceControlState.entries.find((entry) => entry.path === label);
+  if (!sourceChange) {
+    return undefined;
+  }
+
+  return {
+    path: sourceChange.path,
+    summary: sourceChange.summary,
+    content:
+      `// Generated source-control preview\n` +
+      `// ${sourceChange.branch} · ${sourceChange.worktree} · ${sourceChange.review}\n` +
+      `// ${sourceChange.lines}\n`,
+    language: inferLanguageFromPath(sourceChange.path),
+    lineCount: 3,
+    modified: sourceChange.status !== "deleted",
+    origin: "context",
+  };
+}
+
+function inferLanguageFromPath(path: string) {
+  if (path.endsWith(".ts")) {
+    return "TypeScript";
+  }
+  if (path.endsWith(".css")) {
+    return "CSS";
+  }
+  if (path.endsWith(".html")) {
+    return "HTML";
+  }
+  if (path.endsWith(".ps1")) {
+    return "PowerShell";
+  }
+  return "Text";
 }
 
 function initializeSidebarResize() {

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -39,6 +39,7 @@ interface ExplorerItem {
   label: string;
   depth: number;
   kind: "folder" | "file";
+  path?: string;
   open?: boolean;
   active?: boolean;
 }
@@ -54,9 +55,27 @@ interface EditorFile {
   active?: boolean;
 }
 
-interface SourceSummaryItem {
-  label: string;
-  value: string;
+type SourceFilter = "all" | "candidates" | "attention" | "builder-2" | "builder-3";
+
+type ChangeStatus = "modified" | "added" | "deleted" | "renamed";
+type ChangeRisk = "low" | "medium" | "high";
+
+interface SourceChange {
+  path: string;
+  summary: string;
+  status: ChangeStatus;
+  risk: ChangeRisk;
+  worktree: string;
+  branch: string;
+  lines: string;
+  commitCandidate: boolean;
+  needsAttention: boolean;
+  run: string;
+  review: string;
+}
+
+interface SourceControlState {
+  entries: SourceChange[];
 }
 
 interface ContextSection {
@@ -83,6 +102,7 @@ let composerImeActive = false;
 let sidebarWidth = 292;
 let selectedEditorPath = "winsmux-app/src/main.ts";
 let activeComposerMode: ComposerMode = "dispatch";
+let activeSourceFilter: SourceFilter = "all";
 
 const composerModes: Array<{ mode: ComposerMode; label: string; placeholder: string }> = [
   { mode: "ask", label: "Ask", placeholder: "Ask the Operator for clarification, status, or guidance" },
@@ -121,9 +141,9 @@ const sessionItems: SessionItem[] = [
 const explorerItems: ExplorerItem[] = [
   { label: "winsmux-app", depth: 0, kind: "folder", open: true },
   { label: "src", depth: 1, kind: "folder", open: true },
-  { label: "main.ts", depth: 2, kind: "file", active: true },
-  { label: "styles.css", depth: 2, kind: "file" },
-  { label: "index.html", depth: 1, kind: "file" },
+  { label: "main.ts", depth: 2, kind: "file", path: "winsmux-app/src/main.ts", active: true },
+  { label: "styles.css", depth: 2, kind: "file", path: "winsmux-app/src/styles.css" },
+  { label: "index.html", depth: 1, kind: "file", path: "winsmux-app/index.html" },
   { label: "winsmux-core", depth: 0, kind: "folder" },
 ];
 
@@ -158,19 +178,64 @@ const editorFiles: EditorFile[] = [
     content:
       "<section id=\"conversation-panel\">\n  <div id=\"conversation-timeline\"></div>\n  <form id=\"composer\"></form>\n</section>\n\n<aside id=\"editor-surface\" hidden></aside>\n",
   },
+  {
+    path: "winsmux-core/scripts/team-pipeline.ps1",
+    summary: "Review-capable slot dispatch and branch alignment gate",
+    language: "PowerShell",
+    lineCount: 44,
+    modified: true,
+    origin: "context",
+    content:
+      "function Resolve-ReviewTarget {\n  param($Run)\n  # Review is now a slot capability, not a dedicated pane kind.\n}\n\nif ($branchMismatch) {\n  return 'blocked'\n}\n",
+  },
 ];
 
-const sourceSummaryItems: SourceSummaryItem[] = [
-  { label: "Branch", value: "codex/task264-review-capable-slot" },
-  { label: "Changed", value: "3 files" },
-  { label: "Review", value: "passed · branch mismatch" },
-  { label: "Worktree", value: ".worktrees/builder-2" },
-];
+const sourceControlState: SourceControlState = {
+  entries: [
+  {
+    path: "winsmux-app/src/main.ts",
+    summary: "Conversation shell source-control actions and worktree metadata",
+    status: "modified",
+    risk: "medium",
+    worktree: "builder-2",
+    branch: "codex/task138-source-context",
+    lines: "+46 -11",
+    commitCandidate: true,
+    needsAttention: false,
+    run: "run-245",
+    review: "passed",
+  },
+  {
+    path: "winsmux-app/src/styles.css",
+    summary: "Sidebar/context badges and source-control overview cards",
+    status: "modified",
+    risk: "low",
+    worktree: "builder-2",
+    branch: "codex/task138-source-context",
+    lines: "+38 -4",
+    commitCandidate: true,
+    needsAttention: false,
+    run: "run-245",
+    review: "passed",
+  },
+  {
+    path: "winsmux-core/scripts/team-pipeline.ps1",
+    summary: "Branch mismatch still blocks commit despite review PASS",
+    status: "modified",
+    risk: "high",
+    worktree: "builder-3",
+    branch: "codex/task264-review-capable-slot",
+    lines: "+9 -2",
+    commitCandidate: false,
+    needsAttention: true,
+    run: "run-246",
+    review: "blocked",
+  },
+  ],
+};
 
-const contextSections: ContextSection[] = [
+const baseContextSections: ContextSection[] = [
   { label: "slot", value: "worker-2" },
-  { label: "branch", value: "codex/task245-run-inbox" },
-  { label: "review", value: "pending" },
   { label: "next", value: "Open Explain" },
 ];
 
@@ -313,10 +378,12 @@ function renderExplorer() {
     button.style.paddingLeft = `${12 + item.depth * 16}px`;
     button.innerHTML =
       `<span class="sidebar-row-title">${item.kind === "folder" ? (item.open ? "▾ " : "▸ ") : "• "}${item.label}</span>`;
-    if (item.kind === "file") {
+    if (item.kind === "file" && item.path) {
+      const itemPath = item.path;
       button.addEventListener("click", () => {
-        selectedEditorPath = findEditorFile(item.label)?.path || selectedEditorPath;
+        selectedEditorPath = findEditorFile(itemPath)?.path || selectedEditorPath;
         setEditorSurface(true);
+        renderSourceSummary();
       });
     }
     root.appendChild(button);
@@ -338,6 +405,7 @@ function renderOpenEditors() {
     button.addEventListener("click", () => {
       selectedEditorPath = editor.path;
       setEditorSurface(true);
+      renderSourceSummary();
     });
     root.appendChild(button);
   }
@@ -349,8 +417,22 @@ function renderSourceSummary() {
     return;
   }
 
+  const visibleChanges = getVisibleSourceChanges();
+  const primaryChange = getPrimarySourceChange(visibleChanges);
+  const entryCount = visibleChanges.length;
+  const attentionCount = visibleChanges.filter((item) => item.needsAttention).length;
+  const commitCandidates = visibleChanges.filter((item) => item.commitCandidate).length;
+  const summaryItems = [
+    { label: "Branch", value: primaryChange?.branch ?? "No branch" },
+    { label: "Changed", value: `${entryCount} files` },
+    { label: "Review", value: primaryChange?.review ?? "No review state" },
+    { label: "Worktree", value: primaryChange ? `.worktrees/${primaryChange.worktree}` : "No worktree" },
+    { label: "Ready", value: `${commitCandidates} candidate${commitCandidates === 1 ? "" : "s"}` },
+    { label: "Risk", value: `${attentionCount} attention` },
+  ];
+
   root.innerHTML = "";
-  for (const item of sourceSummaryItems) {
+  for (const item of summaryItems) {
     const row = document.createElement("div");
     row.className = "sidebar-summary-row";
     row.innerHTML = `<span class="sidebar-summary-label">${item.label}</span><span class="sidebar-summary-value">${item.value}</span>`;
@@ -358,31 +440,110 @@ function renderSourceSummary() {
   }
 }
 
-function renderContextPanel() {
-  const sectionRoot = document.getElementById("context-sections");
-  const fileRoot = document.getElementById("context-file-list");
-  if (!sectionRoot || !fileRoot) {
+function renderSourceEntries() {
+  const root = document.getElementById("source-entry-list");
+  if (!root) {
     return;
   }
 
+  root.innerHTML = "";
+  const entryItems: Array<{ label: string; value: string; filter: SourceFilter; tone?: "success" | "attention" }> = [
+    { label: "Commit candidates", value: `${sourceControlState.entries.filter((item) => item.commitCandidate).length} ready`, tone: "success", filter: "candidates" },
+    { label: "Needs attention", value: `${sourceControlState.entries.filter((item) => item.needsAttention).length} blocker`, tone: "attention", filter: "attention" },
+    { label: "worktree-builder-2", value: `${sourceControlState.entries.filter((item) => item.worktree === "builder-2").length} files`, filter: "builder-2" },
+    { label: "worktree-builder-3", value: `${sourceControlState.entries.filter((item) => item.worktree === "builder-3").length} files`, filter: "builder-3" },
+  ];
+
+  for (const item of entryItems) {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = `sidebar-row source-entry-row ${activeSourceFilter === item.filter ? "is-active" : ""} ${
+      item.tone ? `is-${item.tone}` : ""
+    }`;
+    button.innerHTML = `<span class="sidebar-row-title">${item.label}</span><span class="sidebar-row-meta">${item.value}</span>`;
+    button.addEventListener("click", () => {
+      activeSourceFilter = item.filter;
+      setContextPanel(true);
+      renderSourceSummary();
+      renderSourceEntries();
+      renderContextPanel();
+    });
+    root.appendChild(button);
+  }
+}
+
+function getVisibleSourceChanges() {
+  switch (activeSourceFilter) {
+    case "candidates":
+      return sourceControlState.entries.filter((item) => item.commitCandidate);
+    case "attention":
+      return sourceControlState.entries.filter((item) => item.needsAttention);
+    case "builder-2":
+      return sourceControlState.entries.filter((item) => item.worktree === "builder-2");
+    case "builder-3":
+      return sourceControlState.entries.filter((item) => item.worktree === "builder-3");
+    default:
+      return sourceControlState.entries;
+  }
+}
+
+function getPrimarySourceChange(changes: SourceChange[]) {
+  return changes.find((item) => item.path === selectedEditorPath) ?? changes[0] ?? sourceControlState.entries[0];
+}
+
+function renderContextPanel() {
+  const sectionRoot = document.getElementById("context-sections");
+  const overviewRoot = document.getElementById("source-overview-cards");
+  const fileRoot = document.getElementById("context-file-list");
+  if (!sectionRoot || !overviewRoot || !fileRoot) {
+    return;
+  }
+
+  const visibleChanges = getVisibleSourceChanges();
+  const primaryChange = getPrimarySourceChange(visibleChanges);
+
   sectionRoot.innerHTML = "";
-  for (const item of contextSections) {
+  const resolvedContextSections = [
+    ...baseContextSections,
+    { label: "branch", value: primaryChange?.branch ?? "No branch" },
+    { label: "review", value: primaryChange?.review ?? "No review state" },
+    { label: "worktree", value: primaryChange ? `.worktrees/${primaryChange.worktree}` : "No worktree" },
+  ];
+  for (const item of resolvedContextSections) {
     const row = document.createElement("div");
     row.className = "context-section";
     row.innerHTML = `<div class="context-label">${item.label}</div><div class="context-value">${item.value}</div>`;
     sectionRoot.appendChild(row);
   }
 
+  overviewRoot.innerHTML = "";
+  const overviewCards = [
+    { label: "Selected scope", value: activeSourceFilter === "all" ? "All changes" : activeSourceFilter.replace("-", " ") },
+    { label: "Commit candidates", value: `${visibleChanges.filter((item) => item.commitCandidate).length}` },
+    { label: "Needs attention", value: `${visibleChanges.filter((item) => item.needsAttention).length}` },
+    { label: "Active worktree", value: primaryChange?.worktree ?? "n/a" },
+  ];
+
+  for (const item of overviewCards) {
+    const card = document.createElement("div");
+    card.className = "source-overview-card";
+    card.innerHTML = `<div class="context-label">${item.label}</div><div class="source-overview-value">${item.value}</div>`;
+    overviewRoot.appendChild(card);
+  }
+
   fileRoot.innerHTML = "";
-  for (const file of editorFiles.filter((item) => item.origin === "context")) {
+  for (const change of visibleChanges) {
     const button = document.createElement("button");
     button.type = "button";
-    button.className = `context-file-row ${file.path === selectedEditorPath && editorSurfaceOpen ? "is-active" : ""}`;
+    button.className = `context-file-row ${change.path === selectedEditorPath && editorSurfaceOpen ? "is-active" : ""} risk-${change.risk}`;
     button.innerHTML =
-      `<span class="context-file-name">${file.path.split("/").pop() ?? file.path}</span><span class="context-file-meta">${file.summary}</span>`;
+      `<span class="context-file-name">${change.path.split("/").pop() ?? change.path}</span>` +
+      `<span class="context-file-meta">${change.summary}</span>` +
+      `<span class="context-file-trace">${change.status} · ${change.lines} · ${change.worktree} · ${change.review}</span>`;
     button.addEventListener("click", () => {
-      selectedEditorPath = file.path;
+      selectedEditorPath = change.path;
       setEditorSurface(true);
+      renderSourceSummary();
     });
     fileRoot.appendChild(button);
   }
@@ -523,6 +684,7 @@ function renderEditorSurface() {
   }
 
   const selected = findEditorFile(selectedEditorPath) || editorFiles[0];
+  const sourceChange = sourceControlState.entries.find((item) => item.path === selected.path);
   selectedEditorPath = selected.path;
 
   path.textContent = selected.path;
@@ -532,6 +694,7 @@ function renderEditorSurface() {
     `${selected.lineCount} lines`,
     selected.modified ? "Modified" : "Saved",
     selected.origin === "context" ? "Opened from context" : "Opened from explorer",
+    sourceChange ? `${sourceChange.status} · ${sourceChange.worktree}` : "No source metadata",
   ]) {
     const chip = document.createElement("span");
     chip.className = `editor-meta-chip ${item === "Modified" ? "is-modified" : ""}`;
@@ -539,7 +702,9 @@ function renderEditorSurface() {
     meta.appendChild(chip);
   }
   code.textContent = selected.content;
-  statusbar.textContent = `Secondary work surface: ${selected.origin === "context" ? "run context" : "explorer"} -> ${selected.path}`;
+  statusbar.textContent = sourceChange
+    ? `Secondary work surface: ${selected.origin === "context" ? "run context" : "explorer"} -> ${selected.path} · ${sourceChange.branch} · ${sourceChange.review}`
+    : `Secondary work surface: ${selected.origin === "context" ? "run context" : "explorer"} -> ${selected.path}`;
   tabs.innerHTML = "";
 
   for (const editor of editorFiles) {
@@ -551,7 +716,9 @@ function renderEditorSurface() {
       selectedEditorPath = editor.path;
       renderEditorSurface();
       renderOpenEditors();
+      renderSourceSummary();
       renderContextPanel();
+      renderSourceEntries();
     });
     tabs.appendChild(tab);
   }
@@ -658,7 +825,7 @@ function appendUserMessage(message: string) {
 }
 
 function findEditorFile(label: string) {
-  return editorFiles.find((editor) => editor.path.endsWith(label));
+  return editorFiles.find((editor) => editor.path === label);
 }
 
 function initializeSidebarResize() {
@@ -704,6 +871,7 @@ window.addEventListener("DOMContentLoaded", async () => {
   renderExplorer();
   renderOpenEditors();
   renderSourceSummary();
+  renderSourceEntries();
   renderContextPanel();
   renderFooterLane();
   renderConversation(seedConversation);

--- a/winsmux-app/src/styles.css
+++ b/winsmux-app/src/styles.css
@@ -176,6 +176,14 @@ textarea {
   text-align: right;
 }
 
+.source-entry-row.is-success {
+  border-color: rgba(74, 222, 128, 0.28);
+}
+
+.source-entry-row.is-attention {
+  border-color: rgba(248, 113, 113, 0.34);
+}
+
 .sidebar-spacer {
   flex: 1;
 }
@@ -645,6 +653,27 @@ textarea {
   color: #e5e9f8;
 }
 
+#source-overview-cards {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.source-overview-card {
+  border: 1px solid #22283b;
+  border-radius: 14px;
+  background: #141927;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.source-overview-value {
+  font-size: 13px;
+  color: #eef2ff;
+}
+
 #context-file-list {
   display: flex;
   flex-direction: column;
@@ -680,6 +709,23 @@ textarea {
 .context-file-meta {
   font-size: 11px;
   color: #8d97b7;
+}
+
+.context-file-trace {
+  font-size: 11px;
+  color: #aab3ce;
+}
+
+.context-file-row.risk-high {
+  border-color: rgba(248, 113, 113, 0.38);
+}
+
+.context-file-row.risk-medium {
+  border-color: rgba(96, 165, 250, 0.34);
+}
+
+.context-file-row.risk-low {
+  border-color: rgba(125, 211, 252, 0.22);
 }
 
 #terminal-drawer {
@@ -868,6 +914,10 @@ textarea {
   #workspace-footer {
     flex-direction: column;
     align-items: flex-start;
+  }
+
+  #source-overview-cards {
+    grid-template-columns: minmax(0, 1fr);
   }
 
   #footer-right {


### PR DESCRIPTION
## Summary
- add a worktree-aware source control surface to the Tauri workspace shell
- unify sidebar summary, source filters, context cards, and changed-file rows around a canonical sourceControlState model
- keep editor/context/source selections aligned when the active source scope changes

## Validation
- npm run build (winsmux-app)
- git diff --check
- reviewer gate PASS after follow-up fixes on winsmux-app/src/main.ts

## Notes
- this advances TASK-138 in v0.20.0 Desktop UX Foundation
- manual fallback review was not needed in the final state because the fresh reviewer returned PASS