### PR TITLE
feat: close v0.21.1 with compare and tactic export baselines

### DIFF
--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -54,13 +54,14 @@
   - fresh reviewer `Parfit` -> `no result yet` after 30s wait; closed without result
   - fresh reviewer `Ptolemy` -> `FAIL`, findings fixed locally
   - fresh reviewer `Halley` -> `FAIL`, stricter guard findings fixed locally
+  - fresh reviewer `Ohm` -> `no result yet` after two 35s waits on the final diff; closed without result
   - manual diff review completed on the compare/promote slice
 
 ## Next actions
 
-1. Run one fresh `/review` on PR #407 after the latest security/recommendability fixes.
-2. Merge PR #407 if CI is green and the review gate passes or times out into documented fallback.
-3. Publish `v0.21.1` with curated release notes after the roadmap truth is synchronized.
+1. Merge PR #407 if CI stays green, using the documented fallback gate (`161/161 PASS`, parser check, diff check, manual diff review, reviewer timeout recorded).
+2. Publish `v0.21.1` with curated release notes after the roadmap truth is synchronized.
+3. Update `docs/handoff.md` again on `main` for release-complete state.
 
 ## Notes
 

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -1,6 +1,6 @@
 # Handoff
 
-> Updated: 2026-04-12T19:31:00+09:00
+> Updated: 2026-04-12T20:19:00+09:00
 > Source of truth: this file
 
 ## Current state
@@ -37,22 +37,29 @@
   - suppressing `compare-runs` winner selection unless both sides are recommendable
   - rejecting `promote-tactic` for non-promotable runs
   - adding regression tests for both guards
+- Reviewer `Halley` returned `FAIL` on the stricter closure criteria.
+- Fixed the findings by:
+  - requiring completed task state, review pass, verification pass, and explicit security allow/pass for recommend/promote
+  - teaching the read model to recognize allow-side security events
+  - adding regression coverage for missing-security promotion and strict healthy-winner selection
 - Another fresh reviewer will run on the updated PR before merge.
 
 ## Validation
 
-- `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `160/160 PASS`
+- `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `161/161 PASS`
+- PowerShell parser check for `scripts/winsmux-core.ps1` and `tests/psmux-bridge.Tests.ps1` -> PASS
 - `git diff --check` -> no substantive diff-check failures
 - Review gate history for the active `v0.21.1` closure slice:
   - explorer audit established release-scope drift
   - fresh reviewer `Parfit` -> `no result yet` after 30s wait; closed without result
   - fresh reviewer `Ptolemy` -> `FAIL`, findings fixed locally
+  - fresh reviewer `Halley` -> `FAIL`, stricter guard findings fixed locally
   - manual diff review completed on the compare/promote slice
 
 ## Next actions
 
-1. Open PR for the `v0.21.1` compare/promote closure slice and run a fresh `/review`.
-2. Merge the closure slice if CI is green and the review gate passes or times out into documented fallback.
+1. Run one fresh `/review` on PR #407 after the latest security/recommendability fixes.
+2. Merge PR #407 if CI is green and the review gate passes or times out into documented fallback.
 3. Publish `v0.21.1` with curated release notes after the roadmap truth is synchronized.
 
 ## Notes

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -1,6 +1,6 @@
 # Handoff
 
-> Updated: 2026-04-12T19:20:00+09:00
+> Updated: 2026-04-12T19:31:00+09:00
 > Source of truth: this file
 
 ## Current state
@@ -32,15 +32,21 @@
   - `.winsmux/playbook-candidates/` file-backed candidate export
 - Expanded regression coverage for compare/promote surfaces.
 - Rebased external planning so `v0.21.1` closes on shipped baseline and moved non-shipped items out.
-- Fresh reviewer timed out after the required wait and was closed. A second fresh reviewer will be run on the PR before merge.
+- Reviewer `Ptolemy` returned `FAIL` on compare winner health and promote guard conditions.
+- Fixed the findings by:
+  - suppressing `compare-runs` winner selection unless both sides are recommendable
+  - rejecting `promote-tactic` for non-promotable runs
+  - adding regression tests for both guards
+- Another fresh reviewer will run on the updated PR before merge.
 
 ## Validation
 
-- `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `158/158 PASS`
+- `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `160/160 PASS`
 - `git diff --check` -> no substantive diff-check failures
 - Review gate history for the active `v0.21.1` closure slice:
   - explorer audit established release-scope drift
   - fresh reviewer `Parfit` -> `no result yet` after 30s wait; closed without result
+  - fresh reviewer `Ptolemy` -> `FAIL`, findings fixed locally
   - manual diff review completed on the compare/promote slice
 
 ## Next actions

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -1,77 +1,57 @@
 # Handoff
 
-> Updated: 2026-04-12T19:05:00+09:00
+> Updated: 2026-04-12T19:20:00+09:00
 > Source of truth: this file
 
 ## Current state
 
 - `v0.20.0`, `v0.20.1`, `v0.20.2`, `v0.20.3`, and `v0.21.0` are released.
-- `v0.21.0: Operator Core & Slot Dispatch` is closed at shipped-baseline scope and publicly released.
-- Released-version roadmap drift is fixed:
-  - `v0.20.0` baseline tasks are now marked done
-  - `v0.20.1` baseline tasks are now marked done
-  - `v0.21.0` shipped baseline tasks are now marked done
-- `v0.21.0` follow-up backlog moved out of the release:
-  - `TASK-167`
-  - `TASK-254`
-  - `TASK-306`
-  - `TASK-310`
-- Current branch is `main`.
+- `v0.21.1` closure is in progress on `codex/v0211-compare-promote-close-20260412`.
+- Current `v0.21.1` shipped-baseline scope is being rebaselined to:
+  - `TASK-163` phase-gated workflow baseline
+  - `TASK-164` structured chaining baseline
+  - `TASK-167` provider/model slot metadata baseline
+  - `TASK-254` provider capability metadata baseline
+  - `TASK-303` compare-runs baseline
+  - `TASK-304` promote-tactic baseline
+- Non-shipped `v0.21.1` work is being moved out of the release:
+  - `TASK-168`
+  - `TASK-169`
+  - `TASK-192`
+  - `TASK-307`
 
 ## This session
 
-- Audited `v0.21.0` against the actual repo state and corrected planning drift.
-- Rebased external planning so `v0.21.0` reflects the shipped baseline:
-  - `TASK-213` unified slot architecture baseline
-  - `TASK-255` autonomous dispatch baseline
-  - `TASK-165` slot-level provider/model selection baseline
-  - `TASK-302` consultation loop baseline
-  - `TASK-166` model resolution baseline
-  - `TASK-190` ConPTY clean environment baseline
-  - `TASK-191` `/task-run` baseline
-  - `TASK-248` config version baseline + metadata surface
-- Moved non-shipped follow-ups out of `v0.21.0`:
-  - `TASK-167` and `TASK-254` to `v0.21.1`
-  - `TASK-306` to `v0.21.2`
-  - `TASK-310` to `v0.24.1`
-- Implemented the missing baseline code to match the rebaselined `v0.21.0` scope:
-  - `config_version` fail-closed contract and metadata surface
-  - clean ConPTY env scrub/reinject helper
-  - doctor metadata check
-  - `/task-run` alias for one-shot pipeline entry
-- Opened PR `#406`, ran a fresh `/review`, merged the closure slice, and published `v0.21.0`.
-- Corrected the generated GitHub Release body after publish so it uses the curated `v0.21.0` notes and only the three public assets remain.
-- Closed completed explorer/reviewer subagents after their results were integrated.
+- Audited `v0.21.1` against the actual repo state before release closure.
+- Confirmed baseline-only shipped truth:
+  - `TASK-163`, `TASK-164`, `TASK-167`, `TASK-254`, `TASK-288` were only partially implemented
+  - `TASK-168`, `TASK-169`, `TASK-192`, `TASK-307` were not implemented
+- Implemented the missing shipped-baseline CLI for honest closure:
+  - `winsmux compare-runs <left> <right> [--json]`
+  - `winsmux promote-tactic <run_id> [--title ...] [--kind ...] [--json]`
+  - `.winsmux/playbook-candidates/` file-backed candidate export
+- Expanded regression coverage for compare/promote surfaces.
+- Rebased external planning so `v0.21.1` closes on shipped baseline and moved non-shipped items out.
+- Fresh reviewer timed out after the required wait and was closed. A second fresh reviewer will be run on the PR before merge.
 
 ## Validation
 
