### PR TITLE
TASK-352 add managed follow-up playbook contracts

### DIFF
--- a/core/src/operator_cli.rs
+++ b/core/src/operator_cli.rs
@@ -15,8 +15,8 @@ use serde_json::{json, Map, Value};
 
 use crate::event_contract::{parse_event_jsonl, EventRecord};
 use crate::ledger::{
-    attach_evidence_chain_to_event, LedgerBoardPayload, LedgerDigestItem, LedgerDigestPayload,
-    LedgerExplainPayload, LedgerInboxPayload, LedgerRunsPayload, LedgerSnapshot,
+    attach_evidence_chain_to_event, public_changed_files, LedgerBoardPayload, LedgerDigestItem,
+    LedgerDigestPayload, LedgerExplainPayload, LedgerInboxPayload, LedgerRunsPayload, LedgerSnapshot,
     LedgerStatusPayload,
 };
 use crate::machine_contract::machine_contract_catalog;
@@ -6011,28 +6011,43 @@ fn compare_runs_payload(
             })
             .unwrap_or(false)
     }) || !(left_recommendable && right_recommendable);
-    let playbook_template = if !winning_run_id.trim().is_empty() {
+    let (playbook_template, follow_up_run) = if !winning_run_id.trim().is_empty() {
         if winning_run_id == left.run.run_id {
-            playbook_template_contract(
+            let playbook_template = playbook_template_contract(
                 &left.run,
                 &left.evidence_digest,
                 "compare_winner_follow_up",
                 "compare_runs",
                 &[&left.run, &right.run],
-            )
+            );
+            let follow_up_run = compare_winner_follow_up_run_contract(
+                &left.run,
+                &left.evidence_digest,
+                &playbook_template,
+            );
+            (playbook_template, follow_up_run)
         } else {
-            playbook_template_contract(
+            let playbook_template = playbook_template_contract(
                 &right.run,
                 &right.evidence_digest,
                 "compare_winner_follow_up",
                 "compare_runs",
                 &[&left.run, &right.run],
-            )
+            );
+            let follow_up_run = compare_winner_follow_up_run_contract(
+                &right.run,
+                &right.evidence_digest,
+                &playbook_template,
+            );
+            (playbook_template, follow_up_run)
         }
     } else if reconcile_consult {
-        compare_reconcile_playbook_template(&left.run, &right.run)
+        (
+            compare_reconcile_playbook_template(&left.run, &right.run),
+            Value::Null,
+        )
     } else {
-        Value::Null
+        (Value::Null, Value::Null)
     };
     let next_action = if left.evidence_digest.next_action == right.evidence_digest.next_action {
         left.evidence_digest.next_action.clone()
@@ -6054,6 +6069,7 @@ fn compare_runs_payload(
             "reconcile_consult": reconcile_consult,
             "next_action": next_action,
             "playbook_template": playbook_template,
+            "follow_up_run": follow_up_run,
         },
     })
 }
@@ -6515,10 +6531,62 @@ fn playbook_template_contract(
         "handoff_refs": run.handoff_refs,
         "execution_backend": "operator_managed",
         "backend_profile_required": false,
+        "approval_defaults": managed_follow_up_approval_defaults(),
         "diversity_policy": diversity_policy,
         "freeform_body_stored": false,
         "private_guidance_stored": false,
         "local_reference_paths_stored": false,
+    })
+}
+
+fn managed_follow_up_approval_defaults() -> Value {
+    json!({
+        "contract_version": 1,
+        "packet_type": "managed_follow_up_approval_defaults",
+        "review_required": true,
+        "human_approval_required": true,
+        "auto_merge_allowed": false,
+        "merge_requires_human": true,
+        "operator_controls_merge": true,
+    })
+}
+
+fn compare_winner_follow_up_run_contract(
+    run: &crate::ledger::LedgerExplainRun,
+    evidence_digest: &crate::ledger::LedgerDigestItem,
+    playbook_template: &Value,
+) -> Value {
+    let mut source_evidence_refs = Vec::new();
+    if !run.experiment_packet.observation_pack_ref.trim().is_empty() {
+        source_evidence_refs.push(run.experiment_packet.observation_pack_ref.clone());
+    }
+    if !run.experiment_packet.consultation_ref.trim().is_empty() {
+        source_evidence_refs.push(run.experiment_packet.consultation_ref.clone());
+    }
+
+    json!({
+        "contract_version": 1,
+        "packet_type": "managed_follow_up_run_contract",
+        "source": "compare_runs",
+        "source_run_id": run.run_id,
+        "task_id": run.task_id,
+        "flow": "compare_winner_follow_up",
+        "run_mode": "operator_managed",
+        "playbook_template_ref": "playbook:compare_winner_follow_up",
+        "required_evidence": playbook_template["required_evidence"],
+        "source_evidence_refs": source_evidence_refs,
+        "changed_files": public_changed_files(&evidence_digest.changed_files),
+        "team_memory_refs": playbook_template["team_memory_refs"],
+        "approval_defaults": managed_follow_up_approval_defaults(),
+        "review_required": true,
+        "human_approval_required": true,
+        "auto_merge_allowed": false,
+        "merge_requires_human": true,
+        "operator_controls_merge": true,
+        "next_action": "start managed follow-up run and request human review before merge",
+        "local_reference_paths_stored": false,
+        "freeform_body_stored": false,
+        "private_guidance_stored": false,
     })
 }
 
