### PR TITLE
test: tighten typed parity contract fixtures

### DIFF
--- a/core/tests-rs/test_parity.rs
+++ b/core/tests-rs/test_parity.rs
@@ -1,5 +1,8 @@
 use crate::types::{AppState, ClientInfo};
+use serde::de::DeserializeOwned;
+use serde::Deserialize;
 use serde_json::Value;
+use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
 
@@ -27,49 +30,252 @@ fn read_rust_parity_fixture(name: &str) -> Value {
         .unwrap_or_else(|err| panic!("failed to parse fixture {}: {}", path.display(), err))
 }
 
+fn read_rust_parity_fixture_typed<T: DeserializeOwned>(name: &str) -> T {
+    let path = rust_parity_fixture_path(name);
+    let raw = fs::read_to_string(&path)
+        .unwrap_or_else(|err| panic!("failed to read fixture {}: {}", path.display(), err));
+    serde_json::from_str(&raw)
+        .unwrap_or_else(|err| panic!("failed to parse typed fixture {}: {}", path.display(), err))
+}
+
+#[derive(Deserialize)]
+struct RustParityBoardFixture {
+    generated_at: String,
+    project_dir: String,
+    summary: RustParityBoardSummary,
+    panes: Vec<RustParityBoardPane>,
+}
+
+#[derive(Deserialize)]
+struct RustParityBoardSummary {
+    pane_count: usize,
+    dirty_panes: usize,
+    review_pending: usize,
+    review_failed: usize,
+    review_passed: usize,
+    tasks_in_progress: usize,
+    tasks_blocked: usize,
+    by_state: HashMap<String, usize>,
+    by_review: HashMap<String, usize>,
+    by_task_state: HashMap<String, usize>,
+}
+
+#[derive(Deserialize)]
+struct RustParityBoardPane {
+    label: String,
+    pane_id: String,
+    task_state: String,
+    changed_file_count: usize,
+    last_event_at: String,
+}
+
+#[derive(Deserialize)]
+struct RustParityInboxFixture {
+    generated_at: String,
+    project_dir: String,
+    summary: RustParityInboxSummary,
+    items: Vec<RustParityInboxItem>,
+}
+
+#[derive(Deserialize)]
+struct RustParityInboxSummary {
+    item_count: usize,
+}
+
+#[derive(Deserialize)]
+struct RustParityInboxItem {
+    kind: String,
+    message: String,
+    label: String,
+    pane_id: String,
+    task_state: String,
+    review_state: String,
+    branch: String,
+    changed_file_count: usize,
+    timestamp: String,
+}
+
+#[derive(Deserialize)]
+struct RustParityDigestFixture {
+    generated_at: String,
+    project_dir: String,
+    summary: RustParityDigestSummary,
+    items: Vec<RustParityDigestItem>,
+}
+
+#[derive(Deserialize)]
+struct RustParityDigestSummary {
+    item_count: usize,
+    dirty_items: usize,
+    actionable_items: usize,
+    review_pending: usize,
+    review_failed: usize,
+}
+
+#[derive(Deserialize)]
+struct RustParityDigestItem {
+    run_id: String,
+    task: String,
+    label: String,
+    pane_id: String,
+    task_state: String,
+    review_state: String,
+    next_action: String,
+    branch: String,
+    changed_file_count: usize,
+    last_event_at: String,
+}
+
+#[derive(Deserialize)]
+struct RustParityExplainFixture {
+    generated_at: String,
+    project_dir: String,
+    run: RustParityExplainRun,
+    evidence_digest: RustParityExplainEvidenceDigest,
+}
+
+#[derive(Deserialize)]
+struct RustParityExplainRun {
+    run_id: String,
+    task: String,
+    state: String,
+    task_state: String,
+    review_state: String,
+    branch: String,
+    head_sha: String,
+    worktree: String,
+    changed_files: Vec<String>,
+    last_event_at: String,
+    action_items: Vec<RustParityExplainActionItem>,
+}
+
+#[derive(Deserialize)]
+struct RustParityExplainActionItem {
+    kind: String,
+    event: String,
+    timestamp: String,
+}
+
+#[derive(Deserialize)]
+struct RustParityExplainEvidenceDigest {
+    next_action: String,
+    changed_file_count: usize,
+    consultation_ref: String,
+}
+
 #[test]
 fn rust_parity_board_fixture_deserializes() {
-    let fixture = read_rust_parity_fixture("board.json");
-    assert_eq!(fixture["generated_at"], "__GENERATED_AT__");
-    assert_eq!(fixture["project_dir"], "__PROJECT_DIR__");
-    assert!(fixture["summary"]["pane_count"].is_number());
-    let panes = fixture["panes"].as_array().expect("board panes must be an array");
-    assert!(!panes.is_empty(), "board fixture should contain at least one pane");
-    assert_eq!(panes[0]["last_event_at"], "__LAST_EVENT_AT__");
+    let fixture: RustParityBoardFixture = read_rust_parity_fixture_typed("board.json");
+    assert_eq!(fixture.generated_at, "__GENERATED_AT__");
+    assert_eq!(fixture.project_dir, "__PROJECT_DIR__");
+    assert_eq!(fixture.summary.pane_count, 2);
+    assert_eq!(fixture.summary.dirty_panes, 1);
+    assert_eq!(fixture.summary.review_pending, 1);
+    assert_eq!(fixture.summary.review_failed, 0);
+    assert_eq!(fixture.summary.review_passed, 0);
+    assert_eq!(fixture.summary.tasks_in_progress, 1);
+    assert_eq!(fixture.summary.tasks_blocked, 0);
+    assert_eq!(fixture.summary.by_state["idle"], 1);
+    assert_eq!(fixture.summary.by_state["busy"], 1);
+    assert_eq!(fixture.summary.by_review["PENDING"], 1);
+    assert_eq!(fixture.summary.by_task_state["in_progress"], 1);
+    assert!(
+        !fixture.panes.is_empty(),
+        "board fixture should contain at least one pane"
+    );
+    let builder_pane = fixture
+        .panes
+        .iter()
+        .find(|pane| pane.label == "builder-1")
+        .expect("board fixture should contain builder-1");
+    assert_eq!(builder_pane.pane_id, "%2");
+    assert_eq!(builder_pane.task_state, "in_progress");
+    assert_eq!(builder_pane.changed_file_count, 2);
+    assert_eq!(builder_pane.last_event_at, "__LAST_EVENT_AT__");
 }
 
 #[test]
 fn rust_parity_inbox_fixture_deserializes() {
-    let fixture = read_rust_parity_fixture("inbox.json");
-    assert_eq!(fixture["generated_at"], "__GENERATED_AT__");
-    assert_eq!(fixture["project_dir"], "__PROJECT_DIR__");
-    assert!(fixture["summary"]["item_count"].is_number());
-    let items = fixture["items"].as_array().expect("inbox items must be an array");
-    assert!(!items.is_empty(), "inbox fixture should contain at least one item");
-    assert_eq!(items[0]["timestamp"], "__TIMESTAMP__");
+    let fixture: RustParityInboxFixture = read_rust_parity_fixture_typed("inbox.json");
+    assert_eq!(fixture.generated_at, "__GENERATED_AT__");
+    assert_eq!(fixture.project_dir, "__PROJECT_DIR__");
+    assert_eq!(fixture.summary.item_count, 4);
+    assert!(
+        !fixture.items.is_empty(),
+        "inbox fixture should contain at least one item"
+    );
+    let blocked_item = fixture
+        .items
+        .iter()
+        .find(|item| item.kind == "task_blocked")
+        .expect("inbox fixture should contain task_blocked");
+    assert_eq!(blocked_item.message, "worker-1 が blocked。");
+    assert_eq!(blocked_item.label, "worker-1");
+    assert_eq!(blocked_item.pane_id, "%6");
+    assert_eq!(blocked_item.task_state, "blocked");
+    assert_eq!(blocked_item.review_state, "");
+    assert_eq!(blocked_item.branch, "worktree-worker-1");
+    assert_eq!(blocked_item.changed_file_count, 0);
+    assert_eq!(blocked_item.timestamp, "__TIMESTAMP__");
 }
 
 #[test]
 fn rust_parity_digest_fixture_deserializes() {
-    let fixture = read_rust_parity_fixture("digest.json");
-    assert_eq!(fixture["generated_at"], "__GENERATED_AT__");
-    assert_eq!(fixture["project_dir"], "__PROJECT_DIR__");
-    let items = fixture["items"].as_array().expect("digest items must be an array");
-    assert_eq!(items.len(), 1, "digest fixture should keep the minimal single-run shape");
-    assert_eq!(items[0]["last_event_at"], "__LAST_EVENT_AT__");
+    let fixture: RustParityDigestFixture = read_rust_parity_fixture_typed("digest.json");
+    assert_eq!(fixture.generated_at, "__GENERATED_AT__");
+    assert_eq!(fixture.project_dir, "__PROJECT_DIR__");
+    assert_eq!(fixture.summary.item_count, 1);
+    assert_eq!(fixture.summary.dirty_items, 1);
+    assert_eq!(fixture.summary.actionable_items, 1);
+    assert_eq!(fixture.summary.review_pending, 0);
+    assert_eq!(fixture.summary.review_failed, 1);
+    assert_eq!(
+        fixture.items.len(),
+        1,
+        "digest fixture should keep the minimal single-run shape"
+    );
+    assert_eq!(fixture.items[0].run_id, "task:task-246");
+    assert_eq!(fixture.items[0].task, "Build evidence digest");
+    assert_eq!(fixture.items[0].label, "builder-1");
+    assert_eq!(fixture.items[0].pane_id, "%2");
+    assert_eq!(fixture.items[0].task_state, "blocked");
+    assert_eq!(fixture.items[0].review_state, "FAIL");
+    assert_eq!(fixture.items[0].next_action, "review_failed");
+    assert_eq!(fixture.items[0].branch, "worktree-builder-1");
+    assert_eq!(fixture.items[0].changed_file_count, 1);
+    assert_eq!(fixture.items[0].last_event_at, "__LAST_EVENT_AT__");
 }
 
 #[test]
 fn rust_parity_explain_fixture_deserializes() {
-    let fixture = read_rust_parity_fixture("explain.json");
-    assert_eq!(fixture["generated_at"], "__GENERATED_AT__");
-    assert_eq!(fixture["project_dir"], "__PROJECT_DIR__");
-    assert_eq!(fixture["run"]["last_event_at"], "__LAST_EVENT_AT__");
-    let action_items = fixture["run"]["action_items"]
-        .as_array()
-        .expect("run.action_items must be an array");
-    assert!(!action_items.is_empty(), "explain fixture should contain at least one action item");
-    assert_eq!(action_items[0]["timestamp"], "__TIMESTAMP__");
+    let fixture: RustParityExplainFixture = read_rust_parity_fixture_typed("explain.json");
+    assert_eq!(fixture.generated_at, "__GENERATED_AT__");
+    assert_eq!(fixture.project_dir, "__PROJECT_DIR__");
+    assert_eq!(fixture.run.run_id, "task:task-256");
+    assert_eq!(fixture.run.task, "Implement run ledger");
+    assert_eq!(fixture.run.state, "idle");
+    assert_eq!(fixture.run.task_state, "in_progress");
+    assert_eq!(fixture.run.review_state, "PENDING");
+    assert_eq!(fixture.run.branch, "worktree-builder-1");
+    assert_eq!(fixture.run.head_sha, "abc1234def5678");
+    assert_eq!(fixture.run.worktree, ".worktrees/builder-1");
+    assert_eq!(fixture.run.changed_files, vec!["scripts/winsmux-core.ps1"]);
+    assert_eq!(fixture.run.last_event_at, "__LAST_EVENT_AT__");
+    assert!(
+        !fixture.run.action_items.is_empty(),
+        "explain fixture should contain at least one action item"
+    );
+    let review_pending = fixture
+        .run
+        .action_items
+        .iter()
+        .find(|item| item.kind == "review_pending")
+        .expect("explain fixture should contain review_pending action item");
+    assert_eq!(review_pending.event, "commander.review_requested");
+    assert_eq!(review_pending.timestamp, "__TIMESTAMP__");
+    assert_eq!(fixture.evidence_digest.next_action, "review_pending");
+    assert_eq!(fixture.evidence_digest.changed_file_count, 1);
+    assert!(fixture.evidence_digest.consultation_ref.contains("__ID__"));
 }
 
 // ════════════════════════════════════════════════════════════════════════════
