### PR TITLE
fix: harden prompt transport stable-core contract

### DIFF
--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -496,6 +496,10 @@ function New-SendDispatchPointerText {
     return "Read the full prompt from '$promptRef' and follow it exactly. This pointer was sent because the original prompt exceeded the send buffer."
 }
 
+function Get-SupportedPromptTransportValues {
+    return @('argv', 'file')
+}
+
 function Resolve-SupportedPromptTransport {
     param([AllowEmptyString()][string]$PromptTransport = 'argv')
 
@@ -505,8 +509,10 @@ function Resolve-SupportedPromptTransport {
         $PromptTransport.Trim().ToLowerInvariant()
     }
 
-    if ($resolved -notin @('argv', 'file')) {
-        throw "Unsupported prompt_transport setting: $PromptTransport"
+    $supportedValues = @(Get-SupportedPromptTransportValues)
+    if ($resolved -notin $supportedValues) {
+        $supportedText = $supportedValues -join ', '
+        throw "Unsupported prompt_transport setting: $PromptTransport. Supported values: $supportedText. stdin is not implemented for pane dispatch."
     }
 
     return $resolved

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -6888,6 +6888,13 @@ Describe 'winsmux send dispatch payload' {
         (Get-Content -LiteralPath $payload['PromptPath'] -Raw -Encoding UTF8).TrimEnd("`r", "`n") | Should -BeExactly 'Write-Host short'
     }
 
+    It 'normalizes blank prompt_transport to argv' {
+        $payload = Resolve-SendDispatchPayload -Text 'Write-Host short' -ProjectDir $script:sendTempRoot -LengthLimit 4000 -PromptTransport '   '
+
+        $payload['PromptTransport'] | Should -Be 'argv'
+        $payload['IsFileBacked'] | Should -Be $false
+    }
+
     It 'normalizes task prompt slugs and writes a stable task prompt file when task_slug is supplied' {
         (ConvertTo-TaskPromptSlug -TaskSlug ' Cache Drift / Build ') | Should -Be 'cache-drift-build'
 
@@ -6910,8 +6917,8 @@ Describe 'winsmux send dispatch payload' {
         (Get-Content -LiteralPath $second['PromptPath'] -Raw -Encoding UTF8).TrimEnd("`r", "`n") | Should -BeExactly 'second prompt'
     }
 
-    It 'rejects unsupported prompt transport values' {
-        { Resolve-SendDispatchPayload -Text 'Write-Host short' -ProjectDir $script:sendTempRoot -LengthLimit 4000 -PromptTransport 'stdin' } | Should -Throw '*prompt_transport*'
+    It 'rejects unsupported prompt transport values with the stable-core contract in the error' {
+        { Resolve-SendDispatchPayload -Text 'Write-Host short' -ProjectDir $script:sendTempRoot -LengthLimit 4000 -PromptTransport 'stdin' } | Should -Throw '*Supported values: argv, file*'
     }
 
     It 'blocks send text when a blocklist security policy pattern matches' {

--- a/winsmux-core/agents/AGENTS.md
+++ b/winsmux-core/agents/AGENTS.md
@@ -50,5 +50,6 @@ printf '%s\n' "Implement TASK-140" | WORKTREE=/path/to/worktree ./builder.sh
 ## Notes
 
 - `WORKTREE` is required for all three roles. Dispatchers must provide a trusted, single-line workspace path.
+- This stdin support belongs to the shell wrappers in this directory. It is separate from the repository-level `.winsmux.yaml` `prompt_transport` setting, whose stable pane-dispatch contract currently supports only `argv` and `file`.
 - These scripts generate prompts only. They do not dispatch panes on their own.
 - `builder.sh` attempts to source `winsmux-core/scripts/builder-queue.ps1` through `pwsh` to stay aligned with the current Builder queue prompt. If that is not available, it falls back to an embedded prompt with the same structure.


### PR DESCRIPTION
## Summary
- harden the stable prompt transport contract around argv/file only
- make unsupported transport errors explicit about the current stable core
- clarify that shell-wrapper stdin support is separate from repo-level pane dispatch

## Validation
- `pwsh -NoProfile -Command "Invoke-Pester tests/winsmux-bridge.Tests.ps1 -CI -Output Detailed"`
- `pwsh -NoProfile -Command "Invoke-Pester tests/HarnessContract.Tests.ps1 -CI -Output Detailed"`
- `pwsh -NoProfile -File .\scripts\git-guard.ps1 -Mode full`
- `pwsh -NoProfile -File .\scripts\audit-public-surface.ps1`

## Notes
- stdin parity is still not implemented for pane dispatch; this slice makes the fail-closed contract explicit instead of widening the runtime boundary.