### PR TITLE
TASK-314: route role launch through provider capabilities

### DIFF
--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -3083,6 +3083,60 @@ function Invoke-Role {
     while ("$newRole-$nextNum" -in $existingLabels) { $nextNum++ }
     $newLabel = "$newRole-$nextNum"
 
+    $manifestEntry = $null
+    if ((Test-Path $manifestPath -PathType Leaf) -and
+        (Get-Command Get-PaneControlManifestEntries -ErrorAction SilentlyContinue)) {
+        $manifestEntry = @(Get-PaneControlManifestEntries -ProjectDir $projectDir | Where-Object {
+            [string]::Equals([string]$_.PaneId, $paneId, [System.StringComparison]::OrdinalIgnoreCase)
+        } | Select-Object -First 1)
+        if ($manifestEntry.Count -gt 0) {
+            $manifestEntry = $manifestEntry[0]
+        } else {
+            $manifestEntry = $null
+        }
+    }
+    $launchDir = $projectDir
+    if ($null -ne $manifestEntry -and -not [string]::IsNullOrWhiteSpace([string]$manifestEntry.LaunchDir)) {
+        $launchDir = [string]$manifestEntry.LaunchDir
+    } elseif ($null -ne $manifestEntry -and -not [string]::IsNullOrWhiteSpace([string]$manifestEntry.BuilderWorktreePath)) {
+        $launchDir = [string]$manifestEntry.BuilderWorktreePath
+    }
+    $gitDir = Join-Path $launchDir ".git"
+    if ($null -ne $manifestEntry -and -not [string]::IsNullOrWhiteSpace([string]$manifestEntry.GitWorktreeDir)) {
+        $gitDir = [string]$manifestEntry.GitWorktreeDir
+    }
+    $settings = Get-BridgeSettings -RootPath $projectDir
+    if (Get-Command Get-SlotAgentConfig -ErrorAction SilentlyContinue) {
+        $roleAgentConfig = Get-SlotAgentConfig -Role $newRole -SlotId $newLabel -Settings $settings -RootPath $projectDir
+    } else {
+        $roleAgentConfig = Get-RoleAgentConfig -Role $newRole -Settings $settings
+    }
+    $manifestRole = switch ($newRole) {
+        'worker' { 'Worker' }
+        'builder' { 'Builder' }
+        'researcher' { 'Researcher' }
+        'reviewer' { 'Reviewer' }
+        default { $newRole }
+    }
+    if ($manifestRole -notin @('Builder', 'Worker')) {
+        $launchDir = $projectDir
+        if (Get-Command Get-PaneControlGitWorktreeDir -ErrorAction SilentlyContinue) {
+            $gitDir = Get-PaneControlGitWorktreeDir -ProjectDir $projectDir
+        } else {
+            $gitDir = Join-Path $projectDir ".git"
+        }
+    }
+    $launchCmd = Get-BridgeProviderLaunchCommand `
+        -ProviderId ([string]$roleAgentConfig.Agent) `
+        -Model ([string]$roleAgentConfig.Model) `
+        -ProjectDir $launchDir `
+        -GitWorktreeDir $gitDir `
+        -RootPath $projectDir
+    $providerTarget = [string]$roleAgentConfig.Agent
+    if (-not [string]::IsNullOrWhiteSpace([string]$roleAgentConfig.Model)) {
+        $providerTarget = "${providerTarget}:$([string]$roleAgentConfig.Model)"
+    }
+
     # Rename pane first (before respawn)
     & winsmux select-pane -t $paneId -T $newLabel
 
@@ -3091,28 +3145,129 @@ function Invoke-Role {
     if ($labels.ContainsKey($oldLabel)) { $labels.Remove($oldLabel) }
     Save-Labels $labels
 
-    # Respawn pane (kills current process + restarts shell in one step, #174)
-    & winsmux respawn-pane -k -t $paneId
-
-    # Wait for shell ready (poll for PS prompt)
-    $deadline = (Get-Date).AddSeconds(15)
-    while ((Get-Date) -lt $deadline) {
-        $snapshot = (& winsmux capture-pane -t $paneId -p 2>$null | Out-String).TrimEnd()
-        $lastLine = ($snapshot -split "`n" | Where-Object { $_.Trim() } | Select-Object -Last 1)
-        if ($lastLine -and $lastLine.Trim() -match '^PS ') { break }
-        Start-Sleep -Milliseconds 500
+    if ((Test-Path $manifestPath -PathType Leaf) -and
+        (Get-Command Set-PaneControlManifestPaneProperties -ErrorAction SilentlyContinue)) {
+        $manifestProperties = [ordered]@{
+            label                      = $newLabel
+            role                       = $manifestRole
+            launch_dir                 = $launchDir
+            worktree_git_dir           = $gitDir
+            provider_target            = $providerTarget
+            capability_adapter         = [string]$roleAgentConfig.CapabilityAdapter
+            capability_command         = [string]$roleAgentConfig.CapabilityCommand
+            supports_parallel_runs     = [bool]$roleAgentConfig.SupportsParallelRuns
+            supports_interrupt         = [bool]$roleAgentConfig.SupportsInterrupt
+            supports_structured_result = [bool]$roleAgentConfig.SupportsStructuredResult
+            supports_file_edit         = [bool]$roleAgentConfig.SupportsFileEdit
+            supports_subagents         = [bool]$roleAgentConfig.SupportsSubagents
+            supports_verification      = [bool]$roleAgentConfig.SupportsVerification
+            supports_consultation      = [bool]$roleAgentConfig.SupportsConsultation
+        }
+        if ($manifestRole -notin @('Builder', 'Worker')) {
+            $manifestProperties['builder_worktree_path'] = ''
+            $manifestProperties['builder_branch'] = ''
+        }
+        Set-PaneControlManifestPaneProperties -ManifestPath $manifestPath -PaneId $paneId -Properties $manifestProperties
     }
 
+    $sessionName = [string]$env:WINSMUX_ORCHESTRA_SESSION
     try {
-        Update-PaneControlManifestPaneLabel -ProjectDir $projectDir -PaneId $paneId -Label $newLabel | Out-Null
+        $manifestForEnvironment = Get-WinsmuxManifest -ProjectDir $projectDir
+        $manifestSessionName = [string](Get-PaneControlValue -InputObject $manifestForEnvironment.session -Name 'name' -Default '')
+        if ([string]::IsNullOrWhiteSpace($sessionName)) {
+            $sessionName = $manifestSessionName
+        }
     } catch {
     }
 
-    # Launch Codex agent
-    $gitDir = Join-Path $projectDir ".git"
-    $launchCmd = "codex --sandbox danger-full-access -C '$projectDir' --add-dir '$gitDir'"
-    & winsmux send-keys -t $paneId -l $launchCmd
-    & winsmux send-keys -t $paneId Enter
+    $transientEnvironmentNames = @()
+    if (-not [string]::IsNullOrWhiteSpace($sessionName) -and
+        (Get-Command Get-WinsmuxPaneEnvironment -ErrorAction SilentlyContinue)) {
+        $persistentEnvironmentNames = @('WINSMUX_ORCHESTRA_SESSION', 'WINSMUX_ORCHESTRA_PROJECT_DIR', 'WINSMUX_ROLE_MAP', 'WINSMUX_HOOK_PROFILE', 'WINSMUX_GOVERNANCE_MODE')
+        if (Get-Command Get-WinsmuxEnvironmentVariableNames -ErrorAction SilentlyContinue) {
+            $transientEnvironmentNames = @(Get-WinsmuxEnvironmentVariableNames | Where-Object { $_ -notin $persistentEnvironmentNames })
+        } else {
+            $transientEnvironmentNames = @(
+                'WINSMUX_ROLE',
+                'WINSMUX_PANE_ID',
+                'WINSMUX_BUILDER_WORKTREE',
+                'WINSMUX_ASSIGNED_WORKTREE',
+                'WINSMUX_ASSIGNED_BRANCH',
+                'WINSMUX_WORKTREE_GITDIR',
+                'WINSMUX_SLOT_ID',
+                'WINSMUX_EXPECTED_ORIGIN'
+            )
+        }
+        foreach ($name in $transientEnvironmentNames) {
+            try {
+                & winsmux set-environment -u -t $sessionName $name
+            } catch {
+            }
+        }
+        $roleMap = [ordered]@{}
+        try {
+            foreach ($entry in @(Get-PaneControlManifestEntries -ProjectDir $projectDir)) {
+                if ([string]::IsNullOrWhiteSpace([string]$entry.PaneId)) {
+                    continue
+                }
+
+                $roleMap[[string]$entry.PaneId] = [string]$entry.Role
+            }
+        } catch {
+        }
+        $roleMap[[string]$paneId] = $manifestRole
+        $roleMapJson = ($roleMap | ConvertTo-Json -Compress)
+        $builderWorktreePath = ''
+        $assignedBranch = ''
+        $environmentGitDir = ''
+        if ($manifestRole -in @('Builder', 'Worker') -and $null -ne $manifestEntry) {
+            $builderWorktreePath = [string]$manifestEntry.BuilderWorktreePath
+            $assignedBranch = [string]$manifestEntry.BuilderBranch
+            $environmentGitDir = $gitDir
+        }
+        $paneEnvironment = Get-WinsmuxPaneEnvironment `
+            -Role $manifestRole `
+            -PaneId $paneId `
+            -SessionName $sessionName `
+            -ProjectDir $projectDir `
+            -RoleMapJson $roleMapJson `
+            -BuilderWorktreePath $builderWorktreePath `
+            -SlotId $newLabel `
+            -AssignedBranch $assignedBranch `
+            -GitWorktreeDir $environmentGitDir
+        foreach ($entry in $paneEnvironment.GetEnumerator()) {
+            & winsmux set-environment -t $sessionName ([string]$entry.Key) ([string]$entry.Value)
+            if ($entry.Key -notin $persistentEnvironmentNames -and $entry.Key -notin $transientEnvironmentNames) {
+                $transientEnvironmentNames += [string]$entry.Key
+            }
+        }
+    }
+
+    try {
+        # Respawn pane (kills current process + restarts shell in one step, #174)
+        & winsmux respawn-pane -k -t $paneId -c $launchDir
+
+        # Wait for shell ready (poll for PS prompt)
+        $deadline = (Get-Date).AddSeconds(15)
+        while ((Get-Date) -lt $deadline) {
+            $snapshot = (& winsmux capture-pane -t $paneId -p 2>$null | Out-String).TrimEnd()
+            $lastLine = ($snapshot -split "`n" | Where-Object { $_.Trim() } | Select-Object -Last 1)
+            if ($lastLine -and $lastLine.Trim() -match '^PS ') { break }
+            Start-Sleep -Milliseconds 500
+        }
+
+        & winsmux send-keys -t $paneId -l $launchCmd
+        & winsmux send-keys -t $paneId Enter
+    } finally {
+        if (-not [string]::IsNullOrWhiteSpace($sessionName)) {
+            foreach ($name in @($transientEnvironmentNames | Select-Object -Unique)) {
+                try {
+                    & winsmux set-environment -u -t $sessionName $name
+                } catch {
+                }
+            }
+        }
+    }
 
     Write-Output "Role changed: $oldLabel -> $newLabel ($paneId)"
 }

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -2082,6 +2082,64 @@ panes:
         $plan.LaunchCommand | Should -Match $([regex]::Escape("-C 'C:\repo\.worktrees\builder-2'"))
     }
 
