### PR TITLE
Reduce orchestra helper process pressure

### DIFF
--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -4750,23 +4750,19 @@ Describe 'orchestra-start watchdog contract' {
         $script:orchestraStartContent = Get-Content -Path $script:orchestraStartPath -Raw -Encoding UTF8
     }
 
-    It 'launches operator-poll with Start-Process before the watchdog' {
-        $script:orchestraStartContent | Should -Match 'function Start-OperatorPollJob \{'
-        $script:orchestraStartContent | Should -Match 'operator-poll\.ps1'
-        $script:orchestraStartContent | Should -Match "'-Interval'"
-        $script:orchestraStartContent | Should -Match '-Interval 20'
-        $script:orchestraStartContent | Should -Match '-OperatorPollPid \$operatorPollProcess\.Id'
-
-        $operatorPollIndex = $script:orchestraStartContent.IndexOf('$operatorPollProcess = Start-OperatorPollJob')
-        $watchdogIndex = $script:orchestraStartContent.IndexOf('$watchdogProcess = Start-AgentWatchdogJob')
-        $operatorPollIndex | Should -BeGreaterThan -1
-        $watchdogIndex | Should -BeGreaterThan -1
-        $operatorPollIndex | Should -BeLessThan $watchdogIndex
+    It 'launches a single orchestra supervisor process for operator and watchdog loops' {
+        $script:orchestraStartContent | Should -Match 'function Start-OrchestraSupervisorJob \{'
+        $script:orchestraStartContent | Should -Match 'orchestra-supervisor\.ps1'
+        $script:orchestraStartContent | Should -Match "'-OperatorPollInterval'"
+        $script:orchestraStartContent | Should -Match "'-AgentWatchdogInterval'"
+        $script:orchestraStartContent | Should -Match "'-ServerWatchdogInterval'"
+        $script:orchestraStartContent | Should -Match '-SupervisorPid \$supervisorProcess\.Id'
+        $script:orchestraStartContent | Should -Not -Match '\$operatorPollProcess = Start-OperatorPollJob'
+        $script:orchestraStartContent | Should -Not -Match '\$watchdogProcess = Start-AgentWatchdogJob'
+        $script:orchestraStartContent | Should -Not -Match '\$serverWatchdogProcess = Start-ServerWatchdogJob'
     }
 
-    It 'launches the watchdog with Start-Process so it survives script exit' {
-        $script:orchestraStartContent | Should -Match 'function Start-AgentWatchdogJob \{'
-        $script:orchestraStartContent | Should -Match 'function Start-ServerWatchdogJob \{'
+    It 'launches the supervisor with Start-Process so it survives script exit' {
         $script:orchestraStartContent | Should -Match 'Start-Process\s+-FilePath\s+''pwsh'''
         $script:orchestraStartContent | Should -Match "'-NoProfile'"
         $script:orchestraStartContent | Should -Match "'-File'"
@@ -4774,16 +4770,10 @@ Describe 'orchestra-start watchdog contract' {
         $script:orchestraStartContent | Should -Not -Match 'Start-Job\s+-Name\s+\("winsmux-watchdog-'
     }
 
-    It 'persists both process pids and prints cleanup guidance' {
-        $script:orchestraStartContent | Should -Match 'operator_poll_pid\s*=\s*\$OperatorPollPid'
-        $script:orchestraStartContent | Should -Match 'Operator Poll PID: \$\(\$operatorPollProcess\.Id\)'
-        $script:orchestraStartContent | Should -Match 'watchdog_pid\s*=\s*\$WatchdogPid'
-        $script:orchestraStartContent | Should -Match 'server_watchdog_pid\s*=\s*\$ServerWatchdogPid'
-        $script:orchestraStartContent | Should -Match '-WatchdogPid \$watchdogProcess\.Id'
-        $script:orchestraStartContent | Should -Match '-ServerWatchdogPid \$serverWatchdogProcess\.Id'
-        $script:orchestraStartContent | Should -Match 'Watchdog PID: \$\(\$watchdogProcess\.Id\)'
-        $script:orchestraStartContent | Should -Match 'Server Watchdog PID: \$\(\$serverWatchdogProcess\.Id\)'
-        $script:orchestraStartContent | Should -Match 'Stop-Process -Id \{0\},\{1\}'
+    It 'persists the supervisor pid and prints cleanup guidance' {
+        $script:orchestraStartContent | Should -Match 'supervisor_pid\s*=\s*\$SupervisorPid'
+        $script:orchestraStartContent | Should -Match 'Supervisor PID: \$\(\$supervisorProcess\.Id\)'
+        $script:orchestraStartContent | Should -Match 'Stop-Process -Id \{0\}'
     }
 }
 
@@ -5200,9 +5190,63 @@ Describe 'orchestra-start server bootstrap' {
         $script:startProcessCalls.Count | Should -Be 0
     }
 
+    It 'reuses attached-client registry confirmation even when the visible host process is gone' {
+        $script:startProcessCalls = @()
+        $script:winsmuxBin = 'C:\winsmux\winsmux.exe'
+        $script:attachStateStore = $null
+
+        Mock Get-OrchestraAttachedClientSnapshot {
+            [PSCustomObject]@{ Ok = $true; Count = 1; Error = ''; Clients = @('client-1') }
+        }
+        Mock Read-OrchestraAttachState {
+            [pscustomobject]@{
+                session_name              = 'winsmux-orchestra'
+                attach_status             = 'attach_confirmed'
+                ui_attach_source          = 'attached-client-registry'
+                attach_process_id         = 4242
+                attached_client_count     = 1
+                attached_client_snapshot  = @('client-1')
+            }
+        }
+        Mock Test-OrchestraLiveVisibleAttachState { $false }
+        Mock Write-OrchestraAttachState {
+            param([string]$SessionName, [hashtable]$Properties)
+            $merged = [ordered]@{}
+            if ($null -ne $script:attachStateStore) {
+                foreach ($property in $script:attachStateStore.PSObject.Properties) {
+                    $merged[$property.Name] = $property.Value
+                }
+            }
+            foreach ($key in $Properties.Keys) {
+                $merged[$key] = $Properties[$key]
+            }
+            $script:attachStateStore = [pscustomobject]$merged
+            return $script:attachStateStore
+        }
+
+        function Start-Process {
+            param([string]$FilePath, [object[]]$ArgumentList, [switch]$PassThru)
+            $script:startProcessCalls += ,([PSCustomObject]@{
+                FilePath     = $FilePath
+                ArgumentList = @($ArgumentList)
+            })
+            return [PSCustomObject]@{ HasExited = $false }
+        }
+
+        $result = Try-StartOrchestraUiAttach -SessionName 'winsmux-orchestra'
+
+        $result.Attempted | Should -Be $false
+        $result.Launched | Should -Be $false
+        $result.Attached | Should -Be $true
+        $result.Status | Should -Be 'attach_already_present'
+        $result.Source | Should -Be 'attached-client-registry'
+        $script:startProcessCalls.Count | Should -Be 0
+    }
+
     It 'does not suppress attach from client-probe alone when no live visible attach state exists' {
         $script:startProcessCalls = @()
         $script:winsmuxBin = 'C:\winsmux\winsmux.exe'
+        $script:attachStateStore = $null
 
         Mock Get-OrchestraAttachedClientSnapshot {
             [PSCustomObject]@{ Ok = $true; Count = 1; Error = ''; Clients = @('client-1') }
@@ -6005,9 +6049,11 @@ Describe 'orchestra-start session reuse contract' {
         $script:orchestraStartContent | Should -Match 'attach_adapter_trace'
     }
 
-    It 'does not mark session_ready true in the manifest until watchdog processes are started' {
+    It 'does not mark session_ready true in the manifest until the supervisor process is started' {
         $script:orchestraStartContent | Should -Match 'Save-OrchestraSessionState[^\r\n]+SessionReady \$false'
-        $script:orchestraStartContent | Should -Match 'Save-OrchestraSessionState[^\r\n]+OperatorPollPid \$operatorPollProcess\.Id[^\r\n]+SessionReady \$true'
+        $script:orchestraStartContent | Should -Match 'Start-OrchestraSupervisorJob[^\r\n]+-StartupToken \$startupToken'
+        $script:orchestraStartContent | Should -Match 'Assert-OrchestraBackgroundProcessStarted -Process \$supervisorProcess -Name ''Orchestra supervisor job'''
+        $script:orchestraStartContent | Should -Match 'Save-OrchestraSessionState[^\r\n]+SupervisorPid \$supervisorProcess\.Id[^\r\n]+SessionReady \$true'
     }
 
     It 'keeps detached startup on the session-ready path even when visible attach still needs retry' {
@@ -6636,6 +6682,114 @@ Describe 'doctor bridge config metadata check' {
         } finally {
             $env:WINSMUX_DOCTOR_POWERSHELL_PROCESS_WARN_THRESHOLD = $originalValue
         }
+    }
+
+    It 'passes the orchestra process contract when smoke reports counts within budget' {
+        Mock Invoke-DoctorOrchestraSmokeJson {
+            [pscustomobject]@{
+                Ok       = $true
+                ExitCode = 0
+                Error    = ''
+                Data     = [pscustomobject]@{
+                    process_contract = [pscustomobject]@{
+                        ok                      = $true
+                        worker_shell_count      = 6
+                        background_helper_count = 3
+                        attach_host_count       = 1
+                        warm_process_count      = 1
+                        stale_process_count     = 0
+                        budgets                 = [pscustomobject]@{
+                            max_worker_shells      = 6
+                            max_background_helpers = 3
+                            max_attach_hosts       = 1
+                            max_warm_processes     = 1
+                            max_stale_processes    = 0
+                        }
+                        warnings                = @()
+                    }
+                }
+            }
+        }
+
+        $result = Test-OrchestraProcessContractCheck
+
+        $result.Status | Should -Be 'pass'
+        $result.Label | Should -Be 'Orchestra process contract'
+        $result.Detail | Should -Be 'workers=6/6; background_helpers=3/3; attach_hosts=1/1; warm_processes=1/1; stale_processes=0/0'
+    }
+
+    It 'fails the orchestra process contract when smoke reports process pressure over budget' {
+        Mock Invoke-DoctorOrchestraSmokeJson {
+            [pscustomobject]@{
+                Ok       = $true
+                ExitCode = 1
+                Error    = ''
+                Data     = [pscustomobject]@{
+                    process_contract = [pscustomobject]@{
+                        ok                      = $false
+                        worker_shell_count      = 7
+                        background_helper_count = 3
+                        attach_host_count       = 1
+                        warm_process_count      = 1
+                        stale_process_count     = 1
+                        budgets                 = [pscustomobject]@{
+                            max_worker_shells      = 6
+                            max_background_helpers = 3
+                            max_attach_hosts       = 1
+                            max_warm_processes     = 1
+                            max_stale_processes    = 0
+                        }
+                        warnings                = @(
+                            'worker shell count 7 exceeds budget 6.'
+                            'stale managed process count 1 exceeds budget 0.'
+                        )
+                    }
+                }
+            }
+        }
+
+        $result = Test-OrchestraProcessContractCheck
+
+        $result.Status | Should -Be 'fail'
+        $result.Label | Should -Be 'Orchestra process contract'
+        $result.Detail | Should -Match 'workers=7/6'
+        $result.Detail | Should -Match 'stale_processes=1/0'
+        $result.Detail | Should -Match 'worker shell count 7 exceeds budget 6'
+        $result.Detail | Should -Match 'stale managed process count 1 exceeds budget 0'
+    }
+
+    It 'handles a single orchestra process contract warning from smoke' {
+        Mock Invoke-DoctorOrchestraSmokeJson {
+            [pscustomobject]@{
+                Ok       = $true
+                ExitCode = 1
+                Error    = ''
+                Data     = [pscustomobject]@{
+                    process_contract = [pscustomobject]@{
+                        ok                      = $false
+                        worker_shell_count      = 6
+                        background_helper_count = 1
+                        attach_host_count       = 1
+                        warm_process_count      = 2
+                        stale_process_count     = 0
+                        budgets                 = [pscustomobject]@{
+                            max_worker_shells      = 6
+                            max_background_helpers = 1
+                            max_attach_hosts       = 1
+                            max_warm_processes     = 1
+                            max_stale_processes    = 0
+                        }
+                        warnings                = 'warm process count 2 exceeds budget 1.'
+                    }
+                }
+            }
+        }
+
+        $result = Test-OrchestraProcessContractCheck
+
+        $result.Status | Should -Be 'fail'
+        $result.Detail | Should -Match 'warm_processes=2/1'
+        $result.Detail | Should -Match 'warm process count 2 exceeds budget 1'
     }
 
     It 'summarizes low-count PowerShell startup evidence without leaking command lines or process ids' {
@@ -12903,6 +13057,42 @@ Describe 'winsmux orchestra-smoke command' {
                 Resolve-OrchestraSmokeAttachState -ProbeState $ProbeState -AttachState $AttachState -ClientProbeOk $ClientProbeOk -ClientSnapshot $ClientSnapshot
             } $ProbeState $AttachState $ClientProbeOk $ClientSnapshot $LiveVisibleAttach
         }
+
+        function Invoke-TestOrchestraProcessContract {
+            param(
+                [AllowNull()]$Manifest,
+                [AllowNull()]$AttachState,
+                [Parameter(Mandatory = $true)][int]$PaneCount,
+                [Parameter(Mandatory = $true)][int]$ExpectedPaneCount,
+                [Parameter(Mandatory = $true)][int]$AttachedClientCount,
+                [AllowNull()]$ProcessSnapshot
+            )
+
+            $contractSource = [regex]::Match(
+                $script:orchestraSmokeContent,
+                '(?s)function ConvertTo-OrchestraSmokeInt \{.*?\r?\n\}\r?\n\r?\nfunction Get-OrchestraAttachedClientSnapshot'
+            ).Value
+
+            if ([string]::IsNullOrWhiteSpace($contractSource)) {
+                throw 'Failed to extract process contract helpers from orchestra-smoke.ps1.'
+            }
+
+            $contractSource = $contractSource -replace '\r?\n\r?\nfunction Get-OrchestraAttachedClientSnapshot$', ''
+
+            & {
+                param($Manifest, $AttachState, $PaneCount, $ExpectedPaneCount, $AttachedClientCount, $ProcessSnapshot)
+
+                Set-StrictMode -Version Latest
+                Invoke-Expression $contractSource
+                Get-OrchestraSmokeProcessContract `
+                    -Manifest $Manifest `
+                    -AttachState $AttachState `
+                    -PaneCount $PaneCount `
+                    -ExpectedPaneCount $ExpectedPaneCount `
+                    -AttachedClientCount $AttachedClientCount `
+                    -ProcessSnapshot $ProcessSnapshot
+            } $Manifest $AttachState $PaneCount $ExpectedPaneCount $AttachedClientCount $ProcessSnapshot
+        }
     }
 
     It 'documents orchestra-smoke and dispatches it through the dedicated startup smoke script' {
@@ -12942,6 +13132,108 @@ Describe 'winsmux orchestra-smoke command' {
         $script:orchestraSmokeContent | Should -Match 'requires_startup'
         $script:orchestraSmokeContent | Should -Match 'worker_isolation'
         $script:orchestraSmokeContent | Should -Match 'worker isolation drift'
+        $script:orchestraSmokeContent | Should -Match 'process_contract'
+        $script:orchestraSmokeContent | Should -Match 'worker_shell_count'
+        $script:orchestraSmokeContent | Should -Match 'background_helper_count'
+        $script:orchestraSmokeContent | Should -Match 'attach_host_count'
+        $script:orchestraSmokeContent | Should -Match 'warm_process_count'
+        $script:orchestraSmokeContent | Should -Match 'stale_process_count'
+    }
+
+    It 'reports process contract counts for worker shells background helpers attach hosts and warm processes' {
+        $snapshot = [pscustomobject]@{
+            Processes = @(
+                [pscustomobject]@{ ProcessId = 101; Name = 'pwsh.exe'; CommandLine = 'pwsh operator-poll.ps1 C:\repo\.winsmux\manifest.yaml' },
+                [pscustomobject]@{ ProcessId = 202; Name = 'pwsh.exe'; CommandLine = 'pwsh agent-watchdog.ps1 C:\repo\.winsmux\manifest.yaml' },
+                [pscustomobject]@{ ProcessId = 303; Name = 'pwsh.exe'; CommandLine = 'pwsh server-watchdog.ps1 C:\repo\.winsmux\manifest.yaml' },
+                [pscustomobject]@{ ProcessId = 404; Name = 'pwsh.exe'; CommandLine = 'pwsh -NoLogo -NoExit -File orchestra-attach-entry.ps1' },
+                [pscustomobject]@{ ProcessId = 505; Name = 'winsmux.exe'; CommandLine = 'winsmux server __warm__' }
+            )
+            ById = @{
+                101 = [pscustomobject]@{ ProcessId = 101; Name = 'pwsh.exe'; CommandLine = 'pwsh operator-poll.ps1 C:\repo\.winsmux\manifest.yaml' }
+                202 = [pscustomobject]@{ ProcessId = 202; Name = 'pwsh.exe'; CommandLine = 'pwsh agent-watchdog.ps1 C:\repo\.winsmux\manifest.yaml' }
+                303 = [pscustomobject]@{ ProcessId = 303; Name = 'pwsh.exe'; CommandLine = 'pwsh server-watchdog.ps1 C:\repo\.winsmux\manifest.yaml' }
+                404 = [pscustomobject]@{ ProcessId = 404; Name = 'pwsh.exe'; CommandLine = 'pwsh -NoLogo -NoExit -File orchestra-attach-entry.ps1' }
+                505 = [pscustomobject]@{ ProcessId = 505; Name = 'winsmux.exe'; CommandLine = 'winsmux server __warm__' }
+            }
+            SupportsCommandLine = $true
+        }
+
+        $contract = Invoke-TestOrchestraProcessContract `
+            -Manifest ([pscustomobject]@{
+                session = [pscustomobject]@{
+                    operator_poll_pid = 101
+                    watchdog_pid = 202
+                    server_watchdog_pid = 303
+                }
+            }) `
+            -AttachState ([pscustomobject]@{ attach_process_id = 404 }) `
+            -PaneCount 6 `
+            -ExpectedPaneCount 6 `
+            -AttachedClientCount 1 `
+            -ProcessSnapshot $snapshot
+
+        $contract.ok | Should -Be $true
+        $contract.worker_shell_count | Should -Be 6
+        $contract.background_helper_count | Should -Be 3
+        $contract.attach_host_count | Should -Be 1
+        $contract.warm_process_count | Should -Be 1
+        $contract.stale_process_count | Should -Be 0
+    }
+
+    It 'treats the orchestra supervisor as one background helper' {
+        $snapshot = [pscustomobject]@{
+            Processes = @(
+                [pscustomobject]@{ ProcessId = 707; Name = 'pwsh.exe'; CommandLine = 'pwsh -NoProfile -File orchestra-supervisor.ps1 -ManifestPath C:\repo\.winsmux\manifest.yaml' }
+            )
+            ById = @{
+                707 = [pscustomobject]@{ ProcessId = 707; Name = 'pwsh.exe'; CommandLine = 'pwsh -NoProfile -File orchestra-supervisor.ps1 -ManifestPath C:\repo\.winsmux\manifest.yaml' }
+            }
+            SupportsCommandLine = $true
+        }
+
+        $contract = Invoke-TestOrchestraProcessContract `
+            -Manifest ([pscustomobject]@{
+                session = [pscustomobject]@{
+                    supervisor_pid = 707
+                }
+            }) `
+            -AttachState $null `
+            -PaneCount 6 `
+            -ExpectedPaneCount 6 `
+            -AttachedClientCount 0 `
+            -ProcessSnapshot $snapshot
+
+        $contract.ok | Should -Be $true
+        $contract.background_helper_count | Should -Be 1
+        $contract.budgets.max_background_helpers | Should -Be 1
+        $contract.background_helpers[0].label | Should -Be 'supervisor_pid'
+    }
+
+    It 'blocks smoke when managed process budget is exceeded' {
+        $snapshot = [pscustomobject]@{
+            Processes = @()
+            ById = @{}
+            SupportsCommandLine = $true
+        }
+
+        $contract = Invoke-TestOrchestraProcessContract `
+            -Manifest ([pscustomobject]@{
+                session = [pscustomobject]@{
+                    operator_poll_pid = 101
+                }
+            }) `
+            -AttachState $null `
+            -PaneCount 7 `
+            -ExpectedPaneCount 6 `
+            -AttachedClientCount 0 `
+            -ProcessSnapshot $snapshot
+
+        $contract.ok | Should -Be $false
+        $contract.stale_process_count | Should -Be 1
+        $contract.warnings | Should -Contain 'worker shell count 7 exceeds budget 6.'
+        $contract.warnings | Should -Contain 'stale managed process count 1 exceeds budget 0.'
+        $script:orchestraSmokeContent | Should -Match 'process contract: \$warning'
     }
 
     It 'keeps ready-with-ui-warning fail-closed only for external operator mode' {

--- a/winsmux-core/scripts/doctor.ps1
+++ b/winsmux-core/scripts/doctor.ps1
@@ -105,6 +105,28 @@ function Get-DoctorNormalizedProcessName {
     return $normalized
 }
 
+function Get-DoctorObjectPropertyValue {
+    param(
+        [AllowNull()]$InputObject,
+        [Parameter(Mandatory = $true)][string]$Name,
+        $Default = $null
+    )
+
+    if ($null -eq $InputObject) {
+        return $Default
+    }
+
+    if ($InputObject -is [System.Collections.IDictionary] -and $InputObject.Contains($Name)) {
+        return $InputObject[$Name]
+    }
+
+    if ($null -ne $InputObject.PSObject -and $InputObject.PSObject.Properties.Name -contains $Name) {
+        return $InputObject.PSObject.Properties[$Name].Value
+    }
+
+    return $Default
+}
+
 function Test-BasicYamlContent {
     param([Parameter(Mandatory = $true)][string]$Content)
 
@@ -629,6 +651,117 @@ function Test-PowerShellStartupEvidenceCheck {
     return New-PowerShellStartupEvidenceResult -Snapshot $snapshot -ProtectedIds $protectedIds -WarnThreshold $warnThreshold -SmokeStatus $smoke.Status -SmokeDetail $smoke.Detail
 }
 
+function Invoke-DoctorOrchestraSmokeJson {
+    $repoRoot = Get-DoctorRepoRoot
+    $smokePath = Join-Path $PSScriptRoot 'orchestra-smoke.ps1'
+    if (-not (Test-Path -LiteralPath $smokePath -PathType Leaf)) {
+        return [PSCustomObject]@{
+            Ok       = $false
+            ExitCode = 1
+            Data     = $null
+            Error    = 'orchestra-smoke.ps1 not found'
+        }
+    }
+
+    $command = Get-Command pwsh -ErrorAction SilentlyContinue | Select-Object -First 1
+    if ($null -eq $command) {
+        return [PSCustomObject]@{
+            Ok       = $false
+            ExitCode = 1
+            Data     = $null
+            Error    = 'pwsh was not found on PATH'
+        }
+    }
+
+    $pwshPath = if ($command.Path) { $command.Path } else { $command.Source }
+    try {
+        $output = & $pwshPath -NoProfile -NoLogo -File $smokePath -ProjectDir $repoRoot -AsJson 2>&1
+        $exitCode = $LASTEXITCODE
+    } catch {
+        return [PSCustomObject]@{
+            Ok       = $false
+            ExitCode = 1
+            Data     = $null
+            Error    = $_.Exception.Message
+        }
+    }
+
+    $text = (@($output) | ForEach-Object { $_.ToString() }) -join [Environment]::NewLine
+    $jsonMatch = [regex]::Match($text, '(?s)\{.*\}')
+    if (-not $jsonMatch.Success) {
+        return [PSCustomObject]@{
+            Ok       = $false
+            ExitCode = $exitCode
+            Data     = $null
+            Error    = 'orchestra-smoke did not return JSON'
+        }
+    }
+
+    try {
+        $data = $jsonMatch.Value | ConvertFrom-Json -ErrorAction Stop
+    } catch {
+        return [PSCustomObject]@{
+            Ok       = $false
+            ExitCode = $exitCode
+            Data     = $null
+            Error    = $_.Exception.Message
+        }
+    }
+
+    return [PSCustomObject]@{
+        Ok       = $true
+        ExitCode = $exitCode
+        Data     = $data
+        Error    = ''
+    }
+}
+
+function New-OrchestraProcessContractDoctorResult {
+    param([Parameter(Mandatory = $true)]$Contract)
+
+    $budgets = Get-DoctorObjectPropertyValue -InputObject $Contract -Name 'budgets'
+    $workerCount = [int](Get-DoctorObjectPropertyValue -InputObject $Contract -Name 'worker_shell_count' -Default 0)
+    $helperCount = [int](Get-DoctorObjectPropertyValue -InputObject $Contract -Name 'background_helper_count' -Default 0)
+    $attachHostCount = [int](Get-DoctorObjectPropertyValue -InputObject $Contract -Name 'attach_host_count' -Default 0)
+    $warmProcessCount = [int](Get-DoctorObjectPropertyValue -InputObject $Contract -Name 'warm_process_count' -Default 0)
+    $staleProcessCount = [int](Get-DoctorObjectPropertyValue -InputObject $Contract -Name 'stale_process_count' -Default 0)
+    $workerBudget = [int](Get-DoctorObjectPropertyValue -InputObject $budgets -Name 'max_worker_shells' -Default 0)
+    $helperBudget = [int](Get-DoctorObjectPropertyValue -InputObject $budgets -Name 'max_background_helpers' -Default 0)
+    $attachHostBudget = [int](Get-DoctorObjectPropertyValue -InputObject $budgets -Name 'max_attach_hosts' -Default 0)
+    $warmProcessBudget = [int](Get-DoctorObjectPropertyValue -InputObject $budgets -Name 'max_warm_processes' -Default 0)
+    $staleProcessBudget = [int](Get-DoctorObjectPropertyValue -InputObject $budgets -Name 'max_stale_processes' -Default 0)
+
+    $detail = "workers=$workerCount/$workerBudget; background_helpers=$helperCount/$helperBudget; attach_hosts=$attachHostCount/$attachHostBudget; warm_processes=$warmProcessCount/$warmProcessBudget; stale_processes=$staleProcessCount/$staleProcessBudget"
+    if ([bool](Get-DoctorObjectPropertyValue -InputObject $Contract -Name 'ok' -Default $false)) {
+        return New-DoctorResult -Status pass -Label 'Orchestra process contract' -Detail $detail
+    }
+
+    $warnings = @(
+        @(Get-DoctorObjectPropertyValue -InputObject $Contract -Name 'warnings' -Default @()) |
+            ForEach-Object { [string]$_ } |
+            Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+    )
+    if ($warnings.Count -gt 0) {
+        $detail = "$detail; $($warnings -join '; ')"
+    }
+
+    return New-DoctorResult -Status fail -Label 'Orchestra process contract' -Detail $detail
+}
+
+function Test-OrchestraProcessContractCheck {
+    $smoke = Invoke-DoctorOrchestraSmokeJson
+    if (-not [bool]$smoke.Ok) {
+        return New-DoctorResult -Status warn -Label 'Orchestra process contract' -Detail "unavailable; $($smoke.Error)"
+    }
+
+    $contract = Get-DoctorObjectPropertyValue -InputObject $smoke.Data -Name 'process_contract'
+    if ($null -eq $contract) {
+        return New-DoctorResult -Status warn -Label 'Orchestra process contract' -Detail 'unavailable; orchestra-smoke did not include process_contract'
+    }
+
+    return New-OrchestraProcessContractDoctorResult -Contract $contract
+}
+
 function Test-BridgeConfigCheck {
     $repoRoot = Get-DoctorRepoRoot
     $configPath = Join-Path $repoRoot '.winsmux.yaml'
@@ -721,6 +854,7 @@ if (-not $functionsOnly) {
         Test-PowerShellProcessPressureCheck
         Test-PowerShellStartupHealthCheck
         Test-PowerShellStartupEvidenceCheck
+        Test-OrchestraProcessContractCheck
         Test-BridgeConfigCheck
         Test-BridgeConfigMetadataCheck
         Test-HookProfileCheck

--- a/winsmux-core/scripts/orchestra-smoke.ps1
+++ b/winsmux-core/scripts/orchestra-smoke.ps1
@@ -80,6 +80,249 @@ function ConvertTo-OrchestraSmokeBoolean {
     }
 }
 
+function ConvertTo-OrchestraSmokeInt {
+    param([AllowNull()]$Value)
+
+    $parsed = 0
+    if ($null -eq $Value) {
+        return 0
+    }
+
+    if ([int]::TryParse(([string]$Value), [ref]$parsed)) {
+        return $parsed
+    }
+
+    return 0
+}
+
+function Get-OrchestraSmokeObjectPropertyValue {
+    param(
+        [AllowNull()]$InputObject,
+        [Parameter(Mandatory = $true)][string]$Name,
+        $Default = $null
+    )
+
+    if ($null -eq $InputObject) {
+        return $Default
+    }
+
+    if ($InputObject -is [System.Collections.IDictionary] -and $InputObject.Contains($Name)) {
+        return $InputObject[$Name]
+    }
+
+    if ($null -ne $InputObject.PSObject -and $InputObject.PSObject.Properties.Name -contains $Name) {
+        return $InputObject.PSObject.Properties[$Name].Value
+    }
+
+    return $Default
+}
+
+function Get-OrchestraSmokeProcessSnapshot {
+    try {
+        $processes = @(Get-CimInstance Win32_Process -OperationTimeoutSec 10)
+        $supportsCommandLine = $true
+    } catch {
+        $processes = @(Get-Process | ForEach-Object {
+            [PSCustomObject]@{
+                ProcessId       = $_.Id
+                ParentProcessId = 0
+                CommandLine     = ''
+                Name            = $_.ProcessName
+            }
+        })
+        $supportsCommandLine = $false
+    }
+
+    $byId = @{}
+    foreach ($process in $processes) {
+        $processId = ConvertTo-OrchestraSmokeInt -Value $process.ProcessId
+        if ($processId -gt 0) {
+            $byId[$processId] = $process
+        }
+    }
+
+    return [PSCustomObject][ordered]@{
+        Processes           = @($processes)
+        ById                = $byId
+        SupportsCommandLine = $supportsCommandLine
+    }
+}
+
+function Test-OrchestraSmokeProcessCommandLineMarker {
+    param(
+        [AllowNull()]$Process,
+        [AllowEmptyString()][string]$Marker = ''
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Marker)) {
+        return $true
+    }
+
+    if ($null -eq $Process) {
+        return $false
+    }
+
+    $commandLine = [string](Get-OrchestraSmokeObjectPropertyValue -InputObject $Process -Name 'CommandLine' -Default '')
+    if ([string]::IsNullOrWhiteSpace($commandLine)) {
+        return $true
+    }
+
+    return ($commandLine.IndexOf($Marker, [System.StringComparison]::OrdinalIgnoreCase) -ge 0)
+}
+
+function Get-OrchestraSmokeManagedProcessPidMap {
+    param([AllowNull()]$Manifest)
+
+    $pidMap = [ordered]@{}
+    $session = Get-OrchestraSmokeObjectPropertyValue -InputObject $Manifest -Name 'session'
+    if ($null -eq $session) {
+        return $pidMap
+    }
+
+    foreach ($propertyName in @('supervisor_pid', 'operator_poll_pid', 'commander_poll_pid', 'watchdog_pid', 'server_watchdog_pid')) {
+        $managedProcessId = ConvertTo-OrchestraSmokeInt -Value (Get-OrchestraSmokeObjectPropertyValue -InputObject $session -Name $propertyName)
+        if ($managedProcessId -lt 1) {
+            continue
+        }
+
+        $normalizedName = if ($propertyName -eq 'commander_poll_pid') { 'operator_poll_pid' } else { $propertyName }
+        if (-not $pidMap.Contains([string]$managedProcessId)) {
+            $pidMap[([string]$managedProcessId)] = $normalizedName
+        }
+    }
+
+    return $pidMap
+}
+
+function Get-OrchestraSmokeManagedScriptName {
+    param([Parameter(Mandatory = $true)][string]$ProcessLabel)
+
+    switch ($ProcessLabel) {
+        'operator_poll_pid' { return 'operator-poll.ps1' }
+        'watchdog_pid' { return 'agent-watchdog.ps1' }
+        'server_watchdog_pid' { return 'server-watchdog.ps1' }
+        'supervisor_pid' { return 'orchestra-supervisor.ps1' }
+        default { return '' }
+    }
+}
+
+function Test-OrchestraSmokeWarmProcess {
+    param([AllowNull()]$Process)
+
+    if ($null -eq $Process) {
+        return $false
+    }
+
+    $commandLine = [string](Get-OrchestraSmokeObjectPropertyValue -InputObject $Process -Name 'CommandLine' -Default '')
+    if ([string]::IsNullOrWhiteSpace($commandLine)) {
+        return $false
+    }
+
+    return ($commandLine.IndexOf('__warm__', [System.StringComparison]::OrdinalIgnoreCase) -ge 0)
+}
+
+function Get-OrchestraSmokeProcessContract {
+    param(
+        [AllowNull()]$Manifest,
+        [AllowNull()]$AttachState,
+        [Parameter(Mandatory = $true)][int]$PaneCount,
+        [Parameter(Mandatory = $true)][int]$ExpectedPaneCount,
+        [Parameter(Mandatory = $true)][int]$AttachedClientCount,
+        [AllowNull()]$ProcessSnapshot = $null
+    )
+
+    $snapshot = if ($null -ne $ProcessSnapshot) { $ProcessSnapshot } else { Get-OrchestraSmokeProcessSnapshot }
+    $pidMap = Get-OrchestraSmokeManagedProcessPidMap -Manifest $Manifest
+    $backgroundHelpers = [System.Collections.Generic.List[object]]::new()
+    $staleProcesses = [System.Collections.Generic.List[object]]::new()
+
+    foreach ($entry in $pidMap.GetEnumerator()) {
+        $managedProcessId = ConvertTo-OrchestraSmokeInt -Value $entry.Key
+        $label = [string]$entry.Value
+        if ($managedProcessId -lt 1) {
+            continue
+        }
+
+        if (-not $snapshot.ById.ContainsKey($managedProcessId)) {
+            $staleProcesses.Add([ordered]@{ pid = $managedProcessId; label = $label; reason = 'missing' }) | Out-Null
+            continue
+        }
+
+        $process = $snapshot.ById[$managedProcessId]
+        $scriptName = Get-OrchestraSmokeManagedScriptName -ProcessLabel $label
+        if (-not (Test-OrchestraSmokeProcessCommandLineMarker -Process $process -Marker $scriptName)) {
+            $staleProcesses.Add([ordered]@{ pid = $managedProcessId; label = $label; reason = 'command_line_mismatch' }) | Out-Null
+            continue
+        }
+
+        $backgroundHelpers.Add([ordered]@{ pid = $managedProcessId; label = $label }) | Out-Null
+    }
+
+    $attachHostCount = 0
+    $attachPid = ConvertTo-OrchestraSmokeInt -Value (Get-OrchestraSmokeObjectPropertyValue -InputObject $AttachState -Name 'attach_process_id')
+    if ($attachPid -gt 0) {
+        if ($snapshot.ById.ContainsKey($attachPid)) {
+            $attachHostCount = 1
+        } elseif ($AttachedClientCount -lt 1) {
+            $staleProcesses.Add([ordered]@{ pid = $attachPid; label = 'visible_attach_host'; reason = 'missing' }) | Out-Null
+        }
+    }
+
+    $warmProcessCount = 0
+    foreach ($process in @($snapshot.Processes)) {
+        if (Test-OrchestraSmokeWarmProcess -Process $process) {
+            $warmProcessCount++
+        }
+    }
+
+    $hasSupervisor = $false
+    foreach ($helper in @($backgroundHelpers)) {
+        if ([string](Get-OrchestraSmokeObjectPropertyValue -InputObject $helper -Name 'label' -Default '') -eq 'supervisor_pid') {
+            $hasSupervisor = $true
+            break
+        }
+    }
+
+    $budgets = [ordered]@{
+        max_worker_shells      = [Math]::Max($ExpectedPaneCount, 0)
+        max_background_helpers = if ($hasSupervisor) { 1 } else { 3 }
+        max_attach_hosts       = 1
+        max_warm_processes     = 1
+        max_stale_processes    = 0
+    }
+
+    $warnings = [System.Collections.Generic.List[string]]::new()
+    if ($PaneCount -gt [int]$budgets.max_worker_shells) {
+        $warnings.Add("worker shell count $PaneCount exceeds budget $($budgets.max_worker_shells).") | Out-Null
+    }
+    if ($backgroundHelpers.Count -gt [int]$budgets.max_background_helpers) {
+        $warnings.Add("background helper count $($backgroundHelpers.Count) exceeds budget $($budgets.max_background_helpers).") | Out-Null
+    }
+    if ($attachHostCount -gt [int]$budgets.max_attach_hosts) {
+        $warnings.Add("attach host count $attachHostCount exceeds budget $($budgets.max_attach_hosts).") | Out-Null
+    }
+    if ($warmProcessCount -gt [int]$budgets.max_warm_processes) {
+        $warnings.Add("warm process count $warmProcessCount exceeds budget $($budgets.max_warm_processes).") | Out-Null
+    }
+    if ($staleProcesses.Count -gt [int]$budgets.max_stale_processes) {
+        $warnings.Add("stale managed process count $($staleProcesses.Count) exceeds budget $($budgets.max_stale_processes).") | Out-Null
+    }
+
+    return [ordered]@{
+        contract_version        = 1
+        ok                      = ($warnings.Count -eq 0)
+        worker_shell_count      = $PaneCount
+        background_helper_count = $backgroundHelpers.Count
+        attach_host_count       = $attachHostCount
+        warm_process_count      = $warmProcessCount
+        stale_process_count     = $staleProcesses.Count
+        budgets                 = $budgets
+        background_helpers      = @($backgroundHelpers)
+        stale_processes         = @($staleProcesses)
+        warnings                = @($warnings)
+    }
+}
+
 function Get-OrchestraAttachedClientSnapshot {
     param(
         [Parameter(Mandatory = $true)][string]$WinsmuxBin,
@@ -544,6 +787,18 @@ if (-not [bool]$workerIsolation.ok) {
         $smokeErrors.Add("worker isolation drift: $($finding.label): $($finding.message)") | Out-Null
     }
 }
+
+$processContract = Get-OrchestraSmokeProcessContract `
+    -Manifest $manifestObject `
+    -AttachState $attachState `
+    -PaneCount $paneCount `
+    -ExpectedPaneCount $expectedPaneCount `
+    -AttachedClientCount $attachedClientCount
+if (-not [bool]$processContract.ok) {
+    foreach ($warning in @($processContract.warnings)) {
+        $smokeErrors.Add("process contract: $warning") | Out-Null
+    }
+}
 $operatorContract = Get-OrchestraOperatorContract `
     -SmokeOk ($smokeErrors.Count -eq 0) `
     -SessionReady $sessionReady `
@@ -582,6 +837,7 @@ $result = [ordered]@{
     ui_attach_source    = $uiAttachSource
     ui_host_kind        = $uiHostKind
     worker_isolation    = $workerIsolation
+    process_contract    = $processContract
     smoke_ok            = ($smokeErrors.Count -eq 0)
     smoke_errors        = @($smokeErrors)
     operator_contract   = $operatorContract

--- a/winsmux-core/scripts/orchestra-start.ps1
+++ b/winsmux-core/scripts/orchestra-start.ps1
@@ -1080,6 +1080,7 @@ function Save-OrchestraSessionState {
         [Nullable[int]]$OperatorPollPid = $null,
         [Nullable[int]]$WatchdogPid = $null,
         [Nullable[int]]$ServerWatchdogPid = $null,
+        [Nullable[int]]$SupervisorPid = $null,
         [AllowEmptyString()][string]$BootstrapMode = '',
         [bool]$SessionReady = $false,
         [bool]$UiAttachLaunched = $false,
@@ -1139,6 +1140,7 @@ function Save-OrchestraSessionState {
             operator_poll_pid  = $OperatorPollPid
             watchdog_pid        = $WatchdogPid
             server_watchdog_pid = $ServerWatchdogPid
+            supervisor_pid      = $SupervisorPid
             bootstrap_mode      = $BootstrapMode
             session_ready       = $SessionReady
             ui_attach_launched  = $UiAttachLaunched
@@ -1199,7 +1201,7 @@ function Stop-OrchestraBackgroundProcessesFromManifest {
     }
 
     $pidMap = [ordered]@{}
-    foreach ($propertyName in @('operator_poll_pid', 'commander_poll_pid', 'watchdog_pid', 'server_watchdog_pid')) {
+    foreach ($propertyName in @('supervisor_pid', 'operator_poll_pid', 'commander_poll_pid', 'watchdog_pid', 'server_watchdog_pid')) {
         $rawPid = $null
         if ($manifest.session -is [System.Collections.IDictionary]) {
             if ($manifest.session.Contains($propertyName)) {
@@ -1233,6 +1235,7 @@ function Stop-OrchestraBackgroundProcessesFromManifest {
             $process = $snapshot.ById[$processId]
             $commandLine = [string]$process.CommandLine
             $requiredScript = switch ($label) {
+                'supervisor_pid' { 'orchestra-supervisor.ps1' }
                 'operator_poll_pid' { 'operator-poll.ps1' }
                 'watchdog_pid' { 'agent-watchdog.ps1' }
                 'server_watchdog_pid' { 'server-watchdog.ps1' }
@@ -1372,6 +1375,45 @@ function Start-ServerWatchdogJob {
             $StartupToken,
             '-PollInterval',
             $PollInterval,
+            '-MaxRestartAttempts',
+            $MaxRestartAttempts,
+            '-RestartWindowMinutes',
+            $RestartWindowMinutes
+        ) -WindowStyle Hidden -PassThru)
+}
+
+function Start-OrchestraSupervisorJob {
+    param(
+        [Parameter(Mandatory = $true)][string]$SupervisorScriptPath,
+        [Parameter(Mandatory = $true)][string]$ManifestPath,
+        [Parameter(Mandatory = $true)][string]$SessionName,
+        [AllowEmptyString()][string]$StartupToken = '',
+        [int]$OperatorPollInterval = 20,
+        [int]$AgentWatchdogInterval = 30,
+        [ValidateRange(5, 10)][int]$ServerWatchdogInterval = 5,
+        [int]$IdleThreshold = 120,
+        [int]$MaxRestartAttempts = 3,
+        [int]$RestartWindowMinutes = 10
+    )
+
+    return (Start-Process -FilePath 'pwsh' -ArgumentList @(
+            '-NoProfile',
+            '-File',
+            $SupervisorScriptPath,
+            '-ManifestPath',
+            $ManifestPath,
+            '-SessionName',
+            $SessionName,
+            '-StartupToken',
+            $StartupToken,
+            '-OperatorPollInterval',
+            $OperatorPollInterval,
+            '-AgentWatchdogInterval',
+            $AgentWatchdogInterval,
+            '-ServerWatchdogInterval',
+            $ServerWatchdogInterval,
+            '-IdleThreshold',
+            $IdleThreshold,
             '-MaxRestartAttempts',
             $MaxRestartAttempts,
             '-RestartWindowMinutes',
@@ -1832,6 +1874,7 @@ if ($MyInvocation.InvocationName -ne '.') {
     $operatorPollProcess = $null
     $watchdogProcess = $null
     $serverWatchdogProcess = $null
+    $supervisorProcess = $null
     $projectDir = $null
     $gitWorktreeDir = $null
     $expectedOrigin = ''
@@ -2244,19 +2287,11 @@ if ($MyInvocation.InvocationName -ne '.') {
     }
 
     $manifestPath = Save-OrchestraSessionState -ProjectDir $projectDir -SessionName $sessionName -Settings $settings -GitWorktreeDir $gitWorktreeDir -PaneSummaries $validPaneSummaries -StartupToken $startupToken -BootstrapMode ([string]$orchestraServer.BootstrapMode) -SessionReady $false -UiAttachLaunched ([bool]$uiAttachResult.Launched) -UiAttached ([bool]$uiAttachResult.Attached) -UiAttachStatus ([string]$uiAttachResult.Status) -UiAttachReason ([string]$uiAttachResult.Reason) -UiAttachSource ([string]$uiAttachResult.Source) -UiHostKind ([string]$uiAttachResult.ui_host_kind) -AttachRequestId ([string]$uiAttachResult.attach_request_id) -AttachAdapterTrace @($uiAttachResult.attach_adapter_trace)
-    $operatorPollScriptPath = Join-Path $scriptDir 'operator-poll.ps1'
-    $operatorPollProcess = Start-OperatorPollJob -OperatorPollScriptPath $operatorPollScriptPath -ManifestPath $manifestPath -StartupToken $startupToken -Interval 20
-    Write-WinsmuxLog -Level INFO -Event 'preflight.operator_poll.started' -Message "Started operator poll for session $sessionName." -Data @{ session_name = $sessionName; manifest_path = $manifestPath; operator_poll_pid = $operatorPollProcess.Id; process_name = $operatorPollProcess.ProcessName } | Out-Null
-    $watchdogScriptPath = Join-Path $scriptDir 'agent-watchdog.ps1'
-    $watchdogProcess = Start-AgentWatchdogJob -WatchdogScriptPath $watchdogScriptPath -ManifestPath $manifestPath -SessionName $sessionName -StartupToken $startupToken
-    $serverWatchdogScriptPath = Join-Path $scriptDir 'server-watchdog.ps1'
-    $serverWatchdogProcess = Start-ServerWatchdogJob -WatchdogScriptPath $serverWatchdogScriptPath -ManifestPath $manifestPath -SessionName $sessionName -StartupToken $startupToken
-    Assert-OrchestraBackgroundProcessStarted -Process $operatorPollProcess -Name 'Operator poll job'
-    Assert-OrchestraBackgroundProcessStarted -Process $watchdogProcess -Name 'Agent watchdog job'
-    Assert-OrchestraBackgroundProcessStarted -Process $serverWatchdogProcess -Name 'Server watchdog job'
-    $manifestPath = Save-OrchestraSessionState -ProjectDir $projectDir -SessionName $sessionName -Settings $settings -GitWorktreeDir $gitWorktreeDir -PaneSummaries $validPaneSummaries -StartupToken $startupToken -OperatorPollPid $operatorPollProcess.Id -WatchdogPid $watchdogProcess.Id -ServerWatchdogPid $serverWatchdogProcess.Id -BootstrapMode ([string]$orchestraServer.BootstrapMode) -SessionReady $true -UiAttachLaunched ([bool]$uiAttachResult.Launched) -UiAttached ([bool]$uiAttachResult.Attached) -UiAttachStatus ([string]$uiAttachResult.Status) -UiAttachReason ([string]$uiAttachResult.Reason) -UiAttachSource ([string]$uiAttachResult.Source) -UiHostKind ([string]$uiAttachResult.ui_host_kind) -AttachRequestId ([string]$uiAttachResult.attach_request_id) -AttachAdapterTrace @($uiAttachResult.attach_adapter_trace)
-    Write-WinsmuxLog -Level INFO -Event 'preflight.watchdog.started' -Message "Started agent watchdog for session $sessionName." -Data @{ session_name = $sessionName; manifest_path = $manifestPath; watchdog_pid = $watchdogProcess.Id; process_name = $watchdogProcess.ProcessName } | Out-Null
-    Write-WinsmuxLog -Level INFO -Event 'preflight.server_watchdog.started' -Message "Started server watchdog for session $sessionName." -Data @{ session_name = $sessionName; manifest_path = $manifestPath; server_watchdog_pid = $serverWatchdogProcess.Id; process_name = $serverWatchdogProcess.ProcessName } | Out-Null
+    $supervisorScriptPath = Join-Path $scriptDir 'orchestra-supervisor.ps1'
+    $supervisorProcess = Start-OrchestraSupervisorJob -SupervisorScriptPath $supervisorScriptPath -ManifestPath $manifestPath -SessionName $sessionName -StartupToken $startupToken
+    Assert-OrchestraBackgroundProcessStarted -Process $supervisorProcess -Name 'Orchestra supervisor job'
+    $manifestPath = Save-OrchestraSessionState -ProjectDir $projectDir -SessionName $sessionName -Settings $settings -GitWorktreeDir $gitWorktreeDir -PaneSummaries $validPaneSummaries -StartupToken $startupToken -SupervisorPid $supervisorProcess.Id -BootstrapMode ([string]$orchestraServer.BootstrapMode) -SessionReady $true -UiAttachLaunched ([bool]$uiAttachResult.Launched) -UiAttached ([bool]$uiAttachResult.Attached) -UiAttachStatus ([string]$uiAttachResult.Status) -UiAttachReason ([string]$uiAttachResult.Reason) -UiAttachSource ([string]$uiAttachResult.Source) -UiHostKind ([string]$uiAttachResult.ui_host_kind) -AttachRequestId ([string]$uiAttachResult.attach_request_id) -AttachAdapterTrace @($uiAttachResult.attach_adapter_trace)
+    Write-WinsmuxLog -Level INFO -Event 'preflight.supervisor.started' -Message "Started orchestra supervisor for session $sessionName." -Data @{ session_name = $sessionName; manifest_path = $manifestPath; supervisor_pid = $supervisorProcess.Id; process_name = $supervisorProcess.ProcessName } | Out-Null
     Write-WinsmuxLog -Level INFO -Event 'orchestra.startup.session_ready' -Message "Orchestra session $sessionName reached session-ready; UI attach remains a separate state." -Data ([ordered]@{
         session_name       = $sessionName
         expected_panes     = $expectedPaneCount
@@ -2318,12 +2353,9 @@ if ($MyInvocation.InvocationName -ne '.') {
 
     Write-Output ''
     Write-Output "Manifest: $manifestPath"
-    Write-Output "Operator Poll PID: $($operatorPollProcess.Id)"
-    Write-Output "Watchdog PID: $($watchdogProcess.Id)"
-    Write-Output "Server Watchdog PID: $($serverWatchdogProcess.Id)"
-    Write-Output 'Cleanup: stop the operator poll and watchdogs after the session ends.'
-    Write-Output ("  Stop-Process -Id {0}" -f $operatorPollProcess.Id)
-    Write-Output ("  Stop-Process -Id {0},{1}" -f $watchdogProcess.Id, $serverWatchdogProcess.Id)
+    Write-Output "Supervisor PID: $($supervisorProcess.Id)"
+    Write-Output 'Cleanup: stop the orchestra supervisor after the session ends.'
+    Write-Output ("  Stop-Process -Id {0}" -f $supervisorProcess.Id)
 } catch {
     Write-Warning "STARTUP ERROR: $($_.Exception.Message)"
     Write-Warning "AT: $($_.ScriptStackTrace)"
@@ -2335,6 +2367,9 @@ if ($MyInvocation.InvocationName -ne '.') {
     }
     if ($null -ne $serverWatchdogProcess) {
         try { Stop-Process -Id $serverWatchdogProcess.Id -Force -ErrorAction SilentlyContinue } catch {}
+    }
+    if ($null -ne $supervisorProcess) {
+        try { Stop-Process -Id $supervisorProcess.Id -Force -ErrorAction SilentlyContinue } catch {}
     }
 
     $rollback = Invoke-OrchestraStartupRollback -ProjectDir $projectDir -SessionName $sessionName -BootstrapPaneId $bootstrapPaneId -CreatedPaneIds $createdPaneIds -CreatedWorktrees $createdWorktrees -FailureMessage $_.Exception.Message

--- a/winsmux-core/scripts/orchestra-supervisor.ps1
+++ b/winsmux-core/scripts/orchestra-supervisor.ps1
@@ -1,0 +1,147 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string]$ManifestPath,
+    [string]$SessionName = 'winsmux-orchestra',
+    [string]$StartupToken = '',
+    [int]$OperatorPollInterval = 20,
+    [int]$AgentWatchdogInterval = 30,
+    [ValidateRange(5, 10)][int]$ServerWatchdogInterval = 5,
+    [int]$IdleThreshold = 120,
+    [int]$MaxRestartAttempts = 3,
+    [int]$RestartWindowMinutes = 10
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+
+$scriptDir = $PSScriptRoot
+. (Join-Path $scriptDir 'operator-poll.ps1') -ManifestPath $ManifestPath -StartupToken $StartupToken -Interval $OperatorPollInterval
+. (Join-Path $scriptDir 'agent-watchdog.ps1') -ManifestPath $ManifestPath -SessionName $SessionName -StartupToken $StartupToken -IdleThreshold $IdleThreshold -PollInterval $AgentWatchdogInterval
+. (Join-Path $scriptDir 'server-watchdog.ps1') -ManifestPath $ManifestPath -SessionName $SessionName -StartupToken $StartupToken -PollInterval $ServerWatchdogInterval -MaxRestartAttempts $MaxRestartAttempts -RestartWindowMinutes $RestartWindowMinutes
+
+function Write-OrchestraSupervisorWarning {
+    param(
+        [Parameter(Mandatory = $true)][string]$Component,
+        [Parameter(Mandatory = $true)][string]$Message
+    )
+
+    Write-Warning ("Orchestra supervisor {0} failed for session {1}: {2}" -f $Component, $SessionName, $Message)
+}
+
+function Invoke-OrchestraSupervisorLoop {
+    param(
+        [Parameter(Mandatory = $true)][string]$ManifestPath,
+        [Parameter(Mandatory = $true)][string]$SessionName,
+        [int]$OperatorPollInterval = 20,
+        [int]$AgentWatchdogInterval = 30,
+        [int]$ServerWatchdogInterval = 5,
+        [int]$IdleThreshold = 120,
+        [int]$MaxRestartAttempts = 3,
+        [int]$RestartWindowMinutes = 10
+    )
+
+    if (-not (Test-Path -LiteralPath $ManifestPath -PathType Leaf)) {
+        throw "Manifest not found: $ManifestPath"
+    }
+
+    $initialManifest = Read-OperatorPollManifest -Path $ManifestPath
+    $projectDir = Get-OperatorPollProjectDir -Manifest $initialManifest -ManifestPath $ManifestPath
+    $eventsPath = Get-OperatorPollEventsPath -ProjectDir $projectDir
+    $processedLineCount = 0
+    $processedEventSignatures = [ordered]@{}
+    if (Test-Path -LiteralPath $eventsPath -PathType Leaf) {
+        $processedLineCount = @(Get-Content -LiteralPath $eventsPath -Encoding UTF8).Count
+    }
+
+    Send-OperatorTelegramNotification -ProjectDir $projectDir `
+        -SessionName (Get-OperatorPollSessionName -Manifest $initialManifest) `
+        -Event 'operator.started' -Message "Operator Poll 開始。間隔: ${OperatorPollInterval}秒"
+
+    $operatorState = 'starting'
+    $commitReadySha = ''
+    $agentPreviousResults = [ordered]@{}
+    $serverState = New-ServerWatchdogState -MaxRestartAttempts $MaxRestartAttempts -RestartWindowMinutes $RestartWindowMinutes
+    $nextOperatorPollAt = Get-Date
+    $nextAgentWatchdogAt = Get-Date
+    $nextServerWatchdogAt = Get-Date
+
+    while ($true) {
+        $now = Get-Date
+
+        if ($now -ge $nextOperatorPollAt) {
+            try {
+                $cycleResult = Invoke-OperatorPollCycle `
+                    -ManifestPath $ManifestPath `
+                    -ProcessedLineCount $processedLineCount `
+                    -ProcessedEventSignatures $processedEventSignatures
+
+                $processedLineCount = [int]$cycleResult['ProcessedLineCount']
+                $processedEventSignatures = $cycleResult['ProcessedEventSignatures']
+                $currentManifest = Read-OperatorPollManifest -Path $ManifestPath
+                $stateResult = Invoke-OperatorStateMachine `
+                    -CurrentState $operatorState `
+                    -CycleSummary ($cycleResult['Summary']) `
+                    -ProjectDir $projectDir `
+                    -SessionName (Get-OperatorPollSessionName -Manifest $currentManifest) `
+                    -ManifestPath $ManifestPath `
+                    -CommitReadySha $commitReadySha
+
+                $operatorState = [string]$stateResult['State']
+                $commitReadySha = [string]$stateResult['CommitReadySha']
+                $summaryOutput = $cycleResult['Summary']
+                $summaryOutput['operator_state'] = $operatorState
+                Write-Output ($summaryOutput | ConvertTo-Json -Compress -Depth 10)
+            } catch {
+                Write-OrchestraSupervisorWarning -Component 'operator-poll' -Message $_.Exception.Message
+            }
+
+            $nextOperatorPollAt = $now.AddSeconds($OperatorPollInterval)
+        }
+
+        if ($now -ge $nextAgentWatchdogAt) {
+            try {
+                $agentResult = Invoke-AgentWatchdogCycle -ManifestPath $ManifestPath -SessionName $SessionName -IdleThreshold $IdleThreshold -PreviousResults $agentPreviousResults
+                $agentPreviousResults = [ordered]@{}
+                if ($null -ne $agentResult -and $null -ne $agentResult.CurrentResults) {
+                    foreach ($entry in $agentResult.CurrentResults.GetEnumerator()) {
+                        $agentPreviousResults[$entry.Key] = $entry.Value
+                    }
+                }
+
+                $agentSummary = Get-AgentWatchdogSummary -CycleResult $agentResult -ManifestPath $ManifestPath -SessionName $SessionName
+                Write-Output ($agentSummary | ConvertTo-Json -Depth 8 -Compress)
+            } catch {
+                Write-OrchestraSupervisorWarning -Component 'agent-watchdog' -Message $_.Exception.Message
+            }
+
+            $nextAgentWatchdogAt = $now.AddSeconds($AgentWatchdogInterval)
+        }
+
+        if ($now -ge $nextServerWatchdogAt) {
+            try {
+                $serverResult = Invoke-ServerWatchdogCycle -ManifestPath $ManifestPath -SessionName $SessionName -State $serverState
+                $serverState = $serverResult.State
+                Write-Output ($serverResult | ConvertTo-Json -Depth 8 -Compress)
+            } catch {
+                Write-OrchestraSupervisorWarning -Component 'server-watchdog' -Message $_.Exception.Message
+            }
+
+            $nextServerWatchdogAt = $now.AddSeconds($ServerWatchdogInterval)
+        }
+
+        Start-Sleep -Seconds 1
+    }
+}
+
+if ($MyInvocation.InvocationName -ne '.') {
+    Invoke-OrchestraSupervisorLoop `
+        -ManifestPath $ManifestPath `
+        -SessionName $SessionName `
+        -OperatorPollInterval $OperatorPollInterval `
+        -AgentWatchdogInterval $AgentWatchdogInterval `
+        -ServerWatchdogInterval $ServerWatchdogInterval `
+        -IdleThreshold $IdleThreshold `
+        -MaxRestartAttempts $MaxRestartAttempts `
+        -RestartWindowMinutes $RestartWindowMinutes
+}

--- a/winsmux-core/scripts/orchestra-ui-attach.ps1
+++ b/winsmux-core/scripts/orchestra-ui-attach.ps1
@@ -881,6 +881,37 @@ function Invoke-OrchestraVisibleAttachRequest {
         }
     }
 
+    $existingAttachStatus = if ($null -eq $existingAttachState) { '' } else { [string](Get-OrchestraAttachStateString -State $existingAttachState -Name 'attach_status') }
+    $existingAttachedClientSnapshot = if ($null -eq $existingAttachState) { @() } else { @(Get-OrchestraAttachStateStringArray -State $existingAttachState -Name 'attached_client_snapshot') }
+    if ($existingAttachStatus -eq 'attach_confirmed' -and [bool]$clientSnapshot.Ok -and (Test-OrchestraAttachClientSnapshotMatch -ExpectedClients $existingAttachedClientSnapshot -CurrentClients @($clientSnapshot.Clients))) {
+        $existingAttachState = Write-OrchestraAttachState -SessionName $SessionName -Properties @{
+            session_name        = $SessionName
+            winsmux_path        = $resolvedWinsmuxPath
+            attach_status       = 'attach_confirmed'
+            attach_confirmed_at = (Get-Date).ToString('o')
+            client_count_seen   = $baselineClientCount
+            attached_client_count = $baselineClientCount
+            attached_client_snapshot = @($clientSnapshot.Clients)
+            ui_attach_source    = 'attached-client-registry'
+            error               = "Detected existing attached-client registry confirmation for session '$SessionName'."
+        }
+
+        return [PSCustomObject][ordered]@{
+            Attempted                = $false
+            Launched                 = $false
+            Attached                 = $true
+            AttachedClientCount      = $baselineClientCount
+            Status                   = 'attach_already_present'
+            Reason                   = "Detected an existing attached-client confirmation for session '$SessionName'; skipped spawning another visible attach window."
+            Path                     = ''
+            Source                   = 'attached-client-registry'
+            attach_request_id        = (Get-OrchestraAttachRequestId -State $existingAttachState)
+            attached_client_snapshot = @(Get-OrchestraAttachStateStringArray -State $existingAttachState -Name 'attached_client_snapshot')
+            ui_host_kind             = (Get-OrchestraAttachStateString -State $existingAttachState -Name 'ui_host_kind')
+            attach_adapter_trace     = @(Get-OrchestraAttachTraceEntries -State $existingAttachState)
+        }
+    }
+
     $attachRequestId = [guid]::NewGuid().ToString('N')
     $state = Write-OrchestraAttachState -SessionName $SessionName -Properties @{
         session_name          = $SessionName


### PR DESCRIPTION
## Summary

- Add `process_contract` to `orchestra-smoke --json` so startup readiness includes worker shell, background helper, attach host, warm process, and stale managed PID budgets.
- Add the same process-contract judgment to `doctor.ps1`.
- Reuse confirmed attached-client registry state instead of launching a duplicate visible attach host.
- Launch one `orchestra-supervisor.ps1` process for operator poll, agent watchdog, and server watchdog loops.

## Validation

- `git diff --check`
- `Invoke-Pester -Path tests\winsmux-bridge.Tests.ps1 -Output Normal` passed with 426 tests
- `pwsh -NoProfile -File scripts\audit-public-surface.ps1`
- `pwsh -NoProfile -File scripts\git-guard.ps1`
- `bash .git/hooks/pre-commit`
- `git push -u origin task-463-process-contract` ran pre-push git-guard, public-surface audit, and gitleaks successfully

## Notes

- Refs #820.
- This keeps #820 open because lazy-starting unused worker panes changes the worker readiness and dispatch contract and should be handled as a follow-up slice.
- Live dogfood `orchestra-smoke.ps1 -AsJson` now fails as designed on the existing session because the current manifest still records three stale legacy helper PIDs. Restarting through the new startup path should replace them with `supervisor_pid`.
