### PR TITLE
feat: add desktop json-rpc envelope transport

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,23 @@ When updating handoff:
 - Reflect external planning truth when version progress changes.
 - Prefer exact identifiers: version, task IDs, PR numbers, release status.
 
+## Rust Learning Note Gate
+
+When handoff work includes Rust, Cargo, Tauri, or Rust-adjacent commands used in winsmux development, Codex must also update the beginner-friendly learning note at:
+
+- `C:\Users\komei\iCloudDrive\iCloud~md~obsidian\MainVault\Learning\Rust Commands - winsmux.md`
+
+Rules:
+
+1. Keep the note outside the repository. Never commit files under the external `Learning` path.
+2. Update the note during handoff in the same session that used the command, not later.
+3. Explain each command in beginner-friendly Japanese:
+   - what it does,
+   - when to use it,
+   - one concrete example from winsmux work.
+4. Prefer updating existing entries over adding duplicates.
+5. If the session did not use or discuss Rust-adjacent commands, no learning-note update is required.
+
 ## Release Notes Policy
 
 GitHub Release titles and bodies must be written in English, regardless of the conversation language.

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -1,6 +1,6 @@
 # Handoff
 
-> Updated: 2026-04-13T21:20:32+09:00
+> Updated: 2026-04-14T01:25:00+09:00
 > Source of truth: this file
 
 ## Current state
@@ -94,6 +94,15 @@
   - `winsmux-app/src/ptyClient.ts` now sends `pty.spawn` / `pty.write` / `pty.resize` / `pty.close` through one `pty_json_rpc` Tauri command instead of per-method `invoke(...)`
   - `winsmux-app/src-tauri/src/pty_backend.rs` now validates JSON-RPC `2.0`, parses PTY params, and returns structured `result/error` responses for PTY lifecycle requests
   - `winsmux-app/src-tauri/src/lib.rs` now routes both `pty_json_rpc` and the legacy per-command handlers through shared PTY helpers, so the transport boundary changed without breaking compatibility
+- Continued the same `TASK-105` slice by wiring real worktree metadata through desktop summary and source preview hydration:
+  - `winsmux-core/scripts/pane-status.ps1` now emits `Worktree` from the current pane cwd first, falls back to manifest builder paths, and only infers `.worktrees/<label>` when the standard `worktree-<label>` branch convention matches
+  - `scripts/winsmux-core.ps1` now preserves `worktree` through `board -> runs -> digest -> desktop-summary run_projections` without dropping hashtable-backed values
+  - `tests/winsmux-bridge.Tests.ps1` now covers explicit worktree precedence, manifest-root relativization, inferred builder worktrees, and the top-level `desktop-summary --json` propagation path
+- Continued `TASK-291 / TASK-107 / TASK-289` on `codex/task105-json-rpc-transport-20260413` by removing more seeded desktop shell state:
+  - `winsmux-app/src/main.ts` now keeps a real `selectedRunId` derived from digest/run-projection data instead of always treating the first run as selected
+  - source context, run summary, Explain, and secondary editor now follow the selected backend run instead of a seeded timeline fallback
+  - the workspace Explorer now builds from projection-derived changed files and standalone editor targets, replacing the old static sample file tree
+  - desktop summary refresh now runs on startup, focus, visibility restore, and a 15s polling interval so the shell follows live inbox/digest movement rather than one-shot hydration
 - Landed `TASK-216` slice 1 and slice 2 on `main`:
   - PR #408: leaf wrapper consolidation for `commander-poll`, `pane-status`, and `pane-control`
   - PR #409: wrapper-based `orchestra-layout` session/window/pane flow
@@ -152,6 +161,20 @@
 - `cargo test --lib` in `winsmux-app/src-tauri` -> PASS (`8 passed`, PTY JSON-RPC dispatch tests added)
 - `npm run build` in `winsmux-app` -> PASS after `pty_json_rpc` client wiring
 - `Invoke-Pester tests/winsmux-bridge.Tests.ps1` -> `167/167 PASS` after the PTY JSON-RPC slice
+- `npm run build` in `winsmux-app` -> PASS after the worktree propagation follow-up
+- `cargo test --lib` in `winsmux-app/src-tauri` -> PASS (`10 passed`) after the editor/worktree backend follow-up
+- `Invoke-Pester tests/winsmux-bridge.Tests.ps1 -CI` -> `171/171 PASS` after fixing desktop-summary worktree propagation
+- `npm run test:editor-targets` in `winsmux-app` -> PASS after selected-run / explorer convergence
+- `npm run build` in `winsmux-app` -> PASS after selected-run state + live desktop summary follow-through
+- `cargo test --lib` in `winsmux-app/src-tauri` -> PASS (`10 passed`) after selected-run / live-follow slice
+- `Invoke-Pester tests/winsmux-bridge.Tests.ps1 -CI` -> `171/171 PASS` after selected-run / live-follow slice
+- root `winsmux-core/scripts/sync-roadmap.ps1` -> PASS (roadmap + internal docs regenerated with no planning drift introduced by this slice)
+- Fresh reviewer `Tesla` -> `PASS` for the selected-run / live-follow slice after delayed completion
+- Manual diff review also completed for the selected-run / live-follow slice
+- `/review` follow-up via `codex exec` -> `REQUEST_CHANGES`, then `APPROVE` after:
+  - preferring `launch_dir` over stale `builder_worktree_path`
+  - relativizing explicit worktrees against `session.project_dir`
+  - adding focused pane-status and desktop-summary regression coverage
 - Fresh reviewer `Kepler` -> `no result yet` after a 30s wait; closed without result
 - Manual diff review completed for the PTY JSON-RPC transport slice
 - `git diff --check` -> warnings only for CRLF normalization, no substantive errors
@@ -196,9 +219,10 @@
 
 ## Next actions
 
-1. Open or update the follow-up PR for the current `TASK-105` transport-convergence slice on `codex/task105-json-rpc-transport-20260413`.
-2. Continue `TASK-291` / `TASK-107` by removing remaining seeded runtime fallback state and by adding a real file preview/read surface for the secondary editor.
-3. Continue `TASK-289` by replacing the remaining one-shot digest/explain hydration with live inbox/digest follow-through in the desktop shell.
+1. Update PR #417 from `codex/task105-json-rpc-transport-20260413` with the selected-run / live-follow slice and describe the remaining `TASK-291 / TASK-289` delta explicitly.
+2. Continue `TASK-291 / TASK-107` by converging the secondary editor on richer real detail DTOs (test results, review verdict, branch/head cards) instead of placeholder preview metadata.
+3. Continue `TASK-289` by replacing polling-only follow-through with material-event subscription or narrower refresh triggers once the backend stream shape is ready.
+4. Keep root-repo planning-sync diffs separate from this worktree slice; the root-side `main.ts` / `ptyClient.ts` / `desktop_backend.rs` changes are a divergent lane and were not auto-cleaned.
 
 ## Notes
 
@@ -206,3 +230,5 @@
 - `TASK-216` landed as small hot-path wrapper slices rather than a single bridge-file refactor.
 - `TASK-295` keeps `.psmux` compatibility paths untouched; those stay under the sunset plan instead of this rename slice.
 - Public GitHub Releases stay English, use Codex-style headings, and keep inline issue/PR refs visible.
+- Review gate for this slice was satisfied after a second `/review` pass returned `APPROVE`; the intermediate `REQUEST_CHANGES` findings were incorporated before continuing.
+- Reviewer `Tesla` initially timed out after the required 35s wait, so work proceeded under the manual-diff fallback gate; the delayed reviewer result later arrived as `PASS` before packaging the slice.

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -1,6 +1,6 @@
 # Handoff
 
-> Updated: 2026-04-14T03:35:00+09:00
+> Updated: 2026-04-14T04:15:00+09:00
 > Source of truth: this file
 
 ## Current state
@@ -113,6 +113,11 @@
   - created `codex/task290-detail-lane-20260414` and moved the selected-run editor targeting change there
   - removed the selected-run detail grid, action chips, and verification/security/action-item summarization from the `v0.22.0` branch
   - kept the `TASK-289 / TASK-291` pieces on `codex/task105-json-rpc-transport-20260413`: material-change follow-through and narrower explain prefetch on unchanged refreshes
+- Attempted a broader selected-run metadata surfacing pass for `TASK-291 / TASK-107`, then reverted it after review marked it as `TASK-290` UX drift.
+- Kept the next `v0.22.0` target narrower: backend-truth fallback cleanup should stay in Explain/editor placeholder handling, not in selected-run or source-metadata presentation.
+- Continued the narrower `TASK-291 / TASK-107` cleanup after that review:
+  - `appendFallbackExplain()` now falls back to current digest counts and next action instead of the older generic placeholder copy when explain loading fails
+  - source summary and secondary-editor metadata surfacing were both pared back after review so the `v0.22.0` slice stays out of `TASK-290` territory
 - Added a durable Rust learning-note rule to `AGENTS.md` for future handoffs:
   - when a session uses Rust / Cargo / Tauri commands during winsmux work, handoff must also update `C:\Users\komei\iCloudDrive\iCloud~md~obsidian\MainVault\Learning\Rust Commands - winsmux.md`
   - the note is kept outside the repo, stays beginner-friendly, and should be updated in the same session rather than deferred
@@ -207,6 +212,12 @@
 - Manual diff review completed for the action-chip / prefetch-gating follow-up
 - `npm run build` in `winsmux-app` -> PASS after splitting `TASK-290` detail UX back out of the `v0.22.0` branch
 - `npm run test:editor-targets` in `winsmux-app` -> PASS after the same boundary cleanup
+- Fresh reviewer `Russell` -> `FAIL`; broader selected-run metadata presentation was classified as `TASK-290` UX drift and reverted from the `v0.22.0` lane
+- `npm run build` in `winsmux-app` -> PASS after narrowing the fallback cleanup back to Explain/editor placeholder handling
+- `npm run test:editor-targets` in `winsmux-app` -> PASS after the same narrowed fallback cleanup
+- Fresh reviewer `Poincare` -> `FAIL`; editor empty-state metadata surfacing was also classified as `TASK-290` UX drift and reverted from the `v0.22.0` lane
+- Fresh reviewer `Carson` -> `PASS` on the narrowed explain-fallback / metadata-reduction follow-up after delayed completion
+- Manual diff review was used provisionally after the initial 30s wait, then superseded by the delayed `PASS` before packaging
 - `/review` follow-up via `codex exec` -> `REQUEST_CHANGES`, then `APPROVE` after:
   - preferring `launch_dir` over stale `builder_worktree_path`
   - relativizing explicit worktrees against `session.project_dir`
@@ -256,7 +267,7 @@
 ## Next actions
 
 1. Update PR #417 from `codex/task105-json-rpc-transport-20260413` with the `v0.22.0` boundary cleanup and verify that only `TASK-105 / TASK-291 / TASK-289` scope remains on the branch.
-2. Continue `TASK-291 / TASK-107` by removing the remaining seeded fallback paths without re-expanding the selected-run detail surface.
+2. Continue `TASK-291 / TASK-107` by removing the remaining seeded fallback paths in Explain/editor hydration flow without re-expanding the selected-run detail surface.
 3. Continue `TASK-289` by reducing polling dependence further, either with narrower refresh triggers or a backend event surface once the transport shape is ready.
 4. Resume `TASK-290` later from `codex/task290-detail-lane-20260414`, after `v0.22.0` closes.
 5. Keep the new Rust learning note current during future handoffs whenever Rust / Cargo / Tauri commands are used in the session.

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -1,6 +1,6 @@
 # Handoff
 
-> Updated: 2026-04-13T19:48:00+09:00
+> Updated: 2026-04-13T19:58:21+09:00
 > Source of truth: this file
 
 ## Current state
@@ -77,6 +77,18 @@
 - Replaced hardcoded source pane filters in `winsmux-app/src/main.ts`:
   - source context no longer assumes only `builder-2` and `builder-3`
   - pane-specific source filters are now generated from the current projection snapshot
+- Merged PR #416 for the PTY seam + backend aggregation slice:
+  - branch: `codex/task105-desktop-summary-pty-20260413`
+  - title: `feat: add desktop summary and pty transport seams`
+  - `Pester Tests` green before merge
+- Synced the external planning source of truth at `C:\Users\komei\iCloudDrive\iCloud~md~obsidian\MainVault\Projects\winsmux\planning`:
+  - `backlog.yaml` now marks `TASK-105`, `TASK-289`, and `TASK-291` as `active`
+  - `ROADMAP.md` regenerated from the backlog after the merged `#411` / `#412` / `#413` / `#414` / `#415` / `#416` slices
+- Started branch `codex/task105-json-rpc-transport-20260413` for the next `TASK-105` slice.
+- Added a JSON-RPC envelope transport for desktop summary/explain calls:
+  - `winsmux-app/src/desktopClient.ts` now defaults to a single `desktop_json_rpc` Tauri command instead of per-method `invoke(...)`
+  - `winsmux-app/src-tauri/src/desktop_backend.rs` now validates JSON-RPC `2.0`, dispatches `desktop.summary.snapshot` / `desktop.run.explain`, and returns structured `result/error` responses
+  - `winsmux-app/src-tauri/src/lib.rs` now exposes `desktop_json_rpc` while keeping the older per-command handlers available
 - Landed `TASK-216` slice 1 and slice 2 on `main`:
   - PR #408: leaf wrapper consolidation for `commander-poll`, `pane-status`, and `pane-control`
   - PR #409: wrapper-based `orchestra-layout` session/window/pane flow
@@ -118,6 +130,13 @@
 - `git diff --check` -> warnings only for CRLF normalization, no substantive errors
 - PR #415 CI -> green (`Pester Tests`)
 - `gh pr merge 415 --merge --delete-branch` -> PASS
+- external planning `backlog.yaml` update + `sync-roadmap.ps1` -> PASS
+- `npm run build` in `winsmux-app` -> PASS after `desktop_json_rpc` transport wiring
+- `cargo fmt` in `winsmux-app/src-tauri` -> PASS after JSON-RPC dispatch formatting
+- `cargo check` in `winsmux-app/src-tauri` -> PASS after JSON-RPC dispatch wiring
+- `cargo test --lib` in `winsmux-app/src-tauri` -> PASS (JSON-RPC dispatch tests added)
+- Fresh reviewer `Euler` -> `no result yet` after a 35s wait; closed without result
+- Manual diff review completed for the JSON-RPC envelope transport slice
 - `npm run build` in `winsmux-app` -> PASS after PTY seam extraction, desktop backend extraction, and dynamic source filters
 - `cargo fmt --check` in `winsmux-app/src-tauri` -> PASS after backend extraction
 - `cargo check` in `winsmux-app/src-tauri` -> PASS after backend extraction
@@ -165,9 +184,9 @@
 
 ## Next actions
 
-1. Open a follow-up PR for the PTY seam + `desktop-summary` backend aggregation slice on `codex/task105-desktop-summary-pty-20260413`.
-2. Continue `TASK-105` by swapping a concrete JSON-RPC transport under `desktopClient.ts` / `desktop_backend.rs` instead of the current PowerShell-backed transports.
-3. Continue `TASK-107` by removing remaining seeded runtime fallback state and by adding a real file preview/read surface for the secondary editor.
+1. Open a follow-up PR for the JSON-RPC envelope slice on `codex/task105-json-rpc-transport-20260413`.
+2. Continue `TASK-105` by replacing the current `PwshScriptTransport` behind `desktop_json_rpc` with a long-lived MCP/JSON-RPC backend client.
+3. Continue `TASK-291` / `TASK-107` by removing remaining seeded runtime fallback state and by adding a real file preview/read surface for the secondary editor.
 
 ## Notes
 

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -1,6 +1,6 @@
 # Handoff
 
-> Updated: 2026-04-14T04:30:00+09:00
+> Updated: 2026-04-14T04:45:00+09:00
 > Source of truth: this file
 
 ## Current state
@@ -122,6 +122,9 @@
   - `appendFallbackExplain()` copy is now shorter and backend-digest-first, without the older explanatory placeholder wording
   - the secondary editor empty state now uses neutral waiting copy instead of source-metadata-like placeholders
   - `refreshDesktopSummary()` now prefetches explain only on first load, selected-run change, cold cache, or explicit explain requests, instead of every material summary change
+- Continued `TASK-291 / TASK-107` on the editor hydration path:
+  - `findEditorFile()` now returns a neutral loading/error body instead of a synthetic metadata block when the backend file content is not cached yet
+  - `renderEditorSurface()` now triggers `ensureEditorFileLoaded()` as soon as the selected editor target is known, so backend preview loading starts without waiting for a second interaction
 - Added a durable Rust learning-note rule to `AGENTS.md` for future handoffs:
   - when a session uses Rust / Cargo / Tauri commands during winsmux work, handoff must also update `C:\Users\komei\iCloudDrive\iCloud~md~obsidian\MainVault\Learning\Rust Commands - winsmux.md`
   - the note is kept outside the repo, stays beginner-friendly, and should be updated in the same session rather than deferred
@@ -224,6 +227,11 @@
 - Manual diff review was used provisionally after the initial 30s wait, then superseded by the delayed `PASS` before packaging
 - `npm run build` in `winsmux-app` -> PASS after narrowing explain copy, editor idle copy, and explain prefetch conditions
 - `npm run test:editor-targets` in `winsmux-app` -> PASS after the same narrow follow-up
+- `npm run build` in `winsmux-app` -> PASS after neutralizing editor hydration placeholders and starting selected-target loads eagerly
+- `npm run test:editor-targets` in `winsmux-app` -> PASS after the same editor hydration follow-up
+- `/review` follow-up via subagent `Helmholtz` -> `PASS` on the editor hydration slice:
+  - eager selected-target loading is guarded by `desktopEditorFileCache` / `desktopEditorLoadingPaths` and stays consistent with `ensureEditorFileLoaded()`
+  - `findEditorFile()` now stays backend-truth-focused by returning a neutral loading/error body instead of synthetic metadata
 - `/review` follow-up via `codex exec` -> `REQUEST_CHANGES`, then `APPROVE` after:
   - preferring `launch_dir` over stale `builder_worktree_path`
   - relativizing explicit worktrees against `session.project_dir`

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -1,6 +1,6 @@
 # Handoff
 
-> Updated: 2026-04-14T04:15:00+09:00
+> Updated: 2026-04-14T04:30:00+09:00
 > Source of truth: this file
 
 ## Current state
@@ -118,6 +118,10 @@
 - Continued the narrower `TASK-291 / TASK-107` cleanup after that review:
   - `appendFallbackExplain()` now falls back to current digest counts and next action instead of the older generic placeholder copy when explain loading fails
   - source summary and secondary-editor metadata surfacing were both pared back after review so the `v0.22.0` slice stays out of `TASK-290` territory
+- Continued the same narrow lane without reintroducing detail UX:
+  - `appendFallbackExplain()` copy is now shorter and backend-digest-first, without the older explanatory placeholder wording
+  - the secondary editor empty state now uses neutral waiting copy instead of source-metadata-like placeholders
+  - `refreshDesktopSummary()` now prefetches explain only on first load, selected-run change, cold cache, or explicit explain requests, instead of every material summary change
 - Added a durable Rust learning-note rule to `AGENTS.md` for future handoffs:
   - when a session uses Rust / Cargo / Tauri commands during winsmux work, handoff must also update `C:\Users\komei\iCloudDrive\iCloud~md~obsidian\MainVault\Learning\Rust Commands - winsmux.md`
   - the note is kept outside the repo, stays beginner-friendly, and should be updated in the same session rather than deferred
@@ -218,6 +222,8 @@
 - Fresh reviewer `Poincare` -> `FAIL`; editor empty-state metadata surfacing was also classified as `TASK-290` UX drift and reverted from the `v0.22.0` lane
 - Fresh reviewer `Carson` -> `PASS` on the narrowed explain-fallback / metadata-reduction follow-up after delayed completion
 - Manual diff review was used provisionally after the initial 30s wait, then superseded by the delayed `PASS` before packaging
+- `npm run build` in `winsmux-app` -> PASS after narrowing explain copy, editor idle copy, and explain prefetch conditions
+- `npm run test:editor-targets` in `winsmux-app` -> PASS after the same narrow follow-up
 - `/review` follow-up via `codex exec` -> `REQUEST_CHANGES`, then `APPROVE` after:
   - preferring `launch_dir` over stale `builder_worktree_path`
   - relativizing explicit worktrees against `session.project_dir`

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -1,6 +1,6 @@
 # Handoff
 
-> Updated: 2026-04-14T04:45:00+09:00
+> Updated: 2026-04-14T05:20:00+09:00
 > Source of truth: this file
 
 ## Current state
@@ -125,6 +125,10 @@
 - Continued `TASK-291 / TASK-107` on the editor hydration path:
   - `findEditorFile()` now returns a neutral loading/error body instead of a synthetic metadata block when the backend file content is not cached yet
   - `renderEditorSurface()` now triggers `ensureEditorFileLoaded()` as soon as the selected editor target is known, so backend preview loading starts without waiting for a second interaction
+- Continued `TASK-289` on the summary follow-through path:
+  - the 15s desktop summary refresh now skips background tabs and relies on `focus` / `visibilitychange` for catch-up when the shell becomes visible again
+  - `getRunProjectionFingerprint()` no longer treats projection summary copy alone as a material change
+  - `refreshDesktopSummary()` now refreshes the selected run explain cache when that run shows a material projection change, instead of relying on copy churn
 - Added a durable Rust learning-note rule to `AGENTS.md` for future handoffs:
   - when a session uses Rust / Cargo / Tauri commands during winsmux work, handoff must also update `C:\Users\komei\iCloudDrive\iCloud~md~obsidian\MainVault\Learning\Rust Commands - winsmux.md`
   - the note is kept outside the repo, stays beginner-friendly, and should be updated in the same session rather than deferred
@@ -232,6 +236,11 @@
 - `/review` follow-up via subagent `Helmholtz` -> `PASS` on the editor hydration slice:
   - eager selected-target loading is guarded by `desktopEditorFileCache` / `desktopEditorLoadingPaths` and stays consistent with `ensureEditorFileLoaded()`
   - `findEditorFile()` now stays backend-truth-focused by returning a neutral loading/error body instead of synthetic metadata
+- `npm run build` in `winsmux-app` -> PASS after trimming background polling and moving explain prefetch onto material selected-run changes
+- `npm run test:editor-targets` in `winsmux-app` -> PASS after the same `TASK-289` follow-through refinement
+- `/review` follow-up via subagent `Popper` -> delayed `PASS` on the `TASK-289` polling/material-change slice after the initial 30s wait
+  - the provisional manual diff review was superseded by the delayed `PASS`
+  - the reviewed slice stayed scoped to skipping hidden-tab interval refresh, removing `projection.summary` from material-change fingerprinting, and refreshing selected-run explain only when that run itself shows a material projection change
 - `/review` follow-up via `codex exec` -> `REQUEST_CHANGES`, then `APPROVE` after:
   - preferring `launch_dir` over stale `builder_worktree_path`
   - relativizing explicit worktrees against `session.project_dir`

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -1,6 +1,6 @@
 # Handoff
 
-> Updated: 2026-04-14T01:25:00+09:00
+> Updated: 2026-04-14T02:20:00+09:00
 > Source of truth: this file
 
 ## Current state
@@ -8,6 +8,7 @@
 - `v0.20.0`, `v0.20.1`, `v0.20.2`, `v0.20.3`, `v0.21.0`, `v0.21.1`, and `v0.21.2` are released.
 - `v0.21.2` shipped as the terminal-based final form release before the `v0.22.0` Tauri control-plane handoff.
 - `v0.22.0` remains on the shortest active path of `TASK-105 -> TASK-291 -> TASK-289`, with the current branch carrying the backend transport convergence work.
+- The current `v0.22.0` slice on `codex/task105-json-rpc-transport-20260413` is now focused on `TASK-290` richer detail surfaces and `TASK-289` material-event follow-through, while keeping roadmap sync and handoff discipline aligned with the root planning lane.
 - `ROADMAP.md` shows `v0.21.2 = 100% (2/2)` with only:
   - `TASK-216` terminal hot-path wrapper baseline
   - `TASK-295` winsmux-surface rename cleanup slice
@@ -103,6 +104,15 @@
   - source context, run summary, Explain, and secondary editor now follow the selected backend run instead of a seeded timeline fallback
   - the workspace Explorer now builds from projection-derived changed files and standalone editor targets, replacing the old static sample file tree
   - desktop summary refresh now runs on startup, focus, visibility restore, and a 15s polling interval so the shell follows live inbox/digest movement rather than one-shot hydration
+- Continued the same `codex/task105-json-rpc-transport-20260413` slice toward `TASK-290 / TASK-289`:
+  - `scripts/winsmux-core.ps1` now carries richer run-projection detail through desktop summary output, including `provider_target`, `head_sha`, `head_short`, `hypothesis`, `confidence`, `observation_pack_ref`, and `consultation_ref`
+  - `winsmux-app/src/desktopClient.ts` and `winsmux-app/src-tauri/src/desktop_backend.rs` now accept the richer detail DTO shape so the frontend can render it without ad hoc casts
+  - `winsmux-app/src/main.ts` now builds selected-run detail cards, changed-file pills, and recent-event cards from the backend detail surfaces instead of seeded placeholder metadata
+  - desktop follow-through now compares the previous and next summary snapshots and only appends runtime activity when there is a material change in run projection or inbox count
+- Added a durable Rust learning-note rule to `AGENTS.md` for future handoffs:
+  - when a session uses Rust / Cargo / Tauri commands during winsmux work, handoff must also update `C:\Users\komei\iCloudDrive\iCloud~md~obsidian\MainVault\Learning\Rust Commands - winsmux.md`
+  - the note is kept outside the repo, stays beginner-friendly, and should be updated in the same session rather than deferred
+- Initialized the external learning note at `C:\Users\komei\iCloudDrive\iCloud~md~obsidian\MainVault\Learning\Rust Commands - winsmux.md` with starter entries for `cargo check`, `cargo test --lib`, `cargo fmt`, `cargo fmt --check`, `cargo build`, and `cargo tauri dev`
 - Landed `TASK-216` slice 1 and slice 2 on `main`:
   - PR #408: leaf wrapper consolidation for `commander-poll`, `pane-status`, and `pane-control`
   - PR #409: wrapper-based `orchestra-layout` session/window/pane flow
@@ -171,6 +181,14 @@
 - root `winsmux-core/scripts/sync-roadmap.ps1` -> PASS (roadmap + internal docs regenerated with no planning drift introduced by this slice)
 - Fresh reviewer `Tesla` -> `PASS` for the selected-run / live-follow slice after delayed completion
 - Manual diff review also completed for the selected-run / live-follow slice
+- `npm run build` in `winsmux-app` -> PASS after richer detail DTO wiring and material-event desktop follow-through
+- `npm run test:editor-targets` in `winsmux-app` -> PASS after the same slice
+- `cargo test --lib` in `winsmux-app/src-tauri` -> PASS (`10 passed`) after detail DTO contract expansion
+- `Invoke-Pester tests/winsmux-bridge.Tests.ps1 -CI` -> `171/171 PASS` after the same slice
+- `git diff --check` -> warnings only for CRLF normalization, no substantive errors
+- Fresh reviewer `Pascal` -> `FAIL`; follow-through fingerprints and removed-run handling were corrected before packaging
+- Fresh reviewer `Nietzsche` -> `no result yet` after a 30s wait on the corrected slice
+- Manual diff review completed for the corrected richer detail DTO / material-event follow-through slice
 - `/review` follow-up via `codex exec` -> `REQUEST_CHANGES`, then `APPROVE` after:
   - preferring `launch_dir` over stale `builder_worktree_path`
   - relativizing explicit worktrees against `session.project_dir`
