### PR TITLE
Add AI organization machine contract

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -30,6 +30,10 @@ name = "event_contract"
 path = "tests-rs/event_contract.rs"
 
 [[test]]
+name = "machine_contract"
+path = "tests-rs/machine_contract.rs"
+
+[[test]]
 name = "ledger_contract"
 path = "tests-rs/ledger_contract.rs"
 

--- a/core/src/machine_contract.rs
+++ b/core/src/machine_contract.rs
@@ -1,0 +1,358 @@
+use serde::Serialize;
+
+pub const MACHINE_CONTRACT_VERSION: &str = "0.24.2";
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+pub struct MachineContractCatalog<'a> {
+    pub version: &'a str,
+    pub roles: &'a [RoleContract<'a>],
+    pub organization: OrganizationContract<'a>,
+    pub projection_surfaces: &'a [ProjectionSurfaceContract<'a>],
+    pub review_state_file: ReviewStateFileContract<'a>,
+    pub event_taxonomy: &'a [EventTaxonomyGroup<'a>],
+    pub verdict_fields: &'a [VerdictFieldContract<'a>],
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+pub struct RoleContract<'a> {
+    pub canonical: &'a str,
+    pub legacy_aliases: &'a [&'a str],
+    pub agent_facing: bool,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+pub struct ProjectionSurfaceContract<'a> {
+    pub name: &'a str,
+    pub command: &'a str,
+    pub shape: &'a str,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+pub struct OrganizationContract<'a> {
+    pub terms: &'a [OrganizationTermContract<'a>],
+    pub manifest_fields: &'a [ManifestFieldContract<'a>],
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+pub struct OrganizationTermContract<'a> {
+    pub name: &'a str,
+    pub description: &'a str,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+pub struct ManifestFieldContract<'a> {
+    pub field: &'a str,
+    pub shape: &'a str,
+    pub required: bool,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+pub struct ReviewStateFileContract<'a> {
+    pub path: &'a str,
+    pub version: u32,
+    pub required_fields: &'a [&'a str],
+    pub optional_fields: &'a [&'a str],
+    pub states: &'a [&'a str],
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+pub struct EventTaxonomyGroup<'a> {
+    pub group: &'a str,
+    pub events: &'a [&'a str],
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+pub struct VerdictFieldContract<'a> {
+    pub field: &'a str,
+    pub allowed_values: &'a [&'a str],
+}
+
+pub fn machine_contract_catalog() -> MachineContractCatalog<'static> {
+    MachineContractCatalog {
+        version: MACHINE_CONTRACT_VERSION,
+        roles: ROLES,
+        organization: ORGANIZATION,
+        projection_surfaces: PROJECTION_SURFACES,
+        review_state_file: REVIEW_STATE_FILE,
+        event_taxonomy: EVENT_TAXONOMY,
+        verdict_fields: VERDICT_FIELDS,
+    }
+}
+
+pub fn canonical_role_for(value: &str) -> Option<&'static str> {
+    let normalized = value.trim().to_ascii_lowercase();
+    ROLES
+        .iter()
+        .find(|role| {
+            role.canonical == normalized
+                || role
+                    .legacy_aliases
+                    .iter()
+                    .any(|alias| alias.to_ascii_lowercase() == normalized)
+        })
+        .map(|role| role.canonical)
+}
+
+const ROLES: &[RoleContract<'static>] = &[
+    RoleContract {
+        canonical: "operator",
+        legacy_aliases: &["Operator", "orchestrator", "controller"],
+        agent_facing: false,
+    },
+    RoleContract {
+        canonical: "worker",
+        legacy_aliases: &["Worker", "agent", "implementer"],
+        agent_facing: true,
+    },
+    RoleContract {
+        canonical: "reviewer",
+        legacy_aliases: &["Reviewer", "review", "auditor"],
+        agent_facing: true,
+    },
+    RoleContract {
+        canonical: "builder",
+        legacy_aliases: &["Builder", "build", "worktree-builder"],
+        agent_facing: true,
+    },
+];
+
+const ORGANIZATION: OrganizationContract<'static> = OrganizationContract {
+    terms: ORGANIZATION_TERMS,
+    manifest_fields: ORGANIZATION_MANIFEST_FIELDS,
+};
+
+const ORGANIZATION_TERMS: &[OrganizationTermContract<'static>] = &[
+    OrganizationTermContract {
+        name: "organization",
+        description: "top-level control plane that groups agents, policies, and budget state",
+    },
+    OrganizationTermContract {
+        name: "agent",
+        description: "addressable worker or reviewer runtime with ownership and capabilities",
+    },
+    OrganizationTermContract {
+        name: "slot",
+        description: "allocatable runtime seat that can host one active agent",
+    },
+    OrganizationTermContract {
+        name: "heartbeat",
+        description: "periodic liveness, progress, and cost signal emitted by an agent",
+    },
+    OrganizationTermContract {
+        name: "task_checkout",
+        description: "exclusive claim for work that prevents duplicate execution",
+    },
+    OrganizationTermContract {
+        name: "board_approval",
+        description: "explicit operator or policy approval before a gated action proceeds",
+    },
+    OrganizationTermContract {
+        name: "budget",
+        description: "monthly cost allowance and alert thresholds for an agent or group",
+    },
+    OrganizationTermContract {
+        name: "audit_trail",
+        description: "append-only evidence that explains who acted and why",
+    },
+];
+
+const ORGANIZATION_MANIFEST_FIELDS: &[ManifestFieldContract<'static>] = &[
+    ManifestFieldContract {
+        field: "agent_id",
+        shape: "string",
+        required: false,
+    },
+    ManifestFieldContract {
+        field: "title",
+        shape: "string",
+        required: false,
+    },
+    ManifestFieldContract {
+        field: "reports_to",
+        shape: "string",
+        required: false,
+    },
+    ManifestFieldContract {
+        field: "capabilities",
+        shape: "string array or JSON string array",
+        required: false,
+    },
+    ManifestFieldContract {
+        field: "budget_monthly_cents",
+        shape: "u64 number or numeric string",
+        required: false,
+    },
+    ManifestFieldContract {
+        field: "spent_monthly_cents",
+        shape: "u64 number or numeric string",
+        required: false,
+    },
+    ManifestFieldContract {
+        field: "cost_soft_limit_pct",
+        shape: "u32 number or numeric string from 0 to 100",
+        required: false,
+    },
+    ManifestFieldContract {
+        field: "cost_hard_limit_pct",
+        shape: "u32 number or numeric string from 0 to 100; greater than or equal to cost_soft_limit_pct when both are set",
+        required: false,
+    },
+];
+
+const PROJECTION_SURFACES: &[ProjectionSurfaceContract<'static>] = &[
+    ProjectionSurfaceContract {
+        name: "status",
+        command: "status --json",
+        shape: "session summary plus pane read models",
+    },
+    ProjectionSurfaceContract {
+        name: "board",
+        command: "board --json",
+        shape: "ordered pane board projection",
+    },
+    ProjectionSurfaceContract {
+        name: "inbox",
+        command: "inbox --json",
+        shape: "actionable inbox items",
+    },
+    ProjectionSurfaceContract {
+        name: "digest",
+        command: "digest --json",
+        shape: "run evidence digest",
+    },
+    ProjectionSurfaceContract {
+        name: "runs",
+        command: "runs --json",
+        shape: "run catalog projection",
+    },
+    ProjectionSurfaceContract {
+        name: "explain",
+        command: "explain <run_id> --json",
+        shape: "single run explanation with recent events",
+    },
+    ProjectionSurfaceContract {
+        name: "poll-events",
+        command: "poll-events --json",
+        shape: "event stream items",
+    },
+    ProjectionSurfaceContract {
+        name: "dispatch-review",
+        command: "dispatch-review --json",
+        shape: "review request dispatch status",
+    },
+    ProjectionSurfaceContract {
+        name: "review-request",
+        command: "review-request --json",
+        shape: "pending review-state record",
+    },
+    ProjectionSurfaceContract {
+        name: "review-approve",
+        command: "review-approve --json",
+        shape: "approved review-state record",
+    },
+    ProjectionSurfaceContract {
+        name: "review-fail",
+        command: "review-fail --json",
+        shape: "failed review-state record",
+    },
+    ProjectionSurfaceContract {
+        name: "review-reset",
+        command: "review-reset --json",
+        shape: "review-state cleanup status",
+    },
+];
+
+const REVIEW_STATE_FILE: ReviewStateFileContract<'static> = ReviewStateFileContract {
+    path: ".winsmux/review-state.json",
+    version: 1,
+    required_fields: &[
+        "status",
+        "branch",
+        "head_sha",
+        "request",
+        "reviewer",
+        "updatedAt",
+    ],
+    optional_fields: &["evidence"],
+    states: &["PENDING", "PASS", "FAIL"],
+};
+
+const EVENT_TAXONOMY: &[EventTaxonomyGroup<'static>] = &[
+    EventTaxonomyGroup {
+        group: "pane_lifecycle",
+        events: &[
+            "pane.started",
+            "pane.idle",
+            "pane.completed",
+            "pane.crashed",
+            "pane.hung",
+            "pane.stalled",
+        ],
+    },
+    EventTaxonomyGroup {
+        group: "operator_actions",
+        events: &[
+            "operator.review_requested",
+            "operator.review_failed",
+            "operator.commit_ready",
+            "operator.followup",
+            "operator.state_transition",
+        ],
+    },
+    EventTaxonomyGroup {
+        group: "consultation",
+        events: &["pane.consult_request", "pane.consult_result"],
+    },
+    EventTaxonomyGroup {
+        group: "agent_heartbeat",
+        events: &[
+            "agent.heartbeat.started",
+            "agent.heartbeat.completed",
+            "agent.heartbeat.blocked",
+            "agent.heartbeat.cost_recorded",
+        ],
+    },
+    EventTaxonomyGroup {
+        group: "task_checkout",
+        events: &[
+            "task.checked_out",
+            "task.checkout_conflict",
+            "task.released",
+        ],
+    },
+    EventTaxonomyGroup {
+        group: "board_approval",
+        events: &[
+            "board.approval.requested",
+            "board.approval.granted",
+            "board.approval.denied",
+        ],
+    },
+    EventTaxonomyGroup {
+        group: "verification",
+        events: &["pipeline.verify.pass", "pipeline.verify.fail"],
+    },
+    EventTaxonomyGroup {
+        group: "security",
+        events: &["pipeline.security.allowed", "pipeline.security.blocked"],
+    },
+];
+
+const VERDICT_FIELDS: &[VerdictFieldContract<'static>] = &[
+    VerdictFieldContract {
+        field: "review_state",
+        allowed_values: &["PENDING", "PASS", "FAIL"],
+    },
+    VerdictFieldContract {
+        field: "verification_result.outcome",
+        allowed_values: &["PASS", "FAIL", "SKIP"],
+    },
+    VerdictFieldContract {
+        field: "security_verdict",
+        allowed_values: &["ALLOW", "BLOCK", "WARN"],
+    },
+    VerdictFieldContract {
+        field: "verdict",
+        allowed_values: &["ALLOW", "BLOCK", "PASS", "FAIL", "WARN"],
+    },
+];

