### PR TITLE
docs: align release format with Codex template

### DIFF
--- a/.references/2026-04-11-CODEX_RELEASE_TEMPLATE_ALIGNMENT.md
+++ b/.references/2026-04-11-CODEX_RELEASE_TEMPLATE_ALIGNMENT.md
@@ -1,0 +1,65 @@
+# Codex Release Template Alignment
+
+Updated: 2026-04-11
+
+## Purpose
+
+Persist the public GitHub Release format that winsmux should follow.
+This is written to be readable by both Codex and Claude Code style agents.
+
+## Source
+
+- Official reference: [openai/codex `rust-v0.119.0`](https://github.com/openai/codex/releases/tag/rust-v0.119.0)
+
+## Default public release structure
+
+Use this section order when the content exists:
+
+1. `New Features`
+2. `Bug Fixes`
+3. `Documentation`
+4. `Chores`
+5. `Full Changelog`
+
+Rules:
+
+- Public GitHub Releases stay in English.
+- Omit empty sections instead of leaving placeholders.
+- `Full Changelog` should point to the compare range for the released tags when available.
+- Reuse the structure, not the wording. Do not copy Codex release prose verbatim.
+- Keep bullets factual and scoped to winsmux changes only.
+
+## What to carry over from Codex
+
+- Clear top-level categorization by change type.
+- Short factual bullets with links or PR references when useful.
+- A final compare-range link as `Full Changelog`.
+- Separation between user-visible features, bug fixes, docs, and maintenance work.
+
+## What not to carry over blindly
+
+- Codex-specific product wording.
+- Sections that have no winsmux content for a given release.
+- Implementation details that belong in PRs or handoff, not public release notes.
+
+## Relevant observations from `rust-v0.119.0`
+
+- The release keeps the body easy to scan by grouping many commits into a few user-meaningful headings.
+- TUI, MCP, remote/app-server, and notification updates are surfaced under `New Features`.
+- Stabilization and usability work are grouped under `Bug Fixes`.
+- README/help wording changes stay under `Documentation`.
+- crate/workspace/CI/compiler work stays under `Chores`.
+- The release ends with a compare link, not a raw dump only.
+
+## winsmux mapping
+
+- `New Features`
+  - user-visible operator shell, orchestration, desktop UX, or release capabilities
+- `Bug Fixes`
+  - regressions, fail-close behavior, runtime fixes, review-path fixes
+- `Documentation`
+  - public docs, help text, release wording, handoff-related public docs when user-facing
+- `Chores`
+  - CI/workflow maintenance, internal cleanup, non-user-facing refactors
+- `Full Changelog`
+  - compare link between the previous release tag and the current release tag

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,16 @@ When generating or editing a release:
 1. Use English section headings and bullets for the public GitHub Release body.
 2. Keep the GitHub Release body aligned with the `/release-notes` structure, but in English.
 3. Local or private post drafts may be Japanese if the task explicitly asks for them, but the public GitHub Release stays English.
+4. Follow the current `openai/codex` release template as the default public structure unless the user explicitly requests otherwise.
+5. Use these section headings in this order when they are relevant:
+   - `New Features`
+   - `Bug Fixes`
+   - `Documentation`
+   - `Chores`
+   - `Full Changelog`
+6. Prefer omitting empty sections rather than leaving placeholders.
+7. `Full Changelog` should point to the compare range for the released tags when that range is available.
+8. When winsmux reuses Codex release phrasing or structure, keep the wording adapted to winsmux facts rather than copying Codex release text verbatim.
 
 ## Third-Party UI Attribution
 
@@ -116,3 +126,4 @@ Codex must follow these rules:
    - reduce concurrent agents,
    - increase wait time,
    - or document the blocker clearly before continuing.
+8. At the end of each implementation or review slice, close all completed or abandoned subagents that are no longer needed. Do not leave idle agents open across unrelated slices.

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -1,6 +1,6 @@
 # Handoff
 
-> Updated: 2026-04-11T01:40:14+09:00
+> Updated: 2026-04-11T08:50:25+09:00
 > Source of truth: this file
 
 ## Current state
@@ -10,7 +10,7 @@
 - `v0.19.7 visible orchestration` is implemented, merged, released, and tracked as `100% (7/7)` in the external planning backlog/roadmap.
 - `v0.19.8 External Operator & Agent Slots` is implemented in order; private planning now tracks `TASK-259`, `TASK-261`, `TASK-262`, `TASK-263`, and `TASK-264` as done, and the external roadmap is synced accordingly.
 - Private planning now swaps `v0.20.0` and `v0.21.0` to match actual implementation order: `v0.20.0` is `Desktop UX Foundation`, and `v0.21.0` is `Operator Core & Slot Dispatch`.
-- PR [#370](https://github.com/Sora-bluesky/winsmux/pull/370), PR [#371](https://github.com/Sora-bluesky/winsmux/pull/371), PR [#372](https://github.com/Sora-bluesky/winsmux/pull/372), PR [#374](https://github.com/Sora-bluesky/winsmux/pull/374), PR [#375](https://github.com/Sora-bluesky/winsmux/pull/375), PR [#376](https://github.com/Sora-bluesky/winsmux/pull/376), PR [#379](https://github.com/Sora-bluesky/winsmux/pull/379), PR [#380](https://github.com/Sora-bluesky/winsmux/pull/380), PR [#381](https://github.com/Sora-bluesky/winsmux/pull/381), PR [#382](https://github.com/Sora-bluesky/winsmux/pull/382), PR [#383](https://github.com/Sora-bluesky/winsmux/pull/383), PR [#384](https://github.com/Sora-bluesky/winsmux/pull/384), PR [#385](https://github.com/Sora-bluesky/winsmux/pull/385), PR [#386](https://github.com/Sora-bluesky/winsmux/pull/386), PR [#387](https://github.com/Sora-bluesky/winsmux/pull/387), PR [#388](https://github.com/Sora-bluesky/winsmux/pull/388), and PR [#389](https://github.com/Sora-bluesky/winsmux/pull/389) are merged into `main`.
+- PR [#370](https://github.com/Sora-bluesky/winsmux/pull/370), PR [#371](https://github.com/Sora-bluesky/winsmux/pull/371), PR [#372](https://github.com/Sora-bluesky/winsmux/pull/372), PR [#374](https://github.com/Sora-bluesky/winsmux/pull/374), PR [#375](https://github.com/Sora-bluesky/winsmux/pull/375), PR [#376](https://github.com/Sora-bluesky/winsmux/pull/376), PR [#379](https://github.com/Sora-bluesky/winsmux/pull/379), PR [#380](https://github.com/Sora-bluesky/winsmux/pull/380), PR [#381](https://github.com/Sora-bluesky/winsmux/pull/381), PR [#382](https://github.com/Sora-bluesky/winsmux/pull/382), PR [#383](https://github.com/Sora-bluesky/winsmux/pull/383), PR [#384](https://github.com/Sora-bluesky/winsmux/pull/384), PR [#385](https://github.com/Sora-bluesky/winsmux/pull/385), PR [#386](https://github.com/Sora-bluesky/winsmux/pull/386), PR [#387](https://github.com/Sora-bluesky/winsmux/pull/387), PR [#388](https://github.com/Sora-bluesky/winsmux/pull/388), PR [#389](https://github.com/Sora-bluesky/winsmux/pull/389), and PR [#390](https://github.com/Sora-bluesky/winsmux/pull/390) are merged into `main`.
 - Planning source of truth is externalized outside the public repository and syncs automatically into the private planning root.
 - `v0.21.x` private planning is aligned to a conversation-first Tauri operator shell, with Codex-App-like shell rules reflected in Figma and backlog notes.
 - `v0.24.x` private planning is split into schema, ledger, machine contract, cutover, and canary phases for Rust runtime convergence before `v1.0.0`.
@@ -54,6 +54,9 @@
 - Started the next `v0.20.0` desktop UX slice on top of `TASK-138`, unifying source-control/worktree mock data into a single `sourceControlState` view model and wiring sidebar source summary, source-entry filters, context overview cards, and changed-file rows to the same state.
 - Merged the `TASK-138` source-control context slice via PR [#389](https://github.com/Sora-bluesky/winsmux/pull/389), making the desktop UX source-control surface worktree-aware and editor-linked from a single `sourceControlState`.
 - Started the `TASK-101` theme-contract slice on `codex/task101-theme-contract-20260411`, adding semantic theme tokens, Codex-derived typography tokens, and `Theme / Density / Wrap` state to the settings sheet.
+- Merged the `TASK-101` theme-contract slice via PR [#390](https://github.com/Sora-bluesky/winsmux/pull/390), adding semantic shell tokens, display preferences, and more concrete Codex OSS attribution tracking for typography, wrapping, footer, and settings affordances.
+- Reviewed the official [openai/codex `rust-v0.119.0` release](https://github.com/openai/codex/releases/tag/rust-v0.119.0) and persisted winsmux release-format alignment in [AGENTS.md](../AGENTS.md) and [.references/2026-04-11-CODEX_RELEASE_TEMPLATE_ALIGNMENT.md](../.references/2026-04-11-CODEX_RELEASE_TEMPLATE_ALIGNMENT.md).
+- Closed idle/abandoned review and explorer subagents after their slices, and strengthened the durable rule so completed or abandoned agents do not stay open across unrelated work.
 
 ## Validation
 
@@ -76,10 +79,11 @@
 - PR [#388](https://github.com/Sora-bluesky/winsmux/pull/388) merged cleanly and the repo is back to `main == origin/main`.
 - Current `TASK-138` source-control slice passes frontend build: `npm run build` in `winsmux-app`.
 - Current `TASK-101` theme-contract slice passes frontend build: `npm run build` in `winsmux-app`.
+- PR [#390](https://github.com/Sora-bluesky/winsmux/pull/390) merged cleanly and the repo is back to `main == origin/main`.
 
 ## Next actions
 
-1. Publish the active `TASK-101` theme-contract slice, then continue `v0.20.0: Desktop UX Foundation` toward richer editor/context integration and Codex-derived styling convergence.
+1. Continue `v0.20.0: Desktop UX Foundation` toward `TASK-286` conversation timeline refinement and remaining desktop UX polish.
 2. Preserve the private planning sync flow: user/agent visible, auto-synced, but not committed to the public repo.
 3. Run the next retro-review tranche over recent merged PRs after each milestone-close sequence.
 


### PR DESCRIPTION
## Summary
- persist Codex-style GitHub Release formatting as a durable project rule
- add a reference note for the official rust-v0.119.0 release template
- refresh handoff with PR #390 merge and release-format alignment

## Validation
- manual diff review
- official reference checked against https://github.com/openai/codex/releases/tag/rust-v0.119.0