### PR TITLE
Add governance cost attribution

### DIFF
--- a/core/src/operator_cli.rs
+++ b/core/src/operator_cli.rs
@@ -1982,6 +1982,11 @@ pub fn run_consult_result_command(args: &[&String]) -> io::Result<()> {
             "next_test": options.next_test,
             "risks": options.risks,
             "consultation_ref": artifact.reference,
+            "cost_unit_refs": consultation_governance_cost_unit_refs(
+                &context,
+                &options.mode,
+                &options.target_slot,
+            ),
             "generated_at": timestamp,
         }));
     }
@@ -5744,6 +5749,10 @@ fn consultation_result_packet(
     timestamp: &str,
 ) -> Value {
     let mut packet = Map::new();
+    let (cost_unit_ref, cost_unit) =
+        consultation_governance_cost_unit(context, &options.mode, &options.target_slot);
+    let has_existing_cost_unit =
+        governance_cost_unit_exists(&options.project_dir, &cost_unit_ref);
     packet.insert("packet_type".to_string(), json!("consultation_packet"));
     packet.insert("generated_at".to_string(), json!(timestamp));
     packet.insert("run_id".to_string(), json!(context.run_id));
@@ -5763,6 +5772,10 @@ fn consultation_result_packet(
     );
     packet.insert("next_test".to_string(), json!(options.next_test));
     packet.insert("risks".to_string(), json!(options.risks));
+    packet.insert("cost_unit_refs".to_string(), json!([cost_unit_ref]));
+    if !has_existing_cost_unit {
+        packet.insert("governance_cost_units".to_string(), json!([cost_unit]));
+    }
     Value::Object(packet)
 }
 
