### PR TITLE
Fix desktop project selection and composer input

### DIFF
--- a/.githooks/pre-commit-whitelist.ps1
+++ b/.githooks/pre-commit-whitelist.ps1
@@ -81,6 +81,7 @@ $whitelistPatterns = @(
     'winsmux-app/scripts/*.mjs',
     'winsmux-app/package.json',
     'winsmux-app/package-lock.json',
+    'winsmux-app/src/composerText.ts',
     'winsmux-app/src/sourceGraph.ts',
     'winsmux-app/src-tauri/Cargo.toml',
     'winsmux-app/src-tauri/Cargo.lock',

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3028,6 +3028,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.1",
  "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -4058,6 +4059,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfd"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
+dependencies = [
+ "block2",
+ "dispatch2",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "rusqlite"
 version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4923,6 +4948,48 @@ dependencies = [
  "tauri-utils",
  "toml 0.9.12+spec-1.1.0",
  "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-dialog"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65981abb771e74e571a38196c3baa11c459379164791eba0e67abc1a5fac9884"
+dependencies = [
+ "log",
+ "raw-window-handle",
+ "rfd",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.18",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-fs"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ecc274121aca0c036a2b42d1cbe83d368d348f54e0bb8a735c2b1548e8f371"
+dependencies = [
+ "anyhow",
+ "dunce",
+ "glob",
+ "log",
+ "objc2-foundation",
+ "percent-encoding",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "toml 1.1.2+spec-1.1.0",
+ "url",
 ]
 
 [[package]]
@@ -6268,6 +6335,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -6299,11 +6375,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -6337,6 +6430,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6347,6 +6446,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6361,10 +6466,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -6379,6 +6496,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6389,6 +6512,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -6403,6 +6532,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6413,6 +6548,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -6501,6 +6642,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-dialog",
  "tauri-plugin-opener",
  "windows-sys 0.61.2",
 ]

--- a/winsmux-app/index.html
+++ b/winsmux-app/index.html
@@ -284,8 +284,7 @@
                 <div id="composer-operator-status" class="composer-operator-status" role="status" aria-live="polite" hidden>
                   <span id="operator-working-label" class="operator-working-label">working</span>
                   <span id="operator-working-elapsed">0m 00s</span>
-                  <span aria-hidden="true">·</span>
-                  <span id="operator-working-hint">Esc to interrupt</span>
+                  <span id="operator-working-hint" hidden>Esc to interrupt</span>
                 </div>
                 <div id="composer-model-row" aria-label="Composer model controls"></div>
               </div>

--- a/winsmux-app/package-lock.json
+++ b/winsmux-app/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.25.7",
       "dependencies": {
         "@tauri-apps/api": "2.11.0",
+        "@tauri-apps/plugin-dialog": "^2.7.1",
         "@tauri-apps/plugin-opener": "^2",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-web-links": "^0.12.0",
@@ -1053,6 +1054,15 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-dialog": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-dialog/-/plugin-dialog-2.7.1.tgz",
+      "integrity": "sha512-OK1UBXYt+ojcmxMktzzuyonYIFta8CmAASpX+CA+DTGK24KlHjhYI6x2iOJ/TjZF4N7/ACK1oFmEOjIY9IhzOQ==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.11.0"
       }
     },
     "node_modules/@tauri-apps/plugin-opener": {

--- a/winsmux-app/package.json
+++ b/winsmux-app/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "dev:browser": "node ./scripts/open-dev-browser.mjs",
     "build": "tsc && vite build",
+    "test:composer-text": "node ./scripts/composer-text-check.mjs",
     "test:editor-targets": "node ./scripts/editor-targets-check.mjs",
     "test:source-graph": "node ./scripts/source-graph-check.mjs",
     "test:viewport-harness": "npm run build && node ./scripts/viewport-harness.mjs",
@@ -15,6 +16,7 @@
   },
   "dependencies": {
     "@tauri-apps/api": "2.11.0",
+    "@tauri-apps/plugin-dialog": "^2.7.1",
     "@tauri-apps/plugin-opener": "^2",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-web-links": "^0.12.0",

--- a/winsmux-app/scripts/composer-text-check.mjs
+++ b/winsmux-app/scripts/composer-text-check.mjs
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import ts from "typescript";
+
+async function loadComposerTextModule() {
+  const sourcePath = path.resolve("src/composerText.ts");
+  const source = await readFile(sourcePath, "utf8");
+  const transpiled = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.ESNext,
+      target: ts.ScriptTarget.ES2020,
+    },
+    fileName: sourcePath,
+  });
+
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "winsmux-composer-text-"));
+  const modulePath = path.join(tempDir, "composerText.mjs");
+  await writeFile(modulePath, transpiled.outputText, "utf8");
+
+  try {
+    return await import(pathToFileURL(modulePath).href);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+const { isComposerCommandText, normalizeComposerPlainTextPaste } = await loadComposerTextModule();
+
+assert.equal(isComposerCommandText("winsmux meta-plan --json"), true);
+assert.equal(isComposerCommandText("  winsmux skills --json"), true);
+assert.equal(isComposerCommandText("調査してください"), false);
+
+assert.equal(
+  normalizeComposerPlainTextPaste('winsmux meta-plan --task "計画して"\n--review-\nrounds 2 --json'),
+  'winsmux meta-plan --task "計画して" --review-rounds 2 --json',
+);
+
+assert.equal(
+  normalizeComposerPlainTextPaste("調査してください。\n編集は禁止です。"),
+  "調査してください。\n編集は禁止です。",
+);
+
+assert.equal(
+  normalizeComposerPlainTextPaste("winsmux skills --json"),
+  "winsmux skills --json",
+);
+
+console.log("composer-text-check: ok");

--- a/winsmux-app/src-tauri/Cargo.toml
+++ b/winsmux-app/src-tauri/Cargo.toml
@@ -19,6 +19,7 @@ tauri-build = { version = "2", features = [] }
 
 [dependencies]
 tauri = { version = "2", features = [] }
+tauri-plugin-dialog = "2"
 tauri-plugin-opener = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/winsmux-app/src-tauri/capabilities/default.json
+++ b/winsmux-app/src-tauri/capabilities/default.json
@@ -5,6 +5,7 @@
   "windows": ["main"],
   "permissions": [
     "core:default",
+    "dialog:default",
     "opener:default"
   ]
 }

