### PR TITLE
Fix bridge namespace forwarding

### DIFF
--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -34,7 +34,7 @@ mod ssh_input;
 mod debug_log;
 mod control;
 use std::io::{self, Write, Read as _, BufRead as _, IsTerminal};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::Duration;
 use std::env;
@@ -51,7 +51,8 @@ use crate::cli::{print_help, print_version, print_commands};
 use crate::session::{cleanup_stale_port_files, read_session_key, send_control,
     send_control_with_response, resolve_last_session_name, resolve_default_session_name,
     kill_remaining_server_processes, request_server_shutdown,
-    cleanup_warm_server_for_socket};
+    cleanup_warm_server_for_socket, resolve_last_session_name_with_prefix,
+    socket_path_session_base, normalize_socket_selector};
 use crate::rendering::apply_cursor_style;
 use crate::client::run_remote;
 use crate::ssh_input::{send_mouse_enable, InputSource};
@@ -157,21 +158,61 @@ fn find_winsmux_core_script() -> Option<PathBuf> {
     candidates.into_iter().find(|path| path.is_file())
 }
 
-fn run_winsmux_core_script(script_path: PathBuf, cmd_args: &[&String]) -> io::Result<()> {
-    let status = Command::new("pwsh")
+fn prepare_winsmux_core_script_command(
+    command: &mut Command,
+    script_path: &Path,
+    cmd_args: &[&String],
+    l_socket_name: Option<&str>,
+    s_socket_path: Option<&str>,
+    session_namespace: Option<&str>,
+) {
+    command
         .arg("-NoProfile")
         .arg("-File")
-        .arg(&script_path)
-        .args(cmd_args.iter().map(|arg| arg.as_str()))
+        .arg(script_path)
+        .args(cmd_args.iter().map(|arg| arg.as_str()));
+
+    if let Some(value) = l_socket_name {
+        command.env("WINSMUX_BRIDGE_NAMESPACE_L", value);
+    }
+    if let Some(value) = s_socket_path {
+        command.env("WINSMUX_BRIDGE_SOCKET_S", value);
+    }
+    if let Some(value) = session_namespace {
+        command.env("WINSMUX_BRIDGE_SESSION_NAMESPACE", value);
+    }
+}
+
+fn run_winsmux_core_script(
+    script_path: PathBuf,
+    cmd_args: &[&String],
+    l_socket_name: Option<&str>,
+    s_socket_path: Option<&str>,
+    session_namespace: Option<&str>,
+) -> io::Result<()> {
+    let mut command = Command::new("pwsh");
+    prepare_winsmux_core_script_command(
+        &mut command,
+        &script_path,
+        cmd_args,
+        l_socket_name,
+        s_socket_path,
+        session_namespace,
+    );
+    let status = command
         .status()
         .or_else(|err| {
             if err.kind() == io::ErrorKind::NotFound {
-                Command::new("powershell")
-                    .arg("-NoProfile")
-                    .arg("-File")
-                    .arg(&script_path)
-                    .args(cmd_args.iter().map(|arg| arg.as_str()))
-                    .status()
+                let mut fallback = Command::new("powershell");
+                prepare_winsmux_core_script_command(
+                    &mut fallback,
+                    &script_path,
+                    cmd_args,
+                    l_socket_name,
+                    s_socket_path,
+                    session_namespace,
+                );
+                fallback.status()
             } else {
                 Err(err)
             }
@@ -181,6 +222,171 @@ fn run_winsmux_core_script(script_path: PathBuf, cmd_args: &[&String]) -> io::Re
         Ok(())
     } else {
         std::process::exit(status.code().unwrap_or(1));
+    }
+}
+
+fn resolve_attach_session_name(
+    args: &[String],
+    namespaced_target_session: Option<String>,
+    has_session_namespace: bool,
+) -> String {
+    resolve_attach_session_name_from_parts(
+        args,
+        namespaced_target_session,
+        has_session_namespace,
+        resolve_default_session_name(),
+        resolve_last_session_name(),
+    )
+}
+
+fn resolve_attach_session_name_from_parts(
+    args: &[String],
+    resolved_target_session: Option<String>,
+    has_session_namespace: bool,
+    default_session: Option<String>,
+    last_session: Option<String>,
+) -> String {
+    let raw_target = args
+        .iter()
+        .position(|a| a == "-t")
+        .and_then(|i| args.get(i + 1))
+        .cloned();
+    let resolved_target = resolved_target_session.filter(|value| !value.trim().is_empty());
+
+    if raw_target.is_some() {
+        return resolved_target
+            .or(raw_target)
+            .or(default_session)
+            .or(last_session)
+            .unwrap_or_else(|| "0".to_string());
+    }
+
+    if has_session_namespace {
+        return resolved_target
+            .or(default_session)
+            .or(last_session)
+            .unwrap_or_else(|| "0".to_string());
+    }
+
+    default_session
+        .or(resolved_target)
+        .or(last_session)
+        .unwrap_or_else(|| "0".to_string())
+}
+
+fn bare_session_headless_server_config(
+    session_name: String,
+    session_namespace: Option<String>,
+) -> terminal_engine::HeadlessServerConfig {
+    terminal_engine::HeadlessServerConfig {
+        session_name,
+        socket_name: session_namespace,
+        ..terminal_engine::HeadlessServerConfig::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{bare_session_headless_server_config, resolve_attach_session_name_from_parts};
+
+    #[test]
+    fn resolve_attach_session_name_prefers_namespaced_target() {
+        let args = vec![
+            "winsmux".to_string(),
+            "-S".to_string(),
+            "socket-name".to_string(),
+            "attach-session".to_string(),
+            "-t".to_string(),
+            "winsmux-orchestra".to_string(),
+        ];
+
+        let resolved = resolve_attach_session_name_from_parts(
+            &args,
+            Some("socket-name__winsmux-orchestra".to_string()),
+            true,
+            None,
+            None,
+        );
+
+        assert_eq!(resolved, "socket-name__winsmux-orchestra");
+    }
+
+    #[test]
+    fn resolve_attach_session_name_keeps_raw_target_without_namespace() {
+        let args = vec![
+            "winsmux".to_string(),
+            "attach-session".to_string(),
+            "-t".to_string(),
+            "winsmux-orchestra".to_string(),
+        ];
+
+        let resolved = resolve_attach_session_name_from_parts(&args, None, false, None, None);
+
+        assert_eq!(resolved, "winsmux-orchestra");
+    }
+
+    #[test]
+    fn resolve_attach_session_name_prefers_default_before_ambient_target() {
+        let args = vec!["winsmux".to_string(), "attach-session".to_string()];
+
+        let resolved = resolve_attach_session_name_from_parts(
+            &args,
+            Some("last-session".to_string()),
+            false,
+            Some("default-session".to_string()),
+            None,
+        );
+
+        assert_eq!(resolved, "default-session");
+    }
+
+    #[test]
+    fn resolve_attach_session_name_uses_namespace_target_without_default() {
+        let args = vec![
+            "winsmux".to_string(),
+            "-S".to_string(),
+            "socket-name".to_string(),
+            "attach-session".to_string(),
+        ];
+
+        let resolved = resolve_attach_session_name_from_parts(
+            &args,
+            Some("socket-name__latest".to_string()),
+            true,
+            None,
+            Some("global-latest".to_string()),
+        );
+
+        assert_eq!(resolved, "socket-name__latest");
+    }
+
+    #[test]
+    fn resolve_attach_session_name_keeps_namespace_before_default() {
+        let args = vec![
+            "winsmux".to_string(),
+            "-L".to_string(),
+            "ops".to_string(),
+            "attach-session".to_string(),
+        ];
+
+        let resolved = resolve_attach_session_name_from_parts(
+            &args,
+            Some("ops__latest".to_string()),
+            true,
+            Some("default-session".to_string()),
+            None,
+        );
+
+        assert_eq!(resolved, "ops__latest");
+    }
+
+    #[test]
+    fn bare_session_headless_server_config_preserves_socket_namespace() {
+        let config =
+            bare_session_headless_server_config("0".to_string(), Some("socket-name".to_string()));
+
+        assert_eq!(config.session_name, "0");
+        assert_eq!(config.socket_name.as_deref(), Some("socket-name"));
     }
 }
 
@@ -199,6 +405,7 @@ fn run_main() -> io::Result<()> {
     // This avoids conflict with subcommand flags (e.g. select-pane -L, resize-pane -L).
     let mut l_socket_name: Option<String> = None;
     let mut f_config_file: Option<String> = None;
+    let mut s_socket_path: Option<String> = None;
     let mut control_mode: u8 = 0; // 0=off, 1=-C (echo), 2=-CC (no echo)
     {
         let mut i = 1; // skip binary name
@@ -216,7 +423,10 @@ fn run_main() -> io::Result<()> {
             } else if arg == "-f" && i + 1 < args.len() {
                 f_config_file = Some(args[i + 1].clone());
                 i += 2;
-            } else if (arg == "-S" || arg == "-t") && i + 1 < args.len() {
+            } else if arg == "-S" && i + 1 < args.len() {
+                s_socket_path = Some(args[i + 1].clone());
+                i += 2;
+            } else if arg == "-t" && i + 1 < args.len() {
                 i += 2; // skip other global flag-value pairs
             } else if arg.starts_with('-') {
                 i += 1; // skip single global flags (e.g. -v, -V)
@@ -230,6 +440,9 @@ fn run_main() -> io::Result<()> {
     if let Some(ref cf) = f_config_file {
         env::set_var("PSMUX_CONFIG_FILE", cf);
     }
+    let s_socket_selector = s_socket_path.as_deref().and_then(normalize_socket_selector);
+    let s_socket_base = s_socket_selector.as_deref().and_then(socket_path_session_base);
+    let session_namespace = s_socket_base.clone().or_else(|| l_socket_name.clone());
 
     // Parse -t flag early to set target session for all commands
     // Supports session:window.pane format (e.g., "dev:0.1")
@@ -244,7 +457,7 @@ fn run_main() -> io::Result<()> {
             let has_explicit_session = parsed_target.session.is_some();
             let session = parsed_target.session.unwrap_or_else(|| "default".to_string());
             // Apply -L namespace prefix for port file lookup
-            let port_file_base = if let Some(ref l) = l_socket_name {
+            let port_file_base = if let Some(ref l) = session_namespace {
                 format!("{}__{}", l, session)
             } else {
                 session.clone()
@@ -296,6 +509,19 @@ fn run_main() -> io::Result<()> {
     }
     // Fallback: if no -t flag and session still not resolved (e.g. TMUX pointed
     // to a warm session, or no TMUX at all), pick the most recent real session.
+    if env::var("PSMUX_TARGET_SESSION").is_err() {
+        if let Some(ref namespace) = session_namespace {
+            let prefix = format!("{namespace}__");
+            if let Some(name) = resolve_last_session_name_with_prefix(&prefix) {
+                env::set_var("PSMUX_TARGET_SESSION", &name);
+            }
+        }
+    }
+    if env::var("PSMUX_TARGET_SESSION").is_err() {
+        if let Some(ref socket_base) = s_socket_base {
+            env::set_var("PSMUX_TARGET_SESSION", socket_base);
+        }
+    }
     if env::var("PSMUX_TARGET_SESSION").is_err() {
         if let Some(name) = crate::session::resolve_last_session_name() {
             env::set_var("PSMUX_TARGET_SESSION", &name);
@@ -367,7 +593,13 @@ fn run_main() -> io::Result<()> {
 
     if is_winsmux_core_bridge_command(cmd) {
         if let Some(script_path) = find_winsmux_core_script() {
-            return run_winsmux_core_script(script_path, &cmd_args);
+            return run_winsmux_core_script(
+                script_path,
+                &cmd_args,
+                l_socket_name.as_deref(),
+                s_socket_selector.as_deref(),
+                session_namespace.as_deref(),
+            );
         }
     }
 
@@ -430,7 +662,7 @@ fn run_main() -> io::Result<()> {
             let home = env::var("USERPROFILE").or_else(|_| env::var("HOME")).unwrap_or_default();
             let psmux_dir = format!("{}\\.psmux", home);
             // Compute namespace prefix for -L filtering (matches list-sessions behavior)
-            let ns_prefix = l_socket_name.as_ref().map(|l| format!("{l}__"));
+            let ns_prefix = session_namespace.as_ref().map(|l| format!("{l}__"));
             let mut targets: Vec<(std::path::PathBuf, u16, String)> = Vec::new();
             let mut stale_ports: Vec<std::path::PathBuf> = Vec::new();
             if let Ok(entries) = std::fs::read_dir(&psmux_dir) {
@@ -474,8 +706,8 @@ fn run_main() -> io::Result<()> {
                 let key_path = path.with_extension("key");
                 let _ = std::fs::remove_file(&key_path);
             }
-            if l_socket_name.is_some() {
-                cleanup_warm_server_for_socket(l_socket_name.as_deref());
+            if session_namespace.is_some() {
+                cleanup_warm_server_for_socket(session_namespace.as_deref());
             }
             // Brief wait then verify no processes remain; if any do, force-kill them.
             // Only do the nuclear fallback when not using -L namespace filtering.
@@ -489,7 +721,7 @@ fn run_main() -> io::Result<()> {
                 let home = env::var("USERPROFILE").or_else(|_| env::var("HOME")).unwrap_or_default();
                 let dir = format!("{}\\.psmux", home);
                 // Compute namespace prefix for -L filtering
-                let ns_prefix = l_socket_name.as_ref().map(|l| format!("{l}__"));
+                let ns_prefix = session_namespace.as_ref().map(|l| format!("{l}__"));
                 if let Ok(entries) = std::fs::read_dir(&dir) {
                     for e in entries.flatten() {
                         if let Some(name) = e.file_name().to_str() {
@@ -548,14 +780,12 @@ fn run_main() -> io::Result<()> {
                 return Ok(());
             }
             "a" | "at" | "attach" | "attach-session" => {
-                let name = args
-                    .iter()
-                    .position(|a| a == "-t")
-                    .and_then(|i| args.get(i + 1))
-                    .map(|s| s.clone())
-                    .or_else(resolve_default_session_name)
-                    .or_else(resolve_last_session_name)
-                    .unwrap_or_else(|| "0".to_string());
+                let name =
+                    resolve_attach_session_name(
+                        &args,
+                        env::var("PSMUX_TARGET_SESSION").ok(),
+                        session_namespace.is_some(),
+                    );
                 env::set_var("PSMUX_SESSION_NAME", name);
                 env::set_var("PSMUX_REMOTE_ATTACH", "1");
             }
@@ -650,10 +880,10 @@ fn run_main() -> io::Result<()> {
 
                 let name = session_name.unwrap_or_else(|| {
                     // tmux-compatible: auto-generate numeric name (0, 1, 2, ...)
-                    crate::session::next_session_name(l_socket_name.as_deref())
+                    crate::session::next_session_name(session_namespace.as_deref())
                 });
                 // Compute port file base name: with -L namespace prefix if specified
-                let port_file_base = if let Some(ref l) = l_socket_name {
+                let port_file_base = if let Some(ref l) = session_namespace {
                     format!("{}__{}", l, name)
                 } else {
                     name.clone()
@@ -711,7 +941,7 @@ fn run_main() -> io::Result<()> {
                 let warm_disabled = std::env::var("PSMUX_NO_WARM").map(|v| v == "1" || v == "true").unwrap_or(false)
                     || crate::config::is_warm_disabled_by_config();
                 let claimed_warm = if !warm_disabled && initial_cmd.is_none() && raw_cmd_args.is_none() && start_dir.is_none() {
-                    let warm_base = if let Some(ref l) = l_socket_name {
+                    let warm_base = if let Some(ref l) = session_namespace {
                         format!("{}____warm__", l)
                     } else {
                         "__warm__".to_string()
@@ -765,7 +995,7 @@ fn run_main() -> io::Result<()> {
                 // Cold path: spawn a background server from scratch
                 let server_config = terminal_engine::HeadlessServerConfig {
                     session_name: name.clone(),
-                    socket_name: l_socket_name.clone(),
+                    socket_name: session_namespace.clone(),
                     initial_command: initial_cmd.clone(),
                     raw_command: raw_cmd_args.clone(),
                     start_dir: start_dir.clone(),
@@ -1231,7 +1461,7 @@ fn run_main() -> io::Result<()> {
                         "-t" => {
                             if let Some(t) = cmd_args.get(i + 1) {
                                 // Apply -L namespace prefix for port file lookup
-                                let namespaced = if let Some(ref l) = l_socket_name {
+                                let namespaced = if let Some(ref l) = session_namespace {
                                     format!("{}__{}", l, t)
                                 } else {
                                     t.to_string()
@@ -1247,7 +1477,7 @@ fn run_main() -> io::Result<()> {
                 let session_name = target.clone().unwrap_or_else(|| {
                     env::var("PSMUX_TARGET_SESSION").unwrap_or_else(|_| {
                         // Apply -L namespace prefix to default
-                        if let Some(ref l) = l_socket_name {
+                        if let Some(ref l) = session_namespace {
                             format!("{}__{}", l, "default")
                         } else {
                             "default".to_string()
@@ -1284,7 +1514,7 @@ fn run_main() -> io::Result<()> {
                         i += 1;
                     }
                     // Apply -L namespace prefix for port file lookup
-                    if let Some(ref l) = l_socket_name {
+                    if let Some(ref l) = session_namespace {
                         format!("{}__{}", l, t)
                     } else {
                         t
@@ -2445,7 +2675,7 @@ fn run_main() -> io::Result<()> {
                 // instant.  Also triggers Windows Defender's scan cache on the
                 // binary, eliminating the ~200-400ms first-run penalty.
                 let home = env::var("USERPROFILE").or_else(|_| env::var("HOME")).unwrap_or_default();
-                let warm_base = if let Some(ref l) = l_socket_name {
+                let warm_base = if let Some(ref l) = session_namespace {
                     format!("{}____warm__", l)
                 } else {
                     "__warm__".to_string()
@@ -2470,7 +2700,7 @@ fn run_main() -> io::Result<()> {
                 // Spawn the warm server
                 let mut config = terminal_engine::HeadlessServerConfig {
                     session_name: "__warm__".to_string(),
-                    socket_name: l_socket_name.clone(),
+                    socket_name: session_namespace.clone(),
                     ..terminal_engine::HeadlessServerConfig::default()
                 };
                 // Detect terminal size for the warm server
@@ -2608,9 +2838,9 @@ fn run_main() -> io::Result<()> {
     if env::var("PSMUX_REMOTE_ATTACH").ok().as_deref() != Some("1") {
         let home = env::var("USERPROFILE").or_else(|_| env::var("HOME")).unwrap_or_default();
         let session_name = env::var("PSMUX_SESSION_NAME").unwrap_or_else(|_| {
-            crate::session::next_session_name(l_socket_name.as_deref())
+            crate::session::next_session_name(session_namespace.as_deref())
         });
-        let port_file_base = if let Some(ref l) = l_socket_name {
+        let port_file_base = if let Some(ref l) = session_namespace {
             format!("{}__{}", l, session_name)
         } else {
             session_name.clone()
@@ -2621,7 +2851,7 @@ fn run_main() -> io::Result<()> {
         // Skipped when PSMUX_NO_WARM=1 is set or config has 'set -g warm off'.
         let warm_disabled = std::env::var("PSMUX_NO_WARM").map(|v| v == "1" || v == "true").unwrap_or(false)
             || crate::config::is_warm_disabled_by_config();
-        let warm_base = if let Some(ref l) = l_socket_name {
+        let warm_base = if let Some(ref l) = session_namespace {
             format!("{}____warm__", l)
         } else {
             "__warm__".to_string()
@@ -2680,12 +2910,10 @@ fn run_main() -> io::Result<()> {
 
         if !warm_claimed {
             // Cold path: spawn a new background server
-            terminal_engine::spawn_headless_server(
-                &terminal_engine::HeadlessServerConfig {
-                    session_name: session_name.clone(),
-                    ..terminal_engine::HeadlessServerConfig::default()
-                },
-            )?;
+            terminal_engine::spawn_headless_server(&bare_session_headless_server_config(
+                session_name.clone(),
+                session_namespace.clone(),
+            ))?;
 
             // Wait for server to start (fast polling — port file is written early)
             for _ in 0..500 {

--- a/core/src/session.rs
+++ b/core/src/session.rs
@@ -1,7 +1,7 @@
 use std::io::{self, Write};
 use std::time::Duration;
 use std::env;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 /// Returns true if this port-file base name belongs to a warm (standby) server.
 /// Warm sessions should be hidden from user-facing lists and never auto-attached.
@@ -21,6 +21,111 @@ pub fn warm_session_base(socket_name: Option<&str>) -> String {
 fn psmux_dir() -> Option<std::path::PathBuf> {
     let home = env::var("USERPROFILE").or_else(|_| env::var("HOME")).ok()?;
     Some(Path::new(&home).join(".psmux"))
+}
+
+pub fn socket_path_session_base(socket_path: &str) -> Option<String> {
+    let selector = normalize_socket_selector(socket_path)?;
+    let path = Path::new(&selector);
+    let looks_like_path =
+        selector.contains('\\') || selector.contains('/') || path.extension().is_some();
+    if looks_like_path {
+        let hash = stable_socket_namespace_hash(&selector);
+        return Some(format!("socket-{hash:016x}"));
+    }
+
+    let candidate = path
+        .file_name()
+        .and_then(|value| value.to_str())
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or(&selector)
+        .trim()
+        .to_string();
+
+    if candidate.is_empty() || is_warm_session(&candidate) {
+        return None;
+    }
+
+    Some(candidate)
+}
+
+pub fn normalize_socket_selector(socket_path: &str) -> Option<String> {
+    let trimmed = socket_path.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    let path = Path::new(trimmed);
+    let looks_like_path =
+        trimmed.contains('\\') || trimmed.contains('/') || path.extension().is_some();
+    if looks_like_path {
+        return Some(normalize_socket_selector_path(path));
+    }
+
+    Some(trimmed.to_string())
+}
+
+fn normalize_socket_selector_path(path: &Path) -> String {
+    let full_path: PathBuf = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        env::current_dir()
+            .map(|current_dir| current_dir.join(path))
+            .unwrap_or_else(|_| path.to_path_buf())
+    };
+    let normalized = full_path.to_string_lossy().replace('\\', "/");
+    if cfg!(windows) {
+        normalized.to_lowercase()
+    } else {
+        normalized
+    }
+}
+
+fn stable_socket_namespace_hash(value: &str) -> u64 {
+    let mut hash = 0xcbf2_9ce4_8422_2325_u64;
+    for byte in value.as_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    hash
+}
+
+pub fn resolve_last_session_name_with_prefix(prefix: &str) -> Option<String> {
+    let dir = psmux_dir()?;
+
+    let last_session = std::fs::read_to_string(dir.join("last_session")).ok();
+    let last_session = last_session.as_deref().map(str::trim).unwrap_or("");
+    if !last_session.is_empty()
+        && !is_warm_session(last_session)
+        && last_session.starts_with(prefix)
+        && dir.join(format!("{last_session}.port")).is_file()
+    {
+        return Some(last_session.to_string());
+    }
+
+    let mut picks: Vec<(String, std::time::SystemTime)> = Vec::new();
+
+    if let Ok(rd) = std::fs::read_dir(dir) {
+        for e in rd.flatten() {
+            if let Some(fname) = e.file_name().to_str() {
+                if let Some((base, ext)) = fname.rsplit_once('.') {
+                    if ext != "port" || is_warm_session(base) || !base.starts_with(prefix) {
+                        continue;
+                    }
+
+                    if let Ok(md) = e.metadata() {
+                        picks.push((
+                            base.to_string(),
+                            md.modified()
+                                .unwrap_or(std::time::SystemTime::UNIX_EPOCH),
+                        ));
+                    }
+                }
+            }
+        }
+    }
+
+    picks.sort_by_key(|(_, t)| *t);
+    picks.last().map(|(n, _)| n.clone())
 }
 
 fn port_is_open(port: u16, timeout: Duration) -> bool {
@@ -574,12 +679,83 @@ pub fn kill_remaining_server_processes() {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn warm_session_base_matches_namespace_encoding() {
         assert_eq!(warm_session_base(None), "__warm__");
         assert_eq!(warm_session_base(Some("preview")), "preview____warm__");
+    }
+
+    #[test]
+    fn socket_path_session_base_preserves_simple_socket_names() {
+        assert_eq!(
+            socket_path_session_base("socket-name").as_deref(),
+            Some("socket-name")
+        );
+    }
+
+    #[test]
+    fn socket_path_session_base_hashes_real_paths() {
+        let first = socket_path_session_base(r"C:\a\mux.sock").expect("first path should resolve");
+        let second = socket_path_session_base(r"C:\b\mux.sock").expect("second path should resolve");
+        let relative = socket_path_session_base("mux.sock").expect("relative path should resolve");
+
+        assert!(first.starts_with("socket-"));
+        assert!(second.starts_with("socket-"));
+        assert!(relative.starts_with("socket-"));
+        assert_ne!(first, second);
+        assert_ne!(first, relative);
+        assert_ne!(second, relative);
+    }
+
+    #[test]
+    fn normalize_socket_selector_resolves_relative_paths() {
+        let expected = env::current_dir()
+            .expect("test should read current dir")
+            .join("mux.sock")
+            .to_string_lossy()
+            .replace('\\', "/");
+        let expected = if cfg!(windows) {
+            expected.to_lowercase()
+        } else {
+            expected
+        };
+
+        assert_eq!(
+            normalize_socket_selector("mux.sock").as_deref(),
+            Some(expected.as_str())
+        );
+    }
+
+    #[test]
+    fn resolve_last_session_name_with_prefix_prefers_matching_last_session() {
+        let _guard = ENV_LOCK.lock().expect("env lock should not be poisoned");
+        let old_userprofile = env::var_os("USERPROFILE");
+        let old_home = env::var_os("HOME");
+        let temp_home = make_temp_psmux_home("session-prefix");
+        let psmux_dir = temp_home.join(".psmux");
+
+        std::fs::write(psmux_dir.join("ops__older.port"), "1")
+            .expect("test should write older port file");
+        std::thread::sleep(Duration::from_millis(20));
+        std::fs::write(psmux_dir.join("ops__newer.port"), "2")
+            .expect("test should write newer port file");
+        std::fs::write(psmux_dir.join("last_session"), "ops__older\n")
+            .expect("test should write last_session");
+
+        env::set_var("USERPROFILE", &temp_home);
+        env::set_var("HOME", &temp_home);
+        let resolved = resolve_last_session_name_with_prefix("ops__");
+
+        restore_env("USERPROFILE", old_userprofile);
+        restore_env("HOME", old_home);
+        let _ = std::fs::remove_dir_all(&temp_home);
+
+        assert_eq!(resolved.as_deref(), Some("ops__older"));
     }
 
     #[test]
@@ -603,6 +779,10 @@ mod tests {
     }
 
     fn make_temp_psmux_dir(name: &str) -> std::path::PathBuf {
+        make_temp_psmux_home(name).join(".psmux")
+    }
+
+    fn make_temp_psmux_home(name: &str) -> std::path::PathBuf {
         let suffix = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .expect("system clock should be after unix epoch")
@@ -611,7 +791,15 @@ mod tests {
             "winsmux-{name}-{}-{suffix}",
             std::process::id()
         ));
-        std::fs::create_dir_all(&path).expect("test should create temp dir");
+        std::fs::create_dir_all(path.join(".psmux")).expect("test should create temp dir");
         path
+    }
+
+    fn restore_env(name: &str, value: Option<std::ffi::OsString>) {
+        if let Some(value) = value {
+            env::set_var(name, value);
+        } else {
+            env::remove_var(name);
+        }
     }
 }

--- a/core/tests-rs/operator_cli.rs
+++ b/core/tests-rs/operator_cli.rs
@@ -100,6 +100,122 @@ Write-Output ("bridge:" + ($Rest -join "|"))
 }
 
 #[test]
+#[cfg(windows)]
+fn operator_cli_forwards_namespace_flags_to_winsmux_core_script() {
+    let project_dir = make_temp_project_dir("winsmux-core-namespace-bridge");
+    let script_path = project_dir.join("winsmux-core-namespace-bridge.ps1");
+    fs::write(
+        &script_path,
+        r#"
+param([Parameter(ValueFromRemainingArguments = $true)][string[]]$Rest)
+Write-Output ("bridge:L=$env:WINSMUX_BRIDGE_NAMESPACE_L;S=$env:WINSMUX_BRIDGE_SOCKET_S;N=$env:WINSMUX_BRIDGE_SESSION_NAMESPACE;args=" + ($Rest -join "|"))
+"#,
+    )
+    .expect("test should write fake winsmux-core script");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .args(["-L", "ops", "-S", "socket-name", "list"])
+        .env("WINSMUX_CORE_SCRIPT", &script_path)
+        .current_dir(&project_dir)
+        .output()
+        .expect("winsmux command should run");
+
+    assert!(
+        output.status.success(),
+        "winsmux command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("bridge:L=ops;S=socket-name;N=socket-name;args=list"),
+        "unexpected stdout: {stdout}"
+    );
+}
+
+#[test]
+#[cfg(windows)]
+fn operator_cli_resolves_relative_socket_path_before_bridge_delegation() {
+    let project_dir = make_temp_project_dir("winsmux-core-relative-socket-bridge");
+    let script_path = project_dir.join("winsmux-core-relative-socket-bridge.ps1");
+    fs::write(
+        &script_path,
+        r#"
+param([Parameter(ValueFromRemainingArguments = $true)][string[]]$Rest)
+Write-Output ("bridge:S=$env:WINSMUX_BRIDGE_SOCKET_S;N=$env:WINSMUX_BRIDGE_SESSION_NAMESPACE;args=" + ($Rest -join "|"))
+"#,
+    )
+    .expect("test should write fake winsmux-core script");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .args(["-S", "mux.sock", "list"])
+        .env("WINSMUX_CORE_SCRIPT", &script_path)
+        .current_dir(&project_dir)
+        .output()
+        .expect("winsmux command should run");
+
+    assert!(
+        output.status.success(),
+        "winsmux command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let expected_socket = project_dir
+        .join("mux.sock")
+        .to_string_lossy()
+        .replace('\\', "/")
+        .to_lowercase();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains(&format!("bridge:S={expected_socket};N=socket-")),
+        "unexpected stdout: {stdout}"
+    );
+    assert!(stdout.contains(";args=list"), "unexpected stdout: {stdout}");
+}
+
+#[test]
+#[cfg(windows)]
+fn operator_cli_uses_socket_path_for_native_target_resolution() {
+    let project_dir = make_temp_project_dir("winsmux-core-socket-target");
+    let home_dir = project_dir.join("home");
+    let psmux_dir = home_dir.join(".psmux");
+    fs::create_dir_all(&psmux_dir).expect("test should create psmux dir");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .args([
+            "-L",
+            "ops",
+            "-S",
+            "socket-name",
+            "display-message",
+            "-t",
+            "winsmux-orchestra",
+            "-p",
+            "probe",
+        ])
+        .env("USERPROFILE", &home_dir)
+        .env("HOME", &home_dir)
+        .env_remove("PSMUX_TARGET_SESSION")
+        .env_remove("PSMUX_TARGET_FULL")
+        .env_remove("TMUX")
+        .current_dir(&project_dir)
+        .output()
+        .expect("winsmux command should run");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        !output.status.success(),
+        "winsmux command should fail because the test only checks target resolution"
+    );
+    assert!(
+        stderr.contains("socket-name__winsmux-orchestra"),
+        "expected -S to select the socket namespace, got stderr={stderr}"
+    );
+    assert!(
+        !stderr.contains("ops__winsmux-orchestra"),
+        "expected -S to take precedence over -L, got stderr={stderr}"
+    );
+}
+
+#[test]
 fn operator_cli_keeps_native_operator_commands_in_rust_binary() {
     let project_dir = make_temp_project_dir("winsmux-core-native");
     write_manifest(&project_dir);

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -5,6 +5,14 @@ param(
     [Parameter(Position=2, ValueFromRemainingArguments=$true)][string[]]$Rest
 )
 
+$script:WinsmuxRawGlobalArgs = @()
+if (-not [string]::IsNullOrWhiteSpace($env:WINSMUX_BRIDGE_NAMESPACE_L)) {
+    $script:WinsmuxRawGlobalArgs += @('-L', $env:WINSMUX_BRIDGE_NAMESPACE_L)
+}
+if (-not [string]::IsNullOrWhiteSpace($env:WINSMUX_BRIDGE_SOCKET_S)) {
+    $script:WinsmuxRawGlobalArgs += @('-S', $env:WINSMUX_BRIDGE_SOCKET_S)
+}
+
 # --- Config ---
 $VERSION = "0.24.22"
 [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
@@ -114,7 +122,12 @@ function Get-SafeLastExitCode {
 function Invoke-WinsmuxRaw {
     param([Parameter(Mandatory = $true)][string[]]$Arguments)
 
-    return & winsmux @Arguments
+    $rawArguments = @()
+    if ($script:WinsmuxRawGlobalArgs) {
+        $rawArguments += $script:WinsmuxRawGlobalArgs
+    }
+    $rawArguments += @($Arguments)
+    return & winsmux @rawArguments
 }
 
 function Resolve-TerminalBackend {
@@ -2239,7 +2252,7 @@ function Test-CodexReadyPromptText {
 function Test-CodexReadyPrompt {
     param([string]$PaneId)
 
-    $output = & winsmux capture-pane -t $PaneId -p -J -S -50
+    $output = Invoke-WinsmuxRaw -Arguments @('capture-pane', '-t', $PaneId, '-p', '-J', '-S', '-50')
     return Test-CodexReadyPromptText (($output | Out-String).TrimEnd())
 }
 
@@ -2407,7 +2420,7 @@ function Test-AgentReadyPrompt {
         [string]$Agent = ''
     )
 
-    $output = & winsmux capture-pane -t $PaneId -p -J -S -50
+    $output = Invoke-WinsmuxRaw -Arguments @('capture-pane', '-t', $PaneId, '-p', '-J', '-S', '-50')
     return Test-AgentReadyPromptText -Text (($output | Out-String).TrimEnd()) -Agent $Agent
 }
 
@@ -2490,7 +2503,7 @@ function Wait-PaneShellReady {
 
     $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
     while ((Get-Date) -lt $deadline) {
-        $snapshot = (& winsmux capture-pane -t $PaneId -p -J -S -50 2>$null | Out-String).TrimEnd()
+        $snapshot = (Invoke-WinsmuxRaw -Arguments @('capture-pane', '-t', $PaneId, '-p', '-J', '-S', '-50') 2>$null | Out-String).TrimEnd()
         $lastLine = Get-LastNonEmptyLine $snapshot
         if ($lastLine -and $lastLine.Trim() -match '^PS ') {
             return
@@ -2504,7 +2517,7 @@ function Wait-PaneShellReady {
 
 function Get-PaneRuntimeMap {
     $paneMap = @{}
-    $raw = & winsmux list-panes -a -F '#{pane_id} #{pane_pid}'
+    $raw = Invoke-WinsmuxRaw -Arguments @('list-panes', '-a', '-F', '#{pane_id} #{pane_pid}')
     $lines = ($raw | Out-String).Trim() -split "`n"
 
     foreach ($line in $lines) {
@@ -2835,13 +2848,13 @@ function Invoke-Id {
     if ($env:TMUX_PANE) {
         Write-Output $env:TMUX_PANE
     } else {
-        $id = & winsmux display-message -p '#{pane_id}'
+        $id = Invoke-WinsmuxRaw -Arguments @('display-message', '-p', '#{pane_id}')
         Write-Output ($id | Out-String).Trim()
     }
 }
 
 function Invoke-List {
-    $raw = & winsmux list-panes -a -F '#{pane_id} #{pane_pid} #{pane_current_command} #{pane_width}x#{pane_height} #{pane_title}'
+    $raw = Invoke-WinsmuxRaw -Arguments @('list-panes', '-a', '-F', '#{pane_id} #{pane_pid} #{pane_current_command} #{pane_width}x#{pane_height} #{pane_title}')
     $labels = Get-Labels
     # Build reverse lookup: paneId -> label
     $reverseLabels = @{}
@@ -2900,7 +2913,7 @@ function Invoke-Read {
     $paneId = Resolve-Target $Target
     $paneId = Confirm-Target $paneId
 
-    $output = & winsmux capture-pane -t $paneId -p -J -S "-$lines"
+    $output = Invoke-WinsmuxRaw -Arguments @('capture-pane', '-t', $paneId, '-p', '-J', '-S', "-$lines")
     $currentText = ($output | Out-String).TrimEnd()
 
     # Watermark-based change detection: if a watermark exists (set by send),
@@ -2930,7 +2943,7 @@ function Invoke-Type {
 
     Assert-ReadMark $paneId
 
-    & winsmux send-keys -t $paneId -l -- "$text"
+    Invoke-WinsmuxRaw -Arguments @('send-keys', '-t', $paneId, '-l', '--', "$text")
 
     Clear-ReadMark $paneId
 }
@@ -2945,7 +2958,7 @@ function Invoke-Keys {
     Assert-ReadMark $paneId
 
     foreach ($key in $Rest) {
-        & winsmux send-keys -t $paneId $key
+        Invoke-WinsmuxRaw -Arguments @('send-keys', '-t', $paneId, $key)
     }
 
     Clear-ReadMark $paneId
@@ -2961,12 +2974,12 @@ function Invoke-Message {
 
     Assert-ReadMark $paneId
 
-    $myId = (& winsmux display-message -p '#{pane_id}' | Out-String).Trim()
-    $myCoord = (& winsmux display-message -p '#{session_name}:#{window_index}.#{pane_index}' | Out-String).Trim()
+    $myId = (Invoke-WinsmuxRaw -Arguments @('display-message', '-p', '#{pane_id}') | Out-String).Trim()
+    $myCoord = (Invoke-WinsmuxRaw -Arguments @('display-message', '-p', '#{session_name}:#{window_index}.#{pane_index}') | Out-String).Trim()
     $agentName = if ($env:WINSMUX_AGENT_NAME) { $env:WINSMUX_AGENT_NAME } else { "unknown" }
 
     $header = "[winsmux from:$agentName pane:$myId at:$myCoord -- load the winsmux skill to reply]"
-    & winsmux send-keys -t $paneId -l -- "$header $text"
+    Invoke-WinsmuxRaw -Arguments @('send-keys', '-t', $paneId, '-l', '--', "$header $text")
 
     Clear-ReadMark $paneId
 }
@@ -3178,7 +3191,7 @@ function Invoke-Name {
 
     # Also set pane title (best-effort)
     try {
-        & winsmux select-pane -t $paneId -T "$label" 2>$null
+        Invoke-WinsmuxRaw -Arguments @('select-pane', '-t', $paneId, '-T', "$label") 2>$null
     } catch { }
 
     Write-Output "Labeled pane $paneId as '$label'"
@@ -3208,7 +3221,7 @@ function Invoke-AutoRebalance {
     $idleBuilders = @()
     foreach ($label in $builderLabels) {
         $paneId = $labels[$label]
-        $snapshot = (& winsmux capture-pane -t $paneId -p 2>$null | Out-String).TrimEnd()
+        $snapshot = (Invoke-WinsmuxRaw -Arguments @('capture-pane', '-t', $paneId, '-p') 2>$null | Out-String).TrimEnd()
         $lastLine = ($snapshot -split "`n" | Where-Object { $_.Trim() } | Select-Object -Last 1)
         $isIdle = $lastLine -and ($lastLine.Trim() -match '\d+% left' -or $lastLine.Trim() -match '^[>›]')
         if ($isIdle) { $idleBuilders += $label }
@@ -3334,7 +3347,7 @@ function Invoke-Role {
     }
 
     # Rename pane first (before respawn)
-    & winsmux select-pane -t $paneId -T $newLabel
+    Invoke-WinsmuxRaw -Arguments @('select-pane', '-t', $paneId, '-T', $newLabel)
 
     # Update labels
     $labels[$newLabel] = $paneId
@@ -3397,7 +3410,7 @@ function Invoke-Role {
         }
         foreach ($name in $transientEnvironmentNames) {
             try {
-                & winsmux set-environment -u -t $sessionName $name
+                Invoke-WinsmuxRaw -Arguments @('set-environment', '-u', '-t', $sessionName, $name)
             } catch {
             }
         }
@@ -3433,7 +3446,7 @@ function Invoke-Role {
             -AssignedBranch $assignedBranch `
             -GitWorktreeDir $environmentGitDir
         foreach ($entry in $paneEnvironment.GetEnumerator()) {
-            & winsmux set-environment -t $sessionName ([string]$entry.Key) ([string]$entry.Value)
+            Invoke-WinsmuxRaw -Arguments @('set-environment', '-t', $sessionName, ([string]$entry.Key), ([string]$entry.Value))
             if ($entry.Key -notin $persistentEnvironmentNames -and $entry.Key -notin $transientEnvironmentNames) {
                 $transientEnvironmentNames += [string]$entry.Key
             }
@@ -3442,24 +3455,24 @@ function Invoke-Role {
 
     try {
         # Respawn pane (kills current process + restarts shell in one step, #174)
-        & winsmux respawn-pane -k -t $paneId -c $launchDir
+        Invoke-WinsmuxRaw -Arguments @('respawn-pane', '-k', '-t', $paneId, '-c', $launchDir)
 
         # Wait for shell ready (poll for PS prompt)
         $deadline = (Get-Date).AddSeconds(15)
         while ((Get-Date) -lt $deadline) {
-            $snapshot = (& winsmux capture-pane -t $paneId -p 2>$null | Out-String).TrimEnd()
+            $snapshot = (Invoke-WinsmuxRaw -Arguments @('capture-pane', '-t', $paneId, '-p') 2>$null | Out-String).TrimEnd()
             $lastLine = ($snapshot -split "`n" | Where-Object { $_.Trim() } | Select-Object -Last 1)
             if ($lastLine -and $lastLine.Trim() -match '^PS ') { break }
             Start-Sleep -Milliseconds 500
         }
 
-        & winsmux send-keys -t $paneId -l $launchCmd
-        & winsmux send-keys -t $paneId Enter
+        Invoke-WinsmuxRaw -Arguments @('send-keys', '-t', $paneId, '-l', $launchCmd)
+        Invoke-WinsmuxRaw -Arguments @('send-keys', '-t', $paneId, 'Enter')
     } finally {
         if (-not [string]::IsNullOrWhiteSpace($sessionName)) {
             foreach ($name in @($transientEnvironmentNames | Select-Object -Unique)) {
                 try {
-                    & winsmux set-environment -u -t $sessionName $name
+                    Invoke-WinsmuxRaw -Arguments @('set-environment', '-u', '-t', $sessionName, $name)
                 } catch {
                 }
             }
@@ -3543,7 +3556,7 @@ function Invoke-Doctor {
 
     # winsmux binary check
     try {
-        $ver = & winsmux -V 2>&1
+        $ver = Invoke-WinsmuxRaw -Arguments @('-V') 2>&1
         Write-Output "winsmux: $($ver | Out-String)".Trim()
     } catch {
         Write-Output "winsmux: NOT FOUND"
@@ -3565,7 +3578,7 @@ function Invoke-Doctor {
 
     # Pane count
     try {
-        $panes = & winsmux list-panes -a -F '#{pane_id}'
+        $panes = Invoke-WinsmuxRaw -Arguments @('list-panes', '-a', '-F', '#{pane_id}')
         $count = (($panes | Out-String).Trim() -split "`n" | Where-Object { $_.Trim() }).Count
         Write-Output "Panes: $count"
     } catch {
@@ -3590,7 +3603,7 @@ function Invoke-Doctor {
 
     # escape-time check
     try {
-        $escTime = (& winsmux show-options -g -v escape-time 2>&1 | Out-String).Trim()
+        $escTime = (Invoke-WinsmuxRaw -Arguments @('show-options', '-g', '-v', 'escape-time') 2>&1 | Out-String).Trim()
         if ($escTime -match '^\d+$' -and [int]$escTime -gt 50) {
             Write-Output "escape-time: $escTime ms [WARNING: >50ms causes IME lag. Set to 0 in .winsmux.conf]"
         } else {
@@ -4444,7 +4457,7 @@ function Invoke-ImeInput {
         return
     }
 
-    & winsmux send-keys -t $paneId -l -- "$text"
+    Invoke-WinsmuxRaw -Arguments @('send-keys', '-t', $paneId, '-l', '--', "$text")
     Clear-ReadMark $paneId
     Write-Output "sent to $paneId"
 }
@@ -4475,7 +4488,7 @@ function Invoke-ImagePaste {
     $img.Dispose()
 
     # Send file path as text to the target pane
-    & winsmux send-keys -t $paneId -l -- "$imgPath"
+    Invoke-WinsmuxRaw -Arguments @('send-keys', '-t', $paneId, '-l', '--', "$imgPath")
     Clear-ReadMark $paneId
     Write-Output "image saved: $imgPath"
     Write-Output "path sent to $paneId"
@@ -4494,7 +4507,7 @@ function Invoke-ClipboardPaste {
         Stop-WithError "clipboard is empty"
     }
 
-    & winsmux send-keys -t $paneId -l -- "$text"
+    Invoke-WinsmuxRaw -Arguments @('send-keys', '-t', $paneId, '-l', '--', "$text")
     Clear-ReadMark $paneId
     Write-Output "sent to $paneId"
 }
@@ -4567,7 +4580,7 @@ function Invoke-Watch {
     if ($Rest -and $Rest.Count -gt 1) { $timeoutSec = [int]$Rest[1] }
 
     # Initial snapshot
-    $output = & winsmux capture-pane -t $paneId -p -J -S -50
+    $output = Invoke-WinsmuxRaw -Arguments @('capture-pane', '-t', $paneId, '-p', '-J', '-S', '-50')
     $prevHash = [System.BitConverter]::ToString(
         [System.Security.Cryptography.SHA256]::Create().ComputeHash(
             [System.Text.Encoding]::UTF8.GetBytes(($output | Out-String))
@@ -4581,7 +4594,7 @@ function Invoke-Watch {
         Start-Sleep -Seconds 1
         $elapsed++
 
-        $output = & winsmux capture-pane -t $paneId -p -J -S -50
+        $output = Invoke-WinsmuxRaw -Arguments @('capture-pane', '-t', $paneId, '-p', '-J', '-S', '-50')
         $currentHash = [System.BitConverter]::ToString(
             [System.Security.Cryptography.SHA256]::Create().ComputeHash(
                 [System.Text.Encoding]::UTF8.GetBytes(($output | Out-String))
@@ -9817,7 +9830,7 @@ function Invoke-Focus {
     $paneId = Confirm-Target $paneId
     Assert-FocusAllowed -PaneId $paneId -RawTarget $FocusTarget
 
-    & winsmux select-pane -t $paneId
+    Invoke-WinsmuxRaw -Arguments @('select-pane', '-t', $paneId)
     Write-Output "Focused pane $paneId ($FocusTarget)"
 }
 
@@ -10088,8 +10101,8 @@ function Invoke-VaultInject {
             # Escape single quotes in value for safe injection
             $escapedValue = $value -replace "'", "''"
             $setCmd = "`$env:$envName = '$escapedValue'"
-            & winsmux send-keys -t $paneId -l -- "$setCmd"
-            & winsmux send-keys -t $paneId Enter
+            Invoke-WinsmuxRaw -Arguments @('send-keys', '-t', $paneId, '-l', '--', "$setCmd")
+            Invoke-WinsmuxRaw -Arguments @('send-keys', '-t', $paneId, 'Enter')
             Start-Sleep -Milliseconds 100
             $injected++
         }
@@ -11207,7 +11220,7 @@ function Invoke-Kill {
     $paneId = Resolve-Target $Target
     $paneId = Confirm-Target $paneId
 
-    & winsmux respawn-pane -k -t $paneId
+    Invoke-WinsmuxRaw -Arguments @('respawn-pane', '-k', '-t', $paneId)
     $nativeExitCode = Get-SafeLastExitCode
     if ($null -ne $nativeExitCode -and $nativeExitCode -ne 0) {
         Stop-WithError "failed to kill pane process: $paneId"
@@ -11231,7 +11244,7 @@ function Invoke-RestartPane {
 
     $plan = Get-PaneControlRestartPlan -ProjectDir $ProjectDir -PaneId $PaneId -Settings $settings
 
-    & winsmux respawn-pane -k -t $PaneId -c $plan.LaunchDir
+    Invoke-WinsmuxRaw -Arguments @('respawn-pane', '-k', '-t', $PaneId, '-c', $plan.LaunchDir)
     $nativeExitCode = Get-SafeLastExitCode
     if ($null -ne $nativeExitCode -and $nativeExitCode -ne 0) {
         Stop-WithError "failed to restart pane shell: $PaneId"
@@ -11243,12 +11256,12 @@ function Invoke-RestartPane {
     } catch {
     }
 
-    & winsmux send-keys -t $PaneId -l -- "$($plan.LaunchCommand)"
+    Invoke-WinsmuxRaw -Arguments @('send-keys', '-t', $PaneId, '-l', '--', "$($plan.LaunchCommand)")
     $nativeExitCode = Get-SafeLastExitCode
     if ($null -ne $nativeExitCode -and $nativeExitCode -ne 0) {
         Stop-WithError "failed to send launch command to $PaneId"
     }
-    & winsmux send-keys -t $PaneId Enter
+    Invoke-WinsmuxRaw -Arguments @('send-keys', '-t', $PaneId, 'Enter')
     $nativeExitCode = Get-SafeLastExitCode
     if ($null -ne $nativeExitCode -and $nativeExitCode -ne 0) {
         Stop-WithError "failed to submit launch command to $PaneId"

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -4414,6 +4414,162 @@ Describe 'orchestra-preflight health contract' {
         . (Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\orchestra-preflight.ps1')
     }
 
+    It 'uses the plain session registry path when no bridge namespace is selected' {
+        $previousNamespace = $env:WINSMUX_BRIDGE_NAMESPACE_L
+        $previousSocket = $env:WINSMUX_BRIDGE_SOCKET_S
+        $previousSessionNamespace = $env:WINSMUX_BRIDGE_SESSION_NAMESPACE
+        try {
+            Remove-Item Env:\WINSMUX_BRIDGE_NAMESPACE_L -ErrorAction SilentlyContinue
+            Remove-Item Env:\WINSMUX_BRIDGE_SOCKET_S -ErrorAction SilentlyContinue
+            Remove-Item Env:\WINSMUX_BRIDGE_SESSION_NAMESPACE -ErrorAction SilentlyContinue
+
+            Split-Path -Leaf (Get-OrchestraSessionPortFilePath -SessionName 'winsmux-orchestra') |
+                Should -Be 'winsmux-orchestra.port'
+            Split-Path -Leaf (Get-OrchestraSessionKeyFilePath -SessionName 'winsmux-orchestra') |
+                Should -Be 'winsmux-orchestra.key'
+        } finally {
+            if ($null -eq $previousNamespace) {
+                Remove-Item Env:\WINSMUX_BRIDGE_NAMESPACE_L -ErrorAction SilentlyContinue
+            } else {
+                $env:WINSMUX_BRIDGE_NAMESPACE_L = $previousNamespace
+            }
+            if ($null -eq $previousSocket) {
+                Remove-Item Env:\WINSMUX_BRIDGE_SOCKET_S -ErrorAction SilentlyContinue
+            } else {
+                $env:WINSMUX_BRIDGE_SOCKET_S = $previousSocket
+            }
+            if ($null -eq $previousSessionNamespace) {
+                Remove-Item Env:\WINSMUX_BRIDGE_SESSION_NAMESPACE -ErrorAction SilentlyContinue
+            } else {
+                $env:WINSMUX_BRIDGE_SESSION_NAMESPACE = $previousSessionNamespace
+            }
+        }
+    }
+
+    It 'uses the forwarded bridge namespace for orchestra registry paths' {
+        $previousNamespace = $env:WINSMUX_BRIDGE_NAMESPACE_L
+        $previousSocket = $env:WINSMUX_BRIDGE_SOCKET_S
+        $previousSessionNamespace = $env:WINSMUX_BRIDGE_SESSION_NAMESPACE
+        try {
+            $env:WINSMUX_BRIDGE_NAMESPACE_L = 'ops'
+            Remove-Item Env:\WINSMUX_BRIDGE_SOCKET_S -ErrorAction SilentlyContinue
+            Remove-Item Env:\WINSMUX_BRIDGE_SESSION_NAMESPACE -ErrorAction SilentlyContinue
+
+            Split-Path -Leaf (Get-OrchestraSessionPortFilePath -SessionName 'winsmux-orchestra') |
+                Should -Be 'ops__winsmux-orchestra.port'
+            Split-Path -Leaf (Get-OrchestraSessionKeyFilePath -SessionName 'winsmux-orchestra') |
+                Should -Be 'ops__winsmux-orchestra.key'
+        } finally {
+            if ($null -eq $previousNamespace) {
+                Remove-Item Env:\WINSMUX_BRIDGE_NAMESPACE_L -ErrorAction SilentlyContinue
+            } else {
+                $env:WINSMUX_BRIDGE_NAMESPACE_L = $previousNamespace
+            }
+            if ($null -eq $previousSocket) {
+                Remove-Item Env:\WINSMUX_BRIDGE_SOCKET_S -ErrorAction SilentlyContinue
+            } else {
+                $env:WINSMUX_BRIDGE_SOCKET_S = $previousSocket
+            }
+            if ($null -eq $previousSessionNamespace) {
+                Remove-Item Env:\WINSMUX_BRIDGE_SESSION_NAMESPACE -ErrorAction SilentlyContinue
+            } else {
+                $env:WINSMUX_BRIDGE_SESSION_NAMESPACE = $previousSessionNamespace
+            }
+        }
+    }
+
+    It 'prefers the forwarded socket namespace over the -L namespace for orchestra registry paths' {
+        $previousNamespace = $env:WINSMUX_BRIDGE_NAMESPACE_L
+        $previousSocket = $env:WINSMUX_BRIDGE_SOCKET_S
+        $previousSessionNamespace = $env:WINSMUX_BRIDGE_SESSION_NAMESPACE
+        try {
+            $env:WINSMUX_BRIDGE_NAMESPACE_L = 'ops'
+            $env:WINSMUX_BRIDGE_SOCKET_S = 'socket-name'
+            Remove-Item Env:\WINSMUX_BRIDGE_SESSION_NAMESPACE -ErrorAction SilentlyContinue
+
+            Split-Path -Leaf (Get-OrchestraSessionPortFilePath -SessionName 'winsmux-orchestra') |
+                Should -Be 'socket-name__winsmux-orchestra.port'
+            Split-Path -Leaf (Get-OrchestraSessionKeyFilePath -SessionName 'winsmux-orchestra') |
+                Should -Be 'socket-name__winsmux-orchestra.key'
+        } finally {
+            if ($null -eq $previousNamespace) {
+                Remove-Item Env:\WINSMUX_BRIDGE_NAMESPACE_L -ErrorAction SilentlyContinue
+            } else {
+                $env:WINSMUX_BRIDGE_NAMESPACE_L = $previousNamespace
+            }
+            if ($null -eq $previousSocket) {
+                Remove-Item Env:\WINSMUX_BRIDGE_SOCKET_S -ErrorAction SilentlyContinue
+            } else {
+                $env:WINSMUX_BRIDGE_SOCKET_S = $previousSocket
+            }
+            if ($null -eq $previousSessionNamespace) {
+                Remove-Item Env:\WINSMUX_BRIDGE_SESSION_NAMESPACE -ErrorAction SilentlyContinue
+            } else {
+                $env:WINSMUX_BRIDGE_SESSION_NAMESPACE = $previousSessionNamespace
+            }
+        }
+    }
+
+    It 'uses the resolved bridge session namespace when the socket selector was path-based' {
+        $previousNamespace = $env:WINSMUX_BRIDGE_NAMESPACE_L
+        $previousSocket = $env:WINSMUX_BRIDGE_SOCKET_S
+        $previousSessionNamespace = $env:WINSMUX_BRIDGE_SESSION_NAMESPACE
+        try {
+            $env:WINSMUX_BRIDGE_NAMESPACE_L = 'ops'
+            $env:WINSMUX_BRIDGE_SOCKET_S = 'C:\tmp\mux.sock'
+            $env:WINSMUX_BRIDGE_SESSION_NAMESPACE = 'socket-0123456789abcdef'
+
+            Split-Path -Leaf (Get-OrchestraSessionPortFilePath -SessionName 'winsmux-orchestra') |
+                Should -Be 'socket-0123456789abcdef__winsmux-orchestra.port'
+        } finally {
+            if ($null -eq $previousNamespace) {
+                Remove-Item Env:\WINSMUX_BRIDGE_NAMESPACE_L -ErrorAction SilentlyContinue
+            } else {
+                $env:WINSMUX_BRIDGE_NAMESPACE_L = $previousNamespace
+            }
+            if ($null -eq $previousSocket) {
+                Remove-Item Env:\WINSMUX_BRIDGE_SOCKET_S -ErrorAction SilentlyContinue
+            } else {
+                $env:WINSMUX_BRIDGE_SOCKET_S = $previousSocket
+            }
+            if ($null -eq $previousSessionNamespace) {
+                Remove-Item Env:\WINSMUX_BRIDGE_SESSION_NAMESPACE -ErrorAction SilentlyContinue
+            } else {
+                $env:WINSMUX_BRIDGE_SESSION_NAMESPACE = $previousSessionNamespace
+            }
+        }
+    }
+
+    It 'hashes a path-based socket selector when no resolved namespace is available' {
+        $previousNamespace = $env:WINSMUX_BRIDGE_NAMESPACE_L
+        $previousSocket = $env:WINSMUX_BRIDGE_SOCKET_S
+        $previousSessionNamespace = $env:WINSMUX_BRIDGE_SESSION_NAMESPACE
+        try {
+            $env:WINSMUX_BRIDGE_NAMESPACE_L = 'ops'
+            $env:WINSMUX_BRIDGE_SOCKET_S = 'C:\tmp\mux.sock'
+            Remove-Item Env:\WINSMUX_BRIDGE_SESSION_NAMESPACE -ErrorAction SilentlyContinue
+
+            Split-Path -Leaf (Get-OrchestraSessionPortFilePath -SessionName 'winsmux-orchestra') |
+                Should -Match '^socket-[0-9a-f]{16}__winsmux-orchestra\.port$'
+        } finally {
+            if ($null -eq $previousNamespace) {
+                Remove-Item Env:\WINSMUX_BRIDGE_NAMESPACE_L -ErrorAction SilentlyContinue
+            } else {
+                $env:WINSMUX_BRIDGE_NAMESPACE_L = $previousNamespace
+            }
+            if ($null -eq $previousSocket) {
+                Remove-Item Env:\WINSMUX_BRIDGE_SOCKET_S -ErrorAction SilentlyContinue
+            } else {
+                $env:WINSMUX_BRIDGE_SOCKET_S = $previousSocket
+            }
+            if ($null -eq $previousSessionNamespace) {
+                Remove-Item Env:\WINSMUX_BRIDGE_SESSION_NAMESPACE -ErrorAction SilentlyContinue
+            } else {
+                $env:WINSMUX_BRIDGE_SESSION_NAMESPACE = $previousSessionNamespace
+            }
+        }
+    }
+
     It 'marks health unhealthy when the pane count does not match the expected topology' {
         Mock Get-OrchestraSessionPortFilePath { 'C:\temp\winsmux-orchestra.port' }
         Mock Test-Path { $true } -ParameterFilter { $LiteralPath -eq 'C:\temp\winsmux-orchestra.port' }
@@ -12018,7 +12174,7 @@ Describe 'winsmux role command provider routing' {
         $script:winsmuxRoleRawContent | Should -Match '\$launchDir = \[string\]\$manifestEntry\.LaunchDir'
         $script:winsmuxRoleRawContent | Should -Match '\$gitDir = \[string\]\$manifestEntry\.GitWorktreeDir'
         $script:winsmuxRoleRawContent | Should -Match 'ProjectDir \$launchDir'
-        $script:winsmuxRoleRawContent | Should -Match 'respawn-pane -k -t \$paneId -c \$launchDir'
+        $script:winsmuxRoleRawContent | Should -Match ([regex]::Escape("Invoke-WinsmuxRaw -Arguments @('respawn-pane', '-k', '-t', `$paneId, '-c', `$launchDir)"))
         $script:winsmuxRoleRawContent | Should -Match 'role\s*=\s*\$manifestRole'
         $script:winsmuxRoleRawContent | Should -Match 'launch_dir\s*=\s*\$launchDir'
         $script:winsmuxRoleRawContent | Should -Match 'worktree_git_dir\s*=\s*\$gitDir'
@@ -12031,16 +12187,16 @@ Describe 'winsmux role command provider routing' {
         $script:winsmuxRoleRawContent | Should -Match 'Get-WinsmuxEnvironmentVariableNames'
         $script:winsmuxRoleRawContent | Should -Match 'Get-WinsmuxPaneEnvironment'
         $script:winsmuxRoleRawContent | Should -Match 'WINSMUX_ROLE_MAP'
-        $script:winsmuxRoleRawContent | Should -Match 'set-environment -t \$sessionName'
-        $script:winsmuxRoleRawContent | Should -Match 'set-environment -u -t \$sessionName \$name'
+        $script:winsmuxRoleRawContent | Should -Match ([regex]::Escape("Invoke-WinsmuxRaw -Arguments @('set-environment', '-t', `$sessionName"))
+        $script:winsmuxRoleRawContent | Should -Match ([regex]::Escape("Invoke-WinsmuxRaw -Arguments @('set-environment', '-u', '-t', `$sessionName, `$name)"))
         $script:winsmuxRoleRawContent | Should -Not -Match 'codex --sandbox danger-full-access -C'
         $launchIndex = $script:winsmuxRoleRawContent.IndexOf('$launchCmd = Get-BridgeProviderLaunchCommand')
         $nonWorkerResetIndex = $script:winsmuxRoleRawContent.IndexOf('$manifestRole -notin @(''Builder'', ''Worker'')')
-        $renameIndex = $script:winsmuxRoleRawContent.IndexOf('& winsmux select-pane -t $paneId -T $newLabel')
+        $renameIndex = $script:winsmuxRoleRawContent.IndexOf('Invoke-WinsmuxRaw -Arguments @(''select-pane'', ''-t'', $paneId, ''-T'', $newLabel)')
         $manifestUpdateIndex = $script:winsmuxRoleRawContent.IndexOf('Set-PaneControlManifestPaneProperties -ManifestPath $manifestPath')
         $environmentIndex = $script:winsmuxRoleRawContent.IndexOf('$paneEnvironment = Get-WinsmuxPaneEnvironment')
-        $environmentClearIndex = $script:winsmuxRoleRawContent.IndexOf('& winsmux set-environment -u -t $sessionName $name')
-        $respawnIndex = $script:winsmuxRoleRawContent.IndexOf('& winsmux respawn-pane -k -t $paneId -c $launchDir')
+        $environmentClearIndex = $script:winsmuxRoleRawContent.IndexOf('Invoke-WinsmuxRaw -Arguments @(''set-environment'', ''-u'', ''-t'', $sessionName, $name)')
+        $respawnIndex = $script:winsmuxRoleRawContent.IndexOf('Invoke-WinsmuxRaw -Arguments @(''respawn-pane'', ''-k'', ''-t'', $paneId, ''-c'', $launchDir)')
         $launchIndex | Should -BeGreaterThan -1
         $nonWorkerResetIndex | Should -BeGreaterThan -1
         $renameIndex | Should -BeGreaterThan -1
@@ -14616,6 +14772,134 @@ Describe 'winsmux control-rpc command' {
     It 'rejects JSON-RPC requests without a method' {
         { ConvertTo-ControlRpcPayload -JsonText '{"jsonrpc":"2.0","id":1}' } |
             Should -Throw 'control-rpc payload must include a non-empty method'
+    }
+}
+
+Describe 'winsmux raw namespace forwarding' {
+    BeforeAll {
+        $script:namespaceBridgePath = Join-Path (Split-Path -Parent $PSScriptRoot) 'scripts\winsmux-core.ps1'
+        $script:previousBridgeNamespaceL = $env:WINSMUX_BRIDGE_NAMESPACE_L
+        $script:previousBridgeSocketS = $env:WINSMUX_BRIDGE_SOCKET_S
+    }
+
+    AfterAll {
+        if ($null -eq $script:previousBridgeNamespaceL) {
+            Remove-Item Env:\WINSMUX_BRIDGE_NAMESPACE_L -ErrorAction SilentlyContinue
+        } else {
+            $env:WINSMUX_BRIDGE_NAMESPACE_L = $script:previousBridgeNamespaceL
+        }
+        if ($null -eq $script:previousBridgeSocketS) {
+            Remove-Item Env:\WINSMUX_BRIDGE_SOCKET_S -ErrorAction SilentlyContinue
+        } else {
+            $env:WINSMUX_BRIDGE_SOCKET_S = $script:previousBridgeSocketS
+        }
+    }
+
+    It 'prepends namespace selectors to nested raw winsmux calls' {
+        $env:WINSMUX_BRIDGE_NAMESPACE_L = 'ops'
+        $env:WINSMUX_BRIDGE_SOCKET_S = 'socket-name'
+        $null = . $script:namespaceBridgePath version
+
+        $script:namespaceRawCalls = [System.Collections.Generic.List[string]]::new()
+        function winsmux {
+            param([Parameter(ValueFromRemainingArguments = $true)][string[]]$Arguments)
+
+            $script:namespaceRawCalls.Add(($Arguments -join '|')) | Out-Null
+            return 'ok'
+        }
+
+        try {
+            Invoke-WinsmuxRaw -Arguments @('list-panes', '-a') | Out-Null
+        } finally {
+            Remove-Item Function:\winsmux -ErrorAction SilentlyContinue
+        }
+
+        $script:namespaceRawCalls.Count | Should -Be 1
+        $script:namespaceRawCalls[0] | Should -Be '-L|ops|-S|socket-name|list-panes|-a'
+    }
+
+    It 'keeps command-scoped socket flags after the delegated command name' {
+        $env:WINSMUX_BRIDGE_NAMESPACE_L = 'ops'
+        $env:WINSMUX_BRIDGE_SOCKET_S = 'socket-name'
+        $null = . $script:namespaceBridgePath version
+
+        $script:namespaceRawCalls = [System.Collections.Generic.List[string]]::new()
+        function winsmux {
+            param([Parameter(ValueFromRemainingArguments = $true)][string[]]$Arguments)
+
+            $script:namespaceRawCalls.Add(($Arguments -join '|')) | Out-Null
+            return 'ok'
+        }
+
+        try {
+            Invoke-WinsmuxRaw -Arguments @('capture-pane', '-t', '%1', '-p', '-J', '-S', '-50') | Out-Null
+        } finally {
+            Remove-Item Function:\winsmux -ErrorAction SilentlyContinue
+        }
+
+        $script:namespaceRawCalls.Count | Should -Be 1
+        $script:namespaceRawCalls[0] | Should -Be '-L|ops|-S|socket-name|capture-pane|-t|%1|-p|-J|-S|-50'
+    }
+
+    It 'prepends namespace selectors through the shared helper command' {
+        $env:WINSMUX_BRIDGE_NAMESPACE_L = 'ops'
+        $env:WINSMUX_BRIDGE_SOCKET_S = 'socket-name'
+        $settingsPath = Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\settings.ps1'
+        . $settingsPath
+
+        $script:namespaceRawCalls = [System.Collections.Generic.List[string]]::new()
+        function winsmux {
+            param([Parameter(ValueFromRemainingArguments = $true)][string[]]$Arguments)
+
+            $script:namespaceRawCalls.Add(($Arguments -join '|')) | Out-Null
+            return 'ok'
+        }
+
+        try {
+            Invoke-WinsmuxBridgeCommand -WinsmuxBin 'winsmux' -Arguments @('list-panes', '-t', 'winsmux-orchestra') | Out-Null
+        } finally {
+            Remove-Item Function:\winsmux -ErrorAction SilentlyContinue
+        }
+
+        $script:namespaceRawCalls.Count | Should -Be 1
+        $script:namespaceRawCalls[0] | Should -Be '-L|ops|-S|socket-name|list-panes|-t|winsmux-orchestra'
+    }
+
+    It 'keeps nested winsmux calls behind Invoke-WinsmuxRaw' {
+        $bridgeContent = Get-Content -LiteralPath $script:namespaceBridgePath -Raw -Encoding UTF8
+
+        $directCallMatches = [regex]::Matches($bridgeContent, '(?m)^\s*(?!return\s+)&\s+winsmux\b')
+        $directAssignmentMatches = [regex]::Matches($bridgeContent, '(?m)^\s*\$[A-Za-z0-9_]+\s*=\s*&\s+winsmux\b')
+
+        $directCallMatches.Count | Should -Be 0
+        $directAssignmentMatches.Count | Should -Be 0
+    }
+
+    It 'keeps helper-script winsmux probes behind the bridge-aware helper' {
+        $repoRoot = Split-Path -Parent $PSScriptRoot
+        $helperPaths = @(
+            'winsmux-core\scripts\agent-monitor.ps1',
+            'winsmux-core\scripts\orchestra-attach-entry.ps1',
+            'winsmux-core\scripts\orchestra-attach.ps1',
+            'winsmux-core\scripts\orchestra-bootstrap.ps1',
+            'winsmux-core\scripts\orchestra-layout.ps1',
+            'winsmux-core\scripts\orchestra-preflight.ps1',
+            'winsmux-core\scripts\orchestra-smoke.ps1',
+            'winsmux-core\scripts\orchestra-start.ps1',
+            'winsmux-core\scripts\orchestra-ui-attach.ps1',
+            'winsmux-core\scripts\operator-poll.ps1',
+            'winsmux-core\scripts\pane-border.ps1',
+            'winsmux-core\scripts\pane-control.ps1',
+            'winsmux-core\scripts\pane-status.ps1',
+            'winsmux-core\scripts\server-watchdog.ps1',
+            'winsmux-core\scripts\vault.ps1'
+        )
+
+        foreach ($relativePath in $helperPaths) {
+            $content = Get-Content -LiteralPath (Join-Path $repoRoot $relativePath) -Raw -Encoding UTF8
+            $directMatches = [regex]::Matches($content, '(?m)&\s+(winsmux|\$winsmuxBin|\$WinsmuxBin|\$winsmuxPath|\$WinsmuxPath|\$script:winsmuxBin)\b')
+            $directMatches.Count | Should -Be 0 -Because "$relativePath should use Invoke-WinsmuxBridgeCommand"
+        }
     }
 }
 

--- a/winsmux-core/scripts/agent-monitor.ps1
+++ b/winsmux-core/scripts/agent-monitor.ps1
@@ -61,7 +61,7 @@ function Invoke-MonitorWinsmux {
     }
 
     if ($CaptureOutput) {
-        $output = & $winsmuxBin @Arguments 2>&1
+        $output = Invoke-WinsmuxBridgeCommand -WinsmuxBin $winsmuxBin -Arguments $Arguments 2>&1
         if ($LASTEXITCODE -ne 0) {
             $message = ($output | Out-String).Trim()
             if ([string]::IsNullOrWhiteSpace($message)) {
@@ -74,7 +74,7 @@ function Invoke-MonitorWinsmux {
         return $output
     }
 
-    & $winsmuxBin @Arguments | Out-Null
+    Invoke-WinsmuxBridgeCommand -WinsmuxBin $winsmuxBin -Arguments $Arguments | Out-Null
     if ($LASTEXITCODE -ne 0) {
         throw "winsmux $($Arguments -join ' ') failed with exit code $LASTEXITCODE."
     }

--- a/winsmux-core/scripts/operator-poll.ps1
+++ b/winsmux-core/scripts/operator-poll.ps1
@@ -296,7 +296,7 @@ function Invoke-OperatorPollWinsmux {
         throw (Get-WinsmuxOperatorNotFoundMessage)
     }
 
-    $output = & $winsmuxBin @Arguments 2>&1
+    $output = Invoke-WinsmuxBridgeCommand -WinsmuxBin $winsmuxBin -Arguments $Arguments 2>&1
     if ($LASTEXITCODE -ne 0) {
         $message = ($output | Out-String).Trim()
         if ([string]::IsNullOrWhiteSpace($message)) {

--- a/winsmux-core/scripts/orchestra-attach-entry.ps1
+++ b/winsmux-core/scripts/orchestra-attach-entry.ps1
@@ -48,7 +48,7 @@ try {
         '-BaselineClientCount', $baselineClientCount
     ) -WindowStyle Hidden | Out-Null
 
-    & $winsmuxPath 'attach-session' '-t' $sessionName
+    Invoke-WinsmuxBridgeCommand -WinsmuxBin $winsmuxPath -Arguments @('attach-session', '-t', $sessionName)
     $exitCode = $LASTEXITCODE
     if ($exitCode -ne 0) {
         Write-OrchestraAttachState -SessionName $sessionName -Properties @{

--- a/winsmux-core/scripts/orchestra-attach.ps1
+++ b/winsmux-core/scripts/orchestra-attach.ps1
@@ -61,7 +61,7 @@ $result = $null
 if ([string]::IsNullOrWhiteSpace($winsmuxPath)) {
     $result = New-OrchestraAttachResult -SessionName $SessionName -SessionExists $false -RequiresStartup $true -Attempted $false -Launched $false -Attached $false -Status 'winsmux_unresolved' -Reason 'winsmux executable could not be resolved.'
 } else {
-    & $winsmuxPath 'has-session' '-t' $SessionName 1>$null 2>$null
+    Invoke-WinsmuxBridgeCommand -WinsmuxBin $winsmuxPath -Arguments @('has-session', '-t', $SessionName) 1>$null 2>$null
     $sessionExists = ($LASTEXITCODE -eq 0)
     if (-not $sessionExists) {
         $result = New-OrchestraAttachResult -SessionName $SessionName -SessionExists $false -RequiresStartup $true -Attempted $false -Launched $false -Attached $false -Status 'session_missing' -Reason "winsmux session '$SessionName' was not found. Run orchestra-start.ps1 first."

--- a/winsmux-core/scripts/orchestra-bootstrap.ps1
+++ b/winsmux-core/scripts/orchestra-bootstrap.ps1
@@ -9,6 +9,8 @@ $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
 [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
 
+. (Join-Path $PSScriptRoot 'settings.ps1')
+
 if ([string]::IsNullOrWhiteSpace($WinsmuxPath)) {
     $WinsmuxPath = Get-Command 'winsmux' -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source -ErrorAction SilentlyContinue
 }
@@ -17,11 +19,11 @@ if ([string]::IsNullOrWhiteSpace($WinsmuxPath)) {
     throw 'winsmux executable not found for orchestra bootstrap.'
 }
 
-& $WinsmuxPath 'has-session' '-t' $SessionName 1>$null 2>$null
+Invoke-WinsmuxBridgeCommand -WinsmuxBin $WinsmuxPath -Arguments @('has-session', '-t', $SessionName) 1>$null 2>$null
 $sessionExists = ($LASTEXITCODE -eq 0)
 
 if ($sessionExists) {
-    & $WinsmuxPath 'attach-session' '-t' $SessionName
+    Invoke-WinsmuxBridgeCommand -WinsmuxBin $WinsmuxPath -Arguments @('attach-session', '-t', $SessionName)
     exit $LASTEXITCODE
 }
 
@@ -29,5 +31,5 @@ if ($AttachOnly) {
     throw "winsmux session '$SessionName' was not found for UI attach."
 }
 
-& $WinsmuxPath 'new-session' '-s' $SessionName
+Invoke-WinsmuxBridgeCommand -WinsmuxBin $WinsmuxPath -Arguments @('new-session', '-s', $SessionName)
 exit $LASTEXITCODE

--- a/winsmux-core/scripts/orchestra-layout.ps1
+++ b/winsmux-core/scripts/orchestra-layout.ps1
@@ -15,12 +15,13 @@ param(
 $ErrorActionPreference = 'Stop'
 [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
 $scriptDir = $PSScriptRoot
+. "$scriptDir/settings.ps1"
 . "$scriptDir/pane-border.ps1"
 
 function Invoke-OrchestraLayoutWinsmux {
     param([Parameter(Mandatory = $true)][string[]]$Arguments)
 
-    $output = & winsmux @Arguments 2>&1
+    $output = Invoke-WinsmuxBridgeCommand -WinsmuxBin 'winsmux' -Arguments $Arguments 2>&1
     if ($LASTEXITCODE -ne 0) {
         $message = ($output | Out-String).Trim()
         if ([string]::IsNullOrWhiteSpace($message)) {

--- a/winsmux-core/scripts/orchestra-preflight.ps1
+++ b/winsmux-core/scripts/orchestra-preflight.ps1
@@ -1,6 +1,13 @@
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
 
+if (-not (Get-Command Invoke-WinsmuxBridgeCommand -ErrorAction SilentlyContinue)) {
+    $settingsScript = Join-Path $PSScriptRoot 'settings.ps1'
+    if (Test-Path -LiteralPath $settingsScript -PathType Leaf) {
+        . $settingsScript
+    }
+}
+
 function Get-ProcessSnapshot {
     try {
         $processes = @(Get-CimInstance Win32_Process -OperationTimeoutSec 10)
@@ -245,9 +252,9 @@ function Remove-OrchestraZombieProcesses {
     $protectedIds = Get-AncestorProcessIds -Snapshot $snapshot -ProcessId $PID
     $paneRootIds = @()
 
-    & $WinsmuxBin has-session -t $SessionName 1>$null 2>$null
+    Invoke-WinsmuxBridgeCommand -WinsmuxBin $WinsmuxBin -Arguments @('has-session', '-t', $SessionName) 1>$null 2>$null
     if ($LASTEXITCODE -eq 0) {
-        $panePidOutput = & $WinsmuxBin list-panes -t $SessionName -F '#{pane_pid}' 2>$null
+        $panePidOutput = Invoke-WinsmuxBridgeCommand -WinsmuxBin $WinsmuxBin -Arguments @('list-panes', '-t', $SessionName, '-F', '#{pane_pid}') 2>$null
         $paneRootIds = @(
             $panePidOutput |
                 ForEach-Object { $_.Trim() } |
@@ -296,6 +303,68 @@ function Get-OrchestraSessionRegistryDir {
     return (Join-Path $homeDir '.psmux')
 }
 
+function Get-StableSocketNamespaceHash {
+    param([Parameter(Mandatory = $true)][string]$Value)
+
+    $hash = [System.Numerics.BigInteger]::Parse('14695981039346656037')
+    $prime = [System.Numerics.BigInteger]::Parse('1099511628211')
+    $modulus = [System.Numerics.BigInteger]::Pow([System.Numerics.BigInteger]2, 64)
+    foreach ($byte in [System.Text.Encoding]::UTF8.GetBytes($Value)) {
+        $hash = [System.Numerics.BigInteger]::Remainder(($hash -bxor [System.Numerics.BigInteger]$byte) * $prime, $modulus)
+    }
+
+    return ('{0:x16}' -f [uint64]$hash)
+}
+
+function Get-WinsmuxSocketNamespaceBase {
+    param([Parameter(Mandatory = $true)][string]$SocketSelector)
+
+    $selector = $SocketSelector.Trim()
+    if ([string]::IsNullOrWhiteSpace($selector)) {
+        return $null
+    }
+
+    $looksLikePath = $selector.Contains('\') -or $selector.Contains('/') -or [System.IO.Path]::HasExtension($selector)
+    if (-not $looksLikePath) {
+        return $selector
+    }
+
+    try {
+        $path = $selector
+        if (-not [System.IO.Path]::IsPathRooted($path)) {
+            $path = Join-Path (Get-Location) $path
+        }
+
+        $normalized = [System.IO.Path]::GetFullPath($path).Replace('\', '/')
+        if ([System.IO.Path]::DirectorySeparatorChar -eq '\') {
+            $normalized = $normalized.ToLowerInvariant()
+        }
+
+        return ('socket-{0}' -f (Get-StableSocketNamespaceHash -Value $normalized))
+    } catch {
+        return ('socket-{0}' -f (Get-StableSocketNamespaceHash -Value $selector.Replace('\', '/').ToLowerInvariant()))
+    }
+}
+
+function Get-OrchestraSessionRegistryBaseName {
+    param([Parameter(Mandatory = $true)][string]$SessionName)
+
+    $namespace = $env:WINSMUX_BRIDGE_SESSION_NAMESPACE
+    if ([string]::IsNullOrWhiteSpace($namespace)) {
+        if (-not [string]::IsNullOrWhiteSpace($env:WINSMUX_BRIDGE_SOCKET_S)) {
+            $namespace = Get-WinsmuxSocketNamespaceBase -SocketSelector $env:WINSMUX_BRIDGE_SOCKET_S
+        } elseif (-not [string]::IsNullOrWhiteSpace($env:WINSMUX_BRIDGE_NAMESPACE_L)) {
+            $namespace = $env:WINSMUX_BRIDGE_NAMESPACE_L.Trim()
+        }
+    }
+
+    if ([string]::IsNullOrWhiteSpace($namespace)) {
+        return $SessionName
+    }
+
+    return ("{0}__{1}" -f $namespace.Trim(), $SessionName)
+}
+
 function Get-OrchestraSessionPortFilePath {
     param([Parameter(Mandatory = $true)][string]$SessionName)
 
@@ -304,7 +373,8 @@ function Get-OrchestraSessionPortFilePath {
         return $null
     }
 
-    return (Join-Path $registryDir "$SessionName.port")
+    $registryBaseName = Get-OrchestraSessionRegistryBaseName -SessionName $SessionName
+    return (Join-Path $registryDir "$registryBaseName.port")
 }
 
 function Get-OrchestraSessionKeyFilePath {
@@ -315,7 +385,8 @@ function Get-OrchestraSessionKeyFilePath {
         return $null
     }
 
-    return (Join-Path $registryDir "$SessionName.key")
+    $registryBaseName = Get-OrchestraSessionRegistryBaseName -SessionName $SessionName
+    return (Join-Path $registryDir "$registryBaseName.key")
 }
 
 function Get-OrchestraSessionPort {
@@ -421,7 +492,7 @@ function Invoke-OrchestraHasSessionProbe {
         [Parameter(Mandatory = $true)][string]$WinsmuxBin
     )
 
-    & $WinsmuxBin has-session -t $SessionName 1>$null 2>$null
+    Invoke-WinsmuxBridgeCommand -WinsmuxBin $WinsmuxBin -Arguments @('has-session', '-t', $SessionName) 1>$null 2>$null
     return ($LASTEXITCODE -eq 0)
 }
 
@@ -431,7 +502,7 @@ function Get-OrchestraSessionPaneCount {
         [Parameter(Mandatory = $true)][string]$WinsmuxBin
     )
 
-    $paneOutput = & $WinsmuxBin list-panes -t $SessionName -F '#{pane_id}' 2>$null
+    $paneOutput = Invoke-WinsmuxBridgeCommand -WinsmuxBin $WinsmuxBin -Arguments @('list-panes', '-t', $SessionName, '-F', '#{pane_id}') 2>$null
     if ($LASTEXITCODE -ne 0) {
         return $null
     }

--- a/winsmux-core/scripts/orchestra-smoke.ps1
+++ b/winsmux-core/scripts/orchestra-smoke.ps1
@@ -100,7 +100,7 @@ function Get-OrchestraAttachedClientSnapshot {
     }
 
     try {
-        $clientLines = & $WinsmuxBin list-clients -t $SessionName 2>&1
+        $clientLines = Invoke-WinsmuxBridgeCommand -WinsmuxBin $WinsmuxBin -Arguments @('list-clients', '-t', $SessionName) 2>&1
         if ($LASTEXITCODE -eq 0) {
             $clients = @(
                 $clientLines |
@@ -218,7 +218,7 @@ function Get-OrchestraSmokeProbeState {
     $paneProbeError = ''
     if (-not [string]::IsNullOrWhiteSpace($WinsmuxBin)) {
         try {
-            $paneLines = & $WinsmuxBin list-panes -t $SessionName 2>&1
+            $paneLines = Invoke-WinsmuxBridgeCommand -WinsmuxBin $WinsmuxBin -Arguments @('list-panes', '-t', $SessionName) 2>&1
             if ($LASTEXITCODE -eq 0) {
                 $paneCount = @($paneLines | Where-Object { -not [string]::IsNullOrWhiteSpace([string]$_) }).Count
                 $paneProbeOk = $true

--- a/winsmux-core/scripts/orchestra-start.ps1
+++ b/winsmux-core/scripts/orchestra-start.ps1
@@ -36,7 +36,7 @@ function Invoke-Winsmux {
     )
 
     if ($CaptureOutput) {
-        $output = & $script:winsmuxBin @Arguments 2>&1
+        $output = Invoke-WinsmuxBridgeCommand -WinsmuxBin $script:winsmuxBin -Arguments $Arguments 2>&1
         $exitCode = $LASTEXITCODE
         if ($exitCode -ne 0) {
             $message = ($output | Out-String).Trim()
@@ -50,7 +50,7 @@ function Invoke-Winsmux {
         return $output
     }
 
-    & $script:winsmuxBin @Arguments | Out-Null
+    Invoke-WinsmuxBridgeCommand -WinsmuxBin $script:winsmuxBin -Arguments $Arguments | Out-Null
     if ($LASTEXITCODE -ne 0) {
         throw "winsmux $($Arguments -join ' ') failed with exit code $LASTEXITCODE."
     }
@@ -62,7 +62,7 @@ function Test-OrchestraServerSession {
         [string]$SessionName
     )
 
-    & $script:winsmuxBin has-session -t $SessionName 1>$null 2>$null
+    Invoke-WinsmuxBridgeCommand -WinsmuxBin $script:winsmuxBin -Arguments @('has-session', '-t', $SessionName) 1>$null 2>$null
     return ($LASTEXITCODE -eq 0)
 }
 
@@ -1933,7 +1933,7 @@ if ($MyInvocation.InvocationName -ne '.') {
 
     # Clean up any leftover orchestra panes in default session (#213)
     try {
-        $existingPanes = & $winsmuxBin list-panes -F '#{pane_id} #{pane_title}' 2>$null
+        $existingPanes = Invoke-WinsmuxBridgeCommand -WinsmuxBin $winsmuxBin -Arguments @('list-panes', '-F', '#{pane_id} #{pane_title}') 2>$null
         if ($LASTEXITCODE -eq 0 -and $existingPanes) {
                     $orchestraLabels = @('worker-', 'builder-', 'researcher-', 'reviewer-')
             foreach ($line in ($existingPanes -split "`n")) {
@@ -1944,7 +1944,7 @@ if ($MyInvocation.InvocationName -ne '.') {
                     foreach ($label in $orchestraLabels) {
                         if ($title -like "$label*") {
                             Write-WinsmuxLog -Level INFO -Event 'preflight.default_pane.kill' -Message "Removing leftover orchestra pane $paneId ($title) from default session." -Data @{ pane_id = $paneId; title = $title } | Out-Null
-                            & $winsmuxBin kill-pane -t $paneId 2>$null
+                            Invoke-WinsmuxBridgeCommand -WinsmuxBin $winsmuxBin -Arguments @('kill-pane', '-t', $paneId) 2>$null
                             break
                         }
                     }

--- a/winsmux-core/scripts/orchestra-ui-attach.ps1
+++ b/winsmux-core/scripts/orchestra-ui-attach.ps1
@@ -2,6 +2,12 @@ $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
 
 . (Join-Path $PSScriptRoot 'clm-safe-io.ps1')
+if (-not (Get-Command Invoke-WinsmuxBridgeCommand -ErrorAction SilentlyContinue)) {
+    $settingsScript = Join-Path $PSScriptRoot 'settings.ps1'
+    if (Test-Path -LiteralPath $settingsScript -PathType Leaf) {
+        . $settingsScript
+    }
+}
 
 $script:OrchestraAttachProfileName = 'winsmux orchestra attach'
 
@@ -329,7 +335,7 @@ function Get-OrchestraAttachedClientSnapshot {
     }
 
     try {
-        $clientLines = & $WinsmuxBin 'list-clients' '-t' $SessionName 2>&1
+        $clientLines = Invoke-WinsmuxBridgeCommand -WinsmuxBin $WinsmuxBin -Arguments @('list-clients', '-t', $SessionName) 2>&1
         if ($LASTEXITCODE -eq 0) {
             $clients = @(
                 $clientLines |

--- a/winsmux-core/scripts/pane-border.ps1
+++ b/winsmux-core/scripts/pane-border.ps1
@@ -1,5 +1,11 @@
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
+if (-not (Get-Command Invoke-WinsmuxBridgeCommand -ErrorAction SilentlyContinue)) {
+    $settingsScript = Join-Path $PSScriptRoot 'settings.ps1'
+    if (Test-Path -LiteralPath $settingsScript -PathType Leaf) {
+        . $settingsScript
+    }
+}
 
 function Set-WinsmuxWindowOption {
     param(
@@ -16,7 +22,7 @@ function Set-WinsmuxWindowOption {
     )
 
     foreach ($attempt in $attempts) {
-        & $WinsmuxBin @attempt 1>$null 2>$null
+        Invoke-WinsmuxBridgeCommand -WinsmuxBin $WinsmuxBin -Arguments $attempt 1>$null 2>$null
         if ($LASTEXITCODE -eq 0) {
             return $true
         }

--- a/winsmux-core/scripts/pane-control.ps1
+++ b/winsmux-core/scripts/pane-control.ps1
@@ -4,7 +4,7 @@
 function Invoke-PaneControlWinsmux {
     param([Parameter(Mandatory = $true)][string[]]$Arguments)
 
-    $output = & winsmux @Arguments 2>&1
+    $output = Invoke-WinsmuxBridgeCommand -WinsmuxBin 'winsmux' -Arguments $Arguments 2>&1
     if ($LASTEXITCODE -ne 0) {
         $message = ($output | Out-String).Trim()
         if ([string]::IsNullOrWhiteSpace($message)) {

--- a/winsmux-core/scripts/pane-status.ps1
+++ b/winsmux-core/scripts/pane-status.ps1
@@ -14,7 +14,7 @@ function Invoke-PaneStatusWinsmux {
     param([Parameter(Mandatory = $true)][string[]]$Arguments)
 
     $global:LASTEXITCODE = 0
-    $output = & winsmux @Arguments 2>&1
+    $output = Invoke-WinsmuxBridgeCommand -WinsmuxBin 'winsmux' -Arguments $Arguments 2>&1
     if ($LASTEXITCODE -ne 0) {
         $message = ($output | Out-String).Trim()
         if ([string]::IsNullOrWhiteSpace($message)) {

--- a/winsmux-core/scripts/server-watchdog.ps1
+++ b/winsmux-core/scripts/server-watchdog.ps1
@@ -124,7 +124,7 @@ function Invoke-ServerWatchdogWinsmux {
         throw (Get-WinsmuxOperatorNotFoundMessage)
     }
 
-    $output = & $winsmuxBin @Arguments 2>&1
+    $output = Invoke-WinsmuxBridgeCommand -WinsmuxBin $winsmuxBin -Arguments $Arguments 2>&1
     $exitCode = $LASTEXITCODE
 
     if ($exitCode -ne 0 -and -not $AllowFailure) {

--- a/winsmux-core/scripts/settings.ps1
+++ b/winsmux-core/scripts/settings.ps1
@@ -104,6 +104,34 @@ if (-not (Get-Command Get-WinsmuxOperatorNotFoundMessage -ErrorAction SilentlyCo
     }
 }
 
+if (-not (Get-Command Get-WinsmuxBridgeGlobalArguments -ErrorAction SilentlyContinue)) {
+    function Get-WinsmuxBridgeGlobalArguments {
+        $forwardedArguments = @()
+        if (-not [string]::IsNullOrWhiteSpace($env:WINSMUX_BRIDGE_NAMESPACE_L)) {
+            $forwardedArguments += @('-L', $env:WINSMUX_BRIDGE_NAMESPACE_L)
+        }
+        if (-not [string]::IsNullOrWhiteSpace($env:WINSMUX_BRIDGE_SOCKET_S)) {
+            $forwardedArguments += @('-S', $env:WINSMUX_BRIDGE_SOCKET_S)
+        }
+
+        return @($forwardedArguments)
+    }
+}
+
+if (-not (Get-Command Invoke-WinsmuxBridgeCommand -ErrorAction SilentlyContinue)) {
+    function Invoke-WinsmuxBridgeCommand {
+        param(
+            [Parameter(Mandatory = $true)][string]$WinsmuxBin,
+            [Parameter(Mandatory = $true)][string[]]$Arguments
+        )
+
+        $forwardedArguments = @()
+        $forwardedArguments += @(Get-WinsmuxBridgeGlobalArguments)
+        $forwardedArguments += @($Arguments)
+        return & $WinsmuxBin @forwardedArguments
+    }
+}
+
 if (-not (Get-Command Get-WinsmuxOption -ErrorAction SilentlyContinue)) {
     function Test-WinsmuxOptionFailureText {
         param([string]$Value)
@@ -127,7 +155,7 @@ if (-not (Get-Command Get-WinsmuxOption -ErrorAction SilentlyContinue)) {
         }
 
         try {
-            $value = (& $winsmuxBin show-options -g -v $Name 2>&1 | Out-String).Trim()
+            $value = (Invoke-WinsmuxBridgeCommand -WinsmuxBin $winsmuxBin -Arguments @('show-options', '-g', '-v', $Name) 2>&1 | Out-String).Trim()
             if (-not (Test-WinsmuxOptionFailureText -Value $value)) {
                 return $value
             }
@@ -146,7 +174,7 @@ if (-not (Get-Command Set-WinsmuxOption -ErrorAction SilentlyContinue)) {
             [Parameter(Mandatory = $true)][string]$OptionValue
         )
 
-        & $WinsmuxBin set-option -g $OptionName $OptionValue | Out-Null
+        Invoke-WinsmuxBridgeCommand -WinsmuxBin $WinsmuxBin -Arguments @('set-option', '-g', $OptionName, $OptionValue) | Out-Null
     }
 }
 

--- a/winsmux-core/scripts/vault.ps1
+++ b/winsmux-core/scripts/vault.ps1
@@ -13,6 +13,13 @@ The commands expect the caller to provide the surrounding bridge context, includ
 `Assert-ReadMark`, and `Clear-ReadMark`.
 #>
 
+if (-not (Get-Command Invoke-WinsmuxBridgeCommand -ErrorAction SilentlyContinue)) {
+    $settingsScript = Join-Path $PSScriptRoot 'settings.ps1'
+    if (Test-Path -LiteralPath $settingsScript -PathType Leaf) {
+        . $settingsScript
+    }
+}
+
 if (-not ('WinCred' -as [type])) {
     # --- Windows Credential Manager P/Invoke ---
     Add-Type -TypeDefinition @'
@@ -154,7 +161,7 @@ function Invoke-WinsmuxCommand {
 
     $global:LASTEXITCODE = 0
     try {
-        $output = & winsmux @Arguments 2>&1
+        $output = Invoke-WinsmuxBridgeCommand -WinsmuxBin 'winsmux' -Arguments $Arguments 2>&1
     } catch {
         return [PSCustomObject]@{
             Success  = $false


### PR DESCRIPTION
## Summary

- Preserve global `-L` and `-S` namespace selectors when delegating bridge commands through `winsmux-core.ps1`.
- Route nested bridge helper probes through shared namespace-aware helpers.
- Resolve native attach and session targets through the selected namespace before falling back to ambient state.

## Validation

- `git diff --check main...HEAD`
- `codex review --commit 2d51dbd -c model="gpt-5.3-codex-spark" -c model_reasoning_effort="high"`
- Prior local validation recorded in `.claude/local/operator-handoff.md`: targeted Pester coverage, `cargo check`, `operator_cli` tests, `audit-public-surface`, and `git-guard`.

Closes #778
