### PR TITLE
TASK-290: add explain detail changed file summary

### DIFF
--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -6739,6 +6739,7 @@ panes:
         $result.run.verification_contract.mode | Should -Be 'adversarial_verify'
         $result.run.verification_result.outcome | Should -Be 'PARTIAL'
         $result.observation_pack.failing_command | Should -Be 'Invoke-Pester tests/winsmux-bridge.Tests.ps1'
+        $result.observation_pack.changed_files | Should -Contain 'scripts/winsmux-core.ps1'
         $result.consultation_packet.kind | Should -Be 'consult_result'
         $result.consultation_packet.mode | Should -Be 'early'
         $result.observation_pack.Contains('packet_type') | Should -BeFalse
@@ -6765,6 +6766,7 @@ panes:
         @($result.recent_events | ForEach-Object { $_.event }) | Should -Contain 'pipeline.verify.partial'
         @($result.recent_events | ForEach-Object { $_.event }) | Should -Contain 'pane.approval_waiting'
         ($result.recent_events | Where-Object { $_.event -eq 'commander.review_requested' } | Select-Object -First 1).hypothesis | Should -Be 'experiment packet should flow into explain'
+        ($result.recent_events | Where-Object { $_.event -eq 'commander.review_requested' } | Select-Object -First 1).observation_pack.changed_files | Should -Contain 'scripts/winsmux-core.ps1'
         ($result.recent_events | Where-Object { $_.event -eq 'commander.review_requested' } | Select-Object -First 1).observation_pack.packet_type | Should -Be 'observation_pack'
         ($result.recent_events | Where-Object { $_.event -eq 'commander.review_requested' } | Select-Object -First 1).consultation_packet.kind | Should -Be 'consult_result'
     }

--- a/winsmux-app/src-tauri/src/desktop_backend.rs
+++ b/winsmux-app/src-tauri/src/desktop_backend.rs
@@ -1859,6 +1859,12 @@ mod tests {
                     result["observation_pack"]["working_tree_summary"],
                     "1 file modified"
                 );
