### PR TITLE
feat: close v0.21.0 baseline scope

### DIFF
--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -1,59 +1,71 @@
 # Handoff
 
-> Updated: 2026-04-12T17:02:00+09:00
+> Updated: 2026-04-12T18:05:00+09:00
 > Source of truth: this file
 
 ## Current state
 
 - `v0.20.0`, `v0.20.1`, `v0.20.2`, and `v0.20.3` are released.
-- `v0.20.3` is closed at `100% (5/5)` with shipped scope:
-  - `TASK-161`
-  - `TASK-162` baseline only
-  - `TASK-172`
-  - `TASK-189`
-  - `TASK-309`
-- Issue `#260` is closed after the public troubleshooting workaround shipped in `v0.20.3`.
-- All existing GitHub Releases on the public releases page were normalized to the latest Codex-style body/title format.
-- `v0.12.1` exists as a git tag only and was not touched because no GitHub Release exists for it.
+- `v0.21.0: Operator Core & Slot Dispatch` is rebaselined to honest shipped scope and ready for PR/release closure.
+- Released-version roadmap drift is fixed:
+  - `v0.20.0` baseline tasks are now marked done
+  - `v0.20.1` baseline tasks are now marked done
+  - `v0.21.0` shipped baseline tasks are now marked done
+- `v0.21.0` follow-up backlog moved out of the release:
+  - `TASK-167`
+  - `TASK-254`
+  - `TASK-306`
+  - `TASK-310`
 - Current branch is `main`.
 
 ## This session
 
-- Merged PR `#405` and released `v0.20.3`.
-- Rebased external planning so `v0.20.3` is `Governance Baseline, Env Contracts & Security Policy Enforcement` at `100% (5/5)`.
-- Published the `v0.20.3` GitHub Release with Codex-style headings and inline issue refs.
-- Updated `README.md`, `README.ja.md`, and `docs/TROUBLESHOOTING.md` so the Windows worktree sandbox workaround is described in external-user-safe language instead of maintainer workflow terms.
-- Closed stale review agents after integrating results.
-- Updated all historical GitHub Releases to the latest title/body format and fixed `scripts/generate-release-notes.ps1` so regenerated notes match the current Codex-style release structure.
+- Audited `v0.21.0` against the actual repo state and corrected planning drift.
+- Rebased external planning so `v0.21.0` reflects the shipped baseline:
+  - `TASK-213` unified slot architecture baseline
+  - `TASK-255` autonomous dispatch baseline
+  - `TASK-165` slot-level provider/model selection baseline
+  - `TASK-302` consultation loop baseline
+  - `TASK-166` model resolution baseline
+  - `TASK-190` ConPTY clean environment baseline
+  - `TASK-191` `/task-run` baseline
+  - `TASK-248` config version baseline + metadata surface
+- Moved non-shipped follow-ups out of `v0.21.0`:
+  - `TASK-167` and `TASK-254` to `v0.21.1`
+  - `TASK-306` to `v0.21.2`
+  - `TASK-310` to `v0.24.1`
+- Implemented the missing baseline code to match the rebaselined `v0.21.0` scope:
+  - `config_version` fail-closed contract and metadata surface
+  - clean ConPTY env scrub/reinject helper
+  - doctor metadata check
+  - `/task-run` alias for one-shot pipeline entry
+- Closed completed explorer/reviewer subagents after their results were integrated.
 
 ## Validation
 
