### PR TITLE
Add public release surface gate

### DIFF
--- a/.github/workflows/release-core.yml
+++ b/.github/workflows/release-core.yml
@@ -40,6 +40,9 @@ jobs:
         with:
           fetch-depth: 0
       - uses: actions/download-artifact@v8
+      - name: Bootstrap repo hooks
+        shell: pwsh
+        run: ./scripts/bootstrap-git-guard.ps1
       - name: Create Release Assets
         run: |
           mkdir -p release
@@ -49,6 +52,9 @@ jobs:
       - name: Generate Release Body
         shell: pwsh
         run: ./scripts/generate-release-notes.ps1 -Version "${{ github.ref_name }}" -OutputPath "release/release-body.md"
+      - name: Audit Release Public Surface
+        shell: pwsh
+        run: ./scripts/audit-public-surface.ps1 -ReleaseNotesPath "release/release-body.md"
       - uses: softprops/action-gh-release@v3
         with:
           body_path: release/release-body.md

--- a/core/docs/configuration.md
+++ b/core/docs/configuration.md
@@ -47,7 +47,7 @@ set -g cursor-blink on
 # Scrollback history
 set -g history-limit 5000
 
-# Prediction dimming (disable for apps like Neovim)
+# Prediction dimming (disable for full-screen terminal editors)
 set -g prediction-dimming off
 
 # Key bindings

--- a/core/docs/faq.md
+++ b/core/docs/faq.md
@@ -4,7 +4,7 @@
 A: No. winsmux is built exclusively for Windows using the Windows ConPTY API. For Linux/macOS, use tmux. winsmux is the Windows counterpart.
 
 **Q: Does winsmux work with Windows Terminal?**
-A: Yes! winsmux works great with Windows Terminal, PowerShell, cmd.exe, ConEmu, and other Windows terminal emulators.
+A: Yes! winsmux works great with Windows Terminal, PowerShell, cmd.exe, and other Windows terminal emulators.
 
 **Q: Why use winsmux instead of Windows Terminal tabs?**
 A: winsmux offers session persistence (detach/reattach), synchronized input to multiple panes, full tmux command scripting, hooks, format engine, and tmux-compatible keybindings. Windows Terminal tabs can't do any of that.

--- a/scripts/audit-public-surface.ps1
+++ b/scripts/audit-public-surface.ps1
@@ -1,5 +1,7 @@
 [CmdletBinding()]
-param()
+param(
+    [string]$ReleaseNotesPath = ''
+)
 
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
@@ -49,6 +51,15 @@ function Test-IsPublicDoc {
     )
 }
 
