### PR TITLE
Add Rust restart command

### DIFF
--- a/core/src/cli.rs
+++ b/core/src/cli.rs
@@ -137,6 +137,7 @@ OPERATOR COMMANDS:
     review-approve          Record PASS for the pending review request
     review-fail             Record FAIL for the pending review request
     review-reset            Clear review state for the current branch
+    restart                 Restart a managed pane using manifest context
     rebind-worktree         Update a Builder/Worker pane to use a new worktree path
 
 LAYOUT COMMANDS:

--- a/core/src/commands.rs
+++ b/core/src/commands.rs
@@ -908,7 +908,7 @@ pub fn execute_command_string(app: &mut AppState, cmd: &str) -> io::Result<()> {
             if let Some(port) = app.control_port {
                 let _ = send_control_to_port(port, "respawn-pane\n", &app.session_key);
             } else {
-                crate::window_ops::respawn_active_pane(app, None)?;
+                crate::window_ops::respawn_active_pane(app, None, None)?;
             }
         }
         "toggle-sync" => {

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -249,6 +249,7 @@ fn run_main() -> io::Result<()> {
         "review-approve" => return operator_cli::run_review_approve_command(&cmd_args[1..]),
         "review-fail" => return operator_cli::run_review_fail_command(&cmd_args[1..]),
         "review-reset" => return operator_cli::run_review_reset_command(&cmd_args[1..]),
+        "restart" => return operator_cli::run_restart_command(&cmd_args[1..]),
         "rebind-worktree" => return operator_cli::run_rebind_worktree_command(&cmd_args[1..]),
         // kill-server MUST be handled early before any potential fall-through
         "kill-server" => {
@@ -1031,7 +1032,7 @@ fn run_main() -> io::Result<()> {
                         }
                         "-t" => {
                             if let Some(t) = cmd_args.get(i + 1) {
-                                cmd.push_str(&format!(" -t {}", t));
+                                cmd.push_str(&format!(" -t {}", crate::util::quote_arg(t)));
                                 i += 1;
                             }
                         }
@@ -1052,7 +1053,7 @@ fn run_main() -> io::Result<()> {
                     match cmd_args[i].as_str() {
                         "-t" => {
                             if let Some(t) = cmd_args.get(i + 1) {
-                                cmd.push_str(&format!(" -t {}", t));
+                                cmd.push_str(&format!(" -t {}", crate::util::quote_arg(t)));
                                 i += 1;
                             }
                         }
@@ -1204,7 +1205,7 @@ fn run_main() -> io::Result<()> {
                         }
                         "-t" => {
                             if let Some(t) = cmd_args.get(i + 1) {
-                                cmd.push_str(&format!(" -t {}", t));
+                                cmd.push_str(&format!(" -t {}", crate::util::quote_arg(t)));
                                 i += 1;
                             }
                         }
@@ -1229,7 +1230,7 @@ fn run_main() -> io::Result<()> {
                         "-Z" => { cmd.push_str(" -Z"); }
                         "-t" => {
                             if let Some(t) = cmd_args.get(i + 1) {
-                                cmd.push_str(&format!(" -t {}", t));
+                                cmd.push_str(&format!(" -t {}", crate::util::quote_arg(t)));
                                 i += 1;
                             }
                         }
@@ -1458,7 +1459,14 @@ fn run_main() -> io::Result<()> {
                         "-k" => { cmd.push_str(" -k"); }
                         "-t" => {
                             if let Some(t) = cmd_args.get(i + 1) {
-                                cmd.push_str(&format!(" -t {}", t));
+                                cmd.push_str(&format!(" -t {}", crate::util::quote_arg(t)));
+                                i += 1;
+                            }
+                        }
+                        "-c" => {
+                            if let Some(dir) = cmd_args.get(i + 1) {
+                                cmd.push_str(" -c ");
+                                cmd.push_str(&crate::util::quote_arg(dir));
                                 i += 1;
                             }
                         }

--- a/core/src/operator_cli.rs
+++ b/core/src/operator_cli.rs
@@ -223,6 +223,27 @@ pub fn run_review_fail_command(args: &[&String]) -> io::Result<()> {
     )
 }
 
+pub fn run_restart_command(args: &[&String]) -> io::Result<()> {
+    if should_print_help(args) {
+        println!("{}", usage_for("restart"));
+        return Ok(());
+    }
+    let options = parse_options("restart", args, 1)?;
+    if options.json {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            usage_for("restart"),
+        ));
+    }
+
+    let target = options.positionals[0].clone();
+    let plan = build_restart_plan(&options.project_dir, &target)?;
+    invoke_restart_plan(&plan)?;
+    let _ = update_restart_manifest_metadata(&options.project_dir, &plan);
+    println!("restarted {} ({})", plan.pane_id, plan.label);
+    Ok(())
+}
+
 pub fn run_rebind_worktree_command(args: &[&String]) -> io::Result<()> {
     if should_print_help(args) {
         println!("{}", usage_for("rebind-worktree"));
@@ -394,6 +415,7 @@ fn usage_for(command: &str) -> &'static str {
         "review-request" => "usage: winsmux review-request [--project-dir <path>]",
         "review-approve" => "usage: winsmux review-approve [--project-dir <path>]",
         "review-fail" => "usage: winsmux review-fail [--project-dir <path>]",
+        "restart" => "usage: winsmux restart <target> [--project-dir <path>]",
         "rebind-worktree" => {
             "usage: winsmux rebind-worktree <target> <new-worktree-path> [--project-dir <path>]"
         }
@@ -628,6 +650,20 @@ struct RebindManifestContext {
     label: String,
     pane_id: String,
     role: String,
+}
+
+#[derive(Clone)]
+struct RestartPlan {
+    label: String,
+    pane_id: String,
+    role: String,
+    session_name: String,
+    launch_dir: String,
+    git_worktree_dir: String,
+    agent: String,
+    model: String,
+    capability_adapter: String,
+    launch_command: String,
 }
 
 fn current_review_pane_context(project_dir: &Path) -> io::Result<ReviewPaneContext> {
@@ -867,11 +903,497 @@ fn manifest_session_name(manifest: &serde_yaml::Value) -> io::Result<String> {
     Ok(session_name)
 }
 
-fn ensure_live_pane_target(session_name: &str, pane_id: &str) -> io::Result<()> {
-    let winsmux_bin = env::var_os("WINSMUX_BIN")
+fn build_restart_plan(project_dir: &Path, target: &str) -> io::Result<RestartPlan> {
+    let manifest_path = project_dir.join(".winsmux").join("manifest.yaml");
+    let raw = fs::read_to_string(&manifest_path)?;
+    let manifest = serde_yaml::from_str::<serde_yaml::Value>(&raw).map_err(|err| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("invalid manifest: {}: {err}", manifest_path.display()),
+        )
+    })?;
+    let session_name = manifest_session_name(&manifest)?;
+    let project_root = manifest_project_dir(&manifest).unwrap_or_else(|| project_dir.to_path_buf());
+    let session_git_worktree_dir = manifest_session_git_worktree_dir(&manifest);
+    let context = resolve_restart_manifest_context(
+        &manifest,
+        target,
+        &manifest_path,
+        &project_root,
+        session_git_worktree_dir.as_deref(),
+    )?;
+    ensure_live_pane_target(&session_name, &context.pane_id)?;
+
+    let (agent, model, capability_adapter) = resolve_restart_provider(project_dir, &context);
+    let launch_command = build_provider_launch_command(
+        &agent,
+        &model,
+        &capability_adapter,
+        &context.launch_dir,
+        &context.git_worktree_dir,
+    )?;
+    Ok(RestartPlan {
+        label: context.label,
+        pane_id: context.pane_id,
+        role: context.role,
+        session_name,
+        launch_dir: context.launch_dir,
+        git_worktree_dir: context.git_worktree_dir,
+        agent,
+        model,
+        capability_adapter,
+        launch_command,
+    })
+}
+
+fn manifest_project_dir(manifest: &serde_yaml::Value) -> Option<PathBuf> {
+    manifest
+        .get("session")
+        .and_then(|session| session.get("project_dir"))
+        .and_then(serde_yaml::Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .map(PathBuf::from)
+}
+
+fn manifest_session_git_worktree_dir(manifest: &serde_yaml::Value) -> Option<String> {
+    manifest
+        .get("session")
+        .and_then(|session| session.get("git_worktree_dir"))
+        .and_then(serde_yaml::Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .map(str::to_string)
+}
+
+fn resolve_restart_manifest_context(
+    manifest: &serde_yaml::Value,
+    target: &str,
+    manifest_path: &Path,
+    project_root: &Path,
+    session_git_worktree_dir: Option<&str>,
+) -> io::Result<RestartPlan> {
+    let Some(context) =
+        find_restart_manifest_context(manifest, target, project_root, session_git_worktree_dir)
+    else {
+        return Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            format!(
+                "Pane {target} was not found in manifest: {}",
+                manifest_path.display()
+            ),
+        ));
+    };
+    Ok(context)
+}
+
+fn find_restart_manifest_context(
+    manifest: &serde_yaml::Value,
+    target: &str,
+    project_root: &Path,
+    session_git_worktree_dir: Option<&str>,
+) -> Option<RestartPlan> {
+    let panes = manifest.get("panes")?;
+    match panes {
+        serde_yaml::Value::Mapping(map) => map.iter().find_map(|(key, pane)| {
+            let label = key.as_str().unwrap_or_default();
+            restart_context_from_value(label, target, pane, project_root, session_git_worktree_dir)
+        }),
+        serde_yaml::Value::Sequence(items) => items.iter().find_map(|pane| {
+            restart_context_from_value("", target, pane, project_root, session_git_worktree_dir)
+        }),
+        _ => None,
+    }
+}
+
+fn restart_context_from_value(
+    fallback_label: &str,
+    target: &str,
+    pane: &serde_yaml::Value,
+    project_root: &Path,
+    session_git_worktree_dir: Option<&str>,
+) -> Option<RestartPlan> {
+    let map = pane.as_mapping()?;
+    let pane_id = manifest_string(map, "pane_id");
+    let label = first_non_empty(&manifest_string(map, "label"), fallback_label);
+    if pane_id != target && label != target {
+        return None;
+    }
+    let role = canonical_manifest_role(&manifest_string(map, "role"), &label)?;
+    let uses_worktree = matches!(role.as_str(), "Builder" | "Worker");
+    let builder_worktree_path = if uses_worktree {
+        manifest_string(map, "builder_worktree_path")
+    } else {
+        String::new()
+    };
+    let mut launch_dir = manifest_string(map, "launch_dir");
+    if launch_dir.trim().is_empty() && !builder_worktree_path.trim().is_empty() {
+        launch_dir = builder_worktree_path;
+    }
+    if launch_dir.trim().is_empty() {
+        launch_dir = project_root.to_string_lossy().to_string();
+    }
+
+    let mut git_worktree_dir = if uses_worktree {
+        manifest_string(map, "worktree_git_dir")
+    } else {
+        String::new()
+    };
+    if git_worktree_dir.trim().is_empty() {
+        git_worktree_dir = session_git_worktree_dir.unwrap_or_default().to_string();
+    }
+    if uses_worktree || git_worktree_dir.trim().is_empty() {
+        git_worktree_dir = pane_git_worktree_dir(Path::new(&launch_dir));
+    }
+
+    Some(RestartPlan {
+        label,
+        pane_id,
+        role,
+        session_name: String::new(),
+        launch_dir,
+        git_worktree_dir,
+        agent: String::new(),
+        model: String::new(),
+        capability_adapter: String::new(),
+        launch_command: String::new(),
+    })
+}
+
+fn pane_git_worktree_dir(project_dir: &Path) -> String {
+    let dot_git = project_dir.join(".git");
+    if dot_git.is_file() {
+        if let Ok(raw) = fs::read_to_string(&dot_git) {
+            if let Some(rest) = raw.trim().strip_prefix("gitdir:") {
+                let value = rest.trim();
+                let path = PathBuf::from(value);
+                return if path.is_absolute() {
+                    path.to_string_lossy().to_string()
+                } else {
+                    project_dir.join(path).to_string_lossy().to_string()
+                };
+            }
+        }
+    }
+    if dot_git.is_dir() {
+        return dot_git.to_string_lossy().to_string();
+    }
+    project_dir.to_string_lossy().to_string()
+}
+
+fn resolve_restart_provider(project_dir: &Path, context: &RestartPlan) -> (String, String, String) {
+    if let Some((agent, model, adapter)) = provider_registry_entry(project_dir, &context.label) {
+        return (agent, model, adapter);
+    }
+    let (agent, model) =
+        split_provider_target(&manifest_provider_target(project_dir, &context.pane_id));
+    let agent = if agent.trim().is_empty() {
+        "codex".to_string()
+    } else {
+        agent
+    };
+    let model = if model.trim().is_empty() {
+        "gpt-5.4".to_string()
+    } else {
+        model
+    };
+    let adapter = manifest_capability_adapter(project_dir, &context.pane_id)
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| provider_adapter_from_agent(&agent));
+    (agent, model, adapter)
+}
+
+fn provider_registry_entry(project_dir: &Path, label: &str) -> Option<(String, String, String)> {
+    let path = project_dir.join(".winsmux").join("provider-registry.json");
+    let raw = fs::read_to_string(path).ok()?;
+    let registry = serde_json::from_str::<Value>(&raw).ok()?;
+    let entry = registry.get("slots")?.get(label)?;
+    let agent = entry.get("agent").and_then(Value::as_str)?.to_string();
+    let model = entry
+        .get("model")
+        .and_then(Value::as_str)
+        .unwrap_or("gpt-5.4")
+        .to_string();
+    let adapter = provider_adapter_from_agent(&agent);
+    Some((agent, model, adapter))
+}
+
+fn manifest_provider_target(project_dir: &Path, pane_id: &str) -> String {
+    manifest_pane_field(project_dir, pane_id, "provider_target").unwrap_or_default()
+}
+
+fn manifest_capability_adapter(project_dir: &Path, pane_id: &str) -> Option<String> {
+    manifest_pane_field(project_dir, pane_id, "capability_adapter")
+}
+
+fn manifest_pane_field(project_dir: &Path, pane_id: &str, field: &str) -> Option<String> {
+    let path = project_dir.join(".winsmux").join("manifest.yaml");
+    let raw = fs::read_to_string(path).ok()?;
+    let manifest = serde_yaml::from_str::<serde_yaml::Value>(&raw).ok()?;
+    let panes = manifest.get("panes")?;
+    match panes {
+        serde_yaml::Value::Mapping(map) => map.values().find_map(|pane| {
+            let map = pane.as_mapping()?;
+            (manifest_string(map, "pane_id") == pane_id)
+                .then(|| manifest_string(map, field))
+                .filter(|value| !value.trim().is_empty())
+        }),
+        serde_yaml::Value::Sequence(items) => items.iter().find_map(|pane| {
+            let map = pane.as_mapping()?;
+            (manifest_string(map, "pane_id") == pane_id)
+                .then(|| manifest_string(map, field))
+                .filter(|value| !value.trim().is_empty())
+        }),
+        _ => None,
+    }
+}
+
+fn split_provider_target(provider_target: &str) -> (String, String) {
+    let trimmed = provider_target.trim();
+    if let Some((agent, model)) = trimmed.split_once(':') {
+        return (agent.trim().to_string(), model.trim().to_string());
+    }
+    (trimmed.to_string(), String::new())
+}
+
+fn provider_adapter_from_agent(agent: &str) -> String {
+    let lowered = agent.trim().to_ascii_lowercase();
+    if lowered.starts_with("claude") {
+        "claude".to_string()
+    } else {
+        "codex".to_string()
+    }
+}
+
+fn build_provider_launch_command(
+    agent: &str,
+    model: &str,
+    capability_adapter: &str,
+    launch_dir: &str,
+    git_worktree_dir: &str,
+) -> io::Result<String> {
+    match capability_adapter.trim().to_ascii_lowercase().as_str() {
+        "codex" | "" => Ok(format!(
+            "{} -c {} --sandbox danger-full-access -C {} --add-dir {}",
+            shell_literal(agent),
+            shell_literal(&format!("model={model}")),
+            shell_literal(launch_dir),
+            shell_literal(git_worktree_dir)
+        )),
+        "claude" => {
+            let mut parts = vec![shell_literal(agent)];
+            if !model.trim().is_empty() {
+                parts.push("--model".to_string());
+                parts.push(shell_literal(model));
+            }
+            parts.push("--permission-mode".to_string());
+            parts.push("bypassPermissions".to_string());
+            Ok(parts.join(" "))
+        }
+        adapter => Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("Unsupported provider adapter '{adapter}' for restart"),
+        )),
+    }
+}
+
+fn shell_literal(value: &str) -> String {
+    if value
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.' | ':' | '/' | '\\'))
+    {
+        return value.to_string();
+    }
+    format!("'{}'", value.replace('\'', "''"))
+}
+
+fn provider_target_with_model(agent: &str, model: &str) -> String {
+    if model.trim().is_empty() {
+        agent.to_string()
+    } else {
+        format!("{}:{}", agent.trim(), model.trim())
+    }
+}
+
+fn invoke_restart_plan(plan: &RestartPlan) -> io::Result<()> {
+    run_winsmux_command(&[
+        "respawn-pane",
+        "-k",
+        "-t",
+        &plan.pane_id,
+        "-c",
+        &plan.launch_dir,
+    ])?;
+    wait_for_shell_prompt(&plan.pane_id)?;
+    run_winsmux_command(&["send-keys", "-t", &plan.pane_id, "-l", "--", &plan.launch_command])?;
+    run_winsmux_command(&["send-keys", "-t", &plan.pane_id, "Enter"])?;
+    wait_for_agent_prompt(&plan.pane_id, &restart_readiness_agent(plan))?;
+    Ok(())
+}
+
+fn restart_readiness_agent(plan: &RestartPlan) -> String {
+    let adapter = readiness_agent_name(&plan.capability_adapter);
+    if !adapter.is_empty() {
+        return adapter;
+    }
+    let agent = readiness_agent_name(&plan.agent);
+    if agent.is_empty() {
+        "codex".to_string()
+    } else {
+        agent
+    }
+}
+
+fn readiness_agent_name(value: &str) -> String {
+    let lowered = value.trim().to_ascii_lowercase();
+    for name in ["codex", "claude", "gemini"] {
+        if lowered == name
+            || lowered.starts_with(&format!("{name}:"))
+            || lowered.starts_with(&format!("{name}-"))
+            || lowered.starts_with(&format!("{name}_"))
+            || lowered.starts_with(&format!("{name}/"))
+        {
+            return name.to_string();
+        }
+    }
+    String::new()
+}
+
+fn wait_for_shell_prompt(pane_id: &str) -> io::Result<()> {
+    let deadline = Instant::now() + Duration::from_secs(15);
+    while Instant::now() < deadline {
+        let text = capture_pane_tail(pane_id)?;
+        if text.lines().any(|line| line.trim().starts_with("PS ")) {
+            return Ok(());
+        }
+        thread::sleep(Duration::from_millis(500));
+    }
+    Err(io::Error::new(
+        io::ErrorKind::TimedOut,
+        format!("timed out waiting for shell prompt in {pane_id}"),
+    ))
+}
+
+fn wait_for_agent_prompt(pane_id: &str, agent: &str) -> io::Result<()> {
+    let deadline = Instant::now() + Duration::from_secs(60);
+    while Instant::now() < deadline {
+        let text = capture_pane_tail(pane_id)?;
+        if agent_ready_prompt(&text, agent) {
+            return Ok(());
+        }
+        thread::sleep(Duration::from_secs(2));
+    }
+    Err(io::Error::new(
+        io::ErrorKind::TimedOut,
+        format!("timed out waiting for {agent} prompt after restart in {pane_id}"),
+    ))
+}
+
+fn capture_pane_tail(pane_id: &str) -> io::Result<String> {
+    let output = winsmux_command_output(&["capture-pane", "-t", pane_id, "-p", "-J", "-S", "-50"])?;
+    Ok(String::from_utf8_lossy(&output.stdout).trim_end().to_string())
+}
+
+fn agent_ready_prompt(text: &str, agent: &str) -> bool {
+    let recent: Vec<&str> = text
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .rev()
+        .take(8)
+        .collect();
+    recent.into_iter().any(|line| {
+        let line = line.trim();
+        match agent {
+            "claude" => {
+                line.eq_ignore_ascii_case("Welcome to Claude Code!")
+                    || line.eq_ignore_ascii_case("Welcome to Claude Code")
+                    || line.starts_with("/help for help, /status for your current setup")
+                    || line.starts_with("?  for shortcuts")
+            }
+            "gemini" => {
+                line.to_ascii_lowercase().starts_with("type your message")
+                    || line.to_ascii_lowercase().starts_with("using:")
+                    || line.to_ascii_lowercase().starts_with("gemini-")
+            }
+            _ => line == ">" || line == "›" || line == "▌" || line == "❯" || line.starts_with('>'),
+        }
+    })
+}
+
+fn run_winsmux_command(args: &[&str]) -> io::Result<()> {
+    let output = winsmux_command_output(args)?;
+    if !output.status.success() {
+        return Err(winsmux_command_error(args, &output));
+    }
+    Ok(())
+}
+
+fn winsmux_command_output(args: &[&str]) -> io::Result<std::process::Output> {
+    let winsmux_bin = winsmux_bin_path();
+    Command::new(&winsmux_bin).args(args).output().map_err(|err| {
+        io::Error::new(
+            io::ErrorKind::Other,
+            format!("failed to run {}: {err}", winsmux_bin.display()),
+        )
+    })
+}
+
+fn winsmux_command_error(args: &[&str], output: &std::process::Output) -> io::Error {
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let detail = if !stderr.is_empty() {
+        stderr
+    } else if !stdout.is_empty() {
+        stdout
+    } else {
+        output.status.to_string()
+    };
+    io::Error::new(
+        io::ErrorKind::Other,
+        format!("winsmux {} failed: {detail}", args.join(" ")),
+    )
+}
+
+fn winsmux_bin_path() -> PathBuf {
+    env::var_os("WINSMUX_BIN")
         .map(PathBuf::from)
         .or_else(|| env::current_exe().ok())
-        .unwrap_or_else(|| PathBuf::from("winsmux"));
+        .unwrap_or_else(|| PathBuf::from("winsmux"))
+}
+
+fn update_restart_manifest_metadata(project_dir: &Path, plan: &RestartPlan) -> io::Result<bool> {
+    let manifest_path = project_dir.join(".winsmux").join("manifest.yaml");
+    with_file_lock(&manifest_path, || {
+        let raw = fs::read_to_string(&manifest_path)?;
+        let mut manifest = serde_yaml::from_str::<serde_yaml::Value>(&raw).map_err(|err| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("invalid manifest: {}: {err}", manifest_path.display()),
+            )
+        })?;
+        let provider_target = provider_target_with_model(&plan.agent, &plan.model);
+        let updated = update_manifest_pane_restart_fields(
+            &mut manifest,
+            &plan.pane_id,
+            &[
+                ("provider_target", provider_target.as_str()),
+                ("capability_adapter", plan.capability_adapter.as_str()),
+            ],
+        );
+        if !updated {
+            return Ok(false);
+        }
+        let content = serde_yaml::to_string(&manifest).map_err(|err| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("failed to serialize manifest: {err}"),
+            )
+        })?;
+        write_text_file_locked(&manifest_path, &content)?;
+        Ok(true)
+    })
+}
+
+fn ensure_live_pane_target(session_name: &str, pane_id: &str) -> io::Result<()> {
+    let winsmux_bin = winsmux_bin_path();
     let output = Command::new(&winsmux_bin)
         .args(["-t", session_name, "list-panes", "-a", "-F", "#{pane_id}"])
         .output()
@@ -1529,6 +2051,46 @@ fn update_manifest_pane_if_matches(
     let role = manifest_string(map, "role");
     let canonical_role = canonical_manifest_role(&role, label);
     if !matches!(canonical_role.as_deref(), Some("Reviewer" | "Worker")) {
+        return false;
+    }
+    for (name, value) in fields {
+        map.insert(
+            serde_yaml::Value::String((*name).to_string()),
+            serde_yaml::Value::String((*value).to_string()),
+        );
+    }
+    true
+}
+
+fn update_manifest_pane_restart_fields(
+    manifest: &mut serde_yaml::Value,
+    pane_id: &str,
+    fields: &[(&str, &str)],
+) -> bool {
+    let Some(panes) = manifest.get_mut("panes") else {
+        return false;
+    };
+
+    match panes {
+        serde_yaml::Value::Mapping(map) => map
+            .values_mut()
+            .any(|pane| update_manifest_pane_by_id(pane, pane_id, fields)),
+        serde_yaml::Value::Sequence(items) => items
+            .iter_mut()
+            .any(|pane| update_manifest_pane_by_id(pane, pane_id, fields)),
+        _ => false,
+    }
+}
+
+fn update_manifest_pane_by_id(
+    pane: &mut serde_yaml::Value,
+    pane_id: &str,
+    fields: &[(&str, &str)],
+) -> bool {
+    let serde_yaml::Value::Mapping(map) = pane else {
+        return false;
+    };
+    if manifest_string(map, "pane_id") != pane_id {
         return false;
     }
     for (name, value) in fields {

--- a/core/src/server/connection.rs
+++ b/core/src/server/connection.rs
@@ -1083,7 +1083,14 @@ match cmd {
             let _ = tx.send(CtrlReq::JoinPane(wid));
         }
     }
-    "respawn-pane" | "respawnp" => { let _ = tx.send(CtrlReq::RespawnPane); }
+    "respawn-pane" | "respawnp" => {
+        let start_dir = args
+            .windows(2)
+            .find(|window| window[0] == "-c")
+            .map(|window| window[1].trim_matches('"').to_string());
+        let pane_id = if pane_is_id { target_pane } else { None };
+        let _ = tx.send(CtrlReq::RespawnPane { pane_id, start_dir });
+    }
     "session-info" => {
         let (rtx, rrx) = mpsc::channel::<String>();
         let _ = tx.send(CtrlReq::SessionInfo(rtx));
@@ -2310,7 +2317,12 @@ fn dispatch_control_command(
             true
         }
         "respawn-pane" | "respawnp" => {
-            let _ = tx.send(CtrlReq::RespawnPane);
+            let start_dir = args
+                .windows(2)
+                .find(|window| window[0] == "-c")
+                .map(|window| window[1].trim_matches('"').to_string());
+            let pane_id = if pane_is_id { target_pane } else { None };
+            let _ = tx.send(CtrlReq::RespawnPane { pane_id, start_dir });
             let _ = resp_tx.send(String::new());
             true
         }

--- a/core/src/server/mod.rs
+++ b/core/src/server/mod.rs
@@ -35,6 +35,7 @@ use crate::window_ops::{toggle_zoom, remote_mouse_down, remote_mouse_drag, remot
     remote_mouse_button, remote_mouse_motion, remote_scroll_up, remote_scroll_down,
     swap_pane, break_pane_to_window, unzoom_if_zoomed, resize_pane_vertical,
     resize_pane_horizontal, resize_pane_absolute, rotate_panes, respawn_active_pane,
+    respawn_pane_by_id,
     handle_pane_mouse, handle_pane_scroll, handle_split_set_sizes, handle_split_resize_done};
 use crate::config::{load_config, parse_key_string, format_key_binding, normalize_key_for_binding,
     parse_config_content};
@@ -2342,8 +2343,12 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                         }
                     }
                 }
