### PR TITLE
fix: harden startup attach and harness contracts

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -84,18 +84,21 @@ Direct operator-side mutation is **outside the standard winsmux operating model*
 When `/winsmux-start` or another restoration flow reports `needs-startup`:
 
 1. Treat that as a hard blocker, not as advisory status.
-2. Before any PR triage, merge proposal, backlog planning, or dispatch planning, run `winsmux-core/scripts/orchestra-start.ps1`.
-3. Verify readiness with `winsmux orchestra-smoke --json`.
-4. Treat `operator_contract.operator_state`, `operator_contract.can_dispatch`, and `operator_contract.requires_startup` from that smoke result as the source of truth.
-5. Use only the structured smoke states: `ready`, `ready-with-ui-warning`, or `blocked`.
-6. If the state is `ready-with-ui-warning`, run `winsmux orchestra-attach --json` once to launch a visible operator window, then continue from the live handoff without asking the user to choose a starting task.
-7. When `.claude/local/operator-handoff.md` contains an ordered `Next actions` list, start the first pending action automatically instead of asking which task to begin.
-8. Once `operator_contract.can_dispatch=true`, do not use Explore subagents for PR/task analysis. Dispatch the task through `winsmux dispatch-task "<task text>"` or `winsmux dispatch-review`.
-9. Startup/status Explore subagents are allowed only while diagnosing orchestra readiness or attach problems.
-10. Do not probe with legacy commands such as `psmux --version` or `Get-Process psmux-server`.
-11. Do not tell the user to manually start a `psmux` server.
-12. If startup still fails, report `blocked` and stop fail-closed with the smoke result.
-13. Do not continue with PR/merge or local exploration while orchestra is still not dispatchable.
+2. Before any PR triage, merge proposal, backlog planning, or dispatch planning, run `winsmux harness-check --json`.
+3. If `harness-check` fails, stop fail-closed and fix the harness contract first.
+4. Then run `winsmux-core/scripts/orchestra-start.ps1`.
+5. Verify readiness with `winsmux orchestra-smoke --json`.
+6. Treat `operator_contract.operator_state`, `operator_contract.can_dispatch`, and `operator_contract.requires_startup` from that smoke result as the source of truth.
+7. Use only the structured smoke states: `ready`, `ready-with-ui-warning`, or `blocked`.
+8. If the state is `ready-with-ui-warning`, run `winsmux orchestra-attach --json` once to launch a visible operator window, then rerun `winsmux orchestra-smoke --json`.
+9. External operator mode remains fail-closed: if `ui_attached=false`, `operator_contract.can_dispatch` must stay `false`.
+10. When `.claude/local/operator-handoff.md` contains an ordered `Next actions` list, start the first pending action automatically instead of asking which task to begin.
+11. Once `operator_contract.can_dispatch=true`, do not use Explore subagents for PR/task analysis. Dispatch the task through `winsmux dispatch-task "<task text>"` or `winsmux dispatch-review`.
+12. Startup/status Explore subagents are allowed only while diagnosing orchestra readiness or attach problems.
+13. Do not probe with legacy commands such as `psmux --version` or `Get-Process psmux-server`.
+14. Do not tell the user to manually start a `psmux` server.
+15. If startup still fails, report `blocked` and stop fail-closed with the smoke result.
+16. Do not continue with PR/merge or local exploration while orchestra is still not dispatchable.
 
 ## Compatibility and release notes
 

--- a/.claude/hooks/lib/sh-utils.js
+++ b/.claude/hooks/lib/sh-utils.js
@@ -28,15 +28,31 @@ const PLANNING_ROOT_MARKER = path.join(
   "planning-root.txt",
 );
 let cachedPlanningRoot = null;
