### PR TITLE
Apply provider registry during pane restart

### DIFF
--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -1427,6 +1427,52 @@ panes:
         $plan.LaunchCommand | Should -Be 'claude --permission-mode bypassPermissions'
     }
 
+    It 'uses provider registry overrides when building a restart plan' {
+@"
+version: 1
+saved_at: '2026-04-07T00:00:00+09:00'
+session:
+  name: 'winsmux-orchestra'
+  project_dir: '${script:paneControlTempRoot}'
+  git_worktree_dir: '${script:paneControlTempRoot}\.git'
+panes:
+  - label: 'worker-1'
+    pane_id: '%2'
+    role: 'Worker'
+    exec_mode: false
+    launch_dir: '${script:paneControlTempRoot}'
+    task: null
+"@ | Set-Content -Path (Join-Path $script:paneControlManifestDir 'manifest.yaml') -Encoding UTF8
+
+        @"
+agent: codex
+model: gpt-5.4
+agent_slots:
+  - slot_id: worker-1
+    runtime_role: worker
+    agent: codex
+    model: gpt-5.4
+    prompt_transport: argv
+"@ | Set-Content -Path (Join-Path $script:paneControlTempRoot '.winsmux.yaml') -Encoding UTF8
+
+        Write-BridgeProviderRegistryEntry `
+            -RootPath $script:paneControlTempRoot `
+            -SlotId 'worker-1' `
+            -Agent 'claude' `
+            -Model 'opus' `
+            -PromptTransport 'file' `
+            -Reason 'operator requested provider hot-swap' | Out-Null
+        $settings = Get-BridgeSettings -RootPath $script:paneControlTempRoot
+
+        $plan = Get-PaneControlRestartPlan -ProjectDir $script:paneControlTempRoot -PaneId '%2' -Settings $settings
+
+        $plan.Agent | Should -Be 'claude'
+        $plan.Model | Should -Be 'opus'
+        $plan.PromptTransport | Should -Be 'file'
+        $plan.Source | Should -Be 'registry'
+        $plan.LaunchCommand | Should -Be 'claude --permission-mode bypassPermissions'
+    }
+
     It 'includes slot-level prompt transport overrides in the restart plan' {
 @'
 version: 1
@@ -2046,6 +2092,78 @@ panes:
                         runtime_role = 'worker'
                         agent = 'claude'
                         model = 'sonnet'
+                    }
+                )
+            }) -ManifestPath $manifestPath -SessionName 'winsmux-orchestra' | Out-Null
+
+            Should -Invoke Get-PaneAgentStatus -Times 1 -Exactly -ParameterFilter {
+                $PaneId -eq '%4' -and $Agent -eq 'claude' -and $Role -eq 'Worker'
+            }
+        } finally {
+            if (Test-Path $tempRoot) {
+                Remove-Item -Path $tempRoot -Recurse -Force
+            }
+        }
+    }
+
+    It 'uses provider registry overrides during a monitor cycle' {
+        $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('winsmux-agent-monitor-tests-' + [guid]::NewGuid().ToString('N'))
+        $manifestDir = Join-Path $tempRoot '.winsmux'
+        $manifestPath = Join-Path $manifestDir 'manifest.yaml'
+
+        try {
+            New-Item -ItemType Directory -Path $manifestDir -Force | Out-Null
+@"
+version: 1
+session:
+  name: winsmux-orchestra
+  project_dir: $tempRoot
+panes:
+  worker-2:
+    pane_id: %4
+    role: Worker
+    launch_dir: $tempRoot
+"@ | Set-Content -Path $manifestPath -Encoding UTF8
+            Write-BridgeProviderRegistryEntry `
+                -RootPath $tempRoot `
+                -SlotId 'worker-2' `
+                -Agent 'claude' `
+                -Model 'opus' `
+                -PromptTransport 'file' `
+                -Reason 'operator requested provider hot-swap' | Out-Null
+
+            Mock Get-PaneAgentStatus {
+                [PSCustomObject]@{
+                    Status       = 'ready'
+                    PaneId       = '%4'
+                    SnapshotTail = ''
+                    SnapshotHash = 'hash-worker'
+                    ExitReason   = ''
+                }
+            }
+            Mock Update-MonitorIdleAlertState {
+                [ordered]@{
+                    ShouldAlert = $false
+                    Message     = ''
+                }
+            }
+            Mock Test-BuilderStall { $false }
+
+            Invoke-AgentMonitorCycle -Settings ([ordered]@{
+                agent = 'codex'
+                model = 'gpt-5.4'
+                roles = [ordered]@{
+                    worker = [ordered]@{
+                        agent = 'codex'
+                        model = 'gpt-5.4'
+                    }
+                }
+                agent_slots = @(
+                    [ordered]@{
+                        slot_id = 'worker-2'
+                        runtime_role = 'worker'
+                        agent = 'codex'
+                        model = 'gpt-5.4'
                     }
                 )
             }) -ManifestPath $manifestPath -SessionName 'winsmux-orchestra' | Out-Null
@@ -8241,6 +8359,10 @@ Describe 'orchestra pane bootstrap plan' {
         $script:orchestraStartContent | Should -Match 'Start-OrchestraPaneBootstrap -PaneId \$paneId -PlanPath \$bootstrapPlanPath'
         $script:orchestraStartContent | Should -Match 'ready_marker_path'
         $script:orchestraStartContent | Should -Match 'Wait-OrchestraServerSessionAbsent -SessionName \$SessionName -TimeoutSeconds 20'
+    }
+
+    It 'passes the project root into slot provider resolution' {
+        $script:orchestraStartContent | Should -Match 'Get-SlotAgentConfig -Role \$canonicalRole -SlotId \$label -Settings \$settings -RootPath \$projectDir'
     }
 
     It 'prints a concise startup summary before invoking the agent launch command' {

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -589,6 +589,43 @@ agent-slots:
         } | Should -Throw '*prompt_transport*'
     }
 
+    It 'rejects structurally malformed provider registries' {
+        $registryPath = Get-BridgeProviderRegistryPath -RootPath $script:settingsTempRoot
+        $registryDir = Split-Path -Parent $registryPath
+        New-Item -ItemType Directory -Path $registryDir -Force | Out-Null
+
+        @'
+{
+  "version": 1,
+  "slots": []
+}
+'@ | Set-Content -Path $registryPath -Encoding UTF8
+        { Read-BridgeProviderRegistry -RootPath $script:settingsTempRoot } | Should -Throw '*provider registry slots*'
+
+        @'
+{
+  "version": 1,
+  "slots": {
+    "worker-1": "claude"
+  }
+}
+'@ | Set-Content -Path $registryPath -Encoding UTF8
+        { Read-BridgeProviderRegistry -RootPath $script:settingsTempRoot } | Should -Throw "*provider registry slot 'worker-1'*"
+
+        @'
+{
+  "version": 1,
+  "slots": {
+    "worker-1": {
+      "updated_at_utc": "2026-04-21T00:00:00Z",
+      "reason": "metadata only"
+    }
+  }
+}
+'@ | Set-Content -Path $registryPath -Encoding UTF8
+        { Read-BridgeProviderRegistry -RootPath $script:settingsTempRoot } | Should -Throw "*provider registry slot 'worker-1'*"
+    }
+
     It 'fails closed when explicit agent slot entries are malformed' {
 @'
 agent: codex
@@ -2220,6 +2257,94 @@ panes:
         } finally {
             if (Test-Path $tempRoot) {
                 Remove-Item -Path $tempRoot -Recurse -Force
+            }
+        }
+    }
+
+    It 'fails closed when the provider registry structure is invalid during a monitor cycle' {
+        $cases = @(
+            [PSCustomObject]@{
+                Name = 'slots array'
+                Body = @'
+{
+  "version": 1,
+  "slots": []
+}
+'@
+                Message = '*provider registry slots*'
+            },
+            [PSCustomObject]@{
+                Name = 'scalar slot entry'
+                Body = @'
+{
+  "version": 1,
+  "slots": {
+    "worker-2": "claude"
+  }
+}
+'@
+                Message = "*provider registry slot 'worker-2'*"
+            },
+            [PSCustomObject]@{
+                Name = 'metadata-only slot entry'
+                Body = @'
+{
+  "version": 1,
+  "slots": {
+    "worker-2": {
+      "updated_at_utc": "2026-04-21T00:00:00Z",
+      "reason": "metadata only"
+    }
+  }
+}
+'@
+                Message = "*provider registry slot 'worker-2'*"
+            }
+        )
+
+        foreach ($case in $cases) {
+            $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('winsmux-agent-monitor-tests-' + [guid]::NewGuid().ToString('N'))
+            $manifestDir = Join-Path $tempRoot '.winsmux'
+            $manifestPath = Join-Path $manifestDir 'manifest.yaml'
+            $registryPath = Join-Path $manifestDir 'provider-registry.json'
+
+            try {
+                New-Item -ItemType Directory -Path $manifestDir -Force | Out-Null
+@"
+version: 1
+session:
+  name: winsmux-orchestra
+  project_dir: $tempRoot
+panes:
+  worker-2:
+    pane_id: %4
+    role: Worker
+    launch_dir: $tempRoot
+"@ | Set-Content -Path $manifestPath -Encoding UTF8
+                $case.Body | Set-Content -Path $registryPath -Encoding UTF8
+
+                Mock Get-PaneAgentStatus {
+                    throw "Get-PaneAgentStatus should not be called for malformed provider registry case '$($case.Name)'."
+                }
+                Mock Update-MonitorIdleAlertState { throw 'Update-MonitorIdleAlertState should not be called.' }
+                Mock Test-BuilderStall { throw 'Test-BuilderStall should not be called.' }
+
+                {
+                    Invoke-AgentMonitorCycle -Settings ([ordered]@{
+                        agent = 'codex'
+                        model = 'gpt-5.4'
+                        roles = [ordered]@{
+                            worker = [ordered]@{
+                                agent = 'codex'
+                                model = 'gpt-5.4'
+                            }
+                        }
+                    }) -ManifestPath $manifestPath -SessionName 'winsmux-orchestra'
+                } | Should -Throw $case.Message
+            } finally {
+                if (Test-Path $tempRoot) {
+                    Remove-Item -Path $tempRoot -Recurse -Force
+                }
             }
         }
     }
