### PR TITLE
fix: route monitor resets through provider metadata

### DIFF
--- a/core/src/operator_cli.rs
+++ b/core/src/operator_cli.rs
@@ -956,6 +956,7 @@ pub fn run_provider_switch_command(args: &[&String]) -> io::Result<()> {
         "supports_subagents": effective.supports_subagents,
         "supports_verification": effective.supports_verification,
         "supports_consultation": effective.supports_consultation,
+        "supports_context_reset": effective.supports_context_reset,
         "registry_path": registry_path.display().to_string(),
         "updated_at_utc": updated_at_utc,
         "reason": reason,
@@ -1152,6 +1153,7 @@ struct SlotAgentConfig {
     supports_subagents: bool,
     supports_verification: bool,
     supports_consultation: bool,
+    supports_context_reset: bool,
 }
 
 #[derive(Debug)]
@@ -1448,6 +1450,7 @@ fn normalize_provider_capability_entry(
         "supports_subagents",
         "supports_verification",
         "supports_consultation",
+        "supports_context_reset",
     ];
 
     for (field, field_value) in entry {
@@ -2015,6 +2018,7 @@ fn finalize_slot_agent_config(
         supports_subagents: capability_bool(capability.as_ref(), "supports_subagents"),
         supports_verification: capability_bool(capability.as_ref(), "supports_verification"),
         supports_consultation: capability_bool(capability.as_ref(), "supports_consultation"),
+        supports_context_reset: capability_bool(capability.as_ref(), "supports_context_reset"),
         agent,
         model,
         prompt_transport,
@@ -5859,6 +5863,17 @@ fn provider_target_with_model(agent: &str, model: &str) -> String {
 }
 
 fn invoke_restart_plan(plan: &RestartPlan) -> io::Result<()> {
+    let readiness_agent = restart_readiness_agent(plan);
+    if readiness_agent.is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "restart readiness adapter missing for pane '{}' ({}). Set provider capability metadata before restart.",
+                plan.pane_id, plan.label
+            ),
+        ));
+    }
+
     run_winsmux_command(&[
         "respawn-pane",
         "-k",
@@ -5877,7 +5892,7 @@ fn invoke_restart_plan(plan: &RestartPlan) -> io::Result<()> {
         &plan.launch_command,
     ])?;
     run_winsmux_command(&["send-keys", "-t", &plan.pane_id, "Enter"])?;
-    wait_for_agent_prompt(&plan.pane_id, &restart_readiness_agent(plan))?;
+    wait_for_agent_prompt(&plan.pane_id, &readiness_agent)?;
     Ok(())
 }
 
@@ -5887,11 +5902,7 @@ fn restart_readiness_agent(plan: &RestartPlan) -> String {
         return adapter;
     }
     let agent = readiness_agent_name(&plan.agent);
-    if agent.is_empty() {
-        "codex".to_string()
-    } else {
-        agent
-    }
+    agent
 }
 
 fn readiness_agent_name(value: &str) -> String {
@@ -9224,4 +9235,47 @@ fn write_json<T: Serialize>(value: &T) -> io::Result<()> {
     })?;
     writeln!(stdout)?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn restart_plan(agent: &str, capability_adapter: &str) -> RestartPlan {
+        RestartPlan {
+            label: "worker-1".to_string(),
+            pane_id: "%2".to_string(),
+            role: "Worker".to_string(),
+            session_name: "winsmux-orchestra".to_string(),
+            launch_dir: "C:\\repo".to_string(),
+            git_worktree_dir: "C:\\repo\\.git".to_string(),
+            agent: agent.to_string(),
+            model: String::new(),
+            capability_adapter: capability_adapter.to_string(),
+            launch_command: "noop".to_string(),
+        }
+    }
+
+    #[test]
+    fn restart_readiness_agent_resolves_known_adapters() {
+        assert_eq!(restart_readiness_agent(&restart_plan("custom", "codex")), "codex");
+        assert_eq!(
+            restart_readiness_agent(&restart_plan("claude-opus", "")),
+            "claude"
+        );
+        assert_eq!(
+            restart_readiness_agent(&restart_plan("gemini:flash", "")),
+            "gemini"
+        );
+    }
+
+    #[test]
+    fn restart_readiness_agent_does_not_default_unknown_to_codex() {
+        assert_eq!(restart_readiness_agent(&restart_plan("", "")), "");
+        assert_eq!(restart_readiness_agent(&restart_plan("custom-agent", "")), "");
+        assert_eq!(
+            restart_readiness_agent(&restart_plan("custom-agent", "custom-adapter")),
+            ""
+        );
+    }
 }

