### PR TITLE
feat: add phase-gated run workflow

### DIFF
--- a/core/src/ledger.rs
+++ b/core/src/ledger.rs
@@ -1,7 +1,7 @@
 use crate::event_contract::{parse_event_jsonl, EventRecord};
 use crate::manifest_contract::{NormalizedManifestPane, WinsmuxManifest};
 use serde::Serialize;
-use serde_json::Value;
+use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, HashMap, HashSet};
@@ -275,6 +275,9 @@ pub struct LedgerExplainRun {
     pub security_verdict: Value,
     pub verification_contract: Value,
     pub verification_result: Value,
+    pub outcome: Value,
+    pub phase_gate: Value,
+    pub draft_pr_gate: Value,
     pub changed_files: Vec<String>,
 }
 
@@ -463,6 +466,9 @@ pub struct LedgerRunProjection {
     pub security_verdict: Value,
     pub verification_contract: Value,
     pub verification_result: Value,
+    pub outcome: Value,
+    pub phase_gate: Value,
+    pub draft_pr_gate: Value,
     pub run_packet: Option<LedgerRunPacket>,
 }
 
@@ -502,6 +508,9 @@ pub struct LedgerRunPacket {
     pub security_verdict: Value,
     pub verification_contract: Value,
     pub verification_result: Value,
+    pub outcome: Value,
+    pub phase_gate: Value,
+    pub draft_pr_gate: Value,
     pub last_event: String,
     pub last_event_at: String,
 }
@@ -707,6 +716,11 @@ impl LedgerRunProjection {
             verification_result: run
                 .map(|run| run.verification_result.clone())
                 .unwrap_or(Value::Null),
+            outcome: run.map(|run| run.outcome.clone()).unwrap_or(Value::Null),
+            phase_gate: run.map(|run| run.phase_gate.clone()).unwrap_or(Value::Null),
+            draft_pr_gate: run
+                .map(|run| run.draft_pr_gate.clone())
+                .unwrap_or(Value::Null),
             run_packet: run.map(LedgerRunPacket::from_explain_run),
         }
     }
@@ -749,6 +763,9 @@ impl LedgerRunPacket {
             security_verdict: run.security_verdict.clone(),
             verification_contract: run.verification_contract.clone(),
             verification_result: run.verification_result.clone(),
+            outcome: run.outcome.clone(),
+            phase_gate: run.phase_gate.clone(),
+            draft_pr_gate: run.draft_pr_gate.clone(),
             last_event: run.last_event.clone(),
             last_event_at: run.last_event_at.clone(),
         }
@@ -1184,8 +1201,9 @@ impl LedgerSnapshot {
             right
                 .timestamp
                 .cmp(&left.timestamp)
-                .then_with(|| left_index.cmp(right_index))
+                .then_with(|| right_index.cmp(left_index))
         });
+        let recent_event_records = recent_events.clone();
         let recent_events: Vec<_> = recent_events
             .into_iter()
             .map(|(_, event)| explain_recent_event_from_event(event))
@@ -1211,7 +1229,7 @@ impl LedgerSnapshot {
             roles.push(evidence_digest.role.clone());
         }
 
