### PR TITLE
Add icon-first shell hierarchy

### DIFF
--- a/winsmux-app/index.html
+++ b/winsmux-app/index.html
@@ -13,27 +13,30 @@
       <aside id="left-rail">
         <div class="brand-block">
           <div class="brand">winsmux</div>
-          <div class="sidebar-caption">Workspace sidebar</div>
+          <div class="sidebar-caption">Operator shell</div>
         </div>
         <section class="sidebar-section">
-          <div class="sidebar-section-title">Sessions</div>
+          <div class="sidebar-section-title"><span class="ui-icon" data-icon="◴" aria-hidden="true"></span>Sessions</div>
           <div id="session-list" class="sidebar-list"></div>
         </section>
         <section class="sidebar-section">
-          <div class="sidebar-section-title">Explorer</div>
+          <div class="sidebar-section-title"><span class="ui-icon" data-icon="▱" aria-hidden="true"></span>Files</div>
           <div id="explorer-list" class="sidebar-list"></div>
         </section>
         <section class="sidebar-section">
-          <div class="sidebar-section-title">Open Editors</div>
+          <div class="sidebar-section-title"><span class="ui-icon" data-icon="✎" aria-hidden="true"></span>Editors</div>
           <div id="open-editors-list" class="sidebar-list"></div>
         </section>
         <section class="sidebar-section">
-          <div class="sidebar-section-title">Source Control</div>
+          <div class="sidebar-section-title"><span class="ui-icon" data-icon="⌁" aria-hidden="true"></span>Source</div>
           <div id="source-summary-list" class="sidebar-list"></div>
           <div id="source-entry-list" class="sidebar-list"></div>
         </section>
         <div class="sidebar-spacer"></div>
-        <button id="settings-btn" class="sidebar-settings-btn" type="button">Settings</button>
+        <button id="settings-btn" class="sidebar-settings-btn" type="button" aria-label="Open settings">
+          <span class="ui-icon" data-icon="⚙" aria-hidden="true"></span>
+          <span class="btn-label">Settings</span>
+        </button>
         <div id="sidebar-resizer" aria-hidden="true"></div>
       </aside>
       <main id="workspace">
@@ -50,8 +53,10 @@
               type="button"
               aria-controls="command-bar"
               aria-expanded="false"
+              aria-label="Open command bar"
             >
-              Command
+              <span class="ui-icon" data-icon="⌘" aria-hidden="true"></span>
+              <span class="btn-label">Command</span>
             </button>
             <button
               class="ghost-btn"
@@ -59,8 +64,10 @@
               type="button"
               aria-controls="left-rail"
               aria-expanded="true"
+              aria-label="Toggle workspace sidebar"
             >
-              Workspace
+              <span class="ui-icon" data-icon="☰" aria-hidden="true"></span>
+              <span class="btn-label">Workspace</span>
             </button>
             <button
               class="ghost-btn"
@@ -68,8 +75,10 @@
               type="button"
               aria-controls="context-panel"
               aria-expanded="true"
+              aria-label="Hide context panel"
             >
-              Context
+              <span class="ui-icon" data-icon="◐" aria-hidden="true"></span>
+              <span class="btn-label">Context</span>
             </button>
             <button
               class="ghost-btn"
@@ -77,8 +86,10 @@
               type="button"
               aria-controls="terminal-drawer"
               aria-expanded="false"
+              aria-label="Open terminal drawer"
             >
-              Terminal
+              <span class="ui-icon" data-icon="▣" aria-hidden="true"></span>
+              <span class="btn-label">Terminal</span>
             </button>
           </div>
         </header>
@@ -91,7 +102,7 @@
             </div>
             <div id="timeline-toolbar">
               <div id="timeline-filter-row" aria-label="Timeline filters"></div>
-              <div id="timeline-feed-hint">Material events only: user messages, operator updates, and structured system cards.</div>
+              <div id="timeline-feed-hint">Key events only. Details open when needed.</div>
             </div>
             <div id="selected-run-summary"></div>
             <div id="conversation-timeline" role="log" aria-live="polite" aria-relevant="additions text"></div>
@@ -164,7 +175,7 @@
 
         <section id="terminal-drawer" hidden>
           <div id="terminal-toolbar">
-            <span>Utility drawer: terminal / raw logs / diagnostics only</span>
+            <span><span class="ui-icon" data-icon="▣" aria-hidden="true"></span>Utility terminal</span>
             <button id="add-pane-btn">+ Pane</button>
           </div>
           <div id="panes-container"></div>

