### PR TITLE
feat: add autonomous run contract fields

### DIFF
--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -5437,10 +5437,10 @@ function ConvertTo-RunEventTimestampText {
         return ''
     }
     if ($Value -is [datetime]) {
-        return $Value.ToString('o', [Globalization.CultureInfo]::InvariantCulture)
+        return $Value.ToUniversalTime().ToString('o', [Globalization.CultureInfo]::InvariantCulture)
     }
     if ($Value -is [datetimeoffset]) {
-        return $Value.ToString('o', [Globalization.CultureInfo]::InvariantCulture)
+        return $Value.UtcDateTime.ToString('o', [Globalization.CultureInfo]::InvariantCulture)
     }
 
     return [string]$Value

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -5398,6 +5398,216 @@ function Get-SecurityVerdictFromEventRecords {
     }
 }
 
+function ConvertTo-RunCheckpointStatus {
+    param(
+        [string]$EventName,
+        [string]$Status = '',
+        [AllowNull()]$Data = $null
+    )
+
+    if ($EventName -in @('pipeline.verify.pass', 'pipeline.security.allowed', 'security.policy.allowed', 'operator.draft_pr.created')) {
+        return 'completed'
+    }
+    if ($EventName -in @('pipeline.verify.fail', 'pipeline.security.blocked', 'security.policy.blocked', 'operator.review_failed')) {
+        return 'blocked'
+    }
+    if ($EventName -in @('pipeline.verify.partial', 'operator.review_requested', 'pane.approval_waiting')) {
+        return 'waiting'
+    }
+    if (-not [string]::IsNullOrWhiteSpace($Status)) {
+        return [string]$Status
+    }
+    if ($null -ne $Data -and $Data -is [System.Collections.IDictionary] -and $Data.Contains('verification_result')) {
+        $verificationResult = $Data['verification_result']
+        if ($verificationResult -is [System.Collections.IDictionary] -and $verificationResult.Contains('outcome')) {
+            $outcome = ([string]$verificationResult['outcome']).ToUpperInvariant()
+            if ($outcome -eq 'PASS') { return 'completed' }
+            if ($outcome -eq 'FAIL') { return 'blocked' }
+            if ($outcome -eq 'PARTIAL') { return 'waiting' }
+        }
+    }
+
+    return 'recorded'
+}
+
+function ConvertTo-RunEventTimestampText {
+    param([AllowNull()]$Value)
+
+    if ($null -eq $Value) {
+        return ''
+    }
+    if ($Value -is [datetime]) {
+        return $Value.ToString('o', [Globalization.CultureInfo]::InvariantCulture)
+    }
+    if ($Value -is [datetimeoffset]) {
+        return $Value.ToString('o', [Globalization.CultureInfo]::InvariantCulture)
+    }
+
+    return [string]$Value
+}
+
+function Get-RunEventTimestampSortKey {
+    param([AllowNull()]$Value)
+
+    if ($null -eq $Value) {
+        return ''
+    }
+    if ($Value -is [datetime]) {
+        return $Value.ToUniversalTime().ToString('o', [Globalization.CultureInfo]::InvariantCulture)
+    }
+    if ($Value -is [datetimeoffset]) {
+        return $Value.UtcDateTime.ToString('o', [Globalization.CultureInfo]::InvariantCulture)
+    }
+
+    $parsed = [datetimeoffset]::MinValue
+    if ([datetimeoffset]::TryParse([string]$Value, [Globalization.CultureInfo]::InvariantCulture, [Globalization.DateTimeStyles]::RoundtripKind, [ref]$parsed)) {
+        return $parsed.UtcDateTime.ToString('o', [Globalization.CultureInfo]::InvariantCulture)
+    }
+
+    return [string]$Value
+}
+
+function Get-RunPlanCheckpointsFromEventRecords {
+    param([object[]]$EventRecords = @())
+
+    $checkpoints = [System.Collections.Generic.List[object]]::new()
+    $checkpointEvents = @(
+        'operator.review_requested',
+        'operator.review_failed',
+        'pane.approval_waiting',
+        'pipeline.verify.pass',
+        'pipeline.verify.fail',
+        'pipeline.verify.partial',
+        'pipeline.security.allowed',
+        'pipeline.security.blocked',
+        'security.policy.allowed',
+        'security.policy.blocked',
+        'operator.draft_pr.created'
+    )
+
+    foreach ($eventRecord in @($EventRecords | Sort-Object @{ Expression = { Get-RunEventTimestampSortKey -Value $_['timestamp'] } }, @{ Expression = { [int]$_.line_number } })) {
+        $eventName = [string]$eventRecord['event']
+        if ($eventName -notin $checkpointEvents) {
+            continue
+        }
+
+        $data = $null
+        if ($eventRecord.Contains('data')) {
+            $data = $eventRecord['data']
+        }
+
+        $outcome = ''
+        if ($null -ne $data -and $data -is [System.Collections.IDictionary] -and $data.Contains('verification_result')) {
+            $verificationResult = $data['verification_result']
+            if ($verificationResult -is [System.Collections.IDictionary] -and $verificationResult.Contains('outcome')) {
+                $outcome = [string]$verificationResult['outcome']
+            }
+        }
+        if ([string]::IsNullOrWhiteSpace($outcome) -and $null -ne $data -and $data -is [System.Collections.IDictionary] -and $data.Contains('result')) {
+            $outcome = [string]$data['result']
+        }
+
+        $lineNumber = [int]$eventRecord['line_number']
+        $checkpoints.Add([ordered]@{
+            id       = if ($lineNumber -gt 0) { "event:$lineNumber" } else { "event:$($checkpoints.Count + 1)" }
+            name     = $eventName
+            status   = ConvertTo-RunCheckpointStatus -EventName $eventName -Status ([string]$eventRecord['status']) -Data $data
+            at       = ConvertTo-RunEventTimestampText -Value $eventRecord['timestamp']
+            event    = $eventName
+            outcome  = $outcome
+            message  = [string]$eventRecord['message']
+        }) | Out-Null
+    }
+
+    return @($checkpoints)
+}
+
+function New-RunPlanContract {
+    param([Parameter(Mandatory = $true)]$Run)
+
+    return [ordered]@{
+        goal              = [string]$Run.goal
+        task_type         = [string]$Run.task_type
+        priority          = [string]$Run.priority
+        write_scope       = @($Run.write_scope)
+        read_scope        = @($Run.read_scope)
+        constraints       = @($Run.constraints)
+        expected_output   = [string]$Run.expected_output
+        verification_plan = @($Run.verification_plan)
+        review_required   = [bool]$Run.review_required
+    }
+}
+
+function New-RunOutcomeContract {
+    param([Parameter(Mandatory = $true)]$Run)
+
+    $status = ''
+    if ([string]$Run.review_state -in @('FAIL', 'FAILED')) {
+        $status = 'failed'
+    } elseif ([string]$Run.review_state -eq 'PASS' -or [string]$Run.task_state -in @('completed', 'task_completed', 'commit_ready', 'done')) {
+        $status = 'completed'
+    } elseif ([string]$Run.task_state -eq 'blocked') {
+        $status = 'blocked'
+    } elseif ([string]$Run.task_state -eq 'in_progress') {
+        $status = 'in_progress'
+    } elseif (-not [string]::IsNullOrWhiteSpace([string]$Run.task_state)) {
+        $status = [string]$Run.task_state
+    }
+
+    $reason = ''
+    if ($null -ne $Run.verification_result -and -not [string]::IsNullOrWhiteSpace([string]$Run.verification_result.summary)) {
+        $reason = [string]$Run.verification_result.summary
+    } elseif ($null -ne $Run.experiment_packet -and -not [string]::IsNullOrWhiteSpace([string]$Run.experiment_packet.result)) {
+        $reason = [string]$Run.experiment_packet.result
+    } elseif (-not [string]::IsNullOrWhiteSpace([string]$Run.last_event)) {
+        $reason = [string]$Run.last_event
+    }
+
+    $confidence = $null
+    if ($null -ne $Run.experiment_packet -and $Run.experiment_packet.Contains('confidence')) {
+        $confidence = $Run.experiment_packet.confidence
+    }
+
+    return [ordered]@{
+        status      = $status
+        reason      = $reason
+        confidence  = $confidence
+        source_event = [string]$Run.last_event
+    }
+}
+
+function New-RunDraftPrGate {
+    param(
+        [Parameter(Mandatory = $true)]$Run,
+        [object[]]$EventRecords = @()
+    )
+
+    $draftPrEvent = @($EventRecords | Where-Object { [string]($_['event']) -eq 'operator.draft_pr.created' } | Sort-Object @{ Expression = { Get-RunEventTimestampSortKey -Value $_['timestamp'] }; Descending = $true }, @{ Expression = { [int]($_['line_number']) }; Descending = $true } | Select-Object -First 1)
+    $state = 'required'
+    $trigger = 'review_state'
+    $draftPrUrl = ''
+    if (@($draftPrEvent).Count -gt 0) {
+        $state = 'passed'
+        $trigger = 'operator.draft_pr.created'
+        $data = $draftPrEvent[0]['data']
+        if ($null -ne $data -and $data -is [System.Collections.IDictionary] -and $data.Contains('draft_pr_url')) {
+            $draftPrUrl = [string]$data['draft_pr_url']
+        }
+    } elseif ([string]$Run.review_state -in @('FAIL', 'FAILED')) {
+        $state = 'blocked'
+    }
+
+    return [ordered]@{
+        kind                 = 'human_judgement'
+        target               = 'draft_pr'
+        state                = $state
+        trigger              = $trigger
+        draft_pr_url         = $draftPrUrl
+        auto_merge_allowed   = $false
+        merge_requires_human = $true
+    }
+}
+
 function New-RunPacketFromRun {
     param([Parameter(Mandatory = $true)]$Run)
 
@@ -5433,6 +5643,10 @@ function New-RunPacketFromRun {
         security_verdict  = $Run.security_verdict
         verification_contract = $Run.verification_contract
         verification_result   = $Run.verification_result
+        plan              = $Run.plan
+        plan_checkpoints  = @($Run.plan_checkpoints)
+        outcome           = $Run.outcome
+        draft_pr_gate     = $Run.draft_pr_gate
         last_event        = [string]$Run.last_event
         last_event_at     = [string]$Run.last_event_at
     }
@@ -5505,6 +5719,10 @@ function New-RunResultPacket {
         verification_result   = $Run.verification_result
         security_policy       = $Run.security_policy
         security_verdict      = $Run.security_verdict
+        plan                  = $Run.plan
+        plan_checkpoints      = @($Run.plan_checkpoints)
+        outcome               = $Run.outcome
+        draft_pr_gate         = $Run.draft_pr_gate
         recent_events         = @($RecentEvents)
     }
 }
