### PR TITLE
feat: add tauri desktop client seam

### DIFF
--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -1,6 +1,6 @@
 # Handoff
 
-> Updated: 2026-04-13T19:15:00+09:00
+> Updated: 2026-04-13T19:32:00+09:00
 > Source of truth: this file
 
 ## Current state
@@ -44,6 +44,11 @@
   - `winsmux-app/src/main.ts` now consumes projection DTOs for source summary, source filters, context list, and editor preview
   - projection consumers now use `pane label + branch` only; they no longer pretend to have separate source/worktree identity
   - `explain` remains detail drill-down only instead of acting as a hidden source-summary join input
+- Started branch `codex/task105-desktop-client-seam-20260413` for the first `TASK-105` slice.
+- Added `winsmux-app/src/desktopClient.ts` as the backend-facing seam for desktop snapshot/explain calls:
+  - `main.ts` no longer invokes `desktop_summary_snapshot` or `desktop_run_explain` directly
+  - backend contract types for summary/explain now live in the client module instead of the main shell
+  - the current transport remains Tauri `invoke`, but the seam is ready for a later JSON-RPC / SDK swap
 - Landed `TASK-216` slice 1 and slice 2 on `main`:
   - PR #408: leaf wrapper consolidation for `commander-poll`, `pane-status`, and `pane-control`
   - PR #409: wrapper-based `orchestra-layout` session/window/pane flow
@@ -76,6 +81,8 @@
 - `pwsh -NoProfile -Command "& { & '.\scripts\winsmux-core.ps1' digest --json }"` -> PASS
 - `pwsh -NoProfile -Command "& { $digest = & '.\scripts\winsmux-core.ps1' digest --json | ConvertFrom-Json; if ($digest.items.Count -gt 0) { & '.\scripts\winsmux-core.ps1' explain $digest.items[0].run_id --json | Out-Null } }"` -> PASS
 - `git diff --check` -> warnings only for CRLF normalization, no substantive errors
+- `cargo check` in `winsmux-app/src-tauri` -> PASS after `desktopClient.ts` extraction
+- `npm run build` in `winsmux-app` -> PASS after `desktopClient.ts` extraction
 - Fresh reviewer `Dewey` -> `PASS` for the projection-driven source-context slice in PR #412
 - Fresh reviewer `Herschel` -> `FAIL`; backend heuristic join removed after review
 - Fresh reviewer `Singer` -> `FAIL`; field semantics corrected to avoid fake worktree/source identity
@@ -117,8 +124,8 @@
 
 ## Next actions
 
-1. Continue `v0.22.0` with the next backend-first slice after PR #413, likely `TASK-105` RPC bootstrap.
-2. Keep raw PTY constrained to the utility drawer while summary surfaces remain the primary desktop state source.
+1. Open a PR for the `TASK-105` desktop client seam slice.
+2. Continue `v0.22.0` with the next backend-first slice after the seam lands, likely JSON-RPC transport substitution inside `desktopClient.ts`.
 3. Track startup latency from per-run `explain` fetches inside `desktop_summary_snapshot` if digest volume grows.
 
 ## Notes

