### PR TITLE
fix: force managed pane dispatch after orchestra restore

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -57,9 +57,9 @@ Direct operator-side mutation is **outside the standard winsmux operating model*
   - the operator and control-plane surface
   - assigns tasks, gathers output, and decides next actions
 - **Subagents**
-  - operator-local information gathering tools
-  - help Claude Code inspect context efficiently
-  - do not replace pane-side execution responsibility
+  - operator-local planning and startup/status diagnosis tools
+  - help Claude Code inspect orchestra readiness efficiently
+  - must not replace pane-side execution or pane-side review once orchestra is dispatchable
 
 ## Operator DO
 
@@ -90,10 +90,12 @@ When `/winsmux-start` or another restoration flow reports `needs-startup`:
 5. Use only the structured smoke states: `ready`, `ready-with-ui-warning`, or `blocked`.
 6. If the state is `ready-with-ui-warning`, run `winsmux orchestra-attach --json` once to launch a visible operator window, then continue from the live handoff without asking the user to choose a starting task.
 7. When `.claude/local/operator-handoff.md` contains an ordered `Next actions` list, start the first pending action automatically instead of asking which task to begin.
-8. Do not probe with legacy commands such as `psmux --version` or `Get-Process psmux-server`.
-9. Do not tell the user to manually start a `psmux` server.
-10. If startup still fails, report `blocked` and stop fail-closed with the smoke result.
-11. Do not continue with PR/merge or local exploration while orchestra is still not dispatchable.
+8. Once `operator_contract.can_dispatch=true`, do not use Explore subagents for PR/task analysis. Dispatch the task through `winsmux dispatch-task "<task text>"` or `winsmux dispatch-review`.
+9. Startup/status Explore subagents are allowed only while diagnosing orchestra readiness or attach problems.
+10. Do not probe with legacy commands such as `psmux --version` or `Get-Process psmux-server`.
+11. Do not tell the user to manually start a `psmux` server.
+12. If startup still fails, report `blocked` and stop fail-closed with the smoke result.
+13. Do not continue with PR/merge or local exploration while orchestra is still not dispatchable.
 
 ## Compatibility and release notes
 

--- a/.claude/hooks/sh-orchestra-gate.js
+++ b/.claude/hooks/sh-orchestra-gate.js
@@ -128,14 +128,15 @@ try {
     }
   }
 
-  // Rule 10: Commander cannot use write-capable Agent modes — delegate to Builder panes (#347)
+  // Rule 10: Operator-side Agent use is limited to planning and startup diagnosis.
   if (toolName === "Agent") {
     const agentMode = normalizeAgentValue(toolInput.mode);
     const subagentType = normalizeAgentValue(toolInput.subagent_type);
-
-    const isAllowedAgentUse = agentMode === "plan" || subagentType === "explore";
+    const isAllowedAgentUse =
+      agentMode === "plan" ||
+      (subagentType === "explore" && isStartupDiagnosisSubagent(toolInput));
     if (!isAllowedAgentUse) {
-      deny("Operator delegated write bypass blocked. Delegate implementation to managed worker panes. Allowed: plan mode, Explore subagents.");
+      deny("Operator delegated execution bypass blocked. Delegate task execution and review to managed worker panes via winsmux dispatch-task or dispatch-review. Allowed: plan mode, startup-diagnosis Explore subagents.");
     }
   }
 
@@ -219,6 +220,59 @@ function stripHeredocBodies(command) {
   }
 
   return output.join("\n");