@@ -5749,6 +5967,10 @@ function Get-RunsPayload {
                 security_verdict   = $null
                 verification_contract = $null
                 verification_result   = $null
+                plan                  = $null
+                plan_checkpoints      = @()
+                outcome               = $null
+                draft_pr_gate         = $null
             }
         }
 
@@ -5894,12 +6116,16 @@ function Get-RunsPayload {
             if ($null -ne $securityVerdict) {
                 $run.security_verdict = $securityVerdict
             }
+            $run.plan_checkpoints = @(Get-RunPlanCheckpointsFromEventRecords -EventRecords $matchingEvents)
         }
     }
 
     $runs = @(
         foreach ($runId in @($runsById.Keys)) {
             $run = $runsById[$runId]
+            $run.plan = New-RunPlanContract -Run $run
+            $run.outcome = New-RunOutcomeContract -Run $run
+            $run.draft_pr_gate = New-RunDraftPrGate -Run $run -EventRecords @($eventRecords | Where-Object { Test-RunMatchesEventRecord -Run $run -EventRecord $_ })
             [ordered]@{
                 run_id             = [string]$run.run_id
                 task_id            = [string]$run.task_id
@@ -5943,6 +6169,10 @@ function Get-RunsPayload {
                 security_verdict   = $run.security_verdict
                 verification_contract = $run.verification_contract
                 verification_result   = $run.verification_result
+                plan                  = $run.plan
+                plan_checkpoints      = @($run.plan_checkpoints)
+                outcome               = $run.outcome
+                draft_pr_gate         = $run.draft_pr_gate
             }
         }
     )

--- a/tests/fixtures/rust-parity/explain.json
+++ b/tests/fixtures/rust-parity/explain.json
@@ -119,7 +119,7 @@
         "id": "event:1",
         "name": "operator.review_requested",
         "status": "waiting",
-        "at": "2026-04-10T12:01:00+09:00",
+        "at": "2026-04-10T03:01:00Z",
         "event": "operator.review_requested",
         "outcome": "",
         "message": "review requested"

--- a/tests/fixtures/rust-parity/explain.json
+++ b/tests/fixtures/rust-parity/explain.json
@@ -92,7 +92,54 @@
     "security_policy": null,
     "security_verdict": null,
     "verification_contract": null,
-    "verification_result": null
+    "verification_result": null,
+    "plan": {
+      "goal": "Ship run contract primitives",
+      "task_type": "implementation",
+      "priority": "P0",
+      "write_scope": [
+        "scripts/winsmux-core.ps1",
+        "tests/winsmux-bridge.Tests.ps1"
+      ],
+      "read_scope": [
+        "winsmux-core/scripts/pane-status.ps1"
+      ],
+      "constraints": [
+        "preserve existing board schema"
+      ],
+      "expected_output": "Stable explain JSON",
+      "verification_plan": [
+        "Invoke-Pester tests/winsmux-bridge.Tests.ps1",
+        "verify explain --json contract"
+      ],
+      "review_required": true
+    },
+    "plan_checkpoints": [
+      {
+        "id": "event:1",
+        "name": "operator.review_requested",
+        "status": "waiting",
+        "at": "2026-04-10T12:01:00+09:00",
+        "event": "operator.review_requested",
+        "outcome": "",
+        "message": "review requested"
+      }
+    ],
+    "outcome": {
+      "status": "in_progress",
+      "reason": "consult before work",
+      "confidence": 0.66,
+      "source_event": "operator.review_requested"
+    },
+    "draft_pr_gate": {
+      "kind": "human_judgement",
+      "target": "draft_pr",
+      "state": "required",
+      "trigger": "review_state",
+      "draft_pr_url": "",
+      "auto_merge_allowed": false,
+      "merge_requires_human": true
+    }
   },
   "observation_pack": {
     "run_id": "task:task-256",

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -8142,7 +8142,7 @@ panes:
         $result.runs[0].plan.verification_plan | Should -Be @('Invoke-Pester tests/winsmux-bridge.Tests.ps1', 'verify runs --json contract')
         $result.runs[0].plan_checkpoints.Count | Should -Be 2
         @($result.runs[0].plan_checkpoints | ForEach-Object { $_.name }) | Should -Be @('pane.approval_waiting', 'pipeline.verify.partial')
-        $result.runs[0].plan_checkpoints[0].at.ToString('o') | Should -Be '2026-04-10T12:01:00.0000000+09:00'
+        $result.runs[0].plan_checkpoints[0].at.ToString('o') | Should -Be '2026-04-10T03:01:00.0000000Z'
         $result.runs[0].outcome.status | Should -Be 'in_progress'
         $result.runs[0].outcome.reason | Should -Be 'rerun focused verification'
         $result.runs[0].outcome.confidence | Should -Be 0.72
@@ -9148,7 +9148,7 @@ panes:
         $result.run.plan.verification_plan | Should -Be @('Invoke-Pester tests/winsmux-bridge.Tests.ps1', 'verify explain --json contract')
         $result.run.plan_checkpoints.Count | Should -Be 3
         @($result.run.plan_checkpoints | ForEach-Object { $_.name }) | Should -Be @('operator.review_requested', 'pipeline.verify.partial', 'pane.approval_waiting')
-        $result.run.plan_checkpoints[0].at.ToString('o') | Should -Be '2026-04-10T12:01:00.0000000+09:00'
+        $result.run.plan_checkpoints[0].at.ToString('o') | Should -Be '2026-04-10T03:01:00.0000000Z'
         $result.run.outcome.status | Should -Be 'in_progress'
         $result.run.outcome.reason | Should -Be 'rerun focused verification'
         $result.run.outcome.confidence | Should -Be 0.66

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -8138,6 +8138,22 @@ panes:
         $result.runs[0].verification_contract.mode | Should -Be 'adversarial_verify'
         $result.runs[0].verification_result.outcome | Should -Be 'PARTIAL'
         $result.runs[0].run_packet.verification_result.outcome | Should -Be 'PARTIAL'
+        $result.runs[0].plan.goal | Should -Be 'Ship run contract primitives'
+        $result.runs[0].plan.verification_plan | Should -Be @('Invoke-Pester tests/winsmux-bridge.Tests.ps1', 'verify runs --json contract')
+        $result.runs[0].plan_checkpoints.Count | Should -Be 2
+        @($result.runs[0].plan_checkpoints | ForEach-Object { $_.name }) | Should -Be @('pane.approval_waiting', 'pipeline.verify.partial')
+        $result.runs[0].plan_checkpoints[0].at.ToString('o') | Should -Be '2026-04-10T12:01:00.0000000+09:00'
+        $result.runs[0].outcome.status | Should -Be 'in_progress'
+        $result.runs[0].outcome.reason | Should -Be 'rerun focused verification'
+        $result.runs[0].outcome.confidence | Should -Be 0.72
+        $result.runs[0].draft_pr_gate.kind | Should -Be 'human_judgement'
+        $result.runs[0].draft_pr_gate.target | Should -Be 'draft_pr'
+        $result.runs[0].draft_pr_gate.state | Should -Be 'required'
+        $result.runs[0].draft_pr_gate.auto_merge_allowed | Should -Be $false
+        $result.runs[0].run_packet.plan.goal | Should -Be 'Ship run contract primitives'
+        $result.runs[0].run_packet.plan_checkpoints.Count | Should -Be 2
+        $result.runs[0].run_packet.outcome.status | Should -Be 'in_progress'
+        $result.runs[0].run_packet.draft_pr_gate.merge_requires_human | Should -Be $true
         $result.runs[0].Contains('observation_pack') | Should -Be $false
         $result.runs[0].Contains('consultation_packet') | Should -Be $false
     }
