### PR TITLE
feat: warn on excessive PowerShell process pressure

### DIFF
--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -6023,6 +6023,60 @@ Describe 'doctor bridge config metadata check' {
         $result.Detail | Should -Match 'branch is main'
         $result.Detail | Should -Match 'Operator shell'
     }
+
+    It 'warns when too many background PowerShell processes remain' {
+        $protectedIds = [System.Collections.Generic.HashSet[int]]::new()
+        $protectedIds.Add(1001) | Out-Null
+        $snapshot = [pscustomobject]@{
+            Processes = @(
+                [pscustomobject]@{ ProcessId = 1001; ParentProcessId = 0; Name = 'pwsh.exe'; CommandLine = 'pwsh -NoProfile' }
+                [pscustomobject]@{ ProcessId = 1002; ParentProcessId = 0; Name = 'pwsh.exe'; CommandLine = 'pwsh -NoProfile -Command secret-value' }
+                [pscustomobject]@{ ProcessId = 1003; ParentProcessId = 0; Name = 'powershell.exe'; CommandLine = 'powershell -NoProfile' }
+                [pscustomobject]@{ ProcessId = 1004; ParentProcessId = 0; Name = 'cmd.exe'; CommandLine = 'cmd /c echo ignored' }
+            )
+            ById = @{}
+            SupportsCommandLine = $true
+        }
+
+        $result = New-PowerShellProcessPressureResult -Snapshot $snapshot -ProtectedIds $protectedIds -WarnThreshold 2
+
+        $result.Status | Should -Be 'warn'
+        $result.Label | Should -Be 'PowerShell process pressure'
+        $result.Detail | Should -Be '2 found; close unneeded pwsh.exe or powershell.exe sessions before starting more winsmux panes'
+        $result.Detail | Should -Not -Match 'secret-value'
+        $result.Detail | Should -Not -Match '1002'
+    }
+
+    It 'passes when background PowerShell process count stays below the warning threshold' {
+        $protectedIds = [System.Collections.Generic.HashSet[int]]::new()
+        $snapshot = [pscustomobject]@{
+            Processes = @(
+                [pscustomobject]@{ ProcessId = 1101; ParentProcessId = 0; Name = 'pwsh'; CommandLine = '' }
+                [pscustomobject]@{ ProcessId = 1102; ParentProcessId = 0; Name = 'codex.exe'; CommandLine = '' }
+            )
+            ById = @{}
+            SupportsCommandLine = $true
+        }
+
+        $result = New-PowerShellProcessPressureResult -Snapshot $snapshot -ProtectedIds $protectedIds -WarnThreshold 2
+
+        $result.Status | Should -Be 'pass'
+        $result.Label | Should -Be 'PowerShell process pressure'
+        $result.Detail | Should -Be '1 found'
+    }
+
+    It 'uses the environment override for the PowerShell process warning threshold' {
+        $originalValue = $env:WINSMUX_DOCTOR_POWERSHELL_PROCESS_WARN_THRESHOLD
+        try {
+            $env:WINSMUX_DOCTOR_POWERSHELL_PROCESS_WARN_THRESHOLD = '7'
+            Get-DoctorPowerShellProcessWarnThreshold | Should -Be 7
+
+            $env:WINSMUX_DOCTOR_POWERSHELL_PROCESS_WARN_THRESHOLD = 'invalid'
+            Get-DoctorPowerShellProcessWarnThreshold | Should -Be 100
+        } finally {
+            $env:WINSMUX_DOCTOR_POWERSHELL_PROCESS_WARN_THRESHOLD = $originalValue
+        }
+    }
 }
 
 Describe 'worker isolation diagnostics' {

--- a/winsmux-core/scripts/doctor.ps1
+++ b/winsmux-core/scripts/doctor.ps1
@@ -94,6 +94,17 @@ function Get-DoctorGitCommandPath {
     return $command.Source
 }
 
+function Get-DoctorNormalizedProcessName {
+    param([AllowNull()][string]$Name)
+
+    $normalized = ([string]$Name).Trim().ToLowerInvariant()
+    if ($normalized.EndsWith('.exe')) {
+        $normalized = $normalized.Substring(0, $normalized.Length - 4)
+    }
+
+    return $normalized
+}
+
 function Test-BasicYamlContent {
     param([Parameter(Mandatory = $true)][string]$Content)
 
@@ -384,11 +395,7 @@ function Test-ZombieProcessesCheck {
             continue
         }
 
-        $name = ([string]$process.Name).Trim().ToLowerInvariant()
-        if ($name.EndsWith('.exe')) {
-            $name = $name.Substring(0, $name.Length - 4)
-        }
-
+        $name = Get-DoctorNormalizedProcessName -Name $process.Name
         if ($name -notin @('codex', 'pwsh', 'powershell')) {
             continue
         }
@@ -422,6 +429,60 @@ function Test-ZombieProcessesCheck {
     }
 
     return New-DoctorResult -Status pass -Label 'Zombie processes' -Detail '0 found'
+}
+
+function Get-DoctorPowerShellProcessWarnThreshold {
+    $threshold = 100
+    $rawValue = [string]$env:WINSMUX_DOCTOR_POWERSHELL_PROCESS_WARN_THRESHOLD
+    if ([string]::IsNullOrWhiteSpace($rawValue)) {
+        return $threshold
+    }
+
+    try {
+        $parsed = [int]$rawValue
+        if ($parsed -gt 0) {
+            return $parsed
+        }
+    } catch {
+        return $threshold
+    }
+
+    return $threshold
+}
+
+function New-PowerShellProcessPressureResult {
+    param(
+        [Parameter(Mandatory = $true)]$Snapshot,
+        [Parameter(Mandatory = $true)]$ProtectedIds,
+        [Parameter(Mandatory = $true)][int]$WarnThreshold
+    )
+
+    $count = 0
+    foreach ($process in $Snapshot.Processes) {
+        $processId = [int]$process.ProcessId
+        if ($ProtectedIds.Contains($processId)) {
+            continue
+        }
+
+        $name = Get-DoctorNormalizedProcessName -Name $process.Name
+        if ($name -in @('pwsh', 'powershell')) {
+            $count++
+        }
+    }
+
+    if ($count -ge $WarnThreshold) {
+        return New-DoctorResult -Status warn -Label 'PowerShell process pressure' -Detail "$count found; close unneeded pwsh.exe or powershell.exe sessions before starting more winsmux panes"
+    }
+
+    return New-DoctorResult -Status pass -Label 'PowerShell process pressure' -Detail "$count found"
+}
+
+function Test-PowerShellProcessPressureCheck {
+    $snapshot = Get-DoctorProcessSnapshot
+    $protectedIds = Get-DoctorAncestorProcessIds -Snapshot $snapshot -ProcessId $PID
+    $warnThreshold = Get-DoctorPowerShellProcessWarnThreshold
+
+    return New-PowerShellProcessPressureResult -Snapshot $snapshot -ProtectedIds $protectedIds -WarnThreshold $warnThreshold
 }
 
 function Test-BridgeConfigCheck {
@@ -497,7 +558,13 @@ function Write-DoctorResult {
     Write-Output ("[{0}] {1}: {2}" -f $status, $Result.Label, $Result.Detail)
 }
 
-if (-not $script:__winsmux_doctor_functions_only) {
+$functionsOnlyVariable = Get-Variable -Name __winsmux_doctor_functions_only -Scope Script -ErrorAction SilentlyContinue
+$functionsOnly = $false
+if ($null -ne $functionsOnlyVariable) {
+    $functionsOnly = [bool]$functionsOnlyVariable.Value
+}
+
+if (-not $functionsOnly) {
     $results = @(
         Test-VersionFileCheck
         Test-HookFilesCheck
@@ -507,6 +574,7 @@ if (-not $script:__winsmux_doctor_functions_only) {
         Test-StaleWorktreesCheck
         Test-WorkerGitDriftCheck
         Test-ZombieProcessesCheck
+        Test-PowerShellProcessPressureCheck
         Test-BridgeConfigCheck
         Test-BridgeConfigMetadataCheck
         Test-HookProfileCheck


### PR DESCRIPTION
Closes #644.

## Summary
- add a doctor warning when too many pwsh.exe or powershell.exe processes remain
- keep the output privacy-preserving by reporting only process counts and cleanup guidance
- allow WINSMUX_DOCTOR_POWERSHELL_PROCESS_WARN_THRESHOLD for controlled validation

## Validation
- Invoke-Pester -Path tests\winsmux-bridge.Tests.ps1 -FullName '*doctor bridge config metadata check*' -Output Detailed
- pwsh -NoProfile -File winsmux-core\scripts\doctor.ps1
- git diff --check
- pwsh -NoProfile -File scripts\audit-public-surface.ps1
- pwsh -NoProfile -File scripts\git-guard.ps1