-- PR `#405` CI passed:
-  - `Pester Tests` green on run `24301402686`
-- Local validation before merge:
-  - PowerShell parser checks passed for the governance/env/security scripts
-  - `node --check .claude/hooks/sh-session-start.js`
-  - `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `149/149 PASS`
-- Review gate history:
-  - `/review` via Codex CLI timed out twice with `no result yet`
-  - reviewer `Locke` -> `FAIL`, findings fixed
-  - reviewer `Fermat` -> `FAIL`, findings fixed
-  - reviewer `Hegel` -> `PASS`
-  - release-readiness reviewer `Kepler` -> `FAIL`, docs/release-body issues fixed
-  - release-readiness reviewer `Einstein` -> `PASS`
-- Release-format normalization validation:
-  - spot-checked `v0.1.0`, `v0.10.0`, `v0.20.2`, and `v0.20.3`
-  - confirmed current releases use `New Features / Bug Fixes / Documentation / Chores / Full Changelog`
-  - confirmed titles are normalized to plain `vX.Y.Z`
+- PowerShell parser checks passed for:
+  - `scripts/winsmux-core.ps1`
+  - `winsmux-core/scripts/settings.ps1`
+  - `winsmux-core/scripts/pane-env.ps1`
+  - `winsmux-core/scripts/orchestra-start.ps1`
+  - `winsmux-core/scripts/doctor.ps1`
+  - `tests/psmux-bridge.Tests.ps1`
+- `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `155/155 PASS`
+- `git diff --check` -> no substantive diff-check failures
+- Review gate history for this `v0.21.0` closure slice:
+  - explorer agents `McClintock`, `Bohr`, and `Linnaeus` identified planning/release-scope drift
+  - reviewer `Beauvoir` -> `FAIL`, findings fixed
+  - fresh `/review` still required on the consolidated PR slice before merge
 
 ## Next actions
 
-1. Commit and push the durable release-note generator change plus this handoff update.
-2. Start `v0.21.0` from the rebalanced roadmap.
-3. If `v0.12.1` should appear on the releases page, create a GitHub Release for the existing tag separately.
+1. Create a branch for the `v0.21.0` closure slice and open a PR.
+2. Run a fresh `/review` on that PR slice and merge if the gate passes or timeout fallback is justified.
+3. Publish the `v0.21.0` GitHub Release and save release/post drafts.
 
 ## Notes
 
-- `TASK-162` intentionally shipped as a governance baseline only; per-call cost tracking moved to `TASK-310`.
+- `v0.21.0` is a baseline release, not the full advanced slot/runtime roadmap.
+- `TASK-167`, `TASK-254`, `TASK-306`, and `TASK-310` were intentionally moved out so the release truth matches shipped code.
 - Public GitHub Releases stay English, use Codex-style headings, and keep inline issue/PR refs visible.
 - `README.md` and `README.ja.md` must be updated again at `v0.21.2` release time to mark the terminal-based final form as the last pre-Tauri shape.

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -5725,6 +5725,7 @@ explain <run_id> [--json] [--follow]  Explain one run and optionally follow new 
   watch <label> [silence_s] [timeout_s]  Block until pane output is silent
   dispatch-route <text>   Route text to appropriate pane by keyword detection
   pipeline <task>       Run plan-exec-verify-fix loop for a task
+  task-run <task>       Alias for pipeline; one-shot orchestration entrypoint
   builder-queue <action> [args]  Manage Builder queue and auto-dispatch next work
   vault set <key> [value]   Store a credential securely (DPAPI)
   vault get <key>           Retrieve a stored credential