@@ -4768,6 +4893,76 @@ panes:
         {
             Get-PaneWorkload -ManifestPath $script:paneScalerManifestPath
         } | Should -Throw "*Invalid provider registry prompt_transport*"
+    }
+
+    It 'fails closed when provider registry structure is invalid through the pane scaling entrypoint' {
+        $cases = @(
+            [PSCustomObject]@{
+                Name = 'slots array'
+                Body = @'
+{
+  "version": 1,
+  "slots": []
+}
+'@
+                Message = '*provider registry slots*'
+            },
+            [PSCustomObject]@{
+                Name = 'scalar slot entry'
+                Body = @'
+{
+  "version": 1,
+  "slots": {
+    "builder-1": "claude"
+  }
+}
+'@
+                Message = "*provider registry slot 'builder-1'*"
+            },
+            [PSCustomObject]@{
+                Name = 'metadata-only slot entry'
+                Body = @'
+{
+  "version": 1,
+  "slots": {
+    "builder-1": {
+      "updated_at_utc": "2026-04-21T00:00:00Z",
+      "reason": "metadata only"
+    }
+  }
+}
+'@
+                Message = "*provider registry slot 'builder-1'*"
+            }
+        )
+
+        foreach ($case in $cases) {
+            @"
+version: 1
+saved_at: 2026-04-05T10:00:00+09:00
+session:
+  name: winsmux-orchestra
+  project_dir: $script:paneScalerTempRoot
+panes:
+  - label: builder-1
+    pane_id: %2
+    role: Builder
+"@ | Set-Content -Path $script:paneScalerManifestPath -Encoding UTF8
+            $case.Body | Set-Content -Path (Join-Path $script:paneScalerManifestDir 'provider-registry.json') -Encoding UTF8
+
+            Mock Get-PaneAgentStatus {
+                throw "Get-PaneAgentStatus should not be called for malformed provider registry case '$($case.Name)'."
+            }
+
+            Push-Location ([System.IO.Path]::GetTempPath())
+            try {
+                {
+                    Invoke-PaneScalingCheck -ManifestPath $script:paneScalerManifestPath -ScaleUpThreshold 0.95 -ScaleDownThreshold 0.0
+                } | Should -Throw $case.Message
+            } finally {
+                Pop-Location
+            }
+        }
     }
 
     It 'reads dictionary-style pane manifests written by orchestra-start' {

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -624,6 +624,21 @@ agent-slots:
 }
 '@ | Set-Content -Path $registryPath -Encoding UTF8
         { Read-BridgeProviderRegistry -RootPath $script:settingsTempRoot } | Should -Throw "*provider registry slot 'worker-1'*"
