### PR TITLE
Polish desktop workbench density

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -87,3 +87,48 @@ Public `openai/codex` TUI-derived UI reuse in winsmux follows the active release
 These are project adaptation guardrails, not additional license terms.
 
 This notice covers attribution and provenance tracking. It does not imply that winsmux reproduces Codex verbatim end-to-end, or that winsmux incorporates non-public Codex App desktop source code.
+
+## microsoft/vscode
+
+- Upstream: https://github.com/microsoft/vscode
+- Pinned snapshot: `98b4a731eefbb5358e44dcc7dea03651baee00aa`
+- License: MIT
+- Copyright: Microsoft Corporation
+
+### winsmux usage policy
+
+winsmux may closely adapt selected public Visual Studio Code workbench density and styling references for the Tauri operator shell, including:
+
+- workbench typography, spacing, and row-density direction
+- activity bar, side bar, status bar, and settings surface affordances
+- terminal colors, gutter behavior, selection, and cursor styling
+
+When code or UI definitions are directly copied or closely adapted from `microsoft/vscode`, the implementing change must:
+
+1. keep this notice file updated,
+2. record the upstream source path(s) in the pull request or handoff,
+3. preserve MIT attribution in the repository.
+
+### Current tracked source references
+
+These upstream areas are the current reference set for public `microsoft/vscode` workbench-derived UI work:
+
+- `src/vs/workbench/browser/parts/activitybar/media/activitybarpart.css`
+- `src/vs/workbench/browser/parts/activitybar/media/activityaction.css`
+- `src/vs/workbench/browser/parts/editor/media/editortitlecontrol.css`
+- `src/vs/workbench/browser/parts/statusbar/media/statusbarpart.css`
+- `src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css`
+- `src/vs/workbench/contrib/terminal/browser/media/terminal.css`
+- `src/vs/workbench/contrib/terminal/browser/media/xterm.css`
+
+### Current winsmux adaptation scope
+
+The current `winsmux-app` density work tracks these public `microsoft/vscode` areas most closely:
+
+- compact side-bar row heights and indentation
+- compact status bar layout
+- settings editor field and tab density
+- terminal header density and dark terminal colors
+- terminal left gutter and scrollbar behavior
+
+This notice covers attribution and provenance tracking. It does not imply that winsmux reproduces Visual Studio Code verbatim end-to-end.

--- a/scripts/audit-public-surface.ps1
+++ b/scripts/audit-public-surface.ps1
@@ -55,6 +55,7 @@ function Test-IsExternalProductReferenceAuditSurface {
     param([Parameter(Mandatory = $true)][string]$Path)
 
     $normalized = $Path.Replace('\', '/')
+    if ($normalized -eq 'THIRD_PARTY_NOTICES.md') { return $false }
     if (Test-IsPublicDoc -Path $Path) { return $true }
     if ($normalized -match '^docs/[^/]+\.md$') { return $true }
     return $normalized -match '^core/docs/.+\.md$'

--- a/tests/PublicSurfacePolicy.Tests.ps1
+++ b/tests/PublicSurfacePolicy.Tests.ps1
@@ -270,10 +270,29 @@ Describe 'Public surface policy' {
             $output = @(& pwsh -NoProfile -File $auditPublicSurface 2>&1)
 
             $LASTEXITCODE | Should -Be 1
-            ($output -join "`n") | Should -Match "public doc contains forbidden external product/reference name 'VS Code'"
+            ($output -join "`n") | Should -Match 'public doc contains forbidden external product/reference'
             ($output -join "`n") | Should -Match 'docs/authentication-support\.md'
         } finally {
             [System.IO.File]::WriteAllText($linkedPublicDoc, $original, [System.Text.UTF8Encoding]::new($false))
+        }
+    }
+
+    It 'allows upstream names in third-party notices for attribution' {
+        $noticePath = Join-Path $repoRoot 'THIRD_PARTY_NOTICES.md'
+        $original = [System.IO.File]::ReadAllText($noticePath)
+        try {
+            [System.IO.File]::WriteAllText(
+                $noticePath,
+                $original + "`nTemporary attribution line for VS Code provenance.`n",
+                [System.Text.UTF8Encoding]::new($false)
+            )
+
+            $output = @(& pwsh -NoProfile -File $auditPublicSurface 2>&1)
+
+            $LASTEXITCODE | Should -Be 0
+            ($output -join "`n") | Should -Match 'audit-public-surface passed'
+        } finally {
+            [System.IO.File]::WriteAllText($noticePath, $original, [System.Text.UTF8Encoding]::new($false))
         }
     }
 
@@ -288,7 +307,8 @@ Describe 'Public surface policy' {
         $output = @(& pwsh -NoProfile -File $auditPublicSurface -ReleaseNotesPath $releaseBody 2>&1)
 
         $LASTEXITCODE | Should -Be 1
-        ($output -join "`n") | Should -Match "release notes contains forbidden external product/reference name 'VS Code'"
+        ($output -join "`n") | Should -Match 'release notes contains forbidden external product/reference'
+        ($output -join "`n") | Should -Match "name 'VS Code'"
     }
 
     It 'uses recorded-baseline gitleaks scans for routine push and CI checks' {

--- a/winsmux-app/scripts/viewport-harness.mjs
+++ b/winsmux-app/scripts/viewport-harness.mjs
@@ -1091,6 +1091,46 @@ async function assertWorkbenchPaneGrid(page, expectedMin = 4) {
   }, expectedMin);
 }
 
