### PR TITLE
feat: add playbook template contracts

### DIFF
--- a/core/src/operator_cli.rs
+++ b/core/src/operator_cli.rs
@@ -5918,6 +5918,27 @@ fn compare_runs_payload(
             })
             .unwrap_or(false)
     }) || !(left_recommendable && right_recommendable);
+    let playbook_template = if !winning_run_id.trim().is_empty() {
+        if winning_run_id == left.run.run_id {
+            playbook_template_contract(
+                &left.run,
+                &left.evidence_digest,
+                "compare_winner_follow_up",
+                "compare_runs",
+            )
+        } else {
+            playbook_template_contract(
+                &right.run,
+                &right.evidence_digest,
+                "compare_winner_follow_up",
+                "compare_runs",
+            )
+        }
+    } else if reconcile_consult {
+        compare_reconcile_playbook_template(&left.run, &right.run)
+    } else {
+        Value::Null
+    };
     let next_action = if left.evidence_digest.next_action == right.evidence_digest.next_action {
         left.evidence_digest.next_action.clone()
     } else {
@@ -5937,6 +5958,7 @@ fn compare_runs_payload(
             "winning_run_id": winning_run_id,
             "reconcile_consult": reconcile_consult,
             "next_action": next_action,
+            "playbook_template": playbook_template,
         },
     })
 }
@@ -6276,6 +6298,136 @@ fn run_recommendable(run: &crate::ledger::LedgerExplainRun) -> bool {
     )
 }
 
