### PR TITLE
TASK-314: pass custom profile agents

### DIFF
--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -6653,6 +6653,45 @@ function Invoke-FocusUnlock {
     Write-Output "Focus unlocked $($entry.paneId) ($($entry.target))"
 }
 
+function ConvertTo-ProfileAgentHashtableLiteral {
+    param([Parameter(Mandatory = $true)][string]$Definition)
+
+    $separatorIndex = $Definition.IndexOf(':')
+    if ($separatorIndex -le 0 -or $separatorIndex -ge ($Definition.Length - 1)) {
+        Stop-WithError "usage: winsmux profile <name> <label:agent-command> [label:agent-command...]"
+    }
+
+    $label = $Definition.Substring(0, $separatorIndex).Trim()
+    $command = $Definition.Substring($separatorIndex + 1).Trim()
+    if ([string]::IsNullOrWhiteSpace($label) -or [string]::IsNullOrWhiteSpace($command)) {
+        Stop-WithError "usage: winsmux profile <name> <label:agent-command> [label:agent-command...]"
+    }
+
+    $adapter = ($command -split '\s+', 2)[0].Trim()
+    $labelLiteral = ConvertTo-BridgePowerShellLiteral -Value $label
+    $commandLiteral = ConvertTo-BridgePowerShellLiteral -Value $command
+    $adapterLiteral = ConvertTo-BridgePowerShellLiteral -Value $adapter
+    return "@{ label = $labelLiteral; command = $commandLiteral; adapter = $adapterLiteral }"
+}
+
+function Get-ProfileAgentGrid {
+    param([Parameter(Mandatory = $true)][int]$Count)
+
+    if ($Count -lt 1) {
+        Stop-WithError 'profile agent count must be greater than zero'
+    }
+
+    $rows = [Math]::Floor([Math]::Sqrt($Count))
+    while ($rows -gt 1 -and ($Count % $rows) -ne 0) {
+        $rows--
+    }
+
+    [PSCustomObject]@{
+        Rows = [int]$rows
+        Cols = [int]($Count / $rows)
+    }
+}
+
 function Invoke-Profile {
     $fragmentDir = Join-Path $env:LOCALAPPDATA "Microsoft\Windows Terminal\Fragments\winsmux"
     $fragmentFile = Join-Path $fragmentDir "winsmux.json"
@@ -6668,7 +6707,7 @@ function Invoke-Profile {
     }
 
     # Generate custom profile fragment
-    # $Target = profile name, $Rest = agent definitions like "builder:codex" "reviewer:claude"
+    # $Target = profile name, $Rest = agent definitions like "builder:codex-nightly" "reviewer:claude --model opus"
     $profileName = $Target
     $agents = @()
     if ($Rest -and $Rest.Count -gt 0) {
@@ -6681,6 +6720,15 @@ function Invoke-Profile {
     if ($agents.Count -gt 0) {
         $agentComment = " # agents: $($agents -join ', ')"
     }
+    $agentArgument = ''
+    if ($agents.Count -gt 0) {
+        $agentLiterals = @($agents | ForEach-Object { ConvertTo-ProfileAgentHashtableLiteral -Definition $_ })
+        $agentGrid = Get-ProfileAgentGrid -Count $agents.Count
+        $agentArgument = ' -Rows {0} -Cols {1} -Agents @({2})' -f $agentGrid.Rows, $agentGrid.Cols, ($agentLiterals -join ', ')
+    }
+    $profileNameLiteral = ConvertTo-BridgePowerShellLiteral -Value $profileName
+    $profileCommand = "& (Join-Path `$env:USERPROFILE '.winsmux\bin\winsmux-core.ps1') doctor; winsmux new-session -s $profileNameLiteral; & (Join-Path `$env:USERPROFILE '.winsmux\bin\start-orchestra.ps1')$agentArgument"
+    $encodedProfileCommand = [Convert]::ToBase64String([System.Text.Encoding]::Unicode.GetBytes($profileCommand))
 
     if (-not (Test-Path $fragmentDir)) {
         New-Item -ItemType Directory -Path $fragmentDir -Force | Out-Null
@@ -6690,7 +6738,7 @@ function Invoke-Profile {
         profiles = @(
             @{
                 name             = "winsmux $profileName"
-                commandline      = "pwsh -NoProfile -Command `"& '%USERPROFILE%\.winsmux\bin\winsmux-core.ps1' doctor; winsmux new-session -s $profileName; pwsh '%USERPROFILE%\.winsmux\bin\start-orchestra.ps1'`""
+                commandline      = "pwsh -NoProfile -EncodedCommand $encodedProfileCommand"
                 icon             = "`u{1F3BC}"
                 startingDirectory = "%USERPROFILE%"
                 tabTitle         = "winsmux $profileName"

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -9184,6 +9184,58 @@ Describe 'winsmux task-run command' {
     }
 }
 
+Describe 'winsmux profile command' {
+    BeforeAll {
+        $script:winsmuxCoreRawPath = Join-Path (Split-Path -Parent $PSScriptRoot) 'scripts\winsmux-core.ps1'
+        $script:winsmuxCoreRawContent = Get-Content -Path $script:winsmuxCoreRawPath -Raw -Encoding UTF8
+    }
+
+    BeforeEach {
+        $script:profileTempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('winsmux-profile-tests-' + [guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $script:profileTempRoot -Force | Out-Null
+    }
+
+    AfterEach {
+        if ($script:profileTempRoot -and (Test-Path $script:profileTempRoot)) {
+            Remove-Item -Path $script:profileTempRoot -Recurse -Force
+        }
+    }
+
+    It 'passes custom provider commands into the generated Windows Terminal profile' {
+        $script:winsmuxCoreRawContent | Should -Match 'function ConvertTo-ProfileAgentHashtableLiteral'
+        $script:winsmuxCoreRawContent | Should -Match 'function Get-ProfileAgentGrid'
+        $script:winsmuxCoreRawContent | Should -Match 'label:agent-command'
+        $script:winsmuxCoreRawContent | Should -Match '\$agentArgument = '' -Rows \{0\} -Cols \{1\} -Agents @\(\{2\}\)'''
+
+        $oldLocalAppData = $env:LOCALAPPDATA
+        $env:LOCALAPPDATA = $script:profileTempRoot
+        try {
+            & pwsh -NoProfile -File $script:winsmuxCoreRawPath profile nightly builder:codex-nightly 'researcher:claude --model opus' 'reviewer:claude --append-system-prompt "hello world"' | Out-Null
+        } finally {
+            $env:LOCALAPPDATA = $oldLocalAppData
+        }
+
+        $fragmentPath = Join-Path $script:profileTempRoot 'Microsoft\Windows Terminal\Fragments\winsmux\winsmux.json'
+        Test-Path -LiteralPath $fragmentPath | Should -Be $true
+        $fragment = Get-Content -LiteralPath $fragmentPath -Raw -Encoding UTF8 | ConvertFrom-Json
+        $commandline = [string]$fragment.profiles[0].commandline
+        $commandline | Should -Match '-EncodedCommand '
+        $encodedCommand = ($commandline -replace '^.*-EncodedCommand\s+', '').Trim()
+        $decodedCommand = [System.Text.Encoding]::Unicode.GetString([Convert]::FromBase64String($encodedCommand))
+        $startOrchestraCall = "& (Join-Path `$env:USERPROFILE '.winsmux\bin\start-orchestra.ps1')"
+        $childStartOrchestraCall = "pwsh (Join-Path `$env:USERPROFILE '.winsmux\bin\start-orchestra.ps1')"
+        $decodedCommand | Should -Match ([regex]::Escape($startOrchestraCall))
+        $decodedCommand | Should -Not -Match ([regex]::Escape($childStartOrchestraCall))
+        $decodedCommand | Should -Match '-Rows 1 -Cols 3 -Agents @\('
+        $decodedCommand | Should -Match "winsmux new-session -s 'nightly'"
+        $decodedCommand | Should -Match "label = 'builder'"
+        $decodedCommand | Should -Match "command = 'codex-nightly'"
+        $decodedCommand | Should -Match "label = 'researcher'"
+        $decodedCommand | Should -Match "command = 'claude --model opus'"
+        $decodedCommand | Should -Match 'command = ''claude --append-system-prompt "hello world"'''
+    }
+}
+
 Describe 'winsmux public first-run commands' {
     BeforeAll {
         $script:winsmuxCoreRawPath = Join-Path (Split-Path -Parent $PSScriptRoot) 'scripts\winsmux-core.ps1'


### PR DESCRIPTION
## Summary
- Pass custom label:agent-command entries from winsmux profile into generated Windows Terminal profiles.
- Generate Rows and Cols values for custom agent counts before calling start-orchestra.ps1.
- Use EncodedCommand and invoke start-orchestra.ps1 in the same PowerShell process so quoted agent arguments and hashtable definitions survive launch.

## Validation
- Invoke-Pester .\\tests\\winsmux-bridge.Tests.ps1 -FullName 'winsmux profile command*' -Output Detailed
- PowerShell parser check for scripts\\winsmux-core.ps1
- Invoke-Pester .\\tests\\winsmux-bridge.Tests.ps1 -Output Detailed
- git diff --check (line-ending warnings only)
- pwsh -NoProfile -File .\\scripts\\audit-public-surface.ps1
- pwsh -NoProfile -File .\\scripts\\git-guard.ps1 -Mode full
- pwsh -NoProfile -File .\\scripts\\gitleaks-history.ps1
- codex exec review --base main --dangerously-bypass-approvals-and-sandbox
