### PR TITLE
TASK-265: Add Rust ledger pane read model

### DIFF
--- a/core/src/ledger.rs
+++ b/core/src/ledger.rs
@@ -11,6 +11,24 @@ pub struct LedgerSnapshot {
     panes_by_id: HashMap<String, NormalizedManifestPane>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LedgerPaneReadModel {
+    pub label: String,
+    pub pane_id: String,
+    pub role: String,
+    pub task_id: String,
+    pub task: String,
+    pub task_state: String,
+    pub review_state: String,
+    pub priority: String,
+    pub branch: String,
+    pub head_sha: String,
+    pub changed_file_count: usize,
+    pub last_event: String,
+    pub last_event_at: String,
+    pub event_count: usize,
+}
+
 impl LedgerSnapshot {
     pub fn from_project_dir(project_dir: impl AsRef<Path>) -> Result<Self, String> {
         let winsmux_dir = project_dir.as_ref().join(".winsmux");
@@ -110,6 +128,31 @@ impl LedgerSnapshot {
             .collect();
         unknown.sort();
         unknown
+    }
+
+    pub fn pane_read_models(&self) -> Vec<LedgerPaneReadModel> {
+        self.panes
+            .iter()
+            .map(|pane| {
+                let event_count = self.events_for_pane(&pane.pane_id).len();
+                LedgerPaneReadModel {
+                    label: pane.label.clone(),
+                    pane_id: pane.pane_id.clone(),
+                    role: pane.role.clone(),
+                    task_id: pane.task_id.clone(),
+                    task: pane.task.clone(),
+                    task_state: pane.task_state.clone(),
+                    review_state: pane.review_state.clone(),
+                    priority: pane.priority.clone(),
+                    branch: pane.branch.clone(),
+                    head_sha: pane.head_sha.clone(),
+                    changed_file_count: pane.changed_file_count,
+                    last_event: pane.last_event.clone(),
+                    last_event_at: pane.last_event_at.clone(),
+                    event_count,
+                }
+            })
+            .collect()
     }
 
     fn validate_event_sessions(&self) -> Result<(), String> {

--- a/core/src/manifest_contract.rs
+++ b/core/src/manifest_contract.rs
@@ -241,6 +241,16 @@ pub struct NormalizedManifestPane {
     pub label: String,
     pub pane_id: String,
     pub role: String,
+    pub task_id: String,
+    pub task: String,
+    pub task_state: String,
+    pub review_state: String,
+    pub priority: String,
+    pub branch: String,
+    pub head_sha: String,
+    pub changed_file_count: usize,
+    pub last_event: String,
+    pub last_event_at: String,
 }
 
 impl WinsmuxManifest {
@@ -253,23 +263,11 @@ impl WinsmuxManifest {
         match &self.panes {
             ManifestPanes::Map(panes) => panes
                 .iter()
-                .map(|(label, pane)| NormalizedManifestPane {
-                    label: if pane.label.is_empty() {
-                        label.clone()
-                    } else {
-                        pane.label.clone()
-                    },
-                    pane_id: pane.pane_id.clone(),
-                    role: pane.role.clone(),
-                })
+                .map(|(label, pane)| normalize_manifest_pane(label, pane))
                 .collect(),
             ManifestPanes::List(panes) => panes
                 .iter()
-                .map(|pane| NormalizedManifestPane {
-                    label: pane.label.clone(),
-                    pane_id: pane.pane_id.clone(),
-                    role: pane.role.clone(),
-                })
+                .map(|pane| normalize_manifest_pane(&pane.label, pane))
                 .collect(),
         }
     }
@@ -305,6 +303,28 @@ impl WinsmuxManifest {
                 .map(|pane| (pane.label.clone(), pane))
                 .collect(),
         }
+    }
+}
+
+fn normalize_manifest_pane(label: &str, pane: &ManifestPane) -> NormalizedManifestPane {
+    NormalizedManifestPane {
+        label: if pane.label.is_empty() {
+            label.to_string()
+        } else {
+            pane.label.clone()
+        },
+        pane_id: pane.pane_id.clone(),
+        role: pane.role.clone(),
+        task_id: pane.task_id.clone(),
+        task: pane.task.clone(),
+        task_state: pane.task_state.clone(),
+        review_state: pane.review_state.clone(),
+        priority: pane.priority.clone(),
+        branch: pane.branch.clone(),
+        head_sha: pane.head_sha.clone(),
+        changed_file_count: pane.changed_file_count.value().unwrap_or(0),
+        last_event: pane.last_event.clone(),
+        last_event_at: pane.last_event_at.clone(),
     }
 }
 
@@ -391,9 +411,12 @@ fn validate_pane(label: &str, pane: &ManifestPane) -> Result<(), String> {
             ));
         }
     }