--- a/winsmux-app/src/desktopClient.ts
+++ b/winsmux-app/src/desktopClient.ts
@@ -1,0 +1,150 @@
+import { invoke } from "@tauri-apps/api/core";
+
+export interface DesktopBoardSummary {
+  pane_count: number;
+  dirty_panes: number;
+  review_pending: number;
+  review_failed: number;
+  review_passed: number;
+  tasks_in_progress: number;
+  tasks_blocked: number;
+}
+
+export interface DesktopBoardPane {
+  label: string;
+  pane_id: string;
+  role: string;
+  task: string;
+  task_state: string;
+  review_state: string;
+  branch: string;
+  changed_file_count: number;
+}
+
+export interface DesktopInboxSummary {
+  item_count: number;
+}
+
+export interface DesktopInboxItem {
+  kind: string;
+  message: string;
+  label: string;
+  pane_id: string;
+  task_state: string;
+  review_state: string;
+  branch: string;
+  changed_file_count: number;
+}
+
+export interface DesktopDigestSummary {
+  item_count: number;
+  actionable_items: number;
+  review_pending: number;
+  review_failed: number;
+}
+
+export interface DesktopDigestItem {
+  run_id: string;
+  task: string;
+  label: string;
+  pane_id: string;
+  role: string;
+  task_state: string;
+  review_state: string;
+  next_action: string;
+  branch: string;
+  head_short: string;
+  changed_file_count: number;
+  changed_files: string[];
+  verification_outcome?: string;
+  security_blocked?: string;
+}
+
+export interface DesktopRunProjection {
+  run_id: string;
+  pane_id: string;
+  label: string;
+  branch: string;
+  task: string;
+  task_state: string;
+  review_state: string;
+  verification_outcome: string;
+  security_blocked: string;
+  changed_files: string[];
+  next_action: string;
+  summary: string;
+  reasons: string[];
+}
+
+export interface DesktopSummarySnapshot {
+  generated_at: string;
+  project_dir: string;
+  board: {
+    summary: DesktopBoardSummary;
+    panes: DesktopBoardPane[];
+  };
+  inbox: {
+    summary: DesktopInboxSummary;
+    items: DesktopInboxItem[];
+  };
+  digest: {
+    summary: DesktopDigestSummary;
+    items: DesktopDigestItem[];
+  };
+  run_projections: DesktopRunProjection[];
+}
+
+export interface DesktopExplainPayload {
+  run: {
+    run_id: string;
+    task: string;
+    state: string;
+    task_state: string;
+    review_state: string;
+    branch: string;
+    head_sha: string;
+    changed_files: string[];
+  };
+  explanation: {
+    summary: string;
+    reasons: string[];
+    next_action: string;
+  };
+  evidence_digest: {
+    next_action: string;
+    changed_file_count: number;
+    changed_files: string[];
+    verification_outcome?: string;
+    security_blocked?: string;
+  };
+  recent_events: Array<{
+    timestamp: string;
+    event: string;
+    label: string;
+    message: string;
+  }>;
+}
+
+function normalizeDesktopError(action: string, error: unknown) {
+  if (error instanceof Error) {
+    return new Error(`${action} failed: ${error.message}`);
+  }
+
+  return new Error(`${action} failed: ${String(error)}`);
+}
+
+export async function getDesktopSummarySnapshot() {
+  try {
+    return await invoke<DesktopSummarySnapshot>("desktop_summary_snapshot");
+  } catch (error) {
+    throw normalizeDesktopError("desktop_summary_snapshot", error);
+  }
+}
+
+export async function getDesktopRunExplain(runId: string) {
+  try {
+    return await invoke<DesktopExplainPayload>("desktop_run_explain", { runId });
+  } catch (error) {
+    throw normalizeDesktopError(`desktop_run_explain(${runId})`, error);
+  }
+}

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -3,6 +3,13 @@ import { listen } from "@tauri-apps/api/event";
 import { Terminal } from "xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import "xterm/css/xterm.css";