--- a/winsmux-app/src-tauri/src/lib.rs
+++ b/winsmux-app/src-tauri/src/lib.rs
@@ -958,6 +958,7 @@ impl PtyCommandTransport for TauriPtyTransport {
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     let app = tauri::Builder::default()
+        .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_opener::init())
         .manage(PtyManager {
             panes: Arc::new(Mutex::new(HashMap::new())),

--- a/winsmux-app/src/composerText.ts
+++ b/winsmux-app/src/composerText.ts
@@ -1,0 +1,18 @@
+export function isComposerCommandText(text: string) {
+  return /^\s*winsmux(?:\s|$)/i.test(text);
+}
+
+export function normalizeComposerPlainTextPaste(text: string) {
+  if (!/[\r\n]/.test(text) || !isComposerCommandText(text)) {
+    return text;
+  }
+
+  return text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .join(" ")
+    .replace(/--([A-Za-z0-9_]+)-\s+([A-Za-z0-9_]+)/g, "--$1-$2")
+    .replace(/\s{2,}/g, " ")
+    .trim();
+}

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -2,6 +2,7 @@ import { Terminal } from "xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import "xterm/css/xterm.css";
 import { isTauri } from "@tauri-apps/api/core";
+import { open as openDialog } from "@tauri-apps/plugin-dialog";
 import { WebviewWindow, getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
 import {
   applyDesktopRuntimeRolePreferences,
@@ -36,6 +37,7 @@ import {
   subscribeToPtyOutput,
   writePtyData,
 } from "./ptyClient";
+import { isComposerCommandText, normalizeComposerPlainTextPaste } from "./composerText";
 
 interface PaneEntry {
   terminal: Terminal;
@@ -562,6 +564,7 @@ const expandedExplorerFolders = new Set<string>();
 let projectExplorerEntries: DesktopExplorerEntry[] = [];
 let projectExplorerLoaded = false;
 let projectExplorerRefreshInFlight: Promise<void> | null = null;
+let projectExplorerRefreshGeneration = 0;
 const projectExplorerLoadedFolderPaths = new Set<string>();
 const projectExplorerFolderLoads = new Map<string, Promise<void>>();
 let explorerContextMenu: HTMLDivElement | null = null;
@@ -581,6 +584,7 @@ const MAX_RUNTIME_CONVERSATION_ITEMS = 80;
 const OPERATOR_PTY_ID = "operator";
 const OPERATOR_PTY_COLS = 120;
 const OPERATOR_PTY_ROWS = 32;
+const OPERATOR_PTY_ACTION_TIMEOUT_MS = 15_000;
 const DEFAULT_EDITOR_FONT_SIZE = 14;
 const MIN_EDITOR_FONT_SIZE = 8;
 const MAX_EDITOR_FONT_SIZE = 32;
@@ -987,14 +991,14 @@ const languageOptions: Array<{ value: LanguageMode; label: string; description: 
 ];
 
 const voiceDraftModeOptions: Array<{ value: VoiceDraftMode; label: string; labelJa: string; description: string; descriptionJa: string }> = [
-  { value: "raw", label: "Raw", labelJa: "そのまま", description: "Insert the recognized transcript without cleanup.", descriptionJa: "認識結果を整形せず下書きへ入れます。" },
+  { value: "raw", label: "Raw", labelJa: "原文", description: "Insert the recognized transcript without cleanup.", descriptionJa: "認識結果を整形せず下書きへ入れます。" },
   { value: "cleaned", label: "Clean draft", labelJa: "整える", description: "Remove fillers and repeated phrases conservatively.", descriptionJa: "不要な言いよどみや繰り返しだけを控えめに整えます。" },
   { value: "operator_request", label: "Operator request", labelJa: "依頼文", description: "Shape spoken intent into an editable operator request.", descriptionJa: "話した意図を編集可能な依頼文として整えます。" },
 ];
 
 const voiceVocabularyModeOptions: Array<{ value: VoiceVocabularyMode; label: string; labelJa: string; description: string; descriptionJa: string }> = [
   { value: "off", label: "Vocabulary off", labelJa: "語彙なし", description: "Use speech recognition text exactly as received.", descriptionJa: "音声認識の結果をそのまま使います。" },
-  { value: "project", label: "Project terms", labelJa: "プロジェクト語彙", description: "Correct common project terms before shaping the draft.", descriptionJa: "下書きを整える前に、よく使うプロジェクト語彙へ直します。" },
+  { value: "project", label: "Project terms", labelJa: "用語補正", description: "Correct common project terms before shaping the draft.", descriptionJa: "下書きを整える前に、よく使うプロジェクト語彙へ直します。" },
   { value: "project_custom", label: "Project + custom", labelJa: "語彙と追加辞書", description: "Also apply local custom readings stored on this device.", descriptionJa: "この端末に保存した追加の読みも使います。" },
 ];
 
@@ -1831,9 +1835,26 @@ function setActiveProjectDir(projectDir: string | null) {
   requestDesktopSummaryRefresh(undefined, 0);
 }
 
-function promptAndAddProjectSession() {
-  const value = window.prompt(getLanguageText("Project path", "プロジェクトのパス"));
-  const projectDir = normalizeProjectDirInput(value);
+async function promptAndAddProjectSession() {
+  let selectedPath: string | null = null;
+  if (isTauri()) {
+    try {
+      const result = await openDialog({
+        directory: true,
+        multiple: false,
+        title: getLanguageText("Select project folder", "プロジェクトフォルダを選択"),
+      });
+      selectedPath = Array.isArray(result) ? result[0] ?? null : result;
+    } catch (error) {
+      console.warn("Failed to open project folder picker", error);
+      window.alert(getLanguageText("Could not open the folder picker.", "フォルダ選択を開けませんでした。"));
+      return;
+    }
+  } else {
+    selectedPath = window.prompt(getLanguageText("Project path", "プロジェクトのパス"));
+  }
+
+  const projectDir = normalizeProjectDirInput(selectedPath);
   if (!projectDir) {
     return;
   }
@@ -1887,8 +1908,8 @@ function getSessionItems() {
       });
     }
     items.push({
-      name: getLanguageText("Add project", "プロジェクトを追加"),
-      meta: getLanguageText("Paste a local project path", "ローカルプロジェクトのパスを貼り付け"),
+      name: getLanguageText("Select project", "プロジェクトを選択"),
+      meta: getLanguageText("Choose a local project folder", "ローカルプロジェクトのフォルダを選択"),
       action: "add-project",
     });
     return items;
@@ -1925,8 +1946,8 @@ function getSessionItems() {
   }
 
   items.push({
-    name: getLanguageText("Add project", "プロジェクトを追加"),
-    meta: getLanguageText("Paste a local project path", "ローカルプロジェクトのパスを貼り付け"),
+    name: getLanguageText("Select project", "プロジェクトを選択"),
+    meta: getLanguageText("Choose a local project folder", "ローカルプロジェクトのフォルダを選択"),
     action: "add-project",
   });
 
@@ -2424,11 +2445,17 @@ async function refreshProjectExplorerEntries() {
     return projectExplorerRefreshInFlight;
   }
 
+  const requestKey = captureProjectRequestKey();
+  const refreshGeneration = ++projectExplorerRefreshGeneration;
   projectExplorerRefreshInFlight = (async () => {
     try {
+      const projectDir = getActiveProjectDirPayload();
       const entries = isTauri()
-        ? normalizeExplorerEntries((await getDesktopExplorerEntries(undefined, getActiveProjectDirPayload())).entries)
+        ? normalizeExplorerEntries((await getDesktopExplorerEntries(undefined, projectDir)).entries)
         : await loadBrowserProjectExplorerEntries();
+      if (!isProjectRequestCurrent(requestKey)) {
+        return;
+      }
       projectExplorerEntries = entries;
       projectExplorerLoaded = true;
       projectExplorerLoadedFolderPaths.clear();
@@ -2437,11 +2464,16 @@ async function refreshProjectExplorerEntries() {
       expandedExplorerFolders.clear();
       renderExplorer();
     } catch (error) {
+      if (!isProjectRequestCurrent(requestKey)) {
+        return;
+      }
       projectExplorerLoaded = true;
       console.warn("Failed to load project explorer entries", error);
       renderExplorer();
     } finally {
-      projectExplorerRefreshInFlight = null;
+      if (projectExplorerRefreshGeneration === refreshGeneration) {
+        projectExplorerRefreshInFlight = null;
+      }
     }
   })();
 
@@ -2738,7 +2770,7 @@ function getFilesystemExplorerItems() {
 }
 
 function getExplorerItems() {
-  if (projectExplorerEntries.length > 0) {
+  if (projectExplorerLoaded || projectExplorerEntries.length > 0) {
     return getFilesystemExplorerItems();
   }
 
@@ -8052,6 +8084,13 @@ function syncComposerInputHeight(composerInput?: HTMLTextAreaElement | null) {
     return;
   }
 
+  const commandMode = isComposerCommandText(input.value);
+  input.dataset.inputMode = commandMode ? "command" : "prose";
+  input.setAttribute("wrap", commandMode ? "off" : "soft");
+  if (!commandMode) {
+    input.scrollLeft = 0;
+  }
+
   input.style.height = "auto";
   const computed = window.getComputedStyle(input);
   const minHeight = Number.parseFloat(computed.minHeight) || 0;
@@ -8397,8 +8436,8 @@ function createComposerVoiceDraftMenu() {
   const selected = getVoiceDraftModeOption();
   const vocabulary = getVoiceVocabularyModeOption();
   const selectedLabel = themeState.language === "ja"
-    ? `${selected.labelJa}・${vocabulary.labelJa}`
-    : `${selected.label} · ${vocabulary.label}`;
+    ? `音声: ${selected.labelJa} / ${vocabulary.labelJa}`
+    : `Voice: ${selected.label} / ${vocabulary.label}`;
   const group = createComposerSessionControl("voice", selectedLabel);
   if (openComposerSessionMenu !== "voice") {
     return group;
@@ -8993,9 +9032,8 @@ function renderConversation(items: ConversationItem[]) {
     meta.className = "timeline-meta-row";
     meta.innerHTML =
       `<span class="timeline-actor">${item.actor}</span>` +
-      `<span class="timeline-meta-separator">·</span>` +
       `<span>${item.timestamp}</span>` +
-      (item.runId ? `<span class="timeline-meta-separator">·</span><span>${item.runId}</span>` : "") +
+      (item.runId ? `<span>${item.runId}</span>` : "") +
       (item.statusLabel ? `<span class="timeline-status-pill">${item.statusLabel}</span>` : "");
     article.appendChild(meta);
 
@@ -9775,7 +9813,7 @@ function getTopMenuItems(menuId: string): TopMenuItem[] {
   switch (menuId) {
     case "menu-file-btn":
       return [
-        { label: getLanguageText("Add project", "プロジェクトを追加"), action: promptAndAddProjectSession },
+        { label: getLanguageText("Select project", "プロジェクトを選択"), action: promptAndAddProjectSession },
         { label: getLanguageText("Settings", "設定"), action: () => setSettingsSheet(true) },
       ];
     case "menu-edit-btn":
@@ -11712,6 +11750,24 @@ function isCurrentOperatorRequest(generation: number) {
   return operatorRequestActive && operatorRequestGeneration === generation;
 }
 
+async function withOperatorTimeout<T>(operation: Promise<T>, label: string): Promise<T> {
+  let timeoutId: number | null = null;
+  try {
+    return await Promise.race([
+      operation,
+      new Promise<T>((_, reject) => {
+        timeoutId = window.setTimeout(() => {
+          reject(new Error(`${label} timed out after ${Math.round(OPERATOR_PTY_ACTION_TIMEOUT_MS / 1000)}s`));
+        }, OPERATOR_PTY_ACTION_TIMEOUT_MS);
+      }),
+    ]);
+  } finally {
+    if (timeoutId !== null) {
+      window.clearTimeout(timeoutId);
+    }
+  }
+}
+
 async function interruptOperatorRequest() {
   if (!operatorRequestActive || operatorInterruptInFlight) {
     return;
@@ -11724,11 +11780,11 @@ async function interruptOperatorRequest() {
   setOperatorRequestActive(false);
   updateOperatorInterruptButton();
   try {
-    await ensureOperatorPtyStarted();
+    await withOperatorTimeout(ensureOperatorPtyStarted(), "operator PTY startup");
     if (operatorRequestGeneration !== canceledGeneration || operatorRequestActive) {
       return;
     }
-    await writePtyData(OPERATOR_PTY_ID, "\x03");
+    await withOperatorTimeout(writePtyData(OPERATOR_PTY_ID, "\x03"), "operator interrupt");
     appendRuntimeConversation({
       type: "system",
       category: "attention",
@@ -11791,11 +11847,11 @@ async function forwardComposerMessageToOperatorPane(
 
   const requestGeneration = beginOperatorRequest();
   try {
-    await ensureOperatorPtyStarted();
+    await withOperatorTimeout(ensureOperatorPtyStarted(), "operator PTY startup");
     if (!isCurrentOperatorRequest(requestGeneration)) {
       return;
     }
-    await writePtyData(OPERATOR_PTY_ID, encodePtySubmission(payload));
+    await withOperatorTimeout(writePtyData(OPERATOR_PTY_ID, encodePtySubmission(payload)), "operator request write");
     if (!isCurrentOperatorRequest(requestGeneration)) {
       return;
     }
@@ -13057,6 +13113,20 @@ window.addEventListener("DOMContentLoaded", async () => {
       }
 
       if (event.clipboardData?.types.includes("text/plain")) {
+        const text = event.clipboardData.getData("text/plain");
+        const normalized = normalizeComposerPlainTextPaste(text);
+        if (normalized !== text) {
+          event.preventDefault();
+          composerInput.setRangeText(
+            normalized,
+            composerInput.selectionStart,
+            composerInput.selectionEnd,
+            "end",
+          );
+          syncComposerInputHeight(composerInput);
+          syncComposerDraftState(composerInput.value);
+          syncComposerSlashState(composerInput.value);
+        }
         return;
       }
 

--- a/winsmux-app/src/styles.css
+++ b/winsmux-app/src/styles.css
@@ -1922,6 +1922,13 @@ body[data-popout-surface="1"] #editor-surface {
   line-height: var(--leading-normal);
 }
 
+#composer-input[data-input-mode="command"] {
+  overflow-x: auto;
+  overflow-wrap: normal;
+  white-space: pre;
+  word-break: normal;
+}
+
 #composer-input:focus {
   border-color: var(--accent-blue-hover);
   box-shadow: 0 0 0 3px rgba(90, 132, 245, 0.18);
@@ -1971,7 +1978,7 @@ body[data-popout-surface="1"] #editor-surface {
 
 #composer-session-row {
   display: flex;
-  flex-wrap: nowrap;
+  flex-wrap: wrap;
   gap: 6px;
   align-items: center;
   justify-content: flex-start;
@@ -1984,7 +1991,7 @@ body[data-popout-surface="1"] #editor-surface {
 
 .composer-session-trigger {
   min-height: 26px;
-  max-width: min(44vw, 240px);
+  max-width: min(44vw, 280px);
   border: 0;
   border-radius: 4px;
   background: transparent;
@@ -2275,6 +2282,7 @@ body[data-popout-surface="1"] #editor-surface {
   justify-content: space-between;
   gap: 12px;
   min-width: 0;
+  flex-wrap: wrap;
 }
 
 .composer-operator-status {
@@ -2282,7 +2290,7 @@ body[data-popout-surface="1"] #editor-surface {
   align-items: center;
   gap: 6px;
   min-width: 0;
-  flex: 0 1 auto;
+  flex: 0 0 auto;
   color: var(--text-muted);
   font-size: var(--text-xs);
   white-space: nowrap;


### PR DESCRIPTION
## Summary

- add a native Tauri folder picker for desktop project selection
- prevent empty selected projects from falling back to stale repository files
- normalize pasted `winsmux` commands and show command-like drafts without visual wrapping
- keep the composer footer and conversation feed closer to the CLI experience

Closes #872.
Closes #873.
Closes #874.

## Validation

- `cmd /c npm run test:composer-text`
- `cmd /c npm run test:editor-targets`
- `cmd /c npm run build`
- `cargo check --manifest-path winsmux-app\src-tauri\Cargo.toml`
- `git diff --check`
- `pwsh -NoProfile -File scripts/git-guard.ps1 -Mode full`
- pre-push: `git-guard`, `audit-public-surface`, gitleaks