@@ -6544,6 +6612,7 @@ fn compare_reconcile_playbook_template(
         "team_memory_refs": compare_team_memory_refs(left_run, right_run),
         "execution_backend": "operator_managed",
         "backend_profile_required": false,
+        "approval_defaults": managed_follow_up_approval_defaults(),
         "diversity_policy": diversity_policy,
         "freeform_body_stored": false,
         "private_guidance_stored": false,

--- a/core/tests-rs/operator_cli.rs
+++ b/core/tests-rs/operator_cli.rs
@@ -1994,6 +1994,13 @@ fn operator_cli_poll_events_handles_missing_file_and_cursor_bounds() {
 fn operator_cli_compare_runs_json_reports_evidence_delta() {
     let project_dir = make_temp_project_dir("compare-runs");
     write_compare_runs_fixture(&project_dir);
+    let manifest_path = project_dir.join(".winsmux").join("manifest.yaml");
+    let manifest = fs::read_to_string(&manifest_path).expect("test should read manifest");
+    let manifest = manifest.replace(
+        "    changed_files: '[\"core/src/operator_cli.rs\"]'",
+        "    changed_files: '[\"core/src/operator_cli.rs\",\"C:\\\\Users\\\\Example\\\\secret.txt\",\"../private.md\"]'",
+    );
+    fs::write(&manifest_path, manifest).expect("test should write manifest");
 
     let json = run_json(
         &project_dir,
@@ -2026,6 +2033,67 @@ fn operator_cli_compare_runs_json_reports_evidence_delta() {
     assert_eq!(
         json["recommend"]["playbook_template"]["freeform_body_stored"],
         false
+    );
+    assert_eq!(
+        json["recommend"]["playbook_template"]["approval_defaults"]["review_required"],
+        true
+    );
+    assert_eq!(
+        json["recommend"]["playbook_template"]["approval_defaults"]["human_approval_required"],
+        true
+    );
+    assert_eq!(
+        json["recommend"]["playbook_template"]["approval_defaults"]["auto_merge_allowed"],
+        false
+    );
+    assert_eq!(
+        json["recommend"]["follow_up_run"]["packet_type"],
+        "managed_follow_up_run_contract"
+    );
+    assert_eq!(
+        json["recommend"]["follow_up_run"]["source_run_id"],
+        "task:task-a"
+    );
+    assert_eq!(
+        json["recommend"]["follow_up_run"]["run_mode"],
+        "operator_managed"
+    );
+    assert_eq!(
+        json["recommend"]["follow_up_run"]["playbook_template_ref"],
+        "playbook:compare_winner_follow_up"
+    );
+    assert_eq!(
+        json["recommend"]["follow_up_run"]["required_evidence"][0],
+        "winning_run"
+    );
+    let follow_up_changed_files = json["recommend"]["follow_up_run"]["changed_files"]
+        .as_array()
+        .expect("follow-up changed_files should be an array");
+    assert_eq!(follow_up_changed_files.len(), 1);
+    assert_eq!(follow_up_changed_files[0], "core/src/operator_cli.rs");
+    assert_eq!(
+        json["recommend"]["follow_up_run"]["source_evidence_refs"][0],
+        ".winsmux/observation-packs/task-a.json"
+    );
+    assert_eq!(
+        json["recommend"]["follow_up_run"]["source_evidence_refs"][1],
+        ".winsmux/consultations/task-a.json"
+    );
+    assert_eq!(
+        json["recommend"]["follow_up_run"]["review_required"],
+        true
+    );
+    assert_eq!(
+        json["recommend"]["follow_up_run"]["human_approval_required"],
+        true
+    );
+    assert_eq!(
+        json["recommend"]["follow_up_run"]["auto_merge_allowed"],
+        false
+    );
+    assert_eq!(
+        json["recommend"]["follow_up_run"]["merge_requires_human"],
+        true
     );
     assert_eq!(
         json["recommend"]["playbook_template"]["diversity_policy"]["packet_type"],
@@ -2264,6 +2332,19 @@ fn operator_cli_compare_runs_emits_conflict_resolution_playbook_when_no_winner()
             ["raw_provider_ids_stored"],
         false
     );
+    assert_eq!(
+        json["recommend"]["playbook_template"]["approval_defaults"]["review_required"],
+        true
+    );
+    assert_eq!(
+        json["recommend"]["playbook_template"]["approval_defaults"]["human_approval_required"],
+        true
+    );
+    assert_eq!(
+        json["recommend"]["playbook_template"]["approval_defaults"]["auto_merge_allowed"],
+        false
+    );
+    assert!(json["recommend"]["follow_up_run"].is_null());
     let diversity_policy_text =
         json["recommend"]["playbook_template"]["diversity_policy"].to_string();
     assert!(!diversity_policy_text.contains("codex"));
@@ -2343,6 +2424,22 @@ fn operator_cli_promote_tactic_writes_playbook_candidate() {
     assert_eq!(
         json["candidate"]["playbook_template"]["freeform_body_stored"],
         false
+    );
+    assert_eq!(
+        json["candidate"]["playbook_template"]["approval_defaults"]["review_required"],
+        true
+    );
+    assert_eq!(
+        json["candidate"]["playbook_template"]["approval_defaults"]["human_approval_required"],
+        true
+    );
+    assert_eq!(
+        json["candidate"]["playbook_template"]["approval_defaults"]["auto_merge_allowed"],
+        false
+    );
+    assert_eq!(
+        json["candidate"]["playbook_template"]["approval_defaults"]["merge_requires_human"],
+        true
     );
     assert!(json["candidate"]["playbook_template"]["freeform_body"].is_null());
     assert_eq!(

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -8062,9 +8062,62 @@ function New-RunPlaybookTemplate {
         handoff_refs              = @($Run.handoff_refs)
         execution_backend         = 'operator_managed'
         backend_profile_required  = $false
+        approval_defaults         = New-ManagedFollowUpApprovalDefaults
         freeform_body_stored      = $false
         private_guidance_stored   = $false
         local_reference_paths_stored = $false
+    }
+}
+
+function New-ManagedFollowUpApprovalDefaults {
+    return [ordered]@{
+        contract_version        = 1
+        packet_type             = 'managed_follow_up_approval_defaults'
+        review_required         = $true
+        human_approval_required = $true
+        auto_merge_allowed      = $false
+        merge_requires_human    = $true
+        operator_controls_merge = $true
+    }
+}
+
+function New-CompareWinnerFollowUpRunContract {
+    param(
+        [Parameter(Mandatory = $true)]$Run,
+        [Parameter(Mandatory = $true)]$EvidenceDigest,
+        [Parameter(Mandatory = $true)]$PlaybookTemplate
+    )
+
+    $experimentPacket = Get-RunContractField -InputObject $Run -Name 'experiment_packet'
+    $observationPackRef = [string](Get-RunContractField -InputObject $experimentPacket -Name 'observation_pack_ref')
+    $consultationRef = [string](Get-RunContractField -InputObject $experimentPacket -Name 'consultation_ref')
+
+    return [ordered]@{
+        contract_version             = 1
+        packet_type                  = 'managed_follow_up_run_contract'
+        source                       = 'compare_runs'
+        source_run_id                = [string]$Run.run_id
+        task_id                      = [string]$Run.task_id
+        flow                         = 'compare_winner_follow_up'
+        run_mode                     = 'operator_managed'
+        playbook_template_ref        = 'playbook:compare_winner_follow_up'
+        required_evidence            = @($PlaybookTemplate.required_evidence)
+        source_evidence_refs         = @(
+            if (-not [string]::IsNullOrWhiteSpace($observationPackRef)) { $observationPackRef }
+            if (-not [string]::IsNullOrWhiteSpace($consultationRef)) { $consultationRef }
+        )
+        changed_files                = @(ConvertTo-RunPublicChangedFiles -ChangedFiles $EvidenceDigest.changed_files)
+        team_memory_refs             = @($PlaybookTemplate.team_memory_refs)
+        approval_defaults            = New-ManagedFollowUpApprovalDefaults
+        review_required              = $true
+        human_approval_required      = $true
+        auto_merge_allowed           = $false
+        merge_requires_human         = $true
+        operator_controls_merge      = $true
+        next_action                  = 'start managed follow-up run and request human review before merge'
+        local_reference_paths_stored = $false
+        freeform_body_stored         = $false
+        private_guidance_stored      = $false
     }
 }
 
@@ -8099,6 +8152,7 @@ function New-CompareReconcilePlaybookTemplate {
         team_memory_refs          = @($teamMemoryRefs | Sort-Object -Unique)
         execution_backend         = 'operator_managed'
         backend_profile_required  = $false
+        approval_defaults         = New-ManagedFollowUpApprovalDefaults
         freeform_body_stored      = $false
         private_guidance_stored   = $false
         local_reference_paths_stored = $false
@@ -8201,11 +8255,14 @@ function ConvertTo-CompareRunsPayload {
         -not ($leftRecommendable -and $rightRecommendable)
     )
     $recommendedPlaybook = $null
+    $recommendedFollowUpRun = $null
     if (-not [string]::IsNullOrWhiteSpace($winningRunId)) {
         if ($winningRunId -eq [string]$leftRun.run_id) {
             $recommendedPlaybook = New-RunPlaybookTemplate -Run $leftRun -EvidenceDigest $leftEvidence -Flow 'compare_winner_follow_up' -Source 'compare_runs'
+            $recommendedFollowUpRun = New-CompareWinnerFollowUpRunContract -Run $leftRun -EvidenceDigest $leftEvidence -PlaybookTemplate $recommendedPlaybook
         } else {
             $recommendedPlaybook = New-RunPlaybookTemplate -Run $rightRun -EvidenceDigest $rightEvidence -Flow 'compare_winner_follow_up' -Source 'compare_runs'
+            $recommendedFollowUpRun = New-CompareWinnerFollowUpRunContract -Run $rightRun -EvidenceDigest $rightEvidence -PlaybookTemplate $recommendedPlaybook
         }
     } elseif ($reconcileConsult) {
         $recommendedPlaybook = New-CompareReconcilePlaybookTemplate -LeftRun $leftRun -RightRun $rightRun
@@ -8251,6 +8308,7 @@ function ConvertTo-CompareRunsPayload {
             reconcile_consult = $reconcileConsult
             next_action = if ([string]$leftEvidence.next_action -eq [string]$rightEvidence.next_action) { [string]$leftEvidence.next_action } else { 'reconcile_consult' }
             playbook_template = $recommendedPlaybook
+            follow_up_run = $recommendedFollowUpRun
         }
     }
 }

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -13307,10 +13307,39 @@ panes:
         $result.recommend.playbook_template.team_memory_refs | Should -Contain 'team-memory:task-compare-a:operator-standard'
         $result.recommend.playbook_template.execution_backend | Should -Be 'operator_managed'
         $result.recommend.playbook_template.backend_profile_required | Should -Be $false
+        $result.recommend.playbook_template.approval_defaults.review_required | Should -Be $true
+        $result.recommend.playbook_template.approval_defaults.human_approval_required | Should -Be $true
+        $result.recommend.playbook_template.approval_defaults.auto_merge_allowed | Should -Be $false
         $result.recommend.playbook_template.freeform_body_stored | Should -Be $false
         $result.recommend.playbook_template.private_guidance_stored | Should -Be $false
         $result.recommend.playbook_template.PSObject.Properties.Name | Should -Not -Contain 'freeform_body'
         $result.recommend.playbook_template.PSObject.Properties.Name | Should -Not -Contain 'private_guidance'
+        $result.recommend.follow_up_run.packet_type | Should -Be 'managed_follow_up_run_contract'
+        $result.recommend.follow_up_run.source_run_id | Should -Be 'task:task-compare-a'
+        $result.recommend.follow_up_run.run_mode | Should -Be 'operator_managed'
+        $result.recommend.follow_up_run.playbook_template_ref | Should -Be 'playbook:compare_winner_follow_up'
+        $result.recommend.follow_up_run.required_evidence | Should -Be @('winning_run', 'comparison_evidence', 'promotion_candidate')
+        $result.recommend.follow_up_run.changed_files | Should -Be @('scripts/winsmux-core.ps1')
+        $unsafeFollowUp = New-CompareWinnerFollowUpRunContract `
+            -Run ([pscustomobject]@{
+                run_id = 'task:task-compare-a'
+                task_id = 'task-compare-a'
+                experiment_packet = [pscustomobject]@{
+                    observation_pack_ref = $script:compareObsA.reference
+                    consultation_ref = $script:compareConsultA.reference
+                }
+            }) `
+            -EvidenceDigest ([pscustomobject]@{ changed_files = @('scripts/winsmux-core.ps1', 'C:\Users\Example\secret.txt', '../private.md') }) `
+            -PlaybookTemplate $result.recommend.playbook_template
+        $unsafeFollowUp.changed_files | Should -Be @('scripts/winsmux-core.ps1')
+        $result.recommend.follow_up_run.source_evidence_refs | Should -Contain $script:compareObsA.reference
+        $result.recommend.follow_up_run.source_evidence_refs | Should -Contain $script:compareConsultA.reference
+        $result.recommend.follow_up_run.team_memory_refs | Should -Contain 'team-memory:task-compare-a:operator-standard'
+        $result.recommend.follow_up_run.review_required | Should -Be $true
+        $result.recommend.follow_up_run.human_approval_required | Should -Be $true
+        $result.recommend.follow_up_run.auto_merge_allowed | Should -Be $false
+        $result.recommend.follow_up_run.merge_requires_human | Should -Be $true
+        $result.recommend.follow_up_run.operator_controls_merge | Should -Be $true
         @($result.differences | ForEach-Object { $_.field }) | Should -Contain 'result'
         @($result.differences | ForEach-Object { $_.field }) | Should -Contain 'confidence'
         @($result.differences | ForEach-Object { $_.field }) | Should -Contain 'changed_files'
@@ -13532,7 +13561,11 @@ panes:
         $result.recommend.playbook_template.compare_run_ids | Should -Be @('task:task-compare-a', 'task:task-compare-b')
         $result.recommend.playbook_template.required_evidence | Should -Be @('overlap_paths', 'reconcile_consult', 'human_decision')
         $result.recommend.playbook_template.team_memory_refs | Should -Contain 'team-memory:task-compare-a:operator-standard'
+        $result.recommend.playbook_template.approval_defaults.review_required | Should -Be $true
+        $result.recommend.playbook_template.approval_defaults.human_approval_required | Should -Be $true
+        $result.recommend.playbook_template.approval_defaults.auto_merge_allowed | Should -Be $false
         $result.recommend.playbook_template.freeform_body_stored | Should -Be $false
+        $result.recommend.follow_up_run | Should -Be $null
     }
 
     It 'exports a playbook candidate from a run and writes a file-backed artifact' {
@@ -13556,6 +13589,10 @@ panes:
         $result.candidate.playbook_template.team_memory_refs | Should -Contain 'team-memory:task-compare-a:operator-standard'
         $result.candidate.playbook_template.execution_backend | Should -Be 'operator_managed'
         $result.candidate.playbook_template.backend_profile_required | Should -Be $false
+        $result.candidate.playbook_template.approval_defaults.review_required | Should -Be $true
+        $result.candidate.playbook_template.approval_defaults.human_approval_required | Should -Be $true
+        $result.candidate.playbook_template.approval_defaults.auto_merge_allowed | Should -Be $false
+        $result.candidate.playbook_template.approval_defaults.merge_requires_human | Should -Be $true
         $result.candidate.playbook_template.freeform_body_stored | Should -Be $false
         $result.candidate.playbook_template.private_guidance_stored | Should -Be $false
         $result.candidate.playbook_template.PSObject.Properties.Name | Should -Not -Contain 'freeform_body'


### PR DESCRIPTION
## Summary
- add managed follow-up approval defaults to compare/promote playbook templates
- emit a managed follow-up run contract for compare winners
- scrub changed files before publishing follow-up contracts

## Validation
- Invoke-Pester -Path tests\\winsmux-bridge.Tests.ps1 -FullName 'winsmux compare-runs and promote-tactic commands' -Output Detailed
- cargo test --manifest-path core\\Cargo.toml --test operator_cli operator_cli_compare_runs -- --nocapture
- cargo test --manifest-path core\\Cargo.toml --test operator_cli operator_cli_promote_tactic_writes_playbook_candidate -- --nocapture
- git diff --check
- pwsh -NoProfile -File scripts\\git-guard.ps1
- codex review --uncommitted