### PR TITLE
TASK-382: Add architecture drift baseline contract

### DIFF
--- a/core/src/ledger.rs
+++ b/core/src/ledger.rs
@@ -280,6 +280,7 @@ pub struct LedgerExplainRun {
     pub context_contract: Value,
     pub team_memory: Value,
     pub run_insights: Value,
+    pub architecture_contract: Value,
     pub child_launch_contract: Value,
     pub checkpoint_package: Value,
     pub tdd_gate: Value,
@@ -480,6 +481,7 @@ pub struct LedgerRunProjection {
     pub context_contract: Value,
     pub team_memory: Value,
     pub run_insights: Value,
+    pub architecture_contract: Value,
     pub child_launch_contract: Value,
     pub checkpoint_package: Value,
     pub tdd_gate: Value,
@@ -531,6 +533,7 @@ pub struct LedgerRunPacket {
     pub context_contract: Value,
     pub team_memory: Value,
     pub run_insights: Value,
+    pub architecture_contract: Value,
     pub child_launch_contract: Value,
     pub checkpoint_package: Value,
     pub tdd_gate: Value,
@@ -756,6 +759,9 @@ impl LedgerRunProjection {
             run_insights: run
                 .map(|run| run.run_insights.clone())
                 .unwrap_or(Value::Null),
+            architecture_contract: run
+                .map(|run| run.architecture_contract.clone())
+                .unwrap_or(Value::Null),
             child_launch_contract: run
                 .map(|run| run.child_launch_contract.clone())
                 .unwrap_or(Value::Null),
@@ -820,6 +826,7 @@ impl LedgerRunPacket {
             context_contract: run.context_contract.clone(),
             team_memory: run.team_memory.clone(),
             run_insights: run.run_insights.clone(),
+            architecture_contract: run.architecture_contract.clone(),
             child_launch_contract: run.child_launch_contract.clone(),
             checkpoint_package: run.checkpoint_package.clone(),
             tdd_gate: run.tdd_gate.clone(),
@@ -1341,6 +1348,7 @@ impl LedgerSnapshot {
             context_contract: Value::Null,
             team_memory: Value::Null,
             run_insights: Value::Null,
+            architecture_contract: Value::Null,
             child_launch_contract: Value::Null,
             checkpoint_package: Value::Null,
             tdd_gate: Value::Null,
@@ -1358,10 +1366,15 @@ impl LedgerSnapshot {
         let team_memory_refs = value_string_list(&run.team_memory, "team_memory_refs");
         run.context_contract =
             context_contract_value(&run.verification_evidence, &team_memory_refs);
+        run.run_insights = run_insights_value(&run, &recent_event_records);
+        run.architecture_contract = run_architecture_contract_value(&run);
+        run.draft_pr_gate = run_draft_pr_gate_value(&run, &recent_event_records);
+        run.phase_gate = run_phase_gate_value(&run, &recent_event_records, &run.draft_pr_gate);
+        run.run_insights = run_insights_value(&run, &recent_event_records);
+        run.architecture_contract = run_architecture_contract_value(&run);
         run.audit_chain = run_audit_chain_value(&run, &recent_event_records);
         run.verification_envelope = run_verification_envelope_value(&run);
         run.outcome = run_outcome_value(&run, &run.phase_gate, &run.draft_pr_gate);
-        run.run_insights = run_insights_value(&run, &recent_event_records);
         run.child_launch_contract = run_child_launch_contract_value(&run);
         run.checkpoint_package = run_checkpoint_package_value(&run);
         let explanation = explain_explanation(&run, &evidence_digest);
@@ -2489,6 +2502,25 @@ fn run_draft_pr_handoff_package_value(run: &LedgerExplainRun, draft_pr_url: &str
         blocked_reasons.push(reason.clone());
         remaining_risks.push(reason);
     }
+    let architecture_score_regression = run
+        .architecture_contract
+        .get("score_regression")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let architecture_review_required = run
+        .architecture_contract
+        .get("baseline")
+        .and_then(|baseline| baseline.get("review_required_on_drift"))
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    if architecture_score_regression
+        && architecture_review_required
+        && !run.review_state.eq_ignore_ascii_case("PASS")
+    {
+        let reason = "architecture baseline mismatch requires review".to_string();
+        blocked_reasons.push(reason.clone());
+        remaining_risks.push(reason);
+    }
 
     let summary = first_non_empty_string(vec![
         verification_summary.clone(),
@@ -2696,6 +2728,17 @@ fn run_verification_envelope_value(run: &LedgerExplainRun) -> Value {
     let draft_pr_gate_state = value_field_string(&run.draft_pr_gate, "state");
     let phase_gate_stop_reason = value_field_string(&run.phase_gate, "stop_reason");
     let phase_gate_stop_stage = value_field_string(&run.phase_gate, "stop_stage");
+    let architecture_score_regression = run
+        .architecture_contract
+        .get("score_regression")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let architecture_review_required = run
+        .architecture_contract
+        .get("baseline")
+        .and_then(|baseline| baseline.get("review_required_on_drift"))
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
     let evidence_complete = !verification_outcome.trim().is_empty()
         && !run.verification_evidence.is_null()
         && !run.audit_chain.is_null();
@@ -2732,10 +2775,17 @@ fn run_verification_envelope_value(run: &LedgerExplainRun) -> Value {
             "phase gate stopped at {stage}: {phase_gate_stop_reason}"
         ));
     }
+    let architecture_review_missing = architecture_score_regression
+        && architecture_review_required
+        && !run.review_state.eq_ignore_ascii_case("PASS");
+    if architecture_review_missing {
+        blocked_reasons.push("architecture baseline mismatch requires review".to_string());
+    }
 
     let human_judgement_required = run.review_required
         || !draft_pr_gate_state.trim().is_empty() && draft_pr_gate_state != "passed"
-        || phase_gate_stop_reason == "needs_user_decision";
+        || phase_gate_stop_reason == "needs_user_decision"
+        || architecture_review_missing;
 
     let status = if !blocked_reasons.is_empty() {
         "blocked"
@@ -2758,6 +2808,7 @@ fn run_verification_envelope_value(run: &LedgerExplainRun) -> Value {
             "required_fields": [
                 "verification_evidence",
                 "context_contract",
+                "architecture_contract",
                 "security_verdict",
                 "audit_chain",
                 "draft_pr_gate",
@@ -2778,6 +2829,7 @@ fn run_verification_envelope_value(run: &LedgerExplainRun) -> Value {
             },
             "approval": approval,
             "context": run.context_contract,
+            "architecture": run.architecture_contract,
             "draft_pr": run.draft_pr_gate,
             "phase": run.phase_gate,
             "audit": {
@@ -2794,6 +2846,7 @@ fn run_verification_envelope_value(run: &LedgerExplainRun) -> Value {
         },
         "verification_evidence": run.verification_evidence,
         "context_contract": run.context_contract,
+        "architecture_contract": run.architecture_contract,
         "security_verdict": run.security_verdict,
         "audit_chain": run.audit_chain,
     })
@@ -2812,12 +2865,15 @@ fn event_timestamp_text(timestamp: &str) -> String {
 fn run_outcome_value(run: &LedgerExplainRun, phase_gate: &Value, draft_pr_gate: &Value) -> Value {
     let phase_gate_stop_reason = value_field_string(phase_gate, "stop_reason");
     let draft_pr_gate_state = value_field_string(draft_pr_gate, "state");
+    let architecture_review_missing = run_architecture_review_missing(run);
     let status = if matches!(run.review_state.as_str(), "FAIL" | "FAILED") {
         "failed".to_string()
     } else if phase_gate_stop_reason == "needs_user_decision" {
         "needs_user_decision".to_string()
     } else if !phase_gate_stop_reason.trim().is_empty() {
         "blocked".to_string()
+    } else if architecture_review_missing {
+        "needs_user_decision".to_string()
     } else if run.review_state == "PASS" && draft_pr_gate_state != "passed" {
         "needs_user_decision".to_string()
     } else if run.review_state == "PASS"
@@ -2867,14 +2923,15 @@ fn run_insights_value(run: &LedgerExplainRun, events: &[(usize, &EventRecord)]) 
 
     let mut drift_signals = Vec::new();
     for (_, event) in events {
+        let event_name = event.event.to_lowercase();
         let text = format!("{} {} {}", event.event, event.message, event.status).to_lowercase();
-        if text.contains("drift") {
+        if text_has_drift_signal(&event_name, &text) {
             push_unique_text(&mut drift_signals, "drift_detected");
         }
-        if text.contains("stale") {
+        if text_has_state_signal(&text, "stale") {
             push_unique_text(&mut drift_signals, "stale_state");
         }
-        if text.contains("mismatch") {
+        if text_has_state_signal(&text, "mismatch") {
             push_unique_text(&mut drift_signals, "state_mismatch");
         }
     }
@@ -2958,6 +3015,97 @@ fn run_insights_value(run: &LedgerExplainRun, events: &[(usize, &EventRecord)]) 
         "unhealthy_session_size": unhealthy_session_size,
         "blocked_reasons": blocked_reasons,
         "next_improvements": next_improvements,
+    })
+}
+
+fn text_has_drift_signal(event_name: &str, text: &str) -> bool {
+    if text.contains("no drift")
+        || text.contains("without drift")
+        || text.contains("drift check passed")
+        || text.contains("drift check ok")
+        || event_name.contains("drift_check.pass")
+        || event_name.contains("drift.pass")
+    {
+        return false;
+    }
+    if event_name.contains(".drift") || event_name.contains("drift.") {
+        return true;
+    }
+    text.contains("drift detected")
+        || text.contains("drift retry")
+        || text.contains("drift check failed")
+        || text.contains("drifted")
+        || text.contains("drifts from")
+        || text.contains("worker isolation drift")
+}
+
+fn text_has_state_signal(text: &str, keyword: &str) -> bool {
+    if text.contains(&format!("no {keyword}"))
+        || text.contains(&format!("without {keyword}"))
+        || text.contains(&format!("{keyword} check passed"))
+        || text.contains(&format!("{keyword} check ok"))
+        || text.contains(&format!("{keyword} resolved"))
+    {
+        return false;
+    }
+    text.contains(keyword)
+}
+
+fn run_architecture_review_missing(run: &LedgerExplainRun) -> bool {
+    let architecture_score_regression = run
+        .architecture_contract
+        .get("score_regression")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let architecture_review_required = run
+        .architecture_contract
+        .get("baseline")
+        .and_then(|baseline| baseline.get("review_required_on_drift"))
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+
+    architecture_score_regression
+        && architecture_review_required
+        && !run.review_state.eq_ignore_ascii_case("PASS")
+}
+
+fn run_architecture_contract_value(run: &LedgerExplainRun) -> Value {
+    let drift_signals = value_string_list(&run.run_insights, "drift_signals");
+    let drift_score = drift_signals.len();
+    let max_drift_score = 0usize;
+    let score_regression = drift_score > max_drift_score;
+    let status = if score_regression {
+        "baseline_mismatch"
+    } else {
+        "baseline_match"
+    };
+
+    json!({
+        "contract_version": 1,
+        "packet_type": "architecture_contract",
+        "scope": "run_architecture_baseline",
+        "run_id": run.run_id,
+        "task_id": run.task_id,
+        "baseline": {
+            "drift_score": 0,
+            "max_drift_score": max_drift_score,
+            "allowed_drift_signals": [],
+            "review_required_on_drift": true
+        },
+        "current": {
+            "drift_score": drift_score,
+            "drift_signals": drift_signals,
+            "retry_count": run.run_insights["retry_count"].as_u64().unwrap_or(0),
+            "intervention_count": run.run_insights["intervention_count"].as_u64().unwrap_or(0),
+            "unhealthy_session_size": run.run_insights["unhealthy_session_size"].as_bool().unwrap_or(false)
+        },
+        "score_regression": score_regression,
+        "status": status,
+        "storage_policy": {
+            "freeform_body_stored": false,
+            "private_content_stored": false,
+            "local_reference_paths_stored": false
+        }
     })
 }
 

--- a/core/src/operator_cli.rs
+++ b/core/src/operator_cli.rs
@@ -6385,12 +6385,33 @@ fn run_recommendable(run: &crate::ledger::LedgerExplainRun) -> bool {
     if json_string_field(&run.verification_result, "outcome").to_ascii_uppercase() != "PASS" {
         return false;
     }
-    matches!(
+    if !matches!(
         json_string_or_field(&run.security_verdict, "verdict")
             .to_ascii_uppercase()
             .as_str(),
         "ALLOW" | "PASS"
-    )
+    ) {
+        return false;
+    }
+    let architecture_score_regression = run
+        .architecture_contract
+        .get("score_regression")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let architecture_review_required = run
+        .architecture_contract
+        .get("baseline")
+        .and_then(|baseline| baseline.get("review_required_on_drift"))
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    if architecture_score_regression
+        && architecture_review_required
+        && !run.review_state.eq_ignore_ascii_case("PASS")
+    {
+        return false;
+    }
+
+    true
 }
 
 fn run_playbook_flow(

--- a/core/tests-rs/fixture_comparison.rs
+++ b/core/tests-rs/fixture_comparison.rs
@@ -245,6 +245,7 @@ const EXPLAIN_RUN_KEYS: &[&str] = &[
     "context_contract",
     "team_memory",
     "run_insights",
+    "architecture_contract",
     "child_launch_contract",
     "checkpoint_package",
     "tdd_gate",

--- a/core/tests-rs/ledger_contract.rs
+++ b/core/tests-rs/ledger_contract.rs
@@ -928,6 +928,31 @@ panes:
         "reduce retry loop before the next run"
     );
     assert_eq!(
+        explain.run.architecture_contract["packet_type"],
+        "architecture_contract"
+    );
+    assert_eq!(
+        explain.run.architecture_contract["baseline"]["max_drift_score"],
+        0
+    );
+    assert_eq!(
+        explain.run.architecture_contract["current"]["drift_score"],
+        1
+    );
+    assert_eq!(
+        explain.run.architecture_contract["current"]["drift_signals"][0],
+        "drift_detected"
+    );
+    assert_eq!(explain.run.architecture_contract["score_regression"], true);
+    assert_eq!(
+        explain.run.architecture_contract["status"],
+        "baseline_mismatch"
+    );
+    assert_eq!(
+        explain.run.architecture_contract["storage_policy"]["local_reference_paths_stored"],
+        false
+    );
+    assert_eq!(
         explain.run.child_launch_contract["packet_type"],
         "child_launch_contract"
     );
@@ -1093,9 +1118,18 @@ panes:
         explain.run.verification_envelope["static_gates"]["required_fields"][0],
         "verification_evidence"
     );
+    assert!(explain.run.verification_envelope["static_gates"]["required_fields"]
+        .as_array()
+        .expect("required fields should be an array")
+        .iter()
+        .any(|item| item.as_str().unwrap_or_default() == "architecture_contract"));
     assert_eq!(
         explain.run.verification_envelope["dynamic_gates"]["context"]["context_mode"],
         "isolated"
+    );
+    assert_eq!(
+        explain.run.verification_envelope["dynamic_gates"]["architecture"]["status"],
+        "baseline_mismatch"
     );
     assert_eq!(
         explain.run.verification_envelope["dynamic_gates"]["verification"]["outcome"],
@@ -1132,6 +1166,16 @@ panes:
             .iter()
             .any(|reason| reason == "draft PR gate is blocked")
     );
+    assert!(explain.run.verification_envelope["release_decision"]["blocked_reasons"]
+        .as_array()
+        .expect("blocked reasons should be an array")
+        .iter()
+        .any(|reason| reason == "architecture baseline mismatch requires review"));
+    assert!(explain.run.draft_pr_gate["handoff_package"]["blocked_reasons"]
+        .as_array()
+        .expect("draft PR blocked reasons should be an array")
+        .iter()
+        .any(|reason| reason == "architecture baseline mismatch requires review"));
     assert!(explain.run.audit_chain["events"]
         .as_array()
         .expect("audit chain events should be an array")
@@ -1140,6 +1184,78 @@ panes:
             && event["at"] == "2026-04-23T03:00:01Z"
             && event["who"]["label"] == "builder-1"));
     assert_eq!(explain.run.security_verdict, "ALLOW");
+}
+
+#[test]
+fn ledger_contract_keeps_in_progress_outcome_when_draft_gate_only_lacks_evidence() {
+    let manifest = r#"version: 1
+session:
+  name: winsmux-orchestra
+panes:
+  builder-1:
+    pane_id: "%2"
+    role: Builder
+    task_id: task-in-progress
+    task: Continue implementation
+    task_state: in_progress
+    review_state: PENDING
+    branch: worktree-builder-1
+    head_sha: abc1234def5678
+"#;
+    let snapshot = ledger::LedgerSnapshot::from_manifest_and_events(manifest, "")
+        .expect("in-progress snapshot should load");
+    let explain = snapshot
+        .explain_projection("task:task-in-progress")
+        .expect("in-progress run should explain");
+
+    assert_eq!(explain.run.draft_pr_gate["state"], "blocked");
+    assert_eq!(
+        explain.run.draft_pr_gate["handoff_package"]["blocked_reasons"][0],
+        "verification evidence is missing"
+    );
+    assert_eq!(
+        explain.run.architecture_contract["status"],
+        "baseline_match"
+    );
+    assert_eq!(explain.run.outcome["status"], "in_progress");
+}
+
+#[test]
+fn ledger_contract_does_not_treat_benign_drift_text_as_architecture_mismatch() {
+    let manifest = r#"version: 1
+session:
+  name: winsmux-orchestra
+panes:
+  builder-1:
+    pane_id: "%2"
+    role: Builder
+    task_id: task-drift-ok
+    task: Check architecture state
+    task_state: in_progress
+    review_state: PENDING
+    branch: worktree-builder-1
+    head_sha: abc1234def5678
+"#;
+    let events = r#"{"timestamp":"2026-04-23T12:00:01+09:00","session":"winsmux-orchestra","event":"pipeline.drift_check.pass","message":"no drift detected; drift check passed","data":{"task_id":"task-drift-ok","verification_result":{"outcome":"PASS"}}}
+"#;
+    let snapshot = ledger::LedgerSnapshot::from_manifest_and_events(manifest, events)
+        .expect("benign drift text snapshot should load");
+    let explain = snapshot
+        .explain_projection("task:task-drift-ok")
+        .expect("benign drift text run should explain");
+
+    assert!(explain.run.run_insights["drift_signals"]
+        .as_array()
+        .expect("drift signals should be an array")
+        .is_empty());
+    assert_eq!(
+        explain.run.architecture_contract["status"],
+        "baseline_match"
+    );
+    assert_eq!(
+        explain.run.architecture_contract["score_regression"],
+        false
+    );
 }
 
 #[test]
@@ -1422,6 +1538,8 @@ fn ledger_contract_serializes_typed_cli_payload_roots() {
             && run["run_packet"]["verification_envelope"]["packet_type"] == "verification_envelope"
             && run["run_insights"]["packet_type"] == "run_insights"
             && run["run_packet"]["run_insights"]["packet_type"] == "run_insights"
+            && run["architecture_contract"]["packet_type"] == "architecture_contract"
+            && run["run_packet"]["architecture_contract"]["packet_type"] == "architecture_contract"
             && run["child_launch_contract"]["packet_type"] == "child_launch_contract"
             && run["run_packet"]["child_launch_contract"]["packet_type"] == "child_launch_contract"
             && run["checkpoint_package"]["packet_type"] == "checkpoint_package"
@@ -1460,6 +1578,10 @@ fn ledger_contract_serializes_typed_cli_payload_roots() {
     assert_eq!(
         explain["run"]["run_insights"]["packet_type"],
         "run_insights"
+    );
+    assert_eq!(
+        explain["run"]["architecture_contract"]["packet_type"],
+        "architecture_contract"
     );
 }
 

--- a/core/tests-rs/operator_cli.rs
+++ b/core/tests-rs/operator_cli.rs
@@ -2517,6 +2517,32 @@ fn operator_cli_promote_tactic_rejects_missing_security_clearance() {
 }
 
 #[test]
+fn operator_cli_promote_tactic_rejects_unreviewed_architecture_drift() {
+    let project_dir = make_temp_project_dir("promote-tactic-architecture-drift");
+    write_compare_runs_fixture(&project_dir);
+    let manifest_path = project_dir.join(".winsmux").join("manifest.yaml");
+    let manifest = fs::read_to_string(&manifest_path)
+        .expect("test should read manifest")
+        .replacen("    review_state: PASS", "    review_state: ", 1);
+    fs::write(manifest_path, manifest).expect("test should write manifest");
+    let events_path = project_dir.join(".winsmux").join("events.jsonl");
+    let events = fs::read_to_string(&events_path)
+        .expect("test should read events")
+        .replace("verification passed", "architecture drift detected after verification");
+    fs::write(events_path, events).expect("test should write events");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .args(["promote-tactic", "task:task-a"])
+        .current_dir(&project_dir)
+        .output()
+        .expect("winsmux command should run");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("run is not promotable: task:task-a"));
+}
+
+#[test]
 fn operator_cli_promote_tactic_rejects_unknown_kind() {
     let project_dir = make_temp_project_dir("promote-tactic-kind");
     write_compare_runs_fixture(&project_dir);

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -5981,8 +5981,9 @@ function Test-RunArchitectureReviewMissing {
     param([Parameter(Mandatory = $true)]$Run)
 
     $reviewState = [string](Get-RunContractField -InputObject $Run -Name 'review_state')
-    $architectureScoreRegression = [bool](Get-RunContractField -InputObject $Run.architecture_contract -Name 'score_regression')
-    $architectureBaseline = Get-RunContractField -InputObject $Run.architecture_contract -Name 'baseline'
+    $architectureContract = Get-RunContractField -InputObject $Run -Name 'architecture_contract'
+    $architectureScoreRegression = [bool](Get-RunContractField -InputObject $architectureContract -Name 'score_regression')
+    $architectureBaseline = Get-RunContractField -InputObject $architectureContract -Name 'baseline'
     $architectureReviewRequired = [bool](Get-RunContractField -InputObject $architectureBaseline -Name 'review_required_on_drift')
 
     return ($architectureScoreRegression -and $architectureReviewRequired -and $reviewState -ne 'PASS')
@@ -6819,8 +6820,9 @@ function New-RunDraftPrHandoffPackage {
         $blockedReasons.Add($reasonText) | Out-Null
         $remainingRisks.Add($reasonText) | Out-Null
     }
-    $architectureScoreRegression = [bool](Get-RunContractField -InputObject $Run.architecture_contract -Name 'score_regression')
-    $architectureBaseline = Get-RunContractField -InputObject $Run.architecture_contract -Name 'baseline'
+    $architectureContract = Get-RunContractField -InputObject $Run -Name 'architecture_contract'
+    $architectureScoreRegression = [bool](Get-RunContractField -InputObject $architectureContract -Name 'score_regression')
+    $architectureBaseline = Get-RunContractField -InputObject $architectureContract -Name 'baseline'
     $architectureReviewRequired = [bool](Get-RunContractField -InputObject $architectureBaseline -Name 'review_required_on_drift')
     if ($architectureScoreRegression -and $architectureReviewRequired -and $reviewState -ne 'PASS') {
         $reasonText = 'architecture baseline mismatch requires review'
@@ -6893,8 +6895,9 @@ function New-RunVerificationEnvelope {
     $draftPrGateState = [string](Get-RunContractField -InputObject $Run.draft_pr_gate -Name 'state')
     $phaseGateStopReason = [string](Get-RunContractField -InputObject $Run.phase_gate -Name 'stop_reason')
     $phaseGateStopStage = [string](Get-RunContractField -InputObject $Run.phase_gate -Name 'stop_stage')
-    $architectureScoreRegression = [bool](Get-RunContractField -InputObject $Run.architecture_contract -Name 'score_regression')
-    $architectureBaseline = Get-RunContractField -InputObject $Run.architecture_contract -Name 'baseline'
+    $architectureContract = Get-RunContractField -InputObject $Run -Name 'architecture_contract'
+    $architectureScoreRegression = [bool](Get-RunContractField -InputObject $architectureContract -Name 'score_regression')
+    $architectureBaseline = Get-RunContractField -InputObject $architectureContract -Name 'baseline'
     $architectureReviewRequired = [bool](Get-RunContractField -InputObject $architectureBaseline -Name 'review_required_on_drift')
 
     $evidenceComplete = (
@@ -6972,7 +6975,7 @@ function New-RunVerificationEnvelope {
             }
             approval     = $approval
             context      = $Run.context_contract
-            architecture = $Run.architecture_contract
+            architecture = $architectureContract
             draft_pr     = $Run.draft_pr_gate
             phase        = $Run.phase_gate
             audit        = [ordered]@{
@@ -6989,7 +6992,7 @@ function New-RunVerificationEnvelope {
         }
         verification_evidence = $Run.verification_evidence
         context_contract      = $Run.context_contract
-        architecture_contract = $Run.architecture_contract
+        architecture_contract = $architectureContract
         security_verdict      = $Run.security_verdict
         audit_chain           = $Run.audit_chain
     }
@@ -7270,6 +7273,8 @@ function New-RunChildLaunchContract {
 function New-RunPacketFromRun {
     param([Parameter(Mandatory = $true)]$Run)
 
+    $architectureContract = Get-RunContractField -InputObject $Run -Name 'architecture_contract'
+
     return [ordered]@{
         run_id            = [string]$Run.run_id
         task_id           = [string]$Run.task_id
@@ -7309,7 +7314,7 @@ function New-RunPacketFromRun {
         context_contract      = $Run.context_contract
         team_memory           = $Run.team_memory
         run_insights          = $Run.run_insights
-        architecture_contract = $Run.architecture_contract
+        architecture_contract = $architectureContract
         child_launch_contract = $Run.child_launch_contract
         checkpoint_package    = $Run.checkpoint_package
         tdd_gate              = $Run.tdd_gate
@@ -7372,6 +7377,8 @@ function New-RunResultPacket {
         }
     }
 
+    $architectureContract = Get-RunContractField -InputObject $Run -Name 'architecture_contract'
+
     return [ordered]@{
         run_id                = [string]$Run.run_id
         status                = $status
@@ -7398,7 +7405,7 @@ function New-RunResultPacket {
         context_contract      = $Run.context_contract
         team_memory           = $Run.team_memory
         run_insights          = $Run.run_insights
-        architecture_contract = $Run.architecture_contract
+        architecture_contract = $architectureContract
         checkpoint_package    = $Run.checkpoint_package
         tdd_gate              = $Run.tdd_gate
         verification_envelope = $Run.verification_envelope
@@ -7972,8 +7979,9 @@ function Test-RunRecommendable {
     if ($securityVerdict -notin @('ALLOW', 'PASS')) {
         return $false
     }
-    $architectureScoreRegression = [bool](Get-RunContractField -InputObject $Run.architecture_contract -Name 'score_regression')
-    $architectureBaseline = Get-RunContractField -InputObject $Run.architecture_contract -Name 'baseline'
+    $architectureContract = Get-RunContractField -InputObject $Run -Name 'architecture_contract'
+    $architectureScoreRegression = [bool](Get-RunContractField -InputObject $architectureContract -Name 'score_regression')
+    $architectureBaseline = Get-RunContractField -InputObject $architectureContract -Name 'baseline'
     $architectureReviewRequired = [bool](Get-RunContractField -InputObject $architectureBaseline -Name 'review_required_on_drift')
     if ($architectureScoreRegression -and $architectureReviewRequired -and $reviewState -ne 'PASS') {
         return $false

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -5932,6 +5932,7 @@ function New-RunOutcomeContract {
     $draftPrGate = Get-RunContractField -InputObject $Run -Name 'draft_pr_gate'
     $phaseGateStopReason = [string](Get-RunContractField -InputObject $phaseGate -Name 'stop_reason')
     $draftPrGateState = [string](Get-RunContractField -InputObject $draftPrGate -Name 'state')
+    $architectureReviewMissing = Test-RunArchitectureReviewMissing -Run $Run
 
     $status = ''
     if ([string]$Run.review_state -in @('FAIL', 'FAILED')) {
@@ -5940,6 +5941,8 @@ function New-RunOutcomeContract {
         $status = 'needs_user_decision'
     } elseif (-not [string]::IsNullOrWhiteSpace($phaseGateStopReason)) {
         $status = 'blocked'
+    } elseif ($architectureReviewMissing) {
+        $status = 'needs_user_decision'
     } elseif ([string]$Run.review_state -eq 'PASS' -and $draftPrGateState -ne 'passed') {
         $status = 'needs_user_decision'
     } elseif ([string]$Run.review_state -eq 'PASS' -or [string]$Run.task_state -in @('completed', 'task_completed', 'commit_ready', 'done')) {
@@ -5972,6 +5975,17 @@ function New-RunOutcomeContract {
         confidence  = $confidence
         source_event = [string]$Run.last_event
     }
+}
+
+function Test-RunArchitectureReviewMissing {
+    param([Parameter(Mandatory = $true)]$Run)
+
+    $reviewState = [string](Get-RunContractField -InputObject $Run -Name 'review_state')
+    $architectureScoreRegression = [bool](Get-RunContractField -InputObject $Run.architecture_contract -Name 'score_regression')
+    $architectureBaseline = Get-RunContractField -InputObject $Run.architecture_contract -Name 'baseline'
+    $architectureReviewRequired = [bool](Get-RunContractField -InputObject $architectureBaseline -Name 'review_required_on_drift')
+
+    return ($architectureScoreRegression -and $architectureReviewRequired -and $reviewState -ne 'PASS')
 }
 
 function Set-RunPhaseGateStage {
@@ -6297,7 +6311,8 @@ function New-RunInsightsContract {
     $interventionCount = @($Run.action_items).Count
 
     foreach ($eventRecord in @($EventRecords)) {
-        $eventText = ("{0} {1} {2}" -f [string]$eventRecord['event'], [string]$eventRecord['message'], [string]$eventRecord['status']).ToLowerInvariant()
+        $eventName = [string]$eventRecord['event']
+        $eventText = ("{0} {1} {2}" -f $eventName, [string]$eventRecord['message'], [string]$eventRecord['status']).ToLowerInvariant()
         $nextAction = ''
         $data = if ($eventRecord.Contains('data')) { $eventRecord['data'] } else { $null }
         if ($null -ne $data -and $data -is [System.Collections.IDictionary] -and $data.Contains('next_action')) {
@@ -6308,13 +6323,13 @@ function New-RunInsightsContract {
             $retryCount++
         }
 
-        if ($eventText.Contains('drift')) {
+        if (Test-RunDriftSignalText -EventName $eventName -Text $eventText) {
             Add-RunInsightText -List $driftSignals -Value 'drift_detected'
         }
-        if ($eventText.Contains('stale')) {
+        if (Test-RunStateSignalText -Text $eventText -Keyword 'stale') {
             Add-RunInsightText -List $driftSignals -Value 'stale_state'
         }
-        if ($eventText.Contains('mismatch')) {
+        if (Test-RunStateSignalText -Text $eventText -Keyword 'mismatch') {
             Add-RunInsightText -List $driftSignals -Value 'state_mismatch'
         }
         if ($eventText.Contains('approval') -or $eventText.Contains('review_requested') -or $eventText.Contains('question') -or $eventText.Contains('user')) {
@@ -6368,6 +6383,97 @@ function New-RunInsightsContract {
         unhealthy_session_size = [bool]$unhealthySessionSize
         blocked_reasons        = @($blockedReasons)
         next_improvements      = @($nextImprovements)
+    }
+}
+
+function Test-RunDriftSignalText {
+    param(
+        [string]$EventName = '',
+        [string]$Text = ''
+    )
+
+    $eventNameText = $EventName.ToLowerInvariant()
+    $bodyText = $Text.ToLowerInvariant()
+    if (
+        $bodyText.Contains('no drift') -or
+        $bodyText.Contains('without drift') -or
+        $bodyText.Contains('drift check passed') -or
+        $bodyText.Contains('drift check ok') -or
+        $eventNameText.Contains('drift_check.pass') -or
+        $eventNameText.Contains('drift.pass')
+    ) {
+        return $false
+    }
+    if ($eventNameText.Contains('.drift') -or $eventNameText.Contains('drift.')) {
+        return $true
+    }
+
+    return (
+        $bodyText.Contains('drift detected') -or
+        $bodyText.Contains('drift retry') -or
+        $bodyText.Contains('drift check failed') -or
+        $bodyText.Contains('drifted') -or
+        $bodyText.Contains('drifts from') -or
+        $bodyText.Contains('worker isolation drift')
+    )
+}
+
+function Test-RunStateSignalText {
+    param(
+        [string]$Text = '',
+        [Parameter(Mandatory = $true)][string]$Keyword
+    )
+
+    $bodyText = $Text.ToLowerInvariant()
+    $keywordText = $Keyword.ToLowerInvariant()
+    if (
+        $bodyText.Contains("no $keywordText") -or
+        $bodyText.Contains("without $keywordText") -or
+        $bodyText.Contains("$keywordText check passed") -or
+        $bodyText.Contains("$keywordText check ok") -or
+        $bodyText.Contains("$keywordText resolved")
+    ) {
+        return $false
+    }
+
+    return $bodyText.Contains($keywordText)
+}
+
+function New-RunArchitectureContract {
+    param([Parameter(Mandatory = $true)]$Run)
+
+    $driftSignals = @(ConvertTo-RunStringArray -Value (Get-RunContractField -InputObject $Run.run_insights -Name 'drift_signals'))
+    $driftScore = @($driftSignals).Count
+    $maxDriftScore = 0
+    $scoreRegression = ($driftScore -gt $maxDriftScore)
+    $status = if ($scoreRegression) { 'baseline_mismatch' } else { 'baseline_match' }
+
+    return [ordered]@{
+        contract_version = 1
+        packet_type      = 'architecture_contract'
+        scope            = 'run_architecture_baseline'
+        run_id           = [string]$Run.run_id
+        task_id          = [string]$Run.task_id
+        baseline         = [ordered]@{
+            drift_score              = 0
+            max_drift_score          = $maxDriftScore
+            allowed_drift_signals    = @()
+            review_required_on_drift = $true
+        }
+        current          = [ordered]@{
+            drift_score            = $driftScore
+            drift_signals          = @($driftSignals)
+            retry_count            = [int](Get-RunContractField -InputObject $Run.run_insights -Name 'retry_count')
+            intervention_count     = [int](Get-RunContractField -InputObject $Run.run_insights -Name 'intervention_count')
+            unhealthy_session_size = [bool](Get-RunContractField -InputObject $Run.run_insights -Name 'unhealthy_session_size')
+        }
+        score_regression = $scoreRegression
+        status           = $status
+        storage_policy   = [ordered]@{
+            freeform_body_stored         = $false
+            private_content_stored       = $false
+            local_reference_paths_stored = $false
+        }
     }
 }
 
@@ -6713,6 +6819,14 @@ function New-RunDraftPrHandoffPackage {
         $blockedReasons.Add($reasonText) | Out-Null
         $remainingRisks.Add($reasonText) | Out-Null
     }
+    $architectureScoreRegression = [bool](Get-RunContractField -InputObject $Run.architecture_contract -Name 'score_regression')
+    $architectureBaseline = Get-RunContractField -InputObject $Run.architecture_contract -Name 'baseline'
+    $architectureReviewRequired = [bool](Get-RunContractField -InputObject $architectureBaseline -Name 'review_required_on_drift')
+    if ($architectureScoreRegression -and $architectureReviewRequired -and $reviewState -ne 'PASS') {
+        $reasonText = 'architecture baseline mismatch requires review'
+        $blockedReasons.Add($reasonText) | Out-Null
+        $remainingRisks.Add($reasonText) | Out-Null
+    }
 
     $summary = if (-not [string]::IsNullOrWhiteSpace($verificationSummary)) {
         $verificationSummary
@@ -6760,6 +6874,7 @@ function New-RunVerificationEnvelope {
     $verificationOutcome = [string](Get-RunContractField -InputObject $Run.verification_result -Name 'outcome')
     $verificationSummary = [string](Get-RunContractField -InputObject $Run.verification_result -Name 'summary')
     $verificationNextAction = [string](Get-RunContractField -InputObject $Run.verification_result -Name 'next_action')
+    $reviewState = ([string]$Run.review_state).ToUpperInvariant()
     $securityVerdict = [string](Get-RunContractField -InputObject $Run.security_verdict -Name 'verdict')
     if ([string]::IsNullOrWhiteSpace($securityVerdict) -and $Run.security_verdict -is [string]) {
         $securityVerdict = [string]$Run.security_verdict
@@ -6778,6 +6893,9 @@ function New-RunVerificationEnvelope {
     $draftPrGateState = [string](Get-RunContractField -InputObject $Run.draft_pr_gate -Name 'state')
     $phaseGateStopReason = [string](Get-RunContractField -InputObject $Run.phase_gate -Name 'stop_reason')
     $phaseGateStopStage = [string](Get-RunContractField -InputObject $Run.phase_gate -Name 'stop_stage')
+    $architectureScoreRegression = [bool](Get-RunContractField -InputObject $Run.architecture_contract -Name 'score_regression')
+    $architectureBaseline = Get-RunContractField -InputObject $Run.architecture_contract -Name 'baseline'
+    $architectureReviewRequired = [bool](Get-RunContractField -InputObject $architectureBaseline -Name 'review_required_on_drift')
 
     $evidenceComplete = (
         -not [string]::IsNullOrWhiteSpace($verificationOutcome) -and
@@ -6808,11 +6926,16 @@ function New-RunVerificationEnvelope {
         $stageText = if (-not [string]::IsNullOrWhiteSpace($phaseGateStopStage)) { $phaseGateStopStage } else { 'unknown' }
         $blockedReasons.Add("phase gate stopped at ${stageText}: $phaseGateStopReason") | Out-Null
     }
+    $architectureReviewMissing = ($architectureScoreRegression -and $architectureReviewRequired -and $reviewState -ne 'PASS')
+    if ($architectureReviewMissing) {
+        $blockedReasons.Add('architecture baseline mismatch requires review') | Out-Null
+    }
 
     $humanJudgementRequired = (
         [bool]$Run.review_required -or
         (-not [string]::IsNullOrWhiteSpace($draftPrGateState) -and $draftPrGateState -ne 'passed') -or
-        $phaseGateStopReason -eq 'needs_user_decision'
+        $phaseGateStopReason -eq 'needs_user_decision' -or
+        $architectureReviewMissing
     )
 
     $status = if (@($blockedReasons).Count -gt 0) {
@@ -6833,7 +6956,7 @@ function New-RunVerificationEnvelope {
             verification_plan = @($Run.verification_plan)
             changed_files     = @($Run.changed_files)
             review_required   = [bool]$Run.review_required
-            required_fields   = @('verification_evidence', 'context_contract', 'security_verdict', 'audit_chain', 'draft_pr_gate', 'phase_gate')
+            required_fields   = @('verification_evidence', 'context_contract', 'architecture_contract', 'security_verdict', 'audit_chain', 'draft_pr_gate', 'phase_gate')
         }
         dynamic_gates        = [ordered]@{
             verification = [ordered]@{
@@ -6849,6 +6972,7 @@ function New-RunVerificationEnvelope {
             }
             approval     = $approval
             context      = $Run.context_contract
+            architecture = $Run.architecture_contract
             draft_pr     = $Run.draft_pr_gate
             phase        = $Run.phase_gate
             audit        = [ordered]@{
@@ -6865,6 +6989,7 @@ function New-RunVerificationEnvelope {
         }
         verification_evidence = $Run.verification_evidence
         context_contract      = $Run.context_contract
+        architecture_contract = $Run.architecture_contract
         security_verdict      = $Run.security_verdict
         audit_chain           = $Run.audit_chain
     }
@@ -7184,6 +7309,7 @@ function New-RunPacketFromRun {
         context_contract      = $Run.context_contract
         team_memory           = $Run.team_memory
         run_insights          = $Run.run_insights
+        architecture_contract = $Run.architecture_contract
         child_launch_contract = $Run.child_launch_contract
         checkpoint_package    = $Run.checkpoint_package
         tdd_gate              = $Run.tdd_gate
@@ -7272,6 +7398,7 @@ function New-RunResultPacket {
         context_contract      = $Run.context_contract
         team_memory           = $Run.team_memory
         run_insights          = $Run.run_insights
+        architecture_contract = $Run.architecture_contract
         checkpoint_package    = $Run.checkpoint_package
         tdd_gate              = $Run.tdd_gate
         verification_envelope = $Run.verification_envelope
@@ -7540,6 +7667,7 @@ function Get-RunsPayload {
                 context_contract      = $null
                 team_memory           = $null
                 run_insights          = $null
+                architecture_contract = $null
                 child_launch_contract = $null
                 checkpoint_package    = $null
                 plan                  = $null
@@ -7713,9 +7841,14 @@ function Get-RunsPayload {
             $run.team_memory = New-RunTeamMemoryContract -Run $run -EventRecords $runEvents
             $run.context_contract = New-RunContextContract -VerificationEvidence $run.verification_evidence -TeamMemoryRefs @($run.team_memory.team_memory_refs)
             $run.audit_chain = New-RunAuditChainContract -Run $run -EventRecords $runEvents
+            $run.run_insights = New-RunInsightsContract -Run $run -EventRecords $runEvents
+            $run.architecture_contract = New-RunArchitectureContract -Run $run
+            $run.draft_pr_gate = New-RunDraftPrGate -Run $run -EventRecords $runEvents
+            $run.phase_gate = New-RunPhaseGateContract -Run $run -EventRecords $runEvents
+            $run.run_insights = New-RunInsightsContract -Run $run -EventRecords $runEvents
+            $run.architecture_contract = New-RunArchitectureContract -Run $run
             $run.verification_envelope = New-RunVerificationEnvelope -Run $run
             $run.outcome = New-RunOutcomeContract -Run $run
-            $run.run_insights = New-RunInsightsContract -Run $run -EventRecords $runEvents
             $run.child_launch_contract = New-RunChildLaunchContract -Run $run
             $run.checkpoint_package = New-RunCheckpointPackage -Run $run
             $nextAction = Get-RunNextAction -Run $run
@@ -7770,6 +7903,7 @@ function Get-RunsPayload {
                 context_contract      = $run.context_contract
                 team_memory           = $run.team_memory
                 run_insights          = $run.run_insights
+                architecture_contract = $run.architecture_contract
                 child_launch_contract = $run.child_launch_contract
                 checkpoint_package    = $run.checkpoint_package
                 tdd_gate              = $run.tdd_gate
@@ -7836,6 +7970,12 @@ function Test-RunRecommendable {
         return $false
     }
     if ($securityVerdict -notin @('ALLOW', 'PASS')) {
+        return $false
+    }
+    $architectureScoreRegression = [bool](Get-RunContractField -InputObject $Run.architecture_contract -Name 'score_regression')
+    $architectureBaseline = Get-RunContractField -InputObject $Run.architecture_contract -Name 'baseline'
+    $architectureReviewRequired = [bool](Get-RunContractField -InputObject $architectureBaseline -Name 'review_required_on_drift')
+    if ($architectureScoreRegression -and $architectureReviewRequired -and $reviewState -ne 'PASS') {
         return $false
     }
 

--- a/tests/fixtures/rust-parity/explain.json
+++ b/tests/fixtures/rust-parity/explain.json
@@ -174,6 +174,33 @@
         "resolve blocked reasons before release"
       ]
     },
+    "architecture_contract": {
+      "contract_version": 1,
+      "packet_type": "architecture_contract",
+      "scope": "run_architecture_baseline",
+      "run_id": "task:task-256",
+      "task_id": "task-256",
+      "baseline": {
+        "drift_score": 0,
+        "max_drift_score": 0,
+        "allowed_drift_signals": [],
+        "review_required_on_drift": true
+      },
+      "current": {
+        "drift_score": 0,
+        "drift_signals": [],
+        "retry_count": 0,
+        "intervention_count": 3,
+        "unhealthy_session_size": false
+      },
+      "score_regression": false,
+      "status": "baseline_match",
+      "storage_policy": {
+        "freeform_body_stored": false,
+        "private_content_stored": false,
+        "local_reference_paths_stored": false
+      }
+    },
     "child_launch_contract": {
       "contract_version": 1,
       "packet_type": "child_launch_contract",
@@ -316,6 +343,7 @@
         "required_fields": [
           "verification_evidence",
           "context_contract",
+          "architecture_contract",
           "security_verdict",
           "audit_chain",
           "draft_pr_gate",
@@ -394,6 +422,33 @@
           "tool_output_pruning": {
             "evidence_only": true,
             "raw_tool_output_stored": false
+          }
+        },
+        "architecture": {
+          "contract_version": 1,
+          "packet_type": "architecture_contract",
+          "scope": "run_architecture_baseline",
+          "run_id": "task:task-256",
+          "task_id": "task-256",
+          "baseline": {
+            "drift_score": 0,
+            "max_drift_score": 0,
+            "allowed_drift_signals": [],
+            "review_required_on_drift": true
+          },
+          "current": {
+            "drift_score": 0,
+            "drift_signals": [],
+            "retry_count": 0,
+            "intervention_count": 3,
+            "unhealthy_session_size": false
+          },
+          "score_regression": false,
+          "status": "baseline_match",
+          "storage_policy": {
+            "freeform_body_stored": false,
+            "private_content_stored": false,
+            "local_reference_paths_stored": false
           }
         },
         "draft_pr": {
@@ -543,6 +598,33 @@
         "tool_output_pruning": {
           "evidence_only": true,
           "raw_tool_output_stored": false
+        }
+      },
+      "architecture_contract": {
+        "contract_version": 1,
+        "packet_type": "architecture_contract",
+        "scope": "run_architecture_baseline",
+        "run_id": "task:task-256",
+        "task_id": "task-256",
+        "baseline": {
+          "drift_score": 0,
+          "max_drift_score": 0,
+          "allowed_drift_signals": [],
+          "review_required_on_drift": true
+        },
+        "current": {
+          "drift_score": 0,
+          "drift_signals": [],
+          "retry_count": 0,
+          "intervention_count": 3,
+          "unhealthy_session_size": false
+        },
+        "score_regression": false,
+        "status": "baseline_match",
+        "storage_policy": {
+          "freeform_body_stored": false,
+          "private_content_stored": false,
+          "local_reference_paths_stored": false
         }
       },
       "security_verdict": null,

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -8474,6 +8474,16 @@ panes:
         $result.runs[0].run_insights.drift_signals | Should -Be @('drift_detected')
         $result.runs[0].run_insights.unhealthy_session_size | Should -Be $true
         $result.runs[0].run_insights.next_improvements | Should -Contain 'split the next run into a smaller scope'
+        $result.runs[0].architecture_contract.packet_type | Should -Be 'architecture_contract'
+        $result.runs[0].architecture_contract.baseline.max_drift_score | Should -Be 0
+        $result.runs[0].architecture_contract.current.drift_score | Should -Be 1
+        $result.runs[0].architecture_contract.current.drift_signals | Should -Be @('drift_detected')
+        $result.runs[0].architecture_contract.score_regression | Should -Be $true
+        $result.runs[0].architecture_contract.status | Should -Be 'baseline_mismatch'
+        $result.runs[0].architecture_contract.storage_policy.local_reference_paths_stored | Should -Be $false
+        $result.runs[0].verification_envelope.static_gates.required_fields | Should -Contain 'architecture_contract'
+        $result.runs[0].verification_envelope.dynamic_gates.architecture.status | Should -Be 'baseline_mismatch'
+        $result.runs[0].verification_envelope.release_decision.blocked_reasons | Should -Contain 'architecture baseline mismatch requires review'
         $result.runs[0].child_launch_contract.packet_type | Should -Be 'child_launch_contract'
         $result.runs[0].child_launch_contract.scope | Should -Be 'operator_managed_child_run'
         $result.runs[0].child_launch_contract.role | Should -Be 'Builder'
@@ -8521,6 +8531,7 @@ panes:
         $result.runs[0].run_packet.team_memory.team_memory_refs | Should -Contain 'team-memory:task-256:operator-standard'
         $result.runs[0].run_packet.team_memory.team_memory_refs | Should -Contain 'team-memory:task:task-256:event-3'
         $result.runs[0].run_packet.run_insights.retry_count | Should -Be 1
+        $result.runs[0].run_packet.architecture_contract.status | Should -Be 'baseline_mismatch'
         $result.runs[0].run_packet.child_launch_contract.packet_type | Should -Be 'child_launch_contract'
         $result.runs[0].run_packet.child_launch_contract.structured_handoff.plan_ref | Should -Be 'plan.md'
         $result.runs[0].run_packet.child_launch_contract.operator_controls_merge | Should -Be $true
@@ -8569,6 +8580,7 @@ panes:
         $result.runs[0].draft_pr_gate.handoff_package.validation.outcome | Should -Be 'PARTIAL'
         $result.runs[0].draft_pr_gate.handoff_package.remaining_risks | Should -Contain 'verification outcome is PARTIAL'
         $result.runs[0].draft_pr_gate.handoff_package.blocked_reasons | Should -Contain 'review state is unresolved: PENDING'
+        $result.runs[0].draft_pr_gate.handoff_package.blocked_reasons | Should -Contain 'architecture baseline mismatch requires review'
         $result.runs[0].draft_pr_gate.handoff_package.package_complete | Should -Be $false
         $result.runs[0].draft_pr_gate.handoff_package.automatic_merge_allowed | Should -Be $false
         $result.runs[0].run_packet.plan.goal | Should -Be 'Ship run contract primitives'
@@ -8613,6 +8625,58 @@ panes:
         $gate.handoff_package.validation.evidence_complete | Should -Be $false
         $gate.handoff_package.blocked_reasons | Should -Contain 'verification evidence is missing'
         $gate.handoff_package.suggested_next_action | Should -Be 'resolve blocked reasons before creating or merging a draft PR'
+    }
+
+    It 'keeps in-progress outcome when draft PR gate is blocked only for missing evidence' {
+        $run = [ordered]@{
+            task_state            = 'in_progress'
+            review_state          = 'PENDING'
+            last_event            = ''
+            experiment_packet     = $null
+            verification_result   = $null
+            phase_gate            = [ordered]@{ stop_reason = '' }
+            draft_pr_gate         = [ordered]@{ state = 'blocked' }
+            architecture_contract = [ordered]@{
+                score_regression = $false
+                baseline = [ordered]@{ review_required_on_drift = $true }
+            }
+        }
+
+        $outcome = New-RunOutcomeContract -Run $run
+
+        $outcome.status | Should -Be 'in_progress'
+    }
+
+    It 'does not treat benign drift text as architecture mismatch' {
+        $run = [ordered]@{
+            run_id        = 'task:task-drift-ok'
+            task_id       = 'task-drift-ok'
+            action_items  = @()
+            pane_count    = 1
+            changed_file_count = 0
+            phase_gate    = [ordered]@{ stop_reason = '' }
+            draft_pr_gate = [ordered]@{ state = '' }
+            tdd_gate      = [ordered]@{ state = '' }
+            verification_result = [ordered]@{ outcome = 'PASS' }
+            verification_evidence = [ordered]@{}
+            security_verdict    = [ordered]@{ verdict = 'ALLOW' }
+        }
+        $events = @(
+            [ordered]@{
+                event   = 'pipeline.drift_check.pass'
+                message = 'no drift detected; drift check passed'
+                status  = 'completed'
+                data    = [ordered]@{ task_id = 'task-drift-ok' }
+            }
+        )
+
+        $run.run_insights = New-RunInsightsContract -Run $run -EventRecords $events
+        $contract = New-RunArchitectureContract -Run $run
+
+        @($run.run_insights.drift_signals).Count | Should -Be 0
+        $contract.current.drift_score | Should -Be 0
+        $contract.score_regression | Should -Be $false
+        $contract.status | Should -Be 'baseline_match'
     }
 
     It 'scrubs checkpoint package path and body fields' {
@@ -8957,6 +9021,9 @@ Set-Location '__RUNS_TEMP_ROOT__'
         $result.runs[0].run_insights.blocked_reasons | Should -Contain 'tdd_gate_blocked'
         $result.runs[0].run_insights.next_improvements | Should -Contain 'capture operator decisions as reusable guidance'
         $result.runs[0].run_insights.next_improvements | Should -Contain 'resolve blocked reasons before release'
+        $result.runs[0].architecture_contract.current.drift_score | Should -Be 0
+        $result.runs[0].architecture_contract.score_regression | Should -Be $false
+        $result.runs[0].architecture_contract.status | Should -Be 'baseline_match'
         $result.runs[0].run_packet.run_insights.retry_count | Should -Be 0
     }
 
@@ -10074,6 +10141,9 @@ panes:
         $result.run.run_insights.drift_signals | Should -Be @('drift_detected')
         $result.run.run_insights.intervention_count | Should -BeGreaterThan 0
         $result.run.run_insights.next_improvements | Should -Contain 'reduce retry loop before the next run'
+        $result.run.architecture_contract.packet_type | Should -Be 'architecture_contract'
+        $result.run.architecture_contract.current.drift_score | Should -Be 1
+        $result.run.architecture_contract.status | Should -Be 'baseline_mismatch'
         $result.run.tdd_gate.required | Should -Be $true
         $result.run.tdd_gate.state | Should -Be 'passed'
         $result.run.tdd_gate.red_event | Should -Be 'pipeline.tdd.red'
@@ -10115,6 +10185,7 @@ panes:
         $result.run.draft_pr_gate.handoff_package.summary | Should -Be 'rerun focused verification'
         $result.run.draft_pr_gate.handoff_package.remaining_risks | Should -Contain 'verification outcome is PARTIAL'
         $result.run.draft_pr_gate.handoff_package.blocked_reasons | Should -Contain 'review state is unresolved: PENDING'
+        $result.run.draft_pr_gate.handoff_package.blocked_reasons | Should -Contain 'architecture baseline mismatch requires review'
         $result.run.draft_pr_gate.handoff_package.automatic_merge_allowed | Should -Be $false
         $result.observation_pack.failing_command | Should -Be 'Invoke-Pester tests/winsmux-bridge.Tests.ps1'
         $result.observation_pack.changed_files | Should -Contain 'scripts/winsmux-core.ps1'
@@ -13585,6 +13656,92 @@ panes:
                         outcome = 'PASS'
                         summary = 'cache hit confirmed'
                     }
+                }
+            } | ConvertTo-Json -Compress)
+        ) | Set-Content -Path $script:compareEventsPath -Encoding UTF8
+
+        { Invoke-PromoteTactic -PromoteTarget 'task:task-compare-a' } | Should -Throw '*run is not promotable*'
+    }
+
+    It 'rejects promote-tactic when architecture drift has not been reviewed' {
+        @"
+version: 1
+session:
+  name: winsmux-orchestra
+  project_dir: $script:compareTempRoot
+panes:
+  builder-1:
+    pane_id: %2
+    role: Builder
+    task_id: task-compare-a
+    task: Compare run A
+    task_state: completed
+    review_state: ''
+    branch: worktree-builder-a
+    head_sha: aaaabbbbccccdddd
+    changed_file_count: 1
+    changed_files: '["scripts/winsmux-core.ps1"]'
+    last_event: pipeline.verify.pass
+    last_event_at: 2026-04-12T10:05:10+09:00
+"@ | Set-Content -Path $script:compareManifestPath -Encoding UTF8
+
+        @(
+            ([ordered]@{
+                timestamp = '2026-04-12T10:00:00+09:00'
+                session   = 'winsmux-orchestra'
+                event     = 'pane.consult_result'
+                message   = 'architecture drift detected before promotion'
+                label     = 'builder-1'
+                pane_id   = '%2'
+                role      = 'Builder'
+                branch    = 'worktree-builder-a'
+                head_sha  = 'aaaabbbbccccdddd'
+                data      = [ordered]@{
+                    task_id              = 'task-compare-a'
+                    run_id               = 'task:task-compare-a'
+                    slot                 = 'slot-builder-a'
+                    hypothesis           = 'deterministic command fixes cache'
+                    result               = 'cache hit done'
+                    confidence           = 0.85
+                    next_action          = 'promote tactic'
+                    observation_pack_ref = $script:compareObsA.reference
+                    consultation_ref     = $script:compareConsultA.reference
+                }
+            } | ConvertTo-Json -Compress),
+            ([ordered]@{
+                timestamp = '2026-04-12T10:05:10+09:00'
+                session   = 'winsmux-orchestra'
+                event     = 'pipeline.verify.pass'
+                message   = 'verification passed'
+                label     = 'builder-1'
+                pane_id   = '%2'
+                role      = 'Builder'
+                branch    = 'worktree-builder-a'
+                head_sha  = 'aaaabbbbccccdddd'
+                data      = [ordered]@{
+                    task_id = 'task-compare-a'
+                    run_id  = 'task:task-compare-a'
+                    verification_result = [ordered]@{
+                        outcome = 'PASS'
+                        summary = 'cache hit confirmed'
+                    }
+                }
+            } | ConvertTo-Json -Compress),
+            ([ordered]@{
+                timestamp = '2026-04-12T10:05:20+09:00'
+                session   = 'winsmux-orchestra'
+                event     = 'pipeline.security.allowed'
+                message   = 'security allowed'
+                label     = 'builder-1'
+                pane_id   = '%2'
+                role      = 'Builder'
+                branch    = 'worktree-builder-a'
+                head_sha  = 'aaaabbbbccccdddd'
+                data      = [ordered]@{
+                    task_id = 'task-compare-a'
+                    run_id  = 'task:task-compare-a'
+                    verdict = 'ALLOW'
+                    reason  = 'verified safe'
                 }
             } | ConvertTo-Json -Compress)
         ) | Set-Content -Path $script:compareEventsPath -Encoding UTF8


### PR DESCRIPTION
## Summary
- add an architecture drift baseline contract to run, explain, run packet, and verification envelope surfaces
- gate promotion and draft PR readiness when architecture mismatch has not been reviewed
- avoid false positives for ordinary in-progress runs and successful drift checks

## Validation
- cargo test --manifest-path core\\Cargo.toml --test ledger_contract ledger_contract_exposes_explain_projection_from_digest_and_events -- --nocapture
- cargo test --manifest-path core\\Cargo.toml --test ledger_contract ledger_contract_keeps_in_progress_outcome_when_draft_gate_only_lacks_evidence -- --nocapture
- cargo test --manifest-path core\\Cargo.toml --test ledger_contract ledger_contract_does_not_treat_benign_drift_text_as_architecture_mismatch -- --nocapture
- cargo test --manifest-path core\\Cargo.toml --test operator_cli operator_cli_promote_tactic_rejects_unreviewed_architecture_drift -- --nocapture
- cargo test --manifest-path core\\Cargo.toml --test fixture_comparison -- --nocapture fixture_comparison_harness_diffs_modeled_projection_payloads
- Invoke-Pester targeted runs/explain tests with normal privileges
- git diff --check
- pwsh -NoProfile -File scripts\\git-guard.ps1
- pwsh -NoProfile -File scripts\\audit-public-surface.ps1
- codex review --uncommitted