### PR TITLE
fix: enable fast mode for Opus 4.6

### DIFF
--- a/winsmux-app/scripts/viewport-harness.mjs
+++ b/winsmux-app/scripts/viewport-harness.mjs
@@ -567,20 +567,25 @@ async function assertComposerSessionControls(page, previewUrl) {
       toggle.getAttribute("aria-checked") === "false" &&
       toggle.textContent?.includes("Opus 4.6");
   });
+  await page.locator("#composer-model-menu .composer-session-option", { hasText: "Opus 4.6" }).click();
+  await page.locator(".composer-session-trigger-model", { hasText: "Opus 4.6・Max" }).waitFor();
+  await page.locator("#composer-model-menu .composer-fast-toggle").click();
+  await page.locator("#composer-model-menu .composer-fast-toggle[aria-checked='true']").waitFor();
 
   await page.reload({ waitUntil: "networkidle" });
   await page.locator(".composer-session-trigger-permission", { hasText: "Plan mode" }).waitFor();
-  await page.locator(".composer-session-trigger-model", { hasText: "Sonnet 4.6・Max" }).waitFor();
+  await page.locator(".composer-session-trigger-model", { hasText: "Opus 4.6・Max" }).waitFor();
 
   await setShellLanguage(page, "ja");
   await page.goto(`${previewUrl}${HARNESS_QUERY}`, { waitUntil: "networkidle" });
   await page.locator(".composer-session-trigger-permission", { hasText: "プランモード" }).waitFor();
-  await page.locator(".composer-session-trigger-model", { hasText: "Sonnet 4.6・Max" }).waitFor();
+  await page.locator(".composer-session-trigger-model", { hasText: "Opus 4.6・Max" }).waitFor();
   await page.click(".composer-session-trigger-model");
   await page.locator("#composer-model-menu", { hasText: "モデル" }).waitFor();
   await page.locator("#composer-model-menu", { hasText: "工数" }).waitFor();
   await page.locator("#composer-model-menu", { hasText: "高速モード" }).waitFor();
-  await page.locator("#composer-model-menu", { hasText: "高速モードは Opus 4.6 でのみ利用できます" }).waitFor();
+  await page.locator("#composer-model-menu", { hasText: "高速モードを有効にする" }).waitFor();
+  await page.locator("#composer-model-menu .composer-fast-toggle[aria-checked='true']").waitFor();
 
   await setShellLanguage(page, "en");
   await page.goto(`${previewUrl}${HARNESS_QUERY}`, { waitUntil: "networkidle" });