-- PowerShell parser checks passed for:
-  - `scripts/winsmux-core.ps1`
-  - `winsmux-core/scripts/settings.ps1`
-  - `winsmux-core/scripts/pane-env.ps1`
-  - `winsmux-core/scripts/orchestra-start.ps1`
-  - `winsmux-core/scripts/doctor.ps1`
-  - `tests/psmux-bridge.Tests.ps1`
-- `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `155/155 PASS`
+- `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `158/158 PASS`
 - `git diff --check` -> no substantive diff-check failures
-- Review gate history for this `v0.21.0` closure slice:
-  - explorer agents `McClintock`, `Bohr`, and `Linnaeus` identified planning/release-scope drift
-  - reviewer `Beauvoir` -> `FAIL`, findings fixed
-  - fresh reviewer `Euclid` -> `no result yet` after repeated waits; fallback gate used
-- PR / release validation:
-  - PR `#406` CI green
-  - merge commit `06e6df1a4871c5bbced69f63484b9a9eb53813b4`
-  - release workflow `24303968440` success
+- Review gate history for the active `v0.21.1` closure slice:
+  - explorer audit established release-scope drift
+  - fresh reviewer `Parfit` -> `no result yet` after 30s wait; closed without result
+  - manual diff review completed on the compare/promote slice
 
 ## Next actions
 
-1. Start `v0.21.1` from the rebalanced roadmap.
-2. Consider a follow-up to keep `release-body.md` out of release assets automatically instead of removing it post-publish.
-3. Keep the `v0.21.2` README gate in place for the terminal-based final-form release.
+1. Open PR for the `v0.21.1` compare/promote closure slice and run a fresh `/review`.
+2. Merge the closure slice if CI is green and the review gate passes or times out into documented fallback.
+3. Publish `v0.21.1` with curated release notes after the roadmap truth is synchronized.
 
 ## Notes
 
-- `v0.21.0` is a baseline release, not the full advanced slot/runtime roadmap.
-- `TASK-167`, `TASK-254`, `TASK-306`, and `TASK-310` were intentionally moved out so the release truth matches shipped code.
+- `v0.21.1` will also be a baseline release, not the full advanced workflow/runtime roadmap.
+- `TASK-168`, `TASK-169`, `TASK-192`, and `TASK-307` are being moved out so the release truth matches shipped code.
 - Public GitHub Releases stay English, use Codex-style headings, and keep inline issue/PR refs visible.
 - `README.md` and `README.ja.md` must be updated again at `v0.21.2` release time to mark the terminal-based final form as the last pre-Tauri shape.

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -4273,6 +4273,54 @@ function Get-RunFromPayload {
     return $null
 }
 
+function Test-RunRecommendable {
+    param([Parameter(Mandatory = $true)]$Run)
+
+    $taskState = [string]$Run.task_state
+    $reviewState = ([string]$Run.review_state).ToUpperInvariant()
+    $verificationOutcome = if ($null -ne $Run.verification_result) { ([string]$Run.verification_result.outcome).ToUpperInvariant() } else { '' }
+    $securityVerdict = if ($null -ne $Run.security_verdict) { ([string]$Run.security_verdict.verdict).ToUpperInvariant() } else { '' }
+
+    if ($taskState -in @('blocked', 'failed')) {
+        return $false
+    }
+    if ($reviewState -in @('FAIL', 'FAILED', 'BLOCKED')) {
+        return $false
+    }
+    if ($verificationOutcome -in @('FAIL', 'FAILED', 'PARTIAL', 'BLOCK', 'BLOCKED')) {
+        return $false
+    }
+    if ($securityVerdict -in @('BLOCK', 'BLOCKED', 'FAIL', 'FAILED')) {
+        return $false
+    }
+
+    return $true
+}
+
+function Test-RunPromotable {
+    param([Parameter(Mandatory = $true)]$Run)
+
+    if (-not (Test-RunRecommendable -Run $Run)) {
+        return $false
+    }
+
+    $taskState = [string]$Run.task_state
+    $reviewState = ([string]$Run.review_state).ToUpperInvariant()
+    $verificationOutcome = if ($null -ne $Run.verification_result) { ([string]$Run.verification_result.outcome).ToUpperInvariant() } else { '' }
+
+    if ($taskState -notin @('completed', 'task_completed', 'commit_ready', 'done')) {
+        return $false
+    }
+    if (-not [string]::IsNullOrWhiteSpace($reviewState) -and $reviewState -ne 'PASS') {
+        return $false
+    }
+    if ($verificationOutcome -ne 'PASS') {
+        return $false
+    }
+
+    return $true
+}
+
 function ConvertTo-CompareRunsPayload {
     param(
         [Parameter(Mandatory = $true)]$LeftPayload,
@@ -4353,6 +4401,17 @@ function ConvertTo-CompareRunsPayload {
         }) | Out-Null
     }
 
