### PR TITLE
TASK-314: Gate bootstrap interrupt by provider capability

### DIFF
--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -701,11 +701,52 @@ agent-slots:
         $config.CapabilityCommand | Should -Be 'codex'
         $config.SupportsParallelRuns | Should -Be $true
         $config.SupportsInterrupt | Should -Be $true
+        $config.SupportsInterruptDeclared | Should -Be $true
         $config.SupportsStructuredResult | Should -Be $true
         $config.SupportsFileEdit | Should -Be $true
         $config.SupportsSubagents | Should -Be $true
         $config.SupportsVerification | Should -Be $true
         $config.SupportsConsultation | Should -Be $false
+    }
+
+    It 'distinguishes a missing interrupt capability from an explicit false value' {
+        $registryPath = Get-BridgeProviderCapabilityRegistryPath -RootPath $script:settingsTempRoot
+        $registryDir = Split-Path -Parent $registryPath
+        New-Item -ItemType Directory -Path $registryDir -Force | Out-Null
+
+@'
+{
+  "version": 1,
+  "providers": {
+    "codex": {
+      "adapter": "codex",
+      "command": "codex",
+      "prompt_transports": ["argv", "file", "stdin"]
+    }
+  }
+}
+'@ | Set-Content -Path $registryPath -Encoding UTF8
+
+@'
+agent: codex
+model: gpt-5.4
+agent-slots:
+  - slot-id: worker-1
+    runtime-role: worker
+    agent: codex
+    model: gpt-5.4
+    prompt-transport: argv
+'@ | Set-Content -Path (Join-Path $script:settingsTempRoot '.winsmux.yaml') -Encoding UTF8
+
+        Mock Get-WinsmuxOption { param($Name, $Default) return $null }
+
+        $settings = Get-BridgeSettings
+        $config = Get-SlotAgentConfig -Role 'Worker' -SlotId 'worker-1' -Settings $settings -RootPath $script:settingsTempRoot
+
+        $config.CapabilityAdapter | Should -Be 'codex'
+        $config.CapabilityCommand | Should -Be 'codex'
+        $config.SupportsInterrupt | Should -Be $false
+        $config.SupportsInterruptDeclared | Should -Be $false
     }
 
     It 'rejects slot prompt transport values not supported by provider capabilities' {
@@ -5281,6 +5322,7 @@ Describe 'orchestra-start rollback helpers' {
         [string]$plan.environment.WINSMUX_ROLE | Should -Be 'Worker'
         [string]$plan.environment.WINSMUX_GOVERNANCE_MODE | Should -Be 'enhanced'
         [string]$plan.launch_command | Should -Be 'codex --help'
+        [bool]$plan.supports_interrupt | Should -Be $true
         [string]$plan.startup_token | Should -Be 'token-123'
         [string]$plan.ready_marker_path | Should -Match '[\\/]2-token-123\.ready\.json$'
         $bridgeCalls.Count | Should -Be 1
@@ -5288,6 +5330,84 @@ Describe 'orchestra-start rollback helpers' {
         $sentCommands.Count | Should -Be 1
         $sentCommands[0] | Should -Match 'orchestra-pane-bootstrap\.ps1'
         $sentCommands[0] | Should -Match '-PlanFile'
+    }
+
+    It 'does not send an interrupt key when the provider cannot interrupt' {
+        $sentCommands = [System.Collections.Generic.List[string]]::new()
+        $bridgeCalls = [System.Collections.Generic.List[object]]::new()
+        $cleanPtyEnv = [PSCustomObject]@{
+            RemoveCommand = ''
+            Environment   = [ordered]@{
+                WINSMUX_ROLE = 'Worker'
+            }
+        }
+
+        Mock Wait-PaneShellReady { }
+        Mock Invoke-Bridge {
+            $bridgeCalls.Add([ordered]@{
+                Arguments    = @($Arguments)
+                CaptureOutput = [bool]$CaptureOutput
+                AllowFailure  = [bool]$AllowFailure
+            }) | Out-Null
+
+            return [ordered]@{
+                ExitCode = 0
+                Output   = @()
+            }
+        } -ParameterFilter {
+            $Arguments[0] -eq 'keys'
+        }
+        Mock Send-OrchestraBridgeCommand {
+            $sentCommands.Add($Text) | Out-Null
+        }
+
+        $planPath = New-OrchestraPaneBootstrapPlan `
+            -ProjectDir $script:orchestraStartTempRoot `
+            -PaneId '%2' `
+            -Label 'worker-1' `
+            -Role 'Worker' `
+            -Agent 'example' `
+            -Model 'example-model' `
+            -StartupToken 'token-456' `
+            -LaunchDir 'C:\repo\.worktrees\builder-1' `
+            -CleanPtyEnv $cleanPtyEnv `
+            -LaunchCommand 'example-agent --help' `
+            -SupportsInterrupt $false
+
+        Start-OrchestraPaneBootstrap -PaneId '%2' -PlanPath $planPath
+
+        Should -Invoke Wait-PaneShellReady -Times 1 -Exactly -ParameterFilter {
+            $PaneId -eq '%2'
+        }
+        $plan = Get-Content -LiteralPath $planPath -Raw -Encoding UTF8 | ConvertFrom-Json -Depth 8
+        [bool]$plan.supports_interrupt | Should -Be $false
+        $bridgeCalls.Count | Should -Be 0
+        $sentCommands.Count | Should -Be 1
+        $sentCommands[0] | Should -Match 'orchestra-pane-bootstrap\.ps1'
+        $sentCommands[0] | Should -Match '-PlanFile'
+    }
+
+    It 'keeps bootstrap interrupts enabled when the capability flag is absent' {
+        $unknownInterrupt = [PSCustomObject]@{
+            CapabilityAdapter = 'example'
+            CapabilityCommand = 'example'
+            SupportsInterrupt = $false
+        }
+        $explicitNoInterrupt = [PSCustomObject]@{
+            CapabilityAdapter = 'example'
+            CapabilityCommand = 'example'
+            SupportsInterrupt = $false
+            SupportsInterruptDeclared = $true
+        }
+        $legacyConfig = [PSCustomObject]@{
+            Agent = 'example'
+            Model = 'example-model'
+            SupportsInterrupt = $false
+        }
+
+        Test-OrchestraProviderInterruptAvailable -SlotAgentConfig $unknownInterrupt | Should -Be $true
+        Test-OrchestraProviderInterruptAvailable -SlotAgentConfig $explicitNoInterrupt | Should -Be $false
+        Test-OrchestraProviderInterruptAvailable -SlotAgentConfig $legacyConfig | Should -Be $true
     }
 }
 

--- a/winsmux-core/scripts/orchestra-start.ps1
+++ b/winsmux-core/scripts/orchestra-start.ps1
@@ -667,7 +667,8 @@ function New-OrchestraPaneBootstrapPlan {
         [Parameter(Mandatory = $true)][string]$StartupToken,
         [Parameter(Mandatory = $true)][string]$LaunchDir,
         [Parameter(Mandatory = $true)]$CleanPtyEnv,
-        [Parameter(Mandatory = $true)][string]$LaunchCommand
+        [Parameter(Mandatory = $true)][string]$LaunchCommand,
+        [bool]$SupportsInterrupt = $true
     )
 
     $bootstrapDir = Join-Path (Join-Path $ProjectDir '.winsmux') 'orchestra-bootstrap'
@@ -691,6 +692,7 @@ function New-OrchestraPaneBootstrapPlan {
         startup_token  = $StartupToken
         launch_dir     = $LaunchDir
         launch_command = $LaunchCommand
+        supports_interrupt = $SupportsInterrupt
         ready_marker_path = $readyMarkerPath
         environment    = $CleanPtyEnv.Environment
     }
@@ -707,11 +709,66 @@ function Start-OrchestraPaneBootstrap {
     )
 
     $bootstrapScriptPath = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot 'orchestra-pane-bootstrap.ps1'))
+    $supportsInterrupt = $true
+    try {
+        $plan = Get-Content -LiteralPath $PlanPath -Raw -Encoding UTF8 | ConvertFrom-Json
+        if ($plan.PSObject.Properties.Name -contains 'supports_interrupt') {
+            $supportsInterrupt = [bool]$plan.supports_interrupt
+        }
+    } catch {
+        $supportsInterrupt = $true
+    }
+
     Wait-PaneShellReady -PaneId $PaneId
-    Invoke-Bridge -Arguments @('keys', $PaneId, 'C-c') -AllowFailure | Out-Null
-    Start-Sleep -Milliseconds 200
+    if ($supportsInterrupt) {
+        Invoke-Bridge -Arguments @('keys', $PaneId, 'C-c') -AllowFailure | Out-Null
+        Start-Sleep -Milliseconds 200
+    }
     Send-OrchestraBridgeCommand -Target $PaneId -Text ("pwsh -NoProfile -File {0} -PlanFile {1}" -f (ConvertTo-PowerShellLiteral -Value $bootstrapScriptPath), (ConvertTo-PowerShellLiteral -Value $PlanPath))
     Start-Sleep -Milliseconds 500
+}
+
+function Get-OrchestraObjectPropertyValue {
+    param(
+        [AllowNull()]$InputObject,
+        [Parameter(Mandatory = $true)][string]$Name,
+        $Default = $null
+    )
+
+    if ($null -eq $InputObject) {
+        return $Default
+    }
+
+    if ($InputObject -is [System.Collections.IDictionary] -and $InputObject.Contains($Name)) {
+        return $InputObject[$Name]
+    }
+
+    if ($null -ne $InputObject.PSObject -and $InputObject.PSObject.Properties.Name -contains $Name) {
+        return $InputObject.PSObject.Properties[$Name].Value
+    }
+
+    return $Default
+}
+
+function Test-OrchestraProviderInterruptAvailable {
+    param([AllowNull()]$SlotAgentConfig)
+
+    if ($null -eq $SlotAgentConfig) {
+        return $true
+    }
+
+    $capabilityAdapter = [string](Get-OrchestraObjectPropertyValue -InputObject $SlotAgentConfig -Name 'CapabilityAdapter' -Default '')
+    $capabilityCommand = [string](Get-OrchestraObjectPropertyValue -InputObject $SlotAgentConfig -Name 'CapabilityCommand' -Default '')
+    if ([string]::IsNullOrWhiteSpace($capabilityAdapter) -and [string]::IsNullOrWhiteSpace($capabilityCommand)) {
+        return $true
+    }
+
+    $interruptDeclared = [bool](Get-OrchestraObjectPropertyValue -InputObject $SlotAgentConfig -Name 'SupportsInterruptDeclared' -Default $false)
+    if (-not $interruptDeclared) {
+        return $true
+    }
+
+    return [bool](Get-OrchestraObjectPropertyValue -InputObject $SlotAgentConfig -Name 'SupportsInterrupt' -Default $false)
 }
 
 function Get-OrchestraPaneBootstrapMarkerPath {
@@ -2002,6 +2059,7 @@ if ($MyInvocation.InvocationName -ne '.') {
         $slotAgentConfig = Get-SlotAgentConfig -Role $canonicalRole -SlotId $label -Settings $settings -RootPath $projectDir
         $execMode = ([string]$slotAgentConfig.Agent).Trim().ToLowerInvariant() -eq 'codex'
         $launchCommand = Get-AgentLaunchCommand -Agent $slotAgentConfig.Agent -Model $slotAgentConfig.Model -ProjectDir $launchDir -GitWorktreeDir $launchGitWorktreeDir -RootPath $projectDir -ExecMode $false
+        $supportsInterrupt = Test-OrchestraProviderInterruptAvailable -SlotAgentConfig $slotAgentConfig
 
         Invoke-Bridge -Arguments @('name', $paneId, $label)
         try {
@@ -2026,7 +2084,8 @@ if ($MyInvocation.InvocationName -ne '.') {
                     -StartupToken $startupToken `
                     -LaunchDir $launchDir `
                     -CleanPtyEnv $cleanPtyEnv `
-                    -LaunchCommand $launchCommand
+                    -LaunchCommand $launchCommand `
+                    -SupportsInterrupt $supportsInterrupt
                 Start-OrchestraPaneBootstrap -PaneId $paneId -PlanPath $bootstrapPlanPath
                 # TASK-231: verify pane exists after respawn
                 try {

--- a/winsmux-core/scripts/settings.ps1
+++ b/winsmux-core/scripts/settings.ps1
@@ -828,6 +828,23 @@ function Get-BridgeProviderCapabilityBoolean {
     return [bool](Get-BridgeProviderCapabilityValue -Capability $Capability -Name $Name -Default $false)
 }
 
+function Test-BridgeProviderCapabilityField {
+    param(
+        [AllowNull()]$Capability,
+        [Parameter(Mandatory = $true)][string]$Name
+    )
+
+    if ($null -eq $Capability) {
+        return $false
+    }
+
+    if ($Capability -is [System.Collections.IDictionary]) {
+        return $Capability.Contains($Name)
+    }
+
+    return ($null -ne $Capability.PSObject -and $Capability.PSObject.Properties.Name -contains $Name)
+}
+
 function Assert-BridgeProviderCapabilityTransport {
     param(
         [Parameter(Mandatory = $true)][string]$ProviderId,
@@ -1612,6 +1629,7 @@ function Get-SlotAgentConfig {
         CapabilityCommand        = [string](Get-BridgeProviderCapabilityValue -Capability $providerCapability -Name 'command' -Default '')
         SupportsParallelRuns     = Get-BridgeProviderCapabilityBoolean -Capability $providerCapability -Name 'supports_parallel_runs'
         SupportsInterrupt        = Get-BridgeProviderCapabilityBoolean -Capability $providerCapability -Name 'supports_interrupt'
+        SupportsInterruptDeclared = Test-BridgeProviderCapabilityField -Capability $providerCapability -Name 'supports_interrupt'
         SupportsStructuredResult = Get-BridgeProviderCapabilityBoolean -Capability $providerCapability -Name 'supports_structured_result'
         SupportsFileEdit         = Get-BridgeProviderCapabilityBoolean -Capability $providerCapability -Name 'supports_file_edit'
         SupportsSubagents        = Get-BridgeProviderCapabilityBoolean -Capability $providerCapability -Name 'supports_subagents'


### PR DESCRIPTION
## Summary
- Persist `supports_interrupt` in the orchestra bootstrap plan.
- Skip the startup `C-c` when the provider is known not to support interruption.
- Preserve compatibility by defaulting capability-unknown plans to the existing interrupt behavior.

## Validation
- `Invoke-Pester -Path .\tests\winsmux-bridge.Tests.ps1 -FullName '*writes a pane bootstrap plan*' -Output Detailed` (`1/1`)
- `Invoke-Pester -Path .\tests\winsmux-bridge.Tests.ps1 -FullName '*does not send an interrupt key*' -Output Detailed` (`1/1`)
- `Invoke-Pester -Path .\tests\winsmux-bridge.Tests.ps1 -Output Detailed` (`299/299`)
- `git diff --check`
- `pwsh -NoProfile -File .\scripts\git-guard.ps1 -Mode full`
- `pwsh -NoProfile -File .\scripts\audit-public-surface.ps1`
- `pwsh -NoProfile -File .\scripts\gitleaks-history.ps1`
- `bash .githooks/pre-push`