@@ -219,10 +237,10 @@
 
 ## Next actions
 
-1. Update PR #417 from `codex/task105-json-rpc-transport-20260413` with the selected-run / live-follow slice and describe the remaining `TASK-291 / TASK-289` delta explicitly.
-2. Continue `TASK-291 / TASK-107` by converging the secondary editor on richer real detail DTOs (test results, review verdict, branch/head cards) instead of placeholder preview metadata.
-3. Continue `TASK-289` by replacing polling-only follow-through with material-event subscription or narrower refresh triggers once the backend stream shape is ready.
-4. Keep root-repo planning-sync diffs separate from this worktree slice; the root-side `main.ts` / `ptyClient.ts` / `desktop_backend.rs` changes are a divergent lane and were not auto-cleaned.
+1. Update PR #417 from `codex/task105-json-rpc-transport-20260413` with the richer detail DTO / material-event follow-through slice and record the reviewer result once it lands.
+2. Continue `TASK-290` by extending the secondary editor and detail surface with more real backend fields such as verification contract/result, security verdict, and action items where they improve operator judgment.
+3. Continue `TASK-289` by reducing polling dependence further, either with narrower refresh triggers or a backend event surface once the transport shape is ready.
+4. Keep the new Rust learning note current during future handoffs whenever Rust / Cargo / Tauri commands are used in the session.
 
 ## Notes
 
@@ -232,3 +250,4 @@
 - Public GitHub Releases stay English, use Codex-style headings, and keep inline issue/PR refs visible.
 - Review gate for this slice was satisfied after a second `/review` pass returned `APPROVE`; the intermediate `REQUEST_CHANGES` findings were incorporated before continuing.
 - Reviewer `Tesla` initially timed out after the required 35s wait, so work proceeded under the manual-diff fallback gate; the delayed reviewer result later arrived as `PASS` before packaging the slice.
+- The external learning note under `MainVault\Learning` is intentionally untracked; only the durable handoff rule in `AGENTS.md` is part of the repo.

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -196,8 +196,11 @@
 - `npm run build` in `winsmux-app` -> PASS after verification/security/action detail-card expansion
 - `npm run test:editor-targets` in `winsmux-app` -> PASS after verification/security/action detail-card expansion
 - root `winsmux-core/scripts/sync-roadmap.ps1` -> PASS after the same slice (no planning drift)
-- Fresh reviewer `Hooke` -> `no result yet` after a 30s wait on the verification/security/action detail slice
-- Manual diff review completed for the verification/security/action detail slice
+- Fresh reviewer `Hooke` -> `FAIL`; detail-card priority and explain fingerprint coverage were corrected before packaging
+- `npm run build` in `winsmux-app` -> PASS after the Hooke follow-up fixes
+- `npm run test:editor-targets` in `winsmux-app` -> PASS after the Hooke follow-up fixes
+- Fresh reviewer `Bohr` -> `no result yet` after a 30s wait on the corrected detail-card/fingerprint follow-up
+- Manual diff review completed for the corrected verification/security/action detail slice
 - `/review` follow-up via `codex exec` -> `REQUEST_CHANGES`, then `APPROVE` after:
   - preferring `launch_dir` over stale `builder_worktree_path`
   - relativizing explicit worktrees against `session.project_dir`

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -1,6 +1,6 @@
 # Handoff
 
-> Updated: 2026-04-14T02:20:00+09:00
+> Updated: 2026-04-14T02:45:00+09:00
 > Source of truth: this file
 
 ## Current state
@@ -109,6 +109,10 @@
   - `winsmux-app/src/desktopClient.ts` and `winsmux-app/src-tauri/src/desktop_backend.rs` now accept the richer detail DTO shape so the frontend can render it without ad hoc casts
   - `winsmux-app/src/main.ts` now builds selected-run detail cards, changed-file pills, and recent-event cards from the backend detail surfaces instead of seeded placeholder metadata
   - desktop follow-through now compares the previous and next summary snapshots and only appends runtime activity when there is a material change in run projection or inbox count
+- Extended the same `TASK-290` detail slice without changing the backend command surface:
+  - `winsmux-app/src/desktopClient.ts` now types `action_items`, `verification_contract`, `verification_result`, `security_policy`, and `security_verdict` from the already-present explain payload
+  - `winsmux-app/src/main.ts` now summarizes verification detail, security detail, and the top action item into the existing selected-run detail grid so operators can judge next steps without opening deeper payloads
+  - explain/follow-through fingerprints now include those new detail fields, so a verification, security, or action-item-only change is treated as material
 - Added a durable Rust learning-note rule to `AGENTS.md` for future handoffs:
   - when a session uses Rust / Cargo / Tauri commands during winsmux work, handoff must also update `C:\Users\komei\iCloudDrive\iCloud~md~obsidian\MainVault\Learning\Rust Commands - winsmux.md`
   - the note is kept outside the repo, stays beginner-friendly, and should be updated in the same session rather than deferred
@@ -189,6 +193,11 @@
 - Fresh reviewer `Pascal` -> `FAIL`; follow-through fingerprints and removed-run handling were corrected before packaging
 - Fresh reviewer `Nietzsche` -> `no result yet` after a 30s wait on the corrected slice
 - Manual diff review completed for the corrected richer detail DTO / material-event follow-through slice
+- `npm run build` in `winsmux-app` -> PASS after verification/security/action detail-card expansion
+- `npm run test:editor-targets` in `winsmux-app` -> PASS after verification/security/action detail-card expansion
+- root `winsmux-core/scripts/sync-roadmap.ps1` -> PASS after the same slice (no planning drift)
+- Fresh reviewer `Hooke` -> `no result yet` after a 30s wait on the verification/security/action detail slice
+- Manual diff review completed for the verification/security/action detail slice
 - `/review` follow-up via `codex exec` -> `REQUEST_CHANGES`, then `APPROVE` after:
   - preferring `launch_dir` over stale `builder_worktree_path`
   - relativizing explicit worktrees against `session.project_dir`
@@ -237,8 +246,8 @@
 
 ## Next actions
 
-1. Update PR #417 from `codex/task105-json-rpc-transport-20260413` with the richer detail DTO / material-event follow-through slice and record the reviewer result once it lands.
-2. Continue `TASK-290` by extending the secondary editor and detail surface with more real backend fields such as verification contract/result, security verdict, and action items where they improve operator judgment.
+1. Update PR #417 from `codex/task105-json-rpc-transport-20260413` with the verification/security/action detail extension and record the fresh reviewer result once it lands.
+2. Continue `TASK-290` by extending the secondary editor and detail surface with deeper evidence links or action chips where they improve operator judgment without bloating the shell.
 3. Continue `TASK-289` by reducing polling dependence further, either with narrower refresh triggers or a backend event surface once the transport shape is ready.
 4. Keep the new Rust learning note current during future handoffs whenever Rust / Cargo / Tauri commands are used in the session.
 

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -1,6 +1,6 @@
 # Handoff
 
-> Updated: 2026-04-14T02:45:00+09:00
+> Updated: 2026-04-14T03:00:00+09:00
 > Source of truth: this file
 
 ## Current state
@@ -113,6 +113,10 @@
   - `winsmux-app/src/desktopClient.ts` now types `action_items`, `verification_contract`, `verification_result`, `security_policy`, and `security_verdict` from the already-present explain payload
   - `winsmux-app/src/main.ts` now summarizes verification detail, security detail, and the top action item into the existing selected-run detail grid so operators can judge next steps without opening deeper payloads
   - explain/follow-through fingerprints now include those new detail fields, so a verification, security, or action-item-only change is treated as material
+- Continued the same `TASK-290 / TASK-289` follow-up in `winsmux-app/src/main.ts`:
+  - the selected-run summary now adds conditional action chips for `Open in Editor` and `Open Audit` while reusing the existing chip-action plumbing instead of introducing a new surface
+  - `refreshDesktopSummary()` now skips explain prefetch on unchanged polling/focus/visibility refreshes unless the selected run changed, the cache is cold, or the refresh was forced
+  - focus/visibility triggers remain in place, but redundant backend explain calls are reduced on steady-state shells
 - Added a durable Rust learning-note rule to `AGENTS.md` for future handoffs:
   - when a session uses Rust / Cargo / Tauri commands during winsmux work, handoff must also update `C:\Users\komei\iCloudDrive\iCloud~md~obsidian\MainVault\Learning\Rust Commands - winsmux.md`
   - the note is kept outside the repo, stays beginner-friendly, and should be updated in the same session rather than deferred
@@ -201,6 +205,10 @@
 - `npm run test:editor-targets` in `winsmux-app` -> PASS after the Hooke follow-up fixes
 - Fresh reviewer `Bohr` -> `no result yet` after a 30s wait on the corrected detail-card/fingerprint follow-up
 - Manual diff review completed for the corrected verification/security/action detail slice
+- `npm run build` in `winsmux-app` -> PASS after conditional action-chip wiring and explain-prefetch gating
+- `npm run test:editor-targets` in `winsmux-app` -> PASS after conditional action-chip wiring and explain-prefetch gating
+- Fresh reviewer `Kierkegaard` -> `no result yet` after a 30s wait on the action-chip / prefetch-gating follow-up
+- Manual diff review completed for the action-chip / prefetch-gating follow-up
 - `/review` follow-up via `codex exec` -> `REQUEST_CHANGES`, then `APPROVE` after:
   - preferring `launch_dir` over stale `builder_worktree_path`
   - relativizing explicit worktrees against `session.project_dir`
@@ -249,8 +257,8 @@
 
 ## Next actions
 
-1. Update PR #417 from `codex/task105-json-rpc-transport-20260413` with the verification/security/action detail extension and record the fresh reviewer result once it lands.
-2. Continue `TASK-290` by extending the secondary editor and detail surface with deeper evidence links or action chips where they improve operator judgment without bloating the shell.
+1. Update PR #417 from `codex/task105-json-rpc-transport-20260413` with the action-chip and prefetch-gating follow-up and record the fresh reviewer result once it lands.
+2. Continue `TASK-290` by extending the secondary editor and detail surface with deeper evidence links or richer action chips only where they improve operator judgment without bloating the shell.
 3. Continue `TASK-289` by reducing polling dependence further, either with narrower refresh triggers or a backend event surface once the transport shape is ready.
 4. Keep the new Rust learning note current during future handoffs whenever Rust / Cargo / Tauri commands are used in the session.
 

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -1,12 +1,13 @@
 # Handoff
 
-> Updated: 2026-04-13T19:58:21+09:00
+> Updated: 2026-04-13T21:20:32+09:00
 > Source of truth: this file
 
 ## Current state
 
 - `v0.20.0`, `v0.20.1`, `v0.20.2`, `v0.20.3`, `v0.21.0`, `v0.21.1`, and `v0.21.2` are released.
 - `v0.21.2` shipped as the terminal-based final form release before the `v0.22.0` Tauri control-plane handoff.
+- `v0.22.0` remains on the shortest active path of `TASK-105 -> TASK-291 -> TASK-289`, with the current branch carrying the backend transport convergence work.
 - `ROADMAP.md` shows `v0.21.2 = 100% (2/2)` with only:
   - `TASK-216` terminal hot-path wrapper baseline
   - `TASK-295` winsmux-surface rename cleanup slice
@@ -89,6 +90,10 @@
   - `winsmux-app/src/desktopClient.ts` now defaults to a single `desktop_json_rpc` Tauri command instead of per-method `invoke(...)`
   - `winsmux-app/src-tauri/src/desktop_backend.rs` now validates JSON-RPC `2.0`, dispatches `desktop.summary.snapshot` / `desktop.run.explain`, and returns structured `result/error` responses
   - `winsmux-app/src-tauri/src/lib.rs` now exposes `desktop_json_rpc` while keeping the older per-command handlers available
+- Continued `TASK-105` on `codex/task105-json-rpc-transport-20260413` by converging PTY pane lifecycle calls on the same single-call pattern:
+  - `winsmux-app/src/ptyClient.ts` now sends `pty.spawn` / `pty.write` / `pty.resize` / `pty.close` through one `pty_json_rpc` Tauri command instead of per-method `invoke(...)`
+  - `winsmux-app/src-tauri/src/pty_backend.rs` now validates JSON-RPC `2.0`, parses PTY params, and returns structured `result/error` responses for PTY lifecycle requests
+  - `winsmux-app/src-tauri/src/lib.rs` now routes both `pty_json_rpc` and the legacy per-command handlers through shared PTY helpers, so the transport boundary changed without breaking compatibility
 - Landed `TASK-216` slice 1 and slice 2 on `main`:
   - PR #408: leaf wrapper consolidation for `commander-poll`, `pane-status`, and `pane-control`
   - PR #409: wrapper-based `orchestra-layout` session/window/pane flow
@@ -142,6 +147,13 @@
 - `cargo check` in `winsmux-app/src-tauri` -> PASS after backend extraction
 - `cargo test --lib` in `winsmux-app/src-tauri` -> PASS (desktop backend transport tests)
 - targeted temp-project harness for `winsmux-core.ps1 desktop-summary --json` -> PASS
+- `cargo fmt` in `winsmux-app/src-tauri` -> PASS after PTY JSON-RPC routing
+- `cargo check` in `winsmux-app/src-tauri` -> PASS after PTY JSON-RPC routing
+- `cargo test --lib` in `winsmux-app/src-tauri` -> PASS (`8 passed`, PTY JSON-RPC dispatch tests added)
+- `npm run build` in `winsmux-app` -> PASS after `pty_json_rpc` client wiring
+- `Invoke-Pester tests/winsmux-bridge.Tests.ps1` -> `167/167 PASS` after the PTY JSON-RPC slice
+- Fresh reviewer `Kepler` -> `no result yet` after a 30s wait; closed without result
+- Manual diff review completed for the PTY JSON-RPC transport slice
 - `git diff --check` -> warnings only for CRLF normalization, no substantive errors
 - Fresh reviewer `Dewey` -> `PASS` for the projection-driven source-context slice in PR #412
 - Fresh reviewer `Herschel` -> `FAIL`; backend heuristic join removed after review
@@ -184,9 +196,9 @@
 
 ## Next actions
 
-1. Open a follow-up PR for the JSON-RPC envelope slice on `codex/task105-json-rpc-transport-20260413`.
-2. Continue `TASK-105` by replacing the current `PwshScriptTransport` behind `desktop_json_rpc` with a long-lived MCP/JSON-RPC backend client.
-3. Continue `TASK-291` / `TASK-107` by removing remaining seeded runtime fallback state and by adding a real file preview/read surface for the secondary editor.
+1. Open or update the follow-up PR for the current `TASK-105` transport-convergence slice on `codex/task105-json-rpc-transport-20260413`.
+2. Continue `TASK-291` / `TASK-107` by removing remaining seeded runtime fallback state and by adding a real file preview/read surface for the secondary editor.
+3. Continue `TASK-289` by replacing the remaining one-shot digest/explain hydration with live inbox/digest follow-through in the desktop shell.
 
 ## Notes
 

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -1,6 +1,6 @@
 # Handoff
 
-> Updated: 2026-04-14T03:00:00+09:00
+> Updated: 2026-04-14T03:35:00+09:00
 > Source of truth: this file
 
 ## Current state
@@ -8,7 +8,7 @@
 - `v0.20.0`, `v0.20.1`, `v0.20.2`, `v0.20.3`, `v0.21.0`, `v0.21.1`, and `v0.21.2` are released.
 - `v0.21.2` shipped as the terminal-based final form release before the `v0.22.0` Tauri control-plane handoff.
 - `v0.22.0` remains on the shortest active path of `TASK-105 -> TASK-291 -> TASK-289`, with the current branch carrying the backend transport convergence work.
-- The current `v0.22.0` slice on `codex/task105-json-rpc-transport-20260413` is now focused on `TASK-290` richer detail surfaces and `TASK-289` material-event follow-through, while keeping roadmap sync and handoff discipline aligned with the root planning lane.
+- The current `v0.22.0` slice on `codex/task105-json-rpc-transport-20260413` is back on `TASK-105 / TASK-291 / TASK-289`; the richer `TASK-290` detail UX now lives on `codex/task290-detail-lane-20260414` so `v0.22.1` keeps that scope.
 - `ROADMAP.md` shows `v0.21.2 = 100% (2/2)` with only:
   - `TASK-216` terminal hot-path wrapper baseline
   - `TASK-295` winsmux-surface rename cleanup slice
@@ -109,14 +109,10 @@
   - `winsmux-app/src/desktopClient.ts` and `winsmux-app/src-tauri/src/desktop_backend.rs` now accept the richer detail DTO shape so the frontend can render it without ad hoc casts
   - `winsmux-app/src/main.ts` now builds selected-run detail cards, changed-file pills, and recent-event cards from the backend detail surfaces instead of seeded placeholder metadata
   - desktop follow-through now compares the previous and next summary snapshots and only appends runtime activity when there is a material change in run projection or inbox count
-- Extended the same `TASK-290` detail slice without changing the backend command surface:
-  - `winsmux-app/src/desktopClient.ts` now types `action_items`, `verification_contract`, `verification_result`, `security_policy`, and `security_verdict` from the already-present explain payload
-  - `winsmux-app/src/main.ts` now summarizes verification detail, security detail, and the top action item into the existing selected-run detail grid so operators can judge next steps without opening deeper payloads
-  - explain/follow-through fingerprints now include those new detail fields, so a verification, security, or action-item-only change is treated as material
-- Continued the same `TASK-290 / TASK-289` follow-up in `winsmux-app/src/main.ts`:
-  - the selected-run summary now adds conditional action chips for `Open in Editor` and `Open Audit` while reusing the existing chip-action plumbing instead of introducing a new surface
-  - `refreshDesktopSummary()` now skips explain prefetch on unchanged polling/focus/visibility refreshes unless the selected run changed, the cache is cold, or the refresh was forced
-  - focus/visibility triggers remain in place, but redundant backend explain calls are reduced on steady-state shells
+- Re-sorted the version boundary after the detail UX drift was identified:
+  - created `codex/task290-detail-lane-20260414` and moved the selected-run editor targeting change there
+  - removed the selected-run detail grid, action chips, and verification/security/action-item summarization from the `v0.22.0` branch
+  - kept the `TASK-289 / TASK-291` pieces on `codex/task105-json-rpc-transport-20260413`: material-change follow-through and narrower explain prefetch on unchanged refreshes
 - Added a durable Rust learning-note rule to `AGENTS.md` for future handoffs:
   - when a session uses Rust / Cargo / Tauri commands during winsmux work, handoff must also update `C:\Users\komei\iCloudDrive\iCloud~md~obsidian\MainVault\Learning\Rust Commands - winsmux.md`
   - the note is kept outside the repo, stays beginner-friendly, and should be updated in the same session rather than deferred
@@ -209,6 +205,8 @@
 - `npm run test:editor-targets` in `winsmux-app` -> PASS after conditional action-chip wiring and explain-prefetch gating
 - Fresh reviewer `Kierkegaard` -> `no result yet` after a 30s wait on the action-chip / prefetch-gating follow-up
 - Manual diff review completed for the action-chip / prefetch-gating follow-up
+- `npm run build` in `winsmux-app` -> PASS after splitting `TASK-290` detail UX back out of the `v0.22.0` branch
+- `npm run test:editor-targets` in `winsmux-app` -> PASS after the same boundary cleanup
 - `/review` follow-up via `codex exec` -> `REQUEST_CHANGES`, then `APPROVE` after:
   - preferring `launch_dir` over stale `builder_worktree_path`
   - relativizing explicit worktrees against `session.project_dir`
@@ -257,10 +255,11 @@
 
 ## Next actions
 
-1. Update PR #417 from `codex/task105-json-rpc-transport-20260413` with the action-chip and prefetch-gating follow-up and record the fresh reviewer result once it lands.
-2. Continue `TASK-290` by extending the secondary editor and detail surface with deeper evidence links or richer action chips only where they improve operator judgment without bloating the shell.
+1. Update PR #417 from `codex/task105-json-rpc-transport-20260413` with the `v0.22.0` boundary cleanup and verify that only `TASK-105 / TASK-291 / TASK-289` scope remains on the branch.
+2. Continue `TASK-291 / TASK-107` by removing the remaining seeded fallback paths without re-expanding the selected-run detail surface.
 3. Continue `TASK-289` by reducing polling dependence further, either with narrower refresh triggers or a backend event surface once the transport shape is ready.
-4. Keep the new Rust learning note current during future handoffs whenever Rust / Cargo / Tauri commands are used in the session.
+4. Resume `TASK-290` later from `codex/task290-detail-lane-20260414`, after `v0.22.0` closes.
+5. Keep the new Rust learning note current during future handoffs whenever Rust / Cargo / Tauri commands are used in the session.
 
 ## Notes
 
@@ -271,3 +270,4 @@
 - Review gate for this slice was satisfied after a second `/review` pass returned `APPROVE`; the intermediate `REQUEST_CHANGES` findings were incorporated before continuing.
 - Reviewer `Tesla` initially timed out after the required 35s wait, so work proceeded under the manual-diff fallback gate; the delayed reviewer result later arrived as `PASS` before packaging the slice.
 - The external learning note under `MainVault\Learning` is intentionally untracked; only the durable handoff rule in `AGENTS.md` is part of the repo.
