### PR TITLE
feat(ledger): add observation and consultation artifacts

### DIFF
--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -1,6 +1,6 @@
 # Handoff
 
-> Updated: 2026-04-11T18:05:00+09:00
+> Updated: 2026-04-11T19:20:06+09:00
 > Source of truth: this file
 
 ## Current state
@@ -15,6 +15,8 @@
 - Planning source of truth is externalized outside the public repository and syncs automatically into the private planning root.
 - `v0.21.x` private planning is aligned to a conversation-first Tauri operator shell, with Codex-App-like shell rules reflected in Figma and backlog notes.
 - `v0.24.x` private planning is split into schema, ledger, machine contract, cutover, and canary phases for Rust runtime convergence before `v1.0.0`.
+- PR [#396](https://github.com/Sora-bluesky/winsmux/pull/396) is merged into `main`, landing the first `TASK-114` experiment-ledger read model slice.
+- External planning is rebalanced so `v0.21.0` is reduced to slot-dispatch core, `v0.21.1` absorbs experiment compare/promotion, and `v0.22.0` is narrowed to backend-first Tauri control-plane foundation.
 
 ## This session
 
@@ -106,12 +108,13 @@
 - `v0.20.0` release workflow run `24276032671` completed successfully and published `winsmux-x64.exe`, `winsmux-arm64.exe`, and `SHA256SUMS`.
 - `TASK-187` transport slice passed focused regression before merge: `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `122/122 PASS`.
 - Current local `TASK-114` experiment-ledger slice passes focused regression: `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `123/123 PASS`.
+- PR [#396](https://github.com/Sora-bluesky/winsmux/pull/396) CI passed before merge: `Pester Tests` run `24280233475`.
 
 ## Next actions
 
-1. Commit and review the current `TASK-114` first slice, then open the PR with the new read-side `experiment_packet` contract on `runs / digest / explain`.
-2. After `TASK-114`, move to `TASK-300` / `TASK-301` so observation packs and consultation packets become file-backed, first-class ledger inputs instead of read-only fields.
-3. Keep the external planning sync flow user-visible but out of the public repo, then reflect consultation/experiment surfaces into the Tauri shell as `TASK-305` approaches.
+1. Start `TASK-300` / `TASK-301` so observation packs and consultation packets become file-backed, first-class ledger inputs instead of read-only fields.
+2. Keep the external planning sync flow user-visible but out of the public repo, then reflect consultation/experiment surfaces into the Tauri shell as `TASK-305` approaches.
+3. Use the rebalanced roadmap as the release train baseline: `v0.21.0` for slot dispatch core, `v0.21.1` for compare/promotion, and `v0.22.0` for backend-first Tauri foundation only.
 
 ## Notes
 

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -177,6 +177,234 @@ function Get-DispatchPromptReference {
     return $promptRef
 }
 
+function ConvertTo-WinsmuxArtifactData {
+    param([AllowNull()]$Data)
+
+    if ($null -eq $Data) {
+        return [ordered]@{}
+    }
+
+    if ($Data -is [System.Collections.IDictionary]) {
+        $clone = [ordered]@{}
+        foreach ($entry in $Data.GetEnumerator()) {
+            $clone[[string]$entry.Key] = $entry.Value
+        }
+        return $clone
+    }
+
+    if ($null -ne $Data.PSObject) {
+        $clone = [ordered]@{}
+        foreach ($property in $Data.PSObject.Properties) {
+            $clone[$property.Name] = $property.Value
+        }
+        return $clone
+    }
+
+    return [ordered]@{ value = $Data }
+}
+
+function Test-WinsmuxArtifactHasCorrelation {
+    param([Parameter(Mandatory = $true)][System.Collections.IDictionary]$Data)
+
+    $runId = if ($Data.Contains('run_id')) { [string]$Data['run_id'] } else { '' }
+    $taskId = if ($Data.Contains('task_id')) { [string]$Data['task_id'] } else { '' }
+    $paneId = if ($Data.Contains('pane_id')) { [string]$Data['pane_id'] } else { '' }
+    $slot = if ($Data.Contains('slot')) { [string]$Data['slot'] } else { '' }
+
+    if (-not [string]::IsNullOrWhiteSpace($runId)) {
+        return $true
+    }
+
+    return (
+        -not [string]::IsNullOrWhiteSpace($taskId) -and
+        (
+            -not [string]::IsNullOrWhiteSpace($paneId) -or
+            -not [string]::IsNullOrWhiteSpace($slot)
+        )
+    )
+}
+
+function Get-ObservationPackDirectory {
+    param([string]$ProjectDir = (Get-Location).Path)
+
+    return Join-Path $ProjectDir '.winsmux\observation-packs'
+}
+
+function Get-ConsultationDirectory {
+    param([string]$ProjectDir = (Get-Location).Path)
+
+    return Join-Path $ProjectDir '.winsmux\consultations'
+}
+
+function Get-WinsmuxArtifactReference {
+    param(
+        [Parameter(Mandatory = $true)][string]$ArtifactPath,
+        [string]$ProjectDir = (Get-Location).Path
+    )
+
+    $artifactRef = $ArtifactPath
+    try {
+        $relativeArtifactPath = [System.IO.Path]::GetRelativePath($ProjectDir, $ArtifactPath)
+        if (-not [string]::IsNullOrWhiteSpace($relativeArtifactPath) -and -not $relativeArtifactPath.StartsWith('..')) {
+            $artifactRef = $relativeArtifactPath.Replace('\', '/')
+        }
+    } catch {
+    }
+
+    return $artifactRef
+}
+
+function Write-WinsmuxArtifactFile {
+    param(
+        [Parameter(Mandatory = $true)][string]$DirectoryPath,
+        [Parameter(Mandatory = $true)][string]$Prefix,
+        [Parameter(Mandatory = $true)][AllowNull()]$Data,
+        [string]$ProjectDir = (Get-Location).Path
+    )
+
+    if (-not (Test-Path -LiteralPath $DirectoryPath -PathType Container)) {
+        New-Item -ItemType Directory -Path $DirectoryPath -Force | Out-Null
+    }
+
+    $fileName = '{0}-{1}.json' -f $Prefix, ([guid]::NewGuid().ToString('N'))
+    $path = Join-Path $DirectoryPath $fileName
+    $tempPath = '{0}.tmp' -f $path
+    $content = ($Data | ConvertTo-Json -Depth 12)
+
+    Write-ClmSafeTextFile -Path $tempPath -Content $content
+    Move-Item -LiteralPath $tempPath -Destination $path -Force
+
+    return [ordered]@{
+        path      = $path
+        reference = Get-WinsmuxArtifactReference -ArtifactPath $path -ProjectDir $ProjectDir
+    }
+}
+
+function New-ObservationPackFile {
+    param(
+        [Parameter(Mandatory = $true)][AllowNull()]$ObservationPack,
+        [string]$ProjectDir = (Get-Location).Path
+    )
+
+    $packet = ConvertTo-WinsmuxArtifactData -Data $ObservationPack
+    if (-not (Test-WinsmuxArtifactHasCorrelation -Data $packet)) {
+        throw 'Observation pack requires run_id or task_id with pane_id/slot.'
+    }
+
+    if (-not $packet.Contains('packet_type')) {
+        $packet['packet_type'] = 'observation_pack'
+    }
+    if (-not $packet.Contains('generated_at')) {
+        $packet['generated_at'] = (Get-Date).ToString('o')
+    }
+
+    return Write-WinsmuxArtifactFile -DirectoryPath (Get-ObservationPackDirectory -ProjectDir $ProjectDir) -Prefix 'observation-pack' -Data $packet -ProjectDir $ProjectDir
+}
+
+function New-ConsultationPacketFile {
+    param(
+        [Parameter(Mandatory = $true)][AllowNull()]$ConsultationPacket,
+        [string]$ProjectDir = (Get-Location).Path
+    )
+
+    $packet = ConvertTo-WinsmuxArtifactData -Data $ConsultationPacket
+    if (-not (Test-WinsmuxArtifactHasCorrelation -Data $packet)) {
+        throw 'Consultation packet requires run_id or task_id with pane_id/slot.'
+    }
+
+    $kind = if ($packet.Contains('kind')) { [string]$packet['kind'] } else { '' }
+    if ($kind -notin @('consult_request', 'consult_result', 'consult_error')) {
+        throw "Unsupported consultation packet kind: $kind"
+    }
+
+    if ($packet.Contains('mode')) {
+        $mode = [string]$packet['mode']
+        if (-not [string]::IsNullOrWhiteSpace($mode) -and $mode -notin @('early', 'stuck', 'reconcile', 'final')) {
+            throw "Unsupported consultation packet mode: $mode"
+        }
+    }
+
+    if (-not $packet.Contains('packet_type')) {
+        $packet['packet_type'] = 'consultation_packet'
+    }
+    if (-not $packet.Contains('generated_at')) {
+        $packet['generated_at'] = (Get-Date).ToString('o')
+    }
+
+    $prefix = switch ($kind) {
+        'consult_request' { 'consult-request' }
+        'consult_result' { 'consult-result' }
+        'consult_error' { 'consult-error' }
+        default { 'consultation' }
+    }
+
+    return Write-WinsmuxArtifactFile -DirectoryPath (Get-ConsultationDirectory -ProjectDir $ProjectDir) -Prefix $prefix -Data $packet -ProjectDir $ProjectDir
+}
+
+function Read-WinsmuxArtifactJson {
+    param(
+        [AllowEmptyString()][string]$Reference,
+        [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [Parameter(Mandatory = $true)][string]$ExpectedDirectoryPath,
+        [string]$ExpectedRunId = ''
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Reference)) {
+        return $null
+    }
+
+    $path = $Reference
+    if (-not [System.IO.Path]::IsPathRooted($path)) {
+        $path = Join-Path $ProjectDir ($Reference.Replace('/', '\'))
+    }
+
+    $fullPath = [System.IO.Path]::GetFullPath($path)
+    $expectedDirectoryFullPath = [System.IO.Path]::GetFullPath($ExpectedDirectoryPath)
+
+    if (-not $fullPath.StartsWith($expectedDirectoryFullPath, [System.StringComparison]::OrdinalIgnoreCase)) {
+        return $null
+    }
+
+    if (-not (Test-Path -LiteralPath $fullPath -PathType Leaf)) {
+        return $null
+    }
+
+    try {
+        $content = Get-Content -LiteralPath $fullPath -Raw -Encoding UTF8
+        $parsed = $content | ConvertFrom-Json -AsHashtable -Depth 12
+    } catch {
+        return $null
+    }
+
+    if (
+        -not [string]::IsNullOrWhiteSpace($ExpectedRunId) -and
+        $parsed.Contains('run_id') -and
+        -not [string]::IsNullOrWhiteSpace([string]$parsed['run_id']) -and
+        [string]$parsed['run_id'] -ne $ExpectedRunId
+    ) {
+        return $null
+    }
+
+    $orderedParsed = [ordered]@{}
+    foreach ($entry in $parsed.GetEnumerator()) {
+        $orderedParsed[[string]$entry.Key] = $entry.Value
+    }
+
+    return $orderedParsed
+}
+
+function Write-BridgeEventRecord {
+    param(
+        [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [Parameter(Mandatory = $true)][AllowNull()]$EventRecord
+    )
+
+    $eventsPath = Get-BridgeEventsPath -ProjectDir $ProjectDir
+    $recordLine = ($EventRecord | ConvertTo-Json -Compress -Depth 12)
+    Write-ClmSafeTextFile -Path $eventsPath -Content $recordLine -Append
+    return $eventsPath
+}
+
 function New-SendDispatchPointerText {
     param(
         [Parameter(Mandatory = $true)][string]$PromptPath,
@@ -2737,6 +2965,73 @@ function Get-ExperimentPacketFromEventRecords {
     }
 }
 
+function Get-HydratedObservationPack {
+    param(
+        [AllowNull()]$ExperimentPacket,
+        [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [string]$ExpectedRunId = ''
+    )
+
+    if ($null -eq $ExperimentPacket) {
+        return $null
+    }
+
+    return Read-WinsmuxArtifactJson `
+        -Reference ([string]$ExperimentPacket.observation_pack_ref) `
+        -ProjectDir $ProjectDir `
+        -ExpectedDirectoryPath (Get-ObservationPackDirectory -ProjectDir $ProjectDir) `
+        -ExpectedRunId $ExpectedRunId
+}
+
+function Get-HydratedConsultationPacket {
+    param(
+        [AllowNull()]$ExperimentPacket,
+        [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [string]$ExpectedRunId = ''
+    )
+
+    if ($null -eq $ExperimentPacket) {
+        return $null
+    }
+
+    return Read-WinsmuxArtifactJson `
+        -Reference ([string]$ExperimentPacket.consultation_ref) `
+        -ProjectDir $ProjectDir `
+        -ExpectedDirectoryPath (Get-ConsultationDirectory -ProjectDir $ProjectDir) `
+        -ExpectedRunId $ExpectedRunId
+}
+
+function Get-ConsultationSummaryFromPacket {
+    param([AllowNull()]$ConsultationPacket)
+
+    if ($null -eq $ConsultationPacket) {
+        return $null
+    }
+
+    $risks = @()
+    if ($ConsultationPacket.Contains('risks') -and $ConsultationPacket['risks'] -is [System.Collections.IEnumerable] -and $ConsultationPacket['risks'] -isnot [string]) {
+        $risks = @($ConsultationPacket['risks'])
+    } elseif ($ConsultationPacket.Contains('risks') -and -not [string]::IsNullOrWhiteSpace([string]$ConsultationPacket['risks'])) {
+        $risks = @([string]$ConsultationPacket['risks'])
+    }
+
+    $nextTest = ''
+    if ($ConsultationPacket.Contains('next_test')) {
+        $nextTest = [string]$ConsultationPacket['next_test']
+    } elseif ($ConsultationPacket.Contains('next_action')) {
+        $nextTest = [string]$ConsultationPacket['next_action']
+    }
+
+    return [ordered]@{
+        kind        = if ($ConsultationPacket.Contains('kind')) { [string]$ConsultationPacket['kind'] } else { '' }
+        mode        = if ($ConsultationPacket.Contains('mode')) { [string]$ConsultationPacket['mode'] } else { '' }
+        target_slot = if ($ConsultationPacket.Contains('target_slot')) { [string]$ConsultationPacket['target_slot'] } else { '' }
+        confidence  = if ($ConsultationPacket.Contains('confidence')) { $ConsultationPacket['confidence'] } else { $null }
+        next_test   = $nextTest
+        risks       = @($risks)
+    }
+}
+
 function New-RunPacketFromRun {
     param([Parameter(Mandatory = $true)]$Run)
 
@@ -2778,7 +3073,10 @@ function New-RunResultPacket {
         [Parameter(Mandatory = $true)]$Run,
         [Parameter(Mandatory = $true)]$EvidenceDigest,
         [AllowNull()]$ReviewState = $null,
-        [Parameter(Mandatory = $true)][object[]]$RecentEvents
+        [Parameter(Mandatory = $true)][object[]]$RecentEvents,
+        [AllowNull()]$ObservationPack = $null,
+        [AllowNull()]$ConsultationPacket = $null,
+        [AllowNull()]$ConsultationSummary = $null
     )
 
     $status = ''
@@ -2821,6 +3119,9 @@ function New-RunResultPacket {
         review_recommendation = $reviewRecommendation
         evidence_refs         = @($EvidenceDigest.changed_files)
         experiment_packet     = $Run.experiment_packet
+        observation_pack      = $ObservationPack
+        consultation_packet   = $ConsultationPacket
+        consultation_summary  = $ConsultationSummary
         action_items          = @($Run.action_items)
         review_state          = $ReviewState
         recent_events         = @($RecentEvents)
@@ -2943,7 +3244,10 @@ function Test-RunMatchesExperimentEventRecord {
 }
 
 function ConvertTo-RunEventRecord {
-    param([Parameter(Mandatory = $true)]$EventRecord)
+    param(
+        [Parameter(Mandatory = $true)]$EventRecord,
+        [string]$ProjectDir = (Get-Location).Path
+    )
 
     $taskId = ''
     $branch = [string]$EventRecord['branch']
@@ -2960,6 +3264,9 @@ function ConvertTo-RunEventRecord {
     }
 
     $experimentPacket = Get-ExperimentPacketFromEventRecords -EventRecords @($EventRecord)
+    $runId = if ($null -ne $experimentPacket) { [string]$experimentPacket.run_id } else { '' }
+    $observationPack = Get-HydratedObservationPack -ExperimentPacket $experimentPacket -ProjectDir $ProjectDir -ExpectedRunId $runId
+    $consultationPacket = Get-HydratedConsultationPacket -ExperimentPacket $experimentPacket -ProjectDir $ProjectDir -ExpectedRunId $runId
 
     return [ordered]@{
         line_number          = [int]$EventRecord['line_number']
@@ -2986,6 +3293,8 @@ function ConvertTo-RunEventRecord {
         worktree             = if ($null -ne $experimentPacket) { [string]$experimentPacket.worktree } else { '' }
         env_fingerprint      = if ($null -ne $experimentPacket) { [string]$experimentPacket.env_fingerprint } else { '' }
         command_hash         = if ($null -ne $experimentPacket) { [string]$experimentPacket.command_hash } else { '' }
+        observation_pack     = $observationPack
+        consultation_packet  = $consultationPacket
     }
 }
 
@@ -3348,7 +3657,7 @@ function Get-ExplainPayload {
     $events = @(
         Get-BridgeEventRecords -ProjectDir $ProjectDir |
             Where-Object { Test-RunMatchesEventRecord -Run $run -EventRecord $_ } |
-            ForEach-Object { ConvertTo-RunEventRecord -EventRecord $_ } |
+            ForEach-Object { ConvertTo-RunEventRecord -EventRecord $_ -ProjectDir $ProjectDir } |
             Sort-Object @{ Expression = { [string]$_.timestamp }; Descending = $true }, @{ Expression = { [int]$_.line_number }; Descending = $true }
     )
 
@@ -3377,13 +3686,29 @@ function Get-ExplainPayload {
 
     $evidenceDigest = ConvertTo-EvidenceDigestItem -Run $run
     $recentEvents = @($events | Select-Object -First 20)
+    $observationPack = Get-HydratedObservationPack -ExperimentPacket $run.experiment_packet -ProjectDir $ProjectDir -ExpectedRunId ([string]$run.run_id)
+    $consultationPacket = Get-HydratedConsultationPacket -ExperimentPacket $run.experiment_packet -ProjectDir $ProjectDir -ExpectedRunId ([string]$run.run_id)
+    $consultationSummary = Get-ConsultationSummaryFromPacket -ConsultationPacket $consultationPacket
+    $experimentPacket = $run.experiment_packet
+    if ($null -ne $experimentPacket) {
+        $hydratedExperimentPacket = [ordered]@{}
+        foreach ($entry in $experimentPacket.GetEnumerator()) {
+            $hydratedExperimentPacket[[string]$entry.Key] = $entry.Value
+        }
+        $hydratedExperimentPacket['observation_pack'] = $observationPack
+        $hydratedExperimentPacket['consultation_packet'] = $consultationPacket
+        $experimentPacket = $hydratedExperimentPacket
+    }
 
     return [ordered]@{
         generated_at    = (Get-Date).ToString('o')
         project_dir     = $ProjectDir
         run             = $run
         run_packet      = New-RunPacketFromRun -Run $run
-        experiment_packet = $run.experiment_packet
+        experiment_packet = $experimentPacket
+        observation_pack = $observationPack
+        consultation_packet = $consultationPacket
+        consultation_summary = $consultationSummary
         evidence_digest = $evidenceDigest
         explanation   = [ordered]@{
             summary       = if (-not [string]::IsNullOrWhiteSpace([string]$run.task)) { [string]$run.task } else { [string]$run.primary_label }
@@ -3398,7 +3723,7 @@ function Get-ExplainPayload {
         }
         review_state    = $reviewState
         recent_events   = $recentEvents
-        result_packet   = New-RunResultPacket -Run $run -EvidenceDigest $evidenceDigest -ReviewState $reviewState -RecentEvents $recentEvents
+        result_packet   = New-RunResultPacket -Run $run -EvidenceDigest $evidenceDigest -ReviewState $reviewState -RecentEvents $recentEvents -ObservationPack $observationPack -ConsultationPacket $consultationPacket -ConsultationSummary $consultationSummary
     }
 }
 
@@ -3904,7 +4229,7 @@ function Invoke-Explain {
                     continue
                 }
 
-                $item = ConvertTo-RunEventRecord -EventRecord $eventRecord
+                $item = ConvertTo-RunEventRecord -EventRecord $eventRecord -ProjectDir $projectDir
                 Write-ExplainFollowItem -Item $item -Json:$jsonOutput
             }
 

--- a/tests/psmux-bridge.Tests.ps1
+++ b/tests/psmux-bridge.Tests.ps1
@@ -3524,6 +3524,31 @@ panes:
     last_event_at: 2026-04-10T12:00:00+09:00
 "@ | Set-Content -Path $script:runsManifestPath -Encoding UTF8
 
+        $runsObservationPack = New-ObservationPackFile -ProjectDir $script:runsTempRoot -ObservationPack ([ordered]@{
+            run_id              = 'task:task-256'
+            task_id             = 'task-256'
+            pane_id             = '%2'
+            slot                = 'slot-builder-1'
+            hypothesis          = 'branch-scoped event data is enough for experiment ledger'
+            test_plan           = @('capture matching events', 'render experiment packet')
+            env_fingerprint     = 'env:abc123'
+            command_hash        = 'cmd:def456'
+            changed_files       = @('scripts/winsmux-core.ps1')
+        })
+        $runsConsultationPacket = New-ConsultationPacketFile -ProjectDir $script:runsTempRoot -ConsultationPacket ([ordered]@{
+            run_id         = 'task:task-256'
+            task_id        = 'task-256'
+            pane_id        = '%2'
+            slot           = 'slot-builder-1'
+            kind           = 'consult_result'
+            mode           = 'early'
+            target_slot    = 'slot-review-1'
+            confidence     = 0.72
+            recommendation = 'keep experiment packet read-only'
+            next_test      = 'review_pending'
+            risks          = @('result still provisional')
+        })
+
         ([ordered]@{
             timestamp = '2026-04-10T12:01:00+09:00'
             session   = 'winsmux-orchestra'
@@ -3540,8 +3565,8 @@ panes:
                 result               = 'hypothesis still pending'
                 confidence           = 0.72
                 next_action          = 'review_pending'
-                observation_pack_ref = '.winsmux/observation-packs/task-256.json'
-                consultation_ref     = '.winsmux/consultations/task-256-review.json'
+                observation_pack_ref = $runsObservationPack.reference
+                consultation_ref     = $runsConsultationPacket.reference
                 run_id               = 'task:task-256'
                 slot                 = 'slot-builder-1'
                 worktree             = '.worktrees/builder-1'
@@ -3587,13 +3612,15 @@ panes:
         $result.runs[0].experiment_packet.result | Should -Be 'hypothesis still pending'
         $result.runs[0].experiment_packet.confidence | Should -Be 0.72
         $result.runs[0].experiment_packet.next_action | Should -Be 'review_pending'
-        $result.runs[0].experiment_packet.observation_pack_ref | Should -Be '.winsmux/observation-packs/task-256.json'
-        $result.runs[0].experiment_packet.consultation_ref | Should -Be '.winsmux/consultations/task-256-review.json'
+        $result.runs[0].experiment_packet.observation_pack_ref | Should -Be $runsObservationPack.reference
+        $result.runs[0].experiment_packet.consultation_ref | Should -Be $runsConsultationPacket.reference
         $result.runs[0].experiment_packet.run_id | Should -Be 'task:task-256'
         $result.runs[0].experiment_packet.slot | Should -Be 'slot-builder-1'
         $result.runs[0].experiment_packet.worktree | Should -Be '.worktrees/builder-1'
         $result.runs[0].experiment_packet.env_fingerprint | Should -Be 'env:abc123'
         $result.runs[0].experiment_packet.command_hash | Should -Be 'cmd:def456'
+        $result.runs[0].Contains('observation_pack') | Should -Be $false
+        $result.runs[0].Contains('consultation_packet') | Should -Be $false
     }
 
     It 'supports winsmux runs --json through the top-level CLI entrypoint' {
@@ -3843,6 +3870,27 @@ panes:
     last_event_at: 2026-04-10T14:00:00+09:00
 "@ | Set-Content -Path $script:digestManifestPath -Encoding UTF8
 
+        $digestObservationPack = New-ObservationPackFile -ProjectDir $script:digestTempRoot -ObservationPack ([ordered]@{
+            run_id          = 'task:task-246'
+            task_id         = 'task-246'
+            pane_id         = '%2'
+            slot            = 'slot-builder-1'
+            hypothesis      = 'result summary should appear in digest'
+            env_fingerprint = 'env:abc123'
+        })
+        $digestConsultationPacket = New-ConsultationPacketFile -ProjectDir $script:digestTempRoot -ConsultationPacket ([ordered]@{
+            run_id         = 'task:task-246'
+            task_id        = 'task-246'
+            pane_id        = '%2'
+            slot           = 'slot-builder-1'
+            kind           = 'consult_result'
+            mode           = 'reconcile'
+            target_slot    = 'slot-review-1'
+            confidence     = 0.88
+            recommendation = 'treat review failure as blocking'
+            next_test      = 'review_failed'
+        })
+
         ([ordered]@{
             timestamp = '2026-04-10T14:01:00+09:00'
             session   = 'winsmux-orchestra'
@@ -3859,8 +3907,8 @@ panes:
                 result               = 'review failure reproduced'
                 confidence           = 0.88
                 next_action          = 'review_failed'
-                observation_pack_ref = '.winsmux/observation-packs/task-246.json'
-                consultation_ref     = '.winsmux/consultations/task-246-reconcile.json'
+                observation_pack_ref = $digestObservationPack.reference
+                consultation_ref     = $digestConsultationPacket.reference
             }
         } | ConvertTo-Json -Compress) | Set-Content -Path $script:digestEventsPath -Encoding UTF8
 
@@ -3882,8 +3930,10 @@ panes:
         $result.items[0].changed_files | Should -Be @('scripts/winsmux-core.ps1')
         $result.items[0].hypothesis | Should -Be 'result summary should appear in digest'
         $result.items[0].confidence | Should -Be 0.88
-        $result.items[0].observation_pack_ref | Should -Be '.winsmux/observation-packs/task-246.json'
-        $result.items[0].consultation_ref | Should -Be '.winsmux/consultations/task-246-reconcile.json'
+        $result.items[0].observation_pack_ref | Should -Be $digestObservationPack.reference
+        $result.items[0].consultation_ref | Should -Be $digestConsultationPacket.reference
+        $result.items[0].Contains('observation_pack') | Should -Be $false
+        $result.items[0].Contains('consultation_packet') | Should -Be $false
     }
 
     It 'returns digest delta items only for runs affected after the current cursor' {
@@ -4125,6 +4175,33 @@ panes:
     last_event_at: 2026-04-10T12:00:00+09:00
 "@ | Set-Content -Path $script:explainManifestPath -Encoding UTF8
 
+        $explainObservationPack = New-ObservationPackFile -ProjectDir $script:explainTempRoot -ObservationPack ([ordered]@{
+            run_id               = 'task:task-256'
+            task_id              = 'task-256'
+            pane_id              = '%2'
+            slot                 = 'slot-builder-1'
+            hypothesis           = 'experiment packet should flow into explain'
+            test_plan            = @('collect matching events', 'normalize packet')
+            changed_files        = @('scripts/winsmux-core.ps1')
+            working_tree_summary = '1 file modified'
+            failing_command      = 'Invoke-Pester tests/psmux-bridge.Tests.ps1'
+            env_fingerprint      = 'env:abc123'
+            command_hash         = 'cmd:def456'
+        })
+        $explainConsultationPacket = New-ConsultationPacketFile -ProjectDir $script:explainTempRoot -ConsultationPacket ([ordered]@{
+            run_id         = 'task:task-256'
+            task_id        = 'task-256'
+            pane_id        = '%2'
+            slot           = 'slot-builder-1'
+            kind           = 'consult_result'
+            mode           = 'early'
+            target_slot    = 'slot-review-1'
+            confidence     = 0.66
+            recommendation = 'consult before work'
+            next_test      = 'approval_waiting'
+            risks          = @('needs reviewer confirmation')
+        })
+
         @(
             ([ordered]@{
                 timestamp = '2026-04-10T12:01:00+09:00'
@@ -4143,8 +4220,8 @@ panes:
                     result               = 'consult before work'
                     confidence           = 0.66
                     next_action          = 'approval_waiting'
-                    observation_pack_ref = '.winsmux/observation-packs/task-256.json'
-                    consultation_ref     = '.winsmux/consultations/task-256-early.json'
+                    observation_pack_ref = $explainObservationPack.reference
+                    consultation_ref     = $explainConsultationPacket.reference
                     run_id               = 'task:task-256'
                     slot                 = 'slot-builder-1'
                     worktree             = '.worktrees/builder-1'
@@ -4221,13 +4298,21 @@ panes:
         $result.experiment_packet.result | Should -Be 'consult before work'
         $result.experiment_packet.confidence | Should -Be 0.66
         $result.experiment_packet.next_action | Should -Be 'approval_waiting'
-        $result.experiment_packet.observation_pack_ref | Should -Be '.winsmux/observation-packs/task-256.json'
-        $result.experiment_packet.consultation_ref | Should -Be '.winsmux/consultations/task-256-early.json'
+        $result.experiment_packet.observation_pack_ref | Should -Be $explainObservationPack.reference
+        $result.experiment_packet.consultation_ref | Should -Be $explainConsultationPacket.reference
         $result.experiment_packet.run_id | Should -Be 'task:task-256'
         $result.experiment_packet.slot | Should -Be 'slot-builder-1'
         $result.experiment_packet.worktree | Should -Be '.worktrees/builder-1'
         $result.experiment_packet.env_fingerprint | Should -Be 'env:abc123'
         $result.experiment_packet.command_hash | Should -Be 'cmd:def456'
+        $result.observation_pack.packet_type | Should -Be 'observation_pack'
+        $result.observation_pack.failing_command | Should -Be 'Invoke-Pester tests/psmux-bridge.Tests.ps1'
+        $result.consultation_packet.kind | Should -Be 'consult_result'
+        $result.consultation_packet.mode | Should -Be 'early'
+        $result.consultation_summary.kind | Should -Be 'consult_result'
+        $result.consultation_summary.next_test | Should -Be 'approval_waiting'
+        $result.experiment_packet.observation_pack.packet_type | Should -Be 'observation_pack'
+        $result.experiment_packet.consultation_packet.kind | Should -Be 'consult_result'
         $result.evidence_digest.run_id | Should -Be 'task:task-256'
         $result.evidence_digest.next_action | Should -Be 'approval_waiting'
         $result.evidence_digest.changed_files | Should -Be @('scripts/winsmux-core.ps1')
@@ -4243,10 +4328,79 @@ panes:
         $result.result_packet.next_action_hint | Should -Be 'approval_waiting'
         $result.result_packet.review_recommendation | Should -Be 'PENDING'
         $result.result_packet.evidence_refs | Should -Be @('scripts/winsmux-core.ps1')
+        $result.result_packet.observation_pack.packet_type | Should -Be 'observation_pack'
+        $result.result_packet.consultation_packet.kind | Should -Be 'consult_result'
+        $result.result_packet.consultation_summary.kind | Should -Be 'consult_result'
         $result.recent_events.Count | Should -Be 2
         @($result.recent_events | ForEach-Object { $_.event }) | Should -Contain 'commander.review_requested'
         @($result.recent_events | ForEach-Object { $_.event }) | Should -Contain 'pane.approval_waiting'
         ($result.recent_events | Where-Object { $_.event -eq 'commander.review_requested' } | Select-Object -First 1).hypothesis | Should -Be 'experiment packet should flow into explain'
+        ($result.recent_events | Where-Object { $_.event -eq 'commander.review_requested' } | Select-Object -First 1).observation_pack.packet_type | Should -Be 'observation_pack'
+        ($result.recent_events | Where-Object { $_.event -eq 'commander.review_requested' } | Select-Object -First 1).consultation_packet.kind | Should -Be 'consult_result'
+    }
+
+    It 'keeps refs and returns null packets when artifact files are missing or malformed' {
+@"
+version: 1
+session:
+  name: winsmux-orchestra
+  project_dir: $script:explainTempRoot
+panes:
+  builder-1:
+    pane_id: %2
+    role: Builder
+    task_id: task-777
+    task: Explain missing packets
+    task_state: in_progress
+    task_owner: builder-1
+    review_state: PENDING
+    branch: worktree-builder-1
+    head_sha: abc1234def5678
+    changed_file_count: 0
+    changed_files: '[]'
+    last_event: commander.review_requested
+    last_event_at: 2026-04-10T12:00:00+09:00
+"@ | Set-Content -Path $script:explainManifestPath -Encoding UTF8
+
+        $badConsultDir = Get-ConsultationDirectory -ProjectDir $script:explainTempRoot
+        New-Item -ItemType Directory -Path $badConsultDir -Force | Out-Null
+        Write-PsmuxBridgeTestFile -Path (Join-Path $badConsultDir 'consult-result-bad.json') -Content '{ nope }'
+
+        ([ordered]@{
+            timestamp = '2026-04-10T12:01:00+09:00'
+            session   = 'winsmux-orchestra'
+            event     = 'commander.review_requested'
+            message   = 'review requested'
+            label     = 'reviewer-1'
+            pane_id   = '%3'
+            role      = 'Reviewer'
+            branch    = 'worktree-builder-1'
+            head_sha  = 'abc1234def5678'
+            data      = [ordered]@{
+                task_id              = 'task-777'
+                hypothesis           = 'hydrate should be resilient'
+                observation_pack_ref = '.winsmux/observation-packs/missing.json'
+                consultation_ref     = '.winsmux/consultations/consult-result-bad.json'
+                run_id               = 'task:task-777'
+                slot                 = 'slot-builder-1'
+            }
+        } | ConvertTo-Json -Compress) | Set-Content -Path $script:explainEventsPath -Encoding UTF8
+
+        function global:winsmux {
+            $commandLine = ($args | ForEach-Object { [string]$_ }) -join ' '
+            switch -Regex ($commandLine) {
+                '^capture-pane .*%2' { return @('gpt-5.4   64% context left', '? send   Ctrl+J newline', '>') }
+                default { throw "unexpected winsmux call: $commandLine" }
+            }
+        }
+
+        $result = (Invoke-Explain -ExplainTarget 'task:task-777' -ExplainRest @('--json') | Out-String | ConvertFrom-Json -AsHashtable)
+
+        $result.experiment_packet.observation_pack_ref | Should -Be '.winsmux/observation-packs/missing.json'
+        $result.experiment_packet.consultation_ref | Should -Be '.winsmux/consultations/consult-result-bad.json'
+        $result.observation_pack | Should -Be $null
+        $result.consultation_packet | Should -Be $null
+        $result.consultation_summary | Should -Be $null
     }
 
     It 'filters explain follow events from the current cursor forward' {
@@ -4400,6 +4554,70 @@ Describe 'winsmux send dispatch payload' {
 
     It 'rejects unsupported prompt transport values' {
         { Resolve-SendDispatchPayload -Text 'Write-Host short' -ProjectDir $script:sendTempRoot -LengthLimit 4000 -PromptTransport 'stdin' } | Should -Throw '*prompt_transport*'
+    }
+}
+
+Describe 'winsmux observation and consultation artifacts' {
+    BeforeAll {
+        $script:winsmuxCorePath = Join-Path (Split-Path -Parent $PSScriptRoot) 'scripts\winsmux-core.ps1'
+        . $script:winsmuxCorePath 'version' *> $null
+    }
+
+    BeforeEach {
+        $script:artifactTempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('winsmux-artifact-tests-' + [guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $script:artifactTempRoot -Force | Out-Null
+    }
+
+    AfterEach {
+        if ($script:artifactTempRoot -and (Test-Path $script:artifactTempRoot)) {
+            Remove-Item -Path $script:artifactTempRoot -Recurse -Force
+        }
+    }
+
+    It 'writes and reads an observation pack with a stable relative reference' {
+        $written = New-ObservationPackFile -ProjectDir $script:artifactTempRoot -ObservationPack ([ordered]@{
+            run_id              = 'task:task-300'
+            task_id             = 'task-300'
+            pane_id             = '%2'
+            slot                = 'slot-builder-1'
+            hypothesis          = 'observation packs should be file-backed'
+            test_plan           = @('write file', 'hydrate explain')
+            env_fingerprint     = 'env:abc123'
+            command_hash        = 'cmd:def456'
+            changed_files       = @('scripts/winsmux-core.ps1')
+            relevant_links      = @('https://example.test/logs/1')
+        })
+
+        $written.reference | Should -BeLike '.winsmux/observation-packs/observation-pack-*.json'
+        Test-Path -LiteralPath $written.path | Should -Be $true
+
+        $hydrated = Read-WinsmuxArtifactJson -Reference $written.reference -ProjectDir $script:artifactTempRoot -ExpectedDirectoryPath (Get-ObservationPackDirectory -ProjectDir $script:artifactTempRoot) -ExpectedRunId 'task:task-300'
+        $hydrated.packet_type | Should -Be 'observation_pack'
+        $hydrated.hypothesis | Should -Be 'observation packs should be file-backed'
+        $hydrated.test_plan | Should -Be @('write file', 'hydrate explain')
+        $hydrated.env_fingerprint | Should -Be 'env:abc123'
+    }
+
+    It 'rejects consultation packets with unsupported kind' {
+        {
+            New-ConsultationPacketFile -ProjectDir $script:artifactTempRoot -ConsultationPacket ([ordered]@{
+                run_id  = 'task:task-301'
+                task_id = 'task-301'
+                pane_id = '%2'
+                kind    = 'consult_maybe'
+                mode    = 'early'
+            })
+        } | Should -Throw '*Unsupported consultation packet kind*'
+    }
+
+    It 'returns null when a packet file contains malformed json' {
+        $badDir = Get-ObservationPackDirectory -ProjectDir $script:artifactTempRoot
+        New-Item -ItemType Directory -Path $badDir -Force | Out-Null
+        $badPath = Join-Path $badDir 'observation-pack-bad.json'
+        Write-PsmuxBridgeTestFile -Path $badPath -Content '{ not-valid-json }'
+
+        $hydrated = Read-WinsmuxArtifactJson -Reference '.winsmux/observation-packs/observation-pack-bad.json' -ProjectDir $script:artifactTempRoot -ExpectedDirectoryPath $badDir -ExpectedRunId 'task:task-300'
+        $hydrated | Should -Be $null
     }
 }
 


### PR DESCRIPTION
## Summary
- add file-backed observation pack and consultation packet artifacts under .winsmux
- keep runs/digest ref-only while hydrating explain/result/recent-events from artifact refs
- add regression coverage for missing and malformed artifacts plus ref-only invariants

## Validation
- Invoke-Pester tests/psmux-bridge.Tests.ps1
- git diff --check