### PR TITLE
fix: harden orchestra attach and rollback boundaries

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -90,17 +90,18 @@ When `/winsmux-start` or another restoration flow reports `needs-startup`:
 5. Verify readiness with `winsmux orchestra-smoke --json`.
 6. Treat `operator_contract.operator_state`, `operator_contract.can_dispatch`, and `operator_contract.requires_startup` from that smoke result as the source of truth.
 7. Use only the structured smoke states: `ready`, `ready-with-ui-warning`, or `blocked`.
-8. If the state is `ready-with-ui-warning`, run `winsmux orchestra-attach --json` once to launch a visible operator window, then rerun `winsmux orchestra-smoke --json`.
-9. External operator mode remains fail-closed: if `ui_attached=false`, `operator_contract.can_dispatch` must stay `false`.
-10. Treat MCP or plugin chatter during startup as non-authoritative side output. `called MCP`, channel notifications, and plugin bootstrap messages must not be used as readiness evidence and must not override `operator_contract`.
-11. If hook validation noise, schema warnings, or an `Interrupted` result prevents a clean `winsmux orchestra-smoke --json` result from being obtained, stop fail-closed and treat the session as `blocked` until the startup contract is re-run cleanly.
-12. When `.claude/local/operator-handoff.md` contains an ordered `Next actions` list, start the first pending action automatically instead of asking which task to begin.
-13. Once `operator_contract.can_dispatch=true`, do not use Explore subagents for PR/task analysis. Dispatch the task through `winsmux dispatch-task "<task text>"` or `winsmux dispatch-review`.
-14. Startup/status Explore subagents are allowed only while diagnosing orchestra readiness or attach problems.
-15. Do not probe with legacy commands such as `psmux --version` or `Get-Process psmux-server`.
-16. Do not tell the user to manually start a `psmux` server.
-17. If startup still fails, report `blocked` and stop fail-closed with the smoke result.
-18. Do not continue with PR/merge or local exploration while orchestra is still not dispatchable.
+8. `ready-with-ui-warning` is not dispatch-ready. It means the session is healthy, but attached-client confirmation is still missing.
+9. If the state is `ready-with-ui-warning`, run `winsmux orchestra-attach --json` once to launch a visible operator window, then rerun `winsmux orchestra-smoke --json`.
+10. External operator mode remains fail-closed: if `ui_attached=false`, `operator_contract.can_dispatch` must stay `false`.
+11. Treat MCP or plugin chatter during startup as non-authoritative side output. `called MCP`, channel notifications, and plugin bootstrap messages must not be used as readiness evidence and must not override `operator_contract`.
+12. If hook validation noise, schema warnings, or an `Interrupted` result prevents a clean `winsmux orchestra-smoke --json` result from being obtained, stop fail-closed and treat the session as `blocked` until the startup contract is re-run cleanly.
+13. When `.claude/local/operator-handoff.md` contains an ordered `Next actions` list, start the first pending action automatically instead of asking which task to begin.
+14. Once `operator_contract.can_dispatch=true`, do not use Explore subagents for PR/task analysis. Dispatch the task through `winsmux dispatch-task "<task text>"` or `winsmux dispatch-review`.
+15. Startup/status Explore subagents are allowed only while diagnosing orchestra readiness or attach problems.
+16. Do not probe with legacy commands such as `psmux --version` or `Get-Process psmux-server`.
+17. Do not tell the user to manually start a `psmux` server.
+18. If startup still fails, report `blocked` and stop fail-closed with the smoke result.
+19. Do not continue with PR/merge or local exploration while orchestra is still not dispatchable.
 
 ## Compatibility and release notes
 

--- a/.claude/hooks/sh-circuit-breaker.js
+++ b/.claude/hooks/sh-circuit-breaker.js
@@ -43,17 +43,8 @@ try {
     // Evidence failure is non-blocking
   }
 
