### PR TITLE
TASK-107: polish editor surface header context

### DIFF
--- a/winsmux-app/index.html
+++ b/winsmux-app/index.html
@@ -118,7 +118,7 @@
               <div class="panel-title" id="editor-surface-title">Editor</div>
               <button class="ghost-btn ghost-btn-small" id="close-editor-btn" type="button">Close</button>
             </div>
-            <div id="editor-surface-summary"></div>
+            <div id="editor-surface-summary" hidden></div>
             <div id="editor-file-path">winsmux-app/src/main.ts</div>
             <div id="editor-meta-row"></div>
             <div id="editor-diff-preview" hidden></div>

--- a/winsmux-app/index.html
+++ b/winsmux-app/index.html
@@ -118,6 +118,7 @@
               <div class="panel-title">Editor</div>
               <button class="ghost-btn ghost-btn-small" id="close-editor-btn" type="button">Close</button>
             </div>
+            <div id="editor-surface-summary"></div>
             <div id="editor-file-path">winsmux-app/src/main.ts</div>
             <div id="editor-meta-row"></div>
             <div id="editor-diff-preview" hidden></div>

--- a/winsmux-app/index.html
+++ b/winsmux-app/index.html
@@ -115,7 +115,7 @@
 
           <aside id="editor-surface" hidden>
             <div class="panel-title-row">
-              <div class="panel-title">Editor</div>
+              <div class="panel-title" id="editor-surface-title">Editor</div>
               <button class="ghost-btn ghost-btn-small" id="close-editor-btn" type="button">Close</button>
             </div>
             <div id="editor-surface-summary"></div>

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -3589,7 +3589,10 @@ function renderEditorSurface() {
     tabs.innerHTML = "";
     code.textContent = "No backend preview cached.";
     code.hidden = false;
-    statusbar.textContent = "Secondary work surface: 0 projected files";
+    renderEditorStatusbar(statusbar, [
+      { label: "Surface", value: "Idle" },
+      { label: "Files", value: "0 projected" },
+    ]);
     return;
   }
   if (selected && !previewModeActive) {
@@ -3700,9 +3703,14 @@ function renderEditorSurface() {
     browserOpenButton.disabled = false;
     code.textContent = "";
     code.hidden = true;
-    statusbar.textContent =
-      `Secondary work surface: preview -> ${previewTarget.url}` +
-      `${lastPreviewExternalState?.url === previewTarget.url ? (lastPreviewExternalState.ok ? " (opened externally)" : " (external blocked)") : ""}`;
+    renderEditorStatusbar(statusbar, [
+      { label: "Surface", value: "Preview" },
+      { label: "Target", value: previewTarget.portLabel },
+      { label: "Source", value: previewTarget.sourceLabel },
+      ...(lastPreviewExternalState?.url === previewTarget.url
+        ? [{ label: "External", value: lastPreviewExternalState.ok ? "Opened" : "Blocked" }]
+        : []),
+    ]);
   } else if (selected) {
     title.textContent = selectedTarget?.sourceChange ? "Diff review" : "Editor";
     path.textContent = selected.path;
@@ -3774,7 +3782,11 @@ function renderEditorSurface() {
       diffPreview.hidden = false;
     }
     code.textContent = selected.content;
-    statusbar.textContent = `Secondary work surface: ${selected.origin === "context" ? "run context" : "explorer"} -> ${selectedWorktreeLabel ? `${selectedWorktreeLabel} / ` : ""}${selected.path}`;
+    renderEditorStatusbar(statusbar, [
+      { label: "Surface", value: selectedTarget?.sourceChange ? "Diff review" : "Editor" },
+      { label: "Source", value: selected.origin === "context" ? "Run context" : "Explorer" },
+      ...(selectedWorktreeLabel ? [{ label: "Worktree", value: selectedWorktreeLabel }] : []),
+    ]);
   }
   tabs.innerHTML = "";
 
@@ -3787,6 +3799,29 @@ function renderEditorSurface() {
       void openEditorTarget(getEditorTargetByKey(editor.key));
     });
     tabs.appendChild(tab);
