### PR TITLE
TASK-307: Add SQLite search ledger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1130,6 +1142,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fancy-regex"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1690,6 +1714,15 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -1713,6 +1746,15 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "heck"
@@ -2295,6 +2337,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -3681,6 +3734,20 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags 2.11.1",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]
@@ -5252,6 +5319,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version-compare"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6142,6 +6215,7 @@ dependencies = [
  "portable-pty-winsmux",
  "ratatui",
  "regex",
+ "rusqlite",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -45,6 +45,10 @@ path = "tests-rs/fixture_comparison.rs"
 name = "operator_cli"
 path = "tests-rs/operator_cli.rs"
 
+[[test]]
+name = "search_ledger_contract"
+path = "tests-rs/search_ledger_contract.rs"
+
 # Windows only
 [target.'cfg(not(windows))'.dependencies]
 [target.'cfg(windows)'.dependencies]
@@ -86,3 +90,4 @@ serde_yaml = "0.9"
 sha2 = "0.10"
 regex = "1"
 glob = "0.3"
+rusqlite = { version = "0.32", features = ["bundled"] }

--- a/core/src/cli.rs
+++ b/core/src/cli.rs
@@ -147,6 +147,7 @@ OPERATOR COMMANDS:
     consult-request         Record a consultation request packet and event
     consult-result          Record a consultation result packet and event
     consult-error           Record a consultation error packet and event
+    search-ledger           Search .winsmux/events.jsonl via SQLite FTS5
     poll-events             Return new monitor events from .winsmux/events.jsonl
     dispatch-review         Send review-request to a review-capable pane
     review-request          Record a pending review request for the current branch
@@ -466,6 +467,7 @@ fn commands_text() -> &'static str {
   rotate-window (rotatew)   - Rotate panes in a window
   run-shell (run)           - Run a shell command
   save-buffer (saveb)       - Save buffer to file
+  search-ledger             - Search .winsmux/events.jsonl via SQLite FTS5
   select-layout (selectl)   - Apply a layout preset
   select-pane (selectp)     - Select a pane
   select-window (selectw)   - Select a window

