### PR TITLE
Fix smoke attach probe refresh

### DIFF
--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -13582,6 +13582,11 @@ Describe 'winsmux orchestra-smoke command' {
         $script:orchestraSmokeContent | Should -Match 'ManifestReadable'
         $script:orchestraSmokeContent | Should -Match 'manifest read failed during startup convergence'
     }
+
+    It 'refreshes the attached client snapshot after startup convergence before resolving attach state' {
+        $script:orchestraSmokeContent | Should -Match 'function Get-OrchestraSmokeClientProbe'
+        $script:orchestraSmokeContent | Should -Match '(?s)Wait-OrchestraSmokeConvergence -ProjectDir \$ProjectDir -SessionName \$SessionName.*?\$clientSnapshot = Get-OrchestraSmokeClientProbe -WinsmuxBin \$winsmuxBin -SessionName \$SessionName.*?Resolve-OrchestraSmokeAttachState'
+    }
 }
 
 Describe 'operator startup restore contract docs' {

--- a/winsmux-core/scripts/orchestra-smoke.ps1
+++ b/winsmux-core/scripts/orchestra-smoke.ps1
@@ -420,6 +420,24 @@ function Get-OrchestraAttachedClientSnapshot {
     }
 }
 
+function Get-OrchestraSmokeClientProbe {
+    param(
+        [AllowEmptyString()][string]$WinsmuxBin = '',
+        [Parameter(Mandatory = $true)][string]$SessionName
+    )
+
+    if ([string]::IsNullOrWhiteSpace($WinsmuxBin)) {
+        return [PSCustomObject][ordered]@{
+            Ok      = $false
+            Count   = 0
+            Error   = 'winsmux executable could not be resolved.'
+            Clients = @()
+        }
+    }
+
+    Get-OrchestraAttachedClientSnapshot -WinsmuxBin $WinsmuxBin -SessionName $SessionName
+}
+
 function Get-OrchestraOperatorContract {
     param(
         [Parameter(Mandatory = $true)][bool]$SmokeOk,
@@ -752,16 +770,7 @@ $paneCount = [int]$probeState.PaneCount
 $paneProbeOk = [bool]$probeState.PaneProbeOk
 $paneProbeError = [string]$probeState.PaneProbeError
 
-$clientSnapshot = if ([string]::IsNullOrWhiteSpace($winsmuxBin)) {
-    [PSCustomObject][ordered]@{
-        Ok      = $false
-        Count   = 0
-        Error   = 'winsmux executable could not be resolved.'
-        Clients = @()
-    }
-} else {
-    Get-OrchestraAttachedClientSnapshot -WinsmuxBin $winsmuxBin -SessionName $SessionName
-}
+$clientSnapshot = Get-OrchestraSmokeClientProbe -WinsmuxBin $winsmuxBin -SessionName $SessionName
 $clientProbeOk = [bool]$clientSnapshot.Ok
 $clientProbeError = [string]$clientSnapshot.Error
 $attachedClientCount = [int]$clientSnapshot.Count
@@ -785,6 +794,11 @@ if ($sessionAlreadyHealthy) {
 } else {
     $startOutput = 'Skipped orchestra-start; run orchestra-start.ps1 when operator_contract.requires_startup is true.'
 }
+
+$clientSnapshot = Get-OrchestraSmokeClientProbe -WinsmuxBin $winsmuxBin -SessionName $SessionName
+$clientProbeOk = [bool]$clientSnapshot.Ok
+$clientProbeError = [string]$clientSnapshot.Error
+$attachedClientCount = [int]$clientSnapshot.Count
 
 $sessionReady = [bool]$probeState.SessionReady
 $uiAttachLaunched = [bool]$probeState.UiAttachLaunched


### PR DESCRIPTION
## Summary
- refresh the attached-client probe after orchestra startup convergence
- reuse a single helper for missing winsmux binary probe results
- cover the refresh ordering in the orchestra-smoke Pester checks

## Validation
- Invoke-Pester -Path tests\winsmux-bridge.Tests.ps1 -FullName '*winsmux orchestra-smoke command*' -Output Detailed
- pwsh -NoProfile -File winsmux-core\scripts\orchestra-smoke.ps1 -AsJson
- git diff --check
- pwsh -NoProfile -File scripts\audit-public-surface.ps1
- pwsh -NoProfile -File scripts\git-guard.ps1 -Mode full

Refs #820