### PR TITLE
refactor: share rust parity fixture helpers

### DIFF
--- a/.githooks/pre-commit-whitelist.ps1
+++ b/.githooks/pre-commit-whitelist.ps1
@@ -30,6 +30,7 @@ $whitelistPatterns = @(
     'tests/PublicSurfacePolicy.Tests.ps1',
     'tests/HarnessContract.Tests.ps1',
     'tests/fixtures/rust-parity/*.json',
+    'tests/test_support/rust_parity.rs',
     'winsmux-core/**',
     '.claude/CLAUDE.md',
     '.claude/hooks/**',

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,8 @@ tasks/*
 tests/
 !tests/
 tests/*
+!tests/test_support/
+!tests/test_support/rust_parity.rs
 !tests/Integration.GateEnforcement.Tests.ps1
 !tests/Integration.MultiAgent.Tests.ps1
 !tests/Runtime.VaultInject.Tests.ps1

--- a/core/tests-rs/test_parity.rs
+++ b/core/tests-rs/test_parity.rs
@@ -1,10 +1,14 @@
 use crate::types::{AppState, ClientInfo};
-use serde::de::DeserializeOwned;
 use serde::Deserialize;
-use serde_json::Value;
 use std::collections::HashMap;
-use std::fs;
 use std::path::PathBuf;
+
+mod rust_parity_support {
+    include!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../tests/test_support/rust_parity.rs"
+    ));
+}
 
 fn mock_app() -> AppState {
     let mut app = AppState::new("test_session".to_string());
@@ -13,29 +17,12 @@ fn mock_app() -> AppState {
     app
 }
 
-fn rust_parity_fixture_path(name: &str) -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("..")
-        .join("tests")
-        .join("fixtures")
-        .join("rust-parity")
-        .join(name)
+fn rust_parity_repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..")
 }
 
-fn read_rust_parity_fixture(name: &str) -> Value {
-    let path = rust_parity_fixture_path(name);
-    let raw = fs::read_to_string(&path)
-        .unwrap_or_else(|err| panic!("failed to read fixture {}: {}", path.display(), err));
-    serde_json::from_str(&raw)
-        .unwrap_or_else(|err| panic!("failed to parse fixture {}: {}", path.display(), err))
-}
-
-fn read_rust_parity_fixture_typed<T: DeserializeOwned>(name: &str) -> T {
-    let path = rust_parity_fixture_path(name);
-    let raw = fs::read_to_string(&path)
-        .unwrap_or_else(|err| panic!("failed to read fixture {}: {}", path.display(), err));
-    serde_json::from_str(&raw)
-        .unwrap_or_else(|err| panic!("failed to parse typed fixture {}: {}", path.display(), err))
+fn read_rust_parity_fixture_typed<T: serde::de::DeserializeOwned>(name: &str) -> T {
+    rust_parity_support::read_json_fixture_typed(&rust_parity_repo_root(), name)
 }
 
 #[derive(Deserialize)]

--- a/tests/test_support/rust_parity.rs
+++ b/tests/test_support/rust_parity.rs
@@ -1,0 +1,29 @@
+use serde::de::DeserializeOwned;
+use serde_json::Value;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+pub fn read_json_fixture(repo_root: &Path, name: &str) -> Value {
+    let path = fixture_path(repo_root, name);
+    let raw = fs::read_to_string(&path)
+        .unwrap_or_else(|err| panic!("failed to read fixture {}: {}", path.display(), err));
+    serde_json::from_str(&raw)
+        .unwrap_or_else(|err| panic!("failed to parse fixture {}: {}", path.display(), err))
+}
+
+#[allow(dead_code)]
+pub fn read_json_fixture_typed<T: DeserializeOwned>(repo_root: &Path, name: &str) -> T {
+    let path = fixture_path(repo_root, name);
+    let raw = fs::read_to_string(&path)
+        .unwrap_or_else(|err| panic!("failed to read fixture {}: {}", path.display(), err));
+    serde_json::from_str(&raw)
+        .unwrap_or_else(|err| panic!("failed to parse typed fixture {}: {}", path.display(), err))
+}
+
+fn fixture_path(repo_root: &Path, name: &str) -> PathBuf {
+    repo_root
+        .join("tests")
+        .join("fixtures")
+        .join("rust-parity")
+        .join(name)
+}

--- a/winsmux-app/src-tauri/src/desktop_backend.rs
+++ b/winsmux-app/src-tauri/src/desktop_backend.rs
@@ -785,8 +785,14 @@ fn run_winsmux_json(project_dir: Option<String>, args: &[String]) -> Result<Valu
 mod tests {
     use super::*;
     use std::cell::RefCell;
-    use std::fs;
     use std::path::PathBuf;
+
+    mod rust_parity_support {
+        include!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../tests/test_support/rust_parity.rs"
+        ));
+    }
 
     struct FakeTransport {
         requests: RefCell<Vec<String>>,
@@ -802,22 +808,14 @@ mod tests {
         }
     }
 
-    fn rust_parity_fixture_path(name: &str) -> PathBuf {
+    fn rust_parity_repo_root() -> PathBuf {
         PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .join("..")
             .join("..")
-            .join("tests")
-            .join("fixtures")
-            .join("rust-parity")
-            .join(name)
     }
 
     fn read_rust_parity_fixture(name: &str) -> Value {
-        let path = rust_parity_fixture_path(name);
-        let raw = fs::read_to_string(&path)
-            .unwrap_or_else(|err| panic!("failed to read fixture {}: {}", path.display(), err));
-        serde_json::from_str(&raw)
-            .unwrap_or_else(|err| panic!("failed to parse fixture {}: {}", path.display(), err))
+        rust_parity_support::read_json_fixture(&rust_parity_repo_root(), name)
     }
 
     fn rust_parity_explain_payload() -> Value {


### PR DESCRIPTION
## Summary
- move Rust parity fixture loading into a shared repo-level test support helper
- keep repo-root resolution local to `core` and `winsmux-app` tests
- whitelist the shared helper as tracked contributor/test surface

## Testing
- `cargo test --manifest-path core/Cargo.toml rust_parity_`
- `cargo test --manifest-path winsmux-app/src-tauri/Cargo.toml desktop_backend`
- `pwsh -NoProfile -File ./scripts/git-guard.ps1 -Mode full`
- `pwsh -NoProfile -File ./scripts/audit-public-surface.ps1`

## Notes
- narrow refactor only; no production runtime changes