### PR TITLE
Add Rust promote-tactic command

### DIFF
--- a/core/src/cli.rs
+++ b/core/src/cli.rs
@@ -134,6 +134,7 @@ OPERATOR COMMANDS:
     runs --json             Print run-oriented evidence JSON
     explain <run_id> --json Print one run explanation JSON
     compare-runs            Compare two runs and surface evidence deltas
+    promote-tactic          Export a reusable tactic candidate from a run
     poll-events             Return new monitor events from .winsmux/events.jsonl
     review-request          Record a pending review request for the current branch
     review-approve          Record PASS for the pending review request

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -246,6 +246,7 @@ fn run_main() -> io::Result<()> {
         "runs" => return operator_cli::run_runs_command(&cmd_args[1..]),
         "explain" => return operator_cli::run_explain_command(&cmd_args[1..]),
         "compare-runs" => return operator_cli::run_compare_runs_command(&cmd_args[1..]),
+        "promote-tactic" => return operator_cli::run_promote_tactic_command(&cmd_args[1..]),
         "poll-events" => return operator_cli::run_poll_events_command(&cmd_args[1..]),
         "review-request" => return operator_cli::run_review_request_command(&cmd_args[1..]),
         "review-approve" => return operator_cli::run_review_approve_command(&cmd_args[1..]),

--- a/core/src/operator_cli.rs
+++ b/core/src/operator_cli.rs
@@ -5,7 +5,7 @@ use std::{
     process::Command,
     sync::atomic::{AtomicU32, Ordering},
     thread,
-    time::{Duration, Instant},
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 
 use chrono::{DateTime, SecondsFormat, Utc};
@@ -151,7 +151,10 @@ pub fn run_compare_runs_command(args: &[&String]) -> io::Result<()> {
         io::Error::new(io::ErrorKind::NotFound, format!("run not found: {left_id}"))
     })?;
     let right = snapshot.explain_projection(&right_id).ok_or_else(|| {
-        io::Error::new(io::ErrorKind::NotFound, format!("run not found: {right_id}"))
+        io::Error::new(
+            io::ErrorKind::NotFound,
+            format!("run not found: {right_id}"),
+        )
     })?;
     let payload = compare_runs_payload(&left, &right);
     if options.json {
@@ -184,7 +187,10 @@ pub fn run_compare_runs_command(args: &[&String]) -> io::Result<()> {
             .as_str()
             .unwrap_or_default()
     );
-    let differences = payload["differences"].as_array().cloned().unwrap_or_default();
+    let differences = payload["differences"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
     if differences.is_empty() {
         println!("Differences: (none)");
     } else {
@@ -198,6 +204,61 @@ pub fn run_compare_runs_command(args: &[&String]) -> io::Result<()> {
             );
         }
     }
+    Ok(())
+}
+
+pub fn run_promote_tactic_command(args: &[&String]) -> io::Result<()> {
+    if should_print_help(args) {
+        println!("{}", usage_for("promote-tactic"));
+        return Ok(());
+    }
+    let options = parse_promote_tactic_options(args)?;
+    let run_id = options.positionals[0].clone();
+    if !matches!(
+        options.kind.as_str(),
+        "playbook" | "prewarm" | "verification"
+    ) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("Unsupported promote kind: {}", options.kind),
+        ));
+    }
+
+    let snapshot = load_snapshot(&options.project_dir)?;
+    let projection = snapshot.explain_projection(&run_id).ok_or_else(|| {
+        io::Error::new(io::ErrorKind::NotFound, format!("run not found: {run_id}"))
+    })?;
+    if !run_recommendable(&projection.run) {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            format!("run is not promotable: {run_id}"),
+        ));
+    }
+
+    let consultation_packet = read_artifact_json(
+        &projection.run.experiment_packet.consultation_ref,
+        &options.project_dir,
+        &[".winsmux", "consultations"],
+        &run_id,
+    );
+    let candidate = promote_tactic_candidate(&projection, &consultation_packet, &options);
+    let artifact = write_playbook_candidate(&options.project_dir, &candidate)?;
+    let result = json!({
+        "generated_at": generated_at(),
+        "run_id": run_id,
+        "candidate_ref": artifact.reference,
+        "candidate_path": artifact.path,
+        "candidate": candidate,
+    });
+
+    if options.json {
+        return write_json(&result);
+    }
+    println!(
+        "promoted tactic from {} -> {}",
+        result["run_id"].as_str().unwrap_or_default(),
+        result["candidate_ref"].as_str().unwrap_or_default()
+    );
     Ok(())
 }
 
