### PR TITLE
TASK-370: add stateful settings footer lane

### DIFF
--- a/winsmux-app/index.html
+++ b/winsmux-app/index.html
@@ -169,7 +169,10 @@
         <section id="settings-sheet" hidden role="dialog" aria-modal="false" aria-labelledby="settings-sheet-title">
           <div class="panel-title-row">
             <div class="panel-title" id="settings-sheet-title">Settings</div>
-            <button class="ghost-btn ghost-btn-small" id="close-settings-btn" type="button">Close</button>
+            <div class="settings-sheet-actions">
+              <button class="ghost-btn ghost-btn-small" id="close-settings-btn" type="button">Cancel</button>
+              <button class="ghost-btn ghost-btn-small" id="apply-settings-btn" type="button">Apply</button>
+            </div>
           </div>
           <div class="settings-section">
             <div class="context-label">Profile</div>

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -1926,12 +1926,18 @@ function getFooterSettingsTone(status: string): SurfaceTone {
   }
 }
 
+function getFooterInboxTone(count: number): SurfaceTone {
+  if (count > 0) {
+    return "warning";
+  }
+  return "success";
+}
+
 function getFooterItems(): { left: FooterStatusItem[]; right: FooterStatusItem[] } {
   const selectedProjection = getPrimaryRunProjection();
   const modeLabel = composerModes.find((item) => item.mode === activeComposerMode)?.label ?? activeComposerMode;
-  const inboxStatus = desktopSummarySnapshot
-    ? `${desktopSummarySnapshot.inbox.summary.item_count} inbox`
-    : "Inbox idle";
+  const inboxCount = desktopSummarySnapshot?.inbox.summary.item_count ?? 0;
+  const inboxStatus = desktopSummarySnapshot ? `${inboxCount} inbox` : "Inbox idle";
   const runStatus = selectedProjection?.label || selectedProjection?.run_id || "No run selected";
   const reviewStatus = selectedProjection?.review_state || "No review";
   const nextStatus = selectedProjection?.next_action || "idle";
@@ -1953,7 +1959,7 @@ function getFooterItems(): { left: FooterStatusItem[]; right: FooterStatusItem[]
       { label: "Operator", value: operatorStatus.label, tone: operatorStatus.tone },
       { label: "Review", value: reviewStatus, tone: getFooterReviewTone(selectedProjection?.review_state) },
       { label: "Next", value: nextStatus, tone: getFooterNextTone(selectedProjection?.next_action) },
-      { label: "Inbox", value: inboxStatus },
+      { label: "Inbox", value: inboxStatus, tone: getFooterInboxTone(inboxCount) },
     ],
   };
 }

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -4328,6 +4328,7 @@ function setContextPanel(open: boolean, options?: { preserveWidePreference?: boo
 
   if ((options?.preserveWidePreference ?? true) && !isNarrowLayout()) {
     preferredWideContextOpen = open;
+    void persistThemeState();
   }
 
   panel.toggleAttribute("hidden", !open);
@@ -4366,6 +4367,7 @@ function setSidebarOpen(open: boolean, options?: { preserveWidePreference?: bool
 
   if ((options?.preserveWidePreference ?? true) && !isNarrowLayout()) {
     preferredWideSidebarOpen = open;
+    void persistThemeState();
   }
 
   shell.classList.toggle("sidebar-open", open);
@@ -4399,6 +4401,7 @@ function applySettingsDraft() {
     applyThemeState(settingsDraftState);
     persistThemeState();
   }
+  settingsDraftState = null;
   setSettingsSheet(false);
 }
 

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -277,6 +277,8 @@ const themeState: ThemeState = {
   density: "comfortable",
   wrapMode: "balanced",
 };
+let settingsDraftState: ThemeState | null = null;
+const SHELL_PREFERENCES_STORAGE_KEY = "winsmux.shell.preferences.v1";
 
 const composerModes: Array<{ mode: ComposerMode; label: string; placeholder: string }> = [
   { mode: "ask", label: "Ask", placeholder: "Ask the Operator for clarification, status, or guidance" },
@@ -1820,32 +1822,77 @@ function getSourceEntryTone(entry: SourceChange): SurfaceTone {
 }
 
 function getFooterItems(): { left: FooterStatusItem[]; right: FooterStatusItem[] } {
-  const themeLabel = themeOptions.find((item) => item.value === themeState.theme)?.label ?? themeState.theme;
-  const densityLabel = densityOptions.find((item) => item.value === themeState.density)?.label ?? themeState.density;
-  const wrapLabel = wrapOptions.find((item) => item.value === themeState.wrapMode)?.label ?? themeState.wrapMode;
+  const selectedProjection = getPrimaryRunProjection();
+  const modeLabel = composerModes.find((item) => item.mode === activeComposerMode)?.label ?? activeComposerMode;
   const summaryStatus = desktopSummarySnapshot
     ? `${desktopSummarySnapshot.digest.summary.item_count} runs`
     : "Operator ready";
   const inboxStatus = desktopSummarySnapshot
     ? `${desktopSummarySnapshot.inbox.summary.item_count} inbox`
-    : "config.toml";
-  const branchStatus = getPrimaryRunProjection()?.branch || "main";
+    : "Inbox idle";
+  const branchStatus = selectedProjection?.branch || "main";
+  const runStatus = selectedProjection?.label || selectedProjection?.run_id || "No run selected";
+  const surfaceStatus = selectedPreviewUrl
+    ? "Preview"
+    : editorSurfaceOpen
+      ? "Code"
+      : terminalDrawerOpen
+        ? "Terminal"
+        : "Shell";
 
   return {
     left: [
-      { label: "Local environment" },
-      { label: themeLabel, tone: "focus" },
-      { label: densityLabel },
-      { label: `Wrap ${wrapLabel}` },
+      { label: "Mode", value: modeLabel, tone: "focus" },
+      { label: "Surface", value: surfaceStatus },
       { label: "Command", value: "Ctrl/Cmd+K", tone: "accent" },
-      { label: "Settings", tone: "accent" },
+      { label: "Settings", value: settingsSheetOpen ? "Editing" : "Preferences", tone: "accent" },
     ],
     right: [
-      { label: inboxStatus },
-      { label: branchStatus },
-      { label: summaryStatus, tone: desktopSummarySnapshot ? "info" : "success" },
+      { label: "Run", value: runStatus },
+      { label: "Branch", value: branchStatus },
+      { label: "Inbox", value: inboxStatus },
+      { label: "Board", value: summaryStatus, tone: desktopSummarySnapshot ? "info" : "success" },
     ],
   };
+}
+
+function cloneThemeState(state: ThemeState): ThemeState {
+  return {
+    theme: state.theme,
+    density: state.density,
+    wrapMode: state.wrapMode,
+  };
+}
+
+function readStoredThemeState(): ThemeState | null {
+  try {
+    const rawValue = window.localStorage.getItem(SHELL_PREFERENCES_STORAGE_KEY);
+    if (!rawValue) {
+      return null;
+    }
+
+    const parsed = JSON.parse(rawValue) as Partial<ThemeState>;
+    const theme = themeOptions.find((item) => item.value === parsed.theme)?.value;
+    const density = densityOptions.find((item) => item.value === parsed.density)?.value;
+    const wrapMode = wrapOptions.find((item) => item.value === parsed.wrapMode)?.value;
+    if (!theme || !density || !wrapMode) {
+      return null;
+    }
+
+    return { theme, density, wrapMode };
+  } catch {
+    return null;
+  }
+}
+
+function persistThemeState() {
+  try {
+    window.localStorage.setItem(SHELL_PREFERENCES_STORAGE_KEY, JSON.stringify(themeState));
+    return true;
+  } catch (error) {
+    console.warn("Failed to persist shell preferences", error);
+    return false;
+  }
 }
 
 function applyShellPreferences() {
@@ -1857,6 +1904,14 @@ function applyShellPreferences() {
   shell.dataset.theme = themeState.theme;
   shell.dataset.density = themeState.density;
   shell.dataset.wrapMode = themeState.wrapMode;
+}
+
+function applyThemeState(nextState: ThemeState) {
+  themeState.theme = nextState.theme;
+  themeState.density = nextState.density;
+  themeState.wrapMode = nextState.wrapMode;
+  applyShellPreferences();
+  renderFooterLane();
 }
 
 function renderPreferenceOptions<T extends string>(
@@ -1883,24 +1938,29 @@ function renderPreferenceOptions<T extends string>(
 }
 
 function renderSettingsControls() {
-  renderPreferenceOptions("theme-options", themeOptions, themeState.theme, (value) => {
-    themeState.theme = value;
-    applyShellPreferences();
-    renderFooterLane();
+  const activeState = settingsDraftState ?? themeState;
+
+  renderPreferenceOptions("theme-options", themeOptions, activeState.theme, (value) => {
+    if (!settingsDraftState) {
+      settingsDraftState = cloneThemeState(themeState);
+    }
+    settingsDraftState.theme = value;
     renderSettingsControls();
   });
 
-  renderPreferenceOptions("density-options", densityOptions, themeState.density, (value) => {
-    themeState.density = value;
-    applyShellPreferences();
-    renderFooterLane();
+  renderPreferenceOptions("density-options", densityOptions, activeState.density, (value) => {
+    if (!settingsDraftState) {
+      settingsDraftState = cloneThemeState(themeState);
+    }
+    settingsDraftState.density = value;
     renderSettingsControls();
   });
 
-  renderPreferenceOptions("wrap-options", wrapOptions, themeState.wrapMode, (value) => {
-    themeState.wrapMode = value;
-    applyShellPreferences();
-    renderFooterLane();
+  renderPreferenceOptions("wrap-options", wrapOptions, activeState.wrapMode, (value) => {
+    if (!settingsDraftState) {
+      settingsDraftState = cloneThemeState(themeState);
+    }
+    settingsDraftState.wrapMode = value;
     renderSettingsControls();
   });
 }
@@ -4105,7 +4165,6 @@ function setSidebarOpen(open: boolean) {
 }
 
 function setSettingsSheet(open: boolean) {
-  settingsSheetOpen = open;
   const sheet = document.getElementById("settings-sheet");
   if (!sheet) {
     return;
@@ -4115,7 +4174,28 @@ function setSettingsSheet(open: boolean) {
     closeCommandBar();
   }
 
+  settingsSheetOpen = open;
+  if (open) {
+    settingsDraftState = cloneThemeState(themeState);
+    renderSettingsControls();
+  } else {
+    settingsDraftState = null;
+  }
   sheet.hidden = !open;
+  renderFooterLane();
+}
+
+function applySettingsDraft() {
+  if (settingsDraftState) {
+    applyThemeState(settingsDraftState);
+    persistThemeState();
+  }
+  setSettingsSheet(false);
+}
+
+function cancelSettingsDraft() {
+  settingsDraftState = null;
+  setSettingsSheet(false);
 }
 
 function syncResponsiveShell() {
@@ -4682,6 +4762,11 @@ function initializeSidebarResize() {
 window.addEventListener("DOMContentLoaded", async () => {
   installViewportHarnessHooks();
 
+  const storedThemeState = readStoredThemeState();
+  if (storedThemeState) {
+    applyThemeState(storedThemeState);
+  }
+
   await subscribeToPtyOutput((payload) => {
     registerPreviewTargets(payload.pane_id, payload.data);
     const entry = payload.pane_id ? panes.get(payload.pane_id) : undefined;
@@ -4765,8 +4850,12 @@ window.addEventListener("DOMContentLoaded", async () => {
     setSettingsSheet(true);
   });
 
+  document.getElementById("apply-settings-btn")?.addEventListener("click", () => {
+    applySettingsDraft();
+  });
+
   document.getElementById("close-settings-btn")?.addEventListener("click", () => {
-    setSettingsSheet(false);
+    cancelSettingsDraft();
   });
 
   document.getElementById("sidebar-overlay")?.addEventListener("click", () => {
@@ -5010,7 +5099,7 @@ window.addEventListener("DOMContentLoaded", async () => {
 
     if (event.key === "Escape" && settingsSheetOpen) {
       event.preventDefault();
-      setSettingsSheet(false);
+      cancelSettingsDraft();
       return;
     }
 

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -1856,28 +1856,72 @@ function getFooterNextTone(nextAction: string | undefined): SurfaceTone {
   }
 }
 
+function getFooterSurfaceStatus() {
+  if (commandBarOpen) {
+    return "Command";
+  }
+  if (settingsSheetOpen) {
+    return "Settings";
+  }
+  if (selectedPreviewUrl) {
+    return "Preview";
+  }
+  if (editorSurfaceOpen) {
+    return "Code";
+  }
+  if (terminalDrawerOpen) {
+    return "Terminal";
+  }
+  return "Shell";
+}
+
+function getFooterOperatorStatus(projection: DesktopRunProjection | undefined) {
+  if (!projection) {
+    return {
+      label: desktopSummarySnapshot ? "Monitoring" : "Ready",
+      tone: desktopSummarySnapshot ? "info" as SurfaceTone : "success" as SurfaceTone,
+    };
+  }
+
+  const taskState = (projection.task_state || "").toLowerCase();
+  if (taskState === "blocked") {
+    return { label: "Blocked", tone: "danger" as SurfaceTone };
+  }
+  if (projection.verification_outcome) {
+    return {
+      label: `Verify ${projection.verification_outcome}`,
+      tone: projection.verification_outcome.toUpperCase() === "PASS" ? "success" as SurfaceTone : "warning" as SurfaceTone,
+    };
+  }
+  if (taskState === "completed" || taskState === "task_completed" || taskState === "done") {
+    return { label: "Completed", tone: "success" as SurfaceTone };
+  }
+  if (projection.next_action) {
+    return {
+      label: projection.next_action,
+      tone: getFooterNextTone(projection.next_action),
+    };
+  }
+  return {
+    label: projection.task_state || "Tracking",
+    tone: "info" as SurfaceTone,
+  };
+}
+
 function getFooterItems(): { left: FooterStatusItem[]; right: FooterStatusItem[] } {
   const selectedProjection = getPrimaryRunProjection();
   const modeLabel = composerModes.find((item) => item.mode === activeComposerMode)?.label ?? activeComposerMode;
-  const summaryStatus = desktopSummarySnapshot
-    ? `${desktopSummarySnapshot.digest.summary.item_count} runs`
-    : "Operator ready";
   const inboxStatus = desktopSummarySnapshot
     ? `${desktopSummarySnapshot.inbox.summary.item_count} inbox`
     : "Inbox idle";
   const runStatus = selectedProjection?.label || selectedProjection?.run_id || "No run selected";
   const reviewStatus = selectedProjection?.review_state || "No review";
   const nextStatus = selectedProjection?.next_action || "idle";
-  const settingsStatus = settingsSheetOpen
-    ? (settingsDraftState && !themeStatesEqual(settingsDraftState, themeState) ? "Draft" : "Editing")
+  const operatorStatus = getFooterOperatorStatus(selectedProjection ?? undefined);
+  const settingsStatus = settingsDraftState
+    ? (themeStatesEqual(settingsDraftState, themeState) ? (settingsSheetOpen ? "Editing" : "Ready") : "Draft")
     : "Saved";
-  const surfaceStatus = selectedPreviewUrl
-    ? "Preview"
-    : editorSurfaceOpen
-      ? "Code"
-      : terminalDrawerOpen
-        ? "Terminal"
-        : "Shell";
+  const surfaceStatus = getFooterSurfaceStatus();
 
   return {
     left: [
@@ -1888,10 +1932,10 @@ function getFooterItems(): { left: FooterStatusItem[]; right: FooterStatusItem[]
     ],
     right: [
       { label: "Run", value: runStatus },
+      { label: "Operator", value: operatorStatus.label, tone: operatorStatus.tone },
       { label: "Review", value: reviewStatus, tone: getFooterReviewTone(selectedProjection?.review_state) },
       { label: "Next", value: nextStatus, tone: getFooterNextTone(selectedProjection?.next_action) },
       { label: "Inbox", value: inboxStatus },
-      { label: "Board", value: summaryStatus, tone: desktopSummarySnapshot ? "info" : "success" },
     ],
   };
 }
@@ -4258,10 +4302,10 @@ function setSettingsSheet(open: boolean) {
 
   settingsSheetOpen = open;
   if (open) {
-    settingsDraftState = cloneThemeState(themeState);
+    if (!settingsDraftState) {
+      settingsDraftState = cloneThemeState(themeState);
+    }
     renderSettingsControls();
-  } else {
-    settingsDraftState = null;
   }
   sheet.hidden = !open;
   renderFooterLane();

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -168,6 +168,12 @@ interface ThemeState {
   wrapMode: WrapMode;
 }
 
+interface ShellPreferenceState extends ThemeState {
+  sidebarWidth: number;
+  wideSidebarOpen: boolean;
+  wideContextOpen: boolean;
+}
+
 interface ComposerAttachment {
   id: string;
   name: string;
@@ -278,6 +284,8 @@ const themeState: ThemeState = {
   wrapMode: "balanced",
 };
 let settingsDraftState: ThemeState | null = null;
+let preferredWideSidebarOpen = true;
+let preferredWideContextOpen = true;
 const SHELL_PREFERENCES_STORAGE_KEY = "winsmux.shell.preferences.v1";
 
 const composerModes: Array<{ mode: ComposerMode; label: string; placeholder: string }> = [
@@ -1864,14 +1872,14 @@ function cloneThemeState(state: ThemeState): ThemeState {
   };
 }
 
-function readStoredThemeState(): ThemeState | null {
+function readStoredShellPreferences(): ShellPreferenceState | null {
   try {
     const rawValue = window.localStorage.getItem(SHELL_PREFERENCES_STORAGE_KEY);
     if (!rawValue) {
       return null;
     }
 
-    const parsed = JSON.parse(rawValue) as Partial<ThemeState>;
+    const parsed = JSON.parse(rawValue) as Partial<ShellPreferenceState>;
     const theme = themeOptions.find((item) => item.value === parsed.theme)?.value;
     const density = densityOptions.find((item) => item.value === parsed.density)?.value;
     const wrapMode = wrapOptions.find((item) => item.value === parsed.wrapMode)?.value;
@@ -1879,7 +1887,18 @@ function readStoredThemeState(): ThemeState | null {
       return null;
     }
 
-    return { theme, density, wrapMode };
+    const sidebarWidthValue = typeof parsed.sidebarWidth === "number" ? parsed.sidebarWidth : 292;
+    const wideSidebarOpen = typeof parsed.wideSidebarOpen === "boolean" ? parsed.wideSidebarOpen : true;
+    const wideContextOpen = typeof parsed.wideContextOpen === "boolean" ? parsed.wideContextOpen : true;
+
+    return {
+      theme,
+      density,
+      wrapMode,
+      sidebarWidth: Math.max(240, Math.min(380, Math.round(sidebarWidthValue))),
+      wideSidebarOpen,
+      wideContextOpen,
+    };
   } catch {
     return null;
   }
@@ -1887,7 +1906,15 @@ function readStoredThemeState(): ThemeState | null {
 
 function persistThemeState() {
   try {
-    window.localStorage.setItem(SHELL_PREFERENCES_STORAGE_KEY, JSON.stringify(themeState));
+    const nextState: ShellPreferenceState = {
+      theme: themeState.theme,
+      density: themeState.density,
+      wrapMode: themeState.wrapMode,
+      sidebarWidth,
+      wideSidebarOpen: preferredWideSidebarOpen,
+      wideContextOpen: preferredWideContextOpen,
+    };
+    window.localStorage.setItem(SHELL_PREFERENCES_STORAGE_KEY, JSON.stringify(nextState));
     return true;
   } catch (error) {
     console.warn("Failed to persist shell preferences", error);
@@ -4116,13 +4143,17 @@ function setTerminalDrawer(open: boolean) {
   });
 }
 
-function setContextPanel(open: boolean) {
+function setContextPanel(open: boolean, options?: { preserveWidePreference?: boolean }) {
   contextPanelOpen = open;
   const panel = document.getElementById("context-panel");
   const button = document.getElementById("toggle-context-btn");
   const body = document.getElementById("workspace-body");
   if (!panel || !button || !body) {
     return;
+  }
+
+  if ((options?.preserveWidePreference ?? true) && !isNarrowLayout()) {
+    preferredWideContextOpen = open;
   }
 
   panel.toggleAttribute("hidden", !open);
@@ -4150,13 +4181,17 @@ function isNarrowLayout() {
   return window.matchMedia("(max-width: 1180px)").matches;
 }
 
-function setSidebarOpen(open: boolean) {
+function setSidebarOpen(open: boolean, options?: { preserveWidePreference?: boolean }) {
   sidebarOpen = open;
   const shell = document.getElementById("app-shell");
   const overlay = document.getElementById("sidebar-overlay");
   const button = document.getElementById("toggle-sidebar-btn");
   if (!shell || !overlay || !button) {
     return;
+  }
+
+  if ((options?.preserveWidePreference ?? true) && !isNarrowLayout()) {
+    preferredWideSidebarOpen = open;
   }
 
   shell.classList.toggle("sidebar-open", open);
@@ -4200,13 +4235,11 @@ function cancelSettingsDraft() {
 
 function syncResponsiveShell() {
   if (isNarrowLayout()) {
-    setSidebarOpen(false);
-    setContextPanel(false);
+    setSidebarOpen(false, { preserveWidePreference: false });
+    setContextPanel(false, { preserveWidePreference: false });
   } else {
-    setSidebarOpen(true);
-    if (!contextPanelOpen) {
-      setContextPanel(true);
-    }
+    setSidebarOpen(preferredWideSidebarOpen, { preserveWidePreference: false });
+    setContextPanel(preferredWideContextOpen, { preserveWidePreference: false });
   }
 }
 
@@ -4743,6 +4776,8 @@ function initializeSidebarResize() {
     return;
   }
 
+  appShell.style.setProperty("--sidebar-width", `${sidebarWidth}px`);
+
   handle.addEventListener("pointerdown", (event) => {
     const startX = event.clientX;
     const startWidth = sidebarWidth;
@@ -4753,6 +4788,7 @@ function initializeSidebarResize() {
     const onUp = () => {
       window.removeEventListener("pointermove", onMove);
       window.removeEventListener("pointerup", onUp);
+      void persistThemeState();
     };
     window.addEventListener("pointermove", onMove);
     window.addEventListener("pointerup", onUp);
@@ -4762,9 +4798,12 @@ function initializeSidebarResize() {
 window.addEventListener("DOMContentLoaded", async () => {
   installViewportHarnessHooks();
 
-  const storedThemeState = readStoredThemeState();
-  if (storedThemeState) {
-    applyThemeState(storedThemeState);
+  const storedShellPreferences = readStoredShellPreferences();
+  if (storedShellPreferences) {
+    applyThemeState(storedShellPreferences);
+    sidebarWidth = storedShellPreferences.sidebarWidth;
+    preferredWideSidebarOpen = storedShellPreferences.wideSidebarOpen;
+    preferredWideContextOpen = storedShellPreferences.wideContextOpen;
   }
 
   await subscribeToPtyOutput((payload) => {

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -1829,6 +1829,33 @@ function getSourceEntryTone(entry: SourceChange): SurfaceTone {
   return "info";
 }
 
+function getFooterReviewTone(reviewState: string | undefined): SurfaceTone {
+  switch ((reviewState || "").toUpperCase()) {
+    case "PASS":
+      return "success";
+    case "PENDING":
+      return "warning";
+    case "FAIL":
+    case "FAILED":
+      return "danger";
+    default:
+      return "info";
+  }
+}
+
+function getFooterNextTone(nextAction: string | undefined): SurfaceTone {
+  switch ((nextAction || "").toLowerCase()) {
+    case "blocked":
+    case "reconcile_consult":
+      return "warning";
+    case "review":
+    case "dispatch":
+      return "focus";
+    default:
+      return "info";
+  }
+}
+
 function getFooterItems(): { left: FooterStatusItem[]; right: FooterStatusItem[] } {
   const selectedProjection = getPrimaryRunProjection();
   const modeLabel = composerModes.find((item) => item.mode === activeComposerMode)?.label ?? activeComposerMode;
@@ -1838,8 +1865,12 @@ function getFooterItems(): { left: FooterStatusItem[]; right: FooterStatusItem[]
   const inboxStatus = desktopSummarySnapshot
     ? `${desktopSummarySnapshot.inbox.summary.item_count} inbox`
     : "Inbox idle";
-  const branchStatus = selectedProjection?.branch || "main";
   const runStatus = selectedProjection?.label || selectedProjection?.run_id || "No run selected";
+  const reviewStatus = selectedProjection?.review_state || "No review";
+  const nextStatus = selectedProjection?.next_action || "idle";
+  const settingsStatus = settingsSheetOpen
+    ? (settingsDraftState && !themeStatesEqual(settingsDraftState, themeState) ? "Draft" : "Editing")
+    : "Saved";
   const surfaceStatus = selectedPreviewUrl
     ? "Preview"
     : editorSurfaceOpen
@@ -1853,11 +1884,12 @@ function getFooterItems(): { left: FooterStatusItem[]; right: FooterStatusItem[]
       { label: "Mode", value: modeLabel, tone: "focus" },
       { label: "Surface", value: surfaceStatus },
       { label: "Command", value: "Ctrl/Cmd+K", tone: "accent" },
-      { label: "Settings", value: settingsSheetOpen ? "Editing" : "Preferences", tone: "accent" },
+      { label: "Settings", value: settingsStatus, tone: "accent" },
     ],
     right: [
       { label: "Run", value: runStatus },
-      { label: "Branch", value: branchStatus },
+      { label: "Review", value: reviewStatus, tone: getFooterReviewTone(selectedProjection?.review_state) },
+      { label: "Next", value: nextStatus, tone: getFooterNextTone(selectedProjection?.next_action) },
       { label: "Inbox", value: inboxStatus },
       { label: "Board", value: summaryStatus, tone: desktopSummarySnapshot ? "info" : "success" },
     ],
@@ -1870,6 +1902,12 @@ function cloneThemeState(state: ThemeState): ThemeState {
     density: state.density,
     wrapMode: state.wrapMode,
   };
+}
+
+function themeStatesEqual(left: ThemeState, right: ThemeState) {
+  return left.theme === right.theme
+    && left.density === right.density
+    && left.wrapMode === right.wrapMode;
 }
 
 function readStoredShellPreferences(): ShellPreferenceState | null {
@@ -1966,6 +2004,7 @@ function renderPreferenceOptions<T extends string>(
 
 function renderSettingsControls() {
   const activeState = settingsDraftState ?? themeState;
+  const applyButton = document.getElementById("apply-settings-btn") as HTMLButtonElement | null;
 
   renderPreferenceOptions("theme-options", themeOptions, activeState.theme, (value) => {
     if (!settingsDraftState) {
@@ -1990,6 +2029,14 @@ function renderSettingsControls() {
     settingsDraftState.wrapMode = value;
     renderSettingsControls();
   });
+
+  if (applyButton) {
+    const hasChanges = Boolean(settingsDraftState && !themeStatesEqual(settingsDraftState, themeState));
+    applyButton.disabled = !hasChanges;
+    applyButton.setAttribute("aria-disabled", hasChanges ? "false" : "true");
+  }
+
+  renderFooterLane();
 }
 
 function renderFooterLane() {

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -1887,14 +1887,17 @@ function getFooterOperatorStatus(projection: DesktopRunProjection | undefined) {
   if (taskState === "blocked") {
     return { label: "Blocked", tone: "danger" as SurfaceTone };
   }
+  if (taskState === "commit_ready") {
+    return { label: "Commit ready", tone: "success" as SurfaceTone };
+  }
+  if (taskState === "completed" || taskState === "task_completed" || taskState === "done") {
+    return { label: "Completed", tone: "success" as SurfaceTone };
+  }
   if (projection.verification_outcome) {
     return {
       label: `Verify ${projection.verification_outcome}`,
       tone: projection.verification_outcome.toUpperCase() === "PASS" ? "success" as SurfaceTone : "warning" as SurfaceTone,
     };
-  }
-  if (taskState === "completed" || taskState === "task_completed" || taskState === "done") {
-    return { label: "Completed", tone: "success" as SurfaceTone };
   }
   if (projection.next_action) {
     return {
@@ -1906,6 +1909,21 @@ function getFooterOperatorStatus(projection: DesktopRunProjection | undefined) {
     label: projection.task_state || "Tracking",
     tone: "info" as SurfaceTone,
   };
+}
+
+function getFooterSettingsTone(status: string): SurfaceTone {
+  switch (status) {
+    case "Draft":
+      return "warning";
+    case "Editing":
+      return "info";
+    case "Ready":
+      return "focus";
+    case "Saved":
+      return "success";
+    default:
+      return "accent";
+  }
 }
 
 function getFooterItems(): { left: FooterStatusItem[]; right: FooterStatusItem[] } {
@@ -1928,7 +1946,7 @@ function getFooterItems(): { left: FooterStatusItem[]; right: FooterStatusItem[]
       { label: "Mode", value: modeLabel, tone: "focus" },
       { label: "Surface", value: surfaceStatus },
       { label: "Command", value: "Ctrl/Cmd+K", tone: "accent" },
-      { label: "Settings", value: settingsStatus, tone: "accent" },
+      { label: "Settings", value: settingsStatus, tone: getFooterSettingsTone(settingsStatus) },
     ],
     right: [
       { label: "Run", value: runStatus },

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -1933,6 +1933,64 @@ function getFooterInboxTone(count: number): SurfaceTone {
   return "success";
 }
 
+function getFooterContextItem(settingsStatus: string): FooterStatusItem {
+  if (commandBarOpen) {
+    const actions = getFilteredCommandActions();
+    const activeAction = actions[Math.min(selectedCommandIndex, Math.max(0, actions.length - 1))];
+    const query = commandBarQuery.trim();
+    return {
+      label: "Context",
+      value: query ? `Search ${query}` : (activeAction?.label || "Search actions"),
+      tone: "focus",
+    };
+  }
+
+  if (settingsSheetOpen) {
+    return {
+      label: "Context",
+      value: `Settings ${settingsStatus}`,
+      tone: getFooterSettingsTone(settingsStatus),
+    };
+  }
+
+  if (selectedPreviewUrl) {
+    const previewTarget = detectedPreviewTargets.get(selectedPreviewUrl);
+    if (previewTarget) {
+      return {
+        label: "Context",
+        value: `${previewTarget.portLabel} · ${previewTarget.sourceLabel}`,
+        tone: "accent",
+      };
+    }
+  }
+
+  if (editorSurfaceOpen) {
+    const editors = getEditorFiles();
+    const selected = editors.find((editor) => editor.key === selectedEditorKey) || editors[0];
+    if (selected) {
+      return {
+        label: "Context",
+        value: selected.path.split("/").pop() ?? selected.path,
+        tone: selected.origin === "context" ? "focus" : "info",
+      };
+    }
+  }
+
+  if (terminalDrawerOpen) {
+    return {
+      label: "Context",
+      value: "Utility drawer",
+      tone: "info",
+    };
+  }
+
+  return {
+    label: "Context",
+    value: "Ctrl/Cmd+K",
+    tone: "accent",
+  };
+}
+
 function getFooterItems(): { left: FooterStatusItem[]; right: FooterStatusItem[] } {
   const selectedProjection = getPrimaryRunProjection();
   const modeLabel = composerModes.find((item) => item.mode === activeComposerMode)?.label ?? activeComposerMode;
@@ -1946,12 +2004,13 @@ function getFooterItems(): { left: FooterStatusItem[]; right: FooterStatusItem[]
     ? (themeStatesEqual(settingsDraftState, themeState) ? (settingsSheetOpen ? "Editing" : "Ready") : "Draft")
     : "Saved";
   const surfaceStatus = getFooterSurfaceStatus();
+  const contextItem = getFooterContextItem(settingsStatus);
 
   return {
     left: [
       { label: "Mode", value: modeLabel, tone: "focus" },
       { label: "Surface", value: surfaceStatus },
-      { label: "Command", value: "Ctrl/Cmd+K", tone: "accent" },
+      contextItem,
       { label: "Settings", value: settingsStatus, tone: getFooterSettingsTone(settingsStatus) },
     ],
     right: [

--- a/winsmux-app/src/styles.css
+++ b/winsmux-app/src/styles.css
@@ -974,6 +974,12 @@ textarea {
   gap: 10px;
 }
 
+.settings-sheet-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
 .panel-title {
   font-size: var(--text-sm);
   font-weight: 700;


### PR DESCRIPTION
## Summary
- add draft/apply/cancel handling for shell preferences in the settings sheet
- persist applied theme, density, and wrap preferences to local storage
- rework the footer lane to show operator state instead of always-on chrome labels

## Validation
- cmd /c npm run build
- pwsh -NoProfile -File .\\scripts\\git-guard.ps1 -Mode full
- pwsh -NoProfile -File .\\scripts\\audit-public-surface.ps1
