### PR TITLE
TASK-314: Use capability adapter for respawn readiness

### DIFF
--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -2526,6 +2526,70 @@ Describe 'agent-monitor helpers' {
         }
     }
 
+    It 'uses provider capability adapters while waiting for respawn readiness' {
+        $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('winsmux-agent-monitor-tests-' + [guid]::NewGuid().ToString('N'))
+        $registryDir = Join-Path $tempRoot '.winsmux'
+
+        try {
+            New-Item -ItemType Directory -Path $registryDir -Force | Out-Null
+@'
+{
+  "version": 1,
+  "providers": {
+    "codex-nightly": {
+      "adapter": "codex",
+      "command": "codex-nightly",
+      "prompt_transports": ["argv", "file"],
+      "supports_parallel_runs": true,
+      "supports_interrupt": true,
+      "supports_structured_result": true,
+      "supports_file_edit": true,
+      "supports_subagents": true,
+      "supports_verification": true,
+      "supports_consultation": false
+    }
+  }
+}
+'@ | Set-Content -Path (Join-Path $registryDir 'provider-capabilities.json') -Encoding UTF8
+
+            Mock Invoke-MonitorWinsmux { } -ParameterFilter {
+                $Arguments[0] -eq 'respawn-pane'
+            }
+            Mock Wait-MonitorPaneShellReady { }
+            Mock Send-MonitorBridgeCommand { }
+            Mock Get-PaneAgentStatus {
+                [PSCustomObject]@{
+                    Status       = 'ready'
+                    PaneId       = '%2'
+                    SnapshotTail = ''
+                    ExitReason   = ''
+                }
+            }
+
+            $result = Invoke-AgentRespawn `
+                -PaneId '%2' `
+                -Agent 'codex-nightly' `
+                -Model 'gpt-5.4-nightly' `
+                -ProjectDir $tempRoot `
+                -GitWorktreeDir 'C:\repo\.git\worktrees\builder-1' `
+                -RootPath $tempRoot `
+                -ReadyTimeoutSeconds 5
+
+            $result.Success | Should -Be $true
+            Should -Invoke Send-MonitorBridgeCommand -Times 1 -Exactly -ParameterFilter {
+                $PaneId -eq '%2' -and
+                $Text -match '^codex-nightly -c model=gpt-5\.4-nightly'
+            }
+            Should -Invoke Get-PaneAgentStatus -Times 1 -Exactly -ParameterFilter {
+                $PaneId -eq '%2' -and $Agent -eq 'codex'
+            }
+        } finally {
+            if (Test-Path $tempRoot) {
+                Remove-Item -Path $tempRoot -Recurse -Force
+            }
+        }
+    }
+
     It 'updates the manifest pane label after a successful respawn' {
         $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('winsmux-agent-monitor-tests-' + [guid]::NewGuid().ToString('N'))
         $manifestDir = Join-Path $tempRoot '.winsmux'

--- a/winsmux-core/scripts/agent-monitor.ps1
+++ b/winsmux-core/scripts/agent-monitor.ps1
@@ -906,7 +906,14 @@ function Invoke-AgentRespawn {
         }
     }
 
+    $statusAgentName = $Agent
     try {
+        $providerCapability = Resolve-BridgeProviderCapability -ProviderId $Agent -RootPath $capabilityRootPath -RequireWhenRegistryPresent
+        $capabilityAdapter = [string](Get-BridgeProviderCapabilityValue -Capability $providerCapability -Name 'adapter' -Default '')
+        if (-not [string]::IsNullOrWhiteSpace($capabilityAdapter)) {
+            $statusAgentName = $capabilityAdapter
+        }
+
         $launchCommand = Get-BridgeProviderLaunchCommand `
             -ProviderId $Agent `
             -Model $Model `
@@ -935,6 +942,10 @@ function Invoke-AgentRespawn {
                 $paneRole = [string](Get-MonitorPropertyValue -InputObject $manifestPaneValue -Name 'role' -Default '')
                 $execModeValue = [string](Get-MonitorPropertyValue -InputObject $manifestPaneValue -Name 'exec_mode' -Default '')
                 $paneExecMode = $execModeValue.Trim().ToLowerInvariant() -eq 'true'
+                $manifestCapabilityAdapter = [string](Get-MonitorPropertyValue -InputObject $manifestPaneValue -Name 'capability_adapter' -Default '')
+                if (-not [string]::IsNullOrWhiteSpace($manifestCapabilityAdapter)) {
+                    $statusAgentName = $manifestCapabilityAdapter
+                }
                 break
             }
         } catch {
@@ -942,7 +953,7 @@ function Invoke-AgentRespawn {
     }
 
     if ($paneExecMode) {
-        $currentStatus = Get-PaneAgentStatus -PaneId $PaneId -Agent $Agent -Role $paneRole -ExecMode $true
+        $currentStatus = Get-PaneAgentStatus -PaneId $PaneId -Agent $statusAgentName -Role $paneRole -ExecMode $true
         if ($currentStatus.Status -eq 'waiting_for_dispatch') {
             return [ordered]@{
                 Success = $true
@@ -970,7 +981,7 @@ function Invoke-AgentRespawn {
     $deadline = (Get-Date).AddSeconds($ReadyTimeoutSeconds)
     while ((Get-Date) -lt $deadline) {
         Start-Sleep -Seconds 3
-        $status = Get-PaneAgentStatus -PaneId $PaneId -Agent $Agent -Role $paneRole -ExecMode $paneExecMode
+        $status = Get-PaneAgentStatus -PaneId $PaneId -Agent $statusAgentName -Role $paneRole -ExecMode $paneExecMode
         if ($status.Status -eq 'ready') {
             if (-not [string]::IsNullOrWhiteSpace($ManifestPath) -and (Test-Path -LiteralPath $ManifestPath -PathType Leaf)) {
                 try {


### PR DESCRIPTION
## Summary
- use provider capability adapters while waiting for monitor respawn readiness
- keep provider command routing on provider id while classifying prompts by adapter type
- add provider alias coverage for codex-nightly respawn readiness

## Validation
- Invoke-Pester -Path .\\tests\\winsmux-bridge.Tests.ps1 -FullNameFilter 'agent-monitor helpers*' -Output Detailed
- Invoke-Pester -Path .\\tests\\winsmux-bridge.Tests.ps1 -Output Detailed
- git diff --check
- pwsh -NoProfile -File .\\scripts\\git-guard.ps1 -Mode full
- pwsh -NoProfile -File .\\scripts\\audit-public-surface.ps1
- pwsh -NoProfile -File .\\scripts\\gitleaks-history.ps1
- bash .githooks/pre-push
- codex exec review --base main --dangerously-bypass-approvals-and-sandbox