### PR TITLE
Add scoped workflow pack discovery

### DIFF
--- a/core/src/operator_cli.rs
+++ b/core/src/operator_cli.rs
@@ -285,6 +285,47 @@ fn progressive_skills_catalog() -> Value {
             "public_contract_only": true,
             "private_skill_bodies_allowed": false,
             "local_absolute_paths_allowed": false,
+            "discovery": {
+                "contract_version": 1,
+                "supported_levels": ["builtin", "user", "repository"],
+                "sources": [
+                    {
+                        "level": "builtin",
+                        "source_ref": "winsmux:operator-contract",
+                        "selection_reason": "built in public workflow packs are always available",
+                        "public_contract_only": true,
+                        "private_skill_bodies_allowed": false,
+                        "local_absolute_paths_allowed": false
+                    },
+                    {
+                        "level": "user",
+                        "source_ref": "user-workflow-packs",
+                        "selection_reason": "user-level workflow packs may extend public contracts without exposing local paths or private bodies",
+                        "public_contract_only": true,
+                        "private_skill_bodies_allowed": false,
+                        "local_absolute_paths_allowed": false
+                    },
+                    {
+                        "level": "repository",
+                        "source_ref": "repository-workflow-packs",
+                        "selection_reason": "repository-level workflow packs may describe task-local contracts from tracked contributor or public docs",
+                        "public_contract_only": true,
+                        "private_skill_bodies_allowed": false,
+                        "local_absolute_paths_allowed": false
+                    }
+                ],
+                "selection_policy": [
+                    "prefer repository packs when the task references repository contracts or tracked docs",
+                    "fall back to user packs when no repository pack matches",
+                    "fall back to builtin packs when no user or repository pack matches",
+                    "derive selected_pack_id, selected_level, and selection_reason only after an explicit operator or workflow request"
+                ],
+                "privacy_guards": [
+                    "do not publish private skill bodies",
+                    "do not publish user home paths or repository absolute paths",
+                    "publish only stable source_ref values and tracked relative supporting files"
+                ]
+            },
             "packs": [
                 {
                     "id": "run-read-models",
@@ -381,6 +422,43 @@ fn progressive_skills_catalog() -> Value {
                     },
                     "evidence_requirements": ["provider_capability", "task_policy", "approval_policy"],
                     "operator_judgement_boundary": "operator may override routing when task risk or budget requires it"
+                },
+                {
+                    "id": "repository-skill-discovery",
+                    "metadata": {
+                        "display_name": "Repository skill discovery",
+                        "purpose": "discover user-level and repository-level workflow packs without exposing private material",
+                        "status": "available",
+                        "review_role": "operator"
+                    },
+                    "scope": [
+                        "discover workflow pack source levels",
+                        "select the narrowest matching public contract",
+                        "prepare scoped supporting-file load plans"
+                    ],
+                    "commands": ["skills --json"],
+                    "supporting_files": ["docs/operator-model.md"],
+                    "provenance": {
+                        "source": "winsmux workflow pack discovery contract",
+                        "source_level": "repository",
+                        "source_ref": "repository-workflow-packs",
+                        "public_contract_only": true,
+                        "private_skill_body_stored": false,
+                        "private_material_referenced": false,
+                        "local_absolute_path_stored": false
+                    },
+                    "discovery": {
+                        "available_source_levels": ["user", "repository"],
+                        "selected_level": "repository",
+                        "selection_reason": "repository contracts take precedence when tracked docs define the workflow pack boundary"
+                    },
+                    "loading_plan": {
+                        "minimum_supporting_files": ["docs/operator-model.md"],
+                        "excluded": ["private skill bodies", "local absolute paths", "generated runtime artifacts"],
+                        "public_contract_only": true
+                    },
+                    "evidence_requirements": ["workflow_pack_registry", "discovery_source_metadata", "scoped_loading_plan"],
+                    "operator_judgement_boundary": "operator decides whether discovered packs are sufficient for the current task"
                 }
             ]
         },
@@ -398,6 +476,8 @@ fn progressive_skills_catalog() -> Value {
                 "return a result contract without private bodies or local absolute paths",
                 "leave task split, merge, release, and escalation decisions to the operator"
             ],
