### PR TITLE
feat(orchestra): baseline governance env and security enforcement

### DIFF
--- a/.claude/hooks/sh-session-start.js
+++ b/.claude/hooks/sh-session-start.js
@@ -58,6 +58,9 @@ const DEFAULT_TOKEN_BUDGET = {
   used: 0,
 };
 
+const winsmuxHookProfile = (process.env.WINSMUX_HOOK_PROFILE || "standard").trim() || "standard";
+const winsmuxGovernanceMode = (process.env.WINSMUX_GOVERNANCE_MODE || "standard").trim() || "standard";
+
 try {
   const input = readHookInput();
   const toolName = input.tool_name || input.toolName || "";
@@ -173,7 +176,14 @@ try {
   session.retry_count = 0;
   session.stop_hook_active = false;
   session.deny_tracker = {};
+  session.winsmux_contract = {
+    hook_profile: winsmuxHookProfile,
+    governance_mode: winsmuxGovernanceMode,
+  };
   contextParts.push("[env-check] Session initialized, token budget set");
+  contextParts.push(
+    `[winsmux] Hook profile: ${winsmuxHookProfile}, governance mode: ${winsmuxGovernanceMode}`,
+  );
 
   // 2c: OpenShell detection (Layer 3b, ADR-037)
   const openshellResult = detectOpenShell();
@@ -373,6 +383,10 @@ try {
             reason: policyCompat.reason,
           }
         : null,
+      winsmux_contract: {
+        hook_profile: winsmuxHookProfile,
+        governance_mode: winsmuxGovernanceMode,
+      },
     });
   } catch {
     // Evidence failure is non-blocking

--- a/README.ja.md
+++ b/README.ja.md
@@ -107,6 +107,12 @@ winsmux new-session -s orchestra
 pwsh winsmux-core/scripts/orchestra-start.ps1
 ```
 
+Windows で `winsmux doctor` が Codex worktree git sandbox limitation を報告した場合も、winsmux の基本分担は変わりません。
+- Codex pane は isolated worktree 内の file edit を担当
+- external operator は、sandboxed Codex が `.git/worktrees/*/index.lock` を作れない場合の `git add/commit/push` を担当
+
+Windows の `ConstrainedLanguageMode` を含む詳細な回避策は [docs/TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md) を参照してください。
+
 現在の既定レイアウトは次です。
 
 - 管理対象ウィンドウの外に external operator terminal

--- a/README.md
+++ b/README.md
@@ -108,6 +108,12 @@ winsmux new-session -s orchestra
 pwsh winsmux-core/scripts/orchestra-start.ps1
 ```
 
+If `winsmux doctor` reports the Codex worktree git sandbox limitation on Windows, keep using the standard winsmux split:
+- Codex panes handle file edits inside isolated worktrees
+- the external operator handles `git add/commit/push` when sandboxed Codex cannot create `.git/worktrees/*/index.lock`
+
+See [docs/TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md) for the Windows `ConstrainedLanguageMode` workaround details.
+
 The default layout is now:
 
 - external operator terminal outside the managed window

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -27,6 +27,26 @@ Remove-Item .winsmux/orchestra.lock -Force
 sandbox = "unelevated"
 ```
 
+### Codex worktree pane で file write や git 操作が不安定
+
+**症状**:
+- worktree pane 内の Codex が `.git/worktrees/*/index.lock` を作れず、`git add` や `git commit` が失敗する
+- PowerShell が `ConstrainedLanguageMode` になり、`Set-Content` / `Out-File` / `[IO.File]::*` が失敗する
+
+**原因**:
+- Windows の `unelevated` sandbox では、Codex pane が worktree git metadata と PowerShell file APIs に制約を受ける
+
+**解決**:
+- winsmux の標準分担を使う
+  - Codex pane: file edit / test / focused verification
+  - external operator: `git add` / `git commit` / `git push`
+- pane 内の file write は `apply_patch` か `cmd /c` を使う
+- `Set-Content` / `Out-File` / `[IO.File]::WriteAllText()` は避ける
+
+**補足**:
+- これは issue `#260` の documented workaround
+- `winsmux doctor` がこの limitation を検知したら、external operator が `git add` / `git commit` / `git push` を担当する
+
 ### vault key が見つからない
 
 **原因**: Windows Credential Manager に登録されていない。

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -1,181 +1,58 @@
 # Handoff
 
-> Updated: 2026-04-12T20:32:00+09:00
+> Updated: 2026-04-12T21:35:00+09:00
 > Source of truth: this file
 
 ## Current state
 
-- `v0.19.5`, `v0.19.6`, `v0.19.7`, and `v0.19.8` are released.
-- `v0.19.6 hardening` is implemented, merged, released, and tracked as `100% (6/6)` in the external planning backlog/roadmap.
-- `v0.19.7 visible orchestration` is implemented, merged, released, and tracked as `100% (7/7)` in the external planning backlog/roadmap.
-- `v0.19.8 External Operator & Agent Slots` is implemented in order; private planning now tracks `TASK-259`, `TASK-261`, `TASK-262`, `TASK-263`, and `TASK-264` as done, and the external roadmap is synced accordingly.
-- Private planning now swaps `v0.20.0` and `v0.21.0` to match actual implementation order: `v0.20.0` is `Desktop UX Foundation`, and `v0.21.0` is `Operator Core & Slot Dispatch`.
-- PR [#370](https://github.com/Sora-bluesky/winsmux/pull/370), PR [#371](https://github.com/Sora-bluesky/winsmux/pull/371), PR [#372](https://github.com/Sora-bluesky/winsmux/pull/372), PR [#374](https://github.com/Sora-bluesky/winsmux/pull/374), PR [#375](https://github.com/Sora-bluesky/winsmux/pull/375), PR [#376](https://github.com/Sora-bluesky/winsmux/pull/376), PR [#379](https://github.com/Sora-bluesky/winsmux/pull/379), PR [#380](https://github.com/Sora-bluesky/winsmux/pull/380), PR [#381](https://github.com/Sora-bluesky/winsmux/pull/381), PR [#382](https://github.com/Sora-bluesky/winsmux/pull/382), PR [#383](https://github.com/Sora-bluesky/winsmux/pull/383), PR [#384](https://github.com/Sora-bluesky/winsmux/pull/384), PR [#385](https://github.com/Sora-bluesky/winsmux/pull/385), PR [#386](https://github.com/Sora-bluesky/winsmux/pull/386), PR [#387](https://github.com/Sora-bluesky/winsmux/pull/387), PR [#388](https://github.com/Sora-bluesky/winsmux/pull/388), PR [#389](https://github.com/Sora-bluesky/winsmux/pull/389), PR [#390](https://github.com/Sora-bluesky/winsmux/pull/390), and PR [#392](https://github.com/Sora-bluesky/winsmux/pull/392) are merged into `main`.
-- `v0.20.0` is released.
-- `v0.20.1` is now fully implemented at `100% (7/7)` in the external planning backlog/roadmap after rebaselining the shipped transport/ledger slices and moving the remaining SQLite FTS5 + stdin parity work into follow-up tasks.
-- `v0.20.1` is released at [v0.20.1](https://github.com/Sora-bluesky/winsmux/releases/tag/v0.20.1); release workflow run `24299025847` published `winsmux-x64.exe`, `winsmux-arm64.exe`, and `SHA256SUMS`.
-- `v0.20.2` is fully implemented at `100% (5/5)` in the external planning backlog/roadmap and is released.
-- Planning source of truth is externalized outside the public repository and syncs automatically into the private planning root.
-- `v0.21.x` private planning is aligned to a conversation-first Tauri operator shell, with Codex-App-like shell rules reflected in Figma and backlog notes.
-- `v0.24.x` private planning is split into schema, ledger, machine contract, cutover, and canary phases for Rust runtime convergence before `v1.0.0`.
-- PR [#396](https://github.com/Sora-bluesky/winsmux/pull/396) is merged into `main`, landing the first `TASK-114` experiment-ledger read model slice.
-- External planning is rebalanced so `v0.21.0` is reduced to slot-dispatch core, `v0.21.1` absorbs experiment compare/promotion, and `v0.22.0` is narrowed to backend-first Tauri control-plane foundation.
+- `v0.20.0`, `v0.20.1`, and `v0.20.2` are released.
+- `v0.20.3` shipped scope is rebaselined locally to these 5 tasks and is pending PR/merge/release:
+  - `TASK-161`
+  - `TASK-162` baseline only
+  - `TASK-172`
+  - `TASK-189`
+  - `TASK-309`
+- Follow-up work is moved out of `v0.20.3`:
+  - `TASK-190`
+  - `TASK-248`
+  - `TASK-306`
+  - `TASK-307`
+  - `TASK-310`
+- Current working branch is `codex/v0203-governance-env-security-20260412`.
 
 ## This session
 
-- Expanded the public operator contract in [docs/operator-model.md](../docs/operator-model.md) to add `Observation Pack`, `Consultation loop`, `Consult-capable slots`, `Experiment isolation and compare`, and `Tactic promotion` as first-class winsmux concepts.
-- Updated the external planning backlog so `TASK-114`, `TASK-187`, `TASK-191`, `TASK-286`, and `TASK-299` explicitly cover experiment-ledger and consultation semantics, and added `TASK-300` through `TASK-305` for observation packs, consultation packets, consult-capable slots, experiment compare, tactic promotion, and the Tauri experiment board.
-- Updated the Figma `winsmux Tauri Operator Workspace` file with a new `E. Experiment Loop & Consultation` section that maps `Experiments`, consultation cards, compare views, and playbook promotion into the sidebar, conversation shell, context side sheet, and command bar.
-- Started the repo-side `TASK-187` first slice locally by introducing `prompt_transport` settings precedence (`global -> role -> slot`) with built-in `argv` default and fail-closed rejection for unsupported values such as `stdin`.
-- Extracted send-path transport planning in [scripts/winsmux-core.ps1](../scripts/winsmux-core.ps1) so normal sends and `codex exec` sends now share a single transport-plan entry point while preserving file-backed prompt handoff as the first stable transport abstraction.
-- Extended [tests/psmux-bridge.Tests.ps1](../tests/psmux-bridge.Tests.ps1) to cover prompt-transport settings precedence, restart-plan propagation, and file-forced dispatch payload behavior, and updated [winsmux-core/scripts/pane-control.ps1](../winsmux-core/scripts/pane-control.ps1) to surface the resolved `PromptTransport` in restart plans.
-- Merged the `TASK-187` first slice via PR [#395](https://github.com/Sora-bluesky/winsmux/pull/395), landing `argv/file` prompt transport resolution, shared send transport planning, and restart-plan transport visibility on `main`.
-- Started the repo-side `TASK-114` first slice locally by extending `runs / digest / explain` to surface a new `experiment_packet` assembled from event-ledger data without changing the existing `run_packet` contract.
-- Added strict experiment-event correlation so experiment packets prefer `run_id / task_id / pane_id / label` over branch-only matching, and added a branch-collision regression to keep parallel hypothesis runs from cross-contaminating each other.
-- Extended [tests/psmux-bridge.Tests.ps1](../tests/psmux-bridge.Tests.ps1) so `winsmux runs --json`, `winsmux digest --json`, `winsmux explain --json`, and explain follow-delta all cover experiment-ledger fields plus a negative case where `experiment_packet` remains null when no experiment metadata exists.
-- Started the repo-side `TASK-301` write-side slice locally by adding consultation writer helpers and thin CLI commands that file `consult_request / consult_result / consult_error` packets under `.winsmux/consultations`, append corresponding bridge events, and project `result / confidence / next_action` back into the existing experiment ledger.
-- Merged the `TASK-301` write-side consultation slice via PR [#398](https://github.com/Sora-bluesky/winsmux/pull/398), landing file-backed consultation packet writers and bridge-event projection fields on `main`.
-- Started the repo-side `TASK-191` first slice locally by teaching one-shot orchestration to insert advisory consult steps before work, on blocked states, and before done using the existing reviewer/researcher lanes without introducing `consult-capable` routing policy yet.
-- Extended [winsmux-core/scripts/team-pipeline.ps1](../winsmux-core/scripts/team-pipeline.ps1) with consult-target selection, advisory consult prompt builders, and `pipeline.consult.*` event emission so one-shot runs can dispatch `early / stuck / final` consult stages around the existing `plan -> build -> verify` loop.
-- Extended [tests/psmux-bridge.Tests.ps1](../tests/psmux-bridge.Tests.ps1) to cover consult target selection plus successful and blocked orchestration paths, asserting that consult stages are inserted only when a non-builder consult target exists.
-- Merged the `TASK-191` first slice via PR [#399](https://github.com/Sora-bluesky/winsmux/pull/399), inserting advisory consult stages into one-shot team orchestration without introducing `consult-capable` routing policy yet.
-- Started the repo-side `TASK-188` first slice locally by extending the transport layer with stable `.winsmux/task-{slug}.md` prompt files so task-scoped handoff can be audited and reused before the full `task-run` command exists.
-- Extended [scripts/winsmux-core.ps1](../scripts/winsmux-core.ps1) with task-prompt helpers (`ConvertTo-TaskPromptSlug`, `Get-TaskPromptPath`, `New-TaskPromptFile`) and task-aware transport planning so file-backed sends can target a deterministic `task-{slug}.md` artifact instead of a random dispatch file.
-- Extended [tests/psmux-bridge.Tests.ps1](../tests/psmux-bridge.Tests.ps1) so send payloads cover normalized task slugs, stable relative references, and overwrite semantics when the same task slug is reused.
-- Rebased the external planning backlog so `TASK-114`, `TASK-187`, `TASK-188`, `TASK-300`, and `TASK-301` reflect the shipped `v0.20.1` slices and are marked done, while the unshipped `stdin` transport parity and SQLite FTS5 search backend moved to new follow-up tasks `TASK-306` and `TASK-307` under `v0.20.3`.
-- Re-synced the external roadmap so `v0.20.1: Run Transport & Event Ledger` now reads as `100% (7/7)` and is ready for release preparation.
-- Drafted and saved the `v0.20.1` release notes and X thread under `C:\Users\komei\iCloudDrive\iCloud~md~obsidian\MainVault\ChangeLogs\winsmux\v0.20.1\`.
-- Tagged and published `v0.20.1`, then replaced the workflow-generated body with the curated Codex-style release notes and removed the extra `release-body.md` asset so the public release ships only `winsmux-x64.exe`, `winsmux-arm64.exe`, and `SHA256SUMS`.
-- Started the first `v0.20.2` slice for `TASK-207` by strengthening `winsmux-core/agents/reviewer.sh` so reviewer prompts must explicitly audit downstream design impact, replacement coverage, and orphaned artifacts instead of limiting review to local diff correctness.
-- Updated `winsmux-core/agents/AGENTS.md` to keep the reviewer-template docs aligned with the stronger audit contract, and added a narrow regression in `tests/psmux-bridge.Tests.ps1` that locks the new review-checklist language in place.
-- Updated `.github/workflows/release-core.yml` from `softprops/action-gh-release@v2` to `@v3` to remove the Node 20 deprecation path that still appeared during the `v0.20.1` release workflow.
-- Started the `TASK-210` runtime slice on `codex/task210-review-scope-contract-20260412`, adding `request.review_contract` to `review-request`, surfacing that contract through `explain/result_packet`, and rejecting `review-approve` / `review-fail` when a pending request lacks the mandatory scope contract.
-- Updated external planning notes so `TASK-210`, `TASK-272`, `TASK-302`, `TASK-303`, `TASK-304`, and `TASK-305` explicitly encode Codex-derived UI acceptance rules (`utility-first`, `real-data-first`, `minimal chrome`, `calm hierarchy`, `one accent`), and added `TASK-308` for Playwright-based desktop viewport / overlap / drawer verification.
-- Updated [THIRD_PARTY_NOTICES.md](../THIRD_PARTY_NOTICES.md) with a short `Adaptation guardrails` bridge so Codex-derived UI reuse points back to release-train acceptance criteria without turning the notice file into additional license terms.
-- Started the `v0.20.2` closing slice on `codex/v0202-verify-security-summary-20260412`, wiring structured verification packets, run-scoped security verdicts/policies, and digest event summaries into the runtime surfaces that back `runs`, `digest`, `explain`, and one-shot orchestration.
-- Extended [winsmux-core/scripts/team-pipeline.ps1](../winsmux-core/scripts/team-pipeline.ps1) so verify stages emit `VERIFY_PASS / VERIFY_FAIL / VERIFY_PARTIAL`, produce utility-first verification packets, and surface security-block decisions as explicit blocked verdicts instead of prompt-only text.
-- Extended [scripts/winsmux-core.ps1](../scripts/winsmux-core.ps1) so `runs`, `result_packet`, `run_packet`, `digest --events`, and `explain` hydrate `verification_contract`, `verification_result`, `security_policy`, and `security_verdict` from ledger events and manifest context.
-- Extended [winsmux-core/scripts/pane-control.ps1](../winsmux-core/scripts/pane-control.ps1) and [winsmux-core/scripts/pane-status.ps1](../winsmux-core/scripts/pane-status.ps1) so manifest `security_policy` survives into pane/run surfaces even when stored as a JSON-escaped scalar in `.winsmux/manifest.yaml`.
-- Extended [tests/psmux-bridge.Tests.ps1](../tests/psmux-bridge.Tests.ps1) to cover structured verify parsing, blocked security verdicts, manifest security policy hydration, digest event summaries, and explain/runs packet projection; local focused regression now passes at `141/141`.
-- Fresh reviewer `Dirac` timed out with `no result yet` after a 30-second wait and was closed; fallback gate for this slice is `manual diff review + Invoke-Pester tests/psmux-bridge.Tests.ps1 + git diff --check`.
-- Merged the `v0.20.2` closing slice via PR [#403](https://github.com/Sora-bluesky/winsmux/pull/403), landing utility-first verification packets, run-scoped security verdict surfaces, and `winsmux digest --events` on `main`.
-- Rebaselined the external planning backlog/roadmap so `TASK-207`, `TASK-210`, `TASK-272`, `TASK-273`, and `TASK-274` are all `done`, `v0.20.2` shows `100% (5/5)`, and the unshipped full security-policy enforcement work moved to new follow-up `TASK-309`.
-- Closed GitHub issues [#315](https://github.com/Sora-bluesky/winsmux/issues/315) and [#318](https://github.com/Sora-bluesky/winsmux/issues/318) after their merged fixes were reflected in planning truth.
-- Drafted and saved the `v0.20.2` release notes and X thread under `C:\Users\komei\iCloudDrive\iCloud~md~obsidian\MainVault\ChangeLogs\winsmux\v0.20.2\`.
-- Tagged and published `v0.20.2`, then replaced the workflow-generated body with the curated Codex-style release notes and removed the extra `release-body.md` asset so the public release ships only `winsmux-x64.exe`, `winsmux-arm64.exe`, and `SHA256SUMS`.
-- Updated the release-notes policy and generator so future GitHub Release bullets preserve visible issue/PR refs inline in Codex style instead of stripping them during summarization.
-- Fresh reviewer `Hooke` timed out with `no result yet` after a 30-second wait and was closed; fallback gate for the release-formatting diff is `pwsh scripts/generate-release-notes.ps1 + manual diff review + git diff --check`.
-- Merged `TASK-287` via PR [#393](https://github.com/Sora-bluesky/winsmux/pull/393), adding the keyboard-first operator command bar (`Ctrl/Cmd+K`) with quick actions, IME-safe input handling, focus restore, and accessible active-option semantics.
-- Merged `TASK-298` via PR [#394](https://github.com/Sora-bluesky/winsmux/pull/394), rewriting `README.ja.md` to match the public operator model, shrinking maintainer-only planning readmes into internal stubs, and making tracked public config/docs safer for external users.
-- Re-synced the external planning backlog/roadmap after PR [#394](https://github.com/Sora-bluesky/winsmux/pull/394), marking `TASK-298` as done so `v0.20.0` now shows `100% (12/12)`.
-- Drafted the `v0.20.0` release notes and X thread in the external changelog root using the Codex-style release template.
-- Published `v0.20.0` from tag `465782b` via GitHub Actions run `24276032671`, then aligned `scripts/generate-release-notes.ps1` and the live release body to the Codex-style section headings.
-- Merged the repo-side `TASK-244` session board surface via PR [#371](https://github.com/Sora-bluesky/winsmux/pull/371).
-- Released `v0.19.6` from tag `eac8615` and updated the public GitHub Release body to `/release-notes` format.
-- Merged `TASK-245` via PR [#372](https://github.com/Sora-bluesky/winsmux/pull/372), adding `winsmux inbox` as the first actionable approval/review/blocker surface.
-- Merged the repo-side `TASK-256` primitives via PR [#374](https://github.com/Sora-bluesky/winsmux/pull/374): `winsmux runs [--json]` and `winsmux explain <run_id> [--json] [--follow]`.
-- Merged `TASK-257` via PR [#375](https://github.com/Sora-bluesky/winsmux/pull/375), tightening notification profiles so Telegram defaults to external-facing events only.
-- Merged `TASK-246` via PR [#376](https://github.com/Sora-bluesky/winsmux/pull/376), adding `winsmux digest [--json]` and evidence digest fields for `explain`.
-- Merged `TASK-253` via PR [#380](https://github.com/Sora-bluesky/winsmux/pull/380), extending manifest/status/board aggregation into first-class `run_packet` and `result_packet` surfaces for `winsmux runs --json` and `winsmux explain --json`.
-- Released `v0.19.7` from tag `833249a` and updated the public GitHub Release body to the standardized English `/release-notes` format.
-- Merged `TASK-285` via PR [#379](https://github.com/Sora-bluesky/winsmux/pull/379), landing the first Tauri operator workspace shell scaffold on `main`.
-- Updated the private planning backlog/roadmap so `v0.19.8`, `v0.20.x`, `v0.21.x`, `v0.22.x`, and `v0.24.x` follow the `Operator / slot / provider / verification / security monitor / Tauri shell` model.
-- Updated `TASK-257` planning notes to be channel-agnostic (`external channel` instead of `Telegram` as the design anchor) and documented the Claude Code channels abstraction in `.references`.
-- Started the repo-side `TASK-261` slice on `codex/task261-agent-slots-20260410`, adding `agent_slots[]` parsing, worker-count synthesis, setup-wizard emission, and the default project slot array.
-- Merged the repo-side `TASK-261` slice via PR [#381](https://github.com/Sora-bluesky/winsmux/pull/381), making `agent_slots[]` the project settings source of truth, rejecting malformed slot definitions fail-closed, and binding setup-wizard / orchestra-start to the canonical project root.
-- Started the repo-side `TASK-262` slice on `codex/task262-slot-provider-model-20260410`, wiring slot-level `agent/model` selection into orchestra startup, restart plans, monitor cycles, and pane scaling paths.
-- Merged the repo-side `TASK-262` slice via PR [#382](https://github.com/Sora-bluesky/winsmux/pull/382), wiring slot-level `agent/model` selection through startup, restart, monitor, and scale paths.
-- Merged the repo-side `TASK-263` slice via PR [#383](https://github.com/Sora-bluesky/winsmux/pull/383), changing legacy role layout handling from implicit count-based activation to explicit `legacy_role_layout=true` opt-in only.
-- Merged the repo-side `TASK-264` starter slice via PR [#384](https://github.com/Sora-bluesky/winsmux/pull/384), moving review-state and pipeline wording from dedicated `reviewer` targets toward generic `review target` semantics while keeping legacy `target_reviewer_*` keys readable.
-- Released `v0.19.8` from tag `6ec6522a6a9b91810a84ab97e4483cb8658e2f19`; the public GitHub Release is published at [v0.19.8](https://github.com/Sora-bluesky/winsmux/releases/tag/v0.19.8) and the binary workflow run `24234569692` completed successfully.
-- Saved `v0.19.8` post drafts to `C:\Users\komei\iCloudDrive\iCloud~md~obsidian\MainVault\ChangeLogs\winsmux\v0.19.8\release-notes.md` and `C:\Users\komei\iCloudDrive\iCloud~md~obsidian\MainVault\ChangeLogs\winsmux\v0.19.8\x-thread-draft.md`.
-- Reworked the Tauri prototype toward `TASK-285`: `winsmux-app` now renders an operator workspace shell scaffold with conversation timeline, sticky composer with inline attachments, context toggle, and a terminal utility drawer instead of a PTY-first full-window layout.
-- Added Figma high-fi anchors for `Operator Home / Inbox`, `Run Explain / Evidence`, and `Editor Secondary Surface`, and clarified how Explorer/Editor/Pane map into the new shell.
-- Tightened the `TASK-285` shell slice locally: `winsmux-app` now uses a workspace sidebar instead of generic nav, adds a Codex-style footer/status lane, keeps wrapping summary-first, and separates sidebar / conversation / editor surface / context side sheet / terminal drawer more explicitly.
-- Updated private planning notes so `TASK-101`, `TASK-285`, `TASK-287`, `TASK-292`, `TASK-294`, `TASK-297`, `TASK-107`, `TASK-138`, `TASK-286`, and `TASK-288` reflect the Codex-TUI-plus-cmux synthesis, then re-synced the external roadmap.
-- Updated the Figma `winsmux Tauri Operator Workspace` file so the high-fi home screen shows the workspace sidebar, sticky composer, and footer/status lane together.
-- Added [THIRD_PARTY_NOTICES.md](../THIRD_PARTY_NOTICES.md) and a matching `AGENTS.md` rule so direct Codex OSS UI reuse keeps Apache-2.0 attribution plus upstream source-path tracking in-repo, and documented the MIT-licensed legacy `psmux` compatibility surface from the core upstream for provenance.
-- Merged the `TASK-285` workspace-sidebar shell slice via PR [#385](https://github.com/Sora-bluesky/winsmux/pull/385), replacing the generic left-nav with a workspace sidebar and landing in-repo third-party UI provenance tracking.
-- Started the next `v0.21.0` UI slice on `codex/task297-sidebar-composer-responsive-20260410`, adding workspace-sidebar responsive behavior, composer mode chips, log semantics, and a settings/menu surface to advance `TASK-297`, `TASK-292`, `TASK-293`, and `TASK-294`.
-- Merged the `TASK-297/292/293/294` starter slice via PR [#386](https://github.com/Sora-bluesky/winsmux/pull/386), adding a responsive workspace sidebar overlay, composer mode chips, settings/menu sheet, and conversation log semantics.
-- Started the next `TASK-107` editor slice on `codex/task107-editor-secondary-surface-20260410`, wiring changed files and source context into the secondary editor surface.
-- Merged the `TASK-107` editor slice via PR [#387](https://github.com/Sora-bluesky/winsmux/pull/387), connecting the secondary editor surface to explorer selections and source-context changed files.
-- Started the workflow maintenance slice on `codex/node24-workflow-actions-20260410`, upgrading GitHub Actions core actions to Node-24-capable majors to remove runner deprecation warnings.
-- Added a durable subagent review-gate rule to [AGENTS.md](../AGENTS.md): close completed review agents promptly, prefer fresh agents per PR slice, wait longer before declaring timeout, and record fallback review grounds explicitly when timeouts persist.
-- Merged the workflow maintenance slice via PR [#388](https://github.com/Sora-bluesky/winsmux/pull/388), upgrading core GitHub Actions dependencies to Node-24-capable majors and landing the durable subagent review-gate workflow rule in [AGENTS.md](../AGENTS.md).
-- Swapped `v0.20.0` and `v0.21.0` in the private planning backlog/roadmap so release numbering matches actual implementation order, then re-synced [ROADMAP.md](C:\Users\komei\iCloudDrive\iCloud~md~obsidian\MainVault\Projects\winsmux\planning\ROADMAP.md).
-- Started the next `v0.20.0` desktop UX slice on top of `TASK-138`, unifying source-control/worktree mock data into a single `sourceControlState` view model and wiring sidebar source summary, source-entry filters, context overview cards, and changed-file rows to the same state.
-- Merged the `TASK-138` source-control context slice via PR [#389](https://github.com/Sora-bluesky/winsmux/pull/389), making the desktop UX source-control surface worktree-aware and editor-linked from a single `sourceControlState`.
-- Started the `TASK-101` theme-contract slice on `codex/task101-theme-contract-20260411`, adding semantic theme tokens, Codex-derived typography tokens, and `Theme / Density / Wrap` state to the settings sheet.
-- Merged the `TASK-101` theme-contract slice via PR [#390](https://github.com/Sora-bluesky/winsmux/pull/390), adding semantic theme tokens, theme/density/wrap controls, and Codex OSS attribution for reused styling patterns.
-- Started the active `v0.20.0` desktop UX slice on `codex/v0200-operator-timeline-public-docs-20260411`, combining `TASK-292`, `TASK-286`, and public operator-doc cleanup: composer attachments now support paste/drag-drop/file-picker, the conversation shell is moving to a concise filtered activity feed, and public operator docs are being split from contributor dogfooding docs.
-- Expanded the active slice to include `TASK-299`, adding strict public operator/pane role-definition docs (`.claude/CLAUDE.md`, `AGENT-BASE.md`, `AGENT.md`, `GEMINI.md`, `docs/operator-model.md`) and aligning the timeline grammar with pane result reports.
-- Merged the public operator/pane docs and concise timeline slice via PR [#392](https://github.com/Sora-bluesky/winsmux/pull/392), adding `AGENT-BASE.md`, `AGENT.md`, the strict-default `.claude/CLAUDE.md`, the reworked `docs/operator-model.md`, and pane report cards with `STATUS/TASK/RESULT/FILES_CHANGED/ISSUES`.
-- Re-synced the external planning backlog/roadmap after PR [#392](https://github.com/Sora-bluesky/winsmux/pull/392), marking `TASK-101`, `TASK-286`, `TASK-292`, and `TASK-299` as done so `v0.20.0` now shows `83% (10/12)`.
-- Started `TASK-287` on `codex/task287-command-bar-20260411`, adding a keyboard-first command bar (`Ctrl/Cmd+K`) with quick actions for dispatch/review/explain, source context, settings, and terminal control.
-- Started `TASK-298` cleanup on `codex/task298-public-surface-cleanup-20260411`, removing maintainer-heavy content from public docs/config, rewriting `README.ja.md`, and shrinking tracked planning readmes into internal stubs.
+- Added `winsmux-core/scripts/pane-env.ps1` to formalize hook-profile / governance-mode resolution and pane env payload generation.
+- Updated `winsmux-core/scripts/orchestra-start.ps1` and `scripts/start-orchestra.ps1` to use the shared pane env / hook-profile contract.
+- Extended `winsmux-core/scripts/doctor.ps1` with hook profile, governance mode, and `WINSMUX_*` env contract checks.
+- Added send-side security policy blocking in `scripts/winsmux-core.ps1` and one-shot pre-dispatch policy blocking in `winsmux-core/scripts/team-pipeline.ps1`.
+- Documented the Codex worktree git sandbox limitation in `README.md`, `README.ja.md`, and `docs/TROUBLESHOOTING.md`.
+- Rebaselined external planning locally so `v0.20.3` now reads as `Governance Baseline, Env Contracts & Security Policy Enforcement`; final `done` state will be applied only after merge/release.
+- Ran `/review` twice via Codex CLI against the current working-tree diff; both attempts timed out with `no result yet`.
+- Spawned fresh review explorers `Fermat` and `Locke`; both also remain `no result yet` after a 35-second wait and have not yet produced findings.
 
 ## Validation
 
-- Docs-only change; no tests run.
-- Release workflow passed for `v0.19.6`.
-- Release workflow passed for `v0.19.7`.
-- Release workflow passed for `v0.19.8`: GitHub Actions run `24234569692` published `winsmux-x64.exe`, `winsmux-arm64.exe`, and `SHA256SUMS`.
-- `TASK-244` PR CI passed before merge.
-- `TASK-245` PR CI passed before merge.
-- `TASK-246` focused regression passed before merge: `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `101/101 PASS`.
-- `TASK-253` focused regression passed before merge: `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `103/103 PASS`.
-- Current Tauri shell scaffold passes frontend build: `npm run build` in `winsmux-app`.
-- Composer scaffold matches the intended keyboard contract (`Enter` sends, `Shift+Enter` inserts newline, IME composition Enter does not send), and Context/Terminal toggles expose disclosure semantics via `aria-controls` plus `aria-expanded`.
-- `TASK-261` settings/layout regression passed before merge: `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `110/110 PASS`.
-- Current `TASK-262` slot wiring regression passes locally: `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `113/113 PASS`.
-- `TASK-263` explicit legacy opt-in regression passed before merge: `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `115/115 PASS`.
-- `TASK-264` starter regression passed before merge: `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `116/116 PASS`.
-- Current Tauri workspace-sidebar slice passes frontend build: `npm run build` in `winsmux-app`.
-- Current `TASK-297/292/293/294` starter slice passes frontend build: `npm run build` in `winsmux-app`.
-- Current `TASK-107` editor slice is merged via PR [#387](https://github.com/Sora-bluesky/winsmux/pull/387).
-- PR [#388](https://github.com/Sora-bluesky/winsmux/pull/388) merged cleanly and the repo is back to `main == origin/main`.
-- Current `TASK-138` source-control slice passes frontend build: `npm run build` in `winsmux-app`.
-- Current `TASK-101` theme-contract slice passes frontend build: `npm run build` in `winsmux-app`.
-- Merged `TASK-292/TASK-286/TASK-299` slice passed frontend build before landing: `npm run build` in `winsmux-app`.
-- Current `TASK-287` command-bar slice passes frontend build: `npm run build` in `winsmux-app`.
-- `TASK-298` docs/config cleanup landed via PR [#394](https://github.com/Sora-bluesky/winsmux/pull/394); its CI `Pester Tests` run `24271531120` passed before merge.
-- `v0.20.0` release workflow run `24276032671` completed successfully and published `winsmux-x64.exe`, `winsmux-arm64.exe`, and `SHA256SUMS`.
-- `TASK-187` transport slice passed focused regression before merge: `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `122/122 PASS`.
-- Current local `TASK-114` experiment-ledger slice passes focused regression: `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `123/123 PASS`.
-- PR [#396](https://github.com/Sora-bluesky/winsmux/pull/396) CI passed before merge: `Pester Tests` run `24280233475`.
-- Current local `TASK-301` write-side consultation slice passes focused regression: `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `130/130 PASS`.
-- PR [#398](https://github.com/Sora-bluesky/winsmux/pull/398) merged cleanly and the repo returned to `main == origin/main`.
-- Current local `TASK-191` consult-insertion slice passes focused regression: `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `133/133 PASS`.
-- Current local `TASK-191` consult-insertion slice passes `git diff --check` aside from benign LF->CRLF warnings on the edited files.
-- PR [#399](https://github.com/Sora-bluesky/winsmux/pull/399) merged cleanly and the repo returned to `main == origin/main`.
-- Current local `TASK-188` task-prompt-file slice passes focused regression: `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `135/135 PASS`.
-- Current local `TASK-188` task-prompt-file slice passes `git diff --check` aside from benign LF->CRLF warnings on the edited files.
-- PR [#400](https://github.com/Sora-bluesky/winsmux/pull/400) merged cleanly and the repo returned to `main == origin/main`.
-- `v0.20.1` release workflow run `24299025847` completed successfully after tag push.
-- Current local `TASK-207` + release-workflow maintenance slice passes focused regression: `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `136/136 PASS`.
-- Current local `TASK-207` + release-workflow maintenance slice passes `git diff --check` aside from benign LF->CRLF warnings on edited files.
-- Current local `TASK-210` runtime-contract slice passes focused regression: `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `136/136 PASS`.
-- Current local `TASK-210` runtime-contract slice passes focused regression: `Invoke-Pester tests/Integration.GateEnforcement.Tests.ps1` -> `45/45 PASS`.
-- Current local `TASK-210` runtime-contract slice passes `git diff --check` aside from benign LF->CRLF warnings on edited files.
-- Current local `v0.20.2` closing slice passes focused regression: `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `141/141 PASS`.
-- Current local `v0.20.2` closing slice passes `git diff --check` aside from benign LF->CRLF warnings on edited files.
-- PR [#403](https://github.com/Sora-bluesky/winsmux/pull/403) CI passed before merge: `Pester Tests` run `24300148509`.
-- `v0.20.2` release workflow run `24300269827` completed successfully and published `winsmux-x64.exe`, `winsmux-arm64.exe`, and `SHA256SUMS`.
-- Current local release-formatting slice passes `pwsh scripts/generate-release-notes.ps1 -Version v0.20.2 ...` and `git diff --check` aside from benign LF->CRLF warnings on edited files.
+- PowerShell parser checks passed for:
+  - `winsmux-core/scripts/pane-env.ps1`
+  - `winsmux-core/scripts/orchestra-start.ps1`
+  - `winsmux-core/scripts/team-pipeline.ps1`
+  - `winsmux-core/scripts/doctor.ps1`
+  - `scripts/start-orchestra.ps1`
+  - `scripts/winsmux-core.ps1`
+- `node --check .claude/hooks/sh-session-start.js` passed.
+- `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `148/148 PASS`.
+- `git diff --check` shows only benign `LF -> CRLF` warnings on edited files.
+- Review gate status: `no result yet`; fallback gate is currently `manual diff review + parser checks + 148/148 PASS + git diff --check`.
 
 ## Next actions
 
-1. Start `v0.20.3` from `TASK-309` or another governance/runtime-contract slice.
-2. Keep `TASK-308` as the explicit `v0.22.1` Playwright viewport / overlap / drawer quality gate for the Tauri desktop shell.
-3. Preserve the Codex-style English release format for future GitHub Releases.
+1. Wait once more for fresh review results; if none arrive, proceed with fallback gate.
+2. Commit, push, and open the `v0.20.3` implementation PR from `codex/v0203-governance-env-security-20260412`.
+3. Merge after CI, publish `v0.20.3`, and close issue `#260`.
 
 ## Notes
 
-- `HANDOFF.md` at the repository root is historical context and no longer authoritative.
-- Public tracked files must not contain personal paths or private planning roots.
-- External planning source of truth stays outside the public repository and is resolved via the configured planning root.
-- Public docs may refer to the external planning contract, but must not embed machine-specific absolute paths.
-- `v0.21.2` release gate includes a required `README.md` / `README.ja.md` refresh so the terminal-based final form is documented before `v0.22.0` begins the desktop control-plane handoff.
-- Public GitHub Release titles and bodies are standardized in English, even when the working session is conducted in Japanese.
-- Before each release, explicitly re-check the boundary between public product docs/config and maintainer dogfooding material.
+- Public GitHub Releases must stay English and use the Codex-style headings plus inline issue/PR refs.
+- `TASK-162` is intentionally shipped as a governance baseline only; per-call cost tracking moved to `TASK-310`.
+- Before release, re-run the public-vs-dogfooding gate and keep the README/troubleshooting language external-user-safe.

--- a/scripts/start-orchestra.ps1
+++ b/scripts/start-orchestra.ps1
@@ -27,6 +27,10 @@ param(
 )
 
 [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+$paneEnvScript = Join-Path $PSScriptRoot '..\winsmux-core\scripts\pane-env.ps1'
+if (Test-Path $paneEnvScript -PathType Leaf) {
+    . $paneEnvScript
+}
 
 function Show-WinsmuxBanner {
     $bannerScript = Join-Path $PSScriptRoot "banner.mjs"
@@ -83,16 +87,20 @@ if ($Agents.Count -ne $expectedPanes) {
 
 # --- Shield Harness (opt-in) ---
 $shieldActive = $false
+$hookProfile = 'standard'
+if (Get-Command Resolve-WinsmuxHookProfile -ErrorAction SilentlyContinue) {
+    $hookProfile = Resolve-WinsmuxHookProfile -ProjectDir $ProjectDir
+}
 if ($ShieldHarness) {
     $markerFile = Join-Path $ProjectDir ".claude\hooks\sh-gate.js"
     if (Test-Path $markerFile) {
-        Write-Output "[shield-harness] Detected in $ProjectDir"
+        Write-Output "[shield-harness] Detected in $ProjectDir (profile: $hookProfile)"
         $shieldActive = $true
     } else {
-        Write-Output "[shield-harness] Initializing in $ProjectDir ..."
+        Write-Output "[shield-harness] Initializing in $ProjectDir (profile: $hookProfile) ..."
         Push-Location $ProjectDir
         try {
-            npx shield-harness init --profile standard
+            npx shield-harness init --profile $hookProfile
             if ($LASTEXITCODE -eq 0) {
                 Write-Output "[shield-harness] Initialized successfully"
                 $shieldActive = $true
@@ -104,6 +112,11 @@ if ($ShieldHarness) {
         }
         Pop-Location
     }
+}
+
+$governanceMode = 'standard'
+if (Get-Command Resolve-WinsmuxGovernanceMode -ErrorAction SilentlyContinue) {
+    $governanceMode = Resolve-WinsmuxGovernanceMode -ProjectDir $ProjectDir
 }
 
 # --- Approval-free mode flags (only with ShieldHarness) ---
@@ -314,7 +327,13 @@ for ($i = 0; $i -lt $Agents.Count; $i++) {
     $agent = $Agents[$i]
     $paneId = $paneIds[$i]
     $cmd = Get-ApprovalFreeCommand $agent.command
-    winsmux send-keys -t $paneId "cd $ProjectDir && $cmd" Enter
+    $envPrefix = @(
+        ('$env:WINSMUX_ORCHESTRA_SESSION = ''{0}''' -f ($session -replace "'", "''"))
+        ('$env:WINSMUX_ORCHESTRA_PROJECT_DIR = ''{0}''' -f ($ProjectDir -replace "'", "''"))
+        ('$env:WINSMUX_HOOK_PROFILE = ''{0}''' -f ($hookProfile -replace "'", "''"))
+        ('$env:WINSMUX_GOVERNANCE_MODE = ''{0}''' -f ($governanceMode -replace "'", "''"))
+    ) -join '; '
+    winsmux send-keys -t $paneId "$envPrefix; cd $ProjectDir; $cmd" Enter
 }
 
 # --- Startup verification ---
@@ -332,6 +351,13 @@ if ($codexConfigBackup) {
 # --- Summary ---
 Write-Output ""
 Write-Output "Orchestra started in session '$session' (${Rows}x${Cols} grid)"
+if (Get-Command Resolve-WinsmuxHookProfile -ErrorAction SilentlyContinue) {
+    try {
+        Write-Output "  Hook profile:  $(Resolve-WinsmuxHookProfile -ProjectDir $ProjectDir)"
+    } catch {
+        Write-Warning "Hook profile resolution failed: $($_.Exception.Message)"
+    }
+}
 foreach ($agent in $Agents) {
     $pad = ($agent.label).PadRight(14)
     Write-Output "  ${pad} $($paneMap[$agent.label])  ($($agent.command))"

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -20,6 +20,7 @@ $PaneControlScript = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\
 $PaneStatusScript = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\winsmux-core\scripts\pane-status.ps1'))
 $RoleGateScript = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\winsmux-core\scripts\role-gate.ps1'))
 $ClmSafeIoScript = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\winsmux-core\scripts\clm-safe-io.ps1'))
+$PaneEnvScript = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\winsmux-core\scripts\pane-env.ps1'))
 
 if (Test-Path $BridgeSettingsScript -PathType Leaf) {
     . $BridgeSettingsScript
@@ -39,6 +40,10 @@ if (Test-Path $RoleGateScript -PathType Leaf) {
 
 if (Test-Path $ClmSafeIoScript -PathType Leaf) {
     . $ClmSafeIoScript
+}
+
+if (Test-Path $PaneEnvScript -PathType Leaf) {
+    . $PaneEnvScript
 }
 
 # --- Windows Credential Manager P/Invoke ---
@@ -475,6 +480,86 @@ function Resolve-SupportedPromptTransport {
     }
 
     return $resolved
+}
+
+function Get-BridgeSecurityPolicyRuleList {
+    param(
+        [AllowNull()]$SecurityPolicy,
+        [Parameter(Mandatory = $true)][string]$Key
+    )
+
+    if ($null -eq $SecurityPolicy) {
+        return @()
+    }
+
+    if ($SecurityPolicy -is [System.Collections.IDictionary] -and $SecurityPolicy.Contains($Key)) {
+        return @($SecurityPolicy[$Key] | Where-Object { -not [string]::IsNullOrWhiteSpace([string]$_) })
+    }
+
+    if ($null -ne $SecurityPolicy.PSObject -and $SecurityPolicy.PSObject.Properties.Name -contains $Key) {
+        return @($SecurityPolicy.$Key | Where-Object { -not [string]::IsNullOrWhiteSpace([string]$_) })
+    }
+
+    return @()
+}
+
+function Find-SendSecurityPolicyViolation {
+    param(
+        [Parameter(Mandatory = $true)][string]$Text,
+        [AllowNull()]$SecurityPolicy
+    )
+
+    if ($null -eq $SecurityPolicy) {
+        return $null
+    }
+
+    $mode = ''
+    if ($SecurityPolicy -is [System.Collections.IDictionary] -and $SecurityPolicy.Contains('mode')) {
+        $mode = [string]$SecurityPolicy['mode']
+    } elseif ($null -ne $SecurityPolicy.PSObject -and $SecurityPolicy.PSObject.Properties.Name -contains 'mode') {
+        $mode = [string]$SecurityPolicy.mode
+    }
+    $mode = $mode.Trim().ToLowerInvariant()
+    if ([string]::IsNullOrWhiteSpace($mode)) {
+        $mode = 'blocklist'
+    }
+
+    $allowPatterns = @(Get-BridgeSecurityPolicyRuleList -SecurityPolicy $SecurityPolicy -Key 'allow_patterns')
+    $blockPatterns = @(Get-BridgeSecurityPolicyRuleList -SecurityPolicy $SecurityPolicy -Key 'block_patterns')
+
+    foreach ($pattern in $blockPatterns) {
+        if ($Text -match $pattern) {
+            return [ordered]@{
+                verdict = 'BLOCK'
+                reason = "send matched blocked security policy pattern '$pattern'"
+                pattern = $pattern
+                mode = $mode
+                allow = @($allowPatterns)
+                block = @($blockPatterns)
+                next_action = 'revise_request_or_override'
+            }
+        }
+    }
+
+    if ($mode -eq 'allowlist' -and $allowPatterns.Count -gt 0) {
+        foreach ($pattern in $allowPatterns) {
+            if ($Text -match $pattern) {
+                return $null
+            }
+        }
+
+        return [ordered]@{
+            verdict = 'BLOCK'
+            reason = 'send did not match any allow_patterns entry required by allowlist security policy'
+            pattern = ''
+            mode = $mode
+            allow = @($allowPatterns)
+            block = @($blockPatterns)
+            next_action = 'revise_request_or_override'
+        }
+    }
+
+    return $null
 }
 
 function Resolve-SendDispatchPayload {
@@ -2173,6 +2258,35 @@ function Invoke-Send {
                 $execMode = $execModeValue.Trim().ToLowerInvariant() -eq 'true' -and [string]$agentConfig.Agent -eq 'codex'
             }
         } catch {
+        }
+    }
+
+    if ($null -ne $context -and $null -ne $context.SecurityPolicy) {
+        $policyViolation = Find-SendSecurityPolicyViolation -Text $text -SecurityPolicy $context.SecurityPolicy
+        if ($null -ne $policyViolation) {
+            $eventRecord = [ordered]@{
+                timestamp = [System.DateTimeOffset]::Now.ToString('o')
+                session   = [string]$context.SessionName
+                event     = 'security.policy.blocked'
+                message   = [string]$policyViolation['reason']
+                label     = [string]$context.Label
+                pane_id   = [string]$context.PaneId
+                role      = [string]$context.Role
+                branch    = [string]$context.Branch
+                head_sha  = [string]$context.HeadSha
+                data      = [ordered]@{
+                    verdict     = [string]$policyViolation['verdict']
+                    reason      = [string]$policyViolation['reason']
+                    pattern     = [string]$policyViolation['pattern']
+                    mode        = [string]$policyViolation['mode']
+                    allow       = @($policyViolation['allow'])
+                    block       = @($policyViolation['block'])
+                    next_action = [string]$policyViolation['next_action']
+                    target      = $Target
+                }
+            }
+            Write-BridgeEventRecord -ProjectDir $projectDir -EventRecord $eventRecord | Out-Null
+            Stop-WithError ([string]$policyViolation['reason'])
         }
     }
 

--- a/tests/psmux-bridge.Tests.ps1
+++ b/tests/psmux-bridge.Tests.ps1
@@ -835,6 +835,93 @@ NEXT_ACTION: rerun focused verification
         $script:securityEventWrites[0].Data.verdict | Should -Be 'BLOCK'
     }
 
+    It 'blocks explicit git commands in plan prompts before dispatch' {
+        $script:securityEventWrites = @()
+        Mock Write-TeamPipelineEvent {
+            param($ProjectDir, $SessionName, $Event, $Message, $Role, $PaneId, $Target, $Data)
+            $script:securityEventWrites += [PSCustomObject]@{
+                Event = $Event
+                Target = $Target
+                Data = $Data
+            }
+        }
+
+        $result = Invoke-TeamPipelineGuardedSend -StageName 'PLAN' -Target 'researcher' -Prompt "git commit -m 'oops'" -ProjectDir 'C:\repo' -SessionName 'winsmux-orchestra' -Role 'Researcher' -Task 'Investigate cache drift'
+
+        $result.Status | Should -Be 'BLOCKED'
+        $result.SecurityVerdict.verdict | Should -Be 'BLOCK'
+        $result.SecurityVerdict.stage | Should -Be 'PLAN'
+        $script:securityEventWrites.Count | Should -Be 1
+        $script:securityEventWrites[0].Data.category | Should -Be 'git'
+    }
+
+    It 'blocks explicit destructive commands in consult prompts before dispatch' {
+        $script:securityEventWrites = @()
+        Mock Write-TeamPipelineEvent {
+            param($ProjectDir, $SessionName, $Event, $Message, $Role, $PaneId, $Target, $Data)
+            $script:securityEventWrites += [PSCustomObject]@{
+                Event = $Event
+                Target = $Target
+                Data = $Data
+            }
+        }
+
+        $result = Invoke-TeamPipelineConsultStage -Mode 'stuck' -Task 'Investigate cache drift' -BuilderLabel 'builder-1' -ProjectDir 'C:\repo' -SessionName 'winsmux-orchestra' -TargetLabel 'reviewer' -ReviewerLabel 'reviewer' -BuilderWorktreePath 'C:\repo\.worktrees\builder-1' -BuildSummary 'Remove-Item logs -Recurse -Force'
+
+        $result.Status | Should -Be 'BLOCKED'
+        $result.SecurityVerdict.verdict | Should -Be 'BLOCK'
+        $result.SecurityVerdict.stage | Should -Be 'CONSULT_STUCK'
+        $script:securityEventWrites.Count | Should -Be 1
+        @($script:securityEventWrites | Select-Object -ExpandProperty Event) | Should -Be @('pipeline.security.blocked')
+    }
+
+    It 'does not record review dispatched when verify prompt is blocked before send' {
+        $manifest = [PSCustomObject]@{
+            Session = [PSCustomObject]@{
+                name        = 'winsmux-orchestra'
+                project_dir = 'C:\repo'
+            }
+            Panes = [ordered]@{
+                'builder-1' = [PSCustomObject]@{ pane_id = '%2'; role = 'Builder'; builder_worktree_path = 'C:\repo\.worktrees\builder-1' }
+                'reviewer'  = [PSCustomObject]@{ pane_id = '%4'; role = 'Reviewer'; launch_dir = 'C:\repo' }
+            }
+        }
+
+        $script:teamPipelineBridgeCalls = @()
+        $script:teamPipelineEvents = @()
+
+        Mock Read-TeamPipelineManifest { $manifest }
+        Mock Invoke-TeamPipelineBridge {
+            param([string[]]$Arguments, [switch]$AllowFailure)
+            $script:teamPipelineBridgeCalls += ,@($Arguments)
+            [PSCustomObject]@{ ExitCode = 0; Output = '' }
+        }
+        Mock Wait-TeamPipelineStage {
+            param([string]$Target, [string]$StageName, [int]$TimeoutSeconds, [int]$PollIntervalSeconds)
+            switch ($StageName) {
+                'PLAN' { return [PSCustomObject]@{ Stage = $StageName; Target = $Target; Status = 'PLAN_DONE'; Summary = 'plan summary'; Transcript = '' } }
+                'CONSULT_EARLY' { return [PSCustomObject]@{ Stage = $StageName; Target = $Target; Status = 'CONSULT_DONE'; Summary = 'early consult summary'; Transcript = '' } }
+                'EXEC' { return [PSCustomObject]@{ Stage = $StageName; Target = $Target; Status = 'EXEC_DONE'; Summary = "git commit -m 'oops'"; Transcript = '' } }
+                default { throw "Unexpected stage $StageName" }
+            }
+        }
+        Mock Write-TeamPipelineEvent {
+            param($ProjectDir, $SessionName, $Event, $Message, $Role, $PaneId, $Target, $Data)
+            $script:teamPipelineEvents += [PSCustomObject]@{
+                Event = $Event
+                Role = $Role
+                Target = $Target
+                Data = $Data
+            }
+        }
+
+        $result = Invoke-TeamPipeline -Task 'Investigate cache drift' -Builder 'builder-1' -Reviewer 'reviewer'
+
+        $result.FinalStatus | Should -Be 'VERIFY_BLOCKED'
+        @($script:teamPipelineEvents | Where-Object { $_.Event -eq 'pipeline.review.dispatched' }).Count | Should -Be 0
+        @($script:teamPipelineEvents | Where-Object { $_.Event -eq 'pipeline.security.blocked' }).Count | Should -BeGreaterThan 0
+    }
+
     It 'selects sensible planning and verification targets from the available roles' {
         $defaultTargets = Get-TeamPipelineStageTargets -BuilderLabel 'builder-1' -ResearcherLabel 'researcher' -ReviewerLabel 'reviewer'
         $defaultTargets.PlanTarget | Should -Be 'researcher'
@@ -959,6 +1046,79 @@ NEXT_ACTION: rerun focused verification
         $result.StuckConsults[0].Status | Should -Be 'CONSULT_DONE'
         @($script:teamPipelineEvents | Where-Object { $_.Event -eq 'pipeline.consult.dispatched' }).Count | Should -Be 2
         @($script:teamPipelineEvents | Where-Object { $_.Event -eq 'pipeline.consult.completed' }).Count | Should -Be 2
+    }
+}
+
+Describe 'winsmux pane env contract' {
+    BeforeAll {
+        . (Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\pane-env.ps1')
+    }
+
+    BeforeEach {
+        $script:paneEnvTempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('winsmux-pane-env-tests-' + [guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path (Join-Path $script:paneEnvTempRoot '.winsmux') -Force | Out-Null
+        $script:previousHookProfile = $env:WINSMUX_HOOK_PROFILE
+        $script:previousGovernanceMode = $env:WINSMUX_GOVERNANCE_MODE
+    }
+
+    AfterEach {
+        if ($null -eq $script:previousHookProfile) {
+            Remove-Item Env:WINSMUX_HOOK_PROFILE -ErrorAction SilentlyContinue
+        } else {
+            $env:WINSMUX_HOOK_PROFILE = $script:previousHookProfile
+        }
+
+        if ($null -eq $script:previousGovernanceMode) {
+            Remove-Item Env:WINSMUX_GOVERNANCE_MODE -ErrorAction SilentlyContinue
+        } else {
+            $env:WINSMUX_GOVERNANCE_MODE = $script:previousGovernanceMode
+        }
+
+        if ($script:paneEnvTempRoot -and (Test-Path $script:paneEnvTempRoot)) {
+            Remove-Item -Path $script:paneEnvTempRoot -Recurse -Force
+        }
+    }
+
+    It 'reads hook profile and governance mode from governance.yaml when env vars are absent' {
+@'
+mode: enhanced
+hook_profile: builder
+'@ | Set-Content -Path (Join-Path $script:paneEnvTempRoot '.winsmux\governance.yaml') -Encoding UTF8
+
+        $contract = Get-WinsmuxEnvironmentContract -ProjectDir $script:paneEnvTempRoot
+
+        $contract.hook_profile | Should -Be 'builder'
+        $contract.governance_mode | Should -Be 'enhanced'
+        $contract.variable_names | Should -Contain 'WINSMUX_HOOK_PROFILE'
+        $contract.variable_names | Should -Contain 'WINSMUX_GOVERNANCE_MODE'
+    }
+
+    It 'lets WINSMUX_HOOK_PROFILE and WINSMUX_GOVERNANCE_MODE override governance.yaml' {
+@'
+mode: core
+hook_profile: ci
+'@ | Set-Content -Path (Join-Path $script:paneEnvTempRoot '.winsmux\governance.yaml') -Encoding UTF8
+        $env:WINSMUX_HOOK_PROFILE = 'commander'
+        $env:WINSMUX_GOVERNANCE_MODE = 'standard'
+
+        (Resolve-WinsmuxHookProfile -ProjectDir $script:paneEnvTempRoot) | Should -Be 'commander'
+        (Resolve-WinsmuxGovernanceMode -ProjectDir $script:paneEnvTempRoot) | Should -Be 'standard'
+    }
+
+    It 'builds a normalized pane environment payload' {
+        $env:WINSMUX_HOOK_PROFILE = 'builder'
+        $env:WINSMUX_GOVERNANCE_MODE = 'enhanced'
+
+        $payload = Get-WinsmuxPaneEnvironment -Role 'Worker' -PaneId '%4' -SessionName 'winsmux-orchestra' -ProjectDir $script:paneEnvTempRoot -RoleMapJson '{"%4":"Worker"}' -BuilderWorktreePath 'C:\repo\.worktrees\builder-1'
+
+        $payload.WINSMUX_ORCHESTRA_SESSION | Should -Be 'winsmux-orchestra'
+        $payload.WINSMUX_ORCHESTRA_PROJECT_DIR | Should -Be $script:paneEnvTempRoot
+        $payload.WINSMUX_ROLE | Should -Be 'Worker'
+        $payload.WINSMUX_PANE_ID | Should -Be '%4'
+        $payload.WINSMUX_ROLE_MAP | Should -Be '{"%4":"Worker"}'
+        $payload.WINSMUX_BUILDER_WORKTREE | Should -Be 'C:\repo\.worktrees\builder-1'
+        $payload.WINSMUX_HOOK_PROFILE | Should -Be 'builder'
+        $payload.WINSMUX_GOVERNANCE_MODE | Should -Be 'enhanced'
     }
 }
 
@@ -4980,6 +5140,29 @@ Describe 'winsmux send dispatch payload' {
 
     It 'rejects unsupported prompt transport values' {
         { Resolve-SendDispatchPayload -Text 'Write-Host short' -ProjectDir $script:sendTempRoot -LengthLimit 4000 -PromptTransport 'stdin' } | Should -Throw '*prompt_transport*'
+    }
+
+    It 'blocks send text when a blocklist security policy pattern matches' {
+        $violation = Find-SendSecurityPolicyViolation -Text 'git reset --hard origin/main' -SecurityPolicy ([ordered]@{
+            mode = 'blocklist'
+            allow_patterns = @('Invoke-Pester')
+            block_patterns = @('git reset --hard')
+        })
+
+        $violation.verdict | Should -Be 'BLOCK'
+        $violation.mode | Should -Be 'blocklist'
+        @($violation.block) | Should -Be @('git reset --hard')
+    }
+
+    It 'blocks allowlist sends when no allow pattern matches' {
+        $violation = Find-SendSecurityPolicyViolation -Text 'Write-Host short' -SecurityPolicy ([ordered]@{
+            mode = 'allowlist'
+            allow_patterns = @('Invoke-Pester')
+            block_patterns = @()
+        })
+
+        $violation.verdict | Should -Be 'BLOCK'
+        $violation.reason | Should -Match 'allow_patterns'
     }
 }
 

--- a/winsmux-core/scripts/doctor.ps1
+++ b/winsmux-core/scripts/doctor.ps1
@@ -10,6 +10,7 @@ Set-StrictMode -Version Latest
 [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
 
 . (Join-Path $PSScriptRoot 'planning-paths.ps1')
+. (Join-Path $PSScriptRoot 'pane-env.ps1')
 
 function New-DoctorResult {
     param(
@@ -403,6 +404,43 @@ function Test-BridgeConfigCheck {
     return New-DoctorResult -Status pass -Label '.winsmux.yaml' -Detail 'found'
 }
 
+function Test-HookProfileCheck {
+    $repoRoot = Get-DoctorRepoRoot
+
+    try {
+        $profile = Resolve-WinsmuxHookProfile -ProjectDir $repoRoot
+    } catch {
+        return New-DoctorResult -Status fail -Label 'Hook profile' -Detail $_.Exception.Message
+    }
+
+    return New-DoctorResult -Status pass -Label 'Hook profile' -Detail $profile
+}
+
+function Test-GovernanceModeCheck {
+    $repoRoot = Get-DoctorRepoRoot
+
+    try {
+        $mode = Resolve-WinsmuxGovernanceMode -ProjectDir $repoRoot
+    } catch {
+        return New-DoctorResult -Status fail -Label 'Governance mode' -Detail $_.Exception.Message
+    }
+
+    return New-DoctorResult -Status pass -Label 'Governance mode' -Detail $mode
+}
+
+function Test-WinsmuxEnvContractCheck {
+    $repoRoot = Get-DoctorRepoRoot
+
+    try {
+        $contract = Get-WinsmuxEnvironmentContract -ProjectDir $repoRoot
+    } catch {
+        return New-DoctorResult -Status fail -Label 'WINSMUX env contract' -Detail $_.Exception.Message
+    }
+
+    $detail = "hook_profile=$($contract['hook_profile']); governance_mode=$($contract['governance_mode']); vars=$((@($contract['variable_names']) -join ','))"
+    return New-DoctorResult -Status pass -Label 'WINSMUX env contract' -Detail $detail
+}
+
 function Write-DoctorResult {
     param([Parameter(Mandatory = $true)]$Result)
 
@@ -419,6 +457,9 @@ $results = @(
     Test-StaleWorktreesCheck
     Test-ZombieProcessesCheck
     Test-BridgeConfigCheck
+    Test-HookProfileCheck
+    Test-GovernanceModeCheck
+    Test-WinsmuxEnvContractCheck
 )
 
 $hasFail = $false

--- a/winsmux-core/scripts/orchestra-start.ps1
+++ b/winsmux-core/scripts/orchestra-start.ps1
@@ -7,6 +7,7 @@ $scriptDir = $PSScriptRoot
 . "$scriptDir/agent-readiness.ps1"
 . "$scriptDir/orchestra-preflight.ps1"
 . "$scriptDir/manifest.ps1"
+. "$scriptDir/pane-env.ps1"
 
 Set-StrictMode -Version Latest
 [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
@@ -1315,7 +1316,13 @@ if ($MyInvocation.InvocationName -ne '.') {
     foreach ($pane in @($layout.Panes)) {
         $sessionRoleMap[[string]$pane.PaneId] = Get-CanonicalRole -AssignmentRole ([string]$pane.Role)
     }
-    Set-OrchestraSessionEnvironment -SessionName $sessionName -Name 'WINSMUX_ROLE_MAP' -Value (($sessionRoleMap | ConvertTo-Json -Compress))
+    $sessionRoleMapJson = ($sessionRoleMap | ConvertTo-Json -Compress)
+    $environmentContract = Get-WinsmuxEnvironmentContract -ProjectDir $projectDir
+    Set-OrchestraSessionEnvironment -SessionName $sessionName -Name 'WINSMUX_ORCHESTRA_SESSION' -Value $sessionName
+    Set-OrchestraSessionEnvironment -SessionName $sessionName -Name 'WINSMUX_ORCHESTRA_PROJECT_DIR' -Value $projectDir
+    Set-OrchestraSessionEnvironment -SessionName $sessionName -Name 'WINSMUX_ROLE_MAP' -Value $sessionRoleMapJson
+    Set-OrchestraSessionEnvironment -SessionName $sessionName -Name 'WINSMUX_HOOK_PROFILE' -Value ([string]$environmentContract['hook_profile'])
+    Set-OrchestraSessionEnvironment -SessionName $sessionName -Name 'WINSMUX_GOVERNANCE_MODE' -Value ([string]$environmentContract['governance_mode'])
 
     $paneSummaries = [System.Collections.Generic.List[object]]::new()
     $builderIndex = 0
@@ -1349,19 +1356,19 @@ if ($MyInvocation.InvocationName -ne '.') {
 
         Invoke-Bridge -Arguments @('name', $paneId, $label)
         try {
-            Set-OrchestraSessionEnvironment -SessionName $sessionName -Name 'WINSMUX_ROLE' -Value $canonicalRole
-            Set-OrchestraSessionEnvironment -SessionName $sessionName -Name 'WINSMUX_PANE_ID' -Value $paneId
+            $paneEnvironment = Get-WinsmuxPaneEnvironment -Role $canonicalRole -PaneId $paneId -SessionName $sessionName -ProjectDir $projectDir -RoleMapJson $sessionRoleMapJson -BuilderWorktreePath $builderWorktreePath
+            foreach ($entry in $paneEnvironment.GetEnumerator()) {
+                if ($entry.Key -in @('WINSMUX_ROLE', 'WINSMUX_PANE_ID')) {
+                    Set-OrchestraSessionEnvironment -SessionName $sessionName -Name ([string]$entry.Key) -Value ([string]$entry.Value)
+                }
+            }
             Invoke-Winsmux -Arguments @('respawn-pane', '-k', '-t', $paneId, '-c', $launchDir)
             Wait-PaneShellReady -PaneId $paneId
             # TASK-236: set cwd via cd (respawn-pane -c unreliable on Windows)
             Send-OrchestraBridgeCommand -Target $paneId -Text "cd $(ConvertTo-PowerShellLiteral -Value $launchDir)"
             Start-Sleep -Milliseconds 500
-            # TASK-236: inject role and pane_id into pane process
-            Send-OrchestraBridgeCommand -Target $paneId -Text "`$env:WINSMUX_ROLE = '$canonicalRole'"
-            Send-OrchestraBridgeCommand -Target $paneId -Text "`$env:WINSMUX_PANE_ID = '$paneId'"
-            # Workers currently share the Builder-style isolated worktree model.
-            if ($canonicalRole -in @('Builder', 'Worker') -and -not [string]::IsNullOrWhiteSpace($builderWorktreePath)) {
-                Send-OrchestraBridgeCommand -Target $paneId -Text "`$env:WINSMUX_BUILDER_WORKTREE = '$builderWorktreePath'"
+            foreach ($entry in $paneEnvironment.GetEnumerator()) {
+                Send-OrchestraBridgeCommand -Target $paneId -Text ('{0} = {1}' -f ('$env:' + [string]$entry.Key), (ConvertTo-PowerShellLiteral -Value ([string]$entry.Value)))
             }
             Start-Sleep -Milliseconds 300
             # TASK-231: verify pane exists after respawn

--- a/winsmux-core/scripts/pane-env.ps1
+++ b/winsmux-core/scripts/pane-env.ps1
@@ -1,0 +1,192 @@
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+function ConvertFrom-WinsmuxEnvScalar {
+    param([AllowNull()]$Value)
+
+    if ($null -eq $Value) {
+        return $null
+    }
+
+    $text = [string]$Value
+    if ([string]::IsNullOrWhiteSpace($text)) {
+        return $null
+    }
+
+    $trimmed = $text.Trim()
+    if ($trimmed.Length -ge 2) {
+        if (($trimmed.StartsWith("'") -and $trimmed.EndsWith("'")) -or ($trimmed.StartsWith('"') -and $trimmed.EndsWith('"'))) {
+            $trimmed = $trimmed.Substring(1, $trimmed.Length - 2)
+        }
+    }
+
+    if ($trimmed -eq 'null') {
+        return $null
+    }
+
+    return $trimmed
+}
+
+function Get-WinsmuxGovernanceFilePath {
+    param([string]$ProjectDir = (Get-Location).Path)
+
+    return Join-Path (Join-Path $ProjectDir '.winsmux') 'governance.yaml'
+}
+
+function Read-WinsmuxGovernanceFile {
+    param([string]$ProjectDir = (Get-Location).Path)
+
+    $path = Get-WinsmuxGovernanceFilePath -ProjectDir $ProjectDir
+    if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
+        return [ordered]@{}
+    }
+
+    $content = Get-Content -LiteralPath $path -Raw -Encoding UTF8
+    if ([string]::IsNullOrWhiteSpace($content)) {
+        return [ordered]@{}
+    }
+
+    $result = [ordered]@{}
+    foreach ($rawLine in ($content -split "\r?\n")) {
+        if ([string]::IsNullOrWhiteSpace($rawLine)) {
+            continue
+        }
+
+        $trimmed = $rawLine.Trim()
+        if ($trimmed.StartsWith('#')) {
+            continue
+        }
+
+        if ($rawLine -match '^\s') {
+            continue
+        }
+
+        if ($trimmed -notmatch '^([A-Za-z0-9_\-]+):\s*(.+?)\s*$') {
+            continue
+        }
+
+        $key = [string]$Matches[1]
+        $value = ConvertFrom-WinsmuxEnvScalar -Value $Matches[2]
+        $result[$key] = $value
+    }
+
+    return $result
+}
+
+function Get-WinsmuxSupportedHookProfiles {
+    return @('standard', 'commander', 'builder', 'ci')
+}
+
+function Resolve-WinsmuxHookProfile {
+    param(
+        [string]$ProjectDir = (Get-Location).Path,
+        [string]$EnvironmentValue = $env:WINSMUX_HOOK_PROFILE
+    )
+
+    $resolved = $EnvironmentValue
+    if ([string]::IsNullOrWhiteSpace($resolved)) {
+        $governance = Read-WinsmuxGovernanceFile -ProjectDir $ProjectDir
+        if ($governance.Contains('hook_profile')) {
+            $resolved = [string]$governance['hook_profile']
+        }
+    }
+
+    if ([string]::IsNullOrWhiteSpace($resolved)) {
+        $resolved = 'standard'
+    }
+
+    $resolved = $resolved.Trim().ToLowerInvariant()
+    if ($resolved -notin (Get-WinsmuxSupportedHookProfiles)) {
+        throw "Unsupported WINSMUX_HOOK_PROFILE '$resolved'. Supported profiles: $((Get-WinsmuxSupportedHookProfiles) -join ', ')."
+    }
+
+    return $resolved
+}
+
+function Get-WinsmuxSupportedGovernanceModes {
+    return @('core', 'standard', 'enhanced')
+}
+
+function Resolve-WinsmuxGovernanceMode {
+    param(
+        [string]$ProjectDir = (Get-Location).Path,
+        [string]$EnvironmentValue = $env:WINSMUX_GOVERNANCE_MODE
+    )
+
+    $resolved = $EnvironmentValue
+    if ([string]::IsNullOrWhiteSpace($resolved)) {
+        $governance = Read-WinsmuxGovernanceFile -ProjectDir $ProjectDir
+        if ($governance.Contains('mode')) {
+            $resolved = [string]$governance['mode']
+        }
+    }
+
+    if ([string]::IsNullOrWhiteSpace($resolved)) {
+        $resolved = 'standard'
+    }
+
+    $resolved = $resolved.Trim().ToLowerInvariant()
+    if ($resolved -notin (Get-WinsmuxSupportedGovernanceModes)) {
+        throw "Unsupported WINSMUX_GOVERNANCE_MODE '$resolved'. Supported modes: $((Get-WinsmuxSupportedGovernanceModes) -join ', ')."
+    }
+
+    return $resolved
+}
+
+function Get-WinsmuxEnvironmentVariableNames {
+    return @(
+        'WINSMUX_ORCHESTRA_SESSION',
+        'WINSMUX_ORCHESTRA_PROJECT_DIR',
+        'WINSMUX_ROLE_MAP',
+        'WINSMUX_ROLE',
+        'WINSMUX_PANE_ID',
+        'WINSMUX_BUILDER_WORKTREE',
+        'WINSMUX_HOOK_PROFILE',
+        'WINSMUX_GOVERNANCE_MODE'
+    )
+}
+
+function Get-WinsmuxEnvironmentContract {
+    param([string]$ProjectDir = (Get-Location).Path)
+
+    return [ordered]@{
+        hook_profile     = Resolve-WinsmuxHookProfile -ProjectDir $ProjectDir
+        governance_mode  = Resolve-WinsmuxGovernanceMode -ProjectDir $ProjectDir
+        governance_path  = Get-WinsmuxGovernanceFilePath -ProjectDir $ProjectDir
+        variable_names   = @(Get-WinsmuxEnvironmentVariableNames)
+    }
+}
+
+function Get-WinsmuxPaneEnvironment {
+    param(
+        [Parameter(Mandatory = $true)][string]$Role,
+        [Parameter(Mandatory = $true)][string]$PaneId,
+        [string]$SessionName = '',
+        [string]$ProjectDir = (Get-Location).Path,
+        [string]$RoleMapJson = '',
+        [string]$BuilderWorktreePath = ''
+    )
+
+    $contract = Get-WinsmuxEnvironmentContract -ProjectDir $ProjectDir
+    $environment = [ordered]@{
+        WINSMUX_ORCHESTRA_PROJECT_DIR = $ProjectDir
+        WINSMUX_ROLE            = $Role
+        WINSMUX_PANE_ID         = $PaneId
+        WINSMUX_HOOK_PROFILE    = [string]$contract['hook_profile']
+        WINSMUX_GOVERNANCE_MODE = [string]$contract['governance_mode']
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($SessionName)) {
+        $environment['WINSMUX_ORCHESTRA_SESSION'] = $SessionName
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($RoleMapJson)) {
+        $environment['WINSMUX_ROLE_MAP'] = $RoleMapJson
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($BuilderWorktreePath)) {
+        $environment['WINSMUX_BUILDER_WORKTREE'] = $BuilderWorktreePath
+    }
+
+    return $environment
+}

--- a/winsmux-core/scripts/team-pipeline.ps1
+++ b/winsmux-core/scripts/team-pipeline.ps1
@@ -496,6 +496,72 @@ function Get-TeamPipelineRunPolicy {
     }
 }
 
+function Get-TeamPipelineExplicitCommandLines {
+    param([AllowNull()][string]$Text)
+
+    if ([string]::IsNullOrWhiteSpace($Text)) {
+        return @()
+    }
+
+    $result = [System.Collections.Generic.List[string]]::new()
+    foreach ($rawLine in ($Text -split "\r?\n")) {
+        $line = $rawLine.Trim()
+        if ([string]::IsNullOrWhiteSpace($line)) {
+            continue
+        }
+
+        $line = ($line -replace '^(?:[-*+]|\d+\.)\s*', '').Trim()
+        if ($line -match '^(?:pwsh|powershell|git|winsmux|apply_patch|Set-Content|Out-File|Add-Content|New-Item|Copy-Item|Move-Item|Remove-Item|curl|wget|Invoke-WebRequest|Invoke-RestMethod|npm|pnpm|yarn|pip|uv|cargo|winget|choco|scoop)\b') {
+            $result.Add($line) | Out-Null
+        }
+    }
+
+    return @($result)
+}
+
+function Find-TeamPipelineSecurityViolation {
+    param(
+        [Parameter(Mandatory = $true)][string]$StageName,
+        [AllowNull()][string]$Text
+    )
+
+    $commandLines = @(Get-TeamPipelineExplicitCommandLines -Text $Text)
+    if ($commandLines.Count -lt 1) {
+        return $null
+    }
+
+    $policy = Get-TeamPipelineRunPolicy -StageName $StageName
+    $categoryPatterns = [ordered]@{
+        write          = '(?i)\b(?:apply_patch|Set-Content|Out-File|Add-Content|New-Item|Copy-Item|Move-Item|Remove-Item)\b'
+        git            = '(?i)\bgit\s+(?:add|commit|push|merge|rebase|checkout|switch|tag|stash|reset|cherry-pick)\b'
+        network        = '(?i)\b(?:curl|wget|Invoke-WebRequest|Invoke-RestMethod|npm\s+install|pnpm\s+add|yarn\s+add|pip\s+install|uv\s+pip|cargo\s+add|winget\s+install|choco\s+install|scoop\s+install)\b'
+        destructive    = '(?im)(rm\s+-rf|Remove-Item\s+.+-Recurse.+-Force|DROP\s+TABLE|DELETE\s+FROM)'
+        force_push     = '(?i)\bgit\s+push\s+--force(?:-with-lease)?\b'
+        hard_reset     = '(?i)\bgit\s+reset\s+--hard\b'
+        recursive_delete = '(?i)\bRemove-Item\b.+-Recurse.+-Force'
+        schema_drop    = '(?i)\bDROP\s+TABLE\b'
+    }
+
+    foreach ($line in $commandLines) {
+        foreach ($blockedCategory in @($policy.block)) {
+            if (-not $categoryPatterns.Contains($blockedCategory)) {
+                continue
+            }
+
+            if ($line -match $categoryPatterns[$blockedCategory]) {
+                return [ordered]@{
+                    line = $line
+                    category = $blockedCategory
+                    reason = "stage $($policy.stage) blocks explicit $blockedCategory commands before dispatch"
+                    policy = $policy
+                }
+            }
+        }
+    }
+
+    return $null
+}
+
 function Get-TeamPipelineChangedPaths {
     param([string]$BuilderWorktreePath)
 
@@ -545,6 +611,52 @@ function New-TeamPipelineSecurityVerdict {
         allow         = @($policy.allow)
         block         = @($policy.block)
         next_action   = 'revise_request_or_override'
+    }
+}
+
+function Invoke-TeamPipelineGuardedSend {
+    param(
+        [Parameter(Mandatory = $true)][string]$StageName,
+        [Parameter(Mandatory = $true)][string]$Target,
+        [Parameter(Mandatory = $true)][string]$Prompt,
+        [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [Parameter(Mandatory = $true)][string]$SessionName,
+        [string]$Role = '',
+        [string]$Task = '',
+        [int]$Attempt = 0
+    )
+
+    $violation = Find-TeamPipelineSecurityViolation -StageName $StageName -Text $Prompt
+    if ($null -eq $violation) {
+        Invoke-TeamPipelineBridge -Arguments @('send', $Target, $Prompt) | Out-Null
+        return $null
+    }
+
+    $securityVerdict = New-TeamPipelineSecurityVerdict -StageName $StageName -Target $Target -Reason ([string]$violation['reason']) -ActionKind 'pre_dispatch' -ActionValue ([string]$violation['line']) -PromptText $Prompt
+    Write-TeamPipelineEvent -ProjectDir $ProjectDir -SessionName $SessionName -Event 'pipeline.security.blocked' -Message "Security monitor blocked $StageName on $Target before dispatch." -Role $Role -Target $Target -Data ([ordered]@{
+        stage         = $securityVerdict.stage
+        attempt       = $Attempt
+        task          = $Task
+        verdict       = $securityVerdict.verdict
+        reason        = $securityVerdict.reason
+        advisory_mode = $securityVerdict.advisory_mode
+        allow         = @($securityVerdict.allow)
+        block         = @($securityVerdict.block)
+        next_action   = $securityVerdict.next_action
+        action_kind   = 'pre_dispatch'
+        action_value  = [string]$violation['line']
+        category      = [string]$violation['category']
+    }) | Out-Null
+
+    return [PSCustomObject]@{
+        Stage      = $StageName
+        Target     = $Target
+        Status     = 'BLOCKED'
+        Summary    = "Security monitor blocked $StageName before dispatch. $([string]$violation['reason'])"
+        Transcript = $Prompt
+        Policy     = [PSCustomObject]$violation['policy']
+        SecurityVerdict = $securityVerdict
+        VerificationResult = $null
     }
 }
 
@@ -1001,8 +1113,11 @@ function Invoke-TeamPipelineConsultStage {
         verify_summary       = $VerificationSummary
     }
 
+    $dispatchResult = Invoke-TeamPipelineGuardedSend -StageName ("CONSULT_{0}" -f $Mode.ToUpperInvariant()) -Target $TargetLabel -Prompt $prompt -ProjectDir $ProjectDir -SessionName $SessionName -Role $consultRole -Task $Task -Attempt $Attempt
+    if ($null -ne $dispatchResult) {
+        return $dispatchResult
+    }
     Write-TeamPipelineEvent -ProjectDir $ProjectDir -SessionName $SessionName -Event 'pipeline.consult.dispatched' -Message "Dispatched $Mode consult to $TargetLabel." -Role $consultRole -Target $TargetLabel -Data $eventData | Out-Null
-    Invoke-TeamPipelineBridge -Arguments @('send', $TargetLabel, $prompt) | Out-Null
     $stage = Wait-TeamPipelineStage -Target $TargetLabel -StageName ("CONSULT_{0}" -f $Mode.ToUpperInvariant()) -TimeoutSeconds $TimeoutSeconds -PollIntervalSeconds $PollIntervalSeconds -ProjectDir $ProjectDir -SessionName $SessionName -Role $consultRole -Task $Task -Attempt $Attempt
 
     $completedEvent = if ($stage.Status -eq 'BLOCKED') { 'pipeline.consult.blocked' } else { 'pipeline.consult.completed' }
@@ -1073,8 +1188,12 @@ function Invoke-TeamPipeline {
     $consultTarget = Get-TeamPipelineConsultTarget -BuilderLabel $Builder -ResearcherLabel $Researcher -ReviewerLabel $Reviewer
     if (-not [string]::IsNullOrWhiteSpace($targets.PlanTarget)) {
         $planPrompt = New-TeamPipelinePlanPrompt -Task $Task
-        Invoke-TeamPipelineBridge -Arguments @('send', $targets.PlanTarget, $planPrompt) | Out-Null
-        $planStage = Wait-TeamPipelineStage -Target $targets.PlanTarget -StageName 'PLAN' -TimeoutSeconds $StageTimeoutSeconds -PollIntervalSeconds $PollIntervalSeconds -ProjectDir $builderContext.ProjectDir -SessionName $sessionName -Role 'Researcher' -Task $Task
+        $planDispatchResult = Invoke-TeamPipelineGuardedSend -StageName 'PLAN' -Target $targets.PlanTarget -Prompt $planPrompt -ProjectDir $builderContext.ProjectDir -SessionName $sessionName -Role 'Researcher' -Task $Task
+        if ($null -ne $planDispatchResult) {
+            $planStage = $planDispatchResult
+        } else {
+            $planStage = Wait-TeamPipelineStage -Target $targets.PlanTarget -StageName 'PLAN' -TimeoutSeconds $StageTimeoutSeconds -PollIntervalSeconds $PollIntervalSeconds -ProjectDir $builderContext.ProjectDir -SessionName $sessionName -Role 'Researcher' -Task $Task
+        }
         $result.Plan = $planStage
         if ($planStage.Status -eq 'BLOCKED') {
         $planSecurityVerdict = Get-TeamPipelineValue -InputObject $planStage -Name 'SecurityVerdict' -Default $null
@@ -1111,8 +1230,12 @@ function Invoke-TeamPipeline {
             New-TeamPipelineFixPrompt -Task $Task -PlanSummary $planSummary -VerificationSummary $previousVerify
         }
 
-        Invoke-TeamPipelineBridge -Arguments @('send', $Builder, $buildPrompt) | Out-Null
-        $buildStage = Wait-TeamPipelineStage -Target $Builder -StageName 'EXEC' -TimeoutSeconds $StageTimeoutSeconds -PollIntervalSeconds $PollIntervalSeconds -ProjectDir $builderContext.ProjectDir -SessionName $sessionName -Role 'Builder' -Task $Task -Attempt $attemptIndex
+        $buildDispatchResult = Invoke-TeamPipelineGuardedSend -StageName 'EXEC' -Target $Builder -Prompt $buildPrompt -ProjectDir $builderContext.ProjectDir -SessionName $sessionName -Role 'Builder' -Task $Task -Attempt $attemptIndex
+        if ($null -ne $buildDispatchResult) {
+            $buildStage = $buildDispatchResult
+        } else {
+            $buildStage = Wait-TeamPipelineStage -Target $Builder -StageName 'EXEC' -TimeoutSeconds $StageTimeoutSeconds -PollIntervalSeconds $PollIntervalSeconds -ProjectDir $builderContext.ProjectDir -SessionName $sessionName -Role 'Builder' -Task $Task -Attempt $attemptIndex
+        }
         $attempt.Build = $buildStage
 
         if ($buildStage.Status -eq 'BLOCKED') {
@@ -1166,16 +1289,20 @@ function Invoke-TeamPipeline {
             $verifyRole = 'Researcher'
         }
 
-        Write-TeamPipelineEvent -ProjectDir $builderContext.ProjectDir -SessionName $sessionName -Event 'pipeline.review.dispatched' -Message "Auto-dispatched review to $($targets.VerifyTarget) after builder completion." -Role $verifyRole -Target $targets.VerifyTarget -Data ([ordered]@{
-            attempt              = $attemptIndex
-            task                 = $Task
-            builder              = $Builder
-            builder_worktree_path = $builderContext.BuilderWorktreePath
-            verify_role          = $verifyRole
-            summary              = $buildNotification.Summary
-        }) | Out-Null
-        Invoke-TeamPipelineBridge -Arguments @('send', $targets.VerifyTarget, $verifyPrompt) | Out-Null
-        $verifyStage = Wait-TeamPipelineStage -Target $targets.VerifyTarget -StageName 'VERIFY' -TimeoutSeconds $StageTimeoutSeconds -PollIntervalSeconds $PollIntervalSeconds -ProjectDir $builderContext.ProjectDir -SessionName $sessionName -Role $verifyRole -Task $Task -Attempt $attemptIndex
+        $verifyDispatchResult = Invoke-TeamPipelineGuardedSend -StageName 'VERIFY' -Target $targets.VerifyTarget -Prompt $verifyPrompt -ProjectDir $builderContext.ProjectDir -SessionName $sessionName -Role $verifyRole -Task $Task -Attempt $attemptIndex
+        if ($null -ne $verifyDispatchResult) {
+            $verifyStage = $verifyDispatchResult
+        } else {
+            Write-TeamPipelineEvent -ProjectDir $builderContext.ProjectDir -SessionName $sessionName -Event 'pipeline.review.dispatched' -Message "Auto-dispatched review to $($targets.VerifyTarget) after builder completion." -Role $verifyRole -Target $targets.VerifyTarget -Data ([ordered]@{
+                attempt              = $attemptIndex
+                task                 = $Task
+                builder              = $Builder
+                builder_worktree_path = $builderContext.BuilderWorktreePath
+                verify_role          = $verifyRole
+                summary              = $buildNotification.Summary
+            }) | Out-Null
+            $verifyStage = Wait-TeamPipelineStage -Target $targets.VerifyTarget -StageName 'VERIFY' -TimeoutSeconds $StageTimeoutSeconds -PollIntervalSeconds $PollIntervalSeconds -ProjectDir $builderContext.ProjectDir -SessionName $sessionName -Role $verifyRole -Task $Task -Attempt $attemptIndex
+        }
         $attempt.Verify = $verifyStage
         $attempt.VerifyPacket = New-TeamPipelineVerificationPacket -Task $Task -VerifyStatus $verifyStage.Status -VerifierLabel $targets.VerifyTarget -BuilderLabel $Builder -BuilderWorktreePath $builderContext.BuilderWorktreePath -Summary $verifyStage.Summary
         $result.VerificationPackets += $attempt.VerifyPacket


### PR DESCRIPTION
## Summary
- add a shared pane env contract for hook profile, governance mode, role map, session, and project context
- enforce pre-dispatch security policy checks for send and one-shot orchestration while keeping blocked events honest
- document the Codex worktree git sandbox limitation for external users and surface the contract via doctor/hook metadata

## Validation
- Invoke-Pester tests/psmux-bridge.Tests.ps1
- node --check .claude/hooks/sh-session-start.js
- PowerShell parser checks for updated scripts
- git diff --check

## Review gate
- Codex CLI /review attempted twice on the working-tree diff and timed out with no result yet
- fresh review explorers found 2 P1 runtime issues and 1 P2 docs issue; all were fixed before this PR
- fallback gate for PR creation is manual diff review + 149/149 PASS + parser checks + diff check