### PR TITLE
feat(transport): add prompt transport abstraction slice

### DIFF
--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -1,6 +1,6 @@
 # Handoff
 
-> Updated: 2026-04-11T11:58:00+09:00
+> Updated: 2026-04-11T14:25:00+09:00
 > Source of truth: this file
 
 ## Current state
@@ -18,6 +18,12 @@
 
 ## This session
 
+- Expanded the public operator contract in [docs/operator-model.md](../docs/operator-model.md) to add `Observation Pack`, `Consultation loop`, `Consult-capable slots`, `Experiment isolation and compare`, and `Tactic promotion` as first-class winsmux concepts.
+- Updated the external planning backlog so `TASK-114`, `TASK-187`, `TASK-191`, `TASK-286`, and `TASK-299` explicitly cover experiment-ledger and consultation semantics, and added `TASK-300` through `TASK-305` for observation packs, consultation packets, consult-capable slots, experiment compare, tactic promotion, and the Tauri experiment board.
+- Updated the Figma `winsmux Tauri Operator Workspace` file with a new `E. Experiment Loop & Consultation` section that maps `Experiments`, consultation cards, compare views, and playbook promotion into the sidebar, conversation shell, context side sheet, and command bar.
+- Started the repo-side `TASK-187` first slice locally by introducing `prompt_transport` settings precedence (`global -> role -> slot`) with built-in `argv` default and fail-closed rejection for unsupported values such as `stdin`.
+- Extracted send-path transport planning in [scripts/winsmux-core.ps1](../scripts/winsmux-core.ps1) so normal sends and `codex exec` sends now share a single transport-plan entry point while preserving file-backed prompt handoff as the first stable transport abstraction.
+- Extended [tests/psmux-bridge.Tests.ps1](../tests/psmux-bridge.Tests.ps1) to cover prompt-transport settings precedence, restart-plan propagation, and file-forced dispatch payload behavior, and updated [winsmux-core/scripts/pane-control.ps1](../winsmux-core/scripts/pane-control.ps1) to surface the resolved `PromptTransport` in restart plans.
 - Merged `TASK-287` via PR [#393](https://github.com/Sora-bluesky/winsmux/pull/393), adding the keyboard-first operator command bar (`Ctrl/Cmd+K`) with quick actions, IME-safe input handling, focus restore, and accessible active-option semantics.
 - Merged `TASK-298` via PR [#394](https://github.com/Sora-bluesky/winsmux/pull/394), rewriting `README.ja.md` to match the public operator model, shrinking maintainer-only planning readmes into internal stubs, and making tracked public config/docs safer for external users.
 - Re-synced the external planning backlog/roadmap after PR [#394](https://github.com/Sora-bluesky/winsmux/pull/394), marking `TASK-298` as done so `v0.20.0` now shows `100% (12/12)`.
@@ -94,12 +100,13 @@
 - Current `TASK-287` command-bar slice passes frontend build: `npm run build` in `winsmux-app`.
 - `TASK-298` docs/config cleanup landed via PR [#394](https://github.com/Sora-bluesky/winsmux/pull/394); its CI `Pester Tests` run `24271531120` passed before merge.
 - `v0.20.0` release workflow run `24276032671` completed successfully and published `winsmux-x64.exe`, `winsmux-arm64.exe`, and `SHA256SUMS`.
+- Current local `TASK-187` transport slice passes focused regression: `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `122/122 PASS`.
 
 ## Next actions
 
-1. Commit and push the release-note generator fix so future GitHub Releases use the Codex-style headings without manual cleanup.
-2. Preserve the private planning sync flow: user/agent visible, auto-synced, but not committed to the public repo.
-3. Run the next retro-review tranche over recent merged PRs after each milestone-close sequence.
+1. Commit and review the current `TASK-187` first slice, then open the PR with the existing `argv/file` transport contract and `stdin` fail-close behavior made explicit.
+2. Follow with `TASK-114` so the event ledger becomes an experiment ledger with searchable `hypothesis / test_plan / result / consultation_ref` fields.
+3. Keep the external planning sync flow user-visible but out of the public repo, then reflect consultation/experiment surfaces into the Tauri shell as `TASK-305` approaches.
 
 ## Notes
 

--- a/docs/operator-model.md
+++ b/docs/operator-model.md
@@ -139,3 +139,73 @@ Pane result reports should follow the shared `AGENT-BASE.md` report shape:
 - `RESULT`
 - `FILES_CHANGED`
 - `ISSUES`
+
+## 8. Observation packs
+
+Before substantive work, the operator should perform a small orientation pass and package the result as an **observation pack** for the target pane or slot.
+
+Observation packs are not freeform prose. They are evidence bundles that can be compared across runs and experiments.
+
+An observation pack should include, when available:
+
+- changed files
+- working tree summary
+- failing command or failing check
+- last passing signal
+- branch/head
+- worktree
+- CI, build, cache, and environment signals
+- relevant links or prior evidence references
+
+## 9. Consultation loop
+
+When the operator judges a task to be difficult, ambiguous, or non-converging, it should consult a **consult-capable slot**.
+
+The standard consultation timings are:
+
+- after initial orientation, before substantive work
+- when stuck
+- when considering a change of approach
+- when evidence conflicts
+- before declaring the task done
+
+Consultation results are advisory. The operator owns the final accept/reject judgement.
+
+## 10. Consult-capable slots
+
+Consultation is handled as a slot capability, similar to review capability.
+
+- no dedicated consultation pane is required
+- Codex is the default consultation candidate for code, build, and debug work
+- Gemini is the default consultation candidate for long-context, multimodal, policy, or specification work
+- other providers may advertise consultation capability in the same slot model
+
+In **advisory mode**, a consult-capable slot does not perform file mutation or destructive command execution. It returns recommendations, risks, confidence, and the next test to run.
+
+The default policy is:
+
+- up to 2 consultation calls per run
+- a 3rd call is allowed only for stuck-state recovery or evidence reconciliation
+
+## 11. Experiment isolation and compare
+
+Hypothesis-driven work should be isolated by run, slot, and worktree.
+
+- one hypothesis should map to one run
+- parallel experiments should use separate slots or worktrees
+- comparison should happen on top of the run ledger, not ad hoc operator memory
+
+The operator uses these isolated runs to compare evidence, detect conflicts, and choose the next experiment.
+
+## 12. Tactic promotion
+
+When a run finds a repeatable winning tactic, winsmux should promote it instead of leaving it as one-off tribal knowledge.
+
+Promotion targets include:
+
+- playbooks
+- prewarm candidates
+- verification presets
+- reusable investigation prompts
+
+This keeps successful debugging, build, and verification loops durable and reusable across future runs.

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -187,24 +187,43 @@ function New-SendDispatchPointerText {
     return "Read the full prompt from '$promptRef' and follow it exactly. This pointer was sent because the original prompt exceeded the send buffer."
 }
 
+function Resolve-SupportedPromptTransport {
+    param([AllowEmptyString()][string]$PromptTransport = 'argv')
+
+    $resolved = if ([string]::IsNullOrWhiteSpace($PromptTransport)) {
+        'argv'
+    } else {
+        $PromptTransport.Trim().ToLowerInvariant()
+    }
+
+    if ($resolved -notin @('argv', 'file')) {
+        throw "Unsupported prompt_transport setting: $PromptTransport"
+    }
+
+    return $resolved
+}
+
 function Resolve-SendDispatchPayload {
     param(
         [Parameter(Mandatory = $true)][string]$Text,
         [string]$ProjectDir = (Get-Location).Path,
-        [int]$LengthLimit = 4000
+        [int]$LengthLimit = 4000,
+        [string]$PromptTransport = 'argv'
     )
 
+    $resolvedPromptTransport = Resolve-SupportedPromptTransport -PromptTransport $PromptTransport
     $payload = [ordered]@{
-        TextToSend     = $Text
-        PromptPath     = $null
+        TextToSend      = $Text
+        PromptPath      = $null
         PromptReference = $null
-        IsFileBacked   = $false
-        TextLength     = $Text.Length
-        LengthLimit    = $LengthLimit
-        FallbackMode   = 'pointer'
+        IsFileBacked    = $false
+        TextLength      = $Text.Length
+        LengthLimit     = $LengthLimit
+        FallbackMode    = 'pointer'
+        PromptTransport = $resolvedPromptTransport
     }
 
-    if ($Text.Length -le $LengthLimit) {
+    if ($resolvedPromptTransport -eq 'argv' -and $Text.Length -le $LengthLimit) {
         return $payload
     }
 
@@ -215,6 +234,75 @@ function Resolve-SendDispatchPayload {
     $payload['TextToSend'] = New-SendDispatchPointerText -PromptPath $promptPath -ProjectDir $ProjectDir
 
     return $payload
+}
+
+function ConvertTo-DispatchPowerShellLiteral {
+    param([Parameter(Mandatory = $true)][AllowEmptyString()][string]$Value)
+
+    $paneControlLiteralHelper = Get-Command ConvertTo-PaneControlPowerShellLiteral -ErrorAction SilentlyContinue
+    if ($null -ne $paneControlLiteralHelper) {
+        return ConvertTo-PaneControlPowerShellLiteral -Value $Value
+    }
+
+    $genericLiteralHelper = Get-Command ConvertTo-PowerShellLiteral -ErrorAction SilentlyContinue
+    if ($null -ne $genericLiteralHelper) {
+        return ConvertTo-PowerShellLiteral -Value $Value
+    }
+
+    return "'" + ($Value -replace "'", "''") + "'"
+}
+
+function Resolve-SendTransportPlan {
+    param(
+        [Parameter(Mandatory = $true)][string]$Text,
+        [string]$ProjectDir = (Get-Location).Path,
+        [int]$LengthLimit = 4000,
+        [string]$PromptTransport = 'argv',
+        [bool]$ExecMode = $false,
+        [string]$LaunchDir,
+        [string]$GitWorktreeDir,
+        [string]$Model
+    )
+
+    $resolvedPromptTransport = Resolve-SupportedPromptTransport -PromptTransport $PromptTransport
+    if (-not $ExecMode) {
+        $payload = Resolve-SendDispatchPayload -Text $Text -ProjectDir $ProjectDir -LengthLimit $LengthLimit -PromptTransport $resolvedPromptTransport
+        return [ordered]@{
+            Mode            = if ($payload['IsFileBacked']) { 'pointer' } else { 'inline' }
+            TextToSend      = [string]$payload['TextToSend']
+            PromptPath      = $payload['PromptPath']
+            PromptReference = $payload['PromptReference']
+            IsFileBacked    = [bool]$payload['IsFileBacked']
+            TextLength      = [int]$payload['TextLength']
+            LengthLimit     = [int]$payload['LengthLimit']
+            FallbackMode    = [string]$payload['FallbackMode']
+            PromptTransport = [string]$payload['PromptTransport']
+            ExecInstruction = $null
+        }
+    }
+
+    $promptPath = New-DispatchPromptFile -Content $Text -ProjectDir $ProjectDir -Prefix 'send-command'
+    $outputPath = '{0}.last-message.txt' -f $promptPath
+    $promptInstruction = 'Read the prompt file at {0} and follow its instructions' -f $promptPath
+    $execInstruction = 'codex exec --sandbox danger-full-access -C {0} --add-dir {1} -o {2} -m {3} {4}' -f `
+        (ConvertTo-DispatchPowerShellLiteral -Value $LaunchDir), `
+        (ConvertTo-DispatchPowerShellLiteral -Value $GitWorktreeDir), `
+        (ConvertTo-DispatchPowerShellLiteral -Value $outputPath), `
+        (ConvertTo-DispatchPowerShellLiteral -Value $Model), `
+        (ConvertTo-DispatchPowerShellLiteral -Value $promptInstruction)
+
+    return [ordered]@{
+        Mode            = 'codex_exec_file'
+        TextToSend      = $null
+        PromptPath      = $promptPath
+        PromptReference = Get-DispatchPromptReference -PromptPath $promptPath -ProjectDir $ProjectDir
+        IsFileBacked    = $true
+        TextLength      = $Text.Length
+        LengthLimit     = $LengthLimit
+        FallbackMode    = 'exec_file'
+        PromptTransport = $resolvedPromptTransport
+        ExecInstruction = $execInstruction
+    }
 }
 
 function Convert-MsysTmpPathToWindowsPath {
@@ -1370,13 +1458,13 @@ function Invoke-Send {
     $projectDir = (Get-Location).Path
     $paneId = Resolve-Target $Target
     $paneId = Confirm-Target $paneId
-    $textToSend = $text
-    $dispatchPayload = Resolve-SendDispatchPayload -Text $text -ProjectDir $projectDir -LengthLimit 4000
-
-    if ($dispatchPayload['IsFileBacked']) {
-        $textToSend = [string]$dispatchPayload['TextToSend']
-        Write-Warning ("send target '{0}' exceeded {1} chars ({2}); wrote full text to {3} and sent a prompt-file pointer instead." -f $Target, $dispatchPayload['LengthLimit'], $dispatchPayload['TextLength'], $dispatchPayload['PromptPath'])
+    $context = $null
+    $agentConfig = [ordered]@{
+        Agent           = 'codex'
+        Model           = 'gpt-5.4'
+        PromptTransport = 'argv'
     }
+    $execMode = $false
 
     try {
         if (Test-Path $PaneControlScript -PathType Leaf) {
@@ -1386,11 +1474,14 @@ function Invoke-Send {
         if (Test-Path $BridgeSettingsScript -PathType Leaf) {
             . $BridgeSettingsScript
         }
+    } catch {
+    }
 
-        $hasManifestHelper = Get-Command Get-PaneControlManifestContext -ErrorAction SilentlyContinue
-        $hasRoleConfigHelper = Get-Command Get-RoleAgentConfig -ErrorAction SilentlyContinue
-        if ($null -ne $hasManifestHelper -and $null -ne $hasRoleConfigHelper) {
-            $projectDir = (Get-Location).Path
+    $hasManifestHelper = Get-Command Get-PaneControlManifestContext -ErrorAction SilentlyContinue
+    $hasRoleConfigHelper = Get-Command Get-RoleAgentConfig -ErrorAction SilentlyContinue
+    $manifestPath = Join-Path $projectDir '.winsmux\manifest.yaml'
+    if ($null -ne $hasManifestHelper -and $null -ne $hasRoleConfigHelper -and (Test-Path $manifestPath -PathType Leaf)) {
+        try {
             $context = Get-PaneControlManifestContext -ProjectDir $projectDir -PaneId $paneId
             if ($null -ne $context -and -not [string]::IsNullOrWhiteSpace([string]$context.ManifestPath)) {
                 $manifestContent = Get-Content -LiteralPath $context.ManifestPath -Raw -Encoding UTF8
@@ -1398,6 +1489,12 @@ function Invoke-Send {
                 $manifestPane = $null
                 if ($null -ne $manifest -and $null -ne $manifest.Panes -and $manifest.Panes.Contains([string]$context.Label)) {
                     $manifestPane = $manifest.Panes[[string]$context.Label]
+                }
+
+                if (Get-Command Get-SlotAgentConfig -ErrorAction SilentlyContinue) {
+                    $agentConfig = Get-SlotAgentConfig -Role $context.Role -SlotId $context.Label
+                } else {
+                    $agentConfig = Get-RoleAgentConfig -Role $context.Role
                 }
 
                 $execModeValue = ''
@@ -1409,47 +1506,32 @@ function Invoke-Send {
                     }
                 }
 
-                $roleAgentConfig = Get-RoleAgentConfig -Role $context.Role
-                $agent = [string]$roleAgentConfig.Agent
-                if ($execModeValue.Trim().ToLowerInvariant() -eq 'true' -and $agent.Trim().ToLowerInvariant() -eq 'codex') {
-                    $quotePowerShellLiteral = {
-                        param([Parameter(Mandatory = $true)][AllowEmptyString()][string]$Value)
-
-                        $paneControlLiteralHelper = Get-Command ConvertTo-PaneControlPowerShellLiteral -ErrorAction SilentlyContinue
-                        if ($null -ne $paneControlLiteralHelper) {
-                            return ConvertTo-PaneControlPowerShellLiteral -Value $Value
-                        }
-
-                        $genericLiteralHelper = Get-Command ConvertTo-PowerShellLiteral -ErrorAction SilentlyContinue
-                        if ($null -ne $genericLiteralHelper) {
-                            return ConvertTo-PowerShellLiteral -Value $Value
-                        }
-
-                        throw 'No PowerShell literal helper is available.'
-                    }
-
-                    $promptPath = New-DispatchPromptFile -Content $text -ProjectDir $projectDir
-                    $outputPath = '{0}.last-message.txt' -f $promptPath
-                    $launchDir = [string]$context.LaunchDir
-                    $gitWorktreeDir = [string]$context.GitWorktreeDir
-                    $model = [string]$roleAgentConfig.Model
-                    $promptInstruction = 'Read the prompt file at {0} and follow its instructions' -f $promptPath
-                    $dispatchCommand = 'codex exec --sandbox danger-full-access -C {0} --add-dir {1} -o {2} -m {3} {4}' -f `
-                        (& $quotePowerShellLiteral $launchDir), `
-                        (& $quotePowerShellLiteral $gitWorktreeDir), `
-                        (& $quotePowerShellLiteral $outputPath), `
-                        (& $quotePowerShellLiteral $model), `
-                        (& $quotePowerShellLiteral $promptInstruction)
-
-                    Send-TextToPane -PaneId $paneId -CommandText $dispatchCommand
-                    return
-                }
+                $execMode = $execModeValue.Trim().ToLowerInvariant() -eq 'true' -and [string]$agentConfig.Agent -eq 'codex'
             }
+        } catch {
         }
-    } catch {
     }
 
-    Send-TextToPane -PaneId $paneId -CommandText $textToSend
+    $transportPlan = Resolve-SendTransportPlan `
+        -Text $text `
+        -ProjectDir $projectDir `
+        -LengthLimit 4000 `
+        -PromptTransport ([string]$agentConfig.PromptTransport) `
+        -ExecMode:$execMode `
+        -LaunchDir ([string]$context.LaunchDir) `
+        -GitWorktreeDir ([string]$context.GitWorktreeDir) `
+        -Model ([string]$agentConfig.Model)
+
+    if ($transportPlan['Mode'] -eq 'codex_exec_file') {
+        Send-TextToPane -PaneId $paneId -CommandText ([string]$transportPlan['ExecInstruction'])
+        return
+    }
+
+    if ($transportPlan['IsFileBacked']) {
+        Write-Warning ("send target '{0}' used prompt_transport={1}; wrote full text to {2} and sent a prompt-file pointer instead." -f $Target, $transportPlan['PromptTransport'], $transportPlan['PromptPath'])
+    }
+
+    Send-TextToPane -PaneId $paneId -CommandText ([string]$transportPlan['TextToSend'])
 }
 
 function Invoke-Name {

--- a/tests/psmux-bridge.Tests.ps1
+++ b/tests/psmux-bridge.Tests.ps1
@@ -170,6 +170,7 @@ Describe 'Get-BridgeSettings' {
 
         $settings.agent | Should -Be 'codex'
         $settings.model | Should -Be 'gpt-5.4'
+        $settings.prompt_transport | Should -Be 'argv'
         $settings.external_commander | Should -Be $true
         $settings.legacy_role_layout | Should -Be $false
         $settings.commanders | Should -Be 0
@@ -300,6 +301,71 @@ roles:
         $commanderConfig = Get-RoleAgentConfig -Role 'Commander' -Settings $settings
         $commanderConfig.Agent | Should -Be 'codex'
         $commanderConfig.Model | Should -Be 'gpt-5.4'
+    }
+
+    It 'parses per-role and slot-level prompt transport overrides with the same precedence as agent/model' {
+@'
+agent: codex
+model: gpt-5.4
+prompt-transport: argv
+roles:
+  worker:
+    agent: codex
+    model: gpt-5.4
+    prompt-transport: file
+agent-slots:
+  - slot-id: worker-1
+    runtime-role: worker
+    agent: claude
+    model: sonnet
+    prompt-transport: argv
+'@ | Set-Content -Path (Join-Path $script:settingsTempRoot '.winsmux.yaml') -Encoding UTF8
+
+        Mock Get-WinsmuxOption { param($Name, $Default) return $null }
+
+        $settings = Get-BridgeSettings
+        $settings.prompt_transport | Should -Be 'argv'
+        $settings.roles.worker.prompt_transport | Should -Be 'file'
+        $settings.agent_slots[0].prompt_transport | Should -Be 'argv'
+
+        $workerRoleConfig = Get-RoleAgentConfig -Role 'Worker' -Settings $settings
+        $workerRoleConfig.PromptTransport | Should -Be 'file'
+
+        $workerOneConfig = Get-SlotAgentConfig -Role 'Worker' -SlotId 'worker-1' -Settings $settings
+        $workerOneConfig.PromptTransport | Should -Be 'argv'
+        $workerOneConfig.Source | Should -Be 'slot'
+
+        $workerTwoConfig = Get-SlotAgentConfig -Role 'Worker' -SlotId 'worker-2' -Settings $settings
+        $workerTwoConfig.PromptTransport | Should -Be 'file'
+        $workerTwoConfig.Source | Should -Be 'role'
+    }
+
+    It 'lets project prompt_transport override the global winsmux option' {
+@'
+prompt-transport: file
+'@ | Set-Content -Path (Join-Path $script:settingsTempRoot '.winsmux.yaml') -Encoding UTF8
+
+        Mock Get-WinsmuxOption {
+            param($Name, $Default)
+
+            switch ($Name) {
+                '@bridge-prompt-transport' { 'argv' }
+                default { $null }
+            }
+        }
+
+        $settings = Get-BridgeSettings
+        $settings.prompt_transport | Should -Be 'file'
+    }
+
+    It 'fails closed when prompt_transport is unsupported' {
+@'
+prompt-transport: stdin
+'@ | Set-Content -Path (Join-Path $script:settingsTempRoot '.winsmux.yaml') -Encoding UTF8
+
+        Mock Get-WinsmuxOption { param($Name, $Default) return $null }
+
+        { Get-BridgeSettings } | Should -Throw '*prompt_transport*'
     }
 
     It 'prefers slot-level agent and model overrides when a matching slot id is provided' {
@@ -808,7 +874,54 @@ panes:
 
         $plan.Agent | Should -Be 'claude'
         $plan.Model | Should -Be 'sonnet'
+        $plan.PromptTransport | Should -Be 'argv'
         $plan.LaunchCommand | Should -Be 'claude --permission-mode bypassPermissions'
+    }
+
+    It 'includes slot-level prompt transport overrides in the restart plan' {
+@'
+version: 1
+saved_at: '2026-04-07T00:00:00+09:00'
+session:
+  name: 'winsmux-orchestra'
+  project_dir: 'C:\repo'
+  git_worktree_dir: 'C:\repo\.git'
+panes:
+  - label: 'worker-1'
+    pane_id: '%2'
+    role: 'Worker'
+    exec_mode: false
+    launch_dir: 'C:\repo'
+    task: null
+'@ | Set-Content -Path (Join-Path $script:paneControlManifestDir 'manifest.yaml') -Encoding UTF8
+
+        $settings = [ordered]@{
+            agent = 'codex'
+            model = 'gpt-5.4'
+            prompt_transport = 'argv'
+            roles = [ordered]@{
+                worker = [ordered]@{
+                    agent = 'codex'
+                    model = 'gpt-5.4'
+                    prompt_transport = 'file'
+                }
+            }
+            agent_slots = @(
+                [ordered]@{
+                    slot_id = 'worker-1'
+                    runtime_role = 'worker'
+                    agent = 'claude'
+                    model = 'sonnet'
+                    prompt_transport = 'argv'
+                }
+            )
+        }
+
+        $plan = Get-PaneControlRestartPlan -ProjectDir $script:paneControlTempRoot -PaneId '%2' -Settings $settings
+
+        $plan.Agent | Should -Be 'claude'
+        $plan.Model | Should -Be 'sonnet'
+        $plan.PromptTransport | Should -Be 'argv'
     }
 
     It 'updates launch_dir and builder_worktree_path together for builder panes' {
@@ -4107,6 +4220,20 @@ Describe 'winsmux send dispatch payload' {
         $promptContent = Get-Content -LiteralPath $payload['PromptPath'] -Raw -Encoding UTF8
         $promptContent.TrimEnd("`r", "`n") | Should -BeExactly $longText
         $payload['TextToSend'] | Should -Match ([regex]::Escape($payload['PromptReference']))
+    }
+
+    It 'always writes a dispatch file when prompt_transport is file' {
+        $payload = Resolve-SendDispatchPayload -Text 'Write-Host short' -ProjectDir $script:sendTempRoot -LengthLimit 4000 -PromptTransport 'file'
+
+        $payload['PromptTransport'] | Should -Be 'file'
+        $payload['IsFileBacked'] | Should -Be $true
+        $payload['TextToSend'] | Should -Match "Read the full prompt from '"
+        $payload['PromptPath'] | Should -Not -BeNullOrEmpty
+        (Get-Content -LiteralPath $payload['PromptPath'] -Raw -Encoding UTF8).TrimEnd("`r", "`n") | Should -BeExactly 'Write-Host short'
+    }
+
+    It 'rejects unsupported prompt transport values' {
+        { Resolve-SendDispatchPayload -Text 'Write-Host short' -ProjectDir $script:sendTempRoot -LengthLimit 4000 -PromptTransport 'stdin' } | Should -Throw '*prompt_transport*'
     }
 }
 

--- a/winsmux-core/scripts/pane-control.ps1
+++ b/winsmux-core/scripts/pane-control.ps1
@@ -506,6 +506,7 @@ function Get-PaneControlRestartPlan {
         GitWorktreeDir = $context.GitWorktreeDir
         Agent          = [string]$agentConfig.Agent
         Model          = [string]$agentConfig.Model
+        PromptTransport = [string]$agentConfig.PromptTransport
         LaunchCommand  = $launchCommand
     }
 }

--- a/winsmux-core/scripts/settings.ps1
+++ b/winsmux-core/scripts/settings.ps1
@@ -17,6 +17,7 @@ $script:BridgeSettingsFileName = '.winsmux.yaml'
 $script:BridgeSettingsSchema = [ordered]@{
     agent               = @{ Type = 'string';   Default = 'codex';       Option = '@bridge-agent' }
     model               = @{ Type = 'string';   Default = 'gpt-5.4';     Option = '@bridge-model' }
+    prompt_transport    = @{ Type = 'transport'; Default = 'argv';       Option = '@bridge-prompt-transport' }
     external_commander  = @{ Type = 'bool';     Default = $true;         Option = '@bridge-external-commander' }
     worker_count        = @{ Type = 'int';      Default = 6;             Option = '@bridge-worker-count' }
     agent_slots         = @{ Type = 'slotlist'; Default = @();           Option = $null }
@@ -207,7 +208,7 @@ function ConvertTo-BridgeSlotEntry {
     $slot = [ordered]@{}
     foreach ($pair in $pairs) {
         $key = $pair.Key.ToString() -replace '-', '_'
-        if ($key -notin @('slot_id', 'runtime_role', 'agent', 'model', 'worktree_mode')) {
+        if ($key -notin @('slot_id', 'runtime_role', 'agent', 'model', 'prompt_transport', 'worktree_mode')) {
             continue
         }
 
@@ -446,6 +447,26 @@ function Test-BridgeSettingValue {
                 }
             }
         }
+        'transport' {
+            $text = ConvertFrom-BridgeYamlScalar $Value
+            if ([string]::IsNullOrWhiteSpace($text)) {
+                return $false
+            }
+
+            switch ($text.Trim().ToLowerInvariant()) {
+                'argv' {
+                    $NormalizedValue.Value = 'argv'
+                    return $true
+                }
+                'file' {
+                    $NormalizedValue.Value = 'file'
+                    return $true
+                }
+                default {
+                    return $false
+                }
+            }
+        }
         'string[]' {
             $items = @()
 
@@ -511,7 +532,7 @@ function Test-BridgeSettingValue {
 
                 foreach ($rolePair in $rolePairs) {
                     $propertyKey = $rolePair.Key.ToString() -replace '-', '_'
-                    if ($propertyKey -notin @('agent', 'model')) {
+                    if ($propertyKey -notin @('agent', 'model', 'prompt_transport')) {
                         continue
                     }
 
@@ -609,6 +630,8 @@ function Read-BridgeGlobalSettings {
             } else {
                 $settings[$key] = $normalizedValue
             }
+        } elseif ($key -eq 'prompt_transport') {
+            throw "Invalid prompt_transport configuration: unsupported value '$rawValue'."
         }
     }
 
@@ -642,6 +665,10 @@ function Get-BridgeSettings {
 
     $rawProjectSettings = Read-BridgeProjectSettings -RootPath $RootPath
     $projectSettings = ConvertTo-BridgeSettingsSource $rawProjectSettings
+
+    if ($rawProjectSettings -is [System.Collections.IDictionary] -and $rawProjectSettings.Contains('prompt_transport') -and -not $projectSettings.Contains('prompt_transport')) {
+        throw "Invalid prompt_transport configuration: unsupported value '$($rawProjectSettings['prompt_transport'])'."
+    }
 
     if ($rawProjectSettings -is [System.Collections.IDictionary] -and $rawProjectSettings.Contains('agent_slots')) {
         $rawSlotEntries = @()
@@ -728,6 +755,14 @@ function Get-RoleAgentConfig {
 
     $agent = $Settings.agent
     $model = $Settings.model
+    $promptTransport = 'argv'
+    if ($Settings -is [System.Collections.IDictionary]) {
+        if ($Settings.Contains('prompt_transport') -and -not [string]::IsNullOrWhiteSpace([string]$Settings['prompt_transport'])) {
+            $promptTransport = [string]$Settings['prompt_transport']
+        }
+    } elseif ($null -ne $Settings.PSObject -and $Settings.PSObject.Properties.Name -contains 'prompt_transport' -and -not [string]::IsNullOrWhiteSpace([string]$Settings.prompt_transport)) {
+        $promptTransport = [string]$Settings.prompt_transport
+    }
 
     if ($resolvedRoleConfig -is [System.Collections.IDictionary]) {
         if ($resolvedRoleConfig.Contains('agent') -and -not [string]::IsNullOrWhiteSpace([string]$resolvedRoleConfig['agent'])) {
@@ -737,6 +772,10 @@ function Get-RoleAgentConfig {
         if ($resolvedRoleConfig.Contains('model') -and -not [string]::IsNullOrWhiteSpace([string]$resolvedRoleConfig['model'])) {
             $model = [string]$resolvedRoleConfig['model']
         }
+
+        if ($resolvedRoleConfig.Contains('prompt_transport') -and -not [string]::IsNullOrWhiteSpace([string]$resolvedRoleConfig['prompt_transport'])) {
+            $promptTransport = [string]$resolvedRoleConfig['prompt_transport']
+        }
     } elseif ($null -ne $resolvedRoleConfig -and $null -ne $resolvedRoleConfig.PSObject) {
         if ($resolvedRoleConfig.PSObject.Properties.Name -contains 'agent' -and -not [string]::IsNullOrWhiteSpace([string]$resolvedRoleConfig.agent)) {
             $agent = [string]$resolvedRoleConfig.agent
@@ -745,11 +784,16 @@ function Get-RoleAgentConfig {
         if ($resolvedRoleConfig.PSObject.Properties.Name -contains 'model' -and -not [string]::IsNullOrWhiteSpace([string]$resolvedRoleConfig.model)) {
             $model = [string]$resolvedRoleConfig.model
         }
+
+        if ($resolvedRoleConfig.PSObject.Properties.Name -contains 'prompt_transport' -and -not [string]::IsNullOrWhiteSpace([string]$resolvedRoleConfig.prompt_transport)) {
+            $promptTransport = [string]$resolvedRoleConfig.prompt_transport
+        }
     }
 
     return [PSCustomObject]@{
-        Agent = [string]$agent
-        Model = [string]$model
+        Agent           = [string]$agent
+        Model           = [string]$model
+        PromptTransport = [string]$promptTransport
     }
 }
 
@@ -767,6 +811,7 @@ function Get-SlotAgentConfig {
     $roleAgentConfig = Get-RoleAgentConfig -Role $Role -Settings $Settings
     $agent = [string]$roleAgentConfig.Agent
     $model = [string]$roleAgentConfig.Model
+    $promptTransport = [string]$roleAgentConfig.PromptTransport
     $source = 'role'
 
     if (-not [string]::IsNullOrWhiteSpace($SlotId)) {
@@ -787,6 +832,7 @@ function Get-SlotAgentConfig {
             $candidateSlotId = ''
             $slotAgent = ''
             $slotModel = ''
+            $slotPromptTransport = ''
 
             if ($slot -is [System.Collections.IDictionary]) {
                 if ($slot.Contains('slot_id')) {
@@ -798,6 +844,9 @@ function Get-SlotAgentConfig {
                 if ($slot.Contains('model')) {
                     $slotModel = [string]$slot['model']
                 }
+                if ($slot.Contains('prompt_transport')) {
+                    $slotPromptTransport = [string]$slot['prompt_transport']
+                }
             } elseif ($null -ne $slot.PSObject) {
                 if ($slot.PSObject.Properties.Name -contains 'slot_id') {
                     $candidateSlotId = [string]$slot.slot_id
@@ -807,6 +856,9 @@ function Get-SlotAgentConfig {
                 }
                 if ($slot.PSObject.Properties.Name -contains 'model') {
                     $slotModel = [string]$slot.model
+                }
+                if ($slot.PSObject.Properties.Name -contains 'prompt_transport') {
+                    $slotPromptTransport = [string]$slot.prompt_transport
                 }
             }
 
@@ -824,15 +876,21 @@ function Get-SlotAgentConfig {
                 $source = 'slot'
             }
 
+            if (-not [string]::IsNullOrWhiteSpace($slotPromptTransport)) {
+                $promptTransport = $slotPromptTransport
+                $source = 'slot'
+            }
+
             break
         }
     }
 
     return [PSCustomObject]@{
-        SlotId = [string]$SlotId
-        Agent  = [string]$agent
-        Model  = [string]$model
-        Source = [string]$source
+        SlotId          = [string]$SlotId
+        Agent           = [string]$agent
+        Model           = [string]$model
+        PromptTransport = [string]$promptTransport
+        Source          = [string]$source
     }
 }
 


### PR DESCRIPTION
## Summary
- add prompt_transport settings precedence with built-in argv default and fail-closed validation
- unify send-path transport planning for inline, pointer, and codex exec file-backed dispatch
- expose resolved PromptTransport in restart plans and cover the new contract with focused Pester tests

## Validation
- Invoke-Pester tests/psmux-bridge.Tests.ps1
- git diff --check