+function Test-IsExternalProductReferenceAuditSurface {
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    $normalized = $Path.Replace('\', '/')
+    if (Test-IsPublicDoc -Path $Path) { return $true }
+    if ($normalized -match '^docs/[^/]+\.md$') { return $true }
+    return $normalized -match '^core/docs/.+\.md$'
+}
+
 function Test-IsTrackedTextSurface {
     param([Parameter(Mandatory = $true)][string]$Path)
 
@@ -83,6 +94,62 @@ function Test-IsMaintainerIdentityScanSurface {
         return $false
     }
     return Test-IsTrackedTextSurface -Path $Path
+}
+
+function Get-ForbiddenExternalProductReferencePatterns {
+    return @(
+        [pscustomobject]@{ Name = 'Visual Studio Code'; Pattern = '(?i)(?<![A-Za-z0-9])Visual Studio Code(?![A-Za-z0-9])' },
+        [pscustomobject]@{ Name = 'VS Code'; Pattern = '(?i)(?<![A-Za-z0-9])VS Code(?![A-Za-z0-9])' },
+        [pscustomobject]@{ Name = 'vscode'; Pattern = '(?i)(?<![A-Za-z0-9])vscode(?![A-Za-z0-9])' },
+        [pscustomobject]@{ Name = 'Cursor'; Pattern = '(?i)(?<![A-Za-z0-9])Cursor(?:[- ](?:AI|agent|editor|IDE|workbench)| style workbench)(?![A-Za-z0-9])' },
+        [pscustomobject]@{ Name = 'Windsurf'; Pattern = '(?i)(?<![A-Za-z0-9])Windsurf(?![A-Za-z0-9])' },
+        [pscustomobject]@{ Name = 'JetBrains'; Pattern = '(?i)(?<![A-Za-z0-9])JetBrains(?![A-Za-z0-9])' },
+        [pscustomobject]@{ Name = 'IntelliJ'; Pattern = '(?i)(?<![A-Za-z0-9])IntelliJ(?![A-Za-z0-9])' },
+        [pscustomobject]@{ Name = 'WebStorm'; Pattern = '(?i)(?<![A-Za-z0-9])WebStorm(?![A-Za-z0-9])' },
+        [pscustomobject]@{ Name = 'PyCharm'; Pattern = '(?i)(?<![A-Za-z0-9])PyCharm(?![A-Za-z0-9])' },
+        [pscustomobject]@{ Name = 'Rider'; Pattern = '(?<![A-Za-z0-9])Rider(?![A-Za-z0-9])' },
+        [pscustomobject]@{ Name = 'CLion'; Pattern = '(?i)(?<![A-Za-z0-9])CLion(?![A-Za-z0-9])' },
+        [pscustomobject]@{ Name = 'GoLand'; Pattern = '(?i)(?<![A-Za-z0-9])GoLand(?![A-Za-z0-9])' },
+        [pscustomobject]@{ Name = 'PhpStorm'; Pattern = '(?i)(?<![A-Za-z0-9])PhpStorm(?![A-Za-z0-9])' },
+        [pscustomobject]@{ Name = 'Android Studio'; Pattern = '(?i)(?<![A-Za-z0-9])Android Studio(?![A-Za-z0-9])' },
+        [pscustomobject]@{ Name = 'Eclipse'; Pattern = '(?<![A-Za-z0-9])Eclipse(?![A-Za-z0-9])' },
+        [pscustomobject]@{ Name = 'NetBeans'; Pattern = '(?i)(?<![A-Za-z0-9])NetBeans(?![A-Za-z0-9])' },
+        [pscustomobject]@{ Name = 'Zed'; Pattern = '(?<![A-Za-z0-9])Zed(?![A-Za-z0-9])' },
+        [pscustomobject]@{ Name = 'Sublime Text'; Pattern = '(?i)(?<![A-Za-z0-9])Sublime Text(?![A-Za-z0-9])' },
+        [pscustomobject]@{ Name = 'Neovim'; Pattern = '(?i)(?<![A-Za-z0-9])Neovim(?![A-Za-z0-9])' },
+        [pscustomobject]@{ Name = 'Warp'; Pattern = '(?<![A-Za-z0-9])Warp(?![A-Za-z0-9])' },
+        [pscustomobject]@{ Name = 'WezTerm'; Pattern = '(?i)(?<![A-Za-z0-9])WezTerm(?![A-Za-z0-9])' },
+        [pscustomobject]@{ Name = 'Alacritty'; Pattern = '(?i)(?<![A-Za-z0-9])Alacritty(?![A-Za-z0-9])' },
+        [pscustomobject]@{ Name = 'iTerm2'; Pattern = '(?i)(?<![A-Za-z0-9])iTerm2(?![A-Za-z0-9])' },
+        [pscustomobject]@{ Name = 'Hyper terminal'; Pattern = '(?i)(?<![A-Za-z0-9])Hyper terminal(?![A-Za-z0-9])' },
+        [pscustomobject]@{ Name = 'Tabby'; Pattern = '(?i)(?<![A-Za-z0-9])Tabby(?![A-Za-z0-9])' },
+        [pscustomobject]@{ Name = 'ConEmu'; Pattern = '(?i)(?<![A-Za-z0-9])ConEmu(?![A-Za-z0-9])' },
+        [pscustomobject]@{ Name = 'Cmder'; Pattern = '(?i)(?<![A-Za-z0-9])Cmder(?![A-Za-z0-9])' },
+        [pscustomobject]@{ Name = 'OpenHands'; Pattern = '(?i)(?<![A-Za-z0-9])OpenHands(?![A-Za-z0-9])' },
+        [pscustomobject]@{ Name = 'Devin'; Pattern = '(?<![A-Za-z0-9])Devin(?![A-Za-z0-9])' },
+        [pscustomobject]@{ Name = 'Cline'; Pattern = '(?i)(?<![A-Za-z0-9])Cline(?![A-Za-z0-9])' },
+        [pscustomobject]@{ Name = 'Roo Code'; Pattern = '(?i)(?<![A-Za-z0-9])Roo Code(?![A-Za-z0-9])' }
+    )
+}
+
+function Add-ForbiddenExternalProductReferenceFailures {
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $true)][string]$Surface
+    )
+
+    $fullPath = if ([System.IO.Path]::IsPathRooted($Path)) { $Path } else { Join-Path $repoRoot $Path }
+    if (-not (Test-Path -LiteralPath $fullPath)) {
+        $failures.Add("$Surface path does not exist: $Path")
+        return
+    }
+
+    $content = Get-Content -LiteralPath $fullPath -Raw -ErrorAction Stop
+    foreach ($reference in Get-ForbiddenExternalProductReferencePatterns) {
+        if ($content -match $reference.Pattern) {
+            $failures.Add("$Surface contains forbidden external product/reference name '$($reference.Name)': $Path")
+        }
+    }
 }
 
 $failures = New-Object System.Collections.Generic.List[string]
