### PR TITLE
TASK-314: align installer first-run launch

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -24,7 +24,7 @@ $PROFILE_FILE = Join-Path $WINSMUX_DIR "install-profile"
 $PROFILE_MANIFEST_FILE = Join-Path $WINSMUX_DIR "install-profile.json"
 $PROFILE_MATRIX = @{
     core = "Runtime binary, wrapper scripts, PATH setup, and base config."
-    orchestra = "Core profile plus orchestration scripts and Windows Terminal profile."
+    orchestra = "Core profile plus orchestration scripts, runtime dependencies, and Windows Terminal profile."
     security = "Core profile plus vault, redaction, and audit-oriented scripts."
     full = "Core, orchestra, and security profile contents."
 }
@@ -71,7 +71,7 @@ function Get-InstallProfileContents {
 
     switch ($Profile) {
         "core" { return @("runtime", "wrappers", "path", "base_config") }
-        "orchestra" { return @("runtime", "wrappers", "path", "base_config", "orchestration_scripts", "windows_terminal_profile") }
+        "orchestra" { return @("runtime", "wrappers", "path", "base_config", "orchestration_scripts", "windows_terminal_profile", "vault") }
         "security" { return @("runtime", "wrappers", "path", "base_config", "vault", "redaction", "audit_scripts") }
         "full" { return @("runtime", "wrappers", "path", "base_config", "orchestration_scripts", "windows_terminal_profile", "vault", "redaction", "audit_scripts") }
         default { throw "Unsupported install profile '$Profile'." }
@@ -107,9 +107,32 @@ function Write-InstallProfileManifest {
 
 function Install-OrchestraSupportScripts {
     Download-File "winsmux-core/scripts/agent-launch.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "agent-launch.ps1")
+    Download-File "winsmux-core/scripts/agent-monitor.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "agent-monitor.ps1")
+    Download-File "winsmux-core/scripts/agent-readiness.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "agent-readiness.ps1")
+    Download-File "winsmux-core/scripts/agent-watchdog.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "agent-watchdog.ps1")
+    Download-File "winsmux-core/scripts/builder-worktree.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "builder-worktree.ps1")
+    Download-File "winsmux-core/scripts/clm-safe-io.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "clm-safe-io.ps1")
+    Download-File "winsmux-core/scripts/commander-poll.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "commander-poll.ps1")
+    Download-File "winsmux-core/scripts/doctor.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "doctor.ps1")
+    Download-File "winsmux-core/scripts/logger.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "logger.ps1")
+    Download-File "winsmux-core/scripts/manifest.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "manifest.ps1")
+    Download-File "winsmux-core/scripts/orchestra-attach-confirm.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "orchestra-attach-confirm.ps1")
+    Download-File "winsmux-core/scripts/orchestra-attach-entry.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "orchestra-attach-entry.ps1")
+    Download-File "winsmux-core/scripts/orchestra-pane-bootstrap.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "orchestra-pane-bootstrap.ps1")
+    Download-File "winsmux-core/scripts/orchestra-preflight.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "orchestra-preflight.ps1")
+    Download-File "winsmux-core/scripts/orchestra-smoke.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "orchestra-smoke.ps1")
     Download-File "winsmux-core/scripts/orchestra-start.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "orchestra-start.ps1")
+    Download-File "winsmux-core/scripts/orchestra-state.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "orchestra-state.ps1")
     Download-File "winsmux-core/scripts/orchestra-layout.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "orchestra-layout.ps1")
+    Download-File "winsmux-core/scripts/orchestra-ui-attach.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "orchestra-ui-attach.ps1")
+    Download-File "winsmux-core/scripts/pane-control.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "pane-control.ps1")
+    Download-File "winsmux-core/scripts/pane-env.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "pane-env.ps1")
+    Download-File "winsmux-core/scripts/pane-border.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "pane-border.ps1")
+    Download-File "winsmux-core/scripts/planning-paths.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "planning-paths.ps1")
+    Download-File "winsmux-core/scripts/public-first-run.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "public-first-run.ps1")
+    Download-File "winsmux-core/scripts/server-watchdog.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "server-watchdog.ps1")
     Download-File "winsmux-core/scripts/settings.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "settings.ps1")
+    Download-File "winsmux-core/scripts/vault.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "vault.ps1")
 }
 
 function Install-SecuritySupportScripts {
@@ -122,7 +145,34 @@ function Remove-ProfileExcludedSupportScripts {
     $scriptGroups = @(
         [PSCustomObject]@{
             Content = "orchestration_scripts"
-            Files = @("agent-launch.ps1", "orchestra-start.ps1", "orchestra-layout.ps1", "settings.ps1")
+            Files = @(
+                "agent-launch.ps1",
+                "agent-monitor.ps1",
+                "agent-readiness.ps1",
+                "agent-watchdog.ps1",
+                "builder-worktree.ps1",
+                "clm-safe-io.ps1",
+                "commander-poll.ps1",
+                "doctor.ps1",
+                "logger.ps1",
+                "manifest.ps1",
+                "orchestra-attach-confirm.ps1",
+                "orchestra-attach-entry.ps1",
+                "orchestra-pane-bootstrap.ps1",
+                "orchestra-preflight.ps1",
+                "orchestra-smoke.ps1",
+                "orchestra-start.ps1",
+                "orchestra-state.ps1",
+                "orchestra-layout.ps1",
+                "orchestra-ui-attach.ps1",
+                "pane-control.ps1",
+                "pane-env.ps1",
+                "pane-border.ps1",
+                "planning-paths.ps1",
+                "public-first-run.ps1",
+                "server-watchdog.ps1",
+                "settings.ps1"
+            )
         },
         [PSCustomObject]@{
             Content = "vault"
@@ -425,9 +475,14 @@ pwsh -NoProfile -File "%USERPROFILE%\.winsmux\bin\winsmux.ps1" %*
         Write-Host "  install profile: $resolvedInstallProfile"
         Write-Host ""
         Write-Host "Next steps:"
-        Write-Host "  1. Start a winsmux session:  winsmux new-session -s work"
-        Write-Host "  2. Set your agent name:    `$env:WINSMUX_AGENT_NAME = 'claude'"
-        Write-Host "  3. Try it out:             winsmux list"
+        if (Test-InstallProfileContent -Profile $resolvedInstallProfile -Content "orchestration_scripts") {
+            Write-Host "  1. Create project config:  winsmux init"
+            Write-Host "  2. Launch first run:       winsmux launch"
+            Write-Host "  3. Inspect panes:          winsmux list"
+        } else {
+            Write-Host "  1. Start a session:        winsmux new-session -s work"
+            Write-Host "  2. Inspect panes:          winsmux list"
+        }
     }
 }
 

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -3442,9 +3442,21 @@ function Invoke-Init {
     Write-Output "next: $($result.next_action)"
 }
 
+function Test-WinsmuxInstalledBinLayout {
+    param([string]$ScriptRoot = $PSScriptRoot)
+
+    if ([string]::IsNullOrWhiteSpace($env:USERPROFILE)) {
+        return $false
+    }
+
+    $installedBin = [System.IO.Path]::GetFullPath((Join-Path $env:USERPROFILE '.winsmux\bin')).TrimEnd([char[]]@('\', '/'))
+    $currentRoot = [System.IO.Path]::GetFullPath($ScriptRoot).TrimEnd([char[]]@('\', '/'))
+    return [string]::Equals($currentRoot, $installedBin, [System.StringComparison]::OrdinalIgnoreCase)
+}
+
 function Invoke-Launch {
     $projectDir = ''
-    $skipDoctor = $false
+    $skipDoctor = Test-WinsmuxInstalledBinLayout
     $asJson = $false
     $remaining = @(@($Target) + @($Rest) | Where-Object { $_ })
     $doctorScriptPath = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\winsmux-core\scripts\doctor.ps1'))

--- a/tests/PublicSurfacePolicy.Tests.ps1
+++ b/tests/PublicSurfacePolicy.Tests.ps1
@@ -19,6 +19,7 @@ Describe 'Public surface policy' {
         $appIndex = Get-Content (Join-Path $repoRoot 'winsmux-app/index.html') -Raw
         $syncRoadmap = Get-Content (Join-Path $repoRoot 'winsmux-core/scripts/sync-roadmap.ps1') -Raw
         $syncInternalDocs = Get-Content (Join-Path $repoRoot 'winsmux-core/scripts/sync-internal-docs.ps1') -Raw
+        $installer = Get-Content (Join-Path $repoRoot 'install.ps1') -Raw
     }
 
     It 'keeps public docs free of contributor/private direct links' {
@@ -121,5 +122,26 @@ Describe 'Public surface policy' {
         $thirdPartyNotices | Should -Not -Match 'Codex-derived UI'
         $appIndex | Should -Match 'Public openai/codex TUI-derived typography'
         $appIndex | Should -Not -Match 'Codex-derived typography'
+    }
+
+    It 'keeps installer next steps aligned with public first-run commands' {
+        $installerSingleLine = $installer -replace '\s+', ' '
+        $installer | Should -Match 'winsmux init'
+        $installer | Should -Match 'winsmux launch'
+        $installer | Should -Not -Match "WINSMUX_AGENT_NAME = 'claude'"
+        $installerSingleLine | Should -Match '"orchestra".*"vault"'
+        $installer | Should -Match 'Test-InstallProfileContent -Profile \$resolvedInstallProfile -Content "orchestration_scripts"'
+        $installer | Should -Match 'winsmux-core/scripts/public-first-run\.ps1'
+        $installer | Should -Match 'winsmux-core/scripts/orchestra-smoke\.ps1'
+        $installer | Should -Match 'winsmux-core/scripts/doctor\.ps1'
+        $installer | Should -Match 'winsmux-core/scripts/orchestra-attach-confirm\.ps1'
+        $installer | Should -Match 'winsmux-core/scripts/orchestra-pane-bootstrap\.ps1'
+        $installer | Should -Match 'winsmux-core/scripts/commander-poll\.ps1'
+        $installer | Should -Match 'winsmux-core/scripts/pane-control\.ps1'
+        $installer | Should -Match 'winsmux-core/scripts/agent-monitor\.ps1'
+        $installer | Should -Match 'winsmux-core/scripts/agent-watchdog\.ps1'
+        $installer | Should -Match 'winsmux-core/scripts/orchestra-state\.ps1'
+        $installer | Should -Match 'winsmux-core/scripts/server-watchdog\.ps1'
+        $installer | Should -Match 'winsmux-core/scripts/pane-border\.ps1'
     }
 }

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -9250,6 +9250,9 @@ Describe 'winsmux public first-run commands' {
         $script:winsmuxCoreRawContent | Should -Match "'init'\s*\{"
         $script:winsmuxCoreRawContent | Should -Match "'launch'\s*\{"
         $script:winsmuxCoreRawContent | Should -Match 'public-first-run\.ps1'
+        $script:winsmuxCoreRawContent | Should -Match 'function Test-WinsmuxInstalledBinLayout'
+        $script:winsmuxCoreRawContent | Should -Match '\$skipDoctor = Test-WinsmuxInstalledBinLayout'
+        $script:winsmuxCoreRawContent | Should -Match 'Invoke-WinsmuxPublicLaunch -ProjectDir \$projectDir -SkipDoctor:\$skipDoctor'
         $script:publicFirstRunContent | Should -Match 'function Invoke-WinsmuxPublicInit'
         $script:publicFirstRunContent | Should -Match 'function Invoke-WinsmuxPublicLaunch'
         $script:publicFirstRunContent | Should -Match 'Run winsmux launch\.'


### PR DESCRIPTION
## Summary
- align installer post-install guidance with public `winsmux init` / `winsmux launch` first-run flow
- ship the orchestration helper dependency set needed by installed launch, attach, watchdog, and monitor paths
- skip the repo-only doctor by default from installed `winsmux launch` wrappers while keeping repo-local launch behavior unchanged

## Validation
- parser checks for `install.ps1` and `scripts/winsmux-core.ps1`
- `Invoke-Pester .\tests\PublicSurfacePolicy.Tests.ps1 -Output Detailed`
- `Invoke-Pester .\tests\winsmux-bridge.Tests.ps1 -Output Detailed`
- `pwsh -NoProfile -File .\scripts\audit-public-surface.ps1`
- `pwsh -NoProfile -File .\scripts\git-guard.ps1 -Mode full`
- `gitleaks detect --source . --no-banner --redact --log-opts "--all"`
- `codex exec review --base main --dangerously-bypass-approvals-and-sandbox`