### PR TITLE
Add Rust consult-request command

### DIFF
--- a/core/src/cli.rs
+++ b/core/src/cli.rs
@@ -135,6 +135,7 @@ OPERATOR COMMANDS:
     explain <run_id> --json Print one run explanation JSON
     compare-runs            Compare two runs and surface evidence deltas
     promote-tactic          Export a reusable tactic candidate from a run
+    consult-request         Record a consultation request packet and event
     consult-result          Record a consultation result packet and event
     poll-events             Return new monitor events from .winsmux/events.jsonl
     review-request          Record a pending review request for the current branch

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -247,6 +247,7 @@ fn run_main() -> io::Result<()> {
         "explain" => return operator_cli::run_explain_command(&cmd_args[1..]),
         "compare-runs" => return operator_cli::run_compare_runs_command(&cmd_args[1..]),
         "promote-tactic" => return operator_cli::run_promote_tactic_command(&cmd_args[1..]),
+        "consult-request" => return operator_cli::run_consult_request_command(&cmd_args[1..]),
         "consult-result" => return operator_cli::run_consult_result_command(&cmd_args[1..]),
         "poll-events" => return operator_cli::run_poll_events_command(&cmd_args[1..]),
         "review-request" => return operator_cli::run_review_request_command(&cmd_args[1..]),

--- a/core/src/operator_cli.rs
+++ b/core/src/operator_cli.rs
@@ -273,7 +273,7 @@ pub fn run_consult_result_command(args: &[&String]) -> io::Result<()> {
     let timestamp = generated_at();
     let context = consultation_command_context(&options.project_dir, &options.run_id)?;
     let packet = consultation_result_packet(&context, &options, &timestamp);
-    let artifact = write_consultation_packet(&options.project_dir, &packet)?;
+    let artifact = write_consultation_packet(&options.project_dir, "consult-result", &packet)?;
     let event = consultation_result_event(&context, &options, &artifact.reference, &timestamp);
     append_event_record(&options.project_dir, &event)?;
     let _ = mark_current_review_pane_last_event(&options.project_dir, "consult.result", &timestamp);
@@ -297,6 +297,26 @@ pub fn run_consult_result_command(args: &[&String]) -> io::Result<()> {
     }
 
     println!("consult result recorded for {}", context.run_id);
+    Ok(())
+}
+
+pub fn run_consult_request_command(args: &[&String]) -> io::Result<()> {
+    if should_print_help(args) {
+        println!("{}", usage_for("consult-request"));
+        return Ok(());
+    }
+    let options = parse_consult_request_options(args)?;
+    assert_consult_role_permission("consult-request")?;
+
+    let timestamp = generated_at();
+    let context = consultation_command_context(&options.project_dir, "")?;
+    let packet = consultation_request_packet(&context, &options, &timestamp);
+    let artifact = write_consultation_packet(&options.project_dir, "consult-request", &packet)?;
+    let event = consultation_request_event(&context, &options, &artifact.reference, &timestamp);
+    append_event_record(&options.project_dir, &event)?;
+    let _ = mark_current_review_pane_last_event(&options.project_dir, "consult.request", &timestamp);
+
+    println!("consult request recorded for {}", context.run_id);
     Ok(())
 }
 
@@ -520,6 +540,13 @@ struct ConsultResultOptions {
     run_id: String,
     next_test: String,
     risks: Vec<String>,
+}
+
+struct ConsultRequestOptions {
+    project_dir: PathBuf,
+    mode: String,
+    message: String,
+    target_slot: String,
 }
 
 fn parse_options(
@@ -846,6 +873,97 @@ fn parse_consult_result_options(args: &[&String]) -> io::Result<ConsultResultOpt
     })
 }
 
