### PR TITLE
TASK-217c: Extract headless server argument boundary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,6 +142,18 @@ Rules:
    - Keep helper files such as templates outside the main TOC by using a non-book prefix like `_`.
    - Update the index note when a new chapter note is added.
 8. If the session did not use or discuss Rust-adjacent commands, no learning-note update is required.
+9. Keep the external Rust learning note at the same Japanese readability bar as `README.ja.md`.
+   - Write for a beginner who does not know the project internals.
+   - Prefer short paragraphs, explicit subjects, and concrete verbs.
+   - Do not mix maintainer shorthand, untranslated workflow jargon, and English noun chains into the body text.
+   - When a section needs both concept and procedure, split them instead of compressing them into one paragraph.
+10. Treat the external Rust learning note as user-facing Japanese, not as maintainer scratch notes.
+    - Keep local paths, private planning roots, and operator-only rituals out of the note body unless they are strictly required for the concrete example.
+    - If a repo-specific example is needed, explain the purpose of the command before naming the file or module.
+    - Preserve the “what it does / when to use it / winsmux example / Rust Book link” structure when revising existing entries.
+11. Japanese updates to the external Rust learning note require an `Opus` review result in the same session.
+    - The review must check readability, mixed-language drift, and whether the note still reads at the same level as `README.ja.md`.
+    - If `Opus` is unavailable, stop before treating the learning-note update as complete and record the blocker in `.claude/local/operator-handoff.md`.
 
 ## Private Maintainer Skill Gate
 

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -21,6 +21,7 @@ mod util;
 mod format;
 mod help;
 mod server;
+mod terminal_engine;
 mod client;
 mod app;
 mod ssh_input;
@@ -43,7 +44,6 @@ use crate::session::{cleanup_stale_port_files, read_session_key, send_control,
     send_control_with_response, resolve_last_session_name, resolve_default_session_name,
     kill_remaining_server_processes};
 use crate::rendering::apply_cursor_style;
-use crate::server::run_server;
 use crate::client::run_remote;
 use crate::ssh_input::{send_mouse_enable, InputSource};
 
