### PR TITLE
fix: harden retained planning evidence

### DIFF
--- a/core/src/operator_cli.rs
+++ b/core/src/operator_cli.rs
@@ -3150,6 +3150,7 @@ fn build_meta_plan_run(options: &MetaPlanOptions) -> io::Result<MetaPlanRun> {
                 "role_definition_policy": "read_only_required",
                 "provider_allowlist": ["claude", "codex"],
                 "private_prompt_bodies_in_audit": false,
+                "private_prompt_bodies_in_artifacts": false,
             },
         }),
     )?;
@@ -3157,6 +3158,7 @@ fn build_meta_plan_run(options: &MetaPlanOptions) -> io::Result<MetaPlanRun> {
     let mut draft_refs = Vec::new();
     let mut role_payloads = Vec::new();
     for role in &roles {
+        let prompt_hash = sha256_hex(role.prompt.as_bytes());
         append_meta_plan_audit_record(
             &options.project_dir,
             &options.session_name,
@@ -3172,12 +3174,13 @@ fn build_meta_plan_run(options: &MetaPlanOptions) -> io::Result<MetaPlanRun> {
                 "plan_mode": role.plan_mode.clone(),
                 "read_only": role.read_only,
                 "review_rounds": role.review_rounds,
+                "prompt_hash": prompt_hash.clone(),
                 "launch_contract": meta_plan_launch_contract(role),
             }),
         )?;
 
         let draft_path = run_dir.join(format!("{}-draft.md", role.role_id));
-        write_text_file_with_lock(&draft_path, &render_meta_plan_role_draft(&run_id, &options.task, role))?;
+        write_text_file_with_lock(&draft_path, &render_meta_plan_role_draft(&run_id, &task_hash, role, &prompt_hash))?;
         let draft_ref = artifact_reference(&options.project_dir, &draft_path);
         draft_refs.push(draft_ref.clone());
         append_meta_plan_audit_record(
@@ -3204,6 +3207,7 @@ fn build_meta_plan_run(options: &MetaPlanOptions) -> io::Result<MetaPlanRun> {
             "read_only": role.read_only,
             "review_rounds": role.review_rounds,
             "capabilities": role.capabilities.clone(),
+            "prompt_hash": prompt_hash.clone(),
             "draft_ref": draft_ref.clone(),
             "launch_contract": meta_plan_launch_contract(role),
         }));
@@ -3250,7 +3254,7 @@ fn build_meta_plan_run(options: &MetaPlanOptions) -> io::Result<MetaPlanRun> {
     let integrated_plan_path = run_dir.join("integrated-plan.md");
     write_text_file_with_lock(
         &integrated_plan_path,
-        &render_meta_plan_integrated_plan(&run_id, &options.task, &roles, &draft_refs, &review_refs),
+        &render_meta_plan_integrated_plan(&run_id, &task_hash, &roles, &draft_refs, &review_refs),
     )?;
     let integrated_plan_ref = artifact_reference(&options.project_dir, &integrated_plan_path);
 
@@ -3443,19 +3447,19 @@ fn meta_plan_launch_contract(role: &MetaPlanRole) -> Value {
     }
 }
 
