### PR TITLE
Add manual checklist release gate

### DIFF
--- a/core/src/cli.rs
+++ b/core/src/cli.rs
@@ -163,6 +163,7 @@ OPERATOR COMMANDS:
     provider-capabilities   Inspect the provider capability registry contract
     machine-contract        Print the hook and agent machine contract JSON
     rust-canary             Print the Rust default-on canary gate JSON
+    manual-checklist        Print the versioned manual validation checklist gate
     provider-switch         Record or clear a runtime provider reassignment
     signal <channel>        Send a file-backed orchestration signal
     wait <channel> [secs]   Wait for a file-backed orchestration signal
@@ -475,6 +476,7 @@ fn commands_text() -> &'static str {
   list-commands (lscm)      - List commands
   machine-contract          - Print the hook and agent machine contract JSON
   rust-canary               - Print the Rust default-on canary gate JSON
+  manual-checklist          - Print the versioned manual validation checklist gate
   list-keys (lsk)           - List key bindings
   list-panes (lsp)          - List panes in a window
   list-sessions (ls)        - List sessions
@@ -626,6 +628,7 @@ mod tests {
         assert!(text.contains("winsmux launches PowerShell 7 (pwsh) by default."));
         assert!(text.contains("machine-contract        Print the hook and agent machine contract JSON"));
         assert!(text.contains("rust-canary             Print the Rust default-on canary gate JSON"));
+        assert!(text.contains("manual-checklist        Print the versioned manual validation checklist gate"));
         assert!(text.contains("winsmux preserves compatibility aliases 'psmux', 'pmux', and 'tmux' where supported."));
         assert!(text.contains("v0.24.5 warning-only sunset mode"));
         assert!(text.contains("For more information: https://github.com/Sora-bluesky/winsmux"));
@@ -651,6 +654,7 @@ mod tests {
         assert!(text.contains("kill-server               - Kill the winsmux server"));
         assert!(text.contains("machine-contract          - Print the hook and agent machine contract JSON"));
         assert!(text.contains("rust-canary               - Print the Rust default-on canary gate JSON"));
+        assert!(text.contains("manual-checklist          - Print the versioned manual validation checklist gate"));
         assert!(!text.contains("Kill the psmux server"));
     }
 }

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -256,6 +256,7 @@ fn run_main() -> io::Result<()> {
         "provider-capabilities" => return operator_cli::run_provider_capabilities_command(&cmd_args[1..]),
         "machine-contract" => return operator_cli::run_machine_contract_command(&cmd_args[1..]),
         "rust-canary" => return operator_cli::run_rust_canary_command(&cmd_args[1..]),
+        "manual-checklist" => return operator_cli::run_manual_checklist_command(&cmd_args[1..]),
         "provider-switch" => return operator_cli::run_provider_switch_command(&cmd_args[1..]),
         "signal" => return operator_cli::run_signal_command(&cmd_args[1..]),
         "wait" if !matches!(

--- a/core/src/operator_cli.rs
+++ b/core/src/operator_cli.rs
@@ -272,6 +272,63 @@ pub fn run_rust_canary_command(args: &[&String]) -> io::Result<()> {
     Ok(())
 }
 
+pub fn run_manual_checklist_command(args: &[&String]) -> io::Result<()> {
+    if should_print_help(args) {
+        println!("{}", usage_for("manual-checklist"));
+        return Ok(());
+    }
+
+    let options = parse_options("manual-checklist", args, 0)?;
+    let payload = json!({
+        "contract_version": 1,
+        "task_id": "TASK-316",
+        "target_version": "v0.24.5",
+        "generated_at": generated_at(),
+        "project_dir": project_dir_string(&options.project_dir),
+        "product_version": VERSION,
+        "document": {
+            "path": "docs/internal/winsmux-manual-checklist-by-version.md",
+            "source": "winsmux-core/scripts/sync-internal-docs.ps1",
+            "tracked": false,
+        },
+        "required_result_values": ["未", "合格", "不合格", "保留"],
+        "release_gates": [
+            "version_by_version_results_recorded",
+            "no_critical_unchecked_items",
+            "pre_v1_fixups_taskified",
+            "reusable_screen_recording_candidates_recorded",
+            "task_220_can_reference_results"
+        ],
+        "v0_24_5_focus": [
+            "legacy_alias_sunset",
+            "rust_default_on_canary",
+            "windows_install_guidance",
+            "release_ci",
+            "public_surface_gate"
+        ],
+        "blocking_conditions": [
+            "missing_manual_checklist_document",
+            "unchecked_critical_item",
+            "failed_result_without_followup_task",
+            "blocked_result_without_owner",
+            "public_surface_drift"
+        ],
+        "next_action": "Record v0.24.5 manual validation results before the v0.24.5 release and feed any failed or blocked item back into backlog."
+    });
+
+    if options.json {
+        return write_json(&payload);
+    }
+
+    println!(
+        "Manual checklist: {} for {}",
+        payload["document"]["path"].as_str().unwrap_or("unknown"),
+        payload["target_version"].as_str().unwrap_or("unknown")
+    );
+    println!("{}", payload["next_action"].as_str().unwrap_or(""));
+    Ok(())
+}
+
 struct RustCanaryBackend {
     backend: String,
     source: String,
@@ -3135,6 +3192,9 @@ fn usage_for(command: &str) -> &'static str {
         }
         "machine-contract" => "usage: winsmux machine-contract --json",
         "rust-canary" => "usage: winsmux rust-canary [--json] [--project-dir <path>]",
+        "manual-checklist" => {
+            "usage: winsmux manual-checklist [--json] [--project-dir <path>]"
+        }
         "provider-switch" => {
             "usage: winsmux provider-switch <slot> [--agent <name>] [--model <name>] [--prompt-transport <argv|file|stdin>] [--auth-mode <mode>] [--reason <text>] [--restart] [--clear] [--json] [--project-dir <path>]"
         }

--- a/core/tests-rs/operator_cli.rs
+++ b/core/tests-rs/operator_cli.rs
@@ -656,6 +656,56 @@ fn operator_cli_rust_canary_rejects_invalid_backend() {
 }
 
 #[test]
+fn operator_cli_manual_checklist_json_reports_release_gate() {
+    let project_dir = make_temp_project_dir("manual-checklist");
+
+    let json = run_json(&project_dir, &["manual-checklist", "--json"]);
+
+    assert_eq!(json["contract_version"], 1);
+    assert_eq!(json["task_id"], "TASK-316");
+    assert_eq!(json["target_version"], "v0.24.5");
+    assert_eq!(
+        json["document"]["path"],
+        "docs/internal/winsmux-manual-checklist-by-version.md"
+    );
+    assert_eq!(json["document"]["tracked"], false);
+    assert_eq!(json["required_result_values"][0], "未");
+    assert_eq!(json["required_result_values"][1], "合格");
+    assert_eq!(json["required_result_values"][2], "不合格");
+    assert_eq!(json["required_result_values"][3], "保留");
+    assert_eq!(
+        json["release_gates"][0],
+        "version_by_version_results_recorded"
+    );
+    assert_eq!(json["v0_24_5_focus"][0], "legacy_alias_sunset");
+    assert_eq!(
+        json["blocking_conditions"][0],
+        "missing_manual_checklist_document"
+    );
+}
+
+#[test]
+fn operator_cli_manual_checklist_text_reports_next_action() {
+    let project_dir = make_temp_project_dir("manual-checklist-text");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .arg("manual-checklist")
+        .current_dir(&project_dir)
+        .output()
+        .expect("winsmux command should run");
+
+    assert!(
+        output.status.success(),
+        "winsmux command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Manual checklist: docs/internal/winsmux-manual-checklist-by-version.md"));
+    assert!(stdout.contains("Record v0.24.5 manual validation results"));
+    assert!(!stdout.trim_start().starts_with('{'));
+}
+
+#[test]
 fn operator_cli_provider_capabilities_json_reads_single_provider_case_insensitive() {
     let project_dir = make_temp_project_dir("provider-capabilities-single");
     let winsmux_dir = project_dir.join(".winsmux");

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -8398,6 +8398,29 @@ function Invoke-RustCanary {
     $output | Write-Output
 }
 
+function Invoke-ManualChecklist {
+    $tokens = @(@($Target) + @($Rest) | Where-Object { $_ })
+    $rustArgs = @('manual-checklist')
+    foreach ($token in $tokens) {
+        switch ($token) {
+            '--json' {
+                $rustArgs += '--json'
+            }
+            default {
+                Stop-WithError "usage: winsmux manual-checklist [--json]"
+            }
+        }
+    }
+
+    $output = Invoke-WinsmuxRaw -Arguments $rustArgs
+    $nativeExitCode = Get-SafeLastExitCode
+    if ($null -ne $nativeExitCode -and $nativeExitCode -ne 0) {
+        exit $nativeExitCode
+    }
+
+    $output | Write-Output
+}
+
 function Invoke-ProviderSwitch {
     $tokens = @(@($Target) + @($Rest) | Where-Object { $_ })
     if ($tokens.Count -lt 1) {
@@ -8596,6 +8619,7 @@ Commands:
   provider-capabilities [provider] [--json]  Inspect the provider capability registry contract
   machine-contract --json  Print the hook and agent machine contract JSON
   rust-canary [--json]  Print the Rust default-on canary gate JSON
+  manual-checklist [--json]  Print the versioned manual validation checklist gate
   provider-switch <slot> [--agent <name>] [--model <name>] [--prompt-transport <argv|file|stdin>] [--auth-mode <mode>] [--reason <text>] [--restart] [--clear] [--json]  Record or clear a runtime provider reassignment for a managed slot
   locks                     List active file locks
   verify <pr-number>        Run Pester in tests/ and merge PR only on PASS
@@ -9291,6 +9315,7 @@ switch ($Command) {
     'provider-capabilities' { Invoke-ProviderCapabilities }
     'machine-contract' { Invoke-MachineContract }
     'rust-canary' { Invoke-RustCanary }
+    'manual-checklist' { Invoke-ManualChecklist }
     'provider-switch' { Invoke-ProviderSwitch }
     'rebind-worktree' { Invoke-RebindWorktree }
     ''                { Show-Usage }

--- a/tests/HarnessContract.Tests.ps1
+++ b/tests/HarnessContract.Tests.ps1
@@ -278,6 +278,14 @@ tasks:
         $bridge | Should -Match 'Invoke-WinsmuxRaw -Arguments \$rustArgs'
     }
 
+    It 'documents and dispatches the manual checklist command' {
+        $bridge = Get-Content -LiteralPath $script:WinsmuxCorePath -Raw -Encoding UTF8
+        $bridge | Should -Match 'manual-checklist \[--json\]'
+        $bridge | Should -Match "'manual-checklist'\s+\{"
+        $bridge | Should -Match 'manual-checklist'
+        $bridge | Should -Match 'Invoke-WinsmuxRaw -Arguments \$rustArgs'
+    }
+
     BeforeEach {
         Remove-TestSettingsLocal
     }


### PR DESCRIPTION
## Summary
- add winsmux manual-checklist as the TASK-316 release gate contract
- expose the command through the PowerShell bridge and CLI help
- add Rust and Pester coverage for the new command

## Validation
- cargo test --manifest-path core/Cargo.toml operator_cli_manual_checklist -- --nocapture
- cargo test --manifest-path core/Cargo.toml cli::tests -- --nocapture
- Invoke-Pester -Path tests/HarnessContract.Tests.ps1 -Output Detailed
- target/debug/winsmux.exe manual-checklist --json
- git diff --check
- pwsh -NoProfile -File scripts/audit-public-surface.ps1
- pwsh -NoProfile -File scripts/git-guard.ps1

Note: cargo fmt --manifest-path core/Cargo.toml -- --check still reports pre-existing formatting drift outside this change, so this PR keeps formatting scoped to the touched behavior.