### PR TITLE
TASK-314: Require structured verification targets

### DIFF
--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -1643,6 +1643,29 @@ NEXT_ACTION: rerun focused verification
         $targets.VerifyTarget | Should -BeNullOrEmpty
     }
 
+    It 'blocks one-shot orchestration when verification is required but no structured verifier exists' {
+        $manifest = [PSCustomObject]@{
+            Session = [PSCustomObject]@{
+                name        = 'winsmux-orchestra'
+                project_dir = 'C:\repo'
+            }
+            Panes = [ordered]@{
+                'builder-1' = [PSCustomObject]@{ pane_id = '%2'; role = 'Builder'; builder_worktree_path = 'C:\repo\.worktrees\builder-1'; supports_verification = 'true'; supports_structured_result = 'false' }
+                'researcher' = [PSCustomObject]@{ pane_id = '%3'; role = 'Researcher'; supports_verification = 'true'; supports_structured_result = 'false' }
+            }
+        }
+
+        Mock Read-TeamPipelineManifest { $manifest }
+        Mock Invoke-TeamPipelineBridge { throw 'pipeline should not dispatch without a structured verifier' }
+
+        $result = Invoke-TeamPipeline -Task 'Investigate cache drift' -Builder 'builder-1' -Researcher 'researcher'
+
+        $result.Success | Should -Be $false
+        $result.FinalStatus | Should -Be 'VERIFY_UNAVAILABLE'
+        $result.VerificationUnavailableReason | Should -Match 'structured results'
+        Should -Invoke Invoke-TeamPipelineBridge -Times 0 -Exactly
+    }
+
     It 'prefers reviewer then researcher for consult targets and skips builder-only runs' {
         (Get-TeamPipelineConsultTarget -BuilderLabel 'builder-1' -ResearcherLabel 'researcher' -ReviewerLabel 'reviewer') | Should -Be 'reviewer'
         (Get-TeamPipelineConsultTarget -BuilderLabel 'builder-1' -ResearcherLabel 'researcher' -ReviewerLabel '') | Should -Be 'researcher'

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -1630,6 +1630,19 @@ NEXT_ACTION: rerun focused verification
         $targets.VerifyTarget | Should -Be 'researcher'
     }
 
