### PR TITLE
Add Rust operator read-model CLI

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -37,6 +37,10 @@ path = "tests-rs/ledger_contract.rs"
 name = "fixture_comparison"
 path = "tests-rs/fixture_comparison.rs"
 
+[[test]]
+name = "operator_cli"
+path = "tests-rs/operator_cli.rs"
+
 # Windows only
 [target.'cfg(not(windows))'.dependencies]
 [target.'cfg(windows)'.dependencies]

--- a/core/src/cli.rs
+++ b/core/src/cli.rs
@@ -126,6 +126,14 @@ CONFIGURATION COMMANDS:
     show-hooks              Show all defined hooks
     list-commands, lscm     List all available commands
 
+OPERATOR COMMANDS:
+    status --json           Print session, pane, and board summary JSON
+    board --json            Print pane, task, review, and git board JSON
+    inbox --json            Print actionable approval and review items JSON
+    digest --json           Print high-signal run digest JSON
+    runs --json             Print run-oriented evidence JSON
+    explain <run_id> --json Print one run explanation JSON
+
 LAYOUT COMMANDS:
     select-layout, selectl  Apply a layout preset
                             Presets: even-horizontal, even-vertical,

--- a/core/src/help.rs
+++ b/core/src/help.rs
@@ -316,6 +316,13 @@ const CLI_COMMANDS: &[(&str, &str, &str)] = &[
     ("display-popup",     "popup",    "Display a popup window"),
     ("list-commands",     "lscm",     "List available commands"),
     ("server-info",       "info",     "Show server information"),
+    // Operator read models
+    ("status",            "",         "Print session and pane JSON with --json"),
+    ("board",             "",         "Print pane/task/review board JSON"),
+    ("inbox",             "",         "Print actionable item JSON"),
+    ("digest",            "",         "Print run digest JSON"),
+    ("runs",              "",         "Print run-oriented evidence JSON"),
+    ("explain",           "",         "Print one run explanation JSON"),
     // Misc
     ("confirm-before",    "confirm",  "Confirm before running command"),
     ("if-shell",          "if",       "Conditional command execution"),

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -25,6 +25,7 @@ mod terminal_engine;
 mod manifest_contract;
 mod event_contract;
 mod ledger;
+mod operator_cli;
 mod client;
 mod app;
 mod ssh_input;
@@ -234,7 +235,16 @@ fn run_main() -> io::Result<()> {
         _ => {}
     }
 
+    if cmd == "status" && operator_cli::is_operator_status_invocation(&cmd_args[1..]) {
+        return operator_cli::run_status_command(&cmd_args[1..]);
+    }
+
     match cmd {
+        "board" => return operator_cli::run_board_command(&cmd_args[1..]),
+        "inbox" => return operator_cli::run_inbox_command(&cmd_args[1..]),
+        "digest" => return operator_cli::run_digest_command(&cmd_args[1..]),
+        "runs" => return operator_cli::run_runs_command(&cmd_args[1..]),
+        "explain" => return operator_cli::run_explain_command(&cmd_args[1..]),
         // kill-server MUST be handled early before any potential fall-through
         "kill-server" => {
             let home = env::var("USERPROFILE").or_else(|_| env::var("HOME")).unwrap_or_default();

--- a/core/src/operator_cli.rs
+++ b/core/src/operator_cli.rs
@@ -1,0 +1,534 @@
+use std::{
+    env, fs,
+    io::{self, Write},
+    path::{Path, PathBuf},
+};
+
+use chrono::{SecondsFormat, Utc};
+use serde::Serialize;
+use serde_json::{json, Map, Value};
+
+use crate::ledger::LedgerSnapshot;
+
+pub fn is_operator_status_invocation(args: &[&String]) -> bool {
+    args.iter()
+        .any(|arg| matches!(arg.as_str(), "--json" | "-h" | "--help"))
+}
+
+pub fn run_status_command(args: &[&String]) -> io::Result<()> {
+    if should_print_help(args) {
+        println!("usage: winsmux status --json [--project-dir <path>]");
+        return Ok(());
+    }
+    let options = parse_options("status", args, 0)?;
+    require_json("status", &options)?;
+
+    let snapshot = load_snapshot(&options.project_dir)?;
+    let status = json!({
+        "generated_at": generated_at(),
+        "project_dir": project_dir_string(&options.project_dir),
+        "session": {
+            "name": snapshot.session_name(),
+            "pane_count": snapshot.pane_count(),
+            "event_count": snapshot.event_count(),
+        },
+        "summary": snapshot.board_summary(),
+        "panes": snapshot.pane_read_models(),
+    });
+    write_json(&status)
+}
+
+pub fn run_board_command(args: &[&String]) -> io::Result<()> {
+    if should_print_help(args) {
+        println!("usage: winsmux board --json [--project-dir <path>]");
+        return Ok(());
+    }
+    let options = parse_options("board", args, 0)?;
+    require_json("board", &options)?;
+
+    let snapshot = load_snapshot(&options.project_dir)?;
+    write_enveloped_json(&options.project_dir, snapshot.board_projection())
+}
+
+pub fn run_inbox_command(args: &[&String]) -> io::Result<()> {
+    if should_print_help(args) {
+        println!("usage: winsmux inbox --json [--project-dir <path>]");
+        return Ok(());
+    }
+    let options = parse_options("inbox", args, 0)?;
+    require_json("inbox", &options)?;
+
+    let snapshot = load_snapshot(&options.project_dir)?;
+    write_enveloped_json(&options.project_dir, snapshot.inbox_projection())
+}
+
+pub fn run_digest_command(args: &[&String]) -> io::Result<()> {
+    if should_print_help(args) {
+        println!("usage: winsmux digest --json [--project-dir <path>]");
+        return Ok(());
+    }
+    let options = parse_options("digest", args, 0)?;
+    require_json("digest", &options)?;
+
+    let snapshot = load_snapshot(&options.project_dir)?;
+    write_enveloped_json(&options.project_dir, snapshot.digest_projection())
+}
+
+pub fn run_runs_command(args: &[&String]) -> io::Result<()> {
+    if should_print_help(args) {
+        println!("usage: winsmux runs --json [--project-dir <path>]");
+        return Ok(());
+    }
+    let options = parse_options("runs", args, 0)?;
+    require_json("runs", &options)?;
+
+    let snapshot = load_snapshot(&options.project_dir)?;
+    let payload = runs_payload(&snapshot, &options.project_dir);
+    write_json(&payload)
+}
+
+pub fn run_explain_command(args: &[&String]) -> io::Result<()> {
+    if should_print_help(args) {
+        println!("usage: winsmux explain <run_id> --json [--project-dir <path>]");
+        return Ok(());
+    }
+    let options = parse_options("explain", args, 1)?;
+    require_json("explain", &options)?;
+
+    let run_id = options.positionals[0].clone();
+    let snapshot = load_snapshot(&options.project_dir)?;
+    let projection = snapshot.explain_projection(&run_id).ok_or_else(|| {
+        io::Error::new(io::ErrorKind::NotFound, format!("run not found: {run_id}"))
+    })?;
+    let observation_pack = read_artifact_json(
+        &projection.run.experiment_packet.observation_pack_ref,
+        &options.project_dir,
+        &[".winsmux", "observation-packs"],
+        &run_id,
+    );
+    let consultation_packet = read_artifact_json(
+        &projection.run.experiment_packet.consultation_ref,
+        &options.project_dir,
+        &[".winsmux", "consultations"],
+        &run_id,
+    );
+    let payload = json!({
+        "generated_at": generated_at(),
+        "project_dir": project_dir_string(&options.project_dir),
+        "run": projection.run,
+        "observation_pack": observation_pack,
+        "consultation_packet": consultation_packet,
+        "evidence_digest": projection.evidence_digest,
+        "explanation": projection.explanation,
+        "review_state": Value::Null,
+        "recent_events": projection.recent_events,
+    });
+    write_json(&payload)
+}
+
+struct ParsedOptions {
+    json: bool,
+    project_dir: PathBuf,
+    positionals: Vec<String>,
+}
+
+fn parse_options(
+    command: &str,
+    args: &[&String],
+    expected_positionals: usize,
+) -> io::Result<ParsedOptions> {
+    let mut json = false;
+    let mut project_dir = None;
+    let mut positionals = Vec::new();
+    let mut index = 0;
+
+    while index < args.len() {
+        let arg = args[index].as_str();
+        match arg {
+            "--json" => {
+                json = true;
+                index += 1;
+            }
+            "--project-dir" => {
+                let Some(value) = args.get(index + 1) else {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        "missing value after --project-dir",
+                    ));
+                };
+                project_dir = Some(PathBuf::from(value.to_string()));
+                index += 2;
+            }
+            value if value.starts_with('-') => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!("unknown argument for winsmux {command}: {value}"),
+                ));
+            }
+            value => {
+                positionals.push(value.to_string());
+                index += 1;
+            }
+        }
+    }
+
+    if positionals.len() != expected_positionals {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            usage_for(command).to_string(),
+        ));
+    }
+
+    Ok(ParsedOptions {
+        json,
+        project_dir: project_dir.unwrap_or(env::current_dir()?),
+        positionals,
+    })
+}
+
+fn should_print_help(args: &[&String]) -> bool {
+    args.iter().any(|arg| *arg == "-h" || *arg == "--help")
+}
+
+fn require_json(command: &str, options: &ParsedOptions) -> io::Result<()> {
+    if options.json {
+        return Ok(());
+    }
+    Err(io::Error::new(
+        io::ErrorKind::InvalidInput,
+        format!("winsmux {command} currently supports only --json in the Rust CLI"),
+    ))
+}
+
+fn usage_for(command: &str) -> &'static str {
+    match command {
+        "status" => "usage: winsmux status --json [--project-dir <path>]",
+        "board" => "usage: winsmux board --json [--project-dir <path>]",
+        "inbox" => "usage: winsmux inbox --json [--project-dir <path>]",
+        "digest" => "usage: winsmux digest --json [--project-dir <path>]",
+        "runs" => "usage: winsmux runs --json [--project-dir <path>]",
+        "explain" => "usage: winsmux explain <run_id> --json [--project-dir <path>]",
+        _ => "usage: winsmux <command> --json [--project-dir <path>]",
+    }
+}
+
+fn load_snapshot(project_dir: &Path) -> io::Result<LedgerSnapshot> {
+    LedgerSnapshot::from_project_dir(project_dir).map_err(|err| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("failed to load winsmux ledger: {err}"),
+        )
+    })
+}
+
+fn runs_payload(snapshot: &LedgerSnapshot, project_dir: &Path) -> Value {
+    let runs: Vec<Value> = snapshot
+        .digest_projection()
+        .items
+        .into_iter()
+        .map(|item| {
+            let explain = snapshot.explain_projection(&item.run_id);
+            let run = explain.as_ref().map(|projection| &projection.run);
+            let action_items = run
+                .map(|run| json!(run.action_items))
+                .unwrap_or_else(|| json!([]));
+            let experiment_packet = run
+                .map(|run| json!(run.experiment_packet))
+                .unwrap_or(Value::Null);
+            let security_policy = run
+                .map(|run| run.security_policy.clone())
+                .unwrap_or(Value::Null);
+            let security_verdict = run
+                .map(|run| run.security_verdict.clone())
+                .unwrap_or(Value::Null);
+            let verification_contract = run
+                .map(|run| run.verification_contract.clone())
+                .unwrap_or(Value::Null);
+            let verification_result = run
+                .map(|run| run.verification_result.clone())
+                .unwrap_or(Value::Null);
+            let run_packet = run
+                .map(|run| {
+                    json!({
+                        "run_id": run.run_id,
+                        "task_id": run.task_id,
+                        "parent_run_id": run.parent_run_id,
+                        "goal": run.goal,
+                        "task": run.task,
+                        "task_type": run.task_type,
+                        "priority": run.priority,
+                        "blocking": run.blocking,
+                        "write_scope": run.write_scope,
+                        "read_scope": run.read_scope,
+                        "constraints": run.constraints,
+                        "expected_output": run.expected_output,
+                        "verification_plan": run.verification_plan,
+                        "review_required": run.review_required,
+                        "provider_target": run.provider_target,
+                        "agent_role": run.agent_role,
+                        "timeout_policy": run.timeout_policy,
+                        "handoff_refs": run.handoff_refs,
+                        "branch": run.branch,
+                        "head_sha": run.head_sha,
+                        "primary_label": run.primary_label,
+                        "primary_pane_id": run.primary_pane_id,
+                        "primary_role": run.primary_role,
+                        "labels": run.labels,
+                        "pane_ids": run.pane_ids,
+                        "roles": run.roles,
+                        "changed_files": run.changed_files,
+                        "security_policy": run.security_policy,
+                        "security_verdict": run.security_verdict,
+                        "verification_contract": run.verification_contract,
+                        "verification_result": run.verification_result,
+                        "last_event": run.last_event,
+                        "last_event_at": run.last_event_at,
+                    })
+                })
+                .unwrap_or(Value::Null);
+
+            let mut value = Map::new();
+            value.insert("run_id".into(), json!(item.run_id));
+            value.insert("task_id".into(), json!(item.task_id));
+            value.insert("task".into(), json!(item.task));
+            value.insert("task_state".into(), json!(item.task_state));
+            value.insert("review_state".into(), json!(item.review_state));
+            value.insert("branch".into(), json!(item.branch));
+            value.insert("worktree".into(), json!(item.worktree));
+            value.insert("head_sha".into(), json!(item.head_sha));
+            value.insert("primary_label".into(), json!(item.label));
+            value.insert("primary_pane_id".into(), json!(item.pane_id));
+            value.insert("primary_role".into(), json!(item.role));
+            value.insert(
+                "state".into(),
+                json!(run.map(|run| run.state.clone()).unwrap_or_default()),
+            );
+            value.insert(
+                "tokens_remaining".into(),
+                json!(run
+                    .map(|run| run.tokens_remaining.clone())
+                    .unwrap_or_default()),
+            );
+            value.insert("last_event".into(), json!(item.last_event));
+            value.insert("last_event_at".into(), json!(item.last_event_at));
+            value.insert(
+                "pane_count".into(),
+                json!(run.map(|run| run.pane_count).unwrap_or(1)),
+            );
+            value.insert("changed_file_count".into(), json!(item.changed_file_count));
+            value.insert(
+                "labels".into(),
+                run.map(|run| json!(run.labels))
+                    .unwrap_or_else(|| json!([item.label])),
+            );
+            value.insert(
+                "pane_ids".into(),
+                run.map(|run| json!(run.pane_ids))
+                    .unwrap_or_else(|| json!([item.pane_id])),
+            );
+            value.insert(
+                "roles".into(),
+                run.map(|run| json!(run.roles))
+                    .unwrap_or_else(|| json!([item.role])),
+            );
+            value.insert("changed_files".into(), json!(item.changed_files));
+            value.insert("action_items".into(), action_items);
+            value.insert(
+                "parent_run_id".into(),
+                json!(run.map(|run| run.parent_run_id.clone()).unwrap_or_default()),
+            );
+            value.insert(
+                "goal".into(),
+                json!(run.map(|run| run.goal.clone()).unwrap_or_default()),
+            );
+            value.insert(
+                "task_type".into(),
+                json!(run.map(|run| run.task_type.clone()).unwrap_or_default()),
+            );
+            value.insert(
+                "priority".into(),
+                json!(run.map(|run| run.priority.clone()).unwrap_or_default()),
+            );
+            value.insert(
+                "blocking".into(),
+                json!(run.map(|run| run.blocking).unwrap_or(false)),
+            );
+            value.insert(
+                "write_scope".into(),
+                run.map(|run| json!(run.write_scope))
+                    .unwrap_or_else(|| json!([])),
+            );
+            value.insert(
+                "read_scope".into(),
+                run.map(|run| json!(run.read_scope))
+                    .unwrap_or_else(|| json!([])),
+            );
+            value.insert(
+                "constraints".into(),
+                run.map(|run| json!(run.constraints))
+                    .unwrap_or_else(|| json!([])),
+            );
+            value.insert(
+                "expected_output".into(),
+                json!(run
+                    .map(|run| run.expected_output.clone())
+                    .unwrap_or_default()),
+            );
+            value.insert(
+                "verification_plan".into(),
+                run.map(|run| json!(run.verification_plan))
+                    .unwrap_or_else(|| json!([])),
+            );
+            value.insert(
+                "review_required".into(),
+                json!(run.map(|run| run.review_required).unwrap_or(false)),
+            );
+            value.insert("provider_target".into(), json!(item.provider_target));
+            value.insert(
+                "agent_role".into(),
+                json!(run.map(|run| run.agent_role.clone()).unwrap_or(item.role)),
+            );
+            value.insert(
+                "timeout_policy".into(),
+                json!(run
+                    .map(|run| run.timeout_policy.clone())
+                    .unwrap_or_default()),
+            );
+            value.insert(
+                "handoff_refs".into(),
+                run.map(|run| json!(run.handoff_refs))
+                    .unwrap_or_else(|| json!([])),
+            );
+            value.insert("experiment_packet".into(), experiment_packet);
+            value.insert("security_policy".into(), security_policy);
+            value.insert("security_verdict".into(), security_verdict);
+            value.insert("verification_contract".into(), verification_contract);
+            value.insert("verification_result".into(), verification_result);
+            value.insert("run_packet".into(), run_packet);
+            Value::Object(value)
+        })
+        .collect();
+
+    json!({
+        "generated_at": generated_at(),
+        "project_dir": project_dir_string(project_dir),
+        "summary": {
+            "run_count": runs.len(),
+            "blocked_runs": runs.iter().filter(|run| json_string_eq(run, "task_state", "blocked")).count(),
+            "review_pending": runs.iter().filter(|run| json_string_eq(run, "review_state", "pending")).count(),
+            "dirty_runs": runs.iter().filter(|run| run["changed_file_count"].as_u64().unwrap_or(0) > 0).count(),
+            "action_item_count": runs
+                .iter()
+                .map(|run| run["action_items"].as_array().map(|items| items.len()).unwrap_or(0))
+                .sum::<usize>(),
+        },
+        "runs": runs,
+    })
+}
+
+fn json_string_eq(value: &Value, key: &str, expected: &str) -> bool {
+    value
+        .get(key)
+        .and_then(Value::as_str)
+        .map(|actual| actual.eq_ignore_ascii_case(expected))
+        .unwrap_or(false)
+}
+
+fn read_artifact_json(
+    reference: &str,
+    project_dir: &Path,
+    expected_segments: &[&str],
+    expected_run_id: &str,
+) -> Value {
+    if reference.trim().is_empty() {
+        return Value::Null;
+    }
+
+    let mut expected_dir = project_dir.to_path_buf();
+    for segment in expected_segments {
+        expected_dir.push(segment);
+    }
+
+    let path = {
+        let normalized = reference.replace('/', std::path::MAIN_SEPARATOR_STR);
+        let candidate = PathBuf::from(&normalized);
+        if candidate.is_absolute() {
+            candidate
+        } else {
+            project_dir.join(candidate)
+        }
+    };
+
+    let Ok(full_path) = fs::canonicalize(&path) else {
+        return Value::Null;
+    };
+    let Ok(expected_dir) = fs::canonicalize(expected_dir) else {
+        return Value::Null;
+    };
+    if !full_path.starts_with(&expected_dir) {
+        return Value::Null;
+    }
+
+    let Ok(content) = fs::read_to_string(&full_path) else {
+        return Value::Null;
+    };
+    let Ok(mut parsed) = serde_json::from_str::<Value>(&content) else {
+        return Value::Null;
+    };
+
+    if let Some(run_id) = parsed.get("run_id").and_then(Value::as_str) {
+        if !run_id.is_empty() && run_id != expected_run_id {
+            return Value::Null;
+        }
+    }
+    if let Value::Object(map) = &mut parsed {
+        map.remove("packet_type");
+    }
+    parsed
+}
+
+fn write_enveloped_json<T: Serialize>(project_dir: &Path, value: T) -> io::Result<()> {
+    let value = serde_json::to_value(value).map_err(|err| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("failed to serialize Rust operator projection: {err}"),
+        )
+    })?;
+    let payload = json!({
+        "generated_at": generated_at(),
+        "project_dir": project_dir_string(project_dir),
+        "summary": value.get("summary").cloned().unwrap_or(Value::Null),
+        "panes": value.get("panes").cloned().unwrap_or(Value::Null),
+        "items": value.get("items").cloned().unwrap_or(Value::Null),
+    });
+    write_json(&strip_null_fields(payload))
+}
+
+fn strip_null_fields(value: Value) -> Value {
+    let Value::Object(mut map) = value else {
+        return value;
+    };
+    map.retain(|_, value| !value.is_null());
+    Value::Object(map)
+}
+
+fn generated_at() -> String {
+    Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true)
+}
+
+fn project_dir_string(project_dir: &Path) -> String {
+    project_dir.display().to_string()
+}
+
+fn write_json<T: Serialize>(value: &T) -> io::Result<()> {
+    let stdout = io::stdout();
+    let mut stdout = stdout.lock();
+    serde_json::to_writer(&mut stdout, value).map_err(|err| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("failed to serialize Rust operator projection: {err}"),
+        )
+    })?;
+    writeln!(stdout)?;
+    Ok(())
+}

