### PR TITLE
TASK-314: Project provider capability flags into runtime surfaces

### DIFF
--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -7104,19 +7104,28 @@ function Invoke-ProviderSwitch {
     }
     $effective = Get-SlotAgentConfig -Role 'Worker' -SlotId $slotId -Settings $settings -RootPath $projectDir
     $result = [ordered]@{
-        slot_id          = $slotId
-        agent            = [string]$effective.Agent
-        model            = [string]$effective.Model
-        prompt_transport = [string]$effective.PromptTransport
-        source           = [string]$effective.Source
-        registry_path    = Get-BridgeProviderRegistryPath -RootPath $projectDir
-        updated_at_utc   = if ($clearRequested) { [string]$clearResult.UpdatedAtUtc } else { [string]$entry.updated_at_utc }
-        reason           = if ((-not $clearRequested) -and $entry.Contains('reason')) { [string]$entry.reason } else { '' }
-        clear_requested  = $clearRequested
-        cleared          = $cleared
-        restart_requested = $restartRequested
-        restarted        = $false
-        restart_pane_id  = ''
+        slot_id                    = $slotId
+        agent                      = [string]$effective.Agent
+        model                      = [string]$effective.Model
+        prompt_transport           = [string]$effective.PromptTransport
+        source                     = [string]$effective.Source
+        capability_adapter         = [string]$effective.CapabilityAdapter
+        capability_command         = [string]$effective.CapabilityCommand
+        supports_parallel_runs     = [bool]$effective.SupportsParallelRuns
+        supports_interrupt         = [bool]$effective.SupportsInterrupt
+        supports_structured_result = [bool]$effective.SupportsStructuredResult
+        supports_file_edit         = [bool]$effective.SupportsFileEdit
+        supports_subagents         = [bool]$effective.SupportsSubagents
+        supports_verification      = [bool]$effective.SupportsVerification
+        supports_consultation      = [bool]$effective.SupportsConsultation
+        registry_path              = Get-BridgeProviderRegistryPath -RootPath $projectDir
+        updated_at_utc             = if ($clearRequested) { [string]$clearResult.UpdatedAtUtc } else { [string]$entry.updated_at_utc }
+        reason                     = if ((-not $clearRequested) -and $entry.Contains('reason')) { [string]$entry.reason } else { '' }
+        clear_requested            = $clearRequested
+        cleared                    = $cleared
+        restart_requested          = $restartRequested
+        restarted                  = $false
+        restart_pane_id            = ''
     }
 
     if ($restartRequested) {

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -656,6 +656,58 @@ agent-slots:
         $capability.command | Should -Be 'codex'
     }
 
