### PR TITLE
refactor: abstract desktop client transport

### DIFF
--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -1,6 +1,6 @@
 # Handoff
 
-> Updated: 2026-04-13T19:32:00+09:00
+> Updated: 2026-04-13T20:05:00+09:00
 > Source of truth: this file
 
 ## Current state
@@ -49,6 +49,15 @@
   - `main.ts` no longer invokes `desktop_summary_snapshot` or `desktop_run_explain` directly
   - backend contract types for summary/explain now live in the client module instead of the main shell
   - the current transport remains Tauri `invoke`, but the seam is ready for a later JSON-RPC / SDK swap
+- Merged PR #414 for the first `TASK-105` slice:
+  - branch: `codex/task105-desktop-client-seam-20260413`
+  - title: `feat: add tauri desktop client seam`
+  - `Pester Tests` green before merge
+- Started branch `codex/task105-desktop-client-transport-20260413` for the next `TASK-105` slice.
+- Refactored `winsmux-app/src/desktopClient.ts` to use an injectable `DesktopCommandTransport`:
+  - Tauri `invoke` is now the default transport implementation instead of the hardwired call site
+  - `getDesktopSummarySnapshot` and `getDesktopRunExplain` now resolve through the transport interface
+  - the next JSON-RPC slice can swap transport behavior without touching `main.ts`
 - Landed `TASK-216` slice 1 and slice 2 on `main`:
   - PR #408: leaf wrapper consolidation for `commander-poll`, `pane-status`, and `pane-control`
   - PR #409: wrapper-based `orchestra-layout` session/window/pane flow
@@ -83,6 +92,11 @@
 - `git diff --check` -> warnings only for CRLF normalization, no substantive errors
 - `cargo check` in `winsmux-app/src-tauri` -> PASS after `desktopClient.ts` extraction
 - `npm run build` in `winsmux-app` -> PASS after `desktopClient.ts` extraction
+- `git diff --check` -> warnings only for CRLF normalization, no substantive errors
+- Fresh reviewer `Darwin` -> `PASS` for the `desktopClient.ts` seam slice
+- PR #414 CI -> green (`Pester Tests`)
+- `npm run build` in `winsmux-app` -> PASS after `DesktopCommandTransport` refactor
+- `git diff --check` -> warnings only for CRLF normalization, no substantive errors
 - Fresh reviewer `Dewey` -> `PASS` for the projection-driven source-context slice in PR #412
 - Fresh reviewer `Herschel` -> `FAIL`; backend heuristic join removed after review
 - Fresh reviewer `Singer` -> `FAIL`; field semantics corrected to avoid fake worktree/source identity
@@ -124,8 +138,8 @@
 
 ## Next actions
 
-1. Open a PR for the `TASK-105` desktop client seam slice.
-2. Continue `v0.22.0` with the next backend-first slice after the seam lands, likely JSON-RPC transport substitution inside `desktopClient.ts`.
+1. Open a PR for the `DesktopCommandTransport` abstraction slice on `codex/task105-desktop-client-transport-20260413`.
+2. Continue `v0.22.0` with the next backend-first slice by swapping a concrete JSON-RPC transport implementation into `desktopClient.ts`.
 3. Track startup latency from per-run `explain` fetches inside `desktop_summary_snapshot` if digest volume grows.
 
 ## Notes

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -58,6 +58,10 @@
   - Tauri `invoke` is now the default transport implementation instead of the hardwired call site
   - `getDesktopSummarySnapshot` and `getDesktopRunExplain` now resolve through the transport interface
   - the next JSON-RPC slice can swap transport behavior without touching `main.ts`
+- Opened PR #415 for the `DesktopCommandTransport` abstraction slice:
+  - branch: `codex/task105-desktop-client-transport-20260413`
+  - title: `refactor: abstract desktop client transport`
+  - status: CI pending at handoff time
 - Landed `TASK-216` slice 1 and slice 2 on `main`:
   - PR #408: leaf wrapper consolidation for `commander-poll`, `pane-status`, and `pane-control`
   - PR #409: wrapper-based `orchestra-layout` session/window/pane flow
