### PR TITLE
fix: validate producer review-state shape

### DIFF
--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -1393,6 +1393,102 @@ function Test-ReviewContractPresent {
     return @($contract['required_scope']).Count -gt 0
 }
 
+function Assert-ReviewStateRecordShape {
+    param(
+        [AllowNull()]$Record,
+        [Parameter(Mandatory = $true)][string]$Branch
+    )
+
+    if ($null -eq $Record -or -not ($Record -is [System.Collections.IDictionary])) {
+        Stop-WithError "invalid review state: branch '$Branch' entry must be an object"
+    }
+
+    $status = [string](Get-ReviewStatePropertyValue -InputObject $Record -Name 'status')
+    if ([string]::IsNullOrWhiteSpace($status)) {
+        Stop-WithError "invalid review state: branch '$Branch' entry is missing status"
+    }
+
+    $recordBranch = [string](Get-ReviewStatePropertyValue -InputObject $Record -Name 'branch')
+    if ([string]::IsNullOrWhiteSpace($recordBranch)) {
+        Stop-WithError "invalid review state: branch '$Branch' entry is missing branch"
+    }
+
+    $recordHeadSha = [string](Get-ReviewStatePropertyValue -InputObject $Record -Name 'head_sha')
+    if ([string]::IsNullOrWhiteSpace($recordHeadSha)) {
+        Stop-WithError "invalid review state: branch '$Branch' entry is missing head_sha"
+    }
+
+    $request = ConvertTo-ReviewStateValue -Value (Get-ReviewStatePropertyValue -InputObject $Record -Name 'request')
+    if ($null -eq $request -or -not ($request -is [System.Collections.IDictionary])) {
+        Stop-WithError "invalid review state: branch '$Branch' entry is missing request"
+    }
+
+    $requestBranch = [string](Get-ReviewStatePropertyValue -InputObject $request -Name 'branch')
+    if ([string]::IsNullOrWhiteSpace($requestBranch)) {
+        Stop-WithError "invalid review state: branch '$Branch' request is missing branch"
+    }
+
+    $requestHeadSha = [string](Get-ReviewStatePropertyValue -InputObject $request -Name 'head_sha')
+    if ([string]::IsNullOrWhiteSpace($requestHeadSha)) {
+        Stop-WithError "invalid review state: branch '$Branch' request is missing head_sha"
+    }
+
+    $targetPaneId = [string](Get-ReviewRequestTargetValue -Request $request -Name 'pane_id')
+    if ([string]::IsNullOrWhiteSpace($targetPaneId)) {
+        Stop-WithError "invalid review state: branch '$Branch' request is missing target review pane id"
+    }
+
+    $targetLabel = [string](Get-ReviewRequestTargetValue -Request $request -Name 'label')
+    if ([string]::IsNullOrWhiteSpace($targetLabel)) {
+        Stop-WithError "invalid review state: branch '$Branch' request is missing target review label"
+    }
+
+    $targetRole = [string](Get-ReviewRequestTargetValue -Request $request -Name 'role')
+    if ([string]::IsNullOrWhiteSpace($targetRole)) {
+        Stop-WithError "invalid review state: branch '$Branch' request is missing target review role"
+    }
+
+    if (-not (Test-ReviewContractPresent -Request $request)) {
+        Stop-WithError "invalid review state: branch '$Branch' request is missing review_contract.required_scope"
+    }
+
+    $reviewer = ConvertTo-ReviewStateValue -Value (Get-ReviewStatePropertyValue -InputObject $Record -Name 'reviewer')
+    if ($null -eq $reviewer -or -not ($reviewer -is [System.Collections.IDictionary])) {
+        Stop-WithError "invalid review state: branch '$Branch' entry is missing reviewer"
+    }
+
+    foreach ($fieldName in @('pane_id', 'label', 'role')) {
+        $fieldValue = [string](Get-ReviewStatePropertyValue -InputObject $reviewer -Name $fieldName)
+        if ([string]::IsNullOrWhiteSpace($fieldValue)) {
+            Stop-WithError "invalid review state: branch '$Branch' reviewer is missing $fieldName"
+        }
+    }
+
+    $updatedAt = [string](Get-ReviewStatePropertyValue -InputObject $Record -Name 'updatedAt')
+    if ([string]::IsNullOrWhiteSpace($updatedAt)) {
+        Stop-WithError "invalid review state: branch '$Branch' entry is missing updatedAt"
+    }
+
+    $evidence = Get-ReviewStatePropertyValue -InputObject $Record -Name 'evidence'
+    if ($null -eq $evidence) {
+        return
+    }
+
+    $evidenceRecord = ConvertTo-ReviewStateValue -Value $evidence
+    if (-not ($evidenceRecord -is [System.Collections.IDictionary])) {
+        Stop-WithError "invalid review state: branch '$Branch' evidence must be an object"
+    }
+
+    $snapshot = ConvertTo-ReviewStateValue -Value (Get-ReviewStatePropertyValue -InputObject $evidenceRecord -Name 'review_contract_snapshot')
+    if ($null -eq $snapshot -or -not ($snapshot -is [System.Collections.IDictionary])) {
+        Stop-WithError "invalid review state: branch '$Branch' evidence is missing review_contract_snapshot"
+    }
+
+    if (-not $snapshot.Contains('required_scope') -or @($snapshot['required_scope']).Count -eq 0) {
+        Stop-WithError "invalid review state: branch '$Branch' evidence is missing review_contract_snapshot.required_scope"
+    }
+}
+
 # --- Helper: Labels ---
 function Get-Labels {
     if (Test-Path $LabelsFile) {
@@ -4815,6 +4911,7 @@ function Get-ExplainPayload {
         $state = Get-ReviewState -ProjectDir $ProjectDir
         if ($state.Contains($branch)) {
             $reviewState = ConvertTo-ReviewStateValue -Value $state[$branch]
+            Assert-ReviewStateRecordShape -Record $reviewState -Branch $branch
         }
     }
 

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -6622,12 +6622,18 @@ panes:
 {
   "worktree-builder-1": {
     "status": "PENDING",
+    "branch": "worktree-builder-1",
     "head_sha": "abc1234def5678",
     "request": {
+      "id": "review-request-__ID__",
       "branch": "worktree-builder-1",
       "head_sha": "abc1234def5678",
+      "target_review_label": "reviewer-1",
+      "target_review_pane_id": "%3",
+      "target_review_role": "Reviewer",
       "target_reviewer_label": "reviewer-1",
       "target_reviewer_pane_id": "%3",
+      "target_reviewer_role": "Reviewer",
       "review_contract": {
         "version": 1,
         "source_task": "TASK-210",
@@ -6638,8 +6644,16 @@ panes:
           "replacement_coverage",
           "orphaned_artifacts"
         ]
-      }
-    }
+      },
+      "dispatched_at": "__TIMESTAMP__"
+    },
+    "reviewer": {
+      "pane_id": "%3",
+      "label": "reviewer-1",
+      "role": "Reviewer",
+      "agent_name": "codex"
+    },
+    "updatedAt": "__TIMESTAMP__"
   }
 }
 '@ | Set-Content -Path $script:explainReviewStatePath -Encoding UTF8
