### PR TITLE
Clarify Rust verification contract

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -187,6 +187,8 @@ winsmux send worker-3 "upstream issue を要約してください。"
 - **Worktree isolation**: ワーカーごとに独立した git ワークツリーを持てる
 - **Credential Vault**: Windows DPAPI でシークレットを管理し、repo に `.env` を置かない
 - **Evidence Ledger**: プロンプト、操作、レビュー証跡を記録できる
+- **証拠を先に扱う検証**: `cargo fmt --check`、`cargo clippy -- -D warnings`、`cargo test`、`cargo audit` のような代表コマンドは、単なる感想ではなく、再利用できるレビュー証拠として扱う
+- **最終判断はオペレーターが持つ**: レビュー可能なペインは指摘と証拠を返しますが、受け入れ可否の最終判断は外部オペレーターが持つ
 
 ## 主要コマンド
 

--- a/README.md
+++ b/README.md
@@ -184,6 +184,8 @@ winsmux send worker-3 "Summarize the upstream issue."
 - **Worktree isolation**: each managed worker pane can run in its own git worktree branch and directory
 - **Credential Vault**: secrets are stored with Windows DPAPI and injected into panes without writing repo `.env` files
 - **Evidence Ledger**: prompts, actions, and review evidence can be captured for audit and compliance workflows
+- **Evidence-first verification**: representative tool output such as `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test`, and `cargo audit` should be handled as reusable review evidence instead of prompt-only commentary
+- **Operator-owned final judgement**: review-capable panes may report findings and evidence, but the final accept/reject decision stays with the external operator
 
 ## Core commands
 

--- a/docs/operator-model.md
+++ b/docs/operator-model.md
@@ -55,6 +55,27 @@ In the standard winsmux operating model, the operator is responsible for:
 
 Direct file mutation or command execution by the operator is outside the standard winsmux operating model.
 
+## 2a. Verification and evidence contract
+
+winsmux treats verification as evidence, not as freeform approval prose.
+
+That means:
+
+- a review-capable slot should return findings, blocking state, and evidence references
+- representative tool output should stay attributable to the tool that produced it
+- the operator should make the final accept / reject judgement after reading that evidence
+
+For Rust-oriented work, the representative evidence set currently includes:
+
+- `cargo fmt --check`
+- `cargo clippy -- -D warnings`
+- `cargo test`
+- `cargo audit`
+
+winsmux may learn from public harness structures, checklists, and policy shapes.
+It does not treat a generic persona prompt as a public product capability.
+The durable public contract is slot capability, evidence shape, and operator-owned final judgement.
+
 ## 3. Pane execution layer
 
 The managed pane layer is where agent CLIs run inside winsmux-controlled panes or slots.


### PR DESCRIPTION
## Summary
- document the Rust verification evidence contract in the public product docs
- clarify that review-capable panes report findings and evidence while the operator keeps final judgement
- refresh TASK-315 planning notes to point to the public docs outputs for #460

## Validation
- pwsh -NoProfile -File .\\winsmux-core\\scripts\\sync-roadmap.ps1
- pwsh -NoProfile -File .\\scripts\\git-guard.ps1 -Mode full
- pwsh -NoProfile -File .\\scripts\\audit-public-surface.ps1