### PR TITLE
fix: align desktop summary types with backend

### DIFF
--- a/winsmux-app/src/desktopClient.ts
+++ b/winsmux-app/src/desktopClient.ts
@@ -55,11 +55,14 @@ export interface DesktopBoardPane {
   label: string;
   pane_id: string;
   role: string;
+  state: string;
   task: string;
   task_state: string;
   review_state: string;
   branch: string;
+  head_sha: string;
   changed_file_count: number;
+  last_event_at: string;
 }
 
 export interface DesktopInboxSummary {
@@ -79,6 +82,7 @@ export interface DesktopInboxItem {
 
 export interface DesktopDigestSummary {
   item_count: number;
+  dirty_items: number;
   actionable_items: number;
   review_pending: number;
   review_failed: number;


### PR DESCRIPTION
## Summary
- add the missing DesktopBoardPane fields that the Rust desktop backend already emits
- add dirty_items to DesktopDigestSummary
- keep the slice narrow to TypeScript type alignment for the current producer contract

## Validation
- [x] cmd /c npm run build
- [x] pwsh -NoProfile -File .\\scripts\\git-guard.ps1 -Mode full
- [x] pwsh -NoProfile -File .\\scripts\\audit-public-surface.ps1
- [x] review: no material findings
