### PR TITLE
feat: add verification evidence envelope

### DIFF
--- a/core/src/ledger.rs
+++ b/core/src/ledger.rs
@@ -275,6 +275,7 @@ pub struct LedgerExplainRun {
     pub security_verdict: Value,
     pub verification_contract: Value,
     pub verification_result: Value,
+    pub verification_evidence: Value,
     pub tdd_gate: Value,
     pub outcome: Value,
     pub phase_gate: Value,
@@ -467,6 +468,7 @@ pub struct LedgerRunProjection {
     pub security_verdict: Value,
     pub verification_contract: Value,
     pub verification_result: Value,
+    pub verification_evidence: Value,
     pub tdd_gate: Value,
     pub outcome: Value,
     pub phase_gate: Value,
@@ -510,6 +512,7 @@ pub struct LedgerRunPacket {
     pub security_verdict: Value,
     pub verification_contract: Value,
     pub verification_result: Value,
+    pub verification_evidence: Value,
     pub tdd_gate: Value,
     pub outcome: Value,
     pub phase_gate: Value,
@@ -719,6 +722,9 @@ impl LedgerRunProjection {
             verification_result: run
                 .map(|run| run.verification_result.clone())
                 .unwrap_or(Value::Null),
+            verification_evidence: run
+                .map(|run| run.verification_evidence.clone())
+                .unwrap_or(Value::Null),
             tdd_gate: run.map(|run| run.tdd_gate.clone()).unwrap_or(Value::Null),
             outcome: run.map(|run| run.outcome.clone()).unwrap_or(Value::Null),
             phase_gate: run.map(|run| run.phase_gate.clone()).unwrap_or(Value::Null),
@@ -767,6 +773,7 @@ impl LedgerRunPacket {
             security_verdict: run.security_verdict.clone(),
             verification_contract: run.verification_contract.clone(),
             verification_result: run.verification_result.clone(),
+            verification_evidence: run.verification_evidence.clone(),
             tdd_gate: run.tdd_gate.clone(),
             outcome: run.outcome.clone(),
             phase_gate: run.phase_gate.clone(),
@@ -1220,6 +1227,7 @@ impl LedgerSnapshot {
             first_event_value(&recent_events, |event| event.verification_contract.clone());
         let verification_result =
             first_event_value(&recent_events, |event| event.verification_result.clone());
+        let verification_evidence = verification_evidence_from_event_records(&recent_event_records);
 
         let mut labels = unique_sorted(panes.iter().map(|pane| pane.label.as_str()));
         let mut pane_ids = unique_sorted(panes.iter().map(|pane| pane.pane_id.as_str()));
@@ -1279,6 +1287,7 @@ impl LedgerSnapshot {
             security_verdict,
             verification_contract,
             verification_result,
+            verification_evidence,
             tdd_gate: Value::Null,
             outcome: Value::Null,
             phase_gate: Value::Null,
@@ -2513,6 +2522,50 @@ fn event_data_value(data: &Value, key: &str) -> Value {
         .and_then(|map| map.get(key))
         .cloned()
         .unwrap_or(Value::Null)
+}
+
+fn verification_evidence_from_event_records(events: &[(usize, &EventRecord)]) -> Value {
+    events
+        .iter()
+        .filter(|(_, event)| is_verification_event(&event.event))
+        .map(|(_, event)| verification_evidence_value(&event.data))
+        .find(|value| !value.is_null())
+        .unwrap_or(Value::Null)
+}
+
+fn verification_evidence_value(data: &Value) -> Value {
+    if !data.is_object() {
+        return Value::Null;
+    }
+
+    json!({
+        "build": verification_evidence_field(data, "build"),
+        "test": verification_evidence_field(data, "test"),
+        "browser": verification_evidence_field(data, "browser"),
+        "screenshot": verification_evidence_field(data, "screenshot"),
+        "recording": verification_evidence_field(data, "recording"),
+        "context_budget": verification_evidence_field(data, "context_budget"),
+        "context_estimate": verification_evidence_field(data, "context_estimate"),
+        "context_pack_id": verification_evidence_field(data, "context_pack_id"),
+        "tool_output_pruned_count": verification_evidence_field(data, "tool_output_pruned_count"),
+        "context_pressure": verification_evidence_field(data, "context_pressure"),
+    })
+}
+
+fn verification_evidence_field(data: &Value, key: &str) -> Value {
+    for container_name in ["verification_evidence", "verification_result", "verification_contract"] {
+        let nested = data
+            .as_object()
+            .and_then(|map| map.get(container_name))
+            .and_then(|container| container.as_object())
+            .and_then(|container| container.get(key))
+            .cloned();
+        if let Some(value) = nested {
+            return value;
+        }
+    }
+
+    event_data_value(data, key)
 }
 
 fn event_data_string_list_option(data: &Value, key: &str) -> Option<Vec<String>> {

--- a/core/tests-rs/fixture_comparison.rs
+++ b/core/tests-rs/fixture_comparison.rs
@@ -241,6 +241,7 @@ const EXPLAIN_RUN_KEYS: &[&str] = &[
     "security_verdict",
     "verification_contract",
     "verification_result",
+    "verification_evidence",
     "tdd_gate",
     "outcome",
     "phase_gate",

--- a/core/tests-rs/ledger_contract.rs
+++ b/core/tests-rs/ledger_contract.rs
@@ -605,7 +605,7 @@ panes:
     head_sha: abc1234def5678
 "#;
     let events = r#"{"timestamp":"2026-04-23T12:00:01+09:00","session":"winsmux-orchestra","event":"pane.approval_waiting","message":"approval prompt detected","label":"builder-1","pane_id":"%2","role":"Builder","status":"approval_waiting","data":{"task_id":"task-256"}}
-{"timestamp":"2026-04-23T12:00:02+09:00","session":"winsmux-orchestra","event":"pipeline.verify.pass","message":"verification passed","data":{"task_id":"task-256","verification_contract":{"command":"cargo test"},"verification_result":{"outcome":"PASS"}}}
+{"timestamp":"2026-04-23T12:00:02+09:00","session":"winsmux-orchestra","event":"pipeline.verify.pass","message":"verification passed","data":{"task_id":"task-256","verification_contract":{"command":"cargo test","build":{"command":"cargo build","outcome":"PASS"},"test":{"command":"cargo test","outcome":"PASS"},"context_budget":120000,"context_estimate":42000,"context_pack_id":"ctx-task-256","tool_output_pruned_count":2,"context_pressure":"medium"},"verification_result":{"outcome":"PASS","browser":{"required":false,"outcome":"SKIPPED"},"screenshot":{"required":false,"artifact_ref":""},"recording":{"required":false,"artifact_ref":""}}}}
 {"timestamp":"2026-04-23T12:00:03+09:00","session":"winsmux-orchestra","event":"pipeline.security.allowed","message":"security allowed","data":{"task_id":"task-256","verdict":"ALLOW"}}
 {"timestamp":"2026-04-23T12:00:04+09:00","session":"winsmux-orchestra","event":"pane.consult_result","message":"experiment result","label":"builder-1","pane_id":"%2","role":"Builder","data":{"task_id":"task-256","hypothesis":"projection can explain the run","test_plan":["load manifest","match events"],"result":"explain payload built","confidence":0.66,"next_action":"approval_waiting","observation_pack_ref":"observations/task-256.json","consultation_ref":"consultations/task-256.json","run_id":"task:task-256","slot":"builder-1","worktree":".worktrees/builder-1","env_fingerprint":"env-123","command_hash":"cmd-456","observation_pack":{"summary":"ok"},"consultation_packet":{"review":"ok"}}}
 {"timestamp":"2026-04-23T12:00:05+09:00","session":"winsmux-orchestra","event":"pane.consult_request","message":"new action only","label":"builder-1","pane_id":"%2","role":"Builder","data":{"task_id":"task-256","next_action":"review_requested"}}
@@ -668,6 +668,26 @@ panes:
         "git reset --hard"
     );
     assert_eq!(explain.run.verification_result["outcome"], "PASS");
+    assert_eq!(explain.run.verification_evidence["build"]["command"], "cargo build");
+    assert_eq!(explain.run.verification_evidence["test"]["outcome"], "PASS");
+    assert_eq!(
+        explain.run.verification_evidence["browser"]["outcome"],
+        "SKIPPED"
+    );
+    assert_eq!(explain.run.verification_evidence["context_budget"], 120000);
+    assert_eq!(explain.run.verification_evidence["context_estimate"], 42000);
+    assert_eq!(
+        explain.run.verification_evidence["context_pack_id"],
+        "ctx-task-256"
+    );
+    assert_eq!(
+        explain.run.verification_evidence["tool_output_pruned_count"],
+        2
+    );
+    assert_eq!(
+        explain.run.verification_evidence["context_pressure"],
+        "medium"
+    );
     assert_eq!(explain.run.security_verdict, "ALLOW");
 }
 

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -5448,7 +5448,7 @@ function Get-VerificationSnapshotFromEventRecords {
     $snapshot = Get-LatestRunEventDataSnapshot `
         -EventRecords $EventRecords `
         -EventNames @('pipeline.verify.pass', 'pipeline.verify.fail', 'pipeline.verify.partial') `
-        -DataFields @('verification_contract', 'verification_result')
+        -DataFields @('verification_contract', 'verification_result', 'verification_evidence', 'build', 'test', 'browser', 'screenshot', 'recording', 'context_budget', 'context_estimate', 'context_pack_id', 'tool_output_pruned_count', 'context_pressure')
     if ($null -eq $snapshot) {
         return $null
     }
@@ -5456,6 +5456,54 @@ function Get-VerificationSnapshotFromEventRecords {
     return [ordered]@{
         verification_contract = if ($snapshot.Contains('verification_contract')) { $snapshot['verification_contract'] } else { $null }
         verification_result   = if ($snapshot.Contains('verification_result')) { $snapshot['verification_result'] } else { $null }
+        verification_evidence = New-VerificationEvidenceEnvelope -Snapshot $snapshot
+    }
+}
+
+function Get-VerificationEvidenceField {
+    param(
+        [AllowNull()]$Snapshot = $null,
+        [Parameter(Mandatory = $true)][string]$Name
+    )
+
+    if ($null -eq $Snapshot -or -not ($Snapshot -is [System.Collections.IDictionary])) {
+        return $null
+    }
+
+    foreach ($containerName in @('verification_evidence', 'verification_result', 'verification_contract')) {
+        if ($Snapshot.Contains($containerName)) {
+            $container = $Snapshot[$containerName]
+            if ($container -is [System.Collections.IDictionary] -and $container.Contains($Name)) {
+                return $container[$Name]
+            }
+        }
+    }
+
+    if ($Snapshot.Contains($Name)) {
+        return $Snapshot[$Name]
+    }
+
+    return $null
+}
+
+function New-VerificationEvidenceEnvelope {
+    param([AllowNull()]$Snapshot = $null)
+
+    if ($null -eq $Snapshot -or -not ($Snapshot -is [System.Collections.IDictionary])) {
+        return $null
+    }
+
+    return [ordered]@{
+        build                    = Get-VerificationEvidenceField -Snapshot $Snapshot -Name 'build'
+        test                     = Get-VerificationEvidenceField -Snapshot $Snapshot -Name 'test'
+        browser                  = Get-VerificationEvidenceField -Snapshot $Snapshot -Name 'browser'
+        screenshot               = Get-VerificationEvidenceField -Snapshot $Snapshot -Name 'screenshot'
+        recording                = Get-VerificationEvidenceField -Snapshot $Snapshot -Name 'recording'
+        context_budget           = Get-VerificationEvidenceField -Snapshot $Snapshot -Name 'context_budget'
+        context_estimate         = Get-VerificationEvidenceField -Snapshot $Snapshot -Name 'context_estimate'
+        context_pack_id          = Get-VerificationEvidenceField -Snapshot $Snapshot -Name 'context_pack_id'
+        tool_output_pruned_count = Get-VerificationEvidenceField -Snapshot $Snapshot -Name 'tool_output_pruned_count'
+        context_pressure         = Get-VerificationEvidenceField -Snapshot $Snapshot -Name 'context_pressure'
     }
 }
 
@@ -6228,6 +6276,7 @@ function New-RunPacketFromRun {
         security_verdict  = $Run.security_verdict
         verification_contract = $Run.verification_contract
         verification_result   = $Run.verification_result
+        verification_evidence = $Run.verification_evidence
         tdd_gate              = $Run.tdd_gate
         plan              = $Run.plan
         plan_checkpoints  = @($Run.plan_checkpoints)
@@ -6308,6 +6357,7 @@ function New-RunResultPacket {
         review_contract       = $reviewContract
         verification_contract = $Run.verification_contract
         verification_result   = $Run.verification_result
+        verification_evidence = $Run.verification_evidence
         tdd_gate              = $Run.tdd_gate
         security_policy       = $Run.security_policy
         security_verdict      = $Run.security_verdict
@@ -6560,6 +6610,7 @@ function Get-RunsPayload {
                 security_verdict   = $null
                 verification_contract = $null
                 verification_result   = $null
+                verification_evidence = $null
                 plan                  = $null
                 plan_checkpoints      = @()
                 managed_loop          = $null
@@ -6705,6 +6756,7 @@ function Get-RunsPayload {
             if ($null -ne $verificationSnapshot) {
                 $run.verification_contract = $verificationSnapshot.verification_contract
                 $run.verification_result = $verificationSnapshot.verification_result
+                $run.verification_evidence = $verificationSnapshot.verification_evidence
             }
 
             $securityVerdict = Get-SecurityVerdictFromEventRecords -EventRecords $matchingEvents
@@ -6773,6 +6825,7 @@ function Get-RunsPayload {
                 security_verdict   = $run.security_verdict
                 verification_contract = $run.verification_contract
                 verification_result   = $run.verification_result
+                verification_evidence = $run.verification_evidence
                 tdd_gate              = $run.tdd_gate
                 plan                  = $run.plan
                 plan_checkpoints      = @($run.plan_checkpoints)
@@ -7029,6 +7082,7 @@ function Get-PromoteTacticPayload {
         observation_pack_ref = if ($null -ne $experimentPacket) { [string]$experimentPacket.observation_pack_ref } else { '' }
         consultation_ref     = if ($null -ne $experimentPacket) { [string]$experimentPacket.consultation_ref } else { '' }
         verification_result  = $run.verification_result
+        verification_evidence = $run.verification_evidence
         security_verdict     = $run.security_verdict
         action_item_count    = @($run.action_items).Count
         action_item_kinds    = @($run.action_items | ForEach-Object { [string]$_.kind } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)

--- a/tests/fixtures/rust-parity/explain.json
+++ b/tests/fixtures/rust-parity/explain.json
@@ -96,6 +96,7 @@
     "security_verdict": null,
     "verification_contract": null,
     "verification_result": null,
+    "verification_evidence": null,
     "tdd_gate": {
       "policy": "test_first_required",
       "required": true,

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -1618,6 +1618,12 @@ NEXT_ACTION: rerun focused verification
         $result.checks[0].status | Should -Be 'PASS'
         $result.next_action | Should -Be 'rerun focused verification'
         $result.adversarial | Should -Be $true
+
+        $envelope = New-TeamPipelineVerificationEvidenceEnvelope -VerificationResult $result
+        $envelope.context_pack_id | Should -BeNullOrEmpty
+        $envelope.context_pressure | Should -BeNullOrEmpty
+        $envelope.context_pack_id | Should -Be $null
+        $envelope.context_pressure | Should -Be $null
     }
 
     It 'detects approval prompts and blocks dangerous confirmations' {
@@ -1939,7 +1945,27 @@ NEXT_ACTION: rerun focused verification
                 'PLAN'          { return [PSCustomObject]@{ Stage = $StageName; Target = $Target; Status = 'PLAN_DONE'; Summary = 'plan summary'; Transcript = '' } }
                 'CONSULT_EARLY' { return [PSCustomObject]@{ Stage = $StageName; Target = $Target; Status = 'CONSULT_DONE'; Summary = 'early consult summary'; Transcript = '' } }
                 'EXEC'          { return [PSCustomObject]@{ Stage = $StageName; Target = $Target; Status = 'EXEC_DONE'; Summary = 'build summary'; Transcript = '' } }
-                'VERIFY'        { return [PSCustomObject]@{ Stage = $StageName; Target = $Target; Status = 'VERIFY_PASS'; Summary = 'verify summary'; Transcript = '' } }
+                'VERIFY'        {
+                    return [PSCustomObject]@{
+                        Stage = $StageName
+                        Target = $Target
+                        Status = 'VERIFY_PASS'
+                        Summary = @'
+SUMMARY: verify summary
+STATUS: VERIFY_PASS
+CHECK: build|PASS|npm run build
+CHECK: test|PASS|Invoke-Pester tests/winsmux-bridge.Tests.ps1
+CHECK: browser|SKIP|not a UI change
+CONTEXT_BUDGET: 120000
+CONTEXT_ESTIMATE: 42000
+CONTEXT_PACK_ID: ctx-pipeline
+TOOL_OUTPUT_PRUNED_COUNT: 2
+CONTEXT_PRESSURE: medium
+NEXT_ACTION: ready_for_done
+'@
+                        Transcript = ''
+                    }
+                }
                 'CONSULT_FINAL' { return [PSCustomObject]@{ Stage = $StageName; Target = $Target; Status = 'CONSULT_DONE'; Summary = 'final consult summary'; Transcript = '' } }
                 default         { throw "Unexpected stage $StageName" }
             }
@@ -1989,6 +2015,14 @@ NEXT_ACTION: rerun focused verification
 
         $verifyResult = @($script:teamPipelineEvents | Where-Object { $_.Event -eq 'pipeline.verify.pass' })[0]
         $verifyResult.Data.cost_unit_refs[0] | Should -Be $verifyDispatch.Data.governance_cost_units[0].unit_id
+        $verifyResult.Data.verification_evidence.build.outcome | Should -Be 'PASS'
+        $verifyResult.Data.verification_evidence.test.detail | Should -Be 'Invoke-Pester tests/winsmux-bridge.Tests.ps1'
+        $verifyResult.Data.verification_evidence.browser.outcome | Should -Be 'SKIP'
+        $verifyResult.Data.verification_evidence.context_budget | Should -Be 120000
+        $verifyResult.Data.verification_evidence.context_estimate | Should -Be 42000
+        $verifyResult.Data.verification_evidence.context_pack_id | Should -Be 'ctx-pipeline'
+        $verifyResult.Data.verification_evidence.tool_output_pruned_count | Should -Be 2
+        $verifyResult.Data.verification_evidence.context_pressure | Should -Be 'medium'
     }
 
     It 'inserts a stuck consult before returning blocked execution' {
@@ -9543,14 +9577,24 @@ panes:
                     run_id  = 'task:task-256'
                     verification_contract = [ordered]@{
                         mode = 'adversarial_verify'
+                        build = [ordered]@{ command = 'npm run build'; outcome = 'PASS' }
+                        test = [ordered]@{ command = 'Invoke-Pester tests/winsmux-bridge.Tests.ps1'; outcome = 'PARTIAL' }
+                        context_budget = 120000
+                        context_estimate = 42000
+                        context_pack_id = 'ctx-task-256'
+                        tool_output_pruned_count = 2
+                        context_pressure = 'medium'
                     }
                     verification_result = [ordered]@{
                         outcome = 'PARTIAL'
                         summary = 'rerun focused verification'
                         next_action = 'rerun_verify'
+                        browser = [ordered]@{ required = $false; outcome = 'SKIPPED' }
+                        screenshot = [ordered]@{ required = $false; artifact_ref = '' }
+                        recording = [ordered]@{ required = $false; artifact_ref = '' }
                     }
                 }
-            } | ConvertTo-Json -Compress),
+            } | ConvertTo-Json -Compress -Depth 8),
             ([ordered]@{
             timestamp = '2026-04-10T12:02:15+09:00'
             session   = 'winsmux-orchestra'
@@ -9671,6 +9715,14 @@ panes:
         $result.run.experiment_packet.command_hash | Should -Be 'cmd:def456'
         $result.run.verification_contract.mode | Should -Be 'adversarial_verify'
         $result.run.verification_result.outcome | Should -Be 'PARTIAL'
+        $result.run.verification_evidence.build.command | Should -Be 'npm run build'
+        $result.run.verification_evidence.test.outcome | Should -Be 'PARTIAL'
+        $result.run.verification_evidence.browser.outcome | Should -Be 'SKIPPED'
+        $result.run.verification_evidence.context_budget | Should -Be 120000
+        $result.run.verification_evidence.context_estimate | Should -Be 42000
+        $result.run.verification_evidence.context_pack_id | Should -Be 'ctx-task-256'
+        $result.run.verification_evidence.tool_output_pruned_count | Should -Be 2
+        $result.run.verification_evidence.context_pressure | Should -Be 'medium'
         $result.run.tdd_gate.required | Should -Be $true
         $result.run.tdd_gate.state | Should -Be 'passed'
         $result.run.tdd_gate.red_event | Should -Be 'pipeline.tdd.red'

--- a/winsmux-core/scripts/team-pipeline.ps1
+++ b/winsmux-core/scripts/team-pipeline.ps1
@@ -537,6 +537,36 @@ function Get-TeamPipelineVerificationResultFromOutput {
         $nextAction = $nextActionMatches[$nextActionMatches.Count - 1].Groups[1].Value.Trim()
     }
 
+    $contextBudget = $null
+    $contextBudgetMatches = [regex]::Matches($Text, '(?im)^\s*CONTEXT_BUDGET:\s*(\d+)\s*$')
+    if ($contextBudgetMatches.Count -gt 0) {
+        $contextBudget = [int64]$contextBudgetMatches[$contextBudgetMatches.Count - 1].Groups[1].Value
+    }
+
+    $contextEstimate = $null
+    $contextEstimateMatches = [regex]::Matches($Text, '(?im)^\s*CONTEXT_ESTIMATE:\s*(\d+)\s*$')
+    if ($contextEstimateMatches.Count -gt 0) {
+        $contextEstimate = [int64]$contextEstimateMatches[$contextEstimateMatches.Count - 1].Groups[1].Value
+    }
+
+    $contextPackId = $null
+    $contextPackMatches = [regex]::Matches($Text, '(?im)^\s*CONTEXT_PACK_ID:\s*(.+?)\s*$')
+    if ($contextPackMatches.Count -gt 0) {
+        $contextPackId = $contextPackMatches[$contextPackMatches.Count - 1].Groups[1].Value.Trim()
+    }
+
+    $toolOutputPrunedCount = $null
+    $toolOutputPrunedMatches = [regex]::Matches($Text, '(?im)^\s*TOOL_OUTPUT_PRUNED_COUNT:\s*(\d+)\s*$')
+    if ($toolOutputPrunedMatches.Count -gt 0) {
+        $toolOutputPrunedCount = [int64]$toolOutputPrunedMatches[$toolOutputPrunedMatches.Count - 1].Groups[1].Value
+    }
+
+    $contextPressure = $null
+    $contextPressureMatches = [regex]::Matches($Text, '(?im)^\s*CONTEXT_PRESSURE:\s*(.+?)\s*$')
+    if ($contextPressureMatches.Count -gt 0) {
+        $contextPressure = $contextPressureMatches[$contextPressureMatches.Count - 1].Groups[1].Value.Trim()
+    }
+
     $outcome = switch ($status) {
         'VERIFY_PASS' { 'PASS' }
         'VERIFY_FAIL' { 'FAIL' }
@@ -551,6 +581,76 @@ function Get-TeamPipelineVerificationResultFromOutput {
         checks      = @($checks)
         next_action = $nextAction
         adversarial = $true
+        context_budget = $contextBudget
+        context_estimate = $contextEstimate
+        context_pack_id = $contextPackId
+        tool_output_pruned_count = $toolOutputPrunedCount
+        context_pressure = $contextPressure
+    }
+}
+
+function Get-TeamPipelineVerificationSurface {
+    param(
+        [AllowNull()]$VerificationResult = $null,
+        [Parameter(Mandatory = $true)][string]$Name
+    )
+
+    if ($null -eq $VerificationResult) {
+        return $null
+    }
+
+    $checks = @(Get-TeamPipelineVerificationResultField -VerificationResult $VerificationResult -Name 'checks')
+    $matches = @($checks | Where-Object {
+            $checkName = if ($_ -is [System.Collections.IDictionary] -and $_.Contains('name')) { [string]$_['name'] } else { [string]$_.name }
+            $checkName.Trim().ToLowerInvariant() -eq $Name
+        })
+    if ($matches.Count -lt 1) {
+        return $null
+    }
+    $match = $matches[0]
+
+    $matchName = if ($match -is [System.Collections.IDictionary] -and $match.Contains('name')) { [string]$match['name'] } else { [string]$match.name }
+    $matchStatus = if ($match -is [System.Collections.IDictionary] -and $match.Contains('status')) { [string]$match['status'] } else { [string]$match.status }
+    $matchDetail = if ($match -is [System.Collections.IDictionary] -and $match.Contains('detail')) { [string]$match['detail'] } else { [string]$match.detail }
+
+    return [PSCustomObject][ordered]@{
+        name = $matchName
+        outcome = $matchStatus
+        detail = $matchDetail
+    }
+}
+
+function Get-TeamPipelineVerificationResultField {
+    param(
+        [AllowNull()]$VerificationResult = $null,
+        [Parameter(Mandatory = $true)][string]$Name
+    )
+
+    if ($null -eq $VerificationResult) {
+        return $null
+    }
+
+    if ($VerificationResult -is [System.Collections.IDictionary] -and $VerificationResult.Contains($Name)) {
+        return $VerificationResult[$Name]
+    }
+
+    return $VerificationResult.$Name
+}
+
+function New-TeamPipelineVerificationEvidenceEnvelope {
+    param([AllowNull()]$VerificationResult = $null)
+
+    return [ordered]@{
+        build                    = Get-TeamPipelineVerificationSurface -VerificationResult $VerificationResult -Name 'build'
+        test                     = Get-TeamPipelineVerificationSurface -VerificationResult $VerificationResult -Name 'test'
+        browser                  = Get-TeamPipelineVerificationSurface -VerificationResult $VerificationResult -Name 'browser'
+        screenshot               = Get-TeamPipelineVerificationSurface -VerificationResult $VerificationResult -Name 'screenshot'
+        recording                = Get-TeamPipelineVerificationSurface -VerificationResult $VerificationResult -Name 'recording'
+        context_budget           = Get-TeamPipelineVerificationResultField -VerificationResult $VerificationResult -Name 'context_budget'
+        context_estimate         = Get-TeamPipelineVerificationResultField -VerificationResult $VerificationResult -Name 'context_estimate'
+        context_pack_id          = Get-TeamPipelineVerificationResultField -VerificationResult $VerificationResult -Name 'context_pack_id'
+        tool_output_pruned_count = Get-TeamPipelineVerificationResultField -VerificationResult $VerificationResult -Name 'tool_output_pruned_count'
+        context_pressure         = Get-TeamPipelineVerificationResultField -VerificationResult $VerificationResult -Name 'context_pressure'
     }
 }
 
@@ -562,6 +662,8 @@ function New-TeamPipelineVerificationContract {
         style            = 'utility_first'
         allowed_outcomes = @('PASS', 'FAIL', 'PARTIAL')
         required_fields  = @('summary', 'checks', 'next_action')
+        evidence_surfaces = @('build', 'test', 'browser', 'screenshot', 'recording')
+        context_fields    = @('context_budget', 'context_estimate', 'context_pack_id', 'tool_output_pruned_count', 'context_pressure')
         rationale        = 'Verification specialists must return concise structured evidence instead of decorative prose.'
     }
 }
@@ -877,11 +979,13 @@ function New-TeamPipelineVerificationPacket {
     }
     $changedPaths = Get-TeamPipelineChangedPaths -BuilderWorktreePath $BuilderWorktreePath
     $policy = Get-TeamPipelineRunPolicy -StageName 'VERIFY'
+    $verificationEvidence = New-TeamPipelineVerificationEvidenceEnvelope -VerificationResult $verificationResult
 
     return [PSCustomObject]@{
         packet_type        = 'verification_packet'
         verification_contract = [PSCustomObject](New-TeamPipelineVerificationContract)
         verification_result = if ($null -ne $verificationResult) { [PSCustomObject]$verificationResult } else { $null }
+        verification_evidence = [PSCustomObject]$verificationEvidence
         style              = 'utility_first'
         task               = $Task
         verifier           = $VerifierLabel
@@ -1589,6 +1693,7 @@ function Invoke-TeamPipeline {
             style             = $attempt.VerifyPacket.style
             verification_contract = $attempt.VerifyPacket.verification_contract
             verification_result = $attempt.VerifyPacket.verification_result
+            verification_evidence = $attempt.VerifyPacket.verification_evidence
         }
         if ($verifyCostUnitDispatched) {
             $verifyEventData['cost_unit_refs'] = @([string]$verifyCostUnit.unit_id)


### PR DESCRIPTION
## Summary

- Add a normalized `verification_evidence` envelope to run, runs, and explain projections.
- Carry build/test/browser/screenshot/recording evidence from `team-pipeline` verify output.
- Record context telemetry fields: `context_budget`, `context_estimate`, `context_pack_id`, `tool_output_pruned_count`, and `context_pressure`.
- Preserve backward compatibility by keeping missing optional context fields as `null`.

## Validation

- `Invoke-Pester -Path tests\winsmux-bridge.Tests.ps1 -Output Detailed` passed: 388 passed, 0 failed.
- `cargo test -p winsmux --test ledger_contract -- --nocapture` passed: 69 passed, 0 failed.
- `cargo test -p winsmux --test fixture_comparison -- --nocapture` passed: 27 passed, 0 failed.
- `git diff --check` passed with line-ending warnings only.
- `pre-commit` git-guard passed.
- `pre-push` git-guard, public surface audit, and gitleaks passed.

## Review Notes

- Subagent review found that missing optional context fields were coerced to empty strings in `team-pipeline`.
- The issue is fixed; missing optional context fields now remain `null`.
- The external Rust learning-note update passed the required Opus readability review.

Task: `TASK-321`
Issue: #675
