### PR TITLE
feat: sync internal planning docs with roadmap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,21 @@ When updating handoff:
 - Reflect external planning truth when version progress changes.
 - Prefer exact identifiers: version, task IDs, PR numbers, release status.
 
+## Roadmap Localization Gate
+
+`backlog.yaml` remains English-first, but `ROADMAP.md` is the Japanese-facing planning view for this repo.
+
+When updating planning:
+
+1. Keep task metadata in `backlog.yaml` in English unless the task explicitly requires otherwise.
+2. Generate planning views through `winsmux-core/scripts/sync-roadmap.ps1`.
+   - This now refreshes `ROADMAP.md` and the internal-only planning docs under `docs/internal/`.
+3. Maintain Japanese roadmap title overrides in `tasks/roadmap-title-ja.psd1`.
+4. For `v0.20.0` and later, do not allow English task titles to leak into `ROADMAP.md`.
+   - If a new task is added or renamed in `backlog.yaml`, update the Japanese title override before considering roadmap sync complete.
+5. Treat missing Japanese roadmap titles as a sync gate failure, not as acceptable drift.
+6. Treat stale internal planning docs under `docs/internal/` as a sync failure when backlog-driven sections no longer match the external planning source of truth.
+
 ## Release Notes Policy
 
 GitHub Release titles and bodies must be written in English, regardless of the conversation language.

--- a/GUARDRAILS.md
+++ b/GUARDRAILS.md
@@ -67,8 +67,8 @@
 
 ### 13. Backlog update without ROADMAP sync
 - **Trigger**: Editing the planning backlog source of truth
-- **Instruction**: Always run sync-roadmap.ps1 immediately after backlog changes so the external ROADMAP stays in sync.
-- **Reason**: ROADMAP.md becomes stale, causing planning errors.
+- **Instruction**: Always run sync-roadmap.ps1 immediately after backlog changes so the external ROADMAP and internal planning docs under docs/internal stay in sync.
+- **Reason**: ROADMAP.md or the internal verification docs become stale, causing planning and test errors.
 
 ### 14. Memory/rules as permanent fix
 - **Trigger**: Recurring problem needs prevention

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -1,12 +1,28 @@
 # Handoff
 
-> Updated: 2026-04-13T19:32:00+09:00
+> Updated: 2026-04-14T03:10:00+09:00
 > Source of truth: this file
 
 ## Current state
 
 - `v0.20.0`, `v0.20.1`, `v0.20.2`, `v0.20.3`, `v0.21.0`, `v0.21.1`, and `v0.21.2` are released.
 - `v0.21.2` shipped as the terminal-based final form release before the `v0.22.0` Tauri control-plane handoff.
+- `ROADMAP.md` is now treated as the Japanese-facing planning surface, while `backlog.yaml` remains English-first.
+- internal-only docs under `docs/internal/` now include a user-facing feature inventory and a version-by-version manual verification checklist; both stay gitignored.
+- `winsmux-core/scripts/sync-roadmap.ps1` now refreshes those internal docs as part of the same planning-sync flow, so backlog changes update `ROADMAP.md` and the two internal verification sheets together.
+- Windows-first planning is explicit again; cross-platform work is no longer on the pre-`v1.0.0` path.
+- public autonomous execution is now planned as a post-`v1.0.0` product line:
+  - `v1.1.0` managed autonomous runs baseline
+  - `v1.2.0` TDD / self-verification / run insights hardening
+  - `v1.3.0` knowledge / playbooks / parallel managed runs
+- enterprise-grade execution isolation is now planned as the next post-`v1.0.0` public line:
+  - `v1.4.0` enterprise isolation profile foundation
+  - `v1.5.0` brokered execution and enterprise guardrails
+  - default execution remains `local-windows`; stronger isolation is added as an opt-in profile, not a replacement
+- roadmap headings now match the actual task contents again:
+  - `v0.22.1` is the Tauri desktop detail lane
+  - `v0.23.0` is the psmux-free dogfooding gate
+  - post-`v1.0.0` work is split into `post-v1.0.0-platform` and `post-v1.0.0-governance`
 - `ROADMAP.md` shows `v0.21.2 = 100% (2/2)` with only:
   - `TASK-216` terminal hot-path wrapper baseline
   - `TASK-295` winsmux-surface rename cleanup slice
@@ -49,6 +65,14 @@
   - `main.ts` no longer invokes `desktop_summary_snapshot` or `desktop_run_explain` directly
   - backend contract types for summary/explain now live in the client module instead of the main shell
   - the current transport remains Tauri `invoke`, but the seam is ready for a later JSON-RPC / SDK swap
+- Added `winsmux-app/src-tauri/src/desktop_backend.rs` as the backend transport boundary for desktop snapshot/explain calls:
+  - `lib.rs` now delegates desktop commands to the backend module instead of holding the PowerShell script plumbing inline
+  - command translation is centralized behind a small transport trait so a future JSON-RPC implementation can slot in without changing the Tauri command surface
+  - the current behavior is unchanged; the slice only reduces coupling and makes the backend seam easier to extend
+- Added `winsmux-app/src/ptyClient.ts` as the PTY transport seam for terminal pane lifecycle calls:
+  - `main.ts` no longer invokes `pty_spawn`, `pty_write`, `pty_resize`, or `pty_close` directly
+  - Tauri `invoke` remains the default transport implementation behind the helper module
+  - the terminal pane behavior is unchanged; only the call boundary moved
 - Landed `TASK-216` slice 1 and slice 2 on `main`:
   - PR #408: leaf wrapper consolidation for `commander-poll`, `pane-status`, and `pane-control`
   - PR #409: wrapper-based `orchestra-layout` session/window/pane flow
@@ -72,15 +96,85 @@
   - `TASK-310` -> `v0.24.3`
   - `TASK-115` -> `v0.24.5`
   - renamed `v0.24.1` to `Rust ledger, projections & session-state convergence`
+- Started branch `codex/roadmap-ja-gate-20260413` for roadmap localization.
+- Added `tasks/roadmap-title-ja.psd1` as the Japanese roadmap title overlay:
+  - `backlog.yaml` stays English-first
+  - `winsmux-core/scripts/sync-roadmap.ps1` now applies Japanese version/task title overrides only when generating `ROADMAP.md`
+  - for `v0.20.0` and later, missing Japanese task titles now fail roadmap sync instead of silently leaking English titles
+- Regenerated external `ROADMAP.md` from the English backlog through the new Japanese overlay/gate.
+- Added a durable repo rule to `AGENTS.md`:
+  - roadmap localization is a sync gate
+  - new or renamed `v0.20.0+` tasks must update `tasks/roadmap-title-ja.psd1` before roadmap sync is considered complete
+- There are carried-over local changes from the separate `TASK-105` transport branch in:
+  - `winsmux-app/src/main.ts`
+  - `winsmux-app/src/ptyClient.ts`
+  These are intentionally outside the roadmap-localization slice and must not be staged with it.
+- Added internal-only verification docs:
+  - `docs/internal/winsmux-feature-inventory.md` now covers released / active / planned user-facing capabilities from `v0.1.0` through `v1.0.0`
+  - `docs/internal/winsmux-manual-checklist-by-version.md` now splits manual verification into a separate per-version checklist sheet
+- Added `TASK-316` to external planning under `v0.24.5`:
+  - English title: `Version-by-version manual checklist + guided E2E validation before v1.0.0`
+  - purpose: use the new internal docs to run a Codex-guided end-to-end verification pass before `v1.0.0`
+  - `TASK-220` now depends on `TASK-316`, so the final release gate cannot pass before the guided verification is complete
+- Expanded `TASK-316` and the manual checklist so the guided verification also captures reusable screen recordings:
+  - the checklist now tracks `収録候補` alongside PASS / FAIL
+  - success cases can be reused later for `README`, `SNS`, and `Zenn`
+  - recording guidance explicitly excludes secrets, personal data, local-only paths, and other internal-only details
+- Moved cross-platform work out of the pre-`v1.0.0` line:
+  - `TASK-249`, `TASK-250`, `TASK-251`, `TASK-252`, `TASK-267`, `TASK-268`, and `TASK-271` now target `post-v1.0.0`
+  - `TASK-270` no longer depends on the moved cross-platform Rust tasks
+  - `TASK-316` no longer depends on `TASK-271`, so the guided pre-`v1.0.0` E2E track remains Windows-first
+- Updated the internal-only verification docs to match the roadmap move:
+  - `docs/internal/winsmux-feature-inventory.md`
+  - `docs/internal/winsmux-manual-checklist-by-version.md`
+- Reorganized roadmap presentation to reduce planning drift:
+  - `winsmux-core/scripts/sync-roadmap.ps1` now applies Japanese version title overrides even when the backlog comments do not provide a default title
+  - `tasks/roadmap-title-ja.psd1` now labels `v0.22.1` as the Tauri desktop detail lane and `v0.23.0` as the psmux-free dogfooding gate
+  - `TASK-271` title wording now correctly says post-`v1.0.0`
+  - `TASK-315` is now explicitly labeled as an internal-operations lane in both planning and internal docs
+  - post-`v1.0.0` planning is split into:
+    - `post-v1.0.0-platform` for Windows/Linux/macOS expansion
+    - `post-v1.0.0-governance` for long-horizon design / security / approval work
+- Added a dedicated public roadmap lane for Devin-style managed autonomy after `v1.0.0`:
+  - moved `TASK-311` out of `v0.22.0` into `v1.1.0` as the autonomous run stage machine core
+  - moved dependent `TASK-312` into `v1.3.0` so version ordering remains dependency-safe
+  - added `TASK-317` to `TASK-326` for autonomous run contract, Claude-managed loop, draft-PR stop gate, TDD policy, self-verification, run insights, knowledge, playbooks, parallel child runs, and the human handoff cockpit
+  - added Japanese roadmap title overlays for `v1.1.0`, `v1.2.0`, `v1.3.0`, and `TASK-317` to `TASK-326`
+- Added the next public roadmap lane for enterprise-grade execution isolation after the autonomy line:
+  - added `v1.4.0` for execution profile contract, isolated workspace runner, typed secret projection, and heartbeat/offline detection
+  - added `v1.5.0` for brokered execution, short-lived run tokens, enterprise capability/network policy, and desktop visibility
+  - kept `TASK-250` and `TASK-268` in `post-v1.0.0-governance`; the new `TASK-329` depends on them rather than moving them into the product lane
+  - fixed the default direction to stay Windows-native (`local-windows`) and treat stronger isolation as `isolated-enterprise`
+  - regenerated the external planning view after the new lane was added:
+    - `C:\Users\komei\iCloudDrive\iCloud~md~obsidian\MainVault\Projects\winsmux\planning\ROADMAP.md`
+    - `v1.4.0` and `v1.5.0` now appear in the Japanese roadmap with localized titles
+- Concretized the Scion-inspired roadmap intake into explicit product tasks:
+  - added `TASK-335` for `phase / activity / detail` state semantics with `waiting_for_input`, `blocked`, and `offline`
+  - added `TASK-337` for a progressive-skills CLI that agents can learn from via self-describing help surfaces
+  - added `TASK-338` for explicit diversity policy across mixed model / harness teams
+  - folded Scion-style notification subscriptions into existing `TASK-144` instead of creating a duplicate notification lane
+  - folded role-vs-backend separation into the existing `TASK-324` + `TASK-327` boundary
+  - folded late-bound credential resolution into `TASK-329` instead of splitting a second auth task
+  - hardened `winsmux-core/scripts/sync-roadmap.ps1` so roadmap generation warns and skips malformed empty `target_version` entries instead of crashing on parameter binding
+- Added internal planning-doc sync to the roadmap flow:
+  - `winsmux-core/scripts/sync-internal-docs.ps1` now regenerates the backlog-driven sections of
+    `docs/internal/winsmux-feature-inventory.md` and
+    `docs/internal/winsmux-manual-checklist-by-version.md`
+  - `winsmux-core/scripts/sync-roadmap.ps1` now calls that script automatically after roadmap generation
+  - the volatile `進行中 / 今後予定` sections and checklist rows are now backlog-synced instead of hand-maintained
+- Normalized external planning metadata for `TASK-144`:
+  - fixed the malformed backlog indentation so `priority = P2` and `status = backlog` are emitted correctly into `ROADMAP.md`
+  - regenerated the roadmap and internal planning docs through the standard sync flow
 
 ## Validation
 