+
+        @'
+{
+  "version": 1,
+  "slots": {
+    "worker-1": {
+      "agent": {
+        "name": "claude"
+      },
+      "model": "opus"
+    }
+  }
+}
+'@ | Set-Content -Path $registryPath -Encoding UTF8
+        { Read-BridgeProviderRegistry -RootPath $script:settingsTempRoot } | Should -Throw "*provider registry field 'agent'*"
     }
 
     It 'fails closed when explicit agent slot entries are malformed' {
@@ -2299,6 +2314,23 @@ panes:
 }
 '@
                 Message = "*provider registry slot 'worker-2'*"
+            },
+            [PSCustomObject]@{
+                Name = 'non-scalar provider field'
+                Body = @'
+{
+  "version": 1,
+  "slots": {
+    "worker-2": {
+      "agent": {
+        "name": "claude"
+      },
+      "model": "opus"
+    }
+  }
+}
+'@
+                Message = "*provider registry field 'agent'*"
             }
         )
 
@@ -4933,6 +4965,23 @@ panes:
 }
 '@
                 Message = "*provider registry slot 'builder-1'*"
+            },
+            [PSCustomObject]@{
+                Name = 'non-scalar provider field'
+                Body = @'
+{
+  "version": 1,
+  "slots": {
+    "builder-1": {
+      "agent": {
+        "name": "claude"
+      },
+      "model": "opus"
+    }
+  }
+}
+'@
+                Message = "*provider registry field 'agent'*"
             }
         )
 

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -2178,6 +2178,52 @@ panes:
         }
     }
 
+    It 'fails closed when the provider registry is malformed during a monitor cycle' {
+        $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('winsmux-agent-monitor-tests-' + [guid]::NewGuid().ToString('N'))
+        $manifestDir = Join-Path $tempRoot '.winsmux'
+        $manifestPath = Join-Path $manifestDir 'manifest.yaml'
+        $registryPath = Join-Path $manifestDir 'provider-registry.json'
+
+        try {
+            New-Item -ItemType Directory -Path $manifestDir -Force | Out-Null
+@"
+version: 1
+session:
+  name: winsmux-orchestra
+  project_dir: $tempRoot
+panes:
+  worker-2:
+    pane_id: %4
+    role: Worker
+    launch_dir: $tempRoot
+"@ | Set-Content -Path $manifestPath -Encoding UTF8
+            '{ invalid json' | Set-Content -Path $registryPath -Encoding UTF8
+
+            Mock Get-PaneAgentStatus {
+                throw 'Get-PaneAgentStatus should not be called when provider registry is malformed.'
+            }
+            Mock Update-MonitorIdleAlertState { throw 'Update-MonitorIdleAlertState should not be called.' }
+            Mock Test-BuilderStall { throw 'Test-BuilderStall should not be called.' }
+
+            {
+                Invoke-AgentMonitorCycle -Settings ([ordered]@{
+                    agent = 'codex'
+                    model = 'gpt-5.4'
+                    roles = [ordered]@{
+                        worker = [ordered]@{
+                            agent = 'codex'
+                            model = 'gpt-5.4'
+                        }
+                    }
+                }) -ManifestPath $manifestPath -SessionName 'winsmux-orchestra'
+            } | Should -Throw "*Invalid provider registry JSON*"
+        } finally {
+            if (Test-Path $tempRoot) {
+                Remove-Item -Path $tempRoot -Recurse -Force
+            }
+        }
+    }
+
     It 'writes state, idle, and stalled events for detected pane states during a monitor cycle' {
         $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('winsmux-agent-monitor-tests-' + [guid]::NewGuid().ToString('N'))
         $manifestDir = Join-Path $tempRoot '.winsmux'
@@ -4601,6 +4647,48 @@ panes:
         $workload.BusyRatio | Should -BeLessThan 0.67
     }
 
