### PR TITLE
Add Rust dispatch-review operator command

### DIFF
--- a/core/src/cli.rs
+++ b/core/src/cli.rs
@@ -147,6 +147,7 @@ OPERATOR COMMANDS:
     consult-result          Record a consultation result packet and event
     consult-error           Record a consultation error packet and event
     poll-events             Return new monitor events from .winsmux/events.jsonl
+    dispatch-review         Send review-request to a review-capable pane
     review-request          Record a pending review request for the current branch
     review-approve          Record PASS for the pending review request
     review-fail             Record FAIL for the pending review request

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -279,6 +279,7 @@ fn run_main() -> io::Result<()> {
         "consult-result" => return operator_cli::run_consult_result_command(&cmd_args[1..]),
         "consult-error" => return operator_cli::run_consult_error_command(&cmd_args[1..]),
         "poll-events" => return operator_cli::run_poll_events_command(&cmd_args[1..]),
+        "dispatch-review" => return operator_cli::run_dispatch_review_command(&cmd_args[1..]),
         "review-request" => return operator_cli::run_review_request_command(&cmd_args[1..]),
         "review-approve" => return operator_cli::run_review_approve_command(&cmd_args[1..]),
         "review-fail" => return operator_cli::run_review_fail_command(&cmd_args[1..]),

--- a/core/src/operator_cli.rs
+++ b/core/src/operator_cli.rs
@@ -2092,6 +2092,53 @@ pub fn run_review_request_command(args: &[&String]) -> io::Result<()> {
     Ok(())
 }
 
+pub fn run_dispatch_review_command(args: &[&String]) -> io::Result<()> {
+    if should_print_help(args) {
+        println!("{}", usage_for("dispatch-review"));
+        return Ok(());
+    }
+    if !args.is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            usage_for("dispatch-review"),
+        ));
+    }
+    assert_dispatch_review_role_permission("dispatch-review")?;
+
+    let project_dir = env::current_dir()?;
+    let branch = current_git_branch(&project_dir)?;
+    let head_sha = current_git_head(&project_dir)?;
+    let context = preferred_review_pane_context(&project_dir)?;
+    let short_head = short_head_sha(&head_sha);
+    println!(
+        "Dispatching review to {} [{}] for branch {} ({})",
+        context.label, context.pane_id, branch, short_head
+    );
+
+    send_review_request_to_pane(&context.pane_id)?;
+    println!(
+        "review-request sent to {}. Waiting for PENDING state...",
+        context.label
+    );
+
+    if !wait_for_pending_review_state(&project_dir, &branch, &head_sha)? {
+        return Err(io::Error::new(
+            io::ErrorKind::TimedOut,
+            format!(
+                "review-request was not recorded after {} attempts. Check review pane {}.",
+                dispatch_review_poll_attempts(),
+                context.pane_id
+            ),
+        ));
+    }
+
+    println!(
+        "PENDING confirmed. {} pane will run review-approve or review-fail. Monitor review-state.json for result.",
+        context.role
+    );
+    Ok(())
+}
+
 pub fn run_review_approve_command(args: &[&String]) -> io::Result<()> {
     record_review_result(
         args,
@@ -2966,6 +3013,7 @@ fn usage_for(command: &str) -> &'static str {
             "usage: winsmux consult-error <early|stuck|reconcile|final> [--message <text>] [--target-slot <slot>] [--project-dir <path>]"
         }
         "poll-events" => "usage: winsmux poll-events [cursor] [--project-dir <path>]",
+        "dispatch-review" => "usage: winsmux dispatch-review",
         "review-reset" => "usage: winsmux review-reset [--project-dir <path>]",
         "review-request" => "usage: winsmux review-request [--project-dir <path>]",
         "review-approve" => "usage: winsmux review-approve [--project-dir <path>]",
@@ -3162,6 +3210,40 @@ fn assert_consult_role_permission(command_name: &str) -> io::Result<()> {
     Ok(())
 }
 
+fn assert_dispatch_review_role_permission(command_name: &str) -> io::Result<()> {
+    let role = current_canonical_role()?;
+    if role != "Operator" {
+        return Err(review_permission_error(command_name));
+    }
+
+    let role_map = role_map_from_env()?;
+    if role_map.is_empty() {
+        return Ok(());
+    }
+
+    let pane_id = env::var("WINSMUX_PANE_ID")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "WINSMUX_PANE_ID not set"))?;
+    let Some(mapped_role) = role_map
+        .get(&pane_id)
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_string)
+    else {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("WINSMUX_ROLE_MAP missing entry for pane {pane_id}"),
+        ));
+    };
+    if mapped_role != role {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("WINSMUX_ROLE mismatch for pane {pane_id}: expected {mapped_role}, got {role}"),
+        ));
+    }
+    Ok(())
+}
+
 fn current_canonical_role() -> io::Result<String> {
     let raw = env::var("WINSMUX_ROLE")
         .ok()
@@ -3294,6 +3376,17 @@ fn current_review_pane_context(project_dir: &Path) -> io::Result<ReviewPaneConte
         ));
     };
     Ok(context)
