### PR TITLE
Add viewport verification harness

### DIFF
--- a/.githooks/pre-commit-whitelist.ps1
+++ b/.githooks/pre-commit-whitelist.ps1
@@ -34,6 +34,7 @@ $whitelistPatterns = @(
     'tests/HarnessContract.Tests.ps1',
     'tests/fixtures/rust-parity/*.json',
     'tests/test_support/rust_parity.rs',
+    'winsmux-app/scripts/*.mjs',
     'winsmux-core/**',
     '.claude/CLAUDE.md',
     '.claude/hooks/**',

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -3007,6 +3007,44 @@ function Invoke-Doctor {
         Write-Output "Codex config: not found"
     }
 
+    $languageMode = [string]$ExecutionContext.SessionState.LanguageMode
+    if ($languageMode -eq 'ConstrainedLanguage') {
+        Write-Output "PowerShell language mode: $languageMode [WARNING: avoid Set-Content/Out-File and prefer apply_patch or cmd /c]"
+    } else {
+        Write-Output "PowerShell language mode: $languageMode [OK]"
+    }
+
+    try {
+        $gitLockPath = (& git rev-parse --git-path index.lock 2>$null | Out-String).Trim()
+        if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($gitLockPath)) {
+            $resolvedGitLockPath = if ([System.IO.Path]::IsPathRooted($gitLockPath)) {
+                $gitLockPath
+            } else {
+                Join-Path (Get-Location).Path $gitLockPath
+            }
+
+            $gitLockDir = Split-Path -Parent $resolvedGitLockPath
+            if ($gitLockDir -match '[\\/]\.git[\\/]worktrees[\\/]') {
+                $probeName = 'winsmux-doctor-write-probe-' + [guid]::NewGuid().ToString('N') + '.tmp'
+                $probePath = Join-Path $gitLockDir $probeName
+                $quotedProbePath = '"' + $probePath.Replace('"', '""') + '"'
+                & cmd /d /c "type nul > $quotedProbePath" | Out-Null
+                if ($LASTEXITCODE -eq 0 -and (Test-Path $probePath)) {
+                    Remove-Item -Path $probePath -Force -ErrorAction SilentlyContinue
+                    Write-Output "Worktree git writes: writable [OK]"
+                } else {
+                    Write-Output "Worktree git writes: blocked [WARNING: keep editing/testing in the pane, but run git add/git commit/git push from a regular shell]"
+                }
+            } else {
+                Write-Output "Worktree git writes: not applicable [OK: not running from a linked worktree]"
+            }
+        } else {
+            Write-Output "Worktree git writes: unavailable [WARNING: git rev-parse --git-path index.lock failed]"
+        }
+    } catch {
+        Write-Output "Worktree git writes: unavailable [WARNING: $($_.Exception.Message)]"
+    }
+
     # Manifest
     $manifestPath = Join-Path (Get-Location).Path '.winsmux' 'manifest.yaml'
     Write-Output "Manifest: $(if (Test-Path $manifestPath) { 'exists' } else { 'not found' })"

--- a/winsmux-app/.gitignore
+++ b/winsmux-app/.gitignore
@@ -10,6 +10,7 @@ lerna-debug.log*
 node_modules
 dist
 dist-ssr
+output
 *.local
 
 # Editor directories and files

--- a/winsmux-app/package-lock.json
+++ b/winsmux-app/package-lock.json
@@ -16,6 +16,7 @@
       },
       "devDependencies": {
         "@tauri-apps/cli": "^2",
+        "playwright": "^1.58.1",
         "typescript": "~5.6.2",
         "vite": "^6.0.3"
       }
@@ -1180,6 +1181,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.1.tgz",
+      "integrity": "sha512-+2uTZHxSCcxjvGc5C891LrS1/NlxglGxzrC4seZiVjcYVQfUa87wBL6rTDqzGjuoWNjnBzRqKmF6zRYGMvQUaQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.1.tgz",
+      "integrity": "sha512-bcWzOaTxcW+VOOGBCQgnaKToLJ65d6AqfLVKEWvexyS3AS6rbXl+xdpYRMGSRBClPvyj44njOWoxjNdL/H9UNg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/winsmux-app/package.json
+++ b/winsmux-app/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "test:editor-targets": "node ./scripts/editor-targets-check.mjs",
+    "test:viewport-harness": "npm run build && node ./scripts/viewport-harness.mjs",
     "preview": "vite preview",
     "tauri": "tauri"
   },
@@ -19,6 +20,7 @@
   },
   "devDependencies": {
     "@tauri-apps/cli": "^2",
+    "playwright": "^1.58.1",
     "typescript": "~5.6.2",
     "vite": "^6.0.3"
   }

--- a/winsmux-app/scripts/viewport-harness.mjs
+++ b/winsmux-app/scripts/viewport-harness.mjs
@@ -265,6 +265,21 @@ async function assertNarrowSettingsRoundtrip(page, returnSelector) {
   await page.locator("#toggle-sidebar-btn[aria-expanded='false']").waitFor();
 }
 
