### PR TITLE
Add Rust signal command

### DIFF
--- a/core/src/cli.rs
+++ b/core/src/cli.rs
@@ -132,6 +132,7 @@ OPERATOR COMMANDS:
     inbox --json            Print actionable approval and review items JSON
     digest --json           Print high-signal run digest JSON
     desktop-summary         Print desktop summary projection JSON or counts
+    signal <channel>        Send a file-backed orchestration signal
     runs --json             Print run-oriented evidence JSON
     explain <run_id> --json Print one run explanation JSON
     compare-runs            Compare two runs and surface evidence deltas

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -244,6 +244,7 @@ fn run_main() -> io::Result<()> {
         "inbox" => return operator_cli::run_inbox_command(&cmd_args[1..]),
         "digest" => return operator_cli::run_digest_command(&cmd_args[1..]),
         "desktop-summary" => return operator_cli::run_desktop_summary_command(&cmd_args[1..]),
+        "signal" => return operator_cli::run_signal_command(&cmd_args[1..]),
         "runs" => return operator_cli::run_runs_command(&cmd_args[1..]),
         "explain" => return operator_cli::run_explain_command(&cmd_args[1..]),
         "compare-runs" => return operator_cli::run_compare_runs_command(&cmd_args[1..]),

--- a/core/src/operator_cli.rs
+++ b/core/src/operator_cli.rs
@@ -116,6 +116,33 @@ pub fn run_desktop_summary_command(args: &[&String]) -> io::Result<()> {
     Ok(())
 }
 
+pub fn run_signal_command(args: &[&String]) -> io::Result<()> {
+    if args.len() != 1 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            usage_for("signal"),
+        ));
+    }
+
+    let channel = args[0].trim();
+    if channel.is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            usage_for("signal"),
+        ));
+    }
+
+    let temp_root = env::var_os("TEMP")
+        .map(PathBuf::from)
+        .unwrap_or_else(env::temp_dir);
+    let signal_dir = temp_root.join("winsmux").join("signals");
+    fs::create_dir_all(&signal_dir)?;
+    let signal_file = signal_dir.join(format!("{channel}.signal"));
+    fs::write(signal_file, generated_at())?;
+    println!("sent signal: {channel}");
+    Ok(())
+}
+
 pub fn run_runs_command(args: &[&String]) -> io::Result<()> {
     if should_print_help(args) {
         println!("usage: winsmux runs --json [--project-dir <path>]");
@@ -1192,6 +1219,7 @@ fn usage_for(command: &str) -> &'static str {
         "inbox" => "usage: winsmux inbox --json [--project-dir <path>]",
         "digest" => "usage: winsmux digest --json [--project-dir <path>]",
         "desktop-summary" => "usage: winsmux desktop-summary [--json] [--stream] [--project-dir <path>]",
+        "signal" => "usage: winsmux signal <channel>",
         "runs" => "usage: winsmux runs --json [--project-dir <path>]",
         "explain" => "usage: winsmux explain <run_id> --json [--project-dir <path>]",
         "compare-runs" => {

--- a/core/tests-rs/operator_cli.rs
+++ b/core/tests-rs/operator_cli.rs
@@ -264,6 +264,65 @@ fn operator_cli_desktop_summary_stream_accepts_top_level_run_fields() {
 }
 
 #[test]
+fn operator_cli_signal_writes_temp_signal_file() {
+    let project_dir = make_temp_project_dir("signal-command");
+    let tmp_dir = project_dir.join("tmp");
+    let temp_dir = project_dir.join("temp");
+    fs::create_dir_all(&tmp_dir).expect("test should create tmp dir");
+    fs::create_dir_all(&temp_dir).expect("test should create temp dir");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .args(["signal", "desktop-ready"])
+        .env("TMP", &tmp_dir)
+        .env("TEMP", &temp_dir)
+        .current_dir(&project_dir)
+        .output()
+        .expect("winsmux command should run");
+
+    assert!(
+        output.status.success(),
+        "winsmux command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        "sent signal: desktop-ready"
+    );
+    let signal_file = temp_dir
+        .join("winsmux")
+        .join("signals")
+        .join("desktop-ready.signal");
+    let signal = fs::read_to_string(signal_file).expect("signal file should exist");
+    assert!(signal.contains('T'));
+}
+
+#[test]
+fn operator_cli_signal_treats_leading_dash_as_channel() {
+    let project_dir = make_temp_project_dir("signal-leading-dash");
+    let temp_dir = project_dir.join("temp");
+    fs::create_dir_all(&temp_dir).expect("test should create temp dir");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .args(["signal", "--json"])
+        .env("TEMP", &temp_dir)
+        .current_dir(&project_dir)
+        .output()
+        .expect("winsmux command should run");
+
+    assert!(
+        output.status.success(),
+        "winsmux command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        "sent signal: --json"
+    );
+    let signal_file = temp_dir.join("winsmux").join("signals").join("--json.signal");
+    assert!(signal_file.exists(), "leading-dash channel should be literal");
+}
+
+#[test]
 fn operator_cli_poll_events_returns_events_after_cursor() {
     let project_dir = make_temp_project_dir("poll-events");
     write_manifest(&project_dir);


### PR DESCRIPTION
## Summary
- add Rust winsmux signal routing
- write signal files under %TEMP%\winsmux\signals for PowerShell wait compatibility
- treat leading-dash channel names as literal channel names

## Validation
- cargo test --manifest-path core\Cargo.toml --test operator_cli signal -- --nocapture
- cargo test --manifest-path core\Cargo.toml --test operator_cli -- --nocapture
- cargo test --manifest-path core\Cargo.toml
- git diff --check
- pwsh -NoProfile -File .\scripts\git-guard.ps1 -Mode full
- pwsh -NoProfile -File .\scripts\audit-public-surface.ps1

Task: TASK-266