### PR TITLE
feat: add configurable meta-planning roles

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -73,6 +73,7 @@ winsmux compare runs <left_run_id> <right_run_id>
 winsmux compare preflight <left_ref> <right_ref>
 winsmux compare promote <run_id>
 winsmux meta-plan --task "この変更を計画して" --json
+winsmux meta-plan --task "この変更を計画して" --roles .winsmux/meta-plan-roles.yaml --review-rounds 2 --json
 winsmux skills --json
 ```
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ winsmux compare runs <left_run_id> <right_run_id>
 winsmux compare preflight <left_ref> <right_ref>
 winsmux compare promote <run_id>
 winsmux meta-plan --task "Plan this change" --json
+winsmux meta-plan --task "Plan this change" --roles .winsmux/meta-plan-roles.yaml --review-rounds 2 --json
 winsmux skills --json
 ```
 

--- a/core/src/operator_cli.rs
+++ b/core/src/operator_cli.rs
@@ -10,7 +10,7 @@ use std::{
 };
 
 use chrono::{DateTime, SecondsFormat, Utc};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::{json, Map, Value};
 use sha2::{Digest, Sha256};
 
@@ -2886,18 +2886,33 @@ struct MetaPlanOptions {
     project_dir: PathBuf,
     task: String,
     session_name: String,
+    role_file: Option<PathBuf>,
+    review_rounds: Option<u8>,
 }
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 struct MetaPlanRole {
+    #[serde(alias = "role-id")]
     role_id: String,
     label: String,
     provider: String,
     model: String,
+    #[serde(alias = "plan-mode")]
     plan_mode: String,
+    #[serde(alias = "read-only")]
     read_only: bool,
+    #[serde(default, alias = "review-rounds")]
+    review_rounds: u8,
+    #[serde(default)]
     capabilities: Vec<String>,
+    #[serde(default)]
     prompt: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct MetaPlanRoleFile {
+    version: u32,
+    roles: Vec<MetaPlanRole>,
 }
 
 struct MetaPlanRun {
@@ -3032,6 +3047,8 @@ fn parse_meta_plan_options(args: &[&String]) -> io::Result<MetaPlanOptions> {
     let mut project_dir = None;
     let mut task = String::new();
     let mut session_name = "winsmux-orchestra".to_string();
+    let mut role_file = None;
+    let mut review_rounds = None;
     let mut trailing_task_parts = Vec::new();
     let mut index = 0;
 
@@ -3051,6 +3068,21 @@ fn parse_meta_plan_options(args: &[&String]) -> io::Result<MetaPlanOptions> {
             }
             "--session" => {
                 session_name = required_option_value(args, index, "--session")?;
+                index += 2;
+            }
+            "--roles" => {
+                role_file = Some(PathBuf::from(required_option_value(args, index, "--roles")?));
+                index += 2;
+            }
+            "--review-rounds" => {
+                let value = required_option_value(args, index, "--review-rounds")?;
+                let parsed = value.parse::<u8>().map_err(|_| {
+                    io::Error::new(io::ErrorKind::InvalidInput, "--review-rounds must be 1 or 2")
+                })?;
+                if !matches!(parsed, 1 | 2) {
+                    return Err(io::Error::new(io::ErrorKind::InvalidInput, "--review-rounds must be 1 or 2"));
+                }
+                review_rounds = Some(parsed);
                 index += 2;
             }
             value if value.starts_with('-') => {
@@ -3081,11 +3113,14 @@ fn parse_meta_plan_options(args: &[&String]) -> io::Result<MetaPlanOptions> {
         project_dir: project_dir.unwrap_or(env::current_dir()?),
         task: task.trim().to_string(),
         session_name: session_name.trim().to_string(),
+        role_file,
+        review_rounds,
     })
 }
 
 fn build_meta_plan_run(options: &MetaPlanOptions) -> io::Result<MetaPlanRun> {
-    let roles = default_meta_plan_roles();
+    let (roles, role_source) = resolve_meta_plan_roles(options)?;
+    let review_rounds = effective_meta_plan_review_rounds(options.review_rounds, &roles);
     let run_id = format!("meta-{}", unique_artifact_id());
     let run_dir = options.project_dir.join(".winsmux").join("meta-plans").join(&run_id);
     fs::create_dir_all(&run_dir)?;
@@ -3109,6 +3144,13 @@ fn build_meta_plan_run(options: &MetaPlanOptions) -> io::Result<MetaPlanRun> {
             "selected_roles": role_ids,
             "operator_pane": env::var("WINSMUX_PANE_ID").unwrap_or_default(),
             "read_only_principle": true,
+            "role_source": role_source.clone(),
+            "review_rounds": review_rounds,
+            "shield_harness": {
+                "role_definition_policy": "read_only_required",
+                "provider_allowlist": ["claude", "codex"],
+                "private_prompt_bodies_in_audit": false,
+            },
         }),
     )?;
 
@@ -3129,6 +3171,7 @@ fn build_meta_plan_run(options: &MetaPlanOptions) -> io::Result<MetaPlanRun> {
                 "model": role.model.clone(),
                 "plan_mode": role.plan_mode.clone(),
                 "read_only": role.read_only,
+                "review_rounds": role.review_rounds,
                 "launch_contract": meta_plan_launch_contract(role),
             }),
         )?;