--- a/winsmux-app/scripts/viewport-harness.mjs
+++ b/winsmux-app/scripts/viewport-harness.mjs
@@ -589,6 +589,23 @@ async function assertComposerSessionControls(page, previewUrl) {
   if (startupInputs[2]?.fastModeEnabled !== true || startupInputs[2]?.fastModeTogglePending !== false) {
     throw new Error("Fast mode persisted state did not keep enabled mode with the launch toggle consumed");
   }
+  await page.click(".composer-session-trigger-model");
+  await page.locator("#composer-model-menu .composer-fast-toggle[aria-checked='true']").click();
+  await page.locator("#composer-model-menu .composer-fast-toggle[aria-checked='false']").waitFor();
+  const disableStartupInputs = await page.evaluate(() => [
+    window.__winsmuxViewportHarness?.getOperatorStartupInput(),
+    window.__winsmuxViewportHarness?.getOperatorStartupInput(),
+    JSON.parse(localStorage.getItem("winsmux.composer-session.v1") || "{}"),
+  ]);
+  if (!String(disableStartupInputs[0]).includes("/fast\r")) {
+    throw new Error("Fast mode toggle was not sent once after disabling Opus 4.6 fast mode");
+  }
+  if (String(disableStartupInputs[1]).includes("/fast\r")) {
+    throw new Error("Fast mode disable toggle was sent more than once");
+  }
+  if (disableStartupInputs[2]?.fastModeEnabled !== false || disableStartupInputs[2]?.fastModeTogglePending !== false) {
+    throw new Error("Fast mode persisted state did not keep disabled mode with the launch toggle consumed");
+  }
 
   await setShellLanguage(page, "ja");
   await page.goto(`${previewUrl}${HARNESS_QUERY}`, { waitUntil: "networkidle" });
@@ -599,7 +616,7 @@ async function assertComposerSessionControls(page, previewUrl) {
   await page.locator("#composer-model-menu", { hasText: "工数" }).waitFor();
   await page.locator("#composer-model-menu", { hasText: "高速モード" }).waitFor();
   await page.locator("#composer-model-menu", { hasText: "高速モードを有効にする" }).waitFor();
-  await page.locator("#composer-model-menu .composer-fast-toggle[aria-checked='true']").waitFor();
+  await page.locator("#composer-model-menu .composer-fast-toggle[aria-checked='false']").waitFor();
 
   await setShellLanguage(page, "en");
   await page.goto(`${previewUrl}${HARNESS_QUERY}`, { waitUntil: "networkidle" });

--- a/winsmux-app/scripts/viewport-harness.mjs
+++ b/winsmux-app/scripts/viewport-harness.mjs
@@ -575,6 +575,20 @@ async function assertComposerSessionControls(page, previewUrl) {
   await page.reload({ waitUntil: "networkidle" });
   await page.locator(".composer-session-trigger-permission", { hasText: "Plan mode" }).waitFor();
   await page.locator(".composer-session-trigger-model", { hasText: "Opus 4.6・Max" }).waitFor();
+  const startupInputs = await page.evaluate(() => [
+    window.__winsmuxViewportHarness?.getOperatorStartupInput(),
+    window.__winsmuxViewportHarness?.getOperatorStartupInput(),
+    JSON.parse(localStorage.getItem("winsmux.composer-session.v1") || "{}"),
+  ]);
+  if (!String(startupInputs[0]).includes("/fast\r")) {
+    throw new Error("Fast mode toggle was not sent once after enabling Opus 4.6 fast mode");
+  }
+  if (String(startupInputs[1]).includes("/fast\r")) {
+    throw new Error("Fast mode toggle was sent more than once after enabling Opus 4.6 fast mode");
+  }
+  if (startupInputs[2]?.fastModeEnabled !== true || startupInputs[2]?.fastModeTogglePending !== false) {
+    throw new Error("Fast mode persisted state did not keep enabled mode with the launch toggle consumed");
+  }
 
   await setShellLanguage(page, "ja");
   await page.goto(`${previewUrl}${HARNESS_QUERY}`, { waitUntil: "networkidle" });

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -1179,7 +1179,6 @@ function getOperatorStartupInput() {
   }
   const startupInput = `${args.join(" ")}\r`;
   const shouldToggleFastMode =
-    activeComposerFastModeEnabled &&
     activeComposerFastModeTogglePending &&
     isComposerFastModeCompatible();
   if (!shouldToggleFastMode) {
@@ -5479,7 +5478,7 @@ function normalizeComposerSessionControls(value: Partial<ComposerSessionControlS
       ? value.fastModeEnabled
       : fallback.fastModeEnabled;
   const fastModeTogglePending =
-    fastModeEnabled && typeof value?.fastModeTogglePending === "boolean"
+    isComposerFastModeCompatible(model) && typeof value?.fastModeTogglePending === "boolean"
       ? value.fastModeTogglePending
       : fallback.fastModeTogglePending;
   return {
@@ -6862,9 +6861,12 @@ function setComposerModel(model: ComposerModelId) {
 }
 
 function setComposerFastMode(enabled: boolean) {
+  const previousAppliedState = activeComposerFastModeTogglePending
+    ? !activeComposerFastModeEnabled
+    : activeComposerFastModeEnabled;
   const nextEnabled = enabled && isComposerFastModeCompatible();
   activeComposerFastModeEnabled = nextEnabled;
-  activeComposerFastModeTogglePending = nextEnabled;
+  activeComposerFastModeTogglePending = nextEnabled !== previousAppliedState;
   persistComposerSessionControls();
   renderComposerSessionControls();
 }

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -203,6 +203,7 @@ declare global {
       openEditorPreview: (path: string, content: string, worktree?: string) => void;
       setContextPanel: (open: boolean) => void;
       setTerminalDrawer: (open: boolean) => void;
+      getOperatorStartupInput: () => string;
     };
   }
 }
@@ -353,6 +354,7 @@ interface ComposerSessionControlState {
   model: ComposerModelId;
   effort: ComposerEffortLevel;
   fastModeEnabled: boolean;
+  fastModeTogglePending: boolean;
 }
 
 interface SpeechRecognitionAlternativeLike {
@@ -443,6 +445,7 @@ let activeComposerPermissionMode: ComposerPermissionMode = "acceptEdits";
 let activeComposerModel: ComposerModelId = "opus-4.7-1m";
 let activeComposerEffort: ComposerEffortLevel = "xhigh";
 let activeComposerFastModeEnabled = false;
+let activeComposerFastModeTogglePending = false;
 let openComposerSessionMenu: "permission" | "model" | null = null;
 let composerSlashOpen = false;
 let composerSlashQuery = "";
@@ -972,6 +975,7 @@ runtimeRolePreferences = readStoredRuntimeRolePreferences();
   activeComposerModel = storedComposerControls.model;
   activeComposerEffort = storedComposerControls.effort;
   activeComposerFastModeEnabled = storedComposerControls.fastModeEnabled;
+  activeComposerFastModeTogglePending = storedComposerControls.fastModeTogglePending;
 }
 
 const fallbackExplorerPaths = [
@@ -1174,9 +1178,16 @@ function getOperatorStartupInput() {
     args.push("--effort", activeComposerEffort);
   }
   const startupInput = `${args.join(" ")}\r`;
-  return activeComposerFastModeEnabled && isComposerFastModeCompatible()
-    ? `${startupInput}/fast\r`
-    : startupInput;
+  const shouldToggleFastMode =
+    activeComposerFastModeEnabled &&
+    activeComposerFastModeTogglePending &&
+    isComposerFastModeCompatible();
+  if (!shouldToggleFastMode) {
+    return startupInput;
+  }
+  activeComposerFastModeTogglePending = false;
+  persistComposerSessionControls();
+  return `${startupInput}/fast\r`;
 }
 
 function ensureOperatorPtyStarted() {
@@ -5456,6 +5467,7 @@ function defaultComposerSessionControls(): ComposerSessionControlState {
     model: "opus-4.7-1m",
     effort: "xhigh",
     fastModeEnabled: false,
+    fastModeTogglePending: false,
   };
 }
 
@@ -5466,11 +5478,16 @@ function normalizeComposerSessionControls(value: Partial<ComposerSessionControlS
     typeof value?.fastModeEnabled === "boolean" && isComposerFastModeCompatible(model)
       ? value.fastModeEnabled
       : fallback.fastModeEnabled;
+  const fastModeTogglePending =
+    fastModeEnabled && typeof value?.fastModeTogglePending === "boolean"
+      ? value.fastModeTogglePending
+      : fallback.fastModeTogglePending;
   return {
     permissionMode: normalizeComposerPermissionMode(value?.permissionMode, fallback.permissionMode),
     model,
     effort: composerEffortOptions.find((item) => item.value === value?.effort)?.value ?? fallback.effort,
     fastModeEnabled,
+    fastModeTogglePending,
   };
 }
 
@@ -5503,6 +5520,7 @@ function persistComposerSessionControls() {
         model: activeComposerModel,
         effort: activeComposerEffort,
         fastModeEnabled: activeComposerFastModeEnabled,
+        fastModeTogglePending: activeComposerFastModeTogglePending,
       }),
     );
     return true;
@@ -6837,13 +6855,16 @@ function setComposerModel(model: ComposerModelId) {
   activeComposerModel = model;
   if (!isComposerFastModeCompatible(model)) {
     activeComposerFastModeEnabled = false;
+    activeComposerFastModeTogglePending = false;
   }
   persistComposerSessionControls();
   renderComposerSessionControls();
 }
 
 function setComposerFastMode(enabled: boolean) {
-  activeComposerFastModeEnabled = enabled && isComposerFastModeCompatible();
+  const nextEnabled = enabled && isComposerFastModeCompatible();
+  activeComposerFastModeEnabled = nextEnabled;
+  activeComposerFastModeTogglePending = nextEnabled;
   persistComposerSessionControls();
   renderComposerSessionControls();
 }
@@ -6983,6 +7004,7 @@ function createComposerModelMenu() {
   const fastModeCompatible = isComposerFastModeCompatible();
   if (!fastModeCompatible && activeComposerFastModeEnabled) {
     activeComposerFastModeEnabled = false;
+    activeComposerFastModeTogglePending = false;
     persistComposerSessionControls();
   }
   const fastToggle = document.createElement("button");
@@ -9969,6 +9991,7 @@ function installViewportHarnessHooks() {
     setTerminalDrawer: (open: boolean) => {
       setTerminalDrawer(open);
     },
+    getOperatorStartupInput: () => getOperatorStartupInput(),
   };
 }
 

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -289,7 +289,7 @@ type RuntimeModelSource = "provider-default" | "cli-discovery" | "official-doc" 
 type RuntimeReasoningEffort = "provider-default" | "low" | "medium" | "high" | "xhigh" | "max";
 type ComposerPermissionMode = "auto" | "default" | "acceptEdits" | "plan";
 type ComposerEffortLevel = "auto" | "low" | "medium" | "high" | "xhigh" | "max";
-type ComposerModelId = "opus-4.7" | "opus-4.7-1m" | "sonnet-4.6" | "haiku-4.5";
+type ComposerModelId = "opus-4.7" | "opus-4.7-1m" | "opus-4.6" | "sonnet-4.6" | "haiku-4.5";
 
 interface ThemeState {
   theme: ThemeMode;
@@ -603,8 +603,9 @@ const composerModelOptions: Array<{
 }> = [
   { value: "opus-4.7", label: "Opus 4.7", labelJa: "Opus 4.7", cliModel: "opus", shortcut: "1" },
   { value: "opus-4.7-1m", label: "Opus 4.7 1M", labelJa: "Opus 4.7 1M", cliModel: "opus[1m]", shortcut: "2" },
-  { value: "sonnet-4.6", label: "Sonnet 4.6", labelJa: "Sonnet 4.6", cliModel: "sonnet", shortcut: "3" },
-  { value: "haiku-4.5", label: "Haiku 4.5", labelJa: "Haiku 4.5", cliModel: "haiku", shortcut: "4" },
+  { value: "opus-4.6", label: "Opus 4.6", labelJa: "Opus 4.6", cliModel: "claude-opus-4-6", shortcut: "3", fastModeCompatible: true },
+  { value: "sonnet-4.6", label: "Sonnet 4.6", labelJa: "Sonnet 4.6", cliModel: "sonnet", shortcut: "4" },
+  { value: "haiku-4.5", label: "Haiku 4.5", labelJa: "Haiku 4.5", cliModel: "haiku", shortcut: "5" },
 ];
 
 const composerEffortOptions: Array<{


### PR DESCRIPTION
## Summary

- Add `Opus 4.6` as a selectable composer model and mark it as the fast-mode-compatible choice.
- Keep the fast-mode switch disabled for incompatible models, but allow it to persist and launch for `Opus 4.6`.
- Extend the viewport harness so it verifies both the disabled Sonnet path and enabled Opus 4.6 path.

Closes #800.

## Validation

- `cmd /c npm run build`
- `cmd /c npm run test:viewport-harness`
- `cmd /c node --check scripts\viewport-harness.mjs`
- `pwsh -NoProfile -File scripts\audit-public-surface.ps1`
- `pwsh -NoProfile -File scripts\git-guard.ps1 -Mode full`
- `git diff --check`
