### PR TITLE
fix: preserve source graph whitespace columns

### DIFF
--- a/.githooks/pre-commit-whitelist.ps1
+++ b/.githooks/pre-commit-whitelist.ps1
@@ -78,6 +78,7 @@ $whitelistPatterns = @(
     'winsmux-app/scripts/*.mjs',
     'winsmux-app/package.json',
     'winsmux-app/package-lock.json',
+    'winsmux-app/src/sourceGraph.ts',
     'winsmux-app/src-tauri/Cargo.toml',
     'winsmux-app/src-tauri/Cargo.lock',
     'winsmux-app/src-tauri/tauri.conf.json',

--- a/winsmux-app/package.json
+++ b/winsmux-app/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "test:editor-targets": "node ./scripts/editor-targets-check.mjs",
+    "test:source-graph": "node ./scripts/source-graph-check.mjs",
     "test:viewport-harness": "npm run build && node ./scripts/viewport-harness.mjs",
     "preview": "vite preview",
     "tauri": "tauri"

--- a/winsmux-app/scripts/source-graph-check.mjs
+++ b/winsmux-app/scripts/source-graph-check.mjs
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import ts from "typescript";
+
+async function loadSourceGraphModule() {
+  const sourcePath = path.resolve("src/sourceGraph.ts");
+  const source = await readFile(sourcePath, "utf8");
+  const transpiled = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.ESNext,
+      target: ts.ScriptTarget.ES2020,
+    },
+    fileName: sourcePath,
+  });
+
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "winsmux-source-graph-"));
+  const modulePath = path.join(tempDir, "sourceGraph.mjs");
+  await writeFile(modulePath, transpiled.outputText, "utf8");
+
+  try {
+    return await import(pathToFileURL(modulePath).href);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+const {
+  getSourceGraphLaneKind,
+  normalizeSourceGraphTokens,
+} = await loadSourceGraphModule();
+
+assert.deepEqual(normalizeSourceGraphTokens("* |"), ["*", " ", "|"]);
+assert.deepEqual(normalizeSourceGraphTokens("| * |"), ["|", " ", "*", " ", "|"]);
+assert.deepEqual(normalizeSourceGraphTokens("|\u00a0*"), ["|", "\u00a0", "*"]);
+assert.deepEqual(normalizeSourceGraphTokens("* | | | |", 6), ["*", " ", "|", " ", "|", " "]);
+assert.deepEqual(normalizeSourceGraphTokens("      *", 6), [" ", " ", " ", " ", " ", " "]);
+assert.deepEqual(normalizeSourceGraphTokens("    "), ["*"]);
+
+assert.equal(getSourceGraphLaneKind(" "), "empty");
+assert.equal(getSourceGraphLaneKind("\u00a0"), "empty");
+assert.equal(getSourceGraphLaneKind("*"), "node");
+assert.equal(getSourceGraphLaneKind("|"), "vertical");
+
+console.log("source-graph-check: ok");

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -30,6 +30,7 @@ import {
   subscribeToPtyOutput,
   writePtyData,
 } from "./ptyClient";
+import { getSourceGraphLaneKind, normalizeSourceGraphTokens, sourceGraphMaxLanes } from "./sourceGraph";
 
 interface PaneEntry {
   terminal: Terminal;
@@ -2784,36 +2785,9 @@ const sourceGraphSvgNamespace = "http://www.w3.org/2000/svg";
 const sourceGraphLaneStep = 8;
 const sourceGraphLaneOffset = 4;
 const sourceGraphRowHeight = 34;
-const sourceGraphMaxLanes = 6;
 
 function getSourceGraphLaneX(laneIndex: number) {
   return sourceGraphLaneOffset + laneIndex * sourceGraphLaneStep;
-}
-
-function normalizeSourceGraphTokens(symbols: string) {
-  const tokens = Array.from(symbols.trimEnd() || "*")
-    .filter((symbol) => symbol.trim().length > 0)
-    .slice(0, sourceGraphMaxLanes);
-  return tokens.length > 0 ? tokens : ["*"];
-}
-
-function getSourceGraphLaneKind(symbol: string) {
-  if (symbol === "*" || symbol === "o") {
-    return "node";
-  }
-  if (symbol === "|") {
-    return "vertical";
-  }
-  if (symbol === "/") {
-    return "diagonal-left";
-  }
-  if (symbol === "\\") {
-    return "diagonal-right";
-  }
-  if (symbol === "_" || symbol === "-") {
-    return "horizontal";
-  }
-  return symbol.trim().length > 0 ? "connector" : "empty";
 }
 
 function appendSourceGraphLine(

--- a/winsmux-app/src/sourceGraph.ts
+++ b/winsmux-app/src/sourceGraph.ts
@@ -1,0 +1,43 @@
+export const sourceGraphMaxLanes = 6;
+
+export type SourceGraphLaneKind =
+  | "node"
+  | "vertical"
+  | "diagonal-left"
+  | "diagonal-right"
+  | "horizontal"
+  | "connector"
+  | "empty";
+
+export function isSourceGraphColumnPlaceholder(symbol: string) {
+  return symbol.trim().length === 0;
+}
+
+export function normalizeSourceGraphTokens(symbols: string, maxLanes = sourceGraphMaxLanes) {
+  const boundedMaxLanes = Math.max(0, maxLanes);
+  const graphSymbols = symbols.trimEnd();
+  if (!graphSymbols) {
+    return ["*"];
+  }
+  const tokens = Array.from(graphSymbols).slice(0, boundedMaxLanes);
+  return tokens.length > 0 ? tokens : ["*"];
+}
+
+export function getSourceGraphLaneKind(symbol: string): SourceGraphLaneKind {
+  if (symbol === "*" || symbol === "o") {
+    return "node";
+  }
+  if (symbol === "|") {
+    return "vertical";
+  }
+  if (symbol === "/") {
+    return "diagonal-left";
+  }
+  if (symbol === "\\") {
+    return "diagonal-right";
+  }
+  if (symbol === "_" || symbol === "-") {
+    return "horizontal";
+  }
+  return isSourceGraphColumnPlaceholder(symbol) ? "empty" : "connector";
+}


### PR DESCRIPTION
## Summary
- Preserve space and NBSP graph columns when normalizing source-control graph symbols.
- Extract source graph normalization into a small tested module.
- Add a focused source graph fixture check for branched rows such as `* |` and `| * |`.

## Validation
- `cmd /c npm run test:source-graph`
- `cmd /c npm run build`
- `git diff --check`
- `codex exec --profile review review --uncommitted --title "TASK-439 source graph whitespace"`
- `pwsh -NoProfile -File scripts\audit-public-surface.ps1`
- `pwsh -NoProfile -File scripts\git-guard.ps1 -Mode full`

Closes #777