-- `npm run build` in `winsmux-app` -> PASS
+- `git diff --check` -> warnings only for LF/CRLF normalization, no substantive errors
+- `npm run build` in `winsmux-app` -> PASS after PTY seam extraction
 - `cargo check` in `winsmux-app/src-tauri` -> PASS
+- `cargo test --lib` in `winsmux-app/src-tauri` -> PASS for the backend transport boundary tests
 - `pwsh -NoProfile -Command "& { & '.\scripts\winsmux-core.ps1' board --json }"` -> PASS
 - `pwsh -NoProfile -Command "& { & '.\scripts\winsmux-core.ps1' digest --json }"` -> PASS
 - `pwsh -NoProfile -Command "& { $digest = & '.\scripts\winsmux-core.ps1' digest --json | ConvertFrom-Json; if ($digest.items.Count -gt 0) { & '.\scripts\winsmux-core.ps1' explain $digest.items[0].run_id --json | Out-Null } }"` -> PASS
-- `git diff --check` -> warnings only for CRLF normalization, no substantive errors
 - `cargo check` in `winsmux-app/src-tauri` -> PASS after `desktopClient.ts` extraction
 - `npm run build` in `winsmux-app` -> PASS after `desktopClient.ts` extraction
 - Fresh reviewer `Dewey` -> `PASS` for the projection-driven source-context slice in PR #412
