### PR TITLE
fix: tighten manifest run shape

### DIFF
--- a/docs/project/rust-schema-freeze-inventory.md
+++ b/docs/project/rust-schema-freeze-inventory.md
@@ -98,8 +98,12 @@ Main PowerShell readers:
 
 Current gap:
 
-- The runtime depends on specific YAML fields, but there is no typed Rust schema or fixture set that freezes the manifest shape.
-- Most validation is still embedded in PowerShell control flow.
+- The runtime still depends on specific YAML fields, and there is still no typed Rust schema or fixture set that freezes the full manifest shape.
+- A first PowerShell-side minimum shape now exists for run/explain consumers:
+  - `review_state` requires `branch` and `head_sha`
+  - `changed_file_count > 0` requires non-empty `changed_files`
+  - `last_event` requires `last_event_at`
+- The remaining work is to inventory and freeze the wider pane/session/task fields without widening this slice back into a full manifest rewrite.
 
 ### 4. `state`
 

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -1514,6 +1514,60 @@ function Assert-ReviewStateRecordShape {
     }
 }
 
+function Assert-ManifestBackedRunShape {
+    param([Parameter(Mandatory = $true)]$PaneRecord)
+
+    $getFieldValue = {
+        param($InputObject, [string[]]$Names)
+
+        foreach ($name in @($Names)) {
+            if ($InputObject -is [System.Collections.IDictionary] -and $InputObject.Contains($name)) {
+                return $InputObject[$name]
+            }
+
+            if ($null -ne $InputObject.PSObject -and $InputObject.PSObject.Properties.Name -contains $name) {
+                return $InputObject.PSObject.Properties[$name].Value
+            }
+        }
+
+        return $null
+    }
+
+    $label = [string](& $getFieldValue $PaneRecord @('label', 'Label'))
+    if ([string]::IsNullOrWhiteSpace($label)) {
+        $label = '<unknown>'
+    }
+
+    $reviewState = [string](& $getFieldValue $PaneRecord @('review_state', 'ReviewState'))
+    if (-not [string]::IsNullOrWhiteSpace($reviewState)) {
+        $branch = [string](& $getFieldValue $PaneRecord @('branch', 'Branch'))
+        if ([string]::IsNullOrWhiteSpace($branch)) {
+            Stop-WithError "invalid manifest: pane '$label' review_state requires branch"
+        }
+
+        $headSha = [string](& $getFieldValue $PaneRecord @('head_sha', 'HeadSha'))
+        if ([string]::IsNullOrWhiteSpace($headSha)) {
+            Stop-WithError "invalid manifest: pane '$label' review_state requires head_sha"
+        }
+    }
+
+    $changedFileCount = & $getFieldValue $PaneRecord @('changed_file_count', 'ChangedFileCount')
+    if ([int]$changedFileCount -gt 0) {
+        $changedFiles = @(& $getFieldValue $PaneRecord @('changed_files', 'ChangedFiles'))
+        if (@($changedFiles).Count -eq 0) {
+            Stop-WithError "invalid manifest: pane '$label' changed_file_count requires changed_files"
+        }
+    }
+
+    $lastEvent = [string](& $getFieldValue $PaneRecord @('last_event', 'LastEvent'))
+    if (-not [string]::IsNullOrWhiteSpace($lastEvent)) {
+        $lastEventAt = [string](& $getFieldValue $PaneRecord @('last_event_at', 'LastEventAt'))
+        if ([string]::IsNullOrWhiteSpace($lastEventAt)) {
+            Stop-WithError "invalid manifest: pane '$label' last_event requires last_event_at"
+        }
+    }
+}
+
 # --- Helper: Labels ---
 function Get-Labels {
     if (Test-Path $LabelsFile) {
@@ -4150,6 +4204,7 @@ function Get-RunsPayload {
     $runsById = [ordered]@{}
 
     foreach ($pane in @($boardPayload.panes)) {
+        Assert-ManifestBackedRunShape -PaneRecord $pane
         $runId = Get-RunIdFromPaneRecord -PaneRecord $pane
         if (-not $runsById.Contains($runId)) {
             $runsById[$runId] = [ordered]@{

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -6917,6 +6917,106 @@ panes:
         { Get-ExplainPayload -ProjectDir $script:explainTempRoot -RunId 'task:task-256' } | Should -Throw '*invalid review state*approved_via*'
     }
 
+    It 'rejects explain when manifest review_state is present without head_sha' {
+@"
+version: 1
+session:
+  name: winsmux-orchestra
+  project_dir: $script:explainTempRoot
+panes:
+  builder-1:
+    pane_id: %2
+    role: Builder
+    task_id: task-256
+    task: Implement run ledger
+    task_state: in_progress
+    task_owner: builder-1
+    review_state: PENDING
+    branch: worktree-builder-1
+    changed_file_count: 1
+    changed_files: '["scripts/winsmux-core.ps1"]'
+    last_event: commander.review_requested
+    last_event_at: 2026-04-10T12:00:00+09:00
+"@ | Set-Content -Path $script:explainManifestPath -Encoding UTF8
+
+        function global:winsmux {
+            $commandLine = ($args | ForEach-Object { [string]$_ }) -join ' '
+            switch -Regex ($commandLine) {
+                '^capture-pane .*%2' { return @('gpt-5.4   64% context left', '? send   Ctrl+J newline', '>') }
+                default { throw "unexpected winsmux call: $commandLine" }
+            }
+        }
+
+        { Get-ExplainPayload -ProjectDir $script:explainTempRoot -RunId 'task:task-256' } | Should -Throw '*invalid manifest*pane ''builder-1'' review_state requires head_sha*'
+    }
+
+    It 'rejects explain when manifest changed_file_count is present without changed_files' {
+@"
+version: 1
+session:
+  name: winsmux-orchestra
+  project_dir: $script:explainTempRoot
+panes:
+  builder-1:
+    pane_id: %2
+    role: Builder
+    task_id: task-256
+    task: Implement run ledger
+    task_state: in_progress
+    task_owner: builder-1
+    review_state: PENDING
+    branch: worktree-builder-1
+    head_sha: abc1234def5678
+    changed_file_count: 1
+    changed_files: '[]'
+    last_event: commander.review_requested
+    last_event_at: 2026-04-10T12:00:00+09:00
+"@ | Set-Content -Path $script:explainManifestPath -Encoding UTF8
+
+        function global:winsmux {
+            $commandLine = ($args | ForEach-Object { [string]$_ }) -join ' '
+            switch -Regex ($commandLine) {
+                '^capture-pane .*%2' { return @('gpt-5.4   64% context left', '? send   Ctrl+J newline', '>') }
+                default { throw "unexpected winsmux call: $commandLine" }
+            }
+        }
+
+        { Get-ExplainPayload -ProjectDir $script:explainTempRoot -RunId 'task:task-256' } | Should -Throw '*invalid manifest*pane ''builder-1'' changed_file_count requires changed_files*'
+    }
+
+    It 'rejects explain when manifest last_event is present without last_event_at' {
+@"
+version: 1
+session:
+  name: winsmux-orchestra
+  project_dir: $script:explainTempRoot
+panes:
+  builder-1:
+    pane_id: %2
+    role: Builder
+    task_id: task-256
+    task: Implement run ledger
+    task_state: in_progress
+    task_owner: builder-1
+    review_state: PENDING
+    branch: worktree-builder-1
+    head_sha: abc1234def5678
+    changed_file_count: 1
+    changed_files: '["scripts/winsmux-core.ps1"]'
+    last_event: commander.review_requested
+"@ | Set-Content -Path $script:explainManifestPath -Encoding UTF8
+
+        function global:winsmux {
+            $commandLine = ($args | ForEach-Object { [string]$_ }) -join ' '
+            switch -Regex ($commandLine) {
+                '^capture-pane .*%2' { return @('gpt-5.4   64% context left', '? send   Ctrl+J newline', '>') }
+                default { throw "unexpected winsmux call: $commandLine" }
+            }
+        }
+
+        { Get-ExplainPayload -ProjectDir $script:explainTempRoot -RunId 'task:task-256' } | Should -Throw '*invalid manifest*pane ''builder-1'' last_event requires last_event_at*'
+    }
+
     It 'keeps refs and returns null packets when artifact files are missing or malformed' {
 @"
 version: 1


### PR DESCRIPTION
## Summary
- fail-close manifest-backed runs when `review_state`, `changed_file_count`, or `last_event` lack their paired fields
- add explain regressions for missing `head_sha`, `changed_files`, and `last_event_at`
- update the schema freeze inventory with the new minimum manifest slice

## Validation
- `Invoke-Pester tests/winsmux-bridge.Tests.ps1 -CI -Output Detailed`
- `pwsh -NoProfile -File .\scripts\git-guard.ps1 -Mode full`
- `pwsh -NoProfile -File .\scripts\audit-public-surface.ps1`