### PR TITLE
fix: align digest last_event_at parity contract

### DIFF
--- a/winsmux-app/src/desktopClient.ts
+++ b/winsmux-app/src/desktopClient.ts
@@ -106,6 +106,7 @@ export interface DesktopDigestItem {
   confidence: number | null;
   observation_pack_ref: string;
   consultation_ref: string;
+  last_event_at: string;
 }
 
 export interface DesktopRunProjection {


### PR DESCRIPTION
## Summary
- add last_event_at to the TypeScript DesktopDigestItem contract
- align the desktop client shape with the current Rust and PowerShell digest producer
- keep the slice narrow to a single missing required field

## Validation
- cargo test --manifest-path winsmux-app/src-tauri/Cargo.toml desktop_backend
- cmd /c npm run build
- pwsh -NoProfile -File .\\scripts\\git-guard.ps1 -Mode full
- pwsh -NoProfile -File .\\scripts\\audit-public-surface.ps1