--- a/core/tests-rs/operator_cli.rs
+++ b/core/tests-rs/operator_cli.rs
@@ -1495,7 +1495,7 @@ fn operator_cli_provider_capabilities_json_reads_single_provider_case_insensitiv
     fs::create_dir_all(&winsmux_dir).expect("test should create .winsmux directory");
     fs::write(
         winsmux_dir.join("provider-capabilities.json"),
-        r#"{"version":1,"providers":{"Codex":{"adapter":" codex ","command":" codex ","prompt_transports":["ARGV"],"auth_modes":["LOCAL_INTERACTIVE"],"supports_file_edit":true}}}"#,
+        r#"{"version":1,"providers":{"Codex":{"adapter":" codex ","command":" codex ","prompt_transports":["ARGV"],"auth_modes":["LOCAL_INTERACTIVE"],"supports_file_edit":true,"supports_context_reset":true}}}"#,
     )
     .expect("test should write provider registry");
 
@@ -1510,6 +1510,7 @@ fn operator_cli_provider_capabilities_json_reads_single_provider_case_insensitiv
         "local_interactive"
     );
     assert_eq!(provider["capabilities"]["supports_file_edit"], true);
+    assert_eq!(provider["capabilities"]["supports_context_reset"], true);
 }
 
 #[test]

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -3358,6 +3358,7 @@ function Invoke-Role {
             supports_subagents         = [bool]$roleAgentConfig.SupportsSubagents
             supports_verification      = [bool]$roleAgentConfig.SupportsVerification
             supports_consultation      = [bool]$roleAgentConfig.SupportsConsultation
+            supports_context_reset     = [bool]$roleAgentConfig.SupportsContextReset
         }
         if ($manifestRole -notin @('Builder', 'Worker')) {
             $manifestProperties['builder_worktree_path'] = ''
@@ -3914,6 +3915,7 @@ function New-LauncherSlotSummary {
         supports_subagents         = [bool]$effective.SupportsSubagents
         supports_verification      = [bool]$effective.SupportsVerification
         supports_consultation      = [bool]$effective.SupportsConsultation
+        supports_context_reset     = [bool]$effective.SupportsContextReset
     }
 }
 
@@ -10831,6 +10833,7 @@ function Invoke-ProviderSwitch {
         supports_subagents         = [bool]$effective.SupportsSubagents
         supports_verification      = [bool]$effective.SupportsVerification
         supports_consultation      = [bool]$effective.SupportsConsultation
+        supports_context_reset     = [bool]$effective.SupportsContextReset
         registry_path              = Get-BridgeProviderRegistryPath -RootPath $projectDir
         updated_at_utc             = if ($clearRequested) { [string]$clearResult.UpdatedAtUtc } else { [string]$entry.updated_at_utc }
         reason                     = if ((-not $clearRequested) -and $entry.Contains('reason')) { [string]$entry.reason } else { '' }

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -686,7 +686,8 @@ agent-slots:
       "supports_file_edit": true,
       "supports_subagents": true,
       "supports_verification": true,
-      "supports_consultation": false
+      "supports_consultation": false,
+      "supports_context_reset": true
     }
   }
 }
@@ -698,6 +699,7 @@ agent-slots:
         $registry.providers.codex.auth_modes | Should -Be @('api-key', 'codex-chatgpt-local')
         $registry.providers.codex.local_interactive_oauth_modes | Should -Be @('codex-chatgpt-local')
         $registry.providers.codex.supports_file_edit | Should -Be $true
