### PR TITLE
fix: widen desktop digest parity contract

### DIFF
--- a/winsmux-app/src-tauri/src/desktop_backend.rs
+++ b/winsmux-app/src-tauri/src/desktop_backend.rs
@@ -87,6 +87,7 @@ pub struct DesktopDigestItem {
     pub label: String,
     pub pane_id: String,
     pub role: String,
+    pub provider_target: String,
     pub task_state: String,
     pub review_state: String,
     pub next_action: String,
@@ -96,6 +97,12 @@ pub struct DesktopDigestItem {
     pub head_short: String,
     pub changed_file_count: usize,
     pub changed_files: Vec<String>,
+    pub verification_outcome: String,
+    pub security_blocked: String,
+    pub hypothesis: String,
+    pub confidence: Option<f64>,
+    pub observation_pack_ref: String,
+    pub consultation_ref: String,
     pub last_event_at: String,
 }
 
@@ -880,6 +887,13 @@ mod tests {
         assert_eq!(snapshot.digest.summary.actionable_items, 1);
         assert_eq!(snapshot.digest.summary.dirty_items, 1);
         assert_eq!(snapshot.digest.items[0].run_id, "task:task-246");
+        assert_eq!(snapshot.digest.items[0].provider_target, "");
+        assert_eq!(snapshot.digest.items[0].verification_outcome, "");
+        assert_eq!(snapshot.digest.items[0].security_blocked, "");
+        assert_eq!(
+            snapshot.digest.items[0].observation_pack_ref,
+            ".winsmux/observation-packs/observation-pack-__ID__.json"
+        );
         assert_eq!(snapshot.digest.items[0].last_event_at, "__LAST_EVENT_AT__");
         assert_eq!(snapshot.run_projections.len(), 1);
         assert_eq!(snapshot.run_projections[0].run_id, "task:task-246");
@@ -984,6 +998,54 @@ mod tests {
         assert!(
             err.contains("head_sha"),
             "expected missing head_sha error, got {err}"
+        );
+    }
+
+    #[test]
+    fn load_desktop_summary_snapshot_rejects_missing_digest_provider_target() {
+        let mut response = rust_parity_summary_snapshot_payload();
+        response["digest"]["items"][0]
+            .as_object_mut()
+            .expect("digest.items[0] must be an object")
+            .remove("provider_target");
+
+        let transport = FakeTransport {
+            requests: RefCell::new(Vec::new()),
+            response,
+        };
+
+        let err = match load_desktop_summary_snapshot(&transport, None) {
+            Ok(_) => panic!("expected summary snapshot parse failure for missing provider_target"),
+            Err(err) => err,
+        };
+
+        assert!(
+            err.contains("provider_target"),
+            "expected missing provider_target error, got {err}"
+        );
+    }
+
+    #[test]
+    fn load_desktop_summary_snapshot_rejects_missing_digest_verification_outcome() {
+        let mut response = rust_parity_summary_snapshot_payload();
+        response["digest"]["items"][0]
+            .as_object_mut()
+            .expect("digest.items[0] must be an object")
+            .remove("verification_outcome");
+
+        let transport = FakeTransport {
+            requests: RefCell::new(Vec::new()),
+            response,
+        };
+
+        let err = match load_desktop_summary_snapshot(&transport, None) {
+            Ok(_) => panic!("expected summary snapshot parse failure for missing verification_outcome"),
+            Err(err) => err,
+        };
+
+        assert!(
+            err.contains("verification_outcome"),
+            "expected missing verification_outcome error, got {err}"
         );
     }
 

--- a/winsmux-app/src/desktopClient.ts
+++ b/winsmux-app/src/desktopClient.ts
@@ -90,7 +90,7 @@ export interface DesktopDigestItem {
   label: string;
   pane_id: string;
   role: string;
-  provider_target?: string;
+  provider_target: string;
   task_state: string;
   review_state: string;
   next_action: string;
@@ -100,12 +100,12 @@ export interface DesktopDigestItem {
   head_short: string;
   changed_file_count: number;
   changed_files: string[];
-  verification_outcome?: string;
-  security_blocked?: string;
-  hypothesis?: string;
-  confidence?: number | null;
-  observation_pack_ref?: string;
-  consultation_ref?: string;
+  verification_outcome: string;
+  security_blocked: string;
+  hypothesis: string;
+  confidence: number | null;
+  observation_pack_ref: string;
+  consultation_ref: string;
 }
 
 export interface DesktopRunProjection {


### PR DESCRIPTION
## Summary\n- carry the remaining digest evidence fields through the Rust desktop summary DTO\n- make the TypeScript DesktopDigestItem require those same fields, with confidence as 
umber | null\n- add fail-close regressions for missing digest provider_target and erification_outcome\n\n## Validation\n- cargo test --manifest-path winsmux-app/src-tauri/Cargo.toml desktop_backend\n- cmd /c npm run build\n- pwsh -NoProfile -File .\\scripts\\git-guard.ps1 -Mode full\n- pwsh -NoProfile -File .\\scripts\\audit-public-surface.ps1\n\n## Notes\n- review: no material findings\n- residual risk: older external desktop-summary --json producers that omit these keys will now fail closed\n