### PR TITLE
fix: preserve composer and meta-plan contracts

### DIFF
--- a/core/src/operator_cli.rs
+++ b/core/src/operator_cli.rs
@@ -1520,6 +1520,7 @@ fn normalize_provider_capability_entry(
         "model_sources",
         "reasoning_efforts",
     ];
+    let raw_string_array_fields = ["read_only_launch_args"];
     let model_option_fields = ["model_options"];
     let bool_fields = [
         "supports_parallel_runs",
@@ -1537,6 +1538,7 @@ fn normalize_provider_capability_entry(
         if !string_fields.contains(&name)
             && !transport_fields.contains(&name)
             && !string_array_fields.contains(&name)
+            && !raw_string_array_fields.contains(&name)
             && !model_option_fields.contains(&name)
             && !bool_fields.contains(&name)
         {
@@ -1601,6 +1603,28 @@ fn normalize_provider_capability_entry(
                     return Err(invalid_provider_capability_field(name));
                 }
                 normalized_items.push(Value::String(normalized_text));
+            }
+            normalized.insert(field.clone(), Value::Array(normalized_items));
+            continue;
+        }
+
+        if raw_string_array_fields.contains(&name) {
+            let Some(items) = field_value.as_array() else {
+                return Err(invalid_provider_capability_field(name));
+            };
+            if items.is_empty() {
+                return Err(invalid_provider_capability_field(name));
+            }
+            let mut normalized_items = Vec::new();
+            for item in items {
+                let Some(text) = item.as_str() else {
+                    return Err(invalid_provider_capability_field(name));
+                };
+                let trimmed_text = text.trim();
+                if trimmed_text.is_empty() {
+                    return Err(invalid_provider_capability_field(name));
+                }
+                normalized_items.push(Value::String(trimmed_text.to_string()));
             }
             normalized.insert(field.clone(), Value::Array(normalized_items));
             continue;
@@ -2906,6 +2930,20 @@ fn capability_string(capability: Option<&Value>, key: &str) -> String {
         .to_string()
 }
 
+fn capability_string_array(capability: Option<&Value>, key: &str) -> Vec<String> {
+    capability
+        .and_then(|value| value.get(key))
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(Value::as_str)
+                .map(ToString::to_string)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
 fn capability_bool(capability: Option<&Value>, key: &str) -> bool {
     capability
         .and_then(|value| value.get(key))
@@ -3880,6 +3918,12 @@ fn build_meta_plan_run(options: &MetaPlanOptions) -> io::Result<MetaPlanRun> {
         .zip(role_provider_commands.iter())
     {
         let prompt_hash = sha256_hex(role.prompt.as_bytes());
+        let launch_contract = meta_plan_launch_contract(
+            &options.project_dir,
+            role,
+            provider_adapter,
+            provider_command,
+        )?;
         append_meta_plan_audit_record(
             &options.project_dir,
             &options.session_name,
@@ -3899,7 +3943,7 @@ fn build_meta_plan_run(options: &MetaPlanOptions) -> io::Result<MetaPlanRun> {
                 "read_only": role.read_only,
                 "review_rounds": role.review_rounds,
                 "prompt_hash": prompt_hash.clone(),
-                "launch_contract": meta_plan_launch_contract(role, provider_adapter, provider_command),
+                "launch_contract": launch_contract.clone(),
             }),
         )?;
 
@@ -3939,7 +3983,7 @@ fn build_meta_plan_run(options: &MetaPlanOptions) -> io::Result<MetaPlanRun> {
             "capabilities": role.capabilities.clone(),
             "prompt_hash": prompt_hash.clone(),
             "draft_ref": draft_ref.clone(),
-            "launch_contract": meta_plan_launch_contract(role, provider_adapter, provider_command),
+            "launch_contract": launch_contract.clone(),
         }));
     }
 
@@ -4171,6 +4215,9 @@ fn validate_meta_plan_role(project_dir: &Path, role: &MetaPlanRole) -> io::Resul
     if provider_adapter != "claude" && role.plan_mode != "read_only_equivalent" {
         return Err(io::Error::new(io::ErrorKind::InvalidInput, format!("meta-plan role '{}' must use plan_mode: read_only_equivalent for non-Claude providers", role.role_id)));
     }
+    if !matches!(provider_adapter.as_str(), "claude" | "codex" | "gemini") {
+        let _ = meta_plan_provider_read_only_launch_args(project_dir, role, &provider_adapter)?;
+    }
     if !matches!(role.review_rounds, 0 | 1 | 2) {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
@@ -4278,14 +4325,42 @@ fn meta_plan_provider_command(project_dir: &Path, role: &MetaPlanRole) -> io::Re
     Ok(command)
 }
 
+fn meta_plan_provider_read_only_launch_args(
+    project_dir: &Path,
+    role: &MetaPlanRole,
+    provider_adapter: &str,
+) -> io::Result<Vec<String>> {
+    if matches!(provider_adapter, "claude" | "codex" | "gemini") {
+        return Ok(Vec::new());
+    }
+
+    let Some(capability) = meta_plan_provider_capability(project_dir, role)? else {
+        return Ok(Vec::new());
+    };
+
+    let args = capability_string_array(Some(&capability), "read_only_launch_args");
+    if args.is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "meta-plan role '{}' provider '{}' with adapter '{}' must declare read_only_launch_args in .winsmux/provider-capabilities.json",
+                role.role_id, role.provider, provider_adapter
+            ),
+        ));
+    }
+
+    Ok(args)
+}
+
 fn meta_plan_launch_contract(
+    project_dir: &Path,
     role: &MetaPlanRole,
     provider_adapter: &str,
     provider_command: &str,
-) -> Value {
+) -> io::Result<Value> {
     let model_override = provider_model_override(&role.model, &role.model_source);
     let mut args = Vec::new();
-    match provider_adapter {
+    let launch_contract = match provider_adapter {
         "claude" => {
             if model_override {
                 args.push("--model".to_string());
@@ -4359,20 +4434,24 @@ fn meta_plan_launch_contract(
                 "read_only": role.read_only,
             })
         }
-        _ => json!({
-            "provider": role.provider.clone(),
-            "provider_adapter": provider_adapter,
-            "command": provider_command,
-            "model": role.model.clone(),
-            "model_source": role.model_source.clone(),
-            "reasoning_effort": role.reasoning_effort.clone(),
-            "model_override": model_override,
-            "args": [],
-            "plan_mode_enforced": false,
-            "read_only_equivalent": true,
-            "read_only": role.read_only,
-        }),
-    }
+        _ => {
+            args = meta_plan_provider_read_only_launch_args(project_dir, role, provider_adapter)?;
+            json!({
+                "provider": role.provider.clone(),
+                "provider_adapter": provider_adapter,
+                "command": provider_command,
+                "model": role.model.clone(),
+                "model_source": role.model_source.clone(),
+                "reasoning_effort": role.reasoning_effort.clone(),
+                "model_override": model_override,
+                "args": args,
+                "plan_mode_enforced": false,
+                "read_only_equivalent": true,
+                "read_only": role.read_only,
+            })
+        }
+    };
+    Ok(launch_contract)
 }
 
 fn render_meta_plan_role_draft(
@@ -9994,7 +10073,8 @@ mod tests {
         validate_meta_plan_role(&project_dir, &role).expect("role should validate");
         let adapter = meta_plan_provider_adapter(&project_dir, &role).expect("adapter");
         let command = meta_plan_provider_command(&project_dir, &role).expect("command");
-        let launch = meta_plan_launch_contract(&role, &adapter, &command);
+        let launch =
+            meta_plan_launch_contract(&project_dir, &role, &adapter, &command).expect("launch");
 
         assert_eq!(adapter, "gemini");
         assert_eq!(command, "gemini");
@@ -10015,6 +10095,77 @@ mod tests {
         assert!(error
             .to_string()
             .contains("must be declared in .winsmux/provider-capabilities.json"));
+
+        let _ = std::fs::remove_dir_all(project_dir);
+    }
+
+    #[test]
+    fn meta_plan_role_rejects_custom_adapter_without_read_only_launch_args() {
+        let project_dir = test_project_dir("meta-plan-custom-provider-no-read-only-args");
+        let capability_path = provider_capability_registry_path(&project_dir);
+        std::fs::write(
+            &capability_path,
+            r#"{
+              "version": 1,
+              "providers": {
+                "future-planner": {
+                  "adapter": "future-cli",
+                  "command": "future",
+                  "prompt_transports": ["stdin"],
+                  "supports_file_edit": false,
+                  "supports_consultation": true
+                }
+              }
+            }"#,
+        )
+        .expect("write provider capability registry");
+
+        let role = meta_plan_role("future-planner", "read_only_equivalent");
+        let error = validate_meta_plan_role(&project_dir, &role).expect_err("role should fail");
+
+        assert!(error
+            .to_string()
+            .contains("must declare read_only_launch_args"));
+
+        let _ = std::fs::remove_dir_all(project_dir);
+    }
+
+    #[test]
+    fn meta_plan_role_uses_custom_adapter_read_only_launch_args() {
+        let project_dir = test_project_dir("meta-plan-custom-provider-read-only-args");
+        let capability_path = provider_capability_registry_path(&project_dir);
+        std::fs::write(
+            &capability_path,
+            r#"{
+              "version": 1,
+              "providers": {
+                "future-planner": {
+                  "adapter": "future-cli",
+                  "command": "future",
+                  "prompt_transports": ["stdin"],
+                  "read_only_launch_args": ["--read-only", "--no-write"],
+                  "supports_file_edit": false,
+                  "supports_consultation": true
+                }
+              }
+            }"#,
+        )
+        .expect("write provider capability registry");
+
+        let role = meta_plan_role("future-planner", "read_only_equivalent");
+        validate_meta_plan_role(&project_dir, &role).expect("role should validate");
+        let adapter = meta_plan_provider_adapter(&project_dir, &role).expect("adapter");
+        let command = meta_plan_provider_command(&project_dir, &role).expect("command");
+        let launch =
+            meta_plan_launch_contract(&project_dir, &role, &adapter, &command).expect("launch");
+
+        assert_eq!(adapter, "future-cli");
+        assert_eq!(command, "future");
+        assert_eq!(launch["provider"], "future-planner");
+        assert_eq!(launch["provider_adapter"], "future-cli");
+        assert_eq!(launch["args"], json!(["--read-only", "--no-write"]));
+        assert_eq!(launch["read_only_equivalent"], true);
+        assert_eq!(launch["read_only"], true);
 
         let _ = std::fs::remove_dir_all(project_dir);
     }