@@ -6726,6 +6740,84 @@ panes:
         ($result.recent_events | Where-Object { $_.event -eq 'commander.review_requested' } | Select-Object -First 1).hypothesis | Should -Be 'experiment packet should flow into explain'
         ($result.recent_events | Where-Object { $_.event -eq 'commander.review_requested' } | Select-Object -First 1).observation_pack.packet_type | Should -Be 'observation_pack'
         ($result.recent_events | Where-Object { $_.event -eq 'commander.review_requested' } | Select-Object -First 1).consultation_packet.kind | Should -Be 'consult_result'
+    }
+
+    It 'rejects explain when matching review-state record is missing reviewer' {
+@"
+version: 1
+session:
+  name: winsmux-orchestra
+  project_dir: $script:explainTempRoot
+panes:
+  builder-1:
+    pane_id: %2
+    role: Builder
+    task_id: task-256
+    task: Implement run ledger
+    task_state: in_progress
+    task_owner: builder-1
+    review_state: PENDING
+    branch: worktree-builder-1
+    head_sha: abc1234def5678
+    changed_file_count: 1
+    changed_files: '["scripts/winsmux-core.ps1"]'
+    last_event: commander.review_requested
+    last_event_at: 2026-04-10T12:00:00+09:00
+"@ | Set-Content -Path $script:explainManifestPath -Encoding UTF8
+
+        ([ordered]@{
+            timestamp = '2026-04-10T12:01:00+09:00'
+            session   = 'winsmux-orchestra'
+            event     = 'commander.review_requested'
+            message   = 'review requested'
+            label     = 'reviewer-1'
+            pane_id   = '%3'
+            role      = 'Reviewer'
+            branch    = 'worktree-builder-1'
+            head_sha  = 'abc1234def5678'
+            data      = [ordered]@{
+                task_id = 'task-256'
+            }
+        } | ConvertTo-Json -Compress) | Set-Content -Path $script:explainEventsPath -Encoding UTF8
+
+@'
+{
+  "worktree-builder-1": {
+    "status": "PENDING",
+    "branch": "worktree-builder-1",
+    "head_sha": "abc1234def5678",
+    "request": {
+      "branch": "worktree-builder-1",
+      "head_sha": "abc1234def5678",
+      "target_review_label": "reviewer-1",
+      "target_review_pane_id": "%3",
+      "target_review_role": "Reviewer",
+      "review_contract": {
+        "version": 1,
+        "source_task": "TASK-210",
+        "issue_ref": "#315",
+        "style": "utility_first",
+        "required_scope": [
+          "design_impact",
+          "replacement_coverage",
+          "orphaned_artifacts"
+        ]
+      }
+    },
+    "updatedAt": "2026-04-10T12:01:00+09:00"
+  }
+}
+'@ | Set-Content -Path $script:explainReviewStatePath -Encoding UTF8
+
+        function global:winsmux {
+            $commandLine = ($args | ForEach-Object { [string]$_ }) -join ' '
+            switch -Regex ($commandLine) {
+                '^capture-pane .*%2' { return @('gpt-5.4   64% context left', '? send   Ctrl+J newline', '>') }
+                default { throw "unexpected winsmux call: $commandLine" }
+            }
+        }
+
+        { Get-ExplainPayload -ProjectDir $script:explainTempRoot -RunId 'task:task-256' } | Should -Throw '*invalid review state*reviewer*'
     }
 
     It 'keeps refs and returns null packets when artifact files are missing or malformed' {


### PR DESCRIPTION
## Summary
- validate the current-branch `review-state` record before `Get-ExplainPayload` emits it
- require the minimum producer shape for `status`, `branch`, `head_sha`, `request`, `reviewer`, `updatedAt`, and `review_contract.required_scope`
- update the explain review-state fixture and add a regression for a missing `reviewer`

## Validation
- `Invoke-Pester tests/winsmux-bridge.Tests.ps1 -CI -Output Detailed`
- `pwsh -NoProfile -File .\scripts\git-guard.ps1 -Mode full`
- `pwsh -NoProfile -File .\scripts\audit-public-surface.ps1`
