### PR TITLE
Add timeline focus display preference

### DIFF
--- a/winsmux-app/index.html
+++ b/winsmux-app/index.html
@@ -209,6 +209,11 @@
             <div id="wrap-options" class="settings-option-row" aria-label="Wrap options"></div>
           </div>
           <div class="settings-section">
+            <div class="context-label">Code font</div>
+            <div class="context-value">Used in code preview, terminal panes, and diff details.</div>
+            <div id="code-font-options" class="settings-option-row" aria-label="Code font options"></div>
+          </div>
+          <div class="settings-section">
             <div class="context-label">Workspace</div>
             <div class="context-value">Sidebar width, context collapse, terminal drawer behavior</div>
           </div>

--- a/winsmux-app/index.html
+++ b/winsmux-app/index.html
@@ -214,6 +214,11 @@
             <div id="code-font-options" class="settings-option-row" aria-label="Code font options"></div>
           </div>
           <div class="settings-section">
+            <div class="context-label">Display</div>
+            <div class="context-value">Choose how much timeline detail stays visible by default.</div>
+            <div id="focus-mode-options" class="settings-option-row" aria-label="Display detail options"></div>
+          </div>
+          <div class="settings-section">
             <div class="context-label">Workspace</div>
             <div class="context-value">Sidebar width, context collapse, terminal drawer behavior</div>
           </div>

--- a/winsmux-app/index.html
+++ b/winsmux-app/index.html
@@ -13,27 +13,30 @@
       <aside id="left-rail">
         <div class="brand-block">
           <div class="brand">winsmux</div>
-          <div class="sidebar-caption">Workspace sidebar</div>
+          <div class="sidebar-caption">Operator shell</div>
         </div>
         <section class="sidebar-section">
-          <div class="sidebar-section-title">Sessions</div>
+          <div class="sidebar-section-title"><span class="ui-icon" data-icon="◴" aria-hidden="true"></span>Sessions</div>
           <div id="session-list" class="sidebar-list"></div>
         </section>
         <section class="sidebar-section">
-          <div class="sidebar-section-title">Explorer</div>
+          <div class="sidebar-section-title"><span class="ui-icon" data-icon="▱" aria-hidden="true"></span>Files</div>
           <div id="explorer-list" class="sidebar-list"></div>
         </section>
         <section class="sidebar-section">
-          <div class="sidebar-section-title">Open Editors</div>
+          <div class="sidebar-section-title"><span class="ui-icon" data-icon="✎" aria-hidden="true"></span>Editors</div>
           <div id="open-editors-list" class="sidebar-list"></div>
         </section>
         <section class="sidebar-section">
-          <div class="sidebar-section-title">Source Control</div>
+          <div class="sidebar-section-title"><span class="ui-icon" data-icon="⌁" aria-hidden="true"></span>Source</div>
           <div id="source-summary-list" class="sidebar-list"></div>
           <div id="source-entry-list" class="sidebar-list"></div>
         </section>
         <div class="sidebar-spacer"></div>
-        <button id="settings-btn" class="sidebar-settings-btn" type="button">Settings</button>
+        <button id="settings-btn" class="sidebar-settings-btn" type="button" aria-label="Open settings">
+          <span class="ui-icon" data-icon="⚙" aria-hidden="true"></span>
+          <span class="btn-label">Settings</span>
+        </button>
         <div id="sidebar-resizer" aria-hidden="true"></div>
       </aside>
       <main id="workspace">
@@ -50,8 +53,10 @@
               type="button"
               aria-controls="command-bar"
               aria-expanded="false"
+              aria-label="Open command bar"
             >
-              Command
+              <span class="ui-icon" data-icon="⌘" aria-hidden="true"></span>
+              <span class="btn-label">Command</span>
             </button>
             <button
               class="ghost-btn"
@@ -59,8 +64,10 @@
               type="button"
               aria-controls="left-rail"
               aria-expanded="true"
+              aria-label="Toggle workspace sidebar"
             >
