### PR TITLE
Trim compatible warm servers

### DIFF
--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -4747,9 +4747,11 @@ Describe 'orchestra-preflight health contract' {
         $snapshot = [pscustomobject]@{
             Processes = @(
                 [pscustomobject]@{ ProcessId = 11; ParentProcessId = 0; Name = 'winsmux.exe'; CommandLine = 'winsmux server -s __warm__ -x 120 -y 30' },
-                [pscustomobject]@{ ProcessId = 22; ParentProcessId = 0; Name = 'winsmux.exe'; CommandLine = 'winsmux server -s __warm__ -x 120 -y 30' },
-                [pscustomobject]@{ ProcessId = 33; ParentProcessId = 0; Name = 'winsmux.exe'; CommandLine = 'winsmux server -s __warm__ -x 120 -y 30' },
-                [pscustomobject]@{ ProcessId = 44; ParentProcessId = 0; Name = 'pwsh.exe'; CommandLine = 'pwsh -NoProfile' }
+                [pscustomobject]@{ ProcessId = 22; ParentProcessId = 0; Name = 'pmux.exe'; CommandLine = 'pmux server -s __warm__ -x 120 -y 30' },
+                [pscustomobject]@{ ProcessId = 33; ParentProcessId = 0; Name = 'tmux.exe'; CommandLine = 'tmux server -s __warm__ -x 120 -y 30' },
+                [pscustomobject]@{ ProcessId = 44; ParentProcessId = 0; Name = 'psmux.exe'; CommandLine = 'psmux server -s __warm__ -x 120 -y 30' },
+                [pscustomobject]@{ ProcessId = 55; ParentProcessId = 0; Name = 'pwsh.exe'; CommandLine = 'pwsh -NoProfile' },
+                [pscustomobject]@{ ProcessId = 66; ParentProcessId = 0; Name = 'winsmux.exe'; CommandLine = 'winsmux attach-session -t winsmux-orchestra' }
             )
             ById = @{}
             ChildrenByParent = @{}
@@ -4759,11 +4761,13 @@ Describe 'orchestra-preflight health contract' {
 
         $cleanup = Remove-OrchestraExcessWarmProcesses -MaxWarmProcesses 1 -ProcessSnapshot $snapshot
 
-        @($cleanup.WarmProcesses).Count | Should -Be 3
-        @($cleanup.Victims).Count | Should -Be 2
-        @($cleanup.Killed).Count | Should -Be 2
+        @($cleanup.WarmProcesses).Count | Should -Be 4
+        @($cleanup.Victims).Count | Should -Be 3
+        @($cleanup.Killed).Count | Should -Be 3
         Should -Invoke Stop-Process -Times 1 -Exactly -ParameterFilter { $Id -eq 22 -and $Force }
         Should -Invoke Stop-Process -Times 1 -Exactly -ParameterFilter { $Id -eq 33 -and $Force }
+        Should -Invoke Stop-Process -Times 1 -Exactly -ParameterFilter { $Id -eq 44 -and $Force }
+        Should -Invoke Stop-Process -Times 0 -Exactly -ParameterFilter { $Id -eq 66 }
     }
 }
 

--- a/winsmux-core/scripts/orchestra-preflight.ps1
+++ b/winsmux-core/scripts/orchestra-preflight.ps1
@@ -298,7 +298,7 @@ function Test-OrchestraWarmProcess {
     }
 
     $processName = Get-OrchestraManagedProcessName -Name ([string]$Process.Name)
-    if ($processName -ne 'winsmux') {
+    if ($processName -notin @('winsmux', 'psmux', 'pmux', 'tmux')) {
         return $false
     }
 


### PR DESCRIPTION
## Summary
- include `psmux.exe`, `pmux.exe`, and `tmux.exe` in orchestra warm server cleanup
- extend the warm-process cleanup test to cover compatibility binaries
- keep non-warm winsmux attach processes out of the cleanup set

## Validation
- PowerShell parser check for `winsmux-core/scripts/orchestra-preflight.ps1`
- `git diff --check`
- `Invoke-Pester -Path tests/winsmux-bridge.Tests.ps1 -FullName "orchestra-preflight health contract" -Output Detailed`
- `pwsh -NoProfile -File scripts/audit-public-surface.ps1`
- `pwsh -NoProfile -File scripts/git-guard.ps1`
