### PR TITLE
test: freeze bridge golden corpus fixtures

### DIFF
--- a/.githooks/pre-commit-whitelist.ps1
+++ b/.githooks/pre-commit-whitelist.ps1
@@ -29,6 +29,7 @@ $whitelistPatterns = @(
     '.githooks/**',
     'tests/PublicSurfacePolicy.Tests.ps1',
     'tests/HarnessContract.Tests.ps1',
+    'tests/fixtures/rust-parity/*.json',
     'winsmux-core/**',
     '.claude/CLAUDE.md',
     '.claude/hooks/**',

--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,10 @@ tests/*
 !tests/PublicSurfacePolicy.Tests.ps1
 !tests/HarnessContract.Tests.ps1
 !tests/README.md
+!tests/fixtures/
+tests/fixtures/*
+!tests/fixtures/rust-parity/
+!tests/fixtures/rust-parity/*.json
 /hooks/
 .worktrees/
 INTERNAL*.md

--- a/tests/fixtures/rust-parity/board.json
+++ b/tests/fixtures/rust-parity/board.json
@@ -1,0 +1,101 @@
+{
+  "generated_at": "__GENERATED_AT__",
+  "project_dir": "__PROJECT_DIR__",
+  "summary": {
+    "pane_count": 2,
+    "dirty_panes": 1,
+    "review_pending": 1,
+    "review_failed": 0,
+    "review_passed": 0,
+    "tasks_in_progress": 1,
+    "tasks_blocked": 0,
+    "by_state": {
+      "idle": 1,
+      "busy": 1
+    },
+    "by_review": {
+      "PENDING": 1,
+      "unknown": 1
+    },
+    "by_task_state": {
+      "in_progress": 1,
+      "backlog": 1
+    }
+  },
+  "panes": [
+    {
+      "label": "builder-1",
+      "role": "Builder",
+      "pane_id": "%2",
+      "state": "idle",
+      "tokens_remaining": "64% context left",
+      "task_id": "task-244",
+      "task": "Implement session board",
+      "task_state": "in_progress",
+      "task_owner": "builder-1",
+      "review_state": "PENDING",
+      "branch": "worktree-builder-1",
+      "worktree": ".worktrees/builder-1",
+      "head_sha": "abc1234def5678",
+      "changed_file_count": 2,
+      "changed_files": [
+        "scripts/winsmux-core.ps1",
+        "tests/winsmux-bridge.Tests.ps1"
+      ],
+      "last_event": "pane.ready",
+      "last_event_at": "2026-04-10T10:00:00+09:00",
+      "parent_run_id": "",
+      "goal": "",
+      "task_type": "",
+      "priority": "",
+      "blocking": false,
+      "write_scope": [],
+      "read_scope": [],
+      "constraints": [],
+      "expected_output": "",
+      "verification_plan": [],
+      "review_required": false,
+      "provider_target": "",
+      "agent_role": "",
+      "timeout_policy": "",
+      "handoff_refs": [],
+      "security_policy": null
+    },
+    {
+      "label": "worker-1",
+      "role": "Worker",
+      "pane_id": "%6",
+      "state": "busy",
+      "tokens_remaining": "52% context left",
+      "task_id": "",
+      "task": "",
+      "task_state": "backlog",
+      "task_owner": "",
+      "review_state": "",
+      "branch": "",
+      "worktree": "",
+      "head_sha": "",
+      "changed_file_count": 0,
+      "changed_files": [],
+      "last_event": "pane.idle",
+      "last_event_at": "2026-04-10T10:05:00+09:00",
+      "parent_run_id": "",
+      "goal": "",
+      "task_type": "",
+      "priority": "",
+      "blocking": false,
+      "write_scope": [],
+      "read_scope": [],
+      "constraints": [],
+      "expected_output": "",
+      "verification_plan": [],
+      "review_required": false,
+      "provider_target": "",
+      "agent_role": "",
+      "timeout_policy": "",
+      "handoff_refs": [],
+      "security_policy": null
+    }
+  ]
+}
+

--- a/tests/fixtures/rust-parity/board.json
+++ b/tests/fixtures/rust-parity/board.json
@@ -43,7 +43,7 @@
         "tests/winsmux-bridge.Tests.ps1"
       ],
       "last_event": "pane.ready",
-      "last_event_at": "2026-04-10T10:00:00+09:00",
+      "last_event_at": "__LAST_EVENT_AT__",
       "parent_run_id": "",
       "goal": "",
       "task_type": "",
@@ -78,7 +78,7 @@
       "changed_file_count": 0,
       "changed_files": [],
       "last_event": "pane.idle",
-      "last_event_at": "2026-04-10T10:05:00+09:00",
+      "last_event_at": "__LAST_EVENT_AT__",
       "parent_run_id": "",
       "goal": "",
       "task_type": "",

--- a/tests/fixtures/rust-parity/digest.json
+++ b/tests/fixtures/rust-parity/digest.json
@@ -1,0 +1,43 @@
+{
+  "generated_at": "__GENERATED_AT__",
+  "project_dir": "__PROJECT_DIR__",
+  "summary": {
+    "item_count": 1,
+    "dirty_items": 1,
+    "review_pending": 0,
+    "review_failed": 1,
+    "actionable_items": 1
+  },
+  "items": [
+    {
+      "run_id": "task:task-246",
+      "task_id": "task-246",
+      "task": "Build evidence digest",
+      "label": "builder-1",
+      "pane_id": "%2",
+      "role": "Builder",
+      "provider_target": "",
+      "task_state": "blocked",
+      "review_state": "FAIL",
+      "next_action": "review_failed",
+      "branch": "worktree-builder-1",
+      "worktree": ".worktrees/builder-1",
+      "head_sha": "abc1234def5678",
+      "head_short": "abc1234",
+      "changed_file_count": 1,
+      "changed_files": [
+        "scripts/winsmux-core.ps1"
+      ],
+      "action_item_count": 3,
+      "last_event": "commander.review_failed",
+      "last_event_at": "2026-04-10T14:00:00+09:00",
+      "verification_outcome": "",
+      "security_blocked": "",
+      "hypothesis": "result summary should appear in digest",
+      "confidence": 0.88,
+      "observation_pack_ref": ".winsmux/observation-packs/observation-pack-__ID__.json",
+      "consultation_ref": ".winsmux/consultations/consult-result-__ID__.json"
+    }
+  ]
+}
+

--- a/tests/fixtures/rust-parity/digest.json
+++ b/tests/fixtures/rust-parity/digest.json
@@ -30,7 +30,7 @@
       ],
       "action_item_count": 3,
       "last_event": "commander.review_failed",
-      "last_event_at": "2026-04-10T14:00:00+09:00",
+      "last_event_at": "__LAST_EVENT_AT__",
       "verification_outcome": "",
       "security_blocked": "",
       "hypothesis": "result summary should appear in digest",

--- a/tests/fixtures/rust-parity/explain.json
+++ b/tests/fixtures/rust-parity/explain.json
@@ -1,0 +1,652 @@
+{
+  "generated_at": "__GENERATED_AT__",
+  "project_dir": "__PROJECT_DIR__",
+  "run": {
+    "run_id": "task:task-256",
+    "task_id": "task-256",
+    "task": "Implement run ledger",
+    "task_state": "in_progress",
+    "review_state": "PENDING",
+    "branch": "worktree-builder-1",
+    "worktree": ".worktrees/builder-1",
+    "head_sha": "abc1234def5678",
+    "primary_label": "builder-1",
+    "primary_pane_id": "%2",
+    "primary_role": "Builder",
+    "state": "idle",
+    "tokens_remaining": "64% context left",
+    "last_event": "commander.review_requested",
+    "last_event_at": "2026-04-10T12:00:00+09:00",
+    "pane_count": 1,
+    "changed_file_count": 1,
+    "labels": [
+      "builder-1"
+    ],
+    "pane_ids": [
+      "%2"
+    ],
+    "roles": [
+      "Builder"
+    ],
+    "changed_files": [
+      "scripts/winsmux-core.ps1"
+    ],
+    "action_items": [
+      {
+        "kind": "review_pending",
+        "message": "builder-1 が review 待機中。",
+        "event": "commander.review_requested",
+        "timestamp": "__TIMESTAMP__",
+        "source": "manifest"
+      },
+      {
+        "kind": "review_requested",
+        "message": "review requested",
+        "event": "commander.review_requested",
+        "timestamp": "__TIMESTAMP__",
+        "source": "events"
+      }
+    ],
+    "parent_run_id": "operator:session-1",
+    "goal": "Ship run contract primitives",
+    "task_type": "implementation",
+    "priority": "P0",
+    "blocking": true,
+    "write_scope": [
+      "scripts/winsmux-core.ps1",
+      "tests/winsmux-bridge.Tests.ps1"
+    ],
+    "read_scope": [
+      "winsmux-core/scripts/pane-status.ps1"
+    ],
+    "constraints": [
+      "preserve existing board schema"
+    ],
+    "expected_output": "Stable run_packet JSON",
+    "verification_plan": [
+      "Invoke-Pester tests/winsmux-bridge.Tests.ps1",
+      "verify explain --json contract"
+    ],
+    "review_required": true,
+    "provider_target": "codex:gpt-5.4",
+    "agent_role": "worker",
+    "timeout_policy": "standard",
+    "handoff_refs": [
+      "docs/handoff.md"
+    ],
+    "experiment_packet": {
+      "hypothesis": "",
+      "test_plan": [],
+      "result": "consult before work",
+      "confidence": 0.66,
+      "next_action": "approval_waiting",
+      "observation_pack_ref": ".winsmux/observation-packs/observation-pack-__ID__.json",
+      "consultation_ref": ".winsmux/consultations/consult-result-__ID__.json",
+      "run_id": "",
+      "slot": "slot-builder-1",
+      "branch": "worktree-builder-1",
+      "worktree": "",
+      "env_fingerprint": "",
+      "command_hash": ""
+    },
+    "security_policy": null,
+    "security_verdict": null,
+    "verification_contract": null,
+    "verification_result": null,
+    "run_packet": {
+      "run_id": "task:task-256",
+      "task_id": "task-256",
+      "parent_run_id": "operator:session-1",
+      "goal": "Ship run contract primitives",
+      "task": "Implement run ledger",
+      "task_type": "implementation",
+      "priority": "P0",
+      "blocking": true,
+      "write_scope": [
+        "scripts/winsmux-core.ps1",
+        "tests/winsmux-bridge.Tests.ps1"
+      ],
+      "read_scope": [
+        "winsmux-core/scripts/pane-status.ps1"
+      ],
+      "constraints": [
+        "preserve existing board schema"
+      ],
+      "expected_output": "Stable run_packet JSON",
+      "verification_plan": [
+        "Invoke-Pester tests/winsmux-bridge.Tests.ps1",
+        "verify explain --json contract"
+      ],
+      "review_required": true,
+      "provider_target": "codex:gpt-5.4",
+      "agent_role": "worker",
+      "timeout_policy": "standard",
+      "handoff_refs": [
+        "docs/handoff.md"
+      ],
+      "branch": "worktree-builder-1",
+      "head_sha": "abc1234def5678",
+      "primary_label": "builder-1",
+      "primary_pane_id": "%2",
+      "primary_role": "Builder",
+      "labels": [
+        "builder-1"
+      ],
+      "pane_ids": [
+        "%2"
+      ],
+      "roles": [
+        "Builder"
+      ],
+      "changed_files": [
+        "scripts/winsmux-core.ps1"
+      ],
+      "security_policy": null,
+      "security_verdict": null,
+      "verification_contract": null,
+      "verification_result": null,
+      "last_event": "commander.review_requested",
+      "last_event_at": "2026-04-10T12:00:00+09:00"
+    }
+  },
+  "run_packet": {
+    "run_id": "task:task-256",
+    "task_id": "task-256",
+    "parent_run_id": "operator:session-1",
+    "goal": "Ship run contract primitives",
+    "task": "Implement run ledger",
+    "task_type": "implementation",
+    "priority": "P0",
+    "blocking": true,
+    "write_scope": [
+      "scripts/winsmux-core.ps1",
+      "tests/winsmux-bridge.Tests.ps1"
+    ],
+    "read_scope": [
+      "winsmux-core/scripts/pane-status.ps1"
+    ],
+    "constraints": [
+      "preserve existing board schema"
+    ],
+    "expected_output": "Stable run_packet JSON",
+    "verification_plan": [
+      "Invoke-Pester tests/winsmux-bridge.Tests.ps1",
+      "verify explain --json contract"
+    ],
+    "review_required": true,
+    "provider_target": "codex:gpt-5.4",
+    "agent_role": "worker",
+    "timeout_policy": "standard",
+    "handoff_refs": [
+      "docs/handoff.md"
+    ],
+    "branch": "worktree-builder-1",
+    "head_sha": "abc1234def5678",
+    "primary_label": "builder-1",
+    "primary_pane_id": "%2",
+    "primary_role": "Builder",
+    "labels": [
+      "builder-1"
+    ],
+    "pane_ids": [
+      "%2"
+    ],
+    "roles": [
+      "Builder"
+    ],
+    "changed_files": [
+      "scripts/winsmux-core.ps1"
+    ],
+    "security_policy": null,
+    "security_verdict": null,
+    "verification_contract": null,
+    "verification_result": null,
+    "last_event": "commander.review_requested",
+    "last_event_at": "2026-04-10T12:00:00+09:00"
+  },
+  "experiment_packet": {
+    "hypothesis": "",
+    "test_plan": [],
+    "result": "consult before work",
+    "confidence": 0.66,
+    "next_action": "approval_waiting",
+    "observation_pack_ref": ".winsmux/observation-packs/observation-pack-__ID__.json",
+    "consultation_ref": ".winsmux/consultations/consult-result-__ID__.json",
+    "run_id": "",
+    "slot": "slot-builder-1",
+    "branch": "worktree-builder-1",
+    "worktree": "",
+    "env_fingerprint": "",
+    "command_hash": "",
+    "observation_pack": {
+      "run_id": "task:task-256",
+      "task_id": "task-256",
+      "pane_id": "%2",
+      "slot": "slot-builder-1",
+      "hypothesis": "experiment packet should flow into explain",
+      "test_plan": [
+        "collect matching events",
+        "normalize packet"
+      ],
+      "changed_files": [
+        "scripts/winsmux-core.ps1"
+      ],
+      "working_tree_summary": "1 file modified",
+      "failing_command": "Invoke-Pester tests/winsmux-bridge.Tests.ps1",
+      "env_fingerprint": "env:abc123",
+      "command_hash": "cmd:def456",
+      "packet_type": "observation_pack",
+      "generated_at": "__GENERATED_AT__"
+    },
+    "consultation_packet": {
+      "run_id": "task:task-256",
+      "task_id": "task-256",
+      "pane_id": "%2",
+      "slot": "slot-builder-1",
+      "kind": "consult_result",
+      "mode": "early",
+      "target_slot": "slot-review-1",
+      "confidence": 0.66,
+      "recommendation": "consult before work",
+      "next_test": "approval_waiting",
+      "risks": [
+        "needs reviewer confirmation"
+      ],
+      "packet_type": "consultation_packet",
+      "generated_at": "__GENERATED_AT__"
+    }
+  },
+  "observation_pack": {
+    "run_id": "task:task-256",
+    "task_id": "task-256",
+    "pane_id": "%2",
+    "slot": "slot-builder-1",
+    "hypothesis": "experiment packet should flow into explain",
+    "test_plan": [
+      "collect matching events",
+      "normalize packet"
+    ],
+    "changed_files": [
+      "scripts/winsmux-core.ps1"
+    ],
+    "working_tree_summary": "1 file modified",
+    "failing_command": "Invoke-Pester tests/winsmux-bridge.Tests.ps1",
+    "env_fingerprint": "env:abc123",
+    "command_hash": "cmd:def456",
+    "packet_type": "observation_pack",
+    "generated_at": "__GENERATED_AT__"
+  },
+  "consultation_packet": {
+    "run_id": "task:task-256",
+    "task_id": "task-256",
+    "pane_id": "%2",
+    "slot": "slot-builder-1",
+    "kind": "consult_result",
+    "mode": "early",
+    "target_slot": "slot-review-1",
+    "confidence": 0.66,
+    "recommendation": "consult before work",
+    "next_test": "approval_waiting",
+    "risks": [
+      "needs reviewer confirmation"
+    ],
+    "packet_type": "consultation_packet",
+    "generated_at": "__GENERATED_AT__"
+  },
+  "consultation_summary": {
+    "kind": "consult_result",
+    "mode": "early",
+    "target_slot": "slot-review-1",
+    "confidence": 0.66,
+    "next_test": "approval_waiting",
+    "risks": [
+      "needs reviewer confirmation"
+    ]
+  },
+  "evidence_digest": {
+    "run_id": "task:task-256",
+    "task_id": "task-256",
+    "task": "Implement run ledger",
+    "label": "builder-1",
+    "pane_id": "%2",
+    "role": "Builder",
+    "provider_target": "codex:gpt-5.4",
+    "task_state": "in_progress",
+    "review_state": "PENDING",
+    "next_action": "review_pending",
+    "branch": "worktree-builder-1",
+    "worktree": ".worktrees/builder-1",
+    "head_sha": "abc1234def5678",
+    "head_short": "abc1234",
+    "changed_file_count": 1,
+    "changed_files": [
+      "scripts/winsmux-core.ps1"
+    ],
+    "action_item_count": 2,
+    "last_event": "commander.review_requested",
+    "last_event_at": "2026-04-10T12:00:00+09:00",
+    "verification_outcome": "",
+    "security_blocked": "",
+    "hypothesis": "",
+    "confidence": 0.66,
+    "observation_pack_ref": ".winsmux/observation-packs/observation-pack-__ID__.json",
+    "consultation_ref": ".winsmux/consultations/consult-result-__ID__.json"
+  },
+  "explanation": {
+    "summary": "Implement run ledger",
+    "reasons": [
+      "task_state=in_progress",
+      "review_state=PENDING",
+      "last_event=commander.review_requested",
+      "action:review_pending",
+      "action:review_requested"
+    ],
+    "next_action": "review_pending",
+    "current_state": {
+      "state": "idle",
+      "task_state": "in_progress",
+      "review_state": "PENDING",
+      "last_event": "commander.review_requested"
+    }
+  },
+  "review_state": null,
+  "recent_events": [
+    {
+      "line_number": 2,
+      "timestamp": "__TIMESTAMP__",
+      "event": "consult.result",
+      "status": "",
+      "message": "consult before work",
+      "label": "builder-1",
+      "pane_id": "%2",
+      "role": "Builder",
+      "task_id": "task-256",
+      "branch": "worktree-builder-1",
+      "head_sha": "abc1234def5678",
+      "source": "",
+      "hypothesis": "",
+      "test_plan": null,
+      "result": "consult before work",
+      "confidence": 0.66,
+      "next_action": "approval_waiting",
+      "observation_pack_ref": ".winsmux/observation-packs/observation-pack-__ID__.json",
+      "consultation_ref": ".winsmux/consultations/consult-result-__ID__.json",
+      "run_id": "",
+      "slot": "",
+      "worktree": "",
+      "env_fingerprint": "",
+      "command_hash": "",
+      "observation_pack": {
+        "run_id": "task:task-256",
+        "task_id": "task-256",
+        "pane_id": "%2",
+        "slot": "slot-builder-1",
+        "hypothesis": "experiment packet should flow into explain",
+        "test_plan": [
+          "collect matching events",
+          "normalize packet"
+        ],
+        "changed_files": [
+          "scripts/winsmux-core.ps1"
+        ],
+        "working_tree_summary": "1 file modified",
+        "failing_command": "Invoke-Pester tests/winsmux-bridge.Tests.ps1",
+        "env_fingerprint": "env:abc123",
+        "command_hash": "cmd:def456",
+        "packet_type": "observation_pack",
+        "generated_at": "__GENERATED_AT__"
+      },
+      "consultation_packet": {
+        "run_id": "task:task-256",
+        "task_id": "task-256",
+        "pane_id": "%2",
+        "slot": "slot-builder-1",
+        "kind": "consult_result",
+        "mode": "early",
+        "target_slot": "slot-review-1",
+        "confidence": 0.66,
+        "recommendation": "consult before work",
+        "next_test": "approval_waiting",
+        "risks": [
+          "needs reviewer confirmation"
+        ],
+        "packet_type": "consultation_packet",
+        "generated_at": "__GENERATED_AT__"
+      },
+      "verification_contract": null,
+      "verification_result": null,
+      "security_verdict": null
+    },
+    {
+      "line_number": 1,
+      "timestamp": "__TIMESTAMP__",
+      "event": "commander.review_requested",
+      "status": "",
+      "message": "review requested",
+      "label": "reviewer-1",
+      "pane_id": "%3",
+      "role": "Reviewer",
+      "task_id": "task-256",
+      "branch": "worktree-builder-1",
+      "head_sha": "abc1234def5678",
+      "source": "",
+      "hypothesis": "",
+      "test_plan": null,
+      "result": "",
+      "confidence": null,
+      "next_action": "",
+      "observation_pack_ref": "",
+      "consultation_ref": "",
+      "run_id": "",
+      "slot": "slot-builder-1",
+      "worktree": "",
+      "env_fingerprint": "",
+      "command_hash": "",
+      "observation_pack": null,
+      "consultation_packet": null,
+      "verification_contract": null,
+      "verification_result": null,
+      "security_verdict": null
+    }
+  ],
+  "result_packet": {
+    "run_id": "task:task-256",
+    "status": "in_progress",
+    "summary": "commander.review_requested",
+    "artifacts": [],
+    "changed_files": [
+      "scripts/winsmux-core.ps1"
+    ],
+    "head_sha": "abc1234def5678",
+    "branch": "worktree-builder-1",
+    "next_action_hint": "review_pending",
+    "review_recommendation": "PENDING",
+    "evidence_refs": [
+      "scripts/winsmux-core.ps1"
+    ],
+    "experiment_packet": {
+      "hypothesis": "",
+      "test_plan": [],
+      "result": "consult before work",
+      "confidence": 0.66,
+      "next_action": "approval_waiting",
+      "observation_pack_ref": ".winsmux/observation-packs/observation-pack-__ID__.json",
+      "consultation_ref": ".winsmux/consultations/consult-result-__ID__.json",
+      "run_id": "",
+      "slot": "slot-builder-1",
+      "branch": "worktree-builder-1",
+      "worktree": "",
+      "env_fingerprint": "",
+      "command_hash": ""
+    },
+    "observation_pack": {
+      "run_id": "task:task-256",
+      "task_id": "task-256",
+      "pane_id": "%2",
+      "slot": "slot-builder-1",
+      "hypothesis": "experiment packet should flow into explain",
+      "test_plan": [
+        "collect matching events",
+        "normalize packet"
+      ],
+      "changed_files": [
+        "scripts/winsmux-core.ps1"
+      ],
+      "working_tree_summary": "1 file modified",
+      "failing_command": "Invoke-Pester tests/winsmux-bridge.Tests.ps1",
+      "env_fingerprint": "env:abc123",
+      "command_hash": "cmd:def456",
+      "packet_type": "observation_pack",
+      "generated_at": "__GENERATED_AT__"
+    },
+    "consultation_packet": {
+      "run_id": "task:task-256",
+      "task_id": "task-256",
+      "pane_id": "%2",
+      "slot": "slot-builder-1",
+      "kind": "consult_result",
+      "mode": "early",
+      "target_slot": "slot-review-1",
+      "confidence": 0.66,
+      "recommendation": "consult before work",
+      "next_test": "approval_waiting",
+      "risks": [
+        "needs reviewer confirmation"
+      ],
+      "packet_type": "consultation_packet",
+      "generated_at": "__GENERATED_AT__"
+    },
+    "consultation_summary": {
+      "kind": "consult_result",
+      "mode": "early",
+      "target_slot": "slot-review-1",
+      "confidence": 0.66,
+      "next_test": "approval_waiting",
+      "risks": [
+        "needs reviewer confirmation"
+      ]
+    },
+    "action_items": [
+      {
+        "kind": "review_pending",
+        "message": "builder-1 が review 待機中。",
+        "event": "commander.review_requested",
+        "timestamp": "__TIMESTAMP__",
+        "source": "manifest"
+      },
+      {
+        "kind": "review_requested",
+        "message": "review requested",
+        "event": "commander.review_requested",
+        "timestamp": "__TIMESTAMP__",
+        "source": "events"
+      }
+    ],
+    "review_state": null,
+    "review_contract": null,
+    "verification_contract": null,
+    "verification_result": null,
+    "security_policy": null,
+    "security_verdict": null,
+    "recent_events": [
+      {
+        "line_number": 2,
+        "timestamp": "__TIMESTAMP__",
+        "event": "consult.result",
+        "status": "",
+        "message": "consult before work",
+        "label": "builder-1",
+        "pane_id": "%2",
+        "role": "Builder",
+        "task_id": "task-256",
+        "branch": "worktree-builder-1",
+        "head_sha": "abc1234def5678",
+        "source": "",
+        "hypothesis": "",
+        "test_plan": null,
+        "result": "consult before work",
+        "confidence": 0.66,
+        "next_action": "approval_waiting",
+        "observation_pack_ref": ".winsmux/observation-packs/observation-pack-__ID__.json",
+        "consultation_ref": ".winsmux/consultations/consult-result-__ID__.json",
+        "run_id": "",
+        "slot": "",
+        "worktree": "",
+        "env_fingerprint": "",
+        "command_hash": "",
+        "observation_pack": {
+          "run_id": "task:task-256",
+          "task_id": "task-256",
+          "pane_id": "%2",
+          "slot": "slot-builder-1",
+          "hypothesis": "experiment packet should flow into explain",
+          "test_plan": [
+            "collect matching events",
+            "normalize packet"
+          ],
+          "changed_files": [
+            "scripts/winsmux-core.ps1"
+          ],
+          "working_tree_summary": "1 file modified",
+          "failing_command": "Invoke-Pester tests/winsmux-bridge.Tests.ps1",
+          "env_fingerprint": "env:abc123",
+          "command_hash": "cmd:def456",
+          "packet_type": "observation_pack",
+          "generated_at": "__GENERATED_AT__"
+        },
+        "consultation_packet": {
+          "run_id": "task:task-256",
+          "task_id": "task-256",
+          "pane_id": "%2",
+          "slot": "slot-builder-1",
+          "kind": "consult_result",
+          "mode": "early",
+          "target_slot": "slot-review-1",
+          "confidence": 0.66,
+          "recommendation": "consult before work",
+          "next_test": "approval_waiting",
+          "risks": [
+            "needs reviewer confirmation"
+          ],
+          "packet_type": "consultation_packet",
+          "generated_at": "__GENERATED_AT__"
+        },
+        "verification_contract": null,
+        "verification_result": null,
+        "security_verdict": null
+      },
+      {
+        "line_number": 1,
+        "timestamp": "__TIMESTAMP__",
+        "event": "commander.review_requested",
+        "status": "",
+        "message": "review requested",
+        "label": "reviewer-1",
+        "pane_id": "%3",
+        "role": "Reviewer",
+        "task_id": "task-256",
+        "branch": "worktree-builder-1",
+        "head_sha": "abc1234def5678",
+        "source": "",
+        "hypothesis": "",
+        "test_plan": null,
+        "result": "",
+        "confidence": null,
+        "next_action": "",
+        "observation_pack_ref": "",
+        "consultation_ref": "",
+        "run_id": "",
+        "slot": "slot-builder-1",
+        "worktree": "",
+        "env_fingerprint": "",
+        "command_hash": "",
+        "observation_pack": null,
+        "consultation_packet": null,
+        "verification_contract": null,
+        "verification_result": null,
+        "security_verdict": null
+      }
+    ]
+  }
+}
+

--- a/tests/fixtures/rust-parity/explain.json
+++ b/tests/fixtures/rust-parity/explain.json
@@ -16,7 +16,7 @@
     "state": "idle",
     "tokens_remaining": "64% context left",
     "last_event": "commander.review_requested",
-    "last_event_at": "2026-04-10T12:00:00+09:00",
+    "last_event_at": "__LAST_EVENT_AT__",
     "pane_count": 1,
     "changed_file_count": 1,
     "labels": [
@@ -146,7 +146,7 @@
       "verification_contract": null,
       "verification_result": null,
       "last_event": "commander.review_requested",
-      "last_event_at": "2026-04-10T12:00:00+09:00"
+      "last_event_at": "__LAST_EVENT_AT__"
     }
   },
   "run_packet": {
@@ -202,7 +202,7 @@
     "verification_contract": null,
     "verification_result": null,
     "last_event": "commander.review_requested",
-    "last_event_at": "2026-04-10T12:00:00+09:00"
+    "last_event_at": "__LAST_EVENT_AT__"
   },
   "experiment_packet": {
     "hypothesis": "",
@@ -324,7 +324,7 @@
     ],
     "action_item_count": 2,
     "last_event": "commander.review_requested",
-    "last_event_at": "2026-04-10T12:00:00+09:00",
+    "last_event_at": "__LAST_EVENT_AT__",
     "verification_outcome": "",
     "security_blocked": "",
     "hypothesis": "",

--- a/tests/fixtures/rust-parity/inbox.json
+++ b/tests/fixtures/rust-parity/inbox.json
@@ -1,0 +1,88 @@
+{
+  "generated_at": "__GENERATED_AT__",
+  "project_dir": "__PROJECT_DIR__",
+  "summary": {
+    "item_count": 4,
+    "by_kind": {
+      "task_blocked": 1,
+      "review_pending": 1,
+      "approval_waiting": 1,
+      "commit_ready": 1
+    }
+  },
+  "items": [
+    {
+      "kind": "task_blocked",
+      "priority": 0,
+      "message": "worker-1 が blocked。",
+      "label": "worker-1",
+      "pane_id": "%6",
+      "role": "Worker",
+      "task_id": "task-999",
+      "task": "Fix blocker",
+      "task_state": "blocked",
+      "review_state": "",
+      "branch": "worktree-worker-1",
+      "head_sha": "def5678abc1234",
+      "changed_file_count": 0,
+      "event": "commander.state_transition",
+      "timestamp": "__TIMESTAMP__",
+      "source": "manifest"
+    },
+    {
+      "kind": "review_pending",
+      "priority": 1,
+      "message": "builder-1 が review 待機中。",
+      "label": "builder-1",
+      "pane_id": "%2",
+      "role": "Builder",
+      "task_id": "task-245",
+      "task": "Build inbox surface",
+      "task_state": "in_progress",
+      "review_state": "PENDING",
+      "branch": "worktree-builder-1",
+      "head_sha": "abc1234def5678",
+      "changed_file_count": 1,
+      "event": "review.requested",
+      "timestamp": "__TIMESTAMP__",
+      "source": "manifest"
+    },
+    {
+      "kind": "approval_waiting",
+      "priority": 1,
+      "message": "approval prompt detected",
+      "label": "builder-1",
+      "pane_id": "%2",
+      "role": "Builder",
+      "task_id": "",
+      "task": "",
+      "task_state": "",
+      "review_state": "",
+      "branch": "",
+      "head_sha": "",
+      "changed_file_count": 0,
+      "event": "approval_waiting",
+      "timestamp": "__TIMESTAMP__",
+      "source": "events"
+    },
+    {
+      "kind": "commit_ready",
+      "priority": 2,
+      "message": "コミット準備完了。",
+      "label": "",
+      "pane_id": "",
+      "role": "Commander",
+      "task_id": "",
+      "task": "",
+      "task_state": "",
+      "review_state": "",
+      "branch": "",
+      "head_sha": "abc1234def5678",
+      "changed_file_count": 0,
+      "event": "commit_ready",
+      "timestamp": "__TIMESTAMP__",
+      "source": "events"
+    }
+  ]
+}
+

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -11,16 +11,64 @@ function script:Write-PsmuxBridgeTestFile {
         New-Item -ItemType Directory -Path $parent -Force | Out-Null
     }
 
-    $escapedPath = $Path -replace '"', '""'
     if ([string]::IsNullOrEmpty($Content)) {
-        cmd /d /c ('type nul > "{0}"' -f $escapedPath) | Out-Null
+        Set-Content -Path $Path -Value '' -Encoding UTF8
     } else {
-        $Content | cmd /d /c ('more > "{0}"' -f $escapedPath) | Out-Null
+        Set-Content -Path $Path -Value $Content -Encoding UTF8
+    }
+}
+
+function script:ConvertTo-GoldenCorpusJson {
+    param(
+        [Parameter(Mandatory = $true)][object]$InputObject,
+        [Parameter(Mandatory = $true)][string]$ProjectDir
+    )
+
+    $json = $InputObject | ConvertTo-Json -Depth 20
+    $escapedProjectDir = [Regex]::Escape(($ProjectDir -replace '\\', '\\'))
+    $normalized = $json -replace $escapedProjectDir, '__PROJECT_DIR__'
+    $normalized = [Regex]::Replace(
+        $normalized,
+        '"generated_at"\s*:\s*"[^"]+"',
+        '"generated_at": "__GENERATED_AT__"'
+    )
+    $normalized = [Regex]::Replace(
+        $normalized,
+        '"timestamp"\s*:\s*"[^"]+"',
+        '"timestamp": "__TIMESTAMP__"'
+    )
+    $normalized = [Regex]::Replace(
+        $normalized,
+        'observation-pack-[a-f0-9]+\.json',
+        'observation-pack-__ID__.json'
+    )
+    $normalized = [Regex]::Replace(
+        $normalized,
+        'consult-result-[a-f0-9]+\.json',
+        'consult-result-__ID__.json'
+    )
+
+    return ($normalized.TrimEnd() + "`n")
+}
+
+function script:Assert-GoldenCorpusFixture {
+    param(
+        [Parameter(Mandatory = $true)][string]$FixturePath,
+        [Parameter(Mandatory = $true)][object]$InputObject,
+        [Parameter(Mandatory = $true)][string]$ProjectDir
+    )
+
+    $repoRoot = Split-Path -Parent $PSScriptRoot
+    $fullFixturePath = Join-Path $repoRoot $FixturePath
+    $actual = ConvertTo-GoldenCorpusJson -InputObject $InputObject -ProjectDir $ProjectDir
+
+    if ($env:WINSMUX_UPDATE_GOLDEN -eq '1') {
+        Write-PsmuxBridgeTestFile -Path $fullFixturePath -Content $actual
     }
 
-    if ($LASTEXITCODE -ne 0) {
-        throw "cmd.exe failed to write $Path"
-    }
+    Test-Path -LiteralPath $fullFixturePath | Should -Be $true
+    $expected = (Get-Content -Raw -Path $fullFixturePath -Encoding UTF8).TrimEnd("`r", "`n")
+    $actual.TrimEnd("`r", "`n") | Should -Be $expected
 }
 
 Describe 'Assert-Role' {
@@ -7365,6 +7413,423 @@ Describe 'orchestra pane bootstrap plan' {
         $script:orchestraPaneBootstrapContent | Should -Match '\[winsmux\] pane bootstrap:'
         $script:orchestraPaneBootstrapContent | Should -Match 'launch_command'
         $script:orchestraPaneBootstrapContent | Should -Match 'Invoke-Expression \$launchCommand'
+    }
+}
+
+Describe 'TASK-278 golden corpus fixtures' {
+    BeforeAll {
+        $script:winsmuxCorePath = Join-Path (Split-Path -Parent $PSScriptRoot) 'scripts\winsmux-core.ps1'
+        . $script:winsmuxCorePath 'version' *> $null
+    }
+
+    AfterEach {
+        $global:Target = $null
+        $global:Rest = @()
+        Remove-Item function:\winsmux -ErrorAction SilentlyContinue
+    }
+
+    It 'keeps board json fixture stable' {
+        $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('winsmux-board-golden-' + [guid]::NewGuid().ToString('N'))
+        $manifestDir = Join-Path $tempRoot '.winsmux'
+        $manifestPath = Join-Path $manifestDir 'manifest.yaml'
+        New-Item -ItemType Directory -Path $manifestDir -Force | Out-Null
+
+        try {
+            Push-Location $tempRoot
+@"
+version: 1
+session:
+  name: winsmux-orchestra
+  project_dir: $tempRoot
+panes:
+  builder-1:
+    pane_id: %2
+    role: Builder
+    task_id: task-244
+    task: Implement session board
+    task_state: in_progress
+    task_owner: builder-1
+    review_state: PENDING
+    branch: worktree-builder-1
+    builder_worktree_path: .worktrees/builder-1
+    head_sha: abc1234def5678
+    changed_file_count: 2
+    changed_files: '["scripts/winsmux-core.ps1","tests/winsmux-bridge.Tests.ps1"]'
+    last_event: pane.ready
+    last_event_at: 2026-04-10T10:00:00+09:00
+  worker-1:
+    pane_id: %6
+    role: Worker
+    task_id: ''
+    task: ''
+    task_state: backlog
+    task_owner: ''
+    review_state: ''
+    branch: ''
+    head_sha: ''
+    changed_file_count: 0
+    changed_files: '[]'
+    last_event: pane.idle
+    last_event_at: 2026-04-10T10:05:00+09:00
+"@ | Set-Content -Path $manifestPath -Encoding UTF8
+
+            function global:winsmux {
+                $commandLine = ($args | ForEach-Object { [string]$_ }) -join ' '
+                switch -Regex ($commandLine) {
+                    '^capture-pane .*%2' { return @('gpt-5.4   64% context left', '? send   Ctrl+J newline', '>') }
+                    '^capture-pane .*%6' { return @('gpt-5.4   52% context left', 'thinking', 'Esc to interrupt') }
+                    default { throw "unexpected winsmux call: $commandLine" }
+                }
+            }
+
+            $result = (Invoke-Board -BoardTarget '--json' | Out-String | ConvertFrom-Json -AsHashtable)
+            Assert-GoldenCorpusFixture -FixturePath 'tests/fixtures/rust-parity/board.json' -InputObject $result -ProjectDir $tempRoot
+        } finally {
+            Pop-Location
+            if (Test-Path $tempRoot) {
+                Remove-Item -Path $tempRoot -Recurse -Force
+            }
+        }
+    }
+
+    It 'keeps inbox json fixture stable' {
+        $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('winsmux-inbox-golden-' + [guid]::NewGuid().ToString('N'))
+        $manifestDir = Join-Path $tempRoot '.winsmux'
+        $manifestPath = Join-Path $manifestDir 'manifest.yaml'
+        $eventsPath = Join-Path $manifestDir 'events.jsonl'
+        New-Item -ItemType Directory -Path $manifestDir -Force | Out-Null
+
+        try {
+            Push-Location $tempRoot
+@"
+version: 1
+session:
+  name: winsmux-orchestra
+  project_dir: $tempRoot
+panes:
+  builder-1:
+    pane_id: %2
+    role: Builder
+    task_id: task-245
+    task: Build inbox surface
+    task_state: in_progress
+    task_owner: builder-1
+    review_state: PENDING
+    branch: worktree-builder-1
+    head_sha: abc1234def5678
+    changed_file_count: 1
+    changed_files: '["scripts/winsmux-core.ps1"]'
+    last_event: review.requested
+    last_event_at: 2026-04-10T11:00:00+09:00
+  worker-1:
+    pane_id: %6
+    role: Worker
+    task_id: task-999
+    task: Fix blocker
+    task_state: blocked
+    task_owner: worker-1
+    review_state: ''
+    branch: worktree-worker-1
+    head_sha: def5678abc1234
+    changed_file_count: 0
+    changed_files: '[]'
+    last_event: commander.state_transition
+    last_event_at: 2026-04-10T11:05:00+09:00
+"@ | Set-Content -Path $manifestPath -Encoding UTF8
+
+            @(
+                ([ordered]@{
+                    timestamp = '2026-04-10T11:02:00+09:00'
+                    session   = 'winsmux-orchestra'
+                    event     = 'pane.approval_waiting'
+                    message   = 'approval prompt detected'
+                    label     = 'builder-1'
+                    pane_id   = '%2'
+                    role      = 'Builder'
+                    status    = 'approval_waiting'
+                } | ConvertTo-Json -Compress),
+                ([ordered]@{
+                    timestamp = '2026-04-10T11:06:00+09:00'
+                    session   = 'winsmux-orchestra'
+                    event     = 'commander.state_transition'
+                    message   = 'State: review_requested -> blocked_no_review_target'
+                    label     = ''
+                    pane_id   = ''
+                    role      = 'Commander'
+                    status    = 'blocked_no_review_target'
+                    data      = [ordered]@{
+                        from = 'review_requested'
+                        to   = 'blocked_no_review_target'
+                    }
+                } | ConvertTo-Json -Compress),
+                ([ordered]@{
+                    timestamp = '2026-04-10T11:08:00+09:00'
+                    session   = 'winsmux-orchestra'
+                    event     = 'commander.commit_ready'
+                    message   = 'コミット準備完了。'
+                    label     = ''
+                    pane_id   = ''
+                    role      = 'Commander'
+                    status    = 'commit_ready'
+                    head_sha  = 'abc1234def5678'
+                } | ConvertTo-Json -Compress)
+            ) | Set-Content -Path $eventsPath -Encoding UTF8
+
+            function global:winsmux {
+                $commandLine = ($args | ForEach-Object { [string]$_ }) -join ' '
+                switch -Regex ($commandLine) {
+                    '^capture-pane .*%2' { return @('gpt-5.4   64% context left', '? send   Ctrl+J newline', '>') }
+                    default { throw "unexpected winsmux call: $commandLine" }
+                }
+            }
+
+            $result = (Invoke-Inbox -InboxTarget '--json' | Out-String | ConvertFrom-Json -AsHashtable)
+            Assert-GoldenCorpusFixture -FixturePath 'tests/fixtures/rust-parity/inbox.json' -InputObject $result -ProjectDir $tempRoot
+        } finally {
+            Pop-Location
+            if (Test-Path $tempRoot) {
+                Remove-Item -Path $tempRoot -Recurse -Force
+            }
+        }
+    }
+
+    It 'keeps digest json fixture stable' {
+        $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('winsmux-digest-golden-' + [guid]::NewGuid().ToString('N'))
+        $manifestDir = Join-Path $tempRoot '.winsmux'
+        $manifestPath = Join-Path $manifestDir 'manifest.yaml'
+        $eventsPath = Join-Path $manifestDir 'events.jsonl'
+        New-Item -ItemType Directory -Path $manifestDir -Force | Out-Null
+
+        try {
+            Push-Location $tempRoot
+@"
+version: 1
+session:
+  name: winsmux-orchestra
+  project_dir: $tempRoot
+panes:
+  builder-1:
+    pane_id: %2
+    role: Builder
+    task_id: task-246
+    task: Build evidence digest
+    task_state: blocked
+    task_owner: builder-1
+    review_state: FAIL
+    branch: worktree-builder-1
+    head_sha: abc1234def5678
+    changed_file_count: 1
+    changed_files: '["scripts/winsmux-core.ps1"]'
+    last_event: commander.review_failed
+    last_event_at: 2026-04-10T14:00:00+09:00
+"@ | Set-Content -Path $manifestPath -Encoding UTF8
+
+            $digestObservationPack = New-ObservationPackFile -ProjectDir $tempRoot -ObservationPack ([ordered]@{
+                run_id          = 'task:task-246'
+                task_id         = 'task-246'
+                pane_id         = '%2'
+                slot            = 'slot-builder-1'
+                hypothesis      = 'result summary should appear in digest'
+                env_fingerprint = 'env:abc123'
+            })
+            $digestConsultationPacket = New-ConsultationPacketFile -ProjectDir $tempRoot -ConsultationPacket ([ordered]@{
+                run_id         = 'task:task-246'
+                task_id        = 'task-246'
+                pane_id        = '%2'
+                slot           = 'slot-builder-1'
+                kind           = 'consult_result'
+                mode           = 'reconcile'
+                target_slot    = 'slot-review-1'
+                confidence     = 0.88
+                recommendation = 'treat review failure as blocking'
+                next_test      = 'review_failed'
+            })
+
+            ([ordered]@{
+                timestamp = '2026-04-10T14:03:00+09:00'
+                session   = 'winsmux-orchestra'
+                event     = 'commander.review_failed'
+                message   = 'review failed'
+                label     = 'builder-1'
+                pane_id   = '%2'
+                role      = 'Builder'
+                status    = 'review_failed'
+                branch    = 'worktree-builder-1'
+                head_sha  = 'abc1234def5678'
+                data      = [ordered]@{
+                    task_id              = 'task-246'
+                    hypothesis           = 'result summary should appear in digest'
+                    result               = 'review failure reproduced'
+                    confidence           = 0.88
+                    next_action          = 'review_failed'
+                    observation_pack_ref = $digestObservationPack.reference
+                    consultation_ref     = $digestConsultationPacket.reference
+                }
+            } | ConvertTo-Json -Compress) | Set-Content -Path $eventsPath -Encoding UTF8
+
+            function global:winsmux {
+                $commandLine = ($args | ForEach-Object { [string]$_ }) -join ' '
+                switch -Regex ($commandLine) {
+                    '^capture-pane .*%2' { return @('gpt-5.4   64% context left', '? send   Ctrl+J newline', '>') }
+                    default { throw "unexpected winsmux call: $commandLine" }
+                }
+            }
+
+            $result = (Invoke-Digest -DigestTarget '--json' | Out-String | ConvertFrom-Json -AsHashtable)
+            Assert-GoldenCorpusFixture -FixturePath 'tests/fixtures/rust-parity/digest.json' -InputObject $result -ProjectDir $tempRoot
+        } finally {
+            Pop-Location
+            if (Test-Path $tempRoot) {
+                Remove-Item -Path $tempRoot -Recurse -Force
+            }
+        }
+    }
+
+    It 'keeps explain json fixture stable' {
+        $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('winsmux-explain-golden-' + [guid]::NewGuid().ToString('N'))
+        $manifestDir = Join-Path $tempRoot '.winsmux'
+        $manifestPath = Join-Path $manifestDir 'manifest.yaml'
+        $eventsPath = Join-Path $manifestDir 'events.jsonl'
+        $reviewStatePath = Join-Path $manifestDir 'review-state.json'
+        New-Item -ItemType Directory -Path $manifestDir -Force | Out-Null
+
+        try {
+            Push-Location $tempRoot
+@"
+version: 1
+session:
+  name: winsmux-orchestra
+  project_dir: $tempRoot
+panes:
+  builder-1:
+    pane_id: %2
+    role: Builder
+    task_id: task-256
+    parent_run_id: operator:session-1
+    goal: Ship run contract primitives
+    task: Implement run ledger
+    task_type: implementation
+    task_state: in_progress
+    task_owner: builder-1
+    review_state: PENDING
+    priority: P0
+    blocking: true
+    branch: worktree-builder-1
+    head_sha: abc1234def5678
+    changed_file_count: 1
+    changed_files: '["scripts/winsmux-core.ps1"]'
+    write_scope: '["scripts/winsmux-core.ps1","tests/winsmux-bridge.Tests.ps1"]'
+    read_scope: '["winsmux-core/scripts/pane-status.ps1"]'
+    constraints: '["preserve existing board schema"]'
+    expected_output: Stable run_packet JSON
+    verification_plan: '["Invoke-Pester tests/winsmux-bridge.Tests.ps1","verify explain --json contract"]'
+    review_required: true
+    provider_target: codex:gpt-5.4
+    agent_role: worker
+    timeout_policy: standard
+    handoff_refs: '["docs/handoff.md"]'
+    last_event: commander.review_requested
+    last_event_at: 2026-04-10T12:00:00+09:00
+"@ | Set-Content -Path $manifestPath -Encoding UTF8
+
+            $explainObservationPack = New-ObservationPackFile -ProjectDir $tempRoot -ObservationPack ([ordered]@{
+                run_id               = 'task:task-256'
+                task_id              = 'task-256'
+                pane_id              = '%2'
+                slot                 = 'slot-builder-1'
+                hypothesis           = 'experiment packet should flow into explain'
+                test_plan            = @('collect matching events', 'normalize packet')
+                changed_files        = @('scripts/winsmux-core.ps1')
+                working_tree_summary = '1 file modified'
+                failing_command      = 'Invoke-Pester tests/winsmux-bridge.Tests.ps1'
+                env_fingerprint      = 'env:abc123'
+                command_hash         = 'cmd:def456'
+            })
+            $explainConsultationPacket = New-ConsultationPacketFile -ProjectDir $tempRoot -ConsultationPacket ([ordered]@{
+                run_id         = 'task:task-256'
+                task_id        = 'task-256'
+                pane_id        = '%2'
+                slot           = 'slot-builder-1'
+                kind           = 'consult_result'
+                mode           = 'early'
+                target_slot    = 'slot-review-1'
+                confidence     = 0.66
+                recommendation = 'consult before work'
+                next_test      = 'approval_waiting'
+                risks          = @('needs reviewer confirmation')
+            })
+
+            @(
+                ([ordered]@{
+                    timestamp = '2026-04-10T12:01:00+09:00'
+                    session   = 'winsmux-orchestra'
+                    event     = 'commander.review_requested'
+                    message   = 'review requested'
+                    label     = 'reviewer-1'
+                    pane_id   = '%3'
+                    role      = 'Reviewer'
+                    branch    = 'worktree-builder-1'
+                    head_sha  = 'abc1234def5678'
+                    data      = [ordered]@{
+                        task_id = 'task-256'
+                        slot    = 'slot-builder-1'
+                    }
+                } | ConvertTo-Json -Compress),
+                ([ordered]@{
+                    timestamp = '2026-04-10T12:02:00+09:00'
+                    session   = 'winsmux-orchestra'
+                    event     = 'consult.result'
+                    message   = 'consult before work'
+                    label     = 'builder-1'
+                    pane_id   = '%2'
+                    role      = 'Builder'
+                    branch    = 'worktree-builder-1'
+                    head_sha  = 'abc1234def5678'
+                    data      = [ordered]@{
+                        task_id              = 'task-256'
+                        result               = 'consult before work'
+                        confidence           = 0.66
+                        next_action          = 'approval_waiting'
+                        observation_pack_ref = $explainObservationPack.reference
+                        consultation_ref     = $explainConsultationPacket.reference
+                    }
+                } | ConvertTo-Json -Compress)
+            ) | Set-Content -Path $eventsPath -Encoding UTF8
+
+@'
+{
+  "task:task-256": {
+    "verification_contract": {
+      "mode": "adversarial_verify",
+      "required_evidence": [
+        "tests",
+        "review"
+      ]
+    },
+    "verification_result": {
+      "outcome": "PARTIAL",
+      "summary": "review pending"
+    }
+  }
+}
+'@ | Set-Content -Path $reviewStatePath -Encoding UTF8
+
+            function global:winsmux {
+                $commandLine = ($args | ForEach-Object { [string]$_ }) -join ' '
+                switch -Regex ($commandLine) {
+                    '^capture-pane .*%2' { return @('gpt-5.4   64% context left', '? send   Ctrl+J newline', '>') }
+                    default { throw "unexpected winsmux call: $commandLine" }
+                }
+            }
+
+            $result = (Invoke-Explain -ExplainTarget 'task:task-256' -ExplainRest @('--json') | Out-String | ConvertFrom-Json -AsHashtable)
+            Assert-GoldenCorpusFixture -FixturePath 'tests/fixtures/rust-parity/explain.json' -InputObject $result -ProjectDir $tempRoot
+        } finally {
+            Pop-Location
+            if (Test-Path $tempRoot) {
+                Remove-Item -Path $tempRoot -Recurse -Force
+            }
+        }
     }
 }
 

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -39,6 +39,11 @@ function script:ConvertTo-GoldenCorpusJson {
     )
     $normalized = [Regex]::Replace(
         $normalized,
+        '"last_event_at"\s*:\s*"[^"]+"',
+        '"last_event_at": "__LAST_EVENT_AT__"'
+    )
+    $normalized = [Regex]::Replace(
+        $normalized,
         'observation-pack-[a-f0-9]+\.json',
         'observation-pack-__ID__.json'
     )


### PR DESCRIPTION
## Summary
- add a minimal tracked golden corpus for the bridge JSON surfaces used by Rust parity work
- cover board, inbox, digest, and explain through fixture-backed tests
- normalize volatile fields so the corpus stays stable across runs

## Validation
- Invoke-Pester tests/winsmux-bridge.Tests.ps1 -CI -Output None
- pwsh -NoProfile -File scripts/git-guard.ps1 -Mode full
- pwsh -NoProfile -File scripts/audit-public-surface.ps1