--- a/core/src/manifest_contract.rs
+++ b/core/src/manifest_contract.rs
@@ -98,6 +98,22 @@ pub struct ManifestPane {
     #[serde(default, deserialize_with = "deserialize_manifest_string")]
     pub task_owner: String,
     #[serde(default, deserialize_with = "deserialize_manifest_string")]
+    pub agent_id: String,
+    #[serde(default, deserialize_with = "deserialize_manifest_string")]
+    pub title: String,
+    #[serde(default, deserialize_with = "deserialize_manifest_string")]
+    pub reports_to: String,
+    #[serde(default)]
+    pub capabilities: ManifestStringList,
+    #[serde(default)]
+    pub budget_monthly_cents: ManifestU64,
+    #[serde(default)]
+    pub spent_monthly_cents: ManifestU64,
+    #[serde(default)]
+    pub cost_soft_limit_pct: ManifestOptionalU32,
+    #[serde(default)]
+    pub cost_hard_limit_pct: ManifestOptionalU32,
+    #[serde(default, deserialize_with = "deserialize_manifest_string")]
     pub review_state: String,
     #[serde(default, deserialize_with = "deserialize_manifest_string")]
     pub priority: String,
@@ -191,6 +207,26 @@ pub enum ManifestUsize {
 
 #[derive(Debug, Default, Deserialize)]
 #[serde(untagged)]
+pub enum ManifestU64 {
+    Number(u64),
+    String(String),
+    Null,
+    #[default]
+    Empty,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(untagged)]
+pub enum ManifestOptionalU32 {
+    Number(u32),
+    String(String),
+    Null,
+    #[default]
+    Empty,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(untagged)]
 pub enum ManifestBool {
     Bool(bool),
     String(String),
@@ -218,6 +254,60 @@ impl ManifestUsize {
             Self::Number(value) => Some(*value),
             Self::String(value) => value.trim().parse().ok(),
             Self::Empty => Some(0),
+        }
+    }
+}
+
+impl ManifestU64 {
+    pub fn value(&self) -> Option<u64> {
+        match self {
+            Self::Number(value) => Some(*value),
+            Self::String(value) => {
+                let trimmed = value.trim();
+                if trimmed.is_empty() {
+                    None
+                } else {
+                    trimmed.parse().ok()
+                }
+            }
+            Self::Null | Self::Empty => None,
+        }
+    }
+
+    pub fn is_valid(&self) -> bool {
+        match self {
+            Self::Number(_) | Self::Null | Self::Empty => true,
+            Self::String(value) => {
+                let trimmed = value.trim();
+                trimmed.is_empty() || trimmed.parse::<u64>().is_ok()
+            }
+        }
+    }
+}
+
+impl ManifestOptionalU32 {
+    pub fn value(&self) -> Option<u32> {
+        match self {
+            Self::Number(value) => Some(*value),
+            Self::String(value) => {
+                let trimmed = value.trim();
+                if trimmed.is_empty() {
+                    None
+                } else {
+                    trimmed.parse().ok()
+                }
+            }
+            Self::Null | Self::Empty => None,
+        }
+    }
+
+    pub fn is_valid(&self) -> bool {
+        match self {
+            Self::Number(_) | Self::Null | Self::Empty => true,
+            Self::String(value) => {
+                let trimmed = value.trim();
+                trimmed.is_empty() || trimmed.parse::<u32>().is_ok()
+            }
         }
     }
 }
@@ -253,6 +343,14 @@ pub struct NormalizedManifestPane {
     pub task_type: String,
     pub task_state: String,
     pub task_owner: String,
+    pub agent_id: String,
+    pub title: String,
+    pub reports_to: String,
+    pub capabilities: Vec<String>,
+    pub budget_monthly_cents: Option<u64>,
+    pub spent_monthly_cents: Option<u64>,
+    pub cost_soft_limit_pct: Option<u32>,
+    pub cost_hard_limit_pct: Option<u32>,
     pub review_state: String,
     pub priority: String,
     pub blocking: bool,
@@ -365,6 +463,14 @@ fn normalize_manifest_pane(
         task_type: pane.task_type.clone(),
         task_state: pane.task_state.clone(),
         task_owner: pane.task_owner.clone(),
+        agent_id: pane.agent_id.clone(),
+        title: pane.title.clone(),
+        reports_to: pane.reports_to.clone(),
+        capabilities: pane.capabilities.values(),
+        budget_monthly_cents: pane.budget_monthly_cents.value(),
+        spent_monthly_cents: pane.spent_monthly_cents.value(),
+        cost_soft_limit_pct: pane.cost_soft_limit_pct.value(),
+        cost_hard_limit_pct: pane.cost_hard_limit_pct.value(),
         review_state: pane.review_state.clone(),
         priority: pane.priority.clone(),
         blocking: pane.blocking.value().unwrap_or(false),
@@ -599,6 +705,43 @@ fn validate_pane(label: &str, pane: &ManifestPane) -> Result<(), String> {
             "manifest pane '{label}' last_event requires last_event_at"
         ));
     }
+    if !pane.budget_monthly_cents.is_valid() {
+        return Err(format!(
+            "manifest pane '{label}' budget_monthly_cents must be numeric"
+        ));
+    }
+    if !pane.spent_monthly_cents.is_valid() {
+        return Err(format!(
+            "manifest pane '{label}' spent_monthly_cents must be numeric"
+        ));
+    }
+    if !pane.cost_soft_limit_pct.is_valid() {
+        return Err(format!(
+            "manifest pane '{label}' cost_soft_limit_pct must be numeric"
+        ));
+    }
+    if !pane.cost_hard_limit_pct.is_valid() {
+        return Err(format!(
+            "manifest pane '{label}' cost_hard_limit_pct must be numeric"
+        ));
+    }
+    let soft_limit = pane.cost_soft_limit_pct.value();
+    let hard_limit = pane.cost_hard_limit_pct.value();
+    if matches!(soft_limit, Some(value) if value > 100) {
+        return Err(format!(
+            "manifest pane '{label}' cost_soft_limit_pct must be between 0 and 100"
+        ));
+    }
+    if matches!(hard_limit, Some(value) if value > 100) {
+        return Err(format!(
+            "manifest pane '{label}' cost_hard_limit_pct must be between 0 and 100"
+        ));
+    }
+    if matches!((soft_limit, hard_limit), (Some(soft), Some(hard)) if hard < soft) {
+        return Err(format!(
+            "manifest pane '{label}' cost_hard_limit_pct must be greater than or equal to cost_soft_limit_pct"
+        ));
+    }
     let has_planning = !pane.goal.trim().is_empty()
         || !pane.task_type.trim().is_empty()
         || !pane.priority.trim().is_empty()
@@ -790,6 +933,135 @@ panes:
         let panes = manifest.panes_with_labels();
         assert_eq!(panes[0].1.blocking.value(), Some(true));
         assert_eq!(panes[0].1.review_required.value(), Some(true));
+    }
+
+    #[test]
+    fn manifest_accepts_agent_organization_fields() {
+        let manifest = WinsmuxManifest::from_yaml(
+            r#"
+version: 1
+session:
+  project_dir: C:\repo
+panes:
+  builder-1:
+    pane_id: "%2"
+    role: Builder
+    agent_id: builder-1
+    title: Implementation Owner
+    reports_to: operator
+    capabilities:
+      - edit
+      - test
+    budget_monthly_cents: "2500"
+    spent_monthly_cents: 475
+    cost_soft_limit_pct: "70"
+    cost_hard_limit_pct: 90
+"#,
+        )
+        .unwrap();
+        manifest.validate().unwrap();
+
+        let pane = &manifest.normalized_panes()[0];
+        assert_eq!(pane.agent_id, "builder-1");
+        assert_eq!(pane.title, "Implementation Owner");
+        assert_eq!(pane.reports_to, "operator");
+        assert_eq!(pane.capabilities, ["edit", "test"]);
+        assert_eq!(pane.budget_monthly_cents, Some(2500));
+        assert_eq!(pane.spent_monthly_cents, Some(475));
+        assert_eq!(pane.cost_soft_limit_pct, Some(70));
+        assert_eq!(pane.cost_hard_limit_pct, Some(90));
+    }
+
+    #[test]
+    fn manifest_rejects_non_numeric_budget_fields() {
+        let manifest = WinsmuxManifest::from_yaml(
+            r#"
+version: 1
+session:
+  project_dir: C:\repo
+panes:
+  builder-1:
+    pane_id: "%2"
+    role: Builder
+    budget_monthly_cents: many
+"#,
+        )
+        .unwrap();
+
+        let err = manifest.validate().unwrap_err();
+
+        assert!(err.contains("budget_monthly_cents must be numeric"));
+    }
+
+    #[test]
+    fn manifest_accepts_null_budget_fields() {
+        let manifest = WinsmuxManifest::from_yaml(
+            r#"
+version: 1
+session:
+  project_dir: C:\repo
+panes:
+  builder-1:
+    pane_id: "%2"
+    role: Builder
+    budget_monthly_cents: null
+    spent_monthly_cents: null
+    cost_soft_limit_pct: null
+    cost_hard_limit_pct: null
+"#,
+        )
+        .unwrap();
+        manifest.validate().unwrap();
+
+        let pane = &manifest.normalized_panes()[0];
+        assert_eq!(pane.budget_monthly_cents, None);
+        assert_eq!(pane.spent_monthly_cents, None);
+        assert_eq!(pane.cost_soft_limit_pct, None);
+        assert_eq!(pane.cost_hard_limit_pct, None);
+    }
+
+    #[test]
+    fn manifest_rejects_out_of_range_cost_limit_pct() {
+        let manifest = WinsmuxManifest::from_yaml(
+            r#"
+version: 1
+session:
+  project_dir: C:\repo
+panes:
+  builder-1:
+    pane_id: "%2"
+    role: Builder
+    cost_soft_limit_pct: 101
+"#,
+        )
+        .unwrap();
+
+        let err = manifest.validate().unwrap_err();
+
+        assert!(err.contains("cost_soft_limit_pct must be between 0 and 100"));
+    }
+
+    #[test]
+    fn manifest_rejects_cost_hard_limit_below_soft_limit() {
+        let manifest = WinsmuxManifest::from_yaml(
+            r#"
+version: 1
+session:
+  project_dir: C:\repo
+panes:
+  builder-1:
+    pane_id: "%2"
+    role: Builder
+    cost_soft_limit_pct: 80
+    cost_hard_limit_pct: 70
+"#,
+        )
+        .unwrap();
+
+        let err = manifest.validate().unwrap_err();
+
+        assert!(err
+            .contains("cost_hard_limit_pct must be greater than or equal to cost_soft_limit_pct"));
     }
 
     #[test]

