### PR TITLE
Add desktop voice capture status

### DIFF
--- a/winsmux-app/index.html
+++ b/winsmux-app/index.html
@@ -254,6 +254,7 @@
                   </svg>
                 </button>
               </div>
+              <div id="voice-input-status" class="voice-input-status" role="status" aria-live="polite" hidden></div>
               <input id="composer-file-input" type="file" hidden multiple />
               <div id="composer-slash-row" aria-label="Composer suggestions" hidden></div>
               <div id="composer-remote-row" aria-label="Composer remote attachments" hidden></div>

--- a/winsmux-app/scripts/viewport-harness.mjs
+++ b/winsmux-app/scripts/viewport-harness.mjs
@@ -1021,6 +1021,10 @@ async function verifyDesktopViewport(page, previewUrl) {
         !voice.disabled &&
         voice.getAttribute("aria-label")?.includes("Ctrl+Alt+M");
     });
+    await page.waitForFunction(() => {
+      const status = document.querySelector("#voice-input-status");
+      return status instanceof HTMLElement && status.hidden;
+    });
     await page.keyboard.press("Control+Alt+M");
     await page.waitForFunction(() => {
       const voice = document.querySelector("#voice-input-btn");

--- a/winsmux-app/src-tauri/src/control_pipe.rs
+++ b/winsmux-app/src-tauri/src/control_pipe.rs
@@ -19,6 +19,7 @@ const DESKTOP_CONTROL_PIPE_METHODS: &[&str] = &[
     "desktop.run.compare",
     "desktop.run.promote",
     "desktop.run.pick_winner",
+    "desktop.voice.capture_status",
 ];
 
 pub fn handle_control_pipe_payload(
@@ -354,6 +355,21 @@ mod tests {
         assert_eq!(value["result"]["pipe"], WINSMUX_CONTROL_PIPE_NAME);
         assert_eq!(value["result"]["localhost_http"], false);
         assert_eq!(value["result"]["websocket"], false);
+    }
+
+    #[test]
+    fn control_pipe_routes_voice_capture_status_to_desktop_handler() {
+        let payload = br#"{"jsonrpc":"2.0","id":1,"method":"desktop.voice.capture_status"}"#;
+        let pty_transport = StubPtyTransport::new();
+        let response =
+            handle_control_pipe_payload(&StubDesktopTransport, &pty_transport, payload, None);
+        let value: Value = serde_json::from_slice(&response).expect("response should be JSON");
+
+        assert_eq!(value["jsonrpc"], "2.0");
+        assert_eq!(value["id"], 1);
+        assert_eq!(value["result"]["capture_mode"], "browser_fallback");
+        assert_eq!(value["result"]["native"]["available"], false);
+        assert_eq!(value["result"]["browser_fallback"]["expected"], true);
     }
 
     #[test]

--- a/winsmux-app/src-tauri/src/desktop_backend.rs
+++ b/winsmux-app/src-tauri/src/desktop_backend.rs
@@ -596,6 +596,32 @@ pub enum DesktopJsonRpcResponse {
     },
 }
 
+#[derive(Serialize, Deserialize)]
+pub struct DesktopVoiceCaptureNativeStatus {
+    pub available: bool,
+    pub state: String,
+    pub permission: String,
+    pub device: String,
+    pub meter_supported: bool,
+    pub restart_supported: bool,
+    pub reason: String,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct DesktopVoiceCaptureBrowserFallbackStatus {
+    pub expected: bool,
+    pub reason: String,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct DesktopVoiceCaptureStatus {
+    pub version: u16,
+    pub capture_mode: String,
+    pub native: DesktopVoiceCaptureNativeStatus,
+    pub browser_fallback: DesktopVoiceCaptureBrowserFallbackStatus,
+    pub state_contract: Vec<String>,
+}
+
 pub enum DesktopCommand {
     SummarySnapshot {
         project_dir: Option<String>,
@@ -633,6 +659,37 @@ pub enum DesktopCommand {
 
 pub enum DesktopStreamCommand {
     Summary { project_dir: Option<String> },
+}
+
+pub fn load_desktop_voice_capture_status() -> DesktopVoiceCaptureStatus {
+    DesktopVoiceCaptureStatus {
+        version: 1,
+        capture_mode: "browser_fallback".to_string(),
+        native: DesktopVoiceCaptureNativeStatus {
+            available: false,
+            state: "unavailable".to_string(),
+            permission: "unknown".to_string(),
+            device: "unknown".to_string(),
+            meter_supported: false,
+            restart_supported: false,
+            reason: "Native microphone capture is not implemented in this build.".to_string(),
+        },
+        browser_fallback: DesktopVoiceCaptureBrowserFallbackStatus {
+            expected: true,
+            reason: "Use browser speech recognition until the native capture backend is available."
+                .to_string(),
+        },
+        state_contract: vec![
+            "unavailable".to_string(),
+            "permission_denied".to_string(),
+            "no_microphone".to_string(),
+            "silence".to_string(),
+            "cancelled".to_string(),
+            "restarting".to_string(),
+            "recording".to_string(),
+            "stopped".to_string(),
+        ],
+    }
 }
 
 impl DesktopCommand {
@@ -1089,12 +1146,23 @@ pub fn handle_desktop_json_rpc(
                     "desktop.run.promote",
                     "desktop.run.pick_winner",
                     "desktop.runtime.roles.apply",
+                    "desktop.voice.capture_status",
                     "desktop.dogfood.event",
                     "desktop.explorer.list",
                     "desktop.editor.read",
                 ],
             }),
         ),
+        "desktop.voice.capture_status" => {
+            match serde_json::to_value(load_desktop_voice_capture_status()) {
+                Ok(result) => json_rpc_result(request_id, result),
+                Err(err) => json_rpc_error(
+                    request_id,
+                    JSON_RPC_INTERNAL_ERROR,
+                    format!("Failed to serialize desktop voice capture payload: {err}"),
+                ),
+            }
+        }
         "desktop.run.explain" => {
             let run_id = match get_required_string_param(params.as_ref(), &["runId", "run_id"]) {
                 Ok(value) => value,
@@ -4534,11 +4602,52 @@ mod tests {
                 assert!(methods
                     .iter()
                     .any(|method| { method.as_str() == Some("desktop.dogfood.event") }));
+                assert!(methods
+                    .iter()
+                    .any(|method| { method.as_str() == Some("desktop.voice.capture_status") }));
             }
             DesktopJsonRpcResponse::Error { error, .. } => {
                 panic!("expected success, got {:?}", error);
             }
         }
+    }
+
+    #[test]
+    fn handle_desktop_json_rpc_routes_voice_capture_status() {
+        let transport = FakeTransport {
+            requests: RefCell::new(Vec::new()),
+            response: serde_json::json!({}),
+        };
+        let response = handle_desktop_json_rpc(
+            &transport,
+            DesktopJsonRpcRequest {
+                jsonrpc: "2.0".to_string(),
+                id: serde_json::json!("req-voice"),
+                method: "desktop.voice.capture_status".to_string(),
+                params: None,
+            },
+            None,
+        );
+
+        match response {
+            DesktopJsonRpcResponse::Success { id, result, .. } => {
+                assert_eq!(id, serde_json::json!("req-voice"));
+                assert_eq!(result["version"], 1);
+                assert_eq!(result["capture_mode"], "browser_fallback");
+                assert_eq!(result["native"]["available"], false);
+                assert_eq!(result["native"]["state"], "unavailable");
+                assert_eq!(result["browser_fallback"]["expected"], true);
+                assert!(result["state_contract"]
+                    .as_array()
+                    .expect("state_contract must be an array")
+                    .iter()
+                    .any(|state| state.as_str() == Some("permission_denied")));
+            }
+            DesktopJsonRpcResponse::Error { error, .. } => {
+                panic!("expected success, got {:?}", error);
+            }
+        }
+        assert!(transport.requests.borrow().is_empty());
     }
 
     #[test]

--- a/winsmux-app/src/desktopClient.ts
+++ b/winsmux-app/src/desktopClient.ts
@@ -8,6 +8,7 @@ type DesktopCommandName =
   | "desktop_run_promote"
   | "desktop_run_pick_winner"
   | "desktop_runtime_roles_apply"
+  | "desktop_voice_capture_status"
   | "desktop_dogfood_event"
   | "desktop_editor_read"
   | "desktop_explorer_list";
@@ -18,6 +19,7 @@ type DesktopJsonRpcMethod =
   | "desktop.run.promote"
   | "desktop.run.pick_winner"
   | "desktop.runtime.roles.apply"
+  | "desktop.voice.capture_status"
   | "desktop.dogfood.event"
   | "desktop.editor.read"
   | "desktop.explorer.list";
@@ -51,6 +53,39 @@ export interface DesktopCommandTransport {
     command: DesktopCommandName,
     payload?: Record<string, unknown>,
   ): Promise<TResponse>;
+}
+
+export type DesktopVoiceCaptureState =
+  | "unavailable"
+  | "permission_denied"
+  | "no_microphone"
+  | "silence"
+  | "cancelled"
+  | "restarting"
+  | "recording"
+  | "stopped";
+
+export interface DesktopVoiceCaptureNativeStatus {
+  available: boolean;
+  state: DesktopVoiceCaptureState;
+  permission: string;
+  device: string;
+  meter_supported: boolean;
+  restart_supported: boolean;
+  reason: string;
+}
+
+export interface DesktopVoiceCaptureBrowserFallbackStatus {
+  expected: boolean;
+  reason: string;
+}
+
+export interface DesktopVoiceCaptureStatus {
+  version: number;
+  capture_mode: "native" | "browser_fallback" | "unavailable";
+  native: DesktopVoiceCaptureNativeStatus;
+  browser_fallback: DesktopVoiceCaptureBrowserFallbackStatus;
+  state_contract: DesktopVoiceCaptureState[];
 }
 
 export interface DesktopBoardSummary {
@@ -534,6 +569,8 @@ function getDesktopJsonRpcMethod(command: DesktopCommandName): DesktopJsonRpcMet
       return "desktop.run.pick_winner";
     case "desktop_runtime_roles_apply":
       return "desktop.runtime.roles.apply";
+    case "desktop_voice_capture_status":
+      return "desktop.voice.capture_status";
     case "desktop_dogfood_event":
       return "desktop.dogfood.event";
     case "desktop_editor_read":
@@ -701,6 +738,17 @@ export async function applyDesktopRuntimeRolePreferences(
     );
   } catch (error) {
     throw normalizeDesktopError("desktop_runtime_roles_apply", error);
+  }
+}
+
+export async function getDesktopVoiceCaptureStatus(projectDir?: string | null) {
+  try {
+    return await desktopCommandTransport.request<DesktopVoiceCaptureStatus>(
+      "desktop_voice_capture_status",
+      buildProjectDirPayload(projectDir),
+    );
+  } catch (error) {
+    throw normalizeDesktopError("desktop_voice_capture_status", error);
   }
 }
 

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -10,6 +10,7 @@ import {
   getDesktopRunExplain,
   getDesktopExplorerEntries,
   getDesktopSummarySnapshot,
+  getDesktopVoiceCaptureStatus,
   pickDesktopRunWinner,
   promoteDesktopRunTactic,
   recordDesktopDogfoodEvent,
@@ -23,6 +24,7 @@ import {
   type DesktopRunProjection,
   type DesktopSummarySnapshot,
   type DesktopRuntimeRolePreference,
+  type DesktopVoiceCaptureStatus,
 } from "./desktopClient";
 import { getEditorFileKey, getSourceChangeKey, pickEditorPathCandidate, pickSourceChangeKeyCandidate } from "./editorTargets";
 import {
@@ -491,6 +493,9 @@ let operatorOutputFlushTimer: number | null = null;
 let voiceRecognition: SpeechRecognitionLike | null = null;
 let voiceListening = false;
 let voiceTranscriptBase = "";
+let voiceCaptureStatus: DesktopVoiceCaptureStatus | null = null;
+let voiceCaptureStatusError = "";
+let voiceCaptureStatusRefreshStarted = false;
 const detectedPreviewTargets = new Map<string, PreviewTarget>();
 const PREVIEW_FRESHNESS_WINDOW_MS = 30_000;
 const PANE_META_REFRESH_INTERVAL_MS = 30_000;
@@ -6890,24 +6895,110 @@ function getSpeechRecognitionConstructor(): SpeechRecognitionConstructor | null 
   return speechWindow.SpeechRecognition ?? speechWindow.webkitSpeechRecognition ?? null;
 }
 
+function isBrowserVoiceInputSupported() {
+  return Boolean(getSpeechRecognitionConstructor());
+}
+
+function getVoiceCaptureStatusMessage() {
+  if (!isTauri()) {
+    return "";
+  }
+
+  if (voiceCaptureStatusError) {
+    return getLanguageText(
+      `Native microphone status failed: ${voiceCaptureStatusError}`,
+      `ネイティブのマイク状態を取得できません: ${voiceCaptureStatusError}`,
+    );
+  }
+
+  if (!voiceCaptureStatus) {
+    return getLanguageText(
+      "Checking native microphone status...",
+      "ネイティブのマイク状態を確認中...",
+    );
+  }
+
+  if (voiceCaptureStatus.native.available) {
+    return getLanguageText(
+      "Native microphone capture is available.",
+      "ネイティブのマイク入力を利用できます。",
+    );
+  }
+
+  if (isBrowserVoiceInputSupported()) {
+    return getLanguageText(
+      "Native microphone capture is not ready; browser voice input is active.",
+      "ネイティブのマイク入力は準備中です。ブラウザーの音声入力を使います。",
+    );
+  }
+
+  return getLanguageText(
+    "Native microphone capture is not ready, and browser voice input is unavailable.",
+    "ネイティブのマイク入力は準備中です。この環境ではブラウザーの音声入力も使えません。",
+  );
+}
+
+function renderVoiceCaptureStatus() {
+  const status = document.getElementById("voice-input-status") as HTMLElement | null;
+  if (!status) {
+    return;
+  }
+
+  const message = getVoiceCaptureStatusMessage();
+  status.hidden = !message;
+  status.textContent = message;
+  status.dataset.state = voiceCaptureStatus?.native.state ?? (voiceCaptureStatusError ? "error" : "unknown");
+}
+
+async function refreshVoiceCaptureStatus() {
+  if (!isTauri()) {
+    renderVoiceCaptureStatus();
+    return;
+  }
+
+  try {
+    voiceCaptureStatus = await getDesktopVoiceCaptureStatus();
+    voiceCaptureStatusError = "";
+  } catch (error) {
+    voiceCaptureStatus = null;
+    voiceCaptureStatusError = error instanceof Error ? error.message : String(error);
+  }
+  updateVoiceInputButton();
+  renderVoiceCaptureStatus();
+}
+
+function ensureVoiceCaptureStatusRefresh() {
+  if (voiceCaptureStatusRefreshStarted) {
+    return;
+  }
+  voiceCaptureStatusRefreshStarted = true;
+  void refreshVoiceCaptureStatus();
+}
+
 function updateVoiceInputButton() {
   const button = document.getElementById("voice-input-btn") as HTMLButtonElement | null;
   if (!button) {
     return;
   }
 
-  const supported = Boolean(getSpeechRecognitionConstructor());
+  const supported = isBrowserVoiceInputSupported();
   button.disabled = !supported;
   button.classList.toggle("is-recording", voiceListening);
   button.setAttribute("aria-pressed", voiceListening ? "true" : "false");
   const label = !supported
-    ? getLanguageText("Voice input is not available in this browser", "このブラウザーでは音声入力を利用できません")
+    ? isTauri()
+      ? getLanguageText(
+        "Voice input is unavailable until native microphone capture is ready",
+        "ネイティブのマイク入力が準備できるまで音声入力は使えません",
+      )
+      : getLanguageText("Voice input is not available in this browser", "このブラウザーでは音声入力を利用できません")
     : voiceListening
       ? getLanguageText("Stop voice input", "音声入力を停止")
       : getLanguageText("Start voice input", "音声入力を開始");
   const labelWithShortcut = supported ? `${label} (${normalizeVoiceShortcut(themeState.voiceShortcut)})` : label;
   button.setAttribute("aria-label", labelWithShortcut);
   button.setAttribute("title", labelWithShortcut);
+  renderVoiceCaptureStatus();
 }
 
 function stopVoiceInput() {
@@ -6924,6 +7015,7 @@ function stopVoiceInput() {
 function startVoiceInput(composerInput: HTMLTextAreaElement) {
   const SpeechRecognition = getSpeechRecognitionConstructor();
   if (!SpeechRecognition) {
+    ensureVoiceCaptureStatusRefresh();
     updateVoiceInputButton();
     return;
   }
@@ -11858,6 +11950,8 @@ window.addEventListener("DOMContentLoaded", async () => {
   const voiceInputButton = document.getElementById("voice-input-btn") as HTMLButtonElement | null;
   const interruptOperatorButton = document.getElementById("interrupt-operator-btn") as HTMLButtonElement | null;
   if (composer && composerInput) {
+    ensureVoiceCaptureStatusRefresh();
+
     voiceInputButton?.addEventListener("click", () => {
       toggleVoiceInput(composerInput);
     });

--- a/winsmux-app/src/styles.css
+++ b/winsmux-app/src/styles.css
@@ -1755,6 +1755,18 @@ body[data-popout-surface="1"] #editor-surface {
   box-shadow: 0 0 0 3px rgba(90, 132, 245, 0.18);
 }
 
+.voice-input-status {
+  margin-top: 6px;
+  color: var(--text-muted);
+  font-size: var(--text-2xs);
+  line-height: var(--leading-tight);
+}
+
+.voice-input-status[data-state="unavailable"],
+.voice-input-status[data-state="error"] {
+  color: var(--status-warning);
+}
+
 #composer-mode-row {
   margin-top: 8px;
   display: flex;


### PR DESCRIPTION
## Summary
- Add desktop.voice.capture_status to the desktop JSON-RPC contract.
- Add typed desktop client support and an inline composer voice status surface.
- Keep the existing browser SpeechRecognition path as the fallback while native capture remains unavailable.

## Validation
- cmd /c node --check winsmux-app\\scripts\\viewport-harness.mjs
- cmd /c npm run build
- cmd /c npm run test:viewport-harness (normal privileges after sandbox esbuild spawn EPERM)
- cargo test -p winsmux-app handle_desktop_json_rpc_routes_voice_capture_status
- cargo test -p winsmux-app
- cargo fmt --package winsmux-app
- git diff --check
- pwsh -NoProfile -File scripts\\audit-public-surface.ps1
- pwsh -NoProfile -File scripts\\git-guard.ps1

## Planning
- TASK-420 is marked active in external planning and remains incomplete after this status-contract slice.