### PR TITLE
fix: harden orchestra pane bootstrap retries

### DIFF
--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -3560,6 +3560,7 @@ Describe 'orchestra-start rollback helpers' {
 
     It 'writes a pane bootstrap plan and launches it with a single bootstrap command after respawn' {
         $sentCommands = [System.Collections.Generic.List[string]]::new()
+        $bridgeCalls = [System.Collections.Generic.List[object]]::new()
         $planRoot = Join-Path $script:orchestraStartTempRoot '.winsmux\orchestra-bootstrap'
         $cleanPtyEnv = [PSCustomObject]@{
             RemoveCommand = "Get-ChildItem Env: | Where-Object { `$_.Name -like 'WINSMUX_*' } | ForEach-Object { Remove-Item -LiteralPath ('Env:' + `$_.Name) -ErrorAction SilentlyContinue }"
@@ -3570,6 +3571,20 @@ Describe 'orchestra-start rollback helpers' {
         }
 
         Mock Wait-PaneShellReady { }
+        Mock Invoke-Bridge {
+            $bridgeCalls.Add([ordered]@{
+                Arguments    = @($Arguments)
+                CaptureOutput = [bool]$CaptureOutput
+                AllowFailure  = [bool]$AllowFailure
+            }) | Out-Null
+
+            return [ordered]@{
+                ExitCode = 0
+                Output   = @()
+            }
+        } -ParameterFilter {
+            $Arguments[0] -eq 'keys'
+        }
         Mock Send-OrchestraBridgeCommand {
             $sentCommands.Add($Text) | Out-Null
         }
@@ -3600,6 +3615,8 @@ Describe 'orchestra-start rollback helpers' {
         [string]$plan.launch_command | Should -Be 'codex --help'
         [string]$plan.startup_token | Should -Be 'token-123'
         [string]$plan.ready_marker_path | Should -Match '[\\/]2-token-123\.ready\.json$'
+        $bridgeCalls.Count | Should -Be 1
+        @($bridgeCalls[0].Arguments) | Should -Be @('keys', '%2', 'C-c')
         $sentCommands.Count | Should -Be 1
         $sentCommands[0] | Should -Match 'orchestra-pane-bootstrap\.ps1'
         $sentCommands[0] | Should -Match '-PlanFile'

--- a/winsmux-core/scripts/orchestra-start.ps1
+++ b/winsmux-core/scripts/orchestra-start.ps1
@@ -763,6 +763,8 @@ function Start-OrchestraPaneBootstrap {
 
     $bootstrapScriptPath = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot 'orchestra-pane-bootstrap.ps1'))
     Wait-PaneShellReady -PaneId $PaneId
+    Invoke-Bridge -Arguments @('keys', $PaneId, 'C-c') -AllowFailure | Out-Null
+    Start-Sleep -Milliseconds 200
     Send-OrchestraBridgeCommand -Target $PaneId -Text ("pwsh -NoProfile -File {0} -PlanFile {1}" -f (ConvertTo-PowerShellLiteral -Value $bootstrapScriptPath), (ConvertTo-PowerShellLiteral -Value $PlanPath))
     Start-Sleep -Milliseconds 500
 }


### PR DESCRIPTION
## Summary
- clear any pending pane input with `C-c` before sending the orchestra pane bootstrap command
- add regression coverage that the bootstrap helper resets pane input before `-PlanFile` launch
- keep clean-room startup and smoke verification green on main-equivalent code

## Validation
- `pwsh -NoProfile -Command "Invoke-Pester tests/winsmux-bridge.Tests.ps1 -CI"`
- `pwsh -NoProfile -File .\winsmux-core\scripts\orchestra-start.ps1`
- `pwsh -NoProfile -File .\scripts\winsmux-core.ps1 orchestra-smoke --json`
- `pwsh -NoProfile -File .\scripts\git-guard.ps1 -Mode full`
- `pwsh -NoProfile -File .\scripts\audit-public-surface.ps1`

## Issues
- refs #431
- refs #426
