### PR TITLE
Fix voice draft recovery review follow-ups

### DIFF
--- a/winsmux-app/scripts/viewport-harness.mjs
+++ b/winsmux-app/scripts/viewport-harness.mjs
@@ -578,6 +578,7 @@ async function assertDesktopVoiceDraftShaping(page) {
   });
   await stopBrowserVoiceInput(page);
 
+  await page.evaluate(() => window.__winsmuxViewportHarness.pushComposerHistoryForTest("older submitted prompt"));
   await composer.fill("/review TASK-426 unclear text README.md");
   await composer.evaluate((input) => {
     const value = input.value;
@@ -752,6 +753,22 @@ async function assertDesktopVoiceLongSessionPrivacy(page) {
   await page.evaluate((timestamp) => window.__winsmuxViewportHarness.setVoiceNow(timestamp), baseNow + 10_000);
   await startBrowserVoiceInput(page);
   await page.evaluate((timestamp) => window.__winsmuxViewportHarness.setVoiceNow(timestamp), baseNow + (6 * 60 * 1000) + 20_000);
+  await page.evaluate(() => window.__winsmuxSpeechRecognition.emitResult("clear this stale voice recovery"));
+  await page.waitForFunction((key) => {
+    const rawValue = window.localStorage.getItem(key);
+    if (!rawValue) {
+      return false;
+    }
+    return JSON.parse(rawValue).value === "clear this stale voice recovery";
+  }, recoveryKey);
+  await composer.fill("");
+  await stopBrowserVoiceInput(page);
+  await page.waitForFunction((key) => window.localStorage.getItem(key) === null, recoveryKey);
+
+  await composer.fill("");
+  await page.evaluate((timestamp) => window.__winsmuxViewportHarness.setVoiceNow(timestamp), baseNow + 30_000);
+  await startBrowserVoiceInput(page);
+  await page.evaluate((timestamp) => window.__winsmuxViewportHarness.setVoiceNow(timestamp), baseNow + (6 * 60 * 1000) + 40_000);
   await page.evaluate(() => window.__winsmuxSpeechRecognition.emitResult("recover this long voice draft"));
   await page.waitForFunction((key) => {
     const rawValue = window.localStorage.getItem(key);

--- a/winsmux-app/scripts/viewport-harness.mjs
+++ b/winsmux-app/scripts/viewport-harness.mjs
@@ -578,7 +578,11 @@ async function assertDesktopVoiceDraftShaping(page) {
   });
   await stopBrowserVoiceInput(page);
 
-  await page.evaluate(() => window.__winsmuxViewportHarness.pushComposerHistoryForTest("older submitted prompt"));
+  await page.evaluate(() => {
+    for (let index = 0; index < 20; index += 1) {
+      window.__winsmuxViewportHarness.pushComposerHistoryForTest(`submitted prompt ${index}`);
+    }
+  });
   await composer.fill("/review TASK-426 unclear text README.md");
   await composer.evaluate((input) => {
     const value = input.value;
@@ -592,6 +596,13 @@ async function assertDesktopVoiceDraftShaping(page) {
     const input = document.querySelector("#composer-input");
     return input instanceof HTMLTextAreaElement &&
       input.value === "/review TASK-426 clear selected wording README.md";
+  });
+  await page.waitForFunction(() => {
+    const values = window.__winsmuxViewportHarness.getComposerHistoryValuesForTest();
+    return values.length === 20 &&
+      values[values.length - 1] === "/review TASK-426 unclear text README.md" &&
+      values.includes("submitted prompt 19") &&
+      !values.includes("submitted prompt 0");
   });
   await stopBrowserVoiceInput(page);
   await page.keyboard.press("ArrowUp");

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -207,6 +207,7 @@ declare global {
       registerPreviewTarget: (sourceLabel: string, url: string) => void;
       openPreviewTarget: (url: string) => void;
       openEditorPreview: (path: string, content: string, worktree?: string) => void;
+      getComposerHistoryValuesForTest: () => string[];
       pushComposerHistoryForTest: (value: string) => void;
       setContextPanel: (open: boolean) => void;
       setTerminalDrawer: (open: boolean) => void;
@@ -7963,7 +7964,7 @@ function pushComposerImmediateHistoryEntry(entry: ComposerHistoryEntry) {
     return;
   }
 
-  composerHistory = [...composerHistory, entry].slice(-20);
+  composerHistory = [...composerHistory.slice(0, 19), entry];
   composerHistoryIndex = -1;
   composerDraftState = { value: "", remoteReferenceIds: [], attachments: [] };
 }
@@ -11227,6 +11228,7 @@ function installViewportHarnessHooks() {
     openEditorPreview: (path: string, content: string, worktree?: string) => {
       openEditorPreviewForHarness(path, content, worktree);
     },
+    getComposerHistoryValuesForTest: () => composerHistory.map((entry) => entry.value),
     pushComposerHistoryForTest: (value: string) => {
       pushComposerHistoryEntry(captureComposerHistoryEntry(value));
     },

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -207,6 +207,7 @@ declare global {
       registerPreviewTarget: (sourceLabel: string, url: string) => void;
       openPreviewTarget: (url: string) => void;
       openEditorPreview: (path: string, content: string, worktree?: string) => void;
+      pushComposerHistoryForTest: (value: string) => void;
       setContextPanel: (open: boolean) => void;
       setTerminalDrawer: (open: boolean) => void;
       getOperatorStartupInput: () => string;
@@ -7061,7 +7062,14 @@ function clearVoiceDraftRecoveryStorage() {
 }
 
 function persistVoiceDraftRecovery(value: string) {
-  if (!themeState.persistVoiceDraftLocally || getVoiceSessionElapsedMs() < VOICE_DRAFT_AUTO_SAVE_MS || !value.trim()) {
+  if (!themeState.persistVoiceDraftLocally) {
+    return;
+  }
+  if (!value.trim()) {
+    clearVoiceDraftRecoveryStorage();
+    return;
+  }
+  if (getVoiceSessionElapsedMs() < VOICE_DRAFT_AUTO_SAVE_MS) {
     return;
   }
   try {
@@ -7572,7 +7580,7 @@ function applyVoiceSelectionEdit(composerInput: HTMLTextAreaElement, transcript:
   }
 
   if (!voiceSelectionEditState.historyCaptured) {
-    pushComposerHistoryEntry(captureComposerHistoryEntry(voiceSelectionEditState.base));
+    pushComposerImmediateHistoryEntry(captureComposerHistoryEntry(voiceSelectionEditState.base));
     voiceSelectionEditState.historyCaptured = true;
   }
 
@@ -7946,6 +7954,16 @@ function pushComposerHistoryEntry(entry: ComposerHistoryEntry) {
   }
 
   composerHistory = [entry, ...composerHistory].slice(0, 20);
+  composerHistoryIndex = -1;
+  composerDraftState = { value: "", remoteReferenceIds: [], attachments: [] };
+}
+
+function pushComposerImmediateHistoryEntry(entry: ComposerHistoryEntry) {
+  if (!entry.value && entry.remoteReferenceIds.length === 0 && entry.attachments.length === 0) {
+    return;
+  }
+
+  composerHistory = [...composerHistory, entry].slice(-20);
   composerHistoryIndex = -1;
   composerDraftState = { value: "", remoteReferenceIds: [], attachments: [] };
 }
@@ -11208,6 +11226,9 @@ function installViewportHarnessHooks() {
     },
     openEditorPreview: (path: string, content: string, worktree?: string) => {
       openEditorPreviewForHarness(path, content, worktree);
+    },
+    pushComposerHistoryForTest: (value: string) => {
+      pushComposerHistoryEntry(captureComposerHistoryEntry(value));
     },
     setContextPanel: (open: boolean) => {
       setContextPanel(open);


### PR DESCRIPTION
## Summary
- clear opted-in voice draft recovery when the active voice draft is emptied before stop
- keep selected-text voice edit snapshots immediately reachable from composer history
- add viewport harness coverage for both review edge cases

## Validation
- cmd /c npm run build
- cmd /c npm run test:viewport-harness
- git diff --check
- pwsh -NoProfile -File scripts\\audit-public-surface.ps1
- pwsh -NoProfile -File scripts\\git-guard.ps1 -Mode full
- push hook: git-guard, audit-public-surface, gitleaks

Closes #855