@@ -9128,6 +9144,18 @@ panes:
         $result.run.experiment_packet.command_hash | Should -Be 'cmd:def456'
         $result.run.verification_contract.mode | Should -Be 'adversarial_verify'
         $result.run.verification_result.outcome | Should -Be 'PARTIAL'
+        $result.run.plan.goal | Should -Be 'Ship run contract primitives'
+        $result.run.plan.verification_plan | Should -Be @('Invoke-Pester tests/winsmux-bridge.Tests.ps1', 'verify explain --json contract')
+        $result.run.plan_checkpoints.Count | Should -Be 3
+        @($result.run.plan_checkpoints | ForEach-Object { $_.name }) | Should -Be @('operator.review_requested', 'pipeline.verify.partial', 'pane.approval_waiting')
+        $result.run.plan_checkpoints[0].at.ToString('o') | Should -Be '2026-04-10T12:01:00.0000000+09:00'
+        $result.run.outcome.status | Should -Be 'in_progress'
+        $result.run.outcome.reason | Should -Be 'rerun focused verification'
+        $result.run.outcome.confidence | Should -Be 0.66
+        $result.run.draft_pr_gate.kind | Should -Be 'human_judgement'
+        $result.run.draft_pr_gate.target | Should -Be 'draft_pr'
+        $result.run.draft_pr_gate.state | Should -Be 'required'
+        $result.run.draft_pr_gate.merge_requires_human | Should -Be $true
         $result.observation_pack.failing_command | Should -Be 'Invoke-Pester tests/winsmux-bridge.Tests.ps1'
         $result.observation_pack.changed_files | Should -Contain 'scripts/winsmux-core.ps1'
         $result.consultation_packet.kind | Should -Be 'consult_result'


