### PR TITLE
docs: clarify meta-planning provider capabilities

### DIFF
--- a/core/src/operator_cli.rs
+++ b/core/src/operator_cli.rs
@@ -9894,6 +9894,7 @@ fn write_json<T: Serialize>(value: &T) -> io::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
 
     fn restart_plan(agent: &str, capability_adapter: &str) -> RestartPlan {
         RestartPlan {
@@ -9909,6 +9910,33 @@ mod tests {
             reasoning_effort: default_provider_reasoning_effort(),
             capability_adapter: capability_adapter.to_string(),
             launch_command: "noop".to_string(),
+        }
+    }
+
+    fn test_project_dir(name: &str) -> PathBuf {
+        let suffix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time should be after epoch")
+            .as_nanos();
+        let path =
+            std::env::temp_dir().join(format!("winsmux-{name}-{}-{suffix}", std::process::id()));
+        std::fs::create_dir_all(path.join(".winsmux")).expect("create test project");
+        path
+    }
+
+    fn meta_plan_role(provider: &str, plan_mode: &str) -> MetaPlanRole {
+        MetaPlanRole {
+            role_id: "planner".to_string(),
+            label: "Planner".to_string(),
+            provider: provider.to_string(),
+            model: "provider-default".to_string(),
+            model_source: default_provider_model_source(),
+            reasoning_effort: default_provider_reasoning_effort(),
+            plan_mode: plan_mode.to_string(),
+            read_only: true,
+            review_rounds: 1,
+            capabilities: vec!["planning".to_string()],
+            prompt: "Plan without editing files.".to_string(),
         }
     }
 
@@ -9939,5 +9967,55 @@ mod tests {
             restart_readiness_agent(&restart_plan("custom-agent", "custom-adapter")),
             ""
         );
+    }
+
+    #[test]
+    fn meta_plan_role_uses_provider_capability_metadata_for_future_provider() {
+        let project_dir = test_project_dir("meta-plan-provider-capability");
+        let capability_path = provider_capability_registry_path(&project_dir);
+        std::fs::write(
+            &capability_path,
+            r#"{
+              "version": 1,
+              "providers": {
+                "gemini-planner": {
+                  "adapter": "gemini",
+                  "command": "gemini",
+                  "prompt_transports": ["stdin"],
+                  "supports_file_edit": false,
+                  "supports_consultation": true
+                }
+              }
+            }"#,
+        )
+        .expect("write provider capability registry");
+
+        let role = meta_plan_role("gemini-planner", "read_only_equivalent");
+        validate_meta_plan_role(&project_dir, &role).expect("role should validate");
+        let adapter = meta_plan_provider_adapter(&project_dir, &role).expect("adapter");
+        let command = meta_plan_provider_command(&project_dir, &role).expect("command");
+        let launch = meta_plan_launch_contract(&role, &adapter, &command);
+
+        assert_eq!(adapter, "gemini");
+        assert_eq!(command, "gemini");
+        assert_eq!(launch["provider"], "gemini-planner");
+        assert_eq!(launch["provider_adapter"], "gemini");
+        assert_eq!(launch["read_only_equivalent"], true);
+        assert_eq!(launch["read_only"], true);
+
+        let _ = std::fs::remove_dir_all(project_dir);
+    }
+
+    #[test]
+    fn meta_plan_role_rejects_future_provider_without_capability_metadata() {
+        let project_dir = test_project_dir("meta-plan-missing-provider-capability");
+        let role = meta_plan_role("future-planner", "read_only_equivalent");
+        let error = validate_meta_plan_role(&project_dir, &role).expect_err("role should fail");
+
+        assert!(error
+            .to_string()
+            .contains("must be declared in .winsmux/provider-capabilities.json"));
+
+        let _ = std::fs::remove_dir_all(project_dir);
     }
 }

--- a/docs/meta-planning-layer-design.md
+++ b/docs/meta-planning-layer-design.md
@@ -3,7 +3,7 @@
 ## Status
 
 Phase 0 design has been reviewed for implementation. `v0.24.18` adds the
-CLI-only `winsmux meta-plan` entrypoint for the fixed MVP role set:
+CLI-only `winsmux meta-plan` entrypoint for the MVP seed role set:
 `investigator` and `verifier`.
 
 The command writes role draft artifacts, cross-review artifacts, an integrated
