### PR TITLE
fix: summarize low-count pwsh startup evidence

### DIFF
--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -6556,6 +6556,60 @@ Describe 'doctor bridge config metadata check' {
             $env:WINSMUX_DOCTOR_POWERSHELL_PROCESS_WARN_THRESHOLD = $originalValue
         }
     }
+
+    It 'summarizes low-count PowerShell startup evidence without leaking command lines or process ids' {
+        $protectedIds = [System.Collections.Generic.HashSet[int]]::new()
+        $snapshot = [pscustomobject]@{
+            Processes = @(
+                [pscustomobject]@{ ProcessId = 2101; ParentProcessId = 0; Name = 'Code.exe'; CommandLine = 'Code.exe' }
+                [pscustomobject]@{ ProcessId = 2102; ParentProcessId = 0; Name = 'WindowsTerminal.exe'; CommandLine = 'WindowsTerminal.exe' }
+                [pscustomobject]@{ ProcessId = 2103; ParentProcessId = 0; Name = 'codex.exe'; CommandLine = 'codex.exe' }
+                [pscustomobject]@{ ProcessId = 2201; ParentProcessId = 2101; Name = 'pwsh.exe'; CommandLine = 'pwsh -NoProfile -Command secret-value' }
+                [pscustomobject]@{ ProcessId = 2202; ParentProcessId = 2102; Name = 'pwsh.exe'; CommandLine = 'pwsh -NoLogo' }
+                [pscustomobject]@{ ProcessId = 2203; ParentProcessId = 2103; Name = 'powershell.exe'; CommandLine = 'powershell -NoProfile' }
+            )
+            ById = @{
+                2101 = [pscustomobject]@{ ProcessId = 2101; ParentProcessId = 0; Name = 'Code.exe'; CommandLine = 'Code.exe' }
+                2102 = [pscustomobject]@{ ProcessId = 2102; ParentProcessId = 0; Name = 'WindowsTerminal.exe'; CommandLine = 'WindowsTerminal.exe' }
+                2103 = [pscustomobject]@{ ProcessId = 2103; ParentProcessId = 0; Name = 'codex.exe'; CommandLine = 'codex.exe' }
+                2201 = [pscustomobject]@{ ProcessId = 2201; ParentProcessId = 2101; Name = 'pwsh.exe'; CommandLine = 'pwsh -NoProfile -Command secret-value' }
+                2202 = [pscustomobject]@{ ProcessId = 2202; ParentProcessId = 2102; Name = 'pwsh.exe'; CommandLine = 'pwsh -NoLogo' }
+                2203 = [pscustomobject]@{ ProcessId = 2203; ParentProcessId = 2103; Name = 'powershell.exe'; CommandLine = 'powershell -NoProfile' }
+            }
+            SupportsCommandLine = $true
+        }
+
+        $result = New-PowerShellStartupEvidenceResult -Snapshot $snapshot -ProtectedIds $protectedIds -WarnThreshold 100 -SmokeStatus pass -SmokeDetail '7.5.4'
+
+        $result.Status | Should -Be 'pass'
+        $result.Label | Should -Be 'PowerShell startup evidence'
+        $result.Detail | Should -Match 'pwsh_count=3'
+        $result.Detail | Should -Match 'count_state=below_threshold'
+        $result.Detail | Should -Match 'bare_pwsh=pass'
+        $result.Detail | Should -Match 'codex=1'
+        $result.Detail | Should -Match 'vscode=1'
+        $result.Detail | Should -Match 'windows-terminal=1'
+        $result.Detail | Should -Match 'command_lines=omitted'
+        $result.Detail | Should -Not -Match 'secret-value'
+        $result.Detail | Should -Not -Match '2201'
+    }
+
+    It 'warns in startup evidence when the bare PowerShell smoke check fails' {
+        $protectedIds = [System.Collections.Generic.HashSet[int]]::new()
+        $snapshot = [pscustomobject]@{
+            Processes = @()
+            ById = @{}
+            SupportsCommandLine = $true
+        }
+
+        $result = New-PowerShellStartupEvidenceResult -Snapshot $snapshot -ProtectedIds $protectedIds -WarnThreshold 100 -SmokeStatus fail -SmokeDetail 'pwsh exited with code 3221225794'
+
+        $result.Status | Should -Be 'warn'
+        $result.Label | Should -Be 'PowerShell startup evidence'
+        $result.Detail | Should -Match 'pwsh_count=0'
+        $result.Detail | Should -Match 'bare_pwsh=fail'
+        $result.Detail | Should -Match '3221225794'
+    }
 }
 
 Describe 'worker isolation diagnostics' {

--- a/winsmux-core/scripts/doctor.ps1
+++ b/winsmux-core/scripts/doctor.ps1
@@ -477,6 +477,85 @@ function New-PowerShellProcessPressureResult {
     return New-DoctorResult -Status pass -Label 'PowerShell process pressure' -Detail "$count found"
 }
 
+function Get-DoctorProcessParentCategory {
+    param(
+        [Parameter(Mandatory = $true)]$Snapshot,
+        [Parameter(Mandatory = $true)]$Process
+    )
+
+    $parentId = [int]$Process.ParentProcessId
+    if ($parentId -le 0 -or -not $Snapshot.ById.ContainsKey($parentId)) {
+        return 'missing-parent'
+    }
+
+    $parent = $Snapshot.ById[$parentId]
+    $name = Get-DoctorNormalizedProcessName -Name $parent.Name
+    $commandLine = [string]$parent.CommandLine
+
+    if ($name -in @('code', 'code-insiders')) {
+        return 'vscode'
+    }
+    if ($name -in @('windowsterminal', 'wt')) {
+        return 'windows-terminal'
+    }
+    if ($commandLine.IndexOf('WindowsTerminal', [System.StringComparison]::OrdinalIgnoreCase) -ge 0) {
+        return 'windows-terminal'
+    }
+    if ($name -eq 'codex') {
+        return 'codex'
+    }
+    if ($name -in @('pwsh', 'powershell')) {
+        return 'powershell'
+    }
+    if ($name -in @('conhost', 'openconsole')) {
+        return 'console-host'
+    }
+
+    return 'other'
+}
+
+function New-PowerShellStartupEvidenceResult {
+    param(
+        [Parameter(Mandatory = $true)]$Snapshot,
+        [Parameter(Mandatory = $true)]$ProtectedIds,
+        [Parameter(Mandatory = $true)][int]$WarnThreshold,
+        [Parameter(Mandatory = $true)][ValidateSet('pass', 'fail')][string]$SmokeStatus,
+        [Parameter(Mandatory = $true)][string]$SmokeDetail
+    )
+
+    $count = 0
+    $categoryCounts = @{}
+    foreach ($process in $Snapshot.Processes) {
+        $processId = [int]$process.ProcessId
+        if ($ProtectedIds.Contains($processId)) {
+            continue
+        }
+
+        $name = Get-DoctorNormalizedProcessName -Name $process.Name
+        if ($name -notin @('pwsh', 'powershell')) {
+            continue
+        }
+
+        $count++
+        $category = Get-DoctorProcessParentCategory -Snapshot $Snapshot -Process $process
+        if (-not $categoryCounts.ContainsKey($category)) {
+            $categoryCounts[$category] = 0
+        }
+        $categoryCounts[$category]++
+    }
+
+    $categoryText = 'none'
+    if ($categoryCounts.Count -gt 0) {
+        $categoryText = (@($categoryCounts.Keys) | Sort-Object | ForEach-Object { "$_=$($categoryCounts[$_])" }) -join ','
+    }
+
+    $countState = if ($count -ge $WarnThreshold) { 'at_or_above_threshold' } else { 'below_threshold' }
+    $status = if ($SmokeStatus -eq 'fail') { 'warn' } else { 'pass' }
+    $detail = "pwsh_count=$count; count_state=$countState; parent_categories=$categoryText; bare_pwsh=$SmokeStatus; smoke_detail=$SmokeDetail; scoped_cleanup=close related VS Code, Windows Terminal, or Codex shells first; command_lines=omitted"
+
+    return New-DoctorResult -Status $status -Label 'PowerShell startup evidence' -Detail $detail
+}
+
 function Test-PowerShellProcessPressureCheck {
     $snapshot = Get-DoctorProcessSnapshot
     $protectedIds = @(Get-DoctorAncestorProcessIds -Snapshot $snapshot -ProcessId $PID)
@@ -485,10 +564,13 @@ function Test-PowerShellProcessPressureCheck {
     return New-PowerShellProcessPressureResult -Snapshot $snapshot -ProtectedIds $protectedIds -WarnThreshold $warnThreshold
 }
 
-function Test-PowerShellStartupHealthCheck {
+function Invoke-DoctorPowerShellStartupSmoke {
     $command = Get-Command pwsh -ErrorAction SilentlyContinue | Select-Object -First 1
     if ($null -eq $command) {
-        return New-DoctorResult -Status fail -Label 'PowerShell startup health' -Detail 'pwsh was not found on PATH'
+        return [PSCustomObject]@{
+            Status = 'fail'
+            Detail = 'pwsh was not found on PATH'
+        }
     }
 
     $pwshPath = $command.Path
@@ -500,7 +582,10 @@ function Test-PowerShellStartupHealthCheck {
         $output = & $pwshPath -NoProfile -NoLogo -Command '$PSVersionTable.PSVersion.ToString()' 2>&1
         $exitCode = $LASTEXITCODE
     } catch {
-        return New-DoctorResult -Status fail -Label 'PowerShell startup health' -Detail $_.Exception.Message
+        return [PSCustomObject]@{
+            Status = 'fail'
+            Detail = $_.Exception.Message
+        }
     }
 
     $message = (@($output) | ForEach-Object { $_.ToString().Trim() } | Where-Object { $_ }) -join '; '
@@ -512,7 +597,10 @@ function Test-PowerShellStartupHealthCheck {
         }
         $message = "$message; check Windows Application event log for pwsh.exe initialization errors"
 
-        return New-DoctorResult -Status fail -Label 'PowerShell startup health' -Detail $message
+        return [PSCustomObject]@{
+            Status = 'fail'
+            Detail = $message
+        }
     }
 
     if ([string]::IsNullOrWhiteSpace($message)) {
@@ -521,7 +609,24 @@ function Test-PowerShellStartupHealthCheck {
         $message = "$message ($pwshPath)"
     }
 
-    return New-DoctorResult -Status pass -Label 'PowerShell startup health' -Detail $message
+    return [PSCustomObject]@{
+        Status = 'pass'
+        Detail = $message
+    }
+}
+
+function Test-PowerShellStartupHealthCheck {
+    $smoke = Invoke-DoctorPowerShellStartupSmoke
+    return New-DoctorResult -Status $smoke.Status -Label 'PowerShell startup health' -Detail $smoke.Detail
+}
+
+function Test-PowerShellStartupEvidenceCheck {
+    $snapshot = Get-DoctorProcessSnapshot
+    $protectedIds = @(Get-DoctorAncestorProcessIds -Snapshot $snapshot -ProcessId $PID)
+    $warnThreshold = Get-DoctorPowerShellProcessWarnThreshold
+    $smoke = Invoke-DoctorPowerShellStartupSmoke
+
+    return New-PowerShellStartupEvidenceResult -Snapshot $snapshot -ProtectedIds $protectedIds -WarnThreshold $warnThreshold -SmokeStatus $smoke.Status -SmokeDetail $smoke.Detail
 }
 
 function Test-BridgeConfigCheck {
@@ -615,6 +720,7 @@ if (-not $functionsOnly) {
         Test-ZombieProcessesCheck
         Test-PowerShellProcessPressureCheck
         Test-PowerShellStartupHealthCheck
+        Test-PowerShellStartupEvidenceCheck
         Test-BridgeConfigCheck
         Test-BridgeConfigMetadataCheck
         Test-HookProfileCheck


### PR DESCRIPTION
## Summary

- Add a `PowerShell startup evidence` doctor check for low-count `pwsh.exe` startup failures.
- Report `pwsh_count`, threshold state, parent process categories, and bare `pwsh -NoProfile` smoke result without command lines or process IDs.
- Add Pester coverage for safe evidence shape and bare-smoke failure warning.

Closes #782

## Validation

- `Invoke-Pester -Path tests\winsmux-bridge.Tests.ps1 -FullName '*startup evidence*' -Output Detailed`
- `Invoke-Pester -Path tests\winsmux-bridge.Tests.ps1 -FullName '*PowerShell process*' -Output Detailed`
- `pwsh -NoProfile -File winsmux-core\scripts\doctor.ps1`
- `git diff --check`
- `pwsh -NoProfile -File scripts\audit-public-surface.ps1`
- `pwsh -NoProfile -File scripts\git-guard.ps1 -Mode full`
- `codex exec --profile review review --uncommitted --title "TASK-445 low-count pwsh diagnostics"`