-fn render_meta_plan_role_draft(run_id: &str, task: &str, role: &MetaPlanRole) -> String {
-    format!("# Meta-Planning Draft: {label}\n\nRun: `{run_id}`\nRole: `{role_id}`\nProvider: `{provider}`\nPlan mode: `{plan_mode}`\nRead-only: `{read_only}`\n\n## Task\n\n{task}\n\n## Responsibility\n\n{prompt}\n\n## Draft Plan\n\n- Confirm facts and constraints for this role.\n- Identify assumptions that must be carried into the integrated plan.\n- Keep all recommendations side-effect-free until operator approval.\n\n## Evidence To Collect\n\n- Existing repository contracts and tests relevant to this role.\n- Gaps, risks, or open questions for the operator to merge.\n", label = &role.label, role_id = &role.role_id, provider = &role.provider, plan_mode = &role.plan_mode, read_only = role.read_only, prompt = &role.prompt)
+fn render_meta_plan_role_draft(run_id: &str, task_hash: &str, role: &MetaPlanRole, prompt_hash: &str) -> String {
+    format!("# Meta-Planning Draft: {label}\n\nRun: `{run_id}`\nRole: `{role_id}`\nProvider: `{provider}`\nPlan mode: `{plan_mode}`\nRead-only: `{read_only}`\nTask hash: `{task_hash}`\nRole prompt hash: `{prompt_hash}`\n\n## Task\n\nThe task body is not stored in this artifact. Use the task hash and audit event references to correlate the operator-owned request.\n\n## Responsibility\n\nThe role prompt body is not stored in this artifact by default. Use the prompt hash and role definition source to correlate the role contract.\n\n## Draft Plan\n\n- Confirm facts and constraints for this role.\n- Identify assumptions that must be carried into the integrated plan.\n- Keep all recommendations side-effect-free until operator approval.\n\n## Evidence To Collect\n\n- Existing repository contracts and tests relevant to this role.\n- Gaps, risks, or open questions for the operator to merge.\n", label = &role.label, role_id = &role.role_id, provider = &role.provider, plan_mode = &role.plan_mode, read_only = role.read_only)
 }
 
 fn render_meta_plan_cross_review(run_id: &str, reviewer: &MetaPlanRole, target: &MetaPlanRole, round: u8) -> String {
     format!("# Cross-Planning Review\n\nRun: `{run_id}`\nReviewer: `{reviewer}`\nTarget: `{target}`\nRound: `{round}`\n\n## Review Checklist\n\n- Check whether the target plan stays read-only.\n- Check whether missing tests or approval gates are visible.\n- Check whether unresolved questions need operator attention.\n\n## Findings\n\nNo blocking finding is recorded in the scaffold. A live worker review can replace this artifact before operator approval.\n", reviewer = &reviewer.role_id, target = &target.role_id)
 }
 
-fn render_meta_plan_integrated_plan(run_id: &str, task: &str, roles: &[MetaPlanRole], draft_refs: &[String], review_refs: &[String]) -> String {
+fn render_meta_plan_integrated_plan(run_id: &str, task_hash: &str, roles: &[MetaPlanRole], draft_refs: &[String], review_refs: &[String]) -> String {
     let role_lines = roles.iter().map(|role| format!("- `{}`: {} via `{}`", role.role_id, role.label, role.provider)).collect::<Vec<_>>().join("\n");
     let draft_lines = draft_refs.iter().map(|reference| format!("- `{reference}`")).collect::<Vec<_>>().join("\n");
     let review_lines = review_refs.iter().map(|reference| format!("- `{reference}`")).collect::<Vec<_>>().join("\n");
-    format!("# Integrated Meta-Plan\n\nRun: `{run_id}`\n\n## Summary\n\n{task}\n\n## Key Changes\n\n- Run a two-role planning pass before execution.\n- Keep worker output as evidence and keep operator approval as the only approval point.\n\n## Interfaces And Data Flow\n\n{role_lines}\n\nDraft artifacts:\n\n{draft_lines}\n\nCross-review artifacts:\n\n{review_lines}\n\n## Safety And Approval Gates\n\n- Workers remain read-only and do not own execution approval.\n- The operator reviews this integrated plan and triggers the single user approval point.\n- JSONL audit events are written before execution.\n\n## Test Plan\n\n- Validate `winsmux meta-plan --json` output.\n- Validate required audit events and artifact references.\n- Validate that generated role contracts remain read-only.\n\n## Open Questions\n\n- Replace scaffold draft artifacts with live worker responses when panes are available.\n")
+    format!("# Integrated Meta-Plan\n\nRun: `{run_id}`\nTask hash: `{task_hash}`\n\n## Summary\n\nThe operator-owned task body is not stored in this scaffold artifact by default. The operator keeps the full request in the interactive approval flow.\n\n## Key Changes\n\n- Run a two-role planning pass before execution.\n- Keep worker output as evidence and keep operator approval as the only approval point.\n\n## Interfaces And Data Flow\n\n{role_lines}\n\nDraft artifacts:\n\n{draft_lines}\n\nCross-review artifacts:\n\n{review_lines}\n\n## Safety And Approval Gates\n\n- Workers remain read-only and do not own execution approval.\n- The operator reviews this integrated plan and triggers the single user approval point.\n- JSONL audit events are written before execution.\n- Private task and role prompt bodies are not retained in generated scaffold artifacts.\n\n## Test Plan\n\n- Validate `winsmux meta-plan --json` output.\n- Validate required audit events and artifact references.\n- Validate that generated role contracts remain read-only.\n- Validate that scaffold artifacts retain hashes instead of private prompt bodies.\n\n## Open Questions\n\n- Replace scaffold draft artifacts with live worker responses when panes are available.\n")
 }
 
 fn meta_plan_audit_log_path(project_dir: &Path, session_name: &str) -> PathBuf {

--- a/core/src/search_ledger.rs
+++ b/core/src/search_ledger.rs
@@ -11,6 +11,47 @@ use std::{
 
 const DEFAULT_LIMIT: usize = 20;
 const MAX_LIMIT: usize = 500;
+const SEARCH_LEDGER_DATA_ALLOWLIST: &[&str] = &[
+    "anchor",
+    "artifact_path",
+    "branch",
+    "category",
+    "commit",
+    "duration_ms",
+    "end_line",
+    "event_id",
+    "evidence_id",
+    "evidence_kind",
+    "exit_code",
+    "file",
+    "head_sha",
+    "hypothesis",
+    "issue",
+    "kind",
+    "label",
+    "line",
+    "next_action",
+    "note",
+    "path",
+    "pr",
+    "public_worktree_ref",
+    "reason",
+    "result",
+    "review_status",
+    "run_id",
+    "sha",
+    "source",
+    "source_path",
+    "source_ref",
+    "start_line",
+    "status",
+    "summary",
+    "task_id",
+    "test_plan",
+    "title",
+    "url",
+    "verification_status",
+];
 
 #[derive(Debug)]
 pub struct SearchLedger {
@@ -753,7 +794,7 @@ fn detail_json(event: &EventRecord) -> Value {
         "run_id": event_field_with_data_fallback(&event.run_id, event, "run_id"),
         "task_id": event_field_with_data_fallback(&event.task_id, event, "task_id"),
         "head_sha": event_field_with_data_fallback(&event.head_sha, event, "head_sha"),
-        "data": redact_sensitive_value("", &event.data),
+        "data": project_searchable_data_for_indexing(event),
     })
 }
 
@@ -806,6 +847,50 @@ fn should_index_event(event: &EventRecord) -> bool {
     }
 
     true
+}
+
+fn project_searchable_data_for_indexing(event: &EventRecord) -> Value {
+    let Some(data) = event.data.as_object() else {
+        return Value::Object(Map::new());
+    };
+
+    let mut projected = Map::new();
+    for (key, value) in data {
+        if is_search_ledger_private_data_key(key) || !is_search_ledger_allowlisted_data_key(key) {
+            continue;
+        }
+        projected.insert(key.clone(), redact_sensitive_value(key, value));
+    }
+
+    Value::Object(projected)
+}
+
+fn is_search_ledger_allowlisted_data_key(key: &str) -> bool {
+    let normalized = normalize_search_ledger_data_key(key);
+    SEARCH_LEDGER_DATA_ALLOWLIST
+        .iter()
+        .any(|allowed| normalize_search_ledger_data_key(allowed) == normalized)
+}
+
+fn is_search_ledger_private_data_key(key: &str) -> bool {
+    let normalized = normalize_search_ledger_data_key(key);
+    normalized.contains("prompt")
+        || normalized.contains("transcript")
+        || normalized.contains("conversation")
+        || normalized.contains("message")
+        || normalized.contains("stdout")
+        || normalized.contains("stderr")
+        || normalized.contains("standardoutput")
+        || normalized.contains("standarderror")
+        || normalized.contains("output")
+        || normalized.contains("content")
+}
+
+fn normalize_search_ledger_data_key(key: &str) -> String {
+    key.to_ascii_lowercase()
+        .chars()
+        .filter(|ch| ch.is_ascii_alphanumeric())
+        .collect()
 }
 
 fn bool_field(data: &Map<String, Value>, key: &str) -> bool {

--- a/core/tests-rs/operator_cli.rs
+++ b/core/tests-rs/operator_cli.rs
@@ -217,8 +217,21 @@ fn operator_cli_meta_plan_json_writes_plan_artifacts_and_audit_log() {
         .expect("integrated plan ref should be present");
     let plan_path = project_dir.join(plan_ref.replace('/', std::path::MAIN_SEPARATOR_STR));
     let plan = fs::read_to_string(plan_path).expect("test should read integrated plan");
-    assert!(plan.contains("日本語IME対応を含むメタ計画を作る"));
+    assert!(plan.contains("Task hash:"));
+    assert!(!plan.contains("日本語IME対応を含むメタ計画を作る"));
     assert!(plan.contains("## Safety And Approval Gates"));
+    assert!(plan.contains("Private task and role prompt bodies are not retained"));
+
+    let draft_ref = json["roles"][0]["draft_ref"]
+        .as_str()
+        .expect("draft ref should be present");
+    let draft_path = project_dir.join(draft_ref.replace('/', std::path::MAIN_SEPARATOR_STR));
+    let draft = fs::read_to_string(draft_path).expect("test should read draft");
+    assert!(draft.contains("Task hash:"));
+    assert!(draft.contains("Role prompt hash:"));
+    assert!(!draft.contains("日本語IME対応を含むメタ計画を作る"));
+    assert!(!draft.contains("Gather facts, constraints, and unknowns. Do not edit files."));
+    assert_eq!(json["roles"][0]["prompt_hash"].as_str().expect("prompt hash should be present").len(), 64);
 
     let audit_ref = json["audit_log_ref"]
         .as_str()
@@ -252,10 +265,18 @@ fn operator_cli_meta_plan_json_writes_plan_artifacts_and_audit_log() {
         .filter(|event| event["event"] == "role_assigned")
         .count();
     assert_eq!(role_assigned, 2);
+    assert!(events.iter().any(|event| {
+        event["event"] == "meta_plan_init"
+            && event["data"]["shield_harness"]["private_prompt_bodies_in_artifacts"] == false
+    }));
     assert!(events
         .iter()
         .filter(|event| event["event"] == "role_assigned")
         .all(|event| event["data"]["read_only"] == true));
+    assert!(events
+        .iter()
+        .filter(|event| event["event"] == "role_assigned")
+        .all(|event| event["data"]["prompt_hash"].as_str().map(|value| value.len() == 64).unwrap_or(false)));
 }
 
 #[test]
@@ -327,7 +348,9 @@ roles:
         .expect("draft ref should be present");
     let draft_path = project_dir.join(draft_ref.replace('/', std::path::MAIN_SEPARATOR_STR));
     let draft = fs::read_to_string(draft_path).expect("test should read draft");
-    assert!(draft.contains("日本語コメントを壊さず、事実と制約を集める。"));
+    assert!(draft.contains("Role prompt hash:"));
+    assert!(!draft.contains("日本語コメントを壊さず、事実と制約を集める。"));
+    assert_eq!(json["roles"][0]["prompt_hash"].as_str().expect("prompt hash should be present").len(), 64);
 
     let audit_ref = json["audit_log_ref"]
         .as_str()

--- a/core/tests-rs/search_ledger_contract.rs
+++ b/core/tests-rs/search_ledger_contract.rs
@@ -58,7 +58,7 @@ fn search_ledger_suppresses_tagged_credentials_and_redacts_sensitive_fields() {
         search_ledger::SearchLedger::open_in_memory().expect("search ledger should open");
     let events = r#"
 {"timestamp":"2026-04-27T12:00:00+09:00","event":"credential.recorded","message":"token alpha-secret","task_id":"TASK-307","data":{"retention_tags":["credential"],"token":"alpha-secret"}}
-{"timestamp":"2026-04-27T12:01:00+09:00","event":"operator.note","message":"token raw-message keep searchable note","task_id":"TASK-307","data":{"api_key":"plain-secret","privateKey":"raw-private","nested":{"password":"hidden","sshKey":"raw-ssh","authHeader":"raw-auth"},"note":"keep this","output":"neutral-secret-value","stderr":"Bearer raw-bearer"}}
+{"timestamp":"2026-04-27T12:01:00+09:00","event":"operator.note","message":"token raw-message keep searchable note","task_id":"TASK-307","data":{"api_key":"plain-secret","privateKey":"raw-private","nested":{"password":"hidden","sshKey":"raw-ssh","authHeader":"raw-auth"},"note":"keep this","prompt":"full prompt phrase","transcript":"pane transcript phrase","conversation":"conversation body phrase","messages":["message list phrase"],"message_body":"message body phrase","content":"content body phrase","output":"neutral-output-value","stdout":"stdout body phrase","stderr":"Bearer raw-bearer"}}
 "#;
     let indexed = ledger
         .rebuild_from_events_jsonl(events)
@@ -90,8 +90,36 @@ fn search_ledger_suppresses_tagged_credentials_and_redacts_sensitive_fields() {
         .expect("message secret search should run")
         .is_empty());
     assert!(ledger
-        .search("neutral-secret-value", 10)
-        .expect("neutral-key secret search should run")
+        .search("neutral-output-value", 10)
+        .expect("output search should run")
+        .is_empty());
+    assert!(ledger
+        .search("full prompt phrase", 10)
+        .expect("prompt search should run")
+        .is_empty());
+    assert!(ledger
+        .search("pane transcript phrase", 10)
+        .expect("transcript search should run")
+        .is_empty());
+    assert!(ledger
+        .search("conversation body phrase", 10)
+        .expect("conversation search should run")
+        .is_empty());
+    assert!(ledger
+        .search("message list phrase", 10)
+        .expect("messages search should run")
+        .is_empty());
+    assert!(ledger
+        .search("message body phrase", 10)
+        .expect("message body search should run")
+        .is_empty());
+    assert!(ledger
+        .search("content body phrase", 10)
+        .expect("content search should run")
+        .is_empty());
+    assert!(ledger
+        .search("stdout body phrase", 10)
+        .expect("stdout search should run")
         .is_empty());
     assert!(ledger
         .search("raw-bearer", 10)
@@ -109,14 +137,92 @@ fn search_ledger_suppresses_tagged_credentials_and_redacts_sensitive_fields() {
         .expect("detail should exist");
     assert_eq!(hit.entry.message, "[redacted]");
     assert_eq!(detail.detail["message"], "[redacted]");
-    assert_eq!(detail.detail["data"]["api_key"], "[redacted]");
-    assert_eq!(detail.detail["data"]["privateKey"], "[redacted]");
-    assert_eq!(detail.detail["data"]["nested"]["password"], "[redacted]");
-    assert_eq!(detail.detail["data"]["nested"]["sshKey"], "[redacted]");
-    assert_eq!(detail.detail["data"]["nested"]["authHeader"], "[redacted]");
     assert_eq!(detail.detail["data"]["note"], "keep this");
-    assert_eq!(detail.detail["data"]["output"], "[redacted]");
-    assert_eq!(detail.detail["data"]["stderr"], "[redacted]");
+    assert!(detail.detail["data"].get("api_key").is_none());
+    assert!(detail.detail["data"].get("privateKey").is_none());
+    assert!(detail.detail["data"].get("nested").is_none());
+    assert!(detail.detail["data"].get("prompt").is_none());
+    assert!(detail.detail["data"].get("transcript").is_none());
+    assert!(detail.detail["data"].get("conversation").is_none());
+    assert!(detail.detail["data"].get("messages").is_none());
+    assert!(detail.detail["data"].get("message_body").is_none());
+    assert!(detail.detail["data"].get("content").is_none());
+    assert!(detail.detail["data"].get("output").is_none());
+    assert!(detail.detail["data"].get("stdout").is_none());
+    assert!(detail.detail["data"].get("stderr").is_none());
+}
+
+#[test]
+fn search_ledger_rebuild_projects_data_with_default_allowlist() {
+    let mut ledger =
+        search_ledger::SearchLedger::open_in_memory().expect("search ledger should open");
+    let events = r#"
+{"timestamp":"2026-04-27T12:00:00+09:00","event":"operator.note","message":"projection smoke","task_id":"TASK-307","data":{"hypothesis":"allowed hypothesis phrase","result":"allowed result phrase","arbitrary":"dropped arbitrary phrase","prompt_text":"dropped prompt phrase","std_out":"dropped stdout phrase","standard_output":"dropped standard output phrase","message_list":"dropped message list phrase","body_content":"dropped content phrase"}}
+"#;
+    let indexed = ledger
+        .rebuild_from_events_jsonl(events)
+        .expect("events should index");
+
+    assert_eq!(indexed, 1);
+    assert_eq!(
+        ledger
+            .search("allowed hypothesis phrase", 10)
+            .expect("allowed field search should run")
+            .len(),
+        1
+    );
+    assert_eq!(
+        ledger
+            .search("allowed result phrase", 10)
+            .expect("allowed result search should run")
+            .len(),
+        1
+    );
+    assert!(ledger
+        .search("dropped arbitrary phrase", 10)
+        .expect("arbitrary field search should run")
+        .is_empty());
+    assert!(ledger
+        .search("dropped prompt phrase", 10)
+        .expect("prompt text search should run")
+        .is_empty());
+    assert!(ledger
+        .search("dropped stdout phrase", 10)
+        .expect("stdout text search should run")
+        .is_empty());
+    assert!(ledger
+        .search("dropped standard output phrase", 10)
+        .expect("standard output text search should run")
+        .is_empty());
+    assert!(ledger
+        .search("dropped message list phrase", 10)
+        .expect("message list text search should run")
+        .is_empty());
+    assert!(ledger
+        .search("dropped content phrase", 10)
+        .expect("content text search should run")
+        .is_empty());
+
+    let hit = ledger
+        .search("projection smoke", 10)
+        .expect("message search should run")
+        .pop()
+        .expect("message should be searchable");
+    let detail = ledger
+        .detail(hit.entry.id)
+        .expect("detail lookup should run")
+        .expect("detail should exist");
+    assert_eq!(
+        detail.detail["data"]["hypothesis"],
+        "allowed hypothesis phrase"
+    );
+    assert_eq!(detail.detail["data"]["result"], "allowed result phrase");
+    assert!(detail.detail["data"].get("arbitrary").is_none());
+    assert!(detail.detail["data"].get("prompt_text").is_none());
+    assert!(detail.detail["data"].get("std_out").is_none());
+    assert!(detail.detail["data"].get("standard_output").is_none());
+    assert!(detail.detail["data"].get("message_list").is_none());
+    assert!(detail.detail["data"].get("body_content").is_none());
 }
 
 #[test]

--- a/docs/meta-planning-layer-design.md
+++ b/docs/meta-planning-layer-design.md
@@ -14,6 +14,11 @@ read-only, and the operator keeps the single approval gate.
 one or two cross-review rounds through `--review-rounds <1|2>`. Role labels and
 prompts may contain Japanese text, while `role_id` remains ASCII for logs.
 
+`v0.24.20` hardens runtime retention. Generated scaffold artifacts keep
+`task_hash` and `prompt_hash` references instead of storing the operator task
+body or role prompt bodies. The operator-owned interactive approval flow remains
+the place where the full request is visible.
+
 ## Goal
 
 Add a meta-planning layer above the normal operator execution flow.


### PR DESCRIPTION
## Summary
- Project search-ledger event data through an allowlist before SQLite detail/FTS storage.
- Drop prompt, transcript, conversation, message, output, stdout, stderr, and content-like data keys by default.
- Store meta-planning scaffold artifacts with task and role prompt hashes instead of private prompt bodies.
- Document the v0.24.20 retention boundary.

## Test Plan
- cargo test -p winsmux --test search_ledger_contract
- cargo test -p winsmux --test operator_cli meta_plan
- cargo check -p winsmux
- git diff --check
- pwsh -NoProfile -File scripts/audit-public-surface.ps1
- pwsh -NoProfile -File scripts/git-guard.ps1 -Mode full

## Review Notes
- gpt-5.5 xhigh Codex CLI review was attempted, but exporting the local code diff to the external review command was blocked by the safety check. No workaround was used; local manual review and validation were used instead.

Closes #764.
Closes #765.