@@ -13,6 +13,9 @@ read-only, and the operator keeps the single approval gate.
 `v0.24.19` adds UTF-8 role YAML loading through `--roles <path>` and supports
 one or two cross-review rounds through `--review-rounds <1|2>`. Role labels and
 prompts may contain Japanese text, while `role_id` remains ASCII for logs.
+The built-in seed remains Claude/Codex for the MVP, but custom role files can
+select future providers when `.winsmux/provider-capabilities.json` declares the
+adapter, launch command, prompt transport, and read-only planning contract.
 
 `v0.24.20` hardens runtime retention. Generated scaffold artifacts keep
 `task_hash` and `prompt_hash` references instead of storing the operator task
@@ -38,7 +41,11 @@ User -> Operator planning session -> specialist planning workers
 ## Constraints
 
 - Windows-native only. Do not require WSL2.
-- ToS-safe worker runtimes only: Claude Code and Codex CLI.
+- The MVP seed uses Claude Code and Codex CLI, but role selection must be
+  capability-driven for custom role files.
+- Providers outside the built-in MVP seed must be declared in
+  `.winsmux/provider-capabilities.json` before they can be used as planning
+  workers.
 - Worker panes must stay read-only and must not leave planning mode.
 - The operator is the only component that may request final user approval.
 - Role names must be configurable per task. Do not build around fixed role pairs.
@@ -123,7 +130,9 @@ Meta-planning must integrate through existing pane control and logging concepts:
 7. The operator requests one user approval for the integrated plan.
 8. Execution remains blocked until that approval exists.
 
-The MVP intentionally skips the Tauri GUI and YAML role editing UI.
+The MVP intentionally skips the Tauri GUI and role editing UI. It does not make
+Claude/Codex a permanent product model; it is the first seed for the
+capability-driven role contract.
 
 ## Audit JSONL Schema Draft
 
@@ -189,10 +198,14 @@ Rules:
 
 - `role_id` must be ASCII and stable for logs.
 - `label` and `prompt` may contain Japanese text.
-- `provider` must be one of the supported official CLIs.
+- `provider` may be `claude` or `codex` for the built-in MVP seed, or a provider
+  id declared in `.winsmux/provider-capabilities.json`.
 - `read_only` must be true for meta-planning workers.
-- `plan_mode` must be `required` for Claude Code or `read_only_equivalent` for
-  Codex until Codex exposes a native plan-mode contract.
+- `plan_mode` must be `required` for Claude-compatible providers and
+  `read_only_equivalent` for non-Claude providers until their capability
+  contract exposes a native plan-mode guarantee.
+- Gemini and future providers are eligible for read-only planning only after
+  their capability metadata declares the provider adapter and launch command.
 
 ## Integrated Plan Format
 
@@ -217,8 +230,6 @@ evidence, not approval surfaces.
 
 ## Open Questions
 
-- Should Codex workers be allowed in Phase 1 MVP if their guarantee is read-only
-  equivalent rather than native plan mode?
 - Should Phase 1 use interactive panes only, or also support non-interactive
   `codex exec --json` collection for planning drafts?
 - Where should role YAML live by default: project `.winsmux/`, external planning

--- a/docs/operator-model.md
+++ b/docs/operator-model.md
@@ -114,6 +114,10 @@ Panes may differ by:
 The current direction is **slot/capability-based orchestration**, not hard-coded vendor roles.
 
 Review is handled by any **review-capable slot**, not by a permanently dedicated reviewer pane.
+Meta-planning follows the same rule: the current Claude/Codex role pair is an
+MVP seed, while custom planning roles should be selected from provider
+capability metadata. The operator remains the only approval owner, and planning
+workers only return read-only drafts or reviews.
 
 ## 4. Public docs vs runtime contracts
 


### PR DESCRIPTION
## Summary

- Clarifies that the built-in Claude/Codex meta-planning role pair is an MVP seed rather than a permanent product model.
- Documents capability-driven custom planning roles through `.winsmux/provider-capabilities.json`.
- Adds Rust coverage for future provider metadata acceptance and missing metadata rejection.

## Validation

- `rustfmt --check core\src\operator_cli.rs`
- `cargo test -p winsmux meta_plan_role`
- `git diff --check`
- `pwsh -NoProfile -File scripts\audit-public-surface.ps1`
- `pwsh -NoProfile -File scripts\git-guard.ps1 -Mode full`

Refs #767
