### PR TITLE
Add named pipe desktop control RPC

### DIFF
--- a/.githooks/pre-commit-whitelist.ps1
+++ b/.githooks/pre-commit-whitelist.ps1
@@ -51,6 +51,7 @@ $whitelistPatterns = @(
     'winsmux-app/src-tauri/Cargo.toml',
     'winsmux-app/src-tauri/Cargo.lock',
     'winsmux-app/src-tauri/tauri.conf.json',
+    'winsmux-app/src-tauri/src/control_pipe.rs',
     'winsmux-core/**',
     '.claude/CLAUDE.md',
     '.claude/hooks/**',

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -8383,12 +8383,103 @@ promote-tactic <run_id> [--title <text>] [--kind <playbook|prewarm|verification>
   mailbox-create <ch>       Create Named Pipe mailbox listener
   mailbox-send <ch> <json>  Send JSON message to mailbox channel
   mailbox-listen <ch>       Alias for mailbox-create
+  control-rpc <json>        Send JSON-RPC to \\.\pipe\winsmux-control
   kill <target>             Stop pane process and respawn its shell
   restart <target>          Restart the pane agent using manifest context
   rebind-worktree <target> <path>  Update a Builder/Worker pane to use a new worktree path
   doctor                    Check environment and IME diagnostics
   version                   Show version
 "@
+}
+
+# --- Control RPC ---
+function Get-ControlRpcPipeName {
+    return 'winsmux-control'
+}
+
+function Get-ControlRpcPipeDisplayName {
+    return '\\.\pipe\winsmux-control'
+}
+
+function ConvertTo-ControlRpcPayload {
+    param([Parameter(Mandatory = $true)][AllowEmptyString()][string]$JsonText)
+
+    if ([string]::IsNullOrWhiteSpace($JsonText)) {
+        Stop-WithError "usage: winsmux control-rpc <json>"
+    }
+
+    try {
+        $payload = $JsonText | ConvertFrom-Json -Depth 100
+    } catch {
+        Stop-WithError "control-rpc payload must be valid JSON: $($_.Exception.Message)"
+    }
+
+    $propertyNames = @($payload.PSObject.Properties.Name)
+    if ($propertyNames -notcontains 'jsonrpc' -or [string]$payload.jsonrpc -ne '2.0') {
+        Stop-WithError "control-rpc payload must be a JSON-RPC 2.0 request"
+    }
+
+    if ($propertyNames -notcontains 'method' -or [string]::IsNullOrWhiteSpace([string]$payload.method)) {
+        Stop-WithError "control-rpc payload must include a non-empty method"
+    }
+
+    return ($payload | ConvertTo-Json -Depth 100 -Compress)
+}
+
+function Invoke-ControlRpcPipeExchange {
+    param(
+        [Parameter(Mandatory = $true)][string]$Payload,
+        [int]$TimeoutMs = 5000
+    )
+
+    $pipeName = Get-ControlRpcPipeName
+    $client = $null
+    try {
+        $client = [System.IO.Pipes.NamedPipeClientStream]::new(
+            '.',
+            $pipeName,
+            [System.IO.Pipes.PipeDirection]::InOut
+        )
+        $client.Connect($TimeoutMs)
+
+        $requestBytes = [System.Text.Encoding]::UTF8.GetBytes($Payload)
+        $client.Write($requestBytes, 0, $requestBytes.Length)
+        $client.Flush()
+
+        $buffer = [byte[]]::new(4096)
+        $memory = [System.IO.MemoryStream]::new()
+        try {
+            while ($true) {
+                $readTask = $client.ReadAsync($buffer, 0, $buffer.Length)
+                if (-not $readTask.Wait($TimeoutMs)) {
+                    Stop-WithError "control-rpc timed out waiting for response from $(Get-ControlRpcPipeDisplayName)"
+                }
+                $count = $readTask.GetAwaiter().GetResult()
+                if ($count -le 0) { break }
+                $memory.Write($buffer, 0, $count)
+            }
+            return [System.Text.Encoding]::UTF8.GetString($memory.ToArray())
+        } finally {
+            $memory.Dispose()
+        }
+    } catch {
+        Stop-WithError "control-rpc failed to reach $(Get-ControlRpcPipeDisplayName): $($_.Exception.Message)"
+    } finally {
+        if ($null -ne $client) {
+            $client.Dispose()
+        }
+    }
+}
+
+function Invoke-ControlRpc {
+    param(
+        [AllowEmptyString()][string]$ControlTarget = $Target,
+        [string[]]$ControlRest = $Rest
+    )
+
+    $jsonText = (@($ControlTarget) + @($ControlRest) | Where-Object { $null -ne $_ }) -join ' '
+    $payload = ConvertTo-ControlRpcPayload -JsonText $jsonText
+    Invoke-ControlRpcPipeExchange -Payload $payload | Write-Output
 }
 
 # --- Named Pipe Mailbox ---
@@ -8860,6 +8951,7 @@ switch ($Command) {
     'mailbox-create'  { Invoke-MailboxCreate }
     'mailbox-send'    { Invoke-MailboxSend }
     'mailbox-listen'  { Invoke-MailboxListen }
+    'control-rpc'     { Invoke-ControlRpc }
     'watch'           { Invoke-Watch }
     'profile'         { Invoke-Profile }
     'doctor'          { Invoke-Doctor }

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -12813,6 +12813,58 @@ panes:
     }
 }
 
