### PR TITLE
Autosize desktop composer input

### DIFF
--- a/winsmux-app/scripts/viewport-harness.mjs
+++ b/winsmux-app/scripts/viewport-harness.mjs
@@ -1050,6 +1050,41 @@ async function verifyDesktopViewport(page, previewUrl) {
     await assertFullyVisible(page, "#workspace-footer");
     await assertNoOverlap(page, "#workspace-body", "#workspace-footer");
   });
+
+  await runStep("desktop composer autosizes without resize grabber", async () => {
+    const initialHeight = await page.locator("#composer-input").evaluate((input) => input.getBoundingClientRect().height);
+    await page.locator("#composer-input").fill(Array.from({ length: 40 }, (_, index) => `line ${index + 1}`).join("\n"));
+    await page.waitForFunction(
+      (baselineHeight) => {
+        const input = document.querySelector("#composer-input");
+        if (!(input instanceof HTMLTextAreaElement)) {
+          return false;
+        }
+        const styles = getComputedStyle(input);
+        const rect = input.getBoundingClientRect();
+        const maxHeight = Number.parseFloat(styles.maxHeight);
+        return styles.resize === "none" &&
+          rect.height > baselineHeight + 20 &&
+          rect.height <= maxHeight + 1 &&
+          input.scrollHeight > input.clientHeight &&
+          styles.overflowY === "auto";
+      },
+      initialHeight,
+    );
+    await page.locator("#composer-input").fill("");
+    await page.waitForFunction(
+      (baselineHeight) => {
+        const input = document.querySelector("#composer-input");
+        if (!(input instanceof HTMLTextAreaElement)) {
+          return false;
+        }
+        const rect = input.getBoundingClientRect();
+        return rect.height <= baselineHeight + 1 && getComputedStyle(input).overflowY === "hidden";
+      },
+      initialHeight,
+    );
+  });
+
   await assertComposerSessionControls(page, previewUrl);
 
   await runStep("desktop command bar", async () => {
@@ -1280,6 +1315,7 @@ async function run() {
           checks: [
             "desktop-operator-chat-contract",
             "desktop-1440x900",
+            "desktop-composer-autosize",
             "desktop-command-bar",
             "desktop-composer-model-controls",
             "desktop-composer-japanese-controls",

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -6874,6 +6874,7 @@ function applyComposerSlashCommand(command: ComposerSlashCommand) {
   } else {
     composerInput.value = `/${command.command}${command.command ? " " : ""}`;
   }
+  syncComposerInputHeight(composerInput);
   syncComposerSlashState(composerInput.value);
   exitComposerHistoryToDraft(composerInput.value);
   composerInput.focus();
@@ -6972,6 +6973,7 @@ function startVoiceInput(composerInput: HTMLTextAreaElement) {
     }
     const separator = voiceTranscriptBase && transcript ? " " : "";
     composerInput.value = `${voiceTranscriptBase}${separator}${transcript}`.trimStart();
+    syncComposerInputHeight(composerInput);
     composerInput.focus();
     const length = composerInput.value.length;
     composerInput.setSelectionRange(length, length);
@@ -7149,6 +7151,21 @@ function isCaretOnLastLine(composerInput: HTMLTextAreaElement) {
   return !composerInput.value.slice(composerInput.selectionEnd).includes("\n");
 }
 
+function syncComposerInputHeight(composerInput?: HTMLTextAreaElement | null) {
+  const input = composerInput ?? (document.getElementById("composer-input") as HTMLTextAreaElement | null);
+  if (!input) {
+    return;
+  }
+
+  input.style.height = "auto";
+  const computed = window.getComputedStyle(input);
+  const minHeight = Number.parseFloat(computed.minHeight) || 0;
+  const maxHeight = Number.parseFloat(computed.maxHeight) || input.scrollHeight;
+  const targetHeight = Math.min(Math.max(input.scrollHeight, minHeight), maxHeight);
+  input.style.height = `${Math.ceil(targetHeight)}px`;
+  input.style.overflowY = input.scrollHeight > maxHeight + 1 ? "auto" : "hidden";
+}
+
 function setComposerValue(value: string) {
   const composerInput = document.getElementById("composer-input") as HTMLTextAreaElement | null;
   if (!composerInput) {
@@ -7156,6 +7173,7 @@ function setComposerValue(value: string) {
   }
 
   composerInput.value = value;
+  syncComposerInputHeight(composerInput);
   syncComposerSlashState(value);
   const length = value.length;
   composerInput.setSelectionRange(length, length);
@@ -11920,6 +11938,7 @@ window.addEventListener("DOMContentLoaded", async () => {
       if (composerHistoryIndex !== -1) {
         composerHistoryIndex = -1;
       }
+      syncComposerInputHeight(composerInput);
       syncComposerDraftState(composerInput.value);
       syncComposerSlashState(composerInput.value);
     });
@@ -11990,6 +12009,7 @@ window.addEventListener("DOMContentLoaded", async () => {
       appendUserMessage(rawValue, submittedAttachments);
       pushComposerHistoryEntry(historyEntry);
       composerInput.value = "";
+      syncComposerInputHeight(composerInput);
       syncComposerSlashState(composerInput.value);
       clearPendingAttachments();
       selectedComposerRemoteReferenceIds.clear();
@@ -11997,6 +12017,8 @@ window.addEventListener("DOMContentLoaded", async () => {
       renderAttachmentTray();
       requestDesktopSummaryRefresh(undefined, 750);
     });
+
+    syncComposerInputHeight(composerInput);
   }
 
   attachButton?.addEventListener("click", () => {
@@ -12084,6 +12106,7 @@ window.addEventListener("DOMContentLoaded", async () => {
 
   window.addEventListener("resize", () => {
     syncResponsiveShell();
+    syncComposerInputHeight();
     fitVisibleWorkbenchPanes();
   });
 

--- a/winsmux-app/src/styles.css
+++ b/winsmux-app/src/styles.css
@@ -1737,7 +1737,9 @@ body[data-popout-surface="1"] #editor-surface {
 #composer-input {
   width: 100%;
   min-height: 54px;
-  resize: vertical;
+  max-height: min(40vh, 360px);
+  resize: none;
+  overflow-y: hidden;
   border: 1px solid #6a6a6a;
   border-radius: 4px;
   background: #1e1e1e;


### PR DESCRIPTION
## Summary
- Hide the native textarea resize grabber in the desktop composer.
- Autosize the composer as text grows, cap it to the viewport, and use internal scrolling after the cap.
- Add viewport harness coverage for the resize-free autosize behavior.

## Validation
- cmd /c node --check scripts\\viewport-harness.mjs
- cmd /c npm run build
- powershell -NoProfile -ExecutionPolicy Bypass -File scripts\\audit-public-surface.ps1
- powershell -NoProfile -ExecutionPolicy Bypass -File scripts\\git-guard.ps1
- codex review: no actionable bug found

Closes #818