-        let run = LedgerExplainRun {
+        let mut run = LedgerExplainRun {
             run_id: evidence_digest.run_id.clone(),
             task_id: evidence_digest.task_id.clone(),
             parent_run_id: primary_pane.parent_run_id.clone(),
@@ -1256,8 +1274,14 @@ impl LedgerSnapshot {
             security_verdict,
             verification_contract,
             verification_result,
+            outcome: Value::Null,
+            phase_gate: Value::Null,
+            draft_pr_gate: Value::Null,
             changed_files: evidence_digest.changed_files.clone(),
         };
+        run.draft_pr_gate = run_draft_pr_gate_value(&run, &recent_event_records);
+        run.phase_gate = run_phase_gate_value(&run, &recent_event_records, &run.draft_pr_gate);
+        run.outcome = run_outcome_value(&run, &run.phase_gate, &run.draft_pr_gate);
         let explanation = explain_explanation(&run, &evidence_digest);
 
         Some(LedgerExplainProjection {
@@ -1625,6 +1649,7 @@ fn run_next_action(
         "review_failed",
         "task_blocked",
         "blocked",
+        "needs_user_decision",
         "commit_ready",
         "task_completed",
         "review_pending",
@@ -1675,6 +1700,15 @@ fn run_state_model(
         };
         return ("package".into(), "completed".into(), detail.into());
     }
+    if matches!(kind_text.as_str(), "needs_user_decision" | "draft_pr_required")
+        || event_text == "operator.draft_pr.required"
+    {
+        return (
+            "package".into(),
+            "waiting_for_input".into(),
+            "needs_user_decision".into(),
+        );
+    }
     if matches!(review_text.as_str(), "FAIL" | "FAILED") || kind_text == "review_failed" {
         return ("review".into(), "blocked".into(), "review_failed".into());
     }
@@ -1691,7 +1725,7 @@ fn run_state_model(
         return (
             "package".into(),
             "waiting_for_input".into(),
-            "draft_pr_required".into(),
+            "needs_user_decision".into(),
         );
     }
     if task_text == "blocked"
@@ -1954,6 +1988,423 @@ fn explain_explanation(
     }
 }
 
+#[derive(Clone)]
+struct RunPhaseStage {
+    stage: &'static str,
+    status: String,
+    reason: String,
+    event: String,
+}
+
+fn set_run_phase_stage(
+    stages: &mut [RunPhaseStage],
+    name: &str,
+    status: &str,
+    reason: &str,
+    event: &str,
+) {
+    if let Some(stage) = stages.iter_mut().find(|stage| stage.stage == name) {
+        stage.status = status.to_string();
+        if !reason.trim().is_empty() {
+            stage.reason = reason.to_string();
+        }
+        if !event.trim().is_empty() {
+            stage.event = event.to_string();
+        }
+    }
+}
+
+fn run_phase_gate_value(
+    run: &LedgerExplainRun,
+    events: &[(usize, &EventRecord)],
+    draft_pr_gate: &Value,
+) -> Value {
+    let order = vec!["plan", "build", "test", "review", "package"];
+    let mut stages: Vec<_> = order
+        .iter()
+        .map(|stage| RunPhaseStage {
+            stage: *stage,
+            status: "pending".to_string(),
+            reason: String::new(),
+            event: String::new(),
+        })
+        .collect();
+
+    if !run.goal.trim().is_empty() || !run.verification_plan.is_empty() {
+        set_run_phase_stage(&mut stages, "plan", "completed", "run_plan_recorded", "");
+    }
+    if !run.task_state.trim().is_empty() {
+        set_run_phase_stage(&mut stages, "build", "in_progress", &run.task_state, "");
+    }
+
+    let mut stop_reason = String::new();
+    let mut stop_stage = String::new();
+    let mut ordered_events = events.to_vec();
+    ordered_events.sort_by(|(left_index, left), (right_index, right)| {
+        left.timestamp
+            .cmp(&right.timestamp)
+            .then_with(|| left_index.cmp(right_index))
+    });
+
+    for (_, event) in ordered_events {
+        match event.event.as_str() {
+            "pipeline.decompose.completed" => {
+                set_run_phase_stage(&mut stages, "plan", "completed", "decomposed", &event.event)
+            }
+            "pipeline.dispatch.assigned" => set_run_phase_stage(
+                &mut stages,
+                "build",
+                "in_progress",
+                "assigned",
+                &event.event,
+            ),
+            "pipeline.collect.completed" => set_run_phase_stage(
+                &mut stages,
+                "build",
+                "completed",
+                "collected",
+                &event.event,
+            ),
+            "pipeline.verify.pass" => {
+                set_run_phase_stage(
+                    &mut stages,
+                    "test",
+                    "completed",
+                    "verification_passed",
+                    &event.event,
+                );
+                if stop_stage == "test" {
+                    stop_reason.clear();
+                    stop_stage.clear();
+                }
+            }
+            "pipeline.verify.fail" => {
+                set_run_phase_stage(
+                    &mut stages,
+                    "test",
+                    "blocked",
+                    "verification_failed",
+                    &event.event,
+                );
+                stop_reason = "verification_failed".to_string();
+                stop_stage = "test".to_string();
+            }
+            "pipeline.verify.partial" => {
+                set_run_phase_stage(
+                    &mut stages,
+                    "test",
+                    "waiting_for_input",
+                    "verification_partial",
+                    &event.event,
+                );
+                stop_reason = "needs_user_decision".to_string();
+                stop_stage = "test".to_string();
+            }
+            "operator.review_requested" => set_run_phase_stage(
+                &mut stages,
+                "review",
+                "waiting_for_input",
+                "review_requested",
+                &event.event,
+            ),
+            "operator.review_failed" => {
+                set_run_phase_stage(
+                    &mut stages,
+                    "review",
+                    "blocked",
+                    "review_failed",
+                    &event.event,
+                );
+                stop_reason = "review_failed".to_string();
+                stop_stage = "review".to_string();
+            }
+            "pipeline.escalate.required" => {
+                set_run_phase_stage(
+                    &mut stages,
+                    "review",
+                    "waiting_for_input",
+                    "needs_user_decision",
+                    &event.event,
+                );
+                stop_reason = "needs_user_decision".to_string();
+                stop_stage = "review".to_string();
+            }
+            "operator.draft_pr.required" => {
+                set_run_phase_stage(
+                    &mut stages,
+                    "package",
+                    "waiting_for_input",
+                    "needs_user_decision",
+                    &event.event,
+                );
+                stop_reason = "needs_user_decision".to_string();
+                stop_stage = "package".to_string();
+            }
+            "operator.draft_pr.created" if draft_pr_event_matches_run_head(run, event) => {
+                set_run_phase_stage(
+                    &mut stages,
+                    "package",
+                    "waiting_for_input",
+                    "draft_pr",
+                    &event.event,
+                );
+                stop_reason = "draft_pr".to_string();
+                stop_stage = "package".to_string();
+            }
+            "operator.commit_ready" => {
+                set_run_phase_stage(
+                    &mut stages,
+                    "package",
+                    "completed",
+                    "commit_ready",
+                    &event.event,
+                );
+                stop_reason.clear();
+                stop_stage.clear();
+            }
+            _ => {}
+        }
+    }
+
+    if run.review_state == "PASS" {
+        set_run_phase_stage(&mut stages, "review", "completed", "review_passed", "");
+        if stop_stage == "review" {
+            stop_reason.clear();
+            stop_stage.clear();
+        }
+        let draft_pr_gate_state = value_field_string(draft_pr_gate, "state");
+        if !draft_pr_gate_state.trim().is_empty() && draft_pr_gate_state != "passed" {
+            set_run_phase_stage(
+                &mut stages,
+                "package",
+                "waiting_for_input",
+                "needs_user_decision",
+                "",
+            );
+            stop_reason = "needs_user_decision".to_string();
+        }
+    } else if run.review_state == "PENDING" {
+        set_run_phase_stage(
+            &mut stages,
+            "review",
+            "waiting_for_input",
+            "review_pending",
+            "",
+        );
+    } else if matches!(run.review_state.as_str(), "FAIL" | "FAILED") {
+        set_run_phase_stage(&mut stages, "review", "blocked", "review_failed", "");
+        stop_reason = "review_failed".to_string();
+    }
+
+    if matches!(
+        run.task_state.as_str(),
+        "completed" | "task_completed" | "commit_ready" | "done"
+    ) {
+        set_run_phase_stage(&mut stages, "build", "completed", &run.task_state, "");
+        set_run_phase_stage(&mut stages, "package", "completed", &run.task_state, "");
+        if matches!(run.task_state.as_str(), "commit_ready" | "done") {
+            stop_reason.clear();
+        }
+    }
+
+    let current_stage = stages
+        .iter()
+        .rev()
+        .find(|stage| stage.status != "pending")
+        .map(|stage| stage.stage)
+        .unwrap_or("plan");
+    let stage_values: Vec<_> = stages
+        .iter()
+        .map(|stage| {
+            json!({
+                "stage": stage.stage,
+                "status": stage.status,
+                "reason": stage.reason,
+                "event": stage.event,
+            })
+        })
+        .collect();
+    let stop_required = !stop_reason.trim().is_empty();
+
+    json!({
+        "order": order,
+        "current_stage": current_stage,
+        "stages": stage_values,
+        "stop_required": stop_required,
+        "stop_reason": stop_reason,
+        "auto_continue_allowed": !stop_required,
+        "requires_human_decision": matches!(stop_reason.as_str(), "needs_user_decision" | "draft_pr"),
+    })
+}
+
+fn run_draft_pr_gate_value(run: &LedgerExplainRun, events: &[(usize, &EventRecord)]) -> Value {
+    let draft_pr_event = events
+        .iter()
+        .map(|(_, event)| *event)
+        .find(|event| {
+            event.event == "operator.draft_pr.created" && draft_pr_event_matches_run_head(run, event)
+        });
+    let draft_pr_url = draft_pr_event
+        .map(|event| event_data_string(&event.data, "draft_pr_url"))
+        .unwrap_or_default();
+    let trigger = if draft_pr_event.is_some() {
+        "operator.draft_pr.created"
+    } else {
+        "review_state"
+    };
+    let handoff_package = run_draft_pr_handoff_package_value(run, &draft_pr_url);
+    let blocked_count = handoff_package
+        .get("blocked_reasons")
+        .and_then(|value| value.as_array())
+        .map(|items| items.len())
+        .unwrap_or(0);
+    let state = if blocked_count > 0 {
+        "blocked"
+    } else if draft_pr_event.is_some() {
+        "passed"
+    } else {
+        "required"
+    };
+
+    json!({
+        "kind": "human_judgement",
+        "target": "draft_pr",
+        "state": state,
+        "trigger": trigger,
+        "draft_pr_url": draft_pr_url,
+        "auto_merge_allowed": false,
+        "merge_requires_human": true,
+        "handoff_package": handoff_package,
+    })
+}
+
+fn run_draft_pr_handoff_package_value(run: &LedgerExplainRun, draft_pr_url: &str) -> Value {
+    let verification_outcome = value_field_string(&run.verification_result, "outcome");
+    let verification_summary = value_field_string(&run.verification_result, "summary");
+    let verification_next_action = value_field_string(&run.verification_result, "next_action");
+    let security_verdict = value_field_string(&run.security_verdict, "verdict");
+    let security_reason = value_field_string(&run.security_verdict, "reason");
+    let mut blocked_reasons = Vec::new();
+    let mut remaining_risks = Vec::new();
+
+    if verification_outcome.trim().is_empty() {
+        blocked_reasons.push("verification evidence is missing".to_string());
+        remaining_risks.push("verification evidence is missing".to_string());
+    }
+    if run.review_required && !matches!(run.review_state.as_str(), "PASS" | "FAIL" | "FAILED") {
+        let reason = format!("review state is unresolved: {}", run.review_state);
+        blocked_reasons.push(reason.clone());
+        remaining_risks.push(reason);
+    }
+    if matches!(run.review_state.as_str(), "FAIL" | "FAILED") {
+        let reason = format!("review failed: {}", run.review_state);
+        blocked_reasons.push(reason.clone());
+        remaining_risks.push(reason);
+    }
+    if !verification_outcome.trim().is_empty() && verification_outcome != "PASS" {
+        remaining_risks.push(format!("verification outcome is {verification_outcome}"));
+    }
+    if security_verdict == "BLOCK" {
+        let reason = if security_reason.trim().is_empty() {
+            "security policy blocked the run".to_string()
+        } else {
+            security_reason
+        };
+        blocked_reasons.push(reason.clone());
+        remaining_risks.push(reason);
+    }
+
+    let summary = first_non_empty_string(vec![
+        verification_summary.clone(),
+        run.experiment_packet.result.clone(),
+        run.task.clone(),
+        run.goal.clone(),
+    ]);
+    let mut suggested_next_action = if !blocked_reasons.is_empty() {
+        "resolve blocked reasons before creating or merging a draft PR".to_string()
+    } else if draft_pr_url.trim().is_empty() {
+        "create a draft PR and request human review".to_string()
+    } else {
+        "human reviewer must decide whether to merge".to_string()
+    };
+    if !verification_next_action.trim().is_empty() && !blocked_reasons.is_empty() {
+        suggested_next_action = verification_next_action.clone();
+    }
+
+    json!({
+        "summary": summary,
+        "validation": {
+            "evidence_complete": !verification_outcome.trim().is_empty(),
+            "outcome": verification_outcome,
+            "summary": verification_summary,
+            "next_action": verification_next_action,
+            "verification_plan": run.verification_plan.clone(),
+            "changed_files": run.changed_files.clone(),
+        },
+        "remaining_risks": remaining_risks,
+        "suggested_next_action": suggested_next_action,
+        "blocked_reasons": blocked_reasons,
+        "package_complete": blocked_reasons.is_empty(),
+        "human_judgement_required": true,
+        "automatic_merge_allowed": false,
+    })
+}
+
+fn run_outcome_value(run: &LedgerExplainRun, phase_gate: &Value, draft_pr_gate: &Value) -> Value {
+    let phase_gate_stop_reason = value_field_string(phase_gate, "stop_reason");
+    let draft_pr_gate_state = value_field_string(draft_pr_gate, "state");
+    let status = if matches!(run.review_state.as_str(), "FAIL" | "FAILED") {
+        "failed".to_string()
+    } else if phase_gate_stop_reason == "needs_user_decision"
+        || (run.review_state == "PASS" && draft_pr_gate_state != "passed")
+    {
+        "needs_user_decision".to_string()
+    } else if run.review_state == "PASS"
+        || matches!(
+            run.task_state.as_str(),
+            "completed" | "task_completed" | "commit_ready" | "done"
+        )
+    {
+        "completed".to_string()
+    } else if run.task_state == "blocked" {
+        "blocked".to_string()
+    } else if run.task_state == "in_progress" {
+        "in_progress".to_string()
+    } else {
+        run.task_state.clone()
+    };
+
+    let reason = first_non_empty_string(vec![
+        value_field_string(&run.verification_result, "summary"),
+        run.experiment_packet.result.clone(),
+        run.last_event.clone(),
+    ]);
+
+    json!({
+        "status": status,
+        "reason": reason,
+        "confidence": run.experiment_packet.confidence,
+        "source_event": run.last_event,
+    })
+}
+
+fn draft_pr_event_matches_run_head(run: &LedgerExplainRun, event: &EventRecord) -> bool {
+    if run.head_sha.trim().is_empty() {
+        return true;
+    }
+    let event_head_sha = event_head_sha(event);
+    !event_head_sha.trim().is_empty() && event_head_sha == run.head_sha
+}
+
+fn value_field_string(value: &Value, key: &str) -> String {
+    value
+        .as_object()
+        .and_then(|map| map.get(key))
+        .and_then(|value| value.as_str())
+        .unwrap_or_default()
+        .to_string()
+}
+
 fn push_reason(reasons: &mut Vec<String>, key: &str, value: &str) {
     if !value.trim().is_empty() {
         let separator = if key == "action" { ":" } else { "=" };
@@ -2210,7 +2661,7 @@ fn inbox_priority(kind: &str) -> usize {
     match kind {
         "blocked" | "task_blocked" | "review_failed" | "bootstrap_invalid" | "crashed" | "hung"
         | "stalled" => 0,
-        "approval_waiting" | "review_requested" | "review_pending" => 1,
+        "approval_waiting" | "needs_user_decision" | "review_requested" | "review_pending" => 1,
         "dispatch_needed" | "task_completed" | "commit_ready" => 2,
         _ => 3,
     }
@@ -2257,6 +2708,7 @@ fn inbox_actionable_event_kind(event: &EventRecord) -> &'static str {
         "operator.review_failed" => "review_failed",
         "operator.blocked" => "blocked",
         "operator.commit_ready" => "commit_ready",
+        "operator.draft_pr.required" => "needs_user_decision",
         "pipeline.security.blocked" => "blocked",
         "security.policy.blocked" => "blocked",
         _ => "",

--- a/core/tests-rs/fixture_comparison.rs
+++ b/core/tests-rs/fixture_comparison.rs
@@ -241,6 +241,9 @@ const EXPLAIN_RUN_KEYS: &[&str] = &[
     "security_verdict",
     "verification_contract",
     "verification_result",
+    "outcome",
+    "phase_gate",
+    "draft_pr_gate",
     "changed_files",
 ];
 

--- a/core/tests-rs/ledger_contract.rs
+++ b/core/tests-rs/ledger_contract.rs
@@ -399,6 +399,59 @@ panes:
 }
 
 #[test]
+fn ledger_contract_classifies_draft_pr_required_as_user_decision_stop() {
+    let manifest = r#"
+version: 1
+session:
+  name: winsmux-orchestra
+panes: {}
+"#;
+    let events = r#"{"timestamp":"2026-04-23T12:00:01+09:00","session":"winsmux-orchestra","event":"operator.draft_pr.required","message":"draft PR required","status":"blocked_draft_pr_required","data":{"task_id":"task-guarded"}}
+"#;
+
+    let snapshot = ledger::LedgerSnapshot::from_manifest_and_events(manifest, events)
+        .expect("ledger snapshot should load draft PR required event");
+
+    let inbox = snapshot.inbox_projection();
+
+    assert_eq!(inbox.summary.item_count, 1);
+    assert_eq!(inbox.summary.by_kind["needs_user_decision"], 1);
+    assert_eq!(inbox.items[0].kind, "needs_user_decision");
+    assert_eq!(inbox.items[0].priority, 1);
+    assert_eq!(inbox.items[0].phase, "package");
+    assert_eq!(inbox.items[0].activity, "waiting_for_input");
+    assert_eq!(inbox.items[0].detail, "needs_user_decision");
+}
+
+#[test]
+fn ledger_contract_classifies_pass_review_as_user_decision_stop() {
+    let manifest = r#"
+version: 1
+session:
+  name: winsmux-orchestra
+panes:
+  builder-1:
+    pane_id: "%2"
+    role: Builder
+    task_id: task-pass
+    task_state: in_progress
+    review_state: PASS
+    review_required: true
+    branch: worktree-builder-1
+    head_sha: current-sha
+"#;
+
+    let snapshot = ledger::LedgerSnapshot::from_manifest_and_events(manifest, "")
+        .expect("ledger snapshot should load PASS review state");
+
+    let board = snapshot.board_projection();
+
+    assert_eq!(board.panes[0].phase, "package");
+    assert_eq!(board.panes[0].activity, "waiting_for_input");
+    assert_eq!(board.panes[0].detail, "needs_user_decision");
+}
+
+#[test]
 fn ledger_contract_filters_inbox_after_latest_event_deduplication() {
     let manifest = r#"
 version: 1
@@ -616,6 +669,45 @@ panes:
     );
     assert_eq!(explain.run.verification_result["outcome"], "PASS");
     assert_eq!(explain.run.security_verdict, "ALLOW");
+}
+
+#[test]
+fn ledger_contract_uses_newest_same_timestamp_draft_pr_evidence() {
+    let manifest = r#"
+version: 1
+session:
+  name: winsmux-orchestra
+panes:
+  builder-1:
+    pane_id: "%2"
+    role: Builder
+    task_id: task-draft
+    task: Create draft package
+    task_state: in_progress
+    review_state: PASS
+    review_required: true
+    branch: worktree-builder-1
+    head_sha: current-sha
+    changed_files: '["scripts/winsmux-core.ps1"]'
+    verification_plan: '["Invoke-Pester"]'
+"#;
+    let events = r#"{"timestamp":"2026-04-23T12:00:01+09:00","session":"winsmux-orchestra","event":"pipeline.verify.pass","message":"verification passed","data":{"task_id":"task-draft","verification_result":{"outcome":"PASS","summary":"verification passed"}}}
+{"timestamp":"2026-04-23T12:00:02+09:00","session":"winsmux-orchestra","event":"pipeline.security.allowed","message":"security allowed","data":{"task_id":"task-draft","verdict":"ALLOW"}}
+{"timestamp":"2026-04-23T12:00:03+09:00","session":"winsmux-orchestra","event":"operator.draft_pr.created","message":"old draft","head_sha":"current-sha","data":{"task_id":"task-draft","draft_pr_url":"https://github.com/Sora-bluesky/winsmux/pull/997"}}
+{"timestamp":"2026-04-23T12:00:03+09:00","session":"winsmux-orchestra","event":"operator.draft_pr.created","message":"new draft","head_sha":"current-sha","data":{"task_id":"task-draft","draft_pr_url":"https://github.com/Sora-bluesky/winsmux/pull/998"}}
+"#;
+
+    let snapshot = ledger::LedgerSnapshot::from_manifest_and_events(manifest, events)
+        .expect("ledger snapshot should load same timestamp draft PR evidence");
+    let explain = snapshot
+        .explain_projection("task:task-draft")
+        .expect("draft run should have explain projection");
+
+    assert_eq!(
+        explain.run.draft_pr_gate["draft_pr_url"],
+        "https://github.com/Sora-bluesky/winsmux/pull/998"
+    );
+    assert_eq!(explain.run.draft_pr_gate["state"], "passed");
 }
 
 #[test]

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -4791,6 +4791,10 @@ function New-RunStateModel {
         $phase = 'package'
         $activity = 'completed'
         $detail = if (-not [string]::IsNullOrWhiteSpace($kindText)) { $kindText } else { 'task_completed' }
+    } elseif ($kindText -eq 'needs_user_decision' -or $kindText -eq 'draft_pr_required' -or $eventText -eq 'operator.draft_pr.required') {
+        $phase = 'package'
+        $activity = 'waiting_for_input'
+        $detail = 'needs_user_decision'
     } elseif ($reviewText -in @('FAIL', 'FAILED') -or $kindText -in @('review_failed')) {
         $phase = 'review'
         $activity = 'blocked'
@@ -4802,7 +4806,7 @@ function New-RunStateModel {
     } elseif ($reviewText -eq 'PASS') {
         $phase = 'package'
         $activity = 'waiting_for_input'
-        $detail = 'draft_pr_required'
+        $detail = 'needs_user_decision'
     } elseif ($taskText -eq 'blocked' -or $kindText -in @('blocked', 'task_blocked') -or $eventText -like '*blocked*') {
         $phase = 'build'
         $activity = 'blocked'
@@ -5028,6 +5032,7 @@ function Get-InboxPriority {
         'hung'             { return 0 }
         'stalled'          { return 0 }
         'approval_waiting' { return 1 }
+        'needs_user_decision' { return 1 }
         'review_requested' { return 1 }
         'review_pending'   { return 1 }
         'dispatch_needed'  { return 2 }
@@ -5134,7 +5139,7 @@ function Get-InboxActionableEventKind {
         'operator.review_failed'    { return 'review_failed' }
         'operator.blocked'          { return 'blocked' }
         'operator.commit_ready'     { return 'commit_ready' }
-        'operator.draft_pr.required' { return 'blocked' }
+        'operator.draft_pr.required' { return 'needs_user_decision' }
         'pipeline.security.blocked'  { return 'blocked' }
         'security.policy.blocked'    { return 'blocked' }
         default                      { return '' }
@@ -5488,8 +5493,11 @@ function ConvertTo-RunCheckpointStatus {
     if ($EventName -in @('pipeline.verify.pass', 'pipeline.security.allowed', 'security.policy.allowed', 'operator.draft_pr.created', 'pipeline.decompose.completed', 'pipeline.dispatch.assigned', 'pipeline.collect.completed')) {
         return 'completed'
     }
-    if ($EventName -in @('pipeline.verify.fail', 'pipeline.security.blocked', 'security.policy.blocked', 'operator.review_failed', 'operator.draft_pr.required')) {
+    if ($EventName -in @('pipeline.verify.fail', 'pipeline.security.blocked', 'security.policy.blocked', 'operator.review_failed')) {
         return 'blocked'
+    }
+    if ($EventName -eq 'operator.draft_pr.required') {
+        return 'needs_user_decision'
     }
     if ($EventName -in @('pipeline.verify.partial', 'operator.review_requested', 'pane.approval_waiting', 'pipeline.escalate.required')) {
         return 'waiting'
@@ -5702,9 +5710,18 @@ function New-RunPlanContract {
 function New-RunOutcomeContract {
     param([Parameter(Mandatory = $true)]$Run)
 
+    $phaseGate = Get-RunContractField -InputObject $Run -Name 'phase_gate'
+    $draftPrGate = Get-RunContractField -InputObject $Run -Name 'draft_pr_gate'
+    $phaseGateStopReason = [string](Get-RunContractField -InputObject $phaseGate -Name 'stop_reason')
+    $draftPrGateState = [string](Get-RunContractField -InputObject $draftPrGate -Name 'state')
+
     $status = ''
     if ([string]$Run.review_state -in @('FAIL', 'FAILED')) {
         $status = 'failed'
+    } elseif ($phaseGateStopReason -eq 'needs_user_decision') {
+        $status = 'needs_user_decision'
+    } elseif ([string]$Run.review_state -eq 'PASS' -and $draftPrGateState -ne 'passed') {
+        $status = 'needs_user_decision'
     } elseif ([string]$Run.review_state -eq 'PASS' -or [string]$Run.task_state -in @('completed', 'task_completed', 'commit_ready', 'done')) {
         $status = 'completed'
     } elseif ([string]$Run.task_state -eq 'blocked') {
@@ -5734,6 +5751,152 @@ function New-RunOutcomeContract {
         reason      = $reason
         confidence  = $confidence
         source_event = [string]$Run.last_event
+    }
+}
+
+function Set-RunPhaseGateStage {
+    param(
+        [Parameter(Mandatory = $true)]$StagesByName,
+        [Parameter(Mandatory = $true)][string]$Name,
+        [Parameter(Mandatory = $true)][string]$Status,
+        [string]$Reason = '',
+        [string]$Event = ''
+    )
+
+    if (-not $StagesByName.Contains($Name)) {
+        return
+    }
+
+    $stage = $StagesByName[$Name]
+    $stage.status = $Status
+    if (-not [string]::IsNullOrWhiteSpace($Reason)) {
+        $stage.reason = $Reason
+    }
+    if (-not [string]::IsNullOrWhiteSpace($Event)) {
+        $stage.event = $Event
+    }
+}
+
+function New-RunPhaseGateContract {
+    param(
+        [Parameter(Mandatory = $true)]$Run,
+        [object[]]$EventRecords = @()
+    )
+
+    $stageOrder = @('plan', 'build', 'test', 'review', 'package')
+    $stagesByName = [ordered]@{}
+    foreach ($stageName in $stageOrder) {
+        $stagesByName[$stageName] = [ordered]@{
+            stage  = $stageName
+            status = 'pending'
+            reason = ''
+            event  = ''
+        }
+    }
+
+    $runGoal = [string](Get-RunContractField -InputObject $Run -Name 'goal')
+    $runTaskState = [string](Get-RunContractField -InputObject $Run -Name 'task_state')
+    $runReviewState = [string](Get-RunContractField -InputObject $Run -Name 'review_state')
+    $runVerificationPlanRaw = Get-RunContractField -InputObject $Run -Name 'verification_plan'
+    $runVerificationPlan = if ($null -eq $runVerificationPlanRaw -or [string]::IsNullOrWhiteSpace([string]$runVerificationPlanRaw)) { @() } else { @($runVerificationPlanRaw) }
+
+    if (-not [string]::IsNullOrWhiteSpace($runGoal) -or @($runVerificationPlan).Count -gt 0) {
+        Set-RunPhaseGateStage -StagesByName $stagesByName -Name 'plan' -Status 'completed' -Reason 'run_plan_recorded'
+    }
+    if (-not [string]::IsNullOrWhiteSpace($runTaskState)) {
+        Set-RunPhaseGateStage -StagesByName $stagesByName -Name 'build' -Status 'in_progress' -Reason $runTaskState
+    }
+
+    $stopReason = ''
+    $stopStage = ''
+    $currentStage = 'plan'
+    $runHeadSha = [string](Get-RunContractField -InputObject $Run -Name 'head_sha')
+    foreach ($eventRecord in @($EventRecords | Sort-Object @{ Expression = { Get-RunEventTimestampSortKey -Value $_['timestamp'] } }, @{ Expression = { [int]$_.line_number } })) {
+        $eventName = [string]$eventRecord['event']
+        switch ($eventName) {
+            'pipeline.decompose.completed' { Set-RunPhaseGateStage -StagesByName $stagesByName -Name 'plan' -Status 'completed' -Reason 'decomposed' -Event $eventName }
+            'pipeline.dispatch.assigned' { Set-RunPhaseGateStage -StagesByName $stagesByName -Name 'build' -Status 'in_progress' -Reason 'assigned' -Event $eventName }
+            'pipeline.collect.completed' { Set-RunPhaseGateStage -StagesByName $stagesByName -Name 'build' -Status 'completed' -Reason 'collected' -Event $eventName }
+            'pipeline.verify.pass' {
+                Set-RunPhaseGateStage -StagesByName $stagesByName -Name 'test' -Status 'completed' -Reason 'verification_passed' -Event $eventName
+                if ($stopStage -eq 'test') {
+                    $stopReason = ''
+                    $stopStage = ''
+                }
+            }
+            'pipeline.verify.fail' { Set-RunPhaseGateStage -StagesByName $stagesByName -Name 'test' -Status 'blocked' -Reason 'verification_failed' -Event $eventName; $stopReason = 'verification_failed'; $stopStage = 'test' }
+            'pipeline.verify.partial' { Set-RunPhaseGateStage -StagesByName $stagesByName -Name 'test' -Status 'waiting_for_input' -Reason 'verification_partial' -Event $eventName; $stopReason = 'needs_user_decision'; $stopStage = 'test' }
+            'operator.review_requested' { Set-RunPhaseGateStage -StagesByName $stagesByName -Name 'review' -Status 'waiting_for_input' -Reason 'review_requested' -Event $eventName }
+            'operator.review_failed' { Set-RunPhaseGateStage -StagesByName $stagesByName -Name 'review' -Status 'blocked' -Reason 'review_failed' -Event $eventName; $stopReason = 'review_failed'; $stopStage = 'review' }
+            'pipeline.escalate.required' { Set-RunPhaseGateStage -StagesByName $stagesByName -Name 'review' -Status 'waiting_for_input' -Reason 'needs_user_decision' -Event $eventName; $stopReason = 'needs_user_decision'; $stopStage = 'review' }
+            'operator.draft_pr.required' { Set-RunPhaseGateStage -StagesByName $stagesByName -Name 'package' -Status 'waiting_for_input' -Reason 'needs_user_decision' -Event $eventName; $stopReason = 'needs_user_decision'; $stopStage = 'package' }
+            'operator.draft_pr.created' {
+                $draftPrEventMatchesHead = $true
+                if (-not [string]::IsNullOrWhiteSpace($runHeadSha)) {
+                    $eventHeadSha = [string]$eventRecord['head_sha']
+                    $eventData = $eventRecord['data']
+                    if ([string]::IsNullOrWhiteSpace($eventHeadSha) -and $null -ne $eventData -and $eventData -is [System.Collections.IDictionary] -and $eventData.Contains('head_sha')) {
+                        $eventHeadSha = [string]$eventData['head_sha']
+                    }
+                    $draftPrEventMatchesHead = (-not [string]::IsNullOrWhiteSpace($eventHeadSha) -and $eventHeadSha -eq $runHeadSha)
+                }
+                if ($draftPrEventMatchesHead) {
+                    Set-RunPhaseGateStage -StagesByName $stagesByName -Name 'package' -Status 'waiting_for_input' -Reason 'draft_pr' -Event $eventName
+                    $stopReason = 'draft_pr'
+                    $stopStage = 'package'
+                }
+            }
+            'operator.commit_ready' { Set-RunPhaseGateStage -StagesByName $stagesByName -Name 'package' -Status 'completed' -Reason 'commit_ready' -Event $eventName; $stopReason = ''; $stopStage = '' }
+        }
+    }
+
+    if ($runReviewState -eq 'PASS') {
+        Set-RunPhaseGateStage -StagesByName $stagesByName -Name 'review' -Status 'completed' -Reason 'review_passed'
+        if ($stopStage -eq 'review') {
+            $stopReason = ''
+            $stopStage = ''
+        }
+        $draftPrGate = Get-RunContractField -InputObject $Run -Name 'draft_pr_gate'
+        $draftPrGateState = [string](Get-RunContractField -InputObject $draftPrGate -Name 'state')
+        if (-not [string]::IsNullOrWhiteSpace($draftPrGateState) -and $draftPrGateState -ne 'passed') {
+            Set-RunPhaseGateStage -StagesByName $stagesByName -Name 'package' -Status 'waiting_for_input' -Reason 'needs_user_decision'
+            $stopReason = 'needs_user_decision'
+            $stopStage = 'package'
+        }
+    } elseif ($runReviewState -eq 'PENDING') {
+        Set-RunPhaseGateStage -StagesByName $stagesByName -Name 'review' -Status 'waiting_for_input' -Reason 'review_pending'
+    } elseif ($runReviewState -in @('FAIL', 'FAILED')) {
+        Set-RunPhaseGateStage -StagesByName $stagesByName -Name 'review' -Status 'blocked' -Reason 'review_failed'
+        $stopReason = 'review_failed'
+        $stopStage = 'review'
+    }
+
+    if ($runTaskState -in @('completed', 'task_completed', 'commit_ready', 'done')) {
+        Set-RunPhaseGateStage -StagesByName $stagesByName -Name 'build' -Status 'completed' -Reason $runTaskState
+        Set-RunPhaseGateStage -StagesByName $stagesByName -Name 'package' -Status 'completed' -Reason $runTaskState
+        if ($runTaskState -in @('commit_ready', 'done')) {
+            $stopReason = ''
+            $stopStage = ''
+        }
+    }
+
+    $stages = @($stageOrder | ForEach-Object { $stagesByName[$_] })
+    for ($i = $stageOrder.Count - 1; $i -ge 0; $i--) {
+        $candidate = $stagesByName[$stageOrder[$i]]
+        if ([string]$candidate.status -ne 'pending') {
+            $currentStage = [string]$candidate.stage
+            break
+        }
+    }
+
+    return [ordered]@{
+        order                   = $stageOrder
+        current_stage           = $currentStage
+        stages                  = $stages
+        stop_required           = -not [string]::IsNullOrWhiteSpace($stopReason)
+        stop_reason             = $stopReason
+        auto_continue_allowed   = [string]::IsNullOrWhiteSpace($stopReason)
+        requires_human_decision = $stopReason -in @('needs_user_decision', 'draft_pr')
     }
 }
 
@@ -5845,7 +6008,21 @@ function New-RunDraftPrGate {
         [object[]]$EventRecords = @()
     )
 
-    $draftPrEvent = @($EventRecords | Where-Object { [string]($_['event']) -eq 'operator.draft_pr.created' } | Sort-Object @{ Expression = { Get-RunEventTimestampSortKey -Value $_['timestamp'] }; Descending = $true }, @{ Expression = { [int]($_['line_number']) }; Descending = $true } | Select-Object -First 1)
+    $runHeadSha = [string](Get-RunContractField -InputObject $Run -Name 'head_sha')
+    $draftPrEvent = @($EventRecords | Where-Object {
+        if ([string]($_['event']) -ne 'operator.draft_pr.created') {
+            return $false
+        }
+        if ([string]::IsNullOrWhiteSpace($runHeadSha)) {
+            return $true
+        }
+        $eventHeadSha = [string]$_['head_sha']
+        $eventData = $_['data']
+        if ([string]::IsNullOrWhiteSpace($eventHeadSha) -and $null -ne $eventData -and $eventData -is [System.Collections.IDictionary] -and $eventData.Contains('head_sha')) {
+            $eventHeadSha = [string]$eventData['head_sha']
+        }
+        return (-not [string]::IsNullOrWhiteSpace($eventHeadSha) -and $eventHeadSha -eq $runHeadSha)
+    } | Sort-Object @{ Expression = { Get-RunEventTimestampSortKey -Value $_['timestamp'] }; Descending = $true }, @{ Expression = { [int]($_['line_number']) }; Descending = $true } | Select-Object -First 1)
     $state = 'required'
     $trigger = 'review_state'
     $draftPrUrl = ''
@@ -5918,6 +6095,7 @@ function New-RunPacketFromRun {
         plan_checkpoints  = @($Run.plan_checkpoints)
         managed_loop      = $Run.managed_loop
         outcome           = $Run.outcome
+        phase_gate        = $Run.phase_gate
         draft_pr_gate     = $Run.draft_pr_gate
         last_event        = [string]$Run.last_event
         last_event_at     = [string]$Run.last_event_at
@@ -5997,6 +6175,7 @@ function New-RunResultPacket {
         plan                  = $Run.plan
         plan_checkpoints      = @($Run.plan_checkpoints)
         outcome               = $Run.outcome
+        phase_gate            = $Run.phase_gate
         draft_pr_gate         = $Run.draft_pr_gate
         recent_events         = @($RecentEvents)
     }
@@ -6400,9 +6579,11 @@ function Get-RunsPayload {
     $runs = @(
         foreach ($runId in @($runsById.Keys)) {
             $run = $runsById[$runId]
+            $runEvents = @($eventRecords | Where-Object { Test-RunMatchesEventRecord -Run $run -EventRecord $_ })
             $run.plan = New-RunPlanContract -Run $run
+            $run.draft_pr_gate = New-RunDraftPrGate -Run $run -EventRecords $runEvents
+            $run.phase_gate = New-RunPhaseGateContract -Run $run -EventRecords $runEvents
             $run.outcome = New-RunOutcomeContract -Run $run
-            $run.draft_pr_gate = New-RunDraftPrGate -Run $run -EventRecords @($eventRecords | Where-Object { Test-RunMatchesEventRecord -Run $run -EventRecord $_ })
             $nextAction = Get-RunNextAction -Run $run
             $stateModel = New-RunStateModel -State ([string]$run.state) -TaskState ([string]$run.task_state) -ReviewState ([string]$run.review_state) -EventKind $nextAction -LastEvent ([string]$run.last_event)
             [ordered]@{
@@ -6455,6 +6636,7 @@ function Get-RunsPayload {
                 plan_checkpoints      = @($run.plan_checkpoints)
                 managed_loop          = $run.managed_loop
                 outcome               = $run.outcome
+                phase_gate            = $run.phase_gate
                 draft_pr_gate         = $run.draft_pr_gate
             }
         }
@@ -6738,6 +6920,7 @@ function Get-RunNextAction {
         'review_failed',
         'task_blocked',
         'blocked',
+        'needs_user_decision',
         'commit_ready',
         'task_completed',
         'review_pending',

--- a/tests/fixtures/rust-parity/explain.json
+++ b/tests/fixtures/rust-parity/explain.json
@@ -135,6 +135,52 @@
       "confidence": 0.66,
       "source_event": "operator.review_requested"
     },
+    "phase_gate": {
+      "order": [
+        "plan",
+        "build",
+        "test",
+        "review",
+        "package"
+      ],
+      "current_stage": "review",
+      "stages": [
+        {
+          "stage": "plan",
+          "status": "completed",
+          "reason": "run_plan_recorded",
+          "event": ""
+        },
+        {
+          "stage": "build",
+          "status": "in_progress",
+          "reason": "in_progress",
+          "event": ""
+        },
+        {
+          "stage": "test",
+          "status": "pending",
+          "reason": "",
+          "event": ""
+        },
+        {
+          "stage": "review",
+          "status": "waiting_for_input",
+          "reason": "review_pending",
+          "event": "operator.review_requested"
+        },
+        {
+          "stage": "package",
+          "status": "pending",
+          "reason": "",
+          "event": ""
+        }
+      ],
+      "stop_required": false,
+      "stop_reason": "",
+      "auto_continue_allowed": true,
+      "requires_human_decision": false
+    },
     "draft_pr_gate": {
       "kind": "human_judgement",
       "target": "draft_pr",

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -8333,7 +8333,15 @@ panes:
         $result.runs[0].managed_loop.escalation_state | Should -Be 'required'
         $result.runs[0].managed_loop.escalation_reason | Should -Be 'VERIFY_PARTIAL'
         $result.runs[0].managed_loop.stages.Count | Should -Be 4
-        $result.runs[0].outcome.status | Should -Be 'in_progress'
+        $result.runs[0].phase_gate.order | Should -Be @('plan', 'build', 'test', 'review', 'package')
+        $result.runs[0].phase_gate.current_stage | Should -Be 'review'
+        $result.runs[0].phase_gate.stop_required | Should -Be $true
+        $result.runs[0].phase_gate.stop_reason | Should -Be 'needs_user_decision'
+        $result.runs[0].phase_gate.auto_continue_allowed | Should -Be $false
+        $result.runs[0].phase_gate.requires_human_decision | Should -Be $true
+        ($result.runs[0].phase_gate.stages | Where-Object { $_.stage -eq 'test' } | Select-Object -First 1).status | Should -Be 'waiting_for_input'
+        ($result.runs[0].phase_gate.stages | Where-Object { $_.stage -eq 'review' } | Select-Object -First 1).reason | Should -Be 'review_pending'
+        $result.runs[0].outcome.status | Should -Be 'needs_user_decision'
         $result.runs[0].outcome.reason | Should -Be 'rerun focused verification'
         $result.runs[0].outcome.confidence | Should -Be 0.72
         $result.runs[0].draft_pr_gate.kind | Should -Be 'human_judgement'
@@ -8350,7 +8358,8 @@ panes:
         $result.runs[0].run_packet.plan_checkpoints.Count | Should -Be 6
         $result.runs[0].run_packet.managed_loop.peer_to_peer_allowed | Should -Be $false
         $result.runs[0].run_packet.managed_loop.assignment_state | Should -Be 'assigned'
-        $result.runs[0].run_packet.outcome.status | Should -Be 'in_progress'
+        $result.runs[0].run_packet.phase_gate.stop_reason | Should -Be 'needs_user_decision'
+        $result.runs[0].run_packet.outcome.status | Should -Be 'needs_user_decision'
         $result.runs[0].run_packet.draft_pr_gate.merge_requires_human | Should -Be $true
         $result.runs[0].run_packet.draft_pr_gate.handoff_package.suggested_next_action | Should -Be 'rerun_verify'
         $result.runs[0].Contains('observation_pack') | Should -Be $false
@@ -8387,6 +8396,146 @@ panes:
         $gate.handoff_package.validation.evidence_complete | Should -Be $false
         $gate.handoff_package.blocked_reasons | Should -Contain 'verification evidence is missing'
         $gate.handoff_package.suggested_next_action | Should -Be 'resolve blocked reasons before creating or merging a draft PR'
+    }
+
+    It 'exposes needs-user-decision as a phase-gated stop before package completion' {
+        $run = [PSCustomObject]@{
+            goal              = 'Ship guarded package'
+            task_state        = 'in_progress'
+            review_state      = 'PASS'
+            verification_plan = @('Invoke-Pester')
+            review_required   = $true
+            changed_files     = @('scripts/winsmux-core.ps1')
+            task              = 'Create guarded package'
+            last_event        = 'operator.draft_pr.required'
+            verification_result = [ordered]@{ outcome = 'PASS'; summary = 'verification passed' }
+            security_verdict  = [ordered]@{ verdict = 'ALLOW'; reason = '' }
+            experiment_packet = $null
+        }
+        $events = @(
+            [ordered]@{ timestamp = '2026-04-10T12:01:00+09:00'; line_number = 1; event = 'pipeline.decompose.completed'; data = [ordered]@{} },
+            [ordered]@{ timestamp = '2026-04-10T12:02:00+09:00'; line_number = 2; event = 'pipeline.collect.completed'; data = [ordered]@{} },
+            [ordered]@{ timestamp = '2026-04-10T12:03:00+09:00'; line_number = 3; event = 'pipeline.verify.pass'; data = [ordered]@{ verification_result = [ordered]@{ outcome = 'PASS' } } },
+            [ordered]@{ timestamp = '2026-04-10T12:04:00+09:00'; line_number = 4; event = 'operator.draft_pr.required'; data = [ordered]@{} }
+        )
+
+        $run | Add-Member -NotePropertyName draft_pr_gate -NotePropertyValue (New-RunDraftPrGate -Run $run -EventRecords $events)
+        $run | Add-Member -NotePropertyName phase_gate -NotePropertyValue (New-RunPhaseGateContract -Run $run -EventRecords $events)
+        $outcome = New-RunOutcomeContract -Run $run
+
+        $run.phase_gate.current_stage | Should -Be 'package'
+        $run.phase_gate.stop_required | Should -Be $true
+        $run.phase_gate.stop_reason | Should -Be 'needs_user_decision'
+        $run.phase_gate.auto_continue_allowed | Should -Be $false
+        ($run.phase_gate.stages | Where-Object { $_.stage -eq 'package' } | Select-Object -First 1).status | Should -Be 'waiting_for_input'
+        ($run.phase_gate.stages | Where-Object { $_.stage -eq 'package' } | Select-Object -First 1).reason | Should -Be 'needs_user_decision'
+        $outcome.status | Should -Be 'needs_user_decision'
+        (Get-InboxActionableEventKind -EventRecord ([ordered]@{ event = 'operator.draft_pr.required'; status = 'blocked_draft_pr_required' })) | Should -Be 'needs_user_decision'
+        $stateModel = New-RunStateModel -EventKind 'needs_user_decision' -LastEvent 'operator.draft_pr.required'
+        $stateModel.phase | Should -Be 'package'
+        $stateModel.activity | Should -Be 'waiting_for_input'
+        $stateModel.detail | Should -Be 'needs_user_decision'
+        $passStateModel = New-RunStateModel -ReviewState 'PASS'
+        $passStateModel.phase | Should -Be 'package'
+        $passStateModel.activity | Should -Be 'waiting_for_input'
+        $passStateModel.detail | Should -Be 'needs_user_decision'
+    }
+
+    It 'clears stale verification stops when later verification passes' {
+        $run = [PSCustomObject]@{
+            goal              = 'Recover guarded package'
+            task_state        = 'in_progress'
+            review_state      = 'PENDING'
+            verification_plan = @('Invoke-Pester')
+            review_required   = $true
+        }
+        $events = @(
+            [ordered]@{ timestamp = '2026-04-10T12:01:00+09:00'; line_number = 1; event = 'pipeline.verify.partial'; data = [ordered]@{} },
+            [ordered]@{ timestamp = '2026-04-10T12:02:00+09:00'; line_number = 2; event = 'pipeline.verify.pass'; data = [ordered]@{ verification_result = [ordered]@{ outcome = 'PASS' } } }
+        )
+
+        $phaseGate = New-RunPhaseGateContract -Run $run -EventRecords $events
+
+        $phaseGate.stop_required | Should -Be $false
+        $phaseGate.stop_reason | Should -Be ''
+        ($phaseGate.stages | Where-Object { $_.stage -eq 'test' } | Select-Object -First 1).status | Should -Be 'completed'
+    }
+
+    It 'ignores stale draft PR evidence that does not match the run head sha' {
+        $run = [PSCustomObject]@{
+            head_sha          = 'current-sha'
+            review_state      = 'PASS'
+            review_required   = $true
+            verification_plan = @('Invoke-Pester')
+            changed_files     = @('scripts/winsmux-core.ps1')
+            task              = 'Create draft package'
+            goal              = 'Create draft package'
+            verification_result = [ordered]@{ outcome = 'PASS'; summary = 'verification passed' }
+            security_verdict  = [ordered]@{ verdict = 'ALLOW'; reason = '' }
+            experiment_packet = $null
+        }
+        $events = @(
+            [ordered]@{
+                timestamp   = '2026-04-10T12:04:00+09:00'
+                line_number = 1
+                event       = 'operator.draft_pr.created'
+                head_sha    = ''
+                data        = [ordered]@{ draft_pr_url = 'https://github.com/Sora-bluesky/winsmux/pull/999' }
+            },
+            [ordered]@{
+                timestamp   = '2026-04-10T12:05:00+09:00'
+                line_number = 2
+                event       = 'operator.draft_pr.created'
+                head_sha    = 'old-sha'
+                data        = [ordered]@{ draft_pr_url = 'https://github.com/Sora-bluesky/winsmux/pull/998' }
+            }
+        )
+
+        $gate = New-RunDraftPrGate -Run $run -EventRecords $events
+        $run | Add-Member -NotePropertyName draft_pr_gate -NotePropertyValue $gate
+        $phaseGate = New-RunPhaseGateContract -Run $run -EventRecords $events
+
+        $gate.state | Should -Be 'required'
+        $gate.draft_pr_url | Should -Be ''
+        $phaseGate.stop_required | Should -Be $true
+        $phaseGate.stop_reason | Should -Be 'needs_user_decision'
+        ($phaseGate.stages | Where-Object { $_.stage -eq 'package' } | Select-Object -First 1).reason | Should -Be 'needs_user_decision'
+    }
+
+    It 'uses the newest same-timestamp draft PR evidence for the run head sha' {
+        $run = [PSCustomObject]@{
+            head_sha            = 'current-sha'
+            review_state        = 'PASS'
+            review_required     = $true
+            verification_plan   = @('Invoke-Pester')
+            changed_files       = @('scripts/winsmux-core.ps1')
+            task                = 'Create draft package'
+            goal                = 'Create draft package'
+            verification_result = [ordered]@{ outcome = 'PASS'; summary = 'verification passed' }
+            security_verdict    = [ordered]@{ verdict = 'ALLOW'; reason = '' }
+            experiment_packet   = $null
+        }
+        $events = @(
+            [ordered]@{
+                timestamp   = '2026-04-10T12:04:00+09:00'
+                line_number = 1
+                event       = 'operator.draft_pr.created'
+                head_sha    = 'current-sha'
+                data        = [ordered]@{ draft_pr_url = 'https://github.com/Sora-bluesky/winsmux/pull/997' }
+            },
+            [ordered]@{
+                timestamp   = '2026-04-10T12:04:00+09:00'
+                line_number = 2
+                event       = 'operator.draft_pr.created'
+                head_sha    = 'current-sha'
+                data        = [ordered]@{ draft_pr_url = 'https://github.com/Sora-bluesky/winsmux/pull/998' }
+            }
+        )
+
+        $gate = New-RunDraftPrGate -Run $run -EventRecords $events
+
+        $gate.state | Should -Be 'passed'
+        $gate.draft_pr_url | Should -Be 'https://github.com/Sora-bluesky/winsmux/pull/998'
     }
 
     It 'supports winsmux runs --json through the top-level CLI entrypoint' {
@@ -9383,7 +9532,12 @@ panes:
         $result.run.plan_checkpoints.Count | Should -Be 3
         @($result.run.plan_checkpoints | ForEach-Object { $_.name }) | Should -Be @('operator.review_requested', 'pipeline.verify.partial', 'pane.approval_waiting')
         $result.run.plan_checkpoints[0].at.ToString('o') | Should -Be '2026-04-10T03:01:00.0000000Z'
-        $result.run.outcome.status | Should -Be 'in_progress'
+        $result.run.phase_gate.order | Should -Be @('plan', 'build', 'test', 'review', 'package')
+        $result.run.phase_gate.current_stage | Should -Be 'review'
+        $result.run.phase_gate.stop_required | Should -Be $true
+        $result.run.phase_gate.stop_reason | Should -Be 'needs_user_decision'
+        $result.run.phase_gate.auto_continue_allowed | Should -Be $false
+        $result.run.outcome.status | Should -Be 'needs_user_decision'
         $result.run.outcome.reason | Should -Be 'rerun focused verification'
         $result.run.outcome.confidence | Should -Be 0.66
         $result.run.draft_pr_gate.kind | Should -Be 'human_judgement'


### PR DESCRIPTION
## Summary
- Add phase_gate to run projections, explain payloads, and run packets.
- Model the plan/build/test/review/package stages and stop reasons.
- Treat draft PR stops and partial verification as needs_user_decision.
- Ignore stale draft PR evidence when head_sha does not match.
- Align PowerShell and Rust handling for review_state=PASS and same-timestamp draft PR evidence.

## Validation
- PowerShell parser check for scripts/winsmux-core.ps1: passed
- Targeted Pester for phase gate and stale draft PR evidence: passed
- Targeted Pester for review fixes: passed
- Invoke-Pester -Path tests/winsmux-bridge.Tests.ps1 -Output Detailed: 384 passed
- cargo test --manifest-path core/Cargo.toml --test ledger_contract -- --nocapture: 66 passed
- cargo test --manifest-path core/Cargo.toml fixture_comparison -- --nocapture: 5 passed
- cmd /c npm run build in winsmux-app: passed
- git diff --check: passed
- scripts/audit-public-surface.ps1: passed
- scripts/git-guard.ps1: passed
- External Rust learning note Opus review: PASS after explicit user approval