### PR TITLE
Add Rust consult-error command

### DIFF
--- a/core/src/cli.rs
+++ b/core/src/cli.rs
@@ -137,6 +137,7 @@ OPERATOR COMMANDS:
     promote-tactic          Export a reusable tactic candidate from a run
     consult-request         Record a consultation request packet and event
     consult-result          Record a consultation result packet and event
+    consult-error           Record a consultation error packet and event
     poll-events             Return new monitor events from .winsmux/events.jsonl
     review-request          Record a pending review request for the current branch
     review-approve          Record PASS for the pending review request

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -249,6 +249,7 @@ fn run_main() -> io::Result<()> {
         "promote-tactic" => return operator_cli::run_promote_tactic_command(&cmd_args[1..]),
         "consult-request" => return operator_cli::run_consult_request_command(&cmd_args[1..]),
         "consult-result" => return operator_cli::run_consult_result_command(&cmd_args[1..]),
+        "consult-error" => return operator_cli::run_consult_error_command(&cmd_args[1..]),
         "poll-events" => return operator_cli::run_poll_events_command(&cmd_args[1..]),
         "review-request" => return operator_cli::run_review_request_command(&cmd_args[1..]),
         "review-approve" => return operator_cli::run_review_approve_command(&cmd_args[1..]),

--- a/core/src/operator_cli.rs
+++ b/core/src/operator_cli.rs
@@ -320,6 +320,26 @@ pub fn run_consult_request_command(args: &[&String]) -> io::Result<()> {
     Ok(())
 }
 
+pub fn run_consult_error_command(args: &[&String]) -> io::Result<()> {
+    if should_print_help(args) {
+        println!("{}", usage_for("consult-error"));
+        return Ok(());
+    }
+    let options = parse_consult_error_options(args)?;
+    assert_consult_role_permission("consult-error")?;
+
+    let timestamp = generated_at();
+    let context = consultation_command_context(&options.project_dir, "")?;
+    let packet = consultation_error_packet(&context, &options, &timestamp);
+    let artifact = write_consultation_packet(&options.project_dir, "consult-error", &packet)?;
+    let event = consultation_error_event(&context, &options, &artifact.reference, &timestamp);
+    append_event_record(&options.project_dir, &event)?;
+    let _ = mark_current_review_pane_last_event(&options.project_dir, "consult.error", &timestamp);
+
+    println!("consult error recorded for {}", context.run_id);
+    Ok(())
+}
+
 pub fn run_poll_events_command(args: &[&String]) -> io::Result<()> {
     if should_print_help(args) {
         println!("{}", usage_for("poll-events"));
@@ -874,6 +894,17 @@ fn parse_consult_result_options(args: &[&String]) -> io::Result<ConsultResultOpt
 }
 
 fn parse_consult_request_options(args: &[&String]) -> io::Result<ConsultRequestOptions> {
+    parse_consult_simple_options("consult-request", args)
+}
+
+fn parse_consult_error_options(args: &[&String]) -> io::Result<ConsultRequestOptions> {
+    parse_consult_simple_options("consult-error", args)
+}
+
+fn parse_consult_simple_options(
+    command: &str,
+    args: &[&String],
+) -> io::Result<ConsultRequestOptions> {
     let mut project_dir = None;
     let mut positionals = Vec::new();
     let mut message = String::new();
@@ -914,10 +945,55 @@ fn parse_consult_request_options(args: &[&String]) -> io::Result<ConsultRequestO
                 target_slot = value.to_string();
                 index += 2;
             }
+            "--run-id" => {
+                let Some(_) = args.get(index + 1) else {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        "--run-id requires a value",
+                    ));
+                };
+                index += 2;
+            }
+            "--confidence" => {
+                let Some(value) = args.get(index + 1) else {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        "--confidence requires a value",
+                    ));
+                };
+                value.parse::<f64>().map_err(|_| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        format!("Invalid confidence value: {value}"),
+                    )
+                })?;
+                index += 2;
+            }
+            "--next-test" => {
+                let Some(_) = args.get(index + 1) else {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        "--next-test requires a value",
+                    ));
+                };
+                index += 2;
+            }
+            "--risk" => {
+                let Some(_) = args.get(index + 1) else {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        "--risk requires a value",
+                    ));
+                };
+                index += 2;
+            }
+            "--json" => {
+                index += 1;
+            }
             value if value.starts_with('-') => {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidInput,
-                    format!("unknown argument for winsmux consult-request: {value}"),
+                    format!("unknown argument for winsmux {command}: {value}"),
                 ));
             }
             value => {
@@ -934,7 +1010,7 @@ fn parse_consult_request_options(args: &[&String]) -> io::Result<ConsultRequestO
     if positionals.len() != 1 {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
-            usage_for("consult-request"),
+            usage_for(command),
         ));
     }
 
