### PR TITLE
feat(tauri): add operator command bar

### DIFF
--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -1,6 +1,6 @@
 # Handoff
 
-> Updated: 2026-04-11T03:20:00+09:00
+> Updated: 2026-04-11T04:25:00+09:00
 > Source of truth: this file
 
 ## Current state
@@ -10,8 +10,8 @@
 - `v0.19.7 visible orchestration` is implemented, merged, released, and tracked as `100% (7/7)` in the external planning backlog/roadmap.
 - `v0.19.8 External Operator & Agent Slots` is implemented in order; private planning now tracks `TASK-259`, `TASK-261`, `TASK-262`, `TASK-263`, and `TASK-264` as done, and the external roadmap is synced accordingly.
 - Private planning now swaps `v0.20.0` and `v0.21.0` to match actual implementation order: `v0.20.0` is `Desktop UX Foundation`, and `v0.21.0` is `Operator Core & Slot Dispatch`.
-- PR [#370](https://github.com/Sora-bluesky/winsmux/pull/370), PR [#371](https://github.com/Sora-bluesky/winsmux/pull/371), PR [#372](https://github.com/Sora-bluesky/winsmux/pull/372), PR [#374](https://github.com/Sora-bluesky/winsmux/pull/374), PR [#375](https://github.com/Sora-bluesky/winsmux/pull/375), PR [#376](https://github.com/Sora-bluesky/winsmux/pull/376), PR [#379](https://github.com/Sora-bluesky/winsmux/pull/379), PR [#380](https://github.com/Sora-bluesky/winsmux/pull/380), PR [#381](https://github.com/Sora-bluesky/winsmux/pull/381), PR [#382](https://github.com/Sora-bluesky/winsmux/pull/382), PR [#383](https://github.com/Sora-bluesky/winsmux/pull/383), PR [#384](https://github.com/Sora-bluesky/winsmux/pull/384), PR [#385](https://github.com/Sora-bluesky/winsmux/pull/385), PR [#386](https://github.com/Sora-bluesky/winsmux/pull/386), PR [#387](https://github.com/Sora-bluesky/winsmux/pull/387), PR [#388](https://github.com/Sora-bluesky/winsmux/pull/388), PR [#389](https://github.com/Sora-bluesky/winsmux/pull/389), and PR [#390](https://github.com/Sora-bluesky/winsmux/pull/390) are merged into `main`.
-- `v0.20.0` now tracks desktop UX work directly; `TASK-101` is merged, `TASK-292`, `TASK-286`, and `TASK-299` are active on the current branch, and `TASK-298` tracks public-repo vs maintainer-dogfooding cleanup.
+- PR [#370](https://github.com/Sora-bluesky/winsmux/pull/370), PR [#371](https://github.com/Sora-bluesky/winsmux/pull/371), PR [#372](https://github.com/Sora-bluesky/winsmux/pull/372), PR [#374](https://github.com/Sora-bluesky/winsmux/pull/374), PR [#375](https://github.com/Sora-bluesky/winsmux/pull/375), PR [#376](https://github.com/Sora-bluesky/winsmux/pull/376), PR [#379](https://github.com/Sora-bluesky/winsmux/pull/379), PR [#380](https://github.com/Sora-bluesky/winsmux/pull/380), PR [#381](https://github.com/Sora-bluesky/winsmux/pull/381), PR [#382](https://github.com/Sora-bluesky/winsmux/pull/382), PR [#383](https://github.com/Sora-bluesky/winsmux/pull/383), PR [#384](https://github.com/Sora-bluesky/winsmux/pull/384), PR [#385](https://github.com/Sora-bluesky/winsmux/pull/385), PR [#386](https://github.com/Sora-bluesky/winsmux/pull/386), PR [#387](https://github.com/Sora-bluesky/winsmux/pull/387), PR [#388](https://github.com/Sora-bluesky/winsmux/pull/388), PR [#389](https://github.com/Sora-bluesky/winsmux/pull/389), PR [#390](https://github.com/Sora-bluesky/winsmux/pull/390), and PR [#392](https://github.com/Sora-bluesky/winsmux/pull/392) are merged into `main`.
+- `v0.20.0` now tracks desktop UX work directly; `TASK-101`, `TASK-286`, `TASK-292`, and `TASK-299` are merged, `TASK-287` is active on `codex/task287-command-bar-20260411`, and `TASK-298` tracks the remaining public-repo vs maintainer-dogfooding cleanup.
 - Planning source of truth is externalized outside the public repository and syncs automatically into the private planning root.
 - `v0.21.x` private planning is aligned to a conversation-first Tauri operator shell, with Codex-App-like shell rules reflected in Figma and backlog notes.
 - `v0.24.x` private planning is split into schema, ledger, machine contract, cutover, and canary phases for Rust runtime convergence before `v1.0.0`.
@@ -58,6 +58,9 @@
 - Merged the `TASK-101` theme-contract slice via PR [#390](https://github.com/Sora-bluesky/winsmux/pull/390), adding semantic theme tokens, theme/density/wrap controls, and Codex OSS attribution for reused styling patterns.
 - Started the active `v0.20.0` desktop UX slice on `codex/v0200-operator-timeline-public-docs-20260411`, combining `TASK-292`, `TASK-286`, and public operator-doc cleanup: composer attachments now support paste/drag-drop/file-picker, the conversation shell is moving to a concise filtered activity feed, and public operator docs are being split from contributor dogfooding docs.
 - Expanded the active slice to include `TASK-299`, adding strict public operator/pane role-definition docs (`.claude/CLAUDE.md`, `AGENT-BASE.md`, `AGENT.md`, `GEMINI.md`, `docs/operator-model.md`) and aligning the timeline grammar with pane result reports.
+- Merged the public operator/pane docs and concise timeline slice via PR [#392](https://github.com/Sora-bluesky/winsmux/pull/392), adding `AGENT-BASE.md`, `AGENT.md`, the strict-default `.claude/CLAUDE.md`, the reworked `docs/operator-model.md`, and pane report cards with `STATUS/TASK/RESULT/FILES_CHANGED/ISSUES`.
+- Re-synced the external planning backlog/roadmap after PR [#392](https://github.com/Sora-bluesky/winsmux/pull/392), marking `TASK-101`, `TASK-286`, `TASK-292`, and `TASK-299` as done so `v0.20.0` now shows `83% (10/12)`.
+- Started `TASK-287` on `codex/task287-command-bar-20260411`, adding a keyboard-first command bar (`Ctrl/Cmd+K`) with quick actions for dispatch/review/explain, source context, settings, and terminal control.
 
 ## Validation
 
@@ -80,11 +83,12 @@
 - PR [#388](https://github.com/Sora-bluesky/winsmux/pull/388) merged cleanly and the repo is back to `main == origin/main`.
 - Current `TASK-138` source-control slice passes frontend build: `npm run build` in `winsmux-app`.
 - Current `TASK-101` theme-contract slice passes frontend build: `npm run build` in `winsmux-app`.
-- Active `TASK-292/TASK-286/TASK-299` slice passes frontend build: `npm run build` in `winsmux-app`.
+- Merged `TASK-292/TASK-286/TASK-299` slice passed frontend build before landing: `npm run build` in `winsmux-app`.
+- Current `TASK-287` command-bar slice passes frontend build: `npm run build` in `winsmux-app`.
 
 ## Next actions
 
-1. Publish the active `TASK-292/TASK-286/TASK-299` desktop UX slice, then continue `v0.20.0: Desktop UX Foundation` toward `TASK-287` and the remaining public-surface cleanup in `TASK-298`.
+1. Publish `TASK-287` (global command bar + quick actions), then continue `v0.20.0: Desktop UX Foundation` with the remaining public-surface cleanup in `TASK-298`.
 2. Preserve the private planning sync flow: user/agent visible, auto-synced, but not committed to the public repo.
 3. Run the next retro-review tranche over recent merged PRs after each milestone-close sequence.
 

--- a/winsmux-app/index.html
+++ b/winsmux-app/index.html
@@ -46,6 +46,15 @@
           <div id="header-actions">
             <button
               class="ghost-btn"
+              id="open-command-bar-btn"
+              type="button"
+              aria-controls="command-bar"
+              aria-expanded="false"
+            >
+              Command
+            </button>
+            <button
+              class="ghost-btn"
               id="toggle-sidebar-btn"
               type="button"
               aria-controls="left-rail"
@@ -168,6 +177,30 @@
           <div class="settings-section">
             <div class="context-label">Input</div>
             <div class="context-value">Enter sends, Shift+Enter inserts newline, IME composition is protected</div>
+          </div>
+        </section>
+
+        <section id="command-bar-shell" hidden>
+          <div id="command-bar-backdrop"></div>
+          <div id="command-bar" role="dialog" aria-modal="true" aria-labelledby="command-bar-title">
+            <div id="command-bar-header">
+              <div>
+                <div class="timeline-eyebrow">Keyboard-first control</div>
+                <div id="command-bar-title">Command bar</div>
+              </div>
+              <div id="command-bar-hint">Ctrl/Cmd+K to open · ↑↓ navigate · Enter execute · Esc close</div>
+            </div>
+            <label class="sr-only" for="command-bar-input">Search commands</label>
+            <input
+              id="command-bar-input"
+              type="text"
+              autocomplete="off"
+              placeholder="Search actions, runs, panels, and operator controls"
+            />
+            <div id="command-bar-meta">
+              <span>Command palette for dispatch, review, explain, source context, settings, and terminal control.</span>
+            </div>
+            <div id="command-bar-results" role="listbox" aria-label="Command results"></div>
           </div>
         </section>
       </main>

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -128,6 +128,16 @@ interface ComposerAttachment {
 
 type ComposerMode = "ask" | "dispatch" | "review" | "explain";
 
+interface CommandAction {
+  id: string;
+  label: string;
+  description: string;
+  keywords: string[];
+  shortcut?: string;
+  tone?: SurfaceTone;
+  run: () => void;
+}
+
 const panes = new Map<string, PaneEntry>();
 let paneCounter = 0;
 let terminalDrawerOpen = false;
@@ -141,6 +151,11 @@ let selectedEditorPath = "winsmux-app/src/main.ts";
 let activeComposerMode: ComposerMode = "dispatch";
 let activeSourceFilter: SourceFilter = "all";
 let activeTimelineFilter: TimelineFilter = "all";
+let commandBarOpen = false;
+let commandBarQuery = "";
+let selectedCommandIndex = 0;
+let commandBarImeActive = false;
+let lastCommandBarFocus: HTMLElement | null = null;
 let pendingAttachments: ComposerAttachment[] = [];
 const themeState: ThemeState = {
   theme: "codex-dark",
@@ -715,6 +730,7 @@ function getFooterItems(): { left: FooterStatusItem[]; right: FooterStatusItem[]
       { label: themeLabel, tone: "focus" },
       { label: densityLabel },
       { label: `Wrap ${wrapLabel}` },
+      { label: "Command", value: "Ctrl/Cmd+K", tone: "accent" },
       { label: "Settings", tone: "accent" },
     ],
     right: [
@@ -799,6 +815,9 @@ function renderFooterLane() {
     button.innerHTML = item.value
       ? `<span class="footer-pill-label">${item.label}</span><span class="footer-pill-value">${item.value}</span>`
       : `<span class="footer-pill-value">${item.label}</span>`;
+    if (item.label === "Command" || item.value === "Command") {
+      button.addEventListener("click", () => openCommandBar());
+    }
     if (item.label === "Settings" || item.value === "Settings") {
       button.addEventListener("click", () => setSettingsSheet(true));
     }
@@ -817,6 +836,22 @@ function renderFooterLane() {
   }
 }
 
+function setComposerMode(mode: ComposerMode) {
+  activeComposerMode = mode;
+  renderComposerModes();
+}
+
+function focusComposer() {
+  const composerInput = document.getElementById("composer-input") as HTMLTextAreaElement | null;
+  if (!composerInput) {
+    return;
+  }
+
+  composerInput.focus();
+  const length = composerInput.value.length;
+  composerInput.setSelectionRange(length, length);
+}
+
 function renderComposerModes() {
   const root = document.getElementById("composer-mode-row");
   const composerInput = document.getElementById("composer-input") as HTMLTextAreaElement | null;
@@ -832,9 +867,7 @@ function renderComposerModes() {
     button.textContent = item.label;
     button.setAttribute("aria-pressed", item.mode === activeComposerMode ? "true" : "false");
     button.addEventListener("click", () => {
-      activeComposerMode = item.mode;
-      composerInput.placeholder = item.placeholder;
-      renderComposerModes();
+      setComposerMode(item.mode);
     });
     root.appendChild(button);
   }
@@ -1165,6 +1198,274 @@ function handleChipAction(action: ChipAction) {
   }
 }
 
+function getCommandActions(): CommandAction[] {
+  return [
+    {
+      id: "dispatch",
+      label: "Dispatch next task",
+      description: "Switch the composer to dispatch mode and focus the operator input.",
+      keywords: ["dispatch", "task", "composer", "operator"],
+      shortcut: "Ctrl/Cmd+K",
+      tone: "focus",
+      run: () => {
+        setComposerMode("dispatch");
+        focusComposer();
+      },
+    },
+    {
+      id: "ask",
+      label: "Ask the operator",
+      description: "Switch to ask mode for status questions, clarifications, and routing checks.",
+      keywords: ["ask", "status", "clarify", "operator"],
+      tone: "info",
+      run: () => {
+        setComposerMode("ask");
+        focusComposer();
+      },
+    },
+    {
+      id: "review",
+      label: "Request review",
+      description: "Switch to review mode to request approval, audit, or verification.",
+      keywords: ["review", "approve", "audit", "verify"],
+      tone: "warning",
+      run: () => {
+        setComposerMode("review");
+        focusComposer();
+      },
+    },
+    {
+      id: "explain",
+      label: "Explain selected run",
+      description: "Open the explain flow for the currently selected run and add operator context to the timeline.",
+      keywords: ["explain", "run", "blocked", "why"],
+      tone: "info",
+      run: () => handleChipAction("open-explain"),
+    },
+    {
+      id: "editor",
+      label: "Open secondary editor",
+      description: "Open the secondary work surface for the currently selected file or run context.",
+      keywords: ["editor", "file", "changed files", "secondary"],
+      tone: "default",
+      run: () => handleChipAction("open-editor"),
+    },
+    {
+      id: "source-context",
+      label: "Open source context",
+      description: "Reveal the source-control context sheet and changed-file drill-down.",
+      keywords: ["source", "context", "changed files", "worktree", "branch"],
+      tone: "default",
+      run: () => handleChipAction("open-source-context"),
+    },
+    {
+      id: "terminal",
+      label: "Open terminal drawer",
+      description: "Show the utility drawer for raw PTY output, diagnostics, and pane control.",
+      keywords: ["terminal", "drawer", "pty", "diagnostics", "pane"],
+      tone: "default",
+      run: () => handleChipAction("open-terminal"),
+    },
+    {
+      id: "settings",
+      label: "Open settings",
+      description: "Open theme, density, wrap, and workspace preferences.",
+      keywords: ["settings", "theme", "density", "wrap", "preferences"],
+      tone: "accent",
+      run: () => setSettingsSheet(true),
+    },
+    {
+      id: "attention-filter",
+      label: "Filter timeline: attention",
+      description: "Show only blocked and urgent attention events in the conversation feed.",
+      keywords: ["filter", "attention", "blocked", "timeline"],
+      tone: "danger",
+      run: () => {
+        activeTimelineFilter = "attention";
+        renderTimelineFilters();
+        renderRunSummary();
+        renderConversation(seedConversation);
+      },
+    },
+    {
+      id: "review-filter",
+      label: "Filter timeline: review",
+      description: "Show review requests, approvals, and review-capable slot activity.",
+      keywords: ["filter", "review", "timeline", "approve"],
+      tone: "warning",
+      run: () => {
+        activeTimelineFilter = "review";
+        renderTimelineFilters();
+        renderRunSummary();
+        renderConversation(seedConversation);
+      },
+    },
+  ];
+}
+
+function getFilteredCommandActions() {
+  const query = commandBarQuery.trim().toLowerCase();
+  const actions = getCommandActions();
+  if (!query) {
+    return actions;
+  }
+
+  return actions.filter((action) => {
+    const haystack = [action.label, action.description, action.shortcut ?? "", ...action.keywords]
+      .join(" ")
+      .toLowerCase();
+    return haystack.includes(query);
+  });
+}
+
+function openCommandBar() {
+  commandBarOpen = true;
+  commandBarQuery = "";
+  selectedCommandIndex = 0;
+  lastCommandBarFocus = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+  if (settingsSheetOpen) {
+    setSettingsSheet(false);
+  }
+  renderCommandBar();
+
+  const shell = document.getElementById("command-bar-shell");
+  const button = document.getElementById("open-command-bar-btn");
+  const input = document.getElementById("command-bar-input") as HTMLInputElement | null;
+  if (shell) {
+    shell.hidden = false;
+  }
+  if (button) {
+    button.setAttribute("aria-expanded", "true");
+  }
+
+  requestAnimationFrame(() => input?.focus());
+}
+
+function closeCommandBar(restoreFocus = true) {
+  commandBarOpen = false;
+  commandBarQuery = "";
+  selectedCommandIndex = 0;
+  commandBarImeActive = false;
+
+  const shell = document.getElementById("command-bar-shell");
+  const button = document.getElementById("open-command-bar-btn");
+  const input = document.getElementById("command-bar-input") as HTMLInputElement | null;
+  if (shell) {
+    shell.hidden = true;
+  }
+  if (button) {
+    button.setAttribute("aria-expanded", "false");
+  }
+  if (input) {
+    input.value = "";
+  }
+
+  if (restoreFocus) {
+    requestAnimationFrame(() => lastCommandBarFocus?.focus());
+  }
+}
+
+function executeSelectedCommand() {
+  const actions = getFilteredCommandActions();
+  if (actions.length === 0) {
+    return;
+  }
+
+  const action = actions[Math.min(selectedCommandIndex, actions.length - 1)];
+  closeCommandBar(false);
+  action.run();
+}
+
+function renderCommandBar() {
+  const input = document.getElementById("command-bar-input") as HTMLInputElement | null;
+  const results = document.getElementById("command-bar-results");
+  if (!input || !results) {
+    return;
+  }
+
+  input.value = commandBarQuery;
+  const actions = getFilteredCommandActions();
+  if (selectedCommandIndex >= actions.length) {
+    selectedCommandIndex = Math.max(0, actions.length - 1);
+  }
+
+  results.innerHTML = "";
+  if (actions.length === 0) {
+    input.removeAttribute("aria-activedescendant");
+    const empty = document.createElement("div");
+    empty.className = "command-bar-empty";
+    empty.textContent = "No matching command. Try run, review, terminal, source, or settings.";
+    results.appendChild(empty);
+    return;
+  }
+
+  actions.forEach((action, index) => {
+    const optionId = `command-option-${action.id}`;
+    const button = document.createElement("button");
+    button.type = "button";
+    button.id = optionId;
+    button.className = `command-bar-item ${index === selectedCommandIndex ? "is-active" : ""}`;
+    button.dataset.tone = action.tone ?? "default";
+    button.setAttribute("role", "option");
+    button.setAttribute("aria-selected", index === selectedCommandIndex ? "true" : "false");
+    button.innerHTML =
+      `<div class="command-bar-item-main">` +
+      `<span class="command-bar-item-label">${action.label}</span>` +
+      `<span class="command-bar-item-description">${action.description}</span>` +
+      `</div>` +
+      `<div class="command-bar-item-meta">` +
+      (action.shortcut ? `<span class="command-bar-item-shortcut">${action.shortcut}</span>` : "") +
+      `<span class="command-bar-item-keywords">${action.keywords.slice(0, 3).join(" · ")}</span>` +
+      `</div>`;
+    button.addEventListener("mouseenter", () => {
+      selectedCommandIndex = index;
+      renderCommandBar();
+    });
+    button.addEventListener("click", () => {
+      selectedCommandIndex = index;
+      executeSelectedCommand();
+    });
+    results.appendChild(button);
+  });
+
+  const activeAction = actions[Math.min(selectedCommandIndex, actions.length - 1)];
+  if (activeAction) {
+    input.setAttribute("aria-activedescendant", `command-option-${activeAction.id}`);
+  } else {
+    input.removeAttribute("aria-activedescendant");
+  }
+}
+
+function trapCommandBarTab(event: KeyboardEvent) {
+  const root = document.getElementById("command-bar");
+  if (!root || event.key !== "Tab") {
+    return;
+  }
+
+  const focusables = Array.from(
+    root.querySelectorAll<HTMLElement>('input, button, [href], [tabindex]:not([tabindex="-1"])'),
+  ).filter((element) => !element.hasAttribute("disabled") && !element.getAttribute("aria-hidden"));
+
+  if (focusables.length === 0) {
+    return;
+  }
+
+  const first = focusables[0];
+  const last = focusables[focusables.length - 1];
+  const active = document.activeElement;
+
+  if (!event.shiftKey && active === last) {
+    event.preventDefault();
+    first.focus();
+    return;
+  }
+
+  if (event.shiftKey && active === first) {
+    event.preventDefault();
+    last.focus();
+  }
+}
+
 function renderEditorSurface() {
   const path = document.getElementById("editor-file-path");
   const meta = document.getElementById("editor-meta-row");
@@ -1292,6 +1593,10 @@ function setSettingsSheet(open: boolean) {
   const sheet = document.getElementById("settings-sheet");
   if (!sheet) {
     return;
+  }
+
+  if (open && commandBarOpen) {
+    closeCommandBar();
   }
 
   sheet.hidden = !open;
@@ -1435,6 +1740,7 @@ window.addEventListener("DOMContentLoaded", async () => {
   renderConversation(seedConversation);
   renderComposerModes();
   renderAttachmentTray();
+  renderCommandBar();
   renderEditorSurface();
   syncResponsiveShell();
   setEditorSurface(false);
@@ -1443,6 +1749,14 @@ window.addEventListener("DOMContentLoaded", async () => {
 
   document.getElementById("toggle-sidebar-btn")?.addEventListener("click", () => {
     setSidebarOpen(!sidebarOpen);
+  });
+
+  document.getElementById("open-command-bar-btn")?.addEventListener("click", () => {
+    if (commandBarOpen) {
+      closeCommandBar();
+      return;
+    }
+    openCommandBar();
   });
 
   document.getElementById("toggle-terminal-btn")?.addEventListener("click", () => {
@@ -1467,6 +1781,67 @@ window.addEventListener("DOMContentLoaded", async () => {
 
   document.getElementById("sidebar-overlay")?.addEventListener("click", () => {
     setSidebarOpen(false);
+  });
+
+  document.getElementById("command-bar-backdrop")?.addEventListener("click", () => {
+    closeCommandBar();
+  });
+
+  document.getElementById("command-bar")?.addEventListener("keydown", (event) => {
+    trapCommandBarTab(event);
+  });
+
+  const commandBarInput = document.getElementById("command-bar-input") as HTMLInputElement | null;
+  commandBarInput?.addEventListener("compositionstart", () => {
+    commandBarImeActive = true;
+  });
+
+  commandBarInput?.addEventListener("compositionend", () => {
+    commandBarImeActive = false;
+  });
+
+  commandBarInput?.addEventListener("input", () => {
+    commandBarQuery = commandBarInput.value;
+    selectedCommandIndex = 0;
+    renderCommandBar();
+  });
+
+  commandBarInput?.addEventListener("keydown", (event) => {
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      const actions = getFilteredCommandActions();
+      if (actions.length === 0) {
+        return;
+      }
+      selectedCommandIndex = (selectedCommandIndex + 1) % actions.length;
+      renderCommandBar();
+      return;
+    }
+
+    if (event.key === "ArrowUp") {
+      event.preventDefault();
+      const actions = getFilteredCommandActions();
+      if (actions.length === 0) {
+        return;
+      }
+      selectedCommandIndex = (selectedCommandIndex - 1 + actions.length) % actions.length;
+      renderCommandBar();
+      return;
+    }
+
+    if (event.key === "Enter") {
+      if (commandBarImeActive || event.isComposing) {
+        return;
+      }
+      event.preventDefault();
+      executeSelectedCommand();
+      return;
+    }
+
+    if (event.key === "Escape") {
+      event.preventDefault();
+      closeCommandBar();
+    }
   });
 
   document.getElementById("add-pane-btn")?.addEventListener("click", () => {
@@ -1558,6 +1933,22 @@ window.addEventListener("DOMContentLoaded", async () => {
   });
 
   window.addEventListener("keydown", (event) => {
+    if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === "k") {
+      event.preventDefault();
+      if (commandBarOpen) {
+        closeCommandBar();
+      } else {
+        openCommandBar();
+      }
+      return;
+    }
+
+    if (event.key === "Escape" && commandBarOpen) {
+      event.preventDefault();
+      closeCommandBar();
+      return;
+    }
+
     if (event.key === "Escape" && settingsSheetOpen) {
       event.preventDefault();
       setSettingsSheet(false);

--- a/winsmux-app/src/styles.css
+++ b/winsmux-app/src/styles.css
@@ -1097,6 +1097,164 @@ textarea {
   z-index: 50;
 }
 
+#command-bar-shell {
+  position: fixed;
+  inset: 0;
+  z-index: 60;
+}
+
+#command-bar-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(6, 8, 14, 0.68);
+  backdrop-filter: blur(8px);
+}
+
+#command-bar {
+  position: relative;
+  width: min(760px, calc(100vw - 40px));
+  margin: 72px auto 0;
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  border: 1px solid var(--border-strong);
+  border-radius: calc(var(--panel-radius) + 2px);
+  background: rgba(18, 21, 33, 0.98);
+  box-shadow: 0 24px 64px rgba(0, 0, 0, 0.44);
+}
+
+#command-bar-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+#command-bar-title {
+  color: var(--text-primary);
+  font-size: var(--text-lg);
+  font-weight: 700;
+}
+
+#command-bar-hint,
+#command-bar-meta {
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+  line-height: var(--leading-normal);
+}
+
+#command-bar-hint {
+  text-align: right;
+}
+
+#command-bar-input {
+  width: 100%;
+  border: 1px solid var(--border-strong);
+  border-radius: 16px;
+  background: var(--bg-panel);
+  color: var(--text-primary);
+  padding: 14px 16px;
+  outline: none;
+  font-size: var(--text-md);
+}
+
+#command-bar-input:focus {
+  border-color: var(--accent-blue-hover);
+  box-shadow: 0 0 0 3px rgba(90, 132, 245, 0.18);
+}
+
+#command-bar-results {
+  max-height: min(52vh, 420px);
+  overflow: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.command-bar-item {
+  width: 100%;
+  border: 1px solid var(--border-muted);
+  border-radius: 16px;
+  background: var(--bg-surface);
+  color: var(--text-secondary);
+  padding: 14px 16px;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  text-align: left;
+  cursor: pointer;
+}
+
+.command-bar-item:hover,
+.command-bar-item.is-active {
+  border-color: var(--status-focus-border);
+  background: var(--bg-panel);
+}
+
+.command-bar-item[data-tone="warning"] {
+  border-color: var(--status-warning-border);
+}
+
+.command-bar-item[data-tone="danger"] {
+  border-color: var(--status-danger-border);
+}
+
+.command-bar-item[data-tone="focus"],
+.command-bar-item[data-tone="accent"] {
+  border-color: var(--status-focus-border);
+}
+
+.command-bar-item-main,
+.command-bar-item-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.command-bar-item-main {
+  min-width: 0;
+}
+
+.command-bar-item-label {
+  color: var(--text-primary);
+  font-size: var(--text-sm);
+  font-weight: 700;
+}
+
+.command-bar-item-description {
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+  line-height: var(--leading-normal);
+}
+
+.command-bar-item-meta {
+  align-items: flex-end;
+  min-width: 160px;
+}
+
+.command-bar-item-shortcut {
+  color: var(--text-primary);
+  font-size: var(--text-2xs);
+  border: 1px solid var(--border-strong);
+  border-radius: 999px;
+  padding: 4px 8px;
+  background: rgba(10, 12, 18, 0.56);
+}
+
+.command-bar-item-keywords {
+  color: var(--text-muted);
+  font-size: var(--text-2xs);
+  text-align: right;
+}
+
+.command-bar-empty {
+  padding: 18px 4px 4px;
+  color: var(--text-muted);
+  font-size: var(--text-sm);
+}
+
 .settings-section {
   display: flex;
   flex-direction: column;
@@ -1323,6 +1481,26 @@ textarea {
   #footer-right {
     justify-content: flex-start;
   }
+
+  #command-bar {
+    width: min(92vw, 760px);
+    margin-top: 32px;
+  }
+
+  #command-bar-header,
+  .command-bar-item {
+    flex-direction: column;
+  }
+
+  #command-bar-hint,
+  .command-bar-item-keywords {
+    text-align: left;
+  }
+
+  .command-bar-item-meta {
+    align-items: flex-start;
+    min-width: 0;
+  }
 }
 
 @media (max-height: 760px) {
@@ -1343,5 +1521,10 @@ textarea {
   #settings-sheet {
     top: auto;
     bottom: 84px;
+  }
+
+  #command-bar {
+    margin-top: 24px;
+    max-height: calc(100vh - 48px);
   }
 }


### PR DESCRIPTION
## Summary
- add a keyboard-first command bar to the Tauri operator shell
- wire quick actions for dispatch/review/explain, source context, settings, and terminal control
- refresh handoff after PR #392 and re-sync external planning state

## Validation
- npm run build
- git diff --check
- fresh reviewer PASS