-              Workspace
+              <span class="ui-icon" data-icon="☰" aria-hidden="true"></span>
+              <span class="btn-label">Workspace</span>
             </button>
             <button
               class="ghost-btn"
@@ -68,8 +75,10 @@
               type="button"
               aria-controls="context-panel"
               aria-expanded="true"
+              aria-label="Hide context panel"
             >
-              Context
+              <span class="ui-icon" data-icon="◐" aria-hidden="true"></span>
+              <span class="btn-label">Context</span>
             </button>
             <button
               class="ghost-btn"
@@ -77,8 +86,10 @@
               type="button"
               aria-controls="terminal-drawer"
               aria-expanded="false"
+              aria-label="Open terminal drawer"
             >
-              Terminal
+              <span class="ui-icon" data-icon="▣" aria-hidden="true"></span>
+              <span class="btn-label">Terminal</span>
             </button>
           </div>
         </header>
@@ -91,7 +102,7 @@
             </div>
             <div id="timeline-toolbar">
               <div id="timeline-filter-row" aria-label="Timeline filters"></div>
-              <div id="timeline-feed-hint">Material events only: user messages, operator updates, and structured system cards.</div>
+              <div id="timeline-feed-hint">Key events only. Details open when needed.</div>
             </div>
             <div id="selected-run-summary"></div>
             <div id="conversation-timeline" role="log" aria-live="polite" aria-relevant="additions text"></div>
@@ -164,7 +175,7 @@
 
         <section id="terminal-drawer" hidden>
           <div id="terminal-toolbar">
-            <span>Utility drawer: terminal / raw logs / diagnostics only</span>
+            <span><span class="ui-icon" data-icon="▣" aria-hidden="true"></span>Utility terminal</span>
             <button id="add-pane-btn">+ Pane</button>
           </div>
           <div id="panes-container"></div>

--- a/winsmux-app/scripts/viewport-harness.mjs
+++ b/winsmux-app/scripts/viewport-harness.mjs
@@ -572,6 +572,42 @@ async function verifyShortNarrowViewport(page, previewUrl) {
   await assertPreviewClosed(page);
 }
 
