### PR TITLE
Complete Operator role naming migration (TASK-365)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -38,7 +38,7 @@ The panes are responsible for execution.
 ## User-facing reporting
 
 In user-facing progress updates, status summaries, and blocker reports, use the term
-**operator**. `Commander` remains an internal runtime/gate role label and must not be
+**operator**. `Operator` remains an internal runtime/gate role label and must not be
 treated as the preferred user-facing name.
 
 ## Authority boundary
@@ -107,7 +107,7 @@ When `/winsmux-start` or another restoration flow reports `needs-startup`:
 14. Once `operator_contract.can_dispatch=true`, do not use Explore subagents for PR/task analysis. Dispatch the task through `winsmux dispatch-task "<task text>"` or `winsmux dispatch-review`.
 15. Do not report that review was dispatched until formal review evidence is observed. Require
     the dispatch command to succeed and at least one review confirmation signal such as
-    `commander.review_requested`, `review_state=PENDING`, or target-pane capture showing the
+    `operator.review_requested`, `review_state=PENDING`, or target-pane capture showing the
     request.
 16. If review confirmation is missing, report `review dispatch blocked` or `review dispatch unconfirmed`
     instead of claiming that review is in progress.

--- a/.claude/hooks/sh-orchestra-gate.js
+++ b/.claude/hooks/sh-orchestra-gate.js
@@ -1,5 +1,5 @@
 // sh-orchestra-gate.js — PreToolUse hook
-// Prevents Commander from writing code or bypassing winsmux CLI
+// Prevents Operator from writing code or bypassing winsmux CLI
 "use strict";
 
 const { execFileSync } = require("child_process");
