### PR TITLE
Fix stale winsmux pane shell detection

### DIFF
--- a/tests/OrchestraPreflight.Tests.ps1
+++ b/tests/OrchestraPreflight.Tests.ps1
@@ -77,6 +77,33 @@ Describe 'orchestra preflight zombie detection' {
         @($victims).Count | Should -Be 0
     }
 
+    It 'detects parentless winsmux-generated pwsh pane shells without worktree paths' {
+        $snapshot = & $script:NewPreflightSnapshot -Processes @(
+            [PSCustomObject]@{
+                ProcessId       = 351
+                ParentProcessId = 0
+                Name            = 'pwsh.exe'
+                CommandLine     = 'pwsh -NoLogo -NoProfile -NoExit -Command "if (-not (Test-Path variable:Global:__psmux_cwd_hook)) { $Global:__psmux_cwd_hook = $true }"'
+            }
+            [PSCustomObject]@{
+                ProcessId       = 352
+                ParentProcessId = 0
+                Name            = 'pwsh.exe'
+                CommandLine     = 'pwsh -noexit -command "try { . C:\Users\test\AppData\Local\Programs\Microsoft VS Code\shellIntegration.ps1 } catch {}"'
+            }
+        )
+
+        $victims = Get-OrchestraZombieVictims `
+            -Snapshot $snapshot `
+            -ProtectedIds ([System.Collections.Generic.HashSet[int]]::new()) `
+            -ProjectDir 'C:\repo' `
+            -GitWorktreeDir 'C:\repo\.git' `
+            -BridgeScript 'C:\repo\scripts\winsmux-core.ps1' `
+            -SessionName 'winsmux-orchestra'
+
+        @($victims | ForEach-Object { [int]$_.ProcessId }) | Should -Be @(351)
+    }
+
     It 'includes pwsh descendants of an existing orchestra session for cleanup' {
         $snapshot = & $script:NewPreflightSnapshot -Processes @(
             [PSCustomObject]@{

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -13281,6 +13281,53 @@ Describe 'winsmux orchestra-smoke command' {
         $contract.stale_process_count | Should -Be 0
     }
 
+    It 'reports parentless winsmux-generated pane shells as stale processes' {
+        $parent = [pscustomobject]@{ ProcessId = 900; ParentProcessId = 0; Name = 'WindowsTerminal.exe'; CommandLine = 'wt' }
+        $staleShell = [pscustomobject]@{
+            ProcessId       = 801
+            ParentProcessId = 700
+            Name            = 'pwsh.exe'
+            CommandLine     = 'pwsh -NoLogo -NoProfile -NoExit -Command "if (-not (Test-Path variable:Global:__psmux_cwd_hook)) { $Global:__psmux_cwd_hook = $true }"'
+        }
+        $vscodeShell = [pscustomobject]@{
+            ProcessId       = 802
+            ParentProcessId = 0
+            Name            = 'pwsh.exe'
+            CommandLine     = 'pwsh -NoExit -Command ". C:\Users\test\AppData\Local\Programs\Microsoft VS Code\shellIntegration.ps1"'
+        }
+        $activeShell = [pscustomobject]@{
+            ProcessId       = 901
+            ParentProcessId = 900
+            Name            = 'pwsh.exe'
+            CommandLine     = 'pwsh -NoLogo -NoProfile -NoExit -Command "$Global:__psmux_cwd_hook = $true"'
+        }
+        $snapshot = [pscustomobject]@{
+            Processes = @($parent, $staleShell, $vscodeShell, $activeShell)
+            ById = @{
+                801 = $staleShell
+                802 = $vscodeShell
+                900 = $parent
+                901 = $activeShell
+            }
+            SupportsCommandLine = $true
+        }
+
+        $contract = Invoke-TestOrchestraProcessContract `
+            -Manifest $null `
+            -AttachState $null `
+            -PaneCount 6 `
+            -ExpectedPaneCount 6 `
+            -AttachedClientCount 0 `
+            -ProcessSnapshot $snapshot
+
+        $contract.ok | Should -Be $false
+        $contract.stale_process_count | Should -Be 1
+        $contract.stale_processes[0].pid | Should -Be 801
+        $contract.stale_processes[0].label | Should -Be 'worker_shell'
+        $contract.stale_processes[0].reason | Should -Be 'parent_missing_winsmux_shell'
+        $contract.warnings | Should -Contain 'stale managed process count 1 exceeds budget 0.'
+    }
+
     It 'treats the orchestra supervisor as one background helper' {
         $snapshot = [pscustomobject]@{
             Processes = @(

--- a/winsmux-core/scripts/orchestra-preflight.ps1
+++ b/winsmux-core/scripts/orchestra-preflight.ps1
@@ -164,6 +164,12 @@ function Test-OrchestraZombieProcessMatch {
     }
 
     if ($processName -in @('pwsh', 'powershell')) {
+        foreach ($marker in @('__psmux_cwd_hook', 'PSMUX_CLAUDE_TEAMMATE_MODE')) {
+            if ($commandLine.IndexOf($marker, [System.StringComparison]::OrdinalIgnoreCase) -ge 0) {
+                return $true
+            }
+        }
+
         return $matchesSharedMarker
     }
 

--- a/winsmux-core/scripts/orchestra-smoke.ps1
+++ b/winsmux-core/scripts/orchestra-smoke.ps1
@@ -221,6 +221,47 @@ function Test-OrchestraSmokeWarmProcess {
     return ($commandLine.IndexOf('__warm__', [System.StringComparison]::OrdinalIgnoreCase) -ge 0)
 }
 
+function Test-OrchestraSmokeGeneratedPaneShell {
+    param(
+        [AllowNull()]$Process,
+        [AllowNull()]$Snapshot
+    )
+
+    if ($null -eq $Process) {
+        return $false
+    }
+
+    $processName = [string](Get-OrchestraSmokeObjectPropertyValue -InputObject $Process -Name 'Name' -Default '')
+    $processName = [System.IO.Path]::GetFileNameWithoutExtension($processName).ToLowerInvariant()
+    if ($processName -notin @('pwsh', 'powershell')) {
+        return $false
+    }
+
+    $commandLine = [string](Get-OrchestraSmokeObjectPropertyValue -InputObject $Process -Name 'CommandLine' -Default '')
+    if ([string]::IsNullOrWhiteSpace($commandLine)) {
+        return $false
+    }
+
+    $hasWinsmuxMarker = $false
+    foreach ($marker in @('__psmux_cwd_hook', 'PSMUX_CLAUDE_TEAMMATE_MODE')) {
+        if ($commandLine.IndexOf($marker, [System.StringComparison]::OrdinalIgnoreCase) -ge 0) {
+            $hasWinsmuxMarker = $true
+            break
+        }
+    }
+
+    if (-not $hasWinsmuxMarker) {
+        return $false
+    }
+
+    $parentProcessId = ConvertTo-OrchestraSmokeInt -Value (Get-OrchestraSmokeObjectPropertyValue -InputObject $Process -Name 'ParentProcessId')
+    if ($parentProcessId -gt 0 -and $null -ne $Snapshot -and $null -ne $Snapshot.ById -and $Snapshot.ById.ContainsKey($parentProcessId)) {
+        return $false
+    }
+
+    return $true
+}
+
 function Get-OrchestraSmokeProcessContract {
     param(
         [AllowNull()]$Manifest,
@@ -235,6 +276,7 @@ function Get-OrchestraSmokeProcessContract {
     $pidMap = Get-OrchestraSmokeManagedProcessPidMap -Manifest $Manifest
     $backgroundHelpers = [System.Collections.Generic.List[object]]::new()
     $staleProcesses = [System.Collections.Generic.List[object]]::new()
+    $staleProcessIds = [System.Collections.Generic.HashSet[int]]::new()
 
     foreach ($entry in $pidMap.GetEnumerator()) {
         $managedProcessId = ConvertTo-OrchestraSmokeInt -Value $entry.Key
@@ -245,6 +287,7 @@ function Get-OrchestraSmokeProcessContract {
 
         if (-not $snapshot.ById.ContainsKey($managedProcessId)) {
             $staleProcesses.Add([ordered]@{ pid = $managedProcessId; label = $label; reason = 'missing' }) | Out-Null
+            $staleProcessIds.Add($managedProcessId) | Out-Null
             continue
         }
 
@@ -252,6 +295,7 @@ function Get-OrchestraSmokeProcessContract {
         $scriptName = Get-OrchestraSmokeManagedScriptName -ProcessLabel $label
         if (-not (Test-OrchestraSmokeProcessCommandLineMarker -Process $process -Marker $scriptName)) {
             $staleProcesses.Add([ordered]@{ pid = $managedProcessId; label = $label; reason = 'command_line_mismatch' }) | Out-Null
+            $staleProcessIds.Add($managedProcessId) | Out-Null
             continue
         }
 
@@ -265,6 +309,7 @@ function Get-OrchestraSmokeProcessContract {
             $attachHostCount = 1
         } elseif ($AttachedClientCount -lt 1) {
             $staleProcesses.Add([ordered]@{ pid = $attachPid; label = 'visible_attach_host'; reason = 'missing' }) | Out-Null
+            $staleProcessIds.Add($attachPid) | Out-Null
         }
     }
 
@@ -272,6 +317,12 @@ function Get-OrchestraSmokeProcessContract {
     foreach ($process in @($snapshot.Processes)) {
         if (Test-OrchestraSmokeWarmProcess -Process $process) {
             $warmProcessCount++
+        }
+
+        $processId = ConvertTo-OrchestraSmokeInt -Value (Get-OrchestraSmokeObjectPropertyValue -InputObject $process -Name 'ProcessId')
+        if ($processId -gt 0 -and -not $staleProcessIds.Contains($processId) -and (Test-OrchestraSmokeGeneratedPaneShell -Process $process -Snapshot $snapshot)) {
+            $staleProcesses.Add([ordered]@{ pid = $processId; label = 'worker_shell'; reason = 'parent_missing_winsmux_shell' }) | Out-Null
+            $staleProcessIds.Add($processId) | Out-Null
         }
     }
 


### PR DESCRIPTION
## Summary
- detect parentless winsmux-generated pwsh/powershell pane shells by ownership markers
- include those shells in the orchestra-smoke process contract so doctor surfaces residue
- add focused Pester coverage for preflight cleanup and smoke diagnostics

## Validation
- Invoke-Pester -Path tests\\OrchestraPreflight.Tests.ps1 -Output Detailed
- Invoke-Pester -Path tests\\winsmux-bridge.Tests.ps1 -FullName '*winsmux orchestra-smoke command*' -Output Detailed
- git diff --check
- pwsh -NoProfile -File scripts\\audit-public-surface.ps1
- pwsh -NoProfile -File scripts\\git-guard.ps1 -Mode full