### PR TITLE
fix: keep worker isolation in blocked smoke state

### DIFF
--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -11038,7 +11038,7 @@ Describe 'winsmux orchestra-smoke command' {
         $attachFailed.next_action | Should -Match 'attached-client confirmation'
     }
 
-    It 'classifies worker isolation drift without requiring startup rerun' {
+    It 'keeps worker isolation drift inside the blocked operator_state contract' {
         $workerDrift = Invoke-TestOrchestraOperatorContract `
             -SmokeOk $false `
             -SessionReady $true `
@@ -11050,9 +11050,10 @@ Describe 'winsmux orchestra-smoke command' {
             -ExpectedPaneCount 6 `
             -SmokeErrors @('worker isolation drift: worker-1: branch is main; expected worktree-worker-1')
 
-        $workerDrift.operator_state | Should -Be 'blocked-worker-isolation'
+        $workerDrift.operator_state | Should -Be 'blocked'
         $workerDrift.can_dispatch | Should -Be $false
         $workerDrift.requires_startup | Should -Be $false
+        $workerDrift.smoke_errors[0] | Should -Match 'worker isolation drift'
         $workerDrift.operator_message | Should -Match 'startup is already session-ready'
         $workerDrift.next_action | Should -Match 'Operator shell'
     }

--- a/winsmux-core/scripts/orchestra-smoke.ps1
+++ b/winsmux-core/scripts/orchestra-smoke.ps1
@@ -175,7 +175,7 @@ function Get-OrchestraOperatorContract {
             $uiWarning = $true
         }
     } elseif ($workerIsolationOnly -and $SessionReady -and $PaneCount -ge $ExpectedPaneCount) {
-        $state = 'blocked-worker-isolation'
+        $state = 'blocked'
         $message = 'Worker isolation drift blocks dispatch, but orchestra startup is already session-ready.'
         $canDispatch = $false
         $requiresStartup = $false


### PR DESCRIPTION
## Summary

- Collapse worker-isolation drift back into `operator_state = blocked`.
- Preserve the worker-isolation cause in `smoke_errors` and keep the repair instruction in `next_action`.
- Update focused `winsmux-bridge` coverage for the strict operator-state contract.

Closes #591.

## Validation

- `Invoke-Pester -Path tests\winsmux-bridge.Tests.ps1 -FullName '*keeps worker isolation drift inside the blocked operator_state contract*' -Output Detailed`
- `Invoke-Pester -Path tests\winsmux-bridge.Tests.ps1 -FullName '*winsmux orchestra-smoke command*' -Output Detailed`
- `Invoke-Pester -Path tests\HarnessContract.Tests.ps1 -Output Detailed`
- `git diff --check`
- `pwsh -NoProfile -File scripts\audit-public-surface.ps1`
- `pwsh -NoProfile -File scripts\git-guard.ps1`