### PR TITLE
Add worker checkpoint package contract

### DIFF
--- a/core/src/ledger.rs
+++ b/core/src/ledger.rs
@@ -280,6 +280,7 @@ pub struct LedgerExplainRun {
     pub context_contract: Value,
     pub team_memory: Value,
     pub run_insights: Value,
+    pub checkpoint_package: Value,
     pub tdd_gate: Value,
     pub verification_envelope: Value,
     pub audit_chain: Value,
@@ -478,6 +479,7 @@ pub struct LedgerRunProjection {
     pub context_contract: Value,
     pub team_memory: Value,
     pub run_insights: Value,
+    pub checkpoint_package: Value,
     pub tdd_gate: Value,
     pub verification_envelope: Value,
     pub audit_chain: Value,
@@ -527,6 +529,7 @@ pub struct LedgerRunPacket {
     pub context_contract: Value,
     pub team_memory: Value,
     pub run_insights: Value,
+    pub checkpoint_package: Value,
     pub tdd_gate: Value,
     pub verification_envelope: Value,
     pub audit_chain: Value,
@@ -750,6 +753,9 @@ impl LedgerRunProjection {
             run_insights: run
                 .map(|run| run.run_insights.clone())
                 .unwrap_or(Value::Null),
+            checkpoint_package: run
+                .map(|run| run.checkpoint_package.clone())
+                .unwrap_or(Value::Null),
             tdd_gate: run.map(|run| run.tdd_gate.clone()).unwrap_or(Value::Null),
             verification_envelope: run
                 .map(|run| run.verification_envelope.clone())
@@ -808,6 +814,7 @@ impl LedgerRunPacket {
             context_contract: run.context_contract.clone(),
             team_memory: run.team_memory.clone(),
             run_insights: run.run_insights.clone(),
+            checkpoint_package: run.checkpoint_package.clone(),
             tdd_gate: run.tdd_gate.clone(),
             verification_envelope: run.verification_envelope.clone(),
             audit_chain: run.audit_chain.clone(),
@@ -1327,6 +1334,7 @@ impl LedgerSnapshot {
             context_contract: Value::Null,
             team_memory: Value::Null,
             run_insights: Value::Null,
+            checkpoint_package: Value::Null,
             tdd_gate: Value::Null,
             verification_envelope: Value::Null,
             audit_chain: Value::Null,
@@ -1346,6 +1354,7 @@ impl LedgerSnapshot {
         run.verification_envelope = run_verification_envelope_value(&run);
         run.outcome = run_outcome_value(&run, &run.phase_gate, &run.draft_pr_gate);
         run.run_insights = run_insights_value(&run, &recent_event_records);
+        run.checkpoint_package = run_checkpoint_package_value(&run);
         let explanation = explain_explanation(&run, &evidence_digest);
 
         Some(LedgerExplainProjection {
@@ -3731,6 +3740,99 @@ fn verdict_summary_from_event(kind: &str, event: &EventRecord) -> Option<LedgerV
         event: event.event.clone(),
         timestamp: event.timestamp.clone(),
     })
+}
+
+fn run_checkpoint_package_value(run: &LedgerExplainRun) -> Value {
+    let worktree_ref = public_worktree_ref(&first_non_empty(
+        &run.worktree,
+        &run.experiment_packet.worktree,
+    ));
+    let changed_files = public_changed_files(&run.changed_files);
+    let session_type = if worktree_ref.starts_with(".worktrees/") {
+        "managed_worktree"
+    } else if worktree_ref.trim().is_empty() {
+        "unknown"
+    } else {
+        "shared_checkout"
+    };
+    let verification_outcome = value_field_string(&run.verification_result, "outcome");
+    let cleanup_required = matches!(
+        run.task_state.as_str(),
+        "completed" | "task_completed" | "commit_ready" | "done"
+    ) || run.review_state.eq_ignore_ascii_case("PASS");
+
+    json!({
+        "contract_version": 1,
+        "packet_type": "checkpoint_package",
+        "scope": "worker_worktree",
+        "run_id": run.run_id,
+        "task_id": run.task_id,
+        "project_ref": "current_project",
+        "project_root_stored": false,
+        "assigned_worktree": worktree_ref,
+        "branch": run.branch,
+        "head_sha": run.head_sha,
+        "session_type": session_type,
+        "changed_files": changed_files,
+        "changed_file_count": changed_files.len(),
+        "verification": {
+            "outcome": verification_outcome,
+            "verification_plan": run.verification_plan,
+            "evidence_complete": !verification_outcome.trim().is_empty()
+        },
+        "rollback_hint": "operator-owned-git-lifecycle",
+        "cleanup_hint": if cleanup_required {
+            "operator may clean the worker worktree after merge or explicit close"
+        } else {
+            "keep the worker worktree for inspection"
+        },
+        "operator_git_required": true,
+        "worker_git_write_allowed": false,
+        "local_reference_paths_stored": false,
+        "freeform_body_stored": false,
+        "private_content_stored": false,
+    })
+}
+
+pub(crate) fn public_worktree_ref(worktree: &str) -> String {
+    let normalized = worktree.trim().replace('\\', "/");
+    if normalized.is_empty() {
+        return String::new();
+    }
+
+    if normalized.starts_with(".worktrees/") || normalized.starts_with("worktrees/") {
+        return normalized;
+    }
+
+    if normalized.contains(':') || normalized.starts_with('/') || normalized.starts_with('~') {
+        if let Some(index) = normalized.rfind("/.worktrees/") {
+            normalized[index + 1..].to_string()
+        } else {
+            String::new()
+        }
+    } else {
+        normalized
+    }
+}
+
+pub(crate) fn public_changed_files(changed_files: &[String]) -> Vec<String> {
+    let mut files = Vec::new();
+    for changed_file in changed_files {
+        let normalized = changed_file.trim().replace('\\', "/");
+        if normalized.is_empty()
+            || normalized.contains(':')
+            || normalized.starts_with('/')
+            || normalized.starts_with('~')
+            || normalized.starts_with("..")
+            || normalized.contains("/../")
+        {
+            continue;
+        }
+        if !files.contains(&normalized) {
+            files.push(normalized);
+        }
+    }
+    files
 }
 
 fn first_non_empty_string(values: Vec<String>) -> String {

--- a/core/tests-rs/fixture_comparison.rs
+++ b/core/tests-rs/fixture_comparison.rs
@@ -245,6 +245,7 @@ const EXPLAIN_RUN_KEYS: &[&str] = &[
     "context_contract",
     "team_memory",
     "run_insights",
+    "checkpoint_package",
     "tdd_gate",
     "verification_envelope",
     "audit_chain",

--- a/core/tests-rs/ledger_contract.rs
+++ b/core/tests-rs/ledger_contract.rs
@@ -778,9 +778,10 @@ panes:
     assert!(!knowledge_source_refs
         .iter()
         .any(|item| item.as_str().unwrap_or_default().contains("LOCALAPPDATA")));
-    assert!(!knowledge_source_refs
-        .iter()
-        .any(|item| item.as_str().unwrap_or_default().contains("private guidance")));
+    assert!(!knowledge_source_refs.iter().any(|item| item
+        .as_str()
+        .unwrap_or_default()
+        .contains("private guidance")));
     assert_eq!(
         explain.run.context_contract["knowledge_layer"]["operating_guidance_refs"][0],
         "guidance:git-guard"
@@ -803,9 +804,10 @@ panes:
     assert!(!evidence_refs
         .iter()
         .any(|item| item.as_str().unwrap_or_default().contains("Users")));
-    assert!(!evidence_refs
-        .iter()
-        .any(|item| item.as_str().unwrap_or_default().contains("pasted evidence")));
+    assert!(!evidence_refs.iter().any(|item| item
+        .as_str()
+        .unwrap_or_default()
+        .contains("pasted evidence")));
     assert_eq!(
         explain.run.context_contract["knowledge_layer"]["rationale_refs"][0],
         "ADR-knowledge-layer"
@@ -816,9 +818,10 @@ panes:
     assert!(!rationale_refs
         .iter()
         .any(|item| item.as_str().unwrap_or_default().contains("LOCALAPPDATA")));
-    assert!(!rationale_refs
-        .iter()
-        .any(|item| item.as_str().unwrap_or_default().contains("pasted rationale")));
+    assert!(!rationale_refs.iter().any(|item| item
+        .as_str()
+        .unwrap_or_default()
+        .contains("pasted rationale")));
     assert_eq!(
         explain.run.context_contract["knowledge_layer"]["team_memory_refs"][0],
         "team-memory:task-256:operator-standard"
@@ -896,6 +899,38 @@ panes:
     assert_eq!(
         explain.run.run_insights["next_improvements"][0],
         "reduce retry loop before the next run"
+    );
+    assert_eq!(
+        explain.run.checkpoint_package["packet_type"],
+        "checkpoint_package"
+    );
+    assert_eq!(
+        explain.run.checkpoint_package["assigned_worktree"],
+        ".worktrees/builder-1"
+    );
+    assert_eq!(
+        explain.run.checkpoint_package["session_type"],
+        "managed_worktree"
+    );
+    assert_eq!(
+        explain.run.checkpoint_package["changed_files"][0],
+        "scripts/winsmux-core.ps1"
+    );
+    let checkpoint_text = explain.run.checkpoint_package.to_string();
+    assert!(!checkpoint_text.contains("Users"));
+    assert!(!checkpoint_text.contains("private next action"));
+    assert_eq!(
+        explain.run.checkpoint_package["verification"]["outcome"],
+        "PASS"
+    );
+    assert_eq!(explain.run.checkpoint_package["project_root_stored"], false);
+    assert_eq!(
+        explain.run.checkpoint_package["local_reference_paths_stored"],
+        false
+    );
+    assert_eq!(
+        explain.run.checkpoint_package["worker_git_write_allowed"],
+        false
     );
     assert_eq!(explain.run.audit_chain["chain_id"], "task:task-256");
     assert_eq!(
@@ -1247,6 +1282,8 @@ fn ledger_contract_serializes_typed_cli_payload_roots() {
             && run["run_packet"]["verification_envelope"]["packet_type"] == "verification_envelope"
             && run["run_insights"]["packet_type"] == "run_insights"
             && run["run_packet"]["run_insights"]["packet_type"] == "run_insights"
+            && run["checkpoint_package"]["packet_type"] == "checkpoint_package"
+            && run["run_packet"]["checkpoint_package"]["packet_type"] == "checkpoint_package"
             && run["team_memory"]["packet_type"] == "team_memory_contract"
             && run["run_packet"]["team_memory"]["packet_type"] == "team_memory_contract"
     }));
@@ -1281,6 +1318,22 @@ fn ledger_contract_serializes_typed_cli_payload_roots() {
     assert_eq!(
         explain["run"]["run_insights"]["packet_type"],
         "run_insights"
+    );
+}
+
+#[test]
+fn ledger_contract_scrubs_checkpoint_package_public_refs() {
+    assert_eq!(
+        ledger::public_worktree_ref(r"C:\Users\Example\repo\.worktrees\builder-1"),
+        ".worktrees/builder-1"
+    );
+    assert_eq!(
+        ledger::public_changed_files(&[
+            r"C:\Users\Example\repo\secret.txt".to_string(),
+            "scripts/winsmux-core.ps1".to_string(),
+            "../private.md".to_string(),
+        ]),
+        vec!["scripts/winsmux-core.ps1".to_string()]
     );
 }
 

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -6911,6 +6911,106 @@ function New-RunDraftPrGate {
     }
 }
 
+function ConvertTo-RunPublicWorktreeRef {
+    param([string]$Worktree = '')
+
+    $normalized = ([string]$Worktree).Trim().Replace('\', '/')
+    if ([string]::IsNullOrWhiteSpace($normalized)) {
+        return ''
+    }
+
+    if ($normalized.StartsWith('.worktrees/') -or $normalized.StartsWith('worktrees/')) {
+        return $normalized
+    }
+
+    if ($normalized -match '^[A-Za-z]:' -or $normalized.StartsWith('/') -or $normalized.StartsWith('~')) {
+        $markerIndex = $normalized.LastIndexOf('/.worktrees/')
+        if ($markerIndex -ge 0) {
+            return $normalized.Substring($markerIndex + 1)
+        }
+
+        return ''
+    }
+
+    return $normalized
+}
+
+function ConvertTo-RunPublicChangedFiles {
+    param([AllowNull()]$ChangedFiles = $null)
+
+    $items = [System.Collections.Generic.List[string]]::new()
+    foreach ($entry in @(ConvertTo-RunStringArray -Value $ChangedFiles)) {
+        $normalized = ([string]$entry).Trim().Replace('\', '/')
+        if (
+            [string]::IsNullOrWhiteSpace($normalized) -or
+            $normalized -match '^[A-Za-z]:' -or
+            $normalized.StartsWith('/') -or
+            $normalized.StartsWith('~') -or
+            $normalized.StartsWith('..') -or
+            $normalized.Contains('/../')
+        ) {
+            continue
+        }
+
+        if (-not $items.Contains($normalized)) {
+            $items.Add($normalized) | Out-Null
+        }
+    }
+
+    return @($items)
+}
+
+function New-RunCheckpointPackage {
+    param([Parameter(Mandatory = $true)]$Run)
+
+    $rawWorktree = [string]$Run.worktree
+    if ([string]::IsNullOrWhiteSpace($rawWorktree) -and $null -ne $Run.experiment_packet) {
+        $rawWorktree = [string](Get-RunContractField -InputObject $Run.experiment_packet -Name 'worktree')
+    }
+    $worktreeRef = ConvertTo-RunPublicWorktreeRef -Worktree $rawWorktree
+    $sessionType = 'unknown'
+    if ($worktreeRef.StartsWith('.worktrees/')) {
+        $sessionType = 'managed_worktree'
+    } elseif (-not [string]::IsNullOrWhiteSpace($worktreeRef)) {
+        $sessionType = 'shared_checkout'
+    }
+
+    $verificationOutcome = [string](Get-RunContractField -InputObject $Run.verification_result -Name 'outcome')
+    $changedFiles = @(ConvertTo-RunPublicChangedFiles -ChangedFiles $Run.changed_files)
+    $cleanupRequired = (
+        [string]$Run.task_state -in @('completed', 'task_completed', 'commit_ready', 'done') -or
+        [string]$Run.review_state -eq 'PASS'
+    )
+
+    return [ordered]@{
+        contract_version             = 1
+        packet_type                  = 'checkpoint_package'
+        scope                        = 'worker_worktree'
+        run_id                       = [string]$Run.run_id
+        task_id                      = [string]$Run.task_id
+        project_ref                  = 'current_project'
+        project_root_stored          = $false
+        assigned_worktree            = $worktreeRef
+        branch                       = [string]$Run.branch
+        head_sha                     = [string]$Run.head_sha
+        session_type                 = $sessionType
+        changed_files                = @($changedFiles)
+        changed_file_count           = @($changedFiles).Count
+        verification                 = [ordered]@{
+            outcome           = $verificationOutcome
+            verification_plan = @($Run.verification_plan)
+            evidence_complete = (-not [string]::IsNullOrWhiteSpace($verificationOutcome))
+        }
+        rollback_hint                = 'operator-owned-git-lifecycle'
+        cleanup_hint                 = if ($cleanupRequired) { 'operator may clean the worker worktree after merge or explicit close' } else { 'keep the worker worktree for inspection' }
+        operator_git_required        = $true
+        worker_git_write_allowed     = $false
+        local_reference_paths_stored = $false
+        freeform_body_stored         = $false
+        private_content_stored       = $false
+    }
+}
+
 function New-RunPacketFromRun {
     param([Parameter(Mandatory = $true)]$Run)
 
@@ -6953,6 +7053,7 @@ function New-RunPacketFromRun {
         context_contract      = $Run.context_contract
         team_memory           = $Run.team_memory
         run_insights          = $Run.run_insights
+        checkpoint_package    = $Run.checkpoint_package
         tdd_gate              = $Run.tdd_gate
         verification_envelope = $Run.verification_envelope
         plan              = $Run.plan
@@ -7039,6 +7140,7 @@ function New-RunResultPacket {
         context_contract      = $Run.context_contract
         team_memory           = $Run.team_memory
         run_insights          = $Run.run_insights
+        checkpoint_package    = $Run.checkpoint_package
         tdd_gate              = $Run.tdd_gate
         verification_envelope = $Run.verification_envelope
         security_policy       = $Run.security_policy
@@ -7306,6 +7408,7 @@ function Get-RunsPayload {
                 context_contract      = $null
                 team_memory           = $null
                 run_insights          = $null
+                checkpoint_package    = $null
                 plan                  = $null
                 plan_checkpoints      = @()
                 managed_loop          = $null
@@ -7480,6 +7583,7 @@ function Get-RunsPayload {
             $run.verification_envelope = New-RunVerificationEnvelope -Run $run
             $run.outcome = New-RunOutcomeContract -Run $run
             $run.run_insights = New-RunInsightsContract -Run $run -EventRecords $runEvents
+            $run.checkpoint_package = New-RunCheckpointPackage -Run $run
             $nextAction = Get-RunNextAction -Run $run
             $stateModel = New-RunStateModel -State ([string]$run.state) -TaskState ([string]$run.task_state) -ReviewState ([string]$run.review_state) -EventKind $nextAction -LastEvent ([string]$run.last_event)
             [ordered]@{
@@ -7532,6 +7636,7 @@ function Get-RunsPayload {
                 context_contract      = $run.context_contract
                 team_memory           = $run.team_memory
                 run_insights          = $run.run_insights
+                checkpoint_package    = $run.checkpoint_package
                 tdd_gate              = $run.tdd_gate
                 verification_envelope = $run.verification_envelope
                 plan                  = $run.plan

--- a/tests/fixtures/rust-parity/explain.json
+++ b/tests/fixtures/rust-parity/explain.json
@@ -174,6 +174,38 @@
         "resolve blocked reasons before release"
       ]
     },
+    "checkpoint_package": {
+      "contract_version": 1,
+      "packet_type": "checkpoint_package",
+      "scope": "worker_worktree",
+      "run_id": "task:task-256",
+      "task_id": "task-256",
+      "project_ref": "current_project",
+      "project_root_stored": false,
+      "assigned_worktree": ".worktrees/builder-1",
+      "branch": "worktree-builder-1",
+      "head_sha": "abc1234def5678",
+      "session_type": "managed_worktree",
+      "changed_files": [
+        "scripts/winsmux-core.ps1"
+      ],
+      "changed_file_count": 1,
+      "verification": {
+        "outcome": "",
+        "verification_plan": [
+          "Invoke-Pester tests/winsmux-bridge.Tests.ps1",
+          "verify explain --json contract"
+        ],
+        "evidence_complete": false
+      },
+      "rollback_hint": "operator-owned-git-lifecycle",
+      "cleanup_hint": "keep the worker worktree for inspection",
+      "operator_git_required": true,
+      "worker_git_write_allowed": false,
+      "local_reference_paths_stored": false,
+      "freeform_body_stored": false,
+      "private_content_stored": false
+    },
     "tdd_gate": {
       "policy": "test_first_required",
       "required": true,

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -8474,10 +8474,22 @@ panes:
         $result.runs[0].run_insights.drift_signals | Should -Be @('drift_detected')
         $result.runs[0].run_insights.unhealthy_session_size | Should -Be $true
         $result.runs[0].run_insights.next_improvements | Should -Contain 'split the next run into a smaller scope'
+        $result.runs[0].checkpoint_package.packet_type | Should -Be 'checkpoint_package'
+        $result.runs[0].checkpoint_package.assigned_worktree | Should -Be '.worktrees/builder-1'
+        $result.runs[0].checkpoint_package.session_type | Should -Be 'managed_worktree'
+        $result.runs[0].checkpoint_package.changed_files | Should -Be @('scripts/winsmux-core.ps1')
+        $result.runs[0].checkpoint_package.verification.outcome | Should -Be 'PARTIAL'
+        ($result.runs[0].checkpoint_package | ConvertTo-Json -Depth 8) | Should -Not -Match 'Users'
+        ($result.runs[0].checkpoint_package | ConvertTo-Json -Depth 8) | Should -Not -Match 'private next action'
+        $result.runs[0].checkpoint_package.project_root_stored | Should -Be $false
+        $result.runs[0].checkpoint_package.local_reference_paths_stored | Should -Be $false
+        $result.runs[0].checkpoint_package.worker_git_write_allowed | Should -Be $false
         $result.runs[0].run_packet.context_contract.context_pack_id | Should -Be 'ctx-runs'
         $result.runs[0].run_packet.team_memory.team_memory_refs | Should -Contain 'team-memory:task-256:operator-standard'
         $result.runs[0].run_packet.team_memory.team_memory_refs | Should -Contain 'team-memory:task:task-256:event-3'
         $result.runs[0].run_packet.run_insights.retry_count | Should -Be 1
+        $result.runs[0].run_packet.checkpoint_package.assigned_worktree | Should -Be '.worktrees/builder-1'
+        $result.runs[0].run_packet.checkpoint_package.operator_git_required | Should -Be $true
         $result.runs[0].tdd_gate.required | Should -Be $true
         $result.runs[0].tdd_gate.state | Should -Be 'passed'
         $result.runs[0].tdd_gate.red_event | Should -Be 'pipeline.tdd.red'
@@ -8565,6 +8577,36 @@ panes:
         $gate.handoff_package.validation.evidence_complete | Should -Be $false
         $gate.handoff_package.blocked_reasons | Should -Contain 'verification evidence is missing'
         $gate.handoff_package.suggested_next_action | Should -Be 'resolve blocked reasons before creating or merging a draft PR'
+    }
+
+    It 'scrubs checkpoint package path and body fields' {
+        $run = [PSCustomObject]@{
+            run_id              = 'task:task-999'
+            task_id             = 'task-999'
+            worktree            = 'C:\Users\Example\repo\.worktrees\builder-1'
+            experiment_packet   = $null
+            branch              = 'worktree-builder-1'
+            head_sha            = 'abc123'
+            task_state          = 'in_progress'
+            review_state        = 'PENDING'
+            changed_files       = @('C:\Users\Example\repo\secret.txt', 'scripts/winsmux-core.ps1', '..\private.md')
+            verification_plan   = @('Invoke-Pester')
+            verification_result = [ordered]@{
+                outcome     = 'PARTIAL'
+                summary     = 'C:\Users\Example must not leak'
+                next_action = 'private next action'
+            }
+        }
+
+        $package = New-RunCheckpointPackage -Run $run
+
+        $package.assigned_worktree | Should -Be '.worktrees/builder-1'
+        $package.changed_files | Should -Be @('scripts/winsmux-core.ps1')
+        $package.changed_file_count | Should -Be 1
+        $package.verification.outcome | Should -Be 'PARTIAL'
+        ($package | ConvertTo-Json -Depth 8) | Should -Not -Match 'Users'
+        ($package | ConvertTo-Json -Depth 8) | Should -Not -Match 'private next action'
+        $package.worker_git_write_allowed | Should -Be $false
     }
 
     It 'exposes needs-user-decision as a phase-gated stop before package completion' {


### PR DESCRIPTION
## Summary
- Add the worker checkpoint package contract to Rust and PowerShell run surfaces.
- Project checkpoint metadata through run packets and explain fixture parity.
- Scrub worktree paths, changed-file references, and body-like checkpoint fields before public projection.

## Validation
- cargo test --manifest-path core/Cargo.toml --test ledger_contract ledger_contract -- --nocapture
- cargo test --manifest-path core/Cargo.toml --test fixture_comparison -- --nocapture fixture_comparison_harness_diffs_modeled_projection_payloads
- pwsh -NoProfile -Command "Invoke-Pester -Path tests\winsmux-bridge.Tests.ps1 -FullName '*returns runs as json*','*scrubs checkpoint package path and body fields*','*keeps explain json fixture stable*' -Output Detailed"
- git diff --check
- pwsh -NoProfile -File scripts\git-guard.ps1
- pwsh -NoProfile -File scripts\audit-public-surface.ps1