### PR TITLE
TASK-313 provider-switch restart path

### DIFF
--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -7009,7 +7009,7 @@ function Invoke-ProviderSwitch {
             Stop-WithError "provider-switch --restart target slot '$slotId' is not present in the orchestra manifest."
         }
 
-        $restartPaneId = [string]$manifestEntry[0].PaneId
+        $restartPaneId = Confirm-Target ([string]$manifestEntry[0].PaneId)
     }
 
     $entry = Write-BridgeProviderRegistryEntry -RootPath $projectDir -SlotId $slotId -Agent $agent -Model $model -PromptTransport $promptTransport -Reason $reason

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -6933,7 +6933,7 @@ function Invoke-ConsultError {
 function Invoke-ProviderSwitch {
     $tokens = @(@($Target) + @($Rest) | Where-Object { $_ })
     if ($tokens.Count -lt 1) {
-        Stop-WithError "usage: winsmux provider-switch <slot> [--agent <name>] [--model <name>] [--prompt-transport <argv|file|stdin>] [--reason <text>] [--json]"
+        Stop-WithError "usage: winsmux provider-switch <slot> [--agent <name>] [--model <name>] [--prompt-transport <argv|file|stdin>] [--reason <text>] [--restart] [--json]"
     }
 
     $slotId = [string]$tokens[0]
@@ -6941,6 +6941,7 @@ function Invoke-ProviderSwitch {
     $model = ''
     $promptTransport = ''
     $reason = ''
+    $restartRequested = $false
     $jsonOutput = $false
 
     for ($index = 1; $index -lt $tokens.Count; $index++) {
@@ -6976,8 +6977,11 @@ function Invoke-ProviderSwitch {
             '--json' {
                 $jsonOutput = $true
             }
+            '--restart' {
+                $restartRequested = $true
+            }
             default {
-                Stop-WithError "usage: winsmux provider-switch <slot> [--agent <name>] [--model <name>] [--prompt-transport <argv|file|stdin>] [--reason <text>] [--json]"
+                Stop-WithError "usage: winsmux provider-switch <slot> [--agent <name>] [--model <name>] [--prompt-transport <argv|file|stdin>] [--reason <text>] [--restart] [--json]"
             }
         }
     }
@@ -6995,6 +6999,19 @@ function Invoke-ProviderSwitch {
         Stop-WithError "provider-switch target slot '$slotId' is not present in agent_slots."
     }
 
+    $restartPaneId = ''
+    if ($restartRequested) {
+        $manifestEntry = @(Get-PaneControlManifestEntries -ProjectDir $projectDir | Where-Object {
+            [string]::Equals([string]$_.Label, $slotId, [System.StringComparison]::OrdinalIgnoreCase)
+        } | Select-Object -First 1)
+
+        if ($manifestEntry.Count -lt 1) {
+            Stop-WithError "provider-switch --restart target slot '$slotId' is not present in the orchestra manifest."
+        }
+
+        $restartPaneId = [string]$manifestEntry[0].PaneId
+    }
+
     $entry = Write-BridgeProviderRegistryEntry -RootPath $projectDir -SlotId $slotId -Agent $agent -Model $model -PromptTransport $promptTransport -Reason $reason
     $effective = Get-SlotAgentConfig -Role 'Worker' -SlotId $slotId -Settings $settings -RootPath $projectDir
     $result = [ordered]@{
@@ -7006,6 +7023,15 @@ function Invoke-ProviderSwitch {
         registry_path    = Get-BridgeProviderRegistryPath -RootPath $projectDir
         updated_at_utc   = [string]$entry.updated_at_utc
         reason           = if ($entry.Contains('reason')) { [string]$entry.reason } else { '' }
+        restart_requested = $restartRequested
+        restarted        = $false
+        restart_pane_id  = ''
+    }
+
+    if ($restartRequested) {
+        $restartResult = Invoke-RestartPane -PaneId $restartPaneId -ProjectDir $projectDir
+        $result['restarted'] = $true
+        $result['restart_pane_id'] = [string]$restartResult.PaneId
     }
 
     if ($jsonOutput) {
@@ -7049,7 +7075,7 @@ Commands:
   consult-request <mode> [--message <text>] [--target-slot <slot>]  Record a consultation request packet/event
   consult-result <mode> [--message <text>] [--target-slot <slot>] [--confidence <0..1>] [--next-test <text>] [--risk <text>] [--run-id <run_id>] [--json]  Record a consultation result packet/event
   consult-error <mode> [--message <text>] [--target-slot <slot>]  Record a consultation error packet/event
-  provider-switch <slot> [--agent <name>] [--model <name>] [--prompt-transport <argv|file|stdin>] [--reason <text>] [--json]  Record a runtime provider reassignment for a managed slot
+  provider-switch <slot> [--agent <name>] [--model <name>] [--prompt-transport <argv|file|stdin>] [--reason <text>] [--restart] [--json]  Record a runtime provider reassignment for a managed slot
   locks                     List active file locks
   verify <pr-number>        Run Pester in tests/ and merge PR only on PASS
   wait <channel> [timeout]  Block until signal received (replaces polling)
@@ -7218,6 +7244,61 @@ function Invoke-Kill {
     Write-Output "killed $paneId"
 }
 
+function Invoke-RestartPane {
+    param(
+        [Parameter(Mandatory = $true)][string]$PaneId,
+        [Parameter(Mandatory = $true)][string]$ProjectDir
+    )
+
+    $settings = $null
+    if (Get-Command Get-BridgeSettings -ErrorAction SilentlyContinue) {
+        $settings = Get-BridgeSettings -RootPath $ProjectDir
+    }
+
+    $plan = Get-PaneControlRestartPlan -ProjectDir $ProjectDir -PaneId $PaneId -Settings $settings
+
+    & winsmux respawn-pane -k -t $PaneId -c $plan.LaunchDir
+    $nativeExitCode = Get-SafeLastExitCode
+    if ($null -ne $nativeExitCode -and $nativeExitCode -ne 0) {
+        Stop-WithError "failed to restart pane shell: $PaneId"
+    }
+
+    Wait-PaneShellReady -PaneId $PaneId
+    try {
+        Update-PaneControlManifestPaneLabel -ProjectDir $ProjectDir -PaneId $PaneId | Out-Null
+    } catch {
+    }
+
+    & winsmux send-keys -t $PaneId -l -- "$($plan.LaunchCommand)"
+    $nativeExitCode = Get-SafeLastExitCode
+    if ($null -ne $nativeExitCode -and $nativeExitCode -ne 0) {
+        Stop-WithError "failed to send launch command to $PaneId"
+    }
+    & winsmux send-keys -t $PaneId Enter
+    $nativeExitCode = Get-SafeLastExitCode
+    if ($null -ne $nativeExitCode -and $nativeExitCode -ne 0) {
+        Stop-WithError "failed to submit launch command to $PaneId"
+    }
+
+    Clear-ReadMark $PaneId
+    Clear-Watermark $PaneId
+
+    if ($plan.Agent.Trim().ToLowerInvariant() -eq 'codex') {
+        $deadline = (Get-Date).AddSeconds(60)
+        while ((Get-Date) -lt $deadline) {
+            if (Test-CodexReadyPrompt $PaneId) {
+                return $plan
+            }
+
+            Start-Sleep -Seconds 2
+        }
+
+        Stop-WithError "timed out waiting for Codex after restart in $PaneId"
+    }
+
+    return $plan
+}
+
 function Invoke-Restart {
     if (-not $Target) { Stop-WithError "usage: winsmux restart <target>" }
     if ($Rest -and $Rest.Count -gt 0) { Stop-WithError "usage: winsmux restart <target>" }
@@ -7225,54 +7306,7 @@ function Invoke-Restart {
     $paneId = Resolve-Target $Target
     $paneId = Confirm-Target $paneId
     $projectDir = (Get-Location).Path
-
-    $settings = $null
-    if (Get-Command Get-BridgeSettings -ErrorAction SilentlyContinue) {
-        $settings = Get-BridgeSettings
-    }
-
-    $plan = Get-PaneControlRestartPlan -ProjectDir $projectDir -PaneId $paneId -Settings $settings
-
-    & winsmux respawn-pane -k -t $paneId -c $plan.LaunchDir
-    $nativeExitCode = Get-SafeLastExitCode
-    if ($null -ne $nativeExitCode -and $nativeExitCode -ne 0) {
-        Stop-WithError "failed to restart pane shell: $paneId"
-    }
-
-    Wait-PaneShellReady -PaneId $paneId
-    try {
-        Update-PaneControlManifestPaneLabel -ProjectDir $projectDir -PaneId $paneId | Out-Null
-    } catch {
-    }
-
-    & winsmux send-keys -t $paneId -l -- "$($plan.LaunchCommand)"
-    $nativeExitCode = Get-SafeLastExitCode
-    if ($null -ne $nativeExitCode -and $nativeExitCode -ne 0) {
-        Stop-WithError "failed to send launch command to $paneId"
-    }
-    & winsmux send-keys -t $paneId Enter
-    $nativeExitCode = Get-SafeLastExitCode
-    if ($null -ne $nativeExitCode -and $nativeExitCode -ne 0) {
-        Stop-WithError "failed to submit launch command to $paneId"
-    }
-
-    Clear-ReadMark $paneId
-    Clear-Watermark $paneId
-
-    if ($plan.Agent.Trim().ToLowerInvariant() -eq 'codex') {
-        $deadline = (Get-Date).AddSeconds(60)
-        while ((Get-Date) -lt $deadline) {
-            if (Test-CodexReadyPrompt $paneId) {
-                Write-Output "restarted $paneId ($($plan.Label))"
-                return
-            }
-
-            Start-Sleep -Seconds 2
-        }
-
-        Stop-WithError "timed out waiting for Codex after restart in $paneId"
-    }
-
+    $plan = Invoke-RestartPane -PaneId $paneId -ProjectDir $projectDir
     Write-Output "restarted $paneId ($($plan.Label))"
 }
 

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -8430,9 +8430,52 @@ agent-slots:
     It 'documents provider-switch restart and routes it through the manifest-backed restart helper' {
         $script:winsmuxCoreRawContent | Should -Match "'--restart'\s*\{"
         $script:winsmuxCoreRawContent | Should -Match 'Get-PaneControlManifestEntries -ProjectDir \$projectDir'
+        $script:winsmuxCoreRawContent | Should -Match 'Confirm-Target \(\[string\]\$manifestEntry\[0\]\.PaneId\)'
         $script:winsmuxCoreRawContent | Should -Match 'Invoke-RestartPane -PaneId'
         $script:winsmuxCoreRawContent | Should -Match 'restart_requested'
         $script:winsmuxCoreRawContent | Should -Match 'restart_pane_id'
+    }
+
+    It 'rejects provider-switch restart when the manifest pane id is stale before writing the registry' {
+        $winsmuxBin = Join-Path $script:providerSwitchTempRoot 'bin'
+        New-Item -ItemType Directory -Path $winsmuxBin -Force | Out-Null
+        @'
+@echo off
+if "%1"=="list-panes" (
+  echo %%live
+  exit /b 0
+)
+exit /b 0
+'@ | Set-Content -Path (Join-Path $winsmuxBin 'winsmux.cmd') -Encoding ASCII
+
+        New-Item -ItemType Directory -Path (Join-Path $script:providerSwitchTempRoot '.winsmux') -Force | Out-Null
+        $manifestContent = @'
+session:
+  name: winsmux-orchestra
+  project_dir: __PROJECT_DIR__
+panes:
+  worker-1:
+    pane_id: "%stale"
+    role: Builder
+    launch_dir: __PROJECT_DIR__
+'@
+        $manifestContent.Replace('__PROJECT_DIR__', $script:providerSwitchTempRoot) |
+            Set-Content -Path (Join-Path $script:providerSwitchTempRoot '.winsmux\manifest.yaml') -Encoding UTF8
+
+        $originalPath = $env:PATH
+        Push-Location $script:providerSwitchTempRoot
+        try {
+            $env:PATH = "$winsmuxBin$([System.IO.Path]::PathSeparator)$env:PATH"
+            $output = & pwsh -NoProfile -File $script:winsmuxCoreRawPath provider-switch worker-1 --agent claude --model opus --restart --json 2>&1
+            $exitCode = $LASTEXITCODE
+        } finally {
+            $env:PATH = $originalPath
+            Pop-Location
+        }
+
+        $exitCode | Should -Be 1
+        ($output | Out-String) | Should -Match 'invalid target: %stale'
+        Test-Path -LiteralPath (Join-Path $script:providerSwitchTempRoot '.winsmux\provider-registry.json') | Should -Be $false
     }
 }
 

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -8399,7 +8399,7 @@ agent-slots:
     }
 
     It 'documents provider-switch in usage and writes a provider registry entry' {
-        $script:winsmuxCoreRawContent | Should -Match 'provider-switch <slot> \[--agent <name>\] \[--model <name>\] \[--prompt-transport <argv\|file\|stdin>\]'
+        $script:winsmuxCoreRawContent | Should -Match 'provider-switch <slot> \[--agent <name>\] \[--model <name>\] \[--prompt-transport <argv\|file\|stdin>\] \[--reason <text>\] \[--restart\] \[--json\]'
         $script:winsmuxCoreRawContent | Should -Match "'provider-switch'\s*\{"
 
         Push-Location $script:providerSwitchTempRoot
@@ -8415,6 +8415,8 @@ agent-slots:
         $result.model | Should -Be 'opus'
         $result.prompt_transport | Should -Be 'file'
         $result.source | Should -Be 'registry'
+        $result.restart_requested | Should -Be $false
+        $result.restarted | Should -Be $false
 
         $registryPath = Join-Path $script:providerSwitchTempRoot '.winsmux\provider-registry.json'
         Test-Path -LiteralPath $registryPath | Should -Be $true
@@ -8423,6 +8425,14 @@ agent-slots:
         $registry.slots.'worker-1'.model | Should -Be 'opus'
         $registry.slots.'worker-1'.prompt_transport | Should -Be 'file'
         $registry.slots.'worker-1'.reason | Should -Be 'operator requested provider switch'
+    }
+
+    It 'documents provider-switch restart and routes it through the manifest-backed restart helper' {
+        $script:winsmuxCoreRawContent | Should -Match "'--restart'\s*\{"
+        $script:winsmuxCoreRawContent | Should -Match 'Get-PaneControlManifestEntries -ProjectDir \$projectDir'
+        $script:winsmuxCoreRawContent | Should -Match 'Invoke-RestartPane -PaneId'
+        $script:winsmuxCoreRawContent | Should -Match 'restart_requested'
+        $script:winsmuxCoreRawContent | Should -Match 'restart_pane_id'
     }
 }
 


### PR DESCRIPTION
## Summary
- adds `winsmux provider-switch --restart`
- resolves the target slot from the orchestra manifest before writing the provider registry
- reuses the existing restart flow through `Invoke-RestartPane`

## Validation
- `Invoke-Pester -Path .\tests\winsmux-bridge.Tests.ps1 -Output Detailed -FullNameFilter 'winsmux provider-switch command*'`
- `Invoke-Pester -Path .\tests\winsmux-bridge.Tests.ps1 -Output Detailed`
- `git diff --check`
- `pwsh -NoProfile -File .\scripts\git-guard.ps1 -Mode full`
- `pwsh -NoProfile -File .\scripts\audit-public-surface.ps1`

## Notes
- No public documentation changed.
- Public documentation review and Opus review are not required for this PR.