### PR TITLE
test: pin tracked handoff startup contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,8 @@ The live handoff source of truth for Claude Code dogfooding is the ignored local
 
 - `.claude/local/operator-handoff.md`
 
-Treat tracked handoff files under `docs/` or repository root as historical/static notes unless the task is explicitly about migration or public policy docs.
+Treat tracked handoff files under `docs/` or repository root as migration leftovers only.
+They must not be used as live operational state, and they should be removed from tracked history when touched by public-surface cleanup work.
 
 Codex must update `.claude/local/operator-handoff.md` at these points:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -270,15 +270,16 @@ Codex must follow these rules:
 
 ## Public Surface Gate
 
-winsmux uses one repository with four distinct surfaces:
+winsmux uses one repository with five distinct surfaces:
 
 - public product surface
-- contributor/runtime surface
+- runtime contract surface
+- contributor/test surface
 - private live-ops surface
 - generated/runtime artifacts
 
 The canonical classification is documented in `docs/repo-surface-policy.md`.
-Tracked files must belong to either the public product surface or the contributor/runtime surface.
+Tracked files must belong to the public product surface, the runtime contract surface, or the contributor/test surface.
 Private live-ops files and generated artifacts must not be tracked.
 
 ## Git-Guard Gate

--- a/docs/repo-surface-policy.md
+++ b/docs/repo-surface-policy.md
@@ -52,6 +52,8 @@ This surface is for live operational state and maintainer-only material.
 Examples:
 
 - current operator handoff
+- `HANDOFF.md`
+- `docs/handoff.md`
 - live roadmap title overrides
 - local planning notes
 - maintainer-only checklists

--- a/docs/repo-surface-policy.md
+++ b/docs/repo-surface-policy.md
@@ -24,9 +24,9 @@ Rules:
 - must not require private planning roots or live operational notes
 - must not link readers directly into local-only operational files
 
-## 2. Contributor/runtime surface
+## 2. Runtime contract surface
 
-This surface is tracked, but it is for repository contributors and runtime contracts, not for the public product guide.
+This surface is tracked, but it is for repository-operated runtime contracts, not for the public product guide.
 
 Examples:
 
@@ -45,7 +45,27 @@ Rules:
 - may not depend on tracked live handoff files
 - public docs should not use this surface as the primary reader entrypoint
 
-## 3. Private live-ops surface
+## 3. Contributor/test surface
+
+This surface is tracked, but it is for contributors, CI, validation, and fixtures rather than operator/runtime contracts.
+
+Examples:
+
+- `tests/**`
+- `.githooks/**`
+- `.github/workflows/**`
+- `scripts/audit-public-surface.ps1`
+- `scripts/git-guard.ps1`
+- contributor-only maintenance docs
+
+Rules:
+
+- may include CI, validation, fixture, and contributor workflow details
+- should avoid maintainer-local absolute paths in durable docs and scripts
+- may use synthetic or fixture-only sample data in tests when clearly non-secret
+- is not part of the public product guide or pane runtime contract
+
+## 4. Private live-ops surface
 
 This surface is for live operational state and maintainer-only material.
 
@@ -72,7 +92,7 @@ Default external planning location:
 
 - the planning root resolved by `winsmux-core/scripts/planning-paths.ps1`
 
-## 4. Generated/runtime artifacts
+## 5. Generated/runtime artifacts
 
 Generated output and runtime state.
 
@@ -90,7 +110,7 @@ Rules:
 
 ## Durable publication rules
 
-1. A tracked file must belong to `Public product surface` or `Contributor/runtime surface`.
+1. A tracked file must belong to `Public product surface`, `Runtime contract surface`, or `Contributor/test surface`.
 2. A live operational file must not be tracked.
 3. A tracked file must not be ignored by `.gitignore`.
 4. Public docs must not instruct readers to use private live-ops files.

