### PR TITLE
feat: add audit chain projection

### DIFF
--- a/core/src/ledger.rs
+++ b/core/src/ledger.rs
@@ -1,5 +1,6 @@
 use crate::event_contract::{parse_event_jsonl, EventRecord};
 use crate::manifest_contract::{NormalizedManifestPane, WinsmuxManifest};
+use chrono::{DateTime, SecondsFormat, Utc};
 use serde::Serialize;
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
@@ -277,6 +278,7 @@ pub struct LedgerExplainRun {
     pub verification_result: Value,
     pub verification_evidence: Value,
     pub tdd_gate: Value,
+    pub audit_chain: Value,
     pub outcome: Value,
     pub phase_gate: Value,
     pub draft_pr_gate: Value,
@@ -470,6 +472,7 @@ pub struct LedgerRunProjection {
     pub verification_result: Value,
     pub verification_evidence: Value,
     pub tdd_gate: Value,
+    pub audit_chain: Value,
     pub outcome: Value,
     pub phase_gate: Value,
     pub draft_pr_gate: Value,
@@ -514,6 +517,7 @@ pub struct LedgerRunPacket {
     pub verification_result: Value,
     pub verification_evidence: Value,
     pub tdd_gate: Value,
+    pub audit_chain: Value,
     pub outcome: Value,
     pub phase_gate: Value,
     pub draft_pr_gate: Value,
@@ -726,6 +730,9 @@ impl LedgerRunProjection {
                 .map(|run| run.verification_evidence.clone())
                 .unwrap_or(Value::Null),
             tdd_gate: run.map(|run| run.tdd_gate.clone()).unwrap_or(Value::Null),
+            audit_chain: run
+                .map(|run| run.audit_chain.clone())
+                .unwrap_or(Value::Null),
             outcome: run.map(|run| run.outcome.clone()).unwrap_or(Value::Null),
             phase_gate: run.map(|run| run.phase_gate.clone()).unwrap_or(Value::Null),
             draft_pr_gate: run
@@ -775,6 +782,7 @@ impl LedgerRunPacket {
             verification_result: run.verification_result.clone(),
             verification_evidence: run.verification_evidence.clone(),
             tdd_gate: run.tdd_gate.clone(),
+            audit_chain: run.audit_chain.clone(),
             outcome: run.outcome.clone(),
             phase_gate: run.phase_gate.clone(),
             draft_pr_gate: run.draft_pr_gate.clone(),
@@ -1289,6 +1297,7 @@ impl LedgerSnapshot {
             verification_result,
             verification_evidence,
             tdd_gate: Value::Null,
+            audit_chain: Value::Null,
             outcome: Value::Null,
             phase_gate: Value::Null,
             draft_pr_gate: Value::Null,
@@ -1297,6 +1306,7 @@ impl LedgerSnapshot {
         run.draft_pr_gate = run_draft_pr_gate_value(&run, &recent_event_records);
         run.tdd_gate = run_tdd_gate_value(&run, &recent_event_records);
         run.phase_gate = run_phase_gate_value(&run, &recent_event_records, &run.draft_pr_gate);
+        run.audit_chain = run_audit_chain_value(&run, &recent_event_records);
         run.outcome = run_outcome_value(&run, &run.phase_gate, &run.draft_pr_gate);
         let explanation = explain_explanation(&run, &evidence_digest);
 
@@ -2451,6 +2461,161 @@ fn run_draft_pr_handoff_package_value(run: &LedgerExplainRun, draft_pr_url: &str
         "human_judgement_required": true,
         "automatic_merge_allowed": false,
     })
+}
+
+fn run_audit_chain_value(run: &LedgerExplainRun, events: &[(usize, &EventRecord)]) -> Value {
+    let mut ordered_events = events.to_vec();
+    ordered_events.sort_by(|(left_index, left), (right_index, right)| {
+        left.timestamp
+            .cmp(&right.timestamp)
+            .then_with(|| left_index.cmp(right_index))
+    });
+    let review_request = ordered_events
+        .iter()
+        .map(|(_, event)| *event)
+        .find(|event| event.event == "operator.review_requested");
+    let decision_event = run_audit_chain_decision_event(run, &ordered_events);
+    let chain_events: Vec<_> = ordered_events
+        .iter()
+        .filter(|(_, event)| is_audit_chain_event(&event.event))
+        .map(|(_, event)| audit_chain_event_value(event))
+        .collect();
+
+    json!({
+        "chain_id": run.run_id,
+        "subject": {
+            "task_id": run.task_id,
+            "task": run.task,
+            "task_type": run.task_type,
+            "priority": run.priority,
+            "branch": run.branch,
+            "head_sha": run.head_sha,
+            "changed_files": run.changed_files,
+        },
+        "actor": {
+            "label": run.primary_label,
+            "pane_id": run.primary_pane_id,
+            "role": run.primary_role,
+            "provider_target": run.provider_target,
+            "agent_role": if run.agent_role.trim().is_empty() {
+                run.primary_role.clone()
+            } else {
+                run.agent_role.clone()
+            },
+        },
+        "approval": {
+            "required": run.review_required,
+            "state": audit_chain_approval_state(&run.review_state, run.review_required),
+            "verdict": run.review_state,
+            "requested_at": review_request.map(|event| event_timestamp_text(&event.timestamp)).unwrap_or_default(),
+            "requested_event": review_request.map(|event| event.event.clone()).unwrap_or_default(),
+            "requested_reviewer_label": review_request.map(|event| event.label.clone()).unwrap_or_default(),
+            "requested_reviewer_pane": review_request.map(|event| event.pane_id.clone()).unwrap_or_default(),
+            "requested_reviewer_role": review_request.map(|event| event.role.clone()).unwrap_or_default(),
+            "decided_at": decision_event.map(|event| event_timestamp_text(&event.timestamp)).unwrap_or_default(),
+            "decided_event": decision_event.map(|event| event.event.clone()).unwrap_or_default(),
+            "human_judgement_required": run.review_required,
+            "automatic_merge_allowed": false,
+        },
+        "events": chain_events,
+    })
+}
+
+fn audit_chain_approval_state(review_state: &str, review_required: bool) -> &'static str {
+    if review_state.eq_ignore_ascii_case("PASS") {
+        "approved"
+    } else if review_state.eq_ignore_ascii_case("FAIL")
+        || review_state.eq_ignore_ascii_case("FAILED")
+    {
+        "failed"
+    } else if review_state.eq_ignore_ascii_case("PENDING") {
+        "pending"
+    } else if review_required {
+        "missing"
+    } else {
+        "not_required"
+    }
+}
+
+fn run_audit_chain_decision_event<'a>(
+    run: &LedgerExplainRun,
+    events: &'a [(usize, &EventRecord)],
+) -> Option<&'a EventRecord> {
+    let decision_events: &[&str] = if run.review_state.eq_ignore_ascii_case("PASS") {
+        &["operator.review_passed", "review.pass"]
+    } else if run.review_state.eq_ignore_ascii_case("FAIL")
+        || run.review_state.eq_ignore_ascii_case("FAILED")
+    {
+        &["operator.review_failed", "review.fail"]
+    } else {
+        &[]
+    };
+    if decision_events.is_empty() {
+        return None;
+    }
+
+    events
+        .iter()
+        .map(|(_, event)| *event)
+        .find(|event| decision_events.contains(&event.event.as_str()))
+}
+
+fn is_audit_chain_event(event: &str) -> bool {
+    matches!(
+        event,
+        "operator.review_requested"
+            | "operator.review_passed"
+            | "operator.review_failed"
+            | "review.pass"
+            | "review.fail"
+            | "pane.approval_waiting"
+            | "pipeline.tdd.red"
+            | "pipeline.tdd.exception"
+            | "pipeline.verify.pass"
+            | "pipeline.verify.fail"
+            | "pipeline.verify.partial"
+            | "pipeline.security.allowed"
+            | "pipeline.security.blocked"
+            | "security.policy.allowed"
+            | "security.policy.blocked"
+            | "operator.draft_pr.created"
+            | "operator.draft_pr.required"
+    )
+}
+
+fn audit_chain_event_value(event: &EventRecord) -> Value {
+    let action = event_data_string(&event.data, "action");
+    let what = if action.trim().is_empty() {
+        event.event.clone()
+    } else {
+        action
+    };
+
+    json!({
+        "at": event_timestamp_text(&event.timestamp),
+        "event": event.event,
+        "who": {
+            "label": event.label,
+            "pane_id": event.pane_id,
+            "role": event.role,
+        },
+        "what": what,
+        "task_id": event_data_string(&event.data, "task_id"),
+        "run_id": event_data_string(&event.data, "run_id"),
+        "branch": event_branch(event),
+        "head_sha": event_head_sha(event),
+        "message": event.message,
+    })
+}
+
+fn event_timestamp_text(timestamp: &str) -> String {
+    DateTime::parse_from_rfc3339(timestamp)
+        .map(|value| {
+            value
+                .with_timezone(&Utc)
+                .to_rfc3339_opts(SecondsFormat::Secs, true)
+        })
+        .unwrap_or_else(|_| timestamp.to_string())
 }
 
 fn run_outcome_value(run: &LedgerExplainRun, phase_gate: &Value, draft_pr_gate: &Value) -> Value {

--- a/core/tests-rs/fixture_comparison.rs
+++ b/core/tests-rs/fixture_comparison.rs
@@ -243,6 +243,7 @@ const EXPLAIN_RUN_KEYS: &[&str] = &[
     "verification_result",
     "verification_evidence",
     "tdd_gate",
+    "audit_chain",
     "outcome",
     "phase_gate",
     "draft_pr_gate",

--- a/core/tests-rs/ledger_contract.rs
+++ b/core/tests-rs/ledger_contract.rs
@@ -688,6 +688,22 @@ panes:
         explain.run.verification_evidence["context_pressure"],
         "medium"
     );
+    assert_eq!(explain.run.audit_chain["chain_id"], "task:task-256");
+    assert_eq!(
+        explain.run.audit_chain["subject"]["changed_files"][0],
+        "scripts/winsmux-core.ps1"
+    );
+    assert_eq!(explain.run.audit_chain["actor"]["label"], "builder-1");
+    assert_eq!(explain.run.audit_chain["approval"]["required"], true);
+    assert_eq!(explain.run.audit_chain["approval"]["state"], "pending");
+    assert_eq!(explain.run.audit_chain["approval"]["requested_at"], "");
+    assert!(explain.run.audit_chain["events"]
+        .as_array()
+        .expect("audit chain events should be an array")
+        .iter()
+        .any(|event| event["event"] == "pane.approval_waiting"
+            && event["at"] == "2026-04-23T03:00:01Z"
+            && event["who"]["label"] == "builder-1"));
     assert_eq!(explain.run.security_verdict, "ALLOW");
 }
 

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -5802,7 +5802,7 @@ function New-RunAuditChainEventRecord {
             pane_id = [string]$EventRecord['pane_id']
             role    = [string]$EventRecord['role']
         }
-        what     = if ($data.Contains('action')) { [string]$data['action'] } else { [string]$EventRecord['event'] }
+        what     = if ($data.Contains('action') -and -not [string]::IsNullOrWhiteSpace([string]$data['action'])) { [string]$data['action'] } else { [string]$EventRecord['event'] }
         task_id  = if ($data.Contains('task_id')) { [string]$data['task_id'] } else { '' }
         run_id   = if ($data.Contains('run_id')) { [string]$data['run_id'] } else { '' }
         branch   = if ($data.Contains('branch')) { [string]$data['branch'] } else { [string]$EventRecord['branch'] }
@@ -6529,12 +6529,14 @@ function Test-RunMatchesEventRecord {
         [Parameter(Mandatory = $true)]$EventRecord
     )
 
+    $runId = [string]$Run.run_id
     $runTaskId = [string]$Run.task_id
     $runBranch = [string]$Run.branch
     $runHeadSha = [string]$Run.head_sha
     $runLabels = @($Run.labels)
     $runPaneIds = @($Run.pane_ids)
 
+    $eventRunId = ''
     $eventTaskId = ''
     $eventBranch = [string]$EventRecord['branch']
     $eventHeadSha = [string]$EventRecord['head_sha']
@@ -6542,25 +6544,28 @@ function Test-RunMatchesEventRecord {
     $eventPaneId = [string]$EventRecord['pane_id']
 
     $data = $null
+    if ($EventRecord.Contains('run_id')) { $eventRunId = [string]$EventRecord['run_id'] }
+    if ($EventRecord.Contains('task_id')) { $eventTaskId = [string]$EventRecord['task_id'] }
     if ($EventRecord.Contains('data')) {
         $data = $EventRecord['data']
     }
 
     if ($null -ne $data -and $data -is [System.Collections.IDictionary]) {
+        if ($data.Contains('run_id')) { $eventRunId = [string]$data['run_id'] }
         if ($data.Contains('task_id')) { $eventTaskId = [string]$data['task_id'] }
         if ([string]::IsNullOrWhiteSpace($eventBranch) -and $data.Contains('branch')) { $eventBranch = [string]$data['branch'] }
         if ([string]::IsNullOrWhiteSpace($eventHeadSha) -and $data.Contains('head_sha')) { $eventHeadSha = [string]$data['head_sha'] }
     }
 
-    if (-not [string]::IsNullOrWhiteSpace($runTaskId) -and $runTaskId -eq $eventTaskId) {
-        return $true
+    if (-not [string]::IsNullOrWhiteSpace($eventRunId)) {
+        return (-not [string]::IsNullOrWhiteSpace($runId) -and $runId -eq $eventRunId)
     }
 
-    if (-not [string]::IsNullOrWhiteSpace($runBranch) -and $runBranch -eq $eventBranch) {
-        return $true
+    if (-not [string]::IsNullOrWhiteSpace($eventTaskId)) {
+        return (-not [string]::IsNullOrWhiteSpace($runTaskId) -and $runTaskId -eq $eventTaskId)
     }
 
-    if (-not [string]::IsNullOrWhiteSpace($runHeadSha) -and $runHeadSha -eq $eventHeadSha) {
+    if (-not [string]::IsNullOrWhiteSpace($eventPaneId) -and $runPaneIds -contains $eventPaneId) {
         return $true
     }
 
@@ -6568,7 +6573,11 @@ function Test-RunMatchesEventRecord {
         return $true
     }
 
-    if (-not [string]::IsNullOrWhiteSpace($eventPaneId) -and $runPaneIds -contains $eventPaneId) {
+    if (-not [string]::IsNullOrWhiteSpace($runBranch) -and -not [string]::IsNullOrWhiteSpace($eventBranch) -and $runBranch -eq $eventBranch) {
+        return $true
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($runHeadSha) -and -not [string]::IsNullOrWhiteSpace($eventHeadSha) -and $runHeadSha -eq $eventHeadSha) {
         return $true
     }
 

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -5739,6 +5739,157 @@ function Get-ManagedLoopContractFromEventRecords {
     return $contract
 }
 
+function ConvertTo-RunAuditChainApprovalState {
+    param(
+        [string]$ReviewState = '',
+        [bool]$ReviewRequired = $false
+    )
+
+    $normalized = ([string]$ReviewState).ToUpperInvariant()
+    if ($normalized -eq 'PASS') { return 'approved' }
+    if ($normalized -in @('FAIL', 'FAILED')) { return 'failed' }
+    if ($normalized -eq 'PENDING') { return 'pending' }
+    if ($ReviewRequired) { return 'missing' }
+    return 'not_required'
+}
+
+function Get-RunAuditChainDecisionEvent {
+    param(
+        [object[]]$EventRecords = @(),
+        [string]$ReviewState = ''
+    )
+
+    $decisionEvents = if (([string]$ReviewState).ToUpperInvariant() -eq 'PASS') {
+        @('operator.review_passed', 'review.pass')
+    } elseif (([string]$ReviewState).ToUpperInvariant() -in @('FAIL', 'FAILED')) {
+        @('operator.review_failed', 'review.fail')
+    } else {
+        @()
+    }
+
+    if (@($decisionEvents).Count -eq 0) {
+        return $null
+    }
+
+    $matches = @(
+        $EventRecords |
+            Where-Object { [string]$_['event'] -in $decisionEvents } |
+            Sort-Object @{ Expression = { Get-RunEventTimestampSortKey -Value $_['timestamp'] } }, @{ Expression = { [int]$_['line_number'] } } |
+            Select-Object -First 1
+    )
+    if ($matches.Count -gt 0) {
+        return $matches[0]
+    }
+    return $null
+}
+
+function New-RunAuditChainEventRecord {
+    param([Parameter(Mandatory = $true)]$EventRecord)
+
+    $data = $null
+    if ($EventRecord.Contains('data')) {
+        $data = $EventRecord['data']
+    }
+    if ($null -eq $data -or $data -isnot [System.Collections.IDictionary]) {
+        $data = [ordered]@{}
+    }
+
+    return [ordered]@{
+        at       = ConvertTo-RunEventTimestampText -Value $EventRecord['timestamp']
+        event    = [string]$EventRecord['event']
+        who      = [ordered]@{
+            label   = [string]$EventRecord['label']
+            pane_id = [string]$EventRecord['pane_id']
+            role    = [string]$EventRecord['role']
+        }
+        what     = if ($data.Contains('action')) { [string]$data['action'] } else { [string]$EventRecord['event'] }
+        task_id  = if ($data.Contains('task_id')) { [string]$data['task_id'] } else { '' }
+        run_id   = if ($data.Contains('run_id')) { [string]$data['run_id'] } else { '' }
+        branch   = if ($data.Contains('branch')) { [string]$data['branch'] } else { [string]$EventRecord['branch'] }
+        head_sha = if ($data.Contains('head_sha')) { [string]$data['head_sha'] } else { [string]$EventRecord['head_sha'] }
+        message  = [string]$EventRecord['message']
+    }
+}
+
+function New-RunAuditChainContract {
+    param(
+        [Parameter(Mandatory = $true)]$Run,
+        [object[]]$EventRecords = @()
+    )
+
+    $orderedEvents = @(
+        $EventRecords |
+            Sort-Object @{ Expression = { Get-RunEventTimestampSortKey -Value $_['timestamp'] } }, @{ Expression = { [int]$_['line_number'] } }
+    )
+    $reviewRequests = @(
+        $orderedEvents |
+            Where-Object { [string]$_['event'] -eq 'operator.review_requested' } |
+            Select-Object -First 1
+    )
+    $reviewRequest = if ($reviewRequests.Count -gt 0) { $reviewRequests[0] } else { $null }
+    $decisionEvent = Get-RunAuditChainDecisionEvent -EventRecords $orderedEvents -ReviewState ([string]$Run.review_state)
+    $chainEvents = @(
+        $orderedEvents |
+            Where-Object {
+                [string]$_['event'] -in @(
+                    'operator.review_requested',
+                    'operator.review_passed',
+                    'operator.review_failed',
+                    'review.pass',
+                    'review.fail',
+                    'pane.approval_waiting',
+                    'pipeline.tdd.red',
+                    'pipeline.tdd.exception',
+                    'pipeline.verify.pass',
+                    'pipeline.verify.fail',
+                    'pipeline.verify.partial',
+                    'pipeline.security.allowed',
+                    'pipeline.security.blocked',
+                    'security.policy.allowed',
+                    'security.policy.blocked',
+                    'operator.draft_pr.created',
+                    'operator.draft_pr.required'
+                )
+            } |
+            ForEach-Object { New-RunAuditChainEventRecord -EventRecord $_ }
+    )
+
+    return [ordered]@{
+        chain_id = [string]$Run.run_id
+        subject  = [ordered]@{
+            task_id       = [string]$Run.task_id
+            task          = [string]$Run.task
+            task_type     = [string]$Run.task_type
+            priority      = [string]$Run.priority
+            branch        = [string]$Run.branch
+            head_sha      = [string]$Run.head_sha
+            changed_files = @($Run.changed_files)
+        }
+        actor    = [ordered]@{
+            label           = [string]$Run.primary_label
+            pane_id         = [string]$Run.primary_pane_id
+            role            = [string]$Run.primary_role
+            provider_target = [string]$Run.provider_target
+            agent_role      = if (-not [string]::IsNullOrWhiteSpace([string]$Run.agent_role)) { [string]$Run.agent_role } else { [string]$Run.primary_role }
+        }
+        approval = [ordered]@{
+            required                 = [bool]$Run.review_required
+            state                    = ConvertTo-RunAuditChainApprovalState -ReviewState ([string]$Run.review_state) -ReviewRequired ([bool]$Run.review_required)
+            verdict                  = [string]$Run.review_state
+            requested_at             = if ($null -ne $reviewRequest) { ConvertTo-RunEventTimestampText -Value $reviewRequest['timestamp'] } else { '' }
+            requested_event          = if ($null -ne $reviewRequest) { [string]$reviewRequest['event'] } else { '' }
+            requested_reviewer_label = if ($null -ne $reviewRequest) { [string]$reviewRequest['label'] } else { '' }
+            requested_reviewer_pane  = if ($null -ne $reviewRequest) { [string]$reviewRequest['pane_id'] } else { '' }
+            requested_reviewer_role  = if ($null -ne $reviewRequest) { [string]$reviewRequest['role'] } else { '' }
+            decided_at               = if ($null -ne $decisionEvent) { ConvertTo-RunEventTimestampText -Value $decisionEvent['timestamp'] } else { '' }
+            decided_event            = if ($null -ne $decisionEvent) { [string]$decisionEvent['event'] } else { '' }
+            human_judgement_required = [bool]$Run.review_required
+            automatic_merge_allowed  = $false
+        }
+        events   = @($chainEvents)
+    }
+}
+
 function New-RunPlanContract {
     param([Parameter(Mandatory = $true)]$Run)
 
@@ -6281,6 +6432,7 @@ function New-RunPacketFromRun {
         plan              = $Run.plan
         plan_checkpoints  = @($Run.plan_checkpoints)
         managed_loop      = $Run.managed_loop
+        audit_chain       = $Run.audit_chain
         outcome           = $Run.outcome
         phase_gate        = $Run.phase_gate
         draft_pr_gate     = $Run.draft_pr_gate
@@ -6363,6 +6515,7 @@ function New-RunResultPacket {
         security_verdict      = $Run.security_verdict
         plan                  = $Run.plan
         plan_checkpoints      = @($Run.plan_checkpoints)
+        audit_chain           = $Run.audit_chain
         outcome               = $Run.outcome
         phase_gate            = $Run.phase_gate
         draft_pr_gate         = $Run.draft_pr_gate
@@ -6614,6 +6767,7 @@ function Get-RunsPayload {
                 plan                  = $null
                 plan_checkpoints      = @()
                 managed_loop          = $null
+                audit_chain           = $null
                 outcome               = $null
                 draft_pr_gate         = $null
                 tdd_gate              = $null
@@ -6765,6 +6919,7 @@ function Get-RunsPayload {
             }
             $run.plan_checkpoints = @(Get-RunPlanCheckpointsFromEventRecords -EventRecords $matchingEvents)
             $run.managed_loop = Get-ManagedLoopContractFromEventRecords -EventRecords $matchingEvents
+            $run.audit_chain = New-RunAuditChainContract -Run $run -EventRecords $matchingEvents
         }
     }
 
@@ -6776,6 +6931,7 @@ function Get-RunsPayload {
             $run.draft_pr_gate = New-RunDraftPrGate -Run $run -EventRecords $runEvents
             $run.tdd_gate = New-RunTddGateContract -Run $run -EventRecords $runEvents
             $run.phase_gate = New-RunPhaseGateContract -Run $run -EventRecords $runEvents
+            $run.audit_chain = New-RunAuditChainContract -Run $run -EventRecords $runEvents
             $run.outcome = New-RunOutcomeContract -Run $run
             $nextAction = Get-RunNextAction -Run $run
             $stateModel = New-RunStateModel -State ([string]$run.state) -TaskState ([string]$run.task_state) -ReviewState ([string]$run.review_state) -EventKind $nextAction -LastEvent ([string]$run.last_event)
@@ -6830,6 +6986,7 @@ function Get-RunsPayload {
                 plan                  = $run.plan
                 plan_checkpoints      = @($run.plan_checkpoints)
                 managed_loop          = $run.managed_loop
+                audit_chain           = $run.audit_chain
                 outcome               = $run.outcome
                 phase_gate            = $run.phase_gate
                 draft_pr_gate         = $run.draft_pr_gate

--- a/tests/fixtures/rust-parity/explain.json
+++ b/tests/fixtures/rust-parity/explain.json
@@ -140,6 +140,73 @@
       }
     ],
     "managed_loop": null,
+    "audit_chain": {
+      "chain_id": "task:task-256",
+      "subject": {
+        "task_id": "task-256",
+        "task": "Implement run ledger",
+        "task_type": "implementation",
+        "priority": "P0",
+        "branch": "worktree-builder-1",
+        "head_sha": "abc1234def5678",
+        "changed_files": [
+          "scripts/winsmux-core.ps1"
+        ]
+      },
+      "actor": {
+        "label": "builder-1",
+        "pane_id": "%2",
+        "role": "Builder",
+        "provider_target": "codex:gpt-5.4",
+        "agent_role": "worker"
+      },
+      "approval": {
+        "required": true,
+        "state": "pending",
+        "verdict": "PENDING",
+        "requested_at": "2026-04-10T03:01:00Z",
+        "requested_event": "operator.review_requested",
+        "requested_reviewer_label": "reviewer-1",
+        "requested_reviewer_pane": "%3",
+        "requested_reviewer_role": "Reviewer",
+        "decided_at": "",
+        "decided_event": "",
+        "human_judgement_required": true,
+        "automatic_merge_allowed": false
+      },
+      "events": [
+        {
+          "at": "2026-04-10T03:01:00Z",
+          "event": "operator.review_requested",
+          "who": {
+            "label": "reviewer-1",
+            "pane_id": "%3",
+            "role": "Reviewer"
+          },
+          "what": "operator.review_requested",
+          "task_id": "task-256",
+          "run_id": "",
+          "branch": "worktree-builder-1",
+          "head_sha": "abc1234def5678",
+          "message": "review requested"
+        },
+        {
+          "at": "2026-04-10T03:03:00Z",
+          "event": "pipeline.tdd.red",
+          "who": {
+            "label": "operator",
+            "pane_id": "",
+            "role": "Operator"
+          },
+          "what": "pipeline.tdd.red",
+          "task_id": "task-256",
+          "run_id": "task:task-256",
+          "branch": "worktree-builder-1",
+          "head_sha": "abc1234def5678",
+          "message": "test failed before implementation"
+        }
+      ]
+    },
     "outcome": {
       "status": "in_progress",
       "reason": "consult before work",

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -9596,6 +9596,37 @@ panes:
                 }
             } | ConvertTo-Json -Compress -Depth 8),
             ([ordered]@{
+                timestamp = '2026-04-10T12:02:05+09:00'
+                session   = 'winsmux-orchestra'
+                event     = 'pipeline.security.allowed'
+                message   = 'security check passed'
+                label     = 'reviewer-1'
+                pane_id   = '%3'
+                role      = 'Reviewer'
+                branch    = 'worktree-builder-1'
+                head_sha  = 'abc1234def5678'
+                data      = [ordered]@{
+                    task_id = 'task-256'
+                    run_id  = 'task:task-256'
+                    action  = ''
+                }
+            } | ConvertTo-Json -Compress),
+            ([ordered]@{
+                timestamp = '2026-04-10T12:02:10+09:00'
+                session   = 'winsmux-orchestra'
+                event     = 'pipeline.verify.fail'
+                message   = 'unrelated task local note should stay out'
+                label     = 'reviewer-1'
+                pane_id   = '%3'
+                role      = 'Reviewer'
+                branch    = 'worktree-builder-1'
+                head_sha  = 'abc1234def5678'
+                data      = [ordered]@{
+                    task_id = 'task-other'
+                    run_id  = 'task:task-other'
+                }
+            } | ConvertTo-Json -Compress),
+            ([ordered]@{
             timestamp = '2026-04-10T12:02:15+09:00'
             session   = 'winsmux-orchestra'
             event     = 'pipeline.tdd.red'
@@ -9736,14 +9767,17 @@ panes:
         $result.run.audit_chain.approval.requested_reviewer_label | Should -Be 'reviewer-1'
         @($result.run.audit_chain.events | ForEach-Object { $_.event }) | Should -Contain 'operator.review_requested'
         @($result.run.audit_chain.events | ForEach-Object { $_.event }) | Should -Contain 'pipeline.verify.partial'
+        @($result.run.audit_chain.events | ForEach-Object { $_.event }) | Should -Contain 'pipeline.security.allowed'
         @($result.run.audit_chain.events | ForEach-Object { $_.event }) | Should -Contain 'pane.approval_waiting'
+        @($result.run.audit_chain.events | ForEach-Object { $_.message }) | Should -Not -Contain 'unrelated task local note should stay out'
+        ($result.run.audit_chain.events | Where-Object { $_.event -eq 'pipeline.security.allowed' } | Select-Object -First 1).what | Should -Be 'pipeline.security.allowed'
         $result.run.phase | Should -Be 'review'
         $result.run.activity | Should -Be 'waiting_for_input'
         $result.run.detail | Should -Be 'review_pending'
         $result.run.plan.goal | Should -Be 'Ship run contract primitives'
         $result.run.plan.verification_plan | Should -Be @('Invoke-Pester tests/winsmux-bridge.Tests.ps1', 'verify explain --json contract')
-        $result.run.plan_checkpoints.Count | Should -Be 3
-        @($result.run.plan_checkpoints | ForEach-Object { $_.name }) | Should -Be @('operator.review_requested', 'pipeline.verify.partial', 'pane.approval_waiting')
+        $result.run.plan_checkpoints.Count | Should -Be 4
+        @($result.run.plan_checkpoints | ForEach-Object { $_.name }) | Should -Be @('operator.review_requested', 'pipeline.verify.partial', 'pipeline.security.allowed', 'pane.approval_waiting')
         $result.run.plan_checkpoints[0].at.ToString('o') | Should -Be '2026-04-10T03:01:00.0000000Z'
         $result.run.phase_gate.order | Should -Be @('plan', 'build', 'test', 'review', 'package')
         $result.run.phase_gate.current_stage | Should -Be 'review'
@@ -9790,11 +9824,13 @@ panes:
         $result.run.Contains('run_packet') | Should -BeFalse
         $result.Contains('run_packet') | Should -Be $false
         $result.Contains('result_packet') | Should -Be $false
-        $result.recent_events.Count | Should -Be 4
+        $result.recent_events.Count | Should -Be 5
         @($result.recent_events | ForEach-Object { $_.event }) | Should -Contain 'operator.review_requested'
         @($result.recent_events | ForEach-Object { $_.event }) | Should -Contain 'pipeline.verify.partial'
+        @($result.recent_events | ForEach-Object { $_.event }) | Should -Contain 'pipeline.security.allowed'
         @($result.recent_events | ForEach-Object { $_.event }) | Should -Contain 'pipeline.tdd.red'
         @($result.recent_events | ForEach-Object { $_.event }) | Should -Contain 'pane.approval_waiting'
+        @($result.recent_events | ForEach-Object { $_.message }) | Should -Not -Contain 'unrelated task local note should stay out'
         ($result.recent_events | Where-Object { $_.event -eq 'operator.review_requested' } | Select-Object -First 1).hypothesis | Should -Be 'experiment packet should flow into explain'
         ($result.recent_events | Where-Object { $_.event -eq 'operator.review_requested' } | Select-Object -First 1).observation_pack.changed_files | Should -Contain 'scripts/winsmux-core.ps1'
         ($result.recent_events | Where-Object { $_.event -eq 'operator.review_requested' } | Select-Object -First 1).observation_pack.packet_type | Should -Be 'observation_pack'

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -9726,6 +9726,17 @@ panes:
         $result.run.tdd_gate.required | Should -Be $true
         $result.run.tdd_gate.state | Should -Be 'passed'
         $result.run.tdd_gate.red_event | Should -Be 'pipeline.tdd.red'
+        $result.run.audit_chain.chain_id | Should -Be 'task:task-256'
+        $result.run.audit_chain.subject.task_id | Should -Be 'task-256'
+        $result.run.audit_chain.subject.changed_files | Should -Be @('scripts/winsmux-core.ps1')
+        $result.run.audit_chain.actor.label | Should -Be 'builder-1'
+        $result.run.audit_chain.approval.required | Should -Be $true
+        $result.run.audit_chain.approval.state | Should -Be 'pending'
+        $result.run.audit_chain.approval.requested_at.ToString('o') | Should -Be '2026-04-10T03:01:00.0000000Z'
+        $result.run.audit_chain.approval.requested_reviewer_label | Should -Be 'reviewer-1'
+        @($result.run.audit_chain.events | ForEach-Object { $_.event }) | Should -Contain 'operator.review_requested'
+        @($result.run.audit_chain.events | ForEach-Object { $_.event }) | Should -Contain 'pipeline.verify.partial'
+        @($result.run.audit_chain.events | ForEach-Object { $_.event }) | Should -Contain 'pane.approval_waiting'
         $result.run.phase | Should -Be 'review'
         $result.run.activity | Should -Be 'waiting_for_input'
         $result.run.detail | Should -Be 'review_pending'


### PR DESCRIPTION
## Summary

- Add `audit_chain` to PowerShell run, runs, and explain projections.
- Add the matching Rust ledger projection contract and fixture comparison coverage.
- Keep audit events scoped by explicit run and task identifiers before falling back to pane, label, branch, or head matching.
- Include reviewer request, decision metadata, approval state, actor, subject, and audit event records.

## Review Notes

- Review subagent `019dd775-3eed-7483-b765-4fda31a6e461` returned `REQUEST_CHANGES`.
- Fixed explicit nonmatching `run_id` / `task_id` event leakage into `audit_chain`.
- Fixed blank `data.action` fallback to the event name.
- External Rust learning note was updated outside the repository and passed Opus readability review.

## Validation

- `Invoke-Pester -Path tests\winsmux-bridge.Tests.ps1 -Output Detailed` passed: 388 passed, 0 failed.
- `cargo test -p winsmux --test ledger_contract -- --nocapture` passed: 69 passed, 0 failed.
- `cargo test -p winsmux --test fixture_comparison -- --nocapture` passed: 27 passed, 0 failed.
- `cargo test -p winsmux --test operator_cli -- --nocapture` passed earlier in this branch: 93 passed, 0 failed under normal privileges.
- `git diff --check` passed with line-ending warnings only.
- `git-guard`, `audit-public-surface`, and `gitleaks` passed during push.

Closes #452