### PR TITLE
Fix post-review run contracts

### DIFF
--- a/core/src/operator_cli.rs
+++ b/core/src/operator_cli.rs
@@ -1992,136 +1992,134 @@ fn operator_jobs_create(options: &OperatorJobsOptions) -> io::Result<Value> {
         }
     }
 
-    let mut state = read_operator_jobs_state(&options.project_dir)?;
-    if state.jobs.iter().any(|job| job.job_id == job_id) {
-        return Err(io::Error::new(
-            io::ErrorKind::AlreadyExists,
-            format!("operator job already exists: {job_id}"),
-        ));
-    }
+    let (job, total_jobs) = mutate_operator_jobs_state(&options.project_dir, |state| {
+        if state.jobs.iter().any(|job| job.job_id == job_id) {
+            return Err(io::Error::new(
+                io::ErrorKind::AlreadyExists,
+                format!("operator job already exists: {job_id}"),
+            ));
+        }
 
-    let now = generated_at();
-    let evidence_requirements = operator_job_evidence_requirements(&kind, &options.evidence);
-    let job = OperatorJobRecord {
-        job_id: job_id.to_string(),
-        kind: kind.clone(),
-        title: options
-            .title
-            .clone()
-            .unwrap_or_else(|| operator_job_default_title(&kind).to_string()),
-        status: "scheduled".to_string(),
-        schedule: OperatorJobSchedule {
-            schedule_type,
-            every: options.every.clone(),
-        },
-        evidence_requirements,
-        command_plan: OperatorJobCommandPlan {
-            workflow_kind: kind,
-            execution_backend: "operator_managed".to_string(),
-            destructive_change_possible: options.destructive,
-            side_effect_policy: if options.destructive {
-                "record_pending_approval_only".to_string()
-            } else {
-                "evidence_only".to_string()
+        let now = generated_at();
+        let evidence_requirements = operator_job_evidence_requirements(&kind, &options.evidence);
+        let job = OperatorJobRecord {
+            job_id: job_id.to_string(),
+            kind: kind.clone(),
+            title: options
+                .title
+                .clone()
+                .unwrap_or_else(|| operator_job_default_title(&kind).to_string()),
+            status: "scheduled".to_string(),
+            schedule: OperatorJobSchedule {
+                schedule_type,
+                every: options.every.clone(),
             },
-        },
-        approval_policy: OperatorJobApprovalPolicy {
-            destructive_changes_require_explicit_approval: true,
-            auto_execute_destructive_changes: false,
-        },
-        created_at: now.clone(),
-        updated_at: now,
-        pending_update: None,
-        runs: Vec::new(),
-    };
-    state.jobs.push(job.clone());
-    write_operator_jobs_state(&options.project_dir, &mut state)?;
+            evidence_requirements,
+            command_plan: OperatorJobCommandPlan {
+                workflow_kind: kind,
+                execution_backend: "operator_managed".to_string(),
+                destructive_change_possible: options.destructive,
+                side_effect_policy: if options.destructive {
+                    "record_pending_approval_only".to_string()
+                } else {
+                    "evidence_only".to_string()
+                },
+            },
+            approval_policy: OperatorJobApprovalPolicy {
+                destructive_changes_require_explicit_approval: true,
+                auto_execute_destructive_changes: false,
+            },
+            created_at: now.clone(),
+            updated_at: now,
+            pending_update: None,
+            runs: Vec::new(),
+        };
+        state.jobs.push(job.clone());
+        Ok((job, state.jobs.len()))
+    })?;
 
     Ok(operator_jobs_result_payload(
         "create",
         format!("created operator job {job_id}"),
         Some(job),
         None,
-        state.jobs.len(),
+        total_jobs,
     ))
 }
 
 fn operator_jobs_start_run(options: &OperatorJobsOptions) -> io::Result<Value> {
     let job_id = required_option(options.job_id.as_deref(), "run requires <job_id>")?;
-    let mut state = read_operator_jobs_state(&options.project_dir)?;
-    let job = find_operator_job_mut(&mut state, job_id)?;
-    if job.status == "paused" || job.status == "delete_pending_approval" {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidInput,
-            format!("operator job {job_id} is not runnable while status is {}", job.status),
-        ));
-    }
-    let run_number = job.runs.len() as u32 + 1;
-    let run_id = format!("operator-job:{job_id}:{run_number}");
-    let destructive = job.command_plan.destructive_change_possible || options.destructive;
-    let evidence = operator_job_run_evidence(job, &options.evidence);
-    let run = OperatorJobRunRecord {
-        run_id,
-        run_number,
-        status: if destructive {
-            "approval_pending".to_string()
-        } else {
-            "evidence_recorded".to_string()
-        },
-        started_at: generated_at(),
-        fresh_record: true,
-        evidence,
-        approval_gate: OperatorJobApprovalGate {
-            required: destructive,
-            state: if destructive {
-                "pending_operator_approval".to_string()
+    let (job, run, total_jobs) = mutate_operator_jobs_state(&options.project_dir, |state| {
+        let job = find_operator_job_mut(state, job_id)?;
+        if job.status == "paused" || job.status == "delete_pending_approval" {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("operator job {job_id} is not runnable while status is {}", job.status),
+            ));
+        }
+        let run_number = job.runs.len() as u32 + 1;
+        let run_id = format!("operator-job:{job_id}:{run_number}");
+        let destructive = job.command_plan.destructive_change_possible || options.destructive;
+        let evidence = operator_job_run_evidence(job, &options.evidence);
+        let run = OperatorJobRunRecord {
+            run_id,
+            run_number,
+            status: if destructive {
+                "approval_pending".to_string()
             } else {
-                "not_required".to_string()
+                "evidence_recorded".to_string()
             },
-            destructive_change: destructive,
-            approved_by: None,
-            approved_at: None,
-            reason: options
-                .reason
-                .clone()
-                .unwrap_or_else(|| "destructive changes are represented only as pending approval".to_string()),
-        },
-    };
-    job.updated_at = generated_at();
-    job.runs.push(run.clone());
-    let job = job.clone();
-    write_operator_jobs_state(&options.project_dir, &mut state)?;
+            started_at: generated_at(),
+            fresh_record: true,
+            evidence,
+            approval_gate: OperatorJobApprovalGate {
+                required: destructive,
+                state: if destructive {
+                    "pending_operator_approval".to_string()
+                } else {
+                    "not_required".to_string()
+                },
+                destructive_change: destructive,
+                approved_by: None,
+                approved_at: None,
+                reason: options.reason.clone().unwrap_or_else(|| {
+                    "destructive changes are represented only as pending approval".to_string()
+                }),
+            },
+        };
+        job.updated_at = generated_at();
+        job.runs.push(run.clone());
+        Ok((job.clone(), run, state.jobs.len()))
+    })?;
 
     Ok(operator_jobs_result_payload(
         "run",
         format!("started fresh run record for {job_id}"),
         Some(job),
         Some(run),
-        state.jobs.len(),
+        total_jobs,
     ))
 }
 
 fn operator_jobs_pause(options: &OperatorJobsOptions) -> io::Result<Value> {
     let job_id = required_option(options.job_id.as_deref(), "pause requires <job_id>")?;
-    let mut state = read_operator_jobs_state(&options.project_dir)?;
-    let job = find_operator_job_mut(&mut state, job_id)?;
-    job.status = "paused".to_string();
-    job.updated_at = generated_at();
-    let job = job.clone();
-    write_operator_jobs_state(&options.project_dir, &mut state)?;
+    let (job, total_jobs) = mutate_operator_jobs_state(&options.project_dir, |state| {
+        let job = find_operator_job_mut(state, job_id)?;
+        job.status = "paused".to_string();
+        job.updated_at = generated_at();
+        Ok((job.clone(), state.jobs.len()))
+    })?;
     Ok(operator_jobs_result_payload(
         "pause",
         format!("paused operator job {job_id}"),
         Some(job),
         None,
-        state.jobs.len(),
+        total_jobs,
     ))
 }
 
 fn operator_jobs_update(options: &OperatorJobsOptions) -> io::Result<Value> {
     let job_id = required_option(options.job_id.as_deref(), "update requires <job_id>")?;
-    let mut state = read_operator_jobs_state(&options.project_dir)?;
-    let job = find_operator_job_mut(&mut state, job_id)?;
     let mut update = Map::new();
     if let Some(title) = options.title.as_deref() {
         update.insert("title".to_string(), json!(title));
@@ -2139,66 +2137,72 @@ fn operator_jobs_update(options: &OperatorJobsOptions) -> io::Result<Value> {
         ));
     }
 
