### PR TITLE
feat: add desktop summary and pty transport seams

### DIFF
--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -1,6 +1,6 @@
 # Handoff
 
-> Updated: 2026-04-13T20:05:00+09:00
+> Updated: 2026-04-13T19:48:00+09:00
 > Source of truth: this file
 
 ## Current state
@@ -58,10 +58,25 @@
   - Tauri `invoke` is now the default transport implementation instead of the hardwired call site
   - `getDesktopSummarySnapshot` and `getDesktopRunExplain` now resolve through the transport interface
   - the next JSON-RPC slice can swap transport behavior without touching `main.ts`
-- Opened PR #415 for the `DesktopCommandTransport` abstraction slice:
+- Merged PR #415 for the `DesktopCommandTransport` abstraction slice:
   - branch: `codex/task105-desktop-client-transport-20260413`
   - title: `refactor: abstract desktop client transport`
-  - status: CI pending at handoff time
+  - `Pester Tests` green before merge
+- Started branch `codex/task105-desktop-summary-pty-20260413` for the next `TASK-105` follow-up slice.
+- Added `winsmux-app/src/ptyClient.ts` as the PTY transport seam for terminal pane lifecycle calls:
+  - `winsmux-app/src/main.ts` no longer invokes `pty_spawn`, `pty_write`, `pty_resize`, or `pty_close` directly
+  - Tauri `invoke` remains the default PTY transport implementation behind the helper
+  - PTY output subscription now also resolves through `ptyClient.ts`, so `main.ts` no longer imports Tauri APIs directly
+- Added `winsmux-app/src-tauri/src/desktop_backend.rs` as the backend transport boundary for desktop summary/explain:
+  - `lib.rs` now delegates desktop summary/explain Tauri commands into a dedicated backend module
+  - `PwshScriptTransport` keeps the current PowerShell execution path isolated behind a transport trait
+  - the next JSON-RPC transport can swap under the backend module without touching Tauri command handlers
+- Added `desktop-summary --json` to `scripts/winsmux-core.ps1` and routed `desktop_summary_snapshot` through it:
+  - board/inbox/digest/run_projections now come back from one backend command instead of three commands plus N `explain` calls in Rust
+  - `tests/winsmux-bridge.Tests.ps1` now covers the top-level `desktop-summary --json` entrypoint
+- Replaced hardcoded source pane filters in `winsmux-app/src/main.ts`:
+  - source context no longer assumes only `builder-2` and `builder-3`
+  - pane-specific source filters are now generated from the current projection snapshot
 - Landed `TASK-216` slice 1 and slice 2 on `main`:
   - PR #408: leaf wrapper consolidation for `commander-poll`, `pane-status`, and `pane-control`
   - PR #409: wrapper-based `orchestra-layout` session/window/pane flow
@@ -101,7 +116,14 @@
 - PR #414 CI -> green (`Pester Tests`)
 - `npm run build` in `winsmux-app` -> PASS after `DesktopCommandTransport` refactor
 - `git diff --check` -> warnings only for CRLF normalization, no substantive errors
-- `git push -u origin codex/task105-desktop-client-transport-20260413` -> PASS
+- PR #415 CI -> green (`Pester Tests`)
+- `gh pr merge 415 --merge --delete-branch` -> PASS
+- `npm run build` in `winsmux-app` -> PASS after PTY seam extraction, desktop backend extraction, and dynamic source filters
+- `cargo fmt --check` in `winsmux-app/src-tauri` -> PASS after backend extraction
+- `cargo check` in `winsmux-app/src-tauri` -> PASS after backend extraction
+- `cargo test --lib` in `winsmux-app/src-tauri` -> PASS (desktop backend transport tests)
+- targeted temp-project harness for `winsmux-core.ps1 desktop-summary --json` -> PASS
+- `git diff --check` -> warnings only for CRLF normalization, no substantive errors
 - Fresh reviewer `Dewey` -> `PASS` for the projection-driven source-context slice in PR #412
 - Fresh reviewer `Herschel` -> `FAIL`; backend heuristic join removed after review
 - Fresh reviewer `Singer` -> `FAIL`; field semantics corrected to avoid fake worktree/source identity
@@ -143,9 +165,9 @@
 
 ## Next actions
 
-1. Check PR #415 CI and merge if green.
-2. Continue `v0.22.0` with the next backend-first slice by swapping a concrete JSON-RPC transport implementation into `desktopClient.ts`.
-3. Track startup latency from per-run `explain` fetches inside `desktop_summary_snapshot` if digest volume grows.
+1. Open a follow-up PR for the PTY seam + `desktop-summary` backend aggregation slice on `codex/task105-desktop-summary-pty-20260413`.
+2. Continue `TASK-105` by swapping a concrete JSON-RPC transport under `desktopClient.ts` / `desktop_backend.rs` instead of the current PowerShell-backed transports.
+3. Continue `TASK-107` by removing remaining seeded runtime fallback state and by adding a real file preview/read surface for the secondary editor.
 
 ## Notes
 

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -4657,6 +4657,87 @@ function Get-DigestPayload {
     }
 }
 
