### PR TITLE
feat: add managed autonomous loop contract

### DIFF
--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -5405,13 +5405,13 @@ function ConvertTo-RunCheckpointStatus {
         [AllowNull()]$Data = $null
     )
 
-    if ($EventName -in @('pipeline.verify.pass', 'pipeline.security.allowed', 'security.policy.allowed', 'operator.draft_pr.created')) {
+    if ($EventName -in @('pipeline.verify.pass', 'pipeline.security.allowed', 'security.policy.allowed', 'operator.draft_pr.created', 'pipeline.decompose.completed', 'pipeline.dispatch.assigned', 'pipeline.collect.completed')) {
         return 'completed'
     }
     if ($EventName -in @('pipeline.verify.fail', 'pipeline.security.blocked', 'security.policy.blocked', 'operator.review_failed')) {
         return 'blocked'
     }
-    if ($EventName -in @('pipeline.verify.partial', 'operator.review_requested', 'pane.approval_waiting')) {
+    if ($EventName -in @('pipeline.verify.partial', 'operator.review_requested', 'pane.approval_waiting', 'pipeline.escalate.required')) {
         return 'waiting'
     }
     if (-not [string]::IsNullOrWhiteSpace($Status)) {
@@ -5482,7 +5482,11 @@ function Get-RunPlanCheckpointsFromEventRecords {
         'pipeline.security.blocked',
         'security.policy.allowed',
         'security.policy.blocked',
-        'operator.draft_pr.created'
+        'operator.draft_pr.created',
+        'pipeline.decompose.completed',
+        'pipeline.dispatch.assigned',
+        'pipeline.collect.completed',
+        'pipeline.escalate.required'
     )
 
     foreach ($eventRecord in @($EventRecords | Sort-Object @{ Expression = { Get-RunEventTimestampSortKey -Value $_['timestamp'] } }, @{ Expression = { [int]$_.line_number } })) {
@@ -5520,6 +5524,82 @@ function Get-RunPlanCheckpointsFromEventRecords {
     }
 
     return @($checkpoints)
+}
+
+function Get-ManagedLoopContractFromEventRecords {
+    param([object[]]$EventRecords = @())
+
+    $contract = [ordered]@{
+        upper_operator       = 'claude_code'
+        aggregation_point    = 'claude_code_operator'
+        worker_topology      = 'operator_managed_panes'
+        peer_to_peer_allowed = $false
+        decompose_state      = 'not_recorded'
+        assignment_state     = 'not_recorded'
+        collection_state     = 'not_recorded'
+        escalation_state     = 'none'
+        escalation_reason    = ''
+        stages               = @()
+    }
+    $stageRecords = [System.Collections.Generic.List[object]]::new()
+
+    foreach ($eventRecord in @($EventRecords | Sort-Object @{ Expression = { Get-RunEventTimestampSortKey -Value $_['timestamp'] } }, @{ Expression = { [int]$_.line_number } })) {
+        $eventName = [string]$eventRecord['event']
+        if ($eventName -notin @('pipeline.decompose.completed', 'pipeline.dispatch.assigned', 'pipeline.collect.completed', 'pipeline.escalate.required')) {
+            continue
+        }
+
+        $data = $null
+        if ($eventRecord.Contains('data')) {
+            $data = $eventRecord['data']
+        }
+        if ($null -eq $data -or $data -isnot [System.Collections.IDictionary]) {
+            $data = [ordered]@{}
+        }
+
+        $stage = if ($data.Contains('stage')) { [string]$data['stage'] } else { $eventName }
+        $state = if ($data.Contains('state')) { [string]$data['state'] } else { ConvertTo-RunCheckpointStatus -EventName $eventName -Status ([string]$eventRecord['status']) -Data $data }
+        if ($data.Contains('upper_operator') -and -not [string]::IsNullOrWhiteSpace([string]$data['upper_operator'])) {
+            $contract['upper_operator'] = [string]$data['upper_operator']
+        }
+        if ($data.Contains('aggregation_point') -and -not [string]::IsNullOrWhiteSpace([string]$data['aggregation_point'])) {
+            $contract['aggregation_point'] = [string]$data['aggregation_point']
+        }
+        if ($data.Contains('worker_topology') -and -not [string]::IsNullOrWhiteSpace([string]$data['worker_topology'])) {
+            $contract['worker_topology'] = [string]$data['worker_topology']
+        }
+        if ($data.Contains('peer_to_peer_allowed')) {
+            $contract['peer_to_peer_allowed'] = [bool]$data['peer_to_peer_allowed']
+        }
+
+        switch ($eventName) {
+            'pipeline.decompose.completed' { $contract['decompose_state'] = $state }
+            'pipeline.dispatch.assigned' { $contract['assignment_state'] = $state }
+            'pipeline.collect.completed' { $contract['collection_state'] = $state }
+            'pipeline.escalate.required' {
+                $contract['escalation_state'] = $state
+                if ($data.Contains('reason')) {
+                    $contract['escalation_reason'] = [string]$data['reason']
+                }
+            }
+        }
+
+        $stageRecords.Add([ordered]@{
+            stage   = $stage
+            state   = $state
+            event   = $eventName
+            target  = if ($data.Contains('target')) { [string]$data['target'] } else { [string]$eventRecord['label'] }
+            at      = ConvertTo-RunEventTimestampText -Value $eventRecord['timestamp']
+            summary = if ($data.Contains('summary')) { [string]$data['summary'] } else { [string]$eventRecord['message'] }
+        }) | Out-Null
+    }
+
+    if ($stageRecords.Count -eq 0) {
+        return $null
+    }
+
+    $contract['stages'] = @($stageRecords)
+    return $contract
 }
 
 function New-RunPlanContract {
@@ -5645,6 +5725,7 @@ function New-RunPacketFromRun {
         verification_result   = $Run.verification_result
         plan              = $Run.plan
         plan_checkpoints  = @($Run.plan_checkpoints)
+        managed_loop      = $Run.managed_loop
         outcome           = $Run.outcome
         draft_pr_gate     = $Run.draft_pr_gate
         last_event        = [string]$Run.last_event
@@ -5969,6 +6050,7 @@ function Get-RunsPayload {
                 verification_result   = $null
                 plan                  = $null
                 plan_checkpoints      = @()
+                managed_loop          = $null
                 outcome               = $null
                 draft_pr_gate         = $null
             }
@@ -6117,6 +6199,7 @@ function Get-RunsPayload {
                 $run.security_verdict = $securityVerdict
             }
             $run.plan_checkpoints = @(Get-RunPlanCheckpointsFromEventRecords -EventRecords $matchingEvents)
+            $run.managed_loop = Get-ManagedLoopContractFromEventRecords -EventRecords $matchingEvents
         }
     }
 
@@ -6171,6 +6254,7 @@ function Get-RunsPayload {
                 verification_result   = $run.verification_result
                 plan                  = $run.plan
                 plan_checkpoints      = @($run.plan_checkpoints)
+                managed_loop          = $run.managed_loop
                 outcome               = $run.outcome
                 draft_pr_gate         = $run.draft_pr_gate
             }

--- a/tests/fixtures/rust-parity/explain.json
+++ b/tests/fixtures/rust-parity/explain.json
@@ -125,6 +125,7 @@
         "message": "review requested"
       }
     ],
+    "managed_loop": null,
     "outcome": {
       "status": "in_progress",
       "reason": "consult before work",

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -1963,7 +1963,17 @@ NEXT_ACTION: rerun focused verification
         @($script:teamPipelineBridgeCalls | Where-Object { $_[0] -eq 'send' -and $_[1] -eq 'reviewer' }).Count | Should -Be 3
         @($script:teamPipelineEvents | Where-Object { $_.Event -eq 'pipeline.consult.dispatched' }).Count | Should -Be 2
         @($script:teamPipelineEvents | Where-Object { $_.Event -eq 'pipeline.consult.completed' }).Count | Should -Be 2
+        @($script:teamPipelineEvents | Where-Object { $_.Event -eq 'pipeline.decompose.completed' }).Count | Should -Be 1
+        @($script:teamPipelineEvents | Where-Object { $_.Event -eq 'pipeline.dispatch.assigned' }).Count | Should -Be 1
+        @($script:teamPipelineEvents | Where-Object { $_.Event -eq 'pipeline.collect.completed' }).Count | Should -Be 1
         @($script:teamPipelineEvents | Where-Object { $_.Event -eq 'pipeline.review.dispatched' }).Count | Should -Be 1
+
+        $managedDispatch = @($script:teamPipelineEvents | Where-Object { $_.Event -eq 'pipeline.dispatch.assigned' })[0]
+        $managedDispatch.Role | Should -Be 'Operator'
+        $managedDispatch.Data.upper_operator | Should -Be 'claude_code'
+        $managedDispatch.Data.aggregation_point | Should -Be 'claude_code_operator'
+        $managedDispatch.Data.peer_to_peer_allowed | Should -Be $false
+        $managedDispatch.Data.state | Should -Be 'assigned'
 
         $consultDispatch = @($script:teamPipelineEvents | Where-Object { $_.Event -eq 'pipeline.consult.dispatched' })[0]
         $consultDispatch.Data.governance_cost_units[0].unit_type | Should -Be 'governance_invocation'
@@ -2030,6 +2040,56 @@ NEXT_ACTION: rerun focused verification
         $result.StuckConsults[0].Status | Should -Be 'CONSULT_DONE'
         @($script:teamPipelineEvents | Where-Object { $_.Event -eq 'pipeline.consult.dispatched' }).Count | Should -Be 2
         @($script:teamPipelineEvents | Where-Object { $_.Event -eq 'pipeline.consult.completed' }).Count | Should -Be 2
+        @($script:teamPipelineEvents | Where-Object { $_.Event -eq 'pipeline.escalate.required' }).Count | Should -Be 1
+
+        $escalation = @($script:teamPipelineEvents | Where-Object { $_.Event -eq 'pipeline.escalate.required' })[0]
+        $escalation.Role | Should -Be 'Operator'
+        $escalation.Data.state | Should -Be 'required'
+        $escalation.Data.reason | Should -Be 'EXEC_BLOCKED'
+        $escalation.Data.peer_to_peer_allowed | Should -Be $false
+    }
+
+    It 'keeps escalation target visible when no consult pane is configured' {
+        $manifest = [PSCustomObject]@{
+            Session = [PSCustomObject]@{
+                name        = 'winsmux-orchestra'
+                project_dir = 'C:\repo'
+            }
+            Panes = [ordered]@{
+                'builder-1' = [PSCustomObject]@{ pane_id = '%2'; role = 'Builder'; builder_worktree_path = 'C:\repo\.worktrees\builder-1' }
+                'reviewer'  = [PSCustomObject]@{ pane_id = '%4'; role = 'Reviewer'; launch_dir = 'C:\repo'; supports_structured_result = 'true'; supports_verification = 'true'; supports_consultation = 'false' }
+            }
+        }
+
+        $script:teamPipelineEvents = @()
+
+        Mock Read-TeamPipelineManifest { $manifest }
+        Mock Invoke-TeamPipelineBridge { [PSCustomObject]@{ ExitCode = 0; Output = '' } }
+        Mock Wait-TeamPipelineStage {
+            param([string]$Target, [string]$StageName)
+            switch ($StageName) {
+                'EXEC'   { return [PSCustomObject]@{ Stage = $StageName; Target = $Target; Status = 'EXEC_DONE'; Summary = 'build summary'; Transcript = '' } }
+                'VERIFY' { return [PSCustomObject]@{ Stage = $StageName; Target = $Target; Status = 'VERIFY_PARTIAL'; Summary = 'needs operator decision'; Transcript = '' } }
+                default  { throw "Unexpected stage $StageName" }
+            }
+        }
+        Mock Write-TeamPipelineEvent {
+            param($ProjectDir, $SessionName, $Event, $Message, $Role, $PaneId, $Target, $Data)
+            $script:teamPipelineEvents += [PSCustomObject]@{
+                Event  = $Event
+                Role   = $Role
+                Target = $Target
+                Data   = $Data
+            }
+        }
+
+        $result = Invoke-TeamPipeline -Task 'Investigate cache drift' -Builder 'builder-1' -SkipPlan
+
+        $result.FinalStatus | Should -Be 'VERIFY_PARTIAL'
+        $escalation = @($script:teamPipelineEvents | Where-Object { $_.Event -eq 'pipeline.escalate.required' })[0]
+        $escalation.Target | Should -Be 'claude_code_operator'
+        $escalation.Data.target | Should -Be 'claude_code_operator'
+        $escalation.Data.peer_to_peer_allowed | Should -Be $false
     }
 }
 
