### PR TITLE
fix: harden startup harness contract

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -92,13 +92,15 @@ When `/winsmux-start` or another restoration flow reports `needs-startup`:
 7. Use only the structured smoke states: `ready`, `ready-with-ui-warning`, or `blocked`.
 8. If the state is `ready-with-ui-warning`, run `winsmux orchestra-attach --json` once to launch a visible operator window, then rerun `winsmux orchestra-smoke --json`.
 9. External operator mode remains fail-closed: if `ui_attached=false`, `operator_contract.can_dispatch` must stay `false`.
-10. When `.claude/local/operator-handoff.md` contains an ordered `Next actions` list, start the first pending action automatically instead of asking which task to begin.
-11. Once `operator_contract.can_dispatch=true`, do not use Explore subagents for PR/task analysis. Dispatch the task through `winsmux dispatch-task "<task text>"` or `winsmux dispatch-review`.
-12. Startup/status Explore subagents are allowed only while diagnosing orchestra readiness or attach problems.
-13. Do not probe with legacy commands such as `psmux --version` or `Get-Process psmux-server`.
-14. Do not tell the user to manually start a `psmux` server.
-15. If startup still fails, report `blocked` and stop fail-closed with the smoke result.
-16. Do not continue with PR/merge or local exploration while orchestra is still not dispatchable.
+10. Treat MCP or plugin chatter during startup as non-authoritative side output. `called MCP`, channel notifications, and plugin bootstrap messages must not be used as readiness evidence and must not override `operator_contract`.
+11. If hook validation noise, schema warnings, or an `Interrupted` result prevents a clean `winsmux orchestra-smoke --json` result from being obtained, stop fail-closed and treat the session as `blocked` until the startup contract is re-run cleanly.
+12. When `.claude/local/operator-handoff.md` contains an ordered `Next actions` list, start the first pending action automatically instead of asking which task to begin.
+13. Once `operator_contract.can_dispatch=true`, do not use Explore subagents for PR/task analysis. Dispatch the task through `winsmux dispatch-task "<task text>"` or `winsmux dispatch-review`.
+14. Startup/status Explore subagents are allowed only while diagnosing orchestra readiness or attach problems.
+15. Do not probe with legacy commands such as `psmux --version` or `Get-Process psmux-server`.
+16. Do not tell the user to manually start a `psmux` server.
+17. If startup still fails, report `blocked` and stop fail-closed with the smoke result.
+18. Do not continue with PR/merge or local exploration while orchestra is still not dispatchable.
 
 ## Compatibility and release notes
 

