### PR TITLE
Add workflow pack execution contract

### DIFF
--- a/core/src/operator_cli.rs
+++ b/core/src/operator_cli.rs
@@ -238,6 +238,17 @@ pub fn run_skills_command(args: &[&String]) -> io::Result<()> {
     }
 
     println!("Progressive skills catalog");
+    if let Some(packs) = payload["workflow_pack_registry"]["packs"].as_array() {
+        println!("Workflow packs");
+        for pack in packs {
+            println!(
+                "- {}: {}",
+                pack["id"].as_str().unwrap_or_default(),
+                pack["metadata"]["purpose"].as_str().unwrap_or_default()
+            );
+        }
+    }
+    println!("Skill contracts");
     for skill in payload["skills"].as_array().into_iter().flatten() {
         println!(
             "- {}: {}",
@@ -269,6 +280,135 @@ fn progressive_skills_catalog() -> Value {
         "private_guidance_stored": false,
         "local_reference_paths_stored": false,
         "operator_judgement_boundary": "operator keeps final task split, merge, release, and human-escalation decisions",
+        "workflow_pack_registry": {
+            "contract_version": 1,
+            "public_contract_only": true,
+            "private_skill_bodies_allowed": false,
+            "local_absolute_paths_allowed": false,
+            "packs": [
+                {
+                    "id": "run-read-models",
+                    "metadata": {
+                        "display_name": "Run read models",
+                        "purpose": "inspect current runs before assigning follow-up work",
+                        "status": "available",
+                        "review_role": "operator"
+                    },
+                    "scope": [
+                        "read run summaries",
+                        "inspect run evidence",
+                        "prepare follow-up context"
+                    ],
+                    "commands": ["runs --json", "explain <run_id> --json"],
+                    "supporting_files": ["README.md", "docs/operator-model.md"],
+                    "provenance": {
+                        "source": "winsmux public operator contract",
+                        "public_contract_only": true,
+                        "private_skill_body_stored": false,
+                        "private_material_referenced": false
+                    },
+                    "evidence_requirements": ["context_contract", "knowledge_layer", "run_insights"],
+                    "operator_judgement_boundary": "use read models as evidence, not as automatic merge permission"
+                },
+                {
+                    "id": "compare-and-promote",
+                    "metadata": {
+                        "display_name": "Compare and promote",
+                        "purpose": "compare runs and export a reusable follow-up input",
+                        "status": "available",
+                        "review_role": "reviewer"
+                    },
+                    "scope": [
+                        "compare run outputs",
+                        "surface winner evidence",
+                        "prepare follow-up candidate contracts"
+                    ],
+                    "commands": ["compare runs <left_run_id> <right_run_id> --json", "compare promote <run_id> --json"],
+                    "supporting_files": ["docs/operator-model.md"],
+                    "provenance": {
+                        "source": "winsmux compare coordination contract",
+                        "public_contract_only": true,
+                        "private_skill_body_stored": false,
+                        "private_material_referenced": false
+                    },
+                    "evidence_requirements": ["comparison_evidence", "playbook_template_contract", "security_verdict"],
+                    "operator_judgement_boundary": "operator chooses whether the exported candidate should become work"
+                },
+                {
+                    "id": "guarded-release",
+                    "metadata": {
+                        "display_name": "Guarded release",
+                        "purpose": "check release gates before tag or merge automation",
+                        "status": "available",
+                        "review_role": "tester"
+                    },
+                    "scope": [
+                        "collect release gate evidence",
+                        "check public surface safety",
+                        "report publish blockers"
+                    ],
+                    "commands": ["guard --json", "manual-checklist --json", "legacy-compat-gate --json"],
+                    "supporting_files": ["docs/operator-model.md"],
+                    "provenance": {
+                        "source": "winsmux release gate contract",
+                        "public_contract_only": true,
+                        "private_skill_body_stored": false,
+                        "private_material_referenced": false
+                    },
+                    "evidence_requirements": ["git_guard", "public_surface_audit", "manual_validation"],
+                    "operator_judgement_boundary": "operator resolves failed gates before publishing"
+                },
+                {
+                    "id": "provider-routing",
+                    "metadata": {
+                        "display_name": "Provider routing",
+                        "purpose": "inspect provider capability and dry-run assignment decisions",
+                        "status": "available",
+                        "review_role": "operator"
+                    },
+                    "scope": [
+                        "read provider capability",
+                        "check task routing policy",
+                        "explain assignment constraints"
+                    ],
+                    "commands": ["provider-capabilities --json", "assign --task <TASK-ID> --json"],
+                    "supporting_files": ["docs/operator-model.md"],
+                    "provenance": {
+                        "source": "winsmux provider capability contract",
+                        "public_contract_only": true,
+                        "private_skill_body_stored": false,
+                        "private_material_referenced": false
+                    },
+                    "evidence_requirements": ["provider_capability", "task_policy", "approval_policy"],
+                    "operator_judgement_boundary": "operator may override routing when task risk or budget requires it"
+                }
+            ]
+        },
+        "workflow_execution_contract": {
+            "contract_version": 1,
+            "entrypoint": "winsmux skills --json",
+            "execution_model": "operator-mediated workflow pack execution",
+            "private_skill_bodies_allowed": false,
+            "local_absolute_paths_allowed": false,
+            "required_request_fields": ["workflow_pack_id", "task_summary", "evidence_references"],
+            "required_result_fields": ["workflow_pack_id", "status", "evidence", "operator_decision"],
+            "execution_steps": [
+                "select a workflow pack by public id",
+                "collect required evidence from public commands or repository docs",
+                "return a result contract without private bodies or local absolute paths",
+                "leave task split, merge, release, and escalation decisions to the operator"
+            ],
+            "operator_judgement_boundaries": [
+                "operator keeps final task split decisions",
+                "operator keeps final merge and release decisions",
+                "operator keeps human escalation decisions"
+            ],
+            "forbidden_payloads": [
+                "private skill bodies",
+                "local absolute paths",
+                "freeform private guidance"
+            ]
+        },
         "skills": [
             {
                 "id": "run-read-models",

--- a/core/tests-rs/operator_cli.rs
+++ b/core/tests-rs/operator_cli.rs
@@ -1213,6 +1213,71 @@ fn operator_cli_skills_json_exposes_agent_readable_contracts() {
     assert_eq!(json["packet_type"], "progressive_skills_catalog");
     assert_eq!(json["private_skill_bodies_allowed"], false);
     assert_eq!(json["freeform_body_stored"], false);
+    let workflow_pack_ids: Vec<_> = json["workflow_pack_registry"]["packs"]
+        .as_array()
+        .expect("workflow packs should be an array")
+        .iter()
+        .map(|pack| pack["id"].as_str().expect("pack id should be a string"))
+        .collect();
+    let skill_ids: Vec<_> = json["skills"]
+        .as_array()
+        .expect("skills should be an array")
+        .iter()
+        .map(|skill| skill["id"].as_str().expect("skill id should be a string"))
+        .collect();
+    assert_eq!(workflow_pack_ids, skill_ids);
+    assert_eq!(
+        json["workflow_pack_registry"]["private_skill_bodies_allowed"],
+        false
+    );
+    assert_eq!(
+        json["workflow_pack_registry"]["local_absolute_paths_allowed"],
+        false
+    );
+    assert_eq!(
+        json["workflow_pack_registry"]["packs"][1]["id"],
+        "compare-and-promote"
+    );
+    assert_eq!(
+        json["workflow_pack_registry"]["packs"][1]["metadata"]["review_role"],
+        "reviewer"
+    );
+    assert_eq!(
+        json["workflow_pack_registry"]["packs"][1]["scope"][2],
+        "prepare follow-up candidate contracts"
+    );
+    assert_eq!(
+        json["workflow_pack_registry"]["packs"][1]["supporting_files"][0],
+        "docs/operator-model.md"
+    );
+    assert_eq!(
+        json["workflow_pack_registry"]["packs"][1]["provenance"]["private_material_referenced"],
+        false
+    );
+    assert_eq!(
+        json["workflow_pack_registry"]["packs"][1]["evidence_requirements"][1],
+        "playbook_template_contract"
+    );
+    assert_eq!(
+        json["workflow_execution_contract"]["entrypoint"],
+        "winsmux skills --json"
+    );
+    assert_eq!(
+        json["workflow_execution_contract"]["private_skill_bodies_allowed"],
+        false
+    );
+    assert_eq!(
+        json["workflow_execution_contract"]["local_absolute_paths_allowed"],
+        false
+    );
+    assert_eq!(
+        json["workflow_execution_contract"]["required_request_fields"][0],
+        "workflow_pack_id"
+    );
+    assert_eq!(
+        json["workflow_execution_contract"]["operator_judgement_boundaries"][1],
+        "operator keeps final merge and release decisions"
+    );
     assert_eq!(json["skills"][0]["id"], "run-read-models");
     assert_eq!(json["skills"][0]["commands"][0], "runs --json");
     assert_eq!(
@@ -1242,6 +1307,17 @@ fn operator_cli_skills_help_and_command_lists_are_discoverable() {
         .expect("winsmux command should run");
     assert!(output.status.success());
     assert!(String::from_utf8_lossy(&output.stdout).contains("skills"));
+
+    let output = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .arg("skills")
+        .current_dir(&project_dir)
+        .output()
+        .expect("winsmux command should run");
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Workflow packs"));
+    assert!(stdout.contains("Skill contracts"));
+    assert!(stdout.contains("compare-and-promote"));
 }
 
 #[test]

--- a/docs/operator-model.md
+++ b/docs/operator-model.md
@@ -144,6 +144,12 @@ Lifecycle presets are declarative workspace policy. They do not execute arbitrar
 `winsmux compare <runs|preflight|promote>` is the public compare coordination surface.
 It wraps run comparison, merge preflight, and follow-up candidate promotion behind one entrypoint.
 The desktop compare card surfaces shared changed files as hotspots and displays a risk badge before winner selection.
+`winsmux skills [--json]` exposes the public workflow pack registry and execution contract.
+Workflow packs are public-safe descriptors for supported operator workflows.
+They list pack metadata, scope, supporting repository documents, provenance, required evidence, and operator judgement boundaries.
+The catalog is contract-only: it does not expose private skill bodies, private guidance, or local absolute paths.
+Workflow execution remains operator-mediated.
+The contract can identify the workflow pack, required evidence, and expected result fields, but the operator keeps final decisions for task splitting, merge, release, and escalation.
 
 Repository-specific runtime contracts also exist for contributor flows, but they are maintained as contributor documents rather than primary public product docs.
 

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -12419,7 +12419,7 @@ Describe 'winsmux skills command' {
         Mock Invoke-WinsmuxRaw {
             param([string[]]$Arguments)
             $script:skillsArgs = @($Arguments)
-            return '{"packet_type":"progressive_skills_catalog","private_skill_bodies_allowed":false,"skills":[{"id":"compare-and-promote","required_evidence":["comparison_evidence","playbook_template_contract"],"private_skill_body_stored":false}]}'
+            return '{"packet_type":"progressive_skills_catalog","private_skill_bodies_allowed":false,"workflow_pack_registry":{"private_skill_bodies_allowed":false,"local_absolute_paths_allowed":false,"packs":[{"id":"compare-and-promote","metadata":{"review_role":"reviewer"},"scope":["compare run outputs"],"supporting_files":["docs/operator-model.md"],"provenance":{"private_material_referenced":false},"evidence_requirements":["comparison_evidence","playbook_template_contract"]}]},"workflow_execution_contract":{"entrypoint":"winsmux skills --json","private_skill_bodies_allowed":false,"local_absolute_paths_allowed":false,"required_request_fields":["workflow_pack_id"]},"skills":[{"id":"compare-and-promote","required_evidence":["comparison_evidence","playbook_template_contract"],"private_skill_body_stored":false}]}'
         }
 
         $output = Invoke-Skills -SkillsTarget '--json'
@@ -12427,6 +12427,14 @@ Describe 'winsmux skills command' {
         $script:skillsArgs | Should -Be @('skills', '--json')
         $json.packet_type | Should -Be 'progressive_skills_catalog'
         $json.private_skill_bodies_allowed | Should -Be $false
+        $json.workflow_pack_registry.private_skill_bodies_allowed | Should -Be $false
+        $json.workflow_pack_registry.local_absolute_paths_allowed | Should -Be $false
+        $json.workflow_pack_registry.packs[0].id | Should -Be 'compare-and-promote'
+        $json.workflow_pack_registry.packs[0].supporting_files | Should -Contain 'docs/operator-model.md'
+        $json.workflow_pack_registry.packs[0].provenance.private_material_referenced | Should -Be $false
+        $json.workflow_pack_registry.packs[0].evidence_requirements | Should -Contain 'playbook_template_contract'
+        $json.workflow_execution_contract.entrypoint | Should -Be 'winsmux skills --json'
+        $json.workflow_execution_contract.required_request_fields | Should -Contain 'workflow_pack_id'
         $json.skills[0].required_evidence | Should -Contain 'playbook_template_contract'
         $json.skills[0].private_skill_body_stored | Should -Be $false
     }


### PR DESCRIPTION
## Summary
- extend winsmux skills --json with a public workflow pack registry and workflow execution contract
- keep the catalog contract-only with no private skill bodies, private guidance, or local absolute paths
- document the operator-mediated workflow pack boundary in docs/operator-model.md

## Validation
- cargo test --manifest-path core\\Cargo.toml operator_cli_skills
- Invoke-Pester -Path tests\\winsmux-bridge.Tests.ps1 -FullName 'winsmux skills command*'
- cargo run --manifest-path core\\Cargo.toml --bin winsmux -- skills --json
- cargo run --manifest-path core\\Cargo.toml --bin winsmux -- skills
- git diff --check
- pwsh -NoProfile -File scripts\\audit-public-surface.ps1
- pwsh -NoProfile -File scripts\\git-guard.ps1 -Mode full
- push hook: git-guard, audit-public-surface, gitleaks

Subagent evidence:
- read-only TASK-451 explorer identified the minimal boundary as winsmux skills --json catalog expansion
- dedicated worker implemented the slice in .worktrees\\task-451; operator reviewed, adjusted text output and ID-alignment coverage, and revalidated

Closes #857