### PR TITLE
feat: add context budget contract

### DIFF
--- a/core/src/ledger.rs
+++ b/core/src/ledger.rs
@@ -277,6 +277,7 @@ pub struct LedgerExplainRun {
     pub verification_contract: Value,
     pub verification_result: Value,
     pub verification_evidence: Value,
+    pub context_contract: Value,
     pub tdd_gate: Value,
     pub verification_envelope: Value,
     pub audit_chain: Value,
@@ -472,6 +473,7 @@ pub struct LedgerRunProjection {
     pub verification_contract: Value,
     pub verification_result: Value,
     pub verification_evidence: Value,
+    pub context_contract: Value,
     pub tdd_gate: Value,
     pub verification_envelope: Value,
     pub audit_chain: Value,
@@ -518,6 +520,7 @@ pub struct LedgerRunPacket {
     pub verification_contract: Value,
     pub verification_result: Value,
     pub verification_evidence: Value,
+    pub context_contract: Value,
     pub tdd_gate: Value,
     pub verification_envelope: Value,
     pub audit_chain: Value,
@@ -732,6 +735,9 @@ impl LedgerRunProjection {
             verification_evidence: run
                 .map(|run| run.verification_evidence.clone())
                 .unwrap_or(Value::Null),
+            context_contract: run
+                .map(|run| run.context_contract.clone())
+                .unwrap_or(Value::Null),
             tdd_gate: run.map(|run| run.tdd_gate.clone()).unwrap_or(Value::Null),
             verification_envelope: run
                 .map(|run| run.verification_envelope.clone())
@@ -787,6 +793,7 @@ impl LedgerRunPacket {
             verification_contract: run.verification_contract.clone(),
             verification_result: run.verification_result.clone(),
             verification_evidence: run.verification_evidence.clone(),
+            context_contract: run.context_contract.clone(),
             tdd_gate: run.tdd_gate.clone(),
             verification_envelope: run.verification_envelope.clone(),
             audit_chain: run.audit_chain.clone(),
@@ -1303,6 +1310,7 @@ impl LedgerSnapshot {
             verification_contract,
             verification_result,
             verification_evidence,
+            context_contract: Value::Null,
             tdd_gate: Value::Null,
             verification_envelope: Value::Null,
             audit_chain: Value::Null,
@@ -1314,6 +1322,7 @@ impl LedgerSnapshot {
         run.draft_pr_gate = run_draft_pr_gate_value(&run, &recent_event_records);
         run.tdd_gate = run_tdd_gate_value(&run, &recent_event_records);
         run.phase_gate = run_phase_gate_value(&run, &recent_event_records, &run.draft_pr_gate);
+        run.context_contract = context_contract_value(&run.verification_evidence);
         run.audit_chain = run_audit_chain_value(&run, &recent_event_records);
         run.verification_envelope = run_verification_envelope_value(&run);
         run.outcome = run_outcome_value(&run, &run.phase_gate, &run.draft_pr_gate);
@@ -2505,6 +2514,7 @@ fn run_audit_chain_value(run: &LedgerExplainRun, events: &[(usize, &EventRecord)
             "branch": run.branch,
             "head_sha": run.head_sha,
             "changed_files": run.changed_files,
+            "context_contract": run.context_contract,
         },
         "actor": {
             "label": run.primary_label,
@@ -2707,6 +2717,7 @@ fn run_verification_envelope_value(run: &LedgerExplainRun) -> Value {
             "review_required": run.review_required,
             "required_fields": [
                 "verification_evidence",
+                "context_contract",
                 "security_verdict",
                 "audit_chain",
                 "draft_pr_gate",
@@ -2726,6 +2737,7 @@ fn run_verification_envelope_value(run: &LedgerExplainRun) -> Value {
                 "blocked": security_verdict == "BLOCK"
             },
             "approval": approval,
+            "context": run.context_contract,
             "draft_pr": run.draft_pr_gate,
             "phase": run.phase_gate,
             "audit": {
@@ -2741,6 +2753,7 @@ fn run_verification_envelope_value(run: &LedgerExplainRun) -> Value {
             "automatic_merge_allowed": false
         },
         "verification_evidence": run.verification_evidence,
+        "context_contract": run.context_contract,
         "security_verdict": run.security_verdict,
         "audit_chain": run.audit_chain,
     })
@@ -2813,6 +2826,14 @@ fn value_field_string(value: &Value, key: &str) -> String {
         .to_string()
 }
 
+fn value_field(value: &Value, key: &str) -> Value {
+    value
+        .as_object()
+        .and_then(|map| map.get(key))
+        .cloned()
+        .unwrap_or(Value::Null)
+}
+
 fn push_reason(reasons: &mut Vec<String>, key: &str, value: &str) {
     if !value.trim().is_empty() {
         let separator = if key == "action" { ":" } else { "=" };
@@ -2850,13 +2871,58 @@ fn verification_evidence_value(data: &Value) -> Value {
         "context_budget": verification_evidence_field(data, "context_budget"),
         "context_estimate": verification_evidence_field(data, "context_estimate"),
         "context_pack_id": verification_evidence_field(data, "context_pack_id"),
+        "context_pack_version": verification_evidence_field(data, "context_pack_version"),
         "tool_output_pruned_count": verification_evidence_field(data, "tool_output_pruned_count"),
         "context_pressure": verification_evidence_field(data, "context_pressure"),
+        "context_mode": verification_evidence_field(data, "context_mode"),
+        "context_fork_reason": verification_evidence_field(data, "context_fork_reason"),
+    })
+}
+
+fn context_contract_value(verification_evidence: &Value) -> Value {
+    let requested_mode = value_field_string(verification_evidence, "context_mode");
+    let fork_reason = value_field_string(verification_evidence, "context_fork_reason");
+    let context_mode =
+        if requested_mode.eq_ignore_ascii_case("fork") && !fork_reason.trim().is_empty() {
+            "fork"
+        } else {
+            "isolated"
+        };
+    let fork_reason_value = if context_mode == "fork" {
+        Value::String(fork_reason)
+    } else {
+        Value::Null
+    };
+
+    json!({
+        "contract_version": 1,
+        "packet_type": "context_budget_contract",
+        "scope": "run",
+        "context_pack_id": value_field(verification_evidence, "context_pack_id"),
+        "context_pack_version": value_field(verification_evidence, "context_pack_version"),
+        "context_budget": value_field(verification_evidence, "context_budget"),
+        "context_estimate": value_field(verification_evidence, "context_estimate"),
+        "context_pressure": value_field(verification_evidence, "context_pressure"),
+        "tool_output_pruned_count": value_field(verification_evidence, "tool_output_pruned_count"),
+        "context_mode": context_mode,
+        "fork_reason": fork_reason_value,
+        "fork_allowed": context_mode == "fork",
+        "prompt_body_stored": false,
+        "private_memory_stored": false,
+        "local_reference_paths_stored": false,
+        "tool_output_pruning": {
+            "evidence_only": true,
+            "raw_tool_output_stored": false
+        }
     })
 }
 
 fn verification_evidence_field(data: &Value, key: &str) -> Value {
-    for container_name in ["verification_evidence", "verification_result", "verification_contract"] {
+    for container_name in [
+        "verification_evidence",
+        "verification_result",
+        "verification_contract",
+    ] {
         let nested = data
             .as_object()
             .and_then(|map| map.get(container_name))

--- a/core/tests-rs/fixture_comparison.rs
+++ b/core/tests-rs/fixture_comparison.rs
@@ -242,6 +242,7 @@ const EXPLAIN_RUN_KEYS: &[&str] = &[
     "verification_contract",
     "verification_result",
     "verification_evidence",
+    "context_contract",
     "tdd_gate",
     "verification_envelope",
     "audit_chain",

--- a/core/tests-rs/ledger_contract.rs
+++ b/core/tests-rs/ledger_contract.rs
@@ -605,7 +605,7 @@ panes:
     head_sha: abc1234def5678
 "#;
     let events = r#"{"timestamp":"2026-04-23T12:00:01+09:00","session":"winsmux-orchestra","event":"pane.approval_waiting","message":"approval prompt detected","label":"builder-1","pane_id":"%2","role":"Builder","status":"approval_waiting","data":{"task_id":"task-256"}}
-{"timestamp":"2026-04-23T12:00:02+09:00","session":"winsmux-orchestra","event":"pipeline.verify.pass","message":"verification passed","data":{"task_id":"task-256","verification_contract":{"command":"cargo test","build":{"command":"cargo build","outcome":"PASS"},"test":{"command":"cargo test","outcome":"PASS"},"context_budget":120000,"context_estimate":42000,"context_pack_id":"ctx-task-256","tool_output_pruned_count":2,"context_pressure":"medium"},"verification_result":{"outcome":"PASS","browser":{"required":false,"outcome":"SKIPPED"},"screenshot":{"required":false,"artifact_ref":""},"recording":{"required":false,"artifact_ref":""}}}}
+{"timestamp":"2026-04-23T12:00:02+09:00","session":"winsmux-orchestra","event":"pipeline.verify.pass","message":"verification passed","data":{"task_id":"task-256","verification_contract":{"command":"cargo test","build":{"command":"cargo build","outcome":"PASS"},"test":{"command":"cargo test","outcome":"PASS"},"context_budget":120000,"context_estimate":42000,"context_pack_id":"ctx-task-256","context_pack_version":"1","tool_output_pruned_count":2,"context_pressure":"medium","context_mode":"isolated"},"verification_result":{"outcome":"PASS","browser":{"required":false,"outcome":"SKIPPED"},"screenshot":{"required":false,"artifact_ref":""},"recording":{"required":false,"artifact_ref":""}}}}
 {"timestamp":"2026-04-23T12:00:03+09:00","session":"winsmux-orchestra","event":"pipeline.security.allowed","message":"security allowed","data":{"task_id":"task-256","verdict":"ALLOW"}}
 {"timestamp":"2026-04-23T12:00:04+09:00","session":"winsmux-orchestra","event":"pane.consult_result","message":"experiment result","label":"builder-1","pane_id":"%2","role":"Builder","data":{"task_id":"task-256","hypothesis":"projection can explain the run","test_plan":["load manifest","match events"],"result":"explain payload built","confidence":0.66,"next_action":"approval_waiting","observation_pack_ref":"observations/task-256.json","consultation_ref":"consultations/task-256.json","run_id":"task:task-256","slot":"builder-1","worktree":".worktrees/builder-1","env_fingerprint":"env-123","command_hash":"cmd-456","observation_pack":{"summary":"ok"},"consultation_packet":{"review":"ok"}}}
 {"timestamp":"2026-04-23T12:00:05+09:00","session":"winsmux-orchestra","event":"pane.consult_request","message":"new action only","label":"builder-1","pane_id":"%2","role":"Builder","data":{"task_id":"task-256","next_action":"review_requested"}}
@@ -688,7 +688,27 @@ panes:
         explain.run.verification_evidence["context_pressure"],
         "medium"
     );
+    assert_eq!(
+        explain.run.context_contract["packet_type"],
+        "context_budget_contract"
+    );
+    assert_eq!(
+        explain.run.context_contract["context_pack_id"],
+        "ctx-task-256"
+    );
+    assert_eq!(explain.run.context_contract["context_mode"], "isolated");
+    assert_eq!(explain.run.context_contract["fork_allowed"], false);
+    assert_eq!(explain.run.context_contract["prompt_body_stored"], false);
+    assert_eq!(explain.run.context_contract["private_memory_stored"], false);
+    assert_eq!(
+        explain.run.context_contract["local_reference_paths_stored"],
+        false
+    );
     assert_eq!(explain.run.audit_chain["chain_id"], "task:task-256");
+    assert_eq!(
+        explain.run.audit_chain["subject"]["context_contract"]["context_pack_id"],
+        "ctx-task-256"
+    );
     assert_eq!(
         explain.run.audit_chain["subject"]["changed_files"][0],
         "scripts/winsmux-core.ps1"
@@ -704,6 +724,10 @@ panes:
     assert_eq!(
         explain.run.verification_envelope["static_gates"]["required_fields"][0],
         "verification_evidence"
+    );
+    assert_eq!(
+        explain.run.verification_envelope["dynamic_gates"]["context"]["context_mode"],
+        "isolated"
     );
     assert_eq!(
         explain.run.verification_envelope["dynamic_gates"]["verification"]["outcome"],

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -5448,7 +5448,7 @@ function Get-VerificationSnapshotFromEventRecords {
     $snapshot = Get-LatestRunEventDataSnapshot `
         -EventRecords $EventRecords `
         -EventNames @('pipeline.verify.pass', 'pipeline.verify.fail', 'pipeline.verify.partial') `
-        -DataFields @('verification_contract', 'verification_result', 'verification_evidence', 'build', 'test', 'browser', 'screenshot', 'recording', 'context_budget', 'context_estimate', 'context_pack_id', 'tool_output_pruned_count', 'context_pressure')
+        -DataFields @('verification_contract', 'verification_result', 'verification_evidence', 'build', 'test', 'browser', 'screenshot', 'recording', 'context_budget', 'context_estimate', 'context_pack_id', 'context_pack_version', 'tool_output_pruned_count', 'context_pressure', 'context_mode', 'context_fork_reason')
     if ($null -eq $snapshot) {
         return $null
     }
@@ -5502,8 +5502,11 @@ function New-VerificationEvidenceEnvelope {
         context_budget           = Get-VerificationEvidenceField -Snapshot $Snapshot -Name 'context_budget'
         context_estimate         = Get-VerificationEvidenceField -Snapshot $Snapshot -Name 'context_estimate'
         context_pack_id          = Get-VerificationEvidenceField -Snapshot $Snapshot -Name 'context_pack_id'
+        context_pack_version     = Get-VerificationEvidenceField -Snapshot $Snapshot -Name 'context_pack_version'
         tool_output_pruned_count = Get-VerificationEvidenceField -Snapshot $Snapshot -Name 'tool_output_pruned_count'
         context_pressure         = Get-VerificationEvidenceField -Snapshot $Snapshot -Name 'context_pressure'
+        context_mode             = Get-VerificationEvidenceField -Snapshot $Snapshot -Name 'context_mode'
+        context_fork_reason      = Get-VerificationEvidenceField -Snapshot $Snapshot -Name 'context_fork_reason'
     }
 }
 
@@ -5864,6 +5867,7 @@ function New-RunAuditChainContract {
             branch        = [string]$Run.branch
             head_sha      = [string]$Run.head_sha
             changed_files = @($Run.changed_files)
+            context_contract = $Run.context_contract
         }
         actor    = [ordered]@{
             label           = [string]$Run.primary_label
@@ -6261,6 +6265,39 @@ function Get-RunContractField {
     return $null
 }
 
+function New-RunContextContract {
+    param([AllowNull()]$VerificationEvidence = $null)
+
+    $requestedMode = [string](Get-RunContractField -InputObject $VerificationEvidence -Name 'context_mode')
+    $forkReason = [string](Get-RunContractField -InputObject $VerificationEvidence -Name 'context_fork_reason')
+    $contextMode = 'isolated'
+    if ($requestedMode -eq 'fork' -and -not [string]::IsNullOrWhiteSpace($forkReason)) {
+        $contextMode = 'fork'
+    }
+
+    return [ordered]@{
+        contract_version             = 1
+        packet_type                  = 'context_budget_contract'
+        scope                        = 'run'
+        context_pack_id              = Get-RunContractField -InputObject $VerificationEvidence -Name 'context_pack_id'
+        context_pack_version         = Get-RunContractField -InputObject $VerificationEvidence -Name 'context_pack_version'
+        context_budget               = Get-RunContractField -InputObject $VerificationEvidence -Name 'context_budget'
+        context_estimate             = Get-RunContractField -InputObject $VerificationEvidence -Name 'context_estimate'
+        context_pressure             = Get-RunContractField -InputObject $VerificationEvidence -Name 'context_pressure'
+        tool_output_pruned_count     = Get-RunContractField -InputObject $VerificationEvidence -Name 'tool_output_pruned_count'
+        context_mode                 = $contextMode
+        fork_reason                  = if ($contextMode -eq 'fork') { $forkReason } else { $null }
+        fork_allowed                 = ($contextMode -eq 'fork')
+        prompt_body_stored           = $false
+        private_memory_stored        = $false
+        local_reference_paths_stored = $false
+        tool_output_pruning          = [ordered]@{
+            evidence_only          = $true
+            raw_tool_output_stored = $false
+        }
+    }
+}
+
 function New-RunDraftPrHandoffPackage {
     param(
         [Parameter(Mandatory = $true)]$Run,
@@ -6418,7 +6455,7 @@ function New-RunVerificationEnvelope {
             verification_plan = @($Run.verification_plan)
             changed_files     = @($Run.changed_files)
             review_required   = [bool]$Run.review_required
-            required_fields   = @('verification_evidence', 'security_verdict', 'audit_chain', 'draft_pr_gate', 'phase_gate')
+            required_fields   = @('verification_evidence', 'context_contract', 'security_verdict', 'audit_chain', 'draft_pr_gate', 'phase_gate')
         }
         dynamic_gates        = [ordered]@{
             verification = [ordered]@{
@@ -6433,6 +6470,7 @@ function New-RunVerificationEnvelope {
                 blocked = ($securityVerdict -eq 'BLOCK')
             }
             approval     = $approval
+            context      = $Run.context_contract
             draft_pr     = $Run.draft_pr_gate
             phase        = $Run.phase_gate
             audit        = [ordered]@{
@@ -6448,6 +6486,7 @@ function New-RunVerificationEnvelope {
             automatic_merge_allowed  = $false
         }
         verification_evidence = $Run.verification_evidence
+        context_contract      = $Run.context_contract
         security_verdict      = $Run.security_verdict
         audit_chain           = $Run.audit_chain
     }
@@ -6543,6 +6582,7 @@ function New-RunPacketFromRun {
         verification_contract = $Run.verification_contract
         verification_result   = $Run.verification_result
         verification_evidence = $Run.verification_evidence
+        context_contract      = $Run.context_contract
         tdd_gate              = $Run.tdd_gate
         verification_envelope = $Run.verification_envelope
         plan              = $Run.plan
@@ -6626,6 +6666,7 @@ function New-RunResultPacket {
         verification_contract = $Run.verification_contract
         verification_result   = $Run.verification_result
         verification_evidence = $Run.verification_evidence
+        context_contract      = $Run.context_contract
         tdd_gate              = $Run.tdd_gate
         verification_envelope = $Run.verification_envelope
         security_policy       = $Run.security_policy
@@ -6890,6 +6931,7 @@ function Get-RunsPayload {
                 verification_contract = $null
                 verification_result   = $null
                 verification_evidence = $null
+                context_contract      = $null
                 plan                  = $null
                 plan_checkpoints      = @()
                 managed_loop          = $null
@@ -7058,6 +7100,7 @@ function Get-RunsPayload {
             $run.draft_pr_gate = New-RunDraftPrGate -Run $run -EventRecords $runEvents
             $run.tdd_gate = New-RunTddGateContract -Run $run -EventRecords $runEvents
             $run.phase_gate = New-RunPhaseGateContract -Run $run -EventRecords $runEvents
+            $run.context_contract = New-RunContextContract -VerificationEvidence $run.verification_evidence
             $run.audit_chain = New-RunAuditChainContract -Run $run -EventRecords $runEvents
             $run.verification_envelope = New-RunVerificationEnvelope -Run $run
             $run.outcome = New-RunOutcomeContract -Run $run
@@ -7110,6 +7153,7 @@ function Get-RunsPayload {
                 verification_contract = $run.verification_contract
                 verification_result   = $run.verification_result
                 verification_evidence = $run.verification_evidence
+                context_contract      = $run.context_contract
                 tdd_gate              = $run.tdd_gate
                 verification_envelope = $run.verification_envelope
                 plan                  = $run.plan

--- a/tests/fixtures/rust-parity/explain.json
+++ b/tests/fixtures/rust-parity/explain.json
@@ -97,6 +97,27 @@
     "verification_contract": null,
     "verification_result": null,
     "verification_evidence": null,
+    "context_contract": {
+      "contract_version": 1,
+      "packet_type": "context_budget_contract",
+      "scope": "run",
+      "context_pack_id": null,
+      "context_pack_version": null,
+      "context_budget": null,
+      "context_estimate": null,
+      "context_pressure": null,
+      "tool_output_pruned_count": null,
+      "context_mode": "isolated",
+      "fork_reason": null,
+      "fork_allowed": false,
+      "prompt_body_stored": false,
+      "private_memory_stored": false,
+      "local_reference_paths_stored": false,
+      "tool_output_pruning": {
+        "evidence_only": true,
+        "raw_tool_output_stored": false
+      }
+    },
     "tdd_gate": {
       "policy": "test_first_required",
       "required": true,
@@ -124,6 +145,7 @@
         "review_required": true,
         "required_fields": [
           "verification_evidence",
+          "context_contract",
           "security_verdict",
           "audit_chain",
           "draft_pr_gate",
@@ -155,6 +177,27 @@
           "decided_event": "",
           "human_judgement_required": true,
           "automatic_merge_allowed": false
+        },
+        "context": {
+          "contract_version": 1,
+          "packet_type": "context_budget_contract",
+          "scope": "run",
+          "context_pack_id": null,
+          "context_pack_version": null,
+          "context_budget": null,
+          "context_estimate": null,
+          "context_pressure": null,
+          "tool_output_pruned_count": null,
+          "context_mode": "isolated",
+          "fork_reason": null,
+          "fork_allowed": false,
+          "prompt_body_stored": false,
+          "private_memory_stored": false,
+          "local_reference_paths_stored": false,
+          "tool_output_pruning": {
+            "evidence_only": true,
+            "raw_tool_output_stored": false
+          }
         },
         "draft_pr": {
           "kind": "human_judgement",
@@ -257,6 +300,27 @@
         "automatic_merge_allowed": false
       },
       "verification_evidence": null,
+      "context_contract": {
+        "contract_version": 1,
+        "packet_type": "context_budget_contract",
+        "scope": "run",
+        "context_pack_id": null,
+        "context_pack_version": null,
+        "context_budget": null,
+        "context_estimate": null,
+        "context_pressure": null,
+        "tool_output_pruned_count": null,
+        "context_mode": "isolated",
+        "fork_reason": null,
+        "fork_allowed": false,
+        "prompt_body_stored": false,
+        "private_memory_stored": false,
+        "local_reference_paths_stored": false,
+        "tool_output_pruning": {
+          "evidence_only": true,
+          "raw_tool_output_stored": false
+        }
+      },
       "security_verdict": null,
       "audit_chain": {
         "chain_id": "task:task-256",
@@ -269,7 +333,28 @@
           "head_sha": "abc1234def5678",
           "changed_files": [
             "scripts/winsmux-core.ps1"
-          ]
+          ],
+          "context_contract": {
+            "contract_version": 1,
+            "packet_type": "context_budget_contract",
+            "scope": "run",
+            "context_pack_id": null,
+            "context_pack_version": null,
+            "context_budget": null,
+            "context_estimate": null,
+            "context_pressure": null,
+            "tool_output_pruned_count": null,
+            "context_mode": "isolated",
+            "fork_reason": null,
+            "fork_allowed": false,
+            "prompt_body_stored": false,
+            "private_memory_stored": false,
+            "local_reference_paths_stored": false,
+            "tool_output_pruning": {
+              "evidence_only": true,
+              "raw_tool_output_stored": false
+            }
+          }
         },
         "actor": {
           "label": "builder-1",
@@ -370,7 +455,28 @@
         "head_sha": "abc1234def5678",
         "changed_files": [
           "scripts/winsmux-core.ps1"
-        ]
+        ],
+        "context_contract": {
+          "contract_version": 1,
+          "packet_type": "context_budget_contract",
+          "scope": "run",
+          "context_pack_id": null,
+          "context_pack_version": null,
+          "context_budget": null,
+          "context_estimate": null,
+          "context_pressure": null,
+          "tool_output_pruned_count": null,
+          "context_mode": "isolated",
+          "fork_reason": null,
+          "fork_allowed": false,
+          "prompt_body_stored": false,
+          "private_memory_stored": false,
+          "local_reference_paths_stored": false,
+          "tool_output_pruning": {
+            "evidence_only": true,
+            "raw_tool_output_stored": false
+          }
+        }
       },
       "actor": {
         "label": "builder-1",

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -8282,6 +8282,13 @@ panes:
                 run_id  = 'task:task-256'
                 verification_contract = [ordered]@{
                     mode = 'adversarial_verify'
+                    context_budget = 120000
+                    context_estimate = 42000
+                    context_pack_id = 'ctx-runs'
+                    context_pack_version = '1'
+                    tool_output_pruned_count = 3
+                    context_pressure = 'high'
+                    context_mode = 'isolated'
                 }
                 verification_result = [ordered]@{
                     outcome = 'PARTIAL'
@@ -8363,6 +8370,13 @@ panes:
         $result.runs[0].verification_contract.mode | Should -Be 'adversarial_verify'
         $result.runs[0].verification_result.outcome | Should -Be 'PARTIAL'
         $result.runs[0].run_packet.verification_result.outcome | Should -Be 'PARTIAL'
+        $result.runs[0].context_contract.context_pack_id | Should -Be 'ctx-runs'
+        $result.runs[0].context_contract.context_pressure | Should -Be 'high'
+        $result.runs[0].context_contract.context_mode | Should -Be 'isolated'
+        $result.runs[0].context_contract.tool_output_pruned_count | Should -Be 3
+        $result.runs[0].context_contract.prompt_body_stored | Should -Be $false
+        $result.runs[0].context_contract.private_memory_stored | Should -Be $false
+        $result.runs[0].run_packet.context_contract.context_pack_id | Should -Be 'ctx-runs'
         $result.runs[0].tdd_gate.required | Should -Be $true
         $result.runs[0].tdd_gate.state | Should -Be 'passed'
         $result.runs[0].tdd_gate.red_event | Should -Be 'pipeline.tdd.red'
@@ -9582,8 +9596,10 @@ panes:
                         context_budget = 120000
                         context_estimate = 42000
                         context_pack_id = 'ctx-task-256'
+                        context_pack_version = '1'
                         tool_output_pruned_count = 2
                         context_pressure = 'medium'
+                        context_mode = 'isolated'
                     }
                     verification_result = [ordered]@{
                         outcome = 'PARTIAL'
@@ -9752,14 +9768,23 @@ panes:
         $result.run.verification_evidence.context_budget | Should -Be 120000
         $result.run.verification_evidence.context_estimate | Should -Be 42000
         $result.run.verification_evidence.context_pack_id | Should -Be 'ctx-task-256'
+        $result.run.verification_evidence.context_pack_version | Should -Be '1'
         $result.run.verification_evidence.tool_output_pruned_count | Should -Be 2
         $result.run.verification_evidence.context_pressure | Should -Be 'medium'
+        $result.run.context_contract.packet_type | Should -Be 'context_budget_contract'
+        $result.run.context_contract.context_pack_id | Should -Be 'ctx-task-256'
+        $result.run.context_contract.context_mode | Should -Be 'isolated'
+        $result.run.context_contract.fork_allowed | Should -Be $false
+        $result.run.context_contract.prompt_body_stored | Should -Be $false
+        $result.run.context_contract.private_memory_stored | Should -Be $false
+        $result.run.context_contract.local_reference_paths_stored | Should -Be $false
         $result.run.tdd_gate.required | Should -Be $true
         $result.run.tdd_gate.state | Should -Be 'passed'
         $result.run.tdd_gate.red_event | Should -Be 'pipeline.tdd.red'
         $result.run.audit_chain.chain_id | Should -Be 'task:task-256'
         $result.run.audit_chain.subject.task_id | Should -Be 'task-256'
         $result.run.audit_chain.subject.changed_files | Should -Be @('scripts/winsmux-core.ps1')
+        $result.run.audit_chain.subject.context_contract.context_mode | Should -Be 'isolated'
         $result.run.audit_chain.actor.label | Should -Be 'builder-1'
         $result.run.audit_chain.approval.required | Should -Be $true
         $result.run.audit_chain.approval.state | Should -Be 'pending'


### PR DESCRIPTION
## Summary
- add a provider-neutral context_budget_contract to run, run_packet, audit chain, and verification envelope projections
- carry context budget telemetry through Rust and PowerShell projections without storing prompt bodies, private memory, local reference paths, or raw tool output
- keep context_mode isolated by default and allow fork mode only when a fork reason is present

## Validation
- cargo test --manifest-path core/Cargo.toml ledger_contract --test ledger_contract -- --nocapture
- Invoke-Pester -Path tests\\winsmux-bridge.Tests.ps1 -FullName '*keeps explain json fixture stable*','*returns runs as json*','*returns a json explanation with related events and review state*' -Output Detailed
- bash .git/hooks/pre-commit
- git push pre-push hooks: git-guard, audit-public-surface, gitleaks