### PR TITLE
feat(runtime): surface verification and security summaries

### DIFF
--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -1,6 +1,6 @@
 # Handoff
 
-> Updated: 2026-04-12T18:25:00+09:00
+> Updated: 2026-04-12T20:05:00+09:00
 > Source of truth: this file
 
 ## Current state
@@ -14,8 +14,7 @@
 - `v0.20.0` is released.
 - `v0.20.1` is now fully implemented at `100% (7/7)` in the external planning backlog/roadmap after rebaselining the shipped transport/ledger slices and moving the remaining SQLite FTS5 + stdin parity work into follow-up tasks.
 - `v0.20.1` is released at [v0.20.1](https://github.com/Sora-bluesky/winsmux/releases/tag/v0.20.1); release workflow run `24299025847` published `winsmux-x64.exe`, `winsmux-arm64.exe`, and `SHA256SUMS`.
-- `v0.20.2` is now the active implementation milestone, starting with reviewer-governance hardening and release-workflow maintenance.
-- `v0.20.2` remains the active implementation milestone; `TASK-207` is merged and the next in-flight slice is `TASK-210` on branch `codex/task210-review-scope-contract-20260412`.
+- `v0.20.2` is the active implementation milestone; `TASK-207`, `TASK-210`, `TASK-272`, `TASK-273`, and `TASK-274` are implemented locally, and the closing PR slice is in progress on `codex/v0202-verify-security-summary-20260412`.
 - Planning source of truth is externalized outside the public repository and syncs automatically into the private planning root.
 - `v0.21.x` private planning is aligned to a conversation-first Tauri operator shell, with Codex-App-like shell rules reflected in Figma and backlog notes.
 - `v0.24.x` private planning is split into schema, ledger, machine contract, cutover, and canary phases for Rust runtime convergence before `v1.0.0`.
@@ -53,6 +52,12 @@
 - Started the `TASK-210` runtime slice on `codex/task210-review-scope-contract-20260412`, adding `request.review_contract` to `review-request`, surfacing that contract through `explain/result_packet`, and rejecting `review-approve` / `review-fail` when a pending request lacks the mandatory scope contract.
 - Updated external planning notes so `TASK-210`, `TASK-272`, `TASK-302`, `TASK-303`, `TASK-304`, and `TASK-305` explicitly encode Codex-derived UI acceptance rules (`utility-first`, `real-data-first`, `minimal chrome`, `calm hierarchy`, `one accent`), and added `TASK-308` for Playwright-based desktop viewport / overlap / drawer verification.
 - Updated [THIRD_PARTY_NOTICES.md](../THIRD_PARTY_NOTICES.md) with a short `Adaptation guardrails` bridge so Codex-derived UI reuse points back to release-train acceptance criteria without turning the notice file into additional license terms.
+- Started the `v0.20.2` closing slice on `codex/v0202-verify-security-summary-20260412`, wiring structured verification packets, run-scoped security verdicts/policies, and digest event summaries into the runtime surfaces that back `runs`, `digest`, `explain`, and one-shot orchestration.
+- Extended [winsmux-core/scripts/team-pipeline.ps1](../winsmux-core/scripts/team-pipeline.ps1) so verify stages emit `VERIFY_PASS / VERIFY_FAIL / VERIFY_PARTIAL`, produce utility-first verification packets, and surface security-block decisions as explicit blocked verdicts instead of prompt-only text.
+- Extended [scripts/winsmux-core.ps1](../scripts/winsmux-core.ps1) so `runs`, `result_packet`, `run_packet`, `digest --events`, and `explain` hydrate `verification_contract`, `verification_result`, `security_policy`, and `security_verdict` from ledger events and manifest context.
+- Extended [winsmux-core/scripts/pane-control.ps1](../winsmux-core/scripts/pane-control.ps1) and [winsmux-core/scripts/pane-status.ps1](../winsmux-core/scripts/pane-status.ps1) so manifest `security_policy` survives into pane/run surfaces even when stored as a JSON-escaped scalar in `.winsmux/manifest.yaml`.
+- Extended [tests/psmux-bridge.Tests.ps1](../tests/psmux-bridge.Tests.ps1) to cover structured verify parsing, blocked security verdicts, manifest security policy hydration, digest event summaries, and explain/runs packet projection; local focused regression now passes at `141/141`.
+- Fresh reviewer `Dirac` timed out with `no result yet` after a 30-second wait and was closed; fallback gate for this slice is `manual diff review + Invoke-Pester tests/psmux-bridge.Tests.ps1 + git diff --check`.
 - Merged `TASK-287` via PR [#393](https://github.com/Sora-bluesky/winsmux/pull/393), adding the keyboard-first operator command bar (`Ctrl/Cmd+K`) with quick actions, IME-safe input handling, focus restore, and accessible active-option semantics.
 - Merged `TASK-298` via PR [#394](https://github.com/Sora-bluesky/winsmux/pull/394), rewriting `README.ja.md` to match the public operator model, shrinking maintainer-only planning readmes into internal stubs, and making tracked public config/docs safer for external users.
 - Re-synced the external planning backlog/roadmap after PR [#394](https://github.com/Sora-bluesky/winsmux/pull/394), marking `TASK-298` as done so `v0.20.0` now shows `100% (12/12)`.
@@ -146,12 +151,14 @@
 - Current local `TASK-210` runtime-contract slice passes focused regression: `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `136/136 PASS`.
 - Current local `TASK-210` runtime-contract slice passes focused regression: `Invoke-Pester tests/Integration.GateEnforcement.Tests.ps1` -> `45/45 PASS`.
 - Current local `TASK-210` runtime-contract slice passes `git diff --check` aside from benign LF->CRLF warnings on edited files.
+- Current local `v0.20.2` closing slice passes focused regression: `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `141/141 PASS`.
+- Current local `v0.20.2` closing slice passes `git diff --check` aside from benign LF->CRLF warnings on edited files.
 
 ## Next actions
 
-1. Run a fresh reviewer on the `TASK-210` slice, then stage / commit / push / open the PR if the fallback gate still looks clean.
-2. After `TASK-210`, continue `v0.20.2` with `TASK-272` so verification output becomes utility-first and structured instead of prompt-only.
-3. Keep `TASK-308` as the explicit `v0.22.1` gate for Playwright viewport / overlap / drawer verification when Codex-derived desktop surfaces become release-bound.
+1. Stage / commit / push the `codex/v0202-verify-security-summary-20260412` closing slice, open the PR, and merge it once CI is green.
+2. Rebaseline external planning so `v0.20.2` reflects the shipped scope of `TASK-272`, `TASK-273`, and `TASK-274`, then sync the roadmap.
+3. Draft and publish the `v0.20.2` release, then update handoff to the released state.
 
 ## Notes
 

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -901,6 +901,7 @@ function Get-CurrentPaneManifestContext {
         ReviewState         = [string]$context.ReviewState
         Branch              = [string]$context.Branch
         HeadSha             = [string]$context.HeadSha
+        SecurityPolicy      = $context.SecurityPolicy
         ParentRunId         = [string]$context.ParentRunId
         Goal                = [string]$context.Goal
         TaskType            = [string]$context.TaskType
@@ -2941,6 +2942,7 @@ function Get-BoardPayload {
                 agent_role         = [string]$_.AgentRole
                 timeout_policy     = [string]$_.TimeoutPolicy
                 handoff_refs       = @($_.HandoffRefs)
+                security_policy    = $_.SecurityPolicy
             }
         }
     )
@@ -3175,6 +3177,8 @@ function Get-InboxActionableEventKind {
         'commander.review_failed'    { return 'review_failed' }
         'commander.blocked'          { return 'blocked' }
         'commander.commit_ready'     { return 'commit_ready' }
+        'pipeline.security.blocked'  { return 'blocked' }
+        'security.policy.blocked'    { return 'blocked' }
         default                      { return '' }
     }
 }
@@ -3468,6 +3472,85 @@ function Get-ConsultationSummaryFromPacket {
     }
 }
 
+function Get-LatestRunEventDataSnapshot {
+    param(
+        [object[]]$EventRecords = @(),
+        [string[]]$EventNames = @(),
+        [string[]]$DataFields = @()
+    )
+
+    $snapshot = [ordered]@{}
+    $matched = $false
+    foreach ($eventRecord in @($EventRecords | Sort-Object @{ Expression = { [string]$_.timestamp } }, @{ Expression = { [int]$_.line_number } })) {
+        $eventName = [string]$eventRecord['event']
+        if (@($EventNames).Count -gt 0 -and $eventName -notin $EventNames) {
+            continue
+        }
+
+        $data = $null
+        if ($eventRecord.Contains('data')) {
+            $data = $eventRecord['data']
+        }
+        if ($null -eq $data -or $data -isnot [System.Collections.IDictionary]) {
+            continue
+        }
+
+        foreach ($fieldName in @($DataFields)) {
+            if ($data.Contains($fieldName)) {
+                $snapshot[$fieldName] = $data[$fieldName]
+                $matched = $true
+            }
+        }
+    }
+
+    if (-not $matched) {
+        return $null
+    }
+
+    return $snapshot
+}
+
+function Get-VerificationSnapshotFromEventRecords {
+    param([object[]]$EventRecords = @())
+
+    $snapshot = Get-LatestRunEventDataSnapshot `
+        -EventRecords $EventRecords `
+        -EventNames @('pipeline.verify.pass', 'pipeline.verify.fail', 'pipeline.verify.partial') `
+        -DataFields @('verification_contract', 'verification_result')
+    if ($null -eq $snapshot) {
+        return $null
+    }
+
+    return [ordered]@{
+        verification_contract = if ($snapshot.Contains('verification_contract')) { $snapshot['verification_contract'] } else { $null }
+        verification_result   = if ($snapshot.Contains('verification_result')) { $snapshot['verification_result'] } else { $null }
+    }
+}
+
+function Get-SecurityVerdictFromEventRecords {
+    param([object[]]$EventRecords = @())
+
+    $snapshot = Get-LatestRunEventDataSnapshot `
+        -EventRecords $EventRecords `
+        -EventNames @('pipeline.security.blocked', 'security.policy.blocked') `
+        -DataFields @('stage', 'attempt', 'task', 'verdict', 'reason', 'advisory_mode', 'allow', 'block', 'next_action')
+    if ($null -eq $snapshot) {
+        return $null
+    }
+
+    return [ordered]@{
+        stage         = if ($snapshot.Contains('stage')) { [string]$snapshot['stage'] } else { '' }
+        attempt       = if ($snapshot.Contains('attempt')) { $snapshot['attempt'] } else { $null }
+        task          = if ($snapshot.Contains('task')) { [string]$snapshot['task'] } else { '' }
+        verdict       = if ($snapshot.Contains('verdict')) { [string]$snapshot['verdict'] } else { '' }
+        reason        = if ($snapshot.Contains('reason')) { [string]$snapshot['reason'] } else { '' }
+        advisory_mode = if ($snapshot.Contains('advisory_mode')) { [bool]$snapshot['advisory_mode'] } else { $false }
+        allow         = if ($snapshot.Contains('allow')) { @($snapshot['allow']) } else { @() }
+        block         = if ($snapshot.Contains('block')) { @($snapshot['block']) } else { @() }
+        next_action   = if ($snapshot.Contains('next_action')) { [string]$snapshot['next_action'] } else { '' }
+    }
+}
+
 function New-RunPacketFromRun {
     param([Parameter(Mandatory = $true)]$Run)
 
@@ -3499,6 +3582,10 @@ function New-RunPacketFromRun {
         pane_ids          = @($Run.pane_ids)
         roles             = @($Run.roles)
         changed_files     = @($Run.changed_files)
+        security_policy   = $Run.security_policy
+        security_verdict  = $Run.security_verdict
+        verification_contract = $Run.verification_contract
+        verification_result   = $Run.verification_result
         last_event        = [string]$Run.last_event
         last_event_at     = [string]$Run.last_event_at
     }
@@ -3569,6 +3656,10 @@ function New-RunResultPacket {
         action_items          = @($Run.action_items)
         review_state          = $ReviewState
         review_contract       = $reviewContract
+        verification_contract = $Run.verification_contract
+        verification_result   = $Run.verification_result
+        security_policy       = $Run.security_policy
+        security_verdict      = $Run.security_verdict
         recent_events         = @($RecentEvents)
     }
 }
@@ -3740,6 +3831,21 @@ function ConvertTo-RunEventRecord {
         command_hash         = if ($null -ne $experimentPacket) { [string]$experimentPacket.command_hash } else { '' }
         observation_pack     = $observationPack
         consultation_packet  = $consultationPacket
+        verification_contract = if ($null -ne $data -and $data -is [System.Collections.IDictionary] -and $data.Contains('verification_contract')) { $data['verification_contract'] } else { $null }
+        verification_result   = if ($null -ne $data -and $data -is [System.Collections.IDictionary] -and $data.Contains('verification_result')) { $data['verification_result'] } else { $null }
+        security_verdict      = if (($EventRecord['event'] -in @('pipeline.security.blocked', 'security.policy.blocked')) -and $null -ne $data -and $data -is [System.Collections.IDictionary]) {
+            [ordered]@{
+                stage         = if ($data.Contains('stage')) { [string]$data['stage'] } else { '' }
+                attempt       = if ($data.Contains('attempt')) { $data['attempt'] } else { $null }
+                task          = if ($data.Contains('task')) { [string]$data['task'] } else { '' }
+                verdict       = if ($data.Contains('verdict')) { [string]$data['verdict'] } else { '' }
+                reason        = if ($data.Contains('reason')) { [string]$data['reason'] } else { '' }
+                advisory_mode = if ($data.Contains('advisory_mode')) { [bool]$data['advisory_mode'] } else { $false }
+                allow         = if ($data.Contains('allow')) { @($data['allow']) } else { @() }
+                block         = if ($data.Contains('block')) { @($data['block']) } else { @() }
+                next_action   = if ($data.Contains('next_action')) { [string]$data['next_action'] } else { '' }
+            }
+        } else { $null }
     }
 }
 
