### PR TITLE
Fix operator send progress and browser failure feedback

### DIFF
--- a/winsmux-app/index.html
+++ b/winsmux-app/index.html
@@ -279,6 +279,12 @@
                     </svg>
                   </button>
                 </div>
+                <div id="composer-operator-status" class="composer-operator-status" role="status" aria-live="polite" hidden>
+                  <span id="operator-working-label" class="operator-working-label">working</span>
+                  <span id="operator-working-elapsed">0m 00s</span>
+                  <span aria-hidden="true">·</span>
+                  <span id="operator-working-hint">Esc to interrupt</span>
+                </div>
                 <div id="composer-model-row" aria-label="Composer model controls"></div>
               </div>
               <div id="attachment-tray" aria-live="polite"></div>

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -482,6 +482,8 @@ let sourceControlCommitMessage = "";
 let operatorPtyStarted = false;
 let operatorPtyStarting: Promise<void> | null = null;
 let operatorRequestActive = false;
+let operatorRequestStartedAt = 0;
+let operatorRequestStatusTimer: number | null = null;
 let operatorInterruptInFlight = false;
 let operatorOutputBuffer = "";
 let operatorOutputFlushTimer: number | null = null;
@@ -6162,6 +6164,7 @@ function applyLanguageChrome() {
   }
   updateVoiceInputButton();
   updateOperatorInterruptButton();
+  updateOperatorStatusIndicator();
   renderComposerSessionControls();
   const sendButton = document.getElementById("send-btn");
   if (sendButton) {
@@ -10488,27 +10491,14 @@ function appendUserMessage(message: string, attachments: ComposerAttachment[]) {
       sizeLabel: attachment.sizeLabel,
     })),
   });
-  appendRuntimeConversation({
-    type: "operator",
-    category: "activity",
-    timestamp,
-    actor: "Operator",
-    title: getLanguageText("Sent to operator", "オペレーターへ送信"),
-    body: getLanguageText(
-      "The request was sent to the operator session.",
-      "依頼内容をオペレーターセッションへ送信しました。",
-    ),
-    details: [
-      { label: "mode", value: activeComposerMode },
-      { label: "permission-mode", value: activeComposerPermissionMode },
-      { label: "model", value: getComposerModelOption().label },
-      { label: "effort", value: activeComposerEffort },
-      { label: "fast-mode", value: activeComposerFastModeEnabled ? "enabled" : "disabled" },
-      { label: "attachments", value: `${attachments.length}` },
-    ],
-    tone: "info",
-  });
-  void forwardComposerMessageToOperatorPane(message, attachments, timestamp);
+  void forwardComposerMessageToOperatorPane(message, attachments, timestamp, [
+    { label: "mode", value: activeComposerMode },
+    { label: "permission-mode", value: activeComposerPermissionMode },
+    { label: "model", value: getComposerModelOption().label },
+    { label: "effort", value: activeComposerEffort },
+    { label: "fast-mode", value: activeComposerFastModeEnabled ? "enabled" : "disabled" },
+    { label: "attachments", value: `${attachments.length}` },
+  ]);
   void recordComposerDogfoodEvent(message, attachments, dogfoodInputSource, dogfoodStartedAt, dogfoodDraft);
   resetComposerDogfoodDraft();
   renderRunSummary();
@@ -10531,9 +10521,70 @@ function updateOperatorInterruptButton() {
   button.setAttribute("title", label);
 }
 
