### PR TITLE
fix: tighten desktop digest parity contract

### DIFF
--- a/winsmux-app/src-tauri/src/desktop_backend.rs
+++ b/winsmux-app/src-tauri/src/desktop_backend.rs
@@ -940,6 +940,54 @@ mod tests {
     }
 
     #[test]
+    fn load_desktop_summary_snapshot_rejects_missing_digest_worktree() {
+        let mut response = rust_parity_summary_snapshot_payload();
+        response["digest"]["items"][0]
+            .as_object_mut()
+            .expect("digest.items[0] must be an object")
+            .remove("worktree");
+
+        let transport = FakeTransport {
+            requests: RefCell::new(Vec::new()),
+            response,
+        };
+
+        let err = match load_desktop_summary_snapshot(&transport, None) {
+            Ok(_) => panic!("expected summary snapshot parse failure for missing worktree"),
+            Err(err) => err,
+        };
+
+        assert!(
+            err.contains("worktree"),
+            "expected missing worktree error, got {err}"
+        );
+    }
+
+    #[test]
+    fn load_desktop_summary_snapshot_rejects_missing_digest_head_sha() {
+        let mut response = rust_parity_summary_snapshot_payload();
+        response["digest"]["items"][0]
+            .as_object_mut()
+            .expect("digest.items[0] must be an object")
+            .remove("head_sha");
+
+        let transport = FakeTransport {
+            requests: RefCell::new(Vec::new()),
+            response,
+        };
+
+        let err = match load_desktop_summary_snapshot(&transport, None) {
+            Ok(_) => panic!("expected summary snapshot parse failure for missing head_sha"),
+            Err(err) => err,
+        };
+
+        assert!(
+            err.contains("head_sha"),
+            "expected missing head_sha error, got {err}"
+        );
+    }
+
+    #[test]
     fn load_desktop_run_explain_uses_explain_command() {
         let transport = FakeTransport {
             requests: RefCell::new(Vec::new()),

--- a/winsmux-app/src/desktopClient.ts
+++ b/winsmux-app/src/desktopClient.ts
@@ -95,8 +95,8 @@ export interface DesktopDigestItem {
   review_state: string;
   next_action: string;
   branch: string;
-  worktree?: string;
-  head_sha?: string;
+  worktree: string;
+  head_sha: string;
   head_short: string;
   changed_file_count: number;
   changed_files: string[];


### PR DESCRIPTION
## Summary\n- tighten DesktopDigestItem.worktree and head_sha from optional to required in the TypeScript desktop client\n- add Rust desktop summary snapshot regressions that fail closed when digest items are missing worktree or head_sha\n- keep provider_target optional in this slice because the current Rust desktop digest DTO does not yet model it\n\n## Validation\n- cargo test --manifest-path winsmux-app/src-tauri/Cargo.toml desktop_backend\n- cmd /c npm run build\n- pwsh -NoProfile -File .\\scripts\\git-guard.ps1 -Mode full\n- pwsh -NoProfile -File .\\scripts\\audit-public-surface.ps1\n