### PR TITLE
TASK-283: Add Rust canary release gate

### DIFF
--- a/core/src/cli.rs
+++ b/core/src/cli.rs
@@ -162,6 +162,7 @@ OPERATOR COMMANDS:
     desktop-summary         Print desktop summary projection JSON or counts
     provider-capabilities   Inspect the provider capability registry contract
     machine-contract        Print the hook and agent machine contract JSON
+    rust-canary             Print the Rust default-on canary gate JSON
     provider-switch         Record or clear a runtime provider reassignment
     signal <channel>        Send a file-backed orchestration signal
     wait <channel> [secs]   Wait for a file-backed orchestration signal
@@ -473,6 +474,7 @@ fn commands_text() -> &'static str {
   list-clients (lsc)        - List connected clients
   list-commands (lscm)      - List commands
   machine-contract          - Print the hook and agent machine contract JSON
+  rust-canary               - Print the Rust default-on canary gate JSON
   list-keys (lsk)           - List key bindings
   list-panes (lsp)          - List panes in a window
   list-sessions (ls)        - List sessions
@@ -623,6 +625,7 @@ mod tests {
         assert!(text.contains("winsmux reads config on startup from the first compatible file found:"));
         assert!(text.contains("winsmux launches PowerShell 7 (pwsh) by default."));
         assert!(text.contains("machine-contract        Print the hook and agent machine contract JSON"));
+        assert!(text.contains("rust-canary             Print the Rust default-on canary gate JSON"));
         assert!(text.contains("winsmux preserves compatibility aliases 'psmux', 'pmux', and 'tmux' where supported."));
         assert!(text.contains("v0.24.5 warning-only sunset mode"));
         assert!(text.contains("For more information: https://github.com/Sora-bluesky/winsmux"));
@@ -647,6 +650,7 @@ mod tests {
         let text = commands_text();
         assert!(text.contains("kill-server               - Kill the winsmux server"));
         assert!(text.contains("machine-contract          - Print the hook and agent machine contract JSON"));
+        assert!(text.contains("rust-canary               - Print the Rust default-on canary gate JSON"));
         assert!(!text.contains("Kill the psmux server"));
     }
 }

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -255,6 +255,7 @@ fn run_main() -> io::Result<()> {
         "desktop-summary" => return operator_cli::run_desktop_summary_command(&cmd_args[1..]),
         "provider-capabilities" => return operator_cli::run_provider_capabilities_command(&cmd_args[1..]),
         "machine-contract" => return operator_cli::run_machine_contract_command(&cmd_args[1..]),
+        "rust-canary" => return operator_cli::run_rust_canary_command(&cmd_args[1..]),
         "provider-switch" => return operator_cli::run_provider_switch_command(&cmd_args[1..]),
         "signal" => return operator_cli::run_signal_command(&cmd_args[1..]),
         "wait" if !matches!(

--- a/core/src/operator_cli.rs
+++ b/core/src/operator_cli.rs
@@ -19,6 +19,7 @@ use crate::ledger::{
     LedgerStatusPayload,
 };
 use crate::machine_contract::machine_contract_catalog;
+use crate::types::VERSION;
 
 static REVIEW_REQUEST_COUNTER: AtomicU32 = AtomicU32::new(0);
 static ATOMIC_WRITE_COUNTER: AtomicU32 = AtomicU32::new(0);
@@ -211,6 +212,98 @@ pub fn run_machine_contract_command(args: &[&String]) -> io::Result<()> {
         ));
     }
     write_json(&machine_contract_catalog())
