### PR TITLE
Clarify reevaluation handling for metadata drift

### DIFF
--- a/docs/project/upstream-reevaluation-gate.md
+++ b/docs/project/upstream-reevaluation-gate.md
@@ -113,6 +113,11 @@ Use this minimum shape:
 
 If that record cannot be written clearly, the pattern is not ready to become a durable contract.
 
+When the input reveals public metadata drift such as version, naming, or license mismatch,
+do not patch around it in unrelated product docs.
+Open or update a public issue, map it into the release-hardening lane, and only then decide
+which public docs need a follow-up correction.
+
 ## Command surface
 
 The working command surface for `TASK-315` is:


### PR DESCRIPTION
## Summary
- require upstream reevaluation findings about version, naming, and license drift to land in a public issue first
- route those findings into the release-hardening lane instead of patching unrelated product docs directly
- align the contributor reevaluation guide with the current planning re-bucket and public metadata hardening flow

## Validation
- pwsh -NoProfile -File .\\winsmux-core\\scripts\\sync-roadmap.ps1
- pwsh -NoProfile -File .\\scripts\\git-guard.ps1 -Mode full
- pwsh -NoProfile -File .\\scripts\\audit-public-surface.ps1
