### PR TITLE
TASK-313 provider-switch clear path

### DIFF
--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -6933,7 +6933,7 @@ function Invoke-ConsultError {
 function Invoke-ProviderSwitch {
     $tokens = @(@($Target) + @($Rest) | Where-Object { $_ })
     if ($tokens.Count -lt 1) {
-        Stop-WithError "usage: winsmux provider-switch <slot> [--agent <name>] [--model <name>] [--prompt-transport <argv|file|stdin>] [--reason <text>] [--restart] [--json]"
+        Stop-WithError "usage: winsmux provider-switch <slot> [--agent <name>] [--model <name>] [--prompt-transport <argv|file|stdin>] [--reason <text>] [--restart] [--clear] [--json]"
     }
 
     $slotId = [string]$tokens[0]
@@ -6942,6 +6942,7 @@ function Invoke-ProviderSwitch {
     $promptTransport = ''
     $reason = ''
     $restartRequested = $false
+    $clearRequested = $false
     $jsonOutput = $false
 
     for ($index = 1; $index -lt $tokens.Count; $index++) {
@@ -6980,10 +6981,17 @@ function Invoke-ProviderSwitch {
             '--restart' {
                 $restartRequested = $true
             }
+            '--clear' {
+                $clearRequested = $true
+            }
             default {
-                Stop-WithError "usage: winsmux provider-switch <slot> [--agent <name>] [--model <name>] [--prompt-transport <argv|file|stdin>] [--reason <text>] [--restart] [--json]"
+                Stop-WithError "usage: winsmux provider-switch <slot> [--agent <name>] [--model <name>] [--prompt-transport <argv|file|stdin>] [--reason <text>] [--restart] [--clear] [--json]"
             }
         }
+    }
+
+    if ($clearRequested -and (-not [string]::IsNullOrWhiteSpace($agent) -or -not [string]::IsNullOrWhiteSpace($model) -or -not [string]::IsNullOrWhiteSpace($promptTransport))) {
+        Stop-WithError 'provider-switch --clear cannot be combined with --agent, --model, or --prompt-transport.'
     }
 
     $projectDir = (Get-Location).Path
@@ -7012,7 +7020,14 @@ function Invoke-ProviderSwitch {
         $restartPaneId = Confirm-Target ([string]$manifestEntry[0].PaneId)
     }
 
-    $entry = Write-BridgeProviderRegistryEntry -RootPath $projectDir -SlotId $slotId -Agent $agent -Model $model -PromptTransport $promptTransport -Reason $reason
+    $entry = $null
+    $cleared = $false
+    if ($clearRequested) {
+        $clearResult = Remove-BridgeProviderRegistryEntry -RootPath $projectDir -SlotId $slotId
+        $cleared = [bool]$clearResult.Removed
+    } else {
+        $entry = Write-BridgeProviderRegistryEntry -RootPath $projectDir -SlotId $slotId -Agent $agent -Model $model -PromptTransport $promptTransport -Reason $reason
+    }
     $effective = Get-SlotAgentConfig -Role 'Worker' -SlotId $slotId -Settings $settings -RootPath $projectDir
     $result = [ordered]@{
         slot_id          = $slotId
@@ -7021,8 +7036,10 @@ function Invoke-ProviderSwitch {
         prompt_transport = [string]$effective.PromptTransport
         source           = [string]$effective.Source
         registry_path    = Get-BridgeProviderRegistryPath -RootPath $projectDir
-        updated_at_utc   = [string]$entry.updated_at_utc
-        reason           = if ($entry.Contains('reason')) { [string]$entry.reason } else { '' }
+        updated_at_utc   = if ($clearRequested) { [string]$clearResult.UpdatedAtUtc } else { [string]$entry.updated_at_utc }
+        reason           = if ((-not $clearRequested) -and $entry.Contains('reason')) { [string]$entry.reason } else { '' }
+        clear_requested  = $clearRequested
+        cleared          = $cleared
         restart_requested = $restartRequested
         restarted        = $false
         restart_pane_id  = ''
@@ -7036,6 +7053,11 @@ function Invoke-ProviderSwitch {
 
     if ($jsonOutput) {
         $result | ConvertTo-Json -Depth 8 -Compress | Write-Output
+        return
+    }
+
+    if ($clearRequested) {
+        Write-Output "provider switch cleared for ${slotId}: $($result.agent) / $($result.model) ($($result.prompt_transport))"
         return
     }
 
@@ -7075,7 +7097,7 @@ Commands:
   consult-request <mode> [--message <text>] [--target-slot <slot>]  Record a consultation request packet/event
   consult-result <mode> [--message <text>] [--target-slot <slot>] [--confidence <0..1>] [--next-test <text>] [--risk <text>] [--run-id <run_id>] [--json]  Record a consultation result packet/event
   consult-error <mode> [--message <text>] [--target-slot <slot>]  Record a consultation error packet/event
-  provider-switch <slot> [--agent <name>] [--model <name>] [--prompt-transport <argv|file|stdin>] [--reason <text>] [--restart] [--json]  Record a runtime provider reassignment for a managed slot
+  provider-switch <slot> [--agent <name>] [--model <name>] [--prompt-transport <argv|file|stdin>] [--reason <text>] [--restart] [--clear] [--json]  Record or clear a runtime provider reassignment for a managed slot
   locks                     List active file locks
   verify <pr-number>        Run Pester in tests/ and merge PR only on PASS
   wait <channel> [timeout]  Block until signal received (replaces polling)

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -589,6 +589,38 @@ agent-slots:
         } | Should -Throw '*prompt_transport*'
     }
 
+    It 'removes a provider registry override and falls back to configured slot settings' {
+@'
+agent: codex
+model: gpt-5.4
+prompt-transport: argv
+agent-slots:
+  - slot-id: worker-1
+    runtime-role: worker
+    agent: codex
+    model: gpt-5.4
+    prompt-transport: argv
+'@ | Set-Content -Path (Join-Path $script:settingsTempRoot '.winsmux.yaml') -Encoding UTF8
+
+        Mock Get-WinsmuxOption { param($Name, $Default) return $null }
+
+        $settings = Get-BridgeSettings
+        Write-BridgeProviderRegistryEntry -RootPath $script:settingsTempRoot -SlotId 'worker-1' -Agent 'claude' -Model 'opus' -PromptTransport 'file' | Out-Null
+        $before = Get-SlotAgentConfig -Role 'Worker' -SlotId 'worker-1' -Settings $settings -RootPath $script:settingsTempRoot
+        $before.Source | Should -Be 'registry'
+
+        $removeResult = Remove-BridgeProviderRegistryEntry -RootPath $script:settingsTempRoot -SlotId 'worker-1'
+        $removeResult.Removed | Should -Be $true
+
+        $after = Get-SlotAgentConfig -Role 'Worker' -SlotId 'worker-1' -Settings $settings -RootPath $script:settingsTempRoot
+        $after.Agent | Should -Be 'codex'
+        $after.Model | Should -Be 'gpt-5.4'
+        $after.PromptTransport | Should -Be 'argv'
+        $after.Source | Should -Be 'slot'
+        $registryAfterRemove = Read-BridgeProviderRegistry -RootPath $script:settingsTempRoot
+        $registryAfterRemove.slots.Count | Should -Be 0
+    }
+
     It 'rejects structurally malformed provider registries' {
         $registryPath = Get-BridgeProviderRegistryPath -RootPath $script:settingsTempRoot
         $registryDir = Split-Path -Parent $registryPath
@@ -8399,7 +8431,7 @@ agent-slots:
     }
 
     It 'documents provider-switch in usage and writes a provider registry entry' {
-        $script:winsmuxCoreRawContent | Should -Match 'provider-switch <slot> \[--agent <name>\] \[--model <name>\] \[--prompt-transport <argv\|file\|stdin>\] \[--reason <text>\] \[--restart\] \[--json\]'
+        $script:winsmuxCoreRawContent | Should -Match 'provider-switch <slot> \[--agent <name>\] \[--model <name>\] \[--prompt-transport <argv\|file\|stdin>\] \[--reason <text>\] \[--restart\] \[--clear\] \[--json\]'
         $script:winsmuxCoreRawContent | Should -Match "'provider-switch'\s*\{"
 
         Push-Location $script:providerSwitchTempRoot
@@ -8427,11 +8459,35 @@ agent-slots:
         $registry.slots.'worker-1'.reason | Should -Be 'operator requested provider switch'
     }
 
+    It 'clears provider-switch overrides and reports the configured slot provider' {
+        Push-Location $script:providerSwitchTempRoot
+        try {
+            & pwsh -NoProfile -File $script:winsmuxCoreRawPath provider-switch worker-1 --agent claude --model opus --prompt-transport file --json | Out-Null
+            $output = & pwsh -NoProfile -File $script:winsmuxCoreRawPath provider-switch worker-1 --clear --json
+        } finally {
+            Pop-Location
+        }
+
+        $result = ($output | Select-Object -Last 1) | ConvertFrom-Json
+        $result.slot_id | Should -Be 'worker-1'
+        $result.agent | Should -Be 'codex'
+        $result.model | Should -Be 'gpt-5.4'
+        $result.prompt_transport | Should -Be 'argv'
+        $result.source | Should -Be 'slot'
+        $result.clear_requested | Should -Be $true
+        $result.cleared | Should -Be $true
+        $registry = Get-Content -LiteralPath (Join-Path $script:providerSwitchTempRoot '.winsmux\provider-registry.json') -Raw -Encoding UTF8 | ConvertFrom-Json
+        $registry.slots.PSObject.Properties.Name | Should -Not -Contain 'worker-1'
+    }
+
     It 'documents provider-switch restart and routes it through the manifest-backed restart helper' {
         $script:winsmuxCoreRawContent | Should -Match "'--restart'\s*\{"
+        $script:winsmuxCoreRawContent | Should -Match "'--clear'\s*\{"
         $script:winsmuxCoreRawContent | Should -Match 'Get-PaneControlManifestEntries -ProjectDir \$projectDir'
         $script:winsmuxCoreRawContent | Should -Match 'Confirm-Target \(\[string\]\$manifestEntry\[0\]\.PaneId\)'
         $script:winsmuxCoreRawContent | Should -Match 'Invoke-RestartPane -PaneId'
+        $script:winsmuxCoreRawContent | Should -Match 'Remove-BridgeProviderRegistryEntry -RootPath \$projectDir -SlotId \$slotId'
+        $script:winsmuxCoreRawContent | Should -Match 'clear_requested'
         $script:winsmuxCoreRawContent | Should -Match 'restart_requested'
         $script:winsmuxCoreRawContent | Should -Match 'restart_pane_id'
     }

--- a/winsmux-core/scripts/settings.ps1
+++ b/winsmux-core/scripts/settings.ps1
@@ -506,6 +506,45 @@ function Write-BridgeProviderRegistryEntry {
     return $registry.slots[$SlotId]
 }
 
+function Remove-BridgeProviderRegistryEntry {
+    param(
+        [Parameter(Mandatory = $true)][string]$SlotId,
+        [string]$RootPath
+    )
+
+    if ([string]::IsNullOrWhiteSpace($SlotId)) {
+        throw 'Provider registry entry requires a slot id.'
+    }
+
+    $registry = Read-BridgeProviderRegistry -RootPath $RootPath
+    $matchedSlotId = $null
+    foreach ($entry in $registry.slots.GetEnumerator()) {
+        if ([string]::Equals([string]$entry.Key, $SlotId, [System.StringComparison]::OrdinalIgnoreCase)) {
+            $matchedSlotId = [string]$entry.Key
+            break
+        }
+    }
+
+    if ($null -ne $matchedSlotId) {
+        $registry.slots.Remove($matchedSlotId)
+    }
+
+    $path = Get-BridgeProviderRegistryPath -RootPath $RootPath
+    $directory = Split-Path -Parent $path
+    if (-not (Test-Path -LiteralPath $directory -PathType Container)) {
+        New-Item -ItemType Directory -Path $directory -Force | Out-Null
+    }
+
+    $registry | ConvertTo-Json -Depth 16 | Set-Content -LiteralPath $path -Encoding UTF8
+
+    return [PSCustomObject][ordered]@{
+        SlotId        = [string]$SlotId
+        Removed       = ($null -ne $matchedSlotId)
+        RegistryPath  = [string]$path
+        UpdatedAtUtc  = (Get-Date).ToUniversalTime().ToString('o')
+    }
+}
+
 function ConvertFrom-BridgeManualYaml {
     param([Parameter(Mandatory = $true)][string]$Content)
 


### PR DESCRIPTION
## Summary
- adds `winsmux provider-switch --clear`
- adds `Remove-BridgeProviderRegistryEntry` for removing runtime provider overrides
- reports the configured slot provider after clearing an override

## Validation
- `Invoke-Pester -Path .\tests\winsmux-bridge.Tests.ps1 -Output Detailed -FullNameFilter 'winsmux provider-switch command*'`
- `Invoke-Pester -Path .\tests\winsmux-bridge.Tests.ps1 -Output Detailed -FullNameFilter '*provider registry*'`
- `Invoke-Pester -Path .\tests\winsmux-bridge.Tests.ps1 -Output Detailed`
- `git diff --check`
- `pwsh -NoProfile -File .\scripts\git-guard.ps1 -Mode full`
- `pwsh -NoProfile -File .\scripts\audit-public-surface.ps1`

## Notes
- No public documentation changed.
- Public documentation review and Opus review are not required for this PR.