+        $registry.providers.codex.supports_context_reset | Should -Be $true
 
         $capability = Get-BridgeProviderCapability -RootPath $script:settingsTempRoot -ProviderId 'CODEX'
         $capability.command | Should -Be 'codex'
@@ -724,7 +726,8 @@ agent-slots:
       "supports_file_edit": true,
       "supports_subagents": true,
       "supports_verification": true,
-      "supports_consultation": false
+      "supports_consultation": false,
+      "supports_context_reset": true
     }
   }
 }
@@ -759,6 +762,8 @@ agent-slots:
         $config.SupportsSubagents | Should -Be $true
         $config.SupportsVerification | Should -Be $true
         $config.SupportsConsultation | Should -Be $false
+        $config.SupportsContextReset | Should -Be $true
+        $config.SupportsContextResetDeclared | Should -Be $true
     }
 
     It 'distinguishes a missing interrupt capability from an explicit false value' {
@@ -2486,7 +2491,8 @@ panes:
       "supports_file_edit": true,
       "supports_subagents": true,
       "supports_verification": true,
-      "supports_consultation": false
+      "supports_consultation": false,
+      "supports_context_reset": true
     }
   }
 }
@@ -2881,6 +2887,22 @@ Describe 'agent-monitor helpers' {
         (Get-MonitorContextRemainingPercent -Text '') | Should -BeNullOrEmpty
     }
 
+    It 'keeps context reset disabled for non-Codex adapters even when provider metadata opts in' {
+        $slotAgentConfig = [PSCustomObject]@{
+            Agent                        = 'claude'
+            SupportsContextReset         = $true
+            SupportsContextResetDeclared = $true
+        }
+
+        $eligible = Test-MonitorContextResetEligible `
+            -SlotAgentConfig $slotAgentConfig `
+            -StatusAgentName 'claude' `
+            -ManifestCapabilityAdapter 'claude' `
+            -ManifestProviderTarget 'claude:sonnet'
+
+        $eligible | Should -Be $false
+    }
+
     It 'respawns the pane in the launch directory before sending the agent command' {
         Mock Invoke-MonitorWinsmux { } -ParameterFilter {
             $Arguments[0] -eq 'respawn-pane'
@@ -2941,7 +2963,8 @@ Describe 'agent-monitor helpers' {
       "supports_file_edit": true,
       "supports_subagents": true,
       "supports_verification": true,
-      "supports_consultation": false
+      "supports_consultation": false,
+      "supports_context_reset": true
     }
   }
 }
@@ -3002,6 +3025,7 @@ panes:
     pane_id: %2
     role: Builder
     launch_dir: $tempRoot
+    capability_adapter: codex
 "@ | Set-Content -Path $manifestPath -Encoding UTF8
 
             Mock Invoke-MonitorWinsmux { } -ParameterFilter {
@@ -3881,6 +3905,63 @@ gpt-5.4   10% context left
         }
     }
 