@@ -8067,6 +8127,75 @@ panes:
             }
         } | ConvertTo-Json -Compress),
         ([ordered]@{
+            timestamp = '2026-04-10T12:01:30+09:00'
+            session   = 'winsmux-orchestra'
+            event     = 'pipeline.decompose.completed'
+            message   = 'operator decomposed task'
+            label     = 'researcher-1'
+            pane_id   = ''
+            role      = 'Operator'
+            branch    = 'worktree-builder-1'
+            head_sha  = 'abc1234def5678'
+            data      = [ordered]@{
+                task_id              = 'task-256'
+                run_id               = 'task:task-256'
+                stage                = 'decompose'
+                state                = 'completed'
+                upper_operator       = 'claude_code'
+                aggregation_point    = 'claude_code_operator'
+                worker_topology      = 'operator_managed_panes'
+                peer_to_peer_allowed = $false
+                target               = 'researcher-1'
+                summary              = 'split implementation and verification'
+            }
+        } | ConvertTo-Json -Compress),
+        ([ordered]@{
+            timestamp = '2026-04-10T12:01:40+09:00'
+            session   = 'winsmux-orchestra'
+            event     = 'pipeline.dispatch.assigned'
+            message   = 'operator assigned builder'
+            label     = 'builder-1'
+            pane_id   = ''
+            role      = 'Operator'
+            branch    = 'worktree-builder-1'
+            head_sha  = 'abc1234def5678'
+            data      = [ordered]@{
+                task_id              = 'task-256'
+                run_id               = 'task:task-256'
+                stage                = 'dispatch'
+                state                = 'assigned'
+                upper_operator       = 'claude_code'
+                aggregation_point    = 'claude_code_operator'
+                worker_topology      = 'operator_managed_panes'
+                peer_to_peer_allowed = $false
+                target               = 'builder-1'
+                summary              = 'builder owns implementation'
+            }
+        } | ConvertTo-Json -Compress),
+        ([ordered]@{
+            timestamp = '2026-04-10T12:01:50+09:00'
+            session   = 'winsmux-orchestra'
+            event     = 'pipeline.collect.completed'
+            message   = 'operator collected builder result'
+            label     = 'builder-1'
+            pane_id   = ''
+            role      = 'Operator'
+            branch    = 'worktree-builder-1'
+            head_sha  = 'abc1234def5678'
+            data      = [ordered]@{
+                task_id              = 'task-256'
+                run_id               = 'task:task-256'
+                stage                = 'collect'
+                state                = 'builder_result_collected'
+                upper_operator       = 'claude_code'
+                aggregation_point    = 'claude_code_operator'
+                worker_topology      = 'operator_managed_panes'
+                peer_to_peer_allowed = $false
+                target               = 'builder-1'
+                summary              = 'builder result is ready for review'
+            }
+        } | ConvertTo-Json -Compress),
+        ([ordered]@{
             timestamp = '2026-04-10T12:02:00+09:00'
             session   = 'winsmux-orchestra'
             event     = 'pipeline.verify.partial'
@@ -8087,6 +8216,30 @@ panes:
                     summary = 'rerun focused verification'
                     next_action = 'rerun_verify'
                 }
+            }
+        } | ConvertTo-Json -Compress),
+        ([ordered]@{
+            timestamp = '2026-04-10T12:03:00+09:00'
+            session   = 'winsmux-orchestra'
+            event     = 'pipeline.escalate.required'
+            message   = 'operator escalation required'
+            label     = 'reviewer-1'
+            pane_id   = ''
+            role      = 'Operator'
+            branch    = 'worktree-builder-1'
+            head_sha  = 'abc1234def5678'
+            data      = [ordered]@{
+                task_id              = 'task-256'
+                run_id               = 'task:task-256'
+                stage                = 'escalate'
+                state                = 'required'
+                reason               = 'VERIFY_PARTIAL'
+                upper_operator       = 'claude_code'
+                aggregation_point    = 'claude_code_operator'
+                worker_topology      = 'operator_managed_panes'
+                peer_to_peer_allowed = $false
+                target               = 'reviewer-1'
+                summary              = 'verification needs an operator decision'
             }
         } | ConvertTo-Json -Compress)
         ) | Set-Content -Path $script:runsEventsPath -Encoding UTF8
