### PR TITLE
TASK-314: Gate pane scaling by parallel capability

### DIFF
--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -5679,8 +5679,17 @@ panes:
     }
 
     It 'scales up when workload exceeds the threshold' {
+        $manifest = [PSCustomObject]@{
+            Panes = [ordered]@{
+                'builder-1' = [PSCustomObject]@{ pane_id = '%2'; role = 'Builder' }
+                'builder-2' = [PSCustomObject]@{ pane_id = '%3'; role = 'Builder' }
+                'builder-3' = [PSCustomObject]@{ pane_id = '%4'; role = 'Builder' }
+            }
+        }
         Mock Get-PaneWorkload {
             [PSCustomObject]@{
+                Manifest     = $manifest
+                ProjectDir   = $script:paneScalerTempRoot
                 BusyRatio    = 0.9
                 BusyPanes    = 3
                 TotalPanes   = 3
@@ -5704,6 +5713,60 @@ panes:
         $result.Label | Should -Be 'builder-4'
         Should -Invoke Add-OrchestraPane -Times 1 -Exactly
         Should -Invoke Remove-OrchestraPane -Times 0 -Exactly
+    }
+
+    It 'does not scale up when the next Builder provider cannot run in parallel' {
+        @"
+version: 1
+saved_at: 2026-04-05T10:00:00+09:00
+session:
+  name: winsmux-orchestra
+  project_dir: $script:paneScalerTempRoot
+panes:
+  builder-1:
+    pane_id: %2
+    role: Builder
+  builder-2:
+    pane_id: %3
+    role: Builder
+  builder-3:
+    pane_id: %4
+    role: Builder
+"@ | Set-Content -Path $script:paneScalerManifestPath -Encoding UTF8
+
+        @'
+{
+  "version": 1,
+  "providers": {
+    "codex": {
+      "adapter": "codex",
+      "command": "codex",
+      "prompt_transports": ["argv"],
+      "supports_parallel_runs": false,
+      "supports_interrupt": true,
+      "supports_structured_result": true,
+      "supports_file_edit": true,
+      "supports_subagents": true,
+      "supports_verification": true,
+      "supports_consultation": false
+    }
+  }
+}
+'@ | Set-Content -Path (Join-Path $script:paneScalerManifestDir 'provider-capabilities.json') -Encoding UTF8
+
+        Mock Get-PaneAgentStatus {
+            [PSCustomObject]@{ Status = 'busy'; ExitReason = '' }
+        }
+        Mock Add-OrchestraPane { throw 'should not add a Builder pane without parallel-run support' }
+        Mock Remove-OrchestraPane { throw 'should not remove' }
+
+        $result = Invoke-PaneScalingCheck -ManifestPath $script:paneScalerManifestPath -ScaleUpThreshold 0.8 -ScaleDownThreshold 0.0
+
+        $result.Action | Should -Be 'no_change'
+        $result.Reason | Should -Be 'parallel_runs_unsupported'
+        $result.Provider | Should -Be 'codex'
+        $result.SlotId | Should -Be 'builder-4'
+        Should -Invoke Add-OrchestraPane -Times 0 -Exactly
     }
 
     It 'scales down when workload is low and more than two builders exist' {

--- a/winsmux-core/scripts/pane-scaler.ps1
+++ b/winsmux-core/scripts/pane-scaler.ps1
@@ -225,6 +225,54 @@ function Get-PaneScalerBuilderIndex {
     return 0
 }
 
+function Get-PaneScalerNextBuilderLabel {
+    param([Parameter(Mandatory = $true)]$Manifest)
+
+    $nextIndex = 1
+    foreach ($builderPane in @(Get-PaneScalerBuilderPanes -Manifest $Manifest)) {
+        $nextIndex = [Math]::Max($nextIndex, (Get-PaneScalerBuilderIndex -Label $builderPane.Label) + 1)
+    }
+
+    return "builder-$nextIndex"
+}
+
+function Get-PaneScalerSlotAgentConfig {
+    param(
+        [Parameter(Mandatory = $true)][string]$SlotId,
+        [Parameter(Mandatory = $true)]$Settings,
+        [Parameter(Mandatory = $true)][string]$ProjectDir
+    )
+
+    if (Get-Command Get-SlotAgentConfig -ErrorAction SilentlyContinue) {
+        return Get-SlotAgentConfig -Role 'Builder' -SlotId $SlotId -Settings $Settings -RootPath $ProjectDir
+    }
+
+    try {
+        return Get-RoleAgentConfig -Role 'Builder' -Settings $Settings
+    } catch {
+        return [PSCustomObject]@{
+            Agent = [string]$Settings.agent
+            Model = [string]$Settings.model
+        }
+    }
+}
+
+function Test-PaneScalerParallelRunsAvailable {
+    param([AllowNull()]$SlotAgentConfig)
+
+    if ($null -eq $SlotAgentConfig) {
+        return $true
+    }
+
+    $capabilityAdapter = [string](Get-MonitorPropertyValue -InputObject $SlotAgentConfig -Name 'CapabilityAdapter' -Default '')
+    $capabilityCommand = [string](Get-MonitorPropertyValue -InputObject $SlotAgentConfig -Name 'CapabilityCommand' -Default '')
+    if ([string]::IsNullOrWhiteSpace($capabilityAdapter) -and [string]::IsNullOrWhiteSpace($capabilityCommand)) {
+        return $true
+    }
+
+    return [bool](Get-MonitorPropertyValue -InputObject $SlotAgentConfig -Name 'SupportsParallelRuns' -Default $false)
+}
+
 function New-PaneScalerBuilderWorktree {
     param(
         [Parameter(Mandatory = $true)][string]$ProjectDir,
@@ -372,15 +420,18 @@ function Add-OrchestraPane {
         throw 'Cannot add a Builder pane because no existing Builder pane was found.'
     }
 
-    $nextIndex = 1
-    foreach ($builderPane in $builderPanes) {
-        $nextIndex = [Math]::Max($nextIndex, (Get-PaneScalerBuilderIndex -Label $builderPane.Label) + 1)
-    }
+    $newLabel = Get-PaneScalerNextBuilderLabel -Manifest $manifest
+    $nextIndex = Get-PaneScalerBuilderIndex -Label $newLabel
 
     $seedPane = $builderPanes | Sort-Object { Get-PaneScalerBuilderIndex -Label $_.Label } | Select-Object -Last 1
     $seedPaneId = [string](Get-MonitorPropertyValue -InputObject $seedPane.Pane -Name 'pane_id' -Default '')
     if ([string]::IsNullOrWhiteSpace($seedPaneId)) {
         throw 'Cannot add a Builder pane because the seed pane has no pane_id.'
+    }
+
+    $roleAgentConfig = Get-PaneScalerSlotAgentConfig -SlotId $newLabel -Settings $Settings -ProjectDir $projectDir
+    if (-not (Test-PaneScalerParallelRunsAvailable -SlotAgentConfig $roleAgentConfig)) {
+        throw "Provider '$([string]$roleAgentConfig.Agent)' does not support parallel Builder panes."
     }
 
     $worktree = $null
@@ -393,22 +444,7 @@ function Add-OrchestraPane {
             throw 'winsmux split-window did not return a pane id.'
         }
 
-        $newLabel = "builder-$nextIndex"
         Invoke-MonitorWinsmux -Arguments @('select-pane', '-t', $newPaneId, '-T', $newLabel) | Out-Null
-
-        $roleAgentConfig = $null
-        if (Get-Command Get-SlotAgentConfig -ErrorAction SilentlyContinue) {
-            $roleAgentConfig = Get-SlotAgentConfig -Role 'Builder' -SlotId $newLabel -Settings $Settings -RootPath $projectDir
-        } else {
-            try {
-                $roleAgentConfig = Get-RoleAgentConfig -Role 'Builder' -Settings $Settings
-            } catch {
-                $roleAgentConfig = [PSCustomObject]@{
-                    Agent = [string]$Settings.agent
-                    Model = [string]$Settings.model
-                }
-            }
-        }
 
         Wait-MonitorPaneShellReady -PaneId $newPaneId
         Send-MonitorBridgeCommand -PaneId $newPaneId -Text (Get-PaneScalerLaunchCommand -Agent ([string]$roleAgentConfig.Agent) -Model ([string]$roleAgentConfig.Model) -ProjectDir $worktree.WorktreePath -GitWorktreeDir $worktree.GitWorktreeDir -RootPath $projectDir)
@@ -535,6 +571,24 @@ function Invoke-PaneScalingCheck {
     }
 
     if ($workload.BusyRatio -gt $ScaleUpThreshold) {
+        $resolvedSettings = $Settings
+        if ($null -eq $resolvedSettings) {
+            $resolvedSettings = Get-BridgeSettings -RootPath $workload.ProjectDir
+        }
+
+        $newLabel = Get-PaneScalerNextBuilderLabel -Manifest $workload.Manifest
+        $slotAgentConfig = Get-PaneScalerSlotAgentConfig -SlotId $newLabel -Settings $resolvedSettings -ProjectDir $workload.ProjectDir
+        if (-not (Test-PaneScalerParallelRunsAvailable -SlotAgentConfig $slotAgentConfig)) {
+            return [PSCustomObject]@{
+                Action   = 'no_change'
+                Reason   = 'parallel_runs_unsupported'
+                Provider = [string]$slotAgentConfig.Agent
+                SlotId   = $newLabel
+                Workload = $workload
+                Changed  = $false
+            }
+        }
+
         $result = Add-OrchestraPane -ManifestPath $ManifestPath -Settings $Settings
         $result | Add-Member -MemberType NoteProperty -Name Workload -Value $workload -Force
         return $result


### PR DESCRIPTION
## Summary
- Gate pane scaler scale-up by provider `supports_parallel_runs`.
- Return `parallel_runs_unsupported` instead of adding a Builder pane when the next Builder provider is known not to support parallel runs.
- Preserve registry-less compatibility by allowing scale-up when capability identity is absent.

## Validation
- `Invoke-Pester -Path .\tests\winsmux-bridge.Tests.ps1 -FullName '*pane scaler helpers*' -Output Detailed` (`11/11`)
- `Invoke-Pester -Path .\tests\winsmux-bridge.Tests.ps1 -Output Detailed` (`298/298`)
- `git diff --check`
- `pwsh -NoProfile -File .\scripts\git-guard.ps1 -Mode full`
- `pwsh -NoProfile -File .\scripts\audit-public-surface.ps1`
- `pwsh -NoProfile -File .\scripts\gitleaks-history.ps1`
- `bash .githooks/pre-push`