### PR TITLE
TASK-314 route launches through provider capabilities

### DIFF
--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -773,6 +773,37 @@ agent-slots:
         } | Should -Throw "*Provider capability 'claude' was not found*"
     }
 
+    It 'builds launch commands from provider capability adapter and command metadata' {
+        $registryPath = Get-BridgeProviderCapabilityRegistryPath -RootPath $script:settingsTempRoot
+        $registryDir = Split-Path -Parent $registryPath
+        New-Item -ItemType Directory -Path $registryDir -Force | Out-Null
+
+@'
+{
+  "version": 1,
+  "providers": {
+    "codex-local": {
+      "adapter": "codex",
+      "command": "codex-beta",
+      "prompt_transports": ["argv", "file"]
+    }
+  }
+}
+'@ | Set-Content -Path $registryPath -Encoding UTF8
+
+        $command = Get-BridgeProviderLaunchCommand `
+            -ProviderId 'codex-local' `
+            -Model 'gpt-5.4' `
+            -ProjectDir 'C:\Project Root' `
+            -GitWorktreeDir 'C:\Project Root\.git\worktrees\worker-1' `
+            -RootPath $script:settingsTempRoot
+
+        $command | Should -Match 'codex-beta'
+        $command | Should -Match '-c model=gpt-5\.4'
+        $command | Should -Match "-C 'C:\\Project Root'"
+        $command | Should -Match "--add-dir 'C:\\Project Root\\.git\\worktrees\\worker-1'"
+    }
+
     It 'rejects structurally malformed provider capability registries' {
         $registryPath = Get-BridgeProviderCapabilityRegistryPath -RootPath $script:settingsTempRoot
         $registryDir = Split-Path -Parent $registryPath
@@ -1796,7 +1827,7 @@ panes:
         $plan.Agent | Should -Be 'claude'
         $plan.Model | Should -Be 'sonnet'
         $plan.PromptTransport | Should -Be 'argv'
-        $plan.LaunchCommand | Should -Be 'claude --permission-mode bypassPermissions'
+        $plan.LaunchCommand | Should -Be "claude --model 'sonnet' --permission-mode bypassPermissions"
     }
 
     It 'uses provider registry overrides when building a restart plan' {
@@ -1842,7 +1873,7 @@ agent_slots:
         $plan.Model | Should -Be 'opus'
         $plan.PromptTransport | Should -Be 'file'
         $plan.Source | Should -Be 'registry'
-        $plan.LaunchCommand | Should -Be 'claude --permission-mode bypassPermissions'
+        $plan.LaunchCommand | Should -Be "claude --model 'opus' --permission-mode bypassPermissions"
     }
 
     It 'includes slot-level prompt transport overrides in the restart plan' {
@@ -5439,7 +5470,7 @@ panes:
         Add-OrchestraPane -ManifestPath $script:paneScalerManifestPath -Settings $settings | Out-Null
 
         Should -Invoke Send-MonitorBridgeCommand -Times 1 -Exactly -ParameterFilter {
-            $PaneId -eq '%3' -and $Text -eq 'claude --permission-mode bypassPermissions'
+            $PaneId -eq '%3' -and $Text -eq "claude --model 'opus' --permission-mode bypassPermissions"
         }
     }
 
@@ -9301,6 +9332,11 @@ Describe 'orchestra pane bootstrap plan' {
 
     It 'passes the project root into slot provider resolution' {
         $script:orchestraStartContent | Should -Match 'Get-SlotAgentConfig -Role \$canonicalRole -SlotId \$label -Settings \$settings -RootPath \$projectDir'
+    }
+
+    It 'builds pane launch commands through provider capability metadata' {
+        $script:orchestraStartContent | Should -Match 'Get-BridgeProviderLaunchCommand'
+        $script:orchestraStartContent | Should -Match 'Get-AgentLaunchCommand -Agent \$slotAgentConfig\.Agent -Model \$slotAgentConfig\.Model -ProjectDir \$launchDir -GitWorktreeDir \$launchGitWorktreeDir -RootPath \$projectDir'
     }
 
     It 'prints a concise startup summary before invoking the agent launch command' {

--- a/winsmux-core/scripts/agent-monitor.ps1
+++ b/winsmux-core/scripts/agent-monitor.ps1
@@ -886,29 +886,38 @@ function Invoke-AgentRespawn {
         [Parameter(Mandatory = $true)][string]$Model,
         [Parameter(Mandatory = $true)][string]$ProjectDir,
         [Parameter(Mandatory = $true)][string]$GitWorktreeDir,
+        [string]$RootPath = '',
         [string]$ManifestPath = '',
         [int]$ReadyTimeoutSeconds = 60
     )
 
-    # Build launch command (same logic as orchestra-start Get-AgentLaunchCommand)
     $launchCommand = $null
     $paneExecMode = $false
     $paneRole = ''
-    switch ($Agent.Trim().ToLowerInvariant()) {
-        'codex' {
-            $escapedProject = "'" + ($ProjectDir -replace "'", "''") + "'"
-            $escapedWorktree = "'" + ($GitWorktreeDir -replace "'", "''") + "'"
-            $launchCommand = "codex -c model=$Model --sandbox danger-full-access -C $escapedProject --add-dir $escapedWorktree"
-        }
-        'claude' {
-            $launchCommand = 'claude --permission-mode bypassPermissions'
-        }
-        default {
-            return [ordered]@{
-                Success = $false
-                PaneId  = $PaneId
-                Message = "Unsupported agent: $Agent"
+
+    $capabilityRootPath = $RootPath
+    if ([string]::IsNullOrWhiteSpace($capabilityRootPath)) {
+        $capabilityRootPath = $ProjectDir
+        if (-not [string]::IsNullOrWhiteSpace($ManifestPath)) {
+            $manifestDir = Split-Path -Parent $ManifestPath
+            if (-not [string]::IsNullOrWhiteSpace($manifestDir) -and (Split-Path -Leaf $manifestDir) -eq '.winsmux') {
+                $capabilityRootPath = Split-Path -Parent $manifestDir
             }
+        }
+    }
+
+    try {
+        $launchCommand = Get-BridgeProviderLaunchCommand `
+            -ProviderId $Agent `
+            -Model $Model `
+            -ProjectDir $ProjectDir `
+            -GitWorktreeDir $GitWorktreeDir `
+            -RootPath $capabilityRootPath
+    } catch {
+        return [ordered]@{
+            Success = $false
+            PaneId  = $PaneId
+            Message = $_.Exception.Message
         }
     }
 