@@ -8140,9 +8293,18 @@ panes:
         $result.runs[0].run_packet.verification_result.outcome | Should -Be 'PARTIAL'
         $result.runs[0].plan.goal | Should -Be 'Ship run contract primitives'
         $result.runs[0].plan.verification_plan | Should -Be @('Invoke-Pester tests/winsmux-bridge.Tests.ps1', 'verify runs --json contract')
-        $result.runs[0].plan_checkpoints.Count | Should -Be 2
-        @($result.runs[0].plan_checkpoints | ForEach-Object { $_.name }) | Should -Be @('pane.approval_waiting', 'pipeline.verify.partial')
+        $result.runs[0].plan_checkpoints.Count | Should -Be 6
+        @($result.runs[0].plan_checkpoints | ForEach-Object { $_.name }) | Should -Be @('pane.approval_waiting', 'pipeline.decompose.completed', 'pipeline.dispatch.assigned', 'pipeline.collect.completed', 'pipeline.verify.partial', 'pipeline.escalate.required')
         $result.runs[0].plan_checkpoints[0].at.ToString('o') | Should -Be '2026-04-10T03:01:00.0000000Z'
+        $result.runs[0].managed_loop.upper_operator | Should -Be 'claude_code'
+        $result.runs[0].managed_loop.aggregation_point | Should -Be 'claude_code_operator'
+        $result.runs[0].managed_loop.peer_to_peer_allowed | Should -Be $false
+        $result.runs[0].managed_loop.decompose_state | Should -Be 'completed'
+        $result.runs[0].managed_loop.assignment_state | Should -Be 'assigned'
+        $result.runs[0].managed_loop.collection_state | Should -Be 'builder_result_collected'
+        $result.runs[0].managed_loop.escalation_state | Should -Be 'required'
+        $result.runs[0].managed_loop.escalation_reason | Should -Be 'VERIFY_PARTIAL'
+        $result.runs[0].managed_loop.stages.Count | Should -Be 4
         $result.runs[0].outcome.status | Should -Be 'in_progress'
         $result.runs[0].outcome.reason | Should -Be 'rerun focused verification'
         $result.runs[0].outcome.confidence | Should -Be 0.72
