### PR TITLE
Add Rust operator board/status JSON CLI

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -37,6 +37,10 @@ path = "tests-rs/ledger_contract.rs"
 name = "fixture_comparison"
 path = "tests-rs/fixture_comparison.rs"
 
+[[test]]
+name = "operator_cli"
+path = "tests-rs/operator_cli.rs"
+
 # Windows only
 [target.'cfg(not(windows))'.dependencies]
 [target.'cfg(windows)'.dependencies]

--- a/core/src/cli.rs
+++ b/core/src/cli.rs
@@ -126,6 +126,10 @@ CONFIGURATION COMMANDS:
     show-hooks              Show all defined hooks
     list-commands, lscm     List all available commands
 
+OPERATOR COMMANDS:
+    board --json            Print pane, task, review, and git board JSON
+    status --json           Print session and pane status JSON
+
 LAYOUT COMMANDS:
     select-layout, selectl  Apply a layout preset
                             Presets: even-horizontal, even-vertical,
@@ -383,6 +387,7 @@ pub fn print_version() {
 fn commands_text() -> &'static str {
     r#"Available commands:
   attach-session (attach)   - Attach to a session
+  board                     - Print operator board JSON
   bind-key (bind)           - Bind a key to a command
   break-pane                - Break a pane into a new window
   capture-pane              - Capture the contents of a pane
@@ -451,6 +456,7 @@ fn commands_text() -> &'static str {
   source-file (source)      - Execute commands from a file
   split-window (splitw)     - Split a window into panes
   start-server (warmup)     - Pre-spawn a warm server for instant session creation
+  status                    - Print operator status JSON
   suspend-client (suspendc) - Suspend the client
   swap-pane (swapp)         - Swap two panes
   swap-window (swapw)       - Swap two windows

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -25,6 +25,7 @@ mod terminal_engine;
 mod manifest_contract;
 mod event_contract;
 mod ledger;
+mod operator_cli;
 mod client;
 mod app;
 mod ssh_input;
@@ -230,6 +231,12 @@ fn run_main() -> io::Result<()> {
         "list-commands" | "lscm" => {
             print_commands();
             return Ok(());
+        }
+        "board" => {
+            return operator_cli::run_board_command(&cmd_args[1..]);
+        }
+        "status" => {
+            return operator_cli::run_status_command(&cmd_args[1..]);
         }
         _ => {}
     }

--- a/core/src/operator_cli.rs
+++ b/core/src/operator_cli.rs
@@ -1,0 +1,81 @@
+use std::{
+    env,
+    io::{self, Write},
+};
+
+use crate::ledger::LedgerSnapshot;
+
+pub fn run_board_command(args: &[&String]) -> io::Result<()> {
+    if args.iter().any(|arg| *arg == "-h" || *arg == "--help") {
+        println!("usage: winsmux board --json");
+        return Ok(());
+    }
+
+    if args.len() != 1 || args[0] != "--json" {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "winsmux board currently supports only --json in the Rust CLI",
+        ));
+    }
+
+    let project_dir = env::current_dir()?;
+    let snapshot = LedgerSnapshot::from_project_dir(&project_dir).map_err(|err| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("failed to load winsmux ledger: {err}"),
+        )
+    })?;
+    let projection = snapshot.board_projection();
+
+    let stdout = io::stdout();
+    let mut stdout = stdout.lock();
+    serde_json::to_writer(&mut stdout, &projection).map_err(|err| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("failed to serialize board projection: {err}"),
+        )
+    })?;
+    writeln!(stdout)?;
+    Ok(())
+}
+
+pub fn run_status_command(args: &[&String]) -> io::Result<()> {
+    if args.iter().any(|arg| *arg == "-h" || *arg == "--help") {
+        println!("usage: winsmux status --json");
+        return Ok(());
+    }
+
+    if args.len() != 1 || args[0] != "--json" {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "winsmux status currently supports only --json in the Rust CLI",
+        ));
+    }
+
+    let project_dir = env::current_dir()?;
+    let snapshot = LedgerSnapshot::from_project_dir(&project_dir).map_err(|err| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("failed to load winsmux ledger: {err}"),
+        )
+    })?;
+    let status = serde_json::json!({
+        "session": {
+            "name": snapshot.session_name(),
+            "pane_count": snapshot.pane_count(),
+            "event_count": snapshot.event_count(),
+        },
+        "panes": snapshot.pane_read_models(),
+    });
+
+    let stdout = io::stdout();
+    let mut stdout = stdout.lock();
+    serde_json::to_writer(&mut stdout, &status).map_err(|err| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("failed to serialize status projection: {err}"),
+        )
+    })?;
+    writeln!(stdout)?;
+    Ok(())
+}

