### PR TITLE
Guard local interactive OAuth auth modes

### DIFF
--- a/docs/authentication-support.ja.md
+++ b/docs/authentication-support.ja.md
@@ -69,6 +69,8 @@ winsmux は次を行いません。
 ## 起動前の確認での扱い
 
 起動前の確認では、CLI 名だけでなく認証方式も見ます。
+起動処理は、プロバイダー対応表と設定された `auth_mode` を見ます。
+その確認を通ってから、ペインを起動します。
 
 例:
 
@@ -82,6 +84,15 @@ winsmux は次を行いません。
 他のペインで共有する資格情報ではありません。
 起動前の確認では、winsmux に認証完了 URL の受信、トークン抽出、
 ペイン間のトークン共有を求める設定を拒否します。
+
+次の `auth_mode` の値は明示的に拒否します。
+
+- `oauth-broker`
+- `token-broker`
+- `callback-url`
+- `callback-url-receiver`
+- `shared-token`
+- `provider-api-proxy`
 
 ## 用語統一
 

--- a/docs/authentication-support.md
+++ b/docs/authentication-support.md
@@ -70,6 +70,8 @@ winsmux does not:
 ## Preflight handling
 
 Preflight handling looks at both the CLI name and the authentication mode.
+The launcher uses the provider capability registry and the configured `auth_mode`
+before it starts a pane.
 
 Examples:
 
@@ -83,6 +85,15 @@ Local interactive modes are allowed only when the official CLI owns the login.
 They are not shared credentials for other panes.
 Preflight must stop if a workflow asks winsmux to receive callback URLs,
 extract tokens, or share tokens across panes.
