### PR TITLE
feat: normalize tauri run projection snapshot

### DIFF
--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -1,6 +1,6 @@
 # Handoff
 
-> Updated: 2026-04-12T02:28:00+09:00
+> Updated: 2026-04-12T23:34:00+09:00
 > Source of truth: this file
 
 ## Current state
@@ -35,11 +35,16 @@
   - `winsmux-app/src/main.ts` now loads a desktop summary snapshot at startup
   - sessions, footer lane, selected run summary, and explain flow prefer backend `board/inbox/digest/explain` data
   - the seeded shell remains as fallback when the backend adapter is unavailable
-- Started branch `codex/task291-source-projection-context-20260412` for the next `TASK-291` slice.
-- Replaced the source-context shell's primary data path with backend projections wherever the current adapter already has data:
+- Merged PR #412 for the next `TASK-291` slice:
   - source summary, source filters, context list, and selected-run chips now derive from `digest.items` plus cached `explain` payloads
   - editor metadata and generated preview content now prefer backend `run/slot/evidence` fields over the old hardcoded `sourceControlState`
   - the seeded state remains only as fallback when no backend summary is available
+- Started branch `codex/task291-run-projection-snapshot-20260412` for the next `TASK-291` slice.
+- Replaced the remaining frontend heuristic join with a backend-normalized `run_projections` snapshot:
+  - `winsmux-app/src-tauri/src/lib.rs` now emits `run_projections` from `board + digest + explain`
+  - `winsmux-app/src/main.ts` now consumes projection DTOs for source summary, source filters, context list, and editor preview
+  - projection consumers now use `pane label + branch` only; they no longer pretend to have separate source/worktree identity
+  - `explain` remains detail drill-down only instead of acting as a hidden source-summary join input
 - Landed `TASK-216` slice 1 and slice 2 on `main`:
   - PR #408: leaf wrapper consolidation for `commander-poll`, `pane-status`, and `pane-control`
   - PR #409: wrapper-based `orchestra-layout` session/window/pane flow
@@ -68,14 +73,20 @@
 
 - `npm run build` in `winsmux-app` -> PASS
 - `cargo check` in `winsmux-app/src-tauri` -> PASS
+- `pwsh -NoProfile -Command "& { & '.\scripts\winsmux-core.ps1' board --json }"` -> PASS
+- `pwsh -NoProfile -Command "& { & '.\scripts\winsmux-core.ps1' digest --json }"` -> PASS
+- `pwsh -NoProfile -Command "& { $digest = & '.\scripts\winsmux-core.ps1' digest --json | ConvertFrom-Json; if ($digest.items.Count -gt 0) { & '.\scripts\winsmux-core.ps1' explain $digest.items[0].run_id --json | Out-Null } }"` -> PASS
 - `git diff --check` -> warnings only for CRLF normalization, no substantive errors
+- Fresh reviewer `Dewey` -> `PASS` for the projection-driven source-context slice in PR #412
+- Fresh reviewer `Herschel` -> `FAIL`; backend heuristic join removed after review
+- Fresh reviewer `Singer` -> `FAIL`; field semantics corrected to avoid fake worktree/source identity
+- Fresh reviewer `Socrates` -> `FAIL`; frontend branch/worktree leakage removed from filters and context copy
+- Fresh reviewer `Aquinas` -> `PASS`; no blocking findings on the final `run_projections` slice
 - Fresh reviewer `Lorentz` -> `no result yet` after two 35s waits; closed without result
 - Manual diff review completed for the `TASK-291` projection-driven source-context slice
-- `cargo check` in `winsmux-app/src-tauri` -> PASS
-- `npm run build` in `winsmux-app` -> PASS
-- `pwsh -NoProfile -Command "& { & '.\scripts\winsmux-core.ps1' board --json }"` -> PASS
-- `git diff --check` -> warnings only for CRLF normalization, no substantive errors
 - PR #411 CI -> green (`Pester Tests`)
