### PR TITLE
fix: tighten manifest planning metadata

### DIFF
--- a/docs/project/rust-schema-freeze-inventory.md
+++ b/docs/project/rust-schema-freeze-inventory.md
@@ -103,6 +103,8 @@ Current gap:
   - `review_state` requires `branch` and `head_sha`
   - `changed_file_count > 0` requires non-empty `changed_files`
   - `last_event` requires `last_event_at`
+- A second PowerShell-side planning metadata slice now exists for run/explain consumers:
+  - if any of `parent_run_id`, `goal`, `task_type`, or `priority` is present, all four fields are required
 - The remaining work is to inventory and freeze the wider pane/session/task fields without widening this slice back into a full manifest rewrite.
 
 ### 4. `state`

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -1566,6 +1566,31 @@ function Assert-ManifestBackedRunShape {
             Stop-WithError "invalid manifest: pane '$label' last_event requires last_event_at"
         }
     }
+
+    $parentRunId = [string](& $getFieldValue $PaneRecord @('parent_run_id', 'ParentRunId'))
+    $goal = [string](& $getFieldValue $PaneRecord @('goal', 'Goal'))
+    $taskType = [string](& $getFieldValue $PaneRecord @('task_type', 'TaskType'))
+    $priority = [string](& $getFieldValue $PaneRecord @('priority', 'Priority'))
+    $hasPlanningMetadata =
+        -not [string]::IsNullOrWhiteSpace($parentRunId) -or
+        -not [string]::IsNullOrWhiteSpace($goal) -or
+        -not [string]::IsNullOrWhiteSpace($taskType) -or
+        -not [string]::IsNullOrWhiteSpace($priority)
+
+    if ($hasPlanningMetadata) {
+        if ([string]::IsNullOrWhiteSpace($parentRunId)) {
+            Stop-WithError "invalid manifest: pane '$label' planning metadata requires parent_run_id"
+        }
+        if ([string]::IsNullOrWhiteSpace($goal)) {
+            Stop-WithError "invalid manifest: pane '$label' planning metadata requires goal"
+        }
+        if ([string]::IsNullOrWhiteSpace($taskType)) {
+            Stop-WithError "invalid manifest: pane '$label' planning metadata requires task_type"
+        }
+        if ([string]::IsNullOrWhiteSpace($priority)) {
+            Stop-WithError "invalid manifest: pane '$label' planning metadata requires priority"
+        }
+    }
 }
 
 # --- Helper: Labels ---

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -7017,6 +7017,154 @@ panes:
         { Get-ExplainPayload -ProjectDir $script:explainTempRoot -RunId 'task:task-256' } | Should -Throw '*invalid manifest*pane ''builder-1'' last_event requires last_event_at*'
     }
 
