### PR TITLE
feat(ledger): add experiment packet read models

### DIFF
--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -1,6 +1,6 @@
 # Handoff
 
-> Updated: 2026-04-11T14:25:00+09:00
+> Updated: 2026-04-11T18:05:00+09:00
 > Source of truth: this file
 
 ## Current state
@@ -24,6 +24,10 @@
 - Started the repo-side `TASK-187` first slice locally by introducing `prompt_transport` settings precedence (`global -> role -> slot`) with built-in `argv` default and fail-closed rejection for unsupported values such as `stdin`.
 - Extracted send-path transport planning in [scripts/winsmux-core.ps1](../scripts/winsmux-core.ps1) so normal sends and `codex exec` sends now share a single transport-plan entry point while preserving file-backed prompt handoff as the first stable transport abstraction.
 - Extended [tests/psmux-bridge.Tests.ps1](../tests/psmux-bridge.Tests.ps1) to cover prompt-transport settings precedence, restart-plan propagation, and file-forced dispatch payload behavior, and updated [winsmux-core/scripts/pane-control.ps1](../winsmux-core/scripts/pane-control.ps1) to surface the resolved `PromptTransport` in restart plans.
+- Merged the `TASK-187` first slice via PR [#395](https://github.com/Sora-bluesky/winsmux/pull/395), landing `argv/file` prompt transport resolution, shared send transport planning, and restart-plan transport visibility on `main`.
+- Started the repo-side `TASK-114` first slice locally by extending `runs / digest / explain` to surface a new `experiment_packet` assembled from event-ledger data without changing the existing `run_packet` contract.
+- Added strict experiment-event correlation so experiment packets prefer `run_id / task_id / pane_id / label` over branch-only matching, and added a branch-collision regression to keep parallel hypothesis runs from cross-contaminating each other.
+- Extended [tests/psmux-bridge.Tests.ps1](../tests/psmux-bridge.Tests.ps1) so `winsmux runs --json`, `winsmux digest --json`, `winsmux explain --json`, and explain follow-delta all cover experiment-ledger fields plus a negative case where `experiment_packet` remains null when no experiment metadata exists.
 - Merged `TASK-287` via PR [#393](https://github.com/Sora-bluesky/winsmux/pull/393), adding the keyboard-first operator command bar (`Ctrl/Cmd+K`) with quick actions, IME-safe input handling, focus restore, and accessible active-option semantics.
 - Merged `TASK-298` via PR [#394](https://github.com/Sora-bluesky/winsmux/pull/394), rewriting `README.ja.md` to match the public operator model, shrinking maintainer-only planning readmes into internal stubs, and making tracked public config/docs safer for external users.
 - Re-synced the external planning backlog/roadmap after PR [#394](https://github.com/Sora-bluesky/winsmux/pull/394), marking `TASK-298` as done so `v0.20.0` now shows `100% (12/12)`.
@@ -100,12 +104,13 @@
 - Current `TASK-287` command-bar slice passes frontend build: `npm run build` in `winsmux-app`.
 - `TASK-298` docs/config cleanup landed via PR [#394](https://github.com/Sora-bluesky/winsmux/pull/394); its CI `Pester Tests` run `24271531120` passed before merge.
 - `v0.20.0` release workflow run `24276032671` completed successfully and published `winsmux-x64.exe`, `winsmux-arm64.exe`, and `SHA256SUMS`.
-- Current local `TASK-187` transport slice passes focused regression: `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `122/122 PASS`.
+- `TASK-187` transport slice passed focused regression before merge: `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `122/122 PASS`.
+- Current local `TASK-114` experiment-ledger slice passes focused regression: `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `123/123 PASS`.
 
 ## Next actions
 
-1. Commit and review the current `TASK-187` first slice, then open the PR with the existing `argv/file` transport contract and `stdin` fail-close behavior made explicit.
-2. Follow with `TASK-114` so the event ledger becomes an experiment ledger with searchable `hypothesis / test_plan / result / consultation_ref` fields.
+1. Commit and review the current `TASK-114` first slice, then open the PR with the new read-side `experiment_packet` contract on `runs / digest / explain`.
+2. After `TASK-114`, move to `TASK-300` / `TASK-301` so observation packs and consultation packets become file-backed, first-class ledger inputs instead of read-only fields.
 3. Keep the external planning sync flow user-visible but out of the public repo, then reflect consultation/experiment surfaces into the Tauri shell as `TASK-305` approaches.
 
 ## Notes

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -2619,6 +2619,124 @@ function Get-RunIdFromPaneRecord {
     return "label:{0}" -f [string]$PaneRecord.label
 }
 
+function ConvertTo-ExperimentPacketStringArray {
+    param([AllowNull()]$Value)
+
+    if ($null -eq $Value) {
+        return @()
+    }
+
+    if ($Value -is [string]) {
+        $text = [string]$Value
+        if ([string]::IsNullOrWhiteSpace($text)) {
+            return @()
+        }
+
+        return @($text)
+    }
+
+    if ($Value -is [System.Collections.IEnumerable]) {
+        $items = [System.Collections.Generic.List[string]]::new()
+        foreach ($entry in $Value) {
+            $text = [string]$entry
+            if (-not [string]::IsNullOrWhiteSpace($text)) {
+                $items.Add($text) | Out-Null
+            }
+        }
+
+        return @($items)
+    }
+
+    return @([string]$Value)
+}
+
+function Get-ExperimentPacketFromEventRecords {
+    param([Parameter(Mandatory = $true)][object[]]$EventRecords)
+
+    $packet = [ordered]@{
+        hypothesis           = ''
+        test_plan            = [System.Collections.Generic.List[string]]::new()
+        result               = ''
+        confidence           = $null
+        next_action          = ''
+        observation_pack_ref = ''
+        consultation_ref     = ''
+        run_id               = ''
+        slot                 = ''
+        branch               = ''
+        worktree             = ''
+        env_fingerprint      = ''
+        command_hash         = ''
+    }
+
+    $hasContent = $false
+
+    foreach ($eventRecord in @($EventRecords | Sort-Object @{ Expression = { [string]$_.timestamp } }, @{ Expression = { [int]$_.line_number } })) {
+        $data = $null
+        if ($eventRecord.Contains('data')) {
+            $data = $eventRecord['data']
+        }
+
+        if ($null -eq $data -or $data -isnot [System.Collections.IDictionary]) {
+            continue
+        }
+
+        foreach ($fieldName in @('hypothesis', 'result', 'next_action', 'observation_pack_ref', 'consultation_ref', 'run_id', 'slot', 'branch', 'worktree', 'env_fingerprint', 'command_hash')) {
+            if ($data.Contains($fieldName)) {
+                $value = [string]$data[$fieldName]
+                if (-not [string]::IsNullOrWhiteSpace($value)) {
+                    $packet[$fieldName] = $value
+                    $hasContent = $true
+                }
+            }
+        }
+
+        if ($data.Contains('test_plan')) {
+            foreach ($step in @(ConvertTo-ExperimentPacketStringArray -Value $data['test_plan'])) {
+                if (-not $packet.test_plan.Contains($step)) {
+                    $packet.test_plan.Add($step) | Out-Null
+                    $hasContent = $true
+                }
+            }
+        }
+
+        if ($data.Contains('confidence')) {
+            $confidenceValue = $data['confidence']
+            if ($null -ne $confidenceValue -and -not [string]::IsNullOrWhiteSpace([string]$confidenceValue)) {
+                $packet.confidence = $confidenceValue
+                $hasContent = $true
+            }
+        }
+
+        if ([string]::IsNullOrWhiteSpace([string]$packet.branch)) {
+            $eventBranch = [string]$eventRecord['branch']
+            if (-not [string]::IsNullOrWhiteSpace($eventBranch)) {
+                $packet.branch = $eventBranch
+            }
+        }
+    }
+
+    if (-not $hasContent) {
+        return $null
+    }
+
+    return [ordered]@{
+        hypothesis           = [string]$packet.hypothesis
+        test_plan            = @($packet.test_plan)
+        result               = [string]$packet.result
+        confidence           = $packet.confidence
+        next_action          = [string]$packet.next_action
+        observation_pack_ref = [string]$packet.observation_pack_ref
+        consultation_ref     = [string]$packet.consultation_ref
+        run_id               = [string]$packet.run_id
+        slot                 = [string]$packet.slot
+        branch               = [string]$packet.branch
+        worktree             = [string]$packet.worktree
+        env_fingerprint      = [string]$packet.env_fingerprint
+        command_hash         = [string]$packet.command_hash
+    }
+}
+
 function New-RunPacketFromRun {
     param([Parameter(Mandatory = $true)]$Run)
 
@@ -2702,6 +2820,7 @@ function New-RunResultPacket {
         next_action_hint      = [string]$EvidenceDigest.next_action
         review_recommendation = $reviewRecommendation
         evidence_refs         = @($EvidenceDigest.changed_files)
+        experiment_packet     = $Run.experiment_packet
         action_items          = @($Run.action_items)
         review_state          = $ReviewState
         recent_events         = @($RecentEvents)
@@ -2760,6 +2879,69 @@ function Test-RunMatchesEventRecord {
     return $false
 }
 
+function Test-RunMatchesExperimentEventRecord {
+    param(
+        [Parameter(Mandatory = $true)]$Run,
+        [Parameter(Mandatory = $true)]$EventRecord
+    )
+
+    $runId = [string]$Run.run_id
+    $runTaskId = [string]$Run.task_id
+    $runBranch = [string]$Run.branch
+    $runHeadSha = [string]$Run.head_sha
+    $runLabels = @($Run.labels)
+    $runPaneIds = @($Run.pane_ids)
+
+    $eventTaskId = ''
+    $eventBranch = [string]$EventRecord['branch']
+    $eventHeadSha = [string]$EventRecord['head_sha']
+    $eventLabel = [string]$EventRecord['label']
+    $eventPaneId = [string]$EventRecord['pane_id']
+    $eventRunId = ''
+
+    $data = $null
+    if ($EventRecord.Contains('data')) {
+        $data = $EventRecord['data']
+    }
+
+    if ($null -ne $data -and $data -is [System.Collections.IDictionary]) {
+        if ($data.Contains('task_id')) { $eventTaskId = [string]$data['task_id'] }
+        if ($data.Contains('run_id')) { $eventRunId = [string]$data['run_id'] }
+        if ([string]::IsNullOrWhiteSpace($eventBranch) -and $data.Contains('branch')) { $eventBranch = [string]$data['branch'] }
+        if ([string]::IsNullOrWhiteSpace($eventHeadSha) -and $data.Contains('head_sha')) { $eventHeadSha = [string]$data['head_sha'] }
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($eventRunId)) {
+        return ($eventRunId -eq $runId)
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($eventTaskId) -and -not [string]::IsNullOrWhiteSpace($runTaskId)) {
+        return ($eventTaskId -eq $runTaskId)
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($eventPaneId)) {
+        return ($runPaneIds -contains $eventPaneId)
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($eventLabel)) {
+        return ($runLabels -contains $eventLabel)
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($eventTaskId) -or -not [string]::IsNullOrWhiteSpace($runTaskId)) {
+        return $false
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($runBranch) -and $runBranch -eq $eventBranch) {
+        return $true
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($runHeadSha) -and $runHeadSha -eq $eventHeadSha) {
+        return $true
+    }
+
+    return $false
+}
+
 function ConvertTo-RunEventRecord {
     param([Parameter(Mandatory = $true)]$EventRecord)
 
@@ -2777,19 +2959,33 @@ function ConvertTo-RunEventRecord {
         if ([string]::IsNullOrWhiteSpace($headSha) -and $data.Contains('head_sha')) { $headSha = [string]$data['head_sha'] }
     }
 
+    $experimentPacket = Get-ExperimentPacketFromEventRecords -EventRecords @($EventRecord)
+
     return [ordered]@{
-        line_number = [int]$EventRecord['line_number']
-        timestamp   = [string]$EventRecord['timestamp']
-        event       = [string]$EventRecord['event']
-        status      = [string]$EventRecord['status']
-        message     = [string]$EventRecord['message']
-        label       = [string]$EventRecord['label']
-        pane_id     = [string]$EventRecord['pane_id']
-        role        = [string]$EventRecord['role']
-        task_id     = $taskId
-        branch      = $branch
-        head_sha    = $headSha
-        source      = [string]$EventRecord['source']
+        line_number          = [int]$EventRecord['line_number']
+        timestamp            = [string]$EventRecord['timestamp']
+        event                = [string]$EventRecord['event']
+        status               = [string]$EventRecord['status']
+        message              = [string]$EventRecord['message']
+        label                = [string]$EventRecord['label']
+        pane_id              = [string]$EventRecord['pane_id']
+        role                 = [string]$EventRecord['role']
+        task_id              = $taskId
+        branch               = $branch
+        head_sha             = $headSha
+        source               = [string]$EventRecord['source']
+        hypothesis           = if ($null -ne $experimentPacket) { [string]$experimentPacket.hypothesis } else { '' }
+        test_plan            = if ($null -ne $experimentPacket) { @($experimentPacket.test_plan) } else { @() }
+        result               = if ($null -ne $experimentPacket) { [string]$experimentPacket.result } else { '' }
+        confidence           = if ($null -ne $experimentPacket) { $experimentPacket.confidence } else { $null }
+        next_action          = if ($null -ne $experimentPacket) { [string]$experimentPacket.next_action } else { '' }
+        observation_pack_ref = if ($null -ne $experimentPacket) { [string]$experimentPacket.observation_pack_ref } else { '' }
+        consultation_ref     = if ($null -ne $experimentPacket) { [string]$experimentPacket.consultation_ref } else { '' }
+        run_id               = if ($null -ne $experimentPacket) { [string]$experimentPacket.run_id } else { '' }
+        slot                 = if ($null -ne $experimentPacket) { [string]$experimentPacket.slot } else { '' }
+        worktree             = if ($null -ne $experimentPacket) { [string]$experimentPacket.worktree } else { '' }
+        env_fingerprint      = if ($null -ne $experimentPacket) { [string]$experimentPacket.env_fingerprint } else { '' }
+        command_hash         = if ($null -ne $experimentPacket) { [string]$experimentPacket.command_hash } else { '' }
     }
 }
 
@@ -2798,6 +2994,7 @@ function Get-RunsPayload {
 
     $boardPayload = Get-BoardPayload -ProjectDir $ProjectDir
     $inboxPayload = Get-InboxPayload -ProjectDir $ProjectDir
+    $eventRecords = @(Get-BridgeEventRecords -ProjectDir $ProjectDir)
     $runsById = [ordered]@{}
 
     foreach ($pane in @($boardPayload.panes)) {
@@ -2840,6 +3037,7 @@ function Get-RunsPayload {
                 agent_role         = [string]$pane.agent_role
                 timeout_policy     = [string]$pane.timeout_policy
                 handoff_refs       = [System.Collections.Generic.List[string]]::new()
+                experiment_packet  = $null
             }
         }
 
@@ -2948,6 +3146,30 @@ function Get-RunsPayload {
         }
     }
 
+    foreach ($runId in @($runsById.Keys)) {
+        $run = $runsById[$runId]
+        $matchingEvents = @(
+            foreach ($eventRecord in $eventRecords) {
+                if (Test-RunMatchesExperimentEventRecord -Run $run -EventRecord $eventRecord) {
+                    $eventRecord
+                }
+            }
+        )
+
+        if (@($matchingEvents).Count -gt 0) {
+            $experimentPacket = Get-ExperimentPacketFromEventRecords -EventRecords $matchingEvents
+            if (
+                $null -ne $experimentPacket -and
+                -not [string]::IsNullOrWhiteSpace([string]$experimentPacket.run_id) -and
+                [string]$experimentPacket.run_id -ne [string]$run.run_id
+            ) {
+                $experimentPacket = $null
+            }
+
+            $run.experiment_packet = $experimentPacket
+        }
+    }
+
     $runs = @(
         foreach ($runId in @($runsById.Keys)) {
             $run = $runsById[$runId]
@@ -2988,6 +3210,7 @@ function Get-RunsPayload {
                 agent_role         = if (-not [string]::IsNullOrWhiteSpace([string]$run.agent_role)) { [string]$run.agent_role } else { [string]$run.primary_role }
                 timeout_policy     = [string]$run.timeout_policy
                 handoff_refs       = @($run.handoff_refs)
+                experiment_packet  = $run.experiment_packet
             }
         }
     )
@@ -3059,6 +3282,8 @@ function Get-RunNextAction {
 function ConvertTo-EvidenceDigestItem {
     param([Parameter(Mandatory = $true)]$Run)
 
+    $experimentPacket = $Run.experiment_packet
+
     return [ordered]@{
         run_id             = [string]$Run.run_id
         task_id            = [string]$Run.task_id
@@ -3077,6 +3302,10 @@ function ConvertTo-EvidenceDigestItem {
         action_item_count  = @($Run.action_items).Count
         last_event         = [string]$Run.last_event
         last_event_at      = [string]$Run.last_event_at
+        hypothesis         = if ($null -ne $experimentPacket) { [string]$experimentPacket.hypothesis } else { '' }
+        confidence         = if ($null -ne $experimentPacket) { $experimentPacket.confidence } else { $null }
+        observation_pack_ref = if ($null -ne $experimentPacket) { [string]$experimentPacket.observation_pack_ref } else { '' }
+        consultation_ref   = if ($null -ne $experimentPacket) { [string]$experimentPacket.consultation_ref } else { '' }
     }
 }
 
@@ -3154,6 +3383,7 @@ function Get-ExplainPayload {
         project_dir     = $ProjectDir
         run             = $run
         run_packet      = New-RunPacketFromRun -Run $run
+        experiment_packet = $run.experiment_packet
         evidence_digest = $evidenceDigest
         explanation   = [ordered]@{
             summary       = if (-not [string]::IsNullOrWhiteSpace([string]$run.task)) { [string]$run.task } else { [string]$run.primary_label }

--- a/tests/psmux-bridge.Tests.ps1
+++ b/tests/psmux-bridge.Tests.ps1
@@ -3533,6 +3533,21 @@ panes:
             pane_id   = '%2'
             role      = 'Builder'
             status    = 'approval_waiting'
+            data      = [ordered]@{
+                task_id              = 'task-256'
+                hypothesis           = 'branch-scoped event data is enough for experiment ledger'
+                test_plan            = @('capture matching events', 'render experiment packet')
+                result               = 'hypothesis still pending'
+                confidence           = 0.72
+                next_action          = 'review_pending'
+                observation_pack_ref = '.winsmux/observation-packs/task-256.json'
+                consultation_ref     = '.winsmux/consultations/task-256-review.json'
+                run_id               = 'task:task-256'
+                slot                 = 'slot-builder-1'
+                worktree             = '.worktrees/builder-1'
+                env_fingerprint      = 'env:abc123'
+                command_hash         = 'cmd:def456'
+            }
         } | ConvertTo-Json -Compress) | Set-Content -Path $script:runsEventsPath -Encoding UTF8
 
         function global:winsmux {
@@ -3567,6 +3582,18 @@ panes:
         $result.runs[0].run_packet.agent_role | Should -Be 'worker'
         $result.runs[0].run_packet.timeout_policy | Should -Be 'standard'
         $result.runs[0].run_packet.handoff_refs | Should -Be @('docs/handoff.md')
+        $result.runs[0].experiment_packet.hypothesis | Should -Be 'branch-scoped event data is enough for experiment ledger'
+        $result.runs[0].experiment_packet.test_plan | Should -Be @('capture matching events', 'render experiment packet')
+        $result.runs[0].experiment_packet.result | Should -Be 'hypothesis still pending'
+        $result.runs[0].experiment_packet.confidence | Should -Be 0.72
+        $result.runs[0].experiment_packet.next_action | Should -Be 'review_pending'
+        $result.runs[0].experiment_packet.observation_pack_ref | Should -Be '.winsmux/observation-packs/task-256.json'
+        $result.runs[0].experiment_packet.consultation_ref | Should -Be '.winsmux/consultations/task-256-review.json'
+        $result.runs[0].experiment_packet.run_id | Should -Be 'task:task-256'
+        $result.runs[0].experiment_packet.slot | Should -Be 'slot-builder-1'
+        $result.runs[0].experiment_packet.worktree | Should -Be '.worktrees/builder-1'
+        $result.runs[0].experiment_packet.env_fingerprint | Should -Be 'env:abc123'
+        $result.runs[0].experiment_packet.command_hash | Should -Be 'cmd:def456'
     }
 
     It 'supports winsmux runs --json through the top-level CLI entrypoint' {
@@ -3612,6 +3639,103 @@ Set-Location '__RUNS_TEMP_ROOT__'
 
         $result.summary.run_count | Should -Be 1
         $result.runs[0].run_id | Should -Be 'task:task-256'
+        $result.runs[0].experiment_packet | Should -Be $null
+    }
+
+    It 'keeps experiment packets scoped to strong run keys when multiple runs share a branch' {
+@"
+version: 1
+session:
+  name: winsmux-orchestra
+  project_dir: $script:runsTempRoot
+panes:
+  builder-1:
+    pane_id: %2
+    role: Builder
+    task_id: task-256
+    task: Investigate cache mismatch
+    task_state: in_progress
+    task_owner: builder-1
+    review_state: PENDING
+    branch: shared-worktree
+    head_sha: abc1234def5678
+    changed_file_count: 1
+    changed_files: '["scripts/winsmux-core.ps1"]'
+    last_event: commander.review_requested
+    last_event_at: 2026-04-10T12:00:00+09:00
+  builder-2:
+    pane_id: %6
+    role: Builder
+    task_id: task-999
+    task: Investigate cache mismatch separately
+    task_state: in_progress
+    task_owner: builder-2
+    review_state: PENDING
+    branch: shared-worktree
+    head_sha: abc1234def5678
+    changed_file_count: 1
+    changed_files: '["tests/psmux-bridge.Tests.ps1"]'
+    last_event: commander.review_requested
+    last_event_at: 2026-04-10T12:01:00+09:00
+"@ | Set-Content -Path $script:runsManifestPath -Encoding UTF8
+
+        @(
+            ([ordered]@{
+                timestamp = '2026-04-10T12:01:00+09:00'
+                session   = 'winsmux-orchestra'
+                event     = 'pane.progress'
+                message   = 'builder-1 hypothesis update'
+                label     = 'builder-1'
+                pane_id   = '%2'
+                role      = 'Builder'
+                status    = 'busy'
+                branch    = 'shared-worktree'
+                head_sha  = 'abc1234def5678'
+                data      = [ordered]@{
+                    task_id    = 'task-256'
+                    run_id     = 'task:task-256'
+                    hypothesis = 'builder-1 owns this experiment packet'
+                    result     = 'pending'
+                }
+            } | ConvertTo-Json -Compress),
+            ([ordered]@{
+                timestamp = '2026-04-10T12:02:00+09:00'
+                session   = 'winsmux-orchestra'
+                event     = 'pane.progress'
+                message   = 'builder-2 hypothesis update'
+                label     = 'builder-2'
+                pane_id   = '%6'
+                role      = 'Builder'
+                status    = 'busy'
+                branch    = 'shared-worktree'
+                head_sha  = 'abc1234def5678'
+                data      = [ordered]@{
+                    task_id    = 'task-999'
+                    run_id     = 'task:task-999'
+                    hypothesis = 'builder-2 owns this experiment packet'
+                    result     = 'pending'
+                }
+            } | ConvertTo-Json -Compress)
+        ) | Set-Content -Path $script:runsEventsPath -Encoding UTF8
+
+        function global:winsmux {
+            $commandLine = ($args | ForEach-Object { [string]$_ }) -join ' '
+            switch -Regex ($commandLine) {
+                '^capture-pane .*%2' { return @('gpt-5.4   64% context left', '? send   Ctrl+J newline', '>') }
+                '^capture-pane .*%6' { return @('gpt-5.4   61% context left', '? send   Ctrl+J newline', '>') }
+                default { throw "unexpected winsmux call: $commandLine" }
+            }
+        }
+
+        $result = (Invoke-Runs -RunsTarget '--json' | Out-String | ConvertFrom-Json -AsHashtable)
+
+        @($result.runs).Count | Should -Be 2
+        $first = @($result.runs | Where-Object { $_.run_id -eq 'task:task-256' })[0]
+        $second = @($result.runs | Where-Object { $_.run_id -eq 'task:task-999' })[0]
+        $first.experiment_packet.run_id | Should -Be 'task:task-256'
+        $first.experiment_packet.hypothesis | Should -Be 'builder-1 owns this experiment packet'
+        $second.experiment_packet.run_id | Should -Be 'task:task-999'
+        $second.experiment_packet.hypothesis | Should -Be 'builder-2 owns this experiment packet'
     }
 }
 
@@ -3730,7 +3854,13 @@ panes:
             branch    = 'worktree-builder-1'
             head_sha  = 'abc1234def5678'
             data      = [ordered]@{
-                task_id = 'task-246'
+                task_id              = 'task-246'
+                hypothesis           = 'result summary should appear in digest'
+                result               = 'review failure reproduced'
+                confidence           = 0.88
+                next_action          = 'review_failed'
+                observation_pack_ref = '.winsmux/observation-packs/task-246.json'
+                consultation_ref     = '.winsmux/consultations/task-246-reconcile.json'
             }
         } | ConvertTo-Json -Compress) | Set-Content -Path $script:digestEventsPath -Encoding UTF8
 
@@ -3750,6 +3880,10 @@ panes:
         $result.items[0].next_action | Should -Be 'review_failed'
         $result.items[0].head_short | Should -Be 'abc1234'
         $result.items[0].changed_files | Should -Be @('scripts/winsmux-core.ps1')
+        $result.items[0].hypothesis | Should -Be 'result summary should appear in digest'
+        $result.items[0].confidence | Should -Be 0.88
+        $result.items[0].observation_pack_ref | Should -Be '.winsmux/observation-packs/task-246.json'
+        $result.items[0].consultation_ref | Should -Be '.winsmux/consultations/task-246-reconcile.json'
     }
 
     It 'returns digest delta items only for runs affected after the current cursor' {
@@ -4003,7 +4137,19 @@ panes:
                 branch    = 'worktree-builder-1'
                 head_sha  = 'abc1234def5678'
                 data      = [ordered]@{
-                    task_id = 'task-256'
+                    task_id              = 'task-256'
+                    hypothesis           = 'experiment packet should flow into explain'
+                    test_plan            = @('collect matching events', 'normalize packet')
+                    result               = 'consult before work'
+                    confidence           = 0.66
+                    next_action          = 'approval_waiting'
+                    observation_pack_ref = '.winsmux/observation-packs/task-256.json'
+                    consultation_ref     = '.winsmux/consultations/task-256-early.json'
+                    run_id               = 'task:task-256'
+                    slot                 = 'slot-builder-1'
+                    worktree             = '.worktrees/builder-1'
+                    env_fingerprint      = 'env:abc123'
+                    command_hash         = 'cmd:def456'
                 }
             } | ConvertTo-Json -Compress),
             ([ordered]@{
@@ -4070,6 +4216,18 @@ panes:
         $result.run_packet.agent_role | Should -Be 'worker'
         $result.run_packet.timeout_policy | Should -Be 'standard'
         $result.run_packet.handoff_refs | Should -Be @('docs/handoff.md')
+        $result.experiment_packet.hypothesis | Should -Be 'experiment packet should flow into explain'
+        $result.experiment_packet.test_plan | Should -Be @('collect matching events', 'normalize packet')
+        $result.experiment_packet.result | Should -Be 'consult before work'
+        $result.experiment_packet.confidence | Should -Be 0.66
+        $result.experiment_packet.next_action | Should -Be 'approval_waiting'
+        $result.experiment_packet.observation_pack_ref | Should -Be '.winsmux/observation-packs/task-256.json'
+        $result.experiment_packet.consultation_ref | Should -Be '.winsmux/consultations/task-256-early.json'
+        $result.experiment_packet.run_id | Should -Be 'task:task-256'
+        $result.experiment_packet.slot | Should -Be 'slot-builder-1'
+        $result.experiment_packet.worktree | Should -Be '.worktrees/builder-1'
+        $result.experiment_packet.env_fingerprint | Should -Be 'env:abc123'
+        $result.experiment_packet.command_hash | Should -Be 'cmd:def456'
         $result.evidence_digest.run_id | Should -Be 'task:task-256'
         $result.evidence_digest.next_action | Should -Be 'approval_waiting'
         $result.evidence_digest.changed_files | Should -Be @('scripts/winsmux-core.ps1')
@@ -4088,6 +4246,7 @@ panes:
         $result.recent_events.Count | Should -Be 2
         @($result.recent_events | ForEach-Object { $_.event }) | Should -Contain 'commander.review_requested'
         @($result.recent_events | ForEach-Object { $_.event }) | Should -Contain 'pane.approval_waiting'
+        ($result.recent_events | Where-Object { $_.event -eq 'commander.review_requested' } | Select-Object -First 1).hypothesis | Should -Be 'experiment packet should flow into explain'
     }
 
     It 'filters explain follow events from the current cursor forward' {
@@ -4162,7 +4321,11 @@ panes:
                 head_sha  = 'abc1234def5678'
                 status    = 'commit_ready'
                 data      = [ordered]@{
-                    task_id = 'task-256'
+                    task_id              = 'task-256'
+                    hypothesis           = 'follow path should keep experiment fields'
+                    result               = 'ready to commit'
+                    next_action          = 'commit_ready'
+                    observation_pack_ref = '.winsmux/observation-packs/task-256.json'
                 }
             } | ConvertTo-Json -Compress)
         ) | Add-Content -Path $script:explainEventsPath -Encoding UTF8
@@ -4177,6 +4340,9 @@ panes:
         $delta.cursor | Should -Be 3
         $matching.Count | Should -Be 1
         $matching[0].event | Should -Be 'commander.commit_ready'
+        $matching[0].hypothesis | Should -Be 'follow path should keep experiment fields'
+        $matching[0].next_action | Should -Be 'commit_ready'
+        $matching[0].observation_pack_ref | Should -Be '.winsmux/observation-packs/task-256.json'
     }
 }
 


### PR DESCRIPTION
## Summary
- add read-side `experiment_packet` aggregation to `winsmux runs`, `winsmux digest`, and `winsmux explain`
- scope experiment events with stronger run keys so parallel branch-sharing runs do not cross-contaminate
- extend focused Pester coverage for experiment fields, negative cases, follow deltas, and branch-collision isolation

## Validation
- `Invoke-Pester tests/psmux-bridge.Tests.ps1` (`123/123 PASS`)
- `git diff --check`
- manual diff review
- fresh reviewer timeout -> fallback review gate per `AGENTS.md`
