### PR TITLE
feat(orchestration): add stable task prompt file handoff

### DIFF
--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -1,6 +1,6 @@
 # Handoff
 
-> Updated: 2026-04-12T01:05:00+09:00
+> Updated: 2026-04-12T01:42:00+09:00
 > Source of truth: this file
 
 ## Current state
@@ -35,6 +35,10 @@
 - Started the repo-side `TASK-191` first slice locally by teaching one-shot orchestration to insert advisory consult steps before work, on blocked states, and before done using the existing reviewer/researcher lanes without introducing `consult-capable` routing policy yet.
 - Extended [winsmux-core/scripts/team-pipeline.ps1](../winsmux-core/scripts/team-pipeline.ps1) with consult-target selection, advisory consult prompt builders, and `pipeline.consult.*` event emission so one-shot runs can dispatch `early / stuck / final` consult stages around the existing `plan -> build -> verify` loop.
 - Extended [tests/psmux-bridge.Tests.ps1](../tests/psmux-bridge.Tests.ps1) to cover consult target selection plus successful and blocked orchestration paths, asserting that consult stages are inserted only when a non-builder consult target exists.
+- Merged the `TASK-191` first slice via PR [#399](https://github.com/Sora-bluesky/winsmux/pull/399), inserting advisory consult stages into one-shot team orchestration without introducing `consult-capable` routing policy yet.
+- Started the repo-side `TASK-188` first slice locally by extending the transport layer with stable `.winsmux/task-{slug}.md` prompt files so task-scoped handoff can be audited and reused before the full `task-run` command exists.
+- Extended [scripts/winsmux-core.ps1](../scripts/winsmux-core.ps1) with task-prompt helpers (`ConvertTo-TaskPromptSlug`, `Get-TaskPromptPath`, `New-TaskPromptFile`) and task-aware transport planning so file-backed sends can target a deterministic `task-{slug}.md` artifact instead of a random dispatch file.
+- Extended [tests/psmux-bridge.Tests.ps1](../tests/psmux-bridge.Tests.ps1) so send payloads cover normalized task slugs, stable relative references, and overwrite semantics when the same task slug is reused.
 - Merged `TASK-287` via PR [#393](https://github.com/Sora-bluesky/winsmux/pull/393), adding the keyboard-first operator command bar (`Ctrl/Cmd+K`) with quick actions, IME-safe input handling, focus restore, and accessible active-option semantics.
 - Merged `TASK-298` via PR [#394](https://github.com/Sora-bluesky/winsmux/pull/394), rewriting `README.ja.md` to match the public operator model, shrinking maintainer-only planning readmes into internal stubs, and making tracked public config/docs safer for external users.
 - Re-synced the external planning backlog/roadmap after PR [#394](https://github.com/Sora-bluesky/winsmux/pull/394), marking `TASK-298` as done so `v0.20.0` now shows `100% (12/12)`.
@@ -118,11 +122,14 @@
 - PR [#398](https://github.com/Sora-bluesky/winsmux/pull/398) merged cleanly and the repo returned to `main == origin/main`.
 - Current local `TASK-191` consult-insertion slice passes focused regression: `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `133/133 PASS`.
 - Current local `TASK-191` consult-insertion slice passes `git diff --check` aside from benign LF->CRLF warnings on the edited files.
+- PR [#399](https://github.com/Sora-bluesky/winsmux/pull/399) merged cleanly and the repo returned to `main == origin/main`.
+- Current local `TASK-188` task-prompt-file slice passes focused regression: `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `135/135 PASS`.
+- Current local `TASK-188` task-prompt-file slice passes `git diff --check` aside from benign LF->CRLF warnings on the edited files.
 
 ## Next actions
 
-1. Commit and review the current `TASK-191` consult-insertion slice, then open the PR with `team-pipeline` consult hooks and regression coverage.
-2. After `TASK-191`, move to the next `v0.20.1` ledger/transport increment without introducing `consult-capable` routing policy before `TASK-302`.
+1. Commit and review the current `TASK-188` task-prompt-file slice, then open the PR with stable `.winsmux/task-{slug}.md` transport helpers and regression coverage.
+2. After `TASK-188`, continue `v0.20.1` by connecting these task prompt files to the eventual `task-run` entrypoint rather than expanding routing policy prematurely.
 3. Keep the external planning sync flow user-visible but out of the public repo, then reflect consultation/experiment surfaces into the Tauri shell as `TASK-305` approaches.
 
 ## Notes

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -140,6 +140,33 @@ function Get-DispatchPromptDirectory {
     return Join-Path $ProjectDir '.winsmux\dispatch-prompts'
 }
 
+function ConvertTo-TaskPromptSlug {
+    param([AllowEmptyString()][string]$TaskSlug)
+
+    if ([string]::IsNullOrWhiteSpace($TaskSlug)) {
+        throw 'task slug is required'
+    }
+
+    $normalized = $TaskSlug.Trim().ToLowerInvariant()
+    $normalized = [regex]::Replace($normalized, '[^a-z0-9._-]+', '-')
+    $normalized = [regex]::Replace($normalized, '-{2,}', '-').Trim('-')
+    if ([string]::IsNullOrWhiteSpace($normalized)) {
+        throw "task slug '$TaskSlug' does not contain any supported characters"
+    }
+
+    return $normalized
+}
+
+function Get-TaskPromptPath {
+    param(
+        [Parameter(Mandatory = $true)][string]$TaskSlug,
+        [string]$ProjectDir = (Get-Location).Path
+    )
+
+    $normalized = ConvertTo-TaskPromptSlug -TaskSlug $TaskSlug
+    return Join-Path (Join-Path $ProjectDir '.winsmux') ("task-{0}.md" -f $normalized)
+}
+
 function New-DispatchPromptFile {
     param(
         [Parameter(Mandatory = $true)][string]$Content,
@@ -155,6 +182,25 @@ function New-DispatchPromptFile {
     $fileName = '{0}-{1}.txt' -f $Prefix, ([guid]::NewGuid().ToString('N'))
     $path = Join-Path $promptDir $fileName
     Write-ClmSafeTextFile -Path $path -Content $Content
+    return $path
+}
+
+function New-TaskPromptFile {
+    param(
+        [Parameter(Mandatory = $true)][string]$Content,
+        [Parameter(Mandatory = $true)][string]$TaskSlug,
+        [string]$ProjectDir = (Get-Location).Path
+    )
+
+    $path = Get-TaskPromptPath -TaskSlug $TaskSlug -ProjectDir $ProjectDir
+    $parent = Split-Path -Parent $path
+    if (-not (Test-Path -LiteralPath $parent -PathType Container)) {
+        New-Item -ItemType Directory -Path $parent -Force | Out-Null
+    }
+
+    $tempPath = '{0}.tmp' -f $path
+    Write-ClmSafeTextFile -Path $tempPath -Content $Content
+    Move-Item -LiteralPath $tempPath -Destination $path -Force
     return $path
 }
 
@@ -436,7 +482,8 @@ function Resolve-SendDispatchPayload {
         [Parameter(Mandatory = $true)][string]$Text,
         [string]$ProjectDir = (Get-Location).Path,
         [int]$LengthLimit = 4000,
-        [string]$PromptTransport = 'argv'
+        [string]$PromptTransport = 'argv',
+        [string]$TaskSlug = ''
     )
 
     $resolvedPromptTransport = Resolve-SupportedPromptTransport -PromptTransport $PromptTransport
@@ -449,6 +496,19 @@ function Resolve-SendDispatchPayload {
         LengthLimit     = $LengthLimit
         FallbackMode    = 'pointer'
         PromptTransport = $resolvedPromptTransport
+        TaskSlug        = ''
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($TaskSlug)) {
+        $normalizedTaskSlug = ConvertTo-TaskPromptSlug -TaskSlug $TaskSlug
+        $promptPath = New-TaskPromptFile -Content $Text -TaskSlug $normalizedTaskSlug -ProjectDir $ProjectDir
+        $payload['PromptPath'] = $promptPath
+        $payload['PromptReference'] = Get-DispatchPromptReference -PromptPath $promptPath -ProjectDir $ProjectDir
+        $payload['IsFileBacked'] = $true
+        $payload['TextToSend'] = New-SendDispatchPointerText -PromptPath $promptPath -ProjectDir $ProjectDir
+        $payload['TaskSlug'] = $normalizedTaskSlug
+        $payload['FallbackMode'] = 'task_file'
+        return $payload
     }
 
     if ($resolvedPromptTransport -eq 'argv' -and $Text.Length -le $LengthLimit) {
@@ -486,6 +546,7 @@ function Resolve-SendTransportPlan {
         [string]$ProjectDir = (Get-Location).Path,
         [int]$LengthLimit = 4000,
         [string]$PromptTransport = 'argv',
+        [string]$TaskSlug = '',
         [bool]$ExecMode = $false,
         [string]$LaunchDir,
         [string]$GitWorktreeDir,
@@ -494,7 +555,7 @@ function Resolve-SendTransportPlan {
 
     $resolvedPromptTransport = Resolve-SupportedPromptTransport -PromptTransport $PromptTransport
     if (-not $ExecMode) {
-        $payload = Resolve-SendDispatchPayload -Text $Text -ProjectDir $ProjectDir -LengthLimit $LengthLimit -PromptTransport $resolvedPromptTransport
+        $payload = Resolve-SendDispatchPayload -Text $Text -ProjectDir $ProjectDir -LengthLimit $LengthLimit -PromptTransport $resolvedPromptTransport -TaskSlug $TaskSlug
         return [ordered]@{
             Mode            = if ($payload['IsFileBacked']) { 'pointer' } else { 'inline' }
             TextToSend      = [string]$payload['TextToSend']
@@ -505,11 +566,19 @@ function Resolve-SendTransportPlan {
             LengthLimit     = [int]$payload['LengthLimit']
             FallbackMode    = [string]$payload['FallbackMode']
             PromptTransport = [string]$payload['PromptTransport']
+            TaskSlug        = [string]$payload['TaskSlug']
             ExecInstruction = $null
         }
     }
 
-    $promptPath = New-DispatchPromptFile -Content $Text -ProjectDir $ProjectDir -Prefix 'send-command'
+    $normalizedTaskSlug = ''
+    $promptPath = $null
+    if (-not [string]::IsNullOrWhiteSpace($TaskSlug)) {
+        $normalizedTaskSlug = ConvertTo-TaskPromptSlug -TaskSlug $TaskSlug
+        $promptPath = New-TaskPromptFile -Content $Text -TaskSlug $normalizedTaskSlug -ProjectDir $ProjectDir
+    } else {
+        $promptPath = New-DispatchPromptFile -Content $Text -ProjectDir $ProjectDir -Prefix 'send-command'
+    }
     $outputPath = '{0}.last-message.txt' -f $promptPath
     $promptInstruction = 'Read the prompt file at {0} and follow its instructions' -f $promptPath
     $execInstruction = 'codex exec --sandbox danger-full-access -C {0} --add-dir {1} -o {2} -m {3} {4}' -f `
@@ -529,6 +598,7 @@ function Resolve-SendTransportPlan {
         LengthLimit     = $LengthLimit
         FallbackMode    = 'exec_file'
         PromptTransport = $resolvedPromptTransport
+        TaskSlug        = $normalizedTaskSlug
         ExecInstruction = $execInstruction
     }
 }
@@ -1978,8 +2048,29 @@ function Invoke-Send {
     if (-not $Target) { Stop-WithError "usage: winsmux send <target> <text>" }
     if (-not $Rest -or $Rest.Count -eq 0) { Stop-WithError "usage: winsmux send <target> <text>" }
 
+    $taskSlug = ''
+    $messageParts = New-Object System.Collections.Generic.List[string]
+    for ($index = 0; $index -lt $Rest.Count; $index++) {
+        $token = [string]$Rest[$index]
+        if ($token -eq '--task-slug') {
+            if ($index + 1 -ge $Rest.Count) {
+                Stop-WithError "--task-slug requires a value"
+            }
+
+            $index++
+            $taskSlug = [string]$Rest[$index]
+            continue
+        }
+
+        $messageParts.Add($token) | Out-Null
+    }
+
+    if ($messageParts.Count -lt 1) {
+        Stop-WithError "usage: winsmux send <target> <text>"
+    }
+
     # Normalize Git Bash /tmp paths before dispatching PowerShell-oriented commands.
-    $text = Normalize-DispatchText -Text ($Rest -join ' ')
+    $text = Normalize-DispatchText -Text ($messageParts -join ' ')
     $projectDir = (Get-Location).Path
     $paneId = Resolve-Target $Target
     $paneId = Confirm-Target $paneId
@@ -2042,6 +2133,7 @@ function Invoke-Send {
         -ProjectDir $projectDir `
         -LengthLimit 4000 `
         -PromptTransport ([string]$agentConfig.PromptTransport) `
+        -TaskSlug $taskSlug `
         -ExecMode:$execMode `
         -LaunchDir ([string]$context.LaunchDir) `
         -GitWorktreeDir ([string]$context.GitWorktreeDir) `

--- a/tests/psmux-bridge.Tests.ps1
+++ b/tests/psmux-bridge.Tests.ps1
@@ -4668,6 +4668,28 @@ Describe 'winsmux send dispatch payload' {
         (Get-Content -LiteralPath $payload['PromptPath'] -Raw -Encoding UTF8).TrimEnd("`r", "`n") | Should -BeExactly 'Write-Host short'
     }
 
+    It 'normalizes task prompt slugs and writes a stable task prompt file when task_slug is supplied' {
+        (ConvertTo-TaskPromptSlug -TaskSlug ' Cache Drift / Build ') | Should -Be 'cache-drift-build'
+
+        $payload = Resolve-SendDispatchPayload -Text 'Write-Host short' -ProjectDir $script:sendTempRoot -LengthLimit 4000 -TaskSlug ' Cache Drift / Build '
+
+        $payload['TaskSlug'] | Should -Be 'cache-drift-build'
+        $payload['IsFileBacked'] | Should -Be $true
+        $payload['FallbackMode'] | Should -Be 'task_file'
+        $payload['PromptPath'] | Should -Be (Join-Path $script:sendTempRoot '.winsmux\task-cache-drift-build.md')
+        $payload['PromptReference'] | Should -Be '.winsmux/task-cache-drift-build.md'
+        (Get-Content -LiteralPath $payload['PromptPath'] -Raw -Encoding UTF8).TrimEnd("`r", "`n") | Should -BeExactly 'Write-Host short'
+    }
+
+    It 'overwrites the same task prompt path when the same task_slug is reused' {
+        $first = Resolve-SendDispatchPayload -Text 'first prompt' -ProjectDir $script:sendTempRoot -LengthLimit 4000 -TaskSlug 'cache-drift'
+        $second = Resolve-SendDispatchPayload -Text 'second prompt' -ProjectDir $script:sendTempRoot -LengthLimit 4000 -TaskSlug 'cache-drift'
+
+        $first['PromptPath'] | Should -Be $second['PromptPath']
+        $second['PromptReference'] | Should -Be '.winsmux/task-cache-drift.md'
+        (Get-Content -LiteralPath $second['PromptPath'] -Raw -Encoding UTF8).TrimEnd("`r", "`n") | Should -BeExactly 'second prompt'
+    }
+
     It 'rejects unsupported prompt transport values' {
         { Resolve-SendDispatchPayload -Text 'Write-Host short' -ProjectDir $script:sendTempRoot -LengthLimit 4000 -PromptTransport 'stdin' } | Should -Throw '*prompt_transport*'
     }


### PR DESCRIPTION
## Summary
- add stable task prompt helpers so file-backed handoff can target deterministic `.winsmux/task-{slug}.md` artifacts
- extend send transport planning to reuse task prompt files when `--task-slug` is supplied
- add regression coverage for slug normalization, stable relative refs, and overwrite semantics

## Validation
- Invoke-Pester tests/psmux-bridge.Tests.ps1
  - 135/135 PASS
- git diff --check

## Review gate
- fresh reviewer waited twice and returned no result yet
- fallback gate used: manual diff review + focused regression + diff check
