### PR TITLE
Add Rust review result commands

### DIFF
--- a/core/src/cli.rs
+++ b/core/src/cli.rs
@@ -134,6 +134,8 @@ OPERATOR COMMANDS:
     runs --json             Print run-oriented evidence JSON
     explain <run_id> --json Print one run explanation JSON
     review-request          Record a pending review request for the current branch
+    review-approve          Record PASS for the pending review request
+    review-fail             Record FAIL for the pending review request
     review-reset            Clear review state for the current branch
 
 LAYOUT COMMANDS:

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -246,6 +246,8 @@ fn run_main() -> io::Result<()> {
         "runs" => return operator_cli::run_runs_command(&cmd_args[1..]),
         "explain" => return operator_cli::run_explain_command(&cmd_args[1..]),
         "review-request" => return operator_cli::run_review_request_command(&cmd_args[1..]),
+        "review-approve" => return operator_cli::run_review_approve_command(&cmd_args[1..]),
+        "review-fail" => return operator_cli::run_review_fail_command(&cmd_args[1..]),
         "review-reset" => return operator_cli::run_review_reset_command(&cmd_args[1..]),
         // kill-server MUST be handled early before any potential fall-through
         "kill-server" => {

--- a/core/src/operator_cli.rs
+++ b/core/src/operator_cli.rs
@@ -162,7 +162,7 @@ pub fn run_review_request_command(args: &[&String]) -> io::Result<()> {
             usage_for("review-request"),
         ));
     }
-    assert_review_request_role_permission()?;
+    assert_review_role_permission("review-request")?;
 
     let branch = current_git_branch(&options.project_dir)?;
     let head_sha = current_git_head(&options.project_dir)?;
@@ -192,6 +192,28 @@ pub fn run_review_request_command(args: &[&String]) -> io::Result<()> {
     let _ = mark_current_pane_review_requested(&options.project_dir, &context, &branch, &head_sha);
     println!("review request recorded for {branch}");
     Ok(())
+}
+
+pub fn run_review_approve_command(args: &[&String]) -> io::Result<()> {
+    record_review_result(
+        args,
+        "review-approve",
+        "PASS",
+        "approved_at",
+        "approved_via",
+        "pass",
+    )
+}
+
+pub fn run_review_fail_command(args: &[&String]) -> io::Result<()> {
+    record_review_result(
+        args,
+        "review-fail",
+        "FAIL",
+        "failed_at",
+        "failed_via",
+        "fail",
+    )
 }
 
 struct ParsedOptions {
@@ -278,6 +300,8 @@ fn usage_for(command: &str) -> &'static str {
         "explain" => "usage: winsmux explain <run_id> --json [--project-dir <path>]",
         "review-reset" => "usage: winsmux review-reset [--project-dir <path>]",
         "review-request" => "usage: winsmux review-request [--project-dir <path>]",
+        "review-approve" => "usage: winsmux review-approve [--project-dir <path>]",
+        "review-fail" => "usage: winsmux review-fail [--project-dir <path>]",
         _ => "usage: winsmux <command> --json [--project-dir <path>]",
     }
 }
@@ -395,10 +419,10 @@ fn save_review_state(project_dir: &Path, state: Map<String, Value>) -> io::Resul
     fs::write(path, format!("{content}\n"))
 }
 
-fn assert_review_request_role_permission() -> io::Result<()> {
+fn assert_review_role_permission(command_name: &str) -> io::Result<()> {
     let role = current_canonical_role()?;
     if !matches!(role.as_str(), "Reviewer" | "Worker") {
-        return Err(review_request_permission_error());
+        return Err(review_permission_error(command_name));
     }
 
     let role_map = role_map_from_env()?;
@@ -490,10 +514,10 @@ fn canonical_role(role: &str) -> Option<String> {
     }
 }
 
-fn review_request_permission_error() -> io::Error {
+fn review_permission_error(command_name: &str) -> io::Error {
     io::Error::new(
         io::ErrorKind::PermissionDenied,
-        "review-request is not permitted for the current role",
+        format!("{command_name} is not permitted for the current role"),
     )
 }
 
@@ -668,6 +692,193 @@ fn review_contract_record() -> Value {
     })
 }
 
