### PR TITLE
Add Rust fixture comparison harness

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -33,6 +33,10 @@ path = "tests-rs/event_contract.rs"
 name = "ledger_contract"
 path = "tests-rs/ledger_contract.rs"
 
+[[test]]
+name = "fixture_comparison"
+path = "tests-rs/fixture_comparison.rs"
+
 # Windows only
 [target.'cfg(not(windows))'.dependencies]
 [target.'cfg(windows)'.dependencies]

--- a/core/tests-rs/fixture_comparison.rs
+++ b/core/tests-rs/fixture_comparison.rs
@@ -1,0 +1,97 @@
+#[path = "../src/manifest_contract.rs"]
+mod manifest_contract;
+
+#[path = "../src/event_contract.rs"]
+mod event_contract;
+
+#[path = "../src/ledger.rs"]
+mod ledger;
+
+mod rust_parity_support {
+    include!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../tests/test_support/rust_parity.rs"
+    ));
+}
+
+use serde_json::Value;
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ProjectionFixture {
+    name: &'static str,
+    file: &'static str,
+}
+
+const PROJECTION_FIXTURES: &[ProjectionFixture] = &[
+    ProjectionFixture {
+        name: "board",
+        file: "board.json",
+    },
+    ProjectionFixture {
+        name: "inbox",
+        file: "inbox.json",
+    },
+    ProjectionFixture {
+        name: "digest",
+        file: "digest.json",
+    },
+    ProjectionFixture {
+        name: "explain",
+        file: "explain.json",
+    },
+];
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("core crate should have a repository parent")
+        .to_path_buf()
+}
+
+fn read_power_shell_golden(case: ProjectionFixture) -> Value {
+    rust_parity_support::read_json_fixture(&repo_root(), case.file)
+}
+
+fn read_rust_ledger_snapshot() -> ledger::LedgerSnapshot {
+    let root = repo_root();
+    let manifest = rust_parity_support::read_text_fixture(&root, "manifest.yaml");
+    let events = rust_parity_support::read_text_fixture(&root, "events.jsonl");
+    ledger::LedgerSnapshot::from_manifest_and_events(&manifest, &events)
+        .expect("frozen manifest and event fixtures should load")
+}
+
+#[test]
+fn fixture_comparison_harness_loads_power_shell_golden_corpus() {
+    for case in PROJECTION_FIXTURES {
+        let value = read_power_shell_golden(*case);
+        assert!(
+            value.is_object(),
+            "{} fixture should be a JSON object",
+            case.name
+        );
+    }
+}
+
+#[test]
+fn fixture_comparison_harness_loads_rust_typed_projection_sources() {
+    let snapshot = read_rust_ledger_snapshot();
+    let board = snapshot.board_projection();
+    let inbox = snapshot.inbox_projection();
+    let digest = snapshot.digest_projection();
+    let explain = snapshot
+        .explain_projection("task:task-256")
+        .expect("fixture task should have an explain projection");
+
+    assert_eq!(board.summary.pane_count, 2);
+    assert!(!inbox.items.is_empty());
+    assert!(!digest.items.is_empty());
+    assert_eq!(explain.run.run_id, "task:task-256");
+}
+
+#[test]
+fn fixture_comparison_harness_declares_projection_coverage() {
+    let names: Vec<_> = PROJECTION_FIXTURES.iter().map(|case| case.name).collect();
+
+    assert_eq!(names, vec!["board", "inbox", "digest", "explain"]);
+}

--- a/docs/project/rust-schema-freeze-inventory.md
+++ b/docs/project/rust-schema-freeze-inventory.md
@@ -199,6 +199,7 @@ Current location:
 
 - `core/src/ledger.rs`
 - `core/tests-rs/ledger_contract.rs`
+- `core/tests-rs/fixture_comparison.rs`
 
 Current boundary:
 
@@ -211,6 +212,7 @@ Current boundary:
 - It derives the first Rust inbox projection from manifest pane state and latest actionable events.
 - It derives the first Rust digest projection from pane read models and inbox action items.
 - It derives the first Rust explain projection from digest items, matching panes, and matching events.
+- It has a fixture comparison harness skeleton that loads the PowerShell golden corpus and Rust typed projection sources.
 - It rejects duplicate manifest `pane_id` values because they make projection identity ambiguous.
 - It preserves manifest pane order separately from the lookup index.
 - It preserves unknown event pane IDs instead of rejecting them, because historical events can outlive the current manifest view.
@@ -225,6 +227,7 @@ Current limitation:
 - The PowerShell and desktop surfaces do not consume the Rust inbox projection yet.
 - The PowerShell and desktop surfaces do not consume the Rust digest projection yet.
 - The PowerShell and desktop surfaces do not consume the Rust explain projection yet.
+- The fixture comparison harness does not diff projection payloads yet.
 
 ### 7. `verdict`
 


### PR DESCRIPTION
## Summary
- add a Rust fixture comparison harness for board, inbox, digest, and explain projection inputs
- load the PowerShell golden corpus and Rust typed ledger sources through one test target
- document that this step only proves shared fixture loading, not payload comparison yet

## Validation
- cargo test --manifest-path .\core\Cargo.toml --test fixture_comparison -- --nocapture
- cargo test --manifest-path .\core\Cargo.toml -- --nocapture
- rustfmt --check core\tests-rs\fixture_comparison.rs
- git diff --check
- pwsh -NoProfile -File .\scripts\git-guard.ps1 -Mode full
- pwsh -NoProfile -File .\scripts\audit-public-surface.ps1
- Opus review for the external Rust learning note: PASS
- subagent review: no blocking findings after staging the new test file

## Task
- TASK-396