-                CtrlReq::RespawnPane => {
-                    respawn_active_pane(&mut app, Some(&*pty_system))?;
+                CtrlReq::RespawnPane { pane_id, start_dir } => {
+                    if let Some(pane_id) = pane_id {
+                        respawn_pane_by_id(&mut app, Some(&*pty_system), pane_id, start_dir.as_deref())?;
+                    } else {
+                        respawn_active_pane(&mut app, Some(&*pty_system), start_dir.as_deref())?;
+                    }
                     hook_event = Some("after-respawn-pane");
                 }
                 CtrlReq::BindKey(table_name, key, command, repeat) => {
@@ -3228,7 +3233,7 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                 }
                 CtrlReq::RespawnWindow => {
                     // Kill all panes in the active window and respawn	
-                    respawn_active_pane(&mut app, Some(&*pty_system))?;
+                    respawn_active_pane(&mut app, Some(&*pty_system), None)?;
                     state_dirty = true;
                 }
                 CtrlReq::PopupInput(data) => {

--- a/core/src/types.rs
+++ b/core/src/types.rs
@@ -907,7 +907,7 @@ pub enum CtrlReq {
     DisplayPaneSelect(usize),
     BreakPane,
     JoinPane(usize),
-    RespawnPane,
+    RespawnPane { pane_id: Option<usize>, start_dir: Option<String> },
     BindKey(String, String, String, bool),  // table, key, command, repeat
     UnbindKey(String),
     ListKeys(mpsc::Sender<String>),

--- a/core/src/window_ops.rs
+++ b/core/src/window_ops.rs
@@ -1153,7 +1153,22 @@ pub fn break_pane_to_window(app: &mut AppState) {
     }
 }
 
-pub fn respawn_active_pane(app: &mut AppState, pty_system_ref: Option<&dyn portable_pty::PtySystem>) -> io::Result<()> {
+pub fn respawn_active_pane(app: &mut AppState, pty_system_ref: Option<&dyn portable_pty::PtySystem>, start_dir: Option<&str>) -> io::Result<()> {
+    let window_idx = app.active_idx;
+    let pane_path = app.windows[window_idx].active_path.clone();
+    respawn_pane_at_path(app, pty_system_ref, window_idx, pane_path, start_dir)
+}
+
+pub fn respawn_pane_by_id(app: &mut AppState, pty_system_ref: Option<&dyn portable_pty::PtySystem>, pane_id: usize, start_dir: Option<&str>) -> io::Result<()> {
+    for (window_idx, window) in app.windows.iter().enumerate() {
+        if let Some(pane_path) = crate::tree::find_path_by_id(&window.root, pane_id) {
+            return respawn_pane_at_path(app, pty_system_ref, window_idx, pane_path, start_dir);
+        }
+    }
+    Err(io::Error::new(io::ErrorKind::InvalidInput, format!("can't find pane: {pane_id}")))
+}
+
+fn respawn_pane_at_path(app: &mut AppState, pty_system_ref: Option<&dyn portable_pty::PtySystem>, window_idx: usize, pane_path: Vec<usize>, start_dir: Option<&str>) -> io::Result<()> {
     // Reuse provided PTY system or create one as fallback
     let owned_pty;
     let pty_system: &dyn portable_pty::PtySystem = if let Some(ps) = pty_system_ref {
@@ -1166,17 +1181,20 @@ pub fn respawn_active_pane(app: &mut AppState, pty_system_ref: Option<&dyn porta
     // Must happen before the mutable borrow of app.windows below.
     let expanded_shell = crate::format::expand_format(&app.default_shell, &app);
 
-    let win = &mut app.windows[app.active_idx];
-    let Some(pane) = active_pane_mut(&mut win.root, &win.active_path) else { return Ok(()); };
-    let pane_id = pane.id;
-    
-    let size = PtySize { rows: pane.last_rows, cols: pane.last_cols, pixel_width: 0, pixel_height: 0 };
+    let (pane_id, size) = {
+        let win = &mut app.windows[window_idx];
+        let Some(pane) = active_pane_mut(&mut win.root, &pane_path) else { return Ok(()); };
+        (pane.id, PtySize { rows: pane.last_rows, cols: pane.last_cols, pixel_width: 0, pixel_height: 0 })
+    };
     let pair = pty_system.openpty(size).map_err(|e| io::Error::new(io::ErrorKind::Other, format!("openpty error: {e}")))?;
     let mut shell_cmd = if !expanded_shell.is_empty() {
         build_default_shell(&expanded_shell, app.env_shim, app.allow_predictions)
     } else {
         detect_shell()
     };
+    if let Some(dir) = start_dir.filter(|value| !value.trim().is_empty()) {
+        shell_cmd.cwd(std::path::Path::new(dir));
+    }
     set_tmux_env(&mut shell_cmd, pane_id, app.control_port, app.socket_name.as_deref(), &app.session_name, app.claude_code_fix_tty, app.claude_code_force_interactive);
     crate::pane::apply_user_environment(&mut shell_cmd, &app.environment);
     let child = pair.slave.spawn_command(shell_cmd).map_err(|e| io::Error::new(io::ErrorKind::Other, format!("spawn shell error: {e}")))?;
@@ -1196,6 +1214,8 @@ pub fn respawn_active_pane(app: &mut AppState, pty_system_ref: Option<&dyn porta
     
     let output_ring = std::sync::Arc::new(std::sync::Mutex::new(std::collections::VecDeque::new()));
     crate::pane::spawn_reader_thread(reader, term_reader, dv_writer, cs_writer, bell_writer, output_ring.clone());
+    let win = &mut app.windows[window_idx];
+    let Some(pane) = active_pane_mut(&mut win.root, &pane_path) else { return Ok(()); };
     pane.output_ring = output_ring;
     
     let mut pty_writer = pair.master.take_writer().map_err(|e| io::Error::new(io::ErrorKind::Other, format!("take writer error: {e}")))?;

--- a/core/tests-rs/operator_cli.rs
+++ b/core/tests-rs/operator_cli.rs
@@ -198,6 +198,32 @@ fn operator_cli_rejects_unknown_and_extra_arguments() {
         "unexpected stderr: {stderr}"
     );
 
+    let output = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .args(["restart", "--json"])
+        .current_dir(&project_dir)
+        .output()
+        .expect("winsmux command should run");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("usage: winsmux restart"),
+        "unexpected stderr: {stderr}"
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .args(["restart", "builder-1", "extra"])
+        .current_dir(&project_dir)
+        .output()
+        .expect("winsmux command should run");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("usage: winsmux restart"),
+        "unexpected stderr: {stderr}"
+    );
+
     for command in ["review-approve", "review-fail"] {
         let output = Command::new(env!("CARGO_BIN_EXE_winsmux"))
             .args([command, "--json"])
@@ -942,6 +968,67 @@ fn operator_cli_rebind_worktree_validates_target_in_manifest_session() {
     );
 }
 
+#[test]
+fn operator_cli_restart_dispatches_launch_plan_and_updates_manifest() {
+    let project_dir = make_temp_project_dir("restart");
+    write_manifest(&project_dir);
+    let manifest_path = project_dir.join(".winsmux").join("manifest.yaml");
+    let manifest = fs::read_to_string(&manifest_path)
+        .expect("test should read manifest")
+        .replace("    provider_target: codex:gpt-5.4\n", "    provider_target: codex:gpt 5.4;unsafe\n");
+    fs::write(&manifest_path, manifest).expect("test should write manifest");
+    let (winsmux_bin, log_path) =
+        write_fake_winsmux_restart(&project_dir, Some("winsmux-orchestra"), &["%2", "%3"]);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .args(["restart", "builder-1"])
+        .env("WINSMUX_BIN", winsmux_bin)
+        .current_dir(&project_dir)
+        .output()
+        .expect("winsmux command should run");
+
+    assert!(
+        output.status.success(),
+        "winsmux command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("restarted %2 (builder-1)"),
+        "unexpected stdout: {stdout}"
+    );
+
+    let log = fs::read_to_string(&log_path).expect("fake winsmux log should exist");
+    assert!(log.contains("respawn-pane -k -t \"%2\" -c"));
+    assert!(log.contains("send-keys -t \"%2\" -l -- \"codex -c 'model=gpt 5.4;unsafe'"));
+    assert!(log.contains("send-keys -t \"%2\" Enter"));
+    let builder = read_manifest_pane(&project_dir, "builder-1");
+    assert_eq!(builder["provider_target"].as_str(), Some("codex:gpt 5.4;unsafe"));
+    assert_eq!(builder["capability_adapter"].as_str(), Some("codex"));
+}
+
+#[test]
+fn operator_cli_restart_rejects_stale_manifest_target() {
+    let project_dir = make_temp_project_dir("restart-stale");
+    write_manifest(&project_dir);
+    let (winsmux_bin, _log_path) =
+        write_fake_winsmux_restart(&project_dir, Some("winsmux-orchestra"), &["%3"]);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .args(["restart", "builder-1"])
+        .env("WINSMUX_BIN", winsmux_bin)
+        .current_dir(&project_dir)
+        .output()
+        .expect("winsmux command should run");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("invalid target: %2"),
+        "unexpected stderr: {stderr}"
+    );
+}
+
 fn run_review_request_and_read_id(project_dir: &std::path::Path) -> String {
     let output = Command::new(env!("CARGO_BIN_EXE_winsmux"))
         .arg("review-request")
@@ -1053,6 +1140,76 @@ fn write_fake_winsmux_list_panes(
                 .expect("test should make fake winsmux executable");
         }
         fake_path
+    }
+}
+
+fn write_fake_winsmux_restart(
+    project_dir: &std::path::Path,
+    expected_session: Option<&str>,
+    pane_ids: &[&str],
+) -> (std::path::PathBuf, std::path::PathBuf) {
+    let fake_dir = project_dir.join(".test-bin");
+    fs::create_dir_all(&fake_dir).expect("test should create fake bin dir");
+    let log_path = fake_dir.join("winsmux-restart.log");
+    #[cfg(windows)]
+    {
+        let fake_path = fake_dir.join("winsmux-restart-fake.cmd");
+        let mut body = String::from("@echo off\r\n");
+        body.push_str("echo %*>>\"");
+        body.push_str(&log_path.to_string_lossy());
+        body.push_str("\"\r\n");
+        if let Some(session) = expected_session {
+            body.push_str("if \"%1\"==\"-t\" if not \"%2\"==\"");
+            body.push_str(session);
+            body.push_str("\" exit /b 0\r\n");
+        }
+        body.push_str("if \"%3\"==\"list-panes\" (\r\n");
+        for pane_id in pane_ids {
+            body.push_str("  echo ");
+            body.push_str(&pane_id.replace('%', "%%"));
+            body.push_str("\r\n");
+        }
+        body.push_str("  exit /b 0\r\n)\r\n");
+        body.push_str(
+            "if \"%1\"==\"capture-pane\" (\r\n  echo PS C:\\repo^>\r\n  echo ^>\r\n  exit /b 0\r\n)\r\n",
+        );
+        body.push_str("exit /b 0\r\n");
+        fs::write(&fake_path, body).expect("test should write fake winsmux");
+        (fake_path, log_path)
+    }
+    #[cfg(not(windows))]
+    {
+        let fake_path = fake_dir.join("winsmux-restart-fake");
+        let mut body = String::from("#!/bin/sh\n");
+        body.push_str("printf '%s\\n' \"$*\" >> '");
+        body.push_str(&log_path.to_string_lossy());
+        body.push_str("'\n");
+        if let Some(session) = expected_session {
+            body.push_str("if [ \"$1\" = \"-t\" ] && [ \"$2\" != '");
+            body.push_str(session);
+            body.push_str("' ]; then\n  exit 0\nfi\n");
+        }
+        body.push_str("if [ \"$3\" = \"list-panes\" ]; then\n");
+        for pane_id in pane_ids {
+            body.push_str("  printf '%s\\n' '");
+            body.push_str(pane_id);
+            body.push_str("'\n");
+        }
+        body.push_str("  exit 0\nfi\n");
+        body.push_str("if [ \"$1\" = \"capture-pane\" ]; then\n  printf '%s\\n' 'PS /repo>' '>'\n  exit 0\nfi\n");
+        body.push_str("exit 0\n");
+        fs::write(&fake_path, body).expect("test should write fake winsmux");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut permissions = fs::metadata(&fake_path)
+                .expect("test should read fake winsmux metadata")
+                .permissions();
+            permissions.set_mode(0o755);
+            fs::set_permissions(&fake_path, permissions)
+                .expect("test should make fake winsmux executable");
+        }
+        (fake_path, log_path)
     }
 }
 


### PR DESCRIPTION
## Summary
- add Rust winsmux restart <target> for managed panes
- validate live manifest session before restart
- preserve espawn-pane -c, quote provider model input, and keep provider_target as gent:model

## Validation
- cargo test --manifest-path core\\Cargo.toml --test operator_cli -- --nocapture
- cargo test --manifest-path core\\Cargo.toml
- git diff --check
- pwsh -NoProfile -File .\\scripts\\git-guard.ps1 -Mode full
- pwsh -NoProfile -File .\\scripts\\audit-public-surface.ps1

## Review
- Laplace findings fixed
- Kuhn finding fixed

## Note
- External Rust learning notes were updated, but Opus review of private external notes was blocked by execution policy.