+
+The following `auth_mode` values are explicitly blocked:
+
+- `oauth-broker`
+- `token-broker`
+- `callback-url`
+- `callback-url-receiver`
+- `shared-token`
+- `provider-api-proxy`
 
 ## Terminology
 

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -3715,6 +3715,8 @@ function New-LauncherSlotSummary {
         agent                      = [string]$effective.Agent
         model                      = [string]$effective.Model
         prompt_transport           = [string]$effective.PromptTransport
+        auth_mode                  = [string]$effective.AuthMode
+        auth_policy                = [string]$effective.AuthPolicy
         source                     = [string]$effective.Source
         capability_adapter         = [string]$effective.CapabilityAdapter
         capability_command         = [string]$effective.CapabilityCommand
@@ -8153,13 +8155,14 @@ function Invoke-ProviderCapabilities {
 function Invoke-ProviderSwitch {
     $tokens = @(@($Target) + @($Rest) | Where-Object { $_ })
     if ($tokens.Count -lt 1) {
-        Stop-WithError "usage: winsmux provider-switch <slot> [--agent <name>] [--model <name>] [--prompt-transport <argv|file|stdin>] [--reason <text>] [--restart] [--clear] [--json]"
+        Stop-WithError "usage: winsmux provider-switch <slot> [--agent <name>] [--model <name>] [--prompt-transport <argv|file|stdin>] [--auth-mode <mode>] [--reason <text>] [--restart] [--clear] [--json]"
     }
 
     $slotId = [string]$tokens[0]
     $agent = ''
     $model = ''
     $promptTransport = ''
+    $authMode = ''
     $reason = ''
     $restartRequested = $false
     $clearRequested = $false
@@ -8188,6 +8191,13 @@ function Invoke-ProviderSwitch {
                 $promptTransport = [string]$tokens[$index + 1]
                 $index++
             }
+            '--auth-mode' {
+                if ($index + 1 -ge $tokens.Count) {
+                    Stop-WithError '--auth-mode requires a value'
+                }
+                $authMode = [string]$tokens[$index + 1]
+                $index++
+            }
             '--reason' {
                 if ($index + 1 -ge $tokens.Count) {
                     Stop-WithError '--reason requires a value'
@@ -8205,13 +8215,13 @@ function Invoke-ProviderSwitch {
                 $clearRequested = $true
             }
             default {
-                Stop-WithError "usage: winsmux provider-switch <slot> [--agent <name>] [--model <name>] [--prompt-transport <argv|file|stdin>] [--reason <text>] [--restart] [--clear] [--json]"
+                Stop-WithError "usage: winsmux provider-switch <slot> [--agent <name>] [--model <name>] [--prompt-transport <argv|file|stdin>] [--auth-mode <mode>] [--reason <text>] [--restart] [--clear] [--json]"
             }
         }
     }
 
-    if ($clearRequested -and (-not [string]::IsNullOrWhiteSpace($agent) -or -not [string]::IsNullOrWhiteSpace($model) -or -not [string]::IsNullOrWhiteSpace($promptTransport))) {
-        Stop-WithError 'provider-switch --clear cannot be combined with --agent, --model, or --prompt-transport.'
+    if ($clearRequested -and (-not [string]::IsNullOrWhiteSpace($agent) -or -not [string]::IsNullOrWhiteSpace($model) -or -not [string]::IsNullOrWhiteSpace($promptTransport) -or -not [string]::IsNullOrWhiteSpace($authMode))) {
+        Stop-WithError 'provider-switch --clear cannot be combined with --agent, --model, --prompt-transport, or --auth-mode.'
     }
 
     $projectDir = (Get-Location).Path
@@ -8246,7 +8256,15 @@ function Invoke-ProviderSwitch {
         $clearResult = Remove-BridgeProviderRegistryEntry -RootPath $projectDir -SlotId $slotId
         $cleared = [bool]$clearResult.Removed
     } else {
-        $entry = Write-BridgeProviderRegistryEntry -RootPath $projectDir -SlotId $slotId -Agent $agent -Model $model -PromptTransport $promptTransport -Reason $reason
+        if (-not [string]::IsNullOrWhiteSpace($authMode)) {
+            $currentEffective = Get-SlotAgentConfig -Role 'Worker' -SlotId $slotId -Settings $settings -RootPath $projectDir
+            $candidateAgent = [string]$currentEffective.Agent
+            if (-not [string]::IsNullOrWhiteSpace($agent)) {
+                $candidateAgent = $agent
+            }
+            Assert-BridgeProviderCapabilityAuthMode -ProviderId $candidateAgent -AuthMode $authMode -RootPath $projectDir
+        }
+        $entry = Write-BridgeProviderRegistryEntry -RootPath $projectDir -SlotId $slotId -Agent $agent -Model $model -PromptTransport $promptTransport -AuthMode $authMode -Reason $reason
     }
     $effective = Get-SlotAgentConfig -Role 'Worker' -SlotId $slotId -Settings $settings -RootPath $projectDir
     $result = [ordered]@{
@@ -8254,6 +8272,8 @@ function Invoke-ProviderSwitch {
         agent                      = [string]$effective.Agent
         model                      = [string]$effective.Model
         prompt_transport           = [string]$effective.PromptTransport
+        auth_mode                  = [string]$effective.AuthMode
+        auth_policy                = [string]$effective.AuthPolicy
         source                     = [string]$effective.Source
         capability_adapter         = [string]$effective.CapabilityAdapter
         capability_command         = [string]$effective.CapabilityCommand
@@ -8286,11 +8306,11 @@ function Invoke-ProviderSwitch {
     }
 
     if ($clearRequested) {
-        Write-Output "provider switch cleared for ${slotId}: $($result.agent) / $($result.model) ($($result.prompt_transport))"
+        Write-Output "provider switch cleared for ${slotId}: $($result.agent) / $($result.model) ($($result.prompt_transport), $($result.auth_policy))"
         return
     }
 
-    Write-Output "provider switched for ${slotId}: $($result.agent) / $($result.model) ($($result.prompt_transport))"
+    Write-Output "provider switched for ${slotId}: $($result.agent) / $($result.model) ($($result.prompt_transport), $($result.auth_policy))"
 }
 
 function Show-Usage {
@@ -8328,7 +8348,7 @@ Commands:
   consult-result <mode> [--message <text>] [--target-slot <slot>] [--confidence <0..1>] [--next-test <text>] [--risk <text>] [--run-id <run_id>] [--json]  Record a consultation result packet/event
   consult-error <mode> [--message <text>] [--target-slot <slot>]  Record a consultation error packet/event
   provider-capabilities [provider] [--json]  Inspect the provider capability registry contract
-  provider-switch <slot> [--agent <name>] [--model <name>] [--prompt-transport <argv|file|stdin>] [--reason <text>] [--restart] [--clear] [--json]  Record or clear a runtime provider reassignment for a managed slot
+  provider-switch <slot> [--agent <name>] [--model <name>] [--prompt-transport <argv|file|stdin>] [--auth-mode <mode>] [--reason <text>] [--restart] [--clear] [--json]  Record or clear a runtime provider reassignment for a managed slot
   locks                     List active file locks
   verify <pr-number>        Run Pester in tests/ and merge PR only on PASS
   wait <channel> [timeout]  Block until signal received (replaces polling)

--- a/tests/PublicSurfacePolicy.Tests.ps1
+++ b/tests/PublicSurfacePolicy.Tests.ps1
@@ -162,8 +162,14 @@ Describe 'Public surface policy' {
 
         $authSupport | Should -Match 'claude-pro-max-oauth.*interactive use on that same PC'
         $authSupport | Should -Match 'gemini-google-oauth.*interactive use on that same PC'
+        $authSupport | Should -Match 'configured `auth_mode`'
+        $authSupport | Should -Match 'token-broker'
+        $authSupport | Should -Match 'provider-api-proxy'
         $authSupportJa | Should -Match 'claude-pro-max-oauth.*その PC 上での対話利用のみ'
         $authSupportJa | Should -Match 'gemini-google-oauth.*その PC 上での対話利用のみ'
+        $authSupportJa | Should -Match '設定された `auth_mode`'
+        $authSupportJa | Should -Match 'token-broker'
+        $authSupportJa | Should -Match 'provider-api-proxy'
     }
 
     It 'uses recorded-baseline gitleaks scans for routine push and CI checks' {

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -673,6 +673,8 @@ agent-slots:
       "display_name": "Codex",
       "command": "codex",
       "prompt_transports": ["argv", "file", "stdin"],
+      "auth_modes": ["api-key", "codex-chatgpt-local"],
+      "local_interactive_oauth_modes": ["codex-chatgpt-local"],
       "supports_parallel_runs": true,
       "supports_interrupt": true,
       "supports_structured_result": true,
@@ -688,6 +690,8 @@ agent-slots:
         $registry = Read-BridgeProviderCapabilityRegistry -RootPath $script:settingsTempRoot
         $registry.providers.codex.adapter | Should -Be 'codex'
         $registry.providers.codex.prompt_transports | Should -Be @('argv', 'file', 'stdin')
+        $registry.providers.codex.auth_modes | Should -Be @('api-key', 'codex-chatgpt-local')
+        $registry.providers.codex.local_interactive_oauth_modes | Should -Be @('codex-chatgpt-local')
         $registry.providers.codex.supports_file_edit | Should -Be $true
 
         $capability = Get-BridgeProviderCapability -RootPath $script:settingsTempRoot -ProviderId 'CODEX'
@@ -707,6 +711,8 @@ agent-slots:
       "adapter": "codex",
       "command": "codex",
       "prompt_transports": ["argv", "file", "stdin"],
+      "auth_modes": ["api-key", "codex-chatgpt-local"],
+      "local_interactive_oauth_modes": ["codex-chatgpt-local"],
       "supports_parallel_runs": true,
       "supports_interrupt": true,
       "supports_structured_result": true,
@@ -728,6 +734,7 @@ agent-slots:
     agent: codex
     model: gpt-5.4
     prompt-transport: argv
+    auth-mode: codex-chatgpt-local
 '@ | Set-Content -Path (Join-Path $script:settingsTempRoot '.winsmux.yaml') -Encoding UTF8
 
         Mock Get-WinsmuxOption { param($Name, $Default) return $null }
@@ -737,6 +744,8 @@ agent-slots:
 
         $config.CapabilityAdapter | Should -Be 'codex'
         $config.CapabilityCommand | Should -Be 'codex'
+        $config.AuthMode | Should -Be 'codex-chatgpt-local'
+        $config.AuthPolicy | Should -Be 'local_interactive_only'
         $config.SupportsParallelRuns | Should -Be $true
         $config.SupportsInterrupt | Should -Be $true
         $config.SupportsInterruptDeclared | Should -Be $true
@@ -865,6 +874,84 @@ agent-slots:
         {
             Get-SlotAgentConfig -Role 'Worker' -SlotId 'worker-1' -Settings $settings -RootPath $script:settingsTempRoot
         } | Should -Throw "*does not support prompt_transport 'stdin'*"
+    }
+
+    It 'rejects blocked provider auth modes before launch resolution' {
+        $registryPath = Get-BridgeProviderCapabilityRegistryPath -RootPath $script:settingsTempRoot
+        $registryDir = Split-Path -Parent $registryPath
+        New-Item -ItemType Directory -Path $registryDir -Force | Out-Null
+
+@'
+{
+  "version": 1,
+  "providers": {
+    "claude": {
+      "adapter": "claude",
+      "command": "claude",
+      "prompt_transports": ["file"],
+      "auth_modes": ["api-key", "claude-pro-max-oauth"],
+      "local_interactive_oauth_modes": ["claude-pro-max-oauth"]
+    }
+  }
+}
+'@ | Set-Content -Path $registryPath -Encoding UTF8
+
+@'
+agent: claude
+model: opus
+agent-slots:
+  - slot-id: worker-1
+    runtime-role: worker
+    agent: claude
+    model: opus
+    prompt-transport: file
+    auth-mode: token-broker
+'@ | Set-Content -Path (Join-Path $script:settingsTempRoot '.winsmux.yaml') -Encoding UTF8
+
+        Mock Get-WinsmuxOption { param($Name, $Default) return $null }
+
+        $settings = Get-BridgeSettings
+        {
+            Get-SlotAgentConfig -Role 'Worker' -SlotId 'worker-1' -Settings $settings -RootPath $script:settingsTempRoot
+        } | Should -Throw '*must not broker OAuth*'
+    }
+
+    It 'rejects top-level blocked provider auth modes before launch resolution' {
+        $registryPath = Get-BridgeProviderCapabilityRegistryPath -RootPath $script:settingsTempRoot
+        $registryDir = Split-Path -Parent $registryPath
+        New-Item -ItemType Directory -Path $registryDir -Force | Out-Null
+
+@'
+{
+  "version": 1,
+  "providers": {
+    "claude": {
+      "adapter": "claude",
+      "command": "claude",
+      "prompt_transports": ["file"],
+      "auth_modes": ["api-key", "claude-pro-max-oauth"],
+      "local_interactive_oauth_modes": ["claude-pro-max-oauth"]
+    }
+  }
+}
+'@ | Set-Content -Path $registryPath -Encoding UTF8
+
+@'
+agent: claude
+model: opus
+prompt-transport: file
+auth-mode: callback-url-receiver
+agent-slots:
+  - slot-id: worker-1
+    runtime-role: worker
+'@ | Set-Content -Path (Join-Path $script:settingsTempRoot '.winsmux.yaml') -Encoding UTF8
+
+        Mock Get-WinsmuxOption { param($Name, $Default) return $null }
+
+        $settings = Get-BridgeSettings
+        {
+            Get-SlotAgentConfig -Role 'Worker' -SlotId 'worker-1' -Settings $settings -RootPath $script:settingsTempRoot
+        } | Should -Throw '*must not broker OAuth*'
     }
 
     It 'rejects providers missing from a non-empty provider capability registry' {
@@ -10295,6 +10382,7 @@ agent_slots:
     agent: claude
     model: opus
     prompt_transport: file
+    auth_mode: claude-pro-max-oauth
   - slot_id: reviewer-1
     runtime_role: reviewer
     agent: claude
@@ -10311,6 +10399,8 @@ agent_slots:
       "display_name": "Codex",
       "command": "codex",
       "prompt_transports": ["argv", "file", "stdin"],
+      "auth_modes": ["api-key", "codex-chatgpt-local"],
+      "local_interactive_oauth_modes": ["codex-chatgpt-local"],
       "supports_file_edit": true,
       "supports_verification": true,
       "supports_structured_result": true,
@@ -10321,6 +10411,8 @@ agent_slots:
       "display_name": "Claude",
       "command": "claude",
       "prompt_transports": ["file"],
+      "auth_modes": ["api-key", "claude-pro-max-oauth"],
+      "local_interactive_oauth_modes": ["claude-pro-max-oauth"],
       "supports_file_edit": true,
       "supports_verification": true,
       "supports_structured_result": false,
@@ -10354,6 +10446,8 @@ agent_slots:
         $payload.slots[0].slot_id | Should -Be 'worker-1'
         $payload.slots[0].capability_adapter | Should -Be 'codex'
         $payload.slots[1].prompt_transport | Should -Be 'file'
+        $payload.slots[1].auth_mode | Should -Be 'claude-pro-max-oauth'
+        $payload.slots[1].auth_policy | Should -Be 'local_interactive_only'
         @($payload.presets.name) | Should -Contain 'all-workers'
         @($payload.presets.name) | Should -Contain 'balanced-build-review'
         @($payload.presets.name) | Should -Contain 'verification'
@@ -10547,6 +10641,8 @@ agent-slots:
       "adapter": "codex",
       "command": "codex",
       "prompt_transports": ["argv", "file", "stdin"],
+      "auth_modes": ["api-key", "codex-chatgpt-local"],
+      "local_interactive_oauth_modes": ["codex-chatgpt-local"],
       "supports_parallel_runs": true,
       "supports_interrupt": true,
       "supports_structured_result": true,
@@ -10559,6 +10655,8 @@ agent-slots:
       "adapter": "claude",
       "command": "claude",
       "prompt_transports": ["file"],
+      "auth_modes": ["api-key", "claude-pro-max-oauth"],
+      "local_interactive_oauth_modes": ["claude-pro-max-oauth"],
       "supports_parallel_runs": false,
       "supports_interrupt": true,
       "supports_structured_result": false,
@@ -10579,12 +10677,12 @@ agent-slots:
     }
 
     It 'documents provider-switch in usage and writes a provider registry entry' {
-        $script:winsmuxCoreRawContent | Should -Match 'provider-switch <slot> \[--agent <name>\] \[--model <name>\] \[--prompt-transport <argv\|file\|stdin>\] \[--reason <text>\] \[--restart\] \[--clear\] \[--json\]'
+        $script:winsmuxCoreRawContent | Should -Match 'provider-switch <slot> \[--agent <name>\] \[--model <name>\] \[--prompt-transport <argv\|file\|stdin>\] \[--auth-mode <mode>\] \[--reason <text>\] \[--restart\] \[--clear\] \[--json\]'
         $script:winsmuxCoreRawContent | Should -Match "'provider-switch'\s*\{"
 
         Push-Location $script:providerSwitchTempRoot
         try {
-            $output = & pwsh -NoProfile -File $script:winsmuxCoreRawPath provider-switch worker-1 --agent claude --model opus --prompt-transport file --reason 'operator requested provider switch' --json
+            $output = & pwsh -NoProfile -File $script:winsmuxCoreRawPath provider-switch worker-1 --agent claude --model opus --prompt-transport file --auth-mode claude-pro-max-oauth --reason 'operator requested provider switch' --json
         } finally {
             Pop-Location
         }
@@ -10594,6 +10692,8 @@ agent-slots:
         $result.agent | Should -Be 'claude'
         $result.model | Should -Be 'opus'
         $result.prompt_transport | Should -Be 'file'
+        $result.auth_mode | Should -Be 'claude-pro-max-oauth'
+        $result.auth_policy | Should -Be 'local_interactive_only'
         $result.source | Should -Be 'registry'
         $result.capability_adapter | Should -Be 'claude'
         $result.capability_command | Should -Be 'claude'
@@ -10610,6 +10710,19 @@ agent-slots:
         $registry.slots.'worker-1'.model | Should -Be 'opus'
         $registry.slots.'worker-1'.prompt_transport | Should -Be 'file'
         $registry.slots.'worker-1'.reason | Should -Be 'operator requested provider switch'
+    }
+
+    It 'rejects provider-switch blocked auth modes before writing the provider registry' {
+        Push-Location $script:providerSwitchTempRoot
+        try {
+            $output = & pwsh -NoProfile -File $script:winsmuxCoreRawPath provider-switch worker-1 --agent claude --model opus --prompt-transport file --auth-mode token-broker --json 2>&1
+        } finally {
+            Pop-Location
+        }
+
+        [string]::Join("`n", @($output)) | Should -Match 'must not broker OAuth'
+        $registryPath = Join-Path $script:providerSwitchTempRoot '.winsmux\provider-registry.json'
+        Test-Path $registryPath | Should -BeFalse
     }
 
     It 'clears provider-switch overrides and reports the configured slot provider' {

--- a/winsmux-core/scripts/settings.ps1
+++ b/winsmux-core/scripts/settings.ps1
@@ -21,6 +21,7 @@ $script:BridgeSettingsSchema = [ordered]@{
     agent               = @{ Type = 'string';   Default = 'codex';       Option = '@bridge-agent' }
     model               = @{ Type = 'string';   Default = 'gpt-5.4';     Option = '@bridge-model' }
     prompt_transport    = @{ Type = 'transport'; Default = 'argv';       Option = '@bridge-prompt-transport' }
+    auth_mode           = @{ Type = 'string';   Default = '';            Option = $null }
     external_operator  = @{ Type = 'bool';     Default = $true;         Option = '@bridge-external-operator' }
     worker_count        = @{ Type = 'int';      Default = 6;             Option = '@bridge-worker-count' }
     agent_slots         = @{ Type = 'slotlist'; Default = @();           Option = $null }
@@ -273,7 +274,7 @@ function ConvertTo-BridgeSlotEntry {
     $slot = [ordered]@{}
     foreach ($pair in $pairs) {
         $key = $pair.Key.ToString() -replace '-', '_'
-        if ($key -notin @('slot_id', 'runtime_role', 'agent', 'model', 'prompt_transport', 'worktree_mode')) {
+        if ($key -notin @('slot_id', 'runtime_role', 'agent', 'model', 'prompt_transport', 'auth_mode', 'worktree_mode')) {
             continue
         }
 
@@ -386,7 +387,7 @@ function ConvertTo-BridgeProviderRegistryEntry {
     $entry = [ordered]@{}
     foreach ($pair in $pairs) {
         $key = $pair.Key.ToString() -replace '-', '_'
-        if ($key -notin @('agent', 'model', 'prompt_transport', 'updated_at_utc', 'reason')) {
+        if ($key -notin @('agent', 'model', 'prompt_transport', 'auth_mode', 'updated_at_utc', 'reason')) {
             continue
         }
 
@@ -396,7 +397,7 @@ function ConvertTo-BridgeProviderRegistryEntry {
 
         $text = ConvertFrom-BridgeYamlScalar $pair.Value
         if ([string]::IsNullOrWhiteSpace($text)) {
-            if ($key -in @('agent', 'model', 'prompt_transport')) {
+            if ($key -in @('agent', 'model', 'prompt_transport', 'auth_mode')) {
                 throw "Invalid provider registry field '$key'."
             }
 
@@ -410,7 +411,7 @@ function ConvertTo-BridgeProviderRegistryEntry {
         $entry[$key] = $text
     }
 
-    if (-not ($entry.Contains('agent') -or $entry.Contains('model') -or $entry.Contains('prompt_transport'))) {
+    if (-not ($entry.Contains('agent') -or $entry.Contains('model') -or $entry.Contains('prompt_transport') -or $entry.Contains('auth_mode'))) {
         return $null
     }
 
@@ -509,6 +510,7 @@ function Write-BridgeProviderRegistryEntry {
         [string]$Agent,
         [string]$Model,
         [string]$PromptTransport,
+        [string]$AuthMode,
         [string]$Reason,
         [string]$RootPath
     )
@@ -531,8 +533,11 @@ function Write-BridgeProviderRegistryEntry {
         }
         $entry.prompt_transport = $normalizedTransport
     }
-    if (-not ($entry.Contains('agent') -or $entry.Contains('model') -or $entry.Contains('prompt_transport'))) {
-        throw 'Provider registry entry requires agent, model, or prompt_transport.'
+    if (-not [string]::IsNullOrWhiteSpace($AuthMode)) {
+        $entry.auth_mode = $AuthMode.Trim()
+    }
+    if (-not ($entry.Contains('agent') -or $entry.Contains('model') -or $entry.Contains('prompt_transport') -or $entry.Contains('auth_mode'))) {
+        throw 'Provider registry entry requires agent, model, prompt_transport, or auth_mode.'
     }
 
     $entry.updated_at_utc = (Get-Date).ToUniversalTime().ToString('o')
@@ -625,6 +630,7 @@ function ConvertTo-BridgeProviderCapabilityEntry {
 
     $stringFields = @('adapter', 'display_name', 'command')
     $transportFields = @('prompt_transports')
+    $stringArrayFields = @('auth_modes', 'local_interactive_oauth_modes')
     $boolFields = @(
         'supports_parallel_runs',
         'supports_interrupt',
@@ -634,7 +640,7 @@ function ConvertTo-BridgeProviderCapabilityEntry {
         'supports_verification',
         'supports_consultation'
     )
-    $allowedFields = @($stringFields + $transportFields + $boolFields)
+    $allowedFields = @($stringFields + $transportFields + $stringArrayFields + $boolFields)
 
     $entry = [ordered]@{}
     foreach ($pair in $pairs) {
@@ -679,6 +685,25 @@ function ConvertTo-BridgeProviderCapabilityEntry {
             }
 
             $entry[$key] = @($transports)
+            continue
+        }
+
+        if ($key -in $stringArrayFields) {
+            if ($pair.Value -isnot [System.Collections.IEnumerable] -or $pair.Value -is [string]) {
+                throw "Invalid provider capability field '$key'."
+            }
+
+            $items = @()
+            foreach ($item in @($pair.Value)) {
+                $text = ConvertFrom-BridgeYamlScalar $item
+                if ([string]::IsNullOrWhiteSpace($text)) {
+                    throw "Invalid provider capability field '$key'."
+                }
+
+                $items += $text.Trim().ToLowerInvariant()
+            }
+
+            $entry[$key] = @($items)
             continue
         }
 
@@ -920,6 +945,78 @@ function Assert-BridgeProviderCapabilityTransport {
     $supportedTransports = @($transports | ForEach-Object { ([string]$_).Trim().ToLowerInvariant() })
     if ($requestedTransport -notin $supportedTransports) {
         throw "Provider capability '$ProviderId' does not support prompt_transport '$requestedTransport'. Supported values: $($supportedTransports -join ', ')."
+    }
+}
+
+function Test-BridgeProviderBlockedAuthMode {
+    param([AllowNull()][string]$AuthMode)
+
+    if ([string]::IsNullOrWhiteSpace($AuthMode)) {
+        return $false
+    }
+
+    $normalized = $AuthMode.Trim().ToLowerInvariant()
+    return ($normalized -in @(
+        'oauth-broker',
+        'token-broker',
+        'callback-url',
+        'callback-url-receiver',
+        'shared-token',
+        'provider-api-proxy'
+    ))
+}
+
+function Get-BridgeProviderAuthPolicy {
+    param(
+        [AllowNull()]$Capability,
+        [AllowNull()][string]$AuthMode
+    )
+
+    if ([string]::IsNullOrWhiteSpace($AuthMode)) {
+        return 'unspecified'
+    }
+
+    $normalized = $AuthMode.Trim().ToLowerInvariant()
+    $localModes = @()
+    if ($null -ne $Capability -and $Capability.Contains('local_interactive_oauth_modes')) {
+        $localModes = @($Capability.local_interactive_oauth_modes | ForEach-Object { ([string]$_).Trim().ToLowerInvariant() })
+    }
+
+    if ($normalized -in $localModes -or $normalized -match '(oauth|chatgpt-local)$') {
+        return 'local_interactive_only'
+    }
+
+    return 'standard'
+}
+
+function Assert-BridgeProviderCapabilityAuthMode {
+    param(
+        [Parameter(Mandatory = $true)][string]$ProviderId,
+        [AllowNull()][string]$AuthMode,
+        [string]$RootPath
+    )
+
+    if ([string]::IsNullOrWhiteSpace($AuthMode)) {
+        return
+    }
+
+    $requestedAuthMode = $AuthMode.Trim().ToLowerInvariant()
+    if (Test-BridgeProviderBlockedAuthMode -AuthMode $requestedAuthMode) {
+        throw "Provider auth_mode '$requestedAuthMode' is not allowed. winsmux must not broker OAuth, receive callback URLs, extract provider tokens, or share provider tokens across panes."
+    }
+
+    $capability = Resolve-BridgeProviderCapability -ProviderId $ProviderId -RootPath $RootPath -RequireWhenRegistryPresent
+    if ($null -eq $capability) {
+        return
+    }
+
+    if (-not $capability.Contains('auth_modes')) {
+        throw "Provider capability '$ProviderId' does not declare auth_modes."
+    }
+
+    $supportedAuthModes = @($capability.auth_modes | ForEach-Object { ([string]$_).Trim().ToLowerInvariant() })
+    if ($requestedAuthMode -notin $supportedAuthModes) {
+        throw "Provider capability '$ProviderId' does not support auth_mode '$requestedAuthMode'. Supported values: $($supportedAuthModes -join ', ')."
     }
 }
 
@@ -1284,7 +1381,7 @@ function Test-BridgeSettingValue {
 
                 foreach ($rolePair in $rolePairs) {
                     $propertyKey = $rolePair.Key.ToString() -replace '-', '_'
-                    if ($propertyKey -notin @('agent', 'model', 'prompt_transport')) {
+                    if ($propertyKey -notin @('agent', 'model', 'prompt_transport', 'auth_mode')) {
                         continue
                     }
 
@@ -1548,12 +1645,21 @@ function Get-RoleAgentConfig {
     $agent = $Settings.agent
     $model = $Settings.model
     $promptTransport = 'argv'
+    $authMode = ''
     if ($Settings -is [System.Collections.IDictionary]) {
         if ($Settings.Contains('prompt_transport') -and -not [string]::IsNullOrWhiteSpace([string]$Settings['prompt_transport'])) {
             $promptTransport = [string]$Settings['prompt_transport']
         }
-    } elseif ($null -ne $Settings.PSObject -and $Settings.PSObject.Properties.Name -contains 'prompt_transport' -and -not [string]::IsNullOrWhiteSpace([string]$Settings.prompt_transport)) {
-        $promptTransport = [string]$Settings.prompt_transport
+        if ($Settings.Contains('auth_mode') -and -not [string]::IsNullOrWhiteSpace([string]$Settings['auth_mode'])) {
+            $authMode = [string]$Settings['auth_mode']
+        }
+    } elseif ($null -ne $Settings.PSObject) {
+        if ($Settings.PSObject.Properties.Name -contains 'prompt_transport' -and -not [string]::IsNullOrWhiteSpace([string]$Settings.prompt_transport)) {
+            $promptTransport = [string]$Settings.prompt_transport
+        }
+        if ($Settings.PSObject.Properties.Name -contains 'auth_mode' -and -not [string]::IsNullOrWhiteSpace([string]$Settings.auth_mode)) {
+            $authMode = [string]$Settings.auth_mode
+        }
     }
 
     if ($resolvedRoleConfig -is [System.Collections.IDictionary]) {
@@ -1568,6 +1674,10 @@ function Get-RoleAgentConfig {
         if ($resolvedRoleConfig.Contains('prompt_transport') -and -not [string]::IsNullOrWhiteSpace([string]$resolvedRoleConfig['prompt_transport'])) {
             $promptTransport = [string]$resolvedRoleConfig['prompt_transport']
         }
+
+        if ($resolvedRoleConfig.Contains('auth_mode') -and -not [string]::IsNullOrWhiteSpace([string]$resolvedRoleConfig['auth_mode'])) {
+            $authMode = [string]$resolvedRoleConfig['auth_mode']
+        }
     } elseif ($null -ne $resolvedRoleConfig -and $null -ne $resolvedRoleConfig.PSObject) {
         if ($resolvedRoleConfig.PSObject.Properties.Name -contains 'agent' -and -not [string]::IsNullOrWhiteSpace([string]$resolvedRoleConfig.agent)) {
             $agent = [string]$resolvedRoleConfig.agent
@@ -1580,12 +1690,17 @@ function Get-RoleAgentConfig {
         if ($resolvedRoleConfig.PSObject.Properties.Name -contains 'prompt_transport' -and -not [string]::IsNullOrWhiteSpace([string]$resolvedRoleConfig.prompt_transport)) {
             $promptTransport = [string]$resolvedRoleConfig.prompt_transport
         }
+
+        if ($resolvedRoleConfig.PSObject.Properties.Name -contains 'auth_mode' -and -not [string]::IsNullOrWhiteSpace([string]$resolvedRoleConfig.auth_mode)) {
+            $authMode = [string]$resolvedRoleConfig.auth_mode
+        }
     }
 
     return [PSCustomObject]@{
         Agent           = [string]$agent
         Model           = [string]$model
         PromptTransport = [string]$promptTransport
+        AuthMode        = [string]$authMode
     }
 }
 
@@ -1605,6 +1720,7 @@ function Get-SlotAgentConfig {
     $agent = [string]$roleAgentConfig.Agent
     $model = [string]$roleAgentConfig.Model
     $promptTransport = [string]$roleAgentConfig.PromptTransport
+    $authMode = [string]$roleAgentConfig.AuthMode
     $source = 'role'
 
     if (-not [string]::IsNullOrWhiteSpace($SlotId)) {
@@ -1626,6 +1742,7 @@ function Get-SlotAgentConfig {
             $slotAgent = ''
             $slotModel = ''
             $slotPromptTransport = ''
+            $slotAuthMode = ''
 
             if ($slot -is [System.Collections.IDictionary]) {
                 if ($slot.Contains('slot_id')) {
@@ -1640,6 +1757,9 @@ function Get-SlotAgentConfig {
                 if ($slot.Contains('prompt_transport')) {
                     $slotPromptTransport = [string]$slot['prompt_transport']
                 }
+                if ($slot.Contains('auth_mode')) {
+                    $slotAuthMode = [string]$slot['auth_mode']
+                }
             } elseif ($null -ne $slot.PSObject) {
                 if ($slot.PSObject.Properties.Name -contains 'slot_id') {
                     $candidateSlotId = [string]$slot.slot_id
@@ -1652,6 +1772,9 @@ function Get-SlotAgentConfig {
                 }
                 if ($slot.PSObject.Properties.Name -contains 'prompt_transport') {
                     $slotPromptTransport = [string]$slot.prompt_transport
+                }
+                if ($slot.PSObject.Properties.Name -contains 'auth_mode') {
+                    $slotAuthMode = [string]$slot.auth_mode
                 }
             }
 
@@ -1674,6 +1797,11 @@ function Get-SlotAgentConfig {
                 $source = 'slot'
             }
 
+            if (-not [string]::IsNullOrWhiteSpace($slotAuthMode)) {
+                $authMode = $slotAuthMode
+                $source = 'slot'
+            }
+
             break
         }
     }
@@ -1692,12 +1820,17 @@ function Get-SlotAgentConfig {
             $promptTransport = [string]$registryEntry.prompt_transport
         }
 
+        if ($registryEntry.Contains('auth_mode')) {
+            $authMode = [string]$registryEntry.auth_mode
+        }
+
         $source = 'registry'
     }
 
     $providerCapability = $null
     if (-not [string]::IsNullOrWhiteSpace($RootPath)) {
         Assert-BridgeProviderCapabilityTransport -ProviderId $agent -PromptTransport $promptTransport -RootPath $RootPath
+        Assert-BridgeProviderCapabilityAuthMode -ProviderId $agent -AuthMode $authMode -RootPath $RootPath
         $providerCapability = Resolve-BridgeProviderCapability -ProviderId $agent -RootPath $RootPath -RequireWhenRegistryPresent
     }
 
@@ -1706,6 +1839,8 @@ function Get-SlotAgentConfig {
         Agent                    = [string]$agent
         Model                    = [string]$model
         PromptTransport          = [string]$promptTransport
+        AuthMode                 = [string]$authMode
+        AuthPolicy               = Get-BridgeProviderAuthPolicy -Capability $providerCapability -AuthMode $authMode
         Source                   = [string]$source
         CapabilityAdapter        = [string](Get-BridgeProviderCapabilityValue -Capability $providerCapability -Name 'adapter' -Default '')
         CapabilityCommand        = [string](Get-BridgeProviderCapabilityValue -Capability $providerCapability -Name 'command' -Default '')


### PR DESCRIPTION
## Summary
- add auth_mode and auth_policy to provider resolution and launcher summaries
- block OAuth broker, callback URL receiver, shared-token, and provider API proxy modes before launch resolution
- add provider-switch --auth-mode validation before provider registry writes
- update authentication support docs and public surface tests

## Validation
- Invoke-Pester .\tests\winsmux-bridge.Tests.ps1 -Output Detailed
- Invoke-Pester .\tests\PublicSurfacePolicy.Tests.ps1 -Output Detailed
- pwsh -NoProfile -File .\scripts\audit-public-surface.ps1
- pwsh -NoProfile -File .\scripts\git-guard.ps1 -Mode full
- pwsh -NoProfile -File .\scripts\gitleaks-history.ps1
- Opus review for Japanese public doc changes: PASS, no findings

## Review
- Subagent review found two issues.
- Fixed top-level auth_mode validation.
- Fixed provider-switch so invalid auth_mode is rejected before registry writes.

Refs #584