### PR TITLE
Add selected text voice editing

### DIFF
--- a/winsmux-app/scripts/viewport-harness.mjs
+++ b/winsmux-app/scripts/viewport-harness.mjs
@@ -577,6 +577,28 @@ async function assertDesktopVoiceDraftShaping(page) {
     return input instanceof HTMLTextAreaElement && input.value === "add a like button";
   });
   await stopBrowserVoiceInput(page);
+
+  await composer.fill("/review TASK-426 unclear text README.md");
+  await composer.evaluate((input) => {
+    const value = input.value;
+    const start = value.indexOf("unclear text");
+    input.focus();
+    input.setSelectionRange(start, start + "unclear text".length);
+  });
+  await startBrowserVoiceInput(page);
+  await page.evaluate(() => window.__winsmuxSpeechRecognition.emitResult("clear selected wording"));
+  await page.waitForFunction(() => {
+    const input = document.querySelector("#composer-input");
+    return input instanceof HTMLTextAreaElement &&
+      input.value === "/review TASK-426 clear selected wording README.md";
+  });
+  await stopBrowserVoiceInput(page);
+  await page.keyboard.press("ArrowUp");
+  await page.waitForFunction(() => {
+    const input = document.querySelector("#composer-input");
+    return input instanceof HTMLTextAreaElement &&
+      input.value === "/review TASK-426 unclear text README.md";
+  });
   await selectVoiceVocabularyMode(page, "Project terms");
 }
 

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -503,6 +503,7 @@ let voiceRecognition: SpeechRecognitionLike | null = null;
 let voiceListening = false;
 let voiceInputMode: "browser" | "native" | null = null;
 let voiceTranscriptBase = "";
+let voiceSelectionEditState: { base: string; start: number; end: number; historyCaptured: boolean } | null = null;
 let activeVoiceVocabularyMode: VoiceVocabularyMode = "project";
 let voiceCaptureStatus: DesktopVoiceCaptureStatus | null = null;
 let voiceCaptureStatusError = "";
@@ -7548,6 +7549,40 @@ function shapeVoiceComposerDraft(base: string, transcript: string) {
   return `${base}${separator}${shapedTranscript}`.trimStart();
 }
 
+function captureVoiceSelectionEditState(composerInput: HTMLTextAreaElement) {
+  if (composerInput.selectionStart === composerInput.selectionEnd) {
+    return null;
+  }
+  return {
+    base: composerInput.value,
+    start: composerInput.selectionStart,
+    end: composerInput.selectionEnd,
+    historyCaptured: false,
+  };
+}
+
+function shapeVoiceSelectionReplacement(transcript: string) {
+  const vocabularyTranscript = applyVoiceVocabulary(transcript);
+  return shapeVoiceTranscript(vocabularyTranscript);
+}
+
+function applyVoiceSelectionEdit(composerInput: HTMLTextAreaElement, transcript: string) {
+  if (!voiceSelectionEditState) {
+    return false;
+  }
+
+  if (!voiceSelectionEditState.historyCaptured) {
+    pushComposerHistoryEntry(captureComposerHistoryEntry(voiceSelectionEditState.base));
+    voiceSelectionEditState.historyCaptured = true;
+  }
+
+  const replacement = shapeVoiceSelectionReplacement(transcript);
+  composerInput.value = `${voiceSelectionEditState.base.slice(0, voiceSelectionEditState.start)}${replacement}${voiceSelectionEditState.base.slice(voiceSelectionEditState.end)}`;
+  const cursor = voiceSelectionEditState.start + replacement.length;
+  composerInput.setSelectionRange(cursor, cursor);
+  return true;
+}
+
 function startVoiceInput(composerInput: HTMLTextAreaElement) {
   const SpeechRecognition = getSpeechRecognitionConstructor();
   if (!SpeechRecognition) {
@@ -7564,6 +7599,7 @@ function startVoiceInput(composerInput: HTMLTextAreaElement) {
   }
 
   voiceTranscriptBase = composerInput.value.trimEnd();
+  voiceSelectionEditState = captureVoiceSelectionEditState(composerInput);
   const recognition = new SpeechRecognition();
   recognition.continuous = true;
   recognition.interimResults = true;
@@ -7580,6 +7616,7 @@ function startVoiceInput(composerInput: HTMLTextAreaElement) {
     voiceRecognition = null;
     voiceInputMode = null;
     voiceTranscriptBase = "";
+    voiceSelectionEditState = null;
     finishVoiceSession();
     updateVoiceInputButton();
     exitComposerHistoryToDraft(composerInput.value);
@@ -7589,6 +7626,7 @@ function startVoiceInput(composerInput: HTMLTextAreaElement) {
     persistVoiceDraftRecovery(composerInput.value);
     voiceListening = false;
     voiceInputMode = null;
+    voiceSelectionEditState = null;
     finishVoiceSession();
     updateVoiceInputButton();
     if (event.error && event.error !== "no-speech" && event.error !== "aborted") {
@@ -7610,11 +7648,16 @@ function startVoiceInput(composerInput: HTMLTextAreaElement) {
     for (let index = event.resultIndex; index < event.results.length; index += 1) {
       transcript += event.results[index]?.[0]?.transcript ?? "";
     }
-    composerInput.value = shapeVoiceComposerDraft(voiceTranscriptBase, transcript);
+    const selectionEditApplied = applyVoiceSelectionEdit(composerInput, transcript);
+    if (!selectionEditApplied) {
+      composerInput.value = shapeVoiceComposerDraft(voiceTranscriptBase, transcript);
+    }
     syncComposerInputHeight(composerInput);
     composerInput.focus();
-    const length = composerInput.value.length;
-    composerInput.setSelectionRange(length, length);
+    if (!selectionEditApplied) {
+      const length = composerInput.value.length;
+      composerInput.setSelectionRange(length, length);
+    }
     syncComposerDraftState(composerInput.value);
     syncComposerSlashState(composerInput.value);
     persistVoiceDraftRecovery(composerInput.value);


### PR DESCRIPTION
## Summary

- Add selection-aware browser voice input for the operator composer.
- Preserve text outside the selected range, including slash commands, task IDs, and file paths.
- Store the pre-edit composer state in history so the previewed voice edit can be reverted.

Closes #852.

## Validation

- `cmd /c npm run build`
- `cmd /c npm run test:viewport-harness`
- `git diff --check`
- `pwsh -NoProfile -File scripts\audit-public-surface.ps1`
- `pwsh -NoProfile -File scripts\git-guard.ps1 -Mode full`

## Notes

- No public-facing docs were changed.
