### PR TITLE
Add pane metadata to utility drawer

### DIFF
--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -5269,7 +5269,10 @@ function renderPaneMetadata() {
       parts.push(eventTime);
     }
     parts.push(waitDuration);
-    pane.metaElement.textContent = parts.filter((value) => Boolean(value)).join(" · ");
+    const metaText = parts.filter((value) => Boolean(value)).join(" · ");
+    pane.metaElement.textContent = metaText;
+    pane.metaElement.title = metaText;
+    pane.labelElement.title = paneLabel;
   });
 }
 

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -12,6 +12,7 @@ import {
   promoteDesktopRunTactic,
   subscribeToDesktopSummaryRefresh,
   type DesktopCompareRunsResult,
+  type DesktopBoardPane,
   type DesktopEditorFilePayload,
   type DesktopExplainPayload,
   type DesktopRunProjection,
@@ -4421,6 +4422,21 @@ function getRunProjectionFingerprint(projection: DesktopRunProjection | null | u
   ]);
 }
 
+function getBoardPaneFingerprint(pane: DesktopBoardPane) {
+  return JSON.stringify([
+    pane.label,
+    pane.role,
+    pane.state,
+    pane.task_state,
+    pane.review_state,
+    pane.branch,
+    pane.worktree,
+    pane.head_sha,
+    pane.changed_file_count,
+    pane.last_event_at,
+  ]);
+}
+
 function diffDesktopSummarySnapshots(
   previousSnapshot: DesktopSummarySnapshot | null,
   nextSnapshot: DesktopSummarySnapshot,
@@ -4441,10 +4457,17 @@ function diffDesktopSummarySnapshots(
   const nextProjectionMap = new Map(
     nextSnapshot.run_projections.map((projection) => [projection.run_id, projection]),
   );
+  const previousBoardPaneMap = new Map(
+    previousSnapshot.board.panes.map((pane) => [pane.pane_id, pane]),
+  );
+  const nextBoardPaneMap = new Map(
+    nextSnapshot.board.panes.map((pane) => [pane.pane_id, pane]),
+  );
 
   const changedRunIds: string[] = [];
   const addedRunIds: string[] = [];
   const removedRunIds: string[] = [];
+  let boardPaneChanged = previousSnapshot.board.panes.length !== nextSnapshot.board.panes.length;
 
   for (const [runId, nextProjection] of nextProjectionMap) {
     const previousProjection = previousProjectionMap.get(runId);
@@ -4464,15 +4487,32 @@ function diffDesktopSummarySnapshots(
     }
   }
 
+  if (!boardPaneChanged) {
+    for (const [paneId, nextPane] of nextBoardPaneMap) {
+      const previousPane = previousBoardPaneMap.get(paneId);
+      if (!previousPane) {
+        boardPaneChanged = true;
+        break;
+      }
+
+      if (getBoardPaneFingerprint(previousPane) !== getBoardPaneFingerprint(nextPane)) {
+        boardPaneChanged = true;
+        break;
+      }
+    }
+  }
+
   const inboxCountChanged =
     previousSnapshot.inbox.summary.item_count !== nextSnapshot.inbox.summary.item_count;
 
   return {
     hasMeaningfulChange:
+      boardPaneChanged ||
       inboxCountChanged ||
       addedRunIds.length > 0 ||
       removedRunIds.length > 0 ||
       changedRunIds.length > 0,
+    boardPaneChanged,
     changedRunIds,
     inboxCountChanged,
     addedRunIds,
@@ -5172,6 +5212,40 @@ function formatPaneWaitDuration(timestamp: string, now = Date.now()) {
   return `${hours}h ${minutes}m wait`;
 }
 
+function summarizeBoardPaneStatus(pane: DesktopBoardPane | null) {
+  if (!pane) {
+    return "";
+  }
+
+  const role = pane.role || "pane";
+  const taskState = (pane.task_state || "").toLowerCase();
+  const reviewState = (pane.review_state || "").toUpperCase();
+
+  if (taskState === "blocked") {
+    return `${role} · blocked`;
+  }
+  if (reviewState === "FAIL" || reviewState === "FAILED") {
+    return `${role} · review failed`;
+  }
+  if (reviewState === "PENDING") {
+    return `${role} · review pending`;
+  }
+  if (reviewState === "PASS") {
+    return `${role} · review pass`;
+  }
+  if (taskState === "commit_ready") {
+    return `${role} · commit ready`;
+  }
+  if (taskState === "completed" || taskState === "task_completed" || taskState === "done") {
+    return `${role} · completed`;
+  }
+  if (pane.task_state) {
+    return `${role} · ${pane.task_state}`;
+  }
+
+  return role;
+}
+
 function renderPaneMetadata() {
   const boardPanes = desktopSummarySnapshot?.board.panes ?? [];
   const now = Date.now();
@@ -5181,6 +5255,7 @@ function renderPaneMetadata() {
     const paneLabel = paneRecord?.label || paneId;
     pane.labelElement.textContent = paneLabel;
 
+    const status = summarizeBoardPaneStatus(paneRecord);
     const branch = paneRecord?.branch || "No branch";
     const eventTime = paneRecord?.last_event_at ? formatPaneMetaTime(paneRecord.last_event_at) : "";
     const waitDuration = paneRecord?.last_event_at
@@ -5189,7 +5264,7 @@ function renderPaneMetadata() {
         ? `${formatPreviewSeenAt(pane.lastOutputAt)} · live output`
         : "waiting for summary";
 
-    const parts = [branch];
+    const parts = [status, branch];
     if (eventTime) {
       parts.push(eventTime);
     }

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -5256,7 +5256,7 @@ function renderPaneMetadata() {
     pane.labelElement.textContent = paneLabel;
 
     const status = summarizeBoardPaneStatus(paneRecord);
-    const branch = paneRecord?.branch || "No branch";
+    const branch = paneRecord?.branch || "";
     const eventTime = paneRecord?.last_event_at ? formatPaneMetaTime(paneRecord.last_event_at) : "";
     const waitDuration = paneRecord?.last_event_at
       ? formatPaneWaitDuration(paneRecord.last_event_at, now)
@@ -5264,7 +5264,10 @@ function renderPaneMetadata() {
         ? `${formatPreviewSeenAt(pane.lastOutputAt)} · live output`
         : "waiting for summary";
 
-    const parts = [status, branch];
+    const parts = [status];
+    if (branch) {
+      parts.push(branch);
+    }
     if (eventTime) {
       parts.push(eventTime);
     }

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -30,6 +30,9 @@ interface PaneEntry {
   terminal: Terminal;
   fitAddon: FitAddon;
   container: HTMLElement;
+  labelElement: HTMLElement;
+  metaElement: HTMLElement;
+  lastOutputAt: number | null;
 }
 
 type ChipAction =
@@ -280,6 +283,7 @@ let lastCommandBarFocus: HTMLElement | null = null;
 let pendingAttachments: ComposerAttachment[] = [];
 const detectedPreviewTargets = new Map<string, PreviewTarget>();
 const PREVIEW_FRESHNESS_WINDOW_MS = 30_000;
+const PANE_META_REFRESH_INTERVAL_MS = 30_000;
 let desktopSummarySnapshot: DesktopSummarySnapshot | null = null;
 let desktopSummaryRefreshInFlight: Promise<void> | null = null;
 let desktopSummaryRefreshTimeout: number | null = null;
@@ -377,16 +381,25 @@ function createPane(paneId?: string): string {
   const header = document.createElement("div");
   header.className = "pane-header";
 
+  const labelGroup = document.createElement("div");
+  labelGroup.className = "pane-heading";
+
   const label = document.createElement("span");
   label.className = "pane-label";
   label.textContent = id;
+
+  const meta = document.createElement("span");
+  meta.className = "pane-meta";
+  meta.textContent = "No branch · waiting for summary";
 
   const closeBtn = document.createElement("button");
   closeBtn.className = "pane-close";
   closeBtn.textContent = "×";
   closeBtn.onclick = () => closePane(id);
 
-  header.appendChild(label);
+  labelGroup.appendChild(label);
+  labelGroup.appendChild(meta);
+  header.appendChild(labelGroup);
   header.appendChild(closeBtn);
 
   const termDiv = document.createElement("div");
@@ -427,7 +440,14 @@ function createPane(paneId?: string): string {
     void resizePtyPane(id, cols, rows);
   });
 
-  panes.set(id, { terminal, fitAddon, container: paneDiv });
+  panes.set(id, {
+    terminal,
+    fitAddon,
+    container: paneDiv,
+    labelElement: label,
+    metaElement: meta,
+    lastOutputAt: null,
+  });
 
   const { cols, rows } = { cols: terminal.cols, rows: terminal.rows };
   void spawnPtyPane(id, cols, rows)
@@ -5104,6 +5124,7 @@ function pruneExplainCache(snapshot: DesktopSummarySnapshot, preservedRunId?: st
 }
 
 function renderDesktopSurfaces() {
+  renderPaneMetadata();
   renderSessions();
   renderFooterLane();
   renderRunSummary();
@@ -5113,6 +5134,68 @@ function renderDesktopSurfaces() {
   renderOpenEditors();
   renderEditorSurface();
   renderConversation(getConversationItems());
+}
+
+function formatPaneMetaTime(timestamp: string) {
+  const parsed = Date.parse(timestamp);
+  if (Number.isNaN(parsed)) {
+    return "";
+  }
+
+  return new Date(parsed).toLocaleTimeString([], {
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function formatPaneWaitDuration(timestamp: string, now = Date.now()) {
+  const parsed = Date.parse(timestamp);
+  if (Number.isNaN(parsed)) {
+    return "";
+  }
+
+  const elapsedMs = Math.max(0, now - parsed);
+  const elapsedMinutes = Math.floor(elapsedMs / 60000);
+  if (elapsedMinutes < 1) {
+    return "<1m wait";
+  }
+  if (elapsedMinutes < 60) {
+    return `${elapsedMinutes}m wait`;
+  }
+
+  const hours = Math.floor(elapsedMinutes / 60);
+  const minutes = elapsedMinutes % 60;
+  if (minutes === 0) {
+    return `${hours}h wait`;
+  }
+
+  return `${hours}h ${minutes}m wait`;
+}
+
+function renderPaneMetadata() {
+  const boardPanes = desktopSummarySnapshot?.board.panes ?? [];
+  const now = Date.now();
+
+  panes.forEach((pane, paneId) => {
+    const paneRecord = boardPanes.find((item) => item.pane_id === paneId) ?? null;
+    const paneLabel = paneRecord?.label || paneId;
+    pane.labelElement.textContent = paneLabel;
+
+    const branch = paneRecord?.branch || "No branch";
+    const eventTime = paneRecord?.last_event_at ? formatPaneMetaTime(paneRecord.last_event_at) : "";
+    const waitDuration = paneRecord?.last_event_at
+      ? formatPaneWaitDuration(paneRecord.last_event_at, now)
+      : pane.lastOutputAt
+        ? `${formatPreviewSeenAt(pane.lastOutputAt)} · live output`
+        : "waiting for summary";
+
+    const parts = [branch];
+    if (eventTime) {
+      parts.push(eventTime);
+    }
+    parts.push(waitDuration);
+    pane.metaElement.textContent = parts.filter((value) => Boolean(value)).join(" · ");
+  });
 }
 
 async function refreshDesktopSummary(forceExplainRunId?: string | null) {
@@ -5330,13 +5413,17 @@ window.addEventListener("DOMContentLoaded", async () => {
     registerPreviewTargets(payload.pane_id, payload.data);
     const entry = payload.pane_id ? panes.get(payload.pane_id) : undefined;
     if (entry) {
+      entry.lastOutputAt = Date.now();
       entry.terminal.write(payload.data);
+      renderPaneMetadata();
       return;
     }
 
     const first = panes.values().next().value as PaneEntry | undefined;
     if (first) {
+      first.lastOutputAt = Date.now();
       first.terminal.write(payload.data);
+      renderPaneMetadata();
     }
   });
 
@@ -5365,6 +5452,9 @@ window.addEventListener("DOMContentLoaded", async () => {
   await refreshDesktopSummary();
   registerDesktopSummaryLiveRefresh();
   initializeSidebarResize();
+  window.setInterval(() => {
+    renderPaneMetadata();
+  }, PANE_META_REFRESH_INTERVAL_MS);
 
   document.getElementById("toggle-sidebar-btn")?.addEventListener("click", () => {
     setSidebarOpen(!sidebarOpen);

--- a/winsmux-app/src/styles.css
+++ b/winsmux-app/src/styles.css
@@ -2100,4 +2100,23 @@ body[data-popout-surface="1"] #editor-surface {
   .footer-pill-label {
     display: none;
   }
+
+  .pane-header {
+    min-height: 46px;
+    padding: 4px 8px;
+    align-items: flex-start;
+    gap: 8px;
+  }
+
+  .pane-heading {
+    gap: 1px;
+  }
+
+  .pane-meta {
+    white-space: normal;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    overflow: hidden;
+  }
 }

--- a/winsmux-app/src/styles.css
+++ b/winsmux-app/src/styles.css
@@ -1747,13 +1747,22 @@ body[data-popout-surface="1"] #editor-surface {
 }
 
 .pane-header {
-  height: 28px;
+  min-height: 40px;
   background: #171c29;
   display: flex;
   align-items: center;
   justify-content: space-between;
   padding: 0 10px;
+  gap: 12px;
   flex-shrink: 0;
+}
+
+.pane-heading {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 2px;
 }
 
 .pane-label {
@@ -1762,12 +1771,22 @@ body[data-popout-surface="1"] #editor-surface {
   font-family: var(--font-code);
 }
 
+.pane-meta {
+  color: var(--text-muted);
+  font-size: var(--text-3xs);
+  line-height: 1.2;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .pane-close {
   background: none;
   border: none;
   color: #8b95b8;
   font-size: 14px;
   cursor: pointer;
+  flex-shrink: 0;
 }
 
 .pane-close:hover {


### PR DESCRIPTION
## Summary
- show pane branch and last event metadata in the utility drawer header
- add a live wait-duration line that refreshes without a new summary event
- keep the drawer surface compact while preserving existing PTY behavior

## Validation
- cmd /c npm run build (winsmux-app)
- pwsh -NoProfile -File .\\scripts\\git-guard.ps1 -Mode full
- pwsh -NoProfile -File .\\scripts\\audit-public-surface.ps1