### PR TITLE
docs: clean public repo surface

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -78,13 +78,6 @@ Direct operator-side mutation is **outside the standard winsmux operating model*
 
 - Legacy `Builder / Researcher / Reviewer` layouts are compatibility mode only.
 - The current architecture is slot- and capability-based.
-- Public GitHub Releases should follow the English Codex-style release template:
-  - `New Features`
-  - `Bug Fixes`
-  - `Documentation`
-  - `Chores`
-  - `Full Changelog`
-- Before each release, re-check the boundary between public product docs/config and maintainer dogfooding material.
 
 ## Related docs
 

--- a/.winsmux.yaml
+++ b/.winsmux.yaml
@@ -1,36 +1,24 @@
-agent: codex
-model: gpt-5.4
+# Public-safe project defaults.
+# Provider/model pinning belongs in local overrides or operator instructions.
 external-commander: true
 agent-slots:
   - slot-id: worker-1
     runtime-role: worker
-    agent: codex
-    model: gpt-5.4
     worktree-mode: managed
   - slot-id: worker-2
     runtime-role: worker
-    agent: codex
-    model: gpt-5.4
     worktree-mode: managed
   - slot-id: worker-3
     runtime-role: worker
-    agent: codex
-    model: gpt-5.4
     worktree-mode: managed
   - slot-id: worker-4
     runtime-role: worker
-    agent: codex
-    model: gpt-5.4
     worktree-mode: managed
   - slot-id: worker-5
     runtime-role: worker
-    agent: codex
-    model: gpt-5.4
     worktree-mode: managed
   - slot-id: worker-6
     runtime-role: worker
-    agent: codex
-    model: gpt-5.4
     worktree-mode: managed
 
 roles: {}

--- a/.winsmux.yaml.example
+++ b/.winsmux.yaml.example
@@ -2,20 +2,19 @@
 # Default mode is external operator + managed worker slots.
 # Set legacy_role_layout: true only if you explicitly want Commander/Builder/Researcher/Reviewer panes.
 
-agent: codex
-model: gpt-5.4
+# Optional:
+# agent: codex
+# model: gpt-5.4
 external-commander: true
 agent-slots:
   - slot-id: worker-1
     runtime-role: worker
-    agent: codex
-    model: gpt-5.4
     worktree-mode: managed
   - slot-id: worker-2
     runtime-role: worker
-    agent: codex
-    model: gpt-5.4
     worktree-mode: managed
-vault_keys:
-  - GH_TOKEN
-terminal: background
+
+# Optional:
+# vault_keys:
+#   - GH_TOKEN
+# terminal: background

--- a/AGENT-BASE.md
+++ b/AGENT-BASE.md
@@ -48,11 +48,12 @@ ISSUES: <problems/risks/concerns, or "none">
 
 ## Shared execution environment
 
-- **OS**: Windows native, no WSL2 assumption
+Current winsmux defaults in this repository are:
+
+- **OS**: Windows native, with no WSL2 assumption in the default pane flow
 - **Auth**: OAuth/token lifecycle is outside your responsibility; auth failures should be reported as `STATUS: BLOCKED`
