### PR TITLE
Add detached secondary surface pop-out

### DIFF
--- a/winsmux-app/index.html
+++ b/winsmux-app/index.html
@@ -116,7 +116,10 @@
           <aside id="editor-surface" hidden>
             <div class="panel-title-row">
               <div class="panel-title" id="editor-surface-title">Editor</div>
-              <button class="ghost-btn ghost-btn-small" id="close-editor-btn" type="button">Close</button>
+              <div class="panel-title-actions">
+                <button class="ghost-btn ghost-btn-small" id="popout-editor-btn" type="button">Pop out</button>
+                <button class="ghost-btn ghost-btn-small" id="close-editor-btn" type="button">Close</button>
+              </div>
             </div>
             <div id="editor-surface-summary" hidden></div>
             <div id="editor-file-path">winsmux-app/src/main.ts</div>

--- a/winsmux-app/scripts/viewport-harness.mjs
+++ b/winsmux-app/scripts/viewport-harness.mjs
@@ -266,6 +266,16 @@ async function assertPopoutShell(popup, visibleSelector) {
     throw new Error("Pop-out window did not enter detached surface mode");
   }
   await popup.locator("#workspace-header").waitFor({ state: "visible" });
+  await popup.waitForFunction(() => {
+    const title = document.querySelector("#workspace-title");
+    const subtitle = document.querySelector("#workspace-subtitle");
+    return (
+      title instanceof HTMLElement &&
+      subtitle instanceof HTMLElement &&
+      Boolean(title.textContent?.trim()) &&
+      subtitle.textContent?.includes("Detached secondary surface")
+    );
+  });
   await popup.locator("#conversation-panel").waitFor({ state: "hidden" });
   await popup.locator("#context-panel").waitFor({ state: "hidden" });
   await popup.locator("#workspace-footer").waitFor({ state: "hidden" });

--- a/winsmux-app/scripts/viewport-harness.mjs
+++ b/winsmux-app/scripts/viewport-harness.mjs
@@ -283,16 +283,38 @@ async function assertPopoutShell(popup, visibleSelector) {
   await assertHorizontallyVisible(popup, "#editor-surface");
 }
 