@@ -3792,6 +3898,10 @@ function Get-RunsPayload {
                 timeout_policy     = [string]$pane.timeout_policy
                 handoff_refs       = [System.Collections.Generic.List[string]]::new()
                 experiment_packet  = $null
+                security_policy    = $pane.security_policy
+                security_verdict   = $null
+                verification_contract = $null
+                verification_result   = $null
             }
         }
 
@@ -3828,6 +3938,9 @@ function Get-RunsPayload {
         }
         if ([string]::IsNullOrWhiteSpace([string]$run.timeout_policy) -and -not [string]::IsNullOrWhiteSpace([string]$pane.timeout_policy)) {
             $run.timeout_policy = [string]$pane.timeout_policy
+        }
+        if ($null -eq $run.security_policy -and $null -ne $pane.security_policy) {
+            $run.security_policy = $pane.security_policy
         }
 
         if (-not [string]::IsNullOrWhiteSpace([string]$pane.label) -and -not $run.labels.Contains([string]$pane.label)) {
@@ -3921,6 +4034,16 @@ function Get-RunsPayload {
             }
 
             $run.experiment_packet = $experimentPacket
+            $verificationSnapshot = Get-VerificationSnapshotFromEventRecords -EventRecords $matchingEvents
+            if ($null -ne $verificationSnapshot) {
+                $run.verification_contract = $verificationSnapshot.verification_contract
+                $run.verification_result = $verificationSnapshot.verification_result
+            }
+
+            $securityVerdict = Get-SecurityVerdictFromEventRecords -EventRecords $matchingEvents
+            if ($null -ne $securityVerdict) {
+                $run.security_verdict = $securityVerdict
+            }
         }
     }
 
@@ -3965,6 +4088,10 @@ function Get-RunsPayload {
                 timeout_policy     = [string]$run.timeout_policy
                 handoff_refs       = @($run.handoff_refs)
                 experiment_packet  = $run.experiment_packet
+                security_policy    = $run.security_policy
+                security_verdict   = $run.security_verdict
+                verification_contract = $run.verification_contract
+                verification_result   = $run.verification_result
             }
         }
     )
@@ -4056,11 +4183,72 @@ function ConvertTo-EvidenceDigestItem {
         action_item_count  = @($Run.action_items).Count
         last_event         = [string]$Run.last_event
         last_event_at      = [string]$Run.last_event_at
+        verification_outcome = if ($null -ne $Run.verification_result) { [string]$Run.verification_result.outcome } else { '' }
+        security_blocked   = if ($null -ne $Run.security_verdict) { [string]$Run.security_verdict.verdict } else { '' }
         hypothesis         = if ($null -ne $experimentPacket) { [string]$experimentPacket.hypothesis } else { '' }
         confidence         = if ($null -ne $experimentPacket) { $experimentPacket.confidence } else { $null }
         observation_pack_ref = if ($null -ne $experimentPacket) { [string]$experimentPacket.observation_pack_ref } else { '' }
         consultation_ref   = if ($null -ne $experimentPacket) { [string]$experimentPacket.consultation_ref } else { '' }
     }
