### PR TITLE
TASK-376: Normalize public metadata surfaces

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -84,8 +84,6 @@ winsmux init --workspace-lifecycle managed-worktree
 winsmux launcher presets --json
 ```
 
-`/winsmux-start` は、このリポジトリ自体の動作確認専用のコマンドです。公開利用では `winsmux init` と `winsmux launch` から始めます。
-
 ## 主要コマンド
 
 ```powershell
@@ -151,4 +149,7 @@ winsmux compare promote <run_id>
 
 ## ライセンス
 
-Apache License 2.0
+Apache License 2.0 です。
+
+一部のランタイム互換コードには、上流由来の MIT ライセンス表示が `core/LICENSE` に残ります。
+詳しくは [サードパーティライセンス](THIRD_PARTY_NOTICES.md) を参照してください。

--- a/README.md
+++ b/README.md
@@ -87,8 +87,6 @@ Inspect launcher presets before starting a compare-oriented run:
 winsmux launcher presets --json
 ```
 
-`/winsmux-start` is only used to test this repository itself. Public usage should start from `winsmux init` and `winsmux launch`.
-
 ## Main Commands
 
 ```powershell
@@ -154,4 +152,7 @@ Developer and contributor rules are intentionally kept out of this README. Start
 
 ## License
 
-Apache License 2.0
+Apache License 2.0.
+
+Some runtime compatibility code keeps an upstream MIT notice under `core/LICENSE`.
+See [Third-party notices](THIRD_PARTY_NOTICES.md) for the split.

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -2,9 +2,9 @@
 name = "winsmux"
 version = "0.23.1"
 edition = "2021"
-description = "Terminal multiplexer for Windows - tmux alternative for PowerShell and Windows Terminal"
-license = "Apache-2.0"
-repository = "https://github.com/winsmux/winsmux"
+description = "Windows-native terminal multiplexer and agent workspace runtime"
+license = "Apache-2.0 AND MIT"
+repository = "https://github.com/Sora-bluesky/winsmux"
 keywords = ["terminal", "multiplexer", "tmux", "windows", "powershell"]
 categories = ["command-line-utilities"]
 

--- a/docs/operator-model.md
+++ b/docs/operator-model.md
@@ -115,7 +115,8 @@ The public first-run entrypoints now converge on:
 - `winsmux conflict-preflight`
 - `winsmux compare <runs|preflight|promote>`
 
-That direction is public product behavior. `/winsmux-start` remains a repository-operated Claude Code dogfooding flow and is not part of the primary public UX.
+That direction is public product behavior.
+Repository-specific startup flows are kept in contributor documents, not in the primary public UX.
 `winsmux launcher presets [--json]` reports the launcher presets, pair templates, and slot capabilities that should exist before a launch or compare-oriented run.
 `winsmux launcher lifecycle [preset|--clear] [--json]` reports or stores the local workspace lifecycle override.
 `winsmux launcher save <name>` stores that launcher template in the project `.winsmux` directory for later reuse.
@@ -124,7 +125,7 @@ Lifecycle presets are declarative workspace policy. They do not execute arbitrar
 It wraps run comparison, merge preflight, and follow-up candidate promotion behind one entrypoint.
 The desktop compare card surfaces shared changed files as hotspots and displays a risk badge before winner selection.
 
-Repository-operated runtime contracts also exist for contributor flows, but they are maintained as contributor/runtime documents rather than primary public product docs.
+Repository-specific runtime contracts also exist for contributor flows, but they are maintained as contributor documents rather than primary public product docs.
 
 ## 5. Public docs vs contributor docs
 