+    It 'does not reset context when provider metadata is missing' {
+        $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('winsmux-agent-monitor-tests-' + [guid]::NewGuid().ToString('N'))
+        $manifestDir = Join-Path $tempRoot '.winsmux'
+        $manifestPath = Join-Path $manifestDir 'manifest.yaml'
+
+        try {
+            New-Item -ItemType Directory -Path $manifestDir -Force | Out-Null
+@"
+version: 1
+session:
+  name: winsmux-orchestra
+  project_dir: $tempRoot
+panes:
+  - label: worker-1
+    pane_id: %2
+    role: Worker
+    launch_dir: $tempRoot
+"@ | Set-Content -Path $manifestPath -Encoding UTF8
+
+            Mock Get-PaneAgentStatus {
+                [ordered]@{
+                    Status       = 'ready'
+                    PaneId       = '%2'
+                    SnapshotTail = @"
+gpt-5.4   10% context left
+>
+"@
+                    SnapshotHash = 'hash-worker'
+                    ExitReason   = ''
+                }
+            }
+            Mock Send-MonitorBridgeCommand { }
+            Mock Update-MonitorIdleAlertState {
+                [ordered]@{
+                    ShouldAlert = $false
+                    Message     = ''
+                }
+            }
+            Mock Test-BuilderStall { $false }
+
+            $result = Invoke-AgentMonitorCycle -Settings ([ordered]@{
+                agent = 'custom-agent'
+                model = 'custom-model'
+                roles = [ordered]@{}
+            }) -ManifestPath $manifestPath -SessionName 'winsmux-orchestra'
+
+            $result.ContextResets | Should -Be 0
+            $result.Results.Count | Should -Be 1
+            $result.Results[0].ContextReset | Should -Be $false
+            Should -Invoke Send-MonitorBridgeCommand -Times 0 -Exactly
+        } finally {
+            if (Test-Path $tempRoot) {
+                Remove-Item -Path $tempRoot -Recurse -Force
+            }
+        }
+    }
+
     It 'syncs task review git state into manifest and monitor events' {
         $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('winsmux-agent-monitor-tests-' + [guid]::NewGuid().ToString('N'))
         $manifestDir = Join-Path $tempRoot '.winsmux'
@@ -4488,6 +4569,7 @@ Describe 'orchestra-start server bootstrap' {
         $pane.project_dir | Should -Be 'C:\repo'
         $pane.worktree_git_dir | Should -Be 'C:\repo\.git\worktrees\worker-1'
         $pane.expected_origin | Should -Be 'https://github.com/example/repo.git'
+        $pane.supports_context_reset | Should -Be $false
     }
 
     It 'returns success when the server session already exists' {
@@ -5624,9 +5706,11 @@ Describe 'orchestra-start session reuse contract' {
         $script:orchestraStartContent | Should -Match 'CapabilityAdapter = \[string\]\$slotAgentConfig\.CapabilityAdapter'
         $script:orchestraStartContent | Should -Match 'SupportsFileEdit = \[bool\]\$slotAgentConfig\.SupportsFileEdit'
         $script:orchestraStartContent | Should -Match 'SupportsVerification = \[bool\]\$slotAgentConfig\.SupportsVerification'
+        $script:orchestraStartContent | Should -Match 'SupportsContextReset = \[bool\]\$slotAgentConfig\.SupportsContextReset'
         $script:orchestraStartContent | Should -Match 'capability_adapter\s*=\s*\[string\]\$paneSummary\.CapabilityAdapter'
         $script:orchestraStartContent | Should -Match 'supports_file_edit\s*=\s*\[bool\]\$paneSummary\.SupportsFileEdit'
         $script:orchestraStartContent | Should -Match 'supports_verification\s*=\s*\[bool\]\$paneSummary\.SupportsVerification'
+        $script:orchestraStartContent | Should -Match 'supports_context_reset\s*=\s*\[bool\]\(Get-OrchestraObjectPropertyValue -InputObject \$paneSummary -Name ''SupportsContextReset'' -Default \$false\)'
     }
 
     It 'uses the capability adapter for startup readiness detection' {
@@ -12009,7 +12093,8 @@ agent-slots:
       "supports_file_edit": true,
       "supports_subagents": true,
       "supports_verification": true,
-      "supports_consultation": false
+      "supports_consultation": false,
+      "supports_context_reset": true
     },
     "claude": {
       "adapter": "claude",
@@ -12023,7 +12108,8 @@ agent-slots:
       "supports_file_edit": true,
       "supports_subagents": false,
       "supports_verification": true,
-      "supports_consultation": true
+      "supports_consultation": true,
+      "supports_context_reset": false
     }
   }
 }
@@ -12060,6 +12146,7 @@ agent-slots:
         $result.supports_file_edit | Should -Be $true
         $result.supports_subagents | Should -Be $false
         $result.supports_consultation | Should -Be $true
+        $result.supports_context_reset | Should -Be $false
         $result.restart_requested | Should -Be $false
         $result.restarted | Should -Be $false
 
@@ -12104,6 +12191,7 @@ agent-slots:
         $result.supports_parallel_runs | Should -Be $true
         $result.supports_verification | Should -Be $true
         $result.supports_consultation | Should -Be $false