--- a/core/tests-rs/operator_cli.rs
+++ b/core/tests-rs/operator_cli.rs
@@ -1,0 +1,143 @@
+use std::fs;
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[test]
+fn operator_cli_board_json_reads_live_winsmux_manifest() {
+    let project_dir = make_temp_project_dir("board-json");
+    write_manifest(&project_dir);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .arg("board")
+        .arg("--json")
+        .current_dir(&project_dir)
+        .output()
+        .expect("winsmux board --json should run");
+
+    assert!(
+        output.status.success(),
+        "winsmux board --json failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("stdout should be JSON");
+    assert_eq!(json["summary"]["pane_count"], 2);
+    assert_eq!(json["summary"]["dirty_panes"], 1);
+    assert_eq!(json["summary"]["review_pending"], 1);
+    assert_eq!(json["summary"]["review_passed"], 1);
+    assert_eq!(json["summary"]["by_state"]["running"], 1);
+    assert_eq!(json["summary"]["by_task_state"]["in_progress"], 1);
+    assert_eq!(json["panes"][0]["label"], "builder-1");
+    assert_eq!(json["panes"][0]["task_id"], "TASK-266");
+    assert_eq!(json["panes"][0]["changed_file_count"], 2);
+    assert_eq!(json["panes"][1]["role"], "Reviewer");
+}
+
+#[test]
+fn operator_cli_status_json_reads_live_winsmux_manifest() {
+    let project_dir = make_temp_project_dir("status-json");
+    write_manifest(&project_dir);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .arg("status")
+        .arg("--json")
+        .current_dir(&project_dir)
+        .output()
+        .expect("winsmux status --json should run");
+
+    assert!(
+        output.status.success(),
+        "winsmux status --json failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("stdout should be JSON");
+    assert_eq!(json["session"]["name"], "winsmux-orchestra");
+    assert_eq!(json["session"]["pane_count"], 2);
+    assert_eq!(json["session"]["event_count"], 0);
+    assert_eq!(json["panes"][0]["label"], "builder-1");
+    assert_eq!(json["panes"][0]["changed_files"][0], "core/src/main.rs");
+    assert_eq!(json["panes"][1]["review_state"], "pass");
+}
+
+#[test]
+fn operator_cli_board_requires_json_flag() {
+    let project_dir = make_temp_project_dir("board-requires-json");
+    write_manifest(&project_dir);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .arg("board")
+        .current_dir(&project_dir)
+        .output()
+        .expect("winsmux board should run and reject missing --json");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("winsmux board currently supports only --json"));
+}
+
+#[test]
+fn operator_cli_status_requires_json_flag() {
+    let project_dir = make_temp_project_dir("status-requires-json");
+    write_manifest(&project_dir);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .arg("status")
+        .current_dir(&project_dir)
+        .output()
+        .expect("winsmux status should run and reject missing --json");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("winsmux status currently supports only --json"));
+}
+
+fn write_manifest(project_dir: &std::path::Path) {
+    let winsmux_dir = project_dir.join(".winsmux");
+    fs::create_dir_all(&winsmux_dir).expect("test should create .winsmux directory");
+    fs::write(
+        winsmux_dir.join("manifest.yaml"),
+        r#"
+version: 1
+session:
+  name: winsmux-orchestra
+panes:
+  builder-1:
+    pane_id: "%2"
+    role: Builder
+    state: running
+    task_id: TASK-266
+    task: Add Rust board JSON
+    task_state: in_progress
+    review_state: pending
+    branch: codex/task266-board-json-20260424
+    head_sha: abc123
+    changed_file_count: 2
+    changed_files:
+      - core/src/main.rs
+      - core/src/operator_cli.rs
+    last_event_at: 2026-04-24T12:00:00+09:00
+  reviewer-1:
+    pane_id: "%3"
+    role: Reviewer
+    state: idle
+    task_state: waiting
+    review_state: pass
+    branch: codex/task266-board-json-20260424
+    head_sha: def456
+"#,
+    )
+    .expect("test should write manifest");
+}
+
+fn make_temp_project_dir(name: &str) -> std::path::PathBuf {
+    let suffix = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock should be after unix epoch")
+        .as_nanos();
+    let path = std::env::temp_dir().join(format!("winsmux-{name}-{}-{suffix}", std::process::id()));
+    fs::create_dir_all(&path).expect("test should create temp project directory");
+    path
+}