+    $leftRecommendable = Test-RunRecommendable -Run $leftRun
+    $rightRecommendable = Test-RunRecommendable -Run $rightRun
+    $winningRunId = ''
+    if ($leftRecommendable -and $rightRecommendable -and $null -ne $confidenceDelta) {
+        if ($confidenceDelta -gt 0) {
+            $winningRunId = [string]$leftRun.run_id
+        } elseif ($confidenceDelta -lt 0) {
+            $winningRunId = [string]$rightRun.run_id
+        }
+    }
+
     return [ordered]@{
         generated_at = (Get-Date).ToString('o')
         left = [ordered]@{
@@ -4367,6 +4426,7 @@ function ConvertTo-CompareRunsPayload {
             changed_files        = @($leftChangedFiles)
             observation_pack_ref = if ($null -ne $leftExperiment) { [string]$leftExperiment.observation_pack_ref } else { '' }
             consultation_ref     = if ($null -ne $leftExperiment) { [string]$leftExperiment.consultation_ref } else { '' }
+            recommendable        = $leftRecommendable
         }
         right = [ordered]@{
             run_id               = [string]$rightRun.run_id
@@ -4380,6 +4440,7 @@ function ConvertTo-CompareRunsPayload {
             changed_files        = @($rightChangedFiles)
             observation_pack_ref = if ($null -ne $rightExperiment) { [string]$rightExperiment.observation_pack_ref } else { '' }
             consultation_ref     = if ($null -ne $rightExperiment) { [string]$rightExperiment.consultation_ref } else { '' }
+            recommendable        = $rightRecommendable
         }
         shared_changed_files = @($sharedChangedFiles)
         left_only_changed_files = @($leftOnlyChangedFiles)
@@ -4387,10 +4448,11 @@ function ConvertTo-CompareRunsPayload {
         confidence_delta = $confidenceDelta
         differences = @($differences)
         recommend = [ordered]@{
-            winning_run_id = if ($null -ne $confidenceDelta) {
-                if ($confidenceDelta -gt 0) { [string]$leftRun.run_id } elseif ($confidenceDelta -lt 0) { [string]$rightRun.run_id } else { '' }
-            } else { '' }
-            reconcile_consult = [bool](@($differences | Where-Object { $_.field -in @('branch', 'worktree', 'env_fingerprint', 'command_hash', 'result') }).Count -gt 0)
+            winning_run_id = $winningRunId
+            reconcile_consult = [bool](
+                @($differences | Where-Object { $_.field -in @('branch', 'worktree', 'env_fingerprint', 'command_hash', 'result') }).Count -gt 0 -or
+                -not ($leftRecommendable -and $rightRecommendable)
+            )
             next_action = if ([string]$leftEvidence.next_action -eq [string]$rightEvidence.next_action) { [string]$leftEvidence.next_action } else { 'reconcile_consult' }
         }
     }
@@ -5329,7 +5391,12 @@ function Invoke-PromoteTactic {
     }
 
     $projectDir = (Get-Location).Path
-    $payload = Get-PromoteTacticPayload -ExplainPayload (Get-ExplainPayload -ProjectDir $projectDir -RunId $runId) -Title $title -Kind $kind
+    $explainPayload = Get-ExplainPayload -ProjectDir $projectDir -RunId $runId
+    if (-not (Test-RunPromotable -Run $explainPayload.run)) {
+        Stop-WithError "run is not promotable: $runId"
+    }
+
+    $payload = Get-PromoteTacticPayload -ExplainPayload $explainPayload -Title $title -Kind $kind
     $artifact = New-PlaybookCandidateFile -ProjectDir $projectDir -PlaybookCandidate $payload
     $result = [ordered]@{
         generated_at = (Get-Date).ToString('o')

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -287,6 +287,12 @@ function Get-ConsultationDirectory {
     return Join-Path $ProjectDir '.winsmux\consultations'
 }
 
+function Get-PlaybookCandidateDirectory {
+    param([string]$ProjectDir = (Get-Location).Path)
+
+    return Join-Path $ProjectDir '.winsmux\playbook-candidates'
+}
+
 function Get-WinsmuxArtifactReference {
     param(
         [Parameter(Mandatory = $true)][string]$ArtifactPath,
@@ -390,6 +396,30 @@ function New-ConsultationPacketFile {
     }
 
     return Write-WinsmuxArtifactFile -DirectoryPath (Get-ConsultationDirectory -ProjectDir $ProjectDir) -Prefix $prefix -Data $packet -ProjectDir $ProjectDir
+}
+
+function New-PlaybookCandidateFile {
+    param(
+        [Parameter(Mandatory = $true)][AllowNull()]$PlaybookCandidate,
+        [string]$ProjectDir = (Get-Location).Path
+    )
+
+    $packet = ConvertTo-WinsmuxArtifactData -Data $PlaybookCandidate
+    if (-not (Test-WinsmuxArtifactHasCorrelation -Data $packet)) {
+        throw 'Playbook candidate requires run_id or task_id with pane_id/slot.'
+    }
+
+    if (-not $packet.Contains('packet_type')) {
+        $packet['packet_type'] = 'playbook_candidate'
+    }
+    if (-not $packet.Contains('generated_at')) {
+        $packet['generated_at'] = (Get-Date).ToString('o')
+    }
+    if (-not $packet.Contains('kind')) {
+        $packet['kind'] = 'playbook'
+    }
+
+    return Write-WinsmuxArtifactFile -DirectoryPath (Get-PlaybookCandidateDirectory -ProjectDir $ProjectDir) -Prefix 'playbook-candidate' -Data $packet -ProjectDir $ProjectDir
 }
 
 function Read-WinsmuxArtifactJson {
@@ -4228,6 +4258,200 @@ function Get-RunsPayload {
     }
 }
 
+function Get-RunFromPayload {
+    param(
+        [Parameter(Mandatory = $true)]$RunsPayload,
+        [Parameter(Mandatory = $true)][string]$RunId
+    )
+
+    foreach ($run in @($RunsPayload.runs)) {
+        if ([string]$run.run_id -eq $RunId) {
+            return $run
+        }
+    }
+
+    return $null
+}
+
+function ConvertTo-CompareRunsPayload {
+    param(
+        [Parameter(Mandatory = $true)]$LeftPayload,
+        [Parameter(Mandatory = $true)]$RightPayload
+    )
+
+    $leftRun = $LeftPayload.run
+    $rightRun = $RightPayload.run
+    $leftExperiment = $LeftPayload.experiment_packet
+    $rightExperiment = $RightPayload.experiment_packet
+    $leftEvidence = $LeftPayload.evidence_digest
+    $rightEvidence = $RightPayload.evidence_digest
+    $leftChangedFiles = @($leftEvidence.changed_files)
+    $rightChangedFiles = @($rightEvidence.changed_files)
+    $sharedChangedFiles = @($leftChangedFiles | Where-Object { $_ -in $rightChangedFiles } | Select-Object -Unique)
+    $leftOnlyChangedFiles = @($leftChangedFiles | Where-Object { $_ -notin $rightChangedFiles })
+    $rightOnlyChangedFiles = @($rightChangedFiles | Where-Object { $_ -notin $leftChangedFiles })
+
+    $leftConfidence = if ($null -ne $leftExperiment -and $leftExperiment.Contains('confidence')) { $leftExperiment.confidence } else { $null }
+    $rightConfidence = if ($null -ne $rightExperiment -and $rightExperiment.Contains('confidence')) { $rightExperiment.confidence } else { $null }
+    $confidenceDelta = $null
+    if ($null -ne $leftConfidence -and $null -ne $rightConfidence) {
+        $confidenceDelta = [math]::Round(([double]$leftConfidence - [double]$rightConfidence), 4)
+    }
+
+    $differences = [System.Collections.Generic.List[object]]::new()
+    foreach ($field in @(
+            'branch',
+            'worktree',
+            'slot',
+            'task_state',
+            'review_state',
+            'state',
+            'next_action',
+            'hypothesis',
+            'result',
+            'env_fingerprint',
+            'command_hash'
+        )) {
+        $leftValue = ''
+        $rightValue = ''
+        switch ($field) {
+            'branch'         { $leftValue = [string]$leftRun.branch; $rightValue = [string]$rightRun.branch }
+            'worktree'       { $leftValue = if ($null -ne $leftExperiment) { [string]$leftExperiment.worktree } else { '' }; $rightValue = if ($null -ne $rightExperiment) { [string]$rightExperiment.worktree } else { '' } }
+            'slot'           { $leftValue = if ($null -ne $leftExperiment) { [string]$leftExperiment.slot } else { '' }; $rightValue = if ($null -ne $rightExperiment) { [string]$rightExperiment.slot } else { '' } }
+            'task_state'     { $leftValue = [string]$leftRun.task_state; $rightValue = [string]$rightRun.task_state }
+            'review_state'   { $leftValue = [string]$leftRun.review_state; $rightValue = [string]$rightRun.review_state }
+            'state'          { $leftValue = [string]$leftRun.state; $rightValue = [string]$rightRun.state }
+            'next_action'    { $leftValue = [string]$leftEvidence.next_action; $rightValue = [string]$rightEvidence.next_action }
+            'hypothesis'     { $leftValue = if ($null -ne $leftExperiment) { [string]$leftExperiment.hypothesis } else { '' }; $rightValue = if ($null -ne $rightExperiment) { [string]$rightExperiment.hypothesis } else { '' } }
+            'result'         { $leftValue = if ($null -ne $leftExperiment) { [string]$leftExperiment.result } else { '' }; $rightValue = if ($null -ne $rightExperiment) { [string]$rightExperiment.result } else { '' } }
+            'env_fingerprint'{ $leftValue = if ($null -ne $leftExperiment) { [string]$leftExperiment.env_fingerprint } else { '' }; $rightValue = if ($null -ne $rightExperiment) { [string]$rightExperiment.env_fingerprint } else { '' } }
+            'command_hash'   { $leftValue = if ($null -ne $leftExperiment) { [string]$leftExperiment.command_hash } else { '' }; $rightValue = if ($null -ne $rightExperiment) { [string]$rightExperiment.command_hash } else { '' } }
+        }
+
+        if ($leftValue -ne $rightValue) {
+            $differences.Add([ordered]@{
+                field = $field
+                left  = $leftValue
+                right = $rightValue
+            }) | Out-Null
+        }
+    }
+
+    if (@($leftOnlyChangedFiles).Count -gt 0 -or @($rightOnlyChangedFiles).Count -gt 0) {
+        $differences.Add([ordered]@{
+            field = 'changed_files'
+            left  = @($leftChangedFiles)
+            right = @($rightChangedFiles)
+        }) | Out-Null
+    }
+
+    if ($null -ne $confidenceDelta -and $confidenceDelta -ne 0) {
+        $differences.Add([ordered]@{
+            field = 'confidence'
+            left  = $leftConfidence
+            right = $rightConfidence
+        }) | Out-Null
+    }
+
+    return [ordered]@{
+        generated_at = (Get-Date).ToString('o')
+        left = [ordered]@{
+            run_id               = [string]$leftRun.run_id
+            label                = [string]$leftRun.primary_label
+            branch               = [string]$leftRun.branch
+            task_state           = [string]$leftRun.task_state
+            review_state         = [string]$leftRun.review_state
+            state                = [string]$leftRun.state
+            next_action          = [string]$leftEvidence.next_action
+            confidence           = $leftConfidence
+            changed_files        = @($leftChangedFiles)
+            observation_pack_ref = if ($null -ne $leftExperiment) { [string]$leftExperiment.observation_pack_ref } else { '' }
+            consultation_ref     = if ($null -ne $leftExperiment) { [string]$leftExperiment.consultation_ref } else { '' }
+        }
+        right = [ordered]@{
+            run_id               = [string]$rightRun.run_id
+            label                = [string]$rightRun.primary_label
+            branch               = [string]$rightRun.branch
+            task_state           = [string]$rightRun.task_state
+            review_state         = [string]$rightRun.review_state
+            state                = [string]$rightRun.state
+            next_action          = [string]$rightEvidence.next_action
+            confidence           = $rightConfidence
+            changed_files        = @($rightChangedFiles)
+            observation_pack_ref = if ($null -ne $rightExperiment) { [string]$rightExperiment.observation_pack_ref } else { '' }
+            consultation_ref     = if ($null -ne $rightExperiment) { [string]$rightExperiment.consultation_ref } else { '' }
+        }
+        shared_changed_files = @($sharedChangedFiles)
+        left_only_changed_files = @($leftOnlyChangedFiles)
+        right_only_changed_files = @($rightOnlyChangedFiles)
+        confidence_delta = $confidenceDelta
+        differences = @($differences)
+        recommend = [ordered]@{
+            winning_run_id = if ($null -ne $confidenceDelta) {
+                if ($confidenceDelta -gt 0) { [string]$leftRun.run_id } elseif ($confidenceDelta -lt 0) { [string]$rightRun.run_id } else { '' }
+            } else { '' }
+            reconcile_consult = [bool](@($differences | Where-Object { $_.field -in @('branch', 'worktree', 'env_fingerprint', 'command_hash', 'result') }).Count -gt 0)
+            next_action = if ([string]$leftEvidence.next_action -eq [string]$rightEvidence.next_action) { [string]$leftEvidence.next_action } else { 'reconcile_consult' }
+        }
+    }
+}
+
+function Get-PromoteTacticPayload {
+    param(
+        [Parameter(Mandatory = $true)]$ExplainPayload,
+        [string]$Title = '',
+        [string]$Kind = 'playbook'
+    )
+
+    $run = $ExplainPayload.run
+    $experimentPacket = $ExplainPayload.experiment_packet
+    $observationPack = $ExplainPayload.observation_pack
+    $consultationPacket = $ExplainPayload.consultation_packet
+    $evidenceDigest = $ExplainPayload.evidence_digest
+
+    if ([string]::IsNullOrWhiteSpace($Title)) {
+        if (-not [string]::IsNullOrWhiteSpace([string]$consultationPacket.recommendation)) {
+            $Title = [string]$consultationPacket.recommendation
+        } elseif (-not [string]::IsNullOrWhiteSpace([string]$experimentPacket.result)) {
+            $Title = [string]$experimentPacket.result
+        } elseif (-not [string]::IsNullOrWhiteSpace([string]$run.task)) {
+            $Title = [string]$run.task
+        } else {
+            $Title = "Tactic from $([string]$run.run_id)"
+        }
+    }
+
+    return [ordered]@{
+        run_id               = [string]$run.run_id
+        task_id              = [string]$run.task_id
+        pane_id              = [string]$run.primary_pane_id
+        slot                 = if ($null -ne $experimentPacket) { [string]$experimentPacket.slot } else { '' }
+        kind                 = [string]$Kind
+        title                = [string]$Title
+        summary              = if (-not [string]::IsNullOrWhiteSpace([string]$consultationPacket.recommendation)) { [string]$consultationPacket.recommendation } else { [string]$experimentPacket.result }
+        hypothesis           = if ($null -ne $experimentPacket) { [string]$experimentPacket.hypothesis } else { '' }
+        next_action          = [string]$evidenceDigest.next_action
+        confidence           = if ($null -ne $experimentPacket -and $experimentPacket.Contains('confidence')) { $experimentPacket.confidence } else { $null }
+        branch               = [string]$run.branch
+        head_sha             = [string]$run.head_sha
+        worktree             = if ($null -ne $experimentPacket) { [string]$experimentPacket.worktree } else { '' }
+        env_fingerprint      = if ($null -ne $experimentPacket) { [string]$experimentPacket.env_fingerprint } else { '' }
+        command_hash         = if ($null -ne $experimentPacket) { [string]$experimentPacket.command_hash } else { '' }
+        changed_files        = @($evidenceDigest.changed_files)
+        observation_pack_ref = if ($null -ne $experimentPacket) { [string]$experimentPacket.observation_pack_ref } else { '' }
+        consultation_ref     = if ($null -ne $experimentPacket) { [string]$experimentPacket.consultation_ref } else { '' }
+        verification_result  = $run.verification_result
+        security_verdict     = $run.security_verdict
+        action_item_count    = @($run.action_items).Count
+        action_item_kinds    = @($run.action_items | ForEach-Object { [string]$_.kind } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
+        reuse_conditions     = @(
+            if (-not [string]::IsNullOrWhiteSpace([string]$run.branch)) { "branch=$([string]$run.branch)" }
+            if ($null -ne $experimentPacket -and -not [string]::IsNullOrWhiteSpace([string]$experimentPacket.env_fingerprint)) { "env_fingerprint=$([string]$experimentPacket.env_fingerprint)" }
+            if ($null -ne $experimentPacket -and -not [string]::IsNullOrWhiteSpace([string]$experimentPacket.command_hash)) { "command_hash=$([string]$experimentPacket.command_hash)" }
+        )
+    }
+}
+
 function Get-ShortHeadSha {
     param([AllowNull()][string]$HeadSha)
 
@@ -4987,6 +5211,142 @@ function Invoke-Runs {
     Write-Output ($table.TrimEnd())
 }
 
+function Invoke-CompareRuns {
+    param(
+        [AllowNull()][string]$CompareTarget = $Target,
+        [AllowNull()][string[]]$CompareRest = $Rest
+    )
+
+    $tokens = @()
+    if (-not [string]::IsNullOrWhiteSpace($CompareTarget)) {
+        $tokens += $CompareTarget
+    }
+    if ($CompareRest) {
+        $tokens += @($CompareRest)
+    }
+
+    $jsonOutput = $false
+    $runIds = [System.Collections.Generic.List[string]]::new()
+    foreach ($token in $tokens) {
+        if ([string]$token -eq '--json') {
+            $jsonOutput = $true
+        } elseif (-not [string]::IsNullOrWhiteSpace([string]$token)) {
+            $runIds.Add([string]$token) | Out-Null
+        }
+    }
+
+    if ($runIds.Count -ne 2) {
+        Stop-WithError 'usage: winsmux compare-runs <left_run_id> <right_run_id> [--json]'
+    }
+
+    $projectDir = (Get-Location).Path
+    $leftPayload = Get-ExplainPayload -ProjectDir $projectDir -RunId ([string]$runIds[0])
+    $rightPayload = Get-ExplainPayload -ProjectDir $projectDir -RunId ([string]$runIds[1])
+    $payload = ConvertTo-CompareRunsPayload -LeftPayload $leftPayload -RightPayload $rightPayload
+
+    if ($jsonOutput) {
+        $payload | ConvertTo-Json -Compress -Depth 12 | Write-Output
+        return
+    }
+
+    Write-Output ("Compare: {0} vs {1}" -f [string]$payload.left.run_id, [string]$payload.right.run_id)
+    Write-Output ("Shared changed files: {0}" -f (@($payload.shared_changed_files).Count))
+    if ($null -ne $payload.confidence_delta) {
+        Write-Output ("Confidence delta: {0}" -f [string]$payload.confidence_delta)
+    }
+    if (-not [string]::IsNullOrWhiteSpace([string]$payload.recommend.winning_run_id)) {
+        Write-Output ("Winning run: {0}" -f [string]$payload.recommend.winning_run_id)
+    }
+    Write-Output ("Next action: {0}" -f [string]$payload.recommend.next_action)
+    if (@($payload.differences).Count -gt 0) {
+        Write-Output 'Differences:'
+        foreach ($difference in @($payload.differences)) {
+            $leftValue = if ($difference.left -is [System.Array]) { (($difference.left | ForEach-Object { [string]$_ }) -join ', ') } else { [string]$difference.left }
+            $rightValue = if ($difference.right -is [System.Array]) { (($difference.right | ForEach-Object { [string]$_ }) -join ', ') } else { [string]$difference.right }
+            Write-Output ("- {0}: left={1} right={2}" -f [string]$difference.field, $leftValue, $rightValue)
+        }
+    } else {
+        Write-Output 'Differences: (none)'
+    }
+}
+
+function Invoke-PromoteTactic {
+    param(
+        [AllowNull()][string]$PromoteTarget = $Target,
+        [AllowNull()][string[]]$PromoteRest = $Rest
+    )
+
+    $tokens = @()
+    if (-not [string]::IsNullOrWhiteSpace($PromoteTarget)) {
+        $tokens += $PromoteTarget
+    }
+    if ($PromoteRest) {
+        $tokens += @($PromoteRest)
+    }
+
+    if ($tokens.Count -eq 0) {
+        Stop-WithError 'usage: winsmux promote-tactic <run_id> [--title <text>] [--kind <playbook|prewarm|verification>] [--json]'
+    }
+
+    $runId = ''
+    $title = ''
+    $kind = 'playbook'
+    $jsonOutput = $false
+
+    for ($i = 0; $i -lt $tokens.Count; $i++) {
+        $token = [string]$tokens[$i]
+        switch ($token) {
+            '--json' { $jsonOutput = $true }
+            '--title' {
+                if ($i + 1 -ge $tokens.Count) {
+                    Stop-WithError '--title requires a value'
+                }
+                $title = [string]$tokens[$i + 1]
+                $i++
+            }
+            '--kind' {
+                if ($i + 1 -ge $tokens.Count) {
+                    Stop-WithError '--kind requires a value'
+                }
+                $kind = [string]$tokens[$i + 1]
+                $i++
+            }
+            default {
+                if ([string]::IsNullOrWhiteSpace($runId)) {
+                    $runId = [string]$token
+                } else {
+                    Stop-WithError 'usage: winsmux promote-tactic <run_id> [--title <text>] [--kind <playbook|prewarm|verification>] [--json]'
+                }
+            }
+        }
+    }
+
+    if ([string]::IsNullOrWhiteSpace($runId)) {
+        Stop-WithError 'usage: winsmux promote-tactic <run_id> [--title <text>] [--kind <playbook|prewarm|verification>] [--json]'
+    }
+    if ($kind -notin @('playbook', 'prewarm', 'verification')) {
+        Stop-WithError "Unsupported promote kind: $kind"
+    }
+
+    $projectDir = (Get-Location).Path
+    $payload = Get-PromoteTacticPayload -ExplainPayload (Get-ExplainPayload -ProjectDir $projectDir -RunId $runId) -Title $title -Kind $kind
+    $artifact = New-PlaybookCandidateFile -ProjectDir $projectDir -PlaybookCandidate $payload
+    $result = [ordered]@{
+        generated_at = (Get-Date).ToString('o')
+        run_id       = [string]$runId
+        candidate_ref = [string]$artifact.reference
+        candidate_path = [string]$artifact.path
+        candidate    = Read-WinsmuxArtifactJson -Reference ([string]$artifact.reference) -ProjectDir $projectDir -ExpectedDirectoryPath (Get-PlaybookCandidateDirectory -ProjectDir $projectDir) -ExpectedRunId $runId
+    }
+
+    if ($jsonOutput) {
+        $result | ConvertTo-Json -Compress -Depth 12 | Write-Output
+        return
+    }
+
+    Write-Output ("promoted tactic from {0} -> {1}" -f [string]$runId, [string]$artifact.reference)
+}
+
 function Invoke-Explain {
     param(
         [AllowNull()][string]$ExplainTarget = $Target,
@@ -5720,6 +6080,8 @@ inbox [--json] [--stream] Report actionable approvals/review/blockers
 runs [--json]             Report run-oriented session view
 digest [--json] [--stream] [--events] Report high-signal evidence digest per run or actionable event summaries
 explain <run_id> [--json] [--follow]  Explain one run and optionally follow new events
+compare-runs <left_run_id> <right_run_id> [--json]  Compare two runs and surface evidence/confidence deltas
+promote-tactic <run_id> [--title <text>] [--kind <playbook|prewarm|verification>] [--json]  Export a reusable tactic candidate from a successful run
   poll-events [cursor]      Return new monitor events from .winsmux/events.jsonl
   signal <channel>          Send signal to unblock a waiting process
   watch <label> [silence_s] [timeout_s]  Block until pane output is silent
@@ -6067,6 +6429,8 @@ switch ($Command) {
         'runs'            { Invoke-Runs }
         'digest'          { Invoke-Digest }
         'explain'         { Invoke-Explain }
+        'compare-runs'    { Invoke-CompareRuns }
+        'promote-tactic'  { Invoke-PromoteTactic }
     'poll-events'     { Invoke-PollEvents }
     'signal'          { Invoke-Signal }
     'mailbox-create'  { Invoke-MailboxCreate }

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -3676,7 +3676,7 @@ function Get-SecurityVerdictFromEventRecords {
 
     $snapshot = Get-LatestRunEventDataSnapshot `
         -EventRecords $EventRecords `
-        -EventNames @('pipeline.security.blocked', 'security.policy.blocked') `
+        -EventNames @('pipeline.security.blocked', 'security.policy.blocked', 'pipeline.security.allowed', 'security.policy.allowed') `
         -DataFields @('stage', 'attempt', 'task', 'verdict', 'reason', 'advisory_mode', 'allow', 'block', 'next_action')
     if ($null -eq $snapshot) {
         return $null
@@ -3977,7 +3977,7 @@ function ConvertTo-RunEventRecord {
         consultation_packet  = $consultationPacket
         verification_contract = if ($null -ne $data -and $data -is [System.Collections.IDictionary] -and $data.Contains('verification_contract')) { $data['verification_contract'] } else { $null }
         verification_result   = if ($null -ne $data -and $data -is [System.Collections.IDictionary] -and $data.Contains('verification_result')) { $data['verification_result'] } else { $null }
-        security_verdict      = if (($EventRecord['event'] -in @('pipeline.security.blocked', 'security.policy.blocked')) -and $null -ne $data -and $data -is [System.Collections.IDictionary]) {
+        security_verdict      = if (($EventRecord['event'] -in @('pipeline.security.blocked', 'security.policy.blocked', 'pipeline.security.allowed', 'security.policy.allowed')) -and $null -ne $data -and $data -is [System.Collections.IDictionary]) {
             [ordered]@{
                 stage         = if ($data.Contains('stage')) { [string]$data['stage'] } else { '' }
                 attempt       = if ($data.Contains('attempt')) { $data['attempt'] } else { $null }
@@ -4281,33 +4281,6 @@ function Test-RunRecommendable {
     $verificationOutcome = if ($null -ne $Run.verification_result) { ([string]$Run.verification_result.outcome).ToUpperInvariant() } else { '' }
     $securityVerdict = if ($null -ne $Run.security_verdict) { ([string]$Run.security_verdict.verdict).ToUpperInvariant() } else { '' }
 
-    if ($taskState -in @('blocked', 'failed')) {
-        return $false
-    }
-    if ($reviewState -in @('FAIL', 'FAILED', 'BLOCKED')) {
-        return $false
-    }
-    if ($verificationOutcome -in @('FAIL', 'FAILED', 'PARTIAL', 'BLOCK', 'BLOCKED')) {
-        return $false
-    }
-    if ($securityVerdict -in @('BLOCK', 'BLOCKED', 'FAIL', 'FAILED')) {
-        return $false
-    }
-
-    return $true
-}
-
-function Test-RunPromotable {
-    param([Parameter(Mandatory = $true)]$Run)
-
-    if (-not (Test-RunRecommendable -Run $Run)) {
-        return $false
-    }
-
-    $taskState = [string]$Run.task_state
-    $reviewState = ([string]$Run.review_state).ToUpperInvariant()
-    $verificationOutcome = if ($null -ne $Run.verification_result) { ([string]$Run.verification_result.outcome).ToUpperInvariant() } else { '' }
-
     if ($taskState -notin @('completed', 'task_completed', 'commit_ready', 'done')) {
         return $false
     }
@@ -4317,8 +4290,17 @@ function Test-RunPromotable {
     if ($verificationOutcome -ne 'PASS') {
         return $false
     }
+    if ($securityVerdict -notin @('ALLOW', 'PASS')) {
+        return $false
+    }
 
     return $true
+}
+
+function Test-RunPromotable {
+    param([Parameter(Mandatory = $true)]$Run)
+
+    return (Test-RunRecommendable -Run $Run)
 }
 
 function ConvertTo-CompareRunsPayload {

--- a/tests/psmux-bridge.Tests.ps1
+++ b/tests/psmux-bridge.Tests.ps1
@@ -5280,6 +5280,198 @@ Describe 'winsmux task-run command' {
     }
 }
 
+Describe 'winsmux compare-runs and promote-tactic commands' {
+    BeforeAll {
+        $script:winsmuxCorePath = Join-Path (Split-Path -Parent $PSScriptRoot) 'scripts\winsmux-core.ps1'
+        . $script:winsmuxCorePath 'version' *> $null
+    }
+
+    BeforeEach {
+        $script:compareTempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('winsmux-compare-tests-' + [guid]::NewGuid().ToString('N'))
+        $script:compareManifestDir = Join-Path $script:compareTempRoot '.winsmux'
+        $script:compareManifestPath = Join-Path $script:compareManifestDir 'manifest.yaml'
+        $script:compareEventsPath = Join-Path $script:compareManifestDir 'events.jsonl'
+        New-Item -ItemType Directory -Path $script:compareManifestDir -Force | Out-Null
+
+@"
+version: 1
+session:
+  name: winsmux-orchestra
+  project_dir: $script:compareTempRoot
+panes:
+  builder-1:
+    pane_id: %2
+    role: Builder
+    task_id: task-compare-a
+    task: Compare run A
+    task_state: in_progress
+    review_state: PENDING
+    branch: worktree-builder-a
+    head_sha: aaaabbbbccccdddd
+    changed_file_count: 1
+    changed_files: '["scripts/winsmux-core.ps1"]'
+    last_event: commander.review_requested
+    last_event_at: 2026-04-12T10:00:00+09:00
+  builder-2:
+    pane_id: %4
+    role: Worker
+    task_id: task-compare-b
+    task: Compare run B
+    task_state: blocked
+    review_state: FAIL
+    branch: worktree-builder-b
+    head_sha: eeeeffff11112222
+    changed_file_count: 2
+    changed_files: '["scripts/winsmux-core.ps1","tests/psmux-bridge.Tests.ps1"]'
+    last_event: pane.consult_result
+    last_event_at: 2026-04-12T10:05:00+09:00
+"@ | Set-Content -Path $script:compareManifestPath -Encoding UTF8
+
+        $script:compareObsA = New-ObservationPackFile -ProjectDir $script:compareTempRoot -ObservationPack ([ordered]@{
+            run_id          = 'task:task-compare-a'
+            task_id         = 'task-compare-a'
+            pane_id         = '%2'
+            slot            = 'slot-builder-a'
+            hypothesis      = 'deterministic command fixes cache drift'
+            test_plan       = @('rerun build', 'check cache hit')
+            env_fingerprint = 'env:a'
+            command_hash    = 'cmd:a'
+            changed_files   = @('scripts/winsmux-core.ps1')
+        })
+        $script:compareObsB = New-ObservationPackFile -ProjectDir $script:compareTempRoot -ObservationPack ([ordered]@{
+            run_id          = 'task:task-compare-b'
+            task_id         = 'task-compare-b'
+            pane_id         = '%4'
+            slot            = 'slot-builder-b'
+            hypothesis      = 'framework inference is re-injecting noise'
+            test_plan       = @('disable inference', 'rerun build')
+            env_fingerprint = 'env:b'
+            command_hash    = 'cmd:b'
+            changed_files   = @('scripts/winsmux-core.ps1', 'tests/psmux-bridge.Tests.ps1')
+        })
+        $script:compareConsultA = New-ConsultationPacketFile -ProjectDir $script:compareTempRoot -ConsultationPacket ([ordered]@{
+            run_id         = 'task:task-compare-a'
+            task_id        = 'task-compare-a'
+            pane_id        = '%2'
+            slot           = 'slot-builder-a'
+            kind           = 'consult_result'
+            mode           = 'early'
+            confidence     = 0.85
+            recommendation = 'prefer deterministic command'
+            next_test      = 'promote tactic'
+        })
+        $script:compareConsultB = New-ConsultationPacketFile -ProjectDir $script:compareTempRoot -ConsultationPacket ([ordered]@{
+            run_id         = 'task:task-compare-b'
+            task_id        = 'task-compare-b'
+            pane_id        = '%4'
+            slot           = 'slot-builder-b'
+            kind           = 'consult_result'
+            mode           = 'reconcile'
+            confidence     = 0.4
+            recommendation = 'needs reconcile consult'
+            next_test      = 'reconcile consult'
+        })
+
+        @(
+            ([ordered]@{
+                timestamp = '2026-04-12T10:00:00+09:00'
+                session   = 'winsmux-orchestra'
+                event     = 'commander.review_requested'
+                message   = 'review requested'
+                label     = 'builder-1'
+                pane_id   = '%2'
+                role      = 'Builder'
+                branch    = 'worktree-builder-a'
+                head_sha  = 'aaaabbbbccccdddd'
+                data      = [ordered]@{
+                    task_id              = 'task-compare-a'
+                    run_id               = 'task:task-compare-a'
+                    slot                 = 'slot-builder-a'
+                    hypothesis           = 'deterministic command fixes cache drift'
+                    result               = 'cache hit done'
+                    confidence           = 0.85
+                    next_action          = 'promote tactic'
+                    observation_pack_ref = $script:compareObsA.reference
+                    consultation_ref     = $script:compareConsultA.reference
+                    worktree             = '.worktrees/builder-a'
+                    env_fingerprint      = 'env:a'
+                    command_hash         = 'cmd:a'
+                }
+            } | ConvertTo-Json -Compress),
+            ([ordered]@{
+                timestamp = '2026-04-12T10:05:00+09:00'
+                session   = 'winsmux-orchestra'
+                event     = 'pane.consult_result'
+                message   = 'consultation completed'
+                label     = 'builder-2'
+                pane_id   = '%4'
+                role      = 'Worker'
+                branch    = 'worktree-builder-b'
+                head_sha  = 'eeeeffff11112222'
+                data      = [ordered]@{
+                    task_id              = 'task-compare-b'
+                    run_id               = 'task:task-compare-b'
+                    slot                 = 'slot-builder-b'
+                    hypothesis           = 'framework inference is re-injecting noise'
+                    result               = 'still dirty'
+                    confidence           = 0.4
+                    next_action          = 'reconcile consult'
+                    observation_pack_ref = $script:compareObsB.reference
+                    consultation_ref     = $script:compareConsultB.reference
+                    worktree             = '.worktrees/builder-b'
+                    env_fingerprint      = 'env:b'
+                    command_hash         = 'cmd:b'
+                }
+            } | ConvertTo-Json -Compress)
+        ) | Set-Content -Path $script:compareEventsPath -Encoding UTF8
+
+        Push-Location $script:compareTempRoot
+    }
+
+    AfterEach {
+        Pop-Location
+        if ($script:compareTempRoot -and (Test-Path $script:compareTempRoot)) {
+            Remove-Item -Path $script:compareTempRoot -Recurse -Force
+        }
+    }
+
+    It 'compares two runs and reports confidence and evidence deltas in json' {
+        $result = (Invoke-CompareRuns -CompareTarget 'task:task-compare-a' -CompareRest @('task:task-compare-b', '--json') | Out-String | ConvertFrom-Json -AsHashtable)
+
+        $result.left.run_id | Should -Be 'task:task-compare-a'
+        $result.right.run_id | Should -Be 'task:task-compare-b'
+        $result.confidence_delta | Should -Be 0.45
+        $result.shared_changed_files | Should -Be @('scripts/winsmux-core.ps1')
+        $result.left_only_changed_files | Should -Be @()
+        $result.right_only_changed_files | Should -Be @('tests/psmux-bridge.Tests.ps1')
+        $result.recommend.winning_run_id | Should -Be 'task:task-compare-a'
+        $result.recommend.reconcile_consult | Should -Be $true
+        @($result.differences | ForEach-Object { $_.field }) | Should -Contain 'result'
+        @($result.differences | ForEach-Object { $_.field }) | Should -Contain 'confidence'
+        @($result.differences | ForEach-Object { $_.field }) | Should -Contain 'changed_files'
+    }
+
+    It 'exports a playbook candidate from a run and writes a file-backed artifact' {
+        $result = (Invoke-PromoteTactic -PromoteTarget 'task:task-compare-a' -PromoteRest @('--title', 'Deterministic build command', '--json') | Out-String | ConvertFrom-Json -AsHashtable)
+
+        $result.run_id | Should -Be 'task:task-compare-a'
+        $result.candidate_ref | Should -BeLike '.winsmux/playbook-candidates/playbook-candidate-*.json'
+        Test-Path -LiteralPath $result.candidate_path | Should -Be $true
+        $result.candidate.packet_type | Should -Be 'playbook_candidate'
+        $result.candidate.kind | Should -Be 'playbook'
+        $result.candidate.title | Should -Be 'Deterministic build command'
+        $result.candidate.summary | Should -Be 'prefer deterministic command'
+        $result.candidate.hypothesis | Should -Be 'deterministic command fixes cache drift'
+        $result.candidate.changed_files | Should -Be @('scripts/winsmux-core.ps1')
+        $result.candidate.observation_pack_ref | Should -Be $script:compareObsA.reference
+        $result.candidate.consultation_ref | Should -Be $script:compareConsultA.reference
+    }
+
+    It 'fails closed for unsupported promote kind' {
+        { Invoke-PromoteTactic -PromoteTarget 'task:task-compare-a' -PromoteRest @('--kind', 'unknown') } | Should -Throw '*Unsupported promote kind*'
+    }
+}
+
 Describe 'winsmux observation and consultation artifacts' {
     BeforeAll {
         $script:winsmuxCorePath = Join-Path (Split-Path -Parent $PSScriptRoot) 'scripts\winsmux-core.ps1'

--- a/tests/psmux-bridge.Tests.ps1
+++ b/tests/psmux-bridge.Tests.ps1
@@ -5460,6 +5460,40 @@ panes:
                         summary = 'rebuild confirmed'
                     }
                 }
+            } | ConvertTo-Json -Compress),
+            ([ordered]@{
+                timestamp = '2026-04-12T10:05:30+09:00'
+                session   = 'winsmux-orchestra'
+                event     = 'pipeline.security.allowed'
+                message   = 'security allowed'
+                label     = 'builder-1'
+                pane_id   = '%2'
+                role      = 'Builder'
+                branch    = 'worktree-builder-a'
+                head_sha  = 'aaaabbbbccccdddd'
+                data      = [ordered]@{
+                    task_id = 'task-compare-a'
+                    run_id  = 'task:task-compare-a'
+                    verdict = 'ALLOW'
+                    reason  = 'verified safe'
+                }
+            } | ConvertTo-Json -Compress),
+            ([ordered]@{
+                timestamp = '2026-04-12T10:05:40+09:00'
+                session   = 'winsmux-orchestra'
+                event     = 'pipeline.security.allowed'
+                message   = 'security allowed'
+                label     = 'builder-2'
+                pane_id   = '%4'
+                role      = 'Worker'
+                branch    = 'worktree-builder-b'
+                head_sha  = 'eeeeffff11112222'
+                data      = [ordered]@{
+                    task_id = 'task-compare-b'
+                    run_id  = 'task:task-compare-b'
+                    verdict = 'ALLOW'
+                    reason  = 'verified safe'
+                }
             } | ConvertTo-Json -Compress)
         ) | Set-Content -Path $script:compareEventsPath -Encoding UTF8
 
@@ -5548,7 +5582,42 @@ panes:
                     worktree             = '.worktrees/builder-a'
                     env_fingerprint      = 'env:a'
                     command_hash         = 'cmd:a'
-                    verification_result  = [ordered]@{ outcome = 'PASS' }
+                }
+            } | ConvertTo-Json -Compress),
+            ([ordered]@{
+                timestamp = '2026-04-12T10:00:20+09:00'
+                session   = 'winsmux-orchestra'
+                event     = 'pipeline.verify.pass'
+                message   = 'verification passed'
+                label     = 'builder-1'
+                pane_id   = '%2'
+                role      = 'Builder'
+                branch    = 'worktree-builder-a'
+                head_sha  = 'aaaabbbbccccdddd'
+                data      = [ordered]@{
+                    task_id = 'task-compare-a'
+                    run_id  = 'task:task-compare-a'
+                    verification_result = [ordered]@{
+                        outcome = 'PASS'
+                        summary = 'cache hit confirmed'
+                    }
+                }
+            } | ConvertTo-Json -Compress),
+            ([ordered]@{
+                timestamp = '2026-04-12T10:00:30+09:00'
+                session   = 'winsmux-orchestra'
+                event     = 'pipeline.security.allowed'
+                message   = 'security allowed'
+                label     = 'builder-1'
+                pane_id   = '%2'
+                role      = 'Builder'
+                branch    = 'worktree-builder-a'
+                head_sha  = 'aaaabbbbccccdddd'
+                data      = [ordered]@{
+                    task_id = 'task-compare-a'
+                    run_id  = 'task:task-compare-a'
+                    verdict = 'ALLOW'
+                    reason  = 'verified safe'
                 }
             } | ConvertTo-Json -Compress),
             ([ordered]@{
@@ -5647,6 +5716,78 @@ panes:
     last_event: commander.review_requested
     last_event_at: 2026-04-12T10:00:00+09:00
 "@ | Set-Content -Path $script:compareManifestPath -Encoding UTF8
+
+        { Invoke-PromoteTactic -PromoteTarget 'task:task-compare-a' } | Should -Throw '*run is not promotable*'
+    }
+
+    It 'rejects promote-tactic when security clearance is missing' {
+        @"
+version: 1
+session:
+  name: winsmux-orchestra
+  project_dir: $script:compareTempRoot
+panes:
+  builder-1:
+    pane_id: %2
+    role: Builder
+    task_id: task-compare-a
+    task: Compare run A
+    task_state: completed
+    review_state: PASS
+    branch: worktree-builder-a
+    head_sha: aaaabbbbccccdddd
+    changed_file_count: 1
+    changed_files: '["scripts/winsmux-core.ps1"]'
+    last_event: commander.review_requested
+    last_event_at: 2026-04-12T10:00:00+09:00
+"@ | Set-Content -Path $script:compareManifestPath -Encoding UTF8
+
+        @(
+            ([ordered]@{
+                timestamp = '2026-04-12T10:00:00+09:00'
+                session   = 'winsmux-orchestra'
+                event     = 'commander.review_requested'
+                message   = 'review requested'
+                label     = 'builder-1'
+                pane_id   = '%2'
+                role      = 'Builder'
+                branch    = 'worktree-builder-a'
+                head_sha  = 'aaaabbbbccccdddd'
+                data      = [ordered]@{
+                    task_id              = 'task-compare-a'
+                    run_id               = 'task:task-compare-a'
+                    slot                 = 'slot-builder-a'
+                    hypothesis           = 'deterministic command fixes cache drift'
+                    result               = 'cache hit done'
+                    confidence           = 0.85
+                    next_action          = 'promote tactic'
+                    observation_pack_ref = $script:compareObsA.reference
+                    consultation_ref     = $script:compareConsultA.reference
+                    worktree             = '.worktrees/builder-a'
+                    env_fingerprint      = 'env:a'
+                    command_hash         = 'cmd:a'
+                }
+            } | ConvertTo-Json -Compress),
+            ([ordered]@{
+                timestamp = '2026-04-12T10:05:10+09:00'
+                session   = 'winsmux-orchestra'
+                event     = 'pipeline.verify.pass'
+                message   = 'verification passed'
+                label     = 'builder-1'
+                pane_id   = '%2'
+                role      = 'Builder'
+                branch    = 'worktree-builder-a'
+                head_sha  = 'aaaabbbbccccdddd'
+                data      = [ordered]@{
+                    task_id = 'task-compare-a'
+                    run_id  = 'task:task-compare-a'
+                    verification_result = [ordered]@{
+                        outcome = 'PASS'
+                        summary = 'cache hit confirmed'
+                    }
+                }
+            } | ConvertTo-Json -Compress)
+        ) | Set-Content -Path $script:compareEventsPath -Encoding UTF8
 
         { Invoke-PromoteTactic -PromoteTarget 'task:task-compare-a' } | Should -Throw '*run is not promotable*'
     }

--- a/tests/psmux-bridge.Tests.ps1
+++ b/tests/psmux-bridge.Tests.ps1
@@ -5304,8 +5304,8 @@ panes:
     role: Builder
     task_id: task-compare-a
     task: Compare run A
-    task_state: in_progress
-    review_state: PENDING
+    task_state: completed
+    review_state: PASS
     branch: worktree-builder-a
     head_sha: aaaabbbbccccdddd
     changed_file_count: 1
@@ -5317,8 +5317,8 @@ panes:
     role: Worker
     task_id: task-compare-b
     task: Compare run B
-    task_state: blocked
-    review_state: FAIL
+    task_state: completed
+    review_state: PASS
     branch: worktree-builder-b
     head_sha: eeeeffff11112222
     changed_file_count: 2
@@ -5422,6 +5422,44 @@ panes:
                     env_fingerprint      = 'env:b'
                     command_hash         = 'cmd:b'
                 }
+            } | ConvertTo-Json -Compress),
+            ([ordered]@{
+                timestamp = '2026-04-12T10:05:10+09:00'
+                session   = 'winsmux-orchestra'
+                event     = 'pipeline.verify.pass'
+                message   = 'verification passed'
+                label     = 'builder-1'
+                pane_id   = '%2'
+                role      = 'Builder'
+                branch    = 'worktree-builder-a'
+                head_sha  = 'aaaabbbbccccdddd'
+                data      = [ordered]@{
+                    task_id = 'task-compare-a'
+                    run_id  = 'task:task-compare-a'
+                    verification_result = [ordered]@{
+                        outcome = 'PASS'
+                        summary = 'cache hit confirmed'
+                    }
+                }
+            } | ConvertTo-Json -Compress),
+            ([ordered]@{
+                timestamp = '2026-04-12T10:05:20+09:00'
+                session   = 'winsmux-orchestra'
+                event     = 'pipeline.verify.pass'
+                message   = 'verification passed'
+                label     = 'builder-2'
+                pane_id   = '%4'
+                role      = 'Worker'
+                branch    = 'worktree-builder-b'
+                head_sha  = 'eeeeffff11112222'
+                data      = [ordered]@{
+                    task_id = 'task-compare-b'
+                    run_id  = 'task:task-compare-b'
+                    verification_result = [ordered]@{
+                        outcome = 'PASS'
+                        summary = 'rebuild confirmed'
+                    }
+                }
             } | ConvertTo-Json -Compress)
         ) | Set-Content -Path $script:compareEventsPath -Encoding UTF8
 
@@ -5451,6 +5489,123 @@ panes:
         @($result.differences | ForEach-Object { $_.field }) | Should -Contain 'changed_files'
     }
 
+    It 'suppresses winner selection when a higher-confidence run is unhealthy' {
+        @"
+version: 1
+session:
+  name: winsmux-orchestra
+  project_dir: $script:compareTempRoot
+panes:
+  builder-1:
+    pane_id: %2
+    role: Builder
+    task_id: task-compare-a
+    task: Compare run A
+    task_state: completed
+    review_state: PASS
+    branch: worktree-builder-a
+    head_sha: aaaabbbbccccdddd
+    changed_file_count: 1
+    changed_files: '["scripts/winsmux-core.ps1"]'
+    last_event: commander.review_requested
+    last_event_at: 2026-04-12T10:00:00+09:00
+  builder-2:
+    pane_id: %4
+    role: Worker
+    task_id: task-compare-b
+    task: Compare run B
+    task_state: blocked
+    review_state: FAIL
+    branch: worktree-builder-b
+    head_sha: eeeeffff11112222
+    changed_file_count: 2
+    changed_files: '["scripts/winsmux-core.ps1","tests/psmux-bridge.Tests.ps1"]'
+    last_event: pane.consult_result
+    last_event_at: 2026-04-12T10:05:00+09:00
+"@ | Set-Content -Path $script:compareManifestPath -Encoding UTF8
+
+        $unhealthyEvents = @(
+            ([ordered]@{
+                timestamp = '2026-04-12T10:00:00+09:00'
+                session   = 'winsmux-orchestra'
+                event     = 'commander.review_requested'
+                message   = 'review requested'
+                label     = 'builder-1'
+                pane_id   = '%2'
+                role      = 'Builder'
+                branch    = 'worktree-builder-a'
+                head_sha  = 'aaaabbbbccccdddd'
+                data      = [ordered]@{
+                    task_id              = 'task-compare-a'
+                    run_id               = 'task:task-compare-a'
+                    slot                 = 'slot-builder-a'
+                    hypothesis           = 'deterministic command fixes cache drift'
+                    result               = 'cache hit done'
+                    confidence           = 0.85
+                    next_action          = 'promote tactic'
+                    observation_pack_ref = $script:compareObsA.reference
+                    consultation_ref     = $script:compareConsultA.reference
+                    worktree             = '.worktrees/builder-a'
+                    env_fingerprint      = 'env:a'
+                    command_hash         = 'cmd:a'
+                    verification_result  = [ordered]@{ outcome = 'PASS' }
+                }
+            } | ConvertTo-Json -Compress),
+            ([ordered]@{
+                timestamp = '2026-04-12T10:05:00+09:00'
+                session   = 'winsmux-orchestra'
+                event     = 'pane.consult_result'
+                message   = 'consultation completed'
+                label     = 'builder-2'
+                pane_id   = '%4'
+                role      = 'Worker'
+                branch    = 'worktree-builder-b'
+                head_sha  = 'eeeeffff11112222'
+                data      = [ordered]@{
+                    task_id              = 'task-compare-b'
+                    run_id               = 'task:task-compare-b'
+                    slot                 = 'slot-builder-b'
+                    hypothesis           = 'framework inference is re-injecting noise'
+                    result               = 'still dirty'
+                    confidence           = 0.95
+                    next_action          = 'reconcile consult'
+                    observation_pack_ref = $script:compareObsB.reference
+                    consultation_ref     = $script:compareConsultB.reference
+                    worktree             = '.worktrees/builder-b'
+                    env_fingerprint      = 'env:b'
+                    command_hash         = 'cmd:b'
+                }
+            } | ConvertTo-Json -Compress),
+            ([ordered]@{
+                timestamp = '2026-04-12T10:05:20+09:00'
+                session   = 'winsmux-orchestra'
+                event     = 'pipeline.verify.fail'
+                message   = 'verification failed'
+                label     = 'builder-2'
+                pane_id   = '%4'
+                role      = 'Worker'
+                branch    = 'worktree-builder-b'
+                head_sha  = 'eeeeffff11112222'
+                data      = [ordered]@{
+                    task_id = 'task-compare-b'
+                    run_id  = 'task:task-compare-b'
+                    verification_result = [ordered]@{
+                        outcome = 'FAIL'
+                        summary = 'dirty build remains'
+                    }
+                }
+            } | ConvertTo-Json -Compress)
+        )
+        $unhealthyEvents | Set-Content -Path $script:compareEventsPath -Encoding UTF8
+
+        $result = (Invoke-CompareRuns -CompareTarget 'task:task-compare-a' -CompareRest @('task:task-compare-b', '--json') | Out-String | ConvertFrom-Json -AsHashtable)
+
+        $result.left.recommendable | Should -Be $true
+        $result.right.recommendable | Should -Be $false
+        $result.recommend.winning_run_id | Should -Be ''
+        $result.recommend.reconcile_consult | Should -Be $true
+    }
+
     It 'exports a playbook candidate from a run and writes a file-backed artifact' {
         $result = (Invoke-PromoteTactic -PromoteTarget 'task:task-compare-a' -PromoteRest @('--title', 'Deterministic build command', '--json') | Out-String | ConvertFrom-Json -AsHashtable)
 
@@ -5469,6 +5624,31 @@ panes:
 
     It 'fails closed for unsupported promote kind' {
         { Invoke-PromoteTactic -PromoteTarget 'task:task-compare-a' -PromoteRest @('--kind', 'unknown') } | Should -Throw '*Unsupported promote kind*'
+    }
+
+    It 'rejects promote-tactic for unhealthy runs' {
+        @"
+version: 1
+session:
+  name: winsmux-orchestra
+  project_dir: $script:compareTempRoot
+panes:
+  builder-1:
+    pane_id: %2
+    role: Builder
+    task_id: task-compare-a
+    task: Compare run A
+    task_state: blocked
+    review_state: FAIL
+    branch: worktree-builder-a
+    head_sha: aaaabbbbccccdddd
+    changed_file_count: 1
+    changed_files: '["scripts/winsmux-core.ps1"]'
+    last_event: commander.review_requested
+    last_event_at: 2026-04-12T10:00:00+09:00
+"@ | Set-Content -Path $script:compareManifestPath -Encoding UTF8
+
+        { Invoke-PromoteTactic -PromoteTarget 'task:task-compare-a' } | Should -Throw '*run is not promotable*'
     }
 }
 


### PR DESCRIPTION
## Summary
- add `winsmux compare-runs` baseline over experiment packet and explain surfaces
- add `winsmux promote-tactic` baseline with file-backed playbook candidate export
- rebaseline `v0.21.1` in handoff as a shipped baseline release before closure

## Validation
- `Invoke-Pester tests/psmux-bridge.Tests.ps1`
- PowerShell parser checks for `scripts/winsmux-core.ps1` and `tests/psmux-bridge.Tests.ps1`
- `git diff --check`

## Review
- fresh reviewer timed out after the required wait before PR creation, so current gate is fallback only: manual diff review + passing validation
- a second fresh `/review` will run before merge if CI is green