### PR TITLE
Add voice vocabulary dictionary

### DIFF
--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -6886,6 +6886,8 @@ Describe 'doctor bridge config metadata check' {
         $result.Label | Should -Be 'PowerShell startup evidence'
         $result.Detail | Should -Match 'pwsh_count=3'
         $result.Detail | Should -Match 'count_state=below_threshold'
+        $result.Detail | Should -Match 'low_count_threshold=8'
+        $result.Detail | Should -Match 'startup_risk=normal'
         $result.Detail | Should -Match 'bare_pwsh=pass'
         $result.Detail | Should -Match 'codex=1'
         $result.Detail | Should -Match 'vscode=1'
@@ -6893,6 +6895,37 @@ Describe 'doctor bridge config metadata check' {
         $result.Detail | Should -Match 'command_lines=omitted'
         $result.Detail | Should -Not -Match 'secret-value'
         $result.Detail | Should -Not -Match '2201'
+    }
+
+    It 'warns for low-count PowerShell startup recurrence risk below the high process threshold' {
+        $protectedIds = [System.Collections.Generic.HashSet[int]]::new()
+        $processes = @()
+        $byId = @{}
+        for ($index = 1; $index -le 12; $index++) {
+            $process = [pscustomobject]@{
+                ProcessId       = 3000 + $index
+                ParentProcessId = 0
+                Name            = 'pwsh.exe'
+                CommandLine     = "pwsh -NoProfile -Command redacted-$index"
+            }
+            $processes += $process
+            $byId[$process.ProcessId] = $process
+        }
+        $snapshot = [pscustomobject]@{
+            Processes = $processes
+            ById = $byId
+            SupportsCommandLine = $true
+        }
+
+        $result = New-PowerShellStartupEvidenceResult -Snapshot $snapshot -ProtectedIds $protectedIds -WarnThreshold 100 -LowCountWarnThreshold 8 -SmokeStatus pass -SmokeDetail '7.5.4'
+
+        $result.Status | Should -Be 'warn'
+        $result.Label | Should -Be 'PowerShell startup evidence'
+        $result.Detail | Should -Match 'pwsh_count=12'
+        $result.Detail | Should -Match 'count_state=below_threshold'
+        $result.Detail | Should -Match 'startup_risk=low_count_risk'
+        $result.Detail | Should -Match 'command_lines=omitted'
+        $result.Detail | Should -Not -Match 'redacted-'
     }
 
     It 'warns in startup evidence when the bare PowerShell smoke check fails' {
@@ -6909,6 +6942,7 @@ Describe 'doctor bridge config metadata check' {
         $result.Label | Should -Be 'PowerShell startup evidence'
         $result.Detail | Should -Match 'pwsh_count=0'
         $result.Detail | Should -Match 'bare_pwsh=fail'
+        $result.Detail | Should -Match 'startup_risk=smoke_failed'
         $result.Detail | Should -Match '3221225794'
     }
 }

--- a/winsmux-app/scripts/viewport-harness.mjs
+++ b/winsmux-app/scripts/viewport-harness.mjs
@@ -475,6 +475,13 @@ async function selectVoiceDraftMode(page, label) {
   await page.locator(".composer-session-trigger-voice", { hasText: label }).waitFor();
 }
 
+async function selectVoiceVocabularyMode(page, label) {
+  await page.click(".composer-session-trigger-voice");
+  await page.locator("#composer-voice-menu", { hasText: "Vocabulary" }).waitFor({ state: "visible" });
+  await page.locator("#composer-voice-menu .composer-session-option", { hasText: label }).click();
+  await page.locator(".composer-session-trigger-voice", { hasText: label }).waitFor();
+}
+
 async function assertDesktopVoiceDraftShaping(page) {
   const composer = page.locator("#composer-input");
   await page.locator(".composer-session-trigger-voice", { hasText: "Raw" }).waitFor();
@@ -534,6 +541,44 @@ async function assertDesktopVoiceDraftShaping(page) {
     const button = document.querySelector("#voice-input-btn");
     return button instanceof HTMLButtonElement && button.getAttribute("aria-pressed") === "false";
   });
+}
+
+async function assertDesktopVoiceVocabularyDictionary(page) {
+  const composer = page.locator("#composer-input");
+  await page.locator(".composer-session-trigger-voice", { hasText: "Project terms" }).waitFor();
+  await selectVoiceDraftMode(page, "Raw");
+  await selectVoiceVocabularyMode(page, "Project terms");
+  await composer.fill("");
+  await startBrowserVoiceInput(page);
+  await page.evaluate(() => window.__winsmuxSpeechRecognition.emitResult("wins mux task four two four read me dot md main dot ts"));
+  await page.waitForFunction(() => {
+    const input = document.querySelector("#composer-input");
+    const preferences = JSON.parse(window.localStorage.getItem("winsmux.composer-session.v1") ?? "{}");
+    return input instanceof HTMLTextAreaElement &&
+      input.value === "winsmux TASK-424 README.md main.ts" &&
+      preferences.voiceVocabularyMode === "project";
+  });
+  await stopBrowserVoiceInput(page);
+
+  await page.evaluate(() => {
+    window.localStorage.setItem(
+      "winsmux.voice-vocabulary.v1",
+      JSON.stringify([{ spoken: "internal memo", replacement: "internal-note.md" }]),
+    );
+  });
+  await selectVoiceVocabularyMode(page, "Project + custom");
+  await composer.fill("");
+  await startBrowserVoiceInput(page);
+  await page.evaluate(() => window.__winsmuxSpeechRecognition.emitResult("internal memo wins mux"));
+  await page.waitForFunction(() => {
+    const input = document.querySelector("#composer-input");
+    const preferences = JSON.parse(window.localStorage.getItem("winsmux.composer-session.v1") ?? "{}");
+    return input instanceof HTMLTextAreaElement &&
+      input.value === "internal-note.md winsmux" &&
+      preferences.voiceVocabularyMode === "project_custom";
+  });
+  await stopBrowserVoiceInput(page);
+  await selectVoiceVocabularyMode(page, "Project terms");
 }
 
 async function startBrowserVoiceInput(page) {
@@ -1371,6 +1416,10 @@ async function verifyDesktopViewport(page, previewUrl) {
     await assertDesktopVoiceDraftShaping(page);
   });
 
