### PR TITLE
TASK-314: Route agent launch helper via provider capabilities

### DIFF
--- a/tests/Integration.MultiAgent.Tests.ps1
+++ b/tests/Integration.MultiAgent.Tests.ps1
@@ -130,6 +130,41 @@ Describe 'agent launch helpers' {
         $command | Should -Be "codex -c model=gpt-5.4 --sandbox danger-full-access -C 'C:\repo path\builder-1' --add-dir 'C:\repo path\.git'"
     }
 
+    It 'uses provider capability command metadata for launch commands' {
+        $root = Join-Path ([System.IO.Path]::GetTempPath()) ('winsmux-agent-launch-tests-' + [guid]::NewGuid().ToString('N'))
+        try {
+            $registryDir = Join-Path $root '.winsmux'
+            New-Item -ItemType Directory -Path $registryDir -Force | Out-Null
+@'
+{
+  "version": 1,
+  "providers": {
+    "codex-nightly": {
+      "adapter": "codex",
+      "command": "C:\\Tools\\Codex Nightly\\codex.exe",
+      "prompt_transports": ["argv", "file", "stdin"],
+      "supports_parallel_runs": true,
+      "supports_interrupt": true,
+      "supports_structured_result": true,
+      "supports_file_edit": true,
+      "supports_subagents": true,
+      "supports_verification": true,
+      "supports_consultation": false
+    }
+  }
+}
+'@ | Set-Content -Path (Join-Path $registryDir 'provider-capabilities.json') -Encoding UTF8
+
+            $command = Get-AgentLaunchCommand -Agent 'codex-nightly' -Model 'gpt-5.4' -ProjectDir "C:\repo path\builder-1" -GitWorktreeDir "C:\repo path\.git" -RootPath $root
+
+            $command | Should -Be "& 'C:\Tools\Codex Nightly\codex.exe' -c model=gpt-5.4 --sandbox danger-full-access -C 'C:\repo path\builder-1' --add-dir 'C:\repo path\.git'"
+        } finally {
+            if (Test-Path -LiteralPath $root) {
+                Remove-Item -LiteralPath $root -Recurse -Force
+            }
+        }
+    }
+
     It 'returns a CLM workaround bootstrap for Codex worktree workers' {
         $builderPrompt = Get-AgentBootstrapPrompt -Agent 'codex' -Role 'Builder'
         $builderPrompt | Should -Match 'ConstrainedLanguageMode'

--- a/winsmux-core/scripts/agent-launch.ps1
+++ b/winsmux-core/scripts/agent-launch.ps1
@@ -1,31 +1,25 @@
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
 
-function ConvertTo-PowerShellLiteral {
-    param([Parameter(Mandatory = $true)][AllowEmptyString()][string]$Value)
-
-    return "'" + ($Value -replace "'", "''") + "'"
-}
+. (Join-Path $PSScriptRoot 'settings.ps1')
 
 function Get-AgentLaunchCommand {
     param(
         [Parameter(Mandatory = $true)][string]$Agent,
         [Parameter(Mandatory = $true)][string]$Model,
         [Parameter(Mandatory = $true)][string]$ProjectDir,
-        [Parameter(Mandatory = $true)][string]$GitWorktreeDir
+        [Parameter(Mandatory = $true)][string]$GitWorktreeDir,
+        [string]$RootPath,
+        [bool]$ExecMode = $false
     )
 
-    switch ($Agent.Trim().ToLowerInvariant()) {
-        'codex' {
-            return "codex -c model=$Model --sandbox danger-full-access -C $(ConvertTo-PowerShellLiteral -Value $ProjectDir) --add-dir $(ConvertTo-PowerShellLiteral -Value $GitWorktreeDir)"
-        }
-        'claude' {
-            return 'claude --permission-mode bypassPermissions'
-        }
-        default {
-            throw "Unsupported agent setting: $Agent"
-        }
-    }
+    return Get-BridgeProviderLaunchCommand `
+        -ProviderId $Agent `
+        -Model $Model `
+        -ProjectDir $ProjectDir `
+        -GitWorktreeDir $GitWorktreeDir `
+        -RootPath $RootPath `
+        -ExecMode $ExecMode
 }
 
 function Get-AgentBootstrapPrompt {


### PR DESCRIPTION
## Summary
- route the standalone agent launch helper through the shared provider capability launch command builder
- keep the existing Codex launch command behavior unchanged
- add integration coverage for provider capability adapter and command metadata

## Validation
- Invoke-Pester -Path .\\tests\\Integration.MultiAgent.Tests.ps1 -FullNameFilter '*agent launch helpers*' -Output Detailed
- Invoke-Pester -Path .\\tests\\Integration.MultiAgent.Tests.ps1 -Output Detailed
- Invoke-Pester -Path .\\tests\\winsmux-bridge.Tests.ps1 -Output Detailed
- git diff --check
- pwsh -NoProfile -File .\\scripts\\git-guard.ps1 -Mode full
- pwsh -NoProfile -File .\\scripts\\audit-public-surface.ps1
- pwsh -NoProfile -File .\\scripts\\gitleaks-history.ps1
- bash .githooks/pre-push
- codex exec review --base main --dangerously-bypass-approvals-and-sandbox