+async function verifyDeveloperWindowViewport(page, previewUrl, width, height, label) {
+  await page.setViewportSize({ width, height });
+  await page.goto(`${previewUrl}${HARNESS_QUERY}`, { waitUntil: "networkidle" });
+
+  await assertButtonVisible(page, "#send-btn");
+  await page.locator("#toggle-sidebar-btn[aria-expanded='false']").waitFor();
+
+  await page.click("#open-command-bar-btn");
+  await page.locator("#command-bar-shell").waitFor({ state: "visible" });
+  await assertFullyVisible(page, "#command-bar");
+  await assertButtonVisible(page, "#command-bar-input");
+  await page.keyboard.press("Escape");
+  await page.locator("#command-bar-shell").waitFor({ state: "hidden" });
+
+  await page.click("#toggle-sidebar-btn");
+  await page.locator("#toggle-sidebar-btn[aria-expanded='true']").waitFor();
+  await waitForHorizontalVisibility(page, "#left-rail");
+  await assertHorizontallyVisible(page, "#left-rail");
+  await assertFullyVisible(page, "#sidebar-overlay");
+  await assertSettingsRoundtrip(page, "#left-rail");
+  const viewport = page.viewportSize();
+  if (!viewport) {
+    throw new Error(`Viewport size is unavailable for ${label}`);
+  }
+  await page.mouse.click(viewport.width - 10, 24);
+  await page.locator("#toggle-sidebar-btn[aria-expanded='false']").waitFor();
+
+  await page.click("#toggle-terminal-btn");
+  await page.locator("#terminal-drawer").waitFor({ state: "visible" });
+  await assertButtonVisible(page, "#add-pane-btn");
+  await assertFullyVisible(page, "#terminal-drawer");
+  await assertHorizontallyVisible(page, "#terminal-toolbar");
+  await page.click("#toggle-terminal-btn");
+  await page.locator("#terminal-drawer").waitFor({ state: "hidden" });
+}
+
 async function run() {
   await ensureOutputDir();
 
@@ -586,6 +622,9 @@ async function run() {
     const page = await browser.newPage();
 
     await verifyDesktopViewport(page, previewUrl);
+    await verifyDeveloperWindowViewport(page, previewUrl, 1366, 768, "developer-1366x768");
+    await verifyDeveloperWindowViewport(page, previewUrl, 1280, 720, "developer-1280x720");
+    await verifyDeveloperWindowViewport(page, previewUrl, 800, 600, "tauri-default-800x600");
     await verifyNarrowViewport(page, previewUrl);
     await verifyShortNarrowViewport(page, previewUrl);
 
@@ -612,6 +651,9 @@ async function run() {
             "desktop-settings-with-preview",
             "desktop-preview-back-to-code",
             "desktop-terminal-drawer",
+            "developer-1366x768",
+            "developer-1280x720",
+            "tauri-default-800x600",
             "narrow-393x852",
             "narrow-command-bar",
             "narrow-settings-sheet",

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -4831,8 +4831,9 @@ function setTerminalDrawer(open: boolean) {
   }
 
   drawer.hidden = !open;
-  button.textContent = open ? "Hide Terminal" : "Terminal";
+  setCompactButtonLabel(button, open ? "Hide" : "Terminal");
   button.setAttribute("aria-expanded", open ? "true" : "false");
+  button.setAttribute("aria-label", open ? "Hide terminal drawer" : "Open terminal drawer");
 
   if (open && panes.size === 0) {
     createPane("main");
@@ -4859,8 +4860,19 @@ function setContextPanel(open: boolean, options?: { preserveWidePreference?: boo
 
   panel.toggleAttribute("hidden", !open);
   body.classList.toggle("context-collapsed", !open);
-  button.textContent = open ? "Hide Context" : "Context";
+  setCompactButtonLabel(button, open ? "Hide" : "Context");
   button.setAttribute("aria-expanded", open ? "true" : "false");
+  button.setAttribute("aria-label", open ? "Hide context panel" : "Show context panel");
+}
+
+function setCompactButtonLabel(button: Element, label: string) {
+  const labelNode = button.querySelector(".btn-label");
+  if (labelNode) {
+    labelNode.textContent = label;
+    return;
+  }
+
+  button.textContent = label;
 }
 
 function setEditorSurface(open: boolean) {

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -4879,7 +4879,7 @@ function setEditorSurface(open: boolean) {
 }
 
 function isNarrowLayout() {
-  return window.matchMedia("(max-width: 1180px)").matches;
+  return window.matchMedia("(max-width: 1366px)").matches;
 }
 
 function setSidebarOpen(open: boolean, options?: { preserveWidePreference?: boolean }) {

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -197,12 +197,14 @@ type ThemeMode = "codex-dark" | "graphite-dark";
 type DensityMode = "comfortable" | "compact";
 type WrapMode = "balanced" | "compact";
 type CodeFontMode = "system" | "google-sans-code" | "jetbrains-mono";
+type FocusMode = "standard" | "focused";
 
 interface ThemeState {
   theme: ThemeMode;
   density: DensityMode;
   wrapMode: WrapMode;
   codeFont: CodeFontMode;
+  focusMode: FocusMode;
 }
 
 interface ShellPreferenceState extends ThemeState {
@@ -324,6 +326,7 @@ const themeState: ThemeState = {
   density: "comfortable",
   wrapMode: "balanced",
   codeFont: "system",
+  focusMode: "standard",
 };
 let settingsDraftState: ThemeState | null = null;
 let preferredWideSidebarOpen = true;
@@ -376,6 +379,11 @@ const codeFontOptions: Array<{ value: CodeFontMode; label: string; description: 
   { value: "system", label: "System mono", description: "Use the current platform monospace stack." },
   { value: "google-sans-code", label: "Google Sans Code", description: "Cleaner code reading when installed on Windows." },
   { value: "jetbrains-mono", label: "JetBrains Mono", description: "Familiar developer font with clear symbols." },
+];
+
+const focusModeOptions: Array<{ value: FocusMode; label: string; description: string }> = [
+  { value: "standard", label: "Standard", description: "Show timeline detail chips on every event." },
+  { value: "focused", label: "Focus", description: "Keep details for selected, review, and attention events." },
 ];
 
 function getCodeFontFamily(mode: CodeFontMode = themeState.codeFont) {
@@ -2456,6 +2464,7 @@ function cloneThemeState(state: ThemeState): ThemeState {
     density: state.density,
     wrapMode: state.wrapMode,
     codeFont: state.codeFont,
+    focusMode: state.focusMode,
   };
 }
 
@@ -2463,7 +2472,8 @@ function themeStatesEqual(left: ThemeState, right: ThemeState) {
   return left.theme === right.theme
     && left.density === right.density
     && left.wrapMode === right.wrapMode
-    && left.codeFont === right.codeFont;
+    && left.codeFont === right.codeFont
+    && left.focusMode === right.focusMode;
 }
 
 function readStoredShellPreferences(): ShellPreferenceState | null {
@@ -2478,6 +2488,7 @@ function readStoredShellPreferences(): ShellPreferenceState | null {
     const density = densityOptions.find((item) => item.value === parsed.density)?.value;
     const wrapMode = wrapOptions.find((item) => item.value === parsed.wrapMode)?.value;
     const codeFont = codeFontOptions.find((item) => item.value === parsed.codeFont)?.value ?? "system";
+    const focusMode = focusModeOptions.find((item) => item.value === parsed.focusMode)?.value ?? "standard";
     if (!theme || !density || !wrapMode) {
       return null;
     }
@@ -2491,6 +2502,7 @@ function readStoredShellPreferences(): ShellPreferenceState | null {
       density,
       wrapMode,
       codeFont,
+      focusMode,
       sidebarWidth: Math.max(240, Math.min(380, Math.round(sidebarWidthValue))),
       wideSidebarOpen,
       wideContextOpen,
@@ -2507,6 +2519,7 @@ function persistThemeState() {
       density: themeState.density,
       wrapMode: themeState.wrapMode,
       codeFont: themeState.codeFont,
+      focusMode: themeState.focusMode,
       sidebarWidth,
       wideSidebarOpen: preferredWideSidebarOpen,
       wideContextOpen: preferredWideContextOpen,
@@ -2529,6 +2542,7 @@ function applyShellPreferences() {
   shell.dataset.density = themeState.density;
   shell.dataset.wrapMode = themeState.wrapMode;
   shell.dataset.codeFont = themeState.codeFont;
+  shell.dataset.focusMode = themeState.focusMode;
 }
 
 function applyThemeState(nextState: ThemeState) {
@@ -2536,8 +2550,11 @@ function applyThemeState(nextState: ThemeState) {
   themeState.density = nextState.density;
   themeState.wrapMode = nextState.wrapMode;
   themeState.codeFont = nextState.codeFont;
+  themeState.focusMode = nextState.focusMode;
   applyShellPreferences();
+  updateTimelineFeedHint();
   applyCodeFontToPanes();
+  renderConversation(getConversationItems());
   renderFooterLane();
 }
 
@@ -2605,6 +2622,14 @@ function renderSettingsControls() {
       settingsDraftState = cloneThemeState(themeState);
     }
     settingsDraftState.codeFont = value;
+    renderSettingsControls();
+  });
+
+  renderPreferenceOptions("focus-mode-options", focusModeOptions, activeState.focusMode, (value) => {
+    if (!settingsDraftState) {
+      settingsDraftState = cloneThemeState(themeState);
+    }
+    settingsDraftState.focusMode = value;
     renderSettingsControls();
   });
 
@@ -3088,6 +3113,29 @@ function getVisibleConversationItems(items: ConversationItem[]) {
   }
 }
 
+function shouldShowTimelineDetails(item: ConversationItem) {
+  if (themeState.focusMode !== "focused") {
+    return true;
+  }
+
+  if (item.category === "attention" || item.category === "review") {
+    return true;
+  }
+
+  return Boolean(item.runId && item.runId === getSelectedRunId());
+}
+
+function updateTimelineFeedHint() {
+  const hint = document.getElementById("timeline-feed-hint");
+  if (!hint) {
+    return;
+  }
+
+  hint.textContent = themeState.focusMode === "focused"
+    ? "Focus mode hides routine details. Select a run to expand it."
+    : "Key events only. Details open when needed.";
+}
+
 function renderTimelineFilters() {
   const root = document.getElementById("timeline-filter-row");
   if (!root) {
@@ -3235,7 +3283,7 @@ function renderConversation(items: ConversationItem[]) {
     body.textContent = item.body;
     article.appendChild(body);
 
-    if (item.details?.length) {
+    if (item.details?.length && shouldShowTimelineDetails(item)) {
       const detailRow = document.createElement("div");
       detailRow.className = "timeline-detail-row";
       for (const detail of item.details) {
@@ -3801,8 +3849,8 @@ function getCommandActions(): CommandAction[] {
     {
       id: "settings",
       label: "Open settings",
-      description: "Open theme, density, wrap, and workspace preferences.",
-      keywords: ["settings", "theme", "density", "wrap", "preferences"],
+      description: "Open theme, density, wrap, font, and display preferences.",
+      keywords: ["settings", "theme", "density", "wrap", "font", "display", "focus", "preferences"],
       tone: "accent",
       run: () => setSettingsSheet(true),
     },

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -196,11 +196,13 @@ type CompareRiskLevel = "low" | "medium" | "high";
 type ThemeMode = "codex-dark" | "graphite-dark";
 type DensityMode = "comfortable" | "compact";
 type WrapMode = "balanced" | "compact";
+type CodeFontMode = "system" | "google-sans-code" | "jetbrains-mono";
 
 interface ThemeState {
   theme: ThemeMode;
   density: DensityMode;
   wrapMode: WrapMode;
+  codeFont: CodeFontMode;
 }
 
 interface ShellPreferenceState extends ThemeState {
@@ -321,6 +323,7 @@ const themeState: ThemeState = {
   theme: "codex-dark",
   density: "comfortable",
   wrapMode: "balanced",
+  codeFont: "system",
 };
 let settingsDraftState: ThemeState | null = null;
 let preferredWideSidebarOpen = true;
@@ -368,6 +371,24 @@ const wrapOptions: Array<{ value: WrapMode; label: string; description: string }
   { value: "balanced", label: "Balanced", description: "Preferred readability for timeline, code, and footer lanes." },
   { value: "compact", label: "Compact", description: "Denser wrapping for narrow windows and long traces." },
 ];
+
+const codeFontOptions: Array<{ value: CodeFontMode; label: string; description: string }> = [
+  { value: "system", label: "System mono", description: "Use the current platform monospace stack." },
+  { value: "google-sans-code", label: "Google Sans Code", description: "Cleaner code reading when installed on Windows." },
+  { value: "jetbrains-mono", label: "JetBrains Mono", description: "Familiar developer font with clear symbols." },
+];
+
+function getCodeFontFamily(mode: CodeFontMode = themeState.codeFont) {
+  switch (mode) {
+    case "google-sans-code":
+      return "\"Google Sans Code\", \"Cascadia Code\", \"Consolas\", monospace";
+    case "jetbrains-mono":
+      return "\"JetBrains Mono\", \"Cascadia Code\", \"Consolas\", monospace";
+    case "system":
+    default:
+      return "\"Cascadia Code\", \"Consolas\", monospace";
+  }
+}
 
 function createPane(paneId?: string): string {
   const id = paneId || `pane-${++paneCounter}`;
@@ -421,7 +442,7 @@ function createPane(paneId?: string): string {
   const terminal = new Terminal({
     cursorBlink: true,
     fontSize: 13,
-    fontFamily: "'Cascadia Code', 'Consolas', monospace",
+    fontFamily: getCodeFontFamily(),
     theme: {
       background: "#131722",
       foreground: "#c7d2e6",
@@ -2434,13 +2455,15 @@ function cloneThemeState(state: ThemeState): ThemeState {
     theme: state.theme,
     density: state.density,
     wrapMode: state.wrapMode,
+    codeFont: state.codeFont,
   };
 }
 
 function themeStatesEqual(left: ThemeState, right: ThemeState) {
   return left.theme === right.theme
     && left.density === right.density
-    && left.wrapMode === right.wrapMode;
+    && left.wrapMode === right.wrapMode
+    && left.codeFont === right.codeFont;
 }
 
 function readStoredShellPreferences(): ShellPreferenceState | null {
@@ -2454,6 +2477,7 @@ function readStoredShellPreferences(): ShellPreferenceState | null {
     const theme = themeOptions.find((item) => item.value === parsed.theme)?.value;
     const density = densityOptions.find((item) => item.value === parsed.density)?.value;
     const wrapMode = wrapOptions.find((item) => item.value === parsed.wrapMode)?.value;
+    const codeFont = codeFontOptions.find((item) => item.value === parsed.codeFont)?.value ?? "system";
     if (!theme || !density || !wrapMode) {
       return null;
     }
@@ -2466,6 +2490,7 @@ function readStoredShellPreferences(): ShellPreferenceState | null {
       theme,
       density,
       wrapMode,
+      codeFont,
       sidebarWidth: Math.max(240, Math.min(380, Math.round(sidebarWidthValue))),
       wideSidebarOpen,
       wideContextOpen,
@@ -2481,6 +2506,7 @@ function persistThemeState() {
       theme: themeState.theme,
       density: themeState.density,
       wrapMode: themeState.wrapMode,
+      codeFont: themeState.codeFont,
       sidebarWidth,
       wideSidebarOpen: preferredWideSidebarOpen,
       wideContextOpen: preferredWideContextOpen,
@@ -2502,14 +2528,25 @@ function applyShellPreferences() {
   shell.dataset.theme = themeState.theme;
   shell.dataset.density = themeState.density;
   shell.dataset.wrapMode = themeState.wrapMode;
+  shell.dataset.codeFont = themeState.codeFont;
 }
 
 function applyThemeState(nextState: ThemeState) {
   themeState.theme = nextState.theme;
   themeState.density = nextState.density;
   themeState.wrapMode = nextState.wrapMode;
+  themeState.codeFont = nextState.codeFont;
   applyShellPreferences();
+  applyCodeFontToPanes();
   renderFooterLane();
+}
+
+function applyCodeFontToPanes() {
+  const fontFamily = getCodeFontFamily();
+  panes.forEach((pane) => {
+    pane.terminal.options.fontFamily = fontFamily;
+    pane.fitAddon.fit();
+  });
 }
 
 function renderPreferenceOptions<T extends string>(
@@ -2560,6 +2597,14 @@ function renderSettingsControls() {
       settingsDraftState = cloneThemeState(themeState);
     }
     settingsDraftState.wrapMode = value;
+    renderSettingsControls();
+  });
+
+  renderPreferenceOptions("code-font-options", codeFontOptions, activeState.codeFont, (value) => {
+    if (!settingsDraftState) {
+      settingsDraftState = cloneThemeState(themeState);
+    }
+    settingsDraftState.codeFont = value;
     renderSettingsControls();
   });
 

--- a/winsmux-app/src/styles.css
+++ b/winsmux-app/src/styles.css
@@ -70,6 +70,27 @@ textarea {
   font: inherit;
 }
 
+.ui-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.15em;
+  height: 1.15em;
+  color: currentColor;
+  line-height: 1;
+  flex: 0 0 auto;
+}
+
+.ui-icon::before {
+  content: attr(data-icon);
+  font-size: 1em;
+  font-weight: 700;
+}
+
+.btn-label {
+  min-width: 0;
+}
+
 .sr-only {
   position: absolute;
   width: 1px;
@@ -181,6 +202,9 @@ textarea {
 }
 
 .sidebar-section-title {
+  display: flex;
+  align-items: center;
+  gap: 7px;
   font-size: var(--text-2xs);
   font-weight: 700;
   text-transform: uppercase;
@@ -258,6 +282,10 @@ textarea {
 }
 
 .sidebar-settings-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
   border: 1px solid var(--border-strong);
   background: var(--bg-surface-raised);
   color: var(--text-secondary);
@@ -325,6 +353,10 @@ textarea {
 }
 
 .ghost-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
   border: 1px solid var(--border-strong);
   background: var(--bg-surface-raised);
   color: var(--text-secondary);
@@ -1740,6 +1772,12 @@ body[data-popout-surface="1"] #editor-surface {
   color: #8f99ba;
 }
 
+#terminal-toolbar span {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+}
+
 #add-pane-btn {
   border: 1px solid var(--border-strong);
   background: var(--bg-surface-raised);
@@ -1858,6 +1896,11 @@ body[data-popout-surface="1"] #editor-surface {
 
   #header-actions {
     flex-wrap: wrap;
+  }
+
+  #header-actions .ghost-btn {
+    min-width: 42px;
+    padding-inline: 11px;
   }
 
   #sidebar-overlay {
@@ -2019,6 +2062,21 @@ body[data-popout-surface="1"] #editor-surface {
   .command-bar-item-meta {
     align-items: flex-start;
     min-width: 0;
+  }
+}
+
+@media (max-width: 720px) {
+  #header-actions .btn-label {
+    display: none;
+  }
+
+  #header-actions .ghost-btn {
+    border-radius: 14px;
+    padding: 10px;
+  }
+
+  .sidebar-section-title {
+    letter-spacing: 0.06em;
   }
 }
 

--- a/winsmux-app/src/styles.css
+++ b/winsmux-app/src/styles.css
@@ -168,6 +168,10 @@ textarea {
   --font-code: "JetBrains Mono", "Cascadia Code", "Consolas", monospace;
 }
 
+#app-shell[data-focus-mode="focused"] .timeline-detail-pill {
+  background: rgba(14, 17, 26, 0.32);
+}
+
 #sidebar-overlay {
   display: none;
 }

--- a/winsmux-app/src/styles.css
+++ b/winsmux-app/src/styles.css
@@ -160,6 +160,14 @@ textarea {
   --editor-white-space: pre-wrap;
 }
 
+#app-shell[data-code-font="google-sans-code"] {
+  --font-code: "Google Sans Code", "Cascadia Code", "Consolas", monospace;
+}
+
+#app-shell[data-code-font="jetbrains-mono"] {
+  --font-code: "JetBrains Mono", "Cascadia Code", "Consolas", monospace;
+}
+
 #sidebar-overlay {
   display: none;
 }

--- a/winsmux-app/src/styles.css
+++ b/winsmux-app/src/styles.css
@@ -1846,7 +1846,7 @@ body[data-popout-surface="1"] #editor-surface {
   }
 }
 
-@media (max-width: 1180px) {
+@media (max-width: 1366px) {
   #app-shell {
     grid-template-columns: minmax(0, 1fr);
   }
@@ -2089,7 +2089,7 @@ body[data-popout-surface="1"] #editor-surface {
   }
 }
 
-@media (max-width: 1180px) and (max-height: 760px) {
+@media (max-width: 1366px) and (max-height: 760px) {
   #editor-surface {
     gap: 8px;
     padding: 10px;


### PR DESCRIPTION
## Summary
- Add a Display preference for timeline focus mode.
- Persist the focus mode in shell preferences with a backward-compatible default.
- Hide routine detail chips in focus mode while keeping selected run, review, and attention details visible.

## Validation
- cmd /c npm run build
- cmd /c npm run test:viewport-harness
- git diff --check
- pwsh -NoProfile -File .\\scripts\\git-guard.ps1 -Mode full
- pwsh -NoProfile -File .\\scripts\\audit-public-surface.ps1

## Review
- Subagent review completed with no findings.

Stacked on #625.