### PR TITLE
[TASK-266] Add Rust inbox text output

### DIFF
--- a/core/src/cli.rs
+++ b/core/src/cli.rs
@@ -129,15 +129,15 @@ CONFIGURATION COMMANDS:
 OPERATOR COMMANDS:
     status --json           Print session, pane, and board summary JSON
     board --json            Print pane, task, review, and git board JSON
-    inbox --json            Print actionable approval and review items JSON
+    inbox                   Print actionable approval and review items
     digest --json           Print high-signal run digest JSON
     desktop-summary         Print desktop summary projection JSON or counts
     provider-capabilities   Inspect the provider capability registry contract
     provider-switch         Record or clear a runtime provider reassignment
     signal <channel>        Send a file-backed orchestration signal
     wait <channel> [secs]   Wait for a file-backed orchestration signal
-    runs --json             Print run-oriented evidence JSON
-    explain <run_id> --json Print one run explanation JSON
+    runs                    Print run-oriented evidence
+    explain <run_id>        Print one run explanation
     compare-runs            Compare two runs and surface evidence deltas
     compare preflight       Run git merge-tree preflight before compare UI
     conflict-preflight      Run git merge-tree preflight before compare UI

--- a/core/src/operator_cli.rs
+++ b/core/src/operator_cli.rs
@@ -67,14 +67,18 @@ pub fn run_board_command(args: &[&String]) -> io::Result<()> {
 
 pub fn run_inbox_command(args: &[&String]) -> io::Result<()> {
     if should_print_help(args) {
-        println!("usage: winsmux inbox --json [--project-dir <path>]");
+        println!("usage: winsmux inbox [--json] [--project-dir <path>]");
         return Ok(());
     }
     let options = parse_options("inbox", args, 0)?;
-    require_json("inbox", &options)?;
 
     let snapshot = load_snapshot(&options.project_dir)?;
-    write_enveloped_json(&options.project_dir, snapshot.inbox_projection())
+    let payload = enveloped_payload(&options.project_dir, snapshot.inbox_projection())?;
+    if options.json {
+        write_json(&payload)
+    } else {
+        print_inbox_table(&payload)
+    }
 }
 
 pub fn run_digest_command(args: &[&String]) -> io::Result<()> {
@@ -2827,7 +2831,7 @@ fn usage_for(command: &str) -> &'static str {
     match command {
         "status" => "usage: winsmux status --json [--project-dir <path>]",
         "board" => "usage: winsmux board [--json] [--project-dir <path>]",
-        "inbox" => "usage: winsmux inbox --json [--project-dir <path>]",
+        "inbox" => "usage: winsmux inbox [--json] [--project-dir <path>]",
         "digest" => "usage: winsmux digest --json [--project-dir <path>]",
         "desktop-summary" => "usage: winsmux desktop-summary [--json] [--stream] [--project-dir <path>]",
         "provider-capabilities" => {
@@ -6011,6 +6015,45 @@ fn print_board_table(payload: &Value) -> io::Result<()> {
             changed,
             json_string_field(&pane, "branch"),
             short_head_sha(&json_string_field(&pane, "head_sha")),
+        ];
+        println!("{}", text_table_value_row(&values, &columns));
+    }
+    Ok(())
+}
+
+fn print_inbox_table(payload: &Value) -> io::Result<()> {
+    let items = payload
+        .get("items")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    if items.is_empty() {
+        println!("(no inbox items)");
+        return Ok(());
+    }
+
+    let columns = [
+        ("Kind", 16usize),
+        ("Label", 14usize),
+        ("PaneId", 8usize),
+        ("Role", 10usize),
+        ("TaskState", 14usize),
+        ("Review", 10usize),
+        ("Branch", 24usize),
+        ("Message", 40usize),
+    ];
+    println!("{}", text_table_row(&columns));
+    println!("{}", text_table_separator(&columns));
+    for item in items {
+        let values = [
+            json_string_field(&item, "kind"),
+            json_string_field(&item, "label"),
+            json_string_field(&item, "pane_id"),
+            json_string_field(&item, "role"),
+            json_string_field(&item, "task_state"),
+            json_string_field(&item, "review_state"),
+            json_string_field(&item, "branch"),
+            json_string_field(&item, "message"),
         ];
         println!("{}", text_table_value_row(&values, &columns));
     }

--- a/core/tests-rs/operator_cli.rs
+++ b/core/tests-rs/operator_cli.rs
@@ -147,6 +147,31 @@ fn operator_cli_explain_text_reads_live_winsmux_manifest() {
 }
 
 #[test]
+fn operator_cli_inbox_text_reads_live_winsmux_manifest() {
+    let project_dir = make_temp_project_dir("inbox-text");
+    write_manifest(&project_dir);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .arg("inbox")
+        .current_dir(&project_dir)
+        .output()
+        .expect("winsmux command should run");
+
+    assert!(
+        output.status.success(),
+        "winsmux command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Kind"));
+    assert!(stdout.contains("Message"));
+    assert!(stdout.contains("review_pending"));
+    assert!(stdout.contains("builder-1"));
+    assert!(stdout.contains("pending"));
+    assert!(!stdout.trim_start().starts_with('{'));
+}
+
+#[test]
 fn operator_cli_inbox_digest_runs_and_explain_use_ledger_projections() {
     let project_dir = make_temp_project_dir("read-models");
     write_manifest(&project_dir);
@@ -2042,7 +2067,7 @@ fn operator_cli_read_models_require_json_flag() {
     let project_dir = make_temp_project_dir("requires-json");
     write_manifest(&project_dir);
 
-    for command in ["inbox", "digest"] {
+    for command in ["digest"] {
         let output = Command::new(env!("CARGO_BIN_EXE_winsmux"))
             .arg(command)
             .current_dir(&project_dir)
@@ -2086,6 +2111,19 @@ fn operator_cli_rejects_unknown_and_extra_arguments() {
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
         stderr.contains("usage: winsmux explain"),
+        "unexpected stderr: {stderr}"
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .args(["inbox", "extra"])
+        .current_dir(&project_dir)
+        .output()
+        .expect("winsmux command should run");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("usage: winsmux inbox [--json]"),
         "unexpected stderr: {stderr}"
     );
 


### PR DESCRIPTION
## Summary
- Add text output for \winsmux inbox\ while preserving \winsmux inbox --json\.
- Print actionable inbox items as a table for operator use.
- Align top-level help text for commands that now have non-JSON output.

## Review
- Review agent \Euclid\ found stale top-level help text for \inbox\.
- Fixed the finding and aligned \uns\ and \xplain\ help wording as part of the same public help surface.

## Validation
- \cargo test --manifest-path core\\Cargo.toml --test operator_cli inbox -- --nocapture\`n- \cargo test --manifest-path core\\Cargo.toml --test operator_cli operator_cli_rejects_unknown_and_extra_arguments -- --nocapture\`n- \cargo test --manifest-path core\\Cargo.toml help_text_uses_winsmux_operator_wording -- --nocapture\`n- \cargo test --manifest-path core\\Cargo.toml --test operator_cli -- --nocapture\`n- \cargo test --manifest-path core\\Cargo.toml\`n- \git diff --check\`n- \pwsh -NoProfile -File .\\scripts\\git-guard.ps1 -Mode full\`n- \pwsh -NoProfile -File .\\scripts\\audit-public-surface.ps1\`n
## Notes
- External Rust learning note was updated outside the repository.
- Opus review for that external note remains blocked by execution policy.