### PR TITLE
fix: clear persisted fast mode on model switch

### DIFF
--- a/winsmux-app/scripts/viewport-harness.mjs
+++ b/winsmux-app/scripts/viewport-harness.mjs
@@ -590,6 +590,40 @@ async function assertComposerSessionControls(page, previewUrl) {
     throw new Error("Fast mode persisted state did not keep enabled mode with the launch toggle consumed");
   }
   await page.click(".composer-session-trigger-model");
+  await page.locator("#composer-model-menu .composer-session-option", { hasText: "Sonnet 4.6" }).click();
+  await page.locator(".composer-session-trigger-model", { hasText: "Sonnet 4.6・Max" }).waitFor();
+  await page.reload({ waitUntil: "networkidle" });
+  await page.locator(".composer-session-trigger-model", { hasText: "Sonnet 4.6・Max" }).waitFor();
+  const modelSwitchDisableStartupInputs = await page.evaluate(() => [
+    window.__winsmuxViewportHarness?.getOperatorStartupInput(),
+    window.__winsmuxViewportHarness?.getOperatorStartupInput(),
+    JSON.parse(localStorage.getItem("winsmux.composer-session.v1") || "{}"),
+  ]);
+  if (!String(modelSwitchDisableStartupInputs[0]).includes("/fast\r")) {
+    throw new Error("Fast mode toggle was not sent once after switching away from Opus 4.6 fast mode");
+  }
+  if (String(modelSwitchDisableStartupInputs[1]).includes("/fast\r")) {
+    throw new Error("Fast mode model-switch disable toggle was sent more than once");
+  }
+  if (modelSwitchDisableStartupInputs[2]?.fastModeEnabled !== false || modelSwitchDisableStartupInputs[2]?.fastModeTogglePending !== false) {
+    throw new Error("Fast mode model-switch disable did not persist with the launch toggle consumed");
+  }
+  await page.click(".composer-session-trigger-model");
+  await page.locator("#composer-model-menu .composer-session-option", { hasText: "Opus 4.6" }).click();
+  await page.locator(".composer-session-trigger-model", { hasText: "Opus 4.6・Max" }).waitFor();
+  await page.locator("#composer-model-menu .composer-fast-toggle").click();
+  await page.locator("#composer-model-menu .composer-fast-toggle[aria-checked='true']").waitFor();
+  const modelSwitchReenableStartupInputs = await page.evaluate(() => [
+    window.__winsmuxViewportHarness?.getOperatorStartupInput(),
+    window.__winsmuxViewportHarness?.getOperatorStartupInput(),
+    JSON.parse(localStorage.getItem("winsmux.composer-session.v1") || "{}"),
+  ]);
+  if (!String(modelSwitchReenableStartupInputs[0]).includes("/fast\r")) {
+    throw new Error("Fast mode toggle was not sent once after re-enabling Opus 4.6 fast mode");
+  }
+  if (String(modelSwitchReenableStartupInputs[1]).includes("/fast\r")) {
+    throw new Error("Fast mode re-enable toggle was sent more than once");
+  }
   await page.locator("#composer-model-menu .composer-fast-toggle[aria-checked='true']").click();
   await page.locator("#composer-model-menu .composer-fast-toggle[aria-checked='false']").waitFor();
   const disableStartupInputs = await page.evaluate(() => [

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -1178,9 +1178,7 @@ function getOperatorStartupInput() {
     args.push("--effort", activeComposerEffort);
   }
   const startupInput = `${args.join(" ")}\r`;
-  const shouldToggleFastMode =
-    activeComposerFastModeTogglePending &&
-    isComposerFastModeCompatible();
+  const shouldToggleFastMode = activeComposerFastModeTogglePending;
   if (!shouldToggleFastMode) {
     return startupInput;
   }
@@ -5473,12 +5471,14 @@ function defaultComposerSessionControls(): ComposerSessionControlState {
 function normalizeComposerSessionControls(value: Partial<ComposerSessionControlState> | null | undefined) {
   const fallback = defaultComposerSessionControls();
   const model = composerModelOptions.find((item) => item.value === value?.model)?.value ?? fallback.model;
-  const fastModeEnabled =
-    typeof value?.fastModeEnabled === "boolean" && isComposerFastModeCompatible(model)
-      ? value.fastModeEnabled
-      : fallback.fastModeEnabled;
+  const fastModeCompatible = isComposerFastModeCompatible(model);
+  const storedFastModeEnabled =
+    typeof value?.fastModeEnabled === "boolean" ? value.fastModeEnabled : fallback.fastModeEnabled;
+  const fastModeEnabled = fastModeCompatible ? storedFastModeEnabled : fallback.fastModeEnabled;
+  const preservesPendingDisable =
+    !fastModeCompatible && storedFastModeEnabled === false && value?.fastModeTogglePending === true;
   const fastModeTogglePending =
-    isComposerFastModeCompatible(model) && typeof value?.fastModeTogglePending === "boolean"
+    typeof value?.fastModeTogglePending === "boolean" && (fastModeCompatible || preservesPendingDisable)
       ? value.fastModeTogglePending
       : fallback.fastModeTogglePending;
   return {
@@ -6833,6 +6833,12 @@ function isComposerFastModeCompatible(model: ComposerModelId = activeComposerMod
   return Boolean(getComposerModelOption(model).fastModeCompatible);
 }
 
+function getComposerFastModeAppliedState() {
+  return activeComposerFastModeTogglePending
+    ? !activeComposerFastModeEnabled
+    : activeComposerFastModeEnabled;
+}
+
 function getComposerEffortOption(effort: ComposerEffortLevel = activeComposerEffort) {
   return composerEffortOptions.find((item) => item.value === effort) ?? composerEffortOptions[0];
 }
@@ -6851,19 +6857,18 @@ function setComposerEffort(effort: ComposerEffortLevel) {
 }
 
 function setComposerModel(model: ComposerModelId) {
+  const previousAppliedState = getComposerFastModeAppliedState();
   activeComposerModel = model;
   if (!isComposerFastModeCompatible(model)) {
     activeComposerFastModeEnabled = false;
-    activeComposerFastModeTogglePending = false;
+    activeComposerFastModeTogglePending = previousAppliedState;
   }
   persistComposerSessionControls();
   renderComposerSessionControls();
 }
 
 function setComposerFastMode(enabled: boolean) {
-  const previousAppliedState = activeComposerFastModeTogglePending
-    ? !activeComposerFastModeEnabled
-    : activeComposerFastModeEnabled;
+  const previousAppliedState = getComposerFastModeAppliedState();
   const nextEnabled = enabled && isComposerFastModeCompatible();
   activeComposerFastModeEnabled = nextEnabled;
   activeComposerFastModeTogglePending = nextEnabled !== previousAppliedState;


### PR DESCRIPTION
## Summary

- Keeps a one-shot `/fast` toggle pending when a user leaves the Opus 4.6 fast-mode path for an incompatible model.
- Treats the pending toggle as the difference between the visible winsmux state and the last applied Claude Code state.
- Extends the viewport harness to cover disabling fast mode by switching from Opus 4.6 to Sonnet, then re-enabling and disabling it again.

## Validation

- `cmd /c node --check scripts\viewport-harness.mjs`
- `git diff --check`
- `cmd /c npm run build`
- `cmd /c npm run test:viewport-harness`
- `pwsh -NoProfile -File scripts\audit-public-surface.ps1`
- `pwsh -NoProfile -File scripts\git-guard.ps1 -Mode full`