-- **Shell**: PowerShell, not bash
-- **Path separator**: backslash (`\`)
-- **Line endings**: CRLF by default; do not silently normalize to LF
+- **Shell**: PowerShell by default unless the operator or pane runtime explicitly says otherwise
+- **Paths and line endings**: follow the repository and task-local conventions instead of silently normalizing formats
 
 ## If uncertain
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,6 +122,7 @@ Before every version release, Codex must verify:
 4. any newly added tracked files are classified as either:
    - public product surface, or
    - dogfooding/contributor surface.
+5. when releasing `v0.21.2`, update `README.md` and `README.ja.md` so they describe the terminal-based final form as the last pre-Tauri release shape before the `v0.22.0` desktop control-plane handoff.
 
 If drift is found, fix or explicitly track it before the release is finalized.
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -24,7 +24,7 @@ Gemini is typically used for:
 
 ## Gemini-specific rules
 
-1. If Gemini edits files directly, include the before/after impact in `RESULT`.
+1. If the operator assigns Gemini an editing task, summarize the file impact in `RESULT`.
 2. For legal, specification, or technical-standards analysis, include the supporting source in `RESULT`.
 3. Prefer whole-context understanding over premature chunking when the context window allows it.
 4. Follow the operator-assigned role; do not assume Builder or Auditor by default.

--- a/README.ja.md
+++ b/README.ja.md
@@ -6,18 +6,68 @@
 
 # winsmux
 
-Windows ネイティブのターミナルマルチプレクサ。AI エージェント間のクロスペイン通信を実現する。WSL2 不要。
+**winsmux は Windows ネイティブの AI エージェントオーケストレーション基盤です。**
 
-- **ユーザー向け** — PowerShell 上で Alt キーバインドによるペイン操作
-- **エージェント向け** — `winsmux` CLI で任意のペインの読み取り・入力・キー送信が可能
-- **エージェント間通信** — Claude Code が隣のペインの Codex に指示を送り、Codex が返答する。シェルコマンドを実行できるエージェントなら何でも参加できる。
-- **プラットフォーム** — Claude Code が提供するランタイム＋オーケストレーション層から、モデルロックインを除いた構成。ベンダー非依存設計。
+1 つのオペレーターが Windows 上の複数のエージェント CLI を統括するための、ランタイムと制御レイヤーを提供します。単一ベンダーに閉じず、ペイン実行、ライブ監督、レビュー統制を同じワークスペースで扱えるようにします。
+
+## winsmux が提供するもの
+
+- **マルチベンダー対応**: Codex、Claude、Gemini など複数の CLI エージェントを同じセッションで並行運用
+- **リアルタイム可視化**: 事後要約ではなく、`winsmux` ペインを通じて各エージェントの状態をライブで監督
+- **統制しやすい実行基盤**: 1 人の外部オペレーター、managed pane agents、review/evidence の導線を分離
 
 ```powershell
-winsmux read codex 20              # ペインを読む
-winsmux type codex "review src/auth.ts"  # テキストを入力
-winsmux keys codex Enter           # Enter を押す
+winsmux read worker-1 20
+winsmux send worker-2 "最新の auth 変更をレビューしてください。"
+winsmux health-check
 ```
+
+## winsmux が向いている場面
+
+多くの agent ツールは、単一ベンダー・単一実行モデルに最適化されています。winsmux は、Windows で複数エージェントを同時に動かしつつ、全体を観測可能かつ統制可能に保ちたいチーム向けに設計されています。
+
+- **ベンダー非依存のオーケストレーション**: 1 つの operator loop の下で Codex、Claude、Gemini、将来のローカルモデルを混在運用
+- **pane-native な運用**: `winsmux` を通じて、ライブのペインを inspect / interrupt / redirect / relabel
+- **統制された実行**: read-before-act、review-capable slot、worker worktree isolation を組み合わせて事故を減らす
+- **Windows-first**: WSL2 や Linux 経由を前提にしない
+
+## プラットフォームモデル
+
+```text
+winsmux
+├── winsmux CLI
+├── Orchestra
+├── Role Gates
+├── Worker Worktree Isolation
+├── Credential Vault (DPAPI)
+└── Evidence Ledger
+```
+
+- **`winsmux`** は pane targeting、messaging、health-check、vault injection、operator controls を担います
+- **Orchestra** は 1 人の external operator と複数の managed pane agents を既定モデルにします
+- **Role gates** は operator と pane agents の実行権限を分離します
+- **Worker worktree isolation** は worker ごとに独立した git worktree を与えます
+- **Evidence Ledger** は review や audit 向けの証跡を扱います
+
+公開向けの operator / pane architecture は [docs/operator-model.md](docs/operator-model.md) を参照してください。役割定義は [`.claude/CLAUDE.md`](.claude/CLAUDE.md)、[`AGENT-BASE.md`](AGENT-BASE.md)、[`AGENT.md`](AGENT.md)、[`GEMINI.md`](GEMINI.md) に分割しています。
+
+## コアランタイム
+
+オーケストレーション層の下には、Rust 製の Windows ネイティブ terminal multiplexer runtime があります。
+
+- **tmux 互換ランタイム**: tmux 風のコマンド体系を話し、`~/.tmux.conf` や既存テーマを利用可能
+- **Windows ネイティブ UX**: ConPTY ベース、マウス対応、WSL/Cygwin/MSYS2 依存なし
+- **複数エントリポイント**: `winsmux`、`pmux`、`tmux`
+- **自動化向け**: 76 個の tmux 互換コマンドと 126+ の format 変数
+
+| ランタイム資料 | 内容 |
+| ------- | ------- |
+| [Features](core/docs/features.md) | マウス、copy mode、layout、format、script surface |
+| [Compatibility](core/docs/compatibility.md) | tmux 互換マトリクスとコマンド実装状況 |
+| [Configuration](core/docs/configuration.md) | config file、option、environment variable、`.tmux.conf` 対応 |
+| [Key Bindings](core/docs/keybindings.md) | 既定のキーボード操作とマウス操作 |
+| [Mouse over SSH](core/docs/mouse-ssh.md) | SSH 越しのマウス動作と Windows 版要件 |
+| [Claude Code](core/docs/claude-code.md) | teammate pane がランタイム上でどう動くか |
 
 ## インストール
 
@@ -25,16 +75,14 @@ winsmux keys codex Enter           # Enter を押す
 irm https://raw.githubusercontent.com/Sora-bluesky/winsmux/main/install.ps1 | iex
 ```
 
-インストールされるもの:
+インストーラーは次を行います。
 
-- **winsmux** — 未インストールの場合は自動インストール（winget, scoop, cargo, chocolatey のいずれか）
-- **winsmux** — クロスペイン通信用 CLI
-- **.winsmux.conf** — Alt キーバインド、マウスサポート、ペインラベルの設定
-- **Windows Terminal Fragment** — WT のドロップダウンメニューに「winsmux Orchestra」プロファイルを追加
+- `winsmux` ランタイムが未インストールなら導入
+- `winsmux` wrapper script を `~\.winsmux\bin` に配置
+- `.winsmux.conf` を構成
+- Windows Terminal に **winsmux Orchestra** profile を登録
 
-すべて `~\.winsmux\` に配置される。
-
-tmux 互換ランタイムだけを使いたい場合は、次の方法でも直接インストールできる:
+tmux 互換ランタイムだけが必要なら、直接インストールも可能です。
 
 ```powershell
 winget install winsmux
@@ -44,301 +92,61 @@ scoop install winsmux
 choco install winsmux
 ```
 
-GitHub Releases の `.zip` を使うか、[`core/`](core) でソースからビルドすることもできる。
+GitHub Releases の `.zip` を使うか、[`core/`](core) でソースからビルドすることもできます。
 
 ## クイックスタート
 
 ```powershell
-# 1. セッションを作成
-winsmux new-session -s work
+# 環境チェック
+winsmux doctor
 
-# 2. ペインを分割（Alt+n でも可）
-winsmux split-window -h
+# セッション開始
+winsmux new-session -s orchestra
 
-# 3. ペインにラベルを付ける
-winsmux name %1 claude
-winsmux name %2 codex
-
-# 4. メッセージを送信
-winsmux read codex 20
-winsmux message codex "review src/auth.ts"
-winsmux read codex 20
-winsmux keys codex Enter
+# 既定の Orchestra レイアウトを起動
+pwsh winsmux-core/scripts/orchestra-start.ps1
 ```
 
-## キーバインド
+現在の既定レイアウトは次です。
 
-すべてのキーバインドは **Alt** キーを使用する。プレフィックス不要。
+- 管理対象ウィンドウの外に external operator terminal
+- 管理対象ウィンドウの中に複数の `worker-*` pane
+- 旧 `Commander / Builder / Researcher / Reviewer` レイアウトは compatibility mode でのみ有効
 
-### ペイン
-
-| キー          | 動作                              |
-| ------------- | --------------------------------- |
-| `Alt+i/k/j/l` | 上/下/左/右に移動                 |
-| `Alt+n`       | 新しいペイン（分割 + 自動タイル） |
-| `Alt+w`       | ペインを閉じる                    |
-| `Alt+o`       | レイアウトを切り替え              |
-| `Alt+g`       | ペインをマーク                    |
-| `Alt+y`       | マークしたペインと入れ替え        |
-
-### ウィンドウ
-
-| キー    | 動作             |
-| ------- | ---------------- |
-| `Alt+m` | 新しいウィンドウ |
-| `Alt+u` | 次のウィンドウ   |
-| `Alt+h` | 前のウィンドウ   |
-
-### スクロール
-
-| キー                | 動作                       |
-| ------------------- | -------------------------- |
-| `Alt+Tab`           | スクロールモードの切り替え |
-| `i/k`               | 上/下にスクロール          |
-| `Shift+I/K`         | 半ページ上/下              |
-| `q` または `Escape` | スクロールモード終了       |
-
-### マウス
-
-- クリックでペインを選択
-- ドラッグでテキスト選択（自動でクリップボードにコピー）
-- スクロールホイールでスクロール
-
-## tmux 互換ランタイム
-
-winsmux の土台には、`core/` にある Rust 製の Windows ネイティブターミナルマルチプレクサが入っている。Orchestra やクロスペイン CLI はこのランタイムの上で動く。
-
-- **tmux 互換** — tmux コマンド体系を話し、`~/.tmux.conf` を読み込み、既存テーマをそのまま使える
-- **Windows ネイティブ** — ConPTY ベースで動き、WSL/Cygwin/MSYS2 を前提にしない
-- **複数エントリポイント** — `winsmux`、`pmux`、`tmux` の3つの名前で起動できる
-- **自動化向け** — 76 個の tmux 互換コマンドと 126+ の format 変数を備え、エージェント運用の基盤になる
-
-| ランタイム資料 | 内容 |
-| ------------- | ---- |
-| [Features](core/docs/features.md) | マウス、コピー、レイアウト、format、スクリプト機能 |
-| [Compatibility](core/docs/compatibility.md) | tmux 互換性マトリクスとコマンド実装状況 |
-| [Configuration](core/docs/configuration.md) | 設定ファイル、オプション、環境変数、`.tmux.conf` 対応 |
-| [Key Bindings](core/docs/keybindings.md) | 既定のキーボード操作とマウス操作 |
-| [Mouse over SSH](core/docs/mouse-ssh.md) | SSH 越しのマウス挙動と Windows バージョン要件 |
-| [Claude Code](core/docs/claude-code.md) | Claude Code の teammate panes がどう載るか |
-
-## winsmux
-
-Windows 向けのクロスペイン通信 CLI。シェルコマンドを実行できるツールなら何でも使える — Claude Code、Codex、Gemini CLI、PowerShell スクリプトなど。
-
-| コマンド                                | 説明                                             |
-| --------------------------------------- | ------------------------------------------------ |
-| `winsmux list`                     | 全ペインをターゲット・プロセス・ラベル付きで表示 |
-| `winsmux read <target> [lines]`    | ペインの末尾 N 行を読み取り（デフォルト 50）     |
-| `winsmux type <target> <text>`     | ペインにテキストを入力（Enter なし）             |
-| `winsmux keys <target> <key>...`   | キーを送信（Enter, Escape, C-c 等）              |
-| `winsmux message <target> <text>`  | 送信者情報付きのタグ付きメッセージを送信         |
-| `winsmux name <target> <label>`    | ペインにラベルを付ける                           |
-| `winsmux resolve <label>`          | ラベルからペインを検索                           |
-| `winsmux id`                       | 自分のペイン ID を表示                           |
-| `winsmux ime-input <target>`       | GUI ダイアログで日本語 IME 入力                  |
-| `winsmux image-paste <target>`     | クリップボード画像を保存してパスを送信           |
-| `winsmux clipboard-paste <target>` | クリップボードテキストをペインに送信             |
-| `winsmux send <target> <text>`     | テキスト送信 + Enter（推奨）                     |
-| `winsmux focus <label\|target>`    | アクティブペイン切替（winsmux 外から操作）         |
-| `winsmux wait <channel> [timeout]` | シグナル受信までブロック（ポーリング置換）       |
-| `winsmux signal <channel>`         | シグナル送信（待機プロセスをアンブロック）       |
-| `winsmux watch <label> [sil] [to]` | ペイン出力の沈黙を検知してブロック解除           |
-| `winsmux vault set <key> [value]`  | 資格情報をセキュアに保存（DPAPI）                |
-| `winsmux vault get <key>`          | 保存済み資格情報を取得                           |
-| `winsmux vault inject <pane>`      | 全資格情報を環境変数としてペインに注入           |
-| `winsmux vault list`               | 保存済み資格情報のキー一覧                       |
-| `winsmux profile [name] [agents]`  | WT ドロップダウンプロファイルの表示・登録         |
-| `winsmux wait-ready <target> [to]` | エージェントのアイドル待ち（デフォルト 30s）     |
-| `winsmux health-check`             | ラベル付きペインの READY/BUSY/HUNG/DEAD を報告   |
-| `winsmux doctor`                   | 環境チェックと IME 診断                          |
-| `winsmux version`                  | バージョンを表示                                 |
-
-### Read Guard
-
-CLI は **read-before-act** ルールを強制する。ペインを `read` しない限り `type` や `keys` は実行できない。`type`/`keys` 実行後はマークがクリアされ、再度 `read` が必要になる。
+セッション内では、pane を一覧・読取・送信できます。
 
 ```powershell
-winsmux type codex "hello"
-# error: must read the pane before interacting. Run: winsmux read codex
+winsmux list
+winsmux read worker-1 30
+winsmux send worker-3 "upstream issue を要約してください。"
 ```
 
-エージェントが誤ったペインに盲目的に入力するのを防ぐ仕組みだ。
+## ガバナンスの要点
 
-### ターゲット指定
+- **Role gates**: external operator と managed pane agents に同じ command surface を与えない
+- **Read Guard**: 読んでいない pane への blind input を防ぐ
+- **Worktree isolation**: worker ごとに独立した git worktree を持てる
+- **Credential Vault**: Windows DPAPI でシークレットを管理し、repo に `.env` を置かない
+- **Evidence Ledger**: prompt、action、review evidence を記録できる
 
-ペインは以下の方法で指定できる:
+## 主要コマンド
 
-- **ペイン ID** — `%3`, `%5`（winsmux ネイティブ ID）
-- **ラベル** — `winsmux name` で設定した任意の名前
-
-ラベルはすべてのコマンドで自動解決される。保存先は `$env:APPDATA\winsmux\labels.json`。
-
-### ペイン境界ラベル
-
-v0.9.5 で、ペイン境界に見えるラベルを出すための winsmux 機能として次の 2 つをサポート:
-
-- `pane-border-format` は各ペイン境界に描画する文字列を制御する
-- `pane-border-status` はその境界文字列の表示を有効にし、位置を `top` または `bottom` にする
-
-`pane-border-format` に `#{pane_title}` を入れると、ペインラベルを表示できる。このタイトルは `select-pane -T` で直接設定することも、`winsmux name` 経由で設定することもできる。
-
-設定例:
-
-```tmux
-set -g pane-border-status top
-set -g pane-border-format " #{pane_index} #{pane_title} "
-
-# どちらのコマンドでも境界に表示するラベルを設定できる。
-select-pane -T claude
-winsmux name %2 codex
-```
-
-## Credential Vault
-
-シークレットをセキュアに保管し、エージェントのペインに注入する。リポジトリに `.env` ファイルを置く必要はない。
-
-```powershell
-# 資格情報を保存（DPAPI 暗号化、Windows Credential Manager）
-winsmux vault set OPENAI_API_KEY sk-...
-winsmux vault set ANTHROPIC_API_KEY sk-ant-...
-
-# ビルダーペインに全資格情報を $env: 変数として注入
-winsmux read builder 10
-winsmux vault inject builder
-```
-
-資格情報は Windows DPAPI でマシン単位に暗号化保存される。`vault inject` はターゲットペインに `$env:KEY = 'value'` コマンドを送信するため、エージェントプロセスは環境変数として受け取る。ディスクに平文は残らない。
-
-## Windows Terminal 連携
-
-インストーラーは [Fragments](https://learn.microsoft.com/en-us/windows/terminal/json-fragment-extensions) 経由で Windows Terminal のドロップダウンに **winsmux Orchestra** プロファイルを自動登録する。ワンクリックで `winsmux doctor` → winsmux セッション作成 → Orchestra スクリプト起動までを実行。
-
-カスタムプロファイルの作成:
-
-```powershell
-winsmux profile mysetup builder:codex reviewer:claude
-```
-
-## Orchestra
-
-Orchestra は1人の Commander が複数の AI エージェントを並列管理する仕組みだ。Commander はユーザーのターミナルで動作（キーボード直接入力可能）、バックグラウンドのエージェントは winsmux ペインで動く。やりたいことを Commander に伝えれば、ビルダーへの作業分割・完了ポーリング・レビュー依頼・競合チェック・コミットまでを自動で進める。
-
-### Commander がやること
-
-1. **作業分割** — ビルダーごとに担当ファイルを割り当て、互いに干渉させない
-2. **完了ポーリング** — 全エージェントを `winsmux read` で巡回し、完了を検知
-3. **段階的レビュー** — ビルダーが完了した順にレビュアーへ送信（全員を待たない）
-4. **競合検知** — マージ前に `git diff --name-only` で変更ファイルの重複をチェック
-5. **安全なコミット** — レビュー通過＋競合なしの場合のみコミット
-
-### マルチベンダー対応
-
-異なる CLI エージェントを同じ Orchestra に混在できる。スクリプトが CLI の種類を自動判定して差異を吸収する:
-
-| CLI         | 承認レスフラグ（`-ShieldHarness` 有効時） |
-| ----------- | ----------------------------------------- |
-| Claude Code | `--permission-mode bypassPermissions`     |
-| Codex CLI   | `--sandbox danger-full-access`             |
-| Gemini CLI  | `--yolo`                                  |
-
-`-ShieldHarness` なし: フラグは付与されない（手動承認モード）。
-
-### クイック起動
-
-```powershell
-# 1. ターミナルを開いて winsmux を起動
-winsmux
-
-# 2. 別のターミナルから Orchestra セットアップを実行
-pwsh scripts/start-orchestra.ps1 -ProjectDir C:\path\to\project
-
-# 3. さらに別のターミナルで Commander を起動
-cd C:\path\to\project
-claude --model claude-opus-4-6 --append-system-prompt-file .commander-prompt.txt
-```
-
-### スケールアップ（例: ビルダー4 + リサーチャー + レビュアー）
-
-```powershell
-pwsh scripts/start-orchestra.ps1 -ProjectDir C:\my\project -Rows 2 -Cols 3 -Agents @(
-  @{label="builder-1"; command="codex"},
-  @{label="builder-2"; command="codex"},
-  @{label="builder-3"; command="gemini --model gemini-3.1-pro-preview"},
-  @{label="researcher"; command="claude --model sonnet"},
-  @{label="builder-4"; command="gemini --model gemini-3-flash-preview"},
-  @{label="reviewer"; command="codex"}
-) -ShieldHarness
-```
-
-```
-┌──────────┬──────────┬──────────┐
-│builder-1 │builder-2 │builder-3 │
-├──────────┼──────────┼──────────┤
-│researcher│builder-4 │reviewer  │
-└──────────┴──────────┴──────────┘
-```
-
-`.commander-prompt.txt` は実際のペインID・ラベル・協調プロトコル付きで自動生成される。Commander は誰にどう話しかければいいか常に把握している。
-
-| パラメータ       | デフォルト        | 説明                                                                                        |
-| ---------------- | ----------------- | ------------------------------------------------------------------------------------------- |
-| `-ProjectDir`    | カレント          | 全ペインの作業ディレクトリ                                                                  |
-| `-Rows`          | 2                 | グリッドの行数                                                                              |
-| `-Cols`          | 2                 | グリッドの列数                                                                              |
-| `-Agents`        | 4ペインデフォルト | `@{label; command}` の配列                                                                  |
-| `-ShieldHarness` | Off               | [Shield Harness](https://github.com/Sora-bluesky/shield-harness) による承認レスモード有効化 |
-
-詳細は [SKILL.md](skills/winsmux/SKILL.md) を参照。管理プロトコル（パイプライン運用、researcher 偵察、reviewer 小分け、エージェント選定）はスキルの references/ に同梱され、エージェントがオンデマンドで読み込む。
-
-## AI Agent Skills
-
-winsmux スキルをインストールすると、エージェントが winsmux の使い方を学習する:
-
-```powershell
-npx skills add Sora-bluesky/winsmux
-```
-
-スキルに含まれるもの:
-
-- winsmux の使い方（[SKILL.md](skills/winsmux/SKILL.md)）
-- Orchestra 管理プロトコル（[references/orchestra-management.md](skills/winsmux/references/orchestra-management.md)）
-- エージェント選定ガイド（[references/agent-selection.md](skills/winsmux/references/agent-selection.md)）
-
-Claude Code、Codex、Cursor、Copilot、[その他のエージェント](https://skills.sh)で動作する。
-
-### Orchestra Layout スキル
-
-Claude Code ユーザー向けに、`orchestra-layout` スキルが決定論的な winsmux グリッドレイアウトを1コマンドで作成する。手動の split-window 試行錯誤を排除:
-
-```bash
-bash .claude/skills/orchestra-layout/scripts/orchestra-layout.sh 4b1r1v
-# 2x3 グリッド作成: ビルダー4 + リサーチャー1 + レビュアー1
-```
-
-## アップデート
-
-```powershell
-winsmux update
-```
-
-## アンインストール
-
-```powershell
-winsmux uninstall
-```
+| コマンド | 用途 |
+| ------- | ------- |
+| `winsmux list` | pane、label、process を表示 |
+| `winsmux read <target> [lines]` | 実行前に pane output を読む |
+| `winsmux send <target> <text>` | text を送って Enter を押す |
+| `winsmux health-check` | label 付き pane の READY/BUSY/HUNG/DEAD を報告 |
+| `winsmux vault set <key> [value]` | DPAPI-backed vault に資格情報を保存 |
+| `winsmux vault inject <pane>` | 保存済み資格情報を対象 pane に注入 |
+| `winsmux update` | 最新版へ更新 |
+| `winsmux uninstall` | winsmux を削除 |
 
 ## 動作要件
 
 - Windows 10/11
-- PowerShell 7+（pwsh）
-- [winsmux core (Rust binary)](https://github.com/Sora-bluesky/winsmux)（自動インストール）
-
-## 謝辞
-
-winsmux は [smux](https://github.com/ShawnPana/smux)（[@ShawnPana](https://github.com/ShawnPana) 作）の Windows ネイティブ版だ。smux は macOS/Linux 向けに tmux を使った同様のターミナルマルチプレクサ + AI エージェント通信ワークフローを提供している。winsmux はその体験を winsmux 経由で Windows にネイティブに持ち込む。WSL2 は不要。
-
-ターミナルバナーは [oh-my-logo](https://github.com/shinshin86/oh-my-logo)（MIT AND CC0-1.0）を使用。
+- PowerShell 7+
+- Windows Terminal 推奨
 
 ## ライセンス
 

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -1,6 +1,6 @@
 # Handoff
 
-> Updated: 2026-04-11T04:25:00+09:00
+> Updated: 2026-04-11T10:25:18+09:00
 > Source of truth: this file
 
 ## Current state
@@ -11,13 +11,16 @@
 - `v0.19.8 External Operator & Agent Slots` is implemented in order; private planning now tracks `TASK-259`, `TASK-261`, `TASK-262`, `TASK-263`, and `TASK-264` as done, and the external roadmap is synced accordingly.
 - Private planning now swaps `v0.20.0` and `v0.21.0` to match actual implementation order: `v0.20.0` is `Desktop UX Foundation`, and `v0.21.0` is `Operator Core & Slot Dispatch`.
 - PR [#370](https://github.com/Sora-bluesky/winsmux/pull/370), PR [#371](https://github.com/Sora-bluesky/winsmux/pull/371), PR [#372](https://github.com/Sora-bluesky/winsmux/pull/372), PR [#374](https://github.com/Sora-bluesky/winsmux/pull/374), PR [#375](https://github.com/Sora-bluesky/winsmux/pull/375), PR [#376](https://github.com/Sora-bluesky/winsmux/pull/376), PR [#379](https://github.com/Sora-bluesky/winsmux/pull/379), PR [#380](https://github.com/Sora-bluesky/winsmux/pull/380), PR [#381](https://github.com/Sora-bluesky/winsmux/pull/381), PR [#382](https://github.com/Sora-bluesky/winsmux/pull/382), PR [#383](https://github.com/Sora-bluesky/winsmux/pull/383), PR [#384](https://github.com/Sora-bluesky/winsmux/pull/384), PR [#385](https://github.com/Sora-bluesky/winsmux/pull/385), PR [#386](https://github.com/Sora-bluesky/winsmux/pull/386), PR [#387](https://github.com/Sora-bluesky/winsmux/pull/387), PR [#388](https://github.com/Sora-bluesky/winsmux/pull/388), PR [#389](https://github.com/Sora-bluesky/winsmux/pull/389), PR [#390](https://github.com/Sora-bluesky/winsmux/pull/390), and PR [#392](https://github.com/Sora-bluesky/winsmux/pull/392) are merged into `main`.
-- `v0.20.0` now tracks desktop UX work directly; `TASK-101`, `TASK-286`, `TASK-292`, and `TASK-299` are merged, `TASK-287` is active on `codex/task287-command-bar-20260411`, and `TASK-298` tracks the remaining public-repo vs maintainer-dogfooding cleanup.
+- `v0.20.0` now tracks desktop UX work directly; `TASK-101`, `TASK-286`, `TASK-287`, `TASK-292`, and `TASK-299` are merged, and `TASK-298` tracks the remaining public-repo vs maintainer-dogfooding cleanup.
 - Planning source of truth is externalized outside the public repository and syncs automatically into the private planning root.
 - `v0.21.x` private planning is aligned to a conversation-first Tauri operator shell, with Codex-App-like shell rules reflected in Figma and backlog notes.
 - `v0.24.x` private planning is split into schema, ledger, machine contract, cutover, and canary phases for Rust runtime convergence before `v1.0.0`.
 
 ## This session
 
+- Merged `TASK-287` via PR [#393](https://github.com/Sora-bluesky/winsmux/pull/393), adding the keyboard-first operator command bar (`Ctrl/Cmd+K`) with quick actions, IME-safe input handling, focus restore, and accessible active-option semantics.
+- Rewrote `README.ja.md` to match the public operator model in `README.md`, keeping it vendor-neutral and removing dogfooding orchestration recipes.
+- Converted `docs/project/README.md` and `tasks/README.md` into maintainer-only stubs that point back to the public product docs.
 - Merged the repo-side `TASK-244` session board surface via PR [#371](https://github.com/Sora-bluesky/winsmux/pull/371).
 - Released `v0.19.6` from tag `eac8615` and updated the public GitHub Release body to `/release-notes` format.
 - Merged `TASK-245` via PR [#372](https://github.com/Sora-bluesky/winsmux/pull/372), adding `winsmux inbox` as the first actionable approval/review/blocker surface.
@@ -61,9 +64,11 @@
 - Merged the public operator/pane docs and concise timeline slice via PR [#392](https://github.com/Sora-bluesky/winsmux/pull/392), adding `AGENT-BASE.md`, `AGENT.md`, the strict-default `.claude/CLAUDE.md`, the reworked `docs/operator-model.md`, and pane report cards with `STATUS/TASK/RESULT/FILES_CHANGED/ISSUES`.
 - Re-synced the external planning backlog/roadmap after PR [#392](https://github.com/Sora-bluesky/winsmux/pull/392), marking `TASK-101`, `TASK-286`, `TASK-292`, and `TASK-299` as done so `v0.20.0` now shows `83% (10/12)`.
 - Started `TASK-287` on `codex/task287-command-bar-20260411`, adding a keyboard-first command bar (`Ctrl/Cmd+K`) with quick actions for dispatch/review/explain, source context, settings, and terminal control.
+- Started `TASK-298` cleanup on `codex/task298-public-surface-cleanup-20260411`, removing maintainer-heavy content from public docs/config, rewriting `README.ja.md`, and shrinking tracked planning readmes into internal stubs.
 
 ## Validation
 
+- Docs-only change; no tests run.
 - Release workflow passed for `v0.19.6`.
 - Release workflow passed for `v0.19.7`.
 - Release workflow passed for `v0.19.8`: GitHub Actions run `24234569692` published `winsmux-x64.exe`, `winsmux-arm64.exe`, and `SHA256SUMS`.
@@ -85,10 +90,11 @@
 - Current `TASK-101` theme-contract slice passes frontend build: `npm run build` in `winsmux-app`.
 - Merged `TASK-292/TASK-286/TASK-299` slice passed frontend build before landing: `npm run build` in `winsmux-app`.
 - Current `TASK-287` command-bar slice passes frontend build: `npm run build` in `winsmux-app`.
+- Current `TASK-298` public-surface cleanup is docs/config only so far: `git diff --check` passes.
 
 ## Next actions
 
-1. Publish `TASK-287` (global command bar + quick actions), then continue `v0.20.0: Desktop UX Foundation` with the remaining public-surface cleanup in `TASK-298`.
+1. Finish `TASK-298` public-surface cleanup, then publish the docs/config cleanup slice.
 2. Preserve the private planning sync flow: user/agent visible, auto-synced, but not committed to the public repo.
 3. Run the next retro-review tranche over recent merged PRs after each milestone-close sequence.
 

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -104,5 +104,6 @@
 - Public tracked files must not contain personal paths or private planning roots.
 - External planning source of truth stays outside the public repository and is resolved via the configured planning root.
 - Public docs may refer to the external planning contract, but must not embed machine-specific absolute paths.
+- `v0.21.2` release gate includes a required `README.md` / `README.ja.md` refresh so the terminal-based final form is documented before `v0.22.0` begins the desktop control-plane handoff.
 - Public GitHub Release titles and bodies are standardized in English, even when the working session is conducted in Japanese.
 - Before each release, explicitly re-check the boundary between public product docs/config and maintainer dogfooding material.

--- a/docs/operator-model.md
+++ b/docs/operator-model.md
@@ -102,15 +102,8 @@ Their responsibilities are:
 
 ## 5. Public docs vs contributor docs
 
-Contributor and dogfooding operations may still exist in repo-facing docs such as:
-
-- `AGENTS.md`
-- `docs/handoff.md`
-
-Those files describe how contributors and AI agents operate **inside this repository**.
-They are not the public end-user guide for winsmux as a product.
-
-Dogfooding-specific rules do not define the public operator or pane contract.
+The files listed in this document describe the **public product contract** for winsmux.
+Contributor workflows, release operations, and repository-specific maintenance rules are documented separately and do not define the public operator or pane contract.
 
 ## 6. Legacy layouts vs current model
 

--- a/docs/project/README.md
+++ b/docs/project/README.md
@@ -1,16 +1,11 @@
-# Project Roadmap
+# Internal Planning Surface
 
-`ROADMAP.md` is maintained outside this repository and is generated from the external planning backlog.
+This directory is for maintainer-only planning notes and sync surfaces.
+It is not public product documentation.
 
-Default resolution order:
+For the public operator model and user-facing product docs, see:
 
-- `WINSMUX_ROADMAP_PATH`
-- `WINSMUX_PLANNING_ROOT\ROADMAP.md`
-- the user-profile-relative default returned by `winsmux-core/scripts/planning-paths.ps1`
+- [README.md](../../README.md)
+- [docs/operator-model.md](../operator-model.md)
 
-Override with:
-
-- `WINSMUX_PLANNING_ROOT`
-- `WINSMUX_ROADMAP_PATH`
-
-Use `winsmux-core/scripts/sync-roadmap.ps1` to regenerate the external roadmap.
+The active planning source of truth is maintained outside the public product docs.

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -1,16 +1,11 @@
-# Planning Backlog
+# Internal Task Surface
 
-`backlog.yaml` is maintained outside this repository.
+This directory is for maintainer-only planning and task sync files.
+It is not public product documentation.
 
-Default resolution order:
+For the public operator model and user-facing product docs, see:
 
-- `WINSMUX_BACKLOG_PATH`
-- `WINSMUX_PLANNING_ROOT\backlog.yaml`
-- the user-profile-relative default returned by `winsmux-core/scripts/planning-paths.ps1`
+- [README.md](../README.md)
+- [docs/operator-model.md](../docs/operator-model.md)
 
-Override with:
-
-- `WINSMUX_PLANNING_ROOT`
-- `WINSMUX_BACKLOG_PATH`
-
-Use `winsmux-core/scripts/sync-roadmap.ps1` to regenerate the external roadmap from the external backlog.
+Task and roadmap sources of truth live outside the public docs.


### PR DESCRIPTION
## Summary
- rewrite README.ja.md to match the public operator model in README.md
- remove maintainer/release-process wording from public operator docs
- make tracked winsmux config files public-safe and shrink internal planning readmes into maintainer-only stubs

## Validation
- git diff --check
- manual diff review
- public marker sweep for planning/env vars and dogfooding recipes
- external roadmap re-synced after updating TASK-287/TASK-298 notes