@@ -1450,6 +1459,7 @@ function Invoke-AgentMonitorCycle {
                 -Model $modelName `
                 -ProjectDir $launchDir `
                 -GitWorktreeDir $launchGitWorktreeDir `
+                -RootPath $projectDir `
                 -ManifestPath $ManifestPath
 
             $result['Respawned'] = $respawnResult.Success

--- a/winsmux-core/scripts/orchestra-start.ps1
+++ b/winsmux-core/scripts/orchestra-start.ps1
@@ -731,24 +731,17 @@ function Get-AgentLaunchCommand {
         [Parameter(Mandatory = $true)][string]$Model,
         [Parameter(Mandatory = $true)][string]$ProjectDir,
         [Parameter(Mandatory = $true)][string]$GitWorktreeDir,
+        [string]$RootPath,
         [bool]$ExecMode = $false
     )
 
-    switch ($Agent.Trim().ToLowerInvariant()) {
-        'codex' {
-            if ($ExecMode) {
-                return ''
-            }
-
-            return "codex -c model=$Model --sandbox danger-full-access -C $(ConvertTo-PowerShellLiteral -Value $ProjectDir) --add-dir $(ConvertTo-PowerShellLiteral -Value $GitWorktreeDir)"
-        }
-        'claude' {
-            return "claude --model $Model --permission-mode bypassPermissions"
-        }
-        default {
-            throw "Unsupported agent setting: $Agent"
-        }
-    }
+    return Get-BridgeProviderLaunchCommand `
+        -ProviderId $Agent `
+        -Model $Model `
+        -ProjectDir $ProjectDir `
+        -GitWorktreeDir $GitWorktreeDir `
+        -RootPath $RootPath `
+        -ExecMode $ExecMode
 }
 
 function Get-VaultValue {
@@ -1999,7 +1992,7 @@ if ($MyInvocation.InvocationName -ne '.') {
 
         $slotAgentConfig = Get-SlotAgentConfig -Role $canonicalRole -SlotId $label -Settings $settings -RootPath $projectDir
         $execMode = ([string]$slotAgentConfig.Agent).Trim().ToLowerInvariant() -eq 'codex'
-        $launchCommand = Get-AgentLaunchCommand -Agent $slotAgentConfig.Agent -Model $slotAgentConfig.Model -ProjectDir $launchDir -GitWorktreeDir $launchGitWorktreeDir -ExecMode $false
+        $launchCommand = Get-AgentLaunchCommand -Agent $slotAgentConfig.Agent -Model $slotAgentConfig.Model -ProjectDir $launchDir -GitWorktreeDir $launchGitWorktreeDir -RootPath $projectDir -ExecMode $false
 
         Invoke-Bridge -Arguments @('name', $paneId, $label)
         try {

--- a/winsmux-core/scripts/pane-control.ps1
+++ b/winsmux-core/scripts/pane-control.ps1
@@ -236,8 +236,18 @@ function Get-PaneControlLaunchCommand {
         [Parameter(Mandatory = $true)][string]$Agent,
         [Parameter(Mandatory = $true)][string]$Model,
         [Parameter(Mandatory = $true)][string]$ProjectDir,
-        [Parameter(Mandatory = $true)][string]$GitWorktreeDir
+        [Parameter(Mandatory = $true)][string]$GitWorktreeDir,
+        [string]$RootPath = ''
     )
+
+    if (Get-Command Get-BridgeProviderLaunchCommand -ErrorAction SilentlyContinue) {
+        return Get-BridgeProviderLaunchCommand `
+            -ProviderId $Agent `
+            -Model $Model `
+            -ProjectDir $ProjectDir `
+            -GitWorktreeDir $GitWorktreeDir `
+            -RootPath $RootPath
+    }
 
     switch ($Agent.Trim().ToLowerInvariant()) {
         'codex' {
@@ -539,7 +549,7 @@ function Get-PaneControlRestartPlan {
         }
     }
 
-    $launchCommand = Get-PaneControlLaunchCommand -Agent $agentConfig.Agent -Model $agentConfig.Model -ProjectDir $context.LaunchDir -GitWorktreeDir $context.GitWorktreeDir
+    $launchCommand = Get-PaneControlLaunchCommand -Agent $agentConfig.Agent -Model $agentConfig.Model -ProjectDir $context.LaunchDir -GitWorktreeDir $context.GitWorktreeDir -RootPath $ProjectDir
 
     return [ordered]@{
         PaneId         = $context.PaneId

--- a/winsmux-core/scripts/pane-scaler.ps1
+++ b/winsmux-core/scripts/pane-scaler.ps1
@@ -169,8 +169,18 @@ function Get-PaneScalerLaunchCommand {
         [Parameter(Mandatory = $true)][string]$Agent,
         [Parameter(Mandatory = $true)][string]$Model,
         [Parameter(Mandatory = $true)][string]$ProjectDir,
-        [Parameter(Mandatory = $true)][string]$GitWorktreeDir
+        [Parameter(Mandatory = $true)][string]$GitWorktreeDir,
+        [string]$RootPath = ''
     )
+
+    if (Get-Command Get-BridgeProviderLaunchCommand -ErrorAction SilentlyContinue) {
+        return Get-BridgeProviderLaunchCommand `
+            -ProviderId $Agent `
+            -Model $Model `
+            -ProjectDir $ProjectDir `
+            -GitWorktreeDir $GitWorktreeDir `
+            -RootPath $RootPath
+    }
 
     switch ($Agent.Trim().ToLowerInvariant()) {
         'codex' {
@@ -401,7 +411,7 @@ function Add-OrchestraPane {
         }
 
         Wait-MonitorPaneShellReady -PaneId $newPaneId
-        Send-MonitorBridgeCommand -PaneId $newPaneId -Text (Get-PaneScalerLaunchCommand -Agent ([string]$roleAgentConfig.Agent) -Model ([string]$roleAgentConfig.Model) -ProjectDir $worktree.WorktreePath -GitWorktreeDir $worktree.GitWorktreeDir)
+        Send-MonitorBridgeCommand -PaneId $newPaneId -Text (Get-PaneScalerLaunchCommand -Agent ([string]$roleAgentConfig.Agent) -Model ([string]$roleAgentConfig.Model) -ProjectDir $worktree.WorktreePath -GitWorktreeDir $worktree.GitWorktreeDir -RootPath $projectDir)
 
         $newPane = [ordered]@{
             label                = $newLabel

--- a/winsmux-core/scripts/settings.ps1
+++ b/winsmux-core/scripts/settings.ps1
@@ -658,6 +658,22 @@ function ConvertTo-BridgeProviderCapabilityEntry {
     return $entry
 }
 
+function ConvertTo-BridgePowerShellLiteral {
+    param([Parameter(Mandatory = $true)][AllowEmptyString()][string]$Value)
+
+    return "'" + ($Value -replace "'", "''") + "'"
+}
+
+function ConvertTo-BridgePowerShellCommandInvocation {
+    param([Parameter(Mandatory = $true)][AllowEmptyString()][string]$Value)
+
+    if ($Value -match '^[a-zA-Z0-9_.:/\\-]+$') {
+        return $Value
+    }
+
+    return '& ' + (ConvertTo-BridgePowerShellLiteral -Value $Value)
+}
+
 function Read-BridgeProviderCapabilityRegistry {
     param([string]$RootPath)
 
@@ -748,6 +764,35 @@ function Get-BridgeProviderCapability {
     return $null
 }
 
+function Resolve-BridgeProviderCapability {
+    param(
+        [Parameter(Mandatory = $true)][string]$ProviderId,
+        [string]$RootPath,
+        [switch]$RequireWhenRegistryPresent
+    )
+
+    if ([string]::IsNullOrWhiteSpace($ProviderId)) {
+        return $null
+    }
+
+    $registry = Read-BridgeProviderCapabilityRegistry -RootPath $RootPath
+    if ($registry.providers.Count -lt 1) {
+        return $null
+    }
+
+    foreach ($entry in $registry.providers.GetEnumerator()) {
+        if ([string]::Equals([string]$entry.Key, $ProviderId, [System.StringComparison]::OrdinalIgnoreCase)) {
+            return $entry.Value
+        }
+    }
+
+    if ($RequireWhenRegistryPresent) {
+        throw "Provider capability '$ProviderId' was not found."
+    }
+
+    return $null
+}
+
 function Assert-BridgeProviderCapabilityTransport {
     param(
         [Parameter(Mandatory = $true)][string]$ProviderId,
@@ -759,21 +804,9 @@ function Assert-BridgeProviderCapabilityTransport {
         return
     }
 
-    $registry = Read-BridgeProviderCapabilityRegistry -RootPath $RootPath
-    if ($registry.providers.Count -lt 1) {
-        return
-    }
-
-    $capability = $null
-    foreach ($entry in $registry.providers.GetEnumerator()) {
-        if ([string]::Equals([string]$entry.Key, $ProviderId, [System.StringComparison]::OrdinalIgnoreCase)) {
-            $capability = $entry.Value
-            break
-        }
-    }
-
+    $capability = Resolve-BridgeProviderCapability -ProviderId $ProviderId -RootPath $RootPath -RequireWhenRegistryPresent
     if ($null -eq $capability) {
-        throw "Provider capability '$ProviderId' was not found."
+        return
     }
 
     $transports = @()
@@ -789,6 +822,57 @@ function Assert-BridgeProviderCapabilityTransport {
     $supportedTransports = @($transports | ForEach-Object { ([string]$_).Trim().ToLowerInvariant() })
     if ($requestedTransport -notin $supportedTransports) {
         throw "Provider capability '$ProviderId' does not support prompt_transport '$requestedTransport'. Supported values: $($supportedTransports -join ', ')."
+    }
+}
+
+function Get-BridgeProviderLaunchCommand {
+    param(
+        [Parameter(Mandatory = $true)][string]$ProviderId,
+        [Parameter(Mandatory = $true)][AllowEmptyString()][string]$Model,
+        [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [Parameter(Mandatory = $true)][string]$GitWorktreeDir,
+        [string]$RootPath,
+        [bool]$ExecMode = $false
+    )
+
+    $provider = $ProviderId.Trim()
+    if ([string]::IsNullOrWhiteSpace($provider)) {
+        throw 'Provider id must not be empty.'
+    }
+
+    $capability = Resolve-BridgeProviderCapability -ProviderId $provider -RootPath $RootPath -RequireWhenRegistryPresent
+    $adapter = $provider
+    $command = $provider
+    if ($null -ne $capability) {
+        $adapter = [string]$capability.adapter
+        $command = [string]$capability.command
+    }
+
+    $adapterKey = $adapter.Trim().ToLowerInvariant()
+    $commandInvocation = ConvertTo-BridgePowerShellCommandInvocation -Value $command
+    switch ($adapterKey) {
+        'codex' {
+            if ($ExecMode) {
+                return ''
+            }
+
+            $projectLiteral = ConvertTo-BridgePowerShellLiteral -Value $ProjectDir
+            $worktreeLiteral = ConvertTo-BridgePowerShellLiteral -Value $GitWorktreeDir
+            return "$commandInvocation -c model=$Model --sandbox danger-full-access -C $projectLiteral --add-dir $worktreeLiteral"
+        }
+        'claude' {
+            $parts = @($commandInvocation)
+            if (-not [string]::IsNullOrWhiteSpace($Model)) {
+                $parts += '--model'
+                $parts += (ConvertTo-BridgePowerShellLiteral -Value $Model)
+            }
+            $parts += '--permission-mode'
+            $parts += 'bypassPermissions'
+            return ($parts -join ' ')
+        }
+        default {
+            throw "Unsupported provider adapter '$adapter' for provider '$provider'."
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- build provider launch commands from capability adapter and command metadata
- route orchestra startup, pane restart, monitor respawn, and pane scaler add-pane through the shared launch helper
- keep existing provider-name fallback when no capability registry is present

## Validation
- Invoke-Pester -Path .\tests\winsmux-bridge.Tests.ps1 -Output Detailed
- git diff --check
- pwsh -NoProfile -File .\scripts\git-guard.ps1 -Mode full
- pwsh -NoProfile -File .\scripts\audit-public-surface.ps1
- pwsh -NoProfile -File .\scripts\gitleaks-history.ps1
- bash .githooks/pre-push