--- a/core/tests-rs/operator_cli.rs
+++ b/core/tests-rs/operator_cli.rs
@@ -1,0 +1,283 @@
+use std::fs;
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[test]
+fn operator_cli_status_json_reads_live_winsmux_manifest() {
+    let project_dir = make_temp_project_dir("status-json");
+    write_manifest(&project_dir);
+
+    let json = run_json(&project_dir, &["status", "--json"]);
+
+    assert_eq!(json["session"]["name"], "winsmux-orchestra");
+    assert_eq!(json["session"]["pane_count"], 2);
+    assert_eq!(json["session"]["event_count"], 2);
+    assert!(json["generated_at"].as_str().is_some());
+    assert_eq!(
+        json["project_dir"],
+        project_dir.to_str().expect("temp path should be utf-8")
+    );
+    assert_eq!(json["summary"]["review_pending"], 1);
+    assert_eq!(json["panes"][0]["label"], "builder-1");
+    assert_eq!(json["panes"][0]["changed_files"][0], "core/src/main.rs");
+}
+
+#[test]
+fn operator_cli_board_json_reads_live_winsmux_manifest() {
+    let project_dir = make_temp_project_dir("board-json");
+    write_manifest(&project_dir);
+
+    let json = run_json(&project_dir, &["board", "--json"]);
+
+    assert_eq!(json["summary"]["pane_count"], 2);
+    assert!(json["generated_at"].as_str().is_some());
+    assert_eq!(
+        json["project_dir"],
+        project_dir.to_str().expect("temp path should be utf-8")
+    );
+    assert_eq!(json["summary"]["dirty_panes"], 1);
+    assert_eq!(json["summary"]["by_state"]["running"], 1);
+    assert_eq!(json["summary"]["by_task_state"]["in_progress"], 1);
+    assert_eq!(json["panes"][0]["task_id"], "TASK-266");
+    assert_eq!(json["panes"][1]["role"], "Reviewer");
+}
+
+#[test]
+fn operator_cli_inbox_digest_runs_and_explain_use_ledger_projections() {
+    let project_dir = make_temp_project_dir("read-models");
+    write_manifest(&project_dir);
+
+    let inbox = run_json(&project_dir, &["inbox", "--json"]);
+    assert!(inbox["generated_at"].as_str().is_some());
+    assert_eq!(
+        inbox["project_dir"],
+        project_dir.to_str().expect("temp path should be utf-8")
+    );
+    assert_eq!(inbox["summary"]["by_kind"]["review_pending"], 1);
+    assert_eq!(inbox["items"][0]["kind"], "review_pending");
+
+    let digest = run_json(&project_dir, &["digest", "--json"]);
+    assert!(digest["generated_at"].as_str().is_some());
+    assert_eq!(digest["items"][0]["run_id"], "task:TASK-266");
+    assert_eq!(digest["items"][0]["review_state"], "pending");
+
+    let runs = run_json(&project_dir, &["runs", "--json"]);
+    assert_eq!(runs["summary"]["run_count"], 2);
+    assert_eq!(runs["summary"]["review_pending"], 1);
+    assert_eq!(runs["summary"]["dirty_runs"], 1);
+    let task_run = runs["runs"]
+        .as_array()
+        .expect("runs should be an array")
+        .iter()
+        .find(|run| run["run_id"] == "task:TASK-266")
+        .expect("task run should exist");
+    assert_eq!(task_run["run_packet"]["priority"], "P0");
+    assert_eq!(
+        task_run["run_packet"]["task"],
+        "Add Rust operator read models"
+    );
+    assert_eq!(
+        task_run["run_packet"]["branch"],
+        "codex/task266-rust-operator-readmodels-20260424"
+    );
+    assert_eq!(task_run["run_packet"]["labels"][0], "builder-1");
+    assert_eq!(task_run["action_items"][0]["kind"], "review_pending");
+
+    let explain = run_json(&project_dir, &["explain", "task:TASK-266", "--json"]);
+    assert!(explain["generated_at"].as_str().is_some());
+    assert_eq!(
+        explain["project_dir"],
+        project_dir.to_str().expect("temp path should be utf-8")
+    );
+    assert_eq!(explain["run"]["run_id"], "task:TASK-266");
+    assert_eq!(
+        explain["observation_pack"]["summary"],
+        "captured operator read model"
+    );
+    assert!(explain["observation_pack"]["packet_type"].is_null());
+    assert_eq!(
+        explain["consultation_packet"]["recommendation"],
+        "keep read-only"
+    );
+    assert_eq!(explain["explanation"]["next_action"], "commit_ready");
+}
+
+#[test]
+fn operator_cli_accepts_project_dir_argument() {
+    let project_dir = make_temp_project_dir("project-dir");
+    write_manifest(&project_dir);
+
+    let json = run_json_with_cwd(
+        std::env::temp_dir(),
+        &[
+            "board",
+            "--json",
+            "--project-dir",
+            project_dir.to_str().expect("temp path should be utf-8"),
+        ],
+    );
+
+    assert_eq!(json["summary"]["pane_count"], 2);
+}
+
+#[test]
+fn operator_cli_read_models_require_json_flag() {
+    let project_dir = make_temp_project_dir("requires-json");
+    write_manifest(&project_dir);
+
+    for command in ["board", "inbox", "digest", "runs"] {
+        let output = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+            .arg(command)
+            .current_dir(&project_dir)
+            .output()
+            .expect("winsmux command should run");
+
+        assert!(!output.status.success());
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            stderr.contains("currently supports only --json"),
+            "unexpected stderr for {command}: {stderr}"
+        );
+    }
+}
+
+#[test]
+fn operator_cli_rejects_unknown_and_extra_arguments() {
+    let project_dir = make_temp_project_dir("invalid-args");
+    write_manifest(&project_dir);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .args(["board", "--json", "--bogus"])
+        .current_dir(&project_dir)
+        .output()
+        .expect("winsmux command should run");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("unknown argument"),
+        "unexpected stderr: {stderr}"
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .args(["explain", "task:TASK-266", "extra", "--json"])
+        .current_dir(&project_dir)
+        .output()
+        .expect("winsmux command should run");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("usage: winsmux explain"),
+        "unexpected stderr: {stderr}"
+    );
+}
+
+fn run_json(project_dir: &std::path::Path, args: &[&str]) -> serde_json::Value {
+    run_json_with_cwd(project_dir, args)
+}
+
+fn run_json_with_cwd(cwd: impl AsRef<std::path::Path>, args: &[&str]) -> serde_json::Value {
+    let output = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .expect("winsmux command should run");
+
+    assert!(
+        output.status.success(),
+        "winsmux command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_slice(&output.stdout).expect("stdout should be JSON")
+}
+
+fn write_manifest(project_dir: &std::path::Path) {
+    let winsmux_dir = project_dir.join(".winsmux");
+    fs::create_dir_all(&winsmux_dir).expect("test should create .winsmux directory");
+    fs::write(
+        winsmux_dir.join("manifest.yaml"),
+        r#"
+version: 1
+session:
+  name: winsmux-orchestra
+panes:
+  builder-1:
+    pane_id: "%2"
+    role: Builder
+    state: running
+    task_id: TASK-266
+    task: Add Rust operator read models
+    task_state: in_progress
+    parent_run_id: operator:session-1
+    goal: Keep Rust read models aligned
+    task_type: implementation
+    priority: P0
+    blocking: true
+    review_state: pending
+    branch: codex/task266-rust-operator-readmodels-20260424
+    head_sha: abc123
+    changed_file_count: 2
+    changed_files:
+      - core/src/main.rs
+      - core/src/operator_cli.rs
+    write_scope:
+      - core/src/operator_cli.rs
+    read_scope:
+      - scripts/winsmux-core.ps1
+    constraints:
+      - preserve PowerShell JSON shape
+    expected_output: Rust read-only CLI
+    verification_plan:
+      - cargo test --manifest-path core/Cargo.toml --test operator_cli
+    review_required: true
+    provider_target: codex:gpt-5.4
+    agent_role: worker
+    timeout_policy: standard
+    handoff_refs:
+      - docs/handoff.md
+    last_event: operator.review_requested
+    last_event_at: 2026-04-24T12:00:00+09:00
+  reviewer-1:
+    pane_id: "%3"
+    role: Reviewer
+    state: idle
+    task_state: waiting
+    review_state: PASS
+    branch: codex/task266-rust-operator-readmodels-20260424
+    head_sha: def456
+"#,
+    )
+    .expect("test should write manifest");
+    fs::create_dir_all(winsmux_dir.join("observation-packs"))
+        .expect("test should create observation pack directory");
+    fs::create_dir_all(winsmux_dir.join("consultations"))
+        .expect("test should create consultation directory");
+    fs::write(
+        winsmux_dir.join("observation-packs").join("task-266.json"),
+        r#"{"packet_type":"observation_pack","run_id":"task:TASK-266","summary":"captured operator read model"}"#,
+    )
+    .expect("test should write observation pack");
+    fs::write(
+        winsmux_dir.join("consultations").join("task-266.json"),
+        r#"{"packet_type":"consultation_packet","run_id":"task:TASK-266","recommendation":"keep read-only"}"#,
+    )
+    .expect("test should write consultation packet");
+    fs::write(
+        winsmux_dir.join("events.jsonl"),
+        r#"{"timestamp":"2026-04-24T12:00:01+09:00","session":"winsmux-orchestra","event":"operator.review_requested","message":"review requested","label":"builder-1","pane_id":"%2","role":"Builder","status":"review_requested","data":{"task_id":"TASK-266","run_id":"task:TASK-266","hypothesis":"Rust can read operator evidence","test_plan":["read manifest"],"result":"captured","confidence":0.91,"next_action":"commit_ready","observation_pack_ref":".winsmux/observation-packs/task-266.json","consultation_ref":".winsmux/consultations/task-266.json"}}
+{"timestamp":"2026-04-24T12:00:02+09:00","session":"winsmux-orchestra","event":"operator.commit_ready","message":"ready to commit","label":"builder-1","pane_id":"%2","role":"Builder","status":"commit_ready","data":{"task_id":"TASK-266"}}
+"#,
+    )
+    .expect("test should write events");
+}
+
+fn make_temp_project_dir(name: &str) -> std::path::PathBuf {
+    let suffix = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock should be after unix epoch")
+        .as_nanos();
+    let path = std::env::temp_dir().join(format!("winsmux-{name}-{}-{suffix}", std::process::id()));
+    fs::create_dir_all(&path).expect("test should create temp project directory");
+    path
+}


### PR DESCRIPTION
## Summary
- Adds read-only Rust CLI JSON surfaces for status, board, inbox, digest, runs, and explain.
- Preserves the existing non-JSON winsmux status path.
- Keeps runs as a run-oriented payload and keeps PowerShell-style top-level envelope fields.

## Validation
- rustfmt --check core\\src\\operator_cli.rs core\\tests-rs\\operator_cli.rs
- cargo test --manifest-path core\\Cargo.toml --test operator_cli -- --nocapture
- cargo test --manifest-path core\\Cargo.toml --test fixture_comparison -- --nocapture
- cargo test --manifest-path core\\Cargo.toml --test ledger_contract -- --nocapture
- cargo test --manifest-path core\\Cargo.toml
- git diff --check
- pwsh -NoProfile -File .\\scripts\\git-guard.ps1 -Mode full
- pwsh -NoProfile -File .\\scripts\\audit-public-surface.ps1

## Notes
- This is a TASK-266 read-only CLI slice. TASK-266 remains open for review lifecycle and restart/rebind command work.
- External Rust learning notes were updated outside the repo and reviewed with Opus: PASS.