### PR TITLE
TASK-314: clarify Codex TUI provenance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -296,7 +296,7 @@ When winsmux directly reuses or closely adapts UI assets, style definitions, men
 3. preserve the original OSS license attribution in-repo,
 4. mention the provenance in `.claude/local/operator-handoff.md` when the change is active in the current session.
 
-For Codex-derived UI work, use `openai/codex` as the upstream reference and track the exact source areas being reused.
+For public `openai/codex` TUI-derived UI work, use `openai/codex` as the upstream reference and track the exact source areas being reused. Do not treat non-public Codex App desktop source as an upstream reference.
 
 ## Subagent Review Gate
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -46,7 +46,7 @@ In other words, this entry is not permanent. It should evolve with the compatibi
 
 ### winsmux usage policy
 
-winsmux may directly reuse or adapt selected Codex UI assets for the Tauri operator shell, including:
+winsmux may directly reuse or adapt selected public `openai/codex` TUI assets for the Tauri operator shell, including:
 
 - typography and color/style direction
 - wrapping and footer/status-lane behavior
@@ -61,7 +61,7 @@ When code or UI definitions are directly copied or closely adapted from `openai/
 
 ### Current tracked source references
 
-These upstream areas are the current reference set for Codex-derived UI work:
+These upstream areas are the current reference set for public `openai/codex` TUI-derived UI work:
 
 - `codex-rs/tui/`
 - `codex-rs/tui/src/app.rs`
@@ -77,7 +77,7 @@ These upstream areas are the current reference set for Codex-derived UI work:
 
 ### Current winsmux adaptation scope
 
-The current `winsmux-app` shell work tracks these Codex-derived areas most closely:
+The current `winsmux-app` shell work tracks these public `openai/codex` TUI-derived areas most closely:
 
 - typography and semantic theme token direction
 - conversation-shell wrapping behavior
@@ -86,8 +86,8 @@ The current `winsmux-app` shell work tracks these Codex-derived areas most close
 
 ### Adaptation guardrails
 
-Codex-derived UI reuse in winsmux follows the active release-train acceptance rules for utility-first surfaces, real-data-first release paths, minimal chrome, and Playwright viewport verification evidence recorded in backlog notes, pull requests, or handoff.
+Public `openai/codex` TUI-derived UI reuse in winsmux follows the active release-train acceptance rules for utility-first surfaces, real-data-first release paths, minimal chrome, and Playwright viewport verification evidence recorded in backlog notes, pull requests, or handoff.
 
 These are project adaptation guardrails, not additional license terms.
 
-This notice covers attribution and provenance tracking. It does not imply that winsmux reproduces Codex verbatim end-to-end.
+This notice covers attribution and provenance tracking. It does not imply that winsmux reproduces Codex verbatim end-to-end, or that winsmux incorporates non-public Codex App desktop source code.

--- a/scripts/start-orchestra.ps1
+++ b/scripts/start-orchestra.ps1
@@ -270,7 +270,7 @@ pwsh $bridgePath read <label>
 ## Git Operations
 Builders NEVER run git commands. Commander handles all staging, committing, and pushing sequentially.
 
-## Codex Builders
+## Builder Agents
 All builder tasks must target files within the project directory. Do not instruct builders to clone, cd, or operate outside the project root.
 
 ## Multi-Builder Coordination Protocol
@@ -281,9 +281,9 @@ All builder tasks must target files within the project directory. Do not instruc
 5. MERGE: If no conflicts, commit. If conflicts, resolve manually then commit.
 
 ## POLL Guard (anti-hang protocol)
-1. Before sending any task via winsmux send, ALWAYS run ``winsmux read <label>`` first and verify the last line shows Codex idle prompt.
+1. Before sending any task via winsmux send, ALWAYS run ``winsmux read <label>`` first and verify that the pane is idle for its configured agent.
 2. If ``wait-ready`` command is available, use it: ``winsmux wait-ready <label> 60``.
-3. If an agent appears hung (no output change after 30 seconds), run ``respawn-pane -k`` and restart codex.
+3. If an agent appears hung (no output change after 30 seconds), run ``respawn-pane -k`` and restart the configured agent command for that label.
 "@
 
 Set-Content -Path $promptFile -Value $promptContent -Encoding UTF8

--- a/tests/PublicSurfacePolicy.Tests.ps1
+++ b/tests/PublicSurfacePolicy.Tests.ps1
@@ -15,6 +15,8 @@ Describe 'Public surface policy' {
         $surfacePolicy = Get-Content (Join-Path $repoRoot 'docs/repo-surface-policy.md') -Raw
         $gitignore = Get-Content (Join-Path $repoRoot '.gitignore') -Raw
         $claudeContract = Get-Content (Join-Path $repoRoot '.claude/CLAUDE.md') -Raw
+        $thirdPartyNotices = Get-Content (Join-Path $repoRoot 'THIRD_PARTY_NOTICES.md') -Raw
+        $appIndex = Get-Content (Join-Path $repoRoot 'winsmux-app/index.html') -Raw
         $syncRoadmap = Get-Content (Join-Path $repoRoot 'winsmux-core/scripts/sync-roadmap.ps1') -Raw
         $syncInternalDocs = Get-Content (Join-Path $repoRoot 'winsmux-core/scripts/sync-internal-docs.ps1') -Raw
     }
@@ -109,5 +111,15 @@ Describe 'Public surface policy' {
         $example | Should -Match 'TaskTitles\s*=\s*@\{\}'
         $example | Should -Not -Match '"v0\.'
         $example | Should -Not -Match '"TASK-'
+    }
+
+    It 'describes Codex UI provenance as public openai/codex TUI-derived work' {
+        $agents | Should -Match 'public `openai/codex` TUI-derived UI work'
+        $agents | Should -Match 'Do not treat non-public Codex App desktop source as an upstream reference'
+        $thirdPartyNotices | Should -Match 'public `openai/codex` TUI-derived UI work'
+        $thirdPartyNotices | Should -Match 'does not imply.*non-public Codex App desktop source code'
+        $thirdPartyNotices | Should -Not -Match 'Codex-derived UI'
+        $appIndex | Should -Match 'Public openai/codex TUI-derived typography'
+        $appIndex | Should -Not -Match 'Codex-derived typography'
     }
 }

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -10061,6 +10061,18 @@ Describe 'operator startup restore contract docs' {
         $watchdogContent | Should -Not -Match 'Tried: winsmux, pmux, tmux'
         $orchestraStartContent | Should -Not -Match 'Tried: winsmux, pmux, tmux'
     }
+
+    It 'keeps the legacy orchestra prompt provider-neutral' {
+        $legacyStartPath = Join-Path (Split-Path -Parent $PSScriptRoot) 'scripts\start-orchestra.ps1'
+        $legacyStartContent = Get-Content -Path $legacyStartPath -Raw -Encoding UTF8
+
+        $legacyStartContent | Should -Match '## Builder Agents'
+        $legacyStartContent | Should -Match 'configured agent'
+        $legacyStartContent | Should -Match 'configured agent command'
+        $legacyStartContent | Should -Not -Match '## Codex Builders'
+        $legacyStartContent | Should -Not -Match 'Codex idle prompt'
+        $legacyStartContent | Should -Not -Match 'restart codex'
+    }
 }
 
 Describe 'orchestra pane bootstrap plan' {

--- a/winsmux-app/index.html
+++ b/winsmux-app/index.html
@@ -184,7 +184,7 @@
           </div>
           <div class="settings-section">
             <div class="context-label">Theme</div>
-            <div class="context-value">Codex-derived typography, semantic color tokens, and shell contrast.</div>
+            <div class="context-value">Public openai/codex TUI-derived typography, semantic color tokens, and shell contrast.</div>
             <div id="theme-options" class="settings-option-row" aria-label="Theme options"></div>
           </div>
           <div class="settings-section">

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -354,7 +354,7 @@ const timelineFilters: Array<{ filter: TimelineFilter; label: string }> = [
 ];
 
 const themeOptions: Array<{ value: ThemeMode; label: string; description: string }> = [
-  { value: "codex-dark", label: "Codex Dark", description: "Close adaptation of Codex typography and contrast." },
+  { value: "codex-dark", label: "Codex TUI Dark", description: "Adaptation of public openai/codex TUI typography and contrast." },
   { value: "graphite-dark", label: "Graphite", description: "Softer shell contrast for long operator sessions." },
 ];
 


### PR DESCRIPTION
## Summary
- clarify Codex UI provenance as public openai/codex TUI-derived work, not non-public Codex App desktop source
- remove Codex-specific wording from the legacy start-orchestra Commander prompt
- add static tests for provenance wording and provider-neutral legacy prompt text

## Validation
- Invoke-Pester .\tests\PublicSurfacePolicy.Tests.ps1 -Output Detailed
- Invoke-Pester .\tests\winsmux-bridge.Tests.ps1 -Output Detailed
- cmd /c npm run build
- git diff --check
- pwsh -NoProfile -File .\scripts\audit-public-surface.ps1
- pwsh -NoProfile -File .\scripts\git-guard.ps1 -Mode full
- pwsh -NoProfile -File .\scripts\gitleaks-history.ps1
- codex exec review --base main --dangerously-bypass-approvals-and-sandbox