### PR TITLE
fix: handle Tauri PTY output event payloads

### DIFF
--- a/tests/HarnessContract.Tests.ps1
+++ b/tests/HarnessContract.Tests.ps1
@@ -706,3 +706,21 @@ exit /b 0
         $json.passed | Should -Be $true
     }
 }
+
+Describe 'desktop PTY event payload contract' {
+    BeforeAll {
+        $script:RepoRoot = Split-Path -Parent $PSScriptRoot
+        $script:PtyClientPath = Join-Path $script:RepoRoot 'winsmux-app\src\ptyClient.ts'
+    }
+
+    It 'accepts object and string pty-output event payloads' {
+        $client = Get-Content -LiteralPath $script:PtyClientPath -Raw -Encoding UTF8
+
+        $client | Should -Match 'function normalizePtyOutputEventPayload'
+        $client | Should -Match 'listen<PtyOutputEvent \| string>\("pty-output"'
+        $client | Should -Not -Match 'listen<string>\("pty-output"'
+        $client | Should -Match 'normalizePtyOutputEventPayload\(event\.payload\)'
+        $client | Should -Match 'typeof payload === "string"'
+        $client | Should -Match 'typeof payload\?\.data === "string"'
+    }
+}

--- a/winsmux-app/src/ptyClient.ts
+++ b/winsmux-app/src/ptyClient.ts
@@ -61,6 +61,24 @@ function normalizePtyError(action: string, error: unknown) {
   return new Error(`${action} failed: ${String(error)}`);
 }
 
+export function normalizePtyOutputEventPayload(payload: PtyOutputEvent | string): PtyOutputEvent {
+  if (typeof payload === "string") {
+    try {
+      return normalizePtyOutputEventPayload(JSON.parse(payload) as PtyOutputEvent);
+    } catch {
+      return {
+        pane_id: "",
+        data: payload,
+      };
+    }
+  }
+
+  return {
+    pane_id: typeof payload?.pane_id === "string" ? payload.pane_id : "",
+    data: typeof payload?.data === "string" ? payload.data : "",
+  };
+}
+
 export function createTauriPtyCommandTransport(
   invokeCommand: typeof invoke = invoke,
 ): PtyCommandTransport {
@@ -172,14 +190,7 @@ export async function subscribeToPtyOutput(
     return async () => {};
   }
 
-  return listen<string>("pty-output", (event) => {
-    try {
-      onOutput(JSON.parse(event.payload) as PtyOutputEvent);
-    } catch {
-      onOutput({
-        pane_id: "",
-        data: event.payload,
-      });
-    }
+  return listen<PtyOutputEvent | string>("pty-output", (event) => {
+    onOutput(normalizePtyOutputEventPayload(event.payload));
   });
 }


### PR DESCRIPTION
## Summary
- fix TASK-409 / #694 by accepting both object and string payloads for the Tauri pty-output event
- add focused Pester coverage so the listener stays typed as object-or-string instead of string-only

## Validation
- cmd /c npm run build
- Invoke-Pester -Path tests\\HarnessContract.Tests.ps1 -FullName '*accepts object and string pty-output event payloads*' -Output Detailed
- git diff --check
- pwsh -NoProfile -File scripts\\audit-public-surface.ps1
- pwsh -NoProfile -File scripts\\git-guard.ps1

Closes #694