@@ -403,6 +464,14 @@ struct ParsedOptions {
     positionals: Vec<String>,
 }
 
+struct PromoteTacticOptions {
+    json: bool,
+    project_dir: PathBuf,
+    positionals: Vec<String>,
+    title: String,
+    kind: String,
+}
+
 fn parse_options(
     command: &str,
     args: &[&String],
@@ -501,6 +570,80 @@ fn parse_poll_events_options(args: &[&String]) -> io::Result<ParsedOptions> {
     })
 }
 
+fn parse_promote_tactic_options(args: &[&String]) -> io::Result<PromoteTacticOptions> {
+    let mut json = false;
+    let mut project_dir = None;
+    let mut positionals = Vec::new();
+    let mut title = String::new();
+    let mut kind = "playbook".to_string();
+    let mut index = 0;
+
+    while index < args.len() {
+        let arg = args[index].as_str();
+        match arg {
+            "--json" => {
+                json = true;
+                index += 1;
+            }
+            "--project-dir" => {
+                let Some(value) = args.get(index + 1) else {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        "missing value after --project-dir",
+                    ));
+                };
+                project_dir = Some(PathBuf::from(value.to_string()));
+                index += 2;
+            }
+            "--title" => {
+                let Some(value) = args.get(index + 1) else {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        "--title requires a value",
+                    ));
+                };
+                title = value.to_string();
+                index += 2;
+            }
+            "--kind" => {
+                let Some(value) = args.get(index + 1) else {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        "--kind requires a value",
+                    ));
+                };
+                kind = value.to_string();
+                index += 2;
+            }
+            value if value.starts_with('-') => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!("unknown argument for winsmux promote-tactic: {value}"),
+                ));
+            }
+            value => {
+                positionals.push(value.to_string());
+                index += 1;
+            }
+        }
+    }
+
+    if positionals.len() != 1 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            usage_for("promote-tactic").to_string(),
+        ));
+    }
+
+    Ok(PromoteTacticOptions {
+        json,
+        project_dir: project_dir.unwrap_or(env::current_dir()?),
+        positionals,
+        title,
+        kind,
+    })
+}
+
 fn parse_rebind_worktree_options(args: &[&String]) -> io::Result<ParsedOptions> {
     let mut project_dir = None;
     let mut positionals = Vec::new();
@@ -576,6 +719,9 @@ fn usage_for(command: &str) -> &'static str {
         "explain" => "usage: winsmux explain <run_id> --json [--project-dir <path>]",
         "compare-runs" => {
             "usage: winsmux compare-runs <left_run_id> <right_run_id> [--json] [--project-dir <path>]"
+        }
+        "promote-tactic" => {
+            "usage: winsmux promote-tactic <run_id> [--title <text>] [--kind <playbook|prewarm|verification>] [--json] [--project-dir <path>]"
         }
         "poll-events" => "usage: winsmux poll-events [cursor] [--project-dir <path>]",
         "review-reset" => "usage: winsmux review-reset [--project-dir <path>]",
@@ -1390,7 +1536,14 @@ fn invoke_restart_plan(plan: &RestartPlan) -> io::Result<()> {
         &plan.launch_dir,
     ])?;
     wait_for_shell_prompt(&plan.pane_id)?;
