### PR TITLE
Separate stale smoke state from process pressure

### DIFF
--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -13165,7 +13165,8 @@ Describe 'winsmux orchestra-smoke command' {
                 [Parameter(Mandatory = $true)][int]$PaneCount,
                 [Parameter(Mandatory = $true)][int]$ExpectedPaneCount,
                 [Parameter(Mandatory = $true)][int]$AttachedClientCount,
-                [AllowNull()]$ProcessSnapshot
+                [AllowNull()]$ProcessSnapshot,
+                [bool]$CountMissingProcessReferences = $true
             )
 
             $contractSource = [regex]::Match(
@@ -13180,7 +13181,7 @@ Describe 'winsmux orchestra-smoke command' {
             $contractSource = $contractSource -replace '\r?\n\r?\nfunction Get-OrchestraAttachedClientSnapshot$', ''
 
             & {
-                param($Manifest, $AttachState, $PaneCount, $ExpectedPaneCount, $AttachedClientCount, $ProcessSnapshot)
+                param($Manifest, $AttachState, $PaneCount, $ExpectedPaneCount, $AttachedClientCount, $ProcessSnapshot, $CountMissingProcessReferences)
 
                 Set-StrictMode -Version Latest
                 Invoke-Expression $contractSource
@@ -13190,8 +13191,9 @@ Describe 'winsmux orchestra-smoke command' {
                     -PaneCount $PaneCount `
                     -ExpectedPaneCount $ExpectedPaneCount `
                     -AttachedClientCount $AttachedClientCount `
-                    -ProcessSnapshot $ProcessSnapshot
-            } $Manifest $AttachState $PaneCount $ExpectedPaneCount $AttachedClientCount $ProcessSnapshot
+                    -ProcessSnapshot $ProcessSnapshot `
+                    -CountMissingProcessReferences $CountMissingProcessReferences
+            } $Manifest $AttachState $PaneCount $ExpectedPaneCount $AttachedClientCount $ProcessSnapshot $CountMissingProcessReferences
         }
     }
 
@@ -13381,6 +13383,31 @@ Describe 'winsmux orchestra-smoke command' {
         $contract.warnings | Should -Contain 'worker shell count 7 exceeds budget 6.'
         $contract.warnings | Should -Contain 'stale managed process count 1 exceeds budget 0.'
         $script:orchestraSmokeContent | Should -Match 'process contract: \$warning'
+    }
+
+    It 'keeps missing manifest process references out of pressure counts when no session is present' {
+        $snapshot = [pscustomobject]@{
+            Processes = @()
+            ById = @{}
+            SupportsCommandLine = $true
+        }
+
+        $contract = Invoke-TestOrchestraProcessContract `
+            -Manifest ([pscustomobject]@{
+                session = [pscustomobject]@{
+                    supervisor_pid = 101
+                }
+            }) `
+            -AttachState ([pscustomobject]@{ attach_process_id = 404 }) `
+            -PaneCount 6 `
+            -ExpectedPaneCount 6 `
+            -AttachedClientCount 0 `
+            -ProcessSnapshot $snapshot `
+            -CountMissingProcessReferences $false
+
+        $contract.ok | Should -Be $true
+        $contract.stale_process_count | Should -Be 0
+        $contract.stale_processes | Should -Be @()
     }
 
     It 'keeps ready-with-ui-warning fail-closed only for external operator mode' {

--- a/winsmux-core/scripts/orchestra-smoke.ps1
+++ b/winsmux-core/scripts/orchestra-smoke.ps1
@@ -269,7 +269,8 @@ function Get-OrchestraSmokeProcessContract {
         [Parameter(Mandatory = $true)][int]$PaneCount,
         [Parameter(Mandatory = $true)][int]$ExpectedPaneCount,
         [Parameter(Mandatory = $true)][int]$AttachedClientCount,
-        [AllowNull()]$ProcessSnapshot = $null
+        [AllowNull()]$ProcessSnapshot = $null,
+        [bool]$CountMissingProcessReferences = $true
     )
 
     $snapshot = if ($null -ne $ProcessSnapshot) { $ProcessSnapshot } else { Get-OrchestraSmokeProcessSnapshot }
@@ -286,8 +287,10 @@ function Get-OrchestraSmokeProcessContract {
         }
 
         if (-not $snapshot.ById.ContainsKey($managedProcessId)) {
-            $staleProcesses.Add([ordered]@{ pid = $managedProcessId; label = $label; reason = 'missing' }) | Out-Null
-            $staleProcessIds.Add($managedProcessId) | Out-Null
+            if ($CountMissingProcessReferences) {
+                $staleProcesses.Add([ordered]@{ pid = $managedProcessId; label = $label; reason = 'missing' }) | Out-Null
+                $staleProcessIds.Add($managedProcessId) | Out-Null
+            }
             continue
         }
 
@@ -307,7 +310,7 @@ function Get-OrchestraSmokeProcessContract {
     if ($attachPid -gt 0) {
         if ($snapshot.ById.ContainsKey($attachPid)) {
             $attachHostCount = 1
-        } elseif ($AttachedClientCount -lt 1) {
+        } elseif ($CountMissingProcessReferences -and $AttachedClientCount -lt 1) {
             $staleProcesses.Add([ordered]@{ pid = $attachPid; label = 'visible_attach_host'; reason = 'missing' }) | Out-Null
             $staleProcessIds.Add($attachPid) | Out-Null
         }
@@ -844,7 +847,8 @@ $processContract = Get-OrchestraSmokeProcessContract `
     -AttachState $attachState `
     -PaneCount $paneCount `
     -ExpectedPaneCount $expectedPaneCount `
-    -AttachedClientCount $attachedClientCount
+    -AttachedClientCount $attachedClientCount `
+    -CountMissingProcessReferences $paneProbeOk
 if (-not [bool]$processContract.ok) {
     foreach ($warning in @($processContract.warnings)) {
         $smokeErrors.Add("process contract: $warning") | Out-Null


### PR DESCRIPTION
## Summary
- keep missing manifest PID references out of process pressure counts when the psmux session is not present
- keep actual stale winsmux-owned pane shells counted through the process contract
- add focused orchestra-smoke coverage for the no-session state

## Validation
- Invoke-Pester -Path tests\\winsmux-bridge.Tests.ps1 -FullName '*winsmux orchestra-smoke command*' -Output Detailed
- pwsh -NoProfile -File winsmux-core\\scripts\\orchestra-smoke.ps1 -AsJson (expected exit 1 because no psmux session; process_contract.ok=true and stale_process_count=0)
- git diff --check
- pwsh -NoProfile -File scripts\\audit-public-surface.ps1
- pwsh -NoProfile -File scripts\\git-guard.ps1 -Mode full