### PR TITLE
Add Rust poll-events command

### DIFF
--- a/core/src/cli.rs
+++ b/core/src/cli.rs
@@ -133,6 +133,7 @@ OPERATOR COMMANDS:
     digest --json           Print high-signal run digest JSON
     runs --json             Print run-oriented evidence JSON
     explain <run_id> --json Print one run explanation JSON
+    poll-events             Return new monitor events from .winsmux/events.jsonl
     review-request          Record a pending review request for the current branch
     review-approve          Record PASS for the pending review request
     review-fail             Record FAIL for the pending review request

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -245,6 +245,7 @@ fn run_main() -> io::Result<()> {
         "digest" => return operator_cli::run_digest_command(&cmd_args[1..]),
         "runs" => return operator_cli::run_runs_command(&cmd_args[1..]),
         "explain" => return operator_cli::run_explain_command(&cmd_args[1..]),
+        "poll-events" => return operator_cli::run_poll_events_command(&cmd_args[1..]),
         "review-request" => return operator_cli::run_review_request_command(&cmd_args[1..]),
         "review-approve" => return operator_cli::run_review_approve_command(&cmd_args[1..]),
         "review-fail" => return operator_cli::run_review_fail_command(&cmd_args[1..]),

--- a/core/src/operator_cli.rs
+++ b/core/src/operator_cli.rs
@@ -137,6 +137,61 @@ pub fn run_explain_command(args: &[&String]) -> io::Result<()> {
     write_json(&payload)
 }
 
+pub fn run_poll_events_command(args: &[&String]) -> io::Result<()> {
+    if should_print_help(args) {
+        println!("{}", usage_for("poll-events"));
+        return Ok(());
+    }
+    let options = parse_poll_events_options(args)?;
+    if options.json {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            usage_for("poll-events"),
+        ));
+    }
+
+    let mut cursor = 0usize;
+    if let Some(raw_cursor) = options.positionals.first() {
+        let parsed = raw_cursor
+            .parse::<i32>()
+            .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, usage_for("poll-events")))?;
+        if parsed > 0 {
+            cursor = parsed as usize;
+        }
+    }
+
+    let events_path = options.project_dir.join(".winsmux").join("events.jsonl");
+    let mut response = json!({
+        "cursor": 0,
+        "events": [],
+    });
+    if !events_path.is_file() {
+        return write_json(&response);
+    }
+
+    let raw = fs::read_to_string(&events_path)
+        .map_err(|err| io::Error::new(err.kind(), format!("failed to read event log: {}", err)))?;
+    let lines: Vec<&str> = raw.lines().filter(|line| !line.trim().is_empty()).collect();
+    if cursor > lines.len() {
+        cursor = lines.len();
+    }
+
+    let mut events = Vec::new();
+    for (index, line) in lines.iter().enumerate().skip(cursor) {
+        let event = serde_json::from_str::<Value>(line).map_err(|err| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("failed to parse event log line {}: {}", index + 1, err),
+            )
+        })?;
+        events.push(event);
+    }
+
+    response["cursor"] = json!(lines.len());
+    response["events"] = Value::Array(events);
+    write_json(&response)
+}
+
 pub fn run_review_reset_command(args: &[&String]) -> io::Result<()> {
     if should_print_help(args) {
         println!("usage: winsmux review-reset [--project-dir <path>]");
@@ -338,6 +393,50 @@ fn parse_options(
     })
 }
 