+fn run_playbook_flow(
+    run: &crate::ledger::LedgerExplainRun,
+    evidence_digest: &crate::ledger::LedgerDigestItem,
+    fallback: &str,
+) -> &'static str {
+    match fallback {
+        "ci" => return "ci",
+        "review" => return "review",
+        "ui" => return "ui",
+        "compare_winner_follow_up" => return "compare_winner_follow_up",
+        "conflict_resolution" => return "conflict_resolution",
+        _ => {}
+    }
+
+    let has_ci_path = evidence_digest.changed_files.iter().any(|path| {
+        path.starts_with(".github/")
+            || path.ends_with(".yml")
+            || path.ends_with(".yaml")
+            || path == "package.json"
+            || path == "package-lock.json"
+    });
+    if has_ci_path {
+        return "ci";
+    }
+    let next_action = format!(
+        "{} {}",
+        evidence_digest.next_action, run.experiment_packet.next_action
+    )
+    .to_ascii_lowercase();
+    if matches!(
+        run.review_state.as_str(),
+        "PENDING" | "FAIL" | "FAILED"
+    ) || next_action.contains("review")
+    {
+        return "review";
+    }
+    let has_ui_path = evidence_digest.changed_files.iter().any(|path| {
+        path.ends_with(".css")
+            || path.ends_with(".tsx")
+            || path.ends_with(".jsx")
+            || path.ends_with(".html")
+            || path.contains("ui")
+            || path.contains("desktop")
+            || path.contains("viewport")
+    });
+    if has_ui_path {
+        return "ui";
+    }
+    match fallback {
+        "ci" => "ci",
+        "review" => "review",
+        "ui" => "ui",
+        "compare_winner_follow_up" => "compare_winner_follow_up",
+        "conflict_resolution" => "conflict_resolution",
+        _ => "bugfix",
+    }
+}
+
+fn playbook_required_evidence(flow: &str) -> Vec<&'static str> {
+    match flow {
+        "ci" => vec!["workflow_status", "build_log", "rerun_evidence"],
+        "review" => vec!["findings", "review_decision", "evidence_refs"],
+        "ui" => vec![
+            "screenshot_or_manual_check",
+            "interaction_check",
+            "viewport_check",
+        ],
+        "compare_winner_follow_up" => {
+            vec!["winning_run", "comparison_evidence", "promotion_candidate"]
+        }
+        "conflict_resolution" => vec!["overlap_paths", "reconcile_consult", "human_decision"],
+        _ => vec!["reproduction", "fix", "regression_test"],
+    }
+}
+
+fn playbook_template_contract(
+    run: &crate::ledger::LedgerExplainRun,
+    evidence_digest: &crate::ledger::LedgerDigestItem,
+    flow: &str,
+    source: &str,
+) -> Value {
+    let resolved_flow = run_playbook_flow(run, evidence_digest, flow);
+    json!({
+        "contract_version": 1,
+        "packet_type": "playbook_template_contract",
+        "source": source,
+        "source_run_id": run.run_id,
+        "flow": resolved_flow,
+        "template_refs": [format!("playbook:{resolved_flow}")],
+        "role_policy": {
+            "builder": "implement smallest verified change",
+            "reviewer": "return findings first with evidence references",
+            "tester": "verify unit integration cli and contract coverage",
+        },
+        "required_evidence": playbook_required_evidence(resolved_flow),
+        "handoff_refs": run.handoff_refs,
+        "execution_backend": "operator_managed",
+        "backend_profile_required": false,
+        "freeform_body_stored": false,
+        "private_guidance_stored": false,
+        "local_reference_paths_stored": false,
+    })
+}
+
+fn compare_reconcile_playbook_template(
+    left_run: &crate::ledger::LedgerExplainRun,
+    right_run: &crate::ledger::LedgerExplainRun,
+) -> Value {
+    json!({
+        "contract_version": 1,
+        "packet_type": "playbook_template_contract",
+        "source": "compare_runs",
+        "source_run_id": "",
+        "flow": "conflict_resolution",
+        "template_refs": ["playbook:conflict_resolution"],
+        "role_policy": {
+            "builder": "prepare minimal conflict evidence",
+            "reviewer": "compare behavior and safety risks",
+            "tester": "verify both branches before choosing",
+        },
+        "required_evidence": playbook_required_evidence("conflict_resolution"),
+        "compare_run_ids": [left_run.run_id, right_run.run_id],
+        "execution_backend": "operator_managed",
+        "backend_profile_required": false,
+        "freeform_body_stored": false,
+        "private_guidance_stored": false,
+        "local_reference_paths_stored": false,
+    })
+}
+
 struct WrittenArtifact {
     path: String,
     reference: String,
@@ -6305,6 +6457,11 @@ fn promote_tactic_candidate(
     } else {
         experiment.result.clone()
     };
+    let playbook_flow = if options.kind == "verification" {
+        "ci"
+    } else {
+        ""
+    };
 
     json!({
         "run_id": run.run_id,
@@ -6327,6 +6484,7 @@ fn promote_tactic_candidate(
         "consultation_ref": experiment.consultation_ref,
         "verification_result": run.verification_result,
         "security_verdict": run.security_verdict,
+        "playbook_template": playbook_template_contract(run, &projection.evidence_digest, playbook_flow, "promote_tactic"),
         "action_item_count": run.action_items.len(),
         "action_item_kinds": action_item_kinds(&run.action_items),
         "reuse_conditions": reuse_conditions(run),

--- a/core/tests-rs/operator_cli.rs
+++ b/core/tests-rs/operator_cli.rs
@@ -1941,6 +1941,22 @@ fn operator_cli_compare_runs_json_reports_evidence_delta() {
     assert_eq!(json["right_only_changed_files"][0], "core/src/main.rs");
     assert_eq!(json["recommend"]["winning_run_id"], "task:task-a");
     assert_eq!(json["recommend"]["reconcile_consult"], true);
+    assert_eq!(
+        json["recommend"]["playbook_template"]["packet_type"],
+        "playbook_template_contract"
+    );
+    assert_eq!(
+        json["recommend"]["playbook_template"]["flow"],
+        "compare_winner_follow_up"
+    );
+    assert_eq!(
+        json["recommend"]["playbook_template"]["required_evidence"][0],
+        "winning_run"
+    );
+    assert_eq!(
+        json["recommend"]["playbook_template"]["freeform_body_stored"],
+        false
+    );
     let fields: Vec<_> = json["differences"]
         .as_array()
         .expect("differences should be array")
@@ -1950,6 +1966,31 @@ fn operator_cli_compare_runs_json_reports_evidence_delta() {
     assert!(fields.contains(&"result"));
     assert!(fields.contains(&"confidence"));
     assert!(fields.contains(&"changed_files"));
+}
+
+#[test]
+fn operator_cli_compare_runs_preserves_follow_up_playbook_for_ci_paths() {
+    let project_dir = make_temp_project_dir("compare-runs-ci-path-playbook");
+    write_compare_runs_fixture(&project_dir);
+    let manifest_path = project_dir.join(".winsmux").join("manifest.yaml");
+    let manifest = fs::read_to_string(&manifest_path).expect("test should read manifest");
+    let manifest = manifest.replace("core/src/operator_cli.rs", ".github/workflows/ci.yml");
+    fs::write(manifest_path, manifest).expect("test should write manifest");
+
+    let json = run_json(
+        &project_dir,
+        &["compare-runs", "task:task-a", "task:task-b", "--json"],
+    );
+
+    assert_eq!(json["recommend"]["winning_run_id"], "task:task-a");
+    assert_eq!(
+        json["recommend"]["playbook_template"]["flow"],
+        "compare_winner_follow_up"
+    );
+    assert_eq!(
+        json["recommend"]["playbook_template"]["template_refs"][0],
+        "playbook:compare_winner_follow_up"
+    );
 }
 
 #[test]
@@ -2040,6 +2081,36 @@ fn operator_cli_compare_runs_uses_powershell_rounding() {
 }
 
 #[test]
+fn operator_cli_compare_runs_emits_conflict_resolution_playbook_when_no_winner() {
+    let project_dir = make_temp_project_dir("compare-runs-conflict-playbook");
+    write_compare_runs_fixture(&project_dir);
+    let events_path = project_dir.join(".winsmux").join("events.jsonl");
+    let events = fs::read_to_string(&events_path)
+        .expect("test should read events")
+        .replace("\"outcome\":\"PASS\"", "\"outcome\":\"FAIL\"");
+    fs::write(events_path, events).expect("test should write events");
+
+    let json = run_json(
+        &project_dir,
+        &["compare-runs", "task:task-a", "task:task-b", "--json"],
+    );
+
+    assert_eq!(json["recommend"]["winning_run_id"], "");
+    assert_eq!(
+        json["recommend"]["playbook_template"]["flow"],
+        "conflict_resolution"
+    );
+    assert_eq!(
+        json["recommend"]["playbook_template"]["compare_run_ids"][0],
+        "task:task-a"
+    );
+    assert_eq!(
+        json["recommend"]["playbook_template"]["required_evidence"][0],
+        "overlap_paths"
+    );
+}
+
+#[test]
 fn operator_cli_promote_tactic_writes_playbook_candidate() {
     let project_dir = make_temp_project_dir("promote-tactic");
     write_compare_runs_fixture(&project_dir);
@@ -2090,6 +2161,26 @@ fn operator_cli_promote_tactic_writes_playbook_candidate() {
         json["candidate"]["consultation_ref"],
         ".winsmux/consultations/task-a.json"
     );
+    assert_eq!(
+        json["candidate"]["playbook_template"]["packet_type"],
+        "playbook_template_contract"
+    );
+    assert_eq!(json["candidate"]["playbook_template"]["flow"], "bugfix");
+    assert_eq!(
+        json["candidate"]["playbook_template"]["required_evidence"][0],
+        "reproduction"
+    );
+    assert_eq!(
+        json["candidate"]["playbook_template"]["execution_backend"],
+        "operator_managed"
+    );
+    assert_eq!(
+        json["candidate"]["playbook_template"]["freeform_body_stored"],
+        false
+    );
+    assert!(
+        json["candidate"]["playbook_template"]["freeform_body"].is_null()
+    );
 }
 
 #[test]
@@ -2118,6 +2209,52 @@ fn operator_cli_compare_promote_alias_writes_playbook_candidate() {
     assert_eq!(json["candidate"]["kind"], "playbook");
     assert_eq!(json["candidate"]["title"], "Deterministic build command");
     assert_eq!(json["candidate"]["summary"], "prefer cache command");
+}
+
+#[test]
+fn operator_cli_promote_tactic_verification_kind_uses_ci_playbook() {
+    let project_dir = make_temp_project_dir("promote-tactic-verification-playbook");
+    write_compare_runs_fixture(&project_dir);
+
+    let json = run_json(
+        &project_dir,
+        &[
+            "promote-tactic",
+            "task:task-a",
+            "--kind",
+            "verification",
+            "--json",
+        ],
+    );
+
+    assert_eq!(json["candidate"]["kind"], "verification");
+    assert_eq!(json["candidate"]["playbook_template"]["flow"], "ci");
+    assert_eq!(
+        json["candidate"]["playbook_template"]["required_evidence"][0],
+        "workflow_status"
+    );
+}
+
+#[test]
+fn operator_cli_promote_tactic_review_next_action_uses_review_playbook() {
+    let project_dir = make_temp_project_dir("promote-tactic-review-playbook");
+    write_compare_runs_fixture(&project_dir);
+    let events_path = project_dir.join(".winsmux").join("events.jsonl");
+    let events = fs::read_to_string(&events_path)
+        .expect("test should read events")
+        .replace("\"next_action\":\"promote tactic\"", "\"next_action\":\"review findings\"");
+    fs::write(events_path, events).expect("test should write events");
+
+    let json = run_json(
+        &project_dir,
+        &["promote-tactic", "task:task-a", "--json"],
+    );
+
+    assert_eq!(json["candidate"]["playbook_template"]["flow"], "review");
+    assert_eq!(
+        json["candidate"]["playbook_template"]["required_evidence"][0],
+        "findings"
+    );
 }
 
 #[test]

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -7391,6 +7391,105 @@ function Test-RunPromotable {
     return (Test-RunRecommendable -Run $Run)
 }
 
+function Get-RunPlaybookFlow {
+    param(
+        [Parameter(Mandatory = $true)]$Run,
+        [AllowNull()]$EvidenceDigest = $null,
+        [string]$Fallback = 'bugfix'
+    )
+
+    $nextAction = [string](Get-RunContractField -InputObject $EvidenceDigest -Name 'next_action')
+    $reviewState = [string](Get-RunContractField -InputObject $Run -Name 'review_state')
+    $changedFiles = @(
+        foreach ($changedFile in @($Run.changed_files)) {
+            [string]$changedFile
+        }
+    )
+
+    if ($changedFiles | Where-Object { $_ -match '^\.github/' -or $_ -match '\.ya?ml$' -or $_ -match 'package(-lock)?\.json$' }) {
+        return 'ci'
+    }
+    if ($reviewState -in @('PENDING', 'FAIL', 'FAILED') -or $nextAction -match 'review') {
+        return 'review'
+    }
+    if ($changedFiles | Where-Object { $_ -match '\.(css|tsx|jsx|html)$' -or $_ -match 'ui|desktop|viewport' }) {
+        return 'ui'
+    }
+
+    return $Fallback
+}
+
+function New-RunPlaybookTemplate {
+    param(
+        [Parameter(Mandatory = $true)]$Run,
+        [AllowNull()]$EvidenceDigest = $null,
+        [string]$Flow = '',
+        [string]$Source = 'run'
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Flow)) {
+        $Flow = Get-RunPlaybookFlow -Run $Run -EvidenceDigest $EvidenceDigest
+    }
+
+    $requiredEvidence = switch ($Flow) {
+        'ci' { @('workflow_status', 'build_log', 'rerun_evidence') }
+        'review' { @('findings', 'review_decision', 'evidence_refs') }
+        'ui' { @('screenshot_or_manual_check', 'interaction_check', 'viewport_check') }
+        'compare_winner_follow_up' { @('winning_run', 'comparison_evidence', 'promotion_candidate') }
+        'conflict_resolution' { @('overlap_paths', 'reconcile_consult', 'human_decision') }
+        default { @('reproduction', 'fix', 'regression_test') }
+    }
+
+    return [ordered]@{
+        contract_version          = 1
+        packet_type               = 'playbook_template_contract'
+        source                    = [string]$Source
+        source_run_id             = [string]$Run.run_id
+        flow                      = [string]$Flow
+        template_refs             = @("playbook:$Flow")
+        role_policy               = [ordered]@{
+            builder  = 'implement smallest verified change'
+            reviewer = 'return findings first with evidence references'
+            tester   = 'verify unit integration cli and contract coverage'
+        }
+        required_evidence         = @($requiredEvidence)
+        handoff_refs              = @($Run.handoff_refs)
+        execution_backend         = 'operator_managed'
+        backend_profile_required  = $false
+        freeform_body_stored      = $false
+        private_guidance_stored   = $false
+        local_reference_paths_stored = $false
+    }
+}
+
+function New-CompareReconcilePlaybookTemplate {
+    param(
+        [Parameter(Mandatory = $true)]$LeftRun,
+        [Parameter(Mandatory = $true)]$RightRun
+    )
+
+    return [ordered]@{
+        contract_version          = 1
+        packet_type               = 'playbook_template_contract'
+        source                    = 'compare_runs'
+        source_run_id             = ''
+        flow                      = 'conflict_resolution'
+        template_refs             = @('playbook:conflict_resolution')
+        role_policy               = [ordered]@{
+            builder  = 'prepare minimal conflict evidence'
+            reviewer = 'compare behavior and safety risks'
+            tester   = 'verify both branches before choosing'
+        }
+        required_evidence         = @('overlap_paths', 'reconcile_consult', 'human_decision')
+        compare_run_ids           = @([string]$LeftRun.run_id, [string]$RightRun.run_id)
+        execution_backend         = 'operator_managed'
+        backend_profile_required  = $false
+        freeform_body_stored      = $false
+        private_guidance_stored   = $false
+        local_reference_paths_stored = $false
+    }
+}
+
 function ConvertTo-CompareRunsPayload {
     param(
         [Parameter(Mandatory = $true)]$LeftPayload,
@@ -7482,6 +7581,21 @@ function ConvertTo-CompareRunsPayload {
         }
     }
 
+    $reconcileConsult = [bool](
+        @($differences | Where-Object { $_.field -in @('branch', 'worktree', 'env_fingerprint', 'command_hash', 'result') }).Count -gt 0 -or
+        -not ($leftRecommendable -and $rightRecommendable)
+    )
+    $recommendedPlaybook = $null
+    if (-not [string]::IsNullOrWhiteSpace($winningRunId)) {
+        if ($winningRunId -eq [string]$leftRun.run_id) {
+            $recommendedPlaybook = New-RunPlaybookTemplate -Run $leftRun -EvidenceDigest $leftEvidence -Flow 'compare_winner_follow_up' -Source 'compare_runs'
+        } else {
+            $recommendedPlaybook = New-RunPlaybookTemplate -Run $rightRun -EvidenceDigest $rightEvidence -Flow 'compare_winner_follow_up' -Source 'compare_runs'
+        }
+    } elseif ($reconcileConsult) {
+        $recommendedPlaybook = New-CompareReconcilePlaybookTemplate -LeftRun $leftRun -RightRun $rightRun
+    }
+
     return [ordered]@{
         generated_at = (Get-Date).ToString('o')
         left = [ordered]@{
@@ -7519,11 +7633,9 @@ function ConvertTo-CompareRunsPayload {
         differences = @($differences)
         recommend = [ordered]@{
             winning_run_id = $winningRunId
-            reconcile_consult = [bool](
-                @($differences | Where-Object { $_.field -in @('branch', 'worktree', 'env_fingerprint', 'command_hash', 'result') }).Count -gt 0 -or
-                -not ($leftRecommendable -and $rightRecommendable)
-            )
+            reconcile_consult = $reconcileConsult
             next_action = if ([string]$leftEvidence.next_action -eq [string]$rightEvidence.next_action) { [string]$leftEvidence.next_action } else { 'reconcile_consult' }
+            playbook_template = $recommendedPlaybook
         }
     }
 }
@@ -7552,6 +7664,10 @@ function Get-PromoteTacticPayload {
             $Title = "Tactic from $([string]$run.run_id)"
         }
     }
+    $playbookFlow = ''
+    if ([string]$Kind -eq 'verification') {
+        $playbookFlow = 'ci'
+    }
 
     return [ordered]@{
         run_id               = [string]$run.run_id
@@ -7575,6 +7691,7 @@ function Get-PromoteTacticPayload {
         verification_result  = $run.verification_result
         verification_evidence = $run.verification_evidence
         security_verdict     = $run.security_verdict
+        playbook_template    = New-RunPlaybookTemplate -Run $run -EvidenceDigest $evidenceDigest -Flow $playbookFlow -Source 'promote_tactic'
         action_item_count    = @($run.action_items).Count
         action_item_kinds    = @($run.action_items | ForEach-Object { [string]$_.kind } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
         reuse_conditions     = @(

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -12977,6 +12977,16 @@ panes:
         $result.right_only_changed_files | Should -Be @('tests/winsmux-bridge.Tests.ps1')
         $result.recommend.winning_run_id | Should -Be 'task:task-compare-a'
         $result.recommend.reconcile_consult | Should -Be $true
+        $result.recommend.playbook_template.packet_type | Should -Be 'playbook_template_contract'
+        $result.recommend.playbook_template.flow | Should -Be 'compare_winner_follow_up'
+        $result.recommend.playbook_template.source_run_id | Should -Be 'task:task-compare-a'
+        $result.recommend.playbook_template.required_evidence | Should -Be @('winning_run', 'comparison_evidence', 'promotion_candidate')
+        $result.recommend.playbook_template.execution_backend | Should -Be 'operator_managed'
+        $result.recommend.playbook_template.backend_profile_required | Should -Be $false
+        $result.recommend.playbook_template.freeform_body_stored | Should -Be $false
+        $result.recommend.playbook_template.private_guidance_stored | Should -Be $false
+        $result.recommend.playbook_template.PSObject.Properties.Name | Should -Not -Contain 'freeform_body'
+        $result.recommend.playbook_template.PSObject.Properties.Name | Should -Not -Contain 'private_guidance'
         @($result.differences | ForEach-Object { $_.field }) | Should -Contain 'result'
         @($result.differences | ForEach-Object { $_.field }) | Should -Contain 'confidence'
         @($result.differences | ForEach-Object { $_.field }) | Should -Contain 'changed_files'
@@ -13176,6 +13186,10 @@ panes:
         $result.right.recommendable | Should -Be $false
         $result.recommend.winning_run_id | Should -Be ''
         $result.recommend.reconcile_consult | Should -Be $true
+        $result.recommend.playbook_template.flow | Should -Be 'conflict_resolution'
+        $result.recommend.playbook_template.compare_run_ids | Should -Be @('task:task-compare-a', 'task:task-compare-b')
+        $result.recommend.playbook_template.required_evidence | Should -Be @('overlap_paths', 'reconcile_consult', 'human_decision')
+        $result.recommend.playbook_template.freeform_body_stored | Should -Be $false
     }
 
     It 'exports a playbook candidate from a run and writes a file-backed artifact' {
@@ -13192,6 +13206,16 @@ panes:
         $result.candidate.changed_files | Should -Be @('scripts/winsmux-core.ps1')
         $result.candidate.observation_pack_ref | Should -Be $script:compareObsA.reference
         $result.candidate.consultation_ref | Should -Be $script:compareConsultA.reference
+        $result.candidate.playbook_template.packet_type | Should -Be 'playbook_template_contract'
+        $result.candidate.playbook_template.flow | Should -Be 'review'
+        $result.candidate.playbook_template.role_policy.reviewer | Should -Be 'return findings first with evidence references'
+        $result.candidate.playbook_template.required_evidence | Should -Be @('findings', 'review_decision', 'evidence_refs')
+        $result.candidate.playbook_template.execution_backend | Should -Be 'operator_managed'
+        $result.candidate.playbook_template.backend_profile_required | Should -Be $false
+        $result.candidate.playbook_template.freeform_body_stored | Should -Be $false
+        $result.candidate.playbook_template.private_guidance_stored | Should -Be $false
+        $result.candidate.playbook_template.PSObject.Properties.Name | Should -Not -Contain 'freeform_body'
+        $result.candidate.playbook_template.PSObject.Properties.Name | Should -Not -Contain 'private_guidance'
     }
 
     It 'fails closed for unsupported promote kind' {


### PR DESCRIPTION
## Summary
- add playbook_template_contract emission to compare-runs and promote-tactic
- keep explicit compare winner and verification flows stable across Rust and PowerShell
- add Rust and PowerShell coverage for winner, conflict, review, bugfix, and ci playbook flows

## Validation
- cargo test --manifest-path core/Cargo.toml --test operator_cli playbook -- --nocapture
- Invoke-Pester -Path tests\\winsmux-bridge.Tests.ps1 -FullName '*compare-runs*','*compare promote*','*promote-tactic*' -Output Detailed
- git diff --check
- pwsh -NoProfile -File scripts\\git-guard.ps1
- pwsh -NoProfile -File scripts\\audit-public-surface.ps1

## Review
- Subagent 019dd977-51c4-7cf3-bcc0-f3eee029e197 found two issues; both were fixed before this PR.