+        $result.supports_context_reset | Should -Be $true
         $result.clear_requested | Should -Be $true
         $result.cleared | Should -Be $true
         $registry = Get-Content -LiteralPath (Join-Path $script:providerSwitchTempRoot '.winsmux\provider-registry.json') -Raw -Encoding UTF8 | ConvertFrom-Json

--- a/winsmux-core/scripts/agent-monitor.ps1
+++ b/winsmux-core/scripts/agent-monitor.ps1
@@ -700,6 +700,37 @@ function Get-MonitorStateEventMessage {
     }
 }
 
+function Test-MonitorContextResetEligible {
+    param(
+        [AllowNull()]$SlotAgentConfig,
+        [string]$StatusAgentName = '',
+        [string]$ManifestCapabilityAdapter = '',
+        [string]$ManifestProviderTarget = ''
+    )
+
+    if ((ConvertTo-ReadinessAgentName $StatusAgentName) -ne 'codex') {
+        return $false
+    }
+
+    $declared = [bool](Get-MonitorPropertyValue -InputObject $SlotAgentConfig -Name 'SupportsContextResetDeclared' -Default $false)
+    if ($declared) {
+        return [bool](Get-MonitorPropertyValue -InputObject $SlotAgentConfig -Name 'SupportsContextReset' -Default $false)
+    }
+
+    $slotAgentName = [string](Get-MonitorPropertyValue -InputObject $SlotAgentConfig -Name 'Agent' -Default '')
+    if ((ConvertTo-ReadinessAgentName $slotAgentName) -eq 'codex') {
+        return $true
+    }
+
+    foreach ($candidate in @($ManifestCapabilityAdapter, $ManifestProviderTarget)) {
+        if ((ConvertTo-ReadinessAgentName $candidate) -eq 'codex') {
+            return $true
+        }
+    }
+
+    return $false
+}
+
 # ---------------------------------------------------------------------------
 # 1. Get-PaneAgentStatus
 # ---------------------------------------------------------------------------