+}
+
+fn preferred_review_pane_context(project_dir: &Path) -> io::Result<ReviewPaneContext> {
+    let manifest_path = project_dir.join(".winsmux").join("manifest.yaml");
+    let manifest = load_manifest_yaml(&manifest_path)?;
+    find_preferred_review_pane_context(&manifest).ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::NotFound,
+            "No review-capable pane found in manifest.",
+        )
+    })
 }
 
 fn consultation_command_context(
@@ -3457,6 +3550,40 @@ fn find_review_pane_context(
     }
 }
 
+fn find_preferred_review_pane_context(manifest: &serde_yaml::Value) -> Option<ReviewPaneContext> {
+    let contexts = review_pane_contexts(manifest);
+    for preferred_role in ["Reviewer", "Worker"] {
+        if let Some(context) = contexts
+            .iter()
+            .find(|context| context.role == preferred_role)
+            .cloned()
+        {
+            return Some(context);
+        }
+    }
+    None
+}
+
+fn review_pane_contexts(manifest: &serde_yaml::Value) -> Vec<ReviewPaneContext> {
+    let Some(panes) = manifest.get("panes") else {
+        return Vec::new();
+    };
+    match panes {
+        serde_yaml::Value::Mapping(map) => map
+            .iter()
+            .filter_map(|(key, pane)| {
+                let label = key.as_str().unwrap_or_default();
+                review_pane_context_from_value(label, "", pane)
+            })
+            .collect(),
+        serde_yaml::Value::Sequence(items) => items
+            .iter()
+            .filter_map(|pane| review_pane_context_from_value("", "", pane))
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
 fn review_pane_context_from_value(
     fallback_label: &str,
     pane_id: &str,
@@ -3464,7 +3591,10 @@ fn review_pane_context_from_value(
 ) -> Option<ReviewPaneContext> {
     let map = pane.as_mapping()?;
     let actual = manifest_string(map, "pane_id");
-    if actual != pane_id {
+    if actual.trim().is_empty() {
+        return None;
+    }
+    if !pane_id.is_empty() && actual != pane_id {
         return None;
     }
     let role = manifest_string(map, "role");
@@ -3478,6 +3608,89 @@ fn review_pane_context_from_value(
         pane_id: actual,
         role: canonical_role.unwrap_or_default(),
     })
+}
+
+fn send_review_request_to_pane(pane_id: &str) -> io::Result<()> {
+    let command_text = "winsmux review-request";
+    let pre_send_text = capture_pane_tail(pane_id)?;
+    run_winsmux_command(&["send-keys", "-t", pane_id, "-l", "--", command_text])?;
+    thread::sleep(Duration::from_millis(300));
+    let typed_text = capture_pane_tail(pane_id)?;
+    if typed_text == pre_send_text {
+        return Err(io::Error::new(
+            io::ErrorKind::Other,
+            format!("pane buffer did not change after typing review request into {pane_id}"),
+        ));
+    }
+    if !typed_text.contains(command_text) {
+        return Err(io::Error::new(
+            io::ErrorKind::Other,
+            format!("typed review request was not observed in {pane_id}"),
+        ));
+    }
+    run_winsmux_command(&["send-keys", "-t", pane_id, "Enter"])
+}
+
+fn wait_for_pending_review_state(
+    project_dir: &Path,
+    branch: &str,
+    head_sha: &str,
+) -> io::Result<bool> {
+    let attempts = dispatch_review_poll_attempts();
+    for attempt in 0..=attempts {
+        let state = load_review_state(project_dir)?;
+        if review_state_is_pending_for_head(&state, branch, head_sha) {
+            return Ok(true);
+        }
+        if attempt < attempts {
+            thread::sleep(dispatch_review_poll_delay());
+        }
+    }
+    Ok(false)
+}
+
+fn dispatch_review_poll_attempts() -> usize {
+    env::var("WINSMUX_DISPATCH_REVIEW_POLL_ATTEMPTS")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(10)
+}
+
+fn dispatch_review_poll_delay() -> Duration {
+    env::var("WINSMUX_DISPATCH_REVIEW_POLL_INTERVAL_MS")
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .map(Duration::from_millis)
+        .unwrap_or_else(|| Duration::from_secs(3))
+}
+
+fn review_state_is_pending_for_head(
+    state: &Map<String, Value>,
+    branch: &str,
+    head_sha: &str,
+) -> bool {
+    let Some(record) = state.get(branch) else {
+        return false;
+    };
+    let status_matches = record
+        .get("status")
+        .and_then(Value::as_str)
+        .map(|status| status == "PENDING")
+        .unwrap_or(false);
+    if !status_matches {
+        return false;
+    }
+    let record_head = record
+        .get("head_sha")
+        .and_then(Value::as_str)
+        .or_else(|| {
+            record
+                .get("request")
+                .and_then(|request| request.get("head_sha"))
+                .and_then(Value::as_str)
+        })
+        .unwrap_or_default();
+    record_head == head_sha
 }
 
 fn canonical_manifest_role(role: &str, label: &str) -> Option<String> {

--- a/core/tests-rs/operator_cli.rs
+++ b/core/tests-rs/operator_cli.rs
@@ -2566,6 +2566,134 @@ fn operator_cli_review_request_records_pending_state_and_manifest_pane() {
 }
 
 #[test]
+fn operator_cli_dispatch_review_sends_review_request_to_preferred_pane() {
+    let project_dir = make_temp_project_dir("dispatch-review");
+    write_manifest(&project_dir);
+    init_git_branch(
+        &project_dir,
+        "codex/task266-rust-operator-readmodels-20260424",
+    );
+    set_git_head(
+        &project_dir,
+        "codex/task266-rust-operator-readmodels-20260424",
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    );
+    write_review_state(
+        &project_dir,
+        r#"{
+  "codex/task266-rust-operator-readmodels-20260424": {
+    "status": "PENDING",
+    "branch": "codex/task266-rust-operator-readmodels-20260424",
+    "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  }
+}"#,
+    );
+    let (winsmux_bin, log_path) = write_fake_winsmux_dispatch_review(&project_dir);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .arg("dispatch-review")
+        .env("WINSMUX_BIN", winsmux_bin)
+        .env("WINSMUX_PANE_ID", "%1")
+        .env("WINSMUX_ROLE", "Operator")
+        .env("WINSMUX_ROLE_MAP", r#"{"%1":"Operator"}"#)
+        .env("WINSMUX_DISPATCH_REVIEW_POLL_ATTEMPTS", "0")
+        .current_dir(&project_dir)
+        .output()
+        .expect("winsmux command should run");
+
+    assert!(
+        output.status.success(),
+        "winsmux command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Dispatching review to reviewer-1 [%3]"),
+        "unexpected stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("PENDING confirmed. Reviewer pane will run review-approve or review-fail."),
+        "unexpected stdout: {stdout}"
+    );
+
+    let log = fs::read_to_string(log_path).expect("test should read fake winsmux log");
+    assert!(
+        log.contains("send-keys") && log.contains("%3") && log.contains("winsmux review-request"),
+        "unexpected fake winsmux log: {log}"
+    );
+    assert!(
+        log.contains("send-keys") && log.contains("%3") && log.contains("Enter"),
+        "unexpected fake winsmux log: {log}"
+    );
+}
+
+#[test]
+fn operator_cli_dispatch_review_rejects_stale_pending_review_state() {
+    let project_dir = make_temp_project_dir("dispatch-review-stale");
+    write_manifest(&project_dir);
+    init_git_branch(
+        &project_dir,
+        "codex/task266-rust-operator-readmodels-20260424",
+    );
+    set_git_head(
+        &project_dir,
+        "codex/task266-rust-operator-readmodels-20260424",
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    );
+    write_review_state(
+        &project_dir,
+        r#"{
+  "codex/task266-rust-operator-readmodels-20260424": {
+    "status": "PENDING",
+    "branch": "codex/task266-rust-operator-readmodels-20260424",
+    "head_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+  }
+}"#,
+    );
+    let (winsmux_bin, _log_path) = write_fake_winsmux_dispatch_review(&project_dir);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .arg("dispatch-review")
+        .env("WINSMUX_BIN", winsmux_bin)
+        .env("WINSMUX_PANE_ID", "%1")
+        .env("WINSMUX_ROLE", "Operator")
+        .env("WINSMUX_ROLE_MAP", r#"{"%1":"Operator"}"#)
+        .env("WINSMUX_DISPATCH_REVIEW_POLL_ATTEMPTS", "0")
+        .current_dir(&project_dir)
+        .output()
+        .expect("winsmux command should run");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("review-request was not recorded after 0 attempts"),
+        "unexpected stderr: {stderr}"
+    );
+}
+
+#[test]
+fn operator_cli_dispatch_review_rejects_non_operator_role() {
+    let project_dir = make_temp_project_dir("dispatch-review-role");
+    write_manifest(&project_dir);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .arg("dispatch-review")
+        .env("WINSMUX_PANE_ID", "%2")
+        .env("WINSMUX_ROLE", "Worker")
+        .env("WINSMUX_ROLE_MAP", r#"{"%2":"Worker"}"#)
+        .current_dir(&project_dir)
+        .output()
+        .expect("winsmux command should run");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("dispatch-review is not permitted for the current role"),
+        "unexpected stderr: {stderr}"
+    );
+}
+
+#[test]
 fn operator_cli_review_request_rejects_non_review_capable_pane() {
     let project_dir = make_temp_project_dir("review-request-builder");
     write_manifest(&project_dir);
@@ -3312,6 +3440,68 @@ fn strip_windows_extended_path_prefix(path: &str) -> String {
         return rest.to_string();
     }
     path.to_string()
+}
+
+fn write_fake_winsmux_dispatch_review(
+    project_dir: &std::path::Path,
+) -> (std::path::PathBuf, std::path::PathBuf) {
+    let fake_dir = project_dir.join(".test-bin");
+    fs::create_dir_all(&fake_dir).expect("test should create fake bin dir");
+    let log_path = fake_dir.join("winsmux-dispatch-review.log");
+    #[cfg(windows)]
+    {
+        let fake_path = fake_dir.join("winsmux-dispatch-review-fake.cmd");
+        let mut body = String::from("@echo off\r\n");
+        body.push_str("echo %*>>\"");
+        body.push_str(&log_path.to_string_lossy());
+        body.push_str("\"\r\n");
+        body.push_str("if \"%1\"==\"capture-pane\" (\r\n");
+        body.push_str("  findstr /c:\"winsmux review-request\" \"");
+        body.push_str(&log_path.to_string_lossy());
+        body.push_str("\" >nul 2>nul\r\n");
+        body.push_str("  if errorlevel 1 (\r\n");
+        body.push_str("    echo PS C:\\repo^>\r\n");
+        body.push_str("  ) else (\r\n");
+        body.push_str("    echo PS C:\\repo^> winsmux review-request\r\n");
+        body.push_str("  )\r\n");
+        body.push_str("  exit /b 0\r\n)\r\n");
+        body.push_str("if \"%1\"==\"send-keys\" exit /b 0\r\n");
+        body.push_str("exit /b 1\r\n");
+        fs::write(&fake_path, body).expect("test should write fake winsmux");
+        (fake_path, log_path)
+    }
+    #[cfg(not(windows))]
+    {
+        let fake_path = fake_dir.join("winsmux-dispatch-review-fake");
+        let mut body = String::from("#!/bin/sh\n");
+        body.push_str("printf '%s\\n' \"$*\" >> '");
+        body.push_str(&log_path.to_string_lossy());
+        body.push_str("'\n");
+        body.push_str("if [ \"$1\" = \"capture-pane\" ]; then\n");
+        body.push_str("  if grep -q 'winsmux review-request' '");
+        body.push_str(&log_path.to_string_lossy());
+        body.push_str("'; then\n");
+        body.push_str("    printf '%s\\n' 'PS /repo> winsmux review-request'\n");
+        body.push_str("  else\n");
+        body.push_str("    printf '%s\\n' 'PS /repo>'\n");
+        body.push_str("  fi\n");
+        body.push_str("  exit 0\n");
+        body.push_str("fi\n");
+        body.push_str("if [ \"$1\" = \"send-keys\" ]; then\n  exit 0\nfi\n");
+        body.push_str("exit 1\n");
+        fs::write(&fake_path, body).expect("test should write fake winsmux");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut permissions = fs::metadata(&fake_path)
+                .expect("test should read fake winsmux metadata")
+                .permissions();
+            permissions.set_mode(0o755);
+            fs::set_permissions(&fake_path, permissions)
+                .expect("test should make fake winsmux executable");
+        }
+        (fake_path, log_path)
+    }
 }
 
 fn write_fake_winsmux_list_panes(


### PR DESCRIPTION
## Summary
- Add the Rust winsmux dispatch-review operator command.
- Select a review-capable pane, send winsmux review-request, and confirm the typed command via capture-pane before pressing Enter.
- Require the Operator role and confirm PENDING review state for the current head_sha.

## Validation
- cargo test --manifest-path core\Cargo.toml --test operator_cli dispatch_review -- --nocapture
- cargo test --manifest-path core\Cargo.toml --test operator_cli review -- --nocapture
- git diff --check
- pwsh -NoProfile -File .\scripts\git-guard.ps1 -Mode full
- pwsh -NoProfile -File .\scripts\audit-public-surface.ps1
- pre-push git-guard, public-surface audit, and gitleaks passed
- GitHub Actions passed: build, Gitleaks Incremental Scan, Public Surface Audit, Pester Tests

## Notes
- External Rust learning note was updated locally for this Rust session.
- Opus review of the updated private learning note passed after explicit user approval.