### PR TITLE
TASK-314: Use capability adapter for monitor status

### DIFF
--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -2817,6 +2817,97 @@ panes:
         }
     }
 
+    It 'uses provider capability adapters during a monitor cycle' {
+        $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('winsmux-agent-monitor-tests-' + [guid]::NewGuid().ToString('N'))
+        $manifestDir = Join-Path $tempRoot '.winsmux'
+        $manifestPath = Join-Path $manifestDir 'manifest.yaml'
+
+        try {
+            New-Item -ItemType Directory -Path $manifestDir -Force | Out-Null
+@"
+version: 1
+session:
+  name: winsmux-orchestra
+  project_dir: $tempRoot
+panes:
+  worker-2:
+    pane_id: %4
+    role: Worker
+    launch_dir: $tempRoot
+"@ | Set-Content -Path $manifestPath -Encoding UTF8
+@'
+{
+  "version": 1,
+  "providers": {
+    "codex-nightly": {
+      "adapter": "codex",
+      "command": "codex-nightly",
+      "prompt_transports": ["argv"],
+      "supports_parallel_runs": true,
+      "supports_interrupt": true,
+      "supports_structured_result": true,
+      "supports_file_edit": true,
+      "supports_subagents": true,
+      "supports_verification": true,
+      "supports_consultation": false
+    }
+  }
+}
+'@ | Set-Content -Path (Join-Path $manifestDir 'provider-capabilities.json') -Encoding UTF8
+            Write-BridgeProviderRegistryEntry `
+                -RootPath $tempRoot `
+                -SlotId 'worker-2' `
+                -Agent 'codex-nightly' `
+                -Model 'gpt-5.4-nightly' `
+                -PromptTransport 'argv' `
+                -Reason 'operator requested provider hot-swap' | Out-Null
+
+            Mock Get-PaneAgentStatus {
+                [PSCustomObject]@{
+                    Status       = 'ready'
+                    PaneId       = '%4'
+                    SnapshotTail = 'gpt-5.4   42% context left'
+                    SnapshotHash = 'hash-worker'
+                    ExitReason   = ''
+                }
+            }
+            Mock Update-MonitorIdleAlertState {
+                [ordered]@{
+                    ShouldAlert = $false
+                    Message     = ''
+                }
+            }
+            Mock Test-BuilderStall { $false }
+
+            Invoke-AgentMonitorCycle -Settings ([ordered]@{
+                agent = 'codex'
+                model = 'gpt-5.4'
+                roles = [ordered]@{
+                    worker = [ordered]@{
+                        agent = 'codex'
+                        model = 'gpt-5.4'
+                    }
+                }
+                agent_slots = @(
+                    [ordered]@{
+                        slot_id = 'worker-2'
+                        runtime_role = 'worker'
+                        agent = 'codex'
+                        model = 'gpt-5.4'
+                    }
+                )
+            }) -ManifestPath $manifestPath -SessionName 'winsmux-orchestra' | Out-Null
+
+            Should -Invoke Get-PaneAgentStatus -Times 1 -Exactly -ParameterFilter {
+                $PaneId -eq '%4' -and $Agent -eq 'codex' -and $Role -eq 'Worker'
+            }
+        } finally {
+            if (Test-Path $tempRoot) {
+                Remove-Item -Path $tempRoot -Recurse -Force
+            }
+        }
+    }
+
     It 'fails closed when the provider registry is malformed during a monitor cycle' {
         $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('winsmux-agent-monitor-tests-' + [guid]::NewGuid().ToString('N'))
         $manifestDir = Join-Path $tempRoot '.winsmux'

--- a/winsmux-core/scripts/agent-monitor.ps1
+++ b/winsmux-core/scripts/agent-monitor.ps1
@@ -1179,11 +1179,18 @@ function Invoke-AgentMonitorCycle {
 
         $agentName = [string]$roleAgentConfig.Agent
         $modelName = [string]$roleAgentConfig.Model
+        $statusAgentName = [string](Get-MonitorPropertyValue -InputObject $roleAgentConfig -Name 'CapabilityAdapter' -Default '')
+        if ([string]::IsNullOrWhiteSpace($statusAgentName)) {
+            $statusAgentName = [string](Get-MonitorPropertyValue -InputObject $pane -Name 'capability_adapter' -Default '')
+        }
+        if ([string]::IsNullOrWhiteSpace($statusAgentName)) {
+            $statusAgentName = $agentName
+        }
         $launchDirFromManifest = [string](Get-MonitorPropertyValue -InputObject $pane -Name 'launch_dir' -Default '')
         $builderWorktreePath = [string](Get-MonitorPropertyValue -InputObject $pane -Name 'builder_worktree_path' -Default '')
 
         $checkedCount++
-        $status = Get-PaneAgentStatus -PaneId $paneId -Agent $agentName -Role $role -ExecMode $paneExecMode -HungThreshold $IdleThreshold
+        $status = Get-PaneAgentStatus -PaneId $paneId -Agent $statusAgentName -Role $role -ExecMode $paneExecMode -HungThreshold $IdleThreshold
         $statusName = [string](Get-MonitorPropertyValue -InputObject $status -Name 'Status' -Default '')
 
         # TASK-240: override empty with bootstrap_invalid if manifest says so
@@ -1291,7 +1298,7 @@ function Invoke-AgentMonitorCycle {
         }
 
         $contextRemainingPercent = Get-MonitorContextRemainingPercent -Text $statusSnapshotTail
-        if ($agentName -eq 'codex' -and $statusName -eq 'ready' -and $null -ne $contextRemainingPercent) {
+        if ($statusAgentName -eq 'codex' -and $statusName -eq 'ready' -and $null -ne $contextRemainingPercent) {
             $result['ContextRemainingPercent'] = $contextRemainingPercent
             if ($contextRemainingPercent -le $ContextResetThresholdPercent) {
                 try {


### PR DESCRIPTION
## Summary
- use provider capability adapters for agent monitor status detection
- keep resolved provider ids for event data and respawn commands
- add coverage for custom provider ids that map to the Codex adapter during monitor cycles

## Validation
- Invoke-Pester -Path .\tests\winsmux-bridge.Tests.ps1 -FullNameFilter 'agent-monitor helpers*' -Output Detailed
- Invoke-Pester -Path .\tests\winsmux-bridge.Tests.ps1 -Output Detailed
- git diff --check
- pwsh -NoProfile -File .\scripts\git-guard.ps1 -Mode full
- pwsh -NoProfile -File .\scripts\audit-public-surface.ps1
- pwsh -NoProfile -File .\scripts\gitleaks-history.ps1
- bash .githooks/pre-push
- codex exec review --base main --dangerously-bypass-approvals-and-sandbox