### PR TITLE
TASK-265: Add Rust ledger inbox projection

### DIFF
--- a/core/src/ledger.rs
+++ b/core/src/ledger.rs
@@ -1,5 +1,7 @@
 use crate::event_contract::{parse_event_jsonl, EventRecord};
 use crate::manifest_contract::{NormalizedManifestPane, WinsmuxManifest};
+use serde_json::Value;
+use std::cmp::Ordering;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::Path;
 
@@ -66,6 +68,38 @@ pub struct LedgerBoardPane {
 pub struct LedgerBoardProjection {
     pub summary: LedgerBoardSummary,
     pub panes: Vec<LedgerBoardPane>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LedgerInboxSummary {
+    pub item_count: usize,
+    pub by_kind: BTreeMap<String, usize>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LedgerInboxItem {
+    pub kind: String,
+    pub priority: usize,
+    pub message: String,
+    pub label: String,
+    pub pane_id: String,
+    pub role: String,
+    pub task_id: String,
+    pub task: String,
+    pub task_state: String,
+    pub review_state: String,
+    pub branch: String,
+    pub head_sha: String,
+    pub changed_file_count: usize,
+    pub event: String,
+    pub timestamp: String,
+    pub source: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LedgerInboxProjection {
+    pub summary: LedgerInboxSummary,
+    pub items: Vec<LedgerInboxItem>,
 }
 
 impl LedgerSnapshot {
@@ -270,6 +304,91 @@ impl LedgerSnapshot {
         }
     }
 
+    pub fn inbox_projection(&self) -> LedgerInboxProjection {
+        let mut items_by_key = BTreeMap::new();
+
+        for pane in self.pane_read_models() {
+            let pane_key_base = pane_key_base(&pane.pane_id, &pane.label);
+            if pane.review_state.eq_ignore_ascii_case("pending") {
+                let key = format!("manifest:review_pending:{pane_key_base}");
+                items_by_key.insert(
+                    key,
+                    LedgerInboxItem::from_manifest_pane(
+                        "review_pending",
+                        format!("{} が review 待機中。", pane.label),
+                        &pane,
+                    ),
+                );
+            }
+
+            if pane.review_state.eq_ignore_ascii_case("fail")
+                || pane.review_state.eq_ignore_ascii_case("failed")
+            {
+                let key = format!("manifest:review_failed:{pane_key_base}");
+                items_by_key.insert(
+                    key,
+                    LedgerInboxItem::from_manifest_pane(
+                        "review_failed",
+                        format!("{} の review が FAIL。", pane.label),
+                        &pane,
+                    ),
+                );
+            }
+
+            if pane.task_state.eq_ignore_ascii_case("blocked") {
+                let key = format!("manifest:task_blocked:{pane_key_base}");
+                items_by_key.insert(
+                    key,
+                    LedgerInboxItem::from_manifest_pane(
+                        "task_blocked",
+                        format!("{} が blocked。", pane.label),
+                        &pane,
+                    ),
+                );
+            }
+        }
+
+        for event in self.inbox_active_events() {
+            let Some(item) = LedgerInboxItem::from_event(event) else {
+                continue;
+            };
+            let key = format!(
+                "events:{}:{}",
+                item.kind,
+                pane_key_base(&item.pane_id, &item.label)
+            );
+            items_by_key.insert(key, item);
+        }
+
+        let mut items: Vec<_> = items_by_key.into_values().collect();
+        items.sort_by(compare_inbox_items);
+        let by_kind = count_inbox_by_kind(&items);
+
+        LedgerInboxProjection {
+            summary: LedgerInboxSummary {
+                item_count: items.len(),
+                by_kind,
+            },
+            items,
+        }
+    }
+
+    fn inbox_active_events(&self) -> Vec<&EventRecord> {
+        let mut keys = Vec::new();
+        let mut latest_by_key = HashMap::new();
+        for event in &self.events {
+            let key = inbox_event_entity_key(event);
+            if !latest_by_key.contains_key(&key) {
+                keys.push(key.clone());
+            }
+            latest_by_key.insert(key, event);
+        }
+
+        keys.into_iter()
+            .filter_map(|key| latest_by_key.remove(&key))
+            .collect()
+    }
+
     fn validate_event_sessions(&self) -> Result<(), String> {
         let session_name = self.session_name();
         if session_name.trim().is_empty() {
@@ -291,6 +410,77 @@ impl LedgerSnapshot {
     }
 }
 
+impl LedgerInboxItem {
+    fn from_manifest_pane(kind: &str, message: String, pane: &LedgerPaneReadModel) -> Self {
+        Self {
+            kind: kind.to_string(),
+            priority: inbox_priority(kind),
+            message,
+            label: pane.label.clone(),
+            pane_id: pane.pane_id.clone(),
+            role: pane.role.clone(),
+            task_id: pane.task_id.clone(),
+            task: pane.task.clone(),
+            task_state: pane.task_state.clone(),
+            review_state: pane.review_state.clone(),
+            branch: pane.branch.clone(),
+            head_sha: pane.head_sha.clone(),
+            changed_file_count: pane.changed_file_count,
+            event: pane.last_event.clone(),
+            timestamp: pane.last_event_at.clone(),
+            source: "manifest".to_string(),
+        }
+    }
+
+    fn from_event(event: &EventRecord) -> Option<Self> {
+        let kind = inbox_actionable_event_kind(event);
+        if kind.is_empty() {
+            return None;
+        }
+
+        let task_id = event_data_string(&event.data, "task_id");
+        let branch = if event.branch.trim().is_empty() {
+            event_data_string(&event.data, "branch")
+        } else {
+            event.branch.clone()
+        };
+        let head_sha = if event.head_sha.trim().is_empty() {
+            event_data_string(&event.data, "head_sha")
+        } else {
+            event.head_sha.clone()
+        };
+        let status = if event.status.trim().is_empty() {
+            event_data_string(&event.data, "to")
+        } else {
+            event.status.clone()
+        };
+        let event_label = if status.trim().is_empty() {
+            event.event.clone()
+        } else {
+            status
+        };
+
+        Some(Self {
+            kind: kind.to_string(),
+            priority: inbox_priority(kind),
+            message: event.message.clone(),
+            label: event.label.clone(),
+            pane_id: event.pane_id.clone(),
+            role: event.role.clone(),
+            task_id,
+            task: String::new(),
+            task_state: String::new(),
+            review_state: String::new(),
+            branch,
+            head_sha,
+            changed_file_count: 0,
+            event: event_label,
+            timestamp: event.timestamp.clone(),
+            source: "events".to_string(),
+        })
+    }
+}
+
 fn project_dir_from_manifest_path(manifest_path: &Path) -> String {
     let project_dir_path = manifest_path
         .parent()
@@ -307,6 +497,112 @@ fn project_dir_from_manifest_path(manifest_path: &Path) -> String {
         .unwrap_or_else(|_| project_dir_path.to_path_buf())
         .to_string_lossy()
         .to_string()
+}
+
+fn inbox_priority(kind: &str) -> usize {
+    match kind {
+        "blocked" | "task_blocked" | "review_failed" | "bootstrap_invalid" | "crashed" | "hung"
+        | "stalled" => 0,
+        "approval_waiting" | "review_requested" | "review_pending" => 1,
+        "dispatch_needed" | "task_completed" | "commit_ready" => 2,
+        _ => 3,
+    }
+}
+
+fn inbox_actionable_event_kind(event: &EventRecord) -> &'static str {
+    let data_status = event_data_string(&event.data, "status");
+    if event.event == "approval_waiting"
+        || event.event == "pane.approval_waiting"
+        || event.status == "approval_waiting"
+        || (event.event == "monitor.status" && data_status == "approval_waiting")
+    {
+        return "approval_waiting";
+    }
+
+    match event.event.as_str() {
+        "pane.idle" => return "dispatch_needed",
+        "pane.completed" => return "task_completed",
+        "pane.bootstrap_invalid" => return "bootstrap_invalid",
+        "pane.crashed" => return "crashed",
+        "pane.hung" => return "hung",
+        "pane.stalled" => return "stalled",
+        _ => {}
+    }
+
+    if event.event == "operator.state_transition" {
+        match event.status.as_str() {
+            "blocked_no_review_target" => return "blocked",
+            "blocked_review_failed" => return "review_failed",
+            "commit_ready" => return "commit_ready",
+            _ => {}
+        }
+
+        match data_status.as_str() {
+            "blocked_no_review_target" => return "blocked",
+            "blocked_review_failed" => return "review_failed",
+            "commit_ready" => return "commit_ready",
+            _ => {}
+        }
+    }
+
+    match event.event.as_str() {
+        "operator.review_requested" => "review_requested",
+        "operator.review_failed" => "review_failed",
+        "operator.blocked" => "blocked",
+        "operator.commit_ready" => "commit_ready",
+        "pipeline.security.blocked" => "blocked",
+        "security.policy.blocked" => "blocked",
+        _ => "",
+    }
+}
+
+fn inbox_event_entity_key(event: &EventRecord) -> String {
+    if event.event.starts_with("operator.") {
+        return "operator".to_string();
+    }
+    if !event.pane_id.trim().is_empty() {
+        return format!("pane:{}", event.pane_id);
+    }
+    if !event.label.trim().is_empty() {
+        return format!("label:{}", event.label);
+    }
+    format!("event:{}", event.event)
+}
+
+fn event_data_string(data: &Value, key: &str) -> String {
+    data.as_object()
+        .and_then(|map| map.get(key))
+        .and_then(|value| value.as_str())
+        .unwrap_or_default()
+        .to_string()
+}
+
+fn pane_key_base(pane_id: &str, label: &str) -> String {
+    if !pane_id.trim().is_empty() {
+        pane_id.to_string()
+    } else {
+        label.to_string()
+    }
+}
+
+fn compare_inbox_items(left: &LedgerInboxItem, right: &LedgerInboxItem) -> Ordering {
+    left.priority
+        .cmp(&right.priority)
+        .then_with(|| right.timestamp.cmp(&left.timestamp))
+        .then_with(|| left.label.cmp(&right.label))
+}
+
+fn count_inbox_by_kind(items: &[LedgerInboxItem]) -> BTreeMap<String, usize> {
+    let mut counts = BTreeMap::new();
+    for item in items {
+        let kind = if item.kind.trim().is_empty() {
+            "unknown"
+        } else {
+            &item.kind
+        };
+        *counts.entry(kind.to_string()).or_insert(0) += 1;
+    }
+    counts
 }
 
 fn count_by<F>(panes: &[LedgerPaneReadModel], selector: F) -> BTreeMap<String, usize>

--- a/core/tests-rs/ledger_contract.rs
+++ b/core/tests-rs/ledger_contract.rs
@@ -111,6 +111,164 @@ fn ledger_contract_exposes_board_projection_in_manifest_order() {
 }
 
 #[test]
+fn ledger_contract_exposes_inbox_projection_from_manifest_and_events() {
+    let manifest = r#"
+version: 1
+session:
+  name: winsmux-orchestra
+panes:
+  builder-1:
+    pane_id: "%2"
+    role: Builder
+    state: idle
+    task_id: task-245
+    task: Build inbox surface
+    task_state: in_progress
+    review_state: PENDING
+    branch: worktree-builder-1
+    head_sha: abc1234def5678
+    changed_file_count: 1
+    changed_files: '["scripts/winsmux-core.ps1"]'
+    last_event: review.requested
+    last_event_at: 2026-04-23T12:00:00+09:00
+  worker-1:
+    pane_id: "%6"
+    role: Worker
+    state: idle
+    task_id: task-999
+    task: Fix blocker
+    task_state: blocked
+    branch: worktree-worker-1
+    head_sha: def5678abc1234
+"#;
+    let events = r#"{"timestamp":"2026-04-23T12:00:01+09:00","session":"winsmux-orchestra","event":"pane.approval_waiting","message":"approval prompt detected","label":"builder-1","pane_id":"%2","role":"Builder","status":"approval_waiting","data":{"task_id":"task-245"}}
+{"timestamp":"2026-04-23T12:00:02+09:00","session":"winsmux-orchestra","event":"operator.commit_ready","message":"ready to commit","label":"","pane_id":"","role":"Operator","status":"commit_ready","head_sha":"abc1234def5678","data":{}}
+"#;
+
+    let snapshot = ledger::LedgerSnapshot::from_manifest_and_events(manifest, events)
+        .expect("ledger snapshot should load inbox inputs");
+
+    let inbox = snapshot.inbox_projection();
+
+    assert_eq!(inbox.summary.item_count, 4);
+    assert_eq!(inbox.summary.by_kind["task_blocked"], 1);
+    assert_eq!(inbox.summary.by_kind["review_pending"], 1);
+    assert_eq!(inbox.summary.by_kind["approval_waiting"], 1);
+    assert_eq!(inbox.summary.by_kind["commit_ready"], 1);
+    assert_eq!(inbox.items[0].kind, "task_blocked");
+    assert_eq!(inbox.items[0].priority, 0);
+    assert_eq!(inbox.items[0].label, "worker-1");
+    assert_eq!(inbox.items[0].pane_id, "%6");
+    assert_eq!(inbox.items[0].role, "Worker");
+    assert_eq!(inbox.items[0].task_id, "task-999");
+    assert_eq!(inbox.items[0].task, "Fix blocker");
+    assert_eq!(inbox.items[0].source, "manifest");
+    assert_eq!(inbox.items[1].kind, "approval_waiting");
+    assert_eq!(inbox.items[1].event, "approval_waiting");
+    assert_eq!(inbox.items[1].task_id, "task-245");
+    assert_eq!(inbox.items[1].source, "events");
+    assert_eq!(inbox.items[2].kind, "review_pending");
+    assert_eq!(inbox.items[2].event, "review.requested");
+    assert_eq!(inbox.items[3].kind, "commit_ready");
+    assert_eq!(inbox.items[3].head_sha, "abc1234def5678");
+}
+
+#[test]
+fn ledger_contract_uses_latest_event_per_inbox_entity() {
+    let manifest = r#"
+version: 1
+session:
+  name: winsmux-orchestra
+panes:
+  builder-1:
+    pane_id: "%2"
+    role: Builder
+    state: idle
+"#;
+    let events = r#"{"timestamp":"2026-04-23T12:00:01+09:00","session":"winsmux-orchestra","event":"pane.approval_waiting","message":"old approval","label":"builder-1","pane_id":"%2","role":"Builder","status":"approval_waiting","data":{"task_id":"task-old"}}
+{"timestamp":"2026-04-23T12:00:02+09:00","session":"winsmux-orchestra","event":"pane.approval_waiting","message":"new approval","label":"builder-1","pane_id":"%2","role":"Builder","status":"approval_waiting","data":{"task_id":"task-new"}}
+"#;
+
+    let snapshot = ledger::LedgerSnapshot::from_manifest_and_events(manifest, events)
+        .expect("ledger snapshot should load repeated inbox events");
+
+    let inbox = snapshot.inbox_projection();
+
+    assert_eq!(inbox.summary.item_count, 1);
+    assert_eq!(inbox.items[0].message, "new approval");
+    assert_eq!(inbox.items[0].task_id, "task-new");
+}
+
+#[test]
+fn ledger_contract_classifies_inbox_actionable_event_taxonomy() {
+    let manifest = r#"
+version: 1
+session:
+  name: winsmux-orchestra
+panes:
+  builder-1:
+    pane_id: "%2"
+    role: Builder
+  builder-2:
+    pane_id: "%3"
+    role: Builder
+  builder-3:
+    pane_id: "%4"
+    role: Builder
+  builder-4:
+    pane_id: "%5"
+    role: Builder
+  builder-5:
+    pane_id: "%6"
+    role: Builder
+"#;
+    let events = r#"{"timestamp":"2026-04-23T12:00:01+09:00","session":"winsmux-orchestra","event":"pane.idle","message":"idle","label":"builder-1","pane_id":"%2","role":"Builder","data":{}}
+{"timestamp":"2026-04-23T12:00:02+09:00","session":"winsmux-orchestra","event":"pane.completed","message":"completed","label":"builder-2","pane_id":"%3","role":"Builder","data":{}}
+{"timestamp":"2026-04-23T12:00:03+09:00","session":"winsmux-orchestra","event":"pane.crashed","message":"crashed","label":"builder-3","pane_id":"%4","role":"Builder","data":{}}
+{"timestamp":"2026-04-23T12:00:04+09:00","session":"winsmux-orchestra","event":"pane.hung","message":"hung","label":"builder-4","pane_id":"%5","role":"Builder","data":{}}
+{"timestamp":"2026-04-23T12:00:05+09:00","session":"winsmux-orchestra","event":"operator.state_transition","message":"blocked","label":"","pane_id":"","role":"Operator","status":"blocked_no_review_target","data":{}}
+{"timestamp":"2026-04-23T12:00:06+09:00","session":"winsmux-orchestra","event":"pane.stalled","message":"stalled","label":"builder-5","pane_id":"%6","role":"Builder","data":{}}
+"#;
+
+    let snapshot = ledger::LedgerSnapshot::from_manifest_and_events(manifest, events)
+        .expect("ledger snapshot should load inbox taxonomy events");
+
+    let inbox = snapshot.inbox_projection();
+
+    assert_eq!(inbox.summary.by_kind["dispatch_needed"], 1);
+    assert_eq!(inbox.summary.by_kind["task_completed"], 1);
+    assert_eq!(inbox.summary.by_kind["crashed"], 1);
+    assert_eq!(inbox.summary.by_kind["hung"], 1);
+    assert_eq!(inbox.summary.by_kind["blocked"], 1);
+    assert_eq!(inbox.summary.by_kind["stalled"], 1);
+}
+
+#[test]
+fn ledger_contract_filters_inbox_after_latest_event_deduplication() {
+    let manifest = r#"
+version: 1
+session:
+  name: winsmux-orchestra
+panes:
+  builder-1:
+    pane_id: "%2"
+    role: Builder
+    state: idle
+"#;
+    let events = r#"{"timestamp":"2026-04-23T12:00:01+09:00","session":"winsmux-orchestra","event":"pane.approval_waiting","message":"old approval","label":"builder-1","pane_id":"%2","role":"Builder","status":"approval_waiting","data":{"task_id":"task-old"}}
+{"timestamp":"2026-04-23T12:00:02+09:00","session":"winsmux-orchestra","event":"pane.output","message":"normal output","label":"builder-1","pane_id":"%2","role":"Builder","data":{}}
+"#;
+
+    let snapshot = ledger::LedgerSnapshot::from_manifest_and_events(manifest, events)
+        .expect("ledger snapshot should load deduplication events");
+
+    let inbox = snapshot.inbox_projection();
+
+    assert_eq!(inbox.summary.item_count, 0);
+    assert!(inbox.items.is_empty());
+}
+
+#[test]
 fn ledger_contract_derives_board_worktree_from_legacy_path_fields() {
     let manifest = r#"
 version: 1

--- a/docs/project/rust-schema-freeze-inventory.md
+++ b/docs/project/rust-schema-freeze-inventory.md
@@ -208,6 +208,7 @@ Current boundary:
 - It indexes panes by `pane_id` for later projection work.
 - It exposes ordered pane read models for later board/inbox/digest/explain projection work.
 - It derives the first Rust board projection from manifest pane read models.
+- It derives the first Rust inbox projection from manifest pane state and latest actionable events.
 - It rejects duplicate manifest `pane_id` values because they make projection identity ambiguous.
 - It preserves manifest pane order separately from the lookup index.
 - It preserves unknown event pane IDs instead of rejecting them, because historical events can outlive the current manifest view.
@@ -219,7 +220,8 @@ Current limitation:
 - The snapshot is still read-only.
 - Projection code does not consume the live snapshot yet.
 - The PowerShell and desktop surfaces do not consume the Rust board projection yet.
-- `inbox`, `digest`, and `explain` are not derived from this snapshot yet.
+- `digest` and `explain` are not derived from this snapshot yet.
+- The PowerShell and desktop surfaces do not consume the Rust inbox projection yet.
 
 ### 7. `verdict`
 


### PR DESCRIPTION
## Summary
- Add Rust inbox projection over manifest panes and latest actionable events.
- Preserve PowerShell inbox ordering, priority, and latest-event filtering behavior.
- Update the Rust schema freeze inventory and external Rust learning note.

## Validation
- cargo test --manifest-path .\core\Cargo.toml --test ledger_contract -- --nocapture
- cargo test --manifest-path .\core\Cargo.toml -- --nocapture
- rustfmt --check core\src\ledger.rs core\tests-rs\ledger_contract.rs
- git diff --check
- pwsh -NoProfile -File .\scripts\git-guard.ps1 -Mode full
- pwsh -NoProfile -File .\scripts\audit-public-surface.ps1
- codex exec review --uncommitted
- Opus review for external Rust learning note: PASS

## Notes
- TASK-265 remains active. Digest and explain projections are still pending.