+async function assertWorkbenchFontSizeScaling(page) {
+  const key = "winsmux.shell.preferences.v1";
+  const originalPreferences = await page.evaluate((storageKey) => window.localStorage.getItem(storageKey), key);
+
+  try {
+    await page.evaluate((storageKey) => {
+      const current = JSON.parse(window.localStorage.getItem(storageKey) ?? "{}");
+      window.localStorage.setItem(
+        storageKey,
+        JSON.stringify({
+          ...current,
+          uiVersion: 2,
+          editorFontSize: 32,
+        }),
+      );
+    }, key);
+    await page.reload({ waitUntil: "networkidle" });
+    await page.waitForFunction(() => {
+      const title = document.querySelector("#session-list .sidebar-row-title");
+      if (!(title instanceof HTMLElement)) {
+        return false;
+      }
+      const styles = getComputedStyle(title);
+      return parseFloat(styles.fontSize) >= 32 && parseFloat(styles.lineHeight) >= 40;
+    });
+  } finally {
+    await page.evaluate(
+      ({ storageKey, value }) => {
+        if (value === null) {
+          window.localStorage.removeItem(storageKey);
+        } else {
+          window.localStorage.setItem(storageKey, value);
+        }
+      },
+      { storageKey: key, value: originalPreferences },
+    );
+    await page.reload({ waitUntil: "networkidle" });
+  }
+}
+
 async function setShellLanguage(page, language) {
   await page.evaluate((nextLanguage) => {
     const key = "winsmux.shell.preferences.v1";
@@ -1595,6 +1635,10 @@ async function verifyDesktopViewport(page, previewUrl) {
     await assertNoOverlap(page, "#workspace-body", "#workspace-footer");
   });
 
+  await runStep("desktop workbench font size scaling", async () => {
+    await assertWorkbenchFontSizeScaling(page);
+  });
+
   await runStep("desktop voice input accessibility coverage", async () => {
     await assertDesktopVoiceInputCoverage(page);
   });
@@ -1879,6 +1923,7 @@ async function run() {
           checks: [
             "desktop-operator-chat-contract",
             "desktop-1440x900",
+            "desktop-workbench-font-size-scaling",
             "desktop-voice-input-a11y",
             "desktop-voice-draft-shaping",
             "desktop-voice-vocabulary-dictionary",

--- a/winsmux-app/scripts/viewport-harness.mjs
+++ b/winsmux-app/scripts/viewport-harness.mjs
@@ -102,6 +102,9 @@ async function stopPreviewServer(child) {
       stdio: ["ignore", "pipe", "pipe"],
     });
     await once(killer, "exit").catch(() => {});
+    child.stdout?.destroy();
+    child.stderr?.destroy();
+    child.unref();
     return;
   }
 
@@ -925,7 +928,7 @@ async function assertSettingsRoundtrip(page, returnSelector) {
   await page.locator("#focus-mode-options", { hasText: "Focus" }).waitFor();
   await page.waitForFunction(() => {
     const input = document.querySelector("#editor-font-size-input");
-    return input instanceof HTMLInputElement && input.value === "14";
+    return input instanceof HTMLInputElement && input.value === "13";
   });
   await page.waitForFunction(() => {
     const input = document.querySelector("#settings-font-family-input");
@@ -1100,9 +1103,10 @@ async function setShellLanguage(page, language) {
         wrapMode: "balanced",
         codeFont: "system",
         codeFontFamily: "Consolas, 'Courier New', monospace",
-        editorFontSize: 14,
+        uiVersion: 2,
+        editorFontSize: 13,
         focusMode: "standard",
-        sidebarWidth: 292,
+        sidebarWidth: 256,
         workbenchWidth: null,
         wideSidebarOpen: true,
         wideContextOpen: false,
@@ -1966,7 +1970,11 @@ async function run() {
   }
 }
 
-run().catch((error) => {
-  console.error(error instanceof Error ? error.message : error);
-  process.exitCode = 1;
-});
+run()
+  .then(() => {
+    process.exit(0);
+  })
+  .catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  });

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -336,6 +336,7 @@ interface ThemeState {
 }
 
 interface ShellPreferenceState extends ThemeState {
+  uiVersion: number;
   sidebarWidth: number;
   workbenchWidth: number | null;
   wideSidebarOpen: boolean;
@@ -466,7 +467,7 @@ let sidebarMode: SidebarMode = "explorer";
 let workbenchLayout: WorkbenchLayoutMode = "2x2";
 let focusedWorkbenchPaneId: string | null = null;
 let composerImeActive = false;
-let sidebarWidth = 292;
+let sidebarWidth = 256;
 let workbenchWidth: number | null = null;
 let selectedEditorKey = "";
 let selectedPreviewUrl = "";
@@ -588,10 +589,40 @@ const OPERATOR_PTY_ID = "operator";
 const OPERATOR_PTY_COLS = 120;
 const OPERATOR_PTY_ROWS = 32;
 const OPERATOR_PTY_ACTION_TIMEOUT_MS = 15_000;
-const DEFAULT_EDITOR_FONT_SIZE = 14;
+const DEFAULT_EDITOR_FONT_SIZE = 13;
 const MIN_EDITOR_FONT_SIZE = 8;
 const MAX_EDITOR_FONT_SIZE = 32;
 const DEFAULT_CODE_FONT_FAMILY = "Consolas, 'Courier New', monospace";
+const DEFAULT_SIDEBAR_WIDTH = 256;
+const MIN_SIDEBAR_WIDTH = 220;
+const MAX_SIDEBAR_WIDTH = 380;
+const SHELL_PREFERENCES_UI_VERSION = 2;
+const LEGACY_DEFAULT_EDITOR_FONT_SIZE = 14;
+const LEGACY_DEFAULT_SIDEBAR_WIDTH = 292;
+const VSCODE_DARK_TERMINAL_THEME = {
+  background: "#1e1e1e",
+  foreground: "#cccccc",
+  cursor: "#cccccc",
+  cursorAccent: "#1e1e1e",
+  selectionBackground: "#264f78",
+  selectionInactiveBackground: "rgba(38, 79, 120, 0.5)",
+  black: "#000000",
+  red: "#cd3131",
+  green: "#0dbc79",
+  yellow: "#e5e510",
+  blue: "#2472c8",
+  magenta: "#bc3fbc",
+  cyan: "#11a8cd",
+  white: "#e5e5e5",
+  brightBlack: "#666666",
+  brightRed: "#f14c4c",
+  brightGreen: "#23d18b",
+  brightYellow: "#f5f543",
+  brightBlue: "#3b8eea",
+  brightMagenta: "#d670d6",
+  brightCyan: "#29b8db",
+  brightWhite: "#e5e5e5",
+};
 const DEFAULT_VOICE_SHORTCUT = "Ctrl+Alt+M";
 const RESERVED_VOICE_SHORTCUTS = new Set(["Win+H", "Ctrl+Space", "Ctrl+Shift+Space"]);
 const VOICE_LONG_SESSION_WARNING_MS = 5 * 60 * 1000;
@@ -1404,14 +1435,19 @@ function createPane(paneId?: string): string {
   container.appendChild(paneDiv);
 
   const terminal = new Terminal({
-    cursorBlink: true,
+    allowProposedApi: true,
+    cursorBlink: false,
+    cursorStyle: "block",
+    cursorInactiveStyle: "outline",
     fontSize: themeState.editorFontSize,
     fontFamily: getCodeFontFamily(),
-    theme: {
-      background: "#131722",
-      foreground: "#c7d2e6",
-      cursor: "#c7d2e6",
-    },
+    fontWeight: "normal",
+    fontWeightBold: "bold",
+    letterSpacing: 0,
+    lineHeight: 1,
+    minimumContrastRatio: 4.5,
+    scrollback: 1000,
+    theme: VSCODE_DARK_TERMINAL_THEME,
   });
 
   const fitAddon = new FitAddon();
@@ -6156,7 +6192,11 @@ function readStoredShellPreferences(): ShellPreferenceState | null {
     const wrapMode = wrapOptions.find((item) => item.value === parsed.wrapMode)?.value;
     const codeFont = codeFontOptions.find((item) => item.value === parsed.codeFont)?.value ?? "system";
     const codeFontFamily = normalizeCodeFontFamily(parsed.codeFontFamily, getCodeFontFamily(codeFont, ""));
-    const editorFontSize = clampEditorFontSize(parsed.editorFontSize);
+    const uiVersion = typeof parsed.uiVersion === "number" ? parsed.uiVersion : 1;
+    const parsedEditorFontSize = uiVersion < SHELL_PREFERENCES_UI_VERSION && parsed.editorFontSize === LEGACY_DEFAULT_EDITOR_FONT_SIZE
+      ? DEFAULT_EDITOR_FONT_SIZE
+      : parsed.editorFontSize;
+    const editorFontSize = clampEditorFontSize(parsedEditorFontSize);
     const voiceShortcut = normalizeVoiceShortcut(parsed.voiceShortcut);
     const persistVoiceDraftLocally = parsed.persistVoiceDraftLocally === true;
     const focusMode = focusModeOptions.find((item) => item.value === parsed.focusMode)?.value ?? "standard";
@@ -6165,7 +6205,10 @@ function readStoredShellPreferences(): ShellPreferenceState | null {
       return null;
     }
 
-    const sidebarWidthValue = typeof parsed.sidebarWidth === "number" ? parsed.sidebarWidth : 292;
+    const sidebarWidthValue = typeof parsed.sidebarWidth === "number" ? parsed.sidebarWidth : DEFAULT_SIDEBAR_WIDTH;
+    const normalizedSidebarWidth = uiVersion < SHELL_PREFERENCES_UI_VERSION && sidebarWidthValue === LEGACY_DEFAULT_SIDEBAR_WIDTH
+      ? DEFAULT_SIDEBAR_WIDTH
+      : sidebarWidthValue;
     const workbenchWidthValue = typeof parsed.workbenchWidth === "number" ? parsed.workbenchWidth : null;
     const wideSidebarOpen = typeof parsed.wideSidebarOpen === "boolean" ? parsed.wideSidebarOpen : true;
     const wideContextOpen = typeof parsed.wideContextOpen === "boolean" ? parsed.wideContextOpen : false;
@@ -6177,6 +6220,7 @@ function readStoredShellPreferences(): ShellPreferenceState | null {
 
     return {
       theme,
+      uiVersion: SHELL_PREFERENCES_UI_VERSION,
       density,
       wrapMode,
       codeFont,
@@ -6186,7 +6230,7 @@ function readStoredShellPreferences(): ShellPreferenceState | null {
       persistVoiceDraftLocally,
       focusMode,
       language,
-      sidebarWidth: Math.max(240, Math.min(380, Math.round(sidebarWidthValue))),
+      sidebarWidth: Math.max(MIN_SIDEBAR_WIDTH, Math.min(MAX_SIDEBAR_WIDTH, Math.round(normalizedSidebarWidth))),
       workbenchWidth: workbenchWidthValue === null ? null : Math.max(360, Math.min(1400, Math.round(workbenchWidthValue))),
       wideSidebarOpen,
       wideContextOpen,
@@ -6203,6 +6247,7 @@ function persistThemeState() {
   try {
     const nextState: ShellPreferenceState = {
       theme: themeState.theme,
+      uiVersion: SHELL_PREFERENCES_UI_VERSION,
       density: themeState.density,
       wrapMode: themeState.wrapMode,
       codeFont: themeState.codeFont,
@@ -6411,10 +6456,10 @@ function applyLanguageChrome() {
   setElementText(
     "editor-font-size-description",
     japanese
-      ? "エディター表示と端末ペインで使うフォントサイズです。既定値は 14 です。"
-      : "Controls the font size used in editor previews and terminal panes. The default is 14.",
+      ? `エディター表示と端末ペインで使うフォントサイズです。既定値は ${DEFAULT_EDITOR_FONT_SIZE} です。`
+      : `Controls the font size used in editor previews and terminal panes. The default is ${DEFAULT_EDITOR_FONT_SIZE}.`,
   );
-  setElementText("editor-font-size-reset-btn", japanese ? "既定値 14" : "Default 14");
+  setElementText("editor-font-size-reset-btn", japanese ? `既定値 ${DEFAULT_EDITOR_FONT_SIZE}` : `Default ${DEFAULT_EDITOR_FONT_SIZE}`);
   setElementText("settings-profile-label", japanese ? "実行環境" : "Runtime");
   setElementText(
     "settings-profile-value",
@@ -6578,6 +6623,10 @@ function applyCodeFontToPanes() {
   panes.forEach((pane) => {
     pane.terminal.options.fontFamily = fontFamily;
     pane.terminal.options.fontSize = fontSize;
+    pane.terminal.options.lineHeight = 1;
+    pane.terminal.options.letterSpacing = 0;
+    pane.terminal.options.minimumContrastRatio = 4.5;
+    pane.terminal.options.theme = VSCODE_DARK_TERMINAL_THEME;
   });
   fitVisibleWorkbenchPanes();
 }
@@ -12714,13 +12763,15 @@ function initializeSidebarResize() {
   handle.addEventListener("pointerdown", (event) => {
     const startX = event.clientX;
     const startWidth = sidebarWidth;
+    document.body.classList.add("is-resizing-sidebar");
     const onMove = (moveEvent: PointerEvent) => {
-      sidebarWidth = Math.max(240, Math.min(380, startWidth + (moveEvent.clientX - startX)));
+      sidebarWidth = Math.max(MIN_SIDEBAR_WIDTH, Math.min(MAX_SIDEBAR_WIDTH, startWidth + (moveEvent.clientX - startX)));
       appShell.style.setProperty("--sidebar-width", `${sidebarWidth}px`);
     };
     const onUp = () => {
       window.removeEventListener("pointermove", onMove);
       window.removeEventListener("pointerup", onUp);
+      document.body.classList.remove("is-resizing-sidebar");
       void persistThemeState();
     };
     window.addEventListener("pointermove", onMove);

--- a/winsmux-app/src/styles.css
+++ b/winsmux-app/src/styles.css
@@ -2653,7 +2653,7 @@ body[data-popout-surface="1"] #editor-surface {
 
 .footer-pill[data-tone="accent"] .footer-pill-label,
 .footer-pill[data-tone="focus"] .footer-pill-label {
-  color: rgba(255, 255, 255, 0.82);
+  color: #ffffff;
 }
 
 .footer-pill[data-tone="success"] {

--- a/winsmux-app/src/styles.css
+++ b/winsmux-app/src/styles.css
@@ -2651,6 +2651,11 @@ body[data-popout-surface="1"] #editor-surface {
   color: #ffffff;
 }
 
+.footer-pill[data-tone="accent"] .footer-pill-label,
+.footer-pill[data-tone="focus"] .footer-pill-label {
+  color: rgba(255, 255, 255, 0.82);
+}
+
 .footer-pill[data-tone="success"] {
   color: var(--status-success);
   background: transparent;

--- a/winsmux-app/src/styles.css
+++ b/winsmux-app/src/styles.css
@@ -37,7 +37,7 @@
   --editor-font-size: 13px;
   --workbench-text-size: var(--editor-font-size);
   --workbench-meta-size: 11px;
-  --workbench-line-height: 22px;
+  --workbench-line-height: max(22px, calc(var(--editor-font-size) + 8px));
   --text-3xs: 10px;
   --text-2xs: 11px;
   --text-xs: 12px;

--- a/winsmux-app/src/styles.css
+++ b/winsmux-app/src/styles.css
@@ -1,15 +1,15 @@
 :root {
-  --bg-canvas: #0f1117;
-  --bg-surface: #151926;
-  --bg-surface-raised: #171c29;
-  --bg-panel: #1b2030;
-  --border-muted: #252b3e;
-  --border-strong: #31374d;
-  --text-primary: #eef2ff;
-  --text-secondary: #d4daf0;
-  --text-muted: #8d97b7;
-  --accent-blue: #4d76f0;
-  --accent-blue-hover: #5d84f5;
+  --bg-canvas: #1e1e1e;
+  --bg-surface: #181818;
+  --bg-surface-raised: #252526;
+  --bg-panel: #2a2d2e;
+  --border-muted: #2b2b2b;
+  --border-strong: #3c3c3c;
+  --text-primary: #cccccc;
+  --text-secondary: #a8a8a8;
+  --text-muted: #858585;
+  --accent-blue: #007acc;
+  --accent-blue-hover: #0a84ff;
   --status-success: #6ee7b7;
   --status-success-bg: rgba(110, 231, 183, 0.14);
   --status-success-border: rgba(110, 231, 183, 0.32);
@@ -26,32 +26,28 @@
   --status-focus-bg: rgba(154, 132, 255, 0.14);
   --status-focus-border: rgba(154, 132, 255, 0.34);
   --font-ui:
-    -apple-system,
-    BlinkMacSystemFont,
-    "SF Pro Text",
-    "Segoe UI Variable",
-    "OpenAI Sans",
-    "Inter",
+    "Segoe WPC",
     "Segoe UI",
-    "Noto Sans JP",
+    "Yu Gothic UI",
+    "Meiryo UI",
     "Noto Sans KR",
     "Apple SD Gothic Neo",
     sans-serif;
   --font-code: "Consolas", "Courier New", monospace;
-  --editor-font-size: 14px;
+  --editor-font-size: 13px;
   --workbench-text-size: var(--editor-font-size);
-  --workbench-meta-size: 12px;
-  --workbench-line-height: calc(var(--editor-font-size) + 8px);
-  --text-3xs: 11px;
-  --text-2xs: 12px;
-  --text-xs: 14px;
-  --text-sm: 14px;
-  --text-md: 15px;
-  --text-lg: 17px;
-  --text-xl: 28px;
+  --workbench-meta-size: 11px;
+  --workbench-line-height: 22px;
+  --text-3xs: 10px;
+  --text-2xs: 11px;
+  --text-xs: 12px;
+  --text-sm: 13px;
+  --text-md: 14px;
+  --text-lg: 15px;
+  --text-xl: 20px;
   --leading-tight: 1.2;
-  --leading-normal: 1.45;
-  --leading-relaxed: 1.6;
+  --leading-normal: 1.4;
+  --leading-relaxed: 1.5;
 }
 
 html,
@@ -63,7 +59,7 @@ body {
   background: var(--bg-canvas);
   color: var(--text-primary);
   font-family: var(--font-ui);
-  font-size: var(--text-xs);
+  font-size: var(--text-sm);
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
   overflow: hidden;
@@ -161,21 +157,22 @@ textarea {
 }
 
 #app-shell {
-  --sidebar-width: 292px;
-  --editor-width: 360px;
-  --context-width: 292px;
+  --sidebar-width: 256px;
+  --editor-width: 340px;
+  --context-width: 276px;
   --activity-width: 48px;
-  --menu-height: 32px;
+  --menu-height: 30px;
+  --statusbar-height: 22px;
   --workbench-width: minmax(420px, 38vw);
-  --shell-padding: 20px;
-  --shell-gap: 16px;
-  --panel-padding: 18px;
-  --composer-padding: 18px;
-  --composer-min-height: 72px;
-  --timeline-max-width: min(78ch, 82%);
+  --shell-padding: 0;
+  --shell-gap: 0;
+  --panel-padding: 0;
+  --composer-padding: 8px;
+  --composer-min-height: 56px;
+  --timeline-max-width: min(76ch, 86%);
   --body-wrap: break-word;
   --editor-white-space: pre-wrap;
-  --panel-radius: 20px;
+  --panel-radius: 0;
   display: grid;
   grid-template-rows: var(--menu-height) minmax(0, 1fr);
   grid-template-columns: var(--activity-width) var(--sidebar-width) minmax(0, 1fr);
@@ -188,32 +185,30 @@ textarea {
 }
 
 #app-shell[data-theme="graphite-dark"] {
-  --bg-canvas: #111318;
-  --bg-surface: #171b23;
-  --bg-surface-raised: #1b2029;
-  --bg-panel: #202633;
-  --border-muted: #2c3344;
-  --border-strong: #3b4458;
-  --text-primary: #edf1f8;
-  --text-secondary: #ced5e4;
-  --text-muted: #8d97ac;
-  --accent-blue: #6f8dff;
-  --accent-blue-hover: #84a0ff;
-  background:
-    radial-gradient(circle at top left, rgba(97, 115, 170, 0.16), transparent 36%),
-    linear-gradient(180deg, var(--bg-canvas) 0%, #131822 100%);
+  --bg-canvas: #1e1e1e;
+  --bg-surface: #181818;
+  --bg-surface-raised: #252526;
+  --bg-panel: #2a2d2e;
+  --border-muted: #2b2b2b;
+  --border-strong: #3c3c3c;
+  --text-primary: #cccccc;
+  --text-secondary: #a8a8a8;
+  --text-muted: #858585;
+  --accent-blue: #007acc;
+  --accent-blue-hover: #0a84ff;
+  background: var(--bg-canvas);
 }
 
 #app-shell[data-density="compact"] {
-  --sidebar-width: 272px;
-  --editor-width: 332px;
-  --context-width: 276px;
-  --shell-padding: 16px;
-  --shell-gap: 12px;
-  --panel-padding: 14px;
-  --composer-padding: 14px;
-  --composer-min-height: 56px;
-  --panel-radius: 16px;
+  --sidebar-width: 232px;
+  --editor-width: 320px;
+  --context-width: 252px;
+  --shell-padding: 0;
+  --shell-gap: 0;
+  --panel-padding: 0;
+  --composer-padding: 6px;
+  --composer-min-height: 48px;
+  --panel-radius: 0;
 }
 
 #app-shell[data-wrap-mode="compact"] {
@@ -243,15 +238,15 @@ textarea {
   position: relative;
   min-width: 0;
   min-height: 0;
-  border-bottom: 1px solid #242834;
+  border-bottom: 1px solid var(--border-muted);
   background: #181a1f;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 16px;
+  gap: 12px;
   padding: 0 10px;
   color: #c9d1dc;
-  font-size: var(--text-xs);
+  font-size: var(--text-sm);
 }
 
 #top-menu-items {
@@ -355,21 +350,21 @@ textarea {
   z-index: 40;
   min-width: 0;
   min-height: 0;
-  border-right: 1px solid #252936;
-  background: #15171c;
+  border-right: 1px solid var(--border-muted);
+  background: var(--bg-surface);
   display: flex;
   flex-direction: column;
   align-items: stretch;
-  padding: 6px 4px;
-  gap: 4px;
+  padding: 0;
+  gap: 0;
 }
 
 .activity-btn {
   position: relative;
-  width: 40px;
-  height: 40px;
+  width: 48px;
+  height: 48px;
   border: 0;
-  border-radius: 4px;
+  border-radius: 0;
   background: transparent;
   color: #8f98a8;
   display: inline-flex;
@@ -379,11 +374,11 @@ textarea {
 }
 
 .activity-icon {
-  width: 23px;
-  height: 23px;
+  width: 22px;
+  height: 22px;
   fill: none;
   stroke: currentColor;
-  stroke-width: 1.7;
+  stroke-width: 1.5;
   stroke-linecap: round;
   stroke-linejoin: round;
 }
@@ -407,21 +402,21 @@ textarea {
 
 .activity-badge {
   position: absolute;
-  right: 4px;
-  bottom: 5px;
+  right: 8px;
+  bottom: 8px;
   min-width: 16px;
   height: 16px;
   padding: 0 4px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border-radius: 999px;
+  border-radius: 20px;
   background: #3d95d8;
   color: #fff;
   font-size: var(--text-3xs);
   line-height: 1;
   font-weight: 700;
-  box-shadow: 0 0 0 2px #15171c;
+  box-shadow: 0 0 0 2px var(--bg-surface);
 }
 
 .activity-spacer {
@@ -431,25 +426,29 @@ textarea {
 #left-rail {
   grid-area: side;
   position: relative;
-  border-right: 1px solid #232737;
-  background: #1b1e26;
-  padding: 10px 8px;
+  border-right: 1px solid var(--border-muted);
+  background: var(--bg-surface);
+  padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 0;
   width: var(--sidebar-width);
-  min-width: 240px;
+  min-width: 220px;
   min-height: 0;
   overflow-y: auto;
   overflow-x: hidden;
 }
 
 .sidebar-mode-title {
-  min-height: 24px;
-  padding: 4px 8px 2px;
-  color: #c9d1dc;
-  font-size: var(--text-xs);
-  font-weight: 600;
+  min-height: 22px;
+  padding: 0 8px 0 20px;
+  color: var(--text-secondary);
+  font-size: var(--text-2xs);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0;
+  display: flex;
+  align-items: center;
 }
 
 .brand-block {
@@ -474,7 +473,7 @@ textarea {
 .sidebar-section {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 0;
 }
 
 #files-sidebar-section {
@@ -485,49 +484,68 @@ textarea {
 .sidebar-section-title {
   display: flex;
   align-items: center;
-  gap: 7px;
+  gap: 6px;
+  min-height: 22px;
+  padding: 0 8px 0 20px;
   font-size: var(--text-2xs);
   font-weight: 700;
   text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: #7d88a9;
+  letter-spacing: 0;
+  color: var(--text-secondary);
 }
 
 .sidebar-list {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 0;
 }
 
 .sidebar-row {
   display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 2px;
+  flex-direction: row;
+  align-items: center;
+  gap: 6px;
   width: 100%;
-  border: 1px solid var(--border-muted);
-  border-radius: 14px;
-  background: var(--bg-surface);
+  min-height: var(--workbench-line-height);
+  border: 0;
+  border-radius: 0;
+  background: transparent;
   color: var(--text-secondary);
-  padding: 10px 12px;
+  padding: 0 8px 0 20px;
   text-align: left;
+  line-height: var(--workbench-line-height);
   cursor: pointer;
 }
 
-.sidebar-row:hover,
+.sidebar-row:hover {
+  background: #2a2d2e;
+}
+
 .sidebar-row.is-active {
-  background: var(--bg-panel);
-  border-color: var(--status-focus-border);
+  background: #37373d;
+  color: #ffffff;
+}
+
+.sidebar-row.is-active .sidebar-row-title,
+.sidebar-row.is-active .sidebar-row-meta {
+  color: #ffffff;
 }
 
 .sidebar-row-title {
-  font-size: var(--text-sm);
+  min-width: 0;
+  font-size: var(--workbench-text-size);
   color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .sidebar-row-meta {
-  font-size: var(--text-2xs);
+  font-size: var(--workbench-meta-size);
   color: var(--text-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .sidebar-tree-row {
@@ -547,11 +565,12 @@ textarea {
   border: 0;
   border-radius: 0;
   background: transparent;
-  padding: 0 6px 0 calc(6px + var(--tree-indent));
+  padding: 0 6px 0 calc(8px + var(--tree-indent));
   display: grid;
   grid-template-columns: 16px 16px minmax(0, 1fr) 22px;
-  column-gap: 3px;
+  column-gap: 4px;
   align-items: center;
+  line-height: var(--workbench-line-height);
   color: #cccccc;
 }
 
@@ -761,17 +780,18 @@ textarea {
   align-items: center;
   justify-content: space-between;
   gap: 10px;
-  border-radius: 12px;
-  padding: 8px 10px;
-  background: var(--bg-surface);
-  border: 1px solid var(--border-muted);
+  min-height: 22px;
+  border-radius: 0;
+  padding: 0 8px 0 20px;
+  background: transparent;
+  border: 0;
 }
 
 .sidebar-summary-label {
   font-size: var(--text-2xs);
   text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: #7d88a9;
+  letter-spacing: 0;
+  color: var(--text-muted);
 }
 
 .sidebar-summary-value {
@@ -875,27 +895,29 @@ textarea {
   min-height: 32px;
   resize: vertical;
   border: 1px solid #3c3c3c;
-  border-radius: 3px;
+  border-radius: 0;
   background: #181818;
   color: #cccccc;
   padding: 5px 8px;
   outline: none;
   font-size: var(--workbench-text-size);
   line-height: var(--leading-normal);
-  font-family: var(--font-code);
+  font-family: var(--font-ui);
 }
 
 #source-control-message:focus {
   border-color: #007fd4;
-  box-shadow: 0 0 0 1px #007fd4;
+  outline: 1px solid #007fd4;
+  outline-offset: -1px;
+  box-shadow: none;
 }
 
 .source-control-commit-btn {
   width: 100%;
-  min-height: 30px;
-  border: 0;
-  border-radius: 3px;
-  background: #007acc;
+  min-height: 26px;
+  border: 1px solid transparent;
+  border-radius: 2px;
+  background: #0e639c;
   color: #fff;
   display: inline-flex;
   align-items: center;
@@ -903,7 +925,7 @@ textarea {
   gap: 8px;
   cursor: pointer;
   font-size: var(--text-xs);
-  font-weight: 700;
+  font-weight: 400;
 }
 
 .source-control-commit-btn:disabled {
@@ -998,10 +1020,15 @@ textarea {
 }
 
 .source-control-status {
-  font-size: var(--text-xs);
+  min-width: 16px;
+  padding: 0 4px;
+  border-radius: 8px;
+  font-size: var(--text-2xs);
+  line-height: 16px;
   color: #d7ba7d;
   font-weight: 700;
   justify-self: end;
+  text-align: center;
 }
 
 .source-control-file-main {
@@ -1017,10 +1044,10 @@ textarea {
   text-overflow: ellipsis;
   white-space: nowrap;
   color: #cccccc;
-  font-family: var(--font-code);
+  font-family: var(--font-ui);
   font-size: var(--workbench-text-size);
   line-height: var(--workbench-line-height);
-  font-weight: 500;
+  font-weight: 400;
 }
 
 .source-control-file-dir {
@@ -1220,6 +1247,23 @@ textarea {
   width: 8px;
   height: 100%;
   cursor: col-resize;
+  z-index: 5;
+}
+
+#sidebar-resizer::before {
+  content: "";
+  position: absolute;
+  top: 10px;
+  bottom: 10px;
+  left: 3px;
+  width: 2px;
+  background: transparent;
+}
+
+#sidebar-resizer:hover::before,
+#sidebar-resizer:focus-visible::before,
+body.is-resizing-sidebar #sidebar-resizer::before {
+  background: var(--accent-blue);
 }
 
 #workspace {
@@ -1229,8 +1273,8 @@ textarea {
   height: 100%;
   display: grid;
   grid-template-rows: minmax(0, 1fr) auto;
-  padding: 10px 12px 8px;
-  gap: 10px;
+  padding: 0;
+  gap: 0;
   overflow: hidden;
 }
 
@@ -1298,11 +1342,12 @@ textarea {
   gap: 6px;
   flex: 0 0 auto;
   white-space: nowrap;
-  border: 1px solid var(--border-strong);
-  background: var(--bg-surface-raised);
+  min-height: 22px;
+  border: 1px solid transparent;
+  background: transparent;
   color: var(--text-secondary);
-  border-radius: 6px;
-  padding: 5px 8px;
+  border-radius: 3px;
+  padding: 0 8px;
   font-size: var(--text-xs);
   line-height: 1.2;
   cursor: pointer;
@@ -1310,18 +1355,19 @@ textarea {
 
 .ghost-btn:hover {
   background: var(--bg-panel);
+  border-color: var(--border-muted);
 }
 
 .ghost-btn-small {
-  padding: 5px 8px;
-  border-radius: 8px;
+  padding: 0 6px;
+  border-radius: 3px;
 }
 
 #workspace-body {
   min-height: 0;
   display: grid;
   grid-template-columns: minmax(300px, 1fr) var(--context-width) var(--workbench-width);
-  gap: 10px;
+  gap: 0;
 }
 
 #workspace-body.editor-open {
@@ -1411,8 +1457,8 @@ body[data-popout-surface="1"] #editor-surface {
 #editor-surface,
 #context-panel,
 #terminal-drawer {
-  border: 1px solid var(--border-muted);
-  border-radius: 8px;
+  border: 0;
+  border-radius: 0;
   background: var(--bg-surface);
 }
 
@@ -1422,13 +1468,14 @@ body[data-popout-surface="1"] #editor-surface {
   grid-template-rows: auto minmax(0, 1fr) auto;
   overflow: hidden;
   background: #1e1e1e;
+  border-right: 1px solid var(--border-muted);
 }
 
 #thread-meta {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  min-height: 34px;
+  min-height: 22px;
   padding: 0 12px;
   border-bottom: 1px solid #2d2d30;
   background: #181818;
@@ -1565,8 +1612,8 @@ body[data-popout-surface="1"] #editor-surface {
 
 .work-dashboard-stage-pill {
   border: 1px solid var(--border-muted);
-  border-radius: 999px;
-  padding: 4px 8px;
+  border-radius: 3px;
+  padding: 2px 6px;
   color: var(--text-secondary);
   font-size: var(--text-2xs);
   white-space: nowrap;
@@ -1591,10 +1638,10 @@ body[data-popout-surface="1"] #editor-surface {
   align-items: center;
   gap: 6px;
   border: 1px solid var(--border-muted);
-  border-radius: 999px;
+  border-radius: 3px;
   background: var(--bg-panel);
   color: var(--text-secondary);
-  padding: 4px 8px;
+  padding: 2px 6px;
   font-size: var(--text-2xs);
 }
 
@@ -1634,10 +1681,10 @@ body[data-popout-surface="1"] #editor-surface {
 
 .timeline-filter-chip {
   border: 1px solid var(--border-strong);
-  border-radius: 999px;
+  border-radius: 3px;
   background: var(--bg-surface-raised);
   color: var(--text-secondary);
-  padding: 6px 10px;
+  padding: 3px 7px;
   cursor: pointer;
   font-size: var(--text-xs);
 }
@@ -1657,9 +1704,9 @@ body[data-popout-surface="1"] #editor-surface {
 
 .run-summary-card {
   border: 1px solid var(--border-muted);
-  border-radius: 10px;
+  border-radius: 4px;
   background: var(--bg-surface-raised);
-  padding: 10px 12px;
+  padding: 8px 10px;
   display: flex;
   flex-direction: column;
   gap: 8px;
@@ -1675,8 +1722,8 @@ body[data-popout-surface="1"] #editor-surface {
 .timeline-eyebrow {
   font-size: var(--text-2xs);
   text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: #7d88a9;
+  letter-spacing: 0;
+  color: var(--text-muted);
   margin-bottom: 4px;
 }
 
@@ -1689,8 +1736,8 @@ body[data-popout-surface="1"] #editor-surface {
 .run-summary-status {
   display: inline-flex;
   align-items: center;
-  border-radius: 999px;
-  padding: 5px 10px;
+  border-radius: 3px;
+  padding: 2px 6px;
   font-size: var(--text-2xs);
   font-weight: 700;
   border: 1px solid var(--border-muted);
@@ -1717,8 +1764,8 @@ body[data-popout-surface="1"] #editor-surface {
 .run-summary-pill {
   display: inline-flex;
   align-items: center;
-  border-radius: 999px;
-  padding: 5px 10px;
+  border-radius: 3px;
+  padding: 2px 6px;
   background: var(--bg-panel);
   border: 1px solid var(--border-muted);
   color: var(--text-secondary);
@@ -1896,7 +1943,7 @@ body[data-popout-surface="1"] #editor-surface {
 
 #composer {
   border-top: 1px solid var(--border-muted);
-  padding: 8px 12px 10px;
+  padding: 8px 12px;
   background: #1e1e1e;
 }
 
@@ -1908,17 +1955,17 @@ body[data-popout-surface="1"] #editor-surface {
 
 #composer-input {
   width: 100%;
-  min-height: 54px;
+  min-height: 40px;
   max-height: min(40vh, 360px);
   resize: none;
   overflow-y: hidden;
-  border: 1px solid #6a6a6a;
-  border-radius: 4px;
+  border: 1px solid #3c3c3c;
+  border-radius: 2px;
   background: #1e1e1e;
   color: #d4d4d4;
-  padding: 10px 78px 10px 12px;
+  padding: 6px 56px 6px 8px;
   outline: none;
-  font-size: var(--text-xs);
+  font-size: var(--text-sm);
   line-height: var(--leading-normal);
 }
 
@@ -1931,7 +1978,9 @@ body[data-popout-surface="1"] #editor-surface {
 
 #composer-input:focus {
   border-color: var(--accent-blue-hover);
-  box-shadow: 0 0 0 3px rgba(90, 132, 245, 0.18);
+  outline: 1px solid var(--accent-blue-hover);
+  outline-offset: -1px;
+  box-shadow: none;
 }
 
 .voice-input-status {
@@ -1990,13 +2039,13 @@ body[data-popout-surface="1"] #editor-surface {
 }
 
 .composer-session-trigger {
-  min-height: 26px;
+  min-height: 22px;
   max-width: min(44vw, 280px);
   border: 0;
-  border-radius: 4px;
+  border-radius: 3px;
   background: transparent;
   color: var(--text-primary);
-  padding: 3px 6px;
+  padding: 0 6px;
   display: inline-flex;
   align-items: center;
   gap: 6px;
@@ -2040,7 +2089,7 @@ body[data-popout-surface="1"] #editor-surface {
   width: min(360px, calc(100vw - 48px));
   padding: 6px;
   border: 1px solid var(--border-strong);
-  border-radius: 7px;
+  border-radius: 4px;
   background: #1e1e1e;
   box-shadow: 0 18px 48px rgba(0, 0, 0, 0.36);
   display: grid;
@@ -2199,10 +2248,10 @@ body[data-popout-surface="1"] #editor-surface {
 
 .mode-chip {
   border: 1px solid var(--border-strong);
-  border-radius: 7px;
+  border-radius: 3px;
   background: var(--bg-surface-raised);
   color: var(--text-secondary);
-  padding: 4px 8px;
+  padding: 3px 7px;
   font-size: var(--text-xs);
   line-height: 1.2;
   cursor: pointer;
@@ -2217,10 +2266,10 @@ body[data-popout-surface="1"] #editor-surface {
 
 .slash-chip {
   border: 1px solid var(--border-muted);
-  border-radius: 14px;
+  border-radius: 4px;
   background: var(--bg-panel);
   color: var(--text-secondary);
-  padding: 8px 10px;
+  padding: 6px 8px;
   cursor: pointer;
   display: inline-flex;
   flex-direction: column;
@@ -2247,10 +2296,10 @@ body[data-popout-surface="1"] #editor-surface {
 
 .remote-chip {
   border: 1px solid var(--border-muted);
-  border-radius: 14px;
+  border-radius: 4px;
   background: var(--bg-surface-raised);
   color: var(--text-secondary);
-  padding: 8px 10px;
+  padding: 6px 8px;
   cursor: pointer;
   display: inline-flex;
   flex-direction: column;
@@ -2339,7 +2388,7 @@ body[data-popout-surface="1"] #editor-surface {
 .attachment-empty-state {
   display: inline-flex;
   align-items: center;
-  min-height: 36px;
+  min-height: 26px;
   padding: 0 2px;
   color: var(--text-muted);
   font-size: var(--text-xs);
@@ -2348,23 +2397,23 @@ body[data-popout-surface="1"] #editor-surface {
 .attachment-item {
   display: grid;
   grid-template-columns: auto minmax(0, 1fr) auto;
-  gap: 10px;
+  gap: 8px;
   align-items: center;
   min-width: 0;
   max-width: 320px;
-  padding: 8px 10px;
-  border-radius: 14px;
+  padding: 6px 8px;
+  border-radius: 4px;
   background: var(--bg-panel);
   border: 1px solid var(--border-muted);
 }
 
 .attachment-thumb {
-  width: 36px;
-  height: 36px;
-  border-radius: 10px;
+  width: 28px;
+  height: 28px;
+  border-radius: 2px;
   object-fit: cover;
   border: 1px solid var(--border-strong);
-  background: #0f1117;
+  background: #1e1e1e;
 }
 
 .attachment-thumb-file {
@@ -2401,8 +2450,8 @@ body[data-popout-surface="1"] #editor-surface {
   border: 1px solid var(--border-strong);
   background: var(--bg-surface-raised);
   color: var(--text-secondary);
-  border-radius: 999px;
-  padding: 6px 10px;
+  border-radius: 3px;
+  padding: 3px 7px;
   cursor: pointer;
   font-size: var(--text-2xs);
 }
@@ -2434,28 +2483,28 @@ body[data-popout-surface="1"] #editor-surface {
 
 .composer-icon-btn {
   position: relative;
-  width: 36px;
-  min-width: 36px;
-  height: 36px;
-  min-height: 36px;
+  width: 24px;
+  min-width: 24px;
+  height: 24px;
+  min-height: 24px;
   padding: 0;
-  border-radius: 999px;
+  border-radius: 3px;
 }
 
 .composer-icon-btn .button-icon {
-  width: 16px;
-  height: 16px;
+  width: 14px;
+  height: 14px;
 }
 
 .composer-input-icon-btn {
   position: absolute;
-  right: 42px;
-  bottom: 8px;
-  width: 30px;
-  min-width: 30px;
-  height: 30px;
-  min-height: 30px;
-  border-radius: 7px;
+  right: 36px;
+  bottom: 6px;
+  width: 24px;
+  min-width: 24px;
+  height: 24px;
+  min-height: 24px;
+  border-radius: 3px;
   background: transparent;
   border-color: transparent;
   color: var(--text-muted);
@@ -2524,14 +2573,14 @@ body[data-popout-surface="1"] #editor-surface {
 
 #send-btn {
   position: absolute;
-  right: 8px;
-  bottom: 8px;
+  right: 6px;
+  bottom: 6px;
   border: 0;
-  border-radius: 7px;
-  width: 30px;
-  min-width: 30px;
-  height: 30px;
-  min-height: 30px;
+  border-radius: 3px;
+  width: 24px;
+  min-width: 24px;
+  height: 24px;
+  min-height: 24px;
   padding: 0;
   background: var(--accent-blue);
   color: #fff;
@@ -2547,62 +2596,78 @@ body[data-popout-surface="1"] #editor-surface {
 
 #workspace-footer {
   display: flex;
-  align-items: center;
+  align-items: stretch;
   justify-content: space-between;
-  gap: 12px;
+  gap: 0;
+  height: var(--statusbar-height);
   min-width: 0;
+  padding: 0;
+  border-top: 1px solid var(--border-muted);
+  background: var(--bg-surface);
+  color: var(--text-primary);
+  font-size: var(--text-xs);
 }
 
 #footer-left,
 #footer-right {
   display: flex;
-  align-items: center;
-  gap: 8px;
+  align-items: stretch;
+  gap: 0;
   min-width: 0;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
 }
 
 #footer-right {
   justify-content: flex-end;
+  margin-left: auto;
 }
 
 .footer-pill {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
-  border: 1px solid var(--border-muted);
-  border-radius: 999px;
-  background: rgba(18, 21, 33, 0.9);
-  color: var(--text-secondary);
-  padding: 8px 12px;
+  gap: 6px;
+  height: var(--statusbar-height);
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  color: var(--text-primary);
+  padding: 0 5px;
+  margin: 0 3px;
+  line-height: var(--statusbar-height);
+  max-width: 40vw;
+  font-variant-numeric: tabular-nums;
   cursor: pointer;
+  white-space: nowrap;
+  min-width: 0;
 }
 
 .footer-pill:hover {
-  background: rgba(25, 31, 47, 0.96);
+  background: rgba(90, 93, 94, 0.31);
 }
 
 .footer-pill[data-tone="accent"],
 .footer-pill[data-tone="focus"] {
-  border-color: var(--status-focus-border);
-  color: var(--text-primary);
+  background: var(--accent-blue);
+  color: #ffffff;
 }
 
 .footer-pill[data-tone="success"] {
-  border-color: var(--status-success-border);
   color: var(--status-success);
+  background: transparent;
 }
 
 .footer-pill-label {
-  font-size: var(--text-2xs);
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
+  font-size: var(--text-xs);
+  text-transform: none;
+  letter-spacing: 0;
   color: var(--text-muted);
 }
 
 .footer-pill-value {
   font-size: var(--text-xs);
   white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 #editor-surface,
@@ -2694,15 +2759,16 @@ body[data-popout-surface="1"] #editor-surface {
 }
 
 #editor-file-path {
-  font-size: var(--text-xs);
+  font-size: var(--workbench-text-size);
   color: #cccccc;
   font-family: var(--font-code);
   display: block;
   min-width: 0;
   overflow-x: auto;
   white-space: nowrap;
-  min-height: 28px;
-  padding: 6px 12px;
+  min-height: 22px;
+  padding: 0 8px;
+  line-height: 22px;
   border-bottom: 1px solid #2d2d30;
   background: #1e1e1e;
 }
@@ -3009,8 +3075,8 @@ body[data-popout-surface="1"] #editor-surface {
   min-height: 22px;
   padding: 3px 10px;
   border-top: 1px solid #2d2d30;
-  background: #181818;
-  font-size: var(--text-2xs);
+  background: #1e1e1e;
+  font-size: var(--text-xs);
   color: #cccccc;
   pointer-events: none;
 }
@@ -3044,13 +3110,13 @@ body[data-popout-surface="1"] #editor-surface {
 .context-label {
   font-size: var(--text-2xs);
   text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: #7e88a8;
+  letter-spacing: 0;
+  color: var(--text-muted);
 }
 
 .context-value {
   font-size: var(--text-sm);
-  color: #e5e9f8;
+  color: var(--text-primary);
 }
 
 #source-overview-cards {
@@ -3067,9 +3133,9 @@ body[data-popout-surface="1"] #editor-surface {
 
 .source-overview-card {
   border: 1px solid var(--border-muted);
-  border-radius: 14px;
+  border-radius: 4px;
   background: var(--bg-surface);
-  padding: 12px;
+  padding: 8px 10px;
   display: flex;
   flex-direction: column;
   gap: 6px;
@@ -3094,9 +3160,9 @@ body[data-popout-surface="1"] #editor-surface {
 
 .handoff-cockpit-row {
   border: 1px solid var(--border-muted);
-  border-radius: 14px;
+  border-radius: 4px;
   background: var(--bg-surface);
-  padding: 10px 12px;
+  padding: 8px 10px;
   display: grid;
   grid-template-columns: minmax(76px, auto) minmax(0, 1fr);
   gap: 3px 10px;
@@ -3123,7 +3189,7 @@ body[data-popout-surface="1"] #editor-surface {
   font-size: var(--text-2xs);
   font-weight: 700;
   text-transform: uppercase;
-  letter-spacing: 0.08em;
+  letter-spacing: 0;
 }
 
 .handoff-cockpit-value {
@@ -3144,9 +3210,9 @@ body[data-popout-surface="1"] #editor-surface {
 
 .experiment-detail-card {
   border: 1px solid var(--border-muted);
-  border-radius: 14px;
+  border-radius: 4px;
   background: var(--bg-surface);
-  padding: 12px;
+  padding: 8px 10px;
   display: flex;
   flex-direction: column;
   gap: 8px;
@@ -3208,7 +3274,7 @@ body[data-popout-surface="1"] #editor-surface {
 
 .experiment-detail-line.is-actionable {
   cursor: pointer;
-  border-radius: 10px;
+  border-radius: 3px;
   padding: 4px 6px;
   margin: 0 -6px;
 }
@@ -3299,7 +3365,7 @@ body[data-popout-surface="1"] #editor-surface {
   gap: 6px;
   padding: 12px 14px;
   border: 1px solid var(--border-muted);
-  border-radius: 16px;
+  border-radius: 4px;
   background: var(--bg-surface);
 }
 
@@ -3310,10 +3376,10 @@ body[data-popout-surface="1"] #editor-surface {
   gap: 2px;
   width: 100%;
   border: 1px solid var(--border-muted);
-  border-radius: 14px;
+  border-radius: 4px;
   background: var(--bg-surface);
   color: var(--text-secondary);
-  padding: 10px 12px;
+  padding: 8px 10px;
   text-align: left;
   cursor: pointer;
 }
@@ -3439,12 +3505,12 @@ body.is-resizing-workbench {
 
 #settings-search-input {
   width: 100%;
-  height: 30px;
+  height: 26px;
   border: 1px solid #3c3c3c;
-  border-radius: 3px;
+  border-radius: 0;
   background: #151515;
   color: #cccccc;
-  padding: 0 60px 0 10px;
+  padding: 0 24px 0 4px;
   font-size: var(--text-xs);
   outline: none;
 }
@@ -3455,8 +3521,8 @@ body.is-resizing-workbench {
 
 .settings-search-actions {
   position: absolute;
-  right: 30px;
-  top: 20px;
+  right: 28px;
+  top: 18px;
   display: inline-flex;
   gap: 8px;
   color: #8f8f8f;
@@ -3465,27 +3531,26 @@ body.is-resizing-workbench {
 
 .settings-tabs {
   display: flex;
-  gap: 18px;
+  gap: 0;
   margin: 10px 24px 0;
   padding: 0;
   border-bottom: 1px solid #2d2d30;
 }
 
 .settings-tab {
-  min-height: 34px;
   border: 0;
   border-bottom: 1px solid transparent;
   background: transparent;
   color: #cccccc;
-  padding: 0 0 1px;
+  padding: 7px 8px 6.5px;
   font: inherit;
   font-size: 13px;
   cursor: pointer;
 }
 
 .settings-tab.is-active {
-  border-bottom-color: #cccccc;
-  color: #ffffff;
+  border-bottom-color: #e7e7e7;
+  color: #e7e7e7;
 }
 
 .settings-layout {
@@ -3594,17 +3659,20 @@ body.is-resizing-workbench {
 #command-bar-input {
   width: 100%;
   border: 1px solid var(--border-strong);
-  border-radius: 16px;
+  border-radius: 2px;
   background: var(--bg-panel);
   color: var(--text-primary);
-  padding: 14px 16px;
+  min-height: 30px;
+  padding: 0 8px;
   outline: none;
-  font-size: var(--text-md);
+  font-size: var(--text-sm);
 }
 
 #command-bar-input:focus {
   border-color: var(--accent-blue-hover);
-  box-shadow: 0 0 0 3px rgba(90, 132, 245, 0.18);
+  outline: 1px solid var(--accent-blue-hover);
+  outline-offset: -1px;
+  box-shadow: none;
 }
 
 #command-bar-results {
@@ -3618,10 +3686,10 @@ body.is-resizing-workbench {
 .command-bar-item {
   width: 100%;
   border: 1px solid var(--border-muted);
-  border-radius: 16px;
+  border-radius: 4px;
   background: var(--bg-surface);
   color: var(--text-secondary);
-  padding: 14px 16px;
+  padding: 8px 10px;
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
@@ -3681,8 +3749,8 @@ body.is-resizing-workbench {
   color: var(--text-primary);
   font-size: var(--text-2xs);
   border: 1px solid var(--border-strong);
-  border-radius: 999px;
-  padding: 4px 8px;
+  border-radius: 3px;
+  padding: 2px 6px;
   background: rgba(10, 12, 18, 0.56);
 }
 
@@ -3702,7 +3770,7 @@ body.is-resizing-workbench {
   display: flex;
   flex-direction: column;
   gap: 7px;
-  padding: 16px 0 18px;
+  padding: 12px 14px 18px;
   border-bottom: 0;
 }
 
@@ -3712,16 +3780,16 @@ body.is-resizing-workbench {
 
 #settings-common-label {
   margin-bottom: 12px;
-  color: #ffffff;
-  font-size: 26px;
-  font-weight: 700;
+  color: #e7e7e7;
+  font-size: 22px;
+  font-weight: 600;
   letter-spacing: 0;
 }
 
 .settings-section:not(.settings-section-main) > .context-label {
-  color: #ffffff;
-  font-size: 18px;
-  font-weight: 700;
+  color: #e7e7e7;
+  font-size: var(--workbench-text-size);
+  font-weight: 600;
   letter-spacing: 0;
 }
 
@@ -3779,9 +3847,9 @@ body.is-resizing-workbench {
 .settings-number-input {
   width: 200px;
   min-width: 0;
-  height: 27px;
+  height: 22px;
   border: 1px solid #3c3c3c;
-  border-radius: 3px;
+  border-radius: 0;
   background: #151515;
   color: #cccccc;
   padding: 0 8px;
@@ -3792,9 +3860,9 @@ body.is-resizing-workbench {
 .settings-text-input {
   width: 420px;
   max-width: 100%;
-  height: 27px;
+  height: 22px;
   border: 1px solid #3c3c3c;
-  border-radius: 3px;
+  border-radius: 0;
   background: #151515;
   color: #cccccc;
   padding: 0 8px;
@@ -4059,8 +4127,9 @@ body.is-resizing-workbench {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 16px;
-  padding: 12px 16px;
+  min-height: 30px;
+  gap: 12px;
+  padding: 0 12px;
   border-bottom: 1px solid var(--border-muted);
   font-size: var(--text-xs);
   color: #8f99ba;
@@ -4069,7 +4138,7 @@ body.is-resizing-workbench {
 #terminal-toolbar-actions {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 4px;
 }
 
 #terminal-toolbar span {
@@ -4082,11 +4151,13 @@ body.is-resizing-workbench {
 #workbench-layout-btn,
 #focused-pane-select {
   border: 1px solid var(--border-strong);
-  background: var(--bg-surface-raised);
+  background: transparent;
   color: var(--text-secondary);
-  border-radius: 6px;
-  padding: 8px 12px;
+  border-radius: 3px;
+  min-height: 22px;
+  padding: 0 8px;
   cursor: pointer;
+  font-size: var(--text-xs);
 }
 
 #add-pane-btn:hover,
@@ -4111,7 +4182,7 @@ body.is-resizing-workbench {
   grid-template-columns: repeat(2, minmax(0, 1fr));
   grid-auto-rows: minmax(0, 1fr);
   overflow: hidden;
-  background: #0f1117;
+  background: #1e1e1e;
 }
 
 #terminal-drawer[data-layout="3x2"] #panes-container {
@@ -4127,41 +4198,41 @@ body.is-resizing-workbench {
   flex-direction: column;
   min-width: 0;
   min-height: 0;
-  border-right: 1px solid #252b3e;
-  border-bottom: 1px solid #252b3e;
+  border-right: 1px solid var(--border-muted);
+  border-bottom: 1px solid var(--border-muted);
   overflow: hidden;
 }
 
 .pane-header {
-  min-height: 30px;
-  background: #171c29;
+  min-height: 22px;
+  background: var(--bg-surface-raised);
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 3px 8px;
-  gap: 8px;
+  padding: 0 8px;
+  gap: 6px;
   flex-shrink: 0;
 }
 
 .pane-heading {
   min-width: 0;
   display: flex;
-  flex-direction: column;
-  justify-content: center;
-  gap: 1px;
+  flex-direction: row;
+  align-items: center;
+  gap: 6px;
 }
 
 .pane-label {
-  color: #8b95b8;
-  font-size: var(--workbench-text-size);
-  line-height: 1.2;
+  color: var(--text-primary);
+  font-size: var(--text-xs);
+  line-height: 22px;
   font-family: var(--font-code);
 }
 
 .pane-meta {
   color: var(--text-muted);
-  font-size: var(--workbench-meta-size);
-  line-height: 1.2;
+  font-size: var(--text-2xs);
+  line-height: 22px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -4171,7 +4242,7 @@ body.is-resizing-workbench {
   background: none;
   border: none;
   color: #8b95b8;
-  font-size: 14px;
+  font-size: 12px;
   cursor: pointer;
   flex-shrink: 0;
 }
@@ -4183,15 +4254,26 @@ body.is-resizing-workbench {
 .pane-terminal {
   flex: 1;
   overflow: hidden;
+  background: #1e1e1e;
 }
 
 .pane-terminal .xterm {
   height: 100%;
+  padding-left: 20px;
+}
+
+.pane-terminal .xterm .xterm-scrollable-element {
+  margin-left: -20px;
+  padding-left: 20px;
+}
+
+.pane-terminal .xterm .xterm-screen {
+  cursor: text;
 }
 
 .pane-terminal .xterm .xterm-viewport {
-  background: #0f1117;
-  scrollbar-color: rgba(126, 136, 160, 0.5) transparent;
+  background: #1e1e1e;
+  scrollbar-color: rgba(121, 121, 121, 0.55) transparent;
   scrollbar-width: thin;
 }
 
@@ -4236,7 +4318,7 @@ body.is-resizing-workbench {
 
 @media (max-width: 1360px) {
   #app-shell {
-    --sidebar-width: 260px;
+    --sidebar-width: 232px;
     --editor-width: 320px;
     --workbench-width: minmax(420px, 44vw);
   }
@@ -4339,8 +4421,7 @@ body.is-resizing-workbench {
   }
 
   #workspace-footer {
-    flex-direction: column;
-    align-items: flex-start;
+    align-items: stretch;
   }
 
   #source-overview-cards,
@@ -4534,10 +4615,10 @@ body.is-resizing-workbench {
 
 @media (max-height: 760px) {
   #app-shell {
-    --shell-padding: 16px;
-    --shell-gap: 12px;
-    --composer-padding: 12px;
-    --composer-min-height: 52px;
+    --shell-padding: 0;
+    --shell-gap: 0;
+    --composer-padding: 6px;
+    --composer-min-height: 48px;
   }
 
   #workspace {
@@ -4549,7 +4630,7 @@ body.is-resizing-workbench {
   }
 
   #thread-meta {
-    padding: 12px 16px 6px;
+    padding: 0 12px;
   }
 
   #timeline-toolbar,
@@ -4626,17 +4707,17 @@ body.is-resizing-workbench {
   }
 
   #workspace-footer {
-    gap: 8px;
+    gap: 0;
   }
 
   #footer-left,
   #footer-right {
-    gap: 6px;
+    gap: 0;
   }
 
   .footer-pill {
     gap: 6px;
-    padding: 6px 10px;
+    padding: 0 5px;
   }
 
   .footer-pill-label {
@@ -4644,21 +4725,19 @@ body.is-resizing-workbench {
   }
 
   .pane-header {
-    min-height: 34px;
-    padding: 3px 8px;
-    align-items: flex-start;
-    gap: 8px;
+    min-height: 22px;
+    padding: 0 8px;
+    align-items: center;
+    gap: 6px;
   }
 
   .pane-heading {
-    gap: 1px;
+    gap: 6px;
   }
 
   .pane-meta {
     white-space: normal;
-    display: -webkit-box;
-    -webkit-box-orient: vertical;
-    -webkit-line-clamp: 2;
+    display: block;
     overflow: hidden;
   }
 }

--- a/winsmux-app/src/styles.css
+++ b/winsmux-app/src/styles.css
@@ -37,7 +37,7 @@
   --editor-font-size: 13px;
   --workbench-text-size: var(--editor-font-size);
   --workbench-meta-size: 11px;
-  --workbench-line-height: max(22px, calc(var(--editor-font-size) + 8px));
+  --workbench-line-height: 22px;
   --text-3xs: 10px;
   --text-2xs: 11px;
   --text-xs: 12px;
@@ -157,6 +157,8 @@ textarea {
 }
 
 #app-shell {
+  --workbench-text-size: var(--editor-font-size);
+  --workbench-line-height: max(22px, calc(var(--editor-font-size) + 8px));
   --sidebar-width: 256px;
   --editor-width: 340px;
   --context-width: 276px;

--- a/winsmux-app/src/styles.css
+++ b/winsmux-app/src/styles.css
@@ -157,8 +157,6 @@ textarea {
 }
 
 #app-shell {
-  --workbench-text-size: var(--editor-font-size);
-  --workbench-line-height: max(22px, calc(var(--editor-font-size) + 8px));
   --sidebar-width: 256px;
   --editor-width: 340px;
   --context-width: 276px;
@@ -497,6 +495,8 @@ textarea {
 }
 
 .sidebar-list {
+  --workbench-text-size: var(--editor-font-size);
+  --workbench-line-height: max(22px, calc(var(--editor-font-size) + 8px));
   display: flex;
   flex-direction: column;
   gap: 0;
@@ -952,6 +952,8 @@ textarea {
 }
 
 #source-control-changes-list {
+  --workbench-text-size: var(--editor-font-size);
+  --workbench-line-height: max(22px, calc(var(--editor-font-size) + 8px));
   flex: 0 0 var(--source-control-changes-height, 320px);
   min-height: 96px;
   max-height: calc(100vh - 280px);
@@ -960,6 +962,8 @@ textarea {
 }
 
 #source-control-graph-list {
+  --workbench-text-size: var(--editor-font-size);
+  --workbench-line-height: max(22px, calc(var(--editor-font-size) + 8px));
   position: relative;
   flex: 1 1 auto;
   min-height: 140px;


### PR DESCRIPTION
## Summary

- tighten the desktop shell toward a denser workbench layout
- migrate stored shell defaults to 13px editor text and a 256px sidebar
- update viewport harness expectations and Windows preview cleanup
- record microsoft/vscode UI provenance and allow required attribution names in third-party notices

## Validation

- `cmd /c npm run build`
- `cmd /c npm run test:composer-text`
- `cmd /c npm run test:editor-targets`
- `cmd /c npm run test:source-graph`
- `cmd /c npm run test:viewport-harness`
- `pwsh -NoProfile -File scripts\audit-public-surface.ps1`
- `pwsh -NoProfile -Command "Invoke-Pester -Path tests\PublicSurfacePolicy.Tests.ps1 -PassThru"`
- `pwsh -NoProfile -File scripts\git-guard.ps1 -Mode full`
- `git diff --check`
