### PR TITLE
docs: make rust learning index canonical

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,9 +114,11 @@ When updating planning:
 
 When local operator handoff work includes Rust, Cargo, Tauri, or Rust-adjacent commands used in winsmux development, Codex must also update the beginner-friendly learning note resolved from one of these sources:
 
-- `WINSMUX_LEARNING_ROOT\Rust learning note.md`
-- `%LOCALAPPDATA%\winsmux\learning-root.txt` marker + `Rust learning note.md`
+- `WINSMUX_LEARNING_ROOT\Rust learning note\00 Index.md`
+- `%LOCALAPPDATA%\winsmux\learning-root.txt` marker + `Rust learning note\00 Index.md`
 - compatibility fallback:
+  - `WINSMUX_LEARNING_ROOT\Rust learning note.md`
+  - `%LOCALAPPDATA%\winsmux\learning-root.txt` marker + `Rust learning note.md`
   - `WINSMUX_LEARNING_ROOT\Rust Commands - winsmux.md`
   - `%LOCALAPPDATA%\winsmux\learning-root.txt` marker + `Rust Commands - winsmux.md`
 
@@ -124,7 +126,7 @@ Rules:
 
 1. Keep the note outside the repository. Never commit files under the external `Learning` path.
 2. Update the note during handoff in the same session that used the command, not later.
-3. Prefer `Rust learning note.md` as the canonical filename for new updates. Use the old filename only as a backward-compatibility fallback.
+3. Prefer `Rust learning note/00 Index.md` as the canonical entry page for new updates. Use `Rust learning note.md` or `Rust Commands - winsmux.md` only as backward-compatibility fallbacks.
 4. Every Rust-adjacent session note update must preserve these three fields for each command or concept entry:
    - the command or concept itself,
    - one concrete example from winsmux work,
@@ -135,7 +137,7 @@ Rules:
    - one concrete example from winsmux work.
 6. Prefer updating existing entries over adding duplicates.
 7. Keep the note structure readable in Obsidian sidebar form.
-   - Maintain the root `Rust learning note.md` as the entry page.
+   - Maintain `Rust learning note/00 Index.md` as the entry page.
    - Maintain numbered chapter notes under `Rust learning note/`.
    - Update the index note when a new chapter note is added.
 8. If the session did not use or discuss Rust-adjacent commands, no learning-note update is required.

--- a/winsmux-app/src-tauri/src/desktop_backend.rs
+++ b/winsmux-app/src-tauri/src/desktop_backend.rs
@@ -1078,6 +1078,54 @@ mod tests {
     }
 
     #[test]
+    fn load_desktop_run_explain_rejects_missing_run_worktree() {
+        let mut response = rust_parity_explain_payload();
+        response["run"]
+            .as_object_mut()
+            .expect("run must be an object")
+            .remove("worktree");
+
+        let transport = FakeTransport {
+            requests: RefCell::new(Vec::new()),
+            response,
+        };
+
+        let err = match load_desktop_run_explain(&transport, "task:task-256".to_string(), None) {
+            Ok(_) => panic!("expected explain payload parse failure"),
+            Err(err) => err,
+        };
+
+        assert!(
+            err.contains("worktree"),
+            "unexpected explain parse error: {err}"
+        );
+    }
+
+    #[test]
+    fn load_desktop_run_explain_rejects_missing_evidence_verification_outcome() {
+        let mut response = rust_parity_explain_payload();
+        response["evidence_digest"]
+            .as_object_mut()
+            .expect("evidence_digest must be an object")
+            .remove("verification_outcome");
+
+        let transport = FakeTransport {
+            requests: RefCell::new(Vec::new()),
+            response,
+        };
+
+        let err = match load_desktop_run_explain(&transport, "task:task-256".to_string(), None) {
+            Ok(_) => panic!("expected explain payload parse failure"),
+            Err(err) => err,
+        };
+
+        assert!(
+            err.contains("verification_outcome"),
+            "unexpected explain parse error: {err}"
+        );
+    }
+
+    #[test]
     fn load_desktop_run_explain_rejects_missing_evidence_security_blocked() {
         let mut response = rust_parity_explain_payload();
         response["evidence_digest"]

--- a/winsmux-app/src/desktopClient.ts
+++ b/winsmux-app/src/desktopClient.ts
@@ -151,19 +151,19 @@ export interface DesktopSummarySnapshot {
 }
 
 export interface DesktopExplainPayload {
-  generated_at?: string;
-  project_dir?: string;
+  generated_at: string;
+  project_dir: string;
   run: {
     run_id: string;
     task: string;
     state: string;
     task_state: string;
     review_state: string;
-    provider_target?: string;
-    agent_role?: string;
+    provider_target: string;
+    agent_role: string;
     branch: string;
     head_sha: string;
-    worktree?: string;
+    worktree: string;
     changed_files: string[];
   };
   explanation: {
@@ -175,8 +175,8 @@ export interface DesktopExplainPayload {
     next_action: string;
     changed_file_count: number;
     changed_files: string[];
-    verification_outcome?: string;
-    security_blocked?: string;
+    verification_outcome: string;
+    security_blocked: string;
   };
   recent_events: Array<{
     timestamp: string;


### PR DESCRIPTION
## Summary
- make `Rust learning note/00 Index.md` the canonical learning note entry page
- keep standalone note filenames as compatibility fallbacks only in the repo contract
- align the Rust learning workflow with the Obsidian sidebar-first structure

## Testing
- pwsh -NoProfile -File .\scripts\git-guard.ps1 -Mode full
- pwsh -NoProfile -File .\scripts\audit-public-surface.ps1