+}
+
+pub fn run_rust_canary_command(args: &[&String]) -> io::Result<()> {
+    if should_print_help(args) {
+        println!("{}", usage_for("rust-canary"));
+        return Ok(());
+    }
+
+    let options = parse_options("rust-canary", args, 0)?;
+    let backend = rust_canary_backend()?;
+    let backend_name = backend.backend;
+    let backend_source = backend.source;
+    let tauri_backend_candidate = backend_name == "tauri";
+    let payload = json!({
+        "contract_version": 1,
+        "task_id": "TASK-283",
+        "target_version": "v0.24.5",
+        "generated_at": generated_at(),
+        "project_dir": project_dir_string(&options.project_dir),
+        "product_version": VERSION,
+        "phase": "default-on-canary",
+        "runtime": {
+            "rust_cli_available": true,
+            "backend_env": "WINSMUX_BACKEND",
+            "backend": backend_name,
+            "backend_source": backend_source,
+            "tauri_backend_candidate": tauri_backend_candidate,
+        },
+        "required_gates": [
+            "local_rust_cli_tests",
+            "tauri_backend_smoke",
+            "shadow_cutover_gate",
+            "versioned_manual_checklist",
+            "public_surface_audit",
+            "release_ci"
+        ],
+        "blocking_conditions": [
+            "invalid_WINSMUX_BACKEND",
+            "shadow_cutover_difference",
+            "tauri_backend_smoke_failure",
+            "release_ci_failure",
+            "public_surface_drift"
+        ],
+        "depends_on": ["TASK-270", "TASK-272", "TASK-273", "TASK-274", "TASK-296"],
+        "next_action": "Run canary validation with WINSMUX_BACKEND=tauri before v0.24.5 release.",
+    });
+
+    if options.json {
+        return write_json(&payload);
+    }
+
+    println!(
+        "Rust canary: {} backend for v0.24.5 (version {})",
+        payload["runtime"]["backend"].as_str().unwrap_or("unknown"),
+        VERSION
+    );
+    println!("{}", payload["next_action"].as_str().unwrap_or(""));
+    Ok(())
+}
+
+struct RustCanaryBackend {
+    backend: String,
+    source: String,
+}
+
+fn rust_canary_backend() -> io::Result<RustCanaryBackend> {
+    let Ok(raw_backend) = env::var("WINSMUX_BACKEND") else {
+        return Ok(RustCanaryBackend {
+            backend: "cli".to_string(),
+            source: "default".to_string(),
+        });
+    };
+
+    let normalized = raw_backend.trim().to_lowercase();
+    match normalized.as_str() {
+        "" => Ok(RustCanaryBackend {
+            backend: "cli".to_string(),
+            source: "default".to_string(),
+        }),
+        "cli" | "winsmux" => Ok(RustCanaryBackend {
+            backend: "cli".to_string(),
+            source: "WINSMUX_BACKEND".to_string(),
+        }),
+        "tauri" | "desktop" => Ok(RustCanaryBackend {
+            backend: "tauri".to_string(),
+            source: "WINSMUX_BACKEND".to_string(),
+        }),
+        _ => Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("WINSMUX_BACKEND must be cli or tauri, got '{raw_backend}'"),
+        )),
+    }
 }
 
 fn parse_machine_contract_options(args: &[&String]) -> io::Result<bool> {
@@ -3041,6 +3134,7 @@ fn usage_for(command: &str) -> &'static str {
             "usage: winsmux provider-capabilities [provider] [--json] [--project-dir <path>]"
         }
         "machine-contract" => "usage: winsmux machine-contract --json",
+        "rust-canary" => "usage: winsmux rust-canary [--json] [--project-dir <path>]",
         "provider-switch" => {
             "usage: winsmux provider-switch <slot> [--agent <name>] [--model <name>] [--prompt-transport <argv|file|stdin>] [--auth-mode <mode>] [--reason <text>] [--restart] [--clear] [--json] [--project-dir <path>]"
         }

--- a/core/tests-rs/operator_cli.rs
+++ b/core/tests-rs/operator_cli.rs
@@ -599,6 +599,63 @@ fn operator_cli_machine_contract_rejects_project_dir() {
 }
 
 #[test]