@@ -1048,6 +1124,9 @@ fn usage_for(command: &str) -> &'static str {
         }
         "consult-result" => {
             "usage: winsmux consult-result <early|stuck|reconcile|final> [--message <text>] [--target-slot <slot>] [--confidence <0..1>] [--next-test <text>] [--risk <text>] [--run-id <run_id>] [--json] [--project-dir <path>]"
+        }
+        "consult-error" => {
+            "usage: winsmux consult-error <early|stuck|reconcile|final> [--message <text>] [--target-slot <slot>] [--project-dir <path>]"
         }
         "poll-events" => "usage: winsmux poll-events [cursor] [--project-dir <path>]",
         "review-reset" => "usage: winsmux review-reset [--project-dir <path>]",
@@ -3462,6 +3541,28 @@ fn consultation_request_packet(
     Value::Object(packet)
 }
 
+fn consultation_error_packet(
+    context: &ConsultationContext,
+    options: &ConsultRequestOptions,
+    timestamp: &str,
+) -> Value {
+    let mut packet = Map::new();
+    packet.insert("packet_type".to_string(), json!("consultation_packet"));
+    packet.insert("generated_at".to_string(), json!(timestamp));
+    packet.insert("run_id".to_string(), json!(context.run_id));
+    packet.insert("task_id".to_string(), json!(context.task_id));
+    packet.insert("pane_id".to_string(), json!(context.pane_id));
+    packet.insert("slot".to_string(), json!(context.slot));
+    packet.insert("kind".to_string(), json!("consult_error"));
+    packet.insert("mode".to_string(), json!(options.mode));
+    packet.insert("target_slot".to_string(), json!(options.target_slot));
+    packet.insert("branch".to_string(), json!(context.branch));
+    packet.insert("head_sha".to_string(), json!(context.head_sha));
+    packet.insert("worktree".to_string(), json!(context.worktree));
+    packet.insert("error".to_string(), json!(options.message));
+    Value::Object(packet)
+}
+
 fn consultation_result_event(
     context: &ConsultationContext,
     options: &ConsultResultOptions,
@@ -3515,6 +3616,34 @@ fn consultation_request_event(
         "timestamp": timestamp,
         "session": context.session_name,
         "event": "pane.consult_request",
+        "message": options.message,
+        "label": context.label,
+        "pane_id": context.pane_id,
+        "role": context.role,
+        "branch": context.branch,
+        "head_sha": context.head_sha,
+        "data": Value::Object(data),
+    })
+}
+
+fn consultation_error_event(
+    context: &ConsultationContext,
+    options: &ConsultRequestOptions,
+    consultation_ref: &str,
+    timestamp: &str,
+) -> Value {
+    let mut data = Map::new();
+    data.insert("task_id".to_string(), json!(context.task_id));
+    data.insert("run_id".to_string(), json!(context.run_id));
+    data.insert("slot".to_string(), json!(context.slot));
+    data.insert("branch".to_string(), json!(context.branch));
+    data.insert("worktree".to_string(), json!(context.worktree));
+    data.insert("consultation_ref".to_string(), json!(consultation_ref));
+
+    json!({
+        "timestamp": timestamp,
+        "session": context.session_name,
+        "event": "pane.consult_error",
         "message": options.message,
         "label": context.label,
         "pane_id": context.pane_id,

--- a/core/tests-rs/operator_cli.rs
+++ b/core/tests-rs/operator_cli.rs
@@ -352,6 +352,74 @@ fn operator_cli_promote_tactic_rejects_unknown_kind() {
 }
 
 #[test]
+fn operator_cli_consult_error_records_packet_event_and_manifest() {
+    let project_dir = make_temp_project_dir("consult-error");
+    write_manifest(&project_dir);
+    let manifest_path = project_dir.join(".winsmux").join("manifest.yaml");
+    let manifest = fs::read_to_string(&manifest_path)
+        .expect("test should read manifest")
+        .replace("    role: Builder\n", "    role: Worker\n");
+    fs::write(&manifest_path, manifest).expect("test should write manifest");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .args([
+            "consult-error",
+            "stuck",
+            "--message",
+            "Reviewer context is missing",
+            "--target-slot",
+            "reviewer-1",
+        ])
+        .current_dir(&project_dir)
+        .env("WINSMUX_PANE_ID", "%2")
+        .env("WINSMUX_ROLE", "Worker")
+        .env("WINSMUX_ROLE_MAP", r#"{"%2":"Worker"}"#)
+        .output()
+        .expect("winsmux command should run");
+
+    assert!(
+        output.status.success(),
+        "winsmux command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("consult error recorded for operator:session-1"));
+
+    let events = fs::read_to_string(project_dir.join(".winsmux").join("events.jsonl"))
+        .expect("events should be readable");
+    let last_event: serde_json::Value = serde_json::from_str(
+        events
+            .lines()
+            .filter(|line| !line.trim().is_empty())
+            .last()
+            .expect("events should contain a consultation error"),
+    )
+    .expect("event should be JSON");
+    assert_eq!(last_event["event"], "pane.consult_error");
+    assert_eq!(last_event["message"], "Reviewer context is missing");
+    let consultation_ref = last_event["data"]["consultation_ref"]
+        .as_str()
+        .expect("consultation_ref should be a string");
+    assert!(consultation_ref.starts_with(".winsmux/consultations/consult-error-"));
+
+    let packet_path =
+        project_dir.join(consultation_ref.replace('/', std::path::MAIN_SEPARATOR_STR));
+    let packet: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(packet_path).expect("packet should be readable"))
+            .expect("packet should be JSON");
+    assert_eq!(packet["packet_type"], "consultation_packet");
+    assert_eq!(packet["kind"], "consult_error");
+    assert_eq!(packet["mode"], "stuck");
+    assert_eq!(packet["error"], "Reviewer context is missing");
+    assert!(packet.get("recommendation").is_none());
+    assert!(last_event["data"].get("result").is_none());
+
+    let builder = read_manifest_pane(&project_dir, "builder-1");
+    assert_eq!(builder["last_event"], "consult.error");
+    assert!(builder["last_event_at"].as_str().is_some());
+}
+
+#[test]
 fn operator_cli_consult_request_records_packet_event_and_manifest() {
     let project_dir = make_temp_project_dir("consult-request");
     write_manifest(&project_dir);
@@ -623,21 +691,35 @@ fn operator_cli_consult_request_rejects_invalid_input() {
     assert!(!bad_mode.status.success());
     assert!(String::from_utf8_lossy(&bad_mode.stderr).contains("Unsupported consult mode"));
 
-    let json_option = Command::new(env!("CARGO_BIN_EXE_winsmux"))
-        .args(["consult-request", "early", "--json"])
+    let ignored_options = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .args([
+            "consult-request",
+            "early",
+            "--message",
+            "compat",
+            "--json",
+            "--run-id",
+            "run-1",
+            "--confidence",
+            "0.5",
+            "--next-test",
+            "ignored",
+            "--risk",
+            "ignored",
+        ])
         .current_dir(&project_dir)
         .env("WINSMUX_PANE_ID", "%2")
         .env("WINSMUX_ROLE", "Builder")
         .output()
         .expect("winsmux command should run");
-    assert!(!json_option.status.success());
     assert!(
-        String::from_utf8_lossy(&json_option.stderr)
-            .contains("unknown argument for winsmux consult-request")
+        ignored_options.status.success(),
+        "winsmux command failed: {}",
+        String::from_utf8_lossy(&ignored_options.stderr)
     );
 
     let unknown_option = Command::new(env!("CARGO_BIN_EXE_winsmux"))
-        .args(["consult-request", "early", "--confidence", "0.5"])
+        .args(["consult-request", "early", "--unknown", "value"])
         .current_dir(&project_dir)
         .env("WINSMUX_PANE_ID", "%2")
         .env("WINSMUX_ROLE", "Builder")
@@ -648,6 +730,98 @@ fn operator_cli_consult_request_rejects_invalid_input() {
         String::from_utf8_lossy(&unknown_option.stderr)
             .contains("unknown argument for winsmux consult-request")
     );
+
+    let bad_confidence = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .args(["consult-request", "early", "--confidence", "nope"])
+        .current_dir(&project_dir)
+        .env("WINSMUX_PANE_ID", "%2")
+        .env("WINSMUX_ROLE", "Builder")
+        .output()
+        .expect("winsmux command should run");
+    assert!(!bad_confidence.status.success());
+    assert!(
+        String::from_utf8_lossy(&bad_confidence.stderr)
+            .contains("Invalid confidence value: nope")
+    );
+}
+
+#[test]
+fn operator_cli_consult_error_rejects_invalid_input() {
+    let project_dir = make_temp_project_dir("consult-error-invalid");
+    write_manifest(&project_dir);
+
+    let bad_mode = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .args(["consult-error", "later", "--message", "nope"])
+        .current_dir(&project_dir)
+        .env("WINSMUX_PANE_ID", "%2")
+        .env("WINSMUX_ROLE", "Builder")
+        .output()
+        .expect("winsmux command should run");
+    assert!(!bad_mode.status.success());
+    assert!(String::from_utf8_lossy(&bad_mode.stderr).contains("Unsupported consult mode"));
+
+    let ignored_options = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .args([
+            "consult-error",
+            "early",
+            "--message",
+            "compat",
+            "--json",
+            "--run-id",
+            "run-1",
+            "--confidence",
+            "0.5",
+            "--next-test",
+            "ignored",
+            "--risk",
+            "ignored",
+        ])
+        .current_dir(&project_dir)
+        .env("WINSMUX_PANE_ID", "%2")
+        .env("WINSMUX_ROLE", "Builder")
+        .output()
+        .expect("winsmux command should run");
+    assert!(
+        ignored_options.status.success(),
+        "winsmux command failed: {}",
+        String::from_utf8_lossy(&ignored_options.stderr)
+    );
+
+    let unknown_option = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .args(["consult-error", "early", "--unknown", "value"])
+        .current_dir(&project_dir)
+        .env("WINSMUX_PANE_ID", "%2")
+        .env("WINSMUX_ROLE", "Builder")
+        .output()
+        .expect("winsmux command should run");
+    assert!(!unknown_option.status.success());
+    assert!(
+        String::from_utf8_lossy(&unknown_option.stderr)
+            .contains("unknown argument for winsmux consult-error")
+    );
+
+    let bad_confidence = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .args(["consult-error", "early", "--confidence", "nope"])
+        .current_dir(&project_dir)
+        .env("WINSMUX_PANE_ID", "%2")
+        .env("WINSMUX_ROLE", "Builder")
+        .output()
+        .expect("winsmux command should run");
+    assert!(!bad_confidence.status.success());
+    assert!(
+        String::from_utf8_lossy(&bad_confidence.stderr)
+            .contains("Invalid confidence value: nope")
+    );
+
+    let missing_run_id = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .args(["consult-error", "early", "--run-id"])
+        .current_dir(&project_dir)
+        .env("WINSMUX_PANE_ID", "%2")
+        .env("WINSMUX_ROLE", "Builder")
+        .output()
+        .expect("winsmux command should run");
+    assert!(!missing_run_id.status.success());
+    assert!(String::from_utf8_lossy(&missing_run_id.stderr).contains("--run-id requires a value"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add the Rust winsmux consult-error route and help surface
- write consult_error packets and pane.consult_error events
- keep simple consult option handling compatible with the PowerShell path

## Validation
- cargo test --manifest-path core\\Cargo.toml --test operator_cli -- --nocapture
- cargo test --manifest-path core\\Cargo.toml
- git diff --check
- pwsh -NoProfile -File .\\scripts\\git-guard.ps1 -Mode full
- pwsh -NoProfile -File .\\scripts\\audit-public-surface.ps1

## Review
- Ohm found option compatibility gaps; fixed.
- Ohm follow-up review: no findings.

## Notes
- TASK-266 remains open after this slice.
- External Rust learning notes were updated outside the repository.
- Opus review for the external learning notes remains blocked by execution policy.