### PR TITLE
ci: move npm release workflow to Node 24

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -23,9 +23,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Stage npm package
         id: stage
@@ -63,9 +63,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           registry-url: "https://registry.npmjs.org"
 
       - name: Stage npm package


### PR DESCRIPTION
## Summary

- Update the npm release workflow from `actions/setup-node@v4` to `actions/setup-node@v6`.
- Run npm verify and publish jobs on Node.js 24.
- Keep staging, dry-run verification, publish command, and `NODE_AUTH_TOKEN` handling unchanged.

## Validation

- Confirmed no remaining `actions/setup-node@v4` or `node-version: 22` in `.github/workflows`.
- `node --version` returned `v24.13.0`.
- `node scripts/stage-npm-release.mjs --version 0.24.10 --out .tmp/npm-release-check/winsmux` passed.
- `node .tmp\npm-release-check\winsmux\index.mjs help` passed.
- `npm pack --dry-run` passed in the staged package directory.
- `git diff --check` passed with line-ending warnings only.
- `pre-commit` git-guard passed.
- `pre-push` git-guard, public surface audit, and gitleaks passed.

## Review Notes

- Subagent review found no high-risk issue. It confirmed the publish path and `NODE_AUTH_TOKEN` handling are unchanged.
- Official context used: `actions/setup-node@v6` runs on Node 24, and GitHub Actions will begin using Node 24 by default on 2026-06-02.

Task: `TASK-410`
Issue: #704