@@ -97,6 +101,7 @@
 - PR #414 CI -> green (`Pester Tests`)
 - `npm run build` in `winsmux-app` -> PASS after `DesktopCommandTransport` refactor
 - `git diff --check` -> warnings only for CRLF normalization, no substantive errors
+- `git push -u origin codex/task105-desktop-client-transport-20260413` -> PASS
 - Fresh reviewer `Dewey` -> `PASS` for the projection-driven source-context slice in PR #412
 - Fresh reviewer `Herschel` -> `FAIL`; backend heuristic join removed after review
 - Fresh reviewer `Singer` -> `FAIL`; field semantics corrected to avoid fake worktree/source identity
@@ -138,7 +143,7 @@
 
 ## Next actions
 
-1. Open a PR for the `DesktopCommandTransport` abstraction slice on `codex/task105-desktop-client-transport-20260413`.
+1. Check PR #415 CI and merge if green.
 2. Continue `v0.22.0` with the next backend-first slice by swapping a concrete JSON-RPC transport implementation into `desktopClient.ts`.
 3. Track startup latency from per-run `explain` fetches inside `desktop_summary_snapshot` if digest volume grows.
 

--- a/winsmux-app/src/desktopClient.ts
+++ b/winsmux-app/src/desktopClient.ts
@@ -1,5 +1,14 @@
 import { invoke } from "@tauri-apps/api/core";
 
+type DesktopCommandName = "desktop_summary_snapshot" | "desktop_run_explain";
+
+export interface DesktopCommandTransport {
+  request<TResponse>(
+    command: DesktopCommandName,
+    payload?: Record<string, unknown>,
+  ): Promise<TResponse>;
+}
+
 export interface DesktopBoardSummary {
   pane_count: number;
   dirty_panes: number;
@@ -133,9 +142,30 @@ function normalizeDesktopError(action: string, error: unknown) {
   return new Error(`${action} failed: ${String(error)}`);
 }
 
+export function createTauriDesktopCommandTransport(
+  invokeCommand: typeof invoke = invoke,
+): DesktopCommandTransport {
+  return {
+    request<TResponse>(command: DesktopCommandName, payload?: Record<string, unknown>) {
+      return invokeCommand<TResponse>(command, payload);
+    },
+  };
+}
+
+let desktopCommandTransport: DesktopCommandTransport =
+  createTauriDesktopCommandTransport();
+
+export function configureDesktopCommandTransport(
+  transport: DesktopCommandTransport,
+) {
+  desktopCommandTransport = transport;
+}
+
 export async function getDesktopSummarySnapshot() {
   try {
-    return await invoke<DesktopSummarySnapshot>("desktop_summary_snapshot");
+    return await desktopCommandTransport.request<DesktopSummarySnapshot>(
+      "desktop_summary_snapshot",
+    );
   } catch (error) {
     throw normalizeDesktopError("desktop_summary_snapshot", error);
   }
@@ -143,7 +173,10 @@ export async function getDesktopSummarySnapshot() {
 
 export async function getDesktopRunExplain(runId: string) {
   try {
-    return await invoke<DesktopExplainPayload>("desktop_run_explain", { runId });
+    return await desktopCommandTransport.request<DesktopExplainPayload>(
+      "desktop_run_explain",
+      { runId },
+    );
   } catch (error) {
     throw normalizeDesktopError(`desktop_run_explain(${runId})`, error);
   }


### PR DESCRIPTION
## Summary
- make \\winsmux-app/src/desktopClient.ts\\ transport-driven instead of hardwiring Tauri \\invoke\\
- add configurable \\DesktopCommandTransport\\ and keep the current Tauri transport as the default implementation
- prepare the next TASK-105 slice so a JSON-RPC transport can be swapped in without touching \\main.ts\\

## Validation
- npm run build
- git diff --check
