### PR TITLE
Gate prompt transport by provider capability

### DIFF
--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -2583,7 +2583,7 @@ function Invoke-Send {
                 }
 
                 if (Get-Command Get-SlotAgentConfig -ErrorAction SilentlyContinue) {
-                    $agentConfig = Get-SlotAgentConfig -Role $context.Role -SlotId $context.Label
+                    $agentConfig = Get-SlotAgentConfig -Role $context.Role -SlotId $context.Label -RootPath $projectDir
                 } else {
                     $agentConfig = Get-RoleAgentConfig -Role $context.Role
                 }
@@ -2600,6 +2600,9 @@ function Invoke-Send {
                 $execMode = $execModeValue.Trim().ToLowerInvariant() -eq 'true' -and [string]$agentConfig.Agent -eq 'codex'
             }
         } catch {
+            if ($_.Exception.Message -match 'Provider capability') {
+                throw
+            }
         }
     }
 

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -656,6 +656,123 @@ agent-slots:
         $capability.command | Should -Be 'codex'
     }
 
+    It 'rejects slot prompt transport values not supported by provider capabilities' {
+        $registryPath = Get-BridgeProviderCapabilityRegistryPath -RootPath $script:settingsTempRoot
+        $registryDir = Split-Path -Parent $registryPath
+        New-Item -ItemType Directory -Path $registryDir -Force | Out-Null
+
+@'
+{
+  "version": 1,
+  "providers": {
+    "codex": {
+      "adapter": "codex",
+      "command": "codex",
+      "prompt_transports": ["argv"]
+    }
+  }
+}
+'@ | Set-Content -Path $registryPath -Encoding UTF8
+
+@'
+agent: codex
+model: gpt-5.4
+agent-slots:
+  - slot-id: worker-1
+    runtime-role: worker
+    agent: codex
+    model: gpt-5.4
+    prompt-transport: file
+'@ | Set-Content -Path (Join-Path $script:settingsTempRoot '.winsmux.yaml') -Encoding UTF8
+
+        Mock Get-WinsmuxOption { param($Name, $Default) return $null }
+
+        $settings = Get-BridgeSettings
+        {
+            Get-SlotAgentConfig -Role 'Worker' -SlotId 'worker-1' -Settings $settings -RootPath $script:settingsTempRoot
+        } | Should -Throw "*does not support prompt_transport 'file'*"
+    }
+
+    It 'rejects provider registry prompt transport overrides not supported by provider capabilities' {
+        $registryPath = Get-BridgeProviderCapabilityRegistryPath -RootPath $script:settingsTempRoot
+        $registryDir = Split-Path -Parent $registryPath
+        New-Item -ItemType Directory -Path $registryDir -Force | Out-Null
+
+@'
+{
+  "version": 1,
+  "providers": {
+    "claude": {
+      "adapter": "claude",
+      "command": "claude",
+      "prompt_transports": ["file"]
+    }
+  }
+}
+'@ | Set-Content -Path $registryPath -Encoding UTF8
+
+@'
+agent: codex
+model: gpt-5.4
+agent-slots:
+  - slot-id: worker-1
+    runtime-role: worker
+    agent: codex
+    model: gpt-5.4
+    prompt-transport: argv
+'@ | Set-Content -Path (Join-Path $script:settingsTempRoot '.winsmux.yaml') -Encoding UTF8
+
+        Mock Get-WinsmuxOption { param($Name, $Default) return $null }
+
+        $settings = Get-BridgeSettings
+        Write-BridgeProviderRegistryEntry `
+            -RootPath $script:settingsTempRoot `
+            -SlotId 'worker-1' `
+            -Agent 'claude' `
+            -PromptTransport 'stdin' | Out-Null
+
+        {
+            Get-SlotAgentConfig -Role 'Worker' -SlotId 'worker-1' -Settings $settings -RootPath $script:settingsTempRoot
+        } | Should -Throw "*does not support prompt_transport 'stdin'*"
+    }
+
+    It 'rejects providers missing from a non-empty provider capability registry' {
+        $registryPath = Get-BridgeProviderCapabilityRegistryPath -RootPath $script:settingsTempRoot
+        $registryDir = Split-Path -Parent $registryPath
+        New-Item -ItemType Directory -Path $registryDir -Force | Out-Null
+
+@'
+{
+  "version": 1,
+  "providers": {
+    "codex": {
+      "adapter": "codex",
+      "command": "codex",
+      "prompt_transports": ["argv"]
+    }
+  }
+}
+'@ | Set-Content -Path $registryPath -Encoding UTF8
+
+@'
+agent: codex
+model: gpt-5.4
+agent-slots:
+  - slot-id: worker-1
+    runtime-role: worker
+    agent: claude
+    model: opus
+    prompt-transport: stdin
+'@ | Set-Content -Path (Join-Path $script:settingsTempRoot '.winsmux.yaml') -Encoding UTF8
+
+        Mock Get-WinsmuxOption { param($Name, $Default) return $null }
+
+        $settings = Get-BridgeSettings
+        {
+            Get-SlotAgentConfig -Role 'Worker' -SlotId 'worker-1' -Settings $settings -RootPath $script:settingsTempRoot
+        } | Should -Throw "*Provider capability 'claude' was not found*"
+    }
+
     It 'rejects structurally malformed provider capability registries' {
         $registryPath = Get-BridgeProviderCapabilityRegistryPath -RootPath $script:settingsTempRoot
         $registryDir = Split-Path -Parent $registryPath
@@ -8192,6 +8309,7 @@ panes:
 Describe 'winsmux send dispatch payload' {
     BeforeAll {
         $script:winsmuxCorePath = Join-Path (Split-Path -Parent $PSScriptRoot) 'scripts\winsmux-core.ps1'
+        $script:winsmuxCoreSendRawContent = Get-Content -Path $script:winsmuxCorePath -Raw -Encoding UTF8
         . $script:winsmuxCorePath 'version' *> $null
     }
 
@@ -8213,6 +8331,11 @@ Describe 'winsmux send dispatch payload' {
         $payload['TextToSend'] | Should -Be 'Write-Host short'
         $payload['PromptPath'] | Should -Be $null
         Test-Path (Join-Path $script:sendTempRoot '.winsmux\dispatch-prompts') | Should -Be $false
+    }
+
+    It 'resolves managed pane send settings through the project capability root' {
+        $script:winsmuxCoreSendRawContent | Should -Match 'Get-SlotAgentConfig -Role \$context\.Role -SlotId \$context\.Label -RootPath \$projectDir'
+        $script:winsmuxCoreSendRawContent | Should -Match 'Provider capability'
     }
 
     It 'writes long text to a dispatch file and returns a prompt pointer for non-exec panes' {

--- a/winsmux-core/scripts/settings.ps1
+++ b/winsmux-core/scripts/settings.ps1
@@ -748,6 +748,50 @@ function Get-BridgeProviderCapability {
     return $null
 }
 
+function Assert-BridgeProviderCapabilityTransport {
+    param(
+        [Parameter(Mandatory = $true)][string]$ProviderId,
+        [Parameter(Mandatory = $true)][string]$PromptTransport,
+        [string]$RootPath
+    )
+
+    if ([string]::IsNullOrWhiteSpace($ProviderId) -or [string]::IsNullOrWhiteSpace($PromptTransport)) {
+        return
+    }
+
+    $registry = Read-BridgeProviderCapabilityRegistry -RootPath $RootPath
+    if ($registry.providers.Count -lt 1) {
+        return
+    }
+
+    $capability = $null
+    foreach ($entry in $registry.providers.GetEnumerator()) {
+        if ([string]::Equals([string]$entry.Key, $ProviderId, [System.StringComparison]::OrdinalIgnoreCase)) {
+            $capability = $entry.Value
+            break
+        }
+    }
+
+    if ($null -eq $capability) {
+        throw "Provider capability '$ProviderId' was not found."
+    }
+
+    $transports = @()
+    if ($capability.Contains('prompt_transports')) {
+        $transports = @($capability.prompt_transports)
+    }
+
+    if ($transports.Count -lt 1) {
+        throw "Provider capability '$ProviderId' does not declare prompt_transports."
+    }
+
+    $requestedTransport = $PromptTransport.Trim().ToLowerInvariant()
+    $supportedTransports = @($transports | ForEach-Object { ([string]$_).Trim().ToLowerInvariant() })
+    if ($requestedTransport -notin $supportedTransports) {
+        throw "Provider capability '$ProviderId' does not support prompt_transport '$requestedTransport'. Supported values: $($supportedTransports -join ', ')."
+    }
+}
+
 function ConvertFrom-BridgeManualYaml {
     param([Parameter(Mandatory = $true)][string]$Content)
 
@@ -1431,6 +1475,10 @@ function Get-SlotAgentConfig {
         }
 
         $source = 'registry'
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($RootPath)) {
+        Assert-BridgeProviderCapabilityTransport -ProviderId $agent -PromptTransport $promptTransport -RootPath $RootPath
     }
 
     return [PSCustomObject]@{


### PR DESCRIPTION
## Summary
- validate resolved slot prompt_transport values against provider capability prompt_transports
- apply the same validation to provider registry overrides
- pass the project root through managed pane winsmux send config resolution so dispatch fails before sending unsupported prompt transports

## Validation
- Invoke-Pester -Path .\tests\winsmux-bridge.Tests.ps1 -Output Detailed -FullNameFilter 'Get-BridgeSettings*'
- Invoke-Pester -Path .\tests\winsmux-bridge.Tests.ps1 -Output Detailed -FullNameFilter 'winsmux send dispatch payload*'
- Invoke-Pester -Path .\tests\winsmux-bridge.Tests.ps1 -Output Detailed
- git diff --check
- pwsh -NoProfile -File .\scripts\git-guard.ps1 -Mode full
- pwsh -NoProfile -File .\scripts\audit-public-surface.ps1
- pwsh -NoProfile -File .\scripts\gitleaks-history.ps1
- bash .githooks/pre-push