### PR TITLE
TASK-314: Use capability adapter for pane status

### DIFF
--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -6098,6 +6098,35 @@ Esc to interrupt
 "@) | Should -Be 'busy'
     }
 
+    It 'uses manifest capability adapters when classifying pane captures' {
+        $manifestPath = Join-Path (Join-Path $script:paneStatusTempRoot '.winsmux') 'manifest.yaml'
+@'
+version: 1
+session:
+  name: winsmux-orchestra
+  project_dir: C:\repo
+panes:
+  reviewer:
+    pane_id: %4
+    role: Reviewer
+    capability_adapter: claude
+'@ | Set-Content -Path $manifestPath -Encoding UTF8
+
+        $records = Get-PaneStatusRecords -ProjectDir $script:paneStatusTempRoot -SnapshotProvider {
+            param($PaneId)
+
+            if ($PaneId -eq '%4') {
+                return 'Welcome to Claude Code!'
+            }
+
+            throw "unexpected pane id: $PaneId"
+        }
+
+        $records.Count | Should -Be 1
+        $records[0].Label | Should -Be 'reviewer'
+        $records[0].State | Should -Be 'idle'
+    }
+
     It 'builds status rows from manifest panes and capture snapshots' {
         $records = Get-PaneStatusRecords -ProjectDir $script:paneStatusTempRoot -SnapshotProvider {
             param($PaneId)

--- a/winsmux-core/scripts/pane-control.ps1
+++ b/winsmux-core/scripts/pane-control.ps1
@@ -359,6 +359,7 @@ function Get-PaneControlManifestEntries {
             ReviewRequired      = ConvertFrom-PaneControlBoolean -Value (Get-PaneControlValue -InputObject $pane -Name 'review_required' -Default $false) -Default $false
             ProviderTarget      = [string](Get-PaneControlValue -InputObject $pane -Name 'provider_target' -Default '')
             AgentRole           = [string](Get-PaneControlValue -InputObject $pane -Name 'agent_role' -Default '')
+            CapabilityAdapter   = [string](Get-PaneControlValue -InputObject $pane -Name 'capability_adapter' -Default '')
             TimeoutPolicy       = [string](Get-PaneControlValue -InputObject $pane -Name 'timeout_policy' -Default '')
             HandoffRefs         = @(ConvertFrom-PaneControlStringArray -Value (Get-PaneControlValue -InputObject $pane -Name 'handoff_refs' -Default @()))
             SecurityPolicy      = ConvertFrom-PaneControlSecurityPolicy -Value (Get-PaneControlValue -InputObject $pane -Name 'security_policy' -Default $null)

--- a/winsmux-core/scripts/pane-status.ps1
+++ b/winsmux-core/scripts/pane-status.ps1
@@ -113,7 +113,10 @@ function Test-CodexSessionText {
 }
 
 function Get-PaneActualStateFromText {
-    param([AllowNull()][string]$Text)
+    param(
+        [AllowNull()][string]$Text,
+        [string]$Agent = 'codex'
+    )
 
     if ([string]::IsNullOrWhiteSpace($Text)) {
         return 'unknown'
@@ -124,15 +127,15 @@ function Get-PaneActualStateFromText {
         return 'pwsh'
     }
 
-    if (Test-CodexBusyIndicatorText -Text $Text) {
+    if ($Agent -eq 'codex' -and (Test-CodexBusyIndicatorText -Text $Text)) {
         return 'busy'
     }
 
-    if (Test-AgentPromptText -Text $Text -Agent 'codex') {
+    if (Test-AgentPromptText -Text $Text -Agent $Agent) {
         return 'idle'
     }
 
-    if (Test-CodexSessionText -Text $Text) {
+    if ($Agent -eq 'codex' -and (Test-CodexSessionText -Text $Text)) {
         return 'codex'
     }
 
@@ -216,6 +219,10 @@ function Get-PaneStatusRecords {
     foreach ($entry in $entries) {
         $snapshot = ''
         $state = 'unknown'
+        $stateAgent = [string]$entry.CapabilityAdapter
+        if ([string]::IsNullOrWhiteSpace($stateAgent)) {
+            $stateAgent = 'codex'
+        }
 
         if (-not [string]::IsNullOrWhiteSpace($entry.PaneId)) {
             try {
@@ -223,7 +230,7 @@ function Get-PaneStatusRecords {
                 if ($null -ne $captured) {
                     $snapshot = [string]$captured
                 }
-                $state = Get-PaneActualStateFromText -Text $snapshot
+                $state = Get-PaneActualStateFromText -Text $snapshot -Agent $stateAgent
             } catch {
                 $state = 'unknown'
             }


### PR DESCRIPTION
## Summary
- pass manifest capability adapters through pane-control entries
- classify pane-status captures with the capability adapter instead of assuming Codex
- add coverage for Claude adapter prompts in pane status records

## Validation
- Invoke-Pester -Path .\tests\winsmux-bridge.Tests.ps1 -FullNameFilter 'pane status helpers*' -Output Detailed
- Invoke-Pester -Path .\tests\winsmux-bridge.Tests.ps1 -Output Detailed
- git diff --check
- pwsh -NoProfile -File .\scripts\git-guard.ps1 -Mode full
- pwsh -NoProfile -File .\scripts\audit-public-surface.ps1
- pwsh -NoProfile -File .\scripts\gitleaks-history.ps1
- bash .githooks/pre-push
- codex exec review --base main --dangerously-bypass-approvals-and-sandbox