@@ -121,12 +215,30 @@
 - Release reviewer `Hypatia` -> `PASS` for `v0.21.2` release readiness
 - Manual diff review completed for the `README.md` / `README.ja.md` release-prep wording
 - GitHub release [v0.21.2](https://github.com/Sora-bluesky/winsmux/releases/tag/v0.21.2) published successfully
+- `git check-ignore -v docs/internal/winsmux-feature-inventory.md` -> PASS
+- `git check-ignore -v docs/internal/winsmux-manual-checklist-by-version.md` -> PASS
+- external `winsmux planning backlog.yaml` updated with `TASK-316`
+- external `winsmux ROADMAP.md` regenerated after adding `TASK-316`
+- external `winsmux planning backlog.yaml` updated for the Windows-first roadmap change
+- `pwsh -NoProfile -File winsmux-core/scripts/sync-roadmap.ps1` -> PASS after version-heading and post-`v1.0.0` bucket split
+- external `winsmux planning backlog.yaml` metadata normalized for `TASK-144`
+- `pwsh -NoProfile -File winsmux-core/scripts/sync-roadmap.ps1` -> PASS after the `TASK-144` metadata fix
+- `pwsh -NoProfile -File winsmux-core/scripts/sync-roadmap.ps1` -> PASS after adding internal-doc auto-sync
+- Manual diff review completed for the planning-sync flow (`sync-roadmap.ps1`, `sync-internal-docs.ps1`, `internal-docs-meta.psd1`)
+- `/review` follow-up via subagent `Euclid` -> `no result yet` after the initial 30s wait on the planning/sync-only slice; manual diff review completed and the packaged scope stayed limited to:
+  - roadmap localization gate hardening in `winsmux-core/scripts/sync-roadmap.ps1`
+  - automatic internal-doc regeneration through `winsmux-core/scripts/sync-internal-docs.ps1`
+  - durable repo rules in `AGENTS.md` / `GUARDRAILS.md`
 
 ## Next actions
 
-1. Open a PR for the `TASK-105` desktop client seam slice.
-2. Continue `v0.22.0` with the next backend-first slice after the seam lands, likely JSON-RPC transport substitution inside `desktopClient.ts`.
-3. Track startup latency from per-run `explain` fetches inside `desktop_summary_snapshot` if digest volume grows.
+1. Continue `v0.22.0` with the next transport substitution slice, likely a real file preview/read surface behind `winsmux-app/src-tauri/src/desktop_backend.rs`.
+2. Keep `TASK-315` clearly marked as an internal-operations lane if more user-facing roadmap cleanup happens around `v0.22.0`.
+3. Use `docs/internal/winsmux-manual-checklist-by-version.md` as the execution sheet when the guided end-to-end verification for `TASK-316` starts, including screen-capture candidates.
+4. Keep the PTY seam limited to terminal pane lifecycle calls so follow-up refactors stay isolated.
+5. Treat `TASK-317` as the first public autonomous-execution entrypoint after the `v1.0.0` release gate rather than mixing it into `TASK-315`.
+6. Keep backlog-driven sections of the two internal verification docs generated through `sync-roadmap.ps1`; do not hand-edit those sections directly.
+7. Treat `v1.4.0` / `v1.5.0` as opt-in enterprise isolation profiles that extend the Windows-native default rather than replacing it with container-first execution.
 
 ## Notes
 
@@ -134,3 +246,8 @@
 - `TASK-216` landed as small hot-path wrapper slices rather than a single bridge-file refactor.
 - `TASK-295` keeps `.psmux` compatibility paths untouched; those stay under the sunset plan instead of this rename slice.
 - Public GitHub Releases stay English, use Codex-style headings, and keep inline issue/PR refs visible.
+- `ROADMAP.md` is Japanese-first for operator readability; `backlog.yaml` remains English-first as the canonical planning dataset.
+- `docs/internal/` remains gitignored; internal verification docs must not be committed as public surface.
+- The enterprise isolation plan intentionally does not make containers mandatory. It reserves room for container-backed or broker-backed isolation profiles without changing the default Windows-first operator model.
+- `TASK-315` stays internal-only; the public autonomous execution line starts at `v1.1.0` with `TASK-317`.
+- `docs/internal/winsmux-feature-inventory.md` and `docs/internal/winsmux-manual-checklist-by-version.md` now contain backlog-driven generated blocks. Manual prose can stay, but the generated blocks should be refreshed via `sync-roadmap.ps1`.

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -8,7 +8,7 @@
 - `v0.20.0`, `v0.20.1`, `v0.20.2`, `v0.20.3`, `v0.21.0`, `v0.21.1`, and `v0.21.2` are released.
 - `v0.21.2` shipped as the terminal-based final form release before the `v0.22.0` Tauri control-plane handoff.
 - `ROADMAP.md` is now treated as the Japanese-facing planning surface, while `backlog.yaml` remains English-first.
-- internal-only docs under `docs/internal/` now include a user-facing feature inventory and a version-by-version manual verification checklist; both stay gitignored.
+- internal-only docs under `docs/internal/` now include a user-facing feature inventory and a version-by-version manual verification checklist; both stay gitignored and now cover the current released, active, and post-`v1.0.0` planned lanes.
 - `winsmux-core/scripts/sync-roadmap.ps1` now refreshes those internal docs as part of the same planning-sync flow, so backlog changes update `ROADMAP.md` and the two internal verification sheets together.
 - Windows-first planning is explicit again; cross-platform work is no longer on the pre-`v1.0.0` path.
 - public autonomous execution is now planned as a post-`v1.0.0` product line:
@@ -110,8 +110,8 @@
   - `winsmux-app/src/ptyClient.ts`
   These are intentionally outside the roadmap-localization slice and must not be staged with it.
 - Added internal-only verification docs:
-  - `docs/internal/winsmux-feature-inventory.md` now covers released / active / planned user-facing capabilities from `v0.1.0` through `v1.0.0`
-  - `docs/internal/winsmux-manual-checklist-by-version.md` now splits manual verification into a separate per-version checklist sheet
+  - `docs/internal/winsmux-feature-inventory.md` now covers released / active / planned user-facing capabilities from `v0.1.0` through the current post-`v1.0.0` roadmap lanes
+  - `docs/internal/winsmux-manual-checklist-by-version.md` now splits manual verification into a separate per-version checklist sheet and tracks the same roadmap horizon
 - Added `TASK-316` to external planning under `v0.24.5`:
   - English title: `Version-by-version manual checklist + guided E2E validation before v1.0.0`
   - purpose: use the new internal docs to run a Codex-guided end-to-end verification pass before `v1.0.0`
@@ -225,10 +225,12 @@
 - `pwsh -NoProfile -File winsmux-core/scripts/sync-roadmap.ps1` -> PASS after the `TASK-144` metadata fix
 - `pwsh -NoProfile -File winsmux-core/scripts/sync-roadmap.ps1` -> PASS after adding internal-doc auto-sync
 - Manual diff review completed for the planning-sync flow (`sync-roadmap.ps1`, `sync-internal-docs.ps1`, `internal-docs-meta.psd1`)
-- `/review` follow-up via subagent `Euclid` -> `no result yet` after the initial 30s wait on the planning/sync-only slice; manual diff review completed and the packaged scope stayed limited to:
-  - roadmap localization gate hardening in `winsmux-core/scripts/sync-roadmap.ps1`
-  - automatic internal-doc regeneration through `winsmux-core/scripts/sync-internal-docs.ps1`
-  - durable repo rules in `AGENTS.md` / `GUARDRAILS.md`
+- `/review` follow-up via subagent `Euclid` -> delayed `FAIL` on the planning/sync-only slice after the initial 30s wait
+- follow-up fix after the delayed `Euclid` review:
+  - `sync-roadmap.ps1` now validates missing Japanese version titles before writing `ROADMAP.md`, so the localization gate fails closed
+  - `sync-internal-docs.ps1` now classifies `done` tasks as `公開済み` instead of leaving them in the generated `進行中` view
+  - `docs/handoff.md` now describes the internal planning docs as extending through the current post-`v1.0.0` lanes
+- follow-up reviewer `Lorentz` -> `PASS` on the fix-up slice for fail-closed roadmap generation, `done` classification, and handoff scope wording
 
 ## Next actions
 

--- a/winsmux-core/scripts/internal-docs-meta.psd1
+++ b/winsmux-core/scripts/internal-docs-meta.psd1
@@ -1,0 +1,272 @@
+@{
+    FeatureInventoryEntries = @(
+        @{
+            Order = 10
+            Category = '画面での操作'
+            Title = 'Tauri デスクトップアプリを、生の端末出力ではなく整理済みデータで動かす'
+            UserValue = 'Tauri デスクトップアプリがターミナルの流れを直接読むのではなく、ダッシュボード、受信箱、要点整理、詳細説明などの整理済みデータから状態を描くようになります。これにより、表示の一貫性が上がり、後続の機能追加もしやすくなります。'
+            UseCase = 'Tauri デスクトップアプリで見えている情報と、実際の運用状態をずらさずに扱いたいときに使います。'
+            ImplementationVersion = 'v0.22.0'
+            TaskIds = @('TASK-105', 'TASK-289', 'TASK-291')
+            AppendixName = 'Tauri デスクトップアプリの整理済みデータ化'
+            TestFocus = '画面表示が整理済みデータで動くか'
+        }
+        @{
+            Order = 20
+            Category = '拡張と今後の強化'
+            Title = '内部運用として、外部の生成支援道具の変化を見張り、自己進化の候補を作る'
+            UserValue = 'OpenAI、Anthropic、Google など外部の生成支援道具の変化を見張り、その内容を winsmux に取り込む候補と、見直すべき機能候補に分けられるようにします。自動化は下書き提案までで止め、最終判断は人が行います。'
+            UseCase = '外部の変化を追い続けながら、winsmux 自体の改善や整理を継続したいときに使います。'
+            ImplementationVersion = 'v0.22.0'
+            TaskIds = @('TASK-315')
+            AppendixName = '内部運用の自己進化'
+            TestFocus = '外部変化の収集、影響判断、見直し候補'
+        }
+        @{
+            Order = 30
+            Category = '拡張と今後の強化'
+            Title = 'Tauri デスクトップアプリと CLI のつなぎ方を整理し、後から差し替えやすくする'
+            UserValue = 'Tauri デスクトップアプリ、CLI、裏側の制御処理の役割分担を整理し、通信方式や実装を後から入れ替えやすくします。'
+            UseCase = '今は PowerShell ベースの処理と Tauri デスクトップアプリが混在していても、将来の移行で大きく作り直さずに進めたいときに使います。'
+            ImplementationVersion = 'v0.22.0'
+            TaskIds = @('TASK-217a', 'TASK-217b', 'TASK-217c', 'TASK-217d', 'TASK-217e', 'TASK-226')
+            AppendixName = 'Tauri デスクトップアプリと CLI の接続整理'
+            TestFocus = '通信経路と役割分担の整理'
+        }
+        @{
+            Order = 40
+            Category = '画面での操作'
+            Title = 'Tauri デスクトップアプリの詳細表示を、日々の運用で判断しやすくする'
+            UserValue = '変更ファイル、確認結果、判定、ブランチや先頭位置、作業役の属性などを、詳細表示で読みやすく確認できるようになります。並べ替えや複数ウィンドウ表示も強化されます。'
+            UseCase = 'Tauri デスクトップアプリだけで「何が変わったか」「確認は通ったか」を追いたいときに使います。'
+            ImplementationVersion = 'v0.22.1'
+            TaskIds = @('TASK-107', 'TASK-108', 'TASK-290', 'TASK-305', 'TASK-308', 'TASK-078')
+            AppendixName = 'Tauri デスクトップアプリの詳細強化'
+            TestFocus = '詳細表示、複数画面、表示確認'
+        }
+        @{
+            Order = 50
+            Category = '基本操作と拡張'
+            Title = '遠隔の区画や外部のプロバイダーも、同じ操作画面で扱えるようにする'
+            UserValue = '遠隔の区画、外部の連携口、プロバイダーの切り替え、手元のマシンの読み取り専用利用などを、同じ枠組みで扱えるようになります。'
+            UseCase = '手元だけでなく、別の場所や別のプロバイダーも含めて運用したいときに使います。'
+            ImplementationVersion = 'v0.22.2'
+            TaskIds = @('TASK-106', 'TASK-147', 'TASK-313', 'TASK-314', 'TASK-258')
+            AppendixName = '遠隔区画とプロバイダー拡張'
+            TestFocus = '遠隔、プロバイダー切り替え、手元マシン連携'
+        }
+        @{
+            Order = 60
+            Category = '基本操作と拡張'
+            Title = '機能の追加方法を整理し、並列処理も広げる'
+            UserValue = '拡張用の読み込み口を整え、命令構造を一元化し、通知や並列処理も増やしやすくします。'
+            UseCase = '後から機能を足しても全体が散らかりにくい形にしたいときに使います。'
+            ImplementationVersion = 'v0.22.0'
+            TaskIds = @('TASK-168', 'TASK-144', 'TASK-306', 'TASK-307', 'TASK-192')
+            AppendixName = '拡張口と並列処理の整理'
+            TestFocus = '拡張しやすい命令構造'
+        }
+        @{
+            Order = 70
+            Category = '作業環境の管理'
+            Title = '作業状態の元データを Rust 側へ移していく'
+            UserValue = '作業状態、履歴、ダッシュボード、要点整理、詳細説明などの元になる情報を、徐々に Rust 側の型付きデータへ寄せていきます。PowerShell は起動や互換のための薄い役割へ縮めていきます。'
+            UseCase = '運用の信頼性を上げつつ、将来の保守をしやすくしたいときに使います。'
+            ImplementationVersion = 'v0.24.0 から v0.24.4'
+            TaskIds = @('TASK-277', 'TASK-278', 'TASK-265', 'TASK-275', 'TASK-280', 'TASK-266', 'TASK-269', 'TASK-281', 'TASK-267', 'TASK-268', 'TASK-284', 'TASK-270', 'TASK-276', 'TASK-282')
+            AppendixName = 'Rust 側への元データ移行'
+            TestFocus = '状態、履歴、一覧の移行'
+        }
+        @{
+            Order = 80
+            Category = '作業環境の管理'
+            Title = '途中再開、退避コピー、証跡強化を進める'
+            UserValue = '途中からの再開、作業場所の退避コピー、改ざん検知つきの証跡などを強められるようになります。'
+            UseCase = '長期運用や、失敗時の巻き戻し、後日の説明責任をより強くしたいときに使います。'
+            ImplementationVersion = 'v0.24.1 から v0.24.3'
+            TaskIds = @('TASK-143', 'TASK-154', 'TASK-169', 'TASK-310')
+            AppendixName = '再開・退避コピー・改ざん検知'
+            TestFocus = '途中再開、退避コピー、証跡強化'
+        }
+        @{
+            Order = 90
+            Category = '公開に向けた最終強化'
+            Title = 'PowerShell 依存を縮め、Rust 中心の配布形へ移る'
+            UserValue = '最終的には Rust を中心にした配布形へ寄せ、PowerShell は導入や互換の補助にとどめる予定です。Windows 向け配布、試験導入、本番移行の流れも整います。'
+            UseCase = '公開版として安定した配布と更新を行いたいときに使います。'
+            ImplementationVersion = 'v0.24.5 から v1.0.0'
+            TaskIds = @('TASK-296', 'TASK-283', 'TASK-115', 'TASK-220', 'TASK-316')
+            AppendixName = 'Rust 中心の配布移行'
+            TestFocus = 'Windows 向け配布、互換終了、試験導入、本公開'
+        }
+        @{
+            Order = 100
+            Category = '公開に向けた最終強化'
+            Title = '公開後に向けた設計書と、より細かな承認制御を整える'
+            UserValue = '要件、脅威、設計書の整備に加えて、命令単位の承認やネットワーク遅延承認のような後続機能を準備します。'
+            UseCase = '公開後に運用や説明責任をさらに強くしたいときに使います。'
+            ImplementationVersion = 'post-v1.0.0-governance'
+            TaskIds = @('TASK-045', 'TASK-046', 'TASK-047', 'TASK-048', 'TASK-050', 'TASK-073', 'TASK-076')
+            AppendixName = '公開後の設計書と細かな承認制御'
+            TestFocus = '説明資料、承認の細分化'
+        }
+        @{
+            Order = 110
+            Category = '拡張と今後の強化'
+            Title = '自律 run を、下書き PR 手前まで管理された形で進める'
+            UserValue = 'Claude Code を司令塔にしたまま、計画、実装、確認、引き継ぎの流れを小さな run 単位で回し、最後は必ず下書き PR か判断待ちで止まるようにします。'
+            UseCase = '利用者が細かな指示を出し続けなくても、自律 run に 85〜95% を進めさせ、最後だけ人が判断したいときに使います。'
+            ImplementationVersion = 'v1.1.0'
+            TaskIds = @('TASK-311', 'TASK-317', 'TASK-318', 'TASK-319')
+            AppendixName = '管理された自律 run の基盤'
+            TestFocus = 'plan から draft PR までの無人完走'
+        }
+        @{
+            Order = 120
+            Category = '拡張と今後の強化'
+            Title = '自律 run に、試験先行と自己確認を標準で持たせる'
+            UserValue = 'バグ修正や中核変更では先に失敗する試験を書き、実装後は build、test、browser、screenshot、recording まで自分で確認する流れを標準にします。'
+            UseCase = '自律 run がコードを書くだけでなく、自分で確かめたうえで人へ返してほしいときに使います。'
+            ImplementationVersion = 'v1.2.0'
+            TaskIds = @('TASK-320', 'TASK-321', 'TASK-322')
+            AppendixName = '自律 run の TDD と自己確認'
+            TestFocus = 'TDD gate、自己確認、run insights'
+        }
+        @{
+            Order = 130
+            Category = '拡張と今後の強化'
+            Title = '知識、手順書、並列子 run を使い回しながら、自律 run を伸ばす'
+            UserValue = 'repo 固有の知識、繰り返し手順、並列で動く子 run、最後の判断を助ける画面をそろえ、自律 run が同じ失敗を繰り返しにくい形へ育てます。'
+            UseCase = '長い案件でも、司令塔が複数の run を束ね、人は最後の 5〜15% に集中したいときに使います。'
+            ImplementationVersion = 'v1.3.0'
+            TaskIds = @('TASK-312', 'TASK-323', 'TASK-324', 'TASK-325', 'TASK-326')
+            AppendixName = '知識・手順書・並列自律 run'
+            TestFocus = 'Knowledge、Playbook、並列子 run、handoff 画面'
+        }
+        @{
+            Order = 140
+            Category = '画面での操作'
+            Title = 'Windows 以外でも使える下地を、v1.0.0 の後で整える'
+            UserValue = '将来、Windows 以外でも同じ操作感で使えるように、確認の組み合わせ、保管庫、PowerShell 依存を整理します。'
+            UseCase = '将来、Windows 以外の環境でも同じ運用をしたいときに使います。'
+            ImplementationVersion = 'post-v1.0.0-platform'
+            TaskIds = @('TASK-249', 'TASK-250', 'TASK-251', 'TASK-252', 'TASK-267', 'TASK-268', 'TASK-271')
+            AppendixName = 'Windows 以外への展開'
+            TestFocus = 'Windows 以外への拡張を始められるか'
+        }
+    )
+    ManualChecklistEntries = @(
+        @{
+            Order = 10
+            Version = 'v0.22.0'
+            TaskIds = @('TASK-105', 'TASK-289', 'TASK-291')
+            Focus = 'Tauri デスクトップアプリが生の端末出力ではなく整理済みデータで動く'
+            Example = 'ダッシュボード、受信箱、要点整理、詳細説明が画面で一貫して見える'
+            Memo = ''
+        }
+        @{
+            Order = 20
+            Version = 'v0.22.0'
+            TaskIds = @('TASK-315')
+            Focus = '自己進化'
+            Example = '外部変化の収集、影響判断、見直し候補の出力'
+            Memo = ''
+        }
+        @{
+            Order = 30
+            Version = 'v0.22.0'
+            TaskIds = @('TASK-217a', 'TASK-217b', 'TASK-217c', 'TASK-217d', 'TASK-217e', 'TASK-226')
+            Focus = 'Tauri デスクトップアプリと CLI の接続整理'
+            Example = '通信経路と役割分担が整理され、差し替え後も同じ見え方を保てる'
+            Memo = ''
+        }
+        @{
+            Order = 40
+            Version = 'v0.22.1'
+            TaskIds = @('TASK-107', 'TASK-108', 'TASK-290', 'TASK-305', 'TASK-308', 'TASK-078')
+            Focus = '詳細表示を運用判断しやすくする'
+            Example = '変更ファイル、確認結果、判定、ブランチ情報が見やすい'
+            Memo = ''
+        }
+        @{
+            Order = 50
+            Version = 'v0.22.2'
+            TaskIds = @('TASK-106', 'TASK-147', 'TASK-313', 'TASK-314', 'TASK-258')
+            Focus = '遠隔区画とプロバイダー切り替え'
+            Example = '遠隔接続、プロバイダー切り替え、手元マシンの読み取り専用連携'
+            Memo = ''
+        }
+        @{
+            Order = 60
+            Version = 'v0.24.0-v0.24.4'
+            TaskIds = @('TASK-277', 'TASK-278', 'TASK-265', 'TASK-275', 'TASK-280', 'TASK-266', 'TASK-269', 'TASK-281', 'TASK-284', 'TASK-270', 'TASK-276', 'TASK-282')
+            Focus = 'Rust 側への元データ移行'
+            Example = 'ダッシュボード、受信箱、要点整理、詳細説明の元データが移っている'
+            Memo = ''
+        }
+        @{
+            Order = 70
+            Version = 'v0.24.1-v0.24.3'
+            TaskIds = @('TASK-143', 'TASK-154', 'TASK-169', 'TASK-310')
+            Focus = '再開、退避コピー、証跡強化'
+            Example = '再開、退避コピー、改ざん検知の観点を確認'
+            Memo = ''
+        }
+        @{
+            Order = 80
+            Version = 'v0.24.5'
+            TaskIds = @('TASK-296', 'TASK-283', 'TASK-115', 'TASK-220', 'TASK-316')
+            Focus = '公開前の総合確認'
+            Example = '互換終了、試験導入、Windows 向け導入案内をまとめて確認'
+            Memo = 'TASK-316 を使う'
+        }
+        @{
+            Order = 90
+            Version = 'v1.0.0'
+            TaskIds = @('TASK-220')
+            Focus = '公開ゲート'
+            Example = '公開資料、配布物、署名、最終説明に抜けがない'
+            Memo = ''
+        }
+        @{
+            Order = 100
+            Version = 'v1.1.0'
+            TaskIds = @('TASK-311', 'TASK-317', 'TASK-318', 'TASK-319')
+            Focus = '管理された自律 run の基盤'
+            Example = 'plan から draft PR まで、止まるべき地点で fail-closed に止まる'
+            Memo = ''
+        }
+        @{
+            Order = 110
+            Version = 'v1.2.0'
+            TaskIds = @('TASK-320', 'TASK-321', 'TASK-322')
+            Focus = '自律 run の TDD と自己確認'
+            Example = '失敗する試験追加、自己確認、screenshot や recording の証跡が残る'
+            Memo = ''
+        }
+        @{
+            Order = 120
+            Version = 'v1.3.0'
+            TaskIds = @('TASK-312', 'TASK-323', 'TASK-324', 'TASK-325', 'TASK-326')
+            Focus = '知識、手順書、並列子 run、handoff 画面'
+            Example = 'Knowledge と Playbook を再利用し、並列 run の結果を一画面で判断できる'
+            Memo = ''
+        }
+        @{
+            Order = 130
+            Version = 'post-v1.0.0-platform'
+            TaskIds = @('TASK-249', 'TASK-250', 'TASK-251', 'TASK-252', 'TASK-267', 'TASK-268', 'TASK-271')
+            Focus = 'Windows 以外への展開'
+            Example = 'Windows 以外で起動、保管庫、PowerShell 依存が崩れない'
+            Memo = ''
+        }
+        @{
+            Order = 140
+            Version = 'post-v1.0.0-governance'
+            TaskIds = @('TASK-045', 'TASK-046', 'TASK-047', 'TASK-048', 'TASK-050', 'TASK-073', 'TASK-076')
+            Focus = '公開後の設計書と細かな承認制御'
+            Example = '要件、脅威、設計、承認制御の説明責任を後追いせず整理できる'
+            Memo = ''
+        }
+    )
+}

--- a/winsmux-core/scripts/sync-internal-docs.ps1
+++ b/winsmux-core/scripts/sync-internal-docs.ps1
@@ -202,7 +202,13 @@ function Get-PlanningState {
     }
 
     foreach ($status in $statuses) {
-        if ($status -in @('active', 'review', 'in-progress', 'in_progress', 'doing', 'done')) {
+        if ($status -eq 'done') {
+            return '公開済み'
+        }
+    }
+
+    foreach ($status in $statuses) {
+        if ($status -in @('active', 'review', 'in-progress', 'in_progress', 'doing')) {
             return '進行中'
         }
     }

--- a/winsmux-core/scripts/sync-internal-docs.ps1
+++ b/winsmux-core/scripts/sync-internal-docs.ps1
@@ -1,0 +1,428 @@
+[CmdletBinding()]
+param(
+    [string]$BacklogPath = '',
+    [string]$RoadmapTitleJaPath = '',
+    [string]$FeatureInventoryPath = '',
+    [string]$ManualChecklistPath = '',
+    [string]$MetaPath = ''
+)
+
+$ErrorActionPreference = 'Stop'
+
+. (Join-Path $PSScriptRoot 'planning-paths.ps1')
+
+function Resolve-WorkspacePath {
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    if ([System.IO.Path]::IsPathRooted($Path)) {
+        return $Path
+    }
+
+    return Join-Path (Get-Location).Path $Path
+}
+
+function ConvertFrom-YamlScalar {
+    param([AllowNull()][string]$Value)
+
+    if ($null -eq $Value) {
+        return $null
+    }
+
+    $trimmed = $Value.Trim()
+    if ($trimmed.Length -ge 2) {
+        if (($trimmed.StartsWith('"') -and $trimmed.EndsWith('"')) -or ($trimmed.StartsWith("'") -and $trimmed.EndsWith("'"))) {
+            return $trimmed.Substring(1, $trimmed.Length - 2)
+        }
+    }
+
+    return $trimmed
+}
+
+function ConvertFrom-YamlInlineList {
+    param([string]$Value)
+
+    $trimmed = $Value.Trim()
+    if ($trimmed -eq '[]') {
+        return @()
+    }
+
+    if (-not ($trimmed.StartsWith('[') -and $trimmed.EndsWith(']'))) {
+        return @((ConvertFrom-YamlScalar -Value $trimmed))
+    }
+
+    $inner = $trimmed.Substring(1, $trimmed.Length - 2).Trim()
+    if ([string]::IsNullOrWhiteSpace($inner)) {
+        return @()
+    }
+
+    $items = @()
+    foreach ($part in ($inner -split ',')) {
+        $parsed = ConvertFrom-YamlScalar -Value $part
+        if (-not [string]::IsNullOrWhiteSpace($parsed)) {
+            $items += $parsed
+        }
+    }
+
+    return $items
+}
+
+function Get-TaskBlocks {
+    param([Parameter(Mandatory = $true)][string]$Content)
+
+    $normalized = $Content -replace "`r`n", "`n"
+    $lines = $normalized -split "`n"
+    $blocks = New-Object System.Collections.Generic.List[object]
+    $current = $null
+
+    foreach ($line in $lines) {
+        if ($line -match '^[ \t]*-[ \t]+id:[ \t]*(?<id>\S+)[ \t]*$') {
+            if ($null -ne $current -and $current.Count -gt 0) {
+                $blocks.Add([pscustomobject]@{ Lines = @($current.ToArray()) })
+            }
+
+            $current = New-Object System.Collections.Generic.List[string]
+            $current.Add($line)
+            continue
+        }
+
+        if ($null -ne $current) {
+            $current.Add($line)
+        }
+    }
+
+    if ($null -ne $current -and $current.Count -gt 0) {
+        $blocks.Add([pscustomobject]@{ Lines = @($current.ToArray()) })
+    }
+
+    return $blocks
+}
+
+function ConvertFrom-TaskBlock {
+    param(
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyString()]
+        [AllowEmptyCollection()]
+        [string[]]$Lines
+    )
+
+    if ($Lines[0] -notmatch '^[ \t]*-[ \t]+id:[ \t]*(?<id>\S+)[ \t]*$') {
+        return $null
+    }
+
+    $values = @{
+        id = $Matches['id']
+        title = ''
+        status = ''
+        target_version = ''
+    }
+
+    for ($index = 1; $index -lt $Lines.Count; $index++) {
+        $line = $Lines[$index]
+        if ($line -match '^[ \t]{4}(?<key>[a-z_]+):[ \t]*(?<value>.*)$') {
+            $key = $Matches['key']
+            $value = $Matches['value']
+
+            if ($value -in @('>', '|')) {
+                continue
+            }
+
+            $values[$key] = if ($value.Trim().StartsWith('[')) { ConvertFrom-YamlInlineList -Value $value } else { ConvertFrom-YamlScalar -Value $value }
+        }
+    }
+
+    return [pscustomobject]@{
+        Id = $values['id']
+        Title = $values['title']
+        Status = $values['status']
+        TargetVersion = $values['target_version']
+    }
+}
+
+function Get-VersionTitleMap {
+    param([Parameter(Mandatory = $true)][string]$Content)
+
+    $normalized = $Content -replace "`r`n", "`n"
+    $versionTitles = [ordered]@{}
+    foreach ($line in ($normalized -split "`n")) {
+        if ($line -match '^[ \t]*#[ \t]*===[ \t]*(?<version>[^:]+):[ \t]*(?<title>.+?)[ \t]*===[ \t]*$') {
+            $versionTitles[$Matches['version'].Trim()] = $Matches['title'].Trim()
+        }
+    }
+
+    return $versionTitles
+}
+
+function Get-RoadmapLocalizationMap {
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        return @{ VersionTitles = @{}; TaskTitles = @{} }
+    }
+
+    $data = Import-PowerShellDataFile -LiteralPath $Path
+    return @{
+        VersionTitles = if ($null -ne $data.VersionTitles) { $data.VersionTitles } else { @{} }
+        TaskTitles = if ($null -ne $data.TaskTitles) { $data.TaskTitles } else { @{} }
+    }
+}
+
+function Get-VersionSortTuple {
+    param([AllowNull()][string]$Version)
+
+    if ($Version -match '^v(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)$') {
+        return @([int]$Matches['major'], [int]$Matches['minor'], [int]$Matches['patch'], $Version)
+    }
+
+    if ($Version -eq 'post-v1.0.0-platform') {
+        return @(9998, 0, 0, $Version)
+    }
+
+    if ($Version -eq 'post-v1.0.0-governance') {
+        return @(9999, 0, 0, $Version)
+    }
+
+    return @(9997, 0, 0, ($Version ?? ''))
+}
+
+function Get-PlanningState {
+    param(
+        [Parameter(Mandatory = $true)][string[]]$TaskIds,
+        [Parameter(Mandatory = $true)][hashtable]$TasksById
+    )
+
+    $statuses = @()
+    foreach ($taskId in $TaskIds) {
+        if ($TasksById.ContainsKey($taskId)) {
+            $statuses += ($TasksById[$taskId].Status ?? '')
+        }
+    }
+
+    if ($statuses.Count -eq 0) {
+        return '今後予定'
+    }
+
+    foreach ($status in $statuses) {
+        if ($status -in @('active', 'review', 'in-progress', 'in_progress', 'doing', 'done')) {
+            return '進行中'
+        }
+    }
+
+    return '今後予定'
+}
+
+function Get-VersionLabel {
+    param(
+        [Parameter(Mandatory = $true)][string]$Version,
+        [Parameter(Mandatory = $true)][hashtable]$VersionTitles,
+        [Parameter(Mandatory = $true)][hashtable]$LocalizedVersionTitles
+    )
+
+    if ($LocalizedVersionTitles.ContainsKey($Version)) {
+        return ('{0}: {1}' -f $Version, [string]$LocalizedVersionTitles[$Version])
+    }
+
+    if ($VersionTitles.ContainsKey($Version)) {
+        return ('{0}: {1}' -f $Version, [string]$VersionTitles[$Version])
+    }
+
+    return $Version
+}
+
+function New-FeatureInventorySection {
+    param(
+        [Parameter(Mandatory = $true)][string]$State,
+        [Parameter(Mandatory = $true)][object[]]$Entries,
+        [Parameter(Mandatory = $true)][hashtable]$TasksById,
+        [Parameter(Mandatory = $true)][hashtable]$VersionTitles,
+        [Parameter(Mandatory = $true)][hashtable]$LocalizedVersionTitles,
+        [Parameter(Mandatory = $true)][int]$StartNumber
+    )
+
+    $filtered = @($Entries | Where-Object { (Get-PlanningState -TaskIds $_.TaskIds -TasksById $TasksById) -eq $State } | Sort-Object Order)
+    $builder = [System.Text.StringBuilder]::new()
+    $currentCategory = ''
+    $number = $StartNumber
+
+    foreach ($entry in $filtered) {
+        if ($entry.Category -ne $currentCategory) {
+            if ($builder.Length -gt 0) {
+                [void]$builder.AppendLine()
+            }
+            [void]$builder.AppendLine(("### {0}" -f $entry.Category))
+            [void]$builder.AppendLine()
+            $currentCategory = $entry.Category
+        }
+
+        $taskLabel = ($entry.TaskIds -join ', ')
+        [void]$builder.AppendLine(("#### {0}. {1}" -f $number, $entry.Title))
+        [void]$builder.AppendLine('利用者ができること:')
+        [void]$builder.AppendLine($entry.UserValue)
+        [void]$builder.AppendLine()
+        [void]$builder.AppendLine('どんな場面で使うか:')
+        [void]$builder.AppendLine($entry.UseCase)
+        [void]$builder.AppendLine()
+        [void]$builder.AppendLine(("今の状態: {0}  " -f $State))
+        [void]$builder.AppendLine(("実装版: {0}  " -f $entry.ImplementationVersion))
+        [void]$builder.AppendLine(("根拠作業番号: {0}" -f $taskLabel))
+        [void]$builder.AppendLine()
+        $number += 1
+    }
+
+    return [pscustomobject]@{
+        Content = $builder.ToString().TrimEnd()
+        NextNumber = $number
+    }
+}
+
+function New-DynamicAppendixRows {
+    param(
+        [Parameter(Mandatory = $true)][object[]]$Entries,
+        [Parameter(Mandatory = $true)][hashtable]$TasksById
+    )
+
+    $rows = foreach ($entry in ($Entries | Sort-Object Order)) {
+        $state = Get-PlanningState -TaskIds $entry.TaskIds -TasksById $TasksById
+        $taskLabel = ($entry.TaskIds -join ',')
+        ('| {0} | {1} | {2} | {3} | {4} |' -f $entry.AppendixName, $state, $entry.ImplementationVersion, $taskLabel, $entry.TestFocus)
+    }
+
+    return ($rows -join "`r`n")
+}
+
+function New-ChecklistRows {
+    param(
+        [Parameter(Mandatory = $true)][object[]]$Entries,
+        [Parameter(Mandatory = $true)][hashtable]$TasksById,
+        [Parameter(Mandatory = $true)][hashtable]$VersionTitles,
+        [Parameter(Mandatory = $true)][hashtable]$LocalizedVersionTitles
+    )
+
+    $rows = foreach ($entry in ($Entries | Sort-Object Order)) {
+        $state = Get-PlanningState -TaskIds $entry.TaskIds -TasksById $TasksById
+        $versionLabel = Get-VersionLabel -Version $entry.Version -VersionTitles $VersionTitles -LocalizedVersionTitles $LocalizedVersionTitles
+        ('| {0} | {1} | {2} | {3} | [ ] 未 | [ ] | {4} |' -f $versionLabel, $state, $entry.Focus, $entry.Example, $entry.Memo)
+    }
+
+    return ($rows -join "`r`n")
+}
+
+function Set-UpdatedDateLine {
+    param(
+        [Parameter(Mandatory = $true)][string]$Content,
+        [Parameter(Mandatory = $true)][string]$DateText
+    )
+
+    $regex = [regex]::new('(?m)^更新日:\s*.+$')
+    return $regex.Replace($Content, "更新日: $DateText", 1)
+}
+
+function Replace-Section {
+    param(
+        [Parameter(Mandatory = $true)][string]$Content,
+        [Parameter(Mandatory = $true)][string]$StartHeader,
+        [Parameter(Mandatory = $true)][string]$EndHeader,
+        [Parameter(Mandatory = $true)][string]$ReplacementBody
+    )
+
+    $pattern = "(?s)(^## $([regex]::Escape($StartHeader))\r?\n\r?\n).*?(?=^## $([regex]::Escape($EndHeader))\r?\n)"
+    $regex = [regex]::new($pattern, [System.Text.RegularExpressions.RegexOptions]::Multiline)
+    return $regex.Replace($Content, ('$1' + $ReplacementBody.TrimEnd() + "`r`n`r`n"), 1)
+}
+
+function Replace-MarkerBlock {
+    param(
+        [Parameter(Mandatory = $true)][string]$Content,
+        [Parameter(Mandatory = $true)][string]$MarkerName,
+        [Parameter(Mandatory = $true)][string]$ReplacementBody
+    )
+
+    $start = "<!-- AUTO-GENERATED:$MarkerName:start -->"
+    $end = "<!-- AUTO-GENERATED:$MarkerName:end -->"
+    $startIndex = $Content.IndexOf($start, [System.StringComparison]::Ordinal)
+    if ($startIndex -lt 0) {
+        return $Content
+    }
+
+    $endIndex = $Content.IndexOf($end, $startIndex, [System.StringComparison]::Ordinal)
+    if ($endIndex -lt 0) {
+        return $Content
+    }
+
+    $replacement = $start + "`r`n" + $ReplacementBody.TrimEnd() + "`r`n" + $end
+    $prefix = $Content.Substring(0, $startIndex)
+    $suffix = $Content.Substring($endIndex + $end.Length)
+    return $prefix + $replacement + $suffix
+}
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+if ([string]::IsNullOrWhiteSpace($BacklogPath)) {
+    $BacklogPath = Resolve-WinsmuxPlanningFilePath -RepoRoot $repoRoot -LocalRelativePath 'tasks/backlog.yaml' -EnvironmentVariable 'WINSMUX_BACKLOG_PATH' -DefaultFileName 'backlog.yaml'
+}
+if ([string]::IsNullOrWhiteSpace($RoadmapTitleJaPath)) {
+    $RoadmapTitleJaPath = Join-Path $repoRoot 'tasks/roadmap-title-ja.psd1'
+}
+if ([string]::IsNullOrWhiteSpace($FeatureInventoryPath)) {
+    $FeatureInventoryPath = Join-Path $repoRoot 'docs\internal\winsmux-feature-inventory.md'
+}
+if ([string]::IsNullOrWhiteSpace($ManualChecklistPath)) {
+    $ManualChecklistPath = Join-Path $repoRoot 'docs\internal\winsmux-manual-checklist-by-version.md'
+}
+if ([string]::IsNullOrWhiteSpace($MetaPath)) {
+    $MetaPath = Join-Path $PSScriptRoot 'internal-docs-meta.psd1'
+}
+
+$resolvedBacklogPath = Resolve-WorkspacePath -Path $BacklogPath
+$resolvedRoadmapTitleJaPath = Resolve-WorkspacePath -Path $RoadmapTitleJaPath
+$resolvedFeatureInventoryPath = Resolve-WorkspacePath -Path $FeatureInventoryPath
+$resolvedManualChecklistPath = Resolve-WorkspacePath -Path $ManualChecklistPath
+$resolvedMetaPath = Resolve-WorkspacePath -Path $MetaPath
+
+$utf8NoBom = [System.Text.UTF8Encoding]::new($false)
+$backlogContent = [System.IO.File]::ReadAllText($resolvedBacklogPath, $utf8NoBom)
+$versionTitles = Get-VersionTitleMap -Content $backlogContent
+$localization = Get-RoadmapLocalizationMap -Path $resolvedRoadmapTitleJaPath
+$meta = Import-PowerShellDataFile -LiteralPath $resolvedMetaPath
+
+$tasks = @()
+foreach ($block in (Get-TaskBlocks -Content $backlogContent)) {
+    $task = ConvertFrom-TaskBlock -Lines @($block.Lines)
+    if ($null -ne $task) {
+        $tasks += $task
+    }
+}
+
+$tasksById = @{}
+foreach ($task in $tasks) {
+    $tasksById[$task.Id] = $task
+}
+
+$dateText = Get-Date -Format 'yyyy-MM-dd'
+$activeSection = New-FeatureInventorySection -State '進行中' -Entries $meta.FeatureInventoryEntries -TasksById $tasksById -VersionTitles $versionTitles -LocalizedVersionTitles $localization.VersionTitles -StartNumber 26
+$plannedSection = New-FeatureInventorySection -State '今後予定' -Entries $meta.FeatureInventoryEntries -TasksById $tasksById -VersionTitles $versionTitles -LocalizedVersionTitles $localization.VersionTitles -StartNumber $activeSection.NextNumber
+$checklistRows = $(
+    foreach ($entry in ($meta.ManualChecklistEntries | Sort-Object Order)) {
+        $state = Get-PlanningState -TaskIds $entry.TaskIds -TasksById $tasksById
+        $versionLabel = Get-VersionLabel -Version $entry.Version -VersionTitles $versionTitles -LocalizedVersionTitles $localization.VersionTitles
+        ('| {0} | {1} | {2} | {3} | [ ] 未 | [ ] | {4} |' -f $versionLabel, $state, $entry.Focus, $entry.Example, $entry.Memo)
+    }
+) -join "`r`n"
+
+$featureContent = [System.IO.File]::ReadAllText($resolvedFeatureInventoryPath, $utf8NoBom)
+$featureContent = Set-UpdatedDateLine -Content $featureContent -DateText $dateText
+$featureContent = Replace-Section -Content $featureContent -StartHeader '進行中（未公開）' -EndHeader '今後実装予定' -ReplacementBody ($activeSection.Content + "`r`n`r`n> この章は backlog から自動同期されます。")
+$featureContent = Replace-Section -Content $featureContent -StartHeader '今後実装予定' -EndHeader '付録' -ReplacementBody ($plannedSection.Content + "`r`n`r`n> この章は backlog から自動同期されます。")
+[System.IO.File]::WriteAllText($resolvedFeatureInventoryPath, $featureContent, $utf8NoBom)
+
+$checklistContent = [System.IO.File]::ReadAllText($resolvedManualChecklistPath, $utf8NoBom)
+$checklistContent = Set-UpdatedDateLine -Content $checklistContent -DateText $dateText
+$checklistSection = @"
+| 版 | 状態 | 実装後に重点確認すること | 確認例 | 結果 | 収録候補 | メモ |
+| --- | --- | --- | --- | --- | --- | --- |
+$checklistRows
+
+> この章は backlog から自動同期されます。
+"@
+$checklistContent = Replace-Section -Content $checklistContent -StartHeader '進行中・今後予定の確認表' -EndHeader '総合確認の進め方' -ReplacementBody $checklistSection
+[System.IO.File]::WriteAllText($resolvedManualChecklistPath, $checklistContent, $utf8NoBom)
+
+Write-Output ("Generated internal docs: {0}, {1}" -f $resolvedFeatureInventoryPath, $resolvedManualChecklistPath)

