### PR TITLE
TASK-314: Remove launch command fallback branches

### DIFF
--- a/winsmux-core/scripts/pane-control.ps1
+++ b/winsmux-core/scripts/pane-control.ps1
@@ -225,12 +225,6 @@ function Get-PaneControlGitWorktreeDir {
     return $ProjectDir
 }
 
-function ConvertTo-PaneControlPowerShellLiteral {
-    param([Parameter(Mandatory = $true)][AllowEmptyString()][string]$Value)
-
-    return "'" + ($Value -replace "'", "''") + "'"
-}
-
 function Get-PaneControlLaunchCommand {
     param(
         [Parameter(Mandatory = $true)][string]$Agent,
@@ -240,26 +234,12 @@ function Get-PaneControlLaunchCommand {
         [string]$RootPath = ''
     )
 
-    if (Get-Command Get-BridgeProviderLaunchCommand -ErrorAction SilentlyContinue) {
-        return Get-BridgeProviderLaunchCommand `
-            -ProviderId $Agent `
-            -Model $Model `
-            -ProjectDir $ProjectDir `
-            -GitWorktreeDir $GitWorktreeDir `
-            -RootPath $RootPath
-    }
-
-    switch ($Agent.Trim().ToLowerInvariant()) {
-        'codex' {
-            return "codex -c model=$Model --sandbox danger-full-access -C $(ConvertTo-PaneControlPowerShellLiteral -Value $ProjectDir) --add-dir $(ConvertTo-PaneControlPowerShellLiteral -Value $GitWorktreeDir)"
-        }
-        'claude' {
-            return 'claude --permission-mode bypassPermissions'
-        }
-        default {
-            throw "Unsupported agent setting: $Agent"
-        }
-    }
+    return Get-BridgeProviderLaunchCommand `
+        -ProviderId $Agent `
+        -Model $Model `
+        -ProjectDir $ProjectDir `
+        -GitWorktreeDir $GitWorktreeDir `
+        -RootPath $RootPath
 }
 
 function ConvertFrom-PaneControlManifestContent {

--- a/winsmux-core/scripts/pane-scaler.ps1
+++ b/winsmux-core/scripts/pane-scaler.ps1
@@ -158,12 +158,6 @@ function Get-PaneScalerGitWorktreeDir {
     return $ProjectDir
 }
 
-function ConvertTo-PaneScalerPowerShellLiteral {
-    param([Parameter(Mandatory = $true)][AllowEmptyString()][string]$Value)
-
-    return "'" + ($Value -replace "'", "''") + "'"
-}
-
 function Get-PaneScalerLaunchCommand {
     param(
         [Parameter(Mandatory = $true)][string]$Agent,
@@ -173,26 +167,12 @@ function Get-PaneScalerLaunchCommand {
         [string]$RootPath = ''
     )
 
-    if (Get-Command Get-BridgeProviderLaunchCommand -ErrorAction SilentlyContinue) {
-        return Get-BridgeProviderLaunchCommand `
-            -ProviderId $Agent `
-            -Model $Model `
-            -ProjectDir $ProjectDir `
-            -GitWorktreeDir $GitWorktreeDir `
-            -RootPath $RootPath
-    }
-
-    switch ($Agent.Trim().ToLowerInvariant()) {
-        'codex' {
-            return "codex -c model=$Model --sandbox danger-full-access -C $(ConvertTo-PaneScalerPowerShellLiteral -Value $ProjectDir) --add-dir $(ConvertTo-PaneScalerPowerShellLiteral -Value $GitWorktreeDir)"
-        }
-        'claude' {
-            return 'claude --permission-mode bypassPermissions'
-        }
-        default {
-            throw "Unsupported agent setting: $Agent"
-        }
-    }
+    return Get-BridgeProviderLaunchCommand `
+        -ProviderId $Agent `
+        -Model $Model `
+        -ProjectDir $ProjectDir `
+        -GitWorktreeDir $GitWorktreeDir `
+        -RootPath $RootPath
 }
 
 function Get-PaneScalerBuilderPanes {


### PR DESCRIPTION
## Summary
- remove unreachable provider-name fallback launch branches from pane restart and pane scaling helpers
- route both helpers directly through the shared provider capability launch command builder
- keep restart and scaling behavior covered by existing helper tests

## Validation
- Invoke-Pester -Path .\\tests\\winsmux-bridge.Tests.ps1 -FullNameFilter 'pane-control helpers*' -Output Detailed
- Invoke-Pester -Path .\\tests\\winsmux-bridge.Tests.ps1 -FullNameFilter 'pane scaler helpers*' -Output Detailed
- Invoke-Pester -Path .\\tests\\winsmux-bridge.Tests.ps1 -Output Detailed
- git diff --check
- pwsh -NoProfile -File .\\scripts\\git-guard.ps1 -Mode full
- pwsh -NoProfile -File .\\scripts\\audit-public-surface.ps1
- pwsh -NoProfile -File .\\scripts\\gitleaks-history.ps1
- bash .githooks/pre-push
- codex exec review --base main --dangerously-bypass-approvals-and-sandbox