### PR TITLE
[TASK-266] Add Rust digest text output

### DIFF
--- a/core/src/cli.rs
+++ b/core/src/cli.rs
@@ -130,7 +130,7 @@ OPERATOR COMMANDS:
     status --json           Print session, pane, and board summary JSON
     board --json            Print pane, task, review, and git board JSON
     inbox                   Print actionable approval and review items
-    digest --json           Print high-signal run digest JSON
+    digest                  Print high-signal run digest
     desktop-summary         Print desktop summary projection JSON or counts
     provider-capabilities   Inspect the provider capability registry contract
     provider-switch         Record or clear a runtime provider reassignment

--- a/core/src/operator_cli.rs
+++ b/core/src/operator_cli.rs
@@ -83,14 +83,18 @@ pub fn run_inbox_command(args: &[&String]) -> io::Result<()> {
 
 pub fn run_digest_command(args: &[&String]) -> io::Result<()> {
     if should_print_help(args) {
-        println!("usage: winsmux digest --json [--project-dir <path>]");
+        println!("usage: winsmux digest [--json] [--project-dir <path>]");
         return Ok(());
     }
     let options = parse_options("digest", args, 0)?;
-    require_json("digest", &options)?;
 
     let snapshot = load_snapshot(&options.project_dir)?;
-    write_enveloped_json(&options.project_dir, snapshot.digest_projection())
+    let payload = enveloped_payload(&options.project_dir, snapshot.digest_projection())?;
+    if options.json {
+        write_json(&payload)
+    } else {
+        print_digest_text(&payload)
+    }
 }
 
 pub fn run_desktop_summary_command(args: &[&String]) -> io::Result<()> {
@@ -2832,7 +2836,7 @@ fn usage_for(command: &str) -> &'static str {
         "status" => "usage: winsmux status --json [--project-dir <path>]",
         "board" => "usage: winsmux board [--json] [--project-dir <path>]",
         "inbox" => "usage: winsmux inbox [--json] [--project-dir <path>]",
-        "digest" => "usage: winsmux digest --json [--project-dir <path>]",
+        "digest" => "usage: winsmux digest [--json] [--project-dir <path>]",
         "desktop-summary" => "usage: winsmux desktop-summary [--json] [--stream] [--project-dir <path>]",
         "provider-capabilities" => {
             "usage: winsmux provider-capabilities [provider] [--json] [--project-dir <path>]"
@@ -6057,6 +6061,63 @@ fn print_inbox_table(payload: &Value) -> io::Result<()> {
         ];
         println!("{}", text_table_value_row(&values, &columns));
     }
+    Ok(())
+}
+
+fn print_digest_text(payload: &Value) -> io::Result<()> {
+    let items = payload
+        .get("items")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    if items.is_empty() {
+        println!("(no digest items)");
+        return Ok(());
+    }
+
+    for item in items {
+        println!("Run: {}", json_string_field(&item, "run_id"));
+        println!(
+            "Primary: {} ({})",
+            json_string_field(&item, "label"),
+            json_string_field(&item, "pane_id")
+        );
+        let task = json_string_field(&item, "task");
+        if !task.trim().is_empty() {
+            println!("Task: {task}");
+        }
+        println!(
+            "State: {} / {}",
+            json_string_field(&item, "task_state"),
+            json_string_field(&item, "review_state")
+        );
+        println!("Next: {}", json_string_field(&item, "next_action"));
+        let branch = json_string_field(&item, "branch");
+        if !branch.trim().is_empty() {
+            println!("Git: {} @ {}", branch, json_string_field(&item, "head_short"));
+        }
+
+        let changed_file_count = item
+            .get("changed_file_count")
+            .and_then(Value::as_u64)
+            .unwrap_or(0);
+        if changed_file_count > 0 {
+            println!("Changed files ({changed_file_count}):");
+            for changed_file in item
+                .get("changed_files")
+                .and_then(Value::as_array)
+                .into_iter()
+                .flatten()
+                .filter_map(Value::as_str)
+            {
+                println!("- {changed_file}");
+            }
+        } else {
+            println!("Changed files: (none)");
+        }
+        println!();
+    }
+
     Ok(())
 }
 

--- a/core/tests-rs/operator_cli.rs
+++ b/core/tests-rs/operator_cli.rs
@@ -172,6 +172,34 @@ fn operator_cli_inbox_text_reads_live_winsmux_manifest() {
 }
 
 #[test]
+fn operator_cli_digest_text_reads_live_winsmux_manifest() {
+    let project_dir = make_temp_project_dir("digest-text");
+    write_manifest(&project_dir);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .arg("digest")
+        .current_dir(&project_dir)
+        .output()
+        .expect("winsmux command should run");
+
+    assert!(
+        output.status.success(),
+        "winsmux command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Run: task:TASK-266"));
+    assert!(stdout.contains("Primary: builder-1 (%2)"));
+    assert!(stdout.contains("Task: Add Rust operator read models"));
+    assert!(stdout.contains("State: in_progress / pending"));
+    assert!(stdout.contains("Next: commit_ready"));
+    assert!(stdout.contains("Git: codex/task266-rust-operator-readmodels-20260424 @ abc123"));
+    assert!(stdout.contains("Changed files (2):"));
+    assert!(stdout.contains("- core/src/operator_cli.rs"));
+    assert!(!stdout.trim_start().starts_with('{'));
+}
+
+#[test]
 fn operator_cli_inbox_digest_runs_and_explain_use_ledger_projections() {
     let project_dir = make_temp_project_dir("read-models");
     write_manifest(&project_dir);
@@ -2063,27 +2091,6 @@ fn operator_cli_accepts_project_dir_argument() {
 }
 
 #[test]
-fn operator_cli_read_models_require_json_flag() {
-    let project_dir = make_temp_project_dir("requires-json");
-    write_manifest(&project_dir);
-
-    for command in ["digest"] {
-        let output = Command::new(env!("CARGO_BIN_EXE_winsmux"))
-            .arg(command)
-            .current_dir(&project_dir)
-            .output()
-            .expect("winsmux command should run");
-
-        assert!(!output.status.success());
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        assert!(
-            stderr.contains("currently supports only --json"),
-            "unexpected stderr for {command}: {stderr}"
-        );
-    }
-}
-
-#[test]
 fn operator_cli_rejects_unknown_and_extra_arguments() {
     let project_dir = make_temp_project_dir("invalid-args");
     write_manifest(&project_dir);
@@ -2124,6 +2131,19 @@ fn operator_cli_rejects_unknown_and_extra_arguments() {
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
         stderr.contains("usage: winsmux inbox [--json]"),
+        "unexpected stderr: {stderr}"
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .args(["digest", "extra"])
+        .current_dir(&project_dir)
+        .output()
+        .expect("winsmux command should run");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("usage: winsmux digest [--json]"),
         "unexpected stderr: {stderr}"
     );
 


### PR DESCRIPTION
## Summary
- add human-readable text output for winsmux digest
- preserve winsmux digest --json payload behavior
- update help and invalid-argument coverage

## Validation
- cargo test --manifest-path core\\Cargo.toml --test operator_cli -- --nocapture
- cargo test --manifest-path core\\Cargo.toml
- git diff --check
- pwsh -NoProfile -File .\\scripts\\git-guard.ps1 -Mode full
- pwsh -NoProfile -File .\\scripts\\audit-public-surface.ps1

## Review
- subagent review: no findings

Task: TASK-266