### PR TITLE
TASK-314: Use capability adapter for startup readiness

### DIFF
--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -4998,6 +4998,24 @@ Describe 'orchestra-start session reuse contract' {
         $script:orchestraStartContent | Should -Match 'supports_verification\s*=\s*\[bool\]\$paneSummary\.SupportsVerification'
     }
 
+    It 'uses the capability adapter for startup readiness detection' {
+        $summary = [pscustomobject]@{
+            Agent = 'codex-nightly'
+            CapabilityAdapter = 'codex'
+        }
+
+        Get-OrchestraReadinessAgentName -PaneSummary $summary | Should -Be 'codex'
+
+        $legacySummary = [pscustomobject]@{
+            Agent = 'codex'
+            CapabilityAdapter = ''
+        }
+
+        Get-OrchestraReadinessAgentName -PaneSummary $legacySummary | Should -Be 'codex'
+        $script:orchestraStartContent | Should -Match '\$readinessAgent\s*=\s*Get-OrchestraReadinessAgentName -PaneSummary \$paneSummary'
+        $script:orchestraStartContent | Should -Match 'Wait-AgentReady -PaneId \$paneSummary\.PaneId -Agent \$readinessAgent'
+    }
+
     It 'routes partial bootstrap invalid state into the startup rollback path by throwing' {
         {
             Assert-OrchestraBootstrapVerification -PaneSummaries @(

--- a/winsmux-core/scripts/orchestra-start.ps1
+++ b/winsmux-core/scripts/orchestra-start.ps1
@@ -1281,6 +1281,17 @@ function Wait-AgentReady {
     throw "Timed out waiting for pane $PaneId to become ready. Last output:`n$(Get-TailPreview -Text $finalText)"
 }
 
+function Get-OrchestraReadinessAgentName {
+    param([Parameter(Mandatory = $true)]$PaneSummary)
+
+    $capabilityAdapter = [string](Get-OrchestraObjectPropertyValue -InputObject $PaneSummary -Name 'CapabilityAdapter' -Default '')
+    if (-not [string]::IsNullOrWhiteSpace($capabilityAdapter)) {
+        return $capabilityAdapter
+    }
+
+    return [string](Get-OrchestraObjectPropertyValue -InputObject $PaneSummary -Name 'Agent' -Default '')
+}
+
 function Start-AgentWatchdogJob {
     param(
         [Parameter(Mandatory = $true)][string]$WatchdogScriptPath,
@@ -2129,7 +2140,8 @@ if ($MyInvocation.InvocationName -ne '.') {
 
     foreach ($paneSummary in $paneSummaries) {
         try {
-            Wait-AgentReady -PaneId $paneSummary.PaneId -Agent $paneSummary.Agent -TimeoutSeconds 60
+            $readinessAgent = Get-OrchestraReadinessAgentName -PaneSummary $paneSummary
+            Wait-AgentReady -PaneId $paneSummary.PaneId -Agent $readinessAgent -TimeoutSeconds 60
         } catch {
             Write-Error "Agent readiness timeout for $($paneSummary.Label) [$($paneSummary.PaneId)]: $($_.Exception.Message)"
             exit 1


### PR DESCRIPTION
## Summary
- use provider capability adapter for startup readiness detection
- keep legacy agent-name readiness fallback when no adapter is present
- add coverage for custom provider ids that map to the Codex adapter

## Validation
- Invoke-Pester -Path .\tests\winsmux-bridge.Tests.ps1 -FullName '*uses the capability adapter for startup readiness detection*' -Output Detailed
- Invoke-Pester -Path .\tests\winsmux-bridge.Tests.ps1 -FullNameFilter 'orchestra-start session reuse contract*' -Output Detailed
- Invoke-Pester -Path .\tests\winsmux-bridge.Tests.ps1 -Output Detailed
- git diff --check
- pwsh -NoProfile -File .\scripts\git-guard.ps1 -Mode full
- pwsh -NoProfile -File .\scripts\audit-public-surface.ps1
- pwsh -NoProfile -File .\scripts\gitleaks-history.ps1
- bash .githooks/pre-push
- codex exec review --base main --dangerously-bypass-approvals-and-sandbox