### PR TITLE
feat(review): require design-impact checklist

### DIFF
--- a/.github/workflows/release-core.yml
+++ b/.github/workflows/release-core.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Generate Release Body
         shell: pwsh
         run: ./scripts/generate-release-notes.ps1 -Version "${{ github.ref_name }}" -OutputPath "release/release-body.md"
-      - uses: softprops/action-gh-release@v2
+      - uses: softprops/action-gh-release@v3
         with:
           body_path: release/release-body.md
           files: release/*

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -1,6 +1,6 @@
 # Handoff
 
-> Updated: 2026-04-12T14:12:00+09:00
+> Updated: 2026-04-12T14:55:00+09:00
 > Source of truth: this file
 
 ## Current state
@@ -14,6 +14,7 @@
 - `v0.20.0` is released.
 - `v0.20.1` is now fully implemented at `100% (7/7)` in the external planning backlog/roadmap after rebaselining the shipped transport/ledger slices and moving the remaining SQLite FTS5 + stdin parity work into follow-up tasks.
 - `v0.20.1` is released at [v0.20.1](https://github.com/Sora-bluesky/winsmux/releases/tag/v0.20.1); release workflow run `24299025847` published `winsmux-x64.exe`, `winsmux-arm64.exe`, and `SHA256SUMS`.
+- `v0.20.2` is now the active implementation milestone, starting with reviewer-governance hardening and release-workflow maintenance.
 - Planning source of truth is externalized outside the public repository and syncs automatically into the private planning root.
 - `v0.21.x` private planning is aligned to a conversation-first Tauri operator shell, with Codex-App-like shell rules reflected in Figma and backlog notes.
 - `v0.24.x` private planning is split into schema, ledger, machine contract, cutover, and canary phases for Rust runtime convergence before `v1.0.0`.
@@ -45,6 +46,9 @@
 - Re-synced the external roadmap so `v0.20.1: Run Transport & Event Ledger` now reads as `100% (7/7)` and is ready for release preparation.
 - Drafted and saved the `v0.20.1` release notes and X thread under `C:\Users\komei\iCloudDrive\iCloud~md~obsidian\MainVault\ChangeLogs\winsmux\v0.20.1\`.
 - Tagged and published `v0.20.1`, then replaced the workflow-generated body with the curated Codex-style release notes and removed the extra `release-body.md` asset so the public release ships only `winsmux-x64.exe`, `winsmux-arm64.exe`, and `SHA256SUMS`.
+- Started the first `v0.20.2` slice for `TASK-207` by strengthening `winsmux-core/agents/reviewer.sh` so reviewer prompts must explicitly audit downstream design impact, replacement coverage, and orphaned artifacts instead of limiting review to local diff correctness.
+- Updated `winsmux-core/agents/AGENTS.md` to keep the reviewer-template docs aligned with the stronger audit contract, and added a narrow regression in `tests/psmux-bridge.Tests.ps1` that locks the new review-checklist language in place.
+- Updated `.github/workflows/release-core.yml` from `softprops/action-gh-release@v2` to `@v3` to remove the Node 20 deprecation path that still appeared during the `v0.20.1` release workflow.
 - Merged `TASK-287` via PR [#393](https://github.com/Sora-bluesky/winsmux/pull/393), adding the keyboard-first operator command bar (`Ctrl/Cmd+K`) with quick actions, IME-safe input handling, focus restore, and accessible active-option semantics.
 - Merged `TASK-298` via PR [#394](https://github.com/Sora-bluesky/winsmux/pull/394), rewriting `README.ja.md` to match the public operator model, shrinking maintainer-only planning readmes into internal stubs, and making tracked public config/docs safer for external users.
 - Re-synced the external planning backlog/roadmap after PR [#394](https://github.com/Sora-bluesky/winsmux/pull/394), marking `TASK-298` as done so `v0.20.0` now shows `100% (12/12)`.
@@ -133,12 +137,14 @@
 - Current local `TASK-188` task-prompt-file slice passes `git diff --check` aside from benign LF->CRLF warnings on the edited files.
 - PR [#400](https://github.com/Sora-bluesky/winsmux/pull/400) merged cleanly and the repo returned to `main == origin/main`.
 - `v0.20.1` release workflow run `24299025847` completed successfully after tag push.
+- Current local `TASK-207` + release-workflow maintenance slice passes focused regression: `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `136/136 PASS`.
+- Current local `TASK-207` + release-workflow maintenance slice passes `git diff --check` aside from benign LF->CRLF warnings on edited files.
 
 ## Next actions
 
-1. Continue with `v0.20.2` verification/security work, keeping `TASK-306` and `TASK-307` as explicit follow-up debt rather than sneaking them into unrelated milestones.
-2. Keep the external planning sync flow user-visible but out of the public repo, then reflect consultation/experiment surfaces into the Tauri shell as `TASK-305` approaches.
-3. Update the release workflow away from `softprops/action-gh-release@v2` or force Node 24 explicitly before the Node 20 deprecation window becomes a blocker.
+1. Land the `TASK-207` reviewer-checklist slice and close the `softprops/action-gh-release` Node 20 warning by merging the current release-workflow update.
+2. Continue with `v0.20.2` verification/security work, keeping `TASK-306` and `TASK-307` as explicit follow-up debt rather than sneaking them into unrelated milestones.
+3. Keep the external planning sync flow user-visible but out of the public repo, then reflect consultation/experiment surfaces into the Tauri shell as `TASK-305` approaches.
 
 ## Notes
 

--- a/tests/psmux-bridge.Tests.ps1
+++ b/tests/psmux-bridge.Tests.ps1
@@ -150,6 +150,20 @@ Describe 'Assert-Role' {
     }
 }
 
+Describe 'reviewer.sh prompt contract' {
+    It 'includes mandatory design-impact checklist items' {
+        $scriptPath = Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\agents\reviewer.sh'
+        $content = Get-Content -Path $scriptPath -Raw -Encoding UTF8
+
+        $content | Should -Match 'downstream behavior, workflow, or monitoring capability'
+        $content | Should -Match 'removed or changed capability replaced elsewhere'
+        $content | Should -Match 'orphaned artifacts such as dead mocks'
+        $content | Should -Match 'design impact'
+        $content | Should -Match 'replacement check'
+        $content | Should -Match 'orphaned artifacts'
+    }
+}
+
 Describe 'Get-BridgeSettings' {
     BeforeAll {
         . (Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\settings.ps1')

--- a/winsmux-core/agents/AGENTS.md
+++ b/winsmux-core/agents/AGENTS.md
@@ -11,7 +11,7 @@ This directory contains bash wrappers that generate fixed user prompts for winsm
 
 - `reviewer.sh`
   - Purpose: emit a Reviewer prompt for diff-based review without editing code.
-  - Guardrails: requires `WORKTREE`, tells the agent to `cd` into it, review `git diff`, and explicitly check for security issues.
+  - Guardrails: requires `WORKTREE`, tells the agent to `cd` into it, review `git diff`, explicitly check for security issues, and always audit downstream design impact / replacement coverage / orphaned artifacts.
   - Completion markers: `REVIEW_PASS` or `REVIEW_FAIL`
   - Optional env var: `DIFF_BASE` to override the diff target. Defaults to `HEAD`.
   - Safety contract for `DIFF_BASE`: it must be a trusted, single-line Git diff target such as `HEAD`, `HEAD~1`, or `origin/main...HEAD`. Do not pass shell fragments, command substitutions, or newline-delimited content. The script renders `DIFF_BASE` as shell-escaped display text only.

--- a/winsmux-core/agents/reviewer.sh
+++ b/winsmux-core/agents/reviewer.sh
@@ -81,12 +81,20 @@ printf '%s\n' "- Inspect the current diff with: git diff $diff_base_display"
 cat <<'PROMPT'
 - Review for correctness, regressions, missing verification, and security issues.
 - Call out any credential exposure, injection risks, auth or authz mistakes, path handling issues, or unsafe shell usage.
+- Explicitly evaluate design impact, not just local diff correctness:
+  - What downstream behavior, workflow, or monitoring capability does this change disable or alter?
+  - Was any removed or changed capability replaced elsewhere, or does it create a blind spot?
+  - Are there orphaned artifacts such as dead mocks, stale helpers, or unused state transitions that indicate an incomplete change?
+- Separate direct code issues from architecture or operational risks.
 - Do not edit code during this review.
 
 Respond with:
 - verdict
 - findings
 - security review
+- design impact
+- replacement check
+- orphaned artifacts
 - recommended follow-ups
 
 If there are no blocking findings, end with exactly:


### PR DESCRIPTION
## Summary
- require reviewer prompts to audit downstream design impact, replacement coverage, and orphaned artifacts
- add a narrow regression test that locks the new reviewer prompt contract
- bump \\softprops/action-gh-release\\ to \\3\\ to remove the Node 20 deprecation path in the release workflow

## Validation
- Invoke-Pester tests/psmux-bridge.Tests.ps1
- git diff --check

## Review gate
- fresh reviewer timed out with no result yet
- fallback used: manual diff review + passing validation
