### PR TITLE
fix: make orchestra smoke observation-only by default

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -88,10 +88,12 @@ When `/winsmux-start` or another restoration flow reports `needs-startup`:
 3. Verify readiness with `winsmux orchestra-smoke --json`.
 4. Treat `operator_contract.operator_state`, `operator_contract.can_dispatch`, and `operator_contract.requires_startup` from that smoke result as the source of truth.
 5. Use only the structured smoke states: `ready`, `ready-with-ui-warning`, or `blocked`.
-6. Do not probe with legacy commands such as `psmux --version` or `Get-Process psmux-server`.
-7. Do not tell the user to manually start a `psmux` server.
-8. If startup still fails, report `blocked` and stop fail-closed with the smoke result.
-9. Do not continue with PR/merge or local exploration while orchestra is still not dispatchable.
+6. If the state is `ready-with-ui-warning`, run `winsmux orchestra-attach --json` once to launch a visible operator window, then continue from the live handoff without asking the user to choose a starting task.
+7. When `.claude/local/operator-handoff.md` contains an ordered `Next actions` list, start the first pending action automatically instead of asking which task to begin.
+8. Do not probe with legacy commands such as `psmux --version` or `Get-Process psmux-server`.
+9. Do not tell the user to manually start a `psmux` server.
+10. If startup still fails, report `blocked` and stop fail-closed with the smoke result.
+11. Do not continue with PR/merge or local exploration while orchestra is still not dispatchable.
 
 ## Compatibility and release notes
 

--- a/.claude/rules/dispatch.md
+++ b/.claude/rules/dispatch.md
@@ -13,9 +13,11 @@ paths: ["winsmux-core/scripts/**", ".claude/**"]
    - `ready`
    - `ready-with-ui-warning`
    Any other state is fail-closed.
-6. Never use `psmux --version`, `Get-Process psmux-server`, or similar legacy probe commands for operator-side startup diagnosis.
-7. If pane expansion does not succeed, treat the session as `blocked` and report the smoke/startup failure.
-8. Do not plan merge work while the orchestra session is still not dispatchable.
+6. If the state is `ready-with-ui-warning`, run `pwsh -NoProfile -File scripts/winsmux-core.ps1 orchestra-attach --json` once, then continue from the first pending `Next actions` item in `.claude/local/operator-handoff.md`.
+7. Never ask the user which task to begin when the live handoff already lists ordered next actions.
+8. Never use `psmux --version`, `Get-Process psmux-server`, or similar legacy probe commands for operator-side startup diagnosis.
+9. If pane expansion does not succeed, treat the session as `blocked` and report the smoke/startup failure.
+10. Do not plan merge work while the orchestra session is still not dispatchable.
 
 ## Builder Dispatch
 1. Check pane state: `winsmux capture-pane -t <pane> -p | tail -5`

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -6300,6 +6300,7 @@ promote-tactic <run_id> [--title <text>] [--kind <playbook|prewarm|verification>
   task-run <task>       Alias for pipeline; one-shot orchestration entrypoint
   builder-queue <action> [args]  Manage Builder queue and auto-dispatch next work
   orchestra-smoke [--json] [--auto-start] [--project-dir <path>]  Report structured startup contract + UI attach state (use --auto-start to start if needed)
+  orchestra-attach [--json] [--project-dir <path>]  Launch a visible attach window for an existing orchestra session
   vault set <key> [value]   Store a credential securely (DPAPI)
   vault get <key>           Retrieve a stored credential
   vault inject <pane>       Inject all credentials as env vars into a pane
@@ -6648,6 +6649,30 @@ switch ($Command) {
             }
         }
         & pwsh -NoProfile -File $smokeScript @smokeArgs
