### PR TITLE
Fix desktop dev startup interactivity

### DIFF
--- a/.githooks/pre-commit-whitelist.ps1
+++ b/.githooks/pre-commit-whitelist.ps1
@@ -19,6 +19,7 @@ $whitelistPatterns = @(
     'core/Cargo.toml',
     'core/Cargo.lock',
     'core/src/*.rs',
+    'core/src/bin/*.rs',
     'core/tests-rs/*.rs',
     'git-graph/**',
     '.gitignore',

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -2,6 +2,7 @@
 name = "winsmux"
 version = "0.24.23"
 edition = "2021"
+autobins = false
 description = "Windows-native terminal multiplexer and agent workspace runtime"
 license = "Apache-2.0 AND MIT"
 repository = "https://github.com/Sora-bluesky/winsmux"
@@ -62,19 +63,19 @@ windows-sys = { version = "0.61", features = [
 
 [[bin]]
 name = "winsmux"
-path = "src/main.rs"
+path = "src/bin/winsmux.rs"
 
 [[bin]]
 name = "psmux"
-path = "src/main.rs"
+path = "src/bin/psmux.rs"
 
 [[bin]]
 name = "pmux"
-path = "src/main.rs"
+path = "src/bin/pmux.rs"
 
 [[bin]]
 name = "tmux"
-path = "src/main.rs"
+path = "src/bin/tmux.rs"
 
 [dependencies]
 ratatui = "0.30"

--- a/core/src/bin/pmux.rs
+++ b/core/src/bin/pmux.rs
@@ -1,0 +1,3 @@
+fn main() {
+    winsmux::main();
+}

--- a/core/src/bin/psmux.rs
+++ b/core/src/bin/psmux.rs
@@ -1,0 +1,3 @@
+fn main() {
+    winsmux::main();
+}

--- a/core/src/bin/tmux.rs
+++ b/core/src/bin/tmux.rs
@@ -1,0 +1,3 @@
+fn main() {
+    winsmux::main();
+}

--- a/core/src/bin/winsmux.rs
+++ b/core/src/bin/winsmux.rs
@@ -1,0 +1,3 @@
+fn main() {
+    winsmux::main();
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,0 +1,3 @@
+#![allow(dead_code)]
+
+include!("main.rs");

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -1,6 +1,4 @@
-// Multi-binary crate (psmux, pmux, tmux) sharing all modules —
-// suppress dead_code warnings for functions only used by a subset of binaries.
-#![allow(dead_code)]
+// Shared CLI implementation used by the winsmux binary and legacy aliases.
 
 mod types;
 mod platform;
@@ -58,7 +56,7 @@ use crate::rendering::apply_cursor_style;
 use crate::client::run_remote;
 use crate::ssh_input::{send_mouse_enable, InputSource};
 
-fn main() {
+pub fn main() {
     if let Err(e) = run_main() {
         // Print a user-friendly error message instead of Rust's Debug format
         // which shows "Error: Custom { kind: Other, error: \"...\" }"  (fixes #47)

--- a/winsmux-app/package-lock.json
+++ b/winsmux-app/package-lock.json
@@ -8,14 +8,14 @@
       "name": "winsmux-app",
       "version": "0.24.23",
       "dependencies": {
-        "@tauri-apps/api": "^2",
+        "@tauri-apps/api": "2.11.0",
         "@tauri-apps/plugin-opener": "^2",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-web-links": "^0.12.0",
         "xterm": "^5.3.0"
       },
       "devDependencies": {
-        "@tauri-apps/cli": "^2",
+        "@tauri-apps/cli": "2.11.0",
         "playwright": "^1.58.1",
         "typescript": "~5.6.2",
         "vite": "^6.4.2"
@@ -814,9 +814,9 @@
       ]
     },
     "node_modules/@tauri-apps/api": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.10.1.tgz",
-      "integrity": "sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.11.0.tgz",
+      "integrity": "sha512-7CinYODhky9lmO23xHnUFv0Xt43fbtWMyxZcLcRBlFkcgXKuEirBvHpmtJ89YMhyeGcq20Wuc47Fa4XjyniywA==",
       "license": "Apache-2.0 OR MIT",
       "funding": {
         "type": "opencollective",
@@ -824,9 +824,9 @@
       }
     },
     "node_modules/@tauri-apps/cli": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli/-/cli-2.10.1.tgz",
-      "integrity": "sha512-jQNGF/5quwORdZSSLtTluyKQ+o6SMa/AUICfhf4egCGFdMHqWssApVgYSbg+jmrZoc8e1DscNvjTnXtlHLS11g==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli/-/cli-2.11.0.tgz",
+      "integrity": "sha512-W5Wbuqsb2pHFPTj4TaRNKTj5rwXhDShPiLSY9T18y4ouSR/NNCptAEFxFsBtyNRgL6Vs1a/q9LzfqqYzEwC+Jw==",
       "dev": true,
       "license": "Apache-2.0 OR MIT",
       "bin": {
@@ -840,23 +840,23 @@
         "url": "https://opencollective.com/tauri"
       },
       "optionalDependencies": {
-        "@tauri-apps/cli-darwin-arm64": "2.10.1",
-        "@tauri-apps/cli-darwin-x64": "2.10.1",
-        "@tauri-apps/cli-linux-arm-gnueabihf": "2.10.1",
-        "@tauri-apps/cli-linux-arm64-gnu": "2.10.1",
-        "@tauri-apps/cli-linux-arm64-musl": "2.10.1",
-        "@tauri-apps/cli-linux-riscv64-gnu": "2.10.1",
-        "@tauri-apps/cli-linux-x64-gnu": "2.10.1",
-        "@tauri-apps/cli-linux-x64-musl": "2.10.1",
-        "@tauri-apps/cli-win32-arm64-msvc": "2.10.1",
-        "@tauri-apps/cli-win32-ia32-msvc": "2.10.1",
-        "@tauri-apps/cli-win32-x64-msvc": "2.10.1"
+        "@tauri-apps/cli-darwin-arm64": "2.11.0",
+        "@tauri-apps/cli-darwin-x64": "2.11.0",
+        "@tauri-apps/cli-linux-arm-gnueabihf": "2.11.0",
+        "@tauri-apps/cli-linux-arm64-gnu": "2.11.0",
+        "@tauri-apps/cli-linux-arm64-musl": "2.11.0",
+        "@tauri-apps/cli-linux-riscv64-gnu": "2.11.0",
+        "@tauri-apps/cli-linux-x64-gnu": "2.11.0",
+        "@tauri-apps/cli-linux-x64-musl": "2.11.0",
+        "@tauri-apps/cli-win32-arm64-msvc": "2.11.0",
+        "@tauri-apps/cli-win32-ia32-msvc": "2.11.0",
+        "@tauri-apps/cli-win32-x64-msvc": "2.11.0"
       }
     },
     "node_modules/@tauri-apps/cli-darwin-arm64": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-arm64/-/cli-darwin-arm64-2.10.1.tgz",
-      "integrity": "sha512-Z2OjCXiZ+fbYZy7PmP3WRnOpM9+Fy+oonKDEmUE6MwN4IGaYqgceTjwHucc/kEEYZos5GICve35f7ZiizgqEnQ==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-arm64/-/cli-darwin-arm64-2.11.0.tgz",
+      "integrity": "sha512-UfMeDNlgIP252rm/KSTuu8yHatPua5TjtUEUf+jyIzVwBNcIl7Ywkdpfj+e5jVVg3EfCTp+4gwuL1dNpgF8clg==",
       "cpu": [
         "arm64"
       ],
@@ -871,9 +871,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-darwin-x64": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-x64/-/cli-darwin-x64-2.10.1.tgz",
-      "integrity": "sha512-V/irQVvjPMGOTQqNj55PnQPVuH4VJP8vZCN7ajnj+ZS8Kom1tEM2hR3qbbIRoS3dBKs5mbG8yg1WC+97dq17Pw==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-x64/-/cli-darwin-x64-2.11.0.tgz",
+      "integrity": "sha512-lY1+aPlgyMN7vgjtCdQ3+WODfZkebAcxnrCrO0HjqDpKSXieDkrJbimqeaoM4RwhTSrCLRHfVYiYrfE5E131tg==",
       "cpu": [
         "x64"
       ],
@@ -888,9 +888,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-arm-gnueabihf": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm-gnueabihf/-/cli-linux-arm-gnueabihf-2.10.1.tgz",
-      "integrity": "sha512-Hyzwsb4VnCWKGfTw+wSt15Z2pLw2f0JdFBfq2vHBOBhvg7oi6uhKiF87hmbXOBXUZaGkyRDkCHsdzJcIfoJC2w==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm-gnueabihf/-/cli-linux-arm-gnueabihf-2.11.0.tgz",
+      "integrity": "sha512-5uCP0AusgN3NrKC8EpkuJwjek1k8pEffBdugJSpXPey/QGbPEb8vZ542n/giJ2mZPjMSllDkdhG2QIDpBY4PpQ==",
       "cpu": [
         "arm"
       ],
@@ -905,13 +905,16 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-arm64-gnu": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-2.10.1.tgz",
-      "integrity": "sha512-OyOYs2t5GkBIvyWjA1+h4CZxTcdz1OZPCWAPz5DYEfB0cnWHERTnQ/SLayQzncrT0kwRoSfSz9KxenkyJoTelA==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-2.11.0.tgz",
+      "integrity": "sha512-loDPqtRHMSbIcrH2VBd4GgHoQlF7jJnrZj7MxA2lj1cixS/jEgMAPFqj83U6Wvjete4HfYplbE/gCpSFifA9jw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -922,13 +925,16 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-arm64-musl": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.10.1.tgz",
-      "integrity": "sha512-MIj78PDDGjkg3NqGptDOGgfXks7SYJwhiMh8SBoZS+vfdz7yP5jN18bNaLnDhsVIPARcAhE1TlsZe/8Yxo2zqg==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.11.0.tgz",
+      "integrity": "sha512-DtSE8ZBlB9H+L+eHkfZ3myt00EVEyAB3e41juEHoE2qT88fgVlJvyrwa9SZYc/xTwCS9TnmK+R84tpg+ZsAg7Q==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -939,13 +945,16 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-riscv64-gnu": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-riscv64-gnu/-/cli-linux-riscv64-gnu-2.10.1.tgz",
-      "integrity": "sha512-X0lvOVUg8PCVaoEtEAnpxmnkwlE1gcMDTqfhbefICKDnOTJ5Est3qL0SrWxizDackIOKBcvtpejrSiVpuJI1kw==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-riscv64-gnu/-/cli-linux-riscv64-gnu-2.11.0.tgz",
+      "integrity": "sha512-5QdgS4LD+kntClI1aj2JmwjW38LosNXxwCe8viIHEwqYIWuMPdNEIau6/cLogI38Yzx9DnfCPRfEWLyI+5li8Q==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -956,13 +965,16 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-x64-gnu": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-gnu/-/cli-linux-x64-gnu-2.10.1.tgz",
-      "integrity": "sha512-2/12bEzsJS9fAKybxgicCDFxYD1WEI9kO+tlDwX5znWG2GwMBaiWcmhGlZ8fi+DMe9CXlcVarMTYc0L3REIRxw==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-gnu/-/cli-linux-x64-gnu-2.11.0.tgz",
+      "integrity": "sha512-5UynPXo3Zq9khjVdAbD+YogeLltdVUeOah2ioSIM3tu6H7wY9vMy6rgGJhv9r5R8ZXmk9GttMippdqYJWrnLnA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -973,13 +985,16 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-x64-musl": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-musl/-/cli-linux-x64-musl-2.10.1.tgz",
-      "integrity": "sha512-Y8J0ZzswPz50UcGOFuXGEMrxbjwKSPgXftx5qnkuMs2rmwQB5ssvLb6tn54wDSYxe7S6vlLob9vt0VKuNOaCIQ==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-musl/-/cli-linux-x64-musl-2.11.0.tgz",
+      "integrity": "sha512-CNz7fHbApz1Zyhhq73jtGn9JqgNEV/lIWnTnUo6h6ujw+mHsTmkLszvJSM8W6JBaDjNpTTFr/RSNoVL5FMwcTg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -990,9 +1005,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-win32-arm64-msvc": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-2.10.1.tgz",
-      "integrity": "sha512-iSt5B86jHYAPJa/IlYw++SXtFPGnWtFJriHn7X0NFBVunF6zu9+/zOn8OgqIWSl8RgzhLGXQEEtGBdR4wzpVgg==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-2.11.0.tgz",
+      "integrity": "sha512-K+br+VXZ+Xx0n/9FdWohpW5Ugq+2FQUpJScqcPl1hTxXfh3fgjYgt4qA2NgrjlJo+zZPNrmUMl+NLvm0ufEqBQ==",
       "cpu": [
         "arm64"
       ],
@@ -1007,9 +1022,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-win32-ia32-msvc": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-ia32-msvc/-/cli-win32-ia32-msvc-2.10.1.tgz",
-      "integrity": "sha512-gXyxgEzsFegmnWywYU5pEBURkcFN/Oo45EAwvZrHMh+zUSEAvO5E8TXsgPADYm31d1u7OQU3O3HsYfVBf2moHw==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-ia32-msvc/-/cli-win32-ia32-msvc-2.11.0.tgz",
+      "integrity": "sha512-OFV+s3MLZnd75zl0ZAFU5riMpGK4waUEA8ZDuijDsnkU0btz/gHhqh5jVlOn8thyvgdtT3Xyoxqo099MMifH3g==",
       "cpu": [
         "ia32"
       ],
@@ -1024,9 +1039,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-win32-x64-msvc": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-x64-msvc/-/cli-win32-x64-msvc-2.10.1.tgz",
-      "integrity": "sha512-6Cn7YpPFwzChy0ERz6djKEmUehWrYlM+xTaNzGPgZocw3BD7OfwfWHKVWxXzdjEW2KfKkHddfdxK1XXTYqBRLg==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-x64-msvc/-/cli-win32-x64-msvc-2.11.0.tgz",
+      "integrity": "sha512-AeDTWBd2cOZ6TX133BWsoo+LutG9o0JRcgjMsIfLE13ZugpgCMv/2dJbUiBGeRvbPOGin5A3aYmsArPVV6ZSHQ==",
       "cpu": [
         "x64"
       ],

--- a/winsmux-app/package.json
+++ b/winsmux-app/package.json
@@ -14,14 +14,14 @@
     "tauri": "tauri"
   },
   "dependencies": {
-    "@tauri-apps/api": "^2",
+    "@tauri-apps/api": "2.11.0",
     "@tauri-apps/plugin-opener": "^2",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-web-links": "^0.12.0",
     "xterm": "^5.3.0"
   },
   "devDependencies": {
-    "@tauri-apps/cli": "^2",
+    "@tauri-apps/cli": "2.11.0",
     "playwright": "^1.58.1",
     "typescript": "~5.6.2",
     "vite": "^6.4.2"

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -482,6 +482,7 @@ let sourceControlCommitMessage = "";
 let operatorPtyStarted = false;
 let operatorPtyStarting: Promise<void> | null = null;
 let operatorRequestActive = false;
+let operatorRequestGeneration = 0;
 let operatorRequestStartedAt = 0;
 let operatorRequestStatusTimer: number | null = null;
 let operatorInterruptInFlight = false;
@@ -10587,6 +10588,20 @@ function setOperatorRequestActive(active: boolean) {
   updateOperatorStatusIndicator();
 }
 
+function beginOperatorRequest() {
+  operatorRequestGeneration += 1;
+  setOperatorRequestActive(true);
+  return operatorRequestGeneration;
+}
+
+function invalidateOperatorRequest() {
+  operatorRequestGeneration += 1;
+}
+
+function isCurrentOperatorRequest(generation: number) {
+  return operatorRequestActive && operatorRequestGeneration === generation;
+}
+
 async function interruptOperatorRequest() {
   if (!operatorRequestActive || operatorInterruptInFlight) {
     return;
@@ -10594,11 +10609,16 @@ async function interruptOperatorRequest() {
 
   const timestamp = new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
   operatorInterruptInFlight = true;
+  invalidateOperatorRequest();
+  const canceledGeneration = operatorRequestGeneration;
+  setOperatorRequestActive(false);
   updateOperatorInterruptButton();
   try {
     await ensureOperatorPtyStarted();
+    if (operatorRequestGeneration !== canceledGeneration || operatorRequestActive) {
+      return;
+    }
     await writePtyData(OPERATOR_PTY_ID, "\x03");
-    setOperatorRequestActive(false);
     appendRuntimeConversation({
       type: "system",
       category: "attention",
@@ -10660,10 +10680,16 @@ async function forwardComposerMessageToOperatorPane(
     return;
   }
 
+  const requestGeneration = beginOperatorRequest();
   try {
-    setOperatorRequestActive(true);
     await ensureOperatorPtyStarted();
+    if (!isCurrentOperatorRequest(requestGeneration)) {
+      return;
+    }
     await writePtyData(OPERATOR_PTY_ID, encodePtySubmission(payload));
+    if (!isCurrentOperatorRequest(requestGeneration)) {
+      return;
+    }
     appendRuntimeConversation({
       type: "operator",
       category: "activity",
@@ -10679,6 +10705,9 @@ async function forwardComposerMessageToOperatorPane(
     });
     renderConversation(getConversationItems());
   } catch (error) {
+    if (!isCurrentOperatorRequest(requestGeneration)) {
+      return;
+    }
     setOperatorRequestActive(false);
     const errorMessage = error instanceof Error ? error.message : String(error);
     const desktopRuntimeError = errorMessage.includes("outside the Tauri runtime");
@@ -11521,7 +11550,7 @@ window.addEventListener("DOMContentLoaded", async () => {
     focusedWorkbenchPaneId = storedShellPreferences.focusedWorkbenchPaneId;
   }
 
-  await subscribeToPtyOutput((payload) => {
+  void subscribeToPtyOutput((payload) => {
     if (payload.pane_id === OPERATOR_PTY_ID) {
       appendOperatorPtyOutput(payload.data);
       return;
@@ -11545,6 +11574,8 @@ window.addEventListener("DOMContentLoaded", async () => {
       first.terminal.write(payload.data);
       renderPaneMetadata();
     }
+  }).catch((error) => {
+    console.warn("Failed to subscribe to PTY output events", error);
   });
 
   renderSessions();
@@ -11573,8 +11604,8 @@ window.addEventListener("DOMContentLoaded", async () => {
   setEditorSurface(false);
   setTerminalDrawer(true);
   applyPopoutSurfaceState(popoutSurfaceState);
-  await refreshDesktopSummary();
   registerDesktopSummaryLiveRefresh();
+  void refreshDesktopSummary();
   initializeSidebarResize();
   initializeWorkbenchResize();
   initializeSourceControlSplitResize();


### PR DESCRIPTION
## Summary
- register desktop PTY and summary refresh work without blocking UI handler setup
- pin Tauri npm packages to 2.11.0 to match the Rust-side Tauri line
- split legacy alias binaries into thin wrappers over the shared winsmux CLI entrypoint
- closes #813

## Validation
- cargo check -p winsmux
- cargo check -p winsmux --bins
- cargo check -p winsmux-app
- cmd /c npm run build
- cmd /c npm run test:viewport-harness (sandbox hit esbuild spawn EPERM; normal privilege rerun passed)
- git diff --check
- pwsh -NoProfile -File scripts/audit-public-surface.ps1
- pwsh -NoProfile -File scripts/git-guard.ps1
- codex exec --profile review review --uncommitted --title "TASK-460 dev startup click handlers"
