### PR TITLE
Fix operator chat and visible attach UX

### DIFF
--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -4936,7 +4936,7 @@ Describe 'orchestra-start server bootstrap' {
         $script:probeCount | Should -Be 2
     }
 
-    It 'launches visible attach through a fixed Windows Terminal profile and handshake' {
+    It 'launches visible attach through Windows Terminal without relying on profile reload timing' {
         $script:startProcessCalls = @()
         $script:winsmuxBin = 'C:\winsmux\winsmux.exe'
 
@@ -4977,6 +4977,8 @@ Describe 'orchestra-start server bootstrap' {
         Mock Wait-OrchestraAttachLaunchObservation {
             [PSCustomObject]@{ Observed = $true; Reason = 'launch observed' }
         }
+        Mock Get-OrchestraPowerShellPath { 'C:\Program Files\PowerShell\7\pwsh.exe' }
+        Mock Get-OrchestraAttachEntryArgumentList { @('-NoLogo', '-NoExit', '-File', 'C:\repo\winsmux-core\scripts\orchestra-attach-entry.ps1') }
         Mock Wait-OrchestraAttachHandshake {
             [PSCustomObject][ordered]@{
                 Confirmed           = $true
@@ -5025,7 +5027,13 @@ Describe 'orchestra-start server bootstrap' {
         $result.attach_adapter_trace[0].launch_result | Should -Be 'attach_confirmed'
         $script:startProcessCalls.Count | Should -Be 1
         $script:startProcessCalls[0].FilePath | Should -Be 'C:\Windows\System32\wt.exe'
-        $script:startProcessCalls[0].ArgumentList | Should -Be @('-w', '-1', 'new-window', '-p', '"winsmux orchestra attach"')
+        $script:startProcessCalls[0].ArgumentList | Should -Contain 'new-window'
+        $script:startProcessCalls[0].ArgumentList | Should -Not -Contain '-p'
+        $script:startProcessCalls[0].ArgumentList | Should -Contain '--title'
+        $script:startProcessCalls[0].ArgumentList | Should -Contain 'winsmux-orchestra'
+        $script:startProcessCalls[0].ArgumentList | Should -Contain '"C:\Program Files\PowerShell\7\pwsh.exe"'
+        $script:startProcessCalls[0].ArgumentList | Should -Contain '-File'
+        $script:startProcessCalls[0].ArgumentList | Should -Contain 'C:\repo\winsmux-core\scripts\orchestra-attach-entry.ps1'
     }
 
     It 'returns attach_already_present only when a live visible attach state already exists' {

--- a/winsmux-app/scripts/viewport-harness.mjs
+++ b/winsmux-app/scripts/viewport-harness.mjs
@@ -8,6 +8,23 @@ import { chromium } from "playwright";
 
 const OUTPUT_DIR = path.join(process.cwd(), "output", "playwright", "viewport-harness");
 const HARNESS_QUERY = "?viewport-harness=1";
+const APP_DIR = process.cwd();
+
+async function assertOperatorChatContractSource() {
+  const source = await fs.readFile(path.join(APP_DIR, "src", "main.ts"), "utf8");
+  const forbiddenSnippets = [
+    "Sent to operator",
+    "オペレーターへ送信",
+    "The request was sent to the operator session.",
+    "依頼内容をオペレーターセッションへ送信しました。",
+  ];
+  const matched = forbiddenSnippets.filter((snippet) => source.includes(snippet));
+  if (matched.length > 0) {
+    throw new Error(
+      `Operator chat must mirror Claude Code output without internal sent acknowledgements: ${matched.join(", ")}`,
+    );
+  }
+}
 
 async function ensureOutputDir() {
   await fs.mkdir(OUTPUT_DIR, { recursive: true });
@@ -1232,6 +1249,7 @@ async function verifyDeveloperWindowViewport(page, previewUrl, width, height, la
 }
 
 async function run() {
+  await runStep("desktop-operator-chat-contract", assertOperatorChatContractSource);
   await ensureOutputDir();
 
   const previewPort = await getAvailablePort();
@@ -1260,6 +1278,7 @@ async function run() {
           generatedAt: new Date().toISOString(),
           previewUrl,
           checks: [
+            "desktop-operator-chat-contract",
             "desktop-1440x900",
             "desktop-command-bar",
             "desktop-composer-model-controls",

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -10492,14 +10492,7 @@ function appendUserMessage(message: string, attachments: ComposerAttachment[]) {
       sizeLabel: attachment.sizeLabel,
     })),
   });
-  void forwardComposerMessageToOperatorPane(message, attachments, timestamp, [
-    { label: "mode", value: activeComposerMode },
-    { label: "permission-mode", value: activeComposerPermissionMode },
-    { label: "model", value: getComposerModelOption().label },
-    { label: "effort", value: activeComposerEffort },
-    { label: "fast-mode", value: activeComposerFastModeEnabled ? "enabled" : "disabled" },
-    { label: "attachments", value: `${attachments.length}` },
-  ]);
+  void forwardComposerMessageToOperatorPane(message, attachments, timestamp);
   void recordComposerDogfoodEvent(message, attachments, dogfoodInputSource, dogfoodStartedAt, dogfoodDraft);
   resetComposerDogfoodDraft();
   renderRunSummary();
@@ -10672,7 +10665,6 @@ async function forwardComposerMessageToOperatorPane(
   message: string,
   attachments: ComposerAttachment[],
   timestamp: string,
-  details: ConversationDetail[],
 ) {
   const payload = formatComposerMessageForPty(message, attachments);
   if (!payload.trim()) {
@@ -10690,20 +10682,6 @@ async function forwardComposerMessageToOperatorPane(
     if (!isCurrentOperatorRequest(requestGeneration)) {
       return;
     }
-    appendRuntimeConversation({
-      type: "operator",
-      category: "activity",
-      timestamp,
-      actor: "Operator",
-      title: getLanguageText("Sent to operator", "オペレーターへ送信"),
-      body: getLanguageText(
-        "The request was sent to the operator session.",
-        "依頼内容をオペレーターセッションへ送信しました。",
-      ),
-      details,
-      tone: "info",
-    });
-    renderConversation(getConversationItems());
   } catch (error) {
     if (!isCurrentOperatorRequest(requestGeneration)) {
       return;

--- a/winsmux-core/scripts/orchestra-ui-attach.ps1
+++ b/winsmux-core/scripts/orchestra-ui-attach.ps1
@@ -428,10 +428,28 @@ function ConvertTo-OrchestraQuotedArgument {
 function Start-OrchestraWindowsTerminalVisibleAttach {
     param(
         [Parameter(Mandatory = $true)][string]$TerminalPath,
-        [Parameter(Mandatory = $true)][string]$ProfileName
+        [Parameter(Mandatory = $true)][string]$ProjectDir
     )
 
-    $process = Start-Process -FilePath $TerminalPath -ArgumentList @('-w', '-1', 'new-window', '-p', (ConvertTo-OrchestraQuotedArgument -Value $ProfileName)) -PassThru
+    $pwshPath = Get-OrchestraPowerShellPath
+    $argumentList = @(
+        '-w',
+        '-1',
+        'new-window',
+        '-d',
+        (ConvertTo-OrchestraQuotedArgument -Value $ProjectDir),
+        '--title',
+        'winsmux-orchestra',
+        (ConvertTo-OrchestraQuotedArgument -Value $pwshPath)
+    ) + (Get-OrchestraAttachEntryArgumentList | ForEach-Object {
+        if ([string]$_ -match '[\s"]') {
+            ConvertTo-OrchestraQuotedArgument -Value ([string]$_)
+        } else {
+            [string]$_
+        }
+    })
+
+    $process = Start-Process -FilePath $TerminalPath -ArgumentList $argumentList -PassThru
     return [PSCustomObject][ordered]@{
         HostKind = 'windows-terminal'
         Path     = $TerminalPath
@@ -582,8 +600,8 @@ function Start-OrchestraVisibleAttachHostCandidate {
 
     switch ([string]$Candidate.HostKind) {
         'windows-terminal' {
-            $profile = Ensure-OrchestraAttachProfile -ProjectDir ([string]$Candidate.ProjectDir)
-            return Start-OrchestraWindowsTerminalVisibleAttach -TerminalPath ([string]$Candidate.Path) -ProfileName ([string]$profile.ProfileName)
+            $null = Ensure-OrchestraAttachProfile -ProjectDir ([string]$Candidate.ProjectDir)
+            return Start-OrchestraWindowsTerminalVisibleAttach -TerminalPath ([string]$Candidate.Path) -ProjectDir ([string]$Candidate.ProjectDir)
         }
         'powershell-window' {
             return Start-OrchestraPowerShellVisibleAttach


### PR DESCRIPTION
## Summary
- Remove the internal sent-to-operator acknowledgement so the desktop chat mirrors actual Claude Code output.
- Add a viewport-harness contract that rejects the acknowledgement strings if they return.
- Launch Windows Terminal visible attach through the attach entry command directly, avoiding failed profile reload timing windows.

Closes #815.

## Validation
- cmd /c node --check scripts\viewport-harness.mjs
- cmd /c npm run build
- cmd /c npm run test:viewport-harness
- Invoke-Pester -Path tests\winsmux-bridge.Tests.ps1 -FullName '*Windows Terminal*' -Output Detailed
- Invoke-Pester -Path tests\winsmux-bridge.Tests.ps1 -Output Normal
- git diff --check
- pwsh -NoProfile -File scripts\audit-public-surface.ps1
- pwsh -NoProfile -File scripts\git-guard.ps1
- codex exec --profile review review --uncommitted --title "TASK-461 operator chat and attach UX"