--- a/winsmux-core/scripts/sync-roadmap.ps1
+++ b/winsmux-core/scripts/sync-roadmap.ps1
@@ -187,6 +187,23 @@ function Test-VersionGreaterOrEqual {
     return $true
 }
 
+function Test-RequiresJapaneseVersionTitle {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Version
+    )
+
+    if ($Version -like 'post-v1.0.0*') {
+        return $true
+    }
+
+    if ($Version -match '^v\d+\.\d+\.\d+$') {
+        return Test-VersionGreaterOrEqual -Version $Version -MinimumVersion 'v0.20.0'
+    }
+
+    return $false
+}
+
 function Convert-TitleFallbackToJapanese {
     param(
         [AllowNull()]
@@ -650,6 +667,7 @@ foreach ($taskBlock in $taskBlocks) {
 $downgradedTasks = New-Object System.Collections.Generic.List[object]
 $validationWarnings = New-Object System.Collections.Generic.List[string]
 $missingJapaneseTitles = New-Object System.Collections.Generic.List[string]
+$missingJapaneseVersionTitles = New-Object System.Collections.Generic.List[string]
 
 foreach ($task in $tasks | Where-Object { $_.Status -eq 'review' }) {
     $referenceFiles = Get-TaskReferenceFiles -Task $task -RoadmapPath $roadmapRelativePath
@@ -767,13 +785,6 @@ foreach ($versionGroup in $versionGroups) {
 [void]$builder.AppendLine('| P2 | 中 |')
 [void]$builder.AppendLine('| P3 | 低 |')
 
-$roadmapDirectory = Split-Path -Parent $resolvedRoadmapPath
-if (-not [string]::IsNullOrWhiteSpace($roadmapDirectory)) {
-    New-Item -ItemType Directory -Force -Path $roadmapDirectory 1>$null
-}
-
-[System.IO.File]::WriteAllText($resolvedRoadmapPath, $builder.ToString(), $utf8NoBom)
-
 foreach ($downgradedTask in $downgradedTasks) {
     Write-Output ("Downgraded {0}: review -> backlog (gitignored: {1})" -f $downgradedTask.Id, ($downgradedTask.Files -join ', '))
 }
@@ -793,11 +804,34 @@ foreach ($task in $tasksWithTargetVersion) {
     }
 }
 
+foreach ($versionGroup in $versionGroups) {
+    if (-not (Test-RequiresJapaneseVersionTitle -Version $versionGroup.Name)) {
+        continue
+    }
+
+    if (-not $roadmapLocalization.VersionTitles.ContainsKey($versionGroup.Name)) {
+        $missingJapaneseVersionTitles.Add($versionGroup.Name)
+    }
+}
+
+if ($missingJapaneseVersionTitles.Count -gt 0) {
+    $missingVersionList = $missingJapaneseVersionTitles | Sort-Object
+    Write-Error ("Roadmap Japanese version-title gate failed. Add version title overrides to {0} for: {1}" -f $resolvedRoadmapTitleJaPath, ($missingVersionList -join ', '))
+    exit 1
+}
+
 if ($missingJapaneseTitles.Count -gt 0) {
     $missingList = $missingJapaneseTitles | Sort-Object
     Write-Error ("Roadmap Japanese title gate failed. Add task title overrides to {0} for: {1}" -f $resolvedRoadmapTitleJaPath, ($missingList -join ', '))
     exit 1
 }
+
+$roadmapDirectory = Split-Path -Parent $resolvedRoadmapPath
+if (-not [string]::IsNullOrWhiteSpace($roadmapDirectory)) {
+    New-Item -ItemType Directory -Force -Path $roadmapDirectory 1>$null
+}
+
+[System.IO.File]::WriteAllText($resolvedRoadmapPath, $builder.ToString(), $utf8NoBom)
 
 $syncInternalDocsScript = Join-Path $PSScriptRoot 'sync-internal-docs.ps1'
 if (Test-Path -LiteralPath $syncInternalDocsScript) {

--- a/winsmux-core/scripts/sync-roadmap.ps1
+++ b/winsmux-core/scripts/sync-roadmap.ps1
@@ -2,7 +2,9 @@
 param(
     [string]$BacklogPath = '',
 
-    [string]$RoadmapPath = ''
+    [string]$RoadmapPath = '',
+
+    [string]$RoadmapTitleJaPath = ''
 )
 
 . (Join-Path $PSScriptRoot 'planning-paths.ps1')
@@ -125,6 +127,134 @@ function Get-VersionTitleMap {
     }
 
     return $versionTitles
+}
+
+function Get-RoadmapLocalizationMap {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Path) -or -not (Test-Path -LiteralPath $Path)) {
+        return @{
+            VersionTitles = @{}
+            TaskTitles    = @{}
+        }
+    }
+
+    $data = Import-PowerShellDataFile -LiteralPath $Path
+    return @{
+        VersionTitles = if ($null -ne $data.VersionTitles) { $data.VersionTitles } else { @{} }
+        TaskTitles    = if ($null -ne $data.TaskTitles) { $data.TaskTitles } else { @{} }
+    }
+}
+
+function Get-VersionSortTuple {
+    param(
+        [AllowNull()]
+        [string]$Version
+    )
+
+    if ($Version -match '^v(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)$') {
+        return @([int]$Matches['major'], [int]$Matches['minor'], [int]$Matches['patch'])
+    }
+
+    return @([int]::MaxValue, [int]::MaxValue, [int]::MaxValue)
+}
+
+function Test-VersionGreaterOrEqual {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Version,
+
+        [Parameter(Mandatory = $true)]
+        [string]$MinimumVersion
+    )
+
+    $left = Get-VersionSortTuple -Version $Version
+    $right = Get-VersionSortTuple -Version $MinimumVersion
+
+    for ($index = 0; $index -lt 3; $index++) {
+        if ($left[$index] -gt $right[$index]) {
+            return $true
+        }
+
+        if ($left[$index] -lt $right[$index]) {
+            return $false
+        }
+    }
+
+    return $true
+}
+
+function Convert-TitleFallbackToJapanese {
+    param(
+        [AllowNull()]
+        [string]$Title
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Title)) {
+        return ''
+    }
+
+    $converted = $Title -replace '→', '→'
+    $converted = $converted -replace ' +— +', ' — '
+    $converted = $converted -replace '^Fix (.+)$', '$1 を修正'
+    $converted = $converted -replace '^Add (.+)$', '$1 を追加'
+    $converted = $converted -replace '^Create (.+)$', '$1 を作成'
+    $converted = $converted -replace '^Implement (.+)$', '$1 を実装'
+    $converted = $converted -replace '^Sync (.+)$', '$1 を同期'
+    $converted = $converted -replace '^Document (.+)$', '$1 を文書化'
+    $converted = $converted -replace '^Write (.+)$', '$1 を作成'
+    $converted = $converted -replace '^Run (.+)$', '$1 を実行'
+    $converted = $converted -replace '^Release (.+)$', '$1 をリリース'
+    $converted = $converted -replace '^Rewrite (.+)$', '$1 を書き直し'
+    $converted = $converted -replace '^Remove (.+)$', '$1 を削除'
+    $converted = $converted -replace '^Replace (.+)$', '$1 を置換'
+    $converted = $converted -replace '^Prevent (.+)$', '$1 を防止'
+    $converted = $converted -replace '^Restore (.+)$', '$1 を復元'
+    $converted = $converted -replace '^Audit (.+)$', '$1 を監査'
+    $converted = $converted -replace '^Complete (.+)$', '$1 を完了'
+    $converted = $converted -replace '^Prepare and submit PR to (.+)$', '$1 への PR を準備して提出'
+
+    return $converted
+}
+
+function Get-RoadmapVersionTitle {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Version,
+
+        [AllowNull()]
+        [string]$DefaultTitle,
+
+        [Parameter(Mandatory = $true)]
+        [hashtable]$Localization
+    )
+
+    if ($Localization.ContainsKey($Version)) {
+        return [string]$Localization[$Version]
+    }
+
+    return $DefaultTitle
+}
+
+function Get-RoadmapTaskTitle {
+    param(
+        [Parameter(Mandatory = $true)]
+        [pscustomobject]$Task,
+
+        [Parameter(Mandatory = $true)]
+        [hashtable]$Localization
+    )
+
+    $hasOverride = $Localization.ContainsKey($Task.Id)
+    $title = if ($hasOverride) { [string]$Localization[$Task.Id] } else { Convert-TitleFallbackToJapanese -Title $Task.Title }
+
+    return [pscustomobject]@{
+        Title       = $title
+        HasOverride = $hasOverride
+    }
 }
 
 function ConvertFrom-TaskBlock {
@@ -489,9 +619,13 @@ if ([string]::IsNullOrWhiteSpace($BacklogPath)) {
 if ([string]::IsNullOrWhiteSpace($RoadmapPath)) {
     $RoadmapPath = Resolve-WinsmuxPlanningFilePath -RepoRoot $repoRoot -LocalRelativePath 'docs/project/ROADMAP.md' -EnvironmentVariable 'WINSMUX_ROADMAP_PATH' -DefaultFileName 'ROADMAP.md'
 }
+if ([string]::IsNullOrWhiteSpace($RoadmapTitleJaPath)) {
+    $RoadmapTitleJaPath = Join-Path $repoRoot 'tasks/roadmap-title-ja.psd1'
+}
 
 $resolvedBacklogPath = Resolve-WorkspacePath -Path $BacklogPath
 $resolvedRoadmapPath = Resolve-WorkspacePath -Path $RoadmapPath
+$resolvedRoadmapTitleJaPath = Resolve-WorkspacePath -Path $RoadmapTitleJaPath
 $roadmapRelativePath = [System.IO.Path]::GetRelativePath((Get-Location).Path, $resolvedRoadmapPath) -replace '\\', '/'
 
 if (-not (Test-Path -LiteralPath $resolvedBacklogPath)) {
@@ -502,6 +636,7 @@ if (-not (Test-Path -LiteralPath $resolvedBacklogPath)) {
 $utf8NoBom = [System.Text.UTF8Encoding]::new($false)
 $backlogContent = [System.IO.File]::ReadAllText($resolvedBacklogPath, $utf8NoBom)
 $versionTitles = Get-VersionTitleMap -Content $backlogContent
+$roadmapLocalization = Get-RoadmapLocalizationMap -Path $resolvedRoadmapTitleJaPath
 $taskBlocks = @(Get-TaskBlocks -Content $backlogContent)
 $tasks = @(
 foreach ($taskBlock in $taskBlocks) {
@@ -514,6 +649,7 @@ foreach ($taskBlock in $taskBlocks) {
 
 $downgradedTasks = New-Object System.Collections.Generic.List[object]
 $validationWarnings = New-Object System.Collections.Generic.List[string]
+$missingJapaneseTitles = New-Object System.Collections.Generic.List[string]
 
 foreach ($task in $tasks | Where-Object { $_.Status -eq 'review' }) {
     $referenceFiles = Get-TaskReferenceFiles -Task $task -RoadmapPath $roadmapRelativePath
@@ -561,7 +697,14 @@ if ($downgradedTasks.Count -gt 0) {
     [System.IO.File]::WriteAllText($resolvedBacklogPath, $backlogContent, $utf8NoBom)
 }
 
-$versionGroups = $tasks |
+$tasksWithoutTargetVersion = @($tasks | Where-Object { [string]::IsNullOrWhiteSpace($_.TargetVersion) })
+foreach ($task in $tasksWithoutTargetVersion) {
+    $validationWarnings.Add(("Roadmap sync warning for {0}: empty target_version. Skipping from version-grouped roadmap output." -f $task.Id))
+}
+
+$tasksWithTargetVersion = @($tasks | Where-Object { -not [string]::IsNullOrWhiteSpace($_.TargetVersion) })
+
+$versionGroups = $tasksWithTargetVersion |
     Group-Object -Property TargetVersion |
     Sort-Object @{ Expression = { (Get-VersionSortKey -Version $_.Name).Major } }, @{ Expression = { (Get-VersionSortKey -Version $_.Name).Minor } }, @{ Expression = { (Get-VersionSortKey -Version $_.Name).Patch } }, @{ Expression = { (Get-VersionSortKey -Version $_.Name).Raw } }
 
@@ -591,7 +734,9 @@ foreach ($versionGroup in $versionGroups) {
 
 foreach ($versionGroup in $versionGroups) {
     $vName = $versionGroup.Name
-    $titleSuffix = if ($versionTitles.Contains($vName)) { ': ' + $versionTitles[$vName] } else { '' }
+    $defaultVersionTitle = if ($versionTitles.Contains($vName)) { $versionTitles[$vName] } else { '' }
+    $localizedVersionTitle = Get-RoadmapVersionTitle -Version $vName -DefaultTitle $defaultVersionTitle -Localization $roadmapLocalization.VersionTitles
+    $titleSuffix = if (-not [string]::IsNullOrWhiteSpace($localizedVersionTitle)) { ': ' + $localizedVersionTitle } else { '' }
     [void]$builder.AppendLine(('### {0}{1}' -f $vName, $titleSuffix))
     [void]$builder.AppendLine()
     [void]$builder.AppendLine('| | ID | Title | Priority | Repo | Status |')
@@ -599,7 +744,8 @@ foreach ($versionGroup in $versionGroups) {
 
     $sortedTasks = @($versionGroup.Group | Sort-Object @{ Expression = { Get-PriorityRank -Priority $_.Priority } }, @{ Expression = { $_.IdNumber } }, @{ Expression = { $_.Id } })
     foreach ($task in $sortedTasks) {
-        [void]$builder.AppendLine(('| {0} | {1} | {2} | {3} | {4} | {5} |' -f (Get-StatusSymbol -Status $task.Status), $task.Id, $task.Title, $task.Priority, $task.Repo, $task.Status))
+        $localizedTaskTitle = Get-RoadmapTaskTitle -Task $task -Localization $roadmapLocalization.TaskTitles
+        [void]$builder.AppendLine(('| {0} | {1} | {2} | {3} | {4} | {5} |' -f (Get-StatusSymbol -Status $task.Status), $task.Id, $localizedTaskTitle.Title, $task.Priority, $task.Repo, $task.Status))
     }
 
     [void]$builder.AppendLine()
@@ -634,6 +780,33 @@ foreach ($downgradedTask in $downgradedTasks) {
 
 foreach ($warning in $validationWarnings) {
     Write-Warning $warning
+}
+
+foreach ($task in $tasksWithTargetVersion) {
+    if (-not (Test-VersionGreaterOrEqual -Version $task.TargetVersion -MinimumVersion 'v0.20.0')) {
+        continue
+    }
+
+    $localizedTaskTitle = Get-RoadmapTaskTitle -Task $task -Localization $roadmapLocalization.TaskTitles
+    if (-not $localizedTaskTitle.HasOverride) {
+        $missingJapaneseTitles.Add(('{0} ({1})' -f $task.Id, $task.Title))
+    }
+}
+
+if ($missingJapaneseTitles.Count -gt 0) {
+    $missingList = $missingJapaneseTitles | Sort-Object
+    Write-Error ("Roadmap Japanese title gate failed. Add task title overrides to {0} for: {1}" -f $resolvedRoadmapTitleJaPath, ($missingList -join ', '))
+    exit 1
+}
+
+$syncInternalDocsScript = Join-Path $PSScriptRoot 'sync-internal-docs.ps1'
+if (Test-Path -LiteralPath $syncInternalDocsScript) {
+    try {
+        & $syncInternalDocsScript -BacklogPath $resolvedBacklogPath -RoadmapTitleJaPath $resolvedRoadmapTitleJaPath
+    } catch {
+        Write-Error ("Internal docs sync failed via {0}: {1}" -f $syncInternalDocsScript, $_.Exception.Message)
+        exit 1
+    }
 }
 
 Write-Output ("Generated roadmap: {0}" -f $resolvedRoadmapPath)


### PR DESCRIPTION
## Summary
- extend roadmap sync so backlog updates also regenerate the internal-only feature inventory and manual checklist
- harden the Japanese roadmap localization gate so missing task and version title overrides fail closed before writing `ROADMAP.md`
- update repo rules and handoff so roadmap/internal-doc sync stays part of the standard planning flow

## Validation
- `pwsh -NoProfile -File .\winsmux-core\scripts\sync-roadmap.ps1`
- `git diff --check` (CRLF warnings only)

## Review
- Fresh reviewer `Euclid` -> delayed `FAIL`; follow-up fixes applied for fail-closed roadmap generation, `done` classification, and handoff wording
- Fresh reviewer `Lorentz` -> `PASS` on the fix-up slice