### PR TITLE
TASK-154: inject manifest-aware session resume context

### DIFF
--- a/.claude/hooks/sh-session-start.js
+++ b/.claude/hooks/sh-session-start.js
@@ -146,6 +146,13 @@ function collectManifestResumeState() {
 }
 
 function collectPlanningResumeState(preferredTaskIds = []) {
+  const preferredSet = new Set(
+    preferredTaskIds.map((taskId) => normalizeTaskId(taskId)).filter(Boolean),
+  );
+  if (preferredSet.size === 0) {
+    return null;
+  }
+
   const backlogPath = getBacklogPath();
   if (!backlogPath || !fs.existsSync(backlogPath)) {
     return null;
@@ -153,16 +160,7 @@ function collectPlanningResumeState(preferredTaskIds = []) {
 
   const backlog = readYaml(backlogPath);
   const tasks = Array.isArray(backlog.tasks) ? backlog.tasks : [];
-  const preferredSet = new Set(
-    preferredTaskIds.map((taskId) => normalizeTaskId(taskId)).filter(Boolean),
-  );
-
   let selected = tasks.filter((task) => preferredSet.has(normalizeTaskId(task.id)));
-  if (selected.length === 0) {
-    selected = tasks.filter(
-      (task) => String(task.status || "").trim().toLowerCase() === "active",
-    );
-  }
 
   selected = selected.slice(0, 2).map((task) => ({
     id: String(task.id || "").trim(),
@@ -339,7 +337,11 @@ try {
   contextParts.push(`[env-check] Platform: ${platform}`);
 
   // 2b: Token budget initialization
-  const session = readSession();
+  const rawSession = readSession();
+  const session =
+    rawSession && typeof rawSession === "object" && !Array.isArray(rawSession)
+      ? rawSession
+      : {};
   if (!session.token_budget) {
     session.token_budget = { ...DEFAULT_TOKEN_BUDGET };
   }

--- a/.claude/hooks/sh-session-start.js
+++ b/.claude/hooks/sh-session-start.js
@@ -14,6 +14,8 @@ const {
   readSession,
   writeSession,
   appendEvidence,
+  readYaml,
+  getBacklogPath,
 } = require("./lib/sh-utils");
 // Enterprise libs — soft-disable with try-catch (Tier 3, not yet validated)
 let detectOpenShell = () => ({ available: false, reason: "module_not_loaded" });
@@ -57,6 +59,175 @@ const DEFAULT_TOKEN_BUDGET = {
   tool_output_limit: 50000,
   used: 0,
 };
+
+function findUpFile(startDir, relativeSegments) {
+  if (!startDir) {
+    return "";
+  }
+
+  let currentDir = path.resolve(startDir);
+  while (true) {
+    const candidate = path.join(currentDir, ...relativeSegments);
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+
+    const parentDir = path.dirname(currentDir);
+    if (parentDir === currentDir) {
+      return "";
+    }
+
+    currentDir = parentDir;
+  }
+}
+
+function resolveManifestPath() {
+  const starts = [process.cwd(), path.resolve(__dirname, "..", "..")];
+  for (const startDir of starts) {
+    const candidate = findUpFile(startDir, [".winsmux", "manifest.yaml"]);
+    if (candidate) {
+      return candidate;
+    }
+  }
+
+  return "";
+}
+
+function normalizeTaskId(value) {
+  return String(value || "").trim().toUpperCase();
+}
+
+function collectManifestResumeState() {
+  const manifestPath = resolveManifestPath();
+  if (!manifestPath) {
+    return null;
+  }
+
+  const manifest = readYaml(manifestPath);
+  const sessionInfo =
+    manifest && typeof manifest.session === "object" ? manifest.session : {};
+  const paneEntries =
+    manifest && manifest.panes && typeof manifest.panes === "object"
+      ? Object.entries(manifest.panes)
+      : [];
+
+  const activePanes = paneEntries
+    .map(([label, pane]) => {
+      if (!pane || typeof pane !== "object") {
+        return null;
+      }
+
+      const taskId = String(pane.task_id || "").trim();
+      const taskState = String(pane.task_state || "").trim();
+      const taskTitle = String(pane.task || pane.goal || "").trim();
+      if (!taskId && !taskState && !taskTitle) {
+        return null;
+      }
+
+      return {
+        label,
+        taskId,
+        taskState,
+        taskTitle,
+      };
+    })
+    .filter(Boolean);
+
+  return {
+    manifestPath,
+    sessionName: String(sessionInfo.name || "").trim(),
+    projectDir: String(sessionInfo.project_dir || "").trim(),
+    paneCount: paneEntries.length,
+    activePanes: activePanes.slice(0, 3),
+    taskIds: activePanes
+      .map((pane) => normalizeTaskId(pane.taskId))
+      .filter(Boolean),
+  };
+}
+
+function collectPlanningResumeState(preferredTaskIds = []) {
+  const backlogPath = getBacklogPath();
+  if (!backlogPath || !fs.existsSync(backlogPath)) {
+    return null;
+  }
+
+  const backlog = readYaml(backlogPath);
+  const tasks = Array.isArray(backlog.tasks) ? backlog.tasks : [];
+  const preferredSet = new Set(
+    preferredTaskIds.map((taskId) => normalizeTaskId(taskId)).filter(Boolean),
+  );
+
+  let selected = tasks.filter((task) => preferredSet.has(normalizeTaskId(task.id)));
+  if (selected.length === 0) {
+    selected = tasks.filter(
+      (task) => String(task.status || "").trim().toLowerCase() === "active",
+    );
+  }
+
+  selected = selected.slice(0, 2).map((task) => ({
+    id: String(task.id || "").trim(),
+    title: String(task.title || "").trim(),
+    targetVersion: String(task.target_version || "").trim(),
+  }));
+
+  if (selected.length === 0) {
+    return null;
+  }
+
+  return {
+    backlogPath,
+    selected,
+  };
+}
+
+function buildWinsmuxResumeContext() {
+  const lines = [];
+  const manifestState = collectManifestResumeState();
+  if (manifestState) {
+    if (manifestState.sessionName) {
+      lines.push(`[winsmux-resume] Session: ${manifestState.sessionName}`);
+    }
+    if (manifestState.projectDir) {
+      lines.push(`[winsmux-resume] Project: ${manifestState.projectDir}`);
+    }
+    lines.push(`[winsmux-resume] Managed panes: ${manifestState.paneCount}`);
+    for (const pane of manifestState.activePanes) {
+      const details = [pane.label];
+      if (pane.taskId) {
+        details.push(pane.taskId);
+      }
+      if (pane.taskState) {
+        details.push(pane.taskState);
+      }
+      if (pane.taskTitle) {
+        details.push(`- ${pane.taskTitle}`);
+      }
+      lines.push(`[winsmux-resume] Pane: ${details.join(" ")}`);
+    }
+  }
+
+  const planningState = manifestState
+    ? collectPlanningResumeState(manifestState.taskIds)
+    : null;
+  if (planningState) {
+    for (const task of planningState.selected) {
+      const details = [task.id];
+      if (task.targetVersion) {
+        details.push(task.targetVersion);
+      }
+      if (task.title) {
+        details.push(`- ${task.title}`);
+      }
+      lines.push(`[winsmux-resume] Planning: ${details.join(" ")}`);
+    }
+  }
+
+  return {
+    lines,
+    manifestState,
+    planningState,
+  };
+}
 
 const winsmuxHookProfile = (process.env.WINSMUX_HOOK_PROFILE || "standard").trim() || "standard";
 const winsmuxGovernanceMode = (process.env.WINSMUX_GOVERNANCE_MODE || "standard").trim() || "standard";
@@ -180,6 +351,28 @@ try {
     hook_profile: winsmuxHookProfile,
     governance_mode: winsmuxGovernanceMode,
   };
+  session.winsmux_resume = {
+    manifest_path: null,
+    pane_count: 0,
+    task_ids: [],
+    backlog_path: null,
+  };
+  const winsmuxResumeContext = buildWinsmuxResumeContext();
+  if (winsmuxResumeContext.lines.length > 0) {
+    contextParts.push(...winsmuxResumeContext.lines);
+    session.winsmux_resume.manifest_path = winsmuxResumeContext.manifestState
+      ? winsmuxResumeContext.manifestState.manifestPath
+      : null;
+    session.winsmux_resume.pane_count = winsmuxResumeContext.manifestState
+      ? winsmuxResumeContext.manifestState.paneCount
+      : 0;
+    session.winsmux_resume.task_ids = winsmuxResumeContext.manifestState
+      ? winsmuxResumeContext.manifestState.taskIds
+      : [];
+    session.winsmux_resume.backlog_path = winsmuxResumeContext.planningState
+      ? winsmuxResumeContext.planningState.backlogPath
+      : null;
+  }
   contextParts.push("[env-check] Session initialized, token budget set");
   contextParts.push(
     `[winsmux] Hook profile: ${winsmuxHookProfile}, governance mode: ${winsmuxGovernanceMode}`,

--- a/tests/HarnessContract.Tests.ps1
+++ b/tests/HarnessContract.Tests.ps1
@@ -453,6 +453,69 @@ tasks:
         }
     }
 
+    It 'does not inject unrelated planning when manifest task ids do not match backlog' {
+        $fixture = New-SessionStartFixture
+        try {
+            Write-TestFileWithCmd -Path (Join-Path $fixture.Root '.winsmux\manifest.yaml') -Content @"
+version: 1
+session:
+  name: winsmux-orchestra
+  project_dir: '$($fixture.Root)'
+panes:
+  builder-1:
+    task_id: TASK-999
+    task_state: in_progress
+    task: Detached resume state
+"@
+
+            $result = Invoke-NodeHookJson -RepoRoot $fixture.Root -HookRelativePath '.claude\hooks\sh-session-start.js' -Payload ([ordered]@{
+                session_id      = 'session-start-unmatched-task'
+                hook_event_name = 'SessionStart'
+            }) -EnvironmentVariables @{
+                WINSMUX_BACKLOG_PATH = $fixture.BacklogPath
+            }
+
+            $result.ExitCode | Should -Be 0
+            $context = [string]$result.Json.hookSpecificOutput.additionalContext
+            $context | Should -Match '\[winsmux-resume\] Pane: builder-1 TASK-999 in_progress - Detached resume state'
+            $context | Should -Not -Match '\[winsmux-resume\] Planning:'
+        } finally {
+            if (Test-Path -LiteralPath $fixture.Root) {
+                Remove-Item -LiteralPath $fixture.Root -Recurse -Force
+            }
+        }
+    }
+
+    It 'recovers when session.json is not an object' {
+        $fixture = New-SessionStartFixture
+        try {
+            $shieldDir = Join-Path $fixture.Root '.shield-harness'
+            New-Item -ItemType Directory -Path $shieldDir -Force | Out-Null
+            Write-TestFileWithCmd -Path (Join-Path $shieldDir 'session.json') -Content '"broken"'
+
+            $result = Invoke-NodeHookJson -RepoRoot $fixture.Root -HookRelativePath '.claude\hooks\sh-session-start.js' -Payload ([ordered]@{
+                session_id      = 'session-start-broken-session'
+                hook_event_name = 'SessionStart'
+            }) -EnvironmentVariables @{
+                WINSMUX_BACKLOG_PATH = $fixture.BacklogPath
+            }
+
+            $result.ExitCode | Should -Be 0
+            $context = [string]$result.Json.hookSpecificOutput.additionalContext
+            $context | Should -Match '\[winsmux-resume\] Session: winsmux-orchestra'
+            $context | Should -Not -Match 'Initialization error'
+
+            $sessionPath = Join-Path $shieldDir 'session.json'
+            $session = Get-Content -LiteralPath $sessionPath -Raw -Encoding UTF8 | ConvertFrom-Json -Depth 20
+            $session.token_budget.session_limit | Should -Be 200000
+            $session.winsmux_resume.manifest_path | Should -Match 'manifest\.yaml$'
+        } finally {
+            if (Test-Path -LiteralPath $fixture.Root) {
+                Remove-Item -LiteralPath $fixture.Root -Recurse -Force
+            }
+        }
+    }
+
     It 'blocks PR merge commands while orchestra restore is still needs-startup' {
         $fixtureRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("winsmux-startup-gate-" + [guid]::NewGuid().ToString('N'))
         try {

--- a/tests/HarnessContract.Tests.ps1
+++ b/tests/HarnessContract.Tests.ps1
@@ -31,11 +31,8 @@ Describe 'harness-check contract' {
                 New-Item -ItemType Directory -Path $parent -Force | Out-Null
             }
 
-            $escapedPath = $Path -replace '"', '""'
-            $Content | cmd /d /c ('more > "{0}"' -f $escapedPath) | Out-Null
-            if ($LASTEXITCODE -ne 0) {
-                throw "cmd.exe failed to write $Path"
-            }
+            $utf8NoBom = [System.Text.UTF8Encoding]::new($false)
+            [System.IO.File]::WriteAllText($Path, $Content, $utf8NoBom)
         }
 
         function Remove-TestSettingsLocal {
@@ -157,6 +154,51 @@ Describe 'harness-check contract' {
                 }
             } finally {
                 $process.Dispose()
+            }
+        }
+
+        function New-SessionStartFixture {
+            $fixtureRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("winsmux-session-start-" + [guid]::NewGuid().ToString('N'))
+            $hooksDir = Join-Path $fixtureRoot '.claude\hooks'
+            $libDir = Join-Path $hooksDir 'lib'
+            $patternsDir = Join-Path $fixtureRoot '.claude\patterns'
+            $winsmuxDir = Join-Path $fixtureRoot '.winsmux'
+
+            New-Item -ItemType Directory -Path $libDir -Force | Out-Null
+            New-Item -ItemType Directory -Path $patternsDir -Force | Out-Null
+            New-Item -ItemType Directory -Path $winsmuxDir -Force | Out-Null
+
+            Copy-Item -LiteralPath (Join-Path $script:RepoRoot '.claude\hooks\sh-session-start.js') -Destination (Join-Path $hooksDir 'sh-session-start.js') -Force
+            Copy-Item -LiteralPath (Join-Path $script:RepoRoot '.claude\hooks\lib\sh-utils.js') -Destination (Join-Path $libDir 'sh-utils.js') -Force
+
+            Write-TestFileWithCmd -Path (Join-Path $fixtureRoot 'CLAUDE.md') -Content '# Fixture'
+            Write-TestFileWithCmd -Path (Join-Path $fixtureRoot '.claude\settings.json') -Content '{"permissions":{"deny":["backlog.yaml"]}}'
+            Write-TestFileWithCmd -Path (Join-Path $patternsDir 'injection-patterns.json') -Content '{}'
+            Write-TestFileWithCmd -Path (Join-Path $winsmuxDir 'manifest.yaml') -Content @"
+version: 1
+session:
+  name: winsmux-orchestra
+  project_dir: '$fixtureRoot'
+panes:
+  builder-1:
+    task_id: TASK-154
+    task_state: in_progress
+    task: Resume session context
+"@
+
+            $backlogPath = Join-Path $fixtureRoot 'backlog.yaml'
+            Write-TestFileWithCmd -Path $backlogPath -Content @"
+version: 3
+tasks:
+  - id: TASK-154
+    title: Manifest-aware session resume / context injection
+    status: active
+    target_version: v0.24.1
+"@
+
+            return [PSCustomObject]@{
+                Root        = $fixtureRoot
+                BacklogPath = $backlogPath
             }
         }
     }
@@ -324,6 +366,89 @@ Describe 'harness-check contract' {
         } finally {
             if (Test-Path -LiteralPath $fixtureRoot) {
                 Remove-Item -LiteralPath $fixtureRoot -Recurse -Force
+            }
+        }
+    }
+
+    It 'injects winsmux resume context from manifest and backlog during SessionStart' {
+        $fixture = New-SessionStartFixture
+        try {
+            $result = Invoke-NodeHookJson -RepoRoot $fixture.Root -HookRelativePath '.claude\hooks\sh-session-start.js' -Payload ([ordered]@{
+                session_id      = 'session-start-test'
+                hook_event_name = 'SessionStart'
+            }) -EnvironmentVariables @{
+                WINSMUX_BACKLOG_PATH = $fixture.BacklogPath
+            }
+
+            $result.ExitCode | Should -Be 0
+            $result.StdErr | Should -Be ''
+            $context = [string]$result.Json.hookSpecificOutput.additionalContext
+            $context | Should -Match '\[winsmux-resume\] Session: winsmux-orchestra'
+            $context | Should -Match '\[winsmux-resume\] Managed panes: 1'
+            $context | Should -Match '\[winsmux-resume\] Pane: builder-1 TASK-154 in_progress - Resume session context'
+            $context | Should -Match '\[winsmux-resume\] Planning: TASK-154 v0.24.1 - Manifest-aware session resume / context injection'
+        } finally {
+            if (Test-Path -LiteralPath $fixture.Root) {
+                Remove-Item -LiteralPath $fixture.Root -Recurse -Force
+            }
+        }
+    }
+
+    It 'does not inject planning context when manifest is missing' {
+        $fixture = New-SessionStartFixture
+        try {
+            Remove-Item -LiteralPath (Join-Path $fixture.Root '.winsmux\manifest.yaml') -Force
+
+            $result = Invoke-NodeHookJson -RepoRoot $fixture.Root -HookRelativePath '.claude\hooks\sh-session-start.js' -Payload ([ordered]@{
+                session_id      = 'session-start-no-manifest'
+                hook_event_name = 'SessionStart'
+            }) -EnvironmentVariables @{
+                WINSMUX_BACKLOG_PATH = $fixture.BacklogPath
+            }
+
+            $result.ExitCode | Should -Be 0
+            $context = [string]$result.Json.hookSpecificOutput.additionalContext
+            $context | Should -Not -Match '\[winsmux-resume\] Planning:'
+            $context | Should -Not -Match '\[winsmux-resume\] Session:'
+        } finally {
+            if (Test-Path -LiteralPath $fixture.Root) {
+                Remove-Item -LiteralPath $fixture.Root -Recurse -Force
+            }
+        }
+    }
+
+    It 'clears stale winsmux resume state when resume sources disappear' {
+        $fixture = New-SessionStartFixture
+        try {
+            $payload = [ordered]@{
+                session_id      = 'session-start-reset'
+                hook_event_name = 'SessionStart'
+            }
+            $environment = @{
+                WINSMUX_BACKLOG_PATH = $fixture.BacklogPath
+            }
+
+            $first = Invoke-NodeHookJson -RepoRoot $fixture.Root -HookRelativePath '.claude\hooks\sh-session-start.js' -Payload $payload -EnvironmentVariables $environment
+            $first.ExitCode | Should -Be 0
+
+            Remove-Item -LiteralPath (Join-Path $fixture.Root '.winsmux\manifest.yaml') -Force
+            Remove-Item -LiteralPath $fixture.BacklogPath -Force
+
+            $second = Invoke-NodeHookJson -RepoRoot $fixture.Root -HookRelativePath '.claude\hooks\sh-session-start.js' -Payload $payload -EnvironmentVariables $environment
+
+            $second.ExitCode | Should -Be 0
+            $context = [string]$second.Json.hookSpecificOutput.additionalContext
+            $context | Should -Not -Match '\[winsmux-resume\]'
+
+            $sessionPath = Join-Path $fixture.Root '.shield-harness\session.json'
+            $session = Get-Content -LiteralPath $sessionPath -Raw -Encoding UTF8 | ConvertFrom-Json -Depth 20
+            $session.winsmux_resume.manifest_path | Should -BeNullOrEmpty
+            $session.winsmux_resume.backlog_path | Should -BeNullOrEmpty
+            @($session.winsmux_resume.task_ids).Count | Should -Be 0
+            $session.winsmux_resume.pane_count | Should -Be 0
+        } finally {
+            if (Test-Path -LiteralPath $fixture.Root) {
+                Remove-Item -LiteralPath $fixture.Root -Recurse -Force
             }
         }
     }


### PR DESCRIPTION
## Summary
- inject SessionStart resume context from .winsmux/manifest.yaml
- include planning context from acklog.yaml only when manifest-backed resume state exists
- add regression coverage for missing manifest and stale session reset paths

## Validation
- Invoke-Pester .\\tests\\HarnessContract.Tests.ps1 -Output Detailed
- pwsh -NoProfile -File .\\scripts\\git-guard.ps1 -Mode full
- pwsh -NoProfile -File .\\scripts\\audit-public-surface.ps1

## Review
- one follow-up review agent is still 
o result yet; manual diff review completed while waiting