### PR TITLE
fix: normalize operator-facing winsmux branding

### DIFF
--- a/core/src/cli.rs
+++ b/core/src/cli.rs
@@ -1,17 +1,23 @@
 use crate::types::{ParsedTarget, VERSION};
 
+fn canonical_program_name_for_display(name: &str) -> String {
+    let normalized = name.to_lowercase().replace(".exe", "");
+    match normalized.as_str() {
+        "" | "winsmux" | "psmux" | "pmux" | "tmux" => "winsmux".to_string(),
+        other => other.to_string(),
+    }
+}
+
 pub fn get_program_name() -> String {
     std::env::current_exe()
         .ok()
         .and_then(|p| p.file_stem().map(|s| s.to_string_lossy().to_string()))
-        .unwrap_or_else(|| "psmux".to_string())
-        .to_lowercase()
-        .replace(".exe", "")
+        .map(|name| canonical_program_name_for_display(&name))
+        .unwrap_or_else(|| "winsmux".to_string())
 }
 
-pub fn print_help() {
-    let prog = get_program_name();
-    println!(r#"{prog} v{ver} - Terminal multiplexer for Windows (tmux alternative)
+fn help_text(prog: &str) -> String {
+    format!(r#"{prog} v{ver} - Terminal multiplexer for Windows (tmux alternative)
 
 USAGE:
     {prog} [COMMAND] [OPTIONS]
@@ -158,7 +164,7 @@ TARGET SYNTAX (-t):
     work:2                  Window 2 in session "work"
 
 CONFIGURATION:
-    psmux reads config on startup from the first file found:
+    winsmux reads config on startup from the first compatible file found:
         %USERPROFILE%\.psmux.conf
         %USERPROFILE%\.psmuxrc
         %USERPROFILE%\.tmux.conf
@@ -184,7 +190,7 @@ CONFIGURATION:
         bind-key -T prefix v split-window -v
 
 SHELL CONFIGURATION:
-    psmux launches PowerShell 7 (pwsh) by default. To change:
+    winsmux launches PowerShell 7 (pwsh) by default. To change:
 
     Use cmd.exe:
         set -g default-shell cmd
@@ -203,8 +209,8 @@ SHELL CONFIGURATION:
         set -g default-shell nu
 
     Launch a window with a specific command:
-        psmux new-window -- cmd /K echo hello
-        psmux new-session -- python
+        {prog} new-window -- cmd /K echo hello
+        {prog} new-session -- python
 
 SET OPTIONS (use with: set -g <option> <value>):
     prefix              Key  Prefix key (default: C-b)
@@ -342,7 +348,7 @@ ENVIRONMENT VARIABLES:
     PSMUX_CURSOR_STYLE       Cursor style (block, underline, bar)
     PSMUX_CURSOR_BLINK       Cursor blinking (1/0)
     PSMUX_DIM_PREDICTIONS    Prediction dimming (1 to enable)
-    TMUX                     Set inside psmux panes (tmux-compatible)
+    TMUX                     Set inside winsmux panes (tmux-compatible)
     TMUX_PANE                Current pane ID (e.g. %1)
 
 EXAMPLES:
@@ -358,10 +364,15 @@ EXAMPLES:
     {prog} set -g default-shell cmd Use cmd.exe as default shell
     {prog} source-file ~/.psmux.conf Reload config
 
-NOTE: psmux ships as 'psmux', 'pmux', and 'tmux' - use whichever you prefer!
+NOTE: winsmux preserves compatibility aliases 'psmux', 'pmux', and 'tmux' where supported.
 
-For more information: https://github.com/psmux/psmux
-"#, prog = prog, ver = VERSION);
+For more information: https://github.com/Sora-bluesky/winsmux
+"#, prog = prog, ver = VERSION)
+}
+
+pub fn print_help() {
+    let prog = get_program_name();
+    println!("{}", help_text(&prog));
 }
 
 pub fn print_version() {
@@ -369,8 +380,8 @@ pub fn print_version() {
     println!("{} {}", prog, VERSION);
 }
 
-pub fn print_commands() {
-    println!(r#"Available commands:
+fn commands_text() -> &'static str {
+    r#"Available commands:
   attach-session (attach)   - Attach to a session
   bind-key (bind)           - Bind a key to a command
   break-pane                - Break a pane into a new window
@@ -392,7 +403,7 @@ pub fn print_commands() {
   if-shell (if)             - Conditional command execution
   join-pane                 - Join a pane to a window
   kill-pane                 - Kill a pane
-  kill-server               - Kill the psmux server
+  kill-server               - Kill the winsmux server
   kill-session              - Kill a session
   kill-window               - Kill a window
   last-pane                 - Select the previously active pane
@@ -448,7 +459,11 @@ pub fn print_commands() {
   unlink-window (unlinkw)   - Unlink a window
   wait-for (wait)           - Wait for a signal
   zoom-pane (zoom)          - Toggle pane zoom
-"#);
+"#
+}
+
+pub fn print_commands() {
+    println!("{}", commands_text());
 }
 
 /// Parse a tmux-style target specification
@@ -523,6 +538,37 @@ pub fn parse_target(target: &str) -> ParsedTarget {
     }
     
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{canonical_program_name_for_display, commands_text, help_text};
+
+    #[test]
+    fn canonical_program_name_prefers_winsmux_for_legacy_aliases() {
+        for alias in ["winsmux", "winsmux.exe", "psmux", "pmux.exe", "tmux"] {
+            assert_eq!(canonical_program_name_for_display(alias), "winsmux");
+        }
+        assert_eq!(canonical_program_name_for_display("custom-tool.exe"), "custom-tool");
+    }
+
+    #[test]
+    fn help_text_uses_winsmux_operator_wording() {
+        let text = help_text("winsmux");
+        assert!(text.contains("winsmux reads config on startup from the first compatible file found:"));
+        assert!(text.contains("winsmux launches PowerShell 7 (pwsh) by default."));
+        assert!(text.contains("winsmux preserves compatibility aliases 'psmux', 'pmux', and 'tmux' where supported."));
+        assert!(text.contains("For more information: https://github.com/Sora-bluesky/winsmux"));
+        assert!(!text.contains("psmux reads config on startup from the first file found:"));
+        assert!(!text.contains("psmux launches PowerShell 7 (pwsh) by default."));
+    }
+
+    #[test]
+    fn commands_text_uses_winsmux_server_wording() {
+        let text = commands_text();
+        assert!(text.contains("kill-server               - Kill the winsmux server"));
+        assert!(!text.contains("Kill the psmux server"));
+    }
 }
 
 /// Extract the session name from a target string (for port file lookup)

--- a/core/src/commands.rs
+++ b/core/src/commands.rs
@@ -1375,7 +1375,7 @@ pub fn execute_command_string(app: &mut AppState, cmd: &str) -> io::Result<()> {
             if let Some(port) = app.control_port {
                 let _ = send_control_to_port(port, "server-info\n", &app.session_key);
             } else {
-                let output = format!("psmux {}\nSession: {}\nWindows: {}\nActive: {}\n",
+                let output = format!("winsmux {}\nSession: {}\nWindows: {}\nActive: {}\n",
                     crate::types::VERSION, app.session_name, app.windows.len(), app.active_idx);
                 show_output_popup(app, "server-info", output);
             }

--- a/core/src/server/mod.rs
+++ b/core/src/server/mod.rs
@@ -69,6 +69,21 @@ fn should_spawn_warm_server(app: &AppState) -> bool {
     app.warm_enabled && app.session_name != "__warm__" && !app.destroy_unattached
 }
 
+fn build_server_info_text(app: &AppState) -> String {
+    format!(
+        "winsmux {} (Windows)\npid: {}\nsession: {}\nwindows: {}\nuptime: {}s\nsocket: {}",
+        VERSION,
+        std::process::id(),
+        app.session_name,
+        app.windows.len(),
+        (chrono::Local::now() - app.created_at).num_seconds(),
+        {
+            let home = env::var("USERPROFILE").or_else(|_| env::var("HOME")).unwrap_or_default();
+            format!("{}\\.psmux\\{}.port", home, app.port_file_base())
+        }
+    )
+}
+
 /// Check if the active pane is currently squelched (hiding injected cd+cls).
 /// Uses the non-consuming `squelch_cleared()` so the layout serialiser can
 /// still properly consume the sentinel via `take_squelch_cleared()`.
@@ -3164,19 +3179,7 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                     let _ = resp.send(output);
                 }
                 CtrlReq::ServerInfo(resp) => {
-                    let info = format!(
-                        "psmux {} (Windows)\npid: {}\nsession: {}\nwindows: {}\nuptime: {}s\nsocket: {}",
-                        VERSION,
-                        std::process::id(),
-                        app.session_name,
-                        app.windows.len(),
-                        (chrono::Local::now() - app.created_at).num_seconds(),
-                        {
-                            let home = env::var("USERPROFILE").or_else(|_| env::var("HOME")).unwrap_or_default();
-                            format!("{}\\.psmux\\{}.port", home, app.port_file_base())
-                        }
-                    );
-                    let _ = resp.send(info);
+                    let _ = resp.send(build_server_info_text(&app));
                 }
                 CtrlReq::SendPrefix => {
                     // Send the prefix key to the active pane as if typed

--- a/core/tests-rs/test_commands_audit.rs
+++ b/core/tests-rs/test_commands_audit.rs
@@ -458,7 +458,7 @@ fn server_info_shows_popup_with_version_and_session() {
     execute_command_string(&mut app, "server-info").unwrap();
     let (cmd, out) = extract_popup(&app);
     assert_eq!(cmd, "server-info");
-    assert!(out.contains("psmux"), "should contain 'psmux'");
+    assert!(out.contains("winsmux"), "should contain 'winsmux'");
     assert!(out.contains("my_sess"), "should contain session name");
     assert!(out.contains("Windows:"), "should contain window count");
 }

--- a/core/tests-rs/test_server.rs
+++ b/core/tests-rs/test_server.rs
@@ -1,3 +1,4 @@
+use super::build_server_info_text;
 use super::should_spawn_warm_server;
 use super::helpers::combined_data_version;
 use crate::types::AppState;
@@ -131,6 +132,37 @@ fn warm_server_is_disabled_when_warm_enabled_is_false() {
 fn warm_server_is_allowed_for_normal_sessions() {
     let app = AppState::new("demo".to_string());
     assert!(should_spawn_warm_server(&app));
+}
+
+#[test]
+fn server_info_text_uses_winsmux_branding() {
+    let mut app = AppState::new("demo".to_string());
+    app.windows.push(crate::types::Window {
+        root: crate::types::Node::Split {
+            kind: crate::types::LayoutKind::Horizontal,
+            sizes: vec![],
+            children: vec![],
+        },
+        active_path: vec![],
+        name: "shell".to_string(),
+        id: 0,
+        activity_flag: false,
+        bell_flag: false,
+        silence_flag: false,
+        last_output_time: std::time::Instant::now(),
+        last_seen_version: 0,
+        manual_rename: false,
+        layout_index: 0,
+        pane_mru: vec![],
+        zoom_saved: None,
+        linked_from: None,
+    });
+
+    let text = build_server_info_text(&app);
+    assert!(text.starts_with("winsmux "));
+    assert!(text.contains("session: demo"));
+    assert!(text.contains("windows: 1"));
+    assert!(!text.contains("psmux "));
 }
 
 // ── Options get/set tests ───────────────────────────────────────


### PR DESCRIPTION
## Summary
- normalize operator-facing help and server-info branding to `winsmux`
- treat `psmux` / `pmux` / `tmux` as compatibility aliases for display surfaces
- add Rust regressions for canonical alias mapping and server-side branding

## Testing
- cargo test --manifest-path core/Cargo.toml canonical_program_name_prefers_winsmux_for_legacy_aliases
- cargo test --manifest-path core/Cargo.toml help_text_uses_winsmux_operator_wording
- cargo test --manifest-path core/Cargo.toml commands_text_uses_winsmux_server_wording
- cargo test --manifest-path core/Cargo.toml server_info_shows_popup_with_version_and_session
- cargo test --manifest-path core/Cargo.toml server_info_text_uses_winsmux_branding
- pwsh -NoProfile -File .\scripts\git-guard.ps1 -Mode full
- pwsh -NoProfile -File .\scripts\audit-public-surface.ps1

Closes #423.