### PR TITLE
feat: consolidate leaf terminal wrappers

### DIFF
--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -1,6 +1,6 @@
 # Handoff
 
-> Updated: 2026-04-12T20:53:00+09:00
+> Updated: 2026-04-12T22:02:00+09:00
 > Source of truth: this file
 
 ## Current state
@@ -21,50 +21,43 @@
 
 ## This session
 
-- Audited `v0.21.1` against the actual repo state before release closure.
-- Confirmed baseline-only shipped truth and rebaselined external planning so non-shipped work moved out of `v0.21.1`.
-- Implemented the missing shipped-baseline CLI required for honest closure:
-  - `winsmux compare-runs <left> <right> [--json]`
-  - `winsmux promote-tactic <run_id> [--title ...] [--kind ...] [--json]`
-  - `.winsmux/playbook-candidates/` file-backed candidate export
-- Expanded regression coverage for compare/promote surfaces.
-- Reviewer `Ptolemy` returned `FAIL` on compare winner health and promote guard conditions.
-- Fixed the findings by:
-  - suppressing `compare-runs` winner selection unless both sides are recommendable
-  - rejecting `promote-tactic` for non-promotable runs
-  - adding regression tests for both guards
-- Reviewer `Halley` returned `FAIL` on the stricter closure criteria.
-- Fixed the findings by:
-  - requiring completed task state, review pass, verification pass, and explicit security allow/pass for recommend/promote
-  - teaching the read model to recognize allow-side security events
-  - adding regression coverage for missing-security promotion and strict healthy-winner selection
-- Fresh reviewer `Ohm` timed out after two waits, so the final merge used the documented fallback gate.
-- Merged PR #407 and released `v0.21.1` with curated notes and cleaned release assets.
+- Started `v0.21.2: Terminal-Based Final Form & Session Ergonomics`.
+- Scoped `TASK-216` to a low-risk first slice that consolidates raw terminal CLI calls in leaf hot-path scripts instead of the central bridge file.
+- Implemented wrapper-based terminal calls in:
+  - `winsmux-core/scripts/commander-poll.ps1`
+  - `winsmux-core/scripts/pane-status.ps1`
+  - `winsmux-core/scripts/pane-control.ps1`
+- Added regression coverage for:
+  - commander review dispatch using wrappers
+  - pane status default snapshot capture through its wrapper
+  - pane title reads through the pane-control wrapper
+- Integrated explorer review findings from `Aristotle` and closed that subagent after use.
+- Validation is passing locally; fresh `/review` is the next gate before commit/PR.
 
 ## Validation
 
-- `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `161/161 PASS`
-- PowerShell parser check for `scripts/winsmux-core.ps1` and `tests/psmux-bridge.Tests.ps1` -> PASS
-- `git diff --check` -> no substantive diff-check failures
-- Review gate history for the active `v0.21.1` closure slice:
-  - explorer audit established release-scope drift
-  - fresh reviewer `Parfit` -> `no result yet` after 30s wait; closed without result
-  - fresh reviewer `Ptolemy` -> `FAIL`, findings fixed locally
-  - fresh reviewer `Halley` -> `FAIL`, stricter guard findings fixed locally
-  - fresh reviewer `Ohm` -> `no result yet` after two 35s waits on the final diff; closed without result
-  - manual diff review completed on the compare/promote slice
-- PR #407 CI -> green (`Pester Tests`)
-- release workflow -> success (`v0.21.1`)
+- `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `164/164 PASS`
+- PowerShell parser check for:
+  - `winsmux-core/scripts/commander-poll.ps1`
+  - `winsmux-core/scripts/pane-status.ps1`
+  - `winsmux-core/scripts/pane-control.ps1`
+  - `tests/psmux-bridge.Tests.ps1`
+  -> PASS
+- `git diff --check` -> warnings only, no substantive diff-check failures
+- Explorer review `Aristotle` completed and recommended the leaf-script-first `TASK-216` slice
+- Fresh reviewer `Mill` -> `no result yet` after two 35s waits; closed without result
+- Manual diff review completed for the `TASK-216` leaf-wrapper slice
 
 ## Next actions
 
