### PR TITLE
TASK-369 Composer slash command baseline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -356,19 +356,24 @@ Repeated `no result yet` responses are treated as a latency problem first, not a
 Codex must follow these rules when review or audit agents are slow:
 
 1. For Rust/Tauri slices, or any review touching more than 2 files, wait at least 60 seconds before the first timeout decision.
-2. For small TypeScript / docs-only slices, 30 seconds remains the default first wait.
+2. For small TypeScript / docs-only slices, wait at least 60 seconds before the first timeout decision.
+   - Desktop UI, composer, CSS, viewport harness, and other interaction slices are included in this bucket.
 3. Keep review concurrency to 1 agent at a time for Rust/Tauri work. If a separate explorer is needed, do not run more than 2 total subagents on the same slice.
 4. Prefer narrow prompts and explicit file paths over `fork_context=true` for routine reviews. Only fork full context when the review truly depends on prior thread state.
 5. If two consecutive review agents on the same slice return `no result yet`, stop spawning more review agents for that slice until either:
    - the diff is reduced,
    - the wait time is increased,
    - or the blocker is documented and manual diff fallback is used.
-6. When a delayed review result arrives after a timeout, record the latency pattern in `.claude/local/operator-handoff.md` and use that result in the final decision.
-7. If the same PR accumulates multiple tiny desktop UI slices and `no result yet` repeats across those slices, stop per-slice review for that PR.
+6. If the same review agent returns `no result yet` twice, keep that agent alive in the background.
+   - Do not report review as complete.
+   - Do not merge before the delayed result is incorporated.
+   - Continue only with non-overlapping local work, local validation, and manual diff review while waiting.
+7. When a delayed review result arrives after a timeout, record the latency pattern in `.claude/local/operator-handoff.md` and use that result in the final decision.
+8. If the same PR accumulates multiple tiny desktop UI slices and `no result yet` repeats across those slices, stop per-slice review for that PR.
    - Switch to milestone-based review instead.
    - A milestone is a semantically meaningful bundle such as:
      - one new surface,
      - one completed interaction flow,
      - or a ready-for-review PR state.
-8. While milestone-based review is active, every interim slice must still pass local validation and manual diff review before commit/push.
-9. Record the switch to milestone-based review in `.claude/local/operator-handoff.md` and link the tracking issue when one exists.
+9. While milestone-based review is active, every interim slice must still pass local validation and manual diff review before commit/push.
+10. Record the switch to milestone-based review in `.claude/local/operator-handoff.md` and link the tracking issue when one exists.

--- a/winsmux-app/index.html
+++ b/winsmux-app/index.html
@@ -100,6 +100,7 @@
               <textarea id="composer-input" rows="2" placeholder="Message the Operator... Dispatch, ask, review, or explain"></textarea>
               <input id="composer-file-input" type="file" hidden multiple />
               <div id="composer-mode-row" aria-label="Composer modes"></div>
+              <div id="composer-slash-row" aria-label="Composer slash commands" hidden></div>
               <div id="composer-footer">
                 <div id="attachment-tray" aria-live="polite"></div>
                 <div id="composer-actions">

--- a/winsmux-app/index.html
+++ b/winsmux-app/index.html
@@ -101,6 +101,7 @@
               <input id="composer-file-input" type="file" hidden multiple />
               <div id="composer-mode-row" aria-label="Composer modes"></div>
               <div id="composer-slash-row" aria-label="Composer slash commands" hidden></div>
+              <div id="composer-remote-row" aria-label="Composer remote attachments" hidden></div>
               <div id="composer-footer">
                 <div id="attachment-tray" aria-live="polite"></div>
                 <div id="composer-actions">

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -205,6 +205,7 @@ let lastPreviewExternalState: { url: string; at: number; ok: boolean } | null = 
 let lastPreviewClipboardState: { url: string; at: number; ok: boolean } | null = null;
 let selectedRunId: string | null = null;
 let activeComposerMode: ComposerMode = "dispatch";
+let composerSlashOpen = false;
 let composerSlashQuery = "";
 let selectedComposerSlashIndex = 0;
 let activeSourceFilter: SourceFilter = "all";
