### PR TITLE
Add initial in-app preview browser shell

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -364,3 +364,11 @@ Codex must follow these rules when review or audit agents are slow:
    - the wait time is increased,
    - or the blocker is documented and manual diff fallback is used.
 6. When a delayed review result arrives after a timeout, record the latency pattern in `.claude/local/operator-handoff.md` and use that result in the final decision.
+7. If the same PR accumulates multiple tiny desktop UI slices and `no result yet` repeats across those slices, stop per-slice review for that PR.
+   - Switch to milestone-based review instead.
+   - A milestone is a semantically meaningful bundle such as:
+     - one new surface,
+     - one completed interaction flow,
+     - or a ready-for-review PR state.
+8. While milestone-based review is active, every interim slice must still pass local validation and manual diff review before commit/push.
+9. Record the switch to milestone-based review in `.claude/local/operator-handoff.md` and link the tracking issue when one exists.

--- a/winsmux-app/index.html
+++ b/winsmux-app/index.html
@@ -120,6 +120,10 @@
             <div id="editor-meta-row"></div>
             <div id="editor-diff-preview" hidden></div>
             <div id="editor-tabs"></div>
+            <div id="browser-surface" hidden>
+              <div id="browser-meta-row"></div>
+              <iframe id="browser-frame" title="Localhost preview browser"></iframe>
+            </div>
             <pre id="editor-code"></pre>
             <div id="editor-statusbar">Secondary work surface: opened from conversation, changed files, or explorer.</div>
           </aside>
@@ -130,6 +134,8 @@
             <div class="panel-title secondary-title">Experiments</div>
             <div id="experiment-overview-cards"></div>
             <div id="experiment-detail-list"></div>
+            <div class="panel-title secondary-title">Ports</div>
+            <div id="preview-target-list"></div>
             <div class="panel-title secondary-title">Source control</div>
             <div id="source-overview-cards"></div>
             <div class="panel-title secondary-title">Changed files</div>

--- a/winsmux-app/index.html
+++ b/winsmux-app/index.html
@@ -124,6 +124,7 @@
               <div id="browser-meta-row"></div>
               <div id="browser-target-list" hidden></div>
               <div id="browser-toolbar">
+                <button class="ghost-btn ghost-btn-small" id="browser-back-btn" type="button">Back to Code</button>
                 <button class="ghost-btn ghost-btn-small" id="browser-reload-btn" type="button">Reload</button>
                 <button class="ghost-btn ghost-btn-small" id="browser-open-btn" type="button">Open External</button>
               </div>

--- a/winsmux-app/index.html
+++ b/winsmux-app/index.html
@@ -126,6 +126,7 @@
               <div id="browser-toolbar">
                 <div id="browser-toolbar-summary"></div>
                 <button class="ghost-btn ghost-btn-small" id="browser-back-btn" type="button">Back to Code</button>
+                <button class="ghost-btn ghost-btn-small" id="browser-copy-btn" type="button">Copy URL</button>
                 <button class="ghost-btn ghost-btn-small" id="browser-reload-btn" type="button">Reload</button>
                 <button class="ghost-btn ghost-btn-small" id="browser-open-btn" type="button">Open External</button>
               </div>

--- a/winsmux-app/index.html
+++ b/winsmux-app/index.html
@@ -124,6 +124,7 @@
               <div id="browser-meta-row"></div>
               <div id="browser-target-list" hidden></div>
               <div id="browser-toolbar">
+                <div id="browser-toolbar-summary"></div>
                 <button class="ghost-btn ghost-btn-small" id="browser-back-btn" type="button">Back to Code</button>
                 <button class="ghost-btn ghost-btn-small" id="browser-reload-btn" type="button">Reload</button>
                 <button class="ghost-btn ghost-btn-small" id="browser-open-btn" type="button">Open External</button>

--- a/winsmux-app/index.html
+++ b/winsmux-app/index.html
@@ -122,6 +122,10 @@
             <div id="editor-tabs"></div>
             <div id="browser-surface" hidden>
               <div id="browser-meta-row"></div>
+              <div id="browser-toolbar">
+                <button class="ghost-btn ghost-btn-small" id="browser-reload-btn" type="button">Reload</button>
+                <button class="ghost-btn ghost-btn-small" id="browser-open-btn" type="button">Open External</button>
+              </div>
               <iframe id="browser-frame" title="Localhost preview browser"></iframe>
             </div>
             <pre id="editor-code"></pre>

--- a/winsmux-app/index.html
+++ b/winsmux-app/index.html
@@ -122,6 +122,7 @@
             <div id="editor-tabs"></div>
             <div id="browser-surface" hidden>
               <div id="browser-meta-row"></div>
+              <div id="browser-target-list" hidden></div>
               <div id="browser-toolbar">
                 <button class="ghost-btn ghost-btn-small" id="browser-reload-btn" type="button">Reload</button>
                 <button class="ghost-btn ghost-btn-small" id="browser-open-btn" type="button">Open External</button>

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -190,6 +190,7 @@ let sidebarWidth = 292;
 let selectedEditorKey = "";
 let selectedPreviewUrl = "";
 let lastExternalPreviewOpen: { url: string; openedAt: number } | null = null;
+let lastCopiedPreviewUrl: { url: string; copiedAt: number } | null = null;
 let selectedRunId: string | null = null;
 let activeComposerMode: ComposerMode = "dispatch";
 let activeSourceFilter: SourceFilter = "all";
@@ -981,6 +982,9 @@ function openPreviewTarget(url: string) {
   if (lastExternalPreviewOpen?.url !== url) {
     lastExternalPreviewOpen = null;
   }
+  if (lastCopiedPreviewUrl?.url !== url) {
+    lastCopiedPreviewUrl = null;
+  }
   setEditorSurface(true);
 }
 
