### PR TITLE
feat: add role model reasoning selectors

### DIFF
--- a/core/src/operator_cli.rs
+++ b/core/src/operator_cli.rs
@@ -873,12 +873,14 @@ pub fn run_provider_switch_command(args: &[&String]) -> io::Result<()> {
     if options.clear
         && (options.agent.is_some()
             || options.model.is_some()
+            || options.model_source.is_some()
+            || options.reasoning_effort.is_some()
             || options.prompt_transport.is_some()
             || options.auth_mode.is_some())
     {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
-            "provider-switch --clear cannot be combined with --agent, --model, --prompt-transport, or --auth-mode.",
+            "provider-switch --clear cannot be combined with --agent, --model, --model-source, --reasoning-effort, --prompt-transport, or --auth-mode.",
         ));
     }
 
@@ -943,9 +945,12 @@ pub fn run_provider_switch_command(args: &[&String]) -> io::Result<()> {
         "slot_id": options.slot_id,
         "agent": effective.agent,
         "model": effective.model,
+        "model_source": effective.model_source,
+        "reasoning_effort": effective.reasoning_effort,
         "prompt_transport": effective.prompt_transport,
         "auth_mode": effective.auth_mode,
         "auth_policy": effective.auth_policy,
+        "local_access_note": effective.local_access_note,
         "source": effective.source,
         "capability_adapter": effective.capability_adapter,
         "capability_command": effective.capability_command,
@@ -1089,6 +1094,8 @@ struct ProviderSwitchOptions {
     slot_id: String,
     agent: Option<String>,
     model: Option<String>,
+    model_source: Option<String>,
+    reasoning_effort: Option<String>,
     prompt_transport: Option<String>,
     auth_mode: Option<String>,
     reason: Option<String>,
@@ -1101,6 +1108,8 @@ struct ProviderSwitchOptions {
 struct BridgeSettings {
     agent: String,
     model: String,
+    model_source: String,
+    reasoning_effort: String,
     prompt_transport: String,
     auth_mode: String,
     agent_explicit: bool,
@@ -1113,6 +1122,8 @@ struct BridgeSettings {
 struct ProviderRoleConfig {
     agent: Option<String>,
     model: Option<String>,
+    model_source: Option<String>,
+    reasoning_effort: Option<String>,
     prompt_transport: Option<String>,
     auth_mode: Option<String>,
 }
@@ -1122,6 +1133,8 @@ struct ProviderSlotConfig {
     slot_id: String,
     agent: Option<String>,
     model: Option<String>,
+    model_source: Option<String>,
+    reasoning_effort: Option<String>,
     prompt_transport: Option<String>,
     auth_mode: Option<String>,
 }
@@ -1130,6 +1143,8 @@ struct ProviderSlotConfig {
 struct ProviderRegistryEntry {
     agent: Option<String>,
     model: Option<String>,
+    model_source: Option<String>,
+    reasoning_effort: Option<String>,
     prompt_transport: Option<String>,
     auth_mode: Option<String>,
     updated_at_utc: String,
@@ -1140,12 +1155,18 @@ struct ProviderRegistryEntry {
 struct SlotAgentConfig {
     agent: String,
     model: String,
+    model_source: String,
+    reasoning_effort: String,
     prompt_transport: String,
     auth_mode: String,
     auth_policy: String,
     source: String,
     capability_adapter: String,
     capability_command: String,
+    model_options: Value,
+    model_sources: Value,
+    reasoning_efforts: Value,
+    local_access_note: String,
     supports_parallel_runs: bool,
     supports_interrupt: bool,
     supports_structured_result: bool,
@@ -1219,6 +1240,8 @@ fn parse_provider_switch_options(args: &[&String]) -> io::Result<ProviderSwitchO
     let mut slot_id: Option<String> = None;
     let mut agent = None;
     let mut model = None;
+    let mut model_source = None;
+    let mut reasoning_effort = None;
     let mut prompt_transport = None;
     let mut auth_mode = None;
     let mut reason = None;
@@ -1235,6 +1258,18 @@ fn parse_provider_switch_options(args: &[&String]) -> io::Result<ProviderSwitchO
             }
             "--model" => {
                 model = Some(required_option_value(args, index, "--model")?);
+                index += 2;
+            }
+            "--model-source" => {
+                let value = required_option_value(args, index, "--model-source")?;
+                validate_model_source(&value)?;
+                model_source = Some(value);
+                index += 2;
+            }
+            "--reasoning-effort" => {
+                let value = required_option_value(args, index, "--reasoning-effort")?;
+                validate_reasoning_effort(&value)?;
+                reasoning_effort = Some(value.trim().to_ascii_lowercase());
                 index += 2;
             }
             "--prompt-transport" => {
@@ -1304,6 +1339,8 @@ fn parse_provider_switch_options(args: &[&String]) -> io::Result<ProviderSwitchO
         slot_id,
         agent: trim_optional(agent),
         model: trim_optional(model),
+        model_source: trim_optional(model_source),
+        reasoning_effort: trim_optional(reasoning_effort),
         prompt_transport,
         auth_mode: trim_optional(auth_mode),
         reason: trim_optional(reason),
@@ -1327,6 +1364,36 @@ fn trim_optional(value: Option<String>) -> Option<String> {
     value
         .map(|text| text.trim().to_string())
         .filter(|text| !text.is_empty())
+}
+
+fn validate_model_source(value: &str) -> io::Result<()> {
+    let normalized = value.trim();
+    if matches!(
+        normalized,
+        "provider-default" | "cli-discovery" | "official-doc" | "operator-override"
+    ) {
+        Ok(())
+    } else {
+        Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("Invalid provider registry model_source '{value}'."),
+        ))
+    }
+}
+
+fn validate_reasoning_effort(value: &str) -> io::Result<()> {
+    let normalized = value.trim().to_ascii_lowercase();
+    if matches!(
+        normalized.as_str(),
+        "provider-default" | "low" | "medium" | "high" | "xhigh" | "max"
+    ) {
+        Ok(())
+    } else {
+        Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("Invalid provider registry reasoning_effort '{value}'."),
+        ))
+    }
 }
 
 fn provider_capability_registry_path(project_dir: &Path) -> PathBuf {
@@ -1439,9 +1506,21 @@ fn normalize_provider_capability_entry(
     }
 
     let mut normalized = Map::new();
-    let string_fields = ["adapter", "display_name", "command"];
+    let string_fields = [
+        "adapter",
+        "display_name",
+        "command",
+        "model_catalog_source",
+        "local_access_note",
+    ];
     let transport_fields = ["prompt_transports"];
-    let string_array_fields = ["auth_modes", "local_interactive_oauth_modes"];
+    let string_array_fields = [
+        "auth_modes",
+        "local_interactive_oauth_modes",
+        "model_sources",
+        "reasoning_efforts",
+    ];
+    let model_option_fields = ["model_options"];
     let bool_fields = [
         "supports_parallel_runs",
         "supports_interrupt",
@@ -1458,6 +1537,7 @@ fn normalize_provider_capability_entry(
         if !string_fields.contains(&name)
             && !transport_fields.contains(&name)
             && !string_array_fields.contains(&name)
+            && !model_option_fields.contains(&name)
             && !bool_fields.contains(&name)
         {
             return Err(invalid_provider_capability_field(name));
@@ -1514,7 +1594,28 @@ fn normalize_provider_capability_entry(
                 if normalized_text.is_empty() {
                     return Err(invalid_provider_capability_field(name));
                 }
+                if name == "model_sources" && !valid_model_source(&normalized_text) {
+                    return Err(invalid_provider_capability_field(name));
+                }
+                if name == "reasoning_efforts" && !valid_reasoning_effort(&normalized_text) {
+                    return Err(invalid_provider_capability_field(name));
+                }
                 normalized_items.push(Value::String(normalized_text));
+            }
+            normalized.insert(field.clone(), Value::Array(normalized_items));
+            continue;
+        }
+
+        if model_option_fields.contains(&name) {
+            let Some(items) = field_value.as_array() else {
+                return Err(invalid_provider_capability_field(name));
+            };
+            if items.is_empty() {
+                return Err(invalid_provider_capability_field(name));
+            }
+            let mut normalized_items = Vec::new();
+            for item in items {
+                normalized_items.push(normalize_provider_model_option(item)?);
             }
             normalized.insert(field.clone(), Value::Array(normalized_items));
             continue;
@@ -1538,6 +1639,94 @@ fn normalize_provider_capability_entry(
     }
 
     Ok(Value::Object(normalized))
+}
+
+fn normalize_provider_model_option(value: &Value) -> io::Result<Value> {
+    let Some(entry) = value.as_object() else {
+        return Err(invalid_provider_capability_field("model_options"));
+    };
+    let mut normalized = Map::new();
+    for (field, field_value) in entry {
+        if !matches!(
+            field.as_str(),
+            "id" | "label" | "source" | "availability" | "notes"
+        ) {
+            return Err(invalid_provider_capability_field("model_options"));
+        }
+        let Some(text) = field_value.as_str() else {
+            return Err(invalid_provider_capability_field("model_options"));
+        };
+        let trimmed = text.trim();
+        if trimmed.is_empty() {
+            if matches!(field.as_str(), "id" | "source") {
+                return Err(invalid_provider_capability_field("model_options"));
+            }
+            continue;
+        }
+        let value = if field == "source" {
+            let normalized_source = trimmed.to_ascii_lowercase();
+            if !valid_model_source(&normalized_source) {
+                return Err(invalid_provider_capability_field("model_options"));
+            }
+            normalized_source
+        } else {
+            trimmed.to_string()
+        };
+        normalized.insert(field.clone(), Value::String(value));
+    }
+    if !normalized.contains_key("id") || !normalized.contains_key("source") {
+        return Err(invalid_provider_capability_field("model_options"));
+    }
+    Ok(Value::Object(normalized))
+}
+
+fn valid_model_source(value: &str) -> bool {
+    matches!(
+        value,
+        "provider-default" | "cli-discovery" | "official-doc" | "operator-override"
+    )
+}
+
+fn valid_reasoning_effort(value: &str) -> bool {
+    matches!(
+        value,
+        "provider-default" | "low" | "medium" | "high" | "xhigh" | "max"
+    )
+}
+
+fn default_provider_model_source() -> String {
+    "provider-default".to_string()
+}
+
+fn default_provider_reasoning_effort() -> String {
+    "provider-default".to_string()
+}
+
+fn inferred_model_source_for_model(model: &str) -> String {
+    if provider_default_model(model) {
+        default_provider_model_source()
+    } else {
+        "operator-override".to_string()
+    }
+}
+
+fn provider_default_model(model: &str) -> bool {
+    model.trim().is_empty() || model.trim().eq_ignore_ascii_case("provider-default")
+}
+
+fn provider_default_model_source(model_source: &str) -> bool {
+    !model_source.trim().is_empty() && model_source.trim().eq_ignore_ascii_case("provider-default")
+}
+
+fn provider_model_override(model: &str, model_source: &str) -> bool {
+    !provider_default_model(model) && !provider_default_model_source(model_source)
+}
+
+fn provider_default_reasoning_effort(reasoning_effort: &str) -> bool {
+    reasoning_effort.trim().is_empty()
+        || reasoning_effort
+            .trim()
+            .eq_ignore_ascii_case("provider-default")
 }
 
 fn invalid_provider_capability_field(field: &str) -> io::Error {
@@ -1601,17 +1790,27 @@ impl ProviderRegistryEntry {
     fn new(options: &ProviderSwitchOptions) -> io::Result<Self> {
         if options.agent.is_none()
             && options.model.is_none()
+            && options.model_source.is_none()
+            && options.reasoning_effort.is_none()
             && options.prompt_transport.is_none()
             && options.auth_mode.is_none()
         {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
-                "Provider registry entry requires agent, model, prompt_transport, or auth_mode.",
+                "Provider registry entry requires agent, model, model_source, reasoning_effort, prompt_transport, or auth_mode.",
             ));
         }
+        let model_source = options.model_source.clone().or_else(|| {
+            options
+                .model
+                .as_deref()
+                .map(inferred_model_source_for_model)
+        });
         Ok(Self {
             agent: options.agent.clone(),
             model: options.model.clone(),
+            model_source,
+            reasoning_effort: options.reasoning_effort.clone(),
             prompt_transport: options.prompt_transport.clone(),
             auth_mode: options.auth_mode.clone(),
             updated_at_utc: generated_at(),
@@ -1631,6 +1830,8 @@ impl ProviderRegistryEntry {
         };
         let agent = provider_registry_optional_string(map, "agent")?;
         let model = provider_registry_optional_string(map, "model")?;
+        let mut model_source = provider_registry_optional_string(map, "model_source")?;
+        let reasoning_effort = provider_registry_optional_string(map, "reasoning_effort")?;
         let prompt_transport = provider_registry_optional_string(map, "prompt_transport")?;
         let auth_mode = provider_registry_optional_string(map, "auth_mode")?;
         let updated_at_utc =
@@ -1644,7 +1845,21 @@ impl ProviderRegistryEntry {
                 ));
             }
         }
-        if agent.is_none() && model.is_none() && prompt_transport.is_none() && auth_mode.is_none() {
+        if let Some(value) = model_source.as_deref() {
+            validate_model_source(value)?;
+        } else if let Some(value) = model.as_deref() {
+            model_source = Some(inferred_model_source_for_model(value));
+        }
+        if let Some(value) = reasoning_effort.as_deref() {
+            validate_reasoning_effort(value)?;
+        }
+        if agent.is_none()
+            && model.is_none()
+            && model_source.is_none()
+            && reasoning_effort.is_none()
+            && prompt_transport.is_none()
+            && auth_mode.is_none()
+        {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 format!(
@@ -1656,6 +1871,8 @@ impl ProviderRegistryEntry {
         Ok(Self {
             agent,
             model,
+            model_source,
+            reasoning_effort,
             prompt_transport,
             auth_mode,
             updated_at_utc,
@@ -1670,6 +1887,15 @@ impl ProviderRegistryEntry {
         }
         if let Some(value) = self.model.as_deref() {
             map.insert("model".to_string(), Value::String(value.to_string()));
+        }
+        if let Some(value) = self.model_source.as_deref() {
+            map.insert("model_source".to_string(), Value::String(value.to_string()));
+        }
+        if let Some(value) = self.reasoning_effort.as_deref() {
+            map.insert(
+                "reasoning_effort".to_string(),
+                Value::String(value.to_string()),
+            );
         }
         if let Some(value) = self.prompt_transport.as_deref() {
             map.insert(
@@ -1696,6 +1922,8 @@ fn read_bridge_settings(project_dir: &Path) -> io::Result<BridgeSettings> {
     let mut settings = BridgeSettings {
         agent: "codex".to_string(),
         model: String::new(),
+        model_source: "provider-default".to_string(),
+        reasoning_effort: "provider-default".to_string(),
         prompt_transport: "argv".to_string(),
         auth_mode: String::new(),
         agent_explicit: false,
@@ -1704,11 +1932,17 @@ fn read_bridge_settings(project_dir: &Path) -> io::Result<BridgeSettings> {
         agent_slots: Vec::new(),
     };
     if !path.exists() {
+        if let Some(runtime_worker_role) = runtime_role_config(project_dir, "worker")? {
+            settings.worker_role = merge_role_config(settings.worker_role, runtime_worker_role);
+        }
         return Ok(settings);
     }
 
     let raw = fs::read_to_string(&path)?;
     if raw.trim().is_empty() {
+        if let Some(runtime_worker_role) = runtime_role_config(project_dir, "worker")? {
+            settings.worker_role = merge_role_config(settings.worker_role, runtime_worker_role);
+        }
         return Ok(settings);
     }
     let root = serde_yaml::from_str::<serde_yaml::Value>(&raw).map_err(|err| {
@@ -1726,6 +1960,18 @@ fn read_bridge_settings(project_dir: &Path) -> io::Result<BridgeSettings> {
         settings.model = value;
         settings.model_explicit = true;
     }
+    if let Some(value) =
+        yaml_string(&root, "model_source").or_else(|| yaml_string(&root, "model-source"))
+    {
+        settings.model_source = value;
+    } else if settings.model_explicit {
+        settings.model_source = inferred_model_source_for_model(&settings.model);
+    }
+    if let Some(value) =
+        yaml_string(&root, "reasoning_effort").or_else(|| yaml_string(&root, "reasoning-effort"))
+    {
+        settings.reasoning_effort = value.to_ascii_lowercase();
+    }
     settings.prompt_transport = yaml_string(&root, "prompt_transport")
         .or_else(|| yaml_string(&root, "prompt-transport"))
         .unwrap_or(settings.prompt_transport);
@@ -1735,6 +1981,9 @@ fn read_bridge_settings(project_dir: &Path) -> io::Result<BridgeSettings> {
     settings.worker_role = yaml_role_config(&root, "Worker")
         .or_else(|| yaml_role_config(&root, "worker"))
         .unwrap_or_default();
+    if let Some(runtime_worker_role) = runtime_role_config(project_dir, "worker")? {
+        settings.worker_role = merge_role_config(settings.worker_role, runtime_worker_role);
+    }
     settings.agent_slots = yaml_agent_slots(&root)?;
     let external_operator = yaml_bool(&root, "external_operator")
         .or_else(|| yaml_bool(&root, "external-operator"))
@@ -1751,6 +2000,8 @@ fn read_bridge_settings(project_dir: &Path) -> io::Result<BridgeSettings> {
                 slot_id: format!("worker-{index}"),
                 agent: settings.agent_explicit.then(|| settings.agent.clone()),
                 model: settings.model_explicit.then(|| settings.model.clone()),
+                model_source: Some(settings.model_source.clone()),
+                reasoning_effort: Some(settings.reasoning_effort.clone()),
                 prompt_transport: Some(settings.prompt_transport.clone()),
                 auth_mode: (!settings.auth_mode.trim().is_empty())
                     .then(|| settings.auth_mode.clone()),
@@ -1758,6 +2009,126 @@ fn read_bridge_settings(project_dir: &Path) -> io::Result<BridgeSettings> {
         }
     }
     Ok(settings)
+}
+
+fn merge_role_config(
+    mut base: ProviderRoleConfig,
+    overlay: ProviderRoleConfig,
+) -> ProviderRoleConfig {
+    if overlay.agent.is_some() {
+        base.agent = overlay.agent;
+    }
+    if overlay.model.is_some() {
+        base.model = overlay.model;
+    }
+    if overlay.model_source.is_some() {
+        base.model_source = overlay.model_source;
+    }
+    if overlay.reasoning_effort.is_some() {
+        base.reasoning_effort = overlay.reasoning_effort;
+    }
+    if overlay.prompt_transport.is_some() {
+        base.prompt_transport = overlay.prompt_transport;
+    }
+    if overlay.auth_mode.is_some() {
+        base.auth_mode = overlay.auth_mode;
+    }
+    base
+}
+
+fn runtime_role_config(project_dir: &Path, role: &str) -> io::Result<Option<ProviderRoleConfig>> {
+    let path = project_dir
+        .join(".winsmux")
+        .join("runtime-role-preferences.json");
+    if !path.exists() {
+        return Ok(None);
+    }
+    let raw = fs::read_to_string(&path)?;
+    if raw.trim().is_empty() {
+        return Ok(None);
+    }
+    let root = serde_json::from_str::<Value>(&raw).map_err(|err| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "invalid runtime role preferences: {}: {err}",
+                path.display()
+            ),
+        )
+    })?;
+    let version = root.get("version").and_then(Value::as_u64).unwrap_or(1);
+    if version != 1 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "Unsupported runtime role preferences version '{version}'. Supported versions: 1."
+            ),
+        ));
+    }
+    let roles = root.get("roles").unwrap_or(&root);
+    runtime_role_config_from_roles(roles, role)
+}
+
+fn runtime_role_config_from_roles(
+    roles: &Value,
+    role: &str,
+) -> io::Result<Option<ProviderRoleConfig>> {
+    if let Some(map) = roles.as_object() {
+        for (key, value) in map {
+            if key.eq_ignore_ascii_case(role) {
+                return Ok(Some(runtime_role_config_from_value(value)?));
+            }
+        }
+        return Ok(None);
+    }
+    if let Some(items) = roles.as_array() {
+        for item in items {
+            let role_id =
+                json_string_any(item, &["role_id", "roleId", "runtime_role", "runtimeRole"])
+                    .unwrap_or_default();
+            if role_id.eq_ignore_ascii_case(role) {
+                return Ok(Some(runtime_role_config_from_value(item)?));
+            }
+        }
+    }
+    Ok(None)
+}
+
+fn runtime_role_config_from_value(value: &Value) -> io::Result<ProviderRoleConfig> {
+    let model = json_string_any(value, &["model"]);
+    let model_source = json_string_any(value, &["model_source", "model-source", "modelSource"])
+        .or_else(|| model.as_deref().map(inferred_model_source_for_model));
+    let config = ProviderRoleConfig {
+        agent: json_string_any(value, &["agent", "provider"])
+            .filter(|value| !value.eq_ignore_ascii_case("provider-default")),
+        model,
+        model_source,
+        reasoning_effort: json_string_any(
+            value,
+            &["reasoning_effort", "reasoning-effort", "reasoningEffort"],
+        )
+        .map(|value| value.to_ascii_lowercase()),
+        prompt_transport: json_string_any(value, &["prompt_transport", "prompt-transport"]),
+        auth_mode: json_string_any(value, &["auth_mode", "auth-mode"]),
+    };
+    if let Some(source) = config.model_source.as_deref() {
+        validate_model_source(source)?;
+    }
+    if let Some(effort) = config.reasoning_effort.as_deref() {
+        validate_reasoning_effort(effort)?;
+    }
+    Ok(config)
+}
+
+fn json_string_any(value: &Value, keys: &[&str]) -> Option<String> {
+    keys.iter().find_map(|key| {
+        value
+            .get(*key)
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|text| !text.is_empty())
+            .map(str::to_string)
+    })
 }
 
 fn yaml_agent_slots(root: &serde_yaml::Value) -> io::Result<Vec<ProviderSlotConfig>> {
@@ -1782,10 +2153,18 @@ fn yaml_agent_slots(root: &serde_yaml::Value) -> io::Result<Vec<ProviderSlotConf
                 "Invalid agent_slots configuration: every slot entry must include at least slot_id.",
             ));
         }
+        let model = yaml_string(item, "model");
+        let model_source = yaml_string(item, "model_source")
+            .or_else(|| yaml_string(item, "model-source"))
+            .or_else(|| model.as_deref().map(inferred_model_source_for_model));
         result.push(ProviderSlotConfig {
             slot_id,
             agent: yaml_string(item, "agent"),
-            model: yaml_string(item, "model"),
+            model,
+            model_source,
+            reasoning_effort: yaml_string(item, "reasoning_effort")
+                .or_else(|| yaml_string(item, "reasoning-effort"))
+                .map(|value| value.to_ascii_lowercase()),
             prompt_transport: yaml_string(item, "prompt_transport")
                 .or_else(|| yaml_string(item, "prompt-transport")),
             auth_mode: yaml_string(item, "auth_mode").or_else(|| yaml_string(item, "auth-mode")),
@@ -1797,9 +2176,17 @@ fn yaml_agent_slots(root: &serde_yaml::Value) -> io::Result<Vec<ProviderSlotConf
 fn yaml_role_config(root: &serde_yaml::Value, role: &str) -> Option<ProviderRoleConfig> {
     let roles = yaml_get(root, "roles")?;
     let role_value = yaml_get(roles, role)?;
+    let model = yaml_string(role_value, "model");
+    let model_source = yaml_string(role_value, "model_source")
+        .or_else(|| yaml_string(role_value, "model-source"))
+        .or_else(|| model.as_deref().map(inferred_model_source_for_model));
     Some(ProviderRoleConfig {
         agent: yaml_string(role_value, "agent"),
-        model: yaml_string(role_value, "model"),
+        model,
+        model_source,
+        reasoning_effort: yaml_string(role_value, "reasoning_effort")
+            .or_else(|| yaml_string(role_value, "reasoning-effort"))
+            .map(|value| value.to_ascii_lowercase()),
         prompt_transport: yaml_string(role_value, "prompt_transport")
             .or_else(|| yaml_string(role_value, "prompt-transport")),
         auth_mode: yaml_string(role_value, "auth_mode")
@@ -1869,6 +2256,8 @@ fn resolve_slot_agent_config_inner(
 ) -> io::Result<SlotAgentConfig> {
     let mut agent = settings.agent.clone();
     let mut model = settings.model.clone();
+    let mut model_source = settings.model_source.clone();
+    let mut reasoning_effort = settings.reasoning_effort.clone();
     let mut prompt_transport = settings.prompt_transport.clone();
     let mut auth_mode = settings.auth_mode.clone();
     let mut source = "role".to_string();
@@ -1876,6 +2265,8 @@ fn resolve_slot_agent_config_inner(
     apply_role_config(
         &mut agent,
         &mut model,
+        &mut model_source,
+        &mut reasoning_effort,
         &mut prompt_transport,
         &mut auth_mode,
         &settings.worker_role,
@@ -1888,6 +2279,14 @@ fn resolve_slot_agent_config_inner(
         }
         if let Some(value) = slot.model.as_deref() {
             model = value.to_string();
+            source = "slot".to_string();
+        }
+        if let Some(value) = slot.model_source.as_deref() {
+            model_source = value.to_string();
+            source = "slot".to_string();
+        }
+        if let Some(value) = slot.reasoning_effort.as_deref() {
+            reasoning_effort = value.to_string();
             source = "slot".to_string();
         }
         if let Some(value) = slot.prompt_transport.as_deref() {
@@ -1908,6 +2307,12 @@ fn resolve_slot_agent_config_inner(
             if let Some(value) = entry.model {
                 model = value;
             }
+            if let Some(value) = entry.model_source {
+                model_source = value;
+            }
+            if let Some(value) = entry.reasoning_effort {
+                reasoning_effort = value;
+            }
             if let Some(value) = entry.prompt_transport {
                 prompt_transport = value;
             }
@@ -1922,6 +2327,8 @@ fn resolve_slot_agent_config_inner(
         project_dir,
         agent,
         model,
+        model_source,
+        reasoning_effort,
         prompt_transport,
         auth_mode,
         source,
@@ -1936,6 +2343,8 @@ fn resolve_slot_agent_config_with_registry_replacement(
 ) -> io::Result<SlotAgentConfig> {
     let mut agent = settings.agent.clone();
     let mut model = settings.model.clone();
+    let mut model_source = settings.model_source.clone();
+    let mut reasoning_effort = settings.reasoning_effort.clone();
     let mut prompt_transport = settings.prompt_transport.clone();
     let mut auth_mode = settings.auth_mode.clone();
     let mut source = "role".to_string();
@@ -1943,6 +2352,8 @@ fn resolve_slot_agent_config_with_registry_replacement(
     apply_role_config(
         &mut agent,
         &mut model,
+        &mut model_source,
+        &mut reasoning_effort,
         &mut prompt_transport,
         &mut auth_mode,
         &settings.worker_role,
@@ -1955,6 +2366,14 @@ fn resolve_slot_agent_config_with_registry_replacement(
         }
         if let Some(value) = slot.model.as_deref() {
             model = value.to_string();
+            source = "slot".to_string();
+        }
+        if let Some(value) = slot.model_source.as_deref() {
+            model_source = value.to_string();
+            source = "slot".to_string();
+        }
+        if let Some(value) = slot.reasoning_effort.as_deref() {
+            reasoning_effort = value.to_string();
             source = "slot".to_string();
         }
         if let Some(value) = slot.prompt_transport.as_deref() {
@@ -1974,6 +2393,12 @@ fn resolve_slot_agent_config_with_registry_replacement(
         if let Some(value) = entry.model.as_deref() {
             model = value.to_string();
         }
+        if let Some(value) = entry.model_source.as_deref() {
+            model_source = value.to_string();
+        }
+        if let Some(value) = entry.reasoning_effort.as_deref() {
+            reasoning_effort = value.to_string();
+        }
         if let Some(value) = entry.prompt_transport.as_deref() {
             prompt_transport = value.to_string();
         }
@@ -1987,6 +2412,8 @@ fn resolve_slot_agent_config_with_registry_replacement(
         project_dir,
         agent,
         model,
+        model_source,
+        reasoning_effort,
         prompt_transport,
         auth_mode,
         source,
@@ -1997,17 +2424,51 @@ fn finalize_slot_agent_config(
     project_dir: &Path,
     agent: String,
     model: String,
+    model_source: String,
+    reasoning_effort: String,
     prompt_transport: String,
     auth_mode: String,
     source: String,
 ) -> io::Result<SlotAgentConfig> {
     assert_provider_prompt_transport(project_dir, &agent, &prompt_transport)?;
     assert_provider_auth_mode(project_dir, &agent, &auth_mode)?;
+    validate_model_source(&model_source)?;
+    validate_reasoning_effort(&reasoning_effort)?;
     let capability = resolve_provider_capability(project_dir, &agent)?;
+    assert_provider_capability_selection(
+        capability.as_ref(),
+        &agent,
+        "model_sources",
+        "model_source",
+        &model_source,
+    )?;
+    assert_provider_capability_selection(
+        capability.as_ref(),
+        &agent,
+        "reasoning_efforts",
+        "reasoning_effort",
+        &reasoning_effort,
+    )?;
     Ok(SlotAgentConfig {
         auth_policy: provider_auth_policy(capability.as_ref(), &auth_mode),
         capability_adapter: capability_string(capability.as_ref(), "adapter"),
         capability_command: capability_string(capability.as_ref(), "command"),
+        model_options: capability
+            .as_ref()
+            .and_then(|value| value.get("model_options"))
+            .cloned()
+            .unwrap_or_else(|| Value::Array(Vec::new())),
+        model_sources: capability
+            .as_ref()
+            .and_then(|value| value.get("model_sources"))
+            .cloned()
+            .unwrap_or_else(|| Value::Array(Vec::new())),
+        reasoning_efforts: capability
+            .as_ref()
+            .and_then(|value| value.get("reasoning_efforts"))
+            .cloned()
+            .unwrap_or_else(|| Value::Array(Vec::new())),
+        local_access_note: capability_string(capability.as_ref(), "local_access_note"),
         supports_parallel_runs: capability_bool(capability.as_ref(), "supports_parallel_runs"),
         supports_interrupt: capability_bool(capability.as_ref(), "supports_interrupt"),
         supports_structured_result: capability_bool(
@@ -2021,6 +2482,8 @@ fn finalize_slot_agent_config(
         supports_context_reset: capability_bool(capability.as_ref(), "supports_context_reset"),
         agent,
         model,
+        model_source,
+        reasoning_effort,
         prompt_transport,
         auth_mode,
         source,
@@ -2030,6 +2493,8 @@ fn finalize_slot_agent_config(
 fn apply_role_config(
     agent: &mut String,
     model: &mut String,
+    model_source: &mut String,
+    reasoning_effort: &mut String,
     prompt_transport: &mut String,
     auth_mode: &mut String,
     config: &ProviderRoleConfig,
@@ -2041,6 +2506,14 @@ fn apply_role_config(
     }
     if let Some(value) = config.model.as_deref() {
         *model = value.to_string();
+        *source = "role".to_string();
+    }
+    if let Some(value) = config.model_source.as_deref() {
+        *model_source = value.to_string();
+        *source = "role".to_string();
+    }
+    if let Some(value) = config.reasoning_effort.as_deref() {
+        *reasoning_effort = value.to_string();
         *source = "role".to_string();
     }
     if let Some(value) = config.prompt_transport.as_deref() {
@@ -2228,7 +2701,15 @@ fn provider_registry_optional_string(
     };
     let trimmed = text.trim();
     if trimmed.is_empty() {
-        if matches!(key, "agent" | "model" | "prompt_transport" | "auth_mode") {
+        if matches!(
+            key,
+            "agent"
+                | "model"
+                | "model_source"
+                | "reasoning_effort"
+                | "prompt_transport"
+                | "auth_mode"
+        ) {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 format!("Invalid provider registry field '{key}'."),
@@ -2333,6 +2814,45 @@ fn assert_provider_auth_mode(
             io::ErrorKind::InvalidInput,
             format!(
                 "Provider capability '{provider_id}' does not support auth_mode '{requested}'. Supported values: {}.",
+                supported.join(", ")
+            ),
+        ));
+    }
+    Ok(())
+}
+
+fn assert_provider_capability_selection(
+    capability: Option<&Value>,
+    provider_id: &str,
+    capability_field: &str,
+    selector_name: &str,
+    value: &str,
+) -> io::Result<()> {
+    if value.trim().is_empty() {
+        return Ok(());
+    }
+    let Some(capability) = capability else {
+        return Ok(());
+    };
+    let Some(raw_values) = capability.get(capability_field) else {
+        return Ok(());
+    };
+    let Some(values) = raw_values.as_array() else {
+        return Err(invalid_provider_capability_field(capability_field));
+    };
+
+    let requested = value.trim().to_ascii_lowercase();
+    let supported: Vec<String> = values
+        .iter()
+        .filter_map(Value::as_str)
+        .map(|item| item.trim().to_ascii_lowercase())
+        .filter(|item| !item.is_empty())
+        .collect();
+    if !supported.iter().any(|item| item == &requested) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "Provider capability '{provider_id}' does not support {selector_name} '{requested}'. Supported values: {}.",
                 supported.join(", ")
             ),
         ));
@@ -3056,6 +3576,13 @@ struct MetaPlanRole {
     label: String,
     provider: String,
     model: String,
+    #[serde(default = "default_provider_model_source", alias = "model-source")]
+    model_source: String,
+    #[serde(
+        default = "default_provider_reasoning_effort",
+        alias = "reasoning-effort"
+    )]
+    reasoning_effort: String,
     #[serde(alias = "plan-mode")]
     plan_mode: String,
     #[serde(alias = "read-only")]
@@ -3366,6 +3893,8 @@ fn build_meta_plan_run(options: &MetaPlanOptions) -> io::Result<MetaPlanRun> {
                 "provider": role.provider.clone(),
                 "provider_adapter": provider_adapter.clone(),
                 "model": role.model.clone(),
+                "model_source": role.model_source.clone(),
+                "reasoning_effort": role.reasoning_effort.clone(),
                 "plan_mode": role.plan_mode.clone(),
                 "read_only": role.read_only,
                 "review_rounds": role.review_rounds,
@@ -3402,6 +3931,8 @@ fn build_meta_plan_run(options: &MetaPlanOptions) -> io::Result<MetaPlanRun> {
             "provider": role.provider.clone(),
             "provider_adapter": provider_adapter.clone(),
             "model": role.model.clone(),
+            "model_source": role.model_source.clone(),
+            "reasoning_effort": role.reasoning_effort.clone(),
             "plan_mode": role.plan_mode.clone(),
             "read_only": role.read_only,
             "review_rounds": role.review_rounds,
@@ -3530,6 +4061,8 @@ fn default_meta_plan_roles() -> Vec<MetaPlanRole> {
             label: "Investigator".to_string(),
             provider: "claude".to_string(),
             model: "provider-default".to_string(),
+            model_source: default_provider_model_source(),
+            reasoning_effort: default_provider_reasoning_effort(),
             plan_mode: "required".to_string(),
             read_only: true,
             review_rounds: 1,
@@ -3541,6 +4074,8 @@ fn default_meta_plan_roles() -> Vec<MetaPlanRole> {
             label: "Verifier".to_string(),
             provider: "codex".to_string(),
             model: "provider-default".to_string(),
+            model_source: default_provider_model_source(),
+            reasoning_effort: default_provider_reasoning_effort(),
             plan_mode: "read_only_equivalent".to_string(),
             read_only: true,
             review_rounds: 1,
@@ -3612,6 +4147,8 @@ fn validate_meta_plan_role(project_dir: &Path, role: &MetaPlanRole) -> io::Resul
             format!("meta-plan role '{}' model must not be empty", role.role_id),
         ));
     }
+    validate_model_source(&role.model_source)?;
+    validate_reasoning_effort(&role.reasoning_effort)?;
     if !role.read_only {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
@@ -3746,31 +4283,90 @@ fn meta_plan_launch_contract(
     provider_adapter: &str,
     provider_command: &str,
 ) -> Value {
+    let model_override = provider_model_override(&role.model, &role.model_source);
+    let mut args = Vec::new();
     match provider_adapter {
-        "claude" => json!({
-            "provider": role.provider.clone(),
-            "provider_adapter": provider_adapter,
-            "command": provider_command,
-            "model": role.model.clone(),
-            "args": ["--permission-mode", "plan"],
-            "plan_mode_enforced": true,
-            "read_only": role.read_only,
-        }),
-        "codex" => json!({
-            "provider": role.provider.clone(),
-            "provider_adapter": provider_adapter,
-            "command": provider_command,
-            "model": role.model.clone(),
-            "args": ["exec", "--sandbox", "read-only"],
-            "plan_mode_enforced": false,
-            "read_only_equivalent": true,
-            "read_only": role.read_only,
-        }),
+        "claude" => {
+            if model_override {
+                args.push("--model".to_string());
+                args.push(role.model.clone());
+            }
+            if !provider_default_reasoning_effort(&role.reasoning_effort) {
+                args.push("--effort".to_string());
+                args.push(role.reasoning_effort.trim().to_ascii_lowercase());
+            }
+            args.push("--permission-mode".to_string());
+            args.push("plan".to_string());
+            json!({
+                "provider": role.provider.clone(),
+                "provider_adapter": provider_adapter,
+                "command": provider_command,
+                "model": role.model.clone(),
+                "model_source": role.model_source.clone(),
+                "reasoning_effort": role.reasoning_effort.clone(),
+                "model_override": model_override,
+                "args": args,
+                "plan_mode_enforced": true,
+                "read_only": role.read_only,
+            })
+        }
+        "codex" => {
+            args.push("exec".to_string());
+            if model_override {
+                args.push("-c".to_string());
+                args.push(format!("model={}", role.model));
+            }
+            if !provider_default_reasoning_effort(&role.reasoning_effort) {
+                args.push("-c".to_string());
+                args.push(format!(
+                    "model_reasoning_effort={}",
+                    role.reasoning_effort.trim().to_ascii_lowercase()
+                ));
+            }
+            args.push("--sandbox".to_string());
+            args.push("read-only".to_string());
+            json!({
+                "provider": role.provider.clone(),
+                "provider_adapter": provider_adapter,
+                "command": provider_command,
+                "model": role.model.clone(),
+                "model_source": role.model_source.clone(),
+                "reasoning_effort": role.reasoning_effort.clone(),
+                "model_override": model_override,
+                "args": args,
+                "plan_mode_enforced": false,
+                "read_only_equivalent": true,
+                "read_only": role.read_only,
+            })
+        }
+        "gemini" => {
+            if model_override {
+                args.push("--model".to_string());
+                args.push(role.model.clone());
+            }
+            args.push("--approval-mode=plan".to_string());
+            json!({
+                "provider": role.provider.clone(),
+                "provider_adapter": provider_adapter,
+                "command": provider_command,
+                "model": role.model.clone(),
+                "model_source": role.model_source.clone(),
+                "reasoning_effort": role.reasoning_effort.clone(),
+                "model_override": model_override,
+                "args": args,
+                "plan_mode_enforced": false,
+                "read_only_equivalent": true,
+                "read_only": role.read_only,
+            })
+        }
         _ => json!({
             "provider": role.provider.clone(),
             "provider_adapter": provider_adapter,
             "command": provider_command,
             "model": role.model.clone(),
+            "model_source": role.model_source.clone(),
+            "reasoning_effort": role.reasoning_effort.clone(),
+            "model_override": model_override,
             "args": [],
             "plan_mode_enforced": false,
             "read_only_equivalent": true,
@@ -3785,7 +4381,7 @@ fn render_meta_plan_role_draft(
     role: &MetaPlanRole,
     prompt_hash: &str,
 ) -> String {
-    format!("# Meta-Planning Draft: {label}\n\nRun: `{run_id}`\nRole: `{role_id}`\nProvider: `{provider}`\nPlan mode: `{plan_mode}`\nRead-only: `{read_only}`\nTask hash: `{task_hash}`\nRole prompt hash: `{prompt_hash}`\n\n## Task\n\nThe task body is not stored in this artifact. Use the task hash and audit event references to correlate the operator-owned request.\n\n## Responsibility\n\nThe role prompt body is not stored in this artifact by default. Use the prompt hash and role definition source to correlate the role contract.\n\n## Draft Plan\n\n- Confirm facts and constraints for this role.\n- Identify assumptions that must be carried into the integrated plan.\n- Keep all recommendations side-effect-free until operator approval.\n\n## Evidence To Collect\n\n- Existing repository contracts and tests relevant to this role.\n- Gaps, risks, or open questions for the operator to merge.\n", label = &role.label, role_id = &role.role_id, provider = &role.provider, plan_mode = &role.plan_mode, read_only = role.read_only)
+    format!("# Meta-Planning Draft: {label}\n\nRun: `{run_id}`\nRole: `{role_id}`\nProvider: `{provider}`\nModel: `{model}`\nModel source: `{model_source}`\nReasoning effort: `{reasoning_effort}`\nPlan mode: `{plan_mode}`\nRead-only: `{read_only}`\nTask hash: `{task_hash}`\nRole prompt hash: `{prompt_hash}`\n\n## Task\n\nThe task body is not stored in this artifact. Use the task hash and audit event references to correlate the operator-owned request.\n\n## Responsibility\n\nThe role prompt body is not stored in this artifact by default. Use the prompt hash and role definition source to correlate the role contract.\n\n## Draft Plan\n\n- Confirm facts and constraints for this role.\n- Identify assumptions that must be carried into the integrated plan.\n- Keep all recommendations side-effect-free until operator approval.\n\n## Evidence To Collect\n\n- Existing repository contracts and tests relevant to this role.\n- Gaps, risks, or open questions for the operator to merge.\n", label = &role.label, role_id = &role.role_id, provider = &role.provider, model = &role.model, model_source = &role.model_source, reasoning_effort = &role.reasoning_effort, plan_mode = &role.plan_mode, read_only = role.read_only)
 }
 
 fn render_meta_plan_cross_review(
@@ -4555,7 +5151,7 @@ fn usage_for(command: &str) -> &'static str {
         }
         "guard" => "usage: winsmux guard [--json] [--project-dir <path>]",
         "provider-switch" => {
-            "usage: winsmux provider-switch <slot> [--agent <name>] [--model <name>] [--prompt-transport <argv|file|stdin>] [--auth-mode <mode>] [--reason <text>] [--restart] [--clear] [--json] [--project-dir <path>]"
+            "usage: winsmux provider-switch <slot> [--agent <name>] [--model <name>] [--model-source <source>] [--reasoning-effort <level>] [--prompt-transport <argv|file|stdin>] [--auth-mode <mode>] [--reason <text>] [--restart] [--clear] [--json] [--project-dir <path>]"
         }
         "signal" => "usage: winsmux signal <channel>",
         "wait" => "usage: winsmux wait <channel> [timeout_seconds]",
@@ -4926,6 +5522,8 @@ struct RestartPlan {
     git_worktree_dir: String,
     agent: String,
     model: String,
+    model_source: String,
+    reasoning_effort: String,
     capability_adapter: String,
     launch_command: String,
 }
@@ -5448,7 +6046,7 @@ fn build_restart_plan(project_dir: &Path, target: &str) -> io::Result<RestartPla
 fn build_restart_plan_with_provider(
     project_dir: &Path,
     target: &str,
-    provider_override: Option<(String, String, String)>,
+    provider_override: Option<(String, String, String, String, String)>,
 ) -> io::Result<RestartPlan> {
     let manifest_path = project_dir.join(".winsmux").join("manifest.yaml");
     let raw = fs::read_to_string(&manifest_path)?;
@@ -5470,14 +6068,17 @@ fn build_restart_plan_with_provider(
     )?;
     ensure_live_pane_target(&session_name, &context.pane_id)?;
 
-    let (agent, model, capability_adapter) = if let Some(provider) = provider_override {
-        provider
-    } else {
-        resolve_restart_provider(project_dir, &context)?
-    };
+    let (agent, model, model_source, reasoning_effort, capability_adapter) =
+        if let Some(provider) = provider_override {
+            provider
+        } else {
+            resolve_restart_provider(project_dir, &context)?
+        };
     let launch_command = build_provider_launch_command(
         &agent,
         &model,
+        &model_source,
+        &reasoning_effort,
         &capability_adapter,
         &context.launch_dir,
         &context.git_worktree_dir,
@@ -5491,6 +6092,8 @@ fn build_restart_plan_with_provider(
         git_worktree_dir: context.git_worktree_dir,
         agent,
         model,
+        model_source,
+        reasoning_effort,
         capability_adapter,
         launch_command,
     })
@@ -5525,7 +6128,13 @@ fn build_provider_switch_restart_plan(
     build_restart_plan_with_provider(
         project_dir,
         pane_id,
-        Some((effective.agent, effective.model, adapter)),
+        Some((
+            effective.agent,
+            effective.model,
+            effective.model_source,
+            effective.reasoning_effort,
+            adapter,
+        )),
     )
 }
 
@@ -5636,7 +6245,9 @@ fn restart_context_from_value(
         git_worktree_dir,
         agent: String::new(),
         model: String::new(),
+        model_source: default_provider_model_source(),
         capability_adapter: String::new(),
+        reasoning_effort: default_provider_reasoning_effort(),
         launch_command: String::new(),
     })
 }
@@ -5665,7 +6276,7 @@ fn pane_git_worktree_dir(project_dir: &Path) -> String {
 fn resolve_restart_provider(
     project_dir: &Path,
     context: &RestartPlan,
-) -> io::Result<(String, String, String)> {
+) -> io::Result<(String, String, String, String, String)> {
     let manifest_provider_target = manifest_provider_target(project_dir, &context.pane_id);
     let manifest_capability_adapter =
         manifest_capability_adapter(project_dir, &context.pane_id).unwrap_or_default();
@@ -5681,7 +6292,13 @@ fn resolve_restart_provider(
                 } else {
                     effective.capability_adapter
                 };
-                return Ok((effective.agent, effective.model, adapter));
+                return Ok((
+                    effective.agent,
+                    effective.model,
+                    effective.model_source,
+                    effective.reasoning_effort,
+                    adapter,
+                ));
             }
         }
     }
@@ -5698,7 +6315,13 @@ fn resolve_restart_provider(
                 .filter(|value| !value.trim().is_empty())
                 .unwrap_or_else(|| provider_adapter_from_agent(&agent))
         };
-        return Ok((agent, model, adapter));
+        return Ok((
+            agent,
+            model.clone(),
+            inferred_model_source_for_model(&model),
+            default_provider_reasoning_effort(),
+            adapter,
+        ));
     }
 
     Err(io::Error::new(
@@ -5808,16 +6431,27 @@ fn provider_adapter_from_agent(agent: &str) -> String {
 fn build_provider_launch_command(
     agent: &str,
     model: &str,
+    model_source: &str,
+    reasoning_effort: &str,
     capability_adapter: &str,
     launch_dir: &str,
     git_worktree_dir: &str,
 ) -> io::Result<String> {
+    let model_override = provider_model_override(model, model_source);
+    let effort_override = !provider_default_reasoning_effort(reasoning_effort);
     match capability_adapter.trim().to_ascii_lowercase().as_str() {
         "codex" => {
             let mut parts = vec![shell_literal(agent)];
-            if !model.trim().is_empty() {
+            if model_override {
                 parts.push("-c".to_string());
                 parts.push(shell_literal(&format!("model={model}")));
+            }
+            if effort_override {
+                parts.push("-c".to_string());
+                parts.push(shell_literal(&format!(
+                    "model_reasoning_effort={}",
+                    reasoning_effort.trim().to_ascii_lowercase()
+                )));
             }
             parts.push("--sandbox".to_string());
             parts.push("danger-full-access".to_string());
@@ -5829,12 +6463,25 @@ fn build_provider_launch_command(
         }
         "claude" => {
             let mut parts = vec![shell_literal(agent)];
-            if !model.trim().is_empty() {
+            if model_override {
                 parts.push("--model".to_string());
                 parts.push(shell_literal(model));
             }
+            if effort_override {
+                parts.push("--effort".to_string());
+                parts.push(reasoning_effort.trim().to_ascii_lowercase());
+            }
             parts.push("--permission-mode".to_string());
             parts.push("bypassPermissions".to_string());
+            Ok(parts.join(" "))
+        }
+        "gemini" => {
+            let mut parts = vec![shell_literal(agent)];
+            if model_override {
+                parts.push("--model".to_string());
+                parts.push(shell_literal(model));
+            }
+            parts.push("--approval-mode=default".to_string());
             Ok(parts.join(" "))
         }
         adapter => Err(io::Error::new(
@@ -5854,8 +6501,8 @@ fn shell_literal(value: &str) -> String {
     format!("'{}'", value.replace('\'', "''"))
 }
 
-fn provider_target_with_model(agent: &str, model: &str) -> String {
-    if model.trim().is_empty() {
+fn provider_target_with_model(agent: &str, model: &str, model_source: &str) -> String {
+    if !provider_model_override(model, model_source) {
         agent.to_string()
     } else {
         format!("{}:{}", agent.trim(), model.trim())
@@ -6037,7 +6684,8 @@ fn update_restart_manifest_metadata(project_dir: &Path, plan: &RestartPlan) -> i
                 format!("invalid manifest: {}: {err}", manifest_path.display()),
             )
         })?;
-        let provider_target = provider_target_with_model(&plan.agent, &plan.model);
+        let provider_target =
+            provider_target_with_model(&plan.agent, &plan.model, &plan.model_source);
         let updated = update_manifest_pane_restart_fields(
             &mut manifest,
             &plan.pane_id,
@@ -9251,6 +9899,8 @@ mod tests {
             git_worktree_dir: "C:\\repo\\.git".to_string(),
             agent: agent.to_string(),
             model: String::new(),
+            model_source: default_provider_model_source(),
+            reasoning_effort: default_provider_reasoning_effort(),
             capability_adapter: capability_adapter.to_string(),
             launch_command: "noop".to_string(),
         }
@@ -9258,7 +9908,10 @@ mod tests {
 
     #[test]
     fn restart_readiness_agent_resolves_known_adapters() {
-        assert_eq!(restart_readiness_agent(&restart_plan("custom", "codex")), "codex");
+        assert_eq!(
+            restart_readiness_agent(&restart_plan("custom", "codex")),
+            "codex"
+        );
         assert_eq!(
             restart_readiness_agent(&restart_plan("claude-opus", "")),
             "claude"
@@ -9272,7 +9925,10 @@ mod tests {
     #[test]
     fn restart_readiness_agent_does_not_default_unknown_to_codex() {
         assert_eq!(restart_readiness_agent(&restart_plan("", "")), "");
-        assert_eq!(restart_readiness_agent(&restart_plan("custom-agent", "")), "");
+        assert_eq!(
+            restart_readiness_agent(&restart_plan("custom-agent", "")),
+            ""
+        );
         assert_eq!(
             restart_readiness_agent(&restart_plan("custom-agent", "custom-adapter")),
             ""

--- a/core/tests-rs/operator_cli.rs
+++ b/core/tests-rs/operator_cli.rs
@@ -326,6 +326,9 @@ fn operator_cli_meta_plan_json_writes_plan_artifacts_and_audit_log() {
         2
     );
     assert_eq!(json["roles"][0]["role_id"], "investigator");
+    assert_eq!(json["roles"][0]["model_source"], "provider-default");
+    assert_eq!(json["roles"][0]["reasoning_effort"], "provider-default");
+    assert_eq!(json["roles"][0]["launch_contract"]["model_override"], false);
     assert_eq!(
         json["roles"][0]["launch_contract"]["args"][0],
         "--permission-mode"
@@ -599,6 +602,11 @@ roles:
         "gemini"
     );
     assert_eq!(json["roles"][2]["launch_contract"]["command"], "gemini-cli");
+    assert_eq!(
+        json["roles"][2]["launch_contract"]["args"][0],
+        "--approval-mode=plan"
+    );
+    assert_eq!(json["roles"][2]["launch_contract"]["model_override"], false);
     assert_eq!(
         json["roles"][2]["launch_contract"]["read_only_equivalent"],
         true
@@ -1106,6 +1114,13 @@ fn operator_cli_provider_capabilities_json_reads_registry() {
     "codex": {
       "adapter": "codex",
       "command": "codex",
+      "model_options": [
+        {"id": "provider-default", "label": "Provider default", "source": "provider-default"},
+        {"id": "gpt-5.3-codex-spark", "label": "GPT-5.3-Codex-Spark", "source": "cli-discovery", "availability": "local-account"}
+      ],
+      "model_sources": ["provider-default", "cli-discovery"],
+      "reasoning_efforts": ["provider-default", "low", "medium", "high", "xhigh"],
+      "local_access_note": "Local Codex CLI catalog and ChatGPT account access.",
       "prompt_transports": ["argv", "file", "stdin"],
       "auth_modes": ["local_interactive"],
       "supports_subagents": true
@@ -1132,6 +1147,18 @@ fn operator_cli_provider_capabilities_json_reads_registry() {
             || registry_path.ends_with(".winsmux/provider-capabilities.json")
     );
     assert_eq!(registry["providers"]["codex"]["adapter"], "codex");
+    assert_eq!(
+        registry["providers"]["codex"]["model_options"][1]["source"],
+        "cli-discovery"
+    );
+    assert_eq!(
+        registry["providers"]["codex"]["reasoning_efforts"][4],
+        "xhigh"
+    );
+    assert_eq!(
+        registry["providers"]["codex"]["local_access_note"],
+        "Local Codex CLI catalog and ChatGPT account access."
+    );
     assert_eq!(
         registry["providers"]["codex"]["prompt_transports"][2],
         "stdin"
@@ -1719,6 +1746,10 @@ fn operator_cli_provider_switch_writes_registry_entry() {
             "claude",
             "--model",
             "opus",
+            "--model-source",
+            "operator-override",
+            "--reasoning-effort",
+            "xhigh",
             "--prompt-transport",
             "file",
             "--auth-mode",
@@ -1732,6 +1763,8 @@ fn operator_cli_provider_switch_writes_registry_entry() {
     assert_eq!(result["slot_id"], "worker-1");
     assert_eq!(result["agent"], "claude");
     assert_eq!(result["model"], "opus");
+    assert_eq!(result["model_source"], "operator-override");
+    assert_eq!(result["reasoning_effort"], "xhigh");
     assert_eq!(result["prompt_transport"], "file");
     assert_eq!(result["auth_mode"], "claude-pro-max-oauth");
     assert_eq!(result["auth_policy"], "local_interactive_only");
@@ -1747,6 +1780,11 @@ fn operator_cli_provider_switch_writes_registry_entry() {
     let registry = read_json_file(&project_dir.join(".winsmux").join("provider-registry.json"));
     assert_eq!(registry["slots"]["worker-1"]["agent"], "claude");
     assert_eq!(registry["slots"]["worker-1"]["model"], "opus");
+    assert_eq!(
+        registry["slots"]["worker-1"]["model_source"],
+        "operator-override"
+    );
+    assert_eq!(registry["slots"]["worker-1"]["reasoning_effort"], "xhigh");
     assert_eq!(registry["slots"]["worker-1"]["prompt_transport"], "file");
     assert_eq!(
         registry["slots"]["worker-1"]["reason"],
@@ -1789,6 +1827,64 @@ fn operator_cli_provider_switch_rejects_blocked_auth_before_write() {
 }
 
 #[test]
+fn operator_cli_provider_switch_rejects_capability_selector_mismatch_before_write() {
+    let project_dir = make_temp_project_dir("provider-switch-capability-selector");
+    write_provider_switch_fixture(&project_dir);
+
+    let model_source_output = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .args([
+            "provider-switch",
+            "worker-1",
+            "--agent",
+            "codex",
+            "--model",
+            "gpt-5.5",
+            "--model-source",
+            "operator-override",
+            "--json",
+        ])
+        .current_dir(&project_dir)
+        .output()
+        .expect("winsmux command should run");
+
+    assert!(!model_source_output.status.success());
+    assert!(
+        String::from_utf8_lossy(&model_source_output.stderr)
+            .contains("does not support model_source 'operator-override'"),
+        "stderr should explain unsupported model source"
+    );
+    assert!(!project_dir
+        .join(".winsmux")
+        .join("provider-registry.json")
+        .exists());
+
+    let reasoning_output = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .args([
+            "provider-switch",
+            "worker-1",
+            "--agent",
+            "codex",
+            "--reasoning-effort",
+            "max",
+            "--json",
+        ])
+        .current_dir(&project_dir)
+        .output()
+        .expect("winsmux command should run");
+
+    assert!(!reasoning_output.status.success());
+    assert!(
+        String::from_utf8_lossy(&reasoning_output.stderr)
+            .contains("does not support reasoning_effort 'max'"),
+        "stderr should explain unsupported reasoning effort"
+    );
+    assert!(!project_dir
+        .join(".winsmux")
+        .join("provider-registry.json")
+        .exists());
+}
+
+#[test]
 fn operator_cli_provider_switch_validates_candidate_before_write() {
     let project_dir = make_temp_project_dir("provider-switch-candidate-before-write");
     write_provider_switch_fixture(&project_dir);
@@ -1823,6 +1919,8 @@ fn operator_cli_provider_switch_replaces_case_variant_registry_key() {
             "WORKER-1",
             "--model",
             "gpt-5.5",
+            "--model-source",
+            "cli-discovery",
             "--json",
         ],
     );
@@ -1833,6 +1931,8 @@ fn operator_cli_provider_switch_replaces_case_variant_registry_key() {
             "worker-1",
             "--model",
             "gpt-5.4",
+            "--model-source",
+            "cli-discovery",
             "--json",
         ],
     );
@@ -1929,6 +2029,7 @@ fn operator_cli_provider_switch_accepts_default_managed_slots() {
         r#"
 agent: codex
 model: gpt-5.4
+model-source: cli-discovery
 prompt-transport: argv
 worker-count: 2
 external-operator: true
@@ -1943,11 +2044,54 @@ external-operator: true
             "worker-2",
             "--model",
             "gpt-5.5",
+            "--model-source",
+            "cli-discovery",
             "--json",
         ],
     );
 
     assert_eq!(result["slot_id"], "worker-2");
+    assert_eq!(result["agent"], "codex");
+    assert_eq!(result["model"], "gpt-5.5");
+    assert_eq!(result["source"], "registry");
+}
+
+#[test]
+fn operator_cli_runtime_provider_default_keeps_configured_provider() {
+    let project_dir = make_temp_project_dir("runtime-provider-default");
+    write_provider_switch_fixture(&project_dir);
+    fs::write(
+        project_dir
+            .join(".winsmux")
+            .join("runtime-role-preferences.json"),
+        r#"{
+  "version": 1,
+  "roles": {
+    "worker": {
+      "provider": "provider-default",
+      "model": "provider-default",
+      "model_source": "provider-default",
+      "reasoning_effort": "provider-default"
+    }
+  }
+}"#,
+    )
+    .expect("test should write runtime role preferences");
+
+    let result = run_json(
+        &project_dir,
+        &[
+            "provider-switch",
+            "worker-1",
+            "--model",
+            "gpt-5.5",
+            "--model-source",
+            "cli-discovery",
+            "--json",
+        ],
+    );
+
+    assert_eq!(result["slot_id"], "worker-1");
     assert_eq!(result["agent"], "codex");
     assert_eq!(result["model"], "gpt-5.5");
     assert_eq!(result["source"], "registry");
@@ -2061,6 +2205,118 @@ panes:
     let log = fs::read_to_string(&log_path).expect("fake winsmux log should exist");
     assert!(log.contains("send-keys -t \"%2\" -l -- \"claude --model opus"));
     assert!(!log.contains("codex -c"));
+}
+
+#[test]
+fn operator_cli_provider_switch_restart_skips_provider_default_model() {
+    let project_dir = make_temp_project_dir("provider-switch-restart-provider-default");
+    write_provider_switch_fixture(&project_dir);
+    fs::write(
+        project_dir.join(".winsmux").join("manifest.yaml"),
+        format!(
+            r#"
+session:
+  name: winsmux-orchestra
+  project_dir: {}
+panes:
+  worker-1:
+    pane_id: "%2"
+    role: Builder
+    launch_dir: {}
+    capability_adapter: codex
+"#,
+            project_dir.display(),
+            project_dir.display()
+        ),
+    )
+    .expect("test should write manifest");
+    let (winsmux_bin, log_path) =
+        write_fake_winsmux_restart(&project_dir, Some("winsmux-orchestra"), &["%2"]);
+
+    let result = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .args([
+            "provider-switch",
+            "worker-1",
+            "--model",
+            "provider-default",
+            "--reasoning-effort",
+            "xhigh",
+            "--restart",
+            "--json",
+        ])
+        .env("WINSMUX_BIN", winsmux_bin)
+        .current_dir(&project_dir)
+        .output()
+        .expect("winsmux command should run");
+
+    assert!(
+        result.status.success(),
+        "winsmux command failed: {}",
+        String::from_utf8_lossy(&result.stderr)
+    );
+    let payload: serde_json::Value =
+        serde_json::from_slice(&result.stdout).expect("stdout should be JSON");
+    assert_eq!(payload["model"], "provider-default");
+    assert_eq!(payload["reasoning_effort"], "xhigh");
+    let log = fs::read_to_string(&log_path).expect("fake winsmux log should exist");
+    assert!(log.contains("send-keys -t \"%2\" -l -- \"codex -c 'model_reasoning_effort=xhigh'"));
+    assert!(!log.contains("model=provider-default"));
+}
+
+#[test]
+fn operator_cli_provider_switch_restart_skips_provider_default_model_source() {
+    let project_dir = make_temp_project_dir("provider-switch-restart-provider-default-source");
+    write_provider_switch_fixture(&project_dir);
+    fs::write(
+        project_dir.join(".winsmux").join("manifest.yaml"),
+        format!(
+            r#"
+session:
+  name: winsmux-orchestra
+  project_dir: {}
+panes:
+  worker-1:
+    pane_id: "%2"
+    role: Builder
+    launch_dir: {}
+    capability_adapter: codex
+"#,
+            project_dir.display(),
+            project_dir.display()
+        ),
+    )
+    .expect("test should write manifest");
+    let (winsmux_bin, log_path) =
+        write_fake_winsmux_restart(&project_dir, Some("winsmux-orchestra"), &["%2"]);
+
+    let result = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .args([
+            "provider-switch",
+            "worker-1",
+            "--model",
+            "gpt-5.4",
+            "--model-source",
+            "provider-default",
+            "--restart",
+            "--json",
+        ])
+        .env("WINSMUX_BIN", winsmux_bin)
+        .current_dir(&project_dir)
+        .output()
+        .expect("winsmux command should run");
+
+    assert!(
+        result.status.success(),
+        "winsmux command failed: {}",
+        String::from_utf8_lossy(&result.stderr)
+    );
+    let payload: serde_json::Value =
+        serde_json::from_slice(&result.stdout).expect("stdout should be JSON");
+    assert_eq!(payload["model"], "gpt-5.4");
+    assert_eq!(payload["model_source"], "provider-default");
+    let log = fs::read_to_string(&log_path).expect("fake winsmux log should exist");
+    assert!(log.contains("send-keys -t \"%2\" -l -- \"codex --sandbox"));
+    assert!(!log.contains("model=gpt-5.4"));
 }
 
 #[test]
@@ -5032,6 +5288,8 @@ panes:
             "worker-1",
             "--model",
             "gpt-5.5",
+            "--model-source",
+            "cli-discovery",
             "--restart",
             "--json",
         ])
@@ -5320,12 +5578,14 @@ fn write_provider_switch_fixture(project_dir: &std::path::Path) {
         r#"
 agent: codex
 model: gpt-5.4
+model-source: cli-discovery
 prompt-transport: argv
 agent-slots:
   - slot-id: worker-1
     runtime-role: worker
     agent: codex
     model: gpt-5.4
+    model-source: cli-discovery
     prompt-transport: argv
 "#,
     )
@@ -5338,6 +5598,13 @@ agent-slots:
     "codex": {
       "adapter": "codex",
       "command": "codex",
+      "model_options": [
+        {"id": "provider-default", "label": "Provider default", "source": "provider-default"},
+        {"id": "gpt-5.3-codex-spark", "label": "GPT-5.3-Codex-Spark", "source": "cli-discovery", "availability": "local-account"}
+      ],
+      "model_sources": ["provider-default", "cli-discovery"],
+      "reasoning_efforts": ["provider-default", "low", "medium", "high", "xhigh"],
+      "local_access_note": "Local Codex CLI catalog and ChatGPT account access.",
       "prompt_transports": ["argv", "file", "stdin"],
       "auth_modes": ["api-key", "codex-chatgpt-local"],
       "local_interactive_oauth_modes": ["codex-chatgpt-local"],
@@ -5352,9 +5619,39 @@ agent-slots:
     "claude": {
       "adapter": "claude",
       "command": "claude",
+      "model_options": [
+        {"id": "provider-default", "label": "Provider default", "source": "provider-default"},
+        {"id": "sonnet", "label": "Sonnet", "source": "official-doc"},
+        {"id": "opus", "label": "Opus", "source": "official-doc"},
+        {"id": "opusplan", "label": "Opus Plan", "source": "official-doc"}
+      ],
+      "model_sources": ["provider-default", "official-doc", "operator-override"],
+      "reasoning_efforts": ["provider-default", "low", "medium", "high", "xhigh", "max"],
+      "local_access_note": "Local Claude Code account and settings.",
       "prompt_transports": ["file"],
       "auth_modes": ["api-key", "claude-pro-max-oauth"],
       "local_interactive_oauth_modes": ["claude-pro-max-oauth"],
+      "supports_parallel_runs": false,
+      "supports_interrupt": true,
+      "supports_structured_result": false,
+      "supports_file_edit": true,
+      "supports_subagents": false,
+      "supports_verification": true,
+      "supports_consultation": true
+    },
+    "gemini": {
+      "adapter": "gemini",
+      "command": "gemini",
+      "model_options": [
+        {"id": "provider-default", "label": "Provider default", "source": "provider-default"},
+        {"id": "operator-override", "label": "Operator override", "source": "operator-override"}
+      ],
+      "model_sources": ["provider-default", "operator-override"],
+      "reasoning_efforts": ["provider-default"],
+      "local_access_note": "Local Gemini CLI account and settings.",
+      "prompt_transports": ["argv", "file"],
+      "auth_modes": ["gemini-local"],
+      "local_interactive_oauth_modes": ["gemini-local"],
       "supports_parallel_runs": false,
       "supports_interrupt": true,
       "supports_structured_result": false,

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -3318,7 +3318,7 @@ function Invoke-Role {
     if (Get-Command Get-SlotAgentConfig -ErrorAction SilentlyContinue) {
         $roleAgentConfig = Get-SlotAgentConfig -Role $newRole -SlotId $newLabel -Settings $settings -RootPath $projectDir
     } else {
-        $roleAgentConfig = Get-RoleAgentConfig -Role $newRole -Settings $settings
+        $roleAgentConfig = Get-RoleAgentConfig -Role $newRole -Settings $settings -RootPath $projectDir
     }
     $manifestRole = switch ($newRole) {
         'worker' { 'Worker' }
@@ -3338,11 +3338,20 @@ function Invoke-Role {
     $launchCmd = Get-BridgeProviderLaunchCommand `
         -ProviderId ([string]$roleAgentConfig.Agent) `
         -Model ([string]$roleAgentConfig.Model) `
+        -ModelSource ([string]$roleAgentConfig.ModelSource) `
+        -ReasoningEffort ([string]$roleAgentConfig.ReasoningEffort) `
         -ProjectDir $launchDir `
         -GitWorktreeDir $gitDir `
         -RootPath $projectDir
     $providerTarget = [string]$roleAgentConfig.Agent
-    if (-not [string]::IsNullOrWhiteSpace([string]$roleAgentConfig.Model)) {
+    $providerModelSource = [string]$roleAgentConfig.ModelSource
+    if ([string]::IsNullOrWhiteSpace($providerModelSource)) {
+        $providerModelSource = 'provider-default'
+    }
+    $hasModelOverride = (-not [string]::IsNullOrWhiteSpace([string]$roleAgentConfig.Model)) -and
+        (-not [string]::Equals(([string]$roleAgentConfig.Model).Trim(), 'provider-default', [System.StringComparison]::OrdinalIgnoreCase)) -and
+        (-not [string]::Equals($providerModelSource.Trim(), 'provider-default', [System.StringComparison]::OrdinalIgnoreCase))
+    if ($hasModelOverride) {
         $providerTarget = "${providerTarget}:$([string]$roleAgentConfig.Model)"
     }
 
@@ -3915,9 +3924,12 @@ function New-LauncherSlotSummary {
         runtime_role               = $runtimeRole
         agent                      = [string]$effective.Agent
         model                      = [string]$effective.Model
+        model_source               = [string]$effective.ModelSource
+        reasoning_effort           = [string]$effective.ReasoningEffort
         prompt_transport           = [string]$effective.PromptTransport
         auth_mode                  = [string]$effective.AuthMode
         auth_policy                = [string]$effective.AuthPolicy
+        local_access_note          = [string]$effective.LocalAccessNote
         source                     = [string]$effective.Source
         capability_adapter         = [string]$effective.CapabilityAdapter
         capability_command         = [string]$effective.CapabilityCommand
@@ -10717,12 +10729,14 @@ function Invoke-Guard {
 function Invoke-ProviderSwitch {
     $tokens = @(@($Target) + @($Rest) | Where-Object { $_ })
     if ($tokens.Count -lt 1) {
-        Stop-WithError "usage: winsmux provider-switch <slot> [--agent <name>] [--model <name>] [--prompt-transport <argv|file|stdin>] [--auth-mode <mode>] [--reason <text>] [--restart] [--clear] [--json]"
+        Stop-WithError "usage: winsmux provider-switch <slot> [--agent <name>] [--model <name>] [--model-source <source>] [--reasoning-effort <level>] [--prompt-transport <argv|file|stdin>] [--auth-mode <mode>] [--reason <text>] [--restart] [--clear] [--json]"
     }
 
     $slotId = [string]$tokens[0]
     $agent = ''
     $model = ''
+    $modelSource = ''
+    $reasoningEffort = ''
     $promptTransport = ''
     $authMode = ''
     $reason = ''
@@ -10744,6 +10758,20 @@ function Invoke-ProviderSwitch {
                     Stop-WithError '--model requires a value'
                 }
                 $model = [string]$tokens[$index + 1]
+                $index++
+            }
+            '--model-source' {
+                if ($index + 1 -ge $tokens.Count) {
+                    Stop-WithError '--model-source requires a value'
+                }
+                $modelSource = [string]$tokens[$index + 1]
+                $index++
+            }
+            '--reasoning-effort' {
+                if ($index + 1 -ge $tokens.Count) {
+                    Stop-WithError '--reasoning-effort requires a value'
+                }
+                $reasoningEffort = [string]$tokens[$index + 1]
                 $index++
             }
             '--prompt-transport' {
@@ -10777,13 +10805,13 @@ function Invoke-ProviderSwitch {
                 $clearRequested = $true
             }
             default {
-                Stop-WithError "usage: winsmux provider-switch <slot> [--agent <name>] [--model <name>] [--prompt-transport <argv|file|stdin>] [--auth-mode <mode>] [--reason <text>] [--restart] [--clear] [--json]"
+                Stop-WithError "usage: winsmux provider-switch <slot> [--agent <name>] [--model <name>] [--model-source <source>] [--reasoning-effort <level>] [--prompt-transport <argv|file|stdin>] [--auth-mode <mode>] [--reason <text>] [--restart] [--clear] [--json]"
             }
         }
     }
 
-    if ($clearRequested -and (-not [string]::IsNullOrWhiteSpace($agent) -or -not [string]::IsNullOrWhiteSpace($model) -or -not [string]::IsNullOrWhiteSpace($promptTransport) -or -not [string]::IsNullOrWhiteSpace($authMode))) {
-        Stop-WithError 'provider-switch --clear cannot be combined with --agent, --model, --prompt-transport, or --auth-mode.'
+    if ($clearRequested -and (-not [string]::IsNullOrWhiteSpace($agent) -or -not [string]::IsNullOrWhiteSpace($model) -or -not [string]::IsNullOrWhiteSpace($modelSource) -or -not [string]::IsNullOrWhiteSpace($reasoningEffort) -or -not [string]::IsNullOrWhiteSpace($promptTransport) -or -not [string]::IsNullOrWhiteSpace($authMode))) {
+        Stop-WithError 'provider-switch --clear cannot be combined with --agent, --model, --model-source, --reasoning-effort, --prompt-transport, or --auth-mode.'
     }
 
     $projectDir = (Get-Location).Path
@@ -10818,24 +10846,28 @@ function Invoke-ProviderSwitch {
         $clearResult = Remove-BridgeProviderRegistryEntry -RootPath $projectDir -SlotId $slotId
         $cleared = [bool]$clearResult.Removed
     } else {
-        if (-not [string]::IsNullOrWhiteSpace($authMode)) {
-            $currentEffective = Get-SlotAgentConfig -Role 'Worker' -SlotId $slotId -Settings $settings -RootPath $projectDir
-            $candidateAgent = [string]$currentEffective.Agent
-            if (-not [string]::IsNullOrWhiteSpace($agent)) {
-                $candidateAgent = $agent
-            }
-            Assert-BridgeProviderCapabilityAuthMode -ProviderId $candidateAgent -AuthMode $authMode -RootPath $projectDir
-        }
-        $entry = Write-BridgeProviderRegistryEntry -RootPath $projectDir -SlotId $slotId -Agent $agent -Model $model -PromptTransport $promptTransport -AuthMode $authMode -Reason $reason
+        $candidateInput = [ordered]@{}
+        if (-not [string]::IsNullOrWhiteSpace($agent)) { $candidateInput.agent = $agent }
+        if (-not [string]::IsNullOrWhiteSpace($model)) { $candidateInput.model = $model }
+        if (-not [string]::IsNullOrWhiteSpace($modelSource)) { $candidateInput.model_source = $modelSource }
+        if (-not [string]::IsNullOrWhiteSpace($reasoningEffort)) { $candidateInput.reasoning_effort = $reasoningEffort }
+        if (-not [string]::IsNullOrWhiteSpace($promptTransport)) { $candidateInput.prompt_transport = $promptTransport }
+        if (-not [string]::IsNullOrWhiteSpace($authMode)) { $candidateInput.auth_mode = $authMode }
+        $candidateEntry = ConvertTo-BridgeProviderRegistryEntry $candidateInput
+        $null = Get-SlotAgentConfig -Role 'Worker' -SlotId $slotId -Settings $settings -RootPath $projectDir -ProviderRegistryEntryOverride $candidateEntry
+        $entry = Write-BridgeProviderRegistryEntry -RootPath $projectDir -SlotId $slotId -Agent $agent -Model $model -ModelSource $modelSource -ReasoningEffort $reasoningEffort -PromptTransport $promptTransport -AuthMode $authMode -Reason $reason
     }
     $effective = Get-SlotAgentConfig -Role 'Worker' -SlotId $slotId -Settings $settings -RootPath $projectDir
     $result = [ordered]@{
         slot_id                    = $slotId
         agent                      = [string]$effective.Agent
         model                      = [string]$effective.Model
+        model_source               = [string]$effective.ModelSource
+        reasoning_effort           = [string]$effective.ReasoningEffort
         prompt_transport           = [string]$effective.PromptTransport
         auth_mode                  = [string]$effective.AuthMode
         auth_policy                = [string]$effective.AuthPolicy
+        local_access_note          = [string]$effective.LocalAccessNote
         source                     = [string]$effective.Source
         capability_adapter         = [string]$effective.CapabilityAdapter
         capability_command         = [string]$effective.CapabilityCommand
@@ -10876,6 +10908,59 @@ function Invoke-ProviderSwitch {
     Write-Output "provider switched for ${slotId}: $($result.agent) / $($result.model) ($($result.prompt_transport), $($result.auth_policy))"
 }
 
+function Invoke-RuntimeRoles {
+    $tokens = @(@($Target) + @($Rest) | Where-Object { $_ })
+    if ($tokens.Count -lt 1 -or $tokens[0] -ne 'apply') {
+        Stop-WithError "usage: winsmux runtime-roles apply --roles-json <json> [--json]"
+    }
+
+    $rolesJson = ''
+    $jsonOutput = $false
+    for ($index = 1; $index -lt $tokens.Count; $index++) {
+        switch ($tokens[$index]) {
+            '--roles-json' {
+                if ($index + 1 -ge $tokens.Count) {
+                    Stop-WithError '--roles-json requires a value'
+                }
+                $rolesJson = [string]$tokens[$index + 1]
+                $index++
+            }
+            '--json' {
+                $jsonOutput = $true
+            }
+            default {
+                Stop-WithError "usage: winsmux runtime-roles apply --roles-json <json> [--json]"
+            }
+        }
+    }
+
+    if ([string]::IsNullOrWhiteSpace($rolesJson)) {
+        Stop-WithError '--roles-json requires a value'
+    }
+
+    try {
+        $roles = $rolesJson | ConvertFrom-Json -Depth 16 -ErrorAction Stop
+    } catch {
+        Stop-WithError 'runtime-roles apply received invalid JSON.'
+    }
+
+    $projectDir = (Get-Location).Path
+    $payload = Write-BridgeRuntimeRolePreferences -RootPath $projectDir -Roles $roles
+    $result = [ordered]@{
+        version        = [int]$payload.version
+        updated_at_utc = [string]$payload.updated_at_utc
+        roles          = $payload.roles
+        preferences_path = Get-BridgeRuntimeRolePreferencesPath -RootPath $projectDir
+    }
+
+    if ($jsonOutput) {
+        $result | ConvertTo-Json -Depth 16 -Compress | Write-Output
+        return
+    }
+
+    Write-Output "runtime role preferences updated: $(@($result.roles.Keys).Count) roles"
+}
+
 function Show-Usage {
     Write-Output @"
 winsmux $VERSION - winsmux bridge for winsmux
@@ -10912,6 +10997,7 @@ Commands:
   consult-error <mode> [--message <text>] [--target-slot <slot>]  Record a consultation error packet/event
   meta-plan --task <text> [--roles <path>] [--review-rounds <1|2>] [--json] [--project-dir <path>] [--session <name>]  Draft a read-only multi-role planning packet
   provider-capabilities [provider] [--json]  Inspect the provider capability registry contract
+  runtime-roles apply --roles-json <json> [--json]  Persist local runtime role provider/model preferences
   skills [--json]  Print agent-readable command skill contracts
   machine-contract --json  Print the hook and agent machine contract JSON
   rust-canary [--json]  Print the Rust default-on canary gate JSON
@@ -10919,7 +11005,7 @@ Commands:
   legacy-compat-gate [--json]  Print the legacy compatibility removal inventory gate
   guard [--json]  Print the public security and release guard baseline
   assign --task <TASK-ID> [--json] [--text <text>]  Dry-run provider, role, model-tier, approval, and sandbox assignment
-  provider-switch <slot> [--agent <name>] [--model <name>] [--prompt-transport <argv|file|stdin>] [--auth-mode <mode>] [--reason <text>] [--restart] [--clear] [--json]  Record or clear a runtime provider reassignment for a managed slot
+  provider-switch <slot> [--agent <name>] [--model <name>] [--model-source <source>] [--reasoning-effort <level>] [--prompt-transport <argv|file|stdin>] [--auth-mode <mode>] [--reason <text>] [--restart] [--clear] [--json]  Record or clear a runtime provider reassignment for a managed slot
   github-preflight [--repo <owner/name>] [--json] [--connector-available] [--require-gh]  Select the GitHub write path before merge/release automation
   locks                     List active file locks
   verify <pr-number>        Run Pester in tests/ and merge PR only on PASS
@@ -11680,6 +11766,7 @@ switch ($Command) {
         }
     }
     'provider-switch' { Invoke-ProviderSwitch }
+    'runtime-roles' { Invoke-RuntimeRoles }
     'rebind-worktree' { Invoke-RebindWorktree }
     ''                { Show-Usage }
     default           { Stop-WithError "unknown command: $Command. Run without arguments for usage." }

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -381,6 +381,97 @@ roles:
         $operatorConfig.Model | Should -Be 'gpt-5.4'
     }
 
+    It 'overlays ignored runtime role preferences on project role defaults' {
+@'
+agent: codex
+model: gpt-5.4
+roles:
+  worker:
+    agent: codex
+    model: gpt-5.4
+agent-slots:
+  - slot-id: worker-1
+    runtime-role: worker
+'@ | Set-Content -Path (Join-Path $script:settingsTempRoot '.winsmux.yaml') -Encoding UTF8
+
+        Mock Get-WinsmuxOption { param($Name, $Default) return $null }
+        $settings = Get-BridgeSettings -RootPath $script:settingsTempRoot
+        $roles = @(
+            [ordered]@{
+                role_id          = 'worker'
+                provider         = 'claude'
+                model            = 'opus'
+                model_source     = 'operator-override'
+                reasoning_effort = 'xhigh'
+            },
+            [ordered]@{
+                role_id          = 'reviewer'
+                provider         = 'codex'
+                model            = 'gpt-5.3-codex-spark'
+                model_source     = 'cli-discovery'
+                reasoning_effort = 'high'
+            }
+        )
+
+        $result = Write-BridgeRuntimeRolePreferences -RootPath $script:settingsTempRoot -Roles $roles
+        $result.roles.worker.agent | Should -Be 'claude'
+
+        $workerConfig = Get-RoleAgentConfig -Role 'Worker' -Settings $settings -RootPath $script:settingsTempRoot
+        $workerConfig.Agent | Should -Be 'claude'
+        $workerConfig.Model | Should -Be 'opus'
+        $workerConfig.ModelSource | Should -Be 'operator-override'
+        $workerConfig.ReasoningEffort | Should -Be 'xhigh'
+
+        $slotConfig = Get-SlotAgentConfig -Role 'Worker' -SlotId 'worker-1' -Settings $settings -RootPath $script:settingsTempRoot
+        $slotConfig.Agent | Should -Be 'claude'
+        $slotConfig.Model | Should -Be 'opus'
+    }
+
+    It 'keeps the configured provider when runtime preferences use provider-default' {
+@'
+agent: codex
+model: gpt-5.4
+roles:
+  worker:
+    agent: codex
+    model: gpt-5.4
+agent-slots:
+  - slot-id: worker-1
+    runtime-role: worker
+'@ | Set-Content -Path (Join-Path $script:settingsTempRoot '.winsmux.yaml') -Encoding UTF8
+
+        Mock Get-WinsmuxOption { param($Name, $Default) return $null }
+        $settings = Get-BridgeSettings -RootPath $script:settingsTempRoot
+        $roles = @(
+            [ordered]@{
+                role_id          = 'worker'
+                provider         = 'provider-default'
+                model            = 'provider-default'
+                model_source     = 'provider-default'
+                reasoning_effort = 'provider-default'
+            }
+        )
+
+        $result = Write-BridgeRuntimeRolePreferences -RootPath $script:settingsTempRoot -Roles $roles
+        $result.roles.worker.Contains('agent') | Should -Be $false
+
+        $slotConfig = Get-SlotAgentConfig -Role 'Worker' -SlotId 'worker-1' -Settings $settings -RootPath $script:settingsTempRoot
+        $slotConfig.Agent | Should -Be 'codex'
+        $slotConfig.Model | Should -Be 'provider-default'
+
+        $command = Get-BridgeProviderLaunchCommand `
+            -ProviderId $slotConfig.Agent `
+            -Model $slotConfig.Model `
+            -ModelSource $slotConfig.ModelSource `
+            -ReasoningEffort $slotConfig.ReasoningEffort `
+            -ProjectDir 'C:\Project Root' `
+            -GitWorktreeDir 'C:\Project Root\.git\worktrees\worker-1' `
+            -RootPath $script:settingsTempRoot
+
+        $command | Should -Match '^codex '
+        $command | Should -Not -Match 'provider-default'
+    }
+
     It 'parses per-role and slot-level prompt transport overrides with the same precedence as agent/model' {
 @'
 agent: codex
@@ -592,12 +683,14 @@ agent-slots:
 @'
 agent: codex
 model: gpt-5.4
+model-source: cli-discovery
 prompt-transport: argv
 agent-slots:
   - slot-id: worker-1
     runtime-role: worker
     agent: codex
     model: gpt-5.4
+    model-source: cli-discovery
     prompt-transport: argv
 '@ | Set-Content -Path (Join-Path $script:settingsTempRoot '.winsmux.yaml') -Encoding UTF8
 
@@ -677,6 +770,13 @@ agent-slots:
       "adapter": "codex",
       "display_name": "Codex",
       "command": "codex",
+      "model_options": [
+        {"id": "provider-default", "label": "Provider default", "source": "provider-default"},
+        {"id": "gpt-5.3-codex-spark", "label": "GPT-5.3-Codex-Spark", "source": "cli-discovery", "availability": "local-account"}
+      ],
+      "model_sources": ["provider-default", "cli-discovery"],
+      "reasoning_efforts": ["provider-default", "low", "medium", "high", "xhigh"],
+      "local_access_note": "Local Codex CLI catalog and ChatGPT account access.",
       "prompt_transports": ["argv", "file", "stdin"],
       "auth_modes": ["api-key", "codex-chatgpt-local"],
       "local_interactive_oauth_modes": ["codex-chatgpt-local"],
@@ -696,6 +796,10 @@ agent-slots:
         $registry = Read-BridgeProviderCapabilityRegistry -RootPath $script:settingsTempRoot
         $registry.providers.codex.adapter | Should -Be 'codex'
         $registry.providers.codex.prompt_transports | Should -Be @('argv', 'file', 'stdin')
+        $registry.providers.codex.model_options[1].source | Should -Be 'cli-discovery'
+        $registry.providers.codex.model_sources | Should -Be @('provider-default', 'cli-discovery')
+        $registry.providers.codex.reasoning_efforts | Should -Be @('provider-default', 'low', 'medium', 'high', 'xhigh')
+        $registry.providers.codex.local_access_note | Should -Be 'Local Codex CLI catalog and ChatGPT account access.'
         $registry.providers.codex.auth_modes | Should -Be @('api-key', 'codex-chatgpt-local')
         $registry.providers.codex.local_interactive_oauth_modes | Should -Be @('codex-chatgpt-local')
         $registry.providers.codex.supports_file_edit | Should -Be $true
@@ -717,6 +821,13 @@ agent-slots:
     "codex": {
       "adapter": "codex",
       "command": "codex",
+      "model_options": [
+        {"id": "provider-default", "label": "Provider default", "source": "provider-default"},
+        {"id": "gpt-5.3-codex-spark", "label": "GPT-5.3-Codex-Spark", "source": "cli-discovery", "availability": "local-account"}
+      ],
+      "model_sources": ["provider-default", "cli-discovery"],
+      "reasoning_efforts": ["provider-default", "low", "medium", "high", "xhigh"],
+      "local_access_note": "Local Codex CLI catalog and ChatGPT account access.",
       "prompt_transports": ["argv", "file", "stdin"],
       "auth_modes": ["api-key", "codex-chatgpt-local"],
       "local_interactive_oauth_modes": ["codex-chatgpt-local"],
@@ -741,6 +852,8 @@ agent-slots:
     runtime-role: worker
     agent: codex
     model: gpt-5.4
+    model-source: cli-discovery
+    reasoning-effort: high
     prompt-transport: argv
     auth-mode: codex-chatgpt-local
 '@ | Set-Content -Path (Join-Path $script:settingsTempRoot '.winsmux.yaml') -Encoding UTF8
@@ -752,6 +865,12 @@ agent-slots:
 
         $config.CapabilityAdapter | Should -Be 'codex'
         $config.CapabilityCommand | Should -Be 'codex'
+        $config.ModelSource | Should -Be 'cli-discovery'
+        $config.ReasoningEffort | Should -Be 'high'
+        $config.ModelOptions[1].source | Should -Be 'cli-discovery'
+        $config.ModelSources | Should -Be @('provider-default', 'cli-discovery')
+        $config.ReasoningEfforts | Should -Be @('provider-default', 'low', 'medium', 'high', 'xhigh')
+        $config.LocalAccessNote | Should -Be 'Local Codex CLI catalog and ChatGPT account access.'
         $config.AuthMode | Should -Be 'codex-chatgpt-local'
         $config.AuthPolicy | Should -Be 'local_interactive_only'
         $config.SupportsParallelRuns | Should -Be $true
@@ -1022,14 +1141,40 @@ agent-slots:
         $command = Get-BridgeProviderLaunchCommand `
             -ProviderId 'codex-local' `
             -Model 'gpt-5.4' `
+            -ModelSource 'cli-discovery' `
+            -ReasoningEffort 'xhigh' `
             -ProjectDir 'C:\Project Root' `
             -GitWorktreeDir 'C:\Project Root\.git\worktrees\worker-1' `
             -RootPath $script:settingsTempRoot
 
         $command | Should -Match 'codex-beta'
         $command | Should -Match "-c 'model=gpt-5\.4'"
+        $command | Should -Match "-c 'model_reasoning_effort=xhigh'"
         $command | Should -Match "-C 'C:\\Project Root'"
         $command | Should -Match "--add-dir 'C:\\Project Root\\.git\\worktrees\\worker-1'"
+
+        $providerDefaultCommand = Get-BridgeProviderLaunchCommand `
+            -ProviderId 'codex-local' `
+            -Model 'provider-default' `
+            -ModelSource 'provider-default' `
+            -ReasoningEffort 'high' `
+            -ProjectDir 'C:\Project Root' `
+            -GitWorktreeDir 'C:\Project Root\.git\worktrees\worker-1' `
+            -RootPath $script:settingsTempRoot
+
+        $providerDefaultCommand | Should -Match "-c 'model_reasoning_effort=high'"
+        $providerDefaultCommand | Should -Not -Match 'model=provider-default'
+
+        $providerDefaultSourceCommand = Get-BridgeProviderLaunchCommand `
+            -ProviderId 'codex-local' `
+            -Model 'gpt-5.4' `
+            -ModelSource 'provider-default' `
+            -ReasoningEffort 'provider-default' `
+            -ProjectDir 'C:\Project Root' `
+            -GitWorktreeDir 'C:\Project Root\.git\worktrees\worker-1' `
+            -RootPath $script:settingsTempRoot
+
+        $providerDefaultSourceCommand | Should -Not -Match 'model=gpt-5\.4'
     }
 
     It 'rejects structurally malformed provider capability registries' {
@@ -11756,6 +11901,13 @@ Describe 'winsmux provider-capabilities command' {
       "adapter": "codex",
       "display_name": "Codex",
       "command": "codex",
+      "model_options": [
+        {"id": "provider-default", "label": "Provider default", "source": "provider-default"},
+        {"id": "gpt-5.3-codex-spark", "label": "GPT-5.3-Codex-Spark", "source": "cli-discovery", "availability": "local-account"}
+      ],
+      "model_sources": ["provider-default", "cli-discovery"],
+      "reasoning_efforts": ["provider-default", "low", "medium", "high", "xhigh"],
+      "local_access_note": "Local Codex CLI catalog and ChatGPT account access.",
       "prompt_transports": ["argv", "file", "stdin"],
       "supports_file_edit": true,
       "supports_verification": true,
@@ -11786,6 +11938,9 @@ Describe 'winsmux provider-capabilities command' {
         $payload = $output | ConvertFrom-Json
         $payload.version | Should -Be 1
         $payload.providers.codex.adapter | Should -Be 'codex'
+        $payload.providers.codex.model_options[1].source | Should -Be 'cli-discovery'
+        $payload.providers.codex.reasoning_efforts | Should -Be @('provider-default', 'low', 'medium', 'high', 'xhigh')
+        $payload.providers.codex.local_access_note | Should -Be 'Local Codex CLI catalog and ChatGPT account access.'
         $payload.providers.codex.prompt_transports | Should -Be @('argv', 'file', 'stdin')
         $payload.providers.codex.supports_file_edit | Should -Be $true
     }
@@ -11801,6 +11956,7 @@ Describe 'winsmux provider-capabilities command' {
         $payload = $output | ConvertFrom-Json
         $payload.provider_id | Should -Be 'CODEX'
         $payload.capabilities.command | Should -Be 'codex'
+        $payload.capabilities.model_sources | Should -Be @('provider-default', 'cli-discovery')
         $payload.capabilities.supports_verification | Should -Be $true
     }
 }
@@ -12224,12 +12380,14 @@ Describe 'winsmux provider-switch command' {
         @'
 agent: codex
 model: gpt-5.4
+model-source: cli-discovery
 prompt-transport: argv
 agent-slots:
   - slot-id: worker-1
     runtime-role: worker
     agent: codex
     model: gpt-5.4
+    model-source: cli-discovery
     prompt-transport: argv
 '@ | Set-Content -Path (Join-Path $script:providerSwitchTempRoot '.winsmux.yaml') -Encoding UTF8
         New-Item -ItemType Directory -Path (Join-Path $script:providerSwitchTempRoot '.winsmux') -Force | Out-Null
@@ -12240,6 +12398,13 @@ agent-slots:
     "codex": {
       "adapter": "codex",
       "command": "codex",
+      "model_options": [
+        {"id": "provider-default", "label": "Provider default", "source": "provider-default"},
+        {"id": "gpt-5.3-codex-spark", "label": "GPT-5.3-Codex-Spark", "source": "cli-discovery", "availability": "local-account"}
+      ],
+      "model_sources": ["provider-default", "cli-discovery"],
+      "reasoning_efforts": ["provider-default", "low", "medium", "high", "xhigh"],
+      "local_access_note": "Local Codex CLI catalog and ChatGPT account access.",
       "prompt_transports": ["argv", "file", "stdin"],
       "auth_modes": ["api-key", "codex-chatgpt-local"],
       "local_interactive_oauth_modes": ["codex-chatgpt-local"],
@@ -12255,6 +12420,15 @@ agent-slots:
     "claude": {
       "adapter": "claude",
       "command": "claude",
+      "model_options": [
+        {"id": "provider-default", "label": "Provider default", "source": "provider-default"},
+        {"id": "sonnet", "label": "Sonnet", "source": "official-doc"},
+        {"id": "opus", "label": "Opus", "source": "official-doc"},
+        {"id": "opusplan", "label": "Opus Plan", "source": "official-doc"}
+      ],
+      "model_sources": ["provider-default", "official-doc", "operator-override"],
+      "reasoning_efforts": ["provider-default", "low", "medium", "high", "xhigh", "max"],
+      "local_access_note": "Local Claude Code account and settings.",
       "prompt_transports": ["file"],
       "auth_modes": ["api-key", "claude-pro-max-oauth"],
       "local_interactive_oauth_modes": ["claude-pro-max-oauth"],
@@ -12279,12 +12453,12 @@ agent-slots:
     }
 
     It 'documents provider-switch in usage and writes a provider registry entry' {
-        $script:winsmuxCoreRawContent | Should -Match 'provider-switch <slot> \[--agent <name>\] \[--model <name>\] \[--prompt-transport <argv\|file\|stdin>\] \[--auth-mode <mode>\] \[--reason <text>\] \[--restart\] \[--clear\] \[--json\]'
+        $script:winsmuxCoreRawContent | Should -Match 'provider-switch <slot> \[--agent <name>\] \[--model <name>\] \[--model-source <source>\] \[--reasoning-effort <level>\] \[--prompt-transport <argv\|file\|stdin>\] \[--auth-mode <mode>\] \[--reason <text>\] \[--restart\] \[--clear\] \[--json\]'
         $script:winsmuxCoreRawContent | Should -Match "'provider-switch'\s*\{"
 
         Push-Location $script:providerSwitchTempRoot
         try {
-            $output = & pwsh -NoProfile -File $script:winsmuxCoreRawPath provider-switch worker-1 --agent claude --model opus --prompt-transport file --auth-mode claude-pro-max-oauth --reason 'operator requested provider switch' --json
+            $output = & pwsh -NoProfile -File $script:winsmuxCoreRawPath provider-switch worker-1 --agent claude --model opus --model-source operator-override --reasoning-effort xhigh --prompt-transport file --auth-mode claude-pro-max-oauth --reason 'operator requested provider switch' --json
         } finally {
             Pop-Location
         }
@@ -12293,12 +12467,15 @@ agent-slots:
         $result.slot_id | Should -Be 'worker-1'
         $result.agent | Should -Be 'claude'
         $result.model | Should -Be 'opus'
+        $result.model_source | Should -Be 'operator-override'
+        $result.reasoning_effort | Should -Be 'xhigh'
         $result.prompt_transport | Should -Be 'file'
         $result.auth_mode | Should -Be 'claude-pro-max-oauth'
         $result.auth_policy | Should -Be 'local_interactive_only'
         $result.source | Should -Be 'registry'
         $result.capability_adapter | Should -Be 'claude'
         $result.capability_command | Should -Be 'claude'
+        $result.local_access_note | Should -Be 'Local Claude Code account and settings.'
         $result.supports_file_edit | Should -Be $true
         $result.supports_subagents | Should -Be $false
         $result.supports_consultation | Should -Be $true
@@ -12311,8 +12488,46 @@ agent-slots:
         $registry = Get-Content -LiteralPath $registryPath -Raw -Encoding UTF8 | ConvertFrom-Json
         $registry.slots.'worker-1'.agent | Should -Be 'claude'
         $registry.slots.'worker-1'.model | Should -Be 'opus'
+        $registry.slots.'worker-1'.model_source | Should -Be 'operator-override'
+        $registry.slots.'worker-1'.reasoning_effort | Should -Be 'xhigh'
         $registry.slots.'worker-1'.prompt_transport | Should -Be 'file'
         $registry.slots.'worker-1'.reason | Should -Be 'operator requested provider switch'
+    }
+
+    It 'persists runtime role preferences for desktop settings' {
+        $script:winsmuxCoreRawContent | Should -Match 'runtime-roles apply --roles-json <json> \[--json\]'
+        $script:winsmuxCoreRawContent | Should -Match "'runtime-roles'\s*\{"
+
+        $rolesJson = @(
+            [ordered]@{
+                role_id          = 'worker'
+                provider         = 'codex'
+                model            = 'gpt-5.3-codex-spark'
+                model_source     = 'cli-discovery'
+                reasoning_effort = 'high'
+            },
+            [ordered]@{
+                role_id          = 'operator'
+                provider         = 'claude'
+                model            = 'provider-default'
+                model_source     = 'provider-default'
+                reasoning_effort = 'provider-default'
+            }
+        ) | ConvertTo-Json -Compress -Depth 8
+
+        Push-Location $script:providerSwitchTempRoot
+        try {
+            $output = & pwsh -NoProfile -File $script:winsmuxCoreRawPath runtime-roles apply --roles-json $rolesJson --json
+        } finally {
+            Pop-Location
+        }
+
+        $result = ($output | Select-Object -Last 1) | ConvertFrom-Json
+        $result.roles.worker.agent | Should -Be 'codex'
+        $result.roles.worker.model | Should -Be 'gpt-5.3-codex-spark'
+        $result.roles.worker.model_source | Should -Be 'cli-discovery'
+        $result.roles.worker.reasoning_effort | Should -Be 'high'
+        Test-Path -LiteralPath (Join-Path $script:providerSwitchTempRoot '.winsmux\runtime-role-preferences.json') | Should -Be $true
     }
 
     It 'rejects provider-switch blocked auth modes before writing the provider registry' {
@@ -12326,6 +12541,42 @@ agent-slots:
         [string]::Join("`n", @($output)) | Should -Match 'must not broker OAuth'
         $registryPath = Join-Path $script:providerSwitchTempRoot '.winsmux\provider-registry.json'
         Test-Path $registryPath | Should -BeFalse
+    }
+
+    It 'rejects provider-switch selectors outside provider capabilities before writing the provider registry' {
+        Push-Location $script:providerSwitchTempRoot
+        try {
+            $modelSourceOutput = & pwsh -NoProfile -File $script:winsmuxCoreRawPath provider-switch worker-1 --agent codex --model gpt-5.5 --model-source operator-override --json 2>&1
+            $reasoningOutput = & pwsh -NoProfile -File $script:winsmuxCoreRawPath provider-switch worker-1 --agent codex --reasoning-effort max --json 2>&1
+        } finally {
+            Pop-Location
+        }
+
+        [string]::Join("`n", @($modelSourceOutput)) | Should -Match "does not support model_source 'operator-override'"
+        [string]::Join("`n", @($reasoningOutput)) | Should -Match "does not support reasoning_effort 'max'"
+        $registryPath = Join-Path $script:providerSwitchTempRoot '.winsmux\provider-registry.json'
+        Test-Path $registryPath | Should -BeFalse
+    }
+
+    It 'allows provider-switch to repair stale provider selector overrides' {
+        $registryPath = Join-Path $script:providerSwitchTempRoot '.winsmux\provider-registry.json'
+@'
+{"version":1,"slots":{"worker-1":{"agent":"codex","model_source":"operator-override","reasoning_effort":"max","updated_at_utc":"2026-05-05T00:00:00Z"}}}
+'@ | Set-Content -Path $registryPath -Encoding UTF8
+
+        Push-Location $script:providerSwitchTempRoot
+        try {
+            $output = & pwsh -NoProfile -File $script:winsmuxCoreRawPath provider-switch worker-1 --reasoning-effort high --json
+        } finally {
+            Pop-Location
+        }
+
+        $result = ($output | Select-Object -Last 1) | ConvertFrom-Json
+        $result.reasoning_effort | Should -Be 'high'
+        $result.model_source | Should -Be 'cli-discovery'
+        $registry = Get-Content -LiteralPath $registryPath -Raw -Encoding UTF8 | ConvertFrom-Json
+        $registry.slots.'worker-1'.reasoning_effort | Should -Be 'high'
+        $registry.slots.'worker-1'.PSObject.Properties.Name | Should -Not -Contain 'model_source'
     }
 
     It 'clears provider-switch overrides and reports the configured slot provider' {
@@ -12894,7 +13145,7 @@ Describe 'orchestra pane bootstrap plan' {
 
     It 'builds pane launch commands through provider capability metadata' {
         $script:orchestraStartContent | Should -Match 'Get-BridgeProviderLaunchCommand'
-        $script:orchestraStartContent | Should -Match 'Get-AgentLaunchCommand -Agent \$slotAgentConfig\.Agent -Model \$slotAgentConfig\.Model -ProjectDir \$launchDir -GitWorktreeDir \$launchGitWorktreeDir -RootPath \$projectDir'
+        $script:orchestraStartContent | Should -Match 'Get-AgentLaunchCommand -Agent \$slotAgentConfig\.Agent -Model \$slotAgentConfig\.Model -ModelSource \$slotAgentConfig\.ModelSource -ReasoningEffort \$slotAgentConfig\.ReasoningEffort -ProjectDir \$launchDir -GitWorktreeDir \$launchGitWorktreeDir -RootPath \$projectDir'
     }
 
     It 'prints a concise startup summary before invoking the agent launch command' {

--- a/winsmux-app/index.html
+++ b/winsmux-app/index.html
@@ -352,6 +352,7 @@
           <div class="settings-section">
             <div class="context-label" id="settings-profile-label">Runtime</div>
             <div class="context-value" id="settings-profile-value">Uses the local Claude Code configuration.</div>
+            <div id="runtime-role-options" class="runtime-role-grid" aria-label="Runtime role controls"></div>
           </div>
           <div class="settings-section">
             <div class="context-label" id="settings-language-label">Language</div>

--- a/winsmux-app/src-tauri/src/desktop_backend.rs
+++ b/winsmux-app/src-tauri/src/desktop_backend.rs
@@ -621,6 +621,10 @@ pub enum DesktopCommand {
         next_test: String,
         project_dir: Option<String>,
     },
+    RuntimeRolesApply {
+        roles_json: String,
+        project_dir: Option<String>,
+    },
 }
 
 pub enum DesktopStreamCommand {
@@ -635,6 +639,7 @@ impl DesktopCommand {
             DesktopCommand::RunCompare { project_dir, .. } => project_dir.as_deref(),
             DesktopCommand::RunPromote { project_dir, .. } => project_dir.as_deref(),
             DesktopCommand::RunPickWinner { project_dir, .. } => project_dir.as_deref(),
+            DesktopCommand::RuntimeRolesApply { project_dir, .. } => project_dir.as_deref(),
         }
     }
 
@@ -692,6 +697,13 @@ impl DesktopCommand {
                 }
                 args
             }
+            DesktopCommand::RuntimeRolesApply { roles_json, .. } => vec![
+                "runtime-roles".to_string(),
+                "apply".to_string(),
+                "--roles-json".to_string(),
+                roles_json.clone(),
+                "--json".to_string(),
+            ],
         }
     }
 }
@@ -965,6 +977,17 @@ pub fn load_desktop_run_pick_winner(
         .map_err(|err| format!("Failed to parse desktop pick-winner payload: {err}"))
 }
 
+pub fn apply_desktop_runtime_roles(
+    transport: &dyn DesktopCommandTransport,
+    roles_json: String,
+    project_dir: Option<String>,
+) -> Result<Value, String> {
+    transport.request_json(&DesktopCommand::RuntimeRolesApply {
+        roles_json,
+        project_dir,
+    })
+}
+
 pub fn load_desktop_editor_file(
     path: String,
     worktree: Option<String>,
@@ -1042,6 +1065,7 @@ pub fn handle_desktop_json_rpc(
                     "desktop.run.compare",
                     "desktop.run.promote",
                     "desktop.run.pick_winner",
+                    "desktop.runtime.roles.apply",
                     "desktop.explorer.list",
                     "desktop.editor.read",
                 ],
@@ -1167,6 +1191,36 @@ pub fn handle_desktop_json_rpc(
                         format!("Failed to serialize desktop pick-winner payload: {err}"),
                     ),
                 },
+                Err(err) => json_rpc_error(request_id, JSON_RPC_SERVER_ERROR, err),
+            }
+        }
+        "desktop.runtime.roles.apply" => {
+            let roles = match params
+                .as_ref()
+                .and_then(|value| value.as_object())
+                .and_then(|object| object.get("roles"))
+            {
+                Some(value) => value.clone(),
+                None => {
+                    return json_rpc_error(
+                        request_id,
+                        JSON_RPC_INVALID_PARAMS,
+                        "Missing required params field: roles",
+                    );
+                }
+            };
+            let roles_json = match serde_json::to_string(&roles) {
+                Ok(value) => value,
+                Err(err) => {
+                    return json_rpc_error(
+                        request_id,
+                        JSON_RPC_INVALID_PARAMS,
+                        format!("Failed to serialize runtime role preferences: {err}"),
+                    );
+                }
+            };
+            match apply_desktop_runtime_roles(transport, roles_json, resolved_project_dir) {
+                Ok(result) => json_rpc_result(request_id, result),
                 Err(err) => json_rpc_error(request_id, JSON_RPC_SERVER_ERROR, err),
             }
         }
@@ -1599,7 +1653,8 @@ fn collect_desktop_ignored_paths(root: &Path, relative_paths: &[String]) -> Hash
 
     if let Some(mut stdin) = child.stdin.take() {
         for relative_path in relative_paths {
-            if stdin.write_all(relative_path.as_bytes()).is_err() || stdin.write_all(&[0]).is_err() {
+            if stdin.write_all(relative_path.as_bytes()).is_err() || stdin.write_all(&[0]).is_err()
+            {
                 return HashSet::new();
             }
         }
@@ -1688,7 +1743,8 @@ fn collect_desktop_explorer_entries(
         if entries.len() >= DESKTOP_EXPLORER_MAX_ENTRIES {
             break;
         }
-        let ignored = ignored_paths.contains(&relative) || ignored_paths.contains(&format!("{relative}/"));
+        let ignored =
+            ignored_paths.contains(&relative) || ignored_paths.contains(&format!("{relative}/"));
         if is_dir {
             entries.push(DesktopExplorerEntry {
                 path: relative.clone(),
@@ -4394,6 +4450,91 @@ mod tests {
             transport.requests.borrow().as_slice(),
             ["desktop-summary --json"]
         );
+    }
+
+    #[test]
+    fn handle_desktop_json_rpc_contract_advertises_runtime_roles_apply() {
+        let transport = FakeTransport {
+            requests: RefCell::new(Vec::new()),
+            response: serde_json::json!({}),
+        };
+        let response = handle_desktop_json_rpc(
+            &transport,
+            DesktopJsonRpcRequest {
+                jsonrpc: "2.0".to_string(),
+                id: serde_json::json!("req-contract"),
+                method: "desktop.control_plane.contract".to_string(),
+                params: None,
+            },
+            None,
+        );
+
+        match response {
+            DesktopJsonRpcResponse::Success { result, .. } => {
+                let methods = result["methods"]
+                    .as_array()
+                    .expect("contract methods must be an array");
+                assert!(methods
+                    .iter()
+                    .any(|method| { method.as_str() == Some("desktop.runtime.roles.apply") }));
+            }
+            DesktopJsonRpcResponse::Error { error, .. } => {
+                panic!("expected success, got {:?}", error);
+            }
+        }
+    }
+
+    #[test]
+    fn handle_desktop_json_rpc_routes_runtime_roles_apply() {
+        let transport = FakeTransport {
+            requests: RefCell::new(Vec::new()),
+            response: serde_json::json!({
+                "version": 1,
+                "roles": {
+                    "worker": {
+                        "agent": "codex",
+                        "model": "gpt-5.3-codex-spark",
+                        "model_source": "cli-discovery",
+                        "reasoning_effort": "high"
+                    }
+                }
+            }),
+        };
+        let response = handle_desktop_json_rpc(
+            &transport,
+            DesktopJsonRpcRequest {
+                jsonrpc: "2.0".to_string(),
+                id: serde_json::json!("req-runtime"),
+                method: "desktop.runtime.roles.apply".to_string(),
+                params: Some(serde_json::json!({
+                    "roles": [
+                        {
+                            "role_id": "worker",
+                            "provider": "codex",
+                            "model": "gpt-5.3-codex-spark",
+                            "model_source": "cli-discovery",
+                            "reasoning_effort": "high"
+                        }
+                    ]
+                })),
+            },
+            None,
+        );
+
+        match response {
+            DesktopJsonRpcResponse::Success { id, result, .. } => {
+                assert_eq!(id, serde_json::json!("req-runtime"));
+                assert_eq!(result["roles"]["worker"]["agent"], "codex");
+            }
+            DesktopJsonRpcResponse::Error { error, .. } => {
+                panic!("expected success, got {:?}", error);
+            }
+        }
+        let requests = transport.requests.borrow();
+        assert_eq!(requests.len(), 1);
+        assert!(requests[0].starts_with("runtime-roles apply --roles-json "));
+        assert!(requests[0].contains("\"role_id\":\"worker\""));
+        assert!(requests[0].ends_with(" --json"));
     }
 
     #[test]

--- a/winsmux-app/src/desktopClient.ts
+++ b/winsmux-app/src/desktopClient.ts
@@ -7,6 +7,7 @@ type DesktopCommandName =
   | "desktop_run_compare"
   | "desktop_run_promote"
   | "desktop_run_pick_winner"
+  | "desktop_runtime_roles_apply"
   | "desktop_editor_read"
   | "desktop_explorer_list";
 type DesktopJsonRpcMethod =
@@ -15,6 +16,7 @@ type DesktopJsonRpcMethod =
   | "desktop.run.compare"
   | "desktop.run.promote"
   | "desktop.run.pick_winner"
+  | "desktop.runtime.roles.apply"
   | "desktop.editor.read"
   | "desktop.explorer.list";
 
@@ -502,6 +504,8 @@ function getDesktopJsonRpcMethod(command: DesktopCommandName): DesktopJsonRpcMet
       return "desktop.run.promote";
     case "desktop_run_pick_winner":
       return "desktop.run.pick_winner";
+    case "desktop_runtime_roles_apply":
+      return "desktop.runtime.roles.apply";
     case "desktop_editor_read":
       return "desktop.editor.read";
     case "desktop_explorer_list":
@@ -645,6 +649,28 @@ export async function pickDesktopRunWinner(
     );
   } catch (error) {
     throw normalizeDesktopError(`desktop_run_pick_winner(${runId})`, error);
+  }
+}
+
+export interface DesktopRuntimeRolePreference {
+  role_id: string;
+  provider: string;
+  model: string;
+  model_source: string;
+  reasoning_effort: string;
+}
+
+export async function applyDesktopRuntimeRolePreferences(
+  roles: DesktopRuntimeRolePreference[],
+  projectDir?: string | null,
+) {
+  try {
+    return await desktopCommandTransport.request<Record<string, unknown>>(
+      "desktop_runtime_roles_apply",
+      { roles, ...buildProjectDirPayload(projectDir) },
+    );
+  } catch (error) {
+    throw normalizeDesktopError("desktop_runtime_roles_apply", error);
   }
 }
 

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -4,6 +4,7 @@ import "xterm/css/xterm.css";
 import { isTauri } from "@tauri-apps/api/core";
 import { WebviewWindow, getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
 import {
+  applyDesktopRuntimeRolePreferences,
   compareDesktopRuns,
   getDesktopEditorFile,
   getDesktopRunExplain,
@@ -19,6 +20,7 @@ import {
   type DesktopExplainPayload,
   type DesktopRunProjection,
   type DesktopSummarySnapshot,
+  type DesktopRuntimeRolePreference,
 } from "./desktopClient";
 import { getEditorFileKey, getSourceChangeKey, pickEditorPathCandidate } from "./editorTargets";
 import {
@@ -281,6 +283,10 @@ type CodeFontMode = "system" | "google-sans-code" | "jetbrains-mono";
 type FocusMode = "standard" | "focused";
 type LanguageMode = "en" | "ja";
 type WorkbenchLayoutMode = "2x2" | "3x2" | "focus";
+type RuntimeRoleId = "operator" | "worker" | "reviewer";
+type RuntimeProviderId = "provider-default" | "codex" | "claude" | "gemini";
+type RuntimeModelSource = "provider-default" | "cli-discovery" | "official-doc" | "operator-override";
+type RuntimeReasoningEffort = "provider-default" | "low" | "medium" | "high" | "xhigh" | "max";
 
 interface ThemeState {
   theme: ThemeMode;
@@ -298,6 +304,14 @@ interface ShellPreferenceState extends ThemeState {
   wideContextOpen: boolean;
   workbenchOpen: boolean;
   workbenchLayout: WorkbenchLayoutMode;
+}
+
+interface RuntimeRolePreference {
+  roleId: RuntimeRoleId;
+  provider: RuntimeProviderId;
+  model: string;
+  modelSource: RuntimeModelSource;
+  reasoningEffort: RuntimeReasoningEffort;
 }
 
 interface ComposerAttachment {
@@ -499,9 +513,12 @@ const themeState: ThemeState = {
   language: "en",
 };
 let settingsDraftState: ThemeState | null = null;
+let runtimeRolePreferences: RuntimeRolePreference[] = [];
+let runtimeRoleDraftState: RuntimeRolePreference[] | null = null;
 let preferredWideSidebarOpen = true;
 let preferredWideContextOpen = false;
 const SHELL_PREFERENCES_STORAGE_KEY = "winsmux.shell.preferences.v1";
+const RUNTIME_ROLE_PREFERENCES_STORAGE_KEY = "winsmux.runtime-role.preferences.v1";
 const POPOUT_SURFACE_STORAGE_KEY_PREFIX = "winsmux.popout-surface.";
 const PROJECT_SESSIONS_STORAGE_KEY = "winsmux.project-sessions.v1";
 const ACTIVE_PROJECT_STORAGE_KEY = "winsmux.active-project.v1";
@@ -775,6 +792,47 @@ const languageOptions: Array<{ value: LanguageMode; label: string; description: 
   { value: "en", label: "English", labelJa: "English", description: "Use English for the workspace chrome and controls.", descriptionJa: "作業領域と操作部品を英語で表示します。" },
   { value: "ja", label: "Japanese", labelJa: "日本語", description: "Use Japanese for the main workspace chrome and settings.", descriptionJa: "主要な操作部品と設定を日本語で表示します。" },
 ];
+
+const runtimeRoleOptions: Array<{ value: RuntimeRoleId; label: string; labelJa: string; description: string; descriptionJa: string }> = [
+  { value: "operator", label: "Operator", labelJa: "オペレーター", description: "Owns approvals and session control.", descriptionJa: "承認とセッション制御を担当します。" },
+  { value: "worker", label: "Worker", labelJa: "ワーカー", description: "Handles implementation and verification work.", descriptionJa: "実装と検証を担当します。" },
+  { value: "reviewer", label: "Reviewer", labelJa: "レビュアー", description: "Checks diffs, risks, and tests.", descriptionJa: "差分、リスク、テストを確認します。" },
+];
+
+const runtimeProviderOptions: Array<{ value: RuntimeProviderId; label: string; labelJa: string }> = [
+  { value: "provider-default", label: "Provider default", labelJa: "既定値" },
+  { value: "codex", label: "Codex CLI", labelJa: "Codex CLI" },
+  { value: "claude", label: "Claude Code", labelJa: "Claude Code" },
+  { value: "gemini", label: "Gemini CLI", labelJa: "Gemini CLI" },
+];
+
+const runtimeModelSourceOptions: Array<{ value: RuntimeModelSource; label: string; labelJa: string }> = [
+  { value: "provider-default", label: "Provider default", labelJa: "既定値" },
+  { value: "cli-discovery", label: "Local CLI catalog", labelJa: "ローカル CLI" },
+  { value: "official-doc", label: "Official docs", labelJa: "公式ドキュメント" },
+  { value: "operator-override", label: "Operator override", labelJa: "明示指定" },
+];
+
+const runtimeReasoningOptions: Array<{ value: RuntimeReasoningEffort; label: string; labelJa: string }> = [
+  { value: "provider-default", label: "Auto", labelJa: "自動" },
+  { value: "low", label: "Low", labelJa: "低" },
+  { value: "medium", label: "Medium", labelJa: "中" },
+  { value: "high", label: "High", labelJa: "高" },
+  { value: "xhigh", label: "X High", labelJa: "特高" },
+  { value: "max", label: "Max", labelJa: "最大" },
+];
+
+const runtimeModelSuggestions = [
+  "provider-default",
+  "gpt-5.3-codex-spark",
+  "gpt-5.5",
+  "default",
+  "sonnet",
+  "opus",
+  "opusplan",
+];
+
+runtimeRolePreferences = readStoredRuntimeRolePreferences();
 
 const fallbackExplorerPaths = [
   ".agents/README.md",
@@ -4804,9 +4862,11 @@ function getFooterItems(): { left: FooterStatusItem[]; right: FooterStatusItem[]
   const reviewStatus = selectedProjection?.review_state || "No review";
   const nextStatus = selectedProjection?.next_action || "idle";
   const operatorStatus = getFooterOperatorStatus(selectedProjection ?? undefined);
-  const settingsStatus = settingsDraftState
-    ? (themeStatesEqual(settingsDraftState, themeState) ? (settingsSheetOpen ? "Editing" : "Ready") : "Draft")
-    : "Saved";
+  const hasThemeDraft = Boolean(settingsDraftState && !themeStatesEqual(settingsDraftState, themeState));
+  const hasRuntimeDraft = Boolean(runtimeRoleDraftState && !runtimeRolePreferencesEqual(runtimeRoleDraftState, runtimeRolePreferences));
+  const settingsStatus = hasThemeDraft || hasRuntimeDraft
+    ? "Draft"
+    : (settingsSheetOpen ? "Editing" : "Saved");
   const surfaceStatus = getFooterSurfaceStatus();
   const contextItem = getFooterContextItem(settingsStatus);
 
@@ -4845,6 +4905,117 @@ function themeStatesEqual(left: ThemeState, right: ThemeState) {
     && left.codeFont === right.codeFont
     && left.focusMode === right.focusMode
     && left.language === right.language;
+}
+
+function defaultRuntimeRolePreferences(): RuntimeRolePreference[] {
+  return [
+    {
+      roleId: "operator",
+      provider: "claude",
+      model: "provider-default",
+      modelSource: "provider-default",
+      reasoningEffort: "provider-default",
+    },
+    {
+      roleId: "worker",
+      provider: "codex",
+      model: "provider-default",
+      modelSource: "provider-default",
+      reasoningEffort: "provider-default",
+    },
+    {
+      roleId: "reviewer",
+      provider: "codex",
+      model: "gpt-5.3-codex-spark",
+      modelSource: "cli-discovery",
+      reasoningEffort: "high",
+    },
+  ];
+}
+
+function cloneRuntimeRolePreferences(state: RuntimeRolePreference[]) {
+  return state.map((item) => ({ ...item }));
+}
+
+function normalizeRuntimeRolePreference(value: Partial<RuntimeRolePreference>, fallback: RuntimeRolePreference): RuntimeRolePreference {
+  const provider = runtimeProviderOptions.find((item) => item.value === value.provider)?.value ?? fallback.provider;
+  const modelSource = runtimeModelSourceOptions.find((item) => item.value === value.modelSource)?.value ?? fallback.modelSource;
+  const reasoningEffort = runtimeReasoningOptions.find((item) => item.value === value.reasoningEffort)?.value ?? fallback.reasoningEffort;
+  const model = typeof value.model === "string" && value.model.trim() ? value.model.trim() : fallback.model;
+  return {
+    roleId: fallback.roleId,
+    provider,
+    model,
+    modelSource,
+    reasoningEffort,
+  };
+}
+
+function readStoredRuntimeRolePreferences(): RuntimeRolePreference[] {
+  const defaults = defaultRuntimeRolePreferences();
+  try {
+    const rawValue = window.localStorage.getItem(RUNTIME_ROLE_PREFERENCES_STORAGE_KEY);
+    if (!rawValue) {
+      return defaults;
+    }
+
+    const parsed = JSON.parse(rawValue) as Partial<RuntimeRolePreference>[] | { roles?: Partial<RuntimeRolePreference>[] };
+    const entries = Array.isArray(parsed) ? parsed : (Array.isArray(parsed.roles) ? parsed.roles : []);
+    return defaults.map((fallback) => {
+      const stored = entries.find((item) => item.roleId === fallback.roleId) ?? {};
+      return normalizeRuntimeRolePreference(stored, fallback);
+    });
+  } catch {
+    return defaults;
+  }
+}
+
+function persistRuntimeRolePreferences() {
+  try {
+    window.localStorage.setItem(RUNTIME_ROLE_PREFERENCES_STORAGE_KEY, JSON.stringify(runtimeRolePreferences));
+    return true;
+  } catch (error) {
+    console.warn("Failed to persist runtime role preferences", error);
+    return false;
+  }
+}
+
+function runtimeRolePreferencesEqual(left: RuntimeRolePreference[], right: RuntimeRolePreference[]) {
+  if (left.length !== right.length) {
+    return false;
+  }
+
+  return left.every((item, index) => {
+    const other = right[index];
+    return Boolean(other)
+      && item.roleId === other.roleId
+      && item.provider === other.provider
+      && item.model === other.model
+      && item.modelSource === other.modelSource
+      && item.reasoningEffort === other.reasoningEffort;
+  });
+}
+
+function toDesktopRuntimeRolePreferences(state: RuntimeRolePreference[]): DesktopRuntimeRolePreference[] {
+  return state.map((item) => ({
+    role_id: item.roleId,
+    provider: item.provider,
+    model: item.model,
+    model_source: item.modelSource,
+    reasoning_effort: item.reasoningEffort,
+  }));
+}
+
+async function applyRuntimeRolePreferencesToDesktop(state: RuntimeRolePreference[]) {
+  if (!isTauri()) {
+    console.warn("Runtime role preferences were saved locally; desktop runtime apply is unavailable outside Tauri.");
+    return;
+  }
+
+  await applyDesktopRuntimeRolePreferences(
+    toDesktopRuntimeRolePreferences(state),
+    activeProjectDir,
+  );
 }
 
 function readStoredShellPreferences(): ShellPreferenceState | null {
@@ -5074,7 +5245,12 @@ function applyLanguageChrome() {
   setElementText("close-settings-btn", japanese ? "キャンセル" : "Cancel");
   setElementText("apply-settings-btn", japanese ? "適用" : "Apply");
   setElementText("settings-profile-label", japanese ? "実行環境" : "Runtime");
-  setElementText("settings-profile-value", japanese ? "ローカルの Claude Code 設定を使用します。" : "Uses the local Claude Code configuration.");
+  setElementText(
+    "settings-profile-value",
+    japanese
+      ? "ロールごとにローカル CLI、モデル入手元、思考量を選べます。既定値ではモデル指定を渡しません。"
+      : "Choose local CLI, model source, and effort per role. Provider default passes no model override.",
+  );
   setElementText("settings-language-label", japanese ? "言語" : "Language");
   setElementText("settings-language-value", japanese ? "作業領域の表示言語を日本語と英語で切り替えます。" : "Switch the workspace chrome between English and Japanese.");
   setElementText("settings-theme-label", japanese ? "テーマ" : "Theme");
@@ -5221,6 +5397,170 @@ function renderPreferenceOptions<T extends string>(
   }
 }
 
+function getRuntimeRoleDraft() {
+  if (!runtimeRoleDraftState) {
+    runtimeRoleDraftState = cloneRuntimeRolePreferences(runtimeRolePreferences);
+  }
+  return runtimeRoleDraftState;
+}
+
+function updateRuntimeRoleDraft(roleId: RuntimeRoleId, patch: Partial<RuntimeRolePreference>) {
+  const draft = getRuntimeRoleDraft();
+  const index = draft.findIndex((item) => item.roleId === roleId);
+  if (index === -1) {
+    return;
+  }
+  draft[index] = { ...draft[index], ...patch };
+  renderSettingsControls();
+}
+
+function runtimeAccessNote(preference: RuntimeRolePreference, japanese: boolean) {
+  if (preference.provider === "codex") {
+    return japanese
+      ? "ローカルの Codex CLI のモデル一覧と ChatGPT アカウント権限を使います。API の一覧だけでは判断しません。"
+      : "Uses the local Codex CLI catalog and ChatGPT account access, not API-only availability.";
+  }
+  if (preference.provider === "claude") {
+    return japanese
+      ? "ローカルの Claude Code 設定を使います。`default`、`sonnet`、`opus`、`opusplan` を指定できます。"
+      : "Uses local Claude Code settings. Aliases such as default, sonnet, opus, and opusplan are accepted.";
+  }
+  if (preference.provider === "gemini") {
+    return japanese
+      ? "ローカルの Gemini CLI 設定を使います。計画時は `--approval-mode plan` を使えます。"
+      : "Uses local Gemini CLI settings. Plan runs can use --approval-mode plan.";
+  }
+  return japanese
+    ? "winsmux はモデル指定を渡さず、プロバイダー側の既定値を使います。"
+    : "winsmux passes no model override and lets the provider choose its default.";
+}
+
+function createRuntimeSelect<T extends string>(
+  id: string,
+  label: string,
+  value: T,
+  options: Array<{ value: T; label: string; labelJa: string }>,
+  japanese: boolean,
+  onChange: (value: T) => void,
+) {
+  const group = document.createElement("label");
+  group.className = "runtime-control-group";
+  group.setAttribute("for", id);
+
+  const caption = document.createElement("span");
+  caption.className = "runtime-control-caption";
+  caption.textContent = label;
+  group.appendChild(caption);
+
+  const select = document.createElement("select");
+  select.id = id;
+  select.className = "runtime-control-select";
+  for (const option of options) {
+    const element = document.createElement("option");
+    element.value = option.value;
+    element.textContent = japanese ? option.labelJa : option.label;
+    element.selected = option.value === value;
+    select.appendChild(element);
+  }
+  select.addEventListener("change", () => onChange(select.value as T));
+  group.appendChild(select);
+  return group;
+}
+
+function renderRuntimeRoleControls() {
+  const root = document.getElementById("runtime-role-options");
+  if (!root) {
+    return;
+  }
+
+  const activeRuntimeState = runtimeRoleDraftState ?? runtimeRolePreferences;
+  const japanese = (settingsDraftState?.language ?? themeState.language) === "ja";
+  root.innerHTML = "";
+
+  const datalist = document.createElement("datalist");
+  datalist.id = "runtime-model-suggestions";
+  for (const model of runtimeModelSuggestions) {
+    const option = document.createElement("option");
+    option.value = model;
+    datalist.appendChild(option);
+  }
+  root.appendChild(datalist);
+
+  for (const role of runtimeRoleOptions) {
+    const preference = activeRuntimeState.find((item) => item.roleId === role.value)
+      ?? defaultRuntimeRolePreferences().find((item) => item.roleId === role.value)!;
+    const panel = document.createElement("section");
+    panel.className = "runtime-role-panel";
+
+    const header = document.createElement("div");
+    header.className = "runtime-role-header";
+    const title = document.createElement("div");
+    title.className = "runtime-role-title";
+    title.textContent = japanese ? role.labelJa : role.label;
+    const description = document.createElement("div");
+    description.className = "runtime-role-description";
+    description.textContent = japanese ? role.descriptionJa : role.description;
+    header.append(title, description);
+    panel.appendChild(header);
+
+    const controls = document.createElement("div");
+    controls.className = "runtime-role-controls";
+    controls.appendChild(createRuntimeSelect(
+      `runtime-provider-${role.value}`,
+      japanese ? "プロバイダー" : "Provider",
+      preference.provider,
+      runtimeProviderOptions,
+      japanese,
+      (provider) => updateRuntimeRoleDraft(role.value, { provider }),
+    ));
+
+    const modelGroup = document.createElement("label");
+    modelGroup.className = "runtime-control-group runtime-control-group-wide";
+    modelGroup.setAttribute("for", `runtime-model-${role.value}`);
+    const modelCaption = document.createElement("span");
+    modelCaption.className = "runtime-control-caption";
+    modelCaption.textContent = japanese ? "モデル" : "Model";
+    const modelInput = document.createElement("input");
+    modelInput.id = `runtime-model-${role.value}`;
+    modelInput.className = "runtime-control-input";
+    modelInput.value = preference.model;
+    modelInput.setAttribute("list", "runtime-model-suggestions");
+    modelInput.placeholder = "provider-default";
+    modelInput.addEventListener("change", () => {
+      const value = modelInput.value.trim() || "provider-default";
+      const nextSource = value === "provider-default" ? "provider-default" : preference.modelSource;
+      updateRuntimeRoleDraft(role.value, { model: value, modelSource: nextSource });
+    });
+    modelGroup.append(modelCaption, modelInput);
+    controls.appendChild(modelGroup);
+
+    controls.appendChild(createRuntimeSelect(
+      `runtime-model-source-${role.value}`,
+      japanese ? "入手元" : "Source",
+      preference.modelSource,
+      runtimeModelSourceOptions,
+      japanese,
+      (modelSource) => updateRuntimeRoleDraft(role.value, { modelSource }),
+    ));
+    controls.appendChild(createRuntimeSelect(
+      `runtime-reasoning-${role.value}`,
+      japanese ? "思考量" : "Effort",
+      preference.reasoningEffort,
+      runtimeReasoningOptions,
+      japanese,
+      (reasoningEffort) => updateRuntimeRoleDraft(role.value, { reasoningEffort }),
+    ));
+    panel.appendChild(controls);
+
+    const note = document.createElement("div");
+    note.className = "runtime-access-note";
+    note.textContent = runtimeAccessNote(preference, japanese);
+    panel.appendChild(note);
+
+    root.appendChild(panel);
+  }
+}
+
 function renderSettingsControls() {
   const activeState = settingsDraftState ?? themeState;
   const applyButton = document.getElementById("apply-settings-btn") as HTMLButtonElement | null;
@@ -5273,8 +5613,12 @@ function renderSettingsControls() {
     renderSettingsControls();
   });
 
+  renderRuntimeRoleControls();
+
   if (applyButton) {
-    const hasChanges = Boolean(settingsDraftState && !themeStatesEqual(settingsDraftState, themeState));
+    const hasThemeChanges = Boolean(settingsDraftState && !themeStatesEqual(settingsDraftState, themeState));
+    const hasRuntimeChanges = Boolean(runtimeRoleDraftState && !runtimeRolePreferencesEqual(runtimeRoleDraftState, runtimeRolePreferences));
+    const hasChanges = hasThemeChanges || hasRuntimeChanges;
     applyButton.disabled = !hasChanges;
     applyButton.setAttribute("aria-disabled", hasChanges ? "false" : "true");
   }
@@ -8462,23 +8806,48 @@ function setSettingsSheet(open: boolean) {
     if (!settingsDraftState) {
       settingsDraftState = cloneThemeState(themeState);
     }
+    if (!runtimeRoleDraftState) {
+      runtimeRoleDraftState = cloneRuntimeRolePreferences(runtimeRolePreferences);
+    }
     renderSettingsControls();
   }
   sheet.hidden = !open;
   renderFooterLane();
 }
 
-function applySettingsDraft() {
+async function applySettingsDraft() {
   if (settingsDraftState) {
     applyThemeState(settingsDraftState);
     persistThemeState();
   }
+  if (runtimeRoleDraftState) {
+    runtimeRolePreferences = cloneRuntimeRolePreferences(runtimeRoleDraftState);
+    persistRuntimeRolePreferences();
+    try {
+      await applyRuntimeRolePreferencesToDesktop(runtimeRolePreferences);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      appendRuntimeConversation({
+        type: "system",
+        category: "attention",
+        timestamp: new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" }),
+        actor: "winsmux",
+        title: getLanguageText("Runtime settings were saved locally", "実行環境設定はローカルに保存しました"),
+        body: message,
+        tone: "warning",
+      });
+      console.warn("Failed to apply runtime role preferences to desktop runtime", error);
+    }
+  }
   settingsDraftState = null;
+  runtimeRoleDraftState = null;
   setSettingsSheet(false);
+  renderConversation(getConversationItems());
 }
 
 function cancelSettingsDraft() {
   settingsDraftState = null;
+  runtimeRoleDraftState = null;
   setSettingsSheet(false);
 }
 
@@ -9670,7 +10039,7 @@ window.addEventListener("DOMContentLoaded", async () => {
   });
 
   document.getElementById("apply-settings-btn")?.addEventListener("click", () => {
-    applySettingsDraft();
+    void applySettingsDraft();
   });
 
   document.getElementById("close-settings-btn")?.addEventListener("click", () => {

--- a/winsmux-app/src/styles.css
+++ b/winsmux-app/src/styles.css
@@ -3043,6 +3043,80 @@ body.is-resizing-workbench {
   line-height: var(--leading-normal);
 }
 
+.runtime-role-grid {
+  display: grid;
+  gap: 8px;
+  margin-top: 4px;
+}
+
+.runtime-role-panel {
+  display: grid;
+  gap: 8px;
+  padding: 10px;
+  border: 1px solid var(--border-muted);
+  border-radius: 8px;
+  background: var(--bg-surface);
+}
+
+.runtime-role-header {
+  display: grid;
+  gap: 2px;
+}
+
+.runtime-role-title {
+  color: var(--text-primary);
+  font-size: var(--text-sm);
+  font-weight: 700;
+}
+
+.runtime-role-description,
+.runtime-access-note {
+  color: var(--text-muted);
+  font-size: var(--text-2xs);
+  line-height: var(--leading-normal);
+}
+
+.runtime-role-controls {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.runtime-control-group {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+
+.runtime-control-group-wide {
+  grid-column: 1 / -1;
+}
+
+.runtime-control-caption {
+  color: var(--text-muted);
+  font-size: var(--text-2xs);
+}
+
+.runtime-control-select,
+.runtime-control-input {
+  min-width: 0;
+  width: 100%;
+  height: 30px;
+  border: 1px solid var(--border-muted);
+  border-radius: 6px;
+  background: #16191f;
+  color: var(--text-primary);
+  padding: 0 8px;
+  font: inherit;
+  font-size: var(--text-xs);
+}
+
+.runtime-control-select:focus,
+.runtime-control-input:focus {
+  outline: 1px solid var(--status-focus-border);
+  border-color: var(--status-focus-border);
+}
+
 #terminal-toolbar {
   display: flex;
   align-items: center;

--- a/winsmux-core/scripts/agent-launch.ps1
+++ b/winsmux-core/scripts/agent-launch.ps1
@@ -7,6 +7,8 @@ function Get-AgentLaunchCommand {
     param(
         [Parameter(Mandatory = $true)][string]$Agent,
         [Parameter(Mandatory = $true)][AllowEmptyString()][string]$Model,
+        [AllowEmptyString()][string]$ModelSource = '',
+        [AllowEmptyString()][string]$ReasoningEffort = '',
         [Parameter(Mandatory = $true)][string]$ProjectDir,
         [Parameter(Mandatory = $true)][string]$GitWorktreeDir,
         [string]$RootPath,
@@ -16,6 +18,8 @@ function Get-AgentLaunchCommand {
     return Get-BridgeProviderLaunchCommand `
         -ProviderId $Agent `
         -Model $Model `
+        -ModelSource $ModelSource `
+        -ReasoningEffort $ReasoningEffort `
         -ProjectDir $ProjectDir `
         -GitWorktreeDir $GitWorktreeDir `
         -RootPath $RootPath `

--- a/winsmux-core/scripts/agent-monitor.ps1
+++ b/winsmux-core/scripts/agent-monitor.ps1
@@ -915,6 +915,8 @@ function Invoke-AgentRespawn {
         [Parameter(Mandatory = $true)][string]$PaneId,
         [Parameter(Mandatory = $true)][string]$Agent,
         [Parameter(Mandatory = $true)][AllowEmptyString()][string]$Model,
+        [AllowEmptyString()][string]$ModelSource = '',
+        [AllowEmptyString()][string]$ReasoningEffort = '',
         [Parameter(Mandatory = $true)][string]$ProjectDir,
         [Parameter(Mandatory = $true)][string]$GitWorktreeDir,
         [string]$RootPath = '',
@@ -948,6 +950,8 @@ function Invoke-AgentRespawn {
         $launchCommand = Get-BridgeProviderLaunchCommand `
             -ProviderId $Agent `
             -Model $Model `
+            -ModelSource $ModelSource `
+            -ReasoningEffort $ReasoningEffort `
             -ProjectDir $ProjectDir `
             -GitWorktreeDir $GitWorktreeDir `
             -RootPath $capabilityRootPath
@@ -1209,7 +1213,7 @@ function Invoke-AgentMonitorCycle {
             $roleAgentConfig = Get-SlotAgentConfig -Role $role -SlotId $label -Settings $Settings -RootPath $projectDir
         } else {
             try {
-                $roleAgentConfig = Get-RoleAgentConfig -Role $role -Settings $Settings
+                $roleAgentConfig = Get-RoleAgentConfig -Role $role -Settings $Settings -RootPath $projectDir
             } catch {
                 # Fallback to default settings when only the legacy role helper is unavailable or malformed.
                 $roleAgentConfig = [ordered]@{

--- a/winsmux-core/scripts/orchestra-start.ps1
+++ b/winsmux-core/scripts/orchestra-start.ps1
@@ -786,6 +786,8 @@ function Get-AgentLaunchCommand {
     param(
         [Parameter(Mandatory = $true)][string]$Agent,
         [Parameter(Mandatory = $true)][AllowEmptyString()][string]$Model,
+        [AllowEmptyString()][string]$ModelSource = '',
+        [AllowEmptyString()][string]$ReasoningEffort = '',
         [Parameter(Mandatory = $true)][string]$ProjectDir,
         [Parameter(Mandatory = $true)][string]$GitWorktreeDir,
         [string]$RootPath,
@@ -795,6 +797,8 @@ function Get-AgentLaunchCommand {
     return Get-BridgeProviderLaunchCommand `
         -ProviderId $Agent `
         -Model $Model `
+        -ModelSource $ModelSource `
+        -ReasoningEffort $ReasoningEffort `
         -ProjectDir $ProjectDir `
         -GitWorktreeDir $GitWorktreeDir `
         -RootPath $RootPath `
@@ -2119,7 +2123,7 @@ if ($MyInvocation.InvocationName -ne '.') {
             $execModeAgent = [string]$slotAgentConfig.Agent
         }
         $execMode = $execModeAgent.Trim().ToLowerInvariant() -eq 'codex'
-        $launchCommand = Get-AgentLaunchCommand -Agent $slotAgentConfig.Agent -Model $slotAgentConfig.Model -ProjectDir $launchDir -GitWorktreeDir $launchGitWorktreeDir -RootPath $projectDir -ExecMode $false
+        $launchCommand = Get-AgentLaunchCommand -Agent $slotAgentConfig.Agent -Model $slotAgentConfig.Model -ModelSource $slotAgentConfig.ModelSource -ReasoningEffort $slotAgentConfig.ReasoningEffort -ProjectDir $launchDir -GitWorktreeDir $launchGitWorktreeDir -RootPath $projectDir -ExecMode $false
         $supportsInterrupt = Test-OrchestraProviderInterruptAvailable -SlotAgentConfig $slotAgentConfig
 
         Invoke-Bridge -Arguments @('name', $paneId, $label)

--- a/winsmux-core/scripts/pane-control.ps1
+++ b/winsmux-core/scripts/pane-control.ps1
@@ -229,6 +229,8 @@ function Get-PaneControlLaunchCommand {
     param(
         [Parameter(Mandatory = $true)][string]$Agent,
         [Parameter(Mandatory = $true)][AllowEmptyString()][string]$Model,
+        [AllowEmptyString()][string]$ModelSource = '',
+        [AllowEmptyString()][string]$ReasoningEffort = '',
         [Parameter(Mandatory = $true)][string]$ProjectDir,
         [Parameter(Mandatory = $true)][string]$GitWorktreeDir,
         [string]$RootPath = ''
@@ -237,6 +239,8 @@ function Get-PaneControlLaunchCommand {
     return Get-BridgeProviderLaunchCommand `
         -ProviderId $Agent `
         -Model $Model `
+        -ModelSource $ModelSource `
+        -ReasoningEffort $ReasoningEffort `
         -ProjectDir $ProjectDir `
         -GitWorktreeDir $GitWorktreeDir `
         -RootPath $RootPath
@@ -538,7 +542,7 @@ function Get-PaneControlRestartPlan {
     if (Get-Command Get-SlotAgentConfig -ErrorAction SilentlyContinue) {
         $agentConfig = Get-SlotAgentConfig -Role $context.Role -SlotId $context.Label -Settings $Settings -RootPath $ProjectDir
     } elseif (Get-Command Get-RoleAgentConfig -ErrorAction SilentlyContinue) {
-        $agentConfig = Get-RoleAgentConfig -Role $context.Role -Settings $Settings
+        $agentConfig = Get-RoleAgentConfig -Role $context.Role -Settings $Settings -RootPath $ProjectDir
     } else {
         $agentConfig = [ordered]@{
             Agent = [string]$Settings.agent
@@ -546,7 +550,7 @@ function Get-PaneControlRestartPlan {
         }
     }
 
-    $launchCommand = Get-PaneControlLaunchCommand -Agent $agentConfig.Agent -Model $agentConfig.Model -ProjectDir $context.LaunchDir -GitWorktreeDir $context.GitWorktreeDir -RootPath $ProjectDir
+    $launchCommand = Get-PaneControlLaunchCommand -Agent $agentConfig.Agent -Model $agentConfig.Model -ModelSource $agentConfig.ModelSource -ReasoningEffort $agentConfig.ReasoningEffort -ProjectDir $context.LaunchDir -GitWorktreeDir $context.GitWorktreeDir -RootPath $ProjectDir
 
     return [ordered]@{
         PaneId         = $context.PaneId

--- a/winsmux-core/scripts/pane-scaler.ps1
+++ b/winsmux-core/scripts/pane-scaler.ps1
@@ -162,6 +162,8 @@ function Get-PaneScalerLaunchCommand {
     param(
         [Parameter(Mandatory = $true)][string]$Agent,
         [Parameter(Mandatory = $true)][AllowEmptyString()][string]$Model,
+        [AllowEmptyString()][string]$ModelSource = '',
+        [AllowEmptyString()][string]$ReasoningEffort = '',
         [Parameter(Mandatory = $true)][string]$ProjectDir,
         [Parameter(Mandatory = $true)][string]$GitWorktreeDir,
         [string]$RootPath = ''
@@ -170,6 +172,8 @@ function Get-PaneScalerLaunchCommand {
     return Get-BridgeProviderLaunchCommand `
         -ProviderId $Agent `
         -Model $Model `
+        -ModelSource $ModelSource `
+        -ReasoningEffort $ReasoningEffort `
         -ProjectDir $ProjectDir `
         -GitWorktreeDir $GitWorktreeDir `
         -RootPath $RootPath
@@ -228,7 +232,7 @@ function Get-PaneScalerSlotAgentConfig {
     }
 
     try {
-        return Get-RoleAgentConfig -Role 'Builder' -Settings $Settings
+        return Get-RoleAgentConfig -Role 'Builder' -Settings $Settings -RootPath $ProjectDir
     } catch {
         return [PSCustomObject]@{
             Agent = [string]$Settings.agent
@@ -341,7 +345,7 @@ function Get-PaneWorkload {
             $roleAgentConfig = Get-SlotAgentConfig -Role 'Builder' -SlotId $label -Settings $Settings -RootPath $projectDir
         } else {
             try {
-                $roleAgentConfig = Get-RoleAgentConfig -Role 'Builder' -Settings $Settings
+                $roleAgentConfig = Get-RoleAgentConfig -Role 'Builder' -Settings $Settings -RootPath $projectDir
             } catch {
                 $roleAgentConfig = [PSCustomObject]@{
                     Agent = [string]$Settings.agent
@@ -432,7 +436,7 @@ function Add-OrchestraPane {
         Invoke-MonitorWinsmux -Arguments @('select-pane', '-t', $newPaneId, '-T', $newLabel) | Out-Null
 
         Wait-MonitorPaneShellReady -PaneId $newPaneId
-        Send-MonitorBridgeCommand -PaneId $newPaneId -Text (Get-PaneScalerLaunchCommand -Agent ([string]$roleAgentConfig.Agent) -Model ([string]$roleAgentConfig.Model) -ProjectDir $worktree.WorktreePath -GitWorktreeDir $worktree.GitWorktreeDir -RootPath $projectDir)
+        Send-MonitorBridgeCommand -PaneId $newPaneId -Text (Get-PaneScalerLaunchCommand -Agent ([string]$roleAgentConfig.Agent) -Model ([string]$roleAgentConfig.Model) -ModelSource ([string]$roleAgentConfig.ModelSource) -ReasoningEffort ([string]$roleAgentConfig.ReasoningEffort) -ProjectDir $worktree.WorktreePath -GitWorktreeDir $worktree.GitWorktreeDir -RootPath $projectDir)
 
         $newPane = [ordered]@{
             label                = $newLabel

--- a/winsmux-core/scripts/settings.ps1
+++ b/winsmux-core/scripts/settings.ps1
@@ -16,10 +16,13 @@ Dot-source this script to load the helpers:
 $script:BridgeSettingsFileName = '.winsmux.yaml'
 $script:BridgeProviderRegistryFileName = 'provider-registry.json'
 $script:BridgeProviderCapabilityRegistryFileName = 'provider-capabilities.json'
+$script:BridgeRuntimeRolePreferencesFileName = 'runtime-role-preferences.json'
 $script:BridgeSettingsSchema = [ordered]@{
     config_version      = @{ Type = 'int';      Default = 1;             Option = $null }
     agent               = @{ Type = 'string';   Default = 'codex';       Option = '@bridge-agent' }
     model               = @{ Type = 'string';   Default = '';            Option = '@bridge-model' }
+    model_source        = @{ Type = 'string';   Default = 'provider-default'; Option = $null }
+    reasoning_effort    = @{ Type = 'string';   Default = 'provider-default'; Option = $null }
     prompt_transport    = @{ Type = 'transport'; Default = 'argv';       Option = '@bridge-prompt-transport' }
     auth_mode           = @{ Type = 'string';   Default = '';            Option = $null }
     external_operator  = @{ Type = 'bool';     Default = $true;         Option = '@bridge-external-operator' }
@@ -302,7 +305,7 @@ function ConvertTo-BridgeSlotEntry {
     $slot = [ordered]@{}
     foreach ($pair in $pairs) {
         $key = $pair.Key.ToString() -replace '-', '_'
-        if ($key -notin @('slot_id', 'runtime_role', 'agent', 'model', 'prompt_transport', 'auth_mode', 'worktree_mode')) {
+        if ($key -notin @('slot_id', 'runtime_role', 'agent', 'model', 'model_source', 'reasoning_effort', 'prompt_transport', 'auth_mode', 'worktree_mode')) {
             continue
         }
 
@@ -320,6 +323,13 @@ function ConvertTo-BridgeSlotEntry {
 
     if (-not $slot.Contains('runtime_role')) {
         $slot.runtime_role = 'worker'
+    }
+    if ($slot.Contains('model') -and -not $slot.Contains('model_source')) {
+        if (Test-BridgeProviderDefaultModel -Model ([string]$slot.model)) {
+            $slot.model_source = 'provider-default'
+        } else {
+            $slot.model_source = 'operator-override'
+        }
     }
 
     return $slot
@@ -418,7 +428,7 @@ function ConvertTo-BridgeProviderRegistryEntry {
     $entry = [ordered]@{}
     foreach ($pair in $pairs) {
         $key = $pair.Key.ToString() -replace '-', '_'
-        if ($key -notin @('agent', 'model', 'prompt_transport', 'auth_mode', 'updated_at_utc', 'reason')) {
+        if ($key -notin @('agent', 'model', 'model_source', 'reasoning_effort', 'prompt_transport', 'auth_mode', 'updated_at_utc', 'reason')) {
             continue
         }
 
@@ -428,7 +438,7 @@ function ConvertTo-BridgeProviderRegistryEntry {
 
         $text = ConvertFrom-BridgeYamlScalar $pair.Value
         if ([string]::IsNullOrWhiteSpace($text)) {
-            if ($key -in @('agent', 'model', 'prompt_transport', 'auth_mode')) {
+            if ($key -in @('agent', 'model', 'model_source', 'reasoning_effort', 'prompt_transport', 'auth_mode')) {
                 throw "Invalid provider registry field '$key'."
             }
 
@@ -438,11 +448,24 @@ function ConvertTo-BridgeProviderRegistryEntry {
         if ($key -eq 'prompt_transport' -and $text -notin @('argv', 'file', 'stdin')) {
             throw "Invalid provider registry prompt_transport '$text'."
         }
+        if ($key -eq 'model_source' -and $text -notin @('provider-default', 'cli-discovery', 'official-doc', 'operator-override')) {
+            throw "Invalid provider registry model_source '$text'."
+        }
+        if ($key -eq 'reasoning_effort' -and $text -notin @('provider-default', 'low', 'medium', 'high', 'xhigh', 'max')) {
+            throw "Invalid provider registry reasoning_effort '$text'."
+        }
 
         $entry[$key] = $text
     }
+    if ($entry.Contains('model') -and -not $entry.Contains('model_source')) {
+        if (Test-BridgeProviderDefaultModel -Model ([string]$entry.model)) {
+            $entry.model_source = 'provider-default'
+        } else {
+            $entry.model_source = 'operator-override'
+        }
+    }
 
-    if (-not ($entry.Contains('agent') -or $entry.Contains('model') -or $entry.Contains('prompt_transport') -or $entry.Contains('auth_mode'))) {
+    if (-not ($entry.Contains('agent') -or $entry.Contains('model') -or $entry.Contains('model_source') -or $entry.Contains('reasoning_effort') -or $entry.Contains('prompt_transport') -or $entry.Contains('auth_mode'))) {
         return $null
     }
 
@@ -540,6 +563,8 @@ function Write-BridgeProviderRegistryEntry {
         [Parameter(Mandatory = $true)][string]$SlotId,
         [string]$Agent,
         [string]$Model,
+        [string]$ModelSource,
+        [string]$ReasoningEffort,
         [string]$PromptTransport,
         [string]$AuthMode,
         [string]$Reason,
@@ -557,6 +582,26 @@ function Write-BridgeProviderRegistryEntry {
     if (-not [string]::IsNullOrWhiteSpace($Model)) {
         $entry.model = $Model.Trim()
     }
+    if (-not [string]::IsNullOrWhiteSpace($ModelSource)) {
+        $normalizedModelSource = $ModelSource.Trim()
+        if ($normalizedModelSource -notin @('provider-default', 'cli-discovery', 'official-doc', 'operator-override')) {
+            throw "Invalid provider registry model_source '$ModelSource'."
+        }
+        $entry.model_source = $normalizedModelSource
+    } elseif ($entry.Contains('model')) {
+        if (Test-BridgeProviderDefaultModel -Model ([string]$entry.model)) {
+            $entry.model_source = 'provider-default'
+        } else {
+            $entry.model_source = 'operator-override'
+        }
+    }
+    if (-not [string]::IsNullOrWhiteSpace($ReasoningEffort)) {
+        $normalizedEffort = $ReasoningEffort.Trim().ToLowerInvariant()
+        if ($normalizedEffort -notin @('provider-default', 'low', 'medium', 'high', 'xhigh', 'max')) {
+            throw "Invalid provider registry reasoning_effort '$ReasoningEffort'."
+        }
+        $entry.reasoning_effort = $normalizedEffort
+    }
     if (-not [string]::IsNullOrWhiteSpace($PromptTransport)) {
         $normalizedTransport = $PromptTransport.Trim().ToLowerInvariant()
         if ($normalizedTransport -notin @('argv', 'file', 'stdin')) {
@@ -567,8 +612,8 @@ function Write-BridgeProviderRegistryEntry {
     if (-not [string]::IsNullOrWhiteSpace($AuthMode)) {
         $entry.auth_mode = $AuthMode.Trim()
     }
-    if (-not ($entry.Contains('agent') -or $entry.Contains('model') -or $entry.Contains('prompt_transport') -or $entry.Contains('auth_mode'))) {
-        throw 'Provider registry entry requires agent, model, prompt_transport, or auth_mode.'
+    if (-not ($entry.Contains('agent') -or $entry.Contains('model') -or $entry.Contains('model_source') -or $entry.Contains('reasoning_effort') -or $entry.Contains('prompt_transport') -or $entry.Contains('auth_mode'))) {
+        throw 'Provider registry entry requires agent, model, model_source, reasoning_effort, prompt_transport, or auth_mode.'
     }
 
     $entry.updated_at_utc = (Get-Date).ToUniversalTime().ToString('o')
@@ -628,6 +673,255 @@ function Remove-BridgeProviderRegistryEntry {
     }
 }
 
+function Get-BridgeRuntimeRolePreferencesPath {
+    param([string]$RootPath)
+
+    if ([string]::IsNullOrWhiteSpace($RootPath)) {
+        $RootPath = (Get-Location).Path
+    }
+
+    return Join-Path (Join-Path $RootPath '.winsmux') $script:BridgeRuntimeRolePreferencesFileName
+}
+
+function ConvertTo-BridgeRuntimeRoleConfig {
+    param([AllowNull()]$Value)
+
+    if ($null -eq $Value) {
+        return $null
+    }
+
+    $pairs = @()
+    if ($Value -is [System.Collections.IDictionary]) {
+        $pairs = $Value.GetEnumerator()
+    } elseif ($Value -is [PSCustomObject]) {
+        $pairs = $Value.PSObject.Properties | ForEach-Object {
+            [PSCustomObject]@{
+                Key   = $_.Name
+                Value = $_.Value
+            }
+        }
+    } else {
+        return $null
+    }
+
+    $entry = [ordered]@{}
+    foreach ($pair in $pairs) {
+        $key = $pair.Key.ToString() -replace '-', '_'
+        switch ($key) {
+            'provider' { $key = 'agent' }
+            'modelSource' { $key = 'model_source' }
+            'reasoningEffort' { $key = 'reasoning_effort' }
+            default { }
+        }
+
+        if ($key -in @('role_id', 'roleId', 'runtime_role', 'runtimeRole')) {
+            continue
+        }
+        if ($key -notin @('agent', 'model', 'model_source', 'reasoning_effort', 'prompt_transport', 'auth_mode')) {
+            continue
+        }
+        if (-not (Test-BridgeProviderRegistryScalarValue $pair.Value)) {
+            throw "Invalid runtime role preference field '$key'."
+        }
+
+        $text = ConvertFrom-BridgeYamlScalar $pair.Value
+        if ([string]::IsNullOrWhiteSpace($text)) {
+            continue
+        }
+        $text = $text.Trim()
+
+        if ($key -eq 'agent' -and [string]::Equals($text, 'provider-default', [System.StringComparison]::OrdinalIgnoreCase)) {
+            continue
+        }
+
+        if ($key -eq 'model_source' -and $text -notin @('provider-default', 'cli-discovery', 'official-doc', 'operator-override')) {
+            throw "Invalid runtime role preference model_source '$text'."
+        }
+        if ($key -eq 'reasoning_effort') {
+            $text = $text.Trim().ToLowerInvariant()
+            if ($text -notin @('provider-default', 'low', 'medium', 'high', 'xhigh', 'max')) {
+                throw "Invalid runtime role preference reasoning_effort '$text'."
+            }
+        }
+
+        $entry[$key] = $text
+    }
+    if ($entry.Contains('model') -and -not $entry.Contains('model_source')) {
+        if (Test-BridgeProviderDefaultModel -Model ([string]$entry.model)) {
+            $entry.model_source = 'provider-default'
+        } else {
+            $entry.model_source = 'operator-override'
+        }
+    }
+
+    return $entry
+}
+
+function Get-BridgeRuntimeRoleId {
+    param([AllowNull()]$Value)
+
+    if ($null -eq $Value) {
+        return ''
+    }
+    if ($Value -is [System.Collections.IDictionary]) {
+        foreach ($key in @('role_id', 'roleId', 'runtime_role', 'runtimeRole')) {
+            if ($Value.Contains($key)) {
+                return [string]$Value[$key]
+            }
+        }
+        return ''
+    }
+    if ($null -ne $Value.PSObject) {
+        foreach ($key in @('role_id', 'roleId', 'runtime_role', 'runtimeRole')) {
+            if ($Value.PSObject.Properties.Name -contains $key) {
+                return [string]$Value.PSObject.Properties[$key].Value
+            }
+        }
+    }
+
+    return ''
+}
+
+function ConvertTo-BridgeRuntimeRolePreferencesMap {
+    param([AllowNull()]$Roles)
+
+    $map = [ordered]@{}
+    if ($null -eq $Roles) {
+        return $map
+    }
+
+    if ($Roles -is [System.Collections.IDictionary]) {
+        foreach ($entry in $Roles.GetEnumerator()) {
+            $roleId = ConvertFrom-BridgeYamlScalar $entry.Key
+            if ([string]::IsNullOrWhiteSpace($roleId)) {
+                continue
+            }
+            $config = ConvertTo-BridgeRuntimeRoleConfig $entry.Value
+            if ($null -ne $config) {
+                $map[$roleId] = $config
+            }
+        }
+        return $map
+    }
+
+    if ($Roles -is [PSCustomObject]) {
+        if ($Roles.PSObject.Properties.Name -contains 'roles') {
+            return ConvertTo-BridgeRuntimeRolePreferencesMap $Roles.roles
+        }
+        foreach ($property in $Roles.PSObject.Properties) {
+            $roleId = ConvertFrom-BridgeYamlScalar $property.Name
+            if ([string]::IsNullOrWhiteSpace($roleId)) {
+                continue
+            }
+            $config = ConvertTo-BridgeRuntimeRoleConfig $property.Value
+            if ($null -ne $config) {
+                $map[$roleId] = $config
+            }
+        }
+        return $map
+    }
+
+    if ($Roles -is [System.Collections.IEnumerable] -and $Roles -isnot [string]) {
+        foreach ($role in @($Roles)) {
+            $roleId = Get-BridgeRuntimeRoleId $role
+            if ([string]::IsNullOrWhiteSpace($roleId)) {
+                continue
+            }
+            $config = ConvertTo-BridgeRuntimeRoleConfig $role
+            if ($null -ne $config) {
+                $map[$roleId] = $config
+            }
+        }
+        return $map
+    }
+
+    return $map
+}
+
+function Read-BridgeRuntimeRolePreferences {
+    param([string]$RootPath)
+
+    $path = Get-BridgeRuntimeRolePreferencesPath -RootPath $RootPath
+    $preferences = [ordered]@{
+        version = 1
+        roles   = [ordered]@{}
+    }
+    if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
+        return $preferences
+    }
+
+    $raw = Get-Content -LiteralPath $path -Raw -Encoding UTF8
+    if ([string]::IsNullOrWhiteSpace($raw)) {
+        return $preferences
+    }
+
+    try {
+        $parsed = $raw | ConvertFrom-Json -Depth 16 -ErrorAction Stop
+    } catch {
+        throw "Invalid runtime role preferences JSON at '$path'."
+    }
+
+    $version = 1
+    if ($null -ne $parsed.PSObject -and $parsed.PSObject.Properties.Name -contains 'version') {
+        $version = [int]$parsed.version
+    }
+    if ($version -ne 1) {
+        throw "Unsupported runtime role preferences version '$version'. Supported versions: 1."
+    }
+
+    $roles = if ($null -ne $parsed.PSObject -and $parsed.PSObject.Properties.Name -contains 'roles') {
+        $parsed.roles
+    } else {
+        $parsed
+    }
+    $preferences.version = $version
+    $preferences.roles = ConvertTo-BridgeRuntimeRolePreferencesMap $roles
+    return $preferences
+}
+
+function Write-BridgeRuntimeRolePreferences {
+    param(
+        [Parameter(Mandatory = $true)]$Roles,
+        [string]$RootPath
+    )
+
+    $roleMap = ConvertTo-BridgeRuntimeRolePreferencesMap $Roles
+    $payload = [ordered]@{
+        version        = 1
+        updated_at_utc = (Get-Date).ToUniversalTime().ToString('o')
+        roles          = $roleMap
+    }
+
+    $path = Get-BridgeRuntimeRolePreferencesPath -RootPath $RootPath
+    $directory = Split-Path -Parent $path
+    if (-not (Test-Path -LiteralPath $directory -PathType Container)) {
+        New-Item -ItemType Directory -Path $directory -Force | Out-Null
+    }
+
+    $payload | ConvertTo-Json -Depth 16 | Set-Content -LiteralPath $path -Encoding UTF8
+    return $payload
+}
+
+function Get-BridgeRuntimeRolePreference {
+    param(
+        [Parameter(Mandatory = $true)][string]$Role,
+        [string]$RootPath
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Role)) {
+        return $null
+    }
+
+    $preferences = Read-BridgeRuntimeRolePreferences -RootPath $RootPath
+    foreach ($entry in $preferences.roles.GetEnumerator()) {
+        if ([string]::Equals([string]$entry.Key, $Role, [System.StringComparison]::OrdinalIgnoreCase)) {
+            return $entry.Value
+        }
+    }
+
+    return $null
+}
+
 function Get-BridgeProviderCapabilityRegistryPath {
     param([string]$RootPath)
 
@@ -659,9 +953,10 @@ function ConvertTo-BridgeProviderCapabilityEntry {
         return $null
     }
 
-    $stringFields = @('adapter', 'display_name', 'command')
+    $stringFields = @('adapter', 'display_name', 'command', 'model_catalog_source', 'local_access_note')
     $transportFields = @('prompt_transports')
-    $stringArrayFields = @('auth_modes', 'local_interactive_oauth_modes')
+    $stringArrayFields = @('auth_modes', 'local_interactive_oauth_modes', 'model_sources', 'reasoning_efforts')
+    $modelOptionFields = @('model_options')
     $boolFields = @(
         'supports_parallel_runs',
         'supports_interrupt',
@@ -672,7 +967,7 @@ function ConvertTo-BridgeProviderCapabilityEntry {
         'supports_consultation',
         'supports_context_reset'
     )
-    $allowedFields = @($stringFields + $transportFields + $stringArrayFields + $boolFields)
+    $allowedFields = @($stringFields + $transportFields + $stringArrayFields + $modelOptionFields + $boolFields)
 
     $entry = [ordered]@{}
     foreach ($pair in $pairs) {
@@ -732,10 +1027,34 @@ function ConvertTo-BridgeProviderCapabilityEntry {
                     throw "Invalid provider capability field '$key'."
                 }
 
-                $items += $text.Trim().ToLowerInvariant()
+                $normalizedText = $text.Trim().ToLowerInvariant()
+                if ($key -eq 'model_sources' -and $normalizedText -notin @('provider-default', 'cli-discovery', 'official-doc', 'operator-override')) {
+                    throw "Invalid provider capability field '$key'."
+                }
+                if ($key -eq 'reasoning_efforts' -and $normalizedText -notin @('provider-default', 'low', 'medium', 'high', 'xhigh', 'max')) {
+                    throw "Invalid provider capability field '$key'."
+                }
+
+                $items += $normalizedText
             }
 
             $entry[$key] = @($items)
+            continue
+        }
+
+        if ($key -in $modelOptionFields) {
+            if ($pair.Value -isnot [System.Collections.IEnumerable] -or $pair.Value -is [string]) {
+                throw "Invalid provider capability field '$key'."
+            }
+
+            $modelOptions = @()
+            foreach ($item in @($pair.Value)) {
+                $modelOptions += ConvertTo-BridgeProviderModelOption -Value $item
+            }
+            if ($modelOptions.Count -lt 1) {
+                throw "Invalid provider capability field '$key'."
+            }
+            $entry[$key] = @($modelOptions)
             continue
         }
 
@@ -759,6 +1078,45 @@ function ConvertTo-BridgeProviderCapabilityEntry {
     }
 
     return $entry
+}
+
+function ConvertTo-BridgeProviderModelOption {
+    param([AllowNull()]$Value)
+
+    if (-not (Test-BridgeProviderRegistryObject $Value)) {
+        throw "Invalid provider capability field 'model_options'."
+    }
+
+    $option = [ordered]@{}
+    foreach ($property in (Get-BridgeProviderRegistryObjectProperties $Value)) {
+        $key = $property.Name.ToString()
+        if ($key -notin @('id', 'label', 'source', 'availability', 'notes')) {
+            throw "Invalid provider capability field 'model_options'."
+        }
+        if (-not (Test-BridgeProviderRegistryScalarValue $property.Value)) {
+            throw "Invalid provider capability field 'model_options'."
+        }
+        $text = ConvertFrom-BridgeYamlScalar $property.Value
+        if ([string]::IsNullOrWhiteSpace($text)) {
+            if ($key -in @('id', 'source')) {
+                throw "Invalid provider capability field 'model_options'."
+            }
+            continue
+        }
+        if ($key -eq 'source') {
+            $text = $text.Trim().ToLowerInvariant()
+            if ($text -notin @('provider-default', 'cli-discovery', 'official-doc', 'operator-override')) {
+                throw "Invalid provider capability field 'model_options'."
+            }
+        }
+        $option[$key] = $text
+    }
+
+    if (-not $option.Contains('id') -or -not $option.Contains('source')) {
+        throw "Invalid provider capability field 'model_options'."
+    }
+
+    return $option
 }
 
 function ConvertTo-BridgePowerShellLiteral {
@@ -1052,10 +1410,39 @@ function Assert-BridgeProviderCapabilityAuthMode {
     }
 }
 
+function Assert-BridgeProviderCapabilitySelection {
+    param(
+        [Parameter(Mandatory = $true)][string]$ProviderId,
+        [AllowNull()]$Capability,
+        [Parameter(Mandatory = $true)][string]$FieldName,
+        [Parameter(Mandatory = $true)][string]$SelectorName,
+        [AllowNull()][string]$Value
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Value)) {
+        return
+    }
+    if ($null -eq $Capability -or -not (Test-BridgeProviderCapabilityField -Capability $Capability -Name $FieldName)) {
+        return
+    }
+
+    $requested = $Value.Trim().ToLowerInvariant()
+    $supported = @(
+        Get-BridgeProviderCapabilityValue -Capability $Capability -Name $FieldName -Default @() |
+            ForEach-Object { ([string]$_).Trim().ToLowerInvariant() } |
+            Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+    )
+    if ($requested -notin $supported) {
+        throw "Provider capability '$ProviderId' does not support $SelectorName '$requested'. Supported values: $($supported -join ', ')."
+    }
+}
+
 function Get-BridgeProviderLaunchCommand {
     param(
         [Parameter(Mandatory = $true)][string]$ProviderId,
         [Parameter(Mandatory = $true)][AllowEmptyString()][string]$Model,
+        [AllowEmptyString()][string]$ModelSource = '',
+        [AllowEmptyString()][string]$ReasoningEffort = '',
         [Parameter(Mandatory = $true)][string]$ProjectDir,
         [Parameter(Mandatory = $true)][string]$GitWorktreeDir,
         [string]$RootPath,
@@ -1077,6 +1464,8 @@ function Get-BridgeProviderLaunchCommand {
 
     $adapterKey = $adapter.Trim().ToLowerInvariant()
     $commandInvocation = ConvertTo-BridgePowerShellCommandInvocation -Value $command
+    $modelOverride = Test-BridgeProviderModelOverride -Model $Model -ModelSource $ModelSource
+    $effortOverride = -not (Test-BridgeProviderDefaultReasoningEffort -ReasoningEffort $ReasoningEffort)
     switch ($adapterKey) {
         'codex' {
             if ($ExecMode) {
@@ -1086,9 +1475,13 @@ function Get-BridgeProviderLaunchCommand {
             $projectLiteral = ConvertTo-BridgePowerShellLiteral -Value $ProjectDir
             $worktreeLiteral = ConvertTo-BridgePowerShellLiteral -Value $GitWorktreeDir
             $parts = @($commandInvocation)
-            if (-not [string]::IsNullOrWhiteSpace($Model)) {
+            if ($modelOverride) {
                 $parts += '-c'
                 $parts += (ConvertTo-BridgePowerShellLiteral -Value "model=$Model")
+            }
+            if ($effortOverride) {
+                $parts += '-c'
+                $parts += (ConvertTo-BridgePowerShellLiteral -Value "model_reasoning_effort=$($ReasoningEffort.Trim().ToLowerInvariant())")
             }
             $parts += '--sandbox'
             $parts += 'danger-full-access'
@@ -1100,18 +1493,68 @@ function Get-BridgeProviderLaunchCommand {
         }
         'claude' {
             $parts = @($commandInvocation)
-            if (-not [string]::IsNullOrWhiteSpace($Model)) {
+            if ($modelOverride) {
                 $parts += '--model'
                 $parts += (ConvertTo-BridgePowerShellLiteral -Value $Model)
             }
+            if ($effortOverride) {
+                $parts += '--effort'
+                $parts += $ReasoningEffort.Trim().ToLowerInvariant()
+            }
             $parts += '--permission-mode'
             $parts += 'bypassPermissions'
+            return ($parts -join ' ')
+        }
+        'gemini' {
+            $parts = @($commandInvocation)
+            if ($modelOverride) {
+                $parts += '--model'
+                $parts += (ConvertTo-BridgePowerShellLiteral -Value $Model)
+            }
+            $parts += '--approval-mode=default'
             return ($parts -join ' ')
         }
         default {
             throw "Unsupported provider adapter '$adapter' for provider '$provider'."
         }
     }
+}
+
+function Test-BridgeProviderDefaultModel {
+    param([AllowNull()][string]$Model)
+
+    return ([string]::IsNullOrWhiteSpace($Model) -or [string]::Equals($Model.Trim(), 'provider-default', [System.StringComparison]::OrdinalIgnoreCase))
+}
+
+function Test-BridgeProviderDefaultModelSource {
+    param([AllowNull()][string]$ModelSource)
+
+    return ((-not [string]::IsNullOrWhiteSpace($ModelSource)) -and [string]::Equals($ModelSource.Trim(), 'provider-default', [System.StringComparison]::OrdinalIgnoreCase))
+}
+
+function Get-BridgeProviderInferredModelSource {
+    param([AllowNull()][string]$Model)
+
+    if (Test-BridgeProviderDefaultModel -Model $Model) {
+        return 'provider-default'
+    }
+
+    return 'operator-override'
+}
+
+function Test-BridgeProviderModelOverride {
+    param(
+        [AllowNull()][string]$Model,
+        [AllowNull()][string]$ModelSource
+    )
+
+    return ((-not (Test-BridgeProviderDefaultModel -Model $Model)) -and (-not (Test-BridgeProviderDefaultModelSource -ModelSource $ModelSource)))
+}
+
+function Test-BridgeProviderDefaultReasoningEffort {
+    param([AllowNull()][string]$ReasoningEffort)
+
+    return ([string]::IsNullOrWhiteSpace($ReasoningEffort) -or [string]::Equals($ReasoningEffort.Trim(), 'provider-default', [System.StringComparison]::OrdinalIgnoreCase))
 }
 
 function ConvertFrom-BridgeManualYaml {
@@ -1424,7 +1867,7 @@ function Test-BridgeSettingValue {
 
                 foreach ($rolePair in $rolePairs) {
                     $propertyKey = $rolePair.Key.ToString() -replace '-', '_'
-                    if ($propertyKey -notin @('agent', 'model', 'prompt_transport', 'auth_mode')) {
+                    if ($propertyKey -notin @('agent', 'model', 'model_source', 'reasoning_effort', 'prompt_transport', 'auth_mode')) {
                         continue
                     }
 
@@ -1434,6 +1877,13 @@ function Test-BridgeSettingValue {
                     }
 
                     $roleConfig[$propertyKey] = $text
+                }
+                if ($roleConfig.Contains('model') -and -not $roleConfig.Contains('model_source')) {
+                    if (Test-BridgeProviderDefaultModel -Model ([string]$roleConfig.model)) {
+                        $roleConfig.model_source = 'provider-default'
+                    } else {
+                        $roleConfig.model_source = 'operator-override'
+                    }
                 }
 
                 $map[$roleKey] = $roleConfig
@@ -1562,6 +2012,13 @@ function Get-BridgeSettings {
             $settings[$key] = $value
         }
     }
+    if ($globalSettings.Contains('model') -and -not $globalSettings.Contains('model_source')) {
+        if (Test-BridgeProviderDefaultModel -Model ([string]$settings.model)) {
+            $settings.model_source = 'provider-default'
+        } else {
+            $settings.model_source = 'operator-override'
+        }
+    }
 
     $rawProjectSettings = Read-BridgeProjectSettings -RootPath $RootPath
     $projectSettings = ConvertTo-BridgeSettingsSource $rawProjectSettings
@@ -1599,6 +2056,13 @@ function Get-BridgeSettings {
             $settings[$key] = @($value)
         } else {
             $settings[$key] = $value
+        }
+    }
+    if ($projectSettings.Contains('model') -and -not $projectSettings.Contains('model_source')) {
+        if (Test-BridgeProviderDefaultModel -Model ([string]$settings.model)) {
+            $settings.model_source = 'provider-default'
+        } else {
+            $settings.model_source = 'operator-override'
         }
     }
 
@@ -1667,7 +2131,8 @@ function Get-BridgeSettingsMetadata {
 function Get-RoleAgentConfig {
     param(
         [Parameter(Mandatory = $true)][string]$Role,
-        $Settings = (Get-BridgeSettings)
+        $Settings = (Get-BridgeSettings),
+        [string]$RootPath
     )
 
     if ($null -eq $Settings) {
@@ -1687,9 +2152,19 @@ function Get-RoleAgentConfig {
 
     $agent = $Settings.agent
     $model = $Settings.model
+    $modelSource = 'provider-default'
+    $reasoningEffort = 'provider-default'
     $promptTransport = 'argv'
     $authMode = ''
+    $settingsModelSourceSet = $false
     if ($Settings -is [System.Collections.IDictionary]) {
+        if ($Settings.Contains('model_source') -and -not [string]::IsNullOrWhiteSpace([string]$Settings['model_source'])) {
+            $modelSource = [string]$Settings['model_source']
+            $settingsModelSourceSet = $true
+        }
+        if ($Settings.Contains('reasoning_effort') -and -not [string]::IsNullOrWhiteSpace([string]$Settings['reasoning_effort'])) {
+            $reasoningEffort = [string]$Settings['reasoning_effort']
+        }
         if ($Settings.Contains('prompt_transport') -and -not [string]::IsNullOrWhiteSpace([string]$Settings['prompt_transport'])) {
             $promptTransport = [string]$Settings['prompt_transport']
         }
@@ -1697,6 +2172,13 @@ function Get-RoleAgentConfig {
             $authMode = [string]$Settings['auth_mode']
         }
     } elseif ($null -ne $Settings.PSObject) {
+        if ($Settings.PSObject.Properties.Name -contains 'model_source' -and -not [string]::IsNullOrWhiteSpace([string]$Settings.model_source)) {
+            $modelSource = [string]$Settings.model_source
+            $settingsModelSourceSet = $true
+        }
+        if ($Settings.PSObject.Properties.Name -contains 'reasoning_effort' -and -not [string]::IsNullOrWhiteSpace([string]$Settings.reasoning_effort)) {
+            $reasoningEffort = [string]$Settings.reasoning_effort
+        }
         if ($Settings.PSObject.Properties.Name -contains 'prompt_transport' -and -not [string]::IsNullOrWhiteSpace([string]$Settings.prompt_transport)) {
             $promptTransport = [string]$Settings.prompt_transport
         }
@@ -1704,7 +2186,12 @@ function Get-RoleAgentConfig {
             $authMode = [string]$Settings.auth_mode
         }
     }
+    if (-not $settingsModelSourceSet) {
+        $modelSource = Get-BridgeProviderInferredModelSource -Model $model
+    }
 
+    $roleModelSet = $false
+    $roleModelSourceSet = $false
     if ($resolvedRoleConfig -is [System.Collections.IDictionary]) {
         if ($resolvedRoleConfig.Contains('agent') -and -not [string]::IsNullOrWhiteSpace([string]$resolvedRoleConfig['agent'])) {
             $agent = [string]$resolvedRoleConfig['agent']
@@ -1712,6 +2199,16 @@ function Get-RoleAgentConfig {
 
         if ($resolvedRoleConfig.Contains('model') -and -not [string]::IsNullOrWhiteSpace([string]$resolvedRoleConfig['model'])) {
             $model = [string]$resolvedRoleConfig['model']
+            $roleModelSet = $true
+        }
+
+        if ($resolvedRoleConfig.Contains('model_source') -and -not [string]::IsNullOrWhiteSpace([string]$resolvedRoleConfig['model_source'])) {
+            $modelSource = [string]$resolvedRoleConfig['model_source']
+            $roleModelSourceSet = $true
+        }
+
+        if ($resolvedRoleConfig.Contains('reasoning_effort') -and -not [string]::IsNullOrWhiteSpace([string]$resolvedRoleConfig['reasoning_effort'])) {
+            $reasoningEffort = [string]$resolvedRoleConfig['reasoning_effort']
         }
 
         if ($resolvedRoleConfig.Contains('prompt_transport') -and -not [string]::IsNullOrWhiteSpace([string]$resolvedRoleConfig['prompt_transport'])) {
@@ -1728,6 +2225,16 @@ function Get-RoleAgentConfig {
 
         if ($resolvedRoleConfig.PSObject.Properties.Name -contains 'model' -and -not [string]::IsNullOrWhiteSpace([string]$resolvedRoleConfig.model)) {
             $model = [string]$resolvedRoleConfig.model
+            $roleModelSet = $true
+        }
+
+        if ($resolvedRoleConfig.PSObject.Properties.Name -contains 'model_source' -and -not [string]::IsNullOrWhiteSpace([string]$resolvedRoleConfig.model_source)) {
+            $modelSource = [string]$resolvedRoleConfig.model_source
+            $roleModelSourceSet = $true
+        }
+
+        if ($resolvedRoleConfig.PSObject.Properties.Name -contains 'reasoning_effort' -and -not [string]::IsNullOrWhiteSpace([string]$resolvedRoleConfig.reasoning_effort)) {
+            $reasoningEffort = [string]$resolvedRoleConfig.reasoning_effort
         }
 
         if ($resolvedRoleConfig.PSObject.Properties.Name -contains 'prompt_transport' -and -not [string]::IsNullOrWhiteSpace([string]$resolvedRoleConfig.prompt_transport)) {
@@ -1738,10 +2245,39 @@ function Get-RoleAgentConfig {
             $authMode = [string]$resolvedRoleConfig.auth_mode
         }
     }
+    if ($roleModelSet -and -not $roleModelSourceSet) {
+        $modelSource = Get-BridgeProviderInferredModelSource -Model $model
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($RootPath)) {
+        $runtimeRoleConfig = Get-BridgeRuntimeRolePreference -Role $Role -RootPath $RootPath
+        if ($runtimeRoleConfig -is [System.Collections.IDictionary]) {
+            if ($runtimeRoleConfig.Contains('agent') -and -not [string]::IsNullOrWhiteSpace([string]$runtimeRoleConfig['agent'])) {
+                $agent = [string]$runtimeRoleConfig['agent']
+            }
+            if ($runtimeRoleConfig.Contains('model') -and -not [string]::IsNullOrWhiteSpace([string]$runtimeRoleConfig['model'])) {
+                $model = [string]$runtimeRoleConfig['model']
+            }
+            if ($runtimeRoleConfig.Contains('model_source') -and -not [string]::IsNullOrWhiteSpace([string]$runtimeRoleConfig['model_source'])) {
+                $modelSource = [string]$runtimeRoleConfig['model_source']
+            }
+            if ($runtimeRoleConfig.Contains('reasoning_effort') -and -not [string]::IsNullOrWhiteSpace([string]$runtimeRoleConfig['reasoning_effort'])) {
+                $reasoningEffort = [string]$runtimeRoleConfig['reasoning_effort']
+            }
+            if ($runtimeRoleConfig.Contains('prompt_transport') -and -not [string]::IsNullOrWhiteSpace([string]$runtimeRoleConfig['prompt_transport'])) {
+                $promptTransport = [string]$runtimeRoleConfig['prompt_transport']
+            }
+            if ($runtimeRoleConfig.Contains('auth_mode') -and -not [string]::IsNullOrWhiteSpace([string]$runtimeRoleConfig['auth_mode'])) {
+                $authMode = [string]$runtimeRoleConfig['auth_mode']
+            }
+        }
+    }
 
     return [PSCustomObject]@{
         Agent           = [string]$agent
         Model           = [string]$model
+        ModelSource     = [string]$modelSource
+        ReasoningEffort = [string]$reasoningEffort
         PromptTransport = [string]$promptTransport
         AuthMode        = [string]$authMode
     }
@@ -1752,16 +2288,20 @@ function Get-SlotAgentConfig {
         [Parameter(Mandatory = $true)][string]$Role,
         [string]$SlotId,
         $Settings = (Get-BridgeSettings),
-        [string]$RootPath
+        [string]$RootPath,
+        [AllowNull()]$ProviderRegistryEntryOverride = $null,
+        [switch]$IgnoreProviderRegistry
     )
 
     if ($null -eq $Settings) {
         throw 'Settings cannot be null.'
     }
 
-    $roleAgentConfig = Get-RoleAgentConfig -Role $Role -Settings $Settings
+    $roleAgentConfig = Get-RoleAgentConfig -Role $Role -Settings $Settings -RootPath $RootPath
     $agent = [string]$roleAgentConfig.Agent
     $model = [string]$roleAgentConfig.Model
+    $modelSource = [string]$roleAgentConfig.ModelSource
+    $reasoningEffort = [string]$roleAgentConfig.ReasoningEffort
     $promptTransport = [string]$roleAgentConfig.PromptTransport
     $authMode = [string]$roleAgentConfig.AuthMode
     $source = 'role'
@@ -1784,8 +2324,12 @@ function Get-SlotAgentConfig {
             $candidateSlotId = ''
             $slotAgent = ''
             $slotModel = ''
+            $slotModelSource = ''
+            $slotReasoningEffort = ''
             $slotPromptTransport = ''
             $slotAuthMode = ''
+            $slotModelSet = $false
+            $slotModelSourceSet = $false
 
             if ($slot -is [System.Collections.IDictionary]) {
                 if ($slot.Contains('slot_id')) {
@@ -1796,6 +2340,14 @@ function Get-SlotAgentConfig {
                 }
                 if ($slot.Contains('model')) {
                     $slotModel = [string]$slot['model']
+                    $slotModelSet = $true
+                }
+                if ($slot.Contains('model_source')) {
+                    $slotModelSource = [string]$slot['model_source']
+                    $slotModelSourceSet = $true
+                }
+                if ($slot.Contains('reasoning_effort')) {
+                    $slotReasoningEffort = [string]$slot['reasoning_effort']
                 }
                 if ($slot.Contains('prompt_transport')) {
                     $slotPromptTransport = [string]$slot['prompt_transport']
@@ -1812,6 +2364,14 @@ function Get-SlotAgentConfig {
                 }
                 if ($slot.PSObject.Properties.Name -contains 'model') {
                     $slotModel = [string]$slot.model
+                    $slotModelSet = $true
+                }
+                if ($slot.PSObject.Properties.Name -contains 'model_source') {
+                    $slotModelSource = [string]$slot.model_source
+                    $slotModelSourceSet = $true
+                }
+                if ($slot.PSObject.Properties.Name -contains 'reasoning_effort') {
+                    $slotReasoningEffort = [string]$slot.reasoning_effort
                 }
                 if ($slot.PSObject.Properties.Name -contains 'prompt_transport') {
                     $slotPromptTransport = [string]$slot.prompt_transport
@@ -1835,6 +2395,20 @@ function Get-SlotAgentConfig {
                 $source = 'slot'
             }
 
+            if (-not [string]::IsNullOrWhiteSpace($slotModelSource)) {
+                $modelSource = $slotModelSource
+                $source = 'slot'
+            }
+            if ($slotModelSet -and -not $slotModelSourceSet) {
+                $modelSource = Get-BridgeProviderInferredModelSource -Model $model
+                $source = 'slot'
+            }
+
+            if (-not [string]::IsNullOrWhiteSpace($slotReasoningEffort)) {
+                $reasoningEffort = $slotReasoningEffort
+                $source = 'slot'
+            }
+
             if (-not [string]::IsNullOrWhiteSpace($slotPromptTransport)) {
                 $promptTransport = $slotPromptTransport
                 $source = 'slot'
@@ -1849,7 +2423,12 @@ function Get-SlotAgentConfig {
         }
     }
 
-    $registryEntry = Get-BridgeProviderRegistryEntry -SlotId $SlotId -RootPath $RootPath
+    $registryEntry = $null
+    if ($null -ne $ProviderRegistryEntryOverride) {
+        $registryEntry = ConvertTo-BridgeProviderRegistryEntry $ProviderRegistryEntryOverride
+    } elseif (-not $IgnoreProviderRegistry) {
+        $registryEntry = Get-BridgeProviderRegistryEntry -SlotId $SlotId -RootPath $RootPath
+    }
     if ($null -ne $registryEntry) {
         if ($registryEntry.Contains('agent')) {
             $agent = [string]$registryEntry.agent
@@ -1857,6 +2436,14 @@ function Get-SlotAgentConfig {
 
         if ($registryEntry.Contains('model')) {
             $model = [string]$registryEntry.model
+        }
+
+        if ($registryEntry.Contains('model_source')) {
+            $modelSource = [string]$registryEntry.model_source
+        }
+
+        if ($registryEntry.Contains('reasoning_effort')) {
+            $reasoningEffort = [string]$registryEntry.reasoning_effort
         }
 
         if ($registryEntry.Contains('prompt_transport')) {
@@ -1875,18 +2462,26 @@ function Get-SlotAgentConfig {
         Assert-BridgeProviderCapabilityTransport -ProviderId $agent -PromptTransport $promptTransport -RootPath $RootPath
         Assert-BridgeProviderCapabilityAuthMode -ProviderId $agent -AuthMode $authMode -RootPath $RootPath
         $providerCapability = Resolve-BridgeProviderCapability -ProviderId $agent -RootPath $RootPath -RequireWhenRegistryPresent
+        Assert-BridgeProviderCapabilitySelection -ProviderId $agent -Capability $providerCapability -FieldName 'model_sources' -SelectorName 'model_source' -Value $modelSource
+        Assert-BridgeProviderCapabilitySelection -ProviderId $agent -Capability $providerCapability -FieldName 'reasoning_efforts' -SelectorName 'reasoning_effort' -Value $reasoningEffort
     }
 
     return [PSCustomObject]@{
         SlotId                   = [string]$SlotId
         Agent                    = [string]$agent
         Model                    = [string]$model
+        ModelSource              = [string]$modelSource
+        ReasoningEffort          = [string]$reasoningEffort
         PromptTransport          = [string]$promptTransport
         AuthMode                 = [string]$authMode
         AuthPolicy               = Get-BridgeProviderAuthPolicy -Capability $providerCapability -AuthMode $authMode
         Source                   = [string]$source
         CapabilityAdapter        = [string](Get-BridgeProviderCapabilityValue -Capability $providerCapability -Name 'adapter' -Default '')
         CapabilityCommand        = [string](Get-BridgeProviderCapabilityValue -Capability $providerCapability -Name 'command' -Default '')
+        ModelOptions             = @(Get-BridgeProviderCapabilityValue -Capability $providerCapability -Name 'model_options' -Default @())
+        ModelSources             = @(Get-BridgeProviderCapabilityValue -Capability $providerCapability -Name 'model_sources' -Default @())
+        ReasoningEfforts         = @(Get-BridgeProviderCapabilityValue -Capability $providerCapability -Name 'reasoning_efforts' -Default @())
+        LocalAccessNote          = [string](Get-BridgeProviderCapabilityValue -Capability $providerCapability -Name 'local_access_note' -Default '')
         SupportsParallelRuns     = Get-BridgeProviderCapabilityBoolean -Capability $providerCapability -Name 'supports_parallel_runs'
         SupportsInterrupt        = Get-BridgeProviderCapabilityBoolean -Capability $providerCapability -Name 'supports_interrupt'
         SupportsInterruptDeclared = Test-BridgeProviderCapabilityField -Capability $providerCapability -Name 'supports_interrupt'


### PR DESCRIPTION
## Summary

- add role-level provider, model source, and reasoning-effort settings across Rust and PowerShell provider contracts
- persist desktop runtime role preferences through the Tauri backend instead of browser-only storage
- pass model source and reasoning effort through pane launch, restart, and monitor paths
- default the reviewer role to `gpt-5.3-codex-spark` with `high` effort

## Validation

- `cargo check`
- `cargo test -p winsmux --test operator_cli provider`
- `cargo test -p winsmux --test operator_cli restart`
- `cargo test -p winsmux --test operator_cli runtime_provider_default`
- `cargo test -p winsmux --test operator_cli meta_plan`
- `cargo test -p winsmux-app handle_desktop_json_rpc_routes_runtime_roles_apply`
- `pwsh -NoProfile -Command "Invoke-Pester -Path tests/winsmux-bridge.Tests.ps1 -Output Normal"` passed with 413 tests
- `cmd /c npm run build`
- `git diff --check HEAD~1..HEAD`

## Review status

- Spark review found and the branch now fixes the runtime `provider-default` provider regression.
- Final Spark re-review is pending because the local Codex account hit the `GPT-5.3-Codex-Spark` usage limit until 8:02 PM.
- Keep this PR draft until Spark re-review completes.

Closes #771
