### PR TITLE
[TASK-266] Add compare runs public alias

### DIFF
--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -262,6 +262,9 @@ fn run_main() -> io::Result<()> {
         "runs" => return operator_cli::run_runs_command(&cmd_args[1..]),
         "explain" => return operator_cli::run_explain_command(&cmd_args[1..]),
         "compare-runs" => return operator_cli::run_compare_runs_command(&cmd_args[1..]),
+        "compare" if matches!(cmd_args.get(1).map(|arg| arg.as_str()), Some("runs")) => {
+            return operator_cli::run_compare_runs_public_command(&cmd_args[2..])
+        }
         "compare" if matches!(cmd_args.get(1).map(|arg| arg.as_str()), Some("preflight")) => {
             return operator_cli::run_compare_preflight_command(&cmd_args[2..])
         }

--- a/core/src/operator_cli.rs
+++ b/core/src/operator_cli.rs
@@ -1747,11 +1747,19 @@ fn run_conflict_preflight(args: &[&String], compare_alias: bool) -> io::Result<(
 }
 
 pub fn run_compare_runs_command(args: &[&String]) -> io::Result<()> {
+    run_compare_runs_with_usage("compare-runs", args)
+}
+
+pub fn run_compare_runs_public_command(args: &[&String]) -> io::Result<()> {
+    run_compare_runs_with_usage("compare runs", args)
+}
+
+fn run_compare_runs_with_usage(command_name: &str, args: &[&String]) -> io::Result<()> {
     if should_print_help(args) {
-        println!("{}", usage_for("compare-runs"));
+        println!("{}", usage_for(command_name));
         return Ok(());
     }
-    let options = parse_options("compare-runs", args, 2)?;
+    let options = parse_options(command_name, args, 2)?;
 
     let snapshot = load_snapshot(&options.project_dir)?;
     let left_id = options.positionals[0].clone();
@@ -2850,6 +2858,9 @@ fn usage_for(command: &str) -> &'static str {
         "explain" => "usage: winsmux explain <run_id> [--json] [--project-dir <path>]",
         "compare-runs" => {
             "usage: winsmux compare-runs <left_run_id> <right_run_id> [--json] [--project-dir <path>]"
+        }
+        "compare runs" => {
+            "usage: winsmux compare runs <left_run_id> <right_run_id> [--json] [--project-dir <path>]"
         }
         "conflict-preflight" => {
             "usage: winsmux conflict-preflight <left_ref> <right_ref> [--json]"

--- a/core/tests-rs/operator_cli.rs
+++ b/core/tests-rs/operator_cli.rs
@@ -1444,6 +1444,51 @@ fn operator_cli_compare_runs_json_reports_evidence_delta() {
 }
 
 #[test]
+fn operator_cli_compare_runs_public_alias_reports_evidence_delta() {
+    let project_dir = make_temp_project_dir("compare-runs-alias");
+    write_compare_runs_fixture(&project_dir);
+
+    let json = run_json(
+        &project_dir,
+        &["compare", "runs", "task:task-a", "task:task-b", "--json"],
+    );
+
+    assert_eq!(json["left"]["run_id"], "task:task-a");
+    assert_eq!(json["right"]["run_id"], "task:task-b");
+    assert_eq!(json["confidence_delta"], 0.25);
+    assert_eq!(json["recommend"]["winning_run_id"], "task:task-a");
+}
+
+#[test]
+fn operator_cli_compare_runs_public_alias_reports_public_usage() {
+    let project_dir = make_temp_project_dir("compare-runs-alias-usage");
+    write_compare_runs_fixture(&project_dir);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .args(["compare", "runs", "--help"])
+        .current_dir(&project_dir)
+        .output()
+        .expect("winsmux command should run");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("usage: winsmux compare runs"));
+
+    let output = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .args(["compare", "runs", "task:task-a"])
+        .current_dir(&project_dir)
+        .output()
+        .expect("winsmux command should run");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("usage: winsmux compare runs"),
+        "unexpected stderr: {stderr}"
+    );
+}
+
+#[test]
 fn operator_cli_compare_runs_text_reports_differences() {
     let project_dir = make_temp_project_dir("compare-runs-text");
     write_compare_runs_fixture(&project_dir);


### PR DESCRIPTION
## Summary
- route public winsmux compare runs to the Rust compare-runs implementation
- keep the legacy compare-runs entrypoint intact
- return public usage text for compare runs help and argument errors

## Validation
- cargo test --manifest-path core\\Cargo.toml --test operator_cli compare_runs -- --nocapture
- cargo test --manifest-path core\\Cargo.toml --test operator_cli -- --nocapture
- cargo test --manifest-path core\\Cargo.toml
- git diff --check
- pwsh -NoProfile -File .\\scripts\\git-guard.ps1 -Mode full
- pwsh -NoProfile -File .\\scripts\\audit-public-surface.ps1

## Review
- Hubble: found public usage text mismatch; fixed
- Sagan: no findings after fix

Task: TASK-266