### PR TITLE
Add hash-chained evidence ledger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6145,6 +6145,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha2",
  "unicode-width",
  "vt100-winsmux",
  "which",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -83,5 +83,6 @@ unicode-width = "0.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"
+sha2 = "0.10"
 regex = "1"
 glob = "0.3"

--- a/core/src/ledger.rs
+++ b/core/src/ledger.rs
@@ -2,6 +2,7 @@ use crate::event_contract::{parse_event_jsonl, EventRecord};
 use crate::manifest_contract::{NormalizedManifestPane, WinsmuxManifest};
 use serde::Serialize;
 use serde_json::Value;
+use sha2::{Digest, Sha256};
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::Path;
@@ -10,8 +11,39 @@ use std::path::Path;
 pub struct LedgerSnapshot {
     manifest: WinsmuxManifest,
     events: Vec<EventRecord>,
+    evidence_chain: LedgerEvidenceChainProjection,
     panes: Vec<NormalizedManifestPane>,
     panes_by_id: HashMap<String, NormalizedManifestPane>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct LedgerEvidenceChainProjection {
+    pub summary: LedgerEvidenceChainSummary,
+    pub entries: Vec<LedgerEvidenceChainEntry>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct LedgerEvidenceChainSummary {
+    pub entry_count: usize,
+    pub recorded_count: usize,
+    pub verified_count: usize,
+    pub tamper_detected_count: usize,
+    pub root_hash: String,
+    pub integrity_status: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct LedgerEvidenceChainEntry {
+    pub index: usize,
+    pub timestamp: String,
+    pub event: String,
+    pub previous_hash: String,
+    pub event_hash: String,
+    pub chain_hash: String,
+    pub recorded_previous_hash: String,
+    pub recorded_event_hash: String,
+    pub recorded_chain_hash: String,
+    pub integrity_status: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -310,6 +342,7 @@ pub struct LedgerStatusPayload {
     pub generated_at: String,
     pub project_dir: String,
     pub session: LedgerStatusSession,
+    pub evidence_chain: LedgerEvidenceChainSummary,
     pub summary: LedgerBoardSummary,
     pub panes: Vec<LedgerPaneReadModel>,
 }
@@ -476,6 +509,7 @@ impl LedgerStatusPayload {
                 pane_count: snapshot.pane_count(),
                 event_count: snapshot.event_count(),
             },
+            evidence_chain: snapshot.evidence_chain.summary.clone(),
             summary: snapshot.board_summary(),
             panes: snapshot.pane_read_models(),
         }
@@ -769,12 +803,14 @@ impl LedgerSnapshot {
         manifest.validate()?;
 
         let events = parse_event_jsonl(events_jsonl)?;
+        let evidence_chain = build_evidence_chain(events_jsonl, &events)?;
         let panes = manifest.normalized_panes_with_project_dir(project_dir);
         let panes_by_id = index_panes_by_id(&panes)?;
 
         let snapshot = Self {
             manifest,
             events,
+            evidence_chain,
             panes,
             panes_by_id,
         };
@@ -792,6 +828,10 @@ impl LedgerSnapshot {
 
     pub fn event_count(&self) -> usize {
         self.events.len()
+    }
+
+    pub fn evidence_chain_projection(&self) -> LedgerEvidenceChainProjection {
+        self.evidence_chain.clone()
     }
 
     pub fn pane_labels(&self) -> Vec<String> {
@@ -1217,6 +1257,40 @@ impl LedgerSnapshot {
 
         Ok(())
     }
+}
+
+pub fn attach_evidence_chain_to_event(
+    existing_events_jsonl: &str,
+    event: &Value,
+) -> Result<Value, String> {
+    let existing_records = parse_event_jsonl(existing_events_jsonl)?;
+    let existing_chain = build_evidence_chain(existing_events_jsonl, &existing_records)?;
+    let previous_hash = existing_chain.summary.root_hash;
+    let event_hash = evidence_event_hash(event)?;
+    let chain_hash = evidence_chain_hash(&previous_hash, &event_hash);
+
+    let mut event = event.clone();
+    let Some(event_object) = event.as_object_mut() else {
+        return Err("event record must be a JSON object".to_string());
+    };
+
+    let data = event_object
+        .entry("data".to_string())
+        .or_insert_with(|| Value::Object(serde_json::Map::new()));
+    let Some(data_object) = data.as_object_mut() else {
+        return Err("event.data must be an object".to_string());
+    };
+
+    data_object.insert(
+        "evidence_chain".to_string(),
+        serde_json::json!({
+            "previous_hash": previous_hash,
+            "event_hash": event_hash,
+            "chain_hash": chain_hash,
+        }),
+    );
+
+    Ok(event)
 }
 
 #[derive(Debug, Clone)]
@@ -1782,6 +1856,145 @@ fn first_non_empty(primary: &str, fallback: &str) -> String {
     }
 }
 
+fn build_evidence_chain(
+    events_jsonl: &str,
+    events: &[EventRecord],
+) -> Result<LedgerEvidenceChainProjection, String> {
+    let mut entries = Vec::new();
+    let mut previous_hash = String::new();
+
+    for (index, line) in events_jsonl
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .enumerate()
+    {
+        let event_value: Value = serde_json::from_str(line)
+            .map_err(|err| format!("failed to parse event line {}: {}", index + 1, err))?;
+        let event = events
+            .get(index)
+            .ok_or_else(|| format!("event line {} did not produce a typed record", index + 1))?;
+        let event_hash = evidence_event_hash(&event_value)?;
+        let chain_hash = evidence_chain_hash(&previous_hash, &event_hash);
+        let recorded_previous_hash = evidence_chain_field(&event_value, "previous_hash");
+        let recorded_event_hash = evidence_chain_field(&event_value, "event_hash");
+        let recorded_chain_hash = evidence_chain_field(&event_value, "chain_hash");
+        let integrity_status = evidence_integrity_status(
+            &previous_hash,
+            &event_hash,
+            &chain_hash,
+            &recorded_previous_hash,
+            &recorded_event_hash,
+            &recorded_chain_hash,
+        );
+
+        entries.push(LedgerEvidenceChainEntry {
+            index,
+            timestamp: event.timestamp.clone(),
+            event: event.event.clone(),
+            previous_hash: previous_hash.clone(),
+            event_hash,
+            chain_hash: chain_hash.clone(),
+            recorded_previous_hash,
+            recorded_event_hash,
+            recorded_chain_hash,
+            integrity_status,
+        });
+        previous_hash = chain_hash;
+    }
+
+    let recorded_count = entries
+        .iter()
+        .filter(|entry| {
+            !entry.recorded_previous_hash.trim().is_empty()
+                || !entry.recorded_event_hash.trim().is_empty()
+                || !entry.recorded_chain_hash.trim().is_empty()
+        })
+        .count();
+    let verified_count = entries
+        .iter()
+        .filter(|entry| entry.integrity_status == "verified")
+        .count();
+    let tamper_detected_count = entries
+        .iter()
+        .filter(|entry| entry.integrity_status == "tamper_detected")
+        .count();
+    let integrity_status = if tamper_detected_count > 0 {
+        "tamper_detected"
+    } else if recorded_count == entries.len() && !entries.is_empty() {
+        "verified"
+    } else {
+        "partial"
+    }
+    .to_string();
+
+    Ok(LedgerEvidenceChainProjection {
+        summary: LedgerEvidenceChainSummary {
+            entry_count: entries.len(),
+            recorded_count,
+            verified_count,
+            tamper_detected_count,
+            root_hash: previous_hash,
+            integrity_status,
+        },
+        entries,
+    })
+}
+
+fn evidence_event_hash(event: &Value) -> Result<String, String> {
+    let mut event = event.clone();
+    if let Some(data) = event.get_mut("data").and_then(Value::as_object_mut) {
+        data.remove("evidence_chain");
+    }
+    let canonical = serde_json::to_string(&event)
+        .map_err(|err| format!("failed to serialize event for evidence hash: {err}"))?;
+    Ok(sha256_hex(canonical.as_bytes()))
+}
+
+fn evidence_chain_hash(previous_hash: &str, event_hash: &str) -> String {
+    let payload = format!("{previous_hash}\n{event_hash}");
+    sha256_hex(payload.as_bytes())
+}
+
+fn evidence_chain_field(event: &Value, field: &str) -> String {
+    event
+        .get("data")
+        .and_then(|data| data.get("evidence_chain"))
+        .and_then(|chain| chain.get(field))
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string()
+}
+
+fn evidence_integrity_status(
+    previous_hash: &str,
+    event_hash: &str,
+    chain_hash: &str,
+    recorded_previous_hash: &str,
+    recorded_event_hash: &str,
+    recorded_chain_hash: &str,
+) -> String {
+    if recorded_previous_hash.trim().is_empty()
+        && recorded_event_hash.trim().is_empty()
+        && recorded_chain_hash.trim().is_empty()
+    {
+        return "unrecorded".to_string();
+    }
+
+    if recorded_previous_hash == previous_hash
+        && recorded_event_hash == event_hash
+        && recorded_chain_hash == chain_hash
+    {
+        return "verified".to_string();
+    }
+
+    "tamper_detected".to_string()
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let digest = Sha256::digest(bytes);
+    digest.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
 fn unique_sorted<'a, I>(values: I) -> Vec<String>
 where
     I: IntoIterator<Item = &'a str>,
@@ -1974,8 +2187,7 @@ fn verdict_summary_from_event(kind: &str, event: &EventRecord) -> Option<LedgerV
         "security" => first_non_empty_string(vec![
             event_data_nested_string(&event.data, "security_verdict", "summary")
                 .unwrap_or_default(),
-            event_data_nested_string(&event.data, "security_verdict", "reason")
-                .unwrap_or_default(),
+            event_data_nested_string(&event.data, "security_verdict", "reason").unwrap_or_default(),
             event_data_value_string(&event.data, "summary"),
             event_data_value_string(&event.data, "reason"),
             event.message.clone(),

--- a/core/src/operator_cli.rs
+++ b/core/src/operator_cli.rs
@@ -14,8 +14,9 @@ use serde_json::{json, Map, Value};
 
 use crate::event_contract::{parse_event_jsonl, EventRecord};
 use crate::ledger::{
-    LedgerBoardPayload, LedgerDigestItem, LedgerDigestPayload, LedgerExplainPayload,
-    LedgerInboxPayload, LedgerRunsPayload, LedgerSnapshot, LedgerStatusPayload,
+    attach_evidence_chain_to_event, LedgerBoardPayload, LedgerDigestItem, LedgerDigestPayload,
+    LedgerExplainPayload, LedgerInboxPayload, LedgerRunsPayload, LedgerSnapshot,
+    LedgerStatusPayload,
 };
 use crate::machine_contract::machine_contract_catalog;
 
@@ -5926,18 +5927,24 @@ fn append_event_record(project_dir: &Path, event: &Value) -> io::Result<()> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
     }
-    let line = serde_json::to_string(event).map_err(|err| {
-        io::Error::new(
-            io::ErrorKind::InvalidData,
-            format!("failed to serialize event record: {err}"),
-        )
-    })?;
     with_file_lock(&path, || {
         let mut content = if path.exists() {
             fs::read_to_string(&path)?
         } else {
             String::new()
         };
+        let event = attach_evidence_chain_to_event(&content, event).map_err(|err| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("failed to attach evidence chain: {err}"),
+            )
+        })?;
+        let line = serde_json::to_string(&event).map_err(|err| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("failed to serialize event record: {err}"),
+            )
+        })?;
         if !content.is_empty() && !content.ends_with('\n') {
             content.push('\n');
         }

--- a/core/tests-rs/ledger_contract.rs
+++ b/core/tests-rs/ledger_contract.rs
@@ -37,6 +37,141 @@ fn ledger_contract_loads_frozen_manifest_and_events() {
 }
 
 #[test]
+fn ledger_contract_computes_evidence_chain_for_legacy_events() {
+    let snapshot =
+        ledger::LedgerSnapshot::from_manifest_and_events(MANIFEST_FIXTURE, EVENTS_FIXTURE)
+            .expect("ledger snapshot should load frozen fixtures");
+
+    let chain = snapshot.evidence_chain_projection();
+
+    assert_eq!(chain.summary.entry_count, 5);
+    assert_eq!(chain.summary.recorded_count, 0);
+    assert_eq!(chain.summary.integrity_status, "partial");
+    assert_eq!(chain.summary.root_hash.len(), 64);
+    assert_eq!(chain.entries[0].previous_hash, "");
+    assert_eq!(chain.entries[1].previous_hash, chain.entries[0].chain_hash);
+    assert!(chain
+        .entries
+        .iter()
+        .all(|entry| entry.integrity_status == "unrecorded"));
+}
+
+#[test]
+fn ledger_contract_verifies_recorded_evidence_chain() {
+    let first = json!({
+        "timestamp": "2026-04-27T12:00:00+09:00",
+        "session": "winsmux-orchestra",
+        "event": "pane.consult_request",
+        "message": "first event",
+        "data": {"task_id": "task-chain"}
+    });
+    let first = ledger::attach_evidence_chain_to_event("", &first)
+        .expect("first event should receive evidence chain fields");
+    let first_line = serde_json::to_string(&first).expect("first event should serialize");
+    let second = json!({
+        "timestamp": "2026-04-27T12:00:01+09:00",
+        "session": "winsmux-orchestra",
+        "event": "pane.consult_result",
+        "message": "second-event-message",
+        "data": {"task_id": "task-chain"}
+    });
+    let second = ledger::attach_evidence_chain_to_event(&format!("{first_line}\n"), &second)
+        .expect("second event should receive evidence chain fields");
+    let second_line = serde_json::to_string(&second).expect("second event should serialize");
+    let events = format!("{first_line}\n{second_line}\n");
+
+    let snapshot = ledger::LedgerSnapshot::from_manifest_and_events(MANIFEST_FIXTURE, &events)
+        .expect("recorded evidence chain should load");
+    let chain = snapshot.evidence_chain_projection();
+
+    assert_eq!(chain.summary.entry_count, 2);
+    assert_eq!(chain.summary.recorded_count, 2);
+    assert_eq!(chain.summary.verified_count, 2);
+    assert_eq!(chain.summary.tamper_detected_count, 0);
+    assert_eq!(chain.summary.integrity_status, "verified");
+    assert_eq!(chain.entries[1].previous_hash, chain.entries[0].chain_hash);
+}
+
+#[test]
+fn ledger_contract_detects_recorded_evidence_chain_tampering() {
+    let first = json!({
+        "timestamp": "2026-04-27T12:00:00+09:00",
+        "session": "winsmux-orchestra",
+        "event": "pane.consult_request",
+        "message": "first event",
+        "data": {"task_id": "task-chain"}
+    });
+    let first = ledger::attach_evidence_chain_to_event("", &first)
+        .expect("first event should receive evidence chain fields");
+    let first_line = serde_json::to_string(&first).expect("first event should serialize");
+    let second = json!({
+        "timestamp": "2026-04-27T12:00:01+09:00",
+        "session": "winsmux-orchestra",
+        "event": "pane.consult_result",
+        "message": "second-event-message",
+        "data": {"task_id": "task-chain"}
+    });
+    let second = ledger::attach_evidence_chain_to_event(&format!("{first_line}\n"), &second)
+        .expect("second event should receive evidence chain fields");
+    let second_line = serde_json::to_string(&second).expect("second event should serialize");
+    let events = format!("{first_line}\n{second_line}\n")
+        .replace("second-event-message", "tampered-event-message");
+
+    let snapshot = ledger::LedgerSnapshot::from_manifest_and_events(MANIFEST_FIXTURE, &events)
+        .expect("tampered evidence chain should still load for reporting");
+    let chain = snapshot.evidence_chain_projection();
+
+    assert_eq!(chain.summary.entry_count, 2);
+    assert_eq!(chain.summary.recorded_count, 2);
+    assert_eq!(chain.summary.verified_count, 1);
+    assert_eq!(chain.summary.tamper_detected_count, 1);
+    assert_eq!(chain.summary.integrity_status, "tamper_detected");
+    assert_eq!(chain.entries[1].integrity_status, "tamper_detected");
+}
+
+#[test]
+fn ledger_contract_detects_recorded_event_hash_tampering() {
+    let event = json!({
+        "timestamp": "2026-04-27T12:00:00+09:00",
+        "session": "winsmux-orchestra",
+        "event": "pane.consult_request",
+        "message": "first event",
+        "data": {"task_id": "task-chain"}
+    });
+    let mut event = ledger::attach_evidence_chain_to_event("", &event)
+        .expect("event should receive evidence chain fields");
+    event["data"]["evidence_chain"]["event_hash"] = Value::String("0".repeat(64));
+    let event_line = serde_json::to_string(&event).expect("event should serialize");
+
+    let snapshot = ledger::LedgerSnapshot::from_manifest_and_events(MANIFEST_FIXTURE, &event_line)
+        .expect("tampered evidence chain should still load for reporting");
+    let chain = snapshot.evidence_chain_projection();
+
+    assert_eq!(chain.summary.entry_count, 1);
+    assert_eq!(chain.summary.recorded_count, 1);
+    assert_eq!(chain.summary.verified_count, 0);
+    assert_eq!(chain.summary.tamper_detected_count, 1);
+    assert_eq!(chain.summary.integrity_status, "tamper_detected");
+    assert_eq!(chain.entries[0].integrity_status, "tamper_detected");
+}
+
+#[test]
+fn ledger_contract_hashes_equivalent_json_key_order_consistently() {
+    let event_a = r#"{"timestamp":"2026-04-27T12:00:00+09:00","session":"winsmux-orchestra","event":"pane.consult_request","message":"same event","data":{"zeta":"last","alpha":"first"}}"#;
+    let event_b = r#"{"data":{"alpha":"first","zeta":"last"},"message":"same event","event":"pane.consult_request","session":"winsmux-orchestra","timestamp":"2026-04-27T12:00:00+09:00"}"#;
+
+    let snapshot_a = ledger::LedgerSnapshot::from_manifest_and_events(MANIFEST_FIXTURE, event_a)
+        .expect("first key order should load");
+    let snapshot_b = ledger::LedgerSnapshot::from_manifest_and_events(MANIFEST_FIXTURE, event_b)
+        .expect("second key order should load");
+    let chain_a = snapshot_a.evidence_chain_projection();
+    let chain_b = snapshot_b.evidence_chain_projection();
+
+    assert_eq!(chain_a.entries[0].event_hash, chain_b.entries[0].event_hash);
+    assert_eq!(chain_a.entries[0].chain_hash, chain_b.entries[0].chain_hash);
+}
+
+#[test]
 fn ledger_contract_exposes_ordered_pane_read_models() {
     let snapshot =
         ledger::LedgerSnapshot::from_manifest_and_events(MANIFEST_FIXTURE, EVENTS_FIXTURE)
@@ -525,9 +660,18 @@ fn ledger_contract_serializes_typed_cli_payload_roots() {
     .expect("status payload should serialize to JSON");
     assert_root_keys(
         &status,
-        &["generated_at", "panes", "project_dir", "session", "summary"],
+        &[
+            "evidence_chain",
+            "generated_at",
+            "panes",
+            "project_dir",
+            "session",
+            "summary",
+        ],
     );
     assert_eq!(status["session"]["name"], "winsmux-orchestra");
+    assert_eq!(status["evidence_chain"]["entry_count"], 5);
+    assert_eq!(status["evidence_chain"]["integrity_status"], "partial");
 
     let board = serde_json::to_value(ledger::LedgerBoardPayload::from_projection(
         "2026-04-27T00:00:00Z".to_string(),


### PR DESCRIPTION
## Summary
- add SHA-256 evidence-chain metadata for Rust-appended event records
- verify recorded `previous_hash`, `event_hash`, and `chain_hash` when loading ledger snapshots
- expose evidence-chain status in the typed status payload and add tamper/legacy/key-order tests

## Validation
- `cargo test --manifest-path core\Cargo.toml --test ledger_contract -- --nocapture` (63 passed)
- `cargo test --manifest-path core\Cargo.toml --test operator_cli -- --nocapture` (88 passed, elevated Windows shell)
- `cargo check --manifest-path core\Cargo.toml`
- `git diff --check -- Cargo.lock core/Cargo.toml core/src/ledger.rs core/src/operator_cli.rs core/tests-rs/ledger_contract.rs`
- `pwsh -NoProfile -File scripts\git-guard.ps1`
- `pwsh -NoProfile -File scripts\audit-public-surface.ps1`
- push hook: `git-guard`, public surface audit, and gitleaks passed

## Notes
- `cargo audit` is not installed in this environment; `cargo tree -i sha2` and `cargo tree -i serde_json` both show a single direct root from `winsmux`.
- Rust learning-note update received `Opus` review: `PASS`.