@@ -386,31 +386,8 @@ fn run_main() -> io::Result<()> {
             }
             "server" => {
                 // Internal command - run headless server (used when spawning background server)
-                let name = args.iter().position(|a| a == "-s").and_then(|i| args.get(i+1)).map(|s| s.clone()).unwrap_or_else(|| "default".to_string());
-                // Parse -L socket name for namespace isolation
-                let server_socket_name = args.iter().position(|a| a == "-L").and_then(|i| args.get(i+1)).map(|s| s.clone());
-                // Check for initial command via -c flag (shell-wrapped)
-                let initial_cmd = args.iter().position(|a| a == "-c").and_then(|i| args.get(i+1)).map(|s| s.clone());
-                // Parse start directory via -d flag
-                let srv_start_dir = args.iter().position(|a| a == "-d").and_then(|i| args.get(i+1)).map(|s| s.clone());
-                // Parse window name via -n flag
-                let srv_window_name = args.iter().position(|a| a == "-n").and_then(|i| args.get(i+1)).map(|s| s.clone());
-                // Parse initial dimensions via -x / -y flags
-                let srv_init_width = args.iter().position(|a| a == "-x").and_then(|i| args.get(i+1)).and_then(|s| s.parse::<u16>().ok());
-                let srv_init_height = args.iter().position(|a| a == "-y").and_then(|i| args.get(i+1)).and_then(|s| s.parse::<u16>().ok());
-                let srv_init_size = match (srv_init_width, srv_init_height) {
-                    (Some(w), Some(h)) => Some((w, h)),
-                    (Some(w), None) => Some((w, 24)),
-                    (None, Some(h)) => Some((80, h)),
-                    _ => None,
-                };
-                // Parse session group target via -g flag
-                let srv_group_target = args.iter().position(|a| a == "-g").and_then(|i| args.get(i+1)).map(|s| s.clone());
-                // Check for raw command after -- (direct execution)
-                let raw_cmd: Option<Vec<String>> = args.iter().position(|a| a == "--").map(|pos| {
-                    args.iter().skip(pos + 1).cloned().collect()
-                }).filter(|v: &Vec<String>| !v.is_empty());
-                return run_server(name, server_socket_name, initial_cmd, raw_cmd, srv_start_dir, srv_window_name, srv_init_size, srv_group_target);
+                let config = terminal_engine::parse_headless_server_config(&args);
+                return terminal_engine::run_headless_server(config);
             }
             "new-session" | "new" => {
                 // Prevent nesting: block new-session inside an existing psmux session
@@ -612,48 +589,19 @@ fn run_main() -> io::Result<()> {
                 if !claimed_warm {
                 // Cold path: spawn a background server from scratch
                 let exe = std::env::current_exe().unwrap_or_else(|_| std::path::PathBuf::from("psmux"));
-                let mut server_args: Vec<String> = vec!["server".into(), "-s".into(), name.clone()];
-                // Pass -L socket name to server for namespace isolation
-                if let Some(ref l) = l_socket_name {
-                    server_args.push("-L".into());
-                    server_args.push(l.clone());
-                }
-                // Pass initial command if provided
-                if let Some(ref init_cmd) = initial_cmd {
-                    server_args.push("-c".into());
-                    server_args.push(init_cmd.clone());
-                }
-                // Pass start directory to server
-                if let Some(ref dir) = start_dir {
-                    server_args.push("-d".into());
-                    server_args.push(dir.clone());
-                }
-                // Pass window name to server
-                if let Some(ref wn) = window_name {
-                    server_args.push("-n".into());
-                    server_args.push(wn.clone());
-                }
-                // Pass initial dimensions to server
-                if let Some(w) = init_width {
-                    server_args.push("-x".into());
-                    server_args.push(w.to_string());
-                }
-                if let Some(h) = init_height {
-                    server_args.push("-y".into());
-                    server_args.push(h.to_string());
-                }
-                // Pass session group target to server
-                if let Some(ref gt) = group_target {
-                    server_args.push("-g".into());
-                    server_args.push(gt.clone());
-                }
-                // Pass raw command args (direct execution) if -- was used
-                if let Some(ref raw_args) = raw_cmd_args {
-                    server_args.push("--".into());
-                    for a in raw_args {
-                        server_args.push(a.clone());
-                    }
-                }
+                let server_args = terminal_engine::build_headless_server_args(
+                    &terminal_engine::HeadlessServerConfig {
+                        session_name: name.clone(),
+                        socket_name: l_socket_name.clone(),
+                        initial_command: initial_cmd.clone(),
+                        raw_command: raw_cmd_args.clone(),
+                        start_dir: start_dir.clone(),
+                        window_name: window_name.clone(),
+                        initial_width: init_width,
+                        initial_height: init_height,
+                        group_target: group_target.clone(),
+                    },
+                );
                 // On Windows, mark parent's stdout/stderr as non-inheritable before
                 // spawning the server. This prevents the server from inheriting
                 // PowerShell's redirect pipes (which would cause the parent to hang
@@ -2354,21 +2302,20 @@ fn run_main() -> io::Result<()> {
                 let _ = std::fs::remove_file(&warm_port_path);
                 // Spawn the warm server
                 let exe = std::env::current_exe().unwrap_or_else(|_| std::path::PathBuf::from("psmux"));
-                let mut server_args: Vec<String> = vec!["server".into(), "-s".into(), "__warm__".into()];
-                if let Some(ref l) = l_socket_name {
-                    server_args.push("-L".into());
-                    server_args.push(l.clone());
-                }
+                let mut config = terminal_engine::HeadlessServerConfig {
+                    session_name: "__warm__".to_string(),
+                    socket_name: l_socket_name.clone(),
+                    ..terminal_engine::HeadlessServerConfig::default()
+                };
                 // Detect terminal size for the warm server
                 if let Ok((tw, th)) = crossterm::terminal::size() {
                     let h = th.saturating_sub(1);
                     if tw > 0 && h > 0 {
-                        server_args.push("-x".into());
-                        server_args.push(tw.to_string());
-                        server_args.push("-y".into());
-                        server_args.push(h.to_string());
+                        config.initial_width = Some(tw);
+                        config.initial_height = Some(h);
                     }
                 }
+                let server_args = terminal_engine::build_headless_server_args(&config);
                 #[cfg(windows)]
                 crate::platform::spawn_server_hidden(&exe, &server_args)?;
                 #[cfg(not(windows))]
@@ -2579,7 +2526,12 @@ fn run_main() -> io::Result<()> {
         if !warm_claimed {
             // Cold path: spawn a new background server
             let exe = std::env::current_exe().unwrap_or_else(|_| std::path::PathBuf::from("psmux"));
-            let server_args: Vec<String> = vec!["server".into(), "-s".into(), session_name.clone()];
+            let server_args = terminal_engine::build_headless_server_args(
+                &terminal_engine::HeadlessServerConfig {
+                    session_name: session_name.clone(),
+                    ..terminal_engine::HeadlessServerConfig::default()
+                },
+            );
             #[cfg(windows)]
             crate::platform::spawn_server_hidden(&exe, &server_args)?;
             #[cfg(not(windows))]

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -588,20 +588,17 @@ fn run_main() -> io::Result<()> {
 
                 if !claimed_warm {
                 // Cold path: spawn a background server from scratch
-                let exe = std::env::current_exe().unwrap_or_else(|_| std::path::PathBuf::from("psmux"));
-                let server_args = terminal_engine::build_headless_server_args(
-                    &terminal_engine::HeadlessServerConfig {
-                        session_name: name.clone(),
-                        socket_name: l_socket_name.clone(),
-                        initial_command: initial_cmd.clone(),
-                        raw_command: raw_cmd_args.clone(),
-                        start_dir: start_dir.clone(),
-                        window_name: window_name.clone(),
-                        initial_width: init_width,
-                        initial_height: init_height,
-                        group_target: group_target.clone(),
-                    },
-                );
+                let server_config = terminal_engine::HeadlessServerConfig {
+                    session_name: name.clone(),
+                    socket_name: l_socket_name.clone(),
+                    initial_command: initial_cmd.clone(),
+                    raw_command: raw_cmd_args.clone(),
+                    start_dir: start_dir.clone(),
+                    window_name: window_name.clone(),
+                    initial_width: init_width,
+                    initial_height: init_height,
+                    group_target: group_target.clone(),
+                };
                 // On Windows, mark parent's stdout/stderr as non-inheritable before
                 // spawning the server. This prevents the server from inheriting
                 // PowerShell's redirect pipes (which would cause the parent to hang
@@ -624,19 +621,7 @@ fn run_main() -> io::Result<()> {
                         SetHandleInformation(stderr, HANDLE_FLAG_INHERIT, 0);
                     }
                 }
-                // Spawn server with a hidden console window via CreateProcessW.
-                // This gives ConPTY a real console while keeping the window invisible.
-                #[cfg(windows)]
-                crate::platform::spawn_server_hidden(&exe, &server_args)?;
-                #[cfg(not(windows))]
-                {
-                    let mut cmd = std::process::Command::new(&exe);
-                    for a in &server_args { cmd.arg(a); }
-                    cmd.stdin(std::process::Stdio::null());
-                    cmd.stdout(std::process::Stdio::null());
-                    cmd.stderr(std::process::Stdio::null());
-                    let _child = cmd.spawn().map_err(|e| io::Error::new(io::ErrorKind::Other, format!("failed to spawn server: {e}")))?;
-                }
+                terminal_engine::spawn_headless_server(&server_config)?;
                 } // end if !claimed_warm (cold path)
                 } // end else (not PSMUX_REMOTE_ATTACH)
                 
@@ -2301,7 +2286,6 @@ fn run_main() -> io::Result<()> {
                 // Clean up stale port file if any
                 let _ = std::fs::remove_file(&warm_port_path);
                 // Spawn the warm server
-                let exe = std::env::current_exe().unwrap_or_else(|_| std::path::PathBuf::from("psmux"));
                 let mut config = terminal_engine::HeadlessServerConfig {
                     session_name: "__warm__".to_string(),
                     socket_name: l_socket_name.clone(),
@@ -2315,18 +2299,7 @@ fn run_main() -> io::Result<()> {
                         config.initial_height = Some(h);
                     }
                 }
-                let server_args = terminal_engine::build_headless_server_args(&config);
-                #[cfg(windows)]
-                crate::platform::spawn_server_hidden(&exe, &server_args)?;
-                #[cfg(not(windows))]
-                {
-                    let mut cmd = std::process::Command::new(&exe);
-                    for a in &server_args { cmd.arg(a); }
-                    cmd.stdin(std::process::Stdio::null());
-                    cmd.stdout(std::process::Stdio::null());
-                    cmd.stderr(std::process::Stdio::null());
-                    let _child = cmd.spawn().map_err(|e| io::Error::new(io::ErrorKind::Other, format!("failed to spawn warm server: {e}")))?;
-                }
+                terminal_engine::spawn_headless_server(&config)?;
                 return Ok(());
             }
             // confirm-before - Ask for confirmation before running a command
@@ -2525,24 +2498,12 @@ fn run_main() -> io::Result<()> {
 
         if !warm_claimed {
             // Cold path: spawn a new background server
-            let exe = std::env::current_exe().unwrap_or_else(|_| std::path::PathBuf::from("psmux"));
-            let server_args = terminal_engine::build_headless_server_args(
+            terminal_engine::spawn_headless_server(
                 &terminal_engine::HeadlessServerConfig {
                     session_name: session_name.clone(),
                     ..terminal_engine::HeadlessServerConfig::default()
                 },
-            );
-            #[cfg(windows)]
-            crate::platform::spawn_server_hidden(&exe, &server_args)?;
-            #[cfg(not(windows))]
-            {
-                let mut cmd = std::process::Command::new(&exe);
-                for a in &server_args { cmd.arg(a); }
-                cmd.stdin(std::process::Stdio::null());
-                cmd.stdout(std::process::Stdio::null());
-                cmd.stderr(std::process::Stdio::null());
-                let _child = cmd.spawn().map_err(|e| io::Error::new(io::ErrorKind::Other, format!("failed to spawn server: {e}")))?;
-            }
+            )?;
 
             // Wait for server to start (fast polling — port file is written early)
             for _ in 0..500 {

--- a/core/src/server/mod.rs
+++ b/core/src/server/mod.rs
@@ -137,32 +137,13 @@ fn spawn_warm_server(app: &AppState) {
         let warm_key_path = format!("{}\\.psmux\\{}.key", home, warm_base);
         let _ = std::fs::remove_file(&warm_key_path);
     }
-    let exe = std::env::current_exe().unwrap_or_else(|_| std::path::PathBuf::from("psmux"));
-    let mut args: Vec<String> = vec!["server".into(), "-s".into(), "__warm__".into()];
-    if let Some(ref sn) = app.socket_name {
-        args.push("-L".into());
-        args.push(sn.clone());
-    }
     // Pass current terminal dimensions so the warm server's first window
     // and warm pane are spawned at the right size.
     let area = app.last_window_area;
-    if area.width > 1 && area.height > 1 {
-        args.push("-x".into());
-        args.push(area.width.to_string());
-        args.push("-y".into());
-        args.push(area.height.to_string());
-    }
-    #[cfg(windows)]
-    { let _ = crate::platform::spawn_server_hidden(&exe, &args); }
-    #[cfg(not(windows))]
-    {
-        let mut cmd = std::process::Command::new(&exe);
-        for a in &args { cmd.arg(a); }
-        cmd.stdin(std::process::Stdio::null());
-        cmd.stdout(std::process::Stdio::null());
-        cmd.stderr(std::process::Stdio::null());
-        let _ = cmd.spawn();
-    }
+    let initial_size = (area.width > 1 && area.height > 1).then_some((area.width, area.height));
+    let config =
+        crate::terminal_engine::HeadlessServerConfig::warm(app.socket_name.clone(), initial_size);
+    let _ = crate::terminal_engine::spawn_headless_server(&config);
 }
 
 /// Parse a popup dimension spec: "80" (absolute) or "95%" (percentage of term_dim).

--- a/core/src/terminal_engine.rs
+++ b/core/src/terminal_engine.rs
@@ -33,6 +33,20 @@ impl HeadlessServerConfig {
     pub(crate) fn initial_size(&self) -> Option<(u16, u16)> {
         initial_size_from_parts(self.initial_width, self.initial_height)
     }
+
+    pub(crate) fn warm(socket_name: Option<String>, initial_size: Option<(u16, u16)>) -> Self {
+        let (initial_width, initial_height) = initial_size
+            .map(|(width, height)| (Some(width), Some(height)))
+            .unwrap_or((None, None));
+
+        Self {
+            session_name: "__warm__".to_string(),
+            socket_name,
+            initial_width,
+            initial_height,
+            ..Self::default()
+        }
+    }
 }
 
 pub(crate) fn parse_headless_server_config(args: &[String]) -> HeadlessServerConfig {
@@ -248,6 +262,26 @@ mod tests {
         assert_eq!(
             build_headless_server_args(&config),
             vec!["server", "-s", "work", "-L", "ops", "--", "pwsh", "-NoLogo"]
+        );
+    }
+
+    #[test]
+    fn warm_config_sets_session_socket_and_size() {
+        let config = HeadlessServerConfig::warm(Some("ops".to_string()), Some((120, 30)));
+
+        assert_eq!(
+            build_headless_server_args(&config),
+            vec!["server", "-s", "__warm__", "-L", "ops", "-x", "120", "-y", "30"]
+        );
+    }
+
+    #[test]
+    fn warm_config_allows_missing_size() {
+        let config = HeadlessServerConfig::warm(Some("ops".to_string()), None);
+
+        assert_eq!(
+            build_headless_server_args(&config),
+            vec!["server", "-s", "__warm__", "-L", "ops"]
         );
     }
 }

--- a/core/src/terminal_engine.rs
+++ b/core/src/terminal_engine.rs
@@ -102,6 +102,12 @@ pub(crate) fn run_headless_server(config: HeadlessServerConfig) -> io::Result<()
     )
 }
 
+pub(crate) fn spawn_headless_server(config: &HeadlessServerConfig) -> io::Result<()> {
+    let exe = std::env::current_exe().unwrap_or_else(|_| std::path::PathBuf::from("psmux"));
+    let args = build_headless_server_args(config);
+    spawn_headless_server_process(&exe, &args)
+}
+
 fn flag_value(args: &[String], flag: &str) -> Option<String> {
     args.iter()
         .take_while(|arg| arg.as_str() != "--")
@@ -131,6 +137,29 @@ fn initial_size_from_parts(width: Option<u16>, height: Option<u16>) -> Option<(u
         (None, Some(height)) => Some((80, height)),
         _ => None,
     }
+}
+
+#[cfg(windows)]
+fn spawn_headless_server_process(exe: &std::path::Path, args: &[String]) -> io::Result<()> {
+    crate::platform::spawn_server_hidden(exe, args)
+}
+
+#[cfg(not(windows))]
+fn spawn_headless_server_process(exe: &std::path::Path, args: &[String]) -> io::Result<()> {
+    let mut cmd = std::process::Command::new(exe);
+    for arg in args {
+        cmd.arg(arg);
+    }
+    cmd.stdin(std::process::Stdio::null());
+    cmd.stdout(std::process::Stdio::null());
+    cmd.stderr(std::process::Stdio::null());
+    let _child = cmd.spawn().map_err(|err| {
+        io::Error::new(
+            io::ErrorKind::Other,
+            format!("failed to spawn server: {err}"),
+        )
+    })?;
+    Ok(())
 }
 
 #[cfg(test)]

--- a/core/src/terminal_engine.rs
+++ b/core/src/terminal_engine.rs
@@ -1,0 +1,224 @@
+use std::io;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct HeadlessServerConfig {
+    pub(crate) session_name: String,
+    pub(crate) socket_name: Option<String>,
+    pub(crate) initial_command: Option<String>,
+    pub(crate) raw_command: Option<Vec<String>>,
+    pub(crate) start_dir: Option<String>,
+    pub(crate) window_name: Option<String>,
+    pub(crate) initial_width: Option<u16>,
+    pub(crate) initial_height: Option<u16>,
+    pub(crate) group_target: Option<String>,
+}
+
+impl Default for HeadlessServerConfig {
+    fn default() -> Self {
+        Self {
+            session_name: "default".to_string(),
+            socket_name: None,
+            initial_command: None,
+            raw_command: None,
+            start_dir: None,
+            window_name: None,
+            initial_width: None,
+            initial_height: None,
+            group_target: None,
+        }
+    }
+}
+
+impl HeadlessServerConfig {
+    pub(crate) fn initial_size(&self) -> Option<(u16, u16)> {
+        initial_size_from_parts(self.initial_width, self.initial_height)
+    }
+}
+
+pub(crate) fn parse_headless_server_config(args: &[String]) -> HeadlessServerConfig {
+    let width = flag_value(args, "-x").and_then(|value| value.parse::<u16>().ok());
+    let height = flag_value(args, "-y").and_then(|value| value.parse::<u16>().ok());
+
+    HeadlessServerConfig {
+        session_name: flag_value(args, "-s").unwrap_or_else(|| "default".to_string()),
+        socket_name: flag_value(args, "-L"),
+        initial_command: flag_value(args, "-c"),
+        raw_command: raw_command_after_separator(args),
+        start_dir: flag_value(args, "-d"),
+        window_name: flag_value(args, "-n"),
+        initial_width: width,
+        initial_height: height,
+        group_target: flag_value(args, "-g"),
+    }
+}
+
+pub(crate) fn build_headless_server_args(config: &HeadlessServerConfig) -> Vec<String> {
+    let mut args = vec![
+        "server".to_string(),
+        "-s".to_string(),
+        config.session_name.clone(),
+    ];
+
+    push_flag_value(&mut args, "-L", config.socket_name.as_deref());
+    push_flag_value(&mut args, "-c", config.initial_command.as_deref());
+    push_flag_value(&mut args, "-d", config.start_dir.as_deref());
+    push_flag_value(&mut args, "-n", config.window_name.as_deref());
+    push_flag_value(
+        &mut args,
+        "-x",
+        config.initial_width.as_ref().map(u16::to_string).as_deref(),
+    );
+    push_flag_value(
+        &mut args,
+        "-y",
+        config
+            .initial_height
+            .as_ref()
+            .map(u16::to_string)
+            .as_deref(),
+    );
+    push_flag_value(&mut args, "-g", config.group_target.as_deref());
+
+    if let Some(raw_command) = &config.raw_command {
+        args.push("--".to_string());
+        args.extend(raw_command.iter().cloned());
+    }
+
+    args
+}
+
+pub(crate) fn run_headless_server(config: HeadlessServerConfig) -> io::Result<()> {
+    let initial_size = config.initial_size();
+
+    crate::server::run_server(
+        config.session_name,
+        config.socket_name,
+        config.initial_command,
+        config.raw_command,
+        config.start_dir,
+        config.window_name,
+        initial_size,
+        config.group_target,
+    )
+}
+
+fn flag_value(args: &[String], flag: &str) -> Option<String> {
+    args.iter()
+        .take_while(|arg| arg.as_str() != "--")
+        .position(|arg| arg == flag)
+        .and_then(|index| args.get(index + 1))
+        .cloned()
+}
+
+fn push_flag_value(args: &mut Vec<String>, flag: &str, value: Option<&str>) {
+    if let Some(value) = value {
+        args.push(flag.to_string());
+        args.push(value.to_string());
+    }
+}
+
+fn raw_command_after_separator(args: &[String]) -> Option<Vec<String>> {
+    args.iter()
+        .position(|arg| arg == "--")
+        .map(|index| args.iter().skip(index + 1).cloned().collect::<Vec<_>>())
+        .filter(|items| !items.is_empty())
+}
+
+fn initial_size_from_parts(width: Option<u16>, height: Option<u16>) -> Option<(u16, u16)> {
+    match (width, height) {
+        (Some(width), Some(height)) => Some((width, height)),
+        (Some(width), None) => Some((width, 24)),
+        (None, Some(height)) => Some((80, height)),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        build_headless_server_args, initial_size_from_parts, parse_headless_server_config,
+        HeadlessServerConfig,
+    };
+
+    fn args(items: &[&str]) -> Vec<String> {
+        items.iter().map(|item| item.to_string()).collect()
+    }
+
+    #[test]
+    fn parse_headless_config_defaults_session_name() {
+        let config = parse_headless_server_config(&args(&["winsmux", "server"]));
+        assert_eq!(config.session_name, "default");
+        assert_eq!(config.initial_size(), None);
+        assert_eq!(config.raw_command, None);
+    }
+
+    #[test]
+    fn parse_headless_config_reads_server_flags() {
+        let config = parse_headless_server_config(&args(&[
+            "winsmux", "server", "-s", "work", "-L", "ops", "-c", "pwsh", "-d", "C:/repo", "-n",
+            "main", "-x", "120", "-y", "40", "-g", "shared",
+        ]));
+
+        assert_eq!(config.session_name, "work");
+        assert_eq!(config.socket_name.as_deref(), Some("ops"));
+        assert_eq!(config.initial_command.as_deref(), Some("pwsh"));
+        assert_eq!(config.start_dir.as_deref(), Some("C:/repo"));
+        assert_eq!(config.window_name.as_deref(), Some("main"));
+        assert_eq!(config.initial_size(), Some((120, 40)));
+        assert_eq!(config.group_target.as_deref(), Some("shared"));
+    }
+
+    #[test]
+    fn parse_headless_config_keeps_raw_command_after_separator() {
+        let config = parse_headless_server_config(&args(&[
+            "winsmux", "server", "-s", "work", "--", "pwsh", "-NoLogo", "-x", "200",
+        ]));
+
+        assert_eq!(
+            config.raw_command,
+            Some(vec![
+                "pwsh".to_string(),
+                "-NoLogo".to_string(),
+                "-x".to_string(),
+                "200".to_string()
+            ])
+        );
+        assert_eq!(config.initial_size(), None);
+    }
+
+    #[test]
+    fn initial_size_keeps_legacy_fallbacks() {
+        assert_eq!(initial_size_from_parts(Some(100), None), Some((100, 24)));
+        assert_eq!(initial_size_from_parts(None, Some(30)), Some((80, 30)));
+        assert_eq!(initial_size_from_parts(None, None), None);
+    }
+
+    #[test]
+    fn build_headless_args_keeps_only_provided_size_flags() {
+        let config = HeadlessServerConfig {
+            session_name: "work".to_string(),
+            initial_width: Some(100),
+            ..HeadlessServerConfig::default()
+        };
+
+        assert_eq!(
+            build_headless_server_args(&config),
+            vec!["server", "-s", "work", "-x", "100"]
+        );
+    }
+
+    #[test]
+    fn build_headless_args_keeps_raw_command_after_separator() {
+        let config = HeadlessServerConfig {
+            session_name: "work".to_string(),
+            socket_name: Some("ops".to_string()),
+            raw_command: Some(vec!["pwsh".to_string(), "-NoLogo".to_string()]),
+            ..HeadlessServerConfig::default()
+        };
+
+        assert_eq!(
+            build_headless_server_args(&config),
+            vec!["server", "-s", "work", "-L", "ops", "--", "pwsh", "-NoLogo"]
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add `terminal_engine` as the first headless server boundary
- move internal `server` argument parsing and spawn-argument construction out of `main.rs`
- keep runtime execution delegated to `server::run_server`
- raise the external Rust learning note quality gate in `AGENTS.md`

## Validation
- `cargo test --manifest-path .\core\Cargo.toml terminal_engine -- --nocapture`
- `cargo test --manifest-path .\core\Cargo.toml -- --nocapture`
- `pwsh -NoProfile -File .\scripts\git-guard.ps1 -Mode full`
- `pwsh -NoProfile -File .\scripts\audit-public-surface.ps1`
- `codex exec review --uncommitted -m gpt-5.3-codex`
- subagent review: no findings
- `Opus` review for external Rust learning note: PASS

## Notes
- `server::run_server` is still the execution path in this change.
- Args after `--` remain raw command args and are not parsed as server flags.