+}
+
+function ConvertTo-DigestSummaryEventItem {
+    param([Parameter(Mandatory = $true)]$EventRecord)
+
+    $kind = Get-InboxActionableEventKind -EventRecord $EventRecord
+    if ([string]::IsNullOrWhiteSpace($kind)) {
+        return $null
+    }
+
+    $data = $null
+    if ($EventRecord.Contains('data')) {
+        $data = $EventRecord['data']
+    }
+
+    $branch = [string]$EventRecord['branch']
+    $headSha = [string]$EventRecord['head_sha']
+    $taskId = ''
+    $runId = ''
+    $nextAction = ''
+    $changedFileCount = 0
+    if ($null -ne $data -and $data -is [System.Collections.IDictionary]) {
+        if ([string]::IsNullOrWhiteSpace($branch) -and $data.Contains('branch')) { $branch = [string]$data['branch'] }
+        if ([string]::IsNullOrWhiteSpace($headSha) -and $data.Contains('head_sha')) { $headSha = [string]$data['head_sha'] }
+        if ($data.Contains('task_id')) { $taskId = [string]$data['task_id'] }
+        if ($data.Contains('run_id')) { $runId = [string]$data['run_id'] }
+        if ($data.Contains('next_action')) { $nextAction = [string]$data['next_action'] }
+        if ($data.Contains('changed_file_count')) { $changedFileCount = [int]$data['changed_file_count'] }
+    }
+
+    return [ordered]@{
+        timestamp          = [string]$EventRecord['timestamp']
+        kind               = $kind
+        source_event       = [string]$EventRecord['event']
+        run_id             = $runId
+        task_id            = $taskId
+        label              = [string]$EventRecord['label']
+        pane_id            = [string]$EventRecord['pane_id']
+        role               = [string]$EventRecord['role']
+        message            = [string]$EventRecord['message']
+        next_action        = $nextAction
+        branch             = $branch
+        head_sha           = $headSha
+        head_short         = Get-ShortHeadSha -HeadSha $headSha
+        changed_file_count = $changedFileCount
+    }
+}
+
+function Get-DigestSummaryEventItems {
+    param([Parameter(Mandatory = $true)][object[]]$EventRecords)
+
+    return @(
+        foreach ($eventRecord in @($EventRecords)) {
+            $item = ConvertTo-DigestSummaryEventItem -EventRecord $eventRecord
+            if ($null -ne $item) {
+                $item
+            }
+        }
+    )
 }
 
 function Get-DigestPayload {
@@ -4136,6 +4324,12 @@ function Get-ExplainPayload {
     }
     foreach ($actionItem in @($run.action_items | Select-Object -First 3)) {
         $reasons.Add("action:$([string]$actionItem.kind)") | Out-Null
+    }
+    if ($null -ne $run.verification_result -and -not [string]::IsNullOrWhiteSpace([string]$run.verification_result.outcome)) {
+        $reasons.Add("verify=$([string]$run.verification_result.outcome)") | Out-Null
+    }
+    if ($null -ne $run.security_verdict -and -not [string]::IsNullOrWhiteSpace([string]$run.security_verdict.verdict)) {
+        $reasons.Add("security=$([string]$run.security_verdict.verdict)") | Out-Null
     }
 
     $evidenceDigest = ConvertTo-EvidenceDigestItem -Run $run
@@ -4241,6 +4435,25 @@ function Get-DigestDeltaItems {
     )
 }
 
+function Write-DigestEventStreamItem {
+    param(
+        [Parameter(Mandatory = $true)]$Item,
+        [switch]$Json
+    )
+
+    if ($Json) {
+        $Item | ConvertTo-Json -Compress -Depth 10 | Write-Output
+        return
+    }
+
+    Write-Output ("[{0}] {1} {2} ({3}) {4}" -f `
+        [string]$Item.timestamp, `
+        [string]$Item.kind, `
+        [string]$Item.label, `
+        [string]$Item.pane_id, `
+        [string]$Item.message)
+}
+
 function Write-DigestStreamItem {
     param(
         [Parameter(Mandatory = $true)]$Item,
@@ -4282,33 +4495,77 @@ function Invoke-Digest {
 
     $jsonOutput = $false
     $streamOutput = $false
+    $eventSummaryOutput = $false
 
     foreach ($token in $tokens) {
         switch ($token) {
             '--json'   { $jsonOutput = $true }
             '--stream' { $streamOutput = $true }
-            default    { Stop-WithError "usage: winsmux digest [--json] [--stream]" }
+            '--events' { $eventSummaryOutput = $true }
+            default    { Stop-WithError "usage: winsmux digest [--json] [--stream] [--events]" }
         }
     }
 
     $projectDir = (Get-Location).Path
     if ($streamOutput) {
-        $snapshot = Get-DigestPayload -ProjectDir $projectDir
-        foreach ($item in @($snapshot.items)) {
-            Write-DigestStreamItem -Item $item -Json:$jsonOutput
+        if ($eventSummaryOutput) {
+            $snapshotEvents = Get-DigestSummaryEventItems -EventRecords @(Get-BridgeEventRecords -ProjectDir $projectDir)
+            foreach ($item in @($snapshotEvents)) {
+                Write-DigestEventStreamItem -Item $item -Json:$jsonOutput
+            }
+        } else {
+            $snapshot = Get-DigestPayload -ProjectDir $projectDir
+            foreach ($item in @($snapshot.items)) {
+                Write-DigestStreamItem -Item $item -Json:$jsonOutput
+            }
         }
 
         $cursor = @(Get-BridgeEventRecords -ProjectDir $projectDir).Count
         while ($true) {
             $delta = Get-BridgeEventDelta -ProjectDir $projectDir -Cursor $cursor
             $cursor = [int]$delta.cursor
-            $items = Get-DigestDeltaItems -ProjectDir $projectDir -EventRecords @($delta.events)
+            $items = if ($eventSummaryOutput) {
+                Get-DigestSummaryEventItems -EventRecords @($delta.events)
+            } else {
+                Get-DigestDeltaItems -ProjectDir $projectDir -EventRecords @($delta.events)
+            }
             foreach ($item in @($items)) {
-                Write-DigestStreamItem -Item $item -Json:$jsonOutput
+                if ($eventSummaryOutput) {
+                    Write-DigestEventStreamItem -Item $item -Json:$jsonOutput
+                } else {
+                    Write-DigestStreamItem -Item $item -Json:$jsonOutput
+                }
             }
 
             Start-Sleep -Seconds 2
         }
+    }
+
+    if ($eventSummaryOutput) {
+        $items = Get-DigestSummaryEventItems -EventRecords @(Get-BridgeEventRecords -ProjectDir $projectDir)
+        $payload = [ordered]@{
+            generated_at = (Get-Date).ToString('o')
+            project_dir  = $projectDir
+            summary      = [ordered]@{
+                item_count = @($items).Count
+            }
+            items        = @($items)
+        }
+
+        if ($jsonOutput) {
+            $payload | ConvertTo-Json -Compress -Depth 10 | Write-Output
+            return
+        }
+
+        if (@($items).Count -eq 0) {
+            Write-Output "(no digest events)"
+            return
+        }
+
+        foreach ($item in @($items)) {
+            Write-DigestEventStreamItem -Item $item
+        }
+        return
     }
 
     $payload = Get-DigestPayload -ProjectDir $projectDir
@@ -5347,7 +5604,7 @@ Commands:
   board [--json]            Report pane/task/review/git session board
 inbox [--json] [--stream] Report actionable approvals/review/blockers
 runs [--json]             Report run-oriented session view
-digest [--json] [--stream] Report high-signal evidence digest per run
+digest [--json] [--stream] [--events] Report high-signal evidence digest per run or actionable event summaries
 explain <run_id> [--json] [--follow]  Explain one run and optionally follow new events
   poll-events [cursor]      Return new monitor events from .winsmux/events.jsonl
   signal <channel>          Send signal to unblock a waiting process

--- a/tests/psmux-bridge.Tests.ps1
+++ b/tests/psmux-bridge.Tests.ps1
@@ -777,6 +777,26 @@ STATUS: VERIFY_PASS
         ((Get-TeamPipelineSummaryFromOutput -Text $output) -replace "`r`n", "`n") | Should -Be "Work finished.`n`nFollow-up note."
     }
 
+    It 'parses structured verification output including VERIFY_PARTIAL' {
+        $output = @'
+STATUS: VERIFY_PARTIAL
+SUMMARY: verify contract incomplete but evidence is usable
+CHECK: diff|PASS|changed files inspected
+CHECK: tests|FAIL|missing rerun evidence
+NEXT_ACTION: rerun focused verification
+'@
+
+        $result = Get-TeamPipelineVerificationResultFromOutput -Text $output
+
+        $result.outcome | Should -Be 'PARTIAL'
+        $result.summary | Should -Be 'verify contract incomplete but evidence is usable'
+        $result.checks.Count | Should -Be 2
+        $result.checks[0].name | Should -Be 'diff'
+        $result.checks[0].status | Should -Be 'PASS'
+        $result.next_action | Should -Be 'rerun focused verification'
+        $result.adversarial | Should -Be $true
+    }
+
     It 'detects approval prompts and blocks dangerous confirmations' {
         $typeEnter = Get-TeamPipelineApprovalAction -Text "Do you want to proceed?`n1. Yes"
         $typeEnter.Kind | Should -Be 'TypeEnter'
@@ -786,6 +806,33 @@ STATUS: VERIFY_PASS
         $shellConfirm.Value | Should -Be 'y'
 
         { Get-TeamPipelineApprovalAction -Text 'Approve command: git reset --hard origin/main' } | Should -Throw
+    }
+
+    It 'returns a blocked security verdict when dangerous approval text appears during a stage wait' {
+        Mock Invoke-TeamPipelineBridge {
+            [PSCustomObject]@{
+                ExitCode = 0
+                Output = "Approve command: git reset --hard origin/main"
+            }
+        }
+        $script:securityEventWrites = @()
+        Mock Write-TeamPipelineEvent {
+            param($ProjectDir, $SessionName, $Event, $Message, $Role, $PaneId, $Target, $Data)
+            $script:securityEventWrites += [PSCustomObject]@{
+                Event = $Event
+                Target = $Target
+                Data = $Data
+            }
+        }
+
+        $result = Wait-TeamPipelineStage -Target 'builder-1' -StageName 'EXEC' -TimeoutSeconds 1 -PollIntervalSeconds 0 -ProjectDir 'C:\repo' -SessionName 'winsmux-orchestra' -Role 'Builder' -Task 'Investigate cache drift' -Attempt 1
+
+        $result.Status | Should -Be 'BLOCKED'
+        $result.SecurityVerdict.verdict | Should -Be 'BLOCK'
+        $result.SecurityVerdict.stage | Should -Be 'EXEC'
+        $script:securityEventWrites.Count | Should -Be 1
+        $script:securityEventWrites[0].Event | Should -Be 'pipeline.security.blocked'
+        $script:securityEventWrites[0].Data.verdict | Should -Be 'BLOCK'
     }
 
     It 'selects sensible planning and verification targets from the available roles' {
@@ -1159,6 +1206,29 @@ panes:
         $entries.Count | Should -Be 1
         $entries[0].ChangedFileCount | Should -Be 0
         $entries[0].ChangedFiles | Should -Be @()
+    }
+
+    It 'surfaces security_policy from the manifest entry' {
+@'
+version: 1
+saved_at: '2026-04-09T00:00:00+09:00'
+session:
+  name: 'winsmux-orchestra'
+  project_dir: 'C:\repo'
+panes:
+  worker-1:
+    pane_id: '%2'
+    role: 'Worker'
+    security_policy: '{\"mode\":\"blocklist\",\"allow_patterns\":[\"Invoke-Pester\"],\"block_patterns\":[\"git reset --hard\"]}'
+'@ | Set-Content -Path (Join-Path $script:paneControlManifestDir 'manifest.yaml') -Encoding UTF8
+
+        $entries = @(Get-PaneControlManifestEntries -ProjectDir $script:paneControlTempRoot)
+        $entry = @($entries | Where-Object { $_.Label -eq 'worker-1' } | Select-Object -First 1)[0]
+
+        $entry | Should -Not -BeNullOrEmpty
+        $entry.SecurityPolicy.mode | Should -Be 'blocklist'
+        @($entry.SecurityPolicy.allow_patterns) | Should -Be @('Invoke-Pester')
+        @($entry.SecurityPolicy.block_patterns) | Should -Be @('git reset --hard')
     }
 
 }
