### PR TITLE
fix: stop release flow when verify fails

### DIFF
--- a/scripts/bump-version.ps1
+++ b/scripts/bump-version.ps1
@@ -389,15 +389,41 @@ try {
     $prNumber = if ($prUrl -match '/(\d+)$') { $Matches[1] } else { $prUrl }
     $bridgeScript = Join-Path $PSScriptRoot "winsmux-core.ps1"
     & pwsh $bridgeScript verify $prNumber
-    Write-Host "[release] PR merged (verified)"
+    $verifyExitCode = $LASTEXITCODE
+    if ($verifyExitCode -ne 0) {
+        throw "verify failed for PR #$prNumber with exit code $verifyExitCode. Refusing to tag or create GitHub Release."
+    }
+
+    $prJson = gh pr view $prNumber --json state,mergeCommit
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to read PR #$prNumber after verify. Refusing to tag or create GitHub Release."
+    }
+    $prState = $prJson | ConvertFrom-Json -Depth 20
+    $releaseCommit = [string]$prState.mergeCommit.oid
+    if ($prState.state -ne 'MERGED' -or [string]::IsNullOrWhiteSpace($releaseCommit)) {
+        throw "PR #$prNumber is not merged after verify. Refusing to tag or create GitHub Release."
+    }
+    Write-Host "[release] PR merged (verified): $releaseCommit"
 
     # Switch back to main and pull
     git checkout main
-    git pull origin main --rebase
+    git pull --ff-only origin main
+    $mainHead = (git rev-parse HEAD).Trim()
+    if ($mainHead -ne $releaseCommit) {
+        throw "main HEAD $mainHead does not match release PR merge commit $releaseCommit. Refusing to tag or create GitHub Release."
+    }
     Write-Host "[release] Main updated"
 
     # Tag the merge commit and push
-    git tag "v$Version"
+    $existingTag = (git tag --list "v$Version" | Out-String).Trim()
+    if (-not [string]::IsNullOrWhiteSpace($existingTag)) {
+        throw "Tag v$Version already exists. Refusing to overwrite a release tag."
+    }
+    $remoteTag = (git ls-remote --tags origin "refs/tags/v$Version" | Out-String).Trim()
+    if (-not [string]::IsNullOrWhiteSpace($remoteTag)) {
+        throw "Remote tag v$Version already exists. Refusing to overwrite a release tag."
+    }
+    git tag "v$Version" $releaseCommit
     git push origin "v$Version"
     Write-Host "[release] Tagged v$Version"
 

--- a/tests/VersionSurface.Tests.ps1
+++ b/tests/VersionSurface.Tests.ps1
@@ -122,4 +122,29 @@ Describe 'winsmux version surface' {
         $compatibility | Should -Match 'does not remove tmux-compatible configuration support'
         $thirdPartyNotices | Should -Match 'warning-only sunset mode'
     }
+
+    It 'stops the release flow when verify fails before tagging or publishing' {
+        $releaseScript = Get-Content -LiteralPath (Join-Path $script:RepoRoot 'scripts\bump-version.ps1') -Raw -Encoding UTF8
+
+        $verifyIndex = $releaseScript.IndexOf('& pwsh $bridgeScript verify $prNumber')
+        $exitCheckIndex = $releaseScript.IndexOf('$verifyExitCode = $LASTEXITCODE')
+        $prStateIndex = $releaseScript.IndexOf('gh pr view $prNumber --json state,mergeCommit')
+        $remoteTagIndex = $releaseScript.IndexOf('git ls-remote --tags origin "refs/tags/v$Version"')
+        $tagIndex = $releaseScript.IndexOf('git tag "v$Version" $releaseCommit')
+        $releaseIndex = $releaseScript.IndexOf('gh release create "v$Version"')
+
+        $verifyIndex | Should -BeGreaterThan -1
+        $exitCheckIndex | Should -BeGreaterThan $verifyIndex
+        $prStateIndex | Should -BeGreaterThan $exitCheckIndex
+        $remoteTagIndex | Should -BeGreaterThan $prStateIndex
+        $tagIndex | Should -BeGreaterThan $remoteTagIndex
+        $releaseIndex | Should -BeGreaterThan $tagIndex
+
+        $releaseScript | Should -Match 'verify failed for PR #\$prNumber'
+        $releaseScript | Should -Match 'Refusing to tag or create GitHub Release'
+        $releaseScript | Should -Match '\$prState\.state -ne ''MERGED'''
+        $releaseScript | Should -Match 'main HEAD .* does not match release PR merge commit'
+        $releaseScript | Should -Match 'Tag v\$Version already exists'
+        $releaseScript | Should -Match 'Remote tag v\$Version already exists'
+    }
 }


### PR DESCRIPTION
## Summary

- stop scripts/bump-version.ps1 when winsmux verify <PR#> returns a non-zero exit code
- require the release PR to be merged and local main to match the merge commit before tagging
- refuse local or remote duplicate version tags before creating a GitHub Release
- add a regression check for the release stop gate ordering

Fixes #734.

## Validation

- Invoke-Pester -Path tests\\VersionSurface.Tests.ps1 -Output Detailed
- git diff --check
- pwsh -NoProfile -File scripts\\git-guard.ps1
- pwsh -NoProfile -File scripts\\audit-public-surface.ps1