--- a/core/src/machine_contract.rs
+++ b/core/src/machine_contract.rs
@@ -238,6 +238,12 @@ const PROJECTION_SURFACES: &[ProjectionSurfaceContract<'static>] = &[
         rust_type: "LedgerExplainPayload",
     },
     ProjectionSurfaceContract {
+        name: "search-ledger",
+        command: "search-ledger <search|timeline|detail> --json",
+        shape: "SQLite FTS5 search, timeline, and detail projection over events.jsonl",
+        rust_type: "SearchLedgerPayload",
+    },
+    ProjectionSurfaceContract {
         name: "poll-events",
         command: "poll-events --json",
         shape: "event stream items",

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -25,6 +25,7 @@ mod terminal_engine;
 mod manifest_contract;
 mod event_contract;
 mod ledger;
+mod search_ledger;
 mod machine_contract;
 mod operator_cli;
 mod client;
@@ -280,6 +281,7 @@ fn run_main() -> io::Result<()> {
         "consult-request" => return operator_cli::run_consult_request_command(&cmd_args[1..]),
         "consult-result" => return operator_cli::run_consult_result_command(&cmd_args[1..]),
         "consult-error" => return operator_cli::run_consult_error_command(&cmd_args[1..]),
+        "search-ledger" => return search_ledger::run_search_ledger_command(&cmd_args[1..]),
         "poll-events" => return operator_cli::run_poll_events_command(&cmd_args[1..]),
         "dispatch-review" => return operator_cli::run_dispatch_review_command(&cmd_args[1..]),
         "review-request" => return operator_cli::run_review_request_command(&cmd_args[1..]),

--- a/core/src/search_ledger.rs
+++ b/core/src/search_ledger.rs
@@ -1,0 +1,988 @@
+use crate::event_contract::{parse_event_jsonl, EventRecord};
+use chrono::{SecondsFormat, Utc};
+use rusqlite::{params, Connection, OptionalExtension};
+use serde::Serialize;
+use serde_json::{json, Map, Value};
+use std::{
+    fs,
+    io::{self, Write},
+    path::{Path, PathBuf},
+};
+
+const DEFAULT_LIMIT: usize = 20;
+const MAX_LIMIT: usize = 500;
+
+#[derive(Debug)]
+pub struct SearchLedger {
+    conn: Connection,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct SearchLedgerEntrySummary {
+    pub id: i64,
+    pub ordinal: usize,
+    pub timestamp: String,
+    pub event: String,
+    pub session: String,
+    pub message: String,
+    pub label: String,
+    pub pane_id: String,
+    pub role: String,
+    pub status: String,
+    pub source: String,
+    pub branch: String,
+    pub run_id: String,
+    pub task_id: String,
+    pub head_sha: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct SearchLedgerHit {
+    #[serde(flatten)]
+    pub entry: SearchLedgerEntrySummary,
+    pub snippet: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct SearchLedgerTimelineItem {
+    #[serde(flatten)]
+    pub entry: SearchLedgerEntrySummary,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct SearchLedgerDetail {
+    #[serde(flatten)]
+    pub entry: SearchLedgerEntrySummary,
+    pub detail: Value,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(untagged)]
+pub enum SearchLedgerPayload {
+    Search(SearchLedgerSearchPayload),
+    Timeline(SearchLedgerTimelinePayload),
+    Detail(SearchLedgerDetailPayload),
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct SearchLedgerSearchPayload {
+    pub generated_at: String,
+    pub project_dir: String,
+    pub sidecar_path: String,
+    pub indexed_count: usize,
+    pub query: String,
+    pub hits: Vec<SearchLedgerHit>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct SearchLedgerTimelinePayload {
+    pub generated_at: String,
+    pub project_dir: String,
+    pub sidecar_path: String,
+    pub indexed_count: usize,
+    pub items: Vec<SearchLedgerTimelineItem>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct SearchLedgerDetailPayload {
+    pub generated_at: String,
+    pub project_dir: String,
+    pub sidecar_path: String,
+    pub indexed_count: usize,
+    pub detail: Option<SearchLedgerDetail>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct SearchLedgerTimelineFilter {
+    pub query: Option<String>,
+    pub run_id: Option<String>,
+    pub task_id: Option<String>,
+    pub pane_id: Option<String>,
+    pub limit: usize,
+    pub descending: bool,
+}
+
+impl SearchLedger {
+    pub fn open_in_memory() -> Result<Self, String> {
+        let ledger = Self {
+            conn: Connection::open_in_memory()
+                .map_err(|err| format!("failed to open in-memory search ledger: {err}"))?,
+        };
+        ledger.initialize_schema()?;
+        Ok(ledger)
+    }
+
+    pub fn open_sidecar(path: impl AsRef<Path>) -> Result<Self, String> {
+        let path = path.as_ref();
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).map_err(|err| {
+                format!(
+                    "failed to create search ledger directory '{}': {err}",
+                    parent.display()
+                )
+            })?;
+        }
+        let ledger = Self {
+            conn: Connection::open(path).map_err(|err| {
+                format!("failed to open search ledger '{}': {err}", path.display())
+            })?,
+        };
+        ledger.initialize_schema()?;
+        Ok(ledger)
+    }
+
+    fn initialize_schema(&self) -> Result<(), String> {
+        self.conn
+            .execute_batch(
+                r#"
+                PRAGMA secure_delete = ON;
+                CREATE TABLE IF NOT EXISTS ledger_entries (
+                    id INTEGER PRIMARY KEY,
+                    ordinal INTEGER NOT NULL,
+                    timestamp TEXT NOT NULL,
+                    event TEXT NOT NULL,
+                    session TEXT NOT NULL,
+                    message TEXT NOT NULL,
+                    label TEXT NOT NULL,
+                    pane_id TEXT NOT NULL,
+                    role TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    source TEXT NOT NULL,
+                    branch TEXT NOT NULL,
+                    run_id TEXT NOT NULL,
+                    task_id TEXT NOT NULL,
+                    head_sha TEXT NOT NULL,
+                    detail_json TEXT NOT NULL,
+                    body TEXT NOT NULL
+                );
+                CREATE VIRTUAL TABLE IF NOT EXISTS ledger_entries_fts USING fts5(
+                    event,
+                    message,
+                    label,
+                    pane_id,
+                    role,
+                    status,
+                    source,
+                    branch,
+                    run_id,
+                    task_id,
+                    head_sha,
+                    body
+                );
+                "#,
+            )
+            .map_err(|err| format!("failed to initialize search ledger schema: {err}"))
+    }
+
+    pub fn rebuild_from_events_jsonl(&mut self, events_jsonl: &str) -> Result<usize, String> {
+        let events = parse_event_jsonl(events_jsonl)?;
+        let tx = self
+            .conn
+            .transaction()
+            .map_err(|err| format!("failed to start search ledger rebuild: {err}"))?;
+        tx.execute("DELETE FROM ledger_entries_fts", [])
+            .map_err(|err| format!("failed to clear search ledger FTS table: {err}"))?;
+        tx.execute("DELETE FROM ledger_entries", [])
+            .map_err(|err| format!("failed to clear search ledger entries: {err}"))?;
+
+        let mut indexed = 0usize;
+        for (ordinal, event) in events.iter().enumerate() {
+            if !should_index_event(event) {
+                continue;
+            }
+            let branch = event_field_with_data_fallback(&event.branch, event, "branch");
+            let run_id = event_field_with_data_fallback(&event.run_id, event, "run_id");
+            let task_id = event_field_with_data_fallback(&event.task_id, event, "task_id");
+            let head_sha = event_field_with_data_fallback(&event.head_sha, event, "head_sha");
+            let message = redact_sensitive_text(&event.message);
+            let detail = detail_json(event);
+            let detail_json = serde_json::to_string(&detail)
+                .map_err(|err| format!("failed to encode search ledger detail: {err}"))?;
+            let body = searchable_body(event, &detail);
+            tx.execute(
+                r#"
+                INSERT INTO ledger_entries (
+                    ordinal, timestamp, event, session, message, label, pane_id, role, status,
+                    source, branch, run_id, task_id, head_sha, detail_json, body
+                )
+                VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)
+                "#,
+                params![
+                    ordinal as i64,
+                    event.timestamp,
+                    event.event,
+                    event.session,
+                    message,
+                    event.label,
+                    event.pane_id,
+                    event.role,
+                    event.status,
+                    event.source,
+                    branch,
+                    run_id,
+                    task_id,
+                    head_sha,
+                    detail_json,
+                    body,
+                ],
+            )
+            .map_err(|err| format!("failed to insert search ledger entry: {err}"))?;
+            let rowid = tx.last_insert_rowid();
+            tx.execute(
+                r#"
+                INSERT INTO ledger_entries_fts (
+                    rowid, event, message, label, pane_id, role, status, source, branch,
+                    run_id, task_id, head_sha, body
+                )
+                VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
+                "#,
+                params![
+                    rowid,
+                    event.event,
+                    message,
+                    event.label,
+                    event.pane_id,
+                    event.role,
+                    event.status,
+                    event.source,
+                    branch,
+                    run_id,
+                    task_id,
+                    head_sha,
+                    body,
+                ],
+            )
+            .map_err(|err| format!("failed to insert search ledger FTS entry: {err}"))?;
+            indexed += 1;
+        }
+
+        tx.commit()
+            .map_err(|err| format!("failed to commit search ledger rebuild: {err}"))?;
+        self.scrub_deleted_content()?;
+        Ok(indexed)
+    }
+
+    fn scrub_deleted_content(&self) -> Result<(), String> {
+        self.conn
+            .execute_batch(
+                r#"
+                PRAGMA secure_delete = ON;
+                VACUUM;
+                "#,
+            )
+            .map_err(|err| format!("failed to scrub deleted search ledger content: {err}"))
+    }
+
+    pub fn search(&self, query: &str, limit: usize) -> Result<Vec<SearchLedgerHit>, String> {
+        self.search_filtered(query, None, None, None, limit)
+    }
+
+    pub fn search_filtered(
+        &self,
+        query: &str,
+        run_id: Option<&str>,
+        task_id: Option<&str>,
+        pane_id: Option<&str>,
+        limit: usize,
+    ) -> Result<Vec<SearchLedgerHit>, String> {
+        let query = query.trim();
+        if query.is_empty() {
+            return Err("search query must be non-empty".to_string());
+        }
+        let limit = normalize_limit(limit);
+        let fts_query = fts5_query(query);
+        let run_id = run_id.unwrap_or_default();
+        let task_id = task_id.unwrap_or_default();
+        let pane_id = pane_id.unwrap_or_default();
+        let mut stmt = self
+            .conn
+            .prepare(
+                r#"
+                SELECT
+                    e.id, e.ordinal, e.timestamp, e.event, e.session, e.message, e.label,
+                    e.pane_id, e.role, e.status, e.source, e.branch, e.run_id, e.task_id,
+                    e.head_sha,
+                    snippet(ledger_entries_fts, 11, '[', ']', '...', 24) AS snippet
+                FROM ledger_entries_fts
+                JOIN ledger_entries e ON e.id = ledger_entries_fts.rowid
+                WHERE ledger_entries_fts MATCH ?1
+                  AND (?2 = '' OR e.run_id = ?2)
+                  AND (?3 = '' OR e.task_id = ?3)
+                  AND (?4 = '' OR e.pane_id = ?4)
+                ORDER BY e.timestamp DESC, e.ordinal DESC
+                LIMIT ?5
+                "#,
+            )
+            .map_err(|err| format!("failed to prepare search ledger query: {err}"))?;
+        let rows = stmt
+            .query_map(
+                params![fts_query, run_id, task_id, pane_id, limit as i64],
+                |row| {
+                    Ok(SearchLedgerHit {
+                        entry: row_to_summary(row)?,
+                        snippet: row.get(15)?,
+                    })
+                },
+            )
+            .map_err(|err| format!("failed to run search ledger query: {err}"))?;
+        collect_rows(rows)
+    }
+
+    pub fn timeline(
+        &self,
+        filter: SearchLedgerTimelineFilter,
+    ) -> Result<Vec<SearchLedgerTimelineItem>, String> {
+        let limit = normalize_limit(filter.limit);
+        let run_id = filter.run_id.unwrap_or_default();
+        let task_id = filter.task_id.unwrap_or_default();
+        let pane_id = filter.pane_id.unwrap_or_default();
+        let order = if filter.descending { "DESC" } else { "ASC" };
+
+        if let Some(query) = filter
+            .query
+            .as_deref()
+            .map(str::trim)
+            .filter(|q| !q.is_empty())
+        {
+            let fts_query = fts5_query(query);
+            let sql = format!(
+                r#"
+                SELECT
+                    e.id, e.ordinal, e.timestamp, e.event, e.session, e.message, e.label,
+                    e.pane_id, e.role, e.status, e.source, e.branch, e.run_id, e.task_id,
+                    e.head_sha
+                FROM ledger_entries_fts
+                JOIN ledger_entries e ON e.id = ledger_entries_fts.rowid
+                WHERE ledger_entries_fts MATCH ?1
+                  AND (?2 = '' OR e.run_id = ?2)
+                  AND (?3 = '' OR e.task_id = ?3)
+                  AND (?4 = '' OR e.pane_id = ?4)
+                ORDER BY e.timestamp {order}, e.ordinal {order}
+                LIMIT ?5
+                "#
+            );
+            let mut stmt = self
+                .conn
+                .prepare(&sql)
+                .map_err(|err| format!("failed to prepare search ledger timeline: {err}"))?;
+            let rows = stmt
+                .query_map(
+                    params![fts_query, run_id, task_id, pane_id, limit as i64],
+                    |row| {
+                        Ok(SearchLedgerTimelineItem {
+                            entry: row_to_summary(row)?,
+                        })
+                    },
+                )
+                .map_err(|err| format!("failed to run search ledger timeline: {err}"))?;
+            return collect_rows(rows);
+        }
+
+        let sql = format!(
+            r#"
+            SELECT
+                id, ordinal, timestamp, event, session, message, label, pane_id, role, status,
+                source, branch, run_id, task_id, head_sha
+            FROM ledger_entries
+            WHERE (?1 = '' OR run_id = ?1)
+              AND (?2 = '' OR task_id = ?2)
+              AND (?3 = '' OR pane_id = ?3)
+            ORDER BY timestamp {order}, ordinal {order}
+            LIMIT ?4
+            "#
+        );
+        let mut stmt = self
+            .conn
+            .prepare(&sql)
+            .map_err(|err| format!("failed to prepare search ledger timeline: {err}"))?;
+        let rows = stmt
+            .query_map(params![run_id, task_id, pane_id, limit as i64], |row| {
+                Ok(SearchLedgerTimelineItem {
+                    entry: row_to_summary(row)?,
+                })
+            })
+            .map_err(|err| format!("failed to run search ledger timeline: {err}"))?;
+        collect_rows(rows)
+    }
+
+    pub fn detail(&self, id: i64) -> Result<Option<SearchLedgerDetail>, String> {
+        let mut stmt = self
+            .conn
+            .prepare(
+                r#"
+                SELECT
+                    id, ordinal, timestamp, event, session, message, label, pane_id, role, status,
+                    source, branch, run_id, task_id, head_sha, detail_json
+                FROM ledger_entries
+                WHERE id = ?1
+                "#,
+            )
+            .map_err(|err| format!("failed to prepare search ledger detail lookup: {err}"))?;
+        stmt.query_row(params![id], |row| {
+            let detail_json: String = row.get(15)?;
+            let detail = serde_json::from_str(&detail_json).map_err(|err| {
+                rusqlite::Error::FromSqlConversionFailure(
+                    15,
+                    rusqlite::types::Type::Text,
+                    Box::new(err),
+                )
+            })?;
+            Ok(SearchLedgerDetail {
+                entry: row_to_summary(row)?,
+                detail,
+            })
+        })
+        .optional()
+        .map_err(|err| format!("failed to load search ledger detail: {err}"))
+    }
+}
+
+pub fn run_search_ledger_command(args: &[&String]) -> io::Result<()> {
+    let options = SearchLedgerCliOptions::parse(args)?;
+    if options.help {
+        print_usage();
+        return Ok(());
+    }
+    if !options.json {
+        return Err(invalid_input(
+            "search-ledger currently requires --json for stable output",
+        ));
+    }
+
+    let mut ledger = SearchLedger::open_sidecar(&options.sidecar_path).map_err(other_error)?;
+    let events_jsonl = read_events_jsonl(&options.project_dir)?;
+    let indexed_count = ledger
+        .rebuild_from_events_jsonl(&events_jsonl)
+        .map_err(other_error)?;
+    let generated_at = Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true);
+    let project_dir = options.project_dir.to_string_lossy().to_string();
+    let sidecar_path = options.sidecar_path.to_string_lossy().to_string();
+
+    match options.mode {
+        SearchLedgerMode::Search => {
+            let query = options
+                .query
+                .ok_or_else(|| invalid_input("missing search query"))?;
+            let hits = ledger
+                .search_filtered(
+                    &query,
+                    options.run_id.as_deref(),
+                    options.task_id.as_deref(),
+                    options.pane_id.as_deref(),
+                    options.limit,
+                )
+                .map_err(other_error)?;
+            write_json(&SearchLedgerPayload::Search(SearchLedgerSearchPayload {
+                generated_at,
+                project_dir,
+                sidecar_path,
+                indexed_count,
+                query,
+                hits,
+            }))
+        }
+        SearchLedgerMode::Timeline => {
+            let items = ledger
+                .timeline(SearchLedgerTimelineFilter {
+                    query: options.query,
+                    run_id: options.run_id,
+                    task_id: options.task_id,
+                    pane_id: options.pane_id,
+                    limit: options.limit,
+                    descending: options.descending,
+                })
+                .map_err(other_error)?;
+            write_json(&SearchLedgerPayload::Timeline(
+                SearchLedgerTimelinePayload {
+                    generated_at,
+                    project_dir,
+                    sidecar_path,
+                    indexed_count,
+                    items,
+                },
+            ))
+        }
+        SearchLedgerMode::Detail => {
+            let id = options
+                .detail_id
+                .ok_or_else(|| invalid_input("missing detail id"))?;
+            let detail = ledger.detail(id).map_err(other_error)?;
+            write_json(&SearchLedgerPayload::Detail(SearchLedgerDetailPayload {
+                generated_at,
+                project_dir,
+                sidecar_path,
+                indexed_count,
+                detail,
+            }))
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SearchLedgerMode {
+    Search,
+    Timeline,
+    Detail,
+}
+
+#[derive(Debug)]
+struct SearchLedgerCliOptions {
+    mode: SearchLedgerMode,
+    project_dir: PathBuf,
+    sidecar_path: PathBuf,
+    query: Option<String>,
+    run_id: Option<String>,
+    task_id: Option<String>,
+    pane_id: Option<String>,
+    detail_id: Option<i64>,
+    limit: usize,
+    descending: bool,
+    json: bool,
+    help: bool,
+}
+
+impl SearchLedgerCliOptions {
+    fn parse(args: &[&String]) -> io::Result<Self> {
+        let mut mode: Option<SearchLedgerMode> = None;
+        let mut project_dir: Option<PathBuf> = None;
+        let mut sidecar_path: Option<PathBuf> = None;
+        let mut query: Option<String> = None;
+        let mut run_id: Option<String> = None;
+        let mut task_id: Option<String> = None;
+        let mut pane_id: Option<String> = None;
+        let mut detail_id: Option<i64> = None;
+        let mut limit = DEFAULT_LIMIT;
+        let mut descending = false;
+        let mut json = false;
+        let mut help = false;
+        let mut positional = Vec::new();
+        let mut i = 0usize;
+
+        while i < args.len() {
+            match args[i].as_str() {
+                "-h" | "--help" => {
+                    help = true;
+                    i += 1;
+                }
+                "--json" => {
+                    json = true;
+                    i += 1;
+                }
+                "--project-dir" => {
+                    let value = required_value(args, i, "--project-dir")?;
+                    project_dir = Some(PathBuf::from(value));
+                    i += 2;
+                }
+                "--sidecar" => {
+                    let value = required_value(args, i, "--sidecar")?;
+                    sidecar_path = Some(PathBuf::from(value));
+                    i += 2;
+                }
+                "--query" => {
+                    query = Some(required_value(args, i, "--query")?.to_string());
+                    i += 2;
+                }
+                "--run-id" => {
+                    run_id = Some(required_value(args, i, "--run-id")?.to_string());
+                    i += 2;
+                }
+                "--task-id" => {
+                    task_id = Some(required_value(args, i, "--task-id")?.to_string());
+                    i += 2;
+                }
+                "--pane-id" => {
+                    pane_id = Some(required_value(args, i, "--pane-id")?.to_string());
+                    i += 2;
+                }
+                "--limit" => {
+                    let value = required_value(args, i, "--limit")?;
+                    limit = value.parse::<usize>().map_err(|_| {
+                        invalid_input(format!("--limit must be a positive integer: {value}"))
+                    })?;
+                    i += 2;
+                }
+                "--desc" => {
+                    descending = true;
+                    i += 1;
+                }
+                "search" if mode.is_none() => {
+                    mode = Some(SearchLedgerMode::Search);
+                    i += 1;
+                }
+                "timeline" if mode.is_none() => {
+                    mode = Some(SearchLedgerMode::Timeline);
+                    i += 1;
+                }
+                "detail" if mode.is_none() => {
+                    mode = Some(SearchLedgerMode::Detail);
+                    i += 1;
+                }
+                arg if arg.starts_with('-') => {
+                    return Err(invalid_input(format!(
+                        "unknown search-ledger option: {arg}"
+                    )));
+                }
+                arg => {
+                    positional.push(arg.to_string());
+                    i += 1;
+                }
+            }
+        }
+
+        let mode = mode.unwrap_or(SearchLedgerMode::Search);
+        match mode {
+            SearchLedgerMode::Search => {
+                if query.is_none() && !positional.is_empty() {
+                    query = Some(positional.join(" "));
+                }
+                if !help && query.as_deref().unwrap_or("").trim().is_empty() {
+                    return Err(invalid_input("missing search query"));
+                }
+            }
+            SearchLedgerMode::Timeline => {
+                if query.is_none() && !positional.is_empty() {
+                    query = Some(positional.join(" "));
+                }
+            }
+            SearchLedgerMode::Detail => {
+                if !help {
+                    if query.is_some()
+                        || run_id.is_some()
+                        || task_id.is_some()
+                        || pane_id.is_some()
+                        || descending
+                    {
+                        return Err(invalid_input(
+                            "detail accepts only --json, --project-dir, --sidecar, and one id",
+                        ));
+                    }
+                    let id = positional
+                        .first()
+                        .ok_or_else(|| invalid_input("missing detail id"))?;
+                    detail_id = Some(id.parse::<i64>().map_err(|_| {
+                        invalid_input(format!("detail id must be an integer: {id}"))
+                    })?);
+                    if positional.len() > 1 {
+                        return Err(invalid_input("detail accepts exactly one id"));
+                    }
+                }
+            }
+        }
+
+        let project_dir = match project_dir {
+            Some(path) => path,
+            None => std::env::current_dir().map_err(|err| {
+                other_error(format!("failed to resolve current directory: {err}"))
+            })?,
+        };
+        let sidecar_path = sidecar_path
+            .unwrap_or_else(|| project_dir.join(".winsmux").join("search-ledger.sqlite"));
+
+        Ok(Self {
+            mode,
+            project_dir,
+            sidecar_path,
+            query,
+            run_id,
+            task_id,
+            pane_id,
+            detail_id,
+            limit,
+            descending,
+            json,
+            help,
+        })
+    }
+}
+
+fn read_events_jsonl(project_dir: &Path) -> io::Result<String> {
+    let events_path = project_dir.join(".winsmux").join("events.jsonl");
+    match fs::read_to_string(&events_path) {
+        Ok(content) => Ok(content),
+        Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(String::new()),
+        Err(err) => Err(other_error(format!(
+            "failed to read events '{}': {err}",
+            events_path.display()
+        ))),
+    }
+}
+
+fn row_to_summary(row: &rusqlite::Row<'_>) -> rusqlite::Result<SearchLedgerEntrySummary> {
+    Ok(SearchLedgerEntrySummary {
+        id: row.get(0)?,
+        ordinal: row.get::<_, i64>(1)? as usize,
+        timestamp: row.get(2)?,
+        event: row.get(3)?,
+        session: row.get(4)?,
+        message: row.get(5)?,
+        label: row.get(6)?,
+        pane_id: row.get(7)?,
+        role: row.get(8)?,
+        status: row.get(9)?,
+        source: row.get(10)?,
+        branch: row.get(11)?,
+        run_id: row.get(12)?,
+        task_id: row.get(13)?,
+        head_sha: row.get(14)?,
+    })
+}
+
+fn collect_rows<T>(
+    rows: rusqlite::MappedRows<'_, impl FnMut(&rusqlite::Row<'_>) -> rusqlite::Result<T>>,
+) -> Result<Vec<T>, String> {
+    let mut values = Vec::new();
+    for row in rows {
+        values.push(row.map_err(|err| format!("failed to read search ledger row: {err}"))?);
+    }
+    Ok(values)
+}
+
+fn detail_json(event: &EventRecord) -> Value {
+    json!({
+        "timestamp": event.timestamp,
+        "event": event.event,
+        "session": event.session,
+        "message": redact_sensitive_text(&event.message),
+        "label": event.label,
+        "pane_id": event.pane_id,
+        "role": event.role,
+        "status": event.status,
+        "exit_reason": event.exit_reason,
+        "source": event.source,
+        "branch": event_field_with_data_fallback(&event.branch, event, "branch"),
+        "run_id": event_field_with_data_fallback(&event.run_id, event, "run_id"),
+        "task_id": event_field_with_data_fallback(&event.task_id, event, "task_id"),
+        "head_sha": event_field_with_data_fallback(&event.head_sha, event, "head_sha"),
+        "data": redact_sensitive_value("", &event.data),
+    })
+}
+
+fn searchable_body(event: &EventRecord, detail: &Value) -> String {
+    let mut parts = vec![
+        event.timestamp.clone(),
+        event.event.clone(),
+        event.session.clone(),
+        redact_sensitive_text(&event.message),
+        event.label.clone(),
+        event.pane_id.clone(),
+        event.role.clone(),
+        event.status.clone(),
+        event.exit_reason.clone(),
+        event.source.clone(),
+        event.branch.clone(),
+        event.run_id.clone(),
+        event.task_id.clone(),
+        event.head_sha.clone(),
+    ];
+    parts.push(detail.to_string());
+    parts.join("\n")
+}
+
+fn should_index_event(event: &EventRecord) -> bool {
+    let Some(data) = event.data.as_object() else {
+        return true;
+    };
+
+    if bool_field(data, "suppress_search")
+        || bool_field(data, "search_suppressed")
+        || bool_field(data, "no_search")
+    {
+        return false;
+    }
+
+    if sensitive_marker(value_string(data.get("retention")).as_deref()) {
+        return false;
+    }
+
+    for key in [
+        "retention_tags",
+        "search_retention_tags",
+        "sensitivity_tags",
+        "classification_tags",
+    ] {
+        if value_array_contains_sensitive_marker(data.get(key)) {
+            return false;
+        }
+    }
+
+    true
+}
+
+fn bool_field(data: &Map<String, Value>, key: &str) -> bool {
+    data.get(key).and_then(Value::as_bool).unwrap_or(false)
+}
+
+fn value_string(value: Option<&Value>) -> Option<String> {
+    value.and_then(Value::as_str).map(|value| value.to_string())
+}
+
+fn event_field_with_data_fallback(top_level: &str, event: &EventRecord, data_key: &str) -> String {
+    if !top_level.trim().is_empty() {
+        return top_level.to_string();
+    }
+
+    event_data_string(&event.data, data_key)
+}
+
+fn event_data_string(data: &Value, key: &str) -> String {
+    data.as_object()
+        .and_then(|map| map.get(key))
+        .and_then(Value::as_str)
+        .map(|value| value.to_string())
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_default()
+}
+
+fn value_array_contains_sensitive_marker(value: Option<&Value>) -> bool {
+    match value {
+        Some(Value::Array(items)) => items
+            .iter()
+            .filter_map(Value::as_str)
+            .any(|item| sensitive_marker(Some(item))),
+        Some(Value::String(item)) => sensitive_marker(Some(item)),
+        _ => false,
+    }
+}
+
+fn sensitive_marker(value: Option<&str>) -> bool {
+    let Some(value) = value else {
+        return false;
+    };
+    matches!(
+        value.trim().to_ascii_lowercase().as_str(),
+        "credential"
+            | "credentials"
+            | "secret"
+            | "secrets"
+            | "token"
+            | "tokens"
+            | "private"
+            | "sensitive"
+            | "no_search"
+            | "search_suppressed"
+            | "do_not_index"
+    )
+}
+
+fn redact_sensitive_value(key: &str, value: &Value) -> Value {
+    if is_sensitive_key(key) {
+        return Value::String("[redacted]".to_string());
+    }
+
+    match value {
+        Value::Object(map) => {
+            let mut redacted = Map::new();
+            for (child_key, child_value) in map {
+                redacted.insert(
+                    child_key.clone(),
+                    redact_sensitive_value(child_key, child_value),
+                );
+            }
+            Value::Object(redacted)
+        }
+        Value::Array(items) => Value::Array(
+            items
+                .iter()
+                .map(|item| redact_sensitive_value(key, item))
+                .collect(),
+        ),
+        Value::String(text) if looks_sensitive_text(text) => {
+            Value::String("[redacted]".to_string())
+        }
+        _ => value.clone(),
+    }
+}
+
+fn is_sensitive_key(key: &str) -> bool {
+    let normalized = key.to_ascii_lowercase();
+    let compact = normalized
+        .chars()
+        .filter(|ch| ch.is_ascii_alphanumeric())
+        .collect::<String>();
+    compact.contains("secret")
+        || compact.contains("token")
+        || compact.contains("password")
+        || compact.contains("credential")
+        || compact.contains("privatekey")
+        || compact.contains("sshkey")
+        || compact.contains("secretkey")
+        || compact.contains("signingkey")
+        || compact.contains("accesskey")
+        || compact.contains("apikey")
+        || compact.contains("authheader")
+        || compact == "authorization"
+        || compact == "bearer"
+        || compact == "key"
+}
+
+fn redact_sensitive_text(text: &str) -> String {
+    if looks_sensitive_text(text) {
+        "[redacted]".to_string()
+    } else {
+        text.to_string()
+    }
+}
+
+fn looks_sensitive_text(text: &str) -> bool {
+    let compact = text
+        .to_ascii_lowercase()
+        .chars()
+        .filter(|ch| ch.is_ascii_alphanumeric())
+        .collect::<String>();
+    compact.contains("secret")
+        || compact.contains("token")
+        || compact.contains("password")
+        || compact.contains("credential")
+        || compact.contains("privatekey")
+        || compact.contains("sshkey")
+        || compact.contains("apikey")
+        || compact.contains("authheader")
+        || compact.contains("bearer")
+}
+
+fn fts5_query(query: &str) -> String {
+    query
+        .split_whitespace()
+        .map(|term| format!("\"{}\"", term.replace('"', "\"\"")))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn normalize_limit(limit: usize) -> usize {
+    match limit {
+        0 => DEFAULT_LIMIT,
+        value if value > MAX_LIMIT => MAX_LIMIT,
+        value => value,
+    }
+}
+
+fn required_value<'a>(args: &'a [&String], index: usize, flag: &str) -> io::Result<&'a str> {
+    args.get(index + 1)
+        .map(|value| value.as_str())
+        .ok_or_else(|| invalid_input(format!("{flag} requires a value")))
+}
+
+fn print_usage() {
+    println!(
+        "usage: winsmux search-ledger <search|timeline|detail> --json [options]\n\
+         search:   winsmux search-ledger search --json <query> [--project-dir <path>] [--limit <n>]\n\
+         timeline: winsmux search-ledger timeline --json [--query <query>] [--run-id <id>] [--task-id <id>] [--pane-id <id>]\n\
+         detail:   winsmux search-ledger detail --json <id> [--project-dir <path>]"
+    );
+}
+
+fn write_json<T: Serialize>(value: &T) -> io::Result<()> {
+    let stdout = io::stdout();
+    let mut handle = stdout.lock();
+    serde_json::to_writer_pretty(&mut handle, value).map_err(other_error)?;
+    writeln!(handle)?;
+    Ok(())
+}
+
+fn invalid_input(message: impl Into<String>) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidInput, message.into())
+}
+
+fn other_error(message: impl ToString) -> io::Error {
+    io::Error::new(io::ErrorKind::Other, message.to_string())
+}

--- a/core/tests-rs/machine_contract.rs
+++ b/core/tests-rs/machine_contract.rs
@@ -40,6 +40,7 @@ fn machine_contract_exposes_projection_surfaces_in_stable_order() {
             "digest",
             "runs",
             "explain",
+            "search-ledger",
             "poll-events",
             "dispatch-review",
             "review-request",
@@ -65,6 +66,7 @@ fn machine_contract_exposes_projection_surfaces_in_stable_order() {
             "LedgerDigestPayload",
             "LedgerRunsPayload",
             "LedgerExplainPayload",
+            "SearchLedgerPayload",
             "PollEventsPayload",
             "ReviewRequestDispatchPayload",
             "ReviewStateRecord",
@@ -260,7 +262,8 @@ fn machine_contract_serializes_to_json() {
         value["organization"]["manifest_fields"][4]["field"],
         "budget_monthly_cents"
     );
-    assert_eq!(value["projection_surfaces"][6]["name"], "poll-events");
+    assert_eq!(value["projection_surfaces"][6]["name"], "search-ledger");
+    assert_eq!(value["projection_surfaces"][7]["name"], "poll-events");
     assert_eq!(
         value["projection_surfaces"][4]["rust_type"],
         "LedgerRunsPayload"

--- a/core/tests-rs/operator_cli.rs
+++ b/core/tests-rs/operator_cli.rs
@@ -544,6 +544,11 @@ fn operator_cli_machine_contract_json_exposes_hook_facing_catalog() {
         json["projection_surfaces"][4]["rust_type"],
         "LedgerRunsPayload"
     );
+    assert_eq!(json["projection_surfaces"][6]["name"], "search-ledger");
+    assert_eq!(
+        json["projection_surfaces"][6]["command"],
+        "search-ledger <search|timeline|detail> --json"
+    );
     assert_eq!(
         json["review_state_file"]["path"],
         ".winsmux/review-state.json"

--- a/core/tests-rs/search_ledger_contract.rs
+++ b/core/tests-rs/search_ledger_contract.rs
@@ -1,0 +1,332 @@
+#[path = "../src/event_contract.rs"]
+mod event_contract;
+
+#[allow(dead_code)]
+#[path = "../src/search_ledger.rs"]
+mod search_ledger;
+
+use serde_json::Value;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[test]
+fn search_ledger_indexes_search_timeline_and_detail() {
+    let mut ledger =
+        search_ledger::SearchLedger::open_in_memory().expect("search ledger should open");
+    let indexed = ledger
+        .rebuild_from_events_jsonl(sample_events())
+        .expect("events should index");
+
+    assert_eq!(indexed, 4);
+
+    let hits = ledger
+        .search("TASK-307 search", 10)
+        .expect("search should run");
+    assert_eq!(hits.len(), 3);
+    assert_eq!(hits[0].entry.task_id, "TASK-307");
+    assert!(hits
+        .iter()
+        .any(|hit| hit.entry.event == "operator.followup"));
+
+    let timeline = ledger
+        .timeline(search_ledger::SearchLedgerTimelineFilter {
+            run_id: Some("run:task-307".to_string()),
+            limit: 10,
+            ..search_ledger::SearchLedgerTimelineFilter::default()
+        })
+        .expect("timeline should run");
+    assert_eq!(timeline.len(), 3);
+    assert_eq!(timeline[0].entry.event, "experiment.started");
+    assert_eq!(timeline[2].entry.event, "experiment.finished");
+
+    let detail = ledger
+        .detail(timeline[1].entry.id)
+        .expect("detail lookup should run")
+        .expect("detail should exist");
+    assert_eq!(detail.entry.event, "operator.followup");
+    assert_eq!(
+        detail.detail["data"]["hypothesis"],
+        "FTS5 sidecar supports search"
+    );
+}
+
+#[test]
+fn search_ledger_suppresses_tagged_credentials_and_redacts_sensitive_fields() {
+    let mut ledger =
+        search_ledger::SearchLedger::open_in_memory().expect("search ledger should open");
+    let events = r#"
+{"timestamp":"2026-04-27T12:00:00+09:00","event":"credential.recorded","message":"token alpha-secret","task_id":"TASK-307","data":{"retention_tags":["credential"],"token":"alpha-secret"}}
+{"timestamp":"2026-04-27T12:01:00+09:00","event":"operator.note","message":"token raw-message keep searchable note","task_id":"TASK-307","data":{"api_key":"plain-secret","privateKey":"raw-private","nested":{"password":"hidden","sshKey":"raw-ssh","authHeader":"raw-auth"},"note":"keep this","output":"neutral-secret-value","stderr":"Bearer raw-bearer"}}
+"#;
+    let indexed = ledger
+        .rebuild_from_events_jsonl(events)
+        .expect("events should index");
+
+    assert_eq!(indexed, 1);
+    assert!(ledger
+        .search("alpha-secret", 10)
+        .expect("credential search should run")
+        .is_empty());
+    assert!(ledger
+        .search("plain-secret", 10)
+        .expect("redacted search should run")
+        .is_empty());
+    assert!(ledger
+        .search("raw-private", 10)
+        .expect("private key search should run")
+        .is_empty());
+    assert!(ledger
+        .search("raw-ssh", 10)
+        .expect("ssh key search should run")
+        .is_empty());
+    assert!(ledger
+        .search("raw-auth", 10)
+        .expect("auth header search should run")
+        .is_empty());
+    assert!(ledger
+        .search("raw-message", 10)
+        .expect("message secret search should run")
+        .is_empty());
+    assert!(ledger
+        .search("neutral-secret-value", 10)
+        .expect("neutral-key secret search should run")
+        .is_empty());
+    assert!(ledger
+        .search("raw-bearer", 10)
+        .expect("bearer search should run")
+        .is_empty());
+
+    let hit = ledger
+        .search("keep", 10)
+        .expect("non-sensitive search should run")
+        .pop()
+        .expect("note should be searchable");
+    let detail = ledger
+        .detail(hit.entry.id)
+        .expect("detail lookup should run")
+        .expect("detail should exist");
+    assert_eq!(hit.entry.message, "[redacted]");
+    assert_eq!(detail.detail["message"], "[redacted]");
+    assert_eq!(detail.detail["data"]["api_key"], "[redacted]");
+    assert_eq!(detail.detail["data"]["privateKey"], "[redacted]");
+    assert_eq!(detail.detail["data"]["nested"]["password"], "[redacted]");
+    assert_eq!(detail.detail["data"]["nested"]["sshKey"], "[redacted]");
+    assert_eq!(detail.detail["data"]["nested"]["authHeader"], "[redacted]");
+    assert_eq!(detail.detail["data"]["note"], "keep this");
+    assert_eq!(detail.detail["data"]["output"], "[redacted]");
+    assert_eq!(detail.detail["data"]["stderr"], "[redacted]");
+}
+
+#[test]
+fn search_ledger_rebuild_scrubs_removed_sidecar_text() {
+    let project_dir = make_temp_project_dir("search-ledger-scrub");
+    let sidecar_path = project_dir.join(".winsmux").join("search-ledger.sqlite");
+    {
+        let mut ledger =
+            search_ledger::SearchLedger::open_sidecar(&sidecar_path).expect("sidecar should open");
+        ledger
+            .rebuild_from_events_jsonl(
+                r#"{"timestamp":"2026-04-27T12:00:00+09:00","event":"operator.note","message":"temporary searchable phrase","task_id":"TASK-307","data":{"note":"temporary searchable phrase"}}"#,
+            )
+            .expect("initial event should index");
+        ledger
+            .rebuild_from_events_jsonl(
+                r#"{"timestamp":"2026-04-27T12:01:00+09:00","event":"operator.note","message":"temporary searchable phrase","task_id":"TASK-307","data":{"suppress_search":true,"note":"temporary searchable phrase"}}"#,
+            )
+            .expect("suppressed rebuild should complete");
+    }
+
+    let sidecar_bytes = fs::read(&sidecar_path).expect("sidecar should be readable");
+    let sidecar_text = String::from_utf8_lossy(&sidecar_bytes);
+    assert!(
+        !sidecar_text.contains("temporary searchable phrase"),
+        "sidecar should not retain text from deleted rows"
+    );
+}
+
+#[test]
+fn search_ledger_uses_data_identifier_fallbacks() {
+    let mut ledger =
+        search_ledger::SearchLedger::open_in_memory().expect("search ledger should open");
+    let events = r#"
+{"timestamp":"2026-04-27T12:00:00+09:00","event":"pane.consult_request","message":"fallback identifiers should index","label":"builder-1","pane_id":"%2","role":"Builder","data":{"run_id":"run:fallback","task_id":"TASK-307","branch":"task-307-search-ledger","head_sha":"abc123"}}
+"#;
+    let indexed = ledger
+        .rebuild_from_events_jsonl(events)
+        .expect("events should index");
+
+    assert_eq!(indexed, 1);
+    let timeline = ledger
+        .timeline(search_ledger::SearchLedgerTimelineFilter {
+            run_id: Some("run:fallback".to_string()),
+            task_id: Some("TASK-307".to_string()),
+            limit: 10,
+            ..search_ledger::SearchLedgerTimelineFilter::default()
+        })
+        .expect("timeline should use fallback identifiers");
+    assert_eq!(timeline.len(), 1);
+    assert_eq!(timeline[0].entry.branch, "task-307-search-ledger");
+    assert_eq!(timeline[0].entry.head_sha, "abc123");
+
+    let detail = ledger
+        .detail(timeline[0].entry.id)
+        .expect("detail lookup should run")
+        .expect("detail should exist");
+    assert_eq!(detail.detail["run_id"], "run:fallback");
+    assert_eq!(detail.detail["task_id"], "TASK-307");
+}
+
+#[test]
+fn search_ledger_cli_search_timeline_and_detail_json() {
+    let project_dir = make_temp_project_dir("search-ledger-cli");
+    let winsmux_dir = project_dir.join(".winsmux");
+    fs::create_dir_all(&winsmux_dir).expect("test should create .winsmux");
+    fs::write(winsmux_dir.join("events.jsonl"), sample_events()).expect("test should write events");
+
+    let search = run_json(
+        &project_dir,
+        &[
+            "search-ledger",
+            "search",
+            "--json",
+            "--project-dir",
+            project_dir.to_str().expect("path should be utf-8"),
+            "TASK-307",
+        ],
+    );
+    assert_eq!(search["indexed_count"], 4);
+    assert_eq!(search["hits"][0]["task_id"], "TASK-307");
+    assert!(
+        search["sidecar_path"]
+            .as_str()
+            .expect("sidecar path should be string")
+            .ends_with(".winsmux\\search-ledger.sqlite")
+            || search["sidecar_path"]
+                .as_str()
+                .expect("sidecar path should be string")
+                .ends_with(".winsmux/search-ledger.sqlite")
+    );
+
+    let filtered_search = run_json(
+        &project_dir,
+        &[
+            "search-ledger",
+            "search",
+            "--json",
+            "--project-dir",
+            project_dir.to_str().expect("path should be utf-8"),
+            "--task-id",
+            "TASK-999",
+            "TASK-307",
+        ],
+    );
+    assert_eq!(
+        filtered_search["hits"]
+            .as_array()
+            .expect("hits should be array")
+            .len(),
+        0
+    );
+
+    let detail_id = search["hits"][0]["id"]
+        .as_i64()
+        .expect("hit id should be numeric");
+    let detail = run_json(
+        &project_dir,
+        &[
+            "search-ledger",
+            "detail",
+            "--json",
+            "--project-dir",
+            project_dir.to_str().expect("path should be utf-8"),
+            &detail_id.to_string(),
+        ],
+    );
+    assert_eq!(detail["detail"]["task_id"], "TASK-307");
+
+    let timeline = run_json(
+        &project_dir,
+        &[
+            "search-ledger",
+            "timeline",
+            "--json",
+            "--project-dir",
+            project_dir.to_str().expect("path should be utf-8"),
+            "--run-id",
+            "run:task-307",
+        ],
+    );
+    assert_eq!(
+        timeline["items"]
+            .as_array()
+            .expect("items should be array")
+            .len(),
+        3
+    );
+    assert_eq!(timeline["items"][0]["event"], "experiment.started");
+}
+
+#[test]
+fn search_ledger_cli_detail_rejects_inapplicable_filters() {
+    let project_dir = make_temp_project_dir("search-ledger-detail-invalid");
+    let winsmux_dir = project_dir.join(".winsmux");
+    fs::create_dir_all(&winsmux_dir).expect("test should create .winsmux");
+    fs::write(winsmux_dir.join("events.jsonl"), sample_events()).expect("test should write events");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .args([
+            "search-ledger",
+            "detail",
+            "--json",
+            "--project-dir",
+            project_dir.to_str().expect("path should be utf-8"),
+            "--task-id",
+            "TASK-307",
+            "1",
+        ])
+        .current_dir(&project_dir)
+        .output()
+        .expect("winsmux command should run");
+    assert!(
+        !output.status.success(),
+        "detail with ignored filters should fail"
+    );
+    assert!(String::from_utf8_lossy(&output.stderr)
+        .contains("detail accepts only --json, --project-dir, --sidecar, and one id"));
+}
+
+fn sample_events() -> &'static str {
+    r#"
+{"timestamp":"2026-04-27T12:00:00+09:00","event":"experiment.started","message":"Implement TASK-307 search ledger","label":"worker-a","pane_id":"%2","role":"Builder","run_id":"run:task-307","task_id":"TASK-307","data":{"hypothesis":"FTS5 sidecar supports search","test_plan":"cargo test search_ledger_contract"}}
+{"timestamp":"2026-04-27T12:02:00+09:00","event":"operator.followup","message":"TASK-307 needs timeline detail display","label":"worker-a","pane_id":"%2","role":"Builder","run_id":"run:task-307","task_id":"TASK-307","data":{"hypothesis":"FTS5 sidecar supports search","next_action":"open detail"}}
+{"timestamp":"2026-04-27T12:03:00+09:00","event":"experiment.finished","message":"search ledger tests passed","label":"worker-a","pane_id":"%2","role":"Builder","run_id":"run:task-307","task_id":"TASK-307","data":{"result":"pass"}}
+{"timestamp":"2026-04-27T12:04:00+09:00","event":"review.note","message":"other task note","label":"reviewer","pane_id":"%3","role":"Reviewer","run_id":"run:task-999","task_id":"TASK-999","data":{"result":"ignored"}}
+"#
+}
+
+fn run_json(project_dir: &Path, args: &[&str]) -> Value {
+    let output = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .args(args)
+        .current_dir(project_dir)
+        .output()
+        .expect("winsmux command should run");
+    assert!(
+        output.status.success(),
+        "command should succeed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_slice(&output.stdout).expect("stdout should be JSON")
+}
+
+fn make_temp_project_dir(label: &str) -> PathBuf {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time should be after unix epoch")
+        .as_nanos();
+    let dir = std::env::temp_dir().join(format!("winsmux-{label}-{unique}"));
+    fs::create_dir_all(&dir).expect("test should create temp project dir");
+    dir
+}


### PR DESCRIPTION
## Summary
- add `winsmux search-ledger` for JSON search, timeline, and detail views over `.winsmux/events.jsonl`
- index events into a SQLite FTS5 sidecar while suppressing or redacting secret-like content
- expose `search-ledger` in the machine contract and add contract tests

## Validation
- `rustfmt --check core\src\search_ledger.rs core\tests-rs\search_ledger_contract.rs core\src\machine_contract.rs core\tests-rs\machine_contract.rs core\tests-rs\operator_cli.rs`
- `cargo test --manifest-path core\Cargo.toml --test search_ledger_contract -- --nocapture`
- `cargo test --manifest-path core\Cargo.toml --test machine_contract -- --nocapture`
- `cargo test --manifest-path core\Cargo.toml --test operator_cli -- --nocapture`
- `cargo check --manifest-path core\Cargo.toml`
- `git diff --check`
- `pwsh -NoProfile -File scripts\git-guard.ps1`
- `pwsh -NoProfile -File scripts\audit-public-surface.ps1`

## Notes
- External Rust learning note was updated for `rusqlite` and `search_ledger_contract`; required Opus review returned PASS.
- Reviewer found one blocking redaction issue; fixed by redacting secret-like scalar values under neutral keys and adding regression coverage.