@@ -79,44 +285,68 @@ fn rust_parity_explain_fixture_deserializes() {
 #[test]
 fn hook_before_new_window_found_in_hooks_map() {
     let mut app = mock_app();
-    crate::config::parse_config_line(&mut app, "set-hook -g before-new-window 'display-message creating'");
+    crate::config::parse_config_line(
+        &mut app,
+        "set-hook -g before-new-window 'display-message creating'",
+    );
     assert!(app.hooks.contains_key("before-new-window"));
-    assert_eq!(app.hooks["before-new-window"][0], "display-message creating");
+    assert_eq!(
+        app.hooks["before-new-window"][0],
+        "display-message creating"
+    );
 }
 
 #[test]
 fn hook_before_split_window_found_in_hooks_map() {
     let mut app = mock_app();
-    crate::config::parse_config_line(&mut app, "set-hook -g before-split-window 'display-message splitting'");
+    crate::config::parse_config_line(
+        &mut app,
+        "set-hook -g before-split-window 'display-message splitting'",
+    );
     assert!(app.hooks.contains_key("before-split-window"));
-    assert_eq!(app.hooks["before-split-window"][0], "display-message splitting");
+    assert_eq!(
+        app.hooks["before-split-window"][0],
+        "display-message splitting"
+    );
 }
 
 #[test]
 fn hook_before_kill_pane_found_in_hooks_map() {
     let mut app = mock_app();
-    crate::config::parse_config_line(&mut app, "set-hook -g before-kill-pane 'display-message killing'");
+    crate::config::parse_config_line(
+        &mut app,
+        "set-hook -g before-kill-pane 'display-message killing'",
+    );
     assert!(app.hooks.contains_key("before-kill-pane"));
 }
 
 #[test]
 fn hook_before_select_window_found_in_hooks_map() {
     let mut app = mock_app();
-    crate::config::parse_config_line(&mut app, "set-hook -g before-select-window 'display-message switching'");
+    crate::config::parse_config_line(
+        &mut app,
+        "set-hook -g before-select-window 'display-message switching'",
+    );
     assert!(app.hooks.contains_key("before-select-window"));
 }
 
 #[test]
 fn hook_before_rename_window_found_in_hooks_map() {
     let mut app = mock_app();
-    crate::config::parse_config_line(&mut app, "set-hook -g before-rename-window 'display-message renaming'");
+    crate::config::parse_config_line(
+        &mut app,
+        "set-hook -g before-rename-window 'display-message renaming'",
+    );
     assert!(app.hooks.contains_key("before-rename-window"));
 }
 
 #[test]
 fn hook_after_new_window_still_works() {
     let mut app = mock_app();
-    crate::config::parse_config_line(&mut app, "set-hook -g after-new-window 'display-message created'");
+    crate::config::parse_config_line(
+        &mut app,
+        "set-hook -g after-new-window 'display-message created'",
+    );
     assert!(app.hooks.contains_key("after-new-window"));
     assert_eq!(app.hooks["after-new-window"][0], "display-message created");
 }
@@ -124,28 +354,40 @@ fn hook_after_new_window_still_works() {
 #[test]
 fn hook_after_split_window_still_works() {
     let mut app = mock_app();
-    crate::config::parse_config_line(&mut app, "set-hook -g after-split-window 'display-message split'");
+    crate::config::parse_config_line(
+        &mut app,
+        "set-hook -g after-split-window 'display-message split'",
+    );
     assert!(app.hooks.contains_key("after-split-window"));
 }
 
 #[test]
 fn hook_after_kill_pane_still_works() {
     let mut app = mock_app();
-    crate::config::parse_config_line(&mut app, "set-hook -g after-kill-pane 'display-message killed'");
+    crate::config::parse_config_line(
+        &mut app,
+        "set-hook -g after-kill-pane 'display-message killed'",
+    );
     assert!(app.hooks.contains_key("after-kill-pane"));
 }
 
 #[test]
 fn hook_after_select_window_still_works() {
     let mut app = mock_app();
-    crate::config::parse_config_line(&mut app, "set-hook -g after-select-window 'display-message switched'");
+    crate::config::parse_config_line(
+        &mut app,
+        "set-hook -g after-select-window 'display-message switched'",
+    );
     assert!(app.hooks.contains_key("after-select-window"));
 }
 
 #[test]
 fn hook_after_resize_pane_still_works() {
     let mut app = mock_app();
-    crate::config::parse_config_line(&mut app, "set-hook -g after-resize-pane 'display-message resized'");
+    crate::config::parse_config_line(
+        &mut app,
+        "set-hook -g after-resize-pane 'display-message resized'",
+    );
     assert!(app.hooks.contains_key("after-resize-pane"));
 }
 
@@ -159,7 +401,10 @@ fn hook_client_attached_still_works() {
 #[test]
 fn hook_session_created_still_works() {
     let mut app = mock_app();
-    crate::config::parse_config_line(&mut app, "set-hook -g session-created 'display-message new'");
+    crate::config::parse_config_line(
+        &mut app,
+        "set-hook -g session-created 'display-message new'",
+    );
     assert!(app.hooks.contains_key("session-created"));
 }
 
@@ -173,9 +418,18 @@ fn hook_pane_set_clipboard_still_works() {
 #[test]
 fn hook_multiple_commands_via_append() {
     let mut app = mock_app();
-    crate::config::parse_config_line(&mut app, "set-hook -g after-new-window 'display-message first'");
-    crate::config::parse_config_line(&mut app, "set-hook -ga after-new-window 'display-message second'");
-    crate::config::parse_config_line(&mut app, "set-hook -ga after-new-window 'display-message third'");
+    crate::config::parse_config_line(
+        &mut app,
+        "set-hook -g after-new-window 'display-message first'",
+    );
+    crate::config::parse_config_line(
+        &mut app,
+        "set-hook -ga after-new-window 'display-message second'",
+    );
+    crate::config::parse_config_line(
+        &mut app,
+        "set-hook -ga after-new-window 'display-message third'",
+    );
     let cmds = app.hooks.get("after-new-window").unwrap();
     assert_eq!(cmds.len(), 3);
     assert_eq!(cmds[0], "display-message first");
@@ -186,8 +440,14 @@ fn hook_multiple_commands_via_append() {
 #[test]
 fn hook_before_and_after_coexist() {
     let mut app = mock_app();
-    crate::config::parse_config_line(&mut app, "set-hook -g before-new-window 'display-message before'");
-    crate::config::parse_config_line(&mut app, "set-hook -g after-new-window 'display-message after'");
+    crate::config::parse_config_line(
+        &mut app,
+        "set-hook -g before-new-window 'display-message before'",
+    );
+    crate::config::parse_config_line(
+        &mut app,
+        "set-hook -g after-new-window 'display-message after'",
+    );
     assert!(app.hooks.contains_key("before-new-window"));
     assert!(app.hooks.contains_key("after-new-window"));
     assert_eq!(app.hooks.len(), 2);
@@ -262,15 +522,18 @@ fn client_registry_add_client() {
 fn client_registry_add_multiple_clients() {
     let mut app = mock_app();
     for i in 0..5 {
-        app.client_registry.insert(i, ClientInfo {
-            id: i,
-            width: 120,
-            height: 30,
-            connected_at: std::time::Instant::now(),
-            last_activity: std::time::Instant::now(),
-            tty_name: format!("/dev/pts/{}", i),
-            is_control: false,
-        });
+        app.client_registry.insert(
+            i,
+            ClientInfo {
+                id: i,
+                width: 120,
+                height: 30,
+                connected_at: std::time::Instant::now(),
+                last_activity: std::time::Instant::now(),
+                tty_name: format!("/dev/pts/{}", i),
+                is_control: false,
+            },
+        );
     }
     assert_eq!(app.client_registry.len(), 5);
 }
@@ -278,24 +541,30 @@ fn client_registry_add_multiple_clients() {
 #[test]
 fn client_registry_remove_client() {
     let mut app = mock_app();
-    app.client_registry.insert(1, ClientInfo {
-        id: 1,
-        width: 120,
-        height: 30,
-        connected_at: std::time::Instant::now(),
-        last_activity: std::time::Instant::now(),
-        tty_name: "/dev/pts/0".to_string(),
-        is_control: false,
-    });
-    app.client_registry.insert(2, ClientInfo {
-        id: 2,
-        width: 80,
-        height: 24,
-        connected_at: std::time::Instant::now(),
-        last_activity: std::time::Instant::now(),
-        tty_name: "/dev/pts/1".to_string(),
-        is_control: false,
-    });
+    app.client_registry.insert(
+        1,
+        ClientInfo {
+            id: 1,
+            width: 120,
+            height: 30,
+            connected_at: std::time::Instant::now(),
+            last_activity: std::time::Instant::now(),
+            tty_name: "/dev/pts/0".to_string(),
+            is_control: false,
+        },
+    );
+    app.client_registry.insert(
+        2,
+        ClientInfo {
+            id: 2,
+            width: 80,
+            height: 24,
+            connected_at: std::time::Instant::now(),
+            last_activity: std::time::Instant::now(),
+            tty_name: "/dev/pts/1".to_string(),
+            is_control: false,
+        },
+    );
     assert_eq!(app.client_registry.len(), 2);
     app.client_registry.remove(&1);
     assert_eq!(app.client_registry.len(), 1);
@@ -345,12 +614,21 @@ fn option_catalog_contains_common_options() {
     let app = mock_app();
     let options = crate::server::option_catalog::build_option_list(&app);
     let names: Vec<&str> = options.iter().map(|(n, _, _)| n.as_str()).collect();
-    assert!(names.contains(&"escape-time"), "catalog should contain escape-time");
+    assert!(
+        names.contains(&"escape-time"),
+        "catalog should contain escape-time"
+    );
     assert!(names.contains(&"mouse"), "catalog should contain mouse");
     assert!(names.contains(&"prefix"), "catalog should contain prefix");
     assert!(names.contains(&"status"), "catalog should contain status");
-    assert!(names.contains(&"base-index"), "catalog should contain base-index");
-    assert!(names.contains(&"mode-keys"), "catalog should contain mode-keys");
+    assert!(
+        names.contains(&"base-index"),
+        "catalog should contain base-index"
+    );
+    assert!(
+        names.contains(&"mode-keys"),
+        "catalog should contain mode-keys"
+    );
 }
 
 #[test]
@@ -358,9 +636,18 @@ fn option_catalog_entries_have_scope() {
     let app = mock_app();
     let options = crate::server::option_catalog::build_option_list(&app);
     let scopes: Vec<&str> = options.iter().map(|(_, _, s)| s.as_str()).collect();
-    assert!(scopes.contains(&"server"), "catalog should have server scope entries");
-    assert!(scopes.contains(&"session"), "catalog should have session scope entries");
-    assert!(scopes.contains(&"window"), "catalog should have window scope entries");
+    assert!(
+        scopes.contains(&"server"),
+        "catalog should have server scope entries"
+    );
+    assert!(
+        scopes.contains(&"session"),
+        "catalog should have session scope entries"
+    );
+    assert!(
+        scopes.contains(&"window"),
+        "catalog should have window scope entries"
+    );
 }
 
 #[test]
@@ -400,7 +687,9 @@ fn option_catalog_all_entries_have_valid_types() {
         assert!(
             valid_types.contains(&def.option_type),
             "option '{}' has invalid type '{}' (expected one of {:?})",
-            def.name, def.option_type, valid_types
+            def.name,
+            def.option_type,
+            valid_types
         );
     }
 }
@@ -412,7 +701,9 @@ fn option_catalog_all_entries_have_valid_scopes() {
         assert!(
             valid_scopes.contains(&def.scope),
             "option '{}' has invalid scope '{}' (expected one of {:?})",
-            def.name, def.scope, valid_scopes
+            def.name,
+            def.scope,
+            valid_scopes
         );
     }
 }
@@ -423,24 +714,34 @@ fn option_catalog_no_duplicate_names() {
     for def in crate::server::option_catalog::OPTION_CATALOG {
         assert!(
             seen.insert(def.name),
-            "duplicate option name in catalog: '{}'", def.name
+            "duplicate option name in catalog: '{}'",
+            def.name
         );
     }
 }
 
 #[test]
 fn option_catalog_default_for_base_index() {
-    assert_eq!(crate::server::option_catalog::default_for("base-index"), Some("0"));
+    assert_eq!(
+        crate::server::option_catalog::default_for("base-index"),
+        Some("0")
+    );
 }
 
 #[test]
 fn option_catalog_default_for_history_limit() {
-    assert_eq!(crate::server::option_catalog::default_for("history-limit"), Some("2000"));
+    assert_eq!(
+        crate::server::option_catalog::default_for("history-limit"),
+        Some("2000")
+    );
 }
 
 #[test]
 fn option_catalog_default_for_remain_on_exit() {
-    assert_eq!(crate::server::option_catalog::default_for("remain-on-exit"), Some("off"));
+    assert_eq!(
+        crate::server::option_catalog::default_for("remain-on-exit"),
+        Some("off")
+    );
 }
 
 // ════════════════════════════════════════════════════════════════════════════
@@ -504,7 +805,10 @@ fn prompt_history_capped_at_100() {
 #[test]
 fn prompt_history_vi_mode_default_insert() {
     let app = mock_app();
-    assert!(!app.command_vi_normal, "command prompt should start in insert mode");
+    assert!(
+        !app.command_vi_normal,
+        "command prompt should start in insert mode"
+    );
 }
 
 // ════════════════════════════════════════════════════════════════════════════
@@ -526,7 +830,8 @@ fn search_next_wraps_by_default() {
 #[test]
 fn search_next_does_not_wrap_when_off() {
     let mut app = mock_app();
-    app.user_options.insert("wrap-search".to_string(), "off".to_string());
+    app.user_options
+        .insert("wrap-search".to_string(), "off".to_string());
     app.copy_search_matches = vec![(0, 5, 8), (1, 10, 13), (2, 0, 3)];
     app.copy_search_idx = 2; // at last match
     crate::copy_mode::search_next(&mut app);
@@ -558,7 +863,8 @@ fn search_prev_wraps_by_default() {
 #[test]
 fn search_prev_does_not_wrap_when_off() {
     let mut app = mock_app();
-    app.user_options.insert("wrap-search".to_string(), "off".to_string());
+    app.user_options
+        .insert("wrap-search".to_string(), "off".to_string());
     app.copy_search_matches = vec![(0, 5, 8), (1, 10, 13), (2, 0, 3)];
     app.copy_search_idx = 0; // at first match
     crate::copy_mode::search_prev(&mut app);
@@ -643,7 +949,10 @@ fn session_group_can_be_set() {
 fn session_id_is_unique() {
     let app1 = AppState::new("s1".to_string());
     let app2 = AppState::new("s2".to_string());
-    assert_ne!(app1.session_id, app2.session_id, "each AppState should get a unique session_id");
+    assert_ne!(
+        app1.session_id, app2.session_id,
+        "each AppState should get a unique session_id"
+    );
 }
 
 #[test]

--- a/winsmux-app/src-tauri/src/desktop_backend.rs
+++ b/winsmux-app/src-tauri/src/desktop_backend.rs
@@ -30,7 +30,7 @@ pub struct DesktopBoardSummary {
 #[derive(Serialize, Deserialize)]
 pub struct DesktopBoardSnapshot {
     pub summary: DesktopBoardSummary,
-    pub panes: Value,
+    pub panes: Vec<DesktopBoardPane>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -59,15 +59,50 @@ pub struct DesktopInboxSnapshot {
 #[derive(Serialize, Deserialize)]
 pub struct DesktopDigestSummary {
     pub item_count: usize,
+    pub dirty_items: usize,
     pub actionable_items: usize,
     pub review_pending: usize,
     pub review_failed: usize,
 }
 
 #[derive(Serialize, Deserialize)]
+pub struct DesktopBoardPane {
+    pub label: String,
+    pub pane_id: String,
+    pub role: String,
+    pub state: String,
+    pub task: String,
+    pub task_state: String,
+    pub review_state: String,
+    pub branch: String,
+    pub head_sha: String,
+    pub changed_file_count: usize,
+    pub last_event_at: String,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct DesktopDigestItem {
+    pub run_id: String,
+    pub task: String,
+    pub label: String,
+    pub pane_id: String,
+    pub role: String,
+    pub task_state: String,
+    pub review_state: String,
+    pub next_action: String,
+    pub branch: String,
+    pub worktree: String,
+    pub head_sha: String,
+    pub head_short: String,
+    pub changed_file_count: usize,
+    pub changed_files: Vec<String>,
+    pub last_event_at: String,
+}
+
+#[derive(Serialize, Deserialize)]
 pub struct DesktopDigestSnapshot {
     pub summary: DesktopDigestSummary,
-    pub items: Value,
+    pub items: Vec<DesktopDigestItem>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -757,6 +792,8 @@ fn run_winsmux_json(project_dir: Option<String>, args: &[String]) -> Result<Valu
 mod tests {
     use super::*;
     use std::cell::RefCell;
+    use std::fs;
+    use std::path::PathBuf;
 
     struct FakeTransport {
         requests: RefCell<Vec<String>>,
@@ -772,81 +809,77 @@ mod tests {
         }
     }
 
+    fn rust_parity_fixture_path(name: &str) -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .join("..")
+            .join("tests")
+            .join("fixtures")
+            .join("rust-parity")
+            .join(name)
+    }
+
+    fn read_rust_parity_fixture(name: &str) -> Value {
+        let path = rust_parity_fixture_path(name);
+        let raw = fs::read_to_string(&path)
+            .unwrap_or_else(|err| panic!("failed to read fixture {}: {}", path.display(), err));
+        serde_json::from_str(&raw)
+            .unwrap_or_else(|err| panic!("failed to parse fixture {}: {}", path.display(), err))
+    }
+
+    fn rust_parity_summary_snapshot_payload() -> Value {
+        serde_json::json!({
+            "generated_at": "__GENERATED_AT__",
+            "project_dir": "__PROJECT_DIR__",
+            "board": read_rust_parity_fixture("board.json"),
+            "inbox": read_rust_parity_fixture("inbox.json"),
+            "digest": read_rust_parity_fixture("digest.json"),
+            "run_projections": [{
+                "run_id": "task:task-246",
+                "pane_id": "%2",
+                "label": "builder-1",
+                "branch": "worktree-builder-1",
+                "worktree": ".worktrees/builder-1",
+                "head_sha": "abc1234def5678",
+                "head_short": "abc1234",
+                "provider_target": "codex:gpt-5.4",
+                "task": "Build evidence digest",
+                "task_state": "blocked",
+                "review_state": "FAIL",
+                "verification_outcome": "",
+                "security_blocked": "",
+                "changed_files": ["scripts/winsmux-core.ps1"],
+                "next_action": "review_failed",
+                "summary": "Build evidence digest",
+                "reasons": ["review_state=FAIL"],
+                "hypothesis": "result summary should appear in digest",
+                "confidence": 0.88,
+                "observation_pack_ref": ".winsmux/observation-packs/observation-pack-__ID__.json",
+                "consultation_ref": ".winsmux/consultations/consult-result-__ID__.json"
+            }]
+        })
+    }
+
     #[test]
     fn load_desktop_summary_snapshot_deserializes_transport_payload() {
         let transport = FakeTransport {
             requests: RefCell::new(Vec::new()),
-            response: serde_json::json!({
-                "generated_at": "2026-04-13T00:00:00Z",
-                "project_dir": "C:/repo",
-                "board": {
-                    "summary": {
-                        "pane_count": 1,
-                        "dirty_panes": 0,
-                        "review_pending": 3,
-                        "review_failed": 0,
-                        "review_passed": 0,
-                        "tasks_in_progress": 1,
-                        "tasks_blocked": 2
-                    },
-                    "panes": []
-                },
-                "inbox": {
-                    "summary": { "item_count": 1 },
-                    "items": [{
-                        "kind": "task",
-                        "message": "Investigate",
-                        "label": "builder-1",
-                        "pane_id": "%4",
-                        "task_state": "blocked",
-                        "review_state": "PENDING",
-                        "branch": "codex/task",
-                        "changed_file_count": 2
-                    }]
-                },
-                "digest": {
-                    "summary": {
-                        "item_count": 1,
-                        "actionable_items": 1,
-                        "review_pending": 1,
-                        "review_failed": 0
-                    },
-                    "items": []
-                },
-                "run_projections": [{
-                    "run_id": "run-1",
-                    "pane_id": "%1",
-                    "label": "builder-1",
-                    "branch": "codex/task",
-                    "worktree": ".worktrees/builder-1",
-                    "head_sha": "abc1234def5678",
-                    "head_short": "abc1234",
-                    "provider_target": "codex:gpt-5.4",
-                    "task": "Implement",
-                    "task_state": "in_progress",
-                    "review_state": "PENDING",
-                    "verification_outcome": "",
-                    "security_blocked": "",
-                    "changed_files": ["winsmux-app/src/main.ts"],
-                    "next_action": "review_requested",
-                    "summary": "Implement",
-                    "reasons": ["task_state=in_progress"],
-                    "hypothesis": "projection should surface detail",
-                    "confidence": 0.75,
-                    "observation_pack_ref": "obs-1",
-                    "consultation_ref": "consult-1"
-                }]
-            }),
+            response: rust_parity_summary_snapshot_payload(),
         };
 
         let snapshot = load_desktop_summary_snapshot(&transport, None).unwrap();
 
-        assert_eq!(snapshot.project_dir, "C:/repo");
-        assert_eq!(snapshot.board.summary.pane_count, 1);
-        assert_eq!(snapshot.board.summary.tasks_blocked, 2);
-        assert_eq!(snapshot.inbox.summary.item_count, 1);
-        assert_eq!(snapshot.inbox.items[0].pane_id, "%4");
+        assert_eq!(snapshot.project_dir, "__PROJECT_DIR__");
+        assert_eq!(snapshot.board.summary.pane_count, 2);
+        assert_eq!(snapshot.board.summary.tasks_blocked, 0);
+        assert_eq!(snapshot.board.panes[0].pane_id, "%2");
+        assert_eq!(snapshot.board.panes[0].last_event_at, "__LAST_EVENT_AT__");
+        assert_eq!(snapshot.inbox.summary.item_count, 4);
+        assert_eq!(snapshot.inbox.items[0].pane_id, "%6");
         assert_eq!(snapshot.digest.summary.actionable_items, 1);
+        assert_eq!(snapshot.digest.summary.dirty_items, 1);
+        assert_eq!(snapshot.digest.items[0].run_id, "task:task-246");
+        assert_eq!(snapshot.digest.items[0].last_event_at, "__LAST_EVENT_AT__");
         assert_eq!(snapshot.run_projections.len(), 1);
         assert_eq!(
             transport.requests.borrow().as_slice(),
@@ -856,45 +889,27 @@ mod tests {
 
     #[test]
     fn load_desktop_summary_snapshot_rejects_missing_required_narrowed_fields() {
+        let mut response = rust_parity_summary_snapshot_payload();
+        response["board"]["summary"]
+            .as_object_mut()
+            .expect("board.summary must be an object")
+            .remove("tasks_blocked");
+        response["inbox"]["items"][0]
+            .as_object_mut()
+            .expect("inbox.items[0] must be an object")
+            .remove("changed_file_count");
+        response["board"]["panes"][0]
+            .as_object_mut()
+            .expect("board.panes[0] must be an object")
+            .remove("pane_id");
+        response["digest"]["items"][0]
+            .as_object_mut()
+            .expect("digest.items[0] must be an object")
+            .remove("last_event_at");
+
         let transport = FakeTransport {
             requests: RefCell::new(Vec::new()),
-            response: serde_json::json!({
-                "generated_at": "2026-04-13T00:00:00Z",
-                "project_dir": "C:/repo",
-                "board": {
-                    "summary": {
-                        "pane_count": 1,
-                        "dirty_panes": 0,
-                        "review_pending": 0,
-                        "review_failed": 0,
-                        "review_passed": 0,
-                        "tasks_in_progress": 1
-                    },
-                    "panes": []
-                },
-                "inbox": {
-                    "summary": { "item_count": 1 },
-                    "items": [{
-                        "kind": "task",
-                        "message": "Investigate",
-                        "label": "builder-1",
-                        "pane_id": "%4",
-                        "task_state": "blocked",
-                        "review_state": "PENDING",
-                        "branch": "codex/task"
-                    }]
-                },
-                "digest": {
-                    "summary": {
-                        "item_count": 1,
-                        "actionable_items": 1,
-                        "review_pending": 1,
-                        "review_failed": 0
-                    },
-                    "items": []
-                },
-                "run_projections": []
-            }),
+            response,
         };
 
         let err = match load_desktop_summary_snapshot(&transport, None) {
@@ -902,7 +917,12 @@ mod tests {
             Err(err) => err,
         };
 
-        assert!(err.contains("tasks_blocked") || err.contains("changed_file_count"));
+        assert!(
+            err.contains("tasks_blocked")
+                || err.contains("changed_file_count")
+                || err.contains("pane_id")
+                || err.contains("last_event_at")
+        );
     }
 
     #[test]
@@ -1121,28 +1141,7 @@ mod tests {
     fn handle_desktop_json_rpc_routes_summary_snapshot() {
         let transport = FakeTransport {
             requests: RefCell::new(Vec::new()),
-            response: serde_json::json!({
-                "generated_at": "2026-04-13T00:00:00Z",
-                "project_dir": "C:/repo",
-                "board": {
-                    "summary": {
-                        "pane_count": 1,
-                        "dirty_panes": 0,
-                        "review_pending": 0,
-                        "review_failed": 0,
-                        "review_passed": 0,
-                        "tasks_in_progress": 0,
-                        "tasks_blocked": 1
-                    },
-                    "panes": []
-                },
-                "inbox": { "summary": { "item_count": 0 }, "items": [] },
-                "digest": {
-                    "summary": { "item_count": 1, "actionable_items": 1, "review_pending": 1, "review_failed": 0 },
-                    "items": []
-                },
-                "run_projections": []
-            }),
+            response: rust_parity_summary_snapshot_payload(),
         };
         let response = handle_desktop_json_rpc(
             &transport,
@@ -1158,9 +1157,13 @@ mod tests {
         match response {
             DesktopJsonRpcResponse::Success { id, result, .. } => {
                 assert_eq!(id, serde_json::json!("req-1"));
-                assert_eq!(result["project_dir"], "C:/repo");
-                assert_eq!(result["board"]["summary"]["tasks_blocked"], 1);
+                assert_eq!(result["project_dir"], "__PROJECT_DIR__");
+                assert_eq!(result["board"]["summary"]["tasks_blocked"], 0);
                 assert_eq!(result["digest"]["summary"]["actionable_items"], 1);
+                assert_eq!(result["digest"]["summary"]["dirty_items"], 1);
+                assert_eq!(result["inbox"]["items"][0]["pane_id"], "%6");
+                assert_eq!(result["board"]["panes"][0]["pane_id"], "%2");
+                assert_eq!(result["digest"]["items"][0]["run_id"], "task:task-246");
             }
             DesktopJsonRpcResponse::Error { error, .. } => {
                 panic!("expected success, got {:?}", error);


### PR DESCRIPTION
## Summary\n- tighten Rust parity tests by deserializing shared fixtures into typed test structs instead of spot-checking raw JSON\n- reuse the same shared fixtures in the Tauri desktop backend tests instead of inline payload copies\n- type nested board pane and digest item arrays in DesktopSummarySnapshot and add negative coverage for missing nested fields\n\n## Validation\n- cargo test --manifest-path C:/Users/komei/Documents/Projects/apps/winsmux/core/Cargo.toml rust_parity_\n- cargo test --manifest-path C:/Users/komei/Documents/Projects/apps/winsmux/winsmux-app/src-tauri/Cargo.toml desktop_backend\n- cargo test --manifest-path C:/Users/komei/Documents/Projects/apps/winsmux/winsmux-app/src-tauri/Cargo.toml\n- pwsh -NoProfile -File scripts/git-guard.ps1 -Mode full\n- pwsh -NoProfile -File scripts/audit-public-surface.ps1\n\n## Review\n- review subagent found partial typed parity coverage and raw nested arrays in the backend snapshot contract\n- those warnings were addressed before PR creation