+    It 'preserves explicit worktree_git_dir when reading a worker entry' {
+@'
+version: 1
+saved_at: '2026-04-07T00:00:00+09:00'
+session:
+  name: 'winsmux-orchestra'
+  project_dir: 'C:\repo'
+  git_worktree_dir: 'C:\repo\.git'
+panes:
+  - label: 'worker-1'
+    pane_id: '%2'
+    role: 'Worker'
+    exec_mode: true
+    launch_dir: 'C:\repo\.worktrees\worker-1'
+    builder_branch: 'worktree-worker-1'
+    builder_worktree_path: 'C:\repo\.worktrees\worker-1'
+    worktree_git_dir: 'C:\repo\.git\worktrees\worker-1'
+    task: null
+'@ | Set-Content -Path (Join-Path $script:paneControlManifestDir 'manifest.yaml') -Encoding UTF8
+
+        $entries = @(Get-PaneControlManifestEntries -ProjectDir $script:paneControlTempRoot)
+
+        $entries.Count | Should -Be 1
+        $entries[0].LaunchDir | Should -Be 'C:\repo\.worktrees\worker-1'
+        $entries[0].BuilderBranch | Should -Be 'worktree-worker-1'
+        $entries[0].GitWorktreeDir | Should -Be 'C:\repo\.git\worktrees\worker-1'
+    }
+
+    It 'ignores stale worker worktree metadata when reading a non-worker entry' {
+@'
+version: 1
+saved_at: '2026-04-23T00:00:00+09:00'
+session:
+  name: 'winsmux-orchestra'
+  project_dir: 'C:\repo'
+  git_worktree_dir: 'C:\repo\.git'
+panes:
+  - label: 'reviewer'
+    pane_id: '%4'
+    role: 'Reviewer'
+    exec_mode: true
+    launch_dir: ''
+    builder_branch: 'worktree-worker-1'
+    builder_worktree_path: 'C:\repo\.worktrees\worker-1'
+    worktree_git_dir: 'C:\repo\.git\worktrees\worker-1'
+    task: null
+'@ | Set-Content -Path (Join-Path $script:paneControlManifestDir 'manifest.yaml') -Encoding UTF8
+
+        $entries = @(Get-PaneControlManifestEntries -ProjectDir $script:paneControlTempRoot)
+
+        $entries.Count | Should -Be 1
+        $entries[0].Role | Should -Be 'Reviewer'
+        $entries[0].LaunchDir | Should -Be 'C:\repo'
+        $entries[0].BuilderBranch | Should -Be ''
+        $entries[0].BuilderWorktreePath | Should -Be ''
+        $entries[0].GitWorktreeDir | Should -Be 'C:\repo\.git'
+    }
+
     It 'uses slot-level agent and model overrides when building a restart plan' {
 @'
 version: 1
@@ -10184,6 +10242,56 @@ Describe 'winsmux provider-capabilities command' {
         $payload.provider_id | Should -Be 'CODEX'
         $payload.capabilities.command | Should -Be 'codex'
         $payload.capabilities.supports_verification | Should -Be $true
+    }
+}
+
+Describe 'winsmux role command provider routing' {
+    BeforeAll {
+        $script:winsmuxRoleRawPath = Join-Path (Split-Path -Parent $PSScriptRoot) 'scripts\winsmux-core.ps1'
+        $script:winsmuxRoleRawContent = Get-Content -Raw -Path $script:winsmuxRoleRawPath -Encoding UTF8
+    }
+
+    It 'builds reassigned role launch commands through provider capabilities' {
+        $script:winsmuxRoleRawContent | Should -Match 'Get-SlotAgentConfig -Role \$newRole -SlotId \$newLabel'
+        $script:winsmuxRoleRawContent | Should -Match 'Get-BridgeProviderLaunchCommand'
+        $script:winsmuxRoleRawContent | Should -Match '\$launchDir = \[string\]\$manifestEntry\.LaunchDir'
+        $script:winsmuxRoleRawContent | Should -Match '\$gitDir = \[string\]\$manifestEntry\.GitWorktreeDir'
+        $script:winsmuxRoleRawContent | Should -Match 'ProjectDir \$launchDir'
+        $script:winsmuxRoleRawContent | Should -Match 'respawn-pane -k -t \$paneId -c \$launchDir'
+        $script:winsmuxRoleRawContent | Should -Match 'role\s*=\s*\$manifestRole'
+        $script:winsmuxRoleRawContent | Should -Match 'launch_dir\s*=\s*\$launchDir'
+        $script:winsmuxRoleRawContent | Should -Match 'worktree_git_dir\s*=\s*\$gitDir'
+        $script:winsmuxRoleRawContent | Should -Match 'provider_target\s*=\s*\$providerTarget'
+        $script:winsmuxRoleRawContent | Should -Match 'capability_adapter\s*=\s*\[string\]\$roleAgentConfig\.CapabilityAdapter'
+        $script:winsmuxRoleRawContent | Should -Match "builder_worktree_path'\]\s*=\s*''"
+        $script:winsmuxRoleRawContent | Should -Match "builder_branch'\]\s*=\s*''"
+        $script:winsmuxRoleRawContent | Should -Match '\$environmentGitDir\s*=\s*'''''
+        $script:winsmuxRoleRawContent | Should -Match '\$assignedBranch\s*=\s*\[string\]\$manifestEntry\.BuilderBranch'
+        $script:winsmuxRoleRawContent | Should -Match 'Get-WinsmuxEnvironmentVariableNames'
+        $script:winsmuxRoleRawContent | Should -Match 'Get-WinsmuxPaneEnvironment'
+        $script:winsmuxRoleRawContent | Should -Match 'WINSMUX_ROLE_MAP'
+        $script:winsmuxRoleRawContent | Should -Match 'set-environment -t \$sessionName'
+        $script:winsmuxRoleRawContent | Should -Match 'set-environment -u -t \$sessionName \$name'
+        $script:winsmuxRoleRawContent | Should -Not -Match 'codex --sandbox danger-full-access -C'
+        $launchIndex = $script:winsmuxRoleRawContent.IndexOf('$launchCmd = Get-BridgeProviderLaunchCommand')
+        $nonWorkerResetIndex = $script:winsmuxRoleRawContent.IndexOf('$manifestRole -notin @(''Builder'', ''Worker'')')
+        $renameIndex = $script:winsmuxRoleRawContent.IndexOf('& winsmux select-pane -t $paneId -T $newLabel')
+        $manifestUpdateIndex = $script:winsmuxRoleRawContent.IndexOf('Set-PaneControlManifestPaneProperties -ManifestPath $manifestPath')
+        $environmentIndex = $script:winsmuxRoleRawContent.IndexOf('$paneEnvironment = Get-WinsmuxPaneEnvironment')
+        $environmentClearIndex = $script:winsmuxRoleRawContent.IndexOf('& winsmux set-environment -u -t $sessionName $name')
+        $respawnIndex = $script:winsmuxRoleRawContent.IndexOf('& winsmux respawn-pane -k -t $paneId -c $launchDir')
+        $launchIndex | Should -BeGreaterThan -1
+        $nonWorkerResetIndex | Should -BeGreaterThan -1
+        $renameIndex | Should -BeGreaterThan -1
+        $manifestUpdateIndex | Should -BeGreaterThan -1
+        $environmentIndex | Should -BeGreaterThan -1
+        $environmentClearIndex | Should -BeGreaterThan -1
+        $respawnIndex | Should -BeGreaterThan -1
+        $nonWorkerResetIndex | Should -BeLessThan $launchIndex
+        $launchIndex | Should -BeLessThan $renameIndex
+        $manifestUpdateIndex | Should -BeLessThan $respawnIndex
+        $environmentClearIndex | Should -BeLessThan $environmentIndex
+        $environmentIndex | Should -BeLessThan $respawnIndex
     }
 }
 

--- a/winsmux-core/scripts/pane-control.ps1
+++ b/winsmux-core/scripts/pane-control.ps1
@@ -310,10 +310,18 @@ function Get-PaneControlManifestEntries {
     foreach ($label in $manifest.Panes.Keys) {
         $pane = $manifest.Panes[$label]
         $role = Get-PaneControlCanonicalRole -Role ([string](Get-PaneControlValue -InputObject $pane -Name 'role' -Default '')) -Label $label
+        $usesWorkerWorktree = $role -in @('Builder', 'Worker')
         $launchDir = [string](Get-PaneControlValue -InputObject $pane -Name 'launch_dir' -Default '')
         $builderWorktreePath = [string](Get-PaneControlValue -InputObject $pane -Name 'builder_worktree_path' -Default '')
+        if (-not $usesWorkerWorktree) {
+            $builderWorktreePath = ''
+        }
+        $builderBranch = [string](Get-PaneControlValue -InputObject $pane -Name 'builder_branch' -Default '')
+        if (-not $usesWorkerWorktree) {
+            $builderBranch = ''
+        }
 
-        if ([string]::IsNullOrWhiteSpace($launchDir) -and -not [string]::IsNullOrWhiteSpace($builderWorktreePath)) {
+        if ($usesWorkerWorktree -and [string]::IsNullOrWhiteSpace($launchDir) -and -not [string]::IsNullOrWhiteSpace($builderWorktreePath)) {
             $launchDir = $builderWorktreePath
         }
 
@@ -321,9 +329,16 @@ function Get-PaneControlManifestEntries {
             $launchDir = $projectRoot
         }
 
-        $gitWorktreeDir = $sessionGitWorktreeDir
-        if ($role -in @('Builder', 'Worker') -or [string]::IsNullOrWhiteSpace($gitWorktreeDir)) {
-            $gitWorktreeDir = Get-PaneControlGitWorktreeDir -ProjectDir $launchDir
+        $paneGitWorktreeDir = ''
+        if ($usesWorkerWorktree) {
+            $paneGitWorktreeDir = [string](Get-PaneControlValue -InputObject $pane -Name 'worktree_git_dir' -Default '')
+        }
+        $gitWorktreeDir = $paneGitWorktreeDir
+        if ([string]::IsNullOrWhiteSpace($gitWorktreeDir)) {
+            $gitWorktreeDir = $sessionGitWorktreeDir
+            if ($usesWorkerWorktree -or [string]::IsNullOrWhiteSpace($gitWorktreeDir)) {
+                $gitWorktreeDir = Get-PaneControlGitWorktreeDir -ProjectDir $launchDir
+            }
         }
 
         $entries += [PSCustomObject][ordered]@{
@@ -333,6 +348,7 @@ function Get-PaneControlManifestEntries {
             PaneId              = [string](Get-PaneControlValue -InputObject $pane -Name 'pane_id' -Default '')
             Role                = $role
             LaunchDir           = $launchDir
+            BuilderBranch       = $builderBranch
             BuilderWorktreePath = $builderWorktreePath
             GitWorktreeDir      = $gitWorktreeDir
             TaskId              = [string](Get-PaneControlValue -InputObject $pane -Name 'task_id' -Default '')


### PR DESCRIPTION
## Summary
- route reassigned role launches through provider capability configuration
- prefer slot-level role config when available
- add Pester coverage that blocks the old hardcoded Codex launch command

## Validation
- Invoke-Pester .\tests\winsmux-bridge.Tests.ps1 -FullName '*winsmux role command provider routing*' -Output Detailed
- Invoke-Pester .\tests\winsmux-bridge.Tests.ps1 -Output Detailed
- git diff --check
- pwsh -NoProfile -File .\scripts\audit-public-surface.ps1
- pwsh -NoProfile -File .\scripts\git-guard.ps1 -Mode full
- gitleaks detect --source . --no-banner --redact --log-opts "--all"
