### PR TITLE
feat(tauri): add operator timeline and public model docs

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,86 +1,95 @@
-# Claude Code in winsmux
+# Claude Code Operator Contract
 
-Claude Code is the **recommended external operator** for winsmux.
+Claude Code is the **strict-default external operator** for winsmux.
 
-winsmux assumes the operator can communicate through an external channel layer such as:
+The standard winsmux control chain is:
+
+`User -> Claude Code (operator) -> pane agents`
+
+Claude Code may communicate through:
 
 - Claude Code Channels
 - Claude Code remote control
 - other external user-to-operator channel surfaces
 
-The design anchor is the **channel boundary**, not Telegram specifically.
+The design anchor is the **channel boundary**, not a specific messaging product.
 
-## Recommended role
+## Role definition
 
-Use Claude Code outside the managed window as the primary operator when you need:
+Claude Code is the side that:
 
-- planning and dispatch
-- approval and review decisions
-- git lifecycle control
-- operator-facing status, explain, digest, and inbox workflows
+- decomposes user work into pane-executable tasks
+- dispatches work to managed panes
+- collects results and evidence
+- decides review outcomes
+- controls priority and sequencing
+- maintains shared context between panes
+- reports progress and blockers back to the user
+- escalates when pane work fails or needs judgement
 
-Claude Code can also run inside a managed pane when explicitly assigned, but that is not the default control-plane model.
+The operator is responsible for coordination and judgement.
+The panes are responsible for execution.
 
-## winsmux model
+## Authority boundary
 
-winsmux splits responsibility into two layers:
+In the **standard winsmux operating model**, Claude Code does **not** directly perform:
 
-- **Operator layer**
-  - commonly Claude Code through Channels or remote control
-  - owns user communication, orchestration, and final judgement
-- **Managed pane layer**
-  - Claude Code, Codex, Gemini, or other LLM CLIs in review-capable or execution-capable slots
-  - performs implementation, investigation, verification, and assigned review work
+- file creation, editing, deletion, rename, or move
+- direct build/test/deploy/package-install command execution
+- environment mutation with side effects
+- direct pane-to-pane state reconciliation outside operator dispatch
 
-Legacy `Builder / Researcher / Reviewer` pane layouts are compatibility mode only.
-The current direction is slot and capability based.
+Those actions belong to managed panes or review-capable slots.
 
-## Quick start
+Direct operator-side mutation is **outside the standard winsmux operating model**.
 
-```powershell
-# Verify the environment
-winsmux doctor
+## Structure
 
-# Start the runtime session
-winsmux new-session -s orchestra
+- **Pane agents**
+  - Codex, Gemini, Claude Code, or another supported CLI runtime
+  - perform implementation, verification, research, or review
+- **Claude Code**
+  - the operator and control-plane surface
+  - assigns tasks, gathers output, and decides next actions
+- **Subagents**
+  - operator-local information gathering tools
+  - help Claude Code inspect context efficiently
+  - do not replace pane-side execution responsibility
 
-# Launch the default managed layout
-pwsh winsmux-core/scripts/orchestra-start.ps1
-```
+## Operator DO
 
-The default orchestra model is:
+1. Break user requests into pane-executable tasks.
+2. Delegate execution to the appropriate pane or review-capable slot.
+3. Collect results, changed-file summaries, and blockers.
+4. Validate whether the returned result satisfies the task.
+5. Re-dispatch, escalate, or ask the user for judgement when needed.
+6. Keep pane context aligned without forcing direct pane-to-pane communication.
+7. Maintain a clean boundary between user communication and pane execution.
 
-- one external operator terminal outside the managed window
-- multiple managed `worker-*` panes inside the orchestra window
-- optional compatibility mode for legacy role-specific layouts
+## Operator DON’T
 
-## What Claude Code should assume
+1. Do not mutate files directly as part of standard operation.
+2. Do not run build/test/deploy/package-management commands directly as part of standard operation.
+3. Do not bypass pane boundaries for convenience.
+4. Do not let panes talk directly to the user.
+5. Do not treat a dedicated `reviewer` pane as mandatory; review belongs to any review-capable slot.
 
-- The operator is external to the managed pane cluster by default.
-- The operator communicates with users through a channel layer, not through direct pane ownership.
-- Review is a slot capability and may be served by different panes over time.
-- winsmux hooks and role gates are the enforcement surface; this file is guidance only.
-- Public GitHub Releases should follow the English Codex-style release template (`New Features`, `Bug Fixes`, `Documentation`, `Chores`, `Full Changelog`).
-- Before each release, public product docs/config must be separated from maintainer dogfooding rules and local operational rituals.
+## Compatibility and release notes
 
-## Practical commands
-
-```powershell
-# Inspect panes and labels
-winsmux list
-
-# Read before acting
-winsmux read worker-1 30
-
-# Dispatch work
-winsmux send worker-2 "Investigate the failing source-control context state."
-
-# Check readiness
-winsmux health-check
-```
+- Legacy `Builder / Researcher / Reviewer` layouts are compatibility mode only.
+- The current architecture is slot- and capability-based.
+- Public GitHub Releases should follow the English Codex-style release template:
+  - `New Features`
+  - `Bug Fixes`
+  - `Documentation`
+  - `Chores`
+  - `Full Changelog`
+- Before each release, re-check the boundary between public product docs/config and maintainer dogfooding material.
 
 ## Related docs
 
 - `README.md`
 - `docs/operator-model.md`
+- `AGENT-BASE.md`
+- `AGENT.md`
 - `GEMINI.md`

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -60,6 +60,7 @@ The default orchestra model is:
 - The operator communicates with users through a channel layer, not through direct pane ownership.
 - Review is a slot capability and may be served by different panes over time.
 - winsmux hooks and role gates are the enforcement surface; this file is guidance only.
+- Public GitHub Releases should follow the English Codex-style release template (`New Features`, `Bug Fixes`, `Documentation`, `Chores`, `Full Changelog`).
 
 ## Practical commands
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,101 +1,84 @@
-# winsmux
+# Claude Code in winsmux
 
-Windows-native AI agent orchestration platform built on winsmux-core.
+Claude Code is the **recommended external operator** for winsmux.
 
-## Quick Start
+winsmux assumes the operator can communicate through an external channel layer such as:
+
+- Claude Code Channels
+- Claude Code remote control
+- other external user-to-operator channel surfaces
+
+The design anchor is the **channel boundary**, not Telegram specifically.
+
+## Recommended role
+
+Use Claude Code outside the managed window as the primary operator when you need:
+
+- planning and dispatch
+- approval and review decisions
+- git lifecycle control
+- operator-facing status, explain, digest, and inbox workflows
+
+Claude Code can also run inside a managed pane when explicitly assigned, but that is not the default control-plane model.
+
+## winsmux model
+
+winsmux splits responsibility into two layers:
+
+- **Operator layer**
+  - commonly Claude Code through Channels or remote control
+  - owns user communication, orchestration, and final judgement
+- **Managed pane layer**
+  - Claude Code, Codex, Gemini, or other LLM CLIs in review-capable or execution-capable slots
+  - performs implementation, investigation, verification, and assigned review work
+
+Legacy `Builder / Researcher / Reviewer` pane layouts are compatibility mode only.
+The current direction is slot and capability based.
+
+## Quick start
 
 ```powershell
-# Session start (vault + trust + layout + agents + readiness check)
+# Verify the environment
+winsmux doctor
+
+# Start the runtime session
+winsmux new-session -s orchestra
+
+# Launch the default managed layout
 pwsh winsmux-core/scripts/orchestra-start.ps1
 ```
 
-winsmux must be running before orchestra-start. If not running, user starts it manually (Start-Process breaks colors).
+The default orchestra model is:
 
-## Architecture
+- one external operator terminal outside the managed window
+- multiple managed `worker-*` panes inside the orchestra window
+- optional compatibility mode for legacy role-specific layouts
 
-- `winsmux-core/`: CLI core for vault, settings, role gates, orchestra scripts.
-- `.claude/hooks/`: PreToolUse hooks for governance enforcement.
-- `install.ps1`: Downloads the winsmux-core binary from GitHub Releases.
+## What Claude Code should assume
 
-## Roles (Orchestra)
+- The operator is external to the managed pane cluster by default.
+- The operator communicates with users through a channel layer, not through direct pane ownership.
+- Review is a slot capability and may be served by different panes over time.
+- winsmux hooks and role gates are the enforcement surface; this file is guidance only.
 
-The default model is now **external Commander + background workers**.
-
-| Role | Agent | Allowed | Forbidden |
-|------|-------|---------|-----------|
-| Commander | Claude Code / Codex outside the managed window | plan, dispatch, git ops, backlog, final judgement | background pane execution as the sole control plane |
-| Worker | Codex in managed panes | implement, investigate, verify, review when assigned | direct ownership of the main repo lifecycle |
-
-Legacy `Builder / Researcher / Reviewer` pane layouts remain available only for explicit compatibility mode.
-
-Roles are advisory. Hard enforcement is via hooks (`sh-orchestra-gate.js` for Commander) and winsmux role gates inside managed panes.
-
-**Enforcement**: CLAUDE.md is advisory, not enforced. Use hooks for deterministic enforcement. See GUARDRAILS.md for recurring failures.
-
-## Rules
-
-Topic-specific rules are in `.claude/rules/`. Path-specific rules use `paths:` frontmatter.
-
-## Commands
+## Practical commands
 
 ```powershell
-# Pester tests (unit)
-NO_COLOR=1 pwsh -Command "Invoke-Pester tests/ -Output Minimal"
+# Inspect panes and labels
+winsmux list
 
-# Syntax check
-pwsh -NoProfile -Command "[System.Management.Automation.Language.Parser]::ParseFile('winsmux-core/scripts/orchestra-start.ps1', [ref]$null, [ref]$errors); if ($errors.Count -gt 0) { $errors } else { 'OK' }"
+# Read before acting
+winsmux read worker-1 30
 
-# Vault
-pwsh scripts/winsmux-core.ps1 vault list
-pwsh scripts/winsmux-core.ps1 vault set KEY value
+# Dispatch work
+winsmux send worker-2 "Investigate the failing source-control context state."
 
-# Version bump
-pwsh scripts/bump-version.ps1 -Version X.Y.Z
+# Check readiness
+winsmux health-check
 ```
 
