### PR TITLE
fix: tighten operator dispatch reporting contract

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -26,7 +26,7 @@ Claude Code is the side that:
 - decomposes user work into pane-executable tasks
 - dispatches work to managed panes
 - collects results and evidence
-- decides review outcomes
+- decides whether to request, accept, or reject review outcomes returned by review-capable slots
 - controls priority and sequencing
 - maintains shared context between panes
 - reports progress and blockers back to the user
@@ -34,6 +34,12 @@ Claude Code is the side that:
 
 The operator is responsible for coordination and judgement.
 The panes are responsible for execution.
+
+## User-facing reporting
+
+In user-facing progress updates, status summaries, and blocker reports, use the term
+**operator**. `Commander` remains an internal runtime/gate role label and must not be
+treated as the preferred user-facing name.
 
 ## Authority boundary
 
@@ -78,6 +84,8 @@ Direct operator-side mutation is **outside the standard winsmux operating model*
 3. Do not bypass pane boundaries for convenience.
 4. Do not let panes talk directly to the user.
 5. Do not treat a dedicated `reviewer` pane as mandatory; review belongs to any review-capable slot.
+6. Do not perform operator-side code review judgements. The operator may run required validation
+   commands, but PASS/FAIL review decisions must come from a review-capable slot.
 
 ## Orchestra restoration gate
 
@@ -97,11 +105,17 @@ When `/winsmux-start` or another restoration flow reports `needs-startup`:
 12. If hook validation noise, schema warnings, or an `Interrupted` result prevents a clean `winsmux orchestra-smoke --json` result from being obtained, stop fail-closed and treat the session as `blocked` until the startup contract is re-run cleanly.
 13. When `.claude/local/operator-handoff.md` contains an ordered `Next actions` list, start the first pending action automatically instead of asking which task to begin.
 14. Once `operator_contract.can_dispatch=true`, do not use Explore subagents for PR/task analysis. Dispatch the task through `winsmux dispatch-task "<task text>"` or `winsmux dispatch-review`.
-15. Startup/status Explore subagents are allowed only while diagnosing orchestra readiness or attach problems.
-16. Do not probe with legacy commands such as `psmux --version` or `Get-Process psmux-server`.
-17. Do not tell the user to manually start a `psmux` server.
-18. If startup still fails, report `blocked` and stop fail-closed with the smoke result.
-19. Do not continue with PR/merge or local exploration while orchestra is still not dispatchable.
+15. Do not report that review was dispatched until formal review evidence is observed. Require
+    the dispatch command to succeed and at least one review confirmation signal such as
+    `commander.review_requested`, `review_state=PENDING`, or target-pane capture showing the
+    request.
+16. If review confirmation is missing, report `review dispatch blocked` or `review dispatch unconfirmed`
+    instead of claiming that review is in progress.
+17. Startup/status Explore subagents are allowed only while diagnosing orchestra readiness or attach problems.
+18. Do not probe with legacy commands such as `psmux --version` or `Get-Process psmux-server`.
+19. Do not tell the user to manually start a `psmux` server.
+20. If startup still fails, report `blocked` and stop fail-closed with the smoke result.
+21. Do not continue with PR/merge or local exploration while orchestra is still not dispatchable.
 
 ## Compatibility and release notes
 

--- a/.claude/rules/dispatch.md
+++ b/.claude/rules/dispatch.md
@@ -2,7 +2,9 @@
 paths: ["winsmux-core/scripts/**", ".claude/**"]
 ---
 
-# Commander Dispatch Procedure
+# Operator Dispatch Procedure
+
+User-facing progress updates must use **operator**. `Commander` is an internal role/gate term only.
 
 ## Orchestra restore preflight
 1. If restoration state is `needs-startup`, do not triage PRs, plan merges, read backlog, or dispatch work yet.
@@ -33,17 +35,24 @@ paths: ["winsmux-core/scripts/**", ".claude/**"]
 3. Send: `winsmux send -t <pane> "Read .builder-prompt.txt and implement"` + Enter via `pwsh -NoProfile -File scripts/winsmux-core.ps1 keys <pane> Enter`
 4. Monitor: `winsmux capture-pane -t <pane> -p | tail -15`
 5. Verify: `git -C <worktree> diff --stat HEAD`