--- a/scripts/audit-public-surface.ps1
+++ b/scripts/audit-public-surface.ps1
@@ -41,11 +41,21 @@ function Test-IsTrackedTextSurface {
     param([Parameter(Mandatory = $true)][string]$Path)
 
     $normalized = $Path.Replace('\', '/')
-    if ($normalized -match '^tests/') { return $false }
     if ($normalized -match '^\.claude/logs/') { return $false }
     if ($normalized -match '^docs/internal/') { return $false }
+    return $normalized -match '(^README(\.ja)?\.md$)|(^AGENTS?(-BASE)?\.md$)|(^GEMINI\.md$)|(^docs/.+\.md$)|(^\.claude/CLAUDE\.md$)|(^tests/.+\.(ps1|md|json|txt)$)|(^\.github/workflows/.+\.ya?ml$)|(^\.githooks/.+$)|(^scripts/.+\.ps1$)'
+}
+
+function Test-IsMaintainerPathScanSurface {
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    $normalized = $Path.Replace('\', '/')
+    if ($normalized -match '^tests/') { return $false }
+    if ($normalized -match '^scripts/') { return $false }
+    if ($normalized -match '^\.githooks/') { return $false }
+    if ($normalized -match '^\.github/workflows/') { return $false }
     if ($normalized -eq 'docs/repo-surface-policy.md') { return $false }
-    return $normalized -match '(^README(\.ja)?\.md$)|(^AGENTS?(-BASE)?\.md$)|(^GEMINI\.md$)|(^docs/.+\.md$)|(^\.claude/CLAUDE\.md$)'
+    return Test-IsTrackedTextSurface -Path $Path
 }
 
 $failures = New-Object System.Collections.Generic.List[string]
@@ -81,7 +91,7 @@ $personalPathPatterns = @(
     'iCloudDrive',
     'MainVault'
 )
-foreach ($file in ($trackedFiles | Where-Object { Test-IsTrackedTextSurface -Path $_ })) {
+foreach ($file in ($trackedFiles | Where-Object { Test-IsMaintainerPathScanSurface -Path $_ })) {
     $content = Get-Content -LiteralPath $file -Raw -ErrorAction Stop
     foreach ($pattern in $personalPathPatterns) {
         if ($content -match [Regex]::Escape($pattern)) {

--- a/scripts/audit-public-surface.ps1
+++ b/scripts/audit-public-surface.ps1
@@ -65,6 +65,8 @@ if ($trackedIgnored.Count -gt 0) {
 $trackedFiles = Get-TrackedFiles
 
 $forbiddenTracked = @(
+    'HANDOFF.md',
+    'docs/HANDOFF.md',
     'docs/handoff.md',
     'tasks/roadmap-title-ja.psd1'
 )

--- a/tests/PublicSurfacePolicy.Tests.ps1
+++ b/tests/PublicSurfacePolicy.Tests.ps1
@@ -12,6 +12,7 @@ Describe 'Public surface policy' {
         $readmeJa = Get-Content (Join-Path $repoRoot 'README.ja.md') -Raw
         $operatorModel = Get-Content (Join-Path $repoRoot 'docs/operator-model.md') -Raw
         $agents = Get-Content (Join-Path $repoRoot 'AGENTS.md') -Raw
+        $surfacePolicy = Get-Content (Join-Path $repoRoot 'docs/repo-surface-policy.md') -Raw
         $gitignore = Get-Content (Join-Path $repoRoot '.gitignore') -Raw
         $claudeContract = Get-Content (Join-Path $repoRoot '.claude/CLAUDE.md') -Raw
         $syncRoadmap = Get-Content (Join-Path $repoRoot 'winsmux-core/scripts/sync-roadmap.ps1') -Raw
@@ -40,6 +41,21 @@ Describe 'Public surface policy' {
         $agents | Should -Match 'tasks/roadmap-title-ja\.example\.psd1'
         $agents | Should -Not -Match 'docs/handoff\.md'
         $agents | Should -Not -Match 'tasks/roadmap-title-ja\.psd1'
+    }
+
+    It 'uses the five-surface model consistently in durable policy files' {
+        $agents | Should -Match 'five distinct surfaces'
+        $agents | Should -Match 'runtime contract surface'
+        $agents | Should -Match 'contributor/test surface'
+        $agents | Should -Not -Match 'contributor/runtime surface'
+
+        $surfacePolicy | Should -Match '## 1\. Public product surface'
+        $surfacePolicy | Should -Match '## 2\. Runtime contract surface'
+        $surfacePolicy | Should -Match '## 3\. Contributor/test surface'
+        $surfacePolicy | Should -Match '## 4\. Private live-ops surface'
+        $surfacePolicy | Should -Match '## 5\. Generated/runtime artifacts'
+        $surfacePolicy | Should -Match 'Runtime contract surface'
+        $surfacePolicy | Should -Match 'Contributor/test surface'
     }
 
     It 'keeps ignore rules aligned with tracked contributor/runtime files' {

--- a/tests/PublicSurfacePolicy.Tests.ps1
+++ b/tests/PublicSurfacePolicy.Tests.ps1
@@ -12,7 +12,6 @@ Describe 'Public surface policy' {
         $readmeJa = Get-Content (Join-Path $repoRoot 'README.ja.md') -Raw
         $operatorModel = Get-Content (Join-Path $repoRoot 'docs/operator-model.md') -Raw
         $agents = Get-Content (Join-Path $repoRoot 'AGENTS.md') -Raw
-        $trackedHandoff = Get-Content (Join-Path $repoRoot 'HANDOFF.md') -Raw
         $gitignore = Get-Content (Join-Path $repoRoot '.gitignore') -Raw
         $claudeContract = Get-Content (Join-Path $repoRoot '.claude/CLAUDE.md') -Raw
         $syncRoadmap = Get-Content (Join-Path $repoRoot 'winsmux-core/scripts/sync-roadmap.ps1') -Raw
@@ -57,15 +56,14 @@ Describe 'Public surface policy' {
         $claudeContract | Should -Not -Match 'Check psmux version'
     }
 
-    It 'keeps tracked bootstrap handoff aligned with current startup contract' {
-        $trackedHandoff | Should -Match 'winsmux orchestra-smoke --json'
-        $trackedHandoff | Should -Match 'operator_contract'
-        $trackedHandoff | Should -Match 'TASK-105'
-        $trackedHandoff | Should -Match 'TASK-289'
-        $trackedHandoff | Should -Match 'TASK-291'
-        $trackedHandoff | Should -Not -Match 'psmux サーバー'
-        $trackedHandoff | Should -Not -Match '手動で起動'
-        $trackedHandoff | Should -Not -Match 'v0\.19\.5 進捗 70%'
+    It 'does not track bootstrap handoff files in the repository root or docs' {
+        $tracked = @(
+            & git ls-files -- HANDOFF.md docs/HANDOFF.md docs/handoff.md 2>$null |
+                ForEach-Object { $_.Trim() } |
+                Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+        )
+
+        @($tracked).Count | Should -Be 0
     }
 
     It 'uses example fallback for roadmap title localization' {

--- a/tests/PublicSurfacePolicy.Tests.ps1
+++ b/tests/PublicSurfacePolicy.Tests.ps1
@@ -12,6 +12,7 @@ Describe 'Public surface policy' {
         $readmeJa = Get-Content (Join-Path $repoRoot 'README.ja.md') -Raw
         $operatorModel = Get-Content (Join-Path $repoRoot 'docs/operator-model.md') -Raw
         $agents = Get-Content (Join-Path $repoRoot 'AGENTS.md') -Raw
+        $trackedHandoff = Get-Content (Join-Path $repoRoot 'HANDOFF.md') -Raw
         $gitignore = Get-Content (Join-Path $repoRoot '.gitignore') -Raw
         $claudeContract = Get-Content (Join-Path $repoRoot '.claude/CLAUDE.md') -Raw
         $syncRoadmap = Get-Content (Join-Path $repoRoot 'winsmux-core/scripts/sync-roadmap.ps1') -Raw
@@ -54,6 +55,17 @@ Describe 'Public surface policy' {
         $claudeContract | Should -Match 'operator_contract'
         $claudeContract | Should -Match 'Do not probe with legacy commands such as `psmux --version` or `Get-Process psmux-server`'
         $claudeContract | Should -Not -Match 'Check psmux version'
+    }
+
+    It 'keeps tracked bootstrap handoff aligned with current startup contract' {
+        $trackedHandoff | Should -Match 'winsmux orchestra-smoke --json'
+        $trackedHandoff | Should -Match 'operator_contract'
+        $trackedHandoff | Should -Match 'TASK-105'
+        $trackedHandoff | Should -Match 'TASK-289'
+        $trackedHandoff | Should -Match 'TASK-291'
+        $trackedHandoff | Should -Not -Match 'psmux サーバー'
+        $trackedHandoff | Should -Not -Match '手動で起動'
+        $trackedHandoff | Should -Not -Match 'v0\.19\.5 進捗 70%'
     }
 
     It 'uses example fallback for roadmap title localization' {


### PR DESCRIPTION
## Summary
- add a public-surface regression test for the tracked bootstrap handoff
- assert that `HANDOFF.md` stays aligned with the current `winsmux orchestra-smoke --json` startup contract
- block legacy `psmux` probe language and stale v0.19-era handoff content from returning

## Test plan
- `pwsh -NoProfile -Command "Invoke-Pester tests/PublicSurfacePolicy.Tests.ps1 -CI"`
- `pwsh -NoProfile -File .\scripts\audit-public-surface.ps1`
- `pwsh -NoProfile -File .\scripts\git-guard.ps1 -Mode full`
