### PR TITLE
fix: avoid duplicate orchestra attach windows

### DIFF
--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -2737,6 +2737,14 @@ Describe 'orchestra-start server bootstrap' {
 
     BeforeEach {
         $script:winsmuxBin = 'winsmux'
+        Mock Get-OrchestraAttachedClientSnapshot {
+            [PSCustomObject][ordered]@{
+                Ok      = $true
+                Count   = 0
+                Error   = ''
+                Clients = @()
+            }
+        }
     }
 
     It 'returns success when the server session already exists' {
@@ -2915,6 +2923,62 @@ Describe 'orchestra-start server bootstrap' {
         $result.Status | Should -Be 'attach_launched_pwsh'
         $script:startProcessCalls.Count | Should -Be 1
         $script:startProcessCalls[0].FilePath | Should -Be 'C:\Program Files\PowerShell\7\pwsh.exe'
+    }
+
+    It 'skips UI attach when an attached client already exists for the session' {
+        $script:startProcessCalls = @()
+
+        function Get-Command {
+            param([string]$Name)
+            if ($Name -eq 'pwsh') {
+                return [PSCustomObject]@{ Source = 'C:\Program Files\PowerShell\7\pwsh.exe' }
+            }
+            if ($Name -eq 'winsmux') {
+                return [PSCustomObject]@{ Source = 'C:\Users\komei\.local\bin\winsmux.exe' }
+            }
+            if ($Name -eq 'wt.exe') {
+                return [PSCustomObject]@{ Source = 'C:\Windows\System32\wt.exe' }
+            }
+
+            throw "unexpected command lookup: $Name"
+        }
+
+        Mock Get-OrchestraWindowsTerminalInfo {
+            [PSCustomObject][ordered]@{
+                Available   = $false
+                Path        = ''
+                AliasPath   = ''
+                IsAliasStub = $false
+                PathSource  = ''
+                Reason      = 'wt_unavailable'
+            }
+        }
+
+        Mock Get-OrchestraAttachedClientSnapshot {
+            [PSCustomObject][ordered]@{
+                Ok      = $true
+                Count   = 2
+                Error   = ''
+                Clients = @('/dev/pts/440', '/dev/pts/618')
+            }
+        }
+
+        function Start-Process {
+            param([string]$FilePath, [object[]]$ArgumentList, [switch]$PassThru)
+            $script:startProcessCalls += ,([PSCustomObject]@{
+                FilePath     = $FilePath
+                ArgumentList = @($ArgumentList)
+            })
+            return [PSCustomObject]@{ HasExited = $false }
+        }
+
+        $result = Try-StartOrchestraUiAttach -SessionName 'winsmux-orchestra'
+
+        $result.Attempted | Should -Be $false
+        $result.Launched | Should -Be $false
+        $result.Attached | Should -Be $true
+        $result.Status | Should -Be 'attach_already_present'
+        $script:startProcessCalls.Count | Should -Be 0
     }
 
     It 'resolves a canonical Windows Terminal path when wt.exe is only a WindowsApps alias' {
@@ -6318,6 +6382,9 @@ Describe 'winsmux orchestra-smoke command' {
         $script:orchestraSmokeContent | Should -Match 'session_ready'
         $script:orchestraSmokeContent | Should -Match 'ui_attach_launched'
         $script:orchestraSmokeContent | Should -Match 'ui_attached'
+        $script:orchestraSmokeContent | Should -Match 'attached_client_count'
+        $script:orchestraSmokeContent | Should -Match 'client_probe_ok'
+        $script:orchestraSmokeContent | Should -Match 'client_probe_error'
         $script:orchestraSmokeContent | Should -Match 'expected_pane_count'
         $script:orchestraSmokeContent | Should -Match 'winsmux_bin'
         $script:orchestraSmokeContent | Should -Match 'pane_probe_ok'
@@ -6342,6 +6409,12 @@ Describe 'winsmux orchestra-smoke command' {
         $script:orchestraSmokeContent | Should -Match '\[switch\]\$AutoStart'
         $script:orchestraSmokeContent | Should -Match 'elseif \(\$AutoStart\)'
         $script:orchestraSmokeContent | Should -Match 'Skipped orchestra-start; run orchestra-start\.ps1 when operator_contract\.requires_startup is true\.'
+    }
+
+    It 'uses attached clients to suppress duplicate UI attach retries' {
+        $script:orchestraSmokeContent | Should -Match 'Get-OrchestraAttachedClientSnapshot'
+        $script:orchestraSmokeContent | Should -Match 'list-clients -t \$SessionName'
+        $script:orchestraSmokeContent | Should -Match "uiAttachStatus = 'attach_already_present'"
     }
 }
 

--- a/winsmux-core/scripts/orchestra-attach.ps1
+++ b/winsmux-core/scripts/orchestra-attach.ps1
@@ -100,6 +100,40 @@ function Start-OrchestraAttachProcess {
     }
 }
 
+function Get-OrchestraAttachedClientSnapshot {
+    param(
+        [Parameter(Mandatory = $true)][string]$WinsmuxPath,
+        [Parameter(Mandatory = $true)][string]$SessionName
+    )
+
+    $clients = @()
+    $error = ''
+    $ok = $false
+
+    try {
+        $clientLines = & $WinsmuxPath 'list-clients' '-t' $SessionName 2>&1
+        if ($LASTEXITCODE -eq 0) {
+            $clients = @(
+                $clientLines |
+                    ForEach-Object { [string]$_ } |
+                    Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+            )
+            $ok = $true
+        } else {
+            $error = ($clientLines | Out-String).Trim()
+        }
+    } catch {
+        $error = $_.Exception.Message
+    }
+
+    [PSCustomObject][ordered]@{
+        Ok     = $ok
+        Count  = $clients.Count
+        Error  = $error
+        Clients = @($clients)
+    }
+}
+
 $winsmuxPath = Get-Command 'winsmux' -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source -ErrorAction SilentlyContinue
 if ([string]::IsNullOrWhiteSpace($winsmuxPath)) {
     $result = [ordered]@{
@@ -123,6 +157,21 @@ if ([string]::IsNullOrWhiteSpace($winsmuxPath)) {
             reason            = "winsmux session '$SessionName' was not found. Run orchestra-start.ps1 first."
         }
     } else {
+        $clientSnapshot = Get-OrchestraAttachedClientSnapshot -WinsmuxPath $winsmuxPath -SessionName $SessionName
+        if ([bool]$clientSnapshot.Ok -and [int]$clientSnapshot.Count -gt 0) {
+            $result = [ordered]@{
+                session_name          = $SessionName
+                session_exists        = $true
+                requires_startup      = $false
+                attempted             = $false
+                launched              = $false
+                attached              = $true
+                attached_client_count = [int]$clientSnapshot.Count
+                status                = 'attach_already_present'
+                reason                = "Detected $($clientSnapshot.Count) attached client(s) for session '$SessionName'; skipped spawning another visible attach window."
+                path                  = ''
+            }
+        } else {
         $pwshPath = Get-Command 'pwsh' -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source -ErrorAction SilentlyContinue
         if ([string]::IsNullOrWhiteSpace($pwshPath)) {
             $pwshPath = 'pwsh'
@@ -172,9 +221,11 @@ if ([string]::IsNullOrWhiteSpace($winsmuxPath)) {
             attempted         = $result.attempted
             launched          = $result.launched
             attached          = $result.attached
+            attached_client_count = 0
             status            = $result.status
             reason            = $result.reason
             path              = $result.path
+        }
         }
     }
 }

--- a/winsmux-core/scripts/orchestra-smoke.ps1
+++ b/winsmux-core/scripts/orchestra-smoke.ps1
@@ -78,6 +78,49 @@ function ConvertTo-OrchestraSmokeBoolean {
     }
 }
 
+function Get-OrchestraAttachedClientSnapshot {
+    param(
+        [Parameter(Mandatory = $true)][string]$WinsmuxBin,
+        [Parameter(Mandatory = $true)][string]$SessionName
+    )
+
+    $clients = @()
+    $error = ''
+    $ok = $false
+
+    if ([string]::IsNullOrWhiteSpace($WinsmuxBin)) {
+        return [PSCustomObject][ordered]@{
+            Ok      = $false
+            Count   = 0
+            Error   = 'winsmux executable could not be resolved.'
+            Clients = @()
+        }
+    }
+
+    try {
+        $clientLines = & $WinsmuxBin list-clients -t $SessionName 2>&1
+        if ($LASTEXITCODE -eq 0) {
+            $clients = @(
+                $clientLines |
+                    ForEach-Object { [string]$_ } |
+                    Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+            )
+            $ok = $true
+        } else {
+            $error = ($clientLines | Out-String).Trim()
+        }
+    } catch {
+        $error = $_.Exception.Message
+    }
+
+    [PSCustomObject][ordered]@{
+        Ok      = $ok
+        Count   = $clients.Count
+        Error   = $error
+        Clients = @($clients)
+    }
+}
+
 function Get-OrchestraOperatorContract {
     param(
         [Parameter(Mandatory = $true)][bool]$SmokeOk,
@@ -181,6 +224,11 @@ if (-not [string]::IsNullOrWhiteSpace($winsmuxBin)) {
     $paneProbeError = 'winsmux executable could not be resolved.'
 }
 
+$clientSnapshot = Get-OrchestraAttachedClientSnapshot -WinsmuxBin $winsmuxBin -SessionName $SessionName
+$clientProbeOk = [bool]$clientSnapshot.Ok
+$clientProbeError = [string]$clientSnapshot.Error
+$attachedClientCount = [int]$clientSnapshot.Count
+
 $startOutput = ''
 $startExitCode = 0
 $sessionAlreadyHealthy = $paneProbeOk -and $paneCount -ge $expectedPaneCount -and $manifestFound
@@ -227,6 +275,12 @@ if ($manifestFound) {
     }
 }
 
+if ($clientProbeOk -and $attachedClientCount -gt 0) {
+    $uiAttached = $true
+    $uiAttachStatus = 'attach_already_present'
+    $uiAttachReason = "Detected $attachedClientCount attached client(s) for session '$SessionName'."
+}
+
 $smokeErrors = [System.Collections.Generic.List[string]]::new()
 if ($startExitCode -ne 0) { $smokeErrors.Add("orchestra-start exited with code $startExitCode.") | Out-Null }
 if (-not $manifestFound) { $smokeErrors.Add('manifest missing after startup.') | Out-Null }
@@ -251,6 +305,9 @@ $result = [ordered]@{
     pane_count          = $paneCount
     pane_probe_ok       = $paneProbeOk
     pane_probe_error    = $paneProbeError
+    client_probe_ok     = $clientProbeOk
+    client_probe_error  = $clientProbeError
+    attached_client_count = $attachedClientCount
     expected_pane_count = $expectedPaneCount
     manifest_found      = $manifestFound
     session_ready       = $sessionReady

--- a/winsmux-core/scripts/orchestra-start.ps1
+++ b/winsmux-core/scripts/orchestra-start.ps1
@@ -170,6 +170,48 @@ function Start-OrchestraAttachProcess {
     }
 }
 
+function Get-OrchestraAttachedClientSnapshot {
+    param(
+        [Parameter(Mandatory = $true)][string]$SessionName
+    )
+
+    $clients = @()
+    $error = ''
+    $ok = $false
+
+    if ([string]::IsNullOrWhiteSpace([string]$script:winsmuxBin)) {
+        return [PSCustomObject][ordered]@{
+            Ok      = $false
+            Count   = 0
+            Error   = 'winsmux executable could not be resolved.'
+            Clients = @()
+        }
+    }
+
+    try {
+        $clientLines = & $script:winsmuxBin 'list-clients' '-t' $SessionName 2>&1
+        if ($LASTEXITCODE -eq 0) {
+            $clients = @(
+                $clientLines |
+                    ForEach-Object { [string]$_ } |
+                    Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+            )
+            $ok = $true
+        } else {
+            $error = ($clientLines | Out-String).Trim()
+        }
+    } catch {
+        $error = $_.Exception.Message
+    }
+
+    [PSCustomObject][ordered]@{
+        Ok      = $ok
+        Count   = $clients.Count
+        Error   = $error
+        Clients = @($clients)
+    }
+}
+
 function Try-StartOrchestraUiAttach {
     param(
         [Parameter(Mandatory = $true)][string]$SessionName,
@@ -216,6 +258,18 @@ function Try-StartOrchestraUiAttach {
             Status    = 'winsmux_unresolved'
             Reason    = 'winsmux executable could not be resolved to an absolute path for the attach child process.'
             Path      = [string]$terminalInfo.Path
+        }
+    }
+
+    $clientSnapshot = Get-OrchestraAttachedClientSnapshot -SessionName $SessionName
+    if ([bool]$clientSnapshot.Ok -and [int]$clientSnapshot.Count -gt 0) {
+        return [PSCustomObject][ordered]@{
+            Attempted = $false
+            Launched  = $false
+            Attached  = $true
+            Status    = 'attach_already_present'
+            Reason    = "Detected $($clientSnapshot.Count) attached client(s) for session '$SessionName'; skipped spawning another visible attach window."
+            Path      = ''
         }
     }
 
@@ -2106,7 +2160,7 @@ if ($MyInvocation.InvocationName -ne '.') {
     Assert-OrchestraBootstrapVerification -PaneSummaries @($paneSummaries) -InvalidCount $invalidCount -ReadyCount $readyCount
 
     $uiAttachResult = Try-StartOrchestraUiAttach -SessionName $sessionName
-    $successfulAttachStatuses = @('attach_launched', 'attach_launched_pwsh', 'attach_launched_wt_fallback')
+    $successfulAttachStatuses = @('attach_launched', 'attach_launched_pwsh', 'attach_launched_wt_fallback', 'attach_already_present')
     if ($successfulAttachStatuses -notcontains [string]$uiAttachResult.Status) {
         Write-Warning "Orchestra UI attach status for ${sessionName}: $($uiAttachResult.Status) ($($uiAttachResult.Reason))"
     }


### PR DESCRIPTION
## Summary
- skip visible UI attach when the orchestra session already has an attached client
- treat detected attached clients as `ui_attached=true` in `orchestra-smoke`
- cover the duplicate-attach regression in `winsmux-bridge` tests

## Validation
- `Invoke-Pester tests/winsmux-bridge.Tests.ps1 -CI`
- `Invoke-Pester tests/Integration.GateEnforcement.Tests.ps1 -CI`
- `pwsh -NoProfile -File .\scripts\audit-public-surface.ps1`
- `pwsh -NoProfile -File .\scripts\git-guard.ps1 -Mode full`
- live verification: `orchestra-attach --json` returned `attach_already_present` and kept attached client count at `1 -> 1`

Closes #426.