-    if options.destructive {
-        job.status = "update_pending_approval".to_string();
+    let (job, total_jobs) = mutate_operator_jobs_state(&options.project_dir, |state| {
+        let job = find_operator_job_mut(state, job_id)?;
+        if options.destructive {
+            job.status = "update_pending_approval".to_string();
+            job.pending_update = Some(json!({
+                "requested_at": generated_at(),
+                "changes": update,
+                "approval_gate": {
+                    "required": true,
+                    "state": "pending_operator_approval",
+                    "destructive_change": true,
+                    "approved_by": null,
+                    "approved_at": null,
+                    "reason": options.reason.clone().unwrap_or_else(|| "destructive job update requires explicit approval".to_string())
+                }
+            }));
+        } else {
+            apply_operator_job_update(job, &update)?;
+        }
+        job.updated_at = generated_at();
+        Ok((job.clone(), state.jobs.len()))
+    })?;
+    Ok(operator_jobs_result_payload(
+        "update",
+        format!("updated operator job {job_id}"),
+        Some(job),
+        None,
+        total_jobs,
+    ))
+}
+
+fn operator_jobs_delete(options: &OperatorJobsOptions) -> io::Result<Value> {
+    let job_id = required_option(options.job_id.as_deref(), "delete requires <job_id>")?;
+    let (job, total_jobs) = mutate_operator_jobs_state(&options.project_dir, |state| {
+        let job = find_operator_job_mut(state, job_id)?;
+        job.status = "delete_pending_approval".to_string();
         job.pending_update = Some(json!({
             "requested_at": generated_at(),
-            "changes": update,
+            "delete_requested": true,
             "approval_gate": {
                 "required": true,
                 "state": "pending_operator_approval",
                 "destructive_change": true,
                 "approved_by": null,
                 "approved_at": null,
-                "reason": options.reason.clone().unwrap_or_else(|| "destructive job update requires explicit approval".to_string())
+                "reason": options.reason.clone().unwrap_or_else(|| "operator job delete is soft pending approval".to_string())
             }
         }));
-    } else {
-        apply_operator_job_update(job, &update)?;
-    }
-    job.updated_at = generated_at();
-    let job = job.clone();
-    write_operator_jobs_state(&options.project_dir, &mut state)?;
-    Ok(operator_jobs_result_payload(
-        "update",
-        format!("updated operator job {job_id}"),
-        Some(job),
-        None,
-        state.jobs.len(),
-    ))
-}
-
-fn operator_jobs_delete(options: &OperatorJobsOptions) -> io::Result<Value> {
-    let job_id = required_option(options.job_id.as_deref(), "delete requires <job_id>")?;
-    let mut state = read_operator_jobs_state(&options.project_dir)?;
-    let job = find_operator_job_mut(&mut state, job_id)?;
-    job.status = "delete_pending_approval".to_string();
-    job.pending_update = Some(json!({
-        "requested_at": generated_at(),
-        "delete_requested": true,
-        "approval_gate": {
-            "required": true,
-            "state": "pending_operator_approval",
-            "destructive_change": true,
-            "approved_by": null,
-            "approved_at": null,
-            "reason": options.reason.clone().unwrap_or_else(|| "operator job delete is soft pending approval".to_string())
-        }
-    }));
-    job.updated_at = generated_at();
-    let job = job.clone();
-    write_operator_jobs_state(&options.project_dir, &mut state)?;
+        job.updated_at = generated_at();
+        Ok((job.clone(), state.jobs.len()))
+    })?;
     Ok(operator_jobs_result_payload(
         "delete",
         format!("recorded delete approval request for {job_id}"),
         Some(job),
         None,
-        state.jobs.len(),
+        total_jobs,
     ))
 }
 
 fn read_operator_jobs_state(project_dir: &Path) -> io::Result<OperatorJobsState> {
     let path = operator_jobs_state_path(project_dir);
+    read_operator_jobs_state_from_path(&path)
+}
+
+fn read_operator_jobs_state_from_path(path: &Path) -> io::Result<OperatorJobsState> {
     if !path.exists() {
         return Ok(default_operator_jobs_state());
     }
@@ -2222,7 +2226,23 @@ fn read_operator_jobs_state(project_dir: &Path) -> io::Result<OperatorJobsState>
     Ok(state)
 }
 