-    if pane.changed_file_count.value().unwrap_or(usize::MAX) > 0
-        && pane.changed_files.values().is_empty()
-    {
+    let Some(changed_file_count) = pane.changed_file_count.value() else {
+        return Err(format!(
+            "manifest pane '{label}' changed_file_count must be numeric"
+        ));
+    };
+    if changed_file_count > 0 && pane.changed_files.values().is_empty() {
         return Err(format!(
             "manifest pane '{label}' changed_file_count requires changed_files"
         ));
@@ -530,6 +553,28 @@ panes:
         )
         .unwrap();
         manifest.validate().unwrap();
+    }
+
+    #[test]
+    fn manifest_rejects_non_numeric_changed_file_count() {
+        let manifest = WinsmuxManifest::from_yaml(
+            r#"
+version: 1
+session:
+  project_dir: C:\repo
+panes:
+  builder-1:
+    pane_id: "%2"
+    role: Builder
+    changed_file_count: nope
+    changed_files: scripts/winsmux-core.ps1
+"#,
+        )
+        .unwrap();
+
+        let err = manifest.validate().unwrap_err();
+
+        assert!(err.contains("changed_file_count must be numeric"));
     }
 
     #[test]

--- a/core/tests-rs/ledger_contract.rs
+++ b/core/tests-rs/ledger_contract.rs
@@ -35,6 +35,31 @@ fn ledger_contract_loads_frozen_manifest_and_events() {
 }
 
 #[test]
+fn ledger_contract_exposes_ordered_pane_read_models() {
+    let snapshot =
+        ledger::LedgerSnapshot::from_manifest_and_events(MANIFEST_FIXTURE, EVENTS_FIXTURE)
+            .expect("ledger snapshot should load frozen fixtures");
+
+    let panes = snapshot.pane_read_models();
+
+    assert_eq!(panes.len(), 2);
+    assert_eq!(panes[0].label, "builder-1");
+    assert_eq!(panes[0].pane_id, "%2");
+    assert_eq!(panes[0].role, "Builder");
+    assert_eq!(panes[0].task_id, "task-256");
+    assert_eq!(panes[0].task_state, "in_progress");
+    assert_eq!(panes[0].review_state, "PENDING");
+    assert_eq!(panes[0].priority, "P0");
+    assert_eq!(panes[0].branch, "worktree-builder-1");
+    assert_eq!(panes[0].head_sha, "abc1234def5678");
+    assert_eq!(panes[0].changed_file_count, 1);
+    assert_eq!(panes[0].last_event, "operator.review_requested");
+    assert_eq!(panes[0].event_count, 2);
+    assert_eq!(panes[1].label, "reviewer-1");
+    assert_eq!(panes[1].event_count, 0);
+}
+
+#[test]
 fn ledger_contract_rejects_duplicate_manifest_pane_id() {
     let manifest = r#"
 version: 1

--- a/docs/project/rust-schema-freeze-inventory.md
+++ b/docs/project/rust-schema-freeze-inventory.md
@@ -206,6 +206,7 @@ Current boundary:
 - It can also load live `.winsmux/manifest.yaml` and `.winsmux/events.jsonl` files.
 - It validates the manifest and event envelope before exposing the snapshot.
 - It indexes panes by `pane_id` for later projection work.
+- It exposes ordered pane read models for later board/inbox/digest/explain projection work.
 - It rejects duplicate manifest `pane_id` values because they make projection identity ambiguous.
 - It preserves manifest pane order separately from the lookup index.
 - It preserves unknown event pane IDs instead of rejecting them, because historical events can outlive the current manifest view.


### PR DESCRIPTION
## Summary
- Adds ordered pane read models from `LedgerSnapshot`.
- Extends normalized manifest panes with task, review, branch, event, and change count fields.
- Counts events by pane id while preserving manifest pane order.
- Rejects non-numeric `changed_file_count` before normalization.
- Keeps board/inbox/digest/explain projection wiring out of scope.

## Validation
- `cargo test --manifest-path .\core\Cargo.toml --test manifest_contract -- --nocapture`
- `cargo test --manifest-path .\core\Cargo.toml --test ledger_contract -- --nocapture`
- `cargo check --manifest-path .\core\Cargo.toml`
- `rustfmt --check core\src\manifest_contract.rs core\src\ledger.rs core\tests-rs\ledger_contract.rs`
- `git diff --check`
- `pwsh -NoProfile -File .\scripts\git-guard.ps1 -Mode full`
- `pwsh -NoProfile -File .\scripts\audit-public-surface.ps1`
- `codex exec review --uncommitted`
- Subagent review: no findings
- `cargo test --manifest-path .\core\Cargo.toml -- --nocapture`
- Opus review for the external Rust learning note: PASS

`TASK-265` remains active. Projection derivation is still out of scope for this PR.