### PR TITLE
Clarify public evidence boundary

### DIFF
--- a/docs/repo-surface-policy.md
+++ b/docs/repo-surface-policy.md
@@ -23,6 +23,8 @@ Rules:
 - must not contain maintainer-local paths
 - must not require private planning roots or live operational notes
 - must not link readers directly into local-only operational files
+- may publish capability contracts, evidence contracts, and operator judgement rules
+- must not publish generic persona prompt bodies or maintainer-only skill bodies as product capabilities
 
 ## 2. Runtime contract surface
 


### PR DESCRIPTION
## Summary
- clarify that public docs may publish capability and evidence contracts
- forbid publishing generic persona prompt bodies as product capabilities
- keep the #460 reevaluation aligned with the public/private surface boundary

## Validation
- pwsh -NoProfile -File .\\winsmux-core\\scripts\\sync-roadmap.ps1
- pwsh -NoProfile -File .\\scripts\\git-guard.ps1 -Mode full
- pwsh -NoProfile -File .\\scripts\\audit-public-surface.ps1