+                let changed_files = result["observation_pack"]["changed_files"]
+                    .as_array()
+                    .expect("observation_pack.changed_files should be an array");
+                assert!(changed_files
+                    .iter()
+                    .any(|value| { value.as_str() == Some("scripts/winsmux-core.ps1") }));
                 assert!(result["observation_pack"].get("packet_type").is_none());
                 assert!(result["consultation_packet"].get("packet_type").is_none());
                 assert_eq!(result["evidence_digest"]["next_action"], "review_pending");

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -1377,6 +1377,9 @@ async function openExplainForSelectedRun() {
     if (payload.run.branch) {
       detailItems.push({ label: "branch", value: payload.run.branch });
     }
+    if (payload.run.worktree) {
+      detailItems.push({ label: "worktree", value: payload.run.worktree });
+    }
     if (payload.run.head_sha) {
       detailItems.push({ label: "head", value: payload.run.head_sha.slice(0, 8) });
     }
@@ -1414,6 +1417,10 @@ async function openExplainForSelectedRun() {
     const bodyParts = [payload.explanation.summary];
     if (payload.run.goal) {
       bodyParts.push(`Goal: ${payload.run.goal}`);
+    }
+    const workspaceContext = summarizeWorkspaceContext(payload.run.branch, payload.run.worktree);
+    if (workspaceContext) {
+      bodyParts.push(`Workspace: ${workspaceContext}`);
     }
     if (payload.explanation.reasons.length > 0) {
       bodyParts.push(`Reasons: ${payload.explanation.reasons.join(" | ")}`);
@@ -1477,6 +1484,7 @@ function appendFallbackExplain() {
   if (!selectedRunId || projection?.run_id !== selectedRunId) {
     return;
   }
+  const workspaceContext = summarizeWorkspaceContext(projection.branch, projection.worktree);
 
   appendRuntimeConversation({
     type: "operator",
@@ -1484,10 +1492,14 @@ function appendFallbackExplain() {
     timestamp,
     actor: "Operator",
     title: "Explain unavailable",
-    body: `Explain unavailable for ${selectedRunId}.`,
+    body: workspaceContext
+      ? `Explain unavailable for ${selectedRunId}. Workspace: ${workspaceContext}.`
+      : `Explain unavailable for ${selectedRunId}.`,
     details: [
       { label: "run", value: selectedRunId },
       { label: "next", value: projection.next_action || "idle" },
+      { label: "branch", value: projection.branch || "no branch" },
+      { label: "worktree", value: projection.worktree || "project root" },
       { label: "changed", value: `${projection.changed_files.length}` },
     ],
     tone: "info",
@@ -2047,6 +2059,11 @@ function summarizeChangedFiles(paths: string[], limit = 3) {
 
   const remaining = paths.length - visible.length;
   return remaining > 0 ? `${visible.join(", ")} +${remaining} more` : visible.join(", ");
+}
+
+function summarizeWorkspaceContext(branch: string, worktree: string) {
+  const parts = [branch, worktree].filter((value) => Boolean(value));
+  return parts.join(" @ ");
 }
 
 function getRunProjectionFingerprint(projection: DesktopRunProjection | null | undefined) {

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -1350,6 +1350,9 @@ async function openExplainForSelectedRun() {
       { label: "run", value: payload.run.run_id },
       { label: "next", value: payload.explanation.next_action || payload.evidence_digest.next_action || "no next action" },
     ];
+    if (payload.run.provider_target) {
+      detailItems.push({ label: "model", value: payload.run.provider_target });
+    }
     if (payload.run.priority) {
       detailItems.push({ label: "priority", value: payload.run.priority });
     }
@@ -1374,6 +1377,9 @@ async function openExplainForSelectedRun() {
     if (payload.run.branch) {
       detailItems.push({ label: "branch", value: payload.run.branch });
     }
+    if (payload.run.head_sha) {
+      detailItems.push({ label: "head", value: payload.run.head_sha.slice(0, 8) });
+    }
     if (payload.run.last_event) {
       detailItems.push({ label: "event", value: payload.run.last_event });
     }
@@ -1389,11 +1395,20 @@ async function openExplainForSelectedRun() {
       ].filter((value) => Boolean(value));
       detailItems.push({ label: "state", value: currentStateParts.join(" / ") });
     }
+    if (payload.run.review_state) {
+      detailItems.push({ label: "review", value: payload.run.review_state });
+    }
     if (payload.evidence_digest.verification_outcome) {
       detailItems.push({ label: "verify", value: payload.evidence_digest.verification_outcome });
     }
     if (payload.evidence_digest.security_blocked) {
       detailItems.push({ label: "security", value: payload.evidence_digest.security_blocked });
+    }
+    const changedFiles = payload.run.changed_files.length > 0
+      ? payload.run.changed_files
+      : payload.evidence_digest.changed_files;
+    if (changedFiles.length > 0) {
+      detailItems.push({ label: "changed", value: `${changedFiles.length}` });
     }
 
     const bodyParts = [payload.explanation.summary];
@@ -1419,6 +1434,9 @@ async function openExplainForSelectedRun() {
         observationPack.failing_command,
       ].filter((value) => Boolean(value));
       bodyParts.push(`Observe: ${observationParts.join(" | ")}`);
+    }
+    if (changedFiles.length > 0) {
+      bodyParts.push(`Files: ${summarizeChangedFiles(changedFiles)}`);
     }
     if (payload.recent_events.length > 0) {
       const recent = payload.recent_events
@@ -2019,6 +2037,16 @@ function getConsultationSummary(payload: DesktopExplainPayload): {
     next_test: packet.next_test,
     risks: packet.risks,
   };
+}
+
+function summarizeChangedFiles(paths: string[], limit = 3) {
+  const visible = paths.filter((value) => Boolean(value)).slice(0, limit);
+  if (visible.length === 0) {
+    return "";
+  }
+
+  const remaining = paths.length - visible.length;
+  return remaining > 0 ? `${visible.join(", ")} +${remaining} more` : visible.join(", ");
 }
 
 function getRunProjectionFingerprint(projection: DesktopRunProjection | null | undefined) {

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -1401,6 +1401,9 @@ async function openExplainForSelectedRun() {
     if (payload.run.review_state) {
       detailItems.push({ label: "review", value: payload.run.review_state });
     }
+    if (payload.review_state?.reviewer?.label) {
+      detailItems.push({ label: "reviewer", value: payload.review_state.reviewer.label });
+    }
     if (payload.evidence_digest.verification_outcome) {
       detailItems.push({ label: "verify", value: payload.evidence_digest.verification_outcome });
     }

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -1422,6 +1422,10 @@ async function openExplainForSelectedRun() {
     if (workspaceContext) {
       bodyParts.push(`Workspace: ${workspaceContext}`);
     }
+    const reviewVerdict = summarizeReviewVerdict(payload);
+    if (reviewVerdict) {
+      bodyParts.push(`Review: ${reviewVerdict}`);
+    }
     if (payload.explanation.reasons.length > 0) {
       bodyParts.push(`Reasons: ${payload.explanation.reasons.join(" | ")}`);
     }
@@ -2064,6 +2068,28 @@ function summarizeChangedFiles(paths: string[], limit = 3) {
 function summarizeWorkspaceContext(branch: string, worktree: string) {
   const parts = [branch, worktree].filter((value) => Boolean(value));
   return parts.join(" @ ");
+}
+
+function summarizeReviewVerdict(payload: DesktopExplainPayload) {
+  const status = payload.review_state?.status || payload.run.review_state;
+  if (!status) {
+    return "";
+  }
+
+  const parts = [status];
+  if (payload.review_state?.reviewer?.label) {
+    parts.push(`by ${payload.review_state.reviewer.label}`);
+  }
+
+  const evidence = payload.review_state?.evidence;
+  const evidenceSource =
+    (status === "PASS" ? evidence?.approved_via : undefined) ||
+    ((status === "FAIL" || status === "FAILED") ? evidence?.failed_via : undefined);
+  if (evidenceSource) {
+    parts.push(`via ${evidenceSource}`);
+  }
+
+  return parts.join(" ");
 }
 
 function getRunProjectionFingerprint(projection: DesktopRunProjection | null | undefined) {


### PR DESCRIPTION
## Summary
- add explain detail pills for model, head, review, and changed-file count
- show a compact changed-files summary in the explain body with evidence fallback
- add PowerShell and Rust coverage for observation pack changed files

## Validation
- cmd /c npm run build
- cargo fmt --manifest-path winsmux-app/src-tauri/Cargo.toml
- cargo test --manifest-path winsmux-app/src-tauri/Cargo.toml
- pwsh -NoProfile -Command "Invoke-Pester .\tests\winsmux-bridge.Tests.ps1 -Output Detailed"
- pwsh -NoProfile -File .\scripts\git-guard.ps1 -Mode full
- pwsh -NoProfile -File .\scripts\audit-public-surface.ps1
