### PR TITLE
feat: add guard baseline report

### DIFF
--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -258,6 +258,7 @@ fn run_main() -> io::Result<()> {
         "machine-contract" => return operator_cli::run_machine_contract_command(&cmd_args[1..]),
         "rust-canary" => return operator_cli::run_rust_canary_command(&cmd_args[1..]),
         "manual-checklist" => return operator_cli::run_manual_checklist_command(&cmd_args[1..]),
+        "guard" => return operator_cli::run_guard_command(&cmd_args[1..]),
         "provider-switch" => return operator_cli::run_provider_switch_command(&cmd_args[1..]),
         "signal" => return operator_cli::run_signal_command(&cmd_args[1..]),
         "wait" if !matches!(

--- a/core/src/operator_cli.rs
+++ b/core/src/operator_cli.rs
@@ -329,6 +329,27 @@ pub fn run_manual_checklist_command(args: &[&String]) -> io::Result<()> {
     Ok(())
 }
 
+pub fn run_guard_command(args: &[&String]) -> io::Result<()> {
+    if should_print_help(args) {
+        println!("{}", usage_for("guard"));
+        return Ok(());
+    }
+
+    let options = parse_options("guard", args, 0)?;
+    let payload = guard_report_payload(&options.project_dir);
+    if options.json {
+        return write_json(&payload);
+    }
+
+    println!(
+        "Guard baseline: {} checks for {}",
+        payload["summary"]["required_check_count"].as_u64().unwrap_or(0),
+        payload["target_version"].as_str().unwrap_or("release")
+    );
+    println!("{}", payload["summary"]["next_action"].as_str().unwrap_or(""));
+    Ok(())
+}
+
 struct RustCanaryBackend {
     backend: String,
     source: String,
@@ -3195,6 +3216,7 @@ fn usage_for(command: &str) -> &'static str {
         "manual-checklist" => {
             "usage: winsmux manual-checklist [--json] [--project-dir <path>]"
         }
+        "guard" => "usage: winsmux guard [--json] [--project-dir <path>]",
         "provider-switch" => {
             "usage: winsmux provider-switch <slot> [--agent <name>] [--model <name>] [--prompt-transport <argv|file|stdin>] [--auth-mode <mode>] [--reason <text>] [--restart] [--clear] [--json] [--project-dir <path>]"
         }
@@ -5747,6 +5769,139 @@ fn git_probe(project_dir: &Path, args: &[&str]) -> io::Result<GitProbeResult> {
         exit_code: output.status.code().unwrap_or(1),
         output: text.trim().to_string(),
     })
+}
+
+fn guard_report_payload(project_dir: &Path) -> Value {
+    let branch = git_output_line(project_dir, &["rev-parse", "--abbrev-ref", "HEAD"])
+        .ok()
+        .flatten()
+        .filter(|value| value != "HEAD")
+        .unwrap_or_default();
+    let head_sha = git_output_line(project_dir, &["rev-parse", "HEAD"])
+        .ok()
+        .flatten()
+        .unwrap_or_default();
+    let hooks_path = git_output_line(project_dir, &["config", "--get", "core.hooksPath"])
+        .ok()
+        .flatten()
+        .unwrap_or_default();
+    let baseline_file = project_dir
+        .join("scripts")
+        .join("gitleaks-history-baseline.txt");
+    let baseline_commit = fs::read_to_string(&baseline_file)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .unwrap_or_default();
+    let required_checks = vec![
+        guard_check(
+            "git_guard_full",
+            "pwsh -NoProfile -File scripts/git-guard.ps1 -Mode full",
+            "scripts/git-guard.ps1",
+            "secret and private surface path guard",
+            file_exists(project_dir, "scripts/git-guard.ps1"),
+        ),
+        guard_check(
+            "public_surface_audit",
+            "pwsh -NoProfile -File scripts/audit-public-surface.ps1",
+            "scripts/audit-public-surface.ps1",
+            "public, contributor, and private surface boundary guard",
+            file_exists(project_dir, "scripts/audit-public-surface.ps1"),
+        ),
+        guard_check(
+            "gitleaks_incremental",
+            "pwsh -NoProfile -File scripts/gitleaks-history.ps1",
+            "scripts/gitleaks-history.ps1",
+            "incremental secret history scan from recorded baseline",
+            file_exists(project_dir, "scripts/gitleaks-history.ps1")
+                && !baseline_commit.trim().is_empty(),
+        ),
+        guard_check(
+            "evidence_envelope",
+            "winsmux runs --json",
+            "run_projection",
+            "verification evidence, security verdict, and audit chain are preserved in run packets",
+            true,
+        ),
+        guard_check(
+            "release_notes_contract",
+            "pwsh -NoProfile -File scripts/generate-release-notes.ps1",
+            "scripts/generate-release-notes.ps1",
+            "English public release notes with traceable issue or PR references",
+            file_exists(project_dir, "scripts/generate-release-notes.ps1"),
+        ),
+    ];
+    let required_check_count = required_checks.len();
+    let available_check_count = required_checks
+        .iter()
+        .filter(|check| check["available"].as_bool().unwrap_or(false))
+        .count();
+
+    json!({
+        "contract_version": 1,
+        "command": "guard",
+        "task_ids": ["TASK-383", "TASK-384"],
+        "target_version": "v0.24.10",
+        "generated_at": generated_at(),
+        "project_dir": project_dir_string(project_dir),
+        "product_version": VERSION,
+        "summary": {
+            "required_check_count": required_check_count,
+            "available_check_count": available_check_count,
+            "blocking_policy": "release automation must stop when any required check fails or evidence is missing",
+            "next_action": "Run the listed guard commands before release tagging or automated merge."
+        },
+        "observed_state": {
+            "branch": branch,
+            "head_sha": head_sha,
+            "hooks_path": hooks_path,
+            "hooks_path_expected": ".githooks",
+            "gitleaks_baseline_file": "scripts/gitleaks-history-baseline.txt",
+            "gitleaks_baseline_commit": baseline_commit
+        },
+        "required_checks": required_checks,
+        "evidence_contract": {
+            "run_surfaces": ["winsmux runs --json", "winsmux digest --json", "winsmux explain <run_id> --json"],
+            "required_fields": [
+                "verification_evidence",
+                "security_verdict",
+                "audit_chain",
+                "draft_pr_gate",
+                "phase_gate"
+            ],
+            "audit_chain_events": [
+                "operator.review_requested",
+                "operator.review_failed",
+                "pipeline.verify.pass",
+                "pipeline.verify.fail",
+                "pipeline.security.allowed",
+                "pipeline.security.blocked"
+            ]
+        },
+        "public_safety": {
+            "tracked_private_paths_allowed": false,
+            "maintainer_local_paths_allowed": false,
+            "private_skill_bodies_allowed": false,
+            "public_release_notes_language": "English"
+        }
+    })
+}
+
+fn guard_check(id: &str, command: &str, source: &str, purpose: &str, available: bool) -> Value {
+    json!({
+        "id": id,
+        "command": command,
+        "source": source,
+        "purpose": purpose,
+        "required": true,
+        "available": available,
+    })
+}
+
+fn file_exists(project_dir: &Path, relative_path: &str) -> bool {
+    relative_path
+        .split('/')
+        .fold(project_dir.to_path_buf(), |path, segment| path.join(segment))
+        .is_file()
 }
 
 fn conflict_path_array(text: &str) -> Vec<String> {

--- a/core/tests-rs/operator_cli.rs
+++ b/core/tests-rs/operator_cli.rs
@@ -706,6 +706,70 @@ fn operator_cli_manual_checklist_text_reports_next_action() {
 }
 
 #[test]
+fn operator_cli_guard_json_reports_release_guard_baseline() {
+    let project_dir = make_temp_project_dir("guard-json");
+    fs::create_dir_all(project_dir.join("scripts")).expect("test should create scripts dir");
+    fs::write(project_dir.join("scripts").join("git-guard.ps1"), "")
+        .expect("test should write git-guard script");
+    fs::write(project_dir.join("scripts").join("audit-public-surface.ps1"), "")
+        .expect("test should write public surface audit script");
+    fs::write(project_dir.join("scripts").join("gitleaks-history.ps1"), "")
+        .expect("test should write gitleaks script");
+    fs::write(
+        project_dir.join("scripts").join("gitleaks-history-baseline.txt"),
+        "abc123\n",
+    )
+    .expect("test should write gitleaks baseline");
+    fs::write(
+        project_dir.join("scripts").join("generate-release-notes.ps1"),
+        "",
+    )
+    .expect("test should write release notes script");
+
+    let json = run_json(&project_dir, &["guard", "--json"]);
+
+    assert_eq!(json["command"], "guard");
+    assert_eq!(json["task_ids"][0], "TASK-383");
+    assert_eq!(json["task_ids"][1], "TASK-384");
+    assert_eq!(json["target_version"], "v0.24.10");
+    assert_eq!(json["summary"]["required_check_count"], 5);
+    assert_eq!(json["summary"]["available_check_count"], 5);
+    assert_eq!(
+        json["observed_state"]["gitleaks_baseline_file"],
+        "scripts/gitleaks-history-baseline.txt"
+    );
+    assert_eq!(
+        json["evidence_contract"]["required_fields"][2],
+        "audit_chain"
+    );
+    assert_eq!(
+        json["public_safety"]["public_release_notes_language"],
+        "English"
+    );
+}
+
+#[test]
+fn operator_cli_guard_text_summarizes_contract() {
+    let project_dir = make_temp_project_dir("guard-text");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .arg("guard")
+        .current_dir(&project_dir)
+        .output()
+        .expect("winsmux command should run");
+
+    assert!(
+        output.status.success(),
+        "winsmux command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Guard baseline: 5 checks for v0.24.10"));
+    assert!(stdout.contains("Run the listed guard commands before release tagging"));
+    assert!(!stdout.trim_start().starts_with('{'));
+}
+
+#[test]
 fn operator_cli_provider_capabilities_json_reads_single_provider_case_insensitive() {
     let project_dir = make_temp_project_dir("provider-capabilities-single");
     let winsmux_dir = project_dir.join(".winsmux");

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -9507,6 +9507,34 @@ function Invoke-ManualChecklist {
     $output | Write-Output
 }
 
+function Invoke-Guard {
+    param(
+        [AllowNull()][string]$GuardTarget = $Target,
+        [AllowNull()][string[]]$GuardRest = $Rest
+    )
+
+    $tokens = @(@($GuardTarget) + @($GuardRest) | Where-Object { $_ })
+    $rustArgs = @('guard')
+    foreach ($token in $tokens) {
+        switch ($token) {
+            '--json' {
+                $rustArgs += '--json'
+            }
+            default {
+                Stop-WithError "usage: winsmux guard [--json]"
+            }
+        }
+    }
+
+    $output = Invoke-WinsmuxRaw -Arguments $rustArgs
+    $nativeExitCode = Get-SafeLastExitCode
+    if ($null -ne $nativeExitCode -and $nativeExitCode -ne 0) {
+        exit $nativeExitCode
+    }
+
+    $output | Write-Output
+}
+
 function Invoke-ProviderSwitch {
     $tokens = @(@($Target) + @($Rest) | Where-Object { $_ })
     if ($tokens.Count -lt 1) {
@@ -9706,6 +9734,7 @@ Commands:
   machine-contract --json  Print the hook and agent machine contract JSON
   rust-canary [--json]  Print the Rust default-on canary gate JSON
   manual-checklist [--json]  Print the versioned manual validation checklist gate
+  guard [--json]  Print the public security and release guard baseline
   assign --task <TASK-ID> [--json] [--text <text>]  Dry-run provider, role, model-tier, approval, and sandbox assignment
   provider-switch <slot> [--agent <name>] [--model <name>] [--prompt-transport <argv|file|stdin>] [--auth-mode <mode>] [--reason <text>] [--restart] [--clear] [--json]  Record or clear a runtime provider reassignment for a managed slot
   github-preflight [--repo <owner/name>] [--json] [--connector-available] [--require-gh]  Select the GitHub write path before merge/release automation
@@ -10431,6 +10460,7 @@ switch ($Command) {
     'machine-contract' { Invoke-MachineContract }
     'rust-canary' { Invoke-RustCanary }
     'manual-checklist' { Invoke-ManualChecklist }
+    'guard' { Invoke-Guard }
     'assign' {
         $assignScript = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\winsmux-core\scripts\assignment-policy.ps1'))
         $assignArgs = @()

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -11150,6 +11150,35 @@ Describe 'winsmux provider-capabilities command' {
     }
 }
 
+Describe 'winsmux guard command' {
+    BeforeAll {
+        $script:winsmuxGuardCoreRawPath = Join-Path (Split-Path -Parent $PSScriptRoot) 'scripts\winsmux-core.ps1'
+        $script:winsmuxGuardCoreRawContent = Get-Content -Raw -Path $script:winsmuxGuardCoreRawPath -Encoding UTF8
+        . $script:winsmuxGuardCoreRawPath 'version' *> $null
+    }
+
+    It 'documents guard in usage and delegates to the Rust guard report' {
+        $script:winsmuxGuardCoreRawContent | Should -Match 'guard \[--json\]'
+        $script:winsmuxGuardCoreRawContent | Should -Match "'guard'\s*\{ Invoke-Guard \}"
+
+        Mock Invoke-WinsmuxRaw {
+            param([string[]]$Arguments)
+            $script:guardArgs = @($Arguments)
+            return '{"command":"guard","task_ids":["TASK-383","TASK-384"]}'
+        }
+
+        $output = Invoke-Guard -GuardTarget '--json'
+        $json = $output | ConvertFrom-Json
+        $script:guardArgs | Should -Be @('guard', '--json')
+        $json.command | Should -Be 'guard'
+        @($json.task_ids) | Should -Be @('TASK-383', 'TASK-384')
+    }
+
+    It 'rejects unknown guard arguments' {
+        { Invoke-Guard -GuardTarget '--private' } | Should -Throw '*usage: winsmux guard [--json]*'
+    }
+}
+
 Describe 'winsmux assign command' {
     BeforeAll {
         $script:winsmuxAssignRawPath = Join-Path (Split-Path -Parent $PSScriptRoot) 'scripts\winsmux-core.ps1'


### PR DESCRIPTION
## Summary

- Add `winsmux guard [--json]` as a public-safe release guard baseline report.
- Surface required guard checks for git-guard, public surface audit, gitleaks, evidence envelope, audit chain, and release notes contract.
- Add PowerShell wrapper support and focused Rust/Pester coverage.

## Validation

- `cargo test -p winsmux --test operator_cli guard -- --nocapture` passed: 2 passed, 0 failed.
- `Invoke-Pester -Path tests\winsmux-bridge.Tests.ps1 -FullName 'winsmux guard command*' -Output Detailed` passed: 2 passed, 0 failed.
- `git diff --check` passed.
- `git-guard`, `audit-public-surface`, and `gitleaks` passed during push.

Refs #523
Refs #525