### PR TITLE
TASK-344: add compare workspace surface

### DIFF
--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -1091,6 +1091,8 @@ function Parse-ConsultCommandArgs {
     $targetSlot = ''
     $nextTest = ''
     $confidence = $null
+    $runId = ''
+    $jsonOutput = $false
     $risks = [System.Collections.Generic.List[string]]::new()
     $messageParts = [System.Collections.Generic.List[string]]::new()
 
@@ -1122,6 +1124,16 @@ function Parse-ConsultCommandArgs {
                 }
                 $confidence = $parsedConfidence
                 $i++
+            }
+            '--run-id' {
+                if ($i + 1 -ge $Args.Count) {
+                    Stop-WithError '--run-id requires a value'
+                }
+                $runId = [string]$Args[$i + 1]
+                $i++
+            }
+            '--json' {
+                $jsonOutput = $true
             }
             '--next-test' {
                 if ($i + 1 -ge $Args.Count) {
@@ -1161,6 +1173,8 @@ function Parse-ConsultCommandArgs {
         message     = [string]$message
         target_slot = [string]$targetSlot
         confidence  = $confidence
+        run_id      = [string]$runId
+        json        = [bool]$jsonOutput
         next_test   = [string]$nextTest
         risks       = @($risks)
     }
@@ -1190,7 +1204,32 @@ function Resolve-CurrentCommandArgs {
 }
 
 function Get-ConsultationCommandContext {
-    param([string]$ProjectDir = (Get-Location).Path)
+    param(
+        [string]$ProjectDir = (Get-Location).Path,
+        [string]$RunId = ''
+    )
+
+    if (-not [string]::IsNullOrWhiteSpace($RunId)) {
+        $payload = Get-ExplainPayload -ProjectDir $ProjectDir -RunId $RunId
+        $manifest = Get-WinsmuxManifest -ProjectDir $ProjectDir
+        $sessionName = ''
+        if ($null -ne $manifest -and $null -ne $manifest.session) {
+            $sessionName = [string]$manifest.session.name
+        }
+
+        return [ordered]@{
+            SessionName = [string]$sessionName
+            Label       = [string]$payload.run.primary_label
+            PaneId      = [string]$payload.run.primary_pane_id
+            Role        = [string]$payload.run.primary_role
+            TaskId      = [string]$payload.run.task_id
+            Branch      = [string]$payload.run.branch
+            HeadSha     = [string]$payload.run.head_sha
+            RunId       = [string]$payload.run.run_id
+            Slot        = [string]$payload.run.primary_label
+            Worktree    = [string]$payload.run.worktree
+        }
+    }
 
     $context = Get-CurrentPaneManifestContext -ProjectDir $ProjectDir
     $branch = [string]$context.Branch
@@ -1247,10 +1286,12 @@ function Write-ConsultationCommandRecord {
         [AllowNull()]$Confidence = $null,
         [string]$NextTest = '',
         [string[]]$Risks = @(),
+        [string]$RunId = '',
+        [bool]$JsonOutput = $false,
         [string]$ProjectDir = (Get-Location).Path
     )
 
-    $context = Get-ConsultationCommandContext -ProjectDir $ProjectDir
+    $context = Get-ConsultationCommandContext -ProjectDir $ProjectDir -RunId $RunId
     $timestamp = (Get-Date).ToString('o')
     $packet = [ordered]@{
         run_id      = [string]$context.RunId
@@ -1323,6 +1364,25 @@ function Write-ConsultationCommandRecord {
         last_event    = ($Kind -replace '_', '.')
         last_event_at = $timestamp
     })
+
+    if ($JsonOutput) {
+        [ordered]@{
+            run_id           = [string]$context.RunId
+            task_id          = [string]$context.TaskId
+            pane_id          = [string]$context.PaneId
+            slot             = [string]$context.Slot
+            kind             = [string]$Kind
+            mode             = [string]$Mode
+            target_slot      = [string]$TargetSlot
+            recommendation   = if ($Kind -eq 'consult_result') { [string]$Message } else { '' }
+            confidence       = $Confidence
+            next_test        = [string]$NextTest
+            risks            = @($Risks)
+            consultation_ref = [string]$artifact.reference
+            generated_at     = $timestamp
+        } | ConvertTo-Json -Compress -Depth 8 | Write-Output
+        return
+    }
 
     $kindLabel = ($Kind -replace '^consult_', 'consult ' -replace '_', ' ')
     Write-Output "$kindLabel recorded for $([string]$context.RunId)"
@@ -6650,7 +6710,7 @@ function Invoke-ConsultResult {
     Assert-WinsmuxRolePermission -CommandName 'consult-result'
     $commandArgs = Resolve-CurrentCommandArgs
     $args = Parse-ConsultCommandArgs -Mode ([string]$commandArgs.target) -Args @($commandArgs.rest)
-    Write-ConsultationCommandRecord -Kind 'consult_result' -Mode ([string]$args.mode) -Message ([string]$args.message) -TargetSlot ([string]$args.target_slot) -Confidence $args.confidence -NextTest ([string]$args.next_test) -Risks @($args.risks)
+    Write-ConsultationCommandRecord -Kind 'consult_result' -Mode ([string]$args.mode) -Message ([string]$args.message) -TargetSlot ([string]$args.target_slot) -Confidence $args.confidence -NextTest ([string]$args.next_test) -Risks @($args.risks) -RunId ([string]$args.run_id) -JsonOutput ([bool]$args.json)
 }
 
 function Invoke-ConsultError {
@@ -6689,7 +6749,7 @@ Commands:
   dispatch-review           Dispatch review-request to a review-capable pane (Reviewer/Worker)
   dispatch-task <text>      Route and send task text to a managed pane using manifest-aware role selection
   consult-request <mode> [--message <text>] [--target-slot <slot>]  Record a consultation request packet/event
-  consult-result <mode> [--message <text>] [--target-slot <slot>] [--confidence <0..1>] [--next-test <text>] [--risk <text>]  Record a consultation result packet/event
+  consult-result <mode> [--message <text>] [--target-slot <slot>] [--confidence <0..1>] [--next-test <text>] [--risk <text>] [--run-id <run_id>] [--json]  Record a consultation result packet/event
   consult-error <mode> [--message <text>] [--target-slot <slot>]  Record a consultation error packet/event
   locks                     List active file locks
   verify <pr-number>        Run Pester in tests/ and merge PR only on PASS

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -9003,6 +9003,23 @@ panes:
         $packet.risks | Should -Be @('cache mismatch')
     }
 
+    It 'accepts run override and json output for consult result' {
+        $args = Parse-ConsultCommandArgs -Mode 'final' -Args @('--run-id', 'task:task-301', '--json', '--message', 'pick builder-1', '--target-slot', 'builder-2', '--next-test', 'promote tactic')
+
+        $args.run_id | Should -Be 'task:task-301'
+        $args.json | Should -Be $true
+
+        $output = Write-ConsultationCommandRecord -Kind 'consult_result' -Mode ([string]$args.mode) -Message ([string]$args.message) -TargetSlot ([string]$args.target_slot) -RunId ([string]$args.run_id) -NextTest ([string]$args.next_test) -JsonOutput ([bool]$args.json) -ProjectDir $script:consultTempRoot
+        $result = ($output | Out-String | ConvertFrom-Json -AsHashtable)
+
+        $result.run_id | Should -Be 'task:task-301'
+        $result.mode | Should -Be 'final'
+        $result.target_slot | Should -Be 'builder-2'
+        $result.recommendation | Should -Be 'pick builder-1'
+        $result.next_test | Should -Be 'promote tactic'
+        $result.consultation_ref | Should -BeLike '.winsmux/consultations/consult-result-*.json'
+    }
+
     It 'fails closed for unsupported consult mode' {
         { Parse-ConsultCommandArgs -Mode 'later' -Args @('--message', 'invalid mode test') } | Should -Throw '*Unsupported consult mode*'
     }

--- a/winsmux-app/src-tauri/src/desktop_backend.rs
+++ b/winsmux-app/src-tauri/src/desktop_backend.rs
@@ -255,6 +255,24 @@ pub struct DesktopCompareRecommendation {
 }
 
 #[derive(Serialize, Deserialize)]
+pub struct DesktopPickWinnerResult {
+    pub run_id: String,
+    pub task_id: String,
+    pub pane_id: String,
+    pub slot: String,
+    pub kind: String,
+    pub mode: String,
+    pub target_slot: String,
+    pub recommendation: String,
+    pub confidence: Option<f64>,
+    pub next_test: String,
+    #[serde(default)]
+    pub risks: Vec<String>,
+    pub consultation_ref: String,
+    pub generated_at: String,
+}
+
+#[derive(Serialize, Deserialize)]
 pub struct DesktopExplainPayload {
     pub generated_at: String,
     pub project_dir: String,
@@ -523,6 +541,14 @@ pub enum DesktopCommand {
         run_id: String,
         project_dir: Option<String>,
     },
+    RunPickWinner {
+        run_id: String,
+        peer_slot: String,
+        recommendation: String,
+        confidence: Option<f64>,
+        next_test: String,
+        project_dir: Option<String>,
+    },
 }
 
 pub enum DesktopStreamCommand {
@@ -536,6 +562,7 @@ impl DesktopCommand {
             DesktopCommand::RunExplain { project_dir, .. } => project_dir.as_deref(),
             DesktopCommand::RunCompare { project_dir, .. } => project_dir.as_deref(),
             DesktopCommand::RunPromote { project_dir, .. } => project_dir.as_deref(),
+            DesktopCommand::RunPickWinner { project_dir, .. } => project_dir.as_deref(),
         }
     }
 
@@ -565,6 +592,33 @@ impl DesktopCommand {
                     run_id.clone(),
                     "--json".to_string(),
                 ]
+            }
+            DesktopCommand::RunPickWinner {
+                run_id,
+                peer_slot,
+                recommendation,
+                confidence,
+                next_test,
+                ..
+            } => {
+                let mut args = vec![
+                    "consult-result".to_string(),
+                    "final".to_string(),
+                    "--run-id".to_string(),
+                    run_id.clone(),
+                    "--message".to_string(),
+                    recommendation.clone(),
+                    "--target-slot".to_string(),
+                    peer_slot.clone(),
+                    "--next-test".to_string(),
+                    next_test.clone(),
+                    "--json".to_string(),
+                ];
+                if let Some(value) = confidence {
+                    args.push("--confidence".to_string());
+                    args.push(value.to_string());
+                }
+                args
             }
         }
     }
