### PR TITLE
Cap orchestra warm processes

### DIFF
--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -4742,6 +4742,29 @@ Describe 'orchestra-preflight health contract' {
 
         $health | Should -Be 'Unhealthy'
     }
+
+    It 'removes excess warm servers while keeping the budgeted warm process' {
+        $snapshot = [pscustomobject]@{
+            Processes = @(
+                [pscustomobject]@{ ProcessId = 11; ParentProcessId = 0; Name = 'winsmux.exe'; CommandLine = 'winsmux server -s __warm__ -x 120 -y 30' },
+                [pscustomobject]@{ ProcessId = 22; ParentProcessId = 0; Name = 'winsmux.exe'; CommandLine = 'winsmux server -s __warm__ -x 120 -y 30' },
+                [pscustomobject]@{ ProcessId = 33; ParentProcessId = 0; Name = 'winsmux.exe'; CommandLine = 'winsmux server -s __warm__ -x 120 -y 30' },
+                [pscustomobject]@{ ProcessId = 44; ParentProcessId = 0; Name = 'pwsh.exe'; CommandLine = 'pwsh -NoProfile' }
+            )
+            ById = @{}
+            ChildrenByParent = @{}
+        }
+
+        Mock Stop-Process { }
+
+        $cleanup = Remove-OrchestraExcessWarmProcesses -MaxWarmProcesses 1 -ProcessSnapshot $snapshot
+
+        @($cleanup.WarmProcesses).Count | Should -Be 3
+        @($cleanup.Victims).Count | Should -Be 2
+        @($cleanup.Killed).Count | Should -Be 2
+        Should -Invoke Stop-Process -Times 1 -Exactly -ParameterFilter { $Id -eq 22 -and $Force }
+        Should -Invoke Stop-Process -Times 1 -Exactly -ParameterFilter { $Id -eq 33 -and $Force }
+    }
 }
 
 Describe 'orchestra-start watchdog contract' {
@@ -6116,6 +6139,23 @@ Describe 'orchestra-start session reuse contract' {
         $sessionExistsIndex | Should -BeLessThan $manifestCleanupIndex
         $manifestCleanupIndex | Should -BeLessThan $clearManifestIndex
         $clearManifestIndex | Should -BeLessThan $zombieCleanupIndex
+    }
+
+    It 'suppresses warm servers and trims excess warm processes during managed startup' {
+        $script:orchestraStartContent | Should -Match 'function Enable-OrchestraManagedWarmSuppression'
+        $script:orchestraStartContent | Should -Match 'Set-Item -Path "Env:\$name" -Value ''1'''
+        $script:orchestraStartContent | Should -Match 'Remove-OrchestraExcessWarmProcesses -MaxWarmProcesses 1'
+
+        $warmSuppressionIndex = $script:orchestraStartContent.IndexOf('        Enable-OrchestraManagedWarmSuppression')
+        $winsmuxResolveIndex = $script:orchestraStartContent.IndexOf('$script:winsmuxBin = Get-WinsmuxBin')
+        $zombieCleanupIndex = $script:orchestraStartContent.IndexOf('$zombieCleanup = Remove-OrchestraZombieProcesses -SessionName $sessionName -ProjectDir $projectDir -GitWorktreeDir $gitWorktreeDir -BridgeScript $bridgeScript -WinsmuxBin $winsmuxBin')
+        $warmCleanupIndex = $script:orchestraStartContent.IndexOf('$warmCleanup = Remove-OrchestraExcessWarmProcesses -MaxWarmProcesses 1')
+        $ensureSessionIndex = $script:orchestraStartContent.IndexOf('$orchestraServer = Ensure-OrchestraBootstrapSession -SessionName $sessionName -TimeoutSeconds 60')
+
+        $warmSuppressionIndex | Should -BeGreaterThan -1
+        $winsmuxResolveIndex | Should -BeGreaterThan $warmSuppressionIndex
+        $warmCleanupIndex | Should -BeGreaterThan $zombieCleanupIndex
+        $ensureSessionIndex | Should -BeGreaterThan $warmCleanupIndex
     }
 
     It 'requires the bootstrap pane topology before considering a fresh session ready' {

--- a/winsmux-core/scripts/orchestra-preflight.ps1
+++ b/winsmux-core/scripts/orchestra-preflight.ps1
@@ -290,6 +290,76 @@ function Remove-OrchestraZombieProcesses {
     }
 }
 
+function Test-OrchestraWarmProcess {
+    param([AllowNull()]$Process)
+
+    if ($null -eq $Process) {
+        return $false
+    }
+
+    $processName = Get-OrchestraManagedProcessName -Name ([string]$Process.Name)
+    if ($processName -ne 'winsmux') {
+        return $false
+    }
+
+    $commandLine = [string]$Process.CommandLine
+    if ([string]::IsNullOrWhiteSpace($commandLine)) {
+        return $false
+    }
+
+    return (
+        $commandLine.IndexOf('__warm__', [System.StringComparison]::OrdinalIgnoreCase) -ge 0 -and
+        $commandLine.IndexOf('server', [System.StringComparison]::OrdinalIgnoreCase) -ge 0
+    )
+}
+
+function Remove-OrchestraExcessWarmProcesses {
+    param(
+        [int]$MaxWarmProcesses = 1,
+        [AllowNull()]$ProcessSnapshot = $null
+    )
+
+    $snapshot = if ($null -ne $ProcessSnapshot) { $ProcessSnapshot } else { Get-ProcessSnapshot }
+    $protectedIds = Get-AncestorProcessIds -Snapshot $snapshot -ProcessId $PID
+    if ($null -eq $protectedIds) {
+        $protectedIds = [System.Collections.Generic.HashSet[int]]::new()
+    }
+    $warmProcesses = @(
+        $snapshot.Processes |
+            Where-Object { Test-OrchestraWarmProcess -Process $_ } |
+            Sort-Object -Property ProcessId
+    )
+
+    $maxAllowed = [Math]::Max(0, $MaxWarmProcesses)
+    $victims = @($warmProcesses | Select-Object -Skip $maxAllowed)
+    $killed = [System.Collections.Generic.List[object]]::new()
+
+    foreach ($victim in $victims) {
+        $victimProcessId = [int]$victim.ProcessId
+        if ($protectedIds.Contains($victimProcessId)) {
+            continue
+        }
+
+        try {
+            Stop-Process -Id $victimProcessId -Force -ErrorAction Stop
+            $killed.Add($victim) | Out-Null
+            Write-Host ("Preflight: killed excess warm server {0} ({1})" -f $victim.Name, $victimProcessId)
+            if (Get-Command Write-WinsmuxLog -ErrorAction SilentlyContinue) {
+                Write-WinsmuxLog -Level INFO -Event 'preflight.warm_process.killed' -Message ("Killed excess warm server {0} ({1})." -f $victim.Name, $victimProcessId) -Data @{ process_name = $victim.Name; process_id = $victimProcessId } | Out-Null
+            }
+        } catch {
+            Write-Warning ("Preflight: failed to kill excess warm server {0} ({1}): {2}" -f $victim.Name, $victimProcessId, $_.Exception.Message)
+        }
+    }
+
+    return [PSCustomObject]@{
+        WarmProcesses    = @($warmProcesses)
+        Victims          = @($victims)
+        Killed           = @($killed)
+        MaxWarmProcesses = $maxAllowed
+    }
+}
+
 function Get-OrchestraSessionRegistryDir {
     $homeDir = $env:USERPROFILE
     if ([string]::IsNullOrWhiteSpace($homeDir)) {

--- a/winsmux-core/scripts/orchestra-start.ps1
+++ b/winsmux-core/scripts/orchestra-start.ps1
@@ -18,6 +18,12 @@ $bridgeScript = [System.IO.Path]::GetFullPath((Join-Path $scriptDir '..\..\scrip
 $layoutScript = [System.IO.Path]::GetFullPath((Join-Path $scriptDir 'orchestra-layout.ps1'))
 $script:winsmuxBin = $null
 
+function Enable-OrchestraManagedWarmSuppression {
+    foreach ($name in @('PSMUX_NO_WARM', 'WINSMUX_NO_WARM')) {
+        Set-Item -Path "Env:$name" -Value '1'
+    }
+}
+
 function Write-OrchestraTextFile {
     param(
         [Parameter(Mandatory = $true)][string]$Path,
@@ -1919,6 +1925,7 @@ if ($MyInvocation.InvocationName -ne '.') {
     $bootstrapPaneId = $null
     $createdWorktrees = @()
     try {
+        Enable-OrchestraManagedWarmSuppression
         $script:winsmuxBin = Get-WinsmuxBin
         $winsmuxBin = $script:winsmuxBin
         if (-not $winsmuxBin) {
@@ -2008,6 +2015,15 @@ if ($MyInvocation.InvocationName -ne '.') {
         if (@($zombieCleanup.Killed).Count -gt 0) {
             Write-WinsmuxLog -Level INFO -Event 'preflight.git_worktree.prune_after_zombie_cleanup' -Message 'Pruning git worktree metadata after zombie cleanup.' -Data @{ killed_count = @($zombieCleanup.Killed).Count } | Out-Null
             Invoke-BuilderWorktreeGit -ProjectDir $projectDir -Arguments @('worktree', 'prune') | Out-Null
+        }
+
+        $warmCleanup = Remove-OrchestraExcessWarmProcesses -MaxWarmProcesses 1
+        if (@($warmCleanup.Killed).Count -gt 0) {
+            Write-WinsmuxLog -Level INFO -Event 'preflight.warm_process.cleanup' -Message 'Removed excess warm servers before orchestra startup.' -Data ([ordered]@{
+                killed_count       = @($warmCleanup.Killed).Count
+                warm_process_count = @($warmCleanup.WarmProcesses).Count
+                max_warm_processes = [int]$warmCleanup.MaxWarmProcesses
+            }) | Out-Null
         }
 
         $orchestraServer = Ensure-OrchestraBootstrapSession -SessionName $sessionName -TimeoutSeconds 60


### PR DESCRIPTION
## Summary
- suppress winsmux warm server creation during managed orchestra startup
- trim excess __warm__ servers before creating/reusing the orchestra session
- add Pester coverage for warm-process cleanup and startup ordering

## Validation
- git diff --check
- PowerShell parser checks for orchestra-preflight.ps1 and orchestra-start.ps1
- Invoke-Pester -Path tests/winsmux-bridge.Tests.ps1 -FullName "orchestra-preflight health contract","orchestra-start session reuse contract" -Output Detailed
- pwsh -NoProfile -File scripts/audit-public-surface.ps1
- pwsh -NoProfile -File scripts/git-guard.ps1
- Invoke-Pester -Path tests/winsmux-bridge.Tests.ps1 -Output Detailed
- pwsh -NoProfile -File winsmux-core/scripts/orchestra-start.ps1
- pwsh -NoProfile -File winsmux-core/scripts/orchestra-smoke.ps1 -AsJson