--- a/docs/meta-planning-layer-design.md
+++ b/docs/meta-planning-layer-design.md
@@ -15,7 +15,8 @@ one or two cross-review rounds through `--review-rounds <1|2>`. Role labels and
 prompts may contain Japanese text, while `role_id` remains ASCII for logs.
 The built-in seed remains Claude/Codex for the MVP, but custom role files can
 select future providers when `.winsmux/provider-capabilities.json` declares the
-adapter, launch command, prompt transport, and read-only planning contract.
+adapter, launch command, prompt transport, and a known read-only launch
+contract.
 
 `v0.24.20` hardens runtime retention. Generated scaffold artifacts keep
 `task_hash` and `prompt_hash` references instead of storing the operator task
@@ -46,6 +47,9 @@ User -> Operator planning session -> specialist planning workers
 - Providers outside the built-in MVP seed must be declared in
   `.winsmux/provider-capabilities.json` before they can be used as planning
   workers.
+- Custom provider adapters outside the known Claude, Codex, and Gemini launch
+  contracts must declare `read_only_launch_args`, which winsmux records in the
+  launch contract before the provider is eligible for planning work.
 - Worker panes must stay read-only and must not leave planning mode.
 - The operator is the only component that may request final user approval.
 - Role names must be configurable per task. Do not build around fixed role pairs.
