### PR TITLE
fix: preserve editor navigation source worktrees

### DIFF
--- a/winsmux-app/scripts/editor-targets-check.mjs
+++ b/winsmux-app/scripts/editor-targets-check.mjs
@@ -31,6 +31,7 @@ const {
   getEditorFileKey,
   getSourceChangeKey,
   pickEditorPathCandidate,
+  pickSourceChangeKeyCandidate,
 } = await loadEditorTargetsModule();
 
 const duplicateCandidates = [
@@ -60,6 +61,28 @@ assert.equal(
 assert.deepEqual(
   pickEditorPathCandidate([{ path: "winsmux-app/src/desktopClient.ts", worktree: "" }], "winsmux-app/src/desktopClient.ts", "", ""),
   { path: "winsmux-app/src/desktopClient.ts", worktree: "" },
+);
+
+assert.deepEqual(
+  pickSourceChangeKeyCandidate(
+    [
+      [{ path: "winsmux-app/src/main.ts", worktree: "builder-2" }],
+      [
+        { path: "winsmux-app/src/main.ts", worktree: "builder-2" },
+        { path: "winsmux-app/src/main.ts", worktree: "builder-3" },
+      ],
+    ],
+    "builder-3::winsmux-app/src/main.ts",
+  ),
+  { path: "winsmux-app/src/main.ts", worktree: "builder-3" },
+);
+
+assert.equal(
+  pickSourceChangeKeyCandidate(
+    [[{ path: "winsmux-app/src/main.ts", worktree: "builder-2" }]],
+    "builder-9::winsmux-app/src/main.ts",
+  ),
+  null,
 );
 
 console.log("editor-targets-check: ok");

--- a/winsmux-app/src/editorTargets.ts
+++ b/winsmux-app/src/editorTargets.ts
@@ -42,3 +42,25 @@ export function pickEditorPathCandidate<T extends EditorPathCandidate>(
 
   return null;
 }
+
+export function pickSourceChangeKeyCandidate<T extends EditorPathCandidate>(
+  candidateGroups: T[][],
+  key: string,
+) {
+  const seen = new Set<string>();
+
+  for (const candidates of candidateGroups) {
+    for (const candidate of candidates) {
+      const candidateKey = getSourceChangeKey(candidate);
+      if (seen.has(candidateKey)) {
+        continue;
+      }
+      seen.add(candidateKey);
+      if (candidateKey === key) {
+        return candidate;
+      }
+    }
+  }
+
+  return null;
+}

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -22,7 +22,7 @@ import {
   type DesktopSummarySnapshot,
   type DesktopRuntimeRolePreference,
 } from "./desktopClient";
-import { getEditorFileKey, getSourceChangeKey, pickEditorPathCandidate } from "./editorTargets";
+import { getEditorFileKey, getSourceChangeKey, pickEditorPathCandidate, pickSourceChangeKeyCandidate } from "./editorTargets";
 import {
   closePtyPane,
   resizePtyPane,
@@ -265,6 +265,7 @@ interface EvidenceItem {
   tone: SurfaceTone;
   runId?: string;
   primaryPath?: string;
+  primaryWorktree?: string;
 }
 
 interface ExperimentDetailLine {
@@ -1873,7 +1874,7 @@ function getProjectionSourceEntries(): SourceChange[] {
 }
 
 function findSourceChangeByKey(key: string) {
-  return getProjectionSourceEntries().find((entry) => getSourceChangeKey(entry) === key);
+  return pickSourceChangeKeyCandidate([getVisibleSourceChanges(), getProjectionSourceEntries()], key);
 }
 
 function findSourceChangeByPath(path: string, worktree = "") {
@@ -3673,6 +3674,7 @@ function getEvidenceItems(): EvidenceItem[] {
         tone: getEvidenceTone(digest.verification_outcome || digest.security_blocked),
         runId: payload.run.run_id,
         primaryPath: digest.changed_files[0] || payload.run.changed_files[0],
+        primaryWorktree: payload.run.worktree || "",
       });
     }
 
@@ -3738,6 +3740,7 @@ function getEvidenceItems(): EvidenceItem[] {
       tone: getEvidenceTone(outcome),
       runId: projection.run_id,
       primaryPath: projection.changed_files[0],
+      primaryWorktree: projection.worktree || "",
     });
   }
 
@@ -3814,7 +3817,7 @@ function renderEvidenceView() {
     });
     button.addEventListener("dblclick", () => {
       if (item.primaryPath) {
-        void openEditorPath(item.primaryPath);
+        void openEditorPath(item.primaryPath, item.primaryWorktree ?? "");
       }
     });
     root.appendChild(button);


### PR DESCRIPTION
## Summary

- Preserves the run worktree on evidence rows so double-clicking a changed file opens it from the source worktree.
- Resolves editor tabs from both visible and projected source changes before falling back to standalone targets.
- Extends the deterministic editor-target fixture for source/projection-backed key resolution.

Closes #781.

## Validation

- `cmd /c node --check scripts\editor-targets-check.mjs`
- `cmd /c node --check scripts\viewport-harness.mjs`
- `cmd /c npm run test:editor-targets`
- `git diff --check`
- `cmd /c npm run build`
- `cmd /c npm run test:viewport-harness`
- `pwsh -NoProfile -File scripts\audit-public-surface.ps1`
- `pwsh -NoProfile -File scripts\git-guard.ps1 -Mode full`
