### PR TITLE
feat: add run insights projection

### DIFF
--- a/core/src/ledger.rs
+++ b/core/src/ledger.rs
@@ -278,6 +278,7 @@ pub struct LedgerExplainRun {
     pub verification_result: Value,
     pub verification_evidence: Value,
     pub context_contract: Value,
+    pub run_insights: Value,
     pub tdd_gate: Value,
     pub verification_envelope: Value,
     pub audit_chain: Value,
@@ -474,6 +475,7 @@ pub struct LedgerRunProjection {
     pub verification_result: Value,
     pub verification_evidence: Value,
     pub context_contract: Value,
+    pub run_insights: Value,
     pub tdd_gate: Value,
     pub verification_envelope: Value,
     pub audit_chain: Value,
@@ -521,6 +523,7 @@ pub struct LedgerRunPacket {
     pub verification_result: Value,
     pub verification_evidence: Value,
     pub context_contract: Value,
+    pub run_insights: Value,
     pub tdd_gate: Value,
     pub verification_envelope: Value,
     pub audit_chain: Value,
@@ -738,6 +741,9 @@ impl LedgerRunProjection {
             context_contract: run
                 .map(|run| run.context_contract.clone())
                 .unwrap_or(Value::Null),
+            run_insights: run
+                .map(|run| run.run_insights.clone())
+                .unwrap_or(Value::Null),
             tdd_gate: run.map(|run| run.tdd_gate.clone()).unwrap_or(Value::Null),
             verification_envelope: run
                 .map(|run| run.verification_envelope.clone())
@@ -794,6 +800,7 @@ impl LedgerRunPacket {
             verification_result: run.verification_result.clone(),
             verification_evidence: run.verification_evidence.clone(),
             context_contract: run.context_contract.clone(),
+            run_insights: run.run_insights.clone(),
             tdd_gate: run.tdd_gate.clone(),
             verification_envelope: run.verification_envelope.clone(),
             audit_chain: run.audit_chain.clone(),
@@ -1311,6 +1318,7 @@ impl LedgerSnapshot {
             verification_result,
             verification_evidence,
             context_contract: Value::Null,
+            run_insights: Value::Null,
             tdd_gate: Value::Null,
             verification_envelope: Value::Null,
             audit_chain: Value::Null,
@@ -1326,6 +1334,7 @@ impl LedgerSnapshot {
         run.audit_chain = run_audit_chain_value(&run, &recent_event_records);
         run.verification_envelope = run_verification_envelope_value(&run);
         run.outcome = run_outcome_value(&run, &run.phase_gate, &run.draft_pr_gate);
+        run.run_insights = run_insights_value(&run, &recent_event_records);
         let explanation = explain_explanation(&run, &evidence_digest);
 
         Some(LedgerExplainProjection {
@@ -2807,6 +2816,124 @@ fn run_outcome_value(run: &LedgerExplainRun, phase_gate: &Value, draft_pr_gate: 
         "confidence": run.experiment_packet.confidence,
         "source_event": run.last_event,
     })
+}
+
+fn run_insights_value(run: &LedgerExplainRun, events: &[(usize, &EventRecord)]) -> Value {
+    let retry_count = events
+        .iter()
+        .filter(|(_, event)| {
+            let text = format!(
+                "{} {} {} {}",
+                event.event,
+                event.message,
+                event.status,
+                value_field_string(&event.data, "next_action")
+            )
+            .to_lowercase();
+            text.contains("retry")
+                || text.contains("rerun")
+                || event_attempt_value(event) > 1
+        })
+        .count();
+
+    let mut drift_signals = Vec::new();
+    for (_, event) in events {
+        let text = format!("{} {} {}", event.event, event.message, event.status).to_lowercase();
+        if text.contains("drift") {
+            push_unique_text(&mut drift_signals, "drift_detected");
+        }
+        if text.contains("stale") {
+            push_unique_text(&mut drift_signals, "stale_state");
+        }
+        if text.contains("mismatch") {
+            push_unique_text(&mut drift_signals, "state_mismatch");
+        }
+    }
+
+    let intervention_count = run.action_items.len()
+        + events
+            .iter()
+            .filter(|(_, event)| {
+                let text = format!("{} {} {}", event.event, event.message, event.status)
+                    .to_lowercase();
+                text.contains("approval")
+                    || text.contains("review_requested")
+                    || text.contains("question")
+                    || text.contains("user")
+            })
+            .count();
+
+    let mut blocked_reasons = Vec::new();
+    push_unique_text(
+        &mut blocked_reasons,
+        &value_field_string(&run.phase_gate, "stop_reason"),
+    );
+    if value_field_string(&run.draft_pr_gate, "state") == "blocked" {
+        push_unique_text(&mut blocked_reasons, "draft_pr_gate_blocked");
+    }
+    if value_field_string(&run.tdd_gate, "state") == "blocked" {
+        push_unique_text(&mut blocked_reasons, "tdd_gate_blocked");
+    }
+    if value_field_string(&run.verification_result, "outcome").eq_ignore_ascii_case("FAIL") {
+        push_unique_text(&mut blocked_reasons, "verification_failed");
+    }
+    if value_field_string(&run.security_verdict, "verdict").eq_ignore_ascii_case("BLOCK") {
+        push_unique_text(&mut blocked_reasons, "security_blocked");
+    }
+    let context_pressure = value_field_string(&run.verification_evidence, "context_pressure");
+    let unhealthy_session_size = run.pane_count > 8
+        || run.changed_file_count > 20
+        || matches!(
+            context_pressure.to_lowercase().as_str(),
+            "high" | "critical" | "exhausted"
+        );
+
+    let mut next_improvements = Vec::new();
+    if retry_count > 0 {
+        push_unique_text(&mut next_improvements, "reduce retry loop before the next run");
+    }
+    if !drift_signals.is_empty() {
+        push_unique_text(&mut next_improvements, "refresh session state before continuing");
+    }
+    if intervention_count > 0 {
+        push_unique_text(
+            &mut next_improvements,
+            "capture operator decisions as reusable guidance",
+        );
+    }
+    if unhealthy_session_size {
+        push_unique_text(&mut next_improvements, "split the next run into a smaller scope");
+    }
+    if !blocked_reasons.is_empty() {
+        push_unique_text(&mut next_improvements, "resolve blocked reasons before release");
+    }
+
+    json!({
+        "packet_type": "run_insights",
+        "scope": "run",
+        "retry_count": retry_count,
+        "drift_signals": drift_signals,
+        "intervention_count": intervention_count,
+        "unhealthy_session_size": unhealthy_session_size,
+        "blocked_reasons": blocked_reasons,
+        "next_improvements": next_improvements,
+    })
+}
+
+fn event_attempt_value(event: &EventRecord) -> i64 {
+    event
+        .data
+        .as_object()
+        .and_then(|map| map.get("attempt"))
+        .and_then(Value::as_i64)
+        .unwrap_or(0)
+}
+
+fn push_unique_text(values: &mut Vec<String>, value: &str) {
+    let value = value.trim();
+    if !value.is_empty() && !values.iter().any(|existing| existing == value) {
+        values.push(value.to_string());
+    }
 }
 
 fn draft_pr_event_matches_run_head(run: &LedgerExplainRun, event: &EventRecord) -> bool {

--- a/core/tests-rs/fixture_comparison.rs
+++ b/core/tests-rs/fixture_comparison.rs
@@ -243,6 +243,7 @@ const EXPLAIN_RUN_KEYS: &[&str] = &[
     "verification_result",
     "verification_evidence",
     "context_contract",
+    "run_insights",
     "tdd_gate",
     "verification_envelope",
     "audit_chain",

--- a/core/tests-rs/ledger_contract.rs
+++ b/core/tests-rs/ledger_contract.rs
@@ -605,7 +605,7 @@ panes:
     head_sha: abc1234def5678
 "#;
     let events = r#"{"timestamp":"2026-04-23T12:00:01+09:00","session":"winsmux-orchestra","event":"pane.approval_waiting","message":"approval prompt detected","label":"builder-1","pane_id":"%2","role":"Builder","status":"approval_waiting","data":{"task_id":"task-256"}}
-{"timestamp":"2026-04-23T12:00:02+09:00","session":"winsmux-orchestra","event":"pipeline.verify.pass","message":"verification passed","data":{"task_id":"task-256","verification_contract":{"command":"cargo test","build":{"command":"cargo build","outcome":"PASS"},"test":{"command":"cargo test","outcome":"PASS"},"context_budget":120000,"context_estimate":42000,"context_pack_id":"ctx-task-256","context_pack_version":"1","tool_output_pruned_count":2,"context_pressure":"medium","context_mode":"isolated","semantic_context_pack_id":"sem-task-256","semantic_context_pack_ref":"context-packs/sem-task-256.json","source_refs":["ADR-001","docs/operator-model.md#context"],"hard_constraints":["do not store prompt bodies"],"safety_rules":["keep local paths out"],"performance_budget":{"max_context_tokens":42000},"rationale":"keep worker context scoped"},"verification_result":{"outcome":"PASS","browser":{"required":false,"outcome":"SKIPPED"},"screenshot":{"required":false,"artifact_ref":""},"recording":{"required":false,"artifact_ref":""}}}}
+{"timestamp":"2026-04-23T12:00:02+09:00","session":"winsmux-orchestra","event":"pipeline.verify.pass","message":"verification passed after drift retry","data":{"task_id":"task-256","attempt":2,"verification_contract":{"command":"cargo test","build":{"command":"cargo build","outcome":"PASS"},"test":{"command":"cargo test","outcome":"PASS"},"context_budget":120000,"context_estimate":42000,"context_pack_id":"ctx-task-256","context_pack_version":"1","tool_output_pruned_count":2,"context_pressure":"medium","context_mode":"isolated","semantic_context_pack_id":"sem-task-256","semantic_context_pack_ref":"context-packs/sem-task-256.json","source_refs":["ADR-001","docs/operator-model.md#context"],"hard_constraints":["do not store prompt bodies"],"safety_rules":["keep local paths out"],"performance_budget":{"max_context_tokens":42000},"rationale":"keep worker context scoped"},"verification_result":{"outcome":"PASS","browser":{"required":false,"outcome":"SKIPPED"},"screenshot":{"required":false,"artifact_ref":""},"recording":{"required":false,"artifact_ref":""}}}}
 {"timestamp":"2026-04-23T12:00:03+09:00","session":"winsmux-orchestra","event":"pipeline.security.allowed","message":"security allowed","data":{"task_id":"task-256","verdict":"ALLOW"}}
 {"timestamp":"2026-04-23T12:00:04+09:00","session":"winsmux-orchestra","event":"pane.consult_result","message":"experiment result","label":"builder-1","pane_id":"%2","role":"Builder","data":{"task_id":"task-256","hypothesis":"projection can explain the run","test_plan":["load manifest","match events"],"result":"explain payload built","confidence":0.66,"next_action":"approval_waiting","observation_pack_ref":"observations/task-256.json","consultation_ref":"consultations/task-256.json","run_id":"task:task-256","slot":"builder-1","worktree":".worktrees/builder-1","env_fingerprint":"env-123","command_hash":"cmd-456","observation_pack":{"summary":"ok"},"consultation_packet":{"review":"ok"}}}
 {"timestamp":"2026-04-23T12:00:05+09:00","session":"winsmux-orchestra","event":"pane.consult_request","message":"new action only","label":"builder-1","pane_id":"%2","role":"Builder","data":{"task_id":"task-256","next_action":"review_requested"}}
@@ -731,6 +731,21 @@ panes:
     assert_eq!(
         explain.run.context_contract["local_reference_paths_stored"],
         false
+    );
+    assert_eq!(explain.run.run_insights["retry_count"], 1);
+    assert_eq!(
+        explain.run.run_insights["drift_signals"][0],
+        "drift_detected"
+    );
+    assert!(
+        explain.run.run_insights["intervention_count"]
+            .as_u64()
+            .expect("intervention count should be numeric")
+            >= 1
+    );
+    assert_eq!(
+        explain.run.run_insights["next_improvements"][0],
+        "reduce retry loop before the next run"
     );
     assert_eq!(explain.run.audit_chain["chain_id"], "task:task-256");
     assert_eq!(
@@ -1072,6 +1087,8 @@ fn ledger_contract_serializes_typed_cli_payload_roots() {
     assert!(runs["runs"].as_array().unwrap().iter().any(|run| {
         run["verification_envelope"]["packet_type"] == "verification_envelope"
             && run["run_packet"]["verification_envelope"]["packet_type"] == "verification_envelope"
+            && run["run_insights"]["packet_type"] == "run_insights"
+            && run["run_packet"]["run_insights"]["packet_type"] == "run_insights"
     }));
 
     let explain_projection = snapshot
@@ -1101,6 +1118,10 @@ fn ledger_contract_serializes_typed_cli_payload_roots() {
         ],
     );
     assert_eq!(explain["run"]["run_id"], "task:task-256");
+    assert_eq!(
+        explain["run"]["run_insights"]["packet_type"],
+        "run_insights"
+    );
 }
 
 #[test]

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -6277,7 +6277,8 @@ function Get-RunEventAttempt {
 function New-RunInsightsContract {
     param(
         [Parameter(Mandatory = $true)]$Run,
-        [Parameter(Mandatory = $true)][object[]]$EventRecords
+        [AllowEmptyCollection()]
+        [object[]]$EventRecords = @()
     )
 
     $driftSignals = [System.Collections.Generic.List[string]]::new()

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -6248,6 +6248,120 @@ function New-RunPhaseGateContract {
     }
 }
 
+function Add-RunInsightText {
+    param(
+        [Parameter(Mandatory = $true)]$List,
+        [AllowNull()]$Value
+    )
+
+    $text = ([string]$Value).Trim()
+    if (-not [string]::IsNullOrWhiteSpace($text) -and -not $List.Contains($text)) {
+        $List.Add($text) | Out-Null
+    }
+}
+
+function Get-RunEventAttempt {
+    param([Parameter(Mandatory = $true)]$EventRecord)
+
+    $data = if ($EventRecord.Contains('data')) { $EventRecord['data'] } else { $null }
+    if ($null -ne $data -and $data -is [System.Collections.IDictionary] -and $data.Contains('attempt')) {
+        $attempt = 0
+        if ([int]::TryParse(([string]$data['attempt']), [ref]$attempt)) {
+            return $attempt
+        }
+    }
+
+    return 0
+}
+
+function New-RunInsightsContract {
+    param(
+        [Parameter(Mandatory = $true)]$Run,
+        [Parameter(Mandatory = $true)][object[]]$EventRecords
+    )
+
+    $driftSignals = [System.Collections.Generic.List[string]]::new()
+    $blockedReasons = [System.Collections.Generic.List[string]]::new()
+    $nextImprovements = [System.Collections.Generic.List[string]]::new()
+
+    $retryCount = 0
+    $interventionCount = @($Run.action_items).Count
+
+    foreach ($eventRecord in @($EventRecords)) {
+        $eventText = ("{0} {1} {2}" -f [string]$eventRecord['event'], [string]$eventRecord['message'], [string]$eventRecord['status']).ToLowerInvariant()
+        $nextAction = ''
+        $data = if ($eventRecord.Contains('data')) { $eventRecord['data'] } else { $null }
+        if ($null -ne $data -and $data -is [System.Collections.IDictionary] -and $data.Contains('next_action')) {
+            $nextAction = [string]$data['next_action']
+        }
+        $retryText = ("{0} {1}" -f $eventText, $nextAction).ToLowerInvariant()
+        if ($retryText.Contains('retry') -or $retryText.Contains('rerun') -or (Get-RunEventAttempt -EventRecord $eventRecord) -gt 1) {
+            $retryCount++
+        }
+
+        if ($eventText.Contains('drift')) {
+            Add-RunInsightText -List $driftSignals -Value 'drift_detected'
+        }
+        if ($eventText.Contains('stale')) {
+            Add-RunInsightText -List $driftSignals -Value 'stale_state'
+        }
+        if ($eventText.Contains('mismatch')) {
+            Add-RunInsightText -List $driftSignals -Value 'state_mismatch'
+        }
+        if ($eventText.Contains('approval') -or $eventText.Contains('review_requested') -or $eventText.Contains('question') -or $eventText.Contains('user')) {
+            $interventionCount++
+        }
+    }
+
+    Add-RunInsightText -List $blockedReasons -Value (Get-RunContractField -InputObject $Run.phase_gate -Name 'stop_reason')
+    if ([string](Get-RunContractField -InputObject $Run.draft_pr_gate -Name 'state') -eq 'blocked') {
+        Add-RunInsightText -List $blockedReasons -Value 'draft_pr_gate_blocked'
+    }
+    if ([string](Get-RunContractField -InputObject $Run.tdd_gate -Name 'state') -eq 'blocked') {
+        Add-RunInsightText -List $blockedReasons -Value 'tdd_gate_blocked'
+    }
+    if (([string](Get-RunContractField -InputObject $Run.verification_result -Name 'outcome')).ToUpperInvariant() -eq 'FAIL') {
+        Add-RunInsightText -List $blockedReasons -Value 'verification_failed'
+    }
+    if (([string](Get-RunContractField -InputObject $Run.security_verdict -Name 'verdict')).ToUpperInvariant() -eq 'BLOCK') {
+        Add-RunInsightText -List $blockedReasons -Value 'security_blocked'
+    }
+
+    $contextPressure = ([string](Get-RunContractField -InputObject $Run.verification_evidence -Name 'context_pressure')).ToLowerInvariant()
+    $unhealthySessionSize = (
+        [int]$Run.pane_count -gt 8 -or
+        [int]$Run.changed_file_count -gt 20 -or
+        $contextPressure -in @('high', 'critical', 'exhausted')
+    )
+
+    if ($retryCount -gt 0) {
+        Add-RunInsightText -List $nextImprovements -Value 'reduce retry loop before the next run'
+    }
+    if ($driftSignals.Count -gt 0) {
+        Add-RunInsightText -List $nextImprovements -Value 'refresh session state before continuing'
+    }
+    if ($interventionCount -gt 0) {
+        Add-RunInsightText -List $nextImprovements -Value 'capture operator decisions as reusable guidance'
+    }
+    if ($unhealthySessionSize) {
+        Add-RunInsightText -List $nextImprovements -Value 'split the next run into a smaller scope'
+    }
+    if ($blockedReasons.Count -gt 0) {
+        Add-RunInsightText -List $nextImprovements -Value 'resolve blocked reasons before release'
+    }
+
+    return [ordered]@{
+        packet_type            = 'run_insights'
+        scope                  = 'run'
+        retry_count            = $retryCount
+        drift_signals          = @($driftSignals)
+        intervention_count     = $interventionCount
+        unhealthy_session_size = [bool]$unhealthySessionSize
+        blocked_reasons        = @($blockedReasons)
+        next_improvements      = @($nextImprovements)
+    }
+}
+
 function Get-RunContractField {
     param(
         [AllowNull()]$InputObject,
@@ -6602,6 +6716,7 @@ function New-RunPacketFromRun {
         verification_result   = $Run.verification_result
         verification_evidence = $Run.verification_evidence
         context_contract      = $Run.context_contract
+        run_insights          = $Run.run_insights
         tdd_gate              = $Run.tdd_gate
         verification_envelope = $Run.verification_envelope
         plan              = $Run.plan
@@ -6686,6 +6801,7 @@ function New-RunResultPacket {
         verification_result   = $Run.verification_result
         verification_evidence = $Run.verification_evidence
         context_contract      = $Run.context_contract
+        run_insights          = $Run.run_insights
         tdd_gate              = $Run.tdd_gate
         verification_envelope = $Run.verification_envelope
         security_policy       = $Run.security_policy
@@ -6951,6 +7067,7 @@ function Get-RunsPayload {
                 verification_result   = $null
                 verification_evidence = $null
                 context_contract      = $null
+                run_insights          = $null
                 plan                  = $null
                 plan_checkpoints      = @()
                 managed_loop          = $null
@@ -7123,6 +7240,7 @@ function Get-RunsPayload {
             $run.audit_chain = New-RunAuditChainContract -Run $run -EventRecords $runEvents
             $run.verification_envelope = New-RunVerificationEnvelope -Run $run
             $run.outcome = New-RunOutcomeContract -Run $run
+            $run.run_insights = New-RunInsightsContract -Run $run -EventRecords $runEvents
             $nextAction = Get-RunNextAction -Run $run
             $stateModel = New-RunStateModel -State ([string]$run.state) -TaskState ([string]$run.task_state) -ReviewState ([string]$run.review_state) -EventKind $nextAction -LastEvent ([string]$run.last_event)
             [ordered]@{
@@ -7173,6 +7291,7 @@ function Get-RunsPayload {
                 verification_result   = $run.verification_result
                 verification_evidence = $run.verification_evidence
                 context_contract      = $run.context_contract
+                run_insights          = $run.run_insights
                 tdd_gate              = $run.tdd_gate
                 verification_envelope = $run.verification_envelope
                 plan                  = $run.plan

--- a/tests/fixtures/rust-parity/explain.json
+++ b/tests/fixtures/rust-parity/explain.json
@@ -130,6 +130,21 @@
         "raw_tool_output_stored": false
       }
     },
+    "run_insights": {
+      "packet_type": "run_insights",
+      "scope": "run",
+      "retry_count": 0,
+      "drift_signals": [],
+      "intervention_count": 3,
+      "unhealthy_session_size": false,
+      "blocked_reasons": [
+        "draft_pr_gate_blocked"
+      ],
+      "next_improvements": [
+        "capture operator decisions as reusable guidance",
+        "resolve blocked reasons before release"
+      ]
+    },
     "tdd_gate": {
       "policy": "test_first_required",
       "required": true,

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -8271,7 +8271,7 @@ panes:
             timestamp = '2026-04-10T12:02:00+09:00'
             session   = 'winsmux-orchestra'
             event     = 'pipeline.verify.partial'
-            message   = 'verification partially complete'
+            message   = 'verification partially complete after drift retry'
             label     = 'reviewer-1'
             pane_id   = '%3'
             role      = 'Reviewer'
@@ -8297,6 +8297,7 @@ panes:
                     performance_budget = [ordered]@{ max_context_tokens = 42000 }
                     rationale = 'keep worker context scoped'
                 }
+                attempt = 2
                 verification_result = [ordered]@{
                     outcome = 'PARTIAL'
                     summary = 'rerun focused verification'
@@ -8389,7 +8390,12 @@ panes:
         $result.runs[0].context_contract.semantic_context.private_source_body_stored | Should -Be $false
         $result.runs[0].context_contract.prompt_body_stored | Should -Be $false
         $result.runs[0].context_contract.private_memory_stored | Should -Be $false
+        $result.runs[0].run_insights.retry_count | Should -Be 1
+        $result.runs[0].run_insights.drift_signals | Should -Be @('drift_detected')
+        $result.runs[0].run_insights.unhealthy_session_size | Should -Be $true
+        $result.runs[0].run_insights.next_improvements | Should -Contain 'split the next run into a smaller scope'
         $result.runs[0].run_packet.context_contract.context_pack_id | Should -Be 'ctx-runs'
+        $result.runs[0].run_packet.run_insights.retry_count | Should -Be 1
         $result.runs[0].tdd_gate.required | Should -Be $true
         $result.runs[0].tdd_gate.state | Should -Be 'passed'
         $result.runs[0].tdd_gate.red_event | Should -Be 'pipeline.tdd.red'
@@ -9593,7 +9599,7 @@ panes:
                 timestamp = '2026-04-10T12:02:00+09:00'
                 session   = 'winsmux-orchestra'
                 event     = 'pipeline.verify.partial'
-                message   = 'verification partial'
+                message   = 'verification partial with drift retry'
                 label     = 'reviewer-1'
                 pane_id   = '%3'
                 role      = 'Reviewer'
@@ -9621,6 +9627,7 @@ panes:
                         performance_budget = [ordered]@{ max_context_tokens = 42000 }
                         rationale = 'keep worker context scoped'
                     }
+                    attempt = 2
                     verification_result = [ordered]@{
                         outcome = 'PARTIAL'
                         summary = 'rerun focused verification'
@@ -9805,6 +9812,10 @@ panes:
         $result.run.context_contract.prompt_body_stored | Should -Be $false
         $result.run.context_contract.private_memory_stored | Should -Be $false
         $result.run.context_contract.local_reference_paths_stored | Should -Be $false
+        $result.run.run_insights.retry_count | Should -Be 1
+        $result.run.run_insights.drift_signals | Should -Be @('drift_detected')
+        $result.run.run_insights.intervention_count | Should -BeGreaterThan 0
+        $result.run.run_insights.next_improvements | Should -Contain 'reduce retry loop before the next run'
         $result.run.tdd_gate.required | Should -Be $true
         $result.run.tdd_gate.state | Should -Be 'passed'
         $result.run.tdd_gate.red_event | Should -Be 'pipeline.tdd.red'

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -8780,6 +8780,16 @@ Set-Location '__RUNS_TEMP_ROOT__'
         $result.summary.run_count | Should -Be 1
         $result.runs[0].run_id | Should -Be 'task:task-256'
         $result.runs[0].experiment_packet | Should -Be $null
+        $result.runs[0].run_insights.retry_count | Should -Be 0
+        @($result.runs[0].run_insights.drift_signals).Count | Should -Be 0
+        $result.runs[0].run_insights.intervention_count | Should -Be 1
+        $result.runs[0].run_insights.unhealthy_session_size | Should -Be $false
+        $result.runs[0].run_insights.blocked_reasons | Should -Contain 'tdd_evidence_missing'
+        $result.runs[0].run_insights.blocked_reasons | Should -Contain 'draft_pr_gate_blocked'
+        $result.runs[0].run_insights.blocked_reasons | Should -Contain 'tdd_gate_blocked'
+        $result.runs[0].run_insights.next_improvements | Should -Contain 'capture operator decisions as reusable guidance'
+        $result.runs[0].run_insights.next_improvements | Should -Contain 'resolve blocked reasons before release'
+        $result.runs[0].run_packet.run_insights.retry_count | Should -Be 0
     }
 
     It 'keeps experiment packets scoped to strong run keys when multiple runs share a branch' {


### PR DESCRIPTION
## Summary
- Add compact run_insights metadata to runs, explain, and run_packet projections.
- Derive retry, drift, intervention, unhealthy session size, blocked category, and next improvement signals.
- Keep blocked reasons as fixed categories only after subagent review flagged free-form reason leakage risk.

## Validation
- cargo test --manifest-path core/Cargo.toml ledger_contract --test ledger_contract -- --nocapture
- Invoke-Pester -Path tests\winsmux-bridge.Tests.ps1 -FullName '*returns runs as json*','*returns a json explanation with related events and review state*' -Output Detailed
- Invoke-Pester -Path tests\winsmux-bridge.Tests.ps1 -FullName '*keeps explain json fixture stable*' -Output Detailed
- cargo test --manifest-path core/Cargo.toml --test fixture_comparison -- --nocapture fixture_comparison_harness_diffs_modeled_projection_payloads
- pwsh -NoProfile -File scripts\git-guard.ps1
- pwsh -NoProfile -File scripts\audit-public-surface.ps1
- git diff --check

## Review
- Subagent review found free-form blocked reason leakage risk; fixed before PR.