-    run_winsmux_command(&["send-keys", "-t", &plan.pane_id, "-l", "--", &plan.launch_command])?;
+    run_winsmux_command(&[
+        "send-keys",
+        "-t",
+        &plan.pane_id,
+        "-l",
+        "--",
+        &plan.launch_command,
+    ])?;
     run_winsmux_command(&["send-keys", "-t", &plan.pane_id, "Enter"])?;
     wait_for_agent_prompt(&plan.pane_id, &restart_readiness_agent(plan))?;
     Ok(())
@@ -1456,7 +1609,9 @@ fn wait_for_agent_prompt(pane_id: &str, agent: &str) -> io::Result<()> {
 
 fn capture_pane_tail(pane_id: &str) -> io::Result<String> {
     let output = winsmux_command_output(&["capture-pane", "-t", pane_id, "-p", "-J", "-S", "-50"])?;
-    Ok(String::from_utf8_lossy(&output.stdout).trim_end().to_string())
+    Ok(String::from_utf8_lossy(&output.stdout)
+        .trim_end()
+        .to_string())
 }
 
 fn agent_ready_prompt(text: &str, agent: &str) -> bool {
@@ -1495,12 +1650,15 @@ fn run_winsmux_command(args: &[&str]) -> io::Result<()> {
 
 fn winsmux_command_output(args: &[&str]) -> io::Result<std::process::Output> {
     let winsmux_bin = winsmux_bin_path();
-    Command::new(&winsmux_bin).args(args).output().map_err(|err| {
-        io::Error::new(
-            io::ErrorKind::Other,
-            format!("failed to run {}: {err}", winsmux_bin.display()),
-        )
-    })
+    Command::new(&winsmux_bin)
+        .args(args)
+        .output()
+        .map_err(|err| {
+            io::Error::new(
+                io::ErrorKind::Other,
+                format!("failed to run {}: {err}", winsmux_bin.display()),
+            )
+        })
 }
 
 fn winsmux_command_error(args: &[&str], output: &std::process::Output) -> io::Error {
@@ -2555,7 +2713,12 @@ fn compare_runs_payload(
     let reconcile_consult = differences.iter().any(|difference| {
         difference["field"]
             .as_str()
-            .map(|field| matches!(field, "branch" | "worktree" | "env_fingerprint" | "command_hash" | "result"))
+            .map(|field| {
+                matches!(
+                    field,
+                    "branch" | "worktree" | "env_fingerprint" | "command_hash" | "result"
+                )
+            })
             .unwrap_or(false)
     }) || !(left_recommendable && right_recommendable);
     let next_action = if left.evidence_digest.next_action == right.evidence_digest.next_action {
@@ -2620,6 +2783,129 @@ fn run_recommendable(run: &crate::ledger::LedgerExplainRun) -> bool {
             .as_str(),
         "ALLOW" | "PASS"
     )
+}
+
+struct WrittenArtifact {
+    path: String,
+    reference: String,
+}
+
+fn promote_tactic_candidate(
+    projection: &crate::ledger::LedgerExplainProjection,
+    consultation_packet: &Value,
+    options: &PromoteTacticOptions,
+) -> Value {
+    let run = &projection.run;
+    let experiment = &run.experiment_packet;
+    let recommendation = json_string_field(consultation_packet, "recommendation");
+    let title = if !options.title.trim().is_empty() {
+        options.title.clone()
+    } else if !recommendation.trim().is_empty() {
+        recommendation.clone()
+    } else if !experiment.result.trim().is_empty() {
+        experiment.result.clone()
+    } else if !run.task.trim().is_empty() {
+        run.task.clone()
+    } else {
+        format!("Tactic from {}", run.run_id)
+    };
+    let summary = if !recommendation.trim().is_empty() {
+        recommendation
+    } else {
+        experiment.result.clone()
+    };
+
+    json!({
+        "run_id": run.run_id,
+        "task_id": run.task_id,
+        "pane_id": run.primary_pane_id,
+        "slot": experiment.slot,
+        "kind": options.kind,
+        "title": title,
+        "summary": summary,
+        "hypothesis": experiment.hypothesis,
+        "next_action": projection.evidence_digest.next_action,
+        "confidence": experiment.confidence,
+        "branch": run.branch,
+        "head_sha": run.head_sha,
+        "worktree": experiment.worktree,
+        "env_fingerprint": experiment.env_fingerprint,
+        "command_hash": experiment.command_hash,
+        "changed_files": projection.evidence_digest.changed_files,
+        "observation_pack_ref": experiment.observation_pack_ref,
+        "consultation_ref": experiment.consultation_ref,
+        "verification_result": run.verification_result,
+        "security_verdict": run.security_verdict,
+        "action_item_count": run.action_items.len(),
+        "action_item_kinds": action_item_kinds(&run.action_items),
+        "reuse_conditions": reuse_conditions(run),
+        "packet_type": "playbook_candidate",
+        "generated_at": generated_at(),
+    })
+}
+
+fn action_item_kinds(items: &[crate::ledger::LedgerExplainActionItem]) -> Vec<String> {
+    let mut values = Vec::new();
+    for item in items {
+        if !item.kind.trim().is_empty() && !values.contains(&item.kind) {
+            values.push(item.kind.clone());
+        }
+    }
+    values
+}
+
+fn reuse_conditions(run: &crate::ledger::LedgerExplainRun) -> Vec<String> {
+    let mut values = Vec::new();
+    if !run.branch.trim().is_empty() {
+        values.push(format!("branch={}", run.branch));
+    }
+    if !run.experiment_packet.env_fingerprint.trim().is_empty() {
+        values.push(format!(
+            "env_fingerprint={}",
+            run.experiment_packet.env_fingerprint
+        ));
+    }
+    if !run.experiment_packet.command_hash.trim().is_empty() {
+        values.push(format!(
+            "command_hash={}",
+            run.experiment_packet.command_hash
+        ));
+    }
+    values
+}
+
+fn write_playbook_candidate(project_dir: &Path, candidate: &Value) -> io::Result<WrittenArtifact> {
+    let dir = project_dir.join(".winsmux").join("playbook-candidates");
+    fs::create_dir_all(&dir)?;
+    let file_name = format!("playbook-candidate-{}.json", unique_artifact_id());
+    let path = dir.join(file_name);
+    let content = serde_json::to_string_pretty(candidate).map_err(|err| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("failed to serialize playbook candidate: {err}"),
+        )
+    })?;
+    write_text_file_with_lock(&path, &content)?;
+    Ok(WrittenArtifact {
+        reference: artifact_reference(project_dir, &path),
+        path: path.display().to_string(),
+    })
+}
+
+fn artifact_reference(project_dir: &Path, path: &Path) -> String {
+    path.strip_prefix(project_dir)
+        .ok()
+        .map(|relative| relative.to_string_lossy().replace('\\', "/"))
+        .unwrap_or_else(|| path.display().to_string().replace('\\', "/"))
+}
+
+fn unique_artifact_id() -> String {
+    let counter = ATOMIC_WRITE_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or_default();
+    format!("{nanos:x}{:08x}{counter:08x}", std::process::id())
 }
 
 fn json_string_field(value: &Value, key: &str) -> String {

--- a/core/tests-rs/operator_cli.rs
+++ b/core/tests-rs/operator_cli.rs
@@ -110,7 +110,13 @@ fn operator_cli_poll_events_returns_events_after_cursor() {
     let json = run_json(&project_dir, &["poll-events", "1"]);
 
     assert_eq!(json["cursor"], 2);
-    assert_eq!(json["events"].as_array().expect("events should be array").len(), 1);
+    assert_eq!(
+        json["events"]
+            .as_array()
+            .expect("events should be array")
+            .len(),
+        1
+    );
     assert_eq!(json["events"][0]["event"], "operator.commit_ready");
     assert_eq!(json["events"][0]["pane_id"], "%2");
 }
@@ -229,6 +235,120 @@ fn operator_cli_compare_runs_uses_powershell_rounding() {
     );
 
     assert_eq!(json["confidence_delta"], 0.1234);
+}
+
+#[test]
+fn operator_cli_promote_tactic_writes_playbook_candidate() {
+    let project_dir = make_temp_project_dir("promote-tactic");
+    write_compare_runs_fixture(&project_dir);
+
+    let json = run_json(
+        &project_dir,
+        &[
+            "promote-tactic",
+            "task:task-a",
+            "--title",
+            "Deterministic build command",
+            "--json",
+        ],
+    );
+
+    assert_eq!(json["run_id"], "task:task-a");
+    assert!(json["candidate_ref"]
+        .as_str()
+        .expect("candidate ref should be a string")
+        .starts_with(".winsmux/playbook-candidates/playbook-candidate-"));
+    let candidate_path = json["candidate_path"]
+        .as_str()
+        .expect("candidate path should be a string");
+    assert!(std::path::Path::new(candidate_path).is_file());
+    let candidate_file =
+        fs::read_to_string(candidate_path).expect("candidate file should be readable");
+    let candidate_json: serde_json::Value =
+        serde_json::from_str(&candidate_file).expect("candidate file should be JSON");
+    assert_eq!(candidate_json["packet_type"], "playbook_candidate");
+    assert_eq!(candidate_json["kind"], "playbook");
+    assert!(candidate_json["generated_at"].as_str().is_some());
+    assert_eq!(candidate_json["title"], "Deterministic build command");
+    assert_eq!(candidate_json["summary"], "prefer cache command");
+    assert_eq!(json["candidate"]["packet_type"], "playbook_candidate");
+    assert_eq!(json["candidate"]["kind"], "playbook");
+    assert_eq!(json["candidate"]["title"], "Deterministic build command");
+    assert_eq!(json["candidate"]["summary"], "prefer cache command");
+    assert_eq!(json["candidate"]["hypothesis"], "cache command is stable");
+    assert_eq!(
+        json["candidate"]["changed_files"][0],
+        "core/src/operator_cli.rs"
+    );
+    assert_eq!(
+        json["candidate"]["observation_pack_ref"],
+        ".winsmux/observation-packs/task-a.json"
+    );
+    assert_eq!(
+        json["candidate"]["consultation_ref"],
+        ".winsmux/consultations/task-a.json"
+    );
+}
+
+#[test]
+fn operator_cli_promote_tactic_rejects_unhealthy_run() {
+    let project_dir = make_temp_project_dir("promote-tactic-unhealthy");
+    write_compare_runs_fixture(&project_dir);
+    let events_path = project_dir.join(".winsmux").join("events.jsonl");
+    let events = fs::read_to_string(&events_path)
+        .expect("test should read events")
+        .replace("\"outcome\":\"PASS\"", "\"outcome\":\"FAIL\"");
+    fs::write(events_path, events).expect("test should write events");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .args(["promote-tactic", "task:task-a"])
+        .current_dir(&project_dir)
+        .output()
+        .expect("winsmux command should run");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("run is not promotable: task:task-a"));
+}
+
+#[test]
+fn operator_cli_promote_tactic_rejects_missing_security_clearance() {
+    let project_dir = make_temp_project_dir("promote-tactic-no-security");
+    write_compare_runs_fixture(&project_dir);
+    let events_path = project_dir.join(".winsmux").join("events.jsonl");
+    let events = fs::read_to_string(&events_path)
+        .expect("test should read events")
+        .lines()
+        .filter(|line| !line.contains("\"event\":\"pipeline.security.allowed\""))
+        .collect::<Vec<_>>()
+        .join("\n");
+    fs::write(events_path, events).expect("test should write events");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .args(["promote-tactic", "task:task-a"])
+        .current_dir(&project_dir)
+        .output()
+        .expect("winsmux command should run");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("run is not promotable: task:task-a"));
+}
+
+#[test]
+fn operator_cli_promote_tactic_rejects_unknown_kind() {
+    let project_dir = make_temp_project_dir("promote-tactic-kind");
+    write_compare_runs_fixture(&project_dir);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .args(["promote-tactic", "task:task-a", "--kind", "unknown"])
+        .current_dir(&project_dir)
+        .output()
+        .expect("winsmux command should run");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Unsupported promote kind: unknown"));
 }
 
 #[test]
@@ -1156,7 +1276,10 @@ fn operator_cli_restart_dispatches_launch_plan_and_updates_manifest() {
     let manifest_path = project_dir.join(".winsmux").join("manifest.yaml");
     let manifest = fs::read_to_string(&manifest_path)
         .expect("test should read manifest")
-        .replace("    provider_target: codex:gpt-5.4\n", "    provider_target: codex:gpt 5.4;unsafe\n");
+        .replace(
+            "    provider_target: codex:gpt-5.4\n",
+            "    provider_target: codex:gpt 5.4;unsafe\n",
+        );
     fs::write(&manifest_path, manifest).expect("test should write manifest");
     let (winsmux_bin, log_path) =
         write_fake_winsmux_restart(&project_dir, Some("winsmux-orchestra"), &["%2", "%3"]);
@@ -1184,7 +1307,10 @@ fn operator_cli_restart_dispatches_launch_plan_and_updates_manifest() {
     assert!(log.contains("send-keys -t \"%2\" -l -- \"codex -c 'model=gpt 5.4;unsafe'"));
     assert!(log.contains("send-keys -t \"%2\" Enter"));
     let builder = read_manifest_pane(&project_dir, "builder-1");
-    assert_eq!(builder["provider_target"].as_str(), Some("codex:gpt 5.4;unsafe"));
+    assert_eq!(
+        builder["provider_target"].as_str(),
+        Some("codex:gpt 5.4;unsafe")
+    );
     assert_eq!(builder["capability_adapter"].as_str(), Some("codex"));
 }
 
@@ -1463,6 +1589,30 @@ panes:
 "#,
     )
     .expect("test should write events");
+    fs::create_dir_all(winsmux_dir.join("observation-packs"))
+        .expect("test should create observation pack directory");
+    fs::create_dir_all(winsmux_dir.join("consultations"))
+        .expect("test should create consultation directory");
+    fs::write(
+        winsmux_dir.join("observation-packs").join("task-a.json"),
+        r#"{"packet_type":"observation_pack","run_id":"task:task-a","summary":"captured cache command"}"#,
+    )
+    .expect("test should write observation pack");
+    fs::write(
+        winsmux_dir.join("consultations").join("task-a.json"),
+        r#"{"packet_type":"consultation_packet","run_id":"task:task-a","recommendation":"prefer cache command"}"#,
+    )
+    .expect("test should write consultation packet");
+    fs::write(
+        winsmux_dir.join("observation-packs").join("task-b.json"),
+        r#"{"packet_type":"observation_pack","run_id":"task:task-b","summary":"captured rebuild command"}"#,
+    )
+    .expect("test should write observation pack");
+    fs::write(
+        winsmux_dir.join("consultations").join("task-b.json"),
+        r#"{"packet_type":"consultation_packet","run_id":"task:task-b","recommendation":"prefer rebuild command"}"#,
+    )
+    .expect("test should write consultation packet");
 }
 
 fn write_manifest(project_dir: &std::path::Path) {


### PR DESCRIPTION
## Summary
- add Rust winsmux promote-tactic routing and help surface
- write playbook candidate artifacts from explain projections
- reject unhealthy runs, missing security clearance, and unsupported promote kinds

## Validation
- cargo test --manifest-path core\\Cargo.toml --test operator_cli -- --nocapture
- cargo test --manifest-path core\\Cargo.toml
- git diff --check
- pwsh -NoProfile -File .\\scripts\\git-guard.ps1 -Mode full
- pwsh -NoProfile -File .\\scripts\\audit-public-surface.ps1

## Review
- review agent findings were addressed with missing security-clearance and artifact file-read tests

Part of TASK-266.