+async function assertTerminalDrawerWithSourceContext(page, returnSelector, extraSelector) {
+  await page.click("#toggle-terminal-btn");
+  await page.locator("#terminal-drawer").waitFor({ state: "visible" });
+  await assertButtonVisible(page, "#add-pane-btn");
+  await assertHorizontallyVisible(page, "#terminal-drawer");
+  await page.locator(returnSelector).waitFor({ state: "visible" });
+  if (extraSelector) {
+    await page.locator(extraSelector).waitFor({ state: "visible" });
+    await assertHorizontallyVisible(page, extraSelector);
+  }
+  await page.click("#toggle-terminal-btn");
+  await page.locator("#terminal-drawer").waitFor({ state: "hidden" });
+  await page.locator(returnSelector).waitFor({ state: "visible" });
+}
+
 async function verifyDesktopViewport(page, previewUrl) {
   await page.setViewportSize({ width: 1440, height: 900 });
   await page.goto(`${previewUrl}${HARNESS_QUERY}`, { waitUntil: "networkidle" });
@@ -294,6 +309,7 @@ async function verifyDesktopViewport(page, previewUrl) {
   await openFirstSourceContextEntry(page);
   await assertCommandBarRoundtrip(page, "#editor-surface");
   await assertSettingsRoundtrip(page, "#editor-surface");
+  await assertTerminalDrawerWithSourceContext(page, "#editor-surface", "#context-panel");
 
   await registerHarnessPreviewTarget(page, `${previewUrl}${HARNESS_QUERY}`);
   await waitForPreviewTargetEntry(page);
@@ -351,6 +367,7 @@ async function verifyNarrowViewport(page, previewUrl) {
   await openFirstSourceContextEntry(page);
   await assertCommandBarRoundtrip(page, "#editor-surface");
   await assertNarrowSettingsRoundtrip(page, "#editor-surface");
+  await assertTerminalDrawerWithSourceContext(page, "#editor-surface");
 
   await page.click("#toggle-terminal-btn");
   await page.locator("#terminal-drawer").waitFor({ state: "visible" });
@@ -444,6 +461,7 @@ async function run() {
             "desktop-source-context",
             "desktop-command-bar-with-editor",
             "desktop-settings-with-editor",
+            "desktop-source-context-with-terminal-drawer",
             "desktop-preview-browser",
             "desktop-command-bar-with-preview",
             "desktop-settings-with-preview",
@@ -456,6 +474,7 @@ async function run() {
             "narrow-source-context",
             "narrow-command-bar-with-editor",
             "narrow-settings-with-editor",
+            "narrow-source-context-with-terminal-drawer",
             "narrow-terminal-drawer",
             "narrow-preview-browser",
             "narrow-command-bar-with-preview",

--- a/winsmux-app/scripts/viewport-harness.mjs
+++ b/winsmux-app/scripts/viewport-harness.mjs
@@ -7,6 +7,7 @@ import process from "node:process";
 import { chromium } from "playwright";
 
 const OUTPUT_DIR = path.join(process.cwd(), "output", "playwright", "viewport-harness");
+const HARNESS_QUERY = "?viewport-harness=1";
 
 async function ensureOutputDir() {
   await fs.mkdir(OUTPUT_DIR, { recursive: true });
@@ -153,6 +154,16 @@ async function assertButtonVisible(page, selector) {
   }
 }
 
+async function assertReachableFrame(page, selector) {
+  const locator = page.locator(selector);
+  await locator.scrollIntoViewIfNeeded();
+  await assertHorizontallyVisible(page, selector);
+  const box = await getBox(page, selector);
+  if (box.height < 120) {
+    throw new Error(`${selector} is too small to use`);
+  }
+}
+
 async function waitForHorizontalVisibility(page, selector) {
   await page.waitForFunction((targetSelector) => {
     const target = document.querySelector(targetSelector);
@@ -164,9 +175,23 @@ async function waitForHorizontalVisibility(page, selector) {
   }, selector);
 }
 
+async function registerHarnessPreviewTarget(page, previewUrl) {
+  await page.waitForFunction(() => Boolean(window.__winsmuxViewportHarness));
+  await page.evaluate((url) => {
+    window.__winsmuxViewportHarness?.registerPreviewTarget("viewport-harness", url);
+  }, previewUrl);
+}
+
+async function openHarnessPreviewTarget(page, previewUrl) {
+  await page.waitForFunction(() => Boolean(window.__winsmuxViewportHarness));
+  await page.evaluate((url) => {
+    window.__winsmuxViewportHarness?.openPreviewTarget(url);
+  }, previewUrl);
+}
+
 async function verifyDesktopViewport(page, previewUrl) {
   await page.setViewportSize({ width: 1440, height: 900 });
-  await page.goto(previewUrl, { waitUntil: "networkidle" });
+  await page.goto(`${previewUrl}${HARNESS_QUERY}`, { waitUntil: "networkidle" });
 
   await assertHorizontallyVisible(page, "#left-rail");
   await assertFullyVisible(page, "#conversation-panel");
@@ -176,15 +201,26 @@ async function verifyDesktopViewport(page, previewUrl) {
   await assertNoOverlap(page, "#workspace-header", "#workspace-body");
   await assertNoOverlap(page, "#workspace-body", "#workspace-footer");
 
+  await registerHarnessPreviewTarget(page, `${previewUrl}${HARNESS_QUERY}`);
+  await page.locator("#preview-target-list .context-file-row").first().waitFor({ state: "visible" });
+  await openHarnessPreviewTarget(page, `${previewUrl}${HARNESS_QUERY}`);
+  await page.locator("#browser-reload-btn").waitFor({ state: "visible" });
+  await assertButtonVisible(page, "#browser-back-btn");
+  await assertButtonVisible(page, "#browser-reload-btn");
+  await assertButtonVisible(page, "#browser-open-btn");
+  await assertHorizontallyVisible(page, "#browser-toolbar");
+  await assertFullyVisible(page, "#browser-frame");
+
   await page.click("#toggle-terminal-btn");
   await page.locator("#terminal-drawer").waitFor({ state: "visible" });
   await assertButtonVisible(page, "#add-pane-btn");
   await assertFullyVisible(page, "#terminal-drawer");
+  await assertHorizontallyVisible(page, "#browser-toolbar");
 }
 
 async function verifyNarrowViewport(page, previewUrl) {
   await page.setViewportSize({ width: 393, height: 852 });
-  await page.goto(previewUrl, { waitUntil: "networkidle" });
+  await page.goto(`${previewUrl}${HARNESS_QUERY}`, { waitUntil: "networkidle" });
 
   await assertButtonVisible(page, "#send-btn");
   await assertFullyVisible(page, "#workspace-footer");
@@ -211,6 +247,20 @@ async function verifyNarrowViewport(page, previewUrl) {
   await page.locator("#terminal-drawer").waitFor({ state: "visible" });
   await assertButtonVisible(page, "#add-pane-btn");
   await assertFullyVisible(page, "#terminal-drawer");
+  await page.click("#toggle-terminal-btn");
+  await page.locator("#terminal-drawer").waitFor({ state: "hidden" });
+
+  await registerHarnessPreviewTarget(page, `${previewUrl}${HARNESS_QUERY}`);
+  await page.locator("#preview-target-list .context-file-row").first().waitFor({ state: "visible" });
+  await openHarnessPreviewTarget(page, `${previewUrl}${HARNESS_QUERY}`);
+  await page.locator("#browser-reload-btn").waitFor({ state: "visible" });
+  await assertButtonVisible(page, "#browser-back-btn");
+  await assertButtonVisible(page, "#browser-reload-btn");
+  await assertButtonVisible(page, "#browser-open-btn");
+  await assertHorizontallyVisible(page, "#browser-toolbar");
+  await assertReachableFrame(page, "#browser-frame");
+  await page.locator("#browser-target-list .editor-tab").first().waitFor({ state: "visible" });
+  await assertReachableFrame(page, "#browser-frame");
 }
 
 async function run() {
@@ -238,7 +288,12 @@ async function run() {
           previewUrl,
           checks: [
             "desktop-1440x900",
+            "desktop-preview-browser",
+            "desktop-terminal-drawer",
             "narrow-393x852",
+            "narrow-context-panel",
+            "narrow-terminal-drawer",
+            "narrow-preview-browser",
           ],
         },
         null,

--- a/winsmux-app/scripts/viewport-harness.mjs
+++ b/winsmux-app/scripts/viewport-harness.mjs
@@ -154,6 +154,36 @@ async function assertButtonVisible(page, selector) {
   }
 }
 
+async function assertToolbarActionStates(page) {
+  const summary = page.locator("#browser-toolbar-summary");
+  await summary.waitFor({ state: "visible" });
+
+  await assertButtonVisible(page, "#browser-copy-btn");
+  await page.click("#browser-copy-btn");
+  await page.waitForFunction(() => {
+    const target = document.querySelector("#browser-toolbar-summary");
+    if (!(target instanceof HTMLElement)) {
+      return false;
+    }
+    return target.textContent?.includes("copied") || target.textContent?.includes("copy failed");
+  });
+
+  await assertButtonVisible(page, "#browser-open-btn");
+  const popupPromise = page.context().waitForEvent("page", { timeout: 2_000 }).catch(() => null);
+  await page.click("#browser-open-btn");
+  await page.waitForFunction(() => {
+    const target = document.querySelector("#browser-toolbar-summary");
+    if (!(target instanceof HTMLElement)) {
+      return false;
+    }
+    return target.textContent?.includes("external open") || target.textContent?.includes("external blocked");
+  });
+  const popup = await popupPromise;
+  if (popup) {
+    await popup.close().catch(() => {});
+  }
+}
+
 async function assertReachableFrame(page, selector) {
   const locator = page.locator(selector);
   await locator.scrollIntoViewIfNeeded();
@@ -320,6 +350,7 @@ async function verifyDesktopViewport(page, previewUrl) {
   await assertButtonVisible(page, "#browser-open-btn");
   await assertHorizontallyVisible(page, "#browser-toolbar");
   await assertFullyVisible(page, "#browser-frame");
+  await assertToolbarActionStates(page);
   await assertCommandBarRoundtrip(page, "#browser-toolbar");
   await assertSettingsRoundtrip(page, "#browser-toolbar");
 
@@ -387,6 +418,7 @@ async function verifyNarrowViewport(page, previewUrl) {
   await assertReachableFrame(page, "#browser-frame");
   await page.locator("#browser-target-list .editor-tab").first().waitFor({ state: "visible" });
   await assertReachableFrame(page, "#browser-frame");
+  await assertToolbarActionStates(page);
   await assertCommandBarRoundtrip(page, "#browser-toolbar");
   await assertNarrowSettingsRoundtrip(page, "#browser-toolbar");
   await assertBackToCode(page);
@@ -463,6 +495,7 @@ async function run() {
             "desktop-settings-with-editor",
             "desktop-source-context-with-terminal-drawer",
             "desktop-preview-browser",
+            "desktop-preview-toolbar-actions",
             "desktop-command-bar-with-preview",
             "desktop-settings-with-preview",
             "desktop-preview-back-to-code",
@@ -477,6 +510,7 @@ async function run() {
             "narrow-source-context-with-terminal-drawer",
             "narrow-terminal-drawer",
             "narrow-preview-browser",
+            "narrow-preview-toolbar-actions",
             "narrow-command-bar-with-preview",
             "narrow-settings-with-preview",
             "narrow-preview-back-to-code",

--- a/winsmux-app/scripts/viewport-harness.mjs
+++ b/winsmux-app/scripts/viewport-harness.mjs
@@ -1,0 +1,286 @@
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import fs from "node:fs/promises";
+import net from "node:net";
+import path from "node:path";
+import process from "node:process";
+import { chromium } from "playwright";
+
+const OUTPUT_DIR = path.join(process.cwd(), "output", "playwright", "viewport-harness");
+
+async function ensureOutputDir() {
+  await fs.mkdir(OUTPUT_DIR, { recursive: true });
+}
+
+async function waitForPreviewServer(url, timeoutMs = 30_000) {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    try {
+      const response = await fetch(url);
+      if (response.ok) {
+        return;
+      }
+    } catch {
+      // Ignore connection errors until the timeout expires.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+
+  throw new Error(`Preview server did not start within ${timeoutMs}ms`);
+}
+
+async function getAvailablePort() {
+  return await new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        server.close();
+        reject(new Error("Failed to resolve a preview port"));
+        return;
+      }
+      const { port } = address;
+      server.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve(port);
+      });
+    });
+    server.on("error", reject);
+  });
+}
+
+function startPreviewServer(previewPort) {
+  const child = spawn(
+    process.platform === "win32" ? "cmd.exe" : "npm",
+    process.platform === "win32"
+      ? ["/c", "npm", "run", "preview", "--", "--host", "127.0.0.1", "--port", `${previewPort}`, "--strictPort"]
+      : ["run", "preview", "--", "--host", "127.0.0.1", "--port", `${previewPort}`, "--strictPort"],
+    {
+      cwd: process.cwd(),
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+
+  child.stdout.on("data", (chunk) => {
+    process.stdout.write(chunk);
+  });
+  child.stderr.on("data", (chunk) => {
+    process.stderr.write(chunk);
+  });
+
+  return child;
+}
+
+async function stopPreviewServer(child) {
+  if (child.exitCode !== null || child.killed) {
+    return;
+  }
+
+  if (process.platform === "win32") {
+    const killer = spawn("taskkill", ["/pid", `${child.pid}`, "/t", "/f"], {
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    await once(killer, "exit").catch(() => {});
+    return;
+  }
+
+  child.kill("SIGTERM");
+  await once(child, "exit").catch(() => {});
+}
+
+async function getBox(page, selector) {
+  const locator = page.locator(selector);
+  await locator.waitFor({ state: "visible" });
+  const box = await locator.boundingBox();
+  if (!box) {
+    throw new Error(`${selector} does not have a visible bounding box`);
+  }
+  return box;
+}
+
+function boxesOverlap(a, b) {
+  return !(
+    a.x + a.width <= b.x ||
+    b.x + b.width <= a.x ||
+    a.y + a.height <= b.y ||
+    b.y + b.height <= a.y
+  );
+}
+
+async function assertFullyVisible(page, selector) {
+  const box = await getBox(page, selector);
+  const viewport = page.viewportSize();
+  if (!viewport) {
+    throw new Error("Viewport size is unavailable");
+  }
+  if (
+    box.x < 0 ||
+    box.y < 0 ||
+    box.x + box.width > viewport.width ||
+    box.y + box.height > viewport.height
+  ) {
+    throw new Error(`${selector} is clipped by the viewport`);
+  }
+}
+
+async function assertHorizontallyVisible(page, selector) {
+  const box = await getBox(page, selector);
+  const viewport = page.viewportSize();
+  if (!viewport) {
+    throw new Error("Viewport size is unavailable");
+  }
+  if (box.x < 0 || box.x + box.width > viewport.width) {
+    throw new Error(`${selector} is clipped horizontally`);
+  }
+}
+
+async function assertNoOverlap(page, firstSelector, secondSelector) {
+  const first = await getBox(page, firstSelector);
+  const second = await getBox(page, secondSelector);
+  if (boxesOverlap(first, second)) {
+    throw new Error(`${firstSelector} overlaps ${secondSelector}`);
+  }
+}
+
+async function assertButtonVisible(page, selector) {
+  await assertFullyVisible(page, selector);
+  const disabled = await page.locator(selector).isDisabled();
+  if (disabled) {
+    throw new Error(`${selector} is disabled`);
+  }
+}
+
+async function waitForHorizontalVisibility(page, selector) {
+  await page.waitForFunction((targetSelector) => {
+    const target = document.querySelector(targetSelector);
+    if (!(target instanceof HTMLElement)) {
+      return false;
+    }
+    const rect = target.getBoundingClientRect();
+    return rect.x >= 0 && rect.right <= window.innerWidth;
+  }, selector);
+}
+
+async function verifyDesktopViewport(page, previewUrl) {
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await page.goto(previewUrl, { waitUntil: "networkidle" });
+
+  await assertHorizontallyVisible(page, "#left-rail");
+  await assertFullyVisible(page, "#conversation-panel");
+  await assertHorizontallyVisible(page, "#context-panel");
+  await assertButtonVisible(page, "#send-btn");
+  await assertFullyVisible(page, "#workspace-footer");
+  await assertNoOverlap(page, "#workspace-header", "#workspace-body");
+  await assertNoOverlap(page, "#workspace-body", "#workspace-footer");
+
+  await page.click("#toggle-terminal-btn");
+  await page.locator("#terminal-drawer").waitFor({ state: "visible" });
+  await assertButtonVisible(page, "#add-pane-btn");
+  await assertFullyVisible(page, "#terminal-drawer");
+}
+
+async function verifyNarrowViewport(page, previewUrl) {
+  await page.setViewportSize({ width: 393, height: 852 });
+  await page.goto(previewUrl, { waitUntil: "networkidle" });
+
+  await assertButtonVisible(page, "#send-btn");
+  await assertFullyVisible(page, "#workspace-footer");
+  await page.locator("#toggle-sidebar-btn[aria-expanded='false']").waitFor();
+
+  await page.click("#toggle-sidebar-btn");
+  await page.locator("#toggle-sidebar-btn[aria-expanded='true']").waitFor();
+  await waitForHorizontalVisibility(page, "#left-rail");
+  await assertHorizontallyVisible(page, "#left-rail");
+  await assertFullyVisible(page, "#sidebar-overlay");
+  const narrowViewport = page.viewportSize();
+  if (!narrowViewport) {
+    throw new Error("Viewport size is unavailable");
+  }
+  await page.mouse.click(narrowViewport.width - 10, 24);
+  await page.locator("#toggle-sidebar-btn[aria-expanded='false']").waitFor();
+
+  await page.click("#toggle-context-btn");
+  await page.locator("#toggle-context-btn[aria-expanded='true']").waitFor();
+  await waitForHorizontalVisibility(page, "#context-panel");
+  await assertHorizontallyVisible(page, "#context-panel");
+
+  await page.click("#toggle-terminal-btn");
+  await page.locator("#terminal-drawer").waitFor({ state: "visible" });
+  await assertButtonVisible(page, "#add-pane-btn");
+  await assertFullyVisible(page, "#terminal-drawer");
+}
+
+async function run() {
+  await ensureOutputDir();
+
+  const previewPort = await getAvailablePort();
+  const previewUrl = `http://127.0.0.1:${previewPort}`;
+  const previewServer = startPreviewServer(previewPort);
+  let browser;
+
+  try {
+    await waitForPreviewServer(previewUrl);
+    browser = await chromium.launch({ headless: true });
+    const page = await browser.newPage();
+
+    await verifyDesktopViewport(page, previewUrl);
+    await verifyNarrowViewport(page, previewUrl);
+
+    await fs.writeFile(
+      path.join(OUTPUT_DIR, "viewport-harness.json"),
+      JSON.stringify(
+        {
+          ok: true,
+          generatedAt: new Date().toISOString(),
+          previewUrl,
+          checks: [
+            "desktop-1440x900",
+            "narrow-393x852",
+          ],
+        },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+  } catch (error) {
+    if (browser) {
+      const page = browser.contexts()[0]?.pages()[0];
+      if (page) {
+        await page.screenshot({
+          path: path.join(OUTPUT_DIR, "viewport-harness-failure.png"),
+          fullPage: true,
+        }).catch(() => {});
+      }
+    }
+
+    await fs.writeFile(
+      path.join(OUTPUT_DIR, "viewport-harness.json"),
+      JSON.stringify(
+        {
+          ok: false,
+          generatedAt: new Date().toISOString(),
+          previewUrl,
+          error: error instanceof Error ? error.message : String(error),
+        },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+    throw error;
+  } finally {
+    if (browser) {
+      await browser.close().catch(() => {});
+    }
+    await stopPreviewServer(previewServer);
+  }
+}
+
+run().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+});

--- a/winsmux-app/scripts/viewport-harness.mjs
+++ b/winsmux-app/scripts/viewport-harness.mjs
@@ -259,6 +259,15 @@ async function assertBackToCode(page) {
   await assertHorizontallyVisible(page, "#editor-code");
 }
 
+async function assertPreviewClosed(page) {
+  await page.click("#browser-back-btn");
+  await page.locator("#browser-surface").waitFor({ state: "hidden" });
+  const editorSurface = page.locator("#editor-surface");
+  if (await editorSurface.isVisible().catch(() => false)) {
+    throw new Error("Editor surface stayed visible after closing the preview");
+  }
+}
+
 async function assertCommandBarRoundtrip(page, returnSelector) {
   await page.click("#open-command-bar-btn");
   await page.locator("#command-bar-shell").waitFor({ state: "visible" });
@@ -460,6 +469,20 @@ async function verifyShortNarrowViewport(page, previewUrl) {
   await assertButtonVisible(page, "#add-pane-btn");
   await assertHorizontallyVisible(page, "#terminal-drawer");
   await assertHorizontallyVisible(page, "#terminal-toolbar");
+  await page.click("#toggle-terminal-btn");
+  await page.locator("#terminal-drawer").waitFor({ state: "hidden" });
+
+  await registerHarnessPreviewTarget(page, `${previewUrl}${HARNESS_QUERY}`);
+  await waitForPreviewTargetEntry(page);
+  await openHarnessPreviewTarget(page, `${previewUrl}${HARNESS_QUERY}`);
+  await page.locator("#browser-reload-btn").waitFor({ state: "visible" });
+  await assertButtonVisible(page, "#browser-back-btn");
+  await assertButtonVisible(page, "#browser-reload-btn");
+  await assertButtonVisible(page, "#browser-open-btn");
+  await assertHorizontallyVisible(page, "#browser-toolbar");
+  await assertReachableFrame(page, "#browser-frame");
+  await assertToolbarActionStates(page);
+  await assertPreviewClosed(page);
 }
 
 async function run() {
@@ -517,6 +540,8 @@ async function run() {
             "short-narrow-command-bar",
             "short-narrow-settings-sheet",
             "short-narrow-terminal-drawer",
+            "short-narrow-preview-browser",
+            "short-narrow-preview-toolbar-actions",
           ],
         },
         null,

--- a/winsmux-app/scripts/viewport-harness.mjs
+++ b/winsmux-app/scripts/viewport-harness.mjs
@@ -220,6 +220,15 @@ async function openFirstSourceContextEntry(page) {
   await assertHorizontallyVisible(page, "#editor-statusbar");
 }
 
+async function assertBackToCode(page) {
+  await page.click("#browser-back-btn");
+  await page.locator("#browser-surface").waitFor({ state: "hidden" });
+  await page.locator("#editor-code").waitFor({ state: "visible" });
+  await page.locator("#editor-tabs .editor-tab").first().waitFor({ state: "visible" });
+  await assertHorizontallyVisible(page, "#editor-surface");
+  await assertHorizontallyVisible(page, "#editor-code");
+}
+
 async function verifyDesktopViewport(page, previewUrl) {
   await page.setViewportSize({ width: 1440, height: 900 });
   await page.goto(`${previewUrl}${HARNESS_QUERY}`, { waitUntil: "networkidle" });
@@ -263,6 +272,8 @@ async function verifyDesktopViewport(page, previewUrl) {
   await assertButtonVisible(page, "#add-pane-btn");
   await assertFullyVisible(page, "#terminal-drawer");
   await assertHorizontallyVisible(page, "#browser-toolbar");
+  await assertBackToCode(page);
+  await assertHorizontallyVisible(page, "#editor-statusbar");
 }
 
 async function verifyNarrowViewport(page, previewUrl) {
@@ -322,6 +333,7 @@ async function verifyNarrowViewport(page, previewUrl) {
   await assertReachableFrame(page, "#browser-frame");
   await page.locator("#browser-target-list .editor-tab").first().waitFor({ state: "visible" });
   await assertReachableFrame(page, "#browser-frame");
+  await assertBackToCode(page);
 }
 
 async function verifyShortNarrowViewport(page, previewUrl) {
@@ -392,6 +404,7 @@ async function run() {
             "desktop-settings-sheet",
             "desktop-source-context",
             "desktop-preview-browser",
+            "desktop-preview-back-to-code",
             "desktop-terminal-drawer",
             "narrow-393x852",
             "narrow-command-bar",
@@ -400,6 +413,7 @@ async function run() {
             "narrow-source-context",
             "narrow-terminal-drawer",
             "narrow-preview-browser",
+            "narrow-preview-back-to-code",
             "short-narrow-command-bar",
             "short-narrow-settings-sheet",
             "short-narrow-terminal-drawer",

--- a/winsmux-app/scripts/viewport-harness.mjs
+++ b/winsmux-app/scripts/viewport-harness.mjs
@@ -329,6 +329,32 @@ async function verifyShortNarrowViewport(page, previewUrl) {
   await page.goto(`${previewUrl}${HARNESS_QUERY}`, { waitUntil: "networkidle" });
 
   await assertButtonVisible(page, "#send-btn");
+  await page.click("#open-command-bar-btn");
+  await page.locator("#command-bar-shell").waitFor({ state: "visible" });
+  await assertFullyVisible(page, "#command-bar");
+  await assertButtonVisible(page, "#command-bar-input");
+  await page.keyboard.press("Escape");
+  await page.locator("#command-bar-shell").waitFor({ state: "hidden" });
+
+  await page.locator("#toggle-sidebar-btn[aria-expanded='false']").waitFor();
+  await page.click("#toggle-sidebar-btn");
+  await page.locator("#toggle-sidebar-btn[aria-expanded='true']").waitFor();
+  await waitForHorizontalVisibility(page, "#left-rail");
+  await assertHorizontallyVisible(page, "#left-rail");
+
+  await page.click("#settings-btn");
+  await page.locator("#settings-sheet").waitFor({ state: "visible" });
+  await assertFullyVisible(page, "#settings-sheet");
+  await assertButtonVisible(page, "#close-settings-btn");
+  await page.click("#close-settings-btn");
+  await page.locator("#settings-sheet").waitFor({ state: "hidden" });
+  const shortNarrowViewport = page.viewportSize();
+  if (!shortNarrowViewport) {
+    throw new Error("Viewport size is unavailable");
+  }
+  await page.mouse.click(shortNarrowViewport.width - 10, 24);
+  await page.locator("#toggle-sidebar-btn[aria-expanded='false']").waitFor();
+
   await page.click("#toggle-terminal-btn");
   await page.locator("#terminal-drawer").waitFor({ state: "visible" });
   await assertButtonVisible(page, "#add-pane-btn");
@@ -374,6 +400,8 @@ async function run() {
             "narrow-source-context",
             "narrow-terminal-drawer",
             "narrow-preview-browser",
+            "short-narrow-command-bar",
+            "short-narrow-settings-sheet",
             "short-narrow-terminal-drawer",
           ],
         },

--- a/winsmux-app/scripts/viewport-harness.mjs
+++ b/winsmux-app/scripts/viewport-harness.mjs
@@ -189,6 +189,37 @@ async function openHarnessPreviewTarget(page, previewUrl) {
   }, previewUrl);
 }
 
+async function waitForPreviewTargetEntry(page) {
+  await page.waitForFunction(() => {
+    return document.querySelectorAll("#preview-target-list .context-file-row").length > 0;
+  });
+}
+
+async function openFirstSourceContextEntry(page) {
+  const firstSourceEntry = page.locator("#context-file-list .context-file-row").first();
+  if (await firstSourceEntry.isVisible().catch(() => false)) {
+    await firstSourceEntry.click();
+  } else {
+    await page.waitForFunction(() => Boolean(window.__winsmuxViewportHarness));
+    await page.evaluate(() => {
+      window.__winsmuxViewportHarness?.openEditorPreview(
+        "winsmux-app/src/main.ts",
+        [
+          "const viewportHarnessPreview = true;",
+          "function sampleViewportState() {",
+          "  return 'context + editor';",
+          "}",
+        ].join("\n"),
+      );
+    });
+  }
+  await page.locator("#editor-surface").waitFor({ state: "visible" });
+  await page.locator("#editor-tabs .editor-tab").first().waitFor({ state: "visible" });
+  await assertHorizontallyVisible(page, "#editor-surface");
+  await assertHorizontallyVisible(page, "#editor-file-path");
+  await assertHorizontallyVisible(page, "#editor-statusbar");
+}
+
 async function verifyDesktopViewport(page, previewUrl) {
   await page.setViewportSize({ width: 1440, height: 900 });
   await page.goto(`${previewUrl}${HARNESS_QUERY}`, { waitUntil: "networkidle" });
@@ -201,8 +232,24 @@ async function verifyDesktopViewport(page, previewUrl) {
   await assertNoOverlap(page, "#workspace-header", "#workspace-body");
   await assertNoOverlap(page, "#workspace-body", "#workspace-footer");
 
+  await page.click("#open-command-bar-btn");
+  await page.locator("#command-bar-shell").waitFor({ state: "visible" });
+  await assertFullyVisible(page, "#command-bar");
+  await assertButtonVisible(page, "#command-bar-input");
+  await page.keyboard.press("Escape");
+  await page.locator("#command-bar-shell").waitFor({ state: "hidden" });
+
+  await page.click("#settings-btn");
+  await page.locator("#settings-sheet").waitFor({ state: "visible" });
+  await assertFullyVisible(page, "#settings-sheet");
+  await assertButtonVisible(page, "#close-settings-btn");
+  await page.click("#close-settings-btn");
+  await page.locator("#settings-sheet").waitFor({ state: "hidden" });
+
+  await openFirstSourceContextEntry(page);
+
   await registerHarnessPreviewTarget(page, `${previewUrl}${HARNESS_QUERY}`);
-  await page.locator("#preview-target-list .context-file-row").first().waitFor({ state: "visible" });
+  await waitForPreviewTargetEntry(page);
   await openHarnessPreviewTarget(page, `${previewUrl}${HARNESS_QUERY}`);
   await page.locator("#browser-reload-btn").waitFor({ state: "visible" });
   await assertButtonVisible(page, "#browser-back-btn");
@@ -226,11 +273,24 @@ async function verifyNarrowViewport(page, previewUrl) {
   await assertFullyVisible(page, "#workspace-footer");
   await page.locator("#toggle-sidebar-btn[aria-expanded='false']").waitFor();
 
+  await page.click("#open-command-bar-btn");
+  await page.locator("#command-bar-shell").waitFor({ state: "visible" });
+  await assertFullyVisible(page, "#command-bar");
+  await assertButtonVisible(page, "#command-bar-input");
+  await page.keyboard.press("Escape");
+  await page.locator("#command-bar-shell").waitFor({ state: "hidden" });
+
   await page.click("#toggle-sidebar-btn");
   await page.locator("#toggle-sidebar-btn[aria-expanded='true']").waitFor();
   await waitForHorizontalVisibility(page, "#left-rail");
   await assertHorizontallyVisible(page, "#left-rail");
   await assertFullyVisible(page, "#sidebar-overlay");
+  await page.click("#settings-btn");
+  await page.locator("#settings-sheet").waitFor({ state: "visible" });
+  await assertFullyVisible(page, "#settings-sheet");
+  await assertButtonVisible(page, "#close-settings-btn");
+  await page.click("#close-settings-btn");
+  await page.locator("#settings-sheet").waitFor({ state: "hidden" });
   const narrowViewport = page.viewportSize();
   if (!narrowViewport) {
     throw new Error("Viewport size is unavailable");
@@ -242,6 +302,7 @@ async function verifyNarrowViewport(page, previewUrl) {
   await page.locator("#toggle-context-btn[aria-expanded='true']").waitFor();
   await waitForHorizontalVisibility(page, "#context-panel");
   await assertHorizontallyVisible(page, "#context-panel");
+  await openFirstSourceContextEntry(page);
 
   await page.click("#toggle-terminal-btn");
   await page.locator("#terminal-drawer").waitFor({ state: "visible" });
@@ -251,7 +312,7 @@ async function verifyNarrowViewport(page, previewUrl) {
   await page.locator("#terminal-drawer").waitFor({ state: "hidden" });
 
   await registerHarnessPreviewTarget(page, `${previewUrl}${HARNESS_QUERY}`);
-  await page.locator("#preview-target-list .context-file-row").first().waitFor({ state: "visible" });
+  await waitForPreviewTargetEntry(page);
   await openHarnessPreviewTarget(page, `${previewUrl}${HARNESS_QUERY}`);
   await page.locator("#browser-reload-btn").waitFor({ state: "visible" });
   await assertButtonVisible(page, "#browser-back-btn");
@@ -261,6 +322,18 @@ async function verifyNarrowViewport(page, previewUrl) {
   await assertReachableFrame(page, "#browser-frame");
   await page.locator("#browser-target-list .editor-tab").first().waitFor({ state: "visible" });
   await assertReachableFrame(page, "#browser-frame");
+}
+
+async function verifyShortNarrowViewport(page, previewUrl) {
+  await page.setViewportSize({ width: 393, height: 720 });
+  await page.goto(`${previewUrl}${HARNESS_QUERY}`, { waitUntil: "networkidle" });
+
+  await assertButtonVisible(page, "#send-btn");
+  await page.click("#toggle-terminal-btn");
+  await page.locator("#terminal-drawer").waitFor({ state: "visible" });
+  await assertButtonVisible(page, "#add-pane-btn");
+  await assertHorizontallyVisible(page, "#terminal-drawer");
+  await assertHorizontallyVisible(page, "#terminal-toolbar");
 }
 
 async function run() {
@@ -278,6 +351,7 @@ async function run() {
 
     await verifyDesktopViewport(page, previewUrl);
     await verifyNarrowViewport(page, previewUrl);
+    await verifyShortNarrowViewport(page, previewUrl);
 
     await fs.writeFile(
       path.join(OUTPUT_DIR, "viewport-harness.json"),
@@ -288,12 +362,19 @@ async function run() {
           previewUrl,
           checks: [
             "desktop-1440x900",
+            "desktop-command-bar",
+            "desktop-settings-sheet",
+            "desktop-source-context",
             "desktop-preview-browser",
             "desktop-terminal-drawer",
             "narrow-393x852",
+            "narrow-command-bar",
+            "narrow-settings-sheet",
             "narrow-context-panel",
+            "narrow-source-context",
             "narrow-terminal-drawer",
             "narrow-preview-browser",
+            "short-narrow-terminal-drawer",
           ],
         },
         null,

--- a/winsmux-app/scripts/viewport-harness.mjs
+++ b/winsmux-app/scripts/viewport-harness.mjs
@@ -229,6 +229,16 @@ async function assertBackToCode(page) {
   await assertHorizontallyVisible(page, "#editor-code");
 }
 
+async function assertCommandBarRoundtrip(page, returnSelector) {
+  await page.click("#open-command-bar-btn");
+  await page.locator("#command-bar-shell").waitFor({ state: "visible" });
+  await assertFullyVisible(page, "#command-bar");
+  await assertButtonVisible(page, "#command-bar-input");
+  await page.keyboard.press("Escape");
+  await page.locator("#command-bar-shell").waitFor({ state: "hidden" });
+  await page.locator(returnSelector).waitFor({ state: "visible" });
+}
+
 async function verifyDesktopViewport(page, previewUrl) {
   await page.setViewportSize({ width: 1440, height: 900 });
   await page.goto(`${previewUrl}${HARNESS_QUERY}`, { waitUntil: "networkidle" });
@@ -256,6 +266,7 @@ async function verifyDesktopViewport(page, previewUrl) {
   await page.locator("#settings-sheet").waitFor({ state: "hidden" });
 
   await openFirstSourceContextEntry(page);
+  await assertCommandBarRoundtrip(page, "#editor-surface");
 
   await registerHarnessPreviewTarget(page, `${previewUrl}${HARNESS_QUERY}`);
   await waitForPreviewTargetEntry(page);
@@ -266,6 +277,7 @@ async function verifyDesktopViewport(page, previewUrl) {
   await assertButtonVisible(page, "#browser-open-btn");
   await assertHorizontallyVisible(page, "#browser-toolbar");
   await assertFullyVisible(page, "#browser-frame");
+  await assertCommandBarRoundtrip(page, "#browser-toolbar");
 
   await page.click("#toggle-terminal-btn");
   await page.locator("#terminal-drawer").waitFor({ state: "visible" });
@@ -314,6 +326,7 @@ async function verifyNarrowViewport(page, previewUrl) {
   await waitForHorizontalVisibility(page, "#context-panel");
   await assertHorizontallyVisible(page, "#context-panel");
   await openFirstSourceContextEntry(page);
+  await assertCommandBarRoundtrip(page, "#editor-surface");
 
   await page.click("#toggle-terminal-btn");
   await page.locator("#terminal-drawer").waitFor({ state: "visible" });
@@ -333,6 +346,7 @@ async function verifyNarrowViewport(page, previewUrl) {
   await assertReachableFrame(page, "#browser-frame");
   await page.locator("#browser-target-list .editor-tab").first().waitFor({ state: "visible" });
   await assertReachableFrame(page, "#browser-frame");
+  await assertCommandBarRoundtrip(page, "#browser-toolbar");
   await assertBackToCode(page);
 }
 
@@ -403,7 +417,9 @@ async function run() {
             "desktop-command-bar",
             "desktop-settings-sheet",
             "desktop-source-context",
+            "desktop-command-bar-with-editor",
             "desktop-preview-browser",
+            "desktop-command-bar-with-preview",
             "desktop-preview-back-to-code",
             "desktop-terminal-drawer",
             "narrow-393x852",
@@ -411,8 +427,10 @@ async function run() {
             "narrow-settings-sheet",
             "narrow-context-panel",
             "narrow-source-context",
+            "narrow-command-bar-with-editor",
             "narrow-terminal-drawer",
             "narrow-preview-browser",
+            "narrow-command-bar-with-preview",
             "narrow-preview-back-to-code",
             "short-narrow-command-bar",
             "short-narrow-settings-sheet",

--- a/winsmux-app/scripts/viewport-harness.mjs
+++ b/winsmux-app/scripts/viewport-harness.mjs
@@ -239,6 +239,32 @@ async function assertCommandBarRoundtrip(page, returnSelector) {
   await page.locator(returnSelector).waitFor({ state: "visible" });
 }
 
+async function assertSettingsRoundtrip(page, returnSelector) {
+  await page.click("#settings-btn");
+  await page.locator("#settings-sheet").waitFor({ state: "visible" });
+  await assertFullyVisible(page, "#settings-sheet");
+  await assertButtonVisible(page, "#close-settings-btn");
+  await page.click("#close-settings-btn");
+  await page.locator("#settings-sheet").waitFor({ state: "hidden" });
+  await page.locator(returnSelector).waitFor({ state: "visible" });
+}
+
+async function assertNarrowSettingsRoundtrip(page, returnSelector) {
+  await page.locator("#toggle-sidebar-btn[aria-expanded='false']").waitFor();
+  await page.click("#toggle-sidebar-btn");
+  await page.locator("#toggle-sidebar-btn[aria-expanded='true']").waitFor();
+  await waitForHorizontalVisibility(page, "#left-rail");
+  await assertHorizontallyVisible(page, "#left-rail");
+  await assertFullyVisible(page, "#sidebar-overlay");
+  await assertSettingsRoundtrip(page, returnSelector);
+  const viewport = page.viewportSize();
+  if (!viewport) {
+    throw new Error("Viewport size is unavailable");
+  }
+  await page.mouse.click(viewport.width - 10, 24);
+  await page.locator("#toggle-sidebar-btn[aria-expanded='false']").waitFor();
+}
+
 async function verifyDesktopViewport(page, previewUrl) {
   await page.setViewportSize({ width: 1440, height: 900 });
   await page.goto(`${previewUrl}${HARNESS_QUERY}`, { waitUntil: "networkidle" });
@@ -267,6 +293,7 @@ async function verifyDesktopViewport(page, previewUrl) {
 
   await openFirstSourceContextEntry(page);
   await assertCommandBarRoundtrip(page, "#editor-surface");
+  await assertSettingsRoundtrip(page, "#editor-surface");
 
   await registerHarnessPreviewTarget(page, `${previewUrl}${HARNESS_QUERY}`);
   await waitForPreviewTargetEntry(page);
@@ -278,6 +305,7 @@ async function verifyDesktopViewport(page, previewUrl) {
   await assertHorizontallyVisible(page, "#browser-toolbar");
   await assertFullyVisible(page, "#browser-frame");
   await assertCommandBarRoundtrip(page, "#browser-toolbar");
+  await assertSettingsRoundtrip(page, "#browser-toolbar");
 
   await page.click("#toggle-terminal-btn");
   await page.locator("#terminal-drawer").waitFor({ state: "visible" });
@@ -308,12 +336,7 @@ async function verifyNarrowViewport(page, previewUrl) {
   await waitForHorizontalVisibility(page, "#left-rail");
   await assertHorizontallyVisible(page, "#left-rail");
   await assertFullyVisible(page, "#sidebar-overlay");
-  await page.click("#settings-btn");
-  await page.locator("#settings-sheet").waitFor({ state: "visible" });
-  await assertFullyVisible(page, "#settings-sheet");
-  await assertButtonVisible(page, "#close-settings-btn");
-  await page.click("#close-settings-btn");
-  await page.locator("#settings-sheet").waitFor({ state: "hidden" });
+  await assertSettingsRoundtrip(page, "#left-rail");
   const narrowViewport = page.viewportSize();
   if (!narrowViewport) {
     throw new Error("Viewport size is unavailable");
@@ -327,6 +350,7 @@ async function verifyNarrowViewport(page, previewUrl) {
   await assertHorizontallyVisible(page, "#context-panel");
   await openFirstSourceContextEntry(page);
   await assertCommandBarRoundtrip(page, "#editor-surface");
+  await assertNarrowSettingsRoundtrip(page, "#editor-surface");
 
   await page.click("#toggle-terminal-btn");
   await page.locator("#terminal-drawer").waitFor({ state: "visible" });
@@ -347,6 +371,7 @@ async function verifyNarrowViewport(page, previewUrl) {
   await page.locator("#browser-target-list .editor-tab").first().waitFor({ state: "visible" });
   await assertReachableFrame(page, "#browser-frame");
   await assertCommandBarRoundtrip(page, "#browser-toolbar");
+  await assertNarrowSettingsRoundtrip(page, "#browser-toolbar");
   await assertBackToCode(page);
 }
 
@@ -418,8 +443,10 @@ async function run() {
             "desktop-settings-sheet",
             "desktop-source-context",
             "desktop-command-bar-with-editor",
+            "desktop-settings-with-editor",
             "desktop-preview-browser",
             "desktop-command-bar-with-preview",
+            "desktop-settings-with-preview",
             "desktop-preview-back-to-code",
             "desktop-terminal-drawer",
             "narrow-393x852",
@@ -428,9 +455,11 @@ async function run() {
             "narrow-context-panel",
             "narrow-source-context",
             "narrow-command-bar-with-editor",
+            "narrow-settings-with-editor",
             "narrow-terminal-drawer",
             "narrow-preview-browser",
             "narrow-command-bar-with-preview",
+            "narrow-settings-with-preview",
             "narrow-preview-back-to-code",
             "short-narrow-command-bar",
             "short-narrow-settings-sheet",

--- a/winsmux-app/src/desktopClient.ts
+++ b/winsmux-app/src/desktopClient.ts
@@ -1,4 +1,4 @@
-import { invoke } from "@tauri-apps/api/core";
+import { invoke, isTauri } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 
 type DesktopCommandName =
@@ -480,6 +480,9 @@ export function createJsonRpcDesktopCommandTransport(
       command: DesktopCommandName,
       payload?: Record<string, unknown>,
     ) {
+      if (!isTauri()) {
+        throw new Error(`desktop command transport is unavailable outside the Tauri runtime (${command})`);
+      }
       const method = getDesktopJsonRpcMethod(command);
       const request: DesktopJsonRpcRequest = {
         jsonrpc: "2.0",
@@ -604,6 +607,10 @@ export async function getDesktopEditorFile(path: string, worktree?: string) {
 export async function subscribeToDesktopSummaryRefresh(
   onRefresh: (event: DesktopSummaryRefreshEvent) => void,
 ): Promise<UnlistenFn> {
+  if (!isTauri()) {
+    return async () => {};
+  }
+
   return listen<DesktopSummaryRefreshEvent | string>(
     "desktop-summary-refresh",
     (event) => {

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -111,6 +111,17 @@ interface PreviewTarget {
   lastSeenAt: number;
 }
 
+declare global {
+  interface Window {
+    __winsmuxViewportHarness?: {
+      registerPreviewTarget: (sourceLabel: string, url: string) => void;
+      openPreviewTarget: (url: string) => void;
+      setContextPanel: (open: boolean) => void;
+      setTerminalDrawer: (open: boolean) => void;
+    };
+  }
+}
+
 type SourceFilter = "all" | "candidates" | "attention" | `pane:${string}`;
 
 type ChangeStatus = "modified" | "added" | "deleted" | "renamed";
@@ -970,6 +981,17 @@ function registerPreviewTargets(paneId: string, data: string) {
     renderContextPanel();
     renderEditorSurface();
   }
+}
+
+function registerPreviewTargetForHarness(sourceLabel: string, url: string) {
+  detectedPreviewTargets.set(url, {
+    url,
+    portLabel: getPreviewPortLabel(url),
+    sourceLabel: sourceLabel || "viewport-harness",
+    lastSeenAt: Date.now(),
+  });
+  renderContextPanel();
+  renderEditorSurface();
 }
 
 function getPreviewTargets(activeUrl = selectedPreviewUrl) {
@@ -3776,6 +3798,28 @@ function syncResponsiveShell() {
   }
 }
 
+function installViewportHarnessHooks() {
+  const searchParams = new URLSearchParams(window.location.search);
+  if (searchParams.get("viewport-harness") !== "1") {
+    return;
+  }
+
+  window.__winsmuxViewportHarness = {
+    registerPreviewTarget: (sourceLabel: string, url: string) => {
+      registerPreviewTargetForHarness(sourceLabel, url);
+    },
+    openPreviewTarget: (url: string) => {
+      openPreviewTarget(url);
+    },
+    setContextPanel: (open: boolean) => {
+      setContextPanel(open);
+    },
+    setTerminalDrawer: (open: boolean) => {
+      setTerminalDrawer(open);
+    },
+  };
+}
+
 function appendUserMessage(message: string, attachments: ComposerAttachment[]) {
   const now = new Date();
   const timestamp = `${`${now.getHours()}`.padStart(2, "0")}:${`${now.getMinutes()}`.padStart(2, "0")}`;
@@ -4301,6 +4345,8 @@ function initializeSidebarResize() {
 }
 
 window.addEventListener("DOMContentLoaded", async () => {
+  installViewportHarnessHooks();
+
   await subscribeToPtyOutput((payload) => {
     registerPreviewTargets(payload.pane_id, payload.data);
     const entry = payload.pane_id ? panes.get(payload.pane_id) : undefined;

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -116,6 +116,7 @@ declare global {
     __winsmuxViewportHarness?: {
       registerPreviewTarget: (sourceLabel: string, url: string) => void;
       openPreviewTarget: (url: string) => void;
+      openEditorPreview: (path: string, content: string, worktree?: string) => void;
       setContextPanel: (open: boolean) => void;
       setTerminalDrawer: (open: boolean) => void;
     };
@@ -992,6 +993,32 @@ function registerPreviewTargetForHarness(sourceLabel: string, url: string) {
   });
   renderContextPanel();
   renderEditorSurface();
+}
+
+function openEditorPreviewForHarness(path: string, content: string, worktree = "") {
+  const target = createStandaloneEditorTarget(path, worktree);
+  desktopStandaloneEditorTargets.set(target.key, target);
+  desktopEditorFileCache.set(target.key, {
+    key: target.key,
+    path,
+    summary: target.summary,
+    content,
+    language: inferLanguageFromPath(path),
+    lineCount: countEditorLines(content),
+    modified: false,
+    origin: "explorer",
+  });
+  desktopEditorLoadErrors.delete(target.key);
+  desktopEditorLoadingPaths.delete(target.key);
+  editorSurfaceMode = "code";
+  selectedPreviewUrl = "";
+  lastPreviewExternalState = null;
+  lastPreviewClipboardState = null;
+  selectedEditorKey = target.key;
+  setEditorSurface(true);
+  renderOpenEditors();
+  renderSourceSummary();
+  renderRunSummary();
 }
 
 function getPreviewTargets(activeUrl = selectedPreviewUrl) {
@@ -3810,6 +3837,9 @@ function installViewportHarnessHooks() {
     },
     openPreviewTarget: (url: string) => {
       openPreviewTarget(url);
+    },
+    openEditorPreview: (path: string, content: string, worktree?: string) => {
+      openEditorPreviewForHarness(path, content, worktree);
     },
     setContextPanel: (open: boolean) => {
       setContextPanel(open);

--- a/winsmux-app/src/ptyClient.ts
+++ b/winsmux-app/src/ptyClient.ts
@@ -1,4 +1,4 @@
-import { invoke } from "@tauri-apps/api/core";
+import { invoke, isTauri } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 
 const PTY_JSON_RPC_VERSION = "2.0";
@@ -52,6 +52,10 @@ export function createTauriPtyCommandTransport(
 ): PtyCommandTransport {
   return {
     async request(command: PtyCommandName, payload: Record<string, unknown>) {
+      if (!isTauri()) {
+        return;
+      }
+
       const request: PtyJsonRpcRequest = {
         jsonrpc: PTY_JSON_RPC_VERSION,
         id: `pty-${++ptyRequestSequence}`,
@@ -118,6 +122,10 @@ export async function closePtyPane(paneId: string) {
 export async function subscribeToPtyOutput(
   onOutput: (event: PtyOutputEvent) => void,
 ): Promise<UnlistenFn> {
+  if (!isTauri()) {
+    return async () => {};
+  }
+
   return listen<string>("pty-output", (event) => {
     try {
       onOutput(JSON.parse(event.payload) as PtyOutputEvent);

--- a/winsmux-app/src/styles.css
+++ b/winsmux-app/src/styles.css
@@ -986,18 +986,20 @@ textarea {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
-  align-items: center;
+  align-items: flex-start;
 }
 
 #browser-toolbar-summary {
-  margin-right: auto;
+  flex: 1 1 220px;
+  min-width: 0;
   font-size: var(--text-2xs);
   color: var(--text-muted);
+  overflow-wrap: anywhere;
 }
 
 #browser-frame {
   flex: 1;
-  min-height: 360px;
+  min-height: clamp(200px, 28vh, 360px);
   width: 100%;
   border: 1px solid var(--border-muted);
   border-radius: 16px;

--- a/winsmux-app/src/styles.css
+++ b/winsmux-app/src/styles.css
@@ -92,7 +92,7 @@ textarea {
   --composer-padding: 18px;
   --composer-min-height: 72px;
   --timeline-max-width: min(78ch, 82%);
-  --body-wrap: anywhere;
+  --body-wrap: break-word;
   --editor-white-space: pre-wrap;
   --panel-radius: 20px;
   display: grid;
@@ -994,7 +994,7 @@ textarea {
   min-width: 0;
   font-size: var(--text-2xs);
   color: var(--text-muted);
-  overflow-wrap: anywhere;
+  overflow-wrap: break-word;
 }
 
 #browser-frame {
@@ -1304,10 +1304,12 @@ textarea {
   top: 76px;
   right: 24px;
   width: min(360px, calc(100vw - 48px));
+  max-height: calc(100vh - 100px);
   padding: var(--panel-padding);
   display: flex;
   flex-direction: column;
   gap: 14px;
+  overflow: auto;
   border: 1px solid var(--border-muted);
   border-radius: var(--panel-radius);
   background: rgba(18, 21, 33, 0.98);
@@ -1331,11 +1333,13 @@ textarea {
 #command-bar {
   position: relative;
   width: min(760px, calc(100vw - 40px));
+  max-height: calc(100vh - 96px);
   margin: 72px auto 0;
   padding: 18px;
   display: flex;
   flex-direction: column;
   gap: 12px;
+  overflow: auto;
   border: 1px solid var(--border-strong);
   border-radius: calc(var(--panel-radius) + 2px);
   background: rgba(18, 21, 33, 0.98);
@@ -1732,8 +1736,47 @@ textarea {
 }
 
 @media (max-height: 760px) {
+  #app-shell {
+    --shell-padding: 16px;
+    --shell-gap: 12px;
+    --composer-padding: 12px;
+    --composer-min-height: 52px;
+  }
+
   #workspace {
     grid-template-rows: auto minmax(0, 1fr);
+  }
+
+  #workspace-subtitle {
+    display: none;
+  }
+
+  #thread-meta {
+    padding: 12px 16px 6px;
+  }
+
+  #timeline-toolbar,
+  #selected-run-summary {
+    padding: 0 16px 8px;
+  }
+
+  #conversation-timeline {
+    padding: 4px 16px 12px;
+    gap: 10px;
+  }
+
+  .run-summary-card {
+    padding: 12px 14px;
+    gap: 8px;
+  }
+
+  #composer-mode-row,
+  #composer-footer {
+    margin-top: 8px;
+  }
+
+  #attachment-tray {
+    min-height: 0;
   }
 
   #terminal-drawer {
@@ -1754,5 +1797,13 @@ textarea {
   #command-bar {
     margin-top: 24px;
     max-height: calc(100vh - 48px);
+  }
+}
+
+@media (max-width: 1180px) and (max-height: 760px) {
+  #terminal-drawer {
+    left: 20px;
+    right: 20px;
+    max-height: 46vh;
   }
 }

--- a/winsmux-app/src/styles.css
+++ b/winsmux-app/src/styles.css
@@ -1806,4 +1806,22 @@ textarea {
     right: 20px;
     max-height: 46vh;
   }
+
+  #workspace-footer {
+    gap: 8px;
+  }
+
+  #footer-left,
+  #footer-right {
+    gap: 6px;
+  }
+
+  .footer-pill {
+    gap: 6px;
+    padding: 6px 10px;
+  }
+
+  .footer-pill-label {
+    display: none;
+  }
 }

--- a/winsmux-app/src/styles.css
+++ b/winsmux-app/src/styles.css
@@ -61,6 +61,10 @@ body {
   box-sizing: border-box;
 }
 
+[hidden] {
+  display: none !important;
+}
+
 button,
 textarea {
   font: inherit;
@@ -148,6 +152,8 @@ textarea {
   flex-direction: column;
   gap: 14px;
   min-width: 240px;
+  min-height: 0;
+  overflow: auto;
 }
 
 .brand-block {
@@ -272,10 +278,13 @@ textarea {
 
 #workspace {
   min-width: 0;
+  min-height: 0;
+  height: 100%;
   display: grid;
   grid-template-rows: auto minmax(0, 1fr) auto auto;
   padding: var(--shell-padding);
   gap: var(--shell-gap);
+  overflow: hidden;
 }
 
 #workspace-header {
@@ -1609,6 +1618,15 @@ textarea {
 @media (max-width: 1180px) {
   #app-shell {
     grid-template-columns: minmax(0, 1fr);
+  }
+
+  #workspace-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  #header-actions {
+    flex-wrap: wrap;
   }
 
   #sidebar-overlay {


### PR DESCRIPTION
## Summary
- add a Playwright-based viewport verification harness for the desktop shell
- harden browser-preview startup so the shell can boot outside the Tauri runtime
- fix shell layout regressions the harness found in desktop and narrow widths

## Validation
- cmd /c npm run test:viewport-harness
- pwsh -NoProfile -File .\scripts\git-guard.ps1 -Mode full
- pwsh -NoProfile -File .\scripts\audit-public-surface.ps1