### PR TITLE
Add provider switch command

### DIFF
--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -6930,6 +6930,92 @@ function Invoke-ConsultError {
     Write-ConsultationCommandRecord -Kind 'consult_error' -Mode ([string]$args.mode) -Message ([string]$args.message) -TargetSlot ([string]$args.target_slot)
 }
 
+function Invoke-ProviderSwitch {
+    $tokens = @(@($Target) + @($Rest) | Where-Object { $_ })
+    if ($tokens.Count -lt 1) {
+        Stop-WithError "usage: winsmux provider-switch <slot> [--agent <name>] [--model <name>] [--prompt-transport <argv|file|stdin>] [--reason <text>] [--json]"
+    }
+
+    $slotId = [string]$tokens[0]
+    $agent = ''
+    $model = ''
+    $promptTransport = ''
+    $reason = ''
+    $jsonOutput = $false
+
+    for ($index = 1; $index -lt $tokens.Count; $index++) {
+        switch ($tokens[$index]) {
+            '--agent' {
+                if ($index + 1 -ge $tokens.Count) {
+                    Stop-WithError '--agent requires a value'
+                }
+                $agent = [string]$tokens[$index + 1]
+                $index++
+            }
+            '--model' {
+                if ($index + 1 -ge $tokens.Count) {
+                    Stop-WithError '--model requires a value'
+                }
+                $model = [string]$tokens[$index + 1]
+                $index++
+            }
+            '--prompt-transport' {
+                if ($index + 1 -ge $tokens.Count) {
+                    Stop-WithError '--prompt-transport requires a value'
+                }
+                $promptTransport = [string]$tokens[$index + 1]
+                $index++
+            }
+            '--reason' {
+                if ($index + 1 -ge $tokens.Count) {
+                    Stop-WithError '--reason requires a value'
+                }
+                $reason = [string]$tokens[$index + 1]
+                $index++
+            }
+            '--json' {
+                $jsonOutput = $true
+            }
+            default {
+                Stop-WithError "usage: winsmux provider-switch <slot> [--agent <name>] [--model <name>] [--prompt-transport <argv|file|stdin>] [--reason <text>] [--json]"
+            }
+        }
+    }
+
+    $projectDir = (Get-Location).Path
+    $settings = Get-BridgeSettings -RootPath $projectDir
+    $knownSlot = $false
+    foreach ($slot in @($settings.agent_slots)) {
+        if ([string]::Equals([string]$slot.slot_id, $slotId, [System.StringComparison]::OrdinalIgnoreCase)) {
+            $knownSlot = $true
+            break
+        }
+    }
+    if (-not $knownSlot) {
+        Stop-WithError "provider-switch target slot '$slotId' is not present in agent_slots."
+    }
+
+    $entry = Write-BridgeProviderRegistryEntry -RootPath $projectDir -SlotId $slotId -Agent $agent -Model $model -PromptTransport $promptTransport -Reason $reason
+    $effective = Get-SlotAgentConfig -Role 'Worker' -SlotId $slotId -Settings $settings -RootPath $projectDir
+    $result = [ordered]@{
+        slot_id          = $slotId
+        agent            = [string]$effective.Agent
+        model            = [string]$effective.Model
+        prompt_transport = [string]$effective.PromptTransport
+        source           = [string]$effective.Source
+        registry_path    = Get-BridgeProviderRegistryPath -RootPath $projectDir
+        updated_at_utc   = [string]$entry.updated_at_utc
+        reason           = if ($entry.Contains('reason')) { [string]$entry.reason } else { '' }
+    }
+
+    if ($jsonOutput) {
+        $result | ConvertTo-Json -Depth 8 -Compress | Write-Output
+        return
+    }
+
+    Write-Output "provider switched for ${slotId}: $($result.agent) / $($result.model) ($($result.prompt_transport))"
+}
+
 function Show-Usage {
     Write-Output @"
 winsmux $VERSION - winsmux bridge for winsmux
@@ -6963,6 +7049,7 @@ Commands:
   consult-request <mode> [--message <text>] [--target-slot <slot>]  Record a consultation request packet/event
   consult-result <mode> [--message <text>] [--target-slot <slot>] [--confidence <0..1>] [--next-test <text>] [--risk <text>] [--run-id <run_id>] [--json]  Record a consultation result packet/event
   consult-error <mode> [--message <text>] [--target-slot <slot>]  Record a consultation error packet/event
+  provider-switch <slot> [--agent <name>] [--model <name>] [--prompt-transport <argv|file|stdin>] [--reason <text>] [--json]  Record a runtime provider reassignment for a managed slot
   locks                     List active file locks
   verify <pr-number>        Run Pester in tests/ and merge PR only on PASS
   wait <channel> [timeout]  Block until signal received (replaces polling)
@@ -7435,6 +7522,7 @@ switch ($Command) {
     'consult-request' { Invoke-ConsultRequest }
     'consult-result'  { Invoke-ConsultResult }
     'consult-error'   { Invoke-ConsultError }
+    'provider-switch' { Invoke-ProviderSwitch }
     'rebind-worktree' { Invoke-RebindWorktree }
     ''                { Show-Usage }
     default           { Stop-WithError "unknown command: $Command. Run without arguments for usage." }

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -7784,6 +7784,62 @@ Describe 'public first-run helper' {
     }
 }
 
+Describe 'winsmux provider-switch command' {
+    BeforeAll {
+        $script:winsmuxCoreRawPath = Join-Path (Split-Path -Parent $PSScriptRoot) 'scripts\winsmux-core.ps1'
+        $script:winsmuxCoreRawContent = Get-Content -Path $script:winsmuxCoreRawPath -Raw -Encoding UTF8
+    }
+
+    BeforeEach {
+        $script:providerSwitchTempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('winsmux-provider-switch-tests-' + [guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $script:providerSwitchTempRoot -Force | Out-Null
+        @'
+agent: codex
+model: gpt-5.4
+prompt-transport: argv
+agent-slots:
+  - slot-id: worker-1
+    runtime-role: worker
+    agent: codex
+    model: gpt-5.4
+    prompt-transport: argv
+'@ | Set-Content -Path (Join-Path $script:providerSwitchTempRoot '.winsmux.yaml') -Encoding UTF8
+    }
+
+    AfterEach {
+        if ($script:providerSwitchTempRoot -and (Test-Path $script:providerSwitchTempRoot)) {
+            Remove-Item -Path $script:providerSwitchTempRoot -Recurse -Force
+        }
+    }
+
+    It 'documents provider-switch in usage and writes a provider registry entry' {
+        $script:winsmuxCoreRawContent | Should -Match 'provider-switch <slot> \[--agent <name>\] \[--model <name>\] \[--prompt-transport <argv\|file\|stdin>\]'
+        $script:winsmuxCoreRawContent | Should -Match "'provider-switch'\s*\{"
+
+        Push-Location $script:providerSwitchTempRoot
+        try {
+            $output = & pwsh -NoProfile -File $script:winsmuxCoreRawPath provider-switch worker-1 --agent claude --model opus --prompt-transport file --reason 'operator requested provider switch' --json
+        } finally {
+            Pop-Location
+        }
+
+        $result = ($output | Select-Object -Last 1) | ConvertFrom-Json
+        $result.slot_id | Should -Be 'worker-1'
+        $result.agent | Should -Be 'claude'
+        $result.model | Should -Be 'opus'
+        $result.prompt_transport | Should -Be 'file'
+        $result.source | Should -Be 'registry'
+
+        $registryPath = Join-Path $script:providerSwitchTempRoot '.winsmux\provider-registry.json'
+        Test-Path -LiteralPath $registryPath | Should -Be $true
+        $registry = Get-Content -LiteralPath $registryPath -Raw -Encoding UTF8 | ConvertFrom-Json
+        $registry.slots.'worker-1'.agent | Should -Be 'claude'
+        $registry.slots.'worker-1'.model | Should -Be 'opus'
+        $registry.slots.'worker-1'.prompt_transport | Should -Be 'file'
+        $registry.slots.'worker-1'.reason | Should -Be 'operator requested provider switch'
+    }
+}
+
 Describe 'winsmux orchestra-smoke command' {
     BeforeAll {
         $script:winsmuxCoreRawPath = Join-Path (Split-Path -Parent $PSScriptRoot) 'scripts\winsmux-core.ps1'


### PR DESCRIPTION
## Summary
- add `winsmux provider-switch` for managed slot provider reassignment
- write runtime reassignment entries to `.winsmux/provider-registry.json`
- validate target slots against `agent_slots` and return effective registry-backed config as JSON

## Validation
- Invoke-Pester -Path .\tests\winsmux-bridge.Tests.ps1 -Output Detailed -FullNameFilter 'winsmux provider-switch command*'
- Invoke-Pester -Path .\tests\winsmux-bridge.Tests.ps1 -Output Detailed
- pwsh -NoProfile -File .\scripts\git-guard.ps1 -Mode full
- pwsh -NoProfile -File .\scripts\audit-public-surface.ps1

## Notes
- This continues TASK-313 after the registry foundation in #537.