+function New-DesktopRunProjection {
+    param(
+        [Parameter(Mandatory = $true)]$DigestItem,
+        [AllowNull()]$ExplainPayload
+    )
+
+    $run = if ($null -ne $ExplainPayload) { $ExplainPayload.run } else { $null }
+    $explanation = if ($null -ne $ExplainPayload) { $ExplainPayload.explanation } else { $null }
+    $evidenceDigest = if ($null -ne $ExplainPayload) { $ExplainPayload.evidence_digest } else { $null }
+
+    $runId = [string]$DigestItem.run_id
+    $task = [string]$DigestItem.task
+    $branch = if ($null -ne $run -and -not [string]::IsNullOrWhiteSpace([string]$run.branch)) {
+        [string]$run.branch
+    } else {
+        [string]$DigestItem.branch
+    }
+    $changedFiles = if ($null -ne $evidenceDigest -and @($evidenceDigest.changed_files).Count -gt 0) {
+        @($evidenceDigest.changed_files)
+    } else {
+        @($DigestItem.changed_files)
+    }
+    $summary = if ($null -ne $explanation -and -not [string]::IsNullOrWhiteSpace([string]$explanation.summary)) {
+        [string]$explanation.summary
+    } elseif (-not [string]::IsNullOrWhiteSpace($task)) {
+        $task
+    } elseif (-not [string]::IsNullOrWhiteSpace($runId)) {
+        "Projected from $runId"
+    } else {
+        'Projected run'
+    }
+
+    return [ordered]@{
+        run_id               = $runId
+        pane_id              = [string]$DigestItem.pane_id
+        label                = [string]$DigestItem.label
+        branch               = $branch
+        task                 = $task
+        task_state           = if ($null -ne $run -and -not [string]::IsNullOrWhiteSpace([string]$run.task_state)) { [string]$run.task_state } else { [string]$DigestItem.task_state }
+        review_state         = if ($null -ne $run -and -not [string]::IsNullOrWhiteSpace([string]$run.review_state)) { [string]$run.review_state } else { [string]$DigestItem.review_state }
+        verification_outcome = if ($null -ne $evidenceDigest -and -not [string]::IsNullOrWhiteSpace([string]$evidenceDigest.verification_outcome)) { [string]$evidenceDigest.verification_outcome } else { [string]$DigestItem.verification_outcome }
+        security_blocked     = if ($null -ne $evidenceDigest -and -not [string]::IsNullOrWhiteSpace([string]$evidenceDigest.security_blocked)) { [string]$evidenceDigest.security_blocked } else { [string]$DigestItem.security_blocked }
+        changed_files        = @($changedFiles)
+        next_action          = if ($null -ne $explanation -and -not [string]::IsNullOrWhiteSpace([string]$explanation.next_action)) { [string]$explanation.next_action } else { [string]$DigestItem.next_action }
+        summary              = $summary
+        reasons              = if ($null -ne $explanation) { @($explanation.reasons) } else { @() }
+    }
+}
+
+function Get-DesktopSummaryPayload {
+    param([Parameter(Mandatory = $true)][string]$ProjectDir)
+
+    $board = Get-BoardPayload -ProjectDir $ProjectDir
+    $inbox = Get-InboxPayload -ProjectDir $ProjectDir
+    $digest = Get-DigestPayload -ProjectDir $ProjectDir
+    $runProjections = @()
+
+    foreach ($digestItem in @($digest.items)) {
+        $explainPayload = $null
+        $runId = [string]$digestItem.run_id
+        if (-not [string]::IsNullOrWhiteSpace($runId)) {
+            try {
+                $explainPayload = Get-ExplainPayload -ProjectDir $ProjectDir -RunId $runId
+            } catch {
+                $explainPayload = $null
+            }
+        }
+
+        $runProjections += @(New-DesktopRunProjection -DigestItem $digestItem -ExplainPayload $explainPayload)
+    }
+
+    return [ordered]@{
+        generated_at    = (Get-Date).ToString('o')
+        project_dir     = $ProjectDir
+        board           = $board
+        inbox           = $inbox
+        digest          = $digest
+        run_projections = @($runProjections)
+    }
+}
+
 function Get-ExplainPayload {
     param(
         [Parameter(Mandatory = $true)][string]$ProjectDir,
@@ -4755,6 +4836,39 @@ function Get-ExplainPayload {
         recent_events   = $recentEvents
         result_packet   = New-RunResultPacket -Run $run -EvidenceDigest $evidenceDigest -ReviewState $reviewState -RecentEvents $recentEvents -ObservationPack $observationPack -ConsultationPacket $consultationPacket -ConsultationSummary $consultationSummary
     }
+}
+
+function Invoke-DesktopSummary {
+    param(
+        [AllowNull()][string]$DesktopSummaryTarget = $Target,
+        [AllowNull()][string[]]$DesktopSummaryRest = $Rest
+    )
+
+    $jsonOutput = $false
+
+    if ($DesktopSummaryTarget) {
+        if ($DesktopSummaryTarget -eq '--json' -and (-not $DesktopSummaryRest -or $DesktopSummaryRest.Count -eq 0)) {
+            $jsonOutput = $true
+        } else {
+            Stop-WithError "usage: winsmux desktop-summary [--json]"
+        }
+    } elseif ($DesktopSummaryRest -and $DesktopSummaryRest.Count -gt 0) {
+        Stop-WithError "usage: winsmux desktop-summary [--json]"
+    }
+
+    $projectDir = (Get-Location).Path
+    $payload = Get-DesktopSummaryPayload -ProjectDir $projectDir
+
+    if ($jsonOutput) {
+        $payload | ConvertTo-Json -Compress -Depth 12 | Write-Output
+        return
+    }
+
+    Write-Output ("Desktop summary: {0} panes, {1} inbox items, {2} digest items, {3} projections" -f `
+        [int]$payload.board.summary.pane_count, `
+        [int]$payload.inbox.summary.item_count, `
+        [int]$payload.digest.summary.item_count, `
+        @($payload.run_projections).Count)
 }
 
 function Write-ExplainFollowItem {
@@ -6125,6 +6239,7 @@ Commands:
   health-check              Report READY/BUSY/HUNG/DEAD for labeled panes
   status                    Report manifest pane states via capture-pane
   board [--json]            Report pane/task/review/git session board
+desktop-summary [--json]  Report the aggregated desktop read-model snapshot
 inbox [--json] [--stream] Report actionable approvals/review/blockers
 runs [--json]             Report run-oriented session view
 digest [--json] [--stream] [--events] Report high-signal evidence digest per run or actionable event summaries
@@ -6474,12 +6589,13 @@ switch ($Command) {
     'health-check'    { Invoke-HealthCheck }
     'status'          { Invoke-Status }
     'board'           { Invoke-Board }
-        'inbox'           { Invoke-Inbox }
-        'runs'            { Invoke-Runs }
-        'digest'          { Invoke-Digest }
-        'explain'         { Invoke-Explain }
-        'compare-runs'    { Invoke-CompareRuns }
-        'promote-tactic'  { Invoke-PromoteTactic }
+    'desktop-summary' { Invoke-DesktopSummary }
+    'inbox'           { Invoke-Inbox }
+    'runs'            { Invoke-Runs }
+    'digest'          { Invoke-Digest }
+    'explain'         { Invoke-Explain }
+    'compare-runs'    { Invoke-CompareRuns }
+    'promote-tactic'  { Invoke-PromoteTactic }
     'poll-events'     { Invoke-PollEvents }
     'signal'          { Invoke-Signal }
     'mailbox-create'  { Invoke-MailboxCreate }

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -4869,6 +4869,53 @@ Set-Location '__DIGEST_TEMP_ROOT__'
         $result.summary.item_count | Should -Be 1
         $result.items[0].run_id | Should -Be 'task:task-246'
     }
+
+    It 'supports winsmux desktop-summary --json through the top-level CLI entrypoint' {
+@"
+version: 1
+session:
+  name: winsmux-orchestra
+  project_dir: $script:digestTempRoot
+panes:
+  builder-1:
+    pane_id: %2
+    role: Builder
+    task_id: task-246
+    task: Build evidence digest
+    task_state: in_progress
+    task_owner: builder-1
+    review_state: PENDING
+    branch: worktree-builder-1
+    head_sha: abc1234def5678
+    changed_file_count: 1
+    changed_files: '["scripts/winsmux-core.ps1"]'
+    last_event: commander.review_requested
+    last_event_at: 2026-04-10T14:00:00+09:00
+"@ | Set-Content -Path $script:digestManifestPath -Encoding UTF8
+
+        $bridgeScript = Join-Path (Split-Path -Parent $PSScriptRoot) 'scripts\winsmux-core.ps1'
+        $childScript = @'
+Set-Item -Path function:winsmux -Value {
+    param([Parameter(ValueFromRemainingArguments = $true)][object[]]$args)
+    $commandLine = ($args | ForEach-Object { [string]$_ }) -join ' '
+    switch -Regex ($commandLine) {
+        '^capture-pane .*%2' { @('gpt-5.4   64% context left', '? send   Ctrl+J newline', '>'); break }
+        default { throw "unexpected winsmux call: $commandLine" }
+    }
+}
+Set-Location '__DIGEST_TEMP_ROOT__'
+& '__BRIDGE_SCRIPT__' desktop-summary --json
+'@
+        $childScript = $childScript.Replace('__DIGEST_TEMP_ROOT__', $script:digestTempRoot).Replace('__BRIDGE_SCRIPT__', $bridgeScript)
+        $output = & pwsh -NoProfile -Command $childScript
+
+        $result = ($output | Out-String | ConvertFrom-Json -AsHashtable)
+
+        $result.board.summary.pane_count | Should -Be 1
+        $result.digest.summary.item_count | Should -Be 1
+        @($result.run_projections).Count | Should -Be 1
+        $result.run_projections[0].run_id | Should -Be 'task:task-246'
+    }
 }
 
 Describe 'winsmux explain command' {

--- a/winsmux-app/src-tauri/src/desktop_backend.rs
+++ b/winsmux-app/src-tauri/src/desktop_backend.rs
@@ -1,0 +1,244 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+#[derive(Serialize, Deserialize)]
+pub struct DesktopSummarySnapshot {
+    pub generated_at: String,
+    pub project_dir: String,
+    pub board: serde_json::Value,
+    pub inbox: serde_json::Value,
+    pub digest: serde_json::Value,
+    pub run_projections: Vec<DesktopRunProjection>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct DesktopRunProjection {
+    pub run_id: String,
+    pub pane_id: String,
+    pub label: String,
+    pub branch: String,
+    pub task: String,
+    pub task_state: String,
+    pub review_state: String,
+    pub verification_outcome: String,
+    pub security_blocked: String,
+    pub changed_files: Vec<String>,
+    pub next_action: String,
+    pub summary: String,
+    pub reasons: Vec<String>,
+}
+
+pub enum DesktopCommand {
+    SummarySnapshot {
+        project_dir: Option<String>,
+    },
+    RunExplain {
+        run_id: String,
+        project_dir: Option<String>,
+    },
+}
+
+impl DesktopCommand {
+    fn project_dir(&self) -> Option<&str> {
+        match self {
+            DesktopCommand::SummarySnapshot { project_dir } => project_dir.as_deref(),
+            DesktopCommand::RunExplain { project_dir, .. } => project_dir.as_deref(),
+        }
+    }
+
+    fn winsmux_args(&self) -> Vec<String> {
+        match self {
+            DesktopCommand::SummarySnapshot { .. } => {
+                vec!["desktop-summary".to_string(), "--json".to_string()]
+            }
+            DesktopCommand::RunExplain { run_id, .. } => {
+                vec!["explain".to_string(), run_id.clone(), "--json".to_string()]
+            }
+        }
+    }
+}
+
+pub trait DesktopCommandTransport {
+    fn request_json(&self, command: &DesktopCommand) -> Result<Value, String>;
+}
+
+pub struct PwshScriptTransport;
+
+impl DesktopCommandTransport for PwshScriptTransport {
+    fn request_json(&self, command: &DesktopCommand) -> Result<Value, String> {
+        run_winsmux_json(
+            command.project_dir().map(|path| path.to_string()),
+            &command.winsmux_args(),
+        )
+    }
+}
+
+pub fn load_desktop_summary_snapshot(
+    transport: &dyn DesktopCommandTransport,
+    project_dir: Option<String>,
+) -> Result<DesktopSummarySnapshot, String> {
+    let snapshot = transport.request_json(&DesktopCommand::SummarySnapshot { project_dir })?;
+    serde_json::from_value(snapshot)
+        .map_err(|err| format!("Failed to parse desktop summary payload: {err}"))
+}
+
+pub fn load_desktop_run_explain(
+    transport: &dyn DesktopCommandTransport,
+    run_id: String,
+    project_dir: Option<String>,
+) -> Result<Value, String> {
+    transport.request_json(&DesktopCommand::RunExplain {
+        run_id,
+        project_dir,
+    })
+}
+
+fn looks_like_repo_root(path: &Path) -> bool {
+    path.join("scripts").join("winsmux-core.ps1").exists()
+}
+
+fn resolve_repo_root() -> Result<PathBuf, String> {
+    let mut candidates = Vec::new();
+
+    if let Ok(current_dir) = std::env::current_dir() {
+        candidates.push(current_dir);
+    }
+    if let Ok(current_exe) = std::env::current_exe() {
+        if let Some(parent) = current_exe.parent() {
+            candidates.push(parent.to_path_buf());
+        }
+    }
+    candidates.push(PathBuf::from(env!("CARGO_MANIFEST_DIR")));
+
+    for candidate in candidates {
+        for ancestor in candidate.ancestors() {
+            if looks_like_repo_root(ancestor) {
+                return Ok(ancestor.to_path_buf());
+            }
+        }
+    }
+
+    Err("Could not locate winsmux repo root from the Tauri runtime".to_string())
+}
+
+fn run_winsmux_json(project_dir: Option<String>, args: &[String]) -> Result<Value, String> {
+    let repo_root = resolve_repo_root()?;
+    let effective_project_dir = match project_dir {
+        Some(path) if !path.trim().is_empty() => PathBuf::from(path),
+        _ => repo_root.clone(),
+    };
+    let script_path = repo_root.join("scripts").join("winsmux-core.ps1");
+    let script_literal = script_path.to_string_lossy().replace('\'', "''");
+    let args_literal = args
+        .iter()
+        .map(|item| format!("'{}'", item.replace('\'', "''")))
+        .collect::<Vec<_>>()
+        .join(" ");
+    let command_text = format!("& {{ & '{}' {} }}", script_literal, args_literal);
+
+    let output = Command::new("pwsh")
+        .arg("-NoProfile")
+        .arg("-ExecutionPolicy")
+        .arg("Bypass")
+        .arg("-Command")
+        .arg(command_text)
+        .current_dir(&effective_project_dir)
+        .output()
+        .map_err(|err| format!("Failed to start winsmux-core.ps1: {err}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        let detail = if !stderr.is_empty() { stderr } else { stdout };
+        return Err(format!("winsmux-core.ps1 failed: {}", detail));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if stdout.is_empty() {
+        return Err("winsmux-core.ps1 returned empty JSON output".to_string());
+    }
+
+    serde_json::from_str(&stdout)
+        .map_err(|err| format!("Failed to parse winsmux JSON payload: {err}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::RefCell;
+
+    struct FakeTransport {
+        requests: RefCell<Vec<String>>,
+        response: Value,
+    }
+
+    impl DesktopCommandTransport for FakeTransport {
+        fn request_json(&self, command: &DesktopCommand) -> Result<Value, String> {
+            self.requests
+                .borrow_mut()
+                .push(command.winsmux_args().join(" "));
+            Ok(self.response.clone())
+        }
+    }
+
+    #[test]
+    fn load_desktop_summary_snapshot_deserializes_transport_payload() {
+        let transport = FakeTransport {
+            requests: RefCell::new(Vec::new()),
+            response: serde_json::json!({
+                "generated_at": "2026-04-13T00:00:00Z",
+                "project_dir": "C:/repo",
+                "board": { "summary": { "pane_count": 1 }, "panes": [] },
+                "inbox": { "summary": { "item_count": 0 }, "items": [] },
+                "digest": { "summary": { "item_count": 1 }, "items": [] },
+                "run_projections": [{
+                    "run_id": "run-1",
+                    "pane_id": "%1",
+                    "label": "builder-1",
+                    "branch": "codex/task",
+                    "task": "Implement",
+                    "task_state": "in_progress",
+                    "review_state": "PENDING",
+                    "verification_outcome": "",
+                    "security_blocked": "",
+                    "changed_files": ["winsmux-app/src/main.ts"],
+                    "next_action": "review_requested",
+                    "summary": "Implement",
+                    "reasons": ["task_state=in_progress"]
+                }]
+            }),
+        };
+
+        let snapshot = load_desktop_summary_snapshot(&transport, None).unwrap();
+
+        assert_eq!(snapshot.project_dir, "C:/repo");
+        assert_eq!(snapshot.run_projections.len(), 1);
+        assert_eq!(
+            transport.requests.borrow().as_slice(),
+            ["desktop-summary --json"]
+        );
+    }
+
+    #[test]
+    fn load_desktop_run_explain_uses_explain_command() {
+        let transport = FakeTransport {
+            requests: RefCell::new(Vec::new()),
+            response: serde_json::json!({
+                "run": { "run_id": "run-7" },
+                "explanation": { "summary": "ok", "reasons": [], "next_action": "idle" },
+                "evidence_digest": { "changed_files": [], "changed_file_count": 0 },
+                "recent_events": []
+            }),
+        };
+
+        let payload = load_desktop_run_explain(&transport, "run-7".to_string(), None).unwrap();
+
+        assert_eq!(payload["run"]["run_id"], "run-7");
+        assert_eq!(
+            transport.requests.borrow().as_slice(),
+            ["explain run-7 --json"]
+        );
+    }
+}

--- a/winsmux-app/src-tauri/src/lib.rs
+++ b/winsmux-app/src-tauri/src/lib.rs
@@ -1,9 +1,12 @@
+mod desktop_backend;
+
+use desktop_backend::{
+    load_desktop_run_explain, load_desktop_summary_snapshot, DesktopSummarySnapshot,
+    PwshScriptTransport,
+};
 use portable_pty::{native_pty_system, CommandBuilder, PtySize};
-use serde_json::{Map, Value};
 use std::collections::HashMap;
 use std::io::{Read, Write};
-use std::path::{Path, PathBuf};
-use std::process::Command;
 use std::sync::{Arc, Mutex};
 use tauri::{AppHandle, Emitter, Manager};
 
@@ -17,243 +20,21 @@ struct PtyManager {
     panes: Arc<Mutex<HashMap<String, SinglePty>>>,
 }
 
-#[derive(serde::Serialize)]
-struct DesktopSummarySnapshot {
-    generated_at: String,
-    project_dir: String,
-    board: serde_json::Value,
-    inbox: serde_json::Value,
-    digest: serde_json::Value,
-    run_projections: Vec<DesktopRunProjection>,
+#[tauri::command]
+async fn desktop_summary_snapshot(
+    project_dir: Option<String>,
+) -> Result<DesktopSummarySnapshot, String> {
+    let transport = PwshScriptTransport;
+    load_desktop_summary_snapshot(&transport, project_dir)
 }
 
-#[derive(serde::Serialize)]
-struct DesktopRunProjection {
+#[tauri::command]
+async fn desktop_run_explain(
     run_id: String,
-    pane_id: String,
-    label: String,
-    branch: String,
-    task: String,
-    task_state: String,
-    review_state: String,
-    verification_outcome: String,
-    security_blocked: String,
-    changed_files: Vec<String>,
-    next_action: String,
-    summary: String,
-    reasons: Vec<String>,
-}
-
-fn looks_like_repo_root(path: &Path) -> bool {
-    path.join("scripts").join("winsmux-core.ps1").exists()
-}
-
-fn resolve_repo_root() -> Result<PathBuf, String> {
-    let mut candidates = Vec::new();
-
-    if let Ok(current_dir) = std::env::current_dir() {
-        candidates.push(current_dir);
-    }
-    if let Ok(current_exe) = std::env::current_exe() {
-        if let Some(parent) = current_exe.parent() {
-            candidates.push(parent.to_path_buf());
-        }
-    }
-    candidates.push(PathBuf::from(env!("CARGO_MANIFEST_DIR")));
-
-    for candidate in candidates {
-        for ancestor in candidate.ancestors() {
-            if looks_like_repo_root(ancestor) {
-                return Ok(ancestor.to_path_buf());
-            }
-        }
-    }
-
-    Err("Could not locate winsmux repo root from the Tauri runtime".to_string())
-}
-
-fn run_winsmux_json(project_dir: Option<String>, args: &[String]) -> Result<serde_json::Value, String> {
-    let repo_root = resolve_repo_root()?;
-    let effective_project_dir = match project_dir {
-        Some(path) if !path.trim().is_empty() => PathBuf::from(path),
-        _ => repo_root.clone(),
-    };
-    let script_path = repo_root.join("scripts").join("winsmux-core.ps1");
-    let script_literal = script_path.to_string_lossy().replace('\'', "''");
-    let args_literal = args
-        .iter()
-        .map(|item| format!("'{}'", item.replace('\'', "''")))
-        .collect::<Vec<_>>()
-        .join(" ");
-    let command_text = format!("& {{ & '{}' {} }}", script_literal, args_literal);
-
-    let output = Command::new("pwsh")
-        .arg("-NoProfile")
-        .arg("-ExecutionPolicy")
-        .arg("Bypass")
-        .arg("-Command")
-        .arg(command_text)
-        .current_dir(&effective_project_dir)
-        .output()
-        .map_err(|err| format!("Failed to start winsmux-core.ps1: {err}"))?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        let detail = if !stderr.is_empty() { stderr } else { stdout };
-        return Err(format!("winsmux-core.ps1 failed: {}", detail));
-    }
-
-    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    if stdout.is_empty() {
-        return Err("winsmux-core.ps1 returned empty JSON output".to_string());
-    }
-
-    serde_json::from_str(&stdout).map_err(|err| format!("Failed to parse winsmux JSON payload: {err}"))
-}
-
-fn get_string(map: &Map<String, Value>, key: &str) -> String {
-    map.get(key)
-        .and_then(|value| value.as_str())
-        .unwrap_or_default()
-        .to_string()
-}
-
-fn get_string_array(map: &Map<String, Value>, key: &str) -> Vec<String> {
-    map.get(key)
-        .and_then(|value| value.as_array())
-        .map(|items| {
-            items.iter()
-                .filter_map(|item| item.as_str().map(|text| text.to_string()))
-                .collect::<Vec<_>>()
-        })
-        .unwrap_or_default()
-}
-
-fn build_run_projection(
-    digest_item: &Map<String, Value>,
-    explain_payload: &Value,
-) -> DesktopRunProjection {
-    let explain_run = explain_payload.get("run").and_then(|value| value.as_object());
-    let explanation = explain_payload
-        .get("explanation")
-        .and_then(|value| value.as_object());
-    let evidence = explain_payload
-        .get("evidence_digest")
-        .and_then(|value| value.as_object());
-
-    let run_id = get_string(digest_item, "run_id");
-    let pane_id = get_string(digest_item, "pane_id");
-    let label = get_string(digest_item, "label");
-    let branch = explain_run
-        .map(|run| get_string(run, "branch"))
-        .filter(|value| !value.is_empty())
-        .unwrap_or_else(|| get_string(digest_item, "branch"));
-    let changed_files = evidence
-        .map(|digest| get_string_array(digest, "changed_files"))
-        .filter(|items| !items.is_empty())
-        .unwrap_or_else(|| get_string_array(digest_item, "changed_files"));
-    let task = get_string(digest_item, "task");
-    let summary = explanation
-        .map(|payload| get_string(payload, "summary"))
-        .filter(|value| !value.is_empty())
-        .unwrap_or_else(|| {
-            if !task.is_empty() {
-                task.clone()
-            } else if !run_id.is_empty() {
-                format!("Projected from {run_id}")
-            } else {
-                "Projected run".to_string()
-            }
-        });
-
-    DesktopRunProjection {
-        run_id,
-        pane_id,
-        label,
-        branch,
-        task,
-        task_state: explain_run
-            .map(|run| get_string(run, "task_state"))
-            .filter(|value| !value.is_empty())
-            .unwrap_or_else(|| get_string(digest_item, "task_state")),
-        review_state: explain_run
-            .map(|run| get_string(run, "review_state"))
-            .filter(|value| !value.is_empty())
-            .unwrap_or_else(|| get_string(digest_item, "review_state")),
-        verification_outcome: evidence
-            .map(|digest| get_string(digest, "verification_outcome"))
-            .filter(|value| !value.is_empty())
-            .unwrap_or_else(|| get_string(digest_item, "verification_outcome")),
-        security_blocked: evidence
-            .map(|digest| get_string(digest, "security_blocked"))
-            .filter(|value| !value.is_empty())
-            .unwrap_or_else(|| get_string(digest_item, "security_blocked")),
-        changed_files,
-        next_action: explanation
-            .map(|payload| get_string(payload, "next_action"))
-            .filter(|value| !value.is_empty())
-            .unwrap_or_else(|| get_string(digest_item, "next_action")),
-        summary,
-        reasons: explanation
-            .map(|payload| get_string_array(payload, "reasons"))
-            .unwrap_or_default(),
-    }
-}
-
-fn build_run_projections(digest: &Value, project_dir: Option<String>) -> Vec<DesktopRunProjection> {
-    digest
-        .get("items")
-        .and_then(|value| value.as_array())
-        .map(|items| {
-            items.iter()
-                .filter_map(|item| item.as_object())
-                .map(|digest_item| {
-                    let run_id = get_string(digest_item, "run_id");
-                    let explain_payload = if run_id.is_empty() {
-                        Value::Null
-                    } else {
-                        run_winsmux_json(
-                            project_dir.clone(),
-                            &["explain".to_string(), run_id, "--json".to_string()],
-                        )
-                        .unwrap_or(Value::Null)
-                    };
-                    build_run_projection(digest_item, &explain_payload)
-                })
-                .collect::<Vec<_>>()
-        })
-        .unwrap_or_default()
-}
-
-#[tauri::command]
-async fn desktop_summary_snapshot(project_dir: Option<String>) -> Result<DesktopSummarySnapshot, String> {
-    let board = run_winsmux_json(project_dir.clone(), &["board".to_string(), "--json".to_string()])?;
-    let inbox = run_winsmux_json(project_dir.clone(), &["inbox".to_string(), "--json".to_string()])?;
-    let digest = run_winsmux_json(project_dir.clone(), &["digest".to_string(), "--json".to_string()])?;
-    let run_projections = build_run_projections(&digest, project_dir.clone());
-
-    let effective_project_dir = match project_dir {
-        Some(path) if !path.trim().is_empty() => path,
-        _ => resolve_repo_root()?.to_string_lossy().to_string(),
-    };
-
-    Ok(DesktopSummarySnapshot {
-        generated_at: chrono::Utc::now().to_rfc3339(),
-        project_dir: effective_project_dir,
-        board,
-        inbox,
-        digest,
-        run_projections,
-    })
-}
-
-#[tauri::command]
-async fn desktop_run_explain(run_id: String, project_dir: Option<String>) -> Result<serde_json::Value, String> {
-    run_winsmux_json(
-        project_dir,
-        &["explain".to_string(), run_id, "--json".to_string()],
-    )
+    project_dir: Option<String>,
+) -> Result<serde_json::Value, String> {
+    let transport = PwshScriptTransport;
+    load_desktop_run_explain(&transport, run_id, project_dir)
 }
 
 #[tauri::command]
@@ -312,7 +93,10 @@ async fn pty_spawn(app: AppHandle, pane_id: String, cols: u16, rows: u16) -> Res
                 Ok(0) => break,
                 Ok(n) => {
                     let data = String::from_utf8_lossy(&buf[..n]).to_string();
-                    let _ = app_handle.emit("pty-output", serde_json::json!({"pane_id": pane_id_clone, "data": data}));
+                    let _ = app_handle.emit(
+                        "pty-output",
+                        serde_json::json!({"pane_id": pane_id_clone, "data": data}),
+                    );
                 }
                 Err(_) => break,
             }
@@ -326,7 +110,9 @@ async fn pty_spawn(app: AppHandle, pane_id: String, cols: u16, rows: u16) -> Res
 async fn pty_write(app: AppHandle, pane_id: String, data: String) -> Result<(), String> {
     let manager = app.state::<PtyManager>();
     let panes = manager.panes.lock().map_err(|e| e.to_string())?;
-    let pty = panes.get(&pane_id).ok_or_else(|| format!("Pane {} not found", pane_id))?;
+    let pty = panes
+        .get(&pane_id)
+        .ok_or_else(|| format!("Pane {} not found", pane_id))?;
     let mut writer = pty.writer.lock().map_err(|e| e.to_string())?;
     writer
         .write_all(data.as_bytes())
@@ -339,7 +125,9 @@ async fn pty_write(app: AppHandle, pane_id: String, data: String) -> Result<(), 
 async fn pty_resize(app: AppHandle, pane_id: String, cols: u16, rows: u16) -> Result<(), String> {
     let manager = app.state::<PtyManager>();
     let panes = manager.panes.lock().map_err(|e| e.to_string())?;
-    let pty = panes.get(&pane_id).ok_or_else(|| format!("Pane {} not found", pane_id))?;
+    let pty = panes
+        .get(&pane_id)
+        .ok_or_else(|| format!("Pane {} not found", pane_id))?;
     let master = pty.master.lock().map_err(|e| e.to_string())?;
     master
         .resize(PtySize {
@@ -356,7 +144,9 @@ async fn pty_resize(app: AppHandle, pane_id: String, cols: u16, rows: u16) -> Re
 async fn pty_close(app: AppHandle, pane_id: String) -> Result<(), String> {
     let manager = app.state::<PtyManager>();
     let mut panes = manager.panes.lock().map_err(|e| e.to_string())?;
-    let entry = panes.remove(&pane_id).ok_or_else(|| format!("Pane {} not found", pane_id))?;
+    let entry = panes
+        .remove(&pane_id)
+        .ok_or_else(|| format!("Pane {} not found", pane_id))?;
     // Kill child process
     if let Ok(mut child) = entry.child.lock() {
         let _ = child.kill();

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -1,5 +1,3 @@
-import { invoke } from "@tauri-apps/api/core";
-import { listen } from "@tauri-apps/api/event";
 import { Terminal } from "xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import "xterm/css/xterm.css";
@@ -10,6 +8,13 @@ import {
   type DesktopExplainPayload,
   type DesktopSummarySnapshot,
 } from "./desktopClient";
+import {
+  closePtyPane,
+  resizePtyPane,
+  spawnPtyPane,
+  subscribeToPtyOutput,
+  writePtyData,
+} from "./ptyClient";
 
 interface PaneEntry {
   terminal: Terminal;
@@ -78,7 +83,7 @@ interface EditorFile {
   active?: boolean;
 }
 
-type SourceFilter = "all" | "candidates" | "attention" | "builder-2" | "builder-3";
+type SourceFilter = "all" | "candidates" | "attention" | `pane:${string}`;
 
 type ChangeStatus = "modified" | "added" | "deleted" | "renamed";
 type ChangeRisk = "low" | "medium" | "high";
@@ -460,17 +465,17 @@ function createPane(paneId?: string): string {
   fitAddon.fit();
 
   terminal.onData((data: string) => {
-    void invoke("pty_write", { paneId: id, data });
+    void writePtyData(id, data);
   });
 
   terminal.onResize(({ cols, rows }) => {
-    void invoke("pty_resize", { paneId: id, cols, rows });
+    void resizePtyPane(id, cols, rows);
   });
 
   panes.set(id, { terminal, fitAddon, container: paneDiv });
 
   const { cols, rows } = { cols: terminal.cols, rows: terminal.rows };
-  void invoke("pty_spawn", { paneId: id, cols, rows });
+  void spawnPtyPane(id, cols, rows);
 
   return id;
 }
@@ -494,7 +499,7 @@ function closePane(id: string) {
 
   entry.container.remove();
   panes.delete(id);
-  void invoke("pty_close", { paneId: id });
+  void closePtyPane(id);
 
   panes.forEach((pane) => pane.fitAddon.fit());
 }
@@ -594,6 +599,18 @@ function getProjectionSourceEntries(): SourceChange[] {
   return entries.length > 0 ? entries : sourceControlState.entries;
 }
 
+function getPaneSourceFilter(label: string): SourceFilter {
+  return `pane:${label}`;
+}
+
+function getPaneLabelFromSourceFilter(filter: SourceFilter) {
+  if (!filter.startsWith("pane:")) {
+    return null;
+  }
+
+  return filter.slice("pane:".length);
+}
+
 function renderExplorer() {
   const root = document.getElementById("explorer-list");
   if (!root) {
@@ -684,9 +701,17 @@ function renderSourceEntries() {
   const entryItems: Array<{ label: string; value: string; filter: SourceFilter; tone?: SurfaceTone }> = [
     { label: "Commit candidates", value: `${activeEntries.filter((item) => item.commitCandidate).length} ready`, tone: "success", filter: "candidates" },
     { label: "Needs attention", value: `${activeEntries.filter((item) => item.needsAttention).length} blocker`, tone: "danger", filter: "attention" },
-    { label: "builder-2", value: `${activeEntries.filter((item) => item.paneLabel === "builder-2").length} files`, filter: "builder-2" },
-    { label: "builder-3", value: `${activeEntries.filter((item) => item.paneLabel === "builder-3").length} files`, filter: "builder-3" },
   ];
+  const paneLabels = [...new Set(activeEntries.map((item) => item.paneLabel).filter((item) => item))].sort((left, right) =>
+    left.localeCompare(right),
+  );
+  for (const paneLabel of paneLabels) {
+    entryItems.push({
+      label: paneLabel,
+      value: `${activeEntries.filter((item) => item.paneLabel === paneLabel).length} files`,
+      filter: getPaneSourceFilter(paneLabel),
+    });
+  }
 
   for (const item of entryItems) {
     const button = document.createElement("button");
@@ -719,17 +744,30 @@ function getVisibleSourceChanges() {
       return activeEntries.filter((item) => item.commitCandidate);
     case "attention":
       return activeEntries.filter((item) => item.needsAttention);
-    case "builder-2":
-      return activeEntries.filter((item) => item.paneLabel === "builder-2");
-    case "builder-3":
-      return activeEntries.filter((item) => item.paneLabel === "builder-3");
     default:
+      if (activeSourceFilter.startsWith("pane:")) {
+        const paneLabel = getPaneLabelFromSourceFilter(activeSourceFilter);
+        return activeEntries.filter((item) => item.paneLabel === paneLabel);
+      }
       return activeEntries;
   }
 }
 
 function getPrimarySourceChange(changes: SourceChange[]) {
   return changes.find((item) => item.path === selectedEditorPath) ?? changes[0] ?? getProjectionSourceEntries()[0];
+}
+
+function getSourceFilterLabel(filter: SourceFilter) {
+  switch (filter) {
+    case "all":
+      return "All changes";
+    case "candidates":
+      return "Commit candidates";
+    case "attention":
+      return "Needs attention";
+    default:
+      return getPaneLabelFromSourceFilter(filter) ?? filter;
+  }
 }
 
 function getPrimaryDigestItem() {
@@ -791,7 +829,7 @@ function renderContextPanel() {
 
   overviewRoot.innerHTML = "";
   const overviewCards = [
-    { label: "Selected scope", value: activeSourceFilter === "all" ? "All changes" : activeSourceFilter.replace("-", " ") },
+    { label: "Selected scope", value: getSourceFilterLabel(activeSourceFilter) },
     { label: "Commit candidates", value: `${visibleChanges.filter((item) => item.commitCandidate).length}` },
     { label: "Needs attention", value: `${visibleChanges.filter((item) => item.needsAttention).length}` },
     { label: "Active pane", value: primaryChange?.paneLabel ?? "n/a" },
@@ -2059,18 +2097,16 @@ function initializeSidebarResize() {
 }
 
 window.addEventListener("DOMContentLoaded", async () => {
-  await listen<string>("pty-output", (event) => {
-    try {
-      const payload = JSON.parse(event.payload);
-      const entry = panes.get(payload.pane_id);
-      if (entry) {
-        entry.terminal.write(payload.data);
-      }
-    } catch {
-      const first = panes.values().next().value as PaneEntry | undefined;
-      if (first) {
-        first.terminal.write(event.payload);
-      }
+  await subscribeToPtyOutput((payload) => {
+    const entry = payload.pane_id ? panes.get(payload.pane_id) : undefined;
+    if (entry) {
+      entry.terminal.write(payload.data);
+      return;
+    }
+
+    const first = panes.values().next().value as PaneEntry | undefined;
+    if (first) {
+      first.terminal.write(payload.data);
     }
   });
 

--- a/winsmux-app/src/ptyClient.ts
+++ b/winsmux-app/src/ptyClient.ts
@@ -1,0 +1,92 @@
+import { invoke } from "@tauri-apps/api/core";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+
+type PtyCommandName = "pty_spawn" | "pty_write" | "pty_resize" | "pty_close";
+
+interface PtyOutputEvent {
+  pane_id: string;
+  data: string;
+}
+
+export interface PtyCommandTransport {
+  request(command: PtyCommandName, payload: Record<string, unknown>): Promise<void>;
+}
+
+function normalizePtyError(action: string, error: unknown) {
+  if (error instanceof Error) {
+    return new Error(`${action} failed: ${error.message}`);
+  }
+
+  return new Error(`${action} failed: ${String(error)}`);
+}
+
+export function createTauriPtyCommandTransport(
+  invokeCommand: typeof invoke = invoke,
+): PtyCommandTransport {
+  return {
+    async request(command: PtyCommandName, payload: Record<string, unknown>) {
+      await invokeCommand(command, payload);
+    },
+  };
+}
+
+let ptyCommandTransport: PtyCommandTransport = createTauriPtyCommandTransport();
+
+export function configurePtyCommandTransport(transport: PtyCommandTransport) {
+  ptyCommandTransport = transport;
+}
+
+export async function spawnPtyPane(
+  paneId: string,
+  cols: number,
+  rows: number,
+) {
+  try {
+    await ptyCommandTransport.request("pty_spawn", { paneId, cols, rows });
+  } catch (error) {
+    throw normalizePtyError(`pty_spawn(${paneId})`, error);
+  }
+}
+
+export async function writePtyData(paneId: string, data: string) {
+  try {
+    await ptyCommandTransport.request("pty_write", { paneId, data });
+  } catch (error) {
+    throw normalizePtyError(`pty_write(${paneId})`, error);
+  }
+}
+
+export async function resizePtyPane(
+  paneId: string,
+  cols: number,
+  rows: number,
+) {
+  try {
+    await ptyCommandTransport.request("pty_resize", { paneId, cols, rows });
+  } catch (error) {
+    throw normalizePtyError(`pty_resize(${paneId})`, error);
+  }
+}
+
+export async function closePtyPane(paneId: string) {
+  try {
+    await ptyCommandTransport.request("pty_close", { paneId });
+  } catch (error) {
+    throw normalizePtyError(`pty_close(${paneId})`, error);
+  }
+}
+
+export async function subscribeToPtyOutput(
+  onOutput: (event: PtyOutputEvent) => void,
+): Promise<UnlistenFn> {
+  return listen<string>("pty-output", (event) => {
+    try {
+      onOutput(JSON.parse(event.payload) as PtyOutputEvent);
+    } catch {
+      onOutput({
+        pane_id: "",
+        data: event.payload,
+      });
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- add a dedicated PTY client seam so main.ts no longer imports Tauri APIs directly
- move desktop summary/explain backend transport wiring into desktop_backend.rs
- add desktop-summary --json to aggregate the desktop read-model in one backend command and switch source pane filters to snapshot-driven labels

## Validation
- npm run build
- cargo fmt --check
- cargo check
- cargo test --lib
- targeted desktop-summary harness
- git diff --check

## Review
- Copernicus no result yet after 40s; manual diff review completed