@@ -1944,8 +1945,12 @@ function getComposerSlashMatch(value: string) {
 }
 
 function getFilteredComposerSlashCommands() {
-  if (!composerSlashQuery) {
+  if (!composerSlashOpen) {
     return [];
+  }
+
+  if (!composerSlashQuery) {
+    return composerSlashCommands;
   }
 
   return composerSlashCommands.filter((item) => item.command.startsWith(composerSlashQuery));
@@ -1978,6 +1983,7 @@ function renderComposerSlashCommands() {
 
 function syncComposerSlashState(value: string) {
   const match = value.match(/^\/([a-z-]*)$/i);
+  composerSlashOpen = Boolean(match);
   composerSlashQuery = match ? match[1].toLowerCase() : "";
   const commands = getFilteredComposerSlashCommands();
   if (commands.length === 0) {

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -205,6 +205,8 @@ let lastPreviewExternalState: { url: string; at: number; ok: boolean } | null = 
 let lastPreviewClipboardState: { url: string; at: number; ok: boolean } | null = null;
 let selectedRunId: string | null = null;
 let activeComposerMode: ComposerMode = "dispatch";
+let composerSlashQuery = "";
+let selectedComposerSlashIndex = 0;
 let activeSourceFilter: SourceFilter = "all";
 let activeTimelineFilter: TimelineFilter = "all";
 let commandBarOpen = false;
@@ -258,6 +260,18 @@ const composerModes: Array<{ mode: ComposerMode; label: string; placeholder: str
   { mode: "review", label: "Review", placeholder: "Request review, approval, or audit from the Operator" },
   { mode: "explain", label: "Explain", placeholder: "Ask the Operator to explain the current run state" },
 ];
+
+const composerSlashCommands: Array<{
+  command: string;
+  label: string;
+  description: string;
+  mode: ComposerMode;
+}> = composerModes.map((item) => ({
+  command: item.mode,
+  label: item.label,
+  description: item.placeholder,
+  mode: item.mode,
+}));
 
 const timelineFilters: Array<{ filter: TimelineFilter; label: string }> = [
   { filter: "all", label: "All" },
@@ -1919,6 +1933,81 @@ function focusComposer() {
   composerInput.setSelectionRange(length, length);
 }
 
+function getComposerSlashMatch(value: string) {
+  const match = value.match(/^\/([a-z-]+)(?=\s|$)/i);
+  if (!match) {
+    return null;
+  }
+
+  const token = match[1].toLowerCase();
+  return composerSlashCommands.find((item) => item.command === token) ?? null;
+}
+
+function getFilteredComposerSlashCommands() {
+  if (!composerSlashQuery) {
+    return [];
+  }
+
+  return composerSlashCommands.filter((item) => item.command.startsWith(composerSlashQuery));
+}
+
+function renderComposerSlashCommands() {
+  const root = document.getElementById("composer-slash-row");
+  if (!root) {
+    return;
+  }
+
+  const commands = getFilteredComposerSlashCommands();
+  root.innerHTML = "";
+  root.hidden = commands.length === 0;
+  if (commands.length === 0) {
+    return;
+  }
+
+  commands.forEach((item, index) => {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = `slash-chip ${index === selectedComposerSlashIndex ? "is-active" : ""}`;
+    button.innerHTML = `<span class="slash-chip-command">/${item.command}</span><span class="slash-chip-description">${item.label}</span>`;
+    button.addEventListener("click", () => {
+      applyComposerSlashCommand(item);
+    });
+    root.appendChild(button);
+  });
+}
+
+function syncComposerSlashState(value: string) {
+  const match = value.match(/^\/([a-z-]*)$/i);
+  composerSlashQuery = match ? match[1].toLowerCase() : "";
+  const commands = getFilteredComposerSlashCommands();
+  if (commands.length === 0) {
+    selectedComposerSlashIndex = 0;
+  } else {
+    selectedComposerSlashIndex = Math.min(selectedComposerSlashIndex, commands.length - 1);
+  }
+  renderComposerSlashCommands();
+}
+
+function applyComposerSlashCommand(command: (typeof composerSlashCommands)[number]) {
+  const composerInput = document.getElementById("composer-input") as HTMLTextAreaElement | null;
+  if (!composerInput) {
+    return;
+  }
+
+  setComposerMode(command.mode);
+  composerInput.value = composerInput.value.replace(/^\/[^\s]+/, "").replace(/^\s+/, "");
+  syncComposerSlashState(composerInput.value);
+  composerInput.focus();
+  const length = composerInput.value.length;
+  composerInput.setSelectionRange(length, length);
+}
+
+function insertComposerTab(composerInput: HTMLTextAreaElement) {
+  const start = composerInput.selectionStart;
+  const end = composerInput.selectionEnd;
+  composerInput.setRangeText("\t", start, end, "end");
+}
+
 function renderComposerModes() {
   const root = document.getElementById("composer-mode-row");
   const composerInput = document.getElementById("composer-input") as HTMLTextAreaElement | null;
@@ -1943,6 +2032,8 @@ function renderComposerModes() {
   if (selected) {
     composerInput.placeholder = selected.placeholder;
   }
+
+  renderComposerSlashCommands();
 }
 
 function formatAttachmentSize(size: number) {
@@ -4404,6 +4495,7 @@ window.addEventListener("DOMContentLoaded", async () => {
   renderRunSummary();
   renderConversation(getConversationItems());
   renderComposerModes();
+  renderComposerSlashCommands();
   renderAttachmentTray();
   renderCommandBar();
   renderEditorSurface();
@@ -4548,6 +4640,32 @@ window.addEventListener("DOMContentLoaded", async () => {
     });
 
     composerInput.addEventListener("keydown", (event) => {
+      const slashCommands = getFilteredComposerSlashCommands();
+      if (event.key === "ArrowDown" && slashCommands.length > 0) {
+        event.preventDefault();
+        selectedComposerSlashIndex = (selectedComposerSlashIndex + 1) % slashCommands.length;
+        renderComposerSlashCommands();
+        return;
+      }
+
+      if (event.key === "ArrowUp" && slashCommands.length > 0) {
+        event.preventDefault();
+        selectedComposerSlashIndex = (selectedComposerSlashIndex - 1 + slashCommands.length) % slashCommands.length;
+        renderComposerSlashCommands();
+        return;
+      }
+
+      if (event.key === "Tab" && !event.shiftKey && !event.ctrlKey && !event.metaKey && !event.altKey) {
+        event.preventDefault();
+        if (slashCommands.length > 0) {
+          applyComposerSlashCommand(slashCommands[selectedComposerSlashIndex] ?? slashCommands[0]);
+          return;
+        }
+        insertComposerTab(composerInput);
+        syncComposerSlashState(composerInput.value);
+        return;
+      }
+
       if (event.key !== "Enter") {
         return;
       }
@@ -4558,6 +4676,10 @@ window.addEventListener("DOMContentLoaded", async () => {
 
       event.preventDefault();
       composer.requestSubmit();
+    });
+
+    composerInput.addEventListener("input", () => {
+      syncComposerSlashState(composerInput.value);
     });
 
     composerInput.addEventListener("paste", (event) => {
@@ -4593,6 +4715,10 @@ window.addEventListener("DOMContentLoaded", async () => {
 
     composer.addEventListener("submit", (event) => {
       event.preventDefault();
+      const slashMatch = getComposerSlashMatch(composerInput.value);
+      if (slashMatch) {
+        applyComposerSlashCommand(slashMatch);
+      }
       const value = composerInput.value.trim();
       if (!value && pendingAttachments.length === 0) {
         return;
@@ -4600,6 +4726,7 @@ window.addEventListener("DOMContentLoaded", async () => {
       const submittedAttachments = [...pendingAttachments];
       appendUserMessage(value, submittedAttachments);
       composerInput.value = "";
+      syncComposerSlashState(composerInput.value);
       clearPendingAttachments();
       renderAttachmentTray();
       requestDesktopSummaryRefresh(undefined, 750);

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -2028,6 +2028,7 @@ function applyComposerSlashCommand(command: (typeof composerSlashCommands)[numbe
   setComposerMode(command.mode);
   composerInput.value = composerInput.value.replace(/^\/[^\s]+/, "").replace(/^\s+/, "");
   syncComposerSlashState(composerInput.value);
+  exitComposerHistoryToDraft(composerInput.value);
   composerInput.focus();
   const length = composerInput.value.length;
   composerInput.setSelectionRange(length, length);
@@ -2061,6 +2062,16 @@ function setComposerValue(value: string) {
   syncComposerSlashState(value);
   const length = value.length;
   composerInput.setSelectionRange(length, length);
+}
+
+function syncComposerDraftState(value?: string) {
+  const composerInput = document.getElementById("composer-input") as HTMLTextAreaElement | null;
+  composerDraftState = captureComposerHistoryEntry(value ?? composerInput?.value ?? "");
+}
+
+function exitComposerHistoryToDraft(value?: string) {
+  composerHistoryIndex = -1;
+  syncComposerDraftState(value);
 }
 
 function snapshotComposerAttachments(attachments: ComposerAttachment[]): ComposerAttachmentSnapshot[] {
@@ -2201,6 +2212,7 @@ function renderComposerRemoteReferences() {
       } else {
         selectedComposerRemoteReferenceIds.add(item.id);
       }
+      exitComposerHistoryToDraft();
       renderComposerRemoteReferences();
     });
     root.appendChild(button);
@@ -2326,6 +2338,7 @@ function renderAttachmentTray() {
     removeButton.addEventListener("click", () => {
       releaseAttachmentPreview(attachment);
       pendingAttachments = pendingAttachments.filter((item) => item.id !== attachment.id);
+      exitComposerHistoryToDraft();
       renderAttachmentTray();
     });
     item.appendChild(removeButton);
@@ -2346,6 +2359,7 @@ function appendAttachments(files: File[]) {
 
   const next = files.slice(0, remaining).map((file) => createComposerAttachment(file));
   pendingAttachments = [...pendingAttachments, ...next];
+  exitComposerHistoryToDraft();
   renderAttachmentTray();
 }
 
@@ -4842,33 +4856,34 @@ window.addEventListener("DOMContentLoaded", async () => {
 
     composerInput.addEventListener("keydown", (event) => {
       const slashCommands = getFilteredComposerSlashCommands();
-      if (event.key === "ArrowUp" && !event.shiftKey && !event.ctrlKey && !event.metaKey && !event.altKey && !composerSlashOpen && composerHistory.length > 0 && isComposerSelectionCollapsed(composerInput) && isCaretOnFirstLine(composerInput)) {
+      const composerImeBlocking = composerImeActive || event.isComposing;
+      if (event.key === "ArrowUp" && !composerImeBlocking && !event.shiftKey && !event.ctrlKey && !event.metaKey && !event.altKey && !composerSlashOpen && composerHistory.length > 0 && isComposerSelectionCollapsed(composerInput) && isCaretOnFirstLine(composerInput)) {
         event.preventDefault();
         stepComposerHistory(-1);
         return;
       }
 
-      if (event.key === "ArrowDown" && !event.shiftKey && !event.ctrlKey && !event.metaKey && !event.altKey && !composerSlashOpen && composerHistoryIndex !== -1 && isComposerSelectionCollapsed(composerInput) && isCaretOnLastLine(composerInput)) {
+      if (event.key === "ArrowDown" && !composerImeBlocking && !event.shiftKey && !event.ctrlKey && !event.metaKey && !event.altKey && !composerSlashOpen && composerHistoryIndex !== -1 && isComposerSelectionCollapsed(composerInput) && isCaretOnLastLine(composerInput)) {
         event.preventDefault();
         stepComposerHistory(1);
         return;
       }
 
-      if (event.key === "ArrowDown" && slashCommands.length > 0) {
+      if (event.key === "ArrowDown" && !composerImeBlocking && slashCommands.length > 0) {
         event.preventDefault();
         selectedComposerSlashIndex = (selectedComposerSlashIndex + 1) % slashCommands.length;
         renderComposerSlashCommands();
         return;
       }
 
-      if (event.key === "ArrowUp" && slashCommands.length > 0) {
+      if (event.key === "ArrowUp" && !composerImeBlocking && slashCommands.length > 0) {
         event.preventDefault();
         selectedComposerSlashIndex = (selectedComposerSlashIndex - 1 + slashCommands.length) % slashCommands.length;
         renderComposerSlashCommands();
         return;
       }
 
-      if (event.key === "Tab" && !event.shiftKey && !event.ctrlKey && !event.metaKey && !event.altKey) {
+      if (event.key === "Tab" && !composerImeBlocking && !event.shiftKey && !event.ctrlKey && !event.metaKey && !event.altKey) {
         event.preventDefault();
         if (slashCommands.length > 0) {
           applyComposerSlashCommand(slashCommands[selectedComposerSlashIndex] ?? slashCommands[0]);
@@ -4876,6 +4891,7 @@ window.addEventListener("DOMContentLoaded", async () => {
         }
         insertComposerTab(composerInput);
         syncComposerSlashState(composerInput.value);
+        exitComposerHistoryToDraft(composerInput.value);
         return;
       }
 
@@ -4892,9 +4908,10 @@ window.addEventListener("DOMContentLoaded", async () => {
     });
 
     composerInput.addEventListener("input", () => {
-      if (composerHistoryIndex === -1) {
-        composerDraftState = captureComposerHistoryEntry(composerInput.value);
+      if (composerHistoryIndex !== -1) {
+        composerHistoryIndex = -1;
       }
+      syncComposerDraftState(composerInput.value);
       syncComposerSlashState(composerInput.value);
     });
 
@@ -4935,12 +4952,13 @@ window.addEventListener("DOMContentLoaded", async () => {
       if (slashMatch) {
         applyComposerSlashCommand(slashMatch);
       }
-      const value = composerInput.value.trim();
+      const rawValue = composerInput.value;
+      const value = rawValue.trim();
       const selectedRemoteReferences = getComposerRemoteReferences().filter((item) => selectedComposerRemoteReferenceIds.has(item.id));
       if (!value && pendingAttachments.length === 0 && selectedRemoteReferences.length === 0) {
         return;
       }
-      const historyEntry = captureComposerHistoryEntry(value);
+      const historyEntry = captureComposerHistoryEntry(rawValue);
       const submittedAttachments = [
         ...pendingAttachments,
         ...selectedRemoteReferences.map((item) => ({
@@ -4951,7 +4969,7 @@ window.addEventListener("DOMContentLoaded", async () => {
           file: new File([], item.label),
         })),
       ];
-      appendUserMessage(value, submittedAttachments);
+      appendUserMessage(rawValue, submittedAttachments);
       pushComposerHistoryEntry(historyEntry);
       composerInput.value = "";
       syncComposerSlashState(composerInput.value);

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -177,6 +177,25 @@ interface ComposerAttachment {
   previewUrl?: string;
 }
 
+interface ComposerRemoteReference {
+  id: string;
+  label: string;
+  meta: string;
+}
+
+interface ComposerAttachmentSnapshot {
+  name: string;
+  kind: "image" | "file";
+  sizeLabel: string;
+  file: File;
+}
+
+interface ComposerHistoryEntry {
+  value: string;
+  remoteReferenceIds: string[];
+  attachments: ComposerAttachmentSnapshot[];
+}
+
 type ComposerMode = "ask" | "dispatch" | "review" | "explain";
 
 interface CommandAction {
@@ -208,6 +227,10 @@ let activeComposerMode: ComposerMode = "dispatch";
 let composerSlashOpen = false;
 let composerSlashQuery = "";
 let selectedComposerSlashIndex = 0;
+let composerHistory: ComposerHistoryEntry[] = [];
+let composerHistoryIndex = -1;
+let composerDraftState: ComposerHistoryEntry = { value: "", remoteReferenceIds: [], attachments: [] };
+let selectedComposerRemoteReferenceIds = new Set<string>();
 let activeSourceFilter: SourceFilter = "all";
 let activeTimelineFilter: TimelineFilter = "all";
 let commandBarOpen = false;
@@ -1779,6 +1802,8 @@ function renderContextPanel() {
     });
     fileRoot.appendChild(button);
   }
+
+  renderComposerRemoteReferences();
 }
 
 function getSourceEntryTone(entry: SourceChange): SurfaceTone {
@@ -2014,6 +2039,174 @@ function insertComposerTab(composerInput: HTMLTextAreaElement) {
   composerInput.setRangeText("\t", start, end, "end");
 }
 
+function isComposerSelectionCollapsed(composerInput: HTMLTextAreaElement) {
+  return composerInput.selectionStart === composerInput.selectionEnd;
+}
+
+function isCaretOnFirstLine(composerInput: HTMLTextAreaElement) {
+  return !composerInput.value.slice(0, composerInput.selectionStart).includes("\n");
+}
+
+function isCaretOnLastLine(composerInput: HTMLTextAreaElement) {
+  return !composerInput.value.slice(composerInput.selectionEnd).includes("\n");
+}
+
+function setComposerValue(value: string) {
+  const composerInput = document.getElementById("composer-input") as HTMLTextAreaElement | null;
+  if (!composerInput) {
+    return;
+  }
+
+  composerInput.value = value;
+  syncComposerSlashState(value);
+  const length = value.length;
+  composerInput.setSelectionRange(length, length);
+}
+
+function snapshotComposerAttachments(attachments: ComposerAttachment[]): ComposerAttachmentSnapshot[] {
+  return attachments.map((item) => ({
+    name: item.name,
+    kind: item.kind,
+    sizeLabel: item.sizeLabel,
+    file: item.file,
+  }));
+}
+
+function restoreComposerAttachments(snapshots: ComposerAttachmentSnapshot[]) {
+  return snapshots.map((item) => ({
+    id: `${item.name}-${item.file.size}-${item.file.lastModified}-${Math.random().toString(36).slice(2, 8)}`,
+    name: item.name,
+    kind: item.kind,
+    sizeLabel: item.sizeLabel,
+    file: item.file,
+    previewUrl: item.kind === "image" ? URL.createObjectURL(item.file) : undefined,
+  }));
+}
+
+function captureComposerHistoryEntry(value: string): ComposerHistoryEntry {
+  return {
+    value,
+    remoteReferenceIds: Array.from(selectedComposerRemoteReferenceIds),
+    attachments: snapshotComposerAttachments(pendingAttachments),
+  };
+}
+
+function applyComposerHistoryEntry(entry: ComposerHistoryEntry) {
+  setComposerValue(entry.value);
+  clearPendingAttachments();
+  pendingAttachments = restoreComposerAttachments(entry.attachments);
+  selectedComposerRemoteReferenceIds = new Set(entry.remoteReferenceIds);
+  renderAttachmentTray();
+  renderComposerRemoteReferences();
+}
+
+function stepComposerHistory(direction: -1 | 1) {
+  if (composerHistory.length === 0) {
+    return;
+  }
+
+  if (direction === -1) {
+    if (composerHistoryIndex === -1) {
+      const composerInput = document.getElementById("composer-input") as HTMLTextAreaElement | null;
+      composerDraftState = captureComposerHistoryEntry(composerInput?.value ?? "");
+      composerHistoryIndex = composerHistory.length - 1;
+    } else if (composerHistoryIndex > 0) {
+      composerHistoryIndex -= 1;
+    }
+    applyComposerHistoryEntry(composerHistory[composerHistoryIndex] ?? composerDraftState);
+    return;
+  }
+
+  if (composerHistoryIndex === -1) {
+    return;
+  }
+
+  if (composerHistoryIndex < composerHistory.length - 1) {
+    composerHistoryIndex += 1;
+    applyComposerHistoryEntry(composerHistory[composerHistoryIndex] ?? composerDraftState);
+    return;
+  }
+
+  composerHistoryIndex = -1;
+  applyComposerHistoryEntry(composerDraftState);
+}
+
+function pushComposerHistoryEntry(entry: ComposerHistoryEntry) {
+  if (!entry.value && entry.remoteReferenceIds.length === 0 && entry.attachments.length === 0) {
+    return;
+  }
+
+  composerHistory = [entry, ...composerHistory].slice(0, 20);
+  composerHistoryIndex = -1;
+  composerDraftState = { value: "", remoteReferenceIds: [], attachments: [] };
+}
+
+function getComposerRemoteReferences() {
+  const selectedProjection = getPrimaryRunProjection();
+  const references: ComposerRemoteReference[] = [];
+
+  if (selectedProjection) {
+    references.push({
+      id: `run:${selectedProjection.run_id}`,
+      label: selectedProjection.run_id,
+      meta: `${selectedProjection.next_action || "idle"} · ${selectedProjection.branch || "no branch"}`,
+    });
+  }
+
+  for (const change of getVisibleSourceChanges().slice(0, 3)) {
+    references.push({
+      id: `change:${getSourceChangeKey(change)}`,
+      label: change.path.split("/").pop() ?? change.path,
+      meta: `${change.status} · ${change.branch}`,
+    });
+  }
+
+  return references;
+}
+
+function renderComposerRemoteReferences() {
+  const root = document.getElementById("composer-remote-row");
+  if (!root) {
+    return;
+  }
+
+  const references = getComposerRemoteReferences();
+  root.innerHTML = "";
+  root.hidden = references.length === 0;
+  if (references.length === 0) {
+    selectedComposerRemoteReferenceIds.clear();
+    return;
+  }
+
+  const validIds = new Set(references.map((item) => item.id));
+  selectedComposerRemoteReferenceIds = new Set(
+    Array.from(selectedComposerRemoteReferenceIds).filter((id) => validIds.has(id)),
+  );
+
+  references.forEach((item) => {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = `remote-chip ${selectedComposerRemoteReferenceIds.has(item.id) ? "is-active" : ""}`;
+    const label = document.createElement("span");
+    label.className = "remote-chip-label";
+    label.textContent = item.label;
+    const meta = document.createElement("span");
+    meta.className = "remote-chip-meta";
+    meta.textContent = item.meta;
+    button.appendChild(label);
+    button.appendChild(meta);
+    button.addEventListener("click", () => {
+      if (selectedComposerRemoteReferenceIds.has(item.id)) {
+        selectedComposerRemoteReferenceIds.delete(item.id);
+      } else {
+        selectedComposerRemoteReferenceIds.add(item.id);
+      }
+      renderComposerRemoteReferences();
+    });
+    root.appendChild(button);
+  });
+}
+
 function renderComposerModes() {
   const root = document.getElementById("composer-mode-row");
   const composerInput = document.getElementById("composer-input") as HTMLTextAreaElement | null;
@@ -2040,6 +2233,7 @@ function renderComposerModes() {
   }
 
   renderComposerSlashCommands();
+  renderComposerRemoteReferences();
 }
 
 function formatAttachmentSize(size: number) {
@@ -4502,6 +4696,7 @@ window.addEventListener("DOMContentLoaded", async () => {
   renderConversation(getConversationItems());
   renderComposerModes();
   renderComposerSlashCommands();
+  renderComposerRemoteReferences();
   renderAttachmentTray();
   renderCommandBar();
   renderEditorSurface();
@@ -4647,6 +4842,18 @@ window.addEventListener("DOMContentLoaded", async () => {
 
     composerInput.addEventListener("keydown", (event) => {
       const slashCommands = getFilteredComposerSlashCommands();
+      if (event.key === "ArrowUp" && !event.shiftKey && !event.ctrlKey && !event.metaKey && !event.altKey && !composerSlashOpen && composerHistory.length > 0 && isComposerSelectionCollapsed(composerInput) && isCaretOnFirstLine(composerInput)) {
+        event.preventDefault();
+        stepComposerHistory(-1);
+        return;
+      }
+
+      if (event.key === "ArrowDown" && !event.shiftKey && !event.ctrlKey && !event.metaKey && !event.altKey && !composerSlashOpen && composerHistoryIndex !== -1 && isComposerSelectionCollapsed(composerInput) && isCaretOnLastLine(composerInput)) {
+        event.preventDefault();
+        stepComposerHistory(1);
+        return;
+      }
+
       if (event.key === "ArrowDown" && slashCommands.length > 0) {
         event.preventDefault();
         selectedComposerSlashIndex = (selectedComposerSlashIndex + 1) % slashCommands.length;
@@ -4685,6 +4892,9 @@ window.addEventListener("DOMContentLoaded", async () => {
     });
 
     composerInput.addEventListener("input", () => {
+      if (composerHistoryIndex === -1) {
+        composerDraftState = captureComposerHistoryEntry(composerInput.value);
+      }
       syncComposerSlashState(composerInput.value);
     });
 
@@ -4726,14 +4936,28 @@ window.addEventListener("DOMContentLoaded", async () => {
         applyComposerSlashCommand(slashMatch);
       }
       const value = composerInput.value.trim();
-      if (!value && pendingAttachments.length === 0) {
+      const selectedRemoteReferences = getComposerRemoteReferences().filter((item) => selectedComposerRemoteReferenceIds.has(item.id));
+      if (!value && pendingAttachments.length === 0 && selectedRemoteReferences.length === 0) {
         return;
       }
-      const submittedAttachments = [...pendingAttachments];
+      const historyEntry = captureComposerHistoryEntry(value);
+      const submittedAttachments = [
+        ...pendingAttachments,
+        ...selectedRemoteReferences.map((item) => ({
+          id: item.id,
+          name: item.label,
+          kind: "file" as const,
+          sizeLabel: item.meta,
+          file: new File([], item.label),
+        })),
+      ];
       appendUserMessage(value, submittedAttachments);
+      pushComposerHistoryEntry(historyEntry);
       composerInput.value = "";
       syncComposerSlashState(composerInput.value);
       clearPendingAttachments();
+      selectedComposerRemoteReferenceIds.clear();
+      renderComposerRemoteReferences();
       renderAttachmentTray();
       requestDesktopSummaryRefresh(undefined, 750);
     });

--- a/winsmux-app/src/styles.css
+++ b/winsmux-app/src/styles.css
@@ -699,6 +699,13 @@ textarea {
   gap: 8px;
 }
 
+#composer-remote-row {
+  margin-top: 8px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
 .mode-chip {
   border: 1px solid var(--border-strong);
   border-radius: 999px;
@@ -741,6 +748,36 @@ textarea {
 }
 
 .slash-chip-description {
+  font-size: var(--text-2xs);
+  color: var(--text-muted);
+}
+
+.remote-chip {
+  border: 1px solid var(--border-muted);
+  border-radius: 14px;
+  background: var(--bg-surface-raised);
+  color: var(--text-secondary);
+  padding: 8px 10px;
+  cursor: pointer;
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+  min-width: 132px;
+}
+
+.remote-chip.is-active,
+.remote-chip:hover {
+  border-color: var(--status-info-border);
+  color: var(--text-primary);
+}
+
+.remote-chip-label {
+  font-size: var(--text-xs);
+  color: var(--text-primary);
+}
+
+.remote-chip-meta {
   font-size: var(--text-2xs);
   color: var(--text-muted);
 }
@@ -1809,6 +1846,7 @@ textarea {
 
   #composer-mode-row,
   #composer-slash-row,
+  #composer-remote-row,
   #composer-footer {
     margin-top: 8px;
   }

--- a/winsmux-app/src/styles.css
+++ b/winsmux-app/src/styles.css
@@ -692,6 +692,13 @@ textarea {
   gap: 8px;
 }
 
+#composer-slash-row {
+  margin-top: 8px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
 .mode-chip {
   border: 1px solid var(--border-strong);
   border-radius: 999px;
@@ -706,6 +713,36 @@ textarea {
   background: var(--bg-panel);
   border-color: var(--status-focus-border);
   color: var(--text-primary);
+}
+
+.slash-chip {
+  border: 1px solid var(--border-muted);
+  border-radius: 14px;
+  background: var(--bg-panel);
+  color: var(--text-secondary);
+  padding: 8px 10px;
+  cursor: pointer;
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+  min-width: 132px;
+}
+
+.slash-chip.is-active,
+.slash-chip:hover {
+  border-color: var(--status-focus-border);
+  color: var(--text-primary);
+}
+
+.slash-chip-command {
+  font-size: var(--text-xs);
+  color: var(--text-primary);
+}
+
+.slash-chip-description {
+  font-size: var(--text-2xs);
+  color: var(--text-muted);
 }
 
 #composer-footer {
@@ -1771,6 +1808,7 @@ textarea {
   }
 
   #composer-mode-row,
+  #composer-slash-row,
   #composer-footer {
     margin-top: 8px;
   }


### PR DESCRIPTION
## Summary\n- add a first composer parity slice with Tab insertion in the textarea\n- add inline slash command suggestions for ask/dispatch/review/explain\n- apply leading slash commands to composer mode before submit\n\n## Validation\n- cmd /c npm run build\n- pwsh -NoProfile -File .\\scripts\\git-guard.ps1 -Mode full\n- pwsh -NoProfile -File .\\scripts\\audit-public-surface.ps1