### PR TITLE
TASK-420 native desktop capture meter

### DIFF
--- a/winsmux-app/src-tauri/src/desktop_backend.rs
+++ b/winsmux-app/src-tauri/src/desktop_backend.rs
@@ -609,6 +609,7 @@ pub struct DesktopVoiceCaptureNativeStatus {
     pub device: String,
     pub device_count: u32,
     pub meter_supported: bool,
+    pub meter_level: f64,
     pub restart_supported: bool,
     pub reason: String,
 }
@@ -710,6 +711,7 @@ pub fn build_desktop_voice_capture_status(
             device,
             device_count: probe.device_count,
             meter_supported: false,
+            meter_level: 0.0,
             restart_supported: false,
             reason,
         },

--- a/winsmux-app/src-tauri/src/lib.rs
+++ b/winsmux-app/src-tauri/src/lib.rs
@@ -7,7 +7,7 @@ use desktop_backend::{
     handle_desktop_json_rpc, load_desktop_run_explain, load_desktop_summary_snapshot,
     spawn_desktop_summary_refresh_stream, DesktopExplainPayload, DesktopJsonRpcRequest,
     DesktopJsonRpcResponse, DesktopStreamCommand, DesktopSummaryRefreshSignal,
-    DesktopSummarySnapshot, PwshScriptTransport,
+    DesktopSummarySnapshot, DesktopVoiceCaptureStatus, PwshScriptTransport,
 };
 use portable_pty::{native_pty_system, CommandBuilder, PtySize};
 use pty_backend::{
@@ -17,7 +17,19 @@ use std::collections::HashMap;
 use std::io::{Read, Write};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 use tauri::{AppHandle, Emitter, Manager};
+
+#[cfg(windows)]
+use windows_sys::Win32::Media::Audio::{
+    waveInAddBuffer, waveInClose, waveInOpen, waveInPrepareHeader, waveInReset, waveInStart,
+    waveInStop, waveInUnprepareHeader, CALLBACK_NULL, WAVEFORMATEX, WAVEHDR, WAVE_FORMAT_PCM,
+    WAVE_MAPPER, WHDR_DONE,
+};
+#[cfg(windows)]
+use windows_sys::Win32::Media::{
+    MMSYSERR_ALLOCATED, MMSYSERR_BADDEVICEID, MMSYSERR_NODRIVER, MMSYSERR_NOERROR,
+};
 
 const DESKTOP_SUMMARY_REFRESH_EVENT: &str = "desktop-summary-refresh";
 const PTY_CAPTURE_LIMIT: usize = 64 * 1024;
@@ -41,6 +53,42 @@ struct PtyManager {
 struct DesktopSummaryStreamManager {
     started: AtomicBool,
     stop_requested: Arc<AtomicBool>,
+}
+
+struct VoiceCaptureSession {
+    generation: u64,
+    stop_requested: Arc<AtomicBool>,
+}
+
+#[derive(Clone, Debug)]
+struct VoiceCaptureRuntimeSnapshot {
+    generation: u64,
+    state: String,
+    permission: String,
+    reason: String,
+    meter_level: f64,
+    running: bool,
+    native_available: bool,
+}
+
+impl Default for VoiceCaptureRuntimeSnapshot {
+    fn default() -> Self {
+        Self {
+            generation: 0,
+            state: "stopped".to_string(),
+            permission: "unknown".to_string(),
+            reason: "Native microphone capture is ready.".to_string(),
+            meter_level: 0.0,
+            running: false,
+            native_available: false,
+        }
+    }
+}
+
+struct VoiceCaptureManager {
+    snapshot: Arc<Mutex<VoiceCaptureRuntimeSnapshot>>,
+    session: Mutex<Option<VoiceCaptureSession>>,
+    next_generation: AtomicU64,
 }
 
 struct TauriPtyTransport {
@@ -67,6 +115,374 @@ fn start_desktop_summary_refresh_streams(app: &AppHandle) {
     ) {
         eprintln!("Failed to start desktop summary stream adapter: {}", err);
     }
+}
+
+fn update_voice_capture_snapshot(
+    snapshot: &Arc<Mutex<VoiceCaptureRuntimeSnapshot>>,
+    generation: u64,
+    update: impl FnOnce(&mut VoiceCaptureRuntimeSnapshot),
+) {
+    if let Ok(mut current) = snapshot.lock() {
+        if current.generation == generation {
+            update(&mut current);
+        }
+    }
+}
+
+fn desktop_voice_capture_status_from_snapshot(
+    snapshot: VoiceCaptureRuntimeSnapshot,
+) -> DesktopVoiceCaptureStatus {
+    let mut status = load_desktop_summary_voice_capture_status();
+    if status.native.device_count > 0 && snapshot.generation == 0 {
+        status.capture_mode = "native".to_string();
+        status.native.available = true;
+        status.native.state = "stopped".to_string();
+        status.native.permission = "unknown".to_string();
+        status.native.meter_supported = true;
+        status.native.meter_level = 0.0;
+        status.native.restart_supported = true;
+        status.native.reason = "Native microphone capture is ready.".to_string();
+        status.browser_fallback.expected = false;
+        status.browser_fallback.reason =
+            "Native microphone capture is available in the desktop runtime.".to_string();
+        return status;
+    }
+
+    if snapshot.generation == 0 || status.native.device_count == 0 {
+        return status;
+    }
+
+    status.capture_mode = if snapshot.native_available {
+        "native".to_string()
+    } else {
+        "unavailable".to_string()
+    };
+    status.native.available = snapshot.native_available;
+    status.native.state = snapshot.state;
+    status.native.permission = snapshot.permission;
+    status.native.meter_supported = true;
+    status.native.meter_level = snapshot.meter_level.clamp(0.0, 1.0);
+    status.native.restart_supported = true;
+    status.native.reason = snapshot.reason;
+    status.browser_fallback.expected = !snapshot.native_available;
+    status.browser_fallback.reason = if snapshot.native_available {
+        "Native microphone capture is running in the desktop runtime.".to_string()
+    } else {
+        "Use browser speech recognition until the native capture backend is available.".to_string()
+    };
+    status
+}
+
+fn load_desktop_summary_voice_capture_status() -> DesktopVoiceCaptureStatus {
+    desktop_backend::load_desktop_voice_capture_status()
+}
+
+fn get_voice_capture_status(app: &AppHandle) -> DesktopVoiceCaptureStatus {
+    let manager = app.state::<VoiceCaptureManager>();
+    let snapshot = manager
+        .snapshot
+        .lock()
+        .map(|value| value.clone())
+        .unwrap_or_default();
+    desktop_voice_capture_status_from_snapshot(snapshot)
+}
+
+#[tauri::command]
+async fn desktop_voice_capture_status(app: AppHandle) -> Result<DesktopVoiceCaptureStatus, String> {
+    Ok(get_voice_capture_status(&app))
+}
+
+#[tauri::command]
+async fn desktop_voice_capture_start(app: AppHandle) -> Result<DesktopVoiceCaptureStatus, String> {
+    let manager = app.state::<VoiceCaptureManager>();
+    let generation = manager.next_generation.fetch_add(1, Ordering::SeqCst);
+    let stop_requested = Arc::new(AtomicBool::new(false));
+    {
+        let mut session = manager.session.lock().map_err(|e| e.to_string())?;
+        if let Some(existing) = session.take() {
+            existing.stop_requested.store(true, Ordering::SeqCst);
+        }
+        *session = Some(VoiceCaptureSession {
+            generation,
+            stop_requested: stop_requested.clone(),
+        });
+    }
+    {
+        let mut snapshot = manager.snapshot.lock().map_err(|e| e.to_string())?;
+        *snapshot = VoiceCaptureRuntimeSnapshot {
+            generation,
+            state: "restarting".to_string(),
+            permission: "unknown".to_string(),
+            reason: "Starting native microphone capture.".to_string(),
+            meter_level: 0.0,
+            running: true,
+            native_available: true,
+        };
+    }
+
+    let snapshot = manager.snapshot.clone();
+    std::thread::spawn(move || {
+        run_voice_capture_worker(snapshot, generation, stop_requested);
+    });
+
+    Ok(get_voice_capture_status(&app))
+}
+
+#[tauri::command]
+async fn desktop_voice_capture_stop(
+    app: AppHandle,
+    cancelled: Option<bool>,
+) -> Result<DesktopVoiceCaptureStatus, String> {
+    let manager = app.state::<VoiceCaptureManager>();
+    let generation = {
+        let mut session = manager.session.lock().map_err(|e| e.to_string())?;
+        match session.take() {
+            Some(existing) => {
+                existing.stop_requested.store(true, Ordering::SeqCst);
+                existing.generation
+            }
+            None => 0,
+        }
+    };
+
+    let state = if cancelled.unwrap_or(false) {
+        "cancelled"
+    } else {
+        "stopped"
+    };
+    if generation > 0 {
+        update_voice_capture_snapshot(&manager.snapshot, generation, |snapshot| {
+            snapshot.state = state.to_string();
+            snapshot.reason = if state == "cancelled" {
+                "Native microphone capture was cancelled by the user.".to_string()
+            } else {
+                "Native microphone capture stopped.".to_string()
+            };
+            snapshot.running = false;
+            snapshot.meter_level = 0.0;
+        });
+    }
+
+    Ok(get_voice_capture_status(&app))
+}
+
+fn run_voice_capture_worker(
+    snapshot: Arc<Mutex<VoiceCaptureRuntimeSnapshot>>,
+    generation: u64,
+    stop_requested: Arc<AtomicBool>,
+) {
+    #[cfg(windows)]
+    run_windows_voice_capture_worker(snapshot, generation, stop_requested);
+
+    #[cfg(not(windows))]
+    {
+        update_voice_capture_snapshot(&snapshot, generation, |current| {
+            current.state = "unavailable".to_string();
+            current.permission = "unknown".to_string();
+            current.reason =
+                "Native microphone capture is only implemented on Windows.".to_string();
+            current.running = false;
+            current.native_available = false;
+            current.meter_level = 0.0;
+        });
+    }
+}
+
+#[cfg(windows)]
+fn run_windows_voice_capture_worker(
+    snapshot: Arc<Mutex<VoiceCaptureRuntimeSnapshot>>,
+    generation: u64,
+    stop_requested: Arc<AtomicBool>,
+) {
+    const SAMPLE_RATE: u32 = 16_000;
+    const CHANNELS: u16 = 1;
+    const BITS_PER_SAMPLE: u16 = 16;
+    const BUFFER_BYTES: usize = (SAMPLE_RATE as usize * 2) / 10;
+    const BUFFER_COUNT: usize = 4;
+
+    let format = WAVEFORMATEX {
+        wFormatTag: WAVE_FORMAT_PCM as u16,
+        nChannels: CHANNELS,
+        nSamplesPerSec: SAMPLE_RATE,
+        nAvgBytesPerSec: SAMPLE_RATE * CHANNELS as u32 * (BITS_PER_SAMPLE as u32 / 8),
+        nBlockAlign: CHANNELS * (BITS_PER_SAMPLE / 8),
+        wBitsPerSample: BITS_PER_SAMPLE,
+        cbSize: 0,
+    };
+    let mut handle = std::ptr::null_mut();
+    let open_result = unsafe { waveInOpen(&mut handle, WAVE_MAPPER, &format, 0, 0, CALLBACK_NULL) };
+    if open_result != MMSYSERR_NOERROR {
+        let (state, permission, native_available, reason) = map_wave_open_error(open_result);
+        update_voice_capture_snapshot(&snapshot, generation, |current| {
+            current.state = state;
+            current.permission = permission;
+            current.reason = reason;
+            current.running = false;
+            current.native_available = native_available;
+            current.meter_level = 0.0;
+        });
+        return;
+    }
+
+    update_voice_capture_snapshot(&snapshot, generation, |current| {
+        current.state = "recording".to_string();
+        current.permission = "granted".to_string();
+        current.reason = "Native microphone capture is recording.".to_string();
+        current.running = true;
+        current.native_available = true;
+        current.meter_level = 0.0;
+    });
+
+    let mut buffers = (0..BUFFER_COUNT)
+        .map(|_| vec![0u8; BUFFER_BYTES])
+        .collect::<Vec<_>>();
+    let mut headers = buffers
+        .iter_mut()
+        .map(|buffer| WAVEHDR {
+            lpData: buffer.as_mut_ptr(),
+            dwBufferLength: buffer.len() as u32,
+            dwBytesRecorded: 0,
+            dwUser: 0,
+            dwFlags: 0,
+            dwLoops: 0,
+            lpNext: std::ptr::null_mut(),
+            reserved: 0,
+        })
+        .collect::<Vec<_>>();
+
+    let header_size = std::mem::size_of::<WAVEHDR>() as u32;
+    let mut queued_buffer_count = 0usize;
+    for header in headers.iter_mut() {
+        let prepare_result = unsafe { waveInPrepareHeader(handle, header, header_size) };
+        if prepare_result == MMSYSERR_NOERROR {
+            let add_result = unsafe { waveInAddBuffer(handle, header, header_size) };
+            if add_result == MMSYSERR_NOERROR {
+                queued_buffer_count += 1;
+            }
+        }
+    }
+    if queued_buffer_count == 0 {
+        update_voice_capture_snapshot(&snapshot, generation, |current| {
+            current.state = "permission_denied".to_string();
+            current.permission = "denied".to_string();
+            current.reason = "Windows could not queue a microphone capture buffer.".to_string();
+            current.running = false;
+            current.native_available = false;
+            current.meter_level = 0.0;
+        });
+        for header in headers.iter_mut() {
+            let _ = unsafe { waveInUnprepareHeader(handle, header, header_size) };
+        }
+        let _ = unsafe { waveInClose(handle) };
+        return;
+    }
+
+    let start_result = unsafe { waveInStart(handle) };
+    if start_result != MMSYSERR_NOERROR {
+        update_voice_capture_snapshot(&snapshot, generation, |current| {
+            current.state = "permission_denied".to_string();
+            current.permission = "denied".to_string();
+            current.reason = format!(
+                "Windows could not start microphone capture: MMSYSERR code {start_result}."
+            );
+            current.running = false;
+            current.native_available = false;
+            current.meter_level = 0.0;
+        });
+    } else {
+        let mut last_voice_at = Instant::now();
+        while !stop_requested.load(Ordering::SeqCst) {
+            for (index, header) in headers.iter_mut().enumerate() {
+                let flags = header.dwFlags;
+                let recorded = header.dwBytesRecorded as usize;
+                if flags & WHDR_DONE == 0 || recorded == 0 {
+                    continue;
+                }
+
+                let bytes = &buffers[index][..recorded.min(BUFFER_BYTES)];
+                let meter = calculate_pcm16_meter_level(bytes);
+                if meter > 0.03 {
+                    last_voice_at = Instant::now();
+                }
+                let silent = last_voice_at.elapsed() >= Duration::from_secs(2);
+                update_voice_capture_snapshot(&snapshot, generation, |current| {
+                    current.state = if silent {
+                        "silence".to_string()
+                    } else {
+                        "recording".to_string()
+                    };
+                    current.permission = "granted".to_string();
+                    current.reason = if silent {
+                        "Native microphone capture is running, but no speech-level input has been detected.".to_string()
+                    } else {
+                        "Native microphone capture is recording.".to_string()
+                    };
+                    current.running = true;
+                    current.native_available = true;
+                    current.meter_level = meter;
+                });
+
+                header.dwBytesRecorded = 0;
+                header.dwFlags &= !WHDR_DONE;
+                let _ = unsafe { waveInAddBuffer(handle, header, header_size) };
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+    }
+
+    let _ = unsafe { waveInStop(handle) };
+    let _ = unsafe { waveInReset(handle) };
+    for header in headers.iter_mut() {
+        let _ = unsafe { waveInUnprepareHeader(handle, header, header_size) };
+    }
+    let _ = unsafe { waveInClose(handle) };
+    update_voice_capture_snapshot(&snapshot, generation, |current| {
+        if current.running {
+            current.state = "stopped".to_string();
+            current.reason = "Native microphone capture stopped.".to_string();
+        }
+        current.running = false;
+        current.meter_level = 0.0;
+    });
+}
+
+#[cfg(windows)]
+fn map_wave_open_error(result: u32) -> (String, String, bool, String) {
+    match result {
+        MMSYSERR_BADDEVICEID | MMSYSERR_NODRIVER => (
+            "no_microphone".to_string(),
+            "unknown".to_string(),
+            false,
+            "Windows did not expose a usable microphone input device.".to_string(),
+        ),
+        MMSYSERR_ALLOCATED => (
+            "permission_denied".to_string(),
+            "denied".to_string(),
+            false,
+            "Windows reported that the microphone input device is unavailable to this app."
+                .to_string(),
+        ),
+        _ => (
+            "permission_denied".to_string(),
+            "denied".to_string(),
+            false,
+            format!("Windows could not open microphone capture: MMSYSERR code {result}."),
+        ),
+    }
+}
+
+fn calculate_pcm16_meter_level(bytes: &[u8]) -> f64 {
+    let mut sum = 0f64;
+    let mut count = 0f64;
+    for chunk in bytes.chunks_exact(2) {
+        let sample = i16::from_le_bytes([chunk[0], chunk[1]]) as f64 / i16::MAX as f64;
+        sum += sample * sample;
+        count += 1.0;
+    }
+    if count == 0.0 {
+        return 0.0;
+    }
+    (sum / count).sqrt().clamp(0.0, 1.0)
 }
 
 #[tauri::command]
@@ -514,6 +930,11 @@ pub fn run() {
             started: AtomicBool::new(false),
             stop_requested: Arc::new(AtomicBool::new(false)),
         })
+        .manage(VoiceCaptureManager {
+            snapshot: Arc::new(Mutex::new(VoiceCaptureRuntimeSnapshot::default())),
+            session: Mutex::new(None),
+            next_generation: AtomicU64::new(1),
+        })
         .setup(|app| {
             let app_handle = app.handle().clone();
             start_control_pipe_server(Arc::new(TauriPtyTransport {
@@ -526,6 +947,9 @@ pub fn run() {
             desktop_summary_snapshot,
             desktop_run_explain,
             desktop_json_rpc,
+            desktop_voice_capture_status,
+            desktop_voice_capture_start,
+            desktop_voice_capture_stop,
             pty_json_rpc,
             pty_spawn,
             pty_write,
@@ -568,5 +992,21 @@ mod tests {
         let output = limit_pty_capture_output("one\ntwo\nthree\nfour\n", Some(2));
 
         assert_eq!(output, "three\nfour");
+    }
+
+    #[test]
+    fn calculate_pcm16_meter_level_reports_silence() {
+        assert_eq!(calculate_pcm16_meter_level(&[0, 0, 0, 0]), 0.0);
+    }
+
+    #[test]
+    fn calculate_pcm16_meter_level_reports_signal_strength() {
+        let level = calculate_pcm16_meter_level(&[
+            0xff, 0x7f, // i16::MAX
+            0x01, 0x80, // i16::MIN + 1
+        ]);
+
+        assert!(level > 0.99);
+        assert!(level <= 1.0);
     }
 }

--- a/winsmux-app/src/desktopClient.ts
+++ b/winsmux-app/src/desktopClient.ts
@@ -9,6 +9,8 @@ type DesktopCommandName =
   | "desktop_run_pick_winner"
   | "desktop_runtime_roles_apply"
   | "desktop_voice_capture_status"
+  | "desktop_voice_capture_start"
+  | "desktop_voice_capture_stop"
   | "desktop_dogfood_event"
   | "desktop_editor_read"
   | "desktop_explorer_list";
@@ -72,6 +74,7 @@ export interface DesktopVoiceCaptureNativeStatus {
   device: string;
   device_count: number;
   meter_supported: boolean;
+  meter_level: number;
   restart_supported: boolean;
   reason: string;
 }
@@ -572,6 +575,9 @@ function getDesktopJsonRpcMethod(command: DesktopCommandName): DesktopJsonRpcMet
       return "desktop.runtime.roles.apply";
     case "desktop_voice_capture_status":
       return "desktop.voice.capture_status";
+    case "desktop_voice_capture_start":
+    case "desktop_voice_capture_stop":
+      throw new Error(`${command} does not use the desktop JSON-RPC transport`);
     case "desktop_dogfood_event":
       return "desktop.dogfood.event";
     case "desktop_editor_read":
@@ -628,14 +634,31 @@ export function createJsonRpcDesktopCommandTransport(
   };
 }
 
-let desktopCommandTransport: DesktopCommandTransport =
-  createJsonRpcDesktopCommandTransport();
-
 export function createTauriDesktopCommandTransport(
   invokeCommand: typeof invoke = invoke,
 ): DesktopCommandTransport {
-  return createJsonRpcDesktopCommandTransport(invokeCommand);
+  const jsonRpcTransport = createJsonRpcDesktopCommandTransport(invokeCommand);
+  return {
+    async request<TResponse>(
+      command: DesktopCommandName,
+      payload?: Record<string, unknown>,
+    ) {
+      if (command === "desktop_voice_capture_status") {
+        return await invokeCommand<TResponse>("desktop_voice_capture_status");
+      }
+      if (command === "desktop_voice_capture_start") {
+        return await invokeCommand<TResponse>("desktop_voice_capture_start");
+      }
+      if (command === "desktop_voice_capture_stop") {
+        return await invokeCommand<TResponse>("desktop_voice_capture_stop", payload);
+      }
+      return await jsonRpcTransport.request<TResponse>(command, payload);
+    },
+  };
 }
+
+let desktopCommandTransport: DesktopCommandTransport =
+  createTauriDesktopCommandTransport();
 
 export function configureDesktopCommandTransport(
   transport: DesktopCommandTransport,
@@ -750,6 +773,27 @@ export async function getDesktopVoiceCaptureStatus(projectDir?: string | null) {
     );
   } catch (error) {
     throw normalizeDesktopError("desktop_voice_capture_status", error);
+  }
+}
+
+export async function startDesktopVoiceCapture() {
+  try {
+    return await desktopCommandTransport.request<DesktopVoiceCaptureStatus>(
+      "desktop_voice_capture_start",
+    );
+  } catch (error) {
+    throw normalizeDesktopError("desktop_voice_capture_start", error);
+  }
+}
+
+export async function stopDesktopVoiceCapture(cancelled = false) {
+  try {
+    return await desktopCommandTransport.request<DesktopVoiceCaptureStatus>(
+      "desktop_voice_capture_stop",
+      { cancelled },
+    );
+  } catch (error) {
+    throw normalizeDesktopError("desktop_voice_capture_stop", error);
   }
 }
 

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -14,6 +14,8 @@ import {
   pickDesktopRunWinner,
   promoteDesktopRunTactic,
   recordDesktopDogfoodEvent,
+  startDesktopVoiceCapture,
+  stopDesktopVoiceCapture,
   subscribeToDesktopSummaryRefresh,
   type DesktopCompareRunsResult,
   type DesktopBoardPane,
@@ -492,10 +494,12 @@ let operatorOutputBuffer = "";
 let operatorOutputFlushTimer: number | null = null;
 let voiceRecognition: SpeechRecognitionLike | null = null;
 let voiceListening = false;
+let voiceInputMode: "browser" | "native" | null = null;
 let voiceTranscriptBase = "";
 let voiceCaptureStatus: DesktopVoiceCaptureStatus | null = null;
 let voiceCaptureStatusError = "";
 let voiceCaptureStatusRefreshStarted = false;
+let voiceCapturePollTimer: number | null = null;
 const detectedPreviewTargets = new Map<string, PreviewTarget>();
 const PREVIEW_FRESHNESS_WINDOW_MS = 30_000;
 const PANE_META_REFRESH_INTERVAL_MS = 30_000;
@@ -6899,6 +6903,18 @@ function isBrowserVoiceInputSupported() {
   return Boolean(getSpeechRecognitionConstructor());
 }
 
+function isNativeVoiceCaptureAvailable() {
+  return isTauri() && voiceCaptureStatus?.native.available === true;
+}
+
+function isNativeVoiceCaptureTerminalState(state: string | undefined) {
+  return state === "stopped" || state === "cancelled" || state === "permission_denied" || state === "no_microphone";
+}
+
+function getVoiceCaptureMeterPercent() {
+  return Math.round(Math.max(0, Math.min(1, voiceCaptureStatus?.native.meter_level ?? 0)) * 100);
+}
+
 function getVoiceCaptureStatusMessage() {
   if (!isTauri()) {
     return "";
@@ -6915,6 +6931,50 @@ function getVoiceCaptureStatusMessage() {
     return getLanguageText(
       "Checking native microphone status...",
       "ネイティブのマイク状態を確認中...",
+    );
+  }
+
+  if (voiceCaptureStatus.native.state === "recording") {
+    const meter = getVoiceCaptureMeterPercent();
+    return getLanguageText(
+      `Native microphone capture is recording. Meter ${meter}%.`,
+      `ネイティブのマイク入力で録音中です。メーターは ${meter}% です。`,
+    );
+  }
+
+  if (voiceCaptureStatus.native.state === "silence") {
+    const meter = getVoiceCaptureMeterPercent();
+    return getLanguageText(
+      `Native microphone capture is running, but speech is not detected. Meter ${meter}%.`,
+      `ネイティブのマイク入力は動作中ですが、発話を検出していません。メーターは ${meter}% です。`,
+    );
+  }
+
+  if (voiceCaptureStatus.native.state === "restarting") {
+    return getLanguageText(
+      "Restarting native microphone capture...",
+      "ネイティブのマイク入力を再起動しています...",
+    );
+  }
+
+  if (voiceCaptureStatus.native.state === "cancelled") {
+    return getLanguageText(
+      "Native microphone capture was cancelled.",
+      "ネイティブのマイク入力をキャンセルしました。",
+    );
+  }
+
+  if (voiceCaptureStatus.native.state === "stopped") {
+    return getLanguageText(
+      "Native microphone capture is ready.",
+      "ネイティブのマイク入力を開始できます。",
+    );
+  }
+
+  if (voiceCaptureStatus.native.state === "permission_denied") {
+    return getLanguageText(
+      "Native microphone capture could not access the microphone.",
+      "ネイティブのマイク入力がマイクにアクセスできませんでした。",
     );
   }
 
@@ -6955,6 +7015,7 @@ function renderVoiceCaptureStatus() {
   status.hidden = !message;
   status.textContent = message;
   status.dataset.state = voiceCaptureStatus?.native.state ?? (voiceCaptureStatusError ? "error" : "unknown");
+  status.style.setProperty("--voice-meter", `${getVoiceCaptureMeterPercent()}%`);
 }
 
 async function refreshVoiceCaptureStatus() {
@@ -6972,6 +7033,12 @@ async function refreshVoiceCaptureStatus() {
   }
   updateVoiceInputButton();
   renderVoiceCaptureStatus();
+  if (voiceInputMode === "native" && isNativeVoiceCaptureTerminalState(voiceCaptureStatus?.native.state)) {
+    voiceListening = false;
+    voiceInputMode = null;
+    stopVoiceCapturePolling();
+    updateVoiceInputButton();
+  }
 }
 
 function ensureVoiceCaptureStatusRefresh() {
@@ -6982,13 +7049,31 @@ function ensureVoiceCaptureStatusRefresh() {
   void refreshVoiceCaptureStatus();
 }
 
+function startVoiceCapturePolling() {
+  if (voiceCapturePollTimer !== null) {
+    return;
+  }
+  voiceCapturePollTimer = window.setInterval(() => {
+    void refreshVoiceCaptureStatus();
+  }, 250);
+}
+
+function stopVoiceCapturePolling() {
+  if (voiceCapturePollTimer === null) {
+    return;
+  }
+  window.clearInterval(voiceCapturePollTimer);
+  voiceCapturePollTimer = null;
+}
+
 function updateVoiceInputButton() {
   const button = document.getElementById("voice-input-btn") as HTMLButtonElement | null;
   if (!button) {
     return;
   }
 
-  const supported = isBrowserVoiceInputSupported();
+  const browserSupported = isBrowserVoiceInputSupported();
+  const supported = browserSupported || isNativeVoiceCaptureAvailable();
   button.disabled = !supported;
   button.classList.toggle("is-recording", voiceListening);
   button.setAttribute("aria-pressed", voiceListening ? "true" : "false");
@@ -7009,6 +7094,11 @@ function updateVoiceInputButton() {
 }
 
 function stopVoiceInput() {
+  if (voiceInputMode === "native") {
+    void stopNativeVoiceInput(true);
+    return;
+  }
+
   if (!voiceRecognition) {
     return;
   }
@@ -7019,10 +7109,49 @@ function stopVoiceInput() {
   }
 }
 
+async function startNativeVoiceInput(composerInput: HTMLTextAreaElement) {
+  try {
+    voiceCaptureStatus = await startDesktopVoiceCapture();
+    voiceCaptureStatusError = "";
+    voiceInputMode = "native";
+    voiceListening = true;
+    markComposerInputSource("voice");
+    startVoiceCapturePolling();
+    updateVoiceInputButton();
+    renderVoiceCaptureStatus();
+    composerInput.focus();
+  } catch (error) {
+    voiceCaptureStatus = null;
+    voiceCaptureStatusError = error instanceof Error ? error.message : String(error);
+    voiceInputMode = null;
+    voiceListening = false;
+    stopVoiceCapturePolling();
+    updateVoiceInputButton();
+    renderVoiceCaptureStatus();
+  }
+}
+
+async function stopNativeVoiceInput(cancelled: boolean) {
+  try {
+    voiceCaptureStatus = await stopDesktopVoiceCapture(cancelled);
+    voiceCaptureStatusError = "";
+  } catch (error) {
+    voiceCaptureStatusError = error instanceof Error ? error.message : String(error);
+  }
+  voiceInputMode = null;
+  voiceListening = false;
+  stopVoiceCapturePolling();
+  updateVoiceInputButton();
+  renderVoiceCaptureStatus();
+}
+
 function startVoiceInput(composerInput: HTMLTextAreaElement) {
   const SpeechRecognition = getSpeechRecognitionConstructor();
   if (!SpeechRecognition) {
     ensureVoiceCaptureStatusRefresh();
+    if (isNativeVoiceCaptureAvailable()) {
+      void startNativeVoiceInput(composerInput);
+    }
     updateVoiceInputButton();
     return;
   }
@@ -7038,11 +7167,13 @@ function startVoiceInput(composerInput: HTMLTextAreaElement) {
   recognition.lang = themeState.language === "ja" ? "ja-JP" : "en-US";
   recognition.onstart = () => {
     voiceListening = true;
+    voiceInputMode = "browser";
     updateVoiceInputButton();
   };
   recognition.onend = () => {
     voiceListening = false;
     voiceRecognition = null;
+    voiceInputMode = null;
     voiceTranscriptBase = "";
     updateVoiceInputButton();
     exitComposerHistoryToDraft(composerInput.value);
@@ -7050,6 +7181,7 @@ function startVoiceInput(composerInput: HTMLTextAreaElement) {
   };
   recognition.onerror = (event) => {
     voiceListening = false;
+    voiceInputMode = null;
     updateVoiceInputButton();
     if (event.error && event.error !== "no-speech" && event.error !== "aborted") {
       appendRuntimeConversation({

--- a/winsmux-app/src/styles.css
+++ b/winsmux-app/src/styles.css
@@ -1756,15 +1756,37 @@ body[data-popout-surface="1"] #editor-surface {
 }
 
 .voice-input-status {
+  position: relative;
   margin-top: 6px;
+  padding-bottom: 4px;
   color: var(--text-muted);
   font-size: var(--text-2xs);
   line-height: var(--leading-tight);
+  --voice-meter: 0%;
 }
 
 .voice-input-status[data-state="unavailable"],
 .voice-input-status[data-state="error"] {
   color: var(--status-warning);
+}
+
+.voice-input-status[data-state="recording"],
+.voice-input-status[data-state="silence"] {
+  color: var(--text-primary);
+}
+
+.voice-input-status[data-state="recording"]::after,
+.voice-input-status[data-state="silence"]::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: auto;
+  bottom: 0;
+  width: var(--voice-meter);
+  max-width: 100%;
+  height: 2px;
+  border-radius: 999px;
+  background: var(--accent-blue-hover);
 }
 
 #composer-mode-row {


### PR DESCRIPTION
## Summary
- add Tauri native voice capture status/start/stop commands backed by WinMM input capture
- report native meter_level plus recording, silence, cancelled, permission, no-microphone, restart, and stopped states
- connect the desktop voice button to native capture when browser speech recognition is unavailable and show a compact meter bar

## Validation
- cmd /c npm run build
- cmd /c node --check winsmux-app\scripts\viewport-harness.mjs
- cmd /c npm run test:viewport-harness (normal privileges after sandbox esbuild spawn EPERM)
- cargo test -p winsmux-app calculate_pcm16_meter_level
- cargo test -p winsmux-app
- git diff --check
- pwsh -NoProfile -File scripts\audit-public-surface.ps1
- pwsh -NoProfile -File scripts\git-guard.ps1

Review note: codex exec review on the uncommitted diff was not run because the approval gate rejected exporting private workspace data before PR creation. Manual diff review found no blocking issue.