@@ -8151,7 +8313,9 @@ panes:
         $result.runs[0].draft_pr_gate.state | Should -Be 'required'
         $result.runs[0].draft_pr_gate.auto_merge_allowed | Should -Be $false
         $result.runs[0].run_packet.plan.goal | Should -Be 'Ship run contract primitives'
-        $result.runs[0].run_packet.plan_checkpoints.Count | Should -Be 2
+        $result.runs[0].run_packet.plan_checkpoints.Count | Should -Be 6
+        $result.runs[0].run_packet.managed_loop.peer_to_peer_allowed | Should -Be $false
+        $result.runs[0].run_packet.managed_loop.assignment_state | Should -Be 'assigned'
         $result.runs[0].run_packet.outcome.status | Should -Be 'in_progress'
         $result.runs[0].run_packet.draft_pr_gate.merge_requires_human | Should -Be $true
         $result.runs[0].Contains('observation_pack') | Should -Be $false

--- a/winsmux-core/scripts/team-pipeline.ps1
+++ b/winsmux-core/scripts/team-pipeline.ps1
@@ -1017,6 +1017,8 @@ Reply with:
 - scope
 - likely files
 - tests or checks to run
+- decomposition: 1-4 concrete subtasks the operator can assign or track
+- dispatch hints: which worker role should own each subtask and why
 
 End with exactly one line:
 STATUS: PLAN_READY
