### PR TITLE
TASK-314: use adapters for restart readiness

### DIFF
--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -7733,20 +7733,17 @@ function Invoke-RestartPane {
 
     $restartReadinessAgent = Get-RestartReadinessAgentName -Plan $plan
 
-    if ($restartReadinessAgent.Trim().ToLowerInvariant() -eq 'codex') {
-        $deadline = (Get-Date).AddSeconds(60)
-        while ((Get-Date) -lt $deadline) {
-            if (Test-CodexReadyPrompt $PaneId) {
-                return $plan
-            }
-
-            Start-Sleep -Seconds 2
+    $deadline = (Get-Date).AddSeconds(60)
+    while ((Get-Date) -lt $deadline) {
+        if (Test-AgentReadyPrompt -PaneId $PaneId -Agent $restartReadinessAgent) {
+            return $plan
         }
 
-        Stop-WithError "timed out waiting for Codex after restart in $PaneId"
+        Start-Sleep -Seconds 2
     }
 
-    return $plan
+    $readinessName = ConvertTo-ReadinessAgentName $restartReadinessAgent
+    Stop-WithError "timed out waiting for $readinessName prompt after restart in $PaneId"
 }
 
 function Invoke-Restart {

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -9762,6 +9762,8 @@ agent-slots:
         $script:winsmuxCoreRawContent | Should -Match 'Confirm-Target \(\[string\]\$manifestEntry\[0\]\.PaneId\)'
         $script:winsmuxCoreRawContent | Should -Match 'Invoke-RestartPane -PaneId'
         $script:winsmuxCoreRawContent | Should -Match '\$restartReadinessAgent\s*=\s*Get-RestartReadinessAgentName -Plan \$plan'
+        $script:winsmuxCoreRawContent | Should -Match 'Test-AgentReadyPrompt -PaneId \$PaneId -Agent \$restartReadinessAgent'
+        $script:winsmuxCoreRawContent | Should -Not -Match 'timed out waiting for Codex after restart'
         $script:winsmuxCoreRawContent | Should -Match 'Remove-BridgeProviderRegistryEntry -RootPath \$projectDir -SlotId \$slotId'
         $script:winsmuxCoreRawContent | Should -Match 'clear_requested'
         $script:winsmuxCoreRawContent | Should -Match 'restart_requested'


### PR DESCRIPTION
## Summary
- Route restart readiness waiting through `Test-AgentReadyPrompt` instead of the Codex-only prompt check.
- Keep the readiness adapter derived from the restart plan capability adapter.
- Remove the Codex-specific restart timeout wording and add static coverage for the shared route.

## Validation
- `Invoke-Pester .\tests\winsmux-bridge.Tests.ps1 -FullName 'winsmux provider-switch command*' -Output Detailed` passed with 4 tests.
- `Invoke-Pester .\tests\winsmux-bridge.Tests.ps1 -FullName 'winsmux send dispatch payload*' -Output Detailed` passed with 15 tests.
- `Invoke-Pester .\tests\winsmux-bridge.Tests.ps1 -Output Detailed` passed with 316 tests.
- `git diff --check` passed with line-ending warnings only.
- `pwsh -NoProfile -File .\scripts\audit-public-surface.ps1` passed.
- `pwsh -NoProfile -File .\scripts\git-guard.ps1 -Mode full` passed.
- `pwsh -NoProfile -File .\scripts\gitleaks-history.ps1` scanned 506 commits and found no leaks.
- `codex exec review --base main --dangerously-bypass-approvals-and-sandbox` returned no actionable findings.