+- PR #412 CI -> green (`Pester Tests`)
+- Fresh reviewer `Dewey` -> `PASS` for the projection-driven source-context slice
 - Fresh reviewer `Anscombe` -> `no result yet` after two 35s waits; closed without result
 - Manual diff review completed for the `TASK-289 / TASK-291` adapter slice
 - `Invoke-Pester tests/winsmux-bridge.Tests.ps1` -> `164/164 PASS`
@@ -106,8 +117,8 @@
 
 ## Next actions
 
-1. Open a PR for the `TASK-291` source-context slice if the current diff still holds after final manual review.
-2. Continue `v0.22.0` with the next backend-first slice after the source-context projection lands.
+1. Open a PR for the `TASK-291` backend-normalized `run_projections` slice.
+2. Continue `v0.22.0` with the next backend-first slice after this lands, likely `TASK-105` RPC bootstrap.
 3. Keep raw PTY constrained to the utility drawer while summary surfaces remain the primary desktop state source.
 
 ## Notes

--- a/winsmux-app/src-tauri/src/lib.rs
+++ b/winsmux-app/src-tauri/src/lib.rs
@@ -1,4 +1,5 @@
 use portable_pty::{native_pty_system, CommandBuilder, PtySize};
+use serde_json::{Map, Value};
 use std::collections::HashMap;
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
@@ -23,6 +24,24 @@ struct DesktopSummarySnapshot {
     board: serde_json::Value,
     inbox: serde_json::Value,
     digest: serde_json::Value,
+    run_projections: Vec<DesktopRunProjection>,
+}
+
+#[derive(serde::Serialize)]
+struct DesktopRunProjection {
+    run_id: String,
+    pane_id: String,
+    label: String,
+    branch: String,
+    task: String,
+    task_state: String,
+    review_state: String,
+    verification_outcome: String,
+    security_blocked: String,
+    changed_files: Vec<String>,
+    next_action: String,
+    summary: String,
+    reasons: Vec<String>,
 }
 
 fn looks_like_repo_root(path: &Path) -> bool {
@@ -93,11 +112,126 @@ fn run_winsmux_json(project_dir: Option<String>, args: &[String]) -> Result<serd
     serde_json::from_str(&stdout).map_err(|err| format!("Failed to parse winsmux JSON payload: {err}"))
 }
 