+let cachedHookInput = null;
 
 function deny(reason) {
-  process.stdout.write(`${JSON.stringify({ decision: "deny", reason })}\n`);
-  process.exit(2);
+  const input = readHookInput();
+  if (isPreToolUseEvent(input)) {
+    const eventName = getHookEventName(input) || "PreToolUse";
+    process.stdout.write(
+      `${JSON.stringify({
+        hookSpecificOutput: {
+          hookEventName: eventName,
+          permissionDecision: "deny",
+          permissionDecisionReason: reason,
+        },
+        systemMessage: reason,
+      })}\n`,
+    );
+    process.exit(0);
+  }
+
+  failClosed(reason);
 }
 
 function allow(additionalContext) {
   if (additionalContext) {
-    process.stderr.write(
+    process.stdout.write(
       `${JSON.stringify({ hookSpecificOutput: { additionalContext } })}\n`,
     );
   }
@@ -49,7 +65,12 @@ function readStdin() {
 }
 
 function readHookInput() {
-  return readStdin();
+  if (cachedHookInput !== null) {
+    return cachedHookInput;
+  }
+
+  cachedHookInput = readStdin();
+  return cachedHookInput;
 }
 
 function sha256(data) {
@@ -57,17 +78,39 @@ function sha256(data) {
 }
 
 function allowWithUpdate(updatedInput) {
-  process.stderr.write(
+  process.stdout.write(
     `${JSON.stringify({ hookSpecificOutput: { updatedInput } })}\n`,
   );
   process.exit(0);
 }
 
 function allowWithResult(resultObj) {
-  process.stderr.write(
+  process.stdout.write(
     `${JSON.stringify({ hookSpecificOutput: { result: resultObj } })}\n`,
   );
   process.exit(0);
+}
+
+function getHookEventName(input = null) {
+  const payload = input || cachedHookInput || {};
+  return (
+    payload.hook_event_name ||
+    payload.hookEventName ||
+    payload.event_name ||
+    payload.eventName ||
+    payload.hook_name ||
+    payload.hookName ||
+    ""
+  );
+}
+
+function isPreToolUseEvent(input = null) {
+  return getHookEventName(input).toLowerCase() === "pretooluse";
+}
+
+function failClosed(message) {
+  process.stderr.write(`${String(message)}\n`);
+  process.exit(2);
 }
 
 function readSession() {
@@ -507,6 +550,9 @@ module.exports = {
   allow,
   readStdin,
   readHookInput,
+  getHookEventName,
+  isPreToolUseEvent,
+  failClosed,
   sha256,
   allowWithUpdate,
   allowWithResult,

--- a/.claude/hooks/sh-channel-detect.js
+++ b/.claude/hooks/sh-channel-detect.js
@@ -6,7 +6,7 @@
 // Always allows (exit 0) — advisory only.
 "use strict";
 
-const fs = require("fs");
+const { allow, readHookInput } = require("./lib/sh-utils");
 
 const CHANNEL_PATTERNS = [
   /\bchat_id\b/i,
@@ -16,15 +16,6 @@ const CHANNEL_PATTERNS = [
   /source\s*=\s*["']?telegram/i,
   /source\s*=\s*["']?channel/i,
 ];
-
-function readStdinPayload() {
-  try {
-    const raw = fs.readFileSync(0, "utf8").trim();
-    return raw ? JSON.parse(raw) : {};
-  } catch {
-    return {};
-  }
-}
 
 function extractText(toolInput) {
   if (!toolInput || typeof toolInput !== "object") {
@@ -54,7 +45,7 @@ function detectChannel(text) {
 }
 
 function main() {
-  const payload = readStdinPayload();
+  const payload = readHookInput();
   const toolInput = payload.tool_input ?? {};
   const text = extractText(toolInput);
 
@@ -65,11 +56,10 @@ function main() {
 
   const matchedPattern = detectChannel(text);
   if (matchedPattern) {
-    const output = JSON.stringify({
-      hookSpecificOutput: {},
-      systemMessage: "External channel input detected — verify source before processing.",
-    });
-    process.stderr.write(output + "\n");
+    allow(
+      "External channel input detected — verify source before processing.",
+    );
+    return;
   }
 
   process.exit(0);

--- a/.claude/hooks/sh-config-guard.js
+++ b/.claude/hooks/sh-config-guard.js
@@ -11,6 +11,7 @@ const {
   readHookInput,
   allow,
   deny,
+  failClosed,
   sha256,
   appendEvidence,
 } = require("./lib/sh-utils");
@@ -433,13 +434,7 @@ if (require.main === module) {
 
     allow();
   } catch (err) {
-    // SECURITY hook — fail-close (§2.3b)
-    process.stdout.write(
-      JSON.stringify({
-        reason: `[${HOOK_NAME}] Hook error (fail-close): ${err.message}`,
-      }),
-    );
-    process.exit(2);
+    failClosed(`[${HOOK_NAME}] Hook error (fail-close): ${err.message}`);
   }
 } // end require.main === module
 

--- a/.claude/hooks/sh-data-boundary.js
+++ b/.claude/hooks/sh-data-boundary.js
@@ -12,6 +12,7 @@ const {
   readHookInput,
   allow,
   deny,
+  failClosed,
   readSession,
   appendEvidence,
 } = require("./lib/sh-utils");
@@ -388,13 +389,7 @@ if (require.main === module) {
     // --- Step 4: All checks passed ---
     allow();
   } catch (err) {
-    // fail-close: any uncaught error = deny
-    process.stdout.write(
-      JSON.stringify({
-        reason: `Hook error (sh-data-boundary): ${err.message}`,
-      }),
-    );
-    process.exit(2);
+    failClosed(`Hook error (sh-data-boundary): ${err.message}`);
   }
 } // end require.main === module
 

--- a/.claude/hooks/sh-elicitation.js
+++ b/.claude/hooks/sh-elicitation.js
@@ -12,6 +12,7 @@ const {
   readHookInput,
   allow,
   deny,
+  failClosed,
   nfkcNormalize,
   appendEvidence,
   SH_DIR,
@@ -225,13 +226,7 @@ try {
 
   allow();
 } catch (err) {
-  // SECURITY hook — fail-close
-  process.stdout.write(
-    JSON.stringify({
-      reason: `[${HOOK_NAME}] Hook error (fail-close): ${err.message}`,
-    }),
-  );
-  process.exit(2);
+  failClosed(`[${HOOK_NAME}] Hook error (fail-close): ${err.message}`);
 }
 
 // ---------------------------------------------------------------------------

--- a/.claude/hooks/sh-gate.js
+++ b/.claude/hooks/sh-gate.js
@@ -13,6 +13,7 @@ const {
   normalizePath,
   appendEvidence,
   trackDeny,
+  failClosed,
 } = require("./lib/sh-utils");
 
 // ---------------------------------------------------------------------------
@@ -342,13 +343,7 @@ if (require.main === module) {
     // Step 10: All checks passed — allow
     allow();
   } catch (err) {
-    // fail-close: any uncaught error = deny (§2.3b)
-    process.stdout.write(
-      JSON.stringify({
-        reason: `Hook error (sh-gate): ${err.message}`,
-      }),
-    );
-    process.exit(2);
+    failClosed(`Hook error (sh-gate): ${err.message}`);
   }
 } // end require.main guard
 

--- a/.claude/hooks/sh-injection-guard.js
+++ b/.claude/hooks/sh-injection-guard.js
@@ -10,6 +10,7 @@ const {
   readHookInput,
   allow,
   deny,
+  failClosed,
   nfkcNormalize,
   loadPatterns,
   appendEvidence,
@@ -194,13 +195,7 @@ if (require.main === module) {
     // All patterns passed — allow
     allow();
   } catch (err) {
-    // fail-close: any uncaught error = deny
-    process.stdout.write(
-      JSON.stringify({
-        reason: `Hook error (sh-injection-guard): ${err.message}`,
-      }),
-    );
-    process.exit(2);
+    failClosed(`Hook error (sh-injection-guard): ${err.message}`);
   }
 } // end require.main guard
 

--- a/.claude/hooks/sh-invisible-char-scan.js
+++ b/.claude/hooks/sh-invisible-char-scan.js
@@ -4,6 +4,7 @@
 const fs = require("fs");
 const path = require("path");
 const { ZERO_WIDTH_RE } = require("./sh-injection-guard");
+const { allow, deny, failClosed } = require("./lib/sh-utils");
 
 const HOOK_NAME = "sh-invisible-char-scan";
 const BLOCKED_EXTENSIONS = new Set([
@@ -236,15 +237,6 @@ function buildMessage(results) {
   return lines.join("\n");
 }
 
-function writeHookMessage(message, permissionDecision) {
-  const output = { hookSpecificOutput: {} };
-  if (permissionDecision) {
-    output.hookSpecificOutput.permissionDecision = permissionDecision;
-  }
-  output.systemMessage = message;
-  process.stderr.write(JSON.stringify(output) + "\n");
-}
-
 function main() {
   const { payload, rawInput, rawTextMode } = readInputPayload();
   const targets = extractTargets(payload, rawInput, rawTextMode);
@@ -262,24 +254,18 @@ function main() {
 
   const message = buildMessage(results);
   if (results.some((result) => result.blocked)) {
-    writeHookMessage(message, "deny");
-    process.exit(2);
+    deny(message);
     return;
   }
 
-  writeHookMessage(message);
-  process.exit(0);
+  allow(message);
 }
 
 if (require.main === module) {
   try {
     main();
   } catch (error) {
-    writeHookMessage(
-      `[${HOOK_NAME}] Hook error: ${error.message}`,
-      "deny",
-    );
-    process.exit(2);
+    failClosed(`[${HOOK_NAME}] Hook error: ${error.message}`);
   }
 }
 

--- a/.claude/hooks/sh-orchestra-gate.js
+++ b/.claude/hooks/sh-orchestra-gate.js
@@ -177,7 +177,8 @@ try {
 
   process.exit(0);
 } catch (e) {
-  deny("Hook parse error: " + e.message);
+  process.stderr.write(`Hook parse error: ${e.message}\n`);
+  process.exit(2);
 }
 
 function logCommand(toolName, command) {
@@ -921,11 +922,15 @@ function resolveGitDir(repoRoot) {
 }
 
 function deny(reason) {
-  process.stderr.write(JSON.stringify({
-    hookSpecificOutput: { permissionDecision: "deny" },
+  process.stdout.write(`${JSON.stringify({
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: reason,
+    },
     systemMessage: reason,
-  }));
-  process.exit(2);
+  })}\n`);
+  process.exit(0);
 }
 
 module.exports = {

--- a/.claude/hooks/sh-permission-learn.js
+++ b/.claude/hooks/sh-permission-learn.js
@@ -11,6 +11,7 @@ const {
   readHookInput,
   allow,
   deny,
+  failClosed,
   appendEvidence,
 } = require("./lib/sh-utils");
 
@@ -207,13 +208,7 @@ try {
 
   allow();
 } catch (err) {
-  // SECURITY hook — fail-close
-  process.stdout.write(
-    JSON.stringify({
-      reason: `[${HOOK_NAME}] Hook error (fail-close): ${err.message}`,
-    }),
-  );
-  process.exit(2);
+  failClosed(`[${HOOK_NAME}] Hook error (fail-close): ${err.message}`);
 }
 
 // ---------------------------------------------------------------------------

--- a/.claude/hooks/sh-permission.js
+++ b/.claude/hooks/sh-permission.js
@@ -6,7 +6,7 @@
 // Target response time: < 50ms
 "use strict";
 
-const { readHookInput, allow, deny } = require("./lib/sh-utils");
+const { readHookInput, allow, deny, failClosed } = require("./lib/sh-utils");
 
 // ---------------------------------------------------------------------------
 // Category Constants
@@ -149,11 +149,5 @@ try {
       break;
   }
 } catch (err) {
-  // fail-close: any uncaught error = deny
-  process.stdout.write(
-    JSON.stringify({
-      reason: `Hook error (sh-permission): ${err.message}`,
-    }),
-  );
-  process.exit(2);
+  failClosed(`Hook error (sh-permission): ${err.message}`);
 }

--- a/.claude/hooks/sh-subagent.js
+++ b/.claude/hooks/sh-subagent.js
@@ -9,6 +9,7 @@ const {
   readHookInput,
   allow,
   deny,
+  failClosed,
   readSession,
   appendEvidence,
 } = require("./lib/sh-utils");
@@ -72,13 +73,7 @@ try {
 
   allow(constraints);
 } catch (err) {
-  // SECURITY hook — fail-close
-  process.stdout.write(
-    JSON.stringify({
-      reason: `[${HOOK_NAME}] Hook error (fail-close): ${err.message}`,
-    }),
-  );
-  process.exit(2);
+  failClosed(`[${HOOK_NAME}] Hook error (fail-close): ${err.message}`);
 }
 
 // ---------------------------------------------------------------------------

--- a/.claude/hooks/sh-user-prompt.js
+++ b/.claude/hooks/sh-user-prompt.js
@@ -6,6 +6,7 @@ const {
   allow,
   loadPatterns,
   nfkcNormalize,
+  failClosed,
 } = require("./lib/sh-utils");
 
 const SEVERITY_ORDER = ["low", "medium", "high", "critical"];
@@ -97,11 +98,6 @@ function resolveSeverity(baseSeverity, promptContext) {
   return boostSeverity(baseSeverity, boostCount);
 }
 
-function writeDeny(decision) {
-  process.stdout.write(`${JSON.stringify(decision)}\n`);
-  process.exit(2);
-}
-
 function main() {
   const input = readHookInput();
   const toolName = input.tool_name || input.toolName || "";
@@ -133,14 +129,9 @@ function main() {
   }
 
   if (matchedDecision && toSeverityIndex(matchedDecision.severity) >= toSeverityIndex("high")) {
-    writeDeny({
-      decision: "deny",
-      result: "deny",
-      reason: "Injection pattern detected",
-      category: matchedDecision.category,
-      pattern: matchedDecision.pattern,
-      severity: matchedDecision.severity,
-    });
+    failClosed(
+      `Injection pattern detected (${matchedDecision.category}, severity: ${matchedDecision.severity})`,
+    );
     return;
   }
 
@@ -150,8 +141,8 @@ function main() {
 if (require.main === module) {
   try {
     main();
-  } catch {
-    allow();
+  } catch (error) {
+    failClosed(`[sh-user-prompt] Hook error (fail-close): ${error.message}`);
   }
 }
 
@@ -165,5 +156,4 @@ module.exports = {
   flattenPatterns,
   detectPromptContext,
   resolveSeverity,
-  writeDeny,
 };

--- a/.claude/rules/dispatch.md
+++ b/.claude/rules/dispatch.md
@@ -6,20 +6,23 @@ paths: ["winsmux-core/scripts/**", ".claude/**"]
 
 ## Orchestra restore preflight
 1. If restoration state is `needs-startup`, do not triage PRs, plan merges, read backlog, or dispatch work yet.
-2. First run `pwsh -NoProfile -File winsmux-core/scripts/orchestra-start.ps1`.
-3. Then run `pwsh -NoProfile -File scripts/winsmux-core.ps1 orchestra-smoke --json`.
-4. Verify `operator_contract.operator_state`, `operator_contract.can_dispatch`, and `operator_contract.requires_startup` from the smoke JSON before any PR triage, merge action, backlog reading, or task dispatch.
-5. Allowed dispatchable states are:
+2. First run `pwsh -NoProfile -File scripts/winsmux-core.ps1 harness-check --json`.
+3. If `harness-check` fails, stop and repair the harness contract before startup.
+4. Then run `pwsh -NoProfile -File winsmux-core/scripts/orchestra-start.ps1`.
+5. Then run `pwsh -NoProfile -File scripts/winsmux-core.ps1 orchestra-smoke --json`.
+6. Verify `operator_contract.operator_state`, `operator_contract.can_dispatch`, and `operator_contract.requires_startup` from the smoke JSON before any PR triage, merge action, backlog reading, or task dispatch.
+7. Allowed dispatchable states are:
    - `ready`
    - `ready-with-ui-warning`
    Any other state is fail-closed.
-6. If the state is `ready-with-ui-warning`, run `pwsh -NoProfile -File scripts/winsmux-core.ps1 orchestra-attach --json` once, then continue from the first pending `Next actions` item in `.claude/local/operator-handoff.md`.
-7. Never ask the user which task to begin when the live handoff already lists ordered next actions.
-8. Once `operator_contract.can_dispatch=true`, do not use Explore subagents for PR/task analysis. Use `pwsh -NoProfile -File scripts/winsmux-core.ps1 dispatch-task "<task text>"` or `dispatch-review`.
-9. Explore subagents are reserved for orchestra startup/status diagnosis only.
-10. Never use `psmux --version`, `Get-Process psmux-server`, or similar legacy probe commands for operator-side startup diagnosis.
-11. If pane expansion does not succeed, treat the session as `blocked` and report the smoke/startup failure.
-12. Do not plan merge work while the orchestra session is still not dispatchable.
+8. If the state is `ready-with-ui-warning`, run `pwsh -NoProfile -File scripts/winsmux-core.ps1 orchestra-attach --json` once, rerun `orchestra-smoke --json`, and continue only after `operator_contract.can_dispatch=true`.
+9. External operator mode is fail-closed: visible attach unconfirmed means no dispatch.
+10. Never ask the user which task to begin when the live handoff already lists ordered next actions.
+11. Once `operator_contract.can_dispatch=true`, do not use Explore subagents for PR/task analysis. Use `pwsh -NoProfile -File scripts/winsmux-core.ps1 dispatch-task "<task text>"` or `dispatch-review`.
+12. Explore subagents are reserved for orchestra startup/status diagnosis only.
+13. Never use `psmux --version`, `Get-Process psmux-server`, or similar legacy probe commands for operator-side startup diagnosis.
+14. If pane expansion or attach confirmation does not succeed, treat the session as `blocked` and report the smoke/startup failure.
+15. Do not plan merge work while the orchestra session is still not dispatchable.
 
 ## Builder Dispatch
 1. Check pane state: `winsmux capture-pane -t <pane> -p | tail -5`

--- a/.githooks/pre-commit-whitelist.ps1
+++ b/.githooks/pre-commit-whitelist.ps1
@@ -27,6 +27,7 @@ $whitelistPatterns = @(
     'scripts/audit-public-surface.ps1',
     '.githooks/**',
     'tests/PublicSurfacePolicy.Tests.ps1',
+    'tests/HarnessContract.Tests.ps1',
     'winsmux-core/**',
     '.claude/CLAUDE.md',
     '.claude/hooks/**',

--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ tests/*
 !tests/Integration.PaneMonitorHook.Tests.ps1
 !tests/BuilderWorktree.Tests.ps1
 !tests/PublicSurfacePolicy.Tests.ps1
+!tests/HarnessContract.Tests.ps1
 !tests/README.md
 /hooks/
 .worktrees/

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -6389,6 +6389,7 @@ promote-tactic <run_id> [--title <text>] [--kind <playbook|prewarm|verification>
   builder-queue <action> [args]  Manage Builder queue and auto-dispatch next work
   orchestra-smoke [--json] [--auto-start] [--project-dir <path>]  Report structured startup contract + UI attach state (use --auto-start to start if needed)
   orchestra-attach [--json] [--project-dir <path>]  Launch a visible attach window for an existing orchestra session
+  harness-check [--json] [--project-dir <path>]  Validate hook/settings/attach contracts before external-operator startup
   vault set <key> [value]   Store a credential securely (DPAPI)
   vault get <key>           Retrieve a stored credential
   vault inject <pane>       Inject all credentials as env vars into a pane
@@ -6762,6 +6763,30 @@ switch ($Command) {
             }
         }
         & pwsh -NoProfile -File $attachScript @attachArgs
+    }
+    'harness-check' {
+        $checkScript = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\winsmux-core\scripts\harness-check.ps1'))
+        $checkArgs = @()
+        $remaining = @(@($Target) + @($Rest) | Where-Object { $_ })
+        for ($index = 0; $index -lt $remaining.Count; $index++) {
+            switch ($remaining[$index]) {
+                '--json' {
+                    $checkArgs += '-AsJson'
+                }
+                '--project-dir' {
+                    if ($index + 1 -ge $remaining.Count) {
+                        Stop-WithError "usage: winsmux harness-check [--json] [--project-dir <path>]"
+                    }
+
+                    $checkArgs += @('-ProjectDir', $remaining[$index + 1])
+                    $index++
+                }
+                default {
+                    Stop-WithError "usage: winsmux harness-check [--json] [--project-dir <path>]"
+                }
+            }
+        }
+        & pwsh -NoProfile -File $checkScript @checkArgs
     }
     'vault'           {
         switch ($Target) {

--- a/tests/HarnessContract.Tests.ps1
+++ b/tests/HarnessContract.Tests.ps1
@@ -1,0 +1,142 @@
+$ErrorActionPreference = 'Stop'
+
+Describe 'harness-check contract' {
+    BeforeAll {
+        $script:RepoRoot = Split-Path -Parent $PSScriptRoot
+        $script:HarnessCheckPath = Join-Path $script:RepoRoot 'winsmux-core\scripts\harness-check.ps1'
+        $script:WinsmuxCorePath = Join-Path $script:RepoRoot 'scripts\winsmux-core.ps1'
+        $script:SettingsLocalPath = Join-Path $script:RepoRoot '.claude\settings.local.json'
+
+        $pwshCommand = Get-Command pwsh -ErrorAction SilentlyContinue | Select-Object -First 1
+        if ($null -eq $pwshCommand) {
+            throw 'pwsh was not found in PATH.'
+        }
+
+        $script:PwshPath = if ($pwshCommand.Path) { $pwshCommand.Path } else { $pwshCommand.Name }
+
+        function Write-TestFileWithCmd {
+            param(
+                [Parameter(Mandatory = $true)][string]$Path,
+                [Parameter(Mandatory = $true)][string]$Content
+            )
+
+            $parent = Split-Path -Parent $Path
+            if (-not (Test-Path -LiteralPath $parent -PathType Container)) {
+                New-Item -ItemType Directory -Path $parent -Force | Out-Null
+            }
+
+            $escapedPath = $Path -replace '"', '""'
+            $Content | cmd /d /c ('more > "{0}"' -f $escapedPath) | Out-Null
+            if ($LASTEXITCODE -ne 0) {
+                throw "cmd.exe failed to write $Path"
+            }
+        }
+
+        function Remove-TestSettingsLocal {
+            if (Test-Path -LiteralPath $script:SettingsLocalPath -PathType Leaf) {
+                Remove-Item -LiteralPath $script:SettingsLocalPath -Force
+            }
+
+            & git -C $script:RepoRoot rm --cached --force --quiet -- '.claude/settings.local.json' 2>$null
+            $null = $LASTEXITCODE
+        }
+
+        function Invoke-HarnessCheckJson {
+            param([string[]]$Arguments)
+
+            $startInfo = [System.Diagnostics.ProcessStartInfo]::new()
+            $startInfo.FileName = $script:PwshPath
+            $startInfo.ArgumentList.Add('-NoProfile')
+            $startInfo.ArgumentList.Add('-File')
+            $startInfo.ArgumentList.Add($script:HarnessCheckPath)
+            foreach ($argument in $Arguments) {
+                $startInfo.ArgumentList.Add($argument)
+            }
+            $startInfo.WorkingDirectory = $script:RepoRoot
+            $startInfo.UseShellExecute = $false
+            $startInfo.CreateNoWindow = $true
+            $startInfo.RedirectStandardOutput = $true
+            $startInfo.RedirectStandardError = $true
+
+            $process = [System.Diagnostics.Process]::Start($startInfo)
+            try {
+                $stdout = $process.StandardOutput.ReadToEnd()
+                $stderr = $process.StandardError.ReadToEnd()
+                $process.WaitForExit()
+                $exitCode = $process.ExitCode
+            } finally {
+                $process.Dispose()
+            }
+
+            $trimmedStdout = $stdout.Trim()
+            $parsed = $null
+            if (-not [string]::IsNullOrWhiteSpace($trimmedStdout)) {
+                $parsed = $trimmedStdout | ConvertFrom-Json -Depth 16
+            }
+
+            [PSCustomObject]@{
+                ExitCode = $exitCode
+                StdOut   = $trimmedStdout
+                StdErr   = $stderr.Trim()
+                Json     = $parsed
+            }
+        }
+    }
+
+    BeforeEach {
+        Remove-TestSettingsLocal
+    }
+
+    AfterEach {
+        Remove-TestSettingsLocal
+    }
+
+    AfterAll {
+        Remove-TestSettingsLocal
+    }
+
+    It 'passes against the current repository contract' {
+        $result = Invoke-HarnessCheckJson -Arguments @('-ProjectDir', $script:RepoRoot, '-AsJson')
+
+        $result.ExitCode | Should -Be 0
+        $result.Json.passed | Should -Be $true
+        ($result.Json.results | Where-Object { -not $_.passed }).Count | Should -Be 0
+    }
+
+    It 'fails when settings.local.json registers hooks' {
+        Write-TestFileWithCmd -Path $script:SettingsLocalPath -Content '{"hooks":{"PreToolUse":[]}}'
+
+        $result = Invoke-HarnessCheckJson -Arguments @('-ProjectDir', $script:RepoRoot, '-AsJson')
+        $settingsLocalRecord = $result.Json.results | Where-Object { $_.name -eq 'settings-local-has-no-hooks' } | Select-Object -First 1
+
+        $result.ExitCode | Should -Be 1
+        $result.Json.passed | Should -Be $false
+        $settingsLocalRecord.passed | Should -Be $false
+        $settingsLocalRecord.message | Should -Match 'must not register hooks'
+    }
+
+    It 'fails when settings.local.json becomes tracked' {
+        Write-TestFileWithCmd -Path $script:SettingsLocalPath -Content '{}'
+        & git -C $script:RepoRoot add -f -- '.claude/settings.local.json'
+        if ($LASTEXITCODE -ne 0) {
+            throw 'git add failed for .claude/settings.local.json'
+        }
+
+        $result = Invoke-HarnessCheckJson -Arguments @('-ProjectDir', $script:RepoRoot, '-AsJson')
+        $trackedRecord = $result.Json.results | Where-Object { $_.name -eq 'settings-local-not-tracked' } | Select-Object -First 1
+
+        $result.ExitCode | Should -Be 1
+        $result.Json.passed | Should -Be $false
+        $trackedRecord.passed | Should -Be $false
+        $trackedRecord.message | Should -Match 'must stay untracked'
+    }
+
+    It 'is exposed through winsmux-core as harness-check --json' {
+        $stdout = & $script:PwshPath -NoProfile -File $script:WinsmuxCorePath harness-check --json 2>&1
+        $exitCode = $LASTEXITCODE
+        $json = (($stdout | Out-String).Trim() | ConvertFrom-Json -Depth 16)
+
+        $exitCode | Should -Be 0
+        $json.passed | Should -Be $true
+    }
+}

--- a/tests/Integration.GateEnforcement.Tests.ps1
+++ b/tests/Integration.GateEnforcement.Tests.ps1
@@ -89,19 +89,26 @@ Describe 'sh-orchestra-gate integration' {
             }
 
             $stderrTrimmed = $stderr.Trim()
-            $parsedError = $null
-            if (-not [string]::IsNullOrWhiteSpace($stderrTrimmed)) {
+            $stdoutTrimmed = $stdout.Trim()
+            $parsedOutput = $null
+            if (-not [string]::IsNullOrWhiteSpace($stdoutTrimmed)) {
                 try {
-                    $parsedError = $stderrTrimmed | ConvertFrom-Json -ErrorAction Stop
+                    $parsedOutput = $stdoutTrimmed | ConvertFrom-Json -ErrorAction Stop
+                } catch {
+                }
+            }
+            if ($null -eq $parsedOutput -and -not [string]::IsNullOrWhiteSpace($stderrTrimmed)) {
+                try {
+                    $parsedOutput = $stderrTrimmed | ConvertFrom-Json -ErrorAction Stop
                 } catch {
                 }
             }
 
             return [PSCustomObject]@{
                 ExitCode    = $exitCode
-                StdOut      = $stdout.Trim()
+                StdOut      = $stdoutTrimmed
                 StdErr      = $stderrTrimmed
-                ErrorObject = $parsedError
+                OutputObject = $parsedOutput
             }
         }
 
@@ -153,10 +160,9 @@ Describe 'sh-orchestra-gate integration' {
         $script:AssertDenyResult = {
             param([Parameter(Mandatory = $true)]$Result)
 
-            $Result.ExitCode | Should -Be 2
-            $Result.StdErr | Should -Not -BeNullOrEmpty
-            $Result.ErrorObject | Should -Not -BeNullOrEmpty
-            $Result.ErrorObject.hookSpecificOutput.permissionDecision | Should -Be 'deny'
+            $Result.ExitCode | Should -Be 0
+            $Result.OutputObject | Should -Not -BeNullOrEmpty
+            $Result.OutputObject.hookSpecificOutput.permissionDecision | Should -Be 'deny'
         }
 
         function New-GateFixture {
@@ -250,7 +256,7 @@ panes:
         })
 
         & $script:AssertDenyResult -Result $result
-        $result.ErrorObject.systemMessage | Should -Match 'review-state\.json'
+        $result.OutputObject.systemMessage | Should -Match 'review-state\.json'
     }
 
     It 'denies direct winsmux send-keys usage' {
@@ -267,7 +273,7 @@ panes:
         })
 
         & $script:AssertDenyResult -Result $result
-        $result.ErrorObject.systemMessage | Should -Match 'settings\.local\.json'
+        $result.OutputObject.systemMessage | Should -Match 'settings\.local\.json'
     }
 
     It 'denies direct codex exec usage' {
@@ -276,7 +282,7 @@ panes:
         }
 
         & $script:AssertDenyResult -Result $result
-        $result.ErrorObject.systemMessage | Should -Be 'Use winsmux send to dispatch Codex to panes'
+        $result.OutputObject.systemMessage | Should -Be 'Use winsmux send to dispatch Codex to panes'
     }
 
     It 'denies direct codex sandbox usage' {
@@ -285,7 +291,7 @@ panes:
         })
 
         & $script:AssertDenyResult -Result $result
-        $result.ErrorObject.systemMessage | Should -Be 'Use winsmux send to dispatch Codex to panes'
+        $result.OutputObject.systemMessage | Should -Be 'Use winsmux send to dispatch Codex to panes'
     }
 
     It 'allows winsmux send codex exec usage' {
@@ -341,7 +347,7 @@ EOF
         })
 
         & $script:AssertDenyResult -Result $result
-        $result.ErrorObject.systemMessage | Should -Match 'review-state\.json'
+        $result.OutputObject.systemMessage | Should -Match 'review-state\.json'
     }
 
     It 'allows Bash reads from review-state.json' {
@@ -361,7 +367,7 @@ EOF
         })
 
         & $script:AssertDenyResult -Result $result
-        $result.ErrorObject.systemMessage | Should -Match 'review-capable pane'
+        $result.OutputObject.systemMessage | Should -Match 'review-capable pane'
     }
 
     It 'allows review-approve when WINSMUX_ROLE is Reviewer' {
@@ -416,7 +422,7 @@ EOF
         })
 
         & $script:AssertDenyResult -Result $result
-        $result.ErrorObject.systemMessage | Should -Match 'Operator shell write bypass blocked'
+        $result.OutputObject.systemMessage | Should -Match 'Operator shell write bypass blocked'
     }
 
     It 'denies cmd /c writing a code file from the operator pane' {
@@ -427,7 +433,7 @@ EOF
         })
 
         & $script:AssertDenyResult -Result $result
-        $result.ErrorObject.systemMessage | Should -Match 'Operator shell write bypass blocked'
+        $result.OutputObject.systemMessage | Should -Match 'Operator shell write bypass blocked'
     }
 
     It 'denies python -c writing a code file from the operator pane' {
@@ -438,7 +444,7 @@ EOF
         })
 
         & $script:AssertDenyResult -Result $result
-        $result.ErrorObject.systemMessage | Should -Match 'Operator shell write bypass blocked'
+        $result.OutputObject.systemMessage | Should -Match 'Operator shell write bypass blocked'
     }
 
     It 'denies Agent acceptEdits mode' {
@@ -447,7 +453,7 @@ EOF
         })
 
         & $script:AssertDenyResult -Result $result
-        $result.ErrorObject.systemMessage | Should -Match 'delegated execution bypass blocked'
+        $result.OutputObject.systemMessage | Should -Match 'delegated execution bypass blocked'
     }
 
     It 'denies Agent auto mode outside worktree isolation' {
@@ -499,7 +505,7 @@ EOF
         })
 
         & $script:AssertDenyResult -Result $result
-        $result.ErrorObject.systemMessage | Should -Match 'dispatch-task'
+        $result.OutputObject.systemMessage | Should -Match 'dispatch-task'
     }
 
     It 'allows startup-diagnosis Explore subagents' {
@@ -557,7 +563,7 @@ EOF
         })
 
         & $script:AssertDenyResult -Result $result
-        $result.ErrorObject.systemMessage | Should -Match 'winsmux orchestra-smoke --json'
+        $result.OutputObject.systemMessage | Should -Match 'winsmux orchestra-smoke --json'
     }
 
     It 'denies legacy psmux-server process probes from the operator pane' {
@@ -568,7 +574,7 @@ EOF
         })
 
         & $script:AssertDenyResult -Result $result
-        $result.ErrorObject.systemMessage | Should -Match 'winsmux list-sessions'
+        $result.OutputObject.systemMessage | Should -Match 'winsmux list-sessions'
     }
 
     It 'allows winsmux orchestra-smoke from the operator pane' {
@@ -609,8 +615,8 @@ EOF
         }
 
         & $script:AssertDenyResult -Result $result
-        $result.ErrorObject.systemMessage | Should -Match 'review-request'
-        $result.ErrorObject.systemMessage | Should -Match 'review-approve'
+        $result.OutputObject.systemMessage | Should -Match 'review-request'
+        $result.OutputObject.systemMessage | Should -Match 'review-approve'
     }
 
     It 'denies git merge without Reviewer PASS for the current branch' {
@@ -622,8 +628,8 @@ EOF
         }
 
         & $script:AssertDenyResult -Result $result
-        $result.ErrorObject.systemMessage | Should -Match 'review-approve'
-        $result.ErrorObject.systemMessage | Should -Match 'review-request'
+        $result.OutputObject.systemMessage | Should -Match 'review-approve'
+        $result.OutputObject.systemMessage | Should -Match 'review-request'
     }
 
     It 'denies gh pr merge without Reviewer PASS for the current branch' {
@@ -635,8 +641,8 @@ EOF
         }
 
         & $script:AssertDenyResult -Result $result
-        $result.ErrorObject.systemMessage | Should -Match 'review-approve'
-        $result.ErrorObject.systemMessage | Should -Match 'review-request'
+        $result.OutputObject.systemMessage | Should -Match 'review-approve'
+        $result.OutputObject.systemMessage | Should -Match 'review-request'
     }
 
     It 'denies git commit when PASS head_sha does not match current HEAD' {
@@ -664,8 +670,8 @@ EOF
         })
 
         & $script:AssertDenyResult -Result $result
-        $result.ErrorObject.systemMessage | Should -Match 'review-approve'
-        $result.ErrorObject.systemMessage | Should -Match 'review-request'
+        $result.OutputObject.systemMessage | Should -Match 'review-approve'
+        $result.OutputObject.systemMessage | Should -Match 'review-request'
     }
 
     It 'denies git commit when reviewer role is not review-capable' {
@@ -693,7 +699,7 @@ EOF
         })
 
         & $script:AssertDenyResult -Result $result
-        $result.ErrorObject.systemMessage | Should -Match 'review-approve'
+        $result.OutputObject.systemMessage | Should -Match 'review-approve'
     }
 
     It 'denies git commit when reviewer pane_id is empty' {
@@ -721,7 +727,7 @@ EOF
         })
 
         & $script:AssertDenyResult -Result $result
-        $result.ErrorObject.systemMessage | Should -Match 'review-approve'
+        $result.OutputObject.systemMessage | Should -Match 'review-approve'
     }
 
     It 'allows git commit after review-approve records PASS for the current branch' {

--- a/tests/Integration.PaneMonitorHook.Tests.ps1
+++ b/tests/Integration.PaneMonitorHook.Tests.ps1
@@ -40,20 +40,27 @@ Describe 'sh-pane-monitor integration' {
                 $stderr = $process.StandardError.ReadToEnd()
                 $process.WaitForExit()
 
+                $stdoutTrimmed = $stdout.Trim()
                 $stderrTrimmed = $stderr.Trim()
-                $parsedError = $null
-                if (-not [string]::IsNullOrWhiteSpace($stderrTrimmed)) {
+                $parsedOutput = $null
+                if (-not [string]::IsNullOrWhiteSpace($stdoutTrimmed)) {
                     try {
-                        $parsedError = $stderrTrimmed | ConvertFrom-Json -ErrorAction Stop
+                        $parsedOutput = $stdoutTrimmed | ConvertFrom-Json -ErrorAction Stop
+                    } catch {
+                    }
+                }
+                if ($null -eq $parsedOutput -and -not [string]::IsNullOrWhiteSpace($stderrTrimmed)) {
+                    try {
+                        $parsedOutput = $stderrTrimmed | ConvertFrom-Json -ErrorAction Stop
                     } catch {
                     }
                 }
 
                 return [ordered]@{
                     ExitCode    = $process.ExitCode
-                    StdOut      = $stdout.Trim()
+                    StdOut      = $stdoutTrimmed
                     StdErr      = $stderrTrimmed
-                    ErrorObject = $parsedError
+                    OutputObject = $parsedOutput
                 }
             } finally {
                 $process.Dispose()
@@ -136,8 +143,8 @@ session:
         })
 
         $result['ExitCode'] | Should -Be 0
-        $result['ErrorObject'] | Should -Not -BeNullOrEmpty
-        $context = [string]$result['ErrorObject'].hookSpecificOutput.additionalContext
+        $result['OutputObject'] | Should -Not -BeNullOrEmpty
+        $context = [string]$result['OutputObject'].hookSpecificOutput.additionalContext
         $context | Should -Match '\[PANE ALERT\] builder-1 completed'
         $context | Should -Match '\[PANE ALERT\] reviewer crashed'
         $context | Should -Match '\[PANE ALERT\] approver awaiting approval'
@@ -161,7 +168,7 @@ session:
 
         $second['ExitCode'] | Should -Be 0
         $second['StdErr'] | Should -Be ''
-        $second['ErrorObject'] | Should -Be $null
+        $second['OutputObject'] | Should -Be $null
     }
 
     It 'persists the cursor and only reports newly appended events' {
@@ -173,14 +180,14 @@ session:
 
         $first = Invoke-PaneMonitorHook -RepoRoot $fixture.RepoRoot -Payload (New-PaneMonitorPayload -ToolName 'Read' -ToolInput ([ordered]@{ file_path = 'docs\handoff.md' }))
         $first['ExitCode'] | Should -Be 0
-        ([string]$first['ErrorObject'].hookSpecificOutput.additionalContext) | Should -Match '\[PANE ALERT\] builder-1 completed'
+        ([string]$first['OutputObject'].hookSpecificOutput.additionalContext) | Should -Match '\[PANE ALERT\] builder-1 completed'
 
         Add-Content -Path $fixture.EventsPath -Value ([ordered]@{ event = 'pane.crashed'; label = 'reviewer'; pane_id = '%4' } | ConvertTo-Json -Compress) -Encoding UTF8
 
         $second = Invoke-PaneMonitorHook -RepoRoot $fixture.RepoRoot -Payload (New-PaneMonitorPayload -ToolName 'Read' -ToolInput ([ordered]@{ file_path = 'docs\handoff.md' }))
 
         $second['ExitCode'] | Should -Be 0
-        $context = [string]$second['ErrorObject'].hookSpecificOutput.additionalContext
+        $context = [string]$second['OutputObject'].hookSpecificOutput.additionalContext
         $context | Should -Match '\[PANE ALERT\] reviewer crashed'
         $context | Should -Not -Match '\[PANE ALERT\] builder-1 completed'
 
@@ -201,14 +208,14 @@ session:
 
         $sessionOneFirst['ExitCode'] | Should -Be 0
         $sessionTwoFirst['ExitCode'] | Should -Be 0
-        ([string]$sessionOneFirst['ErrorObject'].hookSpecificOutput.additionalContext) | Should -Match '\[PANE ALERT\] builder-1 completed'
-        ([string]$sessionTwoFirst['ErrorObject'].hookSpecificOutput.additionalContext) | Should -Match '\[PANE ALERT\] builder-1 completed'
+        ([string]$sessionOneFirst['OutputObject'].hookSpecificOutput.additionalContext) | Should -Match '\[PANE ALERT\] builder-1 completed'
+        ([string]$sessionTwoFirst['OutputObject'].hookSpecificOutput.additionalContext) | Should -Match '\[PANE ALERT\] builder-1 completed'
 
         $sessionOneSecond = Invoke-PaneMonitorHook -RepoRoot $fixture.RepoRoot -Payload (New-PaneMonitorPayload -ToolName 'Read' -ToolInput ([ordered]@{ file_path = 'docs\handoff.md' }) -SessionId 'session-1')
         $sessionTwoSecond = Invoke-PaneMonitorHook -RepoRoot $fixture.RepoRoot -Payload (New-PaneMonitorPayload -ToolName 'Read' -ToolInput ([ordered]@{ file_path = 'docs\handoff.md' }) -SessionId 'session-2')
 
-        $sessionOneSecond['ErrorObject'] | Should -Be $null
-        $sessionTwoSecond['ErrorObject'] | Should -Be $null
+        $sessionOneSecond['OutputObject'] | Should -Be $null
+        $sessionTwoSecond['OutputObject'] | Should -Be $null
         Test-Path (Join-Path $fixture.WinsmuxDir 'monitor-cursor-session-1.txt') | Should -BeTrue
         Test-Path (Join-Path $fixture.WinsmuxDir 'monitor-cursor-session-2.txt') | Should -BeTrue
     }

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -2804,6 +2804,7 @@ Describe 'orchestra-start server bootstrap' {
 
     It 'launches visible attach through a fixed Windows Terminal profile and handshake' {
         $script:startProcessCalls = @()
+        $script:winsmuxBin = 'C:\winsmux\winsmux.exe'
 
         Mock Get-OrchestraAttachedClientSnapshot {
             [PSCustomObject]@{ Ok = $true; Count = 0; Error = ''; Clients = @() }
@@ -2871,6 +2872,7 @@ Describe 'orchestra-start server bootstrap' {
 
     It 'returns attach_already_present when a visible client already exists' {
         $script:startProcessCalls = @()
+        $script:winsmuxBin = 'C:\winsmux\winsmux.exe'
 
         Mock Get-OrchestraAttachedClientSnapshot {
             [PSCustomObject]@{ Ok = $true; Count = 1; Error = ''; Clients = @('client-1') }
@@ -2899,6 +2901,7 @@ Describe 'orchestra-start server bootstrap' {
     }
 
     It 'fails closed when Windows Terminal is unavailable instead of falling back to dynamic attach commands' {
+        $script:winsmuxBin = 'C:\winsmux\winsmux.exe'
         Mock Get-OrchestraAttachedClientSnapshot {
             [PSCustomObject]@{ Ok = $true; Count = 0; Error = ''; Clients = @() }
         }

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -2802,27 +2802,41 @@ Describe 'orchestra-start server bootstrap' {
         $script:probeCount | Should -Be 2
     }
 
-    It 'launches a best-effort UI attach with a real Windows Terminal path' {
+    It 'launches visible attach through a fixed Windows Terminal profile and handshake' {
         $script:startProcessCalls = @()
 
-        function Get-Command {
-            param([string]$Name)
-            if ($Name -eq 'wt.exe') {
-                return [PSCustomObject]@{ Source = 'C:\Windows\System32\wt.exe' }
-            }
-            if ($Name -eq 'pwsh') {
-                return [PSCustomObject]@{ Source = 'C:\Program Files\PowerShell\7\pwsh.exe' }
-            }
-            if ($Name -eq 'winsmux') {
-                return [PSCustomObject]@{ Source = 'C:\Users\komei\.local\bin\winsmux.exe' }
-            }
-
-            throw "unexpected command lookup: $Name"
+        Mock Get-OrchestraAttachedClientSnapshot {
+            [PSCustomObject]@{ Ok = $true; Count = 0; Error = ''; Clients = @() }
         }
-
-        function Get-Item {
-            param([string]$LiteralPath)
-            return [PSCustomObject]@{ Length = 4096 }
+        Mock Get-OrchestraWindowsTerminalInfo {
+            [PSCustomObject][ordered]@{
+                Available   = $true
+                Path        = 'C:\Windows\System32\wt.exe'
+                AliasPath   = ''
+                IsAliasStub = $false
+                PathSource  = 'command'
+                Reason      = 'ready'
+            }
+        }
+        Mock Ensure-OrchestraAttachProfile {
+            [PSCustomObject][ordered]@{
+                ProfileName  = 'winsmux orchestra attach'
+                FragmentPath = 'C:\Users\komei\AppData\Local\Microsoft\Windows Terminal\Fragments\winsmux\winsmux-orchestra-attach.json'
+                Commandline  = '"C:\Program Files\PowerShell\7\pwsh.exe" -NoLogo -NoExit -File "C:\repo\winsmux-core\scripts\orchestra-attach-entry.ps1"'
+            }
+        }
+        Mock Write-OrchestraAttachState {
+            [pscustomobject]@{}
+        }
+        Mock Wait-OrchestraAttachHandshake {
+            [PSCustomObject][ordered]@{
+                Confirmed           = $true
+                Source              = 'handshake'
+                Status              = 'attach_confirmed'
+                Reason              = 'Attach confirmed'
+                AttachedClientCount = 1
+                State               = [pscustomobject]@{}
+            }
         }
 
         function Start-Process {
@@ -2847,111 +2861,22 @@ Describe 'orchestra-start server bootstrap' {
 
         $result.Attempted | Should -Be $true
         $result.Launched | Should -Be $true
-        $result.Attached | Should -Be $false
-        $result.Status | Should -Be 'attach_exited_early'
-        $result.PSObject.Properties.Name | Should -Contain 'FallbackFrom'
-        $result.FallbackFrom | Should -Be 'attach_exited_early'
-        $script:startProcessCalls.Count | Should -Be 2
-        $script:startProcessCalls[0].FilePath | Should -Be 'C:\Program Files\PowerShell\7\pwsh.exe'
-        $script:startProcessCalls[0].ArgumentList | Should -Be @(
-            '-NoProfile', '-NoExit', '-File', ([System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\winsmux-core\scripts\orchestra-bootstrap.ps1'))), '-SessionName', 'winsmux-orchestra', '-WinsmuxPath', 'C:\Users\komei\.local\bin\winsmux.exe', '-AttachOnly'
-        )
-        $script:startProcessCalls[1].FilePath | Should -Be 'C:\Windows\System32\wt.exe'
-        $script:startProcessCalls[1].ArgumentList | Should -Be @(
-            '--size', '200,70',
-            'new-tab',
-            '--title', 'winsmux-orchestra',
-            '--',
-            'C:\Program Files\PowerShell\7\pwsh.exe', '-NoProfile', '-NoExit', '-File', ([System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\winsmux-core\scripts\orchestra-bootstrap.ps1'))), '-SessionName', 'winsmux-orchestra', '-WinsmuxPath', 'C:\Users\komei\.local\bin\winsmux.exe', '-AttachOnly'
-        )
-    }
-
-    It 'keeps ui_attached false while marking attach_launched when the attach child survives the early-failure window' {
-        $script:startProcessCalls = @()
-
-        function Get-Command {
-            param([string]$Name)
-            if ($Name -eq 'wt.exe') {
-                return [PSCustomObject]@{ Source = 'C:\Windows\System32\wt.exe' }
-            }
-            if ($Name -eq 'pwsh') {
-                return [PSCustomObject]@{ Source = 'C:\Program Files\PowerShell\7\pwsh.exe' }
-            }
-            if ($Name -eq 'winsmux') {
-                return [PSCustomObject]@{ Source = 'C:\Users\komei\.local\bin\winsmux.exe' }
-            }
-
-            throw "unexpected command lookup: $Name"
-        }
-
-        function Get-Item {
-            param([string]$LiteralPath)
-            return [PSCustomObject]@{ Length = 4096 }
-        }
-
-        function Start-Process {
-            param(
-                [string]$FilePath,
-                [object[]]$ArgumentList,
-                [switch]$PassThru
-            )
-
-            $script:startProcessCalls += ,([PSCustomObject]@{
-                FilePath     = $FilePath
-                ArgumentList = @($ArgumentList)
-            })
-            return [PSCustomObject]@{ HasExited = $false }
-        }
-
-        function Start-Sleep {
-            param([int]$Milliseconds)
-        }
-
-        $result = Try-StartOrchestraUiAttach -SessionName 'winsmux-orchestra'
-
-        $result.Attempted | Should -Be $true
-        $result.Launched | Should -Be $true
-        $result.Attached | Should -Be $false
-        $result.Status | Should -Be 'attach_launched_pwsh'
+        $result.Attached | Should -Be $true
+        $result.Status | Should -Be 'attach_confirmed'
+        $result.Source | Should -Be 'handshake'
         $script:startProcessCalls.Count | Should -Be 1
-        $script:startProcessCalls[0].FilePath | Should -Be 'C:\Program Files\PowerShell\7\pwsh.exe'
+        $script:startProcessCalls[0].FilePath | Should -Be 'C:\Windows\System32\wt.exe'
+        $script:startProcessCalls[0].ArgumentList | Should -Be @('-w', '-1', 'new-tab', '-p', 'winsmux orchestra attach')
     }
 
-    It 'resolves a canonical Windows Terminal path when wt.exe is only a WindowsApps alias' {
+    It 'returns attach_already_present when a visible client already exists' {
         $script:startProcessCalls = @()
 
-        function Get-Command {
-            param([string]$Name)
-            if ($Name -eq 'wt.exe') {
-                return [PSCustomObject]@{ Source = 'C:\Users\komei\AppData\Local\Microsoft\WindowsApps\wt.exe' }
-            }
-            if ($Name -eq 'pwsh') {
-                return [PSCustomObject]@{ Source = 'C:\Program Files\PowerShell\7\pwsh.exe' }
-            }
-            if ($Name -eq 'winsmux') {
-                return [PSCustomObject]@{ Source = 'C:\Users\komei\.local\bin\winsmux.exe' }
-            }
-
-            throw "unexpected command lookup: $Name"
+        Mock Get-OrchestraAttachedClientSnapshot {
+            [PSCustomObject]@{ Ok = $true; Count = 1; Error = ''; Clients = @('client-1') }
         }
-
-        function Get-Item {
-            param([string]$LiteralPath)
-            return [PSCustomObject]@{ Length = 0 }
-        }
-
-        function Get-AppxPackage {
-            param([string]$Name)
-            if ($Name -eq 'Microsoft.WindowsTerminal') {
-                return [PSCustomObject]@{ InstallLocation = 'C:\Program Files\WindowsApps\Microsoft.WindowsTerminal_1.23.20211.0_x64__8wekyb3d8bbwe' }
-            }
-
-            return $null
-        }
-
-        function Test-Path {
-            param([string]$LiteralPath)
-            return $LiteralPath -eq 'C:\Program Files\WindowsApps\Microsoft.WindowsTerminal_1.23.20211.0_x64__8wekyb3d8bbwe\wt.exe'
+        Mock Write-OrchestraAttachState {
+            [pscustomobject]@{}
         }
 
         function Start-Process {
@@ -2960,76 +2885,44 @@ Describe 'orchestra-start server bootstrap' {
                 FilePath     = $FilePath
                 ArgumentList = @($ArgumentList)
             })
-            return [PSCustomObject]@{ HasExited = $true }
-        }
-
-        function Start-Sleep {
-            param([int]$Milliseconds)
+            return [PSCustomObject]@{ HasExited = $false }
         }
 
         $result = Try-StartOrchestraUiAttach -SessionName 'winsmux-orchestra'
 
-        $result.Attempted | Should -Be $true
-        $result.Launched | Should -Be $true
-        $result.Attached | Should -Be $false
-        $result.Status | Should -Be 'attach_exited_early'
-        $result.PSObject.Properties.Name | Should -Contain 'FallbackFrom'
-        $result.FallbackFrom | Should -Be 'attach_exited_early'
-        $script:startProcessCalls.Count | Should -Be 2
-        $script:startProcessCalls[0].FilePath | Should -Be 'C:\Program Files\PowerShell\7\pwsh.exe'
-        $script:startProcessCalls[1].FilePath | Should -Be 'C:\Program Files\WindowsApps\Microsoft.WindowsTerminal_1.23.20211.0_x64__8wekyb3d8bbwe\wt.exe'
-        $script:startProcessCalls[1].ArgumentList | Should -Be @(
-            '--size', '200,70',
-            'new-tab',
-            '--title', 'winsmux-orchestra',
-            '--',
-            'C:\Program Files\PowerShell\7\pwsh.exe', '-NoProfile', '-NoExit', '-File', ([System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\winsmux-core\scripts\orchestra-bootstrap.ps1'))), '-SessionName', 'winsmux-orchestra', '-WinsmuxPath', 'C:\Users\komei\.local\bin\winsmux.exe', '-AttachOnly'
-        )
+        $result.Attempted | Should -Be $false
+        $result.Launched | Should -Be $false
+        $result.Attached | Should -Be $true
+        $result.Status | Should -Be 'attach_already_present'
+        $result.Source | Should -Be 'client-probe'
+        $script:startProcessCalls.Count | Should -Be 0
     }
 
-    It 'falls back to a standalone PowerShell attach window when wt.exe is only an alias stub and no canonical binary is available' {
-        $script:startProcessCalls = @()
-
-        function Get-Command {
-            param([string]$Name)
-            if ($Name -eq 'pwsh') {
-                return [PSCustomObject]@{ Source = 'C:\Program Files\PowerShell\7\pwsh.exe' }
-            }
-            if ($Name -eq 'winsmux') {
-                return [PSCustomObject]@{ Source = 'C:\Users\komei\.local\bin\winsmux.exe' }
-            }
-
-            throw "unexpected command lookup: $Name"
+    It 'fails closed when Windows Terminal is unavailable instead of falling back to dynamic attach commands' {
+        Mock Get-OrchestraAttachedClientSnapshot {
+            [PSCustomObject]@{ Ok = $true; Count = 0; Error = ''; Clients = @() }
         }
-
         Mock Get-OrchestraWindowsTerminalInfo {
             [PSCustomObject][ordered]@{
                 Available   = $false
                 Path        = ''
-                AliasPath   = 'C:\Users\komei\AppData\Local\Microsoft\WindowsApps\wt.exe'
-                IsAliasStub = $true
+                AliasPath   = ''
+                IsAliasStub = $false
                 PathSource  = ''
-                Reason      = 'wt_alias_stub'
+                Reason      = 'wt_unavailable'
             }
         }
-
-        function Start-Process {
-            param([string]$FilePath, [object[]]$ArgumentList, [switch]$PassThru)
-            $script:startProcessCalls += ,([PSCustomObject]@{
-                FilePath     = $FilePath
-                ArgumentList = @($ArgumentList)
-            })
-            return [PSCustomObject]@{ HasExited = $false }
+        Mock Write-OrchestraAttachState {
+            [pscustomobject]@{}
         }
 
         $result = Try-StartOrchestraUiAttach -SessionName 'winsmux-orchestra'
 
-        $result.Attempted | Should -Be $true
-        $result.Launched | Should -Be $true
+        $result.Attempted | Should -Be $false
+        $result.Launched | Should -Be $false
         $result.Attached | Should -Be $false
-        $result.Status | Should -Be 'attach_launched_pwsh'
-        $script:startProcessCalls.Count | Should -Be 1
-        $script:startProcessCalls[0].FilePath | Should -Be 'C:\Program Files\PowerShell\7\pwsh.exe'
+        $result.Status | Should -Be 'attach_failed'
+        $result.Source | Should -Be 'none'
     }
 
     It 'checks the bootstrap pane count before reporting startup ready' {
@@ -3240,6 +3133,13 @@ Describe 'orchestra-start server bootstrap' {
             }
         }
 
+        Mock Get-OrchestraAttachedClientSnapshot {
+            [PSCustomObject][ordered]@{
+                Ok    = $true
+                Count = 0
+            }
+        }
+
         function Start-Process {
             param([string]$FilePath, [object[]]$ArgumentList, [switch]$PassThru)
             $script:startProcessCalls += ,([PSCustomObject]@{
@@ -3255,12 +3155,12 @@ Describe 'orchestra-start server bootstrap' {
 
         $result = Try-StartOrchestraUiAttach -SessionName 'winsmux-orchestra'
 
-        $result.Attempted | Should -Be $true
-        $result.Launched | Should -Be $true
+        $result.Attempted | Should -Be $false
+        $result.Launched | Should -Be $false
         $result.Attached | Should -Be $false
-        $result.Status | Should -Be 'attach_launched_pwsh'
-        $script:startProcessCalls.Count | Should -Be 1
-        $script:startProcessCalls[0].FilePath | Should -Be 'C:\Program Files\PowerShell\7\pwsh.exe'
+        $result.Status | Should -Be 'attach_failed'
+        $result.Reason | Should -Match 'Windows Terminal is not installed or not on PATH'
+        $script:startProcessCalls.Count | Should -Be 0
     }
 
     It 'skips UI attach when winsmux cannot be resolved to an absolute path for the child process' {
@@ -6363,7 +6263,7 @@ Describe 'operator startup restore contract docs' {
         $script:claudeGuideContent | Should -Match 'ready-with-ui-warning'
         $script:claudeGuideContent | Should -Match 'winsmux orchestra-attach --json'
         $script:claudeGuideContent | Should -Match 'winsmux dispatch-task'
-        $script:claudeGuideContent | Should -Match 'without asking the user to choose a starting task'
+        $script:claudeGuideContent | Should -Match 'start the first pending action automatically instead of asking which task to begin'
         $script:claudeGuideContent | Should -Match 'do not use Explore subagents for PR/task analysis'
         $script:claudeGuideContent | Should -Match 'psmux --version'
         $script:claudeGuideContent | Should -Match 'Get-Process psmux-server'

--- a/winsmux-core/scripts/harness-check.ps1
+++ b/winsmux-core/scripts/harness-check.ps1
@@ -1,0 +1,260 @@
+[CmdletBinding()]
+param(
+    [string]$ProjectDir = '',
+    [switch]$AsJson
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+
+if ([string]::IsNullOrWhiteSpace($ProjectDir)) {
+    $ProjectDir = (Get-Location).Path
+}
+
+$ProjectDir = [System.IO.Path]::GetFullPath($ProjectDir)
+$scriptsRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+. (Join-Path $scriptsRoot 'orchestra-ui-attach.ps1')
+
+function New-HarnessCheckRecord {
+    param(
+        [Parameter(Mandatory = $true)][string]$Name,
+        [Parameter(Mandatory = $true)][bool]$Passed,
+        [Parameter(Mandatory = $true)][string]$Message,
+        [AllowNull()]$Data = $null
+    )
+
+    return [ordered]@{
+        name    = $Name
+        passed  = $Passed
+        message = $Message
+        data    = $Data
+    }
+}
+
+function Test-HarnessWritableFile {
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    try {
+        $parent = Split-Path -Parent $Path
+        if (-not [string]::IsNullOrWhiteSpace($parent) -and -not (Test-Path -LiteralPath $parent -PathType Container)) {
+            New-Item -ItemType Directory -Path $parent -Force | Out-Null
+        }
+
+        $probe = [ordered]@{
+            checked_at = (Get-Date).ToString('o')
+            probe      = [guid]::NewGuid().ToString('N')
+        } | ConvertTo-Json -Depth 4
+
+        Write-WinsmuxTextFile -Path $Path -Content $probe
+        Remove-Item -LiteralPath $Path -Force -ErrorAction Stop
+        return $true
+    } catch {
+        return $false
+    }
+}
+
+function Get-HarnessSettingsObject {
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        return $null
+    }
+
+    $raw = Get-Content -LiteralPath $Path -Raw -Encoding UTF8
+    if ([string]::IsNullOrWhiteSpace($raw)) {
+        return @{}
+    }
+
+    return ($raw | ConvertFrom-Json -Depth 32)
+}
+
+function Test-HarnessHasProperty {
+    param(
+        [AllowNull()]$Object,
+        [Parameter(Mandatory = $true)][string]$Name
+    )
+
+    if ($null -eq $Object) {
+        return $false
+    }
+
+    if ($Object -is [System.Collections.IDictionary]) {
+        return $Object.Contains($Name)
+    }
+
+    return ($null -ne $Object.PSObject.Properties[$Name])
+}
+
+function Test-HarnessSettingsLocalTracked {
+    param([Parameter(Mandatory = $true)][string]$RepoRoot)
+
+    $output = & git -C $RepoRoot ls-files --error-unmatch .claude/settings.local.json 2>$null
+    return ($LASTEXITCODE -eq 0)
+}
+
+function Get-HarnessHookSignatureViolations {
+    param([Parameter(Mandatory = $true)][string]$RepoRoot)
+
+    $violations = [System.Collections.Generic.List[string]]::new()
+    $hookFiles = @(
+        '.claude/hooks/lib/sh-utils.js',
+        '.claude/hooks/sh-channel-detect.js',
+        '.claude/hooks/sh-invisible-char-scan.js',
+        '.claude/hooks/sh-permission.js',
+        '.claude/hooks/sh-gate.js',
+        '.claude/hooks/sh-elicitation.js',
+        '.claude/hooks/sh-orchestra-gate.js'
+    )
+
+    foreach ($relativePath in $hookFiles) {
+        $fullPath = Join-Path $RepoRoot $relativePath
+        if (-not (Test-Path -LiteralPath $fullPath -PathType Leaf)) {
+            $violations.Add("Missing hook file: $relativePath") | Out-Null
+            continue
+        }
+
+        $content = Get-Content -LiteralPath $fullPath -Raw -Encoding UTF8
+        if ($content -match 'process\.stderr\.write\(JSON\.stringify') {
+            $violations.Add("$relativePath emits JSON to stderr.") | Out-Null
+        }
+    }
+
+    $utilsPath = Join-Path $RepoRoot '.claude/hooks/lib/sh-utils.js'
+    if (Test-Path -LiteralPath $utilsPath -PathType Leaf) {
+        $utilsContent = Get-Content -LiteralPath $utilsPath -Raw -Encoding UTF8
+        if ($utilsContent -notmatch 'permissionDecision:\s*"deny"') {
+            $violations.Add('.claude/hooks/lib/sh-utils.js does not emit a structured deny decision for PreToolUse.') | Out-Null
+        }
+        if ($utilsContent -notmatch 'process\.exit\(0\)') {
+            $violations.Add('.claude/hooks/lib/sh-utils.js does not keep successful structured hook replies on exit 0.') | Out-Null
+        }
+    }
+
+    return @($violations)
+}
+
+function Test-HarnessSmokeContract {
+    param([Parameter(Mandatory = $true)][string]$RepoRoot)
+
+    $smokeScript = Join-Path $RepoRoot 'winsmux-core\scripts\orchestra-smoke.ps1'
+    $stdout = & pwsh -NoProfile -File $smokeScript -ProjectDir $RepoRoot -AsJson 2>&1
+    $exitCode = $LASTEXITCODE
+    $raw = ($stdout | Out-String).Trim()
+    $parsed = $null
+    $error = ''
+
+    try {
+        if (-not [string]::IsNullOrWhiteSpace($raw)) {
+            $parsed = $raw | ConvertFrom-Json -Depth 16
+        }
+    } catch {
+        $error = $_.Exception.Message
+    }
+
+    return [ordered]@{
+        exit_code = $exitCode
+        raw       = $raw
+        parsed    = $parsed
+        error     = $error
+    }
+}
+
+$results = [System.Collections.Generic.List[object]]::new()
+
+$settingsPath = Join-Path $ProjectDir '.claude\settings.json'
+$settingsLocalPath = Join-Path $ProjectDir '.claude\settings.local.json'
+$settings = Get-HarnessSettingsObject -Path $settingsPath
+$settingsLocal = Get-HarnessSettingsObject -Path $settingsLocalPath
+
+$settingsExists = Test-Path -LiteralPath $settingsPath -PathType Leaf
+$settingsMessage = if ($settingsExists) { 'Project settings.json found.' } else { 'Missing .claude/settings.json.' }
+$results.Add((New-HarnessCheckRecord -Name 'settings-json-exists' -Passed $settingsExists -Message $settingsMessage -Data $settingsPath)) | Out-Null
+
+$localHasHooks = $false
+if ($null -ne $settingsLocal) {
+    if ($settingsLocal -is [System.Collections.IDictionary]) {
+        if ($settingsLocal.Contains('hooks')) {
+            $localHasHooks = ($null -ne $settingsLocal['hooks'])
+        }
+    } elseif (Test-HarnessHasProperty -Object $settingsLocal -Name 'hooks') {
+        $localHasHooks = ($null -ne $settingsLocal.hooks)
+    }
+}
+$settingsLocalMessage = if (-not $localHasHooks) { 'settings.local.json does not register hooks.' } else { 'settings.local.json must not register hooks.' }
+$results.Add((New-HarnessCheckRecord -Name 'settings-local-has-no-hooks' -Passed (-not $localHasHooks) -Message $settingsLocalMessage -Data $settingsLocalPath)) | Out-Null
+
+$settingsLocalTracked = Test-HarnessSettingsLocalTracked -RepoRoot $ProjectDir
+$settingsLocalTrackedMessage = if (-not $settingsLocalTracked) { 'settings.local.json is not tracked.' } else { 'settings.local.json must stay untracked.' }
+$results.Add((New-HarnessCheckRecord -Name 'settings-local-not-tracked' -Passed (-not $settingsLocalTracked) -Message $settingsLocalTrackedMessage -Data $settingsLocalPath)) | Out-Null
+
+$hookViolations = @(Get-HarnessHookSignatureViolations -RepoRoot $ProjectDir)
+$hookOutputPassed = ($hookViolations.Count -eq 0)
+$hookOutputMessage = if ($hookOutputPassed) { 'Startup hook files match the expected stdout/stderr contract.' } else { 'Hook output contract violations detected.' }
+$results.Add((New-HarnessCheckRecord -Name 'hook-output-contract' -Passed $hookOutputPassed -Message $hookOutputMessage -Data @($hookViolations))) | Out-Null
+
+$profileCheckPassed = $false
+$profileCheckData = $null
+$profileCheckMessage = ''
+try {
+    $profile = Ensure-OrchestraAttachProfile -ProjectDir $ProjectDir
+    $profileCheckPassed = Test-Path -LiteralPath $profile.FragmentPath -PathType Leaf
+    $profileCheckData = $profile
+    $profileCheckMessage = if ($profileCheckPassed) { 'Windows Terminal attach profile is registered.' } else { 'Attach profile fragment was not created.' }
+} catch {
+    $profileCheckMessage = $_.Exception.Message
+}
+$results.Add((New-HarnessCheckRecord -Name 'wt-attach-profile' -Passed $profileCheckPassed -Message $profileCheckMessage -Data $profileCheckData)) | Out-Null
+
+$attachProbePath = Get-OrchestraAttachStatePath -SessionName 'winsmux-harness-check'
+$attachPathWritable = Test-HarnessWritableFile -Path $attachProbePath
+$attachWritableMessage = if ($attachPathWritable) { 'Attach handshake path is writable.' } else { 'Attach handshake path is not writable.' }
+$results.Add((New-HarnessCheckRecord -Name 'attach-handshake-path-writable' -Passed $attachPathWritable -Message $attachWritableMessage -Data $attachProbePath)) | Out-Null
+
+$smokeProbe = Test-HarnessSmokeContract -RepoRoot $ProjectDir
+$smokePassed = $false
+$smokeMessage = ''
+if ($null -eq $smokeProbe.parsed) {
+    $smokeMessage = if ([string]::IsNullOrWhiteSpace($smokeProbe.error)) { 'orchestra-smoke did not return JSON.' } else { "orchestra-smoke JSON parse failed: $($smokeProbe.error)" }
+} else {
+    $contract = $smokeProbe.parsed.operator_contract
+    $hasContract = $null -ne $contract -and
+        (Test-HarnessHasProperty -Object $contract -Name 'operator_state') -and
+        (Test-HarnessHasProperty -Object $contract -Name 'can_dispatch') -and
+        (Test-HarnessHasProperty -Object $contract -Name 'requires_startup')
+    if (-not $hasContract) {
+        $smokeMessage = 'orchestra-smoke result is missing operator_contract fields.'
+    } elseif ($smokeProbe.parsed.session_ready -and -not $smokeProbe.parsed.ui_attached -and $contract.can_dispatch) {
+        $smokeMessage = 'operator_contract.can_dispatch must stay false until visible attach is confirmed.'
+    } else {
+        $smokePassed = $true
+        $smokeMessage = 'orchestra-smoke contract is structurally consistent.'
+    }
+}
+$results.Add((New-HarnessCheckRecord -Name 'orchestra-smoke-contract' -Passed $smokePassed -Message $smokeMessage -Data ([ordered]@{
+    exit_code = $smokeProbe.exit_code
+    smoke_ok  = $(if ($null -ne $smokeProbe.parsed) { $smokeProbe.parsed.smoke_ok } else { $null })
+    ui_attached = $(if ($null -ne $smokeProbe.parsed) { $smokeProbe.parsed.ui_attached } else { $null })
+    can_dispatch = $(if ($null -ne $smokeProbe.parsed -and $null -ne $smokeProbe.parsed.operator_contract) { $smokeProbe.parsed.operator_contract.can_dispatch } else { $null })
+})) ) | Out-Null
+
+$passed = (@($results | Where-Object { -not $_.passed }).Count -eq 0)
+$summary = [ordered]@{
+    checked_at = (Get-Date).ToString('o')
+    project_dir = $ProjectDir
+    passed = $passed
+    results = @($results)
+}
+
+if ($AsJson) {
+    $summary | ConvertTo-Json -Depth 12
+} else {
+    foreach ($result in $summary.results) {
+        $status = if ($result.passed) { 'PASS' } else { 'FAIL' }
+        '{0} {1}: {2}' -f $status, $result.name, $result.message
+    }
+}
+
+if (-not $passed) {
+    exit 1
+}

--- a/winsmux-core/scripts/orchestra-attach-confirm.ps1
+++ b/winsmux-core/scripts/orchestra-attach-confirm.ps1
@@ -1,0 +1,36 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string]$SessionName,
+    [Parameter(Mandatory = $true)][string]$WinsmuxPath,
+    [int]$BaselineClientCount = 0,
+    [int]$TimeoutMilliseconds = 12000,
+    [int]$PollMilliseconds = 250
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+. (Join-Path $PSScriptRoot 'orchestra-ui-attach.ps1')
+
+try {
+    Write-OrchestraAttachState -SessionName $SessionName -Properties @{
+        session_name       = $SessionName
+        winsmux_path       = $WinsmuxPath
+        attach_status      = 'attach_confirming'
+        ui_attach_source   = 'none'
+        attach_process_id  = $PID
+        started_at         = (Get-Date).ToString('o')
+        client_count_seen  = $BaselineClientCount
+        error              = ''
+    } | Out-Null
+
+    $null = Wait-OrchestraAttachHandshake -SessionName $SessionName -WinsmuxBin $WinsmuxPath -BaselineClientCount $BaselineClientCount -TimeoutMilliseconds $TimeoutMilliseconds -PollMilliseconds $PollMilliseconds
+} catch {
+    Write-OrchestraAttachState -SessionName $SessionName -Properties @{
+        attach_status     = 'attach_failed'
+        ui_attach_source  = 'none'
+        attach_process_id = $PID
+        client_count_seen = $BaselineClientCount
+        error             = $_.Exception.Message
+    } | Out-Null
+}

--- a/winsmux-core/scripts/orchestra-attach-entry.ps1
+++ b/winsmux-core/scripts/orchestra-attach-entry.ps1
@@ -1,0 +1,69 @@
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+
+. (Join-Path $PSScriptRoot 'orchestra-ui-attach.ps1')
+
+$defaultSessionName = 'winsmux-orchestra'
+
+try {
+    $state = Read-OrchestraAttachState -SessionName $defaultSessionName
+    if ($null -eq $state) {
+        throw "Attach state file was not found for session '$defaultSessionName'."
+    }
+
+    $sessionName = [string]$state.session_name
+    $winsmuxPath = [string]$state.winsmux_path
+    if ([string]::IsNullOrWhiteSpace($sessionName)) {
+        $sessionName = $defaultSessionName
+    }
+    if ([string]::IsNullOrWhiteSpace($winsmuxPath)) {
+        throw "winsmux executable path missing from attach state for session '$sessionName'."
+    }
+
+    $baselineClientCount = 0
+    if ($state.PSObject.Properties.Name -contains 'baseline_client_count') {
+        [void][int]::TryParse([string]$state.baseline_client_count, [ref]$baselineClientCount)
+    }
+
+    Write-OrchestraAttachState -SessionName $sessionName -Properties @{
+        attach_status     = 'attach_entry_started'
+        attach_process_id = $PID
+        started_at        = (Get-Date).ToString('o')
+        ui_attach_source  = 'none'
+        error             = ''
+    } | Out-Null
+
+    $pwshPath = Get-OrchestraPowerShellPath
+    $confirmScriptPath = Get-OrchestraAttachConfirmScriptPath
+    Start-Process -FilePath $pwshPath -ArgumentList @(
+        '-NoProfile',
+        '-File',
+        $confirmScriptPath,
+        '-SessionName', $sessionName,
+        '-WinsmuxPath', $winsmuxPath,
+        '-BaselineClientCount', $baselineClientCount
+    ) -WindowStyle Hidden | Out-Null
+
+    & $winsmuxPath 'attach-session' '-t' $sessionName
+    $exitCode = $LASTEXITCODE
+    if ($exitCode -ne 0) {
+        Write-OrchestraAttachState -SessionName $sessionName -Properties @{
+            attach_status = 'attach_failed'
+            ui_attach_source = 'none'
+            error = "winsmux attach-session exited with code $exitCode."
+        } | Out-Null
+        exit $exitCode
+    }
+} catch {
+    Write-OrchestraAttachState -SessionName $defaultSessionName -Properties @{
+        attach_status     = 'attach_failed'
+        ui_attach_source  = 'none'
+        attach_process_id = $PID
+        error             = $_.Exception.Message
+    } | Out-Null
+    throw
+}

--- a/winsmux-core/scripts/orchestra-attach.ps1
+++ b/winsmux-core/scripts/orchestra-attach.ps1
@@ -15,178 +15,128 @@ if ([string]::IsNullOrWhiteSpace($ProjectDir)) {
 
 $ProjectDir = [System.IO.Path]::GetFullPath($ProjectDir)
 $scriptsRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
-$bootstrapScriptPath = Join-Path $scriptsRoot 'orchestra-bootstrap.ps1'
 
-function Get-OrchestraWindowsTerminalInfo {
-    $wtExe = Get-Command 'wt.exe' -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source -ErrorAction SilentlyContinue
-    $canonicalWtExe = ''
-    $isAliasStub = $false
+. (Join-Path $scriptsRoot 'orchestra-ui-attach.ps1')
 
-    if (-not [string]::IsNullOrWhiteSpace($wtExe)) {
-        try {
-            $wtItem = Get-Item -LiteralPath $wtExe -ErrorAction Stop
-            $windowsAppsRoot = Join-Path $env:LOCALAPPDATA 'Microsoft\WindowsApps'
-            $normalizedWtExe = [System.IO.Path]::GetFullPath($wtExe)
-            $normalizedWindowsAppsRoot = [System.IO.Path]::GetFullPath($windowsAppsRoot)
-            if ($wtItem.Length -eq 0 -or $normalizedWtExe.StartsWith($normalizedWindowsAppsRoot, [System.StringComparison]::OrdinalIgnoreCase)) {
-                $isAliasStub = $true
-            } else {
-                $canonicalWtExe = $normalizedWtExe
-            }
-        } catch {
-        }
-    }
-
-    if ([string]::IsNullOrWhiteSpace($canonicalWtExe)) {
-        foreach ($packageName in @('Microsoft.WindowsTerminal', 'Microsoft.WindowsTerminalPreview')) {
-            try {
-                $package = Get-AppxPackage -Name $packageName -ErrorAction SilentlyContinue | Select-Object -First 1
-                if ($null -eq $package -or [string]::IsNullOrWhiteSpace([string]$package.InstallLocation)) {
-                    continue
-                }
-
-                $candidatePath = Join-Path ([string]$package.InstallLocation) 'wt.exe'
-                if (-not (Test-Path -LiteralPath $candidatePath)) {
-                    continue
-                }
-
-                $canonicalWtExe = [System.IO.Path]::GetFullPath($candidatePath)
-                break
-            } catch {
-            }
-        }
-    }
-
-    return [PSCustomObject][ordered]@{
-        Available   = -not [string]::IsNullOrWhiteSpace($canonicalWtExe)
-        Path        = $canonicalWtExe
-        AliasPath   = if ($isAliasStub) { [string]$wtExe } else { '' }
-        IsAliasStub = $isAliasStub
-    }
-}
-
-function Start-OrchestraAttachProcess {
+function New-OrchestraAttachResult {
     param(
-        [Parameter(Mandatory = $true)][string]$FilePath,
-        [Parameter(Mandatory = $true)][object[]]$ArgumentList,
-        [Parameter(Mandatory = $true)][string]$Path,
-        [Parameter(Mandatory = $true)][string]$LaunchedStatus,
-        [Parameter(Mandatory = $true)][string]$LaunchedReason,
-        [Parameter(Mandatory = $true)][string]$FallbackReason
+        [Parameter(Mandatory = $true)][string]$SessionName,
+        [Parameter(Mandatory = $true)][bool]$SessionExists,
+        [Parameter(Mandatory = $true)][bool]$RequiresStartup,
+        [Parameter(Mandatory = $true)][bool]$Attempted,
+        [Parameter(Mandatory = $true)][bool]$Launched,
+        [Parameter(Mandatory = $true)][bool]$Attached,
+        [Parameter(Mandatory = $true)][string]$Status,
+        [Parameter(Mandatory = $true)][string]$Reason,
+        [AllowEmptyString()][string]$Path = '',
+        [int]$AttachedClientCount = 0,
+        [AllowEmptyString()][string]$AttachSource = 'none'
     )
 
-    try {
-        $attachProcess = Start-Process -FilePath $FilePath -ArgumentList $ArgumentList -PassThru
-        Start-Sleep -Milliseconds 500
-        $attachStillRunning = -not $attachProcess.HasExited
-
-        return [PSCustomObject][ordered]@{
-            attempted = $true
-            launched  = $true
-            attached  = $false
-            status    = if ($attachStillRunning) { $LaunchedStatus } else { 'attach_exited_early' }
-            reason    = if ($attachStillRunning) { $LaunchedReason } else { $FallbackReason }
-            path      = $Path
-        }
-    } catch {
-        return [PSCustomObject][ordered]@{
-            attempted = $true
-            launched  = $false
-            attached  = $false
-            status    = 'attach_failed'
-            reason    = $_.Exception.Message
-            path      = $Path
-        }
+    return [ordered]@{
+        session_name          = $SessionName
+        session_exists        = $SessionExists
+        requires_startup      = $RequiresStartup
+        attempted             = $Attempted
+        launched              = $Launched
+        attached              = $Attached
+        attached_client_count = $AttachedClientCount
+        status                = $Status
+        reason                = $Reason
+        path                  = $Path
+        ui_attach_source      = $AttachSource
     }
 }
 
 $winsmuxPath = Get-Command 'winsmux' -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source -ErrorAction SilentlyContinue
 if ([string]::IsNullOrWhiteSpace($winsmuxPath)) {
-    $result = [ordered]@{
-        session_name      = $SessionName
-        session_exists    = $false
-        requires_startup  = $true
-        launched          = $false
-        status            = 'winsmux_unresolved'
-        reason            = 'winsmux executable could not be resolved.'
-    }
+    $result = New-OrchestraAttachResult -SessionName $SessionName -SessionExists $false -RequiresStartup $true -Attempted $false -Launched $false -Attached $false -Status 'winsmux_unresolved' -Reason 'winsmux executable could not be resolved.'
 } else {
     & $winsmuxPath 'has-session' '-t' $SessionName 1>$null 2>$null
     $sessionExists = ($LASTEXITCODE -eq 0)
     if (-not $sessionExists) {
-        $result = [ordered]@{
-            session_name      = $SessionName
-            session_exists    = $false
-            requires_startup  = $true
-            launched          = $false
-            status            = 'session_missing'
-            reason            = "winsmux session '$SessionName' was not found. Run orchestra-start.ps1 first."
-        }
+        $result = New-OrchestraAttachResult -SessionName $SessionName -SessionExists $false -RequiresStartup $true -Attempted $false -Launched $false -Attached $false -Status 'session_missing' -Reason "winsmux session '$SessionName' was not found. Run orchestra-start.ps1 first."
     } else {
-        $pwshPath = Get-Command 'pwsh' -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source -ErrorAction SilentlyContinue
-        if ([string]::IsNullOrWhiteSpace($pwshPath)) {
-            $pwshPath = 'pwsh'
-        }
+        $clientSnapshot = Get-OrchestraAttachedClientSnapshot -WinsmuxBin $winsmuxPath -SessionName $SessionName
+        $baselineClientCount = if ([bool]$clientSnapshot.Ok) { [int]$clientSnapshot.Count } else { 0 }
+        if ([bool]$clientSnapshot.Ok -and $baselineClientCount -ge 1) {
+            Write-OrchestraAttachState -SessionName $SessionName -Properties @{
+                session_name       = $SessionName
+                winsmux_path       = $winsmuxPath
+                attach_status      = 'attach_confirmed'
+                attach_confirmed_at = (Get-Date).ToString('o')
+                client_count_seen  = $baselineClientCount
+                ui_attach_source   = 'client-probe'
+                error              = "Detected $baselineClientCount attached client(s) for session '$SessionName'."
+            } | Out-Null
 
-        $bootstrapArguments = @(
-            '-NoProfile', '-NoExit', '-File', $bootstrapScriptPath, '-SessionName', $SessionName, '-WinsmuxPath', $winsmuxPath, '-AttachOnly'
-        )
-
-        $result = Start-OrchestraAttachProcess `
-            -FilePath $pwshPath `
-            -ArgumentList $bootstrapArguments `
-            -Path $pwshPath `
-            -LaunchedStatus 'attach_launched_pwsh' `
-            -LaunchedReason 'Launched orchestra bootstrap in a standalone PowerShell window.' `
-            -FallbackReason 'Standalone PowerShell attach exited during the early-failure window.'
-
-        if ($result.status -eq 'attach_exited_early' -or $result.status -eq 'attach_failed') {
+            $result = New-OrchestraAttachResult -SessionName $SessionName -SessionExists $true -RequiresStartup $false -Attempted $false -Launched $false -Attached $true -Status 'attach_already_present' -Reason "Detected $baselineClientCount attached client(s) for session '$SessionName'; skipped spawning another visible attach window." -AttachedClientCount $baselineClientCount -AttachSource 'client-probe'
+        } else {
             $terminalInfo = Get-OrchestraWindowsTerminalInfo
-            if ([bool]$terminalInfo.Available) {
-                $wtArguments = @(
-                    '--size', '200,70',
-                    'new-tab',
-                    '--title', $SessionName,
-                    '--',
-                    $pwshPath
-                ) + $bootstrapArguments
+            if (-not [bool]$terminalInfo.Available) {
+                $reason = if ([bool]$terminalInfo.IsAliasStub) {
+                    'WindowsApps wt.exe alias was found, but no canonical Windows Terminal binary could be resolved.'
+                } else {
+                    'Windows Terminal is not installed or not on PATH.'
+                }
 
-                $wtResult = Start-OrchestraAttachProcess `
-                    -FilePath ([string]$terminalInfo.Path) `
-                    -ArgumentList $wtArguments `
-                    -Path ([string]$terminalInfo.Path) `
-                    -LaunchedStatus 'attach_launched_wt_fallback' `
-                    -LaunchedReason 'Standalone PowerShell attach failed; launched Windows Terminal attach child as a fallback.' `
-                    -FallbackReason 'Windows Terminal attach child exited during the early-failure window.'
+                Write-OrchestraAttachState -SessionName $SessionName -Properties @{
+                    session_name       = $SessionName
+                    winsmux_path       = $winsmuxPath
+                    attach_status      = 'attach_failed'
+                    requested_at       = (Get-Date).ToString('o')
+                    baseline_client_count = $baselineClientCount
+                    client_count_seen  = $baselineClientCount
+                    ui_attach_source   = 'none'
+                    error              = $reason
+                } | Out-Null
 
-                if ([bool]$wtResult.launched) {
-                    $result = $wtResult
+                $result = New-OrchestraAttachResult -SessionName $SessionName -SessionExists $true -RequiresStartup $false -Attempted $false -Launched $false -Attached $false -Status 'attach_failed' -Reason $reason -Path ([string]$terminalInfo.Path) -AttachedClientCount $baselineClientCount -AttachSource 'none'
+            } else {
+                $profile = Ensure-OrchestraAttachProfile -ProjectDir $ProjectDir
+                $state = Write-OrchestraAttachState -SessionName $SessionName -Properties @{
+                    session_name          = $SessionName
+                    winsmux_path          = $winsmuxPath
+                    project_dir           = $ProjectDir
+                    requested_at          = (Get-Date).ToString('o')
+                    request_id            = [guid]::NewGuid().ToString('N')
+                    baseline_client_count = $baselineClientCount
+                    client_count_seen     = $baselineClientCount
+                    attach_status         = 'attach_requested'
+                    ui_attach_source      = 'none'
+                    error                 = ''
+                }
+
+                try {
+                    $attachProcess = Start-Process -FilePath ([string]$terminalInfo.Path) -ArgumentList @('-w', '-1', 'new-tab', '-p', [string]$profile.ProfileName) -PassThru
+                    $launchedPath = [string]$terminalInfo.Path
+                } catch {
+                    Write-OrchestraAttachState -SessionName $SessionName -Properties @{
+                        attach_status     = 'attach_failed'
+                        ui_attach_source  = 'none'
+                        error             = $_.Exception.Message
+                    } | Out-Null
+
+                    $result = New-OrchestraAttachResult -SessionName $SessionName -SessionExists $true -RequiresStartup $false -Attempted $true -Launched $false -Attached $false -Status 'attach_failed' -Reason $_.Exception.Message -Path ([string]$terminalInfo.Path) -AttachedClientCount $baselineClientCount -AttachSource 'none'
+                }
+
+                if ($null -eq $result) {
+                    $confirmed = Wait-OrchestraAttachHandshake -SessionName $SessionName -WinsmuxBin $winsmuxPath -BaselineClientCount $baselineClientCount
+                    $result = New-OrchestraAttachResult -SessionName $SessionName -SessionExists $true -RequiresStartup $false -Attempted $true -Launched $true -Attached ([bool]$confirmed.Confirmed) -Status ([string]$confirmed.Status) -Reason ([string]$confirmed.Reason) -Path $launchedPath -AttachedClientCount ([int]$confirmed.AttachedClientCount) -AttachSource ([string]$confirmed.Source)
                 }
             }
-        }
-
-        $result = [ordered]@{
-            session_name      = $SessionName
-            session_exists    = $true
-            requires_startup  = $false
-            attempted         = $result.attempted
-            launched          = $result.launched
-            attached          = $result.attached
-            status            = $result.status
-            reason            = $result.reason
-            path              = $result.path
         }
     }
 }
 
 if ($AsJson) {
-    $result | ConvertTo-Json -Depth 6
+    $result | ConvertTo-Json -Depth 8
 } else {
     $result.GetEnumerator() | ForEach-Object {
         '{0}: {1}' -f $_.Key, $_.Value
     }
 }
 
-if ($result.status -in @('attach_failed', 'attach_exited_early', 'session_missing', 'winsmux_unresolved')) {
+if ($result.status -notin @('attach_confirmed', 'attach_already_present')) {
     exit 1
 }

--- a/winsmux-core/scripts/orchestra-smoke.ps1
+++ b/winsmux-core/scripts/orchestra-smoke.ps1
@@ -219,7 +219,16 @@ if (-not [string]::IsNullOrWhiteSpace($winsmuxBin)) {
     $paneProbeError = 'winsmux executable could not be resolved.'
 }
 
-$clientSnapshot = Get-OrchestraAttachedClientSnapshot -WinsmuxBin $winsmuxBin -SessionName $SessionName
+$clientSnapshot = if ([string]::IsNullOrWhiteSpace($winsmuxBin)) {
+    [PSCustomObject][ordered]@{
+        Ok      = $false
+        Count   = 0
+        Error   = 'winsmux executable could not be resolved.'
+        Clients = @()
+    }
+} else {
+    Get-OrchestraAttachedClientSnapshot -WinsmuxBin $winsmuxBin -SessionName $SessionName
+}
 $clientProbeOk = [bool]$clientSnapshot.Ok
 $clientProbeError = [string]$clientSnapshot.Error
 $attachedClientCount = [int]$clientSnapshot.Count
@@ -290,7 +299,16 @@ if ($null -ne $attachState) {
 }
 
 if (-not $uiAttached) {
-    $clientSnapshot = Get-OrchestraAttachedClientSnapshot -WinsmuxBin $winsmuxBin -SessionName $SessionName
+    $clientSnapshot = if ([string]::IsNullOrWhiteSpace($winsmuxBin)) {
+        [PSCustomObject][ordered]@{
+            Ok      = $false
+            Count   = 0
+            Error   = 'winsmux executable could not be resolved.'
+            Clients = @()
+        }
+    } else {
+        Get-OrchestraAttachedClientSnapshot -WinsmuxBin $winsmuxBin -SessionName $SessionName
+    }
     if ([bool]$clientSnapshot.Ok -and [int]$clientSnapshot.Count -ge 1) {
         $uiAttached = $true
         if ([string]::IsNullOrWhiteSpace($uiAttachStatus) -or $uiAttachStatus -eq 'attach_failed') {

--- a/winsmux-core/scripts/orchestra-smoke.ps1
+++ b/winsmux-core/scripts/orchestra-smoke.ps1
@@ -12,6 +12,7 @@ Set-StrictMode -Version Latest
 $scriptsRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
 . (Join-Path $scriptsRoot 'settings.ps1')
 . (Join-Path $scriptsRoot 'manifest.ps1')
+. (Join-Path $scriptsRoot 'orchestra-ui-attach.ps1')
 
 function Get-OrchestraSmokeLayoutSettings {
     param([string]$Root)
@@ -85,6 +86,7 @@ function Get-OrchestraOperatorContract {
         [Parameter(Mandatory = $true)][bool]$UiAttachLaunched,
         [Parameter(Mandatory = $true)][bool]$UiAttached,
         [Parameter(Mandatory = $true)][AllowEmptyString()][string]$UiAttachStatus,
+        [Parameter(Mandatory = $true)][bool]$ExternalOperatorMode,
         [Parameter(Mandatory = $true)][int]$PaneCount,
         [Parameter(Mandatory = $true)][int]$ExpectedPaneCount,
         [Parameter(Mandatory = $true)][AllowEmptyCollection()][string[]]$SmokeErrors
@@ -98,29 +100,21 @@ function Get-OrchestraOperatorContract {
     $nextAction = 'Inspect smoke_errors and rerun orchestra-start before dispatching work.'
 
     if ($SmokeOk) {
-        $state = 'ready'
-        $message = 'Orchestra session is ready for dispatch.'
-        $canDispatch = $true
+        $state = 'ready-with-ui-warning'
+        $message = 'Orchestra session is session-ready, but visible attach still needs confirmation.'
+        $canDispatch = -not $ExternalOperatorMode
         $requiresStartup = $false
-        $nextAction = 'Dispatch work or continue operator flow.'
+        $nextAction = if ($ExternalOperatorMode) { 'Confirm visible attach before dispatching work.' } else { 'Dispatch work or continue operator flow.' }
 
-        if ($SessionReady -and ($UiAttachLaunched -or -not $UiAttached)) {
-            $uiAttachWarningStatuses = @(
-                'attach_launched',
-                'attach_launched_pwsh',
-                'attach_launched_wt_fallback',
-                'wt_alias_stub',
-                'wt_unavailable',
-                'attach_exited_early',
-                'attach_failed',
-                'winsmux_unresolved'
-            )
-            if ($uiAttachWarningStatuses -contains $UiAttachStatus -or -not $UiAttached) {
-                $state = 'ready-with-ui-warning'
-                $message = 'Orchestra session is ready, but UI attach needs attention.'
-                $uiWarning = $true
-                $nextAction = 'Dispatch may continue; retry UI attach only if a visible operator window is required.'
-            }
+        if ($SessionReady -and $UiAttached) {
+            $state = 'ready'
+            $message = 'Orchestra session is ready for dispatch.'
+            $canDispatch = $true
+            $requiresStartup = $false
+            $uiWarning = $false
+            $nextAction = 'Dispatch work or continue operator flow.'
+        } elseif ($SessionReady) {
+            $uiWarning = $true
         }
     } elseif ($PaneCount -lt $ExpectedPaneCount -or -not $SessionReady) {
         $state = 'blocked'
@@ -152,6 +146,7 @@ $startScript = Join-Path $scriptsRoot 'orchestra-start.ps1'
 $winsmuxCorePath = Join-Path (Split-Path -Parent $scriptsRoot) '..\scripts\winsmux-core.ps1'
 $winsmuxCorePath = [System.IO.Path]::GetFullPath($winsmuxCorePath)
 $layoutSettings = Get-OrchestraSmokeLayoutSettings -Root $ProjectDir
+$externalOperatorMode = ([int]$layoutSettings.Commanders -eq 0)
 $expectedPaneCount = Get-OrchestraSmokeExpectedPaneCount -LayoutSettings $layoutSettings
 $manifestPath = Join-Path (Join-Path $ProjectDir '.winsmux') 'manifest.yaml'
 $manifestFound = Test-Path -LiteralPath $manifestPath
@@ -215,6 +210,7 @@ $uiAttachLaunched = $false
 $uiAttached = $false
 $uiAttachStatus = ''
 $uiAttachReason = ''
+$uiAttachSource = 'none'
 
 if ($manifestFound) {
     $manifest = Get-WinsmuxManifest -ProjectDir $ProjectDir
@@ -224,6 +220,36 @@ if ($manifestFound) {
         $uiAttached = ConvertTo-OrchestraSmokeBoolean $manifest.session.ui_attached
         $uiAttachStatus = [string]$manifest.session.ui_attach_status
         $uiAttachReason = [string]$manifest.session.ui_attach_reason
+        if ($manifest.session.PSObject.Properties.Name -contains 'ui_attach_source') {
+            $uiAttachSource = [string]$manifest.session.ui_attach_source
+        }
+    }
+}
+
+$attachState = Read-OrchestraAttachState -SessionName $SessionName
+if ($null -ne $attachState) {
+    $attachStateStatus = [string]$attachState.attach_status
+    if ($attachStateStatus -eq 'attach_confirmed') {
+        $uiAttached = $true
+        $uiAttachStatus = 'attach_confirmed'
+        $uiAttachReason = [string]$attachState.error
+        $uiAttachSource = if ([string]::IsNullOrWhiteSpace([string]$attachState.ui_attach_source)) { 'handshake' } else { [string]$attachState.ui_attach_source }
+    } elseif ($attachStateStatus -eq 'attach_failed') {
+        $uiAttachStatus = 'attach_failed'
+        $uiAttachReason = [string]$attachState.error
+        $uiAttachSource = 'none'
+    }
+}
+
+if (-not $uiAttached) {
+    $clientSnapshot = Get-OrchestraAttachedClientSnapshot -WinsmuxBin $winsmuxBin -SessionName $SessionName
+    if ([bool]$clientSnapshot.Ok -and [int]$clientSnapshot.Count -ge 1) {
+        $uiAttached = $true
+        if ([string]::IsNullOrWhiteSpace($uiAttachStatus) -or $uiAttachStatus -eq 'attach_failed') {
+            $uiAttachStatus = 'attach_confirmed'
+            $uiAttachReason = "Detected $($clientSnapshot.Count) attached client(s) for session '$SessionName'."
+        }
+        $uiAttachSource = 'client-probe'
     }
 }
 
@@ -239,6 +265,7 @@ $operatorContract = Get-OrchestraOperatorContract `
     -UiAttachLaunched $uiAttachLaunched `
     -UiAttached $uiAttached `
     -UiAttachStatus $uiAttachStatus `
+    -ExternalOperatorMode $externalOperatorMode `
     -PaneCount $paneCount `
     -ExpectedPaneCount $expectedPaneCount `
     -SmokeErrors @($smokeErrors)
@@ -258,6 +285,7 @@ $result = [ordered]@{
     ui_attached         = $uiAttached
     ui_attach_status    = $uiAttachStatus
     ui_attach_reason    = $uiAttachReason
+    ui_attach_source    = $uiAttachSource
     smoke_ok            = ($smokeErrors.Count -eq 0)
     smoke_errors        = @($smokeErrors)
     operator_contract   = $operatorContract

--- a/winsmux-core/scripts/orchestra-start.ps1
+++ b/winsmux-core/scripts/orchestra-start.ps1
@@ -8,6 +8,7 @@ $scriptDir = $PSScriptRoot
 . "$scriptDir/orchestra-preflight.ps1"
 . "$scriptDir/manifest.ps1"
 . "$scriptDir/pane-env.ps1"
+. "$scriptDir/orchestra-ui-attach.ps1"
 
 Set-StrictMode -Version Latest
 [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
@@ -177,29 +178,6 @@ function Try-StartOrchestraUiAttach {
         [int]$Height = 70
     )
 
-    $terminalInfo = Get-OrchestraWindowsTerminalInfo
-    $wtResult = $null
-    if (-not [bool]$terminalInfo.Available) {
-        $wtResult = [PSCustomObject][ordered]@{
-            Attempted = $false
-            Launched  = $false
-            Attached  = $false
-            Status    = if ([bool]$terminalInfo.IsAliasStub) { 'wt_alias_stub' } else { 'wt_unavailable' }
-            Reason    = if ([bool]$terminalInfo.IsAliasStub) {
-                'WindowsApps wt.exe alias was found, but no canonical Windows Terminal binary could be resolved.'
-            } else {
-                'Windows Terminal is not installed or not on PATH.'
-            }
-            Path      = if ([bool]$terminalInfo.IsAliasStub) { [string]$terminalInfo.AliasPath } else { '' }
-        }
-    }
-
-    $bootstrapScriptPath = Join-Path $scriptDir 'orchestra-bootstrap.ps1'
-    $pwshPath = Get-Command 'pwsh' -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source -ErrorAction SilentlyContinue
-    if ([string]::IsNullOrWhiteSpace($pwshPath)) {
-        $pwshPath = 'pwsh'
-    }
-
     $winsmuxPathForAttach = [string]$script:winsmuxBin
     if (-not [string]::IsNullOrWhiteSpace($winsmuxPathForAttach) -and -not [System.IO.Path]::IsPathRooted($winsmuxPathForAttach)) {
         $resolvedWinsmuxPath = Get-Command $winsmuxPathForAttach -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source -ErrorAction SilentlyContinue
@@ -214,53 +192,110 @@ function Try-StartOrchestraUiAttach {
             Launched  = $false
             Attached  = $false
             Status    = 'winsmux_unresolved'
-            Reason    = 'winsmux executable could not be resolved to an absolute path for the attach child process.'
+            Reason    = 'winsmux executable could not be resolved to an absolute path for UI attach.'
+            Path      = ''
+            Source    = 'none'
+        }
+    }
+
+    $clientSnapshot = Get-OrchestraAttachedClientSnapshot -WinsmuxBin $winsmuxPathForAttach -SessionName $SessionName
+    $baselineClientCount = if ([bool]$clientSnapshot.Ok) { [int]$clientSnapshot.Count } else { 0 }
+    if ([bool]$clientSnapshot.Ok -and $baselineClientCount -ge 1) {
+        Write-OrchestraAttachState -SessionName $SessionName -Properties @{
+            session_name       = $SessionName
+            winsmux_path       = $winsmuxPathForAttach
+            attach_status      = 'attach_confirmed'
+            attach_confirmed_at = (Get-Date).ToString('o')
+            client_count_seen  = $baselineClientCount
+            ui_attach_source   = 'client-probe'
+            error              = "Detected $baselineClientCount attached client(s) for session '$SessionName'."
+        } | Out-Null
+
+        return [PSCustomObject][ordered]@{
+            Attempted = $false
+            Launched  = $false
+            Attached  = $true
+            Status    = 'attach_already_present'
+            Reason    = "Detected $baselineClientCount attached client(s) for session '$SessionName'; skipped spawning another visible attach window."
+            Path      = ''
+            Source    = 'client-probe'
+        }
+    }
+
+    $terminalInfo = Get-OrchestraWindowsTerminalInfo
+    if (-not [bool]$terminalInfo.Available) {
+        $reason = if ([bool]$terminalInfo.IsAliasStub) {
+            'WindowsApps wt.exe alias was found, but no canonical Windows Terminal binary could be resolved.'
+        } else {
+            'Windows Terminal is not installed or not on PATH.'
+        }
+
+        Write-OrchestraAttachState -SessionName $SessionName -Properties @{
+            session_name          = $SessionName
+            winsmux_path          = $winsmuxPathForAttach
+            requested_at          = (Get-Date).ToString('o')
+            baseline_client_count = $baselineClientCount
+            client_count_seen     = $baselineClientCount
+            attach_status         = 'attach_failed'
+            ui_attach_source      = 'none'
+            error                 = $reason
+        } | Out-Null
+
+        return [PSCustomObject][ordered]@{
+            Attempted = $false
+            Launched  = $false
+            Attached  = $false
+            Status    = 'attach_failed'
+            Reason    = $reason
             Path      = [string]$terminalInfo.Path
+            Source    = 'none'
         }
     }
 
-    $bootstrapArguments = @(
-        '-NoProfile', '-NoExit', '-File', $bootstrapScriptPath, '-SessionName', $SessionName, '-WinsmuxPath', $winsmuxPathForAttach, '-AttachOnly'
-    )
+    $profile = Ensure-OrchestraAttachProfile -ProjectDir $projectDir
+    Write-OrchestraAttachState -SessionName $SessionName -Properties @{
+        session_name          = $SessionName
+        winsmux_path          = $winsmuxPathForAttach
+        project_dir           = $projectDir
+        requested_at          = (Get-Date).ToString('o')
+        request_id            = [guid]::NewGuid().ToString('N')
+        baseline_client_count = $baselineClientCount
+        client_count_seen     = $baselineClientCount
+        attach_status         = 'attach_requested'
+        ui_attach_source      = 'none'
+        error                 = ''
+    } | Out-Null
 
-    $pwshResult = Start-OrchestraAttachProcess `
-        -FilePath $pwshPath `
-        -ArgumentList $bootstrapArguments `
-        -Path $pwshPath `
-        -LaunchedStatus 'attach_launched_pwsh' `
-        -LaunchedReason 'Launched orchestra bootstrap in a standalone PowerShell window.' `
-        -FallbackReason 'Standalone PowerShell attach exited during the early-failure window.'
+    try {
+        Start-Process -FilePath ([string]$terminalInfo.Path) -ArgumentList @('-w', '-1', 'new-tab', '-p', [string]$profile.ProfileName) -PassThru | Out-Null
+    } catch {
+        Write-OrchestraAttachState -SessionName $SessionName -Properties @{
+            attach_status     = 'attach_failed'
+            ui_attach_source  = 'none'
+            error             = $_.Exception.Message
+        } | Out-Null
 
-    if ([string]$pwshResult.Status -ne 'attach_exited_early' -and [string]$pwshResult.Status -ne 'attach_failed') {
-        return $pwshResult
-    }
-
-    if ($null -eq $wtResult) {
-        $wtArguments = @(
-            '--size', "$Width,$Height",
-            'new-tab',
-            '--title', $SessionName,
-            '--',
-            $pwshPath
-        ) + $bootstrapArguments
-
-        $wtResult = Start-OrchestraAttachProcess `
-            -FilePath ([string]$terminalInfo.Path) `
-            -ArgumentList $wtArguments `
-            -Path ([string]$terminalInfo.Path) `
-            -LaunchedStatus 'attach_launched_wt_fallback' `
-            -LaunchedReason 'Standalone PowerShell attach failed; launched Windows Terminal attach child as a fallback.' `
-            -FallbackReason 'Windows Terminal attach child exited during the early-failure window.'
-
-        if ([bool]$wtResult.Launched) {
-            $wtResult | Add-Member -NotePropertyName FallbackFrom -NotePropertyValue ([string]$pwshResult.Status) -Force
-            return $wtResult
+        return [PSCustomObject][ordered]@{
+            Attempted = $true
+            Launched  = $false
+            Attached  = $false
+            Status    = 'attach_failed'
+            Reason    = $_.Exception.Message
+            Path      = [string]$terminalInfo.Path
+            Source    = 'none'
         }
     }
 
-    $pwshResult | Add-Member -NotePropertyName FallbackStatus -NotePropertyValue ([string]$wtResult.Status) -Force
-    $pwshResult | Add-Member -NotePropertyName FallbackReason -NotePropertyValue ([string]$wtResult.Reason) -Force
-    return $pwshResult
+    $confirmed = Wait-OrchestraAttachHandshake -SessionName $SessionName -WinsmuxBin $winsmuxPathForAttach -BaselineClientCount $baselineClientCount
+    return [PSCustomObject][ordered]@{
+        Attempted = $true
+        Launched  = $true
+        Attached  = [bool]$confirmed.Confirmed
+        Status    = [string]$confirmed.Status
+        Reason    = [string]$confirmed.Reason
+        Path      = [string]$terminalInfo.Path
+        Source    = [string]$confirmed.Source
+    }
 }
 
 function Ensure-OrchestraBootstrapSession {
@@ -1086,7 +1121,8 @@ function Save-OrchestraSessionState {
         [bool]$UiAttachLaunched = $false,
         [bool]$UiAttached = $false,
         [AllowEmptyString()][string]$UiAttachStatus = '',
-        [AllowEmptyString()][string]$UiAttachReason = ''
+        [AllowEmptyString()][string]$UiAttachReason = '',
+        [AllowEmptyString()][string]$UiAttachSource = 'none'
     )
 
     $manifestPath = Get-OrchestraManifestPath -ProjectDir $ProjectDir
@@ -1128,6 +1164,7 @@ function Save-OrchestraSessionState {
             ui_attached         = $UiAttached
             ui_attach_status    = $UiAttachStatus
             ui_attach_reason    = $UiAttachReason
+            ui_attach_source    = $UiAttachSource
         }
         panes     = $paneMap
         tasks     = [PSCustomObject]@{
@@ -2106,12 +2143,12 @@ if ($MyInvocation.InvocationName -ne '.') {
     Assert-OrchestraBootstrapVerification -PaneSummaries @($paneSummaries) -InvalidCount $invalidCount -ReadyCount $readyCount
 
     $uiAttachResult = Try-StartOrchestraUiAttach -SessionName $sessionName
-    $successfulAttachStatuses = @('attach_launched', 'attach_launched_pwsh', 'attach_launched_wt_fallback')
+    $successfulAttachStatuses = @('attach_confirmed', 'attach_already_present')
     if ($successfulAttachStatuses -notcontains [string]$uiAttachResult.Status) {
         Write-Warning "Orchestra UI attach status for ${sessionName}: $($uiAttachResult.Status) ($($uiAttachResult.Reason))"
     }
 
-    $manifestPath = Save-OrchestraSessionState -ProjectDir $projectDir -SessionName $sessionName -Settings $settings -GitWorktreeDir $gitWorktreeDir -PaneSummaries $validPaneSummaries -StartupToken $startupToken -BootstrapMode ([string]$orchestraServer.BootstrapMode) -SessionReady $false -UiAttachLaunched ([bool]$uiAttachResult.Launched) -UiAttached ([bool]$uiAttachResult.Attached) -UiAttachStatus ([string]$uiAttachResult.Status) -UiAttachReason ([string]$uiAttachResult.Reason)
+    $manifestPath = Save-OrchestraSessionState -ProjectDir $projectDir -SessionName $sessionName -Settings $settings -GitWorktreeDir $gitWorktreeDir -PaneSummaries $validPaneSummaries -StartupToken $startupToken -BootstrapMode ([string]$orchestraServer.BootstrapMode) -SessionReady $false -UiAttachLaunched ([bool]$uiAttachResult.Launched) -UiAttached ([bool]$uiAttachResult.Attached) -UiAttachStatus ([string]$uiAttachResult.Status) -UiAttachReason ([string]$uiAttachResult.Reason) -UiAttachSource ([string]$uiAttachResult.Source)
     $commanderPollScriptPath = Join-Path $scriptDir 'commander-poll.ps1'
     $commanderPollProcess = Start-CommanderPollJob -CommanderPollScriptPath $commanderPollScriptPath -ManifestPath $manifestPath -StartupToken $startupToken -Interval 20
     Write-WinsmuxLog -Level INFO -Event 'preflight.commander_poll.started' -Message "Started commander poll for session $sessionName." -Data @{ session_name = $sessionName; manifest_path = $manifestPath; commander_poll_pid = $commanderPollProcess.Id; process_name = $commanderPollProcess.ProcessName } | Out-Null
@@ -2122,7 +2159,7 @@ if ($MyInvocation.InvocationName -ne '.') {
     Assert-OrchestraBackgroundProcessStarted -Process $commanderPollProcess -Name 'Commander poll job'
     Assert-OrchestraBackgroundProcessStarted -Process $watchdogProcess -Name 'Agent watchdog job'
     Assert-OrchestraBackgroundProcessStarted -Process $serverWatchdogProcess -Name 'Server watchdog job'
-    $manifestPath = Save-OrchestraSessionState -ProjectDir $projectDir -SessionName $sessionName -Settings $settings -GitWorktreeDir $gitWorktreeDir -PaneSummaries $validPaneSummaries -StartupToken $startupToken -CommanderPollPid $commanderPollProcess.Id -WatchdogPid $watchdogProcess.Id -ServerWatchdogPid $serverWatchdogProcess.Id -BootstrapMode ([string]$orchestraServer.BootstrapMode) -SessionReady $true -UiAttachLaunched ([bool]$uiAttachResult.Launched) -UiAttached ([bool]$uiAttachResult.Attached) -UiAttachStatus ([string]$uiAttachResult.Status) -UiAttachReason ([string]$uiAttachResult.Reason)
+    $manifestPath = Save-OrchestraSessionState -ProjectDir $projectDir -SessionName $sessionName -Settings $settings -GitWorktreeDir $gitWorktreeDir -PaneSummaries $validPaneSummaries -StartupToken $startupToken -CommanderPollPid $commanderPollProcess.Id -WatchdogPid $watchdogProcess.Id -ServerWatchdogPid $serverWatchdogProcess.Id -BootstrapMode ([string]$orchestraServer.BootstrapMode) -SessionReady $true -UiAttachLaunched ([bool]$uiAttachResult.Launched) -UiAttached ([bool]$uiAttachResult.Attached) -UiAttachStatus ([string]$uiAttachResult.Status) -UiAttachReason ([string]$uiAttachResult.Reason) -UiAttachSource ([string]$uiAttachResult.Source)
     Write-WinsmuxLog -Level INFO -Event 'preflight.watchdog.started' -Message "Started agent watchdog for session $sessionName." -Data @{ session_name = $sessionName; manifest_path = $manifestPath; watchdog_pid = $watchdogProcess.Id; process_name = $watchdogProcess.ProcessName } | Out-Null
     Write-WinsmuxLog -Level INFO -Event 'preflight.server_watchdog.started' -Message "Started server watchdog for session $sessionName." -Data @{ session_name = $sessionName; manifest_path = $manifestPath; server_watchdog_pid = $serverWatchdogProcess.Id; process_name = $serverWatchdogProcess.ProcessName } | Out-Null
     Write-WinsmuxLog -Level INFO -Event 'orchestra.startup.session_ready' -Message "Orchestra session $sessionName reached session-ready; UI attach remains a separate state." -Data ([ordered]@{
@@ -2133,6 +2170,7 @@ if ($MyInvocation.InvocationName -ne '.') {
         ui_attach_launched = [bool]$uiAttachResult.Launched
         ui_attach_status   = [string]$uiAttachResult.Status
         ui_attached        = [bool]$uiAttachResult.Attached
+        ui_attach_source   = [string]$uiAttachResult.Source
     }) | Out-Null
 
     Write-Output "Orchestra session: $sessionName"

--- a/winsmux-core/scripts/orchestra-ui-attach.ps1
+++ b/winsmux-core/scripts/orchestra-ui-attach.ps1
@@ -1,0 +1,310 @@
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+. (Join-Path $PSScriptRoot 'clm-safe-io.ps1')
+
+$script:OrchestraAttachProfileName = 'winsmux orchestra attach'
+
+function Get-OrchestraAttachRoot {
+    $localAppData = if ([string]::IsNullOrWhiteSpace($env:LOCALAPPDATA)) {
+        Join-Path $HOME 'AppData\Local'
+    } else {
+        $env:LOCALAPPDATA
+    }
+
+    return Join-Path $localAppData 'winsmux\ui-attach'
+}
+
+function Get-OrchestraAttachStatePath {
+    param([Parameter(Mandatory = $true)][string]$SessionName)
+
+    return Join-Path (Get-OrchestraAttachRoot) ("{0}.json" -f $SessionName)
+}
+
+function Get-OrchestraAttachEntryScriptPath {
+    return [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot 'orchestra-attach-entry.ps1'))
+}
+
+function Get-OrchestraAttachConfirmScriptPath {
+    return [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot 'orchestra-attach-confirm.ps1'))
+}
+
+function Get-OrchestraAttachFragmentDir {
+    $localAppData = if ([string]::IsNullOrWhiteSpace($env:LOCALAPPDATA)) {
+        Join-Path $HOME 'AppData\Local'
+    } else {
+        $env:LOCALAPPDATA
+    }
+
+    return Join-Path $localAppData 'Microsoft\Windows Terminal\Fragments\winsmux'
+}
+
+function Get-OrchestraAttachFragmentPath {
+    return Join-Path (Get-OrchestraAttachFragmentDir) 'winsmux-orchestra-attach.json'
+}
+
+function Get-OrchestraPowerShellPath {
+    $pwshPath = Get-Command 'pwsh' -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source -ErrorAction SilentlyContinue
+    if ([string]::IsNullOrWhiteSpace($pwshPath)) {
+        throw 'pwsh executable could not be resolved.'
+    }
+
+    return [System.IO.Path]::GetFullPath($pwshPath)
+}
+
+function Read-OrchestraAttachState {
+    param([Parameter(Mandatory = $true)][string]$SessionName)
+
+    $path = Get-OrchestraAttachStatePath -SessionName $SessionName
+    if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
+        return $null
+    }
+
+    $raw = Get-Content -LiteralPath $path -Raw -Encoding UTF8
+    if ([string]::IsNullOrWhiteSpace($raw)) {
+        return $null
+    }
+
+    try {
+        return $raw | ConvertFrom-Json -Depth 8
+    } catch {
+        return $null
+    }
+}
+
+function Write-OrchestraAttachState {
+    param(
+        [Parameter(Mandatory = $true)][string]$SessionName,
+        [Parameter(Mandatory = $true)][hashtable]$Properties
+    )
+
+    $existing = Read-OrchestraAttachState -SessionName $SessionName
+    $state = [ordered]@{}
+    if ($null -ne $existing) {
+        foreach ($property in $existing.PSObject.Properties) {
+            $state[$property.Name] = $property.Value
+        }
+    }
+
+    foreach ($key in $Properties.Keys) {
+        $state[$key] = $Properties[$key]
+    }
+
+    $statePath = Get-OrchestraAttachStatePath -SessionName $SessionName
+    $json = ($state | ConvertTo-Json -Depth 8)
+    Write-WinsmuxTextFile -Path $statePath -Content $json
+    return [pscustomobject]$state
+}
+
+function Get-OrchestraAttachedClientSnapshot {
+    param(
+        [Parameter(Mandatory = $true)][string]$WinsmuxBin,
+        [Parameter(Mandatory = $true)][string]$SessionName
+    )
+
+    $clients = @()
+    $error = ''
+    $ok = $false
+
+    if ([string]::IsNullOrWhiteSpace($WinsmuxBin)) {
+        return [PSCustomObject][ordered]@{
+            Ok      = $false
+            Count   = 0
+            Error   = 'winsmux executable could not be resolved.'
+            Clients = @()
+        }
+    }
+
+    try {
+        $clientLines = & $WinsmuxBin 'list-clients' '-t' $SessionName 2>&1
+        if ($LASTEXITCODE -eq 0) {
+            $clients = @(
+                $clientLines |
+                    ForEach-Object { [string]$_ } |
+                    Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+            )
+            $ok = $true
+        } else {
+            $error = ($clientLines | Out-String).Trim()
+        }
+    } catch {
+        $error = $_.Exception.Message
+    }
+
+    [PSCustomObject][ordered]@{
+        Ok      = $ok
+        Count   = $clients.Count
+        Error   = $error
+        Clients = @($clients)
+    }
+}
+
+function Get-OrchestraWindowsTerminalInfo {
+    $wtExe = Get-Command 'wt.exe' -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source -ErrorAction SilentlyContinue
+    $canonicalWtExe = ''
+    $reason = 'wt_unavailable'
+    $pathSource = ''
+    $isAliasStub = $false
+
+    if (-not [string]::IsNullOrWhiteSpace($wtExe)) {
+        try {
+            $wtItem = Get-Item -LiteralPath $wtExe -ErrorAction Stop
+            $windowsAppsRoot = Join-Path $env:LOCALAPPDATA 'Microsoft\WindowsApps'
+            $normalizedWtExe = [System.IO.Path]::GetFullPath($wtExe)
+            $normalizedWindowsAppsRoot = [System.IO.Path]::GetFullPath($windowsAppsRoot)
+            if ($wtItem.Length -eq 0 -or $normalizedWtExe.StartsWith($normalizedWindowsAppsRoot, [System.StringComparison]::OrdinalIgnoreCase)) {
+                $isAliasStub = $true
+            } else {
+                $canonicalWtExe = $normalizedWtExe
+                $reason = 'ready'
+                $pathSource = 'command'
+            }
+        } catch {
+        }
+    }
+
+    if ([string]::IsNullOrWhiteSpace($canonicalWtExe)) {
+        foreach ($packageName in @('Microsoft.WindowsTerminal', 'Microsoft.WindowsTerminalPreview')) {
+            try {
+                $package = Get-AppxPackage -Name $packageName -ErrorAction SilentlyContinue | Select-Object -First 1
+                if ($null -eq $package -or [string]::IsNullOrWhiteSpace([string]$package.InstallLocation)) {
+                    continue
+                }
+
+                $candidatePath = Join-Path ([string]$package.InstallLocation) 'wt.exe'
+                if (-not (Test-Path -LiteralPath $candidatePath)) {
+                    continue
+                }
+
+                $canonicalWtExe = [System.IO.Path]::GetFullPath($candidatePath)
+                $reason = if ($isAliasStub) { 'resolved_from_appx' } else { 'ready' }
+                $pathSource = 'appx'
+                break
+            } catch {
+            }
+        }
+    }
+
+    return [PSCustomObject][ordered]@{
+        Available   = -not [string]::IsNullOrWhiteSpace($canonicalWtExe)
+        Path        = $canonicalWtExe
+        AliasPath   = if ($isAliasStub) { [string]$wtExe } else { '' }
+        IsAliasStub = $isAliasStub
+        PathSource  = $pathSource
+        Reason      = if (-not [string]::IsNullOrWhiteSpace($canonicalWtExe)) { $reason } elseif ($isAliasStub) { 'wt_alias_stub' } else { 'wt_unavailable' }
+    }
+}
+
+function Ensure-OrchestraAttachProfile {
+    param([Parameter(Mandatory = $true)][string]$ProjectDir)
+
+    $fragmentDir = Get-OrchestraAttachFragmentDir
+    if (-not (Test-Path -LiteralPath $fragmentDir -PathType Container)) {
+        New-Item -ItemType Directory -Path $fragmentDir -Force | Out-Null
+    }
+
+    $pwshPath = Get-OrchestraPowerShellPath
+    $attachEntryScriptPath = Get-OrchestraAttachEntryScriptPath
+    $commandline = '"{0}" -NoLogo -NoExit -File "{1}"' -f $pwshPath, $attachEntryScriptPath
+
+    $fragment = @{
+        profiles = @(
+            @{
+                name                    = $script:OrchestraAttachProfileName
+                commandline             = $commandline
+                tabTitle                = 'winsmux-orchestra'
+                suppressApplicationTitle = $true
+                startingDirectory       = $ProjectDir
+                hidden                  = $false
+            }
+        )
+    }
+
+    $json = $fragment | ConvertTo-Json -Depth 6
+    $fragmentPath = Get-OrchestraAttachFragmentPath
+    Write-WinsmuxTextFile -Path $fragmentPath -Content $json
+
+    return [PSCustomObject][ordered]@{
+        ProfileName  = $script:OrchestraAttachProfileName
+        FragmentPath = $fragmentPath
+        Commandline  = $commandline
+    }
+}
+
+function Wait-OrchestraAttachHandshake {
+    param(
+        [Parameter(Mandatory = $true)][string]$SessionName,
+        [Parameter(Mandatory = $true)][string]$WinsmuxBin,
+        [Parameter(Mandatory = $true)][int]$BaselineClientCount,
+        [int]$TimeoutMilliseconds = 12000,
+        [int]$PollMilliseconds = 250
+    )
+
+    $targetClientCount = $BaselineClientCount + 1
+    $deadline = (Get-Date).AddMilliseconds($TimeoutMilliseconds)
+    $lastError = ''
+
+    do {
+        $state = Read-OrchestraAttachState -SessionName $SessionName
+        if ($null -ne $state) {
+            $status = [string]$state.attach_status
+            if ($status -eq 'attach_confirmed') {
+                return [PSCustomObject][ordered]@{
+                    Confirmed           = $true
+                    Source              = 'handshake'
+                    Status              = 'attach_confirmed'
+                    Reason              = [string]$state.error
+                    AttachedClientCount = [int]$state.client_count_seen
+                    State               = $state
+                }
+            }
+
+            if ($status -eq 'attach_failed') {
+                $lastError = [string]$state.error
+            }
+        }
+
+        $snapshot = Get-OrchestraAttachedClientSnapshot -WinsmuxBin $WinsmuxBin -SessionName $SessionName
+        if ([bool]$snapshot.Ok -and [int]$snapshot.Count -ge $targetClientCount) {
+            $confirmedAt = (Get-Date).ToString('o')
+            $updatedState = Write-OrchestraAttachState -SessionName $SessionName -Properties @{
+                attach_status       = 'attach_confirmed'
+                attach_confirmed_at = $confirmedAt
+                client_count_seen   = [int]$snapshot.Count
+                ui_attach_source    = 'client-probe'
+                error               = "Visible attach confirmed for session '$SessionName' with $($snapshot.Count) attached client(s)."
+            }
+
+            return [PSCustomObject][ordered]@{
+                Confirmed           = $true
+                Source              = 'client-probe'
+                Status              = 'attach_confirmed'
+                Reason              = [string]$updatedState.error
+                AttachedClientCount = [int]$snapshot.Count
+                State               = $updatedState
+            }
+        }
+
+        Start-Sleep -Milliseconds $PollMilliseconds
+    } while ((Get-Date) -lt $deadline)
+
+    $failedState = Write-OrchestraAttachState -SessionName $SessionName -Properties @{
+        attach_status     = 'attach_failed'
+        ui_attach_source  = 'none'
+        client_count_seen = $BaselineClientCount
+        error             = if ([string]::IsNullOrWhiteSpace($lastError)) {
+            "Attach confirmation timed out before client count reached $targetClientCount."
+        } else {
+            $lastError
+        }
+    }
+
+    return [PSCustomObject][ordered]@{
+        Confirmed           = $false
+        Source              = 'none'
+        Status              = 'attach_failed'
+        Reason              = [string]$failedState.error
+        AttachedClientCount = $BaselineClientCount
+        State               = $failedState
+    }
+}


### PR DESCRIPTION
## Summary
- replace dynamic visible attach command synthesis with a fixed profile, attach entry script, and handshake contract
- add `winsmux harness-check --json` and align operator hook/settings behavior with the documented contract
- fail closed so external operator mode keeps `can_dispatch=false` until visible attach is confirmed

## Validation
- `Invoke-Pester tests\winsmux-bridge.Tests.ps1 -CI`
- `Invoke-Pester tests\Integration.GateEnforcement.Tests.ps1 -CI`
- `Invoke-Pester tests\HarnessContract.Tests.ps1 -CI`
- `Invoke-Pester tests\PublicSurfacePolicy.Tests.ps1 -CI`
- `pwsh -NoProfile -File .\scripts\audit-public-surface.ps1`
- `pwsh -NoProfile -File .\scripts\git-guard.ps1 -Mode full`
- `pwsh -NoProfile -File .\scripts\winsmux-core.ps1 harness-check --json`

## Related
- #426
- #442
- #443
- #444