### PR TITLE
feat: add progressive skills catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ winsmux health-check
 winsmux compare runs <left_run_id> <right_run_id>
 winsmux compare preflight <left_ref> <right_ref>
 winsmux compare promote <run_id>
+winsmux skills --json
 ```
 
 | Command | Purpose |
@@ -108,6 +109,7 @@ winsmux compare promote <run_id>
 | `winsmux compare runs` | Compare evidence and confidence between two recorded runs |
 | `winsmux compare preflight` | Check two refs before merge or compare review |
 | `winsmux compare promote` | Export a successful run as input for the next run |
+| `winsmux skills` | Print agent-readable command skill contracts |
 | `winsmux read` | Read a pane before acting |
 | `winsmux send` | Send text to a pane |
 | `winsmux vault set` | Store a credential with Windows DPAPI |

--- a/core/src/cli.rs
+++ b/core/src/cli.rs
@@ -161,6 +161,7 @@ OPERATOR COMMANDS:
     digest                  Print high-signal run digest
     desktop-summary         Print desktop summary projection JSON or counts
     provider-capabilities   Inspect the provider capability registry contract
+    skills                  Print agent-readable command skill contracts
     machine-contract        Print the hook and agent machine contract JSON
     rust-canary             Print the Rust default-on canary gate JSON
     manual-checklist        Print the versioned manual validation checklist gate

--- a/core/src/help.rs
+++ b/core/src/help.rs
@@ -323,6 +323,7 @@ const CLI_COMMANDS: &[(&str, &str, &str)] = &[
     ("digest",            "",         "Print run digest JSON"),
     ("runs",              "",         "Print run-oriented evidence JSON"),
     ("explain",           "",         "Print one run explanation JSON"),
+    ("skills",            "",         "Print agent-readable command skill contracts"),
     // Misc
     ("confirm-before",    "confirm",  "Confirm before running command"),
     ("if-shell",          "if",       "Conditional command execution"),

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -255,6 +255,7 @@ fn run_main() -> io::Result<()> {
         "digest" => return operator_cli::run_digest_command(&cmd_args[1..]),
         "desktop-summary" => return operator_cli::run_desktop_summary_command(&cmd_args[1..]),
         "provider-capabilities" => return operator_cli::run_provider_capabilities_command(&cmd_args[1..]),
+        "skills" => return operator_cli::run_skills_command(&cmd_args[1..]),
         "machine-contract" => return operator_cli::run_machine_contract_command(&cmd_args[1..]),
         "rust-canary" => return operator_cli::run_rust_canary_command(&cmd_args[1..]),
         "manual-checklist" => return operator_cli::run_manual_checklist_command(&cmd_args[1..]),

--- a/core/src/operator_cli.rs
+++ b/core/src/operator_cli.rs
@@ -199,6 +199,94 @@ pub fn run_provider_capabilities_command(args: &[&String]) -> io::Result<()> {
     Ok(())
 }
 
+pub fn run_skills_command(args: &[&String]) -> io::Result<()> {
+    if should_print_help(args) {
+        println!("{}", usage_for("skills"));
+        return Ok(());
+    }
+    let json = parse_json_only_options("skills", args)?;
+    let payload = progressive_skills_catalog();
+    if json {
+        return write_json(&payload);
+    }
+
+    println!("Progressive skills catalog");
+    for skill in payload["skills"].as_array().into_iter().flatten() {
+        println!(
+            "- {}: {}",
+            skill["id"].as_str().unwrap_or_default(),
+            skill["purpose"].as_str().unwrap_or_default()
+        );
+        if let Some(commands) = skill["commands"].as_array() {
+            let command_text = commands
+                .iter()
+                .filter_map(Value::as_str)
+                .collect::<Vec<_>>()
+                .join(", ");
+            if !command_text.trim().is_empty() {
+                println!("  commands: {command_text}");
+            }
+        }
+    }
+    Ok(())
+}
+
+fn progressive_skills_catalog() -> Value {
+    json!({
+        "contract_version": 1,
+        "packet_type": "progressive_skills_catalog",
+        "command": "skills",
+        "generated_at": generated_at(),
+        "private_skill_bodies_allowed": false,
+        "freeform_body_stored": false,
+        "private_guidance_stored": false,
+        "local_reference_paths_stored": false,
+        "operator_judgement_boundary": "operator keeps final task split, merge, release, and human-escalation decisions",
+        "skills": [
+            {
+                "id": "run-read-models",
+                "purpose": "inspect current runs before assigning follow-up work",
+                "commands": ["runs --json", "explain <run_id> --json"],
+                "required_evidence": ["context_contract", "knowledge_layer", "run_insights"],
+                "review_role": "operator",
+                "operator_judgement_boundary": "use read models as evidence, not as automatic merge permission",
+                "public_contract_only": true,
+                "private_skill_body_stored": false
+            },
+            {
+                "id": "compare-and-promote",
+                "purpose": "compare two runs and export a reusable follow-up input",
+                "commands": ["compare runs <left_run_id> <right_run_id> --json", "compare promote <run_id> --json"],
+                "required_evidence": ["comparison_evidence", "playbook_template_contract", "security_verdict"],
+                "review_role": "reviewer",
+                "operator_judgement_boundary": "operator chooses whether the exported candidate should become work",
+                "public_contract_only": true,
+                "private_skill_body_stored": false
+            },
+            {
+                "id": "guarded-release",
+                "purpose": "check release gates before tag or merge automation",
+                "commands": ["guard --json", "manual-checklist --json", "legacy-compat-gate --json"],
+                "required_evidence": ["git_guard", "public_surface_audit", "manual_validation"],
+                "review_role": "tester",
+                "operator_judgement_boundary": "operator resolves failed gates before publishing",
+                "public_contract_only": true,
+                "private_skill_body_stored": false
+            },
+            {
+                "id": "provider-routing",
+                "purpose": "inspect provider capability and dry-run assignment decisions",
+                "commands": ["provider-capabilities --json", "assign --task <TASK-ID> --json"],
+                "required_evidence": ["provider_capability", "task_policy", "approval_policy"],
+                "review_role": "operator",
+                "operator_judgement_boundary": "operator may override routing when task risk or budget requires it",
+                "public_contract_only": true,
+                "private_skill_body_stored": false
+            }
+        ]
+    })
+}
+
 pub fn run_machine_contract_command(args: &[&String]) -> io::Result<()> {
     if should_print_help(args) {
         println!("{}", usage_for("machine-contract"));
@@ -692,6 +780,10 @@ fn rust_canary_backend() -> io::Result<RustCanaryBackend> {
 }
 
 fn parse_machine_contract_options(args: &[&String]) -> io::Result<bool> {
+    parse_json_only_options("machine-contract", args)
+}
+
+fn parse_json_only_options(command: &str, args: &[&String]) -> io::Result<bool> {
     let mut json = false;
     for arg in args {
         match arg.as_str() {
@@ -699,13 +791,13 @@ fn parse_machine_contract_options(args: &[&String]) -> io::Result<bool> {
             value if value.starts_with('-') => {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidInput,
-                    format!("unknown argument for winsmux machine-contract: {value}"),
+                    format!("unknown argument for winsmux {command}: {value}"),
                 ));
             }
             _ => {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidInput,
-                    usage_for("machine-contract").to_string(),
+                    usage_for(command).to_string(),
                 ));
             }
         }
@@ -3518,6 +3610,7 @@ fn usage_for(command: &str) -> &'static str {
         "provider-capabilities" => {
             "usage: winsmux provider-capabilities [provider] [--json] [--project-dir <path>]"
         }
+        "skills" => "usage: winsmux skills [--json]",
         "machine-contract" => "usage: winsmux machine-contract --json",
         "rust-canary" => "usage: winsmux rust-canary [--json] [--project-dir <path>]",
         "manual-checklist" => {

--- a/core/src/server/helpers.rs
+++ b/core/src/server/helpers.rs
@@ -279,6 +279,7 @@ pub(crate) const TMUX_COMMANDS: &[&str] = &[
     "show-messages (showmsgs)", "show-options (show)",
     "show-prompt-history (showphist)", "show-window-options (showw)",
     "source-file (source)",
+    "skills",
     "split-window (splitw)", "start-server (start)",
     "suspend-client (suspendc)", "swap-pane (swapp)",
     "swap-window (swapw)", "switch-client (switchc)",

--- a/core/tests-rs/operator_cli.rs
+++ b/core/tests-rs/operator_cli.rs
@@ -565,6 +565,62 @@ fn operator_cli_machine_contract_json_exposes_hook_facing_catalog() {
 }
 
 #[test]
+fn operator_cli_skills_json_exposes_agent_readable_contracts() {
+    let project_dir = make_temp_project_dir("skills-json");
+
+    let json = run_json(&project_dir, &["skills", "--json"]);
+
+    assert_eq!(json["packet_type"], "progressive_skills_catalog");
+    assert_eq!(json["private_skill_bodies_allowed"], false);
+    assert_eq!(json["freeform_body_stored"], false);
+    assert_eq!(json["skills"][0]["id"], "run-read-models");
+    assert_eq!(json["skills"][0]["commands"][0], "runs --json");
+    assert_eq!(
+        json["skills"][1]["required_evidence"][1],
+        "playbook_template_contract"
+    );
+    assert_eq!(json["skills"][1]["private_skill_body_stored"], false);
+    assert_eq!(json["skills"][2]["review_role"], "tester");
+}
+
+#[test]
+fn operator_cli_skills_help_and_command_lists_are_discoverable() {
+    let project_dir = make_temp_project_dir("skills-help");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .args(["skills", "--help"])
+        .current_dir(&project_dir)
+        .output()
+        .expect("winsmux command should run");
+    assert!(output.status.success());
+    assert!(String::from_utf8_lossy(&output.stdout).contains("usage: winsmux skills"));
+
+    let output = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .arg("--help")
+        .current_dir(&project_dir)
+        .output()
+        .expect("winsmux command should run");
+    assert!(output.status.success());
+    assert!(String::from_utf8_lossy(&output.stdout).contains("skills"));
+}
+
+#[test]
+fn operator_cli_skills_rejects_project_dir() {
+    let project_dir = make_temp_project_dir("skills-rejects-project-dir");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .args(["skills", "--json", "--project-dir"])
+        .arg(project_dir.as_os_str())
+        .current_dir(&project_dir)
+        .output()
+        .expect("winsmux command should run");
+
+    assert!(!output.status.success(), "skills should reject project-dir");
+    assert!(String::from_utf8_lossy(&output.stderr)
+        .contains("unknown argument for winsmux skills: --project-dir"));
+}
+
+#[test]
 fn operator_cli_machine_contract_requires_json() {
     let project_dir = make_temp_project_dir("machine-contract-requires-json");
 

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -9903,6 +9903,34 @@ function Invoke-MachineContract {
     $output | Write-Output
 }
 
+function Invoke-Skills {
+    param(
+        [AllowNull()][string]$SkillsTarget = $Target,
+        [AllowNull()][string[]]$SkillsRest = $Rest
+    )
+
+    $tokens = @(@($SkillsTarget) + @($SkillsRest) | Where-Object { $_ })
+    $rustArgs = @('skills')
+    foreach ($token in $tokens) {
+        switch ($token) {
+            '--json' {
+                $rustArgs += '--json'
+            }
+            default {
+                Stop-WithError "usage: winsmux skills [--json]"
+            }
+        }
+    }
+
+    $output = Invoke-WinsmuxRaw -Arguments $rustArgs
+    $nativeExitCode = Get-SafeLastExitCode
+    if ($null -ne $nativeExitCode -and $nativeExitCode -ne 0) {
+        exit $nativeExitCode
+    }
+
+    $output | Write-Output
+}
+
 function Invoke-RustCanary {
     $tokens = @(@($Target) + @($Rest) | Where-Object { $_ })
     $rustArgs = @('rust-canary')
@@ -10196,6 +10224,7 @@ Commands:
   consult-result <mode> [--message <text>] [--target-slot <slot>] [--confidence <0..1>] [--next-test <text>] [--risk <text>] [--run-id <run_id>] [--json]  Record a consultation result packet/event
   consult-error <mode> [--message <text>] [--target-slot <slot>]  Record a consultation error packet/event
   provider-capabilities [provider] [--json]  Inspect the provider capability registry contract
+  skills [--json]  Print agent-readable command skill contracts
   machine-contract --json  Print the hook and agent machine contract JSON
   rust-canary [--json]  Print the Rust default-on canary gate JSON
   manual-checklist [--json]  Print the versioned manual validation checklist gate
@@ -10923,6 +10952,7 @@ switch ($Command) {
     'consult-error'   { Invoke-ConsultError }
     'launcher'        { Invoke-Launcher }
     'provider-capabilities' { Invoke-ProviderCapabilities }
+    'skills' { Invoke-Skills }
     'machine-contract' { Invoke-MachineContract }
     'rust-canary' { Invoke-RustCanary }
     'manual-checklist' { Invoke-ManualChecklist }

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -11298,6 +11298,37 @@ Describe 'winsmux guard command' {
     }
 }
 
+Describe 'winsmux skills command' {
+    BeforeAll {
+        $script:winsmuxSkillsCoreRawPath = Join-Path (Split-Path -Parent $PSScriptRoot) 'scripts\winsmux-core.ps1'
+        $script:winsmuxSkillsCoreRawContent = Get-Content -Raw -Path $script:winsmuxSkillsCoreRawPath -Encoding UTF8
+        . $script:winsmuxSkillsCoreRawPath 'version' *> $null
+    }
+
+    It 'documents skills in usage and delegates to the Rust skills catalog' {
+        $script:winsmuxSkillsCoreRawContent | Should -Match 'skills \[--json\]'
+        $script:winsmuxSkillsCoreRawContent | Should -Match "'skills'\s*\{ Invoke-Skills \}"
+
+        Mock Invoke-WinsmuxRaw {
+            param([string[]]$Arguments)
+            $script:skillsArgs = @($Arguments)
+            return '{"packet_type":"progressive_skills_catalog","private_skill_bodies_allowed":false,"skills":[{"id":"compare-and-promote","required_evidence":["comparison_evidence","playbook_template_contract"],"private_skill_body_stored":false}]}'
+        }
+
+        $output = Invoke-Skills -SkillsTarget '--json'
+        $json = $output | ConvertFrom-Json
+        $script:skillsArgs | Should -Be @('skills', '--json')
+        $json.packet_type | Should -Be 'progressive_skills_catalog'
+        $json.private_skill_bodies_allowed | Should -Be $false
+        $json.skills[0].required_evidence | Should -Contain 'playbook_template_contract'
+        $json.skills[0].private_skill_body_stored | Should -Be $false
+    }
+
+    It 'rejects unknown skills arguments' {
+        { Invoke-Skills -SkillsTarget '--private' } | Should -Throw '*usage: winsmux skills [--json]*'
+    }
+}
+
 Describe 'winsmux assign command' {
     BeforeAll {
         $script:winsmuxAssignRawPath = Join-Path (Split-Path -Parent $PSScriptRoot) 'scripts\winsmux-core.ps1'


### PR DESCRIPTION
## Summary
- add winsmux skills as an agent-readable public contract catalog
- expose commands, required evidence, review role, and operator judgement boundaries without private skill bodies
- wire the command through Rust and PowerShell entrypoints and public command discovery

## Validation
- cargo test --manifest-path core/Cargo.toml --test operator_cli skills -- --nocapture
- cargo test --manifest-path core/Cargo.toml list_commands -- --nocapture
- Invoke-Pester -Path tests\\winsmux-bridge.Tests.ps1 -FullName '*winsmux skills command*' -Output Detailed
- git diff --check
- pwsh -NoProfile -File scripts\\git-guard.ps1
- pwsh -NoProfile -File scripts\\audit-public-surface.ps1

## Review
- Subagent 019dd98c-27ca-7d73-a82c-2ead32805604 found a Rust/PowerShell argument mismatch; fixed before this PR.