--- a/packages/winsmux/README.md
+++ b/packages/winsmux/README.md
@@ -69,3 +69,12 @@ longer part of the selected profile are removed from `~\.winsmux\winsmux-core\sc
 - the publish workflow stays tag-driven
 - the publish job uses the staged package from `scripts/stage-npm-release.mjs`
 - the publish job requires the repository `NPM_TOKEN` secret
+
+## License
+
+The public npm package is Apache-2.0.
+Some runtime compatibility code in the repository keeps an upstream MIT notice.
+See the repository notices for provenance details:
+
+- https://github.com/Sora-bluesky/winsmux/blob/main/core/LICENSE
+- https://github.com/Sora-bluesky/winsmux/blob/main/THIRD_PARTY_NOTICES.md

--- a/scripts/audit-public-surface.ps1
+++ b/scripts/audit-public-surface.ps1
@@ -32,8 +32,10 @@ function Test-IsPublicDoc {
     return $normalized -in @(
         'README.md',
         'README.ja.md',
+        'THIRD_PARTY_NOTICES.md',
         'docs/operator-model.md',
-        'docs/TROUBLESHOOTING.md'
+        'docs/TROUBLESHOOTING.md',
+        'packages/winsmux/README.md'
     )
 }
 
@@ -117,11 +119,24 @@ $forbiddenPublicRefs = @(
     'tasks/roadmap-title-ja.psd1',
     '.agents/skills/'
 )
+$forbiddenPublicProductFragments = @(
+    '/winsmux-start',
+    'test this repository itself',
+    '動作確認専用',
+    'dogfooding',
+    'Repository-operated',
+    'contributor/runtime'
+)
 foreach ($file in ($trackedFiles | Where-Object { Test-IsPublicDoc -Path $_ })) {
     $content = Get-Content -LiteralPath $file -Raw -ErrorAction Stop
     foreach ($reference in $forbiddenPublicRefs) {
         if ($content -match [Regex]::Escape($reference)) {
             $failures.Add("public doc directly references private/contributor surface '$reference': $file")
+        }
+    }
+    foreach ($fragment in $forbiddenPublicProductFragments) {
+        if ($content -match [Regex]::Escape($fragment)) {
+            $failures.Add("public doc exposes repository-only startup wording '$fragment': $file")
         }
     }
 }

--- a/scripts/bump-version.ps1
+++ b/scripts/bump-version.ps1
@@ -229,6 +229,16 @@ $targets = @(
         Replace = "`${1}$Version`${2}"
     },
     @{
+        Path    = Join-Path $Root "winsmux-core\package.json"
+        Pattern = '("version"\s*:\s*")[^"]*(")'
+        Replace = "`${1}$Version`${2}"
+    },
+    @{
+        Path    = Join-Path $Root "winsmux-core\mcp-server.js"
+        Pattern = '(const SERVER_VERSION\s*=\s*")[^"]*(";)'
+        Replace = "`${1}$Version`${2}"
+    },
+    @{
         Path    = Join-Path $Root "skills\winsmux\SKILL.md"
         Pattern = '(version:\s*")[^"]*(")'
         Replace = "`${1}$Version`${2}"
@@ -341,6 +351,8 @@ try {
         "winsmux-app/src-tauri/Cargo.toml",
         "winsmux-app/src-tauri/Cargo.lock",
         "winsmux-app/src-tauri/tauri.conf.json",
+        "winsmux-core/package.json",
+        "winsmux-core/mcp-server.js",
         "skills/winsmux/SKILL.md",
         "skills/winsmux/references/winsmux-core.md"
     )

--- a/tests/NpmReleasePackage.Tests.ps1
+++ b/tests/NpmReleasePackage.Tests.ps1
@@ -153,6 +153,8 @@ Describe 'winsmux npm release package contract' {
         $packageReadme | Should -Match 'Windows verify job'
         $packageReadme | Should -Match 'tag-driven'
         $packageReadme | Should -Match 'NPM_TOKEN'
+        $packageReadme | Should -Match 'github\.com/Sora-bluesky/winsmux/blob/main/core/LICENSE'
+        $packageReadme | Should -Match 'github\.com/Sora-bluesky/winsmux/blob/main/THIRD_PARTY_NOTICES\.md'
         $rootReadme | Should -Match 'npm install -g winsmux'
         $rootReadme | Should -Match 'winsmux install --profile full'
         $rootReadme | Should -Match 'keeps the previously\r?\nrecorded profile'

--- a/tests/PublicSurfacePolicy.Tests.ps1
+++ b/tests/PublicSurfacePolicy.Tests.ps1
@@ -36,16 +36,20 @@ Describe 'Public surface policy' {
             $readme | Should -Not -Match ([Regex]::Escape($reference))
             $readmeJa | Should -Not -Match ([Regex]::Escape($reference))
             $operatorModel | Should -Not -Match ([Regex]::Escape($reference))
+            $thirdPartyNotices | Should -Not -Match ([Regex]::Escape($reference))
         }
     }
 
-    It 'keeps /winsmux-start out of the public UX and advertises future public entrypoints' {
-        $readme | Should -Match '/winsmux-start'
-        $readmeJa | Should -Match '/winsmux-start'
-        $operatorModel | Should -Match '/winsmux-start'
-        $readme | Should -Match 'test this repository itself'
-        $readmeJa | Should -Match '動作確認専用'
-        $operatorModel | Should -Match 'dogfooding flow'
+    It 'keeps repository startup flows out of the public UX and advertises public entrypoints' {
+        $readme | Should -Not -Match '/winsmux-start'
+        $readmeJa | Should -Not -Match '/winsmux-start'
+        $operatorModel | Should -Not -Match '/winsmux-start'
+        $readme | Should -Not -Match 'test this repository itself'
+        $readmeJa | Should -Not -Match '動作確認専用'
+        $operatorModel | Should -Not -Match 'dogfooding'
+        $operatorModel | Should -Not -Match 'Repository-operated'
+        $operatorModel | Should -Not -Match 'contributor/runtime'
+        $operatorModel | Should -Match 'Repository-specific startup flows are kept in contributor documents'
 
         foreach ($entrypoint in @('winsmux init', 'winsmux launch', 'winsmux launcher presets', 'winsmux compare')) {
             $readme | Should -Match ([Regex]::Escape($entrypoint))

--- a/tests/VersionSurface.Tests.ps1
+++ b/tests/VersionSurface.Tests.ps1
@@ -27,6 +27,8 @@ Describe 'winsmux version surface' {
         $bridgeScript | Should -Match ('\$VERSION\s*=\s*"{0}"' -f [regex]::Escape($script:ProductVersion))
         $workspaceLock | Should -Match ('(?ms)^name\s*=\s*"winsmux"\s*\r?\nversion\s*=\s*"{0}"' -f [regex]::Escape($script:ProductVersion))
         $coreManifest | Should -Match ('(?m)^version\s*=\s*"{0}"\r?$' -f [regex]::Escape($script:ProductVersion))
+        $coreManifest | Should -Match '(?m)^license\s*=\s*"Apache-2\.0 AND MIT"\r?$'
+        $coreManifest | Should -Match '(?m)^repository\s*=\s*"https://github\.com/Sora-bluesky/winsmux"\r?$'
         $coreLock | Should -Match ('(?ms)^name\s*=\s*"winsmux"\s*\r?\nversion\s*=\s*"{0}"' -f [regex]::Escape($script:ProductVersion))
     }
 
@@ -42,7 +44,11 @@ Describe 'winsmux version surface' {
         $appPackageLock['version'] | Should -Be $script:ProductVersion
         $appPackageLock['packages']['']['version'] | Should -Be $script:ProductVersion
         $tauriConfig.version | Should -Be $script:ProductVersion
+        $tauriConfig.productName | Should -Be 'winsmux'
+        $tauriConfig.app.windows[0].title | Should -Be 'winsmux'
         $tauriManifest | Should -Match ('(?m)^version\s*=\s*"{0}"\r?$' -f [regex]::Escape($script:ProductVersion))
+        $tauriManifest | Should -Match '(?m)^description\s*=\s*"Desktop control plane for winsmux"\r?$'
+        $tauriManifest | Should -Match '(?m)^authors\s*=\s*\["Sora-bluesky"\]\r?$'
         $workspaceLock | Should -Match ('(?ms)^name\s*=\s*"winsmux-app"\s*\r?\nversion\s*=\s*"{0}"' -f [regex]::Escape($script:ProductVersion))
         $tauriLock | Should -Match ('(?ms)^name\s*=\s*"winsmux-app"\s*\r?\nversion\s*=\s*"{0}"' -f [regex]::Escape($script:ProductVersion))
     }
@@ -62,5 +68,37 @@ Describe 'winsmux version surface' {
 
         $stagedPackage.version | Should -Be $script:ProductVersion
         $stagedInstaller | Should -Match ('\$VERSION\s*=\s*"{0}"' -f [regex]::Escape($script:ProductVersion))
+    }
+
+    It 'keeps tracked package metadata aligned with the public product surface' {
+        $mcpPackage = Get-Content -LiteralPath (Join-Path $script:RepoRoot 'winsmux-core\package.json') -Raw -Encoding UTF8 | ConvertFrom-Json -Depth 20
+        $mcpServer = Get-Content -LiteralPath (Join-Path $script:RepoRoot 'winsmux-core\mcp-server.js') -Raw -Encoding UTF8
+
+        $mcpPackage.name | Should -Be 'winsmux-mcp'
+        $mcpPackage.version | Should -Be $script:ProductVersion
+        $mcpPackage.private | Should -BeTrue
+        $mcpPackage.license | Should -Be 'Apache-2.0'
+        $mcpServer | Should -Match ('const SERVER_VERSION = "{0}";' -f [regex]::Escape($script:ProductVersion))
+    }
+
+    It 'documents the public license split for runtime compatibility notices' {
+        $readme = Get-Content -LiteralPath (Join-Path $script:RepoRoot 'README.md') -Raw -Encoding UTF8
+        $readmeJa = Get-Content -LiteralPath (Join-Path $script:RepoRoot 'README.ja.md') -Raw -Encoding UTF8
+        $packageReadme = Get-Content -LiteralPath (Join-Path $script:RepoRoot 'packages\winsmux\README.md') -Raw -Encoding UTF8
+        $thirdPartyNotices = Get-Content -LiteralPath (Join-Path $script:RepoRoot 'THIRD_PARTY_NOTICES.md') -Raw -Encoding UTF8
+        $coreLicense = Get-Content -LiteralPath (Join-Path $script:RepoRoot 'core\LICENSE') -Raw -Encoding UTF8
+
+        $readme | Should -Match 'Apache License 2\.0'
+        $readme | Should -Match 'core/LICENSE'
+        $readme | Should -Match 'THIRD_PARTY_NOTICES\.md'
+        $readmeJa | Should -Match 'Apache License 2\.0'
+        $readmeJa | Should -Match 'core/LICENSE'
+        $readmeJa | Should -Match 'THIRD_PARTY_NOTICES\.md'
+        $packageReadme | Should -Match 'The public npm package is Apache-2\.0'
+        $packageReadme | Should -Match 'github\.com/Sora-bluesky/winsmux/blob/main/core/LICENSE'
+        $packageReadme | Should -Match 'github\.com/Sora-bluesky/winsmux/blob/main/THIRD_PARTY_NOTICES\.md'
+        $thirdPartyNotices | Should -Match 'License: MIT'
+        $thirdPartyNotices | Should -Match 'MIT-derived `psmux` compatibility surface'
+        $coreLicense | Should -Match 'MIT License'
     }
 }

--- a/winsmux-app/src-tauri/Cargo.toml
+++ b/winsmux-app/src-tauri/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "winsmux-app"
 version = "0.23.1"
-description = "A Tauri App"
-authors = ["you"]
+description = "Desktop control plane for winsmux"
+authors = ["Sora-bluesky"]
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/winsmux-app/src-tauri/tauri.conf.json
+++ b/winsmux-app/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
-  "productName": "winsmux-app",
+  "productName": "winsmux",
   "version": "0.23.1",
   "identifier": "io.github.sora-bluesky.winsmux",
   "build": {
@@ -13,7 +13,7 @@
     "withGlobalTauri": true,
     "windows": [
       {
-        "title": "winsmux-app",
+        "title": "winsmux",
         "width": 800,
         "height": 600
       }

--- a/winsmux-core/mcp-server.js
+++ b/winsmux-core/mcp-server.js
@@ -7,7 +7,7 @@ const path = require("path");
 
 const BRIDGE_SCRIPT = resolveBridgeScript();
 const SERVER_NAME = "winsmux-mcp";
-const SERVER_VERSION = "0.1.0";
+const SERVER_VERSION = "0.23.1";
 const PROTOCOL_VERSION = "2024-11-05";
 
 // --- Tool Definitions ---

--- a/winsmux-core/package.json
+++ b/winsmux-core/package.json
@@ -1,7 +1,8 @@
 {
   "name": "winsmux-mcp",
-  "version": "0.1.0",
+  "version": "0.23.1",
   "description": "MCP server exposing winsmux commands as tools",
+  "private": true,
   "main": "mcp-server.js",
   "bin": {
     "winsmux-mcp": "mcp-server.js"
@@ -9,7 +10,7 @@
   "scripts": {
     "start": "node mcp-server.js"
   },
-  "license": "MIT",
+  "license": "Apache-2.0",
   "engines": {
     "node": ">=18"
   }


### PR DESCRIPTION
## Summary

- Normalize public metadata for `TASK-376` and `#521`.
- Align license/version metadata across Rust, Tauri, MCP package, and public docs.
- Keep repository-only startup wording out of public docs.
- Extend version and public-surface gates so future releases catch this drift.

## Validation

- `Invoke-Pester .\tests\VersionSurface.Tests.ps1, .\tests\NpmReleasePackage.Tests.ps1, .\tests\PublicSurfacePolicy.Tests.ps1 -Output Detailed`
- `cargo check --workspace --locked`
- `cmd /c npm run build` under `winsmux-app`
- `pwsh -NoProfile -File .\scripts\audit-public-surface.ps1`
- `pwsh -NoProfile -File .\scripts\git-guard.ps1 -Mode full`
- `git diff --check`
- `Opus` public docs review: `APPROVE`
- `codex exec` review after npm README fix: `APPROVE`