### PR TITLE
feat: add verification envelope projection

### DIFF
--- a/core/src/ledger.rs
+++ b/core/src/ledger.rs
@@ -2638,6 +2638,9 @@ fn run_verification_envelope_value(run: &LedgerExplainRun) -> Value {
         .and_then(Value::as_array)
         .map(Vec::len)
         .unwrap_or(0);
+    let draft_pr_gate_state = value_field_string(&run.draft_pr_gate, "state");
+    let phase_gate_stop_reason = value_field_string(&run.phase_gate, "stop_reason");
+    let phase_gate_stop_stage = value_field_string(&run.phase_gate, "stop_stage");
     let evidence_complete = !verification_outcome.trim().is_empty()
         && !run.verification_evidence.is_null()
         && !run.audit_chain.is_null();
@@ -2661,10 +2664,27 @@ fn run_verification_envelope_value(run: &LedgerExplainRun) -> Value {
             first_non_empty(&approval_state, &run.review_state)
         ));
     }
+    if !draft_pr_gate_state.trim().is_empty() && draft_pr_gate_state != "passed" {
+        blocked_reasons.push(format!("draft PR gate is {draft_pr_gate_state}"));
+    }
+    if !phase_gate_stop_reason.trim().is_empty() {
+        let stage = if phase_gate_stop_stage.trim().is_empty() {
+            "unknown"
+        } else {
+            phase_gate_stop_stage.as_str()
+        };
+        blocked_reasons.push(format!(
+            "phase gate stopped at {stage}: {phase_gate_stop_reason}"
+        ));
+    }
+
+    let human_judgement_required = run.review_required
+        || !draft_pr_gate_state.trim().is_empty() && draft_pr_gate_state != "passed"
+        || phase_gate_stop_reason == "needs_user_decision";
 
     let status = if !blocked_reasons.is_empty() {
         "blocked"
-    } else if run.review_required {
+    } else if human_judgement_required {
         "approved"
     } else {
         "ready"
@@ -2701,6 +2721,8 @@ fn run_verification_envelope_value(run: &LedgerExplainRun) -> Value {
                 "blocked": security_verdict == "BLOCK"
             },
             "approval": approval,
+            "draft_pr": run.draft_pr_gate,
+            "phase": run.phase_gate,
             "audit": {
                 "chain_id": value_field_string(&run.audit_chain, "chain_id"),
                 "event_count": audit_events,
@@ -2710,7 +2732,7 @@ fn run_verification_envelope_value(run: &LedgerExplainRun) -> Value {
         "release_decision": {
             "status": status,
             "blocked_reasons": blocked_reasons,
-            "human_judgement_required": run.review_required,
+            "human_judgement_required": human_judgement_required,
             "automatic_merge_allowed": false
         },
         "verification_evidence": run.verification_evidence,

--- a/core/src/ledger.rs
+++ b/core/src/ledger.rs
@@ -2217,6 +2217,7 @@ fn run_phase_gate_value(
                 "",
             );
             stop_reason = "needs_user_decision".to_string();
+            stop_stage = "package".to_string();
         }
     } else if run.review_state == "PENDING" {
         set_run_phase_stage(
@@ -2229,6 +2230,7 @@ fn run_phase_gate_value(
     } else if matches!(run.review_state.as_str(), "FAIL" | "FAILED") {
         set_run_phase_stage(&mut stages, "review", "blocked", "review_failed", "");
         stop_reason = "review_failed".to_string();
+        stop_stage = "review".to_string();
     }
 
     if matches!(
@@ -2239,12 +2241,14 @@ fn run_phase_gate_value(
         set_run_phase_stage(&mut stages, "package", "completed", &run.task_state, "");
         if matches!(run.task_state.as_str(), "commit_ready" | "done") {
             stop_reason.clear();
+            stop_stage.clear();
         }
     }
 
     if value_field_string(&run.tdd_gate, "state") == "blocked" {
         set_run_phase_stage(&mut stages, "test", "blocked", "tdd_evidence_missing", "");
         stop_reason = "tdd_evidence_missing".to_string();
+        stop_stage = "test".to_string();
     }
 
     let current_stage = stages
@@ -2272,6 +2276,7 @@ fn run_phase_gate_value(
         "stages": stage_values,
         "stop_required": stop_required,
         "stop_reason": stop_reason,
+        "stop_stage": stop_stage,
         "auto_continue_allowed": !stop_required,
         "requires_human_decision": matches!(stop_reason.as_str(), "needs_user_decision" | "draft_pr"),
     })

--- a/core/src/ledger.rs
+++ b/core/src/ledger.rs
@@ -278,6 +278,7 @@ pub struct LedgerExplainRun {
     pub verification_result: Value,
     pub verification_evidence: Value,
     pub tdd_gate: Value,
+    pub verification_envelope: Value,
     pub audit_chain: Value,
     pub outcome: Value,
     pub phase_gate: Value,
@@ -472,6 +473,7 @@ pub struct LedgerRunProjection {
     pub verification_result: Value,
     pub verification_evidence: Value,
     pub tdd_gate: Value,
+    pub verification_envelope: Value,
     pub audit_chain: Value,
     pub outcome: Value,
     pub phase_gate: Value,
@@ -517,6 +519,7 @@ pub struct LedgerRunPacket {
     pub verification_result: Value,
     pub verification_evidence: Value,
     pub tdd_gate: Value,
+    pub verification_envelope: Value,
     pub audit_chain: Value,
     pub outcome: Value,
     pub phase_gate: Value,
@@ -730,6 +733,9 @@ impl LedgerRunProjection {
                 .map(|run| run.verification_evidence.clone())
                 .unwrap_or(Value::Null),
             tdd_gate: run.map(|run| run.tdd_gate.clone()).unwrap_or(Value::Null),
+            verification_envelope: run
+                .map(|run| run.verification_envelope.clone())
+                .unwrap_or(Value::Null),
             audit_chain: run
                 .map(|run| run.audit_chain.clone())
                 .unwrap_or(Value::Null),
@@ -782,6 +788,7 @@ impl LedgerRunPacket {
             verification_result: run.verification_result.clone(),
             verification_evidence: run.verification_evidence.clone(),
             tdd_gate: run.tdd_gate.clone(),
+            verification_envelope: run.verification_envelope.clone(),
             audit_chain: run.audit_chain.clone(),
             outcome: run.outcome.clone(),
             phase_gate: run.phase_gate.clone(),
@@ -1297,6 +1304,7 @@ impl LedgerSnapshot {
             verification_result,
             verification_evidence,
             tdd_gate: Value::Null,
+            verification_envelope: Value::Null,
             audit_chain: Value::Null,
             outcome: Value::Null,
             phase_gate: Value::Null,
@@ -1307,6 +1315,7 @@ impl LedgerSnapshot {
         run.tdd_gate = run_tdd_gate_value(&run, &recent_event_records);
         run.phase_gate = run_phase_gate_value(&run, &recent_event_records, &run.draft_pr_gate);
         run.audit_chain = run_audit_chain_value(&run, &recent_event_records);
+        run.verification_envelope = run_verification_envelope_value(&run);
         run.outcome = run_outcome_value(&run, &run.phase_gate, &run.draft_pr_gate);
         let explanation = explain_explanation(&run, &evidence_digest);
 
@@ -2605,6 +2614,108 @@ fn audit_chain_event_value(event: &EventRecord) -> Value {
         "branch": event_branch(event),
         "head_sha": event_head_sha(event),
         "message": event.message,
+    })
+}
+
+fn run_verification_envelope_value(run: &LedgerExplainRun) -> Value {
+    let verification_outcome = value_field_string(&run.verification_result, "outcome");
+    let verification_summary = value_field_string(&run.verification_result, "summary");
+    let verification_next_action = value_field_string(&run.verification_result, "next_action");
+    let security_verdict = first_non_empty(
+        &value_field_string(&run.security_verdict, "verdict"),
+        run.security_verdict.as_str().unwrap_or_default(),
+    );
+    let security_reason = value_field_string(&run.security_verdict, "reason");
+    let approval = run
+        .audit_chain
+        .get("approval")
+        .cloned()
+        .unwrap_or(Value::Null);
+    let approval_state = value_field_string(&approval, "state");
+    let audit_events = run
+        .audit_chain
+        .get("events")
+        .and_then(Value::as_array)
+        .map(Vec::len)
+        .unwrap_or(0);
+    let evidence_complete = !verification_outcome.trim().is_empty()
+        && !run.verification_evidence.is_null()
+        && !run.audit_chain.is_null();
+
+    let mut blocked_reasons = Vec::new();
+    if verification_outcome.trim().is_empty() {
+        blocked_reasons.push("verification evidence is missing".to_string());
+    } else if verification_outcome != "PASS" {
+        blocked_reasons.push(format!("verification outcome is {verification_outcome}"));
+    }
+    if security_verdict == "BLOCK" {
+        blocked_reasons.push(if security_reason.trim().is_empty() {
+            "security policy blocked the run".to_string()
+        } else {
+            security_reason.clone()
+        });
+    }
+    if run.review_required && approval_state != "approved" {
+        blocked_reasons.push(format!(
+            "approval state is unresolved: {}",
+            first_non_empty(&approval_state, &run.review_state)
+        ));
+    }
+
+    let status = if !blocked_reasons.is_empty() {
+        "blocked"
+    } else if run.review_required {
+        "approved"
+    } else {
+        "ready"
+    };
+
+    json!({
+        "contract_version": 1,
+        "packet_type": "verification_envelope",
+        "scope": "release_run",
+        "run_id": run.run_id,
+        "task_id": run.task_id,
+        "static_gates": {
+            "verification_plan": run.verification_plan,
+            "changed_files": run.changed_files,
+            "review_required": run.review_required,
+            "required_fields": [
+                "verification_evidence",
+                "security_verdict",
+                "audit_chain",
+                "draft_pr_gate",
+                "phase_gate"
+            ]
+        },
+        "dynamic_gates": {
+            "verification": {
+                "outcome": verification_outcome,
+                "summary": verification_summary,
+                "next_action": verification_next_action,
+                "evidence_complete": evidence_complete
+            },
+            "security": {
+                "verdict": security_verdict,
+                "reason": security_reason,
+                "blocked": security_verdict == "BLOCK"
+            },
+            "approval": approval,
+            "audit": {
+                "chain_id": value_field_string(&run.audit_chain, "chain_id"),
+                "event_count": audit_events,
+                "last_event": run.last_event
+            }
+        },
+        "release_decision": {
+            "status": status,
+            "blocked_reasons": blocked_reasons,
+            "human_judgement_required": run.review_required,
+            "automatic_merge_allowed": false
+        },
+        "verification_evidence": run.verification_evidence,
+        "security_verdict": run.security_verdict,
+        "audit_chain": run.audit_chain,
     })
 }
 

--- a/core/src/operator_cli.rs
+++ b/core/src/operator_cli.rs
@@ -5839,7 +5839,7 @@ fn guard_report_payload(project_dir: &Path) -> Value {
     json!({
         "contract_version": 1,
         "command": "guard",
-        "task_ids": ["TASK-383", "TASK-384"],
+        "task_ids": ["TASK-362", "TASK-383", "TASK-384"],
         "target_version": "v0.24.10",
         "generated_at": generated_at(),
         "project_dir": project_dir_string(project_dir),
@@ -5862,6 +5862,7 @@ fn guard_report_payload(project_dir: &Path) -> Value {
         "evidence_contract": {
             "run_surfaces": ["winsmux runs --json", "winsmux digest --json", "winsmux explain <run_id> --json"],
             "required_fields": [
+                "verification_envelope",
                 "verification_evidence",
                 "security_verdict",
                 "audit_chain",
@@ -5875,7 +5876,19 @@ fn guard_report_payload(project_dir: &Path) -> Value {
                 "pipeline.verify.fail",
                 "pipeline.security.allowed",
                 "pipeline.security.blocked"
-            ]
+            ],
+            "envelope_required_fields": [
+                "contract_version",
+                "packet_type",
+                "scope",
+                "static_gates",
+                "dynamic_gates",
+                "release_decision"
+            ],
+            "release_decision": {
+                "automatic_merge_allowed": false,
+                "human_judgement_required": true
+            }
         },
         "public_safety": {
             "tracked_private_paths_allowed": false,

--- a/core/tests-rs/fixture_comparison.rs
+++ b/core/tests-rs/fixture_comparison.rs
@@ -243,6 +243,7 @@ const EXPLAIN_RUN_KEYS: &[&str] = &[
     "verification_result",
     "verification_evidence",
     "tdd_gate",
+    "verification_envelope",
     "audit_chain",
     "outcome",
     "phase_gate",

--- a/core/tests-rs/ledger_contract.rs
+++ b/core/tests-rs/ledger_contract.rs
@@ -721,6 +721,19 @@ panes:
         explain.run.verification_envelope["release_decision"]["status"],
         "blocked"
     );
+    assert_eq!(
+        explain.run.verification_envelope["dynamic_gates"]["draft_pr"]["state"],
+        "blocked"
+    );
+    assert_eq!(
+        explain.run.verification_envelope["dynamic_gates"]["phase"]["stop_reason"],
+        "needs_user_decision"
+    );
+    assert!(explain.run.verification_envelope["release_decision"]["blocked_reasons"]
+        .as_array()
+        .expect("blocked reasons should be an array")
+        .iter()
+        .any(|reason| reason == "draft PR gate is blocked"));
     assert!(explain.run.audit_chain["events"]
         .as_array()
         .expect("audit chain events should be an array")
@@ -1000,6 +1013,10 @@ fn ledger_contract_serializes_typed_cli_payload_roots() {
     assert_root_keys(&runs, &["generated_at", "project_dir", "runs", "summary"]);
     assert_eq!(runs["summary"]["run_count"], 2);
     assert!(runs["runs"][0]["run_packet"].is_object());
+    assert!(runs["runs"].as_array().unwrap().iter().any(|run| {
+        run["verification_envelope"]["packet_type"] == "verification_envelope"
+            && run["run_packet"]["verification_envelope"]["packet_type"] == "verification_envelope"
+    }));
 
     let explain_projection = snapshot
         .explain_projection("task:task-256")
@@ -1028,6 +1045,65 @@ fn ledger_contract_serializes_typed_cli_payload_roots() {
         ],
     );
     assert_eq!(explain["run"]["run_id"], "task:task-256");
+}
+
+#[test]
+fn ledger_contract_blocks_verification_envelope_when_draft_pr_or_phase_gate_waits() {
+    let manifest = r#"
+version: 1
+session:
+  name: winsmux-orchestra
+panes:
+  builder-1:
+    pane_id: "%2"
+    role: Builder
+    task_id: task-approved-no-pr
+    task: Implement guarded change
+    task_state: completed
+    review_state: PASS
+    branch: worktree-approved-no-pr
+    head_sha: abc1234def5678
+    review_required: true
+    verification_plan: ["cargo test"]
+"#;
+    let events = r#"{"timestamp":"2026-04-23T12:00:01+09:00","session":"winsmux-orchestra","event":"pipeline.verify.pass","message":"verification passed","status":"completed","data":{"task_id":"task-approved-no-pr","verification_result":{"outcome":"PASS","summary":"tests passed"}}}
+{"timestamp":"2026-04-23T12:00:02+09:00","session":"winsmux-orchestra","event":"pipeline.security.allowed","message":"security allowed","status":"ALLOW","data":{"task_id":"task-approved-no-pr","security_verdict":{"verdict":"ALLOW","reason":"policy passed"}}}
+"#;
+
+    let snapshot = ledger::LedgerSnapshot::from_manifest_and_events(manifest, events)
+        .expect("ledger snapshot should load gated envelope inputs");
+    let explain = snapshot
+        .explain_projection("task:task-approved-no-pr")
+        .expect("approved run should still explain");
+
+    assert_eq!(
+        explain.run.verification_envelope["dynamic_gates"]["verification"]["outcome"],
+        "PASS"
+    );
+    assert_eq!(
+        explain.run.verification_envelope["dynamic_gates"]["approval"]["state"],
+        "approved"
+    );
+    assert_eq!(
+        explain.run.verification_envelope["dynamic_gates"]["draft_pr"]["state"],
+        "required"
+    );
+    assert_eq!(
+        explain.run.verification_envelope["dynamic_gates"]["phase"]["stop_reason"],
+        "needs_user_decision"
+    );
+    assert_eq!(
+        explain.run.verification_envelope["release_decision"]["status"],
+        "blocked"
+    );
+    let reasons = explain.run.verification_envelope["release_decision"]["blocked_reasons"]
+        .as_array()
+        .expect("blocked reasons should be an array");
+    assert!(reasons.iter().any(|reason| reason == "draft PR gate is required"));
+    assert!(reasons.iter().any(|reason| reason
+        .as_str()
+        .expect("blocked reason should be a string")
+        .starts_with("phase gate stopped at ")));
 }
 
 #[test]

--- a/core/tests-rs/ledger_contract.rs
+++ b/core/tests-rs/ledger_contract.rs
@@ -697,6 +697,30 @@ panes:
     assert_eq!(explain.run.audit_chain["approval"]["required"], true);
     assert_eq!(explain.run.audit_chain["approval"]["state"], "pending");
     assert_eq!(explain.run.audit_chain["approval"]["requested_at"], "");
+    assert_eq!(
+        explain.run.verification_envelope["packet_type"],
+        "verification_envelope"
+    );
+    assert_eq!(
+        explain.run.verification_envelope["static_gates"]["required_fields"][0],
+        "verification_evidence"
+    );
+    assert_eq!(
+        explain.run.verification_envelope["dynamic_gates"]["verification"]["outcome"],
+        "PASS"
+    );
+    assert_eq!(
+        explain.run.verification_envelope["dynamic_gates"]["security"]["verdict"],
+        "ALLOW"
+    );
+    assert_eq!(
+        explain.run.verification_envelope["dynamic_gates"]["approval"]["state"],
+        "pending"
+    );
+    assert_eq!(
+        explain.run.verification_envelope["release_decision"]["status"],
+        "blocked"
+    );
     assert!(explain.run.audit_chain["events"]
         .as_array()
         .expect("audit chain events should be an array")

--- a/core/tests-rs/ledger_contract.rs
+++ b/core/tests-rs/ledger_contract.rs
@@ -729,6 +729,10 @@ panes:
         explain.run.verification_envelope["dynamic_gates"]["phase"]["stop_reason"],
         "needs_user_decision"
     );
+    assert_eq!(
+        explain.run.verification_envelope["dynamic_gates"]["phase"]["stop_stage"],
+        "package"
+    );
     assert!(explain.run.verification_envelope["release_decision"]["blocked_reasons"]
         .as_array()
         .expect("blocked reasons should be an array")
@@ -1100,10 +1104,34 @@ panes:
         .as_array()
         .expect("blocked reasons should be an array");
     assert!(reasons.iter().any(|reason| reason == "draft PR gate is required"));
-    assert!(reasons.iter().any(|reason| reason
-        .as_str()
-        .expect("blocked reason should be a string")
-        .starts_with("phase gate stopped at ")));
+    assert!(reasons
+        .iter()
+        .any(|reason| reason == "phase gate stopped at package: needs_user_decision"));
+
+    let runs = serde_json::to_value(ledger::LedgerRunsPayload::from_snapshot(
+        "2026-04-27T00:00:00Z".to_string(),
+        "C:\\repo".to_string(),
+        &snapshot,
+    ))
+    .expect("runs payload should serialize");
+    let gated_run = runs["runs"]
+        .as_array()
+        .expect("runs should be an array")
+        .iter()
+        .find(|run| run["run_id"] == "task:task-approved-no-pr")
+        .expect("gated run should be present");
+    assert_eq!(
+        gated_run["verification_envelope"]["release_decision"]["status"],
+        "blocked"
+    );
+    assert_eq!(
+        gated_run["run_packet"]["verification_envelope"]["release_decision"]["status"],
+        "blocked"
+    );
+    assert_eq!(
+        gated_run["verification_envelope"]["dynamic_gates"]["phase"]["stop_stage"],
+        "package"
+    );
 }
 
 #[test]

--- a/core/tests-rs/ledger_contract.rs
+++ b/core/tests-rs/ledger_contract.rs
@@ -727,11 +727,11 @@ panes:
     );
     assert_eq!(
         explain.run.verification_envelope["dynamic_gates"]["phase"]["stop_reason"],
-        "needs_user_decision"
+        "tdd_evidence_missing"
     );
     assert_eq!(
         explain.run.verification_envelope["dynamic_gates"]["phase"]["stop_stage"],
-        "package"
+        "test"
     );
     assert!(explain.run.verification_envelope["release_decision"]["blocked_reasons"]
         .as_array()

--- a/core/tests-rs/operator_cli.rs
+++ b/core/tests-rs/operator_cli.rs
@@ -729,8 +729,9 @@ fn operator_cli_guard_json_reports_release_guard_baseline() {
     let json = run_json(&project_dir, &["guard", "--json"]);
 
     assert_eq!(json["command"], "guard");
-    assert_eq!(json["task_ids"][0], "TASK-383");
-    assert_eq!(json["task_ids"][1], "TASK-384");
+    assert_eq!(json["task_ids"][0], "TASK-362");
+    assert_eq!(json["task_ids"][1], "TASK-383");
+    assert_eq!(json["task_ids"][2], "TASK-384");
     assert_eq!(json["target_version"], "v0.24.10");
     assert_eq!(json["summary"]["required_check_count"], 5);
     assert_eq!(json["summary"]["available_check_count"], 5);
@@ -739,7 +740,7 @@ fn operator_cli_guard_json_reports_release_guard_baseline() {
         "scripts/gitleaks-history-baseline.txt"
     );
     assert_eq!(
-        json["evidence_contract"]["required_fields"][2],
+        json["evidence_contract"]["required_fields"][3],
         "audit_chain"
     );
     assert_eq!(

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -6338,6 +6338,102 @@ function New-RunDraftPrHandoffPackage {
     }
 }
 
+function New-RunVerificationEnvelope {
+    param([Parameter(Mandatory = $true)]$Run)
+
+    $verificationOutcome = [string](Get-RunContractField -InputObject $Run.verification_result -Name 'outcome')
+    $verificationSummary = [string](Get-RunContractField -InputObject $Run.verification_result -Name 'summary')
+    $verificationNextAction = [string](Get-RunContractField -InputObject $Run.verification_result -Name 'next_action')
+    $securityVerdict = [string](Get-RunContractField -InputObject $Run.security_verdict -Name 'verdict')
+    if ([string]::IsNullOrWhiteSpace($securityVerdict) -and $Run.security_verdict -is [string]) {
+        $securityVerdict = [string]$Run.security_verdict
+    }
+    $securityReason = [string](Get-RunContractField -InputObject $Run.security_verdict -Name 'reason')
+    $approval = $null
+    if ($null -ne $Run.audit_chain -and $null -ne $Run.audit_chain.approval) {
+        $approval = $Run.audit_chain.approval
+    }
+    $approvalState = [string](Get-RunContractField -InputObject $approval -Name 'state')
+    $auditChainId = [string](Get-RunContractField -InputObject $Run.audit_chain -Name 'chain_id')
+    $auditEventCount = 0
+    if ($null -ne $Run.audit_chain -and $null -ne $Run.audit_chain.events) {
+        $auditEventCount = @($Run.audit_chain.events).Count
+    }
+
+    $evidenceComplete = (
+        -not [string]::IsNullOrWhiteSpace($verificationOutcome) -and
+        $null -ne $Run.verification_evidence -and
+        $null -ne $Run.audit_chain
+    )
+    $blockedReasons = [System.Collections.Generic.List[string]]::new()
+    if ([string]::IsNullOrWhiteSpace($verificationOutcome)) {
+        $blockedReasons.Add('verification evidence is missing') | Out-Null
+    } elseif ($verificationOutcome -ne 'PASS') {
+        $blockedReasons.Add("verification outcome is $verificationOutcome") | Out-Null
+    }
+    if ($securityVerdict -eq 'BLOCK') {
+        if ([string]::IsNullOrWhiteSpace($securityReason)) {
+            $blockedReasons.Add('security policy blocked the run') | Out-Null
+        } else {
+            $blockedReasons.Add($securityReason) | Out-Null
+        }
+    }
+    if ([bool]$Run.review_required -and $approvalState -ne 'approved') {
+        $stateText = if (-not [string]::IsNullOrWhiteSpace($approvalState)) { $approvalState } else { [string]$Run.review_state }
+        $blockedReasons.Add("approval state is unresolved: $stateText") | Out-Null
+    }
+
+    $status = if (@($blockedReasons).Count -gt 0) {
+        'blocked'
+    } elseif ([bool]$Run.review_required) {
+        'approved'
+    } else {
+        'ready'
+    }
+
+    return [ordered]@{
+        contract_version     = 1
+        packet_type          = 'verification_envelope'
+        scope                = 'release_run'
+        run_id               = [string]$Run.run_id
+        task_id              = [string]$Run.task_id
+        static_gates         = [ordered]@{
+            verification_plan = @($Run.verification_plan)
+            changed_files     = @($Run.changed_files)
+            review_required   = [bool]$Run.review_required
+            required_fields   = @('verification_evidence', 'security_verdict', 'audit_chain', 'draft_pr_gate', 'phase_gate')
+        }
+        dynamic_gates        = [ordered]@{
+            verification = [ordered]@{
+                outcome           = $verificationOutcome
+                summary           = $verificationSummary
+                next_action       = $verificationNextAction
+                evidence_complete = $evidenceComplete
+            }
+            security     = [ordered]@{
+                verdict = $securityVerdict
+                reason  = $securityReason
+                blocked = ($securityVerdict -eq 'BLOCK')
+            }
+            approval     = $approval
+            audit        = [ordered]@{
+                chain_id    = $auditChainId
+                event_count = $auditEventCount
+                last_event  = [string]$Run.last_event
+            }
+        }
+        release_decision     = [ordered]@{
+            status                   = $status
+            blocked_reasons          = @($blockedReasons)
+            human_judgement_required = [bool]$Run.review_required
+            automatic_merge_allowed  = $false
+        }
+        verification_evidence = $Run.verification_evidence
+        security_verdict      = $Run.security_verdict
+        audit_chain           = $Run.audit_chain
+    }
+}
+
 function New-RunDraftPrGate {
     param(
         [Parameter(Mandatory = $true)]$Run,
@@ -6429,6 +6525,7 @@ function New-RunPacketFromRun {
         verification_result   = $Run.verification_result
         verification_evidence = $Run.verification_evidence
         tdd_gate              = $Run.tdd_gate
+        verification_envelope = $Run.verification_envelope
         plan              = $Run.plan
         plan_checkpoints  = @($Run.plan_checkpoints)
         managed_loop      = $Run.managed_loop
@@ -6511,6 +6608,7 @@ function New-RunResultPacket {
         verification_result   = $Run.verification_result
         verification_evidence = $Run.verification_evidence
         tdd_gate              = $Run.tdd_gate
+        verification_envelope = $Run.verification_envelope
         security_policy       = $Run.security_policy
         security_verdict      = $Run.security_verdict
         plan                  = $Run.plan
@@ -6780,6 +6878,7 @@ function Get-RunsPayload {
                 outcome               = $null
                 draft_pr_gate         = $null
                 tdd_gate              = $null
+                verification_envelope = $null
             }
         }
 
@@ -6941,6 +7040,7 @@ function Get-RunsPayload {
             $run.tdd_gate = New-RunTddGateContract -Run $run -EventRecords $runEvents
             $run.phase_gate = New-RunPhaseGateContract -Run $run -EventRecords $runEvents
             $run.audit_chain = New-RunAuditChainContract -Run $run -EventRecords $runEvents
+            $run.verification_envelope = New-RunVerificationEnvelope -Run $run
             $run.outcome = New-RunOutcomeContract -Run $run
             $nextAction = Get-RunNextAction -Run $run
             $stateModel = New-RunStateModel -State ([string]$run.state) -TaskState ([string]$run.task_state) -ReviewState ([string]$run.review_state) -EventKind $nextAction -LastEvent ([string]$run.last_event)
@@ -6992,6 +7092,7 @@ function Get-RunsPayload {
                 verification_result   = $run.verification_result
                 verification_evidence = $run.verification_evidence
                 tdd_gate              = $run.tdd_gate
+                verification_envelope = $run.verification_envelope
                 plan                  = $run.plan
                 plan_checkpoints      = @($run.plan_checkpoints)
                 managed_loop          = $run.managed_loop

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -6359,6 +6359,9 @@ function New-RunVerificationEnvelope {
     if ($null -ne $Run.audit_chain -and $null -ne $Run.audit_chain.events) {
         $auditEventCount = @($Run.audit_chain.events).Count
     }
+    $draftPrGateState = [string](Get-RunContractField -InputObject $Run.draft_pr_gate -Name 'state')
+    $phaseGateStopReason = [string](Get-RunContractField -InputObject $Run.phase_gate -Name 'stop_reason')
+    $phaseGateStopStage = [string](Get-RunContractField -InputObject $Run.phase_gate -Name 'stop_stage')
 
     $evidenceComplete = (
         -not [string]::IsNullOrWhiteSpace($verificationOutcome) -and
@@ -6382,10 +6385,23 @@ function New-RunVerificationEnvelope {
         $stateText = if (-not [string]::IsNullOrWhiteSpace($approvalState)) { $approvalState } else { [string]$Run.review_state }
         $blockedReasons.Add("approval state is unresolved: $stateText") | Out-Null
     }
+    if (-not [string]::IsNullOrWhiteSpace($draftPrGateState) -and $draftPrGateState -ne 'passed') {
+        $blockedReasons.Add("draft PR gate is $draftPrGateState") | Out-Null
+    }
+    if (-not [string]::IsNullOrWhiteSpace($phaseGateStopReason)) {
+        $stageText = if (-not [string]::IsNullOrWhiteSpace($phaseGateStopStage)) { $phaseGateStopStage } else { 'unknown' }
+        $blockedReasons.Add("phase gate stopped at ${stageText}: $phaseGateStopReason") | Out-Null
+    }
+
+    $humanJudgementRequired = (
+        [bool]$Run.review_required -or
+        (-not [string]::IsNullOrWhiteSpace($draftPrGateState) -and $draftPrGateState -ne 'passed') -or
+        $phaseGateStopReason -eq 'needs_user_decision'
+    )
 
     $status = if (@($blockedReasons).Count -gt 0) {
         'blocked'
-    } elseif ([bool]$Run.review_required) {
+    } elseif ($humanJudgementRequired) {
         'approved'
     } else {
         'ready'
@@ -6416,6 +6432,8 @@ function New-RunVerificationEnvelope {
                 blocked = ($securityVerdict -eq 'BLOCK')
             }
             approval     = $approval
+            draft_pr     = $Run.draft_pr_gate
+            phase        = $Run.phase_gate
             audit        = [ordered]@{
                 chain_id    = $auditChainId
                 event_count = $auditEventCount
@@ -6425,7 +6443,7 @@ function New-RunVerificationEnvelope {
         release_decision     = [ordered]@{
             status                   = $status
             blocked_reasons          = @($blockedReasons)
-            human_judgement_required = [bool]$Run.review_required
+            human_judgement_required = $humanJudgementRequired
             automatic_merge_allowed  = $false
         }
         verification_evidence = $Run.verification_evidence

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -6231,6 +6231,7 @@ function New-RunPhaseGateContract {
         stages                  = $stages
         stop_required           = -not [string]::IsNullOrWhiteSpace($stopReason)
         stop_reason             = $stopReason
+        stop_stage              = $stopStage
         auto_continue_allowed   = [string]::IsNullOrWhiteSpace($stopReason)
         requires_human_decision = $stopReason -in @('needs_user_decision', 'draft_pr')
     }

--- a/tests/fixtures/rust-parity/explain.json
+++ b/tests/fixtures/rust-parity/explain.json
@@ -107,6 +107,140 @@
       "red_event": "pipeline.tdd.red",
       "exception_event": ""
     },
+    "verification_envelope": {
+      "contract_version": 1,
+      "packet_type": "verification_envelope",
+      "scope": "release_run",
+      "run_id": "task:task-256",
+      "task_id": "task-256",
+      "static_gates": {
+        "verification_plan": [
+          "Invoke-Pester tests/winsmux-bridge.Tests.ps1",
+          "verify explain --json contract"
+        ],
+        "changed_files": [
+          "scripts/winsmux-core.ps1"
+        ],
+        "review_required": true,
+        "required_fields": [
+          "verification_evidence",
+          "security_verdict",
+          "audit_chain",
+          "draft_pr_gate",
+          "phase_gate"
+        ]
+      },
+      "dynamic_gates": {
+        "verification": {
+          "outcome": "",
+          "summary": "",
+          "next_action": "",
+          "evidence_complete": false
+        },
+        "security": {
+          "verdict": "",
+          "reason": "",
+          "blocked": false
+        },
+        "approval": {
+          "required": true,
+          "state": "pending",
+          "verdict": "PENDING",
+          "requested_at": "2026-04-10T03:01:00Z",
+          "requested_event": "operator.review_requested",
+          "requested_reviewer_label": "reviewer-1",
+          "requested_reviewer_pane": "%3",
+          "requested_reviewer_role": "Reviewer",
+          "decided_at": "",
+          "decided_event": "",
+          "human_judgement_required": true,
+          "automatic_merge_allowed": false
+        },
+        "audit": {
+          "chain_id": "task:task-256",
+          "event_count": 2,
+          "last_event": "operator.review_requested"
+        }
+      },
+      "release_decision": {
+        "status": "blocked",
+        "blocked_reasons": [
+          "verification evidence is missing",
+          "approval state is unresolved: pending"
+        ],
+        "human_judgement_required": true,
+        "automatic_merge_allowed": false
+      },
+      "verification_evidence": null,
+      "security_verdict": null,
+      "audit_chain": {
+        "chain_id": "task:task-256",
+        "subject": {
+          "task_id": "task-256",
+          "task": "Implement run ledger",
+          "task_type": "implementation",
+          "priority": "P0",
+          "branch": "worktree-builder-1",
+          "head_sha": "abc1234def5678",
+          "changed_files": [
+            "scripts/winsmux-core.ps1"
+          ]
+        },
+        "actor": {
+          "label": "builder-1",
+          "pane_id": "%2",
+          "role": "Builder",
+          "provider_target": "codex:gpt-5.4",
+          "agent_role": "worker"
+        },
+        "approval": {
+          "required": true,
+          "state": "pending",
+          "verdict": "PENDING",
+          "requested_at": "2026-04-10T03:01:00Z",
+          "requested_event": "operator.review_requested",
+          "requested_reviewer_label": "reviewer-1",
+          "requested_reviewer_pane": "%3",
+          "requested_reviewer_role": "Reviewer",
+          "decided_at": "",
+          "decided_event": "",
+          "human_judgement_required": true,
+          "automatic_merge_allowed": false
+        },
+        "events": [
+          {
+            "at": "2026-04-10T03:01:00Z",
+            "event": "operator.review_requested",
+            "who": {
+              "label": "reviewer-1",
+              "pane_id": "%3",
+              "role": "Reviewer"
+            },
+            "what": "operator.review_requested",
+            "task_id": "task-256",
+            "run_id": "",
+            "branch": "worktree-builder-1",
+            "head_sha": "abc1234def5678",
+            "message": "review requested"
+          },
+          {
+            "at": "2026-04-10T03:03:00Z",
+            "event": "pipeline.tdd.red",
+            "who": {
+              "label": "operator",
+              "pane_id": "",
+              "role": "Operator"
+            },
+            "what": "pipeline.tdd.red",
+            "task_id": "task-256",
+            "run_id": "task:task-256",
+            "branch": "worktree-builder-1",
+            "head_sha": "abc1234def5678",
+            "message": "test failed before implementation"
+          }
+        ]
+      }
+    },
     "plan": {
       "goal": "Ship run contract primitives",
       "task_type": "implementation",

--- a/tests/fixtures/rust-parity/explain.json
+++ b/tests/fixtures/rust-parity/explain.json
@@ -156,6 +156,89 @@
           "human_judgement_required": true,
           "automatic_merge_allowed": false
         },
+        "draft_pr": {
+          "kind": "human_judgement",
+          "target": "draft_pr",
+          "state": "blocked",
+          "trigger": "review_state",
+          "draft_pr_url": "",
+          "auto_merge_allowed": false,
+          "merge_requires_human": true,
+          "handoff_package": {
+            "summary": "consult before work",
+            "validation": {
+              "evidence_complete": false,
+              "outcome": "",
+              "summary": "",
+              "next_action": "",
+              "verification_plan": [
+                "Invoke-Pester tests/winsmux-bridge.Tests.ps1",
+                "verify explain --json contract"
+              ],
+              "changed_files": [
+                "scripts/winsmux-core.ps1"
+              ]
+            },
+            "remaining_risks": [
+              "verification evidence is missing",
+              "review state is unresolved: PENDING"
+            ],
+            "suggested_next_action": "resolve blocked reasons before creating or merging a draft PR",
+            "blocked_reasons": [
+              "verification evidence is missing",
+              "review state is unresolved: PENDING"
+            ],
+            "package_complete": false,
+            "human_judgement_required": true,
+            "automatic_merge_allowed": false
+          }
+        },
+        "phase": {
+          "order": [
+            "plan",
+            "build",
+            "test",
+            "review",
+            "package"
+          ],
+          "current_stage": "review",
+          "stages": [
+            {
+              "stage": "plan",
+              "status": "completed",
+              "reason": "run_plan_recorded",
+              "event": ""
+            },
+            {
+              "stage": "build",
+              "status": "in_progress",
+              "reason": "in_progress",
+              "event": ""
+            },
+            {
+              "stage": "test",
+              "status": "pending",
+              "reason": "",
+              "event": ""
+            },
+            {
+              "stage": "review",
+              "status": "waiting_for_input",
+              "reason": "review_pending",
+              "event": "operator.review_requested"
+            },
+            {
+              "stage": "package",
+              "status": "pending",
+              "reason": "",
+              "event": ""
+            }
+          ],
+          "stop_required": false,
+          "stop_reason": "",
+          "auto_continue_allowed": true,
+          "requires_human_decision": false
+        },
         "audit": {
           "chain_id": "task:task-256",
           "event_count": 2,
@@ -166,7 +249,8 @@
         "status": "blocked",
         "blocked_reasons": [
           "verification evidence is missing",
-          "approval state is unresolved: pending"
+          "approval state is unresolved: pending",
+          "draft PR gate is blocked"
         ],
         "human_judgement_required": true,
         "automatic_merge_allowed": false

--- a/tests/fixtures/rust-parity/explain.json
+++ b/tests/fixtures/rust-parity/explain.json
@@ -236,6 +236,7 @@
           ],
           "stop_required": false,
           "stop_reason": "",
+          "stop_stage": "",
           "auto_continue_allowed": true,
           "requires_human_decision": false
         },
@@ -474,6 +475,7 @@
       ],
       "stop_required": false,
       "stop_reason": "",
+      "stop_stage": "",
       "auto_continue_allowed": true,
       "requires_human_decision": false
     },

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -11164,14 +11164,14 @@ Describe 'winsmux guard command' {
         Mock Invoke-WinsmuxRaw {
             param([string[]]$Arguments)
             $script:guardArgs = @($Arguments)
-            return '{"command":"guard","task_ids":["TASK-383","TASK-384"]}'
+            return '{"command":"guard","task_ids":["TASK-362","TASK-383","TASK-384"]}'
         }
 
         $output = Invoke-Guard -GuardTarget '--json'
         $json = $output | ConvertFrom-Json
         $script:guardArgs | Should -Be @('guard', '--json')
         $json.command | Should -Be 'guard'
-        @($json.task_ids) | Should -Be @('TASK-383', 'TASK-384')
+        @($json.task_ids) | Should -Be @('TASK-362', 'TASK-383', 'TASK-384')
     }
 
     It 'rejects unknown guard arguments' {


### PR DESCRIPTION
## Summary
- Add verification_envelope to Rust and PowerShell run projections.
- Include the envelope in run packets and guard evidence contract for TASK-362.
- Refresh the Rust parity explain fixture and focused guard tests.

## Validation
- cargo test -p winsmux --test ledger_contract -- --nocapture
- cargo test -p winsmux --test operator_cli guard -- --nocapture
- cargo test -p winsmux --test fixture_comparison -- --nocapture
- Invoke-Pester -Path tests\\winsmux-bridge.Tests.ps1 -FullName 'winsmux guard command*' -Output Detailed
- git diff --check
- git-guard / audit-public-surface / gitleaks via pre-push

TASK-362 (#456)