@@ -3679,6 +3749,7 @@ panes:
             risks          = @('result still provisional')
         })
 
+        @(
         ([ordered]@{
             timestamp = '2026-04-10T12:01:00+09:00'
             session   = 'winsmux-orchestra'
@@ -3703,7 +3774,31 @@ panes:
                 env_fingerprint      = 'env:abc123'
                 command_hash         = 'cmd:def456'
             }
-        } | ConvertTo-Json -Compress) | Set-Content -Path $script:runsEventsPath -Encoding UTF8
+        } | ConvertTo-Json -Compress),
+        ([ordered]@{
+            timestamp = '2026-04-10T12:02:00+09:00'
+            session   = 'winsmux-orchestra'
+            event     = 'pipeline.verify.partial'
+            message   = 'verification partially complete'
+            label     = 'reviewer-1'
+            pane_id   = '%3'
+            role      = 'Reviewer'
+            branch    = 'worktree-builder-1'
+            head_sha  = 'abc1234def5678'
+            data      = [ordered]@{
+                task_id = 'task-256'
+                run_id  = 'task:task-256'
+                verification_contract = [ordered]@{
+                    mode = 'adversarial_verify'
+                }
+                verification_result = [ordered]@{
+                    outcome = 'PARTIAL'
+                    summary = 'rerun focused verification'
+                    next_action = 'rerun_verify'
+                }
+            }
+        } | ConvertTo-Json -Compress)
+        ) | Set-Content -Path $script:runsEventsPath -Encoding UTF8
 
         function global:winsmux {
             $commandLine = ($args | ForEach-Object { [string]$_ }) -join ' '
@@ -3749,6 +3844,9 @@ panes:
         $result.runs[0].experiment_packet.worktree | Should -Be '.worktrees/builder-1'
         $result.runs[0].experiment_packet.env_fingerprint | Should -Be 'env:abc123'
         $result.runs[0].experiment_packet.command_hash | Should -Be 'cmd:def456'
+        $result.runs[0].verification_contract.mode | Should -Be 'adversarial_verify'
+        $result.runs[0].verification_result.outcome | Should -Be 'PARTIAL'
+        $result.runs[0].run_packet.verification_result.outcome | Should -Be 'PARTIAL'
         $result.runs[0].Contains('observation_pack') | Should -Be $false
         $result.runs[0].Contains('consultation_packet') | Should -Be $false
     }
@@ -3893,6 +3991,69 @@ panes:
         $first.experiment_packet.hypothesis | Should -Be 'builder-1 owns this experiment packet'
         $second.experiment_packet.run_id | Should -Be 'task:task-999'
         $second.experiment_packet.hypothesis | Should -Be 'builder-2 owns this experiment packet'
+    }
+
+    It 'surfaces security policy and latest security verdict in runs json' {
+@"
+version: 1
+session:
+  name: winsmux-orchestra
+  project_dir: $script:runsTempRoot
+panes:
+  worker-1:
+    pane_id: %2
+    role: Worker
+    task_id: task-273
+    task: Enforce security policy
+    task_state: blocked
+    task_owner: worker-1
+    review_state: ''
+    branch: worktree-worker-1
+    head_sha: def5678abc1234
+    changed_file_count: 0
+    changed_files: '[]'
+    security_policy: '{\"mode\":\"blocklist\",\"allow_patterns\":[\"Invoke-Pester\"],\"block_patterns\":[\"git reset --hard\"]}'
+    last_event: pipeline.security.blocked
+    last_event_at: 2026-04-10T12:03:00+09:00
+"@ | Set-Content -Path $script:runsManifestPath -Encoding UTF8
+
+        ([ordered]@{
+            timestamp = '2026-04-10T12:03:00+09:00'
+            session   = 'winsmux-orchestra'
+            event     = 'pipeline.security.blocked'
+            message   = 'security monitor blocked exec'
+            label     = 'worker-1'
+            pane_id   = '%2'
+            role      = 'Worker'
+            branch    = 'worktree-worker-1'
+            head_sha  = 'def5678abc1234'
+            data      = [ordered]@{
+                task_id = 'task-273'
+                run_id  = 'task:task-273'
+                stage   = 'EXEC'
+                verdict = 'BLOCK'
+                reason  = 'dangerous command approval'
+                advisory_mode = $false
+                allow   = @('read', 'write')
+                block   = @('hard_reset')
+                next_action = 'revise_request_or_override'
+            }
+        } | ConvertTo-Json -Compress) | Set-Content -Path $script:runsEventsPath -Encoding UTF8
+
+        function global:winsmux {
+            $commandLine = ($args | ForEach-Object { [string]$_ }) -join ' '
+            switch -Regex ($commandLine) {
+                '^capture-pane .*%2' { return @('gpt-5.4   64% context left', '? send   Ctrl+J newline', '>') }
+                default { throw "unexpected winsmux call: $commandLine" }
+            }
+        }
+
+        $result = (Invoke-Runs -RunsTarget '--json' | Out-String | ConvertFrom-Json -AsHashtable)
+
+        $result.runs[0].security_policy.mode | Should -Be 'blocklist'
+        @($result.runs[0].security_policy.block_patterns) | Should -Be @('git reset --hard')
+        $result.runs[0].security_verdict.verdict | Should -Be 'BLOCK'
+        $result.runs[0].run_packet.security_verdict.reason | Should -Be 'dangerous command approval'
     }
 }
 
@@ -4064,6 +4225,74 @@ panes:
         $result.items[0].consultation_ref | Should -Be $digestConsultationPacket.reference
         $result.items[0].Contains('observation_pack') | Should -Be $false
         $result.items[0].Contains('consultation_packet') | Should -Be $false
