### PR TITLE
TASK-265: Load Rust ledger from live winsmux files

### DIFF
--- a/core/src/ledger.rs
+++ b/core/src/ledger.rs
@@ -1,6 +1,7 @@
 use crate::event_contract::{parse_event_jsonl, EventRecord};
 use crate::manifest_contract::{NormalizedManifestPane, WinsmuxManifest};
 use std::collections::{HashMap, HashSet};
+use std::path::Path;
 
 #[derive(Debug)]
 pub struct LedgerSnapshot {
@@ -11,6 +12,41 @@ pub struct LedgerSnapshot {
 }
 
 impl LedgerSnapshot {
+    pub fn from_project_dir(project_dir: impl AsRef<Path>) -> Result<Self, String> {
+        let winsmux_dir = project_dir.as_ref().join(".winsmux");
+        Self::from_paths(
+            winsmux_dir.join("manifest.yaml"),
+            winsmux_dir.join("events.jsonl"),
+        )
+    }
+
+    pub fn from_paths(
+        manifest_path: impl AsRef<Path>,
+        events_path: impl AsRef<Path>,
+    ) -> Result<Self, String> {
+        let manifest_path = manifest_path.as_ref();
+        let events_path = events_path.as_ref();
+
+        let manifest_yaml = std::fs::read_to_string(manifest_path).map_err(|err| {
+            format!(
+                "failed to read manifest '{}': {err}",
+                manifest_path.display()
+            )
+        })?;
+        let events_jsonl = match std::fs::read_to_string(events_path) {
+            Ok(content) => content,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => String::new(),
+            Err(err) => {
+                return Err(format!(
+                    "failed to read events '{}': {err}",
+                    events_path.display()
+                ));
+            }
+        };
+
+        Self::from_manifest_and_events(&manifest_yaml, &events_jsonl)
+    }
+
     pub fn from_manifest_and_events(
         manifest_yaml: &str,
         events_jsonl: &str,

--- a/core/tests-rs/ledger_contract.rs
+++ b/core/tests-rs/ledger_contract.rs
@@ -7,6 +7,10 @@ mod event_contract;
 #[path = "../src/ledger.rs"]
 mod ledger;
 
+use std::fs;
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
 const MANIFEST_FIXTURE: &str = include_str!("../../tests/fixtures/rust-parity/manifest.yaml");
 const EVENTS_FIXTURE: &str = include_str!("../../tests/fixtures/rust-parity/events.jsonl");
 
@@ -49,4 +53,64 @@ panes:
         .expect_err("duplicate manifest pane_id must be rejected");
 
     assert!(err.contains("duplicate manifest pane_id '%2'"));
+}
+
+#[test]
+fn ledger_contract_loads_live_winsmux_files() {
+    let fixture = TempProject::new("live-files");
+    fixture.write_winsmux_file("manifest.yaml", MANIFEST_FIXTURE);
+    fixture.write_winsmux_file("events.jsonl", EVENTS_FIXTURE);
+
+    let snapshot = ledger::LedgerSnapshot::from_project_dir(fixture.path())
+        .expect("ledger snapshot should load live .winsmux files");
+
+    assert_eq!(snapshot.session_name(), "winsmux-orchestra");
+    assert_eq!(snapshot.pane_count(), 2);
+    assert_eq!(snapshot.event_count(), 5);
+}
+
+#[test]
+fn ledger_contract_allows_missing_live_events_file() {
+    let fixture = TempProject::new("missing-events");
+    fixture.write_winsmux_file("manifest.yaml", MANIFEST_FIXTURE);
+
+    let snapshot = ledger::LedgerSnapshot::from_project_dir(fixture.path())
+        .expect("missing events.jsonl should be treated as an empty event stream");
+
+    assert_eq!(snapshot.session_name(), "winsmux-orchestra");
+    assert_eq!(snapshot.event_count(), 0);
+}
+
+struct TempProject {
+    root: PathBuf,
+}
+
+impl TempProject {
+    fn new(label: &str) -> Self {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock should be after unix epoch")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!(
+            "winsmux-ledger-contract-{label}-{}-{unique}",
+            std::process::id()
+        ));
+        fs::create_dir_all(root.join(".winsmux")).expect("temp .winsmux dir should be created");
+        Self { root }
+    }
+
+    fn path(&self) -> &std::path::Path {
+        &self.root
+    }
+
+    fn write_winsmux_file(&self, name: &str, content: &str) {
+        fs::write(self.root.join(".winsmux").join(name), content)
+            .expect("temp winsmux file should be written");
+    }
+}
+
+impl Drop for TempProject {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.root);
+    }
 }

--- a/docs/project/rust-schema-freeze-inventory.md
+++ b/docs/project/rust-schema-freeze-inventory.md
@@ -203,6 +203,7 @@ Current location:
 Current boundary:
 
 - `LedgerSnapshot` loads the frozen `manifest` and `events` fixtures together.
+- It can also load live `.winsmux/manifest.yaml` and `.winsmux/events.jsonl` files.
 - It validates the manifest and event envelope before exposing the snapshot.
 - It indexes panes by `pane_id` for later projection work.
 - It rejects duplicate manifest `pane_id` values because they make projection identity ambiguous.
@@ -214,7 +215,7 @@ Current boundary:
 Current limitation:
 
 - The snapshot is still read-only.
-- Live `.winsmux` file ingestion remains outside this first slice.
+- Projection code does not consume the live snapshot yet.
 - `board`, `inbox`, `digest`, and `explain` are not derived from this snapshot yet.
 
 ### 7. `verdict`


### PR DESCRIPTION
## Summary
- Add read-only live `.winsmux` file ingestion to `LedgerSnapshot`.
- Require `.winsmux/manifest.yaml` and treat a missing `.winsmux/events.jsonl` as an empty event stream.
- Keep projection wiring out of scope and update the schema-freeze inventory.

## Validation
- `rustfmt --check core\src\ledger.rs core\tests-rs\ledger_contract.rs`
- `cargo test --manifest-path .\core\Cargo.toml --test ledger_contract -- --nocapture`
- `cargo test --manifest-path .\core\Cargo.toml --test event_contract -- --nocapture`
- `cargo check --manifest-path .\core\Cargo.toml`
- `cargo test --manifest-path .\core\Cargo.toml -- --nocapture`
- `git diff --check`
- `pwsh -NoProfile -File .\scripts\git-guard.ps1 -Mode full`
- `pwsh -NoProfile -File .\scripts\audit-public-surface.ps1`
- `codex exec review --uncommitted`
- subagent review: no findings
- Rust radar: no ecosystem blocker
- Opus review for external Rust learning note: PASS

Note: `cargo fmt --manifest-path .\core\Cargo.toml -- --check` still reports pre-existing repository-wide formatting drift outside this change scope, so this PR uses targeted `rustfmt --check` for touched Rust files.

`TASK-265` remains active. Projection derivation is still not implemented.
