### PR TITLE
Add Rust review reset command

### DIFF
--- a/core/src/cli.rs
+++ b/core/src/cli.rs
@@ -133,6 +133,7 @@ OPERATOR COMMANDS:
     digest --json           Print high-signal run digest JSON
     runs --json             Print run-oriented evidence JSON
     explain <run_id> --json Print one run explanation JSON
+    review-reset            Clear review state for the current branch
 
 LAYOUT COMMANDS:
     select-layout, selectl  Apply a layout preset

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -245,6 +245,7 @@ fn run_main() -> io::Result<()> {
         "digest" => return operator_cli::run_digest_command(&cmd_args[1..]),
         "runs" => return operator_cli::run_runs_command(&cmd_args[1..]),
         "explain" => return operator_cli::run_explain_command(&cmd_args[1..]),
+        "review-reset" => return operator_cli::run_review_reset_command(&cmd_args[1..]),
         // kill-server MUST be handled early before any potential fall-through
         "kill-server" => {
             let home = env::var("USERPROFILE").or_else(|_| env::var("HOME")).unwrap_or_default();

--- a/core/src/operator_cli.rs
+++ b/core/src/operator_cli.rs
@@ -2,6 +2,7 @@ use std::{
     env, fs,
     io::{self, Write},
     path::{Path, PathBuf},
+    process::Command,
 };
 
 use chrono::{SecondsFormat, Utc};
@@ -126,6 +127,26 @@ pub fn run_explain_command(args: &[&String]) -> io::Result<()> {
     write_json(&payload)
 }
 
+pub fn run_review_reset_command(args: &[&String]) -> io::Result<()> {
+    if should_print_help(args) {
+        println!("usage: winsmux review-reset [--project-dir <path>]");
+        return Ok(());
+    }
+    let options = parse_options("review-reset", args, 0)?;
+    if options.json {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            usage_for("review-reset"),
+        ));
+    }
+
+    let branch = current_git_branch(&options.project_dir)?;
+    clear_review_state_record(&options.project_dir, &branch)?;
+    let _ = clear_current_pane_review_manifest_state(&options.project_dir);
+    println!("review PASS cleared for {branch}");
+    Ok(())
+}
+
 struct ParsedOptions {
     json: bool,
     project_dir: PathBuf,
@@ -208,8 +229,178 @@ fn usage_for(command: &str) -> &'static str {
         "digest" => "usage: winsmux digest --json [--project-dir <path>]",
         "runs" => "usage: winsmux runs --json [--project-dir <path>]",
         "explain" => "usage: winsmux explain <run_id> --json [--project-dir <path>]",
+        "review-reset" => "usage: winsmux review-reset [--project-dir <path>]",
         _ => "usage: winsmux <command> --json [--project-dir <path>]",
     }
