### PR TITLE
chore(release): preserve inline issue refs in notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,9 @@ When generating or editing a release:
 3. Keep the GitHub Release body aligned with the `/release-notes` structure, but in English and mapped onto the Codex-style headings above.
 4. Link the compare range in `Full Changelog` when the repository and tag range support it.
 5. Local or private post drafts may be Japanese if the task explicitly asks for them, but the public GitHub Release stays English.
+6. When an item maps to a repository issue or PR, preserve that reference inline in the bullet in Codex style.
+   - Prefer `(#315)` or `(#315, #318)` at the end of the bullet when the reference is available.
+   - Do not strip issue/PR references out of release bullets during summarization if they materially help traceability.
 
 ## Public-vs-Dogfooding Release Gate
 

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -63,6 +63,8 @@
 - Closed GitHub issues [#315](https://github.com/Sora-bluesky/winsmux/issues/315) and [#318](https://github.com/Sora-bluesky/winsmux/issues/318) after their merged fixes were reflected in planning truth.
 - Drafted and saved the `v0.20.2` release notes and X thread under `C:\Users\komei\iCloudDrive\iCloud~md~obsidian\MainVault\ChangeLogs\winsmux\v0.20.2\`.
 - Tagged and published `v0.20.2`, then replaced the workflow-generated body with the curated Codex-style release notes and removed the extra `release-body.md` asset so the public release ships only `winsmux-x64.exe`, `winsmux-arm64.exe`, and `SHA256SUMS`.
+- Updated the release-notes policy and generator so future GitHub Release bullets preserve visible issue/PR refs inline in Codex style instead of stripping them during summarization.
+- Fresh reviewer `Hooke` timed out with `no result yet` after a 30-second wait and was closed; fallback gate for the release-formatting diff is `pwsh scripts/generate-release-notes.ps1 + manual diff review + git diff --check`.
 - Merged `TASK-287` via PR [#393](https://github.com/Sora-bluesky/winsmux/pull/393), adding the keyboard-first operator command bar (`Ctrl/Cmd+K`) with quick actions, IME-safe input handling, focus restore, and accessible active-option semantics.
 - Merged `TASK-298` via PR [#394](https://github.com/Sora-bluesky/winsmux/pull/394), rewriting `README.ja.md` to match the public operator model, shrinking maintainer-only planning readmes into internal stubs, and making tracked public config/docs safer for external users.
 - Re-synced the external planning backlog/roadmap after PR [#394](https://github.com/Sora-bluesky/winsmux/pull/394), marking `TASK-298` as done so `v0.20.0` now shows `100% (12/12)`.
@@ -160,6 +162,7 @@
 - Current local `v0.20.2` closing slice passes `git diff --check` aside from benign LF->CRLF warnings on edited files.
 - PR [#403](https://github.com/Sora-bluesky/winsmux/pull/403) CI passed before merge: `Pester Tests` run `24300148509`.
 - `v0.20.2` release workflow run `24300269827` completed successfully and published `winsmux-x64.exe`, `winsmux-arm64.exe`, and `SHA256SUMS`.
+- Current local release-formatting slice passes `pwsh scripts/generate-release-notes.ps1 -Version v0.20.2 ...` and `git diff --check` aside from benign LF->CRLF warnings on edited files.
 
 ## Next actions
 

--- a/scripts/generate-release-notes.ps1
+++ b/scripts/generate-release-notes.ps1
@@ -310,6 +310,37 @@ function Get-MatchedCommits {
     return @($Subjects | Where-Object { Test-MatchesAny -Text $_ -Patterns $Patterns })
 }
 
+function Get-RepoReferenceSuffix {
+    param(
+        [AllowNull()]
+        [string]$Text
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Text)) {
+        return ''
+    }
+
+    $matches = [regex]::Matches($Text, '#\d+')
+    if ($matches.Count -eq 0) {
+        return ''
+    }
+
+    $refs = New-Object System.Collections.Generic.List[string]
+    $seen = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::Ordinal)
+    foreach ($match in $matches) {
+        $token = [string]$match.Value
+        if ($seen.Add($token)) {
+            $refs.Add($token)
+        }
+    }
+
+    if ($refs.Count -eq 0) {
+        return ''
+    }
+
+    return ' (' + (($refs.ToArray()) -join ', ') + ')'
+}
+
 function Remove-ExistingBenefits {
     param(
         [string[]]$Items,
@@ -326,6 +357,37 @@ function Remove-ExistingBenefits {
     }
 
     return @($Items | Where-Object { -not $existingSet.Contains($_) })
+}
+
+function Get-UniqueBenefitsWithRefs {
+    param(
+        [string[]]$Values,
+        [int]$Limit = 5
+    )
+
+    $seen = [System.Collections.Generic.HashSet[string]]::new()
+    $results = New-Object System.Collections.Generic.List[string]
+
+    foreach ($value in $Values) {
+        $normalized = ConvertTo-UserBenefit -Text $value
+        if ([string]::IsNullOrWhiteSpace($normalized)) {
+            continue
+        }
+
+        if (-not $seen.Add($normalized)) {
+            continue
+        }
+
+        $suffix = Get-RepoReferenceSuffix -Text $value
+        $display = if ([string]::IsNullOrWhiteSpace($suffix)) { $normalized } else { $normalized + $suffix }
+        $results.Add($display)
+
+        if ($results.Count -ge $Limit) {
+            break
+        }
+    }
+
+    return @($results.ToArray())
 }
 
 function Add-Section {
@@ -405,6 +467,11 @@ if (Test-Path $backlogFullPath) {
     Write-Warning "[release-notes] backlog not found at $backlogFullPath; generating from git history only."
 }
 $doneTasksForVersion = @($tasks | Where-Object { $_.TargetVersion -eq $Version -and $_.Status -eq 'done' })
+$doneTaskTitlesForVersion = @(
+    $doneTasksForVersion |
+        Where-Object { -not [string]::IsNullOrWhiteSpace($_.Title) } |
+        Select-Object -ExpandProperty Title
+)
 
 $previousTag = Get-PreviousTag -CurrentTag $Version
 $commitRange = if ($null -ne $previousTag) { "$previousTag..$Version" } else { $Version }
@@ -435,6 +502,7 @@ if ($highlightCandidates.Count -eq 0) {
 }
 
 $featureSource = @()
+$featureSource += @($doneTaskTitlesForVersion | Where-Object { $_ -notmatch '#\d+' })
 $featureSource += Get-MatchedCommits -Subjects $commitSubjects -Patterns @('Direct Commander.?Reviewer review flow')
 $featureSource += Get-MatchedCommits -Subjects $commitSubjects -Patterns @('runtime state machine', 'closed-loop orchestra startup')
 $featureSource += Get-MatchedCommits -Subjects $commitSubjects -Patterns @('bootstrap verification', 'bootstrap invariants')
@@ -442,6 +510,7 @@ $featureSource += Get-MatchedCommits -Subjects $commitSubjects -Patterns @('Comm
 $featureSource += Get-MatchedCommits -Subjects $commitSubjects -Patterns @('first-class task and review state model', 'first-class pane state model')
 $featureSource += @($commitSubjects | Where-Object { $_ -match '^feat' })
 $fixSource = @()
+$fixSource += @($doneTaskTitlesForVersion | Where-Object { $_ -match '#\d+' })
 $fixSource += Get-MatchedCommits -Subjects $commitSubjects -Patterns @('winsmux send silent failure', 'target pane.*not found', 'fail when target pane is missing')
 $fixSource += Get-MatchedCommits -Subjects $commitSubjects -Patterns @('Monitoring stack non-functional', 'watchdog.?Commander delivery path missing')
 $fixSource += Get-MatchedCommits -Subjects $commitSubjects -Patterns @('false success', 'pane creation does not actually occur', 'detached orchestra layout reliability')
@@ -489,14 +558,14 @@ $choreSource += @(
         }
 )
 
-$highlights = @(Get-UniqueBenefits -Values $highlightCandidates -Limit 3)
-$features = @(Get-UniqueBenefits -Values $featureSource -Limit 5)
+$highlights = @(Get-UniqueBenefitsWithRefs -Values $highlightCandidates -Limit 3)
+$features = @(Get-UniqueBenefitsWithRefs -Values $featureSource -Limit 5)
 $features = @($highlights + (Remove-ExistingBenefits -Items $features -Existing $highlights))
 $features = @($features | Select-Object -First 6)
-$fixes = @(Get-UniqueBenefits -Values $fixSource -Limit 5)
-$security = @(Get-UniqueBenefits -Values $securitySource -Limit 2)
-$documentation = @(Get-UniqueBenefits -Values $docsSource -Limit 4)
-$chores = @(Get-UniqueBenefits -Values $choreSource -Limit 6)
+$fixes = @(Get-UniqueBenefitsWithRefs -Values $fixSource -Limit 5)
+$security = @(Get-UniqueBenefitsWithRefs -Values $securitySource -Limit 2)
+$documentation = @(Get-UniqueBenefitsWithRefs -Values $docsSource -Limit 4)
+$chores = @(Get-UniqueBenefitsWithRefs -Values $choreSource -Limit 6)
 $chores = @($security + (Remove-ExistingBenefits -Items $chores -Existing $security))
 $chores = @($chores | Select-Object -First 4)
 


### PR DESCRIPTION
## Summary
- preserve inline issue/PR refs in release bullets in Codex style
- keep that rule durable in AGENTS.md
- record the fallback review gate in handoff

## Validation
- pwsh scripts/generate-release-notes.ps1 -Version v0.20.2 ...
- git diff --check

## Review gate
- Fresh reviewer timed out after a 30s wait (`no result yet`) and was closed.
- Fallback gate used: manual diff review + generator output check + diff check.