+  }
+}
+
+function renderEditorStatusbar(
+  root: HTMLElement,
+  items: Array<{ label: string; value: string }>,
+) {
+  root.innerHTML = "";
+  for (const item of items) {
+    const entry = document.createElement("span");
+    entry.className = "editor-status-item";
+
+    const label = document.createElement("span");
+    label.className = "editor-status-label";
+    label.textContent = item.label;
+
+    const value = document.createElement("span");
+    value.className = "editor-status-value";
+    value.textContent = item.value;
+
+    entry.appendChild(label);
+    entry.appendChild(value);
+    root.appendChild(entry);
   }
 }
 

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -3577,6 +3577,7 @@ function renderEditorSurface() {
     title.textContent = "Editor";
     path.textContent = "Editor idle";
     summary.innerHTML = "";
+    summary.hidden = true;
     meta.innerHTML = "";
     diffPreview.innerHTML = "";
     diffPreview.hidden = true;
@@ -3604,6 +3605,7 @@ function renderEditorSurface() {
 
   meta.innerHTML = "";
   summary.innerHTML = "";
+  summary.hidden = true;
   diffPreview.innerHTML = "";
   diffPreview.hidden = true;
   browserMeta.innerHTML = "";
@@ -3631,6 +3633,7 @@ function renderEditorSurface() {
       chip.textContent = item;
       summary.appendChild(chip);
     }
+    summary.hidden = summary.childElementCount === 0;
     for (const item of [
       "Preview browser",
       previewTarget.portLabel,
@@ -3724,6 +3727,7 @@ function renderEditorSurface() {
       diffChip.textContent = "Diff review";
       summary.appendChild(diffChip);
     }
+    summary.hidden = summary.childElementCount === 0;
     for (const item of [
       selected.language,
       `${selected.lineCount} lines`,

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -3547,6 +3547,7 @@ function trapCommandBarTab(event: KeyboardEvent) {
 }
 
 function renderEditorSurface() {
+  const title = document.getElementById("editor-surface-title");
   const summary = document.getElementById("editor-surface-summary");
   const path = document.getElementById("editor-file-path");
   const meta = document.getElementById("editor-meta-row");
@@ -3563,7 +3564,7 @@ function renderEditorSurface() {
   const tabs = document.getElementById("editor-tabs");
   const code = document.getElementById("editor-code");
   const statusbar = document.getElementById("editor-statusbar");
-  if (!summary || !path || !meta || !diffPreview || !browserSurface || !browserFrame || !browserMeta || !browserTargetList || !browserToolbarSummary || !browserBackButton || !browserCopyButton || !browserReloadButton || !browserOpenButton || !tabs || !code || !statusbar) {
+  if (!title || !summary || !path || !meta || !diffPreview || !browserSurface || !browserFrame || !browserMeta || !browserTargetList || !browserToolbarSummary || !browserBackButton || !browserCopyButton || !browserReloadButton || !browserOpenButton || !tabs || !code || !statusbar) {
     return;
   }
 
@@ -3573,6 +3574,7 @@ function renderEditorSurface() {
   const previewTargets = getPreviewTargets();
   const previewModeActive = editorSurfaceMode === "preview" && Boolean(previewTarget);
   if (!selected && !previewModeActive) {
+    title.textContent = "Editor";
     path.textContent = "Editor idle";
     summary.innerHTML = "";
     meta.innerHTML = "";
@@ -3616,6 +3618,7 @@ function renderEditorSurface() {
   code.hidden = false;
 
   if (previewModeActive && previewTarget) {
+    title.textContent = "Preview";
     path.textContent = previewTarget.url;
     for (const item of [
       "Preview",
@@ -3698,6 +3701,7 @@ function renderEditorSurface() {
       `Secondary work surface: preview -> ${previewTarget.url}` +
       `${lastPreviewExternalState?.url === previewTarget.url ? (lastPreviewExternalState.ok ? " (opened externally)" : " (external blocked)") : ""}`;
   } else if (selected) {
+    title.textContent = selectedTarget?.sourceChange ? "Diff review" : "Editor";
     path.textContent = selected.path;
     for (const item of [
       "Code",

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -3547,6 +3547,7 @@ function trapCommandBarTab(event: KeyboardEvent) {
 }
 
 function renderEditorSurface() {
+  const summary = document.getElementById("editor-surface-summary");
   const path = document.getElementById("editor-file-path");
   const meta = document.getElementById("editor-meta-row");
   const diffPreview = document.getElementById("editor-diff-preview");
@@ -3562,7 +3563,7 @@ function renderEditorSurface() {
   const tabs = document.getElementById("editor-tabs");
   const code = document.getElementById("editor-code");
   const statusbar = document.getElementById("editor-statusbar");
-  if (!path || !meta || !diffPreview || !browserSurface || !browserFrame || !browserMeta || !browserTargetList || !browserToolbarSummary || !browserBackButton || !browserCopyButton || !browserReloadButton || !browserOpenButton || !tabs || !code || !statusbar) {
+  if (!summary || !path || !meta || !diffPreview || !browserSurface || !browserFrame || !browserMeta || !browserTargetList || !browserToolbarSummary || !browserBackButton || !browserCopyButton || !browserReloadButton || !browserOpenButton || !tabs || !code || !statusbar) {
     return;
   }
 
@@ -3573,6 +3574,7 @@ function renderEditorSurface() {
   const previewModeActive = editorSurfaceMode === "preview" && Boolean(previewTarget);
   if (!selected && !previewModeActive) {
     path.textContent = "Editor idle";
+    summary.innerHTML = "";
     meta.innerHTML = "";
     diffPreview.innerHTML = "";
     diffPreview.hidden = true;
@@ -3599,6 +3601,7 @@ function renderEditorSurface() {
     : "";
 
   meta.innerHTML = "";
+  summary.innerHTML = "";
   diffPreview.innerHTML = "";
   diffPreview.hidden = true;
   browserMeta.innerHTML = "";
@@ -3614,6 +3617,17 @@ function renderEditorSurface() {
 
   if (previewModeActive && previewTarget) {
     path.textContent = previewTarget.url;
+    for (const item of [
+      "Preview",
+      previewTarget.portLabel,
+      previewTarget.sourceLabel,
+    ]) {
+      const chip = document.createElement("span");
+      chip.className = "editor-meta-chip";
+      chip.dataset.tone = item === "Preview" ? "focus" : "default";
+      chip.textContent = item;
+      summary.appendChild(chip);
+    }
     for (const item of [
       "Preview browser",
       previewTarget.portLabel,
@@ -3685,6 +3699,27 @@ function renderEditorSurface() {
       `${lastPreviewExternalState?.url === previewTarget.url ? (lastPreviewExternalState.ok ? " (opened externally)" : " (external blocked)") : ""}`;
   } else if (selected) {
     path.textContent = selected.path;
+    for (const item of [
+      "Code",
+      selected.origin === "context" ? "Run context" : "Explorer",
+      selectedWorktreeLabel,
+    ]) {
+      if (!item) {
+        continue;
+      }
+      const chip = document.createElement("span");
+      chip.className = "editor-meta-chip";
+      chip.dataset.tone = item === "Code" ? "focus" : "default";
+      chip.textContent = item;
+      summary.appendChild(chip);
+    }
+    if (selectedTarget?.sourceChange) {
+      const diffChip = document.createElement("span");
+      diffChip.className = "editor-meta-chip";
+      diffChip.dataset.tone = "focus";
+      diffChip.textContent = "Diff review";
+      summary.appendChild(diffChip);
+    }
     for (const item of [
       selected.language,
       `${selected.lineCount} lines`,

--- a/winsmux-app/src/styles.css
+++ b/winsmux-app/src/styles.css
@@ -1178,7 +1178,28 @@ textarea {
 }
 
 #editor-statusbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
   font-size: var(--text-2xs);
+  color: #8c96b4;
+}
+
+.editor-status-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+
+.editor-status-label {
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.editor-status-value {
+  min-width: 0;
   color: #8c96b4;
 }
 
@@ -1843,6 +1864,10 @@ textarea {
 
   #editor-surface-summary,
   #editor-meta-row {
+    gap: 6px;
+  }
+
+  #editor-statusbar {
     gap: 6px;
   }
 

--- a/winsmux-app/src/styles.css
+++ b/winsmux-app/src/styles.css
@@ -994,6 +994,14 @@ textarea {
   font-size: var(--text-xs);
   color: #8c96b4;
   font-family: var(--font-code);
+  display: block;
+  min-width: 0;
+  overflow-x: auto;
+  white-space: nowrap;
+  padding: 10px 12px;
+  border: 1px solid var(--border-muted);
+  border-radius: 14px;
+  background: var(--bg-surface);
 }
 
 #editor-surface-summary {
@@ -1006,6 +1014,10 @@ textarea {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
+}
+
+#editor-file-path::-webkit-scrollbar {
+  height: 8px;
 }
 
 #editor-diff-preview {

--- a/winsmux-app/src/styles.css
+++ b/winsmux-app/src/styles.css
@@ -1028,6 +1028,7 @@ textarea {
   border: 1px solid var(--border-muted);
   border-radius: 16px;
   background: var(--bg-surface);
+  overflow: hidden;
 }
 
 .editor-diff-preview-title {
@@ -1040,12 +1041,16 @@ textarea {
 .editor-diff-preview-body {
   font-size: var(--text-sm);
   color: var(--text-primary);
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
 }
 
 .editor-diff-preview-meta {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
+  padding-top: 8px;
+  border-top: 1px solid var(--border-muted);
 }
 
 #browser-surface {
@@ -1117,17 +1122,25 @@ textarea {
 
 #editor-tabs {
   display: flex;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   gap: 8px;
+  overflow-x: auto;
+  padding-bottom: 4px;
+}
+
+#editor-tabs::-webkit-scrollbar {
+  height: 8px;
 }
 
 .editor-tab {
+  flex: 0 0 auto;
   border: 1px solid var(--border-muted);
   border-radius: 999px;
   background: var(--bg-surface-raised);
   color: var(--text-secondary);
   padding: 6px 10px;
   cursor: pointer;
+  white-space: nowrap;
 }
 
 .editor-tab.is-active,

--- a/winsmux-app/src/styles.css
+++ b/winsmux-app/src/styles.css
@@ -996,6 +996,12 @@ textarea {
   font-family: var(--font-code);
 }
 
+#editor-surface-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
 #editor-meta-row {
   display: flex;
   flex-wrap: wrap;

--- a/winsmux-app/src/styles.css
+++ b/winsmux-app/src/styles.css
@@ -1073,15 +1073,22 @@ textarea {
 
 #browser-target-list {
   display: flex;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   gap: 8px;
+  overflow-x: auto;
+  padding-bottom: 4px;
 }
 
 #browser-target-list[hidden] {
   display: none;
 }
 
+#browser-target-list::-webkit-scrollbar {
+  height: 8px;
+}
+
 #browser-target-list .editor-tab {
+  flex: 0 0 auto;
   background: var(--bg-surface);
 }
 
@@ -1821,6 +1828,46 @@ textarea {
     grid-template-columns: minmax(0, 1fr);
   }
 
+  #editor-surface {
+    gap: 10px;
+    padding: 12px;
+  }
+
+  #editor-surface .panel-title-row {
+    align-items: flex-start;
+  }
+
+  #editor-file-path {
+    padding: 8px 10px;
+  }
+
+  #editor-surface-summary,
+  #editor-meta-row {
+    gap: 6px;
+  }
+
+  #editor-tabs {
+    gap: 6px;
+  }
+
+  #browser-toolbar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  #browser-toolbar-summary {
+    flex-basis: auto;
+  }
+
+  #browser-meta-row {
+    padding: 10px 12px;
+  }
+
+  #browser-toolbar .ghost-btn {
+    width: 100%;
+    justify-content: center;
+  }
+
   #footer-right {
     justify-content: flex-start;
   }
@@ -1914,6 +1961,15 @@ textarea {
 }
 
 @media (max-width: 1180px) and (max-height: 760px) {
+  #editor-surface {
+    gap: 8px;
+    padding: 10px;
+  }
+
+  #editor-file-path {
+    padding: 7px 9px;
+  }
+
   #terminal-drawer {
     left: 20px;
     right: 20px;


### PR DESCRIPTION
## Summary
- add a secondary-surface summary row under the editor title
- surface code/preview/diff context before the file path row
- keep preview and diff handoff visible without changing the main layout

## Validation
- cmd /c npm run build
- pwsh -NoProfile -File .\\scripts\\git-guard.ps1 -Mode full
- pwsh -NoProfile -File .\\scripts\\audit-public-surface.ps1