@@ -5990,6 +5991,15 @@ switch ($Command) {
         & pwsh -NoProfile -File $splitterScript -Task $taskText -AsJson
     }
     'pipeline' {
+        $pipelineScript = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\winsmux-core\scripts\team-pipeline.ps1'))
+        $taskText = (@($Target) + @($Rest) | Where-Object { $_ } | ForEach-Object { $_.Trim() } | Where-Object { $_ }) -join ' '
+        if ($taskText) {
+            & pwsh -NoProfile -File $pipelineScript -Task $taskText
+        } else {
+            & pwsh -NoProfile -File $pipelineScript
+        }
+    }
+    'task-run' {
         $pipelineScript = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\winsmux-core\scripts\team-pipeline.ps1'))
         $taskText = (@($Target) + @($Rest) | Where-Object { $_ } | ForEach-Object { $_.Trim() } | Where-Object { $_ }) -join ' '
         if ($taskText) {

--- a/tests/psmux-bridge.Tests.ps1
+++ b/tests/psmux-bridge.Tests.ps1
@@ -189,6 +189,7 @@ Describe 'Get-BridgeSettings' {
 
         $settings.agent | Should -Be 'codex'
         $settings.model | Should -Be 'gpt-5.4'
+        $settings.config_version | Should -Be 1
         $settings.prompt_transport | Should -Be 'argv'
         $settings.external_commander | Should -Be $true
         $settings.legacy_role_layout | Should -Be $false
@@ -377,6 +378,24 @@ prompt-transport: file
         $settings.prompt_transport | Should -Be 'file'
     }
 
+    It 'reads config_version metadata and reports it as current' {
+@'
+config-version: 1
+agent: codex
+model: gpt-5.4
+'@ | Set-Content -Path (Join-Path $script:settingsTempRoot '.winsmux.yaml') -Encoding UTF8
+
+        Mock Get-WinsmuxOption { param($Name, $Default) return $null }
+
+        $settings = Get-BridgeSettings
+        $metadata = Get-BridgeSettingsMetadata -Settings $settings
+
+        $settings.config_version | Should -Be 1
+        $metadata.ConfigVersion | Should -Be 1
+        $metadata.MigrationStatus | Should -Be 'current'
+        $metadata.SlotCount | Should -BeGreaterThan 0
+    }
+
     It 'fails closed when prompt_transport is unsupported' {
 @'
 prompt-transport: stdin
@@ -385,6 +404,16 @@ prompt-transport: stdin
         Mock Get-WinsmuxOption { param($Name, $Default) return $null }
 
         { Get-BridgeSettings } | Should -Throw '*prompt_transport*'
+    }
+
+    It 'fails closed when config_version is unsupported' {
+@'
+config-version: 2
+'@ | Set-Content -Path (Join-Path $script:settingsTempRoot '.winsmux.yaml') -Encoding UTF8
+
+        Mock Get-WinsmuxOption { param($Name, $Default) return $null }
+
+        { Get-BridgeSettings } | Should -Throw '*config_version*'
     }
 
     It 'prefers slot-level agent and model overrides when a matching slot id is provided' {
@@ -1119,6 +1148,21 @@ hook_profile: ci
         $payload.WINSMUX_BUILDER_WORKTREE | Should -Be 'C:\repo\.worktrees\builder-1'
         $payload.WINSMUX_HOOK_PROFILE | Should -Be 'builder'
         $payload.WINSMUX_GOVERNANCE_MODE | Should -Be 'enhanced'
+    }
+
+    It 'builds a clean ConPTY boundary that scrubs stray WINSMUX variables before reinjection' {
+        $env:WINSMUX_HOOK_PROFILE = 'builder'
+        $env:WINSMUX_GOVERNANCE_MODE = 'enhanced'
+
+        $payload = Get-WinsmuxPaneEnvironment -Role 'Worker' -PaneId '%4' -SessionName 'winsmux-orchestra' -ProjectDir $script:paneEnvTempRoot -RoleMapJson '{"%4":"Worker"}' -BuilderWorktreePath 'C:\repo\.worktrees\builder-1'
+        $clean = Get-CleanPtyEnv -AllowedEnvironment $payload
+
+        $clean.RemoveCommand | Should -Match 'WINSMUX_\*'
+        $clean.RemoveCommand | Should -Match 'Remove-Item'
+        $clean.AllowedVariableNames | Should -Contain 'WINSMUX_ROLE'
+        $clean.AllowedVariableNames | Should -Contain 'WINSMUX_GOVERNANCE_MODE'
+        $clean.Environment.WINSMUX_ROLE | Should -Be 'Worker'
+        $clean.Environment.WINSMUX_PANE_ID | Should -Be '%4'
     }
 }
 
@@ -2833,6 +2877,63 @@ Describe 'orchestra-start rollback helpers' {
         $events[0].data.bootstrap_respawned | Should -Be $true
         $events[0].data.removed_pane_ids | Should -Be @('%2', '%3')
         $events[0].data.removed_worktrees[0].BranchName | Should -Be 'worktree-builder-1'
+    }
+
+    It 'scrubs WINSMUX variables before reinjecting pane environment after respawn' {
+        $sentCommands = [System.Collections.Generic.List[string]]::new()
+        $cleanPtyEnv = [PSCustomObject]@{
+            RemoveCommand = "Get-ChildItem Env: | Where-Object { `$_.Name -like 'WINSMUX_*' } | ForEach-Object { Remove-Item -LiteralPath ('Env:' + `$_.Name) -ErrorAction SilentlyContinue }"
+            Environment   = [ordered]@{
+                WINSMUX_ROLE            = 'Worker'
+                WINSMUX_GOVERNANCE_MODE = 'enhanced'
+            }
+        }
+
+        Mock Wait-PaneShellReady { }
+        Mock Send-OrchestraBridgeCommand {
+            $sentCommands.Add($Text) | Out-Null
+        }
+
+        Initialize-OrchestraPaneEnvironment -PaneId '%2' -LaunchDir 'C:\repo\.worktrees\builder-1' -CleanPtyEnv $cleanPtyEnv
+
+        Should -Invoke Wait-PaneShellReady -Times 1 -Exactly -ParameterFilter {
+            $PaneId -eq '%2'
+        }
+        $sentCommands.Count | Should -Be 4
+        $sentCommands[0] | Should -Be "cd 'C:\repo\.worktrees\builder-1'"
+        $sentCommands[1] | Should -Match 'WINSMUX_\*'
+        $sentCommands[1] | Should -Match 'Remove-Item'
+        $sentCommands[2] | Should -Be '$env:WINSMUX_ROLE = ''Worker'''
+        $sentCommands[3] | Should -Be '$env:WINSMUX_GOVERNANCE_MODE = ''enhanced'''
+    }
+}
+
+Describe 'doctor bridge config metadata check' {
+    BeforeAll {
+        $script:__winsmux_doctor_functions_only = $true
+        . (Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\doctor.ps1')
+        Remove-Variable -Name __winsmux_doctor_functions_only -Scope Script -ErrorAction SilentlyContinue
+    }
+
+    BeforeEach {
+        $script:doctorTempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('winsmux-doctor-tests-' + [guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $script:doctorTempRoot -Force | Out-Null
+    }
+
+    AfterEach {
+        if ($script:doctorTempRoot -and (Test-Path $script:doctorTempRoot)) {
+            Remove-Item -Path $script:doctorTempRoot -Recurse -Force
+        }
+    }
+
+    It 'fails bridge config metadata check when .winsmux.yaml is missing' {
+        Mock Get-DoctorRepoRoot { $script:doctorTempRoot }
+
+        $result = Test-BridgeConfigMetadataCheck
+
+        $result.Status | Should -Be 'fail'
+        $result.Label | Should -Be 'Bridge config metadata'
+        $result.Detail | Should -Be '.winsmux.yaml not found'
     }
 }
 
@@ -5163,6 +5264,19 @@ Describe 'winsmux send dispatch payload' {
 
         $violation.verdict | Should -Be 'BLOCK'
         $violation.reason | Should -Match 'allow_patterns'
+    }
+}
+
+Describe 'winsmux task-run command' {
+    BeforeAll {
+        $script:winsmuxCoreRawPath = Join-Path (Split-Path -Parent $PSScriptRoot) 'scripts\winsmux-core.ps1'
+        $script:winsmuxCoreRawContent = Get-Content -Path $script:winsmuxCoreRawPath -Raw -Encoding UTF8
+    }
+
+    It 'documents task-run in usage and dispatches it through the one-shot pipeline entrypoint' {
+        $script:winsmuxCoreRawContent | Should -Match 'task-run <task>\s+Alias for pipeline; one-shot orchestration entrypoint'
+        $script:winsmuxCoreRawContent | Should -Match "'task-run'\s*\{"
+        $script:winsmuxCoreRawContent | Should -Match "team-pipeline\.ps1"
     }
 }
 

--- a/winsmux-core/scripts/doctor.ps1
+++ b/winsmux-core/scripts/doctor.ps1
@@ -11,6 +11,7 @@ Set-StrictMode -Version Latest
 
 . (Join-Path $PSScriptRoot 'planning-paths.ps1')
 . (Join-Path $PSScriptRoot 'pane-env.ps1')
+. (Join-Path $PSScriptRoot 'settings.ps1')
 
 function New-DoctorResult {
     param(
@@ -404,6 +405,24 @@ function Test-BridgeConfigCheck {
     return New-DoctorResult -Status pass -Label '.winsmux.yaml' -Detail 'found'
 }
 
+function Test-BridgeConfigMetadataCheck {
+    $repoRoot = Get-DoctorRepoRoot
+    $configPath = Join-Path $repoRoot '.winsmux.yaml'
+
+    if (-not (Test-Path $configPath)) {
+        return New-DoctorResult -Status fail -Label 'Bridge config metadata' -Detail '.winsmux.yaml not found'
+    }
+
+    try {
+        $metadata = Get-BridgeSettingsMetadata -RootPath $repoRoot
+    } catch {
+        return New-DoctorResult -Status fail -Label 'Bridge config metadata' -Detail $_.Exception.Message
+    }
+
+    $detail = "config_version=$($metadata.ConfigVersion); migration_status=$($metadata.MigrationStatus); slot_count=$($metadata.SlotCount); legacy_role_layout=$($metadata.LegacyRoleLayout)"
+    return New-DoctorResult -Status pass -Label 'Bridge config metadata' -Detail $detail
+}
+
 function Test-HookProfileCheck {
     $repoRoot = Get-DoctorRepoRoot
 
@@ -448,30 +467,33 @@ function Write-DoctorResult {
     Write-Output ("[{0}] {1}: {2}" -f $status, $Result.Label, $Result.Detail)
 }
 
-$results = @(
-    Test-VersionFileCheck
-    Test-HookFilesCheck
-    Test-SettingsJsonCheck
-    Test-BacklogYamlCheck
-    Test-ManifestYamlCheck
-    Test-StaleWorktreesCheck
-    Test-ZombieProcessesCheck
-    Test-BridgeConfigCheck
-    Test-HookProfileCheck
-    Test-GovernanceModeCheck
-    Test-WinsmuxEnvContractCheck
-)
+if (-not $script:__winsmux_doctor_functions_only) {
+    $results = @(
+        Test-VersionFileCheck
+        Test-HookFilesCheck
+        Test-SettingsJsonCheck
+        Test-BacklogYamlCheck
+        Test-ManifestYamlCheck
+        Test-StaleWorktreesCheck
+        Test-ZombieProcessesCheck
+        Test-BridgeConfigCheck
+        Test-BridgeConfigMetadataCheck
+        Test-HookProfileCheck
+        Test-GovernanceModeCheck
+        Test-WinsmuxEnvContractCheck
+    )
 
-$hasFail = $false
-foreach ($result in $results) {
-    Write-DoctorResult -Result $result
-    if ($result.Status -eq 'fail') {
-        $hasFail = $true
+    $hasFail = $false
+    foreach ($result in $results) {
+        Write-DoctorResult -Result $result
+        if ($result.Status -eq 'fail') {
+            $hasFail = $true
+        }
     }
-}
 
-if ($hasFail) {
-    exit 1
-}
+    if ($hasFail) {
+        exit 1
+    }
 
-exit 0
+    exit 0
+}

--- a/winsmux-core/scripts/orchestra-start.ps1
+++ b/winsmux-core/scripts/orchestra-start.ps1
@@ -383,6 +383,25 @@ function Send-OrchestraBridgeCommand {
     Invoke-Bridge -Arguments @('send', $Target, $Text)
 }
 
+function Initialize-OrchestraPaneEnvironment {
+    param(
+        [Parameter(Mandatory = $true)][string]$PaneId,
+        [Parameter(Mandatory = $true)][string]$LaunchDir,
+        [Parameter(Mandatory = $true)]$CleanPtyEnv
+    )
+
+    Wait-PaneShellReady -PaneId $PaneId
+    # TASK-236: set cwd via cd (respawn-pane -c unreliable on Windows)
+    Send-OrchestraBridgeCommand -Target $PaneId -Text "cd $(ConvertTo-PowerShellLiteral -Value $LaunchDir)"
+    Start-Sleep -Milliseconds 500
+    Send-OrchestraBridgeCommand -Target $PaneId -Text ([string]$CleanPtyEnv.RemoveCommand)
+    Start-Sleep -Milliseconds 200
+    foreach ($entry in $CleanPtyEnv.Environment.GetEnumerator()) {
+        Send-OrchestraBridgeCommand -Target $PaneId -Text ('{0} = {1}' -f ('$env:' + [string]$entry.Key), (ConvertTo-PowerShellLiteral -Value ([string]$entry.Value)))
+    }
+    Start-Sleep -Milliseconds 300
+}
+
 function Get-AgentLaunchCommand {
     param(
         [Parameter(Mandatory = $true)][string]$Agent,
@@ -1357,20 +1376,14 @@ if ($MyInvocation.InvocationName -ne '.') {
         Invoke-Bridge -Arguments @('name', $paneId, $label)
         try {
             $paneEnvironment = Get-WinsmuxPaneEnvironment -Role $canonicalRole -PaneId $paneId -SessionName $sessionName -ProjectDir $projectDir -RoleMapJson $sessionRoleMapJson -BuilderWorktreePath $builderWorktreePath
+            $cleanPtyEnv = Get-CleanPtyEnv -AllowedEnvironment $paneEnvironment
             foreach ($entry in $paneEnvironment.GetEnumerator()) {
                 if ($entry.Key -in @('WINSMUX_ROLE', 'WINSMUX_PANE_ID')) {
                     Set-OrchestraSessionEnvironment -SessionName $sessionName -Name ([string]$entry.Key) -Value ([string]$entry.Value)
                 }
             }
             Invoke-Winsmux -Arguments @('respawn-pane', '-k', '-t', $paneId, '-c', $launchDir)
-            Wait-PaneShellReady -PaneId $paneId
-            # TASK-236: set cwd via cd (respawn-pane -c unreliable on Windows)
-            Send-OrchestraBridgeCommand -Target $paneId -Text "cd $(ConvertTo-PowerShellLiteral -Value $launchDir)"
-            Start-Sleep -Milliseconds 500
-            foreach ($entry in $paneEnvironment.GetEnumerator()) {
-                Send-OrchestraBridgeCommand -Target $paneId -Text ('{0} = {1}' -f ('$env:' + [string]$entry.Key), (ConvertTo-PowerShellLiteral -Value ([string]$entry.Value)))
-            }
-            Start-Sleep -Milliseconds 300
+            Initialize-OrchestraPaneEnvironment -PaneId $paneId -LaunchDir $launchDir -CleanPtyEnv $cleanPtyEnv
             # TASK-231: verify pane exists after respawn
             try {
                 Invoke-Winsmux -Arguments @('display-message', '-t', $paneId, '-p', '#{pane_id}') -CaptureOutput | Out-Null

--- a/winsmux-core/scripts/pane-env.ps1
+++ b/winsmux-core/scripts/pane-env.ps1
@@ -190,3 +190,31 @@ function Get-WinsmuxPaneEnvironment {
 
     return $environment
 }
+
+function Get-CleanPtyEnv {
+    param(
+        [Parameter(Mandatory = $true)]$AllowedEnvironment
+    )
+
+    $environment = [ordered]@{}
+    if ($AllowedEnvironment -is [System.Collections.IDictionary]) {
+        foreach ($entry in $AllowedEnvironment.GetEnumerator()) {
+            $environment[[string]$entry.Key] = [string]$entry.Value
+        }
+    } elseif ($null -ne $AllowedEnvironment.PSObject) {
+        foreach ($property in $AllowedEnvironment.PSObject.Properties) {
+            $environment[[string]$property.Name] = [string]$property.Value
+        }
+    } else {
+        throw 'AllowedEnvironment must be a dictionary-like object.'
+    }
+
+    $allowedNames = @($environment.Keys)
+    $removeCommand = "Get-ChildItem Env: | Where-Object { `$_.Name -like 'WINSMUX_*' } | ForEach-Object { Remove-Item -LiteralPath ('Env:' + `$_.Name) -ErrorAction SilentlyContinue }"
+
+    return [PSCustomObject]@{
+        RemoveCommand      = $removeCommand
+        Environment        = $environment
+        AllowedVariableNames = $allowedNames
+    }
+}

--- a/winsmux-core/scripts/settings.ps1
+++ b/winsmux-core/scripts/settings.ps1
@@ -15,6 +15,7 @@ Dot-source this script to load the helpers:
 
 $script:BridgeSettingsFileName = '.winsmux.yaml'
 $script:BridgeSettingsSchema = [ordered]@{
+    config_version      = @{ Type = 'int';      Default = 1;             Option = $null }
     agent               = @{ Type = 'string';   Default = 'codex';       Option = '@bridge-agent' }
     model               = @{ Type = 'string';   Default = 'gpt-5.4';     Option = '@bridge-model' }
     prompt_transport    = @{ Type = 'transport'; Default = 'argv';       Option = '@bridge-prompt-transport' }
@@ -700,6 +701,11 @@ function Get-BridgeSettings {
         $settings.agent_slots = @()
     }
 
+    $configVersion = [int]$settings.config_version
+    if ($configVersion -ne 1) {
+        throw "Unsupported config_version '$configVersion'. Supported versions: 1."
+    }
+
     $slotIds = @{}
     foreach ($slot in @($settings.agent_slots)) {
         if ([string]::IsNullOrWhiteSpace([string]$slot.slot_id)) {
@@ -730,6 +736,27 @@ function Get-BridgeSettings {
     }
 
     return $settings
+}
+
+function Get-BridgeSettingsMetadata {
+    param(
+        [string]$RootPath,
+        $Settings = $null
+    )
+
+    if ($null -eq $Settings) {
+        $Settings = Get-BridgeSettings -RootPath $RootPath
+    }
+
+    $configVersion = [int]$Settings.config_version
+    $migrationStatus = if ($configVersion -eq 1) { 'current' } else { 'unsupported' }
+
+    return [PSCustomObject]@{
+        ConfigVersion   = $configVersion
+        MigrationStatus = $migrationStatus
+        LegacyRoleLayout = [bool]$Settings.legacy_role_layout
+        SlotCount       = @($Settings.agent_slots).Count
+    }
 }
 
 function Get-RoleAgentConfig {


### PR DESCRIPTION
## Summary
- close the shipped v0.21.0 baseline scope in code and tests
- add config-version metadata, clean ConPTY env reinjection, doctor metadata checks, and /task-run alias
- update handoff for the rebaselined v0.21.0 closure state

## Validation
- Invoke-Pester tests/psmux-bridge.Tests.ps1
- git diff --check