--- a/.claude/hooks/lib/sh-utils.js
+++ b/.claude/hooks/lib/sh-utils.js
@@ -34,7 +34,7 @@ function deny(reason) {
   const input = readHookInput();
   if (isPreToolUseEvent(input)) {
     const eventName = getHookEventName(input) || "PreToolUse";
-    process.stdout.write(
+    writeStdout(
       `${JSON.stringify({
         hookSpecificOutput: {
           hookEventName: eventName,
@@ -52,8 +52,10 @@ function deny(reason) {
 
 function allow(additionalContext) {
   if (additionalContext) {
-    process.stdout.write(
-      `${JSON.stringify({ hookSpecificOutput: { additionalContext } })}\n`,
+    writeStdout(
+      `${JSON.stringify({
+        hookSpecificOutput: buildHookSpecificOutput({ additionalContext }),
+      })}\n`,
     );
   }
   process.exit(0);
@@ -78,17 +80,33 @@ function sha256(data) {
 }
 
 function allowWithUpdate(updatedInput) {
-  process.stdout.write(
-    `${JSON.stringify({ hookSpecificOutput: { updatedInput } })}\n`,
+  writeStdout(
+    `${JSON.stringify({
+      hookSpecificOutput: buildHookSpecificOutput({ updatedInput }),
+    })}\n`,
   );
   process.exit(0);
 }
 
-function allowWithResult(resultObj) {
-  process.stdout.write(
-    `${JSON.stringify({ hookSpecificOutput: { result: resultObj } })}\n`,
+function allowWithResult(resultObj, additionalContext) {
+  writeStdout(
+    `${JSON.stringify({
+      hookSpecificOutput: buildHookSpecificOutput({
+        updatedMCPToolOutput: resultObj,
+        ...(additionalContext ? { additionalContext } : {}),
+      }),
+    })}\n`,
   );
   process.exit(0);
+}
+
+function buildHookSpecificOutput(extraFields = {}) {
+  const input = readHookInput();
+  const eventName = getHookEventName(input) || "Unknown";
+  return {
+    hookEventName: eventName,
+    ...extraFields,
+  };
 }
 
 function getHookEventName(input = null) {
@@ -109,8 +127,16 @@ function isPreToolUseEvent(input = null) {
 }
 
 function failClosed(message) {
-  process.stderr.write(`${String(message)}\n`);
+  writeStderr(`${String(message)}\n`);
   process.exit(2);
+}
+
+function writeStdout(payload) {
+  fs.writeSync(process.stdout.fd, payload, null, "utf8");
+}
+
+function writeStderr(payload) {
+  fs.writeSync(process.stderr.fd, payload, null, "utf8");
 }
 
 function readSession() {
@@ -572,3 +598,11 @@ module.exports = {
   getBacklogPath,
   getRoadmapPath,
 };
+
+
+
+
+
+
+
+

--- a/.claude/hooks/sh-output-control.js
+++ b/.claude/hooks/sh-output-control.js
@@ -150,6 +150,14 @@ function trackTokenBudget(outputSize) {
   }
 }
 
+function isMcpTool(toolName) {
+  if (typeof toolName !== "string" || toolName.trim() === "") {
+    return false;
+  }
+
+  return /^(mcp__|plugin:)/i.test(toolName.trim());
+}
+
 // ---------------------------------------------------------------------------
 // Main — only execute when run directly (not when require'd for testing)
 // ---------------------------------------------------------------------------
@@ -161,7 +169,11 @@ if (require.main === module) {
     const toolInput = input.tool_input || input.toolInput || {};
     const sessionId = input.session_id || input.sessionId || "";
     const toolResult =
-      input.tool_result !== undefined ? input.tool_result : input.toolResult;
+      input.tool_response !== undefined
+        ? input.tool_response
+        : input.tool_result !== undefined
+          ? input.tool_result
+          : input.toolResult;
     void toolInput;
     void sessionId;
 
@@ -190,13 +202,17 @@ if (require.main === module) {
 
     // Output result
     if (truncated) {
-      // Must use allowWithResult to replace the tool output
-      if (context.length > 0) {
-        // allowWithResult doesn't support additionalContext, so prepend warnings to the result
-        const contextHeader = context.join("\n") + "\n\n";
-        allowWithResult(contextHeader + text);
+      if (isMcpTool(toolName)) {
+        if (context.length > 0) {
+          allowWithResult(text, context.join("\n"));
+        } else {
+          allowWithResult(text);
+        }
       } else {
-        allowWithResult(text);
+        context.push(
+          `[${HOOK_NAME}] ${toolName} の出力置換は MCP tool のみ対応です。出力は保持し、通知だけ追加します。`,
+        );
+        allow(context.join("\n"));
       }
     } else if (context.length > 0) {
       allow(context.join("\n"));
@@ -220,4 +236,5 @@ module.exports = {
   estimateTokens,
   getLimits,
   trackTokenBudget,
+  isMcpTool,
 };

--- a/.claude/rules/dispatch.md
+++ b/.claude/rules/dispatch.md
@@ -17,12 +17,14 @@ paths: ["winsmux-core/scripts/**", ".claude/**"]
    Any other state is fail-closed.
 8. If the state is `ready-with-ui-warning`, run `pwsh -NoProfile -File scripts/winsmux-core.ps1 orchestra-attach --json` once, rerun `orchestra-smoke --json`, and continue only after `operator_contract.can_dispatch=true`.
 9. External operator mode is fail-closed: visible attach unconfirmed means no dispatch.
-10. Never ask the user which task to begin when the live handoff already lists ordered next actions.
-11. Once `operator_contract.can_dispatch=true`, do not use Explore subagents for PR/task analysis. Use `pwsh -NoProfile -File scripts/winsmux-core.ps1 dispatch-task "<task text>"` or `dispatch-review`.
-12. Explore subagents are reserved for orchestra startup/status diagnosis only.
-13. Never use `psmux --version`, `Get-Process psmux-server`, or similar legacy probe commands for operator-side startup diagnosis.
-14. If pane expansion or attach confirmation does not succeed, treat the session as `blocked` and report the smoke/startup failure.
-15. Do not plan merge work while the orchestra session is still not dispatchable.
+10. Treat `called MCP`, plugin initialization chatter, and channel notifications as side output only. They must not be used as readiness evidence and must not override `operator_contract`.
+11. If hook validation noise, schema warnings, or an `Interrupted` result prevents a clean `orchestra-smoke --json` result from being obtained, treat startup as `blocked` and rerun the startup contract instead of continuing.
+12. Never ask the user which task to begin when the live handoff already lists ordered next actions.
+13. Once `operator_contract.can_dispatch=true`, do not use Explore subagents for PR/task analysis. Use `pwsh -NoProfile -File scripts/winsmux-core.ps1 dispatch-task "<task text>"` or `dispatch-review`.
+14. Explore subagents are reserved for orchestra startup/status diagnosis only.
+15. Never use `psmux --version`, `Get-Process psmux-server`, or similar legacy probe commands for operator-side startup diagnosis.
+16. If pane expansion or attach confirmation does not succeed, treat the session as `blocked` and report the smoke/startup failure.
+17. Do not plan merge work while the orchestra session is still not dispatchable.
 
 ## Builder Dispatch
 1. Check pane state: `winsmux capture-pane -t <pane> -p | tail -5`

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -83,6 +83,10 @@
         "hooks": [
           {
             "type": "command",
+            "command": "node .claude/hooks/sh-orchestra-gate.js"
+          },
+          {
+            "type": "command",
             "command": "node .claude/hooks/sh-permission.js"
           }
         ]
@@ -252,3 +256,11 @@
     ]
   }
 }
+
+
+
+
+
+
+
+

--- a/tests/HarnessContract.Tests.ps1
+++ b/tests/HarnessContract.Tests.ps1
@@ -41,6 +41,32 @@ Describe 'harness-check contract' {
             $null = $LASTEXITCODE
         }
 
+        function Backup-TestFile {
+            param([Parameter(Mandatory = $true)][string]$Path)
+
+            if (Test-Path -LiteralPath $Path -PathType Leaf) {
+                return Get-Content -LiteralPath $Path -Raw -Encoding UTF8
+            }
+
+            return $null
+        }
+
+        function Restore-TestFile {
+            param(
+                [Parameter(Mandatory = $true)][string]$Path,
+                [AllowNull()][string]$Content
+            )
+
+            if ($null -eq $Content) {
+                if (Test-Path -LiteralPath $Path -PathType Leaf) {
+                    Remove-Item -LiteralPath $Path -Force
+                }
+                return
+            }
+
+            Write-TestFileWithCmd -Path $Path -Content $Content
+        }
+
         function Invoke-HarnessCheckJson {
             param([string[]]$Arguments)
 
@@ -103,6 +129,29 @@ Describe 'harness-check contract' {
         ($result.Json.results | Where-Object { -not $_.passed }).Count | Should -Be 0
     }
 
+    It 'fails when shared settings stop registering the orchestra gate hook' {
+        $settingsPath = Join-Path $script:RepoRoot '.claude\settings.json'
+        $original = Backup-TestFile -Path $settingsPath
+        try {
+            $settings = $original | ConvertFrom-Json -Depth 32
+            $group = @($settings.hooks.PreToolUse) | Where-Object {
+                @($_.hooks | Where-Object { $_.command -eq 'node .claude/hooks/sh-orchestra-gate.js' }).Count -gt 0
+            } | Select-Object -First 1
+            $group.matcher = 'Bash'
+            $mutated = $settings | ConvertTo-Json -Depth 32
+            Write-TestFileWithCmd -Path $settingsPath -Content $mutated
+
+            $result = Invoke-HarnessCheckJson -Arguments @('-ProjectDir', $script:RepoRoot, '-AsJson')
+            $record = $result.Json.results | Where-Object { $_.name -eq 'settings-shared-registers-orchestra-gate' } | Select-Object -First 1
+
+            $result.ExitCode | Should -Be 1
+            $record.passed | Should -Be $false
+            $record.message | Should -Match 'must register'
+        } finally {
+            Restore-TestFile -Path $settingsPath -Content $original
+        }
+    }
+
     It 'fails when settings.local.json registers hooks' {
         Write-TestFileWithCmd -Path $script:SettingsLocalPath -Content '{"hooks":{"PreToolUse":[]}}'
 
@@ -129,6 +178,24 @@ Describe 'harness-check contract' {
         $result.Json.passed | Should -Be $false
         $trackedRecord.passed | Should -Be $false
         $trackedRecord.message | Should -Match 'must stay untracked'
+    }
+
+    It 'fails when sh-utils success replies omit hookEventName support' {
+        $utilsPath = Join-Path $script:RepoRoot '.claude\hooks\lib\sh-utils.js'
+        $original = Backup-TestFile -Path $utilsPath
+        try {
+            $mutated = $original -replace 'hookSpecificOutput:\s*buildHookSpecificOutput\(\{\s*additionalContext\s*\}\)', 'hookSpecificOutput: { additionalContext }'
+            Write-TestFileWithCmd -Path $utilsPath -Content $mutated
+
+            $result = Invoke-HarnessCheckJson -Arguments @('-ProjectDir', $script:RepoRoot, '-AsJson')
+            $record = $result.Json.results | Where-Object { $_.name -eq 'hook-output-contract' } | Select-Object -First 1
+
+            $result.ExitCode | Should -Be 1
+            $record.passed | Should -Be $false
+            (($record.data | Out-String)) | Should -Match 'allow reply does not include hookEventName'
+        } finally {
+            Restore-TestFile -Path $utilsPath -Content $original
+        }
     }
 
     It 'is exposed through winsmux-core as harness-check --json' {

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -6246,6 +6246,13 @@ Describe 'winsmux orchestra-smoke command' {
         $script:orchestraSmokeContent | Should -Match 'elseif \(\$AutoStart\)'
         $script:orchestraSmokeContent | Should -Match 'Skipped orchestra-start; run orchestra-start\.ps1 when operator_contract\.requires_startup is true\.'
     }
+
+    It 'keeps the structured operator contract independent from MCP or plugin chatter inputs' {
+        $script:orchestraSmokeContent | Should -Not -Match 'called MCP'
+        $script:orchestraSmokeContent | Should -Not -Match 'plugin initialization'
+        $script:orchestraSmokeContent | Should -Not -Match 'channel notifications'
+        $script:orchestraSmokeContent | Should -Match 'Get-OrchestraOperatorContract'
+    }
 }
 
 Describe 'operator startup restore contract docs' {
@@ -6266,6 +6273,10 @@ Describe 'operator startup restore contract docs' {
         $script:claudeGuideContent | Should -Match 'ready-with-ui-warning'
         $script:claudeGuideContent | Should -Match 'winsmux orchestra-attach --json'
         $script:claudeGuideContent | Should -Match 'winsmux dispatch-task'
+        $script:claudeGuideContent | Should -Match 'called MCP'
+        $script:claudeGuideContent | Should -Match 'plugin bootstrap messages must not be used as readiness evidence'
+        $script:claudeGuideContent | Should -Match 'hook validation noise'
+        $script:claudeGuideContent | Should -Match 'prevents a clean `winsmux orchestra-smoke --json` result from being obtained'
         $script:claudeGuideContent | Should -Match 'start the first pending action automatically instead of asking which task to begin'
         $script:claudeGuideContent | Should -Match 'do not use Explore subagents for PR/task analysis'
         $script:claudeGuideContent | Should -Match 'psmux --version'
@@ -6280,6 +6291,10 @@ Describe 'operator startup restore contract docs' {
         $script:dispatchRuleContent | Should -Match 'operator_contract\.can_dispatch'
         $script:dispatchRuleContent | Should -Match 'operator_contract\.requires_startup'
         $script:dispatchRuleContent | Should -Match 'ready-with-ui-warning'
+        $script:dispatchRuleContent | Should -Match 'called MCP'
+        $script:dispatchRuleContent | Should -Match 'must not be used as readiness evidence'
+        $script:dispatchRuleContent | Should -Match 'hook validation noise'
+        $script:dispatchRuleContent | Should -Match 'prevents a clean `orchestra-smoke --json` result from being obtained'
         $script:dispatchRuleContent | Should -Match 'Never ask the user which task to begin'
         $script:dispatchRuleContent | Should -Match 'Explore subagents are reserved for orchestra startup/status diagnosis only'
         $script:dispatchRuleContent | Should -Match 'psmux --version'

--- a/winsmux-core/scripts/harness-check.ps1
+++ b/winsmux-core/scripts/harness-check.ps1
@@ -93,6 +93,73 @@ function Test-HarnessSettingsLocalTracked {
     return ($LASTEXITCODE -eq 0)
 }
 
+function Test-HarnessSettingsHasHookCommand {
+    param(
+        [AllowNull()]$SettingsObject,
+        [Parameter(Mandatory = $true)][string]$EventName,
+        [Parameter(Mandatory = $true)][string]$Command,
+        [string]$Matcher = ''
+    )
+
+    if ($null -eq $SettingsObject -or -not (Test-HarnessHasProperty -Object $SettingsObject -Name 'hooks')) {
+        return $false
+    }
+
+    $hooksRoot = $SettingsObject.hooks
+    if (-not (Test-HarnessHasProperty -Object $hooksRoot -Name $EventName)) {
+        return $false
+    }
+
+    $eventHooks = @($hooksRoot.$EventName)
+    foreach ($group in $eventHooks) {
+        if (-not (Test-HarnessHasProperty -Object $group -Name 'hooks')) {
+            continue
+        }
+
+        $groupMatcher = if (Test-HarnessHasProperty -Object $group -Name 'matcher') { [string]$group.matcher } else { '' }
+        if ($groupMatcher -ne $Matcher) {
+            continue
+        }
+
+        foreach ($hook in @($group.hooks)) {
+            if ((Test-HarnessHasProperty -Object $hook -Name 'command') -and $hook.command -eq $Command) {
+                return $true
+            }
+        }
+    }
+
+    return $false
+}
+
+function Get-HarnessJsFunctionBlock {
+    param(
+        [Parameter(Mandatory = $true)][string]$Source,
+        [Parameter(Mandatory = $true)][string]$FunctionName
+    )
+
+    $functionMatches = [regex]::Matches($Source, '(?m)^\s*function\s+[A-Za-z0-9_]+\s*\(')
+    if ($functionMatches.Count -eq 0) {
+        return ''
+    }
+
+    $targetPattern = '(?m)^\s*function\s+' + [regex]::Escape($FunctionName) + '\s*\('
+    $targetMatch = [regex]::Match($Source, $targetPattern)
+    if (-not $targetMatch.Success) {
+        return ''
+    }
+
+    $startIndex = $targetMatch.Index
+    $endIndex = $Source.Length
+    foreach ($match in $functionMatches) {
+        if ($match.Index -gt $startIndex) {
+            $endIndex = $match.Index
+            break
+        }
+    }
+
+    return $Source.Substring($startIndex, $endIndex - $startIndex)
+}
+
 function Get-HarnessHookSignatureViolations {
     param([Parameter(Mandatory = $true)][string]$RepoRoot)
 
@@ -128,6 +195,15 @@ function Get-HarnessHookSignatureViolations {
         }
         if ($utilsContent -notmatch 'process\.exit\(0\)') {
             $violations.Add('.claude/hooks/lib/sh-utils.js does not keep successful structured hook replies on exit 0.') | Out-Null
+        }
+        if ($utilsContent -notmatch 'function\s+buildHookSpecificOutput\s*\(') {
+            $violations.Add('.claude/hooks/lib/sh-utils.js does not define a shared hookSpecificOutput builder.') | Out-Null
+        }
+        foreach ($functionName in @('allow', 'allowWithUpdate', 'allowWithResult')) {
+            $functionBlock = Get-HarnessJsFunctionBlock -Source $utilsContent -FunctionName $functionName
+            if ([string]::IsNullOrWhiteSpace($functionBlock) -or $functionBlock -notmatch 'buildHookSpecificOutput\s*\(') {
+                $violations.Add(".claude/hooks/lib/sh-utils.js $functionName reply does not include hookEventName via buildHookSpecificOutput.") | Out-Null
+            }
         }
     }
 
@@ -170,6 +246,10 @@ $settingsLocal = Get-HarnessSettingsObject -Path $settingsLocalPath
 $settingsExists = Test-Path -LiteralPath $settingsPath -PathType Leaf
 $settingsMessage = if ($settingsExists) { 'Project settings.json found.' } else { 'Missing .claude/settings.json.' }
 $results.Add((New-HarnessCheckRecord -Name 'settings-json-exists' -Passed $settingsExists -Message $settingsMessage -Data $settingsPath)) | Out-Null
+
+$sharedOrchestraGate = Test-HarnessSettingsHasHookCommand -SettingsObject $settings -EventName 'PreToolUse' -Matcher '' -Command 'node .claude/hooks/sh-orchestra-gate.js'
+$sharedOrchestraGateMessage = if ($sharedOrchestraGate) { 'Project settings.json registers the orchestra gate hook in the empty-matcher PreToolUse group.' } else { 'settings.json must register node .claude/hooks/sh-orchestra-gate.js in the empty-matcher PreToolUse group.' }
+$results.Add((New-HarnessCheckRecord -Name 'settings-shared-registers-orchestra-gate' -Passed $sharedOrchestraGate -Message $sharedOrchestraGateMessage -Data $settingsPath)) | Out-Null
 
 $localHasHooks = $false
 if ($null -ne $settingsLocal) {


### PR DESCRIPTION
## Summary\n- harden Claude Code hook and settings contract checks for startup\n- document fail-closed startup policy so MCP/plugin chatter does not affect readiness\n- add regressions for startup restore guidance and harness-check drift\n\n## Validation\n- Invoke-Pester tests\\winsmux-bridge.Tests.ps1 -CI\n- Invoke-Pester tests\\HarnessContract.Tests.ps1 -CI\n- pwsh -NoProfile -File .\\scripts\\audit-public-surface.ps1\n- pwsh -NoProfile -File .\\scripts\\git-guard.ps1 -Mode full