### PR TITLE
Add desktop summary refresh stream

### DIFF
--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -5026,6 +5026,81 @@ function Get-DesktopSummaryPayload {
     }
 }
 
+function Get-DesktopSummaryRefreshRunId {
+    param([Parameter(Mandatory = $true)]$EventRecord)
+
+    $data = $null
+    if ($EventRecord.Contains('data')) {
+        $data = $EventRecord['data']
+    }
+
+    $runId = ''
+    if ($null -ne $data -and $data -is [System.Collections.IDictionary] -and $data.Contains('run_id')) {
+        $runId = [string]$data['run_id']
+    }
+    if ([string]::IsNullOrWhiteSpace($runId) -and $EventRecord.Contains('run_id')) {
+        $runId = [string]$EventRecord['run_id']
+    }
+    if (-not [string]::IsNullOrWhiteSpace($runId)) {
+        return $runId
+    }
+
+    $taskId = ''
+    if ($null -ne $data -and $data -is [System.Collections.IDictionary] -and $data.Contains('task_id')) {
+        $taskId = [string]$data['task_id']
+    }
+    if ([string]::IsNullOrWhiteSpace($taskId) -and $EventRecord.Contains('task_id')) {
+        $taskId = [string]$EventRecord['task_id']
+    }
+    if (-not [string]::IsNullOrWhiteSpace($taskId)) {
+        return "task:$taskId"
+    }
+
+    $branch = [string]$EventRecord['branch']
+    if ([string]::IsNullOrWhiteSpace($branch) -and $null -ne $data -and $data -is [System.Collections.IDictionary] -and $data.Contains('branch')) {
+        $branch = [string]$data['branch']
+    }
+    if (-not [string]::IsNullOrWhiteSpace($branch)) {
+        return "branch:$branch"
+    }
+
+    return ''
+}
+
+function ConvertTo-DesktopSummaryRefreshItem {
+    param([Parameter(Mandatory = $true)]$EventRecord)
+
+    $reason = [string]$EventRecord['event']
+    if ([string]::IsNullOrWhiteSpace($reason) -and $EventRecord.Contains('status')) {
+        $reason = [string]$EventRecord['status']
+    }
+    if ([string]::IsNullOrWhiteSpace($reason)) {
+        return $null
+    }
+
+    $item = [ordered]@{
+        source = 'summary'
+        reason = $reason
+    }
+
+    $timestamp = [string]$EventRecord['timestamp']
+    if (-not [string]::IsNullOrWhiteSpace($timestamp)) {
+        $item['timestamp'] = $timestamp
+    }
+
+    $paneId = [string]$EventRecord['pane_id']
+    if (-not [string]::IsNullOrWhiteSpace($paneId)) {
+        $item['pane_id'] = $paneId
+    }
+
+    $runId = Get-DesktopSummaryRefreshRunId -EventRecord $EventRecord
+    if (-not [string]::IsNullOrWhiteSpace($runId)) {
+        $item['run_id'] = $runId
+    }
+
+    return $item
+}
+
 function Get-ExplainPayload {
     param(
         [Parameter(Mandatory = $true)][string]$ProjectDir,
@@ -5133,19 +5208,66 @@ function Invoke-DesktopSummary {
         [AllowNull()][string[]]$DesktopSummaryRest = $Rest
     )
 
-    $jsonOutput = $false
+    $tokens = @()
+    if (-not [string]::IsNullOrWhiteSpace($DesktopSummaryTarget)) {
+        $tokens += $DesktopSummaryTarget
+    }
+    if ($DesktopSummaryRest) {
+        $tokens += @($DesktopSummaryRest)
+    }
 
-    if ($DesktopSummaryTarget) {
-        if ($DesktopSummaryTarget -eq '--json' -and (-not $DesktopSummaryRest -or $DesktopSummaryRest.Count -eq 0)) {
-            $jsonOutput = $true
-        } else {
-            Stop-WithError "usage: winsmux desktop-summary [--json]"
+    $jsonOutput = $false
+    $streamOutput = $false
+
+    foreach ($token in $tokens) {
+        switch ($token) {
+            '--json'   { $jsonOutput = $true }
+            '--stream' { $streamOutput = $true }
+            default    { Stop-WithError "usage: winsmux desktop-summary [--json] [--stream]" }
         }
-    } elseif ($DesktopSummaryRest -and $DesktopSummaryRest.Count -gt 0) {
-        Stop-WithError "usage: winsmux desktop-summary [--json]"
     }
 
     $projectDir = (Get-Location).Path
+    if ($streamOutput) {
+        $cursor = @(Get-BridgeEventRecords -ProjectDir $projectDir).Count
+        while ($true) {
+            $delta = Get-BridgeEventDelta -ProjectDir $projectDir -Cursor $cursor
+            $cursor = [int]$delta.cursor
+            foreach ($eventRecord in @($delta.events)) {
+                $item = ConvertTo-DesktopSummaryRefreshItem -EventRecord $eventRecord
+                if ($null -eq $item) {
+                    continue
+                }
+
+                if ($jsonOutput) {
+                    $item | ConvertTo-Json -Compress -Depth 8 | Write-Output
+                    continue
+                }
+
+                $timestamp = if ($item.Contains('timestamp')) { [string]$item.timestamp } else { '' }
+                if ([string]::IsNullOrWhiteSpace($timestamp)) {
+                    $timestamp = (Get-Date).ToString('o')
+                }
+
+                $details = @()
+                if ($item.Contains('pane_id')) {
+                    $details += "pane=$([string]$item.pane_id)"
+                }
+                if ($item.Contains('run_id')) {
+                    $details += "run=$([string]$item.run_id)"
+                }
+
+                if ($details.Count -gt 0) {
+                    Write-Output ("[{0}] summary {1} {2}" -f $timestamp, [string]$item.reason, ($details -join ' '))
+                } else {
+                    Write-Output ("[{0}] summary {1}" -f $timestamp, [string]$item.reason)
+                }
+            }
+
+            Start-Sleep -Seconds 2
+        }
+    }
+
     $payload = Get-DesktopSummaryPayload -ProjectDir $projectDir
 
     if ($jsonOutput) {
@@ -6616,7 +6738,7 @@ Commands:
   health-check              Report READY/BUSY/HUNG/DEAD for labeled panes
   status                    Report manifest pane states via capture-pane
   board [--json]            Report pane/task/review/git session board
-desktop-summary [--json]  Report the aggregated desktop read-model snapshot
+desktop-summary [--json] [--stream]  Report the aggregated desktop read-model snapshot or follow refresh signals
 inbox [--json] [--stream] Report actionable approvals/review/blockers
 runs [--json]             Report run-oriented session view
 digest [--json] [--stream] [--events] Report high-signal evidence digest per run or actionable event summaries

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -6416,6 +6416,33 @@ Set-Location '__DIGEST_TEMP_ROOT__'
         $result.run_projections[0].worktree | Should -Be '.worktrees/builder-1'
     }
 
+    It 'converts event records into desktop summary refresh items' {
+        $item = ConvertTo-DesktopSummaryRefreshItem -EventRecord ([ordered]@{
+                timestamp = '2026-04-10T14:02:00+09:00'
+                event     = 'pane.completed'
+                pane_id   = '%2'
+                branch    = 'worktree-builder-1'
+                data      = [ordered]@{
+                    task_id = 'task-246'
+                }
+            })
+
+        $item.source | Should -Be 'summary'
+        $item.reason | Should -Be 'pane.completed'
+        $item.pane_id | Should -Be '%2'
+        $item.run_id | Should -Be 'task:task-246'
+    }
+
+    It 'derives desktop summary refresh run ids from branch context when task metadata is absent' {
+        $runId = Get-DesktopSummaryRefreshRunId -EventRecord ([ordered]@{
+                event   = 'pane.idle'
+                pane_id = '%6'
+                branch  = 'worktree-builder-1'
+            })
+
+        $runId | Should -Be 'branch:worktree-builder-1'
+    }
+
     It 'prefers launch_dir in desktop-summary projections when the builder path lags behind' {
 @"
 version: 1

--- a/winsmux-app/src-tauri/src/desktop_backend.rs
+++ b/winsmux-app/src-tauri/src/desktop_backend.rs
@@ -331,8 +331,7 @@ pub enum DesktopCommand {
 }
 
 pub enum DesktopStreamCommand {
-    Inbox { project_dir: Option<String> },
-    Digest { project_dir: Option<String> },
+    Summary { project_dir: Option<String> },
 }
 
 impl DesktopCommand {
@@ -358,23 +357,15 @@ impl DesktopCommand {
 impl DesktopStreamCommand {
     fn project_dir(&self) -> Option<&str> {
         match self {
-            DesktopStreamCommand::Inbox { project_dir } => project_dir.as_deref(),
-            DesktopStreamCommand::Digest { project_dir } => project_dir.as_deref(),
+            DesktopStreamCommand::Summary { project_dir } => project_dir.as_deref(),
         }
     }
 
     fn winsmux_args(&self) -> Vec<String> {
         match self {
-            DesktopStreamCommand::Inbox { .. } => {
+            DesktopStreamCommand::Summary { .. } => {
                 vec![
-                    "inbox".to_string(),
-                    "--stream".to_string(),
-                    "--json".to_string(),
-                ]
-            }
-            DesktopStreamCommand::Digest { .. } => {
-                vec![
-                    "digest".to_string(),
+                    "desktop-summary".to_string(),
                     "--stream".to_string(),
                     "--json".to_string(),
                 ]
@@ -384,8 +375,7 @@ impl DesktopStreamCommand {
 
     fn source_name(&self) -> &'static str {
         match self {
-            DesktopStreamCommand::Inbox { .. } => "inbox",
-            DesktopStreamCommand::Digest { .. } => "digest",
+            DesktopStreamCommand::Summary { .. } => "summary",
         }
     }
 }
@@ -620,11 +610,20 @@ pub fn parse_desktop_summary_stream_signal(
     let payload: Value = serde_json::from_str(trimmed).ok()?;
     let object = payload.as_object()?;
 
-    let is_valid = match source {
+    let optional_string = |key: &str| {
+        object
+            .get(key)
+            .and_then(|value| value.as_str())
+            .filter(|value| !value.trim().is_empty())
+            .map(|value| value.to_string())
+    };
+
+    let reason = match source {
         "digest" => object
             .get("run_id")
             .and_then(|value| value.as_str())
-            .is_some(),
+            .is_some()
+            .then(|| "digest.stream".to_string()),
         "inbox" => {
             object
                 .get("kind")
@@ -635,23 +634,17 @@ pub fn parse_desktop_summary_stream_signal(
                     .and_then(|value| value.as_str())
                     .is_some()
         }
-        _ => false,
+        .then(|| "inbox.stream".to_string()),
+        "summary" => optional_string("reason"),
+        _ => None,
     };
-    if !is_valid {
-        return None;
-    }
+    let reason = reason?;
 
     Some(DesktopSummaryRefreshSignal {
         source: source.to_string(),
-        reason: format!("{}.stream", source),
-        pane_id: object
-            .get("pane_id")
-            .and_then(|value| value.as_str())
-            .map(|value| value.to_string()),
-        run_id: object
-            .get("run_id")
-            .and_then(|value| value.as_str())
-            .map(|value| value.to_string()),
+        reason,
+        pane_id: optional_string("pane_id"),
+        run_id: optional_string("run_id"),
     })
 }
 
@@ -1754,10 +1747,30 @@ mod tests {
     }
 
     #[test]
+    fn parse_desktop_summary_stream_signal_accepts_summary_reason_and_run() {
+        let signal = parse_desktop_summary_stream_signal(
+            "summary",
+            r#"{"reason":"pane.completed","pane_id":"%4","run_id":"task:task-289"}"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            signal,
+            DesktopSummaryRefreshSignal {
+                source: "summary".to_string(),
+                reason: "pane.completed".to_string(),
+                pane_id: Some("%4".to_string()),
+                run_id: Some("task:task-289".to_string()),
+            }
+        );
+    }
+
+    #[test]
     fn parse_desktop_summary_stream_signal_rejects_untyped_json_lines() {
         assert!(parse_desktop_summary_stream_signal("digest", r#"{"pane_id":"%2"}"#).is_none());
         assert!(
             parse_desktop_summary_stream_signal("inbox", r#"{"message":"missing kind"}"#).is_none()
         );
+        assert!(parse_desktop_summary_stream_signal("summary", r#"{"pane_id":"%2"}"#).is_none());
     }
 }

--- a/winsmux-app/src-tauri/src/lib.rs
+++ b/winsmux-app/src-tauri/src/lib.rs
@@ -48,26 +48,15 @@ fn start_desktop_summary_refresh_streams(app: &AppHandle) {
         return;
     }
 
-    let inbox_app = app.clone();
+    let summary_app = app.clone();
     if let Err(err) = spawn_desktop_summary_refresh_stream(
-        DesktopStreamCommand::Inbox { project_dir: None },
+        DesktopStreamCommand::Summary { project_dir: None },
         manager.stop_requested.clone(),
         move |signal| {
-            emit_desktop_summary_refresh(&inbox_app, signal);
+            emit_desktop_summary_refresh(&summary_app, signal);
         },
     ) {
-        eprintln!("Failed to start inbox summary stream adapter: {}", err);
-    }
-
-    let digest_app = app.clone();
-    if let Err(err) = spawn_desktop_summary_refresh_stream(
-        DesktopStreamCommand::Digest { project_dir: None },
-        manager.stop_requested.clone(),
-        move |signal| {
-            emit_desktop_summary_refresh(&digest_app, signal);
-        },
-    ) {
-        eprintln!("Failed to start digest summary stream adapter: {}", err);
+        eprintln!("Failed to start desktop summary stream adapter: {}", err);
     }
 }
 


### PR DESCRIPTION
## Summary
- add `winsmux desktop-summary --stream --json` as a compact desktop refresh signal stream
- switch the Tauri desktop refresh adapter to the new summary stream instead of separate inbox/digest subscriptions
- add PowerShell and Rust coverage for summary refresh signal parsing and run-id derivation

## Testing
- cargo fmt --manifest-path winsmux-app/src-tauri/Cargo.toml
- cargo test --manifest-path winsmux-app/src-tauri/Cargo.toml parse_desktop_summary_stream_signal -- --nocapture
- cargo test --manifest-path winsmux-app/src-tauri/Cargo.toml
- cmd /c npm run build
- pwsh -NoProfile -Command "Invoke-Pester .\tests\winsmux-bridge.Tests.ps1 -Output Detailed"
- pwsh -NoProfile -File .\scripts\git-guard.ps1 -Mode full