### PR TITLE
TASK-314: Select team pipeline targets by capabilities

### DIFF
--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -1592,9 +1592,9 @@ NEXT_ACTION: rerun focused verification
     It 'uses manifest capability flags when no explicit verification target is supplied' {
         $manifest = [PSCustomObject]@{
             Panes = [ordered]@{
-                'worker-1' = [ordered]@{ role = 'Worker'; supports_verification = $false }
-                'worker-2' = [ordered]@{ role = 'Worker'; supports_verification = $true }
-                'reviewer' = [ordered]@{ role = 'Reviewer'; supports_verification = $true }
+                'worker-1' = [ordered]@{ role = 'Worker'; supports_verification = 'false' }
+                'worker-2' = [ordered]@{ role = 'Worker'; supports_verification = 'true' }
+                'reviewer' = [ordered]@{ role = 'Reviewer'; supports_verification = 'true' }
             }
         }
 
@@ -1606,8 +1606,8 @@ NEXT_ACTION: rerun focused verification
     It 'falls back to configured researcher when no manifest verification capability is available' {
         $manifest = [PSCustomObject]@{
             Panes = [ordered]@{
-                'worker-1' = [ordered]@{ role = 'Worker'; supports_verification = $false }
-                'worker-2' = [ordered]@{ role = 'Worker'; supports_verification = $false }
+                'worker-1' = [ordered]@{ role = 'Worker'; supports_verification = 'false' }
+                'worker-2' = [ordered]@{ role = 'Worker'; supports_verification = 'false' }
             }
         }
 
@@ -1626,8 +1626,8 @@ NEXT_ACTION: rerun focused verification
     It 'uses manifest consultation capability when no explicit consult target is supplied' {
         $manifest = [PSCustomObject]@{
             Panes = [ordered]@{
-                'worker-1' = [ordered]@{ role = 'Worker'; supports_consultation = $false }
-                'worker-2' = [ordered]@{ role = 'Worker'; supports_consultation = $true }
+                'worker-1' = [ordered]@{ role = 'Worker'; supports_consultation = 'false' }
+                'worker-2' = [ordered]@{ role = 'Worker'; supports_consultation = 'true' }
             }
         }
 

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -1589,11 +1589,51 @@ NEXT_ACTION: rerun focused verification
         $skipTargets.VerifyTarget | Should -BeNullOrEmpty
     }
 
+    It 'uses manifest capability flags when no explicit verification target is supplied' {
+        $manifest = [PSCustomObject]@{
+            Panes = [ordered]@{
+                'worker-1' = [ordered]@{ role = 'Worker'; supports_verification = $false }
+                'worker-2' = [ordered]@{ role = 'Worker'; supports_verification = $true }
+                'reviewer' = [ordered]@{ role = 'Reviewer'; supports_verification = $true }
+            }
+        }
+
+        $targets = Get-TeamPipelineStageTargets -BuilderLabel 'worker-1' -ResearcherLabel '' -ReviewerLabel '' -Manifest $manifest
+
+        $targets.VerifyTarget | Should -Be 'reviewer'
+    }
+
+    It 'falls back to configured researcher when no manifest verification capability is available' {
+        $manifest = [PSCustomObject]@{
+            Panes = [ordered]@{
+                'worker-1' = [ordered]@{ role = 'Worker'; supports_verification = $false }
+                'worker-2' = [ordered]@{ role = 'Worker'; supports_verification = $false }
+            }
+        }
+
+        $targets = Get-TeamPipelineStageTargets -BuilderLabel 'worker-1' -ResearcherLabel 'researcher' -ReviewerLabel '' -Manifest $manifest
+
+        $targets.VerifyTarget | Should -Be 'researcher'
+    }
+
     It 'prefers reviewer then researcher for consult targets and skips builder-only runs' {
         (Get-TeamPipelineConsultTarget -BuilderLabel 'builder-1' -ResearcherLabel 'researcher' -ReviewerLabel 'reviewer') | Should -Be 'reviewer'
         (Get-TeamPipelineConsultTarget -BuilderLabel 'builder-1' -ResearcherLabel 'researcher' -ReviewerLabel '') | Should -Be 'researcher'
         (Get-TeamPipelineConsultTarget -BuilderLabel 'builder-1' -ResearcherLabel '' -ReviewerLabel 'builder-1') | Should -BeNullOrEmpty
         (Get-TeamPipelineConsultTarget -BuilderLabel 'builder-1' -ResearcherLabel '' -ReviewerLabel '') | Should -BeNullOrEmpty
+    }
+
+    It 'uses manifest consultation capability when no explicit consult target is supplied' {
+        $manifest = [PSCustomObject]@{
+            Panes = [ordered]@{
+                'worker-1' = [ordered]@{ role = 'Worker'; supports_consultation = $false }
+                'worker-2' = [ordered]@{ role = 'Worker'; supports_consultation = $true }
+            }
+        }
+
+        $target = Get-TeamPipelineConsultTarget -BuilderLabel 'worker-1' -ResearcherLabel '' -ReviewerLabel '' -Manifest $manifest
+
+        $target | Should -Be 'worker-2'
     }
 
     It 'inserts early and final consult stages into successful one-shot orchestration when a consult target exists' {

--- a/winsmux-core/scripts/team-pipeline.ps1
+++ b/winsmux-core/scripts/team-pipeline.ps1
@@ -119,6 +119,56 @@ function Get-TeamPipelinePaneInfo {
     return $Manifest.Panes[$Label]
 }
 
+function Get-TeamPipelinePaneCapabilityFlag {
+    param(
+        [AllowNull()]$Pane,
+        [Parameter(Mandatory = $true)][string]$Name
+    )
+
+    return [bool](Get-TeamPipelineValue -InputObject $Pane -Name $Name -Default $false)
+}
+
+function Get-TeamPipelineCapabilityTarget {
+    param(
+        [AllowNull()]$Manifest,
+        [Parameter(Mandatory = $true)][string]$CapabilityName,
+        [Parameter(Mandatory = $true)][string]$BuilderLabel
+    )
+
+    if ($null -eq $Manifest -or $null -eq $Manifest.Panes) {
+        return $null
+    }
+
+    foreach ($roleName in @('Reviewer', 'Researcher', 'Worker', 'Builder')) {
+        foreach ($label in @($Manifest.Panes.Keys)) {
+            $labelText = [string]$label
+            if ([string]::Equals($labelText, $BuilderLabel, [System.StringComparison]::OrdinalIgnoreCase)) {
+                continue
+            }
+
+            $pane = $Manifest.Panes[$label]
+            if (-not (Get-TeamPipelinePaneCapabilityFlag -Pane $pane -Name $CapabilityName)) {
+                continue
+            }
+
+            $role = [string](Get-TeamPipelineValue -InputObject $pane -Name 'role' -Default '')
+            if ($roleName -eq 'Builder') {
+                if ([string]::IsNullOrWhiteSpace($role) -or [string]::Equals($role, 'Builder', [System.StringComparison]::OrdinalIgnoreCase)) {
+                    return $labelText
+                }
+
+                continue
+            }
+
+            if ([string]::Equals($role, $roleName, [System.StringComparison]::OrdinalIgnoreCase)) {
+                return $labelText
+            }
+        }
+    }
+
+    return $null
+}
+
 function Resolve-TeamPipelineBuilderContext {
     param(
         [Parameter(Mandatory = $true)][string]$BuilderLabel,
@@ -172,6 +222,7 @@ function Get-TeamPipelineStageTargets {
         [Parameter(Mandatory = $true)][string]$BuilderLabel,
         [string]$ResearcherLabel,
         [string]$ReviewerLabel,
+        [AllowNull()]$Manifest,
         [switch]$SkipPlan,
         [switch]$SkipVerify
     )
@@ -189,9 +240,13 @@ function Get-TeamPipelineStageTargets {
     if (-not $SkipVerify) {
         if (-not [string]::IsNullOrWhiteSpace($ReviewerLabel)) {
             $verifyTarget = $ReviewerLabel
-        } elseif (-not [string]::IsNullOrWhiteSpace($ResearcherLabel)) {
+        } elseif ($null -ne $Manifest) {
+            $verifyTarget = Get-TeamPipelineCapabilityTarget -Manifest $Manifest -CapabilityName 'supports_verification' -BuilderLabel $BuilderLabel
+        }
+
+        if ([string]::IsNullOrWhiteSpace($verifyTarget) -and -not [string]::IsNullOrWhiteSpace($ResearcherLabel)) {
             $verifyTarget = $ResearcherLabel
-        } else {
+        } elseif ([string]::IsNullOrWhiteSpace($verifyTarget)) {
             $verifyTarget = $BuilderLabel
         }
     }
@@ -207,7 +262,8 @@ function Get-TeamPipelineConsultTarget {
     param(
         [Parameter(Mandatory = $true)][string]$BuilderLabel,
         [string]$ResearcherLabel,
-        [string]$ReviewerLabel
+        [string]$ReviewerLabel,
+        [AllowNull()]$Manifest
     )
 
     if (-not [string]::IsNullOrWhiteSpace($ReviewerLabel) -and $ReviewerLabel -ne $BuilderLabel) {
@@ -216,6 +272,11 @@ function Get-TeamPipelineConsultTarget {
 
     if (-not [string]::IsNullOrWhiteSpace($ResearcherLabel) -and $ResearcherLabel -ne $BuilderLabel) {
         return $ResearcherLabel
+    }
+
+    $capabilityTarget = Get-TeamPipelineCapabilityTarget -Manifest $Manifest -CapabilityName 'supports_consultation' -BuilderLabel $BuilderLabel
+    if (-not [string]::IsNullOrWhiteSpace($capabilityTarget)) {
+        return $capabilityTarget
     }
 
     return $null
@@ -1161,7 +1222,7 @@ function Invoke-TeamPipeline {
     $manifest = Read-TeamPipelineManifest -Path $resolvedManifestPath
     $builderContext = Resolve-TeamPipelineBuilderContext -BuilderLabel $Builder -Manifest $manifest -OverrideWorktreePath $BuilderWorktreePath
     $sessionName = Get-TeamPipelineSessionName -Manifest $manifest
-    $targets = Get-TeamPipelineStageTargets -BuilderLabel $Builder -ResearcherLabel $Researcher -ReviewerLabel $Reviewer -SkipPlan:$SkipPlan -SkipVerify:$SkipVerify
+    $targets = Get-TeamPipelineStageTargets -BuilderLabel $Builder -ResearcherLabel $Researcher -ReviewerLabel $Reviewer -Manifest $manifest -SkipPlan:$SkipPlan -SkipVerify:$SkipVerify
 
     $result = [ordered]@{
         Task                = $Task
@@ -1185,7 +1246,7 @@ function Invoke-TeamPipeline {
     }
 
     $planSummary = ''
-    $consultTarget = Get-TeamPipelineConsultTarget -BuilderLabel $Builder -ResearcherLabel $Researcher -ReviewerLabel $Reviewer
+    $consultTarget = Get-TeamPipelineConsultTarget -BuilderLabel $Builder -ResearcherLabel $Researcher -ReviewerLabel $Reviewer -Manifest $manifest
     if (-not [string]::IsNullOrWhiteSpace($targets.PlanTarget)) {
         $planPrompt = New-TeamPipelinePlanPrompt -Task $Task
         $planDispatchResult = Invoke-TeamPipelineGuardedSend -StageName 'PLAN' -Target $targets.PlanTarget -Prompt $planPrompt -ProjectDir $builderContext.ProjectDir -SessionName $sessionName -Role 'Researcher' -Task $Task

--- a/winsmux-core/scripts/team-pipeline.ps1
+++ b/winsmux-core/scripts/team-pipeline.ps1
@@ -125,7 +125,25 @@ function Get-TeamPipelinePaneCapabilityFlag {
         [Parameter(Mandatory = $true)][string]$Name
     )
 
-    return [bool](Get-TeamPipelineValue -InputObject $Pane -Name $Name -Default $false)
+    $value = Get-TeamPipelineValue -InputObject $Pane -Name $Name -Default $false
+    if ($value -is [bool]) {
+        return [bool]$value
+    }
+
+    $text = ([string]$value).Trim()
+    if ([string]::IsNullOrWhiteSpace($text)) {
+        return $false
+    }
+
+    if ([string]::Equals($text, 'true', [System.StringComparison]::OrdinalIgnoreCase)) {
+        return $true
+    }
+
+    if ([string]::Equals($text, 'false', [System.StringComparison]::OrdinalIgnoreCase)) {
+        return $false
+    }
+
+    return $false
 }
 
 function Get-TeamPipelineCapabilityTarget {


### PR DESCRIPTION
## Summary
- use manifest capability flags to pick verification targets when no reviewer is explicitly supplied
- use consultation capability flags when no reviewer or researcher is explicitly supplied
- keep explicit reviewer and researcher arguments as higher-precedence operator intent

## Validation
- `Invoke-Pester -Path .\tests\winsmux-bridge.Tests.ps1 -FullName '*team-pipeline helpers*' -Output Detailed`
- `Invoke-Pester -Path .\tests\winsmux-bridge.Tests.ps1 -Output Detailed`
- `git diff --check`
- `pwsh -NoProfile -File .\scripts\git-guard.ps1 -Mode full`
- `pwsh -NoProfile -File .\scripts\audit-public-surface.ps1`
- `pwsh -NoProfile -File .\scripts\gitleaks-history.ps1`
- `bash .githooks/pre-push`