### PR TITLE
chore: rename remaining winsmux bridge test surface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,7 @@ tests/*
 !tests/Integration.GateEnforcement.Tests.ps1
 !tests/Integration.MultiAgent.Tests.ps1
 !tests/Runtime.VaultInject.Tests.ps1
-!tests/psmux-bridge.Tests.ps1
+!tests/winsmux-bridge.Tests.ps1
 !tests/OrchestraPreflight.Tests.ps1
 !tests/PaneBorder.Tests.ps1
 !tests/Integration.WorktreeHook.Tests.ps1

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -1,11 +1,14 @@
 # Handoff
 
-> Updated: 2026-04-12T22:34:00+09:00
+> Updated: 2026-04-12T23:18:00+09:00
 > Source of truth: this file
 
 ## Current state
 
 - `v0.20.0`, `v0.20.1`, `v0.20.2`, `v0.20.3`, `v0.21.0`, and `v0.21.1` are released.
+- `v0.21.2` is active. `TASK-216` has two landed slices on `main`:
+  - PR #408: leaf wrapper consolidation for `commander-poll`, `pane-status`, and `pane-control`
+  - PR #409: wrapper-based `orchestra-layout` session/window/pane flow
 - `v0.21.1` shipped as a workflow-baseline release for:
   - `TASK-163` phase-gated workflow baseline
   - `TASK-164` structured chaining baseline
@@ -22,53 +25,53 @@
 ## This session
 
 - Started `v0.21.2: Terminal-Based Final Form & Session Ergonomics`.
-- Scoped `TASK-216` to a low-risk first slice that consolidates raw terminal CLI calls in leaf hot-path scripts instead of the central bridge file.
-- Implemented wrapper-based terminal calls in:
-  - `winsmux-core/scripts/commander-poll.ps1`
-  - `winsmux-core/scripts/pane-status.ps1`
-  - `winsmux-core/scripts/pane-control.ps1`
-- Implemented the next `TASK-216` slice in `winsmux-core/scripts/orchestra-layout.ps1`:
-  - wrapper-mediated `has-session`, `new-session`, `new-window`
-  - wrapper-mediated `list-panes`, `display-message`, `split-window`, `select-pane`
-  - array-shape fixes for pane ids and role labels so single-pane and split layouts stay deterministic
-- Added regression coverage for:
-  - commander review dispatch using wrappers
-  - pane status default snapshot capture through its wrapper
-  - pane title reads through the pane-control wrapper
-  - orchestra layout single-pane and split flow execution
-- Integrated explorer review findings from `Aristotle` and closed that subagent after use.
-- Fresh reviewer `Mill` returned `no result yet` after two 35s waits and was closed.
-- Merged PR #408 for the `TASK-216` leaf-wrapper first slice.
-- Validation is passing locally for the `orchestra-layout` slice; fresh `/review` is the next gate before commit/PR.
+- Landed `TASK-216` slice 1 and slice 2 on `main`, keeping the bridge-file refactor deferred while consolidating hot-path wrapper calls first.
+- Started `TASK-295` on branch `codex/task295-rename-surface-20260412`.
+- Renamed the tracked bridge regression file to `tests/winsmux-bridge.Tests.ps1`.
+- Updated tracked references in:
+  - `.gitignore`
+  - `docs/handoff.md`
+  - `scripts/generate-release-notes.ps1`
+  - `tests/winsmux-bridge.Tests.ps1`
+- Confirmed that `.psmux` registry/data-path references remain compatibility surface and stay out of this rename slice.
+- Explorer `Pauli` completed the rename-debt scope audit and was closed.
+- Explorer `Rawls` completed the `v0.21.2` reallocation review and was closed.
+- Fresh reviewer `Planck` returned `PASS` for the `TASK-295` rename slice and was closed.
 
 ## Validation
 
-- `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `164/164 PASS`
-- `Invoke-Pester tests/psmux-bridge.Tests.ps1` -> `166/166 PASS` after the `orchestra-layout` slice
+- `Invoke-Pester tests/winsmux-bridge.Tests.ps1` -> `164/164 PASS`
+- `Invoke-Pester tests/winsmux-bridge.Tests.ps1` -> `166/166 PASS` after the `orchestra-layout` slice
+- `Invoke-Pester tests/winsmux-bridge.Tests.ps1` -> `166/166 PASS` after the `TASK-295` rename slice
 - PowerShell parser check for:
   - `winsmux-core/scripts/commander-poll.ps1`
   - `winsmux-core/scripts/pane-status.ps1`
   - `winsmux-core/scripts/pane-control.ps1`
-  - `tests/psmux-bridge.Tests.ps1`
+  - `tests/winsmux-bridge.Tests.ps1`
   -> PASS
 - `git diff --check` -> warnings only, no substantive diff-check failures
 - Explorer review `Aristotle` completed and recommended the leaf-script-first `TASK-216` slice
 - PR #408 CI -> green (`Pester Tests`)
+- PR #409 CI -> green (`Pester Tests`)
 - Fresh reviewer `Mill` -> `no result yet` after two 35s waits; closed without result
 - Manual diff review completed for the `TASK-216` leaf-wrapper slice
 - Fresh reviewer `Wegener` -> `no result yet` after two 35s waits on the `orchestra-layout` slice; closed without result
 - Manual diff review completed for the `orchestra-layout` wrapper slice
+- Explorer `Pauli` -> rename-debt audit complete
+- Explorer `Rawls` -> `v0.21.2` reallocation recommendation complete
+- Fresh reviewer `Planck` -> `PASS` on the `TASK-295` rename slice
 
 ## Next actions
 
-1. Run a fresh `/review` on the current `orchestra-layout` wrapper slice.
-2. Create branch/commit/PR for the `orchestra-layout` `TASK-216` slice once review is incorporated.
-3. Continue `v0.21.2` toward the remaining terminal/session ergonomics slices after this lands.
-4. At `v0.21.2` release time, update `README.md` and `README.ja.md` to mark the terminal-based final form before `v0.22.0`.
+1. Commit, push, and merge the `TASK-295` rename slice.
+2. Rebaseline `v0.21.2` so only terminal-final-form core remains in the version, and move non-core desktop/packaging work out.
+3. Update `README.md` and `README.ja.md` at `v0.21.2` release time to mark the terminal-based final form before `v0.22.0`.
+4. Generate curated release notes and publish `v0.21.2`.
 
 ## Notes
 
 - `v0.21.1` is a baseline release, not the full advanced workflow/runtime roadmap.
 - `TASK-216` is being landed as small hot-path wrapper slices rather than a single bridge-file refactor.
+- `TASK-295` keeps `.psmux` compatibility paths untouched; those stay under the sunset plan instead of this rename slice.
 - Public GitHub Releases stay English, use Codex-style headings, and keep inline issue/PR refs visible.
 - `README.md` and `README.ja.md` must be updated again at `v0.21.2` release time to mark the terminal-based final form as the last pre-Tauri shape.

--- a/scripts/generate-release-notes.ps1
+++ b/scripts/generate-release-notes.ps1
@@ -256,7 +256,7 @@ function ConvertTo-UserBenefit {
         'pane\.completed|PostToolUse pane monitor hook' {
             return 'Surfaced pane completion events so the operator can make the next decision faster'
         }
-        'complete psmux.?winsmux rename|send buffer overflow' {
+        'complete winsmux-surface rename|send buffer overflow' {
             return 'Continued the winsmux naming convergence and stabilized the send pipeline'
         }
         'bump version|sync backlog and roadmap' {
@@ -549,7 +549,7 @@ $docsSource = @(
         }
 )
 $choreSource = @()
-$choreSource += Get-MatchedCommits -Subjects $commitSubjects -Patterns @('Commander Telegram dense notifications', 'pane\.completed', 'psmux.?winsmux rename')
+$choreSource += Get-MatchedCommits -Subjects $commitSubjects -Patterns @('Commander Telegram dense notifications', 'pane\.completed', 'winsmux-surface rename')
 $choreSource += @(
     $commitSubjects |
         Where-Object {

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -3545,7 +3545,7 @@ panes:
     branch: worktree-builder-1
     head_sha: abc1234def5678
     changed_file_count: 2
-    changed_files: '["scripts/winsmux-core.ps1","tests/psmux-bridge.Tests.ps1"]'
+    changed_files: '["scripts/winsmux-core.ps1","tests/winsmux-bridge.Tests.ps1"]'
     last_event: pane.ready
     last_event_at: 2026-04-10T10:00:00+09:00
   worker-1:
@@ -3610,7 +3610,7 @@ panes:
     branch: worktree-builder-1
     head_sha: abc1234def5678
     changed_file_count: 2
-    changed_files: '["scripts/winsmux-core.ps1","tests/psmux-bridge.Tests.ps1"]'
+    changed_files: '["scripts/winsmux-core.ps1","tests/winsmux-bridge.Tests.ps1"]'
     last_event: pane.ready
     last_event_at: 2026-04-10T10:00:00+09:00
   worker-1:
@@ -3649,7 +3649,7 @@ panes:
         $result.summary.by_state.busy | Should -Be 1
         $result.panes.Count | Should -Be 2
         $result.panes[0].label | Should -Be 'builder-1'
-        $result.panes[0].changed_files | Should -Be @('scripts/winsmux-core.ps1', 'tests/psmux-bridge.Tests.ps1')
+        $result.panes[0].changed_files | Should -Be @('scripts/winsmux-core.ps1', 'tests/winsmux-bridge.Tests.ps1')
         $result.panes[0].last_event | Should -Be 'pane.ready'
         $result.panes[1].label | Should -Be 'worker-1'
         $result.panes[1].state | Should -Be 'busy'
@@ -4030,7 +4030,7 @@ panes:
     branch: worktree-builder-1
     head_sha: abc1234def5678
     changed_file_count: 2
-    changed_files: '["scripts/winsmux-core.ps1","tests/psmux-bridge.Tests.ps1"]'
+    changed_files: '["scripts/winsmux-core.ps1","tests/winsmux-bridge.Tests.ps1"]'
     last_event: commander.review_requested
     last_event_at: 2026-04-10T12:00:00+09:00
   worker-1:
@@ -4114,11 +4114,11 @@ panes:
     head_sha: abc1234def5678
     changed_file_count: 1
     changed_files: '["scripts/winsmux-core.ps1"]'
-    write_scope: '["scripts/winsmux-core.ps1","tests/psmux-bridge.Tests.ps1"]'
+    write_scope: '["scripts/winsmux-core.ps1","tests/winsmux-bridge.Tests.ps1"]'
     read_scope: '["winsmux-core/scripts/pane-status.ps1"]'
     constraints: '["preserve existing board schema"]'
     expected_output: Stable run_packet JSON
-    verification_plan: '["Invoke-Pester tests/psmux-bridge.Tests.ps1","verify runs --json contract"]'
+    verification_plan: '["Invoke-Pester tests/winsmux-bridge.Tests.ps1","verify runs --json contract"]'
     review_required: true
     provider_target: codex:gpt-5.4
     agent_role: worker
@@ -4226,11 +4226,11 @@ panes:
         $result.runs[0].run_packet.task_type | Should -Be 'implementation'
         $result.runs[0].run_packet.priority | Should -Be 'P0'
         $result.runs[0].run_packet.blocking | Should -Be $true
-        $result.runs[0].run_packet.write_scope | Should -Be @('scripts/winsmux-core.ps1', 'tests/psmux-bridge.Tests.ps1')
+        $result.runs[0].run_packet.write_scope | Should -Be @('scripts/winsmux-core.ps1', 'tests/winsmux-bridge.Tests.ps1')
         $result.runs[0].run_packet.read_scope | Should -Be @('winsmux-core/scripts/pane-status.ps1')
         $result.runs[0].run_packet.constraints | Should -Be @('preserve existing board schema')
         $result.runs[0].run_packet.expected_output | Should -Be 'Stable run_packet JSON'
-        $result.runs[0].run_packet.verification_plan | Should -Be @('Invoke-Pester tests/psmux-bridge.Tests.ps1', 'verify runs --json contract')
+        $result.runs[0].run_packet.verification_plan | Should -Be @('Invoke-Pester tests/winsmux-bridge.Tests.ps1', 'verify runs --json contract')
         $result.runs[0].run_packet.review_required | Should -Be $true
         $result.runs[0].run_packet.provider_target | Should -Be 'codex:gpt-5.4'
         $result.runs[0].run_packet.agent_role | Should -Be 'worker'
@@ -4333,7 +4333,7 @@ panes:
     branch: shared-worktree
     head_sha: abc1234def5678
     changed_file_count: 1
-    changed_files: '["tests/psmux-bridge.Tests.ps1"]'
+    changed_files: '["tests/winsmux-bridge.Tests.ps1"]'
     last_event: commander.review_requested
     last_event_at: 2026-04-10T12:01:00+09:00
 "@ | Set-Content -Path $script:runsManifestPath -Encoding UTF8
@@ -4507,7 +4507,7 @@ panes:
     branch: worktree-builder-1
     head_sha: abc1234def5678
     changed_file_count: 2
-    changed_files: '["scripts/winsmux-core.ps1","tests/psmux-bridge.Tests.ps1"]'
+    changed_files: '["scripts/winsmux-core.ps1","tests/winsmux-bridge.Tests.ps1"]'
     last_event: commander.review_requested
     last_event_at: 2026-04-10T14:00:00+09:00
 "@ | Set-Content -Path $script:digestManifestPath -Encoding UTF8
@@ -4717,7 +4717,7 @@ panes:
     branch: worktree-builder-1
     head_sha: abc1234def5678
     changed_file_count: 2
-    changed_files: '["scripts/winsmux-core.ps1","tests/psmux-bridge.Tests.ps1"]'
+    changed_files: '["scripts/winsmux-core.ps1","tests/winsmux-bridge.Tests.ps1"]'
     last_event: commander.review_requested
     last_event_at: 2026-04-10T14:00:00+09:00
   worker-1:
@@ -4924,11 +4924,11 @@ panes:
     head_sha: abc1234def5678
     changed_file_count: 1
     changed_files: '["scripts/winsmux-core.ps1"]'
-    write_scope: '["scripts/winsmux-core.ps1","tests/psmux-bridge.Tests.ps1"]'
+    write_scope: '["scripts/winsmux-core.ps1","tests/winsmux-bridge.Tests.ps1"]'
     read_scope: '["winsmux-core/scripts/pane-status.ps1"]'
     constraints: '["preserve existing board schema"]'
     expected_output: Stable run_packet JSON
-    verification_plan: '["Invoke-Pester tests/psmux-bridge.Tests.ps1","verify explain --json contract"]'
+    verification_plan: '["Invoke-Pester tests/winsmux-bridge.Tests.ps1","verify explain --json contract"]'
     review_required: true
     provider_target: codex:gpt-5.4
     agent_role: worker
@@ -4947,7 +4947,7 @@ panes:
             test_plan            = @('collect matching events', 'normalize packet')
             changed_files        = @('scripts/winsmux-core.ps1')
             working_tree_summary = '1 file modified'
-            failing_command      = 'Invoke-Pester tests/psmux-bridge.Tests.ps1'
+            failing_command      = 'Invoke-Pester tests/winsmux-bridge.Tests.ps1'
             env_fingerprint      = 'env:abc123'
             command_hash         = 'cmd:def456'
         })
@@ -5080,11 +5080,11 @@ panes:
         $result.run_packet.task_type | Should -Be 'implementation'
         $result.run_packet.priority | Should -Be 'P0'
         $result.run_packet.blocking | Should -Be $true
-        $result.run_packet.write_scope | Should -Be @('scripts/winsmux-core.ps1', 'tests/psmux-bridge.Tests.ps1')
+        $result.run_packet.write_scope | Should -Be @('scripts/winsmux-core.ps1', 'tests/winsmux-bridge.Tests.ps1')
         $result.run_packet.read_scope | Should -Be @('winsmux-core/scripts/pane-status.ps1')
         $result.run_packet.constraints | Should -Be @('preserve existing board schema')
         $result.run_packet.expected_output | Should -Be 'Stable run_packet JSON'
-        $result.run_packet.verification_plan | Should -Be @('Invoke-Pester tests/psmux-bridge.Tests.ps1', 'verify explain --json contract')
+        $result.run_packet.verification_plan | Should -Be @('Invoke-Pester tests/winsmux-bridge.Tests.ps1', 'verify explain --json contract')
         $result.run_packet.review_required | Should -Be $true
         $result.run_packet.provider_target | Should -Be 'codex:gpt-5.4'
         $result.run_packet.agent_role | Should -Be 'worker'
@@ -5105,7 +5105,7 @@ panes:
         $result.run_packet.verification_contract.mode | Should -Be 'adversarial_verify'
         $result.run_packet.verification_result.outcome | Should -Be 'PARTIAL'
         $result.observation_pack.packet_type | Should -Be 'observation_pack'
-        $result.observation_pack.failing_command | Should -Be 'Invoke-Pester tests/psmux-bridge.Tests.ps1'
+        $result.observation_pack.failing_command | Should -Be 'Invoke-Pester tests/winsmux-bridge.Tests.ps1'
         $result.consultation_packet.kind | Should -Be 'consult_result'
         $result.consultation_packet.mode | Should -Be 'early'
         $result.consultation_summary.kind | Should -Be 'consult_result'
@@ -5465,7 +5465,7 @@ panes:
     branch: worktree-builder-b
     head_sha: eeeeffff11112222
     changed_file_count: 2
-    changed_files: '["scripts/winsmux-core.ps1","tests/psmux-bridge.Tests.ps1"]'
+    changed_files: '["scripts/winsmux-core.ps1","tests/winsmux-bridge.Tests.ps1"]'
     last_event: pane.consult_result
     last_event_at: 2026-04-12T10:05:00+09:00
 "@ | Set-Content -Path $script:compareManifestPath -Encoding UTF8
@@ -5490,7 +5490,7 @@ panes:
             test_plan       = @('disable inference', 'rerun build')
             env_fingerprint = 'env:b'
             command_hash    = 'cmd:b'
-            changed_files   = @('scripts/winsmux-core.ps1', 'tests/psmux-bridge.Tests.ps1')
+            changed_files   = @('scripts/winsmux-core.ps1', 'tests/winsmux-bridge.Tests.ps1')
         })
         $script:compareConsultA = New-ConsultationPacketFile -ProjectDir $script:compareTempRoot -ConsultationPacket ([ordered]@{
             run_id         = 'task:task-compare-a'
@@ -5658,7 +5658,7 @@ panes:
         $result.confidence_delta | Should -Be 0.45
         $result.shared_changed_files | Should -Be @('scripts/winsmux-core.ps1')
         $result.left_only_changed_files | Should -Be @()
-        $result.right_only_changed_files | Should -Be @('tests/psmux-bridge.Tests.ps1')
+        $result.right_only_changed_files | Should -Be @('tests/winsmux-bridge.Tests.ps1')
         $result.recommend.winning_run_id | Should -Be 'task:task-compare-a'
         $result.recommend.reconcile_consult | Should -Be $true
         @($result.differences | ForEach-Object { $_.field }) | Should -Contain 'result'
@@ -5696,7 +5696,7 @@ panes:
     branch: worktree-builder-b
     head_sha: eeeeffff11112222
     changed_file_count: 2
-    changed_files: '["scripts/winsmux-core.ps1","tests/psmux-bridge.Tests.ps1"]'
+    changed_files: '["scripts/winsmux-core.ps1","tests/winsmux-bridge.Tests.ps1"]'
     last_event: pane.consult_result
     last_event_at: 2026-04-12T10:05:00+09:00
 "@ | Set-Content -Path $script:compareManifestPath -Encoding UTF8


### PR DESCRIPTION
## Summary
- rename the tracked bridge regression test file to winsmux-bridge.Tests.ps1
- update tracked references in handoff, release-note generation, and embedded fixture strings
- keep .psmux compatibility paths unchanged under the sunset plan

## Validation
- Invoke-Pester tests/winsmux-bridge.Tests.ps1
- git diff --check
- /review PASS (Planck)
