### PR TITLE
docs: align public docs with v0.24.15

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,17 @@
 .githooks/* text eol=lf
 .github/workflows/* text eol=lf
 *.sh text eol=lf
+
+# GitHub Languages should emphasize the primary Rust/Tauri implementation.
+# PowerShell remains supported for installer, generated bundle, orchestration,
+# operational script, and test-harness surfaces.
+.githooks/*.ps1 linguist-detectable=false
+install.ps1 linguist-detectable=false
+scripts/*.ps1 linguist-detectable=false
+scripts/winsmux-core.ps1 linguist-generated=true
+tasks/*.psd1 linguist-detectable=false
+tests/*.ps1 linguist-detectable=false
+winsmux-core/*.ps1 linguist-detectable=false
+winsmux-core/scripts/*.ps1 linguist-detectable=false
+core/scripts/*.ps1 linguist-detectable=false
+core/tests/*.ps1 linguist-detectable=false

--- a/README.ja.md
+++ b/README.ja.md
@@ -18,6 +18,8 @@
 - オペレーターがペインを読み、送信し、中断し、状態を確認できます。
 - 分離を有効にすると、ワーカーごとに別々の git ワークツリーを使えます。
 - 記録済みの実行結果を比較し、採用する実行を選ぶ前に両方の実行で変更されたファイルを確認できます。
+- 記録済みの実行について、レビュー、検証、アーキテクチャ、チェックポイント、後続作業の証跡を確認できます。
+- 生の端末ログやローカル環境固有のパスを保存せず、構造化された実行終了時のスナップショットを残せます。
 - 選択した資格情報を Windows DPAPI で保護し、リポジトリに `.env` ファイルを置かずに扱えます。
 - レビューや監査に使う検証証跡を残せます。
 
@@ -31,6 +33,7 @@ Windows PC で複数のコーディングエージェントを動かしつつ、
 - ワーカーごとのファイル変更を分けたい。
 - 最終要約を待たず、実行中のペインを直接見たい。
 - 変更を受け入れる前にレビュー証跡を確認したい。
+- 後から再開または比較できる形で、実行の文脈を残したい。
 - 特定のモデルベンダーに運用を固定したくない。
 
 ターミナルマルチプレクサとしてだけ使いたい場合は、[`core/docs`](core/docs) を参照してください。
@@ -94,6 +97,7 @@ winsmux health-check
 winsmux compare runs <left_run_id> <right_run_id>
 winsmux compare preflight <left_ref> <right_ref>
 winsmux compare promote <run_id>
+winsmux skills --json
 ```
 
 | コマンド | 用途 |
@@ -105,6 +109,7 @@ winsmux compare promote <run_id>
 | `winsmux compare runs` | 2 つの記録済み実行の証跡と信頼度を比較 |
 | `winsmux compare preflight` | マージ前や比較レビュー前に 2 つの参照を確認 |
 | `winsmux compare promote` | 成功した実行結果を、次の実行で使う入力として書き出す |
+| `winsmux skills` | エージェントが読めるコマンド仕様を出力 |
 | `winsmux read` | 操作前にペイン出力を読む |
 | `winsmux send` | ペインへテキストを送る |
 | `winsmux vault set` | 資格情報を Windows DPAPI で保護して保存 |

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ You keep local control. `winsmux` starts the panes, lets you read what each agen
 - Lets an operator read, send, interrupt, and check pane health.
 - Keeps worker agents in separate git worktrees when isolation is enabled.
 - Compares recorded runs and highlights shared changed files before you choose a winner.
+- Shows review, verification, architecture, checkpoint, and follow-up evidence for recorded runs.
+- Captures structured end-of-run snapshots without storing raw terminal transcripts or private local paths.
 - Stores selected credentials with Windows DPAPI instead of writing repository `.env` files.
 - Records review and verification evidence for later audit.
 
@@ -31,6 +33,7 @@ It is especially useful when you want to:
 - Keep each worker's file changes separated.
 - See live pane output instead of waiting for a final summary.
 - Require review evidence before accepting changes.
+- Preserve enough structured context to resume or compare runs later.
 - Avoid tying the workflow to one model vendor.
 
 If you only need a terminal multiplexer, see the runtime docs under [`core/docs`](core/docs).

--- a/docs/operator-model.md
+++ b/docs/operator-model.md
@@ -76,6 +76,22 @@ winsmux may learn from public harness structures, checklists, and policy shapes.
 It does not treat a generic persona prompt as a public product capability.
 The durable public contract is slot capability, evidence shape, and operator-owned final judgement.
 
+## 2b. Run context and recovery contracts
+
+Recent winsmux releases treat run context as structured data rather than a copied chat transcript.
+
+The public contract is:
+
+- each run may carry a structured handoff package for the next pane or follow-up run
+- checkpoint packages record changed-file summaries, review state, verification state, and public worktree references
+- end-of-run snapshots record what can be safely resumed without storing raw terminal transcripts, private local paths, or private prompt bodies
+- context budgets describe why a pane received a bounded context packet instead of the full conversation
+- architecture contracts record drift score, baseline status, review requirement, and whether a gate should stop
+- managed follow-up contracts describe the next run candidate after a compare or promote decision
+- diversity policy records describe model or slot tradeoffs without exposing private provider routing details
+
+These contracts are designed for local-first operation. They make later review, comparison, and recovery possible while keeping the operator responsible for the final decision.
+
 ## 3. Pane execution layer
 
 The managed pane layer is where agent CLIs run inside winsmux-controlled panes or slots.
@@ -151,6 +167,7 @@ The Tauri desktop direction follows the same contract:
 - **context side sheet** for run, slot, evidence, branch, and review state
 - **secondary editor surface** for source-level drill-down
 - **terminal drawer** for raw PTY and diagnostics only
+- **decision cockpit** for verification, review, security, architecture, and operator-decision gates
 
 The roadmap groups these desktop surfaces into three UX layers:
 

--- a/winsmux-app/README.md
+++ b/winsmux-app/README.md
@@ -1,7 +1,35 @@
-# Tauri + Vanilla TS
+# winsmux desktop app
 
-This template should help get you started developing with Tauri in vanilla HTML, CSS and Typescript.
+This directory contains the Tauri desktop control plane for `winsmux`.
 
-## Recommended IDE Setup
+The desktop app is not a replacement for the CLI. It presents the same local-first operator contract through a denser UI:
 
-- [VS Code](https://code.visualstudio.com/) + [Tauri](https://marketplace.visualstudio.com/items?itemName=tauri-apps.tauri-vscode) + [rust-analyzer](https://marketplace.visualstudio.com/items?itemName=rust-lang.rust-analyzer)
+- workspace sidebar for sessions, files, and source-control summary
+- conversation shell for the operator-facing run stream
+- context side sheet for run, slot, branch, evidence, and review state
+- decision cockpit for verification, review, security, architecture, and operator-decision gates
+- terminal drawer for raw PTY output and diagnostics
+
+The app must not proxy AI service sign-in. Each pane agent keeps using its own official authentication setup.
+
+## Development
+
+Install dependencies from this directory:
+
+```powershell
+npm ci
+```
+
+Run a development build:
+
+```powershell
+npm run build
+```
+
+Run the viewport harness when changing desktop UI layout:
+
+```powershell
+npm run test:viewport-harness
+```
+
+Tauri commands live under `src-tauri`. Frontend code lives under `src`.


### PR DESCRIPTION
## Summary
- update README and operator model docs for structured run evidence, end-of-run snapshots, context budgets, architecture gates, and the desktop decision cockpit
- replace the default Tauri app README with winsmux desktop control-plane documentation
- add GitHub Linguist attributes so installer, generated bundle, orchestration, operational script, and test-harness PowerShell surfaces do not dominate the repository language bar

## Validation
- git diff --check
- pwsh -NoProfile -File scripts\git-guard.ps1
- pwsh -NoProfile -File scripts\audit-public-surface.ps1
- Opus review: APPROVE, no blocking findings; non-blocking wording suggestions applied
- GitHub Release bodies for v0.24.13, v0.24.14, and v0.24.15 verified after reformatting
- Issues #714, #455, #524, and #715 closed with implementation comments