+fn get_string(map: &Map<String, Value>, key: &str) -> String {
+    map.get(key)
+        .and_then(|value| value.as_str())
+        .unwrap_or_default()
+        .to_string()
+}
+
+fn get_string_array(map: &Map<String, Value>, key: &str) -> Vec<String> {
+    map.get(key)
+        .and_then(|value| value.as_array())
+        .map(|items| {
+            items.iter()
+                .filter_map(|item| item.as_str().map(|text| text.to_string()))
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default()
+}
+
+fn build_run_projection(
+    digest_item: &Map<String, Value>,
+    explain_payload: &Value,
+) -> DesktopRunProjection {
+    let explain_run = explain_payload.get("run").and_then(|value| value.as_object());
+    let explanation = explain_payload
+        .get("explanation")
+        .and_then(|value| value.as_object());
+    let evidence = explain_payload
+        .get("evidence_digest")
+        .and_then(|value| value.as_object());
+
+    let run_id = get_string(digest_item, "run_id");
+    let pane_id = get_string(digest_item, "pane_id");
+    let label = get_string(digest_item, "label");
+    let branch = explain_run
+        .map(|run| get_string(run, "branch"))
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| get_string(digest_item, "branch"));
+    let changed_files = evidence
+        .map(|digest| get_string_array(digest, "changed_files"))
+        .filter(|items| !items.is_empty())
+        .unwrap_or_else(|| get_string_array(digest_item, "changed_files"));
+    let task = get_string(digest_item, "task");
+    let summary = explanation
+        .map(|payload| get_string(payload, "summary"))
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| {
+            if !task.is_empty() {
+                task.clone()
+            } else if !run_id.is_empty() {
+                format!("Projected from {run_id}")
+            } else {
+                "Projected run".to_string()
+            }
+        });
+
+    DesktopRunProjection {
+        run_id,
+        pane_id,
+        label,
+        branch,
+        task,
+        task_state: explain_run
+            .map(|run| get_string(run, "task_state"))
+            .filter(|value| !value.is_empty())
+            .unwrap_or_else(|| get_string(digest_item, "task_state")),
+        review_state: explain_run
+            .map(|run| get_string(run, "review_state"))
+            .filter(|value| !value.is_empty())
+            .unwrap_or_else(|| get_string(digest_item, "review_state")),
+        verification_outcome: evidence
+            .map(|digest| get_string(digest, "verification_outcome"))
+            .filter(|value| !value.is_empty())
+            .unwrap_or_else(|| get_string(digest_item, "verification_outcome")),
+        security_blocked: evidence
+            .map(|digest| get_string(digest, "security_blocked"))
+            .filter(|value| !value.is_empty())
+            .unwrap_or_else(|| get_string(digest_item, "security_blocked")),
+        changed_files,
+        next_action: explanation
+            .map(|payload| get_string(payload, "next_action"))
+            .filter(|value| !value.is_empty())
+            .unwrap_or_else(|| get_string(digest_item, "next_action")),
+        summary,
+        reasons: explanation
+            .map(|payload| get_string_array(payload, "reasons"))
+            .unwrap_or_default(),
+    }
+}
+
+fn build_run_projections(digest: &Value, project_dir: Option<String>) -> Vec<DesktopRunProjection> {
+    digest
+        .get("items")
+        .and_then(|value| value.as_array())
+        .map(|items| {
+            items.iter()
+                .filter_map(|item| item.as_object())
+                .map(|digest_item| {
+                    let run_id = get_string(digest_item, "run_id");
+                    let explain_payload = if run_id.is_empty() {
+                        Value::Null
+                    } else {
+                        run_winsmux_json(
+                            project_dir.clone(),
+                            &["explain".to_string(), run_id, "--json".to_string()],
+                        )
+                        .unwrap_or(Value::Null)
+                    };
+                    build_run_projection(digest_item, &explain_payload)
+                })
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default()
+}
+
 #[tauri::command]
 async fn desktop_summary_snapshot(project_dir: Option<String>) -> Result<DesktopSummarySnapshot, String> {
     let board = run_winsmux_json(project_dir.clone(), &["board".to_string(), "--json".to_string()])?;
     let inbox = run_winsmux_json(project_dir.clone(), &["inbox".to_string(), "--json".to_string()])?;
     let digest = run_winsmux_json(project_dir.clone(), &["digest".to_string(), "--json".to_string()])?;
+    let run_projections = build_run_projections(&digest, project_dir.clone());
 
     let effective_project_dir = match project_dir {
         Some(path) if !path.trim().is_empty() => path,
@@ -110,6 +244,7 @@ async fn desktop_summary_snapshot(project_dir: Option<String>) -> Result<Desktop
         board,
         inbox,
         digest,
+        run_projections,
     })
 }
 

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -79,10 +79,9 @@ type ChangeRisk = "low" | "medium" | "high";
 interface SourceChange {
   path: string;
   summary: string;
-  slot: string;
+  paneLabel: string;
   status: ChangeStatus;
   risk: ChangeRisk;
-  worktree: string;
   branch: string;
   lines: string;
   commitCandidate: boolean;
@@ -170,6 +169,23 @@ interface DesktopSummarySnapshot {
     summary: DesktopDigestSummary;
     items: DesktopDigestItem[];
   };
+  run_projections: DesktopRunProjection[];
+}
+
+interface DesktopRunProjection {
+  run_id: string;
+  pane_id: string;
+  label: string;
+  branch: string;
+  task: string;
+  task_state: string;
+  review_state: string;
+  verification_outcome: string;
+  security_blocked: string;
+  changed_files: string[];
+  next_action: string;
+  summary: string;
+  reasons: string[];
 }
 
 interface DesktopExplainPayload {
@@ -447,10 +463,9 @@ const sourceControlState: SourceControlState = {
   {
     path: "winsmux-app/src/main.ts",
     summary: "Conversation shell source-control actions and worktree metadata",
-    slot: "worker-2",
+    paneLabel: "worker-2",
     status: "modified",
     risk: "medium",
-    worktree: "builder-2",
     branch: "codex/task138-source-context",
     lines: "+46 -11",
     commitCandidate: true,
@@ -461,10 +476,9 @@ const sourceControlState: SourceControlState = {
   {
     path: "winsmux-app/src/styles.css",
     summary: "Sidebar/context badges and source-control overview cards",
-    slot: "worker-2",
+    paneLabel: "worker-2",
     status: "modified",
     risk: "low",
-    worktree: "builder-2",
     branch: "codex/task138-source-context",
     lines: "+38 -4",
     commitCandidate: true,
@@ -475,10 +489,9 @@ const sourceControlState: SourceControlState = {
   {
     path: "winsmux-core/scripts/team-pipeline.ps1",
     summary: "Branch mismatch still blocks commit despite review PASS",
-    slot: "worker-3",
+    paneLabel: "worker-3",
     status: "modified",
     risk: "high",
-    worktree: "builder-3",
     branch: "codex/task264-review-capable-slot",
     lines: "+9 -2",
     commitCandidate: false,
@@ -643,41 +656,29 @@ function getSessionItems() {
   ] satisfies SessionItem[];
 }
 
-function getBoardPaneForDigestItem(item: DesktopDigestItem) {
-  return (
-    desktopSummarySnapshot?.board.panes.find((pane) => {
-      return (
-        (pane.pane_id && pane.pane_id === item.pane_id) ||
-        (pane.label && pane.label === item.label) ||
-        (pane.branch && pane.branch === item.branch)
-      );
-    }) ?? null
-  );
+function getRunProjections() {
+  return desktopSummarySnapshot?.run_projections ?? [];
 }
 
-function getExplainPayloadForRun(runId: string | null) {
+function getRunProjectionByRunId(runId: string | null) {
   if (!runId) {
     return null;
   }
-  return desktopExplainCache.get(runId) ?? null;
+  return getRunProjections().find((projection) => projection.run_id === runId) ?? null;
 }
 
 function getProjectionSourceEntries(): SourceChange[] {
-  if (!desktopSummarySnapshot) {
+  const projections = getRunProjections();
+  if (projections.length === 0) {
     return sourceControlState.entries;
   }
 
   const entries: SourceChange[] = [];
-  for (const digestItem of desktopSummarySnapshot.digest.items) {
-    const boardPane = getBoardPaneForDigestItem(digestItem);
-    const explainPayload = getExplainPayloadForRun(digestItem.run_id);
-    const changedFiles = explainPayload?.evidence_digest.changed_files?.length
-      ? explainPayload.evidence_digest.changed_files
-      : digestItem.changed_files;
-    const sourceRoot = boardPane?.label || digestItem.label || digestItem.pane_id || "summary-stream";
-    const reviewState = digestItem.review_state || boardPane?.review_state || "unknown";
-    const verification = digestItem.verification_outcome || "";
-    const security = digestItem.security_blocked || "";
+  for (const projection of projections) {
+    const changedFiles = projection.changed_files;
+    const reviewState = projection.review_state || "unknown";
+    const verification = projection.verification_outcome || "";
+    const security = projection.security_blocked || "";
     const commitCandidate =
       reviewState === "PASS" &&
       (verification === "" || verification === "PASS") &&
@@ -687,23 +688,22 @@ function getProjectionSourceEntries(): SourceChange[] {
       reviewState === "FAIL" ||
       reviewState === "FAILED" ||
       security === "BLOCK" ||
-      digestItem.next_action === "blocked";
+      projection.next_action === "blocked";
     const risk: ChangeRisk = needsAttention ? "high" : commitCandidate ? "low" : "medium";
 
     for (const path of changedFiles) {
-      const recentReason = explainPayload?.explanation.reasons?.[0];
+      const recentReason = projection.reasons?.[0];
       entries.push({
         path,
-        summary: recentReason || digestItem.task || `Projected from ${digestItem.run_id}`,
-        slot: sourceRoot,
+        summary: recentReason || projection.summary || projection.task || `Projected from ${projection.run_id}`,
+        paneLabel: projection.label || projection.pane_id || "summary-stream",
         status: "modified",
         risk,
-        worktree: sourceRoot,
-        branch: digestItem.branch || boardPane?.branch || "no branch",
+        branch: projection.branch || "no branch",
         lines: `${changedFiles.length} changed in run`,
         commitCandidate,
         needsAttention,
-        run: digestItem.run_id,
+        run: projection.run_id,
         review: reviewState,
       });
     }
@@ -777,7 +777,7 @@ function renderSourceSummary() {
     { label: "Branch", value: primaryChange?.branch ?? "No branch" },
     { label: "Changed", value: `${entryCount} files` },
     { label: "Review", value: primaryChange?.review ?? "No review state" },
-    { label: "Source", value: primaryChange?.worktree ?? "No source projection" },
+    { label: "Branch", value: primaryChange?.branch ?? "No source projection" },
     { label: "Ready", value: `${commitCandidates} candidate${commitCandidates === 1 ? "" : "s"}` },
     { label: "Risk", value: `${attentionCount} attention · ${activeEntries.length} projected` },
   ];
@@ -802,8 +802,8 @@ function renderSourceEntries() {
   const entryItems: Array<{ label: string; value: string; filter: SourceFilter; tone?: SurfaceTone }> = [
     { label: "Commit candidates", value: `${activeEntries.filter((item) => item.commitCandidate).length} ready`, tone: "success", filter: "candidates" },
     { label: "Needs attention", value: `${activeEntries.filter((item) => item.needsAttention).length} blocker`, tone: "danger", filter: "attention" },
-    { label: "builder-2", value: `${activeEntries.filter((item) => item.worktree === "builder-2" || item.branch === "worktree-builder-2").length} files`, filter: "builder-2" },
-    { label: "builder-3", value: `${activeEntries.filter((item) => item.worktree === "builder-3" || item.branch === "worktree-builder-3").length} files`, filter: "builder-3" },
+    { label: "builder-2", value: `${activeEntries.filter((item) => item.paneLabel === "builder-2").length} files`, filter: "builder-2" },
+    { label: "builder-3", value: `${activeEntries.filter((item) => item.paneLabel === "builder-3").length} files`, filter: "builder-3" },
   ];
 
   for (const item of entryItems) {
@@ -838,9 +838,9 @@ function getVisibleSourceChanges() {
     case "attention":
       return activeEntries.filter((item) => item.needsAttention);
     case "builder-2":
-      return activeEntries.filter((item) => item.worktree === "builder-2" || item.branch === "worktree-builder-2");
+      return activeEntries.filter((item) => item.paneLabel === "builder-2");
     case "builder-3":
-      return activeEntries.filter((item) => item.worktree === "builder-3" || item.branch === "worktree-builder-3");
+      return activeEntries.filter((item) => item.paneLabel === "builder-3");
     default:
       return activeEntries;
   }
@@ -851,7 +851,31 @@ function getPrimarySourceChange(changes: SourceChange[]) {
 }
 
 function getPrimaryDigestItem() {
-  return desktopSummarySnapshot?.digest.items?.[0] ?? null;
+  if (desktopSummarySnapshot?.digest.items?.length) {
+    return desktopSummarySnapshot.digest.items[0];
+  }
+
+  const projection = getRunProjections()[0];
+  if (!projection) {
+    return null;
+  }
+
+  return {
+    run_id: projection.run_id,
+    task: projection.task,
+    label: projection.label,
+    pane_id: projection.pane_id,
+    role: "",
+    task_state: projection.task_state,
+    review_state: projection.review_state,
+    next_action: projection.next_action,
+    branch: projection.branch,
+    head_short: "",
+    changed_file_count: projection.changed_files.length,
+    changed_files: projection.changed_files,
+    verification_outcome: projection.verification_outcome,
+    security_blocked: projection.security_blocked,
+  } satisfies DesktopDigestItem;
 }
 
 function getSelectedRunId() {
@@ -872,10 +896,9 @@ function renderContextPanel() {
   sectionRoot.innerHTML = "";
   const resolvedContextSections = [
     ...baseContextSections,
-    { label: "slot", value: primaryChange?.slot ?? "No slot" },
+    { label: "pane", value: primaryChange?.paneLabel ?? "No pane label" },
     { label: "branch", value: primaryChange?.branch ?? "No branch" },
     { label: "review", value: primaryChange?.review ?? "No review state" },
-    { label: "source", value: primaryChange?.worktree ?? "No source projection" },
   ];
   for (const item of resolvedContextSections) {
     const row = document.createElement("div");
@@ -889,7 +912,7 @@ function renderContextPanel() {
     { label: "Selected scope", value: activeSourceFilter === "all" ? "All changes" : activeSourceFilter.replace("-", " ") },
     { label: "Commit candidates", value: `${visibleChanges.filter((item) => item.commitCandidate).length}` },
     { label: "Needs attention", value: `${visibleChanges.filter((item) => item.needsAttention).length}` },
-    { label: "Active worktree", value: primaryChange?.worktree ?? "n/a" },
+    { label: "Active pane", value: primaryChange?.paneLabel ?? "n/a" },
   ];
 
   for (const item of overviewCards) {
@@ -908,7 +931,7 @@ function renderContextPanel() {
     button.innerHTML =
       `<span class="context-file-name">${change.path.split("/").pop() ?? change.path}</span>` +
       `<span class="context-file-meta">${change.summary}</span>` +
-      `<span class="context-file-trace">${change.status} · ${change.lines} · ${change.worktree} · ${change.review}</span>`;
+      `<span class="context-file-trace">${change.status} · ${change.lines} · ${change.branch} · ${change.review}</span>`;
     button.addEventListener("click", () => {
       selectedEditorPath = change.path;
       setEditorSurface(true);
@@ -1325,9 +1348,9 @@ function renderRunSummary() {
         </div>
       </div>
       <div class="run-summary-meta-row">
-        <span class="run-summary-pill">${primaryChange.slot}</span>
+        <span class="run-summary-pill">${primaryChange.paneLabel}</span>
         <span class="run-summary-pill">${primaryChange.branch}</span>
-        <span class="run-summary-pill">.worktrees/${primaryChange.worktree}</span>
+        <span class="run-summary-pill">${primaryChange.branch}</span>
         <span class="run-summary-pill">${candidateCount} candidate${candidateCount === 1 ? "" : "s"}</span>
         <span class="run-summary-pill">${attentionCount} blocker${attentionCount === 1 ? "" : "s"}</span>
       </div>
@@ -1823,7 +1846,7 @@ function renderEditorSurface() {
     `${selected.lineCount} lines`,
     selected.modified ? "Modified" : "Saved",
     selected.origin === "context" ? "Opened from context" : "Opened from explorer",
-    sourceChange ? `${sourceChange.status} · ${sourceChange.worktree}` : "No source metadata",
+    sourceChange ? `${sourceChange.status} · ${sourceChange.branch}` : "No source metadata",
   ]) {
     const chip = document.createElement("span");
     chip.className = `editor-meta-chip ${item === "Modified" ? "is-modified" : ""}`;
@@ -1993,22 +2016,22 @@ function findEditorFile(label: string) {
     return undefined;
   }
 
-  const explainPayload = getExplainPayloadForRun(sourceChange.run);
-  const explainSummary = explainPayload?.explanation.summary || sourceChange.summary;
-  const branch = explainPayload?.run.branch || sourceChange.branch;
-  const review = explainPayload?.run.review_state || sourceChange.review;
-  const state = explainPayload?.run.task_state || "unknown";
+  const projection = getRunProjectionByRunId(sourceChange.run);
+  const explainSummary = projection?.summary || sourceChange.summary;
+  const branch = projection?.branch || sourceChange.branch;
+  const review = projection?.review_state || sourceChange.review;
+  const state = projection?.task_state || "unknown";
 
   return {
     path: sourceChange.path,
     summary: explainSummary,
     content:
       `// Backend projection preview\n` +
-      `// ${branch} · ${sourceChange.worktree} · ${review}\n` +
+      `// ${branch} · ${sourceChange.paneLabel} · ${review}\n` +
       `// ${sourceChange.lines} · state=${state}\n` +
-      (explainPayload?.explanation.reasons?.length ? `// ${explainPayload.explanation.reasons.join(" | ")}\n` : ""),
+      (projection?.reasons?.length ? `// ${projection.reasons.join(" | ")}\n` : ""),
     language: inferLanguageFromPath(sourceChange.path),
-    lineCount: explainPayload?.evidence_digest.changed_file_count || 3,
+    lineCount: projection?.changed_files.length || 3,
     modified: sourceChange.status !== "deleted",
     origin: "context",
   };
@@ -2035,7 +2058,7 @@ function buildDesktopSummaryConversation(snapshot: DesktopSummarySnapshot): Conv
   const digest = snapshot.digest.summary;
   const inbox = snapshot.inbox.summary;
   const topInboxItems = snapshot.inbox.items.slice(0, 2);
-  const topDigestItems = snapshot.digest.items.slice(0, 3);
+  const topDigestItems = snapshot.run_projections.slice(0, 3);
 
   const items: ConversationItem[] = [
     {
@@ -2079,7 +2102,7 @@ function buildDesktopSummaryConversation(snapshot: DesktopSummarySnapshot): Conv
       timestamp: new Date(snapshot.generated_at).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", hour12: false }),
       actor: digestItem.label || digestItem.pane_id || "Operator",
       title: digestItem.task || "Projected run",
-      body: `Next ${digestItem.next_action || "idle"} · ${digestItem.changed_file_count} changed files · review ${digestItem.review_state || "n/a"}.`,
+      body: `Next ${digestItem.next_action || "idle"} · ${digestItem.changed_files.length} changed files · review ${digestItem.review_state || "n/a"}.`,
       details: [
         { label: "run", value: digestItem.run_id },
         { label: "branch", value: digestItem.branch || "no branch" },


### PR DESCRIPTION
## Summary
- add backend-normalized `run_projections` to the Tauri desktop summary snapshot
- make the frontend consume pane label + branch from backend projections instead of assembling source/worktree semantics heuristically
- keep `explain` as detail drill-down rather than a hidden source-summary join input

## Validation
- cargo check
- npm run build
- `pwsh -NoProfile -Command "& { & '.\\scripts\\winsmux-core.ps1' board --json | Out-Null; & '.\\scripts\\winsmux-core.ps1' digest --json | Out-Null }"`
- `pwsh -NoProfile -Command "& { $digest = & '.\\scripts\\winsmux-core.ps1' digest --json | ConvertFrom-Json; if ($digest.items.Count -gt 0) { & '.\\scripts\\winsmux-core.ps1' explain $digest.items[0].run_id --json | Out-Null } }"`
- git diff --check

## Review
- Herschel FAIL -> removed backend heuristic join
- Singer FAIL -> removed fake worktree/source fields
- Socrates FAIL -> removed branch-based builder/worktree leakage from frontend filters/context
- Aquinas PASS