+            "selection_result_fields": ["selected_pack_id", "selected_level", "selection_reason", "source_ref"],
+            "scoped_loading_plan_fields": ["selected_pack_id", "minimum_supporting_files", "load_order", "excluded"],
             "operator_judgement_boundaries": [
                 "operator keeps final task split decisions",
                 "operator keeps final merge and release decisions",
@@ -447,6 +527,16 @@ fn progressive_skills_catalog() -> Value {
                 "required_evidence": ["provider_capability", "task_policy", "approval_policy"],
                 "review_role": "operator",
                 "operator_judgement_boundary": "operator may override routing when task risk or budget requires it",
+                "public_contract_only": true,
+                "private_skill_body_stored": false
+            },
+            {
+                "id": "repository-skill-discovery",
+                "purpose": "discover user-level and repository-level workflow packs without exposing private material",
+                "commands": ["skills --json"],
+                "required_evidence": ["workflow_pack_registry", "discovery_source_metadata", "scoped_loading_plan"],
+                "review_role": "operator",
+                "operator_judgement_boundary": "operator decides whether discovered packs are sufficient for the current task",
                 "public_contract_only": true,
                 "private_skill_body_stored": false
             }

--- a/core/tests-rs/operator_cli.rs
+++ b/core/tests-rs/operator_cli.rs
@@ -1235,6 +1235,24 @@ fn operator_cli_skills_json_exposes_agent_readable_contracts() {
         false
     );
     assert_eq!(
+        json["workflow_pack_registry"]["discovery"]["supported_levels"][1],
+        "user"
+    );
+    assert_eq!(
+        json["workflow_pack_registry"]["discovery"]["sources"][2]["level"],
+        "repository"
+    );
+    assert_eq!(
+        json["workflow_pack_registry"]["discovery"]["sources"][2]["source_ref"],
+        "repository-workflow-packs"
+    );
+    assert_eq!(
+        json["workflow_pack_registry"]["discovery"]["sources"][1]["private_skill_bodies_allowed"],
+        false
+    );
+    assert!(json["workflow_pack_registry"].get("selected_pack").is_none());
+    assert!(json["workflow_pack_registry"].get("scoped_loading_plan").is_none());
+    assert_eq!(
         json["workflow_pack_registry"]["packs"][1]["id"],
         "compare-and-promote"
     );
@@ -1286,6 +1304,38 @@ fn operator_cli_skills_json_exposes_agent_readable_contracts() {
     );
     assert_eq!(json["skills"][1]["private_skill_body_stored"], false);
     assert_eq!(json["skills"][2]["review_role"], "tester");
+    let discovery_pack = json["workflow_pack_registry"]["packs"]
+        .as_array()
+        .expect("workflow packs should be an array")
+        .iter()
+        .find(|pack| pack["id"] == "repository-skill-discovery")
+        .expect("repository discovery pack should exist");
+    assert_eq!(
+        discovery_pack["discovery"]["available_source_levels"][0],
+        "user"
+    );
+    assert_eq!(
+        discovery_pack["discovery"]["selection_reason"],
+        "repository contracts take precedence when tracked docs define the workflow pack boundary"
+    );
+    assert_eq!(
+        discovery_pack["provenance"]["local_absolute_path_stored"],
+        false
+    );
+    assert_eq!(
+        discovery_pack["loading_plan"]["minimum_supporting_files"][0],
+        "docs/operator-model.md"
+    );
+    assert_eq!(
+        discovery_pack["evidence_requirements"][2],
+        "scoped_loading_plan"
+    );
+    let catalog_text = serde_json::to_string(&json).expect("catalog should serialize");
+    assert!(!catalog_text.contains("private skill body:"));
+    assert!(!catalog_text.contains("C:\\"));
+    assert!(!catalog_text.contains("C:/"));
+    assert!(!catalog_text.contains("\\Users\\"));
+    assert!(!catalog_text.contains("/Users/"));
 }
 
 #[test]