+import {
+  getDesktopRunExplain,
+  getDesktopSummarySnapshot,
+  type DesktopDigestItem,
+  type DesktopExplainPayload,
+  type DesktopSummarySnapshot,
+} from "./desktopClient";
 
 interface PaneEntry {
   terminal: Terminal;
@@ -92,131 +99,6 @@ interface SourceChange {
 
 interface SourceControlState {
   entries: SourceChange[];
-}
-
-interface DesktopBoardSummary {
-  pane_count: number;
-  dirty_panes: number;
-  review_pending: number;
-  review_failed: number;
-  review_passed: number;
-  tasks_in_progress: number;
-  tasks_blocked: number;
-}
-
-interface DesktopBoardPane {
-  label: string;
-  pane_id: string;
-  role: string;
-  task: string;
-  task_state: string;
-  review_state: string;
-  branch: string;
-  changed_file_count: number;
-}
-
-interface DesktopInboxSummary {
-  item_count: number;
-}
-
-interface DesktopInboxItem {
-  kind: string;
-  message: string;
-  label: string;
-  pane_id: string;
-  task_state: string;
-  review_state: string;
-  branch: string;
-  changed_file_count: number;
-}
-
-interface DesktopDigestSummary {
-  item_count: number;
-  actionable_items: number;
-  review_pending: number;
-  review_failed: number;
-}
-
-interface DesktopDigestItem {
-  run_id: string;
-  task: string;
-  label: string;
-  pane_id: string;
-  role: string;
-  task_state: string;
-  review_state: string;
-  next_action: string;
-  branch: string;
-  head_short: string;
-  changed_file_count: number;
-  changed_files: string[];
-  verification_outcome?: string;
-  security_blocked?: string;
-}
-
-interface DesktopSummarySnapshot {
-  generated_at: string;
-  project_dir: string;
-  board: {
-    summary: DesktopBoardSummary;
-    panes: DesktopBoardPane[];
-  };
-  inbox: {
-    summary: DesktopInboxSummary;
-    items: DesktopInboxItem[];
-  };
-  digest: {
-    summary: DesktopDigestSummary;
-    items: DesktopDigestItem[];
-  };
-  run_projections: DesktopRunProjection[];
-}
-
-interface DesktopRunProjection {
-  run_id: string;
-  pane_id: string;
-  label: string;
-  branch: string;
-  task: string;
-  task_state: string;
-  review_state: string;
-  verification_outcome: string;
-  security_blocked: string;
-  changed_files: string[];
-  next_action: string;
-  summary: string;
-  reasons: string[];
-}
-
-interface DesktopExplainPayload {
-  run: {
-    run_id: string;
-    task: string;
-    state: string;
-    task_state: string;
-    review_state: string;
-    branch: string;
-    head_sha: string;
-    changed_files: string[];
-  };
-  explanation: {
-    summary: string;
-    reasons: string[];
-    next_action: string;
-  };
-  evidence_digest: {
-    next_action: string;
-    changed_file_count: number;
-    changed_files: string[];
-    verification_outcome?: string;
-    security_blocked?: string;
-  };
-  recent_events: Array<{
-    timestamp: string;
-    event: string;
-    label: string;
-    message: string;
-  }>;
 }
 
 interface ContextSection {
@@ -1468,7 +1350,7 @@ async function openExplainForSelectedRun() {
   try {
     const payload =
       desktopExplainCache.get(selectedRunId) ??
-      (await invoke<DesktopExplainPayload>("desktop_run_explain", { runId: selectedRunId }));
+      await getDesktopRunExplain(selectedRunId);
     desktopExplainCache.set(selectedRunId, payload);
 
     const detailItems: ConversationDetail[] = [
@@ -2123,12 +2005,12 @@ function buildDesktopSummaryConversation(snapshot: DesktopSummarySnapshot): Conv
 
 async function loadDesktopSummary() {
   try {
-    const snapshot = await invoke<DesktopSummarySnapshot>("desktop_summary_snapshot");
+    const snapshot = await getDesktopSummarySnapshot();
     desktopSummarySnapshot = snapshot;
     const topRunId = snapshot.digest.items[0]?.run_id;
     if (topRunId && !desktopExplainCache.has(topRunId)) {
       try {
-        const explainPayload = await invoke<DesktopExplainPayload>("desktop_run_explain", { runId: topRunId });
+        const explainPayload = await getDesktopRunExplain(topRunId);
         desktopExplainCache.set(topRunId, explainPayload);
       } catch (error) {
         console.warn("Failed to prefetch desktop explain payload", error);


### PR DESCRIPTION
## Summary
- add `winsmux-app/src/desktopClient.ts` as the backend-facing seam for desktop summary/explain calls
- remove direct `desktop_summary_snapshot` / `desktop_run_explain` invokes from `winsmux-app/src/main.ts`
- keep current behavior unchanged while preparing the transport seam for later JSON-RPC / SDK substitution

## Validation
- cargo check
- npm run build
- git diff --check

## Review
- Darwin PASS
