### PR TITLE
feat: add operator assignment dry run

### DIFF
--- a/.githooks/pre-commit-whitelist.ps1
+++ b/.githooks/pre-commit-whitelist.ps1
@@ -47,6 +47,7 @@ $whitelistPatterns = @(
     '.gitattributes',
     'tests/PublicSurfacePolicy.Tests.ps1',
     'tests/GitHubWritePreflight.Tests.ps1',
+    'tests/McpServerContract.Tests.ps1',
     'tests/codex-subagent-worktree-guard.Tests.ps1',
     'tests/HarnessContract.Tests.ps1',
     'tests/NpmReleasePackage.Tests.ps1',

--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ tests/*
 !tests/codex-subagent-worktree-guard.Tests.ps1
 !tests/PublicSurfacePolicy.Tests.ps1
 !tests/GitHubWritePreflight.Tests.ps1
+!tests/McpServerContract.Tests.ps1
 !tests/HarnessContract.Tests.ps1
 !tests/NpmReleasePackage.Tests.ps1
 !tests/VersionSurface.Tests.ps1

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -8637,6 +8637,7 @@ Commands:
   machine-contract --json  Print the hook and agent machine contract JSON
   rust-canary [--json]  Print the Rust default-on canary gate JSON
   manual-checklist [--json]  Print the versioned manual validation checklist gate
+  assign --task <TASK-ID> [--json] [--text <text>]  Dry-run provider, role, model-tier, approval, and sandbox assignment
   provider-switch <slot> [--agent <name>] [--model <name>] [--prompt-transport <argv|file|stdin>] [--auth-mode <mode>] [--reason <text>] [--restart] [--clear] [--json]  Record or clear a runtime provider reassignment for a managed slot
   github-preflight [--repo <owner/name>] [--json] [--connector-available] [--require-gh]  Select the GitHub write path before merge/release automation
   locks                     List active file locks
@@ -9361,6 +9362,38 @@ switch ($Command) {
     'machine-contract' { Invoke-MachineContract }
     'rust-canary' { Invoke-RustCanary }
     'manual-checklist' { Invoke-ManualChecklist }
+    'assign' {
+        $assignScript = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\winsmux-core\scripts\assignment-policy.ps1'))
+        $assignArgs = @()
+        $remaining = @(@($Target) + @($Rest) | Where-Object { $_ })
+        for ($index = 0; $index -lt $remaining.Count; $index++) {
+            switch ($remaining[$index]) {
+                '--task' {
+                    if ($index + 1 -ge $remaining.Count) {
+                        Stop-WithError "usage: winsmux assign --task <TASK-ID> [--json] [--text <text>]"
+                    }
+                    $assignArgs += @('-TaskId', $remaining[$index + 1])
+                    $index++
+                }
+                '--text' {
+                    if ($index + 1 -ge $remaining.Count) {
+                        Stop-WithError "usage: winsmux assign --task <TASK-ID> [--json] [--text <text>]"
+                    }
+                    $assignArgs += @('-Text', $remaining[$index + 1])
+                    $index++
+                }
+                '--json' { $assignArgs += '-Json' }
+                default {
+                    Stop-WithError "usage: winsmux assign --task <TASK-ID> [--json] [--text <text>]"
+                }
+            }
+        }
+        & pwsh -NoProfile -File $assignScript @assignArgs
+        $assignExitCode = Get-SafeLastExitCode
+        if ($null -ne $assignExitCode -and $assignExitCode -ne 0) {
+            exit $assignExitCode
+        }
+    }
     'provider-switch' { Invoke-ProviderSwitch }
     'rebind-worktree' { Invoke-RebindWorktree }
     ''                { Show-Usage }

--- a/tests/McpServerContract.Tests.ps1
+++ b/tests/McpServerContract.Tests.ps1
@@ -1,0 +1,22 @@
+BeforeAll {
+    $script:RepoRoot = Split-Path -Parent $PSScriptRoot
+    $script:McpServerPath = Join-Path $script:RepoRoot 'winsmux-core\mcp-server.js'
+}
+
+Describe 'winsmux MCP server contract' {
+    It 'uses argument-array execution for bridge calls and validates assign task ids' {
+        $content = Get-Content -LiteralPath $script:McpServerPath -Raw -Encoding UTF8
+
+        $content | Should -Match 'execFileSync'
+        $content | Should -Not -Match 'execSync'
+        $content | Should -Match '\^TASK-\\d\+\$'
+        $content | Should -Match 'winsmux_assign requires a TASK id'
+    }
+
+    It 'keeps winsmux_assign exposed through the MCP tool list' {
+        $content = Get-Content -LiteralPath $script:McpServerPath -Raw -Encoding UTF8
+
+        $content | Should -Match 'name: "winsmux_assign"'
+        $content | Should -Match 'return invokeBridge\(\["assign", "--task", args\.task, "--json"'
+    }
+}

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -10474,6 +10474,69 @@ Describe 'winsmux provider-capabilities command' {
     }
 }
 
+Describe 'winsmux assign command' {
+    BeforeAll {
+        $script:winsmuxAssignRawPath = Join-Path (Split-Path -Parent $PSScriptRoot) 'scripts\winsmux-core.ps1'
+        $script:winsmuxAssignRawContent = Get-Content -Raw -Path $script:winsmuxAssignRawPath -Encoding UTF8
+    }
+
+    BeforeEach {
+        $script:winsmuxAssignTempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('winsmux-assign-tests-' + [guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path (Join-Path $script:winsmuxAssignTempRoot 'tasks') -Force | Out-Null
+@'
+tasks:
+  - id: TASK-405
+    title: "Operator judgment memory and dynamic AI team assignment policy for Claude Code runs (#676)"
+    status: backlog
+    priority: P0
+    target_version: "v0.24.8"
+    repo: winsmux
+    labels: [enhancement, orchestration, multi-vendor, model-policy, security, release-blocker]
+    notes: >
+      Add a policy layer that chooses provider, role, model, effort, approval policy,
+      sandbox mode, and context budget from TASK, Issue, and PR content.
+      Do not store provider tokens. Keep Claude Code as the upper operator.
+'@ | Set-Content -Path (Join-Path $script:winsmuxAssignTempRoot 'tasks\backlog.yaml') -Encoding UTF8
+    }
+
+    AfterEach {
+        if ($script:winsmuxAssignTempRoot -and (Test-Path $script:winsmuxAssignTempRoot)) {
+            Remove-Item -Path $script:winsmuxAssignTempRoot -Recurse -Force
+        }
+    }
+
+    It 'documents assign and returns a dry-run JSON assignment without token storage' {
+        $script:winsmuxAssignRawContent | Should -Match 'assign --task <TASK-ID> \[--json\] \[--text <text>\]'
+        $script:winsmuxAssignRawContent | Should -Match "'assign'\s*\{"
+
+        Push-Location $script:winsmuxAssignTempRoot
+        try {
+            $env:WINSMUX_BACKLOG_PATH = Join-Path $script:winsmuxAssignTempRoot 'tasks\backlog.yaml'
+            $output = & pwsh -NoProfile -File $script:winsmuxAssignRawPath assign --task TASK-405 --json
+        } finally {
+            $env:WINSMUX_BACKLOG_PATH = $null
+            Pop-Location
+        }
+
+        $payload = $output | ConvertFrom-Json
+        $payload.dry_run | Should -BeTrue
+        $payload.task_id | Should -Be 'TASK-405'
+        $payload.upper_operator.product | Should -Be 'Claude Code'
+        $payload.upper_operator.owns_final_judgment | Should -BeTrue
+        $payload.assignment.selected.capability_tier | Should -Be 'deep_review'
+        $payload.assignment.selected.model | Should -Be 'alias:opus'
+        $payload.assignment.selected.model_resolution | Should -Be 'alias:opus'
+        $payload.assignment.selected.model_reasoning_effort | Should -Be 'high'
+        $payload.assignment.selected.model_reasoning_summary | Should -Be 'none'
+        $payload.assignment.selected.approvals_reviewer | Should -Be 'operator'
+        $payload.assignment.approval_policy | Should -Be 'operator_review_required'
+        $payload.security.stores_provider_tokens | Should -BeFalse
+        $payload.security.brokers_oauth | Should -BeFalse
+        $payload.generated_outputs | Should -Contain 'provider_capability_catalog.generated.json'
+        $payload.generated_outputs | Should -Contain 'model_resolution_report.json'
+    }
+}
+
 Describe 'winsmux launcher command' {
     BeforeAll {
         $script:winsmuxLauncherRawPath = Join-Path (Split-Path -Parent $PSScriptRoot) 'scripts\winsmux-core.ps1'

--- a/winsmux-core/mcp-server.js
+++ b/winsmux-core/mcp-server.js
@@ -2,7 +2,7 @@
 // Transport: stdio (newline-delimited JSON-RPC 2.0)
 "use strict";
 
-const { execSync } = require("child_process");
+const { execFileSync } = require("child_process");
 const path = require("path");
 
 const BRIDGE_SCRIPT = resolveBridgeScript();
@@ -54,6 +54,18 @@ const TOOLS = [
     },
   },
   {
+    name: "winsmux_assign",
+    description: "Dry-run provider, role, model-tier, approval, and sandbox assignment for a TASK id",
+    inputSchema: {
+      type: "object",
+      properties: {
+        task: { type: "string", description: "TASK id, for example TASK-405" },
+        text: { type: "string", description: "Optional extra task context" },
+      },
+      required: ["task"],
+    },
+  },
+  {
     name: "winsmux_health",
     description: "Health check all panes",
     inputSchema: { type: "object", properties: {}, required: [] },
@@ -92,15 +104,9 @@ function resolveBridgeScript() {
 }
 
 function invokeBridge(args) {
-  const escaped = args.map((a) => {
-    const s = String(a);
-    if (s === "") return '""';
-    if (/\s/.test(s)) return '"' + s.replace(/"/g, '\\"') + '"';
-    return s;
-  });
-  const cmd = `pwsh -NoProfile -File "${BRIDGE_SCRIPT}" ${escaped.join(" ")}`;
+  const bridgeArgs = ["-NoProfile", "-File", BRIDGE_SCRIPT, ...args.map((a) => String(a))];
   try {
-    const stdout = execSync(cmd, {
+    const stdout = execFileSync("pwsh", bridgeArgs, {
       encoding: "utf8",
       timeout: 30000,
       windowsHide: true,
@@ -132,6 +138,13 @@ function handleToolCall(name, args) {
 
     case "winsmux_dispatch":
       return invokeBridge(["dispatch-route", args.text]);
+
+    case "winsmux_assign": {
+      if (!/^TASK-\d+$/.test(String(args.task || ""))) {
+        return { success: false, output: "winsmux_assign requires a TASK id such as TASK-405." };
+      }
+      return invokeBridge(["assign", "--task", args.task, "--json", ...(args.text ? ["--text", args.text] : [])]);
+    }
 
     case "winsmux_health":
       return invokeBridge(["health-check"]);

--- a/winsmux-core/scripts/assignment-policy.ps1
+++ b/winsmux-core/scripts/assignment-policy.ps1
@@ -1,0 +1,271 @@
+[CmdletBinding()]
+param(
+    [string]$TaskId = '',
+    [string]$Text = '',
+    [string]$BacklogPath = '',
+    [switch]$Json
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Resolve-AssignmentBacklogPath {
+    param([string]$Path)
+
+    if (-not [string]::IsNullOrWhiteSpace($Path)) {
+        return [System.IO.Path]::GetFullPath($Path)
+    }
+
+    $repoRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\..'))
+    $planningPaths = Join-Path $PSScriptRoot 'planning-paths.ps1'
+    if (Test-Path -LiteralPath $planningPaths -PathType Leaf) {
+        . $planningPaths
+        return Resolve-WinsmuxPlanningFilePath -RepoRoot $repoRoot -LocalRelativePath 'tasks/backlog.yaml' -EnvironmentVariable 'WINSMUX_BACKLOG_PATH' -DefaultFileName 'backlog.yaml'
+    }
+
+    return Join-Path $repoRoot 'tasks\backlog.yaml'
+}
+
+function Get-BacklogTaskBlock {
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $true)][string]$Id
+    )
+
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        return $null
+    }
+
+    $lines = Get-Content -LiteralPath $Path -Encoding UTF8
+    $start = -1
+    for ($index = 0; $index -lt $lines.Count; $index++) {
+        if ($lines[$index] -match "^\s*-\s+id:\s+$([regex]::Escape($Id))\s*$") {
+            $start = $index
+            break
+        }
+    }
+
+    if ($start -lt 0) {
+        return $null
+    }
+
+    $end = $lines.Count
+    for ($index = $start + 1; $index -lt $lines.Count; $index++) {
+        if ($lines[$index] -match '^\s*-\s+id:\s+TASK-') {
+            $end = $index
+            break
+        }
+    }
+
+    return ($lines[$start..($end - 1)] -join "`n")
+}
+
+function Get-BacklogScalar {
+    param(
+        [Parameter(Mandatory = $true)][string]$Block,
+        [Parameter(Mandatory = $true)][string]$Name
+    )
+
+    $match = [regex]::Match($Block, "(?m)^\s*$([regex]::Escape($Name)):\s*(?<value>.+?)\s*$")
+    if (-not $match.Success) {
+        return ''
+    }
+
+    return $match.Groups['value'].Value.Trim().Trim('"')
+}
+
+function Get-AssignmentInputText {
+    param(
+        [string]$TaskBlock,
+        [string]$FreeText
+    )
+
+    $parts = [System.Collections.Generic.List[string]]::new()
+    if (-not [string]::IsNullOrWhiteSpace($TaskBlock)) {
+        $parts.Add($TaskBlock) | Out-Null
+    }
+    if (-not [string]::IsNullOrWhiteSpace($FreeText)) {
+        $parts.Add($FreeText) | Out-Null
+    }
+    return ($parts -join "`n")
+}
+
+function Test-AssignmentKeyword {
+    param(
+        [Parameter(Mandatory = $true)][string]$InputText,
+        [Parameter(Mandatory = $true)][string[]]$Keywords
+    )
+
+    foreach ($keyword in $Keywords) {
+        if ($InputText -match [regex]::Escape($keyword)) {
+            return $true
+        }
+    }
+    return $false
+}
+
+function Get-AssignmentCapabilityTier {
+    param([Parameter(Mandatory = $true)][string]$InputText)
+
+    if (Test-AssignmentKeyword -InputText $InputText -Keywords @('review', 'audit', 'security', 'release-blocker', '監査', 'レビュー')) {
+        return 'deep_review'
+    }
+
+    if (Test-AssignmentKeyword -InputText $InputText -Keywords @('implement', 'fix', 'bug', 'feature', 'code', 'Rust', 'Tauri', '実装', '修正')) {
+        return 'frontier_coding'
+    }
+
+    if (Test-AssignmentKeyword -InputText $InputText -Keywords @('research', 'investigate', 'planning', 'docs', '調査', '計画')) {
+        return 'fast_coding'
+    }
+
+    return 'cheap_summary'
+}
+
+function New-ProviderCandidate {
+    param(
+        [Parameter(Mandatory = $true)][string]$Provider,
+        [Parameter(Mandatory = $true)][string]$Role,
+        [Parameter(Mandatory = $true)][string]$CapabilityTier,
+        [Parameter(Mandatory = $true)][string]$ModelResolution,
+        [Parameter(Mandatory = $true)][string]$PromptTransport,
+        [Parameter(Mandatory = $true)][string]$AuthMode,
+        [Parameter(Mandatory = $true)][string]$Rationale
+    )
+
+    $effort = switch ($CapabilityTier) {
+        'deep_review' { 'high' }
+        'frontier_coding' { 'high' }
+        'fast_coding' { 'medium' }
+        default { 'low' }
+    }
+
+    [ordered]@{
+        provider                           = $Provider
+        role                               = $Role
+        personality                        = $Role
+        capability_tier                    = $CapabilityTier
+        model                              = $ModelResolution
+        model_resolution                   = $ModelResolution
+        model_reasoning_effort             = $effort
+        model_reasoning_summary            = 'none'
+        prompt_transport                   = $PromptTransport
+        auth_mode                          = $AuthMode
+        credential_store                   = 'official_cli_store'
+        suppress_unstable_features_warning = $true
+        approvals_reviewer                 = 'operator'
+        rationale                          = $Rationale
+    }
+}
+
+function Get-AssignmentPolicy {
+    param(
+        [string]$TaskId,
+        [string]$Text,
+        [string]$BacklogPath
+    )
+
+    $resolvedBacklog = Resolve-AssignmentBacklogPath -Path $BacklogPath
+    $taskBlock = ''
+    if (-not [string]::IsNullOrWhiteSpace($TaskId)) {
+        $taskBlock = Get-BacklogTaskBlock -Path $resolvedBacklog -Id $TaskId
+        if ($null -eq $taskBlock) {
+            throw "task not found in backlog: $TaskId"
+        }
+    }
+
+    $inputText = Get-AssignmentInputText -TaskBlock $taskBlock -FreeText $Text
+    if ([string]::IsNullOrWhiteSpace($inputText)) {
+        throw 'usage: winsmux assign --task <TASK-ID> [--json] [--text <text>]'
+    }
+
+    $title = if (-not [string]::IsNullOrWhiteSpace($taskBlock)) {
+        Get-BacklogScalar -Block $taskBlock -Name 'title'
+    } else {
+        ''
+    }
+    $priority = if (-not [string]::IsNullOrWhiteSpace($taskBlock)) {
+        Get-BacklogScalar -Block $taskBlock -Name 'priority'
+    } else {
+        ''
+    }
+
+    $tier = Get-AssignmentCapabilityTier -InputText $inputText
+    $worktreeRequired = Test-AssignmentKeyword -InputText $inputText -Keywords @('code', 'implement', 'fix', 'Rust', 'Tauri', 'PowerShell', '実装', '修正', '変更')
+    $secretSensitive = Test-AssignmentKeyword -InputText $inputText -Keywords @('token', 'credential', 'OAuth', 'secret', 'auth', '資格情報', '機密')
+
+    $primary = switch ($tier) {
+        'deep_review' {
+            New-ProviderCandidate -Provider 'claude' -Role 'reviewer' -CapabilityTier $tier -ModelResolution 'alias:opus' -PromptTransport 'file' -AuthMode 'claude-official-cli' -Rationale 'Use Claude Code review strength while keeping Claude Code as the upper operator.'
+        }
+        'frontier_coding' {
+            New-ProviderCandidate -Provider 'codex' -Role 'builder' -CapabilityTier $tier -ModelResolution 'provider_recommended_default' -PromptTransport 'file' -AuthMode 'codex-official-cli' -Rationale 'Use Codex for implementation and verification without pinning a stale model id.'
+        }
+        'fast_coding' {
+            New-ProviderCandidate -Provider 'gemini' -Role 'researcher' -CapabilityTier $tier -ModelResolution 'alias:auto' -PromptTransport 'file' -AuthMode 'gemini-official-cli' -Rationale 'Use Gemini for fast investigation and context shaping before implementation.'
+        }
+        default {
+            New-ProviderCandidate -Provider 'claude' -Role 'researcher' -CapabilityTier $tier -ModelResolution 'alias:haiku' -PromptTransport 'file' -AuthMode 'claude-official-cli' -Rationale 'Use a low-cost summary-capable worker for small context packets.'
+        }
+    }
+
+    $fallbacks = @(
+        New-ProviderCandidate -Provider 'claude' -Role 'worker' -CapabilityTier $tier -ModelResolution 'alias:sonnet' -PromptTransport 'file' -AuthMode 'claude-official-cli' -Rationale 'Fallback to Claude Sonnet alias when the primary provider is unavailable.'
+        New-ProviderCandidate -Provider 'codex' -Role 'worker' -CapabilityTier 'fast_coding' -ModelResolution 'provider_recommended_default' -PromptTransport 'file' -AuthMode 'codex-official-cli' -Rationale 'Fallback to Codex default when coding help is still needed and local Codex auth is healthy.'
+        New-ProviderCandidate -Provider 'gemini' -Role 'worker' -CapabilityTier 'cheap_summary' -ModelResolution 'alias:flash' -PromptTransport 'file' -AuthMode 'gemini-official-cli' -Rationale 'Fallback to Gemini Flash alias for summarization or broad context reduction.'
+    )
+
+    [pscustomobject][ordered]@{
+        version = 1
+        dry_run = $true
+        task_id = $TaskId
+        task_title = $title
+        priority = $priority
+        upper_operator = [ordered]@{
+            provider = 'claude'
+            product = 'Claude Code'
+            owns_final_judgment = $true
+        }
+        assignment = [ordered]@{
+            selected = $primary
+            fallback = @($fallbacks)
+            approval_policy = if ($secretSensitive) { 'operator_review_required' } else { 'standard' }
+            sandbox_mode = if ($worktreeRequired) { 'workspace-write' } else { 'read-only' }
+            project_doc_max_bytes = if ($tier -eq 'deep_review') { 200000 } elseif ($tier -eq 'frontier_coding') { 160000 } else { 80000 }
+            worktree_required = $worktreeRequired
+        }
+        security = [ordered]@{
+            stores_provider_tokens = $false
+            brokers_oauth = $false
+            credential_boundary = 'Each provider keeps credentials in its official CLI store.'
+            auth_health = 'probe_only'
+            secret_safe = -not $secretSensitive
+        }
+        context_packet = [ordered]@{
+            purpose = 'Decompose the task into the smallest worker-owned packet that matches the selected role.'
+            non_goals = @('Do not store provider tokens.', 'Do not hard-code dated model ids.', 'Do not bypass the Claude Code operator final judgment.')
+            target_files = @()
+            stop_conditions = @('provider auth is unhealthy', 'task scope needs user approval', 'worktree isolation is unavailable for write work')
+        }
+        rationale = @(
+            'Claude Code remains the upper operator.',
+            'Model selection is expressed as capability tiers and provider aliases instead of fixed model ids.',
+            'The dry-run output explains provider fallback before any pane or registry mutation.'
+        )
+        generated_outputs = @(
+            'provider_capability_catalog.generated.json',
+            'model_resolution_report.json'
+        )
+    }
+}
+
+$result = Get-AssignmentPolicy -TaskId $TaskId -Text $Text -BacklogPath $BacklogPath
+if ($Json) {
+    $result | ConvertTo-Json -Depth 16
+} else {
+    Write-Output "assignment: $($result.assignment.selected.provider) / $($result.assignment.selected.model_resolution)"
+    Write-Output "role: $($result.assignment.selected.role)"
+    Write-Output "tier: $($result.assignment.selected.capability_tier)"
+    Write-Output "approval: $($result.assignment.approval_policy)"
+    Write-Output "sandbox: $($result.assignment.sandbox_mode)"
+}


### PR DESCRIPTION
Closes #676.

## Summary
- add winsmux assign --task <TASK-ID> --json as a dry-run assignment policy surface
- keep Claude Code as the upper operator and express worker selection through provider aliases and capability tiers
- expose provider/model fallback, approval policy, sandbox mode, context budget, credential boundary, and stop conditions
- add winsmux_assign to the MCP server and move MCP bridge execution to argument-array execFileSync
- add MCP contract coverage for command-injection prevention

## Validation
- Invoke-Pester -Path tests\winsmux-bridge.Tests.ps1 -FullName '*winsmux assign command*' -Output Detailed
- Invoke-Pester -Path tests\McpServerContract.Tests.ps1 -Output Detailed
- Invoke-Pester -Path tests\winsmux-bridge.Tests.ps1 -FullName '*winsmux provider-capabilities command*','*winsmux provider-switch command*','*winsmux assign command*' -Output Detailed
- pwsh -NoProfile -File scripts\winsmux-core.ps1 assign --task TASK-405 --json
- PowerShell parser check for modified scripts
- node --check winsmux-core\mcp-server.js
- git diff --check
- pwsh -NoProfile -File scripts\audit-public-surface.ps1
- pwsh -NoProfile -File scripts\git-guard.ps1
- review agent finding addressed: MCP bridge now uses execFileSync with argument arrays and validates TASK ids