+    }
+
+    It 'returns digest event summaries when --events is supplied' {
+@"
+version: 1
+session:
+  name: winsmux-orchestra
+  project_dir: $script:digestTempRoot
+panes:
+  builder-1:
+    pane_id: %2
+    role: Builder
+    task_id: task-274
+    task: Build event summaries
+    task_state: blocked
+    task_owner: builder-1
+    review_state: ''
+    branch: worktree-builder-1
+    head_sha: abc1234def5678
+    changed_file_count: 0
+    changed_files: '[]'
+    last_event: pipeline.security.blocked
+    last_event_at: 2026-04-10T14:02:00+09:00
+"@ | Set-Content -Path $script:digestManifestPath -Encoding UTF8
+
+        @(
+            ([ordered]@{
+                timestamp = '2026-04-10T14:01:00+09:00'
+                session   = 'winsmux-orchestra'
+                event     = 'pane.noise'
+                message   = 'ignore me'
+                label     = 'builder-1'
+                pane_id   = '%2'
+                role      = 'Builder'
+            } | ConvertTo-Json -Compress),
+            ([ordered]@{
+                timestamp = '2026-04-10T14:02:00+09:00'
+                session   = 'winsmux-orchestra'
+                event     = 'pipeline.security.blocked'
+                message   = 'security monitor blocked exec'
+                label     = 'builder-1'
+                pane_id   = '%2'
+                role      = 'Builder'
+                branch    = 'worktree-builder-1'
+                head_sha  = 'abc1234def5678'
+                data      = [ordered]@{
+                    task_id = 'task-274'
+                    run_id  = 'task:task-274'
+                    next_action = 'revise_request_or_override'
+                }
+            } | ConvertTo-Json -Compress)
+        ) | Set-Content -Path $script:digestEventsPath -Encoding UTF8
+
+        function global:winsmux {
+            $commandLine = ($args | ForEach-Object { [string]$_ }) -join ' '
+            switch -Regex ($commandLine) {
+                '^capture-pane .*%2' { return @('gpt-5.4   64% context left', '? send   Ctrl+J newline', '>') }
+                default { throw "unexpected winsmux call: $commandLine" }
+            }
+        }
+
+        $result = (Invoke-Digest -DigestTarget '--events' -DigestRest @('--json') | Out-String | ConvertFrom-Json -AsHashtable)
+
+        $result.summary.item_count | Should -Be 1
+        $result.items[0].kind | Should -Be 'blocked'
+        $result.items[0].source_event | Should -Be 'pipeline.security.blocked'
+        $result.items[0].run_id | Should -Be 'task:task-274'
+        $result.items[0].next_action | Should -Be 'revise_request_or_override'
     }
 
     It 'returns digest delta items only for runs affected after the current cursor' {
@@ -4362,6 +4591,29 @@ panes:
             ([ordered]@{
                 timestamp = '2026-04-10T12:02:00+09:00'
                 session   = 'winsmux-orchestra'
+                event     = 'pipeline.verify.partial'
+                message   = 'verification partial'
+                label     = 'reviewer-1'
+                pane_id   = '%3'
+                role      = 'Reviewer'
+                branch    = 'worktree-builder-1'
+                head_sha  = 'abc1234def5678'
+                data      = [ordered]@{
+                    task_id = 'task-256'
+                    run_id  = 'task:task-256'
+                    verification_contract = [ordered]@{
+                        mode = 'adversarial_verify'
+                    }
+                    verification_result = [ordered]@{
+                        outcome = 'PARTIAL'
+                        summary = 'rerun focused verification'
+                        next_action = 'rerun_verify'
+                    }
+                }
+            } | ConvertTo-Json -Compress),
+            ([ordered]@{
+                timestamp = '2026-04-10T12:02:30+09:00'
+                session   = 'winsmux-orchestra'
                 event     = 'pane.approval_waiting'
                 message   = 'approval prompt detected'
                 label     = 'builder-1'
@@ -4446,6 +4698,8 @@ panes:
         $result.experiment_packet.worktree | Should -Be '.worktrees/builder-1'
         $result.experiment_packet.env_fingerprint | Should -Be 'env:abc123'
         $result.experiment_packet.command_hash | Should -Be 'cmd:def456'
+        $result.run_packet.verification_contract.mode | Should -Be 'adversarial_verify'
+        $result.run_packet.verification_result.outcome | Should -Be 'PARTIAL'
         $result.observation_pack.packet_type | Should -Be 'observation_pack'
         $result.observation_pack.failing_command | Should -Be 'Invoke-Pester tests/psmux-bridge.Tests.ps1'
         $result.consultation_packet.kind | Should -Be 'consult_result'
@@ -4460,6 +4714,7 @@ panes:
         $result.explanation.current_state.review_state | Should -Be 'PENDING'
         $result.explanation.reasons | Should -Contain 'task_state=in_progress'
         $result.explanation.reasons | Should -Contain 'review_state=PENDING'
+        $result.explanation.reasons | Should -Contain 'verify=PARTIAL'
         $result.explanation.reasons | Should -Contain 'review_contract=design_impact,replacement_coverage,orphaned_artifacts'
         $result.review_state.status | Should -Be 'PENDING'
         $result.review_state.request.review_contract.style | Should -Be 'utility_first'
@@ -4474,12 +4729,14 @@ panes:
         $result.result_packet.review_recommendation | Should -Be 'PENDING'
         $result.result_packet.review_contract.style | Should -Be 'utility_first'
         $result.result_packet.review_contract.required_scope | Should -Be @('design_impact', 'replacement_coverage', 'orphaned_artifacts')
+        $result.result_packet.verification_result.outcome | Should -Be 'PARTIAL'
         $result.result_packet.evidence_refs | Should -Be @('scripts/winsmux-core.ps1')
         $result.result_packet.observation_pack.packet_type | Should -Be 'observation_pack'
         $result.result_packet.consultation_packet.kind | Should -Be 'consult_result'
         $result.result_packet.consultation_summary.kind | Should -Be 'consult_result'
-        $result.recent_events.Count | Should -Be 2
+        $result.recent_events.Count | Should -Be 3
         @($result.recent_events | ForEach-Object { $_.event }) | Should -Contain 'commander.review_requested'
+        @($result.recent_events | ForEach-Object { $_.event }) | Should -Contain 'pipeline.verify.partial'
         @($result.recent_events | ForEach-Object { $_.event }) | Should -Contain 'pane.approval_waiting'
         ($result.recent_events | Where-Object { $_.event -eq 'commander.review_requested' } | Select-Object -First 1).hypothesis | Should -Be 'experiment packet should flow into explain'
         ($result.recent_events | Where-Object { $_.event -eq 'commander.review_requested' } | Select-Object -First 1).observation_pack.packet_type | Should -Be 'observation_pack'

--- a/winsmux-core/scripts/pane-control.ps1
+++ b/winsmux-core/scripts/pane-control.ps1
@@ -248,6 +248,37 @@ function ConvertFrom-PaneControlManifestContent {
     }
 }
 
+function ConvertFrom-PaneControlSecurityPolicy {
+    param([AllowNull()]$Value)
+
+    if ($null -eq $Value) {
+        return $null
+    }
+
+    if ($Value -is [System.Collections.IDictionary]) {
+        return $Value
+    }
+
+    $text = [string]$Value
+    if ([string]::IsNullOrWhiteSpace($text)) {
+        return $null
+    }
+
+    $parseCandidates = @($text)
+    if ($text.Contains('\"')) {
+        $parseCandidates += ($text -replace '\\"', '"')
+    }
+
+    foreach ($candidate in $parseCandidates | Select-Object -Unique) {
+        try {
+            return ($candidate | ConvertFrom-Json -AsHashtable -Depth 8)
+        } catch {
+        }
+    }
+
+    return [ordered]@{ raw = $text }
+}
+
 function Get-PaneControlManifestEntries {
     param([Parameter(Mandatory = $true)][string]$ProjectDir)
 
@@ -324,6 +355,7 @@ function Get-PaneControlManifestEntries {
             AgentRole           = [string](Get-PaneControlValue -InputObject $pane -Name 'agent_role' -Default '')
             TimeoutPolicy       = [string](Get-PaneControlValue -InputObject $pane -Name 'timeout_policy' -Default '')
             HandoffRefs         = @(ConvertFrom-PaneControlStringArray -Value (Get-PaneControlValue -InputObject $pane -Name 'handoff_refs' -Default @()))
+            SecurityPolicy      = ConvertFrom-PaneControlSecurityPolicy -Value (Get-PaneControlValue -InputObject $pane -Name 'security_policy' -Default $null)
         }
     }
 

--- a/winsmux-core/scripts/pane-status.ps1
+++ b/winsmux-core/scripts/pane-status.ps1
@@ -186,6 +186,7 @@ function Get-PaneStatusRecords {
             AgentRole       = $entry.AgentRole
             TimeoutPolicy   = $entry.TimeoutPolicy
             HandoffRefs     = @($entry.HandoffRefs)
+            SecurityPolicy  = $entry.SecurityPolicy
         }
     }
 

--- a/winsmux-core/scripts/team-pipeline.ps1
+++ b/winsmux-core/scripts/team-pipeline.ps1
@@ -315,6 +315,70 @@ function Get-TeamPipelineSummaryFromOutput {
     return $cleaned
 }
 
+function Get-TeamPipelineVerificationResultFromOutput {
+    param([AllowNull()][string]$Text)
+
+    if ([string]::IsNullOrWhiteSpace($Text)) {
+        return $null
+    }
+
+    $status = Get-TeamPipelineStatusFromOutput -Text $Text
+    if ([string]::IsNullOrWhiteSpace($status)) {
+        return $null
+    }
+
+    $summary = ''
+    $summaryMatches = [regex]::Matches($Text, '(?im)^\s*SUMMARY:\s*(.+?)\s*$')
+    if ($summaryMatches.Count -gt 0) {
+        $summary = $summaryMatches[$summaryMatches.Count - 1].Groups[1].Value.Trim()
+    } else {
+        $summary = Get-TeamPipelineSummaryFromOutput -Text $Text
+    }
+
+    $checks = @()
+    foreach ($match in [regex]::Matches($Text, '(?im)^\s*CHECK:\s*([^|]+)\|([^|]+)\|(.+?)\s*$')) {
+        $checks += [ordered]@{
+            name   = $match.Groups[1].Value.Trim()
+            status = $match.Groups[2].Value.Trim().ToUpperInvariant()
+            detail = $match.Groups[3].Value.Trim()
+        }
+    }
+
+    $nextAction = ''
+    $nextActionMatches = [regex]::Matches($Text, '(?im)^\s*NEXT_ACTION:\s*(.+?)\s*$')
+    if ($nextActionMatches.Count -gt 0) {
+        $nextAction = $nextActionMatches[$nextActionMatches.Count - 1].Groups[1].Value.Trim()
+    }
+
+    $outcome = switch ($status) {
+        'VERIFY_PASS' { 'PASS' }
+        'VERIFY_FAIL' { 'FAIL' }
+        'VERIFY_PARTIAL' { 'PARTIAL' }
+        'BLOCKED' { 'PARTIAL' }
+        default { 'PARTIAL' }
+    }
+
+    return [ordered]@{
+        outcome     = $outcome
+        summary     = $summary
+        checks      = @($checks)
+        next_action = $nextAction
+        adversarial = $true
+    }
+}
+
+function New-TeamPipelineVerificationContract {
+    return [ordered]@{
+        version          = 1
+        source_task      = 'TASK-272'
+        mode             = 'adversarial_verify'
+        style            = 'utility_first'
+        allowed_outcomes = @('PASS', 'FAIL', 'PARTIAL')
+        required_fields  = @('summary', 'checks', 'next_action')
+        rationale        = 'Verification specialists must return concise structured evidence instead of decorative prose.'
+    }
+}
+
 function Get-TeamPipelineApprovalAction {
     param([AllowNull()][string]$Text)
 
@@ -384,16 +448,174 @@ function Invoke-TeamPipelineApproval {
     }
 }
 
+function Get-TeamPipelineRunPolicy {
+    param([Parameter(Mandatory = $true)][string]$StageName)
+
+    $upperStage = $StageName.ToUpperInvariant()
+    switch -Regex ($upperStage) {
+        '^PLAN$' {
+            return [ordered]@{
+                stage         = $upperStage
+                advisory_mode = $false
+                allow         = @('read', 'analysis')
+                block         = @('write', 'git', 'network', 'destructive')
+            }
+        }
+        '^EXEC$' {
+            return [ordered]@{
+                stage         = $upperStage
+                advisory_mode = $false
+                allow         = @('read', 'write', 'git', 'build', 'test', 'lint')
+                block         = @('force_push', 'hard_reset', 'recursive_delete', 'schema_drop')
+            }
+        }
+        '^VERIFY$' {
+            return [ordered]@{
+                stage         = $upperStage
+                advisory_mode = $false
+                allow         = @('read', 'build', 'test', 'lint')
+                block         = @('write', 'git', 'network', 'destructive')
+            }
+        }
+        '^CONSULT_' {
+            return [ordered]@{
+                stage         = $upperStage
+                advisory_mode = $true
+                allow         = @('read', 'analysis')
+                block         = @('write', 'git', 'network', 'destructive')
+            }
+        }
+        default {
+            return [ordered]@{
+                stage         = $upperStage
+                advisory_mode = $false
+                allow         = @('read')
+                block         = @('destructive')
+            }
+        }
+    }
+}
+
+function Get-TeamPipelineChangedPaths {
+    param([string]$BuilderWorktreePath)
+
+    if ([string]::IsNullOrWhiteSpace($BuilderWorktreePath) -or -not (Test-Path -LiteralPath $BuilderWorktreePath -PathType Container)) {
+        return @()
+    }
+
+    $gitExe = Get-Command git -ErrorAction SilentlyContinue
+    if ($null -eq $gitExe) {
+        return @()
+    }
+
+    try {
+        $changed = & $gitExe.Source -C $BuilderWorktreePath diff --name-only --relative 2>$null
+        if ($LASTEXITCODE -ne 0) {
+            return @()
+        }
+    } catch {
+        return @()
+    }
+
+    return @($changed | Where-Object { -not [string]::IsNullOrWhiteSpace([string]$_) })
+}
+
+function New-TeamPipelineSecurityVerdict {
+    param(
+        [Parameter(Mandatory = $true)][string]$StageName,
+        [Parameter(Mandatory = $true)][string]$Target,
+        [Parameter(Mandatory = $true)][string]$Reason,
+        [string]$ActionKind = '',
+        [string]$ActionValue = '',
+        [string]$PromptText = ''
+    )
+
+    $policy = Get-TeamPipelineRunPolicy -StageName $StageName
+    return [PSCustomObject]@{
+        packet_type   = 'security_verdict'
+        scope         = 'run'
+        stage         = $policy.stage
+        target        = $Target
+        verdict       = 'BLOCK'
+        reason        = $Reason
+        action_kind   = $ActionKind
+        action_value  = $ActionValue
+        prompt_text   = $PromptText
+        advisory_mode = [bool]$policy.advisory_mode
+        allow         = @($policy.allow)
+        block         = @($policy.block)
+        next_action   = 'revise_request_or_override'
+    }
+}
+
+function New-TeamPipelineVerificationPacket {
+    param(
+        [Parameter(Mandatory = $true)][string]$Task,
+        [Parameter(Mandatory = $true)][string]$VerifyStatus,
+        [Parameter(Mandatory = $true)][string]$VerifierLabel,
+        [string]$BuilderLabel = '',
+        [string]$BuilderWorktreePath = '',
+        [string]$Summary = ''
+    )
+
+    $verdict = switch ($VerifyStatus) {
+        'VERIFY_PASS' { 'PASS' }
+        'VERIFY_FAIL' { 'FAIL' }
+        'BLOCKED' { 'PARTIAL' }
+        default { 'PARTIAL' }
+    }
+
+    $nextAction = switch ($verdict) {
+        'PASS' { 'ready_for_done' }
+        'FAIL' { 'fix_and_rerun_verify' }
+        default { 'unblock_verify' }
+    }
+
+    $verificationResult = Get-TeamPipelineVerificationResultFromOutput -Text $Summary
+    $trimmedSummary = [string]$Summary
+    if ($null -ne $verificationResult -and -not [string]::IsNullOrWhiteSpace([string]$verificationResult.summary)) {
+        $trimmedSummary = [string]$verificationResult.summary
+    }
+    $changedPaths = Get-TeamPipelineChangedPaths -BuilderWorktreePath $BuilderWorktreePath
+    $policy = Get-TeamPipelineRunPolicy -StageName 'VERIFY'
+
+    return [PSCustomObject]@{
+        packet_type        = 'verification_packet'
+        verification_contract = [PSCustomObject](New-TeamPipelineVerificationContract)
+        verification_result = if ($null -ne $verificationResult) { [PSCustomObject]$verificationResult } else { $null }
+        style              = 'utility_first'
+        task               = $Task
+        verifier           = $VerifierLabel
+        builder            = $BuilderLabel
+        builder_worktree   = $BuilderWorktreePath
+        verify_status      = $VerifyStatus
+        verdict            = $verdict
+        changed_paths      = @($changedPaths)
+        changed_path_count = @($changedPaths).Count
+        evidence_refs      = @($changedPaths)
+        failing_probe      = if ($verdict -eq 'PASS') { '' } else { $trimmedSummary }
+        next_action        = if ($null -ne $verificationResult -and -not [string]::IsNullOrWhiteSpace([string]$verificationResult.next_action)) { [string]$verificationResult.next_action } else { $nextAction }
+        summary            = $trimmedSummary
+        policy             = [PSCustomObject]$policy
+    }
+}
+
 function Wait-TeamPipelineStage {
     param(
         [Parameter(Mandatory = $true)][string]$Target,
         [Parameter(Mandatory = $true)][string]$StageName,
         [int]$TimeoutSeconds = 240,
-        [int]$PollIntervalSeconds = 10
+        [int]$PollIntervalSeconds = 10,
+        [string]$ProjectDir = '',
+        [string]$SessionName = '',
+        [string]$Role = '',
+        [string]$Task = '',
+        [int]$Attempt = 0
     )
 
     $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
     $lastOutput = ''
+    $policy = [PSCustomObject](Get-TeamPipelineRunPolicy -StageName $StageName)
 
     while ((Get-Date) -lt $deadline) {
         $readResult = Invoke-TeamPipelineBridge -Arguments @('read', $Target, '120')
@@ -401,16 +623,57 @@ function Wait-TeamPipelineStage {
 
         $status = Get-TeamPipelineStatusFromOutput -Text $lastOutput
         if ($null -ne $status) {
+            $verificationResult = $null
+            $summary = Get-TeamPipelineSummaryFromOutput -Text $lastOutput
+            if ($StageName.ToUpperInvariant() -eq 'VERIFY') {
+                $verificationResult = Get-TeamPipelineVerificationResultFromOutput -Text $lastOutput
+                if ($null -ne $verificationResult -and -not [string]::IsNullOrWhiteSpace([string]$verificationResult.summary)) {
+                    $summary = [string]$verificationResult.summary
+                }
+            }
+
             return [PSCustomObject]@{
                 Stage      = $StageName
                 Target     = $Target
                 Status     = $status
-                Summary    = Get-TeamPipelineSummaryFromOutput -Text $lastOutput
+                Summary    = $summary
                 Transcript = $lastOutput
+                Policy     = $policy
+                SecurityVerdict = $null
+                VerificationResult = $verificationResult
             }
         }
 
-        $approvalAction = Get-TeamPipelineApprovalAction -Text $lastOutput
+        $approvalAction = $null
+        try {
+            $approvalAction = Get-TeamPipelineApprovalAction -Text $lastOutput
+        } catch {
+            $securityVerdict = New-TeamPipelineSecurityVerdict -StageName $StageName -Target $Target -Reason $_.Exception.Message -PromptText $lastOutput
+            if (-not [string]::IsNullOrWhiteSpace($ProjectDir) -and -not [string]::IsNullOrWhiteSpace($SessionName)) {
+                Write-TeamPipelineEvent -ProjectDir $ProjectDir -SessionName $SessionName -Event 'pipeline.security.blocked' -Message "Security monitor blocked $StageName on $Target." -Role $Role -Target $Target -Data ([ordered]@{
+                    stage          = $securityVerdict.stage
+                    attempt        = $Attempt
+                    task           = $Task
+                    verdict        = $securityVerdict.verdict
+                    reason         = $securityVerdict.reason
+                    advisory_mode  = $securityVerdict.advisory_mode
+                    allow          = @($securityVerdict.allow)
+                    block          = @($securityVerdict.block)
+                    next_action    = $securityVerdict.next_action
+                }) | Out-Null
+            }
+
+            return [PSCustomObject]@{
+                Stage      = $StageName
+                Target     = $Target
+                Status     = 'BLOCKED'
+                Summary    = "Security monitor blocked approval. $($_.Exception.Message)"
+                Transcript = $lastOutput
+                Policy     = $policy
+                SecurityVerdict = $securityVerdict
+                VerificationResult = $null
+            }
+        }
         if ($null -ne $approvalAction) {
             Invoke-TeamPipelineApproval -Target $Target -Action $approvalAction
             Start-Sleep -Seconds 1
@@ -567,35 +830,43 @@ function New-TeamPipelineVerifyPrompt {
         $BuilderCompletionMessage.Trim()
     }
 
-    return @"
-Verify the latest builder result without editing code.
-
-This review was auto-dispatched after the builder reported completion.
-
-Task:
-$Task
-
-Builder label: $BuilderLabel
-Builder worktree: $BuilderWorktreePath
-
-Builder completion notification:
-$completionBlock
-
-Plan guidance:
-$planBlock
-
-Please inspect the builder workspace, review the current diff, and run focused verification where useful.
-If fixes are needed, provide concrete findings the builder can act on.
-
-End with exactly one line:
-STATUS: VERIFY_PASS
-
-If changes need fixes, end with:
-STATUS: VERIFY_FAIL
-
-If blocked, end with:
-STATUS: BLOCKED
-"@
+    return (@(
+        'Verify the latest builder result without editing code.'
+        ''
+        'This review was auto-dispatched after the builder reported completion.'
+        ''
+        'Task:'
+        $Task
+        ''
+        ('Builder label: {0}' -f $BuilderLabel)
+        ('Builder worktree: {0}' -f $BuilderWorktreePath)
+        ''
+        'Builder completion notification:'
+        $completionBlock
+        ''
+        'Plan guidance:'
+        $planBlock
+        ''
+        'Please inspect the builder workspace, review the current diff, and run focused verification where useful.'
+        'If fixes are needed, provide concrete findings the builder can act on.'
+        ''
+        'End with exactly one line:'
+        'STATUS: VERIFY_PASS'
+        ''
+        'If changes need fixes, end with:'
+        'STATUS: VERIFY_FAIL'
+        ''
+        'If verification is incomplete but actionable evidence exists, end with:'
+        'STATUS: VERIFY_PARTIAL'
+        ''
+        'If blocked, end with:'
+        'STATUS: BLOCKED'
+        ''
+        'Also include:'
+        '- one line SUMMARY: ...'
+        '- 1-4 lines CHECK: name|PASS|detail or CHECK: name|FAIL|detail'
+        '- one line NEXT_ACTION: ...'
+    ) -join "`n")
 }
 
 function New-TeamPipelineFixPrompt {
@@ -640,11 +911,11 @@ function New-TeamPipelineConsultPrompt {
     param(
         [Parameter(Mandatory = $true)][ValidateSet('early', 'stuck', 'final')][string]$Mode,
         [Parameter(Mandatory = $true)][string]$Task,
-        [string]$PlanSummary,
-        [string]$BuildSummary,
-        [string]$VerificationSummary,
-        [string]$BuilderLabel,
-        [string]$BuilderWorktreePath
+        [string]$PlanSummary = '',
+        [string]$BuildSummary = '',
+        [string]$VerificationSummary = '',
+        [string]$BuilderLabel = '',
+        [string]$BuilderWorktreePath = ''
     )
 
     $modeInstruction = switch ($Mode) {
@@ -703,13 +974,13 @@ function Invoke-TeamPipelineConsultStage {
         [Parameter(Mandatory = $true)][string]$BuilderLabel,
         [Parameter(Mandatory = $true)][string]$ProjectDir,
         [Parameter(Mandatory = $true)][string]$SessionName,
-        [string]$TargetLabel,
-        [string]$ResearcherLabel,
-        [string]$ReviewerLabel,
-        [string]$BuilderWorktreePath,
-        [string]$PlanSummary,
-        [string]$BuildSummary,
-        [string]$VerificationSummary,
+        [string]$TargetLabel = '',
+        [string]$ResearcherLabel = '',
+        [string]$ReviewerLabel = '',
+        [string]$BuilderWorktreePath = '',
+        [string]$PlanSummary = '',
+        [string]$BuildSummary = '',
+        [string]$VerificationSummary = '',
         [int]$TimeoutSeconds = 240,
         [int]$PollIntervalSeconds = 10,
         [int]$Attempt = 0
@@ -732,7 +1003,7 @@ function Invoke-TeamPipelineConsultStage {
 
     Write-TeamPipelineEvent -ProjectDir $ProjectDir -SessionName $SessionName -Event 'pipeline.consult.dispatched' -Message "Dispatched $Mode consult to $TargetLabel." -Role $consultRole -Target $TargetLabel -Data $eventData | Out-Null
     Invoke-TeamPipelineBridge -Arguments @('send', $TargetLabel, $prompt) | Out-Null
-    $stage = Wait-TeamPipelineStage -Target $TargetLabel -StageName ("CONSULT_{0}" -f $Mode.ToUpperInvariant()) -TimeoutSeconds $TimeoutSeconds -PollIntervalSeconds $PollIntervalSeconds
+    $stage = Wait-TeamPipelineStage -Target $TargetLabel -StageName ("CONSULT_{0}" -f $Mode.ToUpperInvariant()) -TimeoutSeconds $TimeoutSeconds -PollIntervalSeconds $PollIntervalSeconds -ProjectDir $ProjectDir -SessionName $SessionName -Role $consultRole -Task $Task -Attempt $Attempt
 
     $completedEvent = if ($stage.Status -eq 'BLOCKED') { 'pipeline.consult.blocked' } else { 'pipeline.consult.completed' }
     Write-TeamPipelineEvent -ProjectDir $ProjectDir -SessionName $SessionName -Event $completedEvent -Message "$Mode consult on $TargetLabel completed with status $($stage.Status)." -Role $consultRole -Target $TargetLabel -Data ([ordered]@{
@@ -791,6 +1062,8 @@ function Invoke-TeamPipeline {
         PreWorkConsult      = $null
         FinalConsult        = $null
         StuckConsults       = @()
+        VerificationPackets = @()
+        SecurityVerdicts    = @()
         Attempts            = @()
         Success             = $false
         FinalStatus         = 'NOT_STARTED'
@@ -801,9 +1074,13 @@ function Invoke-TeamPipeline {
     if (-not [string]::IsNullOrWhiteSpace($targets.PlanTarget)) {
         $planPrompt = New-TeamPipelinePlanPrompt -Task $Task
         Invoke-TeamPipelineBridge -Arguments @('send', $targets.PlanTarget, $planPrompt) | Out-Null
-        $planStage = Wait-TeamPipelineStage -Target $targets.PlanTarget -StageName 'PLAN' -TimeoutSeconds $StageTimeoutSeconds -PollIntervalSeconds $PollIntervalSeconds
+        $planStage = Wait-TeamPipelineStage -Target $targets.PlanTarget -StageName 'PLAN' -TimeoutSeconds $StageTimeoutSeconds -PollIntervalSeconds $PollIntervalSeconds -ProjectDir $builderContext.ProjectDir -SessionName $sessionName -Role 'Researcher' -Task $Task
         $result.Plan = $planStage
         if ($planStage.Status -eq 'BLOCKED') {
+        $planSecurityVerdict = Get-TeamPipelineValue -InputObject $planStage -Name 'SecurityVerdict' -Default $null
+        if ($null -ne $planSecurityVerdict) {
+            $result.SecurityVerdicts += $planSecurityVerdict
+        }
             $result.FinalStatus = 'PLAN_BLOCKED'
             return [PSCustomObject]$result
         }
@@ -812,7 +1089,7 @@ function Invoke-TeamPipeline {
     }
 
     if (-not [string]::IsNullOrWhiteSpace($consultTarget)) {
-        $result.PreWorkConsult = Invoke-TeamPipelineConsultStage -Mode 'early' -Task $Task -BuilderLabel $Builder -ProjectDir $builderContext.ProjectDir -SessionName $sessionName -TargetLabel $consultTarget -ResearcherLabel $Researcher -ReviewerLabel $Reviewer -BuilderWorktreePath $builderContext.BuilderWorktreePath -PlanSummary $planSummary -TimeoutSeconds $StageTimeoutSeconds -PollIntervalSeconds $PollIntervalSeconds
+        $result.PreWorkConsult = Invoke-TeamPipelineConsultStage -Mode 'early' -Task $Task -BuilderLabel $Builder -ProjectDir $builderContext.ProjectDir -SessionName $sessionName -TargetLabel $consultTarget -ResearcherLabel $Researcher -ReviewerLabel $Reviewer -BuilderWorktreePath $builderContext.BuilderWorktreePath -PlanSummary $planSummary -BuildSummary '' -VerificationSummary '' -TimeoutSeconds $StageTimeoutSeconds -PollIntervalSeconds $PollIntervalSeconds
     }
 
     $attemptLimit = 1 + [Math]::Max(0, $MaxFixRounds)
@@ -823,6 +1100,7 @@ function Invoke-TeamPipeline {
             BuildNotification = $null
             VerifyDispatch    = $null
             Verify            = $null
+            VerifyPacket      = $null
             StuckConsult      = $null
         }
 
@@ -834,12 +1112,16 @@ function Invoke-TeamPipeline {
         }
 
         Invoke-TeamPipelineBridge -Arguments @('send', $Builder, $buildPrompt) | Out-Null
-        $buildStage = Wait-TeamPipelineStage -Target $Builder -StageName 'EXEC' -TimeoutSeconds $StageTimeoutSeconds -PollIntervalSeconds $PollIntervalSeconds
+        $buildStage = Wait-TeamPipelineStage -Target $Builder -StageName 'EXEC' -TimeoutSeconds $StageTimeoutSeconds -PollIntervalSeconds $PollIntervalSeconds -ProjectDir $builderContext.ProjectDir -SessionName $sessionName -Role 'Builder' -Task $Task -Attempt $attemptIndex
         $attempt.Build = $buildStage
 
         if ($buildStage.Status -eq 'BLOCKED') {
+            $buildSecurityVerdict = Get-TeamPipelineValue -InputObject $buildStage -Name 'SecurityVerdict' -Default $null
+            if ($null -ne $buildSecurityVerdict) {
+                $result.SecurityVerdicts += $buildSecurityVerdict
+            }
             if (-not [string]::IsNullOrWhiteSpace($consultTarget)) {
-                $attempt.StuckConsult = Invoke-TeamPipelineConsultStage -Mode 'stuck' -Task $Task -BuilderLabel $Builder -ProjectDir $builderContext.ProjectDir -SessionName $sessionName -TargetLabel $consultTarget -ResearcherLabel $Researcher -ReviewerLabel $Reviewer -BuilderWorktreePath $builderContext.BuilderWorktreePath -PlanSummary $planSummary -BuildSummary $buildStage.Summary -TimeoutSeconds $StageTimeoutSeconds -PollIntervalSeconds $PollIntervalSeconds -Attempt $attemptIndex
+                $attempt.StuckConsult = Invoke-TeamPipelineConsultStage -Mode 'stuck' -Task $Task -BuilderLabel $Builder -ProjectDir $builderContext.ProjectDir -SessionName $sessionName -TargetLabel $consultTarget -ResearcherLabel $Researcher -ReviewerLabel $Reviewer -BuilderWorktreePath $builderContext.BuilderWorktreePath -PlanSummary $planSummary -BuildSummary $buildStage.Summary -VerificationSummary '' -TimeoutSeconds $StageTimeoutSeconds -PollIntervalSeconds $PollIntervalSeconds -Attempt $attemptIndex
                 if ($null -ne $attempt.StuckConsult) {
                     $result.StuckConsults += $attempt.StuckConsult
                 }
@@ -862,7 +1144,7 @@ function Invoke-TeamPipeline {
 
         if ([string]::IsNullOrWhiteSpace($targets.VerifyTarget)) {
             if (-not [string]::IsNullOrWhiteSpace($consultTarget)) {
-                $result.FinalConsult = Invoke-TeamPipelineConsultStage -Mode 'final' -Task $Task -BuilderLabel $Builder -ProjectDir $builderContext.ProjectDir -SessionName $sessionName -TargetLabel $consultTarget -ResearcherLabel $Researcher -ReviewerLabel $Reviewer -BuilderWorktreePath $builderContext.BuilderWorktreePath -PlanSummary $planSummary -BuildSummary $buildStage.Summary -TimeoutSeconds $StageTimeoutSeconds -PollIntervalSeconds $PollIntervalSeconds -Attempt $attemptIndex
+                $result.FinalConsult = Invoke-TeamPipelineConsultStage -Mode 'final' -Task $Task -BuilderLabel $Builder -ProjectDir $builderContext.ProjectDir -SessionName $sessionName -TargetLabel $consultTarget -ResearcherLabel $Researcher -ReviewerLabel $Reviewer -BuilderWorktreePath $builderContext.BuilderWorktreePath -PlanSummary $planSummary -BuildSummary $buildStage.Summary -VerificationSummary '' -TimeoutSeconds $StageTimeoutSeconds -PollIntervalSeconds $PollIntervalSeconds -Attempt $attemptIndex
             }
             $result.Attempts += [PSCustomObject]$attempt
             $result.Success = $true
@@ -893,8 +1175,33 @@ function Invoke-TeamPipeline {
             summary              = $buildNotification.Summary
         }) | Out-Null
         Invoke-TeamPipelineBridge -Arguments @('send', $targets.VerifyTarget, $verifyPrompt) | Out-Null
-        $verifyStage = Wait-TeamPipelineStage -Target $targets.VerifyTarget -StageName 'VERIFY' -TimeoutSeconds $StageTimeoutSeconds -PollIntervalSeconds $PollIntervalSeconds
+        $verifyStage = Wait-TeamPipelineStage -Target $targets.VerifyTarget -StageName 'VERIFY' -TimeoutSeconds $StageTimeoutSeconds -PollIntervalSeconds $PollIntervalSeconds -ProjectDir $builderContext.ProjectDir -SessionName $sessionName -Role $verifyRole -Task $Task -Attempt $attemptIndex
         $attempt.Verify = $verifyStage
+        $attempt.VerifyPacket = New-TeamPipelineVerificationPacket -Task $Task -VerifyStatus $verifyStage.Status -VerifierLabel $targets.VerifyTarget -BuilderLabel $Builder -BuilderWorktreePath $builderContext.BuilderWorktreePath -Summary $verifyStage.Summary
+        $result.VerificationPackets += $attempt.VerifyPacket
+        $verifySecurityVerdict = Get-TeamPipelineValue -InputObject $verifyStage -Name 'SecurityVerdict' -Default $null
+        if ($null -ne $verifySecurityVerdict) {
+            $result.SecurityVerdicts += $verifySecurityVerdict
+        }
+        $verifyEventName = switch ($attempt.VerifyPacket.verdict) {
+            'PASS' { 'pipeline.verify.pass' }
+            'FAIL' { 'pipeline.verify.fail' }
+            default { 'pipeline.verify.partial' }
+        }
+        Write-TeamPipelineEvent -ProjectDir $builderContext.ProjectDir -SessionName $sessionName -Event $verifyEventName -Message "Verification returned $($attempt.VerifyPacket.verdict) on $($targets.VerifyTarget)." -Role $verifyRole -Target $targets.VerifyTarget -Data ([ordered]@{
+            attempt           = $attemptIndex
+            task              = $Task
+            verifier          = $targets.VerifyTarget
+            verdict           = $attempt.VerifyPacket.verdict
+            verify_status     = $attempt.VerifyPacket.verify_status
+            changed_paths     = @($attempt.VerifyPacket.changed_paths)
+            evidence_refs     = @($attempt.VerifyPacket.evidence_refs)
+            failing_probe     = $attempt.VerifyPacket.failing_probe
+            next_action       = $attempt.VerifyPacket.next_action
+            style             = $attempt.VerifyPacket.style
+            verification_contract = $attempt.VerifyPacket.verification_contract
+            verification_result = $attempt.VerifyPacket.verification_result
+        }) | Out-Null
         $result.Attempts += [PSCustomObject]$attempt
 
         switch ($verifyStage.Status) {
@@ -914,6 +1221,10 @@ function Invoke-TeamPipeline {
                     }
                 }
                 $result.FinalStatus = 'VERIFY_BLOCKED'
+                return [PSCustomObject]$result
+            }
+            'VERIFY_PARTIAL' {
+                $result.FinalStatus = 'VERIFY_PARTIAL'
                 return [PSCustomObject]$result
             }
             'VERIFY_FAIL' {


### PR DESCRIPTION
## Summary
- surface structured verification packets and run-scoped security verdicts in runs/digest/explain
- teach team-pipeline verify/security stages to emit utility-first verification and blocked-security events
- add digest event summaries and regressions for verification/security projection

## Validation
- Invoke-Pester tests/psmux-bridge.Tests.ps1
- git diff --check

## Review gate
- Fresh reviewer timed out after a 30s wait (`no result yet`) and was closed.
- Fallback gate used: manual diff review + passing validation.