### PR TITLE
TASK-265: Add Rust ledger snapshot skeleton

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -29,6 +29,10 @@ path = "tests-rs/manifest_contract.rs"
 name = "event_contract"
 path = "tests-rs/event_contract.rs"
 
+[[test]]
+name = "ledger_contract"
+path = "tests-rs/ledger_contract.rs"
+
 # Windows only
 [target.'cfg(not(windows))'.dependencies]
 [target.'cfg(windows)'.dependencies]
@@ -64,8 +68,6 @@ vt100 = { version = "0.16.5", path = "crates/vt100-winsmux", package = "vt100-wi
 unicode-width = "0.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+serde_yaml = "0.9"
 regex = "1"
 glob = "0.3"
-
-[dev-dependencies]
-serde_yaml = "0.9"

--- a/core/src/ledger.rs
+++ b/core/src/ledger.rs
@@ -1,0 +1,170 @@
+use crate::event_contract::{parse_event_jsonl, EventRecord};
+use crate::manifest_contract::{NormalizedManifestPane, WinsmuxManifest};
+use std::collections::{HashMap, HashSet};
+
+#[derive(Debug)]
+pub struct LedgerSnapshot {
+    manifest: WinsmuxManifest,
+    events: Vec<EventRecord>,
+    panes: Vec<NormalizedManifestPane>,
+    panes_by_id: HashMap<String, NormalizedManifestPane>,
+}
+
+impl LedgerSnapshot {
+    pub fn from_manifest_and_events(
+        manifest_yaml: &str,
+        events_jsonl: &str,
+    ) -> Result<Self, String> {
+        let manifest = WinsmuxManifest::from_yaml(manifest_yaml)
+            .map_err(|err| format!("failed to parse manifest: {err}"))?;
+        manifest.validate()?;
+
+        let events = parse_event_jsonl(events_jsonl)?;
+        let panes = manifest.normalized_panes();
+        let panes_by_id = index_panes_by_id(&panes)?;
+
+        let snapshot = Self {
+            manifest,
+            events,
+            panes,
+            panes_by_id,
+        };
+        snapshot.validate_event_sessions()?;
+        Ok(snapshot)
+    }
+
+    pub fn session_name(&self) -> &str {
+        &self.manifest.session.name
+    }
+
+    pub fn pane_count(&self) -> usize {
+        self.panes.len()
+    }
+
+    pub fn event_count(&self) -> usize {
+        self.events.len()
+    }
+
+    pub fn pane_labels(&self) -> Vec<String> {
+        self.panes.iter().map(|pane| pane.label.clone()).collect()
+    }
+
+    pub fn events_for_pane(&self, pane_id: &str) -> Vec<&EventRecord> {
+        self.events
+            .iter()
+            .filter(|event| event.pane_id == pane_id)
+            .collect()
+    }
+
+    pub fn unknown_event_pane_ids(&self) -> Vec<String> {
+        let known: HashSet<&str> = self.panes_by_id.keys().map(String::as_str).collect();
+        let mut unknown: Vec<String> = self
+            .events
+            .iter()
+            .filter_map(|event| {
+                let pane_id = event.pane_id.trim();
+                if pane_id.is_empty() || known.contains(pane_id) {
+                    None
+                } else {
+                    Some(pane_id.to_string())
+                }
+            })
+            .collect::<HashSet<_>>()
+            .into_iter()
+            .collect();
+        unknown.sort();
+        unknown
+    }
+
+    fn validate_event_sessions(&self) -> Result<(), String> {
+        let session_name = self.session_name();
+        if session_name.trim().is_empty() {
+            return Ok(());
+        }
+
+        for event in &self.events {
+            if event.session.trim().is_empty() || event.session == session_name {
+                continue;
+            }
+
+            return Err(format!(
+                "event '{}' belongs to session '{}', expected '{}'",
+                event.event, event.session, session_name
+            ));
+        }
+
+        Ok(())
+    }
+}
+
+fn index_panes_by_id(
+    panes: &[NormalizedManifestPane],
+) -> Result<HashMap<String, NormalizedManifestPane>, String> {
+    let mut panes_by_id = HashMap::new();
+    for pane in panes {
+        let pane_id = pane.pane_id.trim();
+        if pane_id.is_empty() {
+            continue;
+        }
+        if panes_by_id
+            .insert(pane_id.to_string(), pane.clone())
+            .is_some()
+        {
+            return Err(format!("duplicate manifest pane_id '{pane_id}'"));
+        }
+    }
+    Ok(panes_by_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::LedgerSnapshot;
+
+    const MANIFEST_FIXTURE: &str = include_str!("../../tests/fixtures/rust-parity/manifest.yaml");
+    const EVENTS_FIXTURE: &str = include_str!("../../tests/fixtures/rust-parity/events.jsonl");
+
+    #[test]
+    fn ledger_snapshot_loads_manifest_and_events() {
+        let snapshot =
+            LedgerSnapshot::from_manifest_and_events(MANIFEST_FIXTURE, EVENTS_FIXTURE).unwrap();
+
+        assert_eq!(snapshot.session_name(), "winsmux-orchestra");
+        assert_eq!(snapshot.pane_count(), 2);
+        assert_eq!(snapshot.event_count(), 5);
+        assert!(snapshot.pane_labels().contains(&"builder-1".to_string()));
+        assert_eq!(snapshot.events_for_pane("%2").len(), 2);
+        assert_eq!(
+            snapshot.unknown_event_pane_ids(),
+            vec!["%7".to_string(), "%9".to_string()]
+        );
+    }
+
+    #[test]
+    fn ledger_snapshot_rejects_wrong_event_session() {
+        let events = r#"{"timestamp":"2026-04-23T12:00:00+09:00","session":"other","event":"pane.completed"}"#;
+
+        let err = LedgerSnapshot::from_manifest_and_events(MANIFEST_FIXTURE, events).unwrap_err();
+
+        assert!(err.contains("belongs to session 'other'"));
+    }
+
+    #[test]
+    fn ledger_snapshot_rejects_duplicate_manifest_pane_id() {
+        let manifest = r#"
+version: 1
+session:
+  name: winsmux-orchestra
+panes:
+  builder-1:
+    pane_id: "%2"
+    role: Builder
+  reviewer-1:
+    pane_id: "%2"
+    role: Reviewer
+"#;
+
+        let err = LedgerSnapshot::from_manifest_and_events(manifest, "").unwrap_err();
+
+        assert!(err.contains("duplicate manifest pane_id '%2'"));
+    }
+}

--- a/core/src/manifest_contract.rs
+++ b/core/src/manifest_contract.rs
@@ -1,5 +1,6 @@
+use serde::de::{MapAccess, SeqAccess, Visitor};
 use serde::{Deserialize, Deserializer};
-use std::collections::HashMap;
+use std::fmt;
 
 #[derive(Debug, Deserialize)]
 pub struct WinsmuxManifest {
@@ -20,11 +21,51 @@ pub struct ManifestSession {
     pub ended: String,
 }
 
-#[derive(Debug, Deserialize)]
-#[serde(untagged)]
+#[derive(Debug)]
 pub enum ManifestPanes {
-    Map(HashMap<String, ManifestPane>),
+    Map(Vec<(String, ManifestPane)>),
     List(Vec<ManifestPane>),
+}
+
+impl<'de> Deserialize<'de> for ManifestPanes {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_any(ManifestPanesVisitor)
+    }
+}
+
+struct ManifestPanesVisitor;
+
+impl<'de> Visitor<'de> for ManifestPanesVisitor {
+    type Value = ManifestPanes;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("a pane map or pane list")
+    }
+
+    fn visit_map<M>(self, mut access: M) -> Result<Self::Value, M::Error>
+    where
+        M: MapAccess<'de>,
+    {
+        let mut panes = Vec::new();
+        while let Some(entry) = access.next_entry::<String, ManifestPane>()? {
+            panes.push(entry);
+        }
+        Ok(ManifestPanes::Map(panes))
+    }
+
+    fn visit_seq<S>(self, mut access: S) -> Result<Self::Value, S::Error>
+    where
+        S: SeqAccess<'de>,
+    {
+        let mut panes = Vec::new();
+        while let Some(pane) = access.next_element::<ManifestPane>()? {
+            panes.push(pane);
+        }
+        Ok(ManifestPanes::List(panes))
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -195,7 +236,7 @@ impl ManifestStringList {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NormalizedManifestPane {
     pub label: String,
     pub pane_id: String,
@@ -203,7 +244,6 @@ pub struct NormalizedManifestPane {
 }
 
 impl WinsmuxManifest {
-    #[cfg(test)]
     pub fn from_yaml(content: &str) -> Result<Self, serde_yaml::Error> {
         let normalized = normalize_legacy_manifest_yaml(content);
         serde_yaml::from_str(&normalized)
@@ -268,7 +308,6 @@ impl WinsmuxManifest {
     }
 }
 
-#[cfg(test)]
 fn normalize_legacy_manifest_yaml(content: &str) -> String {
     let mut in_panes = false;
     let mut normalized = Vec::new();
@@ -294,7 +333,6 @@ fn normalize_legacy_manifest_yaml(content: &str) -> String {
     normalized.join("\n")
 }
 
-#[cfg(test)]
 fn normalize_legacy_manifest_line(line: &str) -> String {
     let Some((head, tail)) = line.split_once(':') else {
         return line.to_string();

--- a/core/tests-rs/ledger_contract.rs
+++ b/core/tests-rs/ledger_contract.rs
@@ -1,0 +1,52 @@
+#[path = "../src/manifest_contract.rs"]
+mod manifest_contract;
+
+#[path = "../src/event_contract.rs"]
+mod event_contract;
+
+#[path = "../src/ledger.rs"]
+mod ledger;
+
+const MANIFEST_FIXTURE: &str = include_str!("../../tests/fixtures/rust-parity/manifest.yaml");
+const EVENTS_FIXTURE: &str = include_str!("../../tests/fixtures/rust-parity/events.jsonl");
+
+#[test]
+fn ledger_contract_loads_frozen_manifest_and_events() {
+    let snapshot =
+        ledger::LedgerSnapshot::from_manifest_and_events(MANIFEST_FIXTURE, EVENTS_FIXTURE)
+            .expect("ledger snapshot should load frozen fixtures");
+
+    assert_eq!(snapshot.session_name(), "winsmux-orchestra");
+    assert_eq!(snapshot.pane_count(), 2);
+    assert_eq!(
+        snapshot.pane_labels(),
+        vec!["builder-1".to_string(), "reviewer-1".to_string()]
+    );
+    assert_eq!(snapshot.event_count(), 5);
+    assert_eq!(snapshot.events_for_pane("%2").len(), 2);
+    assert_eq!(
+        snapshot.unknown_event_pane_ids(),
+        vec!["%7".to_string(), "%9".to_string()]
+    );
+}
+
+#[test]
+fn ledger_contract_rejects_duplicate_manifest_pane_id() {
+    let manifest = r#"
+version: 1
+session:
+  name: winsmux-orchestra
+panes:
+  builder-1:
+    pane_id: "%2"
+    role: Builder
+  reviewer-1:
+    pane_id: "%2"
+    role: Reviewer
+"#;
+
+    let err = ledger::LedgerSnapshot::from_manifest_and_events(manifest, EVENTS_FIXTURE)
+        .expect_err("duplicate manifest pane_id must be rejected");
+
+    assert!(err.contains("duplicate manifest pane_id '%2'"));
+}

--- a/docs/project/rust-schema-freeze-inventory.md
+++ b/docs/project/rust-schema-freeze-inventory.md
@@ -166,7 +166,7 @@ Current gap:
   - `security_policy` is preserved as a manifest field
 - Planning metadata has the same bundled requirement:
   - if any of `parent_run_id`, `goal`, `task_type`, or `priority` is present, all four fields are required
-- The remaining work is to connect this contract to ledger persistence without turning it into a full manifest rewrite.
+- `TASK-265` has started connecting this contract to read-only ledger persistence without turning it into a full manifest rewrite.
 
 ## Still-loose surfaces
 
@@ -193,7 +193,30 @@ Current gap:
 - `data` is now limited to JSON object payloads, while the inner payload catalog still remains polymorphic.
 - Downstream projections still infer event meaning through conversion helpers instead of a shared typed payload catalog.
 
-### 6. `verdict`
+### 6. `ledger`
+
+Current location:
+
+- `core/src/ledger.rs`
+- `core/tests-rs/ledger_contract.rs`
+
+Current boundary:
+
+- `LedgerSnapshot` loads the frozen `manifest` and `events` fixtures together.
+- It validates the manifest and event envelope before exposing the snapshot.
+- It indexes panes by `pane_id` for later projection work.
+- It rejects duplicate manifest `pane_id` values because they make projection identity ambiguous.
+- It preserves manifest pane order separately from the lookup index.
+- It preserves unknown event pane IDs instead of rejecting them, because historical events can outlive the current manifest view.
+- It rejects events that explicitly belong to a different session.
+
+Current limitation:
+
+- The snapshot is still read-only.
+- Live `.winsmux` file ingestion remains outside this first slice.
+- `board`, `inbox`, `digest`, and `explain` are not derived from this snapshot yet.
+
+### 7. `verdict`
 
 Current location:
 
@@ -206,10 +229,11 @@ Current gap:
 
 ## Recommended order after this inventory
 
-1. Freeze actionable event payload groups on top of the new `.winsmux/events.jsonl` envelope.
-2. Keep the review-state fixture as the branch-keyed root file shape.
-3. Keep the manifest contract limited to session and pane boundary validation until ledger persistence needs more fields.
-4. Do not expand the contract work into a full runtime rewrite without a separate task.
+1. Keep `LedgerSnapshot` read-only until projection surfaces are ready.
+2. Freeze actionable event payload groups on top of the new `.winsmux/events.jsonl` envelope.
+3. Keep the review-state fixture as the branch-keyed root file shape.
+4. Keep the manifest contract limited to session and pane boundary validation until ledger persistence needs more fields.
+5. Do not expand the contract work into a full runtime rewrite without a separate task.
 
 ## Parallel work that stays safe
 


### PR DESCRIPTION
## Summary
- Add a read-only Rust ledger snapshot over frozen manifest and event fixtures.
- Preserve manifest pane order while indexing panes by pane id.
- Reject duplicate manifest pane ids and wrong-session events.
- Move the manifest YAML parser into normal builds so the ledger can later support live ingestion.

## Validation
- cargo check --manifest-path .\\core\\Cargo.toml
- cargo test --manifest-path .\\core\\Cargo.toml --test ledger_contract -- --nocapture
- cargo test --manifest-path .\\core\\Cargo.toml -- --nocapture
- git diff --check
- pwsh -NoProfile -File .\\scripts\\git-guard.ps1 -Mode full
- pwsh -NoProfile -File .\\scripts\\audit-public-surface.ps1
- codex exec review --uncommitted

## Notes
- TASK-265 remains active after this PR. This is the first read-only ledger boundary, not the full projection implementation.
- External Rust learning note was updated outside the repository and reviewed by Opus with PASS.