### PR TITLE
TASK-314: Update init provider setup wording

### DIFF
--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -3149,7 +3149,7 @@ function Invoke-Init {
             '--force' { $force = $true }
             '--project-dir' {
                 if ($index + 1 -ge $remaining.Count) {
-                    Stop-WithError "usage: winsmux init [--json] [--project-dir <path>] [--force] [--agent <codex|claude>] [--model <name>] [--worker-count <count>]"
+                    Stop-WithError "usage: winsmux init [--json] [--project-dir <path>] [--force] [--agent <provider>] [--model <name>] [--worker-count <count>]"
                 }
 
                 $projectDir = $remaining[$index + 1]
@@ -3157,7 +3157,7 @@ function Invoke-Init {
             }
             '--agent' {
                 if ($index + 1 -ge $remaining.Count) {
-                    Stop-WithError "usage: winsmux init [--json] [--project-dir <path>] [--force] [--agent <codex|claude>] [--model <name>] [--worker-count <count>]"
+                    Stop-WithError "usage: winsmux init [--json] [--project-dir <path>] [--force] [--agent <provider>] [--model <name>] [--worker-count <count>]"
                 }
 
                 $agent = $remaining[$index + 1]
@@ -3165,7 +3165,7 @@ function Invoke-Init {
             }
             '--model' {
                 if ($index + 1 -ge $remaining.Count) {
-                    Stop-WithError "usage: winsmux init [--json] [--project-dir <path>] [--force] [--agent <codex|claude>] [--model <name>] [--worker-count <count>]"
+                    Stop-WithError "usage: winsmux init [--json] [--project-dir <path>] [--force] [--agent <provider>] [--model <name>] [--worker-count <count>]"
                 }
 
                 $model = $remaining[$index + 1]
@@ -3173,14 +3173,14 @@ function Invoke-Init {
             }
             '--worker-count' {
                 if ($index + 1 -ge $remaining.Count) {
-                    Stop-WithError "usage: winsmux init [--json] [--project-dir <path>] [--force] [--agent <codex|claude>] [--model <name>] [--worker-count <count>]"
+                    Stop-WithError "usage: winsmux init [--json] [--project-dir <path>] [--force] [--agent <provider>] [--model <name>] [--worker-count <count>]"
                 }
 
                 $workerCount = [int]$remaining[$index + 1]
                 $index++
             }
             default {
-                Stop-WithError "usage: winsmux init [--json] [--project-dir <path>] [--force] [--agent <codex|claude>] [--model <name>] [--worker-count <count>]"
+                Stop-WithError "usage: winsmux init [--json] [--project-dir <path>] [--force] [--agent <provider>] [--model <name>] [--worker-count <count>]"
             }
         }
     }
@@ -7197,7 +7197,7 @@ function Show-Usage {
 winsmux $VERSION - winsmux bridge for winsmux
 
 Commands:
-  init [--json] [--project-dir <path>] [--force] [--agent <codex|claude>] [--model <name>] [--worker-count <count>]  Create or refresh public first-run config
+  init [--json] [--project-dir <path>] [--force] [--agent <provider>] [--model <name>] [--worker-count <count>]  Create or refresh public first-run config
   launch [--json] [--project-dir <path>] [--skip-doctor]  Run public first-run checks and startup
   id                        Show current pane ID
   list                      List all panes

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -9187,7 +9187,7 @@ Describe 'winsmux public first-run commands' {
     }
 
     It 'documents init and launch in usage and dispatches them through the public first-run helper' {
-        $script:winsmuxCoreRawContent | Should -Match 'init \[--json\] \[--project-dir <path>\] \[--force\] \[--agent <codex\|claude>\] \[--model <name>\] \[--worker-count <count>\]\s+Create or refresh public first-run config'
+        $script:winsmuxCoreRawContent | Should -Match 'init \[--json\] \[--project-dir <path>\] \[--force\] \[--agent <provider>\] \[--model <name>\] \[--worker-count <count>\]\s+Create or refresh public first-run config'
         $script:winsmuxCoreRawContent | Should -Match 'launch \[--json\] \[--project-dir <path>\] \[--skip-doctor\]\s+Run public first-run checks and startup'
         $script:winsmuxCoreRawContent | Should -Match "'init'\s*\{"
         $script:winsmuxCoreRawContent | Should -Match "'launch'\s*\{"
@@ -9336,6 +9336,21 @@ Describe 'public first-run helper' {
         $settings.worker_count | Should -Be 6
         $settings.agent_slots.Count | Should -Be 6
         $settings.agent_slots[0].slot_id | Should -Be 'worker-1'
+    }
+
+    It 'stores custom provider names in managed slots on init' {
+        $result = Invoke-WinsmuxPublicInit -ProjectDir $script:publicFirstRunTempRoot -Agent 'codex-nightly' -Model 'gpt-5.4-code' -WorkerCount 2
+
+        $result.status | Should -Be 'initialized'
+        $result.slot_count | Should -Be 2
+
+        $settings = Get-BridgeSettings -RootPath $script:publicFirstRunTempRoot
+        $settings.agent | Should -Be 'codex-nightly'
+        $settings.model | Should -Be 'gpt-5.4-code'
+        $settings.worker_count | Should -Be 2
+        $settings.agent_slots.Count | Should -Be 2
+        $settings.agent_slots[0].agent | Should -Be 'codex-nightly'
+        $settings.agent_slots[0].model | Should -Be 'gpt-5.4-code'
     }
 
     It 'returns already_initialized when config exists and force is not set' {
@@ -10029,6 +10044,11 @@ Describe 'operator startup restore contract docs' {
 
         $settingsContent | Should -Match 'function Get-WinsmuxOperatorNotFoundMessage'
         $settingsContent | Should -Match 'Could not resolve the winsmux executable from PATH'
+        $setupWizardContent | Should -Match 'AI agent provider'
+        $setupWizardContent | Should -Match 'Test-SetupWizardAgentProvider'
+        $setupWizardContent | Should -Match 'provider-capabilities\.json first'
+        $setupWizardContent | Should -Not -Match 'AI agent CLI \(codex/claude\)'
+        $setupWizardContent | Should -Not -Match "Please enter 'codex' or 'claude'\."
         $setupWizardContent | Should -Not -Match 'Tried: winsmux, pmux, tmux'
         $commanderPollContent | Should -Not -Match 'Tried: winsmux, pmux, tmux'
         $agentMonitorContent | Should -Not -Match 'Tried: winsmux, pmux, tmux'

--- a/winsmux-core/scripts/setup-wizard.ps1
+++ b/winsmux-core/scripts/setup-wizard.ps1
@@ -42,6 +42,22 @@ function Get-BridgeCommand {
     return $null
 }
 
+function Get-SetupWizardProjectRoot {
+    return [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\..'))
+}
+
+function Test-SetupWizardAgentProvider {
+    param([Parameter(Mandatory = $true)][string]$Provider)
+
+    $projectRoot = Get-SetupWizardProjectRoot
+    try {
+        $null = Get-BridgeProviderLaunchCommand -ProviderId $Provider -Model '' -ProjectDir $projectRoot -GitWorktreeDir $projectRoot -RootPath $projectRoot -ExecMode:$false
+        return $true
+    } catch {
+        return $false
+    }
+}
+
 function Read-DefaultValue {
     param(
         [Parameter(Mandatory = $true)][string]$Prompt,
@@ -60,12 +76,12 @@ function Read-AgentCli {
     param([string]$Default = 'codex')
 
     while ($true) {
-        $value = (Read-DefaultValue -Prompt 'AI agent CLI (codex/claude)' -Default $Default).ToLowerInvariant()
-        if ($value -in @('codex', 'claude')) {
+        $value = (Read-DefaultValue -Prompt 'AI agent provider' -Default $Default).ToLowerInvariant()
+        if (Test-SetupWizardAgentProvider -Provider $value) {
             return $value
         }
 
-        Write-Host "Please enter 'codex' or 'claude'."
+        Write-Host "Provider '$value' is not launchable yet. Use 'codex', 'claude', or add it to .winsmux/provider-capabilities.json first."
     }
 }
 
@@ -200,9 +216,6 @@ if ($externalCommander) {
     }
 }
 
-function Get-SetupWizardProjectRoot {
-    return [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\..'))
-}
 $storeVault = Read-YesNo -Prompt 'Store GH_TOKEN in the winsmux vault?' -Default $false
 
 Set-WinsmuxOption -WinsmuxBin $winsmuxBin -OptionName '@bridge-agent' -OptionValue $agentCli


### PR DESCRIPTION
## Summary
- change `winsmux init` usage from fixed `codex|claude` wording to provider wording
- keep `winsmux init` able to store custom provider names such as `codex-nightly`
- make `setup-wizard.ps1` accept custom providers only when they can produce a launch command through provider capabilities

## Validation
- `Invoke-Pester -Path .\tests\winsmux-bridge.Tests.ps1 -Output Detailed`
- `git diff --check`
- `pwsh -NoProfile -File .\scripts\git-guard.ps1 -Mode full`
- `pwsh -NoProfile -File .\scripts\audit-public-surface.ps1`
- `pwsh -NoProfile -File .\scripts\gitleaks-history.ps1`
- `bash .githooks/pre-push`
- `codex exec review --base main --dangerously-bypass-approvals-and-sandbox`

Review note: the first review found that the wizard could save unsupported providers. This PR addresses it by checking the provider launch command before accepting the input. The final review found no blocking issue.