### PR TITLE
fix: converge desktop projection contract

### DIFF
--- a/winsmux-app/src-tauri/src/desktop_backend.rs
+++ b/winsmux-app/src-tauri/src/desktop_backend.rs
@@ -69,6 +69,66 @@ pub struct DesktopEditorFilePayload {
     pub truncated: bool,
 }
 
+#[derive(Serialize, Deserialize)]
+pub struct DesktopExplainPayload {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub generated_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub project_dir: Option<String>,
+    pub run: DesktopExplainRun,
+    pub explanation: DesktopExplainExplanation,
+    pub evidence_digest: DesktopExplainEvidenceDigest,
+    #[serde(default)]
+    pub recent_events: Vec<DesktopExplainRecentEvent>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct DesktopExplainRun {
+    pub run_id: String,
+    pub task: String,
+    pub state: String,
+    pub task_state: String,
+    pub review_state: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub provider_target: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub agent_role: Option<String>,
+    pub branch: String,
+    pub head_sha: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub worktree: Option<String>,
+    #[serde(default)]
+    pub changed_files: Vec<String>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct DesktopExplainExplanation {
+    pub summary: String,
+    #[serde(default)]
+    pub reasons: Vec<String>,
+    pub next_action: String,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct DesktopExplainEvidenceDigest {
+    pub next_action: String,
+    pub changed_file_count: usize,
+    #[serde(default)]
+    pub changed_files: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub verification_outcome: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub security_blocked: Option<String>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct DesktopExplainRecentEvent {
+    pub timestamp: String,
+    pub event: String,
+    pub label: String,
+    pub message: String,
+}
+
 #[derive(Deserialize)]
 pub struct DesktopJsonRpcRequest {
     pub jsonrpc: String,
@@ -197,11 +257,13 @@ pub fn load_desktop_run_explain(
     transport: &dyn DesktopCommandTransport,
     run_id: String,
     project_dir: Option<String>,
-) -> Result<Value, String> {
-    transport.request_json(&DesktopCommand::RunExplain {
+) -> Result<DesktopExplainPayload, String> {
+    let payload = transport.request_json(&DesktopCommand::RunExplain {
         run_id,
         project_dir,
-    })
+    })?;
+    serde_json::from_value(payload)
+        .map_err(|err| format!("Failed to parse desktop explain payload: {err}"))
 }
 
 pub fn load_desktop_editor_file(
@@ -252,7 +314,14 @@ pub fn handle_desktop_json_rpc(
             };
 
             match load_desktop_run_explain(transport, run_id, resolved_project_dir) {
-                Ok(result) => json_rpc_result(request_id, result),
+                Ok(result) => match serde_json::to_value(result) {
+                    Ok(value) => json_rpc_result(request_id, value),
+                    Err(err) => json_rpc_error(
+                        request_id,
+                        JSON_RPC_INTERNAL_ERROR,
+                        format!("Failed to serialize desktop explain payload: {err}"),
+                    ),
+                },
                 Err(err) => json_rpc_error(request_id, JSON_RPC_SERVER_ERROR, err),
             }
         }
@@ -301,9 +370,11 @@ fn get_required_string_param(params: Option<&Value>, keys: &[&str]) -> Result<St
 fn get_optional_string_param(params: Option<&Value>, keys: &[&str]) -> Option<String> {
     let object = params?.as_object()?;
     for key in keys {
-        let value = object.get(*key)?.as_str()?.trim();
-        if !value.is_empty() {
-            return Some(value.to_string());
+        if let Some(value) = object.get(*key).and_then(Value::as_str) {
+            let trimmed = value.trim();
+            if !trimmed.is_empty() {
+                return Some(trimmed.to_string());
+            }
         }
     }
 
@@ -698,19 +769,114 @@ mod tests {
         let transport = FakeTransport {
             requests: RefCell::new(Vec::new()),
             response: serde_json::json!({
-                "run": { "run_id": "run-7" },
+                "generated_at": "2026-04-16T00:00:00Z",
+                "project_dir": "C:/repo",
+                "run": {
+                    "run_id": "run-7",
+                    "task": "Explain payload",
+                    "state": "running",
+                    "task_state": "in_progress",
+                    "review_state": "PENDING",
+                    "provider_target": "codex:gpt-5.4",
+                    "agent_role": "worker",
+                    "branch": "codex/task291",
+                    "head_sha": "abc1234def5678",
+                    "worktree": ".worktrees/builder-1",
+                    "changed_files": ["winsmux-app/src/main.ts"]
+                },
                 "explanation": { "summary": "ok", "reasons": [], "next_action": "idle" },
-                "evidence_digest": { "changed_files": [], "changed_file_count": 0 },
+                "evidence_digest": {
+                    "next_action": "idle",
+                    "changed_files": [],
+                    "changed_file_count": 0
+                },
+                "run_packet": { "provider_target": "should-not-leak" },
                 "recent_events": []
             }),
         };
 
         let payload = load_desktop_run_explain(&transport, "run-7".to_string(), None).unwrap();
 
-        assert_eq!(payload["run"]["run_id"], "run-7");
+        assert_eq!(payload.run.run_id, "run-7");
+        assert_eq!(
+            payload.run.provider_target.as_deref(),
+            Some("codex:gpt-5.4")
+        );
         assert_eq!(
             transport.requests.borrow().as_slice(),
             ["explain run-7 --json"]
+        );
+    }
+
+    #[test]
+    fn handle_desktop_json_rpc_routes_run_explain_and_prunes_extra_packets() {
+        let transport = FakeTransport {
+            requests: RefCell::new(Vec::new()),
+            response: serde_json::json!({
+                "generated_at": "2026-04-16T00:00:00Z",
+                "project_dir": "C:/repo",
+                "run": {
+                    "run_id": "run-8",
+                    "task": "Explain payload",
+                    "state": "running",
+                    "task_state": "in_progress",
+                    "review_state": "PENDING",
+                    "provider_target": "codex:gpt-5.4",
+                    "agent_role": "worker",
+                    "branch": "codex/task291",
+                    "head_sha": "abc1234def5678",
+                    "worktree": ".worktrees/builder-1",
+                    "changed_files": ["winsmux-app/src/main.ts"]
+                },
+                "explanation": {
+                    "summary": "Explain is available",
+                    "reasons": ["task_state=in_progress"],
+                    "next_action": "review_requested"
+                },
+                "evidence_digest": {
+                    "next_action": "review_requested",
+                    "changed_file_count": 1,
+                    "changed_files": ["winsmux-app/src/main.ts"],
+                    "verification_outcome": "PASS",
+                    "security_blocked": "ALLOW"
+                },
+                "recent_events": [{
+                    "timestamp": "2026-04-16T00:00:00Z",
+                    "event": "commander.review_requested",
+                    "label": "builder-1",
+                    "message": "Need review"
+                }],
+                "run_packet": { "provider_target": "should-not-leak" },
+                "result_packet": { "summary": "should-not-leak" }
+            }),
+        };
+        let response = handle_desktop_json_rpc(
+            &transport,
+            DesktopJsonRpcRequest {
+                jsonrpc: "2.0".to_string(),
+                id: serde_json::json!("req-explain"),
+                method: "desktop.run.explain".to_string(),
+                params: Some(serde_json::json!({
+                    "run_id": "run-8"
+                })),
+            },
+            None,
+        );
+
+        match response {
+            DesktopJsonRpcResponse::Success { id, result, .. } => {
+                assert_eq!(id, serde_json::json!("req-explain"));
+                assert_eq!(result["run"]["run_id"], "run-8");
+                assert!(result.get("run_packet").is_none());
+                assert!(result.get("result_packet").is_none());
+            }
+            DesktopJsonRpcResponse::Error { error, .. } => {
+                panic!("expected success, got {:?}", error);
+            }
+        }
+        assert_eq!(
+            transport.requests.borrow().as_slice(),
+            ["explain run-8 --json"]
         );
     }
 

--- a/winsmux-app/src-tauri/src/lib.rs
+++ b/winsmux-app/src-tauri/src/lib.rs
@@ -3,8 +3,9 @@ mod pty_backend;
 
 use desktop_backend::{
     handle_desktop_json_rpc, load_desktop_run_explain, load_desktop_summary_snapshot,
-    spawn_desktop_summary_refresh_stream, DesktopJsonRpcRequest, DesktopJsonRpcResponse,
-    DesktopStreamCommand, DesktopSummaryRefreshSignal, DesktopSummarySnapshot, PwshScriptTransport,
+    spawn_desktop_summary_refresh_stream, DesktopExplainPayload, DesktopJsonRpcRequest,
+    DesktopJsonRpcResponse, DesktopStreamCommand, DesktopSummaryRefreshSignal,
+    DesktopSummarySnapshot, PwshScriptTransport,
 };
 use portable_pty::{native_pty_system, CommandBuilder, PtySize};
 use pty_backend::{
@@ -82,7 +83,7 @@ async fn desktop_summary_snapshot(
 async fn desktop_run_explain(
     run_id: String,
     project_dir: Option<String>,
-) -> Result<serde_json::Value, String> {
+) -> Result<DesktopExplainPayload, String> {
     let transport = PwshScriptTransport;
     load_desktop_run_explain(&transport, run_id, project_dir)
 }

--- a/winsmux-app/src/desktopClient.ts
+++ b/winsmux-app/src/desktopClient.ts
@@ -155,23 +155,12 @@ export interface DesktopExplainPayload {
   project_dir?: string;
   run: {
     run_id: string;
-    task_id?: string;
-    parent_run_id?: string;
     task: string;
-    goal?: string;
-    task_type?: string;
     state: string;
     task_state: string;
     review_state: string;
-    priority?: string;
-    blocking?: string[];
-    review_required?: boolean;
     provider_target?: string;
     agent_role?: string;
-    timeout_policy?: string;
-    tokens_remaining?: number | null;
-    last_event?: string;
-    last_event_at?: string;
     branch: string;
     head_sha: string;
     worktree?: string;
@@ -181,12 +170,6 @@ export interface DesktopExplainPayload {
     summary: string;
     reasons: string[];
     next_action: string;
-    current_state?: {
-      state?: string;
-      task_state?: string;
-      review_state?: string;
-      last_event?: string;
-    };
   };
   evidence_digest: {
     next_action: string;
@@ -194,57 +177,6 @@ export interface DesktopExplainPayload {
     changed_files: string[];
     verification_outcome?: string;
     security_blocked?: string;
-  };
-  review_state?: {
-    status?: string;
-  };
-  consultation_summary?: {
-    kind?: string;
-    recommendation?: string;
-    next_test?: string;
-  } | null;
-  action_items?: Array<{
-    kind?: string;
-    message?: string;
-    event?: string;
-    timestamp?: string;
-    source?: string;
-  }>;
-  verification_contract?: {
-    mode?: string;
-    required?: boolean;
-    checks?: string[];
-    commands?: string[];
-  } | null;
-  verification_result?: {
-    outcome?: string;
-    summary?: string;
-    next_action?: string;
-    failed_checks?: string[];
-    passed_checks?: string[];
-  } | null;
-  security_policy?: {
-    mode?: string;
-    stage?: string;
-    task?: string;
-    allow?: string[];
-    block?: string[];
-  } | null;
-  security_verdict?: {
-    verdict?: string;
-    reason?: string;
-    next_action?: string;
-    advisory_mode?: boolean;
-    stage?: string;
-    allow?: string[];
-    block?: string[];
-  } | null;
-  run_packet?: {
-    provider_target?: string;
-  };
-  result_packet?: {
-    summary?: string;
-    next_action_hint?: string;
   };
   recent_events: Array<{
     timestamp: string;

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -7,7 +7,6 @@ import {
   getDesktopSummarySnapshot,
   subscribeToDesktopSummaryRefresh,
   type DesktopEditorFilePayload,
-  type DesktopDigestItem,
   type DesktopExplainPayload,
   type DesktopRunProjection,
   type DesktopSummarySnapshot,
@@ -384,14 +383,7 @@ function getAvailableRunIds(snapshot: DesktopSummarySnapshot | null = desktopSum
     return [] as string[];
   }
 
-  const runIds = new Set<string>();
-  for (const item of snapshot.digest.items) {
-    runIds.add(item.run_id);
-  }
-  for (const projection of snapshot.run_projections) {
-    runIds.add(projection.run_id);
-  }
-  return Array.from(runIds);
+  return snapshot.run_projections.map((projection) => projection.run_id);
 }
 
 function resolveSelectedRunId(snapshot: DesktopSummarySnapshot | null = desktopSummarySnapshot, preferredRunId?: string | null) {
@@ -416,6 +408,11 @@ function getRunProjectionByRunId(runId: string | null) {
     return null;
   }
   return getRunProjections().find((projection) => projection.run_id === runId) ?? null;
+}
+
+function getPrimaryRunProjection() {
+  const resolvedRunId = resolveSelectedRunId();
+  return getRunProjectionByRunId(resolvedRunId) ?? getRunProjections()[0] ?? null;
 }
 
 function setSelectedRun(runId: string | null) {
@@ -760,45 +757,6 @@ function getSourceFilterLabel(filter: SourceFilter) {
   }
 }
 
-function getPrimaryDigestItem() {
-  if (desktopSummarySnapshot?.digest.items?.length) {
-    const resolvedRunId = resolveSelectedRunId();
-    if (resolvedRunId) {
-      const selectedDigestItem = desktopSummarySnapshot.digest.items.find((item) => item.run_id === resolvedRunId);
-      if (selectedDigestItem) {
-        return selectedDigestItem;
-      }
-    }
-
-    return desktopSummarySnapshot.digest.items[0];
-  }
-
-  const resolvedRunId = resolveSelectedRunId();
-  const projection =
-    getRunProjectionByRunId(resolvedRunId) ??
-    getRunProjections()[0];
-  if (!projection) {
-    return null;
-  }
-
-  return {
-    run_id: projection.run_id,
-    task: projection.task,
-    label: projection.label,
-    pane_id: projection.pane_id,
-    role: "",
-    task_state: projection.task_state,
-    review_state: projection.review_state,
-    next_action: projection.next_action,
-    branch: projection.branch,
-    head_short: "",
-    changed_file_count: projection.changed_files.length,
-    changed_files: projection.changed_files,
-    verification_outcome: projection.verification_outcome,
-    security_blocked: projection.security_blocked,
-  } satisfies DesktopDigestItem;
-}
-
 function getSelectedRunId() {
   return resolveSelectedRunId();
 }
@@ -813,16 +771,16 @@ function renderContextPanel() {
 
   const visibleChanges = getVisibleSourceChanges();
   const primaryChange = getPrimarySourceChange(visibleChanges);
-  const selectedDigestItem = getPrimaryDigestItem();
+  const selectedProjection = getPrimaryRunProjection();
 
   sectionRoot.innerHTML = "";
   const resolvedContextSections = [
-    { label: "next", value: selectedDigestItem?.next_action || "Open Explain" },
-    { label: "run", value: selectedDigestItem?.run_id || primaryChange?.run || "No active run" },
+    { label: "next", value: selectedProjection?.next_action || "Open Explain" },
+    { label: "run", value: selectedProjection?.run_id || primaryChange?.run || "No active run" },
     { label: "pane", value: primaryChange?.paneLabel ?? "No pane label" },
-    { label: "branch", value: primaryChange?.branch ?? "No branch" },
-    { label: "worktree", value: primaryChange?.worktree || "Project root" },
-    { label: "review", value: primaryChange?.review ?? "No review state" },
+    { label: "branch", value: selectedProjection?.branch || primaryChange?.branch || "No branch" },
+    { label: "worktree", value: selectedProjection?.worktree || primaryChange?.worktree || "Project root" },
+    { label: "review", value: selectedProjection?.review_state || primaryChange?.review || "No review state" },
   ];
   for (const item of resolvedContextSections) {
     const row = document.createElement("div");
@@ -888,7 +846,7 @@ function getFooterItems(): { left: FooterStatusItem[]; right: FooterStatusItem[]
   const inboxStatus = desktopSummarySnapshot
     ? `${desktopSummarySnapshot.inbox.summary.item_count} inbox`
     : "config.toml";
-  const branchStatus = getPrimaryDigestItem()?.branch || "main";
+  const branchStatus = getPrimaryRunProjection()?.branch || "main";
 
   return {
     left: [
@@ -1199,39 +1157,39 @@ function renderRunSummary() {
     return;
   }
 
-  const digestItem = getPrimaryDigestItem();
-  if (digestItem) {
+  const projection = getPrimaryRunProjection();
+  if (projection) {
     const statusTone =
-      digestItem.review_state === "PASS"
+      projection.review_state === "PASS"
         ? "success"
-        : digestItem.review_state === "PENDING"
+        : projection.review_state === "PENDING"
           ? "warning"
-          : digestItem.review_state === "FAIL" || digestItem.review_state === "FAILED"
+          : projection.review_state === "FAIL" || projection.review_state === "FAILED"
             ? "danger"
             : "info";
-    const verification = digestItem.verification_outcome ? `verify ${digestItem.verification_outcome}` : "verify n/a";
-    const security = digestItem.security_blocked ? `security ${digestItem.security_blocked}` : "security n/a";
+    const verification = projection.verification_outcome ? `verify ${projection.verification_outcome}` : "verify n/a";
+    const security = projection.security_blocked ? `security ${projection.security_blocked}` : "security n/a";
 
     root.innerHTML = `
       <div class="run-summary-card">
         <div class="run-summary-header">
           <div>
             <div class="timeline-eyebrow">Selected run</div>
-            <div class="run-summary-title">${digestItem.run_id}</div>
+            <div class="run-summary-title">${projection.run_id}</div>
           </div>
           <div class="run-summary-status" data-tone="${statusTone}">
-            ${digestItem.review_state || "ready"}
+            ${projection.review_state || "ready"}
           </div>
         </div>
         <div class="run-summary-meta-row">
-          <span class="run-summary-pill">${digestItem.label || digestItem.pane_id || "summary-stream"}</span>
-          <span class="run-summary-pill">${digestItem.branch || "no branch"}</span>
-          <span class="run-summary-pill">${digestItem.changed_file_count} changed</span>
-          <span class="run-summary-pill">${digestItem.next_action || "no next action"}</span>
+          <span class="run-summary-pill">${projection.label || projection.pane_id || "summary-stream"}</span>
+          <span class="run-summary-pill">${projection.branch || "no branch"}</span>
+          <span class="run-summary-pill">${projection.changed_files.length} changed</span>
+          <span class="run-summary-pill">${projection.next_action || "no next action"}</span>
           <span class="run-summary-pill">${verification}</span>
           <span class="run-summary-pill">${security}</span>
         </div>
-        <div class="run-summary-body">${digestItem.task || "Summary-stream run surfaced by the backend adapter."}</div>
+        <div class="run-summary-body">${projection.summary || projection.task || "Projected run surfaced by the backend adapter."}</div>
         <div class="timeline-chip-row">
           <button type="button" class="timeline-chip" data-action="open-explain">Open Explain</button>
           <button type="button" class="timeline-chip" data-action="open-source-context">Source Context</button>
@@ -1453,26 +1411,26 @@ async function openExplainForSelectedRun() {
 function appendFallbackExplain() {
   const timestamp = new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", hour12: false });
   const selectedRunId = getSelectedRunId();
-  const digestItem = getPrimaryDigestItem();
-  const hasSelectedDigest = Boolean(selectedRunId && digestItem?.run_id === selectedRunId);
-  const digestRunCount = desktopSummarySnapshot?.digest.summary.item_count ?? 0;
+  const projection = getPrimaryRunProjection();
+  const hasSelectedProjection = Boolean(selectedRunId && projection?.run_id === selectedRunId);
+  const runCount = getRunProjections().length;
   const inboxCount = desktopSummarySnapshot?.inbox.summary.item_count ?? 0;
-  const body = hasSelectedDigest
-    ? `Digest fallback for ${selectedRunId}.`
-    : desktopSummarySnapshot && digestRunCount > 0
-      ? "Digest fallback without a selected run."
+  const body = hasSelectedProjection
+    ? `Explain unavailable for ${selectedRunId}.`
+    : desktopSummarySnapshot && runCount > 0
+      ? "Explain unavailable without a selected run."
       : desktopSummarySnapshot
-        ? "Digest fallback without projected runs."
+        ? "Explain unavailable without projected runs."
         : "Backend summary unavailable.";
-  const details = hasSelectedDigest
+  const details = hasSelectedProjection
     ? [
         { label: "run", value: selectedRunId as string },
-        { label: "next", value: digestItem?.next_action || "idle" },
-        { label: "changed", value: `${digestItem?.changed_file_count ?? 0}` },
+        { label: "next", value: projection?.next_action || "idle" },
+        { label: "changed", value: `${projection?.changed_files.length ?? 0}` },
       ]
     : desktopSummarySnapshot
       ? [
-          { label: "runs", value: `${digestRunCount}` },
+          { label: "runs", value: `${runCount}` },
           { label: "inbox", value: `${inboxCount}` },
         ]
       : [{ label: "state", value: "backend unavailable" }];
@@ -1876,18 +1834,12 @@ function getExplainPayloadFingerprint(payload: DesktopExplainPayload | null | un
     payload.run.changed_files.join("|"),
     payload.explanation.summary,
     payload.explanation.next_action,
-    payload.explanation.current_state?.state,
-    payload.explanation.current_state?.task_state,
-    payload.explanation.current_state?.review_state,
-    payload.explanation.current_state?.last_event,
     payload.explanation.reasons.join("|"),
     payload.evidence_digest.next_action,
     payload.evidence_digest.verification_outcome,
     payload.evidence_digest.security_blocked,
     payload.evidence_digest.changed_files.join("|"),
-    payload.review_state?.status,
-    payload.result_packet?.summary,
-    payload.result_packet?.next_action_hint,
+    payload.recent_events.map((item) => `${item.event}:${item.message}`).join("|"),
   ]);
 }
 
@@ -2428,7 +2380,7 @@ function buildDesktopSummaryConversation(snapshot: DesktopSummarySnapshot): Conv
 }
 
 function pruneExplainCache(snapshot: DesktopSummarySnapshot, preservedRunId?: string | null) {
-  const activeRunIds = new Set(snapshot.digest.items.map((item) => item.run_id));
+  const activeRunIds = new Set(snapshot.run_projections.map((projection) => projection.run_id));
   if (preservedRunId) {
     activeRunIds.add(preservedRunId);
   }


### PR DESCRIPTION
## Summary
- switch selected-run desktop surfaces from synthesized digest fallback to run projections
- normalize desktop explain payloads into a typed desktop DTO before they reach Tauri
- fix `runId` / `run_id` JSON-RPC alias resolution for desktop explain requests

## Validation
- cargo test --manifest-path winsmux-app/src-tauri/Cargo.toml
- cmd /c npm run build
- cmd /c npm run test:editor-targets
- pwsh -NoProfile -File .\scripts\git-guard.ps1 -Mode full
- pwsh -NoProfile -File .\scripts\audit-public-surface.ps1

## Task
- TASK-291
