### PR TITLE
TASK-270: Expose PowerShell de-escalation contract

### DIFF
--- a/docs/project/powershell-adapter-inventory.md
+++ b/docs/project/powershell-adapter-inventory.md
@@ -137,6 +137,10 @@ Diff budget:
 4. Update docs after the replacement path exists.
 5. Delete scripts last, and only when public docs, hooks, installer, and startup paths no longer reference them.
 
+`winsmux powershell-deescalation --json` exposes this shrink contract to operators and tests.
+It is the machine-readable gate for deciding whether a PowerShell script is still runtime-owned
+or has become bootstrap, setup, compatibility, security, release, or planning glue.
+
 ## Acceptance checklist
 
 - Every PowerShell or hook entrypoint is classified.

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -8471,6 +8471,7 @@ promote-tactic <run_id> [--title <text>] [--kind <playbook|prewarm|verification>
   orchestra-attach [--json] [--project-dir <path>]  Launch a visible attach window for an existing orchestra session
   harness-check [--json] [--project-dir <path>]  Validate hook/settings/attach contracts before external-operator startup
   shadow-cutover-gate --expected <path> --actual <path> [--surface <name>] [--json]  Compare PowerShell/Rust shadow outputs before cutover
+  powershell-deescalation [--json]  Print the PowerShell shrink contract for runtime cutover
   vault set <key> [value]   Store a credential securely (DPAPI)
   vault get <key>           Retrieve a stored credential
   vault inject <pane>       Inject all credentials as env vars into a pane
@@ -9067,6 +9068,22 @@ switch ($Command) {
             $gateArgs += '-AsJson'
         }
         & pwsh -NoProfile -File $gateScript @gateArgs
+    }
+    'powershell-deescalation' {
+        $contractScript = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\winsmux-core\scripts\powershell-deescalation.ps1'))
+        $remaining = @(@($Target) + @($Rest) | Where-Object { $_ })
+        $contractArgs = @()
+        foreach ($argument in $remaining) {
+            switch ($argument) {
+                '--json' {
+                    $contractArgs += '-AsJson'
+                }
+                default {
+                    Stop-WithError "usage: winsmux powershell-deescalation [--json]"
+                }
+            }
+        }
+        & pwsh -NoProfile -File $contractScript @contractArgs
     }
     'vault'           {
         switch ($Target) {

--- a/tests/HarnessContract.Tests.ps1
+++ b/tests/HarnessContract.Tests.ps1
@@ -5,6 +5,7 @@ Describe 'harness-check contract' {
         $script:RepoRoot = Split-Path -Parent $PSScriptRoot
         $script:HarnessCheckPath = Join-Path $script:RepoRoot 'winsmux-core\scripts\harness-check.ps1'
         $script:ShadowCutoverGatePath = Join-Path $script:RepoRoot 'winsmux-core\scripts\shadow-cutover-gate.ps1'
+        $script:PowerShellDeescalationPath = Join-Path $script:RepoRoot 'winsmux-core\scripts\powershell-deescalation.ps1'
         $script:WinsmuxCorePath = Join-Path $script:RepoRoot 'scripts\winsmux-core.ps1'
         $script:SettingsLocalPath = Join-Path $script:RepoRoot '.claude\settings.local.json'
 
@@ -249,6 +250,25 @@ tasks:
         $bridge | Should -Match 'shadow-cutover-gate --expected <path> --actual <path> \[--surface <name>\] \[--json\]'
         $bridge | Should -Match "'shadow-cutover-gate'\s+\{"
         $bridge | Should -Match 'shadow-cutover-gate\.ps1'
+    }
+
+    It 'reports the PowerShell de-escalation contract as JSON' {
+        $output = & $script:PwshPath -NoProfile -File $script:PowerShellDeescalationPath -AsJson
+        $LASTEXITCODE | Should -Be 0
+        $json = $output | ConvertFrom-Json
+        $json.contract_version | Should -Be 1
+        $json.allowed_roles | Should -Contain 'bootstrap'
+        $json.allowed_roles | Should -Contain 'compatibility_launcher'
+        $json.gates.shadow_gate_required | Should -BeTrue
+        $json.gates.delete_without_shadow_gate | Should -BeFalse
+        $json.shrink_order[0] | Should -Be 'typed_state_and_projection_contracts'
+    }
+
+    It 'documents and dispatches the PowerShell de-escalation contract command' {
+        $bridge = Get-Content -LiteralPath $script:WinsmuxCorePath -Raw -Encoding UTF8
+        $bridge | Should -Match 'powershell-deescalation \[--json\]'
+        $bridge | Should -Match "'powershell-deescalation'\s+\{"
+        $bridge | Should -Match 'powershell-deescalation\.ps1'
     }
 
     BeforeEach {

--- a/winsmux-core/scripts/powershell-deescalation.ps1
+++ b/winsmux-core/scripts/powershell-deescalation.ps1
@@ -1,0 +1,64 @@
+[CmdletBinding()]
+param(
+    [switch]$AsJson
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+
+$contract = [ordered]@{
+    contract_version = 1
+    target_state     = 'PowerShell remains only for bootstrap, local setup, compatibility, contributor security, release, and planning sync until typed replacements exist.'
+    runtime_rule     = 'Runtime ownership may move out of PowerShell only after shadow-cutover-gate passes for the affected machine-readable surface.'
+    allowed_roles    = @(
+        'bootstrap',
+        'local_setup',
+        'compatibility_launcher',
+        'contributor_security',
+        'release',
+        'planning_sync'
+    )
+    shrink_order     = @(
+        'typed_state_and_projection_contracts',
+        'compatibility_launcher_wrappers',
+        'shadow_cutover_gate',
+        'documentation_update',
+        'script_deletion_last'
+    )
+    gates            = [ordered]@{
+        inventory_documented       = $true
+        shadow_gate_required       = $true
+        delete_without_shadow_gate = $false
+        keep_startup_boundaries    = @('bootstrap', 'visible_attach', 'manifest_state', 'watchdog', 'rollback')
+    }
+    thin_shim_candidates = @(
+        'scripts/winsmux.ps1',
+        'scripts/start-orchestra.ps1',
+        'scripts/sync-project-views.ps1',
+        'winsmux-core/psmux-bridge.ps1',
+        'winsmux-core/scripts/orchestra-attach-entry.ps1'
+    )
+    needs_decision = @(
+        'scripts/run-tests.ps1',
+        'winsmux-core/scripts/orchestra-cleanup.ps1',
+        'winsmux-core/scripts/pane-scaler.ps1',
+        'release-tooling-powerShell-lifetime',
+        'planning-sync-powerShell-lifetime'
+    )
+    next_actions = @(
+        'Run shadow-cutover-gate for any Rust replacement before changing runtime ownership.',
+        'Keep public docs and installer paths stable until a replacement path exists.',
+        'Use TASK-217e to switch terminal execution targets without deleting compatibility wrappers.'
+    )
+}
+
+if ($AsJson) {
+    $contract | ConvertTo-Json -Depth 16 -Compress | Write-Output
+    return
+}
+
+Write-Output 'PowerShell de-escalation contract'
+Write-Output ('Target: {0}' -f $contract.target_state)
+Write-Output ('Runtime rule: {0}' -f $contract.runtime_rule)
+Write-Output ('Shadow gate required: {0}' -f $contract.gates.shadow_gate_required)


### PR DESCRIPTION
## Summary
- Add `winsmux powershell-deescalation --json` as the machine-readable shrink contract for TASK-270.
- Keep PowerShell runtime ownership changes gated by `shadow-cutover-gate`.
- Connect the contract back to the PowerShell adapter inventory and add focused Pester coverage.

## Validation
- `pwsh -NoProfile -Command "Invoke-Pester -Path tests\HarnessContract.Tests.ps1 -FullName '*PowerShell de-escalation*' -Output Detailed"`
- `git diff --check`
- `pwsh -NoProfile -File scripts\git-guard.ps1`
- `pwsh -NoProfile -File scripts\audit-public-surface.ps1`