### PR TITLE
feat: wrap orchestra layout terminal calls

### DIFF
--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -1,6 +1,6 @@
 # Handoff
 
-> Updated: 2026-04-12T22:15:00+09:00
+> Updated: 2026-04-12T22:34:00+09:00
 > Source of truth: this file
 
 ## Current state
@@ -27,17 +27,24 @@
   - `winsmux-core/scripts/commander-poll.ps1`
   - `winsmux-core/scripts/pane-status.ps1`
   - `winsmux-core/scripts/pane-control.ps1`
+- Implemented the next `TASK-216` slice in `winsmux-core/scripts/orchestra-layout.ps1`:
+  - wrapper-mediated `has-session`, `new-session`, `new-window`
+  - wrapper-mediated `list-panes`, `display-message`, `split-window`, `select-pane`
+  - array-shape fixes for pane ids and role labels so single-pane and split layouts stay deterministic
 - Added regression coverage for:
   - commander review dispatch using wrappers
   - pane status default snapshot capture through its wrapper
   - pane title reads through the pane-control wrapper
+  - orchestra layout single-pane and split flow execution
 - Integrated explorer review findings from `Aristotle` and closed that subagent after use.
 - Fresh reviewer `Mill` returned `no result yet` after two 35s waits and was closed.
 - Merged PR #408 for the `TASK-216` leaf-wrapper first slice.
+- Validation is passing locally for the `orchestra-layout` slice; fresh `/review` is the next gate before commit/PR.
 
 ## Validation
 
 - `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `164/164 PASS`
+- `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `166/166 PASS` after the `orchestra-layout` slice
 - PowerShell parser check for:
   - `winsmux-core/scripts/commander-poll.ps1`
   - `winsmux-core/scripts/pane-status.ps1`
@@ -49,12 +56,15 @@
 - PR #408 CI -> green (`Pester Tests`)
 - Fresh reviewer `Mill` -> `no result yet` after two 35s waits; closed without result
 - Manual diff review completed for the `TASK-216` leaf-wrapper slice
+- Fresh reviewer `Wegener` -> `no result yet` after two 35s waits on the `orchestra-layout` slice; closed without result
+- Manual diff review completed for the `orchestra-layout` wrapper slice
 
 ## Next actions
 
-1. Continue `TASK-216` with the next densest wrapper consolidation target after the leaf-wrapper slice.
-2. Decide whether the next `v0.21.2` slice is `orchestra-layout` wrapper consolidation or a different terminal-ergonomics task.
-3. At `v0.21.2` release time, update `README.md` and `README.ja.md` to mark the terminal-based final form before `v0.22.0`.
+1. Run a fresh `/review` on the current `orchestra-layout` wrapper slice.
+2. Create branch/commit/PR for the `orchestra-layout` `TASK-216` slice once review is incorporated.
+3. Continue `v0.21.2` toward the remaining terminal/session ergonomics slices after this lands.
+4. At `v0.21.2` release time, update `README.md` and `README.ja.md` to mark the terminal-based final form before `v0.22.0`.
 
 ## Notes
 

--- a/tests/psmux-bridge.Tests.ps1
+++ b/tests/psmux-bridge.Tests.ps1
@@ -3316,6 +3316,86 @@ panes:
     }
 }
 
