### PR TITLE
[TASK-266] Add Rust runs text output

### DIFF
--- a/core/src/operator_cli.rs
+++ b/core/src/operator_cli.rs
@@ -1617,15 +1617,18 @@ fn validate_provider_switch_restart_target(project_dir: &Path, slot_id: &str) ->
 
 pub fn run_runs_command(args: &[&String]) -> io::Result<()> {
     if should_print_help(args) {
-        println!("usage: winsmux runs --json [--project-dir <path>]");
+        println!("usage: winsmux runs [--json] [--project-dir <path>]");
         return Ok(());
     }
     let options = parse_options("runs", args, 0)?;
-    require_json("runs", &options)?;
 
     let snapshot = load_snapshot(&options.project_dir)?;
     let payload = runs_payload(&snapshot, &options.project_dir);
-    write_json(&payload)
+    if options.json {
+        write_json(&payload)
+    } else {
+        print_runs_table(&payload)
+    }
 }
 
 pub fn run_explain_command(args: &[&String]) -> io::Result<()> {
@@ -2832,7 +2835,7 @@ fn usage_for(command: &str) -> &'static str {
         }
         "signal" => "usage: winsmux signal <channel>",
         "wait" => "usage: winsmux wait <channel> [timeout_seconds]",
-        "runs" => "usage: winsmux runs --json [--project-dir <path>]",
+        "runs" => "usage: winsmux runs [--json] [--project-dir <path>]",
         "explain" => "usage: winsmux explain <run_id> --json [--project-dir <path>]",
         "compare-runs" => {
             "usage: winsmux compare-runs <left_run_id> <right_run_id> [--json] [--project-dir <path>]"
@@ -5986,8 +5989,8 @@ fn print_board_table(payload: &Value) -> io::Result<()> {
         ("Branch", 24usize),
         ("Head", 8usize),
     ];
-    println!("{}", board_table_row(&columns));
-    println!("{}", board_table_separator(&columns));
+    println!("{}", text_table_row(&columns));
+    println!("{}", text_table_separator(&columns));
     for pane in panes {
         let changed = pane
             .get("changed_file_count")
@@ -6006,22 +6009,68 @@ fn print_board_table(payload: &Value) -> io::Result<()> {
             json_string_field(&pane, "branch"),
             short_head_sha(&json_string_field(&pane, "head_sha")),
         ];
-        println!("{}", board_table_value_row(&values, &columns));
+        println!("{}", text_table_value_row(&values, &columns));
     }
     Ok(())
 }
 
