### PR TITLE
fix: tighten review-state evidence contract

### DIFF
--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -1487,6 +1487,31 @@ function Assert-ReviewStateRecordShape {
     if (-not $snapshot.Contains('required_scope') -or @($snapshot['required_scope']).Count -eq 0) {
         Stop-WithError "invalid review state: branch '$Branch' evidence is missing review_contract_snapshot.required_scope"
     }
+
+    switch ($status.ToUpperInvariant()) {
+        'PASS' {
+            $approvedAt = [string](Get-ReviewStatePropertyValue -InputObject $evidenceRecord -Name 'approved_at')
+            if ([string]::IsNullOrWhiteSpace($approvedAt)) {
+                Stop-WithError "invalid review state: branch '$Branch' PASS evidence is missing approved_at"
+            }
+
+            $approvedVia = [string](Get-ReviewStatePropertyValue -InputObject $evidenceRecord -Name 'approved_via')
+            if ([string]::IsNullOrWhiteSpace($approvedVia)) {
+                Stop-WithError "invalid review state: branch '$Branch' PASS evidence is missing approved_via"
+            }
+        }
+        'FAIL' {
+            $failedAt = [string](Get-ReviewStatePropertyValue -InputObject $evidenceRecord -Name 'failed_at')
+            if ([string]::IsNullOrWhiteSpace($failedAt)) {
+                Stop-WithError "invalid review state: branch '$Branch' FAIL evidence is missing failed_at"
+            }
+
+            $failedVia = [string](Get-ReviewStatePropertyValue -InputObject $evidenceRecord -Name 'failed_via')
+            if ([string]::IsNullOrWhiteSpace($failedVia)) {
+                Stop-WithError "invalid review state: branch '$Branch' FAIL evidence is missing failed_via"
+            }
+        }
+    }
 }
 
 # --- Helper: Labels ---

--- a/tests/Integration.GateEnforcement.Tests.ps1
+++ b/tests/Integration.GateEnforcement.Tests.ps1
@@ -758,6 +758,8 @@ EOF
         $reviewState.'feature/review-gate'.request.review_contract.source_task | Should -Be 'TASK-210'
         $reviewState.'feature/review-gate'.request.review_contract.style | Should -Be 'utility_first'
         $reviewState.'feature/review-gate'.request.review_contract.required_scope | Should -Be @('design_impact', 'replacement_coverage', 'orphaned_artifacts')
+        $reviewState.'feature/review-gate'.evidence.approved_at | Should -Not -BeNullOrEmpty
+        $reviewState.'feature/review-gate'.evidence.approved_via | Should -Be 'winsmux review-approve'
         $reviewState.'feature/review-gate'.evidence.review_contract_snapshot.required_scope | Should -Be @('design_impact', 'replacement_coverage', 'orphaned_artifacts')
 
         $result = & $script:InvokeOrchestraGate -RepoRoot $fixture.RepoRoot -ToolName 'Bash' -ToolInput @{
@@ -896,5 +898,30 @@ EOF
         $approveResult = & $script:InvokeWinsmuxCore -RepoRoot $fixture.RepoRoot -Arguments @('review-approve') -Environment $reviewerEnv
         $approveResult.ExitCode | Should -Be 1
         $approveResult.StdErr | Should -Match 'missing review_contract'
+    }
+
+    It 'records fail evidence when review-fail is used for the current branch' {
+        $fixture = New-GateFixture
+        $script:FixtureRoot = $fixture.Root
+
+        $reviewerEnv = @{
+            WINSMUX_ROLE       = 'Reviewer'
+            WINSMUX_PANE_ID    = '%4'
+            WINSMUX_ROLE_MAP   = '{"%4":"Reviewer"}'
+            WINSMUX_AGENT_NAME = 'codex'
+        }
+
+        $requestResult = & $script:InvokeWinsmuxCore -RepoRoot $fixture.RepoRoot -Arguments @('review-request') -Environment $reviewerEnv
+        $requestResult.ExitCode | Should -Be 0
+
+        $failResult = & $script:InvokeWinsmuxCore -RepoRoot $fixture.RepoRoot -Arguments @('review-fail') -Environment $reviewerEnv
+        $failResult.ExitCode | Should -Be 0
+
+        $reviewStatePath = Join-Path $fixture.RepoRoot '.winsmux\review-state.json'
+        $reviewState = Get-Content -LiteralPath $reviewStatePath -Raw -Encoding UTF8 | ConvertFrom-Json
+        $reviewState.'feature/review-gate'.status | Should -Be 'FAIL'
+        $reviewState.'feature/review-gate'.evidence.failed_at | Should -Not -BeNullOrEmpty
+        $reviewState.'feature/review-gate'.evidence.failed_via | Should -Be 'winsmux review-fail'
+        $reviewState.'feature/review-gate'.evidence.review_contract_snapshot.required_scope | Should -Be @('design_impact', 'replacement_coverage', 'orphaned_artifacts')
     }
 }

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -6820,6 +6820,103 @@ panes:
         { Get-ExplainPayload -ProjectDir $script:explainTempRoot -RunId 'task:task-256' } | Should -Throw '*invalid review state*reviewer*'
     }
 