+    It 'does not fall back to unstructured verification targets from the manifest' {
+        $manifest = [PSCustomObject]@{
+            Panes = [ordered]@{
+                'worker-1' = [ordered]@{ role = 'Worker'; supports_verification = 'true'; supports_structured_result = 'false' }
+                'researcher' = [ordered]@{ role = 'Researcher'; supports_verification = 'true'; supports_structured_result = 'false' }
+            }
+        }
+
+        $targets = Get-TeamPipelineStageTargets -BuilderLabel 'worker-1' -ResearcherLabel 'researcher' -ReviewerLabel '' -Manifest $manifest
+
+        $targets.VerifyTarget | Should -BeNullOrEmpty
+    }
+
     It 'prefers reviewer then researcher for consult targets and skips builder-only runs' {
         (Get-TeamPipelineConsultTarget -BuilderLabel 'builder-1' -ResearcherLabel 'researcher' -ReviewerLabel 'reviewer') | Should -Be 'reviewer'
         (Get-TeamPipelineConsultTarget -BuilderLabel 'builder-1' -ResearcherLabel 'researcher' -ReviewerLabel '') | Should -Be 'researcher'

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -1592,9 +1592,9 @@ NEXT_ACTION: rerun focused verification
     It 'uses manifest capability flags when no explicit verification target is supplied' {
         $manifest = [PSCustomObject]@{
             Panes = [ordered]@{
-                'worker-1' = [ordered]@{ role = 'Worker'; supports_verification = 'false' }
-                'worker-2' = [ordered]@{ role = 'Worker'; supports_verification = 'true' }
-                'reviewer' = [ordered]@{ role = 'Reviewer'; supports_verification = 'true' }
+                'worker-1' = [ordered]@{ role = 'Worker'; supports_verification = 'false'; supports_structured_result = 'true' }
+                'worker-2' = [ordered]@{ role = 'Worker'; supports_verification = 'true'; supports_structured_result = 'true' }
+                'reviewer' = [ordered]@{ role = 'Reviewer'; supports_verification = 'true'; supports_structured_result = 'true' }
             }
         }
 
@@ -1603,11 +1603,25 @@ NEXT_ACTION: rerun focused verification
         $targets.VerifyTarget | Should -Be 'reviewer'
     }
 
+    It 'requires structured results for automatic verification targets' {
+        $manifest = [PSCustomObject]@{
+            Panes = [ordered]@{
+                'worker-1' = [ordered]@{ role = 'Worker'; supports_verification = 'false'; supports_structured_result = 'true' }
+                'reviewer' = [ordered]@{ role = 'Reviewer'; supports_verification = 'true'; supports_structured_result = 'false' }
+                'worker-2' = [ordered]@{ role = 'Worker'; supports_verification = 'true'; supports_structured_result = 'true' }
+            }
+        }
+
+        $targets = Get-TeamPipelineStageTargets -BuilderLabel 'worker-1' -ResearcherLabel '' -ReviewerLabel '' -Manifest $manifest
+
+        $targets.VerifyTarget | Should -Be 'worker-2'
+    }
+
     It 'falls back to configured researcher when no manifest verification capability is available' {
         $manifest = [PSCustomObject]@{
             Panes = [ordered]@{
-                'worker-1' = [ordered]@{ role = 'Worker'; supports_verification = 'false' }
-                'worker-2' = [ordered]@{ role = 'Worker'; supports_verification = 'false' }
+                'worker-1' = [ordered]@{ role = 'Worker'; supports_verification = 'false'; supports_structured_result = 'true' }
+                'worker-2' = [ordered]@{ role = 'Worker'; supports_verification = 'true'; supports_structured_result = 'false' }
             }
         }
 

--- a/winsmux-core/scripts/team-pipeline.ps1
+++ b/winsmux-core/scripts/team-pipeline.ps1
@@ -1312,10 +1312,17 @@ function Invoke-TeamPipeline {
         FinalConsult        = $null
         StuckConsults       = @()
         VerificationPackets = @()
+        VerificationUnavailableReason = ''
         SecurityVerdicts    = @()
         Attempts            = @()
         Success             = $false
         FinalStatus         = 'NOT_STARTED'
+    }
+
+    if (-not $SkipVerify -and [string]::IsNullOrWhiteSpace($targets.VerifyTarget)) {
+        $result.VerificationUnavailableReason = 'No verification target supports both verification and structured results.'
+        $result.FinalStatus = 'VERIFY_UNAVAILABLE'
+        return [PSCustomObject]$result
     }
 
     $planSummary = ''

--- a/winsmux-core/scripts/team-pipeline.ps1
+++ b/winsmux-core/scripts/team-pipeline.ps1
@@ -205,6 +205,35 @@ function Get-TeamPipelineCapabilityTarget {
     return $null
 }
 
+function Test-TeamPipelineTargetCapabilities {
+    param(
+        [AllowNull()]$Manifest,
+        [Parameter(Mandatory = $true)][string]$Label,
+        [string[]]$CapabilityNames = @()
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Label)) {
+        return $false
+    }
+
+    if ($null -eq $Manifest -or $null -eq $Manifest.Panes) {
+        return $true
+    }
+
+    $pane = Get-TeamPipelinePaneInfo -Manifest $Manifest -Label $Label
+    if ($null -eq $pane) {
+        return $true
+    }
+
+    foreach ($capabilityName in @($CapabilityNames | Where-Object { -not [string]::IsNullOrWhiteSpace([string]$_) })) {
+        if (-not (Get-TeamPipelinePaneCapabilityFlag -Pane $pane -Name $capabilityName)) {
+            return $false
+        }
+    }
+
+    return $true
+}
+
 function Resolve-TeamPipelineBuilderContext {
     param(
         [Parameter(Mandatory = $true)][string]$BuilderLabel,
@@ -273,16 +302,24 @@ function Get-TeamPipelineStageTargets {
     }
 
     $verifyTarget = $null
+    $requiredVerifyCapabilities = @('supports_verification', 'supports_structured_result')
     if (-not $SkipVerify) {
         if (-not [string]::IsNullOrWhiteSpace($ReviewerLabel)) {
             $verifyTarget = $ReviewerLabel
         } elseif ($null -ne $Manifest) {
-            $verifyTarget = Get-TeamPipelineCapabilityTarget -Manifest $Manifest -CapabilityNames @('supports_verification', 'supports_structured_result') -BuilderLabel $BuilderLabel
+            $verifyTarget = Get-TeamPipelineCapabilityTarget -Manifest $Manifest -CapabilityNames $requiredVerifyCapabilities -BuilderLabel $BuilderLabel
         }
 
-        if ([string]::IsNullOrWhiteSpace($verifyTarget) -and -not [string]::IsNullOrWhiteSpace($ResearcherLabel)) {
+        if (
+            [string]::IsNullOrWhiteSpace($verifyTarget) -and
+            -not [string]::IsNullOrWhiteSpace($ResearcherLabel) -and
+            (Test-TeamPipelineTargetCapabilities -Manifest $Manifest -Label $ResearcherLabel -CapabilityNames $requiredVerifyCapabilities)
+        ) {
             $verifyTarget = $ResearcherLabel
-        } elseif ([string]::IsNullOrWhiteSpace($verifyTarget)) {
+        } elseif (
+            [string]::IsNullOrWhiteSpace($verifyTarget) -and
+            (Test-TeamPipelineTargetCapabilities -Manifest $Manifest -Label $BuilderLabel -CapabilityNames $requiredVerifyCapabilities)
+        ) {
             $verifyTarget = $BuilderLabel
         }
     }

--- a/winsmux-core/scripts/team-pipeline.ps1
+++ b/winsmux-core/scripts/team-pipeline.ps1
@@ -149,11 +149,21 @@ function Get-TeamPipelinePaneCapabilityFlag {
 function Get-TeamPipelineCapabilityTarget {
     param(
         [AllowNull()]$Manifest,
-        [Parameter(Mandatory = $true)][string]$CapabilityName,
+        [string]$CapabilityName = '',
+        [string[]]$CapabilityNames = @(),
         [Parameter(Mandatory = $true)][string]$BuilderLabel
     )
 
     if ($null -eq $Manifest -or $null -eq $Manifest.Panes) {
+        return $null
+    }
+
+    $requiredCapabilities = @()
+    if (-not [string]::IsNullOrWhiteSpace($CapabilityName)) {
+        $requiredCapabilities += $CapabilityName
+    }
+    $requiredCapabilities += @($CapabilityNames | Where-Object { -not [string]::IsNullOrWhiteSpace([string]$_) })
+    if ($requiredCapabilities.Count -lt 1) {
         return $null
     }
 
@@ -165,7 +175,15 @@ function Get-TeamPipelineCapabilityTarget {
             }
 
             $pane = $Manifest.Panes[$label]
-            if (-not (Get-TeamPipelinePaneCapabilityFlag -Pane $pane -Name $CapabilityName)) {
+            $hasRequiredCapabilities = $true
+            foreach ($requiredCapability in $requiredCapabilities) {
+                if (-not (Get-TeamPipelinePaneCapabilityFlag -Pane $pane -Name $requiredCapability)) {
+                    $hasRequiredCapabilities = $false
+                    break
+                }
+            }
+
+            if (-not $hasRequiredCapabilities) {
                 continue
             }
 
@@ -259,7 +277,7 @@ function Get-TeamPipelineStageTargets {
         if (-not [string]::IsNullOrWhiteSpace($ReviewerLabel)) {
             $verifyTarget = $ReviewerLabel
         } elseif ($null -ne $Manifest) {
-            $verifyTarget = Get-TeamPipelineCapabilityTarget -Manifest $Manifest -CapabilityName 'supports_verification' -BuilderLabel $BuilderLabel
+            $verifyTarget = Get-TeamPipelineCapabilityTarget -Manifest $Manifest -CapabilityNames @('supports_verification', 'supports_structured_result') -BuilderLabel $BuilderLabel
         }
 
         if ([string]::IsNullOrWhiteSpace($verifyTarget) -and -not [string]::IsNullOrWhiteSpace($ResearcherLabel)) {


### PR DESCRIPTION
## Summary
- require automatic team-pipeline verification targets to support both verification and structured results
- keep explicit reviewer selection unchanged
- add regression coverage for skipping verification-capable panes that cannot return structured results

## Validation
- Invoke-Pester -Path .\tests\winsmux-bridge.Tests.ps1 -FullName '*team-pipeline helpers*' -Output Detailed
- Invoke-Pester -Path .\tests\winsmux-bridge.Tests.ps1 -Output Detailed
- git diff --check
- pwsh -NoProfile -File .\scripts\git-guard.ps1 -Mode full
- pwsh -NoProfile -File .\scripts\audit-public-surface.ps1
- pwsh -NoProfile -File .\scripts\gitleaks-history.ps1
- bash .githooks/pre-push