+}
+
+function isStartupDiagnosisSubagent(toolInput) {
+  const fragments = [];
+  const pushText = (value) => {
+    if (typeof value === "string" && value.trim().length > 0) {
+      fragments.push(value.trim().toLowerCase());
+    }
+  };
+
+  pushText(toolInput.prompt);
+  pushText(toolInput.description);
+  if (Array.isArray(toolInput.items)) {
+    for (const item of toolInput.items) {
+      if (!item || typeof item !== "object") {
+        continue;
+      }
+      pushText(item.text);
+      pushText(item.name);
+      pushText(item.path);
+    }
+  }
+
+  const haystack = fragments.join(" ");
+  if (!haystack) {
+    return false;
+  }
+
+  const keywords = [
+    "orchestra",
+    "startup",
+    "start-up",
+    "smoke",
+    "attach",
+    "lock",
+    "locked",
+    "session",
+    "pane",
+    "worker pane",
+    "manifest",
+    "needs-startup",
+    "ready-with-ui-warning",
+    "blocked",
+    "起動",
+    "セッション",
+    "ペイン",
+    "ロック",
+    "診断",
+    "復旧",
+    "復元",
+  ];
+
+  return keywords.some((keyword) => haystack.includes(keyword));
 }
 
 function getOrchestraRestoreGateState(cwd) {

--- a/.claude/rules/dispatch.md
+++ b/.claude/rules/dispatch.md
@@ -15,9 +15,11 @@ paths: ["winsmux-core/scripts/**", ".claude/**"]
    Any other state is fail-closed.
 6. If the state is `ready-with-ui-warning`, run `pwsh -NoProfile -File scripts/winsmux-core.ps1 orchestra-attach --json` once, then continue from the first pending `Next actions` item in `.claude/local/operator-handoff.md`.
 7. Never ask the user which task to begin when the live handoff already lists ordered next actions.
-8. Never use `psmux --version`, `Get-Process psmux-server`, or similar legacy probe commands for operator-side startup diagnosis.
-9. If pane expansion does not succeed, treat the session as `blocked` and report the smoke/startup failure.
-10. Do not plan merge work while the orchestra session is still not dispatchable.
+8. Once `operator_contract.can_dispatch=true`, do not use Explore subagents for PR/task analysis. Use `pwsh -NoProfile -File scripts/winsmux-core.ps1 dispatch-task "<task text>"` or `dispatch-review`.
+9. Explore subagents are reserved for orchestra startup/status diagnosis only.
+10. Never use `psmux --version`, `Get-Process psmux-server`, or similar legacy probe commands for operator-side startup diagnosis.
+11. If pane expansion does not succeed, treat the session as `blocked` and report the smoke/startup failure.
+12. Do not plan merge work while the orchestra session is still not dispatchable.
 
 ## Builder Dispatch
 1. Check pane state: `winsmux capture-pane -t <pane> -p | tail -5`
@@ -32,6 +34,11 @@ paths: ["winsmux-core/scripts/**", ".claude/**"]
 2. Wait for PASS/FAIL in capture output
 3. On PASS: proceed to commit. On FAIL: re-dispatch fix to Builder
 
+## Standard Dispatch
+1. Use `pwsh -NoProfile -File scripts/winsmux-core.ps1 dispatch-task "<task text>"` as the default operator-to-pane dispatch path.
+2. Use `dispatch-review` only when the next action is to request a formal review-state transition.
+3. Verify the chosen pane with `winsmux capture-pane -t <pane_id> -p | tail -15` before reporting that work was dispatched.
+
 ## Post-Review Commit
 1. Verify `review-state.json` has PASS
 2. Run: `NO_COLOR=1 pwsh -Command "Invoke-Pester tests/ -Output Minimal"`
@@ -39,5 +46,6 @@ paths: ["winsmux-core/scripts/**", ".claude/**"]
 
 ## Prohibited
 - Agent subagent for implementation (#273)
+- Explore subagents for PR/task analysis once `operator_contract.can_dispatch=true`
 - Report pane status without capture verification (#280)
 - Commit without Reviewer PASS (#279)

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -6016,6 +6016,93 @@ function Invoke-DispatchReview {
     Write-Output "PENDING confirmed. $reviewRole pane will run review-approve or review-fail. Monitor review-state.json for result."
 }
 
+function Get-DispatchTaskManifestEntry {
+    param(
+        [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [Parameter(Mandatory = $true)][string]$Label
+    )
+
+    if (Get-Command Get-PaneControlManifestEntries -ErrorAction SilentlyContinue) {
+        $entry = @(Get-PaneControlManifestEntries -ProjectDir $ProjectDir | Where-Object { [string]$_.Label -eq $Label } | Select-Object -First 1)[0]
+        if ($null -ne $entry) {
+            return $entry
+        }
+    }
+
+    $labels = Get-Labels
+    if ($labels.ContainsKey($Label)) {
+        return [PSCustomObject]@{
+            Label  = $Label
+            PaneId = [string]$labels[$Label]
+            Role   = ''
+        }
+    }
+
+    return $null
+}
+
+function Invoke-DispatchTask {
+    $parts = @(
+        @($Target) + @($Rest) |
+            Where-Object { $_ } |
+            ForEach-Object { $_.Trim() } |
+            Where-Object { $_ }
+    )
+    if ($parts.Count -lt 1) {
+        Stop-WithError "usage: winsmux dispatch-task <text>"
+    }
+
+    $taskText = $parts -join ' '
+    $projectDir = (Get-Location).Path
+    $routerScript = Join-Path $PSScriptRoot '..\winsmux-core\scripts\dispatch-router.ps1'
+    if (-not (Test-Path -LiteralPath $routerScript -PathType Leaf)) {
+        Stop-WithError "dispatch router not found: $routerScript"
+    }
+
+    . $routerScript
+
+    $availableTargets = @()
+    if (Get-Command Get-PaneControlManifestEntries -ErrorAction SilentlyContinue) {
+        $availableTargets = @(
+            Get-PaneControlManifestEntries -ProjectDir $projectDir |
+                ForEach-Object { [string]$_.Label } |
+                Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+        )
+    }
+    if ($availableTargets.Count -eq 0) {
+        $availableTargets = @((Get-Labels).Keys | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+    }
+
+    $route = Get-DispatchRoute -Text $taskText -AvailableTargets $availableTargets -DefaultRole 'Worker'
+    if ($route.HandleLocally) {
+        Stop-WithError "dispatch-task routed to Commander. Refine the task text so it can be delegated to a managed pane."
+    }
+
+    $selectedLabel = [string]$route.SelectedTarget
+    $paneId = ''
+    $resolvedRole = [string]$route.SelectedRole
+
+    if ($resolvedRole -eq 'Reviewer') {
+        $reviewEntry = Get-PreferredReviewPaneEntry -ProjectDir $projectDir
+        if ($null -eq $reviewEntry) {
+            Stop-WithError "No review-capable pane found in manifest."
+        }
+
+        $selectedLabel = [string]$reviewEntry.Label
+        $paneId = [string]$reviewEntry.PaneId
+    } else {
+        $manifestEntry = Get-DispatchTaskManifestEntry -ProjectDir $projectDir -Label $selectedLabel
+        if ($null -eq $manifestEntry -or [string]::IsNullOrWhiteSpace([string]$manifestEntry.PaneId)) {
+            Stop-WithError "dispatch-task could not resolve target '$selectedLabel' to a pane."
+        }
+
+        $paneId = [string]$manifestEntry.PaneId
+    }
+
+    Send-TextToPane -PaneId $paneId -CommandText $taskText
+    Write-Output ("Dispatched to {0} [{1}] as {2}. {3}" -f $selectedLabel, $paneId, $resolvedRole, [string]$route.Reason)
+}
+
 function Invoke-ReviewRequest {
     if ($Target -or ($Rest -and $Rest.Count -gt 0)) {
         Stop-WithError "usage: winsmux review-request"
@@ -6275,6 +6362,7 @@ Commands:
   review-fail               Record review FAIL for the current branch
   review-reset              Clear review PASS for the current branch
   dispatch-review           Dispatch review-request to a review-capable pane (Reviewer/Worker)
+  dispatch-task <text>      Route and send task text to a managed pane using manifest-aware role selection
   consult-request <mode> [--message <text>] [--target-slot <slot>]  Record a consultation request packet/event
   consult-result <mode> [--message <text>] [--target-slot <slot>] [--confidence <0..1>] [--next-test <text>] [--risk <text>]  Record a consultation result packet/event
   consult-error <mode> [--message <text>] [--target-slot <slot>]  Record a consultation error packet/event
@@ -6550,6 +6638,7 @@ switch ($Command) {
     'unlock'          { Invoke-Unlock }
     'locks'           { Invoke-Locks }
     'verify'          { Invoke-Verify }
+    'dispatch-task'   { Invoke-DispatchTask }
     'dispatch-route'  {
         $routerScript = Join-Path $PSScriptRoot '..\winsmux-core\scripts\dispatch-router.ps1'
         $fullText = @($Target) + @($Rest) | Where-Object { $_ } | ForEach-Object { $_.Trim() } | Where-Object { $_ }

--- a/tests/Integration.GateEnforcement.Tests.ps1
+++ b/tests/Integration.GateEnforcement.Tests.ps1
@@ -447,7 +447,7 @@ EOF
         })
 
         & $script:AssertDenyResult -Result $result
-        $result.ErrorObject.systemMessage | Should -Match 'delegated write bypass blocked'
+        $result.ErrorObject.systemMessage | Should -Match 'delegated execution bypass blocked'
     }
 
     It 'denies Agent auto mode outside worktree isolation' {
@@ -491,10 +491,22 @@ EOF
         & $script:AssertDenyResult -Result $result
     }
 
-    It 'allows Explore subagents even when mode is write-capable' {
+    It 'denies non-startup Explore subagents once operator execution must stay in managed panes' {
         $result = & $script:InvokeOrchestraGate -ToolName 'Agent' -ToolInput ([ordered]@{
             mode          = 'acceptEdits'
             subagent_type = 'Explore'
+            description   = 'Analyze PR #419 diff scope'
+        })
+
+        & $script:AssertDenyResult -Result $result
+        $result.ErrorObject.systemMessage | Should -Match 'dispatch-task'
+    }
+
+    It 'allows startup-diagnosis Explore subagents' {
+        $result = & $script:InvokeOrchestraGate -ToolName 'Agent' -ToolInput ([ordered]@{
+            mode          = 'acceptEdits'
+            subagent_type = 'Explore'
+            description   = 'Investigate orchestra startup blocked manifest pane count'
         })
 
         $result.ExitCode | Should -Be 0

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -6303,8 +6303,10 @@ Describe 'winsmux orchestra-smoke command' {
     It 'documents orchestra-smoke and dispatches it through the dedicated startup smoke script' {
         $script:winsmuxCoreRawContent | Should -Match 'orchestra-smoke \[--json\] \[--auto-start\] \[--project-dir <path>\]\s+Report structured startup contract \+ UI attach state \(use --auto-start to start if needed\)'
         $script:winsmuxCoreRawContent | Should -Match 'orchestra-attach \[--json\] \[--project-dir <path>\]\s+Launch a visible attach window for an existing orchestra session'
+        $script:winsmuxCoreRawContent | Should -Match 'dispatch-task <text>\s+Route and send task text to a managed pane using manifest-aware role selection'
         $script:winsmuxCoreRawContent | Should -Match "'orchestra-smoke'\s*\{"
         $script:winsmuxCoreRawContent | Should -Match "'orchestra-attach'\s*\{"
+        $script:winsmuxCoreRawContent | Should -Match "'dispatch-task'\s*\{"
         $script:winsmuxCoreRawContent | Should -Match 'orchestra-smoke\.ps1'
         $script:winsmuxCoreRawContent | Should -Match 'orchestra-attach\.ps1'
         $script:winsmuxCoreRawContent | Should -Match '--project-dir <path>'
@@ -6360,12 +6362,15 @@ Describe 'operator startup restore contract docs' {
         $script:claudeGuideContent | Should -Match 'operator_contract\.requires_startup'
         $script:claudeGuideContent | Should -Match 'ready-with-ui-warning'
         $script:claudeGuideContent | Should -Match 'winsmux orchestra-attach --json'
+        $script:claudeGuideContent | Should -Match 'winsmux dispatch-task'
         $script:claudeGuideContent | Should -Match 'without asking the user to choose a starting task'
+        $script:claudeGuideContent | Should -Match 'do not use Explore subagents for PR/task analysis'
         $script:claudeGuideContent | Should -Match 'psmux --version'
         $script:claudeGuideContent | Should -Match 'Get-Process psmux-server'
         $script:claudeGuideContent | Should -Match 'manually start a `psmux` server'
         $script:dispatchRuleContent | Should -Match 'scripts/winsmux-core\.ps1 orchestra-smoke --json'
         $script:dispatchRuleContent | Should -Match 'scripts/winsmux-core\.ps1 orchestra-attach --json'
+        $script:dispatchRuleContent | Should -Match 'scripts/winsmux-core\.ps1 dispatch-task'
         $script:dispatchRuleContent | Should -Match 'needs-startup'
         $script:dispatchRuleContent | Should -Match 'orchestra-start\.ps1'
         $script:dispatchRuleContent | Should -Match 'operator_contract\.operator_state'
@@ -6373,6 +6378,7 @@ Describe 'operator startup restore contract docs' {
         $script:dispatchRuleContent | Should -Match 'operator_contract\.requires_startup'
         $script:dispatchRuleContent | Should -Match 'ready-with-ui-warning'
         $script:dispatchRuleContent | Should -Match 'Never ask the user which task to begin'
+        $script:dispatchRuleContent | Should -Match 'Explore subagents are reserved for orchestra startup/status diagnosis only'
         $script:dispatchRuleContent | Should -Match 'psmux --version'
         $script:dispatchRuleContent | Should -Match 'Get-Process psmux-server'
     }


### PR DESCRIPTION
## Summary
- tighten the operator gate so `Explore` subagents are allowed only for orchestra startup/status diagnosis
- add `winsmux dispatch-task <text>` as the standard route-and-send primitive for managed pane dispatch
- update Claude Code restore/dispatch docs and regression tests so `/winsmux-start` continues into worker dispatch instead of local subagent analysis

## Validation
- `node -c .claude/hooks/sh-orchestra-gate.js`
- `Invoke-Pester tests/Integration.GateEnforcement.Tests.ps1 -CI`
- `Invoke-Pester tests/winsmux-bridge.Tests.ps1 -CI`
- `pwsh -NoProfile -File .\scripts\git-guard.ps1 -Mode full`
- `pwsh -NoProfile -File .\scripts\audit-public-surface.ps1`
- `pwsh -NoProfile -File .\scripts\winsmux-core.ps1 orchestra-smoke --json`
- `pwsh -NoProfile -File .\scripts\winsmux-core.ps1 dispatch-task "Dispatch verification only. Do not edit files. Reply RECEIVED and remain idle."`
- `winsmux capture-pane -t %4 -p -J -S -60`