-1. Start `v0.21.2` closure work.
-2. At `v0.21.2` release time, update `README.md` and `README.ja.md` to mark the terminal-based final form before `v0.22.0`.
-3. Keep GitHub Releases in Codex format with inline issue/PR refs visible.
+1. Run a fresh `/review` on the current `TASK-216` leaf-wrapper slice.
+2. Create branch/commit/PR for the `TASK-216` first slice once review is incorporated.
+3. Continue `v0.21.2` with the next densest wrapper consolidation target after this slice.
+4. At `v0.21.2` release time, update `README.md` and `README.ja.md` to mark the terminal-based final form before `v0.22.0`.
 
 ## Notes
 
 - `v0.21.1` is a baseline release, not the full advanced workflow/runtime roadmap.
-- `TASK-168`, `TASK-169`, `TASK-192`, and `TASK-307` are being moved out so the release truth matches shipped code.
+- `TASK-216` is being landed as small hot-path wrapper slices rather than a single bridge-file refactor.
 - Public GitHub Releases stay English, use Codex-style headings, and keep inline issue/PR refs visible.
 - `README.md` and `README.ja.md` must be updated again at `v0.21.2` release time to mark the terminal-based final form as the last pre-Tauri shape.

--- a/tests/psmux-bridge.Tests.ps1
+++ b/tests/psmux-bridge.Tests.ps1
@@ -1390,6 +1390,22 @@ panes:
         $manifestContent | Should -Match $([regex]::Escape("'builder-2':"))
     }
 
+    It 'reads pane titles through the pane-control winsmux wrapper' {
+        Mock Invoke-PaneControlWinsmux { @('ignored', 'builder-7') } -ParameterFilter {
+            $Arguments.Count -eq 5 -and
+            $Arguments[0] -eq 'display-message' -and
+            $Arguments[1] -eq '-p' -and
+            $Arguments[2] -eq '-t' -and
+            $Arguments[3] -eq '%7' -and
+            $Arguments[4] -eq '#{pane_title}'
+        }
+
+        $title = Get-PaneControlPaneTitle -PaneId '%7'
+
+        $title | Should -Be 'builder-7'
+        Should -Invoke Invoke-PaneControlWinsmux -Times 1 -Exactly
+    }
+
     It 'keeps changed_files empty when the manifest stores an empty array' {
 @'
 version: 1
@@ -3224,6 +3240,35 @@ Esc to interrupt
         $records[2].TokensRemaining | Should -Be '61% context left'
     }
 
+    It 'uses the pane-status winsmux wrapper when no snapshot provider is passed' {
+        Mock Invoke-PaneStatusWinsmux {
+            param([string[]]$Arguments)
+
+            switch ($Arguments[2]) {
+                '%2' { return "PS C:\repo\.worktrees\builder-1>" }
+                '%4' { return "gpt-5.4   82% context left`n?" }
+                '%1' { return "thinking`nEsc to interrupt" }
+                default { throw "unexpected capture target: $($Arguments[2])" }
+            }
+        } -ParameterFilter {
+            $Arguments.Count -eq 7 -and
+            $Arguments[0] -eq 'capture-pane' -and
+            $Arguments[1] -eq '-t' -and
+            $Arguments[3] -eq '-p' -and
+            $Arguments[4] -eq '-J' -and
+            $Arguments[5] -eq '-S' -and
+            $Arguments[6] -eq '-80'
+        }
+
+        $records = Get-PaneStatusRecords -ProjectDir $script:paneStatusTempRoot
+
+        $records.Count | Should -Be 3
+        $records[0].State | Should -Be 'pwsh'
+        $records[1].State | Should -Be 'idle'
+        $records[2].State | Should -Be 'busy'
+        Should -Invoke Invoke-PaneStatusWinsmux -Times 3 -Exactly
+    }
+
     It 'includes task review git fields from the manifest state model' {
         @'
 version: 1
@@ -3337,10 +3382,19 @@ panes:
             $commandLine = ($args | ForEach-Object { [string]$_ }) -join ' '
             switch -Regex ($commandLine) {
                 '^list-panes ' { return @('%2 111', '%4 222') }
-                '^capture-pane .*%2' { return @('Implementation finished.', '>') }
-                '^capture-pane .*%4' { return @('Review in progress...') }
                 default { throw "unexpected winsmux call: $commandLine" }
             }
+        }
+        Mock Invoke-PaneStatusWinsmux {
+            param([string[]]$Arguments)
+
+            switch ($Arguments[2]) {
+                '%2' { return @('Implementation finished.', '>') }
+                '%4' { return @('Review in progress...') }
+                default { throw "unexpected capture target: $($Arguments[2])" }
+            }
+        } -ParameterFilter {
+            $Arguments[0] -eq 'capture-pane'
         }
 
         Mock Get-Process {
@@ -3433,10 +3487,19 @@ panes:
         function global:winsmux {
             $commandLine = ($args | ForEach-Object { [string]$_ }) -join ' '
             switch -Regex ($commandLine) {
-                '^capture-pane .*%2' { return @('gpt-5.4   64% context left', '? send   Ctrl+J newline', '>') }
-                '^capture-pane .*%6' { return @('gpt-5.4   52% context left', 'thinking', 'Esc to interrupt') }
                 default { throw "unexpected winsmux call: $commandLine" }
             }
+        }
+        Mock Invoke-PaneStatusWinsmux {
+            param([string[]]$Arguments)
+
+            switch ($Arguments[2]) {
+                '%2' { return @('gpt-5.4   64% context left', '? send   Ctrl+J newline', '>') }
+                '%6' { return @('gpt-5.4   52% context left', 'thinking', 'Esc to interrupt') }
+                default { throw "unexpected capture target: $($Arguments[2])" }
+            }
+        } -ParameterFilter {
+            $Arguments[0] -eq 'capture-pane'
         }
 
         $output = Invoke-Board | Out-String
@@ -6279,6 +6342,40 @@ panes:
             } else {
                 $env:WINSMUX_TELEGRAM_INCLUDE_INTERNAL_EVENTS = $previousOverride
             }
