### PR TITLE
fix: type review-state explain contract

### DIFF
--- a/tests/fixtures/rust-parity/review-state.json
+++ b/tests/fixtures/rust-parity/review-state.json
@@ -1,0 +1,41 @@
+{
+  "status": "PENDING",
+  "branch": "worktree-builder-1",
+  "head_sha": "abc1234def5678",
+  "request": {
+    "id": "review-request-__ID__",
+    "branch": "worktree-builder-1",
+    "head_sha": "abc1234def5678",
+    "target_review_pane_id": "%4",
+    "target_review_label": "reviewer-1",
+    "target_review_role": "Reviewer",
+    "target_reviewer_pane_id": "%4",
+    "target_reviewer_label": "reviewer-1",
+    "target_reviewer_role": "Reviewer",
+    "review_contract": {
+      "version": 1,
+      "source_task": "TASK-210",
+      "issue_ref": "#315",
+      "style": "utility_first",
+      "required_scope": [
+        "design_impact",
+        "replacement_coverage",
+        "orphaned_artifacts"
+      ],
+      "checklist_labels": [
+        "design impact",
+        "replacement coverage",
+        "orphaned artifacts"
+      ],
+      "rationale": "Review requests must audit downstream design impact, replacement coverage, and orphaned artifacts as part of the runtime contract."
+    },
+    "dispatched_at": "__TIMESTAMP__"
+  },
+  "reviewer": {
+    "pane_id": "%4",
+    "label": "reviewer-1",
+    "role": "Reviewer",
+    "agent_name": "codex"
+  },
+  "updatedAt": "__TIMESTAMP__"
+}

--- a/winsmux-app/src-tauri/src/desktop_backend.rs
+++ b/winsmux-app/src-tauri/src/desktop_backend.rs
@@ -177,6 +177,8 @@ pub struct DesktopExplainPayload {
     pub explanation: DesktopExplainExplanation,
     pub evidence_digest: DesktopExplainEvidenceDigest,
     #[serde(default)]
+    pub review_state: Option<DesktopReviewStateRecord>,
+    #[serde(default)]
     pub recent_events: Vec<DesktopExplainRecentEvent>,
 }
 
