### PR TITLE
Fix v0.25 review regressions

### DIFF
--- a/tests/OrchestraPreflight.Tests.ps1
+++ b/tests/OrchestraPreflight.Tests.ps1
@@ -77,19 +77,25 @@ Describe 'orchestra preflight zombie detection' {
         @($victims).Count | Should -Be 0
     }
 
-    It 'detects parentless winsmux-generated pwsh pane shells without worktree paths' {
+    It 'detects parentless winsmux-generated pwsh pane shells only when scoped to this project' {
         $snapshot = & $script:NewPreflightSnapshot -Processes @(
             [PSCustomObject]@{
                 ProcessId       = 351
                 ParentProcessId = 0
                 Name            = 'pwsh.exe'
-                CommandLine     = 'pwsh -NoLogo -NoProfile -NoExit -Command "if (-not (Test-Path variable:Global:__psmux_cwd_hook)) { $Global:__psmux_cwd_hook = $true }"'
+                CommandLine     = 'pwsh -NoLogo -NoProfile -NoExit -Command "Set-Location C:\repo\.worktrees\builder-1; if (-not (Test-Path variable:Global:__psmux_cwd_hook)) { $Global:__psmux_cwd_hook = $true }"'
             }
             [PSCustomObject]@{
                 ProcessId       = 352
                 ParentProcessId = 0
                 Name            = 'pwsh.exe'
                 CommandLine     = 'pwsh -noexit -command "try { . C:\Users\test\AppData\Local\Programs\Microsoft VS Code\shellIntegration.ps1 } catch {}"'
+            }
+            [PSCustomObject]@{
+                ProcessId       = 353
+                ParentProcessId = 0
+                Name            = 'pwsh.exe'
+                CommandLine     = 'pwsh -NoLogo -NoProfile -NoExit -Command "if (-not (Test-Path variable:Global:__psmux_cwd_hook)) { $Global:__psmux_cwd_hook = $true }"'
             }
         )
 

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -2974,7 +2974,7 @@ param(
         (Test-Path -LiteralPath $lockDir -PathType Container) | Should -Be $false
     }
 
-    It 'keeps live file locks when owner start time cannot be verified' {
+    It 'treats live file locks with malformed owner start time as stale' {
         $logPath = Join-Path $script:loggerTempRoot '.winsmux\logs\live-unverified.jsonl'
         $lockDir = "$logPath.lock"
         $metadataPath = Join-Path $lockDir 'owner.json'
@@ -2984,7 +2984,7 @@ param(
 {"pid":$PID,"started_at":"2000-01-01T00:00:00Z","process_started_at":"not-a-date"}
 "@ | Set-Content -Path $metadataPath -Encoding UTF8
 
-        Test-WinsmuxFileLockStale -Path $logPath -StaleAfterSeconds 0 | Should -Be $false
+        Test-WinsmuxFileLockStale -Path $logPath -StaleAfterSeconds 0 | Should -Be $true
     }
 
     It 'keeps CLM-safe writes on cmd-based lock and replace primitives' {
@@ -13166,7 +13166,8 @@ Describe 'winsmux orchestra-smoke command' {
                 [Parameter(Mandatory = $true)][int]$ExpectedPaneCount,
                 [Parameter(Mandatory = $true)][int]$AttachedClientCount,
                 [AllowNull()]$ProcessSnapshot,
-                [bool]$CountMissingProcessReferences = $true
+                [bool]$CountMissingProcessReferences = $true,
+                [string]$ProjectDir = 'C:\repo'
             )
 
             $contractSource = [regex]::Match(
@@ -13192,8 +13193,9 @@ Describe 'winsmux orchestra-smoke command' {
                     -ExpectedPaneCount $ExpectedPaneCount `
                     -AttachedClientCount $AttachedClientCount `
                     -ProcessSnapshot $ProcessSnapshot `
-                    -CountMissingProcessReferences $CountMissingProcessReferences
-            } $Manifest $AttachState $PaneCount $ExpectedPaneCount $AttachedClientCount $ProcessSnapshot $CountMissingProcessReferences
+                    -CountMissingProcessReferences $CountMissingProcessReferences `
+                    -ProjectDir $ProjectDir
+            } $Manifest $AttachState $PaneCount $ExpectedPaneCount $AttachedClientCount $ProcessSnapshot $CountMissingProcessReferences $ProjectDir
         }
     }
 
@@ -13289,7 +13291,13 @@ Describe 'winsmux orchestra-smoke command' {
             ProcessId       = 801
             ParentProcessId = 700
             Name            = 'pwsh.exe'
-            CommandLine     = 'pwsh -NoLogo -NoProfile -NoExit -Command "if (-not (Test-Path variable:Global:__psmux_cwd_hook)) { $Global:__psmux_cwd_hook = $true }"'
+            CommandLine     = 'pwsh -NoLogo -NoProfile -NoExit -Command "Set-Location C:\repo\.worktrees\builder-1; if (-not (Test-Path variable:Global:__psmux_cwd_hook)) { $Global:__psmux_cwd_hook = $true }"'
+        }
+        $unscopedShell = [pscustomobject]@{
+            ProcessId       = 803
+            ParentProcessId = 701
+            Name            = 'pwsh.exe'
+            CommandLine     = 'pwsh -NoLogo -NoProfile -NoExit -Command "$Global:__psmux_cwd_hook = $true"'
         }
         $vscodeShell = [pscustomobject]@{
             ProcessId       = 802
@@ -13304,10 +13312,11 @@ Describe 'winsmux orchestra-smoke command' {
             CommandLine     = 'pwsh -NoLogo -NoProfile -NoExit -Command "$Global:__psmux_cwd_hook = $true"'
         }
         $snapshot = [pscustomobject]@{
-            Processes = @($parent, $staleShell, $vscodeShell, $activeShell)
+            Processes = @($parent, $staleShell, $vscodeShell, $unscopedShell, $activeShell)
             ById = @{
                 801 = $staleShell
                 802 = $vscodeShell
+                803 = $unscopedShell
                 900 = $parent
                 901 = $activeShell
             }

--- a/winsmux-app/scripts/viewport-harness.mjs
+++ b/winsmux-app/scripts/viewport-harness.mjs
@@ -503,6 +503,23 @@ async function assertDesktopVoiceDraftShaping(page) {
     return button instanceof HTMLButtonElement && button.getAttribute("aria-pressed") === "false";
   });
 
+  await composer.fill("");
+  await page.keyboard.press("Control+Alt+M");
+  await page.waitForFunction(() => {
+    const button = document.querySelector("#voice-input-btn");
+    return button instanceof HTMLButtonElement && button.getAttribute("aria-pressed") === "true";
+  });
+  await page.evaluate(() => window.__winsmuxSpeechRecognition.emitResult("add a like button"));
+  await page.waitForFunction(() => {
+    const input = document.querySelector("#composer-input");
+    return input instanceof HTMLTextAreaElement && input.value === "add a like button";
+  });
+  await page.keyboard.press("Control+Alt+M");
+  await page.waitForFunction(() => {
+    const button = document.querySelector("#voice-input-btn");
+    return button instanceof HTMLButtonElement && button.getAttribute("aria-pressed") === "false";
+  });
+
   await selectVoiceDraftMode(page, "Operator request");
   await composer.fill("");
   await page.keyboard.press("Control+Alt+M");
@@ -541,6 +558,26 @@ async function assertDesktopVoiceDraftShaping(page) {
     const button = document.querySelector("#voice-input-btn");
     return button instanceof HTMLButtonElement && button.getAttribute("aria-pressed") === "false";
   });
+
+  await selectVoiceVocabularyMode(page, "Vocabulary off");
+  await composer.fill("");
+  await startBrowserVoiceInput(page);
+  await page.evaluate(() => window.__winsmuxSpeechRecognition.emitResult("question   about   logs"));
+  await page.waitForFunction(() => {
+    const input = document.querySelector("#composer-input");
+    return input instanceof HTMLTextAreaElement && input.value === "question   about   logs";
+  });
+  await stopBrowserVoiceInput(page);
+
+  await composer.fill("");
+  await startBrowserVoiceInput(page);
+  await page.evaluate(() => window.__winsmuxSpeechRecognition.emitResult("add a like button"));
+  await page.waitForFunction(() => {
+    const input = document.querySelector("#composer-input");
+    return input instanceof HTMLTextAreaElement && input.value === "add a like button";
+  });
+  await stopBrowserVoiceInput(page);
+  await selectVoiceVocabularyMode(page, "Project terms");
 }
 
 async function assertDesktopVoiceVocabularyDictionary(page) {

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -7253,11 +7253,15 @@ function replaceVoiceVocabularyPhrase(value: string, spoken: string, replacement
 }
 
 function applyVoiceVocabulary(transcript: string) {
+  const entries = getVoiceVocabularyEntries();
+  if (entries.length === 0) {
+    return transcript;
+  }
   let nextTranscript = transcript;
-  for (const entry of getVoiceVocabularyEntries()) {
+  for (const entry of entries) {
     nextTranscript = replaceVoiceVocabularyPhrase(nextTranscript, entry.spoken, entry.replacement);
   }
-  return normalizeVoiceDraftWhitespace(nextTranscript);
+  return nextTranscript === transcript ? transcript : normalizeVoiceDraftWhitespace(nextTranscript);
 }
 
 function removeVoiceFillers(value: string) {
@@ -7265,7 +7269,7 @@ function removeVoiceFillers(value: string) {
   for (const filler of ["えー", "えっと", "あの", "あのー", "その", "そのー", "まあ", "なんか"]) {
     text = text.replace(new RegExp(`(^|[\\s、。,.!?])${escapeRegExp(filler)}(?=$|[\\s、。,.!?])`, "g"), "$1");
   }
-  text = text.replace(/\b(?:um|uh|erm|like)\b[,\s]*/gi, "");
+  text = text.replace(/\b(?:um|uh|erm)\b[,\s]*/gi, "");
   return normalizeVoiceDraftWhitespace(text);
 }
 
@@ -7366,6 +7370,13 @@ function shapeVoiceComposerDraft(base: string, transcript: string) {
   const trimmedBase = base.trim();
   const slashBaseCommand = getVoiceSlashBaseCommand(base);
   const vocabularyTranscript = applyVoiceVocabulary(transcript);
+  if (activeVoiceDraftMode === "raw") {
+    if (!base) {
+      return vocabularyTranscript;
+    }
+    const separator = vocabularyTranscript ? " " : "";
+    return `${base.trimEnd()}${separator}${vocabularyTranscript}`;
+  }
   if (slashBaseCommand) {
     const shapedTranscript = shapeVoiceTranscript(vocabularyTranscript);
     const separator = shapedTranscript ? " " : "";

--- a/winsmux-core/scripts/clm-safe-io.ps1
+++ b/winsmux-core/scripts/clm-safe-io.ps1
@@ -65,7 +65,7 @@ function Test-WinsmuxFileLockStale {
                         return $true
                     }
                 } catch {
-                    return $false
+                    return $true
                 }
             }
 

--- a/winsmux-core/scripts/orchestra-preflight.ps1
+++ b/winsmux-core/scripts/orchestra-preflight.ps1
@@ -164,12 +164,6 @@ function Test-OrchestraZombieProcessMatch {
     }
 
     if ($processName -in @('pwsh', 'powershell')) {
-        foreach ($marker in @('__psmux_cwd_hook', 'PSMUX_CLAUDE_TEAMMATE_MODE')) {
-            if ($commandLine.IndexOf($marker, [System.StringComparison]::OrdinalIgnoreCase) -ge 0) {
-                return $true
-            }
-        }
-
         return $matchesSharedMarker
     }
 

--- a/winsmux-core/scripts/orchestra-smoke.ps1
+++ b/winsmux-core/scripts/orchestra-smoke.ps1
@@ -224,7 +224,8 @@ function Test-OrchestraSmokeWarmProcess {
 function Test-OrchestraSmokeGeneratedPaneShell {
     param(
         [AllowNull()]$Process,
-        [AllowNull()]$Snapshot
+        [AllowNull()]$Snapshot,
+        [AllowEmptyString()][string]$ProjectDir = ''
     )
 
     if ($null -eq $Process) {
@@ -254,6 +255,23 @@ function Test-OrchestraSmokeGeneratedPaneShell {
         return $false
     }
 
+    $scopedMarkers = @()
+    if (-not [string]::IsNullOrWhiteSpace($ProjectDir)) {
+        $scopedMarkers += $ProjectDir
+        $scopedMarkers += (Join-Path $ProjectDir '.worktrees')
+    }
+    $scopedMarkers += 'worktree-builder-'
+    $matchesScopedMarker = $false
+    foreach ($marker in @($scopedMarkers | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })) {
+        if ($commandLine.IndexOf($marker, [System.StringComparison]::OrdinalIgnoreCase) -ge 0) {
+            $matchesScopedMarker = $true
+            break
+        }
+    }
+    if (-not $matchesScopedMarker) {
+        return $false
+    }
+
     $parentProcessId = ConvertTo-OrchestraSmokeInt -Value (Get-OrchestraSmokeObjectPropertyValue -InputObject $Process -Name 'ParentProcessId')
     if ($parentProcessId -gt 0 -and $null -ne $Snapshot -and $null -ne $Snapshot.ById -and $Snapshot.ById.ContainsKey($parentProcessId)) {
         return $false
@@ -270,7 +288,8 @@ function Get-OrchestraSmokeProcessContract {
         [Parameter(Mandatory = $true)][int]$ExpectedPaneCount,
         [Parameter(Mandatory = $true)][int]$AttachedClientCount,
         [AllowNull()]$ProcessSnapshot = $null,
-        [bool]$CountMissingProcessReferences = $true
+        [bool]$CountMissingProcessReferences = $true,
+        [AllowEmptyString()][string]$ProjectDir = ''
     )
 
     $snapshot = if ($null -ne $ProcessSnapshot) { $ProcessSnapshot } else { Get-OrchestraSmokeProcessSnapshot }
@@ -323,7 +342,7 @@ function Get-OrchestraSmokeProcessContract {
         }
 
         $processId = ConvertTo-OrchestraSmokeInt -Value (Get-OrchestraSmokeObjectPropertyValue -InputObject $process -Name 'ProcessId')
-        if ($processId -gt 0 -and -not $staleProcessIds.Contains($processId) -and (Test-OrchestraSmokeGeneratedPaneShell -Process $process -Snapshot $snapshot)) {
+        if ($processId -gt 0 -and -not $staleProcessIds.Contains($processId) -and (Test-OrchestraSmokeGeneratedPaneShell -Process $process -Snapshot $snapshot -ProjectDir $ProjectDir)) {
             $staleProcesses.Add([ordered]@{ pid = $processId; label = 'worker_shell'; reason = 'parent_missing_winsmux_shell' }) | Out-Null
             $staleProcessIds.Add($processId) | Out-Null
         }
@@ -862,7 +881,8 @@ $processContract = Get-OrchestraSmokeProcessContract `
     -PaneCount $paneCount `
     -ExpectedPaneCount $expectedPaneCount `
     -AttachedClientCount $attachedClientCount `
-    -CountMissingProcessReferences $paneProbeOk
+    -CountMissingProcessReferences $paneProbeOk `
+    -ProjectDir $ProjectDir
 if (-not [bool]$processContract.ok) {
     foreach ($warning in @($processContract.warnings)) {
         $smokeErrors.Add("process contract: $warning") | Out-Null


### PR DESCRIPTION
## Summary
- preserve Raw + Vocabulary off voice transcripts without whitespace normalization or slash parsing
- keep English content word 'like' when cleaning voice drafts
- scope parentless winsmux PowerShell pane detection to the current project before cleanup or smoke reporting
- reclaim malformed file-lock owner metadata as stale instead of blocking writers

## Validation
- Invoke-Pester -Path tests\\OrchestraPreflight.Tests.ps1 -Output Detailed
- Invoke-Pester -Path tests\\winsmux-bridge.Tests.ps1 -FullName '*winsmux orchestra-smoke command*' -Output Detailed
- Invoke-Pester -Path tests\\winsmux-bridge.Tests.ps1 -FullName '*logger helpers*' -Output Detailed
- cmd /c npm run build
- cmd /c npm run test:viewport-harness
- git diff --check
- pwsh -NoProfile -File scripts\\audit-public-surface.ps1
- pwsh -NoProfile -File scripts\\git-guard.ps1 -Mode full

Refs #820