+}
+
+fn current_git_branch(project_dir: &Path) -> io::Result<String> {
+    if let Some(branch) = git_output_line(project_dir, &["rev-parse", "--abbrev-ref", "HEAD"])? {
+        if branch != "HEAD" {
+            return Ok(branch);
+        }
+    }
+
+    if let Some(branch) = git_output_line(project_dir, &["symbolic-ref", "--short", "HEAD"])? {
+        return Ok(branch);
+    }
+
+    Err(io::Error::new(
+        io::ErrorKind::Other,
+        format!(
+            "unable to determine current git branch in {}",
+            project_dir.display()
+        ),
+    ))
+}
+
+fn git_output_line(project_dir: &Path, args: &[&str]) -> io::Result<Option<String>> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(project_dir)
+        .args(args)
+        .output()
+        .map_err(|err| {
+            io::Error::new(
+                io::ErrorKind::Other,
+                format!(
+                    "unable to determine current git branch in {}: {err}",
+                    project_dir.display()
+                ),
+            )
+        })?;
+
+    if !output.status.success() {
+        return Ok(None);
+    }
+    let value = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    Ok((!value.is_empty()).then_some(value))
+}
+
+fn clear_review_state_record(project_dir: &Path, branch: &str) -> io::Result<()> {
+    let path = project_dir.join(".winsmux").join("review-state.json");
+    if !path.exists() {
+        return Ok(());
+    }
+
+    let raw = fs::read_to_string(&path)?;
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        fs::remove_file(&path)?;
+        return Ok(());
+    }
+
+    let mut state = serde_json::from_str::<Map<String, Value>>(trimmed).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("invalid review state: {}", path.display()),
+        )
+    })?;
+    state.remove(branch);
+
+    if state.is_empty() {
+        fs::remove_file(&path)?;
+        return Ok(());
+    }
+
+    let content = serde_json::to_string_pretty(&state).map_err(|err| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("failed to serialize review state: {err}"),
+        )
+    })?;
+    fs::write(path, format!("{content}\n"))
+}
+
+fn clear_current_pane_review_manifest_state(project_dir: &Path) -> io::Result<bool> {
+    let pane_id = match env::var("WINSMUX_PANE_ID") {
+        Ok(value) if !value.trim().is_empty() => value,
+        _ => return Ok(false),
+    };
+    let manifest_path = project_dir.join(".winsmux").join("manifest.yaml");
+    let raw = fs::read_to_string(&manifest_path)?;
+    let mut manifest = serde_yaml::from_str::<serde_yaml::Value>(&raw).map_err(|err| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("invalid manifest: {}: {err}", manifest_path.display()),
+        )
+    })?;
+
+    let timestamp = generated_at();
+    let updated = update_manifest_pane_review_state(&mut manifest, &pane_id, &timestamp);
+    if !updated {
+        return Ok(false);
+    }
+
+    let content = serde_yaml::to_string(&manifest).map_err(|err| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("failed to serialize manifest: {err}"),
+        )
+    })?;
+    fs::write(manifest_path, content)?;
+    Ok(true)
+}
+
+fn update_manifest_pane_review_state(
+    manifest: &mut serde_yaml::Value,
+    pane_id: &str,
+    timestamp: &str,
+) -> bool {
+    let Some(panes) = manifest.get_mut("panes") else {
+        return false;
+    };
+
+    match panes {
+        serde_yaml::Value::Mapping(map) => map
+            .values_mut()
+            .any(|pane| clear_manifest_pane_if_matches(pane, pane_id, timestamp)),
+        serde_yaml::Value::Sequence(items) => items
+            .iter_mut()
+            .any(|pane| clear_manifest_pane_if_matches(pane, pane_id, timestamp)),
+        _ => false,
+    }
+}
+
+fn clear_manifest_pane_if_matches(
+    pane: &mut serde_yaml::Value,
+    pane_id: &str,
+    timestamp: &str,
+) -> bool {
+    let serde_yaml::Value::Mapping(map) = pane else {
+        return false;
+    };
+    let key = serde_yaml::Value::String("pane_id".to_string());
+    let actual = map
+        .get(&key)
+        .and_then(serde_yaml::Value::as_str)
+        .unwrap_or_default();
+    if actual != pane_id {
+        return false;
+    }
+    let role = map
+        .get(serde_yaml::Value::String("role".to_string()))
+        .and_then(serde_yaml::Value::as_str)
+        .unwrap_or_default();
+    if !matches!(role, "Reviewer" | "Worker") {
+        return false;
+    }
+
+    for name in ["review_state", "branch", "head_sha"] {
+        map.insert(
+            serde_yaml::Value::String(name.to_string()),
+            serde_yaml::Value::String(String::new()),
+        );
+    }
+    map.insert(
+        serde_yaml::Value::String("last_event".to_string()),
+        serde_yaml::Value::String("review.reset".to_string()),
+    );
+    map.insert(
+        serde_yaml::Value::String("last_event_at".to_string()),
+        serde_yaml::Value::String(timestamp.to_string()),
+    );
+    true
 }
 
 fn load_snapshot(project_dir: &Path) -> io::Result<LedgerSnapshot> {

--- a/core/tests-rs/operator_cli.rs
+++ b/core/tests-rs/operator_cli.rs
@@ -171,6 +171,131 @@ fn operator_cli_rejects_unknown_and_extra_arguments() {
         stderr.contains("usage: winsmux explain"),
         "unexpected stderr: {stderr}"
     );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .args(["review-reset", "--json"])
+        .current_dir(&project_dir)
+        .output()
+        .expect("winsmux command should run");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("usage: winsmux review-reset"),
+        "unexpected stderr: {stderr}"
+    );
+}
+
+#[test]
+fn operator_cli_review_reset_clears_current_branch_and_manifest_pane() {
+    let project_dir = make_temp_project_dir("review-reset");
+    write_manifest(&project_dir);
+    init_git_branch(
+        &project_dir,
+        "codex/task266-rust-operator-readmodels-20260424",
+    );
+    write_review_state(
+        &project_dir,
+        r#"{
+  "codex/task266-rust-operator-readmodels-20260424": {
+    "status": "PASS",
+    "branch": "codex/task266-rust-operator-readmodels-20260424",
+    "head_sha": "abc123"
+  },
+  "other-branch": {
+    "status": "PENDING",
+    "branch": "other-branch",
+    "head_sha": "def456"
+  }
+}"#,
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .arg("review-reset")
+        .env("WINSMUX_PANE_ID", "%3")
+        .current_dir(&project_dir)
+        .output()
+        .expect("winsmux command should run");
+
+    assert!(
+        output.status.success(),
+        "winsmux command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("review PASS cleared for codex/task266-rust-operator-readmodels-20260424"),
+        "unexpected stdout: {stdout}"
+    );
+
+    let state_path = project_dir.join(".winsmux").join("review-state.json");
+    let state: serde_json::Value =
+        serde_json::from_slice(&fs::read(&state_path).expect("review state should remain"))
+            .expect("review state should be JSON");
+    assert!(state
+        .get("codex/task266-rust-operator-readmodels-20260424")
+        .is_none());
+    assert!(state.get("other-branch").is_some());
+
+    let manifest_path = project_dir.join(".winsmux").join("manifest.yaml");
+    let manifest: serde_yaml::Value =
+        serde_yaml::from_slice(&fs::read(&manifest_path).expect("manifest should exist"))
+            .expect("manifest should be YAML");
+    let panes = manifest["panes"]
+        .as_mapping()
+        .expect("panes should be a map");
+    let builder = panes
+        .get(&serde_yaml::Value::String("builder-1".to_string()))
+        .expect("builder-1 should exist");
+    assert_eq!(builder["review_state"].as_str(), Some("pending"));
+    assert_eq!(
+        builder["branch"].as_str(),
+        Some("codex/task266-rust-operator-readmodels-20260424")
+    );
+    assert_eq!(builder["head_sha"].as_str(), Some("abc123"));
+    let reviewer = panes
+        .get(&serde_yaml::Value::String("reviewer-1".to_string()))
+        .expect("reviewer-1 should exist");
+    assert_eq!(reviewer["review_state"].as_str(), Some(""));
+    assert_eq!(reviewer["branch"].as_str(), Some(""));
+    assert_eq!(reviewer["head_sha"].as_str(), Some(""));
+    assert_eq!(reviewer["last_event"].as_str(), Some("review.reset"));
+}
+
+#[test]
+fn operator_cli_review_reset_removes_empty_review_state_file() {
+    let project_dir = make_temp_project_dir("review-reset-empty");
+    write_manifest(&project_dir);
+    init_git_branch(
+        &project_dir,
+        "codex/task266-rust-operator-readmodels-20260424",
+    );
+    write_review_state(
+        &project_dir,
+        r#"{
+  "codex/task266-rust-operator-readmodels-20260424": {
+    "status": "PASS",
+    "branch": "codex/task266-rust-operator-readmodels-20260424",
+    "head_sha": "abc123"
+  }
+}"#,
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .arg("review-reset")
+        .current_dir(&project_dir)
+        .output()
+        .expect("winsmux command should run");
+
+    assert!(
+        output.status.success(),
+        "winsmux command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(!project_dir
+        .join(".winsmux")
+        .join("review-state.json")
+        .exists());
 }
 
 fn run_json(project_dir: &std::path::Path, args: &[&str]) -> serde_json::Value {
@@ -270,6 +395,26 @@ panes:
 "#,
     )
     .expect("test should write events");
