### PR TITLE
Add Rust wait command

### DIFF
--- a/core/src/cli.rs
+++ b/core/src/cli.rs
@@ -133,6 +133,7 @@ OPERATOR COMMANDS:
     digest --json           Print high-signal run digest JSON
     desktop-summary         Print desktop summary projection JSON or counts
     signal <channel>        Send a file-backed orchestration signal
+    wait <channel> [secs]   Wait for a file-backed orchestration signal
     runs --json             Print run-oriented evidence JSON
     explain <run_id> --json Print one run explanation JSON
     compare-runs            Compare two runs and surface evidence deltas
@@ -163,7 +164,7 @@ DISPLAY COMMANDS:
     clock-mode              Display a big clock
     run-shell, run          Run a shell command
     if-shell, if            Conditional command execution
-    wait-for, wait          Wait for / signal a named channel
+    wait-for                Wait for / signal a named channel
 
 MISC:
     help                    Show this help message
@@ -479,7 +480,7 @@ fn commands_text() -> &'static str {
   switch-client (switchc)   - Switch to another session
   unbind-key (unbind)       - Unbind a key
   unlink-window (unlinkw)   - Unlink a window
-  wait-for (wait)           - Wait for a signal
+  wait-for                  - Wait for a signal
   zoom-pane (zoom)          - Toggle pane zoom
 "#
 }

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -182,7 +182,7 @@ fn run_main() -> io::Result<()> {
     // -L is only stripped BEFORE the subcommand (global socket namespace flag);
     // after the subcommand, -L is kept (e.g. select-pane -L, resize-pane -L).
     let cmd_args: Vec<&String> = {
-        let mut result = Vec::new();
+        let mut result: Vec<&String> = Vec::new();
         let mut i = 1; // skip binary name
         let mut found_subcommand = false;
         while i < args.len() {
@@ -204,8 +204,13 @@ fn run_main() -> io::Result<()> {
                     // fall through to push the subcommand name
                 }
             } else {
-                // After subcommand: strip only -t (and its value)
-                if args[i] == "-t" && i + 1 < args.len() {
+                // After subcommand: strip only -t (and its value), except
+                // commands that intentionally treat the first argument as a
+                // literal channel name.
+                if result.first().map(|s| s.as_str()) != Some("wait")
+                    && args[i] == "-t"
+                    && i + 1 < args.len()
+                {
                     i += 2;
                     continue;
                 }
@@ -245,6 +250,13 @@ fn run_main() -> io::Result<()> {
         "digest" => return operator_cli::run_digest_command(&cmd_args[1..]),
         "desktop-summary" => return operator_cli::run_desktop_summary_command(&cmd_args[1..]),
         "signal" => return operator_cli::run_signal_command(&cmd_args[1..]),
+        "wait" if !matches!(
+            cmd_args.get(1).map(|arg| arg.as_str()),
+            Some("-S" | "-L" | "-U")
+        ) =>
+        {
+            return operator_cli::run_wait_command(&cmd_args[1..])
+        }
         "runs" => return operator_cli::run_runs_command(&cmd_args[1..]),
         "explain" => return operator_cli::run_explain_command(&cmd_args[1..]),
         "compare-runs" => return operator_cli::run_compare_runs_command(&cmd_args[1..]),

--- a/core/src/operator_cli.rs
+++ b/core/src/operator_cli.rs
@@ -132,15 +132,71 @@ pub fn run_signal_command(args: &[&String]) -> io::Result<()> {
         ));
     }
 
-    let temp_root = env::var_os("TEMP")
-        .map(PathBuf::from)
-        .unwrap_or_else(env::temp_dir);
-    let signal_dir = temp_root.join("winsmux").join("signals");
+    let signal_dir = signal_dir_path();
     fs::create_dir_all(&signal_dir)?;
-    let signal_file = signal_dir.join(format!("{channel}.signal"));
+    let signal_file = signal_file_path(channel);
     fs::write(signal_file, generated_at())?;
     println!("sent signal: {channel}");
     Ok(())
+}
+
+pub fn run_wait_command(args: &[&String]) -> io::Result<()> {
+    if args.is_empty() || args.len() > 2 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            usage_for("wait"),
+        ));
+    }
+
+    let channel = args[0].trim();
+    if channel.is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            usage_for("wait"),
+        ));
+    }
+
+    let timeout_secs = match args.get(1) {
+        Some(raw) => raw
+            .parse::<u64>()
+            .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, usage_for("wait")))?,
+        None => 120,
+    };
+    let signal_dir = signal_dir_path();
+    fs::create_dir_all(&signal_dir)?;
+    let signal_file = signal_file_path(channel);
+    if signal_file.exists() {
+        fs::remove_file(&signal_file)?;
+        println!("received signal: {channel}");
+        return Ok(());
+    }
+
+    let deadline = Instant::now() + Duration::from_secs(timeout_secs);
+    while Instant::now() < deadline {
+        thread::sleep(Duration::from_millis(100));
+        if signal_file.exists() {
+            fs::remove_file(&signal_file)?;
+            println!("received signal: {channel}");
+            return Ok(());
+        }
+    }
+
+    Err(io::Error::new(
+        io::ErrorKind::TimedOut,
+        format!("timeout waiting for signal: {channel} ({timeout_secs}s)"),
+    ))
+}
+
+fn signal_dir_path() -> PathBuf {
+    env::var_os("TEMP")
+        .map(PathBuf::from)
+        .unwrap_or_else(env::temp_dir)
+        .join("winsmux")
+        .join("signals")
+}
+
+fn signal_file_path(channel: &str) -> PathBuf {
+    signal_dir_path().join(format!("{channel}.signal"))
 }
 
 pub fn run_runs_command(args: &[&String]) -> io::Result<()> {
@@ -1220,6 +1276,7 @@ fn usage_for(command: &str) -> &'static str {
         "digest" => "usage: winsmux digest --json [--project-dir <path>]",
         "desktop-summary" => "usage: winsmux desktop-summary [--json] [--stream] [--project-dir <path>]",
         "signal" => "usage: winsmux signal <channel>",
+        "wait" => "usage: winsmux wait <channel> [timeout_seconds]",
         "runs" => "usage: winsmux runs --json [--project-dir <path>]",
         "explain" => "usage: winsmux explain <run_id> --json [--project-dir <path>]",
         "compare-runs" => {

--- a/core/tests-rs/operator_cli.rs
+++ b/core/tests-rs/operator_cli.rs
@@ -323,6 +323,146 @@ fn operator_cli_signal_treats_leading_dash_as_channel() {
 }
 
 #[test]
+fn operator_cli_wait_consumes_temp_signal_file() {
+    let project_dir = make_temp_project_dir("wait-command");
+    let temp_dir = project_dir.join("temp");
+    let signal_dir = temp_dir.join("winsmux").join("signals");
+    fs::create_dir_all(&signal_dir).expect("test should create signal dir");
+    let signal_file = signal_dir.join("desktop-ready.signal");
+    fs::write(&signal_file, "ready").expect("test should write signal file");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .args(["wait", "desktop-ready", "0"])
+        .env("TEMP", &temp_dir)
+        .current_dir(&project_dir)
+        .output()
+        .expect("winsmux command should run");
+
+    assert!(
+        output.status.success(),
+        "winsmux command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        "received signal: desktop-ready"
+    );
+    assert!(!signal_file.exists(), "wait should remove consumed signal");
+}
+
+#[test]
+fn operator_cli_wait_treats_leading_dash_as_channel() {
+    let project_dir = make_temp_project_dir("wait-leading-dash");
+    let temp_dir = project_dir.join("temp");
+    let signal_dir = temp_dir.join("winsmux").join("signals");
+    fs::create_dir_all(&signal_dir).expect("test should create signal dir");
+    let signal_file = signal_dir.join("--json.signal");
+    fs::write(&signal_file, "ready").expect("test should write signal file");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .args(["wait", "--json", "0"])
+        .env("TEMP", &temp_dir)
+        .current_dir(&project_dir)
+        .output()
+        .expect("winsmux command should run");
+
+    assert!(
+        output.status.success(),
+        "winsmux command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        "received signal: --json"
+    );
+    assert!(!signal_file.exists(), "leading-dash channel should be literal");
+}
+
+#[test]
+fn operator_cli_wait_treats_dash_t_as_channel() {
+    let project_dir = make_temp_project_dir("wait-dash-t");
+    let temp_dir = project_dir.join("temp");
+    let signal_dir = temp_dir.join("winsmux").join("signals");
+    fs::create_dir_all(&signal_dir).expect("test should create signal dir");
+    let signal_file = signal_dir.join("-t.signal");
+    fs::write(&signal_file, "ready").expect("test should write signal file");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .args(["wait", "-t", "0"])
+        .env("TEMP", &temp_dir)
+        .current_dir(&project_dir)
+        .output()
+        .expect("winsmux command should run");
+
+    assert!(
+        output.status.success(),
+        "winsmux command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "received signal: -t");
+    assert!(!signal_file.exists(), "-t channel should be literal");
+}
+
+#[test]
+fn operator_cli_wait_signal_option_preserves_tmux_alias() {
+    let output = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .args(["wait", "-S", "compat-channel"])
+        .output()
+        .expect("winsmux command should run");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("no server running") || output.status.success(),
+        "wait -S should route to the tmux-compatible wait path: {stderr}"
+    );
+    assert!(
+        !stderr.contains("Unknown command"),
+        "wait -S must not fall through to unknown command"
+    );
+}
+
+#[test]
+fn operator_cli_wait_timeout_creates_signal_dir() {
+    let project_dir = make_temp_project_dir("wait-creates-dir");
+    let temp_dir = project_dir.join("temp");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .args(["wait", "missing", "0"])
+        .env("TEMP", &temp_dir)
+        .current_dir(&project_dir)
+        .output()
+        .expect("winsmux command should run");
+
+    assert!(!output.status.success(), "wait should fail on timeout");
+    assert!(
+        temp_dir.join("winsmux").join("signals").exists(),
+        "wait should establish the shared signal directory"
+    );
+}
+
+#[test]
+fn operator_cli_wait_times_out_without_signal() {
+    let project_dir = make_temp_project_dir("wait-timeout");
+    let temp_dir = project_dir.join("temp");
+    fs::create_dir_all(&temp_dir).expect("test should create temp dir");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .args(["wait", "missing", "0"])
+        .env("TEMP", &temp_dir)
+        .current_dir(&project_dir)
+        .output()
+        .expect("winsmux command should run");
+
+    assert!(!output.status.success(), "wait should fail on timeout");
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("timeout waiting for signal: missing (0s)"),
+        "stderr should explain timeout: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
 fn operator_cli_poll_events_returns_events_after_cursor() {
     let project_dir = make_temp_project_dir("poll-events");
     write_manifest(&project_dir);


### PR DESCRIPTION
## Summary
- add Rust winsmux wait routing for file-backed orchestration signals
- keep wait -S/-L/-U on the tmux-compatible wait-for path
- create the shared %TEMP%\winsmux\signals directory before polling

## Validation
- cargo test --manifest-path core\Cargo.toml --test operator_cli wait -- --nocapture
- cargo test --manifest-path core\Cargo.toml --test operator_cli -- --nocapture
- cargo test --manifest-path core\Cargo.toml
- git diff --check
- pwsh -NoProfile -File .\scripts\git-guard.ps1 -Mode full
- pwsh -NoProfile -File .\scripts\audit-public-surface.ps1

Task: TASK-266