### PR TITLE
TASK-305: add hypothesis cards to desktop follow updates

### DIFF
--- a/winsmux-app/index.html
+++ b/winsmux-app/index.html
@@ -126,6 +126,9 @@
           <aside id="context-panel">
             <div class="panel-title">Context</div>
             <div id="context-sections"></div>
+            <div class="panel-title secondary-title">Experiments</div>
+            <div id="experiment-overview-cards"></div>
+            <div id="experiment-detail-list"></div>
             <div class="panel-title secondary-title">Source control</div>
             <div id="source-overview-cards"></div>
             <div class="panel-title secondary-title">Changed files</div>

--- a/winsmux-app/src-tauri/src/desktop_backend.rs
+++ b/winsmux-app/src-tauri/src/desktop_backend.rs
@@ -208,6 +208,53 @@ pub struct DesktopPromoteTacticCandidate {
 }
 
 #[derive(Serialize, Deserialize)]
+pub struct DesktopCompareRunsResult {
+    pub generated_at: String,
+    pub left: DesktopCompareRunSide,
+    pub right: DesktopCompareRunSide,
+    pub shared_changed_files: Vec<String>,
+    pub left_only_changed_files: Vec<String>,
+    pub right_only_changed_files: Vec<String>,
+    #[serde(default)]
+    pub confidence_delta: Option<f64>,
+    #[serde(default)]
+    pub differences: Vec<DesktopCompareDifference>,
+    pub recommend: DesktopCompareRecommendation,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct DesktopCompareRunSide {
+    pub run_id: String,
+    pub label: String,
+    pub branch: String,
+    pub task_state: String,
+    pub review_state: String,
+    pub state: String,
+    pub next_action: String,
+    #[serde(default)]
+    pub confidence: Option<f64>,
+    #[serde(default)]
+    pub changed_files: Vec<String>,
+    pub observation_pack_ref: String,
+    pub consultation_ref: String,
+    pub recommendable: bool,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct DesktopCompareDifference {
+    pub field: String,
+    pub left: Value,
+    pub right: Value,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct DesktopCompareRecommendation {
+    pub winning_run_id: String,
+    pub reconcile_consult: bool,
+    pub next_action: String,
+}
+
+#[derive(Serialize, Deserialize)]
 pub struct DesktopExplainPayload {
     pub generated_at: String,
     pub project_dir: String,
@@ -467,6 +514,11 @@ pub enum DesktopCommand {
         run_id: String,
         project_dir: Option<String>,
     },
+    RunCompare {
+        left_run_id: String,
+        right_run_id: String,
+        project_dir: Option<String>,
+    },
     RunPromote {
         run_id: String,
         project_dir: Option<String>,
@@ -482,6 +534,7 @@ impl DesktopCommand {
         match self {
             DesktopCommand::SummarySnapshot { project_dir } => project_dir.as_deref(),
             DesktopCommand::RunExplain { project_dir, .. } => project_dir.as_deref(),
+            DesktopCommand::RunCompare { project_dir, .. } => project_dir.as_deref(),
             DesktopCommand::RunPromote { project_dir, .. } => project_dir.as_deref(),
         }
     }
@@ -493,6 +546,18 @@ impl DesktopCommand {
             }
             DesktopCommand::RunExplain { run_id, .. } => {
                 vec!["explain".to_string(), run_id.clone(), "--json".to_string()]
+            }
+            DesktopCommand::RunCompare {
+                left_run_id,
+                right_run_id,
+                ..
+            } => {
+                vec![
+                    "compare-runs".to_string(),
+                    left_run_id.clone(),
+                    right_run_id.clone(),
+                    "--json".to_string(),
+                ]
             }
             DesktopCommand::RunPromote { run_id, .. } => {
                 vec![
@@ -568,6 +633,21 @@ pub fn load_desktop_run_explain(
         .map_err(|err| format!("Failed to parse desktop explain payload: {err}"))
 }
 
+pub fn load_desktop_run_compare(
+    transport: &dyn DesktopCommandTransport,
+    left_run_id: String,
+    right_run_id: String,
+    project_dir: Option<String>,
+) -> Result<DesktopCompareRunsResult, String> {
+    let payload = transport.request_json(&DesktopCommand::RunCompare {
+        left_run_id,
+        right_run_id,
+        project_dir,
+    })?;
+    serde_json::from_value(payload)
+        .map_err(|err| format!("Failed to parse desktop compare payload: {err}"))
+}
+
 pub fn load_desktop_run_promote(
     transport: &dyn DesktopCommandTransport,
     run_id: String,
@@ -635,6 +715,39 @@ pub fn handle_desktop_json_rpc(
                         request_id,
                         JSON_RPC_INTERNAL_ERROR,
                         format!("Failed to serialize desktop explain payload: {err}"),
+                    ),
+                },
+                Err(err) => json_rpc_error(request_id, JSON_RPC_SERVER_ERROR, err),
+            }
+        }
+        "desktop.run.compare" => {
+            let left_run_id =
+                match get_required_string_param(params.as_ref(), &["leftRunId", "left_run_id"]) {
+                    Ok(value) => value,
+                    Err(err) => {
+                        return json_rpc_error(request_id, JSON_RPC_INVALID_PARAMS, err);
+                    }
+                };
+            let right_run_id =
+                match get_required_string_param(params.as_ref(), &["rightRunId", "right_run_id"]) {
+                    Ok(value) => value,
+                    Err(err) => {
+                        return json_rpc_error(request_id, JSON_RPC_INVALID_PARAMS, err);
+                    }
+                };
+
+            match load_desktop_run_compare(
+                transport,
+                left_run_id,
+                right_run_id,
+                resolved_project_dir,
+            ) {
+                Ok(result) => match serde_json::to_value(result) {
+                    Ok(value) => json_rpc_result(request_id, value),
+                    Err(err) => json_rpc_error(
+                        request_id,
+                        JSON_RPC_INTERNAL_ERROR,
+                        format!("Failed to serialize desktop compare payload: {err}"),
                     ),
                 },
                 Err(err) => json_rpc_error(request_id, JSON_RPC_SERVER_ERROR, err),
@@ -1108,6 +1221,67 @@ mod tests {
                 ],
                 "observation_pack_ref": ".winsmux/observation-packs/observation-pack-__ID__.json",
                 "consultation_ref": ".winsmux/consultations/consult-result-__ID__.json"
+            }
+        })
+    }
+
+    fn desktop_compare_runs_payload() -> Value {
+        serde_json::json!({
+            "generated_at": "__GENERATED_AT__",
+            "left": {
+                "run_id": "task:task-256",
+                "label": "builder-1",
+                "branch": "worktree-builder-a",
+                "task_state": "completed",
+                "review_state": "PASS",
+                "state": "idle",
+                "next_action": "promote tactic",
+                "confidence": 0.85,
+                "changed_files": ["scripts/winsmux-core.ps1"],
+                "observation_pack_ref": ".winsmux/observation-packs/observation-pack-a.json",
+                "consultation_ref": ".winsmux/consultations/consult-result-a.json",
+                "recommendable": true
+            },
+            "right": {
+                "run_id": "task:task-257",
+                "label": "builder-2",
+                "branch": "worktree-builder-b",
+                "task_state": "completed",
+                "review_state": "PASS",
+                "state": "idle",
+                "next_action": "reconcile consult",
+                "confidence": 0.4,
+                "changed_files": [
+                    "scripts/winsmux-core.ps1",
+                    "tests/winsmux-bridge.Tests.ps1"
+                ],
+                "observation_pack_ref": ".winsmux/observation-packs/observation-pack-b.json",
+                "consultation_ref": ".winsmux/consultations/consult-result-b.json",
+                "recommendable": true
+            },
+            "shared_changed_files": ["scripts/winsmux-core.ps1"],
+            "left_only_changed_files": [],
+            "right_only_changed_files": ["tests/winsmux-bridge.Tests.ps1"],
+            "confidence_delta": 0.45,
+            "differences": [
+                {
+                    "field": "result",
+                    "left": "cache hit done",
+                    "right": "still dirty"
+                },
+                {
+                    "field": "changed_files",
+                    "left": ["scripts/winsmux-core.ps1"],
+                    "right": [
+                        "scripts/winsmux-core.ps1",
+                        "tests/winsmux-bridge.Tests.ps1"
+                    ]
+                }
+            ],
+            "recommend": {
+                "winning_run_id": "task:task-256",
+                "reconcile_consult": true,
+                "next_action": "reconcile_consult"
             }
         })
     }
@@ -1931,6 +2105,36 @@ mod tests {
     }
 
     #[test]
+    fn load_desktop_run_compare_uses_compare_command() {
+        let transport = FakeTransport {
+            requests: RefCell::new(Vec::new()),
+            response: desktop_compare_runs_payload(),
+        };
+
+        let payload = load_desktop_run_compare(
+            &transport,
+            "task:task-256".to_string(),
+            "task:task-257".to_string(),
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(payload.left.run_id, "task:task-256");
+        assert_eq!(payload.right.run_id, "task:task-257");
+        assert_eq!(payload.confidence_delta, Some(0.45));
+        assert_eq!(payload.left.changed_files.len(), 1);
+        assert_eq!(payload.right.changed_files.len(), 2);
+        assert_eq!(payload.differences.len(), 2);
+        assert_eq!(payload.recommend.winning_run_id, "task:task-256");
+        assert!(payload.recommend.reconcile_consult);
+        assert_eq!(payload.recommend.next_action, "reconcile_consult");
+        assert_eq!(
+            transport.requests.borrow().as_slice(),
+            ["compare-runs task:task-256 task:task-257 --json"]
+        );
+    }
+
+    #[test]
     fn handle_desktop_json_rpc_routes_run_explain_and_prunes_extra_packets() {
         let transport = FakeTransport {
             requests: RefCell::new(Vec::new()),
@@ -2082,6 +2286,47 @@ mod tests {
         assert_eq!(
             transport.requests.borrow().as_slice(),
             ["promote-tactic task:task-256 --json"]
+        );
+    }
+
+    #[test]
+    fn handle_desktop_json_rpc_routes_run_compare() {
+        let transport = FakeTransport {
+            requests: RefCell::new(Vec::new()),
+            response: desktop_compare_runs_payload(),
+        };
+        let response = handle_desktop_json_rpc(
+            &transport,
+            DesktopJsonRpcRequest {
+                jsonrpc: "2.0".to_string(),
+                id: serde_json::json!("req-compare"),
+                method: "desktop.run.compare".to_string(),
+                params: Some(serde_json::json!({
+                    "leftRunId": "task:task-256",
+                    "rightRunId": "task:task-257"
+                })),
+            },
+            None,
+        );
+
+        match response {
+            DesktopJsonRpcResponse::Success { id, result, .. } => {
+                assert_eq!(id, serde_json::json!("req-compare"));
+                assert_eq!(result["left"]["run_id"], "task:task-256");
+                assert_eq!(result["right"]["run_id"], "task:task-257");
+                assert_eq!(result["confidence_delta"], 0.45);
+                assert_eq!(result["differences"][0]["field"], "result");
+                assert_eq!(result["recommend"]["winning_run_id"], "task:task-256");
+                assert_eq!(result["recommend"]["reconcile_consult"], true);
+                assert_eq!(result["recommend"]["next_action"], "reconcile_consult");
+            }
+            DesktopJsonRpcResponse::Error { error, .. } => {
+                panic!("expected success, got {:?}", error);
+            }
+        }
+        assert_eq!(
+            transport.requests.borrow().as_slice(),
+            ["compare-runs task:task-256 task:task-257 --json"]
         );
     }
 

--- a/winsmux-app/src-tauri/src/desktop_backend.rs
+++ b/winsmux-app/src-tauri/src/desktop_backend.rs
@@ -183,6 +183,31 @@ pub struct DesktopEditorFilePayload {
 }
 
 #[derive(Serialize, Deserialize)]
+pub struct DesktopPromoteTacticResult {
+    pub generated_at: String,
+    pub run_id: String,
+    pub candidate_ref: String,
+    pub candidate_path: String,
+    pub candidate: DesktopPromoteTacticCandidate,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct DesktopPromoteTacticCandidate {
+    pub packet_type: String,
+    pub kind: String,
+    pub title: String,
+    pub summary: String,
+    pub hypothesis: String,
+    pub next_action: String,
+    #[serde(default)]
+    pub confidence: Option<f64>,
+    #[serde(default)]
+    pub changed_files: Vec<String>,
+    pub observation_pack_ref: String,
+    pub consultation_ref: String,
+}
+
+#[derive(Serialize, Deserialize)]
 pub struct DesktopExplainPayload {
     pub generated_at: String,
     pub project_dir: String,
@@ -442,6 +467,10 @@ pub enum DesktopCommand {
         run_id: String,
         project_dir: Option<String>,
     },
+    RunPromote {
+        run_id: String,
+        project_dir: Option<String>,
+    },
 }
 
 pub enum DesktopStreamCommand {
@@ -453,6 +482,7 @@ impl DesktopCommand {
         match self {
             DesktopCommand::SummarySnapshot { project_dir } => project_dir.as_deref(),
             DesktopCommand::RunExplain { project_dir, .. } => project_dir.as_deref(),
+            DesktopCommand::RunPromote { project_dir, .. } => project_dir.as_deref(),
         }
     }
 
@@ -463,6 +493,13 @@ impl DesktopCommand {
             }
             DesktopCommand::RunExplain { run_id, .. } => {
                 vec!["explain".to_string(), run_id.clone(), "--json".to_string()]
+            }
+            DesktopCommand::RunPromote { run_id, .. } => {
+                vec![
+                    "promote-tactic".to_string(),
+                    run_id.clone(),
+                    "--json".to_string(),
+                ]
             }
         }
     }
@@ -531,6 +568,19 @@ pub fn load_desktop_run_explain(
         .map_err(|err| format!("Failed to parse desktop explain payload: {err}"))
 }
 
+pub fn load_desktop_run_promote(
+    transport: &dyn DesktopCommandTransport,
+    run_id: String,
+    project_dir: Option<String>,
+) -> Result<DesktopPromoteTacticResult, String> {
+    let payload = transport.request_json(&DesktopCommand::RunPromote {
+        run_id,
+        project_dir,
+    })?;
+    serde_json::from_value(payload)
+        .map_err(|err| format!("Failed to parse desktop promote payload: {err}"))
+}
+
 pub fn load_desktop_editor_file(
     path: String,
     worktree: Option<String>,
@@ -585,6 +635,26 @@ pub fn handle_desktop_json_rpc(
                         request_id,
                         JSON_RPC_INTERNAL_ERROR,
                         format!("Failed to serialize desktop explain payload: {err}"),
+                    ),
+                },
+                Err(err) => json_rpc_error(request_id, JSON_RPC_SERVER_ERROR, err),
+            }
+        }
+        "desktop.run.promote" => {
+            let run_id = match get_required_string_param(params.as_ref(), &["runId", "run_id"]) {
+                Ok(value) => value,
+                Err(err) => {
+                    return json_rpc_error(request_id, JSON_RPC_INVALID_PARAMS, err);
+                }
+            };
+
+            match load_desktop_run_promote(transport, run_id, resolved_project_dir) {
+                Ok(result) => match serde_json::to_value(result) {
+                    Ok(value) => json_rpc_result(request_id, value),
+                    Err(err) => json_rpc_error(
+                        request_id,
+                        JSON_RPC_INTERNAL_ERROR,
+                        format!("Failed to serialize desktop promote payload: {err}"),
                     ),
                 },
                 Err(err) => json_rpc_error(request_id, JSON_RPC_SERVER_ERROR, err),
@@ -1016,6 +1086,30 @@ mod tests {
         let mut payload = rust_parity_explain_payload();
         payload["review_state"] = rust_parity_review_state_payload();
         payload
+    }
+
+    fn desktop_promote_tactic_payload() -> Value {
+        serde_json::json!({
+            "generated_at": "__GENERATED_AT__",
+            "run_id": "task:task-256",
+            "candidate_ref": ".winsmux/playbook-candidates/playbook-candidate-__ID__.json",
+            "candidate_path": "__PROJECT_DIR__/.winsmux/playbook-candidates/playbook-candidate-__ID__.json",
+            "candidate": {
+                "packet_type": "playbook_candidate",
+                "kind": "playbook",
+                "title": "Stabilize explain contract",
+                "summary": "Promote explain contract handling into the playbook.",
+                "hypothesis": "The explain path is stable enough to reuse.",
+                "next_action": "promote_to_playbook",
+                "confidence": 0.82,
+                "changed_files": [
+                    "winsmux-app/src-tauri/src/desktop_backend.rs",
+                    "winsmux-app/src/main.ts"
+                ],
+                "observation_pack_ref": ".winsmux/observation-packs/observation-pack-__ID__.json",
+                "consultation_ref": ".winsmux/consultations/consult-result-__ID__.json"
+            }
+        })
     }
 
     fn expect_missing_explain_run_field(field_name: &str) -> String {
@@ -1787,6 +1881,56 @@ mod tests {
     }
 
     #[test]
+    fn load_desktop_run_promote_uses_promote_command() {
+        let transport = FakeTransport {
+            requests: RefCell::new(Vec::new()),
+            response: desktop_promote_tactic_payload(),
+        };
+
+        let payload =
+            load_desktop_run_promote(&transport, "task:task-256".to_string(), None).unwrap();
+
+        assert_eq!(payload.run_id, "task:task-256");
+        assert_eq!(payload.generated_at, "__GENERATED_AT__");
+        assert_eq!(
+            payload.candidate_ref,
+            ".winsmux/playbook-candidates/playbook-candidate-__ID__.json"
+        );
+        assert_eq!(payload.candidate.packet_type, "playbook_candidate");
+        assert_eq!(payload.candidate.kind, "playbook");
+        assert_eq!(payload.candidate.title, "Stabilize explain contract");
+        assert_eq!(
+            payload.candidate.summary,
+            "Promote explain contract handling into the playbook."
+        );
+        assert_eq!(
+            payload.candidate.hypothesis,
+            "The explain path is stable enough to reuse."
+        );
+        assert_eq!(payload.candidate.next_action, "promote_to_playbook");
+        assert_eq!(payload.candidate.confidence, Some(0.82));
+        assert_eq!(
+            payload.candidate.changed_files,
+            vec![
+                "winsmux-app/src-tauri/src/desktop_backend.rs".to_string(),
+                "winsmux-app/src/main.ts".to_string()
+            ]
+        );
+        assert_eq!(
+            payload.candidate.observation_pack_ref,
+            ".winsmux/observation-packs/observation-pack-__ID__.json"
+        );
+        assert_eq!(
+            payload.candidate.consultation_ref,
+            ".winsmux/consultations/consult-result-__ID__.json"
+        );
+        assert_eq!(
+            transport.requests.borrow().as_slice(),
+            ["promote-tactic task:task-256 --json"]
+        );
+    }
+
+    #[test]
     fn handle_desktop_json_rpc_routes_run_explain_and_prunes_extra_packets() {
         let transport = FakeTransport {
             requests: RefCell::new(Vec::new()),
@@ -1881,6 +2025,63 @@ mod tests {
         assert_eq!(
             transport.requests.borrow().as_slice(),
             ["explain task:task-256 --json"]
+        );
+    }
+
+    #[test]
+    fn handle_desktop_json_rpc_routes_run_promote() {
+        let transport = FakeTransport {
+            requests: RefCell::new(Vec::new()),
+            response: desktop_promote_tactic_payload(),
+        };
+        let response = handle_desktop_json_rpc(
+            &transport,
+            DesktopJsonRpcRequest {
+                jsonrpc: "2.0".to_string(),
+                id: serde_json::json!("req-promote"),
+                method: "desktop.run.promote".to_string(),
+                params: Some(serde_json::json!({
+                    "runId": "task:task-256"
+                })),
+            },
+            None,
+        );
+
+        match response {
+            DesktopJsonRpcResponse::Success { id, result, .. } => {
+                assert_eq!(id, serde_json::json!("req-promote"));
+                assert_eq!(result["run_id"], "task:task-256");
+                assert_eq!(
+                    result["candidate_ref"],
+                    ".winsmux/playbook-candidates/playbook-candidate-__ID__.json"
+                );
+                assert_eq!(result["candidate"]["packet_type"], "playbook_candidate");
+                assert_eq!(result["candidate"]["kind"], "playbook");
+                assert_eq!(
+                    result["candidate"]["title"],
+                    "Stabilize explain contract"
+                );
+                assert_eq!(
+                    result["candidate"]["next_action"],
+                    "promote_to_playbook"
+                );
+                assert_eq!(result["candidate"]["confidence"], 0.82);
+                assert_eq!(
+                    result["candidate"]["changed_files"][0],
+                    "winsmux-app/src-tauri/src/desktop_backend.rs"
+                );
+                assert_eq!(
+                    result["candidate"]["consultation_ref"],
+                    ".winsmux/consultations/consult-result-__ID__.json"
+                );
+            }
+            DesktopJsonRpcResponse::Error { error, .. } => {
+                panic!("expected success, got {:?}", error);
+            }
+        }
+        assert_eq!(
+            transport.requests.borrow().as_slice(),
+            ["promote-tactic task:task-256 --json"]
         );
     }
 

--- a/winsmux-app/src/desktopClient.ts
+++ b/winsmux-app/src/desktopClient.ts
@@ -4,10 +4,12 @@ import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 type DesktopCommandName =
   | "desktop_summary_snapshot"
   | "desktop_run_explain"
+  | "desktop_run_promote"
   | "desktop_editor_read";
 type DesktopJsonRpcMethod =
   | "desktop.summary.snapshot"
   | "desktop.run.explain"
+  | "desktop.run.promote"
   | "desktop.editor.read";
 
 interface DesktopJsonRpcRequest {
@@ -356,6 +358,27 @@ export interface DesktopSummaryRefreshEvent {
   run_id?: string;
 }
 
+export interface DesktopPromoteTacticCandidate {
+  packet_type: string;
+  kind: string;
+  title: string;
+  summary: string;
+  hypothesis: string;
+  next_action: string;
+  confidence: number | null;
+  changed_files: string[];
+  observation_pack_ref: string;
+  consultation_ref: string;
+}
+
+export interface DesktopPromoteTacticResult {
+  generated_at: string;
+  run_id: string;
+  candidate_ref: string;
+  candidate_path: string;
+  candidate: DesktopPromoteTacticCandidate;
+}
+
 let nextDesktopJsonRpcId = 0;
 
 function normalizeDesktopError(action: string, error: unknown) {
@@ -372,6 +395,8 @@ function getDesktopJsonRpcMethod(command: DesktopCommandName): DesktopJsonRpcMet
       return "desktop.summary.snapshot";
     case "desktop_run_explain":
       return "desktop.run.explain";
+    case "desktop_run_promote":
+      return "desktop.run.promote";
     case "desktop_editor_read":
       return "desktop.editor.read";
   }
@@ -454,6 +479,17 @@ export async function getDesktopRunExplain(runId: string) {
     );
   } catch (error) {
     throw normalizeDesktopError(`desktop_run_explain(${runId})`, error);
+  }
+}
+
+export async function promoteDesktopRunTactic(runId: string) {
+  try {
+    return await desktopCommandTransport.request<DesktopPromoteTacticResult>(
+      "desktop_run_promote",
+      { runId },
+    );
+  } catch (error) {
+    throw normalizeDesktopError(`desktop_run_promote(${runId})`, error);
   }
 }
 

--- a/winsmux-app/src/desktopClient.ts
+++ b/winsmux-app/src/desktopClient.ts
@@ -4,11 +4,13 @@ import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 type DesktopCommandName =
   | "desktop_summary_snapshot"
   | "desktop_run_explain"
+  | "desktop_run_compare"
   | "desktop_run_promote"
   | "desktop_editor_read";
 type DesktopJsonRpcMethod =
   | "desktop.summary.snapshot"
   | "desktop.run.explain"
+  | "desktop.run.compare"
   | "desktop.run.promote"
   | "desktop.editor.read";
 
@@ -379,6 +381,45 @@ export interface DesktopPromoteTacticResult {
   candidate: DesktopPromoteTacticCandidate;
 }
 
+export interface DesktopCompareRunSide {
+  run_id: string;
+  label: string;
+  branch: string;
+  task_state: string;
+  review_state: string;
+  state: string;
+  next_action: string;
+  confidence: number | null;
+  changed_files: string[];
+  observation_pack_ref: string;
+  consultation_ref: string;
+  recommendable: boolean;
+}
+
+export interface DesktopCompareDifference {
+  field: string;
+  left: unknown;
+  right: unknown;
+}
+
+export interface DesktopCompareRecommendation {
+  winning_run_id: string;
+  reconcile_consult: boolean;
+  next_action: string;
+}
+
+export interface DesktopCompareRunsResult {
+  generated_at: string;
+  left: DesktopCompareRunSide;
+  right: DesktopCompareRunSide;
+  shared_changed_files: string[];
+  left_only_changed_files: string[];
+  right_only_changed_files: string[];
+  confidence_delta: number | null;
+  differences: DesktopCompareDifference[];
+  recommend: DesktopCompareRecommendation;
+}
+
 let nextDesktopJsonRpcId = 0;
 
 function normalizeDesktopError(action: string, error: unknown) {
@@ -395,6 +436,8 @@ function getDesktopJsonRpcMethod(command: DesktopCommandName): DesktopJsonRpcMet
       return "desktop.summary.snapshot";
     case "desktop_run_explain":
       return "desktop.run.explain";
+    case "desktop_run_compare":
+      return "desktop.run.compare";
     case "desktop_run_promote":
       return "desktop.run.promote";
     case "desktop_editor_read":
@@ -479,6 +522,20 @@ export async function getDesktopRunExplain(runId: string) {
     );
   } catch (error) {
     throw normalizeDesktopError(`desktop_run_explain(${runId})`, error);
+  }
+}
+
+export async function compareDesktopRuns(leftRunId: string, rightRunId: string) {
+  try {
+    return await desktopCommandTransport.request<DesktopCompareRunsResult>(
+      "desktop_run_compare",
+      { leftRunId, rightRunId },
+    );
+  } catch (error) {
+    throw normalizeDesktopError(
+      `desktop_run_compare(${leftRunId}, ${rightRunId})`,
+      error,
+    );
   }
 }
 

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -2330,8 +2330,10 @@ function buildDesktopFollowConversation(
               },
             ]
           : []),
-        { label: "head", value: projection.head_short || "n/a" },
-        { label: "verify", value: projection.verification_outcome || "n/a" },
+        ...(projection.head_short ? [{ label: "head", value: projection.head_short }] : []),
+        ...(projection.verification_outcome
+          ? [{ label: "verify", value: projection.verification_outcome }]
+          : []),
       ],
       tone,
       runId,
@@ -2354,7 +2356,7 @@ function buildDesktopFollowConversation(
       body: `Run ${runId} dropped out of the desktop summary snapshot.`,
       details: [
         { label: "branch", value: previousProjection.branch || "no branch" },
-        { label: "head", value: previousProjection.head_short || "n/a" },
+        ...(previousProjection.head_short ? [{ label: "head", value: previousProjection.head_short }] : []),
       ],
       tone: "warning",
       runId,

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -2108,8 +2108,32 @@ function summarizeProjectionExperiment(projection: DesktopRunProjection) {
   return parts.join(" · ");
 }
 
+function summarizeProjectionConsultation(projection: DesktopRunProjection) {
+  if (!projection.consultation_ref) {
+    return "";
+  }
+
+  const parts = [summarizeProjectionExperiment(projection) || "Consultation linked"];
+  parts.push(`Next ${projection.next_action || "idle"}`);
+  const reasons = projection.reasons.filter((value) => Boolean(value)).slice(0, 2);
+  if (reasons.length > 0) {
+    parts.push(`Reasons ${reasons.join(" | ")}`);
+  }
+
+  return parts.join(" · ");
+}
+
 function formatConfidencePercent(value: number) {
   return `${Math.round(value * 100)}%`;
+}
+
+function summarizeArtifactRef(path: string) {
+  if (!path) {
+    return "";
+  }
+
+  const parts = path.split(/[\\/]/).filter((value) => Boolean(value));
+  return parts[parts.length - 1] || path;
 }
 
 function getRunProjectionFingerprint(projection: DesktopRunProjection | null | undefined) {
@@ -2227,7 +2251,10 @@ function buildDesktopFollowConversation(
       continue;
     }
     const experimentSummary = summarizeProjectionExperiment(projection);
-    const title = experimentSummary
+    const consultationSummary = summarizeProjectionConsultation(projection);
+    const title = consultationSummary
+      ? (diff.addedRunIds.includes(runId) ? "Consultation surfaced" : "Consultation updated")
+      : experimentSummary
       ? (diff.addedRunIds.includes(runId) ? "Hypothesis surfaced" : "Hypothesis updated")
       : (diff.addedRunIds.includes(runId) ? "Run surfaced" : "Run updated");
 
@@ -2242,7 +2269,9 @@ function buildDesktopFollowConversation(
       timestamp,
       actor: projection.label || projection.pane_id || "System",
       title,
-      body: experimentSummary
+      body: consultationSummary
+        ? `${consultationSummary} · ${projection.changed_files.length} changed files · review ${projection.review_state || "n/a"}.`
+        : experimentSummary
         ? `${experimentSummary} · Next ${projection.next_action || "idle"} · ${projection.changed_files.length} changed files · review ${projection.review_state || "n/a"}.`
         : `Next ${projection.next_action || "idle"} · ${projection.changed_files.length} changed files · review ${projection.review_state || "n/a"}.`,
       details: [
@@ -2252,6 +2281,9 @@ function buildDesktopFollowConversation(
         { label: "verify", value: projection.verification_outcome || "n/a" },
         ...(projection.confidence !== null
           ? [{ label: "confidence", value: formatConfidencePercent(projection.confidence) }]
+          : []),
+        ...(projection.consultation_ref
+          ? [{ label: "source", value: summarizeArtifactRef(projection.consultation_ref) }]
           : []),
       ],
       tone:

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -2309,15 +2309,6 @@ function buildDesktopFollowConversation(
         { label: "branch", value: projection.branch || "no branch" },
         { label: "review", value: projection.review_state || "n/a" },
         { label: "next", value: projection.next_action || "idle" },
-        ...(projection.consultation_ref
-          ? [{ label: "consultation", value: summarizeArtifactRef(projection.consultation_ref) }]
-          : []),
-        ...(projection.hypothesis
-          ? [{ label: "hypothesis", value: projection.hypothesis }]
-          : []),
-        ...(projection.confidence !== null
-          ? [{ label: "confidence", value: formatConfidencePercent(projection.confidence) }]
-          : []),
         ...(!(consultationSummary || experimentSummary) || projection.changed_files.length === 0
           ? [{ label: "changed", value: `${projection.changed_files.length}` }]
           : []),
@@ -2332,6 +2323,15 @@ function buildDesktopFollowConversation(
         ...(projection.head_short ? [{ label: "head", value: projection.head_short }] : []),
         ...(projection.verification_outcome
           ? [{ label: "verify", value: projection.verification_outcome }]
+          : []),
+        ...(projection.consultation_ref
+          ? [{ label: "consultation", value: summarizeArtifactRef(projection.consultation_ref) }]
+          : []),
+        ...(projection.hypothesis
+          ? [{ label: "hypothesis", value: projection.hypothesis }]
+          : []),
+        ...(projection.confidence !== null
+          ? [{ label: "confidence", value: formatConfidencePercent(projection.confidence) }]
           : []),
       ],
       tone,

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -2095,6 +2095,23 @@ function summarizeReviewVerdict(payload: DesktopExplainPayload) {
   return parts.join(" ");
 }
 
+function summarizeProjectionExperiment(projection: DesktopRunProjection) {
+  if (!projection.hypothesis) {
+    return "";
+  }
+
+  const parts = [`Hypothesis ${projection.hypothesis}`];
+  if (projection.confidence !== null) {
+    parts.push(`confidence ${formatConfidencePercent(projection.confidence)}`);
+  }
+
+  return parts.join(" · ");
+}
+
+function formatConfidencePercent(value: number) {
+  return `${Math.round(value * 100)}%`;
+}
+
 function getRunProjectionFingerprint(projection: DesktopRunProjection | null | undefined) {
   if (!projection) {
     return "";
@@ -2111,6 +2128,8 @@ function getRunProjectionFingerprint(projection: DesktopRunProjection | null | u
     projection.branch,
     projection.provider_target,
     projection.changed_files.join("|"),
+    projection.hypothesis,
+    projection.confidence,
   ]);
 }
 
@@ -2207,6 +2226,10 @@ function buildDesktopFollowConversation(
     if (!projection) {
       continue;
     }
+    const experimentSummary = summarizeProjectionExperiment(projection);
+    const title = experimentSummary
+      ? (diff.addedRunIds.includes(runId) ? "Hypothesis surfaced" : "Hypothesis updated")
+      : (diff.addedRunIds.includes(runId) ? "Run surfaced" : "Run updated");
 
     items.push({
       type: "system",
@@ -2218,16 +2241,18 @@ function buildDesktopFollowConversation(
           : "activity",
       timestamp,
       actor: projection.label || projection.pane_id || "System",
-      title: diff.addedRunIds.includes(runId) ? "Run surfaced" : "Run updated",
-      body:
-        `Next ${projection.next_action || "idle"} · ` +
-        `${projection.changed_files.length} changed files · ` +
-        `review ${projection.review_state || "n/a"}.`,
+      title,
+      body: experimentSummary
+        ? `${experimentSummary} · Next ${projection.next_action || "idle"} · ${projection.changed_files.length} changed files · review ${projection.review_state || "n/a"}.`
+        : `Next ${projection.next_action || "idle"} · ${projection.changed_files.length} changed files · review ${projection.review_state || "n/a"}.`,
       details: [
         { label: "run", value: runId },
         { label: "branch", value: projection.branch || "no branch" },
         { label: "head", value: projection.head_short || "n/a" },
         { label: "verify", value: projection.verification_outcome || "n/a" },
+        ...(projection.confidence !== null
+          ? [{ label: "confidence", value: formatConfidencePercent(projection.confidence) }]
+          : []),
       ],
       tone:
         projection.review_state === "PASS"

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -2306,6 +2306,10 @@ function buildDesktopFollowConversation(
         ? `Hypothesis: ${experimentSummary}`
         : `Run: ${projection.next_action || "idle"}`,
       details: [
+        { label: "run", value: runId },
+        { label: "branch", value: projection.branch || "no branch" },
+        { label: "review", value: projection.review_state || "n/a" },
+        { label: "next", value: projection.next_action || "idle" },
         ...(projection.consultation_ref
           ? [{ label: "consultation", value: summarizeArtifactRef(projection.consultation_ref) }]
           : []),
@@ -2315,14 +2319,10 @@ function buildDesktopFollowConversation(
         ...(projection.confidence !== null
           ? [{ label: "confidence", value: formatConfidencePercent(projection.confidence) }]
           : []),
-        { label: "run", value: runId },
-        { label: "next", value: projection.next_action || "idle" },
         { label: "changed", value: `${projection.changed_files.length}` },
         ...((consultationSummary || experimentSummary) && projection.changed_files.length > 0
           ? [{ label: "files", value: summarizeChangedFiles(projection.changed_files) }]
           : []),
-        { label: "review", value: projection.review_state || "n/a" },
-        { label: "branch", value: projection.branch || "no branch" },
         { label: "head", value: projection.head_short || "n/a" },
         { label: "verify", value: projection.verification_outcome || "n/a" },
       ],

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -2301,6 +2301,9 @@ function buildDesktopFollowConversation(
         { label: "run", value: runId },
         { label: "next", value: projection.next_action || "idle" },
         { label: "changed", value: `${projection.changed_files.length}` },
+        ...((consultationSummary || experimentSummary) && projection.changed_files.length > 0
+          ? [{ label: "files", value: summarizeChangedFiles(projection.changed_files) }]
+          : []),
         { label: "review", value: projection.review_state || "n/a" },
         { label: "branch", value: projection.branch || "no branch" },
         { label: "head", value: projection.head_short || "n/a" },

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -2245,16 +2245,20 @@ function buildDesktopFollowConversation(
   ]
     .map((runId, index) => {
       const projection = nextProjectionMap.get(runId);
+      const selectedRank = runId === selected ? 0 : 1;
       const signalRank = projection?.consultation_ref ? 0 : projection?.hypothesis ? 1 : 2;
-      const sourceRank = runId === selected ? 0 : diff.changedRunIds.includes(runId) ? 1 : 2;
-      return { runId, index, signalRank, sourceRank };
+      const sourceRank = diff.changedRunIds.includes(runId) ? 0 : 1;
+      return { runId, index, selectedRank, signalRank, sourceRank };
     })
     .sort((left, right) => {
-      if (left.sourceRank !== right.sourceRank) {
-        return left.sourceRank - right.sourceRank;
+      if (left.selectedRank !== right.selectedRank) {
+        return left.selectedRank - right.selectedRank;
       }
       if (left.signalRank !== right.signalRank) {
         return left.signalRank - right.signalRank;
+      }
+      if (left.sourceRank !== right.sourceRank) {
+        return left.sourceRank - right.sourceRank;
       }
       return left.index - right.index;
     })

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -2318,6 +2318,9 @@ function buildDesktopFollowConversation(
               },
             ]
           : []),
+        ...((consultationSummary || experimentSummary) && projection.head_short
+          ? [{ label: "head", value: projection.head_short }]
+          : []),
         ...((consultationSummary || experimentSummary)
           ? [{ label: "branch", value: projection.branch || "no branch" }]
           : []),
@@ -2333,7 +2336,9 @@ function buildDesktopFollowConversation(
         ...((consultationSummary || experimentSummary)
           ? [{ label: "next", value: projection.next_action || "idle" }]
           : []),
-        ...(projection.head_short ? [{ label: "head", value: projection.head_short }] : []),
+        ...(!(consultationSummary || experimentSummary) && projection.head_short
+          ? [{ label: "head", value: projection.head_short }]
+          : []),
         ...(!(consultationSummary || experimentSummary)
           ? [{ label: "branch", value: projection.branch || "no branch" }]
           : []),

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -2640,6 +2640,7 @@ function getRunProjectionFingerprint(projection: DesktopRunProjection | null | u
   }
 
   return JSON.stringify([
+    projection.label,
     projection.head_sha,
     projection.head_short,
     projection.worktree,

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -2311,7 +2311,9 @@ function buildDesktopFollowConversation(
         : `Run: ${projection.next_action || "idle"}`,
       details: [
         { label: "branch", value: projection.branch || "no branch" },
-        { label: "review", value: projection.review_state || "n/a" },
+        ...((consultationSummary || experimentSummary) || projection.review_state
+          ? [{ label: "review", value: projection.review_state || "n/a" }]
+          : []),
         ...((consultationSummary || experimentSummary)
           ? [{ label: "next", value: projection.next_action || "idle" }]
           : []),

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -190,9 +190,14 @@ let desktopSummaryFallbackRefreshRegistered = false;
 let desktopSummaryLiveRefreshAvailable = false;
 let desktopSummaryLastSuccessfulRefreshAt = 0;
 let desktopSummaryLastStreamSignalAt = 0;
+let desktopSummaryRefreshSerial = 0;
 const desktopExplainCache = new Map<string, DesktopExplainPayload>();
 const desktopRunCompareCache = new Map<string, DesktopCompareRunsResult>();
-const promotedRunCandidates = new Map<string, { fingerprint: string; candidateRef: string }>();
+const promotedRunCandidates = new Map<string, {
+  fingerprint: string;
+  candidateRef: string;
+  collapseAfterRefreshSerial: number;
+}>();
 const desktopEditorFileCache = new Map<string, EditorFile>();
 const desktopEditorLoadingPaths = new Set<string>();
 const desktopEditorLoadErrors = new Map<string, string>();
@@ -889,10 +894,14 @@ function renderExperimentContext() {
   const experimentPacket = payload.run.experiment_packet;
   const explainFingerprint = getExplainPayloadFingerprint(payload);
   const promotedCandidate = promotedRunCandidates.get(selectedProjection.run_id) ?? null;
-  const isPromotedCandidate =
+  const hasPromotedCandidate =
     promotedCandidate !== null &&
     promotedCandidate.fingerprint === explainFingerprint;
-  const promotedCandidateRef = isPromotedCandidate && promotedCandidate
+  const isPromotedCandidate = hasPromotedCandidate &&
+    promotedCandidate !== null &&
+    desktopSummaryRefreshSerial <= promotedCandidate.collapseAfterRefreshSerial;
+  const showLastExport = hasPromotedCandidate && !isPromotedCandidate;
+  const promotedCandidateRef = hasPromotedCandidate && promotedCandidate
     ? summarizeArtifactRef(promotedCandidate.candidateRef)
     : "";
   const comparePeer = getComparePeerProjection(
@@ -1065,7 +1074,9 @@ function renderExperimentContext() {
       details: [
         ...(isPromotedCandidate
           ? [{ label: "exported", value: promotedCandidateRef }]
-          : []),
+          : (showLastExport
+            ? [{ label: "last export", value: promotedCandidateRef }]
+            : [])),
         { label: "next", value: experimentPacket.next_action || "n/a" },
         { label: "consult", value: consultationSummary.next_test || "n/a" },
         { label: "confidence", value: formatConfidencePercent(experimentPacket.confidence || 0) },
@@ -1876,6 +1887,7 @@ async function promoteSelectedRunTactic(runId: string) {
       promotedRunCandidates.set(runId, {
         fingerprint: getExplainPayloadFingerprint(explainPayload),
         candidateRef: result.candidate_ref,
+        collapseAfterRefreshSerial: desktopSummaryRefreshSerial + 1,
       });
     } catch (refreshError) {
       console.warn("Failed to refresh promoted run explain payload", refreshError);
@@ -3345,6 +3357,7 @@ async function refreshDesktopSummary(forceExplainRunId?: string | null) {
     for (const runId of invalidatedRunIds) {
       promotedRunCandidates.delete(runId);
     }
+    desktopSummaryRefreshSerial += 1;
     desktopSummarySnapshot = snapshot;
     desktopSummaryLastSuccessfulRefreshAt = Date.now();
     selectedRunId = resolveSelectedRunId(snapshot, forceExplainRunId);

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -2289,20 +2289,20 @@ function buildDesktopFollowConversation(
         ? `Hypothesis: ${experimentSummary} · Next ${projection.next_action || "idle"} · ${projection.changed_files.length} changed files · review ${projection.review_state || "n/a"}.`
         : `Run: Next ${projection.next_action || "idle"} · ${projection.changed_files.length} changed files · review ${projection.review_state || "n/a"}.`,
       details: [
-        { label: "run", value: runId },
-        { label: "next", value: projection.next_action || "idle" },
-        { label: "branch", value: projection.branch || "no branch" },
-        { label: "head", value: projection.head_short || "n/a" },
-        { label: "verify", value: projection.verification_outcome || "n/a" },
+        ...(projection.consultation_ref
+          ? [{ label: "consultation", value: summarizeArtifactRef(projection.consultation_ref) }]
+          : []),
         ...(projection.hypothesis
           ? [{ label: "hypothesis", value: projection.hypothesis }]
           : []),
         ...(projection.confidence !== null
           ? [{ label: "confidence", value: formatConfidencePercent(projection.confidence) }]
           : []),
-        ...(projection.consultation_ref
-          ? [{ label: "consultation", value: summarizeArtifactRef(projection.consultation_ref) }]
-          : []),
+        { label: "run", value: runId },
+        { label: "next", value: projection.next_action || "idle" },
+        { label: "branch", value: projection.branch || "no branch" },
+        { label: "head", value: projection.head_short || "n/a" },
+        { label: "verify", value: projection.verification_outcome || "n/a" },
       ],
       tone,
       runId,

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -2334,9 +2334,6 @@ function buildDesktopFollowConversation(
         ...(projection.hypothesis
           ? [{ label: "hypothesis", value: projection.hypothesis }]
           : []),
-        ...(projection.confidence !== null
-          ? [{ label: "confidence", value: formatConfidencePercent(projection.confidence) }]
-          : []),
       ],
       tone,
       runId,

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -2313,8 +2313,8 @@ function buildDesktopFollowConversation(
         ...((consultationSummary || experimentSummary)
           ? [{ label: "branch", value: projection.branch || "no branch" }]
           : []),
-        ...((consultationSummary || experimentSummary) || projection.review_state
-          ? [{ label: "review", value: projection.review_state || "n/a" }]
+        ...(projection.review_state
+          ? [{ label: "review", value: projection.review_state }]
           : []),
         ...((consultationSummary || experimentSummary)
           ? [{ label: "next", value: projection.next_action || "idle" }]

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -942,7 +942,12 @@ function renderExperimentContext() {
           ? "Reconcile consult"
           : `Winner ${compareWinnerLabel || "not decided"}`,
         compareResult.recommend.next_action || "reconcile_consult",
-        compareDifferenceSummary || compareFileSummary || "No material diff",
+        [
+          compareDifferenceSummary,
+          compareFileSummary,
+        ]
+          .filter((value) => Boolean(value))
+          .join(" · ") || "No material diff",
       ]
         .filter((value) => Boolean(value))
         .join(" · ")
@@ -1030,6 +1035,8 @@ function renderExperimentContext() {
                 : "n/a",
             },
             { label: "shared", value: `${compareResult.shared_changed_files.length}` },
+            { label: "left", value: `${compareResult.left_only_changed_files.length}` },
+            { label: "right", value: `${compareResult.right_only_changed_files.length}` },
           ]
         : [
             { label: "peer", value: comparePeer?.label || "n/a" },

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -2317,7 +2317,7 @@ function buildDesktopFollowConversation(
         ...((consultationSummary || experimentSummary)
           ? [{ label: "next", value: projection.next_action || "idle" }]
           : []),
-        ...(!(consultationSummary || experimentSummary) || projection.changed_files.length === 0
+        ...(!(consultationSummary || experimentSummary) && projection.changed_files.length > 0
           ? [{ label: "changed", value: `${projection.changed_files.length}` }]
           : []),
         ...((consultationSummary || experimentSummary) && projection.changed_files.length > 0

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -2310,7 +2310,9 @@ function buildDesktopFollowConversation(
         ? `Hypothesis: ${experimentSummary}`
         : `Run: ${projection.next_action || "idle"}`,
       details: [
-        { label: "branch", value: projection.branch || "no branch" },
+        ...((consultationSummary || experimentSummary)
+          ? [{ label: "branch", value: projection.branch || "no branch" }]
+          : []),
         ...((consultationSummary || experimentSummary) || projection.review_state
           ? [{ label: "review", value: projection.review_state || "n/a" }]
           : []),
@@ -2331,6 +2333,9 @@ function buildDesktopFollowConversation(
         ...(projection.head_short ? [{ label: "head", value: projection.head_short }] : []),
         ...(projection.verification_outcome
           ? [{ label: "verify", value: projection.verification_outcome }]
+          : []),
+        ...(!(consultationSummary || experimentSummary)
+          ? [{ label: "branch", value: projection.branch || "no branch" }]
           : []),
         ...(projection.consultation_ref
           ? [{ label: "consultation", value: summarizeArtifactRef(projection.consultation_ref) }]

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -969,6 +969,14 @@ function renderExperimentContext() {
           .filter((value) => Boolean(value))
           .join(" · ")
       : "Compare needs another surfaced run.";
+  const compareCandidateSummary = compareResult
+    ? [
+        compareWinnerLabel ? `winner ${compareWinnerLabel}` : "",
+        `diffs ${compareResult.differences.length}`,
+      ]
+        .filter((value) => Boolean(value))
+        .join(" · ")
+    : "";
   const canPromoteCandidate =
     isDesktopRunPromotable(payload.run) &&
     !promotingRunIds.has(selectedProjection.run_id) &&
@@ -1057,12 +1065,15 @@ function renderExperimentContext() {
       title: "Playbook Candidate",
       body: isPromotedCandidate
         ? `Exported as ${promotedCandidateRef}.`
-        : (
+        : [
           consultationPacket.recommendation ||
-          experimentPacket.result ||
-          experimentPacket.next_action ||
-          "No playbook candidate is ready yet."
-        ),
+            experimentPacket.result ||
+            experimentPacket.next_action ||
+            "No playbook candidate is ready yet.",
+          compareCandidateSummary,
+        ]
+          .filter((value) => Boolean(value))
+          .join(" · "),
       tone: "success" as SurfaceTone,
       actionLabel: canPromoteCandidate ? "Promote" : undefined,
       actionPendingLabel: "Promoting...",

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -2312,7 +2312,9 @@ function buildDesktopFollowConversation(
       details: [
         { label: "branch", value: projection.branch || "no branch" },
         { label: "review", value: projection.review_state || "n/a" },
-        { label: "next", value: projection.next_action || "idle" },
+        ...((consultationSummary || experimentSummary)
+          ? [{ label: "next", value: projection.next_action || "idle" }]
+          : []),
         ...(!(consultationSummary || experimentSummary) || projection.changed_files.length === 0
           ? [{ label: "changed", value: `${projection.changed_files.length}` }]
           : []),

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -5,6 +5,7 @@ import {
   getDesktopEditorFile,
   getDesktopRunExplain,
   getDesktopSummarySnapshot,
+  promoteDesktopRunTactic,
   subscribeToDesktopSummaryRefresh,
   type DesktopEditorFilePayload,
   type DesktopExplainPayload,
@@ -192,6 +193,8 @@ const desktopEditorFileCache = new Map<string, EditorFile>();
 const desktopEditorLoadingPaths = new Set<string>();
 const desktopEditorLoadErrors = new Map<string, string>();
 const desktopStandaloneEditorTargets = new Map<string, EditorTarget>();
+const promotingRunIds = new Set<string>();
+const pendingPromotedRunRefreshIds = new Set<string>();
 const backendConversation: ConversationItem[] = [];
 const runtimeConversation: ConversationItem[] = [];
 const DESKTOP_SUMMARY_REFRESH_FALLBACK_INTERVAL_MS = 15_000;
@@ -811,6 +814,10 @@ function renderExperimentContext() {
   ]
     .filter((value) => Boolean(value))
     .join(" · ");
+  const canPromoteCandidate =
+    isDesktopRunPromotable(payload.run) &&
+    !promotingRunIds.has(selectedProjection.run_id) &&
+    !pendingPromotedRunRefreshIds.has(selectedProjection.run_id);
 
   const overviewCards = [
     {
@@ -872,6 +879,7 @@ function renderExperimentContext() {
         experimentPacket.next_action ||
         "No playbook candidate is ready yet.",
       tone: "success" as SurfaceTone,
+      actionLabel: canPromoteCandidate ? "Promote" : undefined,
       details: [
         { label: "next", value: experimentPacket.next_action || "n/a" },
         { label: "consult", value: consultationSummary.next_test || "n/a" },
@@ -897,6 +905,23 @@ function renderExperimentContext() {
       meta.appendChild(pill);
     }
     card.appendChild(meta);
+
+    if (item.actionLabel && selectedProjection.run_id) {
+      const chipRow = document.createElement("div");
+      chipRow.className = "timeline-chip-row";
+      const button = document.createElement("button");
+      button.type = "button";
+      button.className = "timeline-chip";
+      button.textContent = promotingRunIds.has(selectedProjection.run_id) ? "Promoting..." : item.actionLabel;
+      button.disabled =
+        promotingRunIds.has(selectedProjection.run_id) ||
+        pendingPromotedRunRefreshIds.has(selectedProjection.run_id);
+      button.addEventListener("click", async () => {
+        await promoteSelectedRunTactic(selectedProjection.run_id);
+      });
+      chipRow.appendChild(button);
+      card.appendChild(chipRow);
+    }
     detailRoot.appendChild(card);
   }
 }
@@ -1619,6 +1644,63 @@ async function openExplainForSelectedRun() {
     console.warn("Failed to load desktop explain payload", error);
     appendFallbackExplain();
     return;
+  }
+}
+
+async function promoteSelectedRunTactic(runId: string) {
+  if (promotingRunIds.has(runId) || pendingPromotedRunRefreshIds.has(runId)) {
+    return;
+  }
+
+  promotingRunIds.add(runId);
+  renderContextPanel();
+
+  try {
+    const result = await promoteDesktopRunTactic(runId);
+    pendingPromotedRunRefreshIds.add(runId);
+    renderContextPanel();
+    appendRuntimeConversation({
+      type: "operator",
+      category: "activity",
+      timestamp: new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", hour12: false }),
+      actor: "Operator",
+      title: "Playbook candidate exported",
+      body: result.candidate.summary || result.candidate.title,
+      details: [
+        { label: "run", value: result.run_id },
+        { label: "kind", value: result.candidate.kind },
+        { label: "candidate", value: result.candidate_ref },
+      ],
+      tone: "success",
+      runId,
+    });
+    renderConversation(getConversationItems());
+    requestDesktopSummaryRefresh(undefined, 0);
+    try {
+      const explainPayload = await getDesktopRunExplain(runId);
+      desktopExplainCache.set(runId, explainPayload);
+    } catch (refreshError) {
+      console.warn("Failed to refresh promoted run explain payload", refreshError);
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    appendRuntimeConversation({
+      type: "operator",
+      category: "attention",
+      timestamp: new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", hour12: false }),
+      actor: "Operator",
+      title: "Promote failed",
+      body: message,
+      details: [{ label: "run", value: runId }],
+      tone: "warning",
+      runId,
+    });
+    renderConversation(getConversationItems());
+  } finally {
+    promotingRunIds.delete(runId);
+    pendingPromotedRunRefreshIds.delete(runId);
+    renderContextPanel();
+    renderRunSummary();
   }
 }
 
@@ -2692,6 +2774,33 @@ function findEditorFile(target: EditorTarget | null) {
 
 function countEditorLines(content: string) {
   return content.split(/\r?\n/).length;
+}
+
+function getUpperRecordField(record: Record<string, unknown> | null | undefined, key: string) {
+  const value = record?.[key];
+  return typeof value === "string" ? value.toUpperCase() : "";
+}
+
+function isDesktopRunPromotable(run: DesktopExplainPayload["run"]) {
+  const taskState = (run.task_state || "").toLowerCase();
+  const reviewState = (run.review_state || "").toUpperCase();
+  const verificationOutcome = getUpperRecordField(run.verification_result, "outcome");
+  const securityVerdict = getUpperRecordField(run.security_verdict, "verdict");
+
+  if (!["completed", "task_completed", "commit_ready", "done"].includes(taskState)) {
+    return false;
+  }
+  if (reviewState && reviewState !== "PASS") {
+    return false;
+  }
+  if (verificationOutcome !== "PASS") {
+    return false;
+  }
+  if (!["ALLOW", "PASS"].includes(securityVerdict)) {
+    return false;
+  }
+
+  return true;
 }
 
 function buildCachedEditorFile(

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -766,6 +766,141 @@ function getSelectedRunId() {
   return resolveSelectedRunId();
 }
 
+function renderExperimentContext() {
+  const overviewRoot = document.getElementById("experiment-overview-cards");
+  const detailRoot = document.getElementById("experiment-detail-list");
+  if (!overviewRoot || !detailRoot) {
+    return;
+  }
+
+  overviewRoot.innerHTML = "";
+  detailRoot.innerHTML = "";
+
+  const selectedProjection = getPrimaryRunProjection();
+  if (!selectedProjection) {
+    const empty = document.createElement("div");
+    empty.className = "experiment-detail-card";
+    empty.dataset.tone = "info";
+    empty.innerHTML =
+      `<div class="experiment-detail-title">No experiment run</div>` +
+      `<div class="experiment-detail-body">Select a run to inspect observation, compare, and playbook context.</div>`;
+    detailRoot.appendChild(empty);
+    return;
+  }
+
+  const payload = desktopExplainCache.get(selectedProjection.run_id) ?? null;
+  if (!payload) {
+    const empty = document.createElement("div");
+    empty.className = "experiment-detail-card";
+    empty.dataset.tone = "info";
+    empty.innerHTML =
+      `<div class="experiment-detail-title">Explain not loaded</div>` +
+      `<div class="experiment-detail-body">Open Explain to load experiment context for the selected run.</div>`;
+    detailRoot.appendChild(empty);
+    return;
+  }
+
+  const observationPack = getObservationPack(payload);
+  const consultationPacket = getConsultationPacket(payload);
+  const consultationSummary = getConsultationSummary(payload);
+  const experimentPacket = payload.run.experiment_packet;
+  const compareBody = [
+    payload.run.run_id,
+    payload.run.branch || "no branch",
+    payload.evidence_digest.verification_outcome || payload.run.review_state || "pending",
+  ]
+    .filter((value) => Boolean(value))
+    .join(" · ");
+
+  const overviewCards = [
+    {
+      label: "Hypothesis",
+      value: experimentPacket.hypothesis || selectedProjection.hypothesis || "No hypothesis",
+    },
+    {
+      label: "Observe",
+      value: observationPack.changed_files.length > 0
+        ? `${observationPack.changed_files.length} files`
+        : (observationPack.working_tree_summary || "No observation pack"),
+    },
+    {
+      label: "Consult",
+      value: consultationSummary.next_test || consultationPacket.recommendation || "No consult",
+    },
+    {
+      label: "Candidate",
+      value: experimentPacket.next_action || payload.explanation.next_action || "No candidate",
+    },
+  ];
+
+  for (const item of overviewCards) {
+    const card = document.createElement("div");
+    card.className = "source-overview-card";
+    card.innerHTML = `<div class="context-label">${item.label}</div><div class="source-overview-value">${item.value}</div>`;
+    overviewRoot.appendChild(card);
+  }
+
+  const experimentCards = [
+    {
+      title: "Observation Pack",
+      body:
+        observationPack.working_tree_summary ||
+        observationPack.failing_command ||
+        "Observation details will appear after the selected run emits an observation pack.",
+      tone: "focus" as SurfaceTone,
+      details: [
+        { label: "files", value: `${observationPack.changed_files.length}` },
+        { label: "test", value: observationPack.test_plan[0] || "n/a" },
+        { label: "slot", value: observationPack.slot || "n/a" },
+      ],
+    },
+    {
+      title: "Compare",
+      body: compareBody || "Compare input will appear after the selected run resolves branch and verification state.",
+      tone: "info" as SurfaceTone,
+      details: [
+        { label: "changed", value: `${payload.evidence_digest.changed_file_count}` },
+        { label: "verify", value: payload.evidence_digest.verification_outcome || "n/a" },
+        { label: "review", value: payload.run.review_state || "n/a" },
+      ],
+    },
+    {
+      title: "Playbook Candidate",
+      body:
+        consultationPacket.recommendation ||
+        experimentPacket.result ||
+        experimentPacket.next_action ||
+        "No playbook candidate is ready yet.",
+      tone: "success" as SurfaceTone,
+      details: [
+        { label: "next", value: experimentPacket.next_action || "n/a" },
+        { label: "consult", value: consultationSummary.next_test || "n/a" },
+        { label: "confidence", value: formatConfidencePercent(experimentPacket.confidence || 0) },
+      ],
+    },
+  ];
+
+  for (const item of experimentCards) {
+    const card = document.createElement("div");
+    card.className = "experiment-detail-card";
+    card.dataset.tone = item.tone;
+    card.innerHTML =
+      `<div class="experiment-detail-title">${item.title}</div>` +
+      `<div class="experiment-detail-body">${item.body}</div>`;
+
+    const meta = document.createElement("div");
+    meta.className = "experiment-detail-meta";
+    for (const detail of item.details) {
+      const pill = document.createElement("span");
+      pill.className = "experiment-detail-pill";
+      pill.innerHTML = `<span class="experiment-detail-pill-label">${detail.label}</span><span>${detail.value}</span>`;
+      meta.appendChild(pill);
+    }
+    card.appendChild(meta);
+    detailRoot.appendChild(card);
+  }
+}
+
 function renderContextPanel() {
   const sectionRoot = document.getElementById("context-sections");
   const overviewRoot = document.getElementById("source-overview-cards");
@@ -793,6 +928,8 @@ function renderContextPanel() {
     row.innerHTML = `<div class="context-label">${item.label}</div><div class="context-value">${item.value}</div>`;
     sectionRoot.appendChild(row);
   }
+
+  renderExperimentContext();
 
   overviewRoot.innerHTML = "";
   const overviewCards = [
@@ -1476,6 +1613,7 @@ async function openExplainForSelectedRun() {
       });
     }
     renderRunSummary();
+    renderContextPanel();
     renderConversation(getConversationItems());
   } catch (error) {
     console.warn("Failed to load desktop explain payload", error);
@@ -1513,6 +1651,7 @@ function appendFallbackExplain() {
     runId: selectedRunId,
   });
   renderRunSummary();
+  renderContextPanel();
   renderConversation(getConversationItems());
 }
 

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -2284,10 +2284,10 @@ function buildDesktopFollowConversation(
       actor: projection.label || projection.pane_id || "System",
       title,
       body: consultationSummary
-        ? `${consultationSummary} · ${projection.changed_files.length} changed files · review ${projection.review_state || "n/a"}.`
+        ? `Consultation: ${consultationSummary} · ${projection.changed_files.length} changed files · review ${projection.review_state || "n/a"}.`
         : experimentSummary
-        ? `${experimentSummary} · Next ${projection.next_action || "idle"} · ${projection.changed_files.length} changed files · review ${projection.review_state || "n/a"}.`
-        : `Next ${projection.next_action || "idle"} · ${projection.changed_files.length} changed files · review ${projection.review_state || "n/a"}.`,
+        ? `Hypothesis: ${experimentSummary} · Next ${projection.next_action || "idle"} · ${projection.changed_files.length} changed files · review ${projection.review_state || "n/a"}.`
+        : `Run: Next ${projection.next_action || "idle"} · ${projection.changed_files.length} changed files · review ${projection.review_state || "n/a"}.`,
       details: [
         { label: "run", value: runId },
         { label: "next", value: projection.next_action || "idle" },

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -2286,7 +2286,7 @@ function buildDesktopFollowConversation(
       ? "consultation"
       : experimentSummary
         ? "hypothesis"
-        : projection.next_action || projection.review_state || undefined;
+        : projection.next_action || undefined;
     const title = consultationSummary
       ? (diff.addedRunIds.includes(runId) ? "Consultation surfaced" : "Consultation updated")
       : experimentSummary

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -2310,6 +2310,14 @@ function buildDesktopFollowConversation(
         ? `Hypothesis: ${experimentSummary}`
         : `Run: ${projection.next_action || "idle"}`,
       details: [
+        ...((consultationSummary || experimentSummary) && projection.changed_files.length > 0
+          ? [
+              {
+                label: "files",
+                value: `${projection.changed_files.length}: ${summarizeChangedFiles(projection.changed_files)}`,
+              },
+            ]
+          : []),
         ...((consultationSummary || experimentSummary)
           ? [{ label: "branch", value: projection.branch || "no branch" }]
           : []),
@@ -2321,14 +2329,6 @@ function buildDesktopFollowConversation(
           : []),
         ...(!(consultationSummary || experimentSummary) && projection.changed_files.length > 0
           ? [{ label: "changed", value: `${projection.changed_files.length}` }]
-          : []),
-        ...((consultationSummary || experimentSummary) && projection.changed_files.length > 0
-          ? [
-              {
-                label: "files",
-                value: `${projection.changed_files.length}: ${summarizeChangedFiles(projection.changed_files)}`,
-              },
-            ]
           : []),
         ...(projection.verification_outcome
           ? [{ label: "verify", value: projection.verification_outcome }]

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -2290,14 +2290,18 @@ function buildDesktopFollowConversation(
         : `Next ${projection.next_action || "idle"} · ${projection.changed_files.length} changed files · review ${projection.review_state || "n/a"}.`,
       details: [
         { label: "run", value: runId },
+        { label: "next", value: projection.next_action || "idle" },
         { label: "branch", value: projection.branch || "no branch" },
         { label: "head", value: projection.head_short || "n/a" },
         { label: "verify", value: projection.verification_outcome || "n/a" },
+        ...(projection.hypothesis
+          ? [{ label: "hypothesis", value: projection.hypothesis }]
+          : []),
         ...(projection.confidence !== null
           ? [{ label: "confidence", value: formatConfidencePercent(projection.confidence) }]
           : []),
         ...(projection.consultation_ref
-          ? [{ label: "source", value: summarizeArtifactRef(projection.consultation_ref) }]
+          ? [{ label: "consultation", value: summarizeArtifactRef(projection.consultation_ref) }]
           : []),
       ],
       tone,

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -470,6 +470,39 @@ function getComparePeerProjection(
   return sameBranchPeer ?? null;
 }
 
+function getCompareWinnerLabel(result: DesktopCompareRunsResult) {
+  if (!result.recommend.winning_run_id) {
+    return "";
+  }
+  if (result.recommend.winning_run_id === result.left.run_id) {
+    return result.left.label || result.left.run_id;
+  }
+  if (result.recommend.winning_run_id === result.right.run_id) {
+    return result.right.label || result.right.run_id;
+  }
+  return result.recommend.winning_run_id;
+}
+
+function summarizeCompareDifferenceFields(
+  result: DesktopCompareRunsResult,
+  limit = 3,
+) {
+  const fields = Array.from(
+    new Set(
+      result.differences
+        .map((difference) => difference.field)
+        .filter((field) => Boolean(field)),
+    ),
+  );
+  if (fields.length === 0) {
+    return "";
+  }
+  if (fields.length <= limit) {
+    return fields.join(", ");
+  }
+  return `${fields.slice(0, limit).join(", ")} +${fields.length - limit}`;
+}
+
 function setSelectedRun(runId: string | null) {
   selectedRunId = resolveSelectedRunId(desktopSummarySnapshot, runId);
 }
@@ -875,11 +908,41 @@ function renderExperimentContext() {
   const compareInFlight = comparePairKey
     ? comparingRunPairKeys.has(comparePairKey)
     : false;
+  const compareWinnerLabel = compareResult
+    ? getCompareWinnerLabel(compareResult)
+    : "";
+  const compareDifferenceSummary = compareResult
+    ? summarizeCompareDifferenceFields(compareResult)
+    : "";
+  const compareFileSummary = compareResult
+    ? [
+        compareResult.shared_changed_files.length > 0
+          ? `shared ${summarizeChangedFiles(compareResult.shared_changed_files, 2)}`
+          : "",
+        compareResult.left_only_changed_files.length > 0
+          ? `${compareResult.left.label || "left"} ${summarizeChangedFiles(compareResult.left_only_changed_files, 2)}`
+          : "",
+        compareResult.right_only_changed_files.length > 0
+          ? `${compareResult.right.label || "right"} ${summarizeChangedFiles(compareResult.right_only_changed_files, 2)}`
+          : "",
+      ]
+        .filter((value) => Boolean(value))
+        .join(" · ")
+    : "";
+  const compareTone: SurfaceTone = compareResult
+    ? (
+      compareResult.recommend.reconcile_consult
+        ? "warning"
+        : (compareWinnerLabel ? "success" : "info")
+    )
+    : "info";
   const compareBody = compareResult
     ? [
-        `vs ${comparePeer?.label || compareResult.right.run_id}`,
+        compareResult.recommend.reconcile_consult
+          ? "Reconcile consult"
+          : `Winner ${compareWinnerLabel || "not decided"}`,
         compareResult.recommend.next_action || "reconcile_consult",
-        compareResult.recommend.winning_run_id || "no winner",
+        compareDifferenceSummary || compareFileSummary || "No material diff",
       ]
         .filter((value) => Boolean(value))
         .join(" · ")
@@ -945,7 +1008,7 @@ function renderExperimentContext() {
     {
       title: "Compare",
       body: compareBody,
-      tone: "info" as SurfaceTone,
+      tone: compareTone,
       actionLabel: comparePeer ? "Compare" : undefined,
       actionPendingLabel: "Comparing...",
       actionDisabled: compareInFlight,
@@ -954,7 +1017,11 @@ function renderExperimentContext() {
       actionPeerRunId: comparePeer?.run_id,
       details: compareResult
         ? [
-            { label: "peer", value: comparePeer?.label || compareResult.right.run_id },
+            {
+              label: "peer",
+              value: comparePeer?.label || compareResult.right.label || compareResult.right.run_id,
+            },
+            { label: "winner", value: compareWinnerLabel || "none" },
             { label: "diffs", value: `${compareResult.differences.length}` },
             {
               label: "delta",
@@ -962,6 +1029,7 @@ function renderExperimentContext() {
                 ? formatConfidencePercent(Math.abs(compareResult.confidence_delta))
                 : "n/a",
             },
+            { label: "shared", value: `${compareResult.shared_changed_files.length}` },
           ]
         : [
             { label: "peer", value: comparePeer?.label || "n/a" },
@@ -1847,6 +1915,21 @@ async function compareSelectedRunWithPeer(leftRunId: string, rightRunId: string)
       leftFingerprint !== latestLeftFingerprint ||
       rightFingerprint !== latestRightFingerprint
     ) {
+      appendRuntimeConversation({
+        type: "operator",
+        category: "activity",
+        timestamp: new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", hour12: false }),
+        actor: "Operator",
+        title: "Compare needs rerun",
+        body: "The selected runs changed while compare was running.",
+        details: [
+          { label: "left", value: leftRunId },
+          { label: "right", value: rightRunId },
+        ],
+        tone: "warning",
+        runId: leftRunId,
+      });
+      renderConversation(getConversationItems());
       return;
     }
 

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -2306,7 +2306,6 @@ function buildDesktopFollowConversation(
         ? `Hypothesis: ${experimentSummary}`
         : `Run: ${projection.next_action || "idle"}`,
       details: [
-        { label: "run", value: runId },
         { label: "branch", value: projection.branch || "no branch" },
         { label: "review", value: projection.review_state || "n/a" },
         { label: "next", value: projection.next_action || "idle" },

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -2,11 +2,13 @@ import { Terminal } from "xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import "xterm/css/xterm.css";
 import {
+  compareDesktopRuns,
   getDesktopEditorFile,
   getDesktopRunExplain,
   getDesktopSummarySnapshot,
   promoteDesktopRunTactic,
   subscribeToDesktopSummaryRefresh,
+  type DesktopCompareRunsResult,
   type DesktopEditorFilePayload,
   type DesktopExplainPayload,
   type DesktopRunProjection,
@@ -189,12 +191,14 @@ let desktopSummaryLiveRefreshAvailable = false;
 let desktopSummaryLastSuccessfulRefreshAt = 0;
 let desktopSummaryLastStreamSignalAt = 0;
 const desktopExplainCache = new Map<string, DesktopExplainPayload>();
+const desktopRunCompareCache = new Map<string, DesktopCompareRunsResult>();
 const desktopEditorFileCache = new Map<string, EditorFile>();
 const desktopEditorLoadingPaths = new Set<string>();
 const desktopEditorLoadErrors = new Map<string, string>();
 const desktopStandaloneEditorTargets = new Map<string, EditorTarget>();
 const promotingRunIds = new Set<string>();
 const pendingPromotedRunRefreshIds = new Set<string>();
+const comparingRunPairKeys = new Set<string>();
 const backendConversation: ConversationItem[] = [];
 const runtimeConversation: ConversationItem[] = [];
 const DESKTOP_SUMMARY_REFRESH_FALLBACK_INTERVAL_MS = 15_000;
@@ -421,6 +425,48 @@ function getRunProjectionByRunId(runId: string | null) {
 function getPrimaryRunProjection() {
   const resolvedRunId = resolveSelectedRunId();
   return getRunProjectionByRunId(resolvedRunId) ?? getRunProjections()[0] ?? null;
+}
+
+function getComparePairKey(leftRunId: string, rightRunId: string) {
+  return `${leftRunId}::${rightRunId}`;
+}
+
+function getComparePeerProjection(
+  selectedProjection: DesktopRunProjection,
+  preferredRunId?: string | null,
+) {
+  const otherRuns = getRunProjections().filter(
+    (projection) => projection.run_id !== selectedProjection.run_id,
+  );
+  if (otherRuns.length === 0) {
+    return null;
+  }
+
+  if (preferredRunId) {
+    const preferredPeer = otherRuns.find(
+      (projection) => projection.run_id === preferredRunId,
+    );
+    if (preferredPeer) {
+      return preferredPeer;
+    }
+  }
+
+  const sameTaskPeer = otherRuns.find(
+    (projection) =>
+      Boolean(selectedProjection.task) &&
+      projection.task === selectedProjection.task,
+  );
+  if (sameTaskPeer) {
+    return sameTaskPeer;
+  }
+
+  const sameBranchPeer = otherRuns.find(
+    (projection) =>
+      Boolean(selectedProjection.branch) &&
+      projection.branch === selectedProjection.branch,
+  );
+
+  return sameBranchPeer ?? null;
 }
 
 function setSelectedRun(runId: string | null) {
@@ -807,13 +853,36 @@ function renderExperimentContext() {
   const consultationPacket = getConsultationPacket(payload);
   const consultationSummary = getConsultationSummary(payload);
   const experimentPacket = payload.run.experiment_packet;
-  const compareBody = [
-    payload.run.run_id,
-    payload.run.branch || "no branch",
-    payload.evidence_digest.verification_outcome || payload.run.review_state || "pending",
-  ]
-    .filter((value) => Boolean(value))
-    .join(" · ");
+  const comparePeer = getComparePeerProjection(
+    selectedProjection,
+    payload.run.parent_run_id || null,
+  );
+  const comparePairKey = comparePeer
+    ? getComparePairKey(selectedProjection.run_id, comparePeer.run_id)
+    : "";
+  const compareResult = comparePairKey
+    ? desktopRunCompareCache.get(comparePairKey) ?? null
+    : null;
+  const compareInFlight = comparePairKey
+    ? comparingRunPairKeys.has(comparePairKey)
+    : false;
+  const compareBody = compareResult
+    ? [
+        `vs ${comparePeer?.label || compareResult.right.run_id}`,
+        compareResult.recommend.next_action || "reconcile_consult",
+        compareResult.recommend.winning_run_id || "no winner",
+      ]
+        .filter((value) => Boolean(value))
+        .join(" · ")
+    : comparePeer
+      ? [
+          `vs ${comparePeer.label || comparePeer.run_id}`,
+          comparePeer.branch || "no branch",
+          comparePeer.review_state || "pending",
+        ]
+          .filter((value) => Boolean(value))
+          .join(" · ")
+      : "Compare needs another surfaced run.";
   const canPromoteCandidate =
     isDesktopRunPromotable(payload.run) &&
     !promotingRunIds.has(selectedProjection.run_id) &&
@@ -863,13 +932,30 @@ function renderExperimentContext() {
     },
     {
       title: "Compare",
-      body: compareBody || "Compare input will appear after the selected run resolves branch and verification state.",
+      body: compareBody,
       tone: "info" as SurfaceTone,
-      details: [
-        { label: "changed", value: `${payload.evidence_digest.changed_file_count}` },
-        { label: "verify", value: payload.evidence_digest.verification_outcome || "n/a" },
-        { label: "review", value: payload.run.review_state || "n/a" },
-      ],
+      actionLabel: comparePeer ? "Compare" : undefined,
+      actionPendingLabel: "Comparing...",
+      actionDisabled: compareInFlight,
+      actionType: "compare" as const,
+      actionRunId: selectedProjection.run_id,
+      actionPeerRunId: comparePeer?.run_id,
+      details: compareResult
+        ? [
+            { label: "peer", value: comparePeer?.label || compareResult.right.run_id },
+            { label: "diffs", value: `${compareResult.differences.length}` },
+            {
+              label: "delta",
+              value: compareResult.confidence_delta !== null
+                ? formatConfidencePercent(Math.abs(compareResult.confidence_delta))
+                : "n/a",
+            },
+          ]
+        : [
+            { label: "peer", value: comparePeer?.label || "n/a" },
+            { label: "changed", value: `${payload.evidence_digest.changed_file_count}` },
+            { label: "verify", value: payload.evidence_digest.verification_outcome || "n/a" },
+          ],
     },
     {
       title: "Playbook Candidate",
@@ -880,6 +966,12 @@ function renderExperimentContext() {
         "No playbook candidate is ready yet.",
       tone: "success" as SurfaceTone,
       actionLabel: canPromoteCandidate ? "Promote" : undefined,
+      actionPendingLabel: "Promoting...",
+      actionDisabled:
+        promotingRunIds.has(selectedProjection.run_id) ||
+        pendingPromotedRunRefreshIds.has(selectedProjection.run_id),
+      actionType: "promote" as const,
+      actionRunId: selectedProjection.run_id,
       details: [
         { label: "next", value: experimentPacket.next_action || "n/a" },
         { label: "consult", value: consultationSummary.next_test || "n/a" },
@@ -912,12 +1004,21 @@ function renderExperimentContext() {
       const button = document.createElement("button");
       button.type = "button";
       button.className = "timeline-chip";
-      button.textContent = promotingRunIds.has(selectedProjection.run_id) ? "Promoting..." : item.actionLabel;
-      button.disabled =
-        promotingRunIds.has(selectedProjection.run_id) ||
-        pendingPromotedRunRefreshIds.has(selectedProjection.run_id);
+      button.textContent = item.actionDisabled && item.actionPendingLabel
+        ? item.actionPendingLabel
+        : item.actionLabel;
+      button.disabled = item.actionDisabled ?? false;
       button.addEventListener("click", async () => {
-        await promoteSelectedRunTactic(selectedProjection.run_id);
+        if (item.actionType === "compare" && item.actionPeerRunId) {
+          await compareSelectedRunWithPeer(
+            item.actionRunId ?? selectedProjection.run_id,
+            item.actionPeerRunId,
+          );
+          return;
+        }
+        await promoteSelectedRunTactic(
+          item.actionRunId ?? selectedProjection.run_id,
+        );
       });
       chipRow.appendChild(button);
       card.appendChild(chipRow);
@@ -1701,6 +1802,76 @@ async function promoteSelectedRunTactic(runId: string) {
     pendingPromotedRunRefreshIds.delete(runId);
     renderContextPanel();
     renderRunSummary();
+  }
+}
+
+async function compareSelectedRunWithPeer(leftRunId: string, rightRunId: string) {
+  const pairKey = getComparePairKey(leftRunId, rightRunId);
+  if (comparingRunPairKeys.has(pairKey)) {
+    return;
+  }
+
+  const leftFingerprint = getRunProjectionFingerprint(getRunProjectionByRunId(leftRunId));
+  const rightFingerprint = getRunProjectionFingerprint(getRunProjectionByRunId(rightRunId));
+  comparingRunPairKeys.add(pairKey);
+  renderContextPanel();
+
+  try {
+    const result = await compareDesktopRuns(leftRunId, rightRunId);
+    const latestLeftFingerprint = getRunProjectionFingerprint(getRunProjectionByRunId(leftRunId));
+    const latestRightFingerprint = getRunProjectionFingerprint(getRunProjectionByRunId(rightRunId));
+    if (
+      leftFingerprint !== latestLeftFingerprint ||
+      rightFingerprint !== latestRightFingerprint
+    ) {
+      return;
+    }
+
+    desktopRunCompareCache.set(pairKey, result);
+    appendRuntimeConversation({
+      type: "operator",
+      category: "activity",
+      timestamp: new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", hour12: false }),
+      actor: "Operator",
+      title: "Compare completed",
+      body: [
+        `${result.left.label || result.left.run_id} vs ${result.right.label || result.right.run_id}`,
+        result.recommend.next_action || "reconcile_consult",
+      ].join(" · "),
+      details: [
+        { label: "winner", value: result.recommend.winning_run_id || "none" },
+        { label: "diffs", value: `${result.differences.length}` },
+        {
+          label: "delta",
+          value: result.confidence_delta !== null
+            ? formatConfidencePercent(Math.abs(result.confidence_delta))
+            : "n/a",
+        },
+      ],
+      tone: result.recommend.reconcile_consult ? "warning" : "info",
+      runId: leftRunId,
+    });
+    renderConversation(getConversationItems());
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    appendRuntimeConversation({
+      type: "operator",
+      category: "attention",
+      timestamp: new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", hour12: false }),
+      actor: "Operator",
+      title: "Compare failed",
+      body: message,
+      details: [
+        { label: "left", value: leftRunId },
+        { label: "right", value: rightRunId },
+      ],
+      tone: "warning",
+      runId: leftRunId,
+    });
+    renderConversation(getConversationItems());
+  } finally {
+    comparingRunPairKeys.delete(pairKey);
+    renderContextPanel();
   }
 }
 
@@ -3005,6 +3176,13 @@ function pruneExplainCache(snapshot: DesktopSummarySnapshot, preservedRunId?: st
       desktopExplainCache.delete(runId);
     }
   }
+
+  for (const pairKey of Array.from(desktopRunCompareCache.keys())) {
+    const [leftRunId, rightRunId] = pairKey.split("::");
+    if (!activeRunIds.has(leftRunId) || !activeRunIds.has(rightRunId)) {
+      desktopRunCompareCache.delete(pairKey);
+    }
+  }
 }
 
 function renderDesktopSurfaces() {
@@ -3030,6 +3208,20 @@ async function refreshDesktopSummary(forceExplainRunId?: string | null) {
     const previousSelectedRunId = selectedRunId;
     const snapshot = await getDesktopSummarySnapshot();
     const diff = diffDesktopSummarySnapshots(previousSnapshot, snapshot);
+    const invalidatedRunIds = new Set([
+      ...diff.changedRunIds,
+      ...diff.addedRunIds,
+      ...diff.removedRunIds,
+    ]);
+    for (const pairKey of Array.from(desktopRunCompareCache.keys())) {
+      const [leftRunId, rightRunId] = pairKey.split("::");
+      if (
+        invalidatedRunIds.has(leftRunId) ||
+        invalidatedRunIds.has(rightRunId)
+      ) {
+        desktopRunCompareCache.delete(pairKey);
+      }
+    }
     desktopSummarySnapshot = snapshot;
     desktopSummaryLastSuccessfulRefreshAt = Date.now();
     selectedRunId = resolveSelectedRunId(snapshot, forceExplainRunId);

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -2321,11 +2321,11 @@ function buildDesktopFollowConversation(
         ...((consultationSummary || experimentSummary) && projection.head_short
           ? [{ label: "head", value: projection.head_short }]
           : []),
-        ...((consultationSummary || experimentSummary)
-          ? [{ label: "branch", value: projection.branch || "no branch" }]
-          : []),
         ...(projection.review_state
           ? [{ label: "review", value: projection.review_state }]
+          : []),
+        ...((consultationSummary || experimentSummary)
+          ? [{ label: "branch", value: projection.branch || "no branch" }]
           : []),
         ...(!(consultationSummary || experimentSummary) && projection.changed_files.length > 0
           ? [{ label: "changed", value: `${projection.changed_files.length}` }]

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -2318,11 +2318,11 @@ function buildDesktopFollowConversation(
               },
             ]
           : []),
-        ...((consultationSummary || experimentSummary) && projection.head_short
-          ? [{ label: "head", value: projection.head_short }]
-          : []),
         ...(projection.review_state
           ? [{ label: "review", value: projection.review_state }]
+          : []),
+        ...((consultationSummary || experimentSummary) && projection.head_short
+          ? [{ label: "head", value: projection.head_short }]
           : []),
         ...((consultationSummary || experimentSummary)
           ? [{ label: "branch", value: projection.branch || "no branch" }]

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -2330,10 +2330,10 @@ function buildDesktopFollowConversation(
               },
             ]
           : []),
-        ...(projection.head_short ? [{ label: "head", value: projection.head_short }] : []),
         ...(projection.verification_outcome
           ? [{ label: "verify", value: projection.verification_outcome }]
           : []),
+        ...(projection.head_short ? [{ label: "head", value: projection.head_short }] : []),
         ...(!(consultationSummary || experimentSummary)
           ? [{ label: "branch", value: projection.branch || "no branch" }]
           : []),

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -2324,14 +2324,14 @@ function buildDesktopFollowConversation(
         ...(projection.review_state
           ? [{ label: "review", value: projection.review_state }]
           : []),
-        ...((consultationSummary || experimentSummary)
-          ? [{ label: "next", value: projection.next_action || "idle" }]
-          : []),
         ...(!(consultationSummary || experimentSummary) && projection.changed_files.length > 0
           ? [{ label: "changed", value: `${projection.changed_files.length}` }]
           : []),
         ...(projection.verification_outcome
           ? [{ label: "verify", value: projection.verification_outcome }]
+          : []),
+        ...((consultationSummary || experimentSummary)
+          ? [{ label: "next", value: projection.next_action || "idle" }]
           : []),
         ...(projection.head_short ? [{ label: "head", value: projection.head_short }] : []),
         ...(!(consultationSummary || experimentSummary)

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -2319,9 +2319,16 @@ function buildDesktopFollowConversation(
         ...(projection.confidence !== null
           ? [{ label: "confidence", value: formatConfidencePercent(projection.confidence) }]
           : []),
-        { label: "changed", value: `${projection.changed_files.length}` },
+        ...(!(consultationSummary || experimentSummary) || projection.changed_files.length === 0
+          ? [{ label: "changed", value: `${projection.changed_files.length}` }]
+          : []),
         ...((consultationSummary || experimentSummary) && projection.changed_files.length > 0
-          ? [{ label: "files", value: summarizeChangedFiles(projection.changed_files) }]
+          ? [
+              {
+                label: "files",
+                value: `${projection.changed_files.length}: ${summarizeChangedFiles(projection.changed_files)}`,
+              },
+            ]
           : []),
         { label: "head", value: projection.head_short || "n/a" },
         { label: "verify", value: projection.verification_outcome || "n/a" },

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -192,6 +192,7 @@ let desktopSummaryLastSuccessfulRefreshAt = 0;
 let desktopSummaryLastStreamSignalAt = 0;
 const desktopExplainCache = new Map<string, DesktopExplainPayload>();
 const desktopRunCompareCache = new Map<string, DesktopCompareRunsResult>();
+const promotedRunCandidates = new Map<string, { fingerprint: string; candidateRef: string }>();
 const desktopEditorFileCache = new Map<string, EditorFile>();
 const desktopEditorLoadingPaths = new Set<string>();
 const desktopEditorLoadErrors = new Map<string, string>();
@@ -853,6 +854,14 @@ function renderExperimentContext() {
   const consultationPacket = getConsultationPacket(payload);
   const consultationSummary = getConsultationSummary(payload);
   const experimentPacket = payload.run.experiment_packet;
+  const explainFingerprint = getExplainPayloadFingerprint(payload);
+  const promotedCandidate = promotedRunCandidates.get(selectedProjection.run_id) ?? null;
+  const isPromotedCandidate =
+    promotedCandidate !== null &&
+    promotedCandidate.fingerprint === explainFingerprint;
+  const promotedCandidateRef = isPromotedCandidate && promotedCandidate
+    ? summarizeArtifactRef(promotedCandidate.candidateRef)
+    : "";
   const comparePeer = getComparePeerProjection(
     selectedProjection,
     payload.run.parent_run_id || null,
@@ -886,7 +895,8 @@ function renderExperimentContext() {
   const canPromoteCandidate =
     isDesktopRunPromotable(payload.run) &&
     !promotingRunIds.has(selectedProjection.run_id) &&
-    !pendingPromotedRunRefreshIds.has(selectedProjection.run_id);
+    !pendingPromotedRunRefreshIds.has(selectedProjection.run_id) &&
+    !isPromotedCandidate;
 
   const overviewCards = [
     {
@@ -905,7 +915,9 @@ function renderExperimentContext() {
     },
     {
       label: "Candidate",
-      value: experimentPacket.next_action || payload.explanation.next_action || "No candidate",
+      value: isPromotedCandidate
+        ? "Exported"
+        : (experimentPacket.next_action || payload.explanation.next_action || "No candidate"),
     },
   ];
 
@@ -959,11 +971,14 @@ function renderExperimentContext() {
     },
     {
       title: "Playbook Candidate",
-      body:
-        consultationPacket.recommendation ||
-        experimentPacket.result ||
-        experimentPacket.next_action ||
-        "No playbook candidate is ready yet.",
+      body: isPromotedCandidate
+        ? `Exported as ${promotedCandidateRef}.`
+        : (
+          consultationPacket.recommendation ||
+          experimentPacket.result ||
+          experimentPacket.next_action ||
+          "No playbook candidate is ready yet."
+        ),
       tone: "success" as SurfaceTone,
       actionLabel: canPromoteCandidate ? "Promote" : undefined,
       actionPendingLabel: "Promoting...",
@@ -973,6 +988,9 @@ function renderExperimentContext() {
       actionType: "promote" as const,
       actionRunId: selectedProjection.run_id,
       details: [
+        ...(isPromotedCandidate
+          ? [{ label: "exported", value: promotedCandidateRef }]
+          : []),
         { label: "next", value: experimentPacket.next_action || "n/a" },
         { label: "consult", value: consultationSummary.next_test || "n/a" },
         { label: "confidence", value: formatConfidencePercent(experimentPacket.confidence || 0) },
@@ -1780,8 +1798,13 @@ async function promoteSelectedRunTactic(runId: string) {
     try {
       const explainPayload = await getDesktopRunExplain(runId);
       desktopExplainCache.set(runId, explainPayload);
+      promotedRunCandidates.set(runId, {
+        fingerprint: getExplainPayloadFingerprint(explainPayload),
+        candidateRef: result.candidate_ref,
+      });
     } catch (refreshError) {
       console.warn("Failed to refresh promoted run explain payload", refreshError);
+      promotedRunCandidates.delete(runId);
     }
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
@@ -3183,6 +3206,12 @@ function pruneExplainCache(snapshot: DesktopSummarySnapshot, preservedRunId?: st
       desktopRunCompareCache.delete(pairKey);
     }
   }
+
+  for (const runId of Array.from(promotedRunCandidates.keys())) {
+    if (!activeRunIds.has(runId)) {
+      promotedRunCandidates.delete(runId);
+    }
+  }
 }
 
 function renderDesktopSurfaces() {
@@ -3221,6 +3250,9 @@ async function refreshDesktopSummary(forceExplainRunId?: string | null) {
       ) {
         desktopRunCompareCache.delete(pairKey);
       }
+    }
+    for (const runId of invalidatedRunIds) {
+      promotedRunCandidates.delete(runId);
     }
     desktopSummarySnapshot = snapshot;
     desktopSummaryLastSuccessfulRefreshAt = Date.now();

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -2252,6 +2252,20 @@ function buildDesktopFollowConversation(
     }
     const experimentSummary = summarizeProjectionExperiment(projection);
     const consultationSummary = summarizeProjectionConsultation(projection);
+    const tone: SurfaceTone = consultationSummary
+      ? "focus"
+      : experimentSummary
+        ? "accent"
+        : projection.review_state === "PASS"
+          ? "success"
+          : projection.review_state === "PENDING"
+            ? "warning"
+            : "info";
+    const statusLabel = consultationSummary
+      ? "consultation"
+      : experimentSummary
+        ? "hypothesis"
+        : projection.next_action || projection.review_state || undefined;
     const title = consultationSummary
       ? (diff.addedRunIds.includes(runId) ? "Consultation surfaced" : "Consultation updated")
       : experimentSummary
@@ -2286,14 +2300,9 @@ function buildDesktopFollowConversation(
           ? [{ label: "source", value: summarizeArtifactRef(projection.consultation_ref) }]
           : []),
       ],
-      tone:
-        projection.review_state === "PASS"
-          ? "success"
-          : projection.review_state === "PENDING"
-            ? "warning"
-            : "info",
+      tone,
       runId,
-      statusLabel: projection.next_action || projection.review_state || undefined,
+      statusLabel,
     });
   }
 

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -2242,7 +2242,24 @@ function buildDesktopFollowConversation(
     ...diff.addedRunIds.filter((runId) => runId === selected),
     ...diff.changedRunIds.filter((runId) => runId !== selected),
     ...diff.addedRunIds.filter((runId) => runId !== selected),
-  ].slice(0, 3);
+  ]
+    .map((runId, index) => {
+      const projection = nextProjectionMap.get(runId);
+      const signalRank = projection?.consultation_ref ? 0 : projection?.hypothesis ? 1 : 2;
+      const sourceRank = runId === selected ? 0 : diff.changedRunIds.includes(runId) ? 1 : 2;
+      return { runId, index, signalRank, sourceRank };
+    })
+    .sort((left, right) => {
+      if (left.sourceRank !== right.sourceRank) {
+        return left.sourceRank - right.sourceRank;
+      }
+      if (left.signalRank !== right.signalRank) {
+        return left.signalRank - right.signalRank;
+      }
+      return left.index - right.index;
+    })
+    .map((item) => item.runId)
+    .slice(0, 3);
 
   const items: ConversationItem[] = [];
   for (const runId of prioritizedChangedRunIds) {

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -2284,10 +2284,10 @@ function buildDesktopFollowConversation(
       actor: projection.label || projection.pane_id || "System",
       title,
       body: consultationSummary
-        ? `Consultation: ${consultationSummary} · ${projection.changed_files.length} changed files · review ${projection.review_state || "n/a"}.`
+        ? `Consultation: ${consultationSummary}`
         : experimentSummary
-        ? `Hypothesis: ${experimentSummary} · Next ${projection.next_action || "idle"} · ${projection.changed_files.length} changed files · review ${projection.review_state || "n/a"}.`
-        : `Run: Next ${projection.next_action || "idle"} · ${projection.changed_files.length} changed files · review ${projection.review_state || "n/a"}.`,
+        ? `Hypothesis: ${experimentSummary}`
+        : `Run: ${projection.next_action || "idle"}`,
       details: [
         ...(projection.consultation_ref
           ? [{ label: "consultation", value: summarizeArtifactRef(projection.consultation_ref) }]
@@ -2300,6 +2300,8 @@ function buildDesktopFollowConversation(
           : []),
         { label: "run", value: runId },
         { label: "next", value: projection.next_action || "idle" },
+        { label: "changed", value: `${projection.changed_files.length}` },
+        { label: "review", value: projection.review_state || "n/a" },
         { label: "branch", value: projection.branch || "no branch" },
         { label: "head", value: projection.head_short || "n/a" },
         { label: "verify", value: projection.verification_outcome || "n/a" },

--- a/winsmux-app/src/styles.css
+++ b/winsmux-app/src/styles.css
@@ -997,6 +997,12 @@ textarea {
   gap: 10px;
 }
 
+#experiment-overview-cards {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
 .source-overview-card {
   border: 1px solid var(--border-muted);
   border-radius: 14px;
@@ -1010,6 +1016,70 @@ textarea {
 .source-overview-value {
   font-size: var(--text-sm);
   color: var(--text-primary);
+}
+
+#experiment-detail-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.experiment-detail-card {
+  border: 1px solid var(--border-muted);
+  border-radius: 14px;
+  background: var(--bg-surface);
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.experiment-detail-card[data-tone="focus"] {
+  border-color: var(--status-focus-border);
+}
+
+.experiment-detail-card[data-tone="info"] {
+  border-color: var(--status-info-border);
+}
+
+.experiment-detail-card[data-tone="success"] {
+  border-color: var(--status-success-border);
+}
+
+.experiment-detail-title {
+  font-size: var(--text-sm);
+  color: var(--text-primary);
+  font-weight: 700;
+}
+
+.experiment-detail-body {
+  font-size: var(--text-xs);
+  color: var(--text-secondary);
+  line-height: var(--leading-relaxed);
+}
+
+.experiment-detail-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.experiment-detail-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border-radius: 999px;
+  padding: 5px 9px;
+  background: var(--bg-surface-raised);
+  border: 1px solid var(--border-muted);
+  color: var(--text-secondary);
+  font-size: var(--text-2xs);
+}
+
+.experiment-detail-pill-label {
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
 }
 
 .sidebar-row[data-tone="success"],

--- a/winsmux-app/src/styles.css
+++ b/winsmux-app/src/styles.css
@@ -1544,7 +1544,8 @@ textarea {
     align-items: flex-start;
   }
 
-  #source-overview-cards {
+  #source-overview-cards,
+  #experiment-overview-cards {
     grid-template-columns: minmax(0, 1fr);
   }
 


### PR DESCRIPTION
## Summary
- promote run update cards into hypothesis cards when a projection carries experiment context
- show hypothesis text and confidence in the conversation shell follow cards
- include hypothesis and confidence in the projection fingerprint so hypothesis-only updates still emit cards

## Validation
- pwsh -NoProfile -File .\winsmux-core\scripts\sync-roadmap.ps1
- cmd /c npm run build
- pwsh -NoProfile -File .\scripts\git-guard.ps1 -Mode full
- pwsh -NoProfile -File .\scripts\audit-public-surface.ps1