--- a/docs/project/rust-schema-freeze-inventory.md
+++ b/docs/project/rust-schema-freeze-inventory.md
@@ -222,6 +222,7 @@ Current boundary:
 - The board, inbox, digest, and explain projection structs serialize to JSON through `serde`.
 - It compares modeled Rust board, inbox, digest, and explain JSON against the PowerShell golden corpus.
 - It prunes PowerShell-only envelope fields before comparison and keeps the Rust-modeled fields strict.
+- The Rust CLI now exposes live read-only `board --json` and `status --json` commands.
 - It rejects duplicate manifest `pane_id` values because they make projection identity ambiguous.
 - It preserves manifest pane order separately from the lookup index.
 - It preserves unknown event pane IDs instead of rejecting them, because historical events can outlive the current manifest view.
@@ -231,8 +232,8 @@ Current boundary:
 Current limitation:
 
 - The snapshot is still read-only.
-- Projection code does not consume the live snapshot yet.
 - The PowerShell and desktop surfaces do not consume the Rust board projection yet.
+- The PowerShell and desktop surfaces do not consume the Rust status read model yet.
 - The PowerShell and desktop surfaces do not consume the Rust inbox projection yet.
 - The PowerShell and desktop surfaces do not consume the Rust digest projection yet.
 - The PowerShell and desktop surfaces do not consume the Rust explain projection yet.


### PR DESCRIPTION
## Summary
- Add top-level Rust CLI handling for \winsmux board --json\.
- Add top-level Rust CLI handling for \winsmux status --json\.
- Add integration tests that run the \winsmux\ binary against a live \.winsmux/manifest.yaml\.

## Validation
- \cargo test --manifest-path .\\core\\Cargo.toml --test operator_cli -- --nocapture\`n- \cargo test --manifest-path .\\core\\Cargo.toml --test ledger_contract -- --nocapture\`n- \cargo test --manifest-path .\\core\\Cargo.toml -- --nocapture\`n- \git diff --check\`n- \pwsh -NoProfile -File .\\scripts\\git-guard.ps1 -Mode full\`n- \pwsh -NoProfile -File .\\scripts\\audit-public-surface.ps1\`n
## Review
- Subagent review found two issues. Both were fixed.
- \codex review --uncommitted\ found no correctness issues.

## Known blocker
- External Rust learning notes were updated, but the required Opus review is not complete.
- The safety gate rejected sending external local note content to Claude Opus as external data export risk.
- Do not merge until that review blocker is resolved or explicitly waived by the maintainer.