### PR TITLE
TASK-325: Add managed child launch contract

### DIFF
--- a/core/src/ledger.rs
+++ b/core/src/ledger.rs
@@ -280,6 +280,7 @@ pub struct LedgerExplainRun {
     pub context_contract: Value,
     pub team_memory: Value,
     pub run_insights: Value,
+    pub child_launch_contract: Value,
     pub checkpoint_package: Value,
     pub tdd_gate: Value,
     pub verification_envelope: Value,
@@ -479,6 +480,7 @@ pub struct LedgerRunProjection {
     pub context_contract: Value,
     pub team_memory: Value,
     pub run_insights: Value,
+    pub child_launch_contract: Value,
     pub checkpoint_package: Value,
     pub tdd_gate: Value,
     pub verification_envelope: Value,
@@ -529,6 +531,7 @@ pub struct LedgerRunPacket {
     pub context_contract: Value,
     pub team_memory: Value,
     pub run_insights: Value,
+    pub child_launch_contract: Value,
     pub checkpoint_package: Value,
     pub tdd_gate: Value,
     pub verification_envelope: Value,
@@ -753,6 +756,9 @@ impl LedgerRunProjection {
             run_insights: run
                 .map(|run| run.run_insights.clone())
                 .unwrap_or(Value::Null),
+            child_launch_contract: run
+                .map(|run| run.child_launch_contract.clone())
+                .unwrap_or(Value::Null),
             checkpoint_package: run
                 .map(|run| run.checkpoint_package.clone())
                 .unwrap_or(Value::Null),
@@ -814,6 +820,7 @@ impl LedgerRunPacket {
             context_contract: run.context_contract.clone(),
             team_memory: run.team_memory.clone(),
             run_insights: run.run_insights.clone(),
+            child_launch_contract: run.child_launch_contract.clone(),
             checkpoint_package: run.checkpoint_package.clone(),
             tdd_gate: run.tdd_gate.clone(),
             verification_envelope: run.verification_envelope.clone(),
@@ -1334,6 +1341,7 @@ impl LedgerSnapshot {
             context_contract: Value::Null,
             team_memory: Value::Null,
             run_insights: Value::Null,
+            child_launch_contract: Value::Null,
             checkpoint_package: Value::Null,
             tdd_gate: Value::Null,
             verification_envelope: Value::Null,
@@ -1354,6 +1362,7 @@ impl LedgerSnapshot {
         run.verification_envelope = run_verification_envelope_value(&run);
         run.outcome = run_outcome_value(&run, &run.phase_gate, &run.draft_pr_gate);
         run.run_insights = run_insights_value(&run, &recent_event_records);
+        run.child_launch_contract = run_child_launch_contract_value(&run);
         run.checkpoint_package = run_checkpoint_package_value(&run);
         let explanation = explain_explanation(&run, &evidence_digest);
 
@@ -3790,6 +3799,59 @@ fn run_checkpoint_package_value(run: &LedgerExplainRun) -> Value {
         "worker_git_write_allowed": false,
         "local_reference_paths_stored": false,
         "freeform_body_stored": false,
+        "private_content_stored": false,
+    })
+}
+
+fn run_child_launch_contract_value(run: &LedgerExplainRun) -> Value {
+    let worktree_ref = public_worktree_ref(&first_non_empty(
+        &run.worktree,
+        &run.experiment_packet.worktree,
+    ));
+    let session_type = if worktree_ref.starts_with(".worktrees/") {
+        "managed_worktree"
+    } else if worktree_ref.trim().is_empty() {
+        "unknown"
+    } else {
+        "shared_checkout"
+    };
+    let provider_target = run.provider_target.trim();
+    let provider_kind = provider_target
+        .split_once(':')
+        .map(|(kind, _)| kind)
+        .unwrap_or(provider_target)
+        .trim();
+    let agent_kind = if provider_kind.is_empty() {
+        "unknown".to_string()
+    } else {
+        provider_kind.to_ascii_lowercase()
+    };
+    let role = first_non_empty(&run.primary_role, &run.agent_role);
+    let role_intent = first_non_empty(&run.agent_role, &role);
+
+    json!({
+        "contract_version": 1,
+        "packet_type": "child_launch_contract",
+        "scope": "operator_managed_child_run",
+        "run_id": run.run_id,
+        "task_id": run.task_id,
+        "parent_run_id": run.parent_run_id,
+        "role": role,
+        "role_intent": role_intent,
+        "agent_kind": agent_kind,
+        "provider_target": run.provider_target,
+        "project_ref": "current_project",
+        "project_root_stored": false,
+        "worktree": worktree_ref,
+        "launch_dir": worktree_ref,
+        "session_type": session_type,
+        "startup_command_ref": "managed-pane-launch",
+        "startup_command_stored": false,
+        "operator_controls_merge": true,
+        "peer_to_peer_allowed": false,
+        "child_git_write_allowed": false,
+        "local_reference_paths_stored": false,
+        "freeform_command_stored": false,
         "private_content_stored": false,
     })
 }

--- a/core/tests-rs/fixture_comparison.rs
+++ b/core/tests-rs/fixture_comparison.rs
@@ -245,6 +245,7 @@ const EXPLAIN_RUN_KEYS: &[&str] = &[
     "context_contract",
     "team_memory",
     "run_insights",
+    "child_launch_contract",
     "checkpoint_package",
     "tdd_gate",
     "verification_envelope",

--- a/core/tests-rs/ledger_contract.rs
+++ b/core/tests-rs/ledger_contract.rs
@@ -901,6 +901,44 @@ panes:
         "reduce retry loop before the next run"
     );
     assert_eq!(
+        explain.run.child_launch_contract["packet_type"],
+        "child_launch_contract"
+    );
+    assert_eq!(
+        explain.run.child_launch_contract["scope"],
+        "operator_managed_child_run"
+    );
+    assert_eq!(explain.run.child_launch_contract["role"], "Builder");
+    assert_eq!(explain.run.child_launch_contract["role_intent"], "builder");
+    assert_eq!(explain.run.child_launch_contract["agent_kind"], "codex");
+    assert_eq!(
+        explain.run.child_launch_contract["worktree"],
+        ".worktrees/builder-1"
+    );
+    assert_eq!(
+        explain.run.child_launch_contract["session_type"],
+        "managed_worktree"
+    );
+    assert_eq!(
+        explain.run.child_launch_contract["startup_command_stored"],
+        false
+    );
+    assert_eq!(
+        explain.run.child_launch_contract["project_root_stored"],
+        false
+    );
+    assert_eq!(
+        explain.run.child_launch_contract["operator_controls_merge"],
+        true
+    );
+    assert_eq!(
+        explain.run.child_launch_contract["peer_to_peer_allowed"],
+        false
+    );
+    let launch_contract_text = explain.run.child_launch_contract.to_string();
+    assert!(!launch_contract_text.contains("Users"));
+    assert!(!launch_contract_text.contains("private next action"));
+    assert_eq!(
         explain.run.checkpoint_package["packet_type"],
         "checkpoint_package"
     );
@@ -1282,6 +1320,8 @@ fn ledger_contract_serializes_typed_cli_payload_roots() {
             && run["run_packet"]["verification_envelope"]["packet_type"] == "verification_envelope"
             && run["run_insights"]["packet_type"] == "run_insights"
             && run["run_packet"]["run_insights"]["packet_type"] == "run_insights"
+            && run["child_launch_contract"]["packet_type"] == "child_launch_contract"
+            && run["run_packet"]["child_launch_contract"]["packet_type"] == "child_launch_contract"
             && run["checkpoint_package"]["packet_type"] == "checkpoint_package"
             && run["run_packet"]["checkpoint_package"]["packet_type"] == "checkpoint_package"
             && run["team_memory"]["packet_type"] == "team_memory_contract"

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -7011,6 +7011,66 @@ function New-RunCheckpointPackage {
     }
 }
 
+function New-RunChildLaunchContract {
+    param([Parameter(Mandatory = $true)]$Run)
+
+    $rawWorktree = [string]$Run.worktree
+    if ([string]::IsNullOrWhiteSpace($rawWorktree) -and $null -ne $Run.experiment_packet) {
+        $rawWorktree = [string](Get-RunContractField -InputObject $Run.experiment_packet -Name 'worktree')
+    }
+    $worktreeRef = ConvertTo-RunPublicWorktreeRef -Worktree $rawWorktree
+    $sessionType = 'unknown'
+    if ($worktreeRef.StartsWith('.worktrees/')) {
+        $sessionType = 'managed_worktree'
+    } elseif (-not [string]::IsNullOrWhiteSpace($worktreeRef)) {
+        $sessionType = 'shared_checkout'
+    }
+
+    $providerTarget = [string]$Run.provider_target
+    $agentKind = 'unknown'
+    if (-not [string]::IsNullOrWhiteSpace($providerTarget)) {
+        $agentKind = $providerTarget.Trim().Split(':')[0].Trim().ToLowerInvariant()
+        if ([string]::IsNullOrWhiteSpace($agentKind)) {
+            $agentKind = 'unknown'
+        }
+    }
+
+    $role = [string]$Run.primary_role
+    if ([string]::IsNullOrWhiteSpace($role)) {
+        $role = [string]$Run.agent_role
+    }
+    $roleIntent = [string]$Run.agent_role
+    if ([string]::IsNullOrWhiteSpace($roleIntent)) {
+        $roleIntent = $role
+    }
+
+    return [ordered]@{
+        contract_version             = 1
+        packet_type                  = 'child_launch_contract'
+        scope                        = 'operator_managed_child_run'
+        run_id                       = [string]$Run.run_id
+        task_id                      = [string]$Run.task_id
+        parent_run_id                = [string]$Run.parent_run_id
+        role                         = $role
+        role_intent                  = $roleIntent
+        agent_kind                   = $agentKind
+        provider_target              = $providerTarget
+        project_ref                  = 'current_project'
+        project_root_stored          = $false
+        worktree                     = $worktreeRef
+        launch_dir                   = $worktreeRef
+        session_type                 = $sessionType
+        startup_command_ref          = 'managed-pane-launch'
+        startup_command_stored       = $false
+        operator_controls_merge      = $true
+        peer_to_peer_allowed         = $false
+        child_git_write_allowed      = $false
+        local_reference_paths_stored = $false
+        freeform_command_stored      = $false
+        private_content_stored       = $false
+    }
+}
+
 function New-RunPacketFromRun {
     param([Parameter(Mandatory = $true)]$Run)
 
@@ -7053,6 +7113,7 @@ function New-RunPacketFromRun {
         context_contract      = $Run.context_contract
         team_memory           = $Run.team_memory
         run_insights          = $Run.run_insights
+        child_launch_contract = $Run.child_launch_contract
         checkpoint_package    = $Run.checkpoint_package
         tdd_gate              = $Run.tdd_gate
         verification_envelope = $Run.verification_envelope
@@ -7408,6 +7469,7 @@ function Get-RunsPayload {
                 context_contract      = $null
                 team_memory           = $null
                 run_insights          = $null
+                child_launch_contract = $null
                 checkpoint_package    = $null
                 plan                  = $null
                 plan_checkpoints      = @()
@@ -7583,6 +7645,7 @@ function Get-RunsPayload {
             $run.verification_envelope = New-RunVerificationEnvelope -Run $run
             $run.outcome = New-RunOutcomeContract -Run $run
             $run.run_insights = New-RunInsightsContract -Run $run -EventRecords $runEvents
+            $run.child_launch_contract = New-RunChildLaunchContract -Run $run
             $run.checkpoint_package = New-RunCheckpointPackage -Run $run
             $nextAction = Get-RunNextAction -Run $run
             $stateModel = New-RunStateModel -State ([string]$run.state) -TaskState ([string]$run.task_state) -ReviewState ([string]$run.review_state) -EventKind $nextAction -LastEvent ([string]$run.last_event)
@@ -7636,6 +7699,7 @@ function Get-RunsPayload {
                 context_contract      = $run.context_contract
                 team_memory           = $run.team_memory
                 run_insights          = $run.run_insights
+                child_launch_contract = $run.child_launch_contract
                 checkpoint_package    = $run.checkpoint_package
                 tdd_gate              = $run.tdd_gate
                 verification_envelope = $run.verification_envelope

--- a/tests/fixtures/rust-parity/explain.json
+++ b/tests/fixtures/rust-parity/explain.json
@@ -174,6 +174,31 @@
         "resolve blocked reasons before release"
       ]
     },
+    "child_launch_contract": {
+      "contract_version": 1,
+      "packet_type": "child_launch_contract",
+      "scope": "operator_managed_child_run",
+      "run_id": "task:task-256",
+      "task_id": "task-256",
+      "parent_run_id": "operator:session-1",
+      "role": "Builder",
+      "role_intent": "worker",
+      "agent_kind": "codex",
+      "provider_target": "codex:gpt-5.4",
+      "project_ref": "current_project",
+      "project_root_stored": false,
+      "worktree": ".worktrees/builder-1",
+      "launch_dir": ".worktrees/builder-1",
+      "session_type": "managed_worktree",
+      "startup_command_ref": "managed-pane-launch",
+      "startup_command_stored": false,
+      "operator_controls_merge": true,
+      "peer_to_peer_allowed": false,
+      "child_git_write_allowed": false,
+      "local_reference_paths_stored": false,
+      "freeform_command_stored": false,
+      "private_content_stored": false
+    },
     "checkpoint_package": {
       "contract_version": 1,
       "packet_type": "checkpoint_package",

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -8474,6 +8474,21 @@ panes:
         $result.runs[0].run_insights.drift_signals | Should -Be @('drift_detected')
         $result.runs[0].run_insights.unhealthy_session_size | Should -Be $true
         $result.runs[0].run_insights.next_improvements | Should -Contain 'split the next run into a smaller scope'
+        $result.runs[0].child_launch_contract.packet_type | Should -Be 'child_launch_contract'
+        $result.runs[0].child_launch_contract.scope | Should -Be 'operator_managed_child_run'
+        $result.runs[0].child_launch_contract.role | Should -Be 'Builder'
+        $result.runs[0].child_launch_contract.role_intent | Should -Be 'worker'
+        $result.runs[0].child_launch_contract.agent_kind | Should -Be 'codex'
+        $result.runs[0].child_launch_contract.worktree | Should -Be '.worktrees/builder-1'
+        $result.runs[0].child_launch_contract.launch_dir | Should -Be '.worktrees/builder-1'
+        $result.runs[0].child_launch_contract.session_type | Should -Be 'managed_worktree'
+        $result.runs[0].child_launch_contract.startup_command_ref | Should -Be 'managed-pane-launch'
+        $result.runs[0].child_launch_contract.startup_command_stored | Should -Be $false
+        $result.runs[0].child_launch_contract.project_root_stored | Should -Be $false
+        $result.runs[0].child_launch_contract.operator_controls_merge | Should -Be $true
+        $result.runs[0].child_launch_contract.peer_to_peer_allowed | Should -Be $false
+        ($result.runs[0].child_launch_contract | ConvertTo-Json -Depth 8) | Should -Not -Match 'Users'
+        ($result.runs[0].child_launch_contract | ConvertTo-Json -Depth 8) | Should -Not -Match 'private next action'
         $result.runs[0].checkpoint_package.packet_type | Should -Be 'checkpoint_package'
         $result.runs[0].checkpoint_package.assigned_worktree | Should -Be '.worktrees/builder-1'
         $result.runs[0].checkpoint_package.session_type | Should -Be 'managed_worktree'
@@ -8488,6 +8503,8 @@ panes:
         $result.runs[0].run_packet.team_memory.team_memory_refs | Should -Contain 'team-memory:task-256:operator-standard'
         $result.runs[0].run_packet.team_memory.team_memory_refs | Should -Contain 'team-memory:task:task-256:event-3'
         $result.runs[0].run_packet.run_insights.retry_count | Should -Be 1
+        $result.runs[0].run_packet.child_launch_contract.packet_type | Should -Be 'child_launch_contract'
+        $result.runs[0].run_packet.child_launch_contract.operator_controls_merge | Should -Be $true
         $result.runs[0].run_packet.checkpoint_package.assigned_worktree | Should -Be '.worktrees/builder-1'
         $result.runs[0].run_packet.checkpoint_package.operator_git_required | Should -Be $true
         $result.runs[0].tdd_gate.required | Should -Be $true


### PR DESCRIPTION
## Summary
- Add child_launch_contract to Rust and PowerShell run projections.
- Include the contract in run_packet for operator-managed child runs.
- Record only public-safe refs and explicit non-storage flags for project roots, startup commands, local paths, free-form commands, and private content.

## Validation
- cargo test --manifest-path core/Cargo.toml --test ledger_contract ledger_contract -- --nocapture
- cargo test --manifest-path core/Cargo.toml --test fixture_comparison -- --nocapture fixture_comparison_harness_diffs_modeled_projection_payloads
- Invoke-Pester -Path tests\\winsmux-bridge.Tests.ps1 -FullName '*returns runs as json*','*keeps explain json fixture stable*' -Output Detailed
- git diff --check
- scripts\\git-guard.ps1
- scripts\\audit-public-surface.ps1
- codex review --uncommitted: no actionable correctness findings