### PR TITLE
feat(orchestration): insert advisory consult stages into team pipeline

### DIFF
--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -1,6 +1,6 @@
 # Handoff
 
-> Updated: 2026-04-11T20:24:00+09:00
+> Updated: 2026-04-12T01:05:00+09:00
 > Source of truth: this file
 
 ## Current state
@@ -31,6 +31,10 @@
 - Added strict experiment-event correlation so experiment packets prefer `run_id / task_id / pane_id / label` over branch-only matching, and added a branch-collision regression to keep parallel hypothesis runs from cross-contaminating each other.
 - Extended [tests/psmux-bridge.Tests.ps1](../tests/psmux-bridge.Tests.ps1) so `winsmux runs --json`, `winsmux digest --json`, `winsmux explain --json`, and explain follow-delta all cover experiment-ledger fields plus a negative case where `experiment_packet` remains null when no experiment metadata exists.
 - Started the repo-side `TASK-301` write-side slice locally by adding consultation writer helpers and thin CLI commands that file `consult_request / consult_result / consult_error` packets under `.winsmux/consultations`, append corresponding bridge events, and project `result / confidence / next_action` back into the existing experiment ledger.
+- Merged the `TASK-301` write-side consultation slice via PR [#398](https://github.com/Sora-bluesky/winsmux/pull/398), landing file-backed consultation packet writers and bridge-event projection fields on `main`.
+- Started the repo-side `TASK-191` first slice locally by teaching one-shot orchestration to insert advisory consult steps before work, on blocked states, and before done using the existing reviewer/researcher lanes without introducing `consult-capable` routing policy yet.
+- Extended [winsmux-core/scripts/team-pipeline.ps1](../winsmux-core/scripts/team-pipeline.ps1) with consult-target selection, advisory consult prompt builders, and `pipeline.consult.*` event emission so one-shot runs can dispatch `early / stuck / final` consult stages around the existing `plan -> build -> verify` loop.
+- Extended [tests/psmux-bridge.Tests.ps1](../tests/psmux-bridge.Tests.ps1) to cover consult target selection plus successful and blocked orchestration paths, asserting that consult stages are inserted only when a non-builder consult target exists.
 - Merged `TASK-287` via PR [#393](https://github.com/Sora-bluesky/winsmux/pull/393), adding the keyboard-first operator command bar (`Ctrl/Cmd+K`) with quick actions, IME-safe input handling, focus restore, and accessible active-option semantics.
 - Merged `TASK-298` via PR [#394](https://github.com/Sora-bluesky/winsmux/pull/394), rewriting `README.ja.md` to match the public operator model, shrinking maintainer-only planning readmes into internal stubs, and making tracked public config/docs safer for external users.
 - Re-synced the external planning backlog/roadmap after PR [#394](https://github.com/Sora-bluesky/winsmux/pull/394), marking `TASK-298` as done so `v0.20.0` now shows `100% (12/12)`.
@@ -111,11 +115,14 @@
 - Current local `TASK-114` experiment-ledger slice passes focused regression: `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `123/123 PASS`.
 - PR [#396](https://github.com/Sora-bluesky/winsmux/pull/396) CI passed before merge: `Pester Tests` run `24280233475`.
 - Current local `TASK-301` write-side consultation slice passes focused regression: `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `130/130 PASS`.
+- PR [#398](https://github.com/Sora-bluesky/winsmux/pull/398) merged cleanly and the repo returned to `main == origin/main`.
+- Current local `TASK-191` consult-insertion slice passes focused regression: `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `133/133 PASS`.
+- Current local `TASK-191` consult-insertion slice passes `git diff --check` aside from benign LF->CRLF warnings on the edited files.
 
 ## Next actions
 
-1. Commit and review the current `TASK-301` write-side consultation slice, then open the PR with consultation packet writers and bridge-event append helpers.
-2. After `TASK-301`, move to `TASK-191` so one-shot orchestration can insert consult steps without hard-coding vendor-specific advisor behavior.
+1. Commit and review the current `TASK-191` consult-insertion slice, then open the PR with `team-pipeline` consult hooks and regression coverage.
+2. After `TASK-191`, move to the next `v0.20.1` ledger/transport increment without introducing `consult-capable` routing policy before `TASK-302`.
 3. Keep the external planning sync flow user-visible but out of the public repo, then reflect consultation/experiment surfaces into the Tauri shell as `TASK-305` approaches.
 
 ## Notes

--- a/tests/psmux-bridge.Tests.ps1
+++ b/tests/psmux-bridge.Tests.ps1
@@ -788,6 +788,117 @@ STATUS: VERIFY_PASS
         $skipTargets.PlanTarget | Should -BeNullOrEmpty
         $skipTargets.VerifyTarget | Should -BeNullOrEmpty
     }
+
+    It 'prefers reviewer then researcher for consult targets and skips builder-only runs' {
+        (Get-TeamPipelineConsultTarget -BuilderLabel 'builder-1' -ResearcherLabel 'researcher' -ReviewerLabel 'reviewer') | Should -Be 'reviewer'
+        (Get-TeamPipelineConsultTarget -BuilderLabel 'builder-1' -ResearcherLabel 'researcher' -ReviewerLabel '') | Should -Be 'researcher'
+        (Get-TeamPipelineConsultTarget -BuilderLabel 'builder-1' -ResearcherLabel '' -ReviewerLabel 'builder-1') | Should -BeNullOrEmpty
+        (Get-TeamPipelineConsultTarget -BuilderLabel 'builder-1' -ResearcherLabel '' -ReviewerLabel '') | Should -BeNullOrEmpty
+    }
+
+    It 'inserts early and final consult stages into successful one-shot orchestration when a consult target exists' {
+        $manifest = [PSCustomObject]@{
+            Session = [PSCustomObject]@{
+                name        = 'winsmux-orchestra'
+                project_dir = 'C:\repo'
+            }
+            Panes = [ordered]@{
+                'builder-1' = [PSCustomObject]@{ pane_id = '%2'; role = 'Builder'; builder_worktree_path = 'C:\repo\.worktrees\builder-1' }
+                'reviewer'  = [PSCustomObject]@{ pane_id = '%4'; role = 'Reviewer'; launch_dir = 'C:\repo' }
+            }
+        }
+
+        $script:teamPipelineBridgeCalls = @()
+        $script:teamPipelineEvents = @()
+
+        Mock Read-TeamPipelineManifest { $manifest }
+        Mock Invoke-TeamPipelineBridge {
+            param([string[]]$Arguments, [switch]$AllowFailure)
+            $script:teamPipelineBridgeCalls += ,@($Arguments)
+            [PSCustomObject]@{ ExitCode = 0; Output = '' }
+        }
+        Mock Wait-TeamPipelineStage {
+            param([string]$Target, [string]$StageName, [int]$TimeoutSeconds, [int]$PollIntervalSeconds)
+            switch ($StageName) {
+                'PLAN'          { return [PSCustomObject]@{ Stage = $StageName; Target = $Target; Status = 'PLAN_DONE'; Summary = 'plan summary'; Transcript = '' } }
+                'CONSULT_EARLY' { return [PSCustomObject]@{ Stage = $StageName; Target = $Target; Status = 'CONSULT_DONE'; Summary = 'early consult summary'; Transcript = '' } }
+                'EXEC'          { return [PSCustomObject]@{ Stage = $StageName; Target = $Target; Status = 'EXEC_DONE'; Summary = 'build summary'; Transcript = '' } }
+                'VERIFY'        { return [PSCustomObject]@{ Stage = $StageName; Target = $Target; Status = 'VERIFY_PASS'; Summary = 'verify summary'; Transcript = '' } }
+                'CONSULT_FINAL' { return [PSCustomObject]@{ Stage = $StageName; Target = $Target; Status = 'CONSULT_DONE'; Summary = 'final consult summary'; Transcript = '' } }
+                default         { throw "Unexpected stage $StageName" }
+            }
+        }
+        Mock Write-TeamPipelineEvent {
+            param($ProjectDir, $SessionName, $Event, $Message, $Role, $PaneId, $Target, $Data)
+            $script:teamPipelineEvents += [PSCustomObject]@{
+                Event = $Event
+                Role = $Role
+                Target = $Target
+                Data = $Data
+            }
+        }
+
+        $result = Invoke-TeamPipeline -Task 'Investigate cache drift' -Builder 'builder-1' -Reviewer 'reviewer'
+
+        $result.FinalStatus | Should -Be 'VERIFY_PASS'
+        $result.Success | Should -Be $true
+        $result.PreWorkConsult.Status | Should -Be 'CONSULT_DONE'
+        $result.FinalConsult.Status | Should -Be 'CONSULT_DONE'
+        @($script:teamPipelineBridgeCalls | Where-Object { $_[0] -eq 'send' -and $_[1] -eq 'reviewer' }).Count | Should -Be 3
+        @($script:teamPipelineEvents | Where-Object { $_.Event -eq 'pipeline.consult.dispatched' }).Count | Should -Be 2
+        @($script:teamPipelineEvents | Where-Object { $_.Event -eq 'pipeline.consult.completed' }).Count | Should -Be 2
+    }
+
+    It 'inserts a stuck consult before returning blocked execution' {
+        $manifest = [PSCustomObject]@{
+            Session = [PSCustomObject]@{
+                name        = 'winsmux-orchestra'
+                project_dir = 'C:\repo'
+            }
+            Panes = [ordered]@{
+                'builder-1' = [PSCustomObject]@{ pane_id = '%2'; role = 'Builder'; builder_worktree_path = 'C:\repo\.worktrees\builder-1' }
+                'reviewer'  = [PSCustomObject]@{ pane_id = '%4'; role = 'Reviewer'; launch_dir = 'C:\repo' }
+            }
+        }
+
+        $script:teamPipelineBridgeCalls = @()
+        $script:teamPipelineEvents = @()
+
+        Mock Read-TeamPipelineManifest { $manifest }
+        Mock Invoke-TeamPipelineBridge {
+            param([string[]]$Arguments, [switch]$AllowFailure)
+            $script:teamPipelineBridgeCalls += ,@($Arguments)
+            [PSCustomObject]@{ ExitCode = 0; Output = '' }
+        }
+        Mock Wait-TeamPipelineStage {
+            param([string]$Target, [string]$StageName, [int]$TimeoutSeconds, [int]$PollIntervalSeconds)
+            switch ($StageName) {
+                'PLAN'          { return [PSCustomObject]@{ Stage = $StageName; Target = $Target; Status = 'PLAN_DONE'; Summary = 'plan summary'; Transcript = '' } }
+                'CONSULT_EARLY' { return [PSCustomObject]@{ Stage = $StageName; Target = $Target; Status = 'CONSULT_DONE'; Summary = 'early consult summary'; Transcript = '' } }
+                'EXEC'          { return [PSCustomObject]@{ Stage = $StageName; Target = $Target; Status = 'BLOCKED'; Summary = 'builder blocked summary'; Transcript = '' } }
+                'CONSULT_STUCK' { return [PSCustomObject]@{ Stage = $StageName; Target = $Target; Status = 'CONSULT_DONE'; Summary = 'stuck consult summary'; Transcript = '' } }
+                default         { throw "Unexpected stage $StageName" }
+            }
+        }
+        Mock Write-TeamPipelineEvent {
+            param($ProjectDir, $SessionName, $Event, $Message, $Role, $PaneId, $Target, $Data)
+            $script:teamPipelineEvents += [PSCustomObject]@{
+                Event = $Event
+                Role = $Role
+                Target = $Target
+                Data = $Data
+            }
+        }
+
+        $result = Invoke-TeamPipeline -Task 'Investigate cache drift' -Builder 'builder-1' -Reviewer 'reviewer'
+
+        $result.FinalStatus | Should -Be 'EXEC_BLOCKED'
+        $result.Success | Should -Be $false
+        $result.StuckConsults.Count | Should -Be 1
+        $result.StuckConsults[0].Status | Should -Be 'CONSULT_DONE'
+        @($script:teamPipelineEvents | Where-Object { $_.Event -eq 'pipeline.consult.dispatched' }).Count | Should -Be 2
+        @($script:teamPipelineEvents | Where-Object { $_.Event -eq 'pipeline.consult.completed' }).Count | Should -Be 2
+    }
 }
 
 Describe 'pane-control helpers' {

--- a/winsmux-core/scripts/team-pipeline.ps1
+++ b/winsmux-core/scripts/team-pipeline.ps1
@@ -203,6 +203,24 @@ function Get-TeamPipelineStageTargets {
     }
 }
 
+function Get-TeamPipelineConsultTarget {
+    param(
+        [Parameter(Mandatory = $true)][string]$BuilderLabel,
+        [string]$ResearcherLabel,
+        [string]$ReviewerLabel
+    )
+
+    if (-not [string]::IsNullOrWhiteSpace($ReviewerLabel) -and $ReviewerLabel -ne $BuilderLabel) {
+        return $ReviewerLabel
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($ResearcherLabel) -and $ResearcherLabel -ne $BuilderLabel) {
+        return $ResearcherLabel
+    }
+
+    return $null
+}
+
 function Get-TeamPipelineCanonicalRole {
     param([AllowNull()][string]$Label)
 
@@ -217,6 +235,34 @@ function Get-TeamPipelineCanonicalRole {
         '^(?i)reviewer(?:$|[-_:/\s])' { return 'Reviewer' }
         default { return '' }
     }
+}
+
+function Get-TeamPipelineConsultRole {
+    param(
+        [Parameter(Mandatory = $true)][string]$TargetLabel,
+        [Parameter(Mandatory = $true)][string]$BuilderLabel,
+        [string]$ResearcherLabel,
+        [string]$ReviewerLabel
+    )
+
+    if (-not [string]::IsNullOrWhiteSpace($ReviewerLabel) -and $TargetLabel -eq $ReviewerLabel) {
+        return 'Reviewer'
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($ResearcherLabel) -and $TargetLabel -eq $ResearcherLabel) {
+        return 'Researcher'
+    }
+
+    if ($TargetLabel -eq $BuilderLabel) {
+        return 'Builder'
+    }
+
+    $canonical = Get-TeamPipelineCanonicalRole -Label $TargetLabel
+    if (-not [string]::IsNullOrWhiteSpace($canonical)) {
+        return $canonical
+    }
+
+    return 'Worker'
 }
 
 function Invoke-TeamPipelineBridge {
@@ -590,6 +636,118 @@ STATUS: BLOCKED
 "@
 }
 
+function New-TeamPipelineConsultPrompt {
+    param(
+        [Parameter(Mandatory = $true)][ValidateSet('early', 'stuck', 'final')][string]$Mode,
+        [Parameter(Mandatory = $true)][string]$Task,
+        [string]$PlanSummary,
+        [string]$BuildSummary,
+        [string]$VerificationSummary,
+        [string]$BuilderLabel,
+        [string]$BuilderWorktreePath
+    )
+
+    $modeInstruction = switch ($Mode) {
+        'early' { 'Provide a short second opinion before substantive work starts. Focus on likely failure modes, missing evidence, and the best next experiment.' }
+        'stuck' { 'The run is blocked. Diagnose the block, propose the safest next test, and identify the smallest unblock path.' }
+        'final' { 'The run appears ready to conclude. Sanity-check the result, residual risks, and the single best next validation step before done.' }
+    }
+
+    return @"
+You are acting in advisory mode for winsmux one-shot orchestration.
+
+Task:
+$Task
+
+Consult mode:
+$Mode
+
+Builder:
+$BuilderLabel
+
+Builder worktree:
+$BuilderWorktreePath
+
+Plan summary:
+$PlanSummary
+
+Build summary:
+$BuildSummary
+
+Verification summary:
+$VerificationSummary
+
+$modeInstruction
+
+Constraints:
+- Do not edit files.
+- Do not run destructive commands.
+- Keep the response concise and operational.
+
+Return:
+- 2-4 bullet points with advice
+- one line `NEXT_TEST: ...`
+
+End with exactly one line:
+STATUS: CONSULT_DONE
+
+If you cannot advise safely, end with:
+STATUS: BLOCKED
+"@
+}
+
+function Invoke-TeamPipelineConsultStage {
+    param(
+        [Parameter(Mandatory = $true)][string]$Mode,
+        [Parameter(Mandatory = $true)][string]$Task,
+        [Parameter(Mandatory = $true)][string]$BuilderLabel,
+        [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [Parameter(Mandatory = $true)][string]$SessionName,
+        [string]$TargetLabel,
+        [string]$ResearcherLabel,
+        [string]$ReviewerLabel,
+        [string]$BuilderWorktreePath,
+        [string]$PlanSummary,
+        [string]$BuildSummary,
+        [string]$VerificationSummary,
+        [int]$TimeoutSeconds = 240,
+        [int]$PollIntervalSeconds = 10,
+        [int]$Attempt = 0
+    )
+
+    if ([string]::IsNullOrWhiteSpace($TargetLabel)) {
+        return $null
+    }
+
+    $consultRole = Get-TeamPipelineConsultRole -TargetLabel $TargetLabel -BuilderLabel $BuilderLabel -ResearcherLabel $ResearcherLabel -ReviewerLabel $ReviewerLabel
+    $prompt = New-TeamPipelineConsultPrompt -Mode $Mode -Task $Task -PlanSummary $PlanSummary -BuildSummary $BuildSummary -VerificationSummary $VerificationSummary -BuilderLabel $BuilderLabel -BuilderWorktreePath $BuilderWorktreePath
+    $eventData = [ordered]@{
+        mode                 = $Mode
+        attempt              = $Attempt
+        task                 = $Task
+        builder              = $BuilderLabel
+        builder_worktree_path = $BuilderWorktreePath
+        verify_summary       = $VerificationSummary
+    }
+
+    Write-TeamPipelineEvent -ProjectDir $ProjectDir -SessionName $SessionName -Event 'pipeline.consult.dispatched' -Message "Dispatched $Mode consult to $TargetLabel." -Role $consultRole -Target $TargetLabel -Data $eventData | Out-Null
+    Invoke-TeamPipelineBridge -Arguments @('send', $TargetLabel, $prompt) | Out-Null
+    $stage = Wait-TeamPipelineStage -Target $TargetLabel -StageName ("CONSULT_{0}" -f $Mode.ToUpperInvariant()) -TimeoutSeconds $TimeoutSeconds -PollIntervalSeconds $PollIntervalSeconds
+
+    $completedEvent = if ($stage.Status -eq 'BLOCKED') { 'pipeline.consult.blocked' } else { 'pipeline.consult.completed' }
+    Write-TeamPipelineEvent -ProjectDir $ProjectDir -SessionName $SessionName -Event $completedEvent -Message "$Mode consult on $TargetLabel completed with status $($stage.Status)." -Role $consultRole -Target $TargetLabel -Data ([ordered]@{
+        mode                  = $Mode
+        attempt               = $Attempt
+        task                  = $Task
+        status                = $stage.Status
+        summary               = $stage.Summary
+        builder               = $BuilderLabel
+        builder_worktree_path = $BuilderWorktreePath
+    }) | Out-Null
+
+    return $stage
+}
+
 function Invoke-TeamPipeline {
     param(
         [Parameter(Mandatory = $true)][string]$Task,
@@ -630,12 +788,16 @@ function Invoke-TeamPipeline {
         PlanTarget          = $targets.PlanTarget
         VerifyTarget        = $targets.VerifyTarget
         Plan                = $null
+        PreWorkConsult      = $null
+        FinalConsult        = $null
+        StuckConsults       = @()
         Attempts            = @()
         Success             = $false
         FinalStatus         = 'NOT_STARTED'
     }
 
     $planSummary = ''
+    $consultTarget = Get-TeamPipelineConsultTarget -BuilderLabel $Builder -ResearcherLabel $Researcher -ReviewerLabel $Reviewer
     if (-not [string]::IsNullOrWhiteSpace($targets.PlanTarget)) {
         $planPrompt = New-TeamPipelinePlanPrompt -Task $Task
         Invoke-TeamPipelineBridge -Arguments @('send', $targets.PlanTarget, $planPrompt) | Out-Null
@@ -649,6 +811,10 @@ function Invoke-TeamPipeline {
         $planSummary = $planStage.Summary
     }
 
+    if (-not [string]::IsNullOrWhiteSpace($consultTarget)) {
+        $result.PreWorkConsult = Invoke-TeamPipelineConsultStage -Mode 'early' -Task $Task -BuilderLabel $Builder -ProjectDir $builderContext.ProjectDir -SessionName $sessionName -TargetLabel $consultTarget -ResearcherLabel $Researcher -ReviewerLabel $Reviewer -BuilderWorktreePath $builderContext.BuilderWorktreePath -PlanSummary $planSummary -TimeoutSeconds $StageTimeoutSeconds -PollIntervalSeconds $PollIntervalSeconds
+    }
+
     $attemptLimit = 1 + [Math]::Max(0, $MaxFixRounds)
     for ($attemptIndex = 1; $attemptIndex -le $attemptLimit; $attemptIndex++) {
         $attempt = [ordered]@{
@@ -657,6 +823,7 @@ function Invoke-TeamPipeline {
             BuildNotification = $null
             VerifyDispatch    = $null
             Verify            = $null
+            StuckConsult      = $null
         }
 
         $buildPrompt = if ($attemptIndex -eq 1) {
@@ -671,6 +838,12 @@ function Invoke-TeamPipeline {
         $attempt.Build = $buildStage
 
         if ($buildStage.Status -eq 'BLOCKED') {
+            if (-not [string]::IsNullOrWhiteSpace($consultTarget)) {
+                $attempt.StuckConsult = Invoke-TeamPipelineConsultStage -Mode 'stuck' -Task $Task -BuilderLabel $Builder -ProjectDir $builderContext.ProjectDir -SessionName $sessionName -TargetLabel $consultTarget -ResearcherLabel $Researcher -ReviewerLabel $Reviewer -BuilderWorktreePath $builderContext.BuilderWorktreePath -PlanSummary $planSummary -BuildSummary $buildStage.Summary -TimeoutSeconds $StageTimeoutSeconds -PollIntervalSeconds $PollIntervalSeconds -Attempt $attemptIndex
+                if ($null -ne $attempt.StuckConsult) {
+                    $result.StuckConsults += $attempt.StuckConsult
+                }
+            }
             $result.Attempts += [PSCustomObject]$attempt
             $result.FinalStatus = 'EXEC_BLOCKED'
             return [PSCustomObject]$result
@@ -688,6 +861,9 @@ function Invoke-TeamPipeline {
         }) | Out-Null
 
         if ([string]::IsNullOrWhiteSpace($targets.VerifyTarget)) {
+            if (-not [string]::IsNullOrWhiteSpace($consultTarget)) {
+                $result.FinalConsult = Invoke-TeamPipelineConsultStage -Mode 'final' -Task $Task -BuilderLabel $Builder -ProjectDir $builderContext.ProjectDir -SessionName $sessionName -TargetLabel $consultTarget -ResearcherLabel $Researcher -ReviewerLabel $Reviewer -BuilderWorktreePath $builderContext.BuilderWorktreePath -PlanSummary $planSummary -BuildSummary $buildStage.Summary -TimeoutSeconds $StageTimeoutSeconds -PollIntervalSeconds $PollIntervalSeconds -Attempt $attemptIndex
+            }
             $result.Attempts += [PSCustomObject]$attempt
             $result.Success = $true
             $result.FinalStatus = 'EXEC_DONE'
@@ -723,11 +899,20 @@ function Invoke-TeamPipeline {
 
         switch ($verifyStage.Status) {
             'VERIFY_PASS' {
+                if (-not [string]::IsNullOrWhiteSpace($consultTarget)) {
+                    $result.FinalConsult = Invoke-TeamPipelineConsultStage -Mode 'final' -Task $Task -BuilderLabel $Builder -ProjectDir $builderContext.ProjectDir -SessionName $sessionName -TargetLabel $consultTarget -ResearcherLabel $Researcher -ReviewerLabel $Reviewer -BuilderWorktreePath $builderContext.BuilderWorktreePath -PlanSummary $planSummary -BuildSummary $buildStage.Summary -VerificationSummary $verifyStage.Summary -TimeoutSeconds $StageTimeoutSeconds -PollIntervalSeconds $PollIntervalSeconds -Attempt $attemptIndex
+                }
                 $result.Success = $true
                 $result.FinalStatus = 'VERIFY_PASS'
                 return [PSCustomObject]$result
             }
             'BLOCKED' {
+                if (-not [string]::IsNullOrWhiteSpace($consultTarget)) {
+                    $attempt.StuckConsult = Invoke-TeamPipelineConsultStage -Mode 'stuck' -Task $Task -BuilderLabel $Builder -ProjectDir $builderContext.ProjectDir -SessionName $sessionName -TargetLabel $consultTarget -ResearcherLabel $Researcher -ReviewerLabel $Reviewer -BuilderWorktreePath $builderContext.BuilderWorktreePath -PlanSummary $planSummary -BuildSummary $buildStage.Summary -VerificationSummary $verifyStage.Summary -TimeoutSeconds $StageTimeoutSeconds -PollIntervalSeconds $PollIntervalSeconds -Attempt $attemptIndex
+                    if ($null -ne $attempt.StuckConsult) {
+                        $result.StuckConsults += $attempt.StuckConsult
+                    }
+                }
                 $result.FinalStatus = 'VERIFY_BLOCKED'
                 return [PSCustomObject]$result
             }


### PR DESCRIPTION
## Summary
- insert advisory consult hooks into the one-shot team pipeline before work, on blocked states, and before done
- keep routing policy unchanged by reusing the existing reviewer/researcher lanes as the minimal consult target
- add regression coverage for consult target selection plus successful and blocked orchestration paths

## Validation
- Invoke-Pester tests/psmux-bridge.Tests.ps1
  - 133/133 PASS
- git diff --check

## Review gate
- fresh reviewer waited twice and returned no result yet
- fallback gate used: manual diff review + focused regression + diff check
