### PR TITLE
Add Rust conflict preflight command

### DIFF
--- a/core/src/cli.rs
+++ b/core/src/cli.rs
@@ -138,6 +138,8 @@ OPERATOR COMMANDS:
     runs --json             Print run-oriented evidence JSON
     explain <run_id> --json Print one run explanation JSON
     compare-runs            Compare two runs and surface evidence deltas
+    compare preflight       Run git merge-tree preflight before compare UI
+    conflict-preflight      Run git merge-tree preflight before compare UI
     promote-tactic          Export a reusable tactic candidate from a run
     consult-request         Record a consultation request packet and event
     consult-result          Record a consultation result packet and event

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -261,6 +261,12 @@ fn run_main() -> io::Result<()> {
         "runs" => return operator_cli::run_runs_command(&cmd_args[1..]),
         "explain" => return operator_cli::run_explain_command(&cmd_args[1..]),
         "compare-runs" => return operator_cli::run_compare_runs_command(&cmd_args[1..]),
+        "compare" if matches!(cmd_args.get(1).map(|arg| arg.as_str()), Some("preflight")) => {
+            return operator_cli::run_compare_preflight_command(&cmd_args[2..])
+        }
+        "conflict-preflight" => {
+            return operator_cli::run_conflict_preflight_command(&cmd_args[1..])
+        }
         "promote-tactic" => return operator_cli::run_promote_tactic_command(&cmd_args[1..]),
         "consult-request" => return operator_cli::run_consult_request_command(&cmd_args[1..]),
         "consult-result" => return operator_cli::run_consult_result_command(&cmd_args[1..]),

--- a/core/src/operator_cli.rs
+++ b/core/src/operator_cli.rs
@@ -614,6 +614,71 @@ pub fn run_explain_command(args: &[&String]) -> io::Result<()> {
     write_json(&payload)
 }
 
+pub fn run_conflict_preflight_command(args: &[&String]) -> io::Result<()> {
+    if should_print_help(args) {
+        println!("{}", usage_for("conflict-preflight"));
+        return Ok(());
+    }
+
+    run_conflict_preflight(args, false)
+}
+
+pub fn run_compare_preflight_command(args: &[&String]) -> io::Result<()> {
+    if should_print_help(args) {
+        println!("{}", usage_for("compare-preflight"));
+        return Ok(());
+    }
+
+    run_conflict_preflight(args, true)
+}
+
+fn run_conflict_preflight(args: &[&String], compare_alias: bool) -> io::Result<()> {
+    let usage_key = if compare_alias {
+        "compare-preflight"
+    } else {
+        "conflict-preflight"
+    };
+    let options = parse_conflict_preflight_options(args, usage_key)?;
+    let mut payload =
+        conflict_preflight_payload(&env::current_dir()?, &options.left_ref, &options.right_ref)?;
+    if compare_alias {
+        payload.command = "compare preflight".to_string();
+        payload.next_action = payload.next_action.replace(
+            "winsmux conflict-preflight",
+            "winsmux compare preflight",
+        );
+    }
+    if options.json {
+        return write_json(&payload);
+    }
+
+    let label = if compare_alias {
+        "compare preflight"
+    } else {
+        "conflict preflight"
+    };
+    println!("{label}: {}", payload.status);
+    println!(
+        "left: {} ({})",
+        payload.left_ref,
+        short_head_sha(&payload.left_sha)
+    );
+    println!(
+        "right: {} ({})",
+        payload.right_ref,
+        short_head_sha(&payload.right_sha)
+    );
+    if !payload.merge_base.trim().is_empty() {
+        println!("merge-base: {}", short_head_sha(&payload.merge_base));
+    }
+    println!("overlap paths: {}", payload.overlap_paths.len());
+    for path in &payload.overlap_paths {
+        println!("- {path}");
+    }
+    println!("next: {}", payload.next_action);
+    Ok(())
+}
+
 pub fn run_compare_runs_command(args: &[&String]) -> io::Result<()> {
     if should_print_help(args) {
         println!("{}", usage_for("compare-runs"));
@@ -1033,6 +1098,36 @@ struct PromoteTacticOptions {
     kind: String,
 }
 
+struct ConflictPreflightOptions {
+    json: bool,
+    left_ref: String,
+    right_ref: String,
+}
+
+#[derive(Debug, Serialize)]
+struct ConflictPreflightPayload {
+    command: String,
+    status: String,
+    reason: String,
+    project_dir: String,
+    left_ref: String,
+    right_ref: String,
+    left_sha: String,
+    right_sha: String,
+    merge_base: String,
+    merge_tree_exit_code: Option<i32>,
+    conflict_detected: bool,
+    overlap_paths: Vec<String>,
+    left_only_paths: Vec<String>,
+    right_only_paths: Vec<String>,
+    next_action: String,
+}
+
+struct GitProbeResult {
+    exit_code: i32,
+    output: String,
+}
+
 struct ConsultResultOptions {
     json: bool,
     project_dir: PathBuf,
@@ -1264,6 +1359,44 @@ fn parse_promote_tactic_options(args: &[&String]) -> io::Result<PromoteTacticOpt
         positionals,
         title,
         kind,
+    })
+}
+
+fn parse_conflict_preflight_options(
+    args: &[&String],
+    usage_key: &'static str,
+) -> io::Result<ConflictPreflightOptions> {
+    let mut json = false;
+    let mut refs = Vec::new();
+    let mut index = 0;
+
+    while index < args.len() {
+        match args[index].as_str() {
+            "--json" => {
+                json = true;
+                index += 1;
+            }
+            value if !value.trim().is_empty() => {
+                refs.push(value.to_string());
+                index += 1;
+            }
+            _ => {
+                index += 1;
+            }
+        }
+    }
+
+    if refs.len() != 2 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            usage_for(usage_key).to_string(),
+        ));
+    }
+
+    Ok(ConflictPreflightOptions {
+        json,
+        left_ref: refs[0].clone(),
+        right_ref: refs[1].clone(),
     })
 }
 
