### PR TITLE
TASK-277: Freeze review-state Rust contract

### DIFF
--- a/core/tests-rs/test_parity.rs
+++ b/core/tests-rs/test_parity.rs
@@ -260,6 +260,51 @@ struct RustParityExplainEvidenceDigest {
     consultation_ref: String,
 }
 
+#[derive(Deserialize)]
+struct RustParityReviewStateRecord {
+    status: String,
+    branch: String,
+    head_sha: String,
+    request: RustParityReviewStateRequest,
+    reviewer: RustParityReviewStateReviewer,
+    #[serde(rename = "updatedAt")]
+    updated_at: String,
+}
+
+#[derive(Deserialize)]
+struct RustParityReviewStateRequest {
+    id: String,
+    branch: String,
+    head_sha: String,
+    target_review_pane_id: String,
+    target_review_label: String,
+    target_review_role: String,
+    target_reviewer_pane_id: String,
+    target_reviewer_label: String,
+    target_reviewer_role: String,
+    review_contract: RustParityReviewContract,
+    dispatched_at: String,
+}
+
+#[derive(Deserialize)]
+struct RustParityReviewStateReviewer {
+    pane_id: String,
+    label: String,
+    role: String,
+    agent_name: String,
+}
+
+#[derive(Deserialize)]
+struct RustParityReviewContract {
+    version: u32,
+    source_task: String,
+    issue_ref: String,
+    style: String,
+    required_scope: Vec<String>,
+    checklist_labels: Vec<String>,
+    rationale: String,
+}
+
 #[test]
 fn rust_parity_board_fixture_deserializes() {
     let fixture: RustParityBoardFixture = read_rust_parity_fixture_typed("board.json");
@@ -436,12 +481,10 @@ fn rust_parity_explain_fixture_deserializes() {
     assert_eq!(fixture.run.experiment_packet.command_hash, "");
     assert_eq!(fixture.explanation.summary, "Implement run ledger");
     assert_eq!(fixture.explanation.next_action, "review_pending");
-    assert!(
-        fixture
-            .explanation
-            .reasons
-            .contains(&"review_state=PENDING".to_string())
-    );
+    assert!(fixture
+        .explanation
+        .reasons
+        .contains(&"review_state=PENDING".to_string()));
     assert_eq!(fixture.explanation.current_state.state, "idle");
     assert_eq!(fixture.explanation.current_state.task_state, "in_progress");
     assert_eq!(fixture.explanation.current_state.review_state, "PENDING");
@@ -520,6 +563,59 @@ fn rust_parity_explain_fixture_deserializes() {
     assert_eq!(fixture.evidence_digest.next_action, "review_pending");
     assert_eq!(fixture.evidence_digest.changed_file_count, 1);
     assert!(fixture.evidence_digest.consultation_ref.contains("__ID__"));
+}
+
+#[test]
+fn rust_parity_review_state_fixture_deserializes() {
+    let fixture: HashMap<String, RustParityReviewStateRecord> =
+        read_rust_parity_fixture_typed("review-state.json");
+    let record = fixture
+        .get("worktree-builder-1")
+        .expect("review-state fixture should contain worktree-builder-1");
+
+    assert_eq!(record.status, "PENDING");
+    assert_eq!(record.branch, "worktree-builder-1");
+    assert_eq!(record.head_sha, "abc1234def5678");
+    assert_eq!(record.updated_at, "__TIMESTAMP__");
+    assert_eq!(record.request.id, "review-request-__ID__");
+    assert_eq!(record.request.branch, "worktree-builder-1");
+    assert_eq!(record.request.head_sha, "abc1234def5678");
+    assert_eq!(record.request.target_review_pane_id, "%4");
+    assert_eq!(record.request.target_review_label, "reviewer-1");
+    assert_eq!(record.request.target_review_role, "Reviewer");
+    assert_eq!(record.request.target_reviewer_pane_id, "%4");
+    assert_eq!(record.request.target_reviewer_label, "reviewer-1");
+    assert_eq!(record.request.target_reviewer_role, "Reviewer");
+    assert_eq!(record.request.dispatched_at, "__TIMESTAMP__");
+    assert_eq!(record.request.review_contract.version, 1);
+    assert_eq!(record.request.review_contract.source_task, "TASK-210");
+    assert_eq!(record.request.review_contract.issue_ref, "#315");
+    assert_eq!(record.request.review_contract.style, "utility_first");
+    assert_eq!(
+        record.request.review_contract.required_scope,
+        vec![
+            "design_impact".to_string(),
+            "replacement_coverage".to_string(),
+            "orphaned_artifacts".to_string()
+        ]
+    );
+    assert_eq!(
+        record.request.review_contract.checklist_labels,
+        vec![
+            "design impact".to_string(),
+            "replacement coverage".to_string(),
+            "orphaned artifacts".to_string()
+        ]
+    );
+    assert!(record
+        .request
+        .review_contract
+        .rationale
+        .contains("runtime contract"));
+    assert_eq!(record.reviewer.pane_id, "%4");
+    assert_eq!(record.reviewer.label, "reviewer-1");
+    assert_eq!(record.reviewer.role, "Reviewer");
+    assert_eq!(record.reviewer.agent_name, "codex");
 }
 
 // ════════════════════════════════════════════════════════════════════════════

--- a/docs/project/rust-schema-freeze-inventory.md
+++ b/docs/project/rust-schema-freeze-inventory.md
@@ -7,8 +7,9 @@ This document identifies which runtime data shapes are already close to a typed 
 
 - `summary` is the most freeze-ready surface.
 - `run/explain` is the next most freeze-ready surface.
-- `manifest`, `state`, `event`, and `verdict` still rely on loose PowerShell object shapes.
-- The smallest safe next implementation slice is a typed freeze for `.winsmux/review-state.json`.
+- `.winsmux/review-state.json` now has the first fixture-backed typed Rust snapshot contract.
+- `manifest`, `event`, and `verdict` still rely on loose PowerShell object shapes.
+- The next safe implementation step is to reassess whether `manifest` or `event` is smaller to freeze next.
 
 ## Freeze-ready surfaces
 
@@ -87,9 +88,55 @@ Why this is close to freeze:
 - 最上位 `observation_pack` と `consultation_packet` の `packet_type` も削除済み。`packet_type` は artifact 本体と `recent_events` の生イベント側だけに残る。
 - Rust parity fixture と PowerShell 契約テストは、今の explain shape に揃っている。
 
+## Fixture-backed frozen surfaces
+
+### 3. `state`
+
+Source file:
+
+- `.winsmux/review-state.json`
+
+Main PowerShell readers/writers:
+
+- `scripts/winsmux-core.ps1`
+  - `Get-ReviewStatePath`
+  - `Get-ReviewStatePropertyValue`
+  - `Get-ReviewState`
+  - `Save-ReviewState`
+  - `ConvertTo-ReviewStateValue`
+
+Typed Rust surface:
+
+- `winsmux-app/src-tauri/src/desktop_backend.rs`
+  - `DesktopReviewStateSnapshot`
+  - `DesktopReviewStateRecord`
+  - `DesktopReviewStateRequest`
+  - `DesktopReviewStateReviewer`
+  - `DesktopReviewStateEvidence`
+  - `DesktopReviewContract`
+
+Parity fixtures:
+
+- `tests/fixtures/rust-parity/review-state.json`
+- `tests/test_support/rust_parity.rs`
+- `core/tests-rs/test_parity.rs`
+
+Frozen shape:
+
+- The root object is keyed by branch name.
+- Each branch record requires `status`, `branch`, `head_sha`, `request`, `reviewer`, and `updatedAt`.
+- Each `request.review_contract` requires `required_scope`, `checklist_labels`, and the other review contract fields.
+- The branch key must match the record `branch`.
+- The request `branch` and `head_sha` must match the saved record.
+- `required_scope` must be present and non-empty in the request contract and evidence snapshot.
+- `target_review_*` is the primary request identity. Legacy `target_reviewer_*` remains readable as a fallback.
+- `PASS` requires `evidence.approved_at` and `evidence.approved_via`.
+- `FAIL` / `FAILED` requires `evidence.failed_at` and `evidence.failed_via`.
+- This is a fixture-backed DTO contract. Runtime file ingestion remains PowerShell-owned until the Rust ledger work starts.
+
 ## Still-loose surfaces
 
-### 3. `manifest`
+### 4. `manifest`
 
 Source file:
 
@@ -113,32 +160,6 @@ Current gap:
 - A second PowerShell-side planning metadata slice now exists for run/explain consumers:
   - if any of `parent_run_id`, `goal`, `task_type`, or `priority` is present, all four fields are required
 - The remaining work is to inventory and freeze the wider pane/session/task fields without widening this slice back into a full manifest rewrite.
-
-### 4. `state`
-
-Source file:
-
-- `.winsmux/review-state.json`
-
-Main PowerShell readers/writers:
-
-- `scripts/winsmux-core.ps1`
-  - `Get-ReviewStatePath`
-  - `Get-ReviewStatePropertyValue`
-  - `Get-ReviewState`
-  - `Save-ReviewState`
-  - `ConvertTo-ReviewStateValue`
-
-Current gap:
-
-- The root object is branch-keyed JSON with nested `request`, `status`, `evidence`, and `result` data.
-- The field contract is currently implied by helpers and downstream consumers rather than frozen in one typed schema.
-
-Why this is the best next slice:
-
-- It is smaller than `manifest`.
-- It is less polymorphic than `events.jsonl`.
-- It already feeds `Get-ExplainPayload`, review approval, and review failure flows.
 
 ### 5. `event`
 
@@ -171,9 +192,9 @@ Current gap:
 
 ## Recommended order after this inventory
 
-1. Freeze `.winsmux/review-state.json` as the first typed schema slice for `TASK-277`.
-2. Add parity fixtures and fail-close tests for the frozen review-state shape.
-3. Reassess whether `manifest` or `event` is the next smaller contract after review-state.
+1. Reassess whether `manifest` or `event` is the next smaller contract after review-state.
+2. Keep the review-state fixture as the branch-keyed root file shape.
+3. Avoid expanding `TASK-277` into a full manifest rewrite unless the next contract slice is explicitly scoped.
 4. Keep `TASK-289` as the next serial desktop lane after `TASK-277` planning clarity, not in parallel with contract changes on the same surface.
 
 ## Parallel work that stays safe

--- a/tests/fixtures/rust-parity/review-state.json
+++ b/tests/fixtures/rust-parity/review-state.json
@@ -1,41 +1,43 @@
 {
-  "status": "PENDING",
-  "branch": "worktree-builder-1",
-  "head_sha": "abc1234def5678",
-  "request": {
-    "id": "review-request-__ID__",
+  "worktree-builder-1": {
+    "status": "PENDING",
     "branch": "worktree-builder-1",
     "head_sha": "abc1234def5678",
-    "target_review_pane_id": "%4",
-    "target_review_label": "reviewer-1",
-    "target_review_role": "Reviewer",
-    "target_reviewer_pane_id": "%4",
-    "target_reviewer_label": "reviewer-1",
-    "target_reviewer_role": "Reviewer",
-    "review_contract": {
-      "version": 1,
-      "source_task": "TASK-210",
-      "issue_ref": "#315",
-      "style": "utility_first",
-      "required_scope": [
-        "design_impact",
-        "replacement_coverage",
-        "orphaned_artifacts"
-      ],
-      "checklist_labels": [
-        "design impact",
-        "replacement coverage",
-        "orphaned artifacts"
-      ],
-      "rationale": "Review requests must audit downstream design impact, replacement coverage, and orphaned artifacts as part of the runtime contract."
+    "request": {
+      "id": "review-request-__ID__",
+      "branch": "worktree-builder-1",
+      "head_sha": "abc1234def5678",
+      "target_review_pane_id": "%4",
+      "target_review_label": "reviewer-1",
+      "target_review_role": "Reviewer",
+      "target_reviewer_pane_id": "%4",
+      "target_reviewer_label": "reviewer-1",
+      "target_reviewer_role": "Reviewer",
+      "review_contract": {
+        "version": 1,
+        "source_task": "TASK-210",
+        "issue_ref": "#315",
+        "style": "utility_first",
+        "required_scope": [
+          "design_impact",
+          "replacement_coverage",
+          "orphaned_artifacts"
+        ],
+        "checklist_labels": [
+          "design impact",
+          "replacement coverage",
+          "orphaned artifacts"
+        ],
+        "rationale": "Review requests must audit downstream design impact, replacement coverage, and orphaned artifacts as part of the runtime contract."
+      },
+      "dispatched_at": "__TIMESTAMP__"
     },
-    "dispatched_at": "__TIMESTAMP__"
-  },
-  "reviewer": {
-    "pane_id": "%4",
-    "label": "reviewer-1",
-    "role": "Reviewer",
-    "agent_name": "codex"
-  },
-  "updatedAt": "__TIMESTAMP__"
+    "reviewer": {
+      "pane_id": "%4",
+      "label": "reviewer-1",
+      "role": "Reviewer",
+      "agent_name": "codex"
+    },
+    "updatedAt": "__TIMESTAMP__"
+  }
 }

--- a/winsmux-app/src-tauri/src/desktop_backend.rs
+++ b/winsmux-app/src-tauri/src/desktop_backend.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fs;
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
@@ -441,15 +441,21 @@ pub struct DesktopReviewStateRecord {
     pub evidence: Option<DesktopReviewStateEvidence>,
 }
 
+#[allow(dead_code)]
+pub type DesktopReviewStateSnapshot = BTreeMap<String, DesktopReviewStateRecord>;
+
 #[derive(Serialize, Deserialize)]
 pub struct DesktopReviewStateRequest {
     #[serde(default)]
     pub id: Option<String>,
     pub branch: String,
     pub head_sha: String,
-    pub target_review_pane_id: String,
-    pub target_review_label: String,
-    pub target_review_role: String,
+    #[serde(default)]
+    pub target_review_pane_id: Option<String>,
+    #[serde(default)]
+    pub target_review_label: Option<String>,
+    #[serde(default)]
+    pub target_review_role: Option<String>,
     #[serde(default)]
     pub target_reviewer_pane_id: Option<String>,
     #[serde(default)]
@@ -683,8 +689,165 @@ pub fn load_desktop_run_explain(
         run_id,
         project_dir,
     })?;
-    serde_json::from_value(payload)
-        .map_err(|err| format!("Failed to parse desktop explain payload: {err}"))
+    let payload: DesktopExplainPayload = serde_json::from_value(payload)
+        .map_err(|err| format!("Failed to parse desktop explain payload: {err}"))?;
+    if let Some(review_state) = payload.review_state.as_ref() {
+        validate_desktop_review_state_record(review_state)
+            .map_err(|err| format!("Failed to parse desktop explain payload: {err}"))?;
+    }
+    Ok(payload)
+}
+
+#[allow(dead_code)]
+pub fn parse_desktop_review_state_snapshot(
+    payload: Value,
+) -> Result<DesktopReviewStateSnapshot, String> {
+    let snapshot: DesktopReviewStateSnapshot = serde_json::from_value(payload)
+        .map_err(|err| format!("Failed to parse review-state payload: {err}"))?;
+    for (branch, record) in snapshot.iter() {
+        validate_non_empty("review-state branch key", branch)?;
+        validate_desktop_review_state_record(record)?;
+        if record.branch != *branch {
+            return Err(format!(
+                "review-state record branch mismatch: key={branch}, record={}",
+                record.branch
+            ));
+        }
+    }
+    Ok(snapshot)
+}
+
+fn validate_desktop_review_state_record(record: &DesktopReviewStateRecord) -> Result<(), String> {
+    validate_non_empty("review_state.status", &record.status)?;
+    validate_non_empty("review_state.branch", &record.branch)?;
+    validate_non_empty("review_state.head_sha", &record.head_sha)?;
+    validate_non_empty("review_state.updatedAt", &record.updated_at)?;
+    validate_non_empty("review_state.request.branch", &record.request.branch)?;
+    validate_non_empty("review_state.request.head_sha", &record.request.head_sha)?;
+    validate_equal(
+        "review_state.request.branch",
+        &record.request.branch,
+        "review_state.branch",
+        &record.branch,
+    )?;
+    validate_equal(
+        "review_state.request.head_sha",
+        &record.request.head_sha,
+        "review_state.head_sha",
+        &record.head_sha,
+    )?;
+    validate_non_empty(
+        "review_state.request.target_review_pane_id",
+        review_request_target_value(
+            &record.request.target_review_pane_id,
+            &record.request.target_reviewer_pane_id,
+        ),
+    )?;
+    validate_non_empty(
+        "review_state.request.target_review_label",
+        review_request_target_value(
+            &record.request.target_review_label,
+            &record.request.target_reviewer_label,
+        ),
+    )?;
+    validate_non_empty(
+        "review_state.request.target_review_role",
+        review_request_target_value(
+            &record.request.target_review_role,
+            &record.request.target_reviewer_role,
+        ),
+    )?;
+    validate_non_empty("review_state.reviewer.pane_id", &record.reviewer.pane_id)?;
+    validate_non_empty("review_state.reviewer.label", &record.reviewer.label)?;
+    validate_non_empty("review_state.reviewer.role", &record.reviewer.role)?;
+    validate_desktop_review_contract(
+        "review_state.request.review_contract",
+        &record.request.review_contract,
+    )?;
+
+    match record.status.to_ascii_uppercase().as_str() {
+        "PASS" => {
+            let evidence = record
+                .evidence
+                .as_ref()
+                .ok_or_else(|| "review_state.evidence is required for PASS".to_string())?;
+            validate_non_empty(
+                "review_state.evidence.approved_at",
+                evidence.approved_at.as_deref().unwrap_or_default(),
+            )?;
+            validate_non_empty(
+                "review_state.evidence.approved_via",
+                evidence.approved_via.as_deref().unwrap_or_default(),
+            )?;
+            validate_desktop_review_contract(
+                "review_state.evidence.review_contract_snapshot",
+                &evidence.review_contract_snapshot,
+            )?;
+        }
+        "FAIL" | "FAILED" => {
+            let evidence = record
+                .evidence
+                .as_ref()
+                .ok_or_else(|| "review_state.evidence is required for FAIL".to_string())?;
+            validate_non_empty(
+                "review_state.evidence.failed_at",
+                evidence.failed_at.as_deref().unwrap_or_default(),
+            )?;
+            validate_non_empty(
+                "review_state.evidence.failed_via",
+                evidence.failed_via.as_deref().unwrap_or_default(),
+            )?;
+            validate_desktop_review_contract(
+                "review_state.evidence.review_contract_snapshot",
+                &evidence.review_contract_snapshot,
+            )?;
+        }
+        _ => {}
+    }
+
+    Ok(())
+}
+
+fn validate_desktop_review_contract(
+    name: &str,
+    contract: &DesktopReviewContract,
+) -> Result<(), String> {
+    if contract.required_scope.is_empty() {
+        return Err(format!("{name}.required_scope must not be empty"));
+    }
+    Ok(())
+}
+
+fn review_request_target_value<'a>(
+    primary: &'a Option<String>,
+    legacy: &'a Option<String>,
+) -> &'a str {
+    primary
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+        .or_else(|| legacy.as_deref().filter(|value| !value.trim().is_empty()))
+        .unwrap_or_default()
+}
+
+fn validate_equal(
+    left_name: &str,
+    left: &str,
+    right_name: &str,
+    right: &str,
+) -> Result<(), String> {
+    if left != right {
+        return Err(format!(
+            "{left_name} mismatch: expected {right_name}={right}, got {left}"
+        ));
+    }
+    Ok(())
+}
+
+fn validate_non_empty(name: &str, value: &str) -> Result<(), String> {
+    if value.trim().is_empty() {
+        return Err(format!("{name} must not be empty"));
+    }
+    Ok(())
 }
 
 pub fn load_desktop_run_compare(
@@ -1347,6 +1510,10 @@ mod tests {
     }
 
     fn rust_parity_review_state_payload() -> Value {
+        rust_parity_review_state_snapshot_payload()["worktree-builder-1"].clone()
+    }
+
+    fn rust_parity_review_state_snapshot_payload() -> Value {
         read_rust_parity_fixture("review-state.json")
     }
 
@@ -3518,6 +3685,174 @@ mod tests {
     }
 
     #[test]
+    fn parse_desktop_review_state_snapshot_deserializes_branch_map() {
+        let snapshot =
+            parse_desktop_review_state_snapshot(rust_parity_review_state_snapshot_payload())
+                .expect("review-state fixture should deserialize");
+
+        let record = snapshot
+            .get("worktree-builder-1")
+            .expect("review-state fixture should contain branch key");
+        assert_eq!(record.status, "PENDING");
+        assert_eq!(record.branch, "worktree-builder-1");
+        assert_eq!(record.request.review_contract.source_task, "TASK-210");
+        assert_eq!(
+            record.request.review_contract.required_scope,
+            vec![
+                "design_impact".to_string(),
+                "replacement_coverage".to_string(),
+                "orphaned_artifacts".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_desktop_review_state_snapshot_accepts_legacy_target_reviewer_fields() {
+        let mut response = rust_parity_review_state_snapshot_payload();
+        let request = response["worktree-builder-1"]["request"]
+            .as_object_mut()
+            .expect("review-state request must be an object");
+        request.remove("target_review_pane_id");
+        request.remove("target_review_label");
+        request.remove("target_review_role");
+
+        parse_desktop_review_state_snapshot(response)
+            .expect("legacy target_reviewer fields should remain readable");
+    }
+
+    #[test]
+    fn parse_desktop_review_state_snapshot_rejects_missing_target_review_identity() {
+        let mut response = rust_parity_review_state_snapshot_payload();
+        let request = response["worktree-builder-1"]["request"]
+            .as_object_mut()
+            .expect("review-state request must be an object");
+        request.remove("target_review_pane_id");
+        request.remove("target_reviewer_pane_id");
+
+        let err = match parse_desktop_review_state_snapshot(response) {
+            Ok(_) => panic!("expected review-state payload parse failure"),
+            Err(err) => err,
+        };
+
+        assert!(
+            err.contains("target_review_pane_id"),
+            "unexpected review-state parse error: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_desktop_review_state_snapshot_rejects_missing_reviewer() {
+        let mut response = rust_parity_review_state_snapshot_payload();
+        response["worktree-builder-1"]
+            .as_object_mut()
+            .expect("review-state record must be an object")
+            .remove("reviewer");
+
+        let err = match parse_desktop_review_state_snapshot(response) {
+            Ok(_) => panic!("expected review-state payload parse failure"),
+            Err(err) => err,
+        };
+
+        assert!(
+            err.contains("reviewer"),
+            "unexpected review-state parse error: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_desktop_review_state_snapshot_rejects_branch_mismatch() {
+        let mut response = rust_parity_review_state_snapshot_payload();
+        response["worktree-builder-1"]["branch"] = serde_json::json!("other-branch");
+
+        let err = match parse_desktop_review_state_snapshot(response) {
+            Ok(_) => panic!("expected review-state payload parse failure"),
+            Err(err) => err,
+        };
+
+        assert!(
+            err.contains("branch mismatch"),
+            "unexpected review-state parse error: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_desktop_review_state_snapshot_rejects_request_branch_mismatch() {
+        let mut response = rust_parity_review_state_snapshot_payload();
+        response["worktree-builder-1"]["request"]["branch"] = serde_json::json!("other-branch");
+
+        let err = match parse_desktop_review_state_snapshot(response) {
+            Ok(_) => panic!("expected review-state payload parse failure"),
+            Err(err) => err,
+        };
+
+        assert!(
+            err.contains("request.branch"),
+            "unexpected review-state parse error: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_desktop_review_state_snapshot_rejects_request_head_mismatch() {
+        let mut response = rust_parity_review_state_snapshot_payload();
+        response["worktree-builder-1"]["request"]["head_sha"] = serde_json::json!("other-head");
+
+        let err = match parse_desktop_review_state_snapshot(response) {
+            Ok(_) => panic!("expected review-state payload parse failure"),
+            Err(err) => err,
+        };
+
+        assert!(
+            err.contains("request.head_sha"),
+            "unexpected review-state parse error: {err}"
+        );
+    }
+
+    #[test]
+    fn load_desktop_run_explain_rejects_pass_review_state_without_approved_via() {
+        let mut response = rust_parity_explain_payload_with_review_state();
+        response["review_state"]["status"] = serde_json::json!("PASS");
+        response["review_state"]["evidence"] = serde_json::json!({
+            "approved_at": "__TIMESTAMP__",
+            "review_contract_snapshot": response["review_state"]["request"]["review_contract"].clone()
+        });
+
+        let transport = FakeTransport {
+            requests: RefCell::new(Vec::new()),
+            response,
+        };
+
+        let err = match load_desktop_run_explain(&transport, "task:task-256".to_string(), None) {
+            Ok(_) => panic!("expected explain payload parse failure"),
+            Err(err) => err,
+        };
+
+        assert!(
+            err.contains("approved_via"),
+            "unexpected explain parse error: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_desktop_review_state_snapshot_rejects_fail_without_failed_via() {
+        let mut response = rust_parity_review_state_snapshot_payload();
+        response["worktree-builder-1"]["status"] = serde_json::json!("FAIL");
+        response["worktree-builder-1"]["evidence"] = serde_json::json!({
+            "failed_at": "__TIMESTAMP__",
+            "review_contract_snapshot": response["worktree-builder-1"]["request"]["review_contract"].clone()
+        });
+
+        let err = match parse_desktop_review_state_snapshot(response) {
+            Ok(_) => panic!("expected review-state payload parse failure"),
+            Err(err) => err,
+        };
+
+        assert!(
+            err.contains("failed_via"),
+            "unexpected review-state parse error: {err}"
+        );
+    }
+
+    #[test]
     fn load_desktop_run_explain_rejects_missing_review_contract_required_scope() {
         let mut response = rust_parity_explain_payload_with_review_state();
         response["review_state"]["request"]["review_contract"]
@@ -3538,6 +3873,57 @@ mod tests {
         assert!(
             err.contains("required_scope"),
             "unexpected explain parse error: {err}"
+        );
+    }
+
+    #[test]
+    fn load_desktop_run_explain_rejects_empty_review_contract_required_scope() {
+        let mut response = rust_parity_explain_payload_with_review_state();
+        response["review_state"]["request"]["review_contract"]["required_scope"] =
+            serde_json::json!([]);
+
+        let transport = FakeTransport {
+            requests: RefCell::new(Vec::new()),
+            response,
+        };
+
+        let err = match load_desktop_run_explain(&transport, "task:task-256".to_string(), None) {
+            Ok(_) => panic!("expected explain payload parse failure"),
+            Err(err) => err,
+        };
+
+        assert!(
+            err.contains("required_scope"),
+            "unexpected explain parse error: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_desktop_review_state_snapshot_rejects_empty_evidence_required_scope() {
+        let mut response = rust_parity_review_state_snapshot_payload();
+        response["worktree-builder-1"]["status"] = serde_json::json!("PASS");
+        response["worktree-builder-1"]["evidence"] = serde_json::json!({
+            "approved_at": "__TIMESTAMP__",
+            "approved_via": "winsmux review-approve",
+            "review_contract_snapshot": {
+                "version": 1,
+                "source_task": "TASK-210",
+                "issue_ref": "#315",
+                "style": "utility_first",
+                "required_scope": [],
+                "checklist_labels": ["design impact"],
+                "rationale": "Contract snapshot"
+            }
+        });
+
+        let err = match parse_desktop_review_state_snapshot(response) {
+            Ok(_) => panic!("expected review-state payload parse failure"),
+            Err(err) => err,
+        };
+
+        assert!(
+            err.contains("required_scope"),
+            "unexpected review-state parse error: {err}"
         );
     }
 


### PR DESCRIPTION
## Summary

- Freeze `.winsmux/review-state.json` as a branch-keyed Rust DTO fixture contract.
- Validate review identity, branch/head consistency, reviewer identity, and review evidence scope.
- Split manifest and event schema work into follow-up tasks so TASK-277 stays bounded.

## Validation

- `cargo test --manifest-path .\winsmux-app\src-tauri\Cargo.toml review_state -- --nocapture`
- `cargo test --manifest-path .\core\Cargo.toml rust_parity_review_state_fixture_deserializes -- --nocapture`
- `cargo test --workspace --locked`
- `Invoke-Pester .\tests\winsmux-bridge.Tests.ps1 -Output Detailed`
- `cmd /c npm run build` in `winsmux-app`
- `pwsh -NoProfile -File .\scripts\git-guard.ps1 -Mode full`
- `pwsh -NoProfile -File .\scripts\audit-public-surface.ps1`

## Review

- First Codex review requested changes for branch/head equality, non-empty required scope, legacy target reviewer fallback, and documentation wording.
- Follow-up Codex review approved the fixes.

## Planning

- Adds follow-up planning for manifest and event schema freeze.
- Maps v0.24.6 ultrareview findings to TASK-393, TASK-394, and TASK-395.