### PR TITLE
TASK-282: Add shadow cutover gate

### DIFF
--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -8470,6 +8470,7 @@ promote-tactic <run_id> [--title <text>] [--kind <playbook|prewarm|verification>
   orchestra-smoke [--json] [--auto-start] [--project-dir <path>]  Report structured startup contract + UI attach state (use --auto-start to start if needed)
   orchestra-attach [--json] [--project-dir <path>]  Launch a visible attach window for an existing orchestra session
   harness-check [--json] [--project-dir <path>]  Validate hook/settings/attach contracts before external-operator startup
+  shadow-cutover-gate --expected <path> --actual <path> [--surface <name>] [--json]  Compare PowerShell/Rust shadow outputs before cutover
   vault set <key> [value]   Store a credential securely (DPAPI)
   vault get <key>           Retrieve a stored credential
   vault inject <pane>       Inject all credentials as env vars into a pane
@@ -9017,6 +9018,55 @@ switch ($Command) {
             }
         }
         & pwsh -NoProfile -File $checkScript @checkArgs
+    }
+    'shadow-cutover-gate' {
+        $gateScript = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\winsmux-core\scripts\shadow-cutover-gate.ps1'))
+        $remaining = @(@($Target) + @($Rest) | Where-Object { $_ })
+        $expectedPath = ''
+        $actualPath = ''
+        $surface = 'unspecified'
+        $asJson = $false
+        for ($index = 0; $index -lt $remaining.Count; $index++) {
+            switch ($remaining[$index]) {
+                '--expected' {
+                    if ($index + 1 -ge $remaining.Count) {
+                        Stop-WithError "usage: winsmux shadow-cutover-gate --expected <path> --actual <path> [--surface <name>] [--json]"
+                    }
+                    $expectedPath = $remaining[$index + 1]
+                    $index++
+                }
+                '--actual' {
+                    if ($index + 1 -ge $remaining.Count) {
+                        Stop-WithError "usage: winsmux shadow-cutover-gate --expected <path> --actual <path> [--surface <name>] [--json]"
+                    }
+                    $actualPath = $remaining[$index + 1]
+                    $index++
+                }
+                '--surface' {
+                    if ($index + 1 -ge $remaining.Count) {
+                        Stop-WithError "usage: winsmux shadow-cutover-gate --expected <path> --actual <path> [--surface <name>] [--json]"
+                    }
+                    $surface = $remaining[$index + 1]
+                    $index++
+                }
+                '--json' {
+                    $asJson = $true
+                }
+                default {
+                    Stop-WithError "usage: winsmux shadow-cutover-gate --expected <path> --actual <path> [--surface <name>] [--json]"
+                }
+            }
+        }
+
+        if ([string]::IsNullOrWhiteSpace($expectedPath) -or [string]::IsNullOrWhiteSpace($actualPath)) {
+            Stop-WithError "usage: winsmux shadow-cutover-gate --expected <path> --actual <path> [--surface <name>] [--json]"
+        }
+
+        $gateArgs = @('-ExpectedPath', $expectedPath, '-ActualPath', $actualPath, '-Surface', $surface)
+        if ($asJson) {
+            $gateArgs += '-AsJson'
+        }
+        & pwsh -NoProfile -File $gateScript @gateArgs
     }
     'vault'           {
         switch ($Target) {

--- a/tests/HarnessContract.Tests.ps1
+++ b/tests/HarnessContract.Tests.ps1
@@ -4,6 +4,7 @@ Describe 'harness-check contract' {
     BeforeAll {
         $script:RepoRoot = Split-Path -Parent $PSScriptRoot
         $script:HarnessCheckPath = Join-Path $script:RepoRoot 'winsmux-core\scripts\harness-check.ps1'
+        $script:ShadowCutoverGatePath = Join-Path $script:RepoRoot 'winsmux-core\scripts\shadow-cutover-gate.ps1'
         $script:WinsmuxCorePath = Join-Path $script:RepoRoot 'scripts\winsmux-core.ps1'
         $script:SettingsLocalPath = Join-Path $script:RepoRoot '.claude\settings.local.json'
 
@@ -201,6 +202,53 @@ tasks:
                 BacklogPath = $backlogPath
             }
         }
+    }
+
+    It 'passes shadow cutover gate when only human-readable text changes' {
+        $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('winsmux-shadow-gate-' + [guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $tempRoot -Force | Out-Null
+        try {
+            $expectedPath = Join-Path $tempRoot 'expected.json'
+            $actualPath = Join-Path $tempRoot 'actual.json'
+            Write-TestFileWithCmd -Path $expectedPath -Content '{"operator_contract":{"operator_state":"ready","can_dispatch":true,"requires_startup":false,"operator_message":"ready","next_action":"dispatch"}}'
+            Write-TestFileWithCmd -Path $actualPath -Content '{"operator_contract":{"operator_state":"ready","can_dispatch":true,"requires_startup":false,"operator_message":"ready now","next_action":"continue dispatch"}}'
+
+            $output = & $script:PwshPath -NoProfile -File $script:ShadowCutoverGatePath -ExpectedPath $expectedPath -ActualPath $actualPath -Surface orchestra-smoke -AsJson
+            $LASTEXITCODE | Should -Be 0
+            $json = $output | ConvertFrom-Json
+            $json.passed | Should -BeTrue
+            $json.summary.allowed_differences | Should -Be 2
+            $json.summary.blocking_differences | Should -Be 0
+        } finally {
+            Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'fails shadow cutover gate when a machine-readable field changes' {
+        $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('winsmux-shadow-gate-' + [guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $tempRoot -Force | Out-Null
+        try {
+            $expectedPath = Join-Path $tempRoot 'expected.json'
+            $actualPath = Join-Path $tempRoot 'actual.json'
+            Write-TestFileWithCmd -Path $expectedPath -Content '{"operator_contract":{"operator_state":"ready","can_dispatch":true,"requires_startup":false}}'
+            Write-TestFileWithCmd -Path $actualPath -Content '{"operator_contract":{"operator_state":"ready","can_dispatch":false,"requires_startup":false}}'
+
+            $output = & $script:PwshPath -NoProfile -File $script:ShadowCutoverGatePath -ExpectedPath $expectedPath -ActualPath $actualPath -Surface orchestra-smoke -AsJson
+            $LASTEXITCODE | Should -Be 1
+            $json = $output | ConvertFrom-Json
+            $json.passed | Should -BeFalse
+            $json.summary.blocking_differences | Should -Be 1
+            $json.differences[0].path | Should -Be '$.operator_contract.can_dispatch'
+        } finally {
+            Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'documents and dispatches the shadow cutover gate command' {
+        $bridge = Get-Content -LiteralPath $script:WinsmuxCorePath -Raw -Encoding UTF8
+        $bridge | Should -Match 'shadow-cutover-gate --expected <path> --actual <path> \[--surface <name>\] \[--json\]'
+        $bridge | Should -Match "'shadow-cutover-gate'\s+\{"
+        $bridge | Should -Match 'shadow-cutover-gate\.ps1'
     }
 
     BeforeEach {

--- a/winsmux-core/scripts/shadow-cutover-gate.ps1
+++ b/winsmux-core/scripts/shadow-cutover-gate.ps1
@@ -1,0 +1,202 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$ExpectedPath,
+
+    [Parameter(Mandatory = $true)]
+    [string]$ActualPath,
+
+    [string]$Surface = 'unspecified',
+
+    [switch]$AsJson
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+
+function Stop-GateError {
+    param([Parameter(Mandatory = $true)][string]$Message)
+
+    Write-Error $Message
+    exit 2
+}
+
+function Read-GateJson {
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        Stop-GateError "shadow-cutover-gate input not found: $Path"
+    }
+
+    $raw = Get-Content -LiteralPath $Path -Raw -Encoding UTF8
+    if ([string]::IsNullOrWhiteSpace($raw)) {
+        Stop-GateError "shadow-cutover-gate input is empty: $Path"
+    }
+
+    try {
+        return ($raw | ConvertFrom-Json -Depth 64)
+    } catch {
+        Stop-GateError "shadow-cutover-gate input is not valid JSON: $Path"
+    }
+}
+
+function Test-HumanReadablePath {
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    $leaf = ($Path -split '\.')[-1]
+    return $leaf -in @(
+        'message',
+        'detail',
+        'operator_message',
+        'next_action',
+        'reason',
+        'summary',
+        'description'
+    )
+}
+
+function Add-GateDifference {
+    param(
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyCollection()]
+        [System.Collections.Generic.List[object]]$Differences,
+        [Parameter(Mandatory = $true)][string]$Kind,
+        [Parameter(Mandatory = $true)][string]$Path,
+        [AllowNull()]$Expected,
+        [AllowNull()]$Actual,
+        [bool]$Allowed = $false
+    )
+
+    $Differences.Add([ordered]@{
+        kind     = $Kind
+        path     = $Path
+        expected = $Expected
+        actual   = $Actual
+        allowed  = $Allowed
+    }) | Out-Null
+}
+
+function Get-GateKind {
+    param([AllowNull()]$Value)
+
+    if ($null -eq $Value) {
+        return 'null'
+    }
+
+    if ($Value -is [System.Collections.IDictionary]) {
+        return 'object'
+    }
+
+    if ($Value -is [pscustomobject]) {
+        return 'object'
+    }
+
+    if ($Value -is [System.Array]) {
+        return 'array'
+    }
+
+    return 'scalar'
+}
+
+function Compare-GateJson {
+    param(
+        [AllowNull()]$Expected,
+        [AllowNull()]$Actual,
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyCollection()]
+        [System.Collections.Generic.List[object]]$Differences
+    )
+
+    $expectedKind = Get-GateKind -Value $Expected
+    $actualKind = Get-GateKind -Value $Actual
+
+    if ($expectedKind -ne $actualKind) {
+        Add-GateDifference -Differences $Differences -Kind 'type_mismatch' -Path $Path -Expected $expectedKind -Actual $actualKind
+        return
+    }
+
+    switch ($expectedKind) {
+        'object' {
+            $expectedNames = @($Expected.PSObject.Properties.Name)
+            $actualNames = @($Actual.PSObject.Properties.Name)
+
+            foreach ($name in $expectedNames) {
+                $childPath = if ($Path -eq '$') { '$.' + $name } else { $Path + '.' + $name }
+                if ($name -notin $actualNames) {
+                    Add-GateDifference -Differences $Differences -Kind 'missing_in_actual' -Path $childPath -Expected $Expected.$name -Actual $null
+                    continue
+                }
+
+                Compare-GateJson -Expected $Expected.$name -Actual $Actual.$name -Path $childPath -Differences $Differences
+            }
+
+            foreach ($name in $actualNames) {
+                if ($name -notin $expectedNames) {
+                    $childPath = if ($Path -eq '$') { '$.' + $name } else { $Path + '.' + $name }
+                    Add-GateDifference -Differences $Differences -Kind 'unexpected_in_actual' -Path $childPath -Expected $null -Actual $Actual.$name
+                }
+            }
+        }
+        'array' {
+            if ($Expected.Count -ne $Actual.Count) {
+                Add-GateDifference -Differences $Differences -Kind 'array_length_mismatch' -Path $Path -Expected $Expected.Count -Actual $Actual.Count
+                return
+            }
+
+            for ($index = 0; $index -lt $Expected.Count; $index++) {
+                Compare-GateJson -Expected $Expected[$index] -Actual $Actual[$index] -Path ("{0}[{1}]" -f $Path, $index) -Differences $Differences
+            }
+        }
+        'scalar' {
+            $expectedText = [string]$Expected
+            $actualText = [string]$Actual
+            if ($expectedText -ne $actualText) {
+                $allowed = Test-HumanReadablePath -Path $Path
+                Add-GateDifference -Differences $Differences -Kind 'value_mismatch' -Path $Path -Expected $Expected -Actual $Actual -Allowed $allowed
+            }
+        }
+        default {
+            return
+        }
+    }
+}
+
+$expectedJson = Read-GateJson -Path $ExpectedPath
+$actualJson = Read-GateJson -Path $ActualPath
+$differences = [System.Collections.Generic.List[object]]::new()
+Compare-GateJson -Expected $expectedJson -Actual $actualJson -Path '$' -Differences $differences
+
+$blockingDifferences = @($differences | Where-Object { -not [bool]$_.allowed })
+$allowedDifferences = @($differences | Where-Object { [bool]$_.allowed })
+$passed = ($blockingDifferences.Count -eq 0)
+
+$result = [ordered]@{
+    surface     = $Surface
+    passed      = $passed
+    diff_budget = [ordered]@{
+        machine_readable_fields = 'exact'
+        human_readable_fields   = 'wording differences allowed'
+    }
+    summary     = [ordered]@{
+        blocking_differences = $blockingDifferences.Count
+        allowed_differences  = $allowedDifferences.Count
+        total_differences    = $differences.Count
+    }
+    differences = @($differences)
+}
+
+if ($AsJson) {
+    $result | ConvertTo-Json -Depth 64 -Compress | Write-Output
+} else {
+    if ($passed) {
+        Write-Output "shadow-cutover-gate passed for $Surface"
+    } else {
+        Write-Output ("shadow-cutover-gate failed for {0}: {1} blocking difference(s)" -f $Surface, $blockingDifferences.Count)
+    }
+}
+
+if (-not $passed) {
+    exit 1
+}


### PR DESCRIPTION
## Summary
- Add `winsmux shadow-cutover-gate` for comparing PowerShell and Rust shadow outputs before cutover.
- Enforce exact comparison for machine-readable fields while allowing human-readable wording differences.
- Add focused Pester coverage for pass/fail behavior and bridge dispatch documentation.

## Validation
- `pwsh -NoProfile -Command "Invoke-Pester -Path tests\HarnessContract.Tests.ps1 -FullName '*shadow cutover gate*' -Output Detailed"`
- `git diff --check`
- `pwsh -NoProfile -File scripts\git-guard.ps1`
- `pwsh -NoProfile -File scripts\audit-public-surface.ps1`