### PR TITLE
Expose machine contract JSON

### DIFF
--- a/core/src/cli.rs
+++ b/core/src/cli.rs
@@ -133,6 +133,7 @@ OPERATOR COMMANDS:
     digest                  Print high-signal run digest
     desktop-summary         Print desktop summary projection JSON or counts
     provider-capabilities   Inspect the provider capability registry contract
+    machine-contract        Print the hook and agent machine contract JSON
     provider-switch         Record or clear a runtime provider reassignment
     signal <channel>        Send a file-backed orchestration signal
     wait <channel> [secs]   Wait for a file-backed orchestration signal
@@ -441,6 +442,7 @@ fn commands_text() -> &'static str {
   list-buffers (lsb)        - List paste buffers
   list-clients (lsc)        - List connected clients
   list-commands (lscm)      - List commands
+  machine-contract          - Print the hook and agent machine contract JSON
   list-keys (lsk)           - List key bindings
   list-panes (lsp)          - List panes in a window
   list-sessions (ls)        - List sessions
@@ -586,6 +588,7 @@ mod tests {
         let text = help_text("winsmux");
         assert!(text.contains("winsmux reads config on startup from the first compatible file found:"));
         assert!(text.contains("winsmux launches PowerShell 7 (pwsh) by default."));
+        assert!(text.contains("machine-contract        Print the hook and agent machine contract JSON"));
         assert!(text.contains("winsmux preserves compatibility aliases 'psmux', 'pmux', and 'tmux' where supported."));
         assert!(text.contains("For more information: https://github.com/Sora-bluesky/winsmux"));
         assert!(!text.contains("psmux reads config on startup from the first file found:"));
@@ -596,6 +599,7 @@ mod tests {
     fn commands_text_uses_winsmux_server_wording() {
         let text = commands_text();
         assert!(text.contains("kill-server               - Kill the winsmux server"));
+        assert!(text.contains("machine-contract          - Print the hook and agent machine contract JSON"));
         assert!(!text.contains("Kill the psmux server"));
     }
 }

--- a/core/src/machine_contract.rs
+++ b/core/src/machine_contract.rs
@@ -294,9 +294,13 @@ const EVENT_TAXONOMY: &[EventTaxonomyGroup<'static>] = &[
     EventTaxonomyGroup {
         group: "pane_lifecycle",
         events: &[
+            "approval_waiting",
+            "monitor.status",
             "pane.started",
             "pane.idle",
+            "pane.approval_waiting",
             "pane.completed",
+            "pane.bootstrap_invalid",
             "pane.crashed",
             "pane.hung",
             "pane.stalled",
@@ -307,6 +311,7 @@ const EVENT_TAXONOMY: &[EventTaxonomyGroup<'static>] = &[
         events: &[
             "operator.review_requested",
             "operator.review_failed",
+            "operator.blocked",
             "operator.commit_ready",
             "operator.followup",
             "operator.state_transition",
@@ -314,7 +319,11 @@ const EVENT_TAXONOMY: &[EventTaxonomyGroup<'static>] = &[
     },
     EventTaxonomyGroup {
         group: "consultation",
-        events: &["pane.consult_request", "pane.consult_result"],
+        events: &[
+            "pane.consult_request",
+            "pane.consult_result",
+            "pane.consult_error",
+        ],
     },
     EventTaxonomyGroup {
         group: "agent_heartbeat",
@@ -343,11 +352,20 @@ const EVENT_TAXONOMY: &[EventTaxonomyGroup<'static>] = &[
     },
     EventTaxonomyGroup {
         group: "verification",
-        events: &["pipeline.verify.pass", "pipeline.verify.fail"],
+        events: &[
+            "pipeline.verify.pass",
+            "pipeline.verify.fail",
+            "pipeline.verify.partial",
+        ],
     },
     EventTaxonomyGroup {
         group: "security",
-        events: &["pipeline.security.allowed", "pipeline.security.blocked"],
+        events: &[
+            "pipeline.security.allowed",
+            "pipeline.security.blocked",
+            "security.policy.allowed",
+            "security.policy.blocked",
+        ],
     },
 ];
 

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -25,6 +25,7 @@ mod terminal_engine;
 mod manifest_contract;
 mod event_contract;
 mod ledger;
+mod machine_contract;
 mod operator_cli;
 mod client;
 mod app;
@@ -250,6 +251,7 @@ fn run_main() -> io::Result<()> {
         "digest" => return operator_cli::run_digest_command(&cmd_args[1..]),
         "desktop-summary" => return operator_cli::run_desktop_summary_command(&cmd_args[1..]),
         "provider-capabilities" => return operator_cli::run_provider_capabilities_command(&cmd_args[1..]),
+        "machine-contract" => return operator_cli::run_machine_contract_command(&cmd_args[1..]),
         "provider-switch" => return operator_cli::run_provider_switch_command(&cmd_args[1..]),
         "signal" => return operator_cli::run_signal_command(&cmd_args[1..]),
         "wait" if !matches!(

--- a/core/src/operator_cli.rs
+++ b/core/src/operator_cli.rs
@@ -17,6 +17,7 @@ use crate::ledger::{
     LedgerBoardPayload, LedgerDigestItem, LedgerDigestPayload, LedgerExplainPayload,
     LedgerInboxPayload, LedgerRunsPayload, LedgerSnapshot, LedgerStatusPayload,
 };
+use crate::machine_contract::machine_contract_catalog;
 
 static REVIEW_REQUEST_COUNTER: AtomicU32 = AtomicU32::new(0);
 static ATOMIC_WRITE_COUNTER: AtomicU32 = AtomicU32::new(0);
@@ -193,6 +194,44 @@ pub fn run_provider_capabilities_command(args: &[&String]) -> io::Result<()> {
         println!("  {provider_id}");
     }
     Ok(())
+}
+
+pub fn run_machine_contract_command(args: &[&String]) -> io::Result<()> {
+    if should_print_help(args) {
+        println!("{}", usage_for("machine-contract"));
+        return Ok(());
+    }
+
+    let json = parse_machine_contract_options(args)?;
+    if !json {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "winsmux machine-contract currently supports only --json in the Rust CLI.",
+        ));
+    }
+    write_json(&machine_contract_catalog())
+}
+
+fn parse_machine_contract_options(args: &[&String]) -> io::Result<bool> {
+    let mut json = false;
+    for arg in args {
+        match arg.as_str() {
+            "--json" => json = true,
+            value if value.starts_with('-') => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!("unknown argument for winsmux machine-contract: {value}"),
+                ));
+            }
+            _ => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    usage_for("machine-contract").to_string(),
+                ));
+            }
+        }
+    }
+    Ok(json)
 }
 
 pub fn run_provider_switch_command(args: &[&String]) -> io::Result<()> {
@@ -2995,6 +3034,7 @@ fn usage_for(command: &str) -> &'static str {
         "provider-capabilities" => {
             "usage: winsmux provider-capabilities [provider] [--json] [--project-dir <path>]"
         }
+        "machine-contract" => "usage: winsmux machine-contract --json",
         "provider-switch" => {
             "usage: winsmux provider-switch <slot> [--agent <name>] [--model <name>] [--prompt-transport <argv|file|stdin>] [--auth-mode <mode>] [--reason <text>] [--restart] [--clear] [--json] [--project-dir <path>]"
         }

--- a/core/tests-rs/machine_contract.rs
+++ b/core/tests-rs/machine_contract.rs
@@ -192,8 +192,45 @@ fn machine_contract_exposes_event_taxonomy_groups() {
         .expect("verification taxonomy should exist");
     assert_eq!(
         verification.events,
-        ["pipeline.verify.pass", "pipeline.verify.fail"]
+        [
+            "pipeline.verify.pass",
+            "pipeline.verify.fail",
+            "pipeline.verify.partial"
+        ]
     );
+
+    let pane_lifecycle = catalog
+        .event_taxonomy
+        .iter()
+        .find(|group| group.group == "pane_lifecycle")
+        .expect("pane lifecycle taxonomy should exist");
+    assert!(pane_lifecycle.events.contains(&"approval_waiting"));
+    assert!(pane_lifecycle.events.contains(&"monitor.status"));
+    assert!(pane_lifecycle.events.contains(&"pane.approval_waiting"));
+    assert!(pane_lifecycle.events.contains(&"pane.bootstrap_invalid"));
+    assert!(pane_lifecycle.events.contains(&"pane.crashed"));
+
+    let consultation = catalog
+        .event_taxonomy
+        .iter()
+        .find(|group| group.group == "consultation")
+        .expect("consultation taxonomy should exist");
+    assert!(consultation.events.contains(&"pane.consult_error"));
+
+    let security = catalog
+        .event_taxonomy
+        .iter()
+        .find(|group| group.group == "security")
+        .expect("security taxonomy should exist");
+    assert!(security.events.contains(&"security.policy.allowed"));
+    assert!(security.events.contains(&"security.policy.blocked"));
+
+    let operator_actions = catalog
+        .event_taxonomy
+        .iter()
+        .find(|group| group.group == "operator_actions")
+        .expect("operator actions taxonomy should exist");
+    assert!(operator_actions.events.contains(&"operator.blocked"));
 
     let heartbeat = catalog
         .event_taxonomy

--- a/core/tests-rs/operator_cli.rs
+++ b/core/tests-rs/operator_cli.rs
@@ -524,6 +524,74 @@ fn operator_cli_provider_capabilities_json_reads_registry() {
 }
 
 #[test]
+fn operator_cli_machine_contract_json_exposes_hook_facing_catalog() {
+    let project_dir = make_temp_project_dir("machine-contract");
+
+    let json = run_json(&project_dir, &["machine-contract", "--json"]);
+
+    assert_eq!(json["version"], "0.24.2");
+    assert_eq!(json["roles"][0]["canonical"], "operator");
+    assert_eq!(json["roles"][1]["canonical"], "worker");
+    assert_eq!(json["projection_surfaces"][1]["name"], "board");
+    assert_eq!(
+        json["projection_surfaces"][1]["command"],
+        "board --json"
+    );
+    assert_eq!(
+        json["projection_surfaces"][4]["rust_type"],
+        "LedgerRunsPayload"
+    );
+    assert_eq!(json["review_state_file"]["path"], ".winsmux/review-state.json");
+    assert_eq!(json["event_taxonomy"][7]["group"], "security");
+    assert_eq!(
+        json["event_taxonomy"][7]["events"][3],
+        "security.policy.blocked"
+    );
+    assert_eq!(
+        json["verdict_fields"][1]["field"],
+        "verification_result.outcome"
+    );
+}
+
+#[test]
+fn operator_cli_machine_contract_requires_json() {
+    let project_dir = make_temp_project_dir("machine-contract-requires-json");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .arg("machine-contract")
+        .current_dir(&project_dir)
+        .output()
+        .expect("winsmux command should run");
+
+    assert!(!output.status.success(), "machine-contract should fail");
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("winsmux machine-contract currently supports only --json")
+    );
+}
+
+#[test]
+fn operator_cli_machine_contract_rejects_project_dir() {
+    let project_dir = make_temp_project_dir("machine-contract-rejects-project-dir");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .args(["machine-contract", "--json", "--project-dir"])
+        .arg(project_dir.as_os_str())
+        .current_dir(&project_dir)
+        .output()
+        .expect("winsmux command should run");
+
+    assert!(
+        !output.status.success(),
+        "machine-contract should reject project-dir"
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("unknown argument for winsmux machine-contract: --project-dir")
+    );
+}
+
+#[test]
 fn operator_cli_provider_capabilities_json_reads_single_provider_case_insensitive() {
     let project_dir = make_temp_project_dir("provider-capabilities-single");
     let winsmux_dir = project_dir.join(".winsmux");

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -8152,6 +8152,21 @@ function Invoke-ProviderCapabilities {
     }
 }
 
+function Invoke-MachineContract {
+    $tokens = @(@($Target) + @($Rest) | Where-Object { $_ })
+    if ($tokens.Count -ne 1 -or [string]$tokens[0] -ne '--json') {
+        Stop-WithError "usage: winsmux machine-contract --json"
+    }
+
+    $output = Invoke-WinsmuxRaw -Arguments @('machine-contract', '--json')
+    $nativeExitCode = Get-SafeLastExitCode
+    if ($null -ne $nativeExitCode -and $nativeExitCode -ne 0) {
+        exit $nativeExitCode
+    }
+
+    $output | Write-Output
+}
+
 function Invoke-ProviderSwitch {
     $tokens = @(@($Target) + @($Rest) | Where-Object { $_ })
     if ($tokens.Count -lt 1) {
@@ -8348,6 +8363,7 @@ Commands:
   consult-result <mode> [--message <text>] [--target-slot <slot>] [--confidence <0..1>] [--next-test <text>] [--risk <text>] [--run-id <run_id>] [--json]  Record a consultation result packet/event
   consult-error <mode> [--message <text>] [--target-slot <slot>]  Record a consultation error packet/event
   provider-capabilities [provider] [--json]  Inspect the provider capability registry contract
+  machine-contract --json  Print the hook and agent machine contract JSON
   provider-switch <slot> [--agent <name>] [--model <name>] [--prompt-transport <argv|file|stdin>] [--auth-mode <mode>] [--reason <text>] [--restart] [--clear] [--json]  Record or clear a runtime provider reassignment for a managed slot
   locks                     List active file locks
   verify <pr-number>        Run Pester in tests/ and merge PR only on PASS
@@ -8974,6 +8990,7 @@ switch ($Command) {
     'consult-error'   { Invoke-ConsultError }
     'launcher'        { Invoke-Launcher }
     'provider-capabilities' { Invoke-ProviderCapabilities }
+    'machine-contract' { Invoke-MachineContract }
     'provider-switch' { Invoke-ProviderSwitch }
     'rebind-worktree' { Invoke-RebindWorktree }
     ''                { Show-Usage }


### PR DESCRIPTION
## Summary
- add winsmux machine-contract --json for the Rust hook-facing contract catalog
- route scripts/winsmux-core.ps1 machine-contract --json to the Rust implementation and propagate native failures
- extend the machine contract event taxonomy for existing actionable, verification, security, and consultation events

## Validation
- cargo test --manifest-path core\\Cargo.toml --test machine_contract -- --nocapture
- cargo test --manifest-path core\\Cargo.toml --test operator_cli machine_contract -- --nocapture
- cargo test --manifest-path core\\Cargo.toml --test operator_cli -- --nocapture
- cargo test --manifest-path core\\Cargo.toml cli::tests -- --nocapture
- cargo check --manifest-path core\\Cargo.toml
- cargo build --manifest-path core\\Cargo.toml --bin winsmux
- pwsh -NoProfile -File scripts\\winsmux-core.ps1 machine-contract --json with target\\debug first on PATH
- delegated failure propagation check with fake winsmux.cmd returning exit code 7
- git diff --check
- pwsh -NoProfile -File scripts\\git-guard.ps1
- pwsh -NoProfile -File scripts\\audit-public-surface.ps1
- gpt-5.5-high review: APPROVE

Refs: TASK-269