@@ -5772,6 +5785,8 @@ fn consultation_request_packet(
     timestamp: &str,
 ) -> Value {
     let mut packet = Map::new();
+    let (_, cost_unit) =
+        consultation_governance_cost_unit(context, &options.mode, &options.target_slot);
     packet.insert("packet_type".to_string(), json!("consultation_packet"));
     packet.insert("generated_at".to_string(), json!(timestamp));
     packet.insert("run_id".to_string(), json!(context.run_id));
@@ -5785,6 +5800,7 @@ fn consultation_request_packet(
     packet.insert("head_sha".to_string(), json!(context.head_sha));
     packet.insert("worktree".to_string(), json!(context.worktree));
     packet.insert("request".to_string(), json!(options.message));
+    packet.insert("governance_cost_units".to_string(), json!([cost_unit]));
     Value::Object(packet)
 }
 
@@ -5794,6 +5810,10 @@ fn consultation_error_packet(
     timestamp: &str,
 ) -> Value {
     let mut packet = Map::new();
+    let (cost_unit_ref, cost_unit) =
+        consultation_governance_cost_unit(context, &options.mode, &options.target_slot);
+    let has_existing_cost_unit =
+        governance_cost_unit_exists(&options.project_dir, &cost_unit_ref);
     packet.insert("packet_type".to_string(), json!("consultation_packet"));
     packet.insert("generated_at".to_string(), json!(timestamp));
     packet.insert("run_id".to_string(), json!(context.run_id));
@@ -5807,7 +5827,79 @@ fn consultation_error_packet(
     packet.insert("head_sha".to_string(), json!(context.head_sha));
     packet.insert("worktree".to_string(), json!(context.worktree));
     packet.insert("error".to_string(), json!(options.message));
+    packet.insert("cost_unit_refs".to_string(), json!([cost_unit_ref]));
+    if !has_existing_cost_unit {
+        packet.insert("governance_cost_units".to_string(), json!([cost_unit]));
+    }
     Value::Object(packet)
+}
+
+fn consultation_governance_cost_unit_refs(
+    context: &ConsultationContext,
+    mode: &str,
+    target_slot: &str,
+) -> Vec<String> {
+    let (unit_id, _) = consultation_governance_cost_unit(context, mode, target_slot);
+    vec![unit_id]
+}
+
+fn consultation_governance_cost_unit(
+    context: &ConsultationContext,
+    mode: &str,
+    target_slot: &str,
+) -> (String, Value) {
+    let normalized_mode = mode.trim().to_ascii_lowercase();
+    let stage = format!("consult_{normalized_mode}");
+    let effective_target = if target_slot.trim().is_empty() {
+        context.slot.trim()
+    } else {
+        target_slot.trim()
+    };
+    let parts = [
+        "governance",
+        "consult",
+        normalized_mode.as_str(),
+        stage.as_str(),
+        context.task_id.as_str(),
+        context.run_id.as_str(),
+        effective_target,
+        "0",
+    ];
+    let unit_id = parts
+        .iter()
+        .filter_map(|part| {
+            let trimmed = part.trim();
+            (!trimmed.is_empty()).then_some(trimmed)
+        })
+        .collect::<Vec<_>>()
+        .join(":");
+
+    (
+        unit_id.clone(),
+        json!({
+            "unit_id": unit_id,
+            "unit_type": "governance_invocation",
+            "kind": "consult",
+            "mode": normalized_mode,
+            "stage": stage,
+            "task": context.task_id,
+            "run_id": context.run_id,
+            "role": context.role,
+            "target": effective_target,
+            "attempt": 0,
+            "source": "consult-command",
+            "quantity": 1,
+        }),
+    )
+}
+
+fn governance_cost_unit_exists(project_dir: &Path, unit_id: &str) -> bool {
+    let events_path = project_dir.join(".winsmux").join("events.jsonl");
+    let Ok(raw) = fs::read_to_string(events_path) else {
+        return false;
+    };
+    raw.lines()
+        .any(|line| line.contains("\"governance_cost_units\"") && line.contains(unit_id))
 }
 
 fn consultation_result_event(
@@ -5823,6 +5915,14 @@ fn consultation_result_event(
     data.insert("branch".to_string(), json!(context.branch));
     data.insert("worktree".to_string(), json!(context.worktree));
     data.insert("consultation_ref".to_string(), json!(consultation_ref));
+    let (cost_unit_ref, cost_unit) =
+        consultation_governance_cost_unit(context, &options.mode, &options.target_slot);
+    let has_existing_cost_unit =
+        governance_cost_unit_exists(&options.project_dir, &cost_unit_ref);
+    data.insert("cost_unit_refs".to_string(), json!([cost_unit_ref]));
+    if !has_existing_cost_unit {
+        data.insert("governance_cost_units".to_string(), json!([cost_unit]));
+    }
     data.insert("result".to_string(), json!(options.message));
     if let Some(confidence) = options.confidence {
         data.insert("confidence".to_string(), json!(confidence));
@@ -5858,6 +5958,9 @@ fn consultation_request_event(
     data.insert("branch".to_string(), json!(context.branch));
     data.insert("worktree".to_string(), json!(context.worktree));
     data.insert("consultation_ref".to_string(), json!(consultation_ref));
+    let (_, cost_unit) =
+        consultation_governance_cost_unit(context, &options.mode, &options.target_slot);
+    data.insert("governance_cost_units".to_string(), json!([cost_unit]));
 
     json!({
         "timestamp": timestamp,
@@ -5886,6 +5989,14 @@ fn consultation_error_event(
     data.insert("branch".to_string(), json!(context.branch));
     data.insert("worktree".to_string(), json!(context.worktree));
     data.insert("consultation_ref".to_string(), json!(consultation_ref));
+    let (cost_unit_ref, cost_unit) =
+        consultation_governance_cost_unit(context, &options.mode, &options.target_slot);
+    let has_existing_cost_unit =
+        governance_cost_unit_exists(&options.project_dir, &cost_unit_ref);
+    data.insert("cost_unit_refs".to_string(), json!([cost_unit_ref]));
+    if !has_existing_cost_unit {
+        data.insert("governance_cost_units".to_string(), json!([cost_unit]));
+    }
 
     json!({
         "timestamp": timestamp,

--- a/core/tests-rs/operator_cli.rs
+++ b/core/tests-rs/operator_cli.rs
@@ -195,7 +195,10 @@ fn operator_cli_explain_follow_reports_matching_events() {
 
     assert_eq!(item["event"], "operator.followup");
     assert_eq!(item["message"], "new evidence arrived");
-    assert_eq!(item["branch"], "codex/task266-rust-operator-readmodels-20260424");
+    assert_eq!(
+        item["branch"],
+        "codex/task266-rust-operator-readmodels-20260424"
+    );
     assert_eq!(item["test_plan"][0], "run focused test");
     assert_eq!(item["test_plan"][1], "inspect logs");
     assert_eq!(item["next_action"], "review");
@@ -387,9 +390,9 @@ fn operator_cli_desktop_summary_text_reports_counts() {
         String::from_utf8_lossy(&output.stderr)
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains(
-        "Desktop summary: 2 panes, 2 inbox items, 2 digest items, 2 projections"
-    ));
+    assert!(
+        stdout.contains("Desktop summary: 2 panes, 2 inbox items, 2 digest items, 2 projections")
+    );
 }
 
 #[test]
@@ -520,7 +523,10 @@ fn operator_cli_provider_capabilities_json_reads_registry() {
         registry["providers"]["codex"]["prompt_transports"][2],
         "stdin"
     );
-    assert_eq!(registry["providers"]["claude"]["supports_parallel_runs"], true);
+    assert_eq!(
+        registry["providers"]["claude"]["supports_parallel_runs"],
+        true
+    );
 }
 
 #[test]
@@ -533,15 +539,15 @@ fn operator_cli_machine_contract_json_exposes_hook_facing_catalog() {
     assert_eq!(json["roles"][0]["canonical"], "operator");
     assert_eq!(json["roles"][1]["canonical"], "worker");
     assert_eq!(json["projection_surfaces"][1]["name"], "board");
-    assert_eq!(
-        json["projection_surfaces"][1]["command"],
-        "board --json"
-    );
+    assert_eq!(json["projection_surfaces"][1]["command"], "board --json");
     assert_eq!(
         json["projection_surfaces"][4]["rust_type"],
         "LedgerRunsPayload"
     );
-    assert_eq!(json["review_state_file"]["path"], ".winsmux/review-state.json");
+    assert_eq!(
+        json["review_state_file"]["path"],
+        ".winsmux/review-state.json"
+    );
     assert_eq!(json["event_taxonomy"][7]["group"], "security");
     assert_eq!(
         json["event_taxonomy"][7]["events"][3],
@@ -564,10 +570,8 @@ fn operator_cli_machine_contract_requires_json() {
         .expect("winsmux command should run");
 
     assert!(!output.status.success(), "machine-contract should fail");
-    assert!(
-        String::from_utf8_lossy(&output.stderr)
-            .contains("winsmux machine-contract currently supports only --json")
-    );
+    assert!(String::from_utf8_lossy(&output.stderr)
+        .contains("winsmux machine-contract currently supports only --json"));
 }
 
 #[test]
@@ -585,10 +589,8 @@ fn operator_cli_machine_contract_rejects_project_dir() {
         !output.status.success(),
         "machine-contract should reject project-dir"
     );
-    assert!(
-        String::from_utf8_lossy(&output.stderr)
-            .contains("unknown argument for winsmux machine-contract: --project-dir")
-    );
+    assert!(String::from_utf8_lossy(&output.stderr)
+        .contains("unknown argument for winsmux machine-contract: --project-dir"));
 }
 
 #[test]
@@ -608,7 +610,10 @@ fn operator_cli_provider_capabilities_json_reads_single_provider_case_insensitiv
     assert_eq!(provider["capabilities"]["adapter"], "codex");
     assert_eq!(provider["capabilities"]["command"], "codex");
     assert_eq!(provider["capabilities"]["prompt_transports"][0], "argv");
-    assert_eq!(provider["capabilities"]["auth_modes"][0], "local_interactive");
+    assert_eq!(
+        provider["capabilities"]["auth_modes"][0],
+        "local_interactive"
+    );
     assert_eq!(provider["capabilities"]["supports_file_edit"], true);
 }
 
@@ -777,13 +782,7 @@ fn operator_cli_provider_switch_validates_candidate_before_write() {
     write_provider_switch_fixture(&project_dir);
 
     let output = Command::new(env!("CARGO_BIN_EXE_winsmux"))
-        .args([
-            "provider-switch",
-            "worker-1",
-            "--agent",
-            "claude",
-            "--json",
-        ])
+        .args(["provider-switch", "worker-1", "--agent", "claude", "--json"])
         .current_dir(&project_dir)
         .output()
         .expect("winsmux command should run");
@@ -829,7 +828,9 @@ fn operator_cli_provider_switch_replaces_case_variant_registry_key() {
     assert_eq!(result["slot_id"], "worker-1");
     assert_eq!(result["model"], "gpt-5.4");
     let registry = read_json_file(&project_dir.join(".winsmux").join("provider-registry.json"));
-    let slots = registry["slots"].as_object().expect("slots should be a map");
+    let slots = registry["slots"]
+        .as_object()
+        .expect("slots should be a map");
     assert_eq!(slots.len(), 1);
     assert!(slots.get("WORKER-1").is_none());
     assert_eq!(registry["slots"]["worker-1"]["model"], "gpt-5.4");
@@ -925,7 +926,13 @@ external-operator: true
 
     let result = run_json(
         &project_dir,
-        &["provider-switch", "worker-2", "--model", "gpt-5.5", "--json"],
+        &[
+            "provider-switch",
+            "worker-2",
+            "--model",
+            "gpt-5.5",
+            "--json",
+        ],
     );
 
     assert_eq!(result["slot_id"], "worker-2");
@@ -1111,7 +1118,10 @@ fn operator_cli_provider_switch_restart_merges_partial_override_with_slot() {
     let settings = fs::read_to_string(project_dir.join(".winsmux.yaml"))
         .expect("test should read settings")
         .replace("    agent: codex\n", "    agent: claude\n")
-        .replace("    prompt-transport: argv\n", "    prompt-transport: file\n");
+        .replace(
+            "    prompt-transport: argv\n",
+            "    prompt-transport: file\n",
+        );
     fs::write(project_dir.join(".winsmux.yaml"), settings).expect("test should write settings");
     fs::write(
         project_dir.join(".winsmux").join("manifest.yaml"),
@@ -1178,7 +1188,10 @@ fn operator_cli_conflict_preflight_json_reports_clean_result() {
     run_git(&project_dir, &["commit", "-m", "right change"]);
     run_git(&project_dir, &["branch", "right"]);
 
-    let json = run_json(&project_dir, &["conflict-preflight", "left", "right", "--json"]);
+    let json = run_json(
+        &project_dir,
+        &["conflict-preflight", "left", "right", "--json"],
+    );
 
     assert_eq!(json["command"], "conflict-preflight");
     assert_eq!(json["status"], "clean");
@@ -1252,7 +1265,10 @@ fn operator_cli_conflict_preflight_json_reports_conflict() {
     run_git(&project_dir, &["commit", "-m", "right change"]);
     run_git(&project_dir, &["branch", "right"]);
 
-    let json = run_json(&project_dir, &["conflict-preflight", "left", "right", "--json"]);
+    let json = run_json(
+        &project_dir,
+        &["conflict-preflight", "left", "right", "--json"],
+    );
 
     assert_eq!(json["status"], "conflict");
     assert_eq!(json["reason"], "merge_conflict");
@@ -1355,8 +1371,14 @@ fn operator_cli_signal_treats_leading_dash_as_channel() {
         String::from_utf8_lossy(&output.stdout).trim(),
         "sent signal: --json"
     );
-    let signal_file = temp_dir.join("winsmux").join("signals").join("--json.signal");
-    assert!(signal_file.exists(), "leading-dash channel should be literal");
+    let signal_file = temp_dir
+        .join("winsmux")
+        .join("signals")
+        .join("--json.signal");
+    assert!(
+        signal_file.exists(),
+        "leading-dash channel should be literal"
+    );
 }
 
 #[test]
@@ -1412,7 +1434,10 @@ fn operator_cli_wait_treats_leading_dash_as_channel() {
         String::from_utf8_lossy(&output.stdout).trim(),
         "received signal: --json"
     );
-    assert!(!signal_file.exists(), "leading-dash channel should be literal");
+    assert!(
+        !signal_file.exists(),
+        "leading-dash channel should be literal"
+    );
 }
 
 #[test]
@@ -1436,7 +1461,10 @@ fn operator_cli_wait_treats_dash_t_as_channel() {
         "winsmux command failed: {}",
         String::from_utf8_lossy(&output.stderr)
     );
-    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "received signal: -t");
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        "received signal: -t"
+    );
     assert!(!signal_file.exists(), "-t channel should be literal");
 }
 
@@ -1866,8 +1894,6 @@ fn operator_cli_consult_error_records_packet_event_and_manifest() {
             "stuck",
             "--message",
             "Reviewer context is missing",
-            "--target-slot",
-            "reviewer-1",
         ])
         .current_dir(&project_dir)
         .env("WINSMUX_PANE_ID", "%2")
@@ -1910,8 +1936,28 @@ fn operator_cli_consult_error_records_packet_event_and_manifest() {
     assert_eq!(packet["kind"], "consult_error");
     assert_eq!(packet["mode"], "stuck");
     assert_eq!(packet["error"], "Reviewer context is missing");
+    assert!(packet["cost_unit_refs"][0]
+        .as_str()
+        .expect("cost unit ref should be a string")
+        .starts_with("governance:consult:stuck"));
+    assert!(packet["cost_unit_refs"][0]
+        .as_str()
+        .expect("cost unit ref should be a string")
+        .contains("builder-1"));
+    assert_eq!(
+        packet["governance_cost_units"][0]["unit_id"],
+        packet["cost_unit_refs"][0]
+    );
     assert!(packet.get("recommendation").is_none());
     assert!(last_event["data"].get("result").is_none());
+    assert_eq!(
+        last_event["data"]["cost_unit_refs"],
+        packet["cost_unit_refs"]
+    );
+    assert_eq!(
+        last_event["data"]["governance_cost_units"][0]["unit_id"],
+        packet["cost_unit_refs"][0]
+    );
 
     let builder = read_manifest_pane(&project_dir, "builder-1");
     assert_eq!(builder["last_event"], "consult.error");
@@ -1978,8 +2024,18 @@ fn operator_cli_consult_request_records_packet_event_and_manifest() {
     assert_eq!(packet["mode"], "early");
     assert_eq!(packet["request"], "Please review the Rust port");
     assert!(packet.get("recommendation").is_none());
+    assert_eq!(
+        packet["governance_cost_units"][0]["unit_type"],
+        "governance_invocation"
+    );
+    assert_eq!(packet["governance_cost_units"][0]["kind"], "consult");
+    assert_eq!(packet["governance_cost_units"][0]["mode"], "early");
 
     assert_eq!(last_event["data"]["consultation_ref"], consultation_ref);
+    assert_eq!(
+        last_event["data"]["governance_cost_units"][0]["unit_id"],
+        packet["governance_cost_units"][0]["unit_id"]
+    );
     assert!(last_event["data"].get("result").is_none());
 
     let builder = read_manifest_pane(&project_dir, "builder-1");
@@ -2038,6 +2094,14 @@ fn operator_cli_consult_result_records_packet_event_and_manifest() {
         "cargo test --manifest-path core/Cargo.toml --test operator_cli"
     );
     assert_eq!(json["risks"][0], "manifest update could drift");
+    assert!(json["cost_unit_refs"][0]
+        .as_str()
+        .expect("cost unit ref should be a string")
+        .starts_with("governance:consult:final"));
+    assert!(json["cost_unit_refs"][0]
+        .as_str()
+        .expect("cost unit ref should be a string")
+        .contains("builder-1"));
     let consultation_ref = json["consultation_ref"]
         .as_str()
         .expect("consultation_ref should be a string");
@@ -2054,6 +2118,11 @@ fn operator_cli_consult_result_records_packet_event_and_manifest() {
     assert_eq!(packet["recommendation"], "Ship the Rust command");
     assert_eq!(packet["next_test"], json["next_test"]);
     assert_eq!(packet["risks"][0], "manifest update could drift");
+    assert_eq!(packet["cost_unit_refs"], json["cost_unit_refs"]);
+    assert_eq!(
+        packet["governance_cost_units"][0]["unit_id"],
+        json["cost_unit_refs"][0]
+    );
 
     let events = fs::read_to_string(project_dir.join(".winsmux").join("events.jsonl"))
         .expect("events should be readable");
@@ -2067,10 +2136,15 @@ fn operator_cli_consult_result_records_packet_event_and_manifest() {
     .expect("event should be JSON");
     assert_eq!(last_event["event"], "pane.consult_result");
     assert_eq!(last_event["message"], "Ship the Rust command");
+    assert_eq!(
+        last_event["data"]["governance_cost_units"][0]["unit_id"],
+        json["cost_unit_refs"][0]
+    );
     assert_eq!(last_event["data"]["result"], "Ship the Rust command");
     assert_eq!(last_event["data"]["confidence"], 0.82);
     assert_eq!(last_event["data"]["next_action"], json["next_test"]);
     assert_eq!(last_event["data"]["consultation_ref"], consultation_ref);
+    assert_eq!(last_event["data"]["cost_unit_refs"], json["cost_unit_refs"]);
 
     let builder = read_manifest_pane(&project_dir, "builder-1");
     assert_eq!(builder["last_event"], "consult.result");
@@ -2112,6 +2186,10 @@ fn operator_cli_consult_result_accepts_run_override() {
     assert_eq!(result["target_slot"], "reviewer-1");
     assert_eq!(result["recommendation"], "Use the existing review state");
     assert!(result["confidence"].is_null());
+    assert!(result["cost_unit_refs"][0]
+        .as_str()
+        .expect("cost unit ref should be a string")
+        .starts_with("governance:consult:reconcile"));
 
     let consultation_ref = result["consultation_ref"]
         .as_str()
@@ -2225,10 +2303,8 @@ fn operator_cli_consult_request_rejects_invalid_input() {
         .output()
         .expect("winsmux command should run");
     assert!(!unknown_option.status.success());
-    assert!(
-        String::from_utf8_lossy(&unknown_option.stderr)
-            .contains("unknown argument for winsmux consult-request")
-    );
+    assert!(String::from_utf8_lossy(&unknown_option.stderr)
+        .contains("unknown argument for winsmux consult-request"));
 
     let bad_confidence = Command::new(env!("CARGO_BIN_EXE_winsmux"))
         .args(["consult-request", "early", "--confidence", "nope"])
@@ -2239,8 +2315,7 @@ fn operator_cli_consult_request_rejects_invalid_input() {
         .expect("winsmux command should run");
     assert!(!bad_confidence.status.success());
     assert!(
-        String::from_utf8_lossy(&bad_confidence.stderr)
-            .contains("Invalid confidence value: nope")
+        String::from_utf8_lossy(&bad_confidence.stderr).contains("Invalid confidence value: nope")
     );
 }
 
@@ -2294,10 +2369,8 @@ fn operator_cli_consult_error_rejects_invalid_input() {
         .output()
         .expect("winsmux command should run");
     assert!(!unknown_option.status.success());
-    assert!(
-        String::from_utf8_lossy(&unknown_option.stderr)
-            .contains("unknown argument for winsmux consult-error")
-    );
+    assert!(String::from_utf8_lossy(&unknown_option.stderr)
+        .contains("unknown argument for winsmux consult-error"));
 
     let bad_confidence = Command::new(env!("CARGO_BIN_EXE_winsmux"))
         .args(["consult-error", "early", "--confidence", "nope"])
@@ -2308,8 +2381,7 @@ fn operator_cli_consult_error_rejects_invalid_input() {
         .expect("winsmux command should run");
     assert!(!bad_confidence.status.success());
     assert!(
-        String::from_utf8_lossy(&bad_confidence.stderr)
-            .contains("Invalid confidence value: nope")
+        String::from_utf8_lossy(&bad_confidence.stderr).contains("Invalid confidence value: nope")
     );
 
     let missing_run_id = Command::new(env!("CARGO_BIN_EXE_winsmux"))
@@ -3781,7 +3853,10 @@ fn run_json_with_cwd(cwd: impl AsRef<std::path::Path>, args: &[&str]) -> serde_j
 
 fn init_conflict_preflight_repo(project_dir: &std::path::Path) {
     run_git(project_dir, &["init"]);
-    run_git(project_dir, &["config", "user.email", "winsmux-test@example.com"]);
+    run_git(
+        project_dir,
+        &["config", "user.email", "winsmux-test@example.com"],
+    );
     run_git(project_dir, &["config", "user.name", "winsmux test"]);
     write_git_file(project_dir, "base.txt", "base\n");
     run_git(project_dir, &["add", "base.txt"]);

--- a/scripts/codex-subagent-worktree-guard.ps1
+++ b/scripts/codex-subagent-worktree-guard.ps1
@@ -46,10 +46,10 @@ function New-GuardResult {
     param(
         [Parameter(Mandatory = $true)][bool]$Ok,
         [Parameter(Mandatory = $true)][string]$Reason,
-        [Parameter(Mandatory = $true)][string]$WorktreeRoot,
-        [Parameter(Mandatory = $true)][string]$RepoRoot,
-        [Parameter(Mandatory = $true)][string]$GitDir,
-        [Parameter(Mandatory = $true)][string]$CommonGitDir
+        [Parameter(Mandatory = $true)][AllowEmptyString()][string]$WorktreeRoot,
+        [Parameter(Mandatory = $true)][AllowEmptyString()][string]$RepoRoot,
+        [Parameter(Mandatory = $true)][AllowEmptyString()][string]$GitDir,
+        [Parameter(Mandatory = $true)][AllowEmptyString()][string]$CommonGitDir
     )
 
     [PSCustomObject]@{

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -1302,6 +1302,43 @@ function Get-ConsultationCommandContext {
     }
 }
 
+function Test-ConsultationGovernanceCostUnitExists {
+    param(
+        [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [Parameter(Mandatory = $true)][string]$UnitId
+    )
+
+    foreach ($record in @(Get-BridgeEventRecords -ProjectDir $ProjectDir)) {
+        $data = $record['data']
+        if ($null -eq $data) {
+            continue
+        }
+        $units = @()
+        if ($data -is [hashtable]) {
+            if ($data.ContainsKey('governance_cost_units')) {
+                $units = @($data['governance_cost_units'])
+            }
+        } else {
+            $property = $data.PSObject.Properties['governance_cost_units']
+            if ($null -ne $property) {
+                $units = @($property.Value)
+            }
+        }
+        foreach ($unit in $units) {
+            $candidate = ''
+            if ($unit -is [hashtable] -and $unit.ContainsKey('unit_id')) {
+                $candidate = [string]$unit['unit_id']
+            } elseif ($null -ne $unit.unit_id) {
+                $candidate = [string]$unit.unit_id
+            }
+            if ($candidate -eq $UnitId) {
+                return $true
+            }
+        }
+    }
+    return $false
+}
+
 function Write-ConsultationCommandRecord {
     param(
         [Parameter(Mandatory = $true)][string]$Kind,
@@ -1349,6 +1386,21 @@ function Write-ConsultationCommandRecord {
         default { Stop-WithError "Unsupported consultation command kind: $Kind" }
     }
 
+    $costTarget = [string]$TargetSlot
+    if ([string]::IsNullOrWhiteSpace($costTarget)) {
+        $costTarget = [string]$context.Slot
+    }
+    $costUnit = New-WinsmuxGovernanceCostUnit -Kind 'consult' -Mode $Mode -Task ([string]$context.TaskId) -RunId ([string]$context.RunId) -Stage ("consult_{0}" -f $Mode) -Role ([string]$context.Role) -Target $costTarget -Source 'consult-command'
+    $hasExistingCostUnit = Test-ConsultationGovernanceCostUnitExists -ProjectDir $ProjectDir -UnitId ([string]$costUnit.unit_id)
+    if ($Kind -eq 'consult_request') {
+        $packet['governance_cost_units'] = @($costUnit)
+    } else {
+        $packet['cost_unit_refs'] = @([string]$costUnit.unit_id)
+        if (-not $hasExistingCostUnit) {
+            $packet['governance_cost_units'] = @($costUnit)
+        }
+    }
+
     $artifact = New-ConsultationPacketFile -ProjectDir $ProjectDir -ConsultationPacket $packet
 
     $eventData = [ordered]@{
@@ -1358,6 +1410,14 @@ function Write-ConsultationCommandRecord {
         branch           = [string]$context.Branch
         worktree         = [string]$context.Worktree
         consultation_ref = [string]$artifact.reference
+    }
+    if ($Kind -eq 'consult_request') {
+        $eventData['governance_cost_units'] = @($costUnit)
+    } else {
+        $eventData['cost_unit_refs'] = @([string]$costUnit.unit_id)
+        if (-not $hasExistingCostUnit) {
+            $eventData['governance_cost_units'] = @($costUnit)
+        }
     }
 
     if ($Kind -eq 'consult_result') {
@@ -1404,6 +1464,7 @@ function Write-ConsultationCommandRecord {
             next_test        = [string]$NextTest
             risks            = @($Risks)
             consultation_ref = [string]$artifact.reference
+            cost_unit_refs   = @([string]$costUnit.unit_id)
             generated_at     = $timestamp
         } | ConvertTo-Json -Compress -Depth 8 | Write-Output
         return

--- a/tests/codex-subagent-worktree-guard.Tests.ps1
+++ b/tests/codex-subagent-worktree-guard.Tests.ps1
@@ -31,4 +31,37 @@ Describe 'codex subagent worktree guard' {
         $output.reason | Should -Be 'dedicated git worktree confirmed'
         $output.worktree_root | Should -Be ([System.IO.Path]::GetFullPath($worker))
     }
+
+    It 'returns json when git metadata cannot be read' {
+        $notRepo = Join-Path $TestDrive 'not-repo'
+        New-Item -ItemType Directory -Path $notRepo | Out-Null
+
+        $output = & pwsh -NoProfile -File $script:GuardScript -RepoRoot $script:RepoRoot -WorktreePath $notRepo -Json | ConvertFrom-Json
+
+        $LASTEXITCODE | Should -Be 1
+        $output.ok | Should -BeFalse
+        $output.reason | Should -Match 'git metadata probe failed'
+        $output.worktree_root | Should -Be ''
+        $output.git_dir | Should -Be ''
+    }
+
+    It 'requires the operator repo root when the target is the current linked checkout' {
+        $repo = Join-Path $TestDrive 'repo-current-linked'
+        $worker = Join-Path $TestDrive 'worker-current-linked'
+        New-Item -ItemType Directory -Path $repo | Out-Null
+        & git -C $repo init | Out-Null
+        & git -C $repo config user.name 'winsmux-test' | Out-Null
+        & git -C $repo config user.email 'winsmux-test@example.invalid' | Out-Null
+        Set-Content -Path (Join-Path $repo 'README.md') -Value 'test repo'
+        & git -C $repo add README.md | Out-Null
+        & git -C $repo commit -m 'initial commit' | Out-Null
+        & git -C $repo worktree add -b worker-current-linked $worker | Out-Null
+
+        $output = & pwsh -NoProfile -File $script:GuardScript -RepoRoot $worker -WorktreePath $worker -Json | ConvertFrom-Json
+
+        $LASTEXITCODE | Should -Be 1
+        $output.ok | Should -BeFalse
+        $output.reason | Should -Match 'shared operator checkout'
+        $output.worktree_root | Should -Be ([System.IO.Path]::GetFullPath($worker))
+    }
 }

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -1740,6 +1740,8 @@ NEXT_ACTION: rerun focused verification
         $result.FinalStatus | Should -Be 'VERIFY_BLOCKED'
         @($script:teamPipelineEvents | Where-Object { $_.Event -eq 'pipeline.review.dispatched' }).Count | Should -Be 0
         @($script:teamPipelineEvents | Where-Object { $_.Event -eq 'pipeline.security.blocked' }).Count | Should -BeGreaterThan 0
+        $verifyResult = @($script:teamPipelineEvents | Where-Object { $_.Event -eq 'pipeline.verify.partial' })[0]
+        $verifyResult.Data.Contains('cost_unit_refs') | Should -BeFalse
     }
 
     It 'selects sensible planning and verification targets from the available roles' {
@@ -1958,6 +1960,22 @@ NEXT_ACTION: rerun focused verification
         @($script:teamPipelineBridgeCalls | Where-Object { $_[0] -eq 'send' -and $_[1] -eq 'reviewer' }).Count | Should -Be 3
         @($script:teamPipelineEvents | Where-Object { $_.Event -eq 'pipeline.consult.dispatched' }).Count | Should -Be 2
         @($script:teamPipelineEvents | Where-Object { $_.Event -eq 'pipeline.consult.completed' }).Count | Should -Be 2
+        @($script:teamPipelineEvents | Where-Object { $_.Event -eq 'pipeline.review.dispatched' }).Count | Should -Be 1
+
+        $consultDispatch = @($script:teamPipelineEvents | Where-Object { $_.Event -eq 'pipeline.consult.dispatched' })[0]
+        $consultDispatch.Data.governance_cost_units[0].unit_type | Should -Be 'governance_invocation'
+        $consultDispatch.Data.governance_cost_units[0].kind | Should -Be 'consult'
+        $consultDispatch.Data.governance_cost_units[0].mode | Should -Be 'early'
+
+        $consultComplete = @($script:teamPipelineEvents | Where-Object { $_.Event -eq 'pipeline.consult.completed' })[0]
+        $consultComplete.Data.cost_unit_refs[0] | Should -Be $consultDispatch.Data.governance_cost_units[0].unit_id
+
+        $verifyDispatch = @($script:teamPipelineEvents | Where-Object { $_.Event -eq 'pipeline.review.dispatched' })[0]
+        $verifyDispatch.Data.governance_cost_units[0].unit_type | Should -Be 'governance_invocation'
+        $verifyDispatch.Data.governance_cost_units[0].kind | Should -Be 'verify'
+
+        $verifyResult = @($script:teamPipelineEvents | Where-Object { $_.Event -eq 'pipeline.verify.pass' })[0]
+        $verifyResult.Data.cost_unit_refs[0] | Should -Be $verifyDispatch.Data.governance_cost_units[0].unit_id
     }
 
     It 'inserts a stuck consult before returning blocked execution' {
@@ -2130,6 +2148,17 @@ hook_profile: ci
         $clean.AllowedVariableNames | Should -Contain 'WINSMUX_GOVERNANCE_MODE'
         $clean.Environment.WINSMUX_ROLE | Should -Be 'Worker'
         $clean.Environment.WINSMUX_PANE_ID | Should -Be '%4'
+    }
+
+    It 'creates a normalized governance cost unit' {
+        $unit = New-WinsmuxGovernanceCostUnit -Kind 'Consult' -Mode 'Final' -Task 'TASK-310' -RunId 'task:310' -Stage 'CONSULT_FINAL' -Role 'Reviewer' -Target 'reviewer' -Attempt 1 -Source 'test'
+
+        $unit.unit_type | Should -Be 'governance_invocation'
+        $unit.kind | Should -Be 'consult'
+        $unit.mode | Should -Be 'final'
+        $unit.stage | Should -Be 'consult_final'
+        $unit.quantity | Should -Be 1
+        $unit.unit_id | Should -Match 'TASK-310'
     }
 }
 
@@ -12400,12 +12429,16 @@ panes:
         $events[0].event | Should -Be 'pane.consult_request'
         $events[0].data.consultation_ref | Should -BeLike '.winsmux/consultations/consult-request-*.json'
         $events[0].data.run_id | Should -Be 'task:task-301'
+        $events[0].data.governance_cost_units[0].unit_type | Should -Be 'governance_invocation'
+        $events[0].data.governance_cost_units[0].kind | Should -Be 'consult'
+        $events[0].data.governance_cost_units[0].mode | Should -Be 'early'
 
         $packet = Read-WinsmuxArtifactJson -Reference ([string]$events[0].data.consultation_ref) -ProjectDir $script:consultTempRoot -ExpectedDirectoryPath (Get-ConsultationDirectory -ProjectDir $script:consultTempRoot) -ExpectedRunId 'task:task-301'
         $packet.kind | Should -Be 'consult_request'
         $packet.mode | Should -Be 'early'
         $packet.target_slot | Should -Be 'slot-review-1'
         $packet.request | Should -Be 'sanity-check the current hypothesis'
+        $packet.governance_cost_units[0].unit_id | Should -Be $events[0].data.governance_cost_units[0].unit_id
     }
 
     It 'records a consult result with summary projection fields' {
@@ -12420,6 +12453,9 @@ panes:
         $events[0].data.result | Should -Be 'keep deterministic build command'
         $events[0].data.confidence | Should -Be 0.8
         $events[0].data.next_action | Should -Be 'rerun build'
+        $events[0].data.cost_unit_refs[0] | Should -Match 'governance:consult:final'
+        $events[0].data.cost_unit_refs[0] | Should -Match 'builder-1'
+        $events[0].data.governance_cost_units[0].unit_id | Should -Be $events[0].data.cost_unit_refs[0]
 
         $packet = Read-WinsmuxArtifactJson -Reference ([string]$events[0].data.consultation_ref) -ProjectDir $script:consultTempRoot -ExpectedDirectoryPath (Get-ConsultationDirectory -ProjectDir $script:consultTempRoot) -ExpectedRunId 'task:task-301'
         $packet.kind | Should -Be 'consult_result'
@@ -12428,6 +12464,25 @@ panes:
         $packet.next_test | Should -Be 'rerun build'
         $packet.confidence | Should -Be 0.8
         $packet.risks | Should -Be @('cache mismatch')
+        $packet.cost_unit_refs[0] | Should -Be $events[0].data.cost_unit_refs[0]
+        $packet.governance_cost_units[0].unit_id | Should -Be $events[0].data.cost_unit_refs[0]
+    }
+
+    It 'ignores prior events without governance cost units when recording a consult result' {
+        Write-BridgeEventRecord -ProjectDir $script:consultTempRoot -EventRecord ([ordered]@{
+            timestamp = '2026-04-27T09:00:00.0000000+09:00'
+            event     = 'pane.completed'
+            message   = 'completed before consult'
+            data      = [ordered]@{ task = 'task-301' }
+        }) | Out-Null
+
+        $output = Write-ConsultationCommandRecord -Kind 'consult_result' -Mode 'final' -Message 'safe with old events' -ProjectDir $script:consultTempRoot
+
+        $output | Should -Match 'consult result recorded for task:task-301'
+        $events = @(Get-BridgeEventRecords -ProjectDir $script:consultTempRoot)
+        $events.Count | Should -Be 2
+        $events[-1].data.cost_unit_refs[0] | Should -Match 'governance:consult:final'
+        $events[-1].data.governance_cost_units[0].unit_id | Should -Be $events[-1].data.cost_unit_refs[0]
     }
 
     It 'accepts run override and json output for consult result' {
@@ -12445,6 +12500,7 @@ panes:
         $result.recommendation | Should -Be 'pick builder-1'
         $result.next_test | Should -Be 'promote tactic'
         $result.consultation_ref | Should -BeLike '.winsmux/consultations/consult-result-*.json'
+        $result.cost_unit_refs[0] | Should -Match 'governance:consult:final'
     }
 
     It 'fails closed for unsupported consult mode' {

--- a/winsmux-core/scripts/pane-env.ps1
+++ b/winsmux-core/scripts/pane-env.ps1
@@ -133,6 +133,53 @@ function Resolve-WinsmuxGovernanceMode {
     return $resolved
 }
 
+function New-WinsmuxGovernanceCostUnit {
+    param(
+        [Parameter(Mandatory = $true)][string]$Kind,
+        [string]$Mode = '',
+        [string]$Task = '',
+        [string]$RunId = '',
+        [string]$Stage = '',
+        [string]$Role = '',
+        [string]$Target = '',
+        [int]$Attempt = 0,
+        [string]$Source = 'winsmux'
+    )
+
+    $normalizedKind = $Kind.Trim().ToLowerInvariant()
+    if ([string]::IsNullOrWhiteSpace($normalizedKind)) {
+        throw 'governance cost unit kind is required'
+    }
+
+    $normalizedMode = $Mode.Trim().ToLowerInvariant()
+    $normalizedStage = $Stage.Trim().ToLowerInvariant()
+    $safeParts = @(
+        'governance',
+        $normalizedKind,
+        $normalizedMode,
+        $normalizedStage,
+        ([string]$Task).Trim(),
+        ([string]$RunId).Trim(),
+        ([string]$Target).Trim(),
+        [string]$Attempt
+    ) | Where-Object { -not [string]::IsNullOrWhiteSpace([string]$_) }
+
+    [PSCustomObject]@{
+        unit_id   = ($safeParts -join ':')
+        unit_type = 'governance_invocation'
+        kind      = $normalizedKind
+        mode      = $normalizedMode
+        stage     = $normalizedStage
+        task      = [string]$Task
+        run_id    = [string]$RunId
+        role      = [string]$Role
+        target    = [string]$Target
+        attempt   = $Attempt
+        source    = [string]$Source
+        quantity  = 1
+    }
+}
+
 function Get-WinsmuxEnvironmentVariableNames {
     return @(
         'WINSMUX_ORCHESTRA_SESSION',

--- a/winsmux-core/scripts/team-pipeline.ps1
+++ b/winsmux-core/scripts/team-pipeline.ps1
@@ -21,11 +21,15 @@ Set-StrictMode -Version Latest
 
 $script:TeamPipelineBridgeScript = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\..\scripts\winsmux-core.ps1'))
 $script:TeamPipelineLoggerScript = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot 'logger.ps1'))
+$script:TeamPipelinePaneEnvScript = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot 'pane-env.ps1'))
 $script:TeamPipelineDangerousApprovalPattern = '(?im)(rm\s+-rf|Remove-Item\s+.+-Recurse.+-Force|git\s+push\s+--force|git\s+reset\s+--hard|DROP\s+TABLE|DELETE\s+FROM)'
 
 . (Join-Path $PSScriptRoot 'manifest.ps1')
 if (Test-Path $script:TeamPipelineLoggerScript -PathType Leaf) {
     . $script:TeamPipelineLoggerScript
+}
+if (Test-Path $script:TeamPipelinePaneEnvScript -PathType Leaf) {
+    . $script:TeamPipelinePaneEnvScript
 }
 
 function Get-TeamPipelineValue {
@@ -1287,6 +1291,7 @@ function Invoke-TeamPipelineConsultStage {
 
     $consultRole = Get-TeamPipelineConsultRole -TargetLabel $TargetLabel -BuilderLabel $BuilderLabel -ResearcherLabel $ResearcherLabel -ReviewerLabel $ReviewerLabel
     $prompt = New-TeamPipelineConsultPrompt -Mode $Mode -Task $Task -PlanSummary $PlanSummary -BuildSummary $BuildSummary -VerificationSummary $VerificationSummary -BuilderLabel $BuilderLabel -BuilderWorktreePath $BuilderWorktreePath
+    $costUnit = New-WinsmuxGovernanceCostUnit -Kind 'consult' -Mode $Mode -Task $Task -Stage ("CONSULT_{0}" -f $Mode.ToUpperInvariant()) -Role $consultRole -Target $TargetLabel -Attempt $Attempt -Source 'team-pipeline'
     $eventData = [ordered]@{
         mode                 = $Mode
         attempt              = $Attempt
@@ -1294,6 +1299,7 @@ function Invoke-TeamPipelineConsultStage {
         builder              = $BuilderLabel
         builder_worktree_path = $BuilderWorktreePath
         verify_summary       = $VerificationSummary
+        governance_cost_units = @($costUnit)
     }
 
     $dispatchResult = Invoke-TeamPipelineGuardedSend -StageName ("CONSULT_{0}" -f $Mode.ToUpperInvariant()) -Target $TargetLabel -Prompt $prompt -ProjectDir $ProjectDir -SessionName $SessionName -Role $consultRole -Task $Task -Attempt $Attempt
@@ -1312,6 +1318,7 @@ function Invoke-TeamPipelineConsultStage {
         summary               = $stage.Summary
         builder               = $BuilderLabel
         builder_worktree_path = $BuilderWorktreePath
+        cost_unit_refs        = @([string]$costUnit.unit_id)
     }) | Out-Null
 
     return $stage
@@ -1486,10 +1493,13 @@ function Invoke-TeamPipeline {
             $verifyRole = 'Researcher'
         }
 
+        $verifyCostUnit = New-WinsmuxGovernanceCostUnit -Kind 'verify' -Mode 'review' -Task $Task -Stage 'VERIFY' -Role $verifyRole -Target $targets.VerifyTarget -Attempt $attemptIndex -Source 'team-pipeline'
+        $verifyCostUnitDispatched = $false
         $verifyDispatchResult = Invoke-TeamPipelineGuardedSend -StageName 'VERIFY' -Target $targets.VerifyTarget -Prompt $verifyPrompt -ProjectDir $builderContext.ProjectDir -SessionName $sessionName -Role $verifyRole -Task $Task -Attempt $attemptIndex
         if ($null -ne $verifyDispatchResult) {
             $verifyStage = $verifyDispatchResult
         } else {
+            $verifyCostUnitDispatched = $true
             Write-TeamPipelineEvent -ProjectDir $builderContext.ProjectDir -SessionName $sessionName -Event 'pipeline.review.dispatched' -Message "Auto-dispatched review to $($targets.VerifyTarget) after builder completion." -Role $verifyRole -Target $targets.VerifyTarget -Data ([ordered]@{
                 attempt              = $attemptIndex
                 task                 = $Task
@@ -1497,6 +1507,7 @@ function Invoke-TeamPipeline {
                 builder_worktree_path = $builderContext.BuilderWorktreePath
                 verify_role          = $verifyRole
                 summary              = $buildNotification.Summary
+                governance_cost_units = @($verifyCostUnit)
             }) | Out-Null
             $verifyStage = Wait-TeamPipelineStage -Target $targets.VerifyTarget -StageName 'VERIFY' -TimeoutSeconds $StageTimeoutSeconds -PollIntervalSeconds $PollIntervalSeconds -ProjectDir $builderContext.ProjectDir -SessionName $sessionName -Role $verifyRole -Task $Task -Attempt $attemptIndex
         }
@@ -1512,7 +1523,7 @@ function Invoke-TeamPipeline {
             'FAIL' { 'pipeline.verify.fail' }
             default { 'pipeline.verify.partial' }
         }
-        Write-TeamPipelineEvent -ProjectDir $builderContext.ProjectDir -SessionName $sessionName -Event $verifyEventName -Message "Verification returned $($attempt.VerifyPacket.verdict) on $($targets.VerifyTarget)." -Role $verifyRole -Target $targets.VerifyTarget -Data ([ordered]@{
+        $verifyEventData = [ordered]@{
             attempt           = $attemptIndex
             task              = $Task
             verifier          = $targets.VerifyTarget
@@ -1525,7 +1536,11 @@ function Invoke-TeamPipeline {
             style             = $attempt.VerifyPacket.style
             verification_contract = $attempt.VerifyPacket.verification_contract
             verification_result = $attempt.VerifyPacket.verification_result
-        }) | Out-Null
+        }
+        if ($verifyCostUnitDispatched) {
+            $verifyEventData['cost_unit_refs'] = @([string]$verifyCostUnit.unit_id)
+        }
+        Write-TeamPipelineEvent -ProjectDir $builderContext.ProjectDir -SessionName $sessionName -Event $verifyEventName -Message "Verification returned $($attempt.VerifyPacket.verdict) on $($targets.VerifyTarget)." -Role $verifyRole -Target $targets.VerifyTarget -Data $verifyEventData | Out-Null
         $result.Attempts += [PSCustomObject]$attempt
 
         switch ($verifyStage.Status) {


### PR DESCRIPTION
## Summary
- add governance cost units and refs for consult and verify orchestration records
- keep consult outcome cost refs resolvable without double-counting existing request units
- harden the Codex subagent worktree guard error path

## Validation
- Invoke-Pester for codex-subagent-worktree-guard and winsmux-bridge: 369 passed
- cargo check --manifest-path core\\Cargo.toml
- cargo test --manifest-path core\\Cargo.toml --test operator_cli -- --nocapture: 88 passed
- git diff --check
- scripts\\git-guard.ps1
- scripts\\audit-public-surface.ps1
- codex review --uncommitted: no discrete correctness issues
- Opus review of external Rust learning note: PASS