@@ -3159,46 +3202,48 @@ fn build_meta_plan_run(options: &MetaPlanOptions) -> io::Result<MetaPlanRun> {
             "model": role.model.clone(),
             "plan_mode": role.plan_mode.clone(),
             "read_only": role.read_only,
+            "review_rounds": role.review_rounds,
             "capabilities": role.capabilities.clone(),
             "draft_ref": draft_ref.clone(),
             "launch_contract": meta_plan_launch_contract(role),
         }));
     }
 
-    let review_rounds = 1_u8;
     let mut review_refs = Vec::new();
     let mut review_payloads = Vec::new();
-    for reviewer in &roles {
-        for target in &roles {
-            if reviewer.role_id == target.role_id {
-                continue;
-            }
-            let review_path = run_dir.join(format!("{}-reviews-{}-round-1.md", reviewer.role_id, target.role_id));
-            write_text_file_with_lock(&review_path, &render_meta_plan_cross_review(&run_id, reviewer, target))?;
-            let review_ref = artifact_reference(&options.project_dir, &review_path);
-            review_refs.push(review_ref.clone());
-            review_payloads.push(json!({
-                "round": 1,
-                "reviewer_role_id": reviewer.role_id.clone(),
-                "target_role_id": target.role_id.clone(),
-                "review_ref": review_ref.clone(),
-                "blocking": false,
-            }));
-            append_meta_plan_audit_record(
-                &options.project_dir,
-                &options.session_name,
-                "cross_review",
-                "Cross-planning review artifact recorded.",
-                &reviewer.role_id,
-                json!({
-                    "run_id": run_id.clone(),
-                    "round": 1,
+    for round in 1..=review_rounds {
+        for reviewer in &roles {
+            for target in &roles {
+                if reviewer.role_id == target.role_id {
+                    continue;
+                }
+                let review_path = run_dir.join(format!("{}-reviews-{}-round-{}.md", reviewer.role_id, target.role_id, round));
+                write_text_file_with_lock(&review_path, &render_meta_plan_cross_review(&run_id, reviewer, target, round))?;
+                let review_ref = artifact_reference(&options.project_dir, &review_path);
+                review_refs.push(review_ref.clone());
+                review_payloads.push(json!({
+                    "round": round,
                     "reviewer_role_id": reviewer.role_id.clone(),
                     "target_role_id": target.role_id.clone(),
                     "review_ref": review_ref.clone(),
                     "blocking": false,
-                }),
-            )?;
+                }));
+                append_meta_plan_audit_record(
+                    &options.project_dir,
+                    &options.session_name,
+                    "cross_review",
+                    "Cross-planning review artifact recorded.",
+                    &reviewer.role_id,
+                    json!({
+                        "run_id": run_id.clone(),
+                        "round": round,
+                        "reviewer_role_id": reviewer.role_id.clone(),
+                        "target_role_id": target.role_id.clone(),
+                        "review_ref": review_ref.clone(),
+                        "blocking": false,
+                    }),
+                )?;
+            }
         }
     }
 
@@ -3246,6 +3291,7 @@ fn build_meta_plan_run(options: &MetaPlanOptions) -> io::Result<MetaPlanRun> {
         "task_hash": task_hash,
         "task_preview": task_preview,
         "roles": role_payloads,
+        "role_source": role_source,
         "review_rounds": review_rounds,
         "cross_reviews": review_payloads,
         "integrated_plan_ref": integrated_plan_ref.clone(),
@@ -3277,6 +3323,7 @@ fn default_meta_plan_roles() -> Vec<MetaPlanRole> {
             model: "sonnet".to_string(),
             plan_mode: "required".to_string(),
             read_only: true,
+            review_rounds: 1,
             capabilities: vec!["facts".to_string(), "constraints".to_string()],
             prompt: "Gather facts, constraints, and unknowns. Do not edit files.".to_string(),
         },
@@ -3287,10 +3334,86 @@ fn default_meta_plan_roles() -> Vec<MetaPlanRole> {
             model: "gpt-5.4".to_string(),
             plan_mode: "read_only_equivalent".to_string(),
             read_only: true,
+            review_rounds: 1,
             capabilities: vec!["risk".to_string(), "tests".to_string()],
             prompt: "Find risks, missing tests, and failure modes. Do not edit files.".to_string(),
         },
     ]
+}
+
+fn resolve_meta_plan_roles(options: &MetaPlanOptions) -> io::Result<(Vec<MetaPlanRole>, String)> {
+    let Some(role_file) = options.role_file.as_ref() else {
+        return Ok((default_meta_plan_roles(), "default_fixed_mvp".to_string()));
+    };
+
+    let raw = fs::read_to_string(role_file)?;
+    let parsed: MetaPlanRoleFile = serde_yaml::from_str(&raw).map_err(|err| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("invalid meta-plan role YAML at '{}': {err}", role_file.display()),
+        )
+    })?;
+    if parsed.version != 1 {
+        return Err(io::Error::new(io::ErrorKind::InvalidData, "meta-plan role YAML version must be 1"));
+    }
+    if parsed.roles.len() < 3 {
+        return Err(io::Error::new(io::ErrorKind::InvalidInput, "--roles must define at least three planning roles"));
+    }
+
+    for role in &parsed.roles {
+        validate_meta_plan_role(role)?;
+    }
+
+    Ok((parsed.roles, meta_plan_role_source(role_file, &raw)))
+}
+
+fn validate_meta_plan_role(role: &MetaPlanRole) -> io::Result<()> {
+    if role.role_id.trim().is_empty()
+        || !role.role_id.chars().all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-'))
+    {
+        return Err(io::Error::new(io::ErrorKind::InvalidInput, "meta-plan role_id must be non-empty ASCII alphanumeric, '-' or '_'"));
+    }
+    if role.label.trim().is_empty() {
+        return Err(io::Error::new(io::ErrorKind::InvalidInput, format!("meta-plan role '{}' label must not be empty", role.role_id)));
+    }
+    if !matches!(role.provider.as_str(), "claude" | "codex") {
+        return Err(io::Error::new(io::ErrorKind::InvalidInput, format!("meta-plan role '{}' provider must be claude or codex", role.role_id)));
+    }
+    if role.model.trim().is_empty() {
+        return Err(io::Error::new(io::ErrorKind::InvalidInput, format!("meta-plan role '{}' model must not be empty", role.role_id)));
+    }
+    if !role.read_only {
+        return Err(io::Error::new(io::ErrorKind::InvalidInput, format!("meta-plan role '{}' must set read_only: true", role.role_id)));
+    }
+    if !matches!(role.plan_mode.as_str(), "required" | "read_only_equivalent") {
+        return Err(io::Error::new(io::ErrorKind::InvalidInput, format!("meta-plan role '{}' plan_mode must be required or read_only_equivalent", role.role_id)));
+    }
+    if role.provider == "claude" && role.plan_mode != "required" {
+        return Err(io::Error::new(io::ErrorKind::InvalidInput, format!("meta-plan role '{}' must use plan_mode: required for Claude Code", role.role_id)));
+    }
+    if role.provider == "codex" && role.plan_mode != "read_only_equivalent" {
+        return Err(io::Error::new(io::ErrorKind::InvalidInput, format!("meta-plan role '{}' must use plan_mode: read_only_equivalent for Codex CLI", role.role_id)));
+    }
+    if !matches!(role.review_rounds, 0 | 1 | 2) {
+        return Err(io::Error::new(io::ErrorKind::InvalidInput, format!("meta-plan role '{}' review_rounds must be omitted, 1, or 2", role.role_id)));
+    }
+    Ok(())
+}
+
+fn effective_meta_plan_review_rounds(requested: Option<u8>, roles: &[MetaPlanRole]) -> u8 {
+    requested.unwrap_or_else(|| {
+        roles
+            .iter()
+            .map(|role| role.review_rounds)
+            .max()
+            .filter(|value| matches!(value, 1 | 2))
+            .unwrap_or(1)
+    })
+}
+
+fn meta_plan_role_source(path: &Path, raw: &str) -> String {
+    let name = path.file_name().and_then(|name| name.to_str()).unwrap_or("roles.yaml");
+    format!("yaml:{name}:sha256:{}", sha256_hex(raw.as_bytes()))
 }
 
 fn meta_plan_launch_contract(role: &MetaPlanRole) -> Value {
@@ -3324,8 +3447,8 @@ fn render_meta_plan_role_draft(run_id: &str, task: &str, role: &MetaPlanRole) ->
     format!("# Meta-Planning Draft: {label}\n\nRun: `{run_id}`\nRole: `{role_id}`\nProvider: `{provider}`\nPlan mode: `{plan_mode}`\nRead-only: `{read_only}`\n\n## Task\n\n{task}\n\n## Responsibility\n\n{prompt}\n\n## Draft Plan\n\n- Confirm facts and constraints for this role.\n- Identify assumptions that must be carried into the integrated plan.\n- Keep all recommendations side-effect-free until operator approval.\n\n## Evidence To Collect\n\n- Existing repository contracts and tests relevant to this role.\n- Gaps, risks, or open questions for the operator to merge.\n", label = &role.label, role_id = &role.role_id, provider = &role.provider, plan_mode = &role.plan_mode, read_only = role.read_only, prompt = &role.prompt)
 }
 
