### PR TITLE
TASK-314: Use capability adapter for restart readiness

### DIFF
--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -7377,6 +7377,29 @@ function Invoke-MailboxListen {
 }
 
 # --- Kill / Restart ---
+function Get-RestartReadinessAgentName {
+    param(
+        [Parameter(Mandatory = $true)]$Plan
+    )
+
+    $readinessAgent = ''
+    if ($Plan -is [System.Collections.IDictionary] -and $Plan.Contains('CapabilityAdapter')) {
+        $readinessAgent = [string]$Plan['CapabilityAdapter']
+    } elseif ($null -ne $Plan.PSObject -and ($Plan.PSObject.Properties.Name -contains 'CapabilityAdapter')) {
+        $readinessAgent = [string]$Plan.CapabilityAdapter
+    }
+
+    if ([string]::IsNullOrWhiteSpace($readinessAgent)) {
+        if ($Plan -is [System.Collections.IDictionary] -and $Plan.Contains('Agent')) {
+            $readinessAgent = [string]$Plan['Agent']
+        } else {
+            $readinessAgent = [string]$Plan.Agent
+        }
+    }
+
+    return $readinessAgent
+}
+
 function Invoke-Kill {
     if (-not $Target) { Stop-WithError "usage: winsmux kill <target>" }
     if ($Rest -and $Rest.Count -gt 0) { Stop-WithError "usage: winsmux kill <target>" }
@@ -7434,7 +7457,9 @@ function Invoke-RestartPane {
     Clear-ReadMark $PaneId
     Clear-Watermark $PaneId
 
-    if ($plan.Agent.Trim().ToLowerInvariant() -eq 'codex') {
+    $restartReadinessAgent = Get-RestartReadinessAgentName -Plan $plan
+
+    if ($restartReadinessAgent.Trim().ToLowerInvariant() -eq 'codex') {
         $deadline = (Get-Date).AddSeconds(60)
         while ((Get-Date) -lt $deadline) {
             if (Test-CodexReadyPrompt $PaneId) {

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -2112,6 +2112,57 @@ agent_slots:
         $plan.LaunchCommand | Should -Be "claude --model 'opus' --permission-mode bypassPermissions"
     }
 
+    It 'projects provider capability adapters into restart plans' {
+@"
+version: 1
+saved_at: '2026-04-07T00:00:00+09:00'
+session:
+  name: 'winsmux-orchestra'
+  project_dir: '${script:paneControlTempRoot}'
+  git_worktree_dir: '${script:paneControlTempRoot}\.git'
+panes:
+  - label: 'worker-1'
+    pane_id: '%2'
+    role: 'Worker'
+    exec_mode: false
+    launch_dir: '${script:paneControlTempRoot}'
+    task: null
+"@ | Set-Content -Path (Join-Path $script:paneControlManifestDir 'manifest.yaml') -Encoding UTF8
+@'
+{
+  "version": 1,
+  "providers": {
+    "codex-nightly": {
+      "adapter": "codex",
+      "command": "codex-nightly",
+      "prompt_transports": ["argv", "file"],
+      "supports_parallel_runs": true,
+      "supports_interrupt": true,
+      "supports_structured_result": true,
+      "supports_file_edit": true,
+      "supports_subagents": true,
+      "supports_verification": true,
+      "supports_consultation": false
+    }
+  }
+}
+'@ | Set-Content -Path (Join-Path $script:paneControlManifestDir 'provider-capabilities.json') -Encoding UTF8
+        Write-BridgeProviderRegistryEntry `
+            -RootPath $script:paneControlTempRoot `
+            -SlotId 'worker-1' `
+            -Agent 'codex-nightly' `
+            -Model 'gpt-5.4-nightly' `
+            -PromptTransport 'argv' `
+            -Reason 'operator requested provider hot-swap' | Out-Null
+        $settings = Get-BridgeSettings -RootPath $script:paneControlTempRoot
+
+        $plan = Get-PaneControlRestartPlan -ProjectDir $script:paneControlTempRoot -PaneId '%2' -Settings $settings
+
+        $plan.Agent | Should -Be 'codex-nightly'
+        $plan.CapabilityAdapter | Should -Be 'codex'
+        $plan.LaunchCommand | Should -Match '^codex-nightly -c model=gpt-5\.4-nightly'
+    }
+
     It 'includes slot-level prompt transport overrides in the restart plan' {
 @'
 version: 1
@@ -8960,6 +9011,15 @@ Describe 'winsmux send dispatch payload' {
         $script:winsmuxCoreSendRawContent | Should -Match 'CapabilityCommand'
     }
 
+    It 'resolves restart readiness through dictionary capability adapters' {
+        $plan = [ordered]@{
+            Agent = 'codex-nightly'
+            CapabilityAdapter = 'codex'
+        }
+
+        Get-RestartReadinessAgentName -Plan $plan | Should -Be 'codex'
+    }
+
     It 'writes long text to a dispatch file and returns a prompt pointer for non-exec panes' {
         $longText = 'a' * 4001
 
@@ -9543,6 +9603,7 @@ agent-slots:
         $script:winsmuxCoreRawContent | Should -Match 'Get-PaneControlManifestEntries -ProjectDir \$projectDir'
         $script:winsmuxCoreRawContent | Should -Match 'Confirm-Target \(\[string\]\$manifestEntry\[0\]\.PaneId\)'
         $script:winsmuxCoreRawContent | Should -Match 'Invoke-RestartPane -PaneId'
+        $script:winsmuxCoreRawContent | Should -Match '\$restartReadinessAgent\s*=\s*Get-RestartReadinessAgentName -Plan \$plan'
         $script:winsmuxCoreRawContent | Should -Match 'Remove-BridgeProviderRegistryEntry -RootPath \$projectDir -SlotId \$slotId'
         $script:winsmuxCoreRawContent | Should -Match 'clear_requested'
         $script:winsmuxCoreRawContent | Should -Match 'restart_requested'

--- a/winsmux-core/scripts/pane-control.ps1
+++ b/winsmux-core/scripts/pane-control.ps1
@@ -541,6 +541,7 @@ function Get-PaneControlRestartPlan {
         GitWorktreeDir = $context.GitWorktreeDir
         Agent          = [string]$agentConfig.Agent
         Model          = [string]$agentConfig.Model
+        CapabilityAdapter = [string]$agentConfig.CapabilityAdapter
         PromptTransport = [string]$agentConfig.PromptTransport
         Source         = [string]$agentConfig.Source
         LaunchCommand  = $launchCommand


### PR DESCRIPTION
## Summary
- include provider capability adapter metadata in restart plans
- use the adapter type when waiting for Codex readiness after winsmux restart
- add provider alias coverage for codex-nightly restart planning and dictionary-backed readiness lookup

## Validation
- Invoke-Pester -Path .\tests\winsmux-bridge.Tests.ps1 -FullNameFilter 'pane-control helpers*' -Output Detailed
- Invoke-Pester -Path .\tests\winsmux-bridge.Tests.ps1 -FullNameFilter 'winsmux provider-switch command*' -Output Detailed
- Invoke-Pester -Path .\tests\winsmux-bridge.Tests.ps1 -FullNameFilter 'winsmux send dispatch payload*' -Output Detailed
- Invoke-Pester -Path .\tests\winsmux-bridge.Tests.ps1 -Output Detailed
- git diff --check
- pwsh -NoProfile -File .\scripts\git-guard.ps1 -Mode full
- pwsh -NoProfile -File .\scripts\audit-public-surface.ps1
- pwsh -NoProfile -File .\scripts\gitleaks-history.ps1
- bash .githooks/pre-push
- codex exec review --base main --dangerously-bypass-approvals-and-sandbox