### PR TITLE
TASK-314: Use capability adapter for bootstrap prompts

### DIFF
--- a/tests/Integration.MultiAgent.Tests.ps1
+++ b/tests/Integration.MultiAgent.Tests.ps1
@@ -176,6 +176,55 @@ Describe 'agent launch helpers' {
         (Get-AgentBootstrapPrompt -Agent 'codex' -Role 'Reviewer') | Should -BeNullOrEmpty
         (Get-AgentBootstrapPrompt -Agent 'claude' -Role 'Builder') | Should -BeNullOrEmpty
     }
+
+    It 'uses provider capability adapters for Codex bootstrap prompts' {
+        $root = Join-Path ([System.IO.Path]::GetTempPath()) ('winsmux-agent-bootstrap-tests-' + [guid]::NewGuid().ToString('N'))
+        try {
+            $registryDir = Join-Path $root '.winsmux'
+            New-Item -ItemType Directory -Path $registryDir -Force | Out-Null
+@'
+{
+  "version": 1,
+  "providers": {
+    "codex-nightly": {
+      "adapter": "codex",
+      "command": "codex-nightly",
+      "prompt_transports": ["argv", "file", "stdin"],
+      "supports_parallel_runs": true,
+      "supports_interrupt": true,
+      "supports_structured_result": true,
+      "supports_file_edit": true,
+      "supports_subagents": true,
+      "supports_verification": true,
+      "supports_consultation": false
+    },
+    "claude-opus": {
+      "adapter": "claude",
+      "command": "claude",
+      "prompt_transports": ["argv"],
+      "supports_parallel_runs": false,
+      "supports_interrupt": true,
+      "supports_structured_result": false,
+      "supports_file_edit": true,
+      "supports_subagents": false,
+      "supports_verification": false,
+      "supports_consultation": true
+    }
+  }
+}
+'@ | Set-Content -Path (Join-Path $registryDir 'provider-capabilities.json') -Encoding UTF8
+
+            $prompt = Get-AgentBootstrapPrompt -Agent 'codex-nightly' -Role 'Builder' -RootPath $root
+            $prompt | Should -Match 'ConstrainedLanguageMode'
+            $prompt | Should -Match 'apply_patch'
+
+            Get-AgentBootstrapPrompt -Agent 'claude-opus' -Role 'Builder' -RootPath $root | Should -BeNullOrEmpty
+        } finally {
+            if (Test-Path -LiteralPath $root) {
+                Remove-Item -LiteralPath $root -Recurse -Force
+            }
+        }
+    }
 }
 
 Describe 'manifest round-trip' {

--- a/winsmux-core/scripts/agent-launch.ps1
+++ b/winsmux-core/scripts/agent-launch.ps1
@@ -25,10 +25,17 @@ function Get-AgentLaunchCommand {
 function Get-AgentBootstrapPrompt {
     param(
         [Parameter(Mandatory = $true)][string]$Agent,
-        [Parameter(Mandatory = $true)][string]$Role
+        [Parameter(Mandatory = $true)][string]$Role,
+        [string]$RootPath
     )
 
-    if ($Agent.Trim().ToLowerInvariant() -ne 'codex') {
+    $adapter = $Agent.Trim()
+    $capability = Resolve-BridgeProviderCapability -ProviderId $adapter -RootPath $RootPath -RequireWhenRegistryPresent
+    if ($null -ne $capability) {
+        $adapter = [string](Get-BridgeProviderCapabilityValue -Capability $capability -Name 'adapter' -Default $adapter)
+    }
+
+    if ($adapter.Trim().ToLowerInvariant() -ne 'codex') {
         return $null
     }
 


### PR DESCRIPTION
## Summary
- resolve standalone bootstrap prompts through provider capability adapters
- keep Codex Windows sandbox guidance for aliases such as codex-nightly
- add coverage for Codex-compatible and non-Codex provider aliases

## Validation
- Invoke-Pester -Path .\tests\Integration.MultiAgent.Tests.ps1 -FullNameFilter 'agent launch helpers*' -Output Detailed
- Invoke-Pester -Path .\tests\Integration.MultiAgent.Tests.ps1 -Output Detailed
- Invoke-Pester -Path .\tests\winsmux-bridge.Tests.ps1 -Output Detailed
- git diff --check
- pwsh -NoProfile -File .\scripts\git-guard.ps1 -Mode full
- pwsh -NoProfile -File .\scripts\audit-public-surface.ps1
- pwsh -NoProfile -File .\scripts\gitleaks-history.ps1
- bash .githooks/pre-push
- codex exec review --base main --dangerously-bypass-approvals-and-sandbox