### PR TITLE
feat(review): persist mandatory review scope contract

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -84,4 +84,10 @@ The current `winsmux-app` shell work tracks these Codex-derived areas most close
 - footer/status-lane affordances
 - settings/menu surface affordances
 
+### Adaptation guardrails
+
+Codex-derived UI reuse in winsmux follows the active release-train acceptance rules for utility-first surfaces, real-data-first release paths, minimal chrome, and Playwright viewport verification evidence recorded in backlog notes, pull requests, or handoff.
+
+These are project adaptation guardrails, not additional license terms.
+
 This notice covers attribution and provenance tracking. It does not imply that winsmux reproduces Codex verbatim end-to-end.

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -1,6 +1,6 @@
 # Handoff
 
-> Updated: 2026-04-12T14:55:00+09:00
+> Updated: 2026-04-12T18:25:00+09:00
 > Source of truth: this file
 
 ## Current state
@@ -15,6 +15,7 @@
 - `v0.20.1` is now fully implemented at `100% (7/7)` in the external planning backlog/roadmap after rebaselining the shipped transport/ledger slices and moving the remaining SQLite FTS5 + stdin parity work into follow-up tasks.
 - `v0.20.1` is released at [v0.20.1](https://github.com/Sora-bluesky/winsmux/releases/tag/v0.20.1); release workflow run `24299025847` published `winsmux-x64.exe`, `winsmux-arm64.exe`, and `SHA256SUMS`.
 - `v0.20.2` is now the active implementation milestone, starting with reviewer-governance hardening and release-workflow maintenance.
+- `v0.20.2` remains the active implementation milestone; `TASK-207` is merged and the next in-flight slice is `TASK-210` on branch `codex/task210-review-scope-contract-20260412`.
 - Planning source of truth is externalized outside the public repository and syncs automatically into the private planning root.
 - `v0.21.x` private planning is aligned to a conversation-first Tauri operator shell, with Codex-App-like shell rules reflected in Figma and backlog notes.
 - `v0.24.x` private planning is split into schema, ledger, machine contract, cutover, and canary phases for Rust runtime convergence before `v1.0.0`.
@@ -49,6 +50,9 @@
 - Started the first `v0.20.2` slice for `TASK-207` by strengthening `winsmux-core/agents/reviewer.sh` so reviewer prompts must explicitly audit downstream design impact, replacement coverage, and orphaned artifacts instead of limiting review to local diff correctness.
 - Updated `winsmux-core/agents/AGENTS.md` to keep the reviewer-template docs aligned with the stronger audit contract, and added a narrow regression in `tests/psmux-bridge.Tests.ps1` that locks the new review-checklist language in place.
 - Updated `.github/workflows/release-core.yml` from `softprops/action-gh-release@v2` to `@v3` to remove the Node 20 deprecation path that still appeared during the `v0.20.1` release workflow.
+- Started the `TASK-210` runtime slice on `codex/task210-review-scope-contract-20260412`, adding `request.review_contract` to `review-request`, surfacing that contract through `explain/result_packet`, and rejecting `review-approve` / `review-fail` when a pending request lacks the mandatory scope contract.
+- Updated external planning notes so `TASK-210`, `TASK-272`, `TASK-302`, `TASK-303`, `TASK-304`, and `TASK-305` explicitly encode Codex-derived UI acceptance rules (`utility-first`, `real-data-first`, `minimal chrome`, `calm hierarchy`, `one accent`), and added `TASK-308` for Playwright-based desktop viewport / overlap / drawer verification.
+- Updated [THIRD_PARTY_NOTICES.md](../THIRD_PARTY_NOTICES.md) with a short `Adaptation guardrails` bridge so Codex-derived UI reuse points back to release-train acceptance criteria without turning the notice file into additional license terms.
 - Merged `TASK-287` via PR [#393](https://github.com/Sora-bluesky/winsmux/pull/393), adding the keyboard-first operator command bar (`Ctrl/Cmd+K`) with quick actions, IME-safe input handling, focus restore, and accessible active-option semantics.
 - Merged `TASK-298` via PR [#394](https://github.com/Sora-bluesky/winsmux/pull/394), rewriting `README.ja.md` to match the public operator model, shrinking maintainer-only planning readmes into internal stubs, and making tracked public config/docs safer for external users.
 - Re-synced the external planning backlog/roadmap after PR [#394](https://github.com/Sora-bluesky/winsmux/pull/394), marking `TASK-298` as done so `v0.20.0` now shows `100% (12/12)`.
@@ -139,12 +143,15 @@
 - `v0.20.1` release workflow run `24299025847` completed successfully after tag push.
 - Current local `TASK-207` + release-workflow maintenance slice passes focused regression: `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `136/136 PASS`.
 - Current local `TASK-207` + release-workflow maintenance slice passes `git diff --check` aside from benign LF->CRLF warnings on edited files.
+- Current local `TASK-210` runtime-contract slice passes focused regression: `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `136/136 PASS`.
+- Current local `TASK-210` runtime-contract slice passes focused regression: `Invoke-Pester tests/Integration.GateEnforcement.Tests.ps1` -> `45/45 PASS`.
+- Current local `TASK-210` runtime-contract slice passes `git diff --check` aside from benign LF->CRLF warnings on edited files.
 
 ## Next actions
 
-1. Land the `TASK-207` reviewer-checklist slice and close the `softprops/action-gh-release` Node 20 warning by merging the current release-workflow update.
-2. Continue with `v0.20.2` verification/security work, keeping `TASK-306` and `TASK-307` as explicit follow-up debt rather than sneaking them into unrelated milestones.
-3. Keep the external planning sync flow user-visible but out of the public repo, then reflect consultation/experiment surfaces into the Tauri shell as `TASK-305` approaches.
+1. Run a fresh reviewer on the `TASK-210` slice, then stage / commit / push / open the PR if the fallback gate still looks clean.
+2. After `TASK-210`, continue `v0.20.2` with `TASK-272` so verification output becomes utility-first and structured instead of prompt-only.
+3. Keep `TASK-308` as the explicit `v0.22.1` gate for Playwright viewport / overlap / drawer verification when Codex-derived desktop surfaces become release-bound.
 
 ## Notes
 

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -1224,6 +1224,53 @@ function New-ReviewerStateRecord {
     return $record
 }
 
+function New-ReviewContractRecord {
+    $requiredScope = @(
+        'design_impact'
+        'replacement_coverage'
+        'orphaned_artifacts'
+    )
+
+    return [ordered]@{
+        version           = 1
+        source_task       = 'TASK-210'
+        issue_ref         = '#315'
+        style             = 'utility_first'
+        required_scope    = $requiredScope
+        checklist_labels  = @(
+            'design impact'
+            'replacement coverage'
+            'orphaned artifacts'
+        )
+        rationale         = 'Review requests must audit downstream design impact, replacement coverage, and orphaned artifacts as part of the runtime contract.'
+    }
+}
+
+function Test-ReviewContractPresent {
+    param(
+        [AllowNull()]$Request
+    )
+
+    if ($null -eq $Request -or -not ($Request -is [System.Collections.IDictionary])) {
+        return $false
+    }
+
+    if (-not $Request.Contains('review_contract')) {
+        return $false
+    }
+
+    $contract = $Request['review_contract']
+    if ($null -eq $contract -or -not ($contract -is [System.Collections.IDictionary])) {
+        return $false
+    }
+
+    if (-not $contract.Contains('required_scope')) {
+        return $false
+    }
+
+    return @($contract['required_scope']).Count -gt 0
+}
+
 # --- Helper: Labels ---
 function Get-Labels {
     if (Test-Path $LabelsFile) {
@@ -3496,6 +3543,14 @@ function New-RunResultPacket {
         $reviewRecommendation = [string]$Run.review_state
     }
 
+    $reviewContract = $null
+    if ($ReviewState -is [System.Collections.IDictionary] -and $ReviewState.Contains('request')) {
+        $reviewRequest = $ReviewState['request']
+        if ($reviewRequest -is [System.Collections.IDictionary] -and $reviewRequest.Contains('review_contract')) {
+            $reviewContract = $reviewRequest['review_contract']
+        }
+    }
+
     return [ordered]@{
         run_id                = [string]$Run.run_id
         status                = $status
@@ -3513,6 +3568,7 @@ function New-RunResultPacket {
         consultation_summary  = $ConsultationSummary
         action_items          = @($Run.action_items)
         review_state          = $ReviewState
+        review_contract       = $reviewContract
         recent_events         = @($RecentEvents)
     }
 }
@@ -4065,6 +4121,15 @@ function Get-ExplainPayload {
     }
     if (-not [string]::IsNullOrWhiteSpace([string]$run.review_state)) {
         $reasons.Add("review_state=$([string]$run.review_state)") | Out-Null
+    }
+    if ($reviewState -is [System.Collections.IDictionary] -and $reviewState.Contains('request')) {
+        $reviewRequest = $reviewState['request']
+        if ($reviewRequest -is [System.Collections.IDictionary] -and $reviewRequest.Contains('review_contract')) {
+            $reviewContract = $reviewRequest['review_contract']
+            if ($reviewContract -is [System.Collections.IDictionary] -and $reviewContract.Contains('required_scope')) {
+                $reasons.Add("review_contract=$(([string[]]$reviewContract['required_scope']) -join ',')") | Out-Null
+            }
+        }
     }
     if (-not [string]::IsNullOrWhiteSpace([string]$run.last_event)) {
         $reasons.Add("last_event=$([string]$run.last_event)") | Out-Null
@@ -5035,6 +5100,7 @@ function Invoke-ReviewRequest {
         target_reviewer_pane_id = $context.PaneId
         target_reviewer_label   = $context.Label
         target_reviewer_role    = $context.Role
+        review_contract         = New-ReviewContractRecord
         dispatched_at           = $timestamp
     }
 
@@ -5082,6 +5148,9 @@ function Invoke-ReviewApprove {
     if ($null -eq $request -or $status -ne 'PENDING') {
         Stop-WithError "review request pending for $branch was not found. Run: winsmux review-request"
     }
+    if (-not (Test-ReviewContractPresent -Request $request)) {
+        Stop-WithError "pending review request for $branch is missing review_contract. Re-run: winsmux review-request"
+    }
 
     $requestPaneId = [string](Get-ReviewRequestTargetValue -Request $request -Name 'pane_id')
     $requestBranch = [string](Get-ReviewStatePropertyValue -InputObject $request -Name 'branch')
@@ -5107,8 +5176,9 @@ function Invoke-ReviewApprove {
         agent_name = [string]$env:WINSMUX_AGENT_NAME
     }
     $evidence = [ordered]@{
-        approved_at  = $timestamp
-        approved_via = 'winsmux review-approve'
+        approved_at             = $timestamp
+        approved_via            = 'winsmux review-approve'
+        review_contract_snapshot = Get-ReviewStatePropertyValue -InputObject $request -Name 'review_contract'
     }
 
     $state[$branch] = New-ReviewerStateRecord -Status 'PASS' -Request $request -Reviewer $reviewer -Evidence $evidence -UpdatedAt $timestamp
@@ -5148,6 +5218,9 @@ function Invoke-ReviewFail {
     if ($null -eq $request -or $status -ne 'PENDING') {
         Stop-WithError "review request pending for $branch was not found. Run: winsmux review-request"
     }
+    if (-not (Test-ReviewContractPresent -Request $request)) {
+        Stop-WithError "pending review request for $branch is missing review_contract. Re-run: winsmux review-request"
+    }
 
     $requestPaneId = [string](Get-ReviewRequestTargetValue -Request $request -Name 'pane_id')
     $requestBranch = [string](Get-ReviewStatePropertyValue -InputObject $request -Name 'branch')
@@ -5173,8 +5246,9 @@ function Invoke-ReviewFail {
         agent_name = [string]$env:WINSMUX_AGENT_NAME
     }
     $evidence = [ordered]@{
-        failed_at  = $timestamp
-        failed_via = 'winsmux review-fail'
+        failed_at               = $timestamp
+        failed_via              = 'winsmux review-fail'
+        review_contract_snapshot = Get-ReviewStatePropertyValue -InputObject $request -Name 'review_contract'
     }
 
     $state[$branch] = New-ReviewerStateRecord -Status 'FAIL' -Request $request -Reviewer $reviewer -Evidence $evidence -UpdatedAt $timestamp

--- a/tests/Integration.GateEnforcement.Tests.ps1
+++ b/tests/Integration.GateEnforcement.Tests.ps1
@@ -678,6 +678,10 @@ EOF
         $reviewState.'feature/review-gate'.reviewer.pane_id | Should -Be '%4'
         $reviewState.'feature/review-gate'.request.head_sha | Should -Not -BeNullOrEmpty
         $reviewState.'feature/review-gate'.request.target_reviewer_pane_id | Should -Be '%4'
+        $reviewState.'feature/review-gate'.request.review_contract.source_task | Should -Be 'TASK-210'
+        $reviewState.'feature/review-gate'.request.review_contract.style | Should -Be 'utility_first'
+        $reviewState.'feature/review-gate'.request.review_contract.required_scope | Should -Be @('design_impact', 'replacement_coverage', 'orphaned_artifacts')
+        $reviewState.'feature/review-gate'.evidence.review_contract_snapshot.required_scope | Should -Be @('design_impact', 'replacement_coverage', 'orphaned_artifacts')
 
         $result = & $script:InvokeOrchestraGate -RepoRoot $fixture.RepoRoot -ToolName 'Bash' -ToolInput @{
             command = 'git commit -m "feat: approved"'
@@ -781,5 +785,39 @@ EOF
         $approveResult = & $script:InvokeWinsmuxCore -RepoRoot $fixture.RepoRoot -Arguments @('review-approve') -Environment $reviewerEnv
         $approveResult.ExitCode | Should -Be 1
         $approveResult.StdErr | Should -Match 'review-request'
+    }
+
+    It 'rejects review-approve when the pending request is missing review_contract' {
+        $fixture = New-GateFixture
+        $script:FixtureRoot = $fixture.Root
+
+        $reviewStatePath = Join-Path $fixture.RepoRoot '.winsmux\review-state.json'
+        @'
+{
+  "feature/review-gate": {
+    "status": "PENDING",
+    "branch": "feature/review-gate",
+    "head_sha": "1111111111111111111111111111111111111111",
+    "request": {
+      "branch": "feature/review-gate",
+      "head_sha": "1111111111111111111111111111111111111111",
+      "target_reviewer_pane_id": "%4",
+      "target_reviewer_label": "reviewer-1",
+      "target_reviewer_role": "Reviewer"
+    }
+  }
+}
+'@ | Set-Content -LiteralPath $reviewStatePath -Encoding UTF8
+
+        $reviewerEnv = @{
+            WINSMUX_ROLE      = 'Reviewer'
+            WINSMUX_PANE_ID   = '%4'
+            WINSMUX_ROLE_MAP  = '{"%4":"Reviewer"}'
+            WINSMUX_AGENT_NAME = 'codex'
+        }
+
+        $approveResult = & $script:InvokeWinsmuxCore -RepoRoot $fixture.RepoRoot -Arguments @('review-approve') -Environment $reviewerEnv
+        $approveResult.ExitCode | Should -Be 1
+        $approveResult.StdErr | Should -Match 'missing review_contract'
     }
 }

--- a/tests/psmux-bridge.Tests.ps1
+++ b/tests/psmux-bridge.Tests.ps1
@@ -4390,7 +4390,18 @@ panes:
       "branch": "worktree-builder-1",
       "head_sha": "abc1234def5678",
       "target_reviewer_label": "reviewer-1",
-      "target_reviewer_pane_id": "%3"
+      "target_reviewer_pane_id": "%3",
+      "review_contract": {
+        "version": 1,
+        "source_task": "TASK-210",
+        "issue_ref": "#315",
+        "style": "utility_first",
+        "required_scope": [
+          "design_impact",
+          "replacement_coverage",
+          "orphaned_artifacts"
+        ]
+      }
     }
   }
 }
@@ -4449,7 +4460,11 @@ panes:
         $result.explanation.current_state.review_state | Should -Be 'PENDING'
         $result.explanation.reasons | Should -Contain 'task_state=in_progress'
         $result.explanation.reasons | Should -Contain 'review_state=PENDING'
+        $result.explanation.reasons | Should -Contain 'review_contract=design_impact,replacement_coverage,orphaned_artifacts'
         $result.review_state.status | Should -Be 'PENDING'
+        $result.review_state.request.review_contract.style | Should -Be 'utility_first'
+        $result.review_state.request.review_contract.source_task | Should -Be 'TASK-210'
+        $result.review_state.request.review_contract.required_scope | Should -Be @('design_impact', 'replacement_coverage', 'orphaned_artifacts')
         $result.result_packet.status | Should -Be 'in_progress'
         $result.result_packet.summary | Should -Be 'commander.review_requested'
         $result.result_packet.changed_files | Should -Be @('scripts/winsmux-core.ps1')
@@ -4457,6 +4472,8 @@ panes:
         $result.result_packet.head_sha | Should -Be 'abc1234def5678'
         $result.result_packet.next_action_hint | Should -Be 'approval_waiting'
         $result.result_packet.review_recommendation | Should -Be 'PENDING'
+        $result.result_packet.review_contract.style | Should -Be 'utility_first'
+        $result.result_packet.review_contract.required_scope | Should -Be @('design_impact', 'replacement_coverage', 'orphaned_artifacts')
         $result.result_packet.evidence_refs | Should -Be @('scripts/winsmux-core.ps1')
         $result.result_packet.observation_pack.packet_type | Should -Be 'observation_pack'
         $result.result_packet.consultation_packet.kind | Should -Be 'consult_result'


### PR DESCRIPTION
## Summary
- persist mandatory review scope in review-request state and enforce it on review-approve/review-fail
- surface the review contract through explain/result_packet for operator-facing runtime inspection
- reflect Codex-derived UI acceptance rules in planning/notices and add Playwright desktop verification follow-up tracking

## Validation
- Invoke-Pester tests/psmux-bridge.Tests.ps1
- Invoke-Pester tests/Integration.GateEnforcement.Tests.ps1
- git diff --check

## Review gate
- fresh reviewer waited twice and returned no result yet
- fallback gate used: manual diff review + passing validation