### PR TITLE
fix: tighten explain payload parity contract

### DIFF
--- a/winsmux-app/src-tauri/src/desktop_backend.rs
+++ b/winsmux-app/src-tauri/src/desktop_backend.rs
@@ -1078,6 +1078,54 @@ mod tests {
     }
 
     #[test]
+    fn load_desktop_run_explain_rejects_missing_run_worktree() {
+        let mut response = rust_parity_explain_payload();
+        response["run"]
+            .as_object_mut()
+            .expect("run must be an object")
+            .remove("worktree");
+
+        let transport = FakeTransport {
+            requests: RefCell::new(Vec::new()),
+            response,
+        };
+
+        let err = match load_desktop_run_explain(&transport, "task:task-256".to_string(), None) {
+            Ok(_) => panic!("expected explain payload parse failure"),
+            Err(err) => err,
+        };
+
+        assert!(
+            err.contains("worktree"),
+            "unexpected explain parse error: {err}"
+        );
+    }
+
+    #[test]
+    fn load_desktop_run_explain_rejects_missing_evidence_verification_outcome() {
+        let mut response = rust_parity_explain_payload();
+        response["evidence_digest"]
+            .as_object_mut()
+            .expect("evidence_digest must be an object")
+            .remove("verification_outcome");
+
+        let transport = FakeTransport {
+            requests: RefCell::new(Vec::new()),
+            response,
+        };
+
+        let err = match load_desktop_run_explain(&transport, "task:task-256".to_string(), None) {
+            Ok(_) => panic!("expected explain payload parse failure"),
+            Err(err) => err,
+        };
+
+        assert!(
+            err.contains("verification_outcome"),
+            "unexpected explain parse error: {err}"
+        );
+    }
+
+    #[test]
     fn load_desktop_run_explain_rejects_missing_evidence_security_blocked() {
         let mut response = rust_parity_explain_payload();
         response["evidence_digest"]

--- a/winsmux-app/src/desktopClient.ts
+++ b/winsmux-app/src/desktopClient.ts
@@ -151,19 +151,19 @@ export interface DesktopSummarySnapshot {
 }
 
 export interface DesktopExplainPayload {
-  generated_at?: string;
-  project_dir?: string;
+  generated_at: string;
+  project_dir: string;
   run: {
     run_id: string;
     task: string;
     state: string;
     task_state: string;
     review_state: string;
-    provider_target?: string;
-    agent_role?: string;
+    provider_target: string;
+    agent_role: string;
     branch: string;
     head_sha: string;
-    worktree?: string;
+    worktree: string;
     changed_files: string[];
   };
   explanation: {
@@ -175,8 +175,8 @@ export interface DesktopExplainPayload {
     next_action: string;
     changed_file_count: number;
     changed_files: string[];
-    verification_outcome?: string;
-    security_blocked?: string;
+    verification_outcome: string;
+    security_blocked: string;
   };
   recent_events: Array<{
     timestamp: string;


### PR DESCRIPTION
## Summary
- tighten the TypeScript desktop explain payload types to match the current Rust producer contract
- require `provider_target`, `agent_role`, `worktree`, `verification_outcome`, and `security_blocked` on the explain path
- add fail-closed regressions for missing `worktree` and `verification_outcome`

## Testing
- cargo test --manifest-path winsmux-app/src-tauri/Cargo.toml desktop_backend
- cmd /c npm run build
- pwsh -NoProfile -File .\scripts\git-guard.ps1 -Mode full
- pwsh -NoProfile -File .\scripts\audit-public-surface.ps1