+    It 'uses provider registry overrides when calculating Builder workload' {
+        @"
+version: 1
+saved_at: 2026-04-05T10:00:00+09:00
+session:
+  name: winsmux-orchestra
+  project_dir: $script:paneScalerTempRoot
+panes:
+  - label: builder-1
+    pane_id: %2
+    role: Builder
+"@ | Set-Content -Path $script:paneScalerManifestPath -Encoding UTF8
+        Write-BridgeProviderRegistryEntry `
+            -RootPath $script:paneScalerTempRoot `
+            -SlotId 'builder-1' `
+            -Agent 'claude' `
+            -Model 'opus' `
+            -PromptTransport 'file' `
+            -Reason 'operator requested provider hot-swap' | Out-Null
+
+        Mock Get-PaneAgentStatus {
+            [PSCustomObject]@{ Status = 'ready'; ExitReason = '' }
+        }
+
+        $settings = [ordered]@{
+            agent = 'codex'
+            model = 'gpt-5.4'
+            roles = [ordered]@{
+                builder = [ordered]@{
+                    agent = 'codex'
+                    model = 'gpt-5.4'
+                }
+            }
+        }
+
+        Get-PaneWorkload -ManifestPath $script:paneScalerManifestPath -Settings $settings | Out-Null
+
+        Should -Invoke Get-PaneAgentStatus -Times 1 -Exactly -ParameterFilter {
+            $PaneId -eq '%2' -and $Agent -eq 'claude' -and $Role -eq 'Builder'
+        }
+    }
+
     It 'reads dictionary-style pane manifests written by orchestra-start' {
         @"
 version: 1
@@ -4653,6 +4741,61 @@ panes:
         $content | Should -Match "panes:\r?\n  'builder-1':"
         $content | Should -Not -Match "panes:\r?\n  - label:"
         $content | Should -Match "saved_at: '2026-04-09T11:00:00\+09:00'"
+    }
+
+    It 'uses provider registry overrides when adding a Builder pane' {
+        @"
+version: 1
+saved_at: 2026-04-05T10:00:00+09:00
+session:
+  name: winsmux-orchestra
+  project_dir: $script:paneScalerTempRoot
+panes:
+  builder-1:
+    pane_id: %2
+    role: Builder
+    launch_dir: $script:paneScalerTempRoot
+"@ | Set-Content -Path $script:paneScalerManifestPath -Encoding UTF8
+        Write-BridgeProviderRegistryEntry `
+            -RootPath $script:paneScalerTempRoot `
+            -SlotId 'builder-2' `
+            -Agent 'claude' `
+            -Model 'opus' `
+            -PromptTransport 'file' `
+            -Reason 'operator requested provider hot-swap' | Out-Null
+
+        Mock New-PaneScalerBuilderWorktree {
+            [PSCustomObject]@{
+                BranchName     = 'worktree-builder-2'
+                WorktreePath   = Join-Path $script:paneScalerTempRoot '.worktrees\builder-2'
+                GitWorktreeDir = Join-Path $script:paneScalerTempRoot '.git\worktrees\builder-2'
+            }
+        }
+        Mock Invoke-MonitorWinsmux {
+            if ($Arguments -contains '-F') {
+                return '%3'
+            }
+            return ''
+        }
+        Mock Wait-MonitorPaneShellReady { }
+        Mock Send-MonitorBridgeCommand { }
+
+        $settings = [ordered]@{
+            agent = 'codex'
+            model = 'gpt-5.4'
+            roles = [ordered]@{
+                builder = [ordered]@{
+                    agent = 'codex'
+                    model = 'gpt-5.4'
+                }
+            }
+        }
+
+        Add-OrchestraPane -ManifestPath $script:paneScalerManifestPath -Settings $settings | Out-Null
+
+        Should -Invoke Send-MonitorBridgeCommand -Times 1 -Exactly -ParameterFilter {
+            $PaneId -eq '%3' -and $Text -eq 'claude --permission-mode bypassPermissions'
+        }
     }
 
     It 'scales up when workload exceeds the threshold' {

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -2706,6 +2706,21 @@ Describe 'agent-watchdog helpers' {
     }
 
     It 'runs a watchdog cycle through Invoke-AgentMonitorCycle with the requested thresholds' {
+        $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('winsmux-agent-watchdog-tests-' + [guid]::NewGuid().ToString('N'))
+        $manifestDir = Join-Path $tempRoot '.winsmux'
+        $manifestPath = Join-Path $manifestDir 'manifest.yaml'
+        New-Item -ItemType Directory -Path $manifestDir -Force | Out-Null
+@"
+version: 1
+session:
+  name: winsmux-orchestra
+  project_dir: $tempRoot
+panes:
+  worker-1:
+    pane_id: %2
+    role: Worker
+"@ | Set-Content -Path $manifestPath -Encoding UTF8
+
         Mock Get-BridgeSettings {
             [ordered]@{
                 agent = 'codex'
@@ -2724,13 +2739,22 @@ Describe 'agent-watchdog helpers' {
             }
         }
 
-        $result = Invoke-AgentWatchdogCycle -ManifestPath 'C:\repo\.winsmux\manifest.yaml' -SessionName 'winsmux-orchestra' -IdleThreshold 120
+        try {
+            $result = Invoke-AgentWatchdogCycle -ManifestPath $manifestPath -SessionName 'winsmux-orchestra' -IdleThreshold 120
 
-        $result.Checked | Should -Be 1
-        Should -Invoke Invoke-AgentMonitorCycle -Times 1 -Exactly -ParameterFilter {
-            $ManifestPath -eq 'C:\repo\.winsmux\manifest.yaml' -and
-            $SessionName -eq 'winsmux-orchestra' -and
-            $IdleThreshold -eq 120
+            $result.Checked | Should -Be 1
+            Should -Invoke Get-BridgeSettings -Times 1 -Exactly -ParameterFilter {
+                $RootPath -eq $tempRoot
+            }
+            Should -Invoke Invoke-AgentMonitorCycle -Times 1 -Exactly -ParameterFilter {
+                $ManifestPath -eq $manifestPath -and
+                $SessionName -eq 'winsmux-orchestra' -and
+                $IdleThreshold -eq 120
+            }
+        } finally {
+            if (Test-Path $tempRoot) {
+                Remove-Item -Path $tempRoot -Recurse -Force
+            }
         }
     }
 
@@ -4671,22 +4695,79 @@ panes:
             [PSCustomObject]@{ Status = 'ready'; ExitReason = '' }
         }
 
-        $settings = [ordered]@{
-            agent = 'codex'
-            model = 'gpt-5.4'
-            roles = [ordered]@{
-                builder = [ordered]@{
-                    agent = 'codex'
-                    model = 'gpt-5.4'
-                }
-            }
-        }
-
-        Get-PaneWorkload -ManifestPath $script:paneScalerManifestPath -Settings $settings | Out-Null
+        Get-PaneWorkload -ManifestPath $script:paneScalerManifestPath | Out-Null
 
         Should -Invoke Get-PaneAgentStatus -Times 1 -Exactly -ParameterFilter {
             $PaneId -eq '%2' -and $Agent -eq 'claude' -and $Role -eq 'Builder'
         }
+    }
+
+    It 'uses provider registry overrides through the pane scaling entrypoint without explicit settings' {
+        @"
+version: 1
+saved_at: 2026-04-05T10:00:00+09:00
+session:
+  name: winsmux-orchestra
+  project_dir: $script:paneScalerTempRoot
+panes:
+  - label: builder-1
+    pane_id: %2
+    role: Builder
+"@ | Set-Content -Path $script:paneScalerManifestPath -Encoding UTF8
+        Write-BridgeProviderRegistryEntry `
+            -RootPath $script:paneScalerTempRoot `
+            -SlotId 'builder-1' `
+            -Agent 'claude' `
+            -Model 'opus' `
+            -PromptTransport 'file' `
+            -Reason 'operator requested provider hot-swap' | Out-Null
+
+        Mock Get-PaneAgentStatus {
+            [PSCustomObject]@{ Status = 'ready'; ExitReason = '' }
+        }
+
+        Push-Location ([System.IO.Path]::GetTempPath())
+        try {
+            Invoke-PaneScalingCheck -ManifestPath $script:paneScalerManifestPath -ScaleUpThreshold 0.95 -ScaleDownThreshold 0.0 | Out-Null
+        } finally {
+            Pop-Location
+        }
+
+        Should -Invoke Get-PaneAgentStatus -Times 1 -Exactly -ParameterFilter {
+            $PaneId -eq '%2' -and $Agent -eq 'claude' -and $Role -eq 'Builder'
+        }
+    }
+
+    It 'fails closed when the provider registry is malformed during Builder workload calculation' {
+        @"
+version: 1
+saved_at: 2026-04-05T10:00:00+09:00
+session:
+  name: winsmux-orchestra
+  project_dir: $script:paneScalerTempRoot
+panes:
+  - label: builder-1
+    pane_id: %2
+    role: Builder
+"@ | Set-Content -Path $script:paneScalerManifestPath -Encoding UTF8
+        @'
+{
+  "version": 1,
+  "slots": {
+    "builder-1": {
+      "prompt_transport": "pipe"
+    }
+  }
+}
+'@ | Set-Content -Path (Join-Path $script:paneScalerManifestDir 'provider-registry.json') -Encoding UTF8
+
+        Mock Get-PaneAgentStatus {
+            throw 'Get-PaneAgentStatus should not be called when provider registry is malformed.'
+        }
+
+        {
+            Get-PaneWorkload -ManifestPath $script:paneScalerManifestPath
+        } | Should -Throw "*Invalid provider registry prompt_transport*"
     }
 
     It 'reads dictionary-style pane manifests written by orchestra-start' {

--- a/winsmux-core/scripts/agent-monitor.ps1
+++ b/winsmux-core/scripts/agent-monitor.ps1
@@ -1156,7 +1156,7 @@ function Invoke-AgentMonitorCycle {
         $roleAgentConfig = $null
         try {
             if (Get-Command Get-SlotAgentConfig -ErrorAction SilentlyContinue) {
-                $roleAgentConfig = Get-SlotAgentConfig -Role $role -SlotId $label -Settings $Settings
+                $roleAgentConfig = Get-SlotAgentConfig -Role $role -SlotId $label -Settings $Settings -RootPath $projectDir
             } else {
                 $roleAgentConfig = Get-RoleAgentConfig -Role $role -Settings $Settings
             }
@@ -1530,7 +1530,7 @@ if ($MyInvocation.InvocationName -ne '.') {
         exit 1
     }
 
-    $settings = Get-BridgeSettings
+    $settings = Get-BridgeSettings -RootPath $resolvedProjectDir
     $result = Invoke-AgentMonitorCycle `
         -Settings $settings `
         -ManifestPath $manifestPath `

--- a/winsmux-core/scripts/agent-monitor.ps1
+++ b/winsmux-core/scripts/agent-monitor.ps1
@@ -1154,17 +1154,17 @@ function Invoke-AgentMonitorCycle {
 
         # Determine agent config for this role
         $roleAgentConfig = $null
-        try {
-            if (Get-Command Get-SlotAgentConfig -ErrorAction SilentlyContinue) {
-                $roleAgentConfig = Get-SlotAgentConfig -Role $role -SlotId $label -Settings $Settings -RootPath $projectDir
-            } else {
+        if (Get-Command Get-SlotAgentConfig -ErrorAction SilentlyContinue) {
+            $roleAgentConfig = Get-SlotAgentConfig -Role $role -SlotId $label -Settings $Settings -RootPath $projectDir
+        } else {
+            try {
                 $roleAgentConfig = Get-RoleAgentConfig -Role $role -Settings $Settings
-            }
-        } catch {
-            # Fallback to default settings
-            $roleAgentConfig = [ordered]@{
-                Agent = [string]$Settings.agent
-                Model = [string]$Settings.model
+            } catch {
+                # Fallback to default settings when only the legacy role helper is unavailable or malformed.
+                $roleAgentConfig = [ordered]@{
+                    Agent = [string]$Settings.agent
+                    Model = [string]$Settings.model
+                }
             }
         }
 

--- a/winsmux-core/scripts/agent-watchdog.ps1
+++ b/winsmux-core/scripts/agent-watchdog.ps1
@@ -22,7 +22,10 @@ function Invoke-AgentWatchdogCycle {
         [AllowNull()][System.Collections.IDictionary]$PreviousResults = $null
     )
 
-    $settings = Get-BridgeSettings
+    $content = Get-Content -Path $ManifestPath -Raw -Encoding UTF8
+    $manifest = ConvertFrom-MonitorManifest -Content $content
+    $projectDir = Get-MonitorProjectDir -Manifest $manifest -ManifestPath $ManifestPath
+    $settings = Get-BridgeSettings -RootPath $projectDir
     return (Invoke-AgentMonitorCycle -Settings $settings -ManifestPath $ManifestPath -SessionName $SessionName -IdleThreshold $IdleThreshold -PreviousResults $PreviousResults)
 }
 

--- a/winsmux-core/scripts/orchestra-start.ps1
+++ b/winsmux-core/scripts/orchestra-start.ps1
@@ -1997,7 +1997,7 @@ if ($MyInvocation.InvocationName -ne '.') {
             $builderWorktreePath = $builderWorktree.WorktreePath
         }
 
-        $slotAgentConfig = Get-SlotAgentConfig -Role $canonicalRole -SlotId $label -Settings $settings
+        $slotAgentConfig = Get-SlotAgentConfig -Role $canonicalRole -SlotId $label -Settings $settings -RootPath $projectDir
         $execMode = ([string]$slotAgentConfig.Agent).Trim().ToLowerInvariant() -eq 'codex'
         $launchCommand = Get-AgentLaunchCommand -Agent $slotAgentConfig.Agent -Model $slotAgentConfig.Model -ProjectDir $launchDir -GitWorktreeDir $launchGitWorktreeDir -ExecMode $false
 

--- a/winsmux-core/scripts/pane-control.ps1
+++ b/winsmux-core/scripts/pane-control.ps1
@@ -516,7 +516,7 @@ function Get-PaneControlRestartPlan {
 
     if ($null -eq $Settings) {
         if (Get-Command Get-BridgeSettings -ErrorAction SilentlyContinue) {
-            $Settings = Get-BridgeSettings
+            $Settings = Get-BridgeSettings -RootPath $ProjectDir
         } else {
             $Settings = [ordered]@{
                 agent = 'codex'
@@ -529,7 +529,7 @@ function Get-PaneControlRestartPlan {
     $context = Get-PaneControlManifestContext -ProjectDir $ProjectDir -PaneId $PaneId
     $agentConfig = $null
     if (Get-Command Get-SlotAgentConfig -ErrorAction SilentlyContinue) {
-        $agentConfig = Get-SlotAgentConfig -Role $context.Role -SlotId $context.Label -Settings $Settings
+        $agentConfig = Get-SlotAgentConfig -Role $context.Role -SlotId $context.Label -Settings $Settings -RootPath $ProjectDir
     } elseif (Get-Command Get-RoleAgentConfig -ErrorAction SilentlyContinue) {
         $agentConfig = Get-RoleAgentConfig -Role $context.Role -Settings $Settings
     } else {
@@ -551,6 +551,7 @@ function Get-PaneControlRestartPlan {
         Agent          = [string]$agentConfig.Agent
         Model          = [string]$agentConfig.Model
         PromptTransport = [string]$agentConfig.PromptTransport
+        Source         = [string]$agentConfig.Source
         LaunchCommand  = $launchCommand
     }
 }

--- a/winsmux-core/scripts/pane-scaler.ps1
+++ b/winsmux-core/scripts/pane-scaler.ps1
@@ -280,11 +280,12 @@ function Get-PaneWorkload {
         [int]$HungThreshold = 120
     )
 
+    $manifest = Read-PaneScalerManifest -ManifestPath $ManifestPath
+    $projectDir = Get-PaneScalerProjectDir -Manifest $manifest -ManifestPath $ManifestPath
     if ($null -eq $Settings) {
-        $Settings = Get-BridgeSettings
+        $Settings = Get-BridgeSettings -RootPath $projectDir
     }
 
-    $manifest = Read-PaneScalerManifest -ManifestPath $ManifestPath
     $builderPanes = @(Get-PaneScalerBuilderPanes -Manifest $manifest)
     $statusResults = [System.Collections.Generic.List[object]]::new()
     $busyCount = 0
@@ -298,16 +299,16 @@ function Get-PaneWorkload {
         }
 
         $roleAgentConfig = $null
-        try {
-            if (Get-Command Get-SlotAgentConfig -ErrorAction SilentlyContinue) {
-                $roleAgentConfig = Get-SlotAgentConfig -Role 'Builder' -SlotId $label -Settings $Settings
-            } else {
+        if (Get-Command Get-SlotAgentConfig -ErrorAction SilentlyContinue) {
+            $roleAgentConfig = Get-SlotAgentConfig -Role 'Builder' -SlotId $label -Settings $Settings -RootPath $projectDir
+        } else {
+            try {
                 $roleAgentConfig = Get-RoleAgentConfig -Role 'Builder' -Settings $Settings
-            }
-        } catch {
-            $roleAgentConfig = [PSCustomObject]@{
-                Agent = [string]$Settings.agent
-                Model = [string]$Settings.model
+            } catch {
+                $roleAgentConfig = [PSCustomObject]@{
+                    Agent = [string]$Settings.agent
+                    Model = [string]$Settings.model
+                }
             }
         }
 
@@ -334,7 +335,7 @@ function Get-PaneWorkload {
 
     return [PSCustomObject]@{
         Manifest     = $manifest
-        ProjectDir   = Get-PaneScalerProjectDir -Manifest $manifest -ManifestPath $ManifestPath
+        ProjectDir   = $projectDir
         SessionName  = [string](Get-MonitorPropertyValue -InputObject $manifest.Session -Name 'name' -Default 'winsmux-orchestra')
         BusyPanes    = $busyCount
         TotalPanes   = $totalCount
@@ -350,12 +351,12 @@ function Add-OrchestraPane {
         $Settings = $null
     )
 
-    if ($null -eq $Settings) {
-        $Settings = Get-BridgeSettings
-    }
-
     $manifest = Read-PaneScalerManifest -ManifestPath $ManifestPath
     $projectDir = Get-PaneScalerProjectDir -Manifest $manifest -ManifestPath $ManifestPath
+    if ($null -eq $Settings) {
+        $Settings = Get-BridgeSettings -RootPath $projectDir
+    }
+
     $builderPanes = @(Get-PaneScalerBuilderPanes -Manifest $manifest)
     if ($builderPanes.Count -eq 0) {
         throw 'Cannot add a Builder pane because no existing Builder pane was found.'
@@ -376,26 +377,26 @@ function Add-OrchestraPane {
     $newPaneId = ''
     try {
         $worktree = New-PaneScalerBuilderWorktree -ProjectDir $projectDir -BuilderIndex $nextIndex
-        $splitOutput = Invoke-MonitorPsmux -Arguments @('split-window', '-t', $seedPaneId, '-h', '-c', $worktree.WorktreePath, '-P', '-F', '#{pane_id}') -CaptureOutput
+        $splitOutput = Invoke-MonitorWinsmux -Arguments @('split-window', '-t', $seedPaneId, '-h', '-c', $worktree.WorktreePath, '-P', '-F', '#{pane_id}') -CaptureOutput
         $newPaneId = (($splitOutput | Out-String).Trim() -split "\r?\n" | Where-Object { $_ -match '^%\d+$' } | Select-Object -Last 1)
         if ([string]::IsNullOrWhiteSpace($newPaneId)) {
             throw 'winsmux split-window did not return a pane id.'
         }
 
         $newLabel = "builder-$nextIndex"
-        Invoke-MonitorPsmux -Arguments @('select-pane', '-t', $newPaneId, '-T', $newLabel) | Out-Null
+        Invoke-MonitorWinsmux -Arguments @('select-pane', '-t', $newPaneId, '-T', $newLabel) | Out-Null
 
         $roleAgentConfig = $null
-        try {
-            if (Get-Command Get-SlotAgentConfig -ErrorAction SilentlyContinue) {
-                $roleAgentConfig = Get-SlotAgentConfig -Role 'Builder' -SlotId $newLabel -Settings $Settings
-            } else {
+        if (Get-Command Get-SlotAgentConfig -ErrorAction SilentlyContinue) {
+            $roleAgentConfig = Get-SlotAgentConfig -Role 'Builder' -SlotId $newLabel -Settings $Settings -RootPath $projectDir
+        } else {
+            try {
                 $roleAgentConfig = Get-RoleAgentConfig -Role 'Builder' -Settings $Settings
-            }
-        } catch {
-            $roleAgentConfig = [PSCustomObject]@{
-                Agent = [string]$Settings.agent
-                Model = [string]$Settings.model
+            } catch {
+                $roleAgentConfig = [PSCustomObject]@{
+                    Agent = [string]$Settings.agent
+                    Model = [string]$Settings.model
+                }
             }
         }
 
@@ -433,7 +434,7 @@ function Add-OrchestraPane {
     } catch {
         if (-not [string]::IsNullOrWhiteSpace($newPaneId)) {
             try {
-                Invoke-MonitorPsmux -Arguments @('kill-pane', '-t', $newPaneId) | Out-Null
+                Invoke-MonitorWinsmux -Arguments @('kill-pane', '-t', $newPaneId) | Out-Null
             } catch {
             }
         }
@@ -490,7 +491,7 @@ function Remove-OrchestraPane {
     $branchName = [string](Get-MonitorPropertyValue -InputObject $pane -Name 'builder_branch' -Default '')
 
     if (-not [string]::IsNullOrWhiteSpace($paneId)) {
-        Invoke-MonitorPsmux -Arguments @('kill-pane', '-t', $paneId) | Out-Null
+        Invoke-MonitorWinsmux -Arguments @('kill-pane', '-t', $paneId) | Out-Null
     }
 
     Remove-PaneScalerBuilderWorktree -ProjectDir $projectDir -WorktreePath $worktreePath -BranchName $branchName

--- a/winsmux-core/scripts/pane-scaler.ps1
+++ b/winsmux-core/scripts/pane-scaler.ps1
@@ -457,10 +457,6 @@ function Remove-OrchestraPane {
         [int]$MinimumBuilders = 2
     )
 
-    if ($null -eq $Settings) {
-        $Settings = Get-BridgeSettings
-    }
-
     $workload = Get-PaneWorkload -ManifestPath $ManifestPath -Settings $Settings
     if ($workload.BuilderCount -le $MinimumBuilders) {
         return [PSCustomObject]@{
@@ -517,10 +513,6 @@ function Invoke-PaneScalingCheck {
         [double]$ScaleDownThreshold = 0.3,
         [int]$MinimumBuilders = 2
     )
-
-    if ($null -eq $Settings) {
-        $Settings = Get-BridgeSettings
-    }
 
     $workload = Get-PaneWorkload -ManifestPath $ManifestPath -Settings $Settings
     if ($workload.TotalPanes -eq 0) {

--- a/winsmux-core/scripts/settings.ps1
+++ b/winsmux-core/scripts/settings.ps1
@@ -286,6 +286,20 @@ function Test-BridgeProviderRegistryObject {
     return (($Value -is [System.Collections.IDictionary]) -or ($Value -is [PSCustomObject]))
 }
 
+function Test-BridgeProviderRegistryScalarValue {
+    param([AllowNull()]$Value)
+
+    if ($null -eq $Value) {
+        return $true
+    }
+
+    if ($Value -is [string] -or $Value -is [char]) {
+        return $true
+    }
+
+    return ($Value -is [ValueType])
+}
+
 function Get-BridgeProviderRegistryObjectProperties {
     param([Parameter(Mandatory = $true)]$Value)
 
@@ -329,8 +343,16 @@ function ConvertTo-BridgeProviderRegistryEntry {
             continue
         }
 
+        if (-not (Test-BridgeProviderRegistryScalarValue $pair.Value)) {
+            throw "Invalid provider registry field '$key'."
+        }
+
         $text = ConvertFrom-BridgeYamlScalar $pair.Value
         if ([string]::IsNullOrWhiteSpace($text)) {
+            if ($key -in @('agent', 'model', 'prompt_transport')) {
+                throw "Invalid provider registry field '$key'."
+            }
+
             continue
         }
 

--- a/winsmux-core/scripts/settings.ps1
+++ b/winsmux-core/scripts/settings.ps1
@@ -280,6 +280,27 @@ function Get-BridgeProviderRegistryPath {
     return Join-Path (Join-Path $RootPath '.winsmux') $script:BridgeProviderRegistryFileName
 }
 
+function Test-BridgeProviderRegistryObject {
+    param([AllowNull()]$Value)
+
+    return (($Value -is [System.Collections.IDictionary]) -or ($Value -is [PSCustomObject]))
+}
+
+function Get-BridgeProviderRegistryObjectProperties {
+    param([Parameter(Mandatory = $true)]$Value)
+
+    if ($Value -is [System.Collections.IDictionary]) {
+        return @($Value.GetEnumerator() | ForEach-Object {
+            [PSCustomObject]@{
+                Name  = $_.Key
+                Value = $_.Value
+            }
+        })
+    }
+
+    return @($Value.PSObject.Properties)
+}
+
 function ConvertTo-BridgeProviderRegistryEntry {
     param([AllowNull()]$Value)
 
@@ -290,7 +311,7 @@ function ConvertTo-BridgeProviderRegistryEntry {
     $pairs = @()
     if ($Value -is [System.Collections.IDictionary]) {
         $pairs = $Value.GetEnumerator()
-    } elseif ($null -ne $Value.PSObject) {
+    } elseif ($Value -is [PSCustomObject]) {
         $pairs = $Value.PSObject.Properties | ForEach-Object {
             [PSCustomObject]@{
                 Key = $_.Name
@@ -351,6 +372,10 @@ function Read-BridgeProviderRegistry {
         throw "Invalid provider registry JSON at '$path'."
     }
 
+    if (-not (Test-BridgeProviderRegistryObject $parsed)) {
+        throw "Invalid provider registry JSON at '$path'."
+    }
+
     $version = 1
     if ($null -ne $parsed.PSObject -and $parsed.PSObject.Properties.Name -contains 'version') {
         $version = [int]$parsed.version
@@ -364,16 +389,26 @@ function Read-BridgeProviderRegistry {
         return $registry
     }
 
-    foreach ($slotProperty in $parsed.slots.PSObject.Properties) {
+    if (-not (Test-BridgeProviderRegistryObject $parsed.slots)) {
+        throw "Invalid provider registry slots at '$path'."
+    }
+
+    foreach ($slotProperty in (Get-BridgeProviderRegistryObjectProperties $parsed.slots)) {
         $slotId = ConvertFrom-BridgeYamlScalar $slotProperty.Name
         if ([string]::IsNullOrWhiteSpace($slotId)) {
-            continue
+            throw "Invalid provider registry slot id at '$path'."
+        }
+
+        if (-not (Test-BridgeProviderRegistryObject $slotProperty.Value)) {
+            throw "Invalid provider registry slot '$slotId' at '$path'."
         }
 
         $entry = ConvertTo-BridgeProviderRegistryEntry $slotProperty.Value
-        if ($null -ne $entry) {
-            $registry.slots[$slotId] = $entry
+        if ($null -eq $entry) {
+            throw "Invalid provider registry slot '$slotId' at '$path'."
         }
+
+        $registry.slots[$slotId] = $entry
     }
 
     return $registry


### PR DESCRIPTION
## Summary
- apply provider registry overrides when building pane restart plans
- apply provider registry overrides during monitor cycles and orchestra startup
- add Pester coverage for registry-backed restart and monitor behavior

## Validation
- Invoke-Pester -Path .\tests\winsmux-bridge.Tests.ps1 -Output Detailed -FullNameFilter 'pane-control helpers*'
- Invoke-Pester -Path .\tests\winsmux-bridge.Tests.ps1 -Output Detailed -FullNameFilter 'agent-monitor helpers*'
- Invoke-Pester -Path .\tests\winsmux-bridge.Tests.ps1 -Output Detailed -FullNameFilter 'orchestra pane bootstrap plan*'
- Invoke-Pester -Path .\tests\winsmux-bridge.Tests.ps1 -Output Detailed
- git diff --check
- pwsh -NoProfile -File .\scripts\git-guard.ps1 -Mode full
- pwsh -NoProfile -File .\scripts\audit-public-surface.ps1