@@ -988,6 +992,7 @@ function closePreviewTarget() {
   editorSurfaceMode = "code";
   selectedPreviewUrl = "";
   lastExternalPreviewOpen = null;
+  lastCopiedPreviewUrl = null;
   if (!selectedEditorKey) {
     setEditorSurface(false);
     return;
@@ -1016,6 +1021,18 @@ function openPreviewTargetExternally() {
   };
   renderEditorSurface();
   window.open(selectedPreviewUrl, "_blank", "noopener");
+}
+
+async function copyPreviewTargetUrl() {
+  if (!selectedPreviewUrl || !navigator.clipboard) {
+    return;
+  }
+  await navigator.clipboard.writeText(selectedPreviewUrl);
+  lastCopiedPreviewUrl = {
+    url: selectedPreviewUrl,
+    copiedAt: Date.now(),
+  };
+  renderEditorSurface();
 }
 
 function getSourceFilterLabel(filter: SourceFilter) {
@@ -2896,12 +2913,13 @@ function renderEditorSurface() {
   const browserTargetList = document.getElementById("browser-target-list");
   const browserToolbarSummary = document.getElementById("browser-toolbar-summary");
   const browserBackButton = document.getElementById("browser-back-btn") as HTMLButtonElement | null;
+  const browserCopyButton = document.getElementById("browser-copy-btn") as HTMLButtonElement | null;
   const browserReloadButton = document.getElementById("browser-reload-btn") as HTMLButtonElement | null;
   const browserOpenButton = document.getElementById("browser-open-btn") as HTMLButtonElement | null;
   const tabs = document.getElementById("editor-tabs");
   const code = document.getElementById("editor-code");
   const statusbar = document.getElementById("editor-statusbar");
-  if (!path || !meta || !diffPreview || !browserSurface || !browserFrame || !browserMeta || !browserTargetList || !browserToolbarSummary || !browserBackButton || !browserReloadButton || !browserOpenButton || !tabs || !code || !statusbar) {
+  if (!path || !meta || !diffPreview || !browserSurface || !browserFrame || !browserMeta || !browserTargetList || !browserToolbarSummary || !browserBackButton || !browserCopyButton || !browserReloadButton || !browserOpenButton || !tabs || !code || !statusbar) {
     return;
   }
 
@@ -2946,6 +2964,7 @@ function renderEditorSurface() {
   browserTargetList.hidden = true;
   browserSurface.hidden = true;
   browserBackButton.disabled = true;
+  browserCopyButton.disabled = true;
   browserReloadButton.disabled = true;
   browserOpenButton.disabled = true;
   code.hidden = false;
@@ -3000,9 +3019,13 @@ function renderEditorSurface() {
       browserTargetList.hidden = false;
     }
     browserToolbarSummary.textContent = `${previewTargets.length} targets · active ${previewTarget.portLabel}${lastExternalPreviewOpen?.url === previewTarget.url ? " · external open" : ""}`;
+    if (lastCopiedPreviewUrl?.url === previewTarget.url) {
+      browserToolbarSummary.textContent += " · copied";
+    }
     browserFrame.src = previewTarget.url;
     browserSurface.hidden = false;
     browserBackButton.disabled = false;
+    browserCopyButton.disabled = false;
     browserReloadButton.disabled = false;
     browserOpenButton.disabled = false;
     code.textContent = "";
@@ -4300,6 +4323,10 @@ window.addEventListener("DOMContentLoaded", async () => {
 
   document.getElementById("browser-back-btn")?.addEventListener("click", () => {
     closePreviewTarget();
+  });
+
+  document.getElementById("browser-copy-btn")?.addEventListener("click", async () => {
+    await copyPreviewTargetUrl();
   });
 
   document.getElementById("browser-open-btn")?.addEventListener("click", () => {

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -188,6 +188,7 @@ let composerImeActive = false;
 let sidebarWidth = 292;
 let selectedEditorKey = "";
 let selectedPreviewUrl = "";
+let lastExternalPreviewOpen: { url: string; openedAt: number } | null = null;
 let selectedRunId: string | null = null;
 let activeComposerMode: ComposerMode = "dispatch";
 let activeSourceFilter: SourceFilter = "all";
@@ -957,6 +958,9 @@ function getPreviewTargets() {
 function openPreviewTarget(url: string) {
   selectedPreviewUrl = url;
   editorSurfaceMode = "preview";
+  if (lastExternalPreviewOpen?.url !== url) {
+    lastExternalPreviewOpen = null;
+  }
   setEditorSurface(true);
 }
 
@@ -975,6 +979,11 @@ function openPreviewTargetExternally() {
   if (!selectedPreviewUrl) {
     return;
   }
+  lastExternalPreviewOpen = {
+    url: selectedPreviewUrl,
+    openedAt: Date.now(),
+  };
+  renderEditorSurface();
   window.open(selectedPreviewUrl, "_blank", "noopener");
 }
 
@@ -2926,6 +2935,20 @@ function renderEditorSurface() {
     browserBody.textContent = previewTarget.url;
     browserMeta.appendChild(browserTitle);
     browserMeta.appendChild(browserBody);
+    if (lastExternalPreviewOpen?.url === previewTarget.url) {
+      const openedAt = new Date(lastExternalPreviewOpen.openedAt).toLocaleTimeString([], {
+        hour: "2-digit",
+        minute: "2-digit",
+      });
+      const handoffTitle = document.createElement("div");
+      handoffTitle.className = "editor-diff-preview-title";
+      handoffTitle.textContent = "External browser";
+      const handoffBody = document.createElement("div");
+      handoffBody.className = "editor-diff-preview-body";
+      handoffBody.textContent = `Opened at ${openedAt}`;
+      browserMeta.appendChild(handoffTitle);
+      browserMeta.appendChild(handoffBody);
+    }
     if (previewTargets.length > 0) {
       for (const target of previewTargets) {
         const targetButton = document.createElement("button");
@@ -2946,7 +2969,7 @@ function renderEditorSurface() {
     browserOpenButton.disabled = false;
     code.textContent = "";
     code.hidden = true;
-    statusbar.textContent = `Secondary work surface: preview -> ${previewTarget.url}`;
+    statusbar.textContent = `Secondary work surface: preview -> ${previewTarget.url}${lastExternalPreviewOpen?.url === previewTarget.url ? " (opened externally)" : ""}`;
   } else if (selected) {
     path.textContent = selected.path;
     for (const item of [
@@ -3823,6 +3846,7 @@ async function openEditorTarget(target: EditorTarget | null) {
 
   editorSurfaceMode = "code";
   selectedPreviewUrl = "";
+  lastExternalPreviewOpen = null;
   selectedEditorKey = target.key;
   setSelectedRun(target.sourceChange?.run ?? selectedRunId);
   setEditorSurface(true);
@@ -3852,6 +3876,7 @@ async function openEditorPath(path: string | undefined, worktree = "") {
   desktopStandaloneEditorTargets.set(target.key, target);
   editorSurfaceMode = "code";
   selectedPreviewUrl = "";
+  lastExternalPreviewOpen = null;
   selectedEditorKey = target.key;
   setEditorSurface(true);
   renderOpenEditors();

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -972,8 +972,21 @@ function registerPreviewTargets(paneId: string, data: string) {
   }
 }
 
-function getPreviewTargets() {
-  return Array.from(detectedPreviewTargets.values()).sort((left, right) => left.url.localeCompare(right.url));
+function getPreviewTargets(activeUrl = selectedPreviewUrl) {
+  return Array.from(detectedPreviewTargets.values()).sort((left, right) => {
+    if (activeUrl) {
+      if (left.url === activeUrl && right.url !== activeUrl) {
+        return -1;
+      }
+      if (right.url === activeUrl && left.url !== activeUrl) {
+        return 1;
+      }
+    }
+    if (left.lastSeenAt !== right.lastSeenAt) {
+      return right.lastSeenAt - left.lastSeenAt;
+    }
+    return left.url.localeCompare(right.url);
+  });
 }
 
 function openPreviewTarget(url: string) {

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -2853,18 +2853,20 @@ function renderEditorSurface() {
   const browserSurface = document.getElementById("browser-surface");
   const browserFrame = document.getElementById("browser-frame") as HTMLIFrameElement | null;
   const browserMeta = document.getElementById("browser-meta-row");
+  const browserTargetList = document.getElementById("browser-target-list");
   const browserReloadButton = document.getElementById("browser-reload-btn") as HTMLButtonElement | null;
   const browserOpenButton = document.getElementById("browser-open-btn") as HTMLButtonElement | null;
   const tabs = document.getElementById("editor-tabs");
   const code = document.getElementById("editor-code");
   const statusbar = document.getElementById("editor-statusbar");
-  if (!path || !meta || !diffPreview || !browserSurface || !browserFrame || !browserMeta || !browserReloadButton || !browserOpenButton || !tabs || !code || !statusbar) {
+  if (!path || !meta || !diffPreview || !browserSurface || !browserFrame || !browserMeta || !browserTargetList || !browserReloadButton || !browserOpenButton || !tabs || !code || !statusbar) {
     return;
   }
 
   const editors = getEditorFiles();
   const selected = editors.find((editor) => editor.key === selectedEditorKey) || editors[0];
   const previewTarget = selectedPreviewUrl ? detectedPreviewTargets.get(selectedPreviewUrl) ?? null : null;
+  const previewTargets = getPreviewTargets();
   const previewModeActive = editorSurfaceMode === "preview" && Boolean(previewTarget);
   if (!selected && !previewModeActive) {
     path.textContent = "Editor idle";
@@ -2872,6 +2874,8 @@ function renderEditorSurface() {
     diffPreview.innerHTML = "";
     diffPreview.hidden = true;
     browserMeta.innerHTML = "";
+    browserTargetList.innerHTML = "";
+    browserTargetList.hidden = true;
     browserFrame.src = "about:blank";
     browserSurface.hidden = true;
     tabs.innerHTML = "";
@@ -2895,6 +2899,8 @@ function renderEditorSurface() {
   diffPreview.innerHTML = "";
   diffPreview.hidden = true;
   browserMeta.innerHTML = "";
+  browserTargetList.innerHTML = "";
+  browserTargetList.hidden = true;
   browserSurface.hidden = true;
   browserReloadButton.disabled = true;
   browserOpenButton.disabled = true;
@@ -2920,6 +2926,20 @@ function renderEditorSurface() {
     browserBody.textContent = previewTarget.url;
     browserMeta.appendChild(browserTitle);
     browserMeta.appendChild(browserBody);
+    if (previewTargets.length > 0) {
+      for (const target of previewTargets) {
+        const targetButton = document.createElement("button");
+        targetButton.type = "button";
+        targetButton.className = `editor-tab ${target.url === previewTarget.url ? "is-active" : ""}`;
+        targetButton.textContent = target.portLabel;
+        targetButton.title = `${target.url} (${target.sourceLabel})`;
+        targetButton.addEventListener("click", () => {
+          openPreviewTarget(target.url);
+        });
+        browserTargetList.appendChild(targetButton);
+      }
+      browserTargetList.hidden = false;
+    }
     browserFrame.src = previewTarget.url;
     browserSurface.hidden = false;
     browserReloadButton.disabled = false;

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -984,6 +984,17 @@ function openPreviewTarget(url: string) {
   setEditorSurface(true);
 }
 
+function closePreviewTarget() {
+  editorSurfaceMode = "code";
+  selectedPreviewUrl = "";
+  lastExternalPreviewOpen = null;
+  if (!selectedEditorKey) {
+    setEditorSurface(false);
+    return;
+  }
+  setEditorSurface(true);
+}
+
 function reloadPreviewTarget() {
   if (!selectedPreviewUrl) {
     return;
@@ -2883,12 +2894,13 @@ function renderEditorSurface() {
   const browserFrame = document.getElementById("browser-frame") as HTMLIFrameElement | null;
   const browserMeta = document.getElementById("browser-meta-row");
   const browserTargetList = document.getElementById("browser-target-list");
+  const browserBackButton = document.getElementById("browser-back-btn") as HTMLButtonElement | null;
   const browserReloadButton = document.getElementById("browser-reload-btn") as HTMLButtonElement | null;
   const browserOpenButton = document.getElementById("browser-open-btn") as HTMLButtonElement | null;
   const tabs = document.getElementById("editor-tabs");
   const code = document.getElementById("editor-code");
   const statusbar = document.getElementById("editor-statusbar");
-  if (!path || !meta || !diffPreview || !browserSurface || !browserFrame || !browserMeta || !browserTargetList || !browserReloadButton || !browserOpenButton || !tabs || !code || !statusbar) {
+  if (!path || !meta || !diffPreview || !browserSurface || !browserFrame || !browserMeta || !browserTargetList || !browserBackButton || !browserReloadButton || !browserOpenButton || !tabs || !code || !statusbar) {
     return;
   }
 
@@ -2931,6 +2943,7 @@ function renderEditorSurface() {
   browserTargetList.innerHTML = "";
   browserTargetList.hidden = true;
   browserSurface.hidden = true;
+  browserBackButton.disabled = true;
   browserReloadButton.disabled = true;
   browserOpenButton.disabled = true;
   code.hidden = false;
@@ -2986,6 +2999,7 @@ function renderEditorSurface() {
     }
     browserFrame.src = previewTarget.url;
     browserSurface.hidden = false;
+    browserBackButton.disabled = false;
     browserReloadButton.disabled = false;
     browserOpenButton.disabled = false;
     code.textContent = "";
@@ -4279,6 +4293,10 @@ window.addEventListener("DOMContentLoaded", async () => {
 
   document.getElementById("browser-reload-btn")?.addEventListener("click", () => {
     reloadPreviewTarget();
+  });
+
+  document.getElementById("browser-back-btn")?.addEventListener("click", () => {
+    closePreviewTarget();
   });
 
   document.getElementById("browser-open-btn")?.addEventListener("click", () => {

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -190,7 +190,7 @@ let sidebarWidth = 292;
 let selectedEditorKey = "";
 let selectedPreviewUrl = "";
 let lastExternalPreviewOpen: { url: string; openedAt: number } | null = null;
-let lastCopiedPreviewUrl: { url: string; copiedAt: number } | null = null;
+let lastPreviewClipboardState: { url: string; at: number; ok: boolean } | null = null;
 let selectedRunId: string | null = null;
 let activeComposerMode: ComposerMode = "dispatch";
 let activeSourceFilter: SourceFilter = "all";
@@ -982,8 +982,8 @@ function openPreviewTarget(url: string) {
   if (lastExternalPreviewOpen?.url !== url) {
     lastExternalPreviewOpen = null;
   }
-  if (lastCopiedPreviewUrl?.url !== url) {
-    lastCopiedPreviewUrl = null;
+  if (lastPreviewClipboardState?.url !== url) {
+    lastPreviewClipboardState = null;
   }
   setEditorSurface(true);
 }
@@ -992,7 +992,7 @@ function closePreviewTarget() {
   editorSurfaceMode = "code";
   selectedPreviewUrl = "";
   lastExternalPreviewOpen = null;
-  lastCopiedPreviewUrl = null;
+  lastPreviewClipboardState = null;
   if (!selectedEditorKey) {
     setEditorSurface(false);
     return;
@@ -1027,11 +1027,21 @@ async function copyPreviewTargetUrl() {
   if (!selectedPreviewUrl || !navigator.clipboard) {
     return;
   }
-  await navigator.clipboard.writeText(selectedPreviewUrl);
-  lastCopiedPreviewUrl = {
-    url: selectedPreviewUrl,
-    copiedAt: Date.now(),
-  };
+  const previewUrl = selectedPreviewUrl;
+  try {
+    await navigator.clipboard.writeText(previewUrl);
+    lastPreviewClipboardState = {
+      url: previewUrl,
+      at: Date.now(),
+      ok: true,
+    };
+  } catch {
+    lastPreviewClipboardState = {
+      url: previewUrl,
+      at: Date.now(),
+      ok: false,
+    };
+  }
   renderEditorSurface();
 }
 
@@ -3019,13 +3029,13 @@ function renderEditorSurface() {
       browserTargetList.hidden = false;
     }
     browserToolbarSummary.textContent = `${previewTargets.length} targets · active ${previewTarget.portLabel}${lastExternalPreviewOpen?.url === previewTarget.url ? " · external open" : ""}`;
-    if (lastCopiedPreviewUrl?.url === previewTarget.url) {
-      browserToolbarSummary.textContent += " · copied";
+    if (lastPreviewClipboardState?.url === previewTarget.url) {
+      browserToolbarSummary.textContent += lastPreviewClipboardState.ok ? " · copied" : " · copy failed";
     }
     browserFrame.src = previewTarget.url;
     browserSurface.hidden = false;
     browserBackButton.disabled = false;
-    browserCopyButton.disabled = false;
+    browserCopyButton.disabled = !Boolean(navigator.clipboard);
     browserReloadButton.disabled = false;
     browserOpenButton.disabled = false;
     code.textContent = "";

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -3028,7 +3028,11 @@ function renderEditorSurface() {
       }
       browserTargetList.hidden = false;
     }
-    browserToolbarSummary.textContent = `${previewTargets.length} targets · active ${previewTarget.portLabel}${lastExternalPreviewOpen?.url === previewTarget.url ? " · external open" : ""}`;
+    browserToolbarSummary.textContent =
+      `${previewTargets.length} targets · active ${previewTarget.portLabel}` +
+      ` · from ${previewTarget.sourceLabel}` +
+      ` · seen ${formatPreviewSeenAt(previewTarget.lastSeenAt)}` +
+      `${lastExternalPreviewOpen?.url === previewTarget.url ? " · external open" : ""}`;
     if (lastPreviewClipboardState?.url === previewTarget.url) {
       browserToolbarSummary.textContent += lastPreviewClipboardState.ok ? " · copied" : " · copy failed";
     }

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -2972,7 +2972,7 @@ function renderEditorSurface() {
     statusbar.textContent = "Secondary work surface: 0 projected files";
     return;
   }
-  if (selected) {
+  if (selected && !previewModeActive) {
     selectedEditorKey = selected.key;
   }
   const selectedTarget = selected ? getEditorTargetByKey(selected.key) : null;
@@ -3054,7 +3054,10 @@ function renderEditorSurface() {
     if (lastPreviewClipboardState?.url === previewTarget.url) {
       browserToolbarSummary.textContent += lastPreviewClipboardState.ok ? " · copied" : " · copy failed";
     }
-    browserFrame.src = previewTarget.url;
+    if (browserFrame.dataset.previewUrl !== previewTarget.url) {
+      browserFrame.src = previewTarget.url;
+      browserFrame.dataset.previewUrl = previewTarget.url;
+    }
     browserSurface.hidden = false;
     browserBackButton.disabled = false;
     browserCopyButton.disabled = !Boolean(navigator.clipboard);

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -108,6 +108,7 @@ interface PreviewTarget {
   url: string;
   portLabel: string;
   sourceLabel: string;
+  lastSeenAt: number;
 }
 
 type SourceFilter = "all" | "candidates" | "attention" | `pane:${string}`;
@@ -200,6 +201,7 @@ let commandBarImeActive = false;
 let lastCommandBarFocus: HTMLElement | null = null;
 let pendingAttachments: ComposerAttachment[] = [];
 const detectedPreviewTargets = new Map<string, PreviewTarget>();
+const PREVIEW_FRESHNESS_WINDOW_MS = 30_000;
 let desktopSummarySnapshot: DesktopSummarySnapshot | null = null;
 let desktopSummaryRefreshInFlight: Promise<void> | null = null;
 let desktopSummaryRefreshTimeout: number | null = null;
@@ -931,16 +933,34 @@ function getPreviewPortLabel(url: string) {
   }
 }
 
+function formatPreviewSeenAt(timestamp: number) {
+  return new Date(timestamp).toLocaleTimeString([], {
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
 function registerPreviewTargets(paneId: string, data: string) {
   let changed = false;
+  const now = Date.now();
   for (const url of extractPreviewUrls(data)) {
-    if (detectedPreviewTargets.has(url)) {
+    const existing = detectedPreviewTargets.get(url);
+    if (existing) {
+      if (existing.sourceLabel !== (paneId || "terminal") || now - existing.lastSeenAt >= PREVIEW_FRESHNESS_WINDOW_MS) {
+        detectedPreviewTargets.set(url, {
+          ...existing,
+          sourceLabel: paneId || "terminal",
+          lastSeenAt: now,
+        });
+        changed = true;
+      }
       continue;
     }
     detectedPreviewTargets.set(url, {
       url,
       portLabel: getPreviewPortLabel(url),
       sourceLabel: paneId || "terminal",
+      lastSeenAt: now,
     });
     changed = true;
   }
@@ -1593,7 +1613,7 @@ function renderContextPanel() {
       name.textContent = target.url;
       const metaLine = document.createElement("span");
       metaLine.className = "context-file-meta";
-      metaLine.textContent = `Preview target · ${target.portLabel}`;
+      metaLine.textContent = `Preview target · ${target.portLabel} · Seen ${formatPreviewSeenAt(target.lastSeenAt)}`;
       const trace = document.createElement("span");
       trace.className = "context-file-trace";
       trace.textContent = `Detected from ${target.sourceLabel}`;
@@ -2921,6 +2941,7 @@ function renderEditorSurface() {
       "Preview browser",
       previewTarget.portLabel,
       `Detected from ${previewTarget.sourceLabel}`,
+      `Seen ${formatPreviewSeenAt(previewTarget.lastSeenAt)}`,
     ]) {
       const chip = document.createElement("span");
       chip.className = "editor-meta-chip";
@@ -2955,7 +2976,7 @@ function renderEditorSurface() {
         targetButton.type = "button";
         targetButton.className = `editor-tab ${target.url === previewTarget.url ? "is-active" : ""}`;
         targetButton.textContent = target.portLabel;
-        targetButton.title = `${target.url} (${target.sourceLabel})`;
+        targetButton.title = `${target.url} (${target.sourceLabel}, ${formatPreviewSeenAt(target.lastSeenAt)})`;
         targetButton.addEventListener("click", () => {
           openPreviewTarget(target.url);
         });

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -2894,13 +2894,14 @@ function renderEditorSurface() {
   const browserFrame = document.getElementById("browser-frame") as HTMLIFrameElement | null;
   const browserMeta = document.getElementById("browser-meta-row");
   const browserTargetList = document.getElementById("browser-target-list");
+  const browserToolbarSummary = document.getElementById("browser-toolbar-summary");
   const browserBackButton = document.getElementById("browser-back-btn") as HTMLButtonElement | null;
   const browserReloadButton = document.getElementById("browser-reload-btn") as HTMLButtonElement | null;
   const browserOpenButton = document.getElementById("browser-open-btn") as HTMLButtonElement | null;
   const tabs = document.getElementById("editor-tabs");
   const code = document.getElementById("editor-code");
   const statusbar = document.getElementById("editor-statusbar");
-  if (!path || !meta || !diffPreview || !browserSurface || !browserFrame || !browserMeta || !browserTargetList || !browserBackButton || !browserReloadButton || !browserOpenButton || !tabs || !code || !statusbar) {
+  if (!path || !meta || !diffPreview || !browserSurface || !browserFrame || !browserMeta || !browserTargetList || !browserToolbarSummary || !browserBackButton || !browserReloadButton || !browserOpenButton || !tabs || !code || !statusbar) {
     return;
   }
 
@@ -2941,6 +2942,7 @@ function renderEditorSurface() {
   diffPreview.hidden = true;
   browserMeta.innerHTML = "";
   browserTargetList.innerHTML = "";
+  browserToolbarSummary.textContent = "";
   browserTargetList.hidden = true;
   browserSurface.hidden = true;
   browserBackButton.disabled = true;
@@ -2997,6 +2999,7 @@ function renderEditorSurface() {
       }
       browserTargetList.hidden = false;
     }
+    browserToolbarSummary.textContent = `${previewTargets.length} targets · active ${previewTarget.portLabel}${lastExternalPreviewOpen?.url === previewTarget.url ? " · external open" : ""}`;
     browserFrame.src = previewTarget.url;
     browserSurface.hidden = false;
     browserBackButton.disabled = false;

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -104,6 +104,12 @@ interface EditorTarget {
   sourceChange?: SourceChange;
 }
 
+interface PreviewTarget {
+  url: string;
+  portLabel: string;
+  sourceLabel: string;
+}
+
 type SourceFilter = "all" | "candidates" | "attention" | `pane:${string}`;
 
 type ChangeStatus = "modified" | "added" | "deleted" | "renamed";
@@ -175,11 +181,13 @@ let paneCounter = 0;
 let terminalDrawerOpen = false;
 let contextPanelOpen = true;
 let editorSurfaceOpen = false;
+let editorSurfaceMode: "code" | "preview" = "code";
 let settingsSheetOpen = false;
 let sidebarOpen = true;
 let composerImeActive = false;
 let sidebarWidth = 292;
 let selectedEditorKey = "";
+let selectedPreviewUrl = "";
 let selectedRunId: string | null = null;
 let activeComposerMode: ComposerMode = "dispatch";
 let activeSourceFilter: SourceFilter = "all";
@@ -190,6 +198,7 @@ let selectedCommandIndex = 0;
 let commandBarImeActive = false;
 let lastCommandBarFocus: HTMLElement | null = null;
 let pendingAttachments: ComposerAttachment[] = [];
+const detectedPreviewTargets = new Map<string, PreviewTarget>();
 let desktopSummarySnapshot: DesktopSummarySnapshot | null = null;
 let desktopSummaryRefreshInFlight: Promise<void> | null = null;
 let desktopSummaryRefreshTimeout: number | null = null;
@@ -903,6 +912,54 @@ function getPrimarySourceChange(changes: SourceChange[]) {
   );
 }
 
+function stripAnsi(input: string) {
+  return input.replace(/\u001b\[[0-9;?]*[ -/]*[@-~]/g, "");
+}
+
+function extractPreviewUrls(data: string) {
+  const matches = stripAnsi(data).match(/https?:\/\/(?:localhost|127\.0\.0\.1):\d+(?:\/[^\s"'<>)]*)?/gi);
+  return matches ?? [];
+}
+
+function getPreviewPortLabel(url: string) {
+  try {
+    const parsed = new URL(url);
+    return parsed.port ? `:${parsed.port}` : parsed.host;
+  } catch {
+    return url;
+  }
+}
+
+function registerPreviewTargets(paneId: string, data: string) {
+  let changed = false;
+  for (const url of extractPreviewUrls(data)) {
+    if (detectedPreviewTargets.has(url)) {
+      continue;
+    }
+    detectedPreviewTargets.set(url, {
+      url,
+      portLabel: getPreviewPortLabel(url),
+      sourceLabel: paneId || "terminal",
+    });
+    changed = true;
+  }
+
+  if (changed) {
+    renderContextPanel();
+    renderEditorSurface();
+  }
+}
+
+function getPreviewTargets() {
+  return Array.from(detectedPreviewTargets.values()).sort((left, right) => left.url.localeCompare(right.url));
+}
+
+function openPreviewTarget(url: string) {
+  selectedPreviewUrl = url;
+  editorSurfaceMode = "preview";
+  setEditorSurface(true);
+}
+
 function getSourceFilterLabel(filter: SourceFilter) {
   switch (filter) {
     case "all":
@@ -1460,9 +1517,10 @@ function renderExperimentContext() {
 
 function renderContextPanel() {
   const sectionRoot = document.getElementById("context-sections");
+  const previewRoot = document.getElementById("preview-target-list");
   const overviewRoot = document.getElementById("source-overview-cards");
   const fileRoot = document.getElementById("context-file-list");
-  if (!sectionRoot || !overviewRoot || !fileRoot) {
+  if (!sectionRoot || !previewRoot || !overviewRoot || !fileRoot) {
     return;
   }
 
@@ -1487,6 +1545,40 @@ function renderContextPanel() {
   }
 
   renderExperimentContext();
+
+  previewRoot.innerHTML = "";
+  const previewTargets = getPreviewTargets();
+  if (previewTargets.length === 0) {
+    const empty = document.createElement("div");
+    empty.className = "context-empty-state";
+    empty.innerHTML =
+      `<div class="context-label">No detected ports</div>` +
+      `<div class="context-value">Run a localhost dev server in the utility terminal to surface a preview target.</div>`;
+    previewRoot.appendChild(empty);
+  } else {
+    for (const target of previewTargets) {
+      const button = document.createElement("button");
+      button.type = "button";
+      button.className = `context-file-row ${editorSurfaceOpen && editorSurfaceMode === "preview" && selectedPreviewUrl === target.url ? "is-active" : ""}`;
+      button.dataset.tone = "info";
+      const name = document.createElement("span");
+      name.className = "context-file-name";
+      name.textContent = target.url;
+      const metaLine = document.createElement("span");
+      metaLine.className = "context-file-meta";
+      metaLine.textContent = `Preview target · ${target.portLabel}`;
+      const trace = document.createElement("span");
+      trace.className = "context-file-trace";
+      trace.textContent = `Detected from ${target.sourceLabel}`;
+      button.appendChild(name);
+      button.appendChild(metaLine);
+      button.appendChild(trace);
+      button.addEventListener("click", () => {
+        openPreviewTarget(target.url);
+      });
+      previewRoot.appendChild(button);
+    }
+  }
 
   overviewRoot.innerHTML = "";
   const overviewCards = [
@@ -2740,58 +2832,99 @@ function renderEditorSurface() {
   const path = document.getElementById("editor-file-path");
   const meta = document.getElementById("editor-meta-row");
   const diffPreview = document.getElementById("editor-diff-preview");
+  const browserSurface = document.getElementById("browser-surface");
+  const browserFrame = document.getElementById("browser-frame") as HTMLIFrameElement | null;
+  const browserMeta = document.getElementById("browser-meta-row");
   const tabs = document.getElementById("editor-tabs");
   const code = document.getElementById("editor-code");
   const statusbar = document.getElementById("editor-statusbar");
-  if (!path || !meta || !diffPreview || !tabs || !code || !statusbar) {
+  if (!path || !meta || !diffPreview || !browserSurface || !browserFrame || !browserMeta || !tabs || !code || !statusbar) {
     return;
   }
 
   const editors = getEditorFiles();
   const selected = editors.find((editor) => editor.key === selectedEditorKey) || editors[0];
-  if (!selected) {
+  const previewTarget = selectedPreviewUrl ? detectedPreviewTargets.get(selectedPreviewUrl) ?? null : null;
+  const previewModeActive = editorSurfaceMode === "preview" && Boolean(previewTarget);
+  if (!selected && !previewModeActive) {
     path.textContent = "Editor idle";
     meta.innerHTML = "";
     diffPreview.innerHTML = "";
     diffPreview.hidden = true;
+    browserMeta.innerHTML = "";
+    browserFrame.src = "about:blank";
+    browserSurface.hidden = true;
     tabs.innerHTML = "";
     code.textContent = "No backend preview cached.";
+    code.hidden = false;
     statusbar.textContent = "Secondary work surface: 0 projected files";
     return;
   }
-  selectedEditorKey = selected.key;
-  const selectedTarget = getEditorTargetByKey(selected.key);
-  if (selectedTarget && !desktopEditorFileCache.has(selected.key) && !desktopEditorLoadingPaths.has(selected.key)) {
+  if (selected) {
+    selectedEditorKey = selected.key;
+  }
+  const selectedTarget = selected ? getEditorTargetByKey(selected.key) : null;
+  if (selected && selectedTarget && !desktopEditorFileCache.has(selected.key) && !desktopEditorLoadingPaths.has(selected.key)) {
     void ensureEditorFileLoaded(selectedTarget);
   }
   const selectedWorktreeLabel = selectedTarget?.worktree
     ? getWorktreeLabel(selectedTarget.worktree)
     : "";
 
-  path.textContent = selected.path;
   meta.innerHTML = "";
-  for (const item of [
-    selected.language,
-    `${selected.lineCount} lines`,
-    selected.modified ? "Modified" : "Saved",
-    selected.origin === "context" ? "Opened from context" : "Opened from explorer",
-    selectedWorktreeLabel,
-  ]) {
-    if (!item) {
-      continue;
-    }
-    const chip = document.createElement("span");
-    chip.className = `editor-meta-chip ${item === "Modified" ? "is-modified" : ""}`;
-    chip.dataset.tone = item === "Modified" ? "focus" : "default";
-    chip.textContent = item;
-    meta.appendChild(chip);
-  }
   diffPreview.innerHTML = "";
   diffPreview.hidden = true;
-  if (selectedTarget?.sourceChange) {
-    const previewTitle = document.createElement("div");
-    previewTitle.className = "editor-diff-preview-title";
-    previewTitle.textContent = "Diff preview";
+  browserMeta.innerHTML = "";
+  browserSurface.hidden = true;
+  code.hidden = false;
+
+  if (previewModeActive && previewTarget) {
+    path.textContent = previewTarget.url;
+    for (const item of [
+      "Preview browser",
+      previewTarget.portLabel,
+      `Detected from ${previewTarget.sourceLabel}`,
+    ]) {
+      const chip = document.createElement("span");
+      chip.className = "editor-meta-chip";
+      chip.textContent = item;
+      meta.appendChild(chip);
+    }
+    const browserTitle = document.createElement("div");
+    browserTitle.className = "editor-diff-preview-title";
+    browserTitle.textContent = "Preview target";
+    const browserBody = document.createElement("div");
+    browserBody.className = "editor-diff-preview-body";
+    browserBody.textContent = previewTarget.url;
+    browserMeta.appendChild(browserTitle);
+    browserMeta.appendChild(browserBody);
+    browserFrame.src = previewTarget.url;
+    browserSurface.hidden = false;
+    code.textContent = "";
+    code.hidden = true;
+    statusbar.textContent = `Secondary work surface: preview -> ${previewTarget.url}`;
+  } else if (selected) {
+    path.textContent = selected.path;
+    for (const item of [
+      selected.language,
+      `${selected.lineCount} lines`,
+      selected.modified ? "Modified" : "Saved",
+      selected.origin === "context" ? "Opened from context" : "Opened from explorer",
+      selectedWorktreeLabel,
+    ]) {
+      if (!item) {
+        continue;
+      }
+      const chip = document.createElement("span");
+      chip.className = `editor-meta-chip ${item === "Modified" ? "is-modified" : ""}`;
+      chip.dataset.tone = item === "Modified" ? "focus" : "default";
+      chip.textContent = item;
+      meta.appendChild(chip);
+    }
+    if (selectedTarget?.sourceChange) {
+      const previewTitle = document.createElement("div");
+      previewTitle.className = "editor-diff-preview-title";
+      previewTitle.textContent = "Diff preview";
     const previewBody = document.createElement("div");
     previewBody.className = "editor-diff-preview-body";
     previewBody.textContent = selectedTarget.sourceChange.summary;
@@ -2812,13 +2945,14 @@ function renderEditorSurface() {
       chip.textContent = item;
       previewMeta.appendChild(chip);
     }
-    diffPreview.appendChild(previewTitle);
-    diffPreview.appendChild(previewBody);
-    diffPreview.appendChild(previewMeta);
-    diffPreview.hidden = false;
+      diffPreview.appendChild(previewTitle);
+      diffPreview.appendChild(previewBody);
+      diffPreview.appendChild(previewMeta);
+      diffPreview.hidden = false;
+    }
+    code.textContent = selected.content;
+    statusbar.textContent = `Secondary work surface: ${selected.origin === "context" ? "run context" : "explorer"} -> ${selectedWorktreeLabel ? `${selectedWorktreeLabel} / ` : ""}${selected.path}`;
   }
-  code.textContent = selected.content;
-  statusbar.textContent = `Secondary work surface: ${selected.origin === "context" ? "run context" : "explorer"} -> ${selectedWorktreeLabel ? `${selectedWorktreeLabel} / ` : ""}${selected.path}`;
   tabs.innerHTML = "";
 
   for (const editor of editors) {
@@ -3643,6 +3777,8 @@ async function openEditorTarget(target: EditorTarget | null) {
     return;
   }
 
+  editorSurfaceMode = "code";
+  selectedPreviewUrl = "";
   selectedEditorKey = target.key;
   setSelectedRun(target.sourceChange?.run ?? selectedRunId);
   setEditorSurface(true);
@@ -3670,6 +3806,8 @@ async function openEditorPath(path: string | undefined, worktree = "") {
 
   const target = createStandaloneEditorTarget(path, worktree);
   desktopStandaloneEditorTargets.set(target.key, target);
+  editorSurfaceMode = "code";
+  selectedPreviewUrl = "";
   selectedEditorKey = target.key;
   setEditorSurface(true);
   renderOpenEditors();
@@ -3997,6 +4135,7 @@ function initializeSidebarResize() {
 
 window.addEventListener("DOMContentLoaded", async () => {
   await subscribeToPtyOutput((payload) => {
+    registerPreviewTargets(payload.pane_id, payload.data);
     const entry = payload.pane_id ? panes.get(payload.pane_id) : undefined;
     if (entry) {
       entry.terminal.write(payload.data);

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -189,7 +189,7 @@ let composerImeActive = false;
 let sidebarWidth = 292;
 let selectedEditorKey = "";
 let selectedPreviewUrl = "";
-let lastExternalPreviewOpen: { url: string; openedAt: number } | null = null;
+let lastPreviewExternalState: { url: string; at: number; ok: boolean } | null = null;
 let lastPreviewClipboardState: { url: string; at: number; ok: boolean } | null = null;
 let selectedRunId: string | null = null;
 let activeComposerMode: ComposerMode = "dispatch";
@@ -992,8 +992,8 @@ function getPreviewTargets(activeUrl = selectedPreviewUrl) {
 function openPreviewTarget(url: string) {
   selectedPreviewUrl = url;
   editorSurfaceMode = "preview";
-  if (lastExternalPreviewOpen?.url !== url) {
-    lastExternalPreviewOpen = null;
+  if (lastPreviewExternalState?.url !== url) {
+    lastPreviewExternalState = null;
   }
   if (lastPreviewClipboardState?.url !== url) {
     lastPreviewClipboardState = null;
@@ -1004,7 +1004,7 @@ function openPreviewTarget(url: string) {
 function closePreviewTarget() {
   editorSurfaceMode = "code";
   selectedPreviewUrl = "";
-  lastExternalPreviewOpen = null;
+  lastPreviewExternalState = null;
   lastPreviewClipboardState = null;
   if (!selectedEditorKey) {
     setEditorSurface(false);
@@ -1030,14 +1030,15 @@ function openPreviewTargetExternally() {
   }
   const previewUrl = selectedPreviewUrl;
   const opened = window.open(previewUrl, "_blank", "noopener");
+  lastPreviewExternalState = {
+    url: previewUrl,
+    at: Date.now(),
+    ok: Boolean(opened),
+  };
+  renderEditorSurface();
   if (!opened) {
     return;
   }
-  lastExternalPreviewOpen = {
-    url: previewUrl,
-    openedAt: Date.now(),
-  };
-  renderEditorSurface();
 }
 
 async function copyPreviewTargetUrl() {
@@ -3017,8 +3018,8 @@ function renderEditorSurface() {
     browserBody.textContent = previewTarget.url;
     browserMeta.appendChild(browserTitle);
     browserMeta.appendChild(browserBody);
-    if (lastExternalPreviewOpen?.url === previewTarget.url) {
-      const openedAt = new Date(lastExternalPreviewOpen.openedAt).toLocaleTimeString([], {
+    if (lastPreviewExternalState?.url === previewTarget.url) {
+      const openedAt = new Date(lastPreviewExternalState.at).toLocaleTimeString([], {
         hour: "2-digit",
         minute: "2-digit",
       });
@@ -3027,7 +3028,7 @@ function renderEditorSurface() {
       handoffTitle.textContent = "External browser";
       const handoffBody = document.createElement("div");
       handoffBody.className = "editor-diff-preview-body";
-      handoffBody.textContent = `Opened at ${openedAt}`;
+      handoffBody.textContent = lastPreviewExternalState.ok ? `Opened at ${openedAt}` : `Blocked at ${openedAt}`;
       browserMeta.appendChild(handoffTitle);
       browserMeta.appendChild(handoffBody);
     }
@@ -3049,7 +3050,7 @@ function renderEditorSurface() {
       `${previewTargets.length} targets · active ${previewTarget.portLabel}` +
       ` · from ${previewTarget.sourceLabel}` +
       ` · seen ${formatPreviewSeenAt(previewTarget.lastSeenAt)}` +
-      `${lastExternalPreviewOpen?.url === previewTarget.url ? " · external open" : ""}`;
+      `${lastPreviewExternalState?.url === previewTarget.url ? (lastPreviewExternalState.ok ? " · external open" : " · external blocked") : ""}`;
     if (lastPreviewClipboardState?.url === previewTarget.url) {
       browserToolbarSummary.textContent += lastPreviewClipboardState.ok ? " · copied" : " · copy failed";
     }
@@ -3061,7 +3062,9 @@ function renderEditorSurface() {
     browserOpenButton.disabled = false;
     code.textContent = "";
     code.hidden = true;
-    statusbar.textContent = `Secondary work surface: preview -> ${previewTarget.url}${lastExternalPreviewOpen?.url === previewTarget.url ? " (opened externally)" : ""}`;
+    statusbar.textContent =
+      `Secondary work surface: preview -> ${previewTarget.url}` +
+      `${lastPreviewExternalState?.url === previewTarget.url ? (lastPreviewExternalState.ok ? " (opened externally)" : " (external blocked)") : ""}`;
   } else if (selected) {
     path.textContent = selected.path;
     for (const item of [
@@ -3938,7 +3941,7 @@ async function openEditorTarget(target: EditorTarget | null) {
 
   editorSurfaceMode = "code";
   selectedPreviewUrl = "";
-  lastExternalPreviewOpen = null;
+  lastPreviewExternalState = null;
   selectedEditorKey = target.key;
   setSelectedRun(target.sourceChange?.run ?? selectedRunId);
   setEditorSurface(true);
@@ -3968,7 +3971,7 @@ async function openEditorPath(path: string | undefined, worktree = "") {
   desktopStandaloneEditorTargets.set(target.key, target);
   editorSurfaceMode = "code";
   selectedPreviewUrl = "";
-  lastExternalPreviewOpen = null;
+  lastPreviewExternalState = null;
   selectedEditorKey = target.key;
   setEditorSurface(true);
   renderOpenEditors();

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -1028,12 +1028,16 @@ function openPreviewTargetExternally() {
   if (!selectedPreviewUrl) {
     return;
   }
+  const previewUrl = selectedPreviewUrl;
+  const opened = window.open(previewUrl, "_blank", "noopener");
+  if (!opened) {
+    return;
+  }
   lastExternalPreviewOpen = {
-    url: selectedPreviewUrl,
+    url: previewUrl,
     openedAt: Date.now(),
   };
   renderEditorSurface();
-  window.open(selectedPreviewUrl, "_blank", "noopener");
 }
 
 async function copyPreviewTargetUrl() {

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -960,6 +960,24 @@ function openPreviewTarget(url: string) {
   setEditorSurface(true);
 }
 
+function reloadPreviewTarget() {
+  if (!selectedPreviewUrl) {
+    return;
+  }
+  const browserFrame = document.getElementById("browser-frame") as HTMLIFrameElement | null;
+  if (!browserFrame) {
+    return;
+  }
+  browserFrame.src = selectedPreviewUrl;
+}
+
+function openPreviewTargetExternally() {
+  if (!selectedPreviewUrl) {
+    return;
+  }
+  window.open(selectedPreviewUrl, "_blank", "noopener");
+}
+
 function getSourceFilterLabel(filter: SourceFilter) {
   switch (filter) {
     case "all":
@@ -2835,10 +2853,12 @@ function renderEditorSurface() {
   const browserSurface = document.getElementById("browser-surface");
   const browserFrame = document.getElementById("browser-frame") as HTMLIFrameElement | null;
   const browserMeta = document.getElementById("browser-meta-row");
+  const browserReloadButton = document.getElementById("browser-reload-btn") as HTMLButtonElement | null;
+  const browserOpenButton = document.getElementById("browser-open-btn") as HTMLButtonElement | null;
   const tabs = document.getElementById("editor-tabs");
   const code = document.getElementById("editor-code");
   const statusbar = document.getElementById("editor-statusbar");
-  if (!path || !meta || !diffPreview || !browserSurface || !browserFrame || !browserMeta || !tabs || !code || !statusbar) {
+  if (!path || !meta || !diffPreview || !browserSurface || !browserFrame || !browserMeta || !browserReloadButton || !browserOpenButton || !tabs || !code || !statusbar) {
     return;
   }
 
@@ -2876,6 +2896,8 @@ function renderEditorSurface() {
   diffPreview.hidden = true;
   browserMeta.innerHTML = "";
   browserSurface.hidden = true;
+  browserReloadButton.disabled = true;
+  browserOpenButton.disabled = true;
   code.hidden = false;
 
   if (previewModeActive && previewTarget) {
@@ -2900,6 +2922,8 @@ function renderEditorSurface() {
     browserMeta.appendChild(browserBody);
     browserFrame.src = previewTarget.url;
     browserSurface.hidden = false;
+    browserReloadButton.disabled = false;
+    browserOpenButton.disabled = false;
     code.textContent = "";
     code.hidden = true;
     statusbar.textContent = `Secondary work surface: preview -> ${previewTarget.url}`;
@@ -4185,6 +4209,14 @@ window.addEventListener("DOMContentLoaded", async () => {
 
   document.getElementById("toggle-terminal-btn")?.addEventListener("click", () => {
     setTerminalDrawer(!terminalDrawerOpen);
+  });
+
+  document.getElementById("browser-reload-btn")?.addEventListener("click", () => {
+    reloadPreviewTarget();
+  });
+
+  document.getElementById("browser-open-btn")?.addEventListener("click", () => {
+    openPreviewTargetExternally();
   });
 
   document.getElementById("toggle-context-btn")?.addEventListener("click", () => {

--- a/winsmux-app/src/styles.css
+++ b/winsmux-app/src/styles.css
@@ -941,6 +941,33 @@ textarea {
   gap: 8px;
 }
 
+#browser-surface {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  flex: 1;
+  min-height: 0;
+}
+
+#browser-meta-row {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px 14px;
+  border: 1px solid var(--border-muted);
+  border-radius: 16px;
+  background: var(--bg-surface);
+}
+
+#browser-frame {
+  flex: 1;
+  min-height: 360px;
+  width: 100%;
+  border: 1px solid var(--border-muted);
+  border-radius: 16px;
+  background: #0f1422;
+}
+
 .editor-meta-chip {
   display: inline-flex;
   align-items: center;
@@ -1173,6 +1200,22 @@ textarea {
   display: flex;
   flex-direction: column;
   gap: 8px;
+}
+
+#preview-target-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.context-empty-state {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 12px 14px;
+  border: 1px solid var(--border-muted);
+  border-radius: 16px;
+  background: var(--bg-surface);
 }
 
 .context-file-row {

--- a/winsmux-app/src/styles.css
+++ b/winsmux-app/src/styles.css
@@ -977,6 +977,13 @@ textarea {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
+  align-items: center;
+}
+
+#browser-toolbar-summary {
+  margin-right: auto;
+  font-size: var(--text-2xs);
+  color: var(--text-muted);
 }
 
 #browser-frame {

--- a/winsmux-app/src/styles.css
+++ b/winsmux-app/src/styles.css
@@ -959,6 +959,20 @@ textarea {
   background: var(--bg-surface);
 }
 
+#browser-target-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+#browser-target-list[hidden] {
+  display: none;
+}
+
+#browser-target-list .editor-tab {
+  background: var(--bg-surface);
+}
+
 #browser-toolbar {
   display: flex;
   flex-wrap: wrap;

--- a/winsmux-app/src/styles.css
+++ b/winsmux-app/src/styles.css
@@ -959,6 +959,12 @@ textarea {
   background: var(--bg-surface);
 }
 
+#browser-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
 #browser-frame {
   flex: 1;
   min-height: 360px;


### PR DESCRIPTION
## Summary
- add a first in-app preview browser shell inside the desktop app
- detect localhost preview targets from PTY output and show them in a Ports rail
- let the secondary surface switch between code preview and localhost preview

## Testing
- cmd /c npm run build
- pwsh -NoProfile -File .\\scripts\\git-guard.ps1 -Mode full
- pwsh -NoProfile -File .\\scripts\\audit-public-surface.ps1