+- `TASK-290` remains a `v0.22.1` task; only the minimum observability needed for `TASK-289 / TASK-291` stays on the `v0.22.0` branch.

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -3066,6 +3066,7 @@ function Get-BoardPayload {
                 task_owner         = $_.TaskOwner
                 review_state       = $_.ReviewState
                 branch             = $_.Branch
+                worktree           = if ($null -ne $_.PSObject.Properties['Worktree']) { [string]$_.Worktree } else { '' }
                 head_sha           = $_.HeadSha
                 changed_file_count = $_.ChangedFileCount
                 changed_files      = @($_.ChangedFiles)
@@ -4011,6 +4012,7 @@ function Get-RunsPayload {
                 task_state         = [string]$pane.task_state
                 review_state       = [string]$pane.review_state
                 branch             = [string]$pane.branch
+                worktree           = [string]$pane.worktree
                 head_sha           = [string]$pane.head_sha
                 primary_label      = [string]$pane.label
                 primary_pane_id    = [string]$pane.pane_id
@@ -4070,6 +4072,9 @@ function Get-RunsPayload {
         }
         if ([string]::IsNullOrWhiteSpace([string]$run.expected_output) -and -not [string]::IsNullOrWhiteSpace([string]$pane.expected_output)) {
             $run.expected_output = [string]$pane.expected_output
+        }
+        if ([string]::IsNullOrWhiteSpace([string]$run.worktree) -and -not [string]::IsNullOrWhiteSpace([string]$pane.worktree)) {
+            $run.worktree = [string]$pane.worktree
         }
         if (-not [bool]$run.review_required -and [bool]$pane.review_required) {
             $run.review_required = $true
@@ -4201,6 +4206,7 @@ function Get-RunsPayload {
                 task_state         = [string]$run.task_state
                 review_state       = [string]$run.review_state
                 branch             = [string]$run.branch
+                worktree           = [string]$run.worktree
                 head_sha           = [string]$run.head_sha
                 primary_label      = [string]$run.primary_label
                 primary_pane_id    = [string]$run.primary_pane_id
@@ -4558,6 +4564,7 @@ function ConvertTo-EvidenceDigestItem {
         review_state       = [string]$Run.review_state
         next_action        = Get-RunNextAction -Run $Run
         branch             = [string]$Run.branch
+        worktree           = if ($null -ne $experimentPacket -and -not [string]::IsNullOrWhiteSpace([string]$experimentPacket.worktree)) { [string]$experimentPacket.worktree } else { [string]$Run.worktree }
         head_sha           = [string]$Run.head_sha
         head_short         = Get-ShortHeadSha -HeadSha ([string]$Run.head_sha)
         changed_file_count = [int]$Run.changed_file_count
@@ -4674,6 +4681,16 @@ function New-DesktopRunProjection {
     } else {
         [string]$DigestItem.branch
     }
+    $runWorktree = if ($null -ne $run) { [string]$run.worktree } else { '' }
+    if ([string]::IsNullOrWhiteSpace($runWorktree) -and $null -ne $run -and $null -ne $run.experiment_packet) {
+        $runWorktree = [string]$run.experiment_packet.worktree
+    }
+    $digestWorktree = if ($null -ne $DigestItem) { [string]$DigestItem.worktree } else { '' }
+    $worktree = if (-not [string]::IsNullOrWhiteSpace($runWorktree)) {
+        $runWorktree
+    } else {
+        $digestWorktree
+    }
     $changedFiles = if ($null -ne $evidenceDigest -and @($evidenceDigest.changed_files).Count -gt 0) {
         @($evidenceDigest.changed_files)
     } else {
@@ -4694,6 +4711,7 @@ function New-DesktopRunProjection {
         pane_id              = [string]$DigestItem.pane_id
         label                = [string]$DigestItem.label
         branch               = $branch
+        worktree             = $worktree
         task                 = $task
         task_state           = if ($null -ne $run -and -not [string]::IsNullOrWhiteSpace([string]$run.task_state)) { [string]$run.task_state } else { [string]$DigestItem.task_state }
         review_state         = if ($null -ne $run -and -not [string]::IsNullOrWhiteSpace([string]$run.review_state)) { [string]$run.review_state } else { [string]$DigestItem.review_state }

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -4560,6 +4560,7 @@ function ConvertTo-EvidenceDigestItem {
         label              = [string]$Run.primary_label
         pane_id            = [string]$Run.primary_pane_id
         role               = [string]$Run.primary_role
+        provider_target    = [string]$Run.provider_target
         task_state         = [string]$Run.task_state
         review_state       = [string]$Run.review_state
         next_action        = Get-RunNextAction -Run $Run
@@ -4712,6 +4713,9 @@ function New-DesktopRunProjection {
         label                = [string]$DigestItem.label
         branch               = $branch
         worktree             = $worktree
+        head_sha             = if ($null -ne $run -and -not [string]::IsNullOrWhiteSpace([string]$run.head_sha)) { [string]$run.head_sha } else { [string]$DigestItem.head_sha }
+        head_short           = if ($null -ne $run -and -not [string]::IsNullOrWhiteSpace([string]$run.head_sha)) { Get-ShortHeadSha -HeadSha ([string]$run.head_sha) } else { [string]$DigestItem.head_short }
+        provider_target      = [string]$DigestItem.provider_target
         task                 = $task
         task_state           = if ($null -ne $run -and -not [string]::IsNullOrWhiteSpace([string]$run.task_state)) { [string]$run.task_state } else { [string]$DigestItem.task_state }
         review_state         = if ($null -ne $run -and -not [string]::IsNullOrWhiteSpace([string]$run.review_state)) { [string]$run.review_state } else { [string]$DigestItem.review_state }
@@ -4721,6 +4725,10 @@ function New-DesktopRunProjection {
         next_action          = if ($null -ne $explanation -and -not [string]::IsNullOrWhiteSpace([string]$explanation.next_action)) { [string]$explanation.next_action } else { [string]$DigestItem.next_action }
         summary              = $summary
         reasons              = if ($null -ne $explanation) { @($explanation.reasons) } else { @() }
+        hypothesis           = [string]$DigestItem.hypothesis
+        confidence           = $DigestItem.confidence
+        observation_pack_ref = [string]$DigestItem.observation_pack_ref
+        consultation_ref     = [string]$DigestItem.consultation_ref
     }
 }
 

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -3286,6 +3286,7 @@ panes:
     task_owner: builder-1
     review_state: PENDING
     branch: worktree-builder-1
+    builder_worktree_path: .worktrees/builder-1
     head_sha: abc1234def5678
     changed_file_count: 2
     changed_files: '["winsmux-core/scripts/orchestra-state.ps1","winsmux-core/scripts/agent-monitor.ps1"]'
@@ -3313,6 +3314,79 @@ panes:
         )
         $records[0].LastEvent | Should -Be 'pane.ready'
         $records[0].LastEventAt | Should -Be '2026-04-09T12:00:00+09:00'
+    }
+
+    It 'infers a conventional worktree from branch and label when the manifest path is omitted' {
+        @'
+version: 1
+session:
+  name: winsmux-orchestra
+  project_dir: C:\repo
+panes:
+  - label: builder-1
+    pane_id: %2
+    role: Builder
+    task_id: task-243
+    task: Implement TASK-243
+    task_state: in_progress
+    review_state: PENDING
+    branch: worktree-builder-1
+'@ | Set-Content -Path (Join-Path (Join-Path $script:paneStatusTempRoot '.winsmux') 'manifest.yaml') -Encoding UTF8
+
+        $records = Get-PaneStatusRecords -ProjectDir $script:paneStatusTempRoot -SnapshotProvider {
+            param($PaneId)
+            'gpt-5.4   74% context left'
+        }
+
+        $records.Count | Should -Be 1
+        $records[0].Worktree | Should -Be '.worktrees/builder-1'
+    }
+
+    It 'prefers launch_dir over builder_worktree_path when both are present' {
+        @'
+version: 1
+session:
+  name: winsmux-orchestra
+  project_dir: C:\repo
+panes:
+  - label: builder-1
+    pane_id: %2
+    role: Builder
+    launch_dir: C:\repo\.worktrees\builder-9
+    builder_worktree_path: C:\repo\.worktrees\builder-1
+    branch: worktree-builder-1
+'@ | Set-Content -Path (Join-Path (Join-Path $script:paneStatusTempRoot '.winsmux') 'manifest.yaml') -Encoding UTF8
+
+        $records = Get-PaneStatusRecords -ProjectDir $script:paneStatusTempRoot -SnapshotProvider {
+            param($PaneId)
+            'gpt-5.4   74% context left'
+        }
+
+        $records.Count | Should -Be 1
+        $records[0].Worktree | Should -Be '.worktrees/builder-9'
+    }
+
+    It 'relativizes explicit worktrees against the manifest session project root' {
+        @'
+version: 1
+session:
+  name: winsmux-orchestra
+  project_dir: C:\repo
+panes:
+  - label: builder-1
+    pane_id: %2
+    role: Builder
+    builder_worktree_path: C:\repo\.worktrees\builder-1
+    branch: worktree-builder-1
+'@ | Set-Content -Path (Join-Path (Join-Path $script:paneStatusTempRoot '.winsmux') 'manifest.yaml') -Encoding UTF8
+
+        $records = Get-PaneStatusRecords -ProjectDir $script:paneStatusTempRoot -SnapshotProvider {
+            param($PaneId)
+            'gpt-5.4   74% context left'
+        }
+
+        $records.Count | Should -Be 1
+        $records[0].Worktree | Should -Be '.worktrees/builder-1'
     }
 }
 
@@ -3543,6 +3617,7 @@ panes:
     task_owner: builder-1
     review_state: PENDING
     branch: worktree-builder-1
+    builder_worktree_path: .worktrees/builder-1
     head_sha: abc1234def5678
     changed_file_count: 2
     changed_files: '["scripts/winsmux-core.ps1","tests/winsmux-bridge.Tests.ps1"]'
@@ -4915,6 +4990,54 @@ Set-Location '__DIGEST_TEMP_ROOT__'
         $result.digest.summary.item_count | Should -Be 1
         @($result.run_projections).Count | Should -Be 1
         $result.run_projections[0].run_id | Should -Be 'task:task-246'
+        $result.run_projections[0].worktree | Should -Be '.worktrees/builder-1'
+    }
+
+    It 'prefers launch_dir in desktop-summary projections when the builder path lags behind' {
+@"
+version: 1
+session:
+  name: winsmux-orchestra
+  project_dir: C:\repo
+panes:
+  builder-1:
+    pane_id: %2
+    role: Builder
+    launch_dir: C:\repo\.worktrees\builder-9
+    builder_worktree_path: C:\repo\.worktrees\builder-1
+    task_id: task-246
+    task: Build evidence digest
+    task_state: in_progress
+    task_owner: builder-1
+    review_state: PENDING
+    branch: worktree-builder-1
+    head_sha: abc1234def5678
+    changed_file_count: 1
+    changed_files: '["scripts/winsmux-core.ps1"]'
+    last_event: commander.review_requested
+    last_event_at: 2026-04-10T14:00:00+09:00
+"@ | Set-Content -Path $script:digestManifestPath -Encoding UTF8
+
+        $bridgeScript = Join-Path (Split-Path -Parent $PSScriptRoot) 'scripts\winsmux-core.ps1'
+        $childScript = @'
+Set-Item -Path function:winsmux -Value {
+    param([Parameter(ValueFromRemainingArguments = $true)][object[]]$args)
+    $commandLine = ($args | ForEach-Object { [string]$_ }) -join ' '
+    switch -Regex ($commandLine) {
+        '^capture-pane .*%2' { @('gpt-5.4   64% context left', '? send   Ctrl+J newline', '>'); break }
+        default { throw "unexpected winsmux call: $commandLine" }
+    }
+}
+Set-Location '__DIGEST_TEMP_ROOT__'
+& '__BRIDGE_SCRIPT__' desktop-summary --json
+'@
+        $childScript = $childScript.Replace('__DIGEST_TEMP_ROOT__', $script:digestTempRoot).Replace('__BRIDGE_SCRIPT__', $bridgeScript)
+        $output = & pwsh -NoProfile -Command $childScript
+
+        $result = ($output | Out-String | ConvertFrom-Json -AsHashtable)
+
+        @($result.run_projections).Count | Should -Be 1
+        $result.run_projections[0].worktree | Should -Be '.worktrees/builder-9'
     }
 }
 

--- a/winsmux-app/package.json
+++ b/winsmux-app/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
+    "test:editor-targets": "node ./scripts/editor-targets-check.mjs",
     "preview": "vite preview",
     "tauri": "tauri"
   },

--- a/winsmux-app/scripts/editor-targets-check.mjs
+++ b/winsmux-app/scripts/editor-targets-check.mjs
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import ts from "typescript";
+
+async function loadEditorTargetsModule() {
+  const sourcePath = path.resolve("src/editorTargets.ts");
+  const source = await readFile(sourcePath, "utf8");
+  const transpiled = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.ESNext,
+      target: ts.ScriptTarget.ES2020,
+    },
+    fileName: sourcePath,
+  });
+
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "winsmux-editor-targets-"));
+  const modulePath = path.join(tempDir, "editorTargets.mjs");
+  await writeFile(modulePath, transpiled.outputText, "utf8");
+
+  try {
+    return await import(pathToFileURL(modulePath).href);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+const {
+  getEditorFileKey,
+  getSourceChangeKey,
+  pickEditorPathCandidate,
+} = await loadEditorTargetsModule();
+
+const duplicateCandidates = [
+  { path: "winsmux-app/src/main.ts", worktree: "builder-2" },
+  { path: "winsmux-app/src/main.ts", worktree: "builder-3" },
+];
+
+assert.equal(getEditorFileKey("winsmux-app/src/main.ts"), ".::winsmux-app/src/main.ts");
+assert.equal(getEditorFileKey("winsmux-app/src/main.ts", "builder-2"), "builder-2::winsmux-app/src/main.ts");
+assert.equal(getSourceChangeKey(duplicateCandidates[1]), "builder-3::winsmux-app/src/main.ts");
+
+assert.deepEqual(
+  pickEditorPathCandidate(duplicateCandidates, "winsmux-app/src/main.ts", "builder-3", ""),
+  duplicateCandidates[1],
+);
+
+assert.deepEqual(
+  pickEditorPathCandidate(duplicateCandidates, "winsmux-app/src/main.ts", "", "builder-2::winsmux-app/src/main.ts"),
+  duplicateCandidates[0],
+);
+
+assert.equal(
+  pickEditorPathCandidate(duplicateCandidates, "winsmux-app/src/main.ts", "", ""),
+  null,
+);
+
+assert.deepEqual(
+  pickEditorPathCandidate([{ path: "winsmux-app/src/desktopClient.ts", worktree: "" }], "winsmux-app/src/desktopClient.ts", "", ""),
+  { path: "winsmux-app/src/desktopClient.ts", worktree: "" },
+);
+
+console.log("editor-targets-check: ok");

--- a/winsmux-app/src-tauri/src/desktop_backend.rs
+++ b/winsmux-app/src-tauri/src/desktop_backend.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -26,6 +27,7 @@ pub struct DesktopRunProjection {
     pub pane_id: String,
     pub label: String,
     pub branch: String,
+    pub worktree: String,
     pub task: String,
     pub task_state: String,
     pub review_state: String,
@@ -35,6 +37,14 @@ pub struct DesktopRunProjection {
     pub next_action: String,
     pub summary: String,
     pub reasons: Vec<String>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct DesktopEditorFilePayload {
+    pub path: String,
+    pub content: String,
+    pub line_count: usize,
+    pub truncated: bool,
 }
 
 #[derive(Deserialize)]
@@ -132,6 +142,14 @@ pub fn load_desktop_run_explain(
     })
 }
 
+pub fn load_desktop_editor_file(
+    path: String,
+    worktree: Option<String>,
+    project_dir: Option<String>,
+) -> Result<DesktopEditorFilePayload, String> {
+    read_desktop_editor_file(project_dir, worktree, &path)
+}
+
 pub fn handle_desktop_json_rpc(
     transport: &dyn DesktopCommandTransport,
     request: DesktopJsonRpcRequest,
@@ -173,6 +191,27 @@ pub fn handle_desktop_json_rpc(
 
             match load_desktop_run_explain(transport, run_id, resolved_project_dir) {
                 Ok(result) => json_rpc_result(request_id, result),
+                Err(err) => json_rpc_error(request_id, JSON_RPC_SERVER_ERROR, err),
+            }
+        }
+        "desktop.editor.read" => {
+            let path = match get_required_string_param(params.as_ref(), &["path"]) {
+                Ok(value) => value,
+                Err(err) => {
+                    return json_rpc_error(request_id, JSON_RPC_INVALID_PARAMS, err);
+                }
+            };
+            let worktree = get_optional_string_param(params.as_ref(), &["worktree"]);
+
+            match load_desktop_editor_file(path, worktree, resolved_project_dir) {
+                Ok(result) => match serde_json::to_value(result) {
+                    Ok(value) => json_rpc_result(request_id, value),
+                    Err(err) => json_rpc_error(
+                        request_id,
+                        JSON_RPC_INTERNAL_ERROR,
+                        format!("Failed to serialize desktop editor payload: {err}"),
+                    ),
+                },
                 Err(err) => json_rpc_error(request_id, JSON_RPC_SERVER_ERROR, err),
             }
         }
@@ -256,12 +295,94 @@ fn resolve_repo_root() -> Result<PathBuf, String> {
     Err("Could not locate winsmux repo root from the Tauri runtime".to_string())
 }
 
+fn resolve_effective_project_dir(project_dir: Option<String>) -> Result<PathBuf, String> {
+    let repo_root = resolve_repo_root()?;
+    Ok(match project_dir {
+        Some(path) if !path.trim().is_empty() => PathBuf::from(path),
+        _ => repo_root,
+    })
+}
+
+fn resolve_desktop_read_root(
+    project_dir: Option<String>,
+    worktree: Option<String>,
+) -> Result<PathBuf, String> {
+    let effective_project_dir = resolve_effective_project_dir(project_dir)?;
+    let normalized_project_dir = effective_project_dir
+        .canonicalize()
+        .map_err(|err| format!("Failed to resolve project root for file preview: {err}"))?;
+
+    let requested_root = match worktree {
+        Some(path) if !path.trim().is_empty() => {
+            let requested = PathBuf::from(path);
+            if requested.is_absolute() {
+                requested
+            } else {
+                effective_project_dir.join(requested)
+            }
+        }
+        _ => effective_project_dir.clone(),
+    };
+
+    let normalized_requested_root = requested_root
+        .canonicalize()
+        .map_err(|err| format!("Failed to resolve worktree root for file preview: {err}"))?;
+
+    if !normalized_requested_root.starts_with(&normalized_project_dir) {
+        return Err(
+            "desktop.editor.read rejected a worktree path outside the project directory"
+                .to_string(),
+        );
+    }
+
+    Ok(normalized_requested_root)
+}
+
+fn read_desktop_editor_file(
+    project_dir: Option<String>,
+    worktree: Option<String>,
+    relative_path: &str,
+) -> Result<DesktopEditorFilePayload, String> {
+    let read_root = resolve_desktop_read_root(project_dir, worktree)?;
+    let requested_path = PathBuf::from(relative_path);
+    if requested_path.is_absolute() {
+        return Err("desktop.editor.read expects a project-relative path".to_string());
+    }
+
+    let full_path = read_root.join(&requested_path);
+    let normalized_full_path = full_path
+        .canonicalize()
+        .map_err(|err| format!("Failed to resolve file preview path: {err}"))?;
+
+    if !normalized_full_path.starts_with(&read_root) {
+        return Err(
+            "desktop.editor.read rejected a path outside the selected worktree".to_string(),
+        );
+    }
+
+    let bytes = fs::read(&normalized_full_path)
+        .map_err(|err| format!("Failed to read file preview: {err}"))?;
+    const MAX_PREVIEW_BYTES: usize = 32 * 1024;
+    let truncated = bytes.len() > MAX_PREVIEW_BYTES;
+    let preview_bytes = if truncated {
+        &bytes[..MAX_PREVIEW_BYTES]
+    } else {
+        bytes.as_slice()
+    };
+    let content = String::from_utf8_lossy(preview_bytes).to_string();
+    let line_count = content.lines().count().max(1);
+
+    Ok(DesktopEditorFilePayload {
+        path: requested_path.to_string_lossy().replace('\\', "/"),
+        content,
+        line_count,
+        truncated,
+    })
+}
+
 fn run_winsmux_json(project_dir: Option<String>, args: &[String]) -> Result<Value, String> {
     let repo_root = resolve_repo_root()?;
-    let effective_project_dir = match project_dir {
-        Some(path) if !path.trim().is_empty() => PathBuf::from(path),
-        _ => repo_root.clone(),
-    };
+    let effective_project_dir = resolve_effective_project_dir(project_dir)?;
     let script_path = repo_root.join("scripts").join("winsmux-core.ps1");
     let script_literal = script_path.to_string_lossy().replace('\'', "''");
     let args_literal = args
@@ -331,6 +452,7 @@ mod tests {
                     "pane_id": "%1",
                     "label": "builder-1",
                     "branch": "codex/task",
+                    "worktree": ".worktrees/builder-1",
                     "task": "Implement",
                     "task_state": "in_progress",
                     "review_state": "PENDING",
@@ -373,6 +495,102 @@ mod tests {
             transport.requests.borrow().as_slice(),
             ["explain run-7 --json"]
         );
+    }
+
+    #[test]
+    fn handle_desktop_json_rpc_routes_editor_read() {
+        let temp_dir = std::env::temp_dir().join(format!(
+            "winsmux-desktop-editor-read-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&temp_dir);
+        std::fs::create_dir_all(temp_dir.join("winsmux-app").join("src")).unwrap();
+        std::fs::write(
+            temp_dir.join("winsmux-app").join("src").join("main.ts"),
+            "console.log('hello');\nconsole.log('world');\n",
+        )
+        .unwrap();
+
+        let transport = FakeTransport {
+            requests: RefCell::new(Vec::new()),
+            response: serde_json::json!({}),
+        };
+        let response = handle_desktop_json_rpc(
+            &transport,
+            DesktopJsonRpcRequest {
+                jsonrpc: "2.0".to_string(),
+                id: serde_json::json!("req-file"),
+                method: "desktop.editor.read".to_string(),
+                params: Some(serde_json::json!({
+                    "path": "winsmux-app/src/main.ts",
+                    "worktree": "."
+                })),
+            },
+            Some(temp_dir.to_string_lossy().to_string()),
+        );
+
+        match response {
+            DesktopJsonRpcResponse::Success { id, result, .. } => {
+                assert_eq!(id, serde_json::json!("req-file"));
+                assert_eq!(result["path"], "winsmux-app/src/main.ts");
+                assert_eq!(result["line_count"], 2);
+                assert_eq!(result["truncated"], false);
+            }
+            DesktopJsonRpcResponse::Error { error, .. } => {
+                panic!("expected success, got {:?}", error);
+            }
+        }
+        assert!(transport.requests.borrow().is_empty());
+
+        let _ = std::fs::remove_dir_all(temp_dir);
+    }
+
+    #[test]
+    fn handle_desktop_json_rpc_routes_editor_read_from_worktree() {
+        let temp_dir = std::env::temp_dir().join(format!(
+            "winsmux-desktop-editor-worktree-{}",
+            std::process::id()
+        ));
+        let worktree_dir = temp_dir.join(".worktrees").join("builder-1");
+        let target_file = worktree_dir.join("winsmux-app").join("src").join("main.ts");
+
+        let _ = std::fs::remove_dir_all(&temp_dir);
+        std::fs::create_dir_all(target_file.parent().unwrap()).unwrap();
+        std::fs::write(&target_file, "console.log('worktree');\n").unwrap();
+
+        let transport = FakeTransport {
+            requests: RefCell::new(Vec::new()),
+            response: serde_json::json!({}),
+        };
+        let response = handle_desktop_json_rpc(
+            &transport,
+            DesktopJsonRpcRequest {
+                jsonrpc: "2.0".to_string(),
+                id: serde_json::json!("req-worktree"),
+                method: "desktop.editor.read".to_string(),
+                params: Some(serde_json::json!({
+                    "path": "winsmux-app/src/main.ts",
+                    "worktree": ".worktrees/builder-1"
+                })),
+            },
+            Some(temp_dir.to_string_lossy().to_string()),
+        );
+
+        match response {
+            DesktopJsonRpcResponse::Success { id, result, .. } => {
+                assert_eq!(id, serde_json::json!("req-worktree"));
+                assert_eq!(result["path"], "winsmux-app/src/main.ts");
+                assert!(result["content"]
+                    .as_str()
+                    .unwrap_or_default()
+                    .contains("worktree"));
+            }
+            DesktopJsonRpcResponse::Error { error, .. } => {
+                panic!("expected success, got {:?}", error);
+            }
+        }
+
+        let _ = std::fs::remove_dir_all(temp_dir);
     }
 
     #[test]

--- a/winsmux-app/src-tauri/src/desktop_backend.rs
+++ b/winsmux-app/src-tauri/src/desktop_backend.rs
@@ -3,6 +3,13 @@ use serde_json::Value;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+const DESKTOP_JSON_RPC_VERSION: &str = "2.0";
+const JSON_RPC_INVALID_REQUEST: i32 = -32600;
+const JSON_RPC_METHOD_NOT_FOUND: i32 = -32601;
+const JSON_RPC_INVALID_PARAMS: i32 = -32602;
+const JSON_RPC_INTERNAL_ERROR: i32 = -32603;
+const JSON_RPC_SERVER_ERROR: i32 = -32000;
+
 #[derive(Serialize, Deserialize)]
 pub struct DesktopSummarySnapshot {
     pub generated_at: String,
@@ -28,6 +35,36 @@ pub struct DesktopRunProjection {
     pub next_action: String,
     pub summary: String,
     pub reasons: Vec<String>,
+}
+
+#[derive(Deserialize)]
+pub struct DesktopJsonRpcRequest {
+    pub jsonrpc: String,
+    pub id: Value,
+    pub method: String,
+    #[serde(default)]
+    pub params: Option<Value>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct DesktopJsonRpcError {
+    pub code: i32,
+    pub message: String,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(untagged)]
+pub enum DesktopJsonRpcResponse {
+    Success {
+        jsonrpc: String,
+        id: Value,
+        result: Value,
+    },
+    Error {
+        jsonrpc: String,
+        id: Value,
+        error: DesktopJsonRpcError,
+    },
 }
 
 pub enum DesktopCommand {
@@ -93,6 +130,102 @@ pub fn load_desktop_run_explain(
         run_id,
         project_dir,
     })
+}
+
+pub fn handle_desktop_json_rpc(
+    transport: &dyn DesktopCommandTransport,
+    request: DesktopJsonRpcRequest,
+    project_dir: Option<String>,
+) -> DesktopJsonRpcResponse {
+    let request_id = request.id.clone();
+    if request.jsonrpc != DESKTOP_JSON_RPC_VERSION {
+        return json_rpc_error(
+            request_id,
+            JSON_RPC_INVALID_REQUEST,
+            "desktop_json_rpc expects jsonrpc=\"2.0\"",
+        );
+    }
+
+    let params = request.params;
+    let resolved_project_dir = resolve_project_dir(project_dir, params.as_ref());
+
+    match request.method.as_str() {
+        "desktop.summary.snapshot" => {
+            match load_desktop_summary_snapshot(transport, resolved_project_dir) {
+                Ok(snapshot) => match serde_json::to_value(snapshot) {
+                    Ok(result) => json_rpc_result(request_id, result),
+                    Err(err) => json_rpc_error(
+                        request_id,
+                        JSON_RPC_INTERNAL_ERROR,
+                        format!("Failed to serialize desktop summary payload: {err}"),
+                    ),
+                },
+                Err(err) => json_rpc_error(request_id, JSON_RPC_SERVER_ERROR, err),
+            }
+        }
+        "desktop.run.explain" => {
+            let run_id = match get_required_string_param(params.as_ref(), &["runId", "run_id"]) {
+                Ok(value) => value,
+                Err(err) => {
+                    return json_rpc_error(request_id, JSON_RPC_INVALID_PARAMS, err);
+                }
+            };
+
+            match load_desktop_run_explain(transport, run_id, resolved_project_dir) {
+                Ok(result) => json_rpc_result(request_id, result),
+                Err(err) => json_rpc_error(request_id, JSON_RPC_SERVER_ERROR, err),
+            }
+        }
+        _ => json_rpc_error(
+            request_id,
+            JSON_RPC_METHOD_NOT_FOUND,
+            format!("Unknown desktop JSON-RPC method: {}", request.method),
+        ),
+    }
+}
+
+fn resolve_project_dir(project_dir: Option<String>, params: Option<&Value>) -> Option<String> {
+    if let Some(path) = project_dir.filter(|value| !value.trim().is_empty()) {
+        return Some(path);
+    }
+
+    get_optional_string_param(params, &["projectDir", "project_dir"])
+}
+
+fn get_required_string_param(params: Option<&Value>, keys: &[&str]) -> Result<String, String> {
+    get_optional_string_param(params, keys)
+        .ok_or_else(|| format!("Missing required params field: {}", keys.join(" or ")))
+}
+
+fn get_optional_string_param(params: Option<&Value>, keys: &[&str]) -> Option<String> {
+    let object = params?.as_object()?;
+    for key in keys {
+        let value = object.get(*key)?.as_str()?.trim();
+        if !value.is_empty() {
+            return Some(value.to_string());
+        }
+    }
+
+    None
+}
+
+fn json_rpc_result(id: Value, result: Value) -> DesktopJsonRpcResponse {
+    DesktopJsonRpcResponse::Success {
+        jsonrpc: DESKTOP_JSON_RPC_VERSION.to_string(),
+        id,
+        result,
+    }
+}
+
+fn json_rpc_error(id: Value, code: i32, message: impl Into<String>) -> DesktopJsonRpcResponse {
+    DesktopJsonRpcResponse::Error {
+        jsonrpc: DESKTOP_JSON_RPC_VERSION.to_string(),
+        id,
+        error: DesktopJsonRpcError {
+            code,
+            message: message.into(),
+        },
+    }
 }
 
 fn looks_like_repo_root(path: &Path) -> bool {
@@ -240,5 +373,97 @@ mod tests {
             transport.requests.borrow().as_slice(),
             ["explain run-7 --json"]
         );
+    }
+
+    #[test]
+    fn handle_desktop_json_rpc_routes_summary_snapshot() {
+        let transport = FakeTransport {
+            requests: RefCell::new(Vec::new()),
+            response: serde_json::json!({
+                "generated_at": "2026-04-13T00:00:00Z",
+                "project_dir": "C:/repo",
+                "board": { "summary": { "pane_count": 1 }, "panes": [] },
+                "inbox": { "summary": { "item_count": 0 }, "items": [] },
+                "digest": { "summary": { "item_count": 1 }, "items": [] },
+                "run_projections": []
+            }),
+        };
+        let response = handle_desktop_json_rpc(
+            &transport,
+            DesktopJsonRpcRequest {
+                jsonrpc: "2.0".to_string(),
+                id: serde_json::json!("req-1"),
+                method: "desktop.summary.snapshot".to_string(),
+                params: None,
+            },
+            None,
+        );
+
+        match response {
+            DesktopJsonRpcResponse::Success { id, result, .. } => {
+                assert_eq!(id, serde_json::json!("req-1"));
+                assert_eq!(result["project_dir"], "C:/repo");
+            }
+            DesktopJsonRpcResponse::Error { error, .. } => {
+                panic!("expected success, got {:?}", error);
+            }
+        }
+        assert_eq!(
+            transport.requests.borrow().as_slice(),
+            ["desktop-summary --json"]
+        );
+    }
+
+    #[test]
+    fn handle_desktop_json_rpc_rejects_unknown_method() {
+        let transport = FakeTransport {
+            requests: RefCell::new(Vec::new()),
+            response: serde_json::json!({}),
+        };
+        let response = handle_desktop_json_rpc(
+            &transport,
+            DesktopJsonRpcRequest {
+                jsonrpc: "2.0".to_string(),
+                id: serde_json::json!("req-2"),
+                method: "desktop.unknown".to_string(),
+                params: None,
+            },
+            None,
+        );
+
+        match response {
+            DesktopJsonRpcResponse::Error { id, error, .. } => {
+                assert_eq!(id, serde_json::json!("req-2"));
+                assert_eq!(error.code, JSON_RPC_METHOD_NOT_FOUND);
+            }
+            DesktopJsonRpcResponse::Success { .. } => panic!("expected error response"),
+        }
+        assert!(transport.requests.borrow().is_empty());
+    }
+
+    #[test]
+    fn handle_desktop_json_rpc_requires_run_id_for_explain() {
+        let transport = FakeTransport {
+            requests: RefCell::new(Vec::new()),
+            response: serde_json::json!({}),
+        };
+        let response = handle_desktop_json_rpc(
+            &transport,
+            DesktopJsonRpcRequest {
+                jsonrpc: "2.0".to_string(),
+                id: serde_json::json!("req-3"),
+                method: "desktop.run.explain".to_string(),
+                params: Some(serde_json::json!({})),
+            },
+            None,
+        );
+
+        match response {
+            DesktopJsonRpcResponse::Error { error, .. } => {
+                assert_eq!(error.code, JSON_RPC_INVALID_PARAMS);
+            }
+            DesktopJsonRpcResponse::Success { .. } => panic!("expected invalid params error"),
+        }
+        assert!(transport.requests.borrow().is_empty());
     }
 }

--- a/winsmux-app/src-tauri/src/desktop_backend.rs
+++ b/winsmux-app/src-tauri/src/desktop_backend.rs
@@ -28,6 +28,9 @@ pub struct DesktopRunProjection {
     pub label: String,
     pub branch: String,
     pub worktree: String,
+    pub head_sha: String,
+    pub head_short: String,
+    pub provider_target: String,
     pub task: String,
     pub task_state: String,
     pub review_state: String,
@@ -37,6 +40,10 @@ pub struct DesktopRunProjection {
     pub next_action: String,
     pub summary: String,
     pub reasons: Vec<String>,
+    pub hypothesis: String,
+    pub confidence: Option<f64>,
+    pub observation_pack_ref: String,
+    pub consultation_ref: String,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -453,6 +460,9 @@ mod tests {
                     "label": "builder-1",
                     "branch": "codex/task",
                     "worktree": ".worktrees/builder-1",
+                    "head_sha": "abc1234def5678",
+                    "head_short": "abc1234",
+                    "provider_target": "codex:gpt-5.4",
                     "task": "Implement",
                     "task_state": "in_progress",
                     "review_state": "PENDING",
@@ -461,7 +471,11 @@ mod tests {
                     "changed_files": ["winsmux-app/src/main.ts"],
                     "next_action": "review_requested",
                     "summary": "Implement",
-                    "reasons": ["task_state=in_progress"]
+                    "reasons": ["task_state=in_progress"],
+                    "hypothesis": "projection should surface detail",
+                    "confidence": 0.75,
+                    "observation_pack_ref": "obs-1",
+                    "consultation_ref": "consult-1"
                 }]
             }),
         };

--- a/winsmux-app/src-tauri/src/lib.rs
+++ b/winsmux-app/src-tauri/src/lib.rs
@@ -1,8 +1,8 @@
 mod desktop_backend;
 
 use desktop_backend::{
-    load_desktop_run_explain, load_desktop_summary_snapshot, DesktopSummarySnapshot,
-    PwshScriptTransport,
+    handle_desktop_json_rpc, load_desktop_run_explain, load_desktop_summary_snapshot,
+    DesktopJsonRpcRequest, DesktopJsonRpcResponse, DesktopSummarySnapshot, PwshScriptTransport,
 };
 use portable_pty::{native_pty_system, CommandBuilder, PtySize};
 use std::collections::HashMap;
@@ -35,6 +35,15 @@ async fn desktop_run_explain(
 ) -> Result<serde_json::Value, String> {
     let transport = PwshScriptTransport;
     load_desktop_run_explain(&transport, run_id, project_dir)
+}
+
+#[tauri::command]
+async fn desktop_json_rpc(
+    request: DesktopJsonRpcRequest,
+    project_dir: Option<String>,
+) -> Result<DesktopJsonRpcResponse, String> {
+    let transport = PwshScriptTransport;
+    Ok(handle_desktop_json_rpc(&transport, request, project_dir))
 }
 
 #[tauri::command]
@@ -167,6 +176,7 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             desktop_summary_snapshot,
             desktop_run_explain,
+            desktop_json_rpc,
             pty_spawn,
             pty_write,
             pty_resize,

--- a/winsmux-app/src-tauri/src/lib.rs
+++ b/winsmux-app/src-tauri/src/lib.rs
@@ -1,10 +1,14 @@
 mod desktop_backend;
+mod pty_backend;
 
 use desktop_backend::{
     handle_desktop_json_rpc, load_desktop_run_explain, load_desktop_summary_snapshot,
     DesktopJsonRpcRequest, DesktopJsonRpcResponse, DesktopSummarySnapshot, PwshScriptTransport,
 };
 use portable_pty::{native_pty_system, CommandBuilder, PtySize};
+use pty_backend::{
+    handle_pty_json_rpc, PtyCommand, PtyCommandTransport, PtyJsonRpcRequest, PtyJsonRpcResponse,
+};
 use std::collections::HashMap;
 use std::io::{Read, Write};
 use std::sync::{Arc, Mutex};
@@ -18,6 +22,10 @@ struct SinglePty {
 
 struct PtyManager {
     panes: Arc<Mutex<HashMap<String, SinglePty>>>,
+}
+
+struct TauriPtyTransport {
+    app: AppHandle,
 }
 
 #[tauri::command]
@@ -47,7 +55,35 @@ async fn desktop_json_rpc(
 }
 
 #[tauri::command]
+async fn pty_json_rpc(
+    app: AppHandle,
+    request: PtyJsonRpcRequest,
+) -> Result<PtyJsonRpcResponse, String> {
+    let transport = TauriPtyTransport { app };
+    Ok(handle_pty_json_rpc(&transport, request))
+}
+
+#[tauri::command]
 async fn pty_spawn(app: AppHandle, pane_id: String, cols: u16, rows: u16) -> Result<(), String> {
+    spawn_pty(&app, pane_id, cols, rows)
+}
+
+#[tauri::command]
+async fn pty_write(app: AppHandle, pane_id: String, data: String) -> Result<(), String> {
+    write_pty(&app, &pane_id, &data)
+}
+
+#[tauri::command]
+async fn pty_resize(app: AppHandle, pane_id: String, cols: u16, rows: u16) -> Result<(), String> {
+    resize_pty(&app, &pane_id, cols, rows)
+}
+
+#[tauri::command]
+async fn pty_close(app: AppHandle, pane_id: String) -> Result<(), String> {
+    close_pty(&app, &pane_id)
+}
+
+fn spawn_pty(app: &AppHandle, pane_id: String, cols: u16, rows: u16) -> Result<(), String> {
     let pty_system = native_pty_system();
 
     let pair = pty_system
@@ -115,12 +151,11 @@ async fn pty_spawn(app: AppHandle, pane_id: String, cols: u16, rows: u16) -> Res
     Ok(())
 }
 
-#[tauri::command]
-async fn pty_write(app: AppHandle, pane_id: String, data: String) -> Result<(), String> {
+fn write_pty(app: &AppHandle, pane_id: &str, data: &str) -> Result<(), String> {
     let manager = app.state::<PtyManager>();
     let panes = manager.panes.lock().map_err(|e| e.to_string())?;
     let pty = panes
-        .get(&pane_id)
+        .get(pane_id)
         .ok_or_else(|| format!("Pane {} not found", pane_id))?;
     let mut writer = pty.writer.lock().map_err(|e| e.to_string())?;
     writer
@@ -130,12 +165,11 @@ async fn pty_write(app: AppHandle, pane_id: String, data: String) -> Result<(), 
     Ok(())
 }
 
-#[tauri::command]
-async fn pty_resize(app: AppHandle, pane_id: String, cols: u16, rows: u16) -> Result<(), String> {
+fn resize_pty(app: &AppHandle, pane_id: &str, cols: u16, rows: u16) -> Result<(), String> {
     let manager = app.state::<PtyManager>();
     let panes = manager.panes.lock().map_err(|e| e.to_string())?;
     let pty = panes
-        .get(&pane_id)
+        .get(pane_id)
         .ok_or_else(|| format!("Pane {} not found", pane_id))?;
     let master = pty.master.lock().map_err(|e| e.to_string())?;
     master
@@ -149,12 +183,11 @@ async fn pty_resize(app: AppHandle, pane_id: String, cols: u16, rows: u16) -> Re
     Ok(())
 }
 
-#[tauri::command]
-async fn pty_close(app: AppHandle, pane_id: String) -> Result<(), String> {
+fn close_pty(app: &AppHandle, pane_id: &str) -> Result<(), String> {
     let manager = app.state::<PtyManager>();
     let mut panes = manager.panes.lock().map_err(|e| e.to_string())?;
     let entry = panes
-        .remove(&pane_id)
+        .remove(pane_id)
         .ok_or_else(|| format!("Pane {} not found", pane_id))?;
     // Kill child process
     if let Ok(mut child) = entry.child.lock() {
@@ -164,6 +197,37 @@ async fn pty_close(app: AppHandle, pane_id: String) -> Result<(), String> {
     drop(entry.master);
     drop(entry.writer);
     Ok(())
+}
+
+impl PtyCommandTransport for TauriPtyTransport {
+    fn execute(&self, command: &PtyCommand) -> Result<serde_json::Value, String> {
+        match command {
+            PtyCommand::Spawn {
+                pane_id,
+                cols,
+                rows,
+            } => {
+                spawn_pty(&self.app, pane_id.clone(), *cols, *rows)?;
+                Ok(serde_json::json!({ "paneId": pane_id }))
+            }
+            PtyCommand::Write { pane_id, data } => {
+                write_pty(&self.app, pane_id, data)?;
+                Ok(serde_json::json!({ "paneId": pane_id }))
+            }
+            PtyCommand::Resize {
+                pane_id,
+                cols,
+                rows,
+            } => {
+                resize_pty(&self.app, pane_id, *cols, *rows)?;
+                Ok(serde_json::json!({ "paneId": pane_id }))
+            }
+            PtyCommand::Close { pane_id } => {
+                close_pty(&self.app, pane_id)?;
+                Ok(serde_json::json!({ "paneId": pane_id }))
+            }
+        }
+    }
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -177,6 +241,7 @@ pub fn run() {
             desktop_summary_snapshot,
             desktop_run_explain,
             desktop_json_rpc,
+            pty_json_rpc,
             pty_spawn,
             pty_write,
             pty_resize,

--- a/winsmux-app/src-tauri/src/pty_backend.rs
+++ b/winsmux-app/src-tauri/src/pty_backend.rs
@@ -1,0 +1,295 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+const PTY_JSON_RPC_VERSION: &str = "2.0";
+const JSON_RPC_INVALID_REQUEST: i32 = -32600;
+const JSON_RPC_METHOD_NOT_FOUND: i32 = -32601;
+const JSON_RPC_INVALID_PARAMS: i32 = -32602;
+const JSON_RPC_SERVER_ERROR: i32 = -32000;
+
+#[derive(Deserialize)]
+pub struct PtyJsonRpcRequest {
+    pub jsonrpc: String,
+    pub id: Value,
+    pub method: String,
+    #[serde(default)]
+    pub params: Option<Value>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct PtyJsonRpcError {
+    pub code: i32,
+    pub message: String,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(untagged)]
+pub enum PtyJsonRpcResponse {
+    Success {
+        jsonrpc: String,
+        id: Value,
+        result: Value,
+    },
+    Error {
+        jsonrpc: String,
+        id: Value,
+        error: PtyJsonRpcError,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum PtyCommand {
+    Spawn {
+        pane_id: String,
+        cols: u16,
+        rows: u16,
+    },
+    Write {
+        pane_id: String,
+        data: String,
+    },
+    Resize {
+        pane_id: String,
+        cols: u16,
+        rows: u16,
+    },
+    Close {
+        pane_id: String,
+    },
+}
+
+pub trait PtyCommandTransport {
+    fn execute(&self, command: &PtyCommand) -> Result<Value, String>;
+}
+
+pub fn handle_pty_json_rpc(
+    transport: &dyn PtyCommandTransport,
+    request: PtyJsonRpcRequest,
+) -> PtyJsonRpcResponse {
+    let request_id = request.id.clone();
+    if request.jsonrpc != PTY_JSON_RPC_VERSION {
+        return json_rpc_error(
+            request_id,
+            JSON_RPC_INVALID_REQUEST,
+            "pty_json_rpc expects jsonrpc=\"2.0\"",
+        );
+    }
+
+    let command = match parse_command(request.method.as_str(), request.params.as_ref()) {
+        Ok(command) => command,
+        Err(ParseError::InvalidParams(message)) => {
+            return json_rpc_error(request_id, JSON_RPC_INVALID_PARAMS, message);
+        }
+        Err(ParseError::MethodNotFound(message)) => {
+            return json_rpc_error(request_id, JSON_RPC_METHOD_NOT_FOUND, message);
+        }
+    };
+
+    match transport.execute(&command) {
+        Ok(result) => json_rpc_result(request_id, result),
+        Err(err) => json_rpc_error(request_id, JSON_RPC_SERVER_ERROR, err),
+    }
+}
+
+enum ParseError {
+    InvalidParams(String),
+    MethodNotFound(String),
+}
+
+fn parse_command(method: &str, params: Option<&Value>) -> Result<PtyCommand, ParseError> {
+    match method {
+        "pty.spawn" => Ok(PtyCommand::Spawn {
+            pane_id: get_required_string_param(params, &["paneId", "pane_id"])?,
+            cols: get_required_u16_param(params, &["cols"])?,
+            rows: get_required_u16_param(params, &["rows"])?,
+        }),
+        "pty.write" => Ok(PtyCommand::Write {
+            pane_id: get_required_string_param(params, &["paneId", "pane_id"])?,
+            data: get_required_string_param(params, &["data"])?,
+        }),
+        "pty.resize" => Ok(PtyCommand::Resize {
+            pane_id: get_required_string_param(params, &["paneId", "pane_id"])?,
+            cols: get_required_u16_param(params, &["cols"])?,
+            rows: get_required_u16_param(params, &["rows"])?,
+        }),
+        "pty.close" => Ok(PtyCommand::Close {
+            pane_id: get_required_string_param(params, &["paneId", "pane_id"])?,
+        }),
+        _ => Err(ParseError::MethodNotFound(format!(
+            "Unknown pty JSON-RPC method: {method}"
+        ))),
+    }
+}
+
+fn get_required_string_param(params: Option<&Value>, keys: &[&str]) -> Result<String, ParseError> {
+    let object = params
+        .and_then(Value::as_object)
+        .ok_or_else(|| ParseError::InvalidParams(invalid_params(keys)))?;
+
+    for key in keys {
+        if let Some(value) = object.get(*key).and_then(Value::as_str) {
+            let trimmed = value.trim();
+            if !trimmed.is_empty() {
+                return Ok(trimmed.to_string());
+            }
+        }
+    }
+
+    Err(ParseError::InvalidParams(invalid_params(keys)))
+}
+
+fn get_required_u16_param(params: Option<&Value>, keys: &[&str]) -> Result<u16, ParseError> {
+    let object = params
+        .and_then(Value::as_object)
+        .ok_or_else(|| ParseError::InvalidParams(invalid_params(keys)))?;
+
+    for key in keys {
+        if let Some(raw) = object.get(*key).and_then(Value::as_u64) {
+            let value = u16::try_from(raw).map_err(|_| {
+                ParseError::InvalidParams(format!(
+                    "Invalid params field {}: expected 0-65535",
+                    keys.join(" or ")
+                ))
+            })?;
+            return Ok(value);
+        }
+    }
+
+    Err(ParseError::InvalidParams(invalid_params(keys)))
+}
+
+fn invalid_params(keys: &[&str]) -> String {
+    format!("Missing required params field: {}", keys.join(" or "))
+}
+
+fn json_rpc_result(id: Value, result: Value) -> PtyJsonRpcResponse {
+    PtyJsonRpcResponse::Success {
+        jsonrpc: PTY_JSON_RPC_VERSION.to_string(),
+        id,
+        result,
+    }
+}
+
+fn json_rpc_error(id: Value, code: i32, message: impl Into<String>) -> PtyJsonRpcResponse {
+    PtyJsonRpcResponse::Error {
+        jsonrpc: PTY_JSON_RPC_VERSION.to_string(),
+        id,
+        error: PtyJsonRpcError {
+            code,
+            message: message.into(),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::RefCell;
+
+    struct FakeTransport {
+        commands: RefCell<Vec<PtyCommand>>,
+        response: Value,
+    }
+
+    impl PtyCommandTransport for FakeTransport {
+        fn execute(&self, command: &PtyCommand) -> Result<Value, String> {
+            self.commands.borrow_mut().push(command.clone());
+            Ok(self.response.clone())
+        }
+    }
+
+    #[test]
+    fn handle_pty_json_rpc_routes_spawn() {
+        let transport = FakeTransport {
+            commands: RefCell::new(Vec::new()),
+            response: serde_json::json!({ "paneId": "pane-1" }),
+        };
+
+        let response = handle_pty_json_rpc(
+            &transport,
+            PtyJsonRpcRequest {
+                jsonrpc: "2.0".to_string(),
+                id: serde_json::json!("req-1"),
+                method: "pty.spawn".to_string(),
+                params: Some(serde_json::json!({
+                    "paneId": "pane-1",
+                    "cols": 120,
+                    "rows": 40
+                })),
+            },
+        );
+
+        match response {
+            PtyJsonRpcResponse::Success { id, result, .. } => {
+                assert_eq!(id, serde_json::json!("req-1"));
+                assert_eq!(result["paneId"], "pane-1");
+            }
+            PtyJsonRpcResponse::Error { error, .. } => {
+                panic!("expected success, got {:?}", error);
+            }
+        }
+
+        assert_eq!(
+            transport.commands.borrow().as_slice(),
+            [PtyCommand::Spawn {
+                pane_id: "pane-1".to_string(),
+                cols: 120,
+                rows: 40
+            }]
+        );
+    }
+
+    #[test]
+    fn handle_pty_json_rpc_requires_pane_id() {
+        let transport = FakeTransport {
+            commands: RefCell::new(Vec::new()),
+            response: serde_json::json!({}),
+        };
+
+        let response = handle_pty_json_rpc(
+            &transport,
+            PtyJsonRpcRequest {
+                jsonrpc: "2.0".to_string(),
+                id: serde_json::json!("req-2"),
+                method: "pty.close".to_string(),
+                params: Some(serde_json::json!({})),
+            },
+        );
+
+        match response {
+            PtyJsonRpcResponse::Error { error, .. } => {
+                assert_eq!(error.code, JSON_RPC_INVALID_PARAMS);
+            }
+            PtyJsonRpcResponse::Success { .. } => panic!("expected invalid params error"),
+        }
+
+        assert!(transport.commands.borrow().is_empty());
+    }
+
+    #[test]
+    fn handle_pty_json_rpc_rejects_unknown_method() {
+        let transport = FakeTransport {
+            commands: RefCell::new(Vec::new()),
+            response: serde_json::json!({}),
+        };
+
+        let response = handle_pty_json_rpc(
+            &transport,
+            PtyJsonRpcRequest {
+                jsonrpc: "2.0".to_string(),
+                id: serde_json::json!("req-3"),
+                method: "pty.unknown".to_string(),
+                params: None,
+            },
+        );
+
+        match response {
+            PtyJsonRpcResponse::Error { error, .. } => {
+                assert_eq!(error.code, JSON_RPC_METHOD_NOT_FOUND);
+            }
+            PtyJsonRpcResponse::Success { .. } => panic!("expected method not found error"),
+        }
+
+        assert!(transport.commands.borrow().is_empty());
+    }
+}

--- a/winsmux-app/src/desktopClient.ts
+++ b/winsmux-app/src/desktopClient.ts
@@ -89,15 +89,22 @@ export interface DesktopDigestItem {
   label: string;
   pane_id: string;
   role: string;
+  provider_target?: string;
   task_state: string;
   review_state: string;
   next_action: string;
   branch: string;
+  worktree?: string;
+  head_sha?: string;
   head_short: string;
   changed_file_count: number;
   changed_files: string[];
   verification_outcome?: string;
   security_blocked?: string;
+  hypothesis?: string;
+  confidence?: number | null;
+  observation_pack_ref?: string;
+  consultation_ref?: string;
 }
 
 export interface DesktopRunProjection {
@@ -106,6 +113,9 @@ export interface DesktopRunProjection {
   label: string;
   branch: string;
   worktree: string;
+  head_sha: string;
+  head_short: string;
+  provider_target: string;
   task: string;
   task_state: string;
   review_state: string;
@@ -115,6 +125,10 @@ export interface DesktopRunProjection {
   next_action: string;
   summary: string;
   reasons: string[];
+  hypothesis: string;
+  confidence: number | null;
+  observation_pack_ref: string;
+  consultation_ref: string;
 }
 
 export interface DesktopSummarySnapshot {
@@ -136,20 +150,42 @@ export interface DesktopSummarySnapshot {
 }
 
 export interface DesktopExplainPayload {
+  generated_at?: string;
+  project_dir?: string;
   run: {
     run_id: string;
+    task_id?: string;
+    parent_run_id?: string;
     task: string;
+    goal?: string;
+    task_type?: string;
     state: string;
     task_state: string;
     review_state: string;
+    priority?: string;
+    blocking?: string[];
+    review_required?: boolean;
+    provider_target?: string;
+    agent_role?: string;
+    timeout_policy?: string;
+    tokens_remaining?: number | null;
+    last_event?: string;
+    last_event_at?: string;
     branch: string;
     head_sha: string;
+    worktree?: string;
     changed_files: string[];
   };
   explanation: {
     summary: string;
     reasons: string[];
     next_action: string;
+    current_state?: {
+      state?: string;
+      task_state?: string;
+      review_state?: string;
+      last_event?: string;
+    };
   };
   evidence_digest: {
     next_action: string;
@@ -157,6 +193,21 @@ export interface DesktopExplainPayload {
     changed_files: string[];
     verification_outcome?: string;
     security_blocked?: string;
+  };
+  review_state?: {
+    status?: string;
+  };
+  consultation_summary?: {
+    kind?: string;
+    recommendation?: string;
+    next_test?: string;
+  } | null;
+  run_packet?: {
+    provider_target?: string;
+  };
+  result_packet?: {
+    summary?: string;
+    next_action_hint?: string;
   };
   recent_events: Array<{
     timestamp: string;

--- a/winsmux-app/src/desktopClient.ts
+++ b/winsmux-app/src/desktopClient.ts
@@ -1,6 +1,31 @@
 import { invoke } from "@tauri-apps/api/core";
 
 type DesktopCommandName = "desktop_summary_snapshot" | "desktop_run_explain";
+type DesktopJsonRpcMethod = "desktop.summary.snapshot" | "desktop.run.explain";
+
+interface DesktopJsonRpcRequest {
+  jsonrpc: "2.0";
+  id: string;
+  method: DesktopJsonRpcMethod;
+  params?: Record<string, unknown>;
+}
+
+interface DesktopJsonRpcError {
+  code: number;
+  message: string;
+}
+
+type DesktopJsonRpcResponse<TResponse> =
+  | {
+      jsonrpc: "2.0";
+      id: string;
+      result: TResponse;
+    }
+  | {
+      jsonrpc: "2.0";
+      id: string;
+      error: DesktopJsonRpcError;
+    };
 
 export interface DesktopCommandTransport {
   request<TResponse>(
@@ -134,6 +159,8 @@ export interface DesktopExplainPayload {
   }>;
 }
 
+let nextDesktopJsonRpcId = 0;
+
 function normalizeDesktopError(action: string, error: unknown) {
   if (error instanceof Error) {
     return new Error(`${action} failed: ${error.message}`);
@@ -142,18 +169,67 @@ function normalizeDesktopError(action: string, error: unknown) {
   return new Error(`${action} failed: ${String(error)}`);
 }
 
-export function createTauriDesktopCommandTransport(
+function getDesktopJsonRpcMethod(command: DesktopCommandName): DesktopJsonRpcMethod {
+  switch (command) {
+    case "desktop_summary_snapshot":
+      return "desktop.summary.snapshot";
+    case "desktop_run_explain":
+      return "desktop.run.explain";
+  }
+}
+
+function normalizeDesktopJsonRpcError(
+  method: DesktopJsonRpcMethod,
+  error: DesktopJsonRpcError,
+) {
+  return new Error(`${method} returned JSON-RPC error ${error.code}: ${error.message}`);
+}
+
+export function createJsonRpcDesktopCommandTransport(
   invokeCommand: typeof invoke = invoke,
 ): DesktopCommandTransport {
   return {
-    request<TResponse>(command: DesktopCommandName, payload?: Record<string, unknown>) {
-      return invokeCommand<TResponse>(command, payload);
+    async request<TResponse>(
+      command: DesktopCommandName,
+      payload?: Record<string, unknown>,
+    ) {
+      const method = getDesktopJsonRpcMethod(command);
+      const request: DesktopJsonRpcRequest = {
+        jsonrpc: "2.0",
+        id: `desktop-${++nextDesktopJsonRpcId}`,
+        method,
+      };
+      if (payload && Object.keys(payload).length > 0) {
+        request.params = payload;
+      }
+
+      const response = await invokeCommand<DesktopJsonRpcResponse<TResponse>>(
+        "desktop_json_rpc",
+        { request },
+      );
+      if (response.jsonrpc !== "2.0") {
+        throw new Error(`${method} returned an invalid JSON-RPC version`);
+      }
+      if (response.id !== request.id) {
+        throw new Error(`${method} returned an unexpected JSON-RPC id`);
+      }
+      if ("error" in response) {
+        throw normalizeDesktopJsonRpcError(method, response.error);
+      }
+
+      return response.result;
     },
   };
 }
 
 let desktopCommandTransport: DesktopCommandTransport =
-  createTauriDesktopCommandTransport();
+  createJsonRpcDesktopCommandTransport();
+
+export function createTauriDesktopCommandTransport(
+  invokeCommand: typeof invoke = invoke,
+): DesktopCommandTransport {
+  return createJsonRpcDesktopCommandTransport(invokeCommand);
+}
 
 export function configureDesktopCommandTransport(
   transport: DesktopCommandTransport,

--- a/winsmux-app/src/desktopClient.ts
+++ b/winsmux-app/src/desktopClient.ts
@@ -202,6 +202,42 @@ export interface DesktopExplainPayload {
     recommendation?: string;
     next_test?: string;
   } | null;
+  action_items?: Array<{
+    kind?: string;
+    message?: string;
+    event?: string;
+    timestamp?: string;
+    source?: string;
+  }>;
+  verification_contract?: {
+    mode?: string;
+    required?: boolean;
+    checks?: string[];
+    commands?: string[];
+  } | null;
+  verification_result?: {
+    outcome?: string;
+    summary?: string;
+    next_action?: string;
+    failed_checks?: string[];
+    passed_checks?: string[];
+  } | null;
+  security_policy?: {
+    mode?: string;
+    stage?: string;
+    task?: string;
+    allow?: string[];
+    block?: string[];
+  } | null;
+  security_verdict?: {
+    verdict?: string;
+    reason?: string;
+    next_action?: string;
+    advisory_mode?: boolean;
+    stage?: string;
+    allow?: string[];
+    block?: string[];
+  } | null;
   run_packet?: {
     provider_target?: string;
   };

--- a/winsmux-app/src/desktopClient.ts
+++ b/winsmux-app/src/desktopClient.ts
@@ -1,7 +1,13 @@
 import { invoke } from "@tauri-apps/api/core";
 
-type DesktopCommandName = "desktop_summary_snapshot" | "desktop_run_explain";
-type DesktopJsonRpcMethod = "desktop.summary.snapshot" | "desktop.run.explain";
+type DesktopCommandName =
+  | "desktop_summary_snapshot"
+  | "desktop_run_explain"
+  | "desktop_editor_read";
+type DesktopJsonRpcMethod =
+  | "desktop.summary.snapshot"
+  | "desktop.run.explain"
+  | "desktop.editor.read";
 
 interface DesktopJsonRpcRequest {
   jsonrpc: "2.0";
@@ -99,6 +105,7 @@ export interface DesktopRunProjection {
   pane_id: string;
   label: string;
   branch: string;
+  worktree: string;
   task: string;
   task_state: string;
   review_state: string;
@@ -159,6 +166,13 @@ export interface DesktopExplainPayload {
   }>;
 }
 
+export interface DesktopEditorFilePayload {
+  path: string;
+  content: string;
+  line_count: number;
+  truncated: boolean;
+}
+
 let nextDesktopJsonRpcId = 0;
 
 function normalizeDesktopError(action: string, error: unknown) {
@@ -175,6 +189,8 @@ function getDesktopJsonRpcMethod(command: DesktopCommandName): DesktopJsonRpcMet
       return "desktop.summary.snapshot";
     case "desktop_run_explain":
       return "desktop.run.explain";
+    case "desktop_editor_read":
+      return "desktop.editor.read";
   }
 }
 
@@ -255,5 +271,17 @@ export async function getDesktopRunExplain(runId: string) {
     );
   } catch (error) {
     throw normalizeDesktopError(`desktop_run_explain(${runId})`, error);
+  }
+}
+
+export async function getDesktopEditorFile(path: string, worktree?: string) {
+  try {
+    return await desktopCommandTransport.request<DesktopEditorFilePayload>(
+      "desktop_editor_read",
+      worktree ? { path, worktree } : { path },
+    );
+  } catch (error) {
+    const worktreeSuffix = worktree ? `, ${worktree}` : "";
+    throw normalizeDesktopError(`desktop_editor_read(${path}${worktreeSuffix})`, error);
   }
 }

--- a/winsmux-app/src/editorTargets.ts
+++ b/winsmux-app/src/editorTargets.ts
@@ -1,0 +1,44 @@
+export interface EditorPathCandidate {
+  path: string;
+  worktree: string;
+}
+
+export function getEditorFileKey(path: string, worktree = "") {
+  return `${worktree.trim() || "."}::${path}`;
+}
+
+export function getSourceChangeKey(change: EditorPathCandidate) {
+  return getEditorFileKey(change.path, change.worktree);
+}
+
+export function pickEditorPathCandidate<T extends EditorPathCandidate>(
+  candidates: T[],
+  path: string,
+  requestedWorktree = "",
+  selectedKey = "",
+) {
+  const pathMatches = candidates.filter((entry) => entry.path === path);
+  if (pathMatches.length === 0) {
+    return null;
+  }
+
+  if (requestedWorktree) {
+    const exact = pathMatches.find((entry) => entry.worktree === requestedWorktree);
+    if (exact) {
+      return exact;
+    }
+  }
+
+  if (pathMatches.length === 1) {
+    return pathMatches[0];
+  }
+
+  if (selectedKey) {
+    const selected = pathMatches.find((entry) => getSourceChangeKey(entry) === selectedKey);
+    if (selected) {
+      return selected;
+    }
+  }
+
+  return null;
+}

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -637,17 +637,15 @@ function renderSourceSummary() {
 
   const activeEntries = getProjectionSourceEntries();
   const visibleChanges = getVisibleSourceChanges();
-  const primaryChange = getPrimarySourceChange(visibleChanges);
   const entryCount = visibleChanges.length;
   const attentionCount = visibleChanges.filter((item) => item.needsAttention).length;
   const commitCandidates = visibleChanges.filter((item) => item.commitCandidate).length;
   const summaryItems = [
-    { label: "Branch", value: primaryChange?.branch ?? "No branch" },
-    { label: "Run", value: primaryChange?.run ?? "No selected run" },
+    { label: "Selected scope", value: getSourceFilterLabel(activeSourceFilter) },
+    { label: "Projected", value: `${activeEntries.length} files` },
     { label: "Changed", value: `${entryCount} files` },
-    { label: "Review", value: primaryChange?.review ?? "No review state" },
     { label: "Ready", value: `${commitCandidates} candidate${commitCandidates === 1 ? "" : "s"}` },
-    { label: "Risk", value: `${attentionCount} attention · ${activeEntries.length} projected` },
+    { label: "Risk", value: `${attentionCount} attention` },
   ];
 
   root.innerHTML = "";
@@ -1437,22 +1435,35 @@ async function openExplainForSelectedRun() {
 function appendFallbackExplain() {
   const timestamp = new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", hour12: false });
   const selectedRunId = getSelectedRunId();
+  const digestItem = getPrimaryDigestItem();
+  const hasSelectedDigest = Boolean(selectedRunId && digestItem?.run_id === selectedRunId);
+  const body = hasSelectedDigest
+    ? `Unable to load the latest explain payload for ${selectedRunId}. Backend summary still reports ${digestItem?.changed_file_count ?? 0} changed files and next ${digestItem?.next_action || "idle"}.`
+    : desktopSummarySnapshot && desktopSummarySnapshot.digest.summary.item_count > 0
+      ? "Explain is unavailable until a projected run is selected from the current backend summary."
+      : desktopSummarySnapshot
+        ? "The backend summary is connected, but no projected run is available to explain yet."
+        : "The backend summary is not connected yet. Once the desktop summary loads, Explain will follow the live run state.";
+  const details = hasSelectedDigest
+    ? [
+        { label: "run", value: selectedRunId as string },
+        { label: "next", value: digestItem?.next_action || "idle" },
+        { label: "changed", value: `${digestItem?.changed_file_count ?? 0}` },
+      ]
+    : desktopSummarySnapshot
+      ? [
+          { label: "runs", value: `${desktopSummarySnapshot.digest.summary.item_count}` },
+          { label: "inbox", value: `${desktopSummarySnapshot.inbox.summary.item_count}` },
+        ]
+      : [{ label: "state", value: "backend unavailable" }];
   appendRuntimeConversation({
     type: "operator",
     category: "activity",
     timestamp,
     actor: "Operator",
     title: "Explain opened",
-    body: selectedRunId
-      ? "Unable to load the latest explain payload. The current source context and run summary remain available while the backend refreshes."
-      : desktopSummarySnapshot
-        ? "No active backend run is available to explain yet. Wait for the digest to refresh or select a run from the current summary."
-        : "The backend summary is not connected yet. Once the desktop summary loads, Explain will follow the live run state.",
-    details: selectedRunId
-      ? [{ label: "run", value: selectedRunId }]
-      : desktopSummarySnapshot
-        ? [{ label: "inbox", value: `${desktopSummarySnapshot.inbox.summary.item_count}` }]
-        : [{ label: "state", value: "backend unavailable" }],
+    body,
+    details,
     tone: "info",
     runId: selectedRunId ?? undefined,
   });
@@ -1769,7 +1780,6 @@ function renderEditorSurface() {
     statusbar.textContent = "Secondary work surface: waiting for backend source data";
     return;
   }
-  const sourceChange = findSourceChangeByKey(selected.key);
   selectedEditorKey = selected.key;
 
   path.textContent = selected.path;
@@ -1779,9 +1789,6 @@ function renderEditorSurface() {
     `${selected.lineCount} lines`,
     selected.modified ? "Modified" : "Saved",
     selected.origin === "context" ? "Opened from context" : "Opened from explorer",
-    sourceChange
-      ? `${sourceChange.status} · ${sourceChange.branch}${sourceChange.worktree ? ` · ${sourceChange.worktree}` : ""}`
-      : "No source metadata",
   ]) {
     const chip = document.createElement("span");
     chip.className = `editor-meta-chip ${item === "Modified" ? "is-modified" : ""}`;
@@ -1790,9 +1797,7 @@ function renderEditorSurface() {
     meta.appendChild(chip);
   }
   code.textContent = selected.content;
-  statusbar.textContent = sourceChange
-    ? `Secondary work surface: ${selected.origin === "context" ? "run context" : "explorer"} -> ${selected.path} · ${sourceChange.branch} · ${sourceChange.review}`
-    : `Secondary work surface: ${selected.origin === "context" ? "run context" : "explorer"} -> ${selected.path}`;
+  statusbar.textContent = `Secondary work surface: ${selected.origin === "context" ? "run context" : "explorer"} -> ${selected.path}`;
   tabs.innerHTML = "";
 
   for (const editor of editors) {

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -8,6 +8,7 @@ import {
   type DesktopEditorFilePayload,
   type DesktopDigestItem,
   type DesktopExplainPayload,
+  type DesktopRunProjection,
   type DesktopSummarySnapshot,
 } from "./desktopClient";
 import { getEditorFileKey, getSourceChangeKey, pickEditorPathCandidate } from "./editorTargets";
@@ -186,6 +187,7 @@ const desktopStandaloneEditorTargets = new Map<string, EditorTarget>();
 const backendConversation: ConversationItem[] = [];
 const runtimeConversation: ConversationItem[] = [];
 const DESKTOP_SUMMARY_REFRESH_INTERVAL_MS = 15_000;
+const MAX_RUNTIME_CONVERSATION_ITEMS = 80;
 const themeState: ThemeState = {
   theme: "codex-dark",
   density: "comfortable",
@@ -1176,6 +1178,117 @@ function renderTimelineFilters() {
   }
 }
 
+function buildRunSummaryCards(
+  digestItem: DesktopDigestItem,
+  projection: DesktopRunProjection | null,
+  explainPayload: DesktopExplainPayload | null,
+) {
+  const cards: Array<{ label: string; value: string }> = [
+    { label: "Branch", value: digestItem.branch || projection?.branch || "no branch" },
+    {
+      label: "Head",
+      value: projection?.head_short || digestItem.head_short || "n/a",
+    },
+    {
+      label: "Worktree",
+      value: projection?.worktree || digestItem.worktree || "Project root",
+    },
+    {
+      label: "Provider",
+      value:
+        projection?.provider_target ||
+        digestItem.provider_target ||
+        explainPayload?.run.provider_target ||
+        explainPayload?.run_packet?.provider_target ||
+        "n/a",
+    },
+    {
+      label: "State",
+      value:
+        explainPayload?.explanation.current_state?.task_state ||
+        digestItem.task_state ||
+        projection?.task_state ||
+        "n/a",
+    },
+    {
+      label: "Review",
+      value:
+        explainPayload?.review_state?.status ||
+        digestItem.review_state ||
+        projection?.review_state ||
+        "n/a",
+    },
+    {
+      label: "Verify",
+      value:
+        projection?.verification_outcome ||
+        digestItem.verification_outcome ||
+        explainPayload?.evidence_digest.verification_outcome ||
+        "n/a",
+    },
+    {
+      label: "Security",
+      value:
+        projection?.security_blocked ||
+        digestItem.security_blocked ||
+        explainPayload?.evidence_digest.security_blocked ||
+        "n/a",
+    },
+  ];
+
+  if (projection?.hypothesis || explainPayload?.run.goal) {
+    cards.push({
+      label: "Goal",
+      value: projection?.hypothesis || explainPayload?.run.goal || "n/a",
+    });
+  }
+
+  if (projection?.consultation_ref || explainPayload?.consultation_summary?.next_test) {
+    cards.push({
+      label: "Consult",
+      value:
+        projection?.consultation_ref ||
+        explainPayload?.consultation_summary?.next_test ||
+        "n/a",
+    });
+  }
+
+  if (projection?.observation_pack_ref) {
+    cards.push({
+      label: "Observation",
+      value: projection.observation_pack_ref,
+    });
+  }
+
+  return cards
+    .filter((item) => item.value && item.value !== "n/a")
+    .slice(0, 10);
+}
+
+function buildRunSummaryFiles(
+  digestItem: DesktopDigestItem,
+  projection: DesktopRunProjection | null,
+  explainPayload: DesktopExplainPayload | null,
+) {
+  const candidates = [
+    ...(projection?.changed_files ?? []),
+    ...digestItem.changed_files,
+    ...(explainPayload?.evidence_digest.changed_files ?? []),
+  ];
+  return Array.from(new Set(candidates)).slice(0, 6);
+}
+
+function buildRunSummaryRecentEvents(explainPayload: DesktopExplainPayload | null) {
+  if (!explainPayload) {
+    return [];
+  }
+
+  return explainPayload.recent_events.slice(0, 3).map((event) => ({
+    title: event.event,
+    body: `${event.label}: ${event.message}`,
+  }));
+}
+
 function renderRunSummary() {
   const root = document.getElementById("selected-run-summary");
   if (!root) {
@@ -1184,6 +1297,11 @@ function renderRunSummary() {
 
   const digestItem = getPrimaryDigestItem();
   if (digestItem) {
+    const selectedProjection = getSelectedRunProjection();
+    const selectedExplainPayload = getSelectedExplainPayload();
+    const detailCards = buildRunSummaryCards(digestItem, selectedProjection, selectedExplainPayload);
+    const changedFiles = buildRunSummaryFiles(digestItem, selectedProjection, selectedExplainPayload);
+    const recentEvents = buildRunSummaryRecentEvents(selectedExplainPayload);
     const statusTone =
       digestItem.review_state === "PASS"
         ? "success"
@@ -1215,6 +1333,31 @@ function renderRunSummary() {
           <span class="run-summary-pill">${security}</span>
         </div>
         <div class="run-summary-body">${digestItem.task || "Summary-stream run surfaced by the backend adapter."}</div>
+        <div class="run-summary-detail-grid">
+          ${detailCards
+            .map(
+              (card) =>
+                `<div class="run-summary-detail-card"><div class="run-summary-detail-label">${card.label}</div><div class="run-summary-detail-value">${card.value}</div></div>`,
+            )
+            .join("")}
+        </div>
+        ${
+          changedFiles.length > 0
+            ? `<div class="run-summary-file-list">${changedFiles
+                .map((file) => `<span class="run-summary-file-pill">${file}</span>`)
+                .join("")}</div>`
+            : ""
+        }
+        ${
+          recentEvents.length > 0
+            ? `<div class="run-summary-event-list">${recentEvents
+                .map(
+                  (event) =>
+                    `<div class="run-summary-event-card"><div class="run-summary-detail-label">${event.title}</div><div class="run-summary-event-body">${event.body}</div></div>`,
+                )
+                .join("")}</div>`
+            : ""
+        }
         <div class="timeline-chip-row">
           <button type="button" class="timeline-chip" data-action="open-explain">Open Explain</button>
           <button type="button" class="timeline-chip" data-action="open-source-context">Source Context</button>
@@ -1379,6 +1522,7 @@ async function openExplainForSelectedRun() {
   }
 
   try {
+    const previousPayload = desktopExplainCache.get(selectedRunId) ?? null;
     const payload = await getDesktopRunExplain(selectedRunId);
     desktopExplainCache.set(selectedRunId, payload);
 
@@ -1408,17 +1552,21 @@ async function openExplainForSelectedRun() {
       bodyParts.push(`Recent: ${recent}`);
     }
 
-    runtimeConversation.push({
-      type: "operator",
-      category: "activity",
-      timestamp: new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", hour12: false }),
-      actor: "Operator",
-      title: "Explain opened",
-      body: bodyParts.join(" "),
-      details: detailItems,
-      tone: "info",
-      runId: payload.run.run_id,
-    });
+    const previousFingerprint = getExplainPayloadFingerprint(previousPayload);
+    const nextFingerprint = getExplainPayloadFingerprint(payload);
+    if (previousFingerprint !== nextFingerprint) {
+      appendRuntimeConversation({
+        type: "operator",
+        category: "activity",
+        timestamp: new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", hour12: false }),
+        actor: "Operator",
+        title: "Explain opened",
+        body: bodyParts.join(" "),
+        details: detailItems,
+        tone: "info",
+        runId: payload.run.run_id,
+      });
+    }
     await refreshDesktopSummary(payload.run.run_id);
   } catch (error) {
     console.warn("Failed to load desktop explain payload", error);
@@ -1430,7 +1578,7 @@ async function openExplainForSelectedRun() {
 function appendFallbackExplain() {
   const timestamp = new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", hour12: false });
   const selectedRunId = getSelectedRunId();
-  runtimeConversation.push({
+  appendRuntimeConversation({
     type: "operator",
     category: "activity",
     timestamp,
@@ -1804,6 +1952,260 @@ function getConversationItems() {
   return [...backendConversation, ...runtimeConversation];
 }
 
+function appendRuntimeConversation(item: ConversationItem) {
+  const lastItem = runtimeConversation[runtimeConversation.length - 1];
+  if (
+    lastItem &&
+    lastItem.type === item.type &&
+    lastItem.title === item.title &&
+    lastItem.body === item.body &&
+    lastItem.runId === item.runId
+  ) {
+    return;
+  }
+
+  runtimeConversation.push(item);
+  if (runtimeConversation.length > MAX_RUNTIME_CONVERSATION_ITEMS) {
+    runtimeConversation.splice(0, runtimeConversation.length - MAX_RUNTIME_CONVERSATION_ITEMS);
+  }
+}
+
+function getSelectedRunProjection() {
+  return getRunProjectionByRunId(getSelectedRunId());
+}
+
+function getSelectedExplainPayload() {
+  const runId = getSelectedRunId();
+  if (!runId) {
+    return null;
+  }
+  return desktopExplainCache.get(runId) ?? null;
+}
+
+function getExplainPayloadFingerprint(payload: DesktopExplainPayload | null | undefined) {
+  if (!payload) {
+    return "";
+  }
+
+  return JSON.stringify([
+    payload.run.run_id,
+    payload.run.state,
+    payload.run.task_state,
+    payload.run.review_state,
+    payload.run.provider_target,
+    payload.run.agent_role,
+    payload.run.branch,
+    payload.run.head_sha,
+    payload.run.worktree,
+    payload.run.changed_files.join("|"),
+    payload.explanation.summary,
+    payload.explanation.next_action,
+    payload.explanation.current_state?.state,
+    payload.explanation.current_state?.task_state,
+    payload.explanation.current_state?.review_state,
+    payload.explanation.current_state?.last_event,
+    payload.explanation.reasons.join("|"),
+    payload.evidence_digest.next_action,
+    payload.evidence_digest.verification_outcome,
+    payload.evidence_digest.security_blocked,
+    payload.evidence_digest.changed_files.join("|"),
+    payload.review_state?.status,
+    payload.consultation_summary?.recommendation,
+    payload.consultation_summary?.next_test,
+    payload.result_packet?.summary,
+    payload.result_packet?.next_action_hint,
+  ]);
+}
+
+function getRunProjectionFingerprint(projection: DesktopRunProjection | null | undefined) {
+  if (!projection) {
+    return "";
+  }
+
+  return JSON.stringify([
+    projection.head_sha,
+    projection.head_short,
+    projection.worktree,
+    projection.review_state,
+    projection.next_action,
+    projection.verification_outcome,
+    projection.security_blocked,
+    projection.branch,
+    projection.provider_target,
+    projection.hypothesis,
+    projection.confidence,
+    projection.observation_pack_ref,
+    projection.consultation_ref,
+    projection.changed_files.join("|"),
+    projection.summary,
+  ]);
+}
+
+function diffDesktopSummarySnapshots(
+  previousSnapshot: DesktopSummarySnapshot | null,
+  nextSnapshot: DesktopSummarySnapshot,
+) {
+  if (!previousSnapshot) {
+    return {
+      hasMeaningfulChange: true,
+      changedRunIds: [] as string[],
+      inboxCountChanged: false,
+      addedRunIds: [] as string[],
+      removedRunIds: [] as string[],
+    };
+  }
+
+  const previousProjectionMap = new Map(
+    previousSnapshot.run_projections.map((projection) => [projection.run_id, projection]),
+  );
+  const nextProjectionMap = new Map(
+    nextSnapshot.run_projections.map((projection) => [projection.run_id, projection]),
+  );
+
+  const changedRunIds: string[] = [];
+  const addedRunIds: string[] = [];
+  const removedRunIds: string[] = [];
+
+  for (const [runId, nextProjection] of nextProjectionMap) {
+    const previousProjection = previousProjectionMap.get(runId);
+    if (!previousProjection) {
+      addedRunIds.push(runId);
+      continue;
+    }
+
+    if (getRunProjectionFingerprint(previousProjection) !== getRunProjectionFingerprint(nextProjection)) {
+      changedRunIds.push(runId);
+    }
+  }
+
+  for (const runId of previousProjectionMap.keys()) {
+    if (!nextProjectionMap.has(runId)) {
+      removedRunIds.push(runId);
+    }
+  }
+
+  const inboxCountChanged =
+    previousSnapshot.inbox.summary.item_count !== nextSnapshot.inbox.summary.item_count;
+
+  return {
+    hasMeaningfulChange:
+      inboxCountChanged ||
+      addedRunIds.length > 0 ||
+      removedRunIds.length > 0 ||
+      changedRunIds.length > 0,
+    changedRunIds,
+    inboxCountChanged,
+    addedRunIds,
+    removedRunIds,
+  };
+}
+
+function buildDesktopFollowConversation(
+  previousSnapshot: DesktopSummarySnapshot | null,
+  nextSnapshot: DesktopSummarySnapshot,
+) {
+  const diff = diffDesktopSummarySnapshots(previousSnapshot, nextSnapshot);
+  if (!previousSnapshot || !diff.hasMeaningfulChange) {
+    return [];
+  }
+
+  const timestamp = new Date(nextSnapshot.generated_at).toLocaleTimeString([], {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  });
+  const previousProjectionMap = new Map(
+    previousSnapshot.run_projections.map((projection) => [projection.run_id, projection]),
+  );
+  const nextProjectionMap = new Map(
+    nextSnapshot.run_projections.map((projection) => [projection.run_id, projection]),
+  );
+  const selected = resolveSelectedRunId(nextSnapshot);
+  const prioritizedChangedRunIds = [
+    ...diff.changedRunIds.filter((runId) => runId === selected),
+    ...diff.addedRunIds.filter((runId) => runId === selected),
+    ...diff.changedRunIds.filter((runId) => runId !== selected),
+    ...diff.addedRunIds.filter((runId) => runId !== selected),
+  ].slice(0, 3);
+
+  const items: ConversationItem[] = [];
+  for (const runId of prioritizedChangedRunIds) {
+    const projection = nextProjectionMap.get(runId);
+    if (!projection) {
+      continue;
+    }
+
+    items.push({
+      type: "system",
+      category:
+        projection.review_state === "PENDING" ||
+        projection.review_state === "FAIL" ||
+        projection.review_state === "FAILED"
+          ? "review"
+          : "activity",
+      timestamp,
+      actor: projection.label || projection.pane_id || "System",
+      title: diff.addedRunIds.includes(runId) ? "Run surfaced" : "Run updated",
+      body:
+        `Next ${projection.next_action || "idle"} · ` +
+        `${projection.changed_files.length} changed files · ` +
+        `review ${projection.review_state || "n/a"}.`,
+      details: [
+        { label: "run", value: runId },
+        { label: "branch", value: projection.branch || "no branch" },
+        { label: "head", value: projection.head_short || "n/a" },
+        { label: "verify", value: projection.verification_outcome || "n/a" },
+      ],
+      tone:
+        projection.review_state === "PASS"
+          ? "success"
+          : projection.review_state === "PENDING"
+            ? "warning"
+            : "info",
+      runId,
+      statusLabel: projection.next_action || projection.review_state || undefined,
+    });
+  }
+
+  for (const runId of diff.removedRunIds.slice(0, 2)) {
+    const previousProjection = previousProjectionMap.get(runId);
+    if (!previousProjection) {
+      continue;
+    }
+
+    items.push({
+      type: "system",
+      category: "attention",
+      timestamp,
+      actor: previousProjection.label || previousProjection.pane_id || "System",
+      title: "Run removed",
+      body: `Run ${runId} dropped out of the desktop summary snapshot.`,
+      details: [
+        { label: "branch", value: previousProjection.branch || "no branch" },
+        { label: "head", value: previousProjection.head_short || "n/a" },
+      ],
+      tone: "warning",
+      runId,
+      statusLabel: previousProjection.review_state || undefined,
+    });
+  }
+
+  if (diff.inboxCountChanged) {
+    items.push({
+      type: "system",
+      category: "attention",
+      timestamp,
+      actor: "System",
+      title: "Inbox changed",
+      body: `Inbox items moved from ${previousSnapshot.inbox.summary.item_count} to ${nextSnapshot.inbox.summary.item_count}.`,
+      details: [{ label: "inbox", value: `${nextSnapshot.inbox.summary.item_count}` }],
+      tone: "warning",
+    });
+  }
+
+  return items.slice(0, 4);
+}
+
 function setTerminalDrawer(open: boolean) {
   terminalDrawerOpen = open;
   const drawer = document.getElementById("terminal-drawer");
@@ -1902,7 +2304,7 @@ function syncResponsiveShell() {
 function appendUserMessage(message: string, attachments: ComposerAttachment[]) {
   const now = new Date();
   const timestamp = `${`${now.getHours()}`.padStart(2, "0")}:${`${now.getMinutes()}`.padStart(2, "0")}`;
-  runtimeConversation.push({
+  appendRuntimeConversation({
     type: "user",
     category: "user",
     timestamp,
@@ -1914,7 +2316,7 @@ function appendUserMessage(message: string, attachments: ComposerAttachment[]) {
       sizeLabel: attachment.sizeLabel,
     })),
   });
-  runtimeConversation.push({
+  appendRuntimeConversation({
     type: "operator",
     category: "activity",
     timestamp,
@@ -2211,7 +2613,9 @@ async function refreshDesktopSummary(forceExplainRunId?: string | null) {
 
   desktopSummaryRefreshInFlight = (async () => {
   try {
+    const previousSnapshot = desktopSummarySnapshot;
     const snapshot = await getDesktopSummarySnapshot();
+    const diff = diffDesktopSummarySnapshots(previousSnapshot, snapshot);
     desktopSummarySnapshot = snapshot;
     selectedRunId = resolveSelectedRunId(snapshot, forceExplainRunId);
     pruneExplainCache(snapshot, forceExplainRunId);
@@ -2224,7 +2628,14 @@ async function refreshDesktopSummary(forceExplainRunId?: string | null) {
       }
     }
 
+    if (previousSnapshot && !diff.hasMeaningfulChange && !forceExplainRunId) {
+      return;
+    }
+
     backendConversation.splice(0, backendConversation.length, ...buildDesktopSummaryConversation(snapshot));
+    for (const item of buildDesktopFollowConversation(previousSnapshot, snapshot)) {
+      appendRuntimeConversation(item);
+    }
     renderDesktopSurfaces();
   } catch (error) {
     console.warn("Failed to load desktop summary snapshot", error);

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -1178,239 +1178,6 @@ function renderTimelineFilters() {
   }
 }
 
-function buildRunSummaryCards(
-  digestItem: DesktopDigestItem,
-  projection: DesktopRunProjection | null,
-  explainPayload: DesktopExplainPayload | null,
-) {
-  const cards: Array<{ label: string; value: string }> = [
-    { label: "Branch", value: digestItem.branch || projection?.branch || "no branch" },
-    {
-      label: "Head",
-      value: projection?.head_short || digestItem.head_short || "n/a",
-    },
-    {
-      label: "Worktree",
-      value: projection?.worktree || digestItem.worktree || "Project root",
-    },
-    {
-      label: "Provider",
-      value:
-        projection?.provider_target ||
-        digestItem.provider_target ||
-        explainPayload?.run.provider_target ||
-        explainPayload?.run_packet?.provider_target ||
-        "n/a",
-    },
-    {
-      label: "State",
-      value:
-        explainPayload?.explanation.current_state?.task_state ||
-        digestItem.task_state ||
-        projection?.task_state ||
-        "n/a",
-    },
-    {
-      label: "Review",
-      value:
-        explainPayload?.review_state?.status ||
-        digestItem.review_state ||
-        projection?.review_state ||
-        "n/a",
-    },
-    {
-      label: "Verify",
-      value:
-        projection?.verification_outcome ||
-        digestItem.verification_outcome ||
-        explainPayload?.evidence_digest.verification_outcome ||
-        "n/a",
-    },
-    {
-      label: "Security",
-      value:
-        projection?.security_blocked ||
-        digestItem.security_blocked ||
-        explainPayload?.evidence_digest.security_blocked ||
-        "n/a",
-    },
-  ];
-
-  const verificationDetail = summarizeVerificationDetail(explainPayload);
-  if (verificationDetail) {
-    cards.push({
-      label: "Verify detail",
-      value: verificationDetail,
-    });
-  }
-
-  const securityDetail = summarizeSecurityDetail(explainPayload);
-  if (securityDetail) {
-    cards.push({
-      label: "Security detail",
-      value: securityDetail,
-    });
-  }
-
-  const actionDetail = summarizeActionItems(explainPayload);
-  if (actionDetail) {
-    cards.push({
-      label: "Action",
-      value: actionDetail,
-    });
-  }
-
-  if (projection?.hypothesis || explainPayload?.run.goal) {
-    cards.push({
-      label: "Goal",
-      value: projection?.hypothesis || explainPayload?.run.goal || "n/a",
-    });
-  }
-
-  if (projection?.consultation_ref || explainPayload?.consultation_summary?.next_test) {
-    cards.push({
-      label: "Consult",
-      value:
-        projection?.consultation_ref ||
-        explainPayload?.consultation_summary?.next_test ||
-        "n/a",
-    });
-  }
-
-  if (projection?.observation_pack_ref) {
-    cards.push({
-      label: "Observation",
-      value: projection.observation_pack_ref,
-    });
-  }
-
-  return cards
-    .filter((item) => item.value && item.value !== "n/a")
-    .slice(0, 14);
-}
-
-function buildRunSummaryFiles(
-  digestItem: DesktopDigestItem,
-  projection: DesktopRunProjection | null,
-  explainPayload: DesktopExplainPayload | null,
-) {
-  const candidates = [
-    ...(projection?.changed_files ?? []),
-    ...digestItem.changed_files,
-    ...(explainPayload?.evidence_digest.changed_files ?? []),
-  ];
-  return Array.from(new Set(candidates)).slice(0, 6);
-}
-
-function buildRunSummaryRecentEvents(explainPayload: DesktopExplainPayload | null) {
-  if (!explainPayload) {
-    return [];
-  }
-
-  return explainPayload.recent_events.slice(0, 3).map((event) => ({
-    title: event.event,
-    body: `${event.label}: ${event.message}`,
-  }));
-}
-
-function summarizeVerificationDetail(explainPayload: DesktopExplainPayload | null) {
-  if (!explainPayload) {
-    return "";
-  }
-
-  const parts: string[] = [];
-  const contract = explainPayload.verification_contract;
-  const result = explainPayload.verification_result;
-
-  if (contract?.mode) {
-    parts.push(`contract ${contract.mode}`);
-  }
-  if (typeof contract?.required === "boolean") {
-    parts.push(contract.required ? "required" : "optional");
-  }
-  if (result?.outcome) {
-    parts.push(`result ${result.outcome}`);
-  }
-  if (result?.summary) {
-    parts.push(result.summary);
-  } else if (result?.next_action) {
-    parts.push(result.next_action);
-  }
-  if (Array.isArray(result?.failed_checks) && result.failed_checks.length > 0) {
-    parts.push(`failed ${result.failed_checks[0]}`);
-  }
-
-  return parts.join(" · ");
-}
-
-function summarizeSecurityDetail(explainPayload: DesktopExplainPayload | null) {
-  if (!explainPayload) {
-    return "";
-  }
-
-  const parts: string[] = [];
-  const policy = explainPayload.security_policy;
-  const verdict = explainPayload.security_verdict;
-
-  if (policy?.mode) {
-    parts.push(`policy ${policy.mode}`);
-  }
-  if (verdict?.verdict) {
-    parts.push(`verdict ${verdict.verdict}`);
-  }
-  if (verdict?.reason) {
-    parts.push(verdict.reason);
-  } else if (verdict?.next_action) {
-    parts.push(verdict.next_action);
-  }
-
-  return parts.join(" · ");
-}
-
-function summarizeActionItems(explainPayload: DesktopExplainPayload | null) {
-  if (!explainPayload || !Array.isArray(explainPayload.action_items) || explainPayload.action_items.length === 0) {
-    return "";
-  }
-
-  const firstItem = explainPayload.action_items[0];
-  const count = explainPayload.action_items.length;
-  const parts = [firstItem.kind, firstItem.message].filter((value): value is string => Boolean(value && value.trim()));
-  if (count > 1) {
-    parts.push(`+${count - 1} more`);
-  }
-  return parts.join(" · ");
-}
-
-function buildRunSummaryChips(
-  digestItem: DesktopDigestItem,
-  explainPayload: DesktopExplainPayload | null,
-  changedFiles: string[],
-) {
-  const chips: Array<{ label: string; action: ChipAction }> = [
-    { label: "Open Explain", action: "open-explain" },
-  ];
-
-  if (changedFiles.length > 0) {
-    chips.push({ label: "Open in Editor", action: "open-editor" });
-  }
-
-  if (
-    explainPayload?.verification_result ||
-    explainPayload?.security_verdict ||
-    (Array.isArray(explainPayload?.action_items) && explainPayload.action_items.length > 0) ||
-    digestItem.review_state === "PENDING" ||
-    digestItem.review_state === "FAIL" ||
-    digestItem.review_state === "FAILED"
-  ) {
-    chips.push({ label: "Open Audit", action: "toggle-context" });
-  } else {
-    chips.push({ label: "Source Context", action: "open-source-context" });
-  }
-
-  chips.push({ label: "Terminal", action: "open-terminal" });
-  return chips;
-}
-
 function renderRunSummary() {
   const root = document.getElementById("selected-run-summary");
   if (!root) {
@@ -1419,12 +1186,6 @@ function renderRunSummary() {
 
   const digestItem = getPrimaryDigestItem();
   if (digestItem) {
-    const selectedProjection = getSelectedRunProjection();
-    const selectedExplainPayload = getSelectedExplainPayload();
-    const detailCards = buildRunSummaryCards(digestItem, selectedProjection, selectedExplainPayload);
-    const changedFiles = buildRunSummaryFiles(digestItem, selectedProjection, selectedExplainPayload);
-    const recentEvents = buildRunSummaryRecentEvents(selectedExplainPayload);
-    const chips = buildRunSummaryChips(digestItem, selectedExplainPayload, changedFiles);
     const statusTone =
       digestItem.review_state === "PASS"
         ? "success"
@@ -1456,38 +1217,10 @@ function renderRunSummary() {
           <span class="run-summary-pill">${security}</span>
         </div>
         <div class="run-summary-body">${digestItem.task || "Summary-stream run surfaced by the backend adapter."}</div>
-        <div class="run-summary-detail-grid">
-          ${detailCards
-            .map(
-              (card) =>
-                `<div class="run-summary-detail-card"><div class="run-summary-detail-label">${card.label}</div><div class="run-summary-detail-value">${card.value}</div></div>`,
-            )
-            .join("")}
-        </div>
-        ${
-          changedFiles.length > 0
-            ? `<div class="run-summary-file-list">${changedFiles
-                .map((file) => `<span class="run-summary-file-pill">${file}</span>`)
-                .join("")}</div>`
-            : ""
-        }
-        ${
-          recentEvents.length > 0
-            ? `<div class="run-summary-event-list">${recentEvents
-                .map(
-                  (event) =>
-                    `<div class="run-summary-event-card"><div class="run-summary-detail-label">${event.title}</div><div class="run-summary-event-body">${event.body}</div></div>`,
-                )
-                .join("")}</div>`
-            : ""
-        }
         <div class="timeline-chip-row">
-          ${chips
-            .map(
-              (chip) =>
-                `<button type="button" class="timeline-chip" data-action="${chip.action}">${chip.label}</button>`,
-            )
-            .join("")}
+          <button type="button" class="timeline-chip" data-action="open-explain">Open Explain</button>
+          <button type="button" class="timeline-chip" data-action="open-source-context">Source Context</button>
+          <button type="button" class="timeline-chip" data-action="open-terminal">Terminal</button>
         </div>
       </div>
     `;
@@ -2096,18 +1829,6 @@ function appendRuntimeConversation(item: ConversationItem) {
   }
 }
 
-function getSelectedRunProjection() {
-  return getRunProjectionByRunId(getSelectedRunId());
-}
-
-function getSelectedExplainPayload() {
-  const runId = getSelectedRunId();
-  if (!runId) {
-    return null;
-  }
-  return desktopExplainCache.get(runId) ?? null;
-}
-
 function getExplainPayloadFingerprint(payload: DesktopExplainPayload | null | undefined) {
   if (!payload) {
     return "";
@@ -2136,29 +1857,6 @@ function getExplainPayloadFingerprint(payload: DesktopExplainPayload | null | un
     payload.evidence_digest.security_blocked,
     payload.evidence_digest.changed_files.join("|"),
     payload.review_state?.status,
-    payload.consultation_summary?.recommendation,
-    payload.consultation_summary?.next_test,
-    payload.action_items?.map((item) => `${item.kind}:${item.message}`).join("|"),
-    payload.verification_contract?.mode,
-    payload.verification_contract?.required,
-    payload.verification_contract?.checks?.join("|"),
-    payload.verification_contract?.commands?.join("|"),
-    payload.verification_result?.outcome,
-    payload.verification_result?.summary,
-    payload.verification_result?.next_action,
-    payload.verification_result?.passed_checks?.join("|"),
-    payload.verification_result?.failed_checks?.join("|"),
-    payload.security_policy?.mode,
-    payload.security_policy?.stage,
-    payload.security_policy?.task,
-    payload.security_policy?.allow?.join("|"),
-    payload.security_policy?.block?.join("|"),
-    payload.security_verdict?.verdict,
-    payload.security_verdict?.stage,
-    payload.security_verdict?.reason,
-    payload.security_verdict?.next_action,
-    payload.security_verdict?.allow?.join("|"),
-    payload.security_verdict?.block?.join("|"),
     payload.result_packet?.summary,
     payload.result_packet?.next_action_hint,
   ]);
@@ -2179,10 +1877,6 @@ function getRunProjectionFingerprint(projection: DesktopRunProjection | null | u
     projection.security_blocked,
     projection.branch,
     projection.provider_target,
-    projection.hypothesis,
-    projection.confidence,
-    projection.observation_pack_ref,
-    projection.consultation_ref,
     projection.changed_files.join("|"),
     projection.summary,
   ]);

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -2,12 +2,15 @@ import { Terminal } from "xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import "xterm/css/xterm.css";
 import {
+  getDesktopEditorFile,
   getDesktopRunExplain,
   getDesktopSummarySnapshot,
+  type DesktopEditorFilePayload,
   type DesktopDigestItem,
   type DesktopExplainPayload,
   type DesktopSummarySnapshot,
 } from "./desktopClient";
+import { getEditorFileKey, getSourceChangeKey, pickEditorPathCandidate } from "./editorTargets";
 import {
   closePtyPane,
   resizePtyPane,
@@ -68,11 +71,13 @@ interface ExplorerItem {
   depth: number;
   kind: "folder" | "file";
   path?: string;
+  worktree?: string;
   open?: boolean;
   active?: boolean;
 }
 
 interface EditorFile {
+  key: string;
   path: string;
   summary: string;
   content: string;
@@ -81,6 +86,16 @@ interface EditorFile {
   modified?: boolean;
   origin: "explorer" | "context";
   active?: boolean;
+}
+
+interface EditorTarget {
+  key: string;
+  path: string;
+  summary: string;
+  worktree: string;
+  origin: "explorer" | "context";
+  modified: boolean;
+  sourceChange?: SourceChange;
 }
 
 type SourceFilter = "all" | "candidates" | "attention" | `pane:${string}`;
@@ -92,6 +107,7 @@ interface SourceChange {
   path: string;
   summary: string;
   paneLabel: string;
+  worktree: string;
   status: ChangeStatus;
   risk: ChangeRisk;
   branch: string;
@@ -100,15 +116,6 @@ interface SourceChange {
   needsAttention: boolean;
   run: string;
   review: string;
-}
-
-interface SourceControlState {
-  entries: SourceChange[];
-}
-
-interface ContextSection {
-  label: string;
-  value: string;
 }
 
 interface FooterStatusItem {
@@ -158,7 +165,8 @@ let settingsSheetOpen = false;
 let sidebarOpen = true;
 let composerImeActive = false;
 let sidebarWidth = 292;
-let selectedEditorPath = "winsmux-app/src/main.ts";
+let selectedEditorKey = "";
+let selectedRunId: string | null = null;
 let activeComposerMode: ComposerMode = "dispatch";
 let activeSourceFilter: SourceFilter = "all";
 let activeTimelineFilter: TimelineFilter = "all";
@@ -169,7 +177,15 @@ let commandBarImeActive = false;
 let lastCommandBarFocus: HTMLElement | null = null;
 let pendingAttachments: ComposerAttachment[] = [];
 let desktopSummarySnapshot: DesktopSummarySnapshot | null = null;
+let desktopSummaryRefreshInFlight: Promise<void> | null = null;
 const desktopExplainCache = new Map<string, DesktopExplainPayload>();
+const desktopEditorFileCache = new Map<string, EditorFile>();
+const desktopEditorLoadingPaths = new Set<string>();
+const desktopEditorLoadErrors = new Map<string, string>();
+const desktopStandaloneEditorTargets = new Map<string, EditorTarget>();
+const backendConversation: ConversationItem[] = [];
+const runtimeConversation: ConversationItem[] = [];
+const DESKTOP_SUMMARY_REFRESH_INTERVAL_MS = 15_000;
 const themeState: ThemeState = {
   theme: "codex-dark",
   density: "comfortable",
@@ -188,209 +204,6 @@ const timelineFilters: Array<{ filter: TimelineFilter; label: string }> = [
   { filter: "attention", label: "Attention" },
   { filter: "review", label: "Review" },
   { filter: "activity", label: "Activity" },
-];
-
-const seedConversation: ConversationItem[] = [
-  {
-    type: "user",
-    category: "user",
-    timestamp: "09:41",
-    actor: "User",
-    body: "Please tighten the notification boundary and show why this run is blocked.",
-  },
-  {
-    type: "operator",
-    category: "activity",
-    timestamp: "09:42",
-    actor: "Operator",
-    title: "Operator update",
-    body: "Inbox shows 2 approval waits. I am checking run ledger, source context, and the evidence digest before deciding the next action.",
-    details: [
-      { label: "focus", value: "run-246" },
-      { label: "scope", value: "branch/head mismatch" },
-    ],
-    tone: "info",
-    runId: "run-246",
-  },
-  {
-    type: "system",
-    category: "attention",
-    timestamp: "09:43",
-    actor: "System",
-    title: "Commit blocked",
-    body: "worker-2 changed 3 files. Review passed, but branch/head mismatch still blocks commit. Open Explain or inspect the edited files.",
-    details: [
-      { label: "run", value: "run-246" },
-      { label: "slot", value: "worker-3" },
-      { label: "review", value: "passed" },
-      { label: "next", value: "Open Explain" },
-    ],
-    chips: [
-      { label: "Open Explain", action: "open-explain" },
-      { label: "Open in Editor", action: "open-editor" },
-      { label: "Source Context", action: "open-source-context" },
-      { label: "Terminal", action: "open-terminal" },
-    ],
-    tone: "warning",
-    runId: "run-246",
-    statusLabel: "Blocked",
-  },
-  {
-    type: "operator",
-    category: "review",
-    timestamp: "09:44",
-    actor: "Operator",
-    title: "Review boundary",
-    body: "Only external-facing review and commit-ready events should surface through the channel layer. Internal dispatch noise stays inside the workspace.",
-    details: [
-      { label: "channel", value: "external only" },
-      { label: "profile", value: "review_requested, blocked, commit_ready" },
-    ],
-    tone: "focus",
-  },
-  {
-    type: "system",
-    category: "review",
-    timestamp: "09:46",
-    actor: "System",
-    title: "Review requested",
-    body: "A review-capable slot is ready to inspect the changed files for run-245. The timeline keeps the request, evidence, and next action in the same feed.",
-    details: [
-      { label: "run", value: "run-245" },
-      { label: "slot", value: "worker-2" },
-      { label: "target", value: "Changed files" },
-    ],
-    chips: [
-      { label: "Open in Editor", action: "open-editor" },
-      { label: "Source Context", action: "open-source-context" },
-    ],
-    tone: "focus",
-    runId: "run-245",
-    statusLabel: "Review",
-  },
-  {
-    type: "system",
-    category: "activity",
-    timestamp: "09:48",
-    actor: "worker-2",
-    title: "Pane report",
-    body: "worker-2 returned a structured execution report for the selected run.",
-    details: [
-      { label: "STATUS", value: "SUCCESS" },
-      { label: "TASK", value: "TASK-138 source-control context slice" },
-      { label: "RESULT", value: "source-control context now opens changed files in the editor with worktree-aware metadata" },
-      { label: "FILES_CHANGED", value: "index.html, src/main.ts, src/styles.css" },
-      { label: "ISSUES", value: "none" },
-    ],
-    tone: "info",
-    runId: "run-138",
-    statusLabel: "SUCCESS",
-  },
-];
-
-const sessionItems: SessionItem[] = [
-  { name: "winsmux", meta: "operator active · 2 runs blocked", active: true },
-  { name: "release-check", meta: "digest clean · no review waits" },
-];
-
-const explorerItems: ExplorerItem[] = [
-  { label: "winsmux-app", depth: 0, kind: "folder", open: true },
-  { label: "src", depth: 1, kind: "folder", open: true },
-  { label: "main.ts", depth: 2, kind: "file", path: "winsmux-app/src/main.ts", active: true },
-  { label: "styles.css", depth: 2, kind: "file", path: "winsmux-app/src/styles.css" },
-  { label: "index.html", depth: 1, kind: "file", path: "winsmux-app/index.html" },
-  { label: "winsmux-core", depth: 0, kind: "folder" },
-];
-
-const editorFiles: EditorFile[] = [
-  {
-    path: "winsmux-app/src/main.ts",
-    summary: "Conversation shell scaffold",
-    language: "TypeScript",
-    lineCount: 138,
-    modified: true,
-    origin: "context",
-    active: true,
-    content:
-      "const summaryStream = [\n  'blocked',\n  'review_requested',\n  'commit_ready',\n];\n\nfunction openEditorSurface() {\n  // Secondary work surface opened from conversation or source context.\n}\n",
-  },
-  {
-    path: "winsmux-app/src/styles.css",
-    summary: "Workspace sidebar and responsive shell",
-    language: "CSS",
-    lineCount: 74,
-    modified: true,
-    origin: "context",
-    content:
-      ".workspace-sidebar {\n  width: var(--sidebar-width);\n}\n\n.editor-secondary-surface {\n  border-left: 1px solid var(--border-muted);\n}\n",
-  },
-  {
-    path: "winsmux-app/index.html",
-    summary: "Operator shell structure and panel hierarchy",
-    language: "HTML",
-    lineCount: 67,
-    origin: "explorer",
-    content:
-      "<section id=\"conversation-panel\">\n  <div id=\"conversation-timeline\"></div>\n  <form id=\"composer\"></form>\n</section>\n\n<aside id=\"editor-surface\" hidden></aside>\n",
-  },
-  {
-    path: "winsmux-core/scripts/team-pipeline.ps1",
-    summary: "Review-capable slot dispatch and branch alignment gate",
-    language: "PowerShell",
-    lineCount: 44,
-    modified: true,
-    origin: "context",
-    content:
-      "function Resolve-ReviewTarget {\n  param($Run)\n  # Review is now a slot capability, not a dedicated pane kind.\n}\n\nif ($branchMismatch) {\n  return 'blocked'\n}\n",
-  },
-];
-
-const sourceControlState: SourceControlState = {
-  entries: [
-  {
-    path: "winsmux-app/src/main.ts",
-    summary: "Conversation shell source-control actions and worktree metadata",
-    paneLabel: "worker-2",
-    status: "modified",
-    risk: "medium",
-    branch: "codex/task138-source-context",
-    lines: "+46 -11",
-    commitCandidate: true,
-    needsAttention: false,
-    run: "run-245",
-    review: "passed",
-  },
-  {
-    path: "winsmux-app/src/styles.css",
-    summary: "Sidebar/context badges and source-control overview cards",
-    paneLabel: "worker-2",
-    status: "modified",
-    risk: "low",
-    branch: "codex/task138-source-context",
-    lines: "+38 -4",
-    commitCandidate: true,
-    needsAttention: false,
-    run: "run-245",
-    review: "passed",
-  },
-  {
-    path: "winsmux-core/scripts/team-pipeline.ps1",
-    summary: "Branch mismatch still blocks commit despite review PASS",
-    paneLabel: "worker-3",
-    status: "modified",
-    risk: "high",
-    branch: "codex/task264-review-capable-slot",
-    lines: "+9 -2",
-    commitCandidate: false,
-    needsAttention: true,
-    run: "run-246",
-    review: "blocked",
-  },
-  ],
-};
-
-const baseContextSections: ContextSection[] = [
-  { label: "next", value: "Open Explain" },
 ];
 
 const themeOptions: Array<{ value: ThemeMode; label: string; description: string }> = [
@@ -523,7 +336,7 @@ function renderSessions() {
 
 function getSessionItems() {
   if (!desktopSummarySnapshot) {
-    return sessionItems;
+    return [{ name: "winsmux", meta: "Waiting for backend summary", active: true }] satisfies SessionItem[];
   }
 
   const board = desktopSummarySnapshot.board.summary;
@@ -547,6 +360,38 @@ function getRunProjections() {
   return desktopSummarySnapshot?.run_projections ?? [];
 }
 
+function getAvailableRunIds(snapshot: DesktopSummarySnapshot | null = desktopSummarySnapshot) {
+  if (!snapshot) {
+    return [] as string[];
+  }
+
+  const runIds = new Set<string>();
+  for (const item of snapshot.digest.items) {
+    runIds.add(item.run_id);
+  }
+  for (const projection of snapshot.run_projections) {
+    runIds.add(projection.run_id);
+  }
+  return Array.from(runIds);
+}
+
+function resolveSelectedRunId(snapshot: DesktopSummarySnapshot | null = desktopSummarySnapshot, preferredRunId?: string | null) {
+  const availableRunIds = getAvailableRunIds(snapshot);
+  if (availableRunIds.length === 0) {
+    return null;
+  }
+
+  if (preferredRunId && availableRunIds.includes(preferredRunId)) {
+    return preferredRunId;
+  }
+
+  if (selectedRunId && availableRunIds.includes(selectedRunId)) {
+    return selectedRunId;
+  }
+
+  return availableRunIds[0] ?? null;
+}
+
 function getRunProjectionByRunId(runId: string | null) {
   if (!runId) {
     return null;
@@ -554,10 +399,14 @@ function getRunProjectionByRunId(runId: string | null) {
   return getRunProjections().find((projection) => projection.run_id === runId) ?? null;
 }
 
+function setSelectedRun(runId: string | null) {
+  selectedRunId = resolveSelectedRunId(desktopSummarySnapshot, runId);
+}
+
 function getProjectionSourceEntries(): SourceChange[] {
   const projections = getRunProjections();
   if (projections.length === 0) {
-    return sourceControlState.entries;
+    return [];
   }
 
   const entries: SourceChange[] = [];
@@ -584,6 +433,7 @@ function getProjectionSourceEntries(): SourceChange[] {
         path,
         summary: recentReason || projection.summary || projection.task || `Projected from ${projection.run_id}`,
         paneLabel: projection.label || projection.pane_id || "summary-stream",
+        worktree: projection.worktree || "",
         status: "modified",
         risk,
         branch: projection.branch || "no branch",
@@ -596,7 +446,109 @@ function getProjectionSourceEntries(): SourceChange[] {
     }
   }
 
-  return entries.length > 0 ? entries : sourceControlState.entries;
+  return entries;
+}
+
+function findSourceChangeByKey(key: string) {
+  return getProjectionSourceEntries().find((entry) => getSourceChangeKey(entry) === key);
+}
+
+function findSourceChangeByPath(path: string, worktree = "") {
+  return (
+    pickEditorPathCandidate(getVisibleSourceChanges(), path, worktree, selectedEditorKey) ??
+    pickEditorPathCandidate(getProjectionSourceEntries(), path, worktree, selectedEditorKey)
+  );
+}
+
+function createStandaloneEditorTarget(path: string, worktree = ""): EditorTarget {
+  const key = getEditorFileKey(path, worktree);
+  return {
+    key,
+    path,
+    summary: `Project file preview · ${path.split("/").pop() ?? path}`,
+    worktree,
+    origin: "explorer",
+    modified: false,
+  };
+}
+
+function getExplorerItems() {
+  const targets = new Map<string, EditorTarget>();
+  for (const entry of getProjectionSourceEntries()) {
+    const target = getEditorTargetForSourceChange(entry);
+    if (target) {
+      targets.set(target.key, target);
+    }
+  }
+  for (const [key, target] of desktopStandaloneEditorTargets) {
+    if (!targets.has(key)) {
+      targets.set(key, target);
+    }
+  }
+
+  const items: ExplorerItem[] = [];
+  const seenFolders = new Set<string>();
+
+  for (const target of Array.from(targets.values()).sort((left, right) => left.path.localeCompare(right.path))) {
+    const normalizedPath = target.path.replace(/\\/g, "/");
+    const segments = normalizedPath.split("/").filter(Boolean);
+    let currentPath = "";
+    segments.forEach((segment, index) => {
+      currentPath = currentPath ? `${currentPath}/${segment}` : segment;
+      const depth = index;
+      const isFile = index === segments.length - 1;
+      if (isFile) {
+        items.push({
+          label: segment,
+          depth,
+          kind: "file",
+          path: target.path,
+          worktree: target.worktree,
+          active: target.key === selectedEditorKey,
+        });
+        return;
+      }
+
+      if (seenFolders.has(currentPath)) {
+        return;
+      }
+
+      seenFolders.add(currentPath);
+      items.push({
+        label: segment,
+        depth,
+        kind: "folder",
+        open: true,
+      });
+    });
+  }
+
+  return items;
+}
+
+function getEditorTargetForSourceChange(sourceChange: SourceChange | undefined): EditorTarget | null {
+  if (!sourceChange) {
+    return null;
+  }
+
+  return {
+    key: getSourceChangeKey(sourceChange),
+    path: sourceChange.path,
+    summary: sourceChange.summary,
+    worktree: sourceChange.worktree,
+    origin: "context",
+    modified: sourceChange.status !== "deleted",
+    sourceChange,
+  };
+}
+
+function getEditorTargetByKey(key: string): EditorTarget | null {
+  const sourceChange = findSourceChangeByKey(key);
+  if (sourceChange) {
+    return getEditorTargetForSourceChange(sourceChange);
+  }
+
+  return desktopStandaloneEditorTargets.get(key) ?? null;
 }
 
 function getPaneSourceFilter(label: string): SourceFilter {
@@ -617,7 +569,18 @@ function renderExplorer() {
     return;
   }
 
+  const explorerItems = getExplorerItems();
   root.innerHTML = "";
+  if (explorerItems.length === 0) {
+    const empty = document.createElement("div");
+    empty.className = "sidebar-row";
+    empty.innerHTML =
+      `<span class="sidebar-row-title">No projected files</span>` +
+      `<span class="sidebar-row-meta">Changed files will appear here after the desktop summary refreshes.</span>`;
+    root.appendChild(empty);
+    return;
+  }
+
   for (const item of explorerItems) {
     const button = document.createElement("button");
     button.type = "button";
@@ -627,11 +590,9 @@ function renderExplorer() {
       `<span class="sidebar-row-title">${item.kind === "folder" ? (item.open ? "▾ " : "▸ ") : "• "}${item.label}</span>`;
     if (item.kind === "file" && item.path) {
       const itemPath = item.path;
+      const itemWorktree = item.worktree ?? "";
       button.addEventListener("click", () => {
-        selectedEditorPath = findEditorFile(itemPath)?.path || selectedEditorPath;
-        setEditorSurface(true);
-        renderSourceSummary();
-        renderRunSummary();
+        void openEditorPath(itemPath, itemWorktree);
       });
     }
     root.appendChild(button);
@@ -645,16 +606,22 @@ function renderOpenEditors() {
   }
 
   root.innerHTML = "";
-  for (const editor of editorFiles) {
+  const editors = getEditorFiles();
+  if (editors.length === 0) {
+    const empty = document.createElement("div");
+    empty.className = "sidebar-row";
+    empty.innerHTML = `<span class="sidebar-row-title">No changed files</span><span class="sidebar-row-meta">Connect the backend summary to inspect a real file preview.</span>`;
+    root.appendChild(empty);
+    return;
+  }
+
+  for (const editor of editors) {
     const button = document.createElement("button");
     button.type = "button";
-    button.className = `sidebar-row ${editor.path === selectedEditorPath && editorSurfaceOpen ? "is-active" : ""}`;
+    button.className = `sidebar-row ${editor.key === selectedEditorKey && editorSurfaceOpen ? "is-active" : ""}`;
     button.innerHTML = `<span class="sidebar-row-title">${editor.path.split("/").pop() ?? editor.path}</span><span class="sidebar-row-meta">${editor.summary}</span>`;
     button.addEventListener("click", () => {
-      selectedEditorPath = editor.path;
-      setEditorSurface(true);
-      renderSourceSummary();
-      renderRunSummary();
+      void openEditorTarget(getEditorTargetByKey(editor.key));
     });
     root.appendChild(button);
   }
@@ -674,9 +641,9 @@ function renderSourceSummary() {
   const commitCandidates = visibleChanges.filter((item) => item.commitCandidate).length;
   const summaryItems = [
     { label: "Branch", value: primaryChange?.branch ?? "No branch" },
+    { label: "Run", value: primaryChange?.run ?? "No selected run" },
     { label: "Changed", value: `${entryCount} files` },
     { label: "Review", value: primaryChange?.review ?? "No review state" },
-    { label: "Branch", value: primaryChange?.branch ?? "No source projection" },
     { label: "Ready", value: `${commitCandidates} candidate${commitCandidates === 1 ? "" : "s"}` },
     { label: "Risk", value: `${attentionCount} attention · ${activeEntries.length} projected` },
   ];
@@ -723,8 +690,9 @@ function renderSourceEntries() {
       activeSourceFilter = item.filter;
       setContextPanel(true);
       const primaryChange = getPrimarySourceChange(getVisibleSourceChanges());
+      setSelectedRun(primaryChange?.run ?? null);
       if (editorSurfaceOpen && primaryChange) {
-        selectedEditorPath = primaryChange.path;
+        selectedEditorKey = getSourceChangeKey(primaryChange);
         renderEditorSurface();
         renderOpenEditors();
       }
@@ -754,7 +722,12 @@ function getVisibleSourceChanges() {
 }
 
 function getPrimarySourceChange(changes: SourceChange[]) {
-  return changes.find((item) => item.path === selectedEditorPath) ?? changes[0] ?? getProjectionSourceEntries()[0];
+  return (
+    changes.find((item) => item.run === selectedRunId) ??
+    changes.find((item) => getSourceChangeKey(item) === selectedEditorKey) ??
+    changes[0] ??
+    getProjectionSourceEntries()[0]
+  );
 }
 
 function getSourceFilterLabel(filter: SourceFilter) {
@@ -772,10 +745,21 @@ function getSourceFilterLabel(filter: SourceFilter) {
 
 function getPrimaryDigestItem() {
   if (desktopSummarySnapshot?.digest.items?.length) {
+    const resolvedRunId = resolveSelectedRunId();
+    if (resolvedRunId) {
+      const selectedDigestItem = desktopSummarySnapshot.digest.items.find((item) => item.run_id === resolvedRunId);
+      if (selectedDigestItem) {
+        return selectedDigestItem;
+      }
+    }
+
     return desktopSummarySnapshot.digest.items[0];
   }
 
-  const projection = getRunProjections()[0];
+  const resolvedRunId = resolveSelectedRunId();
+  const projection =
+    getRunProjectionByRunId(resolvedRunId) ??
+    getRunProjections()[0];
   if (!projection) {
     return null;
   }
@@ -799,7 +783,7 @@ function getPrimaryDigestItem() {
 }
 
 function getSelectedRunId() {
-  return getPrimaryDigestItem()?.run_id ?? null;
+  return resolveSelectedRunId();
 }
 
 function renderContextPanel() {
@@ -812,12 +796,15 @@ function renderContextPanel() {
 
   const visibleChanges = getVisibleSourceChanges();
   const primaryChange = getPrimarySourceChange(visibleChanges);
+  const selectedDigestItem = getPrimaryDigestItem();
 
   sectionRoot.innerHTML = "";
   const resolvedContextSections = [
-    ...baseContextSections,
+    { label: "next", value: selectedDigestItem?.next_action || "Open Explain" },
+    { label: "run", value: selectedDigestItem?.run_id || primaryChange?.run || "No active run" },
     { label: "pane", value: primaryChange?.paneLabel ?? "No pane label" },
     { label: "branch", value: primaryChange?.branch ?? "No branch" },
+    { label: "worktree", value: primaryChange?.worktree || "Project root" },
     { label: "review", value: primaryChange?.review ?? "No review state" },
   ];
   for (const item of resolvedContextSections) {
@@ -833,6 +820,7 @@ function renderContextPanel() {
     { label: "Commit candidates", value: `${visibleChanges.filter((item) => item.commitCandidate).length}` },
     { label: "Needs attention", value: `${visibleChanges.filter((item) => item.needsAttention).length}` },
     { label: "Active pane", value: primaryChange?.paneLabel ?? "n/a" },
+    { label: "Worktree", value: primaryChange?.worktree || "Project root" },
   ];
 
   for (const item of overviewCards) {
@@ -846,17 +834,15 @@ function renderContextPanel() {
   for (const change of visibleChanges) {
     const button = document.createElement("button");
     button.type = "button";
-    button.className = `context-file-row ${change.path === selectedEditorPath && editorSurfaceOpen ? "is-active" : ""}`;
+    button.className = `context-file-row ${getSourceChangeKey(change) === selectedEditorKey && editorSurfaceOpen ? "is-active" : ""}`;
     button.dataset.tone = getSourceEntryTone(change);
     button.innerHTML =
       `<span class="context-file-name">${change.path.split("/").pop() ?? change.path}</span>` +
       `<span class="context-file-meta">${change.summary}</span>` +
-      `<span class="context-file-trace">${change.status} · ${change.lines} · ${change.branch} · ${change.review}</span>`;
+      `<span class="context-file-trace">${change.status} · ${change.lines} · ${change.branch} · ${change.review}${change.worktree ? ` · ${change.worktree}` : ""}</span>`;
     button.addEventListener("click", () => {
-      selectedEditorPath = change.path;
-      setEditorSurface(true);
-      renderSourceSummary();
-      renderRunSummary();
+      setSelectedRun(change.run);
+      void openEditorSourceChange(change);
     });
     fileRoot.appendChild(button);
   }
@@ -1183,7 +1169,7 @@ function renderTimelineFilters() {
     button.addEventListener("click", () => {
       activeTimelineFilter = item.filter;
       renderTimelineFilters();
-      renderConversation(seedConversation);
+      renderConversation(getConversationItems());
       renderRunSummary();
     });
     root.appendChild(button);
@@ -1313,6 +1299,13 @@ function renderConversation(items: ConversationItem[]) {
     const article = document.createElement("article");
     article.className = `timeline-item timeline-${item.type}`;
     article.dataset.tone = item.tone ?? (item.type === "operator" ? "info" : item.type === "system" ? "focus" : "default");
+    if (item.runId) {
+      article.classList.toggle("is-selected-run", item.runId === getSelectedRunId());
+      article.addEventListener("click", () => {
+        setSelectedRun(item.runId ?? null);
+        renderDesktopSurfaces();
+      });
+    }
 
     const meta = document.createElement("div");
     meta.className = "timeline-meta-row";
@@ -1386,9 +1379,7 @@ async function openExplainForSelectedRun() {
   }
 
   try {
-    const payload =
-      desktopExplainCache.get(selectedRunId) ??
-      await getDesktopRunExplain(selectedRunId);
+    const payload = await getDesktopRunExplain(selectedRunId);
     desktopExplainCache.set(selectedRunId, payload);
 
     const detailItems: ConversationDetail[] = [
@@ -1417,7 +1408,7 @@ async function openExplainForSelectedRun() {
       bodyParts.push(`Recent: ${recent}`);
     }
 
-    seedConversation.push({
+    runtimeConversation.push({
       type: "operator",
       category: "activity",
       timestamp: new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", hour12: false }),
@@ -1428,41 +1419,47 @@ async function openExplainForSelectedRun() {
       tone: "info",
       runId: payload.run.run_id,
     });
+    await refreshDesktopSummary(payload.run.run_id);
   } catch (error) {
     console.warn("Failed to load desktop explain payload", error);
     appendFallbackExplain();
+    return;
   }
-
-  renderTimelineFilters();
-  renderRunSummary();
-  renderSourceSummary();
-  renderSourceEntries();
-  renderContextPanel();
-  renderEditorSurface();
-  renderConversation(seedConversation);
 }
 
 function appendFallbackExplain() {
-  seedConversation.push({
+  const timestamp = new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", hour12: false });
+  const selectedRunId = getSelectedRunId();
+  runtimeConversation.push({
     type: "operator",
     category: "activity",
-    timestamp: "09:47",
+    timestamp,
     actor: "Operator",
     title: "Explain opened",
-    body: "This run is blocked on branch/head alignment after review passed. Changed files and commit readiness stay available in the context sheet and source-control surface.",
-    details: [
-      { label: "run", value: "run-246" },
-      { label: "focus", value: "branch/head alignment" },
-    ],
+    body: selectedRunId
+      ? "Unable to load the latest explain payload. The current source context and run summary remain available while the backend refreshes."
+      : desktopSummarySnapshot
+        ? "No active backend run is available to explain yet. Wait for the digest to refresh or select a run from the current summary."
+        : "The backend summary is not connected yet. Once the desktop summary loads, Explain will follow the live run state.",
+    details: selectedRunId
+      ? [{ label: "run", value: selectedRunId }]
+      : desktopSummarySnapshot
+        ? [{ label: "inbox", value: `${desktopSummarySnapshot.inbox.summary.item_count}` }]
+        : [{ label: "state", value: "backend unavailable" }],
     tone: "info",
-    runId: "run-246",
+    runId: selectedRunId ?? undefined,
   });
+  renderRunSummary();
+  renderConversation(getConversationItems());
 }
 
 function handleChipAction(action: ChipAction) {
   switch (action) {
     case "open-editor":
-      setEditorSurface(true);
+      void openEditorTarget(
+        getEditorTargetForSourceChange(getPrimarySourceChange(getVisibleSourceChanges())) ??
+          getEditorTargetByKey(selectedEditorKey),
+      );
       break;
     case "open-source-context":
     case "toggle-context":
@@ -1563,7 +1560,7 @@ function getCommandActions(): CommandAction[] {
         activeTimelineFilter = "attention";
         renderTimelineFilters();
         renderRunSummary();
-        renderConversation(seedConversation);
+        renderConversation(getConversationItems());
       },
     },
     {
@@ -1576,7 +1573,7 @@ function getCommandActions(): CommandAction[] {
         activeTimelineFilter = "review";
         renderTimelineFilters();
         renderRunSummary();
-        renderConversation(seedConversation);
+        renderConversation(getConversationItems());
       },
     },
   ];
@@ -1755,9 +1752,18 @@ function renderEditorSurface() {
     return;
   }
 
-  const selected = findEditorFile(selectedEditorPath) || editorFiles[0];
-  const sourceChange = getProjectionSourceEntries().find((item) => item.path === selected.path);
-  selectedEditorPath = selected.path;
+  const editors = getEditorFiles();
+  const selected = editors.find((editor) => editor.key === selectedEditorKey) || editors[0];
+  if (!selected) {
+    path.textContent = "No file selected";
+    meta.innerHTML = "";
+    tabs.innerHTML = "";
+    code.textContent = "Select a changed file to load a real file preview from the backend.";
+    statusbar.textContent = "Secondary work surface: waiting for backend source data";
+    return;
+  }
+  const sourceChange = findSourceChangeByKey(selected.key);
+  selectedEditorKey = selected.key;
 
   path.textContent = selected.path;
   meta.innerHTML = "";
@@ -1766,7 +1772,9 @@ function renderEditorSurface() {
     `${selected.lineCount} lines`,
     selected.modified ? "Modified" : "Saved",
     selected.origin === "context" ? "Opened from context" : "Opened from explorer",
-    sourceChange ? `${sourceChange.status} · ${sourceChange.branch}` : "No source metadata",
+    sourceChange
+      ? `${sourceChange.status} · ${sourceChange.branch}${sourceChange.worktree ? ` · ${sourceChange.worktree}` : ""}`
+      : "No source metadata",
   ]) {
     const chip = document.createElement("span");
     chip.className = `editor-meta-chip ${item === "Modified" ? "is-modified" : ""}`;
@@ -1780,22 +1788,20 @@ function renderEditorSurface() {
     : `Secondary work surface: ${selected.origin === "context" ? "run context" : "explorer"} -> ${selected.path}`;
   tabs.innerHTML = "";
 
-  for (const editor of editorFiles) {
+  for (const editor of editors) {
     const tab = document.createElement("button");
     tab.type = "button";
-    tab.className = `editor-tab ${editor.path === selected.path ? "is-active" : ""}`;
+    tab.className = `editor-tab ${editor.key === selected.key ? "is-active" : ""}`;
     tab.textContent = editor.path.split("/").pop() ?? editor.path;
     tab.addEventListener("click", () => {
-      selectedEditorPath = editor.path;
-      renderEditorSurface();
-      renderOpenEditors();
-      renderSourceSummary();
-      renderContextPanel();
-      renderSourceEntries();
-      renderRunSummary();
+      void openEditorTarget(getEditorTargetByKey(editor.key));
     });
     tabs.appendChild(tab);
   }
+}
+
+function getConversationItems() {
+  return [...backendConversation, ...runtimeConversation];
 }
 
 function setTerminalDrawer(open: boolean) {
@@ -1896,7 +1902,7 @@ function syncResponsiveShell() {
 function appendUserMessage(message: string, attachments: ComposerAttachment[]) {
   const now = new Date();
   const timestamp = `${`${now.getHours()}`.padStart(2, "0")}:${`${now.getMinutes()}`.padStart(2, "0")}`;
-  seedConversation.push({
+  runtimeConversation.push({
     type: "user",
     category: "user",
     timestamp,
@@ -1908,7 +1914,7 @@ function appendUserMessage(message: string, attachments: ComposerAttachment[]) {
       sizeLabel: attachment.sizeLabel,
     })),
   });
-  seedConversation.push({
+  runtimeConversation.push({
     type: "operator",
     category: "activity",
     timestamp,
@@ -1922,39 +1928,171 @@ function appendUserMessage(message: string, attachments: ComposerAttachment[]) {
     tone: "info",
   });
   renderRunSummary();
-  renderConversation(seedConversation);
+  renderConversation(getConversationItems());
 }
 
-function findEditorFile(label: string) {
-  const existing = editorFiles.find((editor) => editor.path === label);
+function findEditorFile(target: EditorTarget | null) {
+  if (!target) {
+    return null;
+  }
+
+  const existing = desktopEditorFileCache.get(target.key);
   if (existing) {
     return existing;
   }
 
-  const sourceChange = getProjectionSourceEntries().find((entry) => entry.path === label);
-  if (!sourceChange) {
-    return undefined;
-  }
-
-  const projection = getRunProjectionByRunId(sourceChange.run);
-  const explainSummary = projection?.summary || sourceChange.summary;
-  const branch = projection?.branch || sourceChange.branch;
-  const review = projection?.review_state || sourceChange.review;
+  const sourceChange = target.sourceChange;
+  const projection = sourceChange ? getRunProjectionByRunId(sourceChange.run) : null;
+  const explainSummary = projection?.summary || target.summary;
+  const branch = projection?.branch || sourceChange?.branch || "";
+  const review = projection?.review_state || sourceChange?.review || "";
   const state = projection?.task_state || "unknown";
+  const loading = desktopEditorLoadingPaths.has(target.key);
+  const loadError = desktopEditorLoadErrors.get(target.key);
+  const previewBody = loadError
+    ? `Unable to load file preview.\n\n${loadError}`
+    : loading
+      ? "Loading file preview from backend..."
+      : "Select this file to load a real preview from the backend.";
 
   return {
-    path: sourceChange.path,
+    key: target.key,
+    path: target.path,
     summary: explainSummary,
     content:
-      `// Backend projection preview\n` +
-      `// ${branch} · ${sourceChange.paneLabel} · ${review}\n` +
-      `// ${sourceChange.lines} · state=${state}\n` +
-      (projection?.reasons?.length ? `// ${projection.reasons.join(" | ")}\n` : ""),
-    language: inferLanguageFromPath(sourceChange.path),
-    lineCount: projection?.changed_files.length || 3,
-    modified: sourceChange.status !== "deleted",
-    origin: "context",
+      `// Backend file preview\n` +
+      (sourceChange ? `// ${branch} · ${sourceChange.paneLabel} · ${review}\n` : `// explorer selection\n`) +
+      (target.worktree ? `// worktree=${target.worktree}\n` : "") +
+      (sourceChange ? `// ${sourceChange.lines} · state=${state}\n` : `// state=${state}\n`) +
+      (projection?.reasons?.length ? `// ${projection.reasons.join(" | ")}\n` : "") +
+      `\n${previewBody}\n`,
+    language: inferLanguageFromPath(target.path),
+    lineCount: projection?.changed_files.length || 1,
+    modified: target.modified,
+    origin: target.origin,
   };
+}
+
+function countEditorLines(content: string) {
+  return content.split(/\r?\n/).length;
+}
+
+function buildCachedEditorFile(
+  target: EditorTarget,
+  payload: DesktopEditorFilePayload,
+): EditorFile {
+  const summary = payload.truncated
+    ? `${target.summary} · preview truncated`
+    : target.summary;
+  return {
+    key: target.key,
+    path: payload.path,
+    summary,
+    content: payload.content,
+    language: inferLanguageFromPath(payload.path),
+    lineCount: payload.line_count || countEditorLines(payload.content),
+    modified: target.modified,
+    origin: target.origin,
+  };
+}
+
+function getEditorFiles() {
+  const targets = new Map<string, EditorTarget>();
+  for (const entry of getProjectionSourceEntries()) {
+    const target = getEditorTargetForSourceChange(entry);
+    if (target) {
+      targets.set(target.key, target);
+    }
+  }
+  for (const [key, target] of desktopStandaloneEditorTargets) {
+    if (!targets.has(key)) {
+      targets.set(key, target);
+    }
+  }
+
+  return Array.from(targets.values()).map((target) =>
+    findEditorFile(target) ?? {
+      key: target.key,
+      path: target.path,
+      summary: target.summary,
+      content: "Loading file preview from backend...",
+      language: inferLanguageFromPath(target.path),
+      lineCount: 1,
+      modified: target.modified,
+      origin: target.origin,
+    },
+  );
+}
+
+async function ensureEditorFileLoaded(target: EditorTarget | null) {
+  if (!target) {
+    return;
+  }
+
+  if (!target.path || desktopEditorFileCache.has(target.key) || desktopEditorLoadingPaths.has(target.key)) {
+    return;
+  }
+
+  desktopEditorLoadingPaths.add(target.key);
+  desktopEditorLoadErrors.delete(target.key);
+  renderEditorSurface();
+  renderOpenEditors();
+
+  try {
+    const payload = await getDesktopEditorFile(target.path, target.worktree || undefined);
+    desktopEditorFileCache.set(target.key, buildCachedEditorFile(target, payload));
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    desktopEditorLoadErrors.set(target.key, message);
+  } finally {
+    desktopEditorLoadingPaths.delete(target.key);
+    renderEditorSurface();
+    renderOpenEditors();
+    renderSourceSummary();
+    renderContextPanel();
+    renderSourceEntries();
+    renderRunSummary();
+  }
+}
+
+async function openEditorTarget(target: EditorTarget | null) {
+  if (!target) {
+    setEditorSurface(true);
+    return;
+  }
+
+  selectedEditorKey = target.key;
+  setSelectedRun(target.sourceChange?.run ?? selectedRunId);
+  setEditorSurface(true);
+  renderSourceSummary();
+  renderRunSummary();
+  await ensureEditorFileLoaded(target);
+}
+
+async function openEditorSourceChange(sourceChange: SourceChange | undefined) {
+  await openEditorTarget(getEditorTargetForSourceChange(sourceChange));
+}
+
+async function openEditorPath(path: string | undefined, worktree = "") {
+  if (!path) {
+    await openEditorSourceChange(getPrimarySourceChange(getVisibleSourceChanges()));
+    return;
+  }
+
+  const sourceChange = findSourceChangeByPath(path, worktree);
+  if (sourceChange) {
+    setSelectedRun(sourceChange.run);
+    await openEditorSourceChange(sourceChange);
+    return;
+  }
+
+  const target = createStandaloneEditorTarget(path, worktree);
+  desktopStandaloneEditorTargets.set(target.key, target);
+  selectedEditorKey = target.key;
+  setEditorSurface(true);
+  renderOpenEditors();
+  renderEditorSurface();
+  await ensureEditorFileLoaded(target);
 }
 
 function inferLanguageFromPath(path: string) {
@@ -2041,36 +2179,77 @@ function buildDesktopSummaryConversation(snapshot: DesktopSummarySnapshot): Conv
   return items;
 }
 
-async function loadDesktopSummary() {
+function pruneExplainCache(snapshot: DesktopSummarySnapshot, preservedRunId?: string | null) {
+  const activeRunIds = new Set(snapshot.digest.items.map((item) => item.run_id));
+  if (preservedRunId) {
+    activeRunIds.add(preservedRunId);
+  }
+
+  for (const runId of Array.from(desktopExplainCache.keys())) {
+    if (!activeRunIds.has(runId)) {
+      desktopExplainCache.delete(runId);
+    }
+  }
+}
+
+function renderDesktopSurfaces() {
+  renderSessions();
+  renderFooterLane();
+  renderRunSummary();
+  renderSourceSummary();
+  renderSourceEntries();
+  renderContextPanel();
+  renderOpenEditors();
+  renderEditorSurface();
+  renderConversation(getConversationItems());
+}
+
+async function refreshDesktopSummary(forceExplainRunId?: string | null) {
+  if (desktopSummaryRefreshInFlight) {
+    return desktopSummaryRefreshInFlight;
+  }
+
+  desktopSummaryRefreshInFlight = (async () => {
   try {
     const snapshot = await getDesktopSummarySnapshot();
     desktopSummarySnapshot = snapshot;
-    const topRunId = snapshot.digest.items[0]?.run_id;
-    if (topRunId && !desktopExplainCache.has(topRunId)) {
+    selectedRunId = resolveSelectedRunId(snapshot, forceExplainRunId);
+    pruneExplainCache(snapshot, forceExplainRunId);
+    if (selectedRunId) {
       try {
-        const explainPayload = await getDesktopRunExplain(topRunId);
-        desktopExplainCache.set(topRunId, explainPayload);
+        const explainPayload = await getDesktopRunExplain(selectedRunId);
+        desktopExplainCache.set(selectedRunId, explainPayload);
       } catch (error) {
         console.warn("Failed to prefetch desktop explain payload", error);
       }
     }
 
-    const existingTitles = new Set(["Summary stream connected", "Inbox: review_pending", "Inbox: review_failed", "Inbox: task_blocked"]);
-    const retainedConversation = seedConversation.filter((item) => !item.title || !existingTitles.has(item.title));
-    seedConversation.splice(0, seedConversation.length, ...buildDesktopSummaryConversation(snapshot), ...retainedConversation);
-
-    renderSessions();
-    renderFooterLane();
-    renderRunSummary();
-    renderSourceSummary();
-    renderSourceEntries();
-    renderContextPanel();
-    renderOpenEditors();
-    renderEditorSurface();
-    renderConversation(seedConversation);
+    backendConversation.splice(0, backendConversation.length, ...buildDesktopSummaryConversation(snapshot));
+    renderDesktopSurfaces();
   } catch (error) {
     console.warn("Failed to load desktop summary snapshot", error);
+  } finally {
+    desktopSummaryRefreshInFlight = null;
   }
+  })();
+
+  return desktopSummaryRefreshInFlight;
+}
+
+function registerDesktopSummaryLiveRefresh() {
+  window.setInterval(() => {
+    void refreshDesktopSummary();
+  }, DESKTOP_SUMMARY_REFRESH_INTERVAL_MS);
+
+  window.addEventListener("focus", () => {
+    void refreshDesktopSummary();
+  });
+
+  document.addEventListener("visibilitychange", () => {
+    if (document.visibilityState === "visible") {
+      void refreshDesktopSummary();
+    }
+  });
 }
 
 function initializeSidebarResize() {
@@ -2121,12 +2300,13 @@ window.addEventListener("DOMContentLoaded", async () => {
   renderFooterLane();
   renderTimelineFilters();
   renderRunSummary();
-  renderConversation(seedConversation);
+  renderConversation(getConversationItems());
   renderComposerModes();
   renderAttachmentTray();
   renderCommandBar();
   renderEditorSurface();
-  await loadDesktopSummary();
+  await refreshDesktopSummary();
+  registerDesktopSummaryLiveRefresh();
   syncResponsiveShell();
   setEditorSurface(false);
   setTerminalDrawer(false);

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -1438,12 +1438,12 @@ function appendFallbackExplain() {
   const digestItem = getPrimaryDigestItem();
   const hasSelectedDigest = Boolean(selectedRunId && digestItem?.run_id === selectedRunId);
   const body = hasSelectedDigest
-    ? `Unable to load the latest explain payload for ${selectedRunId}. Backend summary still reports ${digestItem?.changed_file_count ?? 0} changed files and next ${digestItem?.next_action || "idle"}.`
+    ? `Explain is unavailable for ${selectedRunId}. Backend digest still reports next ${digestItem?.next_action || "idle"}.`
     : desktopSummarySnapshot && desktopSummarySnapshot.digest.summary.item_count > 0
-      ? "Explain is unavailable until a projected run is selected from the current backend summary."
+      ? "Explain is unavailable until a projected run is selected."
       : desktopSummarySnapshot
-        ? "The backend summary is connected, but no projected run is available to explain yet."
-        : "The backend summary is not connected yet. Once the desktop summary loads, Explain will follow the live run state.";
+        ? "No projected run is available to explain yet."
+        : "Backend summary unavailable.";
   const details = hasSelectedDigest
     ? [
         { label: "run", value: selectedRunId as string },
@@ -1773,11 +1773,11 @@ function renderEditorSurface() {
   const editors = getEditorFiles();
   const selected = editors.find((editor) => editor.key === selectedEditorKey) || editors[0];
   if (!selected) {
-    path.textContent = "No file selected";
+    path.textContent = "Editor idle";
     meta.innerHTML = "";
     tabs.innerHTML = "";
-    code.textContent = "Select a changed file to load a real file preview from the backend.";
-    statusbar.textContent = "Secondary work surface: waiting for backend source data";
+    code.textContent = "Open a projected file to load a backend preview.";
+    statusbar.textContent = "Secondary work surface: waiting for file selection";
     return;
   }
   selectedEditorKey = selected.key;
@@ -2469,9 +2469,8 @@ async function refreshDesktopSummary(forceExplainRunId?: string | null) {
     const shouldPrefetchExplain =
       Boolean(selectedRunId) &&
       (
-        !previousSnapshot ||
-        diff.hasMeaningfulChange ||
         forceExplainRunId === selectedRunId ||
+        !previousSnapshot ||
         selectedRunId !== previousSelectedRunId ||
         !desktopExplainCache.has(selectedRunId ?? "")
       );

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -1260,9 +1260,33 @@ function buildRunSummaryCards(
     });
   }
 
+  const verificationDetail = summarizeVerificationDetail(explainPayload);
+  if (verificationDetail) {
+    cards.push({
+      label: "Verify detail",
+      value: verificationDetail,
+    });
+  }
+
+  const securityDetail = summarizeSecurityDetail(explainPayload);
+  if (securityDetail) {
+    cards.push({
+      label: "Security detail",
+      value: securityDetail,
+    });
+  }
+
+  const actionDetail = summarizeActionItems(explainPayload);
+  if (actionDetail) {
+    cards.push({
+      label: "Action",
+      value: actionDetail,
+    });
+  }
+
   return cards
     .filter((item) => item.value && item.value !== "n/a")
-    .slice(0, 10);
+    .slice(0, 12);
 }
 
 function buildRunSummaryFiles(
@@ -1287,6 +1311,74 @@ function buildRunSummaryRecentEvents(explainPayload: DesktopExplainPayload | nul
     title: event.event,
     body: `${event.label}: ${event.message}`,
   }));
+}
+
+function summarizeVerificationDetail(explainPayload: DesktopExplainPayload | null) {
+  if (!explainPayload) {
+    return "";
+  }
+
+  const parts: string[] = [];
+  const contract = explainPayload.verification_contract;
+  const result = explainPayload.verification_result;
+
+  if (contract?.mode) {
+    parts.push(`contract ${contract.mode}`);
+  }
+  if (typeof contract?.required === "boolean") {
+    parts.push(contract.required ? "required" : "optional");
+  }
+  if (result?.outcome) {
+    parts.push(`result ${result.outcome}`);
+  }
+  if (result?.summary) {
+    parts.push(result.summary);
+  } else if (result?.next_action) {
+    parts.push(result.next_action);
+  }
+  if (Array.isArray(result?.failed_checks) && result.failed_checks.length > 0) {
+    parts.push(`failed ${result.failed_checks[0]}`);
+  }
+
+  return parts.join(" · ");
+}
+
+function summarizeSecurityDetail(explainPayload: DesktopExplainPayload | null) {
+  if (!explainPayload) {
+    return "";
+  }
+
+  const parts: string[] = [];
+  const policy = explainPayload.security_policy;
+  const verdict = explainPayload.security_verdict;
+
+  if (policy?.mode) {
+    parts.push(`policy ${policy.mode}`);
+  }
+  if (verdict?.verdict) {
+    parts.push(`verdict ${verdict.verdict}`);
+  }
+  if (verdict?.reason) {
+    parts.push(verdict.reason);
+  } else if (verdict?.next_action) {
+    parts.push(verdict.next_action);
+  }
+
+  return parts.join(" · ");
+}
+
+function summarizeActionItems(explainPayload: DesktopExplainPayload | null) {
+  if (!explainPayload || !Array.isArray(explainPayload.action_items) || explainPayload.action_items.length === 0) {
+    return "";
+  }
+
+  const firstItem = explainPayload.action_items[0];
+  const count = explainPayload.action_items.length;
+  const parts = [firstItem.kind, firstItem.message].filter((value): value is string => Boolean(value && value.trim()));
+  if (count > 1) {
+    parts.push(`+${count - 1} more`);
+  }
+  return parts.join(" · ");
 }
 
 function renderRunSummary() {
@@ -2012,6 +2104,17 @@ function getExplainPayloadFingerprint(payload: DesktopExplainPayload | null | un
     payload.review_state?.status,
     payload.consultation_summary?.recommendation,
     payload.consultation_summary?.next_test,
+    payload.action_items?.map((item) => `${item.kind}:${item.message}`).join("|"),
+    payload.verification_contract?.mode,
+    payload.verification_contract?.required,
+    payload.verification_result?.outcome,
+    payload.verification_result?.summary,
+    payload.verification_result?.next_action,
+    payload.verification_result?.failed_checks?.join("|"),
+    payload.security_policy?.mode,
+    payload.security_verdict?.verdict,
+    payload.security_verdict?.reason,
+    payload.security_verdict?.next_action,
     payload.result_packet?.summary,
     payload.result_packet?.next_action_hint,
   ]);

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -1887,7 +1887,6 @@ function getRunProjectionFingerprint(projection: DesktopRunProjection | null | u
     projection.branch,
     projection.provider_target,
     projection.changed_files.join("|"),
-    projection.summary,
   ]);
 }
 
@@ -2458,13 +2457,18 @@ async function refreshDesktopSummary(forceExplainRunId?: string | null) {
     desktopSummarySnapshot = snapshot;
     selectedRunId = resolveSelectedRunId(snapshot, forceExplainRunId);
     pruneExplainCache(snapshot, forceExplainRunId);
+    const selectedRunHasMaterialChange = Boolean(
+      selectedRunId &&
+        (diff.changedRunIds.includes(selectedRunId) || diff.addedRunIds.includes(selectedRunId)),
+    );
     const shouldPrefetchExplain =
       Boolean(selectedRunId) &&
       (
         forceExplainRunId === selectedRunId ||
         !previousSnapshot ||
         selectedRunId !== previousSelectedRunId ||
-        !desktopExplainCache.has(selectedRunId ?? "")
+        !desktopExplainCache.has(selectedRunId ?? "") ||
+        selectedRunHasMaterialChange
       );
     if (selectedRunId && shouldPrefetchExplain) {
       try {
@@ -2496,6 +2500,9 @@ async function refreshDesktopSummary(forceExplainRunId?: string | null) {
 
 function registerDesktopSummaryLiveRefresh() {
   window.setInterval(() => {
+    if (document.visibilityState !== "visible") {
+      return;
+    }
     void refreshDesktopSummary();
   }, DESKTOP_SUMMARY_REFRESH_INTERVAL_MS);
 

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -1236,30 +1236,6 @@ function buildRunSummaryCards(
     },
   ];
 
-  if (projection?.hypothesis || explainPayload?.run.goal) {
-    cards.push({
-      label: "Goal",
-      value: projection?.hypothesis || explainPayload?.run.goal || "n/a",
-    });
-  }
-
-  if (projection?.consultation_ref || explainPayload?.consultation_summary?.next_test) {
-    cards.push({
-      label: "Consult",
-      value:
-        projection?.consultation_ref ||
-        explainPayload?.consultation_summary?.next_test ||
-        "n/a",
-    });
-  }
-
-  if (projection?.observation_pack_ref) {
-    cards.push({
-      label: "Observation",
-      value: projection.observation_pack_ref,
-    });
-  }
-
   const verificationDetail = summarizeVerificationDetail(explainPayload);
   if (verificationDetail) {
     cards.push({
@@ -1284,9 +1260,33 @@ function buildRunSummaryCards(
     });
   }
 
+  if (projection?.hypothesis || explainPayload?.run.goal) {
+    cards.push({
+      label: "Goal",
+      value: projection?.hypothesis || explainPayload?.run.goal || "n/a",
+    });
+  }
+
+  if (projection?.consultation_ref || explainPayload?.consultation_summary?.next_test) {
+    cards.push({
+      label: "Consult",
+      value:
+        projection?.consultation_ref ||
+        explainPayload?.consultation_summary?.next_test ||
+        "n/a",
+    });
+  }
+
+  if (projection?.observation_pack_ref) {
+    cards.push({
+      label: "Observation",
+      value: projection.observation_pack_ref,
+    });
+  }
+
   return cards
     .filter((item) => item.value && item.value !== "n/a")
-    .slice(0, 12);
+    .slice(0, 14);
 }
 
 function buildRunSummaryFiles(
@@ -2107,14 +2107,24 @@ function getExplainPayloadFingerprint(payload: DesktopExplainPayload | null | un
     payload.action_items?.map((item) => `${item.kind}:${item.message}`).join("|"),
     payload.verification_contract?.mode,
     payload.verification_contract?.required,
+    payload.verification_contract?.checks?.join("|"),
+    payload.verification_contract?.commands?.join("|"),
     payload.verification_result?.outcome,
     payload.verification_result?.summary,
     payload.verification_result?.next_action,
+    payload.verification_result?.passed_checks?.join("|"),
     payload.verification_result?.failed_checks?.join("|"),
     payload.security_policy?.mode,
+    payload.security_policy?.stage,
+    payload.security_policy?.task,
+    payload.security_policy?.allow?.join("|"),
+    payload.security_policy?.block?.join("|"),
     payload.security_verdict?.verdict,
+    payload.security_verdict?.stage,
     payload.security_verdict?.reason,
     payload.security_verdict?.next_action,
+    payload.security_verdict?.allow?.join("|"),
+    payload.security_verdict?.block?.join("|"),
     payload.result_packet?.summary,
     payload.result_packet?.next_action_hint,
   ]);

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -1781,6 +1781,10 @@ function renderEditorSurface() {
     return;
   }
   selectedEditorKey = selected.key;
+  const selectedTarget = getEditorTargetByKey(selected.key);
+  if (selectedTarget && !desktopEditorFileCache.has(selected.key) && !desktopEditorLoadingPaths.has(selected.key)) {
+    void ensureEditorFileLoaded(selectedTarget);
+  }
 
   path.textContent = selected.path;
   meta.innerHTML = "";
@@ -2189,12 +2193,6 @@ function findEditorFile(target: EditorTarget | null) {
     return existing;
   }
 
-  const sourceChange = target.sourceChange;
-  const projection = sourceChange ? getRunProjectionByRunId(sourceChange.run) : null;
-  const explainSummary = projection?.summary || target.summary;
-  const branch = projection?.branch || sourceChange?.branch || "";
-  const review = projection?.review_state || sourceChange?.review || "";
-  const state = projection?.task_state || "unknown";
   const loading = desktopEditorLoadingPaths.has(target.key);
   const loadError = desktopEditorLoadErrors.get(target.key);
   const previewBody = loadError
@@ -2206,16 +2204,10 @@ function findEditorFile(target: EditorTarget | null) {
   return {
     key: target.key,
     path: target.path,
-    summary: explainSummary,
-    content:
-      `// Backend file preview\n` +
-      (sourceChange ? `// ${branch} · ${sourceChange.paneLabel} · ${review}\n` : `// explorer selection\n`) +
-      (target.worktree ? `// worktree=${target.worktree}\n` : "") +
-      (sourceChange ? `// ${sourceChange.lines} · state=${state}\n` : `// state=${state}\n`) +
-      (projection?.reasons?.length ? `// ${projection.reasons.join(" | ")}\n` : "") +
-      `\n${previewBody}\n`,
+    summary: target.summary,
+    content: `${previewBody}\n`,
     language: inferLanguageFromPath(target.path),
-    lineCount: projection?.changed_files.length || 1,
+    lineCount: countEditorLines(previewBody),
     modified: target.modified,
     origin: target.origin,
   };

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -1381,6 +1381,36 @@ function summarizeActionItems(explainPayload: DesktopExplainPayload | null) {
   return parts.join(" · ");
 }
 
+function buildRunSummaryChips(
+  digestItem: DesktopDigestItem,
+  explainPayload: DesktopExplainPayload | null,
+  changedFiles: string[],
+) {
+  const chips: Array<{ label: string; action: ChipAction }> = [
+    { label: "Open Explain", action: "open-explain" },
+  ];
+
+  if (changedFiles.length > 0) {
+    chips.push({ label: "Open in Editor", action: "open-editor" });
+  }
+
+  if (
+    explainPayload?.verification_result ||
+    explainPayload?.security_verdict ||
+    (Array.isArray(explainPayload?.action_items) && explainPayload.action_items.length > 0) ||
+    digestItem.review_state === "PENDING" ||
+    digestItem.review_state === "FAIL" ||
+    digestItem.review_state === "FAILED"
+  ) {
+    chips.push({ label: "Open Audit", action: "toggle-context" });
+  } else {
+    chips.push({ label: "Source Context", action: "open-source-context" });
+  }
+
+  chips.push({ label: "Terminal", action: "open-terminal" });
+  return chips;
+}
+
 function renderRunSummary() {
   const root = document.getElementById("selected-run-summary");
   if (!root) {
@@ -1394,6 +1424,7 @@ function renderRunSummary() {
     const detailCards = buildRunSummaryCards(digestItem, selectedProjection, selectedExplainPayload);
     const changedFiles = buildRunSummaryFiles(digestItem, selectedProjection, selectedExplainPayload);
     const recentEvents = buildRunSummaryRecentEvents(selectedExplainPayload);
+    const chips = buildRunSummaryChips(digestItem, selectedExplainPayload, changedFiles);
     const statusTone =
       digestItem.review_state === "PASS"
         ? "success"
@@ -1451,9 +1482,12 @@ function renderRunSummary() {
             : ""
         }
         <div class="timeline-chip-row">
-          <button type="button" class="timeline-chip" data-action="open-explain">Open Explain</button>
-          <button type="button" class="timeline-chip" data-action="open-source-context">Source Context</button>
-          <button type="button" class="timeline-chip" data-action="open-terminal">Terminal</button>
+          ${chips
+            .map(
+              (chip) =>
+                `<button type="button" class="timeline-chip" data-action="${chip.action}">${chip.label}</button>`,
+            )
+            .join("")}
         </div>
       </div>
     `;
@@ -2727,12 +2761,22 @@ async function refreshDesktopSummary(forceExplainRunId?: string | null) {
   desktopSummaryRefreshInFlight = (async () => {
   try {
     const previousSnapshot = desktopSummarySnapshot;
+    const previousSelectedRunId = selectedRunId;
     const snapshot = await getDesktopSummarySnapshot();
     const diff = diffDesktopSummarySnapshots(previousSnapshot, snapshot);
     desktopSummarySnapshot = snapshot;
     selectedRunId = resolveSelectedRunId(snapshot, forceExplainRunId);
     pruneExplainCache(snapshot, forceExplainRunId);
-    if (selectedRunId) {
+    const shouldPrefetchExplain =
+      Boolean(selectedRunId) &&
+      (
+        !previousSnapshot ||
+        diff.hasMeaningfulChange ||
+        forceExplainRunId === selectedRunId ||
+        selectedRunId !== previousSelectedRunId ||
+        !desktopExplainCache.has(selectedRunId ?? "")
+      );
+    if (selectedRunId && shouldPrefetchExplain) {
       try {
         const explainPayload = await getDesktopRunExplain(selectedRunId);
         desktopExplainCache.set(selectedRunId, explainPayload);
@@ -2741,7 +2785,7 @@ async function refreshDesktopSummary(forceExplainRunId?: string | null) {
       }
     }
 
-    if (previousSnapshot && !diff.hasMeaningfulChange && !forceExplainRunId) {
+    if (previousSnapshot && !diff.hasMeaningfulChange && !forceExplainRunId && !shouldPrefetchExplain) {
       return;
     }
 

--- a/winsmux-app/src/ptyClient.ts
+++ b/winsmux-app/src/ptyClient.ts
@@ -1,16 +1,43 @@
 import { invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 
-type PtyCommandName = "pty_spawn" | "pty_write" | "pty_resize" | "pty_close";
+const PTY_JSON_RPC_VERSION = "2.0";
+type PtyCommandName = "pty.spawn" | "pty.write" | "pty.resize" | "pty.close";
 
 interface PtyOutputEvent {
   pane_id: string;
   data: string;
 }
 
+interface PtyJsonRpcRequest {
+  jsonrpc: typeof PTY_JSON_RPC_VERSION;
+  id: string;
+  method: PtyCommandName;
+  params?: Record<string, unknown>;
+}
+
+interface PtyJsonRpcError {
+  code: number;
+  message: string;
+}
+
+type PtyJsonRpcResponse =
+  | {
+      jsonrpc: typeof PTY_JSON_RPC_VERSION;
+      id: string;
+      result: unknown;
+    }
+  | {
+      jsonrpc: typeof PTY_JSON_RPC_VERSION;
+      id: string;
+      error: PtyJsonRpcError;
+    };
+
 export interface PtyCommandTransport {
   request(command: PtyCommandName, payload: Record<string, unknown>): Promise<void>;
 }
+
+let ptyRequestSequence = 0;
 
 function normalizePtyError(action: string, error: unknown) {
   if (error instanceof Error) {
@@ -25,7 +52,19 @@ export function createTauriPtyCommandTransport(
 ): PtyCommandTransport {
   return {
     async request(command: PtyCommandName, payload: Record<string, unknown>) {
-      await invokeCommand(command, payload);
+      const request: PtyJsonRpcRequest = {
+        jsonrpc: PTY_JSON_RPC_VERSION,
+        id: `pty-${++ptyRequestSequence}`,
+        method: command,
+        params: payload,
+      };
+      const response = await invokeCommand<PtyJsonRpcResponse>("pty_json_rpc", {
+        request,
+      });
+
+      if ("error" in response) {
+        throw new Error(response.error.message);
+      }
     },
   };
 }
@@ -42,17 +81,17 @@ export async function spawnPtyPane(
   rows: number,
 ) {
   try {
-    await ptyCommandTransport.request("pty_spawn", { paneId, cols, rows });
+    await ptyCommandTransport.request("pty.spawn", { paneId, cols, rows });
   } catch (error) {
-    throw normalizePtyError(`pty_spawn(${paneId})`, error);
+    throw normalizePtyError(`pty.spawn(${paneId})`, error);
   }
 }
 
 export async function writePtyData(paneId: string, data: string) {
   try {
-    await ptyCommandTransport.request("pty_write", { paneId, data });
+    await ptyCommandTransport.request("pty.write", { paneId, data });
   } catch (error) {
-    throw normalizePtyError(`pty_write(${paneId})`, error);
+    throw normalizePtyError(`pty.write(${paneId})`, error);
   }
 }
 
@@ -62,17 +101,17 @@ export async function resizePtyPane(
   rows: number,
 ) {
   try {
-    await ptyCommandTransport.request("pty_resize", { paneId, cols, rows });
+    await ptyCommandTransport.request("pty.resize", { paneId, cols, rows });
   } catch (error) {
-    throw normalizePtyError(`pty_resize(${paneId})`, error);
+    throw normalizePtyError(`pty.resize(${paneId})`, error);
   }
 }
 
 export async function closePtyPane(paneId: string) {
   try {
-    await ptyCommandTransport.request("pty_close", { paneId });
+    await ptyCommandTransport.request("pty.close", { paneId });
   } catch (error) {
-    throw normalizePtyError(`pty_close(${paneId})`, error);
+    throw normalizePtyError(`pty.close(${paneId})`, error);
   }
 }
 

--- a/winsmux-app/src/styles.css
+++ b/winsmux-app/src/styles.css
@@ -492,6 +492,56 @@ textarea {
   line-height: var(--leading-normal);
 }
 
+.run-summary-detail-grid,
+.run-summary-event-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 8px;
+}
+
+.run-summary-detail-card,
+.run-summary-event-card {
+  border: 1px solid var(--border-muted);
+  border-radius: 14px;
+  background: var(--bg-panel);
+  padding: 10px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.run-summary-detail-label {
+  color: var(--text-muted);
+  font-size: var(--text-2xs);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.run-summary-detail-value,
+.run-summary-event-body {
+  color: var(--text-primary);
+  font-size: var(--text-xs);
+  line-height: var(--leading-normal);
+  word-break: break-word;
+}
+
+.run-summary-file-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.run-summary-file-pill {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  padding: 5px 10px;
+  background: rgba(120, 136, 180, 0.14);
+  border: 1px solid var(--border-muted);
+  color: var(--text-secondary);
+  font-size: var(--text-2xs);
+}
+
 #conversation-timeline {
   min-height: 0;
   overflow: auto;

--- a/winsmux-app/src/styles.css
+++ b/winsmux-app/src/styles.css
@@ -492,56 +492,6 @@ textarea {
   line-height: var(--leading-normal);
 }
 
-.run-summary-detail-grid,
-.run-summary-event-list {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-  gap: 8px;
-}
-
-.run-summary-detail-card,
-.run-summary-event-card {
-  border: 1px solid var(--border-muted);
-  border-radius: 14px;
-  background: var(--bg-panel);
-  padding: 10px 12px;
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.run-summary-detail-label {
-  color: var(--text-muted);
-  font-size: var(--text-2xs);
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-}
-
-.run-summary-detail-value,
-.run-summary-event-body {
-  color: var(--text-primary);
-  font-size: var(--text-xs);
-  line-height: var(--leading-normal);
-  word-break: break-word;
-}
-
-.run-summary-file-list {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-}
-
-.run-summary-file-pill {
-  display: inline-flex;
-  align-items: center;
-  border-radius: 999px;
-  padding: 5px 10px;
-  background: rgba(120, 136, 180, 0.14);
-  border: 1px solid var(--border-muted);
-  color: var(--text-secondary);
-  font-size: var(--text-2xs);
-}
-
 #conversation-timeline {
   min-height: 0;
   overflow: auto;

--- a/winsmux-core/scripts/pane-status.ps1
+++ b/winsmux-core/scripts/pane-status.ps1
@@ -138,6 +138,64 @@ function Get-PaneActualStateFromText {
     return 'busy'
 }
 
+function Get-PaneStatusWorktree {
+    param(
+        [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [Parameter(Mandatory = $true)]$Entry
+    )
+
+    $entryProjectDir = [string]$Entry.ProjectDir
+    $sessionProjectRoot = if (-not [string]::IsNullOrWhiteSpace($entryProjectDir)) { $entryProjectDir } else { $ProjectDir }
+    $worktreePath = ''
+
+    $launchDir = [string]$Entry.LaunchDir
+    # launch_dir reflects the pane's current cwd, so only prefer it when it points away from the session root.
+    if (
+        -not [string]::IsNullOrWhiteSpace($launchDir) -and
+        $launchDir -ne $ProjectDir -and
+        $launchDir -ne $entryProjectDir
+    ) {
+        $worktreePath = $launchDir
+    }
+
+    if ([string]::IsNullOrWhiteSpace($worktreePath)) {
+        $worktreePath = [string]$Entry.BuilderWorktreePath
+    }
+
+    if ([string]::IsNullOrWhiteSpace($worktreePath)) {
+        $role = [string]$Entry.Role
+        $label = [string]$Entry.Label
+        $branch = [string]$Entry.Branch
+        if (
+            $role -in @('Builder', 'Worker') -and
+            -not [string]::IsNullOrWhiteSpace($label) -and
+            $branch -eq ("worktree-{0}" -f $label)
+        ) {
+            $worktreePath = ".worktrees/$label"
+        }
+    }
+
+    if ([string]::IsNullOrWhiteSpace($worktreePath)) {
+        return ''
+    }
+
+    if (-not [System.IO.Path]::IsPathRooted($worktreePath)) {
+        return ($worktreePath -replace '\\', '/')
+    }
+
+    try {
+        $relativePath = [System.IO.Path]::GetRelativePath($sessionProjectRoot, $worktreePath)
+    } catch {
+        return ($worktreePath -replace '\\', '/')
+    }
+
+    if ([string]::IsNullOrWhiteSpace($relativePath) -or $relativePath -eq '.') {
+        return ''
+    }
+
+    return ($relativePath -replace '\\', '/')
+}
+
 function Get-PaneStatusRecords {
     param(
         [Parameter(Mandatory = $true)][string]$ProjectDir,
@@ -182,6 +240,7 @@ function Get-PaneStatusRecords {
             TaskOwner       = $entry.TaskOwner
             ReviewState     = $entry.ReviewState
             Branch          = $entry.Branch
+            Worktree        = Get-PaneStatusWorktree -ProjectDir $ProjectDir -Entry $entry
             HeadSha         = $entry.HeadSha
             ChangedFileCount = $entry.ChangedFileCount
             ChangedFiles    = @($entry.ChangedFiles)


### PR DESCRIPTION
## Summary
- switch the default desktop frontend transport to a single `desktop_json_rpc` envelope instead of per-command `invoke(...)` calls
- add JSON-RPC 2.0 request/response dispatch in `desktop_backend.rs` for `desktop.summary.snapshot` and `desktop.run.explain`
- update `docs/handoff.md` and sync the external planning backlog/roadmap so `TASK-105`, `TASK-289`, and `TASK-291` are marked active

## Validation
- `npm run build`
- `cargo fmt`
- `cargo check`
- `cargo test --lib`
- `git diff --check` (CRLF warnings only)
- external planning `backlog.yaml` update + `sync-roadmap.ps1`

## Review
- Fresh reviewer `Euler` -> `no result yet` after a 35s wait; closed without result
- Manual diff review completed for this JSON-RPC envelope slice