### PR TITLE
Serialize Rust ledger projections

### DIFF
--- a/core/src/ledger.rs
+++ b/core/src/ledger.rs
@@ -1,5 +1,6 @@
 use crate::event_contract::{parse_event_jsonl, EventRecord};
 use crate::manifest_contract::{NormalizedManifestPane, WinsmuxManifest};
+use serde::Serialize;
 use serde_json::Value;
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, HashMap, HashSet};
@@ -13,7 +14,7 @@ pub struct LedgerSnapshot {
     panes_by_id: HashMap<String, NormalizedManifestPane>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct LedgerPaneReadModel {
     pub label: String,
     pub pane_id: String,
@@ -50,7 +51,7 @@ pub struct LedgerPaneReadModel {
     pub event_count: usize,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct LedgerBoardSummary {
     pub pane_count: usize,
     pub dirty_panes: usize,
@@ -64,7 +65,7 @@ pub struct LedgerBoardSummary {
     pub by_task_state: BTreeMap<String, usize>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct LedgerBoardPane {
     pub label: String,
     pub pane_id: String,
@@ -81,19 +82,19 @@ pub struct LedgerBoardPane {
     pub last_event_at: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct LedgerBoardProjection {
     pub summary: LedgerBoardSummary,
     pub panes: Vec<LedgerBoardPane>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct LedgerInboxSummary {
     pub item_count: usize,
     pub by_kind: BTreeMap<String, usize>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct LedgerInboxItem {
     pub kind: String,
     pub priority: usize,
@@ -113,13 +114,13 @@ pub struct LedgerInboxItem {
     pub source: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct LedgerInboxProjection {
     pub summary: LedgerInboxSummary,
     pub items: Vec<LedgerInboxItem>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct LedgerDigestSummary {
     pub item_count: usize,
     pub dirty_items: usize,
@@ -128,7 +129,7 @@ pub struct LedgerDigestSummary {
     pub actionable_items: usize,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct LedgerDigestItem {
     pub run_id: String,
     pub task_id: String,
@@ -157,13 +158,13 @@ pub struct LedgerDigestItem {
     pub consultation_ref: String,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct LedgerDigestProjection {
     pub summary: LedgerDigestSummary,
     pub items: Vec<LedgerDigestItem>,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct LedgerExplainProjection {
     pub run: LedgerExplainRun,
     pub explanation: LedgerExplainExplanation,
@@ -171,7 +172,7 @@ pub struct LedgerExplainProjection {
     pub recent_events: Vec<LedgerExplainRecentEvent>,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct LedgerExplainRun {
     pub run_id: String,
     pub task_id: String,
@@ -217,7 +218,7 @@ pub struct LedgerExplainRun {
     pub changed_files: Vec<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct LedgerExplainExplanation {
     pub summary: String,
     pub reasons: Vec<String>,
@@ -225,7 +226,7 @@ pub struct LedgerExplainExplanation {
     pub current_state: LedgerExplainCurrentState,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct LedgerExplainCurrentState {
     pub state: String,
     pub task_state: String,
@@ -233,7 +234,7 @@ pub struct LedgerExplainCurrentState {
     pub last_event: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct LedgerExplainActionItem {
     pub kind: String,
     pub message: String,
@@ -242,7 +243,7 @@ pub struct LedgerExplainActionItem {
     pub source: String,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct LedgerExplainExperimentPacket {
     pub hypothesis: String,
     pub test_plan: Vec<String>,
@@ -259,7 +260,7 @@ pub struct LedgerExplainExperimentPacket {
     pub command_hash: String,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct LedgerExplainRecentEvent {
     pub timestamp: String,
     pub event: String,

--- a/core/tests-rs/ledger_contract.rs
+++ b/core/tests-rs/ledger_contract.rs
@@ -480,6 +480,35 @@ panes:
 }
 
 #[test]
+fn ledger_contract_serializes_projection_surfaces_to_json() {
+    let snapshot =
+        ledger::LedgerSnapshot::from_manifest_and_events(MANIFEST_FIXTURE, EVENTS_FIXTURE)
+            .expect("ledger snapshot should load frozen fixtures");
+
+    let board = serde_json::to_value(snapshot.board_projection())
+        .expect("board projection should serialize to JSON");
+    let inbox = serde_json::to_value(snapshot.inbox_projection())
+        .expect("inbox projection should serialize to JSON");
+    let digest = serde_json::to_value(snapshot.digest_projection())
+        .expect("digest projection should serialize to JSON");
+    let explain = serde_json::to_value(
+        snapshot
+            .explain_projection("task:task-256")
+            .expect("fixture explain projection should exist"),
+    )
+    .expect("explain projection should serialize to JSON");
+
+    assert_eq!(board["summary"]["pane_count"], 2);
+    assert!(board["panes"].is_array());
+    assert!(inbox["summary"]["by_kind"].is_object());
+    assert!(inbox["items"].is_array());
+    assert!(digest["summary"]["actionable_items"].is_number());
+    assert!(digest["items"].is_array());
+    assert_eq!(explain["run"]["run_id"], "task:task-256");
+    assert!(explain["recent_events"].is_array());
+}
+
+#[test]
 fn ledger_contract_sorts_digest_projection_by_latest_event_time() {
     let manifest = r#"
 version: 1

--- a/docs/project/rust-schema-freeze-inventory.md
+++ b/docs/project/rust-schema-freeze-inventory.md
@@ -212,6 +212,7 @@ Current boundary:
 - It derives the first Rust inbox projection from manifest pane state and latest actionable events.
 - It derives the first Rust digest projection from pane read models and inbox action items.
 - It derives the first Rust explain projection from digest items, matching panes, and matching events.
+- The board, inbox, digest, and explain projection structs serialize to JSON through `serde`.
 - It has a fixture comparison harness skeleton that loads the PowerShell golden corpus and Rust typed projection sources.
 - It rejects duplicate manifest `pane_id` values because they make projection identity ambiguous.
 - It preserves manifest pane order separately from the lookup index.
@@ -242,7 +243,7 @@ Current gap:
 
 ## Recommended order after this inventory
 
-1. Keep `LedgerSnapshot` read-only until projection surfaces are ready.
+1. Keep `LedgerSnapshot` read-only until projection surfaces have JSON comparison coverage.
 2. Freeze actionable event payload groups on top of the new `.winsmux/events.jsonl` envelope.
 3. Keep the review-state fixture as the branch-keyed root file shape.
 4. Keep the manifest contract limited to session and pane boundary validation until ledger persistence needs more fields.


### PR DESCRIPTION
## Summary
- make the Rust board, inbox, digest, and explain projections serializable with serde
- add a regression test that converts every projection surface to JSON
- document that TASK-275 still owns full golden payload comparison

## Validation
- cargo test --manifest-path .\core\Cargo.toml --test ledger_contract -- --nocapture
- cargo test --manifest-path .\core\Cargo.toml --test fixture_comparison -- --nocapture
- cargo test --manifest-path .\core\Cargo.toml -- --nocapture
- rustfmt --check core\src\ledger.rs core\tests-rs\ledger_contract.rs
- git diff --check
- pwsh -NoProfile -File .\scripts\git-guard.ps1 -Mode full
- pwsh -NoProfile -File .\scripts\audit-public-surface.ps1
- Opus review for the external Rust learning note: PASS
- subagent review: no findings

## Task
- TASK-280