+    }
+    'orchestra-attach' {
+        $attachScript = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\winsmux-core\scripts\orchestra-attach.ps1'))
+        $attachArgs = @()
+        $remaining = @(@($Target) + @($Rest) | Where-Object { $_ })
+        for ($index = 0; $index -lt $remaining.Count; $index++) {
+            switch ($remaining[$index]) {
+                '--json' {
+                    $attachArgs += '-AsJson'
+                }
+                '--project-dir' {
+                    if ($index + 1 -ge $remaining.Count) {
+                        Stop-WithError "usage: winsmux orchestra-attach [--json] [--project-dir <path>]"
+                    }
+
+                    $attachArgs += @('-ProjectDir', $remaining[$index + 1])
+                    $index++
+                }
+                default {
+                    Stop-WithError "usage: winsmux orchestra-attach [--json] [--project-dir <path>]"
+                }
+            }
+        }
+        & pwsh -NoProfile -File $attachScript @attachArgs
     }
     'vault'           {
         switch ($Target) {

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -6299,7 +6299,7 @@ promote-tactic <run_id> [--title <text>] [--kind <playbook|prewarm|verification>
   pipeline <task>       Run plan-exec-verify-fix loop for a task
   task-run <task>       Alias for pipeline; one-shot orchestration entrypoint
   builder-queue <action> [args]  Manage Builder queue and auto-dispatch next work
-  orchestra-smoke [--json] [--project-dir <path>]  Start Orchestra if needed and report structured startup contract + UI attach state
+  orchestra-smoke [--json] [--auto-start] [--project-dir <path>]  Report structured startup contract + UI attach state (use --auto-start to start if needed)
   vault set <key> [value]   Store a credential securely (DPAPI)
   vault get <key>           Retrieve a stored credential
   vault inject <pane>       Inject all credentials as env vars into a pane
@@ -6633,14 +6633,17 @@ switch ($Command) {
                 }
                 '--project-dir' {
                     if ($index + 1 -ge $remaining.Count) {
-                    Stop-WithError "usage: winsmux orchestra-smoke [--json] [--project-dir <path>]"
+                    Stop-WithError "usage: winsmux orchestra-smoke [--json] [--auto-start] [--project-dir <path>]"
                 }
 
                 $smokeArgs += @('-ProjectDir', $remaining[$index + 1])
                 $index++
             }
+                '--auto-start' {
+                    $smokeArgs += '-AutoStart'
+                }
                 default {
-                    Stop-WithError "usage: winsmux orchestra-smoke [--json] [--project-dir <path>]"
+                    Stop-WithError "usage: winsmux orchestra-smoke [--json] [--auto-start] [--project-dir <path>]"
                 }
             }
         }

--- a/tests/Integration.GateEnforcement.Tests.ps1
+++ b/tests/Integration.GateEnforcement.Tests.ps1
@@ -570,6 +570,17 @@ EOF
         $result.StdErr | Should -Be ''
     }
 
