### PR TITLE
[TASK-266] Add compare promote public alias

### DIFF
--- a/core/src/cli.rs
+++ b/core/src/cli.rs
@@ -139,6 +139,7 @@ OPERATOR COMMANDS:
     runs                    Print run-oriented evidence
     explain <run_id>        Print one run explanation
     compare-runs            Compare two runs and surface evidence deltas
+    compare promote         Export a reusable tactic candidate from a run
     compare preflight       Run git merge-tree preflight before compare UI
     conflict-preflight      Run git merge-tree preflight before compare UI
     promote-tactic          Export a reusable tactic candidate from a run

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -268,6 +268,9 @@ fn run_main() -> io::Result<()> {
         "compare" if matches!(cmd_args.get(1).map(|arg| arg.as_str()), Some("preflight")) => {
             return operator_cli::run_compare_preflight_command(&cmd_args[2..])
         }
+        "compare" if matches!(cmd_args.get(1).map(|arg| arg.as_str()), Some("promote")) => {
+            return operator_cli::run_compare_promote_command(&cmd_args[2..])
+        }
         "conflict-preflight" => {
             return operator_cli::run_conflict_preflight_command(&cmd_args[1..])
         }

--- a/core/src/operator_cli.rs
+++ b/core/src/operator_cli.rs
@@ -1825,11 +1825,19 @@ fn run_compare_runs_with_usage(command_name: &str, args: &[&String]) -> io::Resu
 }
 
 pub fn run_promote_tactic_command(args: &[&String]) -> io::Result<()> {
+    run_promote_tactic_with_usage("promote-tactic", args)
+}
+
+pub fn run_compare_promote_command(args: &[&String]) -> io::Result<()> {
+    run_promote_tactic_with_usage("compare promote", args)
+}
+
+fn run_promote_tactic_with_usage(command_name: &'static str, args: &[&String]) -> io::Result<()> {
     if should_print_help(args) {
-        println!("{}", usage_for("promote-tactic"));
+        println!("{}", usage_for(command_name));
         return Ok(());
     }
-    let options = parse_promote_tactic_options(args)?;
+    let options = parse_promote_tactic_options(command_name, args)?;
     let run_id = options.positionals[0].clone();
     if !matches!(
         options.kind.as_str(),
@@ -2363,7 +2371,10 @@ fn parse_poll_events_options(args: &[&String]) -> io::Result<ParsedOptions> {
     })
 }
 
-fn parse_promote_tactic_options(args: &[&String]) -> io::Result<PromoteTacticOptions> {
+fn parse_promote_tactic_options(
+    command_name: &'static str,
+    args: &[&String],
+) -> io::Result<PromoteTacticOptions> {
     let mut json = false;
     let mut project_dir = None;
     let mut positionals = Vec::new();
@@ -2411,7 +2422,7 @@ fn parse_promote_tactic_options(args: &[&String]) -> io::Result<PromoteTacticOpt
             value if value.starts_with('-') => {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidInput,
-                    format!("unknown argument for winsmux promote-tactic: {value}"),
+                    format!("unknown argument for winsmux {command_name}: {value}"),
                 ));
             }
             value => {
@@ -2424,7 +2435,7 @@ fn parse_promote_tactic_options(args: &[&String]) -> io::Result<PromoteTacticOpt
     if positionals.len() != 1 {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
-            usage_for("promote-tactic").to_string(),
+            usage_for(command_name).to_string(),
         ));
     }
 
@@ -2867,6 +2878,9 @@ fn usage_for(command: &str) -> &'static str {
         }
         "compare-preflight" => {
             "usage: winsmux compare preflight <left_ref> <right_ref> [--json]"
+        }
+        "compare promote" => {
+            "usage: winsmux compare promote <run_id> [--title <text>] [--kind <playbook|prewarm|verification>] [--json] [--project-dir <path>]"
         }
         "promote-tactic" => {
             "usage: winsmux promote-tactic <run_id> [--title <text>] [--kind <playbook|prewarm|verification>] [--json] [--project-dir <path>]"

--- a/core/tests-rs/operator_cli.rs
+++ b/core/tests-rs/operator_cli.rs
@@ -1584,6 +1584,63 @@ fn operator_cli_promote_tactic_writes_playbook_candidate() {
 }
 
 #[test]
+fn operator_cli_compare_promote_alias_writes_playbook_candidate() {
+    let project_dir = make_temp_project_dir("compare-promote-alias");
+    write_compare_runs_fixture(&project_dir);
+
+    let json = run_json(
+        &project_dir,
+        &[
+            "compare",
+            "promote",
+            "task:task-a",
+            "--title",
+            "Deterministic build command",
+            "--json",
+        ],
+    );
+
+    assert_eq!(json["run_id"], "task:task-a");
+    assert!(json["candidate_ref"]
+        .as_str()
+        .expect("candidate ref should be a string")
+        .starts_with(".winsmux/playbook-candidates/playbook-candidate-"));
+    assert_eq!(json["candidate"]["packet_type"], "playbook_candidate");
+    assert_eq!(json["candidate"]["kind"], "playbook");
+    assert_eq!(json["candidate"]["title"], "Deterministic build command");
+    assert_eq!(json["candidate"]["summary"], "prefer cache command");
+}
+
+#[test]
+fn operator_cli_compare_promote_alias_reports_public_usage() {
+    let project_dir = make_temp_project_dir("compare-promote-alias-usage");
+    write_compare_runs_fixture(&project_dir);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .args(["compare", "promote", "--help"])
+        .current_dir(&project_dir)
+        .output()
+        .expect("winsmux command should run");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("usage: winsmux compare promote"));
+
+    let output = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .args(["compare", "promote"])
+        .current_dir(&project_dir)
+        .output()
+        .expect("winsmux command should run");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("usage: winsmux compare promote"),
+        "unexpected stderr: {stderr}"
+    );
+}
+
+#[test]
 fn operator_cli_promote_tactic_rejects_unhealthy_run() {
     let project_dir = make_temp_project_dir("promote-tactic-unhealthy");
     write_compare_runs_fixture(&project_dir);


### PR DESCRIPTION
## Summary
- add public Rust route for winsmux compare promote
- reuse the existing promote-tactic implementation
- add alias-specific usage and error text tests

## Validation
- cargo test --manifest-path core\\Cargo.toml --test operator_cli compare_promote -- --nocapture
- cargo test --manifest-path core\\Cargo.toml --test operator_cli promote_tactic -- --nocapture
- cargo test --manifest-path core\\Cargo.toml --test operator_cli -- --nocapture
- cargo test --manifest-path core\\Cargo.toml
- git diff --check
- pwsh -NoProfile -File .\\scripts\\git-guard.ps1 -Mode full
- pwsh -NoProfile -File .\\scripts\\audit-public-surface.ps1

Review agent Hypatia reported no findings.