-fn render_meta_plan_cross_review(run_id: &str, reviewer: &MetaPlanRole, target: &MetaPlanRole) -> String {
-    format!("# Cross-Planning Review\n\nRun: `{run_id}`\nReviewer: `{reviewer}`\nTarget: `{target}`\nRound: `1`\n\n## Review Checklist\n\n- Check whether the target plan stays read-only.\n- Check whether missing tests or approval gates are visible.\n- Check whether unresolved questions need operator attention.\n\n## Findings\n\nNo blocking finding is recorded in the scaffold. A live worker review can replace this artifact before operator approval.\n", reviewer = &reviewer.role_id, target = &target.role_id)
+fn render_meta_plan_cross_review(run_id: &str, reviewer: &MetaPlanRole, target: &MetaPlanRole, round: u8) -> String {
+    format!("# Cross-Planning Review\n\nRun: `{run_id}`\nReviewer: `{reviewer}`\nTarget: `{target}`\nRound: `{round}`\n\n## Review Checklist\n\n- Check whether the target plan stays read-only.\n- Check whether missing tests or approval gates are visible.\n- Check whether unresolved questions need operator attention.\n\n## Findings\n\nNo blocking finding is recorded in the scaffold. A live worker review can replace this artifact before operator approval.\n", reviewer = &reviewer.role_id, target = &target.role_id)
 }
 
 fn render_meta_plan_integrated_plan(run_id: &str, task: &str, roles: &[MetaPlanRole], draft_refs: &[String], review_refs: &[String]) -> String {
@@ -4021,7 +4144,7 @@ fn usage_for(command: &str) -> &'static str {
         "digest" => "usage: winsmux digest [--json] [--project-dir <path>]",
         "desktop-summary" => "usage: winsmux desktop-summary [--json] [--stream] [--project-dir <path>]",
         "meta-plan" => {
-            "usage: winsmux meta-plan --task <text> [--json] [--project-dir <path>] [--session <name>]"
+            "usage: winsmux meta-plan --task <text> [--roles <path>] [--review-rounds <1|2>] [--json] [--project-dir <path>] [--session <name>]"
         }
         "provider-capabilities" => {
             "usage: winsmux provider-capabilities [provider] [--json] [--project-dir <path>]"

--- a/core/tests-rs/operator_cli.rs
+++ b/core/tests-rs/operator_cli.rs
@@ -190,6 +190,133 @@ fn operator_cli_meta_plan_json_writes_plan_artifacts_and_audit_log() {
 }
 
 #[test]
+fn operator_cli_meta_plan_roles_yaml_preserves_japanese_and_two_review_rounds() {
+    let project_dir = make_temp_project_dir("meta-plan-roles-yaml");
+    let role_file = project_dir.join("roles.yaml");
+    fs::write(
+        &role_file,
+        r#"version: 1
+roles:
+  - role_id: investigator
+    label: "調査役"
+    provider: claude
+    model: sonnet
+    plan_mode: required
+    read_only: true
+    review_rounds: 2
+    capabilities: [facts, constraints]
+    prompt: |
+      日本語コメントを壊さず、事実と制約を集める。
+  - role_id: verifier
+    label: "検証役"
+    provider: codex
+    model: gpt-5.4
+    plan_mode: read_only_equivalent
+    read_only: true
+    review_rounds: 2
+    capabilities: [risk, tests]
+    prompt: |
+      回帰リスクと不足テストを確認する。
+  - role_id: advocate
+    label: "利用者代弁役"
+    provider: codex
+    model: gpt-5.4
+    plan_mode: read_only_equivalent
+    read_only: true
+    review_rounds: 2
+    capabilities: [acceptance]
+    prompt: |
+      利用者の受け入れ条件を整理する。
+"#,
+    )
+    .expect("test should write role YAML");
+
+    let role_file_text = role_file.to_string_lossy().to_string();
+    let json = run_json(
+        &project_dir,
+        &[
+            "meta-plan",
+            "--task",
+            "日本語IME対応のロール計画",
+            "--roles",
+            &role_file_text,
+            "--review-rounds",
+            "2",
+            "--json",
+        ],
+    );
+
+    assert_eq!(json["roles"].as_array().expect("roles should be an array").len(), 3);
+    assert_eq!(json["roles"][0]["label"], "調査役");
+    assert_eq!(json["roles"][2]["label"], "利用者代弁役");
+    assert_eq!(json["review_rounds"], 2);
+    assert!(json["role_source"].as_str().unwrap_or_default().starts_with("yaml:roles.yaml:sha256:"));
+    assert_eq!(json["cross_reviews"].as_array().expect("cross reviews should be an array").len(), 12);
+
+    let draft_ref = json["roles"][0]["draft_ref"]
+        .as_str()
+        .expect("draft ref should be present");
+    let draft_path = project_dir.join(draft_ref.replace('/', std::path::MAIN_SEPARATOR_STR));
+    let draft = fs::read_to_string(draft_path).expect("test should read draft");
+    assert!(draft.contains("日本語コメントを壊さず、事実と制約を集める。"));
+
+    let audit_ref = json["audit_log_ref"]
+        .as_str()
+        .expect("audit log ref should be present");
+    let audit_path = project_dir.join(audit_ref.replace('/', std::path::MAIN_SEPARATOR_STR));
+    let audit_raw = fs::read_to_string(audit_path).expect("test should read audit log");
+    assert_eq!(audit_raw.lines().filter(|line| line.contains("\"event\":\"cross_review\"")).count(), 12);
+}
+
+#[test]
+fn operator_cli_meta_plan_roles_yaml_rejects_mutating_roles() {
+    let project_dir = make_temp_project_dir("meta-plan-roles-yaml-reject");
+    let role_file = project_dir.join("roles.yaml");
+    fs::write(
+        &role_file,
+        r#"version: 1
+roles:
+  - role_id: investigator
+    label: "調査役"
+    provider: claude
+    model: sonnet
+    plan_mode: required
+    read_only: false
+  - role_id: verifier
+    label: "検証役"
+    provider: codex
+    model: gpt-5.4
+    plan_mode: read_only_equivalent
+    read_only: true
+  - role_id: advocate
+    label: "利用者代弁役"
+    provider: codex
+    model: gpt-5.4
+    plan_mode: read_only_equivalent
+    read_only: true
+"#,
+    )
+    .expect("test should write role YAML");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .args([
+            "meta-plan",
+            "--task",
+            "reject mutating role",
+            "--roles",
+            role_file.to_str().expect("path should be utf-8"),
+            "--json",
+        ])
+        .current_dir(&project_dir)
+        .output()
+        .expect("winsmux command should run");
+
+    assert!(!output.status.success(), "meta-plan should reject mutating roles");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("must set read_only: true"), "{stderr}");
+}
+
+#[test]
 fn operator_cli_explain_text_reads_live_winsmux_manifest() {
     let project_dir = make_temp_project_dir("explain-text");
     write_manifest(&project_dir);

--- a/docs/meta-planning-layer-design.md
+++ b/docs/meta-planning-layer-design.md
@@ -10,6 +10,10 @@ The command writes role draft artifacts, cross-review artifacts, an integrated
 Markdown plan, and JSONL audit events under `.winsmux/`. Workers remain
 read-only, and the operator keeps the single approval gate.
 
+`v0.24.19` adds UTF-8 role YAML loading through `--roles <path>` and supports
+one or two cross-review rounds through `--review-rounds <1|2>`. Role labels and
+prompts may contain Japanese text, while `role_id` remains ASCII for logs.
+
 ## Goal
 
 Add a meta-planning layer above the normal operator execution flow.

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -10896,7 +10896,7 @@ Commands:
   consult-request <mode> [--message <text>] [--target-slot <slot>]  Record a consultation request packet/event
   consult-result <mode> [--message <text>] [--target-slot <slot>] [--confidence <0..1>] [--next-test <text>] [--risk <text>] [--run-id <run_id>] [--json]  Record a consultation result packet/event
   consult-error <mode> [--message <text>] [--target-slot <slot>]  Record a consultation error packet/event
-  meta-plan --task <text> [--json] [--project-dir <path>] [--session <name>]  Draft a read-only multi-role planning packet
+  meta-plan --task <text> [--roles <path>] [--review-rounds <1|2>] [--json] [--project-dir <path>] [--session <name>]  Draft a read-only multi-role planning packet
   provider-capabilities [provider] [--json]  Inspect the provider capability registry contract
   skills [--json]  Print agent-readable command skill contracts
   machine-contract --json  Print the hook and agent machine contract JSON

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -11551,7 +11551,7 @@ Describe 'winsmux meta-plan command' {
     }
 
     It 'documents meta-plan in usage and delegates to the Rust meta-plan contract' {
-        $script:winsmuxMetaPlanCoreRawContent | Should -Match 'meta-plan --task <text> \[--json\] \[--project-dir <path>\] \[--session <name>\]'
+        $script:winsmuxMetaPlanCoreRawContent | Should -Match 'meta-plan --task <text> \[--roles <path>\] \[--review-rounds <1\|2>\] \[--json\] \[--project-dir <path>\] \[--session <name>\]'
         $script:winsmuxMetaPlanCoreRawContent | Should -Match "'meta-plan'\s*\{ Invoke-MetaPlan \}"
 
         Mock Invoke-WinsmuxRaw {
@@ -11560,9 +11560,9 @@ Describe 'winsmux meta-plan command' {
             return '{"command":"meta-plan","roles":[{"role_id":"investigator"},{"role_id":"verifier"}],"audit_events":["meta_plan_init","role_assigned","plan_drafted","cross_review","plan_merged","exit_plan_mode"]}'
         }
 
-        $output = Invoke-MetaPlan -MetaPlanTarget '--task' -MetaPlanRest @('日本語IME対応', '--json')
+        $output = Invoke-MetaPlan -MetaPlanTarget '--task' -MetaPlanRest @('日本語IME対応', '--roles', 'roles.yaml', '--review-rounds', '2', '--json')
         $json = $output | ConvertFrom-Json
-        $script:metaPlanArgs | Should -Be @('meta-plan', '--task', '日本語IME対応', '--json')
+        $script:metaPlanArgs | Should -Be @('meta-plan', '--task', '日本語IME対応', '--roles', 'roles.yaml', '--review-rounds', '2', '--json')
         $json.command | Should -Be 'meta-plan'
         @($json.roles.role_id) | Should -Be @('investigator', 'verifier')
         $json.audit_events | Should -Contain 'exit_plan_mode'


### PR DESCRIPTION
## Summary

- add `winsmux meta-plan --roles <path>` for UTF-8 role YAML
- add `winsmux meta-plan --review-rounds <1|2>` for one or two cross-review rounds
- validate role definitions as read-only and record role source/review metadata in JSONL audit payloads
- update README usage, design notes, wrapper usage, and tests

## Validation

- `cargo check`
- `cargo test -p winsmux --test operator_cli operator_cli_meta_plan`
- `cargo test -p winsmux --test operator_cli`
- `Invoke-Pester -Path tests/winsmux-bridge.Tests.ps1 -FullName 'winsmux meta-plan command'`
- `git diff --check`
- `bash .git/hooks/pre-commit`

## Review

- External `codex exec` review was not rerun because the approval policy blocks exporting uncommitted diff without explicit user approval.
- Local manual diff review was completed for this scoped change.