-fn write_operator_jobs_state(project_dir: &Path, state: &mut OperatorJobsState) -> io::Result<()> {
+fn mutate_operator_jobs_state<T>(
+    project_dir: &Path,
+    action: impl FnOnce(&mut OperatorJobsState) -> io::Result<T>,
+) -> io::Result<T> {
+    let path = operator_jobs_state_path(project_dir);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    with_file_lock(&path, || {
+        let mut state = read_operator_jobs_state_from_path(&path)?;
+        let result = action(&mut state)?;
+        write_operator_jobs_state_locked(&path, &mut state)?;
+        Ok(result)
+    })
+}
+
+fn write_operator_jobs_state_locked(path: &Path, state: &mut OperatorJobsState) -> io::Result<()> {
     state.updated_at = generated_at();
     let content = serde_json::to_string_pretty(state).map_err(|err| {
         io::Error::new(
@@ -2230,7 +2250,7 @@ fn write_operator_jobs_state(project_dir: &Path, state: &mut OperatorJobsState) 
             format!("failed to serialize operator jobs state: {err}"),
         )
     })?;
-    write_text_file_with_lock(&operator_jobs_state_path(project_dir), &format!("{content}\n"))
+    write_text_file_locked(path, &format!("{content}\n"))
 }
 
 fn default_operator_jobs_state() -> OperatorJobsState {

--- a/core/tests-rs/operator_cli.rs
+++ b/core/tests-rs/operator_cli.rs
@@ -339,6 +339,101 @@ fn operator_cli_operator_jobs_create_and_run_records_fresh_approval_pending() {
 }
 
 #[test]
+fn operator_cli_operator_jobs_run_reads_state_under_the_write_lock() {
+    let project_dir = make_temp_project_dir("operator-jobs-run-lock");
+
+    run_json(
+        &project_dir,
+        &[
+            "operator-jobs",
+            "create",
+            "deps-weekly",
+            "--kind",
+            "dependency-check",
+            "--schedule",
+            "recurring",
+            "--every",
+            "weekly",
+            "--json",
+        ],
+    );
+
+    let state_path = project_dir.join(".winsmux").join("operator-jobs.json");
+    let mut lock_os = state_path.as_os_str().to_os_string();
+    lock_os.push(".lock");
+    let lock_path = std::path::PathBuf::from(lock_os);
+    fs::create_dir_all(&lock_path).expect("test should hold operator jobs lock");
+    fs::write(
+        lock_path.join("owner.json"),
+        format!(
+            r#"{{"pid":{},"started_at":"2026-01-01T00:00:00Z"}}"#,
+            std::process::id()
+        ),
+    )
+    .expect("test should write lock owner");
+
+    let child = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .args(["operator-jobs", "run", "deps-weekly", "--json"])
+        .current_dir(&project_dir)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("winsmux command should start while lock is held");
+
+    std::thread::sleep(Duration::from_millis(250));
+
+    let mut state = read_json_file(&state_path);
+    state["jobs"][0]["runs"]
+        .as_array_mut()
+        .expect("runs should be an array")
+        .push(serde_json::json!({
+            "run_id": "operator-job:deps-weekly:1",
+            "run_number": 1,
+            "status": "evidence_recorded",
+            "started_at": "2026-01-01T00:00:01Z",
+            "fresh_record": true,
+            "evidence": [],
+            "approval_gate": {
+                "required": false,
+                "state": "not_required",
+                "destructive_change": false,
+                "approved_by": null,
+                "approved_at": null,
+                "reason": "manual concurrent state update"
+            }
+        }));
+    fs::write(
+        &state_path,
+        format!(
+            "{}\n",
+            serde_json::to_string_pretty(&state).expect("state should serialize")
+        ),
+    )
+    .expect("test should update operator jobs state while lock is held");
+    fs::remove_dir_all(&lock_path).expect("test should release operator jobs lock");
+
+    let output = child
+        .wait_with_output()
+        .expect("winsmux command should finish");
+    assert!(
+        output.status.success(),
+        "winsmux command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let run: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("stdout should be JSON");
+    assert_eq!(run["run"]["run_number"], 2);
+
+    let state = read_json_file(&state_path);
+    let runs = state["jobs"][0]["runs"]
+        .as_array()
+        .expect("runs should be an array");
+    assert_eq!(runs.len(), 2);
+    assert_eq!(runs[0]["run_number"], 1);
+    assert_eq!(runs[1]["run_number"], 2);
+}
+
+#[test]
 fn operator_cli_operator_jobs_pause_update_delete_keeps_destructive_delete_pending() {
     let project_dir = make_temp_project_dir("operator-jobs-update-delete");
 
@@ -1401,8 +1496,12 @@ fn operator_cli_skills_json_exposes_agent_readable_contracts() {
         json["workflow_pack_registry"]["discovery"]["sources"][1]["private_skill_bodies_allowed"],
         false
     );
-    assert!(json["workflow_pack_registry"].get("selected_pack").is_none());
-    assert!(json["workflow_pack_registry"].get("scoped_loading_plan").is_none());
+    assert!(json["workflow_pack_registry"]
+        .get("selected_pack")
+        .is_none());
+    assert!(json["workflow_pack_registry"]
+        .get("scoped_loading_plan")
+        .is_none());
     assert_eq!(
         json["workflow_pack_registry"]["packs"][1]["id"],
         "compare-and-promote"

--- a/winsmux-app/src-tauri/src/desktop_backend.rs
+++ b/winsmux-app/src-tauri/src/desktop_backend.rs
@@ -419,7 +419,11 @@ pub struct DesktopPhaseGate {
     #[serde(default)]
     pub stage: String,
     #[serde(default)]
+    pub current_stage: String,
+    #[serde(default)]
     pub status: String,
+    #[serde(default)]
+    pub order: Vec<String>,
     #[serde(default)]
     pub stop_required: bool,
     #[serde(default)]
@@ -1000,8 +1004,14 @@ fn collect_safe_desktop_trace_refs(payload: &Value) -> Vec<String> {
     let mut refs = Vec::new();
     if let Some(run) = payload.get("run") {
         collect_string_array_refs(run.pointer("/handoff_refs"), &mut refs);
-        collect_string_ref(run.pointer("/experiment_packet/observation_pack_ref"), &mut refs);
-        collect_string_ref(run.pointer("/experiment_packet/consultation_ref"), &mut refs);
+        collect_string_ref(
+            run.pointer("/experiment_packet/observation_pack_ref"),
+            &mut refs,
+        );
+        collect_string_ref(
+            run.pointer("/experiment_packet/consultation_ref"),
+            &mut refs,
+        );
         collect_string_ref(
             run.pointer("/checkpoint_package/end_of_run_snapshot/terminal/summary_ref"),
             &mut refs,
@@ -2977,13 +2987,28 @@ mod tests {
             payload.run.phase_gate.as_ref().unwrap().stages[0].stage,
             "plan"
         );
+        assert_eq!(
+            payload.run.phase_gate.as_ref().unwrap().current_stage,
+            "review"
+        );
+        assert_eq!(
+            payload.run.phase_gate.as_ref().unwrap().order,
+            vec![
+                "plan".to_string(),
+                "build".to_string(),
+                "test".to_string(),
+                "review".to_string(),
+                "package".to_string()
+            ]
+        );
         assert!(payload
             .run
             .safe_trace_refs
             .contains(&"docs/handoff.md".to_string()));
-        assert!(payload.run.safe_trace_refs.contains(
-            &".winsmux/observation-packs/observation-pack-__ID__.json".to_string()
-        ));
+        assert!(payload
+            .run
+            .safe_trace_refs
+            .contains(&".winsmux/observation-packs/observation-pack-__ID__.json".to_string()));
         assert_eq!(payload.run.experiment_packet.hypothesis, "");
         assert!(payload.run.experiment_packet.test_plan.is_empty());
         assert_eq!(payload.run.experiment_packet.result, "consult before work");
@@ -3133,7 +3158,10 @@ mod tests {
         let payload =
             load_desktop_run_explain(&transport, "task:task-256".to_string(), None).unwrap();
 
-        assert_eq!(payload.run.handoff_refs, vec!["docs/handoff.md".to_string()]);
+        assert_eq!(
+            payload.run.handoff_refs,
+            vec!["docs/handoff.md".to_string()]
+        );
         assert!(payload
             .run
             .safe_trace_refs
@@ -3316,11 +3344,12 @@ mod tests {
                 assert!(result["run"]["verification_contract"].is_null());
                 assert!(result["run"]["verification_result"].is_null());
                 assert_eq!(result["run"]["draft_pr_gate"]["state"], "blocked");
-                assert!(result["run"]["draft_pr_gate"].get("handoff_package").is_none());
-                assert_eq!(
-                    result["run"]["phase_gate"]["stages"][0]["stage"],
-                    "plan"
-                );
+                assert!(result["run"]["draft_pr_gate"]
+                    .get("handoff_package")
+                    .is_none());
+                assert_eq!(result["run"]["phase_gate"]["stages"][0]["stage"], "plan");
+                assert_eq!(result["run"]["phase_gate"]["current_stage"], "review");
+                assert_eq!(result["run"]["phase_gate"]["order"][3], "review");
                 assert!(result["run"]["safe_trace_refs"]
                     .as_array()
                     .expect("safe trace refs should be an array")


### PR DESCRIPTION
## Summary
- Preserve `phase_gate.current_stage` and `phase_gate.order` in desktop run explain JSON-RPC payloads.
- Serialize `operator-jobs` create/run/update/delete as one locked read-modify-write section.
- Add a process-level `operator-jobs` lock test that preserves concurrent state updates.

## Validation
- `cargo test -p winsmux --test operator_cli operator_jobs`
- `cargo test --manifest-path winsmux-app\src-tauri\Cargo.toml load_desktop_run_explain`
- `cargo test --manifest-path core\Cargo.toml operator_cli`
- `git diff --check`
- `pwsh -NoProfile -File scripts\audit-public-surface.ps1`
- `pwsh -NoProfile -File scripts\git-guard.ps1 -Mode full`

Closes #868
Closes #869
