### PR TITLE
feat: add stdin prompt transport parity

### DIFF
--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -497,7 +497,7 @@ function New-SendDispatchPointerText {
 }
 
 function Get-SupportedPromptTransportValues {
-    return @('argv', 'file')
+    return @('argv', 'file', 'stdin')
 }
 
 function Resolve-SupportedPromptTransport {
@@ -512,7 +512,7 @@ function Resolve-SupportedPromptTransport {
     $supportedValues = @(Get-SupportedPromptTransportValues)
     if ($resolved -notin $supportedValues) {
         $supportedText = $supportedValues -join ', '
-        throw "Unsupported prompt_transport setting: $PromptTransport. Supported values: $supportedText. stdin is not implemented for pane dispatch."
+        throw "Unsupported prompt_transport setting: $PromptTransport. Supported values: $supportedText."
     }
 
     return $resolved
@@ -632,6 +632,10 @@ function Resolve-SendDispatchPayload {
         return $payload
     }
 
+    if ($resolvedPromptTransport -eq 'stdin') {
+        return $payload
+    }
+
     if ($resolvedPromptTransport -eq 'argv' -and $Text.Length -le $LengthLimit) {
         return $payload
     }
@@ -692,6 +696,9 @@ function Resolve-SendTransportPlan {
         }
     }
 
+    # Exec-mode dispatch stays file-backed even when prompt_transport is stdin.
+    # The pane receives a single codex exec command, and that command reads the
+    # prompt from a stable file path so long prompts and task-slug reuse stay deterministic.
     $normalizedTaskSlug = ''
     $promptPath = $null
     if (-not [string]::IsNullOrWhiteSpace($TaskSlug)) {
@@ -1691,6 +1698,23 @@ function Invoke-WinsmuxSendKeys {
     }
 }
 
+function Invoke-WinsmuxSendPaste {
+    param(
+        [Parameter(Mandatory = $true)][string]$Target,
+        [Parameter(Mandatory = $true)][AllowEmptyString()][string]$Text
+    )
+
+    $encoded = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($Text))
+    $arguments = @('send-paste', '-t', $Target, $encoded)
+    $output = Invoke-WinsmuxRaw -Arguments $arguments 2>&1
+
+    return [ordered]@{
+        ExitCode = $LASTEXITCODE
+        Output   = ($output | Out-String).Trim()
+        Target   = $Target
+    }
+}
+
 function Split-SendKeysLiteralChunks {
     param(
         [Parameter(Mandatory = $true)][AllowEmptyString()][string]$Text,
@@ -1736,23 +1760,34 @@ function Test-PaneContainsCommandFragment {
 function Send-TextToPane {
     param(
         [Parameter(Mandatory = $true)][string]$PaneId,
-        [Parameter(Mandatory = $true)][string]$CommandText
+        [Parameter(Mandatory = $true)][string]$CommandText,
+        [AllowEmptyString()][string]$PromptTransport = 'argv'
     )
 
+    $resolvedPromptTransport = Resolve-SupportedPromptTransport -PromptTransport $PromptTransport
     $targetCandidates = @(Get-PaneTargetCandidates -PaneId $PaneId)
     $attemptFailures = [System.Collections.Generic.List[string]]::new()
 
     foreach ($sendTarget in $targetCandidates) {
         $preSendText = Get-PaneSnapshotText -PaneId $PaneId -Lines 200
-        $literalChunks = @(Split-SendKeysLiteralChunks -Text $CommandText)
+        if ($resolvedPromptTransport -eq 'stdin') {
+            $pasteResult = Invoke-WinsmuxSendPaste -Target $sendTarget -Text $CommandText
+            if ($pasteResult.ExitCode -ne 0) {
+                $detail = if ([string]::IsNullOrWhiteSpace($pasteResult.Output)) { 'send-paste failed' } else { $pasteResult.Output }
+                $attemptFailures.Add("target ${sendTarget}: $detail") | Out-Null
+                continue
+            }
+        } else {
+            $literalChunks = @(Split-SendKeysLiteralChunks -Text $CommandText)
 
-        # Type text directly (no header; headers break TUI agents like Claude Code)
-        for ($chunkIndex = 0; $chunkIndex -lt $literalChunks.Count; $chunkIndex++) {
-            $literalResult = Invoke-WinsmuxSendKeys -Target $sendTarget -Keys @($literalChunks[$chunkIndex]) -Literal
-            if ($literalResult.ExitCode -ne 0) {
-                $detail = if ([string]::IsNullOrWhiteSpace($literalResult.Output)) { 'send-keys literal failed' } else { $literalResult.Output }
-                $attemptFailures.Add("target ${sendTarget}: chunk $($chunkIndex + 1)/$($literalChunks.Count) $detail") | Out-Null
-                continue 2
+            # Type text directly (no header; headers break TUI agents like Claude Code)
+            for ($chunkIndex = 0; $chunkIndex -lt $literalChunks.Count; $chunkIndex++) {
+                $literalResult = Invoke-WinsmuxSendKeys -Target $sendTarget -Keys @($literalChunks[$chunkIndex]) -Literal
+                if ($literalResult.ExitCode -ne 0) {
+                    $detail = if ([string]::IsNullOrWhiteSpace($literalResult.Output)) { 'send-keys literal failed' } else { $literalResult.Output }
+                    $attemptFailures.Add("target ${sendTarget}: chunk $($chunkIndex + 1)/$($literalChunks.Count) $detail") | Out-Null
+                    continue 2
+                }
             }
         }
 
@@ -2566,7 +2601,7 @@ function Invoke-Send {
         Write-Warning ("send target '{0}' used prompt_transport={1}; wrote full text to {2} and sent a prompt-file pointer instead." -f $Target, $transportPlan['PromptTransport'], $transportPlan['PromptPath'])
     }
 
-    Send-TextToPane -PaneId $paneId -CommandText ([string]$transportPlan['TextToSend'])
+    Send-TextToPane -PaneId $paneId -CommandText ([string]$transportPlan['TextToSend']) -PromptTransport ([string]$transportPlan['PromptTransport'])
 }
 
 function Invoke-Name {

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -449,9 +449,21 @@ model: gpt-5.4
         $metadata.SlotCount | Should -BeGreaterThan 0
     }
 
-    It 'fails closed when prompt_transport is unsupported' {
+    It 'accepts stdin prompt_transport from project settings' {
 @'
 prompt-transport: stdin
+'@ | Set-Content -Path (Join-Path $script:settingsTempRoot '.winsmux.yaml') -Encoding UTF8
+
+        Mock Get-WinsmuxOption { param($Name, $Default) return $null }
+
+        $settings = Get-BridgeSettings
+
+        $settings.prompt_transport | Should -Be 'stdin'
+    }
+
+    It 'fails closed when prompt_transport is unsupported' {
+@'
+prompt-transport: socket
 '@ | Set-Content -Path (Join-Path $script:settingsTempRoot '.winsmux.yaml') -Encoding UTF8
 
         Mock Get-WinsmuxOption { param($Name, $Default) return $null }
@@ -7385,6 +7397,35 @@ Describe 'winsmux send dispatch payload' {
         $payload['IsFileBacked'] | Should -Be $false
     }
 
+    It 'keeps stdin prompt_transport inline even when the payload exceeds the argv length limit' {
+        $payload = Resolve-SendDispatchPayload -Text ('a' * 5000) -ProjectDir $script:sendTempRoot -LengthLimit 4000 -PromptTransport 'stdin'
+
+        $payload['PromptTransport'] | Should -Be 'stdin'
+        $payload['IsFileBacked'] | Should -Be $false
+        $payload['PromptPath'] | Should -Be $null
+        $payload['TextLength'] | Should -Be 5000
+    }
+
+    It 'keeps exec-mode transport file-backed even when prompt_transport is stdin' {
+        $plan = Resolve-SendTransportPlan `
+            -Text ('a' * 5000) `
+            -ProjectDir $script:sendTempRoot `
+            -LengthLimit 4000 `
+            -PromptTransport 'stdin' `
+            -ExecMode:$true `
+            -LaunchDir 'C:\repo' `
+            -GitWorktreeDir 'C:\repo' `
+            -Model 'gpt-5.4'
+
+        $plan['Mode'] | Should -Be 'codex_exec_file'
+        $plan['PromptTransport'] | Should -Be 'stdin'
+        $plan['IsFileBacked'] | Should -Be $true
+        $plan['FallbackMode'] | Should -Be 'exec_file'
+        $plan['PromptPath'] | Should -Not -BeNullOrEmpty
+        (Get-Content -LiteralPath $plan['PromptPath'] -Raw -Encoding UTF8).TrimEnd("`r", "`n") | Should -BeExactly ('a' * 5000)
+        $plan['ExecInstruction'] | Should -Match 'codex exec'
+    }
+
     It 'normalizes task prompt slugs and writes a stable task prompt file when task_slug is supplied' {
         (ConvertTo-TaskPromptSlug -TaskSlug ' Cache Drift / Build ') | Should -Be 'cache-drift-build'
 
@@ -7408,7 +7449,7 @@ Describe 'winsmux send dispatch payload' {
     }
 
     It 'rejects unsupported prompt transport values with the stable-core contract in the error' {
-        { Resolve-SendDispatchPayload -Text 'Write-Host short' -ProjectDir $script:sendTempRoot -LengthLimit 4000 -PromptTransport 'stdin' } | Should -Throw '*Supported values: argv, file*'
+        { Resolve-SendDispatchPayload -Text 'Write-Host short' -ProjectDir $script:sendTempRoot -LengthLimit 4000 -PromptTransport 'socket' } | Should -Throw '*Supported values: argv, file, stdin*'
     }
 
     It 'blocks send text when a blocklist security policy pattern matches' {
@@ -9512,6 +9553,72 @@ Describe 'winsmux send fallback' {
         $result | Should -Be 'sent to %7 via default:0.3'
         (@($script:sendAttempts | Where-Object { $_ -like '* literal*' })).Count | Should -Be 4
         $script:sendAttempts[-1] | Should -Be 'default:0.3 Enter'
+    }
+
+    It 'uses send-paste when prompt_transport is stdin' {
+        $script:sendAttempts = [System.Collections.Generic.List[string]]::new()
+        $script:sendBuffer = '> '
+        $script:sendCommandText = "line 1`nline 2"
+
+        Mock Invoke-WinsmuxRaw {
+            param([string[]]$Arguments)
+
+            switch ($Arguments[0]) {
+                'list-panes' {
+                    $format = $Arguments[-1]
+                    if ($format -eq '#{pane_id}') {
+                        return '%7'
+                    }
+
+                    if ($format -eq "#{pane_id}`t#{session_name}:#{window_index}.#{pane_index}") {
+                        return '%7' + "`t" + 'default:0.3'
+                    }
+
+                    return @()
+                }
+                'capture-pane' {
+                    return $script:sendBuffer
+                }
+                'send-paste' {
+                    $targetIndex = [Array]::IndexOf($Arguments, '-t')
+                    $target = if ($targetIndex -ge 0 -and $targetIndex + 1 -lt $Arguments.Count) {
+                        $Arguments[$targetIndex + 1]
+                    } else {
+                        ''
+                    }
+
+                    $decoded = [System.Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($Arguments[-1]))
+                    $script:sendAttempts.Add("$target paste") | Out-Null
+                    if ($target -eq 'default:0.3') {
+                        $script:sendBuffer = "> $decoded"
+                    }
+                    return
+                }
+                'send-keys' {
+                    $targetIndex = [Array]::IndexOf($Arguments, '-t')
+                    $target = if ($targetIndex -ge 0 -and $targetIndex + 1 -lt $Arguments.Count) {
+                        $Arguments[$targetIndex + 1]
+                    } else {
+                        ''
+                    }
+
+                    $script:sendAttempts.Add("$target Enter") | Out-Null
+                    if ($target -eq 'default:0.3') {
+                        $script:sendBuffer += "`nresult"
+                    }
+                    return
+                }
+                default {
+                    throw "Unexpected winsmux command: $($Arguments -join ' ')"
+                }
+            }
+        }
+
+        $result = Send-TextToPane -PaneId '%7' -CommandText $script:sendCommandText -PromptTransport 'stdin'
+
+        $result | Should -Be 'sent to %7 via default:0.3'
+        $script:sendBuffer | Should -Be "> $script:sendCommandText`nresult"
+        $script:sendAttempts | Should -Be @('%7 paste', 'default:0.3 paste', 'default:0.3 Enter')
     }
 
 }

--- a/winsmux-core/scripts/settings.ps1
+++ b/winsmux-core/scripts/settings.ps1
@@ -479,6 +479,10 @@ function Test-BridgeSettingValue {
                     $NormalizedValue.Value = 'file'
                     return $true
                 }
+                'stdin' {
+                    $NormalizedValue.Value = 'stdin'
+                    return $true
+                }
                 default {
                     return $false
                 }


### PR DESCRIPTION
## Summary
- accept `prompt_transport: stdin` in bridge settings and dispatch payload resolution
- route pane dispatch through `send-paste` when stdin transport is selected
- keep exec-mode transport file-backed and lock that behavior with tests

## Validation
- `pwsh -NoProfile -Command "Invoke-Pester .\tests\winsmux-bridge.Tests.ps1 -Output Detailed"`
- `pwsh -NoProfile -File .\scripts\git-guard.ps1 -Mode full`