@@ -195,6 +262,15 @@ foreach ($file in ($trackedFiles | Where-Object { Test-IsPublicDoc -Path $_ })) 
             $failures.Add("public doc exposes repository-only startup wording '$fragment': $file")
         }
     }
+
+}
+
+foreach ($file in ($trackedFiles | Where-Object { Test-IsExternalProductReferenceAuditSurface -Path $_ })) {
+    Add-ForbiddenExternalProductReferenceFailures -Path $file -Surface 'public doc'
+}
+
+if (-not [string]::IsNullOrWhiteSpace($ReleaseNotesPath)) {
+    Add-ForbiddenExternalProductReferenceFailures -Path $ReleaseNotesPath -Surface 'release notes'
 }
 
 $claudeContractPath = Join-Path $repoRoot '.claude/CLAUDE.md'

--- a/tests/PublicSurfacePolicy.Tests.ps1
+++ b/tests/PublicSurfacePolicy.Tests.ps1
@@ -22,6 +22,13 @@ Describe 'Public surface policy' {
         $syncRoadmap = Get-Content (Join-Path $repoRoot 'winsmux-core/scripts/sync-roadmap.ps1') -Raw
         $syncInternalDocs = Get-Content (Join-Path $repoRoot 'winsmux-core/scripts/sync-internal-docs.ps1') -Raw
         $installer = Get-Content (Join-Path $repoRoot 'install.ps1') -Raw
+        $auditPublicSurface = Join-Path $repoRoot 'scripts/audit-public-surface.ps1'
+        $previousHooksPath = (& git config --get core.hooksPath 2>$null | Out-String).Trim()
+        $hadHooksPath = $LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($previousHooksPath)
+        & git config core.hooksPath .githooks
+        if ($LASTEXITCODE -ne 0) {
+            throw 'Failed to configure core.hooksPath for public surface audit tests.'
+        }
         $publicDocs = @(
             $readme,
             $readmeJa,
@@ -39,6 +46,14 @@ Describe 'Public surface policy' {
             (Get-Content (Join-Path $repoRoot 'docs/TROUBLESHOOTING.ja.md') -Raw),
             (Get-Content (Join-Path $repoRoot 'packages/winsmux/README.md') -Raw)
         )
+    }
+
+    AfterAll {
+        if ($hadHooksPath) {
+            & git config core.hooksPath $previousHooksPath
+        } else {
+            & git config --unset core.hooksPath
+        }
     }
 
     It 'keeps public docs free of contributor/private direct links' {
@@ -219,6 +234,61 @@ Describe 'Public surface policy' {
         $authSupportJa | Should -Match '設定された `auth_mode`'
         $authSupportJa | Should -Match 'token-broker'
         $authSupportJa | Should -Match 'provider-api-proxy'
+    }
+
+    It 'passes the public docs external product reference audit' {
+        $output = @(& pwsh -NoProfile -File $auditPublicSurface 2>&1)
+
+        $LASTEXITCODE | Should -Be 0
+        ($output -join "`n") | Should -Match 'audit-public-surface passed'
+    }
+
+    It 'allows terminal cursor wording in generated release notes' {
+        $releaseBody = Join-Path $TestDrive 'cursor-release-body.md'
+        Set-Content -LiteralPath $releaseBody -Value @'
+## Bug Fixes
+
+- Cursor movement now preserves position after pane redraws.
+'@ -Encoding UTF8
+
+        $output = @(& pwsh -NoProfile -File $auditPublicSurface -ReleaseNotesPath $releaseBody 2>&1)
+
+        $LASTEXITCODE | Should -Be 0
+        ($output -join "`n") | Should -Match 'audit-public-surface passed'
+    }
+
+    It 'blocks forbidden external product names in linked top-level public docs' {
+        $linkedPublicDoc = Join-Path $repoRoot 'docs/authentication-support.md'
+        $original = [System.IO.File]::ReadAllText($linkedPublicDoc)
+        try {
+            [System.IO.File]::WriteAllText(
+                $linkedPublicDoc,
+                $original + "`nThis public page must not compare winsmux to VS Code.`n",
+                [System.Text.UTF8Encoding]::new($false)
+            )
+
+            $output = @(& pwsh -NoProfile -File $auditPublicSurface 2>&1)
+
+            $LASTEXITCODE | Should -Be 1
+            ($output -join "`n") | Should -Match "public doc contains forbidden external product/reference name 'VS Code'"
+            ($output -join "`n") | Should -Match 'docs/authentication-support\.md'
+        } finally {
+            [System.IO.File]::WriteAllText($linkedPublicDoc, $original, [System.Text.UTF8Encoding]::new($false))
+        }
+    }
+
+    It 'blocks forbidden external product names in generated release notes' {
+        $releaseBody = Join-Path $TestDrive 'release-body.md'
+        Set-Content -LiteralPath $releaseBody -Value @'
+## New Features
+
+- Keeps the operator flow separate from VS Code-style workbench assumptions.
+'@ -Encoding UTF8
+
+        $output = @(& pwsh -NoProfile -File $auditPublicSurface -ReleaseNotesPath $releaseBody 2>&1)
+
+        $LASTEXITCODE | Should -Be 1
+        ($output -join "`n") | Should -Match "release notes contains forbidden external product/reference name 'VS Code'"
     }
 
     It 'uses recorded-baseline gitleaks scans for routine push and CI checks' {


### PR DESCRIPTION
## Summary
- Add a public-surface audit gate for external product/reference names in public docs.
- Extend the same audit to generated release notes with `-ReleaseNotesPath`.
- Run the release-body audit in the core release workflow after release notes are generated.

## Validation
- `pwsh -NoProfile -Command "Invoke-Pester -Path tests\PublicSurfacePolicy.Tests.ps1"`
- `pwsh -NoProfile -File scripts\audit-public-surface.ps1`
- `pwsh -NoProfile -File scripts\generate-release-notes.ps1 -Version v0.31.0 -OutputPath .tmp\task-456-release-body.md`
- `pwsh -NoProfile -File scripts\audit-public-surface.ps1 -ReleaseNotesPath .tmp\task-456-release-body.md`
- `pwsh -NoProfile -File scripts\git-guard.ps1 -Mode full`
- `git diff --check`

Closes #858