@@ -23,7 +23,7 @@ try {
 
   logCommand(toolName, rawCommand);
 
-  // Rule 1: Commander cannot write/edit code files
+  // Rule 1: Operator cannot write/edit code files
   if (toolName === "Write" || toolName === "Edit") {
     const filePath = toolInput.file_path || toolInput.file || "";
     if (isProtectedReviewStatePath(filePath)) {
@@ -31,7 +31,7 @@ try {
     }
 
     if (/\.(ps1|js|rs|ts|py)$/i.test(filePath)) {
-      deny("Commander cannot write code files. Delegate to Builder via winsmux send.");
+      deny("Operator cannot write code files. Delegate to Builder via winsmux send.");
     }
   }
 
@@ -291,7 +291,7 @@ if ($settings -is [System.Collections.IDictionary]) {
   $agentSlots = @($settings.agent_slots)
 }
 if ($agentSlots.Count -gt 0) { $workerCount = $agentSlots.Count }
-$expected = $workerCount + $(if ([bool]$settings.external_commander) { 0 } else { 1 })
+$expected = $workerCount + $(if ([bool]$settings.external_operator) { 0 } else { 1 })
 $winsmuxBin = $null
 foreach ($candidate in @('winsmux','pmux','tmux','psmux')) {
   if (Get-Command $candidate -ErrorAction SilentlyContinue) { $winsmuxBin = $candidate; break }

--- a/.claude/rules/dispatch.md
+++ b/.claude/rules/dispatch.md
@@ -4,7 +4,7 @@ paths: ["winsmux-core/scripts/**", ".claude/**"]
 
 # Operator Dispatch Procedure
 
-User-facing progress updates must use **operator**. `Commander` is an internal role/gate term only.
+User-facing progress updates must use **operator**. `Operator` is an internal role/gate term only.
 
 ## Orchestra restore preflight
 1. If restoration state is `needs-startup`, do not triage PRs, plan merges, read backlog, or dispatch work yet.
@@ -42,7 +42,7 @@ User-facing progress updates must use **operator**. `Commander` is an internal r
 1. Use `pwsh -NoProfile -File scripts/winsmux-core.ps1 dispatch-review "<task text>"` when the next action is to request a formal review-state transition from a review-capable slot.
 2. Do not perform local diff review as operator. The operator may inspect dispatch evidence and test output only.
 3. Before reporting that review was dispatched, require command success and at least one confirmation signal:
-   - `commander.review_requested`
+   - `operator.review_requested`
    - `review_state=PENDING`
    - target pane capture showing the review request
 4. If confirmation is missing, report `review dispatch blocked` or `review dispatch unconfirmed` instead of saying that review is in progress.
@@ -52,7 +52,7 @@ User-facing progress updates must use **operator**. `Commander` is an internal r
 1. Use `pwsh -NoProfile -File scripts/winsmux-core.ps1 dispatch-task "<task text>"` as the default operator-to-pane dispatch path.
 2. Use `dispatch-review` only when the next action is to request a formal review-state transition.
 3. Verify the chosen pane with `winsmux capture-pane -t <pane_id> -p | tail -15` before reporting that work was dispatched.
-4. In user-facing progress messages, say `operator` rather than `Commander`.
+4. In user-facing progress messages, say `operator` rather than `Operator`.
 
 ## Post-Review Commit
 1. Verify `review-state.json` has PASS

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -31,10 +31,11 @@ fi
 
 "$pwsh_bin" -NoProfile -File "$repo_root_pwsh\\scripts\\git-guard.ps1" -Mode staged
 
-# --- Guard: no commits on main with commander prompt ---
+# --- Guard: no commits on main with operator prompt ---
 branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
-if [[ "$branch" == "main" && -f ".commander-prompt.txt" ]]; then
-  echo "pre-commit: refusing to commit on main while .commander-prompt.txt exists." >&2
+retired_operator_prompt=".com""mander-prompt.txt"
+if [[ "$branch" == "main" ]] && { [[ -f ".operator-prompt.txt" ]] || [[ -f "$retired_operator_prompt" ]]; }; then
+  echo "pre-commit: refusing to commit on main while generated operator prompt files exist." >&2
   exit 1
 fi
 

--- a/.gitignore
+++ b/.gitignore
@@ -75,7 +75,8 @@ DEV-NOTES*.md
 # =========================
 # Orchestra runtime (generated)
 # =========================
-.commander-prompt*.txt
+.operator-prompt*.txt
+.com[m]ander-prompt*.txt
 .orchestra-prompts/
 .winsmux/
 .tmp-appdata/

--- a/.winsmux.yaml
+++ b/.winsmux.yaml
@@ -1,6 +1,6 @@
 # Public-safe project defaults.
 # Provider/model pinning belongs in local overrides or operator instructions.
-external-commander: true
+external-operator: true
 agent-slots:
   - slot-id: worker-1
     runtime-role: worker

--- a/.winsmux.yaml.example
+++ b/.winsmux.yaml.example
@@ -1,11 +1,11 @@
 # Project-level winsmux settings.
 # Default mode is external operator + managed worker slots.
-# Set legacy_role_layout: true only if you explicitly want Commander/Builder/Researcher/Reviewer panes.
+# Set legacy_role_layout: true only if you explicitly want Operator/Builder/Researcher/Reviewer panes.
 
 # Optional:
 # agent: codex
 # model: gpt-5.4
-external-commander: true
+external-operator: true
 agent-slots:
   - slot-id: worker-1
     runtime-role: worker

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -176,7 +176,7 @@ When editing or reviewing Rust, Cargo, or Tauri code in this repository:
 
 When using `/winsmux-start` or otherwise restoring orchestra-driven work from Claude Code:
 
-1. Treat `external-commander: true` as **"no commander pane is created"**, not as **"worker panes may be absent"**.
+1. Treat `external-operator: true` as **"no operator pane is created"**, not as **"worker panes may be absent"**.
 2. A session is **not ready** when the winsmux session exists but the active pane count is smaller than the expected worker count from `.winsmux.yaml` / resolved `agent_slots`.
 3. In that state, do not summarize status, propose task order, or dispatch work yet.
 4. First run the actual startup path (`winsmux-core/scripts/orchestra-start.ps1`) and verify that the pane count reaches the expected worker count.

--- a/GUARDRAILS.md
+++ b/GUARDRAILS.md
@@ -15,10 +15,10 @@
 - **Instruction**: Always include `-l` (literal mode) flag.
 - **Reason**: Without `-l`, commands silently vanish. No error, no feedback — just lost work.
 
-### 3. Commander writing code directly
-- **Trigger**: Commander tempted to "quickly fix" a file
+### 3. Operator writing code directly
+- **Trigger**: Operator tempted to "quickly fix" a file
 - **Instruction**: Dispatch all code changes to Builder panes via worktree.
-- **Reason**: sh-orchestra-gate.js enforces this. Commander is read-only; separation prevents unreviewed changes.
+- **Reason**: sh-orchestra-gate.js enforces this. Operator is read-only; separation prevents unreviewed changes.
 
 ### 4. Builder without worktree isolation
 - **Trigger**: Dispatching implementation tasks to Builder
@@ -82,5 +82,5 @@
 
 ### 16. Codex sandbox git operations
 - **Trigger**: Builder (Codex) needs to commit changes
-- **Instruction**: Builder edits only. Git operations delegated to Researcher (Sonnet) or Commander.
+- **Instruction**: Builder edits only. Git operations delegated to Researcher (Sonnet) or Operator.
 - **Reason**: Codex --sandbox danger-full-access bypasses CLM; previously --full-auto blocked .git/worktrees/*/index.lock creation.

--- a/README.ja.md
+++ b/README.ja.md
@@ -195,7 +195,7 @@ Windows の `ConstrainedLanguageMode` を含む詳細な回避策は [docs/TROUB
 
 - 管理対象ウィンドウの外に外部オペレーター用ターミナル
 - 管理対象ウィンドウの中に複数の `worker-*` ペイン
-- 旧 `Commander / Builder / Researcher / Reviewer` レイアウトは互換モードでのみ有効
+- 旧 `Operator / Builder / Researcher / Reviewer` レイアウトは互換モードでのみ有効
 
 デスクトップ側のロードマップは、次の 3 つの UX レイヤーに再整理しています。
 

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ The default layout is now:
 
 - external operator terminal outside the managed window
 - 6 managed `worker-*` panes inside the orchestra window
-- legacy `Commander / Builder / Researcher / Reviewer` pane layouts only when explicitly enabled for compatibility
+- legacy `Operator / Builder / Researcher / Reviewer` pane layouts only when explicitly enabled for compatibility
 
 This is the last release line where the terminal surface is the primary operator surface. The next train (`v0.22.0`) keeps the terminal runtime, but shifts primary desktop orchestration toward the Tauri desktop shell.
 

--- a/core/docs/faq.md
+++ b/core/docs/faq.md
@@ -22,7 +22,7 @@ A: Yes! winsmux includes a `tmux` alias. Commands like `tmux new-session`, `tmux
 A: Session creation takes < 100ms. New windows/panes add < 80ms overhead. The bottleneck is your shell's startup time, not winsmux. Compiled with opt-level 3 and full LTO.
 
 **Q: Does winsmux support mouse?**
-A: Full mouse support: click to focus panes, drag to resize borders, scroll wheel, click status-bar tabs, drag-select text, right-click copy. Plus VT mouse forwarding for TUI apps like vim, htop, and midnight commander.
+A: Full mouse support: click to focus panes, drag to resize borders, scroll wheel, click status-bar tabs, drag-select text, right-click copy. Plus VT mouse forwarding for TUI apps like vim, htop, and mc.
 
 **Q: What shells does winsmux support?**
 A: PowerShell 7 (default), PowerShell 5, cmd.exe, Git Bash, WSL, nushell, and any Windows executable. Change with `set -g default-shell <shell>`.

--- a/core/docs/features.md
+++ b/core/docs/features.md
@@ -26,7 +26,7 @@
 - **Scroll wheel** in any pane, scrolls that pane's output
 - **Drag-select** text to copy to clipboard
 - **Right-click** to paste or copy selection
-- **VT mouse forwarding** : apps like vim, htop, and midnight commander get full mouse events
+- **VT mouse forwarding** : apps like vim, htop, and mc get full mouse events
 - **3-layer mouse injection** : VT protocol, VT bridge (for WSL/SSH), and native Win32 MOUSE_EVENT
 - **Mouse over SSH** : works from any OS client when server runs Windows 11 build 22523+
 

--- a/core/tests-rs/test_parity.rs
+++ b/core/tests-rs/test_parity.rs
@@ -320,7 +320,7 @@ fn rust_parity_inbox_fixture_deserializes() {
     assert_eq!(blocked_item.branch, "worktree-worker-1");
     assert_eq!(blocked_item.head_sha, "def5678abc1234");
     assert_eq!(blocked_item.changed_file_count, 0);
-    assert_eq!(blocked_item.event, "commander.state_transition");
+    assert_eq!(blocked_item.event, "operator.state_transition");
     assert_eq!(blocked_item.timestamp, "__TIMESTAMP__");
     assert_eq!(blocked_item.source, "manifest");
 }
@@ -374,7 +374,7 @@ fn rust_parity_explain_fixture_deserializes() {
     assert_eq!(fixture.run.primary_label, "builder-1");
     assert_eq!(fixture.run.primary_pane_id, "%2");
     assert_eq!(fixture.run.primary_role, "Builder");
-    assert_eq!(fixture.run.last_event, "commander.review_requested");
+    assert_eq!(fixture.run.last_event, "operator.review_requested");
     assert_eq!(fixture.run.tokens_remaining, "64% context left");
     assert_eq!(fixture.run.pane_count, 1);
     assert_eq!(fixture.run.changed_file_count, 1);
@@ -447,7 +447,7 @@ fn rust_parity_explain_fixture_deserializes() {
     assert_eq!(fixture.explanation.current_state.review_state, "PENDING");
     assert_eq!(
         fixture.explanation.current_state.last_event,
-        "commander.review_requested"
+        "operator.review_requested"
     );
     assert!(fixture.run.security_policy.is_null());
     assert!(fixture.run.security_verdict.is_null());
@@ -466,7 +466,7 @@ fn rust_parity_explain_fixture_deserializes() {
         .find(|item| item.kind == "review_pending")
         .expect("explain fixture should contain review_pending action item");
     assert_eq!(review_pending.message, "builder-1 が review 待機中。");
-    assert_eq!(review_pending.event, "commander.review_requested");
+    assert_eq!(review_pending.event, "operator.review_requested");
     assert_eq!(review_pending.timestamp, "__TIMESTAMP__");
     assert_eq!(review_pending.source, "manifest");
     assert_eq!(fixture.consultation_packet.run_id, "task:task-256");

--- a/docs/operator-model.md
+++ b/docs/operator-model.md
@@ -124,7 +124,7 @@ Contributor workflows, release operations, repository-specific runtime contracts
 
 ## 6. Legacy layouts vs current model
 
-Older `Commander / Builder / Researcher / Reviewer` pane layouts still exist for compatibility, but they are not the long-term architecture.
+Older `Operator / Builder / Researcher / Reviewer` pane layouts still exist for compatibility, but they are not the long-term architecture.
 
 The current model is:
 

--- a/install.ps1
+++ b/install.ps1
@@ -112,7 +112,7 @@ function Install-OrchestraSupportScripts {
     Download-File "winsmux-core/scripts/agent-watchdog.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "agent-watchdog.ps1")
     Download-File "winsmux-core/scripts/builder-worktree.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "builder-worktree.ps1")
     Download-File "winsmux-core/scripts/clm-safe-io.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "clm-safe-io.ps1")
-    Download-File "winsmux-core/scripts/commander-poll.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "commander-poll.ps1")
+    Download-File "winsmux-core/scripts/operator-poll.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "operator-poll.ps1")
     Download-File "winsmux-core/scripts/doctor.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "doctor.ps1")
     Download-File "winsmux-core/scripts/logger.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "logger.ps1")
     Download-File "winsmux-core/scripts/manifest.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "manifest.ps1")
@@ -152,7 +152,7 @@ function Remove-ProfileExcludedSupportScripts {
                 "agent-watchdog.ps1",
                 "builder-worktree.ps1",
                 "clm-safe-io.ps1",
-                "commander-poll.ps1",
+                "operator-poll.ps1",
                 "doctor.ps1",
                 "logger.ps1",
                 "manifest.ps1",

--- a/scripts/generate-release-notes.ps1
+++ b/scripts/generate-release-notes.ps1
@@ -211,7 +211,7 @@ function ConvertTo-UserBenefit {
         'runtime state machine|closed-loop dispatch/review/commit|closed-loop orchestra startup' {
             return 'Established the closed-loop runtime required for dispatch -> review -> commit orchestration'
         }
-        'Direct Commander.?Reviewer review flow|direct review flow' {
+        'Direct Operator.?Reviewer review flow|direct review flow' {
             return 'Added a direct review handoff from the operator to the reviewer path'
         }
         'bootstrap invariants|bootstrap verification|cwd|WINSMUX_ROLE|pane_id mismatch|stale manifest invalidation' {
@@ -226,7 +226,7 @@ function ConvertTo-UserBenefit {
         'winsmux send silent failure|target pane.*not found|focus_pane_by_id|fail when target pane is missing' {
             return 'Stop silent success when a target pane does not exist and fail explicitly instead'
         }
-        'Monitoring stack non-functional|watchdog.?Commander delivery path missing' {
+        'Monitoring stack non-functional|watchdog.?Operator delivery path missing' {
             return 'Restored watchdog-to-operator delivery for monitoring events'
         }
         'false success|pane creation does not actually occur|detached orchestra layout reliability' {
@@ -235,7 +235,7 @@ function ConvertTo-UserBenefit {
         'Manifest convergence|split-brain schema|CLM-safe writes' {
             return 'Converged the manifest schema and unified CLM-safe write paths'
         }
-        'Commander first-class defaults|default Commander pane|commanders=1' {
+        'Operator first-class defaults|default Operator pane|operators=1' {
             return 'Clarified the default operator pane assumptions and minimum startup layout'
         }
         'defaults alignment and pane status in manifest' {
@@ -250,7 +250,7 @@ function ConvertTo-UserBenefit {
         'Guard settings\.local\.json|hook disable' {
             return 'Made dangerous hook-disable changes harder to land without an explicit approval path'
         }
-        'Commander Telegram dense notifications' {
+        'Operator Telegram dense notifications' {
             return 'Reduced noisy operator notifications and improved visibility into approvals and state changes'
         }
         'pane\.completed|PostToolUse pane monitor hook' {
@@ -503,16 +503,16 @@ if ($highlightCandidates.Count -eq 0) {
 
 $featureSource = @()
 $featureSource += @($doneTaskTitlesForVersion | Where-Object { $_ -notmatch '#\d+' })
-$featureSource += Get-MatchedCommits -Subjects $commitSubjects -Patterns @('Direct Commander.?Reviewer review flow')
+$featureSource += Get-MatchedCommits -Subjects $commitSubjects -Patterns @('Direct Operator.?Reviewer review flow')
 $featureSource += Get-MatchedCommits -Subjects $commitSubjects -Patterns @('runtime state machine', 'closed-loop orchestra startup')
 $featureSource += Get-MatchedCommits -Subjects $commitSubjects -Patterns @('bootstrap verification', 'bootstrap invariants')
-$featureSource += Get-MatchedCommits -Subjects $commitSubjects -Patterns @('Commander first-class defaults', 'defaults alignment')
+$featureSource += Get-MatchedCommits -Subjects $commitSubjects -Patterns @('Operator first-class defaults', 'defaults alignment')
 $featureSource += Get-MatchedCommits -Subjects $commitSubjects -Patterns @('first-class task and review state model', 'first-class pane state model')
 $featureSource += @($commitSubjects | Where-Object { $_ -match '^feat' })
 $fixSource = @()
 $fixSource += @($doneTaskTitlesForVersion | Where-Object { $_ -match '#\d+' })
 $fixSource += Get-MatchedCommits -Subjects $commitSubjects -Patterns @('winsmux send silent failure', 'target pane.*not found', 'fail when target pane is missing')
-$fixSource += Get-MatchedCommits -Subjects $commitSubjects -Patterns @('Monitoring stack non-functional', 'watchdog.?Commander delivery path missing')
+$fixSource += Get-MatchedCommits -Subjects $commitSubjects -Patterns @('Monitoring stack non-functional', 'watchdog.?Operator delivery path missing')
 $fixSource += Get-MatchedCommits -Subjects $commitSubjects -Patterns @('false success', 'pane creation does not actually occur', 'detached orchestra layout reliability')
 $fixSource += Get-MatchedCommits -Subjects $commitSubjects -Patterns @('Manifest convergence', 'CLM-safe writes')
 $fixSource += Get-MatchedCommits -Subjects $commitSubjects -Patterns @('native-exit handling', 'fixture temp dirs out of repo root', 'review-gate CI')
@@ -527,10 +527,10 @@ $fixSource += @(
                 'review-approve',
                 'bootstrap verification',
                 'bootstrap invariants',
-                'Direct Commander.?Reviewer review flow',
+                'Direct Operator.?Reviewer review flow',
                 'first-class task and review state model',
                 'first-class pane state model',
-                'Commander first-class defaults',
+                'Operator first-class defaults',
                 'defaults alignment'
             ))
         }
@@ -549,7 +549,7 @@ $docsSource = @(
         }
 )
 $choreSource = @()
-$choreSource += Get-MatchedCommits -Subjects $commitSubjects -Patterns @('Commander Telegram dense notifications', 'pane\.completed', 'winsmux-surface rename')
+$choreSource += Get-MatchedCommits -Subjects $commitSubjects -Patterns @('Operator Telegram dense notifications', 'pane\.completed', 'winsmux-surface rename')
 $choreSource += @(
     $commitSubjects |
         Where-Object {

--- a/scripts/start-orchestra.ps1
+++ b/scripts/start-orchestra.ps1
@@ -22,7 +22,7 @@ param(
     [int]$Rows = 2,
     [int]$Cols = 2,
     [hashtable[]]$Agents,
-    [string]$CommanderPromptFile,
+    [string]$OperatorPromptFile,
     [switch]$ShieldHarness
 )
 
@@ -492,10 +492,10 @@ for ($i = 0; $i -lt [Math]::Min($Agents.Count, $paneIds.Count); $i++) {
     pwsh $bridgePath name $paneId $label 2>$null | Out-Null
 }
 
-# --- Generate commander prompt ---
-$promptFile = $CommanderPromptFile
+# --- Generate operator prompt ---
+$promptFile = $OperatorPromptFile
 if (-not $promptFile) {
-    $promptFile = Join-Path $ProjectDir ".commander-prompt.txt"
+    $promptFile = Join-Path $ProjectDir ".operator-prompt.txt"
 }
 
 $builderLabels = ($Agents | Where-Object { $_.label -match 'builder' } | ForEach-Object { $_.label }) -join ', '
@@ -507,7 +507,7 @@ $agentRows = $Agents | ForEach-Object {
 }
 
 $promptContent = @"
-You are the COMMANDER in a winsmux Orchestra. You run directly in the user's terminal. $($Agents.Count) background agents run in winsmux panes.
+You are the Operator in a winsmux Orchestra. You run directly in the user's terminal. $($Agents.Count) background agents run in winsmux panes.
 
 ## Background Agents
 
@@ -534,7 +534,7 @@ pwsh $bridgePath read <label>
 6. Poll all agents with ``read`` to check progress. Agents cannot push to you.
 
 ## Git Operations
-Builders NEVER run git commands. Commander handles all staging, committing, and pushing sequentially.
+Builders NEVER run git commands. Operator handles all staging, committing, and pushing sequentially.
 
 ## Builder Agents
 All builder tasks must target files within the project directory. Do not instruct builders to clone, cd, or operate outside the project root.
@@ -553,7 +553,7 @@ All builder tasks must target files within the project directory. Do not instruc
 "@
 
 Set-Content -Path $promptFile -Value $promptContent -Encoding UTF8
-Write-Output "[orchestra] Commander prompt written to $promptFile"
+Write-Output "[orchestra] Operator prompt written to $promptFile"
 
 # --- Codex MCP URL quarantine (workaround: v0.117.0 "url not supported for stdio") ---
 $hasCodex = ($Agents | Where-Object { $_.adapter -eq 'codex' -or $_.command -match 'codex' }).Count -gt 0
@@ -644,7 +644,7 @@ foreach ($agent in $Agents) {
 }
 
 Write-Output ""
-Write-Output "Commander:"
+Write-Output "Operator:"
 Write-Output "  cd $ProjectDir"
 Write-Output "  claude --model claude-opus-4-6 --permission-mode bypassPermissions --append-system-prompt-file $promptFile"
 

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -4092,7 +4092,7 @@ function Get-InboxActionableEventKind {
         'pane.stalled'           { return 'stalled' }
     }
 
-    if ($eventName -eq 'commander.state_transition') {
+    if ($eventName -eq 'operator.state_transition') {
         switch ($status) {
             'blocked_no_review_target' { return 'blocked' }
             'blocked_review_failed'    { return 'review_failed' }
@@ -4107,10 +4107,10 @@ function Get-InboxActionableEventKind {
     }
 
     switch ($eventName) {
-        'commander.review_requested' { return 'review_requested' }
-        'commander.review_failed'    { return 'review_failed' }
-        'commander.blocked'          { return 'blocked' }
-        'commander.commit_ready'     { return 'commit_ready' }
+        'operator.review_requested' { return 'review_requested' }
+        'operator.review_failed'    { return 'review_failed' }
+        'operator.blocked'          { return 'blocked' }
+        'operator.commit_ready'     { return 'commit_ready' }
         'pipeline.security.blocked'  { return 'blocked' }
         'security.policy.blocked'    { return 'blocked' }
         default                      { return '' }
@@ -4164,8 +4164,8 @@ function Get-InboxEventEntityKey {
     param([Parameter(Mandatory = $true)]$EventRecord)
 
     $eventName = [string]$EventRecord['event']
-    if ($eventName -like 'commander.*') {
-        return 'commander'
+    if ($eventName -like 'operator.*') {
+        return 'operator'
     }
 
     $paneId = [string]$EventRecord['pane_id']
@@ -7025,7 +7025,7 @@ function Invoke-DispatchTask {
 
     $route = Get-DispatchRoute -Text $taskText -AvailableTargets $availableTargets -DefaultRole 'Worker'
     if ($route.HandleLocally) {
-        Stop-WithError "dispatch-task routed to Commander. Refine the task text so it can be delegated to a managed pane."
+        Stop-WithError "dispatch-task routed to Operator. Refine the task text so it can be delegated to a managed pane."
     }
 
     $selectedLabel = [string]$route.SelectedTarget
@@ -7162,7 +7162,7 @@ function Invoke-ReviewApprove {
     Save-ReviewState -ProjectDir $projectDir -State $state
     Update-ReviewPaneManifestState -ProjectDir $projectDir -Properties ([ordered]@{
         review_state = 'pass'
-        task_owner   = 'Commander'
+        task_owner   = 'Operator'
         branch       = $branch
         head_sha     = $headSha
         last_event   = 'review.pass'
@@ -7232,7 +7232,7 @@ function Invoke-ReviewFail {
     Save-ReviewState -ProjectDir $projectDir -State $state
     Update-ReviewPaneManifestState -ProjectDir $projectDir -Properties ([ordered]@{
         review_state = 'fail'
-        task_owner   = 'Commander'
+        task_owner   = 'Operator'
         branch       = $branch
         head_sha     = $headSha
         last_event   = 'review.fail'

--- a/tests/HarnessContract.Tests.ps1
+++ b/tests/HarnessContract.Tests.ps1
@@ -346,7 +346,7 @@ function Get-BridgeSettings {
     param([string]$RootPath)
     [pscustomobject]@{
         worker_count       = 6
-        external_commander = $true
+        external_operator = $true
     }
 }
 '@
@@ -395,7 +395,7 @@ function Get-BridgeSettings {
     param([string]$RootPath)
     [pscustomobject]@{
         worker_count       = 6
-        external_commander = $true
+        external_operator = $true
     }
 }
 '@

--- a/tests/Integration.GateEnforcement.Tests.ps1
+++ b/tests/Integration.GateEnforcement.Tests.ps1
@@ -363,7 +363,7 @@ EOF
         $result = & $script:InvokeOrchestraGate -ToolName 'Bash' -ToolInput ([ordered]@{
             command = 'pwsh scripts/winsmux-core.ps1 review-approve'
         }) -Environment ([ordered]@{
-            WINSMUX_ROLE = 'Commander'
+            WINSMUX_ROLE = 'Operator'
         })
 
         & $script:AssertDenyResult -Result $result
@@ -396,7 +396,7 @@ EOF
         $result = & $script:InvokeOrchestraGate -ToolName 'Bash' -ToolInput ([ordered]@{
             command = 'rg review-approve docs/'
         }) -Environment ([ordered]@{
-            WINSMUX_ROLE = 'Commander'
+            WINSMUX_ROLE = 'Operator'
         })
 
         $result.ExitCode | Should -Be 0
@@ -407,7 +407,7 @@ EOF
         $result = & $script:InvokeOrchestraGate -ToolName 'Bash' -ToolInput ([ordered]@{
             command = 'pwsh -Command "rg review-approve .claude/"'
         }) -Environment ([ordered]@{
-            WINSMUX_ROLE = 'Commander'
+            WINSMUX_ROLE = 'Operator'
         })
 
         $result.ExitCode | Should -Be 0
@@ -418,7 +418,7 @@ EOF
         $result = & $script:InvokeOrchestraGate -ToolName 'Bash' -ToolInput ([ordered]@{
             command = 'pwsh -Command "Set-Content -LiteralPath scripts/demo.ps1 -Value ''Write-Host hi''"'
         }) -Environment ([ordered]@{
-            WINSMUX_ROLE = 'Commander'
+            WINSMUX_ROLE = 'Operator'
         })
 
         & $script:AssertDenyResult -Result $result
@@ -429,7 +429,7 @@ EOF
         $result = & $script:InvokeOrchestraGate -ToolName 'Bash' -ToolInput ([ordered]@{
             command = 'cmd /c "echo Write-Host hi > scripts\\demo.ps1"'
         }) -Environment ([ordered]@{
-            WINSMUX_ROLE = 'Commander'
+            WINSMUX_ROLE = 'Operator'
         })
 
         & $script:AssertDenyResult -Result $result
@@ -440,7 +440,7 @@ EOF
         $result = & $script:InvokeOrchestraGate -ToolName 'Bash' -ToolInput ([ordered]@{
             command = 'python -c "from pathlib import Path; Path(''scripts/demo.py'').write_text(''print(1)'', encoding=''utf-8'')"'
         }) -Environment ([ordered]@{
-            WINSMUX_ROLE = 'Commander'
+            WINSMUX_ROLE = 'Operator'
         })
 
         & $script:AssertDenyResult -Result $result
@@ -559,7 +559,7 @@ EOF
         $result = & $script:InvokeOrchestraGate -ToolName 'Bash' -ToolInput @{
             command = 'psmux --version'
         } -Environment ([ordered]@{
-            WINSMUX_ROLE = 'Commander'
+            WINSMUX_ROLE = 'Operator'
         })
 
         & $script:AssertDenyResult -Result $result
@@ -570,7 +570,7 @@ EOF
         $result = & $script:InvokeOrchestraGate -ToolName 'Bash' -ToolInput @{
             command = 'pwsh -Command "Get-Process psmux-server -ErrorAction SilentlyContinue"'
         } -Environment ([ordered]@{
-            WINSMUX_ROLE = 'Commander'
+            WINSMUX_ROLE = 'Operator'
         })
 
         & $script:AssertDenyResult -Result $result
@@ -581,7 +581,7 @@ EOF
         $result = & $script:InvokeOrchestraGate -ToolName 'Bash' -ToolInput @{
             command = 'pwsh -NoProfile -File scripts/winsmux-core.ps1 orchestra-smoke --json'
         } -Environment ([ordered]@{
-            WINSMUX_ROLE = 'Commander'
+            WINSMUX_ROLE = 'Operator'
         })
 
         $result.ExitCode | Should -Be 0
@@ -592,7 +592,7 @@ EOF
         $result = & $script:InvokeOrchestraGate -ToolName 'Bash' -ToolInput @{
             command = 'pwsh -NoProfile -File scripts/winsmux-core.ps1 orchestra-attach --json'
         } -Environment ([ordered]@{
-            WINSMUX_ROLE = 'Commander'
+            WINSMUX_ROLE = 'Operator'
         })
 
         $result.ExitCode | Should -Be 0

--- a/tests/Integration.MultiAgent.Tests.ps1
+++ b/tests/Integration.MultiAgent.Tests.ps1
@@ -10,7 +10,7 @@ Describe 'orchestra cleanup helpers' {
         (Test-OrchestraManagedPaneTitle -Title 'worker-1') | Should -Be $true
         (Test-OrchestraManagedPaneTitle -Title 'researcher-2') | Should -Be $true
         (Test-OrchestraManagedPaneTitle -Title 'Reviewer-3') | Should -Be $true
-        (Test-OrchestraManagedPaneTitle -Title 'Commander') | Should -Be $false
+        (Test-OrchestraManagedPaneTitle -Title 'Operator') | Should -Be $false
         (Test-OrchestraManagedPaneTitle -Title 'PowerShell') | Should -Be $false
     }
 
@@ -58,9 +58,9 @@ Describe 'Get-BridgeSettings defaults' {
 
         $settings.agent | Should -Be 'codex'
         $settings.model | Should -Be 'gpt-5.4'
-        $settings.external_commander | Should -Be $true
+        $settings.external_operator | Should -Be $true
         $settings.legacy_role_layout | Should -Be $false
-        $settings.commanders | Should -Be 0
+        $settings.operators | Should -Be 0
         $settings.worker_count | Should -Be 6
         $settings.builders | Should -Be 0
         $settings.researchers | Should -Be 0
@@ -113,9 +113,9 @@ Describe 'Get-RoleAgentConfig with fallback' {
         $reviewerConfig.Agent | Should -Be 'claude'
         $reviewerConfig.Model | Should -Be 'gpt-5.4'
 
-        $commanderConfig = Get-RoleAgentConfig -Role 'Commander' -Settings $settings
-        $commanderConfig.Agent | Should -Be 'codex'
-        $commanderConfig.Model | Should -Be 'gpt-5.4'
+        $operatorConfig = Get-RoleAgentConfig -Role 'Operator' -Settings $settings
+        $operatorConfig.Agent | Should -Be 'codex'
+        $operatorConfig.Model | Should -Be 'gpt-5.4'
     }
 }
 
@@ -409,7 +409,7 @@ Describe 'orchestra state model' {
                 branch             = 'codex/task-243'
                 head_sha           = 'abcdef1234567'
                 changed_file_count = 2
-                changed_files      = @('winsmux-core/scripts/commander-poll.ps1', 'scripts/winsmux-core.ps1')
+                changed_files      = @('winsmux-core/scripts/operator-poll.ps1', 'scripts/winsmux-core.ps1')
             }
         }
 
@@ -424,7 +424,7 @@ Describe 'orchestra state model' {
         $builderModel.branch | Should -Be 'codex/task-243'
         $builderModel.head_sha | Should -Be 'abcdef1234567'
         $builderModel.changed_file_count | Should -Be 2
-        $builderModel.changed_files | Should -Be @('winsmux-core/scripts/commander-poll.ps1', 'scripts/winsmux-core.ps1')
+        $builderModel.changed_files | Should -Be @('winsmux-core/scripts/operator-poll.ps1', 'scripts/winsmux-core.ps1')
 
         $saved = Get-WinsmuxManifest -ProjectDir $script:orchestraStateTempRoot
         $saved.panes['builder-1'].task_id | Should -Be 'task-243'
@@ -433,7 +433,7 @@ Describe 'orchestra state model' {
         $saved.panes['builder-1'].branch | Should -Be 'codex/task-243'
         $saved.panes['builder-1'].head_sha | Should -Be 'abcdef1234567'
         $saved.panes['builder-1'].changed_file_count | Should -Be '2'
-        $saved.panes['builder-1'].changed_files | Should -Be @('winsmux-core/scripts/commander-poll.ps1', 'scripts/winsmux-core.ps1')
+        $saved.panes['builder-1'].changed_files | Should -Be @('winsmux-core/scripts/operator-poll.ps1', 'scripts/winsmux-core.ps1')
     }
 
     It 'embeds first-class task, git, and review state in emitted event payloads' {
@@ -531,7 +531,7 @@ Describe 'agent monitor idle alerts' {
         $script:agentMonitorIdleStateDir = Join-Path $script:agentMonitorTempRoot 'idle'
         New-Item -ItemType Directory -Path $script:agentMonitorTempRoot -Force | Out-Null
         $script:IdleStateDir = $script:agentMonitorIdleStateDir
-        Mock Send-MonitorCommanderMailboxMessage { return $true }
+        Mock Send-MonitorOperatorMailboxMessage { return $true }
     }
 
     AfterEach {
@@ -548,7 +548,7 @@ Describe 'agent monitor idle alerts' {
 
         $alert = Update-MonitorIdleAlertState -PaneId '%2' -Label 'builder-1' -Role 'Builder' -Status 'ready' -SnapshotTail '> ' -IdleThresholdSeconds 120 -Now $start.AddSeconds(121)
         $alert.ShouldAlert | Should -Be $true
-        $alert.Message | Should -Match 'Commander alert: idle pane builder-1 \(%2, role=Builder\)'
+        $alert.Message | Should -Match 'Operator alert: idle pane builder-1 \(%2, role=Builder\)'
 
         $repeat = Update-MonitorIdleAlertState -PaneId '%2' -Label 'builder-1' -Role 'Builder' -Status 'ready' -SnapshotTail '> ' -IdleThresholdSeconds 120 -Now $start.AddSeconds(240)
         $repeat.ShouldAlert | Should -Be $false
@@ -564,7 +564,7 @@ Describe 'agent monitor idle alerts' {
         $stateAfterBusy | Should -BeNullOrEmpty
     }
 
-    It 'emits commander alerts to stdout and monitor events during a monitor cycle' {
+    It 'emits operator alerts to stdout and monitor events during a monitor cycle' {
         $manifestDir = Join-Path $script:agentMonitorTempRoot '.winsmux'
         New-Item -ItemType Directory -Path $manifestDir -Force | Out-Null
         @"
@@ -603,17 +603,17 @@ panes:
         $output = @(Invoke-AgentMonitorCycle -Settings $settings -ManifestPath (Join-Path $manifestDir 'manifest.yaml') -SessionName 'winsmux-orchestra' -IdleThreshold 120)
 
         $output.Count | Should -Be 2
-        $output[0] | Should -Match 'Commander alert: idle pane builder-1 \(%2, role=Builder\)'
+        $output[0] | Should -Match 'Operator alert: idle pane builder-1 \(%2, role=Builder\)'
         $output[1].IdleAlerts | Should -Be 1
         $output[1].Results[0].IdleAlerted | Should -Be $true
-        $output[1].Results[0].Message | Should -Match 'Commander alert: idle pane builder-1'
+        $output[1].Results[0].Message | Should -Match 'Operator alert: idle pane builder-1'
         Should -Invoke Write-MonitorEvent -Times 1 -Exactly -ParameterFilter {
             $Event -eq 'pane.idle' -and
             $PaneId -eq '%2' -and
             $Role -eq 'Builder' -and
-            $Message -match 'Commander alert: idle pane builder-1'
+            $Message -match 'Operator alert: idle pane builder-1'
         }
-        Should -Invoke Send-MonitorCommanderMailboxMessage -Times 1 -Exactly -ParameterFilter {
+        Should -Invoke Send-MonitorOperatorMailboxMessage -Times 1 -Exactly -ParameterFilter {
             $Event -eq 'pane.idle' -and
             $Label -eq 'builder-1' -and
             $PaneId -eq '%2'
@@ -661,7 +661,7 @@ panes:
         $output = @(Invoke-AgentMonitorCycle -Settings $settings -ManifestPath $manifestPath -SessionName 'winsmux-orchestra' -IdleThreshold 120)
 
         $output.Count | Should -Be 2
-        $output[0] | Should -Match 'Commander alert: idle pane builder-1 \(%2, role=Builder\)'
+        $output[0] | Should -Match 'Operator alert: idle pane builder-1 \(%2, role=Builder\)'
         $output[1].IdleAlerts | Should -Be 1
         $output[1].Results[0].Label | Should -Be 'builder-1'
         Should -Invoke Write-MonitorEvent -Times 1 -Exactly -ParameterFilter {
@@ -711,10 +711,10 @@ panes:
         $output = @(Invoke-AgentMonitorCycle -Settings $settings -ManifestPath (Join-Path $manifestDir 'manifest.yaml') -SessionName 'winsmux-orchestra' -IdleThreshold 120)
 
         $output.Count | Should -Be 2
-        $output[0] | Should -Be 'Commander alert: builder-1 (%2) awaiting approval'
+        $output[0] | Should -Be 'Operator alert: builder-1 (%2) awaiting approval'
         $output[1].ApprovalWaiting | Should -Be 1
         $output[1].Results[0].Status | Should -Be 'approval_waiting'
-        $output[1].Results[0].Message | Should -Be 'Commander alert: builder-1 (%2) awaiting approval'
+        $output[1].Results[0].Message | Should -Be 'Operator alert: builder-1 (%2) awaiting approval'
         Should -Invoke Write-MonitorEvent -Times 1 -Exactly -ParameterFilter {
             $Event -eq 'pane.approval_waiting' -and
             $PaneId -eq '%2' -and
@@ -784,7 +784,7 @@ panes:
         }
     }
 
-    It 'emits commander alerts when a Builder stays busy with the same snapshot for three cycles' {
+    It 'emits operator alerts when a Builder stays busy with the same snapshot for three cycles' {
         $script:BuilderStallHistory = @{}
         $manifestDir = Join-Path $script:agentMonitorTempRoot '.winsmux'
         New-Item -ItemType Directory -Path $manifestDir -Force | Out-Null
@@ -827,15 +827,15 @@ panes:
         $output = @(Invoke-AgentMonitorCycle -Settings $settings -ManifestPath (Join-Path $manifestDir 'manifest.yaml') -SessionName 'winsmux-orchestra' -IdleThreshold 120)
 
         $output.Count | Should -Be 2
-        $output[0] | Should -Match 'Commander alert: stalled Builder pane builder-1 \(%2\)'
+        $output[0] | Should -Match 'Operator alert: stalled Builder pane builder-1 \(%2\)'
         $output[1].Stalls | Should -Be 1
         $output[1].Results[0].StallDetected | Should -Be $true
-        $output[1].Results[0].Message | Should -Match 'Commander alert: stalled Builder pane builder-1'
+        $output[1].Results[0].Message | Should -Match 'Operator alert: stalled Builder pane builder-1'
         Should -Invoke Write-MonitorEvent -Times 1 -Exactly -ParameterFilter {
             $Event -eq 'pane.stalled' -and
             $PaneId -eq '%2' -and
             $Role -eq 'Builder' -and
-            $Message -match 'Commander alert: stalled Builder pane builder-1'
+            $Message -match 'Operator alert: stalled Builder pane builder-1'
         }
     }
 

--- a/tests/PublicSurfacePolicy.Tests.ps1
+++ b/tests/PublicSurfacePolicy.Tests.ps1
@@ -136,7 +136,7 @@ Describe 'Public surface policy' {
         $installer | Should -Match 'winsmux-core/scripts/doctor\.ps1'
         $installer | Should -Match 'winsmux-core/scripts/orchestra-attach-confirm\.ps1'
         $installer | Should -Match 'winsmux-core/scripts/orchestra-pane-bootstrap\.ps1'
-        $installer | Should -Match 'winsmux-core/scripts/commander-poll\.ps1'
+        $installer | Should -Match 'winsmux-core/scripts/operator-poll\.ps1'
         $installer | Should -Match 'winsmux-core/scripts/pane-control\.ps1'
         $installer | Should -Match 'winsmux-core/scripts/agent-monitor\.ps1'
         $installer | Should -Match 'winsmux-core/scripts/agent-watchdog\.ps1'

--- a/tests/fixtures/rust-parity/digest.json
+++ b/tests/fixtures/rust-parity/digest.json
@@ -29,7 +29,7 @@
         "scripts/winsmux-core.ps1"
       ],
       "action_item_count": 3,
-      "last_event": "commander.review_failed",
+      "last_event": "operator.review_failed",
       "last_event_at": "__LAST_EVENT_AT__",
       "verification_outcome": "",
       "security_blocked": "",

--- a/tests/fixtures/rust-parity/explain.json
+++ b/tests/fixtures/rust-parity/explain.json
@@ -15,7 +15,7 @@
     "primary_role": "Builder",
     "state": "idle",
     "tokens_remaining": "64% context left",
-    "last_event": "commander.review_requested",
+    "last_event": "operator.review_requested",
     "last_event_at": "__LAST_EVENT_AT__",
     "pane_count": 1,
     "changed_file_count": 1,
@@ -35,14 +35,14 @@
       {
         "kind": "review_pending",
         "message": "builder-1 が review 待機中。",
-        "event": "commander.review_requested",
+        "event": "operator.review_requested",
         "timestamp": "__TIMESTAMP__",
         "source": "manifest"
       },
       {
         "kind": "review_requested",
         "message": "review requested",
-        "event": "commander.review_requested",
+        "event": "operator.review_requested",
         "timestamp": "__TIMESTAMP__",
         "source": "events"
       }
@@ -149,7 +149,7 @@
       "scripts/winsmux-core.ps1"
     ],
     "action_item_count": 2,
-    "last_event": "commander.review_requested",
+    "last_event": "operator.review_requested",
     "last_event_at": "__LAST_EVENT_AT__",
     "verification_outcome": "",
     "security_blocked": "",
@@ -163,7 +163,7 @@
     "reasons": [
       "task_state=in_progress",
       "review_state=PENDING",
-      "last_event=commander.review_requested",
+      "last_event=operator.review_requested",
       "action:review_pending",
       "action:review_requested"
     ],
@@ -172,7 +172,7 @@
       "state": "idle",
       "task_state": "in_progress",
       "review_state": "PENDING",
-      "last_event": "commander.review_requested"
+      "last_event": "operator.review_requested"
     }
   },
   "review_state": null,
@@ -246,7 +246,7 @@
     {
       "line_number": 1,
       "timestamp": "__TIMESTAMP__",
-      "event": "commander.review_requested",
+      "event": "operator.review_requested",
       "status": "",
       "message": "review requested",
       "label": "reviewer-1",

--- a/tests/fixtures/rust-parity/inbox.json
+++ b/tests/fixtures/rust-parity/inbox.json
@@ -25,7 +25,7 @@
       "branch": "worktree-worker-1",
       "head_sha": "def5678abc1234",
       "changed_file_count": 0,
-      "event": "commander.state_transition",
+      "event": "operator.state_transition",
       "timestamp": "__TIMESTAMP__",
       "source": "manifest"
     },
@@ -71,7 +71,7 @@
       "message": "コミット準備完了。",
       "label": "",
       "pane_id": "",
-      "role": "Commander",
+      "role": "Operator",
       "task_id": "",
       "task": "",
       "task_state": "",

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -93,7 +93,7 @@ Describe 'Assert-Role' {
         $labelsPath = Join-Path $tempRoot 'labels.json'
         @{
             self       = 'pane-self'
-            commander  = 'pane-commander'
+            operator  = 'pane-operator'
             builder    = 'pane-builder'
             worker     = 'pane-worker'
             researcher = 'pane-researcher'
@@ -103,7 +103,7 @@ Describe 'Assert-Role' {
         $script:roleGateTempRoot = $tempRoot
         $script:RoleGateLabelsFile = $labelsPath
         $env:WINSMUX_PANE_ID = 'pane-self'
-        $env:WINSMUX_ROLE_MAP = '{"pane-self":"Commander","pane-commander":"Commander","pane-builder":"Builder","pane-worker":"Worker","pane-researcher":"Researcher","pane-reviewer":"Reviewer"}'
+        $env:WINSMUX_ROLE_MAP = '{"pane-self":"Operator","pane-operator":"Operator","pane-builder":"Builder","pane-worker":"Worker","pane-researcher":"Researcher","pane-reviewer":"Reviewer"}'
     }
 
     AfterEach {
@@ -117,8 +117,8 @@ Describe 'Assert-Role' {
         }
     }
 
-    It 'allows Commander to send anywhere and denies typing into another pane' {
-        $env:WINSMUX_ROLE = 'Commander'
+    It 'allows Operator to send anywhere and denies typing into another pane' {
+        $env:WINSMUX_ROLE = 'Operator'
 
         (Assert-Role -Command 'send' -TargetPane 'reviewer') | Should -Be $true
         (Assert-Role -Command 'status') | Should -Be $true
@@ -134,11 +134,11 @@ Describe 'Assert-Role' {
         (Assert-Role -Command 'type' -TargetPane 'reviewer') | Should -Be $false
     }
 
-    It 'allows Builder to message Commander and denies sending to peers' {
+    It 'allows Builder to message Operator and denies sending to peers' {
         $env:WINSMUX_ROLE = 'Builder'
-        $env:WINSMUX_ROLE_MAP = '{"pane-self":"Builder","pane-commander":"Commander","pane-builder":"Builder","pane-researcher":"Researcher","pane-reviewer":"Reviewer"}'
+        $env:WINSMUX_ROLE_MAP = '{"pane-self":"Builder","pane-operator":"Operator","pane-builder":"Builder","pane-researcher":"Researcher","pane-reviewer":"Reviewer"}'
 
-        (Assert-Role -Command 'send' -TargetPane 'commander') | Should -Be $true
+        (Assert-Role -Command 'send' -TargetPane 'operator') | Should -Be $true
         (Assert-Role -Command 'status') | Should -Be $true
         (Assert-Role -Command 'board') | Should -Be $true
         (Assert-Role -Command 'inbox') | Should -Be $true
@@ -147,16 +147,16 @@ Describe 'Assert-Role' {
         (Assert-Role -Command 'explain') | Should -Be $true
         (Assert-Role -Command 'consult-result') | Should -Be $true
         (Assert-Role -Command 'type' -TargetPane 'self') | Should -Be $true
-        (Assert-Role -Command 'context-reset' -TargetPane 'commander') | Should -Be $false
+        (Assert-Role -Command 'context-reset' -TargetPane 'operator') | Should -Be $false
         (Assert-Role -Command 'send' -TargetPane 'reviewer') | Should -Be $false
         (Assert-Role -Command 'read' -TargetPane 'reviewer') | Should -Be $false
     }
 
-    It 'allows Researcher to message Commander and denies orchestration commands' {
+    It 'allows Researcher to message Operator and denies orchestration commands' {
         $env:WINSMUX_ROLE = 'Researcher'
-        $env:WINSMUX_ROLE_MAP = '{"pane-self":"Researcher","pane-commander":"Commander","pane-builder":"Builder","pane-researcher":"Researcher","pane-reviewer":"Reviewer"}'
+        $env:WINSMUX_ROLE_MAP = '{"pane-self":"Researcher","pane-operator":"Operator","pane-builder":"Builder","pane-researcher":"Researcher","pane-reviewer":"Reviewer"}'
 
-        (Assert-Role -Command 'message' -TargetPane 'commander') | Should -Be $true
+        (Assert-Role -Command 'message' -TargetPane 'operator') | Should -Be $true
         (Assert-Role -Command 'read' -TargetPane 'self') | Should -Be $true
         (Assert-Role -Command 'digest') | Should -Be $true
         (Assert-Role -Command 'consult-error') | Should -Be $true
@@ -165,11 +165,11 @@ Describe 'Assert-Role' {
         (Assert-Role -Command 'wait') | Should -Be $false
     }
 
-    It 'allows Reviewer to message Commander and denies privileged commands' {
+    It 'allows Reviewer to message Operator and denies privileged commands' {
         $env:WINSMUX_ROLE = 'Reviewer'
-        $env:WINSMUX_ROLE_MAP = '{"pane-self":"Reviewer","pane-commander":"Commander","pane-builder":"Builder","pane-worker":"Worker","pane-researcher":"Researcher","pane-reviewer":"Reviewer"}'
+        $env:WINSMUX_ROLE_MAP = '{"pane-self":"Reviewer","pane-operator":"Operator","pane-builder":"Builder","pane-worker":"Worker","pane-researcher":"Researcher","pane-reviewer":"Reviewer"}'
 
-        (Assert-Role -Command 'message' -TargetPane 'commander') | Should -Be $true
+        (Assert-Role -Command 'message' -TargetPane 'operator') | Should -Be $true
         (Assert-Role -Command 'review-request') | Should -Be $true
         (Assert-Role -Command 'review-approve') | Should -Be $true
         (Assert-Role -Command 'consult-result') | Should -Be $true
@@ -182,9 +182,9 @@ Describe 'Assert-Role' {
 
     It 'allows Worker to act as a review-capable pane while staying non-privileged' {
         $env:WINSMUX_ROLE = 'Worker'
-        $env:WINSMUX_ROLE_MAP = '{"pane-self":"Worker","pane-commander":"Commander","pane-builder":"Builder","pane-worker":"Worker","pane-researcher":"Researcher","pane-reviewer":"Reviewer"}'
+        $env:WINSMUX_ROLE_MAP = '{"pane-self":"Worker","pane-operator":"Operator","pane-builder":"Builder","pane-worker":"Worker","pane-researcher":"Researcher","pane-reviewer":"Reviewer"}'
 
-        (Assert-Role -Command 'message' -TargetPane 'commander') | Should -Be $true
+        (Assert-Role -Command 'message' -TargetPane 'operator') | Should -Be $true
         (Assert-Role -Command 'review-request') | Should -Be $true
         (Assert-Role -Command 'review-approve') | Should -Be $true
         (Assert-Role -Command 'review-fail') | Should -Be $true
@@ -196,7 +196,7 @@ Describe 'Assert-Role' {
 
     It 'denies review approval commands outside Reviewer role' {
         $env:WINSMUX_ROLE = 'Builder'
-        $env:WINSMUX_ROLE_MAP = '{"pane-self":"Builder","pane-commander":"Commander","pane-builder":"Builder","pane-researcher":"Researcher","pane-reviewer":"Reviewer"}'
+        $env:WINSMUX_ROLE_MAP = '{"pane-self":"Builder","pane-operator":"Operator","pane-builder":"Builder","pane-researcher":"Researcher","pane-reviewer":"Reviewer"}'
 
         (Assert-Role -Command 'review-request') | Should -Be $false
         (Assert-Role -Command 'review-approve') | Should -Be $false
@@ -244,9 +244,9 @@ Describe 'Get-BridgeSettings' {
         $settings.model | Should -Be 'gpt-5.4'
         $settings.config_version | Should -Be 1
         $settings.prompt_transport | Should -Be 'argv'
-        $settings.external_commander | Should -Be $true
+        $settings.external_operator | Should -Be $true
         $settings.legacy_role_layout | Should -Be $false
-        $settings.commanders | Should -Be 0
+        $settings.operators | Should -Be 0
         $settings.worker_count | Should -Be 6
         $settings.agent_slots.Count | Should -Be 6
         $settings.agent_slots[0].slot_id | Should -Be 'worker-1'
@@ -262,7 +262,7 @@ Describe 'Get-BridgeSettings' {
 @'
 agent: claude
 reviewers: 3
-external-commander: false
+external-operator: false
 legacy-role-layout: true
 vault-keys:
   - GH_TOKEN
@@ -276,7 +276,7 @@ terminal: tab
             switch ($Name) {
                 '@bridge-agent' { 'gemini' }
                 '@bridge-model' { 'gpt-5.5-mini' }
-                '@bridge-external-commander' { 'on' }
+                '@bridge-external-operator' { 'on' }
                 '@bridge-worker-count' { '9' }
                 '@bridge-builders' { '7' }
                 '@bridge-researchers' { '2' }
@@ -291,7 +291,7 @@ terminal: tab
 
         $settings.agent | Should -Be 'claude'
         $settings.model | Should -Be 'gpt-5.5-mini'
-        $settings.external_commander | Should -Be $false
+        $settings.external_operator | Should -Be $false
         $settings.legacy_role_layout | Should -Be $true
         $settings.worker_count | Should -Be 9
         $settings.builders | Should -Be 7
@@ -305,7 +305,7 @@ terminal: tab
 @'
 agent: codex
 model: gpt-5.4
-external-commander: true
+external-operator: true
 agent-slots:
   - slot-id: worker-1
     runtime-role: worker
@@ -371,9 +371,9 @@ roles:
         $reviewerConfig.Agent | Should -Be 'codex'
         $reviewerConfig.Model | Should -Be 'gpt-5.4'
 
-        $commanderConfig = Get-RoleAgentConfig -Role 'Commander' -Settings $settings
-        $commanderConfig.Agent | Should -Be 'codex'
-        $commanderConfig.Model | Should -Be 'gpt-5.4'
+        $operatorConfig = Get-RoleAgentConfig -Role 'Operator' -Settings $settings
+        $operatorConfig.Agent | Should -Be 'codex'
+        $operatorConfig.Model | Should -Be 'gpt-5.4'
     }
 
     It 'parses per-role and slot-level prompt transport overrides with the same precedence as agent/model' {
@@ -484,6 +484,33 @@ prompt-transport: socket
         $settings = Get-BridgeSettings
 
         $settings.prompt_transport | Should -Be 'argv'
+    }
+
+    It 'rejects retired operator role keys from project settings' {
+        $retiredExternalKey = 'external-' + 'comm' + 'ander'
+        $settingsPath = Join-Path $script:settingsTempRoot '.winsmux.yaml'
+@"
+${retiredExternalKey}: false
+"@ | Set-Content -Path $settingsPath -Encoding UTF8
+
+        Mock Get-WinsmuxOption { param($Name, $Default) return $null }
+
+        { Get-BridgeSettings } | Should -Throw '*Retired runtime role setting*external*'
+    }
+
+    It 'rejects retired operator role options from global settings' {
+        $retiredOption = '@bridge-external-' + 'comm' + 'ander'
+        Mock Get-WinsmuxOption {
+            param($Name, $Default)
+
+            if ($Name -eq $retiredOption) {
+                return 'false'
+            }
+
+            return $null
+        }
+
+        { Get-BridgeSettings } | Should -Throw '*Retired runtime role option*'
     }
 
     It 'ignores server-not-running probe text during raw global settings normalization' {
@@ -1089,7 +1116,7 @@ agent-slots:
 @'
 agent: codex
 model: gpt-5.4
-external-commander: true
+external-operator: true
 agent-slots:
   - runtime-role: worker
     agent: codex
@@ -1104,7 +1131,7 @@ agent-slots:
 @'
 agent: codex
 model: gpt-5.4
-external-commander: true
+external-operator: true
 agent-slots:
   - slot-id: worker-1
     runtime-role: worker
@@ -1125,7 +1152,7 @@ agent-slots:
 @'
 agent: codex
 model: gpt-5.4
-external-commander: true
+external-operator: true
 builders: 4
 reviewers: 1
 '@ | Set-Content -Path (Join-Path $script:settingsTempRoot '.winsmux.yaml') -Encoding UTF8
@@ -1144,7 +1171,7 @@ reviewers: 1
 @'
 agent: claude
 model: sonnet
-external-commander: true
+external-operator: true
 agent-slots:
   - slot-id: worker-1
     runtime-role: worker
@@ -1172,20 +1199,20 @@ Describe 'Get-OrchestraLayoutSettings' {
         . (Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\orchestra-start.ps1')
     }
 
-    It 'uses external commander mode by default' {
+    It 'uses external operator mode by default' {
         $layout = Get-OrchestraLayoutSettings -Settings ([ordered]@{
-            external_commander = $true
+            external_operator = $true
             worker_count       = 6
             legacy_role_layout = $false
-            commanders         = 0
+            operators         = 0
             builders           = 0
             researchers        = 0
             reviewers          = 0
         })
 
-        $layout.ExternalCommander | Should -Be $true
+        $layout.ExternalOperator | Should -Be $true
         $layout.LegacyRoleLayout | Should -Be $false
-        $layout.Commanders | Should -Be 0
+        $layout.Operators | Should -Be 0
         $layout.Workers | Should -Be 6
         $layout.Builders | Should -Be 0
         $layout.Researchers | Should -Be 0
@@ -1194,7 +1221,7 @@ Describe 'Get-OrchestraLayoutSettings' {
 
     It 'prefers explicit agent slots over worker_count when deriving managed slot count' {
         $layout = Get-OrchestraLayoutSettings -Settings ([ordered]@{
-            external_commander = $true
+            external_operator = $true
             worker_count       = 2
             agent_slots        = @(
                 [ordered]@{ slot_id = 'worker-1'; runtime_role = 'worker'; agent = 'codex'; model = 'gpt-5.4'; worktree_mode = 'managed' },
@@ -1204,21 +1231,21 @@ Describe 'Get-OrchestraLayoutSettings' {
             agent             = 'codex'
             model             = 'gpt-5.4'
             legacy_role_layout = $false
-            commanders         = 0
+            operators         = 0
             builders           = 0
             researchers        = 0
             reviewers          = 0
         })
 
-        $layout.ExternalCommander | Should -Be $true
+        $layout.ExternalOperator | Should -Be $true
         $layout.LegacyRoleLayout | Should -Be $false
-        $layout.Commanders | Should -Be 0
+        $layout.Operators | Should -Be 0
         $layout.Workers | Should -Be 3
     }
 
     It 'allows agent slots without agent or model fields under strict mode' {
         $layout = Get-OrchestraLayoutSettings -Settings ([ordered]@{
-            external_commander = $true
+            external_operator = $true
             worker_count       = 1
             agent_slots        = @(
                 [pscustomobject]@{
@@ -1233,22 +1260,22 @@ Describe 'Get-OrchestraLayoutSettings' {
                 }
             )
             legacy_role_layout = $false
-            commanders         = 0
+            operators         = 0
             builders           = 0
             researchers        = 0
             reviewers          = 0
         })
 
-        $layout.ExternalCommander | Should -Be $true
+        $layout.ExternalOperator | Should -Be $true
         $layout.LegacyRoleLayout | Should -Be $false
-        $layout.Commanders | Should -Be 0
+        $layout.Operators | Should -Be 0
         $layout.Workers | Should -Be 2
     }
 
     It 'rejects unsupported non-worker runtime_role overrides until slot runtime wiring expands' {
         {
             Get-OrchestraLayoutSettings -Settings ([ordered]@{
-                external_commander = $true
+                external_operator = $true
                 worker_count       = 2
                 agent_slots        = @(
                     [ordered]@{ slot_id = 'worker-1'; runtime_role = 'worker'; agent = 'codex'; model = 'gpt-5.4'; worktree_mode = 'managed' },
@@ -1257,7 +1284,7 @@ Describe 'Get-OrchestraLayoutSettings' {
                 agent              = 'codex'
                 model              = 'gpt-5.4'
                 legacy_role_layout = $false
-                commanders         = 0
+                operators         = 0
                 builders           = 0
                 researchers        = 0
                 reviewers          = 0
@@ -1272,7 +1299,7 @@ Describe 'Get-OrchestraLayoutSettings' {
         Save-BridgeSettings -Scope project -RootPath $projectRoot -Settings ([ordered]@{
             agent              = 'codex'
             model              = 'gpt-5.4'
-            external_commander = $true
+            external_operator = $true
             worker_count       = 2
             agent_slots        = @(
                 [ordered]@{ slot_id = 'worker-1'; runtime_role = 'worker'; agent = 'codex'; model = 'gpt-5.4'; worktree_mode = 'managed' },
@@ -1290,18 +1317,18 @@ Describe 'Get-OrchestraLayoutSettings' {
 
     It 'preserves legacy role layouts only when explicit opt-in is enabled' {
         $layout = Get-OrchestraLayoutSettings -Settings ([ordered]@{
-            external_commander = $false
+            external_operator = $false
             worker_count       = 0
             legacy_role_layout = $true
-            commanders         = 1
+            operators         = 1
             builders           = 4
             researchers        = 1
             reviewers          = 1
         })
 
-        $layout.ExternalCommander | Should -Be $false
+        $layout.ExternalOperator | Should -Be $false
         $layout.LegacyRoleLayout | Should -Be $true
-        $layout.Commanders | Should -Be 1
+        $layout.Operators | Should -Be 1
         $layout.Workers | Should -Be 0
         $layout.Builders | Should -Be 4
         $layout.Researchers | Should -Be 1
@@ -1311,10 +1338,10 @@ Describe 'Get-OrchestraLayoutSettings' {
     It 'rejects implicit legacy role counts when legacy_role_layout is false' {
         {
             Get-OrchestraLayoutSettings -Settings ([ordered]@{
-                external_commander = $true
+                external_operator = $true
                 worker_count       = 6
                 legacy_role_layout = $false
-                commanders         = 0
+                operators         = 0
                 builders           = 4
                 researchers        = 1
                 reviewers          = 1
@@ -1934,10 +1961,10 @@ hook_profile: builder
 mode: core
 hook_profile: ci
 '@ | Set-Content -Path (Join-Path $script:paneEnvTempRoot '.winsmux\governance.yaml') -Encoding UTF8
-        $env:WINSMUX_HOOK_PROFILE = 'commander'
+        $env:WINSMUX_HOOK_PROFILE = 'operator'
         $env:WINSMUX_GOVERNANCE_MODE = 'standard'
 
-        (Resolve-WinsmuxHookProfile -ProjectDir $script:paneEnvTempRoot) | Should -Be 'commander'
+        (Resolve-WinsmuxHookProfile -ProjectDir $script:paneEnvTempRoot) | Should -Be 'operator'
         (Resolve-WinsmuxGovernanceMode -ProjectDir $script:paneEnvTempRoot) | Should -Be 'standard'
     }
 
@@ -2499,7 +2526,7 @@ Describe 'agent-monitor helpers' {
     }
 
     BeforeEach {
-        Mock Send-MonitorCommanderMailboxMessage { return $true }
+        Mock Send-MonitorOperatorMailboxMessage { return $true }
     }
 
     It 'treats Codex context exhaustion followed by a PowerShell prompt as a crash reason' {
@@ -3273,7 +3300,7 @@ panes:
                 if ($PaneId -eq '%2') {
                     return [ordered]@{
                         ShouldAlert = $true
-                        Message     = 'Commander alert: idle pane builder-1 (%2, role=Builder)'
+                        Message     = 'Operator alert: idle pane builder-1 (%2, role=Builder)'
                     }
                 }
 
@@ -4024,18 +4051,18 @@ Describe 'orchestra-start watchdog contract' {
         $script:orchestraStartContent = Get-Content -Path $script:orchestraStartPath -Raw -Encoding UTF8
     }
 
-    It 'launches commander-poll with Start-Process before the watchdog' {
-        $script:orchestraStartContent | Should -Match 'function Start-CommanderPollJob \{'
-        $script:orchestraStartContent | Should -Match 'commander-poll\.ps1'
+    It 'launches operator-poll with Start-Process before the watchdog' {
+        $script:orchestraStartContent | Should -Match 'function Start-OperatorPollJob \{'
+        $script:orchestraStartContent | Should -Match 'operator-poll\.ps1'
         $script:orchestraStartContent | Should -Match "'-Interval'"
         $script:orchestraStartContent | Should -Match '-Interval 20'
-        $script:orchestraStartContent | Should -Match '-CommanderPollPid \$commanderPollProcess\.Id'
+        $script:orchestraStartContent | Should -Match '-OperatorPollPid \$operatorPollProcess\.Id'
 
-        $commanderPollIndex = $script:orchestraStartContent.IndexOf('$commanderPollProcess = Start-CommanderPollJob')
+        $operatorPollIndex = $script:orchestraStartContent.IndexOf('$operatorPollProcess = Start-OperatorPollJob')
         $watchdogIndex = $script:orchestraStartContent.IndexOf('$watchdogProcess = Start-AgentWatchdogJob')
-        $commanderPollIndex | Should -BeGreaterThan -1
+        $operatorPollIndex | Should -BeGreaterThan -1
         $watchdogIndex | Should -BeGreaterThan -1
-        $commanderPollIndex | Should -BeLessThan $watchdogIndex
+        $operatorPollIndex | Should -BeLessThan $watchdogIndex
     }
 
     It 'launches the watchdog with Start-Process so it survives script exit' {
@@ -4049,8 +4076,8 @@ Describe 'orchestra-start watchdog contract' {
     }
 
     It 'persists both process pids and prints cleanup guidance' {
-        $script:orchestraStartContent | Should -Match 'commander_poll_pid\s*=\s*\$CommanderPollPid'
-        $script:orchestraStartContent | Should -Match 'Commander Poll PID: \$\(\$commanderPollProcess\.Id\)'
+        $script:orchestraStartContent | Should -Match 'operator_poll_pid\s*=\s*\$OperatorPollPid'
+        $script:orchestraStartContent | Should -Match 'Operator Poll PID: \$\(\$operatorPollProcess\.Id\)'
         $script:orchestraStartContent | Should -Match 'watchdog_pid\s*=\s*\$WatchdogPid'
         $script:orchestraStartContent | Should -Match 'server_watchdog_pid\s*=\s*\$ServerWatchdogPid'
         $script:orchestraStartContent | Should -Match '-WatchdogPid \$watchdogProcess\.Id'
@@ -5049,7 +5076,7 @@ Describe 'orchestra-start server bootstrap' {
             [PSCustomObject]@{
                 session = [PSCustomObject]@{
                     startup_token       = 'token-123'
-                    commander_poll_pid  = '101'
+                    operator_poll_pid  = '101'
                     watchdog_pid        = '202'
                     server_watchdog_pid = '303'
                 }
@@ -5060,7 +5087,7 @@ Describe 'orchestra-start server bootstrap' {
         Mock Get-ProcessSnapshot {
             [PSCustomObject]@{
                 ById = @{
-                    101 = [PSCustomObject]@{ ProcessId = 101; ParentProcessId = 1; CommandLine = 'pwsh commander-poll.ps1 C:\repo\.winsmux\manifest.yaml -StartupToken token-123 winsmux-orchestra C:\repo\scripts\winsmux-core.ps1'; Name = 'pwsh.exe' }
+                    101 = [PSCustomObject]@{ ProcessId = 101; ParentProcessId = 1; CommandLine = 'pwsh operator-poll.ps1 C:\repo\.winsmux\manifest.yaml -StartupToken token-123 winsmux-orchestra C:\repo\scripts\winsmux-core.ps1'; Name = 'pwsh.exe' }
                     202 = [PSCustomObject]@{ ProcessId = 202; ParentProcessId = 1; CommandLine = 'pwsh agent-watchdog.ps1 C:\repo\.winsmux\manifest.yaml -StartupToken token-123 winsmux-orchestra C:\repo\scripts\winsmux-core.ps1'; Name = 'pwsh.exe' }
                     303 = [PSCustomObject]@{ ProcessId = 303; ParentProcessId = 1; CommandLine = 'pwsh server-watchdog.ps1 C:\repo\.winsmux\manifest.yaml -StartupToken token-123 winsmux-orchestra C:\repo\scripts\winsmux-core.ps1'; Name = 'pwsh.exe' }
                 }
@@ -5079,7 +5106,7 @@ Describe 'orchestra-start server bootstrap' {
         Mock Get-WinsmuxManifest {
             [PSCustomObject]@{
                 session = [PSCustomObject]@{
-                    commander_poll_pid = '101'
+                    operator_poll_pid = '101'
                 }
             }
         }
@@ -5118,7 +5145,7 @@ Describe 'orchestra-start session reuse contract' {
 
     It 'does not mark session_ready true in the manifest until watchdog processes are started' {
         $script:orchestraStartContent | Should -Match 'Save-OrchestraSessionState[^\r\n]+SessionReady \$false'
-        $script:orchestraStartContent | Should -Match 'Save-OrchestraSessionState[^\r\n]+CommanderPollPid \$commanderPollProcess\.Id[^\r\n]+SessionReady \$true'
+        $script:orchestraStartContent | Should -Match 'Save-OrchestraSessionState[^\r\n]+OperatorPollPid \$operatorPollProcess\.Id[^\r\n]+SessionReady \$true'
     }
 
     It 'keeps detached startup on the session-ready path even when visible attach still needs retry' {
@@ -5231,7 +5258,7 @@ Describe 'orchestra-start session reuse contract' {
     It 'routes partial bootstrap invalid state into the startup rollback path by throwing' {
         {
             Assert-OrchestraBootstrapVerification -PaneSummaries @(
-                [pscustomobject]@{ PaneId = '%1'; Label = 'commander' },
+                [pscustomobject]@{ PaneId = '%1'; Label = 'operator' },
                 [pscustomobject]@{ PaneId = '%2'; Label = 'builder-1' }
             ) -InvalidCount 1 -ReadyCount 1
         } | Should -Throw -ExpectedMessage '*startup aborted because 1 pane(s) are bootstrap_invalid and only 1 of 2 expected pane(s) are ready.*'
@@ -5240,7 +5267,7 @@ Describe 'orchestra-start session reuse contract' {
     It 'throws when bootstrap verification finds no ready panes' {
         {
             Assert-OrchestraBootstrapVerification -PaneSummaries @(
-                [pscustomobject]@{ PaneId = '%1'; Label = 'commander' }
+                [pscustomobject]@{ PaneId = '%1'; Label = 'operator' }
             ) -InvalidCount 1 -ReadyCount 0
         } | Should -Throw -ExpectedMessage '*no panes passed bootstrap verification*'
     }
@@ -6177,9 +6204,9 @@ panes:
   - label: reviewer
     pane_id: %4
     role: Reviewer
-  - label: commander
+  - label: operator
     pane_id: %1
-    role: Commander
+    role: Operator
 '@ | Set-Content -Path (Join-Path $manifestDir 'manifest.yaml') -Encoding UTF8
     }
 
@@ -6198,7 +6225,7 @@ panes:
         $entries[0].Role | Should -Be 'Builder'
         $entries[0].GitWorktreeDir | Should -Be 'C:\repo\.worktrees\builder-1'
         $entries[1].Role | Should -Be 'Reviewer'
-        $entries[2].Label | Should -Be 'commander'
+        $entries[2].Label | Should -Be 'operator'
     }
 
     It 'classifies pane captures into pwsh, codex, idle, and busy states' {
@@ -6285,7 +6312,7 @@ Esc to interrupt
         $records[1].State | Should -Be 'idle'
         $records[1].TokensRemaining | Should -Be '82% context left'
 
-        $records[2].Label | Should -Be 'commander'
+        $records[2].Label | Should -Be 'operator'
         $records[2].State | Should -Be 'busy'
         $records[2].TokensRemaining | Should -Be '61% context left'
     }
@@ -6889,7 +6916,7 @@ panes:
     head_sha: def5678abc1234
     changed_file_count: 0
     changed_files: '[]'
-    last_event: commander.state_transition
+    last_event: operator.state_transition
     last_event_at: 2026-04-10T11:05:00+09:00
 "@ | Set-Content -Path $script:inboxManifestPath -Encoding UTF8
 
@@ -6907,11 +6934,11 @@ panes:
             ([ordered]@{
                 timestamp = '2026-04-10T11:06:00+09:00'
                 session   = 'winsmux-orchestra'
-                event     = 'commander.state_transition'
+                event     = 'operator.state_transition'
                 message   = 'State: review_requested -> blocked_no_review_target'
                 label     = ''
                 pane_id   = ''
-                role      = 'Commander'
+                role      = 'Operator'
                 status    = 'blocked_no_review_target'
                 data      = [ordered]@{
                     from = 'review_requested'
@@ -6976,11 +7003,11 @@ panes:
             ([ordered]@{
                 timestamp = '2026-04-10T11:07:00+09:00'
                 session   = 'winsmux-orchestra'
-                event     = 'commander.commit_ready'
+                event     = 'operator.commit_ready'
                 message   = 'コミット準備完了。'
                 label     = ''
                 pane_id   = ''
-                role      = 'Commander'
+                role      = 'Operator'
                 status    = 'commit_ready'
                 head_sha  = 'abc1234def5678'
             } | ConvertTo-Json -Compress)
@@ -7072,8 +7099,8 @@ Invoke-Inbox -InboxTarget '--json'
         (Get-InboxActionableEventKind -EventRecord ([ordered]@{ event = 'pane.crashed'; status = 'crashed' })) | Should -Be 'crashed'
         (Get-InboxActionableEventKind -EventRecord ([ordered]@{ event = 'pane.hung'; status = 'hung' })) | Should -Be 'hung'
         (Get-InboxActionableEventKind -EventRecord ([ordered]@{ event = 'pane.stalled'; status = 'stalled' })) | Should -Be 'stalled'
-        (Get-InboxActionableEventKind -EventRecord ([ordered]@{ event = 'commander.state_transition'; status = 'blocked_no_review_target'; data = [ordered]@{ to = 'blocked_no_review_target' } })) | Should -Be 'blocked'
-        (Get-InboxActionableEventKind -EventRecord ([ordered]@{ event = 'commander.commit_ready'; status = 'commit_ready' })) | Should -Be 'commit_ready'
+        (Get-InboxActionableEventKind -EventRecord ([ordered]@{ event = 'operator.state_transition'; status = 'blocked_no_review_target'; data = [ordered]@{ to = 'blocked_no_review_target' } })) | Should -Be 'blocked'
+        (Get-InboxActionableEventKind -EventRecord ([ordered]@{ event = 'operator.commit_ready'; status = 'commit_ready' })) | Should -Be 'commit_ready'
     }
 
     It 'starts inbox stream after the current event cursor instead of replaying full history' {
@@ -7156,7 +7183,7 @@ panes:
     head_sha: abc1234def5678
     changed_file_count: 2
     changed_files: '["scripts/winsmux-core.ps1","tests/winsmux-bridge.Tests.ps1"]'
-    last_event: commander.review_requested
+    last_event: operator.review_requested
     last_event_at: 2026-04-10T12:00:00+09:00
   worker-1:
     pane_id: %6
@@ -7249,7 +7276,7 @@ panes:
     agent_role: worker
     timeout_policy: standard
     handoff_refs: '["docs/handoff.md"]'
-    last_event: commander.review_requested
+    last_event: operator.review_requested
     last_event_at: 2026-04-10T12:00:00+09:00
 "@ | Set-Content -Path $script:runsManifestPath -Encoding UTF8
 
@@ -7399,7 +7426,7 @@ panes:
     head_sha: abc1234def5678
     changed_file_count: 1
     changed_files: '["scripts/winsmux-core.ps1"]'
-    last_event: commander.review_requested
+    last_event: operator.review_requested
     last_event_at: 2026-04-10T12:00:00+09:00
 "@ | Set-Content -Path $script:runsManifestPath -Encoding UTF8
 
@@ -7445,7 +7472,7 @@ panes:
     head_sha: abc1234def5678
     changed_file_count: 1
     changed_files: '["scripts/winsmux-core.ps1"]'
-    last_event: commander.review_requested
+    last_event: operator.review_requested
     last_event_at: 2026-04-10T12:00:00+09:00
   builder-2:
     pane_id: %6
@@ -7459,7 +7486,7 @@ panes:
     head_sha: abc1234def5678
     changed_file_count: 1
     changed_files: '["tests/winsmux-bridge.Tests.ps1"]'
-    last_event: commander.review_requested
+    last_event: operator.review_requested
     last_event_at: 2026-04-10T12:01:00+09:00
 "@ | Set-Content -Path $script:runsManifestPath -Encoding UTF8
 
@@ -7633,7 +7660,7 @@ panes:
     head_sha: abc1234def5678
     changed_file_count: 2
     changed_files: '["scripts/winsmux-core.ps1","tests/winsmux-bridge.Tests.ps1"]'
-    last_event: commander.review_requested
+    last_event: operator.review_requested
     last_event_at: 2026-04-10T14:00:00+09:00
 "@ | Set-Content -Path $script:digestManifestPath -Encoding UTF8
 
@@ -7686,7 +7713,7 @@ panes:
     head_sha: abc1234def5678
     changed_file_count: 1
     changed_files: '["scripts/winsmux-core.ps1"]'
-    last_event: commander.review_failed
+    last_event: operator.review_failed
     last_event_at: 2026-04-10T14:00:00+09:00
 "@ | Set-Content -Path $script:digestManifestPath -Encoding UTF8
 
@@ -7714,7 +7741,7 @@ panes:
         ([ordered]@{
             timestamp = '2026-04-10T14:01:00+09:00'
             session   = 'winsmux-orchestra'
-            event     = 'commander.review_failed'
+            event     = 'operator.review_failed'
             message   = 'review failed'
             label     = 'reviewer-1'
             pane_id   = '%3'
@@ -7843,7 +7870,7 @@ panes:
     head_sha: abc1234def5678
     changed_file_count: 2
     changed_files: '["scripts/winsmux-core.ps1","tests/winsmux-bridge.Tests.ps1"]'
-    last_event: commander.review_requested
+    last_event: operator.review_requested
     last_event_at: 2026-04-10T14:00:00+09:00
   worker-1:
     pane_id: %6
@@ -7864,7 +7891,7 @@ panes:
         ([ordered]@{
             timestamp = '2026-04-10T14:01:00+09:00'
             session   = 'winsmux-orchestra'
-            event     = 'commander.review_requested'
+            event     = 'operator.review_requested'
             message   = 'review requested'
             label     = 'reviewer-1'
             pane_id   = '%3'
@@ -7901,7 +7928,7 @@ panes:
             ([ordered]@{
                 timestamp = '2026-04-10T14:03:00+09:00'
                 session   = 'winsmux-orchestra'
-                event     = 'commander.commit_ready'
+                event     = 'operator.commit_ready'
                 message   = 'commit ready'
                 label     = ''
                 pane_id   = ''
@@ -7969,7 +7996,7 @@ panes:
     head_sha: abc1234def5678
     changed_file_count: 1
     changed_files: '["scripts/winsmux-core.ps1"]'
-    last_event: commander.review_requested
+    last_event: operator.review_requested
     last_event_at: 2026-04-10T14:00:00+09:00
 "@ | Set-Content -Path $script:digestManifestPath -Encoding UTF8
 
@@ -8014,7 +8041,7 @@ panes:
     head_sha: abc1234def5678
     changed_file_count: 1
     changed_files: '["scripts/winsmux-core.ps1"]'
-    last_event: commander.review_requested
+    last_event: operator.review_requested
     last_event_at: 2026-04-10T14:00:00+09:00
 "@ | Set-Content -Path $script:digestManifestPath -Encoding UTF8
 
@@ -8091,7 +8118,7 @@ panes:
     head_sha: abc1234def5678
     changed_file_count: 1
     changed_files: '["scripts/winsmux-core.ps1"]'
-    last_event: commander.review_requested
+    last_event: operator.review_requested
     last_event_at: 2026-04-10T14:00:00+09:00
 "@ | Set-Content -Path $script:digestManifestPath -Encoding UTF8
 
@@ -8181,7 +8208,7 @@ panes:
     agent_role: worker
     timeout_policy: standard
     handoff_refs: '["docs/handoff.md"]'
-    last_event: commander.review_requested
+    last_event: operator.review_requested
     last_event_at: 2026-04-10T12:00:00+09:00
 "@ | Set-Content -Path $script:explainManifestPath -Encoding UTF8
 
@@ -8216,7 +8243,7 @@ panes:
             ([ordered]@{
                 timestamp = '2026-04-10T12:01:00+09:00'
                 session   = 'winsmux-orchestra'
-                event     = 'commander.review_requested'
+                event     = 'operator.review_requested'
                 message   = 'review requested'
                 label     = 'reviewer-1'
                 pane_id   = '%3'
@@ -8389,13 +8416,13 @@ panes:
         $result.Contains('run_packet') | Should -Be $false
         $result.Contains('result_packet') | Should -Be $false
         $result.recent_events.Count | Should -Be 3
-        @($result.recent_events | ForEach-Object { $_.event }) | Should -Contain 'commander.review_requested'
+        @($result.recent_events | ForEach-Object { $_.event }) | Should -Contain 'operator.review_requested'
         @($result.recent_events | ForEach-Object { $_.event }) | Should -Contain 'pipeline.verify.partial'
         @($result.recent_events | ForEach-Object { $_.event }) | Should -Contain 'pane.approval_waiting'
-        ($result.recent_events | Where-Object { $_.event -eq 'commander.review_requested' } | Select-Object -First 1).hypothesis | Should -Be 'experiment packet should flow into explain'
-        ($result.recent_events | Where-Object { $_.event -eq 'commander.review_requested' } | Select-Object -First 1).observation_pack.changed_files | Should -Contain 'scripts/winsmux-core.ps1'
-        ($result.recent_events | Where-Object { $_.event -eq 'commander.review_requested' } | Select-Object -First 1).observation_pack.packet_type | Should -Be 'observation_pack'
-        ($result.recent_events | Where-Object { $_.event -eq 'commander.review_requested' } | Select-Object -First 1).consultation_packet.kind | Should -Be 'consult_result'
+        ($result.recent_events | Where-Object { $_.event -eq 'operator.review_requested' } | Select-Object -First 1).hypothesis | Should -Be 'experiment packet should flow into explain'
+        ($result.recent_events | Where-Object { $_.event -eq 'operator.review_requested' } | Select-Object -First 1).observation_pack.changed_files | Should -Contain 'scripts/winsmux-core.ps1'
+        ($result.recent_events | Where-Object { $_.event -eq 'operator.review_requested' } | Select-Object -First 1).observation_pack.packet_type | Should -Be 'observation_pack'
+        ($result.recent_events | Where-Object { $_.event -eq 'operator.review_requested' } | Select-Object -First 1).consultation_packet.kind | Should -Be 'consult_result'
     }
 
     It 'rejects explain when matching review-state record is missing reviewer' {
@@ -8417,14 +8444,14 @@ panes:
     head_sha: abc1234def5678
     changed_file_count: 1
     changed_files: '["scripts/winsmux-core.ps1"]'
-    last_event: commander.review_requested
+    last_event: operator.review_requested
     last_event_at: 2026-04-10T12:00:00+09:00
 "@ | Set-Content -Path $script:explainManifestPath -Encoding UTF8
 
         ([ordered]@{
             timestamp = '2026-04-10T12:01:00+09:00'
             session   = 'winsmux-orchestra'
-            event     = 'commander.review_requested'
+            event     = 'operator.review_requested'
             message   = 'review requested'
             label     = 'reviewer-1'
             pane_id   = '%3'
@@ -8591,7 +8618,7 @@ panes:
     branch: worktree-builder-1
     changed_file_count: 1
     changed_files: '["scripts/winsmux-core.ps1"]'
-    last_event: commander.review_requested
+    last_event: operator.review_requested
     last_event_at: 2026-04-10T12:00:00+09:00
 "@ | Set-Content -Path $script:explainManifestPath -Encoding UTF8
 
@@ -8625,7 +8652,7 @@ panes:
     head_sha: abc1234def5678
     changed_file_count: 1
     changed_files: '[]'
-    last_event: commander.review_requested
+    last_event: operator.review_requested
     last_event_at: 2026-04-10T12:00:00+09:00
 "@ | Set-Content -Path $script:explainManifestPath -Encoding UTF8
 
@@ -8659,7 +8686,7 @@ panes:
     head_sha: abc1234def5678
     changed_file_count: 1
     changed_files: '["scripts/winsmux-core.ps1"]'
-    last_event: commander.review_requested
+    last_event: operator.review_requested
 "@ | Set-Content -Path $script:explainManifestPath -Encoding UTF8
 
         function global:winsmux {
@@ -8695,7 +8722,7 @@ panes:
     head_sha: abc1234def5678
     changed_file_count: 1
     changed_files: '["scripts/winsmux-core.ps1"]'
-    last_event: commander.review_requested
+    last_event: operator.review_requested
     last_event_at: 2026-04-10T12:00:00+09:00
 "@ | Set-Content -Path $script:explainManifestPath -Encoding UTF8
 
@@ -8732,7 +8759,7 @@ panes:
     head_sha: abc1234def5678
     changed_file_count: 1
     changed_files: '["scripts/winsmux-core.ps1"]'
-    last_event: commander.review_requested
+    last_event: operator.review_requested
     last_event_at: 2026-04-10T12:00:00+09:00
 "@ | Set-Content -Path $script:explainManifestPath -Encoding UTF8
 
@@ -8769,7 +8796,7 @@ panes:
     head_sha: abc1234def5678
     changed_file_count: 1
     changed_files: '["scripts/winsmux-core.ps1"]'
-    last_event: commander.review_requested
+    last_event: operator.review_requested
     last_event_at: 2026-04-10T12:00:00+09:00
 "@ | Set-Content -Path $script:explainManifestPath -Encoding UTF8
 
@@ -8806,7 +8833,7 @@ panes:
     head_sha: abc1234def5678
     changed_file_count: 1
     changed_files: '["scripts/winsmux-core.ps1"]'
-    last_event: commander.review_requested
+    last_event: operator.review_requested
     last_event_at: 2026-04-10T12:00:00+09:00
 "@ | Set-Content -Path $script:explainManifestPath -Encoding UTF8
 
@@ -8840,7 +8867,7 @@ panes:
     head_sha: abc1234def5678
     changed_file_count: 0
     changed_files: '[]'
-    last_event: commander.review_requested
+    last_event: operator.review_requested
     last_event_at: 2026-04-10T12:00:00+09:00
 "@ | Set-Content -Path $script:explainManifestPath -Encoding UTF8
 
@@ -8851,7 +8878,7 @@ panes:
         ([ordered]@{
             timestamp = '2026-04-10T12:01:00+09:00'
             session   = 'winsmux-orchestra'
-            event     = 'commander.review_requested'
+            event     = 'operator.review_requested'
             message   = 'review requested'
             label     = 'reviewer-1'
             pane_id   = '%3'
@@ -8905,14 +8932,14 @@ panes:
     head_sha: abc1234def5678
     changed_file_count: 1
     changed_files: '["scripts/winsmux-core.ps1"]'
-    last_event: commander.review_requested
+    last_event: operator.review_requested
     last_event_at: 2026-04-10T12:00:00+09:00
 "@ | Set-Content -Path $script:explainManifestPath -Encoding UTF8
 
         ([ordered]@{
             timestamp = '2026-04-10T12:01:00+09:00'
             session   = 'winsmux-orchestra'
-            event     = 'commander.review_requested'
+            event     = 'operator.review_requested'
             message   = 'review requested'
             label     = 'reviewer-1'
             pane_id   = '%3'
@@ -8949,11 +8976,11 @@ panes:
             ([ordered]@{
                 timestamp = '2026-04-10T12:03:00+09:00'
                 session   = 'winsmux-orchestra'
-                event     = 'commander.commit_ready'
+                event     = 'operator.commit_ready'
                 message   = 'commit ready'
                 label     = ''
                 pane_id   = ''
-                role      = 'Commander'
+                role      = 'Operator'
                 branch    = 'worktree-builder-1'
                 head_sha  = 'abc1234def5678'
                 status    = 'commit_ready'
@@ -8976,7 +9003,7 @@ panes:
 
         $delta.cursor | Should -Be 3
         $matching.Count | Should -Be 1
-        $matching[0].event | Should -Be 'commander.commit_ready'
+        $matching[0].event | Should -Be 'operator.commit_ready'
         $matching[0].hypothesis | Should -Be 'follow path should keep experiment fields'
         $matching[0].next_action | Should -Be 'commit_ready'
         $matching[0].observation_pack_ref | Should -Be '.winsmux/observation-packs/task-256.json'
@@ -9389,11 +9416,11 @@ Describe 'public first-run helper' {
         $result.status | Should -Be 'initialized'
         $result.created | Should -Be $true
         $result.slot_count | Should -Be 6
-        $result.external_commander | Should -Be $true
+        $result.external_operator | Should -Be $true
         Test-Path -LiteralPath $result.config_path | Should -Be $true
 
         $settings = Get-BridgeSettings -RootPath $script:publicFirstRunTempRoot
-        $settings.external_commander | Should -Be $true
+        $settings.external_operator | Should -Be $true
         $settings.worker_count | Should -Be 6
         $settings.agent_slots.Count | Should -Be 6
         $settings.agent_slots[0].slot_id | Should -Be 'worker-1'
@@ -10230,14 +10257,14 @@ Describe 'operator startup restore contract docs' {
     It 'keeps operator-facing script errors pinned to winsmux instead of exposing compatibility aliases' {
         $settingsPath = Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\settings.ps1'
         $setupWizardPath = Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\setup-wizard.ps1'
-        $commanderPollPath = Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\commander-poll.ps1'
+        $operatorPollPath = Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\operator-poll.ps1'
         $agentMonitorPath = Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\agent-monitor.ps1'
         $watchdogPath = Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\server-watchdog.ps1'
         $orchestraStartPath = Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\orchestra-start.ps1'
 
         $settingsContent = Get-Content -Path $settingsPath -Raw -Encoding UTF8
         $setupWizardContent = Get-Content -Path $setupWizardPath -Raw -Encoding UTF8
-        $commanderPollContent = Get-Content -Path $commanderPollPath -Raw -Encoding UTF8
+        $operatorPollContent = Get-Content -Path $operatorPollPath -Raw -Encoding UTF8
         $agentMonitorContent = Get-Content -Path $agentMonitorPath -Raw -Encoding UTF8
         $watchdogContent = Get-Content -Path $watchdogPath -Raw -Encoding UTF8
         $orchestraStartContent = Get-Content -Path $orchestraStartPath -Raw -Encoding UTF8
@@ -10250,7 +10277,7 @@ Describe 'operator startup restore contract docs' {
         $setupWizardContent | Should -Not -Match 'AI agent CLI \(codex/claude\)'
         $setupWizardContent | Should -Not -Match "Please enter 'codex' or 'claude'\."
         $setupWizardContent | Should -Not -Match 'Tried: winsmux, pmux, tmux'
-        $commanderPollContent | Should -Not -Match 'Tried: winsmux, pmux, tmux'
+        $operatorPollContent | Should -Not -Match 'Tried: winsmux, pmux, tmux'
         $agentMonitorContent | Should -Not -Match 'Tried: winsmux, pmux, tmux'
         $watchdogContent | Should -Not -Match 'Tried: winsmux, pmux, tmux'
         $orchestraStartContent | Should -Not -Match 'Tried: winsmux, pmux, tmux'
@@ -10454,7 +10481,7 @@ panes:
     head_sha: def5678abc1234
     changed_file_count: 0
     changed_files: '[]'
-    last_event: commander.state_transition
+    last_event: operator.state_transition
     last_event_at: 2026-04-10T11:05:00+09:00
 "@ | Set-Content -Path $manifestPath -Encoding UTF8
 
@@ -10472,11 +10499,11 @@ panes:
                 ([ordered]@{
                     timestamp = '2026-04-10T11:06:00+09:00'
                     session   = 'winsmux-orchestra'
-                    event     = 'commander.state_transition'
+                    event     = 'operator.state_transition'
                     message   = 'State: review_requested -> blocked_no_review_target'
                     label     = ''
                     pane_id   = ''
-                    role      = 'Commander'
+                    role      = 'Operator'
                     status    = 'blocked_no_review_target'
                     data      = [ordered]@{
                         from = 'review_requested'
@@ -10486,11 +10513,11 @@ panes:
                 ([ordered]@{
                     timestamp = '2026-04-10T11:08:00+09:00'
                     session   = 'winsmux-orchestra'
-                    event     = 'commander.commit_ready'
+                    event     = 'operator.commit_ready'
                     message   = 'コミット準備完了。'
                     label     = ''
                     pane_id   = ''
-                    role      = 'Commander'
+                    role      = 'Operator'
                     status    = 'commit_ready'
                     head_sha  = 'abc1234def5678'
                 } | ConvertTo-Json -Compress)
@@ -10541,7 +10568,7 @@ panes:
     head_sha: abc1234def5678
     changed_file_count: 1
     changed_files: '["scripts/winsmux-core.ps1"]'
-    last_event: commander.review_failed
+    last_event: operator.review_failed
     last_event_at: 2026-04-10T14:00:00+09:00
 "@ | Set-Content -Path $manifestPath -Encoding UTF8
 
@@ -10569,7 +10596,7 @@ panes:
             ([ordered]@{
                 timestamp = '2026-04-10T14:03:00+09:00'
                 session   = 'winsmux-orchestra'
-                event     = 'commander.review_failed'
+                event     = 'operator.review_failed'
                 message   = 'review failed'
                 label     = 'builder-1'
                 pane_id   = '%2'
@@ -10649,7 +10676,7 @@ panes:
     agent_role: worker
     timeout_policy: standard
     handoff_refs: '["docs/handoff.md"]'
-    last_event: commander.review_requested
+    last_event: operator.review_requested
     last_event_at: 2026-04-10T12:00:00+09:00
 "@ | Set-Content -Path $manifestPath -Encoding UTF8
 
@@ -10684,7 +10711,7 @@ panes:
                 ([ordered]@{
                     timestamp = '2026-04-10T12:01:00+09:00'
                     session   = 'winsmux-orchestra'
-                    event     = 'commander.review_requested'
+                    event     = 'operator.review_requested'
                     message   = 'review requested'
                     label     = 'reviewer-1'
                     pane_id   = '%3'
@@ -10784,7 +10811,7 @@ panes:
     head_sha: aaaabbbbccccdddd
     changed_file_count: 1
     changed_files: '["scripts/winsmux-core.ps1"]'
-    last_event: commander.review_requested
+    last_event: operator.review_requested
     last_event_at: 2026-04-12T10:00:00+09:00
   builder-2:
     pane_id: %4
@@ -10850,7 +10877,7 @@ panes:
             ([ordered]@{
                 timestamp = '2026-04-12T10:00:00+09:00'
                 session   = 'winsmux-orchestra'
-                event     = 'commander.review_requested'
+                event     = 'operator.review_requested'
                 message   = 'review requested'
                 label     = 'builder-1'
                 pane_id   = '%2'
@@ -11015,7 +11042,7 @@ panes:
     head_sha: aaaabbbbccccdddd
     changed_file_count: 1
     changed_files: '["scripts/winsmux-core.ps1"]'
-    last_event: commander.review_requested
+    last_event: operator.review_requested
     last_event_at: 2026-04-12T10:00:00+09:00
   builder-2:
     pane_id: %4
@@ -11036,7 +11063,7 @@ panes:
             ([ordered]@{
                 timestamp = '2026-04-12T10:00:00+09:00'
                 session   = 'winsmux-orchestra'
-                event     = 'commander.review_requested'
+                event     = 'operator.review_requested'
                 message   = 'review requested'
                 label     = 'builder-1'
                 pane_id   = '%2'
@@ -11187,7 +11214,7 @@ panes:
     head_sha: aaaabbbbccccdddd
     changed_file_count: 1
     changed_files: '["scripts/winsmux-core.ps1"]'
-    last_event: commander.review_requested
+    last_event: operator.review_requested
     last_event_at: 2026-04-12T10:00:00+09:00
 "@ | Set-Content -Path $script:compareManifestPath -Encoding UTF8
 
@@ -11212,7 +11239,7 @@ panes:
     head_sha: aaaabbbbccccdddd
     changed_file_count: 1
     changed_files: '["scripts/winsmux-core.ps1"]'
-    last_event: commander.review_requested
+    last_event: operator.review_requested
     last_event_at: 2026-04-12T10:00:00+09:00
 "@ | Set-Content -Path $script:compareManifestPath -Encoding UTF8
 
@@ -11220,7 +11247,7 @@ panes:
             ([ordered]@{
                 timestamp = '2026-04-12T10:00:00+09:00'
                 session   = 'winsmux-orchestra'
-                event     = 'commander.review_requested'
+                event     = 'operator.review_requested'
                 message   = 'review requested'
                 label     = 'builder-1'
                 pane_id   = '%2'
@@ -11486,46 +11513,46 @@ Describe 'winsmux poll-events command' {
     }
 }
 
-Describe 'commander-poll helpers' {
+Describe 'operator-poll helpers' {
     BeforeAll {
-        $script:commanderPollScriptPath = Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\commander-poll.ps1'
+        $script:operatorPollScriptPath = Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\operator-poll.ps1'
     }
 
     BeforeEach {
-        $script:commanderPollTempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('winsmux-commander-poll-tests-' + [guid]::NewGuid().ToString('N'))
-        $script:commanderPollManifestDir = Join-Path $script:commanderPollTempRoot '.winsmux'
-        $script:commanderPollManifestPath = Join-Path $script:commanderPollManifestDir 'manifest.yaml'
-        New-Item -ItemType Directory -Path $script:commanderPollManifestDir -Force | Out-Null
+        $script:operatorPollTempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('winsmux-operator-poll-tests-' + [guid]::NewGuid().ToString('N'))
+        $script:operatorPollManifestDir = Join-Path $script:operatorPollTempRoot '.winsmux'
+        $script:operatorPollManifestPath = Join-Path $script:operatorPollManifestDir 'manifest.yaml'
+        New-Item -ItemType Directory -Path $script:operatorPollManifestDir -Force | Out-Null
 
 @"
 version: 1
 session:
   name: winsmux-orchestra
-  project_dir: $script:commanderPollTempRoot
+  project_dir: $script:operatorPollTempRoot
 panes:
   - label: builder-1
     pane_id: %2
     role: Builder
-    launch_dir: $script:commanderPollTempRoot
-"@ | Set-Content -Path $script:commanderPollManifestPath -Encoding UTF8
+    launch_dir: $script:operatorPollTempRoot
+"@ | Set-Content -Path $script:operatorPollManifestPath -Encoding UTF8
 
-        . $script:commanderPollScriptPath -ManifestPath $script:commanderPollManifestPath
+        . $script:operatorPollScriptPath -ManifestPath $script:operatorPollManifestPath
     }
 
     AfterEach {
-        if ($script:commanderPollTempRoot -and (Test-Path $script:commanderPollTempRoot)) {
-            Remove-Item -Path $script:commanderPollTempRoot -Recurse -Force
+        if ($script:operatorPollTempRoot -and (Test-Path $script:operatorPollTempRoot)) {
+            Remove-Item -Path $script:operatorPollTempRoot -Recurse -Force
         }
     }
 
     It 'processes mailbox idle messages and logs dispatch-needed guidance' {
-        Mock Receive-CommanderPollMailboxMessages {
+        Mock Receive-OperatorPollMailboxMessages {
             @(
                 [ordered]@{
                     timestamp   = '2026-04-07T09:00:00.0000000+09:00'
                     session     = 'winsmux-orchestra'
                     event       = 'pane.idle'
-                    message     = 'Commander alert: idle pane builder-1 (%2, role=Builder)'
+                    message     = 'Operator alert: idle pane builder-1 (%2, role=Builder)'
                     label       = 'builder-1'
                     pane_id     = '%2'
                     role        = 'Builder'
@@ -11538,17 +11565,17 @@ panes:
                 }
             )
         }
-        Mock Write-CommanderPollLog { }
+        Mock Write-OperatorPollLog { }
 
-        $cycle = Invoke-CommanderPollCycle -ManifestPath $script:commanderPollManifestPath -ProcessedLineCount 0 -ProcessedEventSignatures ([ordered]@{})
+        $cycle = Invoke-OperatorPollCycle -ManifestPath $script:operatorPollManifestPath -ProcessedLineCount 0 -ProcessedEventSignatures ([ordered]@{})
         $summary = $cycle['Summary']
 
         $summary.mailbox_events | Should -Be 1
         $summary.new_events | Should -Be 1
         $summary.dispatches | Should -Be 1
         $summary.messages[0] | Should -Be 'builder-1 (%2) がアイドル。次タスクのディスパッチが必要'
-        Should -Invoke Write-CommanderPollLog -Times 1 -Exactly -ParameterFilter {
-            $EventName -eq 'commander.poll.idle_dispatch_needed' -and
+        Should -Invoke Write-OperatorPollLog -Times 1 -Exactly -ParameterFilter {
+            $EventName -eq 'operator.poll.idle_dispatch_needed' -and
             $PaneId -eq '%2' -and
             $Message -eq 'builder-1 (%2) がアイドル。次タスクのディスパッチが必要'
         }
@@ -11560,21 +11587,21 @@ version: 1
 saved_at: 2026-04-09T11:00:00+09:00
 session:
   name: winsmux-orchestra
-  project_dir: $script:commanderPollTempRoot
+  project_dir: $script:operatorPollTempRoot
 panes:
   builder-1:
     pane_id: %2
     role: Builder
-    launch_dir: $script:commanderPollTempRoot
-"@ | Set-Content -Path $script:commanderPollManifestPath -Encoding UTF8
+    launch_dir: $script:operatorPollTempRoot
+"@ | Set-Content -Path $script:operatorPollManifestPath -Encoding UTF8
 
-        Mock Receive-CommanderPollMailboxMessages {
+        Mock Receive-OperatorPollMailboxMessages {
             @(
                 [ordered]@{
                     timestamp   = '2026-04-07T09:00:00.0000000+09:00'
                     session     = 'winsmux-orchestra'
                     event       = 'pane.idle'
-                    message     = 'Commander alert: idle pane builder-1 (%2, role=Builder)'
+                    message     = 'Operator alert: idle pane builder-1 (%2, role=Builder)'
                     label       = 'builder-1'
                     pane_id     = '%2'
                     role        = 'Builder'
@@ -11587,9 +11614,9 @@ panes:
                 }
             )
         }
-        Mock Write-CommanderPollLog { }
+        Mock Write-OperatorPollLog { }
 
-        $cycle = Invoke-CommanderPollCycle -ManifestPath $script:commanderPollManifestPath -ProcessedLineCount 0 -ProcessedEventSignatures ([ordered]@{})
+        $cycle = Invoke-OperatorPollCycle -ManifestPath $script:operatorPollManifestPath -ProcessedLineCount 0 -ProcessedEventSignatures ([ordered]@{})
         $summary = $cycle['Summary']
 
         $summary.mailbox_events | Should -Be 1
@@ -11604,16 +11631,16 @@ version: 1
 saved_at: 2026-04-09T11:00:00+09:00
 session:
   name: winsmux-orchestra
-  project_dir: $script:commanderPollTempRoot
+  project_dir: $script:operatorPollTempRoot
 panes:
   worker-1:
     pane_id: %2
     role: Worker
-    launch_dir: $script:commanderPollTempRoot
-"@ | Set-Content -Path $script:commanderPollManifestPath -Encoding UTF8
+    launch_dir: $script:operatorPollTempRoot
+"@ | Set-Content -Path $script:operatorPollManifestPath -Encoding UTF8
 
-        $manifest = Read-CommanderPollManifest -Path $script:commanderPollManifestPath
-        $reviewPane = Get-CommanderPollPreferredReviewPane -Manifest $manifest
+        $manifest = Read-OperatorPollManifest -Path $script:operatorPollManifestPath
+        $reviewPane = Get-OperatorPollPreferredReviewPane -Manifest $manifest
 
         $reviewPane.PaneId | Should -Be '%2'
         $reviewPane.Label | Should -Be 'worker-1'
@@ -11626,13 +11653,13 @@ version: 1
 saved_at: 2026-04-09T11:00:00+09:00
 session:
   name: winsmux-orchestra
-  project_dir: $script:commanderPollTempRoot
+  project_dir: $script:operatorPollTempRoot
 panes:
   worker-1:
     pane_id: %2
     role: Worker
-    launch_dir: $script:commanderPollTempRoot
-"@ | Set-Content -Path $script:commanderPollManifestPath -Encoding UTF8
+    launch_dir: $script:operatorPollTempRoot
+"@ | Set-Content -Path $script:operatorPollManifestPath -Encoding UTF8
 
         . (Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\orchestra-state.ps1')
 
@@ -11651,25 +11678,25 @@ panes:
         $record.status | Should -Be 'PENDING'
     }
 
-    It 'appends commander poll log records as jsonl' {
-        Write-CommanderPollLog -ProjectDir $script:commanderPollTempRoot -SessionName 'winsmux-orchestra' -EventName 'commander.poll.idle_dispatch_needed' -Message 'idle' -PaneId '%2'
-        Write-CommanderPollLog -ProjectDir $script:commanderPollTempRoot -SessionName 'winsmux-orchestra' -EventName 'commander.poll.auto_approved' -Message 'approved' -PaneId '%2'
+    It 'appends operator poll log records as jsonl' {
+        Write-OperatorPollLog -ProjectDir $script:operatorPollTempRoot -SessionName 'winsmux-orchestra' -EventName 'operator.poll.idle_dispatch_needed' -Message 'idle' -PaneId '%2'
+        Write-OperatorPollLog -ProjectDir $script:operatorPollTempRoot -SessionName 'winsmux-orchestra' -EventName 'operator.poll.auto_approved' -Message 'approved' -PaneId '%2'
 
-        $logPath = Get-CommanderPollLogPath -ProjectDir $script:commanderPollTempRoot
+        $logPath = Get-OperatorPollLogPath -ProjectDir $script:operatorPollTempRoot
         $lines = @(Get-Content -Path $logPath -Encoding UTF8 | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
 
         $lines.Count | Should -Be 2
-        ($lines[0] | ConvertFrom-Json).event | Should -Be 'commander.poll.idle_dispatch_needed'
-        ($lines[1] | ConvertFrom-Json).event | Should -Be 'commander.poll.auto_approved'
+        ($lines[0] | ConvertFrom-Json).event | Should -Be 'operator.poll.idle_dispatch_needed'
+        ($lines[1] | ConvertFrom-Json).event | Should -Be 'operator.poll.auto_approved'
     }
 
-    It 'does not forward commander dispatch-needed alerts to Telegram by default' {
+    It 'does not forward operator dispatch-needed alerts to Telegram by default' {
         Mock Test-Path { $true }
         Mock Get-Content { 'TELEGRAM_BOT_TOKEN=test-token' }
         Mock Invoke-RestMethod { }
 
-        Send-CommanderTelegramNotification -ProjectDir $script:commanderPollTempRoot -SessionName 'winsmux-orchestra' `
-            -Event 'commander.dispatch_needed' -Message 'idle' -PaneId '%2' -Label 'builder-1' -Role 'Builder'
+        Send-OperatorTelegramNotification -ProjectDir $script:operatorPollTempRoot -SessionName 'winsmux-orchestra' `
+            -Event 'operator.dispatch_needed' -Message 'idle' -PaneId '%2' -Label 'builder-1' -Role 'Builder'
 
         Should -Not -Invoke Invoke-RestMethod
     }
@@ -11679,8 +11706,8 @@ panes:
         Mock Get-Content { 'TELEGRAM_BOT_TOKEN=test-token' }
         Mock Invoke-RestMethod { }
 
-        Send-CommanderTelegramNotification -ProjectDir $script:commanderPollTempRoot -SessionName 'winsmux-orchestra' `
-            -Event 'commander.auto_approved' -Message 'approved' -PaneId '%2' -Label 'builder-1' -Role 'Builder'
+        Send-OperatorTelegramNotification -ProjectDir $script:operatorPollTempRoot -SessionName 'winsmux-orchestra' `
+            -Event 'operator.auto_approved' -Message 'approved' -PaneId '%2' -Label 'builder-1' -Role 'Builder'
 
         Should -Not -Invoke Invoke-RestMethod
     }
@@ -11690,8 +11717,8 @@ panes:
         Mock Get-Content { 'TELEGRAM_BOT_TOKEN=test-token' }
         Mock Invoke-RestMethod { }
 
-        Send-CommanderTelegramNotification -ProjectDir $script:commanderPollTempRoot -SessionName 'winsmux-orchestra' `
-            -Event 'commander.review_requested' -Message 'review requested' -PaneId '%4' -Label 'worker-1' -Role 'Worker'
+        Send-OperatorTelegramNotification -ProjectDir $script:operatorPollTempRoot -SessionName 'winsmux-orchestra' `
+            -Event 'operator.review_requested' -Message 'review requested' -PaneId '%4' -Label 'worker-1' -Role 'Worker'
 
         Should -Invoke Invoke-RestMethod -Times 1 -Exactly
     }
@@ -11701,13 +11728,13 @@ panes:
         Mock Get-Content { 'TELEGRAM_BOT_TOKEN=test-token' }
         Mock Invoke-RestMethod { }
 
-        Send-CommanderTelegramNotification -ProjectDir $script:commanderPollTempRoot -SessionName 'winsmux-orchestra' `
-            -Event 'commander.commit_ready' -Message 'ready to commit' -HeadSha 'abc1234def5678'
+        Send-OperatorTelegramNotification -ProjectDir $script:operatorPollTempRoot -SessionName 'winsmux-orchestra' `
+            -Event 'operator.commit_ready' -Message 'ready to commit' -HeadSha 'abc1234def5678'
 
         Should -Invoke Invoke-RestMethod -Times 1 -Exactly
     }
 
-    It 'allows all commander Telegram alerts when verbose profile is enabled' {
+    It 'allows all operator Telegram alerts when verbose profile is enabled' {
         $previousProfile = $env:WINSMUX_TELEGRAM_PROFILE
         $env:WINSMUX_TELEGRAM_PROFILE = 'verbose'
 
@@ -11716,8 +11743,8 @@ panes:
             Mock Get-Content { 'TELEGRAM_BOT_TOKEN=test-token' }
             Mock Invoke-RestMethod { }
 
-            Send-CommanderTelegramNotification -ProjectDir $script:commanderPollTempRoot -SessionName 'winsmux-orchestra' `
-                -Event 'commander.dispatch_needed' -Message 'idle' -PaneId '%2' -Label 'builder-1' -Role 'Builder'
+            Send-OperatorTelegramNotification -ProjectDir $script:operatorPollTempRoot -SessionName 'winsmux-orchestra' `
+                -Event 'operator.dispatch_needed' -Message 'idle' -PaneId '%2' -Label 'builder-1' -Role 'Builder'
 
             Should -Invoke Invoke-RestMethod -Times 1 -Exactly
         } finally {
@@ -11738,8 +11765,8 @@ panes:
             Mock Get-Content { 'TELEGRAM_BOT_TOKEN=test-token' }
             Mock Invoke-RestMethod { }
 
-            Send-CommanderTelegramNotification -ProjectDir $script:commanderPollTempRoot -SessionName 'winsmux-orchestra' `
-                -Event 'commander.review_failed' -Message 'review failed' -HeadSha 'abc1234def5678'
+            Send-OperatorTelegramNotification -ProjectDir $script:operatorPollTempRoot -SessionName 'winsmux-orchestra' `
+                -Event 'operator.review_failed' -Message 'review failed' -HeadSha 'abc1234def5678'
 
             Should -Not -Invoke Invoke-RestMethod
         } finally {
@@ -11751,7 +11778,7 @@ panes:
         }
     }
 
-    It 'allows internal commander Telegram alerts only when explicitly overridden' {
+    It 'allows internal operator Telegram alerts only when explicitly overridden' {
         $previousOverride = $env:WINSMUX_TELEGRAM_INCLUDE_INTERNAL_EVENTS
         $env:WINSMUX_TELEGRAM_INCLUDE_INTERNAL_EVENTS = 'true'
 
@@ -11760,8 +11787,8 @@ panes:
             Mock Get-Content { 'TELEGRAM_BOT_TOKEN=test-token' }
             Mock Invoke-RestMethod { }
 
-            Send-CommanderTelegramNotification -ProjectDir $script:commanderPollTempRoot -SessionName 'winsmux-orchestra' `
-                -Event 'commander.dispatch_needed' -Message 'idle' -PaneId '%2' -Label 'builder-1' -Role 'Builder'
+            Send-OperatorTelegramNotification -ProjectDir $script:operatorPollTempRoot -SessionName 'winsmux-orchestra' `
+                -Event 'operator.dispatch_needed' -Message 'idle' -PaneId '%2' -Label 'builder-1' -Role 'Builder'
 
             Should -Invoke Invoke-RestMethod -Times 1 -Exactly
         } finally {
@@ -11773,36 +11800,36 @@ panes:
         }
     }
 
-    It 'dispatches review requests through commander poll wrappers' {
+    It 'dispatches review requests through operator poll wrappers' {
 @"
 version: 1
 saved_at: 2026-04-12T10:00:00+09:00
 session:
   name: winsmux-orchestra
-  project_dir: $script:commanderPollTempRoot
+  project_dir: $script:operatorPollTempRoot
 panes:
   reviewer-1:
     pane_id: %4
     role: Reviewer
-    launch_dir: $script:commanderPollTempRoot
-"@ | Set-Content -Path $script:commanderPollManifestPath -Encoding UTF8
+    launch_dir: $script:operatorPollTempRoot
+"@ | Set-Content -Path $script:operatorPollManifestPath -Encoding UTF8
 
-        Mock Send-CommanderPollLiteral { }
-        Mock Approve-CommanderPollPane { }
-        Mock Send-CommanderTelegramNotification { }
+        Mock Send-OperatorPollLiteral { }
+        Mock Approve-OperatorPollPane { }
+        Mock Send-OperatorTelegramNotification { }
 
-        $result = Invoke-CommanderStateMachine `
+        $result = Invoke-OperatorStateMachine `
             -CurrentState 'waiting_for_review' `
             -CycleSummary @{ completions = 1 } `
-            -ProjectDir $script:commanderPollTempRoot `
+            -ProjectDir $script:operatorPollTempRoot `
             -SessionName 'winsmux-orchestra' `
-            -ManifestPath $script:commanderPollManifestPath
+            -ManifestPath $script:operatorPollManifestPath
 
         $result.State | Should -Be 'review_requested'
-        Should -Invoke Send-CommanderPollLiteral -Times 1 -Exactly -ParameterFilter {
+        Should -Invoke Send-OperatorPollLiteral -Times 1 -Exactly -ParameterFilter {
             $PaneId -eq '%4' -and $Text -eq 'winsmux review-request'
         }
-        Should -Invoke Approve-CommanderPollPane -Times 1 -Exactly -ParameterFilter {
+        Should -Invoke Approve-OperatorPollPane -Times 1 -Exactly -ParameterFilter {
             $PaneId -eq '%4'
         }
     }

--- a/winsmux-app/src-tauri/src/desktop_backend.rs
+++ b/winsmux-app/src-tauri/src/desktop_backend.rs
@@ -1569,7 +1569,7 @@ mod tests {
         assert_eq!(snapshot.inbox.items[0].task_id, "task-999");
         assert_eq!(snapshot.inbox.items[0].task, "Fix blocker");
         assert_eq!(snapshot.inbox.items[0].head_sha, "def5678abc1234");
-        assert_eq!(snapshot.inbox.items[0].event, "commander.state_transition");
+        assert_eq!(snapshot.inbox.items[0].event, "operator.state_transition");
         assert_eq!(snapshot.inbox.items[0].timestamp, "__TIMESTAMP__");
         assert_eq!(snapshot.inbox.items[0].source, "manifest");
         assert_eq!(snapshot.digest.summary.actionable_items, 1);
@@ -1580,7 +1580,7 @@ mod tests {
         assert_eq!(snapshot.digest.items[0].action_item_count, 3);
         assert_eq!(
             snapshot.digest.items[0].last_event,
-            "commander.review_failed"
+            "operator.review_failed"
         );
         assert_eq!(snapshot.digest.items[0].verification_outcome, "");
         assert_eq!(snapshot.digest.items[0].security_blocked, "");
@@ -2044,7 +2044,7 @@ mod tests {
         assert_eq!(payload.run.primary_label, "builder-1");
         assert_eq!(payload.run.primary_pane_id, "%2");
         assert_eq!(payload.run.primary_role, "Builder");
-        assert_eq!(payload.run.last_event, "commander.review_requested");
+        assert_eq!(payload.run.last_event, "operator.review_requested");
         assert_eq!(payload.run.last_event_at, "__LAST_EVENT_AT__");
         assert_eq!(payload.run.tokens_remaining, "64% context left");
         assert_eq!(payload.run.pane_count, 1);
@@ -2110,7 +2110,7 @@ mod tests {
         assert_eq!(payload.explanation.current_state.review_state, "PENDING");
         assert_eq!(
             payload.explanation.current_state.last_event,
-            "commander.review_requested"
+            "operator.review_requested"
         );
         assert!(payload.run.security_policy.is_null());
         assert!(payload.run.security_verdict.is_null());
@@ -2125,7 +2125,7 @@ mod tests {
         );
         assert_eq!(
             payload.run.action_items[0].event,
-            "commander.review_requested"
+            "operator.review_requested"
         );
         assert_eq!(payload.run.action_items[0].timestamp, "__TIMESTAMP__");
         assert_eq!(payload.run.action_items[0].source, "manifest");
@@ -2351,7 +2351,7 @@ mod tests {
                 assert_eq!(result["run"]["priority"], "P0");
                 assert_eq!(result["run"]["primary_label"], "builder-1");
                 assert_eq!(result["run"]["primary_pane_id"], "%2");
-                assert_eq!(result["run"]["last_event"], "commander.review_requested");
+                assert_eq!(result["run"]["last_event"], "operator.review_requested");
                 assert_eq!(result["run"]["tokens_remaining"], "64% context left");
                 assert_eq!(result["run"]["pane_count"], 1);
                 assert_eq!(result["run"]["labels"][0], "builder-1");
@@ -2385,7 +2385,7 @@ mod tests {
                 );
                 assert_eq!(
                     result["explanation"]["current_state"]["last_event"],
-                    "commander.review_requested"
+                    "operator.review_requested"
                 );
                 assert_eq!(
                     result["consultation_packet"]["recommendation"],

--- a/winsmux-core/agents/builder.sh
+++ b/winsmux-core/agents/builder.sh
@@ -130,7 +130,7 @@ Additional fixed guardrails for this builder run:
 - Treat WORKTREE as the only workspace you may modify for this task.
 - Do not finish until you have run the relevant tests or checks from that workspace, unless you are blocked.
 - In the verification summary, include the exact commands you ran and whether they passed or failed.
-- Do NOT run git add, git commit, git push, or any git write commands. Your role is code editing only. Git operations are handled by the Researcher or Commander.
+- Do NOT run git add, git commit, git push, or any git write commands. Your role is code editing only. Git operations are handled by the Researcher or Operator.
 - Do NOT run git mv, git rm, or git checkout. Only edit file contents.
 
 Respond with:

--- a/winsmux-core/scripts/agent-monitor.ps1
+++ b/winsmux-core/scripts/agent-monitor.ps1
@@ -267,7 +267,7 @@ function Update-MonitorIdleAlertState {
 
     $elapsedSeconds = ($Now - $readySince).TotalSeconds
     if (($elapsedSeconds -ge $IdleThresholdSeconds) -and ((-not $alertSent) -or $repeatAlertDue)) {
-        $message = "Commander alert: idle pane $Label ($PaneId, role=$Role)"
+        $message = "Operator alert: idle pane $Label ($PaneId, role=$Role)"
         Save-MonitorIdleState -PaneId $PaneId -ReadySince $readySince -AlertSent $true -LastAlertAt $Now
         $result['ShouldAlert'] = $true
         $result['Message'] = $message
@@ -595,7 +595,7 @@ function Write-MonitorEvent {
     }
 }
 
-function Get-MonitorCommanderMailboxChannel {
+function Get-MonitorOperatorMailboxChannel {
     param([string]$SessionName = 'winsmux-orchestra')
 
     $resolvedSessionName = if ([string]::IsNullOrWhiteSpace($SessionName)) {
@@ -605,10 +605,10 @@ function Get-MonitorCommanderMailboxChannel {
     }
 
     $safeSessionName = [regex]::Replace($resolvedSessionName, '[^A-Za-z0-9_-]', '-')
-    return "$safeSessionName-commander"
+    return "$safeSessionName-operator"
 }
 
-function Send-MonitorCommanderMailboxMessage {
+function Send-MonitorOperatorMailboxMessage {
     param(
         [string]$SessionName = 'winsmux-orchestra',
         [Parameter(Mandatory = $true)][string]$Event,
@@ -626,10 +626,10 @@ function Send-MonitorCommanderMailboxMessage {
     }
 
     $bridgeScript = [System.IO.Path]::GetFullPath((Join-Path $scriptDir '..\..\scripts\winsmux-core.ps1'))
-    $channel = Get-MonitorCommanderMailboxChannel -SessionName $SessionName
+    $channel = Get-MonitorOperatorMailboxChannel -SessionName $SessionName
     $payload = [ordered]@{
         from      = if ([string]::IsNullOrWhiteSpace($Label)) { 'agent-monitor' } else { $Label }
-        to        = 'Commander'
+        to        = 'Operator'
         content   = [ordered]@{
             session     = if ([string]::IsNullOrWhiteSpace($SessionName)) { 'winsmux-orchestra' } else { $SessionName }
             event       = $Event
@@ -1289,18 +1289,18 @@ function Invoke-AgentMonitorCycle {
                     $result['Message'] = [string](Get-MonitorPropertyValue -InputObject $approvalResult -Name 'Message' -Default "Auto-approved trust prompt in pane $paneId")
                     Write-Output $result['Message']
                 } catch {
-                    $approvalMessage = "Commander alert: $label ($paneId) awaiting approval (auto-approve failed: $($_.Exception.Message))"
+                    $approvalMessage = "Operator alert: $label ($paneId) awaiting approval (auto-approve failed: $($_.Exception.Message))"
                     $result['Message'] = $approvalMessage
                     Write-Output $approvalMessage
                 }
             } else {
-                $approvalMessage = "Commander alert: $label ($paneId) awaiting approval"
+                $approvalMessage = "Operator alert: $label ($paneId) awaiting approval"
                 $result['Message'] = $approvalMessage
                 Write-Output $approvalMessage
             }
 
             try {
-                Send-MonitorCommanderMailboxMessage -SessionName $SessionName `
+                Send-MonitorOperatorMailboxMessage -SessionName $SessionName `
                     -Event 'pane.approval_waiting' -Message $result['Message'] `
                     -Label $label -PaneId $paneId -Role $role -Status $statusName -ExitReason $statusExitReason `
                     -Data (Merge-OrchestraPaneEventData -StateModel $paneStateModel -Data $stateEventData) | Out-Null
@@ -1360,7 +1360,7 @@ function Invoke-AgentMonitorCycle {
                     snapshot_hash          = $statusSnapshotHash
                 })) | Out-Null
             try {
-                Send-MonitorCommanderMailboxMessage -SessionName $SessionName `
+                Send-MonitorOperatorMailboxMessage -SessionName $SessionName `
                     -Event 'pane.idle' -Message $idleAlert.Message `
                     -Label $label -PaneId $paneId -Role $role -Status $statusName -ExitReason $statusExitReason `
                     -Data (Merge-OrchestraPaneEventData -StateModel $paneStateModel -Data ([ordered]@{
@@ -1377,7 +1377,7 @@ function Invoke-AgentMonitorCycle {
         if ($stallDetected) {
             $stallCount++
             $result['StallDetected'] = $true
-            $stallMessage = "Commander alert: stalled Builder pane $label ($paneId)"
+            $stallMessage = "Operator alert: stalled Builder pane $label ($paneId)"
             $result['Message'] = $stallMessage
             Write-Output $stallMessage
             Write-MonitorEvent -ProjectDir $projectDir -SessionName $SessionName `
@@ -1390,7 +1390,7 @@ function Invoke-AgentMonitorCycle {
                     snapshot_hash    = $statusSnapshotHash
                 })) | Out-Null
             try {
-                Send-MonitorCommanderMailboxMessage -SessionName $SessionName `
+                Send-MonitorOperatorMailboxMessage -SessionName $SessionName `
                     -Event 'pane.stalled' -Message $stallMessage `
                     -Label $label -PaneId $paneId -Role $role -Status $statusName -ExitReason $statusExitReason `
                     -Data (Merge-OrchestraPaneEventData -StateModel $paneStateModel -Data ([ordered]@{

--- a/winsmux-core/scripts/builder-queue.ps1
+++ b/winsmux-core/scripts/builder-queue.ps1
@@ -569,7 +569,7 @@ function Complete-BuilderQueueTask {
         task_id       = $completedEntry.TaskId
         task          = $completedEntry.Task
         task_state    = 'completed'
-        task_owner    = 'Commander'
+        task_owner    = 'Operator'
         last_event    = 'builder.queue.completed'
         last_event_at = (Get-Date).ToString('o')
     })

--- a/winsmux-core/scripts/dispatch-router.ps1
+++ b/winsmux-core/scripts/dispatch-router.ps1
@@ -2,7 +2,7 @@
 param(
     [string]$Text,
     [string[]]$AvailableTargets = @(),
-    [ValidateSet('Worker', 'Builder', 'Reviewer', 'Researcher', 'Commander')]
+    [ValidateSet('Worker', 'Builder', 'Reviewer', 'Researcher', 'Operator')]
     [string]$DefaultRole = 'Worker',
     [switch]$AsJson
 )
@@ -31,7 +31,7 @@ function Get-DispatchRouterKeywordMap {
             'lookup', 'document', 'docs',
             '調査', 'リサーチ', '分析', '探して', '比較', '要約', '検索'
         )
-        Commander = @(
+        Operator = @(
             'plan', 'planner', 'backlog', 'triage', 'coordinate', 'orchestrate',
             'dispatch', 'assign', 'commit', 'merge', 'branch', 'release', 'session',
             'マージ', 'デプロイ', 'リリース', '承認', '計画'
@@ -47,7 +47,7 @@ function Get-DispatchRouterCanonicalRole {
         '^(?i)builder(?:$|[-_:/\s])' { return 'Builder' }
         '^(?i)reviewer(?:$|[-_:/\s])' { return 'Reviewer' }
         '^(?i)researcher(?:$|[-_:/\s])' { return 'Researcher' }
-        '^(?i)commander(?:$|[-_:/\s])' { return 'Commander' }
+        '^(?i)operator(?:$|[-_:/\s])' { return 'Operator' }
         default { return $null }
     }
 }
@@ -110,7 +110,7 @@ function Get-DispatchRoute {
     param(
         [Parameter(Mandatory = $true)][AllowEmptyString()][string]$Text,
         [string[]]$AvailableTargets = @(),
-        [ValidateSet('Worker', 'Builder', 'Reviewer', 'Researcher', 'Commander')]
+        [ValidateSet('Worker', 'Builder', 'Reviewer', 'Researcher', 'Operator')]
         [string]$DefaultRole = 'Worker'
     )
 
@@ -146,11 +146,11 @@ function Get-DispatchRoute {
     }
 
     $selectedTarget = Get-DispatchRouterPreferredLabel -Role $bestRole -AvailableTargets $AvailableTargets
-    if ($bestRole -ne 'Commander' -and $null -eq $selectedTarget) {
+    if ($bestRole -ne 'Operator' -and $null -eq $selectedTarget) {
         $selectedTarget = Get-DispatchRouterPreferredLabel -Role 'Worker' -AvailableTargets $AvailableTargets
     }
 
-    $handleLocally = $bestRole -eq 'Commander' -or $null -eq $selectedTarget
+    $handleLocally = $bestRole -eq 'Operator' -or $null -eq $selectedTarget
 
     $reason = if ($bestScore -gt 0) {
         "Matched role '$bestRole' via: $($bestMatches -join ', ')"
@@ -158,14 +158,14 @@ function Get-DispatchRoute {
         "No routing keywords matched. Defaulted to '$bestRole'."
     }
 
-    if ($bestRole -ne 'Commander' -and $null -eq $selectedTarget) {
+    if ($bestRole -ne 'Operator' -and $null -eq $selectedTarget) {
         $reason = "$reason No '$bestRole' target is available."
-    } elseif ($bestRole -ne 'Commander' -and $null -ne $selectedTarget -and (Get-DispatchRouterCanonicalRole $selectedTarget) -eq 'Worker') {
+    } elseif ($bestRole -ne 'Operator' -and $null -ne $selectedTarget -and (Get-DispatchRouterCanonicalRole $selectedTarget) -eq 'Worker') {
         $reason = "$reason Routed to generic worker target '$selectedTarget'."
     }
 
-    if ($bestRole -eq 'Commander') {
-        $reason = "$reason Handle this task locally as Commander."
+    if ($bestRole -eq 'Operator') {
+        $reason = "$reason Handle this task locally as Operator."
     }
 
     return [PSCustomObject]@{

--- a/winsmux-core/scripts/operator-poll.ps1
+++ b/winsmux-core/scripts/operator-poll.ps1
@@ -31,7 +31,7 @@ if (-not (Get-Command Get-WinsmuxBin -ErrorAction SilentlyContinue)) {
     }
 }
 
-function Get-CommanderPollValue {
+function Get-OperatorPollValue {
     param(
         [AllowNull()]$InputObject,
         [Parameter(Mandatory = $true)][string]$Name,
@@ -53,7 +53,7 @@ function Get-CommanderPollValue {
     return $Default
 }
 
-function ConvertFrom-CommanderPollYamlScalar {
+function ConvertFrom-OperatorPollYamlScalar {
     param([AllowNull()]$Value)
 
     if ($null -eq $Value) {
@@ -74,7 +74,7 @@ function ConvertFrom-CommanderPollYamlScalar {
     return $text
 }
 
-function ConvertFrom-CommanderPollManifestContent {
+function ConvertFrom-OperatorPollManifestContent {
     param([Parameter(Mandatory = $true)][string]$Content)
 
     $parsed = ConvertFrom-ManifestYaml -Content $Content
@@ -84,7 +84,7 @@ function ConvertFrom-CommanderPollManifestContent {
     }
 }
 
-function Read-CommanderPollManifest {
+function Read-OperatorPollManifest {
     param([Parameter(Mandatory = $true)][string]$Path)
 
     if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
@@ -96,16 +96,16 @@ function Read-CommanderPollManifest {
         throw "Manifest is empty: $Path"
     }
 
-    return ConvertFrom-CommanderPollManifestContent -Content $content
+    return ConvertFrom-OperatorPollManifestContent -Content $content
 }
 
-function Get-CommanderPollProjectDir {
+function Get-OperatorPollProjectDir {
     param(
         [Parameter(Mandatory = $true)]$Manifest,
         [Parameter(Mandatory = $true)][string]$ManifestPath
     )
 
-    $projectDir = [string](Get-CommanderPollValue -InputObject $Manifest['Session'] -Name 'project_dir' -Default '')
+    $projectDir = [string](Get-OperatorPollValue -InputObject $Manifest['Session'] -Name 'project_dir' -Default '')
     if (-not [string]::IsNullOrWhiteSpace($projectDir)) {
         return $projectDir
     }
@@ -113,10 +113,10 @@ function Get-CommanderPollProjectDir {
     return Split-Path (Split-Path $ManifestPath -Parent) -Parent
 }
 
-function Get-CommanderPollSessionName {
+function Get-OperatorPollSessionName {
     param([Parameter(Mandatory = $true)]$Manifest)
 
-    $sessionName = [string](Get-CommanderPollValue -InputObject $Manifest['Session'] -Name 'name' -Default '')
+    $sessionName = [string](Get-OperatorPollValue -InputObject $Manifest['Session'] -Name 'name' -Default '')
     if ([string]::IsNullOrWhiteSpace($sessionName)) {
         return 'winsmux-orchestra'
     }
@@ -124,21 +124,21 @@ function Get-CommanderPollSessionName {
     return $sessionName
 }
 
-function Get-CommanderPollEventsPath {
+function Get-OperatorPollEventsPath {
     param([Parameter(Mandatory = $true)][string]$ProjectDir)
 
     return Join-Path (Join-Path $ProjectDir '.winsmux') 'events.jsonl'
 }
 
-function Get-CommanderPollLogPath {
+function Get-OperatorPollLogPath {
     param([Parameter(Mandatory = $true)][string]$ProjectDir)
 
     $logDir = Join-Path $ProjectDir '.winsmux\logs'
     [System.IO.Directory]::CreateDirectory($logDir) | Out-Null
-    return Join-Path $logDir 'commander-poll.jsonl'
+    return Join-Path $logDir 'operator-poll.jsonl'
 }
 
-function Write-CommanderPollLog {
+function Write-OperatorPollLog {
     param(
         [Parameter(Mandatory = $true)][string]$ProjectDir,
         [Parameter(Mandatory = $true)][string]$SessionName,
@@ -160,27 +160,27 @@ function Write-CommanderPollLog {
     }
 
     $line = ($record | ConvertTo-Json -Compress -Depth 10)
-    Write-WinsmuxTextFile -Path (Get-CommanderPollLogPath -ProjectDir $ProjectDir) -Content $line -Append
+    Write-WinsmuxTextFile -Path (Get-OperatorPollLogPath -ProjectDir $ProjectDir) -Content $line -Append
 }
 
-function Get-CommanderPollPaneContext {
+function Get-OperatorPollPaneContext {
     param(
         [Parameter(Mandatory = $true)]$Manifest,
         [Parameter(Mandatory = $true)][string]$ManifestPath,
         [Parameter(Mandatory = $true)]$EventRecord
     )
 
-    $eventPaneId = [string](Get-CommanderPollValue -InputObject $EventRecord -Name 'pane_id' -Default '')
-    $eventLabel = [string](Get-CommanderPollValue -InputObject $EventRecord -Name 'label' -Default '')
-    $eventRole = [string](Get-CommanderPollValue -InputObject $EventRecord -Name 'role' -Default '')
-    $projectDir = Get-CommanderPollProjectDir -Manifest $Manifest -ManifestPath $ManifestPath
+    $eventPaneId = [string](Get-OperatorPollValue -InputObject $EventRecord -Name 'pane_id' -Default '')
+    $eventLabel = [string](Get-OperatorPollValue -InputObject $EventRecord -Name 'label' -Default '')
+    $eventRole = [string](Get-OperatorPollValue -InputObject $EventRecord -Name 'role' -Default '')
+    $projectDir = Get-OperatorPollProjectDir -Manifest $Manifest -ManifestPath $ManifestPath
 
     $matchedLabel = $eventLabel
     $matchedPane = $null
 
     foreach ($label in $Manifest['Panes'].Keys) {
         $pane = $Manifest['Panes'][$label]
-        $paneId = [string](Get-CommanderPollValue -InputObject $pane -Name 'pane_id' -Default '')
+        $paneId = [string](Get-OperatorPollValue -InputObject $pane -Name 'pane_id' -Default '')
 
         if (-not [string]::IsNullOrWhiteSpace($eventPaneId) -and $paneId -eq $eventPaneId) {
             $matchedLabel = $label
@@ -197,7 +197,7 @@ function Get-CommanderPollPaneContext {
 
     $role = $eventRole
     if ($null -ne $matchedPane) {
-        $paneRole = [string](Get-CommanderPollValue -InputObject $matchedPane -Name 'role' -Default '')
+        $paneRole = [string](Get-OperatorPollValue -InputObject $matchedPane -Name 'role' -Default '')
         if (-not [string]::IsNullOrWhiteSpace($paneRole)) {
             $role = $paneRole
         }
@@ -206,7 +206,7 @@ function Get-CommanderPollPaneContext {
     $worktreePath = ''
     if ($null -ne $matchedPane) {
         foreach ($key in @('builder_worktree_path', 'launch_dir')) {
-            $candidate = [string](Get-CommanderPollValue -InputObject $matchedPane -Name $key -Default '')
+            $candidate = [string](Get-OperatorPollValue -InputObject $matchedPane -Name $key -Default '')
             if (-not [string]::IsNullOrWhiteSpace($candidate)) {
                 $worktreePath = $candidate
                 break
@@ -220,27 +220,27 @@ function Get-CommanderPollPaneContext {
 
     $resolvedPaneId = $eventPaneId
     if ([string]::IsNullOrWhiteSpace($resolvedPaneId) -and $null -ne $matchedPane) {
-        $resolvedPaneId = [string](Get-CommanderPollValue -InputObject $matchedPane -Name 'pane_id' -Default '')
+        $resolvedPaneId = [string](Get-OperatorPollValue -InputObject $matchedPane -Name 'pane_id' -Default '')
     }
 
     return [ordered]@{
         project_dir   = $projectDir
-        session_name  = Get-CommanderPollSessionName -Manifest $Manifest
+        session_name  = Get-OperatorPollSessionName -Manifest $Manifest
         pane_id       = $resolvedPaneId
         label         = $matchedLabel
         role          = $role
         worktree_path = $worktreePath
-        task_id       = if ($null -ne $matchedPane) { [string](Get-CommanderPollValue -InputObject $matchedPane -Name 'task_id' -Default '') } else { '' }
-        task          = if ($null -ne $matchedPane) { [string](Get-CommanderPollValue -InputObject $matchedPane -Name 'task' -Default '') } else { '' }
-        task_state    = if ($null -ne $matchedPane) { [string](Get-CommanderPollValue -InputObject $matchedPane -Name 'task_state' -Default '') } else { '' }
-        task_owner    = if ($null -ne $matchedPane) { [string](Get-CommanderPollValue -InputObject $matchedPane -Name 'task_owner' -Default '') } else { '' }
-        review_state  = if ($null -ne $matchedPane) { [string](Get-CommanderPollValue -InputObject $matchedPane -Name 'review_state' -Default '') } else { '' }
-        branch        = if ($null -ne $matchedPane) { [string](Get-CommanderPollValue -InputObject $matchedPane -Name 'branch' -Default '') } else { '' }
-        head_sha      = if ($null -ne $matchedPane) { [string](Get-CommanderPollValue -InputObject $matchedPane -Name 'head_sha' -Default '') } else { '' }
+        task_id       = if ($null -ne $matchedPane) { [string](Get-OperatorPollValue -InputObject $matchedPane -Name 'task_id' -Default '') } else { '' }
+        task          = if ($null -ne $matchedPane) { [string](Get-OperatorPollValue -InputObject $matchedPane -Name 'task' -Default '') } else { '' }
+        task_state    = if ($null -ne $matchedPane) { [string](Get-OperatorPollValue -InputObject $matchedPane -Name 'task_state' -Default '') } else { '' }
+        task_owner    = if ($null -ne $matchedPane) { [string](Get-OperatorPollValue -InputObject $matchedPane -Name 'task_owner' -Default '') } else { '' }
+        review_state  = if ($null -ne $matchedPane) { [string](Get-OperatorPollValue -InputObject $matchedPane -Name 'review_state' -Default '') } else { '' }
+        branch        = if ($null -ne $matchedPane) { [string](Get-OperatorPollValue -InputObject $matchedPane -Name 'branch' -Default '') } else { '' }
+        head_sha      = if ($null -ne $matchedPane) { [string](Get-OperatorPollValue -InputObject $matchedPane -Name 'head_sha' -Default '') } else { '' }
     }
 }
 
-function Update-CommanderPollPaneState {
+function Update-OperatorPollPaneState {
     param(
         [Parameter(Mandatory = $true)]$PaneContext,
         [Parameter(Mandatory = $true)][System.Collections.IDictionary]$Properties
@@ -262,7 +262,7 @@ function Update-CommanderPollPaneState {
     }
 }
 
-function New-CommanderPollStateData {
+function New-OperatorPollStateData {
     param(
         [Parameter(Mandatory = $true)]$PaneContext,
         [AllowNull()]$Data = $null
@@ -288,7 +288,7 @@ function New-CommanderPollStateData {
     return $stateData
 }
 
-function Invoke-CommanderPollWinsmux {
+function Invoke-OperatorPollWinsmux {
     param([Parameter(Mandatory = $true)][string[]]$Arguments)
 
     $winsmuxBin = Get-WinsmuxBin
@@ -309,22 +309,22 @@ function Invoke-CommanderPollWinsmux {
     return $output
 }
 
-function Approve-CommanderPollPane {
+function Approve-OperatorPollPane {
     param([Parameter(Mandatory = $true)][string]$PaneId)
 
-    Invoke-CommanderPollWinsmux -Arguments @('send-keys', '-t', $PaneId, 'Enter') | Out-Null
+    Invoke-OperatorPollWinsmux -Arguments @('send-keys', '-t', $PaneId, 'Enter') | Out-Null
 }
 
-function Send-CommanderPollLiteral {
+function Send-OperatorPollLiteral {
     param(
         [Parameter(Mandatory = $true)][string]$PaneId,
         [Parameter(Mandatory = $true)][string]$Text
     )
 
-    Invoke-CommanderPollWinsmux -Arguments @('send-keys', '-t', $PaneId, '-l', '--', $Text) | Out-Null
+    Invoke-OperatorPollWinsmux -Arguments @('send-keys', '-t', $PaneId, '-l', '--', $Text) | Out-Null
 }
 
-function Get-CommanderPollGitOutput {
+function Get-OperatorPollGitOutput {
     param(
         [Parameter(Mandatory = $true)][string]$WorktreePath,
         [Parameter(Mandatory = $true)][string[]]$Arguments
@@ -342,14 +342,14 @@ function Get-CommanderPollGitOutput {
     return @($output | ForEach-Object { [string]$_ } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
 }
 
-function Get-CommanderPollDiffData {
+function Get-OperatorPollDiffData {
     param([Parameter(Mandatory = $true)][string]$WorktreePath)
 
-    $statusLines = Get-CommanderPollGitOutput -WorktreePath $WorktreePath -Arguments @('status', '--short', '--untracked-files=all')
-    $unstagedDiff = Get-CommanderPollGitOutput -WorktreePath $WorktreePath -Arguments @('diff', '--stat', '--no-ext-diff')
-    $stagedDiff = Get-CommanderPollGitOutput -WorktreePath $WorktreePath -Arguments @('diff', '--cached', '--stat', '--no-ext-diff')
-    $branchLines = Get-CommanderPollGitOutput -WorktreePath $WorktreePath -Arguments @('rev-parse', '--abbrev-ref', 'HEAD')
-    $headShaLines = Get-CommanderPollGitOutput -WorktreePath $WorktreePath -Arguments @('rev-parse', 'HEAD')
+    $statusLines = Get-OperatorPollGitOutput -WorktreePath $WorktreePath -Arguments @('status', '--short', '--untracked-files=all')
+    $unstagedDiff = Get-OperatorPollGitOutput -WorktreePath $WorktreePath -Arguments @('diff', '--stat', '--no-ext-diff')
+    $stagedDiff = Get-OperatorPollGitOutput -WorktreePath $WorktreePath -Arguments @('diff', '--cached', '--stat', '--no-ext-diff')
+    $branchLines = Get-OperatorPollGitOutput -WorktreePath $WorktreePath -Arguments @('rev-parse', '--abbrev-ref', 'HEAD')
+    $headShaLines = Get-OperatorPollGitOutput -WorktreePath $WorktreePath -Arguments @('rev-parse', 'HEAD')
 
     $changedFiles = @()
     foreach ($statusLine in $statusLines) {
@@ -374,25 +374,25 @@ function Get-CommanderPollDiffData {
     }
 }
 
-function Test-CommanderPollApprovalEvent {
+function Test-OperatorPollApprovalEvent {
     param([Parameter(Mandatory = $true)]$EventRecord)
 
-    $eventName = [string](Get-CommanderPollValue -InputObject $EventRecord -Name 'event' -Default '')
+    $eventName = [string](Get-OperatorPollValue -InputObject $EventRecord -Name 'event' -Default '')
     if ($eventName -eq 'approval_waiting') {
         return $true
     }
 
-    $status = [string](Get-CommanderPollValue -InputObject $EventRecord -Name 'status' -Default '')
+    $status = [string](Get-OperatorPollValue -InputObject $EventRecord -Name 'status' -Default '')
     if ($status -eq 'approval_waiting') {
         return $true
     }
 
-    $data = Get-CommanderPollValue -InputObject $EventRecord -Name 'data' -Default $null
-    $dataStatus = [string](Get-CommanderPollValue -InputObject $data -Name 'status' -Default '')
+    $data = Get-OperatorPollValue -InputObject $EventRecord -Name 'data' -Default $null
+    $dataStatus = [string](Get-OperatorPollValue -InputObject $data -Name 'status' -Default '')
     return ($eventName -eq 'monitor.status' -and $dataStatus -eq 'approval_waiting')
 }
 
-function New-CommanderPollCycleSummary {
+function New-OperatorPollCycleSummary {
     param(
         [Parameter(Mandatory = $true)][string]$ManifestPath,
         [Parameter(Mandatory = $true)][string]$EventsPath
@@ -412,7 +412,7 @@ function New-CommanderPollCycleSummary {
     }
 }
 
-function Get-CommanderPollMailboxChannel {
+function Get-OperatorPollMailboxChannel {
     param([string]$SessionName = 'winsmux-orchestra')
 
     $resolvedSessionName = if ([string]::IsNullOrWhiteSpace($SessionName)) {
@@ -422,10 +422,10 @@ function Get-CommanderPollMailboxChannel {
     }
 
     $safeSessionName = [regex]::Replace($resolvedSessionName, '[^A-Za-z0-9_-]', '-')
-    return "$safeSessionName-commander"
+    return "$safeSessionName-operator"
 }
 
-function Receive-CommanderPollMailboxMessages {
+function Receive-OperatorPollMailboxMessages {
     param(
         [string]$SessionName = 'winsmux-orchestra',
         [int]$TimeoutMilliseconds = 25,
@@ -433,7 +433,7 @@ function Receive-CommanderPollMailboxMessages {
     )
 
     $messages = [System.Collections.Generic.List[object]]::new()
-    $pipeName = "winsmux-mailbox-$(Get-CommanderPollMailboxChannel -SessionName $SessionName)"
+    $pipeName = "winsmux-mailbox-$(Get-OperatorPollMailboxChannel -SessionName $SessionName)"
 
     for ($messageIndex = 0; $messageIndex -lt $MaxMessages; $messageIndex++) {
         $server = $null
@@ -468,25 +468,25 @@ function Receive-CommanderPollMailboxMessages {
                 continue
             }
 
-            $content = Get-CommanderPollValue -InputObject $mailboxMessage -Name 'content' -Default $null
-            $eventName = [string](Get-CommanderPollValue -InputObject $content -Name 'event' -Default '')
+            $content = Get-OperatorPollValue -InputObject $mailboxMessage -Name 'content' -Default $null
+            $eventName = [string](Get-OperatorPollValue -InputObject $content -Name 'event' -Default '')
             if ([string]::IsNullOrWhiteSpace($eventName)) {
                 continue
             }
 
             $messages.Add([ordered]@{
-                timestamp   = [string](Get-CommanderPollValue -InputObject $mailboxMessage -Name 'timestamp' -Default ([System.DateTimeOffset]::Now.ToString('o')))
-                session     = [string](Get-CommanderPollValue -InputObject $content -Name 'session' -Default $SessionName)
+                timestamp   = [string](Get-OperatorPollValue -InputObject $mailboxMessage -Name 'timestamp' -Default ([System.DateTimeOffset]::Now.ToString('o')))
+                session     = [string](Get-OperatorPollValue -InputObject $content -Name 'session' -Default $SessionName)
                 event       = $eventName
-                message     = [string](Get-CommanderPollValue -InputObject $content -Name 'message' -Default '')
-                label       = [string](Get-CommanderPollValue -InputObject $content -Name 'label' -Default '')
-                pane_id     = [string](Get-CommanderPollValue -InputObject $content -Name 'pane_id' -Default '')
-                role        = [string](Get-CommanderPollValue -InputObject $content -Name 'role' -Default '')
-                status      = [string](Get-CommanderPollValue -InputObject $content -Name 'status' -Default '')
-                exit_reason = [string](Get-CommanderPollValue -InputObject $content -Name 'exit_reason' -Default '')
-                data        = Get-CommanderPollValue -InputObject $content -Name 'data' -Default ([ordered]@{})
+                message     = [string](Get-OperatorPollValue -InputObject $content -Name 'message' -Default '')
+                label       = [string](Get-OperatorPollValue -InputObject $content -Name 'label' -Default '')
+                pane_id     = [string](Get-OperatorPollValue -InputObject $content -Name 'pane_id' -Default '')
+                role        = [string](Get-OperatorPollValue -InputObject $content -Name 'role' -Default '')
+                status      = [string](Get-OperatorPollValue -InputObject $content -Name 'status' -Default '')
+                exit_reason = [string](Get-OperatorPollValue -InputObject $content -Name 'exit_reason' -Default '')
+                data        = Get-OperatorPollValue -InputObject $content -Name 'data' -Default ([ordered]@{})
                 source      = 'mailbox'
-                mailbox_from = [string](Get-CommanderPollValue -InputObject $mailboxMessage -Name 'from' -Default '')
+                mailbox_from = [string](Get-OperatorPollValue -InputObject $mailboxMessage -Name 'from' -Default '')
             })
         } catch {
             break
@@ -500,18 +500,18 @@ function Receive-CommanderPollMailboxMessages {
     return @($messages)
 }
 
-function Get-CommanderPollEventSignature {
+function Get-OperatorPollEventSignature {
     param([Parameter(Mandatory = $true)]$EventRecord)
 
     return '{0}|{1}|{2}|{3}|{4}' -f `
-        ([string](Get-CommanderPollValue -InputObject $EventRecord -Name 'event' -Default '')), `
-        ([string](Get-CommanderPollValue -InputObject $EventRecord -Name 'pane_id' -Default '')), `
-        ([string](Get-CommanderPollValue -InputObject $EventRecord -Name 'label' -Default '')), `
-        ([string](Get-CommanderPollValue -InputObject $EventRecord -Name 'status' -Default '')), `
-        ([string](Get-CommanderPollValue -InputObject $EventRecord -Name 'message' -Default ''))
+        ([string](Get-OperatorPollValue -InputObject $EventRecord -Name 'event' -Default '')), `
+        ([string](Get-OperatorPollValue -InputObject $EventRecord -Name 'pane_id' -Default '')), `
+        ([string](Get-OperatorPollValue -InputObject $EventRecord -Name 'label' -Default '')), `
+        ([string](Get-OperatorPollValue -InputObject $EventRecord -Name 'status' -Default '')), `
+        ([string](Get-OperatorPollValue -InputObject $EventRecord -Name 'message' -Default ''))
 }
 
-function Get-CommanderTelegramNotificationProfile {
+function Get-OperatorTelegramNotificationProfile {
     $profile = [string]$env:WINSMUX_TELEGRAM_PROFILE
     if (-not [string]::IsNullOrWhiteSpace($profile)) {
         switch ($profile.Trim().ToLowerInvariant()) {
@@ -529,27 +529,27 @@ function Get-CommanderTelegramNotificationProfile {
     return 'external'
 }
 
-function Test-CommanderTelegramNotificationEnabled {
+function Test-OperatorTelegramNotificationEnabled {
     param([Parameter(Mandatory = $true)][string]$Event)
 
     $externalFacingEvents = @(
-        'commander.review_requested',
-        'commander.review_passed',
-        'commander.review_failed',
-        'commander.blocked',
-        'commander.commit_ready',
-        'commander.commit_done'
+        'operator.review_requested',
+        'operator.review_passed',
+        'operator.review_failed',
+        'operator.blocked',
+        'operator.commit_ready',
+        'operator.commit_done'
     )
 
     $internalOnlyEvents = @(
-        'commander.dispatch_needed',
-        'commander.auto_approved',
-        'commander.started',
+        'operator.dispatch_needed',
+        'operator.auto_approved',
+        'operator.started',
         'pane.completed',
         'pane.exec_completed'
     )
 
-    switch (Get-CommanderTelegramNotificationProfile) {
+    switch (Get-OperatorTelegramNotificationProfile) {
         'none' { return $false }
         'verbose' { return $true }
         default {
@@ -566,7 +566,7 @@ function Test-CommanderTelegramNotificationEnabled {
     }
 }
 
-function Send-CommanderTelegramNotification {
+function Send-OperatorTelegramNotification {
     param(
         [Parameter(Mandatory = $true)][string]$ProjectDir,
         [Parameter(Mandatory = $true)][string]$SessionName,
@@ -579,7 +579,7 @@ function Send-CommanderTelegramNotification {
         [string]$HeadSha = ''
     )
 
-    if (-not (Test-CommanderTelegramNotificationEnabled -Event $Event)) {
+    if (-not (Test-OperatorTelegramNotificationEnabled -Event $Event)) {
         return
     }
 
@@ -616,7 +616,7 @@ function Send-CommanderTelegramNotification {
     }
 }
 
-function Invoke-CommanderPollEventRecord {
+function Invoke-OperatorPollEventRecord {
     param(
         [Parameter(Mandatory = $true)]$Manifest,
         [Parameter(Mandatory = $true)][string]$ManifestPath,
@@ -624,26 +624,26 @@ function Invoke-CommanderPollEventRecord {
         [Parameter(Mandatory = $true)]$Summary
     )
 
-    $projectDir = Get-CommanderPollProjectDir -Manifest $Manifest -ManifestPath $ManifestPath
-    $sessionName = Get-CommanderPollSessionName -Manifest $Manifest
-    $eventName = [string](Get-CommanderPollValue -InputObject $EventRecord -Name 'event' -Default '')
-    $paneContext = Get-CommanderPollPaneContext -Manifest $Manifest -ManifestPath $ManifestPath -EventRecord $EventRecord
+    $projectDir = Get-OperatorPollProjectDir -Manifest $Manifest -ManifestPath $ManifestPath
+    $sessionName = Get-OperatorPollSessionName -Manifest $Manifest
+    $eventName = [string](Get-OperatorPollValue -InputObject $EventRecord -Name 'event' -Default '')
+    $paneContext = Get-OperatorPollPaneContext -Manifest $Manifest -ManifestPath $ManifestPath -EventRecord $EventRecord
     $paneId = [string]$paneContext['pane_id']
-    $sourceName = [string](Get-CommanderPollValue -InputObject $EventRecord -Name 'source' -Default 'events_jsonl')
-    $sourceId = [string](Get-CommanderPollValue -InputObject $EventRecord -Name 'id' -Default '')
+    $sourceName = [string](Get-OperatorPollValue -InputObject $EventRecord -Name 'source' -Default 'events_jsonl')
+    $sourceId = [string](Get-OperatorPollValue -InputObject $EventRecord -Name 'id' -Default '')
     $Summary['new_events'] = [int]$Summary['new_events'] + 1
 
     if ($eventName -in @('pane.exec_completed', 'pane.completed')) {
-        $diffData = Get-CommanderPollDiffData -WorktreePath ([string]$paneContext['worktree_path'])
+        $diffData = Get-OperatorPollDiffData -WorktreePath ([string]$paneContext['worktree_path'])
         $message = "$($paneContext['label']) ($paneId) 完了。変更ファイル: $($diffData['changed_file_count'])件"
 
-        Write-CommanderPollLog `
+        Write-OperatorPollLog `
             -ProjectDir $projectDir `
             -SessionName $sessionName `
-            -EventName 'commander.poll.exec_completed' `
+            -EventName 'operator.poll.exec_completed' `
             -Message $message `
             -PaneId $paneId `
-            -Data (New-CommanderPollStateData -PaneContext $paneContext -Data ([ordered]@{
+            -Data (New-OperatorPollStateData -PaneContext $paneContext -Data ([ordered]@{
                     label     = $paneContext['label']
                     role      = $paneContext['role']
                     diff      = $diffData
@@ -653,18 +653,18 @@ function Invoke-CommanderPollEventRecord {
 
         $Summary['completions'] = [int]$Summary['completions'] + 1
         $Summary['messages'] += @($message)
-        Update-CommanderPollPaneState -PaneContext $paneContext -Properties ([ordered]@{
+        Update-OperatorPollPaneState -PaneContext $paneContext -Properties ([ordered]@{
                 task_state         = 'completed'
-                task_owner         = 'Commander'
-                branch             = [string](Get-CommanderPollValue -InputObject $diffData -Name 'branch' -Default '')
-                head_sha           = [string](Get-CommanderPollValue -InputObject $diffData -Name 'head_sha' -Default '')
-                changed_file_count = [int](Get-CommanderPollValue -InputObject $diffData -Name 'changed_file_count' -Default 0)
-                changed_files      = @(Get-CommanderPollValue -InputObject $diffData -Name 'changed_files' -Default @())
-                last_event         = 'commander.poll.exec_completed'
+                task_owner         = 'Operator'
+                branch             = [string](Get-OperatorPollValue -InputObject $diffData -Name 'branch' -Default '')
+                head_sha           = [string](Get-OperatorPollValue -InputObject $diffData -Name 'head_sha' -Default '')
+                changed_file_count = [int](Get-OperatorPollValue -InputObject $diffData -Name 'changed_file_count' -Default 0)
+                changed_files      = @(Get-OperatorPollValue -InputObject $diffData -Name 'changed_files' -Default @())
+                last_event         = 'operator.poll.exec_completed'
                 last_event_at      = (Get-Date).ToString('o')
             })
 
-        Send-CommanderTelegramNotification -ProjectDir $projectDir -SessionName $sessionName `
+        Send-OperatorTelegramNotification -ProjectDir $projectDir -SessionName $sessionName `
             -Event $eventName -Message $message -PaneId $paneId `
             -Label ([string]$paneContext['label']) -Role ([string]$paneContext['role']) `
             -Branch (git -C $projectDir rev-parse --abbrev-ref HEAD 2>$null) `
@@ -675,16 +675,16 @@ function Invoke-CommanderPollEventRecord {
     if ($eventName -eq 'pane.idle') {
         $message = "$($paneContext['label']) ($paneId) がアイドル。次タスクのディスパッチが必要"
 
-        Write-CommanderPollLog `
+        Write-OperatorPollLog `
             -ProjectDir $projectDir `
             -SessionName $sessionName `
-            -EventName 'commander.poll.idle_dispatch_needed' `
+            -EventName 'operator.poll.idle_dispatch_needed' `
             -Message $message `
             -PaneId $paneId `
-            -Data (New-CommanderPollStateData -PaneContext $paneContext -Data ([ordered]@{
+            -Data (New-OperatorPollStateData -PaneContext $paneContext -Data ([ordered]@{
                     label      = $paneContext['label']
                     role       = $paneContext['role']
-                    status     = [string](Get-CommanderPollValue -InputObject $EventRecord -Name 'status' -Default '')
+                    status     = [string](Get-OperatorPollValue -InputObject $EventRecord -Name 'status' -Default '')
                     event      = $eventName
                     source     = $sourceName
                     source_id  = $sourceId
@@ -692,36 +692,36 @@ function Invoke-CommanderPollEventRecord {
 
         $Summary['dispatches'] = [int]$Summary['dispatches'] + 1
         $Summary['messages'] += @($message)
-        Update-CommanderPollPaneState -PaneContext $paneContext -Properties ([ordered]@{
+        Update-OperatorPollPaneState -PaneContext $paneContext -Properties ([ordered]@{
                 task_state    = 'waiting_for_dispatch'
-                task_owner    = 'Commander'
-                last_event    = 'commander.poll.idle_dispatch_needed'
+                task_owner    = 'Operator'
+                last_event    = 'operator.poll.idle_dispatch_needed'
                 last_event_at = (Get-Date).ToString('o')
             })
 
-        Send-CommanderTelegramNotification -ProjectDir $projectDir -SessionName $sessionName `
-            -Event 'commander.dispatch_needed' -Message $message -PaneId $paneId `
+        Send-OperatorTelegramNotification -ProjectDir $projectDir -SessionName $sessionName `
+            -Event 'operator.dispatch_needed' -Message $message -PaneId $paneId `
             -Label ([string]$paneContext['label']) -Role ([string]$paneContext['role'])
         return
     }
 
-    if (Test-CommanderPollApprovalEvent -EventRecord $EventRecord) {
+    if (Test-OperatorPollApprovalEvent -EventRecord $EventRecord) {
         if ([string]::IsNullOrWhiteSpace($paneId)) {
             $Summary['errors'] = [int]$Summary['errors'] + 1
             $Summary['messages'] += @('approval_waiting event is missing pane_id')
             return
         }
 
-        Approve-CommanderPollPane -PaneId $paneId
+        Approve-OperatorPollPane -PaneId $paneId
         $message = "$($paneContext['label']) ($paneId) を自動承認"
 
-        Write-CommanderPollLog `
+        Write-OperatorPollLog `
             -ProjectDir $projectDir `
             -SessionName $sessionName `
-            -EventName 'commander.poll.auto_approved' `
+            -EventName 'operator.poll.auto_approved' `
             -Message $message `
             -PaneId $paneId `
-            -Data (New-CommanderPollStateData -PaneContext $paneContext -Data ([ordered]@{
+            -Data (New-OperatorPollStateData -PaneContext $paneContext -Data ([ordered]@{
                     label     = $paneContext['label']
                     role      = $paneContext['role']
                     source    = $sourceName
@@ -730,19 +730,19 @@ function Invoke-CommanderPollEventRecord {
 
         $Summary['approvals'] = [int]$Summary['approvals'] + 1
         $Summary['messages'] += @($message)
-        Update-CommanderPollPaneState -PaneContext $paneContext -Properties ([ordered]@{
-                task_owner    = 'Commander'
-                last_event    = 'commander.poll.auto_approved'
+        Update-OperatorPollPaneState -PaneContext $paneContext -Properties ([ordered]@{
+                task_owner    = 'Operator'
+                last_event    = 'operator.poll.auto_approved'
                 last_event_at = (Get-Date).ToString('o')
             })
 
-        Send-CommanderTelegramNotification -ProjectDir $projectDir -SessionName $sessionName `
-            -Event 'commander.auto_approved' -Message $message -PaneId $paneId `
+        Send-OperatorTelegramNotification -ProjectDir $projectDir -SessionName $sessionName `
+            -Event 'operator.auto_approved' -Message $message -PaneId $paneId `
             -Label ([string]$paneContext['label']) -Role ([string]$paneContext['role'])
     }
 }
 
-function Invoke-CommanderPollCycle {
+function Invoke-OperatorPollCycle {
     param(
         [Parameter(Mandatory = $true)][string]$ManifestPath,
         [int]$ProcessedLineCount = 0,
@@ -757,11 +757,11 @@ function Invoke-CommanderPollCycle {
         $ProcessedEventSignatures = [ordered]@{}
     }
 
-    $manifest = Read-CommanderPollManifest -Path $ManifestPath
-    $projectDir = Get-CommanderPollProjectDir -Manifest $manifest -ManifestPath $ManifestPath
-    $sessionName = Get-CommanderPollSessionName -Manifest $manifest
-    $eventsPath = Get-CommanderPollEventsPath -ProjectDir $projectDir
-    $summary = New-CommanderPollCycleSummary -ManifestPath $ManifestPath -EventsPath $eventsPath
+    $manifest = Read-OperatorPollManifest -Path $ManifestPath
+    $projectDir = Get-OperatorPollProjectDir -Manifest $manifest -ManifestPath $ManifestPath
+    $sessionName = Get-OperatorPollSessionName -Manifest $manifest
+    $eventsPath = Get-OperatorPollEventsPath -ProjectDir $projectDir
+    $summary = New-OperatorPollCycleSummary -ManifestPath $ManifestPath -EventsPath $eventsPath
 
     try {
         $eventRecords = [System.Collections.Generic.List[object]]::new()
@@ -792,30 +792,30 @@ function Invoke-CommanderPollCycle {
 
         $ProcessedLineCount = $lines.Count
 
-        $mailboxRecords = @(Receive-CommanderPollMailboxMessages -SessionName $sessionName)
+        $mailboxRecords = @(Receive-OperatorPollMailboxMessages -SessionName $sessionName)
         $summary['mailbox_events'] = $mailboxRecords.Count
         foreach ($mailboxRecord in $mailboxRecords) {
             $eventRecords.Add($mailboxRecord)
         }
 
         foreach ($eventRecord in $eventRecords) {
-            $signature = Get-CommanderPollEventSignature -EventRecord $eventRecord
+            $signature = Get-OperatorPollEventSignature -EventRecord $eventRecord
             if ($ProcessedEventSignatures.Contains($signature)) {
                 continue
             }
 
-            $ProcessedEventSignatures[$signature] = [string](Get-CommanderPollValue -InputObject $eventRecord -Name 'timestamp' -Default ([System.DateTimeOffset]::Now.ToString('o')))
-            Invoke-CommanderPollEventRecord -Manifest $manifest -ManifestPath $ManifestPath -EventRecord $eventRecord -Summary $summary
+            $ProcessedEventSignatures[$signature] = [string](Get-OperatorPollValue -InputObject $eventRecord -Name 'timestamp' -Default ([System.DateTimeOffset]::Now.ToString('o')))
+            Invoke-OperatorPollEventRecord -Manifest $manifest -ManifestPath $ManifestPath -EventRecord $eventRecord -Summary $summary
         }
     } catch {
         $summary['errors'] = [int]$summary['errors'] + 1
-        $errorMessage = "commander-poll cycle failed: $($_.Exception.Message)"
+        $errorMessage = "operator-poll cycle failed: $($_.Exception.Message)"
         $summary['messages'] += @($errorMessage)
 
-        Write-CommanderPollLog `
+        Write-OperatorPollLog `
             -ProjectDir $projectDir `
             -SessionName $sessionName `
-            -EventName 'commander.poll.error' `
+            -EventName 'operator.poll.error' `
             -Message $errorMessage `
             -Level 'error'
     }
@@ -827,7 +827,7 @@ function Invoke-CommanderPollCycle {
     }
 }
 
-function Get-CommanderPollPreferredReviewPane {
+function Get-OperatorPollPreferredReviewPane {
     param([AllowNull()]$Manifest)
 
     if ($null -eq $Manifest -or $null -eq $Manifest.Panes) {
@@ -837,11 +837,11 @@ function Get-CommanderPollPreferredReviewPane {
     foreach ($preferredRole in @('Reviewer', 'Worker')) {
         foreach ($label in $Manifest.Panes.Keys) {
             $pane = $Manifest.Panes[$label]
-            $role = [string](Get-CommanderPollValue -InputObject $pane -Name 'role' -Default '')
-            $status = [string](Get-CommanderPollValue -InputObject $pane -Name 'status' -Default '')
+            $role = [string](Get-OperatorPollValue -InputObject $pane -Name 'role' -Default '')
+            $status = [string](Get-OperatorPollValue -InputObject $pane -Name 'status' -Default '')
             if ($role -eq $preferredRole -and $status -ne 'bootstrap_invalid') {
                 return [ordered]@{
-                    PaneId = [string](Get-CommanderPollValue -InputObject $pane -Name 'pane_id' -Default '')
+                    PaneId = [string](Get-OperatorPollValue -InputObject $pane -Name 'pane_id' -Default '')
                     Label  = [string]$label
                     Role   = $role
                 }
@@ -852,7 +852,7 @@ function Get-CommanderPollPreferredReviewPane {
     return $null
 }
 
-function Invoke-CommanderStateMachine {
+function Invoke-OperatorStateMachine {
     param(
         [Parameter(Mandatory = $true)][string]$CurrentState,
         [Parameter(Mandatory = $true)]$CycleSummary,
@@ -877,17 +877,17 @@ function Invoke-CommanderStateMachine {
             try {
                 $branch = (git -C $ProjectDir rev-parse --abbrev-ref HEAD 2>$null)
                 $headSha = (git -C $ProjectDir rev-parse HEAD 2>$null)
-                $manifest = Read-CommanderPollManifest -Path $ManifestPath
-                $reviewPane = Get-CommanderPollPreferredReviewPane -Manifest $manifest
+                $manifest = Read-OperatorPollManifest -Path $ManifestPath
+                $reviewPane = Get-OperatorPollPreferredReviewPane -Manifest $manifest
                 if ($null -eq $reviewPane -or [string]::IsNullOrWhiteSpace([string]$reviewPane.PaneId)) {
-                    Send-CommanderTelegramNotification -ProjectDir $ProjectDir -SessionName $SessionName `
-                        -Event 'commander.blocked' -Message "Review 可能なペインが見つかりません。" -Branch $branch -HeadSha $headSha
+                    Send-OperatorTelegramNotification -ProjectDir $ProjectDir -SessionName $SessionName `
+                        -Event 'operator.blocked' -Message "Review 可能なペインが見つかりません。" -Branch $branch -HeadSha $headSha
                     $nextState = 'blocked_no_review_target'
                 } else {
-                    Send-CommanderPollLiteral -PaneId $reviewPane.PaneId -Text 'winsmux review-request'
-                    Approve-CommanderPollPane -PaneId $reviewPane.PaneId
-                    Send-CommanderTelegramNotification -ProjectDir $ProjectDir -SessionName $SessionName `
-                        -Event 'commander.review_requested' -Message "$($reviewPane.Label) ($($reviewPane.PaneId)) にレビュー依頼送信。PASS/FAIL 待機中。" `
+                    Send-OperatorPollLiteral -PaneId $reviewPane.PaneId -Text 'winsmux review-request'
+                    Approve-OperatorPollPane -PaneId $reviewPane.PaneId
+                    Send-OperatorTelegramNotification -ProjectDir $ProjectDir -SessionName $SessionName `
+                        -Event 'operator.review_requested' -Message "$($reviewPane.Label) ($($reviewPane.PaneId)) にレビュー依頼送信。PASS/FAIL 待機中。" `
                         -PaneId $reviewPane.PaneId -Label $reviewPane.Label -Role $reviewPane.Role -Branch $branch -HeadSha $headSha
                     $nextState = 'review_requested'
                 }
@@ -918,21 +918,21 @@ function Invoke-CommanderStateMachine {
                             }
                         }
                         $manifestReviewPaneId = ''
-                        $manifest2 = Read-CommanderPollManifest -Path $ManifestPath
-                        $reviewPane = Get-CommanderPollPreferredReviewPane -Manifest $manifest2
+                        $manifest2 = Read-OperatorPollManifest -Path $ManifestPath
+                        $reviewPane = Get-OperatorPollPreferredReviewPane -Manifest $manifest2
                         if ($null -ne $reviewPane) {
                             $manifestReviewPaneId = [string]$reviewPane.PaneId
                         }
                         $reviewTargetMatch = [string]::IsNullOrWhiteSpace($rsReviewPaneId) -or $rsReviewPaneId -eq $manifestReviewPaneId
                         if ($st -eq 'PASS' -and $sha -eq $headSha -and $reviewTargetMatch) {
-                            Send-CommanderTelegramNotification -ProjectDir $ProjectDir -SessionName $SessionName `
-                                -Event 'commander.review_passed' -Message "レビュー PASS。" -Branch $branch -HeadSha $headSha
+                            Send-OperatorTelegramNotification -ProjectDir $ProjectDir -SessionName $SessionName `
+                                -Event 'operator.review_passed' -Message "レビュー PASS。" -Branch $branch -HeadSha $headSha
                             $nextState = 'review_passed'
                         } elseif ($st -eq 'PASS' -and $sha -eq $headSha -and -not $reviewTargetMatch) {
                             Write-Warning "TASK-238: review PASS pane_id mismatch: review-state=$rsReviewPaneId manifest=$manifestReviewPaneId"
                         } elseif ($st -eq 'FAIL') {
-                            Send-CommanderTelegramNotification -ProjectDir $ProjectDir -SessionName $SessionName `
-                                -Event 'commander.review_failed' -Message "レビュー FAIL。修正が必要。" -Branch $branch -HeadSha $headSha
+                            Send-OperatorTelegramNotification -ProjectDir $ProjectDir -SessionName $SessionName `
+                                -Event 'operator.review_failed' -Message "レビュー FAIL。修正が必要。" -Branch $branch -HeadSha $headSha
                             $nextState = 'blocked_review_failed'
                         }
                     }
@@ -942,15 +942,15 @@ function Invoke-CommanderStateMachine {
         'review_passed' {
             $headSha = (git -C $ProjectDir rev-parse HEAD 2>$null)
             $nextCommitReadySha = $headSha
-            Send-CommanderTelegramNotification -ProjectDir $ProjectDir -SessionName $SessionName `
-                -Event 'commander.commit_ready' -Message "コミット準備完了。" -HeadSha $headSha
+            Send-OperatorTelegramNotification -ProjectDir $ProjectDir -SessionName $SessionName `
+                -Event 'operator.commit_ready' -Message "コミット準備完了。" -HeadSha $headSha
             $nextState = 'commit_ready'
         }
         'commit_ready' {
             $currentSha = (git -C $ProjectDir rev-parse HEAD 2>$null)
             if ($CommitReadySha -and $currentSha -ne $CommitReadySha) {
-                Send-CommanderTelegramNotification -ProjectDir $ProjectDir -SessionName $SessionName `
-                    -Event 'commander.commit_done' -Message "コミット検出。次タスク待機。" -HeadSha $currentSha
+                Send-OperatorTelegramNotification -ProjectDir $ProjectDir -SessionName $SessionName `
+                    -Event 'operator.commit_done' -Message "コミット検出。次タスク待機。" -HeadSha $currentSha
                 $nextState = 'waiting_for_dispatch'
                 $nextCommitReadySha = ''
             }
@@ -960,8 +960,8 @@ function Invoke-CommanderStateMachine {
         }
         'blocked_no_review_target' {
             try {
-                $manifest = Read-CommanderPollManifest -Path $ManifestPath
-                if ($null -ne (Get-CommanderPollPreferredReviewPane -Manifest $manifest)) {
+                $manifest = Read-OperatorPollManifest -Path $ManifestPath
+                if ($null -ne (Get-OperatorPollPreferredReviewPane -Manifest $manifest)) {
                     $nextState = 'waiting_for_review'
                 }
             } catch { }
@@ -970,15 +970,15 @@ function Invoke-CommanderStateMachine {
     }
 
     if ($nextState -ne $CurrentState) {
-        Write-CommanderPollLog -ProjectDir $ProjectDir -SessionName $SessionName `
-            -EventName 'commander.state_transition' -Message "State: $CurrentState -> $nextState" `
+        Write-OperatorPollLog -ProjectDir $ProjectDir -SessionName $SessionName `
+            -EventName 'operator.state_transition' -Message "State: $CurrentState -> $nextState" `
             -Data ([ordered]@{ from = $CurrentState; to = $nextState })
         try {
             $ep = Join-Path (Join-Path $ProjectDir '.winsmux') 'events.jsonl'
             $rec = [ordered]@{
                 timestamp = (Get-Date).ToString('o'); session = $SessionName
-                event = 'commander.state_transition'; message = "State: $CurrentState -> $nextState"
-                label = ''; pane_id = ''; role = 'Commander'; status = $nextState
+                event = 'operator.state_transition'; message = "State: $CurrentState -> $nextState"
+                label = ''; pane_id = ''; role = 'Operator'; status = $nextState
                 exit_reason = ''; data = [ordered]@{ from = $CurrentState; to = $nextState }
             }
             Write-WinsmuxTextFile -Path $ep -Content ($rec | ConvertTo-Json -Compress -Depth 10) -Append
@@ -993,9 +993,9 @@ if ($MyInvocation.InvocationName -ne '.') {
         throw "Manifest not found: $ManifestPath"
     }
 
-    $initialManifest = Read-CommanderPollManifest -Path $ManifestPath
-    $initialProjectDir = Get-CommanderPollProjectDir -Manifest $initialManifest -ManifestPath $ManifestPath
-    $eventsPath = Get-CommanderPollEventsPath -ProjectDir $initialProjectDir
+    $initialManifest = Read-OperatorPollManifest -Path $ManifestPath
+    $initialProjectDir = Get-OperatorPollProjectDir -Manifest $initialManifest -ManifestPath $ManifestPath
+    $eventsPath = Get-OperatorPollEventsPath -ProjectDir $initialProjectDir
     $processedLineCount = 0
     $processedEventSignatures = [ordered]@{}
 
@@ -1003,34 +1003,34 @@ if ($MyInvocation.InvocationName -ne '.') {
         $processedLineCount = @(Get-Content -LiteralPath $eventsPath -Encoding UTF8).Count
     }
 
-    Send-CommanderTelegramNotification -ProjectDir $initialProjectDir `
-        -SessionName (Get-CommanderPollSessionName -Manifest $initialManifest) `
-        -Event 'commander.started' -Message "Commander Poll 開始。間隔: ${Interval}秒"
+    Send-OperatorTelegramNotification -ProjectDir $initialProjectDir `
+        -SessionName (Get-OperatorPollSessionName -Manifest $initialManifest) `
+        -Event 'operator.started' -Message "Operator Poll 開始。間隔: ${Interval}秒"
 
-    $commanderState = 'starting'
+    $operatorState = 'starting'
     $commitReadySha = ''
 
     while ($true) {
-        $cycleResult = Invoke-CommanderPollCycle `
+        $cycleResult = Invoke-OperatorPollCycle `
             -ManifestPath $ManifestPath `
             -ProcessedLineCount $processedLineCount `
             -ProcessedEventSignatures $processedEventSignatures
 
         $processedLineCount = [int]$cycleResult['ProcessedLineCount']
         $processedEventSignatures = $cycleResult['ProcessedEventSignatures']
-        $smResult = Invoke-CommanderStateMachine `
-            -CurrentState $commanderState `
+        $smResult = Invoke-OperatorStateMachine `
+            -CurrentState $operatorState `
             -CycleSummary ($cycleResult['Summary']) `
             -ProjectDir $initialProjectDir `
-            -SessionName (Get-CommanderPollSessionName -Manifest (Read-CommanderPollManifest -Path $ManifestPath)) `
+            -SessionName (Get-OperatorPollSessionName -Manifest (Read-OperatorPollManifest -Path $ManifestPath)) `
             -ManifestPath $ManifestPath `
             -CommitReadySha $commitReadySha
 
-        $commanderState = [string]$smResult['State']
+        $operatorState = [string]$smResult['State']
         $commitReadySha = [string]$smResult['CommitReadySha']
 
         $summaryOutput = $cycleResult['Summary']
-        $summaryOutput['commander_state'] = $commanderState
+        $summaryOutput['operator_state'] = $operatorState
         Write-Output ($summaryOutput | ConvertTo-Json -Compress -Depth 10)
         Start-Sleep -Seconds $Interval
     }

--- a/winsmux-core/scripts/orchestra-layout.ps1
+++ b/winsmux-core/scripts/orchestra-layout.ps1
@@ -5,7 +5,7 @@
 [CmdletBinding()]
 param(
     [string]$SessionName = $env:WINSMUX_ORCHESTRA_SESSION,
-    [int]$Commanders = 0,
+    [int]$Operators = 0,
     [int]$Workers = 0,
     [int]$Builders = 0,
     [int]$Researchers = 0,
@@ -107,7 +107,7 @@ function Split-Equal {
 
 function Get-RoleLabels {
     param(
-        [int]$CommanderCount = 0,
+        [int]$OperatorCount = 0,
         [int]$WorkerCount = 0,
         [int]$BuilderCount,
         [int]$ResearcherCount,
@@ -116,8 +116,8 @@ function Get-RoleLabels {
 
     $labels = [System.Collections.Generic.List[string]]::new()
 
-    for ($i = 1; $i -le $CommanderCount; $i++) {
-        $labels.Add("Commander-$i")
+    for ($i = 1; $i -le $OperatorCount; $i++) {
+        $labels.Add("Operator-$i")
     }
 
     for ($i = 1; $i -le $WorkerCount; $i++) {
@@ -139,7 +139,7 @@ function Get-RoleLabels {
     return $labels
 }
 
-Test-PositiveCount -Name 'Commanders' -Value $Commanders
+Test-PositiveCount -Name 'Operators' -Value $Operators
 Test-PositiveCount -Name 'Workers' -Value $Workers
 Test-PositiveCount -Name 'Builders' -Value $Builders
 Test-PositiveCount -Name 'Researchers' -Value $Researchers
@@ -149,7 +149,7 @@ if ([string]::IsNullOrWhiteSpace($SessionName)) {
     throw 'SessionName is required. Pass -SessionName or set WINSMUX_ORCHESTRA_SESSION.'
 }
 
-$total = $Commanders + $Workers + $Builders + $Researchers + $Reviewers
+$total = $Operators + $Workers + $Builders + $Researchers + $Reviewers
 if ($total -lt 1 -or $total -gt 12) {
     throw "Total panes must be 1-12 (got $total)."
 }
@@ -208,7 +208,7 @@ if ($allIds.Count -lt $total) {
     throw "Expected at least $total panes but found $($allIds.Count)."
 }
 
-$labels = @(Get-RoleLabels -CommanderCount $Commanders -WorkerCount $Workers -BuilderCount $Builders -ResearcherCount $Researchers -ReviewerCount $Reviewers)
+$labels = @(Get-RoleLabels -OperatorCount $Operators -WorkerCount $Workers -BuilderCount $Builders -ResearcherCount $Researchers -ReviewerCount $Reviewers)
 $assignments = [System.Collections.Generic.List[object]]::new()
 
 for ($index = 0; $index -lt $total; $index++) {

--- a/winsmux-core/scripts/orchestra-smoke.ps1
+++ b/winsmux-core/scripts/orchestra-smoke.ps1
@@ -30,7 +30,7 @@ function Get-OrchestraSmokeLayoutSettings {
 
     if ([bool]$settings.legacy_role_layout) {
         return [ordered]@{
-            Commanders  = [int]$settings.commanders
+            Operators  = [int]$settings.operators
             Workers     = 0
             Builders    = [int]$settings.builders
             Researchers = [int]$settings.researchers
@@ -43,7 +43,7 @@ function Get-OrchestraSmokeLayoutSettings {
     }
 
     return [ordered]@{
-        Commanders = if ([bool]$settings.external_commander) { 0 } else { 1 }
+        Operators = if ([bool]$settings.external_operator) { 0 } else { 1 }
         Workers    = $workers
         Builders   = 0
         Researchers = 0
@@ -54,7 +54,7 @@ function Get-OrchestraSmokeLayoutSettings {
 function Get-OrchestraSmokeExpectedPaneCount {
     param($LayoutSettings)
 
-    return [int]$LayoutSettings.Commanders +
+    return [int]$LayoutSettings.Operators +
         [int]$LayoutSettings.Workers +
         [int]$LayoutSettings.Builders +
         [int]$LayoutSettings.Researchers +
@@ -420,7 +420,7 @@ $startScript = Join-Path $scriptsRoot 'orchestra-start.ps1'
 $winsmuxCorePath = Join-Path (Split-Path -Parent $scriptsRoot) '..\scripts\winsmux-core.ps1'
 $winsmuxCorePath = [System.IO.Path]::GetFullPath($winsmuxCorePath)
 $layoutSettings = Get-OrchestraSmokeLayoutSettings -Root $ProjectDir
-$externalOperatorMode = ([int]$layoutSettings.Commanders -eq 0)
+$externalOperatorMode = ([int]$layoutSettings.Operators -eq 0)
 $expectedPaneCount = Get-OrchestraSmokeExpectedPaneCount -LayoutSettings $layoutSettings
 
 $winsmuxBin = ''

--- a/winsmux-core/scripts/orchestra-start.ps1
+++ b/winsmux-core/scripts/orchestra-start.ps1
@@ -503,7 +503,7 @@ function Get-CanonicalRole {
         '^(?i)builder(?:$|[-_:/\s])' { return 'Builder' }
         '^(?i)researcher(?:$|[-_:/\s])' { return 'Researcher' }
         '^(?i)reviewer(?:$|[-_:/\s])' { return 'Reviewer' }
-        '^(?i)commander(?:$|[-_:/\s])' { return 'Commander' }
+        '^(?i)operator(?:$|[-_:/\s])' { return 'Operator' }
         default { throw "Unsupported pane role label: $AssignmentRole" }
     }
 }
@@ -511,7 +511,7 @@ function Get-CanonicalRole {
 function Get-OrchestraLayoutSettings {
     param([Parameter(Mandatory = $true)]$Settings)
 
-    $commanders = [int]$Settings.commanders
+    $operators = [int]$Settings.operators
     $workers = [int]$Settings.worker_count
     $agentSlots = @()
     if ($Settings -is [System.Collections.IDictionary]) {
@@ -524,14 +524,14 @@ function Get-OrchestraLayoutSettings {
     $builders = [int]$Settings.builders
     $researchers = [int]$Settings.researchers
     $reviewers = [int]$Settings.reviewers
-    $externalCommander = [bool]$Settings.external_commander
+    $externalOperator = [bool]$Settings.external_operator
     $legacyRoleLayout = [bool]$Settings.legacy_role_layout
 
-    $legacyCount = $commanders + $builders + $researchers + $reviewers
+    $legacyCount = $operators + $builders + $researchers + $reviewers
     $useLegacyLayout = $legacyRoleLayout
 
     if ($legacyCount -gt 0 -and -not $useLegacyLayout) {
-        throw 'Legacy role counts require legacy_role_layout=true. Set legacy_role_layout explicitly to opt into Commander/Builder/Researcher/Reviewer panes.'
+        throw 'Legacy role counts require legacy_role_layout=true. Set legacy_role_layout explicitly to opt into Operator/Builder/Researcher/Reviewer panes.'
     }
 
     if (-not $useLegacyLayout -and $agentSlots.Count -gt 0) {
@@ -589,9 +589,9 @@ function Get-OrchestraLayoutSettings {
 
     if ($useLegacyLayout) {
         return [ordered]@{
-            ExternalCommander = $false
+            ExternalOperator = $false
             LegacyRoleLayout  = $true
-            Commanders        = $commanders
+            Operators        = $operators
             Workers           = 0
             Builders          = $builders
             Researchers       = $researchers
@@ -599,18 +599,18 @@ function Get-OrchestraLayoutSettings {
         }
     }
 
-    $managedCommanders = if ($externalCommander) { 0 } else { 1 }
+    $managedOperators = if ($externalOperator) { 0 } else { 1 }
     if ($agentSlots.Count -gt 0) {
         $workers = $agentSlots.Count
     }
     if ($workers -lt 1) {
-        throw "worker_count must be 1 or greater in external commander mode (got $workers)."
+        throw "worker_count must be 1 or greater in external operator mode (got $workers)."
     }
 
     return [ordered]@{
-        ExternalCommander = $externalCommander
+        ExternalOperator = $externalOperator
         LegacyRoleLayout  = $false
-        Commanders        = $managedCommanders
+        Operators        = $managedOperators
         Workers           = $workers
         Builders          = 0
         Researchers       = 0
@@ -621,7 +621,7 @@ function Get-OrchestraLayoutSettings {
 function Get-OrchestraExpectedPaneCount {
     param([Parameter(Mandatory = $true)]$LayoutSettings)
 
-    return [int]$LayoutSettings.Commanders +
+    return [int]$LayoutSettings.Operators +
         [int]$LayoutSettings.Workers +
         [int]$LayoutSettings.Builders +
         [int]$LayoutSettings.Researchers +
@@ -1073,7 +1073,7 @@ function Save-OrchestraSessionState {
         [Parameter(Mandatory = $true)][string]$GitWorktreeDir,
         [Parameter(Mandatory = $true)][System.Collections.IEnumerable]$PaneSummaries,
         [AllowEmptyString()][string]$StartupToken = '',
-        [Nullable[int]]$CommanderPollPid = $null,
+        [Nullable[int]]$OperatorPollPid = $null,
         [Nullable[int]]$WatchdogPid = $null,
         [Nullable[int]]$ServerWatchdogPid = $null,
         [AllowEmptyString()][string]$BootstrapMode = '',
@@ -1127,7 +1127,7 @@ function Save-OrchestraSessionState {
             project_dir         = $ProjectDir
             git_worktree_dir    = $GitWorktreeDir
             startup_token       = $StartupToken
-            commander_poll_pid  = $CommanderPollPid
+            operator_poll_pid  = $OperatorPollPid
             watchdog_pid        = $WatchdogPid
             server_watchdog_pid = $ServerWatchdogPid
             bootstrap_mode      = $BootstrapMode
@@ -1190,7 +1190,7 @@ function Stop-OrchestraBackgroundProcessesFromManifest {
     }
 
     $pidMap = [ordered]@{}
-    foreach ($propertyName in @('commander_poll_pid', 'watchdog_pid', 'server_watchdog_pid')) {
+    foreach ($propertyName in @('operator_poll_pid', 'watchdog_pid', 'server_watchdog_pid')) {
         $rawPid = $null
         if ($manifest.session -is [System.Collections.IDictionary]) {
             if ($manifest.session.Contains($propertyName)) {
@@ -1224,7 +1224,7 @@ function Stop-OrchestraBackgroundProcessesFromManifest {
             $process = $snapshot.ById[$processId]
             $commandLine = [string]$process.CommandLine
             $requiredScript = switch ($label) {
-                'commander_poll_pid' { 'commander-poll.ps1' }
+                'operator_poll_pid' { 'operator-poll.ps1' }
                 'watchdog_pid' { 'agent-watchdog.ps1' }
                 'server_watchdog_pid' { 'server-watchdog.ps1' }
                 default { '' }
@@ -1319,9 +1319,9 @@ function Start-AgentWatchdogJob {
         ) -WindowStyle Hidden -PassThru)
 }
 
-function Start-CommanderPollJob {
+function Start-OperatorPollJob {
     param(
-        [Parameter(Mandatory = $true)][string]$CommanderPollScriptPath,
+        [Parameter(Mandatory = $true)][string]$OperatorPollScriptPath,
         [Parameter(Mandatory = $true)][string]$ManifestPath,
         [AllowEmptyString()][string]$StartupToken = '',
         [int]$Interval = 20
@@ -1330,7 +1330,7 @@ function Start-CommanderPollJob {
     return (Start-Process -FilePath 'pwsh' -ArgumentList @(
             '-NoProfile',
             '-File',
-            $CommanderPollScriptPath,
+            $OperatorPollScriptPath,
             '-ManifestPath',
             $ManifestPath,
             '-StartupToken',
@@ -1784,7 +1784,7 @@ function Test-PaneBootstrapInvariants {
 }
 
 if ($MyInvocation.InvocationName -ne '.') {
-    $commanderPollProcess = $null
+    $operatorPollProcess = $null
     $watchdogProcess = $null
     $serverWatchdogProcess = $null
     $projectDir = $null
@@ -1816,10 +1816,10 @@ if ($MyInvocation.InvocationName -ne '.') {
         Write-WinsmuxLog -Level INFO -Event 'preflight.settings.loaded' -Message 'Loaded orchestra settings.' -Data @{
             agent              = $settings.agent
             model              = $settings.model
-            external_commander = $layoutSettings.ExternalCommander
+            external_operator = $layoutSettings.ExternalOperator
             legacy_role_layout = $layoutSettings.LegacyRoleLayout
             workers            = $layoutSettings.Workers
-            commanders         = $layoutSettings.Commanders
+            operators         = $layoutSettings.Operators
             builders           = $layoutSettings.Builders
             researchers        = $layoutSettings.Researchers
             reviewers          = $layoutSettings.Reviewers
@@ -1990,8 +1990,8 @@ if ($MyInvocation.InvocationName -ne '.') {
 
         try {
             try {
-                Write-Warning "DEBUG: layout start session=$sessionName external=$($layoutSettings.ExternalCommander) legacy=$($layoutSettings.LegacyRoleLayout) C=$($layoutSettings.Commanders) W=$($layoutSettings.Workers) B=$($layoutSettings.Builders) R=$($layoutSettings.Researchers) Rev=$($layoutSettings.Reviewers)"
-                $layout = . $layoutScript -SessionName $sessionName -Commanders $layoutSettings.Commanders -Workers $layoutSettings.Workers -Builders $layoutSettings.Builders -Researchers $layoutSettings.Researchers -Reviewers $layoutSettings.Reviewers
+                Write-Warning "DEBUG: layout start session=$sessionName external=$($layoutSettings.ExternalOperator) legacy=$($layoutSettings.LegacyRoleLayout) C=$($layoutSettings.Operators) W=$($layoutSettings.Workers) B=$($layoutSettings.Builders) R=$($layoutSettings.Researchers) Rev=$($layoutSettings.Reviewers)"
+                $layout = . $layoutScript -SessionName $sessionName -Operators $layoutSettings.Operators -Workers $layoutSettings.Workers -Builders $layoutSettings.Builders -Researchers $layoutSettings.Researchers -Reviewers $layoutSettings.Reviewers
                 Write-Warning "DEBUG: layout done, panes=$($layout.Panes.Count)"
                 foreach ($sessionPaneId in @(Get-OrchestraSessionPaneIds -SessionName $sessionName)) {
                     if ($createdPaneIds -notcontains $sessionPaneId) {
@@ -2189,17 +2189,17 @@ if ($MyInvocation.InvocationName -ne '.') {
     }
 
     $manifestPath = Save-OrchestraSessionState -ProjectDir $projectDir -SessionName $sessionName -Settings $settings -GitWorktreeDir $gitWorktreeDir -PaneSummaries $validPaneSummaries -StartupToken $startupToken -BootstrapMode ([string]$orchestraServer.BootstrapMode) -SessionReady $false -UiAttachLaunched ([bool]$uiAttachResult.Launched) -UiAttached ([bool]$uiAttachResult.Attached) -UiAttachStatus ([string]$uiAttachResult.Status) -UiAttachReason ([string]$uiAttachResult.Reason) -UiAttachSource ([string]$uiAttachResult.Source) -UiHostKind ([string]$uiAttachResult.ui_host_kind) -AttachRequestId ([string]$uiAttachResult.attach_request_id) -AttachAdapterTrace @($uiAttachResult.attach_adapter_trace)
-    $commanderPollScriptPath = Join-Path $scriptDir 'commander-poll.ps1'
-    $commanderPollProcess = Start-CommanderPollJob -CommanderPollScriptPath $commanderPollScriptPath -ManifestPath $manifestPath -StartupToken $startupToken -Interval 20
-    Write-WinsmuxLog -Level INFO -Event 'preflight.commander_poll.started' -Message "Started commander poll for session $sessionName." -Data @{ session_name = $sessionName; manifest_path = $manifestPath; commander_poll_pid = $commanderPollProcess.Id; process_name = $commanderPollProcess.ProcessName } | Out-Null
+    $operatorPollScriptPath = Join-Path $scriptDir 'operator-poll.ps1'
+    $operatorPollProcess = Start-OperatorPollJob -OperatorPollScriptPath $operatorPollScriptPath -ManifestPath $manifestPath -StartupToken $startupToken -Interval 20
+    Write-WinsmuxLog -Level INFO -Event 'preflight.operator_poll.started' -Message "Started operator poll for session $sessionName." -Data @{ session_name = $sessionName; manifest_path = $manifestPath; operator_poll_pid = $operatorPollProcess.Id; process_name = $operatorPollProcess.ProcessName } | Out-Null
     $watchdogScriptPath = Join-Path $scriptDir 'agent-watchdog.ps1'
     $watchdogProcess = Start-AgentWatchdogJob -WatchdogScriptPath $watchdogScriptPath -ManifestPath $manifestPath -SessionName $sessionName -StartupToken $startupToken
     $serverWatchdogScriptPath = Join-Path $scriptDir 'server-watchdog.ps1'
     $serverWatchdogProcess = Start-ServerWatchdogJob -WatchdogScriptPath $serverWatchdogScriptPath -ManifestPath $manifestPath -SessionName $sessionName -StartupToken $startupToken
-    Assert-OrchestraBackgroundProcessStarted -Process $commanderPollProcess -Name 'Commander poll job'
+    Assert-OrchestraBackgroundProcessStarted -Process $operatorPollProcess -Name 'Operator poll job'
     Assert-OrchestraBackgroundProcessStarted -Process $watchdogProcess -Name 'Agent watchdog job'
     Assert-OrchestraBackgroundProcessStarted -Process $serverWatchdogProcess -Name 'Server watchdog job'
-    $manifestPath = Save-OrchestraSessionState -ProjectDir $projectDir -SessionName $sessionName -Settings $settings -GitWorktreeDir $gitWorktreeDir -PaneSummaries $validPaneSummaries -StartupToken $startupToken -CommanderPollPid $commanderPollProcess.Id -WatchdogPid $watchdogProcess.Id -ServerWatchdogPid $serverWatchdogProcess.Id -BootstrapMode ([string]$orchestraServer.BootstrapMode) -SessionReady $true -UiAttachLaunched ([bool]$uiAttachResult.Launched) -UiAttached ([bool]$uiAttachResult.Attached) -UiAttachStatus ([string]$uiAttachResult.Status) -UiAttachReason ([string]$uiAttachResult.Reason) -UiAttachSource ([string]$uiAttachResult.Source) -UiHostKind ([string]$uiAttachResult.ui_host_kind) -AttachRequestId ([string]$uiAttachResult.attach_request_id) -AttachAdapterTrace @($uiAttachResult.attach_adapter_trace)
+    $manifestPath = Save-OrchestraSessionState -ProjectDir $projectDir -SessionName $sessionName -Settings $settings -GitWorktreeDir $gitWorktreeDir -PaneSummaries $validPaneSummaries -StartupToken $startupToken -OperatorPollPid $operatorPollProcess.Id -WatchdogPid $watchdogProcess.Id -ServerWatchdogPid $serverWatchdogProcess.Id -BootstrapMode ([string]$orchestraServer.BootstrapMode) -SessionReady $true -UiAttachLaunched ([bool]$uiAttachResult.Launched) -UiAttached ([bool]$uiAttachResult.Attached) -UiAttachStatus ([string]$uiAttachResult.Status) -UiAttachReason ([string]$uiAttachResult.Reason) -UiAttachSource ([string]$uiAttachResult.Source) -UiHostKind ([string]$uiAttachResult.ui_host_kind) -AttachRequestId ([string]$uiAttachResult.attach_request_id) -AttachAdapterTrace @($uiAttachResult.attach_adapter_trace)
     Write-WinsmuxLog -Level INFO -Event 'preflight.watchdog.started' -Message "Started agent watchdog for session $sessionName." -Data @{ session_name = $sessionName; manifest_path = $manifestPath; watchdog_pid = $watchdogProcess.Id; process_name = $watchdogProcess.ProcessName } | Out-Null
     Write-WinsmuxLog -Level INFO -Event 'preflight.server_watchdog.started' -Message "Started server watchdog for session $sessionName." -Data @{ session_name = $sessionName; manifest_path = $manifestPath; server_watchdog_pid = $serverWatchdogProcess.Id; process_name = $serverWatchdogProcess.ProcessName } | Out-Null
     Write-WinsmuxLog -Level INFO -Event 'orchestra.startup.session_ready' -Message "Orchestra session $sessionName reached session-ready; UI attach remains a separate state." -Data ([ordered]@{
@@ -2235,10 +2235,10 @@ if ($MyInvocation.InvocationName -ne '.') {
     Write-Output "Model: $(if ([string]::IsNullOrWhiteSpace($defaultModel)) { 'per-slot / override only' } else { $defaultModel })"
     if ($layoutSettings.LegacyRoleLayout) {
         Write-Output "Mode: legacy role layout"
-    } elseif ($layoutSettings.ExternalCommander) {
-        Write-Output "Mode: external commander + $($layoutSettings.Workers) workers"
+    } elseif ($layoutSettings.ExternalOperator) {
+        Write-Output "Mode: external operator + $($layoutSettings.Workers) workers"
     } else {
-        Write-Output "Mode: managed commander + $($layoutSettings.Workers) workers"
+        Write-Output "Mode: managed operator + $($layoutSettings.Workers) workers"
     }
     Write-Output "ProjectDir: $projectDir"
     Write-Output "GitWorktreeDir: $gitWorktreeDir"
@@ -2263,17 +2263,17 @@ if ($MyInvocation.InvocationName -ne '.') {
 
     Write-Output ''
     Write-Output "Manifest: $manifestPath"
-    Write-Output "Commander Poll PID: $($commanderPollProcess.Id)"
+    Write-Output "Operator Poll PID: $($operatorPollProcess.Id)"
     Write-Output "Watchdog PID: $($watchdogProcess.Id)"
     Write-Output "Server Watchdog PID: $($serverWatchdogProcess.Id)"
-    Write-Output 'Cleanup: stop the commander poll and watchdogs after the session ends.'
-    Write-Output ("  Stop-Process -Id {0}" -f $commanderPollProcess.Id)
+    Write-Output 'Cleanup: stop the operator poll and watchdogs after the session ends.'
+    Write-Output ("  Stop-Process -Id {0}" -f $operatorPollProcess.Id)
     Write-Output ("  Stop-Process -Id {0},{1}" -f $watchdogProcess.Id, $serverWatchdogProcess.Id)
 } catch {
     Write-Warning "STARTUP ERROR: $($_.Exception.Message)"
     Write-Warning "AT: $($_.ScriptStackTrace)"
-    if ($null -ne $commanderPollProcess) {
-        try { Stop-Process -Id $commanderPollProcess.Id -Force -ErrorAction SilentlyContinue } catch {}
+    if ($null -ne $operatorPollProcess) {
+        try { Stop-Process -Id $operatorPollProcess.Id -Force -ErrorAction SilentlyContinue } catch {}
     }
     if ($null -ne $watchdogProcess) {
         try { Stop-Process -Id $watchdogProcess.Id -Force -ErrorAction SilentlyContinue } catch {}

--- a/winsmux-core/scripts/pane-control.ps1
+++ b/winsmux-core/scripts/pane-control.ps1
@@ -193,7 +193,7 @@ function Get-PaneControlCanonicalRole {
 
     $candidate = if ([string]::IsNullOrWhiteSpace($Role)) { $Label } else { $Role }
     if ([string]::IsNullOrWhiteSpace($candidate)) {
-        return 'Commander'
+        return 'Operator'
     }
 
     switch -Regex ($candidate.Trim()) {
@@ -201,8 +201,8 @@ function Get-PaneControlCanonicalRole {
         '^(?i)builder(?:$|[-_:/\s])' { return 'Builder' }
         '^(?i)researcher(?:$|[-_:/\s])' { return 'Researcher' }
         '^(?i)reviewer(?:$|[-_:/\s])' { return 'Reviewer' }
-        '^(?i)commander(?:$|[-_:/\s])' { return 'Commander' }
-        default { return 'Commander' }
+        '^(?i)operator(?:$|[-_:/\s])' { return 'Operator' }
+        default { return 'Operator' }
     }
 }
 

--- a/winsmux-core/scripts/pane-env.ps1
+++ b/winsmux-core/scripts/pane-env.ps1
@@ -74,7 +74,7 @@ function Read-WinsmuxGovernanceFile {
 }
 
 function Get-WinsmuxSupportedHookProfiles {
-    return @('standard', 'commander', 'builder', 'ci')
+    return @('standard', 'operator', 'builder', 'ci')
 }
 
 function Resolve-WinsmuxHookProfile {

--- a/winsmux-core/scripts/pane-scaler.ps1
+++ b/winsmux-core/scripts/pane-scaler.ps1
@@ -66,7 +66,7 @@ function Get-PaneScalerCanonicalRole {
         '^(?i)builder(?:$|[-_:/\s])' { return 'Builder' }
         '^(?i)researcher(?:$|[-_:/\s])' { return 'Researcher' }
         '^(?i)reviewer(?:$|[-_:/\s])' { return 'Reviewer' }
-        '^(?i)commander(?:$|[-_:/\s])' { return 'Commander' }
+        '^(?i)operator(?:$|[-_:/\s])' { return 'Operator' }
         default { return $candidate.Trim() }
     }
 }

--- a/winsmux-core/scripts/public-first-run.ps1
+++ b/winsmux-core/scripts/public-first-run.ps1
@@ -47,7 +47,7 @@ function Invoke-WinsmuxPublicInit {
             project_dir         = $resolvedProjectDir
             config_path         = $configPath
             created             = $false
-            external_commander  = [bool]$existing.external_commander
+            external_operator  = [bool]$existing.external_operator
             worker_count        = [int]$existing.worker_count
             slot_count          = @($existing.agent_slots).Count
             next_action         = 'Run winsmux launch.'
@@ -58,11 +58,11 @@ function Invoke-WinsmuxPublicInit {
     Save-BridgeSettings -Scope project -RootPath $resolvedProjectDir -Settings ([ordered]@{
         agent               = $Agent
         model               = $Model
-        external_commander  = $true
+        external_operator  = $true
         worker_count        = $WorkerCount
         agent_slots         = @($agentSlots)
         legacy_role_layout  = $false
-        commanders          = 0
+        operators          = 0
         builders            = 0
         researchers         = 0
         reviewers           = 0
@@ -75,7 +75,7 @@ function Invoke-WinsmuxPublicInit {
         project_dir         = $resolvedProjectDir
         config_path         = $configPath
         created             = $true
-        external_commander  = $true
+        external_operator  = $true
         worker_count        = $WorkerCount
         slot_count          = @($agentSlots).Count
         next_action         = 'Run winsmux launch.'

--- a/winsmux-core/scripts/role-gate.ps1
+++ b/winsmux-core/scripts/role-gate.ps1
@@ -1,9 +1,9 @@
 $RolePermissions = @{
-    Commander = @{
+    Operator = @{
         ReadOwn       = $true
         ReadOther     = $true
         SendAny       = $true
-        SendCommander = $true
+        SendOperator = $true
         HealthCheck   = $true
         Watch         = $true
         WaitReady     = $true
@@ -42,7 +42,7 @@ $RolePermissions = @{
         ReadOwn       = $true
         ReadOther     = $false
         SendAny       = $false
-        SendCommander = $true
+        SendOperator = $true
         HealthCheck   = $false
         Watch         = $false
         WaitReady     = $false
@@ -81,7 +81,7 @@ $RolePermissions = @{
         ReadOwn       = $true
         ReadOther     = $false
         SendAny       = $false
-        SendCommander = $true
+        SendOperator = $true
         HealthCheck   = $false
         Watch         = $false
         WaitReady     = $false
@@ -120,7 +120,7 @@ $RolePermissions = @{
         ReadOwn       = $true
         ReadOther     = $false
         SendAny       = $false
-        SendCommander = $true
+        SendOperator = $true
         HealthCheck   = $false
         Watch         = $false
         WaitReady     = $false
@@ -159,7 +159,7 @@ $RolePermissions = @{
         ReadOwn       = $true
         ReadOther     = $false
         SendAny       = $false
-        SendCommander = $true
+        SendOperator = $true
         HealthCheck   = $false
         Watch         = $false
         WaitReady     = $false
@@ -206,7 +206,7 @@ function ConvertTo-CanonicalWinsmuxRole {
     }
 
     switch -Regex ($RoleName.Trim()) {
-        '^(?i)Commander$' { return 'Commander' }
+        '^(?i)Operator$' { return 'Operator' }
         '^(?i)Worker$' { return 'Worker' }
         '^(?i)Builder$' { return 'Builder' }
         '^(?i)Researcher$' { return 'Researcher' }
@@ -353,14 +353,14 @@ function Get-RoleGateTargetRole {
     return $roleMap[$resolvedPane]
 }
 
-function Test-RoleGateCommanderTarget {
+function Test-RoleGateOperatorTarget {
     param([AllowNull()][string]$TargetPane)
 
     if ([string]::IsNullOrWhiteSpace($TargetPane)) {
         return $false
     }
 
-    return (Get-RoleGateTargetRole $TargetPane) -eq 'Commander'
+    return (Get-RoleGateTargetRole $TargetPane) -eq 'Operator'
 }
 
 function Deny-RoleCommand {
@@ -397,12 +397,12 @@ function Assert-Role {
         }
         'send' {
             if ($permissions.SendAny) { return $true }
-            if ($permissions.SendCommander -and (Test-RoleGateCommanderTarget $TargetPane)) { return $true }
+            if ($permissions.SendOperator -and (Test-RoleGateOperatorTarget $TargetPane)) { return $true }
             return Deny-RoleCommand -Role $role -Command $normalizedCommand
         }
         'message' {
             if ($permissions.SendAny) { return $true }
-            if ($permissions.SendCommander -and (Test-RoleGateCommanderTarget $TargetPane)) { return $true }
+            if ($permissions.SendOperator -and (Test-RoleGateOperatorTarget $TargetPane)) { return $true }
             return Deny-RoleCommand -Role $role -Command $normalizedCommand
         }
         'health-check' {

--- a/winsmux-core/scripts/settings.ps1
+++ b/winsmux-core/scripts/settings.ps1
@@ -21,17 +21,62 @@ $script:BridgeSettingsSchema = [ordered]@{
     agent               = @{ Type = 'string';   Default = 'codex';       Option = '@bridge-agent' }
     model               = @{ Type = 'string';   Default = 'gpt-5.4';     Option = '@bridge-model' }
     prompt_transport    = @{ Type = 'transport'; Default = 'argv';       Option = '@bridge-prompt-transport' }
-    external_commander  = @{ Type = 'bool';     Default = $true;         Option = '@bridge-external-commander' }
+    external_operator  = @{ Type = 'bool';     Default = $true;         Option = '@bridge-external-operator' }
     worker_count        = @{ Type = 'int';      Default = 6;             Option = '@bridge-worker-count' }
     agent_slots         = @{ Type = 'slotlist'; Default = @();           Option = $null }
     legacy_role_layout  = @{ Type = 'bool';     Default = $false;        Option = '@bridge-legacy-role-layout' }
-    commanders          = @{ Type = 'int';      Default = 0;             Option = '@bridge-commanders' }
+    operators          = @{ Type = 'int';      Default = 0;             Option = '@bridge-operators' }
     builders            = @{ Type = 'int';      Default = 0;             Option = '@bridge-builders' }
     researchers         = @{ Type = 'int';      Default = 0;             Option = '@bridge-researchers' }
     reviewers           = @{ Type = 'int';      Default = 0;             Option = '@bridge-reviewers' }
     vault_keys          = @{ Type = 'string[]'; Default = @('GH_TOKEN'); Option = '@bridge-vault-keys' }
     terminal            = @{ Type = 'string';   Default = 'background';  Option = '@bridge-terminal' }
     roles               = @{ Type = 'map';      Default = [ordered]@{};  Option = $null }
+}
+$script:BridgeRetiredOperatorSettingKeys = @(
+    ('external_' + 'comm' + 'ander'),
+    ('comm' + 'anders')
+)
+$script:BridgeRetiredOperatorOptionNames = @(
+    ('@bridge-external-' + 'comm' + 'ander'),
+    ('@bridge-' + 'comm' + 'anders')
+)
+
+function Test-BridgeRetiredOperatorSettingKey {
+    param([string]$Name)
+
+    if ([string]::IsNullOrWhiteSpace($Name)) {
+        return $false
+    }
+
+    $key = $Name -replace '-', '_'
+    return ($key -in $script:BridgeRetiredOperatorSettingKeys)
+}
+
+function Assert-BridgeNoRetiredOperatorSetting {
+    param(
+        [Parameter(Mandatory = $true)][string]$Name,
+        [string]$Source = 'settings'
+    )
+
+    if (Test-BridgeRetiredOperatorSettingKey -Name $Name) {
+        throw "Retired runtime role setting '$Name' in $Source is no longer supported. Use external_operator or operators."
+    }
+}
+
+function Assert-BridgeNoRetiredOperatorGlobalSettings {
+    foreach ($optionName in $script:BridgeRetiredOperatorOptionNames) {
+        $rawValue = Get-WinsmuxOption -Name $optionName -Default $null
+        if ($null -eq $rawValue -or [string]::IsNullOrWhiteSpace($rawValue)) {
+            continue
+        }
+
+        if (Test-WinsmuxOptionFailureText -Value ([string]$rawValue)) {
+            continue
+        }
+
+        throw "Retired runtime role option '$optionName' is no longer supported. Use @bridge-external-operator or @bridge-operators."
+    }
 }
 
 if (-not (Get-Command Get-WinsmuxBin -ErrorAction SilentlyContinue)) {
@@ -996,6 +1041,8 @@ function ConvertFrom-BridgeManualYaml {
 
         $key = $Matches[1] -replace '-', '_'
         $value = $Matches[2]
+        Assert-BridgeNoRetiredOperatorSetting -Name $key -Source $script:BridgeSettingsFileName
+
         if (-not $script:BridgeSettingsSchema.Contains($key)) {
             continue
         }
@@ -1272,6 +1319,8 @@ function ConvertTo-BridgeSettingsSource {
 
     foreach ($pair in $pairs) {
         $key = $pair.Key.ToString() -replace '-', '_'
+        Assert-BridgeNoRetiredOperatorSetting -Name $key -Source 'settings source'
+
         if (-not $script:BridgeSettingsSchema.Contains($key)) {
             continue
         }
@@ -1338,6 +1387,8 @@ function Get-BridgeSettings {
     }
 
     $globalSettings = Read-BridgeGlobalSettings
+    Assert-BridgeNoRetiredOperatorGlobalSettings
+
     foreach ($key in $globalSettings.Keys) {
         $value = $globalSettings[$key]
         if ($value -is [System.Array]) {
@@ -1403,14 +1454,14 @@ function Get-BridgeSettings {
         $slotIds[$slotId] = $true
     }
 
-    $legacyCount = [int]$settings.commanders + [int]$settings.builders + [int]$settings.researchers + [int]$settings.reviewers
+    $legacyCount = [int]$settings.operators + [int]$settings.builders + [int]$settings.researchers + [int]$settings.reviewers
     $useLegacyLayout = [bool]$settings.legacy_role_layout
 
     if ($legacyCount -gt 0 -and -not $useLegacyLayout) {
-        throw 'Legacy role counts require legacy_role_layout=true. Set legacy_role_layout explicitly to opt into Commander/Builder/Researcher/Reviewer panes.'
+        throw 'Legacy role counts require legacy_role_layout=true. Set legacy_role_layout explicitly to opt into Operator/Builder/Researcher/Reviewer panes.'
     }
 
-    if (@($settings.agent_slots).Count -eq 0 -and -not $useLegacyLayout -and [bool]$settings.external_commander -and [int]$settings.worker_count -gt 0) {
+    if (@($settings.agent_slots).Count -eq 0 -and -not $useLegacyLayout -and [bool]$settings.external_operator -and [int]$settings.worker_count -gt 0) {
         $settings.agent_slots = New-BridgeManagedAgentSlots -Count ([int]$settings.worker_count) -Agent ([string]$settings.agent) -Model ([string]$settings.model)
     }
 

--- a/winsmux-core/scripts/setup-wizard.ps1
+++ b/winsmux-core/scripts/setup-wizard.ps1
@@ -190,27 +190,27 @@ Write-Host ''
 
 $agentCli = Read-AgentCli -Default 'codex'
 $model = Read-DefaultValue -Prompt 'Model' -Default 'gpt-5.4'
-$externalCommander = Read-YesNo -Prompt 'Use an external Operator terminal?' -Default $true
+$externalOperator = Read-YesNo -Prompt 'Use an external Operator terminal?' -Default $true
 $legacyRoleLayout = $false
-$commanders = 0
+$operators = 0
 $workerCount = 6
 $agentSlots = @()
 $builders = 0
 $researchers = 0
 $reviewers = 0
 
-if ($externalCommander) {
+if ($externalOperator) {
     $workerCount = Read-PositiveInt -Prompt 'Managed worker pane count' -Default 6
     $agentSlots = New-BridgeManagedAgentSlots -Count $workerCount -Agent $agentCli -Model $model
 } else {
-    $legacyRoleLayout = Read-YesNo -Prompt 'Use legacy role layout (Commander/Builder/Researcher/Reviewer panes)?' -Default $false
+    $legacyRoleLayout = Read-YesNo -Prompt 'Use legacy role layout (Operator/Builder/Researcher/Reviewer panes)?' -Default $false
     if ($legacyRoleLayout) {
-        $commanders = Read-PositiveInt -Prompt 'Commanders count' -Default 1
+        $operators = Read-PositiveInt -Prompt 'Operators count' -Default 1
         $builders = Read-PositiveInt -Prompt 'Builders count' -Default 4
         $researchers = Read-PositiveInt -Prompt 'Researchers count' -Default 1
         $reviewers = Read-PositiveInt -Prompt 'Reviewers count' -Default 1
     } else {
-        $commanders = 0
+        $operators = 0
         $workerCount = Read-PositiveInt -Prompt 'Managed worker pane count' -Default 6
         $agentSlots = New-BridgeManagedAgentSlots -Count $workerCount -Agent $agentCli -Model $model
     }
@@ -220,9 +220,9 @@ $storeVault = Read-YesNo -Prompt 'Store GH_TOKEN in the winsmux vault?' -Default
 
 Set-WinsmuxOption -WinsmuxBin $winsmuxBin -OptionName '@bridge-agent' -OptionValue $agentCli
 Set-WinsmuxOption -WinsmuxBin $winsmuxBin -OptionName '@bridge-model' -OptionValue $model
-Set-WinsmuxOption -WinsmuxBin $winsmuxBin -OptionName '@bridge-external-commander' -OptionValue $(if ($externalCommander) { 'on' } else { 'off' })
+Set-WinsmuxOption -WinsmuxBin $winsmuxBin -OptionName '@bridge-external-operator' -OptionValue $(if ($externalOperator) { 'on' } else { 'off' })
 Set-WinsmuxOption -WinsmuxBin $winsmuxBin -OptionName '@bridge-legacy-role-layout' -OptionValue $(if ($legacyRoleLayout) { 'on' } else { 'off' })
-Set-WinsmuxOption -WinsmuxBin $winsmuxBin -OptionName '@bridge-commanders' -OptionValue $commanders.ToString()
+Set-WinsmuxOption -WinsmuxBin $winsmuxBin -OptionName '@bridge-operators' -OptionValue $operators.ToString()
 Set-WinsmuxOption -WinsmuxBin $winsmuxBin -OptionName '@bridge-worker-count' -OptionValue $workerCount.ToString()
 Set-WinsmuxOption -WinsmuxBin $winsmuxBin -OptionName '@bridge-builders' -OptionValue $builders.ToString()
 Set-WinsmuxOption -WinsmuxBin $winsmuxBin -OptionName '@bridge-researchers' -OptionValue $researchers.ToString()
@@ -231,11 +231,11 @@ Set-WinsmuxOption -WinsmuxBin $winsmuxBin -OptionName '@bridge-reviewers' -Optio
 Save-BridgeSettings -Scope project -Settings ([ordered]@{
     agent               = $agentCli
     model               = $model
-    external_commander  = $externalCommander
+    external_operator  = $externalOperator
     worker_count        = $workerCount
     agent_slots         = @($agentSlots)
     legacy_role_layout  = $legacyRoleLayout
-    commanders          = $commanders
+    operators          = $operators
     builders            = $builders
     researchers         = $researchers
     reviewers           = $reviewers
@@ -257,9 +257,9 @@ Write-Host 'Saved settings:'
 Write-Host "  winsmux binary:         $winsmuxBin"
 Write-Host "  @bridge-agent:        $agentCli"
 Write-Host "  @bridge-model:        $model"
-Write-Host "  @bridge-external-commander: $externalCommander"
+Write-Host "  @bridge-external-operator: $externalOperator"
 Write-Host "  @bridge-legacy-role-layout: $legacyRoleLayout"
-Write-Host "  @bridge-commanders:   $commanders"
+Write-Host "  @bridge-operators:   $operators"
 Write-Host "  @bridge-worker-count: $workerCount"
 Write-Host "  @bridge-builders:     $builders"
 Write-Host "  @bridge-researchers:  $researchers"


### PR DESCRIPTION
## Summary
- Complete `TASK-365` by migrating runtime role naming from Commander to Operator across tracked runtime, docs, tests, and fixtures.
- Rename `commander-poll.ps1` to `operator-poll.ps1` and align generated prompts, events, settings, and app projections.
- Reject retired role settings/options instead of silently falling back, and keep generated prompt artifacts ignored.

## Validation
- `Invoke-Pester .\tests\winsmux-bridge.Tests.ps1 -Output Detailed` (`319/319`)
- `Invoke-Pester .\tests\Integration.GateEnforcement.Tests.ps1 -Output Detailed` (`52/52`)
- `Invoke-Pester .\tests\PublicSurfacePolicy.Tests.ps1 -Output Detailed` (`11/11`)
- `cargo test --manifest-path winsmux-app/src-tauri/Cargo.toml` (`123/123`)
- `cargo test --manifest-path core/Cargo.toml rust_parity_`
- `cmd /c npm run build` in `winsmux-app`
- `bash -n .githooks/pre-commit`
- `git diff --check`
- `pwsh -NoProfile -File .\scripts\audit-public-surface.ps1`
- `pwsh -NoProfile -File .\scripts\git-guard.ps1 -Mode full`
- `gitleaks detect --source . --no-banner --redact --log-opts "--all"`
- Focused `codex exec` review returned `No findings` after addressing earlier review comments.

Closes #465.