### PR TITLE
fix: reap legacy commander poll process

### DIFF
--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -5375,6 +5375,34 @@ Describe 'orchestra-start server bootstrap' {
         $script:stoppedProcessIds | Should -Be @(101, 202, 303)
     }
 
+    It 'treats legacy commander_poll_pid as the operator poll process during manifest cleanup' {
+        Mock Get-WinsmuxManifest {
+            [PSCustomObject]@{
+                session = [PSCustomObject]@{
+                    startup_token      = 'token-123'
+                    commander_poll_pid = '101'
+                }
+            }
+        }
+
+        $script:stoppedProcessIds = @()
+        Mock Get-ProcessSnapshot {
+            [PSCustomObject]@{
+                ById = @{
+                    101 = [PSCustomObject]@{ ProcessId = 101; ParentProcessId = 1; CommandLine = 'pwsh operator-poll.ps1 C:\repo\.winsmux\manifest.yaml -StartupToken token-123 winsmux-orchestra C:\repo\scripts\winsmux-core.ps1'; Name = 'pwsh.exe' }
+                }
+            }
+        }
+        Mock Stop-Process { $script:stoppedProcessIds += $Id }
+
+        $result = Stop-OrchestraBackgroundProcessesFromManifest -ProjectDir 'C:\repo' -GitWorktreeDir 'C:\repo\.git' -BridgeScript 'C:\repo\scripts\winsmux-core.ps1' -SessionName 'winsmux-orchestra'
+
+        @($result.Stopped).Count | Should -Be 1
+        $result.Stopped[0].label | Should -Be 'operator_poll_pid'
+        @($result.Errors).Count | Should -Be 0
+        $script:stoppedProcessIds | Should -Be @(101)
+    }
+
     It 'skips targeted background cleanup when the manifest has no startup token' {
         Mock Get-WinsmuxManifest {
             [PSCustomObject]@{

--- a/winsmux-core/scripts/orchestra-start.ps1
+++ b/winsmux-core/scripts/orchestra-start.ps1
@@ -1194,7 +1194,7 @@ function Stop-OrchestraBackgroundProcessesFromManifest {
     }
 
     $pidMap = [ordered]@{}
-    foreach ($propertyName in @('operator_poll_pid', 'watchdog_pid', 'server_watchdog_pid')) {
+    foreach ($propertyName in @('operator_poll_pid', 'commander_poll_pid', 'watchdog_pid', 'server_watchdog_pid')) {
         $rawPid = $null
         if ($manifest.session -is [System.Collections.IDictionary]) {
             if ($manifest.session.Contains($propertyName)) {
@@ -1211,7 +1211,7 @@ function Stop-OrchestraBackgroundProcessesFromManifest {
 
         $resolvedPidKey = [string]$resolvedPid
         if (-not $pidMap.Contains($resolvedPidKey)) {
-            $pidMap[$resolvedPidKey] = $propertyName
+            $pidMap[$resolvedPidKey] = if ($propertyName -eq 'commander_poll_pid') { 'operator_poll_pid' } else { $propertyName }
         }
     }
 


### PR DESCRIPTION
## Summary
- fix TASK-394 / #592 by treating legacy commander_poll_pid as operator_poll_pid during manifest background cleanup
- add focused Pester coverage for v0.22.2-style manifest cleanup

## Validation
- Invoke-Pester -Path tests\\winsmux-bridge.Tests.ps1 -FullName '*legacy commander_poll_pid*' -Output Detailed
- Invoke-Pester -Path tests\\winsmux-bridge.Tests.ps1 -FullName '*background processes recorded in the manifest*' -Output Detailed
- git diff --check -- winsmux-core/scripts/orchestra-start.ps1 tests/winsmux-bridge.Tests.ps1
- pwsh -NoProfile -File scripts\\audit-public-surface.ps1
- pwsh -NoProfile -File scripts\\git-guard.ps1

Closes #592