--- a/winsmux-app/scripts/viewport-harness.mjs
+++ b/winsmux-app/scripts/viewport-harness.mjs
@@ -572,6 +572,42 @@ async function verifyShortNarrowViewport(page, previewUrl) {
   await assertPreviewClosed(page);
 }
 
+async function verifyDeveloperWindowViewport(page, previewUrl, width, height, label) {
+  await page.setViewportSize({ width, height });
+  await page.goto(`${previewUrl}${HARNESS_QUERY}`, { waitUntil: "networkidle" });
+
+  await assertButtonVisible(page, "#send-btn");
+  await page.locator("#toggle-sidebar-btn[aria-expanded='false']").waitFor();
+
+  await page.click("#open-command-bar-btn");
+  await page.locator("#command-bar-shell").waitFor({ state: "visible" });
+  await assertFullyVisible(page, "#command-bar");
+  await assertButtonVisible(page, "#command-bar-input");
+  await page.keyboard.press("Escape");
+  await page.locator("#command-bar-shell").waitFor({ state: "hidden" });
+
+  await page.click("#toggle-sidebar-btn");
+  await page.locator("#toggle-sidebar-btn[aria-expanded='true']").waitFor();
+  await waitForHorizontalVisibility(page, "#left-rail");
+  await assertHorizontallyVisible(page, "#left-rail");
+  await assertFullyVisible(page, "#sidebar-overlay");
+  await assertSettingsRoundtrip(page, "#left-rail");
+  const viewport = page.viewportSize();
+  if (!viewport) {
+    throw new Error(`Viewport size is unavailable for ${label}`);
+  }
+  await page.mouse.click(viewport.width - 10, 24);
+  await page.locator("#toggle-sidebar-btn[aria-expanded='false']").waitFor();
+
+  await page.click("#toggle-terminal-btn");
+  await page.locator("#terminal-drawer").waitFor({ state: "visible" });
+  await assertButtonVisible(page, "#add-pane-btn");
+  await assertFullyVisible(page, "#terminal-drawer");
+  await assertHorizontallyVisible(page, "#terminal-toolbar");
+  await page.click("#toggle-terminal-btn");
+  await page.locator("#terminal-drawer").waitFor({ state: "hidden" });
+}
+
 async function run() {
   await ensureOutputDir();
 
@@ -586,6 +622,9 @@ async function run() {
     const page = await browser.newPage();
 
     await verifyDesktopViewport(page, previewUrl);
+    await verifyDeveloperWindowViewport(page, previewUrl, 1366, 768, "developer-1366x768");
+    await verifyDeveloperWindowViewport(page, previewUrl, 1280, 720, "developer-1280x720");
+    await verifyDeveloperWindowViewport(page, previewUrl, 800, 600, "tauri-default-800x600");
     await verifyNarrowViewport(page, previewUrl);
     await verifyShortNarrowViewport(page, previewUrl);
 
@@ -612,6 +651,9 @@ async function run() {
             "desktop-settings-with-preview",
             "desktop-preview-back-to-code",
             "desktop-terminal-drawer",
+            "developer-1366x768",
+            "developer-1280x720",
+            "tauri-default-800x600",
             "narrow-393x852",
             "narrow-command-bar",
             "narrow-settings-sheet",

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -4831,8 +4831,9 @@ function setTerminalDrawer(open: boolean) {
   }
 
   drawer.hidden = !open;
-  button.textContent = open ? "Hide Terminal" : "Terminal";
+  setCompactButtonLabel(button, open ? "Hide" : "Terminal");
   button.setAttribute("aria-expanded", open ? "true" : "false");
+  button.setAttribute("aria-label", open ? "Hide terminal drawer" : "Open terminal drawer");
 
   if (open && panes.size === 0) {
     createPane("main");
@@ -4859,8 +4860,19 @@ function setContextPanel(open: boolean, options?: { preserveWidePreference?: boo
 
   panel.toggleAttribute("hidden", !open);
   body.classList.toggle("context-collapsed", !open);
-  button.textContent = open ? "Hide Context" : "Context";
+  setCompactButtonLabel(button, open ? "Hide" : "Context");
   button.setAttribute("aria-expanded", open ? "true" : "false");
+  button.setAttribute("aria-label", open ? "Hide context panel" : "Show context panel");
+}
+
+function setCompactButtonLabel(button: Element, label: string) {
+  const labelNode = button.querySelector(".btn-label");
+  if (labelNode) {
+    labelNode.textContent = label;
+    return;
+  }
+
+  button.textContent = label;
 }
 
 function setEditorSurface(open: boolean) {

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -4879,7 +4879,7 @@ function setEditorSurface(open: boolean) {
 }
 
 function isNarrowLayout() {
-  return window.matchMedia("(max-width: 1180px)").matches;
+  return window.matchMedia("(max-width: 1366px)").matches;
 }
 
 function setSidebarOpen(open: boolean, options?: { preserveWidePreference?: boolean }) {

--- a/winsmux-app/src/styles.css
+++ b/winsmux-app/src/styles.css
@@ -70,6 +70,27 @@ textarea {
   font: inherit;
 }
 
+.ui-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.15em;
+  height: 1.15em;
+  color: currentColor;
+  line-height: 1;
+  flex: 0 0 auto;
+}
+
+.ui-icon::before {
+  content: attr(data-icon);
+  font-size: 1em;
+  font-weight: 700;
+}
+
+.btn-label {
+  min-width: 0;
+}
+
 .sr-only {
   position: absolute;
   width: 1px;
@@ -181,6 +202,9 @@ textarea {
 }
 
 .sidebar-section-title {
+  display: flex;
+  align-items: center;
+  gap: 7px;
   font-size: var(--text-2xs);
   font-weight: 700;
   text-transform: uppercase;
@@ -258,6 +282,10 @@ textarea {
 }
 
 .sidebar-settings-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
   border: 1px solid var(--border-strong);
   background: var(--bg-surface-raised);
   color: var(--text-secondary);
@@ -325,6 +353,10 @@ textarea {
 }
 
 .ghost-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
   border: 1px solid var(--border-strong);
   background: var(--bg-surface-raised);
   color: var(--text-secondary);
@@ -1740,6 +1772,12 @@ body[data-popout-surface="1"] #editor-surface {
   color: #8f99ba;
 }
 
+#terminal-toolbar span {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+}
+
 #add-pane-btn {
   border: 1px solid var(--border-strong);
   background: var(--bg-surface-raised);
@@ -1858,6 +1896,11 @@ body[data-popout-surface="1"] #editor-surface {
 
   #header-actions {
     flex-wrap: wrap;
+  }
+
+  #header-actions .ghost-btn {
+    min-width: 42px;
+    padding-inline: 11px;
   }
 
   #sidebar-overlay {
@@ -2019,6 +2062,21 @@ body[data-popout-surface="1"] #editor-surface {
   .command-bar-item-meta {
     align-items: flex-start;
     min-width: 0;
+  }
+}
+
+@media (max-width: 720px) {
+  #header-actions .btn-label {
+    display: none;
+  }
+
+  #header-actions .ghost-btn {
+    border-radius: 14px;
+    padding: 10px;
+  }
+
+  .sidebar-section-title {
+    letter-spacing: 0.06em;
   }
 }
 

--- a/winsmux-app/src/styles.css
+++ b/winsmux-app/src/styles.css
@@ -1846,7 +1846,7 @@ body[data-popout-surface="1"] #editor-surface {
   }
 }
 
-@media (max-width: 1180px) {
+@media (max-width: 1366px) {
   #app-shell {
     grid-template-columns: minmax(0, 1fr);
   }
@@ -2089,7 +2089,7 @@ body[data-popout-surface="1"] #editor-surface {
   }
 }
 
-@media (max-width: 1180px) and (max-height: 760px) {
+@media (max-width: 1366px) and (max-height: 760px) {
   #editor-surface {
     gap: 8px;
     padding: 10px;


### PR DESCRIPTION
## Summary
- add simple icon-assisted labels for the header, sidebar, settings, and terminal drawer
- shorten the feed and terminal drawer copy
- keep accessible names for narrow icon-only controls

## Validation
- cmd /c npm run build
- cmd /c npm run test:viewport-harness
- git diff --check
- pwsh -NoProfile -File .\\scripts\\git-guard.ps1 -Mode full
- pwsh -NoProfile -File .\\scripts\\audit-public-surface.ps1

## Review
- subagent review found accessibility findings; fixed
- follow-up subagent review found no findings

## Notes
- Stacked on PR #622 / TASK-398.