### PR TITLE
Document reevaluation record minimums

### DIFF
--- a/docs/project/upstream-reevaluation-gate.md
+++ b/docs/project/upstream-reevaluation-gate.md
@@ -80,6 +80,39 @@ The current default task mapping for `#460` is:
 
 If a pattern does not clearly fit one of those landing zones, reject it until the destination is clear.
 
+## Minimum reevaluation record
+
+Every accepted reevaluation pass should leave a short durable record.
+
+That record should answer these questions:
+
+1. Which upstream source set was reviewed?
+2. Which patterns were accepted?
+3. Which patterns were rejected?
+4. Which landing zone received the accepted change?
+5. Which issue and `TASK-*` entries now track the result?
+
+Use this minimum shape:
+
+- source date or release range
+- source type:
+  - official docs
+  - release notes
+  - CLI help
+  - policy/checklist shape
+  - public issue/PR discussion
+- accepted pattern summary
+- rejected pattern summary with a reason
+- landing zone:
+  - public docs
+  - contributor docs
+  - external planning
+  - private maintainer assets
+- related issue or PR
+- related `TASK-*`
+
+If that record cannot be written clearly, the pattern is not ready to become a durable contract.
+
 ## Command surface
 
 The working command surface for `TASK-315` is:


### PR DESCRIPTION
## Summary\n- add a minimum reevaluation record section to the upstream reevaluation gate doc\n- fix the required questions for accepted upstream input passes\n- define the minimum fields needed before a pattern becomes a durable contract\n\n## Testing\n- pwsh -NoProfile -File .\\scripts\\git-guard.ps1 -Mode full\n- pwsh -NoProfile -File .\\scripts\\audit-public-surface.ps1\n