### PR TITLE
Add agent work dashboard

### DIFF
--- a/winsmux-app/index.html
+++ b/winsmux-app/index.html
@@ -227,6 +227,7 @@
               <div id="timeline-feed-hint">Key events only. Details open when needed.</div>
             </div>
             <div id="selected-run-summary"></div>
+            <div id="agent-work-dashboard"></div>
             <div id="conversation-timeline" role="log" aria-live="polite" aria-relevant="additions text"></div>
             <form id="composer" autocomplete="off">
               <label class="sr-only" for="composer-input">Message the Operator</label>

--- a/winsmux-app/src-tauri/src/desktop_backend.rs
+++ b/winsmux-app/src-tauri/src/desktop_backend.rs
@@ -379,6 +379,12 @@ pub struct DesktopExplainRun {
     pub review_required: bool,
     pub timeout_policy: String,
     pub handoff_refs: Vec<String>,
+    #[serde(default)]
+    pub draft_pr_gate: Option<DesktopDraftPrGate>,
+    #[serde(default)]
+    pub phase_gate: Option<DesktopPhaseGate>,
+    #[serde(default)]
+    pub safe_trace_refs: Vec<String>,
     pub experiment_packet: DesktopExplainExperimentPacket,
     pub security_policy: Value,
     pub security_verdict: Value,
@@ -388,6 +394,50 @@ pub struct DesktopExplainRun {
     pub changed_files: Vec<String>,
     #[serde(default)]
     pub action_items: Vec<DesktopExplainActionItem>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct DesktopDraftPrGate {
+    #[serde(default)]
+    pub kind: String,
+    #[serde(default)]
+    pub target: String,
+    #[serde(default)]
+    pub state: String,
+    #[serde(default)]
+    pub trigger: String,
+    #[serde(default)]
+    pub draft_pr_url: String,
+    #[serde(default)]
+    pub auto_merge_allowed: bool,
+    #[serde(default)]
+    pub merge_requires_human: bool,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct DesktopPhaseGate {
+    #[serde(default)]
+    pub stage: String,
+    #[serde(default)]
+    pub status: String,
+    #[serde(default)]
+    pub stop_required: bool,
+    #[serde(default)]
+    pub stop_reason: String,
+    #[serde(default)]
+    pub stages: Vec<DesktopPhaseGateStage>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct DesktopPhaseGateStage {
+    #[serde(default)]
+    pub stage: String,
+    #[serde(default)]
+    pub status: String,
+    #[serde(default)]
+    pub reason: String,
+    #[serde(default)]
+    pub event: String,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -930,17 +980,87 @@ pub fn load_desktop_run_explain(
     run_id: String,
     project_dir: Option<String>,
 ) -> Result<DesktopExplainPayload, String> {
-    let payload = transport.request_json(&DesktopCommand::RunExplain {
+    let payload_value = transport.request_json(&DesktopCommand::RunExplain {
         run_id,
         project_dir,
     })?;
-    let payload: DesktopExplainPayload = serde_json::from_value(payload)
+    let safe_trace_refs = collect_safe_desktop_trace_refs(&payload_value);
+    let mut payload: DesktopExplainPayload = serde_json::from_value(payload_value)
         .map_err(|err| format!("Failed to parse desktop explain payload: {err}"))?;
+    payload.run.handoff_refs = filter_safe_desktop_refs(payload.run.handoff_refs);
+    payload.run.safe_trace_refs = safe_trace_refs;
     if let Some(review_state) = payload.review_state.as_ref() {
         validate_desktop_review_state_record(review_state)
             .map_err(|err| format!("Failed to parse desktop explain payload: {err}"))?;
     }
     Ok(payload)
+}
+
+fn collect_safe_desktop_trace_refs(payload: &Value) -> Vec<String> {
+    let mut refs = Vec::new();
+    if let Some(run) = payload.get("run") {
+        collect_string_array_refs(run.pointer("/handoff_refs"), &mut refs);
+        collect_string_ref(run.pointer("/experiment_packet/observation_pack_ref"), &mut refs);
+        collect_string_ref(run.pointer("/experiment_packet/consultation_ref"), &mut refs);
+        collect_string_ref(
+            run.pointer("/checkpoint_package/end_of_run_snapshot/terminal/summary_ref"),
+            &mut refs,
+        );
+        collect_string_array_refs(
+            run.pointer("/checkpoint_package/end_of_run_snapshot/artifacts/summary_refs"),
+            &mut refs,
+        );
+        collect_string_array_refs(
+            run.pointer("/checkpoint_package/end_of_run_snapshot/artifacts/artifact_refs"),
+            &mut refs,
+        );
+        collect_string_array_refs(run.pointer("/team_memory/evidence_note_refs"), &mut refs);
+    }
+
+    filter_safe_desktop_refs(refs)
+}
+
+fn collect_string_array_refs(value: Option<&Value>, refs: &mut Vec<String>) {
+    if let Some(values) = value.and_then(Value::as_array) {
+        for value in values {
+            collect_string_ref(Some(value), refs);
+        }
+    }
+}
+
+fn collect_string_ref(value: Option<&Value>, refs: &mut Vec<String>) {
+    if let Some(value) = value.and_then(Value::as_str) {
+        refs.push(value.to_string());
+    }
+}
+
+fn filter_safe_desktop_refs(refs: Vec<String>) -> Vec<String> {
+    let mut safe_refs = Vec::new();
+    for raw_ref in refs {
+        let normalized = raw_ref.trim().replace('\\', "/");
+        if !is_safe_desktop_ref(&normalized) || safe_refs.contains(&normalized) {
+            continue;
+        }
+        safe_refs.push(normalized);
+    }
+    safe_refs
+}
+
+fn is_safe_desktop_ref(value: &str) -> bool {
+    if value.is_empty()
+        || value.starts_with('/')
+        || value.starts_with('~')
+        || value.starts_with("//")
+        || value.contains("://")
+        || value.contains('\0')
+        || value.split('/').any(|part| part == "..")
+    {
+        return false;
+    }
+    if value.len() >= 2 && value.as_bytes()[1] == b':' {
+        return false;
+    }
+    value.starts_with(".winsmux/") || value.starts_with("docs/") || value.starts_with("tasks/")
 }
 
 #[allow(dead_code)]
@@ -2852,6 +2972,18 @@ mod tests {
             payload.run.handoff_refs,
             vec!["docs/handoff.md".to_string()]
         );
+        assert_eq!(payload.run.draft_pr_gate.as_ref().unwrap().state, "blocked");
+        assert_eq!(
+            payload.run.phase_gate.as_ref().unwrap().stages[0].stage,
+            "plan"
+        );
+        assert!(payload
+            .run
+            .safe_trace_refs
+            .contains(&"docs/handoff.md".to_string()));
+        assert!(payload.run.safe_trace_refs.contains(
+            &".winsmux/observation-packs/observation-pack-__ID__.json".to_string()
+        ));
         assert_eq!(payload.run.experiment_packet.hypothesis, "");
         assert!(payload.run.experiment_packet.test_plan.is_empty());
         assert_eq!(payload.run.experiment_packet.result, "consult before work");
@@ -2975,6 +3107,46 @@ mod tests {
             transport.requests.borrow().as_slice(),
             ["explain task:task-256 --json"]
         );
+    }
+
+    #[test]
+    fn load_desktop_run_explain_scrubs_trace_refs() {
+        let mut response = rust_parity_explain_payload_with_review_state();
+        response["run"]["handoff_refs"] = serde_json::json!([
+            "docs/handoff.md",
+            "C:/Users/example/private.md",
+            "../outside.md"
+        ]);
+        response["run"]["checkpoint_package"]["end_of_run_snapshot"]["terminal"]["summary_ref"] =
+            serde_json::json!(".winsmux/traces/session-summary.md");
+        response["run"]["checkpoint_package"]["end_of_run_snapshot"]["artifacts"]["summary_refs"] =
+            serde_json::json!([
+                ".winsmux/evidence/run-summary.md",
+                "https://example.invalid/private"
+            ]);
+
+        let transport = FakeTransport {
+            requests: RefCell::new(Vec::new()),
+            response,
+        };
+
+        let payload =
+            load_desktop_run_explain(&transport, "task:task-256".to_string(), None).unwrap();
+
+        assert_eq!(payload.run.handoff_refs, vec!["docs/handoff.md".to_string()]);
+        assert!(payload
+            .run
+            .safe_trace_refs
+            .contains(&".winsmux/traces/session-summary.md".to_string()));
+        assert!(payload
+            .run
+            .safe_trace_refs
+            .contains(&".winsmux/evidence/run-summary.md".to_string()));
+        assert!(!payload
+            .run
+            .safe_trace_refs
+            .iter()
+            .any(|value| value.contains("Users") || value.contains("://") || value.contains("..")));
     }
 
     #[test]
@@ -3143,6 +3315,17 @@ mod tests {
                 assert!(result["run"]["security_verdict"].is_null());
                 assert!(result["run"]["verification_contract"].is_null());
                 assert!(result["run"]["verification_result"].is_null());
+                assert_eq!(result["run"]["draft_pr_gate"]["state"], "blocked");
+                assert!(result["run"]["draft_pr_gate"].get("handoff_package").is_none());
+                assert_eq!(
+                    result["run"]["phase_gate"]["stages"][0]["stage"],
+                    "plan"
+                );
+                assert!(result["run"]["safe_trace_refs"]
+                    .as_array()
+                    .expect("safe trace refs should be an array")
+                    .iter()
+                    .any(|value| value.as_str() == Some("docs/handoff.md")));
                 assert_eq!(result["explanation"]["current_state"]["state"], "idle");
                 assert_eq!(
                     result["explanation"]["current_state"]["task_state"],

--- a/winsmux-app/src/desktopClient.ts
+++ b/winsmux-app/src/desktopClient.ts
@@ -276,6 +276,28 @@ export interface DesktopExplainPayload {
     review_required: boolean;
     timeout_policy: string;
     handoff_refs: string[];
+    draft_pr_gate?: {
+      kind?: string;
+      target?: string;
+      state?: string;
+      trigger?: string;
+      draft_pr_url?: string;
+      auto_merge_allowed?: boolean;
+      merge_requires_human?: boolean;
+    } | null;
+    phase_gate?: {
+      stage?: string;
+      status?: string;
+      stop_required?: boolean;
+      stop_reason?: string;
+      stages?: Array<{
+        stage?: string;
+        status?: string;
+        reason?: string;
+        event?: string;
+      }>;
+    } | null;
+    safe_trace_refs?: string[];
     experiment_packet: {
       hypothesis: string;
       test_plan: string[];

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -62,6 +62,22 @@ interface ConversationChip {
 
 type TimelineFilter = "all" | "attention" | "review" | "activity";
 type ConversationCategory = "user" | "attention" | "review" | "activity";
+type WorkPipelineStage = "open" | "triaged" | "planning" | "implementing" | "reviewing" | "shipped";
+
+interface WorkDashboardRecord {
+  projection: DesktopRunProjection;
+  payload: DesktopExplainPayload | null;
+  stage: WorkPipelineStage;
+  issueRef: string;
+  taskRef: string;
+  prRef: string;
+  prUrl: string;
+  reviewRef: string;
+  evidenceRefs: string[];
+  traceRefs: string[];
+  summary: string;
+  tone: SurfaceTone;
+}
 
 interface ConversationDetail {
   label: string;
@@ -1956,6 +1972,193 @@ function getRunProjectionByRunId(runId: string | null) {
 function getPrimaryRunProjection() {
   const resolvedRunId = resolveSelectedRunId();
   return getRunProjectionByRunId(resolvedRunId) ?? getRunProjections()[0] ?? null;
+}
+
+const workPipelineStages: WorkPipelineStage[] = [
+  "open",
+  "triaged",
+  "planning",
+  "implementing",
+  "reviewing",
+  "shipped",
+];
+
+const workPipelineStageLabels: Record<WorkPipelineStage, string> = {
+  open: "Open",
+  triaged: "Triaged",
+  planning: "Planning",
+  implementing: "Implementing",
+  reviewing: "Reviewing",
+  shipped: "Shipped",
+};
+
+const workPipelineStageLabelsJa: Record<WorkPipelineStage, string> = {
+  open: "未着手",
+  triaged: "整理済み",
+  planning: "計画中",
+  implementing: "実装中",
+  reviewing: "レビュー中",
+  shipped: "出荷済み",
+};
+
+function getWorkStageLabel(stage: WorkPipelineStage) {
+  return themeState.language === "ja" ? workPipelineStageLabelsJa[stage] : workPipelineStageLabels[stage];
+}
+
+function getTaskRefForDashboard(projection: DesktopRunProjection, payload: DesktopExplainPayload | null) {
+  if (payload?.run.task_id) {
+    return payload.run.task_id;
+  }
+  if (projection.run_id.startsWith("task:")) {
+    return projection.run_id.slice("task:".length);
+  }
+  return projection.task || projection.run_id || "";
+}
+
+function getIssueRefForDashboard(payload: DesktopExplainPayload | null) {
+  return (
+    payload?.review_state?.request?.review_contract?.issue_ref ||
+    payload?.review_state?.request?.review_contract?.pathspec_policy?.issue_ref ||
+    ""
+  );
+}
+
+function getPrRefForDashboard(payload: DesktopExplainPayload | null) {
+  const gate = payload?.run.draft_pr_gate;
+  const url = gate?.draft_pr_url?.trim() || "";
+  if (url) {
+    const match = url.match(/\/pull\/(\d+)(?:$|[/?#])/);
+    return match ? `#${match[1]}` : url;
+  }
+  if (gate?.state) {
+    return `${gate.target || "draft_pr"} ${gate.state}`;
+  }
+  return "";
+}
+
+function isSafeDashboardFileRef(ref: string) {
+  const normalized = ref.trim().replace(/\\/g, "/");
+  if (
+    !normalized ||
+    normalized.startsWith("/") ||
+    normalized.startsWith("~") ||
+    normalized.startsWith("//") ||
+    normalized.includes("://") ||
+    normalized.split("/").includes("..") ||
+    /^[A-Za-z]:/.test(normalized)
+  ) {
+    return false;
+  }
+  return normalized.startsWith(".winsmux/") || normalized.startsWith("docs/") || normalized.startsWith("tasks/");
+}
+
+function normalizeSafeDashboardRefs(refs: string[]) {
+  const safeRefs: string[] = [];
+  for (const ref of refs) {
+    const normalized = ref.trim().replace(/\\/g, "/");
+    if (!isSafeDashboardFileRef(normalized) || safeRefs.includes(normalized)) {
+      continue;
+    }
+    safeRefs.push(normalized);
+  }
+  return safeRefs;
+}
+
+function getEvidenceRefsForDashboard(projection: DesktopRunProjection, payload: DesktopExplainPayload | null) {
+  return normalizeSafeDashboardRefs([
+    projection.observation_pack_ref,
+    projection.consultation_ref,
+    payload?.run.experiment_packet?.observation_pack_ref || "",
+    payload?.run.experiment_packet?.consultation_ref || "",
+    ...(payload?.evidence_digest.changed_files ?? []),
+  ]);
+}
+
+function getTraceRefsForDashboard(payload: DesktopExplainPayload | null) {
+  return normalizeSafeDashboardRefs([
+    ...(payload?.run.safe_trace_refs ?? []),
+    ...(payload?.run.handoff_refs ?? []),
+  ]);
+}
+
+function getReviewRefForDashboard(projection: DesktopRunProjection, payload: DesktopExplainPayload | null) {
+  const status = payload?.review_state?.status || projection.review_state || "";
+  const reviewer = payload?.review_state?.reviewer?.label || payload?.review_state?.request?.target_review_label || "";
+  return [status, reviewer ? `by ${reviewer}` : ""].filter((value) => value).join(" ");
+}
+
+function getDashboardStage(projection: DesktopRunProjection, payload: DesktopExplainPayload | null): WorkPipelineStage {
+  const phase = (payload?.run.phase || projection.phase || "").toLowerCase();
+  const taskState = (payload?.run.task_state || projection.task_state || "").toLowerCase();
+  const reviewState = (payload?.run.review_state || projection.review_state || "").toUpperCase();
+  const nextAction = (payload?.explanation.next_action || projection.next_action || "").toLowerCase();
+  const activity = (payload?.run.activity || projection.activity || "").toLowerCase();
+  const verification = (payload?.evidence_digest.verification_outcome || projection.verification_outcome || "").toUpperCase();
+  const prGateState = (payload?.run.draft_pr_gate?.state || "").toLowerCase();
+
+  if (
+    nextAction.includes("shipped") ||
+    nextAction.includes("release_done") ||
+    (reviewState === "PASS" && (verification === "PASS" || taskState === "completed" || taskState === "done"))
+  ) {
+    return "shipped";
+  }
+  if (reviewState || phase.includes("review") || nextAction.includes("review") || prGateState === "blocked") {
+    return "reviewing";
+  }
+  if (
+    taskState.includes("progress") ||
+    taskState.includes("commit") ||
+    activity.includes("running") ||
+    activity.includes("working") ||
+    phase.includes("implement")
+  ) {
+    return "implementing";
+  }
+  if (phase.includes("plan") || nextAction.includes("plan") || nextAction.includes("consult")) {
+    return "planning";
+  }
+  if (getIssueRefForDashboard(payload) || getTaskRefForDashboard(projection, payload)) {
+    return "triaged";
+  }
+  return "open";
+}
+
+function getDashboardTone(stage: WorkPipelineStage, projection: DesktopRunProjection, payload: DesktopExplainPayload | null): SurfaceTone {
+  const reviewState = (payload?.run.review_state || projection.review_state || "").toUpperCase();
+  const security = (payload?.evidence_digest.security_blocked || projection.security_blocked || "").toUpperCase();
+  if (security === "BLOCK" || security === "BLOCKED" || reviewState === "FAIL" || reviewState === "FAILED") {
+    return "danger";
+  }
+  if (stage === "shipped") {
+    return "success";
+  }
+  if (stage === "reviewing" || reviewState === "PENDING") {
+    return "warning";
+  }
+  return stage === "implementing" ? "focus" : "info";
+}
+
+function buildWorkDashboardRecords() {
+  return getRunProjections().map((projection): WorkDashboardRecord => {
+    const payload = desktopExplainCache.get(projection.run_id) ?? null;
+    const stage = getDashboardStage(projection, payload);
+    const prUrl = payload?.run.draft_pr_gate?.draft_pr_url?.trim() || "";
+    return {
+      projection,
+      payload,
+      stage,
+      issueRef: getIssueRefForDashboard(payload),
+      taskRef: getTaskRefForDashboard(projection, payload),
+      prRef: getPrRefForDashboard(payload),
+      prUrl,
+      reviewRef: getReviewRefForDashboard(projection, payload),
+      evidenceRefs: getEvidenceRefsForDashboard(projection, payload),
+      traceRefs: getTraceRefsForDashboard(payload),
+      summary: payload?.explanation.summary || projection.summary || projection.task || projection.run_id,
+      tone: getDashboardTone(stage, projection, payload),
+    };
+  });
 }
 
 function getComparePairKey(leftRunId: string, rightRunId: string) {
@@ -8620,6 +8823,143 @@ function renderRunSummary() {
   root.innerHTML = "";
 }
 
+function renderAgentWorkDashboard() {
+  const root = document.getElementById("agent-work-dashboard");
+  if (!root) {
+    return;
+  }
+
+  const records = buildWorkDashboardRecords();
+  if (records.length === 0) {
+    root.hidden = true;
+    root.innerHTML = "";
+    return;
+  }
+
+  const selected = getSelectedRunId();
+  const stageCounts = new Map<WorkPipelineStage, number>();
+  for (const stage of workPipelineStages) {
+    stageCounts.set(stage, 0);
+  }
+  for (const record of records) {
+    stageCounts.set(record.stage, (stageCounts.get(record.stage) ?? 0) + 1);
+  }
+
+  root.hidden = false;
+  root.innerHTML = "";
+
+  const shell = document.createElement("section");
+  shell.className = "work-dashboard";
+  shell.setAttribute("aria-label", getLanguageText("Agent work dashboard", "エージェント作業ダッシュボード"));
+
+  const header = document.createElement("div");
+  header.className = "work-dashboard-header";
+  const title = document.createElement("div");
+  title.innerHTML =
+    `<div class="timeline-eyebrow">${getLanguageText("Issue-to-run pipeline", "Issue から実行まで")}</div>` +
+    `<div class="work-dashboard-title">${getLanguageText("Agent work dashboard", "エージェント作業ダッシュボード")}</div>`;
+  const meta = document.createElement("div");
+  meta.className = "work-dashboard-meta";
+  meta.textContent = getLanguageText(
+    `${records.length} runs · safe evidence refs only`,
+    `${records.length} 件の実行・安全な証跡参照のみ`,
+  );
+  header.append(title, meta);
+  shell.appendChild(header);
+
+  const stageRow = document.createElement("div");
+  stageRow.className = "work-dashboard-stages";
+  for (const stage of workPipelineStages) {
+    const item = document.createElement("div");
+    item.className = "work-dashboard-stage";
+    item.dataset.active = (stageCounts.get(stage) ?? 0) > 0 ? "true" : "false";
+    const label = document.createElement("span");
+    label.textContent = getWorkStageLabel(stage);
+    const count = document.createElement("strong");
+    count.textContent = `${stageCounts.get(stage) ?? 0}`;
+    item.append(label, count);
+    stageRow.appendChild(item);
+  }
+  shell.appendChild(stageRow);
+
+  const list = document.createElement("div");
+  list.className = "work-dashboard-list";
+  for (const record of records.slice(0, 6)) {
+    const row = document.createElement("article");
+    row.className = `work-dashboard-row ${record.projection.run_id === selected ? "is-active" : ""}`;
+    row.dataset.tone = record.tone;
+
+    const rowHeader = document.createElement("div");
+    rowHeader.className = "work-dashboard-row-header";
+    const rowTitle = document.createElement("button");
+    rowTitle.type = "button";
+    rowTitle.className = "work-dashboard-run";
+    rowTitle.textContent = record.projection.run_id;
+    rowTitle.title = getLanguageText("Select run and load explain data", "実行を選択し、説明を読み込みます");
+    rowTitle.addEventListener("click", () => {
+      setSelectedRun(record.projection.run_id);
+      void openExplainForSelectedRun();
+      renderDesktopSurfaces();
+    });
+    const stage = document.createElement("span");
+    stage.className = "work-dashboard-stage-pill";
+    stage.textContent = getWorkStageLabel(record.stage);
+    rowHeader.append(rowTitle, stage);
+    row.appendChild(rowHeader);
+
+    const summary = document.createElement("div");
+    summary.className = "work-dashboard-summary";
+    summary.textContent = record.summary;
+    row.appendChild(summary);
+
+    const links = document.createElement("div");
+    links.className = "work-dashboard-links";
+    const linkItems = [
+      ["issue", record.issueRef || getLanguageText("not linked", "未連携")],
+      ["task", record.taskRef || getLanguageText("not linked", "未連携")],
+      ["PR", record.prRef || getLanguageText("not linked", "未連携")],
+      ["review", record.reviewRef || getLanguageText("not requested", "未依頼")],
+      ["evidence", record.evidenceRefs.length > 0 ? `${record.evidenceRefs.length}` : getLanguageText("none", "なし")],
+      ["trace", record.traceRefs.length > 0 ? `${record.traceRefs.length}` : getLanguageText("none", "なし")],
+    ];
+    for (const [label, value] of linkItems) {
+      const pill = document.createElement("span");
+      pill.className = "work-dashboard-link-pill";
+      const labelElement = document.createElement("span");
+      labelElement.textContent = label;
+      const valueElement = document.createElement("strong");
+      valueElement.textContent = value;
+      pill.append(labelElement, valueElement);
+      if (label === "PR" && record.prUrl) {
+        pill.title = record.prUrl;
+      }
+      links.appendChild(pill);
+    }
+    row.appendChild(links);
+
+    const refRow = document.createElement("div");
+    refRow.className = "work-dashboard-ref-row";
+    for (const ref of [...record.evidenceRefs, ...record.traceRefs].slice(0, 4)) {
+      const refButton = document.createElement("button");
+      refButton.type = "button";
+      refButton.className = "work-dashboard-ref";
+      refButton.textContent = summarizeArtifactRef(ref);
+      refButton.title = ref;
+      refButton.addEventListener("click", () => {
+        void openEditorPath(ref, "");
+      });
+      refRow.appendChild(refButton);
+    }
+    if (refRow.childElementCount > 0) {
+      row.appendChild(refRow);
+    }
+
+    list.appendChild(row);
+  }
+  shell.appendChild(list);
+  root.appendChild(shell);
+}
+
 function renderConversation(items: ConversationItem[]) {
   const timeline = document.getElementById("conversation-timeline");
   if (!timeline) {
@@ -8878,6 +9218,7 @@ async function openExplainForSelectedRun() {
       });
     }
     renderRunSummary();
+    renderAgentWorkDashboard();
     renderContextPanel();
     renderConversation(getConversationItems());
   } catch (error) {
@@ -11826,6 +12167,7 @@ function renderDesktopSurfaces() {
   renderContextPanel();
   renderOpenEditors();
   renderEditorSurface();
+  renderAgentWorkDashboard();
   renderConversation(getConversationItems());
 }
 

--- a/winsmux-app/src/styles.css
+++ b/winsmux-app/src/styles.css
@@ -1442,7 +1442,8 @@ body[data-popout-surface="1"] #editor-surface {
 }
 
 #timeline-toolbar,
-#selected-run-summary {
+#selected-run-summary,
+#agent-work-dashboard {
   padding: 0 20px 12px;
 }
 
@@ -1452,6 +1453,177 @@ body[data-popout-surface="1"] #editor-surface {
 
 #selected-run-summary {
   display: none;
+}
+
+#agent-work-dashboard[hidden] {
+  display: none;
+}
+
+.work-dashboard {
+  border: 1px solid var(--border-muted);
+  border-radius: 8px;
+  background: #232323;
+  padding: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.work-dashboard-header,
+.work-dashboard-row-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.work-dashboard-title {
+  color: var(--text-primary);
+  font-size: var(--text-sm);
+  font-weight: 700;
+}
+
+.work-dashboard-meta {
+  color: var(--text-muted);
+  font-size: var(--text-2xs);
+  white-space: nowrap;
+}
+
+.work-dashboard-stages {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: 6px;
+}
+
+.work-dashboard-stage {
+  min-width: 0;
+  border: 1px solid var(--border-muted);
+  border-radius: 8px;
+  background: var(--bg-panel);
+  color: var(--text-muted);
+  padding: 6px 8px;
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  font-size: var(--text-2xs);
+}
+
+.work-dashboard-stage[data-active="true"] {
+  border-color: var(--status-focus-border);
+  color: var(--text-primary);
+}
+
+.work-dashboard-list {
+  display: grid;
+  gap: 8px;
+}
+
+.work-dashboard-row {
+  min-width: 0;
+  border: 1px solid var(--border-muted);
+  border-radius: 8px;
+  background: var(--bg-surface);
+  padding: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.work-dashboard-row.is-active {
+  border-color: var(--status-focus-border);
+}
+
+.work-dashboard-row[data-tone="success"] {
+  border-color: var(--status-success-border);
+}
+
+.work-dashboard-row[data-tone="warning"] {
+  border-color: var(--status-warning-border);
+}
+
+.work-dashboard-row[data-tone="danger"] {
+  border-color: var(--status-danger-border);
+}
+
+.work-dashboard-run {
+  border: 0;
+  background: transparent;
+  color: var(--text-primary);
+  padding: 0;
+  font: inherit;
+  font-size: var(--text-xs);
+  font-weight: 700;
+  cursor: pointer;
+  text-align: left;
+}
+
+.work-dashboard-run:hover,
+.work-dashboard-run:focus-visible {
+  color: var(--status-focus);
+  outline: none;
+}
+
+.work-dashboard-stage-pill {
+  border: 1px solid var(--border-muted);
+  border-radius: 999px;
+  padding: 4px 8px;
+  color: var(--text-secondary);
+  font-size: var(--text-2xs);
+  white-space: nowrap;
+}
+
+.work-dashboard-summary {
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+  line-height: var(--leading-normal);
+}
+
+.work-dashboard-links,
+.work-dashboard-ref-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.work-dashboard-link-pill {
+  min-width: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border: 1px solid var(--border-muted);
+  border-radius: 999px;
+  background: var(--bg-panel);
+  color: var(--text-secondary);
+  padding: 4px 8px;
+  font-size: var(--text-2xs);
+}
+
+.work-dashboard-link-pill span {
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0;
+}
+
+.work-dashboard-link-pill strong {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.work-dashboard-ref {
+  border: 1px solid var(--border-muted);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-secondary);
+  padding: 4px 7px;
+  font-size: var(--text-2xs);
+  cursor: pointer;
+}
+
+.work-dashboard-ref:hover,
+.work-dashboard-ref:focus-visible {
+  background: var(--bg-panel);
+  color: var(--text-primary);
+  outline: none;
 }
 
 #timeline-filter-row {
@@ -4284,6 +4456,20 @@ body.is-resizing-workbench {
     grid-template-columns: minmax(0, 1fr);
   }
 
+  .work-dashboard-header,
+  .work-dashboard-row-header {
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .work-dashboard-meta {
+    white-space: normal;
+  }
+
+  .work-dashboard-stages {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
   #composer-session-row {
     flex-wrap: wrap;
   }
@@ -4359,7 +4545,8 @@ body.is-resizing-workbench {
   }
 
   #timeline-toolbar,
-  #selected-run-summary {
+  #selected-run-summary,
+  #agent-work-dashboard {
     padding: 0 16px 8px;
   }
 


### PR DESCRIPTION
## Summary

- add a compact agent work dashboard that links runs to task, issue, PR, review, evidence, and trace references
- expose safe trace references and narrowly typed gate fields from the desktop backend
- add responsive dashboard styling and preserve local-path scrubbing for trace refs

## Validation

- `cmd /c npm run build`
- `cargo test --manifest-path winsmux-app\src-tauri\Cargo.toml`
- `cmd /c npm run test:viewport-harness`
- `pwsh -NoProfile -File scripts\audit-public-surface.ps1`
- `pwsh -NoProfile -File scripts\git-guard.ps1 -Mode full`
- `git diff --check`

Closes #861
