### PR TITLE
fix: focus one worker pane in focus layout

### DIFF
--- a/winsmux-app/index.html
+++ b/winsmux-app/index.html
@@ -329,6 +329,7 @@
             <div id="terminal-toolbar">
               <span><span class="ui-icon" data-icon="▣" aria-hidden="true"></span><span id="workbench-title">Worker panes</span></span>
               <div id="terminal-toolbar-actions">
+                <select id="focused-pane-select" aria-label="Focused worker pane" hidden></select>
                 <button id="workbench-layout-btn" type="button" aria-label="Switch workbench layout">2x2</button>
                 <button id="add-pane-btn" type="button">+ Pane</button>
               </div>

--- a/winsmux-app/scripts/viewport-harness.mjs
+++ b/winsmux-app/scripts/viewport-harness.mjs
@@ -111,6 +111,17 @@ function boxesOverlap(a, b) {
   );
 }
 
+async function runStep(name, action) {
+  try {
+    await action();
+  } catch (error) {
+    if (error instanceof Error) {
+      error.message = `${name}: ${error.message}`;
+    }
+    throw error;
+  }
+}
+
 async function assertFullyVisible(page, selector) {
   await page.locator(selector).scrollIntoViewIfNeeded().catch(() => {});
   const box = await getBox(page, selector);
@@ -387,7 +398,7 @@ async function assertNarrowSettingsRoundtrip(page, returnSelector) {
 async function assertTerminalDrawerWithSourceContext(page, returnSelector, extraSelector) {
   await ensureWorkbenchOpen(page);
   await page.locator("#terminal-drawer").waitFor({ state: "visible" });
-  await assertButtonVisible(page, "#add-pane-btn");
+  await assertFullyVisible(page, "#add-pane-btn");
   await assertHorizontallyVisible(page, "#terminal-drawer");
   await page.locator("#panes-container .pane").first().waitFor({ state: "visible" });
   await page.locator(returnSelector).waitFor({ state: "visible" });
@@ -423,10 +434,166 @@ async function assertWorkbenchPaneGrid(page, expectedMin = 4) {
   await ensureWorkbenchOpen(page);
   await assertHorizontallyVisible(page, "#terminal-drawer");
   await assertButtonVisible(page, "#workbench-layout-btn");
-  await assertButtonVisible(page, "#add-pane-btn");
+  await assertFullyVisible(page, "#add-pane-btn");
   await page.waitForFunction((minCount) => {
     return document.querySelectorAll("#panes-container .pane").length >= minCount;
   }, expectedMin);
+}
+
+async function getVisibleWorkbenchPaneLabels(page) {
+  return page.evaluate(() => {
+    return Array.from(document.querySelectorAll("#panes-container .pane"))
+      .filter((pane) => pane instanceof HTMLElement && !pane.hidden && getComputedStyle(pane).display !== "none")
+      .map((pane) => pane.querySelector(".pane-label")?.textContent?.trim() ?? "");
+  });
+}
+
+async function getWorkbenchPaneLabels(page) {
+  return page.evaluate(() => {
+    return Array.from(document.querySelectorAll("#panes-container .pane"))
+      .map((pane) => pane.querySelector(".pane-label")?.textContent?.trim() ?? "");
+  });
+}
+
+async function assertVisibleWorkbenchPaneCount(page, expectedCount, label) {
+  try {
+    await page.waitForFunction((count) => {
+      return Array.from(document.querySelectorAll("#panes-container .pane"))
+        .filter((pane) => pane instanceof HTMLElement && !pane.hidden && getComputedStyle(pane).display !== "none")
+        .length === count;
+    }, expectedCount);
+  } catch (error) {
+    const visibleLabels = await getVisibleWorkbenchPaneLabels(page).catch(() => []);
+    const paneLabels = await getWorkbenchPaneLabels(page).catch(() => []);
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `${label} expected ${expectedCount} visible panes, visible: ${visibleLabels.join(", ") || "(none)"}, all: ${paneLabels.join(", ") || "(none)"}. ${reason}`,
+    );
+  }
+  const labels = await getVisibleWorkbenchPaneLabels(page);
+  if (labels.length !== expectedCount) {
+    throw new Error(`${label} expected ${expectedCount} visible panes, got ${labels.length}`);
+  }
+  return labels;
+}
+
+async function setWorkbenchLayout(page, layout) {
+  for (let attempt = 0; attempt < 4; attempt += 1) {
+    const current = (await page.locator("#workbench-layout-btn").textContent())?.trim();
+    if (current === layout) {
+      return;
+    }
+    await page.click("#workbench-layout-btn");
+  }
+  throw new Error(`Unable to switch workbench layout to ${layout}`);
+}
+
+async function assertWorkbenchLayoutCycle(page) {
+  let visibleLabels;
+
+  await runStep("workbench focus cycle 2x2 initial", async () => {
+    await ensureWorkbenchOpen(page);
+    await setWorkbenchLayout(page, "2x2");
+    await assertVisibleWorkbenchPaneCount(page, 4, "2x2 initial");
+    await page.locator("#menu-layout-status", { hasText: "2x2 · 4 panes" }).waitFor();
+  });
+
+  await runStep("workbench focus cycle 3x2", async () => {
+    await setWorkbenchLayout(page, "3x2");
+    await assertVisibleWorkbenchPaneCount(page, 6, "3x2");
+    await page.locator("#menu-layout-status", { hasText: "3x2 · 6 panes" }).waitFor();
+  });
+
+  await runStep("workbench focus cycle select worker-6", async () => {
+    await setWorkbenchLayout(page, "focus");
+    visibleLabels = await assertVisibleWorkbenchPaneCount(page, 1, "focus");
+    await page.locator("#focused-pane-select").waitFor({ state: "visible" });
+    await page.locator("#menu-layout-status", { hasText: "focus · 1 pane" }).waitFor();
+
+    await page.selectOption("#focused-pane-select", "worker-6");
+    visibleLabels = await assertVisibleWorkbenchPaneCount(page, 1, "focus worker-6");
+    if (visibleLabels[0] !== "worker-6") {
+      throw new Error(`focus layout selected ${visibleLabels[0]} instead of worker-6`);
+    }
+  });
+
+  await runStep("workbench focus cycle reload worker-6", async () => {
+    await page.reload({ waitUntil: "networkidle" });
+    visibleLabels = await assertVisibleWorkbenchPaneCount(page, 1, "focus worker-6 after reload");
+    if (visibleLabels[0] !== "worker-6") {
+      throw new Error(`focus layout restored ${visibleLabels[0]} instead of worker-6`);
+    }
+    await page.locator("#focused-pane-select").waitFor({ state: "visible" });
+    const restoredFocusedPane = await page.locator("#focused-pane-select").inputValue();
+    if (restoredFocusedPane !== "worker-6") {
+      throw new Error(`focus selector restored ${restoredFocusedPane} instead of worker-6`);
+    }
+  });
+
+  await runStep("workbench focus cycle close worker-6", async () => {
+    await page.locator("#panes-container .pane[data-focused-pane] .pane-close").click();
+    await page.waitForFunction(() => {
+      const labels = Array.from(document.querySelectorAll("#panes-container .pane"))
+        .filter((pane) => pane instanceof HTMLElement && !pane.hidden && getComputedStyle(pane).display !== "none")
+        .map((pane) => pane.querySelector(".pane-label")?.textContent?.trim() ?? "");
+      return labels.length === 1 && labels[0] === "worker-1";
+    });
+    const persistedFocusAfterClose = await page.evaluate(() => {
+      const rawValue = window.localStorage.getItem("winsmux.shell.preferences.v1");
+      return rawValue ? JSON.parse(rawValue).focusedWorkbenchPaneId : null;
+    });
+    if (persistedFocusAfterClose === "worker-6") {
+      throw new Error("focus layout kept closed worker-6 in persisted preferences");
+    }
+
+    await page.reload({ waitUntil: "networkidle" });
+    visibleLabels = await assertVisibleWorkbenchPaneCount(page, 1, "focus after closing worker-6 and reloading");
+    if (visibleLabels[0] !== "worker-1") {
+      throw new Error(`focus layout restored ${visibleLabels[0]} after worker-6 was closed`);
+    }
+    const labelsAfterCloseReload = await getWorkbenchPaneLabels(page);
+    if (labelsAfterCloseReload.includes("worker-6")) {
+      throw new Error("focus layout recreated closed worker-6 after reload");
+    }
+  });
+
+  await runStep("workbench focus cycle 2x2 restored", async () => {
+    await setWorkbenchLayout(page, "2x2");
+    visibleLabels = await assertVisibleWorkbenchPaneCount(page, 4, "2x2 restored");
+    if (visibleLabels.includes("worker-5") || visibleLabels.includes("worker-6")) {
+      throw new Error(`2x2 restored with extra panes visible: ${visibleLabels.join(", ")}`);
+    }
+    await page.locator("#focused-pane-select").waitFor({ state: "hidden" });
+    await page.locator("#menu-layout-status", { hasText: "2x2 · 4 panes" }).waitFor();
+  });
+
+  await runStep("workbench focus cycle stale focus fallback", async () => {
+    await page.evaluate(() => {
+      const key = "winsmux.shell.preferences.v1";
+      const current = JSON.parse(window.localStorage.getItem(key) ?? "{}");
+      window.localStorage.setItem(
+        key,
+        JSON.stringify({
+          ...current,
+          workbenchOpen: true,
+          workbenchLayout: "focus",
+          focusedWorkbenchPaneId: "pane-5",
+        }),
+      );
+    });
+    await page.reload({ waitUntil: "networkidle" });
+    visibleLabels = await assertVisibleWorkbenchPaneCount(page, 1, "focus stale pane id after reload");
+    if (visibleLabels[0] !== "worker-1") {
+      throw new Error(`focus layout restored stale pane id as ${visibleLabels[0]} instead of worker-1`);
+    }
+    const fallbackFocusedPane = await page.locator("#focused-pane-select").inputValue();
+    if (fallbackFocusedPane !== "worker-1") {
+      throw new Error(`focus selector fallback restored ${fallbackFocusedPane} instead of worker-1`);
+    }
+
+    await setWorkbenchLayout(page, "2x2");
+    await assertVisibleWorkbenchPaneCount(page, 4, "2x2 after stale focus fallback");
+  });
 }
 
 async function assertSourceControlChrome(page) {
@@ -496,55 +663,74 @@ async function verifyDesktopViewport(page, previewUrl) {
   await page.setViewportSize({ width: 1440, height: 900 });
   await page.goto(`${previewUrl}${HARNESS_QUERY}`, { waitUntil: "networkidle" });
 
-  await assertHorizontallyVisible(page, "#left-rail");
-  await assertFullyVisible(page, "#conversation-panel");
-  await assertWorkbenchPaneGrid(page);
-  await assertButtonVisible(page, "#send-btn");
-  await assertFullyVisible(page, "#workspace-footer");
-  await assertNoOverlap(page, "#workspace-body", "#workspace-footer");
+  await runStep("desktop initial chrome", async () => {
+    await assertHorizontallyVisible(page, "#left-rail");
+    await assertFullyVisible(page, "#conversation-panel");
+    await assertWorkbenchPaneGrid(page);
+    await assertButtonVisible(page, "#send-btn");
+    await assertFullyVisible(page, "#workspace-footer");
+    await assertNoOverlap(page, "#workspace-body", "#workspace-footer");
+  });
 
-  await page.click("#activity-search-btn");
-  await page.locator("#command-bar-shell").waitFor({ state: "visible" });
-  await assertFullyVisible(page, "#command-bar");
-  await assertButtonVisible(page, "#command-bar-input");
-  await page.keyboard.press("Escape");
-  await page.locator("#command-bar-shell").waitFor({ state: "hidden" });
+  await runStep("desktop command bar", async () => {
+    await page.click("#activity-search-btn");
+    await page.locator("#command-bar-shell").waitFor({ state: "visible" });
+    await assertFullyVisible(page, "#command-bar");
+    await assertButtonVisible(page, "#command-bar-input");
+    await page.keyboard.press("Escape");
+    await page.locator("#command-bar-shell").waitFor({ state: "hidden" });
+  });
 
-  await page.click("#activity-settings-btn");
-  await page.locator("#settings-sheet").waitFor({ state: "visible" });
-  await assertFullyVisible(page, "#settings-sheet");
-  await assertButtonVisible(page, "#close-settings-btn");
-  await page.click("#close-settings-btn");
-  await page.locator("#settings-sheet").waitFor({ state: "hidden" });
+  await runStep("desktop settings sheet", async () => {
+    await page.click("#activity-settings-btn");
+    await page.locator("#settings-sheet").waitFor({ state: "visible" });
+    await assertFullyVisible(page, "#settings-sheet");
+    await assertButtonVisible(page, "#close-settings-btn");
+    await page.click("#close-settings-btn");
+    await page.locator("#settings-sheet").waitFor({ state: "hidden" });
+  });
 
-  await assertSourceControlChrome(page);
-  await assertExplorerFolderExpandsInline(page);
-  await assertExplorerFileOpensMainEditor(page);
-  await ensureContextPanelOpen(page);
-  await openFirstSourceContextEntry(page);
-  await assertEditorPopout(page);
-  await assertCommandBarRoundtrip(page, "#editor-surface");
-  await assertSettingsRoundtrip(page, "#editor-surface");
-  await assertTerminalDrawerWithSourceContext(page, "#editor-surface", "#context-panel");
+  await runStep("desktop editor surface", async () => {
+    await assertSourceControlChrome(page);
+    await assertExplorerFolderExpandsInline(page);
+    await assertExplorerFileOpensMainEditor(page);
+    await ensureContextPanelOpen(page);
+    await openFirstSourceContextEntry(page);
+    await assertEditorPopout(page);
+    await assertCommandBarRoundtrip(page, "#editor-surface");
+    await assertSettingsRoundtrip(page, "#editor-surface");
+    await assertTerminalDrawerWithSourceContext(page, "#editor-surface", "#context-panel");
+  });
 
-  await registerHarnessPreviewTarget(page, `${previewUrl}${HARNESS_QUERY}`);
-  await openHarnessPreviewTarget(page, `${previewUrl}${HARNESS_QUERY}`);
-  await page.locator("#browser-reload-btn").waitFor({ state: "visible" });
-  await assertButtonVisible(page, "#browser-back-btn");
-  await assertButtonVisible(page, "#browser-reload-btn");
-  await assertButtonVisible(page, "#browser-open-btn");
-  await assertHorizontallyVisible(page, "#browser-toolbar");
-  await assertFullyVisible(page, "#browser-frame");
-  await assertToolbarActionStates(page);
-  await assertPreviewPopout(page);
-  await assertCommandBarRoundtrip(page, "#browser-toolbar");
-  await assertSettingsRoundtrip(page, "#browser-toolbar");
+  await runStep("desktop browser surface", async () => {
+    await registerHarnessPreviewTarget(page, `${previewUrl}${HARNESS_QUERY}`);
+    await openHarnessPreviewTarget(page, `${previewUrl}${HARNESS_QUERY}`);
+    await page.locator("#browser-reload-btn").waitFor({ state: "visible" });
+    await assertButtonVisible(page, "#browser-back-btn");
+    await assertButtonVisible(page, "#browser-reload-btn");
+    await assertButtonVisible(page, "#browser-open-btn");
+    await assertHorizontallyVisible(page, "#browser-toolbar");
+    await assertFullyVisible(page, "#browser-frame");
+    await assertToolbarActionStates(page);
+    await assertPreviewPopout(page);
+    await assertCommandBarRoundtrip(page, "#browser-toolbar");
+    await assertSettingsRoundtrip(page, "#browser-toolbar");
+  });
 
-  await assertWorkbenchPaneGrid(page);
-  await assertFullyVisible(page, "#terminal-drawer");
-  await assertHorizontallyVisible(page, "#browser-toolbar");
-  await assertBackToCode(page);
-  await assertHorizontallyVisible(page, "#editor-code");
+  await runStep("desktop workbench layout", async () => {
+    await runStep("desktop workbench grid after browser preview", async () => {
+      await assertWorkbenchPaneGrid(page);
+      await assertFullyVisible(page, "#terminal-drawer");
+      await assertHorizontallyVisible(page, "#browser-toolbar");
+    });
+    await runStep("desktop browser back to code", async () => {
+      await assertBackToCode(page);
+      await assertHorizontallyVisible(page, "#editor-code");
+    });
+    await runStep("desktop workbench focus cycle", async () => {
+      await assertWorkbenchLayoutCycle(page);
+    });
+  });
 }
 
 async function verifyNarrowViewport(page, previewUrl) {
@@ -725,6 +911,10 @@ async function run() {
             "desktop-settings-with-preview",
             "desktop-preview-back-to-code",
             "desktop-terminal-drawer",
+            "desktop-workbench-layout-cycle",
+            "desktop-workbench-focus-persistence",
+            "desktop-workbench-focus-close-persistence",
+            "desktop-workbench-focus-fallback",
             "developer-1366x768",
             "developer-1280x720",
             "tauri-default-800x600",

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -307,6 +307,7 @@ interface ShellPreferenceState extends ThemeState {
   wideContextOpen: boolean;
   workbenchOpen: boolean;
   workbenchLayout: WorkbenchLayoutMode;
+  focusedWorkbenchPaneId: string | null;
 }
 
 interface RuntimeRolePreference {
@@ -421,6 +422,7 @@ let settingsSheetOpen = false;
 let sidebarOpen = true;
 let sidebarMode: SidebarMode = "explorer";
 let workbenchLayout: WorkbenchLayoutMode = "2x2";
+let focusedWorkbenchPaneId: string | null = null;
 let composerImeActive = false;
 let sidebarWidth = 292;
 let workbenchWidth: number | null = null;
@@ -991,6 +993,18 @@ function getPaneDisplayLabel(paneId: string, backendLabel?: string) {
   return paneId.startsWith("worker-") ? paneId : label;
 }
 
+function getWorkbenchPaneOrdinal(paneId: string | null | undefined) {
+  if (!paneId) {
+    return null;
+  }
+  const workerPane = /^worker-(\d+)$/.exec(paneId);
+  if (workerPane) {
+    const ordinal = Number(workerPane[1]);
+    return ordinal >= 1 && ordinal <= 6 ? ordinal : null;
+  }
+  return null;
+}
+
 function createPane(paneId?: string): string {
   const id = paneId || getNextWorkerPaneId();
   const container = document.getElementById("panes-container");
@@ -1078,6 +1092,13 @@ function createPane(paneId?: string): string {
     ptyStarted: false,
     ptyStarting: null,
   });
+  const hasKnownFocusedPane = focusedWorkbenchPaneId && (panes.has(focusedWorkbenchPaneId) || getWorkbenchPaneOrdinal(focusedWorkbenchPaneId) !== null);
+  if (!hasKnownFocusedPane || (!paneId && workbenchLayout === "focus")) {
+    focusedWorkbenchPaneId = id;
+  }
+  if (!paneId && workbenchLayout === "2x2" && panes.size > 4) {
+    workbenchLayout = "3x2";
+  }
   updateWorkbenchControls();
 
   if (shouldAutoStartPane(id)) {
@@ -1178,7 +1199,11 @@ function closePane(id: string) {
 
   entry.container.remove();
   panes.delete(id);
+  if (focusedWorkbenchPaneId === id) {
+    focusedWorkbenchPaneId = null;
+  }
   updateWorkbenchControls();
+  void persistThemeState();
   if (entry.ptyStarted || entry.ptyStarting) {
     void closePtyPane(id)
       .catch((error) => {
@@ -1189,7 +1214,7 @@ function closePane(id: string) {
       });
   }
 
-  panes.forEach((pane) => pane.fitAddon.fit());
+  fitVisibleWorkbenchPanes();
 }
 
 function ensureDefaultWorkbenchPanes() {
@@ -1211,6 +1236,81 @@ function ensureWorkbenchPaneCount(targetCount: number) {
   }
 }
 
+function getWorkbenchPaneIds() {
+  return Array.from(panes.keys());
+}
+
+function getFocusedWorkbenchPaneId() {
+  if (focusedWorkbenchPaneId && panes.has(focusedWorkbenchPaneId)) {
+    return focusedWorkbenchPaneId;
+  }
+  const firstPaneId = getWorkbenchPaneIds()[0] ?? null;
+  const pendingOrdinal = getWorkbenchPaneOrdinal(focusedWorkbenchPaneId);
+  if (pendingOrdinal !== null && panes.size < pendingOrdinal) {
+    return firstPaneId;
+  }
+  if (!focusedWorkbenchPaneId || !panes.has(focusedWorkbenchPaneId)) {
+    focusedWorkbenchPaneId = firstPaneId;
+  }
+  return firstPaneId;
+}
+
+function getWorkbenchPaneCountForLayout() {
+  if (workbenchLayout === "3x2") {
+    return 6;
+  }
+  if (workbenchLayout === "focus") {
+    return Math.max(4, getWorkbenchPaneOrdinal(focusedWorkbenchPaneId) ?? 1);
+  }
+  return 4;
+}
+
+function getVisibleWorkbenchPaneIds() {
+  const paneIds = getWorkbenchPaneIds();
+  if (workbenchLayout === "focus") {
+    const focusedPaneId = getFocusedWorkbenchPaneId();
+    return focusedPaneId ? [focusedPaneId] : [];
+  }
+  return paneIds.slice(0, workbenchLayout === "3x2" ? 6 : 4);
+}
+
+function syncFocusedPaneSelect() {
+  const select = document.getElementById("focused-pane-select") as HTMLSelectElement | null;
+  if (!select) {
+    return;
+  }
+
+  const focusedPaneId = getFocusedWorkbenchPaneId();
+  select.replaceChildren(...getWorkbenchPaneIds().map((paneId) => {
+    const option = document.createElement("option");
+    option.value = paneId;
+    option.textContent = getPaneDisplayLabel(paneId);
+    return option;
+  }));
+  if (focusedPaneId) {
+    select.value = focusedPaneId;
+  }
+  select.hidden = workbenchLayout !== "focus";
+  select.disabled = workbenchLayout !== "focus" || panes.size <= 1;
+}
+
+function syncWorkbenchPaneVisibility() {
+  const visibleIds = new Set(getVisibleWorkbenchPaneIds());
+  panes.forEach((pane, paneId) => {
+    const visible = visibleIds.has(paneId);
+    pane.container.hidden = !visible;
+    pane.container.toggleAttribute("data-focused-pane", workbenchLayout === "focus" && visible);
+  });
+}
+
+function fitVisibleWorkbenchPanes() {
+  panes.forEach((pane) => {
+    if (!pane.container.hidden) {
+      pane.fitAddon.fit();
+    }
+  });
+}
+
 function updateWorkbenchControls() {
   const drawer = document.getElementById("terminal-drawer");
   const addButton = document.getElementById("add-pane-btn") as HTMLButtonElement | null;
@@ -1218,6 +1318,8 @@ function updateWorkbenchControls() {
   const menuLayoutStatus = document.getElementById("menu-layout-status");
 
   drawer?.setAttribute("data-layout", workbenchLayout);
+  syncWorkbenchPaneVisibility();
+  syncFocusedPaneSelect();
   if (addButton) {
     addButton.disabled = panes.size >= 6;
     addButton.textContent = panes.size >= 6 ? getLanguageText("6 panes", "6 ペイン") : getLanguageText("+ Pane", "+ ペイン");
@@ -1230,8 +1332,9 @@ function updateWorkbenchControls() {
     layoutButton.textContent = workbenchLayout;
   }
   if (menuLayoutStatus) {
-    const paneCount = Math.max(panes.size, terminalDrawerOpen ? 4 : panes.size);
-    menuLayoutStatus.textContent = getLanguageText(`${workbenchLayout} · ${paneCount} panes`, `${workbenchLayout}・${paneCount} ペイン`);
+    const paneCount = terminalDrawerOpen ? getVisibleWorkbenchPaneIds().length : panes.size;
+    const paneLabel = paneCount === 1 ? "pane" : "panes";
+    menuLayoutStatus.textContent = getLanguageText(`${workbenchLayout} · ${paneCount} ${paneLabel}`, `${workbenchLayout}・${paneCount} ペイン`);
   }
 }
 
@@ -5172,6 +5275,9 @@ function readStoredShellPreferences(): ShellPreferenceState | null {
     const wideContextOpen = typeof parsed.wideContextOpen === "boolean" ? parsed.wideContextOpen : false;
     const workbenchOpen = typeof parsed.workbenchOpen === "boolean" ? parsed.workbenchOpen : true;
     const workbenchLayout = parsed.workbenchLayout === "3x2" || parsed.workbenchLayout === "focus" ? parsed.workbenchLayout : "2x2";
+    const storedFocusedWorkbenchPaneId = typeof parsed.focusedWorkbenchPaneId === "string" && getWorkbenchPaneOrdinal(parsed.focusedWorkbenchPaneId) !== null
+      ? parsed.focusedWorkbenchPaneId
+      : null;
 
     return {
       theme,
@@ -5186,6 +5292,7 @@ function readStoredShellPreferences(): ShellPreferenceState | null {
       wideContextOpen,
       workbenchOpen,
       workbenchLayout,
+      focusedWorkbenchPaneId: storedFocusedWorkbenchPaneId,
     };
   } catch {
     return null;
@@ -5207,6 +5314,7 @@ function persistThemeState() {
       wideContextOpen: preferredWideContextOpen,
       workbenchOpen: terminalDrawerOpen,
       workbenchLayout,
+      focusedWorkbenchPaneId: focusedWorkbenchPaneId && panes.has(focusedWorkbenchPaneId) ? focusedWorkbenchPaneId : null,
     };
     window.localStorage.setItem(SHELL_PREFERENCES_STORAGE_KEY, JSON.stringify(nextState));
     return true;
@@ -5255,7 +5363,7 @@ function applyWorkbenchWidth(width: number) {
   const handle = document.getElementById("workbench-resizer");
   handle?.setAttribute("aria-valuenow", `${workbenchWidth}`);
   requestAnimationFrame(() => {
-    panes.forEach((pane) => pane.fitAddon.fit());
+    fitVisibleWorkbenchPanes();
   });
 }
 
@@ -5500,8 +5608,8 @@ function applyCodeFontToPanes() {
   const fontFamily = getCodeFontFamily();
   panes.forEach((pane) => {
     pane.terminal.options.fontFamily = fontFamily;
-    pane.fitAddon.fit();
   });
+  fitVisibleWorkbenchPanes();
 }
 
 function renderPreferenceOptions<T extends string>(
@@ -8863,13 +8971,13 @@ function setTerminalDrawer(open: boolean) {
   button.setAttribute("aria-label", open ? getLanguageText("Hide worker panes", "ワーカーペインを隠す") : getLanguageText("Show worker panes", "ワーカーペインを表示"));
 
   if (open) {
-    ensureWorkbenchPaneCount(workbenchLayout === "3x2" ? 6 : 4);
+    ensureWorkbenchPaneCount(getWorkbenchPaneCountForLayout());
   }
 
   updateWorkbenchControls();
   void persistThemeState();
   requestAnimationFrame(() => {
-    panes.forEach((pane) => pane.fitAddon.fit());
+    fitVisibleWorkbenchPanes();
   });
 }
 
@@ -8949,7 +9057,7 @@ function cycleWorkbenchLayout() {
   updateWorkbenchControls();
   void persistThemeState();
   requestAnimationFrame(() => {
-    panes.forEach((pane) => pane.fitAddon.fit());
+    fitVisibleWorkbenchPanes();
   });
 }
 
@@ -10092,6 +10200,7 @@ window.addEventListener("DOMContentLoaded", async () => {
     preferredWideContextOpen = storedShellPreferences.wideContextOpen;
     terminalDrawerOpen = true;
     workbenchLayout = storedShellPreferences.workbenchLayout;
+    focusedWorkbenchPaneId = storedShellPreferences.focusedWorkbenchPaneId;
   }
 
   await subscribeToPtyOutput((payload) => {
@@ -10381,6 +10490,19 @@ window.addEventListener("DOMContentLoaded", async () => {
     cycleWorkbenchLayout();
   });
 
+  document.getElementById("focused-pane-select")?.addEventListener("change", (event) => {
+    const value = (event.currentTarget as HTMLSelectElement).value;
+    if (!panes.has(value)) {
+      return;
+    }
+    focusedWorkbenchPaneId = value;
+    updateWorkbenchControls();
+    void persistThemeState();
+    requestAnimationFrame(() => {
+      fitVisibleWorkbenchPanes();
+    });
+  });
+
   const composer = document.getElementById("composer") as HTMLFormElement | null;
   const composerInput = document.getElementById("composer-input") as HTMLTextAreaElement | null;
   const composerFileInput = document.getElementById("composer-file-input") as HTMLInputElement | null;
@@ -10618,7 +10740,7 @@ window.addEventListener("DOMContentLoaded", async () => {
 
   window.addEventListener("resize", () => {
     syncResponsiveShell();
-    panes.forEach((pane) => pane.fitAddon.fit());
+    fitVisibleWorkbenchPanes();
   });
 
   window.addEventListener("beforeunload", () => {

--- a/winsmux-app/src/styles.css
+++ b/winsmux-app/src/styles.css
@@ -3234,7 +3234,8 @@ body.is-resizing-workbench {
 }
 
 #add-pane-btn,
-#workbench-layout-btn {
+#workbench-layout-btn,
+#focused-pane-select {
   border: 1px solid var(--border-strong);
   background: var(--bg-surface-raised);
   color: var(--text-secondary);
@@ -3244,8 +3245,19 @@ body.is-resizing-workbench {
 }
 
 #add-pane-btn:hover,
-#workbench-layout-btn:hover {
+#workbench-layout-btn:hover,
+#focused-pane-select:hover {
   background: var(--bg-panel);
+}
+
+#focused-pane-select {
+  min-width: 112px;
+  max-width: 152px;
+  font-size: var(--text-xs);
+}
+
+#focused-pane-select[hidden] {
+  display: none;
 }
 
 #panes-container {


### PR DESCRIPTION
## Summary

- Hide non-visible worker panes per layout so `focus` shows one pane and `2x2` shows four panes.
- Add a focused worker selector that appears only in `focus` layout.
- Extend the viewport harness to cover `2x2 -> 3x2 -> focus -> 2x2` and verify hidden extra panes stay out of the main grid.

Closes #784

## Validation

- `cmd /c npm run build`
- `cmd /c node --check scripts\viewport-harness.mjs`
- `cmd /c npm run test:viewport-harness`
- `git diff --check`
- `pwsh -NoProfile -File scripts\audit-public-surface.ps1`
- `pwsh -NoProfile -File scripts\git-guard.ps1 -Mode full`
- `codex exec --profile review review --uncommitted --title "TASK-446 focus workbench layout"`
