### PR TITLE
TASK-412: Add end-of-run snapshot manifest

### DIFF
--- a/core/src/ledger.rs
+++ b/core/src/ledger.rs
@@ -3078,6 +3078,7 @@ fn durable_ref_allowed(value: &str, prefixes: &[&str]) -> bool {
         || value.len() > 256
         || value.contains('\n')
         || value.contains('\r')
+        || value.contains(":/")
         || value.contains('\\')
         || value.contains(' ')
         || value.starts_with('%')
@@ -3130,6 +3131,15 @@ fn value_field(value: &Value, key: &str) -> Value {
         .and_then(|map| map.get(key))
         .cloned()
         .unwrap_or(Value::Null)
+}
+
+fn value_field_durable_ref(value: &Value, key: &str, prefixes: &[&str]) -> Value {
+    let text = value_field_string(value, key);
+    if durable_ref_allowed(&text, prefixes) {
+        Value::String(text.trim().to_string())
+    } else {
+        Value::Null
+    }
 }
 
 pub(crate) fn value_string_list(value: &Value, key: &str) -> Vec<String> {
@@ -3188,6 +3198,10 @@ fn public_context_ref_prefixes() -> &'static [&'static str] {
         "evidence:",
         "rationale:",
     ]
+}
+
+fn public_context_pack_id_prefixes() -> &'static [&'static str] {
+    &["ctx-", "sem-", "context:", "context-packs/"]
 }
 
 fn push_reason(reasons: &mut Vec<String>, key: &str, value: &str) {
@@ -3765,6 +3779,17 @@ fn run_checkpoint_package_value(run: &LedgerExplainRun) -> Value {
         "shared_checkout"
     };
     let verification_outcome = value_field_string(&run.verification_result, "outcome");
+    let context_pack_id = value_field_durable_ref(
+        &run.context_contract,
+        "context_pack_id",
+        public_context_pack_id_prefixes(),
+    );
+    let semantic_context = value_field(&run.context_contract, "semantic_context");
+    let semantic_context_pack_id = value_field_durable_ref(
+        &semantic_context,
+        "context_pack_id",
+        public_context_pack_id_prefixes(),
+    );
     let cleanup_required = matches!(
         run.task_state.as_str(),
         "completed" | "task_completed" | "commit_ready" | "done"
@@ -3782,12 +3807,53 @@ fn run_checkpoint_package_value(run: &LedgerExplainRun) -> Value {
         "branch": run.branch,
         "head_sha": run.head_sha,
         "session_type": session_type,
-        "changed_files": changed_files,
+        "changed_files": changed_files.clone(),
         "changed_file_count": changed_files.len(),
         "verification": {
             "outcome": verification_outcome,
             "verification_plan": run.verification_plan,
             "evidence_complete": !verification_outcome.trim().is_empty()
+        },
+        "end_of_run_snapshot": {
+            "contract_version": 1,
+            "packet_type": "end_of_run_snapshot_manifest",
+            "status": "partial",
+            "capture_policy": {
+                "snapshot_failure_does_not_fail_worker": true,
+                "raw_terminal_transcript_stored": false,
+                "untracked_file_names_stored": false,
+                "private_content_stored": false,
+                "local_reference_paths_stored": false
+            },
+            "repo_diff": {
+                "changed_files": changed_files.clone(),
+                "changed_file_count": changed_files.len(),
+                "untracked_files": {
+                    "state": "not_captured",
+                    "count_bucket": "unknown",
+                    "file_names_stored": false
+                }
+            },
+            "terminal": {
+                "state": "not_captured",
+                "summary_ref": Value::Null,
+                "raw_transcript_stored": false
+            },
+            "artifacts": {
+                "artifact_refs": [],
+                "summary_refs": []
+            },
+            "context": {
+                "context_pack_id": context_pack_id,
+                "semantic_context_pack_id": semantic_context_pack_id
+            },
+            "hydration": {
+                "project_ref": "current_project",
+                "assigned_worktree": worktree_ref,
+                "session_type": session_type,
+                "branch": run.branch,
+                "head_sha": run.head_sha
+            }
         },
         "rollback_hint": "operator-owned-git-lifecycle",
         "cleanup_hint": if cleanup_required {

--- a/core/tests-rs/ledger_contract.rs
+++ b/core/tests-rs/ledger_contract.rs
@@ -631,6 +631,33 @@ panes:
         r#""rationale_refs":["ADR-knowledge-layer"]"#,
         r#""rationale_refs":["ADR-knowledge-layer","%LOCALAPPDATA%\\winsmux\\rationale.md","pasted rationale body"]"#,
     );
+    let unsafe_context_events = events
+        .replace(
+            r#""context_pack_id":"ctx-task-256""#,
+            r#""context_pack_id":"ctx-C:/Users/Example/context.md""#,
+        )
+        .replace(
+            r#""semantic_context_pack_id":"sem-task-256""#,
+            r#""semantic_context_pack_id":"sem-C:/Users/Example/semantic.md""#,
+        );
+    let unsafe_context_snapshot =
+        ledger::LedgerSnapshot::from_manifest_and_events(manifest, &unsafe_context_events)
+            .expect("ledger snapshot should load explain inputs with unsafe context ids");
+    let unsafe_context_explain = unsafe_context_snapshot
+        .explain_projection("task:task-256")
+        .expect("ledger explain projection should exist for unsafe context ids");
+    assert!(
+        unsafe_context_explain.run.checkpoint_package["end_of_run_snapshot"]["context"]
+            ["context_pack_id"]
+            .is_null()
+    );
+    assert!(
+        unsafe_context_explain.run.checkpoint_package["end_of_run_snapshot"]["context"]
+            ["semantic_context_pack_id"]
+            .is_null()
+    );
+    let unsafe_context_checkpoint_text = unsafe_context_explain.run.checkpoint_package.to_string();
+    assert!(!unsafe_context_checkpoint_text.contains("Users"));
 
     let snapshot = ledger::LedgerSnapshot::from_manifest_and_events(manifest, &events)
         .expect("ledger snapshot should load explain inputs");
@@ -989,6 +1016,45 @@ panes:
     assert_eq!(
         explain.run.checkpoint_package["changed_files"][0],
         "scripts/winsmux-core.ps1"
+    );
+    assert_eq!(
+        explain.run.checkpoint_package["end_of_run_snapshot"]["packet_type"],
+        "end_of_run_snapshot_manifest"
+    );
+    assert_eq!(
+        explain.run.checkpoint_package["end_of_run_snapshot"]["status"],
+        "partial"
+    );
+    assert_eq!(
+        explain.run.checkpoint_package["end_of_run_snapshot"]["capture_policy"]
+            ["snapshot_failure_does_not_fail_worker"],
+        true
+    );
+    assert_eq!(
+        explain.run.checkpoint_package["end_of_run_snapshot"]["repo_diff"]["changed_files"][0],
+        "scripts/winsmux-core.ps1"
+    );
+    assert_eq!(
+        explain.run.checkpoint_package["end_of_run_snapshot"]["repo_diff"]["untracked_files"]
+            ["file_names_stored"],
+        false
+    );
+    assert_eq!(
+        explain.run.checkpoint_package["end_of_run_snapshot"]["terminal"]["raw_transcript_stored"],
+        false
+    );
+    assert_eq!(
+        explain.run.checkpoint_package["end_of_run_snapshot"]["context"]["context_pack_id"],
+        "ctx-task-256"
+    );
+    assert_eq!(
+        explain.run.checkpoint_package["end_of_run_snapshot"]["context"]
+            ["semantic_context_pack_id"],
+        "sem-task-256"
+    );
+    assert_eq!(
+        explain.run.checkpoint_package["end_of_run_snapshot"]["hydration"]["assigned_worktree"],
+        ".worktrees/builder-1"
     );
     let checkpoint_text = explain.run.checkpoint_package.to_string();
     assert!(!checkpoint_text.contains("Users"));

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -6453,6 +6453,7 @@ function Test-RunDurableRef {
         $text.Length -gt 256 -or
         $text.Contains("`n") -or
         $text.Contains("`r") -or
+        $text.Contains(':/') -or
         $text.Contains('\') -or
         $text.Contains(' ') -or
         $text.StartsWith('%') -or
@@ -6510,6 +6511,15 @@ function Get-RunPublicContextRefPrefixes {
         'knowledge/',
         'evidence:',
         'rationale:'
+    )
+}
+
+function Get-RunPublicContextPackIdPrefixes {
+    return @(
+        'ctx-',
+        'sem-',
+        'context:',
+        'context-packs/'
     )
 }
 
@@ -6977,6 +6987,12 @@ function New-RunCheckpointPackage {
 
     $verificationOutcome = [string](Get-RunContractField -InputObject $Run.verification_result -Name 'outcome')
     $changedFiles = @(ConvertTo-RunPublicChangedFiles -ChangedFiles $Run.changed_files)
+    $contextPackId = [string](Get-RunContractField -InputObject $Run.context_contract -Name 'context_pack_id')
+    $semanticContext = Get-RunContractField -InputObject $Run.context_contract -Name 'semantic_context'
+    $semanticContextPackId = [string](Get-RunContractField -InputObject $semanticContext -Name 'context_pack_id')
+    $contextPackIdPrefixes = Get-RunPublicContextPackIdPrefixes
+    $safeContextPackId = if (Test-RunDurableRef -Value $contextPackId -Prefixes $contextPackIdPrefixes) { $contextPackId.Trim() } else { $null }
+    $safeSemanticContextPackId = if (Test-RunDurableRef -Value $semanticContextPackId -Prefixes $contextPackIdPrefixes) { $semanticContextPackId.Trim() } else { $null }
     $cleanupRequired = (
         [string]$Run.task_state -in @('completed', 'task_completed', 'commit_ready', 'done') -or
         [string]$Run.review_state -eq 'PASS'
@@ -7000,6 +7016,47 @@ function New-RunCheckpointPackage {
             outcome           = $verificationOutcome
             verification_plan = @($Run.verification_plan)
             evidence_complete = (-not [string]::IsNullOrWhiteSpace($verificationOutcome))
+        }
+        end_of_run_snapshot          = [ordered]@{
+            contract_version = 1
+            packet_type      = 'end_of_run_snapshot_manifest'
+            status           = 'partial'
+            capture_policy   = [ordered]@{
+                snapshot_failure_does_not_fail_worker = $true
+                raw_terminal_transcript_stored        = $false
+                untracked_file_names_stored           = $false
+                private_content_stored                = $false
+                local_reference_paths_stored          = $false
+            }
+            repo_diff        = [ordered]@{
+                changed_files      = @($changedFiles)
+                changed_file_count = @($changedFiles).Count
+                untracked_files    = [ordered]@{
+                    state             = 'not_captured'
+                    count_bucket      = 'unknown'
+                    file_names_stored = $false
+                }
+            }
+            terminal         = [ordered]@{
+                state                = 'not_captured'
+                summary_ref          = $null
+                raw_transcript_stored = $false
+            }
+            artifacts        = [ordered]@{
+                artifact_refs = @()
+                summary_refs  = @()
+            }
+            context          = [ordered]@{
+                context_pack_id          = $safeContextPackId
+                semantic_context_pack_id = $safeSemanticContextPackId
+            }
+            hydration        = [ordered]@{
+                project_ref       = 'current_project'
+                assigned_worktree = $worktreeRef
+                session_type      = $sessionType
+                branch            = [string]$Run.branch
+                head_sha          = [string]$Run.head_sha
+            }
         }
         rollback_hint                = 'operator-owned-git-lifecycle'
         cleanup_hint                 = if ($cleanupRequired) { 'operator may clean the worker worktree after merge or explicit close' } else { 'keep the worker worktree for inspection' }

--- a/tests/fixtures/rust-parity/explain.json
+++ b/tests/fixtures/rust-parity/explain.json
@@ -237,6 +237,49 @@
         ],
         "evidence_complete": false
       },
+      "end_of_run_snapshot": {
+        "contract_version": 1,
+        "packet_type": "end_of_run_snapshot_manifest",
+        "status": "partial",
+        "capture_policy": {
+          "snapshot_failure_does_not_fail_worker": true,
+          "raw_terminal_transcript_stored": false,
+          "untracked_file_names_stored": false,
+          "private_content_stored": false,
+          "local_reference_paths_stored": false
+        },
+        "repo_diff": {
+          "changed_files": [
+            "scripts/winsmux-core.ps1"
+          ],
+          "changed_file_count": 1,
+          "untracked_files": {
+            "state": "not_captured",
+            "count_bucket": "unknown",
+            "file_names_stored": false
+          }
+        },
+        "terminal": {
+          "state": "not_captured",
+          "summary_ref": null,
+          "raw_transcript_stored": false
+        },
+        "artifacts": {
+          "artifact_refs": [],
+          "summary_refs": []
+        },
+        "context": {
+          "context_pack_id": null,
+          "semantic_context_pack_id": null
+        },
+        "hydration": {
+          "project_ref": "current_project",
+          "assigned_worktree": ".worktrees/builder-1",
+          "session_type": "managed_worktree",
+          "branch": "worktree-builder-1",
+          "head_sha": "abc1234def5678"
+        }
+      },
       "rollback_hint": "operator-owned-git-lifecycle",
       "cleanup_hint": "keep the worker worktree for inspection",
       "operator_git_required": true,

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -8503,6 +8503,15 @@ panes:
         $result.runs[0].checkpoint_package.session_type | Should -Be 'managed_worktree'
         $result.runs[0].checkpoint_package.changed_files | Should -Be @('scripts/winsmux-core.ps1')
         $result.runs[0].checkpoint_package.verification.outcome | Should -Be 'PARTIAL'
+        $result.runs[0].checkpoint_package.end_of_run_snapshot.packet_type | Should -Be 'end_of_run_snapshot_manifest'
+        $result.runs[0].checkpoint_package.end_of_run_snapshot.status | Should -Be 'partial'
+        $result.runs[0].checkpoint_package.end_of_run_snapshot.capture_policy.snapshot_failure_does_not_fail_worker | Should -Be $true
+        $result.runs[0].checkpoint_package.end_of_run_snapshot.repo_diff.changed_files | Should -Be @('scripts/winsmux-core.ps1')
+        $result.runs[0].checkpoint_package.end_of_run_snapshot.repo_diff.untracked_files.file_names_stored | Should -Be $false
+        $result.runs[0].checkpoint_package.end_of_run_snapshot.terminal.raw_transcript_stored | Should -Be $false
+        $result.runs[0].checkpoint_package.end_of_run_snapshot.context.context_pack_id | Should -Be 'ctx-runs'
+        $result.runs[0].checkpoint_package.end_of_run_snapshot.context.semantic_context_pack_id | Should -Be 'sem-runs'
+        $result.runs[0].checkpoint_package.end_of_run_snapshot.hydration.assigned_worktree | Should -Be '.worktrees/builder-1'
         ($result.runs[0].checkpoint_package | ConvertTo-Json -Depth 8) | Should -Not -Match 'Users'
         ($result.runs[0].checkpoint_package | ConvertTo-Json -Depth 8) | Should -Not -Match 'private next action'
         $result.runs[0].checkpoint_package.project_root_stored | Should -Be $false
@@ -8623,6 +8632,12 @@ panes:
                 summary     = 'C:\Users\Example must not leak'
                 next_action = 'private next action'
             }
+            context_contract    = [ordered]@{
+                context_pack_id = 'ctx-C:/Users/Example/context.md'
+                semantic_context = [ordered]@{
+                    context_pack_id = 'sem-C:/Users/Example/semantic.md'
+                }
+            }
         }
 
         $package = New-RunCheckpointPackage -Run $run
@@ -8631,6 +8646,8 @@ panes:
         $package.changed_files | Should -Be @('scripts/winsmux-core.ps1')
         $package.changed_file_count | Should -Be 1
         $package.verification.outcome | Should -Be 'PARTIAL'
+        $package.end_of_run_snapshot.context.context_pack_id | Should -Be $null
+        $package.end_of_run_snapshot.context.semantic_context_pack_id | Should -Be $null
         ($package | ConvertTo-Json -Depth 8) | Should -Not -Match 'Users'
         ($package | ConvertTo-Json -Depth 8) | Should -Not -Match 'private next action'
         $package.worker_git_write_allowed | Should -Be $false


### PR DESCRIPTION
## Summary
- add an `end_of_run_snapshot` manifest under `checkpoint_package`
- expose safe repo diff, capture policy, context, and hydration fields in Rust and PowerShell run surfaces
- reject blank, raw local-path, and prefixed local-path context identifiers before snapshot storage

## Validation
- `cargo test --manifest-path core\Cargo.toml --test ledger_contract ledger_contract_exposes_explain_projection_from_digest_and_events -- --nocapture`
- `cargo test --manifest-path core\Cargo.toml --test fixture_comparison -- --nocapture fixture_comparison_harness_diffs_modeled_projection_payloads`
- `Invoke-Pester -Path tests\winsmux-bridge.Tests.ps1 -FullName '*returns runs as json*','*scrubs checkpoint package path and body fields*','*keeps explain json fixture stable*' -Output Detailed` (normal privileges)
- `git diff --check`
- `pwsh -NoProfile -File scripts\git-guard.ps1`
- `pwsh -NoProfile -File scripts\audit-public-surface.ps1`
- `codex review --uncommitted`