### PR TITLE
TASK-314: route provider readiness through adapters

### DIFF
--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -2885,7 +2885,8 @@ function Invoke-Send {
                 if ([string]::IsNullOrWhiteSpace($capabilityAdapter)) {
                     $capabilityAdapter = [string]$agentConfig.Agent
                 }
-                $execMode = $execModeValue.Trim().ToLowerInvariant() -eq 'true' -and $capabilityAdapter -eq 'codex'
+                $execModeAgent = ConvertTo-ReadinessAgentName $capabilityAdapter
+                $execMode = $execModeValue.Trim().ToLowerInvariant() -eq 'true' -and $execModeAgent -eq 'codex'
             }
         } catch {
             if ($_.Exception.Message -match 'Provider capability') {

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -6194,6 +6194,37 @@ panes:
         }
     }
 
+    It 'uses capability adapters when calculating Builder workload' {
+        @"
+version: 1
+saved_at: 2026-04-05T10:00:00+09:00
+session:
+  name: winsmux-orchestra
+  project_dir: $script:paneScalerTempRoot
+panes:
+  - label: builder-1
+    pane_id: %2
+    role: Builder
+"@ | Set-Content -Path $script:paneScalerManifestPath -Encoding UTF8
+
+        Mock Get-SlotAgentConfig {
+            [PSCustomObject]@{
+                Agent             = 'codex-nightly'
+                Model             = 'gpt-5.4-nightly'
+                CapabilityAdapter = 'codex'
+            }
+        }
+        Mock Get-PaneAgentStatus {
+            [PSCustomObject]@{ Status = 'ready'; ExitReason = '' }
+        }
+
+        Get-PaneWorkload -ManifestPath $script:paneScalerManifestPath -Settings ([ordered]@{ agent = 'codex-nightly'; model = 'gpt-5.4-nightly'; roles = [ordered]@{} }) | Out-Null
+
+        Should -Invoke Get-PaneAgentStatus -Times 1 -Exactly -ParameterFilter {
+            $PaneId -eq '%2' -and $Agent -eq 'codex' -and $Role -eq 'Builder'
+        }
+    }
+
     It 'uses provider registry overrides through the pane scaling entrypoint without explicit settings' {
         @"
 version: 1
@@ -6661,6 +6692,35 @@ panes:
     pane_id: %4
     role: Reviewer
     capability_adapter: claude
+'@ | Set-Content -Path $manifestPath -Encoding UTF8
+
+        $records = Get-PaneStatusRecords -ProjectDir $script:paneStatusTempRoot -SnapshotProvider {
+            param($PaneId)
+
+            if ($PaneId -eq '%4') {
+                return 'Welcome to Claude Code!'
+            }
+
+            throw "unexpected pane id: $PaneId"
+        }
+
+        $records.Count | Should -Be 1
+        $records[0].Label | Should -Be 'reviewer'
+        $records[0].State | Should -Be 'idle'
+    }
+
+    It 'uses manifest provider targets when classifying pane captures' {
+        $manifestPath = Join-Path (Join-Path $script:paneStatusTempRoot '.winsmux') 'manifest.yaml'
+@'
+version: 1
+session:
+  name: winsmux-orchestra
+  project_dir: C:\repo
+panes:
+  reviewer:
+    pane_id: %4
+    role: Reviewer
+    provider_target: claude:opus
 '@ | Set-Content -Path $manifestPath -Encoding UTF8
 
         $records = Get-PaneStatusRecords -ProjectDir $script:paneStatusTempRoot -SnapshotProvider {
@@ -10036,6 +10096,12 @@ thinking
 Welcome to Claude Code!
 thinking
 "@ -Agent 'claude') | Should -Be $false
+    }
+
+    It 'normalizes provider aliases before adapter readiness checks' {
+        ConvertTo-ReadinessAgentName 'codex-nightly' | Should -Be 'codex'
+        ConvertTo-ReadinessAgentName 'Claude/opus' | Should -Be 'claude'
+        ConvertTo-ReadinessAgentName 'gemini:flash' | Should -Be 'gemini'
     }
 
     It 'resolves readiness adapters from the pane manifest' {

--- a/winsmux-core/scripts/pane-scaler.ps1
+++ b/winsmux-core/scripts/pane-scaler.ps1
@@ -350,7 +350,12 @@ function Get-PaneWorkload {
             }
         }
 
-        $status = Get-PaneAgentStatus -PaneId $paneId -Agent ([string]$roleAgentConfig.Agent) -Role 'Builder' -HungThreshold $HungThreshold
+        $statusAgent = [string](Get-MonitorPropertyValue -InputObject $roleAgentConfig -Name 'CapabilityAdapter' -Default '')
+        if ([string]::IsNullOrWhiteSpace($statusAgent)) {
+            $statusAgent = [string]$roleAgentConfig.Agent
+        }
+
+        $status = Get-PaneAgentStatus -PaneId $paneId -Agent $statusAgent -Role 'Builder' -HungThreshold $HungThreshold
         $statusName = [string](Get-MonitorPropertyValue -InputObject $status -Name 'Status' -Default '')
         if ($statusName -in @('busy', 'approval_waiting')) {
             $busyCount++

--- a/winsmux-core/scripts/pane-status.ps1
+++ b/winsmux-core/scripts/pane-status.ps1
@@ -142,6 +142,45 @@ function Get-PaneActualStateFromText {
     return 'busy'
 }
 
+function ConvertTo-PaneStatusReadinessAgent {
+    param([AllowNull()][string]$Name)
+
+    if ([string]::IsNullOrWhiteSpace($Name)) {
+        return ''
+    }
+
+    $normalized = $Name.Trim().ToLowerInvariant()
+    if ($normalized -in @('codex', 'claude', 'gemini')) {
+        return $normalized
+    }
+
+    if ($normalized -match '^(codex|claude|gemini)(?:$|[:/_-])') {
+        return $Matches[1]
+    }
+
+    return ''
+}
+
+function Get-PaneStatusReadinessAgent {
+    param([AllowNull()]$Entry)
+
+    if ($null -eq $Entry) {
+        return 'codex'
+    }
+
+    $adapterName = ConvertTo-PaneStatusReadinessAgent ([string]$Entry.CapabilityAdapter)
+    if (-not [string]::IsNullOrWhiteSpace($adapterName)) {
+        return $adapterName
+    }
+
+    $providerName = ConvertTo-PaneStatusReadinessAgent ([string]$Entry.ProviderTarget)
+    if (-not [string]::IsNullOrWhiteSpace($providerName)) {
+        return $providerName
+    }
+
+    return 'codex'
+}
+
 function Get-PaneStatusWorktree {
     param(
         [Parameter(Mandatory = $true)][string]$ProjectDir,
@@ -219,10 +258,7 @@ function Get-PaneStatusRecords {
     foreach ($entry in $entries) {
         $snapshot = ''
         $state = 'unknown'
-        $stateAgent = [string]$entry.CapabilityAdapter
-        if ([string]::IsNullOrWhiteSpace($stateAgent)) {
-            $stateAgent = 'codex'
-        }
+        $stateAgent = Get-PaneStatusReadinessAgent -Entry $entry
 
         if (-not [string]::IsNullOrWhiteSpace($entry.PaneId)) {
             try {


### PR DESCRIPTION
## Summary
- route pane status readiness through capability adapters and provider targets
- route pane scaler workload checks through capability adapters
- normalize send exec-mode eligibility through adapter names for provider aliases

## Validation
- Invoke-Pester .\tests\winsmux-bridge.Tests.ps1 -FullName '*pane scaler helpers*' -Output Detailed
- Invoke-Pester .\tests\winsmux-bridge.Tests.ps1 -FullName '*pane status helpers*' -Output Detailed
- Invoke-Pester .\tests\winsmux-bridge.Tests.ps1 -FullName '*winsmux readiness adapter helpers*' -Output Detailed
- Invoke-Pester .\tests\winsmux-bridge.Tests.ps1 -Output Detailed
- git diff --check
- pwsh -NoProfile -File .\scripts\audit-public-surface.ps1
- pwsh -NoProfile -File .\scripts\git-guard.ps1 -Mode full
- gitleaks detect --source . --no-banner --redact --log-opts "--all"

## Review
- Subagent review: no actionable findings