### PR TITLE
Add typed ledger payloads

### DIFF
--- a/core/src/ledger.rs
+++ b/core/src/ledger.rs
@@ -293,6 +293,406 @@ pub struct LedgerExplainRecentEvent {
     pub security_verdict: Value,
 }
 
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct LedgerStatusPayload {
+    pub generated_at: String,
+    pub project_dir: String,
+    pub session: LedgerStatusSession,
+    pub summary: LedgerBoardSummary,
+    pub panes: Vec<LedgerPaneReadModel>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct LedgerStatusSession {
+    pub name: String,
+    pub pane_count: usize,
+    pub event_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct LedgerBoardPayload {
+    pub generated_at: String,
+    pub project_dir: String,
+    pub summary: LedgerBoardSummary,
+    pub panes: Vec<LedgerBoardPane>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct LedgerInboxPayload {
+    pub generated_at: String,
+    pub project_dir: String,
+    pub summary: LedgerInboxSummary,
+    pub items: Vec<LedgerInboxItem>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct LedgerDigestPayload {
+    pub generated_at: String,
+    pub project_dir: String,
+    pub summary: LedgerDigestSummary,
+    pub items: Vec<LedgerDigestItem>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct LedgerRunsPayload {
+    pub generated_at: String,
+    pub project_dir: String,
+    pub summary: LedgerRunsSummary,
+    pub runs: Vec<LedgerRunProjection>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct LedgerRunsSummary {
+    pub run_count: usize,
+    pub blocked_runs: usize,
+    pub review_pending: usize,
+    pub dirty_runs: usize,
+    pub action_item_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct LedgerRunProjection {
+    pub run_id: String,
+    pub task_id: String,
+    pub task: String,
+    pub task_state: String,
+    pub review_state: String,
+    pub branch: String,
+    pub worktree: String,
+    pub head_sha: String,
+    pub primary_label: String,
+    pub primary_pane_id: String,
+    pub primary_role: String,
+    pub state: String,
+    pub tokens_remaining: String,
+    pub last_event: String,
+    pub last_event_at: String,
+    pub pane_count: usize,
+    pub changed_file_count: usize,
+    pub labels: Vec<String>,
+    pub pane_ids: Vec<String>,
+    pub roles: Vec<String>,
+    pub changed_files: Vec<String>,
+    pub action_items: Vec<LedgerExplainActionItem>,
+    pub parent_run_id: String,
+    pub goal: String,
+    pub task_type: String,
+    pub priority: String,
+    pub blocking: bool,
+    pub write_scope: Vec<String>,
+    pub read_scope: Vec<String>,
+    pub constraints: Vec<String>,
+    pub expected_output: String,
+    pub verification_plan: Vec<String>,
+    pub review_required: bool,
+    pub provider_target: String,
+    pub agent_role: String,
+    pub timeout_policy: String,
+    pub handoff_refs: Vec<String>,
+    pub experiment_packet: Option<LedgerExplainExperimentPacket>,
+    pub security_policy: Value,
+    pub security_verdict: Value,
+    pub verification_contract: Value,
+    pub verification_result: Value,
+    pub run_packet: Option<LedgerRunPacket>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct LedgerRunPacket {
+    pub run_id: String,
+    pub task_id: String,
+    pub parent_run_id: String,
+    pub goal: String,
+    pub task: String,
+    pub task_type: String,
+    pub priority: String,
+    pub blocking: bool,
+    pub write_scope: Vec<String>,
+    pub read_scope: Vec<String>,
+    pub constraints: Vec<String>,
+    pub expected_output: String,
+    pub verification_plan: Vec<String>,
+    pub review_required: bool,
+    pub provider_target: String,
+    pub agent_role: String,
+    pub timeout_policy: String,
+    pub handoff_refs: Vec<String>,
+    pub branch: String,
+    pub head_sha: String,
+    pub primary_label: String,
+    pub primary_pane_id: String,
+    pub primary_role: String,
+    pub labels: Vec<String>,
+    pub pane_ids: Vec<String>,
+    pub roles: Vec<String>,
+    pub changed_files: Vec<String>,
+    pub security_policy: Value,
+    pub security_verdict: Value,
+    pub verification_contract: Value,
+    pub verification_result: Value,
+    pub last_event: String,
+    pub last_event_at: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct LedgerExplainPayload {
+    pub generated_at: String,
+    pub project_dir: String,
+    pub run: LedgerExplainRun,
+    pub observation_pack: Value,
+    pub consultation_packet: Value,
+    pub evidence_digest: LedgerDigestItem,
+    pub explanation: LedgerExplainExplanation,
+    pub review_state: Value,
+    pub recent_events: Vec<LedgerExplainRecentEvent>,
+}
+
+impl LedgerStatusPayload {
+    pub fn from_snapshot(
+        generated_at: String,
+        project_dir: String,
+        snapshot: &LedgerSnapshot,
+    ) -> Self {
+        Self {
+            generated_at,
+            project_dir,
+            session: LedgerStatusSession {
+                name: snapshot.session_name().to_string(),
+                pane_count: snapshot.pane_count(),
+                event_count: snapshot.event_count(),
+            },
+            summary: snapshot.board_summary(),
+            panes: snapshot.pane_read_models(),
+        }
+    }
+}
+
+impl LedgerBoardPayload {
+    pub fn from_projection(
+        generated_at: String,
+        project_dir: String,
+        projection: LedgerBoardProjection,
+    ) -> Self {
+        Self {
+            generated_at,
+            project_dir,
+            summary: projection.summary,
+            panes: projection.panes,
+        }
+    }
+}
+
+impl LedgerInboxPayload {
+    pub fn from_projection(
+        generated_at: String,
+        project_dir: String,
+        projection: LedgerInboxProjection,
+    ) -> Self {
+        Self {
+            generated_at,
+            project_dir,
+            summary: projection.summary,
+            items: projection.items,
+        }
+    }
+}
+
+impl LedgerDigestPayload {
+    pub fn from_projection(
+        generated_at: String,
+        project_dir: String,
+        projection: LedgerDigestProjection,
+    ) -> Self {
+        Self {
+            generated_at,
+            project_dir,
+            summary: projection.summary,
+            items: projection.items,
+        }
+    }
+}
+
+impl LedgerRunsPayload {
+    pub fn from_snapshot(
+        generated_at: String,
+        project_dir: String,
+        snapshot: &LedgerSnapshot,
+    ) -> Self {
+        let runs: Vec<LedgerRunProjection> = snapshot
+            .digest_projection()
+            .items
+            .into_iter()
+            .map(|item| {
+                let explain = snapshot.explain_projection(&item.run_id);
+                LedgerRunProjection::from_digest_item(
+                    item,
+                    explain.as_ref().map(|projection| &projection.run),
+                )
+            })
+            .collect();
+        let summary = LedgerRunsSummary {
+            run_count: runs.len(),
+            blocked_runs: runs
+                .iter()
+                .filter(|run| run.task_state.eq_ignore_ascii_case("blocked"))
+                .count(),
+            review_pending: runs
+                .iter()
+                .filter(|run| run.review_state.eq_ignore_ascii_case("pending"))
+                .count(),
+            dirty_runs: runs.iter().filter(|run| run.changed_file_count > 0).count(),
+            action_item_count: runs.iter().map(|run| run.action_items.len()).sum(),
+        };
+        Self {
+            generated_at,
+            project_dir,
+            summary,
+            runs,
+        }
+    }
+}
+
+impl LedgerRunProjection {
+    fn from_digest_item(item: LedgerDigestItem, run: Option<&LedgerExplainRun>) -> Self {
+        let primary_label = item.label.clone();
+        let primary_pane_id = item.pane_id.clone();
+        let primary_role = item.role.clone();
+
+        Self {
+            run_id: item.run_id,
+            task_id: item.task_id,
+            task: item.task,
+            task_state: item.task_state,
+            review_state: item.review_state,
+            branch: item.branch,
+            worktree: item.worktree,
+            head_sha: item.head_sha,
+            primary_label: primary_label.clone(),
+            primary_pane_id: primary_pane_id.clone(),
+            primary_role: primary_role.clone(),
+            state: run.map(|run| run.state.clone()).unwrap_or_default(),
+            tokens_remaining: run
+                .map(|run| run.tokens_remaining.clone())
+                .unwrap_or_default(),
+            last_event: item.last_event,
+            last_event_at: item.last_event_at,
+            pane_count: run.map(|run| run.pane_count).unwrap_or(1),
+            changed_file_count: item.changed_file_count,
+            labels: run
+                .map(|run| run.labels.clone())
+                .unwrap_or_else(|| vec![primary_label]),
+            pane_ids: run
+                .map(|run| run.pane_ids.clone())
+                .unwrap_or_else(|| vec![primary_pane_id]),
+            roles: run
+                .map(|run| run.roles.clone())
+                .unwrap_or_else(|| vec![primary_role.clone()]),
+            changed_files: item.changed_files,
+            action_items: run.map(|run| run.action_items.clone()).unwrap_or_default(),
+            parent_run_id: run.map(|run| run.parent_run_id.clone()).unwrap_or_default(),
+            goal: run.map(|run| run.goal.clone()).unwrap_or_default(),
+            task_type: run.map(|run| run.task_type.clone()).unwrap_or_default(),
+            priority: run.map(|run| run.priority.clone()).unwrap_or_default(),
+            blocking: run.map(|run| run.blocking).unwrap_or(false),
+            write_scope: run.map(|run| run.write_scope.clone()).unwrap_or_default(),
+            read_scope: run.map(|run| run.read_scope.clone()).unwrap_or_default(),
+            constraints: run.map(|run| run.constraints.clone()).unwrap_or_default(),
+            expected_output: run
+                .map(|run| run.expected_output.clone())
+                .unwrap_or_default(),
+            verification_plan: run
+                .map(|run| run.verification_plan.clone())
+                .unwrap_or_default(),
+            review_required: run.map(|run| run.review_required).unwrap_or(false),
+            provider_target: item.provider_target,
+            agent_role: run
+                .map(|run| run.agent_role.clone())
+                .unwrap_or(primary_role),
+            timeout_policy: run
+                .map(|run| run.timeout_policy.clone())
+                .unwrap_or_default(),
+            handoff_refs: run.map(|run| run.handoff_refs.clone()).unwrap_or_default(),
+            experiment_packet: run.map(|run| run.experiment_packet.clone()),
+            security_policy: run
+                .map(|run| run.security_policy.clone())
+                .unwrap_or(Value::Null),
+            security_verdict: run
+                .map(|run| run.security_verdict.clone())
+                .unwrap_or(Value::Null),
+            verification_contract: run
+                .map(|run| run.verification_contract.clone())
+                .unwrap_or(Value::Null),
+            verification_result: run
+                .map(|run| run.verification_result.clone())
+                .unwrap_or(Value::Null),
+            run_packet: run.map(LedgerRunPacket::from_explain_run),
+        }
+    }
+}
+
+impl LedgerRunPacket {
+    fn from_explain_run(run: &LedgerExplainRun) -> Self {
+        Self {
+            run_id: run.run_id.clone(),
+            task_id: run.task_id.clone(),
+            parent_run_id: run.parent_run_id.clone(),
+            goal: run.goal.clone(),
+            task: run.task.clone(),
+            task_type: run.task_type.clone(),
+            priority: run.priority.clone(),
+            blocking: run.blocking,
+            write_scope: run.write_scope.clone(),
+            read_scope: run.read_scope.clone(),
+            constraints: run.constraints.clone(),
+            expected_output: run.expected_output.clone(),
+            verification_plan: run.verification_plan.clone(),
+            review_required: run.review_required,
+            provider_target: run.provider_target.clone(),
+            agent_role: run.agent_role.clone(),
+            timeout_policy: run.timeout_policy.clone(),
+            handoff_refs: run.handoff_refs.clone(),
+            branch: run.branch.clone(),
+            head_sha: run.head_sha.clone(),
+            primary_label: run.primary_label.clone(),
+            primary_pane_id: run.primary_pane_id.clone(),
+            primary_role: run.primary_role.clone(),
+            labels: run.labels.clone(),
+            pane_ids: run.pane_ids.clone(),
+            roles: run.roles.clone(),
+            changed_files: run.changed_files.clone(),
+            security_policy: run.security_policy.clone(),
+            security_verdict: run.security_verdict.clone(),
+            verification_contract: run.verification_contract.clone(),
+            verification_result: run.verification_result.clone(),
+            last_event: run.last_event.clone(),
+            last_event_at: run.last_event_at.clone(),
+        }
+    }
+}
+
+impl LedgerExplainPayload {
+    pub fn from_projection(
+        generated_at: String,
+        project_dir: String,
+        projection: LedgerExplainProjection,
+        observation_pack: Value,
+        consultation_packet: Value,
+        review_state: Value,
+    ) -> Self {
+        Self {
+            generated_at,
+            project_dir,
+            run: projection.run,
+            observation_pack,
+            consultation_packet,
+            evidence_digest: projection.evidence_digest,
+            explanation: projection.explanation,
+            review_state,
+            recent_events: projection.recent_events,
+        }
+    }
+}
+
 impl LedgerSnapshot {
     pub fn from_project_dir(project_dir: impl AsRef<Path>) -> Result<Self, String> {
         let winsmux_dir = project_dir.as_ref().join(".winsmux");

--- a/core/src/machine_contract.rs
+++ b/core/src/machine_contract.rs
@@ -25,6 +25,7 @@ pub struct ProjectionSurfaceContract<'a> {
     pub name: &'a str,
     pub command: &'a str,
     pub shape: &'a str,
+    pub rust_type: &'a str,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
@@ -204,61 +205,73 @@ const PROJECTION_SURFACES: &[ProjectionSurfaceContract<'static>] = &[
         name: "status",
         command: "status --json",
         shape: "session summary plus pane read models",
+        rust_type: "LedgerStatusPayload",
     },
     ProjectionSurfaceContract {
         name: "board",
         command: "board --json",
         shape: "ordered pane board projection",
+        rust_type: "LedgerBoardPayload",
     },
     ProjectionSurfaceContract {
         name: "inbox",
         command: "inbox --json",
         shape: "actionable inbox items",
+        rust_type: "LedgerInboxPayload",
     },
     ProjectionSurfaceContract {
         name: "digest",
         command: "digest --json",
         shape: "run evidence digest",
+        rust_type: "LedgerDigestPayload",
     },
     ProjectionSurfaceContract {
         name: "runs",
         command: "runs --json",
         shape: "run catalog projection",
+        rust_type: "LedgerRunsPayload",
     },
     ProjectionSurfaceContract {
         name: "explain",
         command: "explain <run_id> --json",
         shape: "single run explanation with recent events",
+        rust_type: "LedgerExplainPayload",
     },
     ProjectionSurfaceContract {
         name: "poll-events",
         command: "poll-events --json",
         shape: "event stream items",
+        rust_type: "PollEventsPayload",
     },
     ProjectionSurfaceContract {
         name: "dispatch-review",
         command: "dispatch-review --json",
         shape: "review request dispatch status",
+        rust_type: "ReviewRequestDispatchPayload",
     },
     ProjectionSurfaceContract {
         name: "review-request",
         command: "review-request --json",
         shape: "pending review-state record",
+        rust_type: "ReviewStateRecord",
     },
     ProjectionSurfaceContract {
         name: "review-approve",
         command: "review-approve --json",
         shape: "approved review-state record",
+        rust_type: "ReviewStateRecord",
     },
     ProjectionSurfaceContract {
         name: "review-fail",
         command: "review-fail --json",
         shape: "failed review-state record",
+        rust_type: "ReviewStateRecord",
     },
     ProjectionSurfaceContract {
         name: "review-reset",
         command: "review-reset --json",
         shape: "review-state cleanup status",
+        rust_type: "ReviewResetPayload",
     },
 ];
 

--- a/core/src/operator_cli.rs
+++ b/core/src/operator_cli.rs
@@ -13,7 +13,10 @@ use serde::Serialize;
 use serde_json::{json, Map, Value};
 
 use crate::event_contract::{parse_event_jsonl, EventRecord};
-use crate::ledger::{LedgerDigestItem, LedgerSnapshot};
+use crate::ledger::{
+    LedgerBoardPayload, LedgerDigestItem, LedgerDigestPayload, LedgerExplainPayload,
+    LedgerInboxPayload, LedgerRunsPayload, LedgerSnapshot, LedgerStatusPayload,
+};
 
 static REVIEW_REQUEST_COUNTER: AtomicU32 = AtomicU32::new(0);
 static ATOMIC_WRITE_COUNTER: AtomicU32 = AtomicU32::new(0);
@@ -36,18 +39,12 @@ pub fn run_status_command(args: &[&String]) -> io::Result<()> {
     require_json("status", &options)?;
 
     let snapshot = load_snapshot(&options.project_dir)?;
-    let status = json!({
-        "generated_at": generated_at(),
-        "project_dir": project_dir_string(&options.project_dir),
-        "session": {
-            "name": snapshot.session_name(),
-            "pane_count": snapshot.pane_count(),
-            "event_count": snapshot.event_count(),
-        },
-        "summary": snapshot.board_summary(),
-        "panes": snapshot.pane_read_models(),
-    });
-    write_json(&status)
+    let payload = LedgerStatusPayload::from_snapshot(
+        generated_at(),
+        project_dir_string(&options.project_dir),
+        &snapshot,
+    );
+    write_json(&payload)
 }
 
 pub fn run_board_command(args: &[&String]) -> io::Result<()> {
@@ -58,10 +55,15 @@ pub fn run_board_command(args: &[&String]) -> io::Result<()> {
     let options = parse_options("board", args, 0)?;
 
     let snapshot = load_snapshot(&options.project_dir)?;
-    let payload = enveloped_payload(&options.project_dir, snapshot.board_projection())?;
+    let payload = LedgerBoardPayload::from_projection(
+        generated_at(),
+        project_dir_string(&options.project_dir),
+        snapshot.board_projection(),
+    );
     if options.json {
         return write_json(&payload);
     }
+    let payload = payload_to_value(&payload)?;
     print_board_table(&payload)
 }
 
@@ -73,10 +75,15 @@ pub fn run_inbox_command(args: &[&String]) -> io::Result<()> {
     let options = parse_options("inbox", args, 0)?;
 
     let snapshot = load_snapshot(&options.project_dir)?;
-    let payload = enveloped_payload(&options.project_dir, snapshot.inbox_projection())?;
+    let payload = LedgerInboxPayload::from_projection(
+        generated_at(),
+        project_dir_string(&options.project_dir),
+        snapshot.inbox_projection(),
+    );
     if options.json {
         write_json(&payload)
     } else {
+        let payload = payload_to_value(&payload)?;
         print_inbox_table(&payload)
     }
 }
@@ -89,10 +96,15 @@ pub fn run_digest_command(args: &[&String]) -> io::Result<()> {
     let options = parse_options("digest", args, 0)?;
 
     let snapshot = load_snapshot(&options.project_dir)?;
-    let payload = enveloped_payload(&options.project_dir, snapshot.digest_projection())?;
+    let payload = LedgerDigestPayload::from_projection(
+        generated_at(),
+        project_dir_string(&options.project_dir),
+        snapshot.digest_projection(),
+    );
     if options.json {
         write_json(&payload)
     } else {
+        let payload = payload_to_value(&payload)?;
         print_digest_text(&payload)
     }
 }
@@ -1631,10 +1643,15 @@ pub fn run_runs_command(args: &[&String]) -> io::Result<()> {
     let options = parse_options("runs", args, 0)?;
 
     let snapshot = load_snapshot(&options.project_dir)?;
-    let payload = runs_payload(&snapshot, &options.project_dir);
+    let payload = LedgerRunsPayload::from_snapshot(
+        generated_at(),
+        project_dir_string(&options.project_dir),
+        &snapshot,
+    );
     if options.json {
         write_json(&payload)
     } else {
+        let payload = payload_to_value(&payload)?;
         print_runs_table(&payload)
     }
 }
@@ -1663,28 +1680,28 @@ pub fn run_explain_command(args: &[&String]) -> io::Result<()> {
         &[".winsmux", "consultations"],
         &run_id,
     );
-    let payload = json!({
-        "generated_at": generated_at(),
-        "project_dir": project_dir_string(&options.project_dir),
-        "run": projection.run,
-        "observation_pack": observation_pack,
-        "consultation_packet": consultation_packet,
-        "evidence_digest": projection.evidence_digest,
-        "explanation": projection.explanation,
-        "review_state": Value::Null,
-        "recent_events": projection.recent_events,
-    });
+    let payload = LedgerExplainPayload::from_projection(
+        generated_at(),
+        project_dir_string(&options.project_dir),
+        projection,
+        observation_pack,
+        consultation_packet,
+        Value::Null,
+    );
     if options.follow {
         if options.json {
             write_json(&payload)?;
         } else {
-            print_explain_follow_header(&payload)?;
+            let payload_value = payload_to_value(&payload)?;
+            print_explain_follow_header(&payload_value)?;
         }
+        let payload = payload_to_value(&payload)?;
         return stream_explain_follow(&options.project_dir, payload, options.json);
     }
     if options.json {
         write_json(&payload)
     } else {
+        let payload = payload_to_value(&payload)?;
         print_explain_text(&payload)
     }
 }
@@ -6008,211 +6025,6 @@ fn compare_display_value(value: &Value) -> String {
     value.to_string()
 }
 
-fn runs_payload(snapshot: &LedgerSnapshot, project_dir: &Path) -> Value {
-    let runs: Vec<Value> = snapshot
-        .digest_projection()
-        .items
-        .into_iter()
-        .map(|item| {
-            let explain = snapshot.explain_projection(&item.run_id);
-            let run = explain.as_ref().map(|projection| &projection.run);
-            let action_items = run
-                .map(|run| json!(run.action_items))
-                .unwrap_or_else(|| json!([]));
-            let experiment_packet = run
-                .map(|run| json!(run.experiment_packet))
-                .unwrap_or(Value::Null);
-            let security_policy = run
-                .map(|run| run.security_policy.clone())
-                .unwrap_or(Value::Null);
-            let security_verdict = run
-                .map(|run| run.security_verdict.clone())
-                .unwrap_or(Value::Null);
-            let verification_contract = run
-                .map(|run| run.verification_contract.clone())
-                .unwrap_or(Value::Null);
-            let verification_result = run
-                .map(|run| run.verification_result.clone())
-                .unwrap_or(Value::Null);
-            let run_packet = run
-                .map(|run| {
-                    json!({
-                        "run_id": run.run_id,
-                        "task_id": run.task_id,
-                        "parent_run_id": run.parent_run_id,
-                        "goal": run.goal,
-                        "task": run.task,
-                        "task_type": run.task_type,
-                        "priority": run.priority,
-                        "blocking": run.blocking,
-                        "write_scope": run.write_scope,
-                        "read_scope": run.read_scope,
-                        "constraints": run.constraints,
-                        "expected_output": run.expected_output,
-                        "verification_plan": run.verification_plan,
-                        "review_required": run.review_required,
-                        "provider_target": run.provider_target,
-                        "agent_role": run.agent_role,
-                        "timeout_policy": run.timeout_policy,
-                        "handoff_refs": run.handoff_refs,
-                        "branch": run.branch,
-                        "head_sha": run.head_sha,
-                        "primary_label": run.primary_label,
-                        "primary_pane_id": run.primary_pane_id,
-                        "primary_role": run.primary_role,
-                        "labels": run.labels,
-                        "pane_ids": run.pane_ids,
-                        "roles": run.roles,
-                        "changed_files": run.changed_files,
-                        "security_policy": run.security_policy,
-                        "security_verdict": run.security_verdict,
-                        "verification_contract": run.verification_contract,
-                        "verification_result": run.verification_result,
-                        "last_event": run.last_event,
-                        "last_event_at": run.last_event_at,
-                    })
-                })
-                .unwrap_or(Value::Null);
-
-            let mut value = Map::new();
-            value.insert("run_id".into(), json!(item.run_id));
-            value.insert("task_id".into(), json!(item.task_id));
-            value.insert("task".into(), json!(item.task));
-            value.insert("task_state".into(), json!(item.task_state));
-            value.insert("review_state".into(), json!(item.review_state));
-            value.insert("branch".into(), json!(item.branch));
-            value.insert("worktree".into(), json!(item.worktree));
-            value.insert("head_sha".into(), json!(item.head_sha));
-            value.insert("primary_label".into(), json!(item.label));
-            value.insert("primary_pane_id".into(), json!(item.pane_id));
-            value.insert("primary_role".into(), json!(item.role));
-            value.insert(
-                "state".into(),
-                json!(run.map(|run| run.state.clone()).unwrap_or_default()),
-            );
-            value.insert(
-                "tokens_remaining".into(),
-                json!(run
-                    .map(|run| run.tokens_remaining.clone())
-                    .unwrap_or_default()),
-            );
-            value.insert("last_event".into(), json!(item.last_event));
-            value.insert("last_event_at".into(), json!(item.last_event_at));
-            value.insert(
-                "pane_count".into(),
-                json!(run.map(|run| run.pane_count).unwrap_or(1)),
-            );
-            value.insert("changed_file_count".into(), json!(item.changed_file_count));
-            value.insert(
-                "labels".into(),
-                run.map(|run| json!(run.labels))
-                    .unwrap_or_else(|| json!([item.label])),
-            );
-            value.insert(
-                "pane_ids".into(),
-                run.map(|run| json!(run.pane_ids))
-                    .unwrap_or_else(|| json!([item.pane_id])),
-            );
-            value.insert(
-                "roles".into(),
-                run.map(|run| json!(run.roles))
-                    .unwrap_or_else(|| json!([item.role])),
-            );
-            value.insert("changed_files".into(), json!(item.changed_files));
-            value.insert("action_items".into(), action_items);
-            value.insert(
-                "parent_run_id".into(),
-                json!(run.map(|run| run.parent_run_id.clone()).unwrap_or_default()),
-            );
-            value.insert(
-                "goal".into(),
-                json!(run.map(|run| run.goal.clone()).unwrap_or_default()),
-            );
-            value.insert(
-                "task_type".into(),
-                json!(run.map(|run| run.task_type.clone()).unwrap_or_default()),
-            );
-            value.insert(
-                "priority".into(),
-                json!(run.map(|run| run.priority.clone()).unwrap_or_default()),
-            );
-            value.insert(
-                "blocking".into(),
-                json!(run.map(|run| run.blocking).unwrap_or(false)),
-            );
-            value.insert(
-                "write_scope".into(),
-                run.map(|run| json!(run.write_scope))
-                    .unwrap_or_else(|| json!([])),
-            );
-            value.insert(
-                "read_scope".into(),
-                run.map(|run| json!(run.read_scope))
-                    .unwrap_or_else(|| json!([])),
-            );
-            value.insert(
-                "constraints".into(),
-                run.map(|run| json!(run.constraints))
-                    .unwrap_or_else(|| json!([])),
-            );
-            value.insert(
-                "expected_output".into(),
-                json!(run
-                    .map(|run| run.expected_output.clone())
-                    .unwrap_or_default()),
-            );
-            value.insert(
-                "verification_plan".into(),
-                run.map(|run| json!(run.verification_plan))
-                    .unwrap_or_else(|| json!([])),
-            );
-            value.insert(
-                "review_required".into(),
-                json!(run.map(|run| run.review_required).unwrap_or(false)),
-            );
-            value.insert("provider_target".into(), json!(item.provider_target));
-            value.insert(
-                "agent_role".into(),
-                json!(run.map(|run| run.agent_role.clone()).unwrap_or(item.role)),
-            );
-            value.insert(
-                "timeout_policy".into(),
-                json!(run
-                    .map(|run| run.timeout_policy.clone())
-                    .unwrap_or_default()),
-            );
-            value.insert(
-                "handoff_refs".into(),
-                run.map(|run| json!(run.handoff_refs))
-                    .unwrap_or_else(|| json!([])),
-            );
-            value.insert("experiment_packet".into(), experiment_packet);
-            value.insert("security_policy".into(), security_policy);
-            value.insert("security_verdict".into(), security_verdict);
-            value.insert("verification_contract".into(), verification_contract);
-            value.insert("verification_result".into(), verification_result);
-            value.insert("run_packet".into(), run_packet);
-            Value::Object(value)
-        })
-        .collect();
-
-    json!({
-        "generated_at": generated_at(),
-        "project_dir": project_dir_string(project_dir),
-        "summary": {
-            "run_count": runs.len(),
-            "blocked_runs": runs.iter().filter(|run| json_string_eq(run, "task_state", "blocked")).count(),
-            "review_pending": runs.iter().filter(|run| json_string_eq(run, "review_state", "pending")).count(),
-            "dirty_runs": runs.iter().filter(|run| run["changed_file_count"].as_u64().unwrap_or(0) > 0).count(),
-            "action_item_count": runs
-                .iter()
-                .map(|run| run["action_items"].as_array().map(|items| items.len()).unwrap_or(0))
-                .sum::<usize>(),
-        },
-        "runs": runs,
-    })
-}
-
 fn desktop_summary_payload(snapshot: &LedgerSnapshot, project_dir: &Path) -> io::Result<Value> {
     let board = desktop_board_payload(snapshot, project_dir);
     let inbox = enveloped_payload(project_dir, snapshot.inbox_projection())?;
@@ -6975,14 +6787,6 @@ fn json_field_string(value: &Value, key: &str) -> String {
         .to_string()
 }
 
-fn json_string_eq(value: &Value, key: &str, expected: &str) -> bool {
-    value
-        .get(key)
-        .and_then(Value::as_str)
-        .map(|actual| actual.eq_ignore_ascii_case(expected))
-        .unwrap_or(false)
-}
-
 fn read_artifact_json(
     reference: &str,
     project_dir: &Path,
@@ -7039,6 +6843,15 @@ fn read_artifact_json(
 fn write_enveloped_json<T: Serialize>(project_dir: &Path, value: T) -> io::Result<()> {
     let payload = enveloped_payload(project_dir, value)?;
     write_json(&payload)
+}
+
+fn payload_to_value<T: Serialize>(value: &T) -> io::Result<Value> {
+    serde_json::to_value(value).map_err(|err| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("failed to serialize Rust operator projection: {err}"),
+        )
+    })
 }
 
 fn enveloped_payload<T: Serialize>(project_dir: &Path, value: T) -> io::Result<Value> {

--- a/core/tests-rs/ledger_contract.rs
+++ b/core/tests-rs/ledger_contract.rs
@@ -11,6 +11,8 @@ use std::fs;
 use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use serde_json::{json, Value};
+
 const MANIFEST_FIXTURE: &str = include_str!("../../tests/fixtures/rust-parity/manifest.yaml");
 const EVENTS_FIXTURE: &str = include_str!("../../tests/fixtures/rust-parity/events.jsonl");
 
@@ -507,6 +509,91 @@ fn ledger_contract_serializes_projection_surfaces_to_json() {
     assert!(digest["items"].is_array());
     assert_eq!(explain["run"]["run_id"], "task:task-256");
     assert!(explain["recent_events"].is_array());
+}
+
+#[test]
+fn ledger_contract_serializes_typed_cli_payload_roots() {
+    let snapshot =
+        ledger::LedgerSnapshot::from_manifest_and_events(MANIFEST_FIXTURE, EVENTS_FIXTURE)
+            .expect("ledger snapshot should load frozen fixtures");
+
+    let status = serde_json::to_value(ledger::LedgerStatusPayload::from_snapshot(
+        "2026-04-27T00:00:00Z".to_string(),
+        "C:\\repo".to_string(),
+        &snapshot,
+    ))
+    .expect("status payload should serialize to JSON");
+    assert_root_keys(
+        &status,
+        &["generated_at", "panes", "project_dir", "session", "summary"],
+    );
+    assert_eq!(status["session"]["name"], "winsmux-orchestra");
+
+    let board = serde_json::to_value(ledger::LedgerBoardPayload::from_projection(
+        "2026-04-27T00:00:00Z".to_string(),
+        "C:\\repo".to_string(),
+        snapshot.board_projection(),
+    ))
+    .expect("board payload should serialize to JSON");
+    assert_root_keys(&board, &["generated_at", "panes", "project_dir", "summary"]);
+    assert_eq!(board["panes"][0]["label"], "builder-1");
+
+    let inbox = serde_json::to_value(ledger::LedgerInboxPayload::from_projection(
+        "2026-04-27T00:00:00Z".to_string(),
+        "C:\\repo".to_string(),
+        snapshot.inbox_projection(),
+    ))
+    .expect("inbox payload should serialize to JSON");
+    assert_root_keys(&inbox, &["generated_at", "items", "project_dir", "summary"]);
+
+    let digest = serde_json::to_value(ledger::LedgerDigestPayload::from_projection(
+        "2026-04-27T00:00:00Z".to_string(),
+        "C:\\repo".to_string(),
+        snapshot.digest_projection(),
+    ))
+    .expect("digest payload should serialize to JSON");
+    assert_root_keys(
+        &digest,
+        &["generated_at", "items", "project_dir", "summary"],
+    );
+
+    let runs = serde_json::to_value(ledger::LedgerRunsPayload::from_snapshot(
+        "2026-04-27T00:00:00Z".to_string(),
+        "C:\\repo".to_string(),
+        &snapshot,
+    ))
+    .expect("runs payload should serialize to JSON");
+    assert_root_keys(&runs, &["generated_at", "project_dir", "runs", "summary"]);
+    assert_eq!(runs["summary"]["run_count"], 2);
+    assert!(runs["runs"][0]["run_packet"].is_object());
+
+    let explain_projection = snapshot
+        .explain_projection("task:task-256")
+        .expect("fixture explain projection should exist");
+    let explain = serde_json::to_value(ledger::LedgerExplainPayload::from_projection(
+        "2026-04-27T00:00:00Z".to_string(),
+        "C:\\repo".to_string(),
+        explain_projection,
+        json!({"summary": "ok"}),
+        json!({"recommendation": "ok"}),
+        Value::Null,
+    ))
+    .expect("explain payload should serialize to JSON");
+    assert_root_keys(
+        &explain,
+        &[
+            "consultation_packet",
+            "evidence_digest",
+            "explanation",
+            "generated_at",
+            "observation_pack",
+            "project_dir",
+            "recent_events",
+            "review_state",
+            "run",
+        ],
+    );
+    assert_eq!(explain["run"]["run_id"], "task:task-256");
 }
 
 #[test]
@@ -1091,4 +1178,15 @@ impl Drop for TempProject {
     fn drop(&mut self) {
         let _ = fs::remove_dir_all(&self.root);
     }
+}
+
+fn assert_root_keys(value: &Value, expected: &[&str]) {
+    let mut keys = value
+        .as_object()
+        .expect("value should be an object")
+        .keys()
+        .map(String::as_str)
+        .collect::<Vec<_>>();
+    keys.sort_unstable();
+    assert_eq!(keys, expected);
 }

--- a/core/tests-rs/machine_contract.rs
+++ b/core/tests-rs/machine_contract.rs
@@ -52,6 +52,27 @@ fn machine_contract_exposes_projection_surfaces_in_stable_order() {
         catalog.projection_surfaces[5].command,
         "explain <run_id> --json"
     );
+    assert_eq!(
+        catalog
+            .projection_surfaces
+            .iter()
+            .map(|surface| surface.rust_type)
+            .collect::<Vec<_>>(),
+        vec![
+            "LedgerStatusPayload",
+            "LedgerBoardPayload",
+            "LedgerInboxPayload",
+            "LedgerDigestPayload",
+            "LedgerRunsPayload",
+            "LedgerExplainPayload",
+            "PollEventsPayload",
+            "ReviewRequestDispatchPayload",
+            "ReviewStateRecord",
+            "ReviewStateRecord",
+            "ReviewStateRecord",
+            "ReviewResetPayload",
+        ]
+    );
 }
 
 #[test]
@@ -203,6 +224,10 @@ fn machine_contract_serializes_to_json() {
         "budget_monthly_cents"
     );
     assert_eq!(value["projection_surfaces"][6]["name"], "poll-events");
+    assert_eq!(
+        value["projection_surfaces"][4]["rust_type"],
+        "LedgerRunsPayload"
+    );
     assert_eq!(value["review_state_file"]["states"][2], "FAIL");
     assert_eq!(value["event_taxonomy"][7]["group"], "security");
     assert_eq!(


### PR DESCRIPTION
## Summary
- move operator CLI JSON payload construction into typed ledger payload structs
- expose Rust payload type names in the machine contract
- add contract coverage for typed payload roots and all projection surface type metadata

## Validation
- cargo test --manifest-path core\Cargo.toml --test ledger_contract -- --nocapture
- cargo test --manifest-path core\Cargo.toml --test machine_contract -- --nocapture
- cargo test --manifest-path core\Cargo.toml --test operator_cli -- --nocapture
- cargo test --manifest-path core\Cargo.toml --test fixture_comparison -- --nocapture
- cargo check --manifest-path core\Cargo.toml
- git diff --check
- pwsh -NoProfile -File scripts\git-guard.ps1
- pwsh -NoProfile -File scripts\audit-public-surface.ps1
- codex exec review --uncommitted -m gpt-5.5 -c model_reasoning_effort="high"