+Describe 'orchestra layout script' {
+    BeforeAll {
+        $script:orchestraLayoutPath = Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\orchestra-layout.ps1'
+    }
+
+    BeforeEach {
+        Mock Start-Sleep { }
+    }
+
+    It 'creates a single labeled pane through the orchestra wrapper' {
+        $global:winsmuxCalls = [System.Collections.Generic.List[string]]::new()
+
+        function global:winsmux {
+            $global:LASTEXITCODE = 0
+            $commandLine = ($args | ForEach-Object { [string]$_ }) -join ' '
+            $global:winsmuxCalls.Add($commandLine) | Out-Null
+
+            switch -Regex ($commandLine) {
+                '^has-session ' { return @() }
+                '^new-window ' { return '@1 %2' }
+                '^list-panes -t @1 -F #\{pane_id\}$' { return '%2' }
+                '^set-option ' { return @() }
+                '^select-pane -t %2 -T Builder-1$' { return @() }
+                '^select-pane -t %2$' { return @() }
+                default { throw "unexpected winsmux call: $commandLine" }
+            }
+        }
+
+        $result = & $script:orchestraLayoutPath -SessionName 'winsmux-orchestra' -Builders 1
+
+        $result.Total | Should -Be 1
+        $result.Rows | Should -Be 1
+        $result.Cols | Should -Be 1
+        $result.Panes.Count | Should -Be 1
+        $result.Panes[0].PaneId | Should -Be '%2'
+        $result.Panes[0].Role | Should -Be 'Builder-1'
+        @($global:winsmuxCalls) | Should -Contain 'list-panes -t @1 -F #{pane_id}'
+        @($global:winsmuxCalls) | Should -Contain 'select-pane -t %2 -T Builder-1'
+    }
+
+    It 'uses wrapper-mediated split flow for a two-pane layout' {
+        $global:winsmuxCalls = [System.Collections.Generic.List[string]]::new()
+        $global:layoutPaneIds = @('%2')
+
+        function global:winsmux {
+            $global:LASTEXITCODE = 0
+            $commandLine = ($args | ForEach-Object { [string]$_ }) -join ' '
+            $global:winsmuxCalls.Add($commandLine) | Out-Null
+
+            switch -Regex ($commandLine) {
+                '^has-session ' { return @() }
+                '^new-window ' { return '@1 %2' }
+                '^set-option ' { return @() }
+                '^display-message -t %2 -p #\{window_id\}$' { return '@1' }
+                '^display-message -t %2 -p #\{pane_width\}x#\{pane_height\}$' { return '120x40' }
+                '^split-window -t %2 -h -p 50$' {
+                    $global:layoutPaneIds = @('%2', '%3')
+                    return @()
+                }
+                '^list-panes -t @1 -F #\{pane_id\}$' { return $global:layoutPaneIds }
+                '^select-pane -t %2$' { return @() }
+                '^select-pane -t %2 -T Builder-1$' { return @() }
+                '^select-pane -t %3 -T Builder-2$' { return @() }
+                default { throw "unexpected winsmux call: $commandLine" }
+            }
+        }
+
+        $result = & $script:orchestraLayoutPath -SessionName 'winsmux-orchestra' -Builders 2
+
+        $result.Total | Should -Be 2
+        $result.Rows | Should -Be 1
+        $result.Cols | Should -Be 2
+        $result.Panes.Count | Should -Be 2
+        $result.Panes[0].Role | Should -Be 'Builder-1'
+        $result.Panes[1].Role | Should -Be 'Builder-2'
+        @($global:winsmuxCalls) | Should -Contain 'split-window -t %2 -h -p 50'
+        @($global:winsmuxCalls) | Should -Contain 'select-pane -t %3 -T Builder-2'
+    }
+}
+
 Describe 'winsmux status command' {
     BeforeAll {
         $script:winsmuxCorePath = Join-Path (Split-Path -Parent $PSScriptRoot) 'scripts\winsmux-core.ps1'

--- a/winsmux-core/scripts/orchestra-layout.ps1
+++ b/winsmux-core/scripts/orchestra-layout.ps1
@@ -17,6 +17,22 @@ $ErrorActionPreference = 'Stop'
 $scriptDir = $PSScriptRoot
 . "$scriptDir/pane-border.ps1"
 
+function Invoke-OrchestraLayoutWinsmux {
+    param([Parameter(Mandatory = $true)][string[]]$Arguments)
+
+    $output = & winsmux @Arguments 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        $message = ($output | Out-String).Trim()
+        if ([string]::IsNullOrWhiteSpace($message)) {
+            $message = 'unknown winsmux error'
+        }
+
+        throw "winsmux $($Arguments -join ' ') failed: $message"
+    }
+
+    return $output
+}
+
 function Test-PositiveCount {
     param(
         [string]$Name,
@@ -50,7 +66,7 @@ function Get-PaneIds {
         [string]$Target
     )
 
-    $rawPaneIds = & winsmux list-panes -t $Target -F '#{pane_id}' 2>$null
+    $rawPaneIds = Invoke-OrchestraLayoutWinsmux -Arguments @('list-panes', '-t', $Target, '-F', '#{pane_id}')
     return @(
         $rawPaneIds |
             ForEach-Object { $_.Trim() } |
@@ -68,7 +84,7 @@ function Split-Equal {
     )
 
     # TASK-233: resolve window ID for pane count verification (fail fast)
-    $windowId = (& winsmux display-message -t $Target -p '#{window_id}' 2>$null)
+    $windowId = Invoke-OrchestraLayoutWinsmux -Arguments @('display-message', '-t', $Target, '-p', '#{window_id}')
     if ([string]::IsNullOrWhiteSpace($windowId)) {
         throw "Split-Equal: could not resolve window ID for target pane $Target. Cannot verify pane creation."
     }
@@ -77,12 +93,8 @@ function Split-Equal {
         $remaining = $PaneCount - $i
         $percent = [int](100 / $remaining)
         $beforeCount = @(Get-PaneIds -Target $windowId).Count
-        $actualSize = (& winsmux display-message -t $Target -p '#{pane_width}x#{pane_height}' 2>$null)
-
-        & winsmux split-window -t $Target $Direction -p $percent | Out-Null
-        if ($LASTEXITCODE -ne 0) {
-            throw "winsmux split-window failed while creating $PaneCount panes in direction $Direction. Target=$Target, ActualSize=$actualSize"
-        }
+        $actualSize = Invoke-OrchestraLayoutWinsmux -Arguments @('display-message', '-t', $Target, '-p', '#{pane_width}x#{pane_height}')
+        Invoke-OrchestraLayoutWinsmux -Arguments @('split-window', '-t', $Target, $Direction, '-p', $percent) | Out-Null
 
         # TASK-233: verify pane count change (fail fast)
         Start-Sleep -Milliseconds 100
@@ -146,20 +158,14 @@ $grid = Get-GridDimensions -PaneCount $total
 $rows = $grid.Rows
 $cols = $grid.Cols
 
-& winsmux has-session -t $SessionName 1>$null 2>$null
-if ($LASTEXITCODE -ne 0) {
-    & winsmux new-session -d -s $SessionName | Out-Null
-    if ($LASTEXITCODE -ne 0) {
-        throw 'winsmux new-session failed.'
-    }
-
+try {
+    Invoke-OrchestraLayoutWinsmux -Arguments @('has-session', '-t', $SessionName) | Out-Null
+} catch {
+    Invoke-OrchestraLayoutWinsmux -Arguments @('new-session', '-d', '-s', $SessionName) | Out-Null
     Start-Sleep -Milliseconds 500
 }
 
-$windowMetadata = (& winsmux new-window -t $SessionName -P -F '#{window_id} #{pane_id}' 2>$null | Out-String).Trim()
-if ($LASTEXITCODE -ne 0) {
-    throw 'winsmux new-window failed.'
-}
+$windowMetadata = (Invoke-OrchestraLayoutWinsmux -Arguments @('new-window', '-t', $SessionName, '-P', '-F', '#{window_id} #{pane_id}') | Out-String).Trim()
 
 $windowParts = @($windowMetadata -split '\s+')
 if ($windowParts.Count -lt 2) {
@@ -183,40 +189,33 @@ if ($rows -gt 1) {
     Split-Equal -Target $newPaneId -PaneCount $rows -Direction '-v'
 }
 
-$rowIds = Get-PaneIds -Target $newWindowId
+$rowIds = @(Get-PaneIds -Target $newWindowId)
 if ($rowIds.Count -lt $rows) {
     throw "Expected at least $rows row panes but found $($rowIds.Count)."
 }
 
 if ($cols -gt 1) {
     for ($rowIndex = 0; $rowIndex -lt $rows; $rowIndex++) {
-        & winsmux select-pane -t $rowIds[$rowIndex] | Out-Null
-        if ($LASTEXITCODE -ne 0) {
-            throw "winsmux select-pane failed for row pane $($rowIds[$rowIndex])."
-        }
-
+        Invoke-OrchestraLayoutWinsmux -Arguments @('select-pane', '-t', $rowIds[$rowIndex]) | Out-Null
         Split-Equal -Target $rowIds[$rowIndex] -PaneCount $cols -Direction '-h'
     }
 }
 
 Start-Sleep -Milliseconds 300
 
-$allIds = Get-PaneIds -Target $newWindowId
+$allIds = @(Get-PaneIds -Target $newWindowId)
 if ($allIds.Count -lt $total) {
     throw "Expected at least $total panes but found $($allIds.Count)."
 }
 
-$labels = Get-RoleLabels -CommanderCount $Commanders -WorkerCount $Workers -BuilderCount $Builders -ResearcherCount $Researchers -ReviewerCount $Reviewers
+$labels = @(Get-RoleLabels -CommanderCount $Commanders -WorkerCount $Workers -BuilderCount $Builders -ResearcherCount $Researchers -ReviewerCount $Reviewers)
 $assignments = [System.Collections.Generic.List[object]]::new()
 
 for ($index = 0; $index -lt $total; $index++) {
     $paneId = $allIds[$index]
     $label = $labels[$index]
 
-    & winsmux select-pane -t $paneId -T $label | Out-Null
-    if ($LASTEXITCODE -ne 0) {
-        throw "winsmux select-pane -T failed for pane $paneId."
-    }
+    Invoke-OrchestraLayoutWinsmux -Arguments @('select-pane', '-t', $paneId, '-T', $label) | Out-Null
 
     $assignments.Add([PSCustomObject]@{
         PaneId = $paneId
@@ -224,10 +223,7 @@ for ($index = 0; $index -lt $total; $index++) {
     })
 }
 
-& winsmux select-pane -t $allIds[0] | Out-Null
-if ($LASTEXITCODE -ne 0) {
-    throw "winsmux select-pane failed for pane $($allIds[0])."
-}
+Invoke-OrchestraLayoutWinsmux -Arguments @('select-pane', '-t', $allIds[0]) | Out-Null
 
 [PSCustomObject]@{
     Builders    = $Builders


### PR DESCRIPTION
## Summary
- wrap raw terminal calls in orchestra-layout through a single helper
- keep pane id and role label arrays deterministic for single-pane and split layouts
- add orchestra-layout regression coverage for single-pane and split execution

## Validation
- Invoke-Pester tests/psmux-bridge.Tests.ps1
- PowerShell parser check for modified files
- git diff --check

## Review
- Fresh reviewer `Wegener` returned no result after two 35s waits and was closed
- Fallback gate used: manual diff review + passing validation