@@ -1197,6 +1228,13 @@ function Invoke-AgentMonitorCycle {
         if ([string]::IsNullOrWhiteSpace($statusAgentName)) {
             $statusAgentName = $agentName
         }
+        $manifestCapabilityAdapter = [string](Get-MonitorPropertyValue -InputObject $pane -Name 'capability_adapter' -Default '')
+        $manifestProviderTarget = [string](Get-MonitorPropertyValue -InputObject $pane -Name 'provider_target' -Default '')
+        $supportsContextReset = Test-MonitorContextResetEligible `
+            -SlotAgentConfig $roleAgentConfig `
+            -StatusAgentName $statusAgentName `
+            -ManifestCapabilityAdapter $manifestCapabilityAdapter `
+            -ManifestProviderTarget $manifestProviderTarget
         $launchDirFromManifest = [string](Get-MonitorPropertyValue -InputObject $pane -Name 'launch_dir' -Default '')
         $builderWorktreePath = [string](Get-MonitorPropertyValue -InputObject $pane -Name 'builder_worktree_path' -Default '')
 
@@ -1309,7 +1347,7 @@ function Invoke-AgentMonitorCycle {
         }
 
         $contextRemainingPercent = Get-MonitorContextRemainingPercent -Text $statusSnapshotTail
-        if ($statusAgentName -eq 'codex' -and $statusName -eq 'ready' -and $null -ne $contextRemainingPercent) {
+        if ($supportsContextReset -and $statusName -eq 'ready' -and $null -ne $contextRemainingPercent) {
             $result['ContextRemainingPercent'] = $contextRemainingPercent
             if ($contextRemainingPercent -le $ContextResetThresholdPercent) {
                 try {

--- a/winsmux-core/scripts/agent-readiness.ps1
+++ b/winsmux-core/scripts/agent-readiness.ps1
@@ -46,6 +46,23 @@ function Get-RecentNonEmptyLines {
     return @($recent)
 }
 
+function ConvertTo-ReadinessAgentName {
+    param([AllowNull()][string]$Value)
+
+    $lowered = if ($null -eq $Value) { '' } else { $Value.Trim().ToLowerInvariant() }
+    foreach ($name in @('codex', 'claude', 'gemini')) {
+        if ($lowered -eq $name `
+            -or $lowered.StartsWith("${name}:") `
+            -or $lowered.StartsWith("${name}-") `
+            -or $lowered.StartsWith("${name}_") `
+            -or $lowered.StartsWith("${name}/")) {
+            return $name
+        }
+    }
+
+    return ''
+}
+
 function Test-AgentPromptText {
     param(
         [AllowNull()][string]$Text,

--- a/winsmux-core/scripts/orchestra-start.ps1
+++ b/winsmux-core/scripts/orchestra-start.ps1
@@ -1111,6 +1111,7 @@ function Save-OrchestraSessionState {
             supports_subagents         = [bool]$paneSummary.SupportsSubagents
             supports_verification      = [bool]$paneSummary.SupportsVerification
             supports_consultation      = [bool]$paneSummary.SupportsConsultation
+            supports_context_reset     = [bool](Get-OrchestraObjectPropertyValue -InputObject $paneSummary -Name 'SupportsContextReset' -Default $false)
             task                       = $null
             status                     = if ($paneSummary.Status) { $paneSummary.Status } else { 'ready' }
         }
@@ -2179,6 +2180,7 @@ if ($MyInvocation.InvocationName -ne '.') {
             SupportsSubagents = [bool]$slotAgentConfig.SupportsSubagents
             SupportsVerification = [bool]$slotAgentConfig.SupportsVerification
             SupportsConsultation = [bool]$slotAgentConfig.SupportsConsultation
+            SupportsContextReset = [bool]$slotAgentConfig.SupportsContextReset
             ExecMode = $false
             LaunchDir = $launchDir
             ProjectDir = $projectDir

--- a/winsmux-core/scripts/settings.ps1
+++ b/winsmux-core/scripts/settings.ps1
@@ -641,7 +641,8 @@ function ConvertTo-BridgeProviderCapabilityEntry {
         'supports_file_edit',
         'supports_subagents',
         'supports_verification',
-        'supports_consultation'
+        'supports_consultation',
+        'supports_context_reset'
     )
     $allowedFields = @($stringFields + $transportFields + $stringArrayFields + $boolFields)
 
@@ -1866,6 +1867,8 @@ function Get-SlotAgentConfig {
         SupportsSubagents        = Get-BridgeProviderCapabilityBoolean -Capability $providerCapability -Name 'supports_subagents'
         SupportsVerification     = Get-BridgeProviderCapabilityBoolean -Capability $providerCapability -Name 'supports_verification'
         SupportsConsultation     = Get-BridgeProviderCapabilityBoolean -Capability $providerCapability -Name 'supports_consultation'
+        SupportsContextReset     = Get-BridgeProviderCapabilityBoolean -Capability $providerCapability -Name 'supports_context_reset'
+        SupportsContextResetDeclared = Test-BridgeProviderCapabilityField -Capability $providerCapability -Name 'supports_context_reset'
     }
 }
 


### PR DESCRIPTION
## Summary
- add supports_context_reset to Rust and PowerShell provider capability projections
- gate monitor context resets through provider metadata without losing the configured Codex default path
- keep provider-switch and manifest capability JSON in sync

## Validation
- cargo test -p winsmux restart_readiness_agent -- --nocapture
- cargo test -p winsmux --test operator_cli provider_capabilities_json_reads_single_provider_case_insensitive -- --nocapture
- Invoke-Pester -Path tests\winsmux-bridge.Tests.ps1 -Output Detailed -FullName '*provider-switch*','*provider capability*','*pane manifest entries*','*context*reset*','*readiness adapter*'
- Invoke-Pester -Path tests\Integration.MultiAgent.Tests.ps1 -Output Detailed
- cargo check -p winsmux
- git diff --check
- pwsh -NoProfile -File scripts\audit-public-surface.ps1
- codex review --commit ef0b064 -c model="gpt-5.5" -c model_reasoning_effort="xhigh"