@@ -1324,6 +1326,52 @@ function Invoke-TeamPipelineConsultStage {
     return $stage
 }
 
+function New-TeamPipelineManagedLoopData {
+    param(
+        [Parameter(Mandatory = $true)][string]$Task,
+        [Parameter(Mandatory = $true)][ValidateSet('decompose', 'dispatch', 'collect', 'escalate')][string]$Stage,
+        [string]$State = '',
+        [string]$BuilderLabel = '',
+        [string]$ResearcherLabel = '',
+        [string]$ReviewerLabel = '',
+        [string]$TargetLabel = '',
+        [string]$Summary = '',
+        [string]$Reason = '',
+        [int]$Attempt = 0
+    )
+
+    $data = [ordered]@{
+        task                 = $Task
+        stage                = $Stage
+        state                = $State
+        upper_operator       = 'claude_code'
+        aggregation_point    = 'claude_code_operator'
+        worker_topology      = 'operator_managed_panes'
+        peer_to_peer_allowed = $false
+        builder              = $BuilderLabel
+        researcher           = $ResearcherLabel
+        reviewer             = $ReviewerLabel
+        target               = $TargetLabel
+        summary              = $Summary
+        reason               = $Reason
+    }
+    if ($Attempt -gt 0) {
+        $data['attempt'] = $Attempt
+    }
+
+    return $data
+}
+
+function Get-TeamPipelineEscalationTarget {
+    param([string]$ConsultTarget = '')
+
+    if ([string]::IsNullOrWhiteSpace($ConsultTarget)) {
+        return 'claude_code_operator'
+    }
+
+    return $ConsultTarget
+}
+
 function Invoke-TeamPipeline {
     param(
         [Parameter(Mandatory = $true)][string]$Task,
@@ -1409,6 +1457,7 @@ function Invoke-TeamPipeline {
         }
 
         $planSummary = $planStage.Summary
+        Write-TeamPipelineEvent -ProjectDir $builderContext.ProjectDir -SessionName $sessionName -Event 'pipeline.decompose.completed' -Message 'Claude Code operator decomposed the task for managed pane assignment.' -Role 'Operator' -Target $targets.PlanTarget -Data (New-TeamPipelineManagedLoopData -Task $Task -Stage 'decompose' -State 'completed' -BuilderLabel $Builder -ResearcherLabel $Researcher -ReviewerLabel $Reviewer -TargetLabel $targets.PlanTarget -Summary $planSummary) | Out-Null
     }
 
     if (-not [string]::IsNullOrWhiteSpace($consultTarget)) {
@@ -1434,6 +1483,7 @@ function Invoke-TeamPipeline {
             New-TeamPipelineFixPrompt -Task $Task -PlanSummary $planSummary -VerificationSummary $previousVerify
         }
 
+        Write-TeamPipelineEvent -ProjectDir $builderContext.ProjectDir -SessionName $sessionName -Event 'pipeline.dispatch.assigned' -Message "Claude Code operator assigned attempt $attemptIndex to $Builder." -Role 'Operator' -Target $Builder -Data (New-TeamPipelineManagedLoopData -Task $Task -Stage 'dispatch' -State 'assigned' -BuilderLabel $Builder -ResearcherLabel $Researcher -ReviewerLabel $Reviewer -TargetLabel $Builder -Summary "Attempt $attemptIndex assigned to $Builder." -Attempt $attemptIndex) | Out-Null
         $buildDispatchResult = Invoke-TeamPipelineGuardedSend -StageName 'EXEC' -Target $Builder -Prompt $buildPrompt -ProjectDir $builderContext.ProjectDir -SessionName $sessionName -Role 'Builder' -Task $Task -Attempt $attemptIndex
         if ($null -ne $buildDispatchResult) {
             $buildStage = $buildDispatchResult
@@ -1447,12 +1497,14 @@ function Invoke-TeamPipeline {
             if ($null -ne $buildSecurityVerdict) {
                 $result.SecurityVerdicts += $buildSecurityVerdict
             }
+            $escalationTarget = Get-TeamPipelineEscalationTarget -ConsultTarget $consultTarget
             if (-not [string]::IsNullOrWhiteSpace($consultTarget)) {
                 $attempt.StuckConsult = Invoke-TeamPipelineConsultStage -Mode 'stuck' -Task $Task -BuilderLabel $Builder -ProjectDir $builderContext.ProjectDir -SessionName $sessionName -TargetLabel $consultTarget -ResearcherLabel $Researcher -ReviewerLabel $Reviewer -BuilderWorktreePath $builderContext.BuilderWorktreePath -PlanSummary $planSummary -BuildSummary $buildStage.Summary -VerificationSummary '' -TimeoutSeconds $StageTimeoutSeconds -PollIntervalSeconds $PollIntervalSeconds -Attempt $attemptIndex
                 if ($null -ne $attempt.StuckConsult) {
                     $result.StuckConsults += $attempt.StuckConsult
                 }
             }
+            Write-TeamPipelineEvent -ProjectDir $builderContext.ProjectDir -SessionName $sessionName -Event 'pipeline.escalate.required' -Message "Claude Code operator escalation required after blocked execution attempt $attemptIndex." -Role 'Operator' -Target $escalationTarget -Data (New-TeamPipelineManagedLoopData -Task $Task -Stage 'escalate' -State 'required' -BuilderLabel $Builder -ResearcherLabel $Researcher -ReviewerLabel $Reviewer -TargetLabel $escalationTarget -Summary $buildStage.Summary -Reason 'EXEC_BLOCKED' -Attempt $attemptIndex) | Out-Null
             $result.Attempts += [PSCustomObject]$attempt
             $result.FinalStatus = 'EXEC_BLOCKED'
             return [PSCustomObject]$result
@@ -1468,6 +1520,7 @@ function Invoke-TeamPipeline {
             verify_target        = $targets.VerifyTarget
             summary              = $buildNotification.Summary
         }) | Out-Null
+        Write-TeamPipelineEvent -ProjectDir $builderContext.ProjectDir -SessionName $sessionName -Event 'pipeline.collect.completed' -Message "Claude Code operator collected builder result for attempt $attemptIndex." -Role 'Operator' -Target $Builder -Data (New-TeamPipelineManagedLoopData -Task $Task -Stage 'collect' -State 'builder_result_collected' -BuilderLabel $Builder -ResearcherLabel $Researcher -ReviewerLabel $Reviewer -TargetLabel $Builder -Summary $buildNotification.Summary -Attempt $attemptIndex) | Out-Null
 
         if ([string]::IsNullOrWhiteSpace($targets.VerifyTarget)) {
             if (-not [string]::IsNullOrWhiteSpace($consultTarget)) {
@@ -1553,16 +1606,20 @@ function Invoke-TeamPipeline {
                 return [PSCustomObject]$result
             }
             'BLOCKED' {
+                $escalationTarget = Get-TeamPipelineEscalationTarget -ConsultTarget $consultTarget
                 if (-not [string]::IsNullOrWhiteSpace($consultTarget)) {
                     $attempt.StuckConsult = Invoke-TeamPipelineConsultStage -Mode 'stuck' -Task $Task -BuilderLabel $Builder -ProjectDir $builderContext.ProjectDir -SessionName $sessionName -TargetLabel $consultTarget -ResearcherLabel $Researcher -ReviewerLabel $Reviewer -BuilderWorktreePath $builderContext.BuilderWorktreePath -PlanSummary $planSummary -BuildSummary $buildStage.Summary -VerificationSummary $verifyStage.Summary -TimeoutSeconds $StageTimeoutSeconds -PollIntervalSeconds $PollIntervalSeconds -Attempt $attemptIndex
                     if ($null -ne $attempt.StuckConsult) {
                         $result.StuckConsults += $attempt.StuckConsult
                     }
                 }
+                Write-TeamPipelineEvent -ProjectDir $builderContext.ProjectDir -SessionName $sessionName -Event 'pipeline.escalate.required' -Message "Claude Code operator escalation required after blocked verification attempt $attemptIndex." -Role 'Operator' -Target $escalationTarget -Data (New-TeamPipelineManagedLoopData -Task $Task -Stage 'escalate' -State 'required' -BuilderLabel $Builder -ResearcherLabel $Researcher -ReviewerLabel $Reviewer -TargetLabel $escalationTarget -Summary $verifyStage.Summary -Reason 'VERIFY_BLOCKED' -Attempt $attemptIndex) | Out-Null
                 $result.FinalStatus = 'VERIFY_BLOCKED'
                 return [PSCustomObject]$result
             }
             'VERIFY_PARTIAL' {
+                $escalationTarget = Get-TeamPipelineEscalationTarget -ConsultTarget $consultTarget
+                Write-TeamPipelineEvent -ProjectDir $builderContext.ProjectDir -SessionName $sessionName -Event 'pipeline.escalate.required' -Message "Claude Code operator escalation required after partial verification attempt $attemptIndex." -Role 'Operator' -Target $escalationTarget -Data (New-TeamPipelineManagedLoopData -Task $Task -Stage 'escalate' -State 'required' -BuilderLabel $Builder -ResearcherLabel $Researcher -ReviewerLabel $Reviewer -TargetLabel $escalationTarget -Summary $verifyStage.Summary -Reason 'VERIFY_PARTIAL' -Attempt $attemptIndex) | Out-Null
                 $result.FinalStatus = 'VERIFY_PARTIAL'
                 return [PSCustomObject]$result
             }
@@ -1576,6 +1633,8 @@ function Invoke-TeamPipeline {
     }
 
     $result.FinalStatus = 'VERIFY_FAIL'
+    $escalationTarget = Get-TeamPipelineEscalationTarget -ConsultTarget $consultTarget
+    Write-TeamPipelineEvent -ProjectDir $builderContext.ProjectDir -SessionName $sessionName -Event 'pipeline.escalate.required' -Message 'Claude Code operator escalation required after verification fixes were exhausted.' -Role 'Operator' -Target $escalationTarget -Data (New-TeamPipelineManagedLoopData -Task $Task -Stage 'escalate' -State 'required' -BuilderLabel $Builder -ResearcherLabel $Researcher -ReviewerLabel $Reviewer -TargetLabel $escalationTarget -Summary 'Verification failed after all fix attempts.' -Reason 'VERIFY_FAIL' -Attempt $attemptLimit) | Out-Null
     return [PSCustomObject]$result
 }
 


### PR DESCRIPTION
## Summary
- Add operator-managed loop events for decompose, assignment, collection, and escalation.
- Surface managed_loop in runs JSON and run_packet with Claude Code as the aggregation point.
- Keep pane agents non-peer-to-peer with peer_to_peer_allowed=false and a visible escalation fallback target.

Closes #672

## Validation
- PowerShell parser checks for winsmux-core/scripts/team-pipeline.ps1 and scripts/winsmux-core.ps1
- Invoke-Pester -Path tests/winsmux-bridge.Tests.ps1 -FullName '*team-pipeline helpers*','*winsmux runs command*returns runs as json','*TASK-278 golden corpus fixtures*' -Output Detailed
- Invoke-Pester -Path tests/winsmux-bridge.Tests.ps1 -Output Detailed
- cargo test --manifest-path core/Cargo.toml fixture_comparison -- --nocapture
- git diff --check
- pwsh -NoProfile -File scripts/audit-public-surface.ps1
- pwsh -NoProfile -File scripts/git-guard.ps1