+fn parse_consult_request_options(args: &[&String]) -> io::Result<ConsultRequestOptions> {
+    let mut project_dir = None;
+    let mut positionals = Vec::new();
+    let mut message = String::new();
+    let mut message_parts = Vec::new();
+    let mut target_slot = String::new();
+    let mut index = 0;
+
+    while index < args.len() {
+        let arg = args[index].as_str();
+        match arg {
+            "--project-dir" => {
+                let Some(value) = args.get(index + 1) else {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        "missing value after --project-dir",
+                    ));
+                };
+                project_dir = Some(PathBuf::from(value.to_string()));
+                index += 2;
+            }
+            "--message" => {
+                let Some(value) = args.get(index + 1) else {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        "--message requires a value",
+                    ));
+                };
+                message = value.to_string();
+                index += 2;
+            }
+            "--target-slot" => {
+                let Some(value) = args.get(index + 1) else {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        "--target-slot requires a value",
+                    ));
+                };
+                target_slot = value.to_string();
+                index += 2;
+            }
+            value if value.starts_with('-') => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!("unknown argument for winsmux consult-request: {value}"),
+                ));
+            }
+            value => {
+                if positionals.is_empty() {
+                    positionals.push(value.to_string());
+                } else if !value.trim().is_empty() {
+                    message_parts.push(value.to_string());
+                }
+                index += 1;
+            }
+        }
+    }
+
+    if positionals.len() != 1 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            usage_for("consult-request"),
+        ));
+    }
+
+    let mode = positionals[0].trim().to_ascii_lowercase();
+    if !matches!(mode.as_str(), "early" | "stuck" | "reconcile" | "final") {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("Unsupported consult mode: {}", positionals[0]),
+        ));
+    }
+
+    if message.trim().is_empty() && !message_parts.is_empty() {
+        message = message_parts.join(" ");
+    }
+    if message.trim().is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "consult message is required",
+        ));
+    }
+
+    Ok(ConsultRequestOptions {
+        project_dir: project_dir.unwrap_or(env::current_dir()?),
+        mode,
+        message,
+        target_slot,
+    })
+}
+
 fn parse_rebind_worktree_options(args: &[&String]) -> io::Result<ParsedOptions> {
     let mut project_dir = None;
     let mut positionals = Vec::new();
@@ -924,6 +1042,9 @@ fn usage_for(command: &str) -> &'static str {
         }
         "promote-tactic" => {
             "usage: winsmux promote-tactic <run_id> [--title <text>] [--kind <playbook|prewarm|verification>] [--json] [--project-dir <path>]"
+        }
+        "consult-request" => {
+            "usage: winsmux consult-request <early|stuck|reconcile|final> [--message <text>] [--target-slot <slot>] [--project-dir <path>]"
         }
         "consult-result" => {
             "usage: winsmux consult-result <early|stuck|reconcile|final> [--message <text>] [--target-slot <slot>] [--confidence <0..1>] [--next-test <text>] [--risk <text>] [--run-id <run_id>] [--json] [--project-dir <path>]"
@@ -3319,6 +3440,28 @@ fn consultation_result_packet(
     Value::Object(packet)
 }
 
+fn consultation_request_packet(
+    context: &ConsultationContext,
+    options: &ConsultRequestOptions,
+    timestamp: &str,
+) -> Value {
+    let mut packet = Map::new();
+    packet.insert("packet_type".to_string(), json!("consultation_packet"));
+    packet.insert("generated_at".to_string(), json!(timestamp));
+    packet.insert("run_id".to_string(), json!(context.run_id));
+    packet.insert("task_id".to_string(), json!(context.task_id));
+    packet.insert("pane_id".to_string(), json!(context.pane_id));
+    packet.insert("slot".to_string(), json!(context.slot));
+    packet.insert("kind".to_string(), json!("consult_request"));
+    packet.insert("mode".to_string(), json!(options.mode));
+    packet.insert("target_slot".to_string(), json!(options.target_slot));
+    packet.insert("branch".to_string(), json!(context.branch));
+    packet.insert("head_sha".to_string(), json!(context.head_sha));
+    packet.insert("worktree".to_string(), json!(context.worktree));
+    packet.insert("request".to_string(), json!(options.message));
+    Value::Object(packet)
+}
+
 fn consultation_result_event(
     context: &ConsultationContext,
     options: &ConsultResultOptions,
@@ -3354,10 +3497,42 @@ fn consultation_result_event(
     })
 }
 