@@ -220,6 +222,72 @@ pub struct DesktopExplainRecentEvent {
     pub event: String,
     pub label: String,
     pub message: String,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct DesktopReviewStateRecord {
+    pub status: String,
+    pub branch: String,
+    pub head_sha: String,
+    pub request: DesktopReviewStateRequest,
+    pub reviewer: DesktopReviewStateReviewer,
+    #[serde(rename = "updatedAt")]
+    pub updated_at: String,
+    #[serde(default)]
+    pub evidence: Option<DesktopReviewStateEvidence>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct DesktopReviewStateRequest {
+    #[serde(default)]
+    pub id: Option<String>,
+    pub branch: String,
+    pub head_sha: String,
+    pub target_review_pane_id: String,
+    pub target_review_label: String,
+    pub target_review_role: String,
+    #[serde(default)]
+    pub target_reviewer_pane_id: Option<String>,
+    #[serde(default)]
+    pub target_reviewer_label: Option<String>,
+    #[serde(default)]
+    pub target_reviewer_role: Option<String>,
+    pub review_contract: DesktopReviewContract,
+    #[serde(default)]
+    pub dispatched_at: Option<String>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct DesktopReviewStateReviewer {
+    pub pane_id: String,
+    pub label: String,
+    pub role: String,
+    #[serde(default)]
+    pub agent_name: Option<String>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct DesktopReviewStateEvidence {
+    #[serde(default)]
+    pub approved_at: Option<String>,
+    #[serde(default)]
+    pub approved_via: Option<String>,
+    #[serde(default)]
+    pub failed_at: Option<String>,
+    #[serde(default)]
+    pub failed_via: Option<String>,
+    pub review_contract_snapshot: DesktopReviewContract,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct DesktopReviewContract {
+    pub version: u32,
+    pub source_task: String,
+    pub issue_ref: String,
+    pub style: String,
+    pub required_scope: Vec<String>,
+    pub checklist_labels: Vec<String>,
+    pub rationale: String,
 }
 
 #[derive(Deserialize)]
@@ -833,6 +901,16 @@ mod tests {
         read_rust_parity_fixture("explain.json")
     }
 
+    fn rust_parity_review_state_payload() -> Value {
+        read_rust_parity_fixture("review-state.json")
+    }
+
+    fn rust_parity_explain_payload_with_review_state() -> Value {
+        let mut payload = rust_parity_explain_payload();
+        payload["review_state"] = rust_parity_review_state_payload();
+        payload
+    }
+
     fn rust_parity_run_projection_payload() -> Value {
         let digest = read_rust_parity_fixture("digest.json");
         let item = &digest["items"][0];
@@ -1166,7 +1244,7 @@ mod tests {
     fn load_desktop_run_explain_uses_explain_command() {
         let transport = FakeTransport {
             requests: RefCell::new(Vec::new()),
-            response: rust_parity_explain_payload(),
+            response: rust_parity_explain_payload_with_review_state(),
         };
 
         let payload =
@@ -1182,6 +1260,27 @@ mod tests {
         assert_eq!(payload.evidence_digest.next_action, "review_pending");
         assert_eq!(payload.evidence_digest.verification_outcome, "");
         assert_eq!(payload.evidence_digest.security_blocked, "");
+        assert_eq!(
+            payload
+                .review_state
+                .as_ref()
+                .map(|state| state.status.as_str()),
+            Some("PENDING")
+        );
+        assert_eq!(
+            payload
+                .review_state
+                .as_ref()
+                .map(|state| state.updated_at.as_str()),
+            Some("__TIMESTAMP__")
+        );
+        assert_eq!(
+            payload
+                .review_state
+                .as_ref()
+                .map(|state| state.request.review_contract.style.as_str()),
+            Some("utility_first")
+        );
         assert_eq!(payload.recent_events.len(), 2);
         assert_eq!(
             transport.requests.borrow().as_slice(),
@@ -1193,7 +1292,7 @@ mod tests {
     fn handle_desktop_json_rpc_routes_run_explain_and_prunes_extra_packets() {
         let transport = FakeTransport {
             requests: RefCell::new(Vec::new()),
-            response: rust_parity_explain_payload(),
+            response: rust_parity_explain_payload_with_review_state(),
         };
         let response = handle_desktop_json_rpc(
             &transport,
@@ -1214,6 +1313,7 @@ mod tests {
                 assert_eq!(result["run"]["run_id"], "task:task-256");
                 assert_eq!(result["run"]["provider_target"], "codex:gpt-5.4");
                 assert_eq!(result["evidence_digest"]["next_action"], "review_pending");
+                assert_eq!(result["review_state"]["status"], "PENDING");
                 assert!(result.get("run_packet").is_none());
                 assert!(result.get("result_packet").is_none());
                 assert!(result.get("consultation_packet").is_none());
@@ -1250,6 +1350,19 @@ mod tests {
             err.contains("head_sha"),
             "unexpected explain parse error: {err}"
         );
+    }
+
+    #[test]
+    fn load_desktop_run_explain_allows_null_review_state() {
+        let transport = FakeTransport {
+            requests: RefCell::new(Vec::new()),
+            response: rust_parity_explain_payload(),
+        };
+
+        let payload =
+            load_desktop_run_explain(&transport, "task:task-256".to_string(), None).unwrap();
+
+        assert!(payload.review_state.is_none());
     }
 
     #[test]
@@ -1368,6 +1481,54 @@ mod tests {
 
         assert!(
             err.contains("security_blocked"),
+            "unexpected explain parse error: {err}"
+        );
+    }
+
+    #[test]
+    fn load_desktop_run_explain_rejects_missing_review_state_status_when_present() {
+        let mut response = rust_parity_explain_payload_with_review_state();
+        response["review_state"]
+            .as_object_mut()
+            .expect("review_state must be an object")
+            .remove("status");
+
+        let transport = FakeTransport {
+            requests: RefCell::new(Vec::new()),
+            response,
+        };
+
+        let err = match load_desktop_run_explain(&transport, "task:task-256".to_string(), None) {
+            Ok(_) => panic!("expected explain payload parse failure"),
+            Err(err) => err,
+        };
+
+        assert!(
+            err.contains("status"),
+            "unexpected explain parse error: {err}"
+        );
+    }
+
+    #[test]
+    fn load_desktop_run_explain_rejects_missing_review_contract_required_scope() {
+        let mut response = rust_parity_explain_payload_with_review_state();
+        response["review_state"]["request"]["review_contract"]
+            .as_object_mut()
+            .expect("review_state.request.review_contract must be an object")
+            .remove("required_scope");
+
+        let transport = FakeTransport {
+            requests: RefCell::new(Vec::new()),
+            response,
+        };
+
+        let err = match load_desktop_run_explain(&transport, "task:task-256".to_string(), None) {
+            Ok(_) => panic!("expected explain payload parse failure"),
+            Err(err) => err,
+        };
+
+        assert!(
+            err.contains("required_scope"),
             "unexpected explain parse error: {err}"
         );
     }

--- a/winsmux-app/src/desktopClient.ts
+++ b/winsmux-app/src/desktopClient.ts
@@ -187,12 +187,62 @@ export interface DesktopExplainPayload {
     verification_outcome: string;
     security_blocked: string;
   };
+  review_state?: DesktopReviewStateRecord | null;
   recent_events: Array<{
     timestamp: string;
     event: string;
     label: string;
     message: string;
   }>;
+}
+
+export interface DesktopReviewStateRecord {
+  status: string;
+  branch: string;
+  head_sha: string;
+  request: DesktopReviewStateRequest;
+  reviewer: DesktopReviewStateReviewer;
+  updatedAt: string;
+  evidence?: DesktopReviewStateEvidence | null;
+}
+
+export interface DesktopReviewStateRequest {
+  id?: string | null;
+  branch: string;
+  head_sha: string;
+  target_review_pane_id: string;
+  target_review_label: string;
+  target_review_role: string;
+  target_reviewer_pane_id?: string | null;
+  target_reviewer_label?: string | null;
+  target_reviewer_role?: string | null;
+  review_contract: DesktopReviewContract;
+  dispatched_at?: string | null;
+}
+
+export interface DesktopReviewStateReviewer {
+  pane_id: string;
+  label: string;
+  role: string;
+  agent_name?: string | null;
+}
+
+export interface DesktopReviewStateEvidence {
+  approved_at?: string | null;
+  approved_via?: string | null;
+  failed_at?: string | null;
+  failed_via?: string | null;
+  review_contract_snapshot: DesktopReviewContract;
+}
+
+export interface DesktopReviewContract {
+  version: number;
+  source_task: string;
+  issue_ref: string;
+  style: string;
+  required_scope: string[];
+  checklist_labels: string[];
+  rationale: string;
 }
 
 export interface DesktopEditorFilePayload {


### PR DESCRIPTION
## Summary
- type `DesktopExplainPayload.review_state` as an optional structured contract on the Rust desktop backend
- add a dedicated `review-state.json` parity fixture and fail-close regressions for malformed present review-state objects
- align the TypeScript desktop client so `review_state` remains optional and nullable on the wire

## Validation
- `cargo fmt --manifest-path winsmux-app/src-tauri/Cargo.toml`
- `cargo test --manifest-path winsmux-app/src-tauri/Cargo.toml desktop_backend`
- `cmd /c npm run build`
- `pwsh -NoProfile -File .\scripts\git-guard.ps1 -Mode full`
- `pwsh -NoProfile -File .\scripts\audit-public-surface.ps1`

## Review
- review agent found one TypeScript optionality mismatch and it was integrated before push
