### PR TITLE
Enforce voice dictation fallback contract

### DIFF
--- a/tests/HarnessContract.Tests.ps1
+++ b/tests/HarnessContract.Tests.ps1
@@ -8,6 +8,8 @@ Describe 'harness-check contract' {
         $script:PowerShellDeescalationPath = Join-Path $script:RepoRoot 'winsmux-core\scripts\powershell-deescalation.ps1'
         $script:WinsmuxCorePath = Join-Path $script:RepoRoot 'scripts\winsmux-core.ps1'
         $script:InternalDocsMetaPath = Join-Path $script:RepoRoot 'winsmux-core\scripts\internal-docs-meta.psd1'
+        $script:DesktopMainPath = Join-Path $script:RepoRoot 'winsmux-app\src\main.ts'
+        $script:TauriLibPath = Join-Path $script:RepoRoot 'winsmux-app\src-tauri\src\lib.rs'
         $script:SettingsLocalPath = Join-Path $script:RepoRoot '.claude\settings.local.json'
 
         $pwshCommand = Get-Command pwsh -ErrorAction SilentlyContinue | Select-Object -First 1
@@ -305,6 +307,17 @@ tasks:
         $voiceEntry[0].Focus | Should -Match '音声入力'
         $voiceEntry[0].Example | Should -Match 'フォールバック'
         $voiceEntry[0].Memo | Should -Match 'TASK-468'
+    }
+
+    It 'does not treat native microphone metering as composer dictation' {
+        $desktopMain = Get-Content -LiteralPath $script:DesktopMainPath -Raw -Encoding UTF8
+        $tauriLib = Get-Content -LiteralPath $script:TauriLibPath -Raw -Encoding UTF8
+
+        $desktopMain | Should -Match 'const supported = browserSupported;'
+        $desktopMain | Should -Not -Match 'if \(!SpeechRecognition\)[\s\S]{0,300}startNativeVoiceInput'
+        $desktopMain | Should -Match 'does not convert native audio into composer text'
+        $tauriLib | Should -Match 'Native microphone capture does not transcribe audio into text'
+        $tauriLib | Should -Match 'capture_mode = "browser_fallback"'
     }
 
     It 'documents and dispatches the legacy compatibility gate command' {

--- a/winsmux-app/src-tauri/src/lib.rs
+++ b/winsmux-app/src-tauri/src/lib.rs
@@ -33,6 +33,10 @@ use windows_sys::Win32::Media::{
 
 const DESKTOP_SUMMARY_REFRESH_EVENT: &str = "desktop-summary-refresh";
 const PTY_CAPTURE_LIMIT: usize = 64 * 1024;
+const NATIVE_VOICE_METER_ONLY_REASON: &str =
+    "Native microphone capture is available for metering only; desktop dictation still uses the documented text fallback.";
+const NATIVE_VOICE_DICTATION_FALLBACK_REASON: &str =
+    "Use browser speech recognition for composer dictation. Native microphone capture does not transcribe audio into text.";
 
 struct SinglePty {
     writer: Arc<Mutex<Box<dyn Write + Send>>>,
@@ -144,19 +148,23 @@ fn wait_voice_capture_cleanup(session: &VoiceCaptureSession, timeout: Duration) 
 fn desktop_voice_capture_status_from_snapshot(
     snapshot: VoiceCaptureRuntimeSnapshot,
 ) -> DesktopVoiceCaptureStatus {
-    let mut status = load_desktop_summary_voice_capture_status();
+    let status = load_desktop_summary_voice_capture_status();
+    desktop_voice_capture_status_from_base(status, snapshot)
+}
+
+fn desktop_voice_capture_status_from_base(
+    mut status: DesktopVoiceCaptureStatus,
+    snapshot: VoiceCaptureRuntimeSnapshot,
+) -> DesktopVoiceCaptureStatus {
     if status.native.device_count > 0 && snapshot.generation == 0 {
-        status.capture_mode = "native".to_string();
+        apply_native_voice_dictation_fallback_contract(&mut status);
         status.native.available = true;
         status.native.state = "stopped".to_string();
         status.native.permission = "unknown".to_string();
         status.native.meter_supported = true;
         status.native.meter_level = 0.0;
         status.native.restart_supported = true;
-        status.native.reason = "Native microphone capture is ready.".to_string();
-        status.browser_fallback.expected = false;
-        status.browser_fallback.reason =
-            "Native microphone capture is available in the desktop runtime.".to_string();
+        status.native.reason = NATIVE_VOICE_METER_ONLY_REASON.to_string();
         return status;
     }
 
@@ -165,7 +173,7 @@ fn desktop_voice_capture_status_from_snapshot(
     }
 
     status.capture_mode = if snapshot.native_available {
-        "native".to_string()
+        "browser_fallback".to_string()
     } else {
         "unavailable".to_string()
     };
@@ -176,13 +184,19 @@ fn desktop_voice_capture_status_from_snapshot(
     status.native.meter_level = snapshot.meter_level.clamp(0.0, 1.0);
     status.native.restart_supported = true;
     status.native.reason = snapshot.reason;
-    status.browser_fallback.expected = !snapshot.native_available;
+    status.browser_fallback.expected = true;
     status.browser_fallback.reason = if snapshot.native_available {
-        "Native microphone capture is running in the desktop runtime.".to_string()
+        NATIVE_VOICE_DICTATION_FALLBACK_REASON.to_string()
     } else {
         "Use browser speech recognition until the native capture backend is available.".to_string()
     };
     status
+}
+
+fn apply_native_voice_dictation_fallback_contract(status: &mut DesktopVoiceCaptureStatus) {
+    status.capture_mode = "browser_fallback".to_string();
+    status.browser_fallback.expected = true;
+    status.browser_fallback.reason = NATIVE_VOICE_DICTATION_FALLBACK_REASON.to_string();
 }
 
 fn load_desktop_summary_voice_capture_status() -> DesktopVoiceCaptureStatus {
@@ -1074,5 +1088,62 @@ mod tests {
             &session,
             Duration::from_millis(1)
         ));
+    }
+
+    #[test]
+    fn native_voice_status_keeps_dictation_on_text_fallback_contract() {
+        let mut status = desktop_backend::build_desktop_voice_capture_status(
+            desktop_backend::DesktopVoiceDeviceProbe {
+                device_count: 1,
+                first_device_name: Some("USB Microphone".to_string()),
+                error: None,
+            },
+        );
+
+        status.native.available = true;
+        status.native.meter_supported = true;
+        apply_native_voice_dictation_fallback_contract(&mut status);
+
+        assert_eq!(status.capture_mode, "browser_fallback");
+        assert!(status.native.available);
+        assert!(status.native.meter_supported);
+        assert!(status.browser_fallback.expected);
+        assert!(status
+            .browser_fallback
+            .reason
+            .contains("does not transcribe audio into text"));
+    }
+
+    #[test]
+    fn native_voice_snapshot_status_keeps_dictation_on_text_fallback_contract() {
+        let base_status = desktop_backend::build_desktop_voice_capture_status(
+            desktop_backend::DesktopVoiceDeviceProbe {
+                device_count: 1,
+                first_device_name: Some("USB Microphone".to_string()),
+                error: None,
+            },
+        );
+        let status = desktop_voice_capture_status_from_base(
+            base_status,
+            VoiceCaptureRuntimeSnapshot {
+                generation: 7,
+                state: "recording".to_string(),
+                permission: "granted".to_string(),
+                reason: "Native microphone capture is recording.".to_string(),
+                meter_level: 1.5,
+                running: true,
+                native_available: true,
+            },
+        );
+
+        assert_eq!(status.capture_mode, "browser_fallback");
+        assert!(status.native.available);
+        assert_eq!(status.native.state, "recording");
+        assert_eq!(status.native.meter_level, 1.0);
+        assert!(status.browser_fallback.expected);
+        assert!(status
+            .browser_fallback
+            .reason
+            .contains("does not transcribe audio into text"));
     }
 }

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -15,8 +15,6 @@ import {
   pickDesktopRunWinner,
   promoteDesktopRunTactic,
   recordDesktopDogfoodEvent,
-  startDesktopVoiceCapture,
-  stopDesktopVoiceCapture,
   subscribeToDesktopSummaryRefresh,
   type DesktopCompareRunsResult,
   type DesktopBoardPane,
@@ -525,14 +523,12 @@ let operatorOutputBuffer = "";
 let operatorOutputFlushTimer: number | null = null;
 let voiceRecognition: SpeechRecognitionLike | null = null;
 let voiceListening = false;
-let voiceInputMode: "browser" | "native" | null = null;
 let voiceTranscriptBase = "";
 let voiceSelectionEditState: { base: string; start: number; end: number; historyCaptured: boolean } | null = null;
 let activeVoiceVocabularyMode: VoiceVocabularyMode = "project";
 let voiceCaptureStatus: DesktopVoiceCaptureStatus | null = null;
 let voiceCaptureStatusError = "";
 let voiceCaptureStatusRefreshStarted = false;
-let voiceCapturePollTimer: number | null = null;
 let voiceSessionStartedAt = 0;
 let voiceSessionWarningTimer: number | null = null;
 let viewportHarnessVoiceNow: number | null = null;
@@ -6493,8 +6489,8 @@ function applyLanguageChrome() {
   setElementText(
     "voice-shortcut-description",
     japanese
-      ? "音声入力の開始と停止に使います。認識した文字は送信せず、オペレーター入力欄の下書きに入れます。"
-      : "Starts or stops voice capture and writes recognized text into the operator composer as an editable draft.",
+      ? "ブラウザーの音声認識の開始と停止に使います。認識した文字は送信せず、オペレーター入力欄の下書きに入れます。"
+      : "Starts or stops browser speech recognition and writes recognized text into the operator composer as an editable draft.",
   );
   setElementText("voice-shortcut-reset-btn", japanese ? `既定値 ${DEFAULT_VOICE_SHORTCUT}` : `Default ${DEFAULT_VOICE_SHORTCUT}`);
   setElementText("voice-draft-storage-label", japanese ? "音声下書きの復元" : "Voice Draft Recovery");
@@ -7410,8 +7406,11 @@ function isNativeVoiceCaptureAvailable() {
   return isTauri() && voiceCaptureStatus?.native.available === true;
 }
 
-function isNativeVoiceCaptureTerminalState(state: string | undefined) {
-  return state === "stopped" || state === "cancelled" || state === "permission_denied" || state === "no_microphone";
+function getNativeVoiceMeterOnlyMessage() {
+  return getLanguageText(
+    "Native microphone metering is available, but this build does not convert native audio into composer text. Use browser voice input, Windows voice typing, or keyboard input for dictation.",
+    "ネイティブのマイクメーターは使えますが、このビルドではネイティブ音声を入力欄の文字に変換しません。音声入力にはブラウザーの音声認識、Windows 音声入力、またはキーボード入力を使ってください。",
+  );
 }
 
 function getVoiceCaptureMeterPercent() {
@@ -7550,16 +7549,16 @@ function getVoiceCaptureStatusMessage() {
   if (voiceCaptureStatus.native.state === "recording") {
     const meter = getVoiceCaptureMeterPercent();
     return getLanguageText(
-      `Native microphone capture is recording. Meter ${meter}%.`,
-      `ネイティブのマイク入力で録音中です。メーターは ${meter}% です。`,
+      `Native microphone metering is running. Meter ${meter}%. It does not write text into the composer.`,
+      `ネイティブのマイクメーターは動作中です。メーターは ${meter}% です。入力欄へ文字は入りません。`,
     );
   }
 
   if (voiceCaptureStatus.native.state === "silence") {
     const meter = getVoiceCaptureMeterPercent();
     return getLanguageText(
-      `Native microphone capture is running, but speech is not detected. Meter ${meter}%.`,
-      `ネイティブのマイク入力は動作中ですが、発話を検出していません。メーターは ${meter}% です。`,
+      `Native microphone metering is running, but speech is not detected. Meter ${meter}%. It does not write text into the composer.`,
+      `ネイティブのマイクメーターは動作中ですが、発話を検出していません。メーターは ${meter}% です。入力欄へ文字は入りません。`,
     );
   }
 
@@ -7578,10 +7577,12 @@ function getVoiceCaptureStatusMessage() {
   }
 
   if (voiceCaptureStatus.native.state === "stopped") {
-    return getLanguageText(
-      "Native microphone capture is ready.",
-      "ネイティブのマイク入力を開始できます。",
-    );
+    return isNativeVoiceCaptureAvailable()
+      ? getNativeVoiceMeterOnlyMessage()
+      : getLanguageText(
+        "Browser voice input is the supported dictation fallback.",
+        "音声入力の対応済みフォールバックはブラウザーの音声認識です。",
+      );
   }
 
   if (voiceCaptureStatus.native.state === "permission_denied") {
@@ -7592,10 +7593,7 @@ function getVoiceCaptureStatusMessage() {
   }
 
   if (voiceCaptureStatus.native.available) {
-    return getLanguageText(
-      "Native microphone capture is available.",
-      "ネイティブのマイク入力を利用できます。",
-    );
+    return getNativeVoiceMeterOnlyMessage();
   }
 
   if (voiceCaptureStatus.native.state === "no_microphone") {
@@ -7648,12 +7646,6 @@ async function refreshVoiceCaptureStatus() {
   }
   updateVoiceInputButton();
   renderVoiceCaptureStatus();
-  if (voiceInputMode === "native" && isNativeVoiceCaptureTerminalState(voiceCaptureStatus?.native.state)) {
-    voiceListening = false;
-    voiceInputMode = null;
-    stopVoiceCapturePolling();
-    updateVoiceInputButton();
-  }
 }
 
 function ensureVoiceCaptureStatusRefresh() {
@@ -7664,23 +7656,6 @@ function ensureVoiceCaptureStatusRefresh() {
   void refreshVoiceCaptureStatus();
 }
 
-function startVoiceCapturePolling() {
-  if (voiceCapturePollTimer !== null) {
-    return;
-  }
-  voiceCapturePollTimer = window.setInterval(() => {
-    void refreshVoiceCaptureStatus();
-  }, 250);
-}
-
-function stopVoiceCapturePolling() {
-  if (voiceCapturePollTimer === null) {
-    return;
-  }
-  window.clearInterval(voiceCapturePollTimer);
-  voiceCapturePollTimer = null;
-}
-
 function updateVoiceInputButton() {
   const button = document.getElementById("voice-input-btn") as HTMLButtonElement | null;
   if (!button) {
@@ -7688,15 +7663,15 @@ function updateVoiceInputButton() {
   }
 
   const browserSupported = isBrowserVoiceInputSupported();
-  const supported = browserSupported || isNativeVoiceCaptureAvailable();
+  const supported = browserSupported;
   button.disabled = !supported;
   button.classList.toggle("is-recording", voiceListening);
   button.setAttribute("aria-pressed", voiceListening ? "true" : "false");
   const label = !supported
     ? isTauri()
       ? getLanguageText(
-        "Voice input is unavailable until native microphone capture is ready",
-        "ネイティブのマイク入力が準備できるまで音声入力は使えません",
+        "Voice input is unavailable because browser speech recognition is missing. Use Windows voice typing or keyboard input instead.",
+        "ブラウザーの音声認識がないため、音声入力は使えません。Windows 音声入力またはキーボード入力を使ってください",
       )
       : getLanguageText("Voice input is not available in this browser", "このブラウザーでは音声入力を利用できません")
     : voiceListening
@@ -7709,15 +7684,6 @@ function updateVoiceInputButton() {
 }
 
 function stopVoiceInput() {
-  if (voiceInputMode === "native") {
-    const composerInput = document.getElementById("composer-input") as HTMLTextAreaElement | null;
-    if (composerInput) {
-      persistVoiceDraftRecovery(composerInput.value);
-    }
-    void stopNativeVoiceInput(true);
-    return;
-  }
-
   if (!voiceRecognition) {
     return;
   }
@@ -7726,45 +7692,6 @@ function stopVoiceInput() {
   } catch {
     voiceRecognition.abort();
   }
-}
-
-async function startNativeVoiceInput(composerInput: HTMLTextAreaElement) {
-  try {
-    voiceCaptureStatus = await startDesktopVoiceCapture();
-    voiceCaptureStatusError = "";
-    voiceInputMode = "native";
-    voiceListening = true;
-    beginVoiceSession();
-    markComposerInputSource("voice");
-    startVoiceCapturePolling();
-    updateVoiceInputButton();
-    renderVoiceCaptureStatus();
-    composerInput.focus();
-  } catch (error) {
-    voiceCaptureStatus = null;
-    voiceCaptureStatusError = error instanceof Error ? error.message : String(error);
-    voiceInputMode = null;
-    voiceListening = false;
-    finishVoiceSession();
-    stopVoiceCapturePolling();
-    updateVoiceInputButton();
-    renderVoiceCaptureStatus();
-  }
-}
-
-async function stopNativeVoiceInput(cancelled: boolean) {
-  try {
-    voiceCaptureStatus = await stopDesktopVoiceCapture(cancelled);
-    voiceCaptureStatusError = "";
-  } catch (error) {
-    voiceCaptureStatusError = error instanceof Error ? error.message : String(error);
-  }
-  voiceInputMode = null;
-  voiceListening = false;
-  finishVoiceSession();
-  stopVoiceCapturePolling();
-  updateVoiceInputButton();
-  renderVoiceCaptureStatus();
 }
 
 function escapeRegExp(value: string) {
@@ -8008,9 +7935,6 @@ function startVoiceInput(composerInput: HTMLTextAreaElement) {
   const SpeechRecognition = getSpeechRecognitionConstructor();
   if (!SpeechRecognition) {
     ensureVoiceCaptureStatusRefresh();
-    if (isNativeVoiceCaptureAvailable()) {
-      void startNativeVoiceInput(composerInput);
-    }
     updateVoiceInputButton();
     return;
   }
@@ -8027,7 +7951,6 @@ function startVoiceInput(composerInput: HTMLTextAreaElement) {
   recognition.lang = themeState.language === "ja" ? "ja-JP" : "en-US";
   recognition.onstart = () => {
     voiceListening = true;
-    voiceInputMode = "browser";
     beginVoiceSession();
     updateVoiceInputButton();
   };
@@ -8035,7 +7958,6 @@ function startVoiceInput(composerInput: HTMLTextAreaElement) {
     persistVoiceDraftRecovery(composerInput.value);
     voiceListening = false;
     voiceRecognition = null;
-    voiceInputMode = null;
     voiceTranscriptBase = "";
     voiceSelectionEditState = null;
     finishVoiceSession();
@@ -8046,7 +7968,6 @@ function startVoiceInput(composerInput: HTMLTextAreaElement) {
   recognition.onerror = (event) => {
     persistVoiceDraftRecovery(composerInput.value);
     voiceListening = false;
-    voiceInputMode = null;
     voiceSelectionEditState = null;
     finishVoiceSession();
     updateVoiceInputButton();


### PR DESCRIPTION
## Summary
- Keep native microphone capture as metering only and remove it from composer dictation start/stop flow.
- Report native desktop voice status as browser_fallback for dictation until native speech-to-text exists.
- Add Rust and Pester contract coverage for the fallback behavior.

## Validation
- Invoke-Pester -Path tests\HarnessContract.Tests.ps1 -PassThru
- cargo test --manifest-path winsmux-app\src-tauri\Cargo.toml
- cmd /c npm run test:composer-text
- cmd /c npm run build
- pwsh -NoProfile -File scripts\audit-public-surface.ps1
- pwsh -NoProfile -File scripts\git-guard.ps1 -Mode full
- git diff --check
- codex exec review on the three changed files: no must-fix findings; addressed the direct snapshot-path test warning.

Refs #885