--- a/core/tests-rs/machine_contract.rs
+++ b/core/tests-rs/machine_contract.rs
@@ -1,0 +1,212 @@
+#[path = "../src/machine_contract.rs"]
+mod machine_contract;
+
+use machine_contract::{canonical_role_for, machine_contract_catalog};
+
+#[test]
+fn machine_contract_exposes_version_and_canonical_roles() {
+    let catalog = machine_contract_catalog();
+
+    assert_eq!(catalog.version, "0.24.2");
+    assert_eq!(
+        catalog
+            .roles
+            .iter()
+            .map(|role| role.canonical)
+            .collect::<Vec<_>>(),
+        vec!["operator", "worker", "reviewer", "builder"]
+    );
+    assert_eq!(canonical_role_for("Operator"), Some("operator"));
+    assert_eq!(canonical_role_for("agent"), Some("worker"));
+    assert_eq!(canonical_role_for("Reviewer"), Some("reviewer"));
+    assert_eq!(canonical_role_for("Builder"), Some("builder"));
+    assert_eq!(canonical_role_for("unknown"), None);
+}
+
+#[test]
+fn machine_contract_exposes_projection_surfaces_in_stable_order() {
+    let catalog = machine_contract_catalog();
+
+    assert_eq!(
+        catalog
+            .projection_surfaces
+            .iter()
+            .map(|surface| surface.name)
+            .collect::<Vec<_>>(),
+        vec![
+            "status",
+            "board",
+            "inbox",
+            "digest",
+            "runs",
+            "explain",
+            "poll-events",
+            "dispatch-review",
+            "review-request",
+            "review-approve",
+            "review-fail",
+            "review-reset",
+        ]
+    );
+    assert_eq!(
+        catalog.projection_surfaces[5].command,
+        "explain <run_id> --json"
+    );
+}
+
+#[test]
+fn machine_contract_exposes_review_state_and_verdict_fields() {
+    let catalog = machine_contract_catalog();
+
+    assert_eq!(catalog.review_state_file.path, ".winsmux/review-state.json");
+    assert_eq!(catalog.review_state_file.version, 1);
+    assert!(catalog
+        .review_state_file
+        .required_fields
+        .contains(&"status"));
+    assert_eq!(
+        catalog.review_state_file.states,
+        ["PENDING", "PASS", "FAIL"]
+    );
+
+    let review_state = catalog
+        .verdict_fields
+        .iter()
+        .find(|field| field.field == "review_state")
+        .expect("review_state verdict field should exist");
+    assert_eq!(review_state.allowed_values, ["PENDING", "PASS", "FAIL"]);
+
+    let security = catalog
+        .verdict_fields
+        .iter()
+        .find(|field| field.field == "security_verdict")
+        .expect("security verdict field should exist");
+    assert!(security.allowed_values.contains(&"BLOCK"));
+}
+
+#[test]
+fn machine_contract_exposes_organization_contract() {
+    let catalog = machine_contract_catalog();
+
+    let terms = catalog
+        .organization
+        .terms
+        .iter()
+        .map(|term| term.name)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        terms,
+        vec![
+            "organization",
+            "agent",
+            "slot",
+            "heartbeat",
+            "task_checkout",
+            "board_approval",
+            "budget",
+            "audit_trail",
+        ]
+    );
+
+    let fields = catalog
+        .organization
+        .manifest_fields
+        .iter()
+        .map(|field| field.field)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        fields,
+        vec![
+            "agent_id",
+            "title",
+            "reports_to",
+            "capabilities",
+            "budget_monthly_cents",
+            "spent_monthly_cents",
+            "cost_soft_limit_pct",
+            "cost_hard_limit_pct",
+        ]
+    );
+    assert!(catalog
+        .organization
+        .manifest_fields
+        .iter()
+        .all(|field| !field.required));
+    let budget = catalog
+        .organization
+        .manifest_fields
+        .iter()
+        .find(|field| field.field == "budget_monthly_cents")
+        .expect("budget field should exist");
+    assert_eq!(budget.shape, "u64 number or numeric string");
+}
+
+#[test]
+fn machine_contract_exposes_event_taxonomy_groups() {
+    let catalog = machine_contract_catalog();
+
+    let groups = catalog
+        .event_taxonomy
+        .iter()
+        .map(|group| group.group)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        groups,
+        vec![
+            "pane_lifecycle",
+            "operator_actions",
+            "consultation",
+            "agent_heartbeat",
+            "task_checkout",
+            "board_approval",
+            "verification",
+            "security"
+        ]
+    );
+
+    let verification = catalog
+        .event_taxonomy
+        .iter()
+        .find(|group| group.group == "verification")
+        .expect("verification taxonomy should exist");
+    assert_eq!(
+        verification.events,
+        ["pipeline.verify.pass", "pipeline.verify.fail"]
+    );
+
+    let heartbeat = catalog
+        .event_taxonomy
+        .iter()
+        .find(|group| group.group == "agent_heartbeat")
+        .expect("agent heartbeat taxonomy should exist");
+    assert!(heartbeat.events.contains(&"agent.heartbeat.cost_recorded"));
+
+    let checkout = catalog
+        .event_taxonomy
+        .iter()
+        .find(|group| group.group == "task_checkout")
+        .expect("task checkout taxonomy should exist");
+    assert!(checkout.events.contains(&"task.checkout_conflict"));
+}
+
+#[test]
+fn machine_contract_serializes_to_json() {
+    let value = serde_json::to_value(machine_contract_catalog())
+        .expect("machine contract should serialize to JSON");
+
+    assert_eq!(value["version"], "0.24.2");
+    assert_eq!(value["roles"][3]["canonical"], "builder");
+    assert_eq!(value["roles"][3]["legacy_aliases"][0], "Builder");
+    assert_eq!(value["organization"]["terms"][1]["name"], "agent");
+    assert_eq!(
+        value["organization"]["manifest_fields"][4]["field"],
+        "budget_monthly_cents"
+    );
+    assert_eq!(value["projection_surfaces"][6]["name"], "poll-events");
+    assert_eq!(value["review_state_file"]["states"][2], "FAIL");
+    assert_eq!(value["event_taxonomy"][7]["group"], "security");
+    assert_eq!(
+        value["verdict_fields"][1]["field"],
+        "verification_result.outcome"
+    );
+}