+fn operator_cli_rust_canary_json_reports_default_cli_gate() {
+    let project_dir = make_temp_project_dir("rust-canary-default");
+
+    let json = run_json(&project_dir, &["rust-canary", "--json"]);
+
+    assert_eq!(json["contract_version"], 1);
+    assert_eq!(json["task_id"], "TASK-283");
+    assert_eq!(json["target_version"], "v0.24.5");
+    assert_eq!(json["phase"], "default-on-canary");
+    assert_eq!(json["runtime"]["rust_cli_available"], true);
+    assert_eq!(json["runtime"]["backend"], "cli");
+    assert_eq!(json["runtime"]["backend_source"], "default");
+    assert_eq!(json["runtime"]["tauri_backend_candidate"], false);
+    assert_eq!(json["required_gates"][2], "shadow_cutover_gate");
+    assert_eq!(json["blocking_conditions"][0], "invalid_WINSMUX_BACKEND");
+}
+
+#[test]
+fn operator_cli_rust_canary_json_reports_tauri_candidate() {
+    let project_dir = make_temp_project_dir("rust-canary-tauri");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .args(["rust-canary", "--json"])
+        .env("WINSMUX_BACKEND", "desktop")
+        .current_dir(&project_dir)
+        .output()
+        .expect("winsmux command should run");
+
+    assert!(
+        output.status.success(),
+        "winsmux command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("stdout should be JSON");
+    assert_eq!(json["runtime"]["backend"], "tauri");
+    assert_eq!(json["runtime"]["backend_source"], "WINSMUX_BACKEND");
+    assert_eq!(json["runtime"]["tauri_backend_candidate"], true);
+}
+
+#[test]
+fn operator_cli_rust_canary_rejects_invalid_backend() {
+    let project_dir = make_temp_project_dir("rust-canary-invalid");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .args(["rust-canary", "--json"])
+        .env("WINSMUX_BACKEND", "remote")
+        .current_dir(&project_dir)
+        .output()
+        .expect("winsmux command should run");
+
+    assert!(!output.status.success(), "rust-canary should fail");
+    assert!(String::from_utf8_lossy(&output.stderr)
+        .contains("WINSMUX_BACKEND must be cli or tauri"));
+}
+
+#[test]
 fn operator_cli_provider_capabilities_json_reads_single_provider_case_insensitive() {
     let project_dir = make_temp_project_dir("provider-capabilities-single");
     let winsmux_dir = project_dir.join(".winsmux");

--- a/docs/project/powershell-adapter-inventory.md
+++ b/docs/project/powershell-adapter-inventory.md
@@ -143,6 +143,19 @@ Diff budget:
 It is the machine-readable gate for deciding whether a PowerShell script is still runtime-owned
 or has become bootstrap, setup, compatibility, security, release, or planning glue.
 
+## Inputs for `TASK-283`
+
+`TASK-283` should use `winsmux rust-canary --json` as the machine-readable release gate for
+the Rust default-on canary phase.
+
+Canary requirements:
+
+- `WINSMUX_BACKEND` unset must report `runtime.backend = cli`.
+- `WINSMUX_BACKEND=tauri` or `WINSMUX_BACKEND=desktop` must report `runtime.backend = tauri`.
+- Any other `WINSMUX_BACKEND` value must fail before release validation continues.
+- The payload must list the blocking conditions that prevent the default-on release gate.
+- The canary remains a gate and observation surface; it must not silently change runtime ownership without the shadow cutover gate.
+
 ## Inputs for `TASK-407`
 
 `TASK-407` should classify Pester files before deleting or rewriting them.

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -8375,6 +8375,29 @@ function Invoke-MachineContract {
     $output | Write-Output
 }
 
+function Invoke-RustCanary {
+    $tokens = @(@($Target) + @($Rest) | Where-Object { $_ })
+    $rustArgs = @('rust-canary')
+    foreach ($token in $tokens) {
+        switch ($token) {
+            '--json' {
+                $rustArgs += '--json'
+            }
+            default {
+                Stop-WithError "usage: winsmux rust-canary [--json]"
+            }
+        }
+    }
+
+    $output = Invoke-WinsmuxRaw -Arguments $rustArgs
+    $nativeExitCode = Get-SafeLastExitCode
+    if ($null -ne $nativeExitCode -and $nativeExitCode -ne 0) {
+        exit $nativeExitCode
+    }
+
+    $output | Write-Output
+}
+
 function Invoke-ProviderSwitch {
     $tokens = @(@($Target) + @($Rest) | Where-Object { $_ })
     if ($tokens.Count -lt 1) {
@@ -8572,6 +8595,7 @@ Commands:
   consult-error <mode> [--message <text>] [--target-slot <slot>]  Record a consultation error packet/event
   provider-capabilities [provider] [--json]  Inspect the provider capability registry contract
   machine-contract --json  Print the hook and agent machine contract JSON
+  rust-canary [--json]  Print the Rust default-on canary gate JSON
   provider-switch <slot> [--agent <name>] [--model <name>] [--prompt-transport <argv|file|stdin>] [--auth-mode <mode>] [--reason <text>] [--restart] [--clear] [--json]  Record or clear a runtime provider reassignment for a managed slot
   locks                     List active file locks
   verify <pr-number>        Run Pester in tests/ and merge PR only on PASS
@@ -9266,6 +9290,7 @@ switch ($Command) {
     'launcher'        { Invoke-Launcher }
     'provider-capabilities' { Invoke-ProviderCapabilities }
     'machine-contract' { Invoke-MachineContract }
+    'rust-canary' { Invoke-RustCanary }
     'provider-switch' { Invoke-ProviderSwitch }
     'rebind-worktree' { Invoke-RebindWorktree }
     ''                { Show-Usage }

--- a/tests/HarnessContract.Tests.ps1
+++ b/tests/HarnessContract.Tests.ps1
@@ -271,6 +271,13 @@ tasks:
         $bridge | Should -Match 'powershell-deescalation\.ps1'
     }
 
+    It 'documents and dispatches the Rust canary command' {
+        $bridge = Get-Content -LiteralPath $script:WinsmuxCorePath -Raw -Encoding UTF8
+        $bridge | Should -Match 'rust-canary \[--json\]'
+        $bridge | Should -Match "'rust-canary'\s+\{"
+        $bridge | Should -Match 'Invoke-WinsmuxRaw -Arguments \$rustArgs'
+    }
+
     BeforeEach {
         Remove-TestSettingsLocal
     }


### PR DESCRIPTION
## Summary
- Add winsmux rust-canary as a machine-readable v0.24.5 canary gate.
- Report WINSMUX_BACKEND default, tauri candidate state, required gates, and blocking conditions.
- Expose rust-canary through the PowerShell bridge and document it in the adapter inventory.

## Validation
- cargo test for operator_cli_rust_canary passed.
- cargo test for cli::tests passed.
- HarnessContract Pester test for rust-canary passed.
- CLI smoke for default, tauri, and invalid backend behavior passed.
- git diff check, git-guard, and public surface audit passed.