@@ -1647,6 +1780,12 @@ fn usage_for(command: &str) -> &'static str {
         "explain" => "usage: winsmux explain <run_id> --json [--project-dir <path>]",
         "compare-runs" => {
             "usage: winsmux compare-runs <left_run_id> <right_run_id> [--json] [--project-dir <path>]"
+        }
+        "conflict-preflight" => {
+            "usage: winsmux conflict-preflight <left_ref> <right_ref> [--json]"
+        }
+        "compare-preflight" => {
+            "usage: winsmux compare preflight <left_ref> <right_ref> [--json]"
         }
         "promote-tactic" => {
             "usage: winsmux promote-tactic <run_id> [--title <text>] [--kind <playbook|prewarm|verification>] [--json] [--project-dir <path>]"
@@ -3873,6 +4012,154 @@ fn compare_runs_payload(
             "next_action": next_action,
         },
     })
+}
+
+fn conflict_preflight_payload(
+    project_dir: &Path,
+    left_ref: &str,
+    right_ref: &str,
+) -> io::Result<ConflictPreflightPayload> {
+    let repo_root = resolve_conflict_preflight_repo_root(project_dir)?;
+    let left_sha = resolve_conflict_commit(&repo_root, left_ref)?;
+    let right_sha = resolve_conflict_commit(&repo_root, right_ref)?;
+    let merge_base_result = git_probe(&repo_root, &["merge-base", left_ref, right_ref])?;
+    if merge_base_result.exit_code != 0 || merge_base_result.output.trim().is_empty() {
+        return Ok(ConflictPreflightPayload {
+            command: "conflict-preflight".to_string(),
+            status: "blocked".to_string(),
+            reason: "no_merge_base".to_string(),
+            project_dir: repo_root.display().to_string(),
+            left_ref: left_ref.to_string(),
+            right_ref: right_ref.to_string(),
+            left_sha,
+            right_sha,
+            merge_base: String::new(),
+            merge_tree_exit_code: None,
+            conflict_detected: false,
+            overlap_paths: Vec::new(),
+            left_only_paths: Vec::new(),
+            right_only_paths: Vec::new(),
+            next_action:
+                "Choose related refs with a shared merge base and rerun winsmux conflict-preflight."
+                    .to_string(),
+        });
+    }
+
+    let merge_base = merge_base_result.output;
+    let left_paths = conflict_path_array(
+        &git_probe(&repo_root, &["diff", "--name-only", &merge_base, left_ref])?.output,
+    );
+    let right_paths = conflict_path_array(
+        &git_probe(&repo_root, &["diff", "--name-only", &merge_base, right_ref])?.output,
+    );
+    let overlap_paths: Vec<String> = left_paths
+        .iter()
+        .filter(|path| right_paths.contains(path))
+        .cloned()
+        .collect();
+    let left_only_paths: Vec<String> = left_paths
+        .iter()
+        .filter(|path| !right_paths.contains(path))
+        .cloned()
+        .collect();
+    let right_only_paths: Vec<String> = right_paths
+        .iter()
+        .filter(|path| !left_paths.contains(path))
+        .cloned()
+        .collect();
+    let merge_tree_result = git_probe(
+        &repo_root,
+        &["merge-tree", "--write-tree", "--quiet", left_ref, right_ref],
+    )?;
+    let (status, reason, conflict_detected, next_action) = match merge_tree_result.exit_code {
+        0 => (
+            "clean",
+            "",
+            false,
+            "Safe to continue to compare UI or follow-up review.",
+        ),
+        1 => (
+            "conflict",
+            "merge_conflict",
+            true,
+            "Inspect overlap paths before compare or merge.",
+        ),
+        _ => (
+            "blocked",
+            "merge_tree_failed",
+            false,
+            "Inspect git merge-tree output and rerun winsmux conflict-preflight.",
+        ),
+    };
+
+    Ok(ConflictPreflightPayload {
+        command: "conflict-preflight".to_string(),
+        status: status.to_string(),
+        reason: reason.to_string(),
+        project_dir: repo_root.display().to_string(),
+        left_ref: left_ref.to_string(),
+        right_ref: right_ref.to_string(),
+        left_sha,
+        right_sha,
+        merge_base,
+        merge_tree_exit_code: Some(merge_tree_result.exit_code),
+        conflict_detected,
+        overlap_paths,
+        left_only_paths,
+        right_only_paths,
+        next_action: next_action.to_string(),
+    })
+}
+
+fn resolve_conflict_preflight_repo_root(project_dir: &Path) -> io::Result<PathBuf> {
+    if !project_dir.is_dir() {
+        return Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            format!("project directory not found: {}", project_dir.display()),
+        ));
+    }
+    let result = git_probe(project_dir, &["rev-parse", "--show-toplevel"])?;
+    if result.exit_code != 0 || result.output.trim().is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            format!(
+                "git repository root could not be resolved from: {}",
+                project_dir.display()
+            ),
+        ));
+    }
+    Ok(PathBuf::from(result.output))
+}
+
+fn resolve_conflict_commit(project_dir: &Path, git_ref: &str) -> io::Result<String> {
+    let rev = format!("{git_ref}^{{commit}}");
+    let result = git_probe(project_dir, &["rev-parse", "--verify", &rev])?;
+    if result.exit_code != 0 || result.output.trim().is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            format!("git ref could not be resolved: {git_ref}"),
+        ));
+    }
+    Ok(result.output)
+}
+
+fn git_probe(project_dir: &Path, args: &[&str]) -> io::Result<GitProbeResult> {
+    let output = Command::new("git").args(args).current_dir(project_dir).output()?;
+    let mut text = String::new();
+    text.push_str(&String::from_utf8_lossy(&output.stdout));
+    text.push_str(&String::from_utf8_lossy(&output.stderr));
+    Ok(GitProbeResult {
+        exit_code: output.status.code().unwrap_or(1),
+        output: text.trim().to_string(),
+    })
+}
+
+fn conflict_path_array(text: &str) -> Vec<String> {
+    text.lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(str::to_string)
+        .collect()
 }
 
 fn compare_run_side(

--- a/core/tests-rs/operator_cli.rs
+++ b/core/tests-rs/operator_cli.rs
@@ -407,6 +407,142 @@ fn operator_cli_provider_capabilities_rejects_blank_required_field() {
 }
 
 #[test]
+fn operator_cli_conflict_preflight_json_reports_clean_result() {
+    let project_dir = make_temp_project_dir("conflict-preflight-clean");
+    init_conflict_preflight_repo(&project_dir);
+    write_git_file(&project_dir, "left.txt", "left\n");
+    run_git(&project_dir, &["add", "left.txt"]);
+    run_git(&project_dir, &["commit", "-m", "left change"]);
+    run_git(&project_dir, &["branch", "left"]);
+    run_git(&project_dir, &["checkout", "base"]);
+    write_git_file(&project_dir, "right.txt", "right\n");
+    run_git(&project_dir, &["add", "right.txt"]);
+    run_git(&project_dir, &["commit", "-m", "right change"]);
+    run_git(&project_dir, &["branch", "right"]);
+
+    let json = run_json(&project_dir, &["conflict-preflight", "left", "right", "--json"]);
+
+    assert_eq!(json["command"], "conflict-preflight");
+    assert_eq!(json["status"], "clean");
+    assert_eq!(json["reason"], "");
+    assert_eq!(json["conflict_detected"], false);
+    assert_eq!(json["left_ref"], "left");
+    assert_eq!(json["right_ref"], "right");
+    assert_eq!(json["merge_tree_exit_code"], 0);
+    assert_eq!(json["overlap_paths"].as_array().unwrap().len(), 0);
+    assert_eq!(json["left_only_paths"][0], "left.txt");
+    assert_eq!(json["right_only_paths"][0], "right.txt");
+}
+
+#[test]
+fn operator_cli_compare_preflight_json_uses_public_command_name() {
+    let project_dir = make_temp_project_dir("compare-preflight-clean");
+    init_conflict_preflight_repo(&project_dir);
+    write_git_file(&project_dir, "left.txt", "left\n");
+    run_git(&project_dir, &["add", "left.txt"]);
+    run_git(&project_dir, &["commit", "-m", "left change"]);
+    run_git(&project_dir, &["branch", "left"]);
+    run_git(&project_dir, &["checkout", "base"]);
+    write_git_file(&project_dir, "right.txt", "right\n");
+    run_git(&project_dir, &["add", "right.txt"]);
+    run_git(&project_dir, &["commit", "-m", "right change"]);
+    run_git(&project_dir, &["branch", "right"]);
+
+    let json = run_json(
+        &project_dir,
+        &["compare", "preflight", "left", "right", "--json"],
+    );
+
+    assert_eq!(json["command"], "compare preflight");
+    assert_eq!(json["status"], "clean");
+    assert_eq!(
+        json["next_action"],
+        "Safe to continue to compare UI or follow-up review."
+    );
+}
+
+#[test]
+fn operator_cli_compare_preflight_invalid_usage_reports_public_command() {
+    let output = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .args(["compare", "preflight", "left-only"])
+        .output()
+        .expect("winsmux command should run");
+
+    assert!(!output.status.success(), "invalid usage should fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("usage: winsmux compare preflight <left_ref> <right_ref> [--json]"),
+        "stderr should show public usage: {stderr}"
+    );
+    assert!(
+        !stderr.contains("conflict-preflight"),
+        "public usage should not mention compatibility command: {stderr}"
+    );
+}
+
+#[test]
+fn operator_cli_conflict_preflight_json_reports_conflict() {
+    let project_dir = make_temp_project_dir("conflict-preflight-conflict");
+    init_conflict_preflight_repo(&project_dir);
+    write_git_file(&project_dir, "shared.txt", "left\n");
+    run_git(&project_dir, &["add", "shared.txt"]);
+    run_git(&project_dir, &["commit", "-m", "left change"]);
+    run_git(&project_dir, &["branch", "left"]);
+    run_git(&project_dir, &["checkout", "base"]);
+    write_git_file(&project_dir, "shared.txt", "right\n");
+    run_git(&project_dir, &["add", "shared.txt"]);
+    run_git(&project_dir, &["commit", "-m", "right change"]);
+    run_git(&project_dir, &["branch", "right"]);
+
+    let json = run_json(&project_dir, &["conflict-preflight", "left", "right", "--json"]);
+
+    assert_eq!(json["status"], "conflict");
+    assert_eq!(json["reason"], "merge_conflict");
+    assert_eq!(json["conflict_detected"], true);
+    assert_eq!(json["merge_tree_exit_code"], 1);
+    assert_eq!(json["overlap_paths"][0], "shared.txt");
+}
+
+#[test]
+fn operator_cli_conflict_preflight_json_reports_no_merge_base() {
+    let project_dir = make_temp_project_dir("conflict-preflight-no-merge-base");
+    init_conflict_preflight_repo(&project_dir);
+    write_git_file(&project_dir, "left.txt", "left\n");
+    run_git(&project_dir, &["add", "left.txt"]);
+    run_git(&project_dir, &["commit", "-m", "left change"]);
+    run_git(&project_dir, &["branch", "left"]);
+    run_git(&project_dir, &["checkout", "--orphan", "unrelated"]);
+    run_git(&project_dir, &["rm", "-rf", "."]);
+    write_git_file(&project_dir, "unrelated.txt", "unrelated\n");
+    run_git(&project_dir, &["add", "unrelated.txt"]);
+    run_git(&project_dir, &["commit", "-m", "unrelated change"]);
+
+    let json = run_json(
+        &project_dir,
+        &["conflict-preflight", "left", "unrelated", "--json"],
+    );
+
+    assert_eq!(json["status"], "blocked");
+    assert_eq!(json["reason"], "no_merge_base");
+    assert_eq!(json["merge_tree_exit_code"], serde_json::Value::Null);
+    assert_eq!(json["conflict_detected"], false);
+    assert_eq!(
+        json["next_action"],
+        "Choose related refs with a shared merge base and rerun winsmux conflict-preflight."
+    );
+
+    let alias_json = run_json(
+        &project_dir,
+        &["compare", "preflight", "left", "unrelated", "--json"],
+    );
+    assert_eq!(alias_json["command"], "compare preflight");
+    assert_eq!(
+        alias_json["next_action"],
+        "Choose related refs with a shared merge base and rerun winsmux compare preflight."
+    );
+}
+
+#[test]
 fn operator_cli_signal_writes_temp_signal_file() {
     let project_dir = make_temp_project_dir("signal-command");
     let tmp_dir = project_dir.join("tmp");
@@ -2513,6 +2649,35 @@ fn run_json_with_cwd(cwd: impl AsRef<std::path::Path>, args: &[&str]) -> serde_j
         String::from_utf8_lossy(&output.stderr)
     );
     serde_json::from_slice(&output.stdout).expect("stdout should be JSON")
+}
+
+fn init_conflict_preflight_repo(project_dir: &std::path::Path) {
+    run_git(project_dir, &["init"]);
+    run_git(project_dir, &["config", "user.email", "winsmux-test@example.com"]);
+    run_git(project_dir, &["config", "user.name", "winsmux test"]);
+    write_git_file(project_dir, "base.txt", "base\n");
+    run_git(project_dir, &["add", "base.txt"]);
+    run_git(project_dir, &["commit", "-m", "base"]);
+    run_git(project_dir, &["branch", "base"]);
+}
+
+fn write_git_file(project_dir: &std::path::Path, name: &str, text: &str) {
+    fs::write(project_dir.join(name), text).expect("test should write git file");
+}
+
+fn run_git(project_dir: &std::path::Path, args: &[&str]) {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(project_dir)
+        .output()
+        .expect("git should run");
+    assert!(
+        output.status.success(),
+        "git {:?} failed\nstdout:\n{}\nstderr:\n{}",
+        args,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
 }
 
 fn write_compare_runs_fixture(project_dir: &std::path::Path) {


### PR DESCRIPTION
## Summary
- add Rust operator CLI support for winsmux conflict-preflight
- add public winsmux compare preflight routing with PowerShell-compatible JSON command rewriting
- cover clean, conflict, no-merge-base, and invalid public usage cases

## Validation
- cargo test --manifest-path core\\Cargo.toml --test operator_cli preflight -- --nocapture
- cargo test --manifest-path core\\Cargo.toml --test operator_cli -- --nocapture
- cargo test --manifest-path core\\Cargo.toml
- git diff --check
- pwsh -NoProfile -File .\\scripts\\git-guard.ps1 -Mode full
- pwsh -NoProfile -File .\\scripts\\audit-public-surface.ps1

## Reviews
- review agents found and rechecked the public compare preflight route, usage text, and text-output compatibility gaps
- final review reported no findings