### PR TITLE
feat: stream desktop summary refresh events

### DIFF
--- a/winsmux-app/src-tauri/src/desktop_backend.rs
+++ b/winsmux-app/src-tauri/src/desktop_backend.rs
@@ -1,8 +1,13 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::fs;
+use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
 
 const DESKTOP_JSON_RPC_VERSION: &str = "2.0";
 const JSON_RPC_INVALID_REQUEST: i32 = -32600;
@@ -19,6 +24,16 @@ pub struct DesktopSummarySnapshot {
     pub inbox: serde_json::Value,
     pub digest: serde_json::Value,
     pub run_projections: Vec<DesktopRunProjection>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DesktopSummaryRefreshSignal {
+    pub source: String,
+    pub reason: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pane_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub run_id: Option<String>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -94,6 +109,11 @@ pub enum DesktopCommand {
     },
 }
 
+pub enum DesktopStreamCommand {
+    Inbox { project_dir: Option<String> },
+    Digest { project_dir: Option<String> },
+}
+
 impl DesktopCommand {
     fn project_dir(&self) -> Option<&str> {
         match self {
@@ -110,6 +130,41 @@ impl DesktopCommand {
             DesktopCommand::RunExplain { run_id, .. } => {
                 vec!["explain".to_string(), run_id.clone(), "--json".to_string()]
             }
+        }
+    }
+}
+
+impl DesktopStreamCommand {
+    fn project_dir(&self) -> Option<&str> {
+        match self {
+            DesktopStreamCommand::Inbox { project_dir } => project_dir.as_deref(),
+            DesktopStreamCommand::Digest { project_dir } => project_dir.as_deref(),
+        }
+    }
+
+    fn winsmux_args(&self) -> Vec<String> {
+        match self {
+            DesktopStreamCommand::Inbox { .. } => {
+                vec![
+                    "inbox".to_string(),
+                    "--stream".to_string(),
+                    "--json".to_string(),
+                ]
+            }
+            DesktopStreamCommand::Digest { .. } => {
+                vec![
+                    "digest".to_string(),
+                    "--stream".to_string(),
+                    "--json".to_string(),
+                ]
+            }
+        }
+    }
+
+    fn source_name(&self) -> &'static str {
+        match self {
+            DesktopStreamCommand::Inbox { .. } => "inbox",
+            DesktopStreamCommand::Digest { .. } => "digest",
         }
     }
 }
@@ -310,6 +365,160 @@ fn resolve_effective_project_dir(project_dir: Option<String>) -> Result<PathBuf,
     })
 }
 
