### PR TITLE
TASK-107: continue editor surface polish

### DIFF
--- a/winsmux-app/index.html
+++ b/winsmux-app/index.html
@@ -120,7 +120,7 @@
             </div>
             <div id="editor-surface-summary" hidden></div>
             <div id="editor-file-path">winsmux-app/src/main.ts</div>
-            <div id="editor-meta-row"></div>
+            <div id="editor-meta-row" hidden></div>
             <div id="editor-diff-preview" hidden></div>
             <div id="editor-tabs"></div>
             <div id="browser-surface" hidden>

--- a/winsmux-app/index.html
+++ b/winsmux-app/index.html
@@ -124,7 +124,7 @@
             <div id="editor-diff-preview" hidden></div>
             <div id="editor-tabs"></div>
             <div id="browser-surface" hidden>
-              <div id="browser-meta-row"></div>
+              <div id="browser-meta-row" hidden></div>
               <div id="browser-target-list" hidden></div>
               <div id="browser-toolbar">
                 <div id="browser-toolbar-summary"></div>

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -3582,6 +3582,7 @@ function renderEditorSurface() {
     diffPreview.innerHTML = "";
     diffPreview.hidden = true;
     browserMeta.innerHTML = "";
+    browserMeta.hidden = true;
     browserTargetList.innerHTML = "";
     browserTargetList.hidden = true;
     browserFrame.src = "about:blank";
@@ -3612,6 +3613,7 @@ function renderEditorSurface() {
   diffPreview.innerHTML = "";
   diffPreview.hidden = true;
   browserMeta.innerHTML = "";
+  browserMeta.hidden = true;
   browserTargetList.innerHTML = "";
   browserToolbarSummary.textContent = "";
   browserTargetList.hidden = true;
@@ -3646,14 +3648,6 @@ function renderEditorSurface() {
       chip.textContent = item;
       meta.appendChild(chip);
     }
-    const browserTitle = document.createElement("div");
-    browserTitle.className = "editor-diff-preview-title";
-    browserTitle.textContent = "Preview target";
-    const browserBody = document.createElement("div");
-    browserBody.className = "editor-diff-preview-body";
-    browserBody.textContent = previewTarget.url;
-    browserMeta.appendChild(browserTitle);
-    browserMeta.appendChild(browserBody);
     if (lastPreviewExternalState?.url === previewTarget.url) {
       const openedAt = new Date(lastPreviewExternalState.at).toLocaleTimeString([], {
         hour: "2-digit",
@@ -3667,6 +3661,7 @@ function renderEditorSurface() {
       handoffBody.textContent = lastPreviewExternalState.ok ? `Opened at ${openedAt}` : `Blocked at ${openedAt}`;
       browserMeta.appendChild(handoffTitle);
       browserMeta.appendChild(handoffBody);
+      browserMeta.hidden = false;
     }
     if (previewTargets.length > 0) {
       for (const target of previewTargets) {

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -3639,8 +3639,6 @@ function renderEditorSurface() {
     summary.hidden = summary.childElementCount === 0;
     for (const item of [
       "Preview browser",
-      previewTarget.portLabel,
-      `Detected from ${previewTarget.sourceLabel}`,
       `Seen ${formatPreviewSeenAt(previewTarget.lastSeenAt)}`,
     ]) {
       const chip = document.createElement("span");
@@ -3740,8 +3738,6 @@ function renderEditorSurface() {
       selected.language,
       `${selected.lineCount} lines`,
       selected.modified ? "Modified" : "Saved",
-      selected.origin === "context" ? "Opened from context" : "Opened from explorer",
-      selectedWorktreeLabel,
     ]) {
       if (!item) {
         continue;

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -3579,6 +3579,7 @@ function renderEditorSurface() {
     summary.innerHTML = "";
     summary.hidden = true;
     meta.innerHTML = "";
+    meta.hidden = true;
     diffPreview.innerHTML = "";
     diffPreview.hidden = true;
     browserMeta.innerHTML = "";
@@ -3608,6 +3609,7 @@ function renderEditorSurface() {
     : "";
 
   meta.innerHTML = "";
+  meta.hidden = true;
   summary.innerHTML = "";
   summary.hidden = true;
   diffPreview.innerHTML = "";
@@ -3639,15 +3641,6 @@ function renderEditorSurface() {
       summary.appendChild(chip);
     }
     summary.hidden = summary.childElementCount === 0;
-    for (const item of [
-      "Preview browser",
-      `Seen ${formatPreviewSeenAt(previewTarget.lastSeenAt)}`,
-    ]) {
-      const chip = document.createElement("span");
-      chip.className = "editor-meta-chip";
-      chip.textContent = item;
-      meta.appendChild(chip);
-    }
     if (lastPreviewExternalState?.url === previewTarget.url) {
       const openedAt = new Date(lastPreviewExternalState.at).toLocaleTimeString([], {
         hour: "2-digit",
@@ -3700,6 +3693,7 @@ function renderEditorSurface() {
       { label: "Surface", value: "Preview" },
       { label: "Target", value: previewTarget.portLabel },
       { label: "Source", value: previewTarget.sourceLabel },
+      { label: "Seen", value: formatPreviewSeenAt(previewTarget.lastSeenAt) },
       ...(lastPreviewExternalState?.url === previewTarget.url
         ? [{ label: "External", value: lastPreviewExternalState.ok ? "Opened" : "Blocked" }]
         : []),
@@ -3743,6 +3737,7 @@ function renderEditorSurface() {
       chip.textContent = item;
       meta.appendChild(chip);
     }
+    meta.hidden = meta.childElementCount === 0;
     if (selectedTarget?.sourceChange) {
       const previewTitle = document.createElement("div");
       previewTitle.className = "editor-diff-preview-title";

--- a/winsmux-app/src/styles.css
+++ b/winsmux-app/src/styles.css
@@ -1864,15 +1864,33 @@ textarea {
 
   #editor-surface-summary,
   #editor-meta-row {
+    flex-wrap: nowrap;
     gap: 6px;
+    overflow-x: auto;
+    padding-bottom: 4px;
   }
 
   #editor-statusbar {
+    flex-wrap: nowrap;
     gap: 6px;
+    overflow-x: auto;
+    padding-bottom: 4px;
   }
 
   #editor-tabs {
     gap: 6px;
+  }
+
+  #editor-surface-summary::-webkit-scrollbar,
+  #editor-meta-row::-webkit-scrollbar,
+  #editor-statusbar::-webkit-scrollbar {
+    height: 8px;
+  }
+
+  #editor-surface-summary .editor-meta-chip,
+  #editor-meta-row .editor-meta-chip,
+  .editor-status-item {
+    flex: 0 0 auto;
   }
 
   #browser-toolbar {


### PR DESCRIPTION
## Summary
- keep trimming duplicated secondary-surface metadata after #509
- reduce preview overlap between path, meta, and status rows
- keep the follow-up bundle focused on editor/preview layout polish

## Validation
- cmd /c npm run build
- pwsh -NoProfile -File .\\scripts\\git-guard.ps1 -Mode full
- pwsh -NoProfile -File .\\scripts\\audit-public-surface.ps1