### PR DESCRIPTION
## Summary

- add a Rust `machine_contract` catalog for roles, projection surfaces, review-state fields, organization terms, manifest organization fields, and event taxonomy
- extend the manifest contract with optional agent hierarchy, capability, and budget metadata
- validate budget fields, cost percentage bounds, and hard-limit >= soft-limit while preserving backward compatibility for missing and `null` fields

## Validation

- `cargo test --manifest-path core\Cargo.toml --test machine_contract -- --nocapture`
- `cargo test --manifest-path core\Cargo.toml --test manifest_contract -- --nocapture`
- `cargo check --manifest-path core\Cargo.toml`
- `rustfmt --check core\src\machine_contract.rs core\src\manifest_contract.rs core\tests-rs\machine_contract.rs`
- `git diff --check`
- `pwsh -NoProfile -File .\scripts\git-guard.ps1 -Mode full`
- `pwsh -NoProfile -File .\scripts\audit-public-surface.ps1`
- tracked-file-only blocked-keyword scan
- `claude --model opus` external Rust learning-note review: PASS

## Notes

- Internal research notes remain ignored under `docs/project/*`.
- The external planning task is `TASK-402` for issue #659.
- A repeated Claude Code `SessionEnd` hook sandbox failure was filed separately as #660 and mapped to `TASK-403`.