### PR TITLE
Fix failed deferred worker send blocking

### DIFF
--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -3025,7 +3025,7 @@ function Test-DeferredPaneStartManifestEntry {
         return $false
     }
 
-    return @('deferred_start', 'deferred_starting') -contains $status.Trim().ToLowerInvariant()
+    return @('deferred_start', 'deferred_starting', 'deferred_start_failed') -contains $status.Trim().ToLowerInvariant()
 }
 
 function Set-DeferredPaneStartStatus {
@@ -3103,7 +3103,7 @@ function Start-DeferredPaneFromManifestEntry {
     $markerPath = [string](Get-SendConfigValue -InputObject $plan -Name 'ready_marker_path' -Default '')
     $status = [string](Get-SendConfigValue -InputObject $ManifestEntry -Name 'Status' -Default '')
 
-    if ($status.Trim().ToLowerInvariant() -eq 'deferred_start') {
+    if (@('deferred_start', 'deferred_start_failed') -contains $status.Trim().ToLowerInvariant()) {
         Set-DeferredPaneStartStatus -ProjectDir $ProjectDir -PaneId $paneId -Status 'deferred_starting' -MarkerPath $markerPath
         $bootstrapScriptPath = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\winsmux-core\scripts\orchestra-pane-bootstrap.ps1'))
         $bootstrapCommand = "pwsh -NoProfile -File {0} -PlanFile {1}" -f `

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -15783,6 +15783,43 @@ Describe 'deferred worker startup' {
         $script:deferredStatusWrites | Should -Be @('ready')
     }
 
+    It 'retries a previously failed deferred pane instead of sending task text to the shell' {
+        $entry = [PSCustomObject]@{
+            Label             = 'worker-2'
+            PaneId            = '%3'
+            Status            = 'deferred_start_failed'
+            BootstrapPlanPath = $script:deferredPlanPath
+            CapabilityAdapter = 'codex'
+            ProviderTarget    = ''
+        }
+
+        $started = Start-DeferredPaneFromManifestEntry -ProjectDir $script:deferredTempRoot -ManifestEntry $entry
+
+        $started | Should -Be $true
+        Should -Invoke Wait-PaneShellReady -Times 1 -Exactly -ParameterFilter { $PaneId -eq '%3' }
+        $script:deferredSendCommands.Count | Should -Be 1
+        $script:deferredSendCommands[0] | Should -Match 'orchestra-pane-bootstrap\.ps1'
+        $script:deferredStatusWrites | Should -Be @('deferred_starting', 'ready')
+    }
+
+    It 'blocks a previously failed deferred pane when the bootstrap plan is still missing' {
+        $missingPlan = Join-Path $script:deferredTempRoot 'missing-worker-2.json'
+        $entry = [PSCustomObject]@{
+            Label             = 'worker-2'
+            PaneId            = '%3'
+            Status            = 'deferred_start_failed'
+            BootstrapPlanPath = $missingPlan
+            CapabilityAdapter = 'codex'
+            ProviderTarget    = ''
+        }
+
+        { Start-DeferredPaneFromManifestEntry -ProjectDir $script:deferredTempRoot -ManifestEntry $entry } |
+            Should -Throw "*bootstrap plan not found*"
+
+        $script:deferredSendCommands.Count | Should -Be 0
+        $script:deferredStatusWrites | Should -Be @('deferred_start_failed')
+    }
+
     It 'keeps send, dispatch-task, and monitor paths aware of deferred panes' {
         $script:deferredCoreContent | Should -Match 'function Start-DeferredPaneFromManifestEntry'
         $script:deferredCoreContent | Should -Match 'Start-DeferredPaneFromManifestEntry -ProjectDir \$projectDir -ManifestEntry \$context'


### PR DESCRIPTION
## Summary
- treat `deferred_start_failed` as a deferred state instead of falling through to normal send delivery
- retry a failed deferred pane by relaunching its bootstrap plan when the plan exists
- keep missing bootstrap plans blocking so task text is not executed by the raw PowerShell pane

## Validation
- `git diff --check`
- PowerShell parser check for `scripts\winsmux-core.ps1`
- `Invoke-Pester -Path tests\winsmux-bridge.Tests.ps1 -FullName 'deferred worker startup' -Output Detailed`
- `pwsh -NoProfile -File scripts\audit-public-surface.ps1`
- `pwsh -NoProfile -File scripts\git-guard.ps1`

Follow-up for #822. Refs #820.