### PR DESCRIPTION
## Summary
- Add first-class autonomous run contract fields to runs and explain JSON: plan, plan_checkpoints, outcome, and draft_pr_gate.
- Keep the draft PR stop gate explicit and human-owned with auto_merge_allowed=false and merge_requires_human=true.
- Update the explain golden fixture for the additive contract shape.

Closes #671.

## Validation
- PowerShell parser check for scripts\\winsmux-core.ps1
- Invoke-Pester -Path tests\\winsmux-bridge.Tests.ps1 -FullName '*winsmux runs command*returns runs as json','*winsmux explain command*returns a json explanation with related events and review state' -Output Detailed
- Invoke-Pester -Path tests\\winsmux-bridge.Tests.ps1 -FullName '*TASK-278 golden corpus fixtures*' -Output Detailed
- cargo test --manifest-path core\\Cargo.toml ledger_contract -- --nocapture
- cargo test --manifest-path core\\Cargo.toml fixture_comparison -- --nocapture
- Invoke-Pester -Path tests\\winsmux-bridge.Tests.ps1 -Output Detailed
- git diff --check
- pwsh -NoProfile -File scripts\\audit-public-surface.ps1
- pwsh -NoProfile -File scripts\\git-guard.ps1
- Post-review targeted rerun: Invoke-Pester -Path tests\\winsmux-bridge.Tests.ps1 -FullName '*winsmux runs command*returns runs as json','*winsmux explain command*returns a json explanation with related events and review state','*keeps explain json fixture stable' -Output Detailed

## Review
- Subagent review found one timestamp-format defect and fixed it before push.
- Remaining findings from that review: none.