### PR TITLE
Fix AppState-owned pane cleanup

### DIFF
--- a/core/src/types.rs
+++ b/core/src/types.rs
@@ -763,6 +763,20 @@ impl AppState {
     }
 }
 
+impl Drop for AppState {
+    fn drop(&mut self) {
+        crate::tree::kill_all_children_batch(&mut self.windows);
+        if let Some(warm_pane) = self.warm_pane.as_mut() {
+            crate::platform::process_kill::kill_process_tree(&mut warm_pane.child);
+        }
+        for pipe in self.pipe_panes.iter_mut() {
+            if let Some(process) = pipe.process.as_mut() {
+                let _ = process.kill();
+            }
+        }
+    }
+}
+
 pub struct DragState {
     pub split_path: Vec<usize>,
     pub kind: LayoutKind,


### PR DESCRIPTION
## Summary

- Add AppState drop cleanup for owned pane children, warm-pane children, and pipe-pane child processes.
- Prevent direct Rust tests that create panes without running the full server loop from leaving cmd /c pause shells behind.
- Keep issue #820 open because broader stale worker ownership cleanup may still be needed outside this direct test path.

## Validation

- cargo test --manifest-path core\Cargo.toml focus_pane_by_id_returns_false_and_preserves_focus_when_target_is_missing -- --nocapture
- cargo test --manifest-path core\Cargo.toml
- git diff --check
- pwsh -NoProfile -File scripts\audit-public-surface.ps1
- pwsh -NoProfile -File scripts\git-guard.ps1 -Mode full

## Notes

- The observed cmd /c pause count stayed at 6 before and after the targeted test and the full core test.
- cargo fmt --manifest-path core\Cargo.toml --check still reports pre-existing formatting differences in untouched core/tests-rs files.