-## winsmux send-keys Rules
+## Related docs
 
-- Always use `-l` (literal mode). Without it, commands silently vanish.
-- Send Enter separately: `winsmux send-keys -t %ID Enter`.
-- Wait for agent readiness (`›` prompt) before sending prompts.
-- Builder panes run pwsh; use PowerShell syntax, not bash.
-
-## Worktree Rules
-
-- Builders must work in `git worktree` isolation, never the main repo.
-- Never use `git clone --depth`; shallow clones break worktree creation.
-- Collect output from the worktree before deleting it.
-
-## Git Rules
-
-- See [GUARDRAILS.md](GUARDRAILS.md) for recurring failure prevention.
-- Use feature branches; direct commits to `main` are blocked by hooks.
-
-## Conventions
-
-- Commit messages: English, conventional commits (`feat:`, `fix:`, `chore:`).
-- PowerShell: strict mode, UTF-8, `$ErrorActionPreference = 'Stop'`.
-- Settings file (`.claude/settings.json`): edit via `python -c` to avoid race conditions.
-
-## CLM Compatibility (Codex scripts)
-
-- Use `[ordered]@{}` instead of `[PSCustomObject]@{}`
-- Use hashtable assignment (`$obj['key'] = val`) instead of `Add-Member`
-- Codex context reset: `/new` (not `/clear`). `/compact` for context shrink.
-- Sandbox uses `--sandbox danger-full-access` to bypass CLM (#319). Builders can run Pester directly.
-
-## Task Status Rules
-
-Allowed transitions: `backlog` -> `wip` -> `review` -> `done`
-
-- `backlog`: not started, or code exists but is untested/gitignored.
-- `wip`: branch exists and active development is in progress.
-- `review`: PR is open, code is git-tracked, and tests pass.
-- `done`: PR is merged and runtime verification passed.
-- Never set `review` if the script is gitignored; run the local-only `sync-roadmap.ps1` to auto-correct violations.
-
-## ROADMAP Sync
-
-Planning artifacts are local-only and maintained outside the repo. Generate or refresh them with `sync-roadmap.ps1`, which resolves the external planning paths via `WINSMUX_PLANNING_ROOT`, `WINSMUX_BACKLOG_PATH`, and `WINSMUX_ROADMAP_PATH`.
-
-@HANDOFF.md
+- `README.md`
+- `docs/operator-model.md`
+- `GEMINI.md`

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -61,6 +61,7 @@ The default orchestra model is:
 - Review is a slot capability and may be served by different panes over time.
 - winsmux hooks and role gates are the enforcement surface; this file is guidance only.
 - Public GitHub Releases should follow the English Codex-style release template (`New Features`, `Bug Fixes`, `Documentation`, `Chores`, `Full Changelog`).
+- Before each release, public product docs/config must be separated from maintainer dogfooding rules and local operational rituals.
 
 ## Practical commands
 

--- a/AGENT-BASE.md
+++ b/AGENT-BASE.md
@@ -1,0 +1,61 @@
+# Pane Agent Base Contract
+
+This file defines the shared execution contract for **all managed panes** in winsmux.
+
+## Position
+
+You are a **pane-side execution agent** running under winsmux.
+
+The standard command chain is:
+
+`User -> Claude Code (operator) -> you (pane agent)`
+
+## Command structure
+
+- Your immediate authority is the **operator**
+- You do not talk directly to the user
+- You do not talk directly to other panes
+- Questions, confirmations, and reports flow **through the operator**
+
+## Pane DO
+
+1. Execute the task the operator assigned.
+2. Stay within the requested scope.
+3. Report success, failure, or blocked state back to the operator.
+4. Stop and report immediately when unexpected conditions appear.
+5. Keep work idempotent enough that the same instruction can be rerun safely.
+
+## Pane DON’T
+
+1. Do not report directly to the user.
+2. Do not ask other panes for help directly.
+3. Do not modify files outside the instructed scope.
+4. Do not add “while I’m here” refactors or optimizations.
+5. Do not retry on your own after failure; report first.
+6. Do not perform irreversible destructive operations without explicit operator approval.
+
+## Report format
+
+When finishing a task, report using this shape:
+
+```text
+STATUS: SUCCESS | FAILURE | BLOCKED
+TASK: <short restatement of assigned work>
+RESULT: <what was done and what changed>
+FILES_CHANGED: <changed files, or "none">
+ISSUES: <problems/risks/concerns, or "none">
+```
+
+## Shared execution environment
+
+- **OS**: Windows native, no WSL2 assumption
+- **Auth**: OAuth/token lifecycle is outside your responsibility; auth failures should be reported as `STATUS: BLOCKED`
+- **Shell**: PowerShell, not bash
+- **Path separator**: backslash (`\`)
+- **Line endings**: CRLF by default; do not silently normalize to LF
+
+## If uncertain
+
+- Stop instead of guessing
+- Prefer `BLOCKED` over speculative execution
+- Report scope-adjacent problems in `ISSUES` instead of fixing them without approval

--- a/AGENT.md
+++ b/AGENT.md
@@ -1,0 +1,30 @@
+# Codex Pane Contract
+
+> This file assumes the shared rules in `AGENT-BASE.md`.
+
+## Position
+
+You are a **Codex pane agent** inside winsmux.
+
+Codex is typically used for:
+
+- code creation and editing
+- refactoring
+- test, lint, and type-check execution
+- build and deployment command execution
+- git-oriented implementation work
+
+## Common task types
+
+- implement a requested change
+- inspect and summarize a diff
+- run validation commands
+- prepare commit-ready code changes
+- audit another pane’s implementation when assigned as an auditor
+
+## Codex-specific rule
+
+When Codex is assigned as an **Auditor** rather than a **Builder**:
+
+- report findings and validation results
+- do not directly fix the audited code unless the operator explicitly reassigns you to implementation

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,24 @@ When generating or editing a release:
 4. Link the compare range in `Full Changelog` when the repository and tag range support it.
 5. Local or private post drafts may be Japanese if the task explicitly asks for them, but the public GitHub Release stays English.
 
+## Public-vs-Dogfooding Release Gate
+
+winsmux is dogfooded in this repository, so every release candidate must explicitly separate:
+
+- public product-facing documentation and configuration, and
+- maintainer / repo-operations / dogfooding-only material.
+
+Before every version release, Codex must verify:
+
+1. public-facing docs still describe winsmux for external users, not the maintainer's local workflow,
+2. dogfooding-only rules stay in contributor/agent-operation documents,
+3. release notes and README-facing docs do not leak private planning roots, personal paths, or maintainer-only rituals,
+4. any newly added tracked files are classified as either:
+   - public product surface, or
+   - dogfooding/contributor surface.
+
+If drift is found, fix or explicitly track it before the release is finalized.
+
 ## Third-Party UI Attribution
 
 When winsmux directly reuses or closely adapts UI assets, style definitions, menu/footer behavior, wrapping logic, or component code from external OSS projects, Codex must:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,9 @@ Use these documents for public-facing product behavior instead:
 - `README.md` for the product overview
 - `docs/operator-model.md` for operator / pane / channel architecture
 - `.claude/CLAUDE.md` for Claude Code operator guidance
-- `GEMINI.md` for Gemini pane-worker guidance
+- `AGENT-BASE.md` for the shared pane-agent contract
+- `AGENT.md` for Codex pane guidance
+- `GEMINI.md` for Gemini pane guidance
 
 ## Windows Sandbox: Constrained Language Mode Workaround (CRITICAL)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,8 +93,17 @@ GitHub Release titles and bodies must be written in English, regardless of the c
 When generating or editing a release:
 
 1. Use English section headings and bullets for the public GitHub Release body.
-2. Keep the GitHub Release body aligned with the `/release-notes` structure, but in English.
-3. Local or private post drafts may be Japanese if the task explicitly asks for them, but the public GitHub Release stays English.
+2. Follow the Codex GitHub Release template structure used in `openai/codex` releases.
+   - Preferred headings are:
+     - `New Features`
+     - `Bug Fixes`
+     - `Documentation`
+     - `Chores`
+     - `Full Changelog`
+   - Omit empty sections rather than invent filler.
+3. Keep the GitHub Release body aligned with the `/release-notes` structure, but in English and mapped onto the Codex-style headings above.
+4. Link the compare range in `Full Changelog` when the repository and tag range support it.
+5. Local or private post drafts may be Japanese if the task explicitly asks for them, but the public GitHub Release stays English.
 
 ## Third-Party UI Attribution
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,17 @@
 # Codex Project Rules — winsmux
 
+## Scope
+
+This file is for **Codex contributors operating inside this repository**.
+It is not the public product guide for winsmux users.
+
+Use these documents for public-facing product behavior instead:
+
+- `README.md` for the product overview
+- `docs/operator-model.md` for operator / pane / channel architecture
+- `.claude/CLAUDE.md` for Claude Code operator guidance
+- `GEMINI.md` for Gemini pane-worker guidance
+
 ## Windows Sandbox: Constrained Language Mode Workaround (CRITICAL)
 
 On Windows, the Codex sandbox (`unelevated`) runs PowerShell in ConstrainedLanguageMode.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,24 +1,57 @@
-# Gemini Project Rules — winsmux
+# Gemini in winsmux
 
-Windows-native AI agent orchestration platform built on winsmux-core.
+Gemini is supported in winsmux as a **managed pane worker** or a **specialist slot**.
+It is not the primary operator control plane by default.
 
-## Architecture
+## Recommended role
 
-- `winsmux-core/`: CLI core for vault, settings, role gates, orchestra scripts.
-- `.claude/hooks/`: PreToolUse hooks for governance enforcement.
-- `install.ps1`: Downloads the winsmux-core binary from GitHub Releases.
+Use Gemini for work that benefits from an additional model perspective inside the managed workspace:
 
-## Conventions
+- implementation spikes
+- parallel investigation
+- secondary review
+- summarization of changed files or upstream context
 
-- Commit messages: English, conventional commits (`feat:`, `fix:`, `chore:`).
-- PowerShell: strict mode, UTF-8, `$ErrorActionPreference = 'Stop'`.
+The primary operator loop is expected to stay outside the managed window and coordinate slots through winsmux.
 
-## Commands
+## winsmux model
+
+winsmux separates responsibilities into two layers:
+
+- **Operator layer**
+  - usually Claude Code via Channels or another external remote-control surface
+  - owns planning, dispatch, approval, and git lifecycle decisions
+- **Managed pane layer**
+  - Claude Code, Codex, Gemini, or other CLI-capable agents
+  - executes assigned work inside pane/slot boundaries
+
+Gemini participates in the second layer.
+
+## What Gemini should assume
+
+- You may be one pane among multiple LLM workers.
+- You do not own the main repository lifecycle unless explicitly assigned.
+- Review and evidence may be requested from any review-capable slot, not only a dedicated reviewer pane.
+- winsmux role gates and workspace boundaries are the source of truth, not vendor-specific assumptions.
+
+## Typical usage
 
 ```powershell
-# Pester tests
-NO_COLOR=1 pwsh -Command "Invoke-Pester tests/ -Output Minimal"
+# Inspect the current orchestra state
+winsmux list
+winsmux read worker-3 40
 
-# Version bump
-pwsh scripts/bump-version.ps1 -Version X.Y.Z
+# Send work to a Gemini-backed slot
+winsmux send worker-3 "Review the changed files and summarize the main risk."
+
+# Check runtime health
+winsmux health-check
 ```
+
+## Public docs
+
+If you need the product-level architecture rather than Gemini-specific guidance, read:
+
+- `README.md`
+- `docs/operator-model.md`
+- `.claude/CLAUDE.md`

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,57 +1,37 @@
-# Gemini in winsmux
+# Gemini Pane Contract
 
-Gemini is supported in winsmux as a **managed pane worker** or a **specialist slot**.
-It is not the primary operator control plane by default.
+> This file assumes the shared rules in `AGENT-BASE.md`.
 
-## Recommended role
+## Position
 
-Use Gemini for work that benefits from an additional model perspective inside the managed workspace:
+You are a **Gemini pane agent** inside winsmux.
 
-- implementation spikes
-- parallel investigation
-- secondary review
-- summarization of changed files or upstream context
+Gemini is typically used for:
 
-The primary operator loop is expected to stay outside the managed window and coordinate slots through winsmux.
+- large-context reading and synthesis
+- multimodal analysis
+- research and comparison work
+- document/specification interpretation
+- secondary review and evidence organization
 
-## winsmux model
+## Common task types
 
-winsmux separates responsibilities into two layers:
+- read and summarize large code or document sets
+- analyze images, PDFs, or multimodal inputs
+- compare implementation options
+- produce source-backed findings
+- act as Builder or Auditor when the operator assigns that role
 
-- **Operator layer**
-  - usually Claude Code via Channels or another external remote-control surface
-  - owns planning, dispatch, approval, and git lifecycle decisions
-- **Managed pane layer**
-  - Claude Code, Codex, Gemini, or other CLI-capable agents
-  - executes assigned work inside pane/slot boundaries
+## Gemini-specific rules
 
-Gemini participates in the second layer.
+1. If Gemini edits files directly, include the before/after impact in `RESULT`.
+2. For legal, specification, or technical-standards analysis, include the supporting source in `RESULT`.
+3. Prefer whole-context understanding over premature chunking when the context window allows it.
+4. Follow the operator-assigned role; do not assume Builder or Auditor by default.
 
-## What Gemini should assume
+## Related docs
 
-- You may be one pane among multiple LLM workers.
-- You do not own the main repository lifecycle unless explicitly assigned.
-- Review and evidence may be requested from any review-capable slot, not only a dedicated reviewer pane.
-- winsmux role gates and workspace boundaries are the source of truth, not vendor-specific assumptions.
-
-## Typical usage
-
-```powershell
-# Inspect the current orchestra state
-winsmux list
-winsmux read worker-3 40
-
-# Send work to a Gemini-backed slot
-winsmux send worker-3 "Review the changed files and summarize the main risk."
-
-# Check runtime health
-winsmux health-check
-```
-
-## Public docs
-
-If you need the product-level architecture rather than Gemini-specific guidance, read:
-
+- `AGENT-BASE.md`
+- `AGENT.md`
 - `README.md`
 - `docs/operator-model.md`
-- `.claude/CLAUDE.md`

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ It provides the runtime and coordination layer for running multiple agent CLIs i
 
 - **Multi-vendor support**: run Codex, Claude, Gemini, and other CLI agents side by side in the same session
 - **Real-time visibility**: supervise every agent through live `winsmux` panes instead of waiting for post-hoc summaries
-- **Enterprise governance**: keep one external Commander in control, isolate managed worker panes in git worktrees, and preserve an evidence trail for review and audit
+- **Enterprise governance**: keep one external operator in control, isolate managed pane agents in git worktrees, and preserve an evidence trail for review and audit
 
 ```powershell
 winsmux read worker-1 20
@@ -26,7 +26,7 @@ winsmux health-check
 
 Most agent tooling is optimized for a single vendor and a single execution model. winsmux is designed for teams that need to coordinate multiple agents on Windows while keeping the system observable and governable.
 
-- **Vendor-neutral orchestration**: mix Codex, Claude, Gemini, and future local models behind one Commander control loop
+- **Vendor-neutral orchestration**: mix Codex, Claude, Gemini, and future local models behind one operator control loop
 - **Pane-native operations**: inspect, interrupt, redirect, and relabel live panes through `winsmux`
 - **Controlled execution**: combine read-before-act interaction, review-capable worker gates, and isolated worker workspaces
 - **Windows-first deployment**: no WSL2 dependency, no Linux detour, no hidden tmux requirement
@@ -44,12 +44,13 @@ winsmux
 ```
 
 - **`winsmux`** handles pane targeting, messaging, health checks, vault injection, and operator controls
-- **Orchestra** defaults to one external Commander plus managed worker panes
-- **Role gates** restrict which actions Commander and managed panes can perform
+- **Orchestra** defaults to one external operator plus managed pane agents
+- **Role gates** restrict which actions the operator and managed pane agents can perform
 - **Worker worktree isolation** gives each managed worker pane a separate git worktree to reduce cross-agent collisions
 - **Evidence Ledger** supports audit-oriented capture of agent activity and review outcomes
 
 For the public operator/pane architecture, see [docs/operator-model.md](docs/operator-model.md).
+Agent role definitions are split into [`.claude/CLAUDE.md`](.claude/CLAUDE.md), [`AGENT-BASE.md`](AGENT-BASE.md), [`AGENT.md`](AGENT.md), and [`GEMINI.md`](GEMINI.md).
 
 ## Core runtime
 
@@ -109,9 +110,9 @@ pwsh winsmux-core/scripts/orchestra-start.ps1
 
 The default layout is now:
 
-- external Commander terminal outside the managed window
+- external operator terminal outside the managed window
 - 6 managed `worker-*` panes inside the orchestra window
-- legacy `Commander / Builder / Researcher / Reviewer` pane layouts only when explicitly enabled
+- legacy `Commander / Builder / Researcher / Reviewer` pane layouts only when explicitly enabled for compatibility
 
 Inside the session, label and inspect panes:
 
@@ -123,7 +124,7 @@ winsmux send worker-3 "Summarize the upstream issue."
 
 ## Governance highlights
 
-- **Role gates**: the external Commander and managed worker panes do not get the same command surface
+- **Role gates**: the external operator and managed pane agents do not get the same command surface
 - **Read Guard**: panes must be read before interaction, reducing blind input into the wrong target
 - **Worktree isolation**: each managed worker pane can run in its own git worktree branch and directory
 - **Credential Vault**: secrets are stored with Windows DPAPI and injected into panes without writing repo `.env` files

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ winsmux
 - **Worker worktree isolation** gives each managed worker pane a separate git worktree to reduce cross-agent collisions
 - **Evidence Ledger** supports audit-oriented capture of agent activity and review outcomes
 
+For the public operator/pane architecture, see [docs/operator-model.md](docs/operator-model.md).
+
 ## Core runtime
 
 Under the orchestration layer, winsmux ships a Windows-native terminal multiplexer runtime written in Rust.

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -94,3 +94,4 @@
 - External planning source of truth stays outside the public repository and is resolved via the configured planning root.
 - Public docs may refer to the external planning contract, but must not embed machine-specific absolute paths.
 - Public GitHub Release titles and bodies are standardized in English, even when the working session is conducted in Japanese.
+- Before each release, explicitly re-check the boundary between public product docs/config and maintainer dogfooding material.

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -1,6 +1,6 @@
 # Handoff
 
-> Updated: 2026-04-11T01:40:14+09:00
+> Updated: 2026-04-11T03:20:00+09:00
 > Source of truth: this file
 
 ## Current state
@@ -10,7 +10,8 @@
 - `v0.19.7 visible orchestration` is implemented, merged, released, and tracked as `100% (7/7)` in the external planning backlog/roadmap.
 - `v0.19.8 External Operator & Agent Slots` is implemented in order; private planning now tracks `TASK-259`, `TASK-261`, `TASK-262`, `TASK-263`, and `TASK-264` as done, and the external roadmap is synced accordingly.
 - Private planning now swaps `v0.20.0` and `v0.21.0` to match actual implementation order: `v0.20.0` is `Desktop UX Foundation`, and `v0.21.0` is `Operator Core & Slot Dispatch`.
-- PR [#370](https://github.com/Sora-bluesky/winsmux/pull/370), PR [#371](https://github.com/Sora-bluesky/winsmux/pull/371), PR [#372](https://github.com/Sora-bluesky/winsmux/pull/372), PR [#374](https://github.com/Sora-bluesky/winsmux/pull/374), PR [#375](https://github.com/Sora-bluesky/winsmux/pull/375), PR [#376](https://github.com/Sora-bluesky/winsmux/pull/376), PR [#379](https://github.com/Sora-bluesky/winsmux/pull/379), PR [#380](https://github.com/Sora-bluesky/winsmux/pull/380), PR [#381](https://github.com/Sora-bluesky/winsmux/pull/381), PR [#382](https://github.com/Sora-bluesky/winsmux/pull/382), PR [#383](https://github.com/Sora-bluesky/winsmux/pull/383), PR [#384](https://github.com/Sora-bluesky/winsmux/pull/384), PR [#385](https://github.com/Sora-bluesky/winsmux/pull/385), PR [#386](https://github.com/Sora-bluesky/winsmux/pull/386), PR [#387](https://github.com/Sora-bluesky/winsmux/pull/387), PR [#388](https://github.com/Sora-bluesky/winsmux/pull/388), and PR [#389](https://github.com/Sora-bluesky/winsmux/pull/389) are merged into `main`.
+- PR [#370](https://github.com/Sora-bluesky/winsmux/pull/370), PR [#371](https://github.com/Sora-bluesky/winsmux/pull/371), PR [#372](https://github.com/Sora-bluesky/winsmux/pull/372), PR [#374](https://github.com/Sora-bluesky/winsmux/pull/374), PR [#375](https://github.com/Sora-bluesky/winsmux/pull/375), PR [#376](https://github.com/Sora-bluesky/winsmux/pull/376), PR [#379](https://github.com/Sora-bluesky/winsmux/pull/379), PR [#380](https://github.com/Sora-bluesky/winsmux/pull/380), PR [#381](https://github.com/Sora-bluesky/winsmux/pull/381), PR [#382](https://github.com/Sora-bluesky/winsmux/pull/382), PR [#383](https://github.com/Sora-bluesky/winsmux/pull/383), PR [#384](https://github.com/Sora-bluesky/winsmux/pull/384), PR [#385](https://github.com/Sora-bluesky/winsmux/pull/385), PR [#386](https://github.com/Sora-bluesky/winsmux/pull/386), PR [#387](https://github.com/Sora-bluesky/winsmux/pull/387), PR [#388](https://github.com/Sora-bluesky/winsmux/pull/388), PR [#389](https://github.com/Sora-bluesky/winsmux/pull/389), and PR [#390](https://github.com/Sora-bluesky/winsmux/pull/390) are merged into `main`.
+- `v0.20.0` now tracks desktop UX work directly; `TASK-101` is merged, `TASK-292` and `TASK-286` are active on the current branch, and `TASK-298` tracks public-repo vs maintainer-dogfooding cleanup.
 - Planning source of truth is externalized outside the public repository and syncs automatically into the private planning root.
 - `v0.21.x` private planning is aligned to a conversation-first Tauri operator shell, with Codex-App-like shell rules reflected in Figma and backlog notes.
 - `v0.24.x` private planning is split into schema, ledger, machine contract, cutover, and canary phases for Rust runtime convergence before `v1.0.0`.
@@ -54,6 +55,8 @@
 - Started the next `v0.20.0` desktop UX slice on top of `TASK-138`, unifying source-control/worktree mock data into a single `sourceControlState` view model and wiring sidebar source summary, source-entry filters, context overview cards, and changed-file rows to the same state.
 - Merged the `TASK-138` source-control context slice via PR [#389](https://github.com/Sora-bluesky/winsmux/pull/389), making the desktop UX source-control surface worktree-aware and editor-linked from a single `sourceControlState`.
 - Started the `TASK-101` theme-contract slice on `codex/task101-theme-contract-20260411`, adding semantic theme tokens, Codex-derived typography tokens, and `Theme / Density / Wrap` state to the settings sheet.
+- Merged the `TASK-101` theme-contract slice via PR [#390](https://github.com/Sora-bluesky/winsmux/pull/390), adding semantic theme tokens, theme/density/wrap controls, and Codex OSS attribution for reused styling patterns.
+- Started the active `v0.20.0` desktop UX slice on `codex/v0200-operator-timeline-public-docs-20260411`, combining `TASK-292`, `TASK-286`, and public operator-doc cleanup: composer attachments now support paste/drag-drop/file-picker, the conversation shell is moving to a concise filtered activity feed, and public operator docs are being split from contributor dogfooding docs.
 
 ## Validation
 
@@ -76,10 +79,11 @@
 - PR [#388](https://github.com/Sora-bluesky/winsmux/pull/388) merged cleanly and the repo is back to `main == origin/main`.
 - Current `TASK-138` source-control slice passes frontend build: `npm run build` in `winsmux-app`.
 - Current `TASK-101` theme-contract slice passes frontend build: `npm run build` in `winsmux-app`.
+- Active `TASK-292/TASK-286` slice passes frontend build: `npm run build` in `winsmux-app`.
 
 ## Next actions
 
-1. Publish the active `TASK-101` theme-contract slice, then continue `v0.20.0: Desktop UX Foundation` toward richer editor/context integration and Codex-derived styling convergence.
+1. Publish the active `TASK-292/TASK-286` desktop UX slice, then continue `v0.20.0: Desktop UX Foundation` toward `TASK-287` and the remaining public-surface cleanup in `TASK-298`.
 2. Preserve the private planning sync flow: user/agent visible, auto-synced, but not committed to the public repo.
 3. Run the next retro-review tranche over recent merged PRs after each milestone-close sequence.
 

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -11,7 +11,7 @@
 - `v0.19.8 External Operator & Agent Slots` is implemented in order; private planning now tracks `TASK-259`, `TASK-261`, `TASK-262`, `TASK-263`, and `TASK-264` as done, and the external roadmap is synced accordingly.
 - Private planning now swaps `v0.20.0` and `v0.21.0` to match actual implementation order: `v0.20.0` is `Desktop UX Foundation`, and `v0.21.0` is `Operator Core & Slot Dispatch`.
 - PR [#370](https://github.com/Sora-bluesky/winsmux/pull/370), PR [#371](https://github.com/Sora-bluesky/winsmux/pull/371), PR [#372](https://github.com/Sora-bluesky/winsmux/pull/372), PR [#374](https://github.com/Sora-bluesky/winsmux/pull/374), PR [#375](https://github.com/Sora-bluesky/winsmux/pull/375), PR [#376](https://github.com/Sora-bluesky/winsmux/pull/376), PR [#379](https://github.com/Sora-bluesky/winsmux/pull/379), PR [#380](https://github.com/Sora-bluesky/winsmux/pull/380), PR [#381](https://github.com/Sora-bluesky/winsmux/pull/381), PR [#382](https://github.com/Sora-bluesky/winsmux/pull/382), PR [#383](https://github.com/Sora-bluesky/winsmux/pull/383), PR [#384](https://github.com/Sora-bluesky/winsmux/pull/384), PR [#385](https://github.com/Sora-bluesky/winsmux/pull/385), PR [#386](https://github.com/Sora-bluesky/winsmux/pull/386), PR [#387](https://github.com/Sora-bluesky/winsmux/pull/387), PR [#388](https://github.com/Sora-bluesky/winsmux/pull/388), PR [#389](https://github.com/Sora-bluesky/winsmux/pull/389), and PR [#390](https://github.com/Sora-bluesky/winsmux/pull/390) are merged into `main`.
-- `v0.20.0` now tracks desktop UX work directly; `TASK-101` is merged, `TASK-292` and `TASK-286` are active on the current branch, and `TASK-298` tracks public-repo vs maintainer-dogfooding cleanup.
+- `v0.20.0` now tracks desktop UX work directly; `TASK-101` is merged, `TASK-292`, `TASK-286`, and `TASK-299` are active on the current branch, and `TASK-298` tracks public-repo vs maintainer-dogfooding cleanup.
 - Planning source of truth is externalized outside the public repository and syncs automatically into the private planning root.
 - `v0.21.x` private planning is aligned to a conversation-first Tauri operator shell, with Codex-App-like shell rules reflected in Figma and backlog notes.
 - `v0.24.x` private planning is split into schema, ledger, machine contract, cutover, and canary phases for Rust runtime convergence before `v1.0.0`.
@@ -57,6 +57,7 @@
 - Started the `TASK-101` theme-contract slice on `codex/task101-theme-contract-20260411`, adding semantic theme tokens, Codex-derived typography tokens, and `Theme / Density / Wrap` state to the settings sheet.
 - Merged the `TASK-101` theme-contract slice via PR [#390](https://github.com/Sora-bluesky/winsmux/pull/390), adding semantic theme tokens, theme/density/wrap controls, and Codex OSS attribution for reused styling patterns.
 - Started the active `v0.20.0` desktop UX slice on `codex/v0200-operator-timeline-public-docs-20260411`, combining `TASK-292`, `TASK-286`, and public operator-doc cleanup: composer attachments now support paste/drag-drop/file-picker, the conversation shell is moving to a concise filtered activity feed, and public operator docs are being split from contributor dogfooding docs.
+- Expanded the active slice to include `TASK-299`, adding strict public operator/pane role-definition docs (`.claude/CLAUDE.md`, `AGENT-BASE.md`, `AGENT.md`, `GEMINI.md`, `docs/operator-model.md`) and aligning the timeline grammar with pane result reports.
 
 ## Validation
 
@@ -79,11 +80,11 @@
 - PR [#388](https://github.com/Sora-bluesky/winsmux/pull/388) merged cleanly and the repo is back to `main == origin/main`.
 - Current `TASK-138` source-control slice passes frontend build: `npm run build` in `winsmux-app`.
 - Current `TASK-101` theme-contract slice passes frontend build: `npm run build` in `winsmux-app`.
-- Active `TASK-292/TASK-286` slice passes frontend build: `npm run build` in `winsmux-app`.
+- Active `TASK-292/TASK-286/TASK-299` slice passes frontend build: `npm run build` in `winsmux-app`.
 
 ## Next actions
 
-1. Publish the active `TASK-292/TASK-286` desktop UX slice, then continue `v0.20.0: Desktop UX Foundation` toward `TASK-287` and the remaining public-surface cleanup in `TASK-298`.
+1. Publish the active `TASK-292/TASK-286/TASK-299` desktop UX slice, then continue `v0.20.0: Desktop UX Foundation` toward `TASK-287` and the remaining public-surface cleanup in `TASK-298`.
 2. Preserve the private planning sync flow: user/agent visible, auto-synced, but not committed to the public repo.
 3. Run the next retro-review tranche over recent merged PRs after each milestone-close sequence.
 

--- a/docs/operator-model.md
+++ b/docs/operator-model.md
@@ -3,43 +3,70 @@
 winsmux is built around a **two-layer orchestration model**:
 
 - an **external operator layer**
-- a **managed pane layer**
+- a **managed pane execution layer**
 
-This separation is the key to understanding how Claude Code, Codex, Gemini, and other LLM tools fit into winsmux.
+This separation is the main contract of the product.
 
-## 1. External operator layer
+## 1. Standard control chain
 
-The operator layer is where user communication, dispatch, approval, and final judgement happen.
+The standard winsmux operating model is:
 
-The recommended operator is **Claude Code** because winsmux is designed to work well with:
+`User -> Claude Code (operator) -> pane agents`
+
+That model means:
+
+- the user communicates with the operator
+- the operator coordinates work
+- pane agents execute work
+- pane agents do not communicate directly with the user
+- pane agents do not communicate directly with each other
+
+## 2. Operator layer
+
+The operator layer is where:
+
+- user communication
+- dispatch
+- approval
+- review interpretation
+- prioritization
+- escalation
+- final judgement
+
+happen.
+
+The recommended operator is **Claude Code**.
+winsmux is designed to work well with:
 
 - Claude Code Channels
 - Claude Code remote control
 - other external user-to-operator channel surfaces
 
-The important abstraction is the **external channel boundary**.
-Telegram, Discord, or another channel can sit on top of that boundary, but the architecture is not tied to one messaging product.
+The important abstraction is the **channel boundary**, not Telegram, Discord, or another single product.
 
-Typical operator responsibilities:
+In the standard winsmux operating model, the operator is responsible for:
 
-- talk to the user
-- inspect `inbox`, `runs`, `explain`, and `digest`
-- decide what to dispatch next
-- request or interpret review
-- own git lifecycle decisions
+- decomposition
+- delegation
+- result collection
+- context alignment
+- review decisions
+- git lifecycle judgement
 
-## 2. Managed pane layer
+Direct file mutation or command execution by the operator is outside the standard winsmux operating model.
 
-The managed pane layer is where multiple agent CLIs run inside winsmux-controlled panes or slots.
+## 3. Pane execution layer
+
+The managed pane layer is where agent CLIs run inside winsmux-controlled panes or slots.
 
 Examples:
 
-- Claude Code
 - Codex
 - Gemini
+- Claude Code when explicitly assigned to a pane
 - future local or hosted LLM CLIs
 
-These panes are expected to work in parallel and may differ by:
+Panes may differ by:
 
 - provider
 - model
@@ -49,30 +76,31 @@ These panes are expected to work in parallel and may differ by:
 
 The current direction is **slot/capability-based orchestration**, not hard-coded vendor roles.
 
-## 3. Legacy layouts vs current model
+Review is handled by any **review-capable slot**, not by a permanently dedicated reviewer pane.
 
-Older `Commander / Builder / Researcher / Reviewer` pane layouts still exist for compatibility, but they are not the long-term architecture.
+## 4. Public role-definition documents
 
-The current model is:
-
-- one external operator
-- multiple managed worker slots
-- review handled by any review-capable slot
-
-This means:
-
-- `reviewer` is not required to be a permanent dedicated pane
-- operator channels are not tied to Telegram specifically
-- vendor identity does not define authority by itself
-
-## 4. Public product docs vs contributor docs
-
-Public product behavior should be read from:
+The public contract is split across these files:
 
 - `README.md`
 - `.claude/CLAUDE.md`
+- `AGENT-BASE.md`
+- `AGENT.md`
 - `GEMINI.md`
 - this file
+
+Their responsibilities are:
+
+- `.claude/CLAUDE.md`
+  - operator role definition
+- `AGENT-BASE.md`
+  - pane-wide shared execution contract
+- `AGENT.md`
+  - Codex-specific pane contract
+- `GEMINI.md`
+  - Gemini-specific pane contract
+
+## 5. Public docs vs contributor docs
 
 Contributor and dogfooding operations may still exist in repo-facing docs such as:
 
@@ -82,9 +110,21 @@ Contributor and dogfooding operations may still exist in repo-facing docs such a
 Those files describe how contributors and AI agents operate **inside this repository**.
 They are not the public end-user guide for winsmux as a product.
 
-## 5. UI/UX direction
+Dogfooding-specific rules do not define the public operator or pane contract.
 
-The Tauri desktop direction follows the same operator model:
+## 6. Legacy layouts vs current model
+
+Older `Commander / Builder / Researcher / Reviewer` pane layouts still exist for compatibility, but they are not the long-term architecture.
+
+The current model is:
+
+- one external operator
+- multiple managed pane agents
+- review handled by any review-capable slot
+
+## 7. Tauri UI direction
+
+The Tauri desktop direction follows the same contract:
 
 - **workspace sidebar** for sessions, explorer, open editors, and source control summary
 - **conversation shell** as the primary operator surface
@@ -92,4 +132,17 @@ The Tauri desktop direction follows the same operator model:
 - **secondary editor surface** for source-level drill-down
 - **terminal drawer** for raw PTY and diagnostics only
 
-This keeps the operator loop separate from the managed pane execution layer.
+`TASK-286` aligns the timeline grammar with the docs contract:
+
+- user message
+- operator update
+- system card
+- pane result report
+
+Pane result reports should follow the shared `AGENT-BASE.md` report shape:
+
+- `STATUS`
+- `TASK`
+- `RESULT`
+- `FILES_CHANGED`
+- `ISSUES`

--- a/docs/operator-model.md
+++ b/docs/operator-model.md
@@ -1,0 +1,95 @@
+# Operator Model
+
+winsmux is built around a **two-layer orchestration model**:
+
+- an **external operator layer**
+- a **managed pane layer**
+
+This separation is the key to understanding how Claude Code, Codex, Gemini, and other LLM tools fit into winsmux.
+
+## 1. External operator layer
+
+The operator layer is where user communication, dispatch, approval, and final judgement happen.
+
+The recommended operator is **Claude Code** because winsmux is designed to work well with:
+
+- Claude Code Channels
+- Claude Code remote control
+- other external user-to-operator channel surfaces
+
+The important abstraction is the **external channel boundary**.
+Telegram, Discord, or another channel can sit on top of that boundary, but the architecture is not tied to one messaging product.
+
+Typical operator responsibilities:
+
+- talk to the user
+- inspect `inbox`, `runs`, `explain`, and `digest`
+- decide what to dispatch next
+- request or interpret review
+- own git lifecycle decisions
+
+## 2. Managed pane layer
+
+The managed pane layer is where multiple agent CLIs run inside winsmux-controlled panes or slots.
+
+Examples:
+
+- Claude Code
+- Codex
+- Gemini
+- future local or hosted LLM CLIs
+
+These panes are expected to work in parallel and may differ by:
+
+- provider
+- model
+- review capability
+- worktree assignment
+- runtime role
+
+The current direction is **slot/capability-based orchestration**, not hard-coded vendor roles.
+
+## 3. Legacy layouts vs current model
+
+Older `Commander / Builder / Researcher / Reviewer` pane layouts still exist for compatibility, but they are not the long-term architecture.
+
+The current model is:
+
+- one external operator
+- multiple managed worker slots
+- review handled by any review-capable slot
+
+This means:
+
+- `reviewer` is not required to be a permanent dedicated pane
+- operator channels are not tied to Telegram specifically
+- vendor identity does not define authority by itself
+
+## 4. Public product docs vs contributor docs
+
+Public product behavior should be read from:
+
+- `README.md`
+- `.claude/CLAUDE.md`
+- `GEMINI.md`
+- this file
+
+Contributor and dogfooding operations may still exist in repo-facing docs such as:
+
+- `AGENTS.md`
+- `docs/handoff.md`
+
+Those files describe how contributors and AI agents operate **inside this repository**.
+They are not the public end-user guide for winsmux as a product.
+
+## 5. UI/UX direction
+
+The Tauri desktop direction follows the same operator model:
+
+- **workspace sidebar** for sessions, explorer, open editors, and source control summary
+- **conversation shell** as the primary operator surface
+- **context side sheet** for run, slot, evidence, branch, and review state
+- **secondary editor surface** for source-level drill-down
+- **terminal drawer** for raw PTY and diagnostics only
+
+This keeps the operator loop separate from the managed pane execution layer.

--- a/winsmux-app/index.html
+++ b/winsmux-app/index.html
@@ -78,21 +78,24 @@
           <section id="conversation-panel">
             <div id="thread-meta">
               <span>winsmux session</span>
-              <span>conversation shell</span>
+              <span>conversation shell · concise feed</span>
             </div>
+            <div id="timeline-toolbar">
+              <div id="timeline-filter-row" aria-label="Timeline filters"></div>
+              <div id="timeline-feed-hint">Material events only: user messages, operator updates, and structured system cards.</div>
+            </div>
+            <div id="selected-run-summary"></div>
             <div id="conversation-timeline" role="log" aria-live="polite" aria-relevant="additions text"></div>
             <form id="composer" autocomplete="off">
               <label class="sr-only" for="composer-input">Message the Operator</label>
               <textarea id="composer-input" rows="2" placeholder="Message the Operator... Dispatch, ask, review, or explain"></textarea>
+              <input id="composer-file-input" type="file" hidden multiple />
               <div id="composer-mode-row" aria-label="Composer modes"></div>
               <div id="composer-footer">
-                <div id="attachment-tray">
-                  <button type="button" class="attachment-chip">Screen 1.png</button>
-                  <button type="button" class="attachment-chip">Trace.txt</button>
-                  <button type="button" class="attachment-chip attachment-chip-muted">+1</button>
-                </div>
+                <div id="attachment-tray" aria-live="polite"></div>
                 <div id="composer-actions">
                   <span id="ime-hint">IME-safe: Enter sends, Shift+Enter inserts newline, composing Enter never sends.</span>
+                  <button type="button" id="attach-btn" class="ghost-btn ghost-btn-small">Attach</button>
                   <button type="submit" id="send-btn">Send</button>
                 </div>
               </div>

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -240,6 +240,24 @@ const seedConversation: ConversationItem[] = [
     runId: "run-245",
     statusLabel: "Review",
   },
+  {
+    type: "system",
+    category: "activity",
+    timestamp: "09:48",
+    actor: "worker-2",
+    title: "Pane report",
+    body: "worker-2 returned a structured execution report for the selected run.",
+    details: [
+      { label: "STATUS", value: "SUCCESS" },
+      { label: "TASK", value: "TASK-138 source-control context slice" },
+      { label: "RESULT", value: "source-control context now opens changed files in the editor with worktree-aware metadata" },
+      { label: "FILES_CHANGED", value: "index.html, src/main.ts, src/styles.css" },
+      { label: "ISSUES", value: "none" },
+    ],
+    tone: "info",
+    runId: "run-138",
+    statusLabel: "SUCCESS",
+  },
 ];
 
 const sessionItems: SessionItem[] = [

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -22,12 +22,27 @@ interface ConversationChip {
   action: ChipAction;
 }
 
+type TimelineFilter = "all" | "attention" | "review" | "activity";
+type ConversationCategory = "user" | "attention" | "review" | "activity";
+
+interface ConversationDetail {
+  label: string;
+  value: string;
+}
+
 interface ConversationItem {
   type: "user" | "operator" | "system";
+  category: ConversationCategory;
+  timestamp: string;
+  actor: string;
   title?: string;
   body: string;
+  details?: ConversationDetail[];
   chips?: ConversationChip[];
+  attachments?: Array<{ name: string; kind: "image" | "file"; sizeLabel: string }>;
   tone?: SurfaceTone;
+  runId?: string;
+  statusLabel?: string;
 }
 
 interface SessionItem {
@@ -102,6 +117,15 @@ interface ThemeState {
   wrapMode: WrapMode;
 }
 
+interface ComposerAttachment {
+  id: string;
+  name: string;
+  kind: "image" | "file";
+  sizeLabel: string;
+  file: File;
+  previewUrl?: string;
+}
+
 type ComposerMode = "ask" | "dispatch" | "review" | "explain";
 
 const panes = new Map<string, PaneEntry>();
@@ -116,6 +140,8 @@ let sidebarWidth = 292;
 let selectedEditorPath = "winsmux-app/src/main.ts";
 let activeComposerMode: ComposerMode = "dispatch";
 let activeSourceFilter: SourceFilter = "all";
+let activeTimelineFilter: TimelineFilter = "all";
+let pendingAttachments: ComposerAttachment[] = [];
 const themeState: ThemeState = {
   theme: "codex-dark",
   density: "comfortable",
@@ -129,20 +155,48 @@ const composerModes: Array<{ mode: ComposerMode; label: string; placeholder: str
   { mode: "explain", label: "Explain", placeholder: "Ask the Operator to explain the current run state" },
 ];
 
+const timelineFilters: Array<{ filter: TimelineFilter; label: string }> = [
+  { filter: "all", label: "All" },
+  { filter: "attention", label: "Attention" },
+  { filter: "review", label: "Review" },
+  { filter: "activity", label: "Activity" },
+];
+
 const seedConversation: ConversationItem[] = [
   {
     type: "user",
+    category: "user",
+    timestamp: "09:41",
+    actor: "User",
     body: "Please tighten the notification boundary and show why this run is blocked.",
   },
   {
     type: "operator",
-    body: "Operator update: inbox shows 2 approval waits. I am checking run ledger and evidence digest now.",
+    category: "activity",
+    timestamp: "09:42",
+    actor: "Operator",
+    title: "Operator update",
+    body: "Inbox shows 2 approval waits. I am checking run ledger, source context, and the evidence digest before deciding the next action.",
+    details: [
+      { label: "focus", value: "run-246" },
+      { label: "scope", value: "branch/head mismatch" },
+    ],
     tone: "info",
+    runId: "run-246",
   },
   {
     type: "system",
+    category: "attention",
+    timestamp: "09:43",
+    actor: "System",
     title: "Commit blocked",
     body: "worker-2 changed 3 files. Review passed, but branch/head mismatch still blocks commit. Open Explain or inspect the edited files.",
+    details: [
+      { label: "run", value: "run-246" },
+      { label: "slot", value: "worker-3" },
+      { label: "review", value: "passed" },
+      { label: "next", value: "Open Explain" },
+    ],
     chips: [
       { label: "Open Explain", action: "open-explain" },
       { label: "Open in Editor", action: "open-editor" },
@@ -150,6 +204,41 @@ const seedConversation: ConversationItem[] = [
       { label: "Terminal", action: "open-terminal" },
     ],
     tone: "warning",
+    runId: "run-246",
+    statusLabel: "Blocked",
+  },
+  {
+    type: "operator",
+    category: "review",
+    timestamp: "09:44",
+    actor: "Operator",
+    title: "Review boundary",
+    body: "Only external-facing review and commit-ready events should surface through the channel layer. Internal dispatch noise stays inside the workspace.",
+    details: [
+      { label: "channel", value: "external only" },
+      { label: "profile", value: "review_requested, blocked, commit_ready" },
+    ],
+    tone: "focus",
+  },
+  {
+    type: "system",
+    category: "review",
+    timestamp: "09:46",
+    actor: "System",
+    title: "Review requested",
+    body: "A review-capable slot is ready to inspect the changed files for run-245. The timeline keeps the request, evidence, and next action in the same feed.",
+    details: [
+      { label: "run", value: "run-245" },
+      { label: "slot", value: "worker-2" },
+      { label: "target", value: "Changed files" },
+    ],
+    chips: [
+      { label: "Open in Editor", action: "open-editor" },
+      { label: "Source Context", action: "open-source-context" },
+    ],
+    tone: "focus",
+    runId: "run-245",
+    statusLabel: "Review",
   },
 ];
 
@@ -408,6 +497,7 @@ function renderExplorer() {
         selectedEditorPath = findEditorFile(itemPath)?.path || selectedEditorPath;
         setEditorSurface(true);
         renderSourceSummary();
+        renderRunSummary();
       });
     }
     root.appendChild(button);
@@ -430,6 +520,7 @@ function renderOpenEditors() {
       selectedEditorPath = editor.path;
       setEditorSurface(true);
       renderSourceSummary();
+      renderRunSummary();
     });
     root.appendChild(button);
   }
@@ -496,6 +587,7 @@ function renderSourceEntries() {
       renderSourceSummary();
       renderSourceEntries();
       renderContextPanel();
+      renderRunSummary();
     });
     root.appendChild(button);
   }
@@ -575,6 +667,7 @@ function renderContextPanel() {
       selectedEditorPath = change.path;
       setEditorSurface(true);
       renderSourceSummary();
+      renderRunSummary();
     });
     fileRoot.appendChild(button);
   }
@@ -734,6 +827,206 @@ function renderComposerModes() {
   }
 }
 
+function formatAttachmentSize(size: number) {
+  if (size >= 1024 * 1024) {
+    return `${(size / (1024 * 1024)).toFixed(1)} MB`;
+  }
+  if (size >= 1024) {
+    return `${Math.max(1, Math.round(size / 1024))} KB`;
+  }
+  return `${size} B`;
+}
+
+function synthesizeScreenshotName() {
+  const now = new Date();
+  const date = `${now.getFullYear()}-${`${now.getMonth() + 1}`.padStart(2, "0")}-${`${now.getDate()}`.padStart(2, "0")}`;
+  const time = `${`${now.getHours()}`.padStart(2, "0")}.${`${now.getMinutes()}`.padStart(2, "0")}.${`${now.getSeconds()}`.padStart(2, "0")}`;
+  return `Screenshot ${date} ${time}.png`;
+}
+
+function createComposerAttachment(file: File) {
+  const name = file.name?.trim() ? file.name : file.type.startsWith("image/") ? synthesizeScreenshotName() : "Attachment";
+  const kind: "image" | "file" = file.type.startsWith("image/") ? "image" : "file";
+  return {
+    id: `${name}-${file.size}-${file.lastModified}-${Math.random().toString(36).slice(2, 8)}`,
+    name,
+    kind,
+    sizeLabel: formatAttachmentSize(file.size),
+    file,
+    previewUrl: kind === "image" ? URL.createObjectURL(file) : undefined,
+  } satisfies ComposerAttachment;
+}
+
+function releaseAttachmentPreview(attachment: ComposerAttachment) {
+  if (attachment.previewUrl) {
+    URL.revokeObjectURL(attachment.previewUrl);
+  }
+}
+
+function clearPendingAttachments() {
+  for (const attachment of pendingAttachments) {
+    releaseAttachmentPreview(attachment);
+  }
+  pendingAttachments = [];
+}
+
+function renderAttachmentTray() {
+  const tray = document.getElementById("attachment-tray");
+  if (!tray) {
+    return;
+  }
+
+  tray.innerHTML = "";
+  tray.classList.toggle("is-empty", pendingAttachments.length === 0);
+
+  if (pendingAttachments.length === 0) {
+    const empty = document.createElement("div");
+    empty.className = "attachment-empty-state";
+    empty.textContent = "Paste a screenshot, drop files, or use Attach.";
+    tray.appendChild(empty);
+    return;
+  }
+
+  for (const attachment of pendingAttachments) {
+    const item = document.createElement("div");
+    item.className = "attachment-item";
+
+    if (attachment.previewUrl) {
+      const thumb = document.createElement("img");
+      thumb.className = "attachment-thumb";
+      thumb.src = attachment.previewUrl;
+      thumb.alt = attachment.name;
+      item.appendChild(thumb);
+    } else {
+      const icon = document.createElement("div");
+      icon.className = "attachment-thumb attachment-thumb-file";
+      icon.textContent = attachment.kind === "image" ? "IMG" : "FILE";
+      item.appendChild(icon);
+    }
+
+    const meta = document.createElement("div");
+    meta.className = "attachment-meta";
+    meta.innerHTML = `<span class="attachment-name">${attachment.name}</span><span class="attachment-size">${attachment.sizeLabel}</span>`;
+    item.appendChild(meta);
+
+    const removeButton = document.createElement("button");
+    removeButton.type = "button";
+    removeButton.className = "attachment-remove";
+    removeButton.setAttribute("aria-label", `Remove ${attachment.name}`);
+    removeButton.textContent = "Remove";
+    removeButton.addEventListener("click", () => {
+      releaseAttachmentPreview(attachment);
+      pendingAttachments = pendingAttachments.filter((item) => item.id !== attachment.id);
+      renderAttachmentTray();
+    });
+    item.appendChild(removeButton);
+
+    tray.appendChild(item);
+  }
+}
+
+function appendAttachments(files: File[]) {
+  if (files.length === 0) {
+    return;
+  }
+
+  const remaining = Math.max(0, 5 - pendingAttachments.length);
+  if (remaining <= 0) {
+    return;
+  }
+
+  const next = files.slice(0, remaining).map((file) => createComposerAttachment(file));
+  pendingAttachments = [...pendingAttachments, ...next];
+  renderAttachmentTray();
+}
+
+function getVisibleConversationItems(items: ConversationItem[]) {
+  switch (activeTimelineFilter) {
+    case "attention":
+      return items.filter((item) => item.category === "attention");
+    case "review":
+      return items.filter((item) => item.category === "review");
+    case "activity":
+      return items.filter((item) => item.category === "activity" || item.type === "operator");
+    default:
+      return items;
+  }
+}
+
+function renderTimelineFilters() {
+  const root = document.getElementById("timeline-filter-row");
+  if (!root) {
+    return;
+  }
+
+  root.innerHTML = "";
+  for (const item of timelineFilters) {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = `timeline-filter-chip ${item.filter === activeTimelineFilter ? "is-active" : ""}`;
+    button.textContent = item.label;
+    button.setAttribute("aria-pressed", item.filter === activeTimelineFilter ? "true" : "false");
+    button.addEventListener("click", () => {
+      activeTimelineFilter = item.filter;
+      renderTimelineFilters();
+      renderConversation(seedConversation);
+      renderRunSummary();
+    });
+    root.appendChild(button);
+  }
+}
+
+function renderRunSummary() {
+  const root = document.getElementById("selected-run-summary");
+  if (!root) {
+    return;
+  }
+
+  const visibleChanges = getVisibleSourceChanges();
+  const primaryChange = getPrimarySourceChange(visibleChanges);
+  if (!primaryChange) {
+    root.innerHTML = "";
+    return;
+  }
+
+  const attentionCount = visibleChanges.filter((item) => item.needsAttention).length;
+  const candidateCount = visibleChanges.filter((item) => item.commitCandidate).length;
+  root.innerHTML = `
+    <div class="run-summary-card">
+      <div class="run-summary-header">
+        <div>
+          <div class="timeline-eyebrow">Selected run</div>
+          <div class="run-summary-title">${primaryChange.run}</div>
+        </div>
+        <div class="run-summary-status" data-tone="${primaryChange.needsAttention ? "warning" : "success"}">
+          ${primaryChange.review}
+        </div>
+      </div>
+      <div class="run-summary-meta-row">
+        <span class="run-summary-pill">${primaryChange.slot}</span>
+        <span class="run-summary-pill">${primaryChange.branch}</span>
+        <span class="run-summary-pill">.worktrees/${primaryChange.worktree}</span>
+        <span class="run-summary-pill">${candidateCount} candidate${candidateCount === 1 ? "" : "s"}</span>
+        <span class="run-summary-pill">${attentionCount} blocker${attentionCount === 1 ? "" : "s"}</span>
+      </div>
+      <div class="run-summary-body">${primaryChange.summary}</div>
+      <div class="timeline-chip-row">
+        <button type="button" class="timeline-chip" data-action="open-explain">Open Explain</button>
+        <button type="button" class="timeline-chip" data-action="open-editor">Open in Editor</button>
+        <button type="button" class="timeline-chip" data-action="open-source-context">Source Context</button>
+      </div>
+    </div>
+  `;
+
+  for (const button of root.querySelectorAll<HTMLButtonElement>(".timeline-chip")) {
+    const action = button.dataset.action as ChipAction | undefined;
+    if (!action) {
+      continue;
+    }
+    button.addEventListener("click", () => handleChipAction(action));
+  }
+}
+
 function renderConversation(items: ConversationItem[]) {
   const timeline = document.getElementById("conversation-timeline");
   if (!timeline) {
@@ -741,11 +1034,30 @@ function renderConversation(items: ConversationItem[]) {
   }
 
   timeline.innerHTML = "";
+  const visibleItems = getVisibleConversationItems(items);
 
-  for (const item of items) {
+  if (visibleItems.length === 0) {
+    const empty = document.createElement("div");
+    empty.className = "attachment-empty-state";
+    empty.textContent = "No events in this filter yet.";
+    timeline.appendChild(empty);
+    return;
+  }
+
+  for (const item of visibleItems) {
     const article = document.createElement("article");
     article.className = `timeline-item timeline-${item.type}`;
     article.dataset.tone = item.tone ?? (item.type === "operator" ? "info" : item.type === "system" ? "focus" : "default");
+
+    const meta = document.createElement("div");
+    meta.className = "timeline-meta-row";
+    meta.innerHTML =
+      `<span class="timeline-actor">${item.actor}</span>` +
+      `<span class="timeline-meta-separator">·</span>` +
+      `<span>${item.timestamp}</span>` +
+      (item.runId ? `<span class="timeline-meta-separator">·</span><span>${item.runId}</span>` : "") +
+      (item.statusLabel ? `<span class="timeline-status-pill">${item.statusLabel}</span>` : "");
+    article.appendChild(meta);
 
     if (item.title) {
       const title = document.createElement("div");
@@ -758,6 +1070,30 @@ function renderConversation(items: ConversationItem[]) {
     body.className = "timeline-body";
     body.textContent = item.body;
     article.appendChild(body);
+
+    if (item.details?.length) {
+      const detailRow = document.createElement("div");
+      detailRow.className = "timeline-detail-row";
+      for (const detail of item.details) {
+        const pill = document.createElement("span");
+        pill.className = "timeline-detail-pill";
+        pill.innerHTML = `<span class="timeline-detail-label">${detail.label}</span><span>${detail.value}</span>`;
+        detailRow.appendChild(pill);
+      }
+      article.appendChild(detailRow);
+    }
+
+    if (item.attachments?.length) {
+      const attachmentRow = document.createElement("div");
+      attachmentRow.className = "timeline-attachment-row";
+      for (const attachment of item.attachments) {
+        const pill = document.createElement("span");
+        pill.className = "timeline-attachment-pill";
+        pill.innerHTML = `<span>${attachment.kind === "image" ? "Image" : "File"}</span><span>${attachment.name}</span><span>${attachment.sizeLabel}</span>`;
+        attachmentRow.appendChild(pill);
+      }
+      article.appendChild(attachmentRow);
+    }
 
     if (item.chips?.length) {
       const chipRow = document.createElement("div");
@@ -792,8 +1128,20 @@ function handleChipAction(action: ChipAction) {
     case "open-explain":
       seedConversation.push({
         type: "operator",
-        body: "Explain opened: this run is blocked on branch/head alignment after review passed. Changed files and commit readiness are available in the context sheet.",
+        category: "activity",
+        timestamp: "09:47",
+        actor: "Operator",
+        title: "Explain opened",
+        body: "This run is blocked on branch/head alignment after review passed. Changed files and commit readiness stay available in the context sheet and source-control surface.",
+        details: [
+          { label: "run", value: "run-246" },
+          { label: "focus", value: "branch/head alignment" },
+        ],
+        tone: "info",
+        runId: "run-246",
       });
+      renderTimelineFilters();
+      renderRunSummary();
       renderConversation(seedConversation);
       break;
   }
@@ -846,6 +1194,7 @@ function renderEditorSurface() {
       renderSourceSummary();
       renderContextPanel();
       renderSourceEntries();
+      renderRunSummary();
     });
     tabs.appendChild(tab);
   }
@@ -942,13 +1291,35 @@ function syncResponsiveShell() {
   }
 }
 
-function appendUserMessage(message: string) {
-  seedConversation.push({ type: "user", body: message });
+function appendUserMessage(message: string, attachments: ComposerAttachment[]) {
+  const now = new Date();
+  const timestamp = `${`${now.getHours()}`.padStart(2, "0")}:${`${now.getMinutes()}`.padStart(2, "0")}`;
+  seedConversation.push({
+    type: "user",
+    category: "user",
+    timestamp,
+    actor: "User",
+    body: message || "Attached files for dispatch.",
+    attachments: attachments.map((attachment) => ({
+      name: attachment.name,
+      kind: attachment.kind,
+      sizeLabel: attachment.sizeLabel,
+    })),
+  });
   seedConversation.push({
     type: "operator",
-    body: "Operator update: queued for dispatch. Open Explain, inspect changed files, or use the terminal drawer if raw PTY detail becomes necessary.",
+    category: "activity",
+    timestamp,
+    actor: "Operator",
+    title: "Queued for dispatch",
+    body: "The request is now part of the operator feed. Open Explain, inspect changed files, or use the terminal drawer only if raw PTY detail becomes necessary.",
+    details: [
+      { label: "mode", value: activeComposerMode },
+      { label: "attachments", value: `${attachments.length}` },
+    ],
     tone: "info",
   });
+  renderRunSummary();
   renderConversation(seedConversation);
 }
 
@@ -1041,8 +1412,11 @@ window.addEventListener("DOMContentLoaded", async () => {
   applyShellPreferences();
   renderSettingsControls();
   renderFooterLane();
+  renderTimelineFilters();
+  renderRunSummary();
   renderConversation(seedConversation);
   renderComposerModes();
+  renderAttachmentTray();
   renderEditorSurface();
   syncResponsiveShell();
   setEditorSurface(false);
@@ -1086,6 +1460,8 @@ window.addEventListener("DOMContentLoaded", async () => {
 
   const composer = document.getElementById("composer") as HTMLFormElement | null;
   const composerInput = document.getElementById("composer-input") as HTMLTextAreaElement | null;
+  const composerFileInput = document.getElementById("composer-file-input") as HTMLInputElement | null;
+  const attachButton = document.getElementById("attach-btn") as HTMLButtonElement | null;
   if (composer && composerInput) {
     composerInput.addEventListener("compositionstart", () => {
       composerImeActive = true;
@@ -1108,16 +1484,60 @@ window.addEventListener("DOMContentLoaded", async () => {
       composer.requestSubmit();
     });
 
+    composerInput.addEventListener("paste", (event) => {
+      const items = Array.from(event.clipboardData?.items ?? []);
+      const attachmentFiles = items
+        .filter((item) => item.kind === "file")
+        .map((item) => item.getAsFile())
+        .filter((file): file is File => Boolean(file));
+
+      if (attachmentFiles.length === 0) {
+        return;
+      }
+
+      event.preventDefault();
+      appendAttachments(attachmentFiles);
+    });
+
+    composerInput.addEventListener("dragover", (event) => {
+      if (event.dataTransfer?.files?.length) {
+        event.preventDefault();
+      }
+    });
+
+    composerInput.addEventListener("drop", (event) => {
+      const files = Array.from(event.dataTransfer?.files ?? []);
+      if (files.length === 0) {
+        return;
+      }
+
+      event.preventDefault();
+      appendAttachments(files);
+    });
+
     composer.addEventListener("submit", (event) => {
       event.preventDefault();
       const value = composerInput.value.trim();
-      if (!value) {
+      if (!value && pendingAttachments.length === 0) {
         return;
       }
-      appendUserMessage(value);
+      const submittedAttachments = [...pendingAttachments];
+      appendUserMessage(value, submittedAttachments);
       composerInput.value = "";
+      clearPendingAttachments();
+      renderAttachmentTray();
     });
   }
+
+  attachButton?.addEventListener("click", () => {
+    composerFileInput?.click();
+  });
+
+  composerFileInput?.addEventListener("change", () => {
+    const files = Array.from(composerFileInput.files ?? []);
+    appendAttachments(files);
+    composerFileInput.value = "";
+  });
 
   window.addEventListener("keydown", (event) => {
     if (event.key === "Escape" && settingsSheetOpen) {

--- a/winsmux-app/src/styles.css
+++ b/winsmux-app/src/styles.css
@@ -376,6 +376,122 @@ textarea {
   font-size: var(--text-xs);
 }
 
+#timeline-toolbar,
+#selected-run-summary {
+  padding: 0 20px 12px;
+}
+
+#timeline-toolbar {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+#timeline-filter-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.timeline-filter-chip {
+  border: 1px solid var(--border-strong);
+  border-radius: 999px;
+  background: var(--bg-surface-raised);
+  color: var(--text-secondary);
+  padding: 6px 10px;
+  cursor: pointer;
+  font-size: var(--text-xs);
+}
+
+.timeline-filter-chip.is-active,
+.timeline-filter-chip:hover {
+  border-color: var(--status-focus-border);
+  background: var(--bg-panel);
+  color: var(--text-primary);
+}
+
+#timeline-feed-hint {
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+  line-height: var(--leading-normal);
+}
+
+.run-summary-card {
+  border: 1px solid var(--border-muted);
+  border-radius: 18px;
+  background: var(--bg-surface-raised);
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.run-summary-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.timeline-eyebrow {
+  font-size: var(--text-2xs);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #7d88a9;
+  margin-bottom: 4px;
+}
+
+.run-summary-title {
+  color: var(--text-primary);
+  font-size: var(--text-md);
+  font-weight: 700;
+}
+
+.run-summary-status {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  padding: 5px 10px;
+  font-size: var(--text-2xs);
+  font-weight: 700;
+  border: 1px solid var(--border-muted);
+}
+
+.run-summary-status[data-tone="warning"] {
+  border-color: var(--status-warning-border);
+  color: var(--status-warning);
+  background: var(--status-warning-bg);
+}
+
+.run-summary-status[data-tone="success"] {
+  border-color: var(--status-success-border);
+  color: var(--status-success);
+  background: var(--status-success-bg);
+}
+
+.run-summary-meta-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.run-summary-pill {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  padding: 5px 10px;
+  background: var(--bg-panel);
+  border: 1px solid var(--border-muted);
+  color: var(--text-secondary);
+  font-size: var(--text-2xs);
+}
+
+.run-summary-body {
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+  line-height: var(--leading-normal);
+}
+
 #conversation-timeline {
   min-height: 0;
   overflow: auto;
@@ -395,6 +511,35 @@ textarea {
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.03);
   background: var(--bg-panel);
   border: 1px solid transparent;
+}
+
+.timeline-meta-row {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
+  color: var(--text-muted);
+  font-size: var(--text-2xs);
+}
+
+.timeline-actor {
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+.timeline-meta-separator {
+  color: #66708f;
+}
+
+.timeline-status-pill {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  padding: 4px 8px;
+  border: 1px solid var(--status-focus-border);
+  background: var(--status-focus-bg);
+  color: var(--text-primary);
 }
 
 .timeline-user {
@@ -442,10 +587,52 @@ textarea {
   overflow-wrap: var(--body-wrap);
 }
 
+.timeline-detail-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.timeline-detail-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 5px 10px;
+  border-radius: 999px;
+  border: 1px solid var(--border-muted);
+  background: rgba(14, 17, 26, 0.4);
+  color: var(--text-secondary);
+  font-size: var(--text-2xs);
+}
+
+.timeline-detail-label {
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
 .timeline-chip-row {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
+}
+
+.timeline-attachment-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.timeline-attachment-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: rgba(14, 17, 26, 0.48);
+  border: 1px solid var(--border-muted);
+  color: var(--text-secondary);
+  font-size: var(--text-2xs);
 }
 
 .timeline-chip {
@@ -524,20 +711,83 @@ textarea {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
+  min-height: 42px;
+  align-items: flex-start;
 }
 
-.attachment-chip {
-  border: 0;
+.attachment-empty-state {
+  display: inline-flex;
+  align-items: center;
+  min-height: 36px;
+  padding: 0 2px;
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+}
+
+.attachment-item {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: 10px;
+  align-items: center;
+  min-width: 0;
+  max-width: 320px;
+  padding: 8px 10px;
+  border-radius: 14px;
+  background: var(--bg-panel);
+  border: 1px solid var(--border-muted);
+}
+
+.attachment-thumb {
+  width: 36px;
+  height: 36px;
+  border-radius: 10px;
+  object-fit: cover;
+  border: 1px solid var(--border-strong);
+  background: #0f1117;
+}
+
+.attachment-thumb-file {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-secondary);
+  font-size: var(--text-2xs);
+  font-weight: 700;
+}
+
+.attachment-meta {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.attachment-name {
+  color: var(--text-primary);
+  font-size: var(--text-xs);
+  line-height: var(--leading-normal);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.attachment-size {
+  color: var(--text-muted);
+  font-size: var(--text-2xs);
+}
+
+.attachment-remove {
+  border: 1px solid var(--border-strong);
+  background: var(--bg-surface-raised);
+  color: var(--text-secondary);
   border-radius: 999px;
-  padding: 7px 11px;
-  background: #f4f5f3;
-  color: #161922;
+  padding: 6px 10px;
   cursor: pointer;
+  font-size: var(--text-2xs);
 }
 
-.attachment-chip-muted {
-  background: #323851;
-  color: #eef2ff;
+.attachment-remove:hover {
+  background: var(--bg-panel);
 }
 
 #composer-actions {
@@ -1040,9 +1290,25 @@ textarea {
     align-items: flex-start;
   }
 
+  #selected-run-summary,
+  #timeline-toolbar {
+    padding-right: 16px;
+    padding-left: 16px;
+  }
+
+  #attachment-tray {
+    width: 100%;
+  }
+
+  .attachment-item {
+    max-width: 100%;
+    width: 100%;
+  }
+
   #composer-actions {
     width: 100%;
     justify-content: space-between;
+    flex-wrap: wrap;
   }
 
   #workspace-footer {


### PR DESCRIPTION
## Summary
- add a concise operator timeline with filters, run summary, and composer attachments
- split public operator/model guidance into README, .claude/CLAUDE.md, GEMINI.md, and docs/operator-model.md
- clarify AGENTS scope as contributor-facing and refresh handoff for the active v0.20.0 slice

## Validation
- npm run build (winsmux-app)
- git diff --check
- fresh review agent timed out twice (
o result yet); fallback gate used: manual diff review + validation