### PR TITLE
Add worker isolation drift diagnostics

### DIFF
--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -5781,6 +5781,145 @@ Describe 'doctor bridge config metadata check' {
         $result.Label | Should -Be 'Bridge config metadata'
         $result.Detail | Should -Be '.winsmux.yaml not found'
     }
+
+    It 'fails worker drift check with operator remediation text' {
+        Mock Get-DoctorRepoRoot { $script:doctorTempRoot }
+        Mock Get-DoctorGitCommandPath { 'git' }
+        Mock Get-WinsmuxManifest { [pscustomobject]@{} }
+        Mock Get-WinsmuxWorkerIsolationReport {
+            [pscustomobject]@{
+                ok          = $false
+                summary     = '1 worker isolation issue'
+                findings    = @([pscustomobject]@{ label = 'worker-1'; message = 'branch is main; expected worktree-worker-1' })
+                remediation = 'Run git add, git commit, git push, and PR merge from the Operator shell.'
+            }
+        }
+
+        New-Item -ItemType Directory -Path (Join-Path $script:doctorTempRoot '.winsmux') -Force | Out-Null
+        New-Item -ItemType File -Path (Join-Path $script:doctorTempRoot '.winsmux\manifest.yaml') -Force | Out-Null
+
+        $result = Test-WorkerGitDriftCheck
+
+        $result.Status | Should -Be 'fail'
+        $result.Label | Should -Be 'Worker isolation drift'
+        $result.Detail | Should -Match 'branch is main'
+        $result.Detail | Should -Match 'Operator shell'
+    }
+}
+
+Describe 'worker isolation diagnostics' {
+    BeforeAll {
+        . (Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\worker-isolation.ps1')
+    }
+
+    BeforeEach {
+        $script:workerIsolationTempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('winsmux-worker-isolation-tests-' + [guid]::NewGuid().ToString('N'))
+        $script:workerIsolationWorktree = Join-Path $script:workerIsolationTempRoot '.worktrees\worker-1'
+        $script:workerIsolationGitDir = Join-Path $script:workerIsolationTempRoot '.git\worktrees\worker-1'
+        New-Item -ItemType Directory -Path $script:workerIsolationWorktree -Force | Out-Null
+        New-Item -ItemType Directory -Path $script:workerIsolationGitDir -Force | Out-Null
+    }
+
+    AfterEach {
+        if ($script:workerIsolationTempRoot -and (Test-Path $script:workerIsolationTempRoot)) {
+            Remove-Item -Path $script:workerIsolationTempRoot -Recurse -Force
+        }
+    }
+
+    BeforeAll {
+        function script:New-TestWorkerIsolationManifest {
+            param(
+                [string]$ExpectedOrigin = 'https://github.com/example/repo.git'
+            )
+
+            [pscustomobject]@{
+                panes = [ordered]@{
+                    'worker-1' = [pscustomobject]@{
+                        role                  = 'Worker'
+                        launch_dir            = $script:workerIsolationWorktree
+                        builder_worktree_path = $script:workerIsolationWorktree
+                        builder_branch        = 'worktree-worker-1'
+                        worktree_git_dir      = $script:workerIsolationGitDir
+                        expected_origin       = $ExpectedOrigin
+                    }
+                }
+            }
+        }
+
+        function script:New-TestWorkerIsolationGitInvoker {
+            param(
+                [string]$Branch = 'worktree-worker-1',
+                [string]$Origin = 'https://github.com/example/repo.git'
+            )
+
+            return {
+                param([string]$WorktreePath, [string[]]$Arguments)
+
+                switch ($Arguments -join ' ') {
+                    'rev-parse --show-toplevel' { $WorktreePath; break }
+                    'branch --show-current' { $Branch; break }
+                    'config --get remote.origin.url' { $Origin; break }
+                    'rev-parse --git-dir' { $script:workerIsolationGitDir; break }
+                    default { throw "unexpected git args: $($Arguments -join ' ')" }
+                }
+            }.GetNewClosure()
+        }
+    }
+
+    It 'passes when worker root, branch, origin, and gitdir match the manifest' {
+        . (Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\worker-isolation.ps1')
+
+        $report = Get-WinsmuxWorkerIsolationReport `
+            -ProjectDir $script:workerIsolationTempRoot `
+            -Manifest (New-TestWorkerIsolationManifest) `
+            -GitPath 'git' `
+            -GitInvoker {
+                param([string]$WorktreePath, [string[]]$Arguments)
+
+                switch ($Arguments -join ' ') {
+                    'rev-parse --show-toplevel' { $WorktreePath; break }
+                    'branch --show-current' { 'worktree-worker-1'; break }
+                    'config --get remote.origin.url' { 'https://github.com/example/repo.git'; break }
+                    'rev-parse --git-dir' { $script:workerIsolationGitDir; break }
+                    default { throw "unexpected git args: $($Arguments -join ' ')" }
+                }
+            }
+
+        $report.ok | Should -Be $true
+        $report.status | Should -Be 'pass'
+        $report.worker_count | Should -Be 1
+        $report.summary | Should -Be '1 worker pane(s) isolated'
+    }
+
+    It 'fails when the worker branch drifts from the manifest' {
+        . (Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\worker-isolation.ps1')
+
+        $report = Get-WinsmuxWorkerIsolationReport `
+            -ProjectDir $script:workerIsolationTempRoot `
+            -Manifest (New-TestWorkerIsolationManifest) `
+            -GitPath 'git' `
+            -GitInvoker (New-TestWorkerIsolationGitInvoker -Branch 'main')
+
+        $report.ok | Should -Be $false
+        $report.status | Should -Be 'fail'
+        $report.findings[0].message | Should -Match 'branch is main'
+        $report.remediation | Should -Match 'Operator shell'
+    }
+
+    It 'redacts credentials from origin drift findings' {
+        . (Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\worker-isolation.ps1')
+
+        $report = Get-WinsmuxWorkerIsolationReport `
+            -ProjectDir $script:workerIsolationTempRoot `
+            -Manifest (New-TestWorkerIsolationManifest -ExpectedOrigin 'https://expected-token@github.com/example/repo.git') `
+            -GitPath 'git' `
+            -GitInvoker (New-TestWorkerIsolationGitInvoker -Origin 'https://actual-token@github.com/example/repo.git')
+
+        $message = ($report.findings | ForEach-Object { $_.message }) -join '; '
+        $message | Should -Match '\[redacted\]@github.com'
+        $message | Should -Not -Match 'expected-token'
+        $message | Should -Not -Match 'actual-token'
+    }
 }
 
 Describe 'pane scaler helpers' {
@@ -10123,6 +10262,8 @@ Describe 'winsmux orchestra-smoke command' {
         $script:orchestraSmokeContent | Should -Match 'ready-with-ui-warning'
         $script:orchestraSmokeContent | Should -Match 'can_dispatch'
         $script:orchestraSmokeContent | Should -Match 'requires_startup'
+        $script:orchestraSmokeContent | Should -Match 'worker_isolation'
+        $script:orchestraSmokeContent | Should -Match 'worker isolation drift'
     }
 
     It 'keeps ready-with-ui-warning fail-closed only for external operator mode' {

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -5968,6 +5968,82 @@ Describe 'worker isolation diagnostics' {
         $report.worker_count | Should -Be 1
     }
 
+    It 'allows local-only repositories when expected origin is recorded as empty' {
+        . (Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\worker-isolation.ps1')
+
+        $report = Get-WinsmuxWorkerIsolationReport `
+            -ProjectDir $script:workerIsolationTempRoot `
+            -Manifest (New-TestWorkerIsolationManifest -ExpectedOrigin '') `
+            -GitPath 'git' `
+            -GitInvoker {
+                param([string]$WorktreePath, [string[]]$Arguments)
+
+                switch ($Arguments -join ' ') {
+                    'rev-parse --show-toplevel' { $WorktreePath; break }
+                    'branch --show-current' { 'worktree-worker-1'; break }
+                    'config --get remote.origin.url' { throw 'remote origin not configured' }
+                    'rev-parse --git-dir' { $script:workerIsolationGitDir; break }
+                    default { throw "unexpected git args: $($Arguments -join ' ')" }
+                }
+            }
+
+        $report.ok | Should -Be $true
+        $report.findings.Count | Should -Be 0
+    }
+
+    It 'fails when expected origin is empty but the worker has an origin' {
+        . (Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\worker-isolation.ps1')
+
+        $report = Get-WinsmuxWorkerIsolationReport `
+            -ProjectDir $script:workerIsolationTempRoot `
+            -Manifest (New-TestWorkerIsolationManifest -ExpectedOrigin '') `
+            -GitPath 'git' `
+            -GitInvoker (New-TestWorkerIsolationGitInvoker -Origin 'https://github.com/example/repo.git')
+
+        $report.ok | Should -Be $false
+        $report.findings[0].message | Should -Match 'expected no origin'
+    }
+
+    It 'fails when expected gitdir is recorded as empty' {
+        . (Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\worker-isolation.ps1')
+
+        $manifest = New-TestWorkerIsolationManifest
+        $manifest.panes.'worker-1'.worktree_git_dir = ''
+
+        $report = Get-WinsmuxWorkerIsolationReport `
+            -ProjectDir $script:workerIsolationTempRoot `
+            -Manifest $manifest `
+            -GitPath 'git' `
+            -GitInvoker (New-TestWorkerIsolationGitInvoker)
+
+        $report.ok | Should -Be $false
+        $report.findings[0].message | Should -Be 'worktree_git_dir is empty'
+    }
+
+    It 'fails when actual gitdir drifts from the manifest' {
+        . (Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\worker-isolation.ps1')
+
+        $otherGitDir = Join-Path $script:workerIsolationTempRoot '.git\worktrees\other-worker'
+        $report = Get-WinsmuxWorkerIsolationReport `
+            -ProjectDir $script:workerIsolationTempRoot `
+            -Manifest (New-TestWorkerIsolationManifest) `
+            -GitPath 'git' `
+            -GitInvoker {
+                param([string]$WorktreePath, [string[]]$Arguments)
+
+                switch ($Arguments -join ' ') {
+                    'rev-parse --show-toplevel' { $WorktreePath; break }
+                    'branch --show-current' { 'worktree-worker-1'; break }
+                    'config --get remote.origin.url' { 'https://github.com/example/repo.git'; break }
+                    'rev-parse --git-dir' { $otherGitDir; break }
+                    default { throw "unexpected git args: $($Arguments -join ' ')" }
+                }
+            }
+
+        $report.ok | Should -Be $false
+        $report.findings[0].message | Should -Match 'gitdir is'
+    }
+
     It 'fails when the worker branch drifts from the manifest' {
         . (Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\worker-isolation.ps1')
 

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -5920,6 +5920,54 @@ Describe 'worker isolation diagnostics' {
         $report.findings[0].message | Should -Match 'branch is main'
     }
 
+    It 'ignores non-worker panes without assigned worktree metadata' {
+        . (Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\worker-isolation.ps1')
+
+        $manifest = [pscustomobject]@{
+            panes = [ordered]@{
+                operator = [pscustomobject]@{
+                    role             = 'Operator'
+                    launch_dir       = $script:workerIsolationTempRoot
+                    worktree_git_dir = $script:workerIsolationGitDir
+                    expected_origin  = 'https://github.com/example/repo.git'
+                }
+            }
+        }
+
+        $report = Get-WinsmuxWorkerIsolationReport `
+            -ProjectDir $script:workerIsolationTempRoot `
+            -Manifest $manifest `
+            -GitPath 'git' `
+            -GitInvoker (New-TestWorkerIsolationGitInvoker -Branch 'main')
+
+        $report.ok | Should -Be $true
+        $report.worker_count | Should -Be 0
+    }
+
+    It 'allows scaled worker panes before gitdir and origin metadata are refreshed' {
+        . (Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\worker-isolation.ps1')
+
+        $manifest = [pscustomobject]@{
+            panes = [ordered]@{
+                'worker-7' = [pscustomobject]@{
+                    role                  = 'Worker'
+                    launch_dir            = $script:workerIsolationWorktree
+                    builder_worktree_path = $script:workerIsolationWorktree
+                    builder_branch        = 'worktree-worker-1'
+                }
+            }
+        }
+
+        $report = Get-WinsmuxWorkerIsolationReport `
+            -ProjectDir $script:workerIsolationTempRoot `
+            -Manifest $manifest `
+            -GitPath 'git' `
+            -GitInvoker (New-TestWorkerIsolationGitInvoker)
+
+        $report.ok | Should -Be $true
+        $report.worker_count | Should -Be 1
+    }
+
     It 'fails when the worker branch drifts from the manifest' {
         . (Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\worker-isolation.ps1')
 

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -5829,13 +5829,14 @@ Describe 'worker isolation diagnostics' {
     BeforeAll {
         function script:New-TestWorkerIsolationManifest {
             param(
-                [string]$ExpectedOrigin = 'https://github.com/example/repo.git'
+                [string]$ExpectedOrigin = 'https://github.com/example/repo.git',
+                [string]$Role = 'Worker'
             )
 
             [pscustomobject]@{
                 panes = [ordered]@{
                     'worker-1' = [pscustomobject]@{
-                        role                  = 'Worker'
+                        role                  = $Role
                         launch_dir            = $script:workerIsolationWorktree
                         builder_worktree_path = $script:workerIsolationWorktree
                         builder_branch        = 'worktree-worker-1'
@@ -5889,6 +5890,34 @@ Describe 'worker isolation diagnostics' {
         $report.status | Should -Be 'pass'
         $report.worker_count | Should -Be 1
         $report.summary | Should -Be '1 worker pane(s) isolated'
+    }
+
+    It 'audits legacy Builder panes with worktree metadata' {
+        . (Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\worker-isolation.ps1')
+
+        $report = Get-WinsmuxWorkerIsolationReport `
+            -ProjectDir $script:workerIsolationTempRoot `
+            -Manifest (New-TestWorkerIsolationManifest -Role 'Builder') `
+            -GitPath 'git' `
+            -GitInvoker (New-TestWorkerIsolationGitInvoker -Branch 'main')
+
+        $report.ok | Should -Be $false
+        $report.worker_count | Should -Be 1
+        $report.findings[0].message | Should -Match 'branch is main'
+    }
+
+    It 'audits pane entries that expose worktree metadata even without worker role' {
+        . (Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\worker-isolation.ps1')
+
+        $report = Get-WinsmuxWorkerIsolationReport `
+            -ProjectDir $script:workerIsolationTempRoot `
+            -Manifest (New-TestWorkerIsolationManifest -Role 'Researcher') `
+            -GitPath 'git' `
+            -GitInvoker (New-TestWorkerIsolationGitInvoker -Branch 'main')
+
+        $report.ok | Should -Be $false
+        $report.worker_count | Should -Be 1
+        $report.findings[0].message | Should -Match 'branch is main'
     }
 
     It 'fails when the worker branch drifts from the manifest' {

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -5906,17 +5906,42 @@ Describe 'worker isolation diagnostics' {
         $report.remediation | Should -Match 'Operator shell'
     }
 
+    It 'passes when actual origin only differs by credentials' {
+        . (Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\worker-isolation.ps1')
+
+        $report = Get-WinsmuxWorkerIsolationReport `
+            -ProjectDir $script:workerIsolationTempRoot `
+            -Manifest (New-TestWorkerIsolationManifest -ExpectedOrigin 'https://github.com/example/repo.git') `
+            -GitPath 'git' `
+            -GitInvoker {
+                param([string]$WorktreePath, [string[]]$Arguments)
+
+                switch ($Arguments -join ' ') {
+                    'rev-parse --show-toplevel' { $WorktreePath; break }
+                    'branch --show-current' { 'worktree-worker-1'; break }
+                    'config --get remote.origin.url' { 'https://actual-token@github.com/example/repo.git'; break }
+                    'rev-parse --git-dir' { $script:workerIsolationGitDir; break }
+                    default { throw "unexpected git args: $($Arguments -join ' ')" }
+                }
+            }
+
+        $report.ok | Should -Be $true
+        $report.findings.Count | Should -Be 0
+        $report.workers[0].actual_origin | Should -Be 'https://[redacted]@github.com/example/repo.git'
+    }
+
     It 'redacts credentials from origin drift findings' {
         . (Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\worker-isolation.ps1')
 
         $report = Get-WinsmuxWorkerIsolationReport `
             -ProjectDir $script:workerIsolationTempRoot `
-            -Manifest (New-TestWorkerIsolationManifest -ExpectedOrigin 'https://expected-token@github.com/example/repo.git') `
+            -Manifest (New-TestWorkerIsolationManifest -ExpectedOrigin 'ssh://expected-token@example.com/example/repo.git') `
             -GitPath 'git' `
-            -GitInvoker (New-TestWorkerIsolationGitInvoker -Origin 'https://actual-token@github.com/example/repo.git')
+            -GitInvoker (New-TestWorkerIsolationGitInvoker -Origin 'ssh://actual-token@github.com/example/other.git')
 
         $message = ($report.findings | ForEach-Object { $_.message }) -join '; '
         $message | Should -Match '\[redacted\]@github.com'
+        $message | Should -Match '\[redacted\]@example.com'
         $message | Should -Not -Match 'expected-token'
         $message | Should -Not -Match 'actual-token'
     }

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -10344,6 +10344,25 @@ Describe 'winsmux orchestra-smoke command' {
         $attachFailed.next_action | Should -Match 'attached-client confirmation'
     }
 
+    It 'classifies worker isolation drift without requiring startup rerun' {
+        $workerDrift = Invoke-TestOrchestraOperatorContract `
+            -SmokeOk $false `
+            -SessionReady $true `
+            -UiAttachLaunched $true `
+            -UiAttached $true `
+            -UiAttachStatus 'attach_confirmed' `
+            -ExternalOperatorMode $true `
+            -PaneCount 6 `
+            -ExpectedPaneCount 6 `
+            -SmokeErrors @('worker isolation drift: worker-1: branch is main; expected worktree-worker-1')
+
+        $workerDrift.operator_state | Should -Be 'blocked-worker-isolation'
+        $workerDrift.can_dispatch | Should -Be $false
+        $workerDrift.requires_startup | Should -Be $false
+        $workerDrift.operator_message | Should -Match 'startup is already session-ready'
+        $workerDrift.next_action | Should -Match 'Operator shell'
+    }
+
     It 'fails closed to runtime attach state instead of trusting manifest ui_attached alone' {
         $script:orchestraSmokeContent | Should -Match '\$uiAttached = \$false'
         $script:orchestraSmokeContent | Should -Match 'if \(\$null -eq \$attachState\)'

--- a/winsmux-core/scripts/doctor.ps1
+++ b/winsmux-core/scripts/doctor.ps1
@@ -12,6 +12,8 @@ Set-StrictMode -Version Latest
 . (Join-Path $PSScriptRoot 'planning-paths.ps1')
 . (Join-Path $PSScriptRoot 'pane-env.ps1')
 . (Join-Path $PSScriptRoot 'settings.ps1')
+. (Join-Path $PSScriptRoot 'manifest.ps1')
+. (Join-Path $PSScriptRoot 'worker-isolation.ps1')
 
 function New-DoctorResult {
     param(
@@ -331,6 +333,34 @@ function Test-StaleWorktreesCheck {
     return New-DoctorResult -Status pass -Label 'Stale worktrees' -Detail '0 found'
 }
 
+function Test-WorkerGitDriftCheck {
+    $repoRoot = Get-DoctorRepoRoot
+    $manifestPath = Join-Path $repoRoot '.winsmux/manifest.yaml'
+
+    if (-not (Test-Path -LiteralPath $manifestPath -PathType Leaf)) {
+        return New-DoctorResult -Status warn -Label 'Worker isolation drift' -Detail 'manifest not found (orchestra not started)'
+    }
+
+    try {
+        $manifest = Get-WinsmuxManifest -ProjectDir $repoRoot
+    } catch {
+        return New-DoctorResult -Status fail -Label 'Worker isolation drift' -Detail $_.Exception.Message
+    }
+
+    $gitPath = Get-DoctorGitCommandPath
+    $report = Get-WinsmuxWorkerIsolationReport -ProjectDir $repoRoot -Manifest $manifest -GitPath $gitPath
+    if ($report.ok) {
+        return New-DoctorResult -Status pass -Label 'Worker isolation drift' -Detail $report.summary
+    }
+
+    $findingText = (@($report.findings) | ForEach-Object { "$($_.label): $($_.message)" }) -join '; '
+    if (-not [string]::IsNullOrWhiteSpace($report.remediation)) {
+        $findingText = "$findingText; $($report.remediation)"
+    }
+
+    return New-DoctorResult -Status fail -Label 'Worker isolation drift' -Detail $findingText
+}
+
 function Test-ZombieProcessesCheck {
     $repoRoot = Get-DoctorRepoRoot
     $snapshot = Get-DoctorProcessSnapshot
@@ -475,6 +505,7 @@ if (-not $script:__winsmux_doctor_functions_only) {
         Test-BacklogYamlCheck
         Test-ManifestYamlCheck
         Test-StaleWorktreesCheck
+        Test-WorkerGitDriftCheck
         Test-ZombieProcessesCheck
         Test-BridgeConfigCheck
         Test-BridgeConfigMetadataCheck

--- a/winsmux-core/scripts/orchestra-smoke.ps1
+++ b/winsmux-core/scripts/orchestra-smoke.ps1
@@ -142,6 +142,16 @@ function Get-OrchestraOperatorContract {
     $requiresStartup = $true
     $uiWarning = $false
     $nextAction = 'Inspect smoke_errors and rerun orchestra-start before dispatching work.'
+    $workerIsolationOnly = $false
+    if ($SmokeErrors.Count -gt 0) {
+        $workerIsolationOnly = $true
+        foreach ($error in @($SmokeErrors)) {
+            if (-not ([string]$error).StartsWith('worker isolation drift:')) {
+                $workerIsolationOnly = $false
+                break
+            }
+        }
+    }
 
     if ($SmokeOk) {
         $state = 'ready-with-ui-warning'
@@ -164,6 +174,12 @@ function Get-OrchestraOperatorContract {
         } elseif ($SessionReady) {
             $uiWarning = $true
         }
+    } elseif ($workerIsolationOnly -and $SessionReady -and $PaneCount -ge $ExpectedPaneCount) {
+        $state = 'blocked-worker-isolation'
+        $message = 'Worker isolation drift blocks dispatch, but orchestra startup is already session-ready.'
+        $canDispatch = $false
+        $requiresStartup = $false
+        $nextAction = 'Fix worker root, branch, origin, or gitdir drift from the Operator shell, then recheck orchestra-smoke.'
     } elseif ($PaneCount -lt $ExpectedPaneCount -or -not $SessionReady) {
         $state = 'blocked'
         $message = 'Orchestra startup did not reach session-ready.'

--- a/winsmux-core/scripts/orchestra-smoke.ps1
+++ b/winsmux-core/scripts/orchestra-smoke.ps1
@@ -13,6 +13,7 @@ $scriptsRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
 . (Join-Path $scriptsRoot 'settings.ps1')
 . (Join-Path $scriptsRoot 'manifest.ps1')
 . (Join-Path $scriptsRoot 'orchestra-ui-attach.ps1')
+. (Join-Path $scriptsRoot 'worker-isolation.ps1')
 
 function Get-OrchestraSmokeLayoutSettings {
     param([string]$Root)
@@ -495,6 +496,23 @@ $attachedClientRegistryCount = [int]$attachResolution.AttachedClientRegistryCoun
 $attachedClientSnapshot = @($attachResolution.AttachedClientSnapshot)
 $attachAdapterTrace = @($attachResolution.AttachAdapterTrace)
 
+$gitPath = ''
+try {
+    $gitPath = (Get-Command 'git' -ErrorAction Stop).Source
+} catch {
+}
+
+$manifestObject = $null
+if ($manifestFound -and $manifestReadable) {
+    try {
+        $manifestObject = Get-WinsmuxManifest -ProjectDir $ProjectDir
+    } catch {
+        $manifestObject = $null
+    }
+}
+
+$workerIsolation = Get-WinsmuxWorkerIsolationReport -ProjectDir $ProjectDir -Manifest $manifestObject -GitPath $gitPath
+
 $smokeErrors = [System.Collections.Generic.List[string]]::new()
 if ($startExitCode -ne 0) { $smokeErrors.Add("orchestra-start exited with code $startExitCode.") | Out-Null }
 if (-not $manifestFound) {
@@ -505,6 +523,11 @@ if (-not $manifestFound) {
 if (-not $sessionReady) { $smokeErrors.Add('session_ready is false.') | Out-Null }
 if (-not $paneProbeOk) { $smokeErrors.Add("pane probe failed: $paneProbeError") | Out-Null }
 if ($paneProbeOk -and $paneCount -lt $expectedPaneCount) { $smokeErrors.Add("pane count $paneCount is below expected $expectedPaneCount.") | Out-Null }
+if (-not [bool]$workerIsolation.ok) {
+    foreach ($finding in @($workerIsolation.findings)) {
+        $smokeErrors.Add("worker isolation drift: $($finding.label): $($finding.message)") | Out-Null
+    }
+}
 $operatorContract = Get-OrchestraOperatorContract `
     -SmokeOk ($smokeErrors.Count -eq 0) `
     -SessionReady $sessionReady `
@@ -542,6 +565,7 @@ $result = [ordered]@{
     ui_attach_reason    = $uiAttachReason
     ui_attach_source    = $uiAttachSource
     ui_host_kind        = $uiHostKind
+    worker_isolation    = $workerIsolation
     smoke_ok            = ($smokeErrors.Count -eq 0)
     smoke_errors        = @($smokeErrors)
     operator_contract   = $operatorContract

--- a/winsmux-core/scripts/worker-isolation.ps1
+++ b/winsmux-core/scripts/worker-isolation.ps1
@@ -68,6 +68,42 @@ function ConvertTo-WinsmuxWorkerIsolationComparableOrigin {
     return [regex]::Replace($trimmed, '^[^/@\s]+@([^:\s]+:.+)$', '$1')
 }
 
+function Test-WinsmuxWorkerIsolationPaneEntry {
+    param([AllowNull()]$Pane)
+
+    if ($null -eq $Pane) {
+        return $false
+    }
+
+    $role = [string](Get-WinsmuxWorkerIsolationProperty -Value $Pane -Name 'role')
+    if ($role -ieq 'Worker' -or $role -ieq 'Builder') {
+        return $true
+    }
+
+    foreach ($name in @('launch_dir', 'builder_worktree_path', 'builder_branch', 'worktree_git_dir', 'expected_origin')) {
+        $value = [string](Get-WinsmuxWorkerIsolationProperty -Value $Pane -Name $name)
+        if (-not [string]::IsNullOrWhiteSpace($value)) {
+            return $true
+        }
+    }
+
+    return $false
+}
+
+function Get-WinsmuxWorkerIsolationPaneLabel {
+    param(
+        [AllowNull()]$Pane,
+        [AllowEmptyString()][string]$Fallback
+    )
+
+    $label = [string](Get-WinsmuxWorkerIsolationProperty -Value $Pane -Name 'label')
+    if (-not [string]::IsNullOrWhiteSpace($label)) {
+        return $label
+    }
+
+    return $Fallback
+}
+
 function Get-WinsmuxWorkerIsolationPaneEntries {
     param([AllowNull()]$Manifest)
 
@@ -80,10 +116,24 @@ function Get-WinsmuxWorkerIsolationPaneEntries {
     if ($panes -is [System.Collections.IDictionary]) {
         foreach ($key in $panes.Keys) {
             $pane = $panes[$key]
-            $role = [string](Get-WinsmuxWorkerIsolationProperty -Value $pane -Name 'role')
-            if ($role -ieq 'Worker') {
+            if (Test-WinsmuxWorkerIsolationPaneEntry -Pane $pane) {
                 $entries.Add([PSCustomObject]@{
-                    Label = [string]$key
+                    Label = Get-WinsmuxWorkerIsolationPaneLabel -Pane $pane -Fallback ([string]$key)
+                    Pane  = $pane
+                }) | Out-Null
+            }
+        }
+
+        return @($entries)
+    }
+
+    if ($panes -is [System.Collections.IEnumerable] -and -not ($panes -is [string])) {
+        $index = 0
+        foreach ($pane in @($panes)) {
+            $index++
+            if (Test-WinsmuxWorkerIsolationPaneEntry -Pane $pane) {
+                $entries.Add([PSCustomObject]@{
+                    Label = Get-WinsmuxWorkerIsolationPaneLabel -Pane $pane -Fallback "pane-$index"
                     Pane  = $pane
                 }) | Out-Null
             }
@@ -94,10 +144,9 @@ function Get-WinsmuxWorkerIsolationPaneEntries {
 
     foreach ($property in $panes.PSObject.Properties) {
         $pane = $property.Value
-        $role = [string](Get-WinsmuxWorkerIsolationProperty -Value $pane -Name 'role')
-        if ($role -ieq 'Worker') {
+        if (Test-WinsmuxWorkerIsolationPaneEntry -Pane $pane) {
             $entries.Add([PSCustomObject]@{
-                Label = [string]$property.Name
+                Label = Get-WinsmuxWorkerIsolationPaneLabel -Pane $pane -Fallback ([string]$property.Name)
                 Pane  = $pane
             }) | Out-Null
         }

--- a/winsmux-core/scripts/worker-isolation.ps1
+++ b/winsmux-core/scripts/worker-isolation.ps1
@@ -26,6 +26,23 @@ function Get-WinsmuxWorkerIsolationProperty {
     return $null
 }
 
+function Test-WinsmuxWorkerIsolationProperty {
+    param(
+        [AllowNull()]$Value,
+        [Parameter(Mandatory = $true)][string]$Name
+    )
+
+    if ($null -eq $Value) {
+        return $false
+    }
+
+    if ($Value -is [System.Collections.IDictionary]) {
+        return $Value.Contains($Name)
+    }
+
+    return ($null -ne $Value.PSObject -and $Value.PSObject.Properties.Name -contains $Name)
+}
+
 function Resolve-WinsmuxWorkerIsolationPath {
     param(
         [Parameter(Mandatory = $true)][string]$BasePath,
@@ -233,6 +250,8 @@ function Get-WinsmuxWorkerIsolationReport {
         $branchExpected = [string](Get-WinsmuxWorkerIsolationProperty -Value $pane -Name 'builder_branch')
         $gitDirExpectedRaw = [string](Get-WinsmuxWorkerIsolationProperty -Value $pane -Name 'worktree_git_dir')
         $originExpected = [string](Get-WinsmuxWorkerIsolationProperty -Value $pane -Name 'expected_origin')
+        $hasGitDirExpected = Test-WinsmuxWorkerIsolationProperty -Value $pane -Name 'worktree_git_dir'
+        $hasOriginExpected = Test-WinsmuxWorkerIsolationProperty -Value $pane -Name 'expected_origin'
 
         $worktreePath = Resolve-WinsmuxWorkerIsolationPath -BasePath $ProjectDir -Path $worktreePathRaw
         $launchPath = Resolve-WinsmuxWorkerIsolationPath -BasePath $ProjectDir -Path $launchDir
@@ -284,28 +303,40 @@ function Get-WinsmuxWorkerIsolationReport {
                 Add-WinsmuxWorkerIsolationFinding -Findings $findings -Label $label -Message "branch probe failed: $($branchProbe.Error)$($branchProbe.Output)"
             }
 
-            $originProbe = Invoke-WinsmuxWorkerIsolationGit -GitPath $GitPath -WorktreePath $worktreePath -Arguments @('config', '--get', 'remote.origin.url') -GitInvoker $GitInvoker
-            if ($originProbe.Ok) {
-                $actualOrigin = $originProbe.Output.Trim()
-                $actualOriginComparable = ConvertTo-WinsmuxWorkerIsolationComparableOrigin -Origin $actualOrigin
-                $originExpectedComparable = ConvertTo-WinsmuxWorkerIsolationComparableOrigin -Origin $originExpected
-                if (-not [string]::IsNullOrWhiteSpace($originExpected) -and $actualOriginComparable -ne $originExpectedComparable) {
-                    $safeActualOrigin = ConvertTo-WinsmuxWorkerIsolationSafeOrigin -Origin $actualOrigin
-                    $safeExpectedOrigin = ConvertTo-WinsmuxWorkerIsolationSafeOrigin -Origin $originExpected
-                    Add-WinsmuxWorkerIsolationFinding -Findings $findings -Label $label -Message "origin is $safeActualOrigin; expected $safeExpectedOrigin"
+            if ($hasOriginExpected) {
+                $originProbe = Invoke-WinsmuxWorkerIsolationGit -GitPath $GitPath -WorktreePath $worktreePath -Arguments @('config', '--get', 'remote.origin.url') -GitInvoker $GitInvoker
+                if ($originProbe.Ok) {
+                    $actualOrigin = $originProbe.Output.Trim()
+                    $actualOriginComparable = ConvertTo-WinsmuxWorkerIsolationComparableOrigin -Origin $actualOrigin
+                    $originExpectedComparable = ConvertTo-WinsmuxWorkerIsolationComparableOrigin -Origin $originExpected
+                    if ($actualOriginComparable -ne $originExpectedComparable) {
+                        $safeActualOrigin = ConvertTo-WinsmuxWorkerIsolationSafeOrigin -Origin $actualOrigin
+                        $safeExpectedOrigin = ConvertTo-WinsmuxWorkerIsolationSafeOrigin -Origin $originExpected
+                        if ([string]::IsNullOrWhiteSpace($safeExpectedOrigin)) {
+                            Add-WinsmuxWorkerIsolationFinding -Findings $findings -Label $label -Message "origin is $safeActualOrigin; expected no origin"
+                        } else {
+                            Add-WinsmuxWorkerIsolationFinding -Findings $findings -Label $label -Message "origin is $safeActualOrigin; expected $safeExpectedOrigin"
+                        }
+                    }
+                } elseif (-not [string]::IsNullOrWhiteSpace($originExpected)) {
+                    Add-WinsmuxWorkerIsolationFinding -Findings $findings -Label $label -Message "origin probe failed: $($originProbe.Error)$($originProbe.Output)"
                 }
-            } else {
-                Add-WinsmuxWorkerIsolationFinding -Findings $findings -Label $label -Message "origin probe failed: $($originProbe.Error)$($originProbe.Output)"
             }
 
-            $gitDirProbe = Invoke-WinsmuxWorkerIsolationGit -GitPath $GitPath -WorktreePath $worktreePath -Arguments @('rev-parse', '--git-dir') -GitInvoker $GitInvoker
-            if ($gitDirProbe.Ok) {
-                $actualGitDir = Resolve-WinsmuxWorkerIsolationPath -BasePath $worktreePath -Path $gitDirProbe.Output
-                if (-not [string]::IsNullOrWhiteSpace($gitDirExpected) -and $actualGitDir -ne $gitDirExpected) {
-                    Add-WinsmuxWorkerIsolationFinding -Findings $findings -Label $label -Message "gitdir is $actualGitDir; expected $gitDirExpected"
+            if ($hasGitDirExpected) {
+                if ([string]::IsNullOrWhiteSpace($gitDirExpected)) {
+                    Add-WinsmuxWorkerIsolationFinding -Findings $findings -Label $label -Message 'worktree_git_dir is empty'
+                } else {
+                    $gitDirProbe = Invoke-WinsmuxWorkerIsolationGit -GitPath $GitPath -WorktreePath $worktreePath -Arguments @('rev-parse', '--git-dir') -GitInvoker $GitInvoker
+                    if ($gitDirProbe.Ok) {
+                        $actualGitDir = Resolve-WinsmuxWorkerIsolationPath -BasePath $worktreePath -Path $gitDirProbe.Output
+                        if ($actualGitDir -ne $gitDirExpected) {
+                            Add-WinsmuxWorkerIsolationFinding -Findings $findings -Label $label -Message "gitdir is $actualGitDir; expected $gitDirExpected"
+                        }
+                    } else {
+                        Add-WinsmuxWorkerIsolationFinding -Findings $findings -Label $label -Message "gitdir probe failed: $($gitDirProbe.Error)$($gitDirProbe.Output)"
+                    }
                 }
-            } else {
-                Add-WinsmuxWorkerIsolationFinding -Findings $findings -Label $label -Message "gitdir probe failed: $($gitDirProbe.Error)$($gitDirProbe.Output)"
             }
         }
 

--- a/winsmux-core/scripts/worker-isolation.ps1
+++ b/winsmux-core/scripts/worker-isolation.ps1
@@ -51,7 +51,21 @@ function ConvertTo-WinsmuxWorkerIsolationSafeOrigin {
         return ''
     }
 
-    return [regex]::Replace($Origin, '^(https?://)[^/@]+@', '$1[redacted]@')
+    $trimmed = $Origin.Trim()
+    $trimmed = [regex]::Replace($trimmed, '^([A-Za-z][A-Za-z0-9+.-]*://)[^/@]+@', '$1[redacted]@')
+    return [regex]::Replace($trimmed, '^[^/@\s]+@([^:\s]+:.+)$', '[redacted]@$1')
+}
+
+function ConvertTo-WinsmuxWorkerIsolationComparableOrigin {
+    param([AllowEmptyString()][string]$Origin)
+
+    if ([string]::IsNullOrWhiteSpace($Origin)) {
+        return ''
+    }
+
+    $trimmed = $Origin.Trim()
+    $trimmed = [regex]::Replace($trimmed, '^([A-Za-z][A-Za-z0-9+.-]*://)[^/@]+@', '$1')
+    return [regex]::Replace($trimmed, '^[^/@\s]+@([^:\s]+:.+)$', '$1')
 }
 
 function Get-WinsmuxWorkerIsolationPaneEntries {
@@ -234,7 +248,9 @@ function Get-WinsmuxWorkerIsolationReport {
             $originProbe = Invoke-WinsmuxWorkerIsolationGit -GitPath $GitPath -WorktreePath $worktreePath -Arguments @('config', '--get', 'remote.origin.url') -GitInvoker $GitInvoker
             if ($originProbe.Ok) {
                 $actualOrigin = $originProbe.Output.Trim()
-                if (-not [string]::IsNullOrWhiteSpace($originExpected) -and $actualOrigin -ne $originExpected) {
+                $actualOriginComparable = ConvertTo-WinsmuxWorkerIsolationComparableOrigin -Origin $actualOrigin
+                $originExpectedComparable = ConvertTo-WinsmuxWorkerIsolationComparableOrigin -Origin $originExpected
+                if (-not [string]::IsNullOrWhiteSpace($originExpected) -and $actualOriginComparable -ne $originExpectedComparable) {
                     $safeActualOrigin = ConvertTo-WinsmuxWorkerIsolationSafeOrigin -Origin $actualOrigin
                     $safeExpectedOrigin = ConvertTo-WinsmuxWorkerIsolationSafeOrigin -Origin $originExpected
                     Add-WinsmuxWorkerIsolationFinding -Findings $findings -Label $label -Message "origin is $safeActualOrigin; expected $safeExpectedOrigin"

--- a/winsmux-core/scripts/worker-isolation.ps1
+++ b/winsmux-core/scripts/worker-isolation.ps1
@@ -80,11 +80,9 @@ function Test-WinsmuxWorkerIsolationPaneEntry {
         return $true
     }
 
-    foreach ($name in @('launch_dir', 'builder_worktree_path', 'builder_branch', 'worktree_git_dir', 'expected_origin')) {
-        $value = [string](Get-WinsmuxWorkerIsolationProperty -Value $Pane -Name $name)
-        if (-not [string]::IsNullOrWhiteSpace($value)) {
-            return $true
-        }
+    $worktreePath = [string](Get-WinsmuxWorkerIsolationProperty -Value $Pane -Name 'builder_worktree_path')
+    if (-not [string]::IsNullOrWhiteSpace($worktreePath)) {
+        return $true
     }
 
     return $false
@@ -252,14 +250,6 @@ function Get-WinsmuxWorkerIsolationReport {
 
         if ([string]::IsNullOrWhiteSpace($branchExpected)) {
             Add-WinsmuxWorkerIsolationFinding -Findings $findings -Label $label -Message 'builder_branch is missing'
-        }
-
-        if ([string]::IsNullOrWhiteSpace($gitDirExpected)) {
-            Add-WinsmuxWorkerIsolationFinding -Findings $findings -Label $label -Message 'worktree_git_dir is missing'
-        }
-
-        if ([string]::IsNullOrWhiteSpace($originExpected)) {
-            Add-WinsmuxWorkerIsolationFinding -Findings $findings -Label $label -Message 'expected_origin is missing'
         }
 
         if (-not [string]::IsNullOrWhiteSpace($worktreePath) -and -not (Test-Path -LiteralPath $worktreePath -PathType Container)) {

--- a/winsmux-core/scripts/worker-isolation.ps1
+++ b/winsmux-core/scripts/worker-isolation.ps1
@@ -1,0 +1,287 @@
+[CmdletBinding()]
+param()
+
+function Get-WinsmuxWorkerIsolationProperty {
+    param(
+        [AllowNull()]$Value,
+        [Parameter(Mandatory = $true)][string]$Name
+    )
+
+    if ($null -eq $Value) {
+        return $null
+    }
+
+    if ($Value -is [System.Collections.IDictionary]) {
+        if ($Value.Contains($Name)) {
+            return $Value[$Name]
+        }
+
+        return $null
+    }
+
+    if ($null -ne $Value.PSObject -and $Value.PSObject.Properties.Name -contains $Name) {
+        return $Value.$Name
+    }
+
+    return $null
+}
+
+function Resolve-WinsmuxWorkerIsolationPath {
+    param(
+        [Parameter(Mandatory = $true)][string]$BasePath,
+        [AllowEmptyString()][string]$Path
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Path)) {
+        return ''
+    }
+
+    $expanded = [Environment]::ExpandEnvironmentVariables($Path.Trim())
+    if ([System.IO.Path]::IsPathRooted($expanded)) {
+        return [System.IO.Path]::GetFullPath($expanded)
+    }
+
+    return [System.IO.Path]::GetFullPath((Join-Path $BasePath $expanded))
+}
+
+function ConvertTo-WinsmuxWorkerIsolationSafeOrigin {
+    param([AllowEmptyString()][string]$Origin)
+
+    if ([string]::IsNullOrWhiteSpace($Origin)) {
+        return ''
+    }
+
+    return [regex]::Replace($Origin, '^(https?://)[^/@]+@', '$1[redacted]@')
+}
+
+function Get-WinsmuxWorkerIsolationPaneEntries {
+    param([AllowNull()]$Manifest)
+
+    $entries = [System.Collections.Generic.List[object]]::new()
+    $panes = Get-WinsmuxWorkerIsolationProperty -Value $Manifest -Name 'panes'
+    if ($null -eq $panes) {
+        return @()
+    }
+
+    if ($panes -is [System.Collections.IDictionary]) {
+        foreach ($key in $panes.Keys) {
+            $pane = $panes[$key]
+            $role = [string](Get-WinsmuxWorkerIsolationProperty -Value $pane -Name 'role')
+            if ($role -ieq 'Worker') {
+                $entries.Add([PSCustomObject]@{
+                    Label = [string]$key
+                    Pane  = $pane
+                }) | Out-Null
+            }
+        }
+
+        return @($entries)
+    }
+
+    foreach ($property in $panes.PSObject.Properties) {
+        $pane = $property.Value
+        $role = [string](Get-WinsmuxWorkerIsolationProperty -Value $pane -Name 'role')
+        if ($role -ieq 'Worker') {
+            $entries.Add([PSCustomObject]@{
+                Label = [string]$property.Name
+                Pane  = $pane
+            }) | Out-Null
+        }
+    }
+
+    return @($entries)
+}
+
+function Invoke-WinsmuxWorkerIsolationGit {
+    param(
+        [Parameter(Mandatory = $true)][string]$GitPath,
+        [Parameter(Mandatory = $true)][string]$WorktreePath,
+        [Parameter(Mandatory = $true)][string[]]$Arguments,
+        [AllowNull()][scriptblock]$GitInvoker = $null
+    )
+
+    try {
+        if ($null -ne $GitInvoker) {
+            $output = & $GitInvoker -WorktreePath $WorktreePath -Arguments $Arguments 2>&1
+            $exitCode = 0
+        } else {
+            $output = & $GitPath -C $WorktreePath @Arguments 2>&1
+            $exitCode = $LASTEXITCODE
+        }
+
+        return [PSCustomObject]@{
+            Ok     = ($exitCode -eq 0)
+            Output = (($output | ForEach-Object { [string]$_ }) -join "`n").Trim()
+            Error  = ''
+        }
+    } catch {
+        return [PSCustomObject]@{
+            Ok     = $false
+            Output = ''
+            Error  = $_.Exception.Message
+        }
+    }
+}
+
+function Add-WinsmuxWorkerIsolationFinding {
+    param(
+        [Parameter(Mandatory = $true)]$Findings,
+        [Parameter(Mandatory = $true)][string]$Label,
+        [Parameter(Mandatory = $true)][string]$Message
+    )
+
+    $Findings.Add([PSCustomObject]@{
+        label   = $Label
+        message = $Message
+    }) | Out-Null
+}
+
+function Get-WinsmuxWorkerIsolationReport {
+    param(
+        [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [AllowNull()]$Manifest,
+        [AllowEmptyString()][string]$GitPath = '',
+        [AllowNull()][scriptblock]$GitInvoker = $null
+    )
+
+    $findings = [System.Collections.Generic.List[object]]::new()
+    $workers = [System.Collections.Generic.List[object]]::new()
+    $workerEntries = @(Get-WinsmuxWorkerIsolationPaneEntries -Manifest $Manifest)
+
+    if ($workerEntries.Count -eq 0) {
+        return [PSCustomObject]@{
+            ok          = $true
+            status      = 'pass'
+            worker_count = 0
+            findings    = @()
+            workers     = @()
+            summary     = '0 worker panes in manifest'
+            remediation = ''
+        }
+    }
+
+    if ([string]::IsNullOrWhiteSpace($GitPath)) {
+        Add-WinsmuxWorkerIsolationFinding -Findings $findings -Label 'git' -Message 'git executable not found'
+    }
+
+    foreach ($entry in $workerEntries) {
+        $pane = $entry.Pane
+        $label = [string]$entry.Label
+        $launchDir = [string](Get-WinsmuxWorkerIsolationProperty -Value $pane -Name 'launch_dir')
+        $worktreePathRaw = [string](Get-WinsmuxWorkerIsolationProperty -Value $pane -Name 'builder_worktree_path')
+        $branchExpected = [string](Get-WinsmuxWorkerIsolationProperty -Value $pane -Name 'builder_branch')
+        $gitDirExpectedRaw = [string](Get-WinsmuxWorkerIsolationProperty -Value $pane -Name 'worktree_git_dir')
+        $originExpected = [string](Get-WinsmuxWorkerIsolationProperty -Value $pane -Name 'expected_origin')
+
+        $worktreePath = Resolve-WinsmuxWorkerIsolationPath -BasePath $ProjectDir -Path $worktreePathRaw
+        $launchPath = Resolve-WinsmuxWorkerIsolationPath -BasePath $ProjectDir -Path $launchDir
+        $gitDirExpected = Resolve-WinsmuxWorkerIsolationPath -BasePath $ProjectDir -Path $gitDirExpectedRaw
+
+        if ([string]::IsNullOrWhiteSpace($worktreePath)) {
+            Add-WinsmuxWorkerIsolationFinding -Findings $findings -Label $label -Message 'builder_worktree_path is missing'
+        }
+
+        if ([string]::IsNullOrWhiteSpace($launchPath)) {
+            Add-WinsmuxWorkerIsolationFinding -Findings $findings -Label $label -Message 'launch_dir is missing'
+        } elseif (-not [string]::IsNullOrWhiteSpace($worktreePath) -and $launchPath -ne $worktreePath) {
+            Add-WinsmuxWorkerIsolationFinding -Findings $findings -Label $label -Message "launch_dir is $launchPath; expected $worktreePath"
+        }
+
+        if ([string]::IsNullOrWhiteSpace($branchExpected)) {
+            Add-WinsmuxWorkerIsolationFinding -Findings $findings -Label $label -Message 'builder_branch is missing'
+        }
+
+        if ([string]::IsNullOrWhiteSpace($gitDirExpected)) {
+            Add-WinsmuxWorkerIsolationFinding -Findings $findings -Label $label -Message 'worktree_git_dir is missing'
+        }
+
+        if ([string]::IsNullOrWhiteSpace($originExpected)) {
+            Add-WinsmuxWorkerIsolationFinding -Findings $findings -Label $label -Message 'expected_origin is missing'
+        }
+
+        if (-not [string]::IsNullOrWhiteSpace($worktreePath) -and -not (Test-Path -LiteralPath $worktreePath -PathType Container)) {
+            Add-WinsmuxWorkerIsolationFinding -Findings $findings -Label $label -Message "assigned worktree does not exist: $worktreePath"
+        }
+
+        $actualRoot = ''
+        $actualBranch = ''
+        $actualOrigin = ''
+        $actualGitDir = ''
+
+        if (-not [string]::IsNullOrWhiteSpace($GitPath) -and
+            -not [string]::IsNullOrWhiteSpace($worktreePath) -and
+            (Test-Path -LiteralPath $worktreePath -PathType Container)) {
+            $rootProbe = Invoke-WinsmuxWorkerIsolationGit -GitPath $GitPath -WorktreePath $worktreePath -Arguments @('rev-parse', '--show-toplevel') -GitInvoker $GitInvoker
+            if ($rootProbe.Ok) {
+                $actualRoot = Resolve-WinsmuxWorkerIsolationPath -BasePath $ProjectDir -Path $rootProbe.Output
+                if ($actualRoot -ne $worktreePath) {
+                    Add-WinsmuxWorkerIsolationFinding -Findings $findings -Label $label -Message "git root is $actualRoot; expected $worktreePath"
+                }
+            } else {
+                Add-WinsmuxWorkerIsolationFinding -Findings $findings -Label $label -Message "git root probe failed: $($rootProbe.Error)$($rootProbe.Output)"
+            }
+
+            $branchProbe = Invoke-WinsmuxWorkerIsolationGit -GitPath $GitPath -WorktreePath $worktreePath -Arguments @('branch', '--show-current') -GitInvoker $GitInvoker
+            if ($branchProbe.Ok) {
+                $actualBranch = $branchProbe.Output.Trim()
+                if (-not [string]::IsNullOrWhiteSpace($branchExpected) -and $actualBranch -ne $branchExpected) {
+                    Add-WinsmuxWorkerIsolationFinding -Findings $findings -Label $label -Message "branch is $actualBranch; expected $branchExpected"
+                }
+            } else {
+                Add-WinsmuxWorkerIsolationFinding -Findings $findings -Label $label -Message "branch probe failed: $($branchProbe.Error)$($branchProbe.Output)"
+            }
+
+            $originProbe = Invoke-WinsmuxWorkerIsolationGit -GitPath $GitPath -WorktreePath $worktreePath -Arguments @('config', '--get', 'remote.origin.url') -GitInvoker $GitInvoker
+            if ($originProbe.Ok) {
+                $actualOrigin = $originProbe.Output.Trim()
+                if (-not [string]::IsNullOrWhiteSpace($originExpected) -and $actualOrigin -ne $originExpected) {
+                    $safeActualOrigin = ConvertTo-WinsmuxWorkerIsolationSafeOrigin -Origin $actualOrigin
+                    $safeExpectedOrigin = ConvertTo-WinsmuxWorkerIsolationSafeOrigin -Origin $originExpected
+                    Add-WinsmuxWorkerIsolationFinding -Findings $findings -Label $label -Message "origin is $safeActualOrigin; expected $safeExpectedOrigin"
+                }
+            } else {
+                Add-WinsmuxWorkerIsolationFinding -Findings $findings -Label $label -Message "origin probe failed: $($originProbe.Error)$($originProbe.Output)"
+            }
+
+            $gitDirProbe = Invoke-WinsmuxWorkerIsolationGit -GitPath $GitPath -WorktreePath $worktreePath -Arguments @('rev-parse', '--git-dir') -GitInvoker $GitInvoker
+            if ($gitDirProbe.Ok) {
+                $actualGitDir = Resolve-WinsmuxWorkerIsolationPath -BasePath $worktreePath -Path $gitDirProbe.Output
+                if (-not [string]::IsNullOrWhiteSpace($gitDirExpected) -and $actualGitDir -ne $gitDirExpected) {
+                    Add-WinsmuxWorkerIsolationFinding -Findings $findings -Label $label -Message "gitdir is $actualGitDir; expected $gitDirExpected"
+                }
+            } else {
+                Add-WinsmuxWorkerIsolationFinding -Findings $findings -Label $label -Message "gitdir probe failed: $($gitDirProbe.Error)$($gitDirProbe.Output)"
+            }
+        }
+
+        $workers.Add([PSCustomObject]@{
+            label             = $label
+            launch_dir        = $launchPath
+            assigned_worktree = $worktreePath
+            expected_branch   = $branchExpected
+            actual_branch     = $actualBranch
+            expected_origin   = (ConvertTo-WinsmuxWorkerIsolationSafeOrigin -Origin $originExpected)
+            actual_origin     = (ConvertTo-WinsmuxWorkerIsolationSafeOrigin -Origin $actualOrigin)
+            expected_gitdir   = $gitDirExpected
+            actual_gitdir     = $actualGitDir
+            actual_root       = $actualRoot
+        }) | Out-Null
+    }
+
+    $ok = ($findings.Count -eq 0)
+    $summary = if ($ok) {
+        "$($workerEntries.Count) worker pane(s) isolated"
+    } else {
+        "$($findings.Count) worker isolation issue(s)"
+    }
+
+    return [PSCustomObject]@{
+        ok          = $ok
+        status      = $(if ($ok) { 'pass' } else { 'fail' })
+        worker_count = $workerEntries.Count
+        findings    = @($findings)
+        workers     = @($workers)
+        summary     = $summary
+        remediation = $(if ($ok) { '' } else { 'Keep edits and tests in the assigned worker worktree. Run git add, git commit, git push, and PR merge from the Operator shell.' })
+    }
+}


### PR DESCRIPTION
## Summary
- add shared worker isolation drift diagnostics for worker root, branch, origin, and worktree gitdir
- surface the diagnostics in winsmux doctor and orchestra-smoke --json
- fail orchestra-smoke dispatch readiness when worker isolation drift is detected
- redact credentials from origin drift output

## Validation
- PowerShell parser check for worker-isolation.ps1, doctor.ps1, orchestra-smoke.ps1, and winsmux-bridge.Tests.ps1
- Invoke-Pester .\tests\winsmux-bridge.Tests.ps1 -Output Detailed
- git diff --check
- pwsh -NoProfile -File .\scripts\audit-public-surface.ps1
- pwsh -NoProfile -File .\scripts\git-guard.ps1 -Mode full
- gitleaks detect --source . --no-banner --redact --log-opts "--all"

Refs #571
TASK-387