+    It 'allows winsmux orchestra-attach from the operator pane' {
+        $result = & $script:InvokeOrchestraGate -ToolName 'Bash' -ToolInput @{
+            command = 'pwsh -NoProfile -File scripts/winsmux-core.ps1 orchestra-attach --json'
+        } -Environment ([ordered]@{
+            WINSMUX_ROLE = 'Commander'
+        })
+
+        $result.ExitCode | Should -Be 0
+        $result.StdErr | Should -Be ''
+    }
+
     It 'wires the startup gate disable environment flag into the orchestra readiness gate' {
         $hookContent = Get-Content -LiteralPath $script:SourceHookPath -Raw -Encoding UTF8
 

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -6301,10 +6301,11 @@ Describe 'winsmux orchestra-smoke command' {
     }
 
     It 'documents orchestra-smoke and dispatches it through the dedicated startup smoke script' {
-        $script:winsmuxCoreRawContent | Should -Match 'orchestra-smoke \[--json\] \[--project-dir <path>\]\s+Start Orchestra if needed and report structured startup contract \+ UI attach state'
+        $script:winsmuxCoreRawContent | Should -Match 'orchestra-smoke \[--json\] \[--auto-start\] \[--project-dir <path>\]\s+Report structured startup contract \+ UI attach state \(use --auto-start to start if needed\)'
         $script:winsmuxCoreRawContent | Should -Match "'orchestra-smoke'\s*\{"
         $script:winsmuxCoreRawContent | Should -Match 'orchestra-smoke\.ps1'
         $script:winsmuxCoreRawContent | Should -Match '--project-dir <path>'
+        $script:winsmuxCoreRawContent | Should -Match '--auto-start'
         $script:winsmuxCoreRawContent | Should -Not -Match '--session-name <name>'
     }
 
@@ -6330,6 +6331,12 @@ Describe 'winsmux orchestra-smoke command' {
 
     It 'allows an empty smoke_errors collection when building the operator contract' {
         $script:orchestraSmokeContent | Should -Match '\[AllowEmptyCollection\(\)\]\[string\[\]\]\$SmokeErrors'
+    }
+
+    It 'defaults orchestra-smoke to observation-only and only auto-starts when requested' {
+        $script:orchestraSmokeContent | Should -Match '\[switch\]\$AutoStart'
+        $script:orchestraSmokeContent | Should -Match 'elseif \(\$AutoStart\)'
+        $script:orchestraSmokeContent | Should -Match 'Skipped orchestra-start; run orchestra-start\.ps1 when operator_contract\.requires_startup is true\.'
     }
 }
 

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -6302,8 +6302,11 @@ Describe 'winsmux orchestra-smoke command' {
 
     It 'documents orchestra-smoke and dispatches it through the dedicated startup smoke script' {
         $script:winsmuxCoreRawContent | Should -Match 'orchestra-smoke \[--json\] \[--auto-start\] \[--project-dir <path>\]\s+Report structured startup contract \+ UI attach state \(use --auto-start to start if needed\)'
+        $script:winsmuxCoreRawContent | Should -Match 'orchestra-attach \[--json\] \[--project-dir <path>\]\s+Launch a visible attach window for an existing orchestra session'
         $script:winsmuxCoreRawContent | Should -Match "'orchestra-smoke'\s*\{"
+        $script:winsmuxCoreRawContent | Should -Match "'orchestra-attach'\s*\{"
         $script:winsmuxCoreRawContent | Should -Match 'orchestra-smoke\.ps1'
+        $script:winsmuxCoreRawContent | Should -Match 'orchestra-attach\.ps1'
         $script:winsmuxCoreRawContent | Should -Match '--project-dir <path>'
         $script:winsmuxCoreRawContent | Should -Match '--auto-start'
         $script:winsmuxCoreRawContent | Should -Not -Match '--session-name <name>'
@@ -6356,16 +6359,20 @@ Describe 'operator startup restore contract docs' {
         $script:claudeGuideContent | Should -Match 'operator_contract\.can_dispatch'
         $script:claudeGuideContent | Should -Match 'operator_contract\.requires_startup'
         $script:claudeGuideContent | Should -Match 'ready-with-ui-warning'
+        $script:claudeGuideContent | Should -Match 'winsmux orchestra-attach --json'
+        $script:claudeGuideContent | Should -Match 'without asking the user to choose a starting task'
         $script:claudeGuideContent | Should -Match 'psmux --version'
         $script:claudeGuideContent | Should -Match 'Get-Process psmux-server'
         $script:claudeGuideContent | Should -Match 'manually start a `psmux` server'
         $script:dispatchRuleContent | Should -Match 'scripts/winsmux-core\.ps1 orchestra-smoke --json'
+        $script:dispatchRuleContent | Should -Match 'scripts/winsmux-core\.ps1 orchestra-attach --json'
         $script:dispatchRuleContent | Should -Match 'needs-startup'
         $script:dispatchRuleContent | Should -Match 'orchestra-start\.ps1'
         $script:dispatchRuleContent | Should -Match 'operator_contract\.operator_state'
         $script:dispatchRuleContent | Should -Match 'operator_contract\.can_dispatch'
         $script:dispatchRuleContent | Should -Match 'operator_contract\.requires_startup'
         $script:dispatchRuleContent | Should -Match 'ready-with-ui-warning'
+        $script:dispatchRuleContent | Should -Match 'Never ask the user which task to begin'
         $script:dispatchRuleContent | Should -Match 'psmux --version'
         $script:dispatchRuleContent | Should -Match 'Get-Process psmux-server'
     }

--- a/winsmux-core/scripts/orchestra-attach.ps1
+++ b/winsmux-core/scripts/orchestra-attach.ps1
@@ -1,0 +1,192 @@
+[CmdletBinding()]
+param(
+    [string]$ProjectDir = '',
+    [string]$SessionName = 'winsmux-orchestra',
+    [switch]$AsJson
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+
+if ([string]::IsNullOrWhiteSpace($ProjectDir)) {
+    $ProjectDir = (Get-Location).Path
+}
+
+$ProjectDir = [System.IO.Path]::GetFullPath($ProjectDir)
+$scriptsRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+$bootstrapScriptPath = Join-Path $scriptsRoot 'orchestra-bootstrap.ps1'
+
+function Get-OrchestraWindowsTerminalInfo {
+    $wtExe = Get-Command 'wt.exe' -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source -ErrorAction SilentlyContinue
+    $canonicalWtExe = ''
+    $isAliasStub = $false
+
+    if (-not [string]::IsNullOrWhiteSpace($wtExe)) {
+        try {
+            $wtItem = Get-Item -LiteralPath $wtExe -ErrorAction Stop
+            $windowsAppsRoot = Join-Path $env:LOCALAPPDATA 'Microsoft\WindowsApps'
+            $normalizedWtExe = [System.IO.Path]::GetFullPath($wtExe)
+            $normalizedWindowsAppsRoot = [System.IO.Path]::GetFullPath($windowsAppsRoot)
+            if ($wtItem.Length -eq 0 -or $normalizedWtExe.StartsWith($normalizedWindowsAppsRoot, [System.StringComparison]::OrdinalIgnoreCase)) {
+                $isAliasStub = $true
+            } else {
+                $canonicalWtExe = $normalizedWtExe
+            }
+        } catch {
+        }
+    }
+
+    if ([string]::IsNullOrWhiteSpace($canonicalWtExe)) {
+        foreach ($packageName in @('Microsoft.WindowsTerminal', 'Microsoft.WindowsTerminalPreview')) {
+            try {
+                $package = Get-AppxPackage -Name $packageName -ErrorAction SilentlyContinue | Select-Object -First 1
+                if ($null -eq $package -or [string]::IsNullOrWhiteSpace([string]$package.InstallLocation)) {
+                    continue
+                }
+
+                $candidatePath = Join-Path ([string]$package.InstallLocation) 'wt.exe'
+                if (-not (Test-Path -LiteralPath $candidatePath)) {
+                    continue
+                }
+
+                $canonicalWtExe = [System.IO.Path]::GetFullPath($candidatePath)
+                break
+            } catch {
+            }
+        }
+    }
+
+    return [PSCustomObject][ordered]@{
+        Available   = -not [string]::IsNullOrWhiteSpace($canonicalWtExe)
+        Path        = $canonicalWtExe
+        AliasPath   = if ($isAliasStub) { [string]$wtExe } else { '' }
+        IsAliasStub = $isAliasStub
+    }
+}
+
+function Start-OrchestraAttachProcess {
+    param(
+        [Parameter(Mandatory = $true)][string]$FilePath,
+        [Parameter(Mandatory = $true)][object[]]$ArgumentList,
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $true)][string]$LaunchedStatus,
+        [Parameter(Mandatory = $true)][string]$LaunchedReason,
+        [Parameter(Mandatory = $true)][string]$FallbackReason
+    )
+
+    try {
+        $attachProcess = Start-Process -FilePath $FilePath -ArgumentList $ArgumentList -PassThru
+        Start-Sleep -Milliseconds 500
+        $attachStillRunning = -not $attachProcess.HasExited
+
+        return [PSCustomObject][ordered]@{
+            attempted = $true
+            launched  = $true
+            attached  = $false
+            status    = if ($attachStillRunning) { $LaunchedStatus } else { 'attach_exited_early' }
+            reason    = if ($attachStillRunning) { $LaunchedReason } else { $FallbackReason }
+            path      = $Path
+        }
+    } catch {
+        return [PSCustomObject][ordered]@{
+            attempted = $true
+            launched  = $false
+            attached  = $false
+            status    = 'attach_failed'
+            reason    = $_.Exception.Message
+            path      = $Path
+        }
+    }
+}
+
+$winsmuxPath = Get-Command 'winsmux' -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source -ErrorAction SilentlyContinue
+if ([string]::IsNullOrWhiteSpace($winsmuxPath)) {
+    $result = [ordered]@{
+        session_name      = $SessionName
+        session_exists    = $false
+        requires_startup  = $true
+        launched          = $false
+        status            = 'winsmux_unresolved'
+        reason            = 'winsmux executable could not be resolved.'
+    }
+} else {
+    & $winsmuxPath 'has-session' '-t' $SessionName 1>$null 2>$null
+    $sessionExists = ($LASTEXITCODE -eq 0)
+    if (-not $sessionExists) {
+        $result = [ordered]@{
+            session_name      = $SessionName
+            session_exists    = $false
+            requires_startup  = $true
+            launched          = $false
+            status            = 'session_missing'
+            reason            = "winsmux session '$SessionName' was not found. Run orchestra-start.ps1 first."
+        }
+    } else {
+        $pwshPath = Get-Command 'pwsh' -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source -ErrorAction SilentlyContinue
+        if ([string]::IsNullOrWhiteSpace($pwshPath)) {
+            $pwshPath = 'pwsh'
+        }
+
+        $bootstrapArguments = @(
+            '-NoProfile', '-NoExit', '-File', $bootstrapScriptPath, '-SessionName', $SessionName, '-WinsmuxPath', $winsmuxPath, '-AttachOnly'
+        )
+
+        $result = Start-OrchestraAttachProcess `
+            -FilePath $pwshPath `
+            -ArgumentList $bootstrapArguments `
+            -Path $pwshPath `
+            -LaunchedStatus 'attach_launched_pwsh' `
+            -LaunchedReason 'Launched orchestra bootstrap in a standalone PowerShell window.' `
+            -FallbackReason 'Standalone PowerShell attach exited during the early-failure window.'
+
+        if ($result.status -eq 'attach_exited_early' -or $result.status -eq 'attach_failed') {
+            $terminalInfo = Get-OrchestraWindowsTerminalInfo
+            if ([bool]$terminalInfo.Available) {
+                $wtArguments = @(
+                    '--size', '200,70',
+                    'new-tab',
+                    '--title', $SessionName,
+                    '--',
+                    $pwshPath
+                ) + $bootstrapArguments
+
+                $wtResult = Start-OrchestraAttachProcess `
+                    -FilePath ([string]$terminalInfo.Path) `
+                    -ArgumentList $wtArguments `
+                    -Path ([string]$terminalInfo.Path) `
+                    -LaunchedStatus 'attach_launched_wt_fallback' `
+                    -LaunchedReason 'Standalone PowerShell attach failed; launched Windows Terminal attach child as a fallback.' `
+                    -FallbackReason 'Windows Terminal attach child exited during the early-failure window.'
+
+                if ([bool]$wtResult.launched) {
+                    $result = $wtResult
+                }
+            }
+        }
+
+        $result = [ordered]@{
+            session_name      = $SessionName
+            session_exists    = $true
+            requires_startup  = $false
+            attempted         = $result.attempted
+            launched          = $result.launched
+            attached          = $result.attached
+            status            = $result.status
+            reason            = $result.reason
+            path              = $result.path
+        }
+    }
+}
+
+if ($AsJson) {
+    $result | ConvertTo-Json -Depth 6
+} else {
+    $result.GetEnumerator() | ForEach-Object {
+        '{0}: {1}' -f $_.Key, $_.Value
+    }
+}
+
+if ($result.status -in @('attach_failed', 'attach_exited_early', 'session_missing', 'winsmux_unresolved')) {
+    exit 1
+}

--- a/winsmux-core/scripts/orchestra-smoke.ps1
+++ b/winsmux-core/scripts/orchestra-smoke.ps1
@@ -1,7 +1,8 @@
 [CmdletBinding()]
 param(
     [string]$ProjectDir = '',
-    [switch]$AsJson
+    [switch]$AsJson,
+    [switch]$AutoStart
 )
 
 $ErrorActionPreference = 'Stop'
@@ -185,7 +186,7 @@ $startExitCode = 0
 $sessionAlreadyHealthy = $paneProbeOk -and $paneCount -ge $expectedPaneCount -and $manifestFound
 if ($sessionAlreadyHealthy) {
     $startOutput = 'Skipped orchestra-start; existing orchestra session already meets the smoke prerequisites.'
-} else {
+} elseif ($AutoStart) {
     $startOutput = & pwsh -NoProfile -Command "Set-Location -LiteralPath '$ProjectDir'; & '$startScript'" 2>&1
     $startExitCode = $LASTEXITCODE
     $manifestFound = Test-Path -LiteralPath $manifestPath
@@ -205,6 +206,8 @@ if ($sessionAlreadyHealthy) {
             $paneProbeError = $_.Exception.Message
         }
     }
+} else {
+    $startOutput = 'Skipped orchestra-start; run orchestra-start.ps1 when operator_contract.requires_startup is true.'
 }
 
 $sessionReady = $false


### PR DESCRIPTION
## Summary
- make orchestra-smoke observation-only by default
- require explicit --auto-start for start-if-needed behavior
- prevent /winsmux-start startup checks from re-entering orchestra-start and colliding on the startup lock

## Test plan
- `pwsh -NoProfile -File .\\winsmux-core\\scripts\\orchestra-start.ps1`
- `pwsh -NoProfile -File .\\scripts\\winsmux-core.ps1 orchestra-smoke --json`
- `pwsh -NoProfile -Command "Invoke-Pester tests\\winsmux-bridge.Tests.ps1 -CI"`
