### PR TITLE
fix: harden orchestra smoke startup contract

### DIFF
--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -406,6 +406,36 @@ prompt-transport: stdin
         { Get-BridgeSettings } | Should -Throw '*prompt_transport*'
     }
 
+    It 'ignores global prompt_transport probe errors when no winsmux server is running yet' {
+        Mock Get-WinsmuxOption {
+            param($Name, $Default)
+
+            switch ($Name) {
+                '@bridge-prompt-transport' { "psmux: no server running on session 'default'" }
+                default { $null }
+            }
+        }
+
+        $settings = Get-BridgeSettings
+
+        $settings.prompt_transport | Should -Be 'argv'
+    }
+
+    It 'ignores server-not-running probe text during raw global settings normalization' {
+        Mock Get-WinsmuxOption {
+            param($Name, $Default)
+
+            switch ($Name) {
+                '@bridge-prompt-transport' { "psmux: no server running on session 'default'" }
+                default { $null }
+            }
+        }
+
+        $settings = Read-BridgeGlobalSettings
+
+        $settings.Contains('prompt_transport') | Should -BeFalse
+    }
+
     It 'fails closed when config_version is unsupported' {
 @'
 config-version: 2
@@ -6275,6 +6305,14 @@ Describe 'winsmux orchestra-smoke command' {
         $script:orchestraSmokeContent | Should -Match 'ready-with-ui-warning'
         $script:orchestraSmokeContent | Should -Match 'can_dispatch'
         $script:orchestraSmokeContent | Should -Match 'requires_startup'
+    }
+
+    It 'allows empty ui_attach_status when building the operator contract' {
+        $script:orchestraSmokeContent | Should -Match '\[AllowEmptyString\(\)\]\[string\]\$UiAttachStatus'
+    }
+
+    It 'allows an empty smoke_errors collection when building the operator contract' {
+        $script:orchestraSmokeContent | Should -Match '\[AllowEmptyCollection\(\)\]\[string\[\]\]\$SmokeErrors'
     }
 }
 

--- a/winsmux-core/scripts/orchestra-smoke.ps1
+++ b/winsmux-core/scripts/orchestra-smoke.ps1
@@ -83,10 +83,10 @@ function Get-OrchestraOperatorContract {
         [Parameter(Mandatory = $true)][bool]$SessionReady,
         [Parameter(Mandatory = $true)][bool]$UiAttachLaunched,
         [Parameter(Mandatory = $true)][bool]$UiAttached,
-        [Parameter(Mandatory = $true)][string]$UiAttachStatus,
+        [Parameter(Mandatory = $true)][AllowEmptyString()][string]$UiAttachStatus,
         [Parameter(Mandatory = $true)][int]$PaneCount,
         [Parameter(Mandatory = $true)][int]$ExpectedPaneCount,
-        [Parameter(Mandatory = $true)][string[]]$SmokeErrors
+        [Parameter(Mandatory = $true)][AllowEmptyCollection()][string[]]$SmokeErrors
     )
 
     $state = 'blocked'

--- a/winsmux-core/scripts/settings.ps1
+++ b/winsmux-core/scripts/settings.ps1
@@ -50,6 +50,16 @@ if (-not (Get-Command Get-WinsmuxBin -ErrorAction SilentlyContinue)) {
 }
 
 if (-not (Get-Command Get-WinsmuxOption -ErrorAction SilentlyContinue)) {
+    function Test-WinsmuxOptionFailureText {
+        param([string]$Value)
+
+        if ([string]::IsNullOrWhiteSpace($Value)) {
+            return $true
+        }
+
+        return ($Value -match 'unknown|error|invalid|no server running on session|not recognized as the name|is not recognized as a name|failed with exit code|failed to connect|could not connect|no such session')
+    }
+
     function Get-WinsmuxOption {
         param(
             [Parameter(Mandatory = $true)][string]$Name,
@@ -63,7 +73,7 @@ if (-not (Get-Command Get-WinsmuxOption -ErrorAction SilentlyContinue)) {
 
         try {
             $value = (& $winsmuxBin show-options -g -v $Name 2>&1 | Out-String).Trim()
-            if ($value -and $value -notmatch 'unknown|error|invalid') {
+            if (-not (Test-WinsmuxOptionFailureText -Value $value)) {
                 return $value
             }
         } catch {
@@ -621,6 +631,10 @@ function Read-BridgeGlobalSettings {
 
         $rawValue = Get-WinsmuxOption -Name $optionName -Default $null
         if ($null -eq $rawValue -or [string]::IsNullOrWhiteSpace($rawValue)) {
+            continue
+        }
+
+        if (Test-WinsmuxOptionFailureText -Value ([string]$rawValue)) {
             continue
         }
 


### PR DESCRIPTION
## Summary
- fail-soft global bridge option probes when no winsmux server is running yet
- allow empty ui attach status and smoke error collections in the orchestra smoke operator contract
- lock the clean-room smoke readiness behavior with regression tests

## Validation
- `pwsh -NoProfile -Command "Invoke-Pester tests/winsmux-bridge.Tests.ps1 -CI"`
- `pwsh -NoProfile -File .\winsmux-core\scripts\orchestra-start.ps1`
- `pwsh -NoProfile -File .\scripts\winsmux-core.ps1 orchestra-smoke --json`
- `pwsh -NoProfile -File .\scripts\git-guard.ps1 -Mode full`
- `pwsh -NoProfile -File .\scripts\audit-public-surface.ps1`

## Issues
- closes #425
- refs #426