+}
+
+fn write_review_state(project_dir: &std::path::Path, content: &str) {
+    let winsmux_dir = project_dir.join(".winsmux");
+    fs::create_dir_all(&winsmux_dir).expect("test should create .winsmux directory");
+    fs::write(winsmux_dir.join("review-state.json"), content)
+        .expect("test should write review state");
+}
+
+fn init_git_branch(project_dir: &std::path::Path, branch: &str) {
+    let init = Command::new("git")
+        .args(["init", "-b", branch])
+        .current_dir(project_dir)
+        .output()
+        .expect("git init should run");
+    assert!(
+        init.status.success(),
+        "git init failed: {}",
+        String::from_utf8_lossy(&init.stderr)
+    );
 }
 
 fn make_temp_project_dir(name: &str) -> std::path::PathBuf {


### PR DESCRIPTION
## Summary
- add Rust handling for winsmux review-reset
- clear the current branch entry from .winsmux/review-state.json
- best-effort clear manifest review fields only for Reviewer or Worker panes

## Validation
- cargo test --manifest-path core\Cargo.toml --test operator_cli -- --nocapture
- cargo test --manifest-path core\Cargo.toml --test fixture_comparison -- --nocapture
- cargo test --manifest-path core\Cargo.toml --test ledger_contract -- --nocapture
- cargo test --manifest-path core\Cargo.toml
- pwsh -NoProfile -File .\scripts\git-guard.ps1 -Mode full
- pwsh -NoProfile -File .\scripts\audit-public-surface.ps1

## Review
- subagent review found a Builder pane manifest sync drift
- fixed by limiting manifest sync to Reviewer and Worker

## Note
- TASK-266 remains open; review request, approve, fail, restart, and rebind work remains
- external Rust learning note was updated, but Opus review is blocked by private-note external disclosure policy