-fn board_table_row(columns: &[(&str, usize)]) -> String {
+fn print_runs_table(payload: &Value) -> io::Result<()> {
+    let runs = payload
+        .get("runs")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    if runs.is_empty() {
+        println!("(no runs)");
+        return Ok(());
+    }
+
+    let columns = [
+        ("RunId", 18usize),
+        ("Label", 14usize),
+        ("Task", 30usize),
+        ("TaskState", 14usize),
+        ("Review", 10usize),
+        ("State", 12usize),
+        ("Branch", 24usize),
+        ("Head", 8usize),
+        ("ActionItems", 11usize),
+    ];
+    println!("{}", text_table_row(&columns));
+    println!("{}", text_table_separator(&columns));
+    for run in runs {
+        let action_items = run
+            .get("action_items")
+            .and_then(Value::as_array)
+            .map(|items| items.len().to_string())
+            .unwrap_or_else(|| "0".to_string());
+        let values = [
+            json_string_field(&run, "run_id"),
+            json_string_field(&run, "primary_label"),
+            json_string_field(&run, "task"),
+            json_string_field(&run, "task_state"),
+            json_string_field(&run, "review_state"),
+            json_string_field(&run, "state"),
+            json_string_field(&run, "branch"),
+            short_head_sha(&json_string_field(&run, "head_sha")),
+            action_items,
+        ];
+        println!("{}", text_table_value_row(&values, &columns));
+    }
+    Ok(())
+}
+
+fn text_table_row(columns: &[(&str, usize)]) -> String {
     columns
         .iter()
-        .map(|(label, width)| board_table_cell(label, *width))
+        .map(|(label, width)| text_table_cell(label, *width))
         .collect::<Vec<_>>()
         .join("  ")
         .trim_end()
         .to_string()
 }
 
-fn board_table_separator(columns: &[(&str, usize)]) -> String {
+fn text_table_separator(columns: &[(&str, usize)]) -> String {
     columns
         .iter()
         .map(|(_, width)| "-".repeat(*width))
@@ -6029,18 +6078,18 @@ fn board_table_separator(columns: &[(&str, usize)]) -> String {
         .join("  ")
 }
 
-fn board_table_value_row(values: &[String], columns: &[(&str, usize)]) -> String {
+fn text_table_value_row(values: &[String], columns: &[(&str, usize)]) -> String {
     values
         .iter()
         .zip(columns.iter())
-        .map(|(value, (_, width))| board_table_cell(value, *width))
+        .map(|(value, (_, width))| text_table_cell(value, *width))
         .collect::<Vec<_>>()
         .join("  ")
         .trim_end()
         .to_string()
 }
 
-fn board_table_cell(value: &str, width: usize) -> String {
+fn text_table_cell(value: &str, width: usize) -> String {
     let mut text: String = value.chars().take(width).collect();
     let count = text.chars().count();
     if count < width {

--- a/core/tests-rs/operator_cli.rs
+++ b/core/tests-rs/operator_cli.rs
@@ -93,6 +93,32 @@ fn operator_cli_board_text_reads_live_winsmux_manifest() {
 }
 
 #[test]
+fn operator_cli_runs_text_reads_live_winsmux_manifest() {
+    let project_dir = make_temp_project_dir("runs-text");
+    write_manifest(&project_dir);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .arg("runs")
+        .current_dir(&project_dir)
+        .output()
+        .expect("winsmux command should run");
+
+    assert!(
+        output.status.success(),
+        "winsmux command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("RunId"));
+    assert!(stdout.contains("ActionItems"));
+    assert!(stdout.contains("task:TASK-266"));
+    assert!(stdout.contains("builder-1"));
+    assert!(stdout.contains("Add Rust operator read models"));
+    assert!(stdout.contains("pending"));
+    assert!(!stdout.trim_start().starts_with('{'));
+}
+
+#[test]
 fn operator_cli_inbox_digest_runs_and_explain_use_ledger_projections() {
     let project_dir = make_temp_project_dir("read-models");
     write_manifest(&project_dir);
@@ -1988,7 +2014,7 @@ fn operator_cli_read_models_require_json_flag() {
     let project_dir = make_temp_project_dir("requires-json");
     write_manifest(&project_dir);
 
-    for command in ["inbox", "digest", "runs"] {
+    for command in ["inbox", "digest"] {
         let output = Command::new(env!("CARGO_BIN_EXE_winsmux"))
             .arg(command)
             .current_dir(&project_dir)
@@ -2032,6 +2058,19 @@ fn operator_cli_rejects_unknown_and_extra_arguments() {
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
         stderr.contains("usage: winsmux explain"),
+        "unexpected stderr: {stderr}"
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .args(["runs", "extra"])
+        .current_dir(&project_dir)
+        .output()
+        .expect("winsmux command should run");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("usage: winsmux runs [--json]"),
         "unexpected stderr: {stderr}"
     );
 


### PR DESCRIPTION
## Summary
- Add text output for \winsmux runs\ while preserving \winsmux runs --json\.
- Reuse the table renderer shared with \winsmux board\.
- Add coverage for normal text output and stale invalid-argument usage text.

## Review
- Review agent \Socrates\ found stale \uns\ usage text in the invalid-argument path.
- Fixed the finding and added a focused test.

## Validation
- \cargo test --manifest-path core\\Cargo.toml --test operator_cli runs -- --nocapture\`n- \cargo test --manifest-path core\\Cargo.toml --test operator_cli operator_cli_rejects_unknown_and_extra_arguments -- --nocapture\`n- \cargo test --manifest-path core\\Cargo.toml --test operator_cli -- --nocapture\`n- \cargo test --manifest-path core\\Cargo.toml\`n- \git diff --check\`n- \pwsh -NoProfile -File .\\scripts\\git-guard.ps1 -Mode full\`n- \pwsh -NoProfile -File .\\scripts\\audit-public-surface.ps1\`n
## Notes
- External Rust learning note was updated outside the repository.
- Opus review for that external note is blocked by execution policy.