### PR TITLE
Guard preflight cleanup logging

### DIFF
--- a/winsmux-core/scripts/orchestra-preflight.ps1
+++ b/winsmux-core/scripts/orchestra-preflight.ps1
@@ -284,7 +284,9 @@ function Remove-OrchestraZombieProcesses {
             Stop-Process -Id ([int]$victim.ProcessId) -Force -ErrorAction Stop
             $killed.Add($victim) | Out-Null
             Write-Host ("Preflight: killed zombie process {0} ({1})" -f $victim.Name, $victim.ProcessId)
-            Write-WinsmuxLog -Level INFO -Event 'preflight.zombie_process.killed' -Message ("Killed zombie process {0} ({1})." -f $victim.Name, $victim.ProcessId) -Data @{ process_name = $victim.Name; process_id = [int]$victim.ProcessId } | Out-Null
+            if (Get-Command Write-WinsmuxLog -ErrorAction SilentlyContinue) {
+                Write-WinsmuxLog -Level INFO -Event 'preflight.zombie_process.killed' -Message ("Killed zombie process {0} ({1})." -f $victim.Name, $victim.ProcessId) -Data @{ process_name = $victim.Name; process_id = [int]$victim.ProcessId } | Out-Null
+            }
         } catch {
             Write-Warning ("Preflight: failed to kill zombie process {0} ({1}): {2}" -f $victim.Name, $victim.ProcessId, $_.Exception.Message)
         }


### PR DESCRIPTION
## Summary
- avoid reporting successful stale-process cleanup as failed when Write-WinsmuxLog is not loaded
- keep the standalone preflight helper usable for manual cleanup checks

## Validation
- Invoke-Pester -Path tests\\OrchestraPreflight.Tests.ps1 -Output Detailed
- git diff --check
- pwsh -NoProfile -File scripts\\audit-public-surface.ps1
- pwsh -NoProfile -File scripts\\git-guard.ps1 -Mode full