### PR TITLE
Clear stale setup wizard model overrides

### DIFF
--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -13064,7 +13064,7 @@ Describe 'operator startup restore contract docs' {
         $setupWizardContent | Should -Match 'AI agent provider'
         $setupWizardContent | Should -Match 'Test-SetupWizardAgentProvider'
         $setupWizardContent | Should -Match 'provider-capabilities\.json first'
-        $setupWizardContent | Should -Match "(?s)if \(-not \[string\]::IsNullOrWhiteSpace\(\`$model\)\) \{\s*Set-WinsmuxOption -WinsmuxBin \`$winsmuxBin -OptionName '@bridge-model' -OptionValue \`$model"
+        $setupWizardContent | Should -Match "(?s)if \(\[string\]::IsNullOrWhiteSpace\(\`$model\)\) \{\s*Clear-WinsmuxOption -WinsmuxBin \`$winsmuxBin -OptionName '@bridge-model'\s*\} else \{\s*Set-WinsmuxOption -WinsmuxBin \`$winsmuxBin -OptionName '@bridge-model' -OptionValue \`$model"
         $setupWizardContent | Should -Not -Match 'AI agent CLI \(codex/claude\)'
         $setupWizardContent | Should -Not -Match "Please enter 'codex' or 'claude'\."
         $setupWizardContent | Should -Not -Match 'Tried: winsmux, pmux, tmux'
@@ -13072,6 +13072,15 @@ Describe 'operator startup restore contract docs' {
         $agentMonitorContent | Should -Not -Match 'Tried: winsmux, pmux, tmux'
         $watchdogContent | Should -Not -Match 'Tried: winsmux, pmux, tmux'
         $orchestraStartContent | Should -Not -Match 'Tried: winsmux, pmux, tmux'
+    }
+
+    It 'clears stale setup wizard model overrides when provider default is selected' {
+        $setupWizardPath = Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\setup-wizard.ps1'
+        $setupWizardContent = Get-Content -Path $setupWizardPath -Raw -Encoding UTF8
+
+        $setupWizardContent | Should -Match 'function Clear-WinsmuxOption'
+        $setupWizardContent | Should -Match 'set-option -gu \$OptionName'
+        $setupWizardContent | Should -Match "(?s)if \(\[string\]::IsNullOrWhiteSpace\(\`$model\)\) \{\s*Clear-WinsmuxOption -WinsmuxBin \`$winsmuxBin -OptionName '@bridge-model'"
     }
 
     It 'keeps the legacy orchestra prompt provider-neutral' {

--- a/winsmux-core/scripts/setup-wizard.ps1
+++ b/winsmux-core/scripts/setup-wizard.ps1
@@ -153,6 +153,15 @@ function Set-WinsmuxOption {
     & $WinsmuxBin set-option -g $OptionName $OptionValue | Out-Null
 }
 
+function Clear-WinsmuxOption {
+    param(
+        [Parameter(Mandatory = $true)][string]$WinsmuxBin,
+        [Parameter(Mandatory = $true)][string]$OptionName
+    )
+
+    & $WinsmuxBin set-option -gu $OptionName | Out-Null
+}
+
 function Set-GitHubTokenVault {
     param([Parameter(Mandatory = $true)][string]$BridgeCommand)
 
@@ -219,7 +228,9 @@ if ($externalOperator) {
 $storeVault = Read-YesNo -Prompt 'Store GH_TOKEN in the winsmux vault?' -Default $false
 
 Set-WinsmuxOption -WinsmuxBin $winsmuxBin -OptionName '@bridge-agent' -OptionValue $agentCli
-if (-not [string]::IsNullOrWhiteSpace($model)) {
+if ([string]::IsNullOrWhiteSpace($model)) {
+    Clear-WinsmuxOption -WinsmuxBin $winsmuxBin -OptionName '@bridge-model'
+} else {
     Set-WinsmuxOption -WinsmuxBin $winsmuxBin -OptionName '@bridge-model' -OptionValue $model
 }
 Set-WinsmuxOption -WinsmuxBin $winsmuxBin -OptionName '@bridge-external-operator' -OptionValue $(if ($externalOperator) { 'on' } else { 'off' })


### PR DESCRIPTION
## Summary

- Clear stale global `@bridge-model` values when the setup wizard keeps the provider default model.
- Add coverage for rerunning the setup wizard with an existing model override and a blank model input.

## Validation

- `Invoke-Pester -Path tests\winsmux-bridge.Tests.ps1 -FullName '*clears stale setup wizard model overrides*' -Output Detailed`
- `Invoke-Pester -Path tests\winsmux-bridge.Tests.ps1 -FullName '*keeps operator-facing script errors pinned*' -Output Detailed`
- `git diff --check`
- `pwsh -NoProfile -File scripts\audit-public-surface.ps1`
- `pwsh -NoProfile -File scripts\git-guard.ps1 -Mode full`
- `codex exec --profile review review --uncommitted --title "TASK-442 clear stale setup model"`

Closes #780
