### PR TITLE
fix: add GitHub write preflight

### DIFF
--- a/.githooks/pre-commit-whitelist.ps1
+++ b/.githooks/pre-commit-whitelist.ps1
@@ -46,6 +46,7 @@ $whitelistPatterns = @(
     '.githooks/**',
     '.gitattributes',
     'tests/PublicSurfacePolicy.Tests.ps1',
+    'tests/GitHubWritePreflight.Tests.ps1',
     'tests/codex-subagent-worktree-guard.Tests.ps1',
     'tests/HarnessContract.Tests.ps1',
     'tests/NpmReleasePackage.Tests.ps1',

--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ tests/*
 !tests/BuilderWorktree.Tests.ps1
 !tests/codex-subagent-worktree-guard.Tests.ps1
 !tests/PublicSurfacePolicy.Tests.ps1
+!tests/GitHubWritePreflight.Tests.ps1
 !tests/HarnessContract.Tests.ps1
 !tests/NpmReleasePackage.Tests.ps1
 !tests/VersionSurface.Tests.ps1

--- a/scripts/bump-version.ps1
+++ b/scripts/bump-version.ps1
@@ -128,6 +128,14 @@ if ($DoRelease) {
         Write-Error "GitHub CLI (gh) is required for release. Install: winget install GitHub.cli"
         exit 1
     }
+
+    $githubPreflightScript = Join-Path $Root 'winsmux-core\scripts\github-write-preflight.ps1'
+    if (Test-Path -LiteralPath $githubPreflightScript -PathType Leaf) {
+        & pwsh -NoProfile -File $githubPreflightScript -Repository 'Sora-bluesky/winsmux' -RequireGh
+        if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+        }
+    }
 }
 
 # --- Release requires clean working tree ---

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -3486,6 +3486,15 @@ function Invoke-Verify {
         Stop-WithError "gh CLI not found. Install GitHub CLI before running verify."
     }
 
+    $githubPreflightScript = Join-Path $repoRoot 'winsmux-core\scripts\github-write-preflight.ps1'
+    if (Test-Path -LiteralPath $githubPreflightScript -PathType Leaf) {
+        & pwsh -NoProfile -File $githubPreflightScript -Repository 'Sora-bluesky/winsmux' -RequireGh
+        $preflightExitCode = Get-SafeLastExitCode
+        if ($null -ne $preflightExitCode -and $preflightExitCode -ne 0) {
+            exit $preflightExitCode
+        }
+    }
+
     if (-not (Test-Path -LiteralPath $testsDir -PathType Container)) {
         Stop-WithError "tests directory not found: $testsDir"
     }
@@ -8629,6 +8638,7 @@ Commands:
   rust-canary [--json]  Print the Rust default-on canary gate JSON
   manual-checklist [--json]  Print the versioned manual validation checklist gate
   provider-switch <slot> [--agent <name>] [--model <name>] [--prompt-transport <argv|file|stdin>] [--auth-mode <mode>] [--reason <text>] [--restart] [--clear] [--json]  Record or clear a runtime provider reassignment for a managed slot
+  github-preflight [--repo <owner/name>] [--json] [--connector-available] [--require-gh]  Select the GitHub write path before merge/release automation
   locks                     List active file locks
   verify <pr-number>        Run Pester in tests/ and merge PR only on PASS
   wait <channel> [timeout]  Block until signal received (replaces polling)
@@ -9055,6 +9065,33 @@ switch ($Command) {
     'lock'            { Invoke-Lock }
     'unlock'          { Invoke-Unlock }
     'locks'           { Invoke-Locks }
+    'github-preflight' {
+        $preflightScript = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\winsmux-core\scripts\github-write-preflight.ps1'))
+        $preflightArgs = @()
+        $remaining = @(@($Target) + @($Rest) | Where-Object { $_ })
+        for ($index = 0; $index -lt $remaining.Count; $index++) {
+            switch ($remaining[$index]) {
+                '--repo' {
+                    if ($index + 1 -ge $remaining.Count) {
+                        Stop-WithError "usage: winsmux github-preflight [--repo <owner/name>] [--json] [--connector-available] [--require-gh]"
+                    }
+                    $preflightArgs += @('-Repository', $remaining[$index + 1])
+                    $index++
+                }
+                '--json' { $preflightArgs += '-Json' }
+                '--connector-available' { $preflightArgs += '-ConnectorAvailable' }
+                '--require-gh' { $preflightArgs += '-RequireGh' }
+                default {
+                    Stop-WithError "usage: winsmux github-preflight [--repo <owner/name>] [--json] [--connector-available] [--require-gh]"
+                }
+            }
+        }
+        & pwsh -NoProfile -File $preflightScript @preflightArgs
+        $preflightExitCode = Get-SafeLastExitCode
+        if ($null -ne $preflightExitCode -and $preflightExitCode -ne 0) {
+            exit $preflightExitCode
+        }
+    }
     'verify'          { Invoke-Verify }
     'dispatch-task'   { Invoke-DispatchTask }
     'dispatch-route'  {

--- a/tests/GitHubWritePreflight.Tests.ps1
+++ b/tests/GitHubWritePreflight.Tests.ps1
@@ -1,0 +1,129 @@
+BeforeAll {
+    $script:RepoRoot = Split-Path -Parent $PSScriptRoot
+    $script:PreflightScript = Join-Path $script:RepoRoot 'winsmux-core\scripts\github-write-preflight.ps1'
+}
+
+Describe 'GitHub write preflight' {
+    It 'selects gh only after api user, permission, and git probes pass' {
+        $fixture = Join-Path ([System.IO.Path]::GetTempPath()) ("winsmux-gh-preflight-" + [guid]::NewGuid().ToString('N'))
+        try {
+            New-Item -ItemType Directory -Path $fixture -Force | Out-Null
+            $log = Join-Path $fixture 'calls.log'
+            $gh = Join-Path $fixture 'gh.cmd'
+            $git = Join-Path $fixture 'git.cmd'
+
+            Set-Content -LiteralPath $gh -Encoding ASCII -Value @"
+@echo off
+echo %*>>"$log"
+if "%1 %2"=="api user" (
+  echo test-user
+  exit /b 0
+)
+if "%1 %2"=="api repos/Sora-bluesky/winsmux" (
+  echo {"admin":false,"maintain":false,"push":true}
+  exit /b 0
+)
+if "%1 %2"=="auth status" (
+  exit /b 99
+)
+exit /b 2
+"@
+            Set-Content -LiteralPath $git -Encoding ASCII -Value @"
+@echo off
+echo git %*>>"$log"
+if "%1 %2"=="ls-remote --exit-code" (
+  echo abc HEAD
+  exit /b 0
+)
+exit /b 2
+"@
+
+            $oldPath = $env:PATH
+            $env:PATH = "$fixture;$oldPath"
+            $json = & pwsh -NoProfile -File $script:PreflightScript -Repository 'Sora-bluesky/winsmux' -Json
+            $exitCode = $LASTEXITCODE
+            $result = $json | ConvertFrom-Json
+            $calls = Get-Content -LiteralPath $log -Raw
+
+            $exitCode | Should -Be 0
+            $result.status | Should -Be 'ok'
+            $result.selected_path | Should -Be 'gh'
+            $result.gh_user | Should -Be 'test-user'
+            $result.git_remote_probe | Should -Be 'ok'
+            $calls | Should -Match 'api user'
+            $calls | Should -Match 'api repos/Sora-bluesky/winsmux'
+            $calls | Should -Not -Match 'auth status'
+        } finally {
+            $env:PATH = $oldPath
+            if (Test-Path -LiteralPath $fixture) {
+                Remove-Item -LiteralPath $fixture -Recurse -Force
+            }
+        }
+    }
+
+    It 'fails closed when gh api user fails even if auth status would pass' {
+        $fixture = Join-Path ([System.IO.Path]::GetTempPath()) ("winsmux-gh-preflight-" + [guid]::NewGuid().ToString('N'))
+        try {
+            New-Item -ItemType Directory -Path $fixture -Force | Out-Null
+            $gh = Join-Path $fixture 'gh.cmd'
+            Set-Content -LiteralPath $gh -Encoding ASCII -Value @"
+@echo off
+if "%1 %2"=="api user" (
+  echo HTTP 401: Requires authentication
+  exit /b 1
+)
+if "%1 %2"=="auth status" (
+  exit /b 0
+)
+exit /b 2
+"@
+
+            $oldPath = $env:PATH
+            $env:PATH = "$fixture;$oldPath"
+            $json = & pwsh -NoProfile -File $script:PreflightScript -Repository 'Sora-bluesky/winsmux' -Json 2>&1
+            $exitCode = $LASTEXITCODE
+            $result = ($json | Out-String) | ConvertFrom-Json
+
+            $exitCode | Should -Be 1
+            $result.status | Should -Be 'failed'
+            $result.selected_path | Should -Be 'stop'
+            $result.reason | Should -Match 'gh api user failed'
+        } finally {
+            $env:PATH = $oldPath
+            if (Test-Path -LiteralPath $fixture) {
+                Remove-Item -LiteralPath $fixture -Recurse -Force
+            }
+        }
+    }
+
+    It 'selects connector fallback only when gh is unhealthy and connector fallback is allowed' {
+        $fixture = Join-Path ([System.IO.Path]::GetTempPath()) ("winsmux-gh-preflight-" + [guid]::NewGuid().ToString('N'))
+        try {
+            New-Item -ItemType Directory -Path $fixture -Force | Out-Null
+            $gh = Join-Path $fixture 'gh.cmd'
+            Set-Content -LiteralPath $gh -Encoding ASCII -Value @"
+@echo off
+if "%1 %2"=="api user" (
+  echo HTTP 401: Requires authentication
+  exit /b 1
+)
+exit /b 2
+"@
+
+            $oldPath = $env:PATH
+            $env:PATH = "$fixture;$oldPath"
+            $json = & pwsh -NoProfile -File $script:PreflightScript -Repository 'Sora-bluesky/winsmux' -ConnectorAvailable -Json
+            $exitCode = $LASTEXITCODE
+            $result = $json | ConvertFrom-Json
+
+            $exitCode | Should -Be 0
+            $result.status | Should -Be 'fallback'
+            $result.selected_path | Should -Be 'github_connector'
+        } finally {
+            $env:PATH = $oldPath
+            if (Test-Path -LiteralPath $fixture) {
+                Remove-Item -LiteralPath $fixture -Recurse -Force
+            }
+        }
+    }
+}

--- a/winsmux-core/scripts/github-write-preflight.ps1
+++ b/winsmux-core/scripts/github-write-preflight.ps1
@@ -1,0 +1,145 @@
+param(
+    [string]$Repository = 'Sora-bluesky/winsmux',
+    [switch]$Json,
+    [switch]$ConnectorAvailable,
+    [switch]$RequireGh,
+    [switch]$SkipGitProbe
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function New-GitHubWritePreflightResult {
+    param(
+        [Parameter(Mandatory = $true)][string]$Status,
+        [Parameter(Mandatory = $true)][string]$SelectedPath,
+        [string]$GhUser = '',
+        [string]$RepoPermission = 'unknown',
+        [string]$GitRemoteProbe = 'skipped',
+        [string]$Reason = '',
+        [string]$NextAction = ''
+    )
+
+    [pscustomobject][ordered]@{
+        status           = $Status
+        selected_path    = $SelectedPath
+        repository       = $Repository
+        gh_user          = $GhUser
+        repo_permission  = $RepoPermission
+        git_remote_probe = $GitRemoteProbe
+        reason           = $Reason
+        next_action      = $NextAction
+    }
+}
+
+function Invoke-NativeCommand {
+    param(
+        [Parameter(Mandatory = $true)][string]$Command,
+        [Parameter(Mandatory = $true)][string[]]$Arguments
+    )
+
+    $output = & $Command @Arguments 2>&1
+    $exitCode = $LASTEXITCODE
+    [pscustomobject]@{
+        ExitCode = $exitCode
+        Output   = @($output)
+        Text     = (@($output) -join "`n").Trim()
+    }
+}
+
+function Resolve-GitHubWriteFallback {
+    param([Parameter(Mandatory = $true)][string]$Reason)
+
+    if ($ConnectorAvailable -and -not $RequireGh) {
+        return New-GitHubWritePreflightResult `
+            -Status 'fallback' `
+            -SelectedPath 'github_connector' `
+            -Reason $Reason `
+            -NextAction 'Use the GitHub connector write path for merge or release operations. Do not retry gh auth refresh repeatedly.'
+    }
+
+    return New-GitHubWritePreflightResult `
+        -Status 'failed' `
+        -SelectedPath 'stop' `
+        -Reason $Reason `
+        -NextAction 'Re-authenticate GitHub CLI in the browser, or switch to an explicit GitHub connector write path before merge or release automation.'
+}
+
+function Test-GitHubWritePreflight {
+    $ghCommand = Get-Command gh -ErrorAction SilentlyContinue
+    if (-not $ghCommand) {
+        return Resolve-GitHubWriteFallback -Reason 'gh CLI was not found.'
+    }
+
+    $userProbe = Invoke-NativeCommand -Command $ghCommand.Source -Arguments @('api', 'user', '--jq', '.login')
+    if ($userProbe.ExitCode -ne 0 -or [string]::IsNullOrWhiteSpace($userProbe.Text)) {
+        return Resolve-GitHubWriteFallback -Reason "gh api user failed. gh auth status is not sufficient for write automation. $($userProbe.Text)"
+    }
+
+    $permissionProbe = Invoke-NativeCommand -Command $ghCommand.Source -Arguments @('api', "repos/$Repository", '--jq', '.permissions')
+    if ($permissionProbe.ExitCode -ne 0 -or [string]::IsNullOrWhiteSpace($permissionProbe.Text)) {
+        return Resolve-GitHubWriteFallback -Reason "gh repository permission probe failed for $Repository. $($permissionProbe.Text)"
+    }
+
+    try {
+        $permissions = $permissionProbe.Text | ConvertFrom-Json
+    } catch {
+        return Resolve-GitHubWriteFallback -Reason "gh repository permission probe returned invalid JSON for $Repository."
+    }
+
+    $hasWritePermission =
+        ($permissions.PSObject.Properties.Name -contains 'admin' -and [bool]$permissions.admin) -or
+        ($permissions.PSObject.Properties.Name -contains 'maintain' -and [bool]$permissions.maintain) -or
+        ($permissions.PSObject.Properties.Name -contains 'push' -and [bool]$permissions.push)
+
+    if (-not $hasWritePermission) {
+        return Resolve-GitHubWriteFallback -Reason "gh user '$($userProbe.Text)' does not report write permission for $Repository."
+    }
+
+    $gitRemoteProbe = 'skipped'
+    if (-not $SkipGitProbe) {
+        $gitCommand = Get-Command git -ErrorAction SilentlyContinue
+        if (-not $gitCommand) {
+            return Resolve-GitHubWriteFallback -Reason 'git CLI was not found for the remote credential probe.'
+        }
+
+        $gitProbe = Invoke-NativeCommand -Command $gitCommand.Source -Arguments @('ls-remote', '--exit-code', 'origin', 'HEAD')
+        if ($gitProbe.ExitCode -ne 0) {
+            return Resolve-GitHubWriteFallback -Reason "git remote credential probe failed. $($gitProbe.Text)"
+        }
+
+        $gitRemoteProbe = 'ok'
+    }
+
+    return New-GitHubWritePreflightResult `
+        -Status 'ok' `
+        -SelectedPath 'gh' `
+        -GhUser $userProbe.Text `
+        -RepoPermission 'write' `
+        -GitRemoteProbe $gitRemoteProbe `
+        -Reason 'gh api user, repository permission, and git remote probes passed.' `
+        -NextAction 'Use gh for merge or release automation.'
+}
+
+$result = Test-GitHubWritePreflight
+
+if ($Json) {
+    $result | ConvertTo-Json -Depth 8
+} else {
+    Write-Output "GitHub write path: $($result.selected_path)"
+    Write-Output "status: $($result.status)"
+    Write-Output "repository: $($result.repository)"
+    if (-not [string]::IsNullOrWhiteSpace($result.gh_user)) {
+        Write-Output "gh user: $($result.gh_user)"
+    }
+    Write-Output "repo permission: $($result.repo_permission)"
+    Write-Output "git remote probe: $($result.git_remote_probe)"
+    Write-Output "reason: $($result.reason)"
+    Write-Output "next: $($result.next_action)"
+}
+
+if ($result.status -eq 'failed') {
+    exit 1
+}
+
+exit 0


### PR DESCRIPTION
Closes #682.

## Summary
- add a GitHub write preflight that checks gh api user instead of trusting gh auth status
- require repository write permission and a non-destructive git remote credential probe before gh merge/release paths
- expose winsmux github-preflight and wire release/verify flows through the check
- add tests for healthy gh, unhealthy gh, and connector fallback selection

## Validation
- Invoke-Pester -Path tests\GitHubWritePreflight.Tests.ps1 -Output Detailed
- pwsh -NoProfile -File winsmux-core\scripts\github-write-preflight.ps1 -Repository Sora-bluesky/winsmux -Json
- pwsh -NoProfile -File scripts\winsmux-core.ps1 github-preflight --json
- PowerShell parser check for modified scripts
- git diff --cached --check
- pwsh -NoProfile -File scripts\audit-public-surface.ps1
- pwsh -NoProfile -File scripts\git-guard.ps1
- git push pre-push gates: git-guard, public-surface audit, gitleaks