### PR TITLE
TASK-314: Use capability adapter for send exec

### DIFF
--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -676,6 +676,16 @@ function ConvertTo-DispatchPowerShellLiteral {
     return "'" + ($Value -replace "'", "''") + "'"
 }
 
+function ConvertTo-DispatchPowerShellCommandInvocation {
+    param([Parameter(Mandatory = $true)][AllowEmptyString()][string]$Value)
+
+    if ($Value -match '^[a-zA-Z0-9_.:/\\-]+$') {
+        return $Value
+    }
+
+    return '& ' + (ConvertTo-DispatchPowerShellLiteral -Value $Value)
+}
+
 function Resolve-SendTransportPlan {
     param(
         [Parameter(Mandatory = $true)][string]$Text,
@@ -686,7 +696,8 @@ function Resolve-SendTransportPlan {
         [bool]$ExecMode = $false,
         [string]$LaunchDir,
         [string]$GitWorktreeDir,
-        [string]$Model
+        [string]$Model,
+        [string]$ExecCommand = 'codex'
     )
 
     $resolvedPromptTransport = Resolve-SupportedPromptTransport -PromptTransport $PromptTransport
@@ -720,7 +731,10 @@ function Resolve-SendTransportPlan {
     }
     $outputPath = '{0}.last-message.txt' -f $promptPath
     $promptInstruction = 'Read the prompt file at {0} and follow its instructions' -f $promptPath
-    $execInstruction = 'codex exec --sandbox danger-full-access -C {0} --add-dir {1} -o {2} -m {3} {4}' -f `
+    $resolvedExecCommand = if ([string]::IsNullOrWhiteSpace($ExecCommand)) { 'codex' } else { $ExecCommand }
+    $execCommandInvocation = ConvertTo-DispatchPowerShellCommandInvocation -Value $resolvedExecCommand
+    $execInstruction = '{0} exec --sandbox danger-full-access -C {1} --add-dir {2} -o {3} -m {4} {5}' -f `
+        $execCommandInvocation, `
         (ConvertTo-DispatchPowerShellLiteral -Value $LaunchDir), `
         (ConvertTo-DispatchPowerShellLiteral -Value $GitWorktreeDir), `
         (ConvertTo-DispatchPowerShellLiteral -Value $outputPath), `
@@ -2519,6 +2533,32 @@ function Invoke-Message {
     Clear-ReadMark $paneId
 }
 
+function Get-SendConfigValue {
+    param(
+        [AllowNull()]$InputObject,
+        [Parameter(Mandatory = $true)][string]$Name,
+        $Default = ''
+    )
+
+    if ($null -eq $InputObject) {
+        return $Default
+    }
+
+    if ($InputObject -is [System.Collections.IDictionary]) {
+        if ($InputObject.Contains($Name)) {
+            return $InputObject[$Name]
+        }
+
+        return $Default
+    }
+
+    if ($null -ne $InputObject.PSObject -and ($InputObject.PSObject.Properties.Name -contains $Name)) {
+        return $InputObject.$Name
+    }
+
+    return $Default
+}
+
 function Invoke-Send {
     if (-not $Target) { Stop-WithError "usage: winsmux send <target> <text>" }
     if (-not $Rest -or $Rest.Count -eq 0) { Stop-WithError "usage: winsmux send <target> <text>" }
@@ -2597,7 +2637,11 @@ function Invoke-Send {
                     }
                 }
 
-                $execMode = $execModeValue.Trim().ToLowerInvariant() -eq 'true' -and [string]$agentConfig.Agent -eq 'codex'
+                $capabilityAdapter = [string](Get-SendConfigValue -InputObject $agentConfig -Name 'CapabilityAdapter' -Default '')
+                if ([string]::IsNullOrWhiteSpace($capabilityAdapter)) {
+                    $capabilityAdapter = [string]$agentConfig.Agent
+                }
+                $execMode = $execModeValue.Trim().ToLowerInvariant() -eq 'true' -and $capabilityAdapter -eq 'codex'
             }
         } catch {
             if ($_.Exception.Message -match 'Provider capability') {
@@ -2664,7 +2708,8 @@ function Invoke-Send {
         -ExecMode:$execMode `
         -LaunchDir $contextLaunchDir `
         -GitWorktreeDir $contextGitWorktreeDir `
-        -Model ([string]$agentConfig.Model)
+        -Model ([string]$agentConfig.Model) `
+        -ExecCommand ([string](Get-SendConfigValue -InputObject $agentConfig -Name 'CapabilityCommand' -Default $agentConfig.Agent))
 
     if ($transportPlan['Mode'] -eq 'codex_exec_file') {
         Send-TextToPane -PaneId $paneId -CommandText ([string]$transportPlan['ExecInstruction'])

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -8892,6 +8892,8 @@ Describe 'winsmux send dispatch payload' {
     It 'resolves managed pane send settings through the project capability root' {
         $script:winsmuxCoreSendRawContent | Should -Match 'Get-SlotAgentConfig -Role \$context\.Role -SlotId \$context\.Label -RootPath \$projectDir'
         $script:winsmuxCoreSendRawContent | Should -Match 'Provider capability'
+        $script:winsmuxCoreSendRawContent | Should -Match 'CapabilityAdapter'
+        $script:winsmuxCoreSendRawContent | Should -Match 'CapabilityCommand'
     }
 
     It 'writes long text to a dispatch file and returns a prompt pointer for non-exec panes' {
@@ -8954,6 +8956,39 @@ Describe 'winsmux send dispatch payload' {
         $plan['PromptPath'] | Should -Not -BeNullOrEmpty
         (Get-Content -LiteralPath $plan['PromptPath'] -Raw -Encoding UTF8).TrimEnd("`r", "`n") | Should -BeExactly ('a' * 5000)
         $plan['ExecInstruction'] | Should -Match 'codex exec'
+    }
+
+    It 'uses the provider capability command for exec-mode send plans' {
+        $plan = Resolve-SendTransportPlan `
+            -Text 'Summarize status' `
+            -ProjectDir $script:sendTempRoot `
+            -LengthLimit 4000 `
+            -PromptTransport 'argv' `
+            -ExecMode:$true `
+            -LaunchDir 'C:\repo' `
+            -GitWorktreeDir 'C:\repo' `
+            -Model 'gpt-5.4-nightly' `
+            -ExecCommand 'codex-nightly'
+
+        $plan['Mode'] | Should -Be 'codex_exec_file'
+        $plan['ExecInstruction'] | Should -Match '^codex-nightly exec'
+        $plan['ExecInstruction'] | Should -Not -Match '^codex exec'
+    }
+
+    It 'quotes provider capability executable paths for exec-mode send plans' {
+        $plan = Resolve-SendTransportPlan `
+            -Text 'Summarize status' `
+            -ProjectDir $script:sendTempRoot `
+            -LengthLimit 4000 `
+            -PromptTransport 'argv' `
+            -ExecMode:$true `
+            -LaunchDir 'C:\repo' `
+            -GitWorktreeDir 'C:\repo' `
+            -Model 'gpt-5.4-nightly' `
+            -ExecCommand 'C:\Tools\Codex Nightly\codex.exe'
+
+        $plan['Mode'] | Should -Be 'codex_exec_file'
+        $plan['ExecInstruction'] | Should -Match "^& 'C:\\Tools\\Codex Nightly\\codex.exe' exec"
     }
 
     It 'normalizes task prompt slugs and writes a stable task prompt file when task_slug is supplied' {


### PR DESCRIPTION
## Summary
- use provider capability adapters when deciding whether managed send targets can use exec mode
- build exec-mode send commands from provider capability command metadata
- quote executable provider command paths so paths with spaces work in PowerShell
- keep exec-mode prompts file-backed while allowing provider aliases such as codex-nightly

## Validation
- Invoke-Pester -Path .\\tests\\winsmux-bridge.Tests.ps1 -FullNameFilter 'winsmux send dispatch payload*' -Output Detailed
- Invoke-Pester -Path .\\tests\\winsmux-bridge.Tests.ps1 -Output Detailed
- git diff --check
- pwsh -NoProfile -File .\\scripts\\git-guard.ps1 -Mode full
- pwsh -NoProfile -File .\\scripts\\audit-public-surface.ps1
- pwsh -NoProfile -File .\\scripts\\gitleaks-history.ps1
- bash .githooks/pre-push
- codex exec review --base main --dangerously-bypass-approvals-and-sandbox