### PR TITLE
chore: support empty roadmap release slots

### DIFF
--- a/winsmux-core/scripts/internal-docs-meta.psd1
+++ b/winsmux-core/scripts/internal-docs-meta.psd1
@@ -222,6 +222,14 @@
         }
         @{
             Order = 90
+            Version = 'v0.24.6'
+            TaskIds = @()
+            Focus = 'ultrareview 指摘の吸収'
+            Example = 'v1.0.0 前にバグや再発を独立枠で確認'
+            Memo = '指摘が出た時点で TASK を追加'
+        }
+        @{
+            Order = 100
             Version = 'v1.0.0'
             TaskIds = @('TASK-220')
             Focus = '公開ゲート'
@@ -229,7 +237,7 @@
             Memo = ''
         }
         @{
-            Order = 100
+            Order = 110
             Version = 'v1.1.0'
             TaskIds = @('TASK-311', 'TASK-317', 'TASK-318', 'TASK-319')
             Focus = '管理された自律 run の基盤'
@@ -237,7 +245,7 @@
             Memo = ''
         }
         @{
-            Order = 110
+            Order = 120
             Version = 'v1.2.0'
             TaskIds = @('TASK-320', 'TASK-321', 'TASK-322')
             Focus = '自律 run の TDD と自己確認'
@@ -245,7 +253,7 @@
             Memo = ''
         }
         @{
-            Order = 120
+            Order = 130
             Version = 'v1.3.0'
             TaskIds = @('TASK-312', 'TASK-323', 'TASK-324', 'TASK-325', 'TASK-326')
             Focus = '知識、手順書、並列子 run、handoff 画面'
@@ -253,7 +261,7 @@
             Memo = ''
         }
         @{
-            Order = 130
+            Order = 140
             Version = 'pending'
             TaskIds = @('TASK-249', 'TASK-250', 'TASK-251', 'TASK-252', 'TASK-267', 'TASK-268', 'TASK-271')
             Focus = 'Windows 以外への展開'
@@ -261,7 +269,7 @@
             Memo = ''
         }
         @{
-            Order = 140
+            Order = 150
             Version = 'v1.6.0'
             TaskIds = @('TASK-045', 'TASK-046', 'TASK-047', 'TASK-048', 'TASK-050', 'TASK-073', 'TASK-076')
             Focus = '公開後の設計書と細かな承認制御'

--- a/winsmux-core/scripts/sync-internal-docs.ps1
+++ b/winsmux-core/scripts/sync-internal-docs.ps1
@@ -182,7 +182,7 @@ function Get-VersionSortTuple {
 
 function Get-PlanningState {
     param(
-        [Parameter(Mandatory = $true)][string[]]$TaskIds,
+        [Parameter(Mandatory = $true)][AllowEmptyCollection()][string[]]$TaskIds,
         [Parameter(Mandatory = $true)][hashtable]$TasksById
     )
 

--- a/winsmux-core/scripts/sync-roadmap.ps1
+++ b/winsmux-core/scripts/sync-roadmap.ps1
@@ -726,8 +726,24 @@ foreach ($task in $tasksWithoutTargetVersion) {
 
 $tasksWithTargetVersion = @($tasks | Where-Object { -not [string]::IsNullOrWhiteSpace($_.TargetVersion) })
 
-$versionGroups = $tasksWithTargetVersion |
-    Group-Object -Property TargetVersion |
+$versionGroupMap = [ordered]@{}
+foreach ($group in ($tasksWithTargetVersion | Group-Object -Property TargetVersion)) {
+    $versionGroupMap[$group.Name] = [pscustomobject]@{
+        Name  = $group.Name
+        Group = @($group.Group)
+    }
+}
+
+foreach ($version in $versionTitles.Keys) {
+    if (-not $versionGroupMap.Contains($version)) {
+        $versionGroupMap[$version] = [pscustomobject]@{
+            Name  = $version
+            Group = @()
+        }
+    }
+}
+
+$versionGroups = @($versionGroupMap.Values) |
     Sort-Object @{ Expression = { (Get-VersionSortKey -Version $_.Name).Major } }, @{ Expression = { (Get-VersionSortKey -Version $_.Name).Minor } }, @{ Expression = { (Get-VersionSortKey -Version $_.Name).Patch } }, @{ Expression = { (Get-VersionSortKey -Version $_.Name).Raw } }
 
 $builder = [System.Text.StringBuilder]::new()


### PR DESCRIPTION
## Summary
- include comment-only version headings in generated roadmap output
- allow empty task lists in internal manual checklist metadata
- add the v0.24.6 manual-checklist row for the ultrareview cleanup slot

## Validation
- `pwsh -NoProfile -File .\winsmux-core\scripts\sync-roadmap.ps1 ...`
- parser check for roadmap sync scripts
- `git diff --check`
- `pwsh -NoProfile -File .\scripts\git-guard.ps1 -Mode full`