+function formatOperatorWorkingElapsed(startedAt: number) {
+  const elapsedSeconds = Math.max(0, Math.floor((Date.now() - startedAt) / 1000));
+  const minutes = Math.floor(elapsedSeconds / 60);
+  const seconds = elapsedSeconds % 60;
+  return `${minutes}m ${`${seconds}`.padStart(2, "0")}s`;
+}
+
+function updateOperatorStatusIndicator() {
+  const status = document.getElementById("composer-operator-status");
+  if (!status) {
+    return;
+  }
+
+  status.hidden = !operatorRequestActive;
+  if (!operatorRequestActive) {
+    return;
+  }
+
+  const label = document.getElementById("operator-working-label");
+  const elapsed = document.getElementById("operator-working-elapsed");
+  const hint = document.getElementById("operator-working-hint");
+  if (label) {
+    label.textContent = getLanguageText("working", "処理中");
+  }
+  if (elapsed) {
+    elapsed.textContent = formatOperatorWorkingElapsed(operatorRequestStartedAt || Date.now());
+  }
+  if (hint) {
+    hint.textContent = getLanguageText("Esc to interrupt", "Esc で中断");
+  }
+}
+
+function startOperatorStatusTimer() {
+  if (operatorRequestStatusTimer !== null) {
+    return;
+  }
+
+  operatorRequestStatusTimer = window.setInterval(() => {
+    updateOperatorStatusIndicator();
+  }, 1000);
+}
+
+function stopOperatorStatusTimer() {
+  if (operatorRequestStatusTimer === null) {
+    return;
+  }
+
+  window.clearInterval(operatorRequestStatusTimer);
+  operatorRequestStatusTimer = null;
+}
+
 function setOperatorRequestActive(active: boolean) {
+  const wasActive = operatorRequestActive;
   operatorRequestActive = active;
+  if (active && !wasActive) {
+    operatorRequestStartedAt = Date.now();
+    startOperatorStatusTimer();
+  }
+  if (!active) {
+    operatorRequestStartedAt = 0;
+    stopOperatorStatusTimer();
+  }
   updateOperatorInterruptButton();
+  updateOperatorStatusIndicator();
 }
 
 async function interruptOperatorRequest() {
@@ -10601,6 +10652,7 @@ async function forwardComposerMessageToOperatorPane(
   message: string,
   attachments: ComposerAttachment[],
   timestamp: string,
+  details: ConversationDetail[],
 ) {
   const payload = formatComposerMessageForPty(message, attachments);
   if (!payload.trim()) {
@@ -10609,18 +10661,39 @@ async function forwardComposerMessageToOperatorPane(
   }
 
   try {
+    setOperatorRequestActive(true);
     await ensureOperatorPtyStarted();
     await writePtyData(OPERATOR_PTY_ID, encodePtySubmission(payload));
-    setOperatorRequestActive(true);
+    appendRuntimeConversation({
+      type: "operator",
+      category: "activity",
+      timestamp,
+      actor: "Operator",
+      title: getLanguageText("Sent to operator", "オペレーターへ送信"),
+      body: getLanguageText(
+        "The request was sent to the operator session.",
+        "依頼内容をオペレーターセッションへ送信しました。",
+      ),
+      details,
+      tone: "info",
+    });
+    renderConversation(getConversationItems());
   } catch (error) {
     setOperatorRequestActive(false);
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    const desktopRuntimeError = errorMessage.includes("outside the Tauri runtime");
     appendRuntimeConversation({
       type: "system",
       category: "attention",
       timestamp,
       actor: "winsmux",
       title: getLanguageText("Claude Code send failed", "Claude Code 送信に失敗"),
-      body: error instanceof Error ? error.message : String(error),
+      body: desktopRuntimeError
+        ? getLanguageText(
+          "Open winsmux in the desktop runtime. The browser preview cannot launch or write to the operator CLI.",
+          "winsmux デスクトップで開いてください。ブラウザー表示ではオペレーター CLI を起動・送信できません。",
+        )
+        : errorMessage,
       tone: "warning",
     });
     renderConversation(getConversationItems());
@@ -11985,6 +12058,12 @@ window.addEventListener("DOMContentLoaded", async () => {
       event.preventDefault();
       openComposerSessionMenu = null;
       renderComposerSessionControls();
+      return;
+    }
+
+    if (event.key === "Escape" && operatorRequestActive && !operatorInterruptInFlight && !keyInsideSettings) {
+      event.preventDefault();
+      void interruptOperatorRequest();
       return;
     }
 

--- a/winsmux-app/src/ptyClient.ts
+++ b/winsmux-app/src/ptyClient.ts
@@ -95,7 +95,7 @@ export function createTauriPtyCommandTransport(
           } as T;
         }
 
-        return undefined as T;
+        throw new Error(`PTY command transport is unavailable outside the Tauri runtime (${command})`);
       }
 
       const request: PtyJsonRpcRequest = {

--- a/winsmux-app/src/styles.css
+++ b/winsmux-app/src/styles.css
@@ -2064,6 +2064,47 @@ body[data-popout-surface="1"] #editor-surface {
   min-width: 0;
 }
 
+.composer-operator-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  flex: 0 1 auto;
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+  white-space: nowrap;
+}
+
+.composer-operator-status[hidden] {
+  display: none;
+}
+
+.operator-working-label {
+  position: relative;
+  color: transparent;
+  background: linear-gradient(
+    90deg,
+    var(--text-muted) 0%,
+    var(--text-primary) 38%,
+    var(--accent-blue) 50%,
+    var(--text-primary) 62%,
+    var(--text-muted) 100%
+  );
+  background-size: 220% 100%;
+  -webkit-background-clip: text;
+  background-clip: text;
+  animation: operator-working-sweep 1.4s linear infinite;
+}
+
+@keyframes operator-working-sweep {
+  from {
+    background-position: 120% 0;
+  }
+  to {
+    background-position: -120% 0;
+  }
+}
+
 #attachment-tray {
   display: flex;
   flex-wrap: wrap;
@@ -2250,6 +2291,14 @@ body[data-popout-surface="1"] #editor-surface {
 #interrupt-operator-btn .button-icon {
   fill: currentColor;
   stroke: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .operator-working-label {
+    color: var(--text-primary);
+    background: none;
+    animation: none;
+  }
 }
 
 #send-btn {


### PR DESCRIPTION
## Summary
- add an inline operator working state with elapsed time and Esc-to-interrupt guidance
- move the sent-to-operator event after the PTY write succeeds
- fail closed when the browser preview tries to use PTY spawn/write, with a desktop-runtime error message

Closes #811.

## Validation
- cmd /c npm run build
- Playwright browser preview smoke: desktop-runtime failure visible, no sent-success log, status clears
- cmd /c npm run test:viewport-harness
- pwsh -NoProfile -File scripts/audit-public-surface.ps1
- pwsh -NoProfile -File scripts/git-guard.ps1
- git diff --check