@@ -659,6 +713,27 @@ pub fn load_desktop_run_promote(
     })?;
     serde_json::from_value(payload)
         .map_err(|err| format!("Failed to parse desktop promote payload: {err}"))
+}
+
+pub fn load_desktop_run_pick_winner(
+    transport: &dyn DesktopCommandTransport,
+    run_id: String,
+    peer_slot: String,
+    recommendation: String,
+    confidence: Option<f64>,
+    next_test: String,
+    project_dir: Option<String>,
+) -> Result<DesktopPickWinnerResult, String> {
+    let payload = transport.request_json(&DesktopCommand::RunPickWinner {
+        run_id,
+        peer_slot,
+        recommendation,
+        confidence,
+        next_test,
+        project_dir,
+    })?;
+    serde_json::from_value(payload)
+        .map_err(|err| format!("Failed to parse desktop pick-winner payload: {err}"))
 }
 
 pub fn load_desktop_editor_file(
@@ -773,6 +848,56 @@ pub fn handle_desktop_json_rpc(
                 Err(err) => json_rpc_error(request_id, JSON_RPC_SERVER_ERROR, err),
             }
         }
+        "desktop.run.pick_winner" => {
+            let run_id = match get_required_string_param(params.as_ref(), &["runId", "run_id"]) {
+                Ok(value) => value,
+                Err(err) => {
+                    return json_rpc_error(request_id, JSON_RPC_INVALID_PARAMS, err);
+                }
+            };
+            let peer_slot =
+                match get_required_string_param(params.as_ref(), &["peerSlot", "peer_slot"]) {
+                    Ok(value) => value,
+                    Err(err) => {
+                        return json_rpc_error(request_id, JSON_RPC_INVALID_PARAMS, err);
+                    }
+                };
+            let recommendation =
+                match get_required_string_param(params.as_ref(), &["recommendation", "message"]) {
+                    Ok(value) => value,
+                    Err(err) => {
+                        return json_rpc_error(request_id, JSON_RPC_INVALID_PARAMS, err);
+                    }
+                };
+            let next_test =
+                match get_required_string_param(params.as_ref(), &["nextTest", "next_test"]) {
+                    Ok(value) => value,
+                    Err(err) => {
+                        return json_rpc_error(request_id, JSON_RPC_INVALID_PARAMS, err);
+                    }
+                };
+            let confidence = get_optional_f64_param(params.as_ref(), &["confidence"]);
+
+            match load_desktop_run_pick_winner(
+                transport,
+                run_id,
+                peer_slot,
+                recommendation,
+                confidence,
+                next_test,
+                resolved_project_dir,
+            ) {
+                Ok(result) => match serde_json::to_value(result) {
+                    Ok(value) => json_rpc_result(request_id, value),
+                    Err(err) => json_rpc_error(
+                        request_id,
+                        JSON_RPC_INTERNAL_ERROR,
+                        format!("Failed to serialize desktop pick-winner payload: {err}"),
+                    ),
+                },
+                Err(err) => json_rpc_error(request_id, JSON_RPC_SERVER_ERROR, err),
+            }
+        }
         "desktop.editor.read" => {
             let path = match get_required_string_param(params.as_ref(), &["path"]) {
                 Ok(value) => value,
@@ -823,6 +948,17 @@ fn get_optional_string_param(params: Option<&Value>, keys: &[&str]) -> Option<St
             if !trimmed.is_empty() {
                 return Some(trimmed.to_string());
             }
+        }
+    }
+
+    None
+}
+
+fn get_optional_f64_param(params: Option<&Value>, keys: &[&str]) -> Option<f64> {
+    let object = params?.as_object()?;
+    for key in keys {
+        if let Some(value) = object.get(*key).and_then(Value::as_f64) {
+            return Some(value);
         }
     }
 
@@ -1283,6 +1419,24 @@ mod tests {
                 "reconcile_consult": true,
                 "next_action": "reconcile_consult"
             }
+        })
+    }
+
+    fn desktop_pick_winner_payload() -> Value {
+        serde_json::json!({
+            "run_id": "task:task-256",
+            "task_id": "task-256",
+            "pane_id": "%2",
+            "slot": "builder-1",
+            "kind": "consult_result",
+            "mode": "final",
+            "target_slot": "builder-2",
+            "recommendation": "Pick builder-1",
+            "confidence": 0.85,
+            "next_test": "promote tactic",
+            "risks": [],
+            "consultation_ref": ".winsmux/consultations/consult-result-__ID__.json",
+            "generated_at": "__GENERATED_AT__"
         })
     }
 