+fn record_review_result(
+    args: &[&String],
+    command_name: &str,
+    status: &str,
+    timestamp_key: &str,
+    via_key: &str,
+    manifest_state: &str,
+) -> io::Result<()> {
+    if should_print_help(args) {
+        println!("{}", usage_for(command_name));
+        return Ok(());
+    }
+    let options = parse_options(command_name, args, 0)?;
+    if options.json {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            usage_for(command_name),
+        ));
+    }
+    assert_review_role_permission(command_name)?;
+
+    let branch = current_git_branch(&options.project_dir)?;
+    let head_sha = current_git_head(&options.project_dir)?;
+    let context = current_review_pane_context(&options.project_dir)?;
+    let mut state = load_review_state(&options.project_dir)?;
+    let request = pending_review_request(&state, &branch, &head_sha, &context)?;
+    let timestamp = generated_at();
+    let reviewer = review_result_reviewer(&context);
+    let evidence =
+        review_result_evidence(&request, timestamp_key, via_key, command_name, &timestamp);
+    let request_branch = request_string(&request, "branch");
+    let request_head_sha = request_string(&request, "head_sha");
+
+    state.insert(
+        branch.clone(),
+        json!({
+            "status": status,
+            "branch": request_branch,
+            "head_sha": request_head_sha,
+            "request": request,
+            "reviewer": reviewer,
+            "updatedAt": timestamp,
+            "evidence": evidence,
+        }),
+    );
+    save_review_state(&options.project_dir, state)?;
+    let _ = mark_current_pane_review_result(
+        &options.project_dir,
+        &context,
+        &branch,
+        &head_sha,
+        manifest_state,
+    );
+    println!("review {status} recorded for {branch}");
+    Ok(())
+}
+
+fn pending_review_request(
+    state: &Map<String, Value>,
+    branch: &str,
+    head_sha: &str,
+    context: &ReviewPaneContext,
+) -> io::Result<Value> {
+    let Some(entry) = state.get(branch) else {
+        return Err(pending_review_request_missing(branch));
+    };
+    let status = entry
+        .get("status")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let Some(request) = entry.get("request").cloned() else {
+        return Err(pending_review_request_missing(branch));
+    };
+    if status != "PENDING" || !request.is_object() {
+        return Err(pending_review_request_missing(branch));
+    }
+    if !review_contract_present(&request) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("pending review request for {branch} is missing review_contract. Re-run: winsmux review-request"),
+        ));
+    }
+
+    let request_pane_id = review_request_target_value(&request, "pane_id");
+    if request_pane_id != context.pane_id {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "pending review request for {branch} is assigned to {request_pane_id}, not {}",
+                context.pane_id
+            ),
+        ));
+    }
+
+    let request_branch = request_string(&request, "branch");
+    if request_branch != branch {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "pending review request branch mismatch: expected {request_branch}, got {branch}"
+            ),
+        ));
+    }
+
+    let request_head_sha = request_string(&request, "head_sha");
+    if request_head_sha != head_sha {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "pending review request head mismatch: expected {request_head_sha}, got {head_sha}"
+            ),
+        ));
+    }
+
+    Ok(request)
+}
+
+fn pending_review_request_missing(branch: &str) -> io::Error {
+    io::Error::new(
+        io::ErrorKind::NotFound,
+        format!("review request pending for {branch} was not found. Run: winsmux review-request"),
+    )
+}
+
+fn review_contract_present(request: &Value) -> bool {
+    let Some(contract) = request.get("review_contract").and_then(Value::as_object) else {
+        return false;
+    };
+    match contract.get("required_scope") {
+        Some(Value::Array(items)) => !items.is_empty(),
+        Some(Value::String(value)) => !value.trim().is_empty(),
+        Some(Value::Null) | None => false,
+        Some(_) => true,
+    }
+}
+
+fn review_request_target_value(request: &Value, name: &str) -> String {
+    let primary = format!("target_review_{name}");
+    let legacy = format!("target_reviewer_{name}");
+    let primary_value = request_string(request, &primary);
+    if primary_value.trim().is_empty() {
+        request_string(request, &legacy)
+    } else {
+        primary_value
+    }
+}
+
+fn request_string(request: &Value, name: &str) -> String {
+    request
+        .get(name)
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string()
+}
+
+fn review_result_reviewer(context: &ReviewPaneContext) -> Value {
+    json!({
+        "pane_id": context.pane_id,
+        "label": context.label,
+        "role": context.role,
+        "agent_name": env::var("WINSMUX_AGENT_NAME").unwrap_or_default(),
+    })
+}
+
+fn review_result_evidence(
+    request: &Value,
+    timestamp_key: &str,
+    via_key: &str,
+    command_name: &str,
+    timestamp: &str,
+) -> Value {
+    let mut evidence = Map::new();
+    evidence.insert(timestamp_key.to_string(), json!(timestamp));
+    evidence.insert(
+        via_key.to_string(),
+        json!(format!("winsmux {command_name}")),
+    );
+    evidence.insert(
+        "review_contract_snapshot".to_string(),
+        request
+            .get("review_contract")
+            .cloned()
+            .unwrap_or(Value::Null),
+    );
+    Value::Object(evidence)
+}
+
 fn mark_current_pane_review_requested(
     project_dir: &Path,
     context: &ReviewPaneContext,
@@ -692,6 +903,48 @@ fn mark_current_pane_review_requested(
             ("branch", branch),
             ("head_sha", head_sha),
             ("last_event", "review.requested"),
+            ("last_event_at", &timestamp),
+        ],
+    );
+    if !updated {
+        return Ok(false);
+    }
+    let content = serde_yaml::to_string(&manifest).map_err(|err| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("failed to serialize manifest: {err}"),
+        )
+    })?;
+    fs::write(manifest_path, content)?;
+    Ok(true)
+}
+
+fn mark_current_pane_review_result(
+    project_dir: &Path,
+    context: &ReviewPaneContext,
+    branch: &str,
+    head_sha: &str,
+    review_state: &str,
+) -> io::Result<bool> {
+    let manifest_path = project_dir.join(".winsmux").join("manifest.yaml");
+    let raw = fs::read_to_string(&manifest_path)?;
+    let mut manifest = serde_yaml::from_str::<serde_yaml::Value>(&raw).map_err(|err| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("invalid manifest: {}: {err}", manifest_path.display()),
+        )
+    })?;
+    let timestamp = generated_at();
+    let last_event = format!("review.{review_state}");
+    let updated = update_manifest_pane_fields(
+        &mut manifest,
+        &context.pane_id,
+        &[
+            ("review_state", review_state),
+            ("task_owner", "Operator"),
+            ("branch", branch),
+            ("head_sha", head_sha),
+            ("last_event", &last_event),
             ("last_event_at", &timestamp),
         ],
     );

