### PR TITLE
TASK-314: Block build targets without file edit support

### DIFF
--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -1666,6 +1666,59 @@ NEXT_ACTION: rerun focused verification
         Should -Invoke Invoke-TeamPipelineBridge -Times 0 -Exactly
     }
 
+    It 'blocks one-shot orchestration when the build target cannot edit files' {
+        $manifest = [PSCustomObject]@{
+            Session = [PSCustomObject]@{
+                name        = 'winsmux-orchestra'
+                project_dir = 'C:\repo'
+            }
+            Panes = [ordered]@{
+                'builder-1' = [PSCustomObject]@{ pane_id = '%2'; role = 'Builder'; builder_worktree_path = 'C:\repo\.worktrees\builder-1'; capability_adapter = 'codex'; capability_command = 'codex'; supports_file_edit = 'false'; supports_verification = 'true'; supports_structured_result = 'true' }
+                'reviewer'  = [PSCustomObject]@{ pane_id = '%3'; role = 'Reviewer'; supports_file_edit = 'false'; supports_verification = 'true'; supports_structured_result = 'true' }
+            }
+        }
+
+        Mock Read-TeamPipelineManifest { $manifest }
+        Mock Invoke-TeamPipelineBridge { throw 'pipeline should not dispatch to a build target without file edit support' }
+
+        $result = Invoke-TeamPipeline -Task 'Investigate cache drift' -Builder 'builder-1' -Reviewer 'reviewer' -SkipVerify
+
+        $result.Success | Should -Be $false
+        $result.FinalStatus | Should -Be 'EXEC_UNAVAILABLE'
+        $result.BuildUnavailableReason | Should -Match 'file edits'
+        Should -Invoke Invoke-TeamPipelineBridge -Times 0 -Exactly
+    }
+
+    It 'treats generated default file edit flags without capability identity as unknown' {
+        $manifest = [PSCustomObject]@{
+            Session = [PSCustomObject]@{
+                name        = 'winsmux-orchestra'
+                project_dir = 'C:\repo'
+            }
+            Panes = [ordered]@{
+                'builder-1' = [PSCustomObject]@{ pane_id = '%2'; role = 'Builder'; builder_worktree_path = 'C:\repo\.worktrees\builder-1'; supports_file_edit = 'false' }
+            }
+        }
+
+        $script:teamPipelineBridgeCalls = @()
+
+        Mock Read-TeamPipelineManifest { $manifest }
+        Mock Invoke-TeamPipelineBridge {
+            param([string[]]$Arguments, [switch]$AllowFailure)
+            $script:teamPipelineBridgeCalls += ,@($Arguments)
+            [PSCustomObject]@{ ExitCode = 0; Output = '' }
+        }
+        Mock Wait-TeamPipelineStage {
+            [PSCustomObject]@{ Stage = 'EXEC'; Target = 'builder-1'; Status = 'EXEC_DONE'; Summary = 'build summary'; Transcript = '' }
+        }
+
+        $result = Invoke-TeamPipeline -Task 'Investigate cache drift' -Builder 'builder-1' -SkipPlan -SkipVerify
+
+        $result.Success | Should -Be $true
+        $result.FinalStatus | Should -Be 'EXEC_DONE'
+        @($script:teamPipelineBridgeCalls | Where-Object { $_[0] -eq 'send' -and $_[1] -eq 'builder-1' }).Count | Should -Be 1
+    }
+
     It 'prefers reviewer then researcher for consult targets and skips builder-only runs' {
         (Get-TeamPipelineConsultTarget -BuilderLabel 'builder-1' -ResearcherLabel 'researcher' -ReviewerLabel 'reviewer') | Should -Be 'reviewer'
         (Get-TeamPipelineConsultTarget -BuilderLabel 'builder-1' -ResearcherLabel 'researcher' -ReviewerLabel '') | Should -Be 'researcher'

--- a/winsmux-core/scripts/team-pipeline.ps1
+++ b/winsmux-core/scripts/team-pipeline.ps1
@@ -50,6 +50,27 @@ function Get-TeamPipelineValue {
     return $Default
 }
 
+function Test-TeamPipelineValueExists {
+    param(
+        [AllowNull()]$InputObject,
+        [Parameter(Mandatory = $true)][string]$Name
+    )
+
+    if ($null -eq $InputObject) {
+        return $false
+    }
+
+    if ($InputObject -is [System.Collections.IDictionary]) {
+        return $InputObject.Contains($Name)
+    }
+
+    if ($null -ne $InputObject.PSObject -and $InputObject.PSObject.Properties.Name -contains $Name) {
+        return $true
+    }
+
+    return $false
+}
+
 function ConvertFrom-TeamPipelineYamlScalar {
     param([AllowNull()]$Value)
 
@@ -144,6 +165,34 @@ function Get-TeamPipelinePaneCapabilityFlag {
     }
 
     return $false
+}
+
+function Test-TeamPipelineBuildTargetAvailable {
+    param(
+        [AllowNull()]$Manifest,
+        [Parameter(Mandatory = $true)][string]$BuilderLabel
+    )
+
+    if ($null -eq $Manifest -or $null -eq $Manifest.Panes) {
+        return $true
+    }
+
+    $pane = Get-TeamPipelinePaneInfo -Manifest $Manifest -Label $BuilderLabel
+    if ($null -eq $pane) {
+        return $true
+    }
+
+    if (-not (Test-TeamPipelineValueExists -InputObject $pane -Name 'supports_file_edit')) {
+        return $true
+    }
+
+    $capabilityAdapter = [string](Get-TeamPipelineValue -InputObject $pane -Name 'capability_adapter' -Default '')
+    $capabilityCommand = [string](Get-TeamPipelineValue -InputObject $pane -Name 'capability_command' -Default '')
+    if ([string]::IsNullOrWhiteSpace($capabilityAdapter) -and [string]::IsNullOrWhiteSpace($capabilityCommand)) {
+        return $true
+    }
+
+    return (Get-TeamPipelinePaneCapabilityFlag -Pane $pane -Name 'supports_file_edit')
 }
 
 function Get-TeamPipelineCapabilityTarget {
@@ -1312,11 +1361,18 @@ function Invoke-TeamPipeline {
         FinalConsult        = $null
         StuckConsults       = @()
         VerificationPackets = @()
+        BuildUnavailableReason = ''
         VerificationUnavailableReason = ''
         SecurityVerdicts    = @()
         Attempts            = @()
         Success             = $false
         FinalStatus         = 'NOT_STARTED'
+    }
+
+    if (-not (Test-TeamPipelineBuildTargetAvailable -Manifest $manifest -BuilderLabel $Builder)) {
+        $result.BuildUnavailableReason = 'Build target does not support file edits.'
+        $result.FinalStatus = 'EXEC_UNAVAILABLE'
+        return [PSCustomObject]$result
     }
 
     if (-not $SkipVerify -and [string]::IsNullOrWhiteSpace($targets.VerifyTarget)) {


### PR DESCRIPTION
## Summary
- Block `team-pipeline` execution before dispatch when the selected build target explicitly declares `supports_file_edit: false` with provider capability identity.
- Keep older and registry-less manifests compatible by treating generated default file-edit flags without capability identity as unknown.
- Add regression coverage for both explicit non-editing build targets and generated unknown file-edit flags.

## Review response
- Addressed the `P1` review finding about registry-less generated manifests writing `supports_file_edit: false` by requiring capability identity before enforcing the false value.

## Validation
- `Invoke-Pester -Path .\tests\winsmux-bridge.Tests.ps1 -FullName '*team-pipeline helpers*' -Output Detailed` (`21/21`)
- `Invoke-Pester -Path .\tests\winsmux-bridge.Tests.ps1 -Output Detailed` (`297/297`)
- `git diff --check`
- `pwsh -NoProfile -File .\scripts\git-guard.ps1 -Mode full`
- `pwsh -NoProfile -File .\scripts\audit-public-surface.ps1`
- `pwsh -NoProfile -File .\scripts\gitleaks-history.ps1`
- `bash .githooks/pre-push`