-6. **Commander runs tests** (Builder cannot — CLM #319): `NO_COLOR=1 pwsh -Command "Invoke-Pester <worktree>/tests/ -Output Minimal"`
+6. **Operator runs tests** when the flow requires it (Builder cannot — CLM #319): `NO_COLOR=1 pwsh -Command "Invoke-Pester <worktree>/tests/ -Output Minimal"`
+7. Running tests is allowed; operator-side code review judgement is not. PASS/FAIL review decisions must come from a review-capable slot.
 
 ## Reviewer Dispatch
-1. Send review request: `winsmux send -t reviewer-1 "Review diffs in .worktrees/builder-N"` + Enter
-2. Wait for PASS/FAIL in capture output
-3. On PASS: proceed to commit. On FAIL: re-dispatch fix to Builder
+1. Use `pwsh -NoProfile -File scripts/winsmux-core.ps1 dispatch-review "<task text>"` when the next action is to request a formal review-state transition from a review-capable slot.
+2. Do not perform local diff review as operator. The operator may inspect dispatch evidence and test output only.
+3. Before reporting that review was dispatched, require command success and at least one confirmation signal:
+   - `commander.review_requested`
+   - `review_state=PENDING`
+   - target pane capture showing the review request
+4. If confirmation is missing, report `review dispatch blocked` or `review dispatch unconfirmed` instead of saying that review is in progress.
+5. On PASS: proceed to commit. On FAIL: re-dispatch fix to Builder.
 
 ## Standard Dispatch
 1. Use `pwsh -NoProfile -File scripts/winsmux-core.ps1 dispatch-task "<task text>"` as the default operator-to-pane dispatch path.
 2. Use `dispatch-review` only when the next action is to request a formal review-state transition.
 3. Verify the chosen pane with `winsmux capture-pane -t <pane_id> -p | tail -15` before reporting that work was dispatched.
+4. In user-facing progress messages, say `operator` rather than `Commander`.
 
 ## Post-Review Commit
 1. Verify `review-state.json` has PASS

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -7259,6 +7259,7 @@ Describe 'operator startup restore contract docs' {
 
     It 'requires orchestra-smoke operator_contract instead of legacy psmux probes' {
         $script:claudeGuideContent | Should -Match 'winsmux orchestra-smoke --json'
+        $script:claudeGuideContent | Should -Match 'use the term\s+\*\*operator\*\*'
         $script:claudeGuideContent | Should -Match 'needs-startup'
         $script:claudeGuideContent | Should -Match 'orchestra-start\.ps1'
         $script:claudeGuideContent | Should -Match 'operator_contract\.operator_state'
@@ -7275,9 +7276,14 @@ Describe 'operator startup restore contract docs' {
         $script:claudeGuideContent | Should -Match 'prevents a clean `winsmux orchestra-smoke --json` result from being obtained'
         $script:claudeGuideContent | Should -Match 'start the first pending action automatically instead of asking which task to begin'
         $script:claudeGuideContent | Should -Match 'do not use Explore subagents for PR/task analysis'
+        $script:claudeGuideContent | Should -Match 'Do not perform operator-side code review judgements'
+        $script:claudeGuideContent | Should -Match 'Do not report that review was dispatched until formal review evidence is observed'
+        $script:claudeGuideContent | Should -Match 'review dispatch blocked'
         $script:claudeGuideContent | Should -Match 'psmux --version'
         $script:claudeGuideContent | Should -Match 'Get-Process psmux-server'
         $script:claudeGuideContent | Should -Match 'manually start a `psmux` server'
+        $script:dispatchRuleContent | Should -Match '# Operator Dispatch Procedure'
+        $script:dispatchRuleContent | Should -Match 'User-facing progress updates must use \*\*operator\*\*'
         $script:dispatchRuleContent | Should -Match 'scripts/winsmux-core\.ps1 orchestra-smoke --json'
         $script:dispatchRuleContent | Should -Match 'scripts/winsmux-core\.ps1 orchestra-attach --json'
         $script:dispatchRuleContent | Should -Match 'scripts/winsmux-core\.ps1 dispatch-task'
@@ -7296,6 +7302,10 @@ Describe 'operator startup restore contract docs' {
         $script:dispatchRuleContent | Should -Match 'prevents a clean `orchestra-smoke --json` result from being obtained'
         $script:dispatchRuleContent | Should -Match 'Never ask the user which task to begin'
         $script:dispatchRuleContent | Should -Match 'Explore subagents are reserved for orchestra startup/status diagnosis only'
+        $script:dispatchRuleContent | Should -Match 'Operator runs tests'
+        $script:dispatchRuleContent | Should -Match 'operator-side code review judgement is not'
+        $script:dispatchRuleContent | Should -Match 'Before reporting that review was dispatched'
+        $script:dispatchRuleContent | Should -Match 'review dispatch blocked'
         $script:dispatchRuleContent | Should -Match 'psmux --version'
         $script:dispatchRuleContent | Should -Match 'Get-Process psmux-server'
     }


### PR DESCRIPTION
## Summary
- tighten the external operator runtime contract so user-facing progress uses `operator`
- forbid operator-side code review judgement while still allowing operator-run validation commands
- require review dispatch confirmation evidence before reporting that review is in progress

## Testing
- `pwsh -NoProfile -Command "Invoke-Pester tests/winsmux-bridge.Tests.ps1 -CI -Output Detailed"`
- `pwsh -NoProfile -File .\scripts\git-guard.ps1 -Mode full`
- `pwsh -NoProfile -File .\scripts\audit-public-surface.ps1`

## Related
- Reopened #280
