### PR TITLE
TASK-314 provider capability registry contract

### DIFF
--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -6930,6 +6930,77 @@ function Invoke-ConsultError {
     Write-ConsultationCommandRecord -Kind 'consult_error' -Mode ([string]$args.mode) -Message ([string]$args.message) -TargetSlot ([string]$args.target_slot)
 }
 
+function Invoke-ProviderCapabilities {
+    $tokens = @(@($Target) + @($Rest) | Where-Object { $_ })
+    $providerId = ''
+    $jsonOutput = $false
+
+    for ($index = 0; $index -lt $tokens.Count; $index++) {
+        switch ($tokens[$index]) {
+            '--json' {
+                $jsonOutput = $true
+            }
+            default {
+                if ([string]::IsNullOrWhiteSpace($providerId)) {
+                    $providerId = [string]$tokens[$index]
+                    continue
+                }
+
+                Stop-WithError "usage: winsmux provider-capabilities [provider] [--json]"
+            }
+        }
+    }
+
+    $projectDir = (Get-Location).Path
+    $registry = Read-BridgeProviderCapabilityRegistry -RootPath $projectDir
+    if (-not [string]::IsNullOrWhiteSpace($providerId)) {
+        $capabilities = Get-BridgeProviderCapability -RootPath $projectDir -ProviderId $providerId
+        if ($null -eq $capabilities) {
+            Stop-WithError "provider capability '$providerId' was not found."
+        }
+
+        $result = [ordered]@{
+            provider_id   = $providerId
+            capabilities  = $capabilities
+            registry_path = Get-BridgeProviderCapabilityRegistryPath -RootPath $projectDir
+        }
+        if ($jsonOutput) {
+            $result | ConvertTo-Json -Depth 16 -Compress | Write-Output
+            return
+        }
+
+        Write-Output "provider capability $providerId"
+        foreach ($property in $capabilities.GetEnumerator()) {
+            $value = $property.Value
+            if ($value -is [System.Array]) {
+                $value = ($value -join ',')
+            }
+            Write-Output "  $($property.Key): $value"
+        }
+        return
+    }
+
+    $result = [ordered]@{
+        version       = [int]$registry.version
+        registry_path = Get-BridgeProviderCapabilityRegistryPath -RootPath $projectDir
+        providers     = $registry.providers
+    }
+    if ($jsonOutput) {
+        $result | ConvertTo-Json -Depth 16 -Compress | Write-Output
+        return
+    }
+
+    if ($registry.providers.Count -lt 1) {
+        Write-Output 'provider capabilities: none'
+        return
+    }
+
+    Write-Output 'provider capabilities'
+    foreach ($entry in $registry.providers.GetEnumerator()) {
+        Write-Output "  $($entry.Key)"
+    }
+}
+
 function Invoke-ProviderSwitch {
     $tokens = @(@($Target) + @($Rest) | Where-Object { $_ })
     if ($tokens.Count -lt 1) {
@@ -7097,6 +7168,7 @@ Commands:
   consult-request <mode> [--message <text>] [--target-slot <slot>]  Record a consultation request packet/event
   consult-result <mode> [--message <text>] [--target-slot <slot>] [--confidence <0..1>] [--next-test <text>] [--risk <text>] [--run-id <run_id>] [--json]  Record a consultation result packet/event
   consult-error <mode> [--message <text>] [--target-slot <slot>]  Record a consultation error packet/event
+  provider-capabilities [provider] [--json]  Inspect the provider capability registry contract
   provider-switch <slot> [--agent <name>] [--model <name>] [--prompt-transport <argv|file|stdin>] [--reason <text>] [--restart] [--clear] [--json]  Record or clear a runtime provider reassignment for a managed slot
   locks                     List active file locks
   verify <pr-number>        Run Pester in tests/ and merge PR only on PASS
@@ -7578,6 +7650,7 @@ switch ($Command) {
     'consult-request' { Invoke-ConsultRequest }
     'consult-result'  { Invoke-ConsultResult }
     'consult-error'   { Invoke-ConsultError }
+    'provider-capabilities' { Invoke-ProviderCapabilities }
     'provider-switch' { Invoke-ProviderSwitch }
     'rebind-worktree' { Invoke-RebindWorktree }
     ''                { Show-Usage }

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -682,6 +682,9 @@ agent-slots:
   "version": 1,
   "providers": {
     "codex": {
+      "adapter": "codex",
+      "command": "codex",
+      "prompt_transports": ["argv"],
       "supports_file_edit": "yes"
     }
   }
@@ -694,6 +697,35 @@ agent-slots:
   "version": 1,
   "providers": {
     "codex": {
+      "adapter": "codex",
+      "command": "codex",
+      "prompt_transports": ["argv"],
+      "supports_verificaton": true
+    }
+  }
+}
+'@ | Set-Content -Path $registryPath -Encoding UTF8
+        { Read-BridgeProviderCapabilityRegistry -RootPath $script:settingsTempRoot } | Should -Throw "*provider capability field 'supports_verificaton'*"
+
+@'
+{
+  "version": 1,
+  "providers": {
+    "codex": {
+      "supports_file_edit": true
+    }
+  }
+}
+'@ | Set-Content -Path $registryPath -Encoding UTF8
+        { Read-BridgeProviderCapabilityRegistry -RootPath $script:settingsTempRoot } | Should -Throw "*Missing provider capability field 'adapter'*"
+
+@'
+{
+  "version": 1,
+  "providers": {
+    "codex": {
+      "adapter": "codex",
+      "command": "codex",
       "prompt_transports": ["socket"]
     }
   }

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -621,6 +621,87 @@ agent-slots:
         $registryAfterRemove.slots.Count | Should -Be 0
     }
 
+    It 'reads provider capability registry entries' {
+        $registryPath = Get-BridgeProviderCapabilityRegistryPath -RootPath $script:settingsTempRoot
+        $registryDir = Split-Path -Parent $registryPath
+        New-Item -ItemType Directory -Path $registryDir -Force | Out-Null
+
+@'
+{
+  "version": 1,
+  "providers": {
+    "codex": {
+      "adapter": "codex",
+      "display_name": "Codex",
+      "command": "codex",
+      "prompt_transports": ["argv", "file", "stdin"],
+      "supports_parallel_runs": true,
+      "supports_interrupt": true,
+      "supports_structured_result": true,
+      "supports_file_edit": true,
+      "supports_subagents": true,
+      "supports_verification": true,
+      "supports_consultation": false
+    }
+  }
+}
+'@ | Set-Content -Path $registryPath -Encoding UTF8
+
+        $registry = Read-BridgeProviderCapabilityRegistry -RootPath $script:settingsTempRoot
+        $registry.providers.codex.adapter | Should -Be 'codex'
+        $registry.providers.codex.prompt_transports | Should -Be @('argv', 'file', 'stdin')
+        $registry.providers.codex.supports_file_edit | Should -Be $true
+
+        $capability = Get-BridgeProviderCapability -RootPath $script:settingsTempRoot -ProviderId 'CODEX'
+        $capability.command | Should -Be 'codex'
+    }
+
+    It 'rejects structurally malformed provider capability registries' {
+        $registryPath = Get-BridgeProviderCapabilityRegistryPath -RootPath $script:settingsTempRoot
+        $registryDir = Split-Path -Parent $registryPath
+        New-Item -ItemType Directory -Path $registryDir -Force | Out-Null
+
+@'
+{
+  "version": 2,
+  "providers": {}
+}
+'@ | Set-Content -Path $registryPath -Encoding UTF8
+        { Read-BridgeProviderCapabilityRegistry -RootPath $script:settingsTempRoot } | Should -Throw '*provider capability registry version*'
+
+@'
+{
+  "version": 1,
+  "providers": []
+}
+'@ | Set-Content -Path $registryPath -Encoding UTF8
+        { Read-BridgeProviderCapabilityRegistry -RootPath $script:settingsTempRoot } | Should -Throw '*provider capability registry providers*'
+
+@'
+{
+  "version": 1,
+  "providers": {
+    "codex": {
+      "supports_file_edit": "yes"
+    }
+  }
+}
+'@ | Set-Content -Path $registryPath -Encoding UTF8
+        { Read-BridgeProviderCapabilityRegistry -RootPath $script:settingsTempRoot } | Should -Throw "*provider capability field 'supports_file_edit'*"
+
+@'
+{
+  "version": 1,
+  "providers": {
+    "codex": {
+      "prompt_transports": ["socket"]
+    }
+  }
+}
+'@ | Set-Content -Path $registryPath -Encoding UTF8
+        { Read-BridgeProviderCapabilityRegistry -RootPath $script:settingsTempRoot } | Should -Throw '*provider capability prompt transport*'
+    }
+
     It 'rejects structurally malformed provider registries' {
         $registryPath = Get-BridgeProviderRegistryPath -RootPath $script:settingsTempRoot
         $registryDir = Split-Path -Parent $registryPath
@@ -8399,6 +8480,73 @@ Describe 'public first-run helper' {
         $result.requires_startup | Should -Be $false
         $result.operator_message | Should -Be 'ready'
         $result.next_action | Should -Be 'Dispatch work or continue operator flow.'
+    }
+}
+
+Describe 'winsmux provider-capabilities command' {
+    BeforeAll {
+        $script:winsmuxCoreRawPath = Join-Path (Split-Path -Parent $PSScriptRoot) 'scripts\winsmux-core.ps1'
+        $script:winsmuxCoreRawContent = Get-Content -Raw -Path $script:winsmuxCoreRawPath -Encoding UTF8
+    }
+
+    BeforeEach {
+        $script:providerCapabilitiesTempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('winsmux-provider-capabilities-tests-' + [guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path (Join-Path $script:providerCapabilitiesTempRoot '.winsmux') -Force | Out-Null
+
+@'
+{
+  "version": 1,
+  "providers": {
+    "codex": {
+      "adapter": "codex",
+      "display_name": "Codex",
+      "command": "codex",
+      "prompt_transports": ["argv", "file", "stdin"],
+      "supports_file_edit": true,
+      "supports_verification": true,
+      "supports_subagents": true
+    }
+  }
+}
+'@ | Set-Content -Path (Join-Path $script:providerCapabilitiesTempRoot '.winsmux\provider-capabilities.json') -Encoding UTF8
+    }
+
+    AfterEach {
+        if ($script:providerCapabilitiesTempRoot -and (Test-Path $script:providerCapabilitiesTempRoot)) {
+            Remove-Item -Path $script:providerCapabilitiesTempRoot -Recurse -Force
+        }
+    }
+
+    It 'documents provider-capabilities in usage and reports the registry contract' {
+        $script:winsmuxCoreRawContent | Should -Match 'provider-capabilities \[provider\] \[--json\]'
+        $script:winsmuxCoreRawContent | Should -Match "'provider-capabilities'\s*\{"
+
+        Push-Location $script:providerCapabilitiesTempRoot
+        try {
+            $output = & pwsh -NoProfile -File $script:winsmuxCoreRawPath provider-capabilities --json
+        } finally {
+            Pop-Location
+        }
+
+        $payload = $output | ConvertFrom-Json
+        $payload.version | Should -Be 1
+        $payload.providers.codex.adapter | Should -Be 'codex'
+        $payload.providers.codex.prompt_transports | Should -Be @('argv', 'file', 'stdin')
+        $payload.providers.codex.supports_file_edit | Should -Be $true
+    }
+
+    It 'reports one provider capability entry' {
+        Push-Location $script:providerCapabilitiesTempRoot
+        try {
+            $output = & pwsh -NoProfile -File $script:winsmuxCoreRawPath provider-capabilities CODEX --json
+        } finally {
+            Pop-Location
+        }
+
+        $payload = $output | ConvertFrom-Json
+        $payload.provider_id | Should -Be 'CODEX'
+        $payload.capabilities.command | Should -Be 'codex'
+        $payload.capabilities.supports_verification | Should -Be $true
     }
 }
 

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -756,6 +756,20 @@ agent-slots:
   "version": 1,
   "providers": {
     "codex": {
+      "adapter": "codex",
+      "command": "codex",
+      "prompt-transports": ["argv"]
+    }
+  }
+}
+'@ | Set-Content -Path $registryPath -Encoding UTF8
+        { Read-BridgeProviderCapabilityRegistry -RootPath $script:settingsTempRoot } | Should -Throw "*provider capability field 'prompt-transports'*"
+
+@'
+{
+  "version": 1,
+  "providers": {
+    "codex": {
       "supports_file_edit": true
     }
   }

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -671,11 +671,55 @@ agent-slots:
 
 @'
 {
+  "version": "1",
+  "providers": {}
+}
+'@ | Set-Content -Path $registryPath -Encoding UTF8
+        { Read-BridgeProviderCapabilityRegistry -RootPath $script:settingsTempRoot } | Should -Throw '*provider capability registry version*'
+
+@'
+{
+  "version": 1.1,
+  "providers": {}
+}
+'@ | Set-Content -Path $registryPath -Encoding UTF8
+        { Read-BridgeProviderCapabilityRegistry -RootPath $script:settingsTempRoot } | Should -Throw '*provider capability registry version*'
+
+@'
+{
   "version": 1,
   "providers": []
 }
 '@ | Set-Content -Path $registryPath -Encoding UTF8
         { Read-BridgeProviderCapabilityRegistry -RootPath $script:settingsTempRoot } | Should -Throw '*provider capability registry providers*'
+
+@'
+{
+  "version": 1,
+  "providers": {
+    "codex": {
+      "adapter": true,
+      "command": "codex",
+      "prompt_transports": ["argv"]
+    }
+  }
+}
+'@ | Set-Content -Path $registryPath -Encoding UTF8
+        { Read-BridgeProviderCapabilityRegistry -RootPath $script:settingsTempRoot } | Should -Throw "*provider capability field 'adapter'*"
+
+@'
+{
+  "version": 1,
+  "providers": {
+    "codex": {
+      "adapter": "codex",
+      "command": 123,
+      "prompt_transports": ["argv"]
+    }
+  }
+}
+'@ | Set-Content -Path $registryPath -Encoding UTF8
+        { Read-BridgeProviderCapabilityRegistry -RootPath $script:settingsTempRoot } | Should -Throw "*provider capability field 'command'*"
 
 @'
 {

--- a/winsmux-core/scripts/settings.ps1
+++ b/winsmux-core/scripts/settings.ps1
@@ -588,10 +588,15 @@ function ConvertTo-BridgeProviderCapabilityEntry {
         'supports_verification',
         'supports_consultation'
     )
+    $allowedFields = @($stringFields + $transportFields + $boolFields)
 
     $entry = [ordered]@{}
     foreach ($pair in $pairs) {
         $key = $pair.Key.ToString() -replace '-', '_'
+        if ($key -notin $allowedFields) {
+            throw "Invalid provider capability field '$key'."
+        }
+
         if ($key -in $stringFields) {
             if (-not (Test-BridgeProviderRegistryScalarValue $pair.Value)) {
                 throw "Invalid provider capability field '$key'."
@@ -611,12 +616,20 @@ function ConvertTo-BridgeProviderCapabilityEntry {
 
             $transports = @()
             foreach ($transport in @($pair.Value)) {
-                $text = (ConvertFrom-BridgeYamlScalar $transport).ToLowerInvariant()
+                $text = ConvertFrom-BridgeYamlScalar $transport
+                if ([string]::IsNullOrWhiteSpace($text)) {
+                    throw "Invalid provider capability field '$key'."
+                }
+
+                $text = $text.ToLowerInvariant()
                 if ($text -notin @('argv', 'file', 'stdin')) {
                     throw "Invalid provider capability prompt transport '$text'."
                 }
 
                 $transports += $text
+            }
+            if ($transports.Count -lt 1) {
+                throw "Invalid provider capability field '$key'."
             }
 
             $entry[$key] = @($transports)
@@ -634,6 +647,12 @@ function ConvertTo-BridgeProviderCapabilityEntry {
 
     if ($entry.Count -lt 1) {
         return $null
+    }
+
+    foreach ($requiredField in @('adapter', 'command', 'prompt_transports')) {
+        if (-not $entry.Contains($requiredField)) {
+            throw "Missing provider capability field '$requiredField'."
+        }
     }
 
     return $entry

--- a/winsmux-core/scripts/settings.ps1
+++ b/winsmux-core/scripts/settings.ps1
@@ -592,7 +592,7 @@ function ConvertTo-BridgeProviderCapabilityEntry {
 
     $entry = [ordered]@{}
     foreach ($pair in $pairs) {
-        $key = $pair.Key.ToString() -replace '-', '_'
+        $key = $pair.Key.ToString()
         if ($key -notin $allowedFields) {
             throw "Invalid provider capability field '$key'."
         }

--- a/winsmux-core/scripts/settings.ps1
+++ b/winsmux-core/scripts/settings.ps1
@@ -598,7 +598,7 @@ function ConvertTo-BridgeProviderCapabilityEntry {
         }
 
         if ($key -in $stringFields) {
-            if (-not (Test-BridgeProviderRegistryScalarValue $pair.Value)) {
+            if ($pair.Value -isnot [string]) {
                 throw "Invalid provider capability field '$key'."
             }
 
@@ -688,6 +688,10 @@ function Read-BridgeProviderCapabilityRegistry {
 
     $version = 1
     if ($null -ne $parsed.PSObject -and $parsed.PSObject.Properties.Name -contains 'version') {
+        if ($parsed.version -isnot [int] -and $parsed.version -isnot [long]) {
+            throw "Invalid provider capability registry version at '$path'."
+        }
+
         $version = [int]$parsed.version
     }
     if ($version -ne 1) {

--- a/winsmux-core/scripts/settings.ps1
+++ b/winsmux-core/scripts/settings.ps1
@@ -15,6 +15,7 @@ Dot-source this script to load the helpers:
 
 $script:BridgeSettingsFileName = '.winsmux.yaml'
 $script:BridgeProviderRegistryFileName = 'provider-registry.json'
+$script:BridgeProviderCapabilityRegistryFileName = 'provider-capabilities.json'
 $script:BridgeSettingsSchema = [ordered]@{
     config_version      = @{ Type = 'int';      Default = 1;             Option = $null }
     agent               = @{ Type = 'string';   Default = 'codex';       Option = '@bridge-agent' }
@@ -543,6 +544,185 @@ function Remove-BridgeProviderRegistryEntry {
         RegistryPath  = [string]$path
         UpdatedAtUtc  = (Get-Date).ToUniversalTime().ToString('o')
     }
+}
+
+function Get-BridgeProviderCapabilityRegistryPath {
+    param([string]$RootPath)
+
+    if ([string]::IsNullOrWhiteSpace($RootPath)) {
+        $RootPath = (Get-Location).Path
+    }
+
+    return Join-Path (Join-Path $RootPath '.winsmux') $script:BridgeProviderCapabilityRegistryFileName
+}
+
+function ConvertTo-BridgeProviderCapabilityEntry {
+    param([AllowNull()]$Value)
+
+    if ($null -eq $Value) {
+        return $null
+    }
+
+    $pairs = @()
+    if ($Value -is [System.Collections.IDictionary]) {
+        $pairs = $Value.GetEnumerator()
+    } elseif ($Value -is [PSCustomObject]) {
+        $pairs = $Value.PSObject.Properties | ForEach-Object {
+            [PSCustomObject]@{
+                Key   = $_.Name
+                Value = $_.Value
+            }
+        }
+    } else {
+        return $null
+    }
+
+    $stringFields = @('adapter', 'display_name', 'command')
+    $transportFields = @('prompt_transports')
+    $boolFields = @(
+        'supports_parallel_runs',
+        'supports_interrupt',
+        'supports_structured_result',
+        'supports_file_edit',
+        'supports_subagents',
+        'supports_verification',
+        'supports_consultation'
+    )
+
+    $entry = [ordered]@{}
+    foreach ($pair in $pairs) {
+        $key = $pair.Key.ToString() -replace '-', '_'
+        if ($key -in $stringFields) {
+            if (-not (Test-BridgeProviderRegistryScalarValue $pair.Value)) {
+                throw "Invalid provider capability field '$key'."
+            }
+
+            $text = ConvertFrom-BridgeYamlScalar $pair.Value
+            if (-not [string]::IsNullOrWhiteSpace($text)) {
+                $entry[$key] = $text
+            }
+            continue
+        }
+
+        if ($key -in $transportFields) {
+            if ($pair.Value -isnot [System.Collections.IEnumerable] -or $pair.Value -is [string]) {
+                throw "Invalid provider capability field '$key'."
+            }
+
+            $transports = @()
+            foreach ($transport in @($pair.Value)) {
+                $text = (ConvertFrom-BridgeYamlScalar $transport).ToLowerInvariant()
+                if ($text -notin @('argv', 'file', 'stdin')) {
+                    throw "Invalid provider capability prompt transport '$text'."
+                }
+
+                $transports += $text
+            }
+
+            $entry[$key] = @($transports)
+            continue
+        }
+
+        if ($key -in $boolFields) {
+            if ($pair.Value -isnot [bool]) {
+                throw "Invalid provider capability field '$key'."
+            }
+
+            $entry[$key] = [bool]$pair.Value
+        }
+    }
+
+    if ($entry.Count -lt 1) {
+        return $null
+    }
+
+    return $entry
+}
+
+function Read-BridgeProviderCapabilityRegistry {
+    param([string]$RootPath)
+
+    $path = Get-BridgeProviderCapabilityRegistryPath -RootPath $RootPath
+    $registry = [ordered]@{
+        version   = 1
+        providers = [ordered]@{}
+    }
+
+    if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
+        return $registry
+    }
+
+    $raw = Get-Content -LiteralPath $path -Raw -Encoding UTF8
+    if ([string]::IsNullOrWhiteSpace($raw)) {
+        return $registry
+    }
+
+    try {
+        $parsed = $raw | ConvertFrom-Json -Depth 16 -ErrorAction Stop
+    } catch {
+        throw "Invalid provider capability registry JSON at '$path'."
+    }
+
+    if (-not (Test-BridgeProviderRegistryObject $parsed)) {
+        throw "Invalid provider capability registry JSON at '$path'."
+    }
+
+    $version = 1
+    if ($null -ne $parsed.PSObject -and $parsed.PSObject.Properties.Name -contains 'version') {
+        $version = [int]$parsed.version
+    }
+    if ($version -ne 1) {
+        throw "Unsupported provider capability registry version '$version'. Supported versions: 1."
+    }
+
+    $registry.version = $version
+    if ($null -eq $parsed.PSObject -or -not ($parsed.PSObject.Properties.Name -contains 'providers') -or $null -eq $parsed.providers) {
+        return $registry
+    }
+
+    if (-not (Test-BridgeProviderRegistryObject $parsed.providers)) {
+        throw "Invalid provider capability registry providers at '$path'."
+    }
+
+    foreach ($providerProperty in (Get-BridgeProviderRegistryObjectProperties $parsed.providers)) {
+        $providerId = ConvertFrom-BridgeYamlScalar $providerProperty.Name
+        if ([string]::IsNullOrWhiteSpace($providerId)) {
+            throw "Invalid provider capability id at '$path'."
+        }
+
+        if (-not (Test-BridgeProviderRegistryObject $providerProperty.Value)) {
+            throw "Invalid provider capability entry '$providerId' at '$path'."
+        }
+
+        $entry = ConvertTo-BridgeProviderCapabilityEntry $providerProperty.Value
+        if ($null -eq $entry) {
+            throw "Invalid provider capability entry '$providerId' at '$path'."
+        }
+
+        $registry.providers[$providerId] = $entry
+    }
+
+    return $registry
+}
+
+function Get-BridgeProviderCapability {
+    param(
+        [Parameter(Mandatory = $true)][string]$ProviderId,
+        [string]$RootPath
+    )
+
+    if ([string]::IsNullOrWhiteSpace($ProviderId)) {
+        return $null
+    }
+
+    $registry = Read-BridgeProviderCapabilityRegistry -RootPath $RootPath
+    foreach ($entry in $registry.providers.GetEnumerator()) {
+        if ([string]::Equals([string]$entry.Key, $ProviderId, [System.StringComparison]::OrdinalIgnoreCase)) {
+            return $entry.Value
+        }
+    }
+
+    return $null
 }
 
 function ConvertFrom-BridgeManualYaml {


### PR DESCRIPTION
## Summary
- add .winsmux/provider-capabilities.json reader with versioned provider capability validation
- add winsmux provider-capabilities inspection command
- add Pester coverage for registry structure and CLI output

## Validation
- Invoke-Pester -Path .\tests\winsmux-bridge.Tests.ps1 -Output Detailed
- git diff --check
- pwsh -NoProfile -File .\scripts\git-guard.ps1 -Mode full
- pwsh -NoProfile -File .\scripts\audit-public-surface.ps1