-  // Show checklist and allow stop
-  allow(
-    [
-      "[session-end] チェックリスト:",
-      "  □ Worktree 未コミット変更はないか？ (git worktree list)",
-      "  □ PR 提出済み / Builder への差し戻し完了？",
-      "  □ 外部 planning backlog のタスクステータスは最新か？",
-      "  □ 外部 ROADMAP の再 sync が必要か？ (sync-roadmap.ps1)",
-      "  □ HANDOFF.md は更新済みか？",
-    ].join("\n"),
-  );
+  // Stop hooks do not use hookSpecificOutput additionalContext. Keep this allow path silent.
+  allow();
 } catch (_err) {
   // Control hook — fail-open (allow stop on error)
   allow();

--- a/.claude/hooks/sh-pane-monitor.js
+++ b/.claude/hooks/sh-pane-monitor.js
@@ -13,6 +13,7 @@ const WINSMUX_DIR = path.join(PROJECT_ROOT, ".winsmux");
 const EVENTS_PATH = path.join(WINSMUX_DIR, "events.jsonl");
 const CURSOR_FILE_PREFIX = "monitor-cursor";
 const CURSOR_PATH = path.join(WINSMUX_DIR, `${CURSOR_FILE_PREFIX}.txt`);
+const MAX_ALERT_COUNT = 20;
 const ALERT_EVENTS = new Set([
   "pane.completed",
   "pane.crashed",
@@ -166,6 +167,14 @@ function readCursor(cursorPath = CURSOR_PATH) {
   }
 }
 
+function hasCursor(cursorPath = CURSOR_PATH) {
+  try {
+    return fs.existsSync(cursorPath);
+  } catch {
+    return false;
+  }
+}
+
 function writeCursor(cursor, cursorPath = CURSOR_PATH) {
   fs.mkdirSync(path.dirname(cursorPath), { recursive: true });
   fs.writeFileSync(cursorPath, `${cursor}\n`, "utf8");
@@ -252,17 +261,38 @@ function collectAlerts(content) {
     .filter(Boolean);
 }
 
+function formatAlertBatch(alerts) {
+  if (!Array.isArray(alerts) || alerts.length === 0) {
+    return "";
+  }
+
+  const visibleAlerts = alerts.slice(0, MAX_ALERT_COUNT);
+  if (alerts.length <= MAX_ALERT_COUNT) {
+    return visibleAlerts.join("\n");
+  }
+
+  const omittedCount = alerts.length - MAX_ALERT_COUNT;
+  return `${visibleAlerts.join("\n")}\n[PANE ALERT] ${omittedCount} older alerts omitted`;
+}
+
 function main() {
   try {
     const input = readHookInput();
     const cursorPath = getCursorPath(input);
+
+    if (!hasCursor(cursorPath)) {
+      const initialCursor = fs.existsSync(EVENTS_PATH) ? fs.statSync(EVENTS_PATH).size : 0;
+      writeCursor(initialCursor, cursorPath);
+      allow();
+      return;
+    }
 
     const chunk = readNewEventChunk(EVENTS_PATH, cursorPath);
     writeCursor(chunk.cursor, cursorPath);
 
     const alerts = collectAlerts(chunk.content);
     if (alerts.length > 0) {
-      allow(alerts.join("\n"));
+      allow(formatAlertBatch(alerts));
       return;
     }
   } catch {
@@ -289,6 +319,8 @@ module.exports = {
   isAlertEvent,
   parseManifestProjectDir,
   parseEventLines,
+  formatAlertBatch,
+  hasCursor,
   readCursor,
   readProjectDirFromManifest,
   readNewEventChunk,

--- a/.claude/rules/dispatch.md
+++ b/.claude/rules/dispatch.md
@@ -11,20 +11,21 @@ paths: ["winsmux-core/scripts/**", ".claude/**"]
 4. Then run `pwsh -NoProfile -File winsmux-core/scripts/orchestra-start.ps1`.
 5. Then run `pwsh -NoProfile -File scripts/winsmux-core.ps1 orchestra-smoke --json`.
 6. Verify `operator_contract.operator_state`, `operator_contract.can_dispatch`, and `operator_contract.requires_startup` from the smoke JSON before any PR triage, merge action, backlog reading, or task dispatch.
-7. Allowed dispatchable states are:
+7. Allowed structured startup states are:
    - `ready`
    - `ready-with-ui-warning`
    Any other state is fail-closed.
-8. If the state is `ready-with-ui-warning`, run `pwsh -NoProfile -File scripts/winsmux-core.ps1 orchestra-attach --json` once, rerun `orchestra-smoke --json`, and continue only after `operator_contract.can_dispatch=true`.
-9. External operator mode is fail-closed: visible attach unconfirmed means no dispatch.
-10. Treat `called MCP`, plugin initialization chatter, and channel notifications as side output only. They must not be used as readiness evidence and must not override `operator_contract`.
-11. If hook validation noise, schema warnings, or an `Interrupted` result prevents a clean `orchestra-smoke --json` result from being obtained, treat startup as `blocked` and rerun the startup contract instead of continuing.
-12. Never ask the user which task to begin when the live handoff already lists ordered next actions.
-13. Once `operator_contract.can_dispatch=true`, do not use Explore subagents for PR/task analysis. Use `pwsh -NoProfile -File scripts/winsmux-core.ps1 dispatch-task "<task text>"` or `dispatch-review`.
-14. Explore subagents are reserved for orchestra startup/status diagnosis only.
-15. Never use `psmux --version`, `Get-Process psmux-server`, or similar legacy probe commands for operator-side startup diagnosis.
-16. If pane expansion or attach confirmation does not succeed, treat the session as `blocked` and report the smoke/startup failure.
-17. Do not plan merge work while the orchestra session is still not dispatchable.
+8. `ready-with-ui-warning` is not dispatch-ready. It means the session is healthy, but attached-client confirmation is still missing.
+9. If the state is `ready-with-ui-warning`, run `pwsh -NoProfile -File scripts/winsmux-core.ps1 orchestra-attach --json` once, rerun `orchestra-smoke --json`, and continue only after `operator_contract.can_dispatch=true`.
+10. External operator mode is fail-closed: visible attach unconfirmed means no dispatch.
+11. Treat `called MCP`, plugin initialization chatter, and channel notifications as side output only. They must not be used as readiness evidence and must not override `operator_contract`.
+12. If hook validation noise, schema warnings, or an `Interrupted` result prevents a clean `orchestra-smoke --json` result from being obtained, treat startup as `blocked` and rerun the startup contract instead of continuing.
+13. Never ask the user which task to begin when the live handoff already lists ordered next actions.
+14. Once `operator_contract.can_dispatch=true`, do not use Explore subagents for PR/task analysis. Use `pwsh -NoProfile -File scripts/winsmux-core.ps1 dispatch-task "<task text>"` or `dispatch-review`.
+15. Explore subagents are reserved for orchestra startup/status diagnosis only.
+16. Never use `psmux --version`, `Get-Process psmux-server`, or similar legacy probe commands for operator-side startup diagnosis.
+17. If pane expansion or attach confirmation does not succeed, treat the session as `blocked` and report the smoke/startup failure.
+18. Do not plan merge work while the orchestra session is still not dispatchable.
 
 ## Builder Dispatch
 1. Check pane state: `winsmux capture-pane -t <pane> -p | tail -5`

--- a/tests/Integration.PaneMonitorHook.Tests.ps1
+++ b/tests/Integration.PaneMonitorHook.Tests.ps1
@@ -123,7 +123,7 @@ session:
         $script:FixtureRoot = $null
     }
 
-    It 'reads new pane events and emits alerts' {
+    It 'bootstraps a new session cursor at EOF without replaying historical alerts' {
         $fixture = New-PaneMonitorFixture
         $script:FixtureRoot = $fixture.Root
 
@@ -143,11 +143,7 @@ session:
         })
 
         $result['ExitCode'] | Should -Be 0
-        $result['OutputObject'] | Should -Not -BeNullOrEmpty
-        $context = [string]$result['OutputObject'].hookSpecificOutput.additionalContext
-        $context | Should -Match '\[PANE ALERT\] builder-1 completed'
-        $context | Should -Match '\[PANE ALERT\] reviewer crashed'
-        $context | Should -Match '\[PANE ALERT\] approver awaiting approval'
+        $result['OutputObject'] | Should -Be $null
 
         $expectedCursor = (Get-Item -LiteralPath $fixture.EventsPath).Length
         $cursorPath = Join-Path $fixture.WinsmuxDir 'monitor-cursor-session-1.txt'
@@ -171,7 +167,7 @@ session:
         $second['OutputObject'] | Should -Be $null
     }
 
-    It 'persists the cursor and only reports newly appended events' {
+    It 'reports only events appended after the initial cursor bootstrap' {
         $fixture = New-PaneMonitorFixture
         $script:FixtureRoot = $fixture.Root
 
@@ -180,7 +176,7 @@ session:
 
         $first = Invoke-PaneMonitorHook -RepoRoot $fixture.RepoRoot -Payload (New-PaneMonitorPayload -ToolName 'Read' -ToolInput ([ordered]@{ file_path = 'docs\handoff.md' }))
         $first['ExitCode'] | Should -Be 0
-        ([string]$first['OutputObject'].hookSpecificOutput.additionalContext) | Should -Match '\[PANE ALERT\] builder-1 completed'
+        $first['OutputObject'] | Should -Be $null
 
         Add-Content -Path $fixture.EventsPath -Value ([ordered]@{ event = 'pane.crashed'; label = 'reviewer'; pane_id = '%4' } | ConvertTo-Json -Compress) -Encoding UTF8
 
@@ -196,7 +192,7 @@ session:
         (Get-Content -LiteralPath $cursorPath -Raw -Encoding UTF8).Trim() | Should -Be "$expectedCursor"
     }
 
-    It 'keeps cursor state isolated per session' {
+    It 'keeps cursor state isolated per session after bootstrap' {
         $fixture = New-PaneMonitorFixture
         $script:FixtureRoot = $fixture.Root
 
@@ -208,14 +204,16 @@ session:
 
         $sessionOneFirst['ExitCode'] | Should -Be 0
         $sessionTwoFirst['ExitCode'] | Should -Be 0
-        ([string]$sessionOneFirst['OutputObject'].hookSpecificOutput.additionalContext) | Should -Match '\[PANE ALERT\] builder-1 completed'
-        ([string]$sessionTwoFirst['OutputObject'].hookSpecificOutput.additionalContext) | Should -Match '\[PANE ALERT\] builder-1 completed'
+        $sessionOneFirst['OutputObject'] | Should -Be $null
+        $sessionTwoFirst['OutputObject'] | Should -Be $null
+
+        Add-Content -Path $fixture.EventsPath -Value ([ordered]@{ event = 'pane.crashed'; label = 'reviewer'; pane_id = '%4' } | ConvertTo-Json -Compress) -Encoding UTF8
 
         $sessionOneSecond = Invoke-PaneMonitorHook -RepoRoot $fixture.RepoRoot -Payload (New-PaneMonitorPayload -ToolName 'Read' -ToolInput ([ordered]@{ file_path = 'docs\handoff.md' }) -SessionId 'session-1')
         $sessionTwoSecond = Invoke-PaneMonitorHook -RepoRoot $fixture.RepoRoot -Payload (New-PaneMonitorPayload -ToolName 'Read' -ToolInput ([ordered]@{ file_path = 'docs\handoff.md' }) -SessionId 'session-2')
 
-        $sessionOneSecond['OutputObject'] | Should -Be $null
-        $sessionTwoSecond['OutputObject'] | Should -Be $null
+        ([string]$sessionOneSecond['OutputObject'].hookSpecificOutput.additionalContext) | Should -Match '\[PANE ALERT\] reviewer crashed'
+        ([string]$sessionTwoSecond['OutputObject'].hookSpecificOutput.additionalContext) | Should -Match '\[PANE ALERT\] reviewer crashed'
         Test-Path (Join-Path $fixture.WinsmuxDir 'monitor-cursor-session-1.txt') | Should -BeTrue
         Test-Path (Join-Path $fixture.WinsmuxDir 'monitor-cursor-session-2.txt') | Should -BeTrue
     }

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -1515,6 +1515,8 @@ panes:
 Describe 'logger helpers' {
     BeforeAll {
         . (Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\logger.ps1')
+        $script:clmSafeIoContent = Get-Content -Path (Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\clm-safe-io.ps1') -Raw -Encoding UTF8
+        $script:loggerPwshPath = (Get-Command pwsh -ErrorAction Stop).Source
     }
 
     BeforeEach {
@@ -1561,6 +1563,68 @@ Describe 'logger helpers' {
         $records[0].data.panes | Should -Be 3
         $records[1].level | Should -Be 'warn'
         $records[1].data.finding_count | Should -Be 2
+    }
+
+    It 'serializes concurrent jsonl appends across multiple PowerShell processes' {
+        $logPath = Join-Path $script:loggerTempRoot '.winsmux\logs\concurrent.jsonl'
+        $workerScriptPath = Join-Path $script:loggerTempRoot 'append-worker.ps1'
+        $clmSafeIoPath = Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\clm-safe-io.ps1'
+        $workerScript = (@'
+param(
+    [Parameter(Mandatory = $true)][string]$TargetPath,
+    [Parameter(Mandatory = $true)][int]$WorkerId
+)
+
+. '{0}'
+
+1..20 | ForEach-Object {{
+    Write-WinsmuxTextFile -Path $TargetPath -Content ("worker=$WorkerId seq=$_") -Append
+}}
+'@) -f ($clmSafeIoPath -replace "'", "''")
+
+        Set-Content -Path $workerScriptPath -Value $workerScript -Encoding UTF8
+
+        $processes = 1..3 | ForEach-Object {
+            Start-Process -FilePath $script:loggerPwshPath -ArgumentList @('-NoProfile', '-File', $workerScriptPath, '-TargetPath', $logPath, '-WorkerId', $_) -PassThru -WindowStyle Hidden
+        }
+
+        foreach ($process in $processes) {
+            $process.WaitForExit(180000) | Should -Be $true
+            $process.ExitCode | Should -Be 0
+        }
+
+        $lines = @(Get-Content -Path $logPath -Encoding UTF8 | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+        $lines.Count | Should -Be 60
+        @($lines | Select-Object -Unique).Count | Should -Be 60
+    }
+
+    It 'reclaims stale file locks left by dead processes' {
+        $logPath = Join-Path $script:loggerTempRoot '.winsmux\logs\stale.jsonl'
+        $lockDir = "$logPath.lock"
+        $metadataPath = Join-Path $lockDir 'owner.json'
+
+        New-Item -ItemType Directory -Path $lockDir -Force | Out-Null
+        @"
+{"pid":999999,"started_at":"2000-01-01T00:00:00Z"}
+"@ | Set-Content -Path $metadataPath -Encoding UTF8
+
+        Write-WinsmuxTextFile -Path $logPath -Content 'stale-lock-recovered' -Append
+
+        $lines = @(Get-Content -Path $logPath -Encoding UTF8 | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+        $lines.Count | Should -Be 1
+        $lines[0] | Should -Be 'stale-lock-recovered'
+        (Test-Path -LiteralPath $lockDir -PathType Container) | Should -Be $false
+    }
+
+    It 'keeps CLM-safe writes on cmd-based lock and replace primitives' {
+        $script:clmSafeIoContent | Should -Match 'function Get-WinsmuxFileLockDir'
+        $script:clmSafeIoContent | Should -Match 'function Test-WinsmuxFileLockStale'
+        $script:clmSafeIoContent | Should -Match 'cmd /d /c \(''mkdir'
+        $script:clmSafeIoContent | Should -Match 'cmd /d /c \(''move /y'
+        $script:clmSafeIoContent | Should -Match 'owner\.json'
+        $script:clmSafeIoContent | Should -Not -Match 'System\.Threading\.Mutex'
+        $script:clmSafeIoContent | Should -Not -Match 'System\.IO\.File'
+        $script:clmSafeIoContent | Should -Not -Match 'StreamWriter'
     }
 }
 
@@ -2829,6 +2893,9 @@ Describe 'orchestra-start server bootstrap' {
         Mock Write-OrchestraAttachState {
             [pscustomobject]@{}
         }
+        Mock Wait-OrchestraAttachLaunchObservation {
+            [PSCustomObject]@{ Observed = $true; Reason = 'launch observed' }
+        }
         Mock Wait-OrchestraAttachHandshake {
             [PSCustomObject][ordered]@{
                 Confirmed           = $true
@@ -2867,16 +2934,25 @@ Describe 'orchestra-start server bootstrap' {
         $result.Source | Should -Be 'handshake'
         $script:startProcessCalls.Count | Should -Be 1
         $script:startProcessCalls[0].FilePath | Should -Be 'C:\Windows\System32\wt.exe'
-        $script:startProcessCalls[0].ArgumentList | Should -Be @('-w', '-1', 'new-tab', '-p', 'winsmux orchestra attach')
+        $script:startProcessCalls[0].ArgumentList | Should -Be @('-w', '-1', 'new-window', '-p', 'winsmux orchestra attach')
     }
 
-    It 'returns attach_already_present when a visible client already exists' {
+    It 'returns attach_already_present only when a live visible attach state already exists' {
         $script:startProcessCalls = @()
         $script:winsmuxBin = 'C:\winsmux\winsmux.exe'
 
         Mock Get-OrchestraAttachedClientSnapshot {
             [PSCustomObject]@{ Ok = $true; Count = 1; Error = ''; Clients = @('client-1') }
         }
+        Mock Read-OrchestraAttachState {
+            [pscustomobject]@{
+                session_name     = 'winsmux-orchestra'
+                attach_status    = 'attach_confirmed'
+                ui_attach_source = 'handshake'
+                attach_process_id = 4242
+            }
+        }
+        Mock Test-OrchestraLiveVisibleAttachState { $true }
         Mock Write-OrchestraAttachState {
             [pscustomobject]@{}
         }
@@ -2896,15 +2972,176 @@ Describe 'orchestra-start server bootstrap' {
         $result.Launched | Should -Be $false
         $result.Attached | Should -Be $true
         $result.Status | Should -Be 'attach_already_present'
+        $result.Source | Should -Be 'handshake'
+        $script:startProcessCalls.Count | Should -Be 0
+    }
+
+    It 'preserves a client-probe confirmation source when the live attach process is still alive' {
+        $script:startProcessCalls = @()
+        $script:winsmuxBin = 'C:\winsmux\winsmux.exe'
+
+        Mock Get-OrchestraAttachedClientSnapshot {
+            [PSCustomObject]@{ Ok = $true; Count = 1; Error = ''; Clients = @('client-1') }
+        }
+        Mock Read-OrchestraAttachState {
+            [pscustomobject]@{
+                session_name      = 'winsmux-orchestra'
+                attach_status     = 'attach_confirmed'
+                ui_attach_source  = 'client-probe'
+                attach_process_id = 4242
+            }
+        }
+        Mock Test-OrchestraProcessAlive { $true }
+        Mock Write-OrchestraAttachState {
+            [pscustomobject]@{}
+        }
+
+        $result = Try-StartOrchestraUiAttach -SessionName 'winsmux-orchestra'
+
+        $result.Attempted | Should -Be $false
+        $result.Launched | Should -Be $false
+        $result.Attached | Should -Be $true
+        $result.Status | Should -Be 'attach_already_present'
         $result.Source | Should -Be 'client-probe'
         $script:startProcessCalls.Count | Should -Be 0
     }
 
-    It 'fails closed when Windows Terminal is unavailable instead of falling back to dynamic attach commands' {
+    It 'does not suppress attach from client-probe alone when no live visible attach state exists' {
+        $script:startProcessCalls = @()
+        $script:winsmuxBin = 'C:\winsmux\winsmux.exe'
+
+        Mock Get-OrchestraAttachedClientSnapshot {
+            [PSCustomObject]@{ Ok = $true; Count = 1; Error = ''; Clients = @('client-1') }
+        }
+        Mock Read-OrchestraAttachState { $null }
+        Mock Test-OrchestraLiveVisibleAttachState { $false }
+        Mock Get-OrchestraWindowsTerminalInfo {
+            [PSCustomObject][ordered]@{
+                Available   = $true
+                Path        = 'C:\Windows\System32\wt.exe'
+                AliasPath   = ''
+                IsAliasStub = $false
+                PathSource  = 'command'
+                Reason      = 'ready'
+            }
+        }
+        Mock Ensure-OrchestraAttachProfile {
+            [PSCustomObject][ordered]@{
+                ProfileName  = 'winsmux orchestra attach'
+                FragmentPath = 'C:\Users\komei\AppData\Local\Microsoft\Windows Terminal\Fragments\winsmux\winsmux-orchestra-attach.json'
+                Commandline  = '"C:\Program Files\PowerShell\7\pwsh.exe" -NoLogo -NoExit -File "C:\repo\winsmux-core\scripts\orchestra-attach-entry.ps1"'
+            }
+        }
+        Mock Write-OrchestraAttachState {
+            [pscustomobject]@{}
+        }
+        Mock Wait-OrchestraAttachLaunchObservation {
+            [PSCustomObject]@{ Observed = $true; Reason = 'launch observed' }
+        }
+        Mock Wait-OrchestraAttachHandshake {
+            [PSCustomObject][ordered]@{
+                Confirmed           = $true
+                Source              = 'handshake'
+                Status              = 'attach_confirmed'
+                Reason              = 'Attach confirmed'
+                AttachedClientCount = 2
+                State               = [pscustomobject]@{}
+            }
+        }
+
+        function Start-Process {
+            param([string]$FilePath, [object[]]$ArgumentList, [switch]$PassThru)
+            $script:startProcessCalls += ,([PSCustomObject]@{
+                FilePath     = $FilePath
+                ArgumentList = @($ArgumentList)
+            })
+            return [PSCustomObject]@{ HasExited = $true }
+        }
+
+        $result = Try-StartOrchestraUiAttach -SessionName 'winsmux-orchestra'
+
+        $result.Attempted | Should -Be $true
+        $result.Launched | Should -Be $true
+        $result.Attached | Should -Be $true
+        $result.Status | Should -Be 'attach_confirmed'
+        $result.Source | Should -Be 'handshake'
+        $script:startProcessCalls.Count | Should -Be 1
+    }
+
+    It 'falls back to a direct PowerShell visible attach host when Windows Terminal launch does not advance attach state' {
+        $script:startProcessCalls = @()
+        $script:winsmuxBin = 'C:\winsmux\winsmux.exe'
+
+        Mock Get-OrchestraAttachedClientSnapshot {
+            [PSCustomObject]@{ Ok = $true; Count = 1; Error = ''; Clients = @('client-1') }
+        }
+        Mock Read-OrchestraAttachState { $null }
+        Mock Test-OrchestraLiveVisibleAttachState { $false }
+        Mock Get-OrchestraWindowsTerminalInfo {
+            [PSCustomObject][ordered]@{
+                Available   = $true
+                Path        = 'C:\Windows\System32\wt.exe'
+                AliasPath   = ''
+                IsAliasStub = $false
+                PathSource  = 'command'
+                Reason      = 'ready'
+            }
+        }
+        Mock Ensure-OrchestraAttachProfile {
+            [PSCustomObject][ordered]@{
+                ProfileName  = 'winsmux orchestra attach'
+                FragmentPath = 'C:\Users\komei\AppData\Local\Microsoft\Windows Terminal\Fragments\winsmux\winsmux-orchestra-attach.json'
+                Commandline  = '"C:\Program Files\PowerShell\7\pwsh.exe" -NoLogo -NoExit -File "C:\repo\winsmux-core\scripts\orchestra-attach-entry.ps1"'
+            }
+        }
+        Mock Write-OrchestraAttachState {
+            [pscustomobject]@{}
+        }
+        Mock Wait-OrchestraAttachLaunchObservation {
+            [PSCustomObject]@{ Observed = $false; Reason = 'no attach state change observed' }
+        }
+        Mock Get-OrchestraPowerShellPath { 'C:\Program Files\PowerShell\7\pwsh.exe' }
+        Mock Get-OrchestraAttachEntryArgumentList { @('-NoLogo', '-NoExit', '-File', 'C:\repo\winsmux-core\scripts\orchestra-attach-entry.ps1') }
+        Mock Wait-OrchestraAttachHandshake {
+            [PSCustomObject][ordered]@{
+                Confirmed           = $true
+                Source              = 'handshake'
+                Status              = 'attach_confirmed'
+                Reason              = 'Attach confirmed after fallback'
+                AttachedClientCount = 1
+                State               = [pscustomobject]@{}
+            }
+        }
+
+        function Start-Process {
+            param([string]$FilePath, [object[]]$ArgumentList, [switch]$PassThru)
+            $script:startProcessCalls += ,([PSCustomObject]@{
+                FilePath     = $FilePath
+                ArgumentList = @($ArgumentList)
+            })
+            return [PSCustomObject]@{ HasExited = $false }
+        }
+
+        $result = Try-StartOrchestraUiAttach -SessionName 'winsmux-orchestra'
+
+        $result.Attempted | Should -Be $true
+        $result.Launched | Should -Be $true
+        $result.Attached | Should -Be $true
+        $result.Status | Should -Be 'attach_confirmed'
+        $result.Path | Should -Be 'C:\Program Files\PowerShell\7\pwsh.exe'
+        $script:startProcessCalls.Count | Should -Be 2
+        $script:startProcessCalls[0].FilePath | Should -Be 'C:\Windows\System32\wt.exe'
+        $script:startProcessCalls[1].FilePath | Should -Be 'C:\Program Files\PowerShell\7\pwsh.exe'
+    }
+
+    It 'falls back to a direct PowerShell visible attach host when Windows Terminal is unavailable' {
+        $script:startProcessCalls = @()
         $script:winsmuxBin = 'C:\winsmux\winsmux.exe'
         Mock Get-OrchestraAttachedClientSnapshot {
             [PSCustomObject]@{ Ok = $true; Count = 0; Error = ''; Clients = @() }
         }
+        Mock Read-OrchestraAttachState { $null }
+        Mock Test-OrchestraLiveVisibleAttachState { $false }
         Mock Get-OrchestraWindowsTerminalInfo {
             [PSCustomObject][ordered]@{
                 Available   = $false
@@ -2918,14 +3155,109 @@ Describe 'orchestra-start server bootstrap' {
         Mock Write-OrchestraAttachState {
             [pscustomobject]@{}
         }
+        Mock Get-OrchestraPowerShellPath { 'C:\Program Files\PowerShell\7\pwsh.exe' }
+        Mock Get-OrchestraAttachEntryArgumentList { @('-NoLogo', '-NoExit', '-File', 'C:\repo\winsmux-core\scripts\orchestra-attach-entry.ps1') }
+        Mock Wait-OrchestraAttachHandshake {
+            [PSCustomObject][ordered]@{
+                Confirmed           = $true
+                Source              = 'handshake'
+                Status              = 'attach_confirmed'
+                Reason              = 'Attach confirmed via fallback host'
+                AttachedClientCount = 1
+                State               = [pscustomobject]@{}
+            }
+        }
+
+        function Start-Process {
+            param([string]$FilePath, [object[]]$ArgumentList, [switch]$PassThru)
+            $script:startProcessCalls += ,([PSCustomObject]@{
+                FilePath     = $FilePath
+                ArgumentList = @($ArgumentList)
+            })
+            return [PSCustomObject]@{ HasExited = $false }
+        }
 
         $result = Try-StartOrchestraUiAttach -SessionName 'winsmux-orchestra'
 
-        $result.Attempted | Should -Be $false
-        $result.Launched | Should -Be $false
-        $result.Attached | Should -Be $false
+        $result.Attempted | Should -Be $true
+        $result.Launched | Should -Be $true
+        $result.Attached | Should -Be $true
+        $result.Status | Should -Be 'attach_confirmed'
+        $result.Path | Should -Be 'C:\Program Files\PowerShell\7\pwsh.exe'
+        $result.Source | Should -Be 'handshake'
+        $script:startProcessCalls.Count | Should -Be 1
+        $script:startProcessCalls[0].FilePath | Should -Be 'C:\Program Files\PowerShell\7\pwsh.exe'
+    }
+
+    It 'confirms visible attach on client transition even when client count does not increase' {
+        $script:attachStateReads = 0
+
+        Mock Read-OrchestraAttachState {
+            $script:attachStateReads++
+            [pscustomobject]@{
+                session_name      = 'winsmux-orchestra'
+                attach_status     = 'attach_entry_started'
+                ui_attach_source  = 'none'
+                attach_process_id = 4242
+                baseline_clients  = @('client-old')
+            }
+        }
+        Mock Get-OrchestraAttachedClientSnapshot {
+            [PSCustomObject]@{
+                Ok      = $true
+                Count   = 1
+                Error   = ''
+                Clients = @('client-new')
+            }
+        }
+        Mock Test-OrchestraProcessAlive { $true }
+        Mock Write-OrchestraAttachState {
+            param([string]$SessionName, [hashtable]$Properties)
+            [pscustomobject]$Properties
+        }
+        function Start-Sleep {
+            param([int]$Milliseconds)
+        }
+
+        $result = Wait-OrchestraAttachHandshake -SessionName 'winsmux-orchestra' -WinsmuxBin 'C:\winsmux\winsmux.exe' -BaselineClientCount 1 -BaselineClients @('client-old') -TimeoutMilliseconds 1000 -PollMilliseconds 1
+
+        $result.Confirmed | Should -Be $true
+        $result.Source | Should -Be 'handshake'
+        $result.Status | Should -Be 'attach_confirmed'
+        $result.AttachedClientCount | Should -Be 1
+    }
+
+    It 'does not confirm attach from a first client when baseline is empty and attach entry never started' {
+        Mock Read-OrchestraAttachState {
+            [pscustomobject]@{
+                session_name      = 'winsmux-orchestra'
+                attach_status     = 'attach_requested'
+                ui_attach_source  = 'none'
+                attach_process_id = 0
+                baseline_clients  = @()
+            }
+        }
+        Mock Get-OrchestraAttachedClientSnapshot {
+            [PSCustomObject]@{
+                Ok      = $true
+                Count   = 1
+                Error   = ''
+                Clients = @('client-1')
+            }
+        }
+        Mock Write-OrchestraAttachState {
+            param([string]$SessionName, [hashtable]$Properties)
+            [pscustomobject]$Properties
+        }
+        function Start-Sleep {
+            param([int]$Milliseconds)
+        }
+
+        $result = Wait-OrchestraAttachHandshake -SessionName 'winsmux-orchestra' -WinsmuxBin 'C:\winsmux\winsmux.exe' -BaselineClientCount 0 -BaselineClients @() -TimeoutMilliseconds 5 -PollMilliseconds 1
+
+        $result.Confirmed | Should -Be $false
         $result.Status | Should -Be 'attach_failed'
-        $result.Source | Should -Be 'none'
+        $result.Reason | Should -Match 'Attach confirmation timed out before client count reached 1'
     }
 
     It 'checks the bootstrap pane count before reporting startup ready' {
@@ -3004,6 +3336,15 @@ Describe 'orchestra-start server bootstrap' {
             $script:clearCalls++
         }
 
+        function Wait-OrchestraServerSessionAbsent {
+            param([string]$SessionName, [int]$TimeoutSeconds = 20)
+            $script:waitCalls++
+            return [ordered]@{
+                Ready       = $true
+                PollAttempt = 1
+            }
+        }
+
         function Ensure-OrchestraBootstrapSession {
             param([string]$SessionName, [int]$TimeoutSeconds = 60, [int]$ExpectedPaneCount = 1)
             $script:ensureCalls++
@@ -3027,7 +3368,7 @@ Describe 'orchestra-start server bootstrap' {
         $script:killCalls | Should -Be 1
         $script:clearCalls | Should -Be 1
         $script:ensureCalls | Should -Be 1
-        $script:waitCalls | Should -Be 0
+        $script:waitCalls | Should -Be 1
         $script:ensureTimeoutSeconds | Should -Be 60
         $script:ensureExpectedPaneCount | Should -Be 1
     }
@@ -3138,8 +3479,24 @@ Describe 'orchestra-start server bootstrap' {
 
         Mock Get-OrchestraAttachedClientSnapshot {
             [PSCustomObject][ordered]@{
-                Ok    = $true
-                Count = 0
+                Ok      = $true
+                Count   = 0
+                Clients = @()
+            }
+        }
+        Mock Read-OrchestraAttachState { $null }
+        Mock Test-OrchestraLiveVisibleAttachState { $false }
+        Mock Write-OrchestraAttachState { [pscustomobject]@{} }
+        Mock Get-OrchestraPowerShellPath { 'C:\Program Files\PowerShell\7\pwsh.exe' }
+        Mock Get-OrchestraAttachEntryArgumentList { @('-NoLogo', '-NoExit', '-File', 'C:\repo\winsmux-core\scripts\orchestra-attach-entry.ps1') }
+        Mock Wait-OrchestraAttachHandshake {
+            [PSCustomObject][ordered]@{
+                Confirmed           = $true
+                Source              = 'handshake'
+                Status              = 'attach_confirmed'
+                Reason              = 'Attach confirmed via fallback host'
+                AttachedClientCount = 1
+                State               = [pscustomobject]@{}
             }
         }
 
@@ -3158,12 +3515,12 @@ Describe 'orchestra-start server bootstrap' {
 
         $result = Try-StartOrchestraUiAttach -SessionName 'winsmux-orchestra'
 
-        $result.Attempted | Should -Be $false
-        $result.Launched | Should -Be $false
-        $result.Attached | Should -Be $false
-        $result.Status | Should -Be 'attach_failed'
-        $result.Reason | Should -Match 'Windows Terminal is not installed or not on PATH'
-        $script:startProcessCalls.Count | Should -Be 0
+        $result.Attempted | Should -Be $true
+        $result.Launched | Should -Be $true
+        $result.Attached | Should -Be $true
+        $result.Status | Should -Be 'attach_confirmed'
+        $script:startProcessCalls.Count | Should -Be 1
+        $script:startProcessCalls[0].FilePath | Should -Be 'C:\Program Files\PowerShell\7\pwsh.exe'
     }
 
     It 'skips UI attach when winsmux cannot be resolved to an absolute path for the child process' {
@@ -3271,6 +3628,30 @@ Describe 'orchestra-start session reuse contract' {
     It 'does not mark session_ready true in the manifest until watchdog processes are started' {
         $script:orchestraStartContent | Should -Match 'Save-OrchestraSessionState[^\r\n]+SessionReady \$false'
         $script:orchestraStartContent | Should -Match 'Save-OrchestraSessionState[^\r\n]+CommanderPollPid \$commanderPollProcess\.Id[^\r\n]+SessionReady \$true'
+    }
+
+    It 'keeps detached startup on the session-ready path even when visible attach still needs retry' {
+        $script:orchestraStartContent | Should -Match '\$successfulAttachStatuses\s*=\s*@\(''attach_confirmed'', ''attach_already_present''\)'
+        $script:orchestraStartContent | Should -Match 'if \(\$successfulAttachStatuses -notcontains \[string\]\$uiAttachResult\.Status\) \{\s*Write-Warning'
+        $script:orchestraStartContent | Should -Match 'Save-OrchestraSessionState[^\r\n]+SessionReady \$false[^\r\n]+UiAttachLaunched \(\[bool\]\$uiAttachResult\.Launched\)[^\r\n]+UiAttached \(\[bool\]\$uiAttachResult\.Attached\)'
+        $script:orchestraStartContent | Should -Match 'Save-OrchestraSessionState[^\r\n]+SessionReady \$true[^\r\n]+UiAttachLaunched \(\[bool\]\$uiAttachResult\.Launched\)[^\r\n]+UiAttached \(\[bool\]\$uiAttachResult\.Attached\)'
+        $script:orchestraStartContent | Should -Match 'reached session-ready; UI attach remains a separate state'
+    }
+
+    It 'does not route visible attach retry conditions into startup rollback handling' {
+        $script:orchestraStartContent | Should -Match '\$uiAttachResult\s*=\s*Try-StartOrchestraUiAttach -SessionName \$sessionName'
+        $script:orchestraStartContent | Should -Match 'Write-Warning "Orchestra UI attach status for \$\{sessionName\}: \$\(\$uiAttachResult\.Status\) \(\$\(\$uiAttachResult\.Reason\)\)"'
+        $script:orchestraStartContent | Should -Match '\$rollback = Invoke-OrchestraStartupRollback -ProjectDir \$projectDir -SessionName \$sessionName'
+
+        $uiAttachIndex = $script:orchestraStartContent.IndexOf('$uiAttachResult = Try-StartOrchestraUiAttach -SessionName $sessionName')
+        $warningIndex = $script:orchestraStartContent.IndexOf('Write-Warning "Orchestra UI attach status for ${sessionName}: $($uiAttachResult.Status) ($($uiAttachResult.Reason))"')
+        $rollbackIndex = $script:orchestraStartContent.IndexOf('$rollback = Invoke-OrchestraStartupRollback -ProjectDir $projectDir -SessionName $sessionName')
+        $sessionReadyLogIndex = $script:orchestraStartContent.IndexOf("Write-WinsmuxLog -Level INFO -Event 'orchestra.startup.session_ready'")
+
+        $uiAttachIndex | Should -BeGreaterThan -1
+        $warningIndex | Should -BeGreaterThan $uiAttachIndex
+        $sessionReadyLogIndex | Should -BeGreaterThan $warningIndex
+        $rollbackIndex | Should -BeGreaterThan $sessionReadyLogIndex
     }
 
     It 'checks the expected pane count before layout without requiring strict health metadata' {
@@ -3459,6 +3840,137 @@ Describe 'orchestra-start rollback helpers' {
 
         $rollback.RollbackErrors.Count | Should -Be 0
         (Test-Path (Join-Path $manifestDir 'manifest.yaml')) | Should -Be $false
+    }
+
+    It 'continues rollback when listing session panes fails and still removes created non-bootstrap panes' {
+        Mock Invoke-Winsmux { throw 'list failure' } -ParameterFilter {
+            $Arguments[0] -eq 'list-panes'
+        }
+        Mock Invoke-Winsmux { } -ParameterFilter {
+            $Arguments[0] -eq 'kill-pane'
+        }
+        Mock Invoke-Winsmux { } -ParameterFilter {
+            $Arguments[0] -eq 'respawn-pane'
+        }
+        Mock Wait-PaneShellReady { }
+        Mock Remove-OrchestraCreatedWorktrees {
+            [ordered]@{
+                RemovedWorktrees = @()
+                Errors           = @()
+            }
+        }
+
+        $rollback = Invoke-OrchestraStartupRollback `
+            -ProjectDir $script:orchestraStartTempRoot `
+            -SessionName 'winsmux-orchestra' `
+            -BootstrapPaneId '%1' `
+            -CreatedPaneIds @('%1', '%2', '%3') `
+            -CreatedWorktrees @() `
+            -FailureMessage 'list panes unavailable'
+
+        $rollback.RemovedPaneIds | Should -Be @('%2', '%3')
+        @($rollback.RollbackErrors | Where-Object { $_ -like 'list-panes failed:*' }).Count | Should -Be 1
+        Should -Invoke Invoke-Winsmux -Times 2 -Exactly -ParameterFilter {
+            $Arguments[0] -eq 'kill-pane'
+        }
+    }
+
+    It 'records respawn and worktree cleanup failures in rollback errors without aborting rollback completion' {
+        $createdWorktrees = @(
+            [ordered]@{
+                BranchName   = 'worktree-builder-1'
+                WorktreePath = (Join-Path $script:orchestraStartTempRoot '.worktrees\builder-1')
+            }
+        )
+
+        Mock Invoke-Winsmux { @('%1', '%2') } -ParameterFilter {
+            $Arguments[0] -eq 'list-panes'
+        }
+        Mock Invoke-Winsmux { } -ParameterFilter {
+            $Arguments[0] -eq 'kill-pane'
+        }
+        Mock Invoke-Winsmux { throw 'respawn failed' } -ParameterFilter {
+            $Arguments[0] -eq 'respawn-pane'
+        }
+        Mock Wait-PaneShellReady { throw 'should not wait after respawn failure' }
+        Mock Remove-OrchestraCreatedWorktrees {
+            [ordered]@{
+                RemovedWorktrees = @(
+                    [ordered]@{
+                        BranchName   = 'worktree-builder-1'
+                        WorktreePath = (Join-Path $script:orchestraStartTempRoot '.worktrees\builder-1')
+                    }
+                )
+                Errors = @('branch delete worktree-builder-1 failed with exit code 1.')
+            }
+        }
+
+        $rollback = Invoke-OrchestraStartupRollback `
+            -ProjectDir $script:orchestraStartTempRoot `
+            -SessionName 'winsmux-orchestra' `
+            -BootstrapPaneId '%1' `
+            -CreatedPaneIds @('%1', '%2') `
+            -CreatedWorktrees $createdWorktrees `
+            -FailureMessage 'respawn path failed'
+
+        $rollback.RemovedPaneIds | Should -Be @('%2')
+        $rollback.BootstrapRespawned | Should -Be $false
+        @($rollback.RollbackErrors | Where-Object { $_ -like 'respawn-pane %1 failed:*' }).Count | Should -Be 1
+        @($rollback.RollbackErrors | Where-Object { $_ -like 'branch delete worktree-builder-1 failed*' }).Count | Should -Be 1
+
+        $eventsPath = Join-Path $script:orchestraStartTempRoot '.winsmux\events.jsonl'
+        $events = @(Get-Content -Path $eventsPath -Encoding UTF8 | Where-Object { $_ } | ForEach-Object { $_ | ConvertFrom-Json })
+        $events.Count | Should -Be 1
+        @($events[0].data.rollback_errors | Where-Object { $_ -like 'respawn-pane %1 failed:*' }).Count | Should -Be 1
+        @($events[0].data.rollback_errors | Where-Object { $_ -like 'branch delete worktree-builder-1 failed*' }).Count | Should -Be 1
+    }
+
+    It 'surfaces worktree cleanup exit-code failures without dropping the attempted cleanup record' {
+        $worktreePath = Join-Path $script:orchestraStartTempRoot '.worktrees\builder-1'
+        New-Item -ItemType Directory -Path $worktreePath -Force | Out-Null
+        $originalGitFunction = Get-Item -Path Function:\git -ErrorAction SilentlyContinue
+
+        function global:git {
+            param([Parameter(ValueFromRemainingArguments = $true)]$Args)
+
+            if ($Args[2] -eq 'worktree' -and $Args[3] -eq 'remove') {
+                $global:LASTEXITCODE = 1
+                return
+            }
+
+            if ($Args[2] -eq 'branch' -and $Args[3] -eq 'worktree-builder-1') {
+                $global:LASTEXITCODE = 1
+                return
+            }
+
+            if ($Args[2] -eq 'rev-parse') {
+                $global:LASTEXITCODE = 0
+                return
+            }
+
+            $global:LASTEXITCODE = 0
+        }
+
+        try {
+            $result = Remove-OrchestraCreatedWorktrees `
+                -ProjectDir $script:orchestraStartTempRoot `
+                -CreatedWorktrees @(
+                    [ordered]@{
+                        BranchName   = 'worktree-builder-1'
+                        WorktreePath = $worktreePath
+                    }
+                )
+
+            @($result.RemovedWorktrees).Count | Should -Be 1
+            @($result.Errors | Where-Object { $_ -like 'worktree remove *' }).Count | Should -Be 1
+            @($result.Errors | Where-Object { $_ -like 'branch delete worktree-builder-1 failed*' }).Count | Should -Be 1
+            (Test-Path -LiteralPath $worktreePath) | Should -Be $true
+        } finally {
+            Remove-Item -Path Function:\git -ErrorAction SilentlyContinue
+            if ($null -ne $originalGitFunction) {
+                Set-Item -Path Function:\git -Value $originalGitFunction.ScriptBlock
+            }
+        }
     }
 
     It 'writes a pane bootstrap plan and launches it with a single bootstrap command after respawn' {
@@ -6201,6 +6713,46 @@ Describe 'winsmux orchestra-smoke command' {
         $script:winsmuxCoreRawContent = Get-Content -Path $script:winsmuxCoreRawPath -Raw -Encoding UTF8
         $script:orchestraSmokePath = Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\orchestra-smoke.ps1'
         $script:orchestraSmokeContent = Get-Content -Path $script:orchestraSmokePath -Raw -Encoding UTF8
+
+        function Invoke-TestOrchestraOperatorContract {
+            param(
+                [Parameter(Mandatory = $true)][bool]$SmokeOk,
+                [Parameter(Mandatory = $true)][bool]$SessionReady,
+                [Parameter(Mandatory = $true)][bool]$UiAttachLaunched,
+                [Parameter(Mandatory = $true)][bool]$UiAttached,
+                [Parameter(Mandatory = $true)][string]$UiAttachStatus,
+                [Parameter(Mandatory = $true)][bool]$ExternalOperatorMode,
+                [Parameter(Mandatory = $true)][int]$PaneCount,
+                [Parameter(Mandatory = $true)][int]$ExpectedPaneCount,
+                [Parameter(Mandatory = $true)][string[]]$SmokeErrors
+            )
+
+            $contractSource = [regex]::Match(
+                $script:orchestraSmokeContent,
+                '(?s)function Get-OrchestraOperatorContract \{.*?\r?\n\}\r?\n\r?\nfunction Get-OrchestraSmokeProbeState'
+            ).Value
+
+            if ([string]::IsNullOrWhiteSpace($contractSource)) {
+                throw 'Failed to extract Get-OrchestraOperatorContract from orchestra-smoke.ps1.'
+            }
+
+            $contractSource = $contractSource -replace '\r?\n\r?\nfunction Get-OrchestraSmokeProbeState$', ''
+
+            & {
+                Set-StrictMode -Version Latest
+                Invoke-Expression $contractSource
+                Get-OrchestraOperatorContract `
+                    -SmokeOk $SmokeOk `
+                    -SessionReady $SessionReady `
+                    -UiAttachLaunched $UiAttachLaunched `
+                    -UiAttached $UiAttached `
+                    -UiAttachStatus $UiAttachStatus `
+                    -ExternalOperatorMode $ExternalOperatorMode `
+                    -PaneCount $PaneCount `
+                    -ExpectedPaneCount $ExpectedPaneCount `
+                    -SmokeErrors $SmokeErrors
+            }
+        }
     }
 
     It 'documents orchestra-smoke and dispatches it through the dedicated startup smoke script' {
@@ -6233,6 +6785,71 @@ Describe 'winsmux orchestra-smoke command' {
         $script:orchestraSmokeContent | Should -Match 'requires_startup'
     }
 
+    It 'keeps ready-with-ui-warning fail-closed only for external operator mode' {
+        $externalWarning = Invoke-TestOrchestraOperatorContract `
+            -SmokeOk $true `
+            -SessionReady $true `
+            -UiAttachLaunched $true `
+            -UiAttached $false `
+            -UiAttachStatus 'attach_pending' `
+            -ExternalOperatorMode $true `
+            -PaneCount 6 `
+            -ExpectedPaneCount 6 `
+            -SmokeErrors @('attach_pending')
+
+        $internalWarning = Invoke-TestOrchestraOperatorContract `
+            -SmokeOk $true `
+            -SessionReady $true `
+            -UiAttachLaunched $true `
+            -UiAttached $false `
+            -UiAttachStatus 'attach_pending' `
+            -ExternalOperatorMode $false `
+            -PaneCount 6 `
+            -ExpectedPaneCount 6 `
+            -SmokeErrors @('attach_pending')
+
+        $externalWarning.operator_state | Should -Be 'ready-with-ui-warning'
+        $externalWarning.can_dispatch | Should -Be $false
+        $externalWarning.operator_message | Should -Match 'external operator dispatch stays blocked'
+        $externalWarning.next_action | Should -Match 'attached-client confirmation'
+
+        $internalWarning.operator_state | Should -Be 'ready-with-ui-warning'
+        $internalWarning.can_dispatch | Should -Be $true
+        $internalWarning.operator_message | Should -Match 'internal operator mode may continue dispatch'
+        $internalWarning.next_action | Should -Be 'Dispatch work or continue operator flow.'
+    }
+
+    It 'keeps host-launch-failed-but-session-healthy in warning state instead of treating startup as blocked' {
+        $attachFailed = Invoke-TestOrchestraOperatorContract `
+            -SmokeOk $true `
+            -SessionReady $true `
+            -UiAttachLaunched $false `
+            -UiAttached $false `
+            -UiAttachStatus 'attach_failed' `
+            -ExternalOperatorMode $true `
+            -PaneCount 6 `
+            -ExpectedPaneCount 6 `
+            -SmokeErrors @('attach_failed')
+
+        $attachFailed.operator_state | Should -Be 'ready-with-ui-warning'
+        $attachFailed.can_dispatch | Should -Be $false
+        $attachFailed.requires_startup | Should -Be $false
+        $attachFailed.operator_message | Should -Match 'session-ready'
+        $attachFailed.next_action | Should -Match 'attached-client confirmation'
+    }
+
+    It 'fails closed to runtime attach state instead of trusting manifest ui_attached alone' {
+        $script:orchestraSmokeContent | Should -Match '\$uiAttached = \$false'
+        $script:orchestraSmokeContent | Should -Match 'if \(\$null -eq \$attachState\)'
+        $script:orchestraSmokeContent | Should -Match 'Visible attach state is missing; runtime attach confirmation is unavailable\.'
+    }
+
+    It 'accepts attached-client registry matches as attach truth when the host launcher process is gone' {
+        $script:orchestraSmokeContent | Should -Match 'Test-OrchestraAttachClientSnapshotMatch'
+        $script:orchestraSmokeContent | Should -Match 'attached_client_snapshot'
+        $script:orchestraSmokeContent | Should -Match 'attached-client-registry'
+    }
+
     It 'allows empty ui_attach_status when building the operator contract' {
         $script:orchestraSmokeContent | Should -Match '\[AllowEmptyString\(\)\]\[string\]\$UiAttachStatus'
     }
@@ -6253,6 +6870,16 @@ Describe 'winsmux orchestra-smoke command' {
         $script:orchestraSmokeContent | Should -Not -Match 'channel notifications'
         $script:orchestraSmokeContent | Should -Match 'Get-OrchestraOperatorContract'
     }
+
+    It 'waits briefly for manifest and pane convergence after auto-start before finalizing smoke' {
+        $script:orchestraSmokeContent | Should -Match 'function Get-OrchestraSmokeProbeState'
+        $script:orchestraSmokeContent | Should -Match 'function Wait-OrchestraSmokeConvergence'
+        $script:orchestraSmokeContent | Should -Match 'Wait-OrchestraSmokeConvergence -ProjectDir \$ProjectDir -SessionName \$SessionName'
+        $script:orchestraSmokeContent | Should -Match 'PaneCount -lt \$ExpectedPaneCount'
+        $script:orchestraSmokeContent | Should -Match 'PaneProbeOk'
+        $script:orchestraSmokeContent | Should -Match 'ManifestReadable'
+        $script:orchestraSmokeContent | Should -Match 'manifest read failed during startup convergence'
+    }
 }
 
 Describe 'operator startup restore contract docs' {
@@ -6271,6 +6898,8 @@ Describe 'operator startup restore contract docs' {
         $script:claudeGuideContent | Should -Match 'operator_contract\.can_dispatch'
         $script:claudeGuideContent | Should -Match 'operator_contract\.requires_startup'
         $script:claudeGuideContent | Should -Match 'ready-with-ui-warning'
+        $script:claudeGuideContent | Should -Match 'not dispatch-ready'
+        $script:claudeGuideContent | Should -Match 'attached-client confirmation is still missing'
         $script:claudeGuideContent | Should -Match 'winsmux orchestra-attach --json'
         $script:claudeGuideContent | Should -Match 'winsmux dispatch-task'
         $script:claudeGuideContent | Should -Match 'called MCP'
@@ -6291,6 +6920,9 @@ Describe 'operator startup restore contract docs' {
         $script:dispatchRuleContent | Should -Match 'operator_contract\.can_dispatch'
         $script:dispatchRuleContent | Should -Match 'operator_contract\.requires_startup'
         $script:dispatchRuleContent | Should -Match 'ready-with-ui-warning'
+        $script:dispatchRuleContent | Should -Match 'Allowed structured startup states'
+        $script:dispatchRuleContent | Should -Match 'not dispatch-ready'
+        $script:dispatchRuleContent | Should -Match 'attached-client confirmation is still missing'
         $script:dispatchRuleContent | Should -Match 'called MCP'
         $script:dispatchRuleContent | Should -Match 'must not be used as readiness evidence'
         $script:dispatchRuleContent | Should -Match 'hook validation noise'
@@ -6299,6 +6931,30 @@ Describe 'operator startup restore contract docs' {
         $script:dispatchRuleContent | Should -Match 'Explore subagents are reserved for orchestra startup/status diagnosis only'
         $script:dispatchRuleContent | Should -Match 'psmux --version'
         $script:dispatchRuleContent | Should -Match 'Get-Process psmux-server'
+    }
+
+    It 'keeps operator-facing script errors pinned to winsmux instead of exposing compatibility aliases' {
+        $settingsPath = Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\settings.ps1'
+        $setupWizardPath = Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\setup-wizard.ps1'
+        $commanderPollPath = Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\commander-poll.ps1'
+        $agentMonitorPath = Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\agent-monitor.ps1'
+        $watchdogPath = Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\server-watchdog.ps1'
+        $orchestraStartPath = Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\orchestra-start.ps1'
+
+        $settingsContent = Get-Content -Path $settingsPath -Raw -Encoding UTF8
+        $setupWizardContent = Get-Content -Path $setupWizardPath -Raw -Encoding UTF8
+        $commanderPollContent = Get-Content -Path $commanderPollPath -Raw -Encoding UTF8
+        $agentMonitorContent = Get-Content -Path $agentMonitorPath -Raw -Encoding UTF8
+        $watchdogContent = Get-Content -Path $watchdogPath -Raw -Encoding UTF8
+        $orchestraStartContent = Get-Content -Path $orchestraStartPath -Raw -Encoding UTF8
+
+        $settingsContent | Should -Match 'function Get-WinsmuxOperatorNotFoundMessage'
+        $settingsContent | Should -Match 'Could not resolve the winsmux executable from PATH'
+        $setupWizardContent | Should -Not -Match 'Tried: winsmux, pmux, tmux'
+        $commanderPollContent | Should -Not -Match 'Tried: winsmux, pmux, tmux'
+        $agentMonitorContent | Should -Not -Match 'Tried: winsmux, pmux, tmux'
+        $watchdogContent | Should -Not -Match 'Tried: winsmux, pmux, tmux'
+        $orchestraStartContent | Should -Not -Match 'Tried: winsmux, pmux, tmux'
     }
 }
 
@@ -6314,9 +6970,11 @@ Describe 'orchestra pane bootstrap plan' {
         $script:orchestraStartContent | Should -Match 'function New-OrchestraPaneBootstrapPlan'
         $script:orchestraStartContent | Should -Match 'function Get-OrchestraPaneBootstrapMarkerPath'
         $script:orchestraStartContent | Should -Match 'function Start-OrchestraPaneBootstrap'
+        $script:orchestraStartContent | Should -Match 'function Wait-OrchestraServerSessionAbsent'
         $script:orchestraStartContent | Should -Match 'orchestra-pane-bootstrap\.ps1'
         $script:orchestraStartContent | Should -Match 'Start-OrchestraPaneBootstrap -PaneId \$paneId -PlanPath \$bootstrapPlanPath'
         $script:orchestraStartContent | Should -Match 'ready_marker_path'
+        $script:orchestraStartContent | Should -Match 'Wait-OrchestraServerSessionAbsent -SessionName \$SessionName -TimeoutSeconds 20'
     }
 
     It 'prints a concise startup summary before invoking the agent launch command' {

--- a/winsmux-core/scripts/agent-monitor.ps1
+++ b/winsmux-core/scripts/agent-monitor.ps1
@@ -57,7 +57,7 @@ function Invoke-MonitorWinsmux {
 
     $winsmuxBin = Get-WinsmuxBin
     if (-not $winsmuxBin) {
-        throw 'Could not find a winsmux binary. Tried: winsmux, pmux, tmux.'
+        throw (Get-WinsmuxOperatorNotFoundMessage)
     }
 
     if ($CaptureOutput) {

--- a/winsmux-core/scripts/clm-safe-io.ps1
+++ b/winsmux-core/scripts/clm-safe-io.ps1
@@ -1,6 +1,128 @@
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
 
+function Get-WinsmuxFileLockDir {
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    return "$Path.lock"
+}
+
+function Get-WinsmuxFileLockMetadataPath {
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    return Join-Path (Get-WinsmuxFileLockDir -Path $Path) 'owner.json'
+}
+
+function Test-WinsmuxFileLockStale {
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [int]$StaleAfterSeconds = 60
+    )
+
+    $lockDir = Get-WinsmuxFileLockDir -Path $Path
+    if (-not (Test-Path -LiteralPath $lockDir -PathType Container)) {
+        return $false
+    }
+
+    $metadataPath = Get-WinsmuxFileLockMetadataPath -Path $Path
+    $metadata = $null
+    if (Test-Path -LiteralPath $metadataPath -PathType Leaf) {
+        try {
+            $metadata = Get-Content -LiteralPath $metadataPath -Raw -Encoding UTF8 | ConvertFrom-Json
+        } catch {
+            $metadata = $null
+        }
+    }
+
+    if ($null -ne $metadata) {
+        $ownerPid = 0
+        if ($metadata.PSObject.Properties.Name -contains 'pid') {
+            $ownerPid = [int]$metadata.pid
+        }
+
+        if ($ownerPid -gt 0) {
+            return ($null -eq (Get-Process -Id $ownerPid -ErrorAction SilentlyContinue))
+        }
+
+        if ($metadata.PSObject.Properties.Name -contains 'started_at') {
+            try {
+                [void][datetime]$metadata.started_at
+            } catch {
+                return $true
+            }
+        }
+
+        return $false
+    }
+
+    try {
+        $lockAge = ((Get-Date) - (Get-Item -LiteralPath $lockDir).LastWriteTime).TotalSeconds
+        return ($lockAge -ge $StaleAfterSeconds)
+    } catch {
+        return $false
+    }
+}
+
+function Remove-WinsmuxFileLock {
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    $lockDir = Get-WinsmuxFileLockDir -Path $Path
+    if (-not (Test-Path -LiteralPath $lockDir -PathType Container)) {
+        return
+    }
+
+    $escapedLockDir = $lockDir -replace '"', '""'
+    cmd /d /c ('rmdir /s /q "{0}"' -f $escapedLockDir) 1>$null 2>$null
+}
+
+function Invoke-WinsmuxWithFileLock {
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $true)][scriptblock]$Action,
+        [int]$TimeoutMilliseconds = 120000,
+        [int]$StaleAfterSeconds = 60
+    )
+
+    $lockDir = Get-WinsmuxFileLockDir -Path $Path
+    $escapedLockDir = $lockDir -replace '"', '""'
+    $deadline = (Get-Date).AddMilliseconds($TimeoutMilliseconds)
+    $hasLock = $false
+    $metadataPath = Get-WinsmuxFileLockMetadataPath -Path $Path
+    $escapedMetadataPath = $metadataPath -replace '"', '""'
+    try {
+        while ((Get-Date) -lt $deadline) {
+            cmd /d /c ('mkdir "{0}"' -f $escapedLockDir) 1>$null 2>$null
+            if ($LASTEXITCODE -eq 0) {
+                $hasLock = $true
+                $metadataJson = ([ordered]@{
+                        pid        = $PID
+                        started_at = (Get-Date).ToString('o')
+                        path       = $Path
+                    } | ConvertTo-Json)
+                $metadataJson | cmd /d /c ('more > "{0}"' -f $escapedMetadataPath) | Out-Null
+                break
+            }
+
+            if (Test-WinsmuxFileLockStale -Path $Path -StaleAfterSeconds $StaleAfterSeconds) {
+                Remove-WinsmuxFileLock -Path $Path
+                continue
+            }
+
+            Start-Sleep -Milliseconds 100
+        }
+
+        if (-not $hasLock) {
+            throw "Timed out waiting for file lock for $Path"
+        }
+
+        & $Action
+    } finally {
+        if ($hasLock) {
+            Remove-WinsmuxFileLock -Path $Path
+        }
+    }
+}
+
 function Write-WinsmuxTextFile {
     param(
         [Parameter(Mandatory = $true)][string]$Path,
@@ -14,18 +136,41 @@ function Write-WinsmuxTextFile {
     }
 
     $escapedPath = $Path -replace '"', '""'
-    if ([string]::IsNullOrEmpty($Content)) {
+    Invoke-WinsmuxWithFileLock -Path $Path -Action {
         if ($Append) {
+            if ([string]::IsNullOrEmpty($Content)) {
+                return
+            }
+
+            $Content | cmd /d /c ('more >> "{0}"' -f $escapedPath) | Out-Null
+            if ($LASTEXITCODE -ne 0) {
+                throw "cmd.exe failed to append $Path"
+            }
+
             return
         }
 
-        cmd /d /c ('type nul > "{0}"' -f $escapedPath) | Out-Null
-    } else {
-        $redirect = if ($Append) { '>>' } else { '>' }
-        $Content | cmd /d /c ('more {0} "{1}"' -f $redirect, $escapedPath) | Out-Null
-    }
+        $tempPath = "$Path.tmp-$((New-Guid).Guid)"
+        $escapedTempPath = $tempPath -replace '"', '""'
+        try {
+            if ([string]::IsNullOrEmpty($Content)) {
+                cmd /d /c ('type nul > "{0}"' -f $escapedTempPath) | Out-Null
+            } else {
+                $Content | cmd /d /c ('more > "{0}"' -f $escapedTempPath) | Out-Null
+            }
 
-    if ($LASTEXITCODE -ne 0) {
-        throw "cmd.exe failed to write $Path"
+            if ($LASTEXITCODE -ne 0) {
+                throw "cmd.exe failed to write temporary file for $Path"
+            }
+
+            cmd /d /c ('move /y "{0}" "{1}"' -f $escapedTempPath, $escapedPath) | Out-Null
+            if ($LASTEXITCODE -ne 0) {
+                throw "cmd.exe failed to replace $Path"
+            }
+        } finally {
+            if (Test-Path -LiteralPath $tempPath -PathType Leaf) {
+                cmd /d /c ('del /f /q "{0}"' -f $escapedTempPath) 1>$null 2>$null
+            }
+        }
     }
 }

--- a/winsmux-core/scripts/commander-poll.ps1
+++ b/winsmux-core/scripts/commander-poll.ps1
@@ -293,7 +293,7 @@ function Invoke-CommanderPollWinsmux {
 
     $winsmuxBin = Get-WinsmuxBin
     if (-not $winsmuxBin) {
-        throw 'Could not find a winsmux binary. Tried: winsmux, pmux, tmux.'
+        throw (Get-WinsmuxOperatorNotFoundMessage)
     }
 
     $output = & $winsmuxBin @Arguments 2>&1

--- a/winsmux-core/scripts/harness-check.ps1
+++ b/winsmux-core/scripts/harness-check.ps1
@@ -305,7 +305,7 @@ if ($null -eq $smokeProbe.parsed) {
     if (-not $hasContract) {
         $smokeMessage = 'orchestra-smoke result is missing operator_contract fields.'
     } elseif ($smokeProbe.parsed.session_ready -and -not $smokeProbe.parsed.ui_attached -and $contract.can_dispatch) {
-        $smokeMessage = 'operator_contract.can_dispatch must stay false until visible attach is confirmed.'
+        $smokeMessage = 'operator_contract.can_dispatch must stay false until attached-client confirmation is recorded.'
     } else {
         $smokePassed = $true
         $smokeMessage = 'orchestra-smoke contract is structurally consistent.'

--- a/winsmux-core/scripts/orchestra-attach-confirm.ps1
+++ b/winsmux-core/scripts/orchestra-attach-confirm.ps1
@@ -18,8 +18,8 @@ try {
         winsmux_path       = $WinsmuxPath
         attach_status      = 'attach_confirming'
         ui_attach_source   = 'none'
-        attach_process_id  = $PID
-        started_at         = (Get-Date).ToString('o')
+        confirm_process_id = $PID
+        confirm_started_at = (Get-Date).ToString('o')
         client_count_seen  = $BaselineClientCount
         error              = ''
     } | Out-Null
@@ -29,7 +29,7 @@ try {
     Write-OrchestraAttachState -SessionName $SessionName -Properties @{
         attach_status     = 'attach_failed'
         ui_attach_source  = 'none'
-        attach_process_id = $PID
+        confirm_process_id = $PID
         client_count_seen = $BaselineClientCount
         error             = $_.Exception.Message
     } | Out-Null

--- a/winsmux-core/scripts/orchestra-attach.ps1
+++ b/winsmux-core/scripts/orchestra-attach.ps1
@@ -49,6 +49,7 @@ function New-OrchestraAttachResult {
 }
 
 $winsmuxPath = Get-Command 'winsmux' -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source -ErrorAction SilentlyContinue
+$result = $null
 if ([string]::IsNullOrWhiteSpace($winsmuxPath)) {
     $result = New-OrchestraAttachResult -SessionName $SessionName -SessionExists $false -RequiresStartup $true -Attempted $false -Launched $false -Attached $false -Status 'winsmux_unresolved' -Reason 'winsmux executable could not be resolved.'
 } else {
@@ -59,39 +60,70 @@ if ([string]::IsNullOrWhiteSpace($winsmuxPath)) {
     } else {
         $clientSnapshot = Get-OrchestraAttachedClientSnapshot -WinsmuxBin $winsmuxPath -SessionName $SessionName
         $baselineClientCount = if ([bool]$clientSnapshot.Ok) { [int]$clientSnapshot.Count } else { 0 }
-        if ([bool]$clientSnapshot.Ok -and $baselineClientCount -ge 1) {
+        $baselineClients = if ([bool]$clientSnapshot.Ok) { @($clientSnapshot.Clients) } else { @() }
+        $existingAttachState = Read-OrchestraAttachState -SessionName $SessionName
+        $existingAttachSource = if ($null -eq $existingAttachState) { '' } else { [string]$existingAttachState.ui_attach_source }
+        if ([string]::IsNullOrWhiteSpace($existingAttachSource)) {
+            $existingAttachSource = 'handshake'
+        }
+        $hasLiveVisibleAttach = (Test-OrchestraLiveVisibleAttachState -State $existingAttachState -SessionName $SessionName)
+        if ($hasLiveVisibleAttach -and [bool]$clientSnapshot.Ok -and $baselineClientCount -ge 1) {
             Write-OrchestraAttachState -SessionName $SessionName -Properties @{
                 session_name       = $SessionName
                 winsmux_path       = $winsmuxPath
                 attach_status      = 'attach_confirmed'
                 attach_confirmed_at = (Get-Date).ToString('o')
                 client_count_seen  = $baselineClientCount
-                ui_attach_source   = 'client-probe'
+                ui_attach_source   = $existingAttachSource
                 error              = "Detected $baselineClientCount attached client(s) for session '$SessionName'."
             } | Out-Null
 
-            $result = New-OrchestraAttachResult -SessionName $SessionName -SessionExists $true -RequiresStartup $false -Attempted $false -Launched $false -Attached $true -Status 'attach_already_present' -Reason "Detected $baselineClientCount attached client(s) for session '$SessionName'; skipped spawning another visible attach window." -AttachedClientCount $baselineClientCount -AttachSource 'client-probe'
+            $result = New-OrchestraAttachResult -SessionName $SessionName -SessionExists $true -RequiresStartup $false -Attempted $false -Launched $false -Attached $true -Status 'attach_already_present' -Reason "Detected an existing live visible attach for session '$SessionName'; skipped spawning another visible attach window." -AttachedClientCount $baselineClientCount -AttachSource $existingAttachSource
         } else {
             $terminalInfo = Get-OrchestraWindowsTerminalInfo
             if (-not [bool]$terminalInfo.Available) {
-                $reason = if ([bool]$terminalInfo.IsAliasStub) {
-                    'WindowsApps wt.exe alias was found, but no canonical Windows Terminal binary could be resolved.'
-                } else {
-                    'Windows Terminal is not installed or not on PATH.'
-                }
-
                 Write-OrchestraAttachState -SessionName $SessionName -Properties @{
-                    session_name       = $SessionName
-                    winsmux_path       = $winsmuxPath
-                    attach_status      = 'attach_failed'
-                    requested_at       = (Get-Date).ToString('o')
+                    session_name          = $SessionName
+                    winsmux_path          = $winsmuxPath
+                    requested_at          = (Get-Date).ToString('o')
                     baseline_client_count = $baselineClientCount
-                    client_count_seen  = $baselineClientCount
-                    ui_attach_source   = 'none'
-                    error              = $reason
+                    baseline_clients      = @($baselineClients)
+                    client_count_seen     = $baselineClientCount
+                    attach_process_id     = 0
+                    attach_status         = 'attach_requested'
+                    attach_confirmed_at   = ''
+                    started_at            = ''
+                    ui_attach_source      = 'none'
+                    error                 = ''
                 } | Out-Null
 
-                $result = New-OrchestraAttachResult -SessionName $SessionName -SessionExists $true -RequiresStartup $false -Attempted $false -Launched $false -Attached $false -Status 'attach_failed' -Reason $reason -Path ([string]$terminalInfo.Path) -AttachedClientCount $baselineClientCount -AttachSource 'none'
+                try {
+                    $attachLaunch = Start-OrchestraPowerShellVisibleAttach
+                    if ($null -ne $attachLaunch.Process -and $null -ne $attachLaunch.Process.PSObject -and ($attachLaunch.Process.PSObject.Properties.Name -contains 'Id')) {
+                        Write-OrchestraAttachState -SessionName $SessionName -Properties @{
+                            attach_process_id = $attachLaunch.Process.Id
+                            started_at        = (Get-Date).ToString('o')
+                            ui_host_kind      = [string]$attachLaunch.HostKind
+                        } | Out-Null
+                    }
+                    $confirmed = Wait-OrchestraAttachHandshake -SessionName $SessionName -WinsmuxBin $winsmuxPath -BaselineClientCount $baselineClientCount -BaselineClients $baselineClients
+                    $result = New-OrchestraAttachResult -SessionName $SessionName -SessionExists $true -RequiresStartup $false -Attempted $true -Launched $true -Attached ([bool]$confirmed.Confirmed) -Status ([string]$confirmed.Status) -Reason ([string]$confirmed.Reason) -Path ([string]$attachLaunch.Path) -AttachedClientCount ([int]$confirmed.AttachedClientCount) -AttachSource ([string]$confirmed.Source)
+                } catch {
+                    $reason = if ([bool]$terminalInfo.IsAliasStub) {
+                        'WindowsApps wt.exe alias was found, but no canonical Windows Terminal binary could be resolved.'
+                    } else {
+                        'Windows Terminal is not installed or not on PATH.'
+                    }
+
+                    $failureReason = "$reason Fallback host launch failed: $($_.Exception.Message)"
+                    Write-OrchestraAttachState -SessionName $SessionName -Properties @{
+                        attach_status     = 'attach_failed'
+                        ui_attach_source  = 'none'
+                        error             = $failureReason
+                    } | Out-Null
+
+                    $result = New-OrchestraAttachResult -SessionName $SessionName -SessionExists $true -RequiresStartup $false -Attempted $true -Launched $false -Attached $false -Status 'attach_failed' -Reason $failureReason -Path '' -AttachedClientCount $baselineClientCount -AttachSource 'none'
+                }
             } else {
                 $profile = Ensure-OrchestraAttachProfile -ProjectDir $ProjectDir
                 $state = Write-OrchestraAttachState -SessionName $SessionName -Properties @{
@@ -101,27 +133,77 @@ if ([string]::IsNullOrWhiteSpace($winsmuxPath)) {
                     requested_at          = (Get-Date).ToString('o')
                     request_id            = [guid]::NewGuid().ToString('N')
                     baseline_client_count = $baselineClientCount
+                    baseline_clients      = @($baselineClients)
                     client_count_seen     = $baselineClientCount
+                    attach_process_id     = 0
                     attach_status         = 'attach_requested'
+                    attach_confirmed_at   = ''
+                    started_at            = ''
                     ui_attach_source      = 'none'
                     error                 = ''
                 }
 
                 try {
-                    $attachProcess = Start-Process -FilePath ([string]$terminalInfo.Path) -ArgumentList @('-w', '-1', 'new-tab', '-p', [string]$profile.ProfileName) -PassThru
-                    $launchedPath = [string]$terminalInfo.Path
+                    $attachLaunch = Start-OrchestraWindowsTerminalVisibleAttach -TerminalPath ([string]$terminalInfo.Path) -ProfileName ([string]$profile.ProfileName)
+                    $launchedPath = [string]$attachLaunch.Path
+                    if ($null -ne $attachLaunch.Process -and $null -ne $attachLaunch.Process.PSObject -and ($attachLaunch.Process.PSObject.Properties.Name -contains 'Id')) {
+                        Write-OrchestraAttachState -SessionName $SessionName -Properties @{
+                            attach_process_id = $attachLaunch.Process.Id
+                            started_at        = (Get-Date).ToString('o')
+                            ui_host_kind      = [string]$attachLaunch.HostKind
+                        } | Out-Null
+                    }
                 } catch {
-                    Write-OrchestraAttachState -SessionName $SessionName -Properties @{
-                        attach_status     = 'attach_failed'
-                        ui_attach_source  = 'none'
-                        error             = $_.Exception.Message
-                    } | Out-Null
+                    try {
+                        $attachLaunch = Start-OrchestraPowerShellVisibleAttach
+                        $launchedPath = [string]$attachLaunch.Path
+                        if ($null -ne $attachLaunch.Process -and $null -ne $attachLaunch.Process.PSObject -and ($attachLaunch.Process.PSObject.Properties.Name -contains 'Id')) {
+                            Write-OrchestraAttachState -SessionName $SessionName -Properties @{
+                                attach_process_id = $attachLaunch.Process.Id
+                                started_at        = (Get-Date).ToString('o')
+                                ui_host_kind      = [string]$attachLaunch.HostKind
+                            } | Out-Null
+                        }
+                    } catch {
+                        Write-OrchestraAttachState -SessionName $SessionName -Properties @{
+                            attach_status     = 'attach_failed'
+                            ui_attach_source  = 'none'
+                            error             = $_.Exception.Message
+                        } | Out-Null
 
-                    $result = New-OrchestraAttachResult -SessionName $SessionName -SessionExists $true -RequiresStartup $false -Attempted $true -Launched $false -Attached $false -Status 'attach_failed' -Reason $_.Exception.Message -Path ([string]$terminalInfo.Path) -AttachedClientCount $baselineClientCount -AttachSource 'none'
+                        $result = New-OrchestraAttachResult -SessionName $SessionName -SessionExists $true -RequiresStartup $false -Attempted $true -Launched $false -Attached $false -Status 'attach_failed' -Reason $_.Exception.Message -Path ([string]$terminalInfo.Path) -AttachedClientCount $baselineClientCount -AttachSource 'none'
+                    }
                 }
 
                 if ($null -eq $result) {
-                    $confirmed = Wait-OrchestraAttachHandshake -SessionName $SessionName -WinsmuxBin $winsmuxPath -BaselineClientCount $baselineClientCount
+                    if ($launchedPath -eq [string]$terminalInfo.Path) {
+                        $launchObserved = Wait-OrchestraAttachLaunchObservation -SessionName $SessionName -WinsmuxBin $winsmuxPath -BaselineClientCount $baselineClientCount -BaselineClients $baselineClients
+                        if (-not [bool]$launchObserved.Observed) {
+                            try {
+                                $attachLaunch = Start-OrchestraPowerShellVisibleAttach
+                                $launchedPath = [string]$attachLaunch.Path
+                                if ($null -ne $attachLaunch.Process -and $null -ne $attachLaunch.Process.PSObject -and ($attachLaunch.Process.PSObject.Properties.Name -contains 'Id')) {
+                                    Write-OrchestraAttachState -SessionName $SessionName -Properties @{
+                                        attach_process_id = $attachLaunch.Process.Id
+                                        started_at        = (Get-Date).ToString('o')
+                                        ui_host_kind      = [string]$attachLaunch.HostKind
+                                    } | Out-Null
+                                }
+                            } catch {
+                                Write-OrchestraAttachState -SessionName $SessionName -Properties @{
+                                    attach_status     = 'attach_failed'
+                                    ui_attach_source  = 'none'
+                                    error             = $_.Exception.Message
+                                } | Out-Null
+
+                                $result = New-OrchestraAttachResult -SessionName $SessionName -SessionExists $true -RequiresStartup $false -Attempted $true -Launched $false -Attached $false -Status 'attach_failed' -Reason $_.Exception.Message -Path ([string]$terminalInfo.Path) -AttachedClientCount $baselineClientCount -AttachSource 'none'
+                            }
+                        }
+                    }
+                }
+
+                if ($null -eq $result) {
+                    $confirmed = Wait-OrchestraAttachHandshake -SessionName $SessionName -WinsmuxBin $winsmuxPath -BaselineClientCount $baselineClientCount -BaselineClients $baselineClients
                     $result = New-OrchestraAttachResult -SessionName $SessionName -SessionExists $true -RequiresStartup $false -Attempted $true -Launched $true -Attached ([bool]$confirmed.Confirmed) -Status ([string]$confirmed.Status) -Reason ([string]$confirmed.Reason) -Path $launchedPath -AttachedClientCount ([int]$confirmed.AttachedClientCount) -AttachSource ([string]$confirmed.Source)
                 }
             }

--- a/winsmux-core/scripts/orchestra-smoke.ps1
+++ b/winsmux-core/scripts/orchestra-smoke.ps1
@@ -144,10 +144,14 @@ function Get-OrchestraOperatorContract {
 
     if ($SmokeOk) {
         $state = 'ready-with-ui-warning'
-        $message = 'Orchestra session is session-ready, but visible attach still needs confirmation.'
         $canDispatch = -not $ExternalOperatorMode
         $requiresStartup = $false
-        $nextAction = if ($ExternalOperatorMode) { 'Confirm visible attach before dispatching work.' } else { 'Dispatch work or continue operator flow.' }
+        $message = if ($ExternalOperatorMode) {
+            'Orchestra session is session-ready, but external operator dispatch stays blocked until attached-client confirmation succeeds.'
+        } else {
+            'Orchestra session is session-ready. Visible attach is still unconfirmed, but internal operator mode may continue dispatch.'
+        }
+        $nextAction = if ($ExternalOperatorMode) { 'Run the visible attach step and wait for attached-client confirmation before dispatching work.' } else { 'Dispatch work or continue operator flow.' }
 
         if ($SessionReady -and $UiAttached) {
             $state = 'ready'
@@ -179,6 +183,109 @@ function Get-OrchestraOperatorContract {
     }
 }
 
+function Get-OrchestraSmokeProbeState {
+    param(
+        [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [Parameter(Mandatory = $true)][string]$SessionName,
+        [Parameter(Mandatory = $true)][int]$ExpectedPaneCount,
+        [AllowEmptyString()][string]$WinsmuxBin = ''
+    )
+
+    $manifestPath = Join-Path (Join-Path $ProjectDir '.winsmux') 'manifest.yaml'
+    $manifestFound = Test-Path -LiteralPath $manifestPath
+    $manifestReadable = $true
+    $manifestReadError = ''
+
+    $paneCount = 0
+    $paneProbeOk = $false
+    $paneProbeError = ''
+    if (-not [string]::IsNullOrWhiteSpace($WinsmuxBin)) {
+        try {
+            $paneLines = & $WinsmuxBin list-panes -t $SessionName 2>&1
+            if ($LASTEXITCODE -eq 0) {
+                $paneCount = @($paneLines | Where-Object { -not [string]::IsNullOrWhiteSpace([string]$_) }).Count
+                $paneProbeOk = $true
+            } else {
+                $paneProbeError = ($paneLines | Out-String).Trim()
+            }
+        } catch {
+            $paneProbeError = $_.Exception.Message
+        }
+    } else {
+        $paneProbeError = 'winsmux executable could not be resolved.'
+    }
+
+    $sessionReady = $false
+    $uiAttachLaunched = $false
+    $uiAttached = $false
+    $uiAttachStatus = ''
+    $uiAttachReason = ''
+    $uiAttachSource = 'none'
+
+    if ($manifestFound) {
+        try {
+            $manifest = Get-WinsmuxManifest -ProjectDir $ProjectDir
+            if ($null -ne $manifest -and $null -ne $manifest.session) {
+                $sessionReady = ConvertTo-OrchestraSmokeBoolean $manifest.session.session_ready
+                $uiAttachLaunched = ConvertTo-OrchestraSmokeBoolean $manifest.session.ui_attach_launched
+                $uiAttached = ConvertTo-OrchestraSmokeBoolean $manifest.session.ui_attached
+                $uiAttachStatus = [string]$manifest.session.ui_attach_status
+                $uiAttachReason = [string]$manifest.session.ui_attach_reason
+                if ($manifest.session.PSObject.Properties.Name -contains 'ui_attach_source') {
+                    $uiAttachSource = [string]$manifest.session.ui_attach_source
+                }
+            }
+        } catch {
+            $manifestReadable = $false
+            $manifestReadError = $_.Exception.Message
+        }
+    }
+
+    return [ordered]@{
+        ManifestPath      = $manifestPath
+        ManifestFound     = $manifestFound
+        ManifestReadable  = $manifestReadable
+        ManifestReadError = $manifestReadError
+        PaneCount         = $paneCount
+        PaneProbeOk       = $paneProbeOk
+        PaneProbeError    = $paneProbeError
+        SessionReady      = $sessionReady
+        UiAttachLaunched  = $uiAttachLaunched
+        UiAttached        = $uiAttached
+        UiAttachStatus    = $uiAttachStatus
+        UiAttachReason    = $uiAttachReason
+        UiAttachSource    = $uiAttachSource
+        ExpectedPaneCount = $ExpectedPaneCount
+    }
+}
+
+function Wait-OrchestraSmokeConvergence {
+    param(
+        [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [Parameter(Mandatory = $true)][string]$SessionName,
+        [Parameter(Mandatory = $true)][int]$ExpectedPaneCount,
+        [AllowEmptyString()][string]$WinsmuxBin = '',
+        [int]$TimeoutSeconds = 10
+    )
+
+    $state = Get-OrchestraSmokeProbeState -ProjectDir $ProjectDir -SessionName $SessionName -ExpectedPaneCount $ExpectedPaneCount -WinsmuxBin $WinsmuxBin
+    $needsConvergence = (-not $state.ManifestFound) -or (-not $state.ManifestReadable) -or (-not $state.SessionReady) -or ((-not [string]::IsNullOrWhiteSpace($WinsmuxBin)) -and ((-not $state.PaneProbeOk) -or ($state.PaneCount -lt $ExpectedPaneCount)))
+    if (-not $needsConvergence) {
+        return $state
+    }
+
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    while ((Get-Date) -lt $deadline) {
+        Start-Sleep -Seconds 1
+        $state = Get-OrchestraSmokeProbeState -ProjectDir $ProjectDir -SessionName $SessionName -ExpectedPaneCount $ExpectedPaneCount -WinsmuxBin $WinsmuxBin
+        if ($state.ManifestFound -and $state.ManifestReadable -and $state.SessionReady -and $state.PaneProbeOk -and $state.PaneCount -ge $ExpectedPaneCount) {
+            return $state
+        }
+    }
+
+    return $state
+}
+
 if ([string]::IsNullOrWhiteSpace($ProjectDir)) {
     $ProjectDir = (Get-Location).Path
 }
@@ -191,8 +298,6 @@ $winsmuxCorePath = [System.IO.Path]::GetFullPath($winsmuxCorePath)
 $layoutSettings = Get-OrchestraSmokeLayoutSettings -Root $ProjectDir
 $externalOperatorMode = ([int]$layoutSettings.Commanders -eq 0)
 $expectedPaneCount = Get-OrchestraSmokeExpectedPaneCount -LayoutSettings $layoutSettings
-$manifestPath = Join-Path (Join-Path $ProjectDir '.winsmux') 'manifest.yaml'
-$manifestFound = Test-Path -LiteralPath $manifestPath
 
 $winsmuxBin = ''
 try {
@@ -200,24 +305,14 @@ try {
 } catch {
 }
 
-$paneCount = 0
-$paneProbeOk = $false
-$paneProbeError = ''
-if (-not [string]::IsNullOrWhiteSpace($winsmuxBin)) {
-    try {
-        $paneLines = & $winsmuxBin list-panes -t $SessionName 2>&1
-        if ($LASTEXITCODE -eq 0) {
-            $paneCount = @($paneLines | Where-Object { -not [string]::IsNullOrWhiteSpace([string]$_) }).Count
-            $paneProbeOk = $true
-        } else {
-            $paneProbeError = ($paneLines | Out-String).Trim()
-        }
-    } catch {
-        $paneProbeError = $_.Exception.Message
-    }
-} else {
-    $paneProbeError = 'winsmux executable could not be resolved.'
-}
+$probeState = Get-OrchestraSmokeProbeState -ProjectDir $ProjectDir -SessionName $SessionName -ExpectedPaneCount $expectedPaneCount -WinsmuxBin $winsmuxBin
+$manifestPath = [string]$probeState.ManifestPath
+$manifestFound = [bool]$probeState.ManifestFound
+$manifestReadable = [bool]$probeState.ManifestReadable
+$manifestReadError = [string]$probeState.ManifestReadError
+$paneCount = [int]$probeState.PaneCount
+$paneProbeOk = [bool]$probeState.PaneProbeOk
+$paneProbeError = [string]$probeState.PaneProbeError
 
 $clientSnapshot = if ([string]::IsNullOrWhiteSpace($winsmuxBin)) {
     [PSCustomObject][ordered]@{
@@ -235,99 +330,90 @@ $attachedClientCount = [int]$clientSnapshot.Count
 
 $startOutput = ''
 $startExitCode = 0
-$sessionAlreadyHealthy = $paneProbeOk -and $paneCount -ge $expectedPaneCount -and $manifestFound
+$sessionAlreadyHealthy = $paneProbeOk -and $paneCount -ge $expectedPaneCount -and $manifestFound -and $manifestReadable
 if ($sessionAlreadyHealthy) {
     $startOutput = 'Skipped orchestra-start; existing orchestra session already meets the smoke prerequisites.'
 } elseif ($AutoStart) {
     $startOutput = & pwsh -NoProfile -Command "Set-Location -LiteralPath '$ProjectDir'; & '$startScript'" 2>&1
     $startExitCode = $LASTEXITCODE
-    $manifestFound = Test-Path -LiteralPath $manifestPath
-    if (-not [string]::IsNullOrWhiteSpace($winsmuxBin)) {
-        try {
-            $paneLines = & $winsmuxBin list-panes -t $SessionName 2>&1
-            if ($LASTEXITCODE -eq 0) {
-                $paneCount = @($paneLines | Where-Object { -not [string]::IsNullOrWhiteSpace([string]$_) }).Count
-                $paneProbeOk = $true
-                $paneProbeError = ''
-            } else {
-                $paneProbeOk = $false
-                $paneProbeError = ($paneLines | Out-String).Trim()
-            }
-        } catch {
-            $paneProbeOk = $false
-            $paneProbeError = $_.Exception.Message
-        }
-    }
+    $probeState = Wait-OrchestraSmokeConvergence -ProjectDir $ProjectDir -SessionName $SessionName -ExpectedPaneCount $expectedPaneCount -WinsmuxBin $winsmuxBin -TimeoutSeconds 10
+    $manifestPath = [string]$probeState.ManifestPath
+    $manifestFound = [bool]$probeState.ManifestFound
+    $manifestReadable = [bool]$probeState.ManifestReadable
+    $manifestReadError = [string]$probeState.ManifestReadError
+    $paneCount = [int]$probeState.PaneCount
+    $paneProbeOk = [bool]$probeState.PaneProbeOk
+    $paneProbeError = [string]$probeState.PaneProbeError
 } else {
     $startOutput = 'Skipped orchestra-start; run orchestra-start.ps1 when operator_contract.requires_startup is true.'
 }
 
-$sessionReady = $false
-$uiAttachLaunched = $false
+$sessionReady = [bool]$probeState.SessionReady
+$uiAttachLaunched = [bool]$probeState.UiAttachLaunched
 $uiAttached = $false
-$uiAttachStatus = ''
-$uiAttachReason = ''
-$uiAttachSource = 'none'
-
-if ($manifestFound) {
-    $manifest = Get-WinsmuxManifest -ProjectDir $ProjectDir
-    if ($null -ne $manifest -and $null -ne $manifest.session) {
-        $sessionReady = ConvertTo-OrchestraSmokeBoolean $manifest.session.session_ready
-        $uiAttachLaunched = ConvertTo-OrchestraSmokeBoolean $manifest.session.ui_attach_launched
-        $uiAttached = ConvertTo-OrchestraSmokeBoolean $manifest.session.ui_attached
-        $uiAttachStatus = [string]$manifest.session.ui_attach_status
-        $uiAttachReason = [string]$manifest.session.ui_attach_reason
-        if ($manifest.session.PSObject.Properties.Name -contains 'ui_attach_source') {
-            $uiAttachSource = [string]$manifest.session.ui_attach_source
-        }
-    }
-}
+$uiAttachStatus = [string]$probeState.UiAttachStatus
+$uiAttachReason = [string]$probeState.UiAttachReason
+$uiAttachSource = [string]$probeState.UiAttachSource
 
 $attachState = Read-OrchestraAttachState -SessionName $SessionName
-if ($null -ne $attachState) {
+if ($null -eq $attachState) {
+    $uiAttached = $false
+    if ($uiAttachLaunched) {
+        $uiAttachStatus = 'attach_unconfirmed'
+        $uiAttachReason = 'Visible attach state is missing; runtime attach confirmation is unavailable.'
+    } else {
+        $uiAttachStatus = ''
+        $uiAttachReason = ''
+    }
+    $uiAttachSource = 'none'
+} else {
     $attachStateStatus = [string]$attachState.attach_status
-    if ($attachStateStatus -eq 'attach_confirmed') {
+    if (($attachStateStatus -eq 'attach_confirmed') -and [bool]$clientProbeOk -and (Test-OrchestraLiveVisibleAttachState -State $attachState -SessionName $SessionName)) {
         $uiAttached = $true
         $uiAttachStatus = 'attach_confirmed'
         $uiAttachReason = [string]$attachState.error
         $uiAttachSource = if ([string]::IsNullOrWhiteSpace([string]$attachState.ui_attach_source)) { 'handshake' } else { [string]$attachState.ui_attach_source }
+    } elseif (($attachStateStatus -eq 'attach_confirmed') -and [bool]$clientProbeOk -and (Test-OrchestraAttachClientSnapshotMatch -ExpectedClients $attachState.attached_client_snapshot -CurrentClients $clientSnapshot.Clients)) {
+        $uiAttached = $true
+        $uiAttachStatus = 'attach_confirmed'
+        $uiAttachReason = if ([string]::IsNullOrWhiteSpace([string]$attachState.error)) {
+            'Attached-client registry matches the current runtime client snapshot.'
+        } else {
+            [string]$attachState.error
+        }
+        $uiAttachSource = 'attached-client-registry'
+    } elseif ($attachStateStatus -eq 'attach_confirmed') {
+        $uiAttached = $false
+        $uiAttachStatus = 'attach_unconfirmed'
+        $uiAttachReason = if (-not [bool]$clientProbeOk) {
+            'Attach state exists, but the runtime client probe is unavailable.'
+        } else {
+            'Attach state exists, but no live visible attach process is associated with it.'
+        }
+        $uiAttachSource = if ([string]::IsNullOrWhiteSpace([string]$attachState.ui_attach_source)) { 'none' } else { [string]$attachState.ui_attach_source }
     } elseif ($attachStateStatus -eq 'attach_failed') {
         $uiAttachStatus = 'attach_failed'
         $uiAttachReason = [string]$attachState.error
         $uiAttachSource = 'none'
-    }
-}
-
-if (-not $uiAttached) {
-    $clientSnapshot = if ([string]::IsNullOrWhiteSpace($winsmuxBin)) {
-        [PSCustomObject][ordered]@{
-            Ok      = $false
-            Count   = 0
-            Error   = 'winsmux executable could not be resolved.'
-            Clients = @()
+    } elseif ($attachStateStatus -in @('attach_requested', 'attach_entry_started', 'attach_confirming')) {
+        $uiAttached = $false
+        $uiAttachStatus = 'attach_pending'
+        $uiAttachReason = if ([string]::IsNullOrWhiteSpace([string]$attachState.error)) {
+            'Visible attach is still pending confirmation.'
+        } else {
+            [string]$attachState.error
         }
-    } else {
-        Get-OrchestraAttachedClientSnapshot -WinsmuxBin $winsmuxBin -SessionName $SessionName
+        $uiAttachSource = 'none'
     }
-    if ([bool]$clientSnapshot.Ok -and [int]$clientSnapshot.Count -ge 1) {
-        $uiAttached = $true
-        if ([string]::IsNullOrWhiteSpace($uiAttachStatus) -or $uiAttachStatus -eq 'attach_failed') {
-            $uiAttachStatus = 'attach_confirmed'
-            $uiAttachReason = "Detected $($clientSnapshot.Count) attached client(s) for session '$SessionName'."
-        }
-        $uiAttachSource = 'client-probe'
-    }
-}
-
-if ($clientProbeOk -and $attachedClientCount -gt 0) {
-    $uiAttached = $true
-    $uiAttachStatus = 'attach_already_present'
-    $uiAttachReason = "Detected $attachedClientCount attached client(s) for session '$SessionName'."
 }
 
 $smokeErrors = [System.Collections.Generic.List[string]]::new()
 if ($startExitCode -ne 0) { $smokeErrors.Add("orchestra-start exited with code $startExitCode.") | Out-Null }
-if (-not $manifestFound) { $smokeErrors.Add('manifest missing after startup.') | Out-Null }
+if (-not $manifestFound) {
+    $smokeErrors.Add('manifest missing after startup.') | Out-Null
+} elseif (-not $manifestReadable) {
+    $smokeErrors.Add("manifest read failed during startup convergence: $manifestReadError") | Out-Null
+}
 if (-not $sessionReady) { $smokeErrors.Add('session_ready is false.') | Out-Null }
 if (-not $paneProbeOk) { $smokeErrors.Add("pane probe failed: $paneProbeError") | Out-Null }
 if ($paneProbeOk -and $paneCount -lt $expectedPaneCount) { $smokeErrors.Add("pane count $paneCount is below expected $expectedPaneCount.") | Out-Null }

--- a/winsmux-core/scripts/orchestra-start.ps1
+++ b/winsmux-core/scripts/orchestra-start.ps1
@@ -200,14 +200,21 @@ function Try-StartOrchestraUiAttach {
 
     $clientSnapshot = Get-OrchestraAttachedClientSnapshot -WinsmuxBin $winsmuxPathForAttach -SessionName $SessionName
     $baselineClientCount = if ([bool]$clientSnapshot.Ok) { [int]$clientSnapshot.Count } else { 0 }
-    if ([bool]$clientSnapshot.Ok -and $baselineClientCount -ge 1) {
+    $baselineClients = if ([bool]$clientSnapshot.Ok) { @($clientSnapshot.Clients) } else { @() }
+    $existingAttachState = Read-OrchestraAttachState -SessionName $SessionName
+    $existingAttachSource = if ($null -eq $existingAttachState) { '' } else { [string]$existingAttachState.ui_attach_source }
+    if ([string]::IsNullOrWhiteSpace($existingAttachSource)) {
+        $existingAttachSource = 'handshake'
+    }
+    $hasLiveVisibleAttach = (Test-OrchestraLiveVisibleAttachState -State $existingAttachState -SessionName $SessionName)
+    if ($hasLiveVisibleAttach -and [bool]$clientSnapshot.Ok -and $baselineClientCount -ge 1) {
         Write-OrchestraAttachState -SessionName $SessionName -Properties @{
             session_name       = $SessionName
             winsmux_path       = $winsmuxPathForAttach
             attach_status      = 'attach_confirmed'
             attach_confirmed_at = (Get-Date).ToString('o')
             client_count_seen  = $baselineClientCount
-            ui_attach_source   = 'client-probe'
+            ui_attach_source   = $existingAttachSource
             error              = "Detected $baselineClientCount attached client(s) for session '$SessionName'."
         } | Out-Null
 
@@ -216,39 +223,72 @@ function Try-StartOrchestraUiAttach {
             Launched  = $false
             Attached  = $true
             Status    = 'attach_already_present'
-            Reason    = "Detected $baselineClientCount attached client(s) for session '$SessionName'; skipped spawning another visible attach window."
+            Reason    = "Detected an existing live visible attach for session '$SessionName'; skipped spawning another visible attach window."
             Path      = ''
-            Source    = 'client-probe'
+            Source    = $existingAttachSource
         }
     }
 
     $terminalInfo = Get-OrchestraWindowsTerminalInfo
     if (-not [bool]$terminalInfo.Available) {
-        $reason = if ([bool]$terminalInfo.IsAliasStub) {
-            'WindowsApps wt.exe alias was found, but no canonical Windows Terminal binary could be resolved.'
-        } else {
-            'Windows Terminal is not installed or not on PATH.'
-        }
-
         Write-OrchestraAttachState -SessionName $SessionName -Properties @{
             session_name          = $SessionName
             winsmux_path          = $winsmuxPathForAttach
             requested_at          = (Get-Date).ToString('o')
             baseline_client_count = $baselineClientCount
+            baseline_clients      = @($baselineClients)
             client_count_seen     = $baselineClientCount
-            attach_status         = 'attach_failed'
+            attach_process_id     = 0
+            attach_status         = 'attach_requested'
+            attach_confirmed_at   = ''
+            started_at            = ''
             ui_attach_source      = 'none'
-            error                 = $reason
+            error                 = ''
         } | Out-Null
 
-        return [PSCustomObject][ordered]@{
-            Attempted = $false
-            Launched  = $false
-            Attached  = $false
-            Status    = 'attach_failed'
-            Reason    = $reason
-            Path      = [string]$terminalInfo.Path
-            Source    = 'none'
+        try {
+            $attachLaunch = Start-OrchestraPowerShellVisibleAttach
+            $launchedPath = [string]$attachLaunch.Path
+            if ($null -ne $attachLaunch.Process -and $null -ne $attachLaunch.Process.PSObject -and ($attachLaunch.Process.PSObject.Properties.Name -contains 'Id')) {
+                Write-OrchestraAttachState -SessionName $SessionName -Properties @{
+                    attach_process_id = $attachLaunch.Process.Id
+                    started_at        = (Get-Date).ToString('o')
+                    ui_host_kind      = [string]$attachLaunch.HostKind
+                } | Out-Null
+            }
+            $confirmed = Wait-OrchestraAttachHandshake -SessionName $SessionName -WinsmuxBin $winsmuxPathForAttach -BaselineClientCount $baselineClientCount -BaselineClients $baselineClients
+            return [PSCustomObject][ordered]@{
+                Attempted = $true
+                Launched  = $true
+                Attached  = [bool]$confirmed.Confirmed
+                Status    = [string]$confirmed.Status
+                Reason    = [string]$confirmed.Reason
+                Path      = $launchedPath
+                Source    = [string]$confirmed.Source
+            }
+        } catch {
+            $reason = if ([bool]$terminalInfo.IsAliasStub) {
+                'WindowsApps wt.exe alias was found, but no canonical Windows Terminal binary could be resolved.'
+            } else {
+                'Windows Terminal is not installed or not on PATH.'
+            }
+
+            $failureReason = "$reason Fallback host launch failed: $($_.Exception.Message)"
+            Write-OrchestraAttachState -SessionName $SessionName -Properties @{
+                attach_status     = 'attach_failed'
+                ui_attach_source  = 'none'
+                error             = $failureReason
+            } | Out-Null
+
+            return [PSCustomObject][ordered]@{
+                Attempted = $true
+                Launched  = $false
+                Attached  = $false
+                Status    = 'attach_failed'
+                Reason    = $failureReason
+                Path      = ''
+                Source    = 'none'
+            }
         }
     }
 
@@ -260,40 +300,97 @@ function Try-StartOrchestraUiAttach {
         requested_at          = (Get-Date).ToString('o')
         request_id            = [guid]::NewGuid().ToString('N')
         baseline_client_count = $baselineClientCount
+        baseline_clients      = @($baselineClients)
         client_count_seen     = $baselineClientCount
+        attach_process_id     = 0
         attach_status         = 'attach_requested'
+        attach_confirmed_at   = ''
+        started_at            = ''
         ui_attach_source      = 'none'
         error                 = ''
     } | Out-Null
 
     try {
-        Start-Process -FilePath ([string]$terminalInfo.Path) -ArgumentList @('-w', '-1', 'new-tab', '-p', [string]$profile.ProfileName) -PassThru | Out-Null
+        $attachLaunch = Start-OrchestraWindowsTerminalVisibleAttach -TerminalPath ([string]$terminalInfo.Path) -ProfileName ([string]$profile.ProfileName)
+        $launchedPath = [string]$attachLaunch.Path
+        if ($null -ne $attachLaunch.Process -and $null -ne $attachLaunch.Process.PSObject -and ($attachLaunch.Process.PSObject.Properties.Name -contains 'Id')) {
+            Write-OrchestraAttachState -SessionName $SessionName -Properties @{
+                attach_process_id = $attachLaunch.Process.Id
+                started_at        = (Get-Date).ToString('o')
+                ui_host_kind      = [string]$attachLaunch.HostKind
+            } | Out-Null
+        }
     } catch {
-        Write-OrchestraAttachState -SessionName $SessionName -Properties @{
-            attach_status     = 'attach_failed'
-            ui_attach_source  = 'none'
-            error             = $_.Exception.Message
-        } | Out-Null
+        try {
+            $attachLaunch = Start-OrchestraPowerShellVisibleAttach
+            $launchedPath = [string]$attachLaunch.Path
+            if ($null -ne $attachLaunch.Process -and $null -ne $attachLaunch.Process.PSObject -and ($attachLaunch.Process.PSObject.Properties.Name -contains 'Id')) {
+                Write-OrchestraAttachState -SessionName $SessionName -Properties @{
+                    attach_process_id = $attachLaunch.Process.Id
+                    started_at        = (Get-Date).ToString('o')
+                    ui_host_kind      = [string]$attachLaunch.HostKind
+                } | Out-Null
+            }
+        } catch {
+            Write-OrchestraAttachState -SessionName $SessionName -Properties @{
+                attach_status     = 'attach_failed'
+                ui_attach_source  = 'none'
+                error             = $_.Exception.Message
+            } | Out-Null
 
-        return [PSCustomObject][ordered]@{
-            Attempted = $true
-            Launched  = $false
-            Attached  = $false
-            Status    = 'attach_failed'
-            Reason    = $_.Exception.Message
-            Path      = [string]$terminalInfo.Path
-            Source    = 'none'
+            return [PSCustomObject][ordered]@{
+                Attempted = $true
+                Launched  = $false
+                Attached  = $false
+                Status    = 'attach_failed'
+                Reason    = $_.Exception.Message
+                Path      = [string]$terminalInfo.Path
+                Source    = 'none'
+            }
         }
     }
 
-    $confirmed = Wait-OrchestraAttachHandshake -SessionName $SessionName -WinsmuxBin $winsmuxPathForAttach -BaselineClientCount $baselineClientCount
+    if ($launchedPath -eq [string]$terminalInfo.Path) {
+        $launchObserved = Wait-OrchestraAttachLaunchObservation -SessionName $SessionName -WinsmuxBin $winsmuxPathForAttach -BaselineClientCount $baselineClientCount -BaselineClients $baselineClients
+        if (-not [bool]$launchObserved.Observed) {
+            try {
+                $attachLaunch = Start-OrchestraPowerShellVisibleAttach
+                $launchedPath = [string]$attachLaunch.Path
+                if ($null -ne $attachLaunch.Process -and $null -ne $attachLaunch.Process.PSObject -and ($attachLaunch.Process.PSObject.Properties.Name -contains 'Id')) {
+                    Write-OrchestraAttachState -SessionName $SessionName -Properties @{
+                        attach_process_id = $attachLaunch.Process.Id
+                        started_at        = (Get-Date).ToString('o')
+                        ui_host_kind      = [string]$attachLaunch.HostKind
+                    } | Out-Null
+                }
+            } catch {
+                Write-OrchestraAttachState -SessionName $SessionName -Properties @{
+                    attach_status     = 'attach_failed'
+                    ui_attach_source  = 'none'
+                    error             = $_.Exception.Message
+                } | Out-Null
+
+                return [PSCustomObject][ordered]@{
+                    Attempted = $true
+                    Launched  = $false
+                    Attached  = $false
+                    Status    = 'attach_failed'
+                    Reason    = $_.Exception.Message
+                    Path      = [string]$terminalInfo.Path
+                    Source    = 'none'
+                }
+            }
+        }
+    }
+
+    $confirmed = Wait-OrchestraAttachHandshake -SessionName $SessionName -WinsmuxBin $winsmuxPathForAttach -BaselineClientCount $baselineClientCount -BaselineClients $baselineClients
     return [PSCustomObject][ordered]@{
         Attempted = $true
         Launched  = $true
         Attached  = [bool]$confirmed.Confirmed
         Status    = [string]$confirmed.Status
         Reason    = [string]$confirmed.Reason
-        Path      = [string]$terminalInfo.Path
+        Path      = $launchedPath
         Source    = [string]$confirmed.Source
     }
 }
@@ -386,8 +483,9 @@ function Reset-OrchestraServerSession {
     if (Test-OrchestraServerSession -SessionName $SessionName) {
         try {
             Invoke-Winsmux -Arguments @('kill-session', '-t', $SessionName)
+            Wait-OrchestraServerSessionAbsent -SessionName $SessionName -TimeoutSeconds 20 | Out-Null
         } catch {
-            Write-Warning "Reset-OrchestraServerSession: failed to kill $SessionName during ${Reason}: $($_.Exception.Message)"
+            throw "Reset-OrchestraServerSession: failed to fully reset $SessionName during ${Reason}: $($_.Exception.Message)"
         }
     }
 
@@ -422,6 +520,33 @@ function Reset-OrchestraServerSession {
         BootstrapMode  = $bootstrapMode
         Health         = $health
     }
+}
+
+function Wait-OrchestraServerSessionAbsent {
+    param(
+        [Parameter(Mandatory = $true)][string]$SessionName,
+        [int]$TimeoutSeconds = 20
+    )
+
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    $pollAttempt = 0
+    while ((Get-Date) -lt $deadline) {
+        $pollAttempt++
+        if (-not (Test-OrchestraServerSession -SessionName $SessionName)) {
+            return [ordered]@{
+                Ready       = $true
+                PollAttempt = $pollAttempt
+            }
+        }
+
+        if ($pollAttempt -le 5 -or $pollAttempt % 10 -eq 0) {
+            Write-Warning "Wait-OrchestraServerSessionAbsent: poll $pollAttempt still sees session $SessionName"
+        }
+
+        Start-Sleep -Milliseconds 500
+    }
+
+    throw "Timed out waiting for session '$SessionName' to disappear after kill-session."
 }
 
 function Get-OrchestraStartupLockPath {
@@ -1463,6 +1588,7 @@ function Remove-OrchestraCreatedWorktrees {
     )
 
     $removedWorktrees = [System.Collections.Generic.List[object]]::new()
+    $cleanupErrors = [System.Collections.Generic.List[string]]::new()
     foreach ($createdWorktree in @($CreatedWorktrees)) {
         if ($null -eq $createdWorktree) {
             continue
@@ -1477,14 +1603,23 @@ function Remove-OrchestraCreatedWorktrees {
         if (-not [string]::IsNullOrWhiteSpace($worktreePath) -and (Test-Path -LiteralPath $worktreePath)) {
             try {
                 & git -C $ProjectDir worktree remove $worktreePath --force 2>$null | Out-Null
+                if ($LASTEXITCODE -ne 0) {
+                    $cleanupErrors.Add("worktree remove $worktreePath failed with exit code $LASTEXITCODE.") | Out-Null
+                }
             } catch {
+                $cleanupErrors.Add("worktree remove $worktreePath failed: $($_.Exception.Message)") | Out-Null
             }
         }
 
         if (-not [string]::IsNullOrWhiteSpace($branchName)) {
             try {
                 & git -C $ProjectDir branch -D $branchName 2>$null | Out-Null
+                $branchDeleteExitCode = $LASTEXITCODE
+                if ($branchDeleteExitCode -ne 0) {
+                    $cleanupErrors.Add("branch delete $branchName failed with exit code $branchDeleteExitCode.") | Out-Null
+                }
             } catch {
+                $cleanupErrors.Add("branch delete $branchName failed: $($_.Exception.Message)") | Out-Null
             }
         }
 
@@ -1494,7 +1629,10 @@ function Remove-OrchestraCreatedWorktrees {
         }) | Out-Null
     }
 
-    return @($removedWorktrees)
+    return [ordered]@{
+        RemovedWorktrees = @($removedWorktrees)
+        Errors           = @($cleanupErrors)
+    }
 }
 
 function Write-OrchestraStartupFailureEvent {
@@ -1617,7 +1755,32 @@ function Invoke-OrchestraStartupRollback {
     }
 
     if (-not [string]::IsNullOrWhiteSpace($ProjectDir)) {
-        $removedWorktrees = @(Remove-OrchestraCreatedWorktrees -ProjectDir $ProjectDir -CreatedWorktrees $CreatedWorktrees)
+        $worktreeCleanup = Remove-OrchestraCreatedWorktrees -ProjectDir $ProjectDir -CreatedWorktrees $CreatedWorktrees
+        $hasStructuredCleanup = $false
+        $cleanupResultRemoved = @()
+        $cleanupResultErrors = @()
+        if ($worktreeCleanup -is [System.Collections.IDictionary]) {
+            $hasStructuredCleanup = $worktreeCleanup.Contains('RemovedWorktrees')
+            if ($hasStructuredCleanup) {
+                $cleanupResultRemoved = @($worktreeCleanup['RemovedWorktrees'])
+                $cleanupResultErrors = @($worktreeCleanup['Errors'])
+            }
+        } elseif (($null -ne $worktreeCleanup) -and ($null -ne $worktreeCleanup.PSObject) -and ($worktreeCleanup.PSObject.Properties.Name -contains 'RemovedWorktrees')) {
+            $hasStructuredCleanup = $true
+            $cleanupResultRemoved = @($worktreeCleanup.RemovedWorktrees)
+            $cleanupResultErrors = @($worktreeCleanup.Errors)
+        }
+
+        if ($hasStructuredCleanup) {
+            $removedWorktrees = @($cleanupResultRemoved)
+            foreach ($cleanupError in @($cleanupResultErrors)) {
+                if (-not [string]::IsNullOrWhiteSpace([string]$cleanupError)) {
+                    $rollbackErrors.Add([string]$cleanupError) | Out-Null
+                }
+            }
+        } else {
+            $removedWorktrees = @($worktreeCleanup)
+        }
         $null = Write-OrchestraStartupFailureEvent -ProjectDir $ProjectDir -SessionName $SessionName -FailureMessage $FailureMessage -BootstrapPaneId $BootstrapPaneId -RemovedPaneIds @($removedPaneIds) -RemovedWorktrees $removedWorktrees -BootstrapRespawned $bootstrapRespawned -RollbackErrors @($rollbackErrors)
     }
 
@@ -1774,7 +1937,7 @@ if ($MyInvocation.InvocationName -ne '.') {
         $script:winsmuxBin = Get-WinsmuxBin
         $winsmuxBin = $script:winsmuxBin
         if (-not $winsmuxBin) {
-            Write-Error 'Could not find a winsmux binary. Tried: winsmux, pmux, tmux.'
+            Write-Error (Get-WinsmuxOperatorNotFoundMessage)
             exit 1
         }
 

--- a/winsmux-core/scripts/orchestra-ui-attach.ps1
+++ b/winsmux-core/scripts/orchestra-ui-attach.ps1
@@ -72,6 +72,149 @@ function Read-OrchestraAttachState {
     }
 }
 
+function ConvertTo-OrchestraAttachProcessId {
+    param([AllowNull()]$Value)
+
+    $processId = 0
+    if ($null -eq $Value) {
+        return 0
+    }
+
+    if ([int]::TryParse(([string]$Value), [ref]$processId)) {
+        return $processId
+    }
+
+    return 0
+}
+
+function Test-OrchestraProcessAlive {
+    param([AllowNull()]$ProcessId)
+
+    $resolvedProcessId = ConvertTo-OrchestraAttachProcessId -Value $ProcessId
+    if ($resolvedProcessId -le 0) {
+        return $false
+    }
+
+    try {
+        return ($null -ne (Get-Process -Id $resolvedProcessId -ErrorAction SilentlyContinue))
+    } catch {
+        return $false
+    }
+}
+
+function Test-OrchestraLiveVisibleAttachState {
+    param(
+        [AllowNull()]$State,
+        [Parameter(Mandatory = $true)][string]$SessionName
+    )
+
+    if ($null -eq $State) {
+        return $false
+    }
+
+    $stateSessionName = [string]$State.session_name
+    if (-not [string]::IsNullOrWhiteSpace($stateSessionName) -and $stateSessionName -ne $SessionName) {
+        return $false
+    }
+
+    $status = [string]$State.attach_status
+    if ($status -ne 'attach_confirmed') {
+        return $false
+    }
+
+    return (Test-OrchestraProcessAlive -ProcessId $State.attach_process_id)
+}
+
+function Get-OrchestraBaselineClients {
+    param(
+        [AllowNull()]$BaselineClients,
+        [AllowNull()]$State
+    )
+
+    $clients = @()
+    if ($null -ne $BaselineClients) {
+        $clients = @(
+            @($BaselineClients) |
+                ForEach-Object { [string]$_ } |
+                Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+        )
+    }
+
+    if ($clients.Count -gt 0) {
+        return $clients
+    }
+
+    if ($null -ne $State -and $State.PSObject.Properties.Name -contains 'baseline_clients') {
+        return @(
+            @($State.baseline_clients) |
+                ForEach-Object { [string]$_ } |
+                Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+        )
+    }
+
+    return @()
+}
+
+function Test-OrchestraAttachClientTransition {
+    param(
+        [AllowEmptyCollection()][string[]]$BaselineClients = @(),
+        [AllowEmptyCollection()][string[]]$CurrentClients = @()
+    )
+
+    $baseline = @(
+        @($BaselineClients) |
+            ForEach-Object { [string]$_ } |
+            Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+            Sort-Object -Unique
+    )
+    $current = @(
+        @($CurrentClients) |
+            ForEach-Object { [string]$_ } |
+            Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+            Sort-Object -Unique
+    )
+
+    if ($baseline.Count -eq 0) {
+        return ($current.Count -gt 0)
+    }
+
+    if ($baseline.Count -ne $current.Count) {
+        return $true
+    }
+
+    if ($baseline.Count -eq 0 -and $current.Count -eq 0) {
+        return $false
+    }
+
+    return (($baseline -join "`n") -ne ($current -join "`n"))
+}
+
+function Test-OrchestraAttachClientSnapshotMatch {
+    param(
+        [AllowNull()]$ExpectedClients,
+        [AllowNull()]$CurrentClients
+    )
+
+    $expected = @(
+        @($ExpectedClients) |
+            ForEach-Object { [string]$_ } |
+            Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+            Sort-Object -Unique
+    )
+    $current = @(
+        @($CurrentClients) |
+            ForEach-Object { [string]$_ } |
+            Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+            Sort-Object -Unique
+    )
+
+    if ($expected.Count -eq 0) {
+        return $false
+    }
+
+    return (($expected -join "`n") -eq ($current -join "`n"))
+}
+
 function Write-OrchestraAttachState {
     param(
         [Parameter(Mandatory = $true)][string]$SessionName,
@@ -195,6 +338,82 @@ function Get-OrchestraWindowsTerminalInfo {
     }
 }
 
+function Get-OrchestraAttachEntryArgumentList {
+    $attachEntryScriptPath = Get-OrchestraAttachEntryScriptPath
+    return @('-NoLogo', '-NoExit', '-File', $attachEntryScriptPath)
+}
+
+function Start-OrchestraWindowsTerminalVisibleAttach {
+    param(
+        [Parameter(Mandatory = $true)][string]$TerminalPath,
+        [Parameter(Mandatory = $true)][string]$ProfileName
+    )
+
+    $process = Start-Process -FilePath $TerminalPath -ArgumentList @('-w', '-1', 'new-window', '-p', $ProfileName) -PassThru
+    return [PSCustomObject][ordered]@{
+        HostKind = 'windows-terminal'
+        Path     = $TerminalPath
+        Process  = $process
+    }
+}
+
+function Start-OrchestraPowerShellVisibleAttach {
+    $pwshPath = Get-OrchestraPowerShellPath
+    $process = Start-Process -FilePath $pwshPath -ArgumentList (Get-OrchestraAttachEntryArgumentList) -PassThru
+    return [PSCustomObject][ordered]@{
+        HostKind = 'powershell-window'
+        Path     = $pwshPath
+        Process  = $process
+    }
+}
+
+function Wait-OrchestraAttachLaunchObservation {
+    param(
+        [Parameter(Mandatory = $true)][string]$SessionName,
+        [Parameter(Mandatory = $true)][string]$WinsmuxBin,
+        [Parameter(Mandatory = $true)][int]$BaselineClientCount,
+        [AllowEmptyCollection()][string[]]$BaselineClients = @(),
+        [int]$TimeoutMilliseconds = 2500,
+        [int]$PollMilliseconds = 250
+    )
+
+    $deadline = (Get-Date).AddMilliseconds($TimeoutMilliseconds)
+    do {
+        $state = Read-OrchestraAttachState -SessionName $SessionName
+        if ($null -ne $state) {
+            $status = [string]$state.attach_status
+            if ($status -in @('attach_entry_started', 'attach_confirming', 'attach_confirmed')) {
+                return [PSCustomObject][ordered]@{
+                    Observed = $true
+                    Reason   = "Attach state advanced to '$status'."
+                }
+            }
+        }
+
+        $snapshot = Get-OrchestraAttachedClientSnapshot -WinsmuxBin $WinsmuxBin -SessionName $SessionName
+        $effectiveBaselineClients = @(Get-OrchestraBaselineClients -BaselineClients $BaselineClients -State $state)
+        $clientTransition = if ([bool]$snapshot.Ok) {
+            Test-OrchestraAttachClientTransition -BaselineClients $effectiveBaselineClients -CurrentClients @($snapshot.Clients)
+        } else {
+            $false
+        }
+
+        if ([bool]$snapshot.Ok -and (([int]$snapshot.Count -ge ($BaselineClientCount + 1)) -or $clientTransition)) {
+            return [PSCustomObject][ordered]@{
+                Observed = $true
+                Reason   = 'Attached client probe changed during attach launch.'
+            }
+        }
+
+        Start-Sleep -Milliseconds $PollMilliseconds
+    } while ((Get-Date) -lt $deadline)
+
+    return [PSCustomObject][ordered]@{
+        Observed = $false
+        Reason   = 'Attach launch did not advance state or change attached clients before timeout.'
+    }
+}
+
 function Ensure-OrchestraAttachProfile {
     param([Parameter(Mandatory = $true)][string]$ProjectDir)
 
@@ -236,6 +455,7 @@ function Wait-OrchestraAttachHandshake {
         [Parameter(Mandatory = $true)][string]$SessionName,
         [Parameter(Mandatory = $true)][string]$WinsmuxBin,
         [Parameter(Mandatory = $true)][int]$BaselineClientCount,
+        [AllowEmptyCollection()][string[]]$BaselineClients = @(),
         [int]$TimeoutMilliseconds = 12000,
         [int]$PollMilliseconds = 250
     )
@@ -265,19 +485,46 @@ function Wait-OrchestraAttachHandshake {
         }
 
         $snapshot = Get-OrchestraAttachedClientSnapshot -WinsmuxBin $WinsmuxBin -SessionName $SessionName
-        if ([bool]$snapshot.Ok -and [int]$snapshot.Count -ge $targetClientCount) {
+        $effectiveBaselineClients = Get-OrchestraBaselineClients -BaselineClients $BaselineClients -State $state
+        $clientTransition = if ([bool]$snapshot.Ok) {
+            Test-OrchestraAttachClientTransition -BaselineClients $effectiveBaselineClients -CurrentClients @($snapshot.Clients)
+        } else {
+            $false
+        }
+        $attachEntryObserved = $false
+        if ($null -ne $state) {
+            $currentStatus = [string]$state.attach_status
+            $attachEntryObserved = $currentStatus -in @('attach_entry_started', 'attach_confirming', 'attach_confirmed')
+        }
+        $countAdvanced = [bool]$snapshot.Ok -and ([int]$snapshot.Count -ge $targetClientCount)
+        $countBasedConfirmationAllowed = $countAdvanced -and (
+            ($BaselineClientCount -gt 0) -or
+            (@($effectiveBaselineClients).Count -gt 0) -or
+            $attachEntryObserved
+        )
+        $identityBasedConfirmationAllowed = $clientTransition -and (@($effectiveBaselineClients).Count -gt 0)
+
+        if ($countBasedConfirmationAllowed -or $identityBasedConfirmationAllowed) {
+            $source = if ($attachEntryObserved) { 'handshake' } else { 'client-probe' }
+
             $confirmedAt = (Get-Date).ToString('o')
             $updatedState = Write-OrchestraAttachState -SessionName $SessionName -Properties @{
                 attach_status       = 'attach_confirmed'
                 attach_confirmed_at = $confirmedAt
                 client_count_seen   = [int]$snapshot.Count
-                ui_attach_source    = 'client-probe'
-                error               = "Visible attach confirmed for session '$SessionName' with $($snapshot.Count) attached client(s)."
+                attached_client_count = [int]$snapshot.Count
+                attached_client_snapshot = @($snapshot.Clients)
+                ui_attach_source    = $source
+                error               = if ($identityBasedConfirmationAllowed -and [int]$snapshot.Count -lt $targetClientCount) {
+                    "Visible attach confirmed for session '$SessionName' after attached client identity changed."
+                } else {
+                    "Visible attach confirmed for session '$SessionName' with $($snapshot.Count) attached client(s)."
+                }
             }
 
             return [PSCustomObject][ordered]@{
                 Confirmed           = $true
-                Source              = 'client-probe'
+                Source              = $source
                 Status              = 'attach_confirmed'
                 Reason              = [string]$updatedState.error
                 AttachedClientCount = [int]$snapshot.Count

--- a/winsmux-core/scripts/server-watchdog.ps1
+++ b/winsmux-core/scripts/server-watchdog.ps1
@@ -121,7 +121,7 @@ function Invoke-ServerWatchdogWinsmux {
 
     $winsmuxBin = Get-WinsmuxBin
     if (-not $winsmuxBin) {
-        throw 'Could not find a winsmux binary. Tried: winsmux, pmux, tmux.'
+        throw (Get-WinsmuxOperatorNotFoundMessage)
     }
 
     $output = & $winsmuxBin @Arguments 2>&1

--- a/winsmux-core/scripts/settings.ps1
+++ b/winsmux-core/scripts/settings.ps1
@@ -49,6 +49,12 @@ if (-not (Get-Command Get-WinsmuxBin -ErrorAction SilentlyContinue)) {
     }
 }
 
+if (-not (Get-Command Get-WinsmuxOperatorNotFoundMessage -ErrorAction SilentlyContinue)) {
+    function Get-WinsmuxOperatorNotFoundMessage {
+        return 'Could not resolve the winsmux executable from PATH. Install winsmux or expose the winsmux binary before running startup, status, or probe commands.'
+    }
+}
+
 if (-not (Get-Command Get-WinsmuxOption -ErrorAction SilentlyContinue)) {
     function Test-WinsmuxOptionFailureText {
         param([string]$Value)
@@ -1040,7 +1046,7 @@ function Save-BridgeSettings {
 
     $winsmuxBin = Get-WinsmuxBin
     if (-not $winsmuxBin) {
-        throw 'Could not find a winsmux binary. Tried: winsmux, pmux, tmux.'
+        throw (Get-WinsmuxOperatorNotFoundMessage)
     }
 
     foreach ($key in $normalized.Keys) {

--- a/winsmux-core/scripts/setup-wizard.ps1
+++ b/winsmux-core/scripts/setup-wizard.ps1
@@ -163,13 +163,13 @@ function Set-GitHubTokenVault {
 
 $winsmuxBin = Get-WinsmuxBin
 if (-not $winsmuxBin) {
-    Write-Error "Could not find a winsmux binary. Tried: winsmux, pmux, tmux."
+    Write-Error (Get-WinsmuxOperatorNotFoundMessage)
     exit 1
 }
 
 Write-Host 'winsmux setup wizard'
 Write-Host ''
-Write-Host "Using multiplexer binary: $winsmuxBin"
+Write-Host 'winsmux CLI detected on PATH.'
 Write-Host ''
 
 $agentCli = Read-AgentCli -Default 'codex'


### PR DESCRIPTION
## Summary
- harden visible attach and rollback boundaries for the orchestra startup path
- surface rollback cleanup failures in `rollback_errors` and cover those regressions in Pester
- reduce the concurrent JSONL append flake by resolving `pwsh` explicitly and checking worker exit codes

## Test plan
- `Invoke-Pester tests/winsmux-bridge.Tests.ps1 -CI`
- `Invoke-Pester tests/HarnessContract.Tests.ps1 -CI`
- `Invoke-Pester tests/Integration.PaneMonitorHook.Tests.ps1 -CI`
- `pwsh -NoProfile -File .\winsmux-core\scripts\harness-check.ps1 -ProjectDir . -AsJson`
- `pwsh -NoProfile -File .\scripts\git-guard.ps1 -Mode full`
- `pwsh -NoProfile -File .\scripts\audit-public-surface.ps1`