+        }
+    }
+
+    It 'dispatches review requests through commander poll wrappers' {
+@"
+version: 1
+saved_at: 2026-04-12T10:00:00+09:00
+session:
+  name: winsmux-orchestra
+  project_dir: $script:commanderPollTempRoot
+panes:
+  reviewer-1:
+    pane_id: %4
+    role: Reviewer
+    launch_dir: $script:commanderPollTempRoot
+"@ | Set-Content -Path $script:commanderPollManifestPath -Encoding UTF8
+
+        Mock Send-CommanderPollLiteral { }
+        Mock Approve-CommanderPollPane { }
+        Mock Send-CommanderTelegramNotification { }
+
+        $result = Invoke-CommanderStateMachine `
+            -CurrentState 'waiting_for_review' `
+            -CycleSummary @{ completions = 1 } `
+            -ProjectDir $script:commanderPollTempRoot `
+            -SessionName 'winsmux-orchestra' `
+            -ManifestPath $script:commanderPollManifestPath
+
+        $result.State | Should -Be 'review_requested'
+        Should -Invoke Send-CommanderPollLiteral -Times 1 -Exactly -ParameterFilter {
+            $PaneId -eq '%4' -and $Text -eq 'winsmux review-request'
+        }
+        Should -Invoke Approve-CommanderPollPane -Times 1 -Exactly -ParameterFilter {
+            $PaneId -eq '%4'
         }
     }
 }

--- a/winsmux-core/scripts/commander-poll.ps1
+++ b/winsmux-core/scripts/commander-poll.ps1
@@ -314,6 +314,15 @@ function Approve-CommanderPollPane {
     Invoke-CommanderPollWinsmux -Arguments @('send-keys', '-t', $PaneId, 'Enter') | Out-Null
 }
 
+function Send-CommanderPollLiteral {
+    param(
+        [Parameter(Mandatory = $true)][string]$PaneId,
+        [Parameter(Mandatory = $true)][string]$Text
+    )
+
+    Invoke-CommanderPollWinsmux -Arguments @('send-keys', '-t', $PaneId, '-l', '--', $Text) | Out-Null
+}
+
 function Get-CommanderPollGitOutput {
     param(
         [Parameter(Mandatory = $true)][string]$WorktreePath,
@@ -874,9 +883,8 @@ function Invoke-CommanderStateMachine {
                         -Event 'commander.blocked' -Message "Review 可能なペインが見つかりません。" -Branch $branch -HeadSha $headSha
                     $nextState = 'blocked_no_review_target'
                 } else {
-                    $wb = Get-WinsmuxBin
-                    & $wb send-keys -t $reviewPane.PaneId -l 'winsmux review-request' 2>$null | Out-Null
-                    & $wb send-keys -t $reviewPane.PaneId Enter 2>$null | Out-Null
+                    Send-CommanderPollLiteral -PaneId $reviewPane.PaneId -Text 'winsmux review-request'
+                    Approve-CommanderPollPane -PaneId $reviewPane.PaneId
                     Send-CommanderTelegramNotification -ProjectDir $ProjectDir -SessionName $SessionName `
                         -Event 'commander.review_requested' -Message "$($reviewPane.Label) ($($reviewPane.PaneId)) にレビュー依頼送信。PASS/FAIL 待機中。" `
                         -PaneId $reviewPane.PaneId -Label $reviewPane.Label -Role $reviewPane.Role -Branch $branch -HeadSha $headSha

--- a/winsmux-core/scripts/pane-control.ps1
+++ b/winsmux-core/scripts/pane-control.ps1
@@ -1,5 +1,21 @@
- . (Join-Path $PSScriptRoot 'settings.ps1')
- . (Join-Path $PSScriptRoot 'manifest.ps1')
+. (Join-Path $PSScriptRoot 'settings.ps1')
+. (Join-Path $PSScriptRoot 'manifest.ps1')
+
+function Invoke-PaneControlWinsmux {
+    param([Parameter(Mandatory = $true)][string[]]$Arguments)
+
+    $output = & winsmux @Arguments 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        $message = ($output | Out-String).Trim()
+        if ([string]::IsNullOrWhiteSpace($message)) {
+            $message = 'unknown winsmux error'
+        }
+
+        throw "winsmux $($Arguments -join ' ') failed: $message"
+    }
+
+    return $output
+}
 
 function ConvertFrom-PaneControlYamlScalar {
     param([AllowNull()]$Value)
@@ -438,11 +454,7 @@ function Set-PaneControlManifestPaneProperties {
 function Get-PaneControlPaneTitle {
     param([Parameter(Mandatory = $true)][string]$PaneId)
 
-    $titleOutput = & winsmux display-message -p -t $PaneId '#{pane_title}' 2>$null
-    if ($LASTEXITCODE -ne 0) {
-        throw "failed to read pane title for $PaneId"
-    }
-
+    $titleOutput = Invoke-PaneControlWinsmux -Arguments @('display-message', '-p', '-t', $PaneId, '#{pane_title}')
     return (($titleOutput | Out-String).Trim() -split "\r?\n" | Select-Object -Last 1).Trim()
 }
 

--- a/winsmux-core/scripts/pane-status.ps1
+++ b/winsmux-core/scripts/pane-status.ps1
@@ -10,6 +10,22 @@ if (Test-Path $paneControlScript -PathType Leaf) {
     . $paneControlScript
 }
 
+function Invoke-PaneStatusWinsmux {
+    param([Parameter(Mandatory = $true)][string[]]$Arguments)
+
+    $output = & winsmux @Arguments 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        $message = ($output | Out-String).Trim()
+        if ([string]::IsNullOrWhiteSpace($message)) {
+            $message = 'unknown winsmux error'
+        }
+
+        throw "winsmux $($Arguments -join ' ') failed: $message"
+    }
+
+    return $output
+}
+
 function Get-PaneTokensRemainingText {
     param([AllowNull()][string]$Text)
 
@@ -131,7 +147,7 @@ function Get-PaneStatusRecords {
     if ($null -eq $SnapshotProvider) {
         $SnapshotProvider = {
             param($PaneId)
-            (& winsmux capture-pane -t $PaneId -p -J -S '-80' | Out-String).TrimEnd()
+            (Invoke-PaneStatusWinsmux -Arguments @('capture-pane', '-t', $PaneId, '-p', '-J', '-S', '-80') | Out-String).TrimEnd()
         }
     }
 


### PR DESCRIPTION
## Summary
- consolidate leaf terminal wrapper calls in commander-poll, pane-status, and pane-control
- route commander review dispatch through helper functions instead of direct send-keys calls
- add regressions for pane-status wrapper use, pane title reads, and commander review dispatch

## Validation
- Invoke-Pester tests/psmux-bridge.Tests.ps1
- PowerShell parser check for modified scripts and tests
- git diff --check

## Review
- Explorer `Aristotle` guided the slice selection and was closed after integration
- Fresh reviewer `Mill` returned no result after two 35s waits and was closed
- Fallback gate used: manual diff review + passing validation