+    It 'rejects explain when manifest planning metadata is missing parent_run_id' {
+@"
+version: 1
+session:
+  name: winsmux-orchestra
+  project_dir: $script:explainTempRoot
+panes:
+  builder-1:
+    pane_id: %2
+    role: Builder
+    task_id: task-256
+    task: Implement run ledger
+    goal: Ship run contract primitives
+    task_type: implementation
+    task_state: in_progress
+    task_owner: builder-1
+    review_state: PENDING
+    priority: P0
+    branch: worktree-builder-1
+    head_sha: abc1234def5678
+    changed_file_count: 1
+    changed_files: '["scripts/winsmux-core.ps1"]'
+    last_event: commander.review_requested
+    last_event_at: 2026-04-10T12:00:00+09:00
+"@ | Set-Content -Path $script:explainManifestPath -Encoding UTF8
+
+        function global:winsmux {
+            $commandLine = ($args | ForEach-Object { [string]$_ }) -join ' '
+            switch -Regex ($commandLine) {
+                '^capture-pane .*%2' { return @('gpt-5.4   64% context left', '? send   Ctrl+J newline', '>') }
+                default { throw "unexpected winsmux call: $commandLine" }
+            }
+        }
+
+        { Get-ExplainPayload -ProjectDir $script:explainTempRoot -RunId 'task:task-256' } | Should -Throw '*invalid manifest*pane ''builder-1'' planning metadata requires parent_run_id*'
+    }
+
+    It 'rejects explain when manifest planning metadata is missing goal' {
+@"
+version: 1
+session:
+  name: winsmux-orchestra
+  project_dir: $script:explainTempRoot
+panes:
+  builder-1:
+    pane_id: %2
+    role: Builder
+    task_id: task-256
+    parent_run_id: operator:session-1
+    task: Implement run ledger
+    task_type: implementation
+    task_state: in_progress
+    task_owner: builder-1
+    review_state: PENDING
+    priority: P0
+    branch: worktree-builder-1
+    head_sha: abc1234def5678
+    changed_file_count: 1
+    changed_files: '["scripts/winsmux-core.ps1"]'
+    last_event: commander.review_requested
+    last_event_at: 2026-04-10T12:00:00+09:00
+"@ | Set-Content -Path $script:explainManifestPath -Encoding UTF8
+
+        function global:winsmux {
+            $commandLine = ($args | ForEach-Object { [string]$_ }) -join ' '
+            switch -Regex ($commandLine) {
+                '^capture-pane .*%2' { return @('gpt-5.4   64% context left', '? send   Ctrl+J newline', '>') }
+                default { throw "unexpected winsmux call: $commandLine" }
+            }
+        }
+
+        { Get-ExplainPayload -ProjectDir $script:explainTempRoot -RunId 'task:task-256' } | Should -Throw '*invalid manifest*pane ''builder-1'' planning metadata requires goal*'
+    }
+
+    It 'rejects explain when manifest planning metadata is missing task_type' {
+@"
+version: 1
+session:
+  name: winsmux-orchestra
+  project_dir: $script:explainTempRoot
+panes:
+  builder-1:
+    pane_id: %2
+    role: Builder
+    task_id: task-256
+    parent_run_id: operator:session-1
+    task: Implement run ledger
+    goal: Ship run contract primitives
+    task_state: in_progress
+    task_owner: builder-1
+    review_state: PENDING
+    priority: P0
+    branch: worktree-builder-1
+    head_sha: abc1234def5678
+    changed_file_count: 1
+    changed_files: '["scripts/winsmux-core.ps1"]'
+    last_event: commander.review_requested
+    last_event_at: 2026-04-10T12:00:00+09:00
+"@ | Set-Content -Path $script:explainManifestPath -Encoding UTF8
+
+        function global:winsmux {
+            $commandLine = ($args | ForEach-Object { [string]$_ }) -join ' '
+            switch -Regex ($commandLine) {
+                '^capture-pane .*%2' { return @('gpt-5.4   64% context left', '? send   Ctrl+J newline', '>') }
+                default { throw "unexpected winsmux call: $commandLine" }
+            }
+        }
+
+        { Get-ExplainPayload -ProjectDir $script:explainTempRoot -RunId 'task:task-256' } | Should -Throw '*invalid manifest*pane ''builder-1'' planning metadata requires task_type*'
+    }
+
+    It 'rejects explain when manifest planning metadata is missing priority' {
+@"
+version: 1
+session:
+  name: winsmux-orchestra
+  project_dir: $script:explainTempRoot
+panes:
+  builder-1:
+    pane_id: %2
+    role: Builder
+    task_id: task-256
+    parent_run_id: operator:session-1
+    task: Implement run ledger
+    goal: Ship run contract primitives
+    task_type: implementation
+    task_state: in_progress
+    task_owner: builder-1
+    review_state: PENDING
+    branch: worktree-builder-1
+    head_sha: abc1234def5678
+    changed_file_count: 1
+    changed_files: '["scripts/winsmux-core.ps1"]'
+    last_event: commander.review_requested
+    last_event_at: 2026-04-10T12:00:00+09:00
+"@ | Set-Content -Path $script:explainManifestPath -Encoding UTF8
+
+        function global:winsmux {
+            $commandLine = ($args | ForEach-Object { [string]$_ }) -join ' '
+            switch -Regex ($commandLine) {
+                '^capture-pane .*%2' { return @('gpt-5.4   64% context left', '? send   Ctrl+J newline', '>') }
+                default { throw "unexpected winsmux call: $commandLine" }
+            }
+        }
+
+        { Get-ExplainPayload -ProjectDir $script:explainTempRoot -RunId 'task:task-256' } | Should -Throw '*invalid manifest*pane ''builder-1'' planning metadata requires priority*'
+    }
+
     It 'keeps refs and returns null packets when artifact files are missing or malformed' {
 @"
 version: 1


### PR DESCRIPTION
## Summary
- fail-close manifest-backed runs when the planning metadata family is only partially populated
- add explain regressions for missing `parent_run_id`, `goal`, `task_type`, and `priority`
- update the schema freeze inventory with the new planning metadata slice

## Validation
- `Invoke-Pester tests/winsmux-bridge.Tests.ps1 -CI -Output Detailed`
- `pwsh -NoProfile -File .\scripts\git-guard.ps1 -Mode full`
- `pwsh -NoProfile -File .\scripts\audit-public-surface.ps1`