### PR TITLE
Fix deferred worker startup verification

### DIFF
--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -3086,6 +3086,24 @@ function Start-DeferredPaneFromManifestEntry {
         Stop-WithError "deferred pane '$label' is missing pane id"
     }
 
+    $status = [string](Get-SendConfigValue -InputObject $ManifestEntry -Name 'Status' -Default '')
+    $normalizedStatus = $status.Trim().ToLowerInvariant()
+    $readinessAgent = ConvertTo-ReadinessAgentName ([string](Get-SendConfigValue -InputObject $ManifestEntry -Name 'CapabilityAdapter' -Default ''))
+    if ([string]::IsNullOrWhiteSpace($readinessAgent)) {
+        $readinessAgent = ConvertTo-ReadinessAgentName ([string](Get-SendConfigValue -InputObject $ManifestEntry -Name 'ProviderTarget' -Default ''))
+    }
+
+    if ($normalizedStatus -eq 'deferred_start_failed') {
+        try {
+            if (Test-AgentReadyPrompt -PaneId $paneId -Agent $readinessAgent) {
+                Set-DeferredPaneStartStatus -ProjectDir $ProjectDir -PaneId $paneId -Status 'ready'
+                return $true
+            }
+        } catch {
+            # Fall through to the bootstrap retry path when the pane cannot be probed.
+        }
+    }
+
     $planPath = [string](Get-SendConfigValue -InputObject $ManifestEntry -Name 'BootstrapPlanPath' -Default '')
     if ([string]::IsNullOrWhiteSpace($planPath)) {
         Set-DeferredPaneStartStatus -ProjectDir $ProjectDir -PaneId $paneId -Status 'deferred_start_failed'
@@ -3101,9 +3119,8 @@ function Start-DeferredPaneFromManifestEntry {
 
     $plan = Get-Content -LiteralPath $planPath -Raw -Encoding UTF8 | ConvertFrom-Json -Depth 8
     $markerPath = [string](Get-SendConfigValue -InputObject $plan -Name 'ready_marker_path' -Default '')
-    $status = [string](Get-SendConfigValue -InputObject $ManifestEntry -Name 'Status' -Default '')
 
-    if (@('deferred_start', 'deferred_start_failed') -contains $status.Trim().ToLowerInvariant()) {
+    if (@('deferred_start', 'deferred_start_failed') -contains $normalizedStatus) {
         Set-DeferredPaneStartStatus -ProjectDir $ProjectDir -PaneId $paneId -Status 'deferred_starting' -MarkerPath $markerPath
         $bootstrapScriptPath = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\winsmux-core\scripts\orchestra-pane-bootstrap.ps1'))
         $bootstrapCommand = "pwsh -NoProfile -File {0} -PlanFile {1}" -f `
@@ -3114,10 +3131,6 @@ function Start-DeferredPaneFromManifestEntry {
         Send-TextToPane -PaneId $paneId -CommandText $bootstrapCommand | Out-Null
     }
 
-    $readinessAgent = ConvertTo-ReadinessAgentName ([string](Get-SendConfigValue -InputObject $ManifestEntry -Name 'CapabilityAdapter' -Default ''))
-    if ([string]::IsNullOrWhiteSpace($readinessAgent)) {
-        $readinessAgent = ConvertTo-ReadinessAgentName ([string](Get-SendConfigValue -InputObject $ManifestEntry -Name 'ProviderTarget' -Default ''))
-    }
     if ([string]::IsNullOrWhiteSpace($readinessAgent)) {
         $readinessAgent = ConvertTo-ReadinessAgentName ([string](Get-SendConfigValue -InputObject $plan -Name 'agent' -Default ''))
     }

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -6159,6 +6159,15 @@ Describe 'orchestra-start session reuse contract' {
         $script:orchestraStartContent | Should -Match 'Wait-AgentReady -PaneId \$paneSummary\.PaneId -Agent \$readinessAgent'
     }
 
+    It 'skips bootstrap readiness and cwd verification for deferred worker panes' {
+        Test-OrchestraPaneBootstrapVerificationDeferred -PaneSummary ([pscustomobject]@{ Status = 'deferred_start' }) | Should -Be $true
+        Test-OrchestraPaneBootstrapVerificationDeferred -PaneSummary ([pscustomobject]@{ Status = 'deferred_starting' }) | Should -Be $true
+        Test-OrchestraPaneBootstrapVerificationDeferred -PaneSummary ([pscustomobject]@{ Status = 'ready' }) | Should -Be $false
+
+        $script:orchestraStartContent | Should -Match 'Test-OrchestraPaneBootstrapVerificationDeferred -PaneSummary \$paneSummary'
+        $script:orchestraStartContent | Should -Match '\$validPaneSummaries\.Add\(\$paneSummary\)'
+    }
+
     It 'uses the capability adapter for startup exec-mode labels' {
         $script:orchestraStartContent | Should -Match '\$execModeAgent = \[string\]\$slotAgentConfig\.CapabilityAdapter'
         $script:orchestraStartContent | Should -Match '\$execMode = \$execModeAgent\.Trim\(\)\.ToLowerInvariant\(\) -eq ''codex'''
@@ -15724,6 +15733,9 @@ Describe 'deferred worker startup' {
         } | ConvertTo-Json -Depth 6) | Set-Content -Path $script:deferredPlanPath -Encoding UTF8
         $script:deferredSendCommands = [System.Collections.Generic.List[string]]::new()
         $script:deferredStatusWrites = [System.Collections.Generic.List[string]]::new()
+        $script:deferredReadyProbeCount = 0
+        $script:deferredPreRetryProbeApplies = $false
+        $script:deferredPreRetryReady = $false
 
         Mock Wait-PaneShellReady { }
         Mock Send-TextToPane {
@@ -15731,7 +15743,14 @@ Describe 'deferred worker startup' {
             $script:deferredSendCommands.Add($CommandText) | Out-Null
             return "sent to $PaneId"
         }
-        Mock Test-AgentReadyPrompt { return $true }
+        Mock Test-AgentReadyPrompt {
+            $script:deferredReadyProbeCount++
+            if ($script:deferredReadyProbeCount -eq 1 -and $script:deferredPreRetryProbeApplies) {
+                return [bool]$script:deferredPreRetryReady
+            }
+
+            return $true
+        }
         Mock Set-PaneControlManifestPaneProperties {
             param([string]$ManifestPath, [string]$PaneId, [System.Collections.IDictionary]$Properties)
             $script:deferredStatusWrites.Add([string]$Properties['status']) | Out-Null
@@ -15784,6 +15803,8 @@ Describe 'deferred worker startup' {
     }
 
     It 'retries a previously failed deferred pane instead of sending task text to the shell' {
+        $script:deferredPreRetryProbeApplies = $true
+        $script:deferredPreRetryReady = $false
         $entry = [PSCustomObject]@{
             Label             = 'worker-2'
             PaneId            = '%3'
@@ -15802,7 +15823,30 @@ Describe 'deferred worker startup' {
         $script:deferredStatusWrites | Should -Be @('deferred_starting', 'ready')
     }
 
+    It 'marks a previously failed deferred pane ready when the delayed bootstrap already reached an agent prompt' {
+        $script:deferredPreRetryProbeApplies = $true
+        $script:deferredPreRetryReady = $true
+        $entry = [PSCustomObject]@{
+            Label             = 'worker-2'
+            PaneId            = '%3'
+            Status            = 'deferred_start_failed'
+            BootstrapPlanPath = $script:deferredPlanPath
+            CapabilityAdapter = 'codex'
+            ProviderTarget    = ''
+        }
+
+        $started = Start-DeferredPaneFromManifestEntry -ProjectDir $script:deferredTempRoot -ManifestEntry $entry
+
+        $started | Should -Be $true
+        Should -Invoke Wait-PaneShellReady -Times 0 -Exactly
+        $script:deferredSendCommands.Count | Should -Be 0
+        $script:deferredReadyProbeCount | Should -Be 1
+        $script:deferredStatusWrites | Should -Be @('ready')
+    }
+
     It 'blocks a previously failed deferred pane when the bootstrap plan is still missing' {
+        $script:deferredPreRetryProbeApplies = $true
+        $script:deferredPreRetryReady = $false
         $missingPlan = Join-Path $script:deferredTempRoot 'missing-worker-2.json'
         $entry = [PSCustomObject]@{
             Label             = 'worker-2'

--- a/winsmux-core/scripts/orchestra-start.ps1
+++ b/winsmux-core/scripts/orchestra-start.ps1
@@ -804,6 +804,17 @@ function Test-OrchestraPaneDeferredStart {
     return ([int]$Matches[1] -gt 1)
 }
 
+function Test-OrchestraPaneBootstrapVerificationDeferred {
+    param([AllowNull()]$PaneSummary)
+
+    $status = [string](Get-OrchestraObjectPropertyValue -InputObject $PaneSummary -Name 'Status' -Default '')
+    if ([string]::IsNullOrWhiteSpace($status)) {
+        return $false
+    }
+
+    return @('deferred_start', 'deferred_starting') -contains $status.Trim().ToLowerInvariant()
+}
+
 function Get-AgentLaunchCommand {
     param(
         [Parameter(Mandatory = $true)][string]$Agent,
@@ -2280,7 +2291,7 @@ if ($MyInvocation.InvocationName -ne '.') {
     }
 
     foreach ($paneSummary in $paneSummaries) {
-        if ([string](Get-OrchestraObjectPropertyValue -InputObject $paneSummary -Name 'Status' -Default '') -eq 'deferred_start') {
+        if (Test-OrchestraPaneBootstrapVerificationDeferred -PaneSummary $paneSummary) {
             continue
         }
 
@@ -2297,6 +2308,11 @@ if ($MyInvocation.InvocationName -ne '.') {
     $validPaneSummaries = [System.Collections.Generic.List[object]]::new()
     $invalidCount = 0
     foreach ($paneSummary in $paneSummaries) {
+        if (Test-OrchestraPaneBootstrapVerificationDeferred -PaneSummary $paneSummary) {
+            $validPaneSummaries.Add($paneSummary)
+            continue
+        }
+
         $failures = @(Test-PaneBootstrapInvariants `
             -PaneId $paneSummary.PaneId `
             -Label $paneSummary.Label `


### PR DESCRIPTION
## Summary
- skip readiness and cwd bootstrap verification for deferred worker panes during orchestra startup
- preserve deferred worker manifest entries so `worker-2+` can be started lazily by send/dispatch
- re-check agent readiness before retrying a `deferred_start_failed` pane, so slow completed bootstraps are marked ready instead of being relaunched

## Validation
- `git diff --check`
- PowerShell parser checks for `scripts\winsmux-core.ps1` and `winsmux-core\scripts\orchestra-start.ps1`
- `Invoke-Pester -Path tests\winsmux-bridge.Tests.ps1 -FullName 'deferred worker startup','orchestra-start server bootstrap','orchestra pane bootstrap plan' -Output Detailed`
- `pwsh -NoProfile -File scripts\audit-public-surface.ps1`
- `pwsh -NoProfile -File scripts\git-guard.ps1`

Follow-up for #822 and #823. Refs #820.