### PR TITLE
feat(ledger): add consultation write-side events

### DIFF
--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -1,6 +1,6 @@
 # Handoff
 
-> Updated: 2026-04-11T19:20:06+09:00
+> Updated: 2026-04-11T20:24:00+09:00
 > Source of truth: this file
 
 ## Current state
@@ -30,6 +30,7 @@
 - Started the repo-side `TASK-114` first slice locally by extending `runs / digest / explain` to surface a new `experiment_packet` assembled from event-ledger data without changing the existing `run_packet` contract.
 - Added strict experiment-event correlation so experiment packets prefer `run_id / task_id / pane_id / label` over branch-only matching, and added a branch-collision regression to keep parallel hypothesis runs from cross-contaminating each other.
 - Extended [tests/psmux-bridge.Tests.ps1](../tests/psmux-bridge.Tests.ps1) so `winsmux runs --json`, `winsmux digest --json`, `winsmux explain --json`, and explain follow-delta all cover experiment-ledger fields plus a negative case where `experiment_packet` remains null when no experiment metadata exists.
+- Started the repo-side `TASK-301` write-side slice locally by adding consultation writer helpers and thin CLI commands that file `consult_request / consult_result / consult_error` packets under `.winsmux/consultations`, append corresponding bridge events, and project `result / confidence / next_action` back into the existing experiment ledger.
 - Merged `TASK-287` via PR [#393](https://github.com/Sora-bluesky/winsmux/pull/393), adding the keyboard-first operator command bar (`Ctrl/Cmd+K`) with quick actions, IME-safe input handling, focus restore, and accessible active-option semantics.
 - Merged `TASK-298` via PR [#394](https://github.com/Sora-bluesky/winsmux/pull/394), rewriting `README.ja.md` to match the public operator model, shrinking maintainer-only planning readmes into internal stubs, and making tracked public config/docs safer for external users.
 - Re-synced the external planning backlog/roadmap after PR [#394](https://github.com/Sora-bluesky/winsmux/pull/394), marking `TASK-298` as done so `v0.20.0` now shows `100% (12/12)`.
@@ -109,12 +110,13 @@
 - `TASK-187` transport slice passed focused regression before merge: `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `122/122 PASS`.
 - Current local `TASK-114` experiment-ledger slice passes focused regression: `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `123/123 PASS`.
 - PR [#396](https://github.com/Sora-bluesky/winsmux/pull/396) CI passed before merge: `Pester Tests` run `24280233475`.
+- Current local `TASK-301` write-side consultation slice passes focused regression: `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `130/130 PASS`.
 
 ## Next actions
 
-1. Start `TASK-300` / `TASK-301` so observation packs and consultation packets become file-backed, first-class ledger inputs instead of read-only fields.
-2. Keep the external planning sync flow user-visible but out of the public repo, then reflect consultation/experiment surfaces into the Tauri shell as `TASK-305` approaches.
-3. Use the rebalanced roadmap as the release train baseline: `v0.21.0` for slot dispatch core, `v0.21.1` for compare/promotion, and `v0.22.0` for backend-first Tauri foundation only.
+1. Commit and review the current `TASK-301` write-side consultation slice, then open the PR with consultation packet writers and bridge-event append helpers.
+2. After `TASK-301`, move to `TASK-191` so one-shot orchestration can insert consult steps without hard-coding vendor-specific advisor behavior.
+3. Keep the external planning sync flow user-visible but out of the public repo, then reflect consultation/experiment surfaces into the Tauri shell as `TASK-305` approaches.
 
 ## Notes
 

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -793,6 +793,51 @@ function Get-CurrentReviewPaneManifestContext {
     }
 }
 
+function Get-CurrentPaneManifestContext {
+    param([string]$ProjectDir = (Get-Location).Path)
+
+    if ([string]::IsNullOrWhiteSpace($env:WINSMUX_PANE_ID)) {
+        Stop-WithError 'WINSMUX_PANE_ID not set'
+    }
+
+    try {
+        $context = Get-PaneControlManifestContext -ProjectDir $ProjectDir -PaneId $env:WINSMUX_PANE_ID
+    } catch {
+        Stop-WithError $_.Exception.Message
+    }
+
+    $sessionName = ''
+    try {
+        $manifestContent = Get-Content -LiteralPath ([string]$context.ManifestPath) -Raw -Encoding UTF8
+        $manifest = ConvertFrom-PaneControlManifestContent -Content $manifestContent
+        $sessionName = [string](Get-PaneControlValue -InputObject $manifest.Session -Name 'name' -Default '')
+    } catch {
+    }
+
+    return [ordered]@{
+        ManifestPath        = [string]$context.ManifestPath
+        ProjectDir          = [string]$context.ProjectDir
+        SessionName         = [string]$sessionName
+        Label               = [string]$context.Label
+        PaneId              = [string]$context.PaneId
+        Role                = [string]$context.Role
+        LaunchDir           = [string]$context.LaunchDir
+        BuilderWorktreePath = [string]$context.BuilderWorktreePath
+        GitWorktreeDir      = [string]$context.GitWorktreeDir
+        TaskId              = [string]$context.TaskId
+        Task                = [string]$context.Task
+        TaskState           = [string]$context.TaskState
+        TaskOwner           = [string]$context.TaskOwner
+        ReviewState         = [string]$context.ReviewState
+        Branch              = [string]$context.Branch
+        HeadSha             = [string]$context.HeadSha
+        ParentRunId         = [string]$context.ParentRunId
+        Goal                = [string]$context.Goal
+        TaskType            = [string]$context.TaskType
+        Priority            = [string]$context.Priority
+    }
+}
+
 function Update-ReviewPaneManifestState {
     param(
         [Parameter(Mandatory = $true)][string]$ProjectDir,
@@ -830,6 +875,258 @@ function New-ReviewRequestId {
     $timestamp = Get-Date -Format 'yyyyMMddHHmmss'
     $suffix = ([guid]::NewGuid().ToString('N')).Substring(0, 8)
     return "review-$timestamp-$suffix"
+}
+
+function Parse-ConsultCommandArgs {
+    param(
+        [Parameter(Mandatory = $true)][string]$Mode,
+        [string[]]$Args = @()
+    )
+
+    $normalizedMode = if ([string]::IsNullOrWhiteSpace($Mode)) { '' } else { $Mode.Trim().ToLowerInvariant() }
+    if ($normalizedMode -notin @('early', 'stuck', 'reconcile', 'final')) {
+        Stop-WithError "Unsupported consult mode: $Mode"
+    }
+
+    $message = ''
+    $targetSlot = ''
+    $nextTest = ''
+    $confidence = $null
+    $risks = [System.Collections.Generic.List[string]]::new()
+    $messageParts = [System.Collections.Generic.List[string]]::new()
+
+    for ($i = 0; $i -lt $Args.Count; $i++) {
+        $token = [string]$Args[$i]
+        switch ($token) {
+            '--message' {
+                if ($i + 1 -ge $Args.Count) {
+                    Stop-WithError '--message requires a value'
+                }
+                $message = [string]$Args[$i + 1]
+                $i++
+            }
+            '--target-slot' {
+                if ($i + 1 -ge $Args.Count) {
+                    Stop-WithError '--target-slot requires a value'
+                }
+                $targetSlot = [string]$Args[$i + 1]
+                $i++
+            }
+            '--confidence' {
+                if ($i + 1 -ge $Args.Count) {
+                    Stop-WithError '--confidence requires a value'
+                }
+                $rawConfidence = [string]$Args[$i + 1]
+                $parsedConfidence = 0.0
+                if (-not [double]::TryParse($rawConfidence, [System.Globalization.NumberStyles]::Float, [System.Globalization.CultureInfo]::InvariantCulture, [ref]$parsedConfidence)) {
+                    Stop-WithError "Invalid confidence value: $rawConfidence"
+                }
+                $confidence = $parsedConfidence
+                $i++
+            }
+            '--next-test' {
+                if ($i + 1 -ge $Args.Count) {
+                    Stop-WithError '--next-test requires a value'
+                }
+                $nextTest = [string]$Args[$i + 1]
+                $i++
+            }
+            '--risk' {
+                if ($i + 1 -ge $Args.Count) {
+                    Stop-WithError '--risk requires a value'
+                }
+                $risk = [string]$Args[$i + 1]
+                if (-not [string]::IsNullOrWhiteSpace($risk)) {
+                    $risks.Add($risk) | Out-Null
+                }
+                $i++
+            }
+            default {
+                if (-not [string]::IsNullOrWhiteSpace($token)) {
+                    $messageParts.Add($token) | Out-Null
+                }
+            }
+        }
+    }
+
+    if ([string]::IsNullOrWhiteSpace($message) -and $messageParts.Count -gt 0) {
+        $message = ($messageParts -join ' ')
+    }
+
+    if ([string]::IsNullOrWhiteSpace($message)) {
+        Stop-WithError 'consult message is required'
+    }
+
+    return [ordered]@{
+        mode        = $normalizedMode
+        message     = [string]$message
+        target_slot = [string]$targetSlot
+        confidence  = $confidence
+        next_test   = [string]$nextTest
+        risks       = @($risks)
+    }
+}
+
+function Resolve-CurrentCommandArgs {
+    $resolvedTarget = [string]$Target
+    if ([string]::IsNullOrWhiteSpace($resolvedTarget)) {
+        $globalTarget = Get-Variable -Name Target -Scope Global -ValueOnly -ErrorAction SilentlyContinue
+        if ($null -ne $globalTarget) {
+            $resolvedTarget = [string]$globalTarget
+        }
+    }
+
+    $resolvedRest = @($Rest)
+    if (@($resolvedRest).Count -eq 0) {
+        $globalRest = Get-Variable -Name Rest -Scope Global -ValueOnly -ErrorAction SilentlyContinue
+        if ($null -ne $globalRest) {
+            $resolvedRest = @($globalRest)
+        }
+    }
+
+    return [ordered]@{
+        target = [string]$resolvedTarget
+        rest   = @($resolvedRest)
+    }
+}
+
+function Get-ConsultationCommandContext {
+    param([string]$ProjectDir = (Get-Location).Path)
+
+    $context = Get-CurrentPaneManifestContext -ProjectDir $ProjectDir
+    $branch = [string]$context.Branch
+    if ([string]::IsNullOrWhiteSpace($branch)) {
+        $branch = Get-CurrentGitBranch -ProjectDir $ProjectDir
+    }
+
+    $headSha = [string]$context.HeadSha
+    if ([string]::IsNullOrWhiteSpace($headSha)) {
+        $headSha = Get-CurrentGitHead -ProjectDir $ProjectDir
+    }
+
+    $runId = [string]$context.ParentRunId
+    if ([string]::IsNullOrWhiteSpace($runId) -and -not [string]::IsNullOrWhiteSpace([string]$context.TaskId)) {
+        $runId = "task:$([string]$context.TaskId)"
+    }
+
+    if ([string]::IsNullOrWhiteSpace($runId) -and [string]::IsNullOrWhiteSpace([string]$context.TaskId)) {
+        Stop-WithError 'consultation commands require task_id or parent_run_id in the current pane manifest entry'
+    }
+
+    $worktree = ''
+    $worktreePath = [string]$context.GitWorktreeDir
+    if ([string]::IsNullOrWhiteSpace($worktreePath)) {
+        $worktreePath = [string]$context.BuilderWorktreePath
+    }
+    if ([string]::IsNullOrWhiteSpace($worktreePath)) {
+        $worktreePath = [string]$context.LaunchDir
+    }
+    if (-not [string]::IsNullOrWhiteSpace($worktreePath)) {
+        $worktree = Get-WinsmuxArtifactReference -ArtifactPath $worktreePath -ProjectDir $ProjectDir
+    }
+
+    return [ordered]@{
+        SessionName = [string]$context.SessionName
+        Label       = [string]$context.Label
+        PaneId      = [string]$context.PaneId
+        Role        = [string]$context.Role
+        TaskId      = [string]$context.TaskId
+        Branch      = [string]$branch
+        HeadSha     = [string]$headSha
+        RunId       = [string]$runId
+        Slot        = [string]$context.Label
+        Worktree    = [string]$worktree
+    }
+}
+
+function Write-ConsultationCommandRecord {
+    param(
+        [Parameter(Mandatory = $true)][string]$Kind,
+        [Parameter(Mandatory = $true)][string]$Mode,
+        [Parameter(Mandatory = $true)][string]$Message,
+        [string]$TargetSlot = '',
+        [AllowNull()]$Confidence = $null,
+        [string]$NextTest = '',
+        [string[]]$Risks = @(),
+        [string]$ProjectDir = (Get-Location).Path
+    )
+
+    $context = Get-ConsultationCommandContext -ProjectDir $ProjectDir
+    $timestamp = (Get-Date).ToString('o')
+    $packet = [ordered]@{
+        run_id      = [string]$context.RunId
+        task_id     = [string]$context.TaskId
+        pane_id     = [string]$context.PaneId
+        slot        = [string]$context.Slot
+        kind        = [string]$Kind
+        mode        = [string]$Mode
+        target_slot = [string]$TargetSlot
+        branch      = [string]$context.Branch
+        head_sha    = [string]$context.HeadSha
+        worktree    = [string]$context.Worktree
+    }
+
+    switch ($Kind) {
+        'consult_request' { $packet['request'] = $Message }
+        'consult_result' {
+            $packet['recommendation'] = $Message
+            if ($null -ne $Confidence) {
+                $packet['confidence'] = $Confidence
+            }
+            if (-not [string]::IsNullOrWhiteSpace($NextTest)) {
+                $packet['next_test'] = $NextTest
+            }
+            if (@($Risks).Count -gt 0) {
+                $packet['risks'] = @($Risks)
+            }
+        }
+        'consult_error' { $packet['error'] = $Message }
+        default { Stop-WithError "Unsupported consultation command kind: $Kind" }
+    }
+
+    $artifact = New-ConsultationPacketFile -ProjectDir $ProjectDir -ConsultationPacket $packet
+
+    $eventData = [ordered]@{
+        task_id          = [string]$context.TaskId
+        run_id           = [string]$context.RunId
+        slot             = [string]$context.Slot
+        branch           = [string]$context.Branch
+        worktree         = [string]$context.Worktree
+        consultation_ref = [string]$artifact.reference
+    }
+
+    if ($Kind -eq 'consult_result') {
+        $eventData['result'] = $Message
+    }
+    if ($null -ne $Confidence) {
+        $eventData['confidence'] = $Confidence
+    }
+    if (-not [string]::IsNullOrWhiteSpace($NextTest)) {
+        $eventData['next_action'] = $NextTest
+    }
+
+    $eventRecord = [ordered]@{
+        timestamp = $timestamp
+        session   = [string]$context.SessionName
+        event     = "pane.$Kind"
+        message   = $Message
+        label     = [string]$context.Label
+        pane_id   = [string]$context.PaneId
+        role      = [string]$context.Role
+        branch    = [string]$context.Branch
+        head_sha  = [string]$context.HeadSha
+        data      = $eventData
+    }
+
+    Write-BridgeEventRecord -ProjectDir $ProjectDir -EventRecord $eventRecord | Out-Null
+
+    Update-ReviewPaneManifestState -ProjectDir $ProjectDir -Properties ([ordered]@{
+        last_event    = ($Kind -replace '_', '.')
+        last_event_at = $timestamp
+    })
+
+    $kindLabel = ($Kind -replace '^consult_', 'consult ' -replace '_', ' ')
+    Write-Output "$kindLabel recorded for $([string]$context.RunId)"
 }
 
 function New-ReviewerStateRecord {
@@ -4824,6 +5121,27 @@ function Invoke-ReviewReset {
     Write-Output "review PASS cleared for $branch"
 }
 
+function Invoke-ConsultRequest {
+    Assert-WinsmuxRolePermission -CommandName 'consult-request'
+    $commandArgs = Resolve-CurrentCommandArgs
+    $args = Parse-ConsultCommandArgs -Mode ([string]$commandArgs.target) -Args @($commandArgs.rest)
+    Write-ConsultationCommandRecord -Kind 'consult_request' -Mode ([string]$args.mode) -Message ([string]$args.message) -TargetSlot ([string]$args.target_slot)
+}
+
+function Invoke-ConsultResult {
+    Assert-WinsmuxRolePermission -CommandName 'consult-result'
+    $commandArgs = Resolve-CurrentCommandArgs
+    $args = Parse-ConsultCommandArgs -Mode ([string]$commandArgs.target) -Args @($commandArgs.rest)
+    Write-ConsultationCommandRecord -Kind 'consult_result' -Mode ([string]$args.mode) -Message ([string]$args.message) -TargetSlot ([string]$args.target_slot) -Confidence $args.confidence -NextTest ([string]$args.next_test) -Risks @($args.risks)
+}
+
+function Invoke-ConsultError {
+    Assert-WinsmuxRolePermission -CommandName 'consult-error'
+    $commandArgs = Resolve-CurrentCommandArgs
+    $args = Parse-ConsultCommandArgs -Mode ([string]$commandArgs.target) -Args @($commandArgs.rest)
+    Write-ConsultationCommandRecord -Kind 'consult_error' -Mode ([string]$args.mode) -Message ([string]$args.message) -TargetSlot ([string]$args.target_slot)
+}
+
 function Show-Usage {
     Write-Output @"
 winsmux $VERSION - winsmux bridge for winsmux
@@ -4851,6 +5169,9 @@ Commands:
   review-fail               Record review FAIL for the current branch
   review-reset              Clear review PASS for the current branch
   dispatch-review           Dispatch review-request to a review-capable pane (Reviewer/Worker)
+  consult-request <mode> [--message <text>] [--target-slot <slot>]  Record a consultation request packet/event
+  consult-result <mode> [--message <text>] [--target-slot <slot>] [--confidence <0..1>] [--next-test <text>] [--risk <text>]  Record a consultation result packet/event
+  consult-error <mode> [--message <text>] [--target-slot <slot>]  Record a consultation error packet/event
   locks                     List active file locks
   verify <pr-number>        Run Pester in tests/ and merge PR only on PASS
   wait <channel> [timeout]  Block until signal received (replaces polling)
@@ -5221,6 +5542,9 @@ switch ($Command) {
     'review-approve'  { Invoke-ReviewApprove }
     'review-fail'     { Invoke-ReviewFail }
     'review-reset'    { Invoke-ReviewReset }
+    'consult-request' { Invoke-ConsultRequest }
+    'consult-result'  { Invoke-ConsultResult }
+    'consult-error'   { Invoke-ConsultError }
     'rebind-worktree' { Invoke-RebindWorktree }
     ''                { Show-Usage }
     default           { Stop-WithError "unknown command: $Command. Run without arguments for usage." }

--- a/tests/psmux-bridge.Tests.ps1
+++ b/tests/psmux-bridge.Tests.ps1
@@ -77,6 +77,7 @@ Describe 'Assert-Role' {
         (Assert-Role -Command 'context-reset' -TargetPane 'reviewer') | Should -Be $true
         (Assert-Role -Command 'poll-events') | Should -Be $true
         (Assert-Role -Command 'vault') | Should -Be $true
+        (Assert-Role -Command 'consult-request') | Should -Be $true
         (Assert-Role -Command 'type' -TargetPane 'reviewer') | Should -Be $false
     }
 
@@ -91,6 +92,7 @@ Describe 'Assert-Role' {
         (Assert-Role -Command 'runs') | Should -Be $true
         (Assert-Role -Command 'digest') | Should -Be $true
         (Assert-Role -Command 'explain') | Should -Be $true
+        (Assert-Role -Command 'consult-result') | Should -Be $true
         (Assert-Role -Command 'type' -TargetPane 'self') | Should -Be $true
         (Assert-Role -Command 'context-reset' -TargetPane 'commander') | Should -Be $false
         (Assert-Role -Command 'send' -TargetPane 'reviewer') | Should -Be $false
@@ -104,6 +106,7 @@ Describe 'Assert-Role' {
         (Assert-Role -Command 'message' -TargetPane 'commander') | Should -Be $true
         (Assert-Role -Command 'read' -TargetPane 'self') | Should -Be $true
         (Assert-Role -Command 'digest') | Should -Be $true
+        (Assert-Role -Command 'consult-error') | Should -Be $true
         (Assert-Role -Command 'poll-events') | Should -Be $false
         (Assert-Role -Command 'signal') | Should -Be $false
         (Assert-Role -Command 'wait') | Should -Be $false
@@ -116,6 +119,7 @@ Describe 'Assert-Role' {
         (Assert-Role -Command 'message' -TargetPane 'commander') | Should -Be $true
         (Assert-Role -Command 'review-request') | Should -Be $true
         (Assert-Role -Command 'review-approve') | Should -Be $true
+        (Assert-Role -Command 'consult-result') | Should -Be $true
         (Assert-Role -Command 'status') | Should -Be $true
         (Assert-Role -Command 'digest') | Should -Be $true
         (Assert-Role -Command 'list') | Should -Be $true
@@ -131,6 +135,7 @@ Describe 'Assert-Role' {
         (Assert-Role -Command 'review-request') | Should -Be $true
         (Assert-Role -Command 'review-approve') | Should -Be $true
         (Assert-Role -Command 'review-fail') | Should -Be $true
+        (Assert-Role -Command 'consult-request') | Should -Be $true
         (Assert-Role -Command 'digest') | Should -Be $true
         (Assert-Role -Command 'vault') | Should -Be $false
         (Assert-Role -Command 'focus') | Should -Be $false
@@ -4618,6 +4623,103 @@ Describe 'winsmux observation and consultation artifacts' {
 
         $hydrated = Read-WinsmuxArtifactJson -Reference '.winsmux/observation-packs/observation-pack-bad.json' -ProjectDir $script:artifactTempRoot -ExpectedDirectoryPath $badDir -ExpectedRunId 'task:task-300'
         $hydrated | Should -Be $null
+    }
+}
+
+Describe 'winsmux consultation commands' {
+    BeforeAll {
+        $script:winsmuxCorePath = Join-Path (Split-Path -Parent $PSScriptRoot) 'scripts\winsmux-core.ps1'
+        . $script:winsmuxCorePath 'version' *> $null
+    }
+
+    BeforeEach {
+        $script:consultTempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('winsmux-consult-tests-' + [guid]::NewGuid().ToString('N'))
+        $manifestDir = Join-Path $script:consultTempRoot '.winsmux'
+        $script:consultManifestPath = Join-Path $manifestDir 'manifest.yaml'
+        New-Item -ItemType Directory -Path $manifestDir -Force | Out-Null
+        New-Item -ItemType Directory -Path (Join-Path $script:consultTempRoot '.worktrees\builder-1') -Force | Out-Null
+
+@"
+version: 1
+session:
+  name: winsmux-orchestra
+  project_dir: $script:consultTempRoot
+panes:
+  builder-1:
+    pane_id: %2
+    role: Builder
+    launch_dir: $script:consultTempRoot
+    builder_worktree_path: $(Join-Path $script:consultTempRoot '.worktrees\builder-1')
+    task_id: task-301
+    task: Investigate consultation packets
+    task_state: in_progress
+    branch: worktree-builder-1
+    head_sha: abc1234def5678
+"@ | Set-Content -Path $script:consultManifestPath -Encoding UTF8
+
+        Push-Location $script:consultTempRoot
+        $script:originalPaneId = $env:WINSMUX_PANE_ID
+        $script:originalAgentName = $env:WINSMUX_AGENT_NAME
+        $script:originalRole = $env:WINSMUX_ROLE
+        $env:WINSMUX_PANE_ID = '%2'
+        $env:WINSMUX_AGENT_NAME = 'codex'
+        $env:WINSMUX_ROLE = 'Builder'
+    }
+
+    AfterEach {
+        $env:WINSMUX_PANE_ID = $script:originalPaneId
+        $env:WINSMUX_AGENT_NAME = $script:originalAgentName
+        $env:WINSMUX_ROLE = $script:originalRole
+        Pop-Location
+
+        if ($script:consultTempRoot -and (Test-Path $script:consultTempRoot)) {
+            Remove-Item -Path $script:consultTempRoot -Recurse -Force
+        }
+    }
+
+    It 'records a consult request as a file-backed packet and event' {
+        $args = Parse-ConsultCommandArgs -Mode 'early' -Args @('--target-slot', 'slot-review-1', '--message', 'sanity-check the current hypothesis')
+
+        $output = Write-ConsultationCommandRecord -Kind 'consult_request' -Mode ([string]$args.mode) -Message ([string]$args.message) -TargetSlot ([string]$args.target_slot) -ProjectDir $script:consultTempRoot
+
+        $output | Should -Match 'consult request recorded for task:task-301'
+        $events = @(Get-BridgeEventRecords -ProjectDir $script:consultTempRoot)
+        $events.Count | Should -Be 1
+        $events[0].event | Should -Be 'pane.consult_request'
+        $events[0].data.consultation_ref | Should -BeLike '.winsmux/consultations/consult-request-*.json'
+        $events[0].data.run_id | Should -Be 'task:task-301'
+
+        $packet = Read-WinsmuxArtifactJson -Reference ([string]$events[0].data.consultation_ref) -ProjectDir $script:consultTempRoot -ExpectedDirectoryPath (Get-ConsultationDirectory -ProjectDir $script:consultTempRoot) -ExpectedRunId 'task:task-301'
+        $packet.kind | Should -Be 'consult_request'
+        $packet.mode | Should -Be 'early'
+        $packet.target_slot | Should -Be 'slot-review-1'
+        $packet.request | Should -Be 'sanity-check the current hypothesis'
+    }
+
+    It 'records a consult result with summary projection fields' {
+        $args = Parse-ConsultCommandArgs -Mode 'final' -Args @('--message', 'keep deterministic build command', '--confidence', '0.8', '--next-test', 'rerun build', '--risk', 'cache mismatch')
+
+        $output = Write-ConsultationCommandRecord -Kind 'consult_result' -Mode ([string]$args.mode) -Message ([string]$args.message) -TargetSlot ([string]$args.target_slot) -Confidence $args.confidence -NextTest ([string]$args.next_test) -Risks @($args.risks) -ProjectDir $script:consultTempRoot
+
+        $output | Should -Match 'consult result recorded for task:task-301'
+        $events = @(Get-BridgeEventRecords -ProjectDir $script:consultTempRoot)
+        $events.Count | Should -Be 1
+        $events[0].event | Should -Be 'pane.consult_result'
+        $events[0].data.result | Should -Be 'keep deterministic build command'
+        $events[0].data.confidence | Should -Be 0.8
+        $events[0].data.next_action | Should -Be 'rerun build'
+
+        $packet = Read-WinsmuxArtifactJson -Reference ([string]$events[0].data.consultation_ref) -ProjectDir $script:consultTempRoot -ExpectedDirectoryPath (Get-ConsultationDirectory -ProjectDir $script:consultTempRoot) -ExpectedRunId 'task:task-301'
+        $packet.kind | Should -Be 'consult_result'
+        $packet.mode | Should -Be 'final'
+        $packet.recommendation | Should -Be 'keep deterministic build command'
+        $packet.next_test | Should -Be 'rerun build'
+        $packet.confidence | Should -Be 0.8
+        $packet.risks | Should -Be @('cache mismatch')
+    }
+
+    It 'fails closed for unsupported consult mode' {
+        { Parse-ConsultCommandArgs -Mode 'later' -Args @('--message', 'invalid mode test') } | Should -Throw '*Unsupported consult mode*'
     }
 }
 

--- a/winsmux-core/scripts/role-gate.ps1
+++ b/winsmux-core/scripts/role-gate.ps1
@@ -33,6 +33,7 @@ $RolePermissions = @{
         Restart       = $true
         ContextReset  = $true
         ReviewApprove = $false
+        ConsultWrite  = $true
         Id            = $true
         Version       = $true
         Doctor        = $true
@@ -71,6 +72,7 @@ $RolePermissions = @{
         Restart       = $false
         ContextReset  = $false
         ReviewApprove = $false
+        ConsultWrite  = $true
         Id            = $true
         Version       = $true
         Doctor        = $true
@@ -109,6 +111,7 @@ $RolePermissions = @{
         Restart       = $false
         ContextReset  = $false
         ReviewApprove = $true
+        ConsultWrite  = $true
         Id            = $true
         Version       = $true
         Doctor        = $true
@@ -147,6 +150,7 @@ $RolePermissions = @{
         Restart       = $false
         ContextReset  = $false
         ReviewApprove = $false
+        ConsultWrite  = $true
         Id            = $true
         Version       = $true
         Doctor        = $true
@@ -185,6 +189,7 @@ $RolePermissions = @{
         Restart       = $false
         ContextReset  = $false
         ReviewApprove = $true
+        ConsultWrite  = $true
         Id            = $true
         Version       = $true
         Doctor        = $true
@@ -559,6 +564,18 @@ function Assert-Role {
         }
         'review-fail' {
             if ($permissions.ReviewApprove) { return $true }
+            return Deny-RoleCommand -Role $role -Command $normalizedCommand
+        }
+        'consult-request' {
+            if ($permissions.ConsultWrite) { return $true }
+            return Deny-RoleCommand -Role $role -Command $normalizedCommand
+        }
+        'consult-result' {
+            if ($permissions.ConsultWrite) { return $true }
+            return Deny-RoleCommand -Role $role -Command $normalizedCommand
+        }
+        'consult-error' {
+            if ($permissions.ConsultWrite) { return $true }
             return Deny-RoleCommand -Role $role -Command $normalizedCommand
         }
         'id' {


### PR DESCRIPTION
## Summary
- add write-side consultation helpers and thin consult-request/result/error commands
- append file-backed consultation events into the bridge event ledger with strong run correlation
- extend regression coverage for consultation writes and role-gate permissions

## Validation
- Invoke-Pester tests/psmux-bridge.Tests.ps1
- git diff --check