--- a/core/tests-rs/operator_cli.rs
+++ b/core/tests-rs/operator_cli.rs
@@ -197,6 +197,21 @@ fn operator_cli_rejects_unknown_and_extra_arguments() {
         stderr.contains("usage: winsmux review-request"),
         "unexpected stderr: {stderr}"
     );
+
+    for command in ["review-approve", "review-fail"] {
+        let output = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+            .args([command, "--json"])
+            .current_dir(&project_dir)
+            .output()
+            .expect("winsmux command should run");
+
+        assert!(!output.status.success());
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            stderr.contains(&format!("usage: winsmux {command}")),
+            "unexpected stderr for {command}: {stderr}"
+        );
+    }
 }
 
 #[test]
@@ -425,6 +440,262 @@ fn operator_cli_review_request_generates_distinct_request_ids() {
 }
 
 #[test]
+fn operator_cli_review_approve_records_pass_state_and_manifest_pane() {
+    let project_dir = make_temp_project_dir("review-approve");
+    write_manifest(&project_dir);
+    init_git_branch(
+        &project_dir,
+        "codex/task266-rust-operator-readmodels-20260424",
+    );
+    set_git_head(
+        &project_dir,
+        "codex/task266-rust-operator-readmodels-20260424",
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    );
+    run_review_request_and_read_id(&project_dir);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .arg("review-approve")
+        .env("WINSMUX_PANE_ID", "%3")
+        .env("WINSMUX_ROLE", "Reviewer")
+        .env("WINSMUX_ROLE_MAP", r#"{"%3":"Reviewer"}"#)
+        .env("WINSMUX_AGENT_NAME", "codex")
+        .current_dir(&project_dir)
+        .output()
+        .expect("winsmux command should run");
+
+    assert!(
+        output.status.success(),
+        "winsmux command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("review PASS recorded for codex/task266-rust-operator-readmodels-20260424"),
+        "unexpected stdout: {stdout}"
+    );
+
+    let state = read_review_state(&project_dir);
+    let record = &state["codex/task266-rust-operator-readmodels-20260424"];
+    assert_eq!(record["status"], "PASS");
+    assert_eq!(
+        record["head_sha"],
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    );
+    assert_eq!(record["reviewer"]["pane_id"], "%3");
+    assert_eq!(record["reviewer"]["agent_name"], "codex");
+    assert!(record["evidence"]["approved_at"].as_str().is_some());
+    assert_eq!(record["evidence"]["approved_via"], "winsmux review-approve");
+    assert_eq!(
+        record["evidence"]["review_contract_snapshot"]["required_scope"][0],
+        "design_impact"
+    );
+
+    let reviewer = read_manifest_pane(&project_dir, "reviewer-1");
+    assert_eq!(reviewer["review_state"].as_str(), Some("pass"));
+    assert_eq!(reviewer["task_owner"].as_str(), Some("Operator"));
+    assert_eq!(reviewer["last_event"].as_str(), Some("review.pass"));
+}
+
+#[test]
+fn operator_cli_review_fail_records_fail_state_and_manifest_pane() {
+    let project_dir = make_temp_project_dir("review-fail");
+    write_manifest(&project_dir);
+    init_git_branch(
+        &project_dir,
+        "codex/task266-rust-operator-readmodels-20260424",
+    );
+    set_git_head(
+        &project_dir,
+        "codex/task266-rust-operator-readmodels-20260424",
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    );
+    run_review_request_and_read_id(&project_dir);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .arg("review-fail")
+        .env("WINSMUX_PANE_ID", "%3")
+        .env("WINSMUX_ROLE", "Reviewer")
+        .env("WINSMUX_ROLE_MAP", r#"{"%3":"Reviewer"}"#)
+        .env("WINSMUX_AGENT_NAME", "codex")
+        .current_dir(&project_dir)
+        .output()
+        .expect("winsmux command should run");
+
+    assert!(
+        output.status.success(),
+        "winsmux command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("review FAIL recorded for codex/task266-rust-operator-readmodels-20260424"),
+        "unexpected stdout: {stdout}"
+    );
+
+    let state = read_review_state(&project_dir);
+    let record = &state["codex/task266-rust-operator-readmodels-20260424"];
+    assert_eq!(record["status"], "FAIL");
+    assert!(record["evidence"]["failed_at"].as_str().is_some());
+    assert_eq!(record["evidence"]["failed_via"], "winsmux review-fail");
+
+    let reviewer = read_manifest_pane(&project_dir, "reviewer-1");
+    assert_eq!(reviewer["review_state"].as_str(), Some("fail"));
+    assert_eq!(reviewer["task_owner"].as_str(), Some("Operator"));
+    assert_eq!(reviewer["last_event"].as_str(), Some("review.fail"));
+}
+
+#[test]
+fn operator_cli_review_result_requires_pending_request() {
+    for command in ["review-approve", "review-fail"] {
+        let project_dir = make_temp_project_dir(command);
+        write_manifest(&project_dir);
+        init_git_branch(
+            &project_dir,
+            "codex/task266-rust-operator-readmodels-20260424",
+        );
+        set_git_head(
+            &project_dir,
+            "codex/task266-rust-operator-readmodels-20260424",
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        );
+
+        let output = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+            .arg(command)
+            .env("WINSMUX_PANE_ID", "%3")
+            .env("WINSMUX_ROLE", "Reviewer")
+            .env("WINSMUX_ROLE_MAP", r#"{"%3":"Reviewer"}"#)
+            .current_dir(&project_dir)
+            .output()
+            .expect("winsmux command should run");
+
+        assert!(!output.status.success());
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            stderr.contains("review request pending for codex/task266-rust-operator-readmodels-20260424 was not found"),
+            "unexpected stderr for {command}: {stderr}"
+        );
+    }
+}
+
+#[test]
+fn operator_cli_review_result_requires_review_contract() {
+    let project_dir = make_temp_project_dir("review-result-contract");
+    write_manifest(&project_dir);
+    init_git_branch(
+        &project_dir,
+        "codex/task266-rust-operator-readmodels-20260424",
+    );
+    set_git_head(
+        &project_dir,
+        "codex/task266-rust-operator-readmodels-20260424",
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    );
+    write_review_state(
+        &project_dir,
+        r#"{
+  "codex/task266-rust-operator-readmodels-20260424": {
+    "status": "PENDING",
+    "branch": "codex/task266-rust-operator-readmodels-20260424",
+    "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "request": {
+      "branch": "codex/task266-rust-operator-readmodels-20260424",
+      "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "target_review_pane_id": "%3"
+    }
+  }
+}"#,
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .arg("review-approve")
+        .env("WINSMUX_PANE_ID", "%3")
+        .env("WINSMUX_ROLE", "Reviewer")
+        .env("WINSMUX_ROLE_MAP", r#"{"%3":"Reviewer"}"#)
+        .current_dir(&project_dir)
+        .output()
+        .expect("winsmux command should run");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("is missing review_contract"),
+        "unexpected stderr: {stderr}"
+    );
+}
+
+#[test]
+fn operator_cli_review_result_rejects_pane_and_head_mismatch() {
+    let cases = [
+        (
+            "review-result-pane-mismatch",
+            r#"{
+  "codex/task266-rust-operator-readmodels-20260424": {
+    "status": "PENDING",
+    "branch": "codex/task266-rust-operator-readmodels-20260424",
+    "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "request": {
+      "branch": "codex/task266-rust-operator-readmodels-20260424",
+      "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "target_review_pane_id": "%9",
+      "review_contract": {"required_scope":["design_impact"]}
+    }
+  }
+}"#,
+            "is assigned to %9, not %3",
+        ),
+        (
+            "review-result-head-mismatch",
+            r#"{
+  "codex/task266-rust-operator-readmodels-20260424": {
+    "status": "PENDING",
+    "branch": "codex/task266-rust-operator-readmodels-20260424",
+    "head_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "request": {
+      "branch": "codex/task266-rust-operator-readmodels-20260424",
+      "head_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "target_review_pane_id": "%3",
+      "review_contract": {"required_scope":["design_impact"]}
+    }
+  }
+}"#,
+            "pending review request head mismatch",
+        ),
+    ];
+
+    for (name, state, expected) in cases {
+        let project_dir = make_temp_project_dir(name);
+        write_manifest(&project_dir);
+        init_git_branch(
+            &project_dir,
+            "codex/task266-rust-operator-readmodels-20260424",
+        );
+        set_git_head(
+            &project_dir,
+            "codex/task266-rust-operator-readmodels-20260424",
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        );
+        write_review_state(&project_dir, state);
+
+        let output = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+            .arg("review-approve")
+            .env("WINSMUX_PANE_ID", "%3")
+            .env("WINSMUX_ROLE", "Reviewer")
+            .env("WINSMUX_ROLE_MAP", r#"{"%3":"Reviewer"}"#)
+            .current_dir(&project_dir)
+            .output()
+            .expect("winsmux command should run");
+
+        assert!(!output.status.success());
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            stderr.contains(expected),
+            "unexpected stderr for {name}: {stderr}"
+        );
+    }
+}
+
+#[test]
 fn operator_cli_review_reset_clears_current_branch_and_manifest_pane() {
     let project_dir = make_temp_project_dir("review-reset");
     write_manifest(&project_dir);
@@ -560,6 +831,26 @@ fn run_review_request_and_read_id(project_dir: &std::path::Path) -> String {
         .as_str()
         .expect("request id should be a string")
         .to_string()
+}
+
+fn read_review_state(project_dir: &std::path::Path) -> serde_json::Value {
+    let state_path = project_dir.join(".winsmux").join("review-state.json");
+    serde_json::from_slice(&fs::read(&state_path).expect("review state should exist"))
+        .expect("review state should be JSON")
+}
+
+fn read_manifest_pane(project_dir: &std::path::Path, label: &str) -> serde_yaml::Value {
+    let manifest_path = project_dir.join(".winsmux").join("manifest.yaml");
+    let manifest: serde_yaml::Value =
+        serde_yaml::from_slice(&fs::read(&manifest_path).expect("manifest should exist"))
+            .expect("manifest should be YAML");
+    let panes = manifest["panes"]
+        .as_mapping()
+        .expect("panes should be a map");
+    panes
+        .get(serde_yaml::Value::String(label.to_string()))
+        .expect("pane should exist")
+        .clone()
 }
 
 fn run_json(project_dir: &std::path::Path, args: &[&str]) -> serde_json::Value {


### PR DESCRIPTION
## Summary
- add Rust \winsmux review-approve\ and \winsmux review-fail\
- preserve the PowerShell review-state contract for \PASS\ and \FAIL\
- reject stale, mismatched, or contractless pending review requests

## Validation
- \cargo test --manifest-path core\\Cargo.toml --test operator_cli -- --nocapture\
- \cargo test --manifest-path core\\Cargo.toml --test fixture_comparison -- --nocapture\
- \cargo test --manifest-path core\\Cargo.toml --test ledger_contract -- --nocapture\
- \cargo test --manifest-path core\\Cargo.toml\
- \git diff --check\
- \pwsh -NoProfile -File .\\scripts\\git-guard.ps1 -Mode full\
- \pwsh -NoProfile -File .\\scripts\\audit-public-surface.ps1\

## Review
- Review agent: no findings

Part of \TASK-266\.