@@ -5270,7 +5320,9 @@ fn operator_cli_restart_rejects_malformed_provider_registry() {
     let project_dir = make_temp_project_dir("restart-malformed-capability-registry");
     write_manifest(&project_dir);
     fs::write(
-        project_dir.join(".winsmux").join("provider-capabilities.json"),
+        project_dir
+            .join(".winsmux")
+            .join("provider-capabilities.json"),
         "{",
     )
     .expect("test should write malformed provider capability registry");

--- a/docs/operator-model.md
+++ b/docs/operator-model.md
@@ -148,6 +148,11 @@ The desktop compare card surfaces shared changed files as hotspots and displays 
 Workflow packs are public-safe descriptors for supported operator workflows.
 They list pack metadata, scope, supporting repository documents, provenance, required evidence, and operator judgement boundaries.
 The catalog is contract-only: it does not expose private skill bodies, private guidance, or local absolute paths.
+The registry also reports public-safe discovery metadata for built-in, user-level, and repository-level workflow pack sources.
+Those source records use stable `source_ref` values rather than local filesystem paths.
+Each workflow pack can report source level metadata and a selection reason for use after an explicit operator or workflow request.
+The pack-level loading plan lists the minimum supporting files needed for that contract.
+For repository-level skill discovery, the candidate plan loads only `docs/operator-model.md` and explicitly excludes private skill bodies, local absolute paths, and generated runtime artifacts.
 Workflow execution remains operator-mediated.
 The contract can identify the workflow pack, required evidence, and expected result fields, but the operator keeps final decisions for task splitting, merge, release, and escalation.
 

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -12419,7 +12419,7 @@ Describe 'winsmux skills command' {
         Mock Invoke-WinsmuxRaw {
             param([string[]]$Arguments)
             $script:skillsArgs = @($Arguments)
-            return '{"packet_type":"progressive_skills_catalog","private_skill_bodies_allowed":false,"workflow_pack_registry":{"private_skill_bodies_allowed":false,"local_absolute_paths_allowed":false,"packs":[{"id":"compare-and-promote","metadata":{"review_role":"reviewer"},"scope":["compare run outputs"],"supporting_files":["docs/operator-model.md"],"provenance":{"private_material_referenced":false},"evidence_requirements":["comparison_evidence","playbook_template_contract"]}]},"workflow_execution_contract":{"entrypoint":"winsmux skills --json","private_skill_bodies_allowed":false,"local_absolute_paths_allowed":false,"required_request_fields":["workflow_pack_id"]},"skills":[{"id":"compare-and-promote","required_evidence":["comparison_evidence","playbook_template_contract"],"private_skill_body_stored":false}]}'
+            return '{"packet_type":"progressive_skills_catalog","private_skill_bodies_allowed":false,"workflow_pack_registry":{"private_skill_bodies_allowed":false,"local_absolute_paths_allowed":false,"discovery":{"supported_levels":["builtin","user","repository"],"sources":[{"level":"user","source_ref":"user-workflow-packs","private_skill_bodies_allowed":false,"local_absolute_paths_allowed":false},{"level":"repository","source_ref":"repository-workflow-packs","private_skill_bodies_allowed":false,"local_absolute_paths_allowed":false}]},"packs":[{"id":"compare-and-promote","metadata":{"review_role":"reviewer"},"scope":["compare run outputs"],"supporting_files":["docs/operator-model.md"],"provenance":{"private_material_referenced":false},"evidence_requirements":["comparison_evidence","playbook_template_contract"]},{"id":"repository-skill-discovery","metadata":{"review_role":"operator"},"scope":["discover workflow pack source levels"],"supporting_files":["docs/operator-model.md"],"provenance":{"private_material_referenced":false,"local_absolute_path_stored":false},"discovery":{"available_source_levels":["user","repository"],"selected_level":"repository","selection_reason":"repository contracts take precedence when tracked docs define the workflow pack boundary"},"loading_plan":{"minimum_supporting_files":["docs/operator-model.md"],"public_contract_only":true},"evidence_requirements":["workflow_pack_registry","discovery_source_metadata","scoped_loading_plan"]}]},"workflow_execution_contract":{"entrypoint":"winsmux skills --json","private_skill_bodies_allowed":false,"local_absolute_paths_allowed":false,"required_request_fields":["workflow_pack_id"],"selection_result_fields":["selected_pack_id","selected_level","selection_reason","source_ref"],"scoped_loading_plan_fields":["selected_pack_id","minimum_supporting_files","load_order","excluded"]},"skills":[{"id":"compare-and-promote","required_evidence":["comparison_evidence","playbook_template_contract"],"private_skill_body_stored":false},{"id":"repository-skill-discovery","required_evidence":["workflow_pack_registry","discovery_source_metadata","scoped_loading_plan"],"private_skill_body_stored":false}]}'
         }
 
         $output = Invoke-Skills -SkillsTarget '--json'
@@ -12429,14 +12429,29 @@ Describe 'winsmux skills command' {
         $json.private_skill_bodies_allowed | Should -Be $false
         $json.workflow_pack_registry.private_skill_bodies_allowed | Should -Be $false
         $json.workflow_pack_registry.local_absolute_paths_allowed | Should -Be $false
+        $json.workflow_pack_registry.discovery.supported_levels | Should -Contain 'user'
+        $json.workflow_pack_registry.discovery.supported_levels | Should -Contain 'repository'
+        $json.workflow_pack_registry.discovery.sources[1].source_ref | Should -Be 'repository-workflow-packs'
+        $json.workflow_pack_registry.PSObject.Properties.Name | Should -Not -Contain 'selected_pack'
+        $json.workflow_pack_registry.PSObject.Properties.Name | Should -Not -Contain 'scoped_loading_plan'
         $json.workflow_pack_registry.packs[0].id | Should -Be 'compare-and-promote'
         $json.workflow_pack_registry.packs[0].supporting_files | Should -Contain 'docs/operator-model.md'
         $json.workflow_pack_registry.packs[0].provenance.private_material_referenced | Should -Be $false
         $json.workflow_pack_registry.packs[0].evidence_requirements | Should -Contain 'playbook_template_contract'
+        $json.workflow_pack_registry.packs[1].id | Should -Be 'repository-skill-discovery'
+        $json.workflow_pack_registry.packs[1].discovery.selection_reason | Should -Match 'repository contracts'
+        $json.workflow_pack_registry.packs[1].loading_plan.minimum_supporting_files | Should -Be @('docs/operator-model.md')
+        $json.workflow_pack_registry.packs[1].provenance.local_absolute_path_stored | Should -Be $false
         $json.workflow_execution_contract.entrypoint | Should -Be 'winsmux skills --json'
         $json.workflow_execution_contract.required_request_fields | Should -Contain 'workflow_pack_id'
+        $json.workflow_execution_contract.selection_result_fields | Should -Contain 'selection_reason'
+        $json.workflow_execution_contract.scoped_loading_plan_fields | Should -Contain 'minimum_supporting_files'
         $json.skills[0].required_evidence | Should -Contain 'playbook_template_contract'
         $json.skills[0].private_skill_body_stored | Should -Be $false
+        $json.skills[1].required_evidence | Should -Contain 'scoped_loading_plan'
+        ($output -join "`n") | Should -Not -Match 'C:\\'
+        ($output -join "`n") | Should -Not -Match 'C:/'
+        ($output -join "`n") | Should -Not -Match '\\Users\\'
     }
 
     It 'rejects unknown skills arguments' {


### PR DESCRIPTION
## Summary

- extend the workflow pack registry with public-safe builtin, user, and repository discovery metadata
- expose selected pack fields and a scoped loading plan without private skill bodies or local absolute paths
- document the repository/user discovery boundary in the operator model

## Validation

- `cargo test --manifest-path core\Cargo.toml operator_cli_skills`
- `cargo test -p winsmux --test operator_cli operator_cli_skills`
- `pwsh -NoProfile -Command "Invoke-Pester -Path tests\winsmux-bridge.Tests.ps1 -FullName 'winsmux skills command*'"`
- `pwsh -NoProfile -File scripts\audit-public-surface.ps1`
- `pwsh -NoProfile -File scripts\git-guard.ps1 -Mode full`
- `git diff --check`

Closes #860