+    It 'projects provider capability fields onto resolved slot configs' {
+        $registryPath = Get-BridgeProviderCapabilityRegistryPath -RootPath $script:settingsTempRoot
+        $registryDir = Split-Path -Parent $registryPath
+        New-Item -ItemType Directory -Path $registryDir -Force | Out-Null
+
+@'
+{
+  "version": 1,
+  "providers": {
+    "codex": {
+      "adapter": "codex",
+      "command": "codex",
+      "prompt_transports": ["argv", "file", "stdin"],
+      "supports_parallel_runs": true,
+      "supports_interrupt": true,
+      "supports_structured_result": true,
+      "supports_file_edit": true,
+      "supports_subagents": true,
+      "supports_verification": true,
+      "supports_consultation": false
+    }
+  }
+}
+'@ | Set-Content -Path $registryPath -Encoding UTF8
+
+@'
+agent: codex
+model: gpt-5.4
+agent-slots:
+  - slot-id: worker-1
+    runtime-role: worker
+    agent: codex
+    model: gpt-5.4
+    prompt-transport: argv
+'@ | Set-Content -Path (Join-Path $script:settingsTempRoot '.winsmux.yaml') -Encoding UTF8
+
+        Mock Get-WinsmuxOption { param($Name, $Default) return $null }
+
+        $settings = Get-BridgeSettings
+        $config = Get-SlotAgentConfig -Role 'Worker' -SlotId 'worker-1' -Settings $settings -RootPath $script:settingsTempRoot
+
+        $config.CapabilityAdapter | Should -Be 'codex'
+        $config.CapabilityCommand | Should -Be 'codex'
+        $config.SupportsParallelRuns | Should -Be $true
+        $config.SupportsInterrupt | Should -Be $true
+        $config.SupportsStructuredResult | Should -Be $true
+        $config.SupportsFileEdit | Should -Be $true
+        $config.SupportsSubagents | Should -Be $true
+        $config.SupportsVerification | Should -Be $true
+        $config.SupportsConsultation | Should -Be $false
+    }
+
     It 'rejects slot prompt transport values not supported by provider capabilities' {
         $registryPath = Get-BridgeProviderCapabilityRegistryPath -RootPath $script:settingsTempRoot
         $registryDir = Split-Path -Parent $registryPath
@@ -4753,6 +4805,15 @@ Describe 'orchestra-start session reuse contract' {
         $script:orchestraStartContent | Should -Match '\$defaultModel'
     }
 
+    It 'persists provider capability fields in pane manifest entries' {
+        $script:orchestraStartContent | Should -Match 'CapabilityAdapter = \[string\]\$slotAgentConfig\.CapabilityAdapter'
+        $script:orchestraStartContent | Should -Match 'SupportsFileEdit = \[bool\]\$slotAgentConfig\.SupportsFileEdit'
+        $script:orchestraStartContent | Should -Match 'SupportsVerification = \[bool\]\$slotAgentConfig\.SupportsVerification'
+        $script:orchestraStartContent | Should -Match 'capability_adapter\s*=\s*\[string\]\$paneSummary\.CapabilityAdapter'
+        $script:orchestraStartContent | Should -Match 'supports_file_edit\s*=\s*\[bool\]\$paneSummary\.SupportsFileEdit'
+        $script:orchestraStartContent | Should -Match 'supports_verification\s*=\s*\[bool\]\$paneSummary\.SupportsVerification'
+    }
+
     It 'routes partial bootstrap invalid state into the startup rollback path by throwing' {
         {
             Assert-OrchestraBootstrapVerification -PaneSummaries @(
@@ -8814,6 +8875,38 @@ agent-slots:
     model: gpt-5.4
     prompt-transport: argv
 '@ | Set-Content -Path (Join-Path $script:providerSwitchTempRoot '.winsmux.yaml') -Encoding UTF8
+        New-Item -ItemType Directory -Path (Join-Path $script:providerSwitchTempRoot '.winsmux') -Force | Out-Null
+@'
+{
+  "version": 1,
+  "providers": {
+    "codex": {
+      "adapter": "codex",
+      "command": "codex",
+      "prompt_transports": ["argv", "file", "stdin"],
+      "supports_parallel_runs": true,
+      "supports_interrupt": true,
+      "supports_structured_result": true,
+      "supports_file_edit": true,
+      "supports_subagents": true,
+      "supports_verification": true,
+      "supports_consultation": false
+    },
+    "claude": {
+      "adapter": "claude",
+      "command": "claude",
+      "prompt_transports": ["file"],
+      "supports_parallel_runs": false,
+      "supports_interrupt": true,
+      "supports_structured_result": false,
+      "supports_file_edit": true,
+      "supports_subagents": false,
+      "supports_verification": true,
+      "supports_consultation": true
+    }
+  }
+}
+'@ | Set-Content -Path (Join-Path $script:providerSwitchTempRoot '.winsmux\provider-capabilities.json') -Encoding UTF8
     }
 
     AfterEach {
@@ -8839,6 +8932,11 @@ agent-slots:
         $result.model | Should -Be 'opus'
         $result.prompt_transport | Should -Be 'file'
         $result.source | Should -Be 'registry'
+        $result.capability_adapter | Should -Be 'claude'
+        $result.capability_command | Should -Be 'claude'
+        $result.supports_file_edit | Should -Be $true
+        $result.supports_subagents | Should -Be $false
+        $result.supports_consultation | Should -Be $true
         $result.restart_requested | Should -Be $false
         $result.restarted | Should -Be $false
 
@@ -8866,6 +8964,10 @@ agent-slots:
         $result.model | Should -Be 'gpt-5.4'
         $result.prompt_transport | Should -Be 'argv'
         $result.source | Should -Be 'slot'
+        $result.capability_adapter | Should -Be 'codex'
+        $result.supports_parallel_runs | Should -Be $true
+        $result.supports_verification | Should -Be $true
+        $result.supports_consultation | Should -Be $false
         $result.clear_requested | Should -Be $true
         $result.cleared | Should -Be $true
         $registry = Get-Content -LiteralPath (Join-Path $script:providerSwitchTempRoot '.winsmux\provider-registry.json') -Raw -Encoding UTF8 | ConvertFrom-Json

--- a/winsmux-core/scripts/orchestra-start.ps1
+++ b/winsmux-core/scripts/orchestra-start.ps1
@@ -1035,14 +1035,23 @@ function Save-OrchestraSessionState {
     $paneMap = [ordered]@{}
     foreach ($paneSummary in @($PaneSummaries)) {
         $paneEntry = [PSCustomObject]@{
-            pane_id               = $paneSummary.PaneId
-            role                  = $paneSummary.Role
-            exec_mode             = [bool]$paneSummary.ExecMode
-            launch_dir            = $paneSummary.LaunchDir
-            builder_branch        = $paneSummary.BuilderBranch
-            builder_worktree_path = $paneSummary.BuilderWorktreePath
-            task                  = $null
-            status                = if ($paneSummary.Status) { $paneSummary.Status } else { 'ready' }
+            pane_id                    = $paneSummary.PaneId
+            role                       = $paneSummary.Role
+            exec_mode                  = [bool]$paneSummary.ExecMode
+            launch_dir                 = $paneSummary.LaunchDir
+            builder_branch             = $paneSummary.BuilderBranch
+            builder_worktree_path      = $paneSummary.BuilderWorktreePath
+            capability_adapter         = [string]$paneSummary.CapabilityAdapter
+            capability_command         = [string]$paneSummary.CapabilityCommand
+            supports_parallel_runs     = [bool]$paneSummary.SupportsParallelRuns
+            supports_interrupt         = [bool]$paneSummary.SupportsInterrupt
+            supports_structured_result = [bool]$paneSummary.SupportsStructuredResult
+            supports_file_edit         = [bool]$paneSummary.SupportsFileEdit
+            supports_subagents         = [bool]$paneSummary.SupportsSubagents
+            supports_verification      = [bool]$paneSummary.SupportsVerification
+            supports_consultation      = [bool]$paneSummary.SupportsConsultation
+            task                       = $null
+            status                     = if ($paneSummary.Status) { $paneSummary.Status } else { 'ready' }
         }
         if ($paneSummary.Contains('BootstrapFailures') -and $paneSummary['BootstrapFailures']) {
             $paneEntry | Add-Member -NotePropertyName 'bootstrap_failures' -NotePropertyValue $paneSummary['BootstrapFailures']
@@ -2041,6 +2050,15 @@ if ($MyInvocation.InvocationName -ne '.') {
             Role = $canonicalRole
             Agent = [string]$slotAgentConfig.Agent
             Model = [string]$slotAgentConfig.Model
+            CapabilityAdapter = [string]$slotAgentConfig.CapabilityAdapter
+            CapabilityCommand = [string]$slotAgentConfig.CapabilityCommand
+            SupportsParallelRuns = [bool]$slotAgentConfig.SupportsParallelRuns
+            SupportsInterrupt = [bool]$slotAgentConfig.SupportsInterrupt
+            SupportsStructuredResult = [bool]$slotAgentConfig.SupportsStructuredResult
+            SupportsFileEdit = [bool]$slotAgentConfig.SupportsFileEdit
+            SupportsSubagents = [bool]$slotAgentConfig.SupportsSubagents
+            SupportsVerification = [bool]$slotAgentConfig.SupportsVerification
+            SupportsConsultation = [bool]$slotAgentConfig.SupportsConsultation
             ExecMode = $false
             LaunchDir = $launchDir
             BuilderBranch = $builderBranch

--- a/winsmux-core/scripts/settings.ps1
+++ b/winsmux-core/scripts/settings.ps1
@@ -793,6 +793,41 @@ function Resolve-BridgeProviderCapability {
     return $null
 }
 
+function Get-BridgeProviderCapabilityValue {
+    param(
+        [AllowNull()]$Capability,
+        [Parameter(Mandatory = $true)][string]$Name,
+        [AllowNull()]$Default = $null
+    )
+
+    if ($null -eq $Capability) {
+        return $Default
+    }
+
+    if ($Capability -is [System.Collections.IDictionary]) {
+        if ($Capability.Contains($Name)) {
+            return $Capability[$Name]
+        }
+
+        return $Default
+    }
+
+    if ($null -ne $Capability.PSObject -and $Capability.PSObject.Properties.Name -contains $Name) {
+        return $Capability.PSObject.Properties[$Name].Value
+    }
+
+    return $Default
+}
+
+function Get-BridgeProviderCapabilityBoolean {
+    param(
+        [AllowNull()]$Capability,
+        [Parameter(Mandatory = $true)][string]$Name
+    )
+
+    return [bool](Get-BridgeProviderCapabilityValue -Capability $Capability -Name $Name -Default $false)
+}
+
 function Assert-BridgeProviderCapabilityTransport {
     param(
         [Parameter(Mandatory = $true)][string]$ProviderId,
@@ -1561,16 +1596,27 @@ function Get-SlotAgentConfig {
         $source = 'registry'
     }
 
+    $providerCapability = $null
     if (-not [string]::IsNullOrWhiteSpace($RootPath)) {
         Assert-BridgeProviderCapabilityTransport -ProviderId $agent -PromptTransport $promptTransport -RootPath $RootPath
+        $providerCapability = Resolve-BridgeProviderCapability -ProviderId $agent -RootPath $RootPath -RequireWhenRegistryPresent
     }
 
     return [PSCustomObject]@{
-        SlotId          = [string]$SlotId
-        Agent           = [string]$agent
-        Model           = [string]$model
-        PromptTransport = [string]$promptTransport
-        Source          = [string]$source
+        SlotId                   = [string]$SlotId
+        Agent                    = [string]$agent
+        Model                    = [string]$model
+        PromptTransport          = [string]$promptTransport
+        Source                   = [string]$source
+        CapabilityAdapter        = [string](Get-BridgeProviderCapabilityValue -Capability $providerCapability -Name 'adapter' -Default '')
+        CapabilityCommand        = [string](Get-BridgeProviderCapabilityValue -Capability $providerCapability -Name 'command' -Default '')
+        SupportsParallelRuns     = Get-BridgeProviderCapabilityBoolean -Capability $providerCapability -Name 'supports_parallel_runs'
+        SupportsInterrupt        = Get-BridgeProviderCapabilityBoolean -Capability $providerCapability -Name 'supports_interrupt'
+        SupportsStructuredResult = Get-BridgeProviderCapabilityBoolean -Capability $providerCapability -Name 'supports_structured_result'
+        SupportsFileEdit         = Get-BridgeProviderCapabilityBoolean -Capability $providerCapability -Name 'supports_file_edit'
+        SupportsSubagents        = Get-BridgeProviderCapabilityBoolean -Capability $providerCapability -Name 'supports_subagents'
+        SupportsVerification     = Get-BridgeProviderCapabilityBoolean -Capability $providerCapability -Name 'supports_verification'
+        SupportsConsultation     = Get-BridgeProviderCapabilityBoolean -Capability $providerCapability -Name 'supports_consultation'
     }
 }
 


### PR DESCRIPTION
## Summary
- project provider capability metadata onto resolved slot configs
- return resolved capability flags from `winsmux provider-switch --json`
- persist capability fields into orchestra pane manifest entries

## Validation
- `Invoke-Pester -Path .\tests\winsmux-bridge.Tests.ps1 -FullName '*projects provider capability fields onto resolved slot configs*' -Output Detailed`
- `Invoke-Pester -Path .\tests\winsmux-bridge.Tests.ps1 -FullName '*winsmux provider-switch command*' -Output Detailed`
- `Invoke-Pester -Path .\tests\winsmux-bridge.Tests.ps1 -FullName '*persists provider capability fields in pane manifest entries*' -Output Detailed`
- `Invoke-Pester -Path .\tests\winsmux-bridge.Tests.ps1 -Output Detailed`
- `git diff --check`
- `pwsh -NoProfile -File .\scripts\git-guard.ps1 -Mode full`
- `pwsh -NoProfile -File .\scripts\audit-public-surface.ps1`
- `pwsh -NoProfile -File .\scripts\gitleaks-history.ps1`
- `bash .githooks/pre-push`