@@ -2135,6 +2289,40 @@ mod tests {
     }
 
     #[test]
+    fn load_desktop_run_pick_winner_uses_consult_result_command() {
+        let transport = FakeTransport {
+            requests: RefCell::new(Vec::new()),
+            response: desktop_pick_winner_payload(),
+        };
+
+        let payload = load_desktop_run_pick_winner(
+            &transport,
+            "task:task-256".to_string(),
+            "builder-2".to_string(),
+            "Pick builder-1".to_string(),
+            Some(0.85),
+            "promote tactic".to_string(),
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(payload.run_id, "task:task-256");
+        assert_eq!(payload.mode, "final");
+        assert_eq!(payload.target_slot, "builder-2");
+        assert_eq!(payload.recommendation, "Pick builder-1");
+        assert_eq!(payload.confidence, Some(0.85));
+        assert_eq!(payload.next_test, "promote tactic");
+        assert_eq!(
+            payload.consultation_ref,
+            ".winsmux/consultations/consult-result-__ID__.json"
+        );
+        assert_eq!(
+            transport.requests.borrow().as_slice(),
+            ["consult-result final --run-id task:task-256 --message Pick builder-1 --target-slot builder-2 --next-test promote tactic --json --confidence 0.85"]
+        );
+    }
+
+    #[test]
     fn handle_desktop_json_rpc_routes_run_explain_and_prunes_extra_packets() {
         let transport = FakeTransport {
             requests: RefCell::new(Vec::new()),
@@ -2261,14 +2449,8 @@ mod tests {
                 );
                 assert_eq!(result["candidate"]["packet_type"], "playbook_candidate");
                 assert_eq!(result["candidate"]["kind"], "playbook");
-                assert_eq!(
-                    result["candidate"]["title"],
-                    "Stabilize explain contract"
-                );
-                assert_eq!(
-                    result["candidate"]["next_action"],
-                    "promote_to_playbook"
-                );
+                assert_eq!(result["candidate"]["title"], "Stabilize explain contract");
+                assert_eq!(result["candidate"]["next_action"], "promote_to_playbook");
                 assert_eq!(result["candidate"]["confidence"], 0.82);
                 assert_eq!(
                     result["candidate"]["changed_files"][0],
@@ -2327,6 +2509,49 @@ mod tests {
         assert_eq!(
             transport.requests.borrow().as_slice(),
             ["compare-runs task:task-256 task:task-257 --json"]
+        );
+    }
+
+    #[test]
+    fn handle_desktop_json_rpc_routes_run_pick_winner() {
+        let transport = FakeTransport {
+            requests: RefCell::new(Vec::new()),
+            response: desktop_pick_winner_payload(),
+        };
+        let response = handle_desktop_json_rpc(
+            &transport,
+            DesktopJsonRpcRequest {
+                jsonrpc: "2.0".to_string(),
+                id: serde_json::json!("req-pick-winner"),
+                method: "desktop.run.pick_winner".to_string(),
+                params: Some(serde_json::json!({
+                    "runId": "task:task-256",
+                    "peerSlot": "builder-2",
+                    "recommendation": "Pick builder-1",
+                    "confidence": 0.85,
+                    "nextTest": "promote tactic"
+                })),
+            },
+            None,
+        );
+
+        match response {
+            DesktopJsonRpcResponse::Success { id, result, .. } => {
+                assert_eq!(id, serde_json::json!("req-pick-winner"));
+                assert_eq!(result["run_id"], "task:task-256");
+                assert_eq!(result["mode"], "final");
+                assert_eq!(result["target_slot"], "builder-2");
+                assert_eq!(result["recommendation"], "Pick builder-1");
+                assert_eq!(result["next_test"], "promote tactic");
+            }
+            DesktopJsonRpcResponse::Error { error, .. } => {
+                panic!("expected success, got {:?}", error);
+            }
+        }
+
+        assert_eq!(
+            transport.requests.borrow().as_slice(),
+            ["consult-result final --run-id task:task-256 --message Pick builder-1 --target-slot builder-2 --next-test promote tactic --json --confidence 0.85"]
         );
     }
 

--- a/winsmux-app/src/desktopClient.ts
+++ b/winsmux-app/src/desktopClient.ts
@@ -6,12 +6,14 @@ type DesktopCommandName =
   | "desktop_run_explain"
   | "desktop_run_compare"
   | "desktop_run_promote"
+  | "desktop_run_pick_winner"
   | "desktop_editor_read";
 type DesktopJsonRpcMethod =
   | "desktop.summary.snapshot"
   | "desktop.run.explain"
   | "desktop.run.compare"
   | "desktop.run.promote"
+  | "desktop.run.pick_winner"
   | "desktop.editor.read";
 
 interface DesktopJsonRpcRequest {
@@ -297,6 +299,22 @@ export interface DesktopExplainPayload {
   }>;
 }
 
+export interface DesktopPickWinnerResult {
+  run_id: string;
+  task_id: string;
+  pane_id: string;
+  slot: string;
+  kind: string;
+  mode: string;
+  target_slot: string;
+  recommendation: string;
+  confidence: number | null;
+  next_test: string;
+  risks: string[];
+  consultation_ref: string;
+  generated_at: string;
+}
+
 export interface DesktopReviewStateRecord {
   status: string;
   branch: string;
@@ -440,6 +458,8 @@ function getDesktopJsonRpcMethod(command: DesktopCommandName): DesktopJsonRpcMet
       return "desktop.run.compare";
     case "desktop_run_promote":
       return "desktop.run.promote";
+    case "desktop_run_pick_winner":
+      return "desktop.run.pick_winner";
     case "desktop_editor_read":
       return "desktop.editor.read";
   }
@@ -547,6 +567,25 @@ export async function promoteDesktopRunTactic(runId: string) {
     );
   } catch (error) {
     throw normalizeDesktopError(`desktop_run_promote(${runId})`, error);
+  }
+}
+
+export async function pickDesktopRunWinner(
+  runId: string,
+  peerSlot: string,
+  recommendation: string,
+  confidence: number | null,
+  nextTest: string,
+) {
+  try {
+    return await desktopCommandTransport.request<DesktopPickWinnerResult>(
+      "desktop_run_pick_winner",
+      confidence === null
+        ? { runId, peerSlot, recommendation, nextTest }
+        : { runId, peerSlot, recommendation, confidence, nextTest },
+    );
+  } catch (error) {
+    throw normalizeDesktopError(`desktop_run_pick_winner(${runId})`, error);
   }
 }
 

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -1081,6 +1081,19 @@ function renderExperimentContext() {
                 .join(" · "),
             },
             {
+              label: "Decision",
+              value: compareResult.recommend.reconcile_consult
+                ? "consult before pick"
+                : [
+                  compareWinnerLabel || "no winner",
+                  compareResult.confidence_delta !== null
+                    ? formatConfidencePercent(Math.abs(compareResult.confidence_delta))
+                    : "",
+                ]
+                  .filter((value) => Boolean(value))
+                  .join(" · "),
+            },
+            {
               label: "Recommendation",
               value: compareResult.recommend.next_action || "reconcile_consult",
             },

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -999,6 +999,16 @@ function renderExperimentContext() {
       value: consultationSummary.next_test || consultationPacket.recommendation || "No consult",
     },
     {
+      label: "Compare",
+      value: compareResult
+        ? (
+          compareResult.recommend.reconcile_consult
+            ? "Consult before pick"
+            : `Winner ${compareWinnerLabel || "not decided"}`
+        )
+        : (comparePeer ? `vs ${comparePeer.label || comparePeer.run_id}` : "Need peer"),
+    },
+    {
       label: "Candidate",
       value: isPromotedCandidate
         ? "Exported"

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -1060,6 +1060,28 @@ function renderExperimentContext() {
             { label: "changed", value: `${payload.evidence_digest.changed_file_count}` },
             { label: "verify", value: payload.evidence_digest.verification_outcome || "n/a" },
           ],
+      lines: compareResult
+        ? [
+            {
+              label: "Shared files",
+              value: compareResult.shared_changed_files.length > 0
+                ? summarizeChangedFiles(compareResult.shared_changed_files, 4)
+                : "none",
+            },
+            {
+              label: `${selectedProjection.label || "Selected"} only`,
+              value: compareResult.left_only_changed_files.length > 0
+                ? summarizeChangedFiles(compareResult.left_only_changed_files, 4)
+                : "none",
+            },
+            {
+              label: `${comparePeer?.label || compareResult.right.label || "Peer"} only`,
+              value: compareResult.right_only_changed_files.length > 0
+                ? summarizeChangedFiles(compareResult.right_only_changed_files, 4)
+                : "none",
+            },
+          ]
+        : [],
     },
     {
       title: "Playbook Candidate",
@@ -1112,6 +1134,20 @@ function renderExperimentContext() {
       meta.appendChild(pill);
     }
     card.appendChild(meta);
+
+    if (item.lines && item.lines.length > 0) {
+      const lineList = document.createElement("div");
+      lineList.className = "experiment-detail-lines";
+      for (const line of item.lines) {
+        const row = document.createElement("div");
+        row.className = "experiment-detail-line";
+        row.innerHTML =
+          `<span class="experiment-detail-line-label">${line.label}</span>` +
+          `<span class="experiment-detail-line-value">${line.value}</span>`;
+        lineList.appendChild(row);
+      }
+      card.appendChild(lineList);
+    }
 
     if (item.actionLabel && selectedProjection.run_id) {
       const chipRow = document.createElement("div");

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -1083,6 +1083,7 @@ function renderExperimentContext() {
             {
               label: "Selected run",
               value: [
+                compareResult.left.branch || "no branch",
                 compareResult.left.review_state || compareResult.left.state,
                 compareResult.left.next_action || "idle",
               ]
@@ -1092,6 +1093,7 @@ function renderExperimentContext() {
             {
               label: "Peer run",
               value: [
+                compareResult.right.branch || "no branch",
                 compareResult.right.review_state || compareResult.right.state,
                 compareResult.right.next_action || "idle",
               ]

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -937,6 +937,12 @@ function renderExperimentContext() {
   const compareWinnerProjection = compareWinnerRunId
     ? getRunProjectionByRunId(compareWinnerRunId)
     : null;
+  const compareLeftProjection = compareResult
+    ? (getRunProjectionByRunId(compareResult.left.run_id) ?? selectedProjection)
+    : selectedProjection;
+  const compareRightProjection = compareResult
+    ? (getRunProjectionByRunId(compareResult.right.run_id) ?? comparePeer)
+    : comparePeer;
   const canFocusCompareWinner = Boolean(
     compareResult &&
     !compareResult.recommend.reconcile_consult &&
@@ -1112,7 +1118,8 @@ function renderExperimentContext() {
             {
               label: "Selected run",
               value: [
-                compareResult.left.branch || "no branch",
+                compareResult.left.branch || compareLeftProjection?.branch || "no branch",
+                compareLeftProjection?.head_short || "",
                 compareResult.left.review_state || compareResult.left.state,
                 compareResult.left.next_action || "idle",
               ]
@@ -1122,7 +1129,8 @@ function renderExperimentContext() {
             {
               label: "Peer run",
               value: [
-                compareResult.right.branch || "no branch",
+                compareResult.right.branch || compareRightProjection?.branch || "no branch",
+                compareRightProjection?.head_short || "",
                 compareResult.right.review_state || compareResult.right.state,
                 compareResult.right.next_action || "idle",
               ]

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -1063,6 +1063,24 @@ function renderExperimentContext() {
       lines: compareResult
         ? [
             {
+              label: "Selected run",
+              value: [
+                compareResult.left.review_state || compareResult.left.state,
+                compareResult.left.next_action || "idle",
+              ]
+                .filter((value) => Boolean(value))
+                .join(" · "),
+            },
+            {
+              label: "Peer run",
+              value: [
+                compareResult.right.review_state || compareResult.right.state,
+                compareResult.right.next_action || "idle",
+              ]
+                .filter((value) => Boolean(value))
+                .join(" · "),
+            },
+            {
               label: "Recommendation",
               value: compareResult.recommend.next_action || "reconcile_consult",
             },

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -6,6 +6,7 @@ import {
   getDesktopEditorFile,
   getDesktopRunExplain,
   getDesktopSummarySnapshot,
+  pickDesktopRunWinner,
   promoteDesktopRunTactic,
   subscribeToDesktopSummaryRefresh,
   type DesktopCompareRunsResult,
@@ -203,6 +204,7 @@ const desktopEditorLoadingPaths = new Set<string>();
 const desktopEditorLoadErrors = new Map<string, string>();
 const desktopStandaloneEditorTargets = new Map<string, EditorTarget>();
 const promotingRunIds = new Set<string>();
+const pickingWinnerRunIds = new Set<string>();
 const pendingPromotedRunRefreshIds = new Set<string>();
 const comparingRunPairKeys = new Set<string>();
 const backendConversation: ConversationItem[] = [];
@@ -943,12 +945,39 @@ function renderExperimentContext() {
   const compareRightProjection = compareResult
     ? (getRunProjectionByRunId(compareResult.right.run_id) ?? comparePeer)
     : comparePeer;
-  const canFocusCompareWinner = Boolean(
+  const compareWinnerConfidence = compareResult
+    ? (
+      compareResult.left.run_id === compareWinnerRunId
+        ? (compareResult.left.confidence ?? null)
+        : (
+          compareResult.right.run_id === compareWinnerRunId
+            ? (compareResult.right.confidence ?? null)
+            : null
+        )
+    )
+    : null;
+  const compareLoserSlot = compareResult
+    ? (
+      compareResult.left.run_id === compareWinnerRunId
+        ? (compareRightProjection?.label || compareResult.right.label || compareResult.right.run_id)
+        : (compareLeftProjection?.label || compareResult.left.label || compareResult.left.run_id)
+    )
+    : "";
+  const canPickCompareWinner = Boolean(
     compareResult &&
     !compareResult.recommend.reconcile_consult &&
-    compareWinnerProjection &&
-    compareWinnerProjection.run_id !== selectedProjection.run_id,
+    compareWinnerProjection,
   );
+  const persistedCompareTargetMatchesPeer = Boolean(
+    comparePeer &&
+    consultationPacket.target_slot &&
+    consultationPacket.target_slot === (comparePeer.label || comparePeer.run_id),
+  );
+  const hasPersistedCompareWinner =
+    !compareResult &&
+    consultationPacket.kind === "consult_result" &&
+    consultationPacket.mode === "final" &&
+    persistedCompareTargetMatchesPeer;
   const compareWinnerLabel = compareResult
     ? getCompareWinnerLabel(compareResult)
     : "";
@@ -976,6 +1005,8 @@ function renderExperimentContext() {
         ? "warning"
         : (compareWinnerLabel ? "success" : "info")
     )
+    : hasPersistedCompareWinner
+      ? "success"
     : "info";
   const compareBody = compareResult
     ? [
@@ -992,14 +1023,25 @@ function renderExperimentContext() {
       ]
         .filter((value) => Boolean(value))
         .join(" · ")
-    : comparePeer
-      ? [
+      : comparePeer
+      ? (
+        hasPersistedCompareWinner
+          ? [
+              "Winner selected",
+              consultationPacket.recommendation || selectedProjection.label || selectedProjection.run_id,
+              consultationPacket.target_slot ? `vs ${consultationPacket.target_slot}` : "",
+              consultationPacket.next_test || "winner persisted",
+            ]
+              .filter((value) => Boolean(value))
+              .join(" · ")
+          : [
           `vs ${comparePeer.label || comparePeer.run_id}`,
           comparePeer.branch || "no branch",
           comparePeer.review_state || "pending",
         ]
-          .filter((value) => Boolean(value))
-          .join(" · ")
+              .filter((value) => Boolean(value))
+              .join(" · ")
+      )
       : "Compare needs another surfaced run.";
   const compareOverviewValue = compareInFlight
     ? "Refreshing compare"
@@ -1010,7 +1052,11 @@ function renderExperimentContext() {
             ? "Consult before pick"
             : `Winner ${compareWinnerLabel || "not decided"}`
         )
+        : (
+          hasPersistedCompareWinner
+            ? "Winner selected"
         : (comparePeer ? `vs ${comparePeer.label || comparePeer.run_id}` : "Need peer")
+        )
     );
   const compareDisplayBody = compareInFlight
     ? `Refreshing compare result${compareResult ? "..." : " from current runs..." }`
@@ -1087,9 +1133,24 @@ function renderExperimentContext() {
       actionType: "compare" as const,
       actionRunId: selectedProjection.run_id,
       actionPeerRunId: comparePeer?.run_id,
-      secondaryActionLabel: canFocusCompareWinner ? "Pick winner" : undefined,
-      secondaryActionType: "focus" as const,
+      secondaryActionLabel: canPickCompareWinner ? "Pick winner" : undefined,
+      secondaryActionType: "pick_winner" as const,
       secondaryActionRunId: compareWinnerProjection?.run_id,
+      secondaryActionPeerSlot: compareLoserSlot || undefined,
+      secondaryActionPeerRunId: compareResult
+        ? (
+          compareResult.left.run_id === compareWinnerRunId
+            ? compareResult.right.run_id
+            : compareResult.left.run_id
+        )
+        : undefined,
+      secondaryActionRecommendation: compareResult
+        ? `Pick ${compareWinnerLabel || compareWinnerProjection?.label || compareWinnerProjection?.run_id || "winner"}`
+        : undefined,
+      secondaryActionConfidence: compareWinnerConfidence,
+      secondaryActionNextTest: compareResult?.recommend.next_action || undefined,
+      secondaryActionDisabled: compareWinnerRunId ? pickingWinnerRunIds.has(compareWinnerRunId) : false,
+      secondaryActionPendingLabel: "Picking...",
       details: compareResult
         ? [
             {
@@ -1108,6 +1169,12 @@ function renderExperimentContext() {
             { label: "left", value: `${compareResult.left_only_changed_files.length}` },
             { label: "right", value: `${compareResult.right_only_changed_files.length}` },
           ]
+        : hasPersistedCompareWinner
+          ? [
+              { label: "winner", value: selectedProjection.label || selectedProjection.run_id },
+              { label: "target", value: consultationPacket.target_slot || "n/a" },
+              { label: "next", value: consultationPacket.next_test || "n/a" },
+            ]
         : [
             { label: "peer", value: comparePeer?.label || "n/a" },
             { label: "changed", value: `${payload.evidence_digest.changed_file_count}` },
@@ -1259,11 +1326,15 @@ function renderExperimentContext() {
       chipRow.className = "timeline-chip-row";
       const appendActionButton = (
         label: string,
-        type: "compare" | "promote" | "focus",
+        type: "compare" | "promote" | "focus" | "pick_winner",
         runId: string,
         disabled?: boolean,
         pendingLabel?: string,
         peerRunId?: string,
+        peerSlot?: string,
+        recommendation?: string,
+        confidence?: number | null,
+        nextTest?: string,
       ) => {
         const button = document.createElement("button");
         button.type = "button";
@@ -1277,6 +1348,17 @@ function renderExperimentContext() {
           }
           if (type === "focus") {
             await focusRunInContext(runId);
+            return;
+          }
+          if (type === "pick_winner") {
+            await pickCompareWinner(
+              runId,
+              peerRunId || "",
+              peerSlot || "",
+              recommendation || "",
+              confidence ?? null,
+              nextTest || "",
+            );
             return;
           }
           await promoteSelectedRunTactic(runId);
@@ -1299,6 +1381,13 @@ function renderExperimentContext() {
           item.secondaryActionLabel,
           item.secondaryActionType,
           item.secondaryActionRunId,
+          item.secondaryActionDisabled,
+          item.secondaryActionPendingLabel,
+          item.secondaryActionPeerRunId,
+          item.secondaryActionPeerSlot,
+          item.secondaryActionRecommendation,
+          item.secondaryActionConfidence,
+          item.secondaryActionNextTest,
         );
       }
       card.appendChild(chipRow);
@@ -2106,6 +2195,71 @@ async function focusRunInContext(runId: string) {
     console.warn("Failed to preload explain payload for focused run", error);
   } finally {
     renderDesktopSurfaces();
+  }
+}
+
+async function pickCompareWinner(
+  runId: string,
+  peerRunId: string,
+  peerSlot: string,
+  recommendation: string,
+  confidence: number | null,
+  nextTest: string,
+) {
+  if (pickingWinnerRunIds.has(runId)) {
+    return;
+  }
+
+  pickingWinnerRunIds.add(runId);
+  renderContextPanel();
+
+  try {
+    const result = await pickDesktopRunWinner(
+      runId,
+      peerSlot,
+      recommendation,
+      confidence,
+      nextTest,
+    );
+    appendRuntimeConversation({
+      type: "operator",
+      category: "activity",
+      timestamp: new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", hour12: false }),
+      actor: "Operator",
+      title: "Winner picked",
+      body: result.recommendation || runId,
+      details: [
+        { label: "run", value: result.run_id },
+        { label: "target", value: result.target_slot || "n/a" },
+        { label: "next", value: result.next_test || "n/a" },
+      ],
+      tone: "success",
+      runId,
+    });
+    renderConversation(getConversationItems());
+    if (peerRunId) {
+      desktopRunCompareCache.delete(getComparePairKey(runId, peerRunId));
+      desktopRunCompareCache.delete(getComparePairKey(peerRunId, runId));
+    }
+    requestDesktopSummaryRefresh(runId, 0);
+    await focusRunInContext(runId);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    appendRuntimeConversation({
+      type: "operator",
+      category: "attention",
+      timestamp: new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", hour12: false }),
+      actor: "Operator",
+      title: "Pick winner failed",
+      body: message,
+      details: [{ label: "run", value: runId }],
+      tone: "warning",
+      runId,
+    });
+    renderConversation(getConversationItems());
+  } finally {
+    pickingWinnerRunIds.delete(runId);
+    renderContextPanel();
   }
 }
 

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -437,6 +437,22 @@ function getComparePairKey(leftRunId: string, rightRunId: string) {
   return `${leftRunId}::${rightRunId}`;
 }
 
+function mirrorCompareRunsResult(result: DesktopCompareRunsResult): DesktopCompareRunsResult {
+  return {
+    ...result,
+    left: result.right,
+    right: result.left,
+    left_only_changed_files: [...result.right_only_changed_files],
+    right_only_changed_files: [...result.left_only_changed_files],
+    confidence_delta: result.confidence_delta !== null ? -result.confidence_delta : null,
+    differences: result.differences.map((difference) => ({
+      ...difference,
+      left: difference.right,
+      right: difference.left,
+    })),
+  };
+}
+
 function getComparePeerProjection(
   selectedProjection: DesktopRunProjection,
   preferredRunId?: string | null,
@@ -917,6 +933,16 @@ function renderExperimentContext() {
   const compareInFlight = comparePairKey
     ? comparingRunPairKeys.has(comparePairKey)
     : false;
+  const compareWinnerRunId = compareResult?.recommend.winning_run_id || null;
+  const compareWinnerProjection = compareWinnerRunId
+    ? getRunProjectionByRunId(compareWinnerRunId)
+    : null;
+  const canFocusCompareWinner = Boolean(
+    compareResult &&
+    !compareResult.recommend.reconcile_consult &&
+    compareWinnerProjection &&
+    compareWinnerProjection.run_id !== selectedProjection.run_id,
+  );
   const compareWinnerLabel = compareResult
     ? getCompareWinnerLabel(compareResult)
     : "";
@@ -1055,6 +1081,9 @@ function renderExperimentContext() {
       actionType: "compare" as const,
       actionRunId: selectedProjection.run_id,
       actionPeerRunId: comparePeer?.run_id,
+      secondaryActionLabel: canFocusCompareWinner ? "Pick winner" : undefined,
+      secondaryActionType: "focus" as const,
+      secondaryActionRunId: compareWinnerProjection?.run_id,
       details: compareResult
         ? [
             {
@@ -1217,29 +1246,53 @@ function renderExperimentContext() {
       card.appendChild(lineList);
     }
 
-    if (item.actionLabel && selectedProjection.run_id) {
+    if ((item.actionLabel || item.secondaryActionLabel) && selectedProjection.run_id) {
       const chipRow = document.createElement("div");
       chipRow.className = "timeline-chip-row";
-      const button = document.createElement("button");
-      button.type = "button";
-      button.className = "timeline-chip";
-      button.textContent = item.actionDisabled && item.actionPendingLabel
-        ? item.actionPendingLabel
-        : item.actionLabel;
-      button.disabled = item.actionDisabled ?? false;
-      button.addEventListener("click", async () => {
-        if (item.actionType === "compare" && item.actionPeerRunId) {
-          await compareSelectedRunWithPeer(
-            item.actionRunId ?? selectedProjection.run_id,
-            item.actionPeerRunId,
-          );
-          return;
-        }
-        await promoteSelectedRunTactic(
+      const appendActionButton = (
+        label: string,
+        type: "compare" | "promote" | "focus",
+        runId: string,
+        disabled?: boolean,
+        pendingLabel?: string,
+        peerRunId?: string,
+      ) => {
+        const button = document.createElement("button");
+        button.type = "button";
+        button.className = "timeline-chip";
+        button.textContent = disabled && pendingLabel ? pendingLabel : label;
+        button.disabled = disabled ?? false;
+        button.addEventListener("click", async () => {
+          if (type === "compare" && peerRunId) {
+            await compareSelectedRunWithPeer(runId, peerRunId);
+            return;
+          }
+          if (type === "focus") {
+            await focusRunInContext(runId);
+            return;
+          }
+          await promoteSelectedRunTactic(runId);
+        });
+        chipRow.appendChild(button);
+      };
+
+      if (item.actionLabel) {
+        appendActionButton(
+          item.actionLabel,
+          item.actionType,
           item.actionRunId ?? selectedProjection.run_id,
+          item.actionDisabled,
+          item.actionPendingLabel,
+          item.actionPeerRunId,
         );
-      });
-      chipRow.appendChild(button);
+      }
+      if (item.secondaryActionLabel && item.secondaryActionType && item.secondaryActionRunId) {
+        appendActionButton(
+          item.secondaryActionLabel,
+          item.secondaryActionType,
+          item.secondaryActionRunId,
+        );
+      }
       card.appendChild(chipRow);
     }
     detailRoot.appendChild(card);
@@ -2030,6 +2083,24 @@ async function promoteSelectedRunTactic(runId: string) {
   }
 }
 
+async function focusRunInContext(runId: string) {
+  setSelectedRun(runId);
+  const focusedSourceChange = getProjectionSourceEntries().find((change) => change.run === runId);
+  if (focusedSourceChange) {
+    selectedEditorKey = getSourceChangeKey(focusedSourceChange);
+  }
+  renderDesktopSurfaces();
+
+  try {
+    const explainPayload = await getDesktopRunExplain(runId);
+    desktopExplainCache.set(runId, explainPayload);
+  } catch (error) {
+    console.warn("Failed to preload explain payload for focused run", error);
+  } finally {
+    renderDesktopSurfaces();
+  }
+}
+
 async function compareSelectedRunWithPeer(leftRunId: string, rightRunId: string) {
   const pairKey = getComparePairKey(leftRunId, rightRunId);
   if (comparingRunPairKeys.has(pairKey)) {
@@ -2068,6 +2139,10 @@ async function compareSelectedRunWithPeer(leftRunId: string, rightRunId: string)
     }
 
     desktopRunCompareCache.set(pairKey, result);
+    desktopRunCompareCache.set(
+      getComparePairKey(rightRunId, leftRunId),
+      mirrorCompareRunsResult(result),
+    );
     appendRuntimeConversation({
       type: "operator",
       category: "activity",

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -1094,6 +1094,15 @@ function renderExperimentContext() {
                   .join(" · "),
             },
             {
+              label: "Decision basis",
+              value: [
+                compareDifferenceSummary,
+                compareFileSummary,
+              ]
+                .filter((value) => Boolean(value))
+                .join(" · ") || "none",
+            },
+            {
               label: "Recommendation",
               value: compareResult.recommend.next_action || "reconcile_consult",
             },

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -1063,6 +1063,14 @@ function renderExperimentContext() {
       lines: compareResult
         ? [
             {
+              label: "Recommendation",
+              value: compareResult.recommend.next_action || "reconcile_consult",
+            },
+            {
+              label: "Difference fields",
+              value: compareDifferenceSummary || "none",
+            },
+            {
               label: "Shared files",
               value: compareResult.shared_changed_files.length > 0
                 ? summarizeChangedFiles(compareResult.shared_changed_files, 4)

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -969,6 +969,20 @@ function renderExperimentContext() {
           .filter((value) => Boolean(value))
           .join(" · ")
       : "Compare needs another surfaced run.";
+  const compareOverviewValue = compareInFlight
+    ? "Refreshing compare"
+    : (
+      compareResult
+        ? (
+          compareResult.recommend.reconcile_consult
+            ? "Consult before pick"
+            : `Winner ${compareWinnerLabel || "not decided"}`
+        )
+        : (comparePeer ? `vs ${comparePeer.label || comparePeer.run_id}` : "Need peer")
+    );
+  const compareDisplayBody = compareInFlight
+    ? `Refreshing compare result${compareResult ? "..." : " from current runs..." }`
+    : compareBody;
   const compareCandidateSummary = compareResult
     ? [
         compareWinnerLabel ? `winner ${compareWinnerLabel}` : "",
@@ -1000,13 +1014,7 @@ function renderExperimentContext() {
     },
     {
       label: "Compare",
-      value: compareResult
-        ? (
-          compareResult.recommend.reconcile_consult
-            ? "Consult before pick"
-            : `Winner ${compareWinnerLabel || "not decided"}`
-        )
-        : (comparePeer ? `vs ${comparePeer.label || comparePeer.run_id}` : "Need peer"),
+      value: compareOverviewValue,
     },
     {
       label: "Candidate",
@@ -1039,7 +1047,7 @@ function renderExperimentContext() {
     },
     {
       title: "Compare",
-      body: compareBody,
+      body: compareDisplayBody,
       tone: compareTone,
       actionLabel: comparePeer ? "Compare" : undefined,
       actionPendingLabel: "Comparing...",

--- a/winsmux-app/src/styles.css
+++ b/winsmux-app/src/styles.css
@@ -1064,6 +1064,31 @@ textarea {
   gap: 6px;
 }
 
+.experiment-detail-lines {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  border-top: 1px solid var(--border-muted);
+  padding-top: 8px;
+}
+
+.experiment-detail-line {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  font-size: var(--text-2xs);
+  color: var(--text-secondary);
+}
+
+.experiment-detail-line-label {
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+.experiment-detail-line-value {
+  text-align: right;
+}
+
 .experiment-detail-pill {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- add compare workspace rows inside the desktop Context panel
- show shared, selected-only, and peer-only file summaries under the Compare card
- keep the first TASK-344 slice inside the existing compare surface

## Testing
- cmd /c npm run build
- pwsh -NoProfile -File .\\scripts\\git-guard.ps1 -Mode full
- pwsh -NoProfile -File .\\scripts\\audit-public-surface.ps1