+async function assertDetachedSessionEntry(page, expectedName) {
+  await page.waitForFunction((name) => {
+    const rows = Array.from(document.querySelectorAll("#session-list .sidebar-row"));
+    return rows.some((row) => {
+      const title = row.querySelector(".sidebar-row-title");
+      return title instanceof HTMLElement && title.textContent?.trim() === name;
+    });
+  }, expectedName);
+}
+
+async function assertDetachedSessionEntryCleared(page, expectedName) {
+  await page.waitForFunction((name) => {
+    const rows = Array.from(document.querySelectorAll("#session-list .sidebar-row"));
+    return rows.every((row) => {
+      const title = row.querySelector(".sidebar-row-title");
+      return !(title instanceof HTMLElement) || title.textContent?.trim() !== name;
+    });
+  }, expectedName);
+}
+
 async function assertPreviewPopout(page) {
   const popupPromise = page.waitForEvent("popup");
   await page.click("#popout-editor-btn");
   const popup = await popupPromise;
+  await assertDetachedSessionEntry(page, "detached-preview");
   await assertPopoutShell(popup, "#browser-surface");
   await popup.locator("#browser-frame").waitFor({ state: "visible" });
   await popup.locator("#browser-toolbar").waitFor({ state: "visible" });
   const closePromise = popup.waitForEvent("close");
   await popup.click("#close-editor-btn");
   await closePromise;
+  await assertDetachedSessionEntryCleared(page, "detached-preview");
   await page.locator("#browser-surface").waitFor({ state: "visible" });
   await page.locator("#browser-toolbar").waitFor({ state: "visible" });
   await assertHorizontallyVisible(page, "#editor-surface");
@@ -302,6 +324,7 @@ async function assertEditorPopout(page) {
   const popupPromise = page.waitForEvent("popup");
   await page.click("#popout-editor-btn");
   const popup = await popupPromise;
+  await assertDetachedSessionEntry(page, "detached-editor");
   await assertPopoutShell(popup, "#editor-code");
   await popup.locator("#editor-file-path").waitFor({ state: "visible" });
   await popup.locator("#editor-statusbar").waitFor({ state: "visible" });
@@ -312,6 +335,7 @@ async function assertEditorPopout(page) {
   const closePromise = popup.waitForEvent("close");
   await popup.click("#close-editor-btn");
   await closePromise;
+  await assertDetachedSessionEntryCleared(page, "detached-editor");
   await page.locator("#editor-code").waitFor({ state: "visible" });
   await page.waitForFunction(() => {
     const target = document.querySelector("#editor-code");

--- a/winsmux-app/scripts/viewport-harness.mjs
+++ b/winsmux-app/scripts/viewport-harness.mjs
@@ -259,6 +259,32 @@ async function assertBackToCode(page) {
   await assertHorizontallyVisible(page, "#editor-code");
 }
 
+async function assertPopoutShell(popup, visibleSelector) {
+  await popup.locator(visibleSelector).waitFor({ state: "visible" });
+  const isPopout = await popup.evaluate(() => document.body.dataset.popoutSurface === "1");
+  if (!isPopout) {
+    throw new Error("Pop-out window did not enter detached surface mode");
+  }
+  await popup.locator("#workspace-header").waitFor({ state: "visible" });
+  await popup.locator("#conversation-panel").waitFor({ state: "hidden" });
+  await popup.locator("#context-panel").waitFor({ state: "hidden" });
+  await popup.locator("#workspace-footer").waitFor({ state: "hidden" });
+  await popup.locator("#header-actions").waitFor({ state: "hidden" });
+  await assertHorizontallyVisible(popup, "#editor-surface");
+}
+
+async function assertPreviewPopout(page) {
+  const popupPromise = page.waitForEvent("popup");
+  await page.click("#popout-editor-btn");
+  const popup = await popupPromise;
+  await assertPopoutShell(popup, "#browser-surface");
+  await popup.locator("#browser-frame").waitFor({ state: "visible" });
+  await popup.locator("#browser-toolbar").waitFor({ state: "visible" });
+  const closePromise = popup.waitForEvent("close");
+  await popup.click("#close-editor-btn");
+  await closePromise;
+}
+
 async function assertPreviewClosed(page) {
   await page.click("#browser-back-btn");
   await page.locator("#browser-surface").waitFor({ state: "hidden" });
@@ -360,6 +386,7 @@ async function verifyDesktopViewport(page, previewUrl) {
   await assertHorizontallyVisible(page, "#browser-toolbar");
   await assertFullyVisible(page, "#browser-frame");
   await assertToolbarActionStates(page);
+  await assertPreviewPopout(page);
   await assertCommandBarRoundtrip(page, "#browser-toolbar");
   await assertSettingsRoundtrip(page, "#browser-toolbar");
 
@@ -519,6 +546,7 @@ async function run() {
             "desktop-source-context-with-terminal-drawer",
             "desktop-preview-browser",
             "desktop-preview-toolbar-actions",
+            "desktop-preview-popout",
             "desktop-command-bar-with-preview",
             "desktop-settings-with-preview",
             "desktop-preview-back-to-code",

--- a/winsmux-app/scripts/viewport-harness.mjs
+++ b/winsmux-app/scripts/viewport-harness.mjs
@@ -293,6 +293,9 @@ async function assertPreviewPopout(page) {
   const closePromise = popup.waitForEvent("close");
   await popup.click("#close-editor-btn");
   await closePromise;
+  await page.locator("#browser-surface").waitFor({ state: "visible" });
+  await page.locator("#browser-toolbar").waitFor({ state: "visible" });
+  await assertHorizontallyVisible(page, "#editor-surface");
 }
 
 async function assertEditorPopout(page) {
@@ -309,6 +312,12 @@ async function assertEditorPopout(page) {
   const closePromise = popup.waitForEvent("close");
   await popup.click("#close-editor-btn");
   await closePromise;
+  await page.locator("#editor-code").waitFor({ state: "visible" });
+  await page.waitForFunction(() => {
+    const target = document.querySelector("#editor-code");
+    return target instanceof HTMLElement && target.textContent?.includes("context + editor");
+  });
+  await assertHorizontallyVisible(page, "#editor-surface");
 }
 
 async function assertPreviewClosed(page) {

--- a/winsmux-app/scripts/viewport-harness.mjs
+++ b/winsmux-app/scripts/viewport-harness.mjs
@@ -285,6 +285,18 @@ async function assertPreviewPopout(page) {
   await closePromise;
 }
 
+async function assertEditorPopout(page) {
+  const popupPromise = page.waitForEvent("popup");
+  await page.click("#popout-editor-btn");
+  const popup = await popupPromise;
+  await assertPopoutShell(popup, "#editor-code");
+  await popup.locator("#editor-file-path").waitFor({ state: "visible" });
+  await popup.locator("#editor-statusbar").waitFor({ state: "visible" });
+  const closePromise = popup.waitForEvent("close");
+  await popup.click("#close-editor-btn");
+  await closePromise;
+}
+
 async function assertPreviewClosed(page) {
   await page.click("#browser-back-btn");
   await page.locator("#browser-surface").waitFor({ state: "hidden" });
@@ -372,6 +384,7 @@ async function verifyDesktopViewport(page, previewUrl) {
   await page.locator("#settings-sheet").waitFor({ state: "hidden" });
 
   await openFirstSourceContextEntry(page);
+  await assertEditorPopout(page);
   await assertCommandBarRoundtrip(page, "#editor-surface");
   await assertSettingsRoundtrip(page, "#editor-surface");
   await assertTerminalDrawerWithSourceContext(page, "#editor-surface", "#context-panel");
@@ -541,6 +554,7 @@ async function run() {
             "desktop-command-bar",
             "desktop-settings-sheet",
             "desktop-source-context",
+            "desktop-editor-popout",
             "desktop-command-bar-with-editor",
             "desktop-settings-with-editor",
             "desktop-source-context-with-terminal-drawer",

--- a/winsmux-app/scripts/viewport-harness.mjs
+++ b/winsmux-app/scripts/viewport-harness.mjs
@@ -292,6 +292,10 @@ async function assertEditorPopout(page) {
   await assertPopoutShell(popup, "#editor-code");
   await popup.locator("#editor-file-path").waitFor({ state: "visible" });
   await popup.locator("#editor-statusbar").waitFor({ state: "visible" });
+  await popup.waitForFunction(() => {
+    const target = document.querySelector("#editor-code");
+    return target instanceof HTMLElement && target.textContent?.includes("context + editor");
+  });
   const closePromise = popup.waitForEvent("close");
   await popup.click("#close-editor-btn");
   await closePromise;

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -120,6 +120,8 @@ type PopoutSurfaceState =
       portLabel: string;
       sourceLabel: string;
       lastSeenAt: number;
+      runId?: string;
+      runLabel?: string;
     }
   | {
       mode: "editor";
@@ -130,6 +132,8 @@ type PopoutSurfaceState =
       modified: boolean;
       sourceChange?: SourceChange | null;
       content?: string;
+      runId?: string;
+      runLabel?: string;
     };
 
 declare global {
@@ -250,6 +254,7 @@ let selectedPreviewUrl = "";
 let lastPreviewExternalState: { url: string; at: number; ok: boolean } | null = null;
 let lastPreviewClipboardState: { url: string; at: number; ok: boolean } | null = null;
 let selectedRunId: string | null = null;
+let detachedSurfaceRunLabel = "";
 let activeComposerMode: ComposerMode = "dispatch";
 let composerSlashOpen = false;
 let composerSlashQuery = "";
@@ -1114,6 +1119,9 @@ function restoreStandaloneEditorFromSnapshot(state: Extract<PopoutSurfaceState, 
 }
 
 function getCurrentEditorSurfaceState(): PopoutSurfaceState | null {
+  const selectedProjection = getPrimaryRunProjection();
+  const runId = selectedProjection?.run_id || undefined;
+  const runLabel = selectedProjection?.label || selectedProjection?.run_id || undefined;
   const previewTarget = selectedPreviewUrl ? detectedPreviewTargets.get(selectedPreviewUrl) ?? null : null;
   if (editorSurfaceMode === "preview" && previewTarget) {
     return {
@@ -1122,6 +1130,8 @@ function getCurrentEditorSurfaceState(): PopoutSurfaceState | null {
       portLabel: previewTarget.portLabel,
       sourceLabel: previewTarget.sourceLabel,
       lastSeenAt: previewTarget.lastSeenAt,
+      runId,
+      runLabel,
     };
   }
 
@@ -1141,6 +1151,8 @@ function getCurrentEditorSurfaceState(): PopoutSurfaceState | null {
     modified: Boolean(selected.modified),
     sourceChange: selectedTarget?.sourceChange ?? null,
     content: isTauri() ? undefined : selected.content,
+    runId,
+    runLabel,
   };
 }
 
@@ -1173,6 +1185,7 @@ function applyPopoutSurfaceState(state: PopoutSurfaceState | null) {
   }
 
   document.body.dataset.popoutSurface = "1";
+  detachedSurfaceRunLabel = state.runLabel ?? state.runId ?? "";
   const title = document.getElementById("workspace-title");
   const subtitle = document.getElementById("workspace-subtitle");
   const editorLabel = state.mode === "editor" ? state.path.split("/").pop() ?? state.path : "";
@@ -1186,8 +1199,8 @@ function applyPopoutSurfaceState(state: PopoutSurfaceState | null) {
   if (subtitle) {
     subtitle.textContent =
       state.mode === "preview"
-        ? `Detached secondary surface from ${state.sourceLabel}.`
-        : `Detached secondary surface for ${editorWorktreeLabel}.`;
+        ? `Detached secondary surface from ${state.sourceLabel}${detachedSurfaceRunLabel ? ` · ${detachedSurfaceRunLabel}` : ""}.`
+        : `Detached secondary surface for ${editorWorktreeLabel}${detachedSurfaceRunLabel ? ` · ${detachedSurfaceRunLabel}` : ""}.`;
   }
 
   setSidebarOpen(false, { preserveWidePreference: false });
@@ -1197,6 +1210,7 @@ function applyPopoutSurfaceState(state: PopoutSurfaceState | null) {
   closeCommandBar();
 
   if (state.mode === "preview") {
+    setSelectedRun(state.runId ?? null);
     registerPreviewTargetForHarness(state.sourceLabel, state.url);
     const target = detectedPreviewTargets.get(state.url);
     if (target) {
@@ -1208,10 +1222,12 @@ function applyPopoutSurfaceState(state: PopoutSurfaceState | null) {
   }
 
   if (typeof state.content === "string") {
+    setSelectedRun(state.runId ?? null);
     restoreStandaloneEditorFromSnapshot({ ...state, content: state.content });
     return;
   }
 
+  setSelectedRun(state.runId ?? null);
   void openEditorPath(state.path, state.worktree);
 }
 
@@ -3873,6 +3889,7 @@ function renderEditorSurface() {
     renderEditorStatusbar(statusbar, [
       { label: "Surface", value: "Preview" },
       ...(detachedSurface ? [{ label: "Window", value: "Detached" }] : []),
+      ...(detachedSurface && detachedSurfaceRunLabel ? [{ label: "Run", value: detachedSurfaceRunLabel }] : []),
       { label: "Target", value: previewTarget.portLabel },
       { label: "Source", value: previewTarget.sourceLabel },
       { label: "Seen", value: formatPreviewSeenAt(previewTarget.lastSeenAt) },
@@ -3955,6 +3972,7 @@ function renderEditorSurface() {
     renderEditorStatusbar(statusbar, [
       { label: "Surface", value: selectedTarget?.sourceChange ? "Diff review" : "Editor" },
       ...(detachedSurface ? [{ label: "Window", value: "Detached" }] : []),
+      ...(detachedSurface && detachedSurfaceRunLabel ? [{ label: "Run", value: detachedSurfaceRunLabel }] : []),
       { label: "Source", value: selected.origin === "context" ? "Run context" : "Explorer" },
       ...(selectedWorktreeLabel ? [{ label: "Worktree", value: selectedWorktreeLabel }] : []),
     ]);

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -125,6 +125,7 @@ type PopoutSurfaceState =
       mode: "editor";
       path: string;
       worktree: string;
+      content?: string;
     };
 
 declare global {
@@ -1109,6 +1110,7 @@ function getCurrentEditorSurfaceState(): PopoutSurfaceState | null {
     mode: "editor",
     path: selected.path,
     worktree: selectedTarget?.worktree ?? "",
+    content: isTauri() ? undefined : selected.content,
   };
 }
 
@@ -1167,6 +1169,11 @@ function applyPopoutSurfaceState(state: PopoutSurfaceState | null) {
       target.lastSeenAt = state.lastSeenAt || target.lastSeenAt;
     }
     openPreviewTarget(state.url);
+    return;
+  }
+
+  if (state.content) {
+    openEditorPreviewForHarness(state.path, state.content, state.worktree);
     return;
   }
 

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -73,6 +73,11 @@ interface SessionItem {
   active?: boolean;
 }
 
+interface DetachedSurfaceSessionState {
+  name: string;
+  meta: string;
+}
+
 interface ExplorerItem {
   label: string;
   meta?: string;
@@ -255,6 +260,8 @@ let lastPreviewExternalState: { url: string; at: number; ok: boolean } | null = 
 let lastPreviewClipboardState: { url: string; at: number; ok: boolean } | null = null;
 let selectedRunId: string | null = null;
 let detachedSurfaceRunLabel = "";
+let detachedSurfaceSession: DetachedSurfaceSessionState | null = null;
+let detachedSurfacePollTimer: number | null = null;
 let activeComposerMode: ComposerMode = "dispatch";
 let composerSlashOpen = false;
 let composerSlashQuery = "";
@@ -490,7 +497,7 @@ function getSessionItems() {
   const inbox = desktopSummarySnapshot.inbox.summary;
   const digest = desktopSummarySnapshot.digest.summary;
 
-  return [
+  const items = [
     {
       name: "winsmux",
       meta: `${board.pane_count} panes · ${inbox.item_count} inbox · ${board.tasks_blocked} blocked`,
@@ -501,6 +508,15 @@ function getSessionItems() {
       meta: `${digest.item_count} runs · ${digest.actionable_items} actionable · ${board.review_pending} review pending`,
     },
   ] satisfies SessionItem[];
+
+  if (detachedSurfaceSession) {
+    items.push({
+      name: detachedSurfaceSession.name,
+      meta: detachedSurfaceSession.meta,
+    });
+  }
+
+  return items;
 }
 
 function getRunProjections() {
@@ -1179,6 +1195,36 @@ function readPopoutSurfaceState() {
   }
 }
 
+function describeDetachedSurfaceSession(state: PopoutSurfaceState): DetachedSurfaceSessionState {
+  if (state.mode === "preview") {
+    return {
+      name: "detached-preview",
+      meta: `${state.portLabel} · ${state.sourceLabel}${state.runLabel ? ` · ${state.runLabel}` : ""}`,
+    };
+  }
+
+  const fileLabel = state.path.split("/").pop() ?? state.path;
+  const worktreeLabel = state.worktree ? getWorktreeLabel(state.worktree) : "Project root";
+  return {
+    name: "detached-editor",
+    meta: `${fileLabel} · ${worktreeLabel}${state.runLabel ? ` · ${state.runLabel}` : ""}`,
+  };
+}
+
+function clearDetachedSurfaceSession() {
+  detachedSurfaceSession = null;
+  if (detachedSurfacePollTimer !== null) {
+    window.clearInterval(detachedSurfacePollTimer);
+    detachedSurfacePollTimer = null;
+  }
+  renderSessions();
+}
+
+function setDetachedSurfaceSession(state: PopoutSurfaceState) {
+  detachedSurfaceSession = describeDetachedSurfaceSession(state);
+  renderSessions();
+}
+
 function applyPopoutSurfaceState(state: PopoutSurfaceState | null) {
   if (!state) {
     return;
@@ -1338,7 +1384,7 @@ async function openEditorSurfacePopout() {
   const popoutUrl = `/?popout=1&popout-key=${encodeURIComponent(key)}`;
   if (isTauri()) {
     const label = `secondary-surface-${Date.now()}`;
-    new WebviewWindow(label, {
+    const detachedWindow = new WebviewWindow(label, {
       url: popoutUrl,
       title: state.mode === "preview" ? "winsmux Preview" : "winsmux Editor",
       width: state.mode === "preview" ? 1180 : 1040,
@@ -1347,10 +1393,26 @@ async function openEditorSurfacePopout() {
       minHeight: 480,
       focus: true,
     });
+    setDetachedSurfaceSession(state);
+    void detachedWindow.once("tauri://destroyed", () => {
+      clearDetachedSurfaceSession();
+    });
     return;
   }
 
-  window.open(popoutUrl, "_blank", "noopener");
+  const popup = window.open(popoutUrl, "_blank", "noopener");
+  if (!popup) {
+    return;
+  }
+  setDetachedSurfaceSession(state);
+  if (detachedSurfacePollTimer !== null) {
+    window.clearInterval(detachedSurfacePollTimer);
+  }
+  detachedSurfacePollTimer = window.setInterval(() => {
+    if (popup.closed) {
+      clearDetachedSurfaceSession();
+    }
+  }, 500);
 }
 
 function getSourceFilterLabel(filter: SourceFilter) {

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -1,6 +1,8 @@
 import { Terminal } from "xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import "xterm/css/xterm.css";
+import { isTauri } from "@tauri-apps/api/core";
+import { WebviewWindow, getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
 import {
   compareDesktopRuns,
   getDesktopEditorFile,
@@ -110,6 +112,20 @@ interface PreviewTarget {
   sourceLabel: string;
   lastSeenAt: number;
 }
+
+type PopoutSurfaceState =
+  | {
+      mode: "preview";
+      url: string;
+      portLabel: string;
+      sourceLabel: string;
+      lastSeenAt: number;
+    }
+  | {
+      mode: "editor";
+      path: string;
+      worktree: string;
+    };
 
 declare global {
   interface Window {
@@ -287,6 +303,7 @@ let settingsDraftState: ThemeState | null = null;
 let preferredWideSidebarOpen = true;
 let preferredWideContextOpen = true;
 const SHELL_PREFERENCES_STORAGE_KEY = "winsmux.shell.preferences.v1";
+const POPOUT_SURFACE_STORAGE_KEY_PREFIX = "winsmux.popout-surface.";
 
 const composerModes: Array<{ mode: ComposerMode; label: string; placeholder: string }> = [
   { mode: "ask", label: "Ask", placeholder: "Ask the Operator for clarification, status, or guidance" },
@@ -1069,6 +1086,93 @@ function openEditorPreviewForHarness(path: string, content: string, worktree = "
   renderRunSummary();
 }
 
+function getCurrentEditorSurfaceState(): PopoutSurfaceState | null {
+  const previewTarget = selectedPreviewUrl ? detectedPreviewTargets.get(selectedPreviewUrl) ?? null : null;
+  if (editorSurfaceMode === "preview" && previewTarget) {
+    return {
+      mode: "preview",
+      url: previewTarget.url,
+      portLabel: previewTarget.portLabel,
+      sourceLabel: previewTarget.sourceLabel,
+      lastSeenAt: previewTarget.lastSeenAt,
+    };
+  }
+
+  const editors = getEditorFiles();
+  const selected = editors.find((editor) => editor.key === selectedEditorKey) || editors[0];
+  if (!selected) {
+    return null;
+  }
+
+  const selectedTarget = getEditorTargetByKey(selected.key);
+  return {
+    mode: "editor",
+    path: selected.path,
+    worktree: selectedTarget?.worktree ?? "",
+  };
+}
+
+function readPopoutSurfaceState() {
+  const searchParams = new URLSearchParams(window.location.search);
+  if (searchParams.get("popout") !== "1") {
+    return null;
+  }
+
+  const key = searchParams.get("popout-key");
+  if (!key) {
+    return null;
+  }
+
+  try {
+    const raw = window.localStorage.getItem(key);
+    if (!raw) {
+      return null;
+    }
+    window.localStorage.removeItem(key);
+    return JSON.parse(raw) as PopoutSurfaceState;
+  } catch {
+    return null;
+  }
+}
+
+function applyPopoutSurfaceState(state: PopoutSurfaceState | null) {
+  if (!state) {
+    return;
+  }
+
+  document.body.dataset.popoutSurface = "1";
+  const title = document.getElementById("workspace-title");
+  const subtitle = document.getElementById("workspace-subtitle");
+  if (title) {
+    title.textContent = state.mode === "preview" ? "Preview pop-out" : "Editor pop-out";
+  }
+  if (subtitle) {
+    subtitle.textContent =
+      state.mode === "preview"
+        ? "Detached secondary surface for localhost preview review."
+        : "Detached secondary surface for code and diff review.";
+  }
+
+  setSidebarOpen(false, { preserveWidePreference: false });
+  setContextPanel(false, { preserveWidePreference: false });
+  setTerminalDrawer(false);
+  setSettingsSheet(false);
+  closeCommandBar();
+
+  if (state.mode === "preview") {
+    registerPreviewTargetForHarness(state.sourceLabel, state.url);
+    const target = detectedPreviewTargets.get(state.url);
+    if (target) {
+      target.portLabel = state.portLabel || target.portLabel;
+      target.lastSeenAt = state.lastSeenAt || target.lastSeenAt;
+    }
+    openPreviewTarget(state.url);
+    return;
+  }
+
+  void openEditorPath(state.path, state.worktree);
+}
+
 function getPreviewTargets(activeUrl = selectedPreviewUrl) {
   return Array.from(detectedPreviewTargets.values()).sort((left, right) => {
     if (activeUrl) {
@@ -1158,6 +1262,37 @@ async function copyPreviewTargetUrl() {
     };
   }
   renderEditorSurface();
+}
+
+async function openEditorSurfacePopout() {
+  const state = getCurrentEditorSurfaceState();
+  if (!state) {
+    return;
+  }
+
+  const key = `${POPOUT_SURFACE_STORAGE_KEY_PREFIX}${Date.now()}`;
+  try {
+    window.localStorage.setItem(key, JSON.stringify(state));
+  } catch {
+    return;
+  }
+
+  const popoutUrl = `/?popout=1&popout-key=${encodeURIComponent(key)}`;
+  if (isTauri()) {
+    const label = `secondary-surface-${Date.now()}`;
+    new WebviewWindow(label, {
+      url: popoutUrl,
+      title: state.mode === "preview" ? "winsmux Preview" : "winsmux Editor",
+      width: state.mode === "preview" ? 1180 : 1040,
+      height: 760,
+      minWidth: 720,
+      minHeight: 480,
+      focus: true,
+    });
+    return;
+  }
+
+  window.open(popoutUrl, "_blank", "noopener");
 }
 
 function getSourceFilterLabel(filter: SourceFilter) {
@@ -3561,10 +3696,11 @@ function renderEditorSurface() {
   const browserCopyButton = document.getElementById("browser-copy-btn") as HTMLButtonElement | null;
   const browserReloadButton = document.getElementById("browser-reload-btn") as HTMLButtonElement | null;
   const browserOpenButton = document.getElementById("browser-open-btn") as HTMLButtonElement | null;
+  const popoutButton = document.getElementById("popout-editor-btn") as HTMLButtonElement | null;
   const tabs = document.getElementById("editor-tabs");
   const code = document.getElementById("editor-code");
   const statusbar = document.getElementById("editor-statusbar");
-  if (!title || !summary || !path || !meta || !diffPreview || !browserSurface || !browserFrame || !browserMeta || !browserTargetList || !browserToolbarSummary || !browserBackButton || !browserCopyButton || !browserReloadButton || !browserOpenButton || !tabs || !code || !statusbar) {
+  if (!title || !summary || !path || !meta || !diffPreview || !browserSurface || !browserFrame || !browserMeta || !browserTargetList || !browserToolbarSummary || !browserBackButton || !browserCopyButton || !browserReloadButton || !browserOpenButton || !popoutButton || !tabs || !code || !statusbar) {
     return;
   }
 
@@ -3595,6 +3731,7 @@ function renderEditorSurface() {
       { label: "Surface", value: "Idle" },
       { label: "Files", value: "0 projected" },
     ]);
+    popoutButton.disabled = true;
     return;
   }
   if (selected && !previewModeActive) {
@@ -3698,6 +3835,7 @@ function renderEditorSurface() {
         ? [{ label: "External", value: lastPreviewExternalState.ok ? "Opened" : "Blocked" }]
         : []),
     ]);
+    popoutButton.disabled = false;
   } else if (selected) {
     title.textContent = selectedTarget?.sourceChange ? "Diff review" : "Editor";
     path.textContent = selected.path;
@@ -3773,6 +3911,7 @@ function renderEditorSurface() {
       { label: "Source", value: selected.origin === "context" ? "Run context" : "Explorer" },
       ...(selectedWorktreeLabel ? [{ label: "Worktree", value: selectedWorktreeLabel }] : []),
     ]);
+    popoutButton.disabled = false;
   }
   tabs.innerHTML = "";
 
@@ -5038,6 +5177,7 @@ function initializeSidebarResize() {
 
 window.addEventListener("DOMContentLoaded", async () => {
   installViewportHarnessHooks();
+  const popoutSurfaceState = readPopoutSurfaceState();
 
   const storedShellPreferences = readStoredShellPreferences();
   if (storedShellPreferences) {
@@ -5079,11 +5219,12 @@ window.addEventListener("DOMContentLoaded", async () => {
   renderAttachmentTray();
   renderCommandBar();
   renderEditorSurface();
-  await refreshDesktopSummary();
-  registerDesktopSummaryLiveRefresh();
   syncResponsiveShell();
   setEditorSurface(false);
   setTerminalDrawer(false);
+  applyPopoutSurfaceState(popoutSurfaceState);
+  await refreshDesktopSummary();
+  registerDesktopSummaryLiveRefresh();
   initializeSidebarResize();
 
   document.getElementById("toggle-sidebar-btn")?.addEventListener("click", () => {
@@ -5122,8 +5263,20 @@ window.addEventListener("DOMContentLoaded", async () => {
     setContextPanel(!contextPanelOpen);
   });
 
-  document.getElementById("close-editor-btn")?.addEventListener("click", () => {
+  document.getElementById("close-editor-btn")?.addEventListener("click", async () => {
+    if (document.body.dataset.popoutSurface === "1") {
+      if (isTauri()) {
+        await getCurrentWebviewWindow().close();
+        return;
+      }
+      window.close();
+      return;
+    }
     setEditorSurface(false);
+  });
+
+  document.getElementById("popout-editor-btn")?.addEventListener("click", async () => {
+    await openEditorSurfacePopout();
   });
 
   document.getElementById("settings-btn")?.addEventListener("click", () => {

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -3828,9 +3828,13 @@ function renderEditorSurface() {
     for (const item of [
       "Preview",
       detachedSurface ? "Detached" : "",
+      detachedSurfaceRunLabel,
       previewTarget.portLabel,
       previewTarget.sourceLabel,
     ]) {
+      if (!item) {
+        continue;
+      }
       const chip = document.createElement("span");
       chip.className = "editor-meta-chip";
       chip.dataset.tone = item === "Preview" ? "focus" : "default";
@@ -3904,6 +3908,7 @@ function renderEditorSurface() {
     for (const item of [
       "Code",
       detachedSurface ? "Detached" : "",
+      detachedSurfaceRunLabel,
       selected.origin === "context" ? "Run context" : "Explorer",
       selectedWorktreeLabel,
     ]) {

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -125,6 +125,10 @@ type PopoutSurfaceState =
       mode: "editor";
       path: string;
       worktree: string;
+      summary: string;
+      origin: "explorer" | "context";
+      modified: boolean;
+      sourceChange?: SourceChange | null;
       content?: string;
     };
 
@@ -1062,17 +1066,38 @@ function registerPreviewTargetForHarness(sourceLabel: string, url: string) {
 }
 
 function openEditorPreviewForHarness(path: string, content: string, worktree = "") {
-  const target = createStandaloneEditorTarget(path, worktree);
+  restoreStandaloneEditorFromSnapshot({
+    mode: "editor",
+    path,
+    worktree,
+    summary: `Project file preview · ${path.split("/").pop() ?? path}`,
+    origin: "explorer",
+    modified: false,
+    sourceChange: null,
+    content,
+  });
+}
+
+function restoreStandaloneEditorFromSnapshot(state: Extract<PopoutSurfaceState, { mode: "editor" }> & { content: string }) {
+  const target: EditorTarget = {
+    key: getEditorFileKey(state.path, state.worktree),
+    path: state.path,
+    summary: state.summary,
+    worktree: state.worktree,
+    origin: state.origin,
+    modified: state.modified,
+    sourceChange: state.sourceChange ?? undefined,
+  };
   desktopStandaloneEditorTargets.set(target.key, target);
   desktopEditorFileCache.set(target.key, {
     key: target.key,
-    path,
-    summary: target.summary,
-    content,
-    language: inferLanguageFromPath(path),
-    lineCount: countEditorLines(content),
-    modified: false,
-    origin: "explorer",
+    path: state.path,
+    summary: state.summary,
+    content: state.content,
+    language: inferLanguageFromPath(state.path),
+    lineCount: countEditorLines(state.content),
+    modified: state.modified,
+    origin: state.origin,
   });
   desktopEditorLoadErrors.delete(target.key);
   desktopEditorLoadingPaths.delete(target.key);
@@ -1081,6 +1106,7 @@ function openEditorPreviewForHarness(path: string, content: string, worktree = "
   lastPreviewExternalState = null;
   lastPreviewClipboardState = null;
   selectedEditorKey = target.key;
+  setSelectedRun(target.sourceChange?.run ?? selectedRunId);
   setEditorSurface(true);
   renderOpenEditors();
   renderSourceSummary();
@@ -1110,6 +1136,10 @@ function getCurrentEditorSurfaceState(): PopoutSurfaceState | null {
     mode: "editor",
     path: selected.path,
     worktree: selectedTarget?.worktree ?? "",
+    summary: selected.summary,
+    origin: selected.origin,
+    modified: Boolean(selected.modified),
+    sourceChange: selectedTarget?.sourceChange ?? null,
     content: isTauri() ? undefined : selected.content,
   };
 }
@@ -1172,8 +1202,8 @@ function applyPopoutSurfaceState(state: PopoutSurfaceState | null) {
     return;
   }
 
-  if (state.content) {
-    openEditorPreviewForHarness(state.path, state.content, state.worktree);
+  if (typeof state.content === "string") {
+    restoreStandaloneEditorFromSnapshot({ ...state, content: state.content });
     return;
   }
 
@@ -3716,6 +3746,7 @@ function renderEditorSurface() {
   const previewTarget = selectedPreviewUrl ? detectedPreviewTargets.get(selectedPreviewUrl) ?? null : null;
   const previewTargets = getPreviewTargets();
   const previewModeActive = editorSurfaceMode === "preview" && Boolean(previewTarget);
+  const detachedSurface = document.body.dataset.popoutSurface === "1";
   if (!selected && !previewModeActive) {
     title.textContent = "Editor";
     path.textContent = "Editor idle";
@@ -3775,6 +3806,7 @@ function renderEditorSurface() {
     path.textContent = previewTarget.url;
     for (const item of [
       "Preview",
+      detachedSurface ? "Detached" : "",
       previewTarget.portLabel,
       previewTarget.sourceLabel,
     ]) {
@@ -3835,6 +3867,7 @@ function renderEditorSurface() {
     code.hidden = true;
     renderEditorStatusbar(statusbar, [
       { label: "Surface", value: "Preview" },
+      ...(detachedSurface ? [{ label: "Window", value: "Detached" }] : []),
       { label: "Target", value: previewTarget.portLabel },
       { label: "Source", value: previewTarget.sourceLabel },
       { label: "Seen", value: formatPreviewSeenAt(previewTarget.lastSeenAt) },
@@ -3848,6 +3881,7 @@ function renderEditorSurface() {
     path.textContent = selected.path;
     for (const item of [
       "Code",
+      detachedSurface ? "Detached" : "",
       selected.origin === "context" ? "Run context" : "Explorer",
       selectedWorktreeLabel,
     ]) {
@@ -3915,6 +3949,7 @@ function renderEditorSurface() {
     code.textContent = selected.content;
     renderEditorStatusbar(statusbar, [
       { label: "Surface", value: selectedTarget?.sourceChange ? "Diff review" : "Editor" },
+      ...(detachedSurface ? [{ label: "Window", value: "Detached" }] : []),
       { label: "Source", value: selected.origin === "context" ? "Run context" : "Explorer" },
       ...(selectedWorktreeLabel ? [{ label: "Worktree", value: selectedWorktreeLabel }] : []),
     ]);

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -490,7 +490,14 @@ function renderSessions() {
 
 function getSessionItems() {
   if (!desktopSummarySnapshot) {
-    return [{ name: "winsmux", meta: "Connecting to desktop summary", active: true }] satisfies SessionItem[];
+    const items: SessionItem[] = [{ name: "winsmux", meta: "Connecting to desktop summary", active: true }];
+    if (detachedSurfaceSession) {
+      items.push({
+        name: detachedSurfaceSession.name,
+        meta: detachedSurfaceSession.meta,
+      });
+    }
+    return items;
   }
 
   const board = desktopSummarySnapshot.board.summary;
@@ -1400,7 +1407,7 @@ async function openEditorSurfacePopout() {
     return;
   }
 
-  const popup = window.open(popoutUrl, "_blank", "noopener");
+  const popup = window.open(popoutUrl, "_blank");
   if (!popup) {
     return;
   }

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -1175,14 +1175,19 @@ function applyPopoutSurfaceState(state: PopoutSurfaceState | null) {
   document.body.dataset.popoutSurface = "1";
   const title = document.getElementById("workspace-title");
   const subtitle = document.getElementById("workspace-subtitle");
+  const editorLabel = state.mode === "editor" ? state.path.split("/").pop() ?? state.path : "";
+  const editorWorktreeLabel = state.mode === "editor" && state.worktree ? getWorktreeLabel(state.worktree) : "Project root";
   if (title) {
-    title.textContent = state.mode === "preview" ? "Preview pop-out" : "Editor pop-out";
+    title.textContent =
+      state.mode === "preview"
+        ? `${state.portLabel} preview`
+        : `${editorLabel} editor`;
   }
   if (subtitle) {
     subtitle.textContent =
       state.mode === "preview"
-        ? "Detached secondary surface for localhost preview review."
-        : "Detached secondary surface for code and diff review.";
+        ? `Detached secondary surface from ${state.sourceLabel}.`
+        : `Detached secondary surface for ${editorWorktreeLabel}.`;
   }
 
   setSidebarOpen(false, { preserveWidePreference: false });

--- a/winsmux-app/src/styles.css
+++ b/winsmux-app/src/styles.css
@@ -392,6 +392,10 @@ body[data-popout-surface="1"] #header-actions {
   display: none;
 }
 
+body[data-popout-surface="1"] #popout-editor-btn {
+  display: none;
+}
+
 body[data-popout-surface="1"] #editor-surface {
   min-height: 0;
 }

--- a/winsmux-app/src/styles.css
+++ b/winsmux-app/src/styles.css
@@ -361,6 +361,41 @@ textarea {
   grid-template-columns: minmax(0, 1fr) var(--editor-width);
 }
 
+body[data-popout-surface="1"] #sidebar-overlay,
+body[data-popout-surface="1"] #left-rail,
+body[data-popout-surface="1"] #conversation-panel,
+body[data-popout-surface="1"] #context-panel,
+body[data-popout-surface="1"] #workspace-footer,
+body[data-popout-surface="1"] #terminal-drawer,
+body[data-popout-surface="1"] #settings-sheet,
+body[data-popout-surface="1"] #command-bar-backdrop,
+body[data-popout-surface="1"] #command-bar {
+  display: none !important;
+}
+
+body[data-popout-surface="1"] #app-shell {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+body[data-popout-surface="1"] #workspace {
+  grid-template-rows: auto minmax(0, 1fr);
+}
+
+body[data-popout-surface="1"] #workspace-body,
+body[data-popout-surface="1"] #workspace-body.editor-open,
+body[data-popout-surface="1"] #workspace-body.context-collapsed,
+body[data-popout-surface="1"] #workspace-body.editor-open.context-collapsed {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+body[data-popout-surface="1"] #header-actions {
+  display: none;
+}
+
+body[data-popout-surface="1"] #editor-surface {
+  min-height: 0;
+}
+
 #conversation-panel,
 #editor-surface,
 #context-panel,
@@ -972,6 +1007,12 @@ textarea {
   align-items: center;
   justify-content: space-between;
   gap: 10px;
+}
+
+.panel-title-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
 }
 
 .settings-sheet-actions {


### PR DESCRIPTION
## Summary
- add a Pop out action for the secondary surface
- open preview and editor surfaces in a detached window with a pop-out shell mode
- cover preview pop-out handoff and close via viewport harness