-fn write_consultation_packet(project_dir: &Path, packet: &Value) -> io::Result<WrittenArtifact> {
+fn consultation_request_event(
+    context: &ConsultationContext,
+    options: &ConsultRequestOptions,
+    consultation_ref: &str,
+    timestamp: &str,
+) -> Value {
+    let mut data = Map::new();
+    data.insert("task_id".to_string(), json!(context.task_id));
+    data.insert("run_id".to_string(), json!(context.run_id));
+    data.insert("slot".to_string(), json!(context.slot));
+    data.insert("branch".to_string(), json!(context.branch));
+    data.insert("worktree".to_string(), json!(context.worktree));
+    data.insert("consultation_ref".to_string(), json!(consultation_ref));
+
+    json!({
+        "timestamp": timestamp,
+        "session": context.session_name,
+        "event": "pane.consult_request",
+        "message": options.message,
+        "label": context.label,
+        "pane_id": context.pane_id,
+        "role": context.role,
+        "branch": context.branch,
+        "head_sha": context.head_sha,
+        "data": Value::Object(data),
+    })
+}
+
+fn write_consultation_packet(
+    project_dir: &Path,
+    file_prefix: &str,
+    packet: &Value,
+) -> io::Result<WrittenArtifact> {
     let dir = project_dir.join(".winsmux").join("consultations");
     fs::create_dir_all(&dir)?;
-    let path = dir.join(format!("consult-result-{}.json", unique_artifact_id()));
+    let path = dir.join(format!("{}-{}.json", file_prefix, unique_artifact_id()));
     let content = serde_json::to_string_pretty(packet).map_err(|err| {
         io::Error::new(
             io::ErrorKind::InvalidData,

--- a/core/tests-rs/operator_cli.rs
+++ b/core/tests-rs/operator_cli.rs
@@ -352,6 +352,75 @@ fn operator_cli_promote_tactic_rejects_unknown_kind() {
 }
 
 #[test]
+fn operator_cli_consult_request_records_packet_event_and_manifest() {
+    let project_dir = make_temp_project_dir("consult-request");
+    write_manifest(&project_dir);
+    let manifest_path = project_dir.join(".winsmux").join("manifest.yaml");
+    let manifest = fs::read_to_string(&manifest_path)
+        .expect("test should read manifest")
+        .replace("    role: Builder\n", "    role: Worker\n");
+    fs::write(&manifest_path, manifest).expect("test should write manifest");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .args([
+            "consult-request",
+            "early",
+            "--message",
+            "Please review the Rust port",
+            "--target-slot",
+            "reviewer-1",
+        ])
+        .current_dir(&project_dir)
+        .env("WINSMUX_PANE_ID", "%2")
+        .env("WINSMUX_ROLE", "Worker")
+        .env("WINSMUX_ROLE_MAP", r#"{"%2":"Worker"}"#)
+        .output()
+        .expect("winsmux command should run");
+
+    assert!(
+        output.status.success(),
+        "winsmux command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("consult request recorded for operator:session-1"));
+
+    let events = fs::read_to_string(project_dir.join(".winsmux").join("events.jsonl"))
+        .expect("events should be readable");
+    let last_event: serde_json::Value = serde_json::from_str(
+        events
+            .lines()
+            .filter(|line| !line.trim().is_empty())
+            .last()
+            .expect("events should contain a consultation request"),
+    )
+    .expect("event should be JSON");
+    assert_eq!(last_event["event"], "pane.consult_request");
+    assert_eq!(last_event["message"], "Please review the Rust port");
+    let consultation_ref = last_event["data"]["consultation_ref"]
+        .as_str()
+        .expect("consultation_ref should be a string");
+    assert!(consultation_ref.starts_with(".winsmux/consultations/consult-request-"));
+    let packet_path =
+        project_dir.join(consultation_ref.replace('/', std::path::MAIN_SEPARATOR_STR));
+    let packet: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(packet_path).expect("packet should be readable"))
+            .expect("packet should be JSON");
+    assert_eq!(packet["packet_type"], "consultation_packet");
+    assert_eq!(packet["kind"], "consult_request");
+    assert_eq!(packet["mode"], "early");
+    assert_eq!(packet["request"], "Please review the Rust port");
+    assert!(packet.get("recommendation").is_none());
+
+    assert_eq!(last_event["data"]["consultation_ref"], consultation_ref);
+    assert!(last_event["data"].get("result").is_none());
+
+    let builder = read_manifest_pane(&project_dir, "builder-1");
+    assert_eq!(builder["last_event"], "consult.request");
+    assert!(builder["last_event_at"].as_str().is_some());
+}
+
+#[test]
 fn operator_cli_consult_result_records_packet_event_and_manifest() {
     let project_dir = make_temp_project_dir("consult-result");
     write_manifest(&project_dir);
@@ -536,6 +605,48 @@ fn operator_cli_consult_result_rejects_invalid_input() {
     assert!(!missing_message.status.success());
     assert!(
         String::from_utf8_lossy(&missing_message.stderr).contains("consult message is required")
+    );
+}
+
+#[test]
+fn operator_cli_consult_request_rejects_invalid_input() {
+    let project_dir = make_temp_project_dir("consult-request-invalid");
+    write_manifest(&project_dir);
+
+    let bad_mode = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .args(["consult-request", "later", "--message", "nope"])
+        .current_dir(&project_dir)
+        .env("WINSMUX_PANE_ID", "%2")
+        .env("WINSMUX_ROLE", "Builder")
+        .output()
+        .expect("winsmux command should run");
+    assert!(!bad_mode.status.success());
+    assert!(String::from_utf8_lossy(&bad_mode.stderr).contains("Unsupported consult mode"));
+
+    let json_option = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .args(["consult-request", "early", "--json"])
+        .current_dir(&project_dir)
+        .env("WINSMUX_PANE_ID", "%2")
+        .env("WINSMUX_ROLE", "Builder")
+        .output()
+        .expect("winsmux command should run");
+    assert!(!json_option.status.success());
+    assert!(
+        String::from_utf8_lossy(&json_option.stderr)
+            .contains("unknown argument for winsmux consult-request")
+    );
+
+    let unknown_option = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .args(["consult-request", "early", "--confidence", "0.5"])
+        .current_dir(&project_dir)
+        .env("WINSMUX_PANE_ID", "%2")
+        .env("WINSMUX_ROLE", "Builder")
+        .output()
+        .expect("winsmux command should run");
+    assert!(!unknown_option.status.success());
+    assert!(
+        String::from_utf8_lossy(&unknown_option.stderr)
+            .contains("unknown argument for winsmux consult-request")
     );
 }
 


### PR DESCRIPTION
## Summary
- Add Rust routing and help text for winsmux consult-request.
- Record consult_request packets under .winsmux/consultations and pane.consult_request events.
- Keep consult_result packet filenames working by making the writer accept an explicit prefix.
- Add Rust CLI tests for request packet/event output, manifest sync, and invalid input.

## Validation
- cargo test --manifest-path core\\Cargo.toml --test operator_cli -- --nocapture
- cargo test --manifest-path core\\Cargo.toml
- git diff --check
- pwsh -NoProfile -File .\\scripts\\git-guard.ps1 -Mode full
- pwsh -NoProfile -File .\\scripts\\audit-public-surface.ps1

## Review
- Review agent returned no result yet twice after 120s waits.
- Manual diff review completed before PR creation.
- If the delayed result arrives before merge, it will be incorporated before the final merge decision.

Part of TASK-266.