+    It 'rejects explain when PASS review-state evidence is missing approved_via' {
+@"
+version: 1
+session:
+  name: winsmux-orchestra
+  project_dir: $script:explainTempRoot
+panes:
+  builder-1:
+    pane_id: %2
+    role: Builder
+    task_id: task-256
+    task: Implement run ledger
+    task_state: done
+    task_owner: builder-1
+    review_state: PASS
+    branch: worktree-builder-1
+    head_sha: abc1234def5678
+    changed_file_count: 1
+    changed_files: '["scripts/winsmux-core.ps1"]'
+    last_event: review.pass
+    last_event_at: 2026-04-10T12:10:00+09:00
+"@ | Set-Content -Path $script:explainManifestPath -Encoding UTF8
+
+        ([ordered]@{
+            timestamp = '2026-04-10T12:10:00+09:00'
+            session   = 'winsmux-orchestra'
+            event     = 'review.pass'
+            message   = 'review PASS recorded'
+            label     = 'reviewer-1'
+            pane_id   = '%3'
+            role      = 'Reviewer'
+            branch    = 'worktree-builder-1'
+            head_sha  = 'abc1234def5678'
+            data      = [ordered]@{
+                task_id = 'task-256'
+            }
+        } | ConvertTo-Json -Compress) | Set-Content -Path $script:explainEventsPath -Encoding UTF8
+
+@'
+{
+  "worktree-builder-1": {
+    "status": "PASS",
+    "branch": "worktree-builder-1",
+    "head_sha": "abc1234def5678",
+    "request": {
+      "branch": "worktree-builder-1",
+      "head_sha": "abc1234def5678",
+      "target_review_label": "reviewer-1",
+      "target_review_pane_id": "%3",
+      "target_review_role": "Reviewer",
+      "review_contract": {
+        "version": 1,
+        "source_task": "TASK-210",
+        "issue_ref": "#315",
+        "style": "utility_first",
+        "required_scope": [
+          "design_impact",
+          "replacement_coverage",
+          "orphaned_artifacts"
+        ]
+      }
+    },
+    "reviewer": {
+      "pane_id": "%3",
+      "label": "reviewer-1",
+      "role": "Reviewer"
+    },
+    "updatedAt": "2026-04-10T12:10:00+09:00",
+    "evidence": {
+      "approved_at": "2026-04-10T12:10:00+09:00",
+      "review_contract_snapshot": {
+        "version": 1,
+        "source_task": "TASK-210",
+        "issue_ref": "#315",
+        "style": "utility_first",
+        "required_scope": [
+          "design_impact",
+          "replacement_coverage",
+          "orphaned_artifacts"
+        ]
+      }
+    }
+  }
+}
+'@ | Set-Content -Path $script:explainReviewStatePath -Encoding UTF8
+
+        function global:winsmux {
+            $commandLine = ($args | ForEach-Object { [string]$_ }) -join ' '
+            switch -Regex ($commandLine) {
+                '^capture-pane .*%2' { return @('gpt-5.4   64% context left', '? send   Ctrl+J newline', '>') }
+                default { throw "unexpected winsmux call: $commandLine" }
+            }
+        }
+
+        { Get-ExplainPayload -ProjectDir $script:explainTempRoot -RunId 'task:task-256' } | Should -Throw '*invalid review state*approved_via*'
+    }
+
     It 'keeps refs and returns null packets when artifact files are missing or malformed' {
 @"
 version: 1


### PR DESCRIPTION
## Summary
- require `review-state.evidence` to carry status-specific fields for `PASS` and `FAIL`
- verify `review-approve` and `review-fail` persist the expected evidence payloads
- fail-close explain when `PASS` evidence is missing `approved_via`

## Validation
- `Invoke-Pester tests/Integration.GateEnforcement.Tests.ps1 -CI -Output Detailed`
- `Invoke-Pester tests/winsmux-bridge.Tests.ps1 -CI -Output Detailed`
- `pwsh -NoProfile -File .\scripts\git-guard.ps1 -Mode full`
- `pwsh -NoProfile -File .\scripts\audit-public-surface.ps1`