### PR TITLE
TASK-314: Use capability adapter for startup exec labels

### DIFF
--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -5222,6 +5222,12 @@ Describe 'orchestra-start session reuse contract' {
         $script:orchestraStartContent | Should -Match 'Wait-AgentReady -PaneId \$paneSummary\.PaneId -Agent \$readinessAgent'
     }
 
+    It 'uses the capability adapter for startup exec-mode labels' {
+        $script:orchestraStartContent | Should -Match '\$execModeAgent = \[string\]\$slotAgentConfig\.CapabilityAdapter'
+        $script:orchestraStartContent | Should -Match '\$execMode = \$execModeAgent\.Trim\(\)\.ToLowerInvariant\(\) -eq ''codex'''
+        $script:orchestraStartContent | Should -Not -Match '\$execMode = \(\[string\]\$slotAgentConfig\.Agent\)\.Trim\(\)\.ToLowerInvariant\(\) -eq ''codex'''
+    }
+
     It 'routes partial bootstrap invalid state into the startup rollback path by throwing' {
         {
             Assert-OrchestraBootstrapVerification -PaneSummaries @(

--- a/winsmux-core/scripts/orchestra-start.ps1
+++ b/winsmux-core/scripts/orchestra-start.ps1
@@ -2068,7 +2068,11 @@ if ($MyInvocation.InvocationName -ne '.') {
         }
 
         $slotAgentConfig = Get-SlotAgentConfig -Role $canonicalRole -SlotId $label -Settings $settings -RootPath $projectDir
-        $execMode = ([string]$slotAgentConfig.Agent).Trim().ToLowerInvariant() -eq 'codex'
+        $execModeAgent = [string]$slotAgentConfig.CapabilityAdapter
+        if ([string]::IsNullOrWhiteSpace($execModeAgent)) {
+            $execModeAgent = [string]$slotAgentConfig.Agent
+        }
+        $execMode = $execModeAgent.Trim().ToLowerInvariant() -eq 'codex'
         $launchCommand = Get-AgentLaunchCommand -Agent $slotAgentConfig.Agent -Model $slotAgentConfig.Model -ProjectDir $launchDir -GitWorktreeDir $launchGitWorktreeDir -RootPath $projectDir -ExecMode $false
         $supportsInterrupt = Test-OrchestraProviderInterruptAvailable -SlotAgentConfig $slotAgentConfig
 


### PR DESCRIPTION
## Summary
- make startup exec-mode labels prefer `CapabilityAdapter` before falling back to the provider id
- add coverage so the old provider-id-only expression does not return

## Validation
- `Invoke-Pester -Path .\tests\winsmux-bridge.Tests.ps1 -FullNameFilter 'orchestra-start session reuse contract*' -Output Detailed`
- `Invoke-Pester -Path .\tests\winsmux-bridge.Tests.ps1 -Output Detailed`
- `git diff --check`
- `pwsh -NoProfile -File .\scripts\git-guard.ps1 -Mode full`
- `pwsh -NoProfile -File .\scripts\audit-public-surface.ps1`
- `pwsh -NoProfile -File .\scripts\gitleaks-history.ps1`
- `bash .githooks/pre-push`
- `codex exec review --base main --dangerously-bypass-approvals-and-sandbox`

Review result: no introduced functional regression in the changed lines.