+fn build_winsmux_command_text(script_path: &Path, args: &[String]) -> String {
+    let script_literal = script_path.to_string_lossy().replace('\'', "''");
+    let args_literal = args
+        .iter()
+        .map(|item| format!("'{}'", item.replace('\'', "''")))
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    format!("& {{ & '{}' {} }}", script_literal, args_literal)
+}
+
+pub fn parse_desktop_summary_stream_signal(
+    source: &str,
+    line: &str,
+) -> Option<DesktopSummaryRefreshSignal> {
+    let trimmed = line.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    let payload: Value = serde_json::from_str(trimmed).ok()?;
+    let object = payload.as_object()?;
+
+    let is_valid = match source {
+        "digest" => object
+            .get("run_id")
+            .and_then(|value| value.as_str())
+            .is_some(),
+        "inbox" => {
+            object
+                .get("kind")
+                .and_then(|value| value.as_str())
+                .is_some()
+                && object
+                    .get("pane_id")
+                    .and_then(|value| value.as_str())
+                    .is_some()
+        }
+        _ => false,
+    };
+    if !is_valid {
+        return None;
+    }
+
+    Some(DesktopSummaryRefreshSignal {
+        source: source.to_string(),
+        reason: format!("{}.stream", source),
+        pane_id: object
+            .get("pane_id")
+            .and_then(|value| value.as_str())
+            .map(|value| value.to_string()),
+        run_id: object
+            .get("run_id")
+            .and_then(|value| value.as_str())
+            .map(|value| value.to_string()),
+    })
+}
+
+pub fn spawn_desktop_summary_refresh_stream<F>(
+    command: DesktopStreamCommand,
+    stop_requested: Arc<AtomicBool>,
+    mut on_signal: F,
+) -> Result<(), String>
+where
+    F: FnMut(DesktopSummaryRefreshSignal) + Send + 'static,
+{
+    let repo_root = resolve_repo_root()?;
+    let effective_project_dir =
+        resolve_effective_project_dir(command.project_dir().map(|value| value.to_string()))?;
+    let script_path = repo_root.join("scripts").join("winsmux-core.ps1");
+    let command_text = build_winsmux_command_text(&script_path, &command.winsmux_args());
+    let source = command.source_name().to_string();
+
+    thread::spawn(move || {
+        while !stop_requested.load(Ordering::Relaxed) {
+            let mut child = match Command::new("pwsh")
+                .arg("-NoProfile")
+                .arg("-ExecutionPolicy")
+                .arg("Bypass")
+                .arg("-Command")
+                .arg(&command_text)
+                .current_dir(&effective_project_dir)
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .spawn()
+            {
+                Ok(child) => child,
+                Err(err) => {
+                    eprintln!("Failed to start {} summary stream: {}", source, err);
+                    if stop_requested.load(Ordering::Relaxed) {
+                        break;
+                    }
+                    thread::sleep(Duration::from_secs(2));
+                    continue;
+                }
+            };
+
+            if let Some(stderr) = child.stderr.take() {
+                let stderr_source = source.clone();
+                thread::spawn(move || {
+                    let reader = BufReader::new(stderr);
+                    for line in reader.lines().map_while(Result::ok) {
+                        let trimmed = line.trim();
+                        if !trimmed.is_empty() {
+                            eprintln!("winsmux {} stream stderr: {}", stderr_source, trimmed);
+                        }
+                    }
+                });
+            }
+
+            let stdout = match child.stdout.take() {
+                Some(stdout) => stdout,
+                None => {
+                    eprintln!("winsmux {} stream stdout pipe missing", source);
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    if stop_requested.load(Ordering::Relaxed) {
+                        break;
+                    }
+                    thread::sleep(Duration::from_secs(2));
+                    continue;
+                }
+            };
+
+            let reader = BufReader::new(stdout);
+            for line in reader.lines() {
+                if stop_requested.load(Ordering::Relaxed) {
+                    let _ = child.kill();
+                    break;
+                }
+                match line {
+                    Ok(line) => {
+                        if let Some(signal) = parse_desktop_summary_stream_signal(&source, &line) {
+                            on_signal(signal);
+                        }
+                    }
+                    Err(err) => {
+                        eprintln!("winsmux {} stream read failed: {}", source, err);
+                        break;
+                    }
+                }
+            }
+
+            let _ = child.wait();
+            if stop_requested.load(Ordering::Relaxed) {
+                break;
+            }
+            thread::sleep(Duration::from_secs(2));
+        }
+    });
+
+    Ok(())
+}
+
 fn resolve_desktop_read_root(
     project_dir: Option<String>,
     worktree: Option<String>,
@@ -391,13 +600,7 @@ fn run_winsmux_json(project_dir: Option<String>, args: &[String]) -> Result<Valu
     let repo_root = resolve_repo_root()?;
     let effective_project_dir = resolve_effective_project_dir(project_dir)?;
     let script_path = repo_root.join("scripts").join("winsmux-core.ps1");
-    let script_literal = script_path.to_string_lossy().replace('\'', "''");
-    let args_literal = args
-        .iter()
-        .map(|item| format!("'{}'", item.replace('\'', "''")))
-        .collect::<Vec<_>>()
-        .join(" ");
-    let command_text = format!("& {{ & '{}' {} }}", script_literal, args_literal);
+    let command_text = build_winsmux_command_text(&script_path, args);
 
     let output = Command::new("pwsh")
         .arg("-NoProfile")
@@ -697,5 +900,46 @@ mod tests {
             DesktopJsonRpcResponse::Success { .. } => panic!("expected invalid params error"),
         }
         assert!(transport.requests.borrow().is_empty());
+    }
+
+    #[test]
+    fn parse_desktop_summary_stream_signal_extracts_digest_run_and_pane() {
+        let signal = parse_desktop_summary_stream_signal(
+            "digest",
+            r#"{"run_id":"task:task-289","pane_id":"%4","label":"builder-1"}"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            signal,
+            DesktopSummaryRefreshSignal {
+                source: "digest".to_string(),
+                reason: "digest.stream".to_string(),
+                pane_id: Some("%4".to_string()),
+                run_id: Some("task:task-289".to_string()),
+            }
+        );
+    }
+
+    #[test]
+    fn parse_desktop_summary_stream_signal_accepts_inbox_items_without_run_id() {
+        let signal = parse_desktop_summary_stream_signal(
+            "inbox",
+            r#"{"kind":"review_requested","pane_id":"%7","label":"reviewer-1"}"#,
+        )
+        .unwrap();
+
+        assert_eq!(signal.source, "inbox");
+        assert_eq!(signal.reason, "inbox.stream");
+        assert_eq!(signal.pane_id.as_deref(), Some("%7"));
+        assert_eq!(signal.run_id, None);
+    }
+
+    #[test]
+    fn parse_desktop_summary_stream_signal_rejects_untyped_json_lines() {
+        assert!(parse_desktop_summary_stream_signal("digest", r#"{"pane_id":"%2"}"#).is_none());
+        assert!(
+            parse_desktop_summary_stream_signal("inbox", r#"{"message":"missing kind"}"#).is_none()
+        );
     }
 }

--- a/winsmux-app/src-tauri/src/lib.rs
+++ b/winsmux-app/src-tauri/src/lib.rs
@@ -3,7 +3,8 @@ mod pty_backend;
 
 use desktop_backend::{
     handle_desktop_json_rpc, load_desktop_run_explain, load_desktop_summary_snapshot,
-    DesktopJsonRpcRequest, DesktopJsonRpcResponse, DesktopSummarySnapshot, PwshScriptTransport,
+    spawn_desktop_summary_refresh_stream, DesktopJsonRpcRequest, DesktopJsonRpcResponse,
+    DesktopStreamCommand, DesktopSummaryRefreshSignal, DesktopSummarySnapshot, PwshScriptTransport,
 };
 use portable_pty::{native_pty_system, CommandBuilder, PtySize};
 use pty_backend::{
@@ -11,6 +12,7 @@ use pty_backend::{
 };
 use std::collections::HashMap;
 use std::io::{Read, Write};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use tauri::{AppHandle, Emitter, Manager};
 
@@ -26,18 +28,46 @@ struct PtyManager {
     panes: Arc<Mutex<HashMap<String, SinglePty>>>,
 }
 
+struct DesktopSummaryStreamManager {
+    started: AtomicBool,
+    stop_requested: Arc<AtomicBool>,
+}
+
 struct TauriPtyTransport {
     app: AppHandle,
 }
 
-fn emit_desktop_summary_refresh(app: &AppHandle, reason: &str, pane_id: &str) {
-    let _ = app.emit(
-        DESKTOP_SUMMARY_REFRESH_EVENT,
-        serde_json::json!({
-            "reason": reason,
-            "pane_id": pane_id,
-        }),
-    );
+fn emit_desktop_summary_refresh(app: &AppHandle, signal: DesktopSummaryRefreshSignal) {
+    let _ = app.emit(DESKTOP_SUMMARY_REFRESH_EVENT, signal);
+}
+
+fn start_desktop_summary_refresh_streams(app: &AppHandle) {
+    let manager = app.state::<DesktopSummaryStreamManager>();
+    if manager.started.swap(true, Ordering::SeqCst) {
+        return;
+    }
+
+    let inbox_app = app.clone();
+    if let Err(err) = spawn_desktop_summary_refresh_stream(
+        DesktopStreamCommand::Inbox { project_dir: None },
+        manager.stop_requested.clone(),
+        move |signal| {
+            emit_desktop_summary_refresh(&inbox_app, signal);
+        },
+    ) {
+        eprintln!("Failed to start inbox summary stream adapter: {}", err);
+    }
+
+    let digest_app = app.clone();
+    if let Err(err) = spawn_desktop_summary_refresh_stream(
+        DesktopStreamCommand::Digest { project_dir: None },
+        manager.stop_requested.clone(),
+        move |signal| {
+            emit_desktop_summary_refresh(&digest_app, signal);
+        },
+    ) {
+        eprintln!("Failed to start digest summary stream adapter: {}", err);
+    }
 }
 
 #[tauri::command]
@@ -140,7 +170,15 @@ fn spawn_pty(app: &AppHandle, pane_id: String, cols: u16, rows: u16) -> Result<(
         panes.insert(pane_id.clone(), single);
     }
 
-    emit_desktop_summary_refresh(app, "pty.spawn", &pane_id);
+    emit_desktop_summary_refresh(
+        app,
+        DesktopSummaryRefreshSignal {
+            source: "pty".to_string(),
+            reason: "pty.spawn".to_string(),
+            pane_id: Some(pane_id.clone()),
+            run_id: None,
+        },
+    );
 
     // Read PTY output in background thread
     let app_handle = app.clone();
@@ -210,7 +248,15 @@ fn close_pty(app: &AppHandle, pane_id: &str) -> Result<(), String> {
     // Drop master to signal EOF to reader thread
     drop(entry.master);
     drop(entry.writer);
-    emit_desktop_summary_refresh(app, "pty.close", pane_id);
+    emit_desktop_summary_refresh(
+        app,
+        DesktopSummaryRefreshSignal {
+            source: "pty".to_string(),
+            reason: "pty.close".to_string(),
+            pane_id: Some(pane_id.to_string()),
+            run_id: None,
+        },
+    );
     Ok(())
 }
 
@@ -247,10 +293,18 @@ impl PtyCommandTransport for TauriPtyTransport {
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    tauri::Builder::default()
+    let app = tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
         .manage(PtyManager {
             panes: Arc::new(Mutex::new(HashMap::new())),
+        })
+        .manage(DesktopSummaryStreamManager {
+            started: AtomicBool::new(false),
+            stop_requested: Arc::new(AtomicBool::new(false)),
+        })
+        .setup(|app| {
+            start_desktop_summary_refresh_streams(&app.handle().clone());
+            Ok(())
         })
         .invoke_handler(tauri::generate_handler![
             desktop_summary_snapshot,
@@ -262,6 +316,16 @@ pub fn run() {
             pty_resize,
             pty_close
         ])
-        .run(tauri::generate_context!())
-        .expect("error while running tauri application");
+        .build(tauri::generate_context!())
+        .expect("error while building tauri application");
+
+    app.run(|app_handle, event| {
+        if matches!(
+            event,
+            tauri::RunEvent::ExitRequested { .. } | tauri::RunEvent::Exit
+        ) {
+            let manager = app_handle.state::<DesktopSummaryStreamManager>();
+            manager.stop_requested.store(true, Ordering::SeqCst);
+        }
+    });
 }

--- a/winsmux-app/src/desktopClient.ts
+++ b/winsmux-app/src/desktopClient.ts
@@ -262,8 +262,10 @@ export interface DesktopEditorFilePayload {
 }
 
 export interface DesktopSummaryRefreshEvent {
+  source?: string;
   reason?: string;
   pane_id?: string;
+  run_id?: string;
 }
 
 let nextDesktopJsonRpcId = 0;


### PR DESCRIPTION
## Summary
- add inbox/digest stream adapters that emit desktop summary refresh events from the Tauri backend
- switch the desktop refresh event payload to a typed signal with source, reason, pane_id, and optional run_id
- start and stop the summary stream workers with application lifecycle state instead of ad-hoc PTY-only refreshes

## Validation
- cargo fmt --manifest-path winsmux-app/src-tauri/Cargo.toml --check
- cargo test --manifest-path winsmux-app/src-tauri/Cargo.toml desktop_backend
- cargo test --manifest-path winsmux-app/src-tauri/Cargo.toml
- cmd /c npm run build

## Review
- explorer review: no material findings