+Describe 'winsmux control-rpc command' {
+    BeforeAll {
+        $script:controlRpcBridgePath = Join-Path (Split-Path -Parent $PSScriptRoot) 'scripts\winsmux-core.ps1'
+        $script:controlRpcBridgeContent = Get-Content -Raw -Path $script:controlRpcBridgePath -Encoding UTF8
+        $null = . $script:controlRpcBridgePath version
+    }
+
+    It 'documents control-rpc in usage and fixes the named pipe endpoint' {
+        $script:controlRpcBridgeContent | Should -Match 'control-rpc <json>'
+        $script:controlRpcBridgeContent | Should -Match "'control-rpc'\s*\{\s*Invoke-ControlRpc\s*\}"
+        $script:controlRpcBridgeContent | Should -Match '\$client\.ReadAsync\(\$buffer, 0, \$buffer\.Length\)'
+        $script:controlRpcBridgeContent | Should -Match 'timed out waiting for response'
+        Get-ControlRpcPipeName | Should -Be 'winsmux-control'
+        Get-ControlRpcPipeDisplayName | Should -Be '\\.\pipe\winsmux-control'
+    }
+
+    It 'normalizes JSON-RPC requests before sending them to the control pipe' {
+        Mock Invoke-ControlRpcPipeExchange {
+            param([string]$Payload)
+            $script:controlRpcPayload = $Payload
+            return '{"jsonrpc":"2.0","id":1,"result":{"ok":true}}'
+        }
+
+        $script:controlRpcPayload = ''
+        $output = Invoke-ControlRpc `
+            -ControlTarget '{"jsonrpc":"2.0","id":1,' `
+            -ControlRest @('"method":"desktop.control_plane.contract"}')
+
+        Should -Invoke Invoke-ControlRpcPipeExchange -Times 1 -Exactly
+        $script:controlRpcPayload | Should -Be '{"jsonrpc":"2.0","id":1,"method":"desktop.control_plane.contract"}'
+        $output | Should -Be '{"jsonrpc":"2.0","id":1,"result":{"ok":true}}'
+    }
+
+    It 'rejects missing JSON-RPC payloads' {
+        { ConvertTo-ControlRpcPayload -JsonText '' } | Should -Throw 'usage: winsmux control-rpc <json>'
+    }
+
+    It 'rejects invalid JSON payloads' {
+        { ConvertTo-ControlRpcPayload -JsonText '{' } | Should -Throw 'control-rpc payload must be valid JSON:*'
+    }
+
+    It 'rejects non JSON-RPC 2.0 payloads' {
+        { ConvertTo-ControlRpcPayload -JsonText '{"jsonrpc":"1.0","method":"desktop.summary.snapshot"}' } |
+            Should -Throw 'control-rpc payload must be a JSON-RPC 2.0 request'
+    }
+
+    It 'rejects JSON-RPC requests without a method' {
+        { ConvertTo-ControlRpcPayload -JsonText '{"jsonrpc":"2.0","id":1}' } |
+            Should -Throw 'control-rpc payload must include a non-empty method'
+    }
+}
+
 Describe 'winsmux send fallback' {
     BeforeAll {
         $bridgePath = Join-Path (Split-Path -Parent $PSScriptRoot) 'scripts\winsmux-core.ps1'

--- a/winsmux-app/src-tauri/Cargo.lock
+++ b/winsmux-app/src-tauri/Cargo.lock
@@ -5197,6 +5197,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-opener",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/winsmux-app/src-tauri/Cargo.toml
+++ b/winsmux-app/src-tauri/Cargo.toml
@@ -24,4 +24,5 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 portable-pty = "0.9.0"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
+windows-sys = { version = "0.61.2", features = ["Win32_Foundation", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_IO", "Win32_System_Pipes"] }
 

--- a/winsmux-app/src-tauri/src/control_pipe.rs
+++ b/winsmux-app/src-tauri/src/control_pipe.rs
@@ -1,0 +1,327 @@
+use crate::desktop_backend::{
+    handle_desktop_json_rpc, DesktopCommandTransport, DesktopJsonRpcRequest, PwshScriptTransport,
+};
+use serde_json::{json, Value};
+
+pub const WINSMUX_CONTROL_PIPE_NAME: &str = r"\\.\pipe\winsmux-control";
+
+const JSON_RPC_PARSE_ERROR: i32 = -32700;
+const JSON_RPC_METHOD_NOT_FOUND: i32 = -32601;
+const JSON_RPC_INVALID_PARAMS: i32 = -32602;
+const JSON_RPC_INTERNAL_ERROR: i32 = -32603;
+
+const CONTROL_PIPE_METHODS: &[&str] = &[
+    "desktop.control_plane.contract",
+    "desktop.summary.snapshot",
+    "desktop.run.explain",
+    "desktop.run.compare",
+    "desktop.run.promote",
+    "desktop.run.pick_winner",
+];
+
+pub fn handle_control_pipe_payload(
+    transport: &dyn DesktopCommandTransport,
+    payload: &[u8],
+    project_dir: Option<String>,
+) -> Vec<u8> {
+    let request_value = match serde_json::from_slice::<Value>(payload) {
+        Ok(value) => value,
+        Err(err) => {
+            return serialize_control_pipe_error(
+                Value::Null,
+                JSON_RPC_PARSE_ERROR,
+                format!("Invalid JSON-RPC request: {err}"),
+            );
+        }
+    };
+    let request_id = request_value.get("id").cloned().unwrap_or(Value::Null);
+    let method = match request_value.get("method").and_then(Value::as_str) {
+        Some(value) => value,
+        None => {
+            return serialize_control_pipe_error(
+                request_id,
+                JSON_RPC_INVALID_PARAMS,
+                "JSON-RPC request method must be a string".to_string(),
+            );
+        }
+    };
+    if !CONTROL_PIPE_METHODS.contains(&method) {
+        return serialize_control_pipe_error(
+            request_id,
+            JSON_RPC_METHOD_NOT_FOUND,
+            format!("Control pipe method is not exposed: {method}"),
+        );
+    }
+    if has_project_dir_override(&request_value) {
+        return serialize_control_pipe_error(
+            request_id,
+            JSON_RPC_INVALID_PARAMS,
+            "Control pipe requests must not override projectDir".to_string(),
+        );
+    }
+
+    let request = match serde_json::from_value::<DesktopJsonRpcRequest>(request_value) {
+        Ok(value) => value,
+        Err(err) => {
+            return serialize_control_pipe_error(
+                Value::Null,
+                JSON_RPC_PARSE_ERROR,
+                format!("Invalid JSON-RPC request: {err}"),
+            );
+        }
+    };
+
+    match serde_json::to_vec(&handle_desktop_json_rpc(transport, request, project_dir)) {
+        Ok(value) => value,
+        Err(err) => serialize_control_pipe_error(
+            Value::Null,
+            JSON_RPC_INTERNAL_ERROR,
+            format!("Failed to serialize JSON-RPC response: {err}"),
+        ),
+    }
+}
+
+fn has_project_dir_override(request_value: &Value) -> bool {
+    request_value
+        .get("params")
+        .and_then(Value::as_object)
+        .is_some_and(|params| {
+            params.contains_key("projectDir") || params.contains_key("project_dir")
+        })
+}
+
+fn serialize_control_pipe_error(id: Value, code: i32, message: String) -> Vec<u8> {
+    serde_json::to_vec(&json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "error": {
+            "code": code,
+            "message": message,
+        },
+    }))
+    .unwrap_or_else(|_| {
+        br#"{"jsonrpc":"2.0","id":null,"error":{"code":-32603,"message":"Failed to serialize JSON-RPC error"}}"#.to_vec()
+    })
+}
+
+#[cfg(windows)]
+pub fn start_control_pipe_server() {
+    std::thread::spawn(move || loop {
+        if let Err(err) = serve_one_control_pipe_client() {
+            eprintln!("winsmux control pipe error: {err}");
+        }
+    });
+}
+
+#[cfg(not(windows))]
+pub fn start_control_pipe_server() {}
+
+#[cfg(windows)]
+fn serve_one_control_pipe_client() -> Result<(), String> {
+    use std::ffi::OsStr;
+    use std::os::windows::ffi::OsStrExt;
+    use std::ptr::null_mut;
+    use windows_sys::Win32::Foundation::{
+        CloseHandle, GetLastError, ERROR_PIPE_CONNECTED, HANDLE, INVALID_HANDLE_VALUE,
+    };
+    use windows_sys::Win32::Storage::FileSystem::{
+        FlushFileBuffers, ReadFile, WriteFile, FILE_FLAG_FIRST_PIPE_INSTANCE, PIPE_ACCESS_DUPLEX,
+    };
+    use windows_sys::Win32::System::Pipes::{
+        ConnectNamedPipe, CreateNamedPipeW, DisconnectNamedPipe, PIPE_READMODE_MESSAGE,
+        PIPE_REJECT_REMOTE_CLIENTS, PIPE_TYPE_MESSAGE, PIPE_UNLIMITED_INSTANCES, PIPE_WAIT,
+    };
+
+    struct PipeHandle(HANDLE);
+
+    impl Drop for PipeHandle {
+        fn drop(&mut self) {
+            unsafe {
+                CloseHandle(self.0);
+            }
+        }
+    }
+
+    let pipe_name: Vec<u16> = OsStr::new(WINSMUX_CONTROL_PIPE_NAME)
+        .encode_wide()
+        .chain(Some(0))
+        .collect();
+
+    let handle = unsafe {
+        CreateNamedPipeW(
+            pipe_name.as_ptr(),
+            PIPE_ACCESS_DUPLEX | FILE_FLAG_FIRST_PIPE_INSTANCE,
+            PIPE_TYPE_MESSAGE | PIPE_READMODE_MESSAGE | PIPE_WAIT | PIPE_REJECT_REMOTE_CLIENTS,
+            PIPE_UNLIMITED_INSTANCES,
+            1024 * 1024,
+            1024 * 1024,
+            0,
+            null_mut(),
+        )
+    };
+
+    if handle == INVALID_HANDLE_VALUE {
+        return Err(format!("CreateNamedPipeW failed with {}", unsafe {
+            GetLastError()
+        }));
+    }
+    let pipe = PipeHandle(handle);
+
+    let connected = unsafe { ConnectNamedPipe(pipe.0, null_mut()) };
+    if connected == 0 {
+        let error = unsafe { GetLastError() };
+        if error != ERROR_PIPE_CONNECTED {
+            return Err(format!("ConnectNamedPipe failed with {error}"));
+        }
+    }
+
+    let mut buffer = vec![0u8; 1024 * 1024];
+    let mut bytes_read = 0u32;
+    let read_ok = unsafe {
+        ReadFile(
+            pipe.0,
+            buffer.as_mut_ptr().cast(),
+            buffer.len() as u32,
+            &mut bytes_read,
+            null_mut(),
+        )
+    };
+    if read_ok == 0 {
+        return Err(format!("ReadFile failed with {}", unsafe {
+            GetLastError()
+        }));
+    }
+    buffer.truncate(bytes_read as usize);
+
+    let response = handle_control_pipe_payload(&PwshScriptTransport, &buffer, None);
+    let mut bytes_written = 0u32;
+    let write_ok = unsafe {
+        WriteFile(
+            pipe.0,
+            response.as_ptr().cast(),
+            response.len() as u32,
+            &mut bytes_written,
+            null_mut(),
+        )
+    };
+    if write_ok == 0 {
+        return Err(format!("WriteFile failed with {}", unsafe {
+            GetLastError()
+        }));
+    }
+    if bytes_written as usize != response.len() {
+        return Err(format!(
+            "WriteFile wrote {} of {} bytes",
+            bytes_written,
+            response.len()
+        ));
+    }
+
+    unsafe {
+        FlushFileBuffers(pipe.0);
+        DisconnectNamedPipe(pipe.0);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::desktop_backend::{DesktopCommand, DesktopCommandTransport};
+    use serde_json::json;
+
+    struct StubTransport;
+
+    impl DesktopCommandTransport for StubTransport {
+        fn request_json(&self, command: &DesktopCommand) -> Result<Value, String> {
+            match command {
+                DesktopCommand::SummarySnapshot { .. } => Ok(json!({
+                    "version": 1,
+                    "generated_at": "2026-04-23T00:00:00Z",
+                    "project": {
+                        "root": "C:/repo",
+                        "branch": "main",
+                        "head_sha": "abc123",
+                        "base_sha": "def456",
+                        "dirty": false,
+                        "untracked_count": 0
+                    },
+                    "summary": {
+                        "total_panes": 0,
+                        "running": 0,
+                        "waiting": 0,
+                        "needs_attention": 0,
+                        "ready_for_review": 0,
+                        "by_state": {},
+                        "by_review": {},
+                        "by_task_state": {}
+                    },
+                    "board": [],
+                    "inbox": {
+                        "summary": {
+                            "total": 0,
+                            "unread": 0,
+                            "high_priority": 0,
+                            "by_kind": {}
+                        },
+                        "items": []
+                    },
+                    "runs": []
+                })),
+                _ => Err("unexpected command".to_string()),
+            }
+        }
+    }
+
+    #[test]
+    fn control_pipe_routes_json_rpc_to_desktop_handler() {
+        let payload = br#"{"jsonrpc":"2.0","id":1,"method":"desktop.control_plane.contract"}"#;
+        let response = handle_control_pipe_payload(&StubTransport, payload, None);
+        let value: Value = serde_json::from_slice(&response).expect("response should be JSON");
+
+        assert_eq!(value["jsonrpc"], "2.0");
+        assert_eq!(value["id"], 1);
+        assert_eq!(value["result"]["version"], 1);
+        assert_eq!(value["result"]["pipe"], WINSMUX_CONTROL_PIPE_NAME);
+        assert_eq!(value["result"]["localhost_http"], false);
+        assert_eq!(value["result"]["websocket"], false);
+    }
+
+    #[test]
+    fn control_pipe_rejects_invalid_json() {
+        let response = handle_control_pipe_payload(&StubTransport, b"{", None);
+        let value: Value = serde_json::from_slice(&response).expect("response should be JSON");
+
+        assert_eq!(value["jsonrpc"], "2.0");
+        assert_eq!(value["id"], Value::Null);
+        assert_eq!(value["error"]["code"], JSON_RPC_PARSE_ERROR);
+    }
+
+    #[test]
+    fn control_pipe_name_is_named_pipe_not_localhost_transport() {
+        assert_eq!(WINSMUX_CONTROL_PIPE_NAME, r"\\.\pipe\winsmux-control");
+        assert!(!WINSMUX_CONTROL_PIPE_NAME.contains("localhost"));
+        assert!(!WINSMUX_CONTROL_PIPE_NAME.contains("ws://"));
+        assert!(!WINSMUX_CONTROL_PIPE_NAME.contains("http://"));
+    }
+
+    #[test]
+    fn control_pipe_rejects_project_dir_override() {
+        let payload = br#"{"jsonrpc":"2.0","id":1,"method":"desktop.summary.snapshot","params":{"projectDir":"C:/other"}}"#;
+        let response = handle_control_pipe_payload(&StubTransport, payload, None);
+        let value: Value = serde_json::from_slice(&response).expect("response should be JSON");
+
+        assert_eq!(value["id"], 1);
+        assert_eq!(value["error"]["code"], JSON_RPC_INVALID_PARAMS);
+    }
+
+    #[test]
+    fn control_pipe_blocks_editor_read() {
+        let payload = br#"{"jsonrpc":"2.0","id":1,"method":"desktop.editor.read","params":{"path":"README.md"}}"#;
+        let response = handle_control_pipe_payload(&StubTransport, payload, None);
+        let value: Value = serde_json::from_slice(&response).expect("response should be JSON");
+
+        assert_eq!(value["id"], 1);
+        assert_eq!(value["error"]["code"], JSON_RPC_METHOD_NOT_FOUND);
+    }
+}

--- a/winsmux-app/src-tauri/src/desktop_backend.rs
+++ b/winsmux-app/src-tauri/src/desktop_backend.rs
@@ -775,6 +775,25 @@ pub fn handle_desktop_json_rpc(
                 Err(err) => json_rpc_error(request_id, JSON_RPC_SERVER_ERROR, err),
             }
         }
+        "desktop.control_plane.contract" => json_rpc_result(
+            request_id,
+            serde_json::json!({
+                "version": 1,
+                "transport": "named_pipe_json_rpc",
+                "pipe": r"\\.\pipe\winsmux-control",
+                "jsonrpc": DESKTOP_JSON_RPC_VERSION,
+                "localhost_http": false,
+                "websocket": false,
+                "methods": [
+                    "desktop.control_plane.contract",
+                    "desktop.summary.snapshot",
+                    "desktop.run.explain",
+                    "desktop.run.compare",
+                    "desktop.run.promote",
+                    "desktop.run.pick_winner",
+                ],
+            }),
+        ),
         "desktop.run.explain" => {
             let run_id = match get_required_string_param(params.as_ref(), &["runId", "run_id"]) {
                 Ok(value) => value,

--- a/winsmux-app/src-tauri/src/lib.rs
+++ b/winsmux-app/src-tauri/src/lib.rs
@@ -1,6 +1,8 @@
+mod control_pipe;
 mod desktop_backend;
 mod pty_backend;
 
+use control_pipe::start_control_pipe_server;
 use desktop_backend::{
     handle_desktop_json_rpc, load_desktop_run_explain, load_desktop_summary_snapshot,
     spawn_desktop_summary_refresh_stream, DesktopExplainPayload, DesktopJsonRpcRequest,
@@ -293,6 +295,7 @@ pub fn run() {
             stop_requested: Arc::new(AtomicBool::new(false)),
         })
         .setup(|app| {
+            start_control_pipe_server();
             start_desktop_summary_refresh_streams(&app.handle().clone());
             Ok(())
         })


### PR DESCRIPTION
## Summary
- add a local Windows named-pipe JSON-RPC control path for the Tauri desktop
- expose the desktop control-plane contract and allowlisted desktop methods
- add PowerShell control-rpc client coverage and Rust route/security tests

## Validation
- Invoke-Pester .\tests\winsmux-bridge.Tests.ps1 -Output Detailed
- cargo test --manifest-path .\winsmux-app\src-tauri\Cargo.toml -- --nocapture
- cmd /c npm run build (winsmux-app)
- pwsh -NoProfile -File .\scripts\git-guard.ps1 -Mode full
- pwsh -NoProfile -File .\scripts\audit-public-surface.ps1

## Review
- codex exec review: APPROVE after fixing named-pipe security, method allowlist, projectDir rejection, partial-write checking, and bounded client reads