@@ -204,8 +208,9 @@ Rules:
 - `plan_mode` must be `required` for Claude-compatible providers and
   `read_only_equivalent` for non-Claude providers until their capability
   contract exposes a native plan-mode guarantee.
-- Gemini and future providers are eligible for read-only planning only after
-  their capability metadata declares the provider adapter and launch command.
+- Gemini is eligible through its known plan-approval launch contract. Future
+  custom adapters are eligible only after their metadata declares adapter,
+  command, prompt transport, and explicit `read_only_launch_args`.
 
 ## Integrated Plan Format
 

--- a/winsmux-app/scripts/viewport-harness.mjs
+++ b/winsmux-app/scripts/viewport-harness.mjs
@@ -560,8 +560,13 @@ async function assertComposerSessionControls(page, previewUrl) {
   await page.locator("#composer-model-menu .composer-session-option", { hasText: "Max" }).click();
   await page.locator("#composer-model-menu .composer-session-option", { hasText: "Sonnet 4.6" }).click();
   await page.locator(".composer-session-trigger-model", { hasText: "Sonnet 4.6・Max" }).waitFor();
-  await page.locator("#composer-model-menu .composer-fast-toggle").click();
-  await page.locator("#composer-model-menu .composer-fast-toggle[aria-checked='true']").waitFor();
+  await page.waitForFunction(() => {
+    const toggle = document.querySelector("#composer-model-menu .composer-fast-toggle");
+    return toggle instanceof HTMLButtonElement &&
+      toggle.disabled &&
+      toggle.getAttribute("aria-checked") === "false" &&
+      toggle.textContent?.includes("Opus 4.6");
+  });
 
   await page.reload({ waitUntil: "networkidle" });
   await page.locator(".composer-session-trigger-permission", { hasText: "Plan mode" }).waitFor();
@@ -575,7 +580,7 @@ async function assertComposerSessionControls(page, previewUrl) {
   await page.locator("#composer-model-menu", { hasText: "モデル" }).waitFor();
   await page.locator("#composer-model-menu", { hasText: "工数" }).waitFor();
   await page.locator("#composer-model-menu", { hasText: "高速モード" }).waitFor();
-  await page.locator("#composer-model-menu", { hasText: "高速モードを有効にする" }).waitFor();
+  await page.locator("#composer-model-menu", { hasText: "高速モードは Opus 4.6 でのみ利用できます" }).waitFor();
 
   await setShellLanguage(page, "en");
   await page.goto(`${previewUrl}${HARNESS_QUERY}`, { waitUntil: "networkidle" });

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -599,9 +599,10 @@ const composerModelOptions: Array<{
   labelJa: string;
   cliModel: string;
   shortcut: string;
+  fastModeCompatible?: boolean;
 }> = [
   { value: "opus-4.7", label: "Opus 4.7", labelJa: "Opus 4.7", cliModel: "opus", shortcut: "1" },
-  { value: "opus-4.7-1m", label: "Opus 4.7 1M", labelJa: "Opus 4.7 1M", cliModel: "opusplan", shortcut: "2" },
+  { value: "opus-4.7-1m", label: "Opus 4.7 1M", labelJa: "Opus 4.7 1M", cliModel: "opus[1m]", shortcut: "2" },
   { value: "sonnet-4.6", label: "Sonnet 4.6", labelJa: "Sonnet 4.6", cliModel: "sonnet", shortcut: "3" },
   { value: "haiku-4.5", label: "Haiku 4.5", labelJa: "Haiku 4.5", cliModel: "haiku", shortcut: "4" },
 ];
@@ -1172,7 +1173,7 @@ function getOperatorStartupInput() {
     args.push("--effort", activeComposerEffort);
   }
   const startupInput = `${args.join(" ")}\r`;
-  return activeComposerFastModeEnabled
+  return activeComposerFastModeEnabled && isComposerFastModeCompatible()
     ? `${startupInput}/fast\r`
     : startupInput;
 }
@@ -5459,11 +5460,16 @@ function defaultComposerSessionControls(): ComposerSessionControlState {
 
 function normalizeComposerSessionControls(value: Partial<ComposerSessionControlState> | null | undefined) {
   const fallback = defaultComposerSessionControls();
+  const model = composerModelOptions.find((item) => item.value === value?.model)?.value ?? fallback.model;
+  const fastModeEnabled =
+    typeof value?.fastModeEnabled === "boolean" && isComposerFastModeCompatible(model)
+      ? value.fastModeEnabled
+      : fallback.fastModeEnabled;
   return {
     permissionMode: normalizeComposerPermissionMode(value?.permissionMode, fallback.permissionMode),
-    model: composerModelOptions.find((item) => item.value === value?.model)?.value ?? fallback.model,
+    model,
     effort: composerEffortOptions.find((item) => item.value === value?.effort)?.value ?? fallback.effort,
-    fastModeEnabled: typeof value?.fastModeEnabled === "boolean" ? value.fastModeEnabled : fallback.fastModeEnabled,
+    fastModeEnabled,
   };
 }
 
@@ -6805,6 +6811,10 @@ function getComposerModelOption(model: ComposerModelId = activeComposerModel) {
   return composerModelOptions.find((item) => item.value === model) ?? composerModelOptions[0];
 }
 
+function isComposerFastModeCompatible(model: ComposerModelId = activeComposerModel) {
+  return Boolean(getComposerModelOption(model).fastModeCompatible);
+}
+
 function getComposerEffortOption(effort: ComposerEffortLevel = activeComposerEffort) {
   return composerEffortOptions.find((item) => item.value === effort) ?? composerEffortOptions[0];
 }
@@ -6824,12 +6834,15 @@ function setComposerEffort(effort: ComposerEffortLevel) {
 
 function setComposerModel(model: ComposerModelId) {
   activeComposerModel = model;
+  if (!isComposerFastModeCompatible(model)) {
+    activeComposerFastModeEnabled = false;
+  }
   persistComposerSessionControls();
   renderComposerSessionControls();
 }
 
 function setComposerFastMode(enabled: boolean) {
-  activeComposerFastModeEnabled = enabled;
+  activeComposerFastModeEnabled = enabled && isComposerFastModeCompatible();
   persistComposerSessionControls();
   renderComposerSessionControls();
 }
@@ -6966,17 +6979,27 @@ function createComposerModelMenu() {
   }
   appendComposerMenuSeparator(menu);
   appendComposerMenuHeading(menu, japanese ? "高速モード" : "Fast mode");
+  const fastModeCompatible = isComposerFastModeCompatible();
+  if (!fastModeCompatible && activeComposerFastModeEnabled) {
+    activeComposerFastModeEnabled = false;
+    persistComposerSessionControls();
+  }
   const fastToggle = document.createElement("button");
   fastToggle.type = "button";
   fastToggle.className = `composer-fast-toggle ${activeComposerFastModeEnabled ? "is-active" : ""}`;
+  fastToggle.disabled = !fastModeCompatible;
   fastToggle.setAttribute("role", "switch");
   fastToggle.setAttribute("aria-checked", activeComposerFastModeEnabled ? "true" : "false");
+  fastToggle.setAttribute("aria-disabled", fastModeCompatible ? "false" : "true");
   fastToggle.innerHTML = `
-    <span>${japanese ? "高速モードを有効にする" : "Enable fast mode"}</span>
+    <span>${fastModeCompatible ? (japanese ? "高速モードを有効にする" : "Enable fast mode") : (japanese ? "高速モードは Opus 4.6 でのみ利用できます" : "Fast mode is only available on Opus 4.6")}</span>
     <span class="composer-fast-toggle-track" aria-hidden="true"><span class="composer-fast-toggle-thumb"></span></span>
   `;
   fastToggle.addEventListener("click", (event) => {
     event.stopPropagation();
+    if (!fastModeCompatible) {
+      return;
+    }
     setComposerFastMode(!activeComposerFastModeEnabled);
   });
   menu.appendChild(fastToggle);

--- a/winsmux-app/src/styles.css
+++ b/winsmux-app/src/styles.css
@@ -1919,6 +1919,17 @@ body[data-popout-surface="1"] #editor-surface {
   color: var(--text-primary);
 }
 
+.composer-fast-toggle:disabled {
+  cursor: not-allowed;
+  color: var(--text-muted);
+  opacity: 0.65;
+}
+
+.composer-fast-toggle:disabled:hover {
+  background: transparent;
+  color: var(--text-muted);
+}
+
 .composer-fast-toggle-track {
   width: 28px;
   height: 16px;


### PR DESCRIPTION
## Summary

- Pass `opus[1m]` for the `Opus 4.7 1M` composer model option instead of the shorter-context `opusplan` alias.
- Keep fast mode disabled unless the selected model explicitly supports it, and normalize stale incompatible fast-mode state off at startup.
- Require custom meta-planning adapters to declare `read_only_launch_args` before they can be used as read-only planning workers.

Closes #800.

## Validation

- `rustfmt --check core\src\operator_cli.rs`
- `cargo test -p winsmux meta_plan_role`
- `cmd /c node --check scripts\viewport-harness.mjs`
- `cmd /c npm run test:editor-targets`
- `cmd /c npm run build`
- `cmd /c npm run test:viewport-harness`
- `pwsh -NoProfile -File scripts\audit-public-surface.ps1`
- `pwsh -NoProfile -File scripts\git-guard.ps1 -Mode full`
- `git diff --check`
