### PR TITLE
TASK-265: Add Rust ledger board projection

### DIFF
--- a/core/src/ledger.rs
+++ b/core/src/ledger.rs
@@ -1,6 +1,6 @@
 use crate::event_contract::{parse_event_jsonl, EventRecord};
 use crate::manifest_contract::{NormalizedManifestPane, WinsmuxManifest};
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::Path;
 
 #[derive(Debug)]
@@ -16,17 +16,56 @@ pub struct LedgerPaneReadModel {
     pub label: String,
     pub pane_id: String,
     pub role: String,
+    pub state: String,
     pub task_id: String,
     pub task: String,
     pub task_state: String,
     pub review_state: String,
     pub priority: String,
     pub branch: String,
+    pub worktree: String,
     pub head_sha: String,
     pub changed_file_count: usize,
     pub last_event: String,
     pub last_event_at: String,
     pub event_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LedgerBoardSummary {
+    pub pane_count: usize,
+    pub dirty_panes: usize,
+    pub review_pending: usize,
+    pub review_failed: usize,
+    pub review_passed: usize,
+    pub tasks_in_progress: usize,
+    pub tasks_blocked: usize,
+    pub by_state: BTreeMap<String, usize>,
+    pub by_review: BTreeMap<String, usize>,
+    pub by_task_state: BTreeMap<String, usize>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LedgerBoardPane {
+    pub label: String,
+    pub pane_id: String,
+    pub role: String,
+    pub state: String,
+    pub task_id: String,
+    pub task: String,
+    pub task_state: String,
+    pub review_state: String,
+    pub branch: String,
+    pub worktree: String,
+    pub head_sha: String,
+    pub changed_file_count: usize,
+    pub last_event_at: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LedgerBoardProjection {
+    pub summary: LedgerBoardSummary,
+    pub panes: Vec<LedgerBoardPane>,
 }
 
 impl LedgerSnapshot {
@@ -62,19 +101,29 @@ impl LedgerSnapshot {
             }
         };
 
-        Self::from_manifest_and_events(&manifest_yaml, &events_jsonl)
+        let project_dir = project_dir_from_manifest_path(manifest_path);
+
+        Self::from_manifest_and_events_with_project_dir(&manifest_yaml, &events_jsonl, &project_dir)
     }
 
     pub fn from_manifest_and_events(
         manifest_yaml: &str,
         events_jsonl: &str,
     ) -> Result<Self, String> {
+        Self::from_manifest_and_events_with_project_dir(manifest_yaml, events_jsonl, "")
+    }
+
+    fn from_manifest_and_events_with_project_dir(
+        manifest_yaml: &str,
+        events_jsonl: &str,
+        project_dir: &str,
+    ) -> Result<Self, String> {
         let manifest = WinsmuxManifest::from_yaml(manifest_yaml)
             .map_err(|err| format!("failed to parse manifest: {err}"))?;
         manifest.validate()?;
 
         let events = parse_event_jsonl(events_jsonl)?;
-        let panes = manifest.normalized_panes();
+        let panes = manifest.normalized_panes_with_project_dir(project_dir);
         let panes_by_id = index_panes_by_id(&panes)?;
 
         let snapshot = Self {
@@ -139,12 +188,14 @@ impl LedgerSnapshot {
                     label: pane.label.clone(),
                     pane_id: pane.pane_id.clone(),
                     role: pane.role.clone(),
+                    state: pane.state.clone(),
                     task_id: pane.task_id.clone(),
                     task: pane.task.clone(),
                     task_state: pane.task_state.clone(),
                     review_state: pane.review_state.clone(),
                     priority: pane.priority.clone(),
                     branch: pane.branch.clone(),
+                    worktree: pane.worktree.clone(),
                     head_sha: pane.head_sha.clone(),
                     changed_file_count: pane.changed_file_count,
                     last_event: pane.last_event.clone(),
@@ -153,6 +204,70 @@ impl LedgerSnapshot {
                 }
             })
             .collect()
+    }
+
+    pub fn board_summary(&self) -> LedgerBoardSummary {
+        let panes = self.pane_read_models();
+        LedgerBoardSummary {
+            pane_count: panes.len(),
+            dirty_panes: panes
+                .iter()
+                .filter(|pane| pane.changed_file_count > 0)
+                .count(),
+            review_pending: panes
+                .iter()
+                .filter(|pane| pane.review_state.eq_ignore_ascii_case("pending"))
+                .count(),
+            review_failed: panes
+                .iter()
+                .filter(|pane| {
+                    pane.review_state.eq_ignore_ascii_case("fail")
+                        || pane.review_state.eq_ignore_ascii_case("failed")
+                })
+                .count(),
+            review_passed: panes
+                .iter()
+                .filter(|pane| pane.review_state.eq_ignore_ascii_case("pass"))
+                .count(),
+            tasks_in_progress: panes
+                .iter()
+                .filter(|pane| pane.task_state == "in_progress")
+                .count(),
+            tasks_blocked: panes
+                .iter()
+                .filter(|pane| pane.task_state == "blocked")
+                .count(),
+            by_state: count_by(&panes, |pane| &pane.state),
+            by_review: count_by(&panes, |pane| &pane.review_state),
+            by_task_state: count_by(&panes, |pane| &pane.task_state),
+        }
+    }
+
+    pub fn board_projection(&self) -> LedgerBoardProjection {
+        let panes = self
+            .pane_read_models()
+            .into_iter()
+            .map(|pane| LedgerBoardPane {
+                label: pane.label,
+                pane_id: pane.pane_id,
+                role: pane.role,
+                state: pane.state,
+                task_id: pane.task_id,
+                task: pane.task,
+                task_state: pane.task_state,
+                review_state: pane.review_state,
+                branch: pane.branch,
+                worktree: pane.worktree,
+                head_sha: pane.head_sha,
+                changed_file_count: pane.changed_file_count,
+                last_event_at: pane.last_event_at,
+            })
+            .collect();
+
+        LedgerBoardProjection {
+            summary: self.board_summary(),
+            panes,
+        }
     }
 
     fn validate_event_sessions(&self) -> Result<(), String> {
@@ -176,6 +291,41 @@ impl LedgerSnapshot {
     }
 }
 
+fn project_dir_from_manifest_path(manifest_path: &Path) -> String {
+    let project_dir_path = manifest_path
+        .parent()
+        .and_then(|winsmux_dir| winsmux_dir.parent())
+        .unwrap_or_else(|| Path::new(""));
+    let project_dir_path = if project_dir_path.as_os_str().is_empty() {
+        Path::new(".")
+    } else {
+        project_dir_path
+    };
+
+    project_dir_path
+        .canonicalize()
+        .unwrap_or_else(|_| project_dir_path.to_path_buf())
+        .to_string_lossy()
+        .to_string()
+}
+
+fn count_by<F>(panes: &[LedgerPaneReadModel], selector: F) -> BTreeMap<String, usize>
+where
+    F: Fn(&LedgerPaneReadModel) -> &str,
+{
+    let mut counts = BTreeMap::new();
+    for pane in panes {
+        let raw_value = selector(pane).trim();
+        let value = if raw_value.is_empty() {
+            "unknown"
+        } else {
+            raw_value
+        };
+        *counts.entry(value.to_string()).or_insert(0) += 1;
+    }
+    counts
+}
+
 fn index_panes_by_id(
     panes: &[NormalizedManifestPane],
 ) -> Result<HashMap<String, NormalizedManifestPane>, String> {
@@ -197,7 +347,8 @@ fn index_panes_by_id(
 
 #[cfg(test)]
 mod tests {
-    use super::LedgerSnapshot;
+    use super::{project_dir_from_manifest_path, LedgerSnapshot};
+    use std::path::Path;
 
     const MANIFEST_FIXTURE: &str = include_str!("../../tests/fixtures/rust-parity/manifest.yaml");
     const EVENTS_FIXTURE: &str = include_str!("../../tests/fixtures/rust-parity/events.jsonl");
@@ -245,5 +396,17 @@ panes:
         let err = LedgerSnapshot::from_manifest_and_events(manifest, "").unwrap_err();
 
         assert!(err.contains("duplicate manifest pane_id '%2'"));
+    }
+
+    #[test]
+    fn ledger_project_dir_from_bare_winsmux_manifest_path_uses_current_dir() {
+        let project_dir = project_dir_from_manifest_path(Path::new(".winsmux/manifest.yaml"));
+        let expected = Path::new(".")
+            .canonicalize()
+            .expect("current dir should be available")
+            .to_string_lossy()
+            .to_string();
+
+        assert_eq!(project_dir, expected);
     }
 }

--- a/core/src/manifest_contract.rs
+++ b/core/src/manifest_contract.rs
@@ -79,6 +79,8 @@ pub struct ManifestPane {
     #[serde(default, deserialize_with = "deserialize_manifest_string")]
     pub state: String,
     #[serde(default, deserialize_with = "deserialize_manifest_string")]
+    pub status: String,
+    #[serde(default, deserialize_with = "deserialize_manifest_string")]
     pub tokens_remaining: String,
     #[serde(default, deserialize_with = "deserialize_manifest_string")]
     pub task_id: String,
@@ -241,12 +243,14 @@ pub struct NormalizedManifestPane {
     pub label: String,
     pub pane_id: String,
     pub role: String,
+    pub state: String,
     pub task_id: String,
     pub task: String,
     pub task_state: String,
     pub review_state: String,
     pub priority: String,
     pub branch: String,
+    pub worktree: String,
     pub head_sha: String,
     pub changed_file_count: usize,
     pub last_event: String,
@@ -260,14 +264,27 @@ impl WinsmuxManifest {
     }
 
     pub fn normalized_panes(&self) -> Vec<NormalizedManifestPane> {
+        self.normalized_panes_with_project_dir("")
+    }
+
+    pub fn normalized_panes_with_project_dir(
+        &self,
+        project_dir: &str,
+    ) -> Vec<NormalizedManifestPane> {
+        let project_dir = if self.session.project_dir.trim().is_empty() {
+            project_dir
+        } else {
+            &self.session.project_dir
+        };
+
         match &self.panes {
             ManifestPanes::Map(panes) => panes
                 .iter()
-                .map(|(label, pane)| normalize_manifest_pane(label, pane))
+                .map(|(label, pane)| normalize_manifest_pane(project_dir, label, pane))
                 .collect(),
             ManifestPanes::List(panes) => panes
                 .iter()
-                .map(|pane| normalize_manifest_pane(&pane.label, pane))
+                .map(|pane| normalize_manifest_pane(project_dir, &pane.label, pane))
                 .collect(),
         }
     }
@@ -306,26 +323,125 @@ impl WinsmuxManifest {
     }
 }
 
-fn normalize_manifest_pane(label: &str, pane: &ManifestPane) -> NormalizedManifestPane {
+fn normalize_manifest_pane(
+    project_dir: &str,
+    label: &str,
+    pane: &ManifestPane,
+) -> NormalizedManifestPane {
+    let normalized_label = if pane.label.is_empty() {
+        label.to_string()
+    } else {
+        pane.label.clone()
+    };
     NormalizedManifestPane {
-        label: if pane.label.is_empty() {
-            label.to_string()
-        } else {
-            pane.label.clone()
-        },
+        label: normalized_label.clone(),
         pane_id: pane.pane_id.clone(),
         role: pane.role.clone(),
+        state: normalize_pane_state(&pane.state, &pane.status),
         task_id: pane.task_id.clone(),
         task: pane.task.clone(),
         task_state: pane.task_state.clone(),
         review_state: pane.review_state.clone(),
         priority: pane.priority.clone(),
         branch: pane.branch.clone(),
+        worktree: normalize_pane_worktree(
+            project_dir,
+            &normalized_label,
+            &pane.role,
+            &pane.branch,
+            &pane.worktree,
+            &pane.launch_dir,
+            &pane.builder_worktree_path,
+        ),
         head_sha: pane.head_sha.clone(),
         changed_file_count: pane.changed_file_count.value().unwrap_or(0),
         last_event: pane.last_event.clone(),
         last_event_at: pane.last_event_at.clone(),
     }
+}
+
+fn normalize_pane_worktree(
+    project_dir: &str,
+    label: &str,
+    role: &str,
+    branch: &str,
+    worktree: &str,
+    launch_dir: &str,
+    builder_worktree_path: &str,
+) -> String {
+    let is_managed_worktree = is_managed_worktree_role(role);
+    if !is_managed_worktree {
+        return String::new();
+    }
+
+    let project_dir = project_dir.trim();
+    for candidate in [launch_dir.trim(), builder_worktree_path.trim()] {
+        if candidate.is_empty() || same_path(candidate, project_dir) {
+            continue;
+        }
+        return relativize_path(project_dir, candidate);
+    }
+
+    if !worktree.trim().is_empty() {
+        return worktree.trim().to_string();
+    }
+
+    let label = label.trim();
+    if is_managed_worktree && !label.is_empty() && branch.trim() == format!("worktree-{label}") {
+        return format!(".worktrees/{label}");
+    }
+
+    String::new()
+}
+
+fn normalize_pane_state(state: &str, status: &str) -> String {
+    if state.trim().is_empty() {
+        status.to_string()
+    } else {
+        state.to_string()
+    }
+}
+
+fn is_managed_worktree_role(role: &str) -> bool {
+    matches!(
+        role.trim().to_ascii_lowercase().as_str(),
+        "builder" | "worker"
+    )
+}
+
+fn same_path(left: &str, right: &str) -> bool {
+    if left.is_empty() || right.is_empty() {
+        return false;
+    }
+    normalize_path_for_compare(left) == normalize_path_for_compare(right)
+}
+
+fn relativize_path(project_dir: &str, candidate: &str) -> String {
+    let project = normalize_path_for_compare(project_dir);
+    let normalized_candidate = normalize_path_for_compare(candidate);
+
+    if project.is_empty() || !normalized_candidate.starts_with(&(project.clone() + "/")) {
+        return candidate.trim().to_string();
+    }
+
+    normalized_candidate[project.len() + 1..].to_string()
+}
+
+fn normalize_path_for_compare(path: &str) -> String {
+    let normalized = path
+        .trim()
+        .trim_end_matches(['\\', '/'])
+        .replace('\\', "/")
+        .to_ascii_lowercase();
+
+    if let Some(path) = normalized.strip_prefix("//?/unc/") {
+        return format!("//{path}");
+    }
+    if let Some(path) = normalized.strip_prefix("//?/") {
+        return path.to_string();
+    }
+
+    normalized
 }
 
 fn normalize_legacy_manifest_yaml(content: &str) -> String {

--- a/core/src/manifest_contract.rs
+++ b/core/src/manifest_contract.rs
@@ -1,6 +1,7 @@
 use serde::de::{MapAccess, SeqAccess, Visitor};
 use serde::{Deserialize, Deserializer};
 use std::fmt;
+use std::path::Path;
 
 #[derive(Debug, Deserialize)]
 pub struct WinsmuxManifest {
@@ -419,29 +420,49 @@ fn same_path(left: &str, right: &str) -> bool {
 fn relativize_path(project_dir: &str, candidate: &str) -> String {
     let project = normalize_path_for_compare(project_dir);
     let normalized_candidate = normalize_path_for_compare(candidate);
+    let project_prefix = if project == "/" {
+        "/".to_string()
+    } else {
+        project.clone() + "/"
+    };
 
-    if project.is_empty() || !normalized_candidate.starts_with(&(project.clone() + "/")) {
+    if project.is_empty() || !normalized_candidate.starts_with(&project_prefix) {
         return candidate.trim().to_string();
     }
 
-    normalized_candidate[project.len() + 1..].to_string()
+    normalized_candidate[project_prefix.len()..].to_string()
 }
 
 fn normalize_path_for_compare(path: &str) -> String {
-    let normalized = path
-        .trim()
-        .trim_end_matches(['\\', '/'])
-        .replace('\\', "/")
-        .to_ascii_lowercase();
+    let trimmed = path.trim();
+    let comparable_path = Path::new(trimmed)
+        .canonicalize()
+        .ok()
+        .map(|path| path.to_string_lossy().to_string())
+        .unwrap_or_else(|| trimmed.to_string());
+    let normalized = comparable_path.replace('\\', "/").to_ascii_lowercase();
 
     if let Some(path) = normalized.strip_prefix("//?/unc/") {
-        return format!("//{path}");
+        return trim_trailing_separator_for_compare(&format!("//{path}"));
     }
     if let Some(path) = normalized.strip_prefix("//?/") {
+        return trim_trailing_separator_for_compare(path);
+    }
+
+    trim_trailing_separator_for_compare(&normalized)
+}
+
+fn trim_trailing_separator_for_compare(path: &str) -> String {
+    if path == "/" {
         return path.to_string();
     }
 
-    normalized
+    let trimmed = path.trim_end_matches('/');
+    if trimmed.is_empty() {
+        path.to_string()
+    } else {
+        trimmed.to_string()
+    }
 }
 
 fn normalize_legacy_manifest_yaml(content: &str) -> String {

--- a/core/tests-rs/ledger_contract.rs
+++ b/core/tests-rs/ledger_contract.rs
@@ -200,6 +200,8 @@ panes:
 "#
     );
     fixture.write_winsmux_file("manifest.yaml", &manifest);
+    fs::create_dir_all(fixture.path().join(".worktrees").join("builder-1"))
+        .expect("temp builder worktree dir should be created");
 
     let snapshot = ledger::LedgerSnapshot::from_project_dir(fixture.path())
         .expect("ledger snapshot should use live project dir fallback");
@@ -474,6 +476,29 @@ panes:
 
     let snapshot = ledger::LedgerSnapshot::from_manifest_and_events(manifest, "")
         .expect("ledger snapshot should relativize extended paths");
+
+    let board = snapshot.board_projection();
+
+    assert_eq!(board.panes[0].worktree, ".worktrees/builder-1");
+}
+
+#[test]
+fn ledger_contract_relativizes_drive_root_project_paths() {
+    let manifest = r#"
+version: 1
+session:
+  name: winsmux-orchestra
+  project_dir: C:\
+panes:
+  builder-1:
+    pane_id: "%2"
+    role: Builder
+    state: idle
+    launch_dir: C:\.worktrees\builder-1
+"#;
+
+    let snapshot = ledger::LedgerSnapshot::from_manifest_and_events(manifest, "")
+        .expect("ledger snapshot should relativize drive root paths");
 
     let board = snapshot.board_projection();
 

--- a/core/tests-rs/ledger_contract.rs
+++ b/core/tests-rs/ledger_contract.rs
@@ -46,6 +46,7 @@ fn ledger_contract_exposes_ordered_pane_read_models() {
     assert_eq!(panes[0].label, "builder-1");
     assert_eq!(panes[0].pane_id, "%2");
     assert_eq!(panes[0].role, "Builder");
+    assert_eq!(panes[0].state, "idle");
     assert_eq!(panes[0].task_id, "task-256");
     assert_eq!(panes[0].task_state, "in_progress");
     assert_eq!(panes[0].review_state, "PENDING");
@@ -57,6 +58,311 @@ fn ledger_contract_exposes_ordered_pane_read_models() {
     assert_eq!(panes[0].event_count, 2);
     assert_eq!(panes[1].label, "reviewer-1");
     assert_eq!(panes[1].event_count, 0);
+}
+
+#[test]
+fn ledger_contract_derives_board_summary_from_manifest_panes() {
+    let snapshot =
+        ledger::LedgerSnapshot::from_manifest_and_events(MANIFEST_FIXTURE, EVENTS_FIXTURE)
+            .expect("ledger snapshot should load frozen fixtures");
+
+    let summary = snapshot.board_summary();
+
+    assert_eq!(summary.pane_count, 2);
+    assert_eq!(summary.dirty_panes, 1);
+    assert_eq!(summary.review_pending, 1);
+    assert_eq!(summary.review_failed, 0);
+    assert_eq!(summary.review_passed, 0);
+    assert_eq!(summary.tasks_in_progress, 1);
+    assert_eq!(summary.tasks_blocked, 0);
+    assert_eq!(summary.by_state["idle"], 2);
+    assert_eq!(summary.by_review["PENDING"], 1);
+    assert_eq!(summary.by_review["unknown"], 1);
+    assert_eq!(summary.by_task_state["in_progress"], 1);
+    assert_eq!(summary.by_task_state["backlog"], 1);
+}
+
+#[test]
+fn ledger_contract_exposes_board_projection_in_manifest_order() {
+    let snapshot =
+        ledger::LedgerSnapshot::from_manifest_and_events(MANIFEST_FIXTURE, EVENTS_FIXTURE)
+            .expect("ledger snapshot should load frozen fixtures");
+
+    let board = snapshot.board_projection();
+
+    assert_eq!(board.summary.pane_count, 2);
+    assert_eq!(board.summary.review_pending, 1);
+    assert_eq!(board.summary.tasks_in_progress, 1);
+    assert_eq!(board.panes.len(), 2);
+    assert_eq!(board.panes[0].label, "builder-1");
+    assert_eq!(board.panes[0].pane_id, "%2");
+    assert_eq!(board.panes[0].role, "Builder");
+    assert_eq!(board.panes[0].state, "idle");
+    assert_eq!(board.panes[0].task_id, "task-256");
+    assert_eq!(board.panes[0].task, "Implement run ledger");
+    assert_eq!(board.panes[0].task_state, "in_progress");
+    assert_eq!(board.panes[0].review_state, "PENDING");
+    assert_eq!(board.panes[0].branch, "worktree-builder-1");
+    assert_eq!(board.panes[0].worktree, ".worktrees/builder-1");
+    assert_eq!(board.panes[0].head_sha, "abc1234def5678");
+    assert_eq!(board.panes[0].changed_file_count, 1);
+    assert_eq!(board.panes[0].last_event_at, "__LAST_EVENT_AT__");
+    assert_eq!(board.panes[1].label, "reviewer-1");
+}
+
+#[test]
+fn ledger_contract_derives_board_worktree_from_legacy_path_fields() {
+    let manifest = r#"
+version: 1
+session:
+  name: winsmux-orchestra
+  project_dir: C:\repo
+panes:
+  builder-1:
+    pane_id: "%2"
+    role: Builder
+    state: idle
+    builder_worktree_path: C:\repo\.worktrees\builder-1
+    launch_dir: C:\repo
+"#;
+
+    let snapshot = ledger::LedgerSnapshot::from_manifest_and_events(manifest, "")
+        .expect("ledger snapshot should load legacy path fields");
+
+    let board = snapshot.board_projection();
+
+    assert_eq!(board.panes[0].worktree, ".worktrees/builder-1");
+}
+
+#[test]
+fn ledger_contract_prefers_rebound_launch_dir_for_board_worktree() {
+    let manifest = r#"
+version: 1
+session:
+  name: winsmux-orchestra
+  project_dir: C:\repo
+panes:
+  builder-1:
+    pane_id: "%2"
+    role: Builder
+    state: idle
+    builder_worktree_path: C:\repo\.worktrees\builder-1
+    launch_dir: C:\repo\.worktrees\builder-2
+"#;
+
+    let snapshot = ledger::LedgerSnapshot::from_manifest_and_events(manifest, "")
+        .expect("ledger snapshot should load rebound launch_dir");
+
+    let board = snapshot.board_projection();
+
+    assert_eq!(board.panes[0].worktree, ".worktrees/builder-2");
+}
+
+#[test]
+fn ledger_contract_derives_board_worktree_from_branch_label_fallback() {
+    let manifest = r#"
+version: 1
+session:
+  name: winsmux-orchestra
+  project_dir: C:\repo
+panes:
+  builder-1:
+    pane_id: "%2"
+    role: Builder
+    state: idle
+    branch: worktree-builder-1
+"#;
+
+    let snapshot = ledger::LedgerSnapshot::from_manifest_and_events(manifest, "")
+        .expect("ledger snapshot should load branch label fallback");
+
+    let board = snapshot.board_projection();
+
+    assert_eq!(board.panes[0].worktree, ".worktrees/builder-1");
+}
+
+#[test]
+fn ledger_contract_uses_live_project_dir_when_manifest_omits_project_dir() {
+    let fixture = TempProject::new("project-dir-fallback");
+    let root = fixture.path_string();
+    let manifest = format!(
+        r#"
+version: 1
+session:
+  name: winsmux-orchestra
+panes:
+  builder-1:
+    pane_id: "%2"
+    role: Builder
+    state: idle
+    launch_dir: {root}
+    builder_worktree_path: {root}/.worktrees/builder-1
+"#
+    );
+    fixture.write_winsmux_file("manifest.yaml", &manifest);
+
+    let snapshot = ledger::LedgerSnapshot::from_project_dir(fixture.path())
+        .expect("ledger snapshot should use live project dir fallback");
+
+    let board = snapshot.board_projection();
+
+    assert_eq!(board.panes[0].worktree, ".worktrees/builder-1");
+}
+
+#[test]
+fn ledger_contract_does_not_assign_branch_label_worktree_to_reviewer() {
+    let manifest = r#"
+version: 1
+session:
+  name: winsmux-orchestra
+  project_dir: C:\repo
+panes:
+  reviewer-1:
+    pane_id: "%2"
+    role: Reviewer
+    state: idle
+    branch: worktree-reviewer-1
+"#;
+
+    let snapshot = ledger::LedgerSnapshot::from_manifest_and_events(manifest, "")
+        .expect("ledger snapshot should load reviewer branch");
+
+    let board = snapshot.board_projection();
+
+    assert_eq!(board.panes[0].worktree, "");
+}
+
+#[test]
+fn ledger_contract_ignores_stale_worker_paths_on_reviewer() {
+    let manifest = r#"
+version: 1
+session:
+  name: winsmux-orchestra
+  project_dir: C:\repo
+panes:
+  reviewer-1:
+    pane_id: "%2"
+    role: Reviewer
+    state: idle
+    launch_dir: C:\repo\.worktrees\worker-1
+    builder_worktree_path: C:\repo\.worktrees\worker-1
+    branch: worktree-worker-1
+"#;
+
+    let snapshot = ledger::LedgerSnapshot::from_manifest_and_events(manifest, "")
+        .expect("ledger snapshot should ignore stale reviewer paths");
+
+    let board = snapshot.board_projection();
+
+    assert_eq!(board.panes[0].worktree, "");
+}
+
+#[test]
+fn ledger_contract_ignores_stale_explicit_worktree_on_reviewer() {
+    let manifest = r#"
+version: 1
+session:
+  name: winsmux-orchestra
+  project_dir: C:\repo
+panes:
+  reviewer-1:
+    pane_id: "%2"
+    role: Reviewer
+    state: idle
+    worktree: .worktrees\worker-1
+"#;
+
+    let snapshot = ledger::LedgerSnapshot::from_manifest_and_events(manifest, "")
+        .expect("ledger snapshot should ignore stale explicit reviewer worktree");
+
+    let board = snapshot.board_projection();
+
+    assert_eq!(board.panes[0].worktree, "");
+}
+
+#[test]
+fn ledger_contract_uses_status_as_state_fallback() {
+    let manifest = r#"
+version: 1
+session:
+  name: winsmux-orchestra
+  project_dir: C:\repo
+panes:
+  builder-1:
+    pane_id: "%2"
+    role: Builder
+    status: ready
+"#;
+
+    let snapshot = ledger::LedgerSnapshot::from_manifest_and_events(manifest, "")
+        .expect("ledger snapshot should use status as state fallback");
+
+    let board = snapshot.board_projection();
+
+    assert_eq!(board.panes[0].state, "ready");
+    assert_eq!(board.summary.by_state["ready"], 1);
+}
+
+#[test]
+fn ledger_contract_prefers_current_paths_over_stale_explicit_worktree() {
+    let manifest = r#"
+version: 1
+session:
+  name: winsmux-orchestra
+  project_dir: C:\repo
+panes:
+  builder-1:
+    pane_id: "%2"
+    role: Builder
+    state: idle
+    worktree: .worktrees\builder-1
+    launch_dir: C:\repo\.worktrees\builder-9
+    builder_worktree_path: C:\repo\.worktrees\builder-9
+"#;
+
+    let snapshot = ledger::LedgerSnapshot::from_manifest_and_events(manifest, "")
+        .expect("ledger snapshot should prefer current path fields");
+
+    let board = snapshot.board_projection();
+
+    assert_eq!(board.panes[0].worktree, ".worktrees/builder-9");
+}
+
+#[test]
+fn ledger_contract_counts_lowercase_review_states() {
+    let manifest = r#"
+version: 1
+session:
+  name: winsmux-orchestra
+panes:
+  pending:
+    pane_id: "%2"
+    role: Builder
+    review_state: pending
+    branch: worktree-builder-1
+    head_sha: abc1234def5678
+  pass:
+    pane_id: "%3"
+    role: Reviewer
+    review_state: pass
+    branch: worktree-reviewer-1
+    head_sha: def5678abc1234
+  fail:
+    pane_id: "%4"
+    role: Reviewer
+    review_state: fail
+    branch: worktree-reviewer-2
+    head_sha: 1234def5678abc
+"#;
+
+    let snapshot = ledger::LedgerSnapshot::from_manifest_and_events(manifest, "")
+        .expect("ledger snapshot should load lowercase review states");
+
+    let summary = snapshot.board_summary();
+
+    assert_eq!(summary.review_pending, 1);
+    assert_eq!(summary.review_passed, 1);
+    assert_eq!(summary.review_failed, 1);
 }
 
 #[test]
@@ -106,6 +412,74 @@ fn ledger_contract_allows_missing_live_events_file() {
     assert_eq!(snapshot.event_count(), 0);
 }
 
+#[test]
+fn ledger_contract_relativizes_live_paths_loaded_from_relative_manifest_path() {
+    let fixture = TempProject::new_under_current("relative-manifest");
+    let root = fixture.path_string();
+    let manifest = format!(
+        r#"
+version: 1
+session:
+  name: winsmux-orchestra
+panes:
+  builder-1:
+    pane_id: "%2"
+    role: Builder
+    state: idle
+    launch_dir: {root}
+    builder_worktree_path: {root}/.worktrees/builder-1
+"#
+    );
+    fixture.write_winsmux_file("manifest.yaml", &manifest);
+    fixture.write_winsmux_file("events.jsonl", "");
+
+    let current_dir = std::env::current_dir().expect("current dir should be available");
+    let manifest_path = fixture
+        .root
+        .join(".winsmux")
+        .join("manifest.yaml")
+        .strip_prefix(&current_dir)
+        .expect("fixture should be under current dir")
+        .to_path_buf();
+    let events_path = fixture
+        .root
+        .join(".winsmux")
+        .join("events.jsonl")
+        .strip_prefix(&current_dir)
+        .expect("fixture should be under current dir")
+        .to_path_buf();
+
+    let snapshot = ledger::LedgerSnapshot::from_paths(manifest_path, events_path)
+        .expect("ledger snapshot should load relative manifest path");
+
+    let board = snapshot.board_projection();
+
+    assert_eq!(board.panes[0].worktree, ".worktrees/builder-1");
+}
+
+#[test]
+fn ledger_contract_relativizes_extended_windows_paths() {
+    let manifest = r#"
+version: 1
+session:
+  name: winsmux-orchestra
+  project_dir: \\?\C:\repo
+panes:
+  builder-1:
+    pane_id: "%2"
+    role: Builder
+    state: idle
+    launch_dir: \\?\C:\repo\.worktrees\builder-1
+"#;
+
+    let snapshot = ledger::LedgerSnapshot::from_manifest_and_events(manifest, "")
+        .expect("ledger snapshot should relativize extended paths");
+
+    let board = snapshot.board_projection();
+
+    assert_eq!(board.panes[0].worktree, ".worktrees/builder-1");
+}
+
 struct TempProject {
     root: PathBuf,
 }
@@ -124,8 +498,26 @@ impl TempProject {
         Self { root }
     }
 
+    fn new_under_current(label: &str) -> Self {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock should be after unix epoch")
+            .as_nanos();
+        let root = std::env::current_dir()
+            .expect("current dir should be available")
+            .join("target")
+            .join("ledger-contract")
+            .join(format!("{label}-{}-{unique}", std::process::id()));
+        fs::create_dir_all(root.join(".winsmux")).expect("temp .winsmux dir should be created");
+        Self { root }
+    }
+
     fn path(&self) -> &std::path::Path {
         &self.root
+    }
+
+    fn path_string(&self) -> String {
+        self.root.to_string_lossy().replace('\\', "/")
     }
 
     fn write_winsmux_file(&self, name: &str, content: &str) {

--- a/docs/project/rust-schema-freeze-inventory.md
+++ b/docs/project/rust-schema-freeze-inventory.md
@@ -207,6 +207,7 @@ Current boundary:
 - It validates the manifest and event envelope before exposing the snapshot.
 - It indexes panes by `pane_id` for later projection work.
 - It exposes ordered pane read models for later board/inbox/digest/explain projection work.
+- It derives the first Rust board projection from manifest pane read models.
 - It rejects duplicate manifest `pane_id` values because they make projection identity ambiguous.
 - It preserves manifest pane order separately from the lookup index.
 - It preserves unknown event pane IDs instead of rejecting them, because historical events can outlive the current manifest view.
@@ -217,7 +218,8 @@ Current limitation:
 
 - The snapshot is still read-only.
 - Projection code does not consume the live snapshot yet.
-- `board`, `inbox`, `digest`, and `explain` are not derived from this snapshot yet.
+- The PowerShell and desktop surfaces do not consume the Rust board projection yet.
+- `inbox`, `digest`, and `explain` are not derived from this snapshot yet.
 
 ### 7. `verdict`
 


### PR DESCRIPTION
## Summary
- add `LedgerBoardSummary`, `LedgerBoardPane`, and `LedgerBoardProjection`
- derive board summary and panes from `LedgerSnapshot` while preserving manifest order
- normalize worktree values from launch path, builder path, explicit worktree, and branch-label fallback
- suppress stale worktree metadata on non-Builder/Worker panes
- add status-to-state fallback for current live manifests
- cover relative manifest paths and Windows extended paths
- keep Tauri and CLI wiring out of scope for this change

## Validation
- `cargo test --manifest-path .\core\Cargo.toml --test ledger_contract -- --nocapture` passed: 36/36
- `cargo test --manifest-path .\core\Cargo.toml --test manifest_contract -- --nocapture` passed: 13/13
- `cargo check --manifest-path .\core\Cargo.toml` passed
- `rustfmt --check core\src\manifest_contract.rs core\src\ledger.rs core\tests-rs\ledger_contract.rs` passed
- `cargo test --manifest-path .\core\Cargo.toml -- --nocapture` passed
- `git diff --check` passed with line-ending warnings only
- `pwsh -NoProfile -File .\scripts\git-guard.ps1 -Mode full` passed
- `pwsh -NoProfile -File .\scripts\audit-public-surface.ps1` passed
- `codex exec review --uncommitted` found no correctness issue
- subagent review found no findings
- external Rust learning note updated; Opus review verdict: PASS

`TASK-265` remains active until the remaining projections are complete.