+  await runStep("desktop voice vocabulary dictionary", async () => {
+    await assertDesktopVoiceVocabularyDictionary(page);
+  });
+
   await runStep("desktop slash-aware voice draft", async () => {
     await assertDesktopSlashAwareVoiceDraft(page);
   });
@@ -1641,6 +1690,7 @@ async function run() {
             "desktop-1440x900",
             "desktop-voice-input-a11y",
             "desktop-voice-draft-shaping",
+            "desktop-voice-vocabulary-dictionary",
             "desktop-slash-aware-voice-draft",
             "desktop-composer-autosize",
             "desktop-command-bar",

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -299,6 +299,7 @@ type ComposerPermissionMode = "auto" | "default" | "acceptEdits" | "plan";
 type ComposerEffortLevel = "auto" | "low" | "medium" | "high" | "xhigh" | "max";
 type ComposerModelId = "opus-4.7" | "opus-4.7-1m" | "opus-4.6" | "sonnet-4.6" | "haiku-4.5";
 type VoiceDraftMode = "raw" | "cleaned" | "operator_request";
+type VoiceVocabularyMode = "off" | "project" | "project_custom";
 
 interface ThemeState {
   theme: ThemeMode;
@@ -363,6 +364,7 @@ interface ComposerSessionControlState {
   model: ComposerModelId;
   effort: ComposerEffortLevel;
   voiceDraftMode: VoiceDraftMode;
+  voiceVocabularyMode: VoiceVocabularyMode;
   fastModeEnabled: boolean;
   fastModeTogglePending: boolean;
 }
@@ -499,6 +501,7 @@ let voiceRecognition: SpeechRecognitionLike | null = null;
 let voiceListening = false;
 let voiceInputMode: "browser" | "native" | null = null;
 let voiceTranscriptBase = "";
+let activeVoiceVocabularyMode: VoiceVocabularyMode = "project";
 let voiceCaptureStatus: DesktopVoiceCaptureStatus | null = null;
 let voiceCaptureStatusError = "";
 let voiceCaptureStatusRefreshStarted = false;
@@ -580,6 +583,7 @@ let preferredWideContextOpen = false;
 const SHELL_PREFERENCES_STORAGE_KEY = "winsmux.shell.preferences.v1";
 const RUNTIME_ROLE_PREFERENCES_STORAGE_KEY = "winsmux.runtime-role.preferences.v1";
 const COMPOSER_SESSION_STORAGE_KEY = "winsmux.composer-session.v1";
+const VOICE_VOCABULARY_STORAGE_NAME = "winsmux.voice-vocabulary.v1";
 const POPOUT_SURFACE_STORAGE_KEY_PREFIX = "winsmux.popout-surface.";
 const PROJECT_SESSIONS_STORAGE_KEY = "winsmux.project-sessions.v1";
 const ACTIVE_PROJECT_STORAGE_KEY = "winsmux.active-project.v1";
@@ -960,6 +964,31 @@ const voiceDraftModeOptions: Array<{ value: VoiceDraftMode; label: string; label
   { value: "operator_request", label: "Operator request", labelJa: "依頼文", description: "Shape spoken intent into an editable operator request.", descriptionJa: "話した意図を編集可能な依頼文として整えます。" },
 ];
 
+const voiceVocabularyModeOptions: Array<{ value: VoiceVocabularyMode; label: string; labelJa: string; description: string; descriptionJa: string }> = [
+  { value: "off", label: "Vocabulary off", labelJa: "語彙なし", description: "Use speech recognition text exactly as received.", descriptionJa: "音声認識の結果をそのまま使います。" },
+  { value: "project", label: "Project terms", labelJa: "プロジェクト語彙", description: "Correct common project terms before shaping the draft.", descriptionJa: "下書きを整える前に、よく使うプロジェクト語彙へ直します。" },
+  { value: "project_custom", label: "Project + custom", labelJa: "語彙と追加辞書", description: "Also apply local custom readings stored on this device.", descriptionJa: "この端末に保存した追加の読みも使います。" },
+];
+
+const projectVoiceVocabularyEntries = [
+  { spoken: "wins mux", replacement: "winsmux" },
+  { spoken: "win smux", replacement: "winsmux" },
+  { spoken: "ウィンズ マックス", replacement: "winsmux" },
+  { spoken: "ウィンズマックス", replacement: "winsmux" },
+  { spoken: "task four two four", replacement: "TASK-424" },
+  { spoken: "task four twenty four", replacement: "TASK-424" },
+  { spoken: "task 424", replacement: "TASK-424" },
+  { spoken: "タスク 四 二 四", replacement: "TASK-424" },
+  { spoken: "タスク よん に よん", replacement: "TASK-424" },
+  { spoken: "read me dot md", replacement: "README.md" },
+  { spoken: "readme dot md", replacement: "README.md" },
+  { spoken: "road map dot md", replacement: "ROADMAP.md" },
+  { spoken: "main dot ts", replacement: "main.ts" },
+  { spoken: "viewport harness", replacement: "viewport-harness.mjs" },
+  { spoken: "slash review", replacement: "slash review" },
+  { spoken: "slash dispatch", replacement: "slash dispatch" },
+];
+
 const runtimeRoleOptions: Array<{ value: RuntimeRoleId; label: string; labelJa: string; description: string; descriptionJa: string }> = [
   { value: "operator", label: "Operator", labelJa: "オペレーター", description: "Owns approvals and session control.", descriptionJa: "承認とセッション制御を担当します。" },
   { value: "worker", label: "Worker", labelJa: "ワーカー", description: "Handles implementation and verification work.", descriptionJa: "実装と検証を担当します。" },
@@ -1013,6 +1042,7 @@ runtimeRolePreferences = readStoredRuntimeRolePreferences();
   activeComposerModel = storedComposerControls.model;
   activeComposerEffort = storedComposerControls.effort;
   activeVoiceDraftMode = storedComposerControls.voiceDraftMode;
+  activeVoiceVocabularyMode = storedComposerControls.voiceVocabularyMode;
   activeComposerFastModeEnabled = storedComposerControls.fastModeEnabled;
   activeComposerFastModeTogglePending = storedComposerControls.fastModeTogglePending;
 }
@@ -5709,6 +5739,7 @@ function defaultComposerSessionControls(): ComposerSessionControlState {
     model: "opus-4.7-1m",
     effort: "xhigh",
     voiceDraftMode: "raw",
+    voiceVocabularyMode: "project",
     fastModeEnabled: false,
     fastModeTogglePending: false,
   };
@@ -5732,6 +5763,7 @@ function normalizeComposerSessionControls(value: Partial<ComposerSessionControlS
     model,
     effort: composerEffortOptions.find((item) => item.value === value?.effort)?.value ?? fallback.effort,
     voiceDraftMode: voiceDraftModeOptions.find((item) => item.value === value?.voiceDraftMode)?.value ?? fallback.voiceDraftMode,
+    voiceVocabularyMode: voiceVocabularyModeOptions.find((item) => item.value === value?.voiceVocabularyMode)?.value ?? fallback.voiceVocabularyMode,
     fastModeEnabled,
     fastModeTogglePending,
   };
@@ -5766,6 +5798,7 @@ function persistComposerSessionControls() {
         model: activeComposerModel,
         effort: activeComposerEffort,
         voiceDraftMode: activeVoiceDraftMode,
+        voiceVocabularyMode: activeVoiceVocabularyMode,
         fastModeEnabled: activeComposerFastModeEnabled,
         fastModeTogglePending: activeComposerFastModeTogglePending,
       }),
@@ -7170,6 +7203,63 @@ function normalizeVoiceDraftWhitespace(value: string) {
     .trim();
 }
 
+function isVoiceVocabularyModeEnabled() {
+  return activeVoiceVocabularyMode === "project" || activeVoiceVocabularyMode === "project_custom";
+}
+
+function readStoredCustomVoiceVocabularyEntries() {
+  try {
+    const rawValue = window.localStorage.getItem(VOICE_VOCABULARY_STORAGE_NAME);
+    if (!rawValue) {
+      return [];
+    }
+    const parsed = JSON.parse(rawValue);
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+    return parsed
+      .map((entry) => ({
+        spoken: typeof entry?.spoken === "string" ? normalizeVoiceDraftWhitespace(entry.spoken).slice(0, 80) : "",
+        replacement: typeof entry?.replacement === "string" ? normalizeVoiceDraftWhitespace(entry.replacement).slice(0, 120) : "",
+      }))
+      .filter((entry) => entry.spoken.length >= 2 && entry.replacement.length >= 1)
+      .slice(0, 40);
+  } catch {
+    return [];
+  }
+}
+
+function getVoiceVocabularyEntries() {
+  if (!isVoiceVocabularyModeEnabled()) {
+    return [];
+  }
+  const entries = [...projectVoiceVocabularyEntries];
+  if (activeVoiceVocabularyMode === "project_custom") {
+    entries.push(...readStoredCustomVoiceVocabularyEntries());
+  }
+  return entries;
+}
+
+function replaceVoiceVocabularyPhrase(value: string, spoken: string, replacement: string) {
+  const phrase = normalizeVoiceDraftWhitespace(spoken);
+  if (!phrase) {
+    return value;
+  }
+  const pattern = phrase
+    .split(" ")
+    .map((part) => escapeRegExp(part))
+    .join("\\s+");
+  return value.replace(new RegExp(`(^|[\\s、。,.!?])${pattern}(?=$|[\\s、。,.!?])`, "gi"), `$1${replacement}`);
+}
+
+function applyVoiceVocabulary(transcript: string) {
+  let nextTranscript = transcript;
+  for (const entry of getVoiceVocabularyEntries()) {
+    nextTranscript = replaceVoiceVocabularyPhrase(nextTranscript, entry.spoken, entry.replacement);
+  }
+  return normalizeVoiceDraftWhitespace(nextTranscript);
+}
+
 function removeVoiceFillers(value: string) {
   let text = value;
   for (const filler of ["えー", "えっと", "あの", "あのー", "その", "そのー", "まあ", "なんか"]) {
@@ -7275,20 +7365,21 @@ function shapeVoiceTranscript(transcript: string) {
 function shapeVoiceComposerDraft(base: string, transcript: string) {
   const trimmedBase = base.trim();
   const slashBaseCommand = getVoiceSlashBaseCommand(base);
+  const vocabularyTranscript = applyVoiceVocabulary(transcript);
   if (slashBaseCommand) {
-    const shapedTranscript = shapeVoiceTranscript(transcript);
+    const shapedTranscript = shapeVoiceTranscript(vocabularyTranscript);
     const separator = shapedTranscript ? " " : "";
     return `${base.trimEnd()}${separator}${shapedTranscript}`.trimStart();
   }
 
   if (!trimmedBase || /^\/[^\s]*$/.test(trimmedBase)) {
-    const slashDraft = parseVoiceSlashCommand(transcript);
+    const slashDraft = parseVoiceSlashCommand(vocabularyTranscript);
     if (slashDraft) {
       return `/${slashDraft.command}${slashDraft.body ? ` ${slashDraft.body}` : ""}`;
     }
   }
 
-  const shapedTranscript = shapeVoiceTranscript(transcript);
+  const shapedTranscript = shapeVoiceTranscript(vocabularyTranscript);
   const separator = base && shapedTranscript ? " " : "";
   return `${base}${separator}${shapedTranscript}`.trimStart();
 }
@@ -7705,6 +7796,10 @@ function getVoiceDraftModeOption(mode: VoiceDraftMode = activeVoiceDraftMode) {
   return voiceDraftModeOptions.find((item) => item.value === mode) ?? voiceDraftModeOptions[0];
 }
 
+function getVoiceVocabularyModeOption(mode: VoiceVocabularyMode = activeVoiceVocabularyMode) {
+  return voiceVocabularyModeOptions.find((item) => item.value === mode) ?? voiceVocabularyModeOptions[1];
+}
+
 function setComposerPermissionMode(mode: ComposerPermissionMode) {
   activeComposerPermissionMode = mode;
   persistComposerSessionControls();
@@ -7740,6 +7835,13 @@ function setComposerFastMode(enabled: boolean) {
 
 function setVoiceDraftMode(mode: VoiceDraftMode) {
   activeVoiceDraftMode = mode;
+  persistComposerSessionControls();
+  openComposerSessionMenu = null;
+  renderComposerSessionControls();
+}
+
+function setVoiceVocabularyMode(mode: VoiceVocabularyMode) {
+  activeVoiceVocabularyMode = mode;
   persistComposerSessionControls();
   openComposerSessionMenu = null;
   renderComposerSessionControls();
@@ -7857,7 +7959,11 @@ function createComposerPermissionMenu() {
 
 function createComposerVoiceDraftMenu() {
   const selected = getVoiceDraftModeOption();
-  const group = createComposerSessionControl("voice", themeState.language === "ja" ? selected.labelJa : selected.label);
+  const vocabulary = getVoiceVocabularyModeOption();
+  const selectedLabel = themeState.language === "ja"
+    ? `${selected.labelJa}・${vocabulary.labelJa}`
+    : `${selected.label} · ${vocabulary.label}`;
+  const group = createComposerSessionControl("voice", selectedLabel);
   if (openComposerSessionMenu !== "voice") {
     return group;
   }
@@ -7866,6 +7972,11 @@ function createComposerVoiceDraftMenu() {
   appendComposerMenuHeading(menu, themeState.language === "ja" ? "音声下書き" : "Voice draft");
   for (const option of voiceDraftModeOptions) {
     appendComposerOptionButton(menu, option, activeVoiceDraftMode, setVoiceDraftMode);
+  }
+  appendComposerMenuSeparator(menu);
+  appendComposerMenuHeading(menu, themeState.language === "ja" ? "語彙辞書" : "Vocabulary");
+  for (const option of voiceVocabularyModeOptions) {
+    appendComposerOptionButton(menu, option, activeVoiceVocabularyMode, setVoiceVocabularyMode);
   }
   group.appendChild(menu);
   return group;

--- a/winsmux-core/scripts/doctor.ps1
+++ b/winsmux-core/scripts/doctor.ps1
@@ -472,6 +472,25 @@ function Get-DoctorPowerShellProcessWarnThreshold {
     return $threshold
 }
 
+function Get-DoctorPowerShellStartupLowCountWarnThreshold {
+    $threshold = 8
+    $rawValue = [string]$env:WINSMUX_DOCTOR_POWERSHELL_STARTUP_LOW_COUNT_WARN_THRESHOLD
+    if ([string]::IsNullOrWhiteSpace($rawValue)) {
+        return $threshold
+    }
+
+    try {
+        $parsed = [int]$rawValue
+        if ($parsed -gt 0) {
+            return $parsed
+        }
+    } catch {
+        return $threshold
+    }
+
+    return $threshold
+}
+
 function New-PowerShellProcessPressureResult {
     param(
         [Parameter(Mandatory = $true)]$Snapshot,
@@ -541,6 +560,7 @@ function New-PowerShellStartupEvidenceResult {
         [Parameter(Mandatory = $true)]$Snapshot,
         [Parameter(Mandatory = $true)]$ProtectedIds,
         [Parameter(Mandatory = $true)][int]$WarnThreshold,
+        [int]$LowCountWarnThreshold = 8,
         [Parameter(Mandatory = $true)][ValidateSet('pass', 'fail')][string]$SmokeStatus,
         [Parameter(Mandatory = $true)][string]$SmokeDetail
     )
@@ -572,8 +592,16 @@ function New-PowerShellStartupEvidenceResult {
     }
 
     $countState = if ($count -ge $WarnThreshold) { 'at_or_above_threshold' } else { 'below_threshold' }
-    $status = if ($SmokeStatus -eq 'fail') { 'warn' } else { 'pass' }
-    $detail = "pwsh_count=$count; count_state=$countState; parent_categories=$categoryText; bare_pwsh=$SmokeStatus; smoke_detail=$SmokeDetail; scoped_cleanup=close related VS Code, Windows Terminal, or Codex shells first; command_lines=omitted"
+    $startupRisk = 'normal'
+    if ($SmokeStatus -eq 'fail') {
+        $startupRisk = 'smoke_failed'
+    } elseif ($count -ge $WarnThreshold) {
+        $startupRisk = 'high_count'
+    } elseif ($count -ge $LowCountWarnThreshold) {
+        $startupRisk = 'low_count_risk'
+    }
+    $status = if ($startupRisk -eq 'normal') { 'pass' } else { 'warn' }
+    $detail = "pwsh_count=$count; count_state=$countState; low_count_threshold=$LowCountWarnThreshold; startup_risk=$startupRisk; parent_categories=$categoryText; bare_pwsh=$SmokeStatus; smoke_detail=$SmokeDetail; scoped_cleanup=close related VS Code, Windows Terminal, or Codex shells first; command_lines=omitted"
 
     return New-DoctorResult -Status $status -Label 'PowerShell startup evidence' -Detail $detail
 }
@@ -646,9 +674,10 @@ function Test-PowerShellStartupEvidenceCheck {
     $snapshot = Get-DoctorProcessSnapshot
     $protectedIds = @(Get-DoctorAncestorProcessIds -Snapshot $snapshot -ProcessId $PID)
     $warnThreshold = Get-DoctorPowerShellProcessWarnThreshold
+    $lowCountWarnThreshold = Get-DoctorPowerShellStartupLowCountWarnThreshold
     $smoke = Invoke-DoctorPowerShellStartupSmoke
 
-    return New-PowerShellStartupEvidenceResult -Snapshot $snapshot -ProtectedIds $protectedIds -WarnThreshold $warnThreshold -SmokeStatus $smoke.Status -SmokeDetail $smoke.Detail
+    return New-PowerShellStartupEvidenceResult -Snapshot $snapshot -ProtectedIds $protectedIds -WarnThreshold $warnThreshold -LowCountWarnThreshold $lowCountWarnThreshold -SmokeStatus $smoke.Status -SmokeDetail $smoke.Detail
 }
 
 function Invoke-DoctorOrchestraSmokeJson {


### PR DESCRIPTION
## Summary

- Add project vocabulary modes for desktop voice input: off, project terms, and project plus local custom readings.
- Apply vocabulary corrections before voice draft cleanup and slash-command shaping so task IDs, file names, and product terms land correctly in the composer.
- Extend doctor startup evidence so low-count pwsh.exe recurrence risk is reported before the old high process-count threshold.

Closes #820

## Validation

- cmd /c npm run build
- cmd /c npm run test:viewport-harness
- Invoke-Pester -Path tests\winsmux-bridge.Tests.ps1 -FullName '*PowerShell startup evidence*' -Output Detailed
- Invoke-Pester -Path tests\winsmux-bridge.Tests.ps1 -FullName '*startup recurrence*' -Output Detailed
- Invoke-Pester -Path tests\winsmux-bridge.Tests.ps1 -FullName '*bare PowerShell smoke*' -Output Detailed
- git diff --check
- pwsh -NoProfile -File scripts\audit-public-surface.ps1
- pwsh -NoProfile -File scripts\git-guard.ps1 -Mode full
- gitleaks detect --source . --log-opts 00b3df4d6a6cfe77864bd6412b9ba336303c5518..HEAD --redact --exit-code 1 --verbose

## Notes

- Local doctor now warns for pwsh_count=10 with startup_risk=low_count_risk.
- Local doctor still reports stale missing manifest PIDs for supervisor_pid and visible_attach_host; those are dead references, not live processes.