### PR TITLE
TASK-217e: Switch terminal bridge to Tauri backend

### DIFF
--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -117,6 +117,109 @@ function Invoke-WinsmuxRaw {
     return & winsmux @Arguments
 }
 
+function Resolve-TerminalBackend {
+    $rawBackend = [string]$env:WINSMUX_BACKEND
+    if ([string]::IsNullOrWhiteSpace($rawBackend)) {
+        return 'cli'
+    }
+
+    switch ($rawBackend.Trim().ToLowerInvariant()) {
+        { $_ -in @('cli', 'winsmux') } { return 'cli' }
+        { $_ -in @('tauri', 'desktop') } { return 'tauri' }
+        default {
+            Stop-WithError "WINSMUX_BACKEND must be cli or tauri, got '$rawBackend'"
+        }
+    }
+}
+
+function New-TerminalJsonRpcPayload {
+    param(
+        [Parameter(Mandatory = $true)][string]$Method,
+        [Parameter(Mandatory = $true)]$Params
+    )
+
+    return ([ordered]@{
+        jsonrpc = '2.0'
+        id      = "terminal-$([guid]::NewGuid().ToString('N'))"
+        method  = $Method
+        params   = $Params
+    } | ConvertTo-Json -Depth 100 -Compress)
+}
+
+function Invoke-TerminalJsonRpc {
+    param(
+        [Parameter(Mandatory = $true)][string]$Method,
+        [Parameter(Mandatory = $true)]$Params
+    )
+
+    $payload = New-TerminalJsonRpcPayload -Method $Method -Params $Params
+    $responseText = Invoke-ControlRpcPipeExchange -Payload $payload
+    try {
+        $response = $responseText | ConvertFrom-Json -Depth 100 -ErrorAction Stop
+    } catch {
+        Stop-WithError "terminal Tauri request $Method returned invalid JSON: $($_.Exception.Message)"
+    }
+
+    $propertyNames = @($response.PSObject.Properties.Name)
+    if ($propertyNames -contains 'error') {
+        $message = [string]$response.error.message
+        if ([string]::IsNullOrWhiteSpace($message)) {
+            $message = 'unknown error'
+        }
+        Stop-WithError "terminal Tauri request $Method failed: $message"
+    }
+
+    if ($propertyNames -contains 'result') {
+        return $response.result
+    }
+
+    return $null
+}
+
+function Invoke-TerminalCapture {
+    param([Parameter(Mandatory = $true)][string]$PaneId, [int]$Lines = 50)
+
+    if ((Resolve-TerminalBackend) -eq 'tauri') {
+        $result = Invoke-TerminalJsonRpc -Method 'pty.capture' -Params ([ordered]@{
+            paneId = $PaneId
+            lines  = $Lines
+        })
+        if ($null -eq $result) {
+            return ''
+        }
+        return [string]$result.output
+    }
+
+    $output = Invoke-WinsmuxRaw -Arguments @('capture-pane', '-t', $PaneId, '-p', '-J', '-S', "-$Lines")
+    return ($output | Out-String).TrimEnd()
+}
+
+function Invoke-TerminalWrite {
+    param(
+        [Parameter(Mandatory = $true)][string]$Target,
+        [Parameter(Mandatory = $true)][AllowEmptyString()][string]$Text
+    )
+
+    if ((Resolve-TerminalBackend) -eq 'tauri') {
+        $null = Invoke-TerminalJsonRpc -Method 'pty.write' -Params ([ordered]@{
+            paneId = $Target
+            data   = $Text
+        })
+        return [ordered]@{
+            ExitCode = 0
+            Output   = ''
+            Target   = $Target
+        }
+    }
+
+    $output = Invoke-WinsmuxRaw -Arguments @('send-keys', '-t', $Target, '-l', '--', $Text) 2>&1
+    return [ordered]@{
+        ExitCode = $LASTEXITCODE
+        Output   = ($output | Out-String).Trim()
+        Target   = $Target
+    }
+}
+
 function Write-ClmSafeTextFile {
     param(
         [Parameter(Mandatory = $true)][string]$Path,
@@ -1828,6 +1931,22 @@ function Invoke-WinsmuxSendKeys {
         [switch]$Literal
     )
 
+    if ((Resolve-TerminalBackend) -eq 'tauri') {
+        if ($Literal) {
+            return Invoke-TerminalWrite -Target $Target -Text ($Keys -join '')
+        }
+
+        if ($Keys.Count -eq 1 -and $Keys[0] -eq 'Enter') {
+            return Invoke-TerminalWrite -Target $Target -Text "`r"
+        }
+
+        return [ordered]@{
+            ExitCode = 1
+            Output   = 'Tauri terminal backend supports only literal text and Enter for send-keys.'
+            Target   = $Target
+        }
+    }
+
     $arguments = @('send-keys', '-t', $Target)
     if ($Literal) {
         $arguments += '-l'
@@ -1849,6 +1968,10 @@ function Invoke-WinsmuxSendPaste {
         [Parameter(Mandatory = $true)][string]$Target,
         [Parameter(Mandatory = $true)][AllowEmptyString()][string]$Text
     )
+
+    if ((Resolve-TerminalBackend) -eq 'tauri') {
+        return Invoke-TerminalWrite -Target $Target -Text $Text
+    }
 
     $encoded = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($Text))
     $arguments = @('send-paste', '-t', $Target, $encoded)
@@ -1911,7 +2034,12 @@ function Send-TextToPane {
     )
 
     $resolvedPromptTransport = Resolve-SupportedPromptTransport -PromptTransport $PromptTransport
-    $targetCandidates = @(Get-PaneTargetCandidates -PaneId $PaneId)
+    $terminalBackend = Resolve-TerminalBackend
+    $targetCandidates = if ($terminalBackend -eq 'tauri') {
+        @($PaneId)
+    } else {
+        @(Get-PaneTargetCandidates -PaneId $PaneId)
+    }
     $attemptFailures = [System.Collections.Generic.List[string]]::new()
 
     foreach ($sendTarget in $targetCandidates) {
@@ -2406,8 +2534,7 @@ function Get-PaneRuntimeMap {
 function Get-PaneSnapshotText {
     param([string]$PaneId, [int]$Lines = 50)
 
-    $output = Invoke-WinsmuxRaw -Arguments @('capture-pane', '-t', $PaneId, '-p', '-J', '-S', "-$Lines")
-    return ($output | Out-String).TrimEnd()
+    return Invoke-TerminalCapture -PaneId $PaneId -Lines $Lines
 }
 
 # --- Helper: Focus Policy Stack ---
@@ -2893,7 +3020,9 @@ function Invoke-Send {
     $text = Normalize-DispatchText -Text ($messageParts -join ' ')
     $projectDir = (Get-Location).Path
     $paneId = Resolve-Target $Target
-    $paneId = Confirm-Target $paneId
+    if ((Resolve-TerminalBackend) -eq 'cli') {
+        $paneId = Confirm-Target $paneId
+    }
     $context = $null
     $agentConfig = [ordered]@{
         Agent           = 'codex'

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -12923,6 +12923,118 @@ Describe 'winsmux control-rpc command' {
     }
 }
 
+Describe 'winsmux terminal backend switch' {
+    BeforeAll {
+        $bridgePath = Join-Path (Split-Path -Parent $PSScriptRoot) 'scripts\winsmux-core.ps1'
+        $null = . $bridgePath version
+    }
+
+    BeforeEach {
+        $script:previousWinsmuxBackend = $env:WINSMUX_BACKEND
+        Remove-Item Env:\WINSMUX_BACKEND -ErrorAction SilentlyContinue
+        $script:terminalRpcPayloads = [System.Collections.Generic.List[string]]::new()
+    }
+
+    AfterEach {
+        if ($null -eq $script:previousWinsmuxBackend) {
+            Remove-Item Env:\WINSMUX_BACKEND -ErrorAction SilentlyContinue
+        } else {
+            $env:WINSMUX_BACKEND = $script:previousWinsmuxBackend
+        }
+    }
+
+    It 'defaults terminal operations to the CLI backend and accepts Tauri aliases' {
+        Resolve-TerminalBackend | Should -Be 'cli'
+
+        $env:WINSMUX_BACKEND = 'desktop'
+        Resolve-TerminalBackend | Should -Be 'tauri'
+
+        $env:WINSMUX_BACKEND = 'winsmux'
+        Resolve-TerminalBackend | Should -Be 'cli'
+    }
+
+    It 'rejects unsupported terminal backend values' {
+        $env:WINSMUX_BACKEND = 'remote'
+
+        { Resolve-TerminalBackend } | Should -Throw "*WINSMUX_BACKEND must be cli or tauri*"
+    }
+
+    It 'captures pane text through the Tauri pty JSON-RPC path' {
+        Mock Invoke-ControlRpcPipeExchange {
+            param([string]$Payload)
+            $script:terminalRpcPayloads.Add($Payload) | Out-Null
+            return '{"jsonrpc":"2.0","id":"terminal-test","result":{"paneId":"pane-1","output":"ready"}}'
+        }
+
+        $env:WINSMUX_BACKEND = 'tauri'
+        $output = Get-PaneSnapshotText -PaneId 'pane-1' -Lines 25
+
+        $output | Should -Be 'ready'
+        Should -Invoke Invoke-ControlRpcPipeExchange -Times 1 -Exactly
+        $request = $script:terminalRpcPayloads[0] | ConvertFrom-Json
+        $request.method | Should -Be 'pty.capture'
+        $request.params.paneId | Should -Be 'pane-1'
+        $request.params.lines | Should -Be 25
+    }
+
+    It 'writes literal text and Enter through the Tauri pty JSON-RPC path' {
+        Mock Invoke-ControlRpcPipeExchange {
+            param([string]$Payload)
+            $script:terminalRpcPayloads.Add($Payload) | Out-Null
+            return '{"jsonrpc":"2.0","id":"terminal-test","result":{"paneId":"pane-1"}}'
+        }
+
+        $env:WINSMUX_BACKEND = 'tauri'
+        $literal = Invoke-WinsmuxSendKeys -Target 'pane-1' -Keys @('echo test') -Literal
+        $enter = Invoke-WinsmuxSendKeys -Target 'pane-1' -Keys @('Enter')
+
+        $literal.ExitCode | Should -Be 0
+        $enter.ExitCode | Should -Be 0
+        Should -Invoke Invoke-ControlRpcPipeExchange -Times 2 -Exactly
+        $literalRequest = $script:terminalRpcPayloads[0] | ConvertFrom-Json
+        $enterRequest = $script:terminalRpcPayloads[1] | ConvertFrom-Json
+        $literalRequest.method | Should -Be 'pty.write'
+        $literalRequest.params.data | Should -Be 'echo test'
+        $enterRequest.method | Should -Be 'pty.write'
+        $enterRequest.params.data | Should -Be "`r"
+    }
+
+    It 'sends text through one Tauri pane target without CLI fallback resolution' {
+        Mock Start-Sleep { }
+        Mock Save-Watermark { }
+        Mock Set-ReadMark { }
+        Mock Invoke-WinsmuxRaw { throw "CLI backend should not be called: $($Arguments -join ' ')" }
+        Mock Invoke-ControlRpcPipeExchange {
+            param([string]$Payload)
+            $script:terminalRpcPayloads.Add($Payload) | Out-Null
+            $request = $Payload | ConvertFrom-Json
+            if ($request.method -eq 'pty.write') {
+                if ($request.params.data -eq "`r") {
+                    $script:terminalPaneText = "> echo test`nresult"
+                } else {
+                    $script:terminalPaneText = "> $($request.params.data)"
+                }
+                return '{"jsonrpc":"2.0","id":"terminal-test","result":{"paneId":"pane-1"}}'
+            }
+
+            $escaped = ([string]$script:terminalPaneText | ConvertTo-Json -Compress)
+            return '{"jsonrpc":"2.0","id":"terminal-test","result":{"paneId":"pane-1","output":' + $escaped + '}}'
+        }
+
+        $env:WINSMUX_BACKEND = 'tauri'
+        $script:terminalPaneText = '> '
+        $result = Send-TextToPane -PaneId 'pane-1' -CommandText 'echo test'
+
+        $result | Should -Be 'sent to pane-1 via pane-1'
+        $writes = @($script:terminalRpcPayloads |
+            ForEach-Object { $_ | ConvertFrom-Json } |
+            Where-Object { $_.method -eq 'pty.write' })
+        $writes.Count | Should -Be 2
+        $writes[0].params.data | Should -Be 'echo test'
+        $writes[1].params.data | Should -Be "`r"
+    }
+}
+
 Describe 'winsmux send fallback' {
     BeforeAll {
         $bridgePath = Join-Path (Split-Path -Parent $PSScriptRoot) 'scripts\winsmux-core.ps1'

--- a/winsmux-app/src-tauri/src/control_pipe.rs
+++ b/winsmux-app/src-tauri/src/control_pipe.rs
@@ -1,7 +1,9 @@
 use crate::desktop_backend::{
     handle_desktop_json_rpc, DesktopCommandTransport, DesktopJsonRpcRequest, PwshScriptTransport,
 };
+use crate::pty_backend::{handle_pty_json_rpc, PtyCommandTransport, PtyJsonRpcRequest};
 use serde_json::{json, Value};
+use std::sync::Arc;
 
 pub const WINSMUX_CONTROL_PIPE_NAME: &str = r"\\.\pipe\winsmux-control";
 
@@ -10,7 +12,7 @@ const JSON_RPC_METHOD_NOT_FOUND: i32 = -32601;
 const JSON_RPC_INVALID_PARAMS: i32 = -32602;
 const JSON_RPC_INTERNAL_ERROR: i32 = -32603;
 
-const CONTROL_PIPE_METHODS: &[&str] = &[
+const DESKTOP_CONTROL_PIPE_METHODS: &[&str] = &[
     "desktop.control_plane.contract",
     "desktop.summary.snapshot",
     "desktop.run.explain",
@@ -20,7 +22,8 @@ const CONTROL_PIPE_METHODS: &[&str] = &[
 ];
 
 pub fn handle_control_pipe_payload(
-    transport: &dyn DesktopCommandTransport,
+    desktop_transport: &dyn DesktopCommandTransport,
+    pty_transport: &dyn PtyCommandTransport,
     payload: &[u8],
     project_dir: Option<String>,
 ) -> Vec<u8> {
@@ -45,13 +48,6 @@ pub fn handle_control_pipe_payload(
             );
         }
     };
-    if !CONTROL_PIPE_METHODS.contains(&method) {
-        return serialize_control_pipe_error(
-            request_id,
-            JSON_RPC_METHOD_NOT_FOUND,
-            format!("Control pipe method is not exposed: {method}"),
-        );
-    }
     if has_project_dir_override(&request_value) {
         return serialize_control_pipe_error(
             request_id,
@@ -60,25 +56,66 @@ pub fn handle_control_pipe_payload(
         );
     }
 
-    let request = match serde_json::from_value::<DesktopJsonRpcRequest>(request_value) {
-        Ok(value) => value,
-        Err(err) => {
-            return serialize_control_pipe_error(
-                Value::Null,
-                JSON_RPC_PARSE_ERROR,
-                format!("Invalid JSON-RPC request: {err}"),
-            );
-        }
-    };
+    if DESKTOP_CONTROL_PIPE_METHODS.contains(&method) {
+        let request = match serde_json::from_value::<DesktopJsonRpcRequest>(request_value) {
+            Ok(value) => value,
+            Err(err) => {
+                return serialize_control_pipe_error(
+                    Value::Null,
+                    JSON_RPC_PARSE_ERROR,
+                    format!("Invalid JSON-RPC request: {err}"),
+                );
+            }
+        };
 
-    match serde_json::to_vec(&handle_desktop_json_rpc(transport, request, project_dir)) {
-        Ok(value) => value,
-        Err(err) => serialize_control_pipe_error(
-            Value::Null,
-            JSON_RPC_INTERNAL_ERROR,
-            format!("Failed to serialize JSON-RPC response: {err}"),
-        ),
+        return match serde_json::to_vec(&handle_desktop_json_rpc(
+            desktop_transport,
+            request,
+            project_dir,
+        )) {
+            Ok(value) => value,
+            Err(err) => serialize_control_pipe_error(
+                Value::Null,
+                JSON_RPC_INTERNAL_ERROR,
+                format!("Failed to serialize JSON-RPC response: {err}"),
+            ),
+        };
     }
+
+    if is_pty_control_pipe_method(method) {
+        let request = match serde_json::from_value::<PtyJsonRpcRequest>(request_value) {
+            Ok(value) => value,
+            Err(err) => {
+                return serialize_control_pipe_error(
+                    Value::Null,
+                    JSON_RPC_PARSE_ERROR,
+                    format!("Invalid JSON-RPC request: {err}"),
+                );
+            }
+        };
+
+        return match serde_json::to_vec(&handle_pty_json_rpc(pty_transport, request)) {
+            Ok(value) => value,
+            Err(err) => serialize_control_pipe_error(
+                Value::Null,
+                JSON_RPC_INTERNAL_ERROR,
+                format!("Failed to serialize JSON-RPC response: {err}"),
+            ),
+        };
+    }
+
+    serialize_control_pipe_error(
+        request_id,
+        JSON_RPC_METHOD_NOT_FOUND,
+        format!("Control pipe method is not exposed: {method}"),
+    )
+}
+
+fn is_pty_control_pipe_method(method: &str) -> bool {
+    matches!(
+        method,
+        "pty.spawn" | "pty.write" | "pty.resize" | "pty.capture" | "pty.respawn" | "pty.close"
+    )
 }
 
 fn has_project_dir_override(request_value: &Value) -> bool {
@@ -105,19 +142,19 @@ fn serialize_control_pipe_error(id: Value, code: i32, message: String) -> Vec<u8
 }
 
 #[cfg(windows)]
-pub fn start_control_pipe_server() {
+pub fn start_control_pipe_server(pty_transport: Arc<dyn PtyCommandTransport + Send + Sync>) {
     std::thread::spawn(move || loop {
-        if let Err(err) = serve_one_control_pipe_client() {
+        if let Err(err) = serve_one_control_pipe_client(pty_transport.as_ref()) {
             eprintln!("winsmux control pipe error: {err}");
         }
     });
 }
 
 #[cfg(not(windows))]
-pub fn start_control_pipe_server() {}
+pub fn start_control_pipe_server(_pty_transport: Arc<dyn PtyCommandTransport + Send + Sync>) {}
 
 #[cfg(windows)]
-fn serve_one_control_pipe_client() -> Result<(), String> {
+fn serve_one_control_pipe_client(pty_transport: &dyn PtyCommandTransport) -> Result<(), String> {
     use std::ffi::OsStr;
     use std::os::windows::ffi::OsStrExt;
     use std::ptr::null_mut;
@@ -193,7 +230,7 @@ fn serve_one_control_pipe_client() -> Result<(), String> {
     }
     buffer.truncate(bytes_read as usize);
 
-    let response = handle_control_pipe_payload(&PwshScriptTransport, &buffer, None);
+    let response = handle_control_pipe_payload(&PwshScriptTransport, pty_transport, &buffer, None);
     let mut bytes_written = 0u32;
     let write_ok = unsafe {
         WriteFile(
@@ -228,11 +265,13 @@ fn serve_one_control_pipe_client() -> Result<(), String> {
 mod tests {
     use super::*;
     use crate::desktop_backend::{DesktopCommand, DesktopCommandTransport};
+    use crate::pty_backend::PtyCommand;
     use serde_json::json;
+    use std::sync::Mutex;
 
-    struct StubTransport;
+    struct StubDesktopTransport;
 
-    impl DesktopCommandTransport for StubTransport {
+    impl DesktopCommandTransport for StubDesktopTransport {
         fn request_json(&self, command: &DesktopCommand) -> Result<Value, String> {
             match command {
                 DesktopCommand::SummarySnapshot { .. } => Ok(json!({
@@ -273,10 +312,40 @@ mod tests {
         }
     }
 
+    struct StubPtyTransport {
+        commands: Mutex<Vec<PtyCommand>>,
+    }
+
+    impl StubPtyTransport {
+        fn new() -> Self {
+            Self {
+                commands: Mutex::new(Vec::new()),
+            }
+        }
+    }
+
+    impl PtyCommandTransport for StubPtyTransport {
+        fn execute(&self, command: &PtyCommand) -> Result<Value, String> {
+            self.commands
+                .lock()
+                .expect("commands lock")
+                .push(command.clone());
+            match command {
+                PtyCommand::Capture { pane_id, .. } => Ok(json!({
+                    "paneId": pane_id,
+                    "output": "ready"
+                })),
+                _ => Ok(json!({ "ok": true })),
+            }
+        }
+    }
+
     #[test]
     fn control_pipe_routes_json_rpc_to_desktop_handler() {
         let payload = br#"{"jsonrpc":"2.0","id":1,"method":"desktop.control_plane.contract"}"#;
-        let response = handle_control_pipe_payload(&StubTransport, payload, None);
+        let pty_transport = StubPtyTransport::new();
+        let response =
+            handle_control_pipe_payload(&StubDesktopTransport, &pty_transport, payload, None);
         let value: Value = serde_json::from_slice(&response).expect("response should be JSON");
 
         assert_eq!(value["jsonrpc"], "2.0");
@@ -289,7 +358,9 @@ mod tests {
 
     #[test]
     fn control_pipe_rejects_invalid_json() {
-        let response = handle_control_pipe_payload(&StubTransport, b"{", None);
+        let pty_transport = StubPtyTransport::new();
+        let response =
+            handle_control_pipe_payload(&StubDesktopTransport, &pty_transport, b"{", None);
         let value: Value = serde_json::from_slice(&response).expect("response should be JSON");
 
         assert_eq!(value["jsonrpc"], "2.0");
@@ -308,7 +379,9 @@ mod tests {
     #[test]
     fn control_pipe_rejects_project_dir_override() {
         let payload = br#"{"jsonrpc":"2.0","id":1,"method":"desktop.summary.snapshot","params":{"projectDir":"C:/other"}}"#;
-        let response = handle_control_pipe_payload(&StubTransport, payload, None);
+        let pty_transport = StubPtyTransport::new();
+        let response =
+            handle_control_pipe_payload(&StubDesktopTransport, &pty_transport, payload, None);
         let value: Value = serde_json::from_slice(&response).expect("response should be JSON");
 
         assert_eq!(value["id"], 1);
@@ -316,9 +389,54 @@ mod tests {
     }
 
     #[test]
+    fn control_pipe_routes_pty_methods_to_pty_handler() {
+        let payload =
+            br#"{"jsonrpc":"2.0","id":1,"method":"pty.capture","params":{"paneId":"pane-1"}}"#;
+        let pty_transport = StubPtyTransport::new();
+        let response =
+            handle_control_pipe_payload(&StubDesktopTransport, &pty_transport, payload, None);
+        let value: Value = serde_json::from_slice(&response).expect("response should be JSON");
+
+        assert_eq!(value["jsonrpc"], "2.0");
+        assert_eq!(value["id"], 1);
+        assert_eq!(value["result"]["paneId"], "pane-1");
+        assert_eq!(value["result"]["output"], "ready");
+        assert_eq!(
+            pty_transport
+                .commands
+                .lock()
+                .expect("commands lock")
+                .as_slice(),
+            [PtyCommand::Capture {
+                pane_id: "pane-1".to_string(),
+                lines: None
+            }]
+        );
+    }
+
+    #[test]
+    fn control_pipe_rejects_project_dir_override_for_pty_methods() {
+        let payload = br#"{"jsonrpc":"2.0","id":1,"method":"pty.capture","params":{"paneId":"pane-1","projectDir":"C:/other"}}"#;
+        let pty_transport = StubPtyTransport::new();
+        let response =
+            handle_control_pipe_payload(&StubDesktopTransport, &pty_transport, payload, None);
+        let value: Value = serde_json::from_slice(&response).expect("response should be JSON");
+
+        assert_eq!(value["id"], 1);
+        assert_eq!(value["error"]["code"], JSON_RPC_INVALID_PARAMS);
+        assert!(pty_transport
+            .commands
+            .lock()
+            .expect("commands lock")
+            .is_empty());
+    }
+
+    #[test]
     fn control_pipe_blocks_editor_read() {
         let payload = br#"{"jsonrpc":"2.0","id":1,"method":"desktop.editor.read","params":{"path":"README.md"}}"#;
-        let response = handle_control_pipe_payload(&StubTransport, payload, None);
+        let pty_transport = StubPtyTransport::new();
+        let response =
+            handle_control_pipe_payload(&StubDesktopTransport, &pty_transport, payload, None);
         let value: Value = serde_json::from_slice(&response).expect("response should be JSON");
 
         assert_eq!(value["id"], 1);

--- a/winsmux-app/src-tauri/src/lib.rs
+++ b/winsmux-app/src-tauri/src/lib.rs
@@ -120,8 +120,12 @@ async fn pty_resize(app: AppHandle, pane_id: String, cols: u16, rows: u16) -> Re
 }
 
 #[tauri::command]
-async fn pty_capture(app: AppHandle, pane_id: String) -> Result<serde_json::Value, String> {
-    capture_pty(&app, &pane_id)
+async fn pty_capture(
+    app: AppHandle,
+    pane_id: String,
+    lines: Option<u16>,
+) -> Result<serde_json::Value, String> {
+    capture_pty(&app, &pane_id, lines)
 }
 
 #[tauri::command]
@@ -337,7 +341,28 @@ fn resize_pty(app: &AppHandle, pane_id: &str, cols: u16, rows: u16) -> Result<()
     Ok(())
 }
 
-fn capture_pty(app: &AppHandle, pane_id: &str) -> Result<serde_json::Value, String> {
+fn limit_pty_capture_output(output: &str, lines: Option<u16>) -> String {
+    let Some(lines) = lines else {
+        return output.to_string();
+    };
+    if lines == 0 {
+        return String::new();
+    }
+
+    let mut tail = output
+        .lines()
+        .rev()
+        .take(lines as usize)
+        .collect::<Vec<_>>();
+    tail.reverse();
+    tail.join("\n")
+}
+
+fn capture_pty(
+    app: &AppHandle,
+    pane_id: &str,
+    lines: Option<u16>,
+) -> Result<serde_json::Value, String> {
     let manager = app.state::<PtyManager>();
     let panes = manager.panes.lock().map_err(|e| e.to_string())?;
     let pty = panes
@@ -348,6 +373,7 @@ fn capture_pty(app: &AppHandle, pane_id: &str) -> Result<serde_json::Value, Stri
         .lock()
         .map_err(|e| e.to_string())?
         .clone();
+    let output = limit_pty_capture_output(&output, lines);
     Ok(serde_json::json!({
         "paneId": pane_id,
         "output": output
@@ -454,7 +480,7 @@ impl PtyCommandTransport for TauriPtyTransport {
                 resize_pty(&self.app, pane_id, *cols, *rows)?;
                 Ok(serde_json::json!({ "paneId": pane_id }))
             }
-            PtyCommand::Capture { pane_id } => capture_pty(&self.app, pane_id),
+            PtyCommand::Capture { pane_id, lines } => capture_pty(&self.app, pane_id, *lines),
             PtyCommand::Respawn { pane_id } => {
                 respawn_pty(&self.app, pane_id)?;
                 Ok(serde_json::json!({ "paneId": pane_id }))
@@ -481,6 +507,13 @@ mod tests {
         assert!(history.is_char_boundary(0));
         assert!(history.ends_with('あ'));
     }
+
+    #[test]
+    fn limit_pty_capture_output_returns_recent_lines() {
+        let output = limit_pty_capture_output("one\ntwo\nthree\nfour\n", Some(2));
+
+        assert_eq!(output, "three\nfour");
+    }
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -496,8 +529,11 @@ pub fn run() {
             stop_requested: Arc::new(AtomicBool::new(false)),
         })
         .setup(|app| {
-            start_control_pipe_server();
-            start_desktop_summary_refresh_streams(&app.handle().clone());
+            let app_handle = app.handle().clone();
+            start_control_pipe_server(Arc::new(TauriPtyTransport {
+                app: app_handle.clone(),
+            }));
+            start_desktop_summary_refresh_streams(&app_handle);
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![

--- a/winsmux-app/src-tauri/src/pty_backend.rs
+++ b/winsmux-app/src-tauri/src/pty_backend.rs
@@ -55,6 +55,7 @@ pub enum PtyCommand {
     },
     Capture {
         pane_id: String,
+        lines: Option<u16>,
     },
     Respawn {
         pane_id: String,
@@ -120,6 +121,7 @@ fn parse_command(method: &str, params: Option<&Value>) -> Result<PtyCommand, Par
         }),
         "pty.capture" => Ok(PtyCommand::Capture {
             pane_id: get_required_string_param(params, &["paneId", "pane_id"])?,
+            lines: get_optional_u16_param(params, &["lines"])?,
         }),
         "pty.respawn" => Ok(PtyCommand::Respawn {
             pane_id: get_required_string_param(params, &["paneId", "pane_id"])?,
@@ -168,6 +170,29 @@ fn get_required_u16_param(params: Option<&Value>, keys: &[&str]) -> Result<u16, 
     }
 
     Err(ParseError::InvalidParams(invalid_params(keys)))
+}
+
+fn get_optional_u16_param(
+    params: Option<&Value>,
+    keys: &[&str],
+) -> Result<Option<u16>, ParseError> {
+    let Some(object) = params.and_then(Value::as_object) else {
+        return Ok(None);
+    };
+
+    for key in keys {
+        if let Some(raw) = object.get(*key).and_then(Value::as_u64) {
+            let value = u16::try_from(raw).map_err(|_| {
+                ParseError::InvalidParams(format!(
+                    "Invalid params field {}: expected 0-65535",
+                    keys.join(" or ")
+                ))
+            })?;
+            return Ok(Some(value));
+        }
+    }
+
+    Ok(None)
 }
 
 fn invalid_params(keys: &[&str]) -> String {
@@ -268,7 +293,8 @@ mod tests {
                 id: serde_json::json!("req-capture"),
                 method: "pty.capture".to_string(),
                 params: Some(serde_json::json!({
-                    "paneId": "pane-1"
+                    "paneId": "pane-1",
+                    "lines": 25
                 })),
             },
         );
@@ -285,7 +311,8 @@ mod tests {
         assert_eq!(
             transport.commands.borrow().as_slice(),
             [PtyCommand::Capture {
-                pane_id: "pane-1".to_string()
+                pane_id: "pane-1".to_string(),
+                lines: Some(25)
             }]
         );
     }


### PR DESCRIPTION
## Summary

- Add `WINSMUX_BACKEND` resolution for CLI vs Tauri terminal operations.
- Route capture/write/send paths through the Tauri control pipe when `WINSMUX_BACKEND=tauri`.
- Expose pty JSON-RPC methods through the named control pipe and preserve `projectDir` override rejection.
- Preserve capture line limits across the Tauri backend and add regression coverage for the end-to-end send path.

## Validation

- `Invoke-Pester -Path tests\winsmux-bridge.Tests.ps1 -FullName '*terminal backend switch*' -Output Detailed` — 5 passed.
- `Invoke-Pester -Path tests\winsmux-bridge.Tests.ps1 -Output Detailed` — 370 passed.
- `cargo test --manifest-path winsmux-app\src-tauri\Cargo.toml -- --nocapture` — 145 passed.
- `cargo check --manifest-path winsmux-app\src-tauri\Cargo.toml` — passed.
- `cargo fmt --manifest-path winsmux-app\src-tauri\Cargo.toml -- --check` — passed.
- `git diff --check` — passed, with line-ending warnings only.
- `pwsh -NoProfile -File scripts\git-guard.ps1` — passed.
- `pwsh -NoProfile -File scripts\audit-public-surface.ps1` — passed.

## Review Notes

- Read-only Codex explorer review found two issues: missing Tauri capture line limiting and missing send-path coverage.
- Both findings were fixed before opening this PR.