+fn parse_poll_events_options(args: &[&String]) -> io::Result<ParsedOptions> {
+    let mut json = false;
+    let mut project_dir = None;
+    let mut positionals = Vec::new();
+    let mut index = 0;
+
+    while index < args.len() {
+        let arg = args[index].as_str();
+        match arg {
+            "--json" => {
+                json = true;
+                index += 1;
+            }
+            "--project-dir" => {
+                let Some(value) = args.get(index + 1) else {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        "missing value after --project-dir",
+                    ));
+                };
+                project_dir = Some(PathBuf::from(value.to_string()));
+                index += 2;
+            }
+            value => {
+                positionals.push(value.to_string());
+                index += 1;
+            }
+        }
+    }
+
+    if positionals.len() > 1 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            usage_for("poll-events"),
+        ));
+    }
+
+    Ok(ParsedOptions {
+        json,
+        project_dir: project_dir.unwrap_or(env::current_dir()?),
+        positionals,
+    })
+}
+
 fn parse_rebind_worktree_options(args: &[&String]) -> io::Result<ParsedOptions> {
     let mut project_dir = None;
     let mut positionals = Vec::new();
@@ -411,6 +510,7 @@ fn usage_for(command: &str) -> &'static str {
         "digest" => "usage: winsmux digest --json [--project-dir <path>]",
         "runs" => "usage: winsmux runs --json [--project-dir <path>]",
         "explain" => "usage: winsmux explain <run_id> --json [--project-dir <path>]",
+        "poll-events" => "usage: winsmux poll-events [cursor] [--project-dir <path>]",
         "review-reset" => "usage: winsmux review-reset [--project-dir <path>]",
         "review-request" => "usage: winsmux review-request [--project-dir <path>]",
         "review-approve" => "usage: winsmux review-approve [--project-dir <path>]",

--- a/core/tests-rs/operator_cli.rs
+++ b/core/tests-rs/operator_cli.rs
@@ -103,6 +103,65 @@ fn operator_cli_inbox_digest_runs_and_explain_use_ledger_projections() {
 }
 
 #[test]
+fn operator_cli_poll_events_returns_events_after_cursor() {
+    let project_dir = make_temp_project_dir("poll-events");
+    write_manifest(&project_dir);
+
+    let json = run_json(&project_dir, &["poll-events", "1"]);
+
+    assert_eq!(json["cursor"], 2);
+    assert_eq!(json["events"].as_array().expect("events should be array").len(), 1);
+    assert_eq!(json["events"][0]["event"], "operator.commit_ready");
+    assert_eq!(json["events"][0]["pane_id"], "%2");
+}
+
+#[test]
+fn operator_cli_poll_events_handles_missing_file_and_cursor_bounds() {
+    let project_dir = make_temp_project_dir("poll-events-empty");
+    fs::create_dir_all(project_dir.join(".winsmux")).expect("test should create .winsmux");
+
+    let missing = run_json(&project_dir, &["poll-events"]);
+    assert_eq!(missing["cursor"], 0);
+    assert_eq!(
+        missing["events"]
+            .as_array()
+            .expect("events should be array")
+            .len(),
+        0
+    );
+
+    fs::write(
+        project_dir.join(".winsmux").join("events.jsonl"),
+        r#"
+{"timestamp":"2026-04-24T12:00:01+09:00","event":"one"}
+
+{"timestamp":"2026-04-24T12:00:02+09:00","event":"two"}
+"#,
+    )
+    .expect("test should write events");
+
+    let past_end = run_json(&project_dir, &["poll-events", "99"]);
+    assert_eq!(past_end["cursor"], 2);
+    assert_eq!(
+        past_end["events"]
+            .as_array()
+            .expect("events should be array")
+            .len(),
+        0
+    );
+
+    let negative = run_json(&project_dir, &["poll-events", "-1"]);
+    assert_eq!(negative["cursor"], 2);
+    assert_eq!(
+        negative["events"]
+            .as_array()
+            .expect("events should be array")
+            .len(),
+        2
+    );
+}
+
+#[test]
 fn operator_cli_accepts_project_dir_argument() {
     let project_dir = make_temp_project_dir("project-dir");
     write_manifest(&project_dir);
@@ -221,6 +280,45 @@ fn operator_cli_rejects_unknown_and_extra_arguments() {
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
         stderr.contains("usage: winsmux restart"),
+        "unexpected stderr: {stderr}"
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .args(["poll-events", "1", "extra"])
+        .current_dir(&project_dir)
+        .output()
+        .expect("winsmux command should run");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("usage: winsmux poll-events"),
+        "unexpected stderr: {stderr}"
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .args(["poll-events", "not-a-number"])
+        .current_dir(&project_dir)
+        .output()
+        .expect("winsmux command should run");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("usage: winsmux poll-events"),
+        "unexpected stderr: {stderr}"
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .args(["poll-events", "2147483648"])
+        .current_dir(&project_dir)
+        .output()
+        .expect("winsmux command should run");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("usage: winsmux poll-events"),
         "unexpected stderr: {stderr}"
     );
 


### PR DESCRIPTION
## Summary
- add Rust winsmux poll-events support for .winsmux/events.jsonl
- match the PowerShell cursor contract, including blank-line filtering and i32 cursor bounds
- add operator CLI tests for missing files, cursor bounds, and usage errors

## Validation
- cargo test --manifest-path core\\Cargo.toml --test operator_cli -- --nocapture
- cargo test --manifest-path core\\Cargo.toml
- git diff --check
- pwsh -NoProfile -File .\\scripts\\git-guard.ps1 -Mode full
- pwsh -NoProfile -File .\\scripts\\audit-public-surface.ps1

## Review
- review agent found one cursor range mismatch; fixed before PR

Part of TASK-266.