### PR TITLE
feat: add draft PR stop gate package

### DIFF
--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -5055,6 +5055,7 @@ function Get-InboxActionableEventKind {
         'operator.review_failed'    { return 'review_failed' }
         'operator.blocked'          { return 'blocked' }
         'operator.commit_ready'     { return 'commit_ready' }
+        'operator.draft_pr.required' { return 'blocked' }
         'pipeline.security.blocked'  { return 'blocked' }
         'security.policy.blocked'    { return 'blocked' }
         default                      { return '' }
@@ -5408,7 +5409,7 @@ function ConvertTo-RunCheckpointStatus {
     if ($EventName -in @('pipeline.verify.pass', 'pipeline.security.allowed', 'security.policy.allowed', 'operator.draft_pr.created', 'pipeline.decompose.completed', 'pipeline.dispatch.assigned', 'pipeline.collect.completed')) {
         return 'completed'
     }
-    if ($EventName -in @('pipeline.verify.fail', 'pipeline.security.blocked', 'security.policy.blocked', 'operator.review_failed')) {
+    if ($EventName -in @('pipeline.verify.fail', 'pipeline.security.blocked', 'security.policy.blocked', 'operator.review_failed', 'operator.draft_pr.required')) {
         return 'blocked'
     }
     if ($EventName -in @('pipeline.verify.partial', 'operator.review_requested', 'pane.approval_waiting', 'pipeline.escalate.required')) {
@@ -5483,6 +5484,7 @@ function Get-RunPlanCheckpointsFromEventRecords {
         'security.policy.allowed',
         'security.policy.blocked',
         'operator.draft_pr.created',
+        'operator.draft_pr.required',
         'pipeline.decompose.completed',
         'pipeline.dispatch.assigned',
         'pipeline.collect.completed',
@@ -5656,6 +5658,108 @@ function New-RunOutcomeContract {
     }
 }
 
+function Get-RunContractField {
+    param(
+        [AllowNull()]$InputObject,
+        [Parameter(Mandatory = $true)][string]$Name
+    )
+
+    if ($null -eq $InputObject) {
+        return $null
+    }
+    if ($InputObject -is [System.Collections.IDictionary]) {
+        if ($InputObject.Contains($Name)) {
+            return $InputObject[$Name]
+        }
+        return $null
+    }
+
+    $property = $InputObject.PSObject.Properties[$Name]
+    if ($null -ne $property) {
+        return $property.Value
+    }
+
+    return $null
+}
+
+function New-RunDraftPrHandoffPackage {
+    param(
+        [Parameter(Mandatory = $true)]$Run,
+        [string]$DraftPrUrl = ''
+    )
+
+    $verificationOutcome = [string](Get-RunContractField -InputObject $Run.verification_result -Name 'outcome')
+    $verificationSummary = [string](Get-RunContractField -InputObject $Run.verification_result -Name 'summary')
+    $verificationNextAction = [string](Get-RunContractField -InputObject $Run.verification_result -Name 'next_action')
+    $securityVerdict = [string](Get-RunContractField -InputObject $Run.security_verdict -Name 'verdict')
+    $securityReason = [string](Get-RunContractField -InputObject $Run.security_verdict -Name 'reason')
+    $reviewState = [string]$Run.review_state
+    $reviewRequired = [bool]$Run.review_required
+    $blockedReasons = [System.Collections.Generic.List[string]]::new()
+    $remainingRisks = [System.Collections.Generic.List[string]]::new()
+
+    $hasVerificationEvidence = -not [string]::IsNullOrWhiteSpace($verificationOutcome)
+    if (-not $hasVerificationEvidence) {
+        $blockedReasons.Add('verification evidence is missing') | Out-Null
+        $remainingRisks.Add('verification evidence is missing') | Out-Null
+    }
+    if ($reviewRequired -and $reviewState -notin @('PASS', 'FAIL', 'FAILED')) {
+        $blockedReasons.Add("review state is unresolved: $reviewState") | Out-Null
+        $remainingRisks.Add("review state is unresolved: $reviewState") | Out-Null
+    }
+    if ($reviewState -in @('FAIL', 'FAILED')) {
+        $blockedReasons.Add("review failed: $reviewState") | Out-Null
+        $remainingRisks.Add("review failed: $reviewState") | Out-Null
+    }
+    if (-not [string]::IsNullOrWhiteSpace($verificationOutcome) -and $verificationOutcome -ne 'PASS') {
+        $remainingRisks.Add("verification outcome is $verificationOutcome") | Out-Null
+    }
+    if ($securityVerdict -eq 'BLOCK') {
+        $reasonText = if (-not [string]::IsNullOrWhiteSpace($securityReason)) { $securityReason } else { 'security policy blocked the run' }
+        $blockedReasons.Add($reasonText) | Out-Null
+        $remainingRisks.Add($reasonText) | Out-Null
+    }
+
+    $summary = if (-not [string]::IsNullOrWhiteSpace($verificationSummary)) {
+        $verificationSummary
+    } elseif ($null -ne $Run.experiment_packet -and -not [string]::IsNullOrWhiteSpace([string]$Run.experiment_packet.result)) {
+        [string]$Run.experiment_packet.result
+    } elseif (-not [string]::IsNullOrWhiteSpace([string]$Run.task)) {
+        [string]$Run.task
+    } else {
+        [string]$Run.goal
+    }
+
+    $suggestedNextAction = if (@($blockedReasons).Count -gt 0) {
+        'resolve blocked reasons before creating or merging a draft PR'
+    } elseif ([string]::IsNullOrWhiteSpace($DraftPrUrl)) {
+        'create a draft PR and request human review'
+    } else {
+        'human reviewer must decide whether to merge'
+    }
+    if (-not [string]::IsNullOrWhiteSpace($verificationNextAction) -and @($blockedReasons).Count -gt 0) {
+        $suggestedNextAction = $verificationNextAction
+    }
+
+    return [ordered]@{
+        summary                  = $summary
+        validation               = [ordered]@{
+            evidence_complete  = $hasVerificationEvidence
+            outcome            = $verificationOutcome
+            summary            = $verificationSummary
+            next_action        = $verificationNextAction
+            verification_plan  = @($Run.verification_plan)
+            changed_files      = @($Run.changed_files)
+        }
+        remaining_risks          = @($remainingRisks)
+        suggested_next_action    = $suggestedNextAction
+        blocked_reasons          = @($blockedReasons)
+        package_complete         = (@($blockedReasons).Count -eq 0)
+        human_judgement_required = $true
+        automatic_merge_allowed  = $false
+    }
+}
+
 function New-RunDraftPrGate {
     param(
         [Parameter(Mandatory = $true)]$Run,
@@ -5667,14 +5771,18 @@ function New-RunDraftPrGate {
     $trigger = 'review_state'
     $draftPrUrl = ''
     if (@($draftPrEvent).Count -gt 0) {
-        $state = 'passed'
         $trigger = 'operator.draft_pr.created'
         $data = $draftPrEvent[0]['data']
         if ($null -ne $data -and $data -is [System.Collections.IDictionary] -and $data.Contains('draft_pr_url')) {
             $draftPrUrl = [string]$data['draft_pr_url']
         }
-    } elseif ([string]$Run.review_state -in @('FAIL', 'FAILED')) {
+    }
+
+    $handoffPackage = New-RunDraftPrHandoffPackage -Run $Run -DraftPrUrl $draftPrUrl
+    if (@($handoffPackage.blocked_reasons).Count -gt 0) {
         $state = 'blocked'
+    } elseif (@($draftPrEvent).Count -gt 0) {
+        $state = 'passed'
     }
 
     return [ordered]@{
@@ -5685,6 +5793,7 @@ function New-RunDraftPrGate {
         draft_pr_url         = $draftPrUrl
         auto_merge_allowed   = $false
         merge_requires_human = $true
+        handoff_package      = $handoffPackage
     }
 }
 

--- a/tests/fixtures/rust-parity/explain.json
+++ b/tests/fixtures/rust-parity/explain.json
@@ -135,11 +135,39 @@
     "draft_pr_gate": {
       "kind": "human_judgement",
       "target": "draft_pr",
-      "state": "required",
+      "state": "blocked",
       "trigger": "review_state",
       "draft_pr_url": "",
       "auto_merge_allowed": false,
-      "merge_requires_human": true
+      "merge_requires_human": true,
+      "handoff_package": {
+        "summary": "consult before work",
+        "validation": {
+          "evidence_complete": false,
+          "outcome": "",
+          "summary": "",
+          "next_action": "",
+          "verification_plan": [
+            "Invoke-Pester tests/winsmux-bridge.Tests.ps1",
+            "verify explain --json contract"
+          ],
+          "changed_files": [
+            "scripts/winsmux-core.ps1"
+          ]
+        },
+        "remaining_risks": [
+          "verification evidence is missing",
+          "review state is unresolved: PENDING"
+        ],
+        "suggested_next_action": "resolve blocked reasons before creating or merging a draft PR",
+        "blocked_reasons": [
+          "verification evidence is missing",
+          "review state is unresolved: PENDING"
+        ],
+        "package_complete": false,
+        "human_judgement_required": true,
+        "automatic_merge_allowed": false
+      }
     }
   },
   "observation_pack": {

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -8310,16 +8310,55 @@ panes:
         $result.runs[0].outcome.confidence | Should -Be 0.72
         $result.runs[0].draft_pr_gate.kind | Should -Be 'human_judgement'
         $result.runs[0].draft_pr_gate.target | Should -Be 'draft_pr'
-        $result.runs[0].draft_pr_gate.state | Should -Be 'required'
+        $result.runs[0].draft_pr_gate.state | Should -Be 'blocked'
         $result.runs[0].draft_pr_gate.auto_merge_allowed | Should -Be $false
+        $result.runs[0].draft_pr_gate.handoff_package.summary | Should -Be 'rerun focused verification'
+        $result.runs[0].draft_pr_gate.handoff_package.validation.outcome | Should -Be 'PARTIAL'
+        $result.runs[0].draft_pr_gate.handoff_package.remaining_risks | Should -Contain 'verification outcome is PARTIAL'
+        $result.runs[0].draft_pr_gate.handoff_package.blocked_reasons | Should -Contain 'review state is unresolved: PENDING'
+        $result.runs[0].draft_pr_gate.handoff_package.package_complete | Should -Be $false
+        $result.runs[0].draft_pr_gate.handoff_package.automatic_merge_allowed | Should -Be $false
         $result.runs[0].run_packet.plan.goal | Should -Be 'Ship run contract primitives'
         $result.runs[0].run_packet.plan_checkpoints.Count | Should -Be 6
         $result.runs[0].run_packet.managed_loop.peer_to_peer_allowed | Should -Be $false
         $result.runs[0].run_packet.managed_loop.assignment_state | Should -Be 'assigned'
         $result.runs[0].run_packet.outcome.status | Should -Be 'in_progress'
         $result.runs[0].run_packet.draft_pr_gate.merge_requires_human | Should -Be $true
+        $result.runs[0].run_packet.draft_pr_gate.handoff_package.suggested_next_action | Should -Be 'rerun_verify'
         $result.runs[0].Contains('observation_pack') | Should -Be $false
         $result.runs[0].Contains('consultation_packet') | Should -Be $false
+    }
+
+    It 'blocks draft PR gate when draft PR evidence exists without verification evidence' {
+        $run = [ordered]@{
+            review_state      = 'PASS'
+            review_required   = $true
+            verification_plan = @('Invoke-Pester')
+            changed_files     = @('scripts/winsmux-core.ps1')
+            task              = 'Create draft package'
+            goal              = 'Create draft package'
+            verification_result = $null
+            security_verdict  = $null
+            experiment_packet = $null
+        }
+        $events = @(
+            [ordered]@{
+                timestamp   = '2026-04-10T12:04:00+09:00'
+                line_number = 1
+                event       = 'operator.draft_pr.created'
+                data        = [ordered]@{ draft_pr_url = 'https://github.com/Sora-bluesky/winsmux/pull/999' }
+            }
+        )
+
+        $gate = New-RunDraftPrGate -Run $run -EventRecords $events
+
+        $gate.state | Should -Be 'blocked'
+        $gate.draft_pr_url | Should -Be 'https://github.com/Sora-bluesky/winsmux/pull/999'
+        $gate.auto_merge_allowed | Should -Be $false
+        $gate.merge_requires_human | Should -Be $true
+        $gate.handoff_package.validation.evidence_complete | Should -Be $false
+        $gate.handoff_package.blocked_reasons | Should -Contain 'verification evidence is missing'
+        $gate.handoff_package.suggested_next_action | Should -Be 'resolve blocked reasons before creating or merging a draft PR'
     }
 
     It 'supports winsmux runs --json through the top-level CLI entrypoint' {
@@ -9318,8 +9357,12 @@ panes:
         $result.run.outcome.confidence | Should -Be 0.66
         $result.run.draft_pr_gate.kind | Should -Be 'human_judgement'
         $result.run.draft_pr_gate.target | Should -Be 'draft_pr'
-        $result.run.draft_pr_gate.state | Should -Be 'required'
+        $result.run.draft_pr_gate.state | Should -Be 'blocked'
         $result.run.draft_pr_gate.merge_requires_human | Should -Be $true
+        $result.run.draft_pr_gate.handoff_package.summary | Should -Be 'rerun focused verification'
+        $result.run.draft_pr_gate.handoff_package.remaining_risks | Should -Contain 'verification outcome is PARTIAL'
+        $result.run.draft_pr_gate.handoff_package.blocked_reasons | Should -Contain 'review state is unresolved: PENDING'
+        $result.run.draft_pr_gate.handoff_package.automatic_merge_allowed | Should -Be $false
         $result.observation_pack.failing_command | Should -Be 'Invoke-Pester tests/winsmux-bridge.Tests.ps1'
         $result.observation_pack.changed_files | Should -Contain 'scripts/winsmux-core.ps1'
         $result.consultation_packet.kind | Should -Be 'consult_result'
@@ -13212,6 +13255,79 @@ panes:
         }
         Should -Invoke Approve-OperatorPollPane -Times 1 -Exactly -ParameterFilter {
             $PaneId -eq '%4'
+        }
+    }
+
+    It 'stops at the draft PR gate after review passed' {
+        Mock Send-OperatorTelegramNotification { }
+
+        $result = Invoke-OperatorStateMachine `
+            -CurrentState 'review_passed' `
+            -CycleSummary @{ completions = 0 } `
+            -ProjectDir $script:operatorPollTempRoot `
+            -SessionName 'winsmux-orchestra' `
+            -ManifestPath $script:operatorPollManifestPath
+
+        $result.State | Should -Be 'blocked_draft_pr_required'
+        $result.CommitReadySha | Should -Be ''
+
+        $eventsPath = Join-Path $script:operatorPollManifestDir 'events.jsonl'
+        $events = @(Get-Content -Path $eventsPath -Encoding UTF8 | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | ForEach-Object { $_ | ConvertFrom-Json -AsHashtable })
+        @($events | ForEach-Object { $_['event'] }) | Should -Contain 'operator.draft_pr.required'
+        $draftEvent = @($events | Where-Object { $_['event'] -eq 'operator.draft_pr.required' })[0]
+        $draftEvent['status'] | Should -Be 'blocked_draft_pr_required'
+        $draftEvent['data']['human_merge_required'] | Should -Be $true
+        $draftEvent['data']['auto_merge_allowed'] | Should -Be $false
+        @($events | ForEach-Object { $_['event'] }) | Should -Not -Contain 'operator.commit_ready'
+
+        Should -Invoke Send-OperatorTelegramNotification -Times 1 -Exactly -ParameterFilter {
+            $Event -eq 'operator.draft_pr.required'
+        }
+    }
+
+    It 'ignores draft PR events without a matching head sha' {
+        $eventsPath = Join-Path $script:operatorPollManifestDir 'events.jsonl'
+        @(
+            ([ordered]@{
+                timestamp = '2026-04-12T10:00:00+09:00'
+                event     = 'operator.draft_pr.created'
+                head_sha  = ''
+                data      = [ordered]@{ target = 'draft_pr'; draft_pr_url = 'https://github.com/Sora-bluesky/winsmux/pull/900' }
+            } | ConvertTo-Json -Compress -Depth 10),
+            ([ordered]@{
+                timestamp = '2026-04-12T10:01:00+09:00'
+                event     = 'operator.draft_pr.created'
+                head_sha  = 'old-sha'
+                data      = [ordered]@{ target = 'draft_pr'; draft_pr_url = 'https://github.com/Sora-bluesky/winsmux/pull/901' }
+            } | ConvertTo-Json -Compress -Depth 10)
+        ) | Set-Content -Path $eventsPath -Encoding UTF8
+
+        Test-OperatorDraftPrCreated -ProjectDir $script:operatorPollTempRoot -HeadSha 'current-sha' | Should -Be $false
+    }
+
+    It 'resumes from the draft PR gate when matching draft PR evidence appears' {
+        Mock git { 'abc123' }
+        Mock Send-OperatorTelegramNotification { }
+
+        $eventsPath = Join-Path $script:operatorPollManifestDir 'events.jsonl'
+        ([ordered]@{
+            timestamp = '2026-04-12T10:02:00+09:00'
+            event     = 'operator.draft_pr.created'
+            head_sha  = 'abc123'
+            data      = [ordered]@{ target = 'draft_pr'; draft_pr_url = 'https://github.com/Sora-bluesky/winsmux/pull/902' }
+        } | ConvertTo-Json -Compress -Depth 10) | Set-Content -Path $eventsPath -Encoding UTF8
+
+        $result = Invoke-OperatorStateMachine `
+            -CurrentState 'blocked_draft_pr_required' `
+            -CycleSummary @{ completions = 0 } `
+            -ProjectDir $script:operatorPollTempRoot `
+            -SessionName 'winsmux-orchestra' `
+            -ManifestPath $script:operatorPollManifestPath
+
+        $result.State | Should -Be 'commit_ready'
+        $result.CommitReadySha | Should -Be 'abc123'
+        Should -Invoke Send-OperatorTelegramNotification -Times 1 -Exactly -ParameterFilter {
+            $Event -eq 'operator.commit_ready' -and $HeadSha -eq 'abc123'
         }
     }
 }

--- a/winsmux-core/scripts/operator-poll.ps1
+++ b/winsmux-core/scripts/operator-poll.ps1
@@ -537,6 +537,7 @@ function Test-OperatorTelegramNotificationEnabled {
         'operator.review_passed',
         'operator.review_failed',
         'operator.blocked',
+        'operator.draft_pr.required',
         'operator.commit_ready',
         'operator.commit_done'
     )
@@ -852,6 +853,94 @@ function Get-OperatorPollPreferredReviewPane {
     return $null
 }
 
+function Test-OperatorDraftPrCreated {
+    param(
+        [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [string]$HeadSha = ''
+    )
+
+    if ([string]::IsNullOrWhiteSpace($HeadSha)) {
+        return $false
+    }
+
+    $eventsPath = Join-Path (Join-Path $ProjectDir '.winsmux') 'events.jsonl'
+    if (-not (Test-Path $eventsPath -PathType Leaf)) {
+        return $false
+    }
+
+    foreach ($line in @(Get-Content -Path $eventsPath -Encoding UTF8)) {
+        if ([string]::IsNullOrWhiteSpace($line)) {
+            continue
+        }
+
+        try {
+            $record = $line | ConvertFrom-Json -AsHashtable -ErrorAction Stop
+        } catch {
+            continue
+        }
+
+        if ([string]$record['event'] -ne 'operator.draft_pr.created') {
+            continue
+        }
+
+        $recordHeadSha = [string]$record['head_sha']
+        $data = $null
+        if ($record.Contains('data')) {
+            $data = $record['data']
+        }
+        if ([string]::IsNullOrWhiteSpace($recordHeadSha) -and $null -ne $data -and $data -is [System.Collections.IDictionary] -and $data.Contains('head_sha')) {
+            $recordHeadSha = [string]$data['head_sha']
+        }
+
+        if ([string]::IsNullOrWhiteSpace($recordHeadSha)) {
+            continue
+        }
+
+        if ($null -ne $data -and $data -is [System.Collections.IDictionary] -and $data.Contains('target')) {
+            if ([string]$data['target'] -ne 'draft_pr') {
+                continue
+            }
+        }
+
+        if ($recordHeadSha -eq $HeadSha) {
+            return $true
+        }
+    }
+
+    return $false
+}
+
+function Write-OperatorDraftPrRequiredEvent {
+    param(
+        [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [Parameter(Mandatory = $true)][string]$SessionName,
+        [string]$HeadSha = ''
+    )
+
+    $eventsPath = Join-Path (Join-Path $ProjectDir '.winsmux') 'events.jsonl'
+    $record = [ordered]@{
+        timestamp   = (Get-Date).ToString('o')
+        session     = $SessionName
+        event       = 'operator.draft_pr.required'
+        message     = 'Draft PR is required before this autonomous run can proceed.'
+        label       = ''
+        pane_id     = ''
+        role        = 'Operator'
+        status      = 'blocked_draft_pr_required'
+        exit_reason = ''
+        head_sha    = $HeadSha
+        data        = [ordered]@{
+            target                = 'draft_pr'
+            reason                = 'draft_pr_required'
+            human_merge_required  = $true
+            auto_merge_allowed    = $false
+            suggested_next_action = 'create a draft PR and request human review'
+        }
+    }
+
+    Write-WinsmuxTextFile -Path $eventsPath -Content ($record | ConvertTo-Json -Compress -Depth 10) -Append
+}
+
 function Invoke-OperatorStateMachine {
     param(
         [Parameter(Mandatory = $true)][string]$CurrentState,
@@ -941,10 +1030,17 @@ function Invoke-OperatorStateMachine {
         }
         'review_passed' {
             $headSha = (git -C $ProjectDir rev-parse HEAD 2>$null)
-            $nextCommitReadySha = $headSha
-            Send-OperatorTelegramNotification -ProjectDir $ProjectDir -SessionName $SessionName `
-                -Event 'operator.commit_ready' -Message "コミット準備完了。" -HeadSha $headSha
-            $nextState = 'commit_ready'
+            if (Test-OperatorDraftPrCreated -ProjectDir $ProjectDir -HeadSha $headSha) {
+                $nextCommitReadySha = $headSha
+                Send-OperatorTelegramNotification -ProjectDir $ProjectDir -SessionName $SessionName `
+                    -Event 'operator.commit_ready' -Message "コミット準備完了。" -HeadSha $headSha
+                $nextState = 'commit_ready'
+            } else {
+                Write-OperatorDraftPrRequiredEvent -ProjectDir $ProjectDir -SessionName $SessionName -HeadSha $headSha
+                Send-OperatorTelegramNotification -ProjectDir $ProjectDir -SessionName $SessionName `
+                    -Event 'operator.draft_pr.required' -Message "draft PR 作成と人間の判断が必要です。自動 merge は許可されません。" -HeadSha $headSha
+                $nextState = 'blocked_draft_pr_required'
+            }
         }
         'commit_ready' {
             $currentSha = (git -C $ProjectDir rev-parse HEAD 2>$null)
@@ -965,6 +1061,15 @@ function Invoke-OperatorStateMachine {
                     $nextState = 'waiting_for_review'
                 }
             } catch { }
+        }
+        'blocked_draft_pr_required' {
+            $headSha = (git -C $ProjectDir rev-parse HEAD 2>$null)
+            if (Test-OperatorDraftPrCreated -ProjectDir $ProjectDir -HeadSha $headSha) {
+                $nextCommitReadySha = $headSha
+                Send-OperatorTelegramNotification -ProjectDir $ProjectDir -SessionName $SessionName `
+                    -Event 'operator.commit_ready' -Message "コミット準備完了。" -HeadSha $headSha
+                $nextState = 'commit_ready'
+            }
         }
         'blocked_bootstrap_invalid' { }
     }


### PR DESCRIPTION
## Summary
- Closes #673.
- Adds a draft PR handoff package with validation evidence, remaining risks, blocked reasons, and suggested next action.
- Stops autonomous runs after review PASS until matching draft PR evidence exists.
- Keeps automatic merge disabled and human judgement required.

## Validation
- PowerShell parser check for winsmux-core/scripts/operator-poll.ps1: passed.
- PowerShell parser check for scripts/winsmux-core.ps1: passed.
- Invoke-Pester targeted runs/explain/operator-poll draft PR gate tests: 10 passed.
- Invoke-Pester -Path tests/winsmux-bridge.Tests.ps1 -Output Detailed: 380 passed.
- cargo test --manifest-path core/Cargo.toml fixture_comparison -- --nocapture: 5 passed.
- git diff --check: passed.
- pwsh -NoProfile -File scripts/audit-public-surface.ps1: passed.
- pwsh -NoProfile -File scripts/git-guard.ps1: passed.

## Review
- Initial review subagent found stale/headless draft PR evidence and blocked state recovery issues; both fixed.
- Final review subagent found no blocking issues.