### PR TITLE
Record voice fallback release evidence

### DIFF
--- a/core/src/operator_cli.rs
+++ b/core/src/operator_cli.rs
@@ -956,6 +956,25 @@ pub fn run_manual_checklist_command(args: &[&String]) -> io::Result<()> {
                 "required_evidence": "Long processing and notification text remains visible or intentionally truncated at common desktop widths."
             }
         ],
+        "native_voice_fallback_contract": {
+            "task_id": "TASK-468",
+            "issue": "#885",
+            "release_gate": "native_voice_dictation_or_fallback_contract_recorded",
+            "status": "recorded_for_v1",
+            "native_speech_to_text": "not_implemented",
+            "metering_is_dictation": false,
+            "accepted_fallbacks": [
+                "browser_speech_recognition",
+                "windows_voice_typing",
+                "keyboard_input"
+            ],
+            "required_evidence": [
+                "desktop_voice_status_reports_browser_fallback_when_native_metering_exists",
+                "composer_voice_button_does_not_start_native_metering_as_dictation",
+                "manual_checklist_records_supported_fallback_contract"
+            ],
+            "decision": "For v1.0.0, native microphone capture is metering only. Composer dictation uses browser speech recognition when available; otherwise Windows voice typing or keyboard input is the supported fallback."
+        },
         "blocking_conditions": [
             "missing_manual_checklist_document",
             "unchecked_critical_item",
@@ -963,7 +982,7 @@ pub fn run_manual_checklist_command(args: &[&String]) -> io::Result<()> {
             "blocked_result_without_owner",
             "missing_desktop_artifact_evidence",
             "missing_desktop_dogfood_evidence",
-            "missing_native_voice_dictation_contract",
+            "missing_native_voice_dictation_or_fallback_contract",
             "public_surface_drift"
         ],
         "next_action": "Record v1.0.0 desktop manual validation results before the v1.0.0 release and feed any failed or blocked item back into backlog."

--- a/core/tests-rs/operator_cli.rs
+++ b/core/tests-rs/operator_cli.rs
@@ -1869,6 +1869,47 @@ fn operator_cli_manual_checklist_json_reports_release_gate() {
         "native_voice_dictation_or_fallback_contract"
     );
     assert_eq!(
+        json["native_voice_fallback_contract"]["task_id"],
+        "TASK-468"
+    );
+    assert_eq!(json["native_voice_fallback_contract"]["issue"], "#885");
+    assert_eq!(
+        json["native_voice_fallback_contract"]["release_gate"],
+        "native_voice_dictation_or_fallback_contract_recorded"
+    );
+    assert_eq!(
+        json["native_voice_fallback_contract"]["status"],
+        "recorded_for_v1"
+    );
+    assert_eq!(
+        json["native_voice_fallback_contract"]["native_speech_to_text"],
+        "not_implemented"
+    );
+    assert_eq!(
+        json["native_voice_fallback_contract"]["metering_is_dictation"],
+        false
+    );
+    assert_eq!(
+        json["native_voice_fallback_contract"]["accepted_fallbacks"],
+        serde_json::json!([
+            "browser_speech_recognition",
+            "windows_voice_typing",
+            "keyboard_input"
+        ])
+    );
+    assert_eq!(
+        json["native_voice_fallback_contract"]["required_evidence"],
+        serde_json::json!([
+            "desktop_voice_status_reports_browser_fallback_when_native_metering_exists",
+            "composer_voice_button_does_not_start_native_metering_as_dictation",
+            "manual_checklist_records_supported_fallback_contract"
+        ])
+    );
+    assert!(json["native_voice_fallback_contract"]["decision"]
+        .as_str()
+        .unwrap_or_default()
+        .contains("native microphone capture is metering only"));
+    assert_eq!(
         json["blocking_conditions"][0],
         "missing_manual_checklist_document"
     );
@@ -1878,7 +1919,7 @@ fn operator_cli_manual_checklist_json_reports_release_gate() {
     );
     assert_eq!(
         json["blocking_conditions"][6],
-        "missing_native_voice_dictation_contract"
+        "missing_native_voice_dictation_or_fallback_contract"
     );
 }
 


### PR DESCRIPTION
## Summary
- Add a structured native_voice_fallback_contract object to manual-checklist JSON for TASK-468.
- Record browser speech recognition, Windows voice typing, and keyboard input as the supported v1 fallback path when native speech-to-text is not implemented.
- Align the blocking condition name with the dictation-or-fallback release gate and test the full fallback/evidence arrays.

## Validation
- cargo test --manifest-path core\\Cargo.toml --test operator_cli manual_checklist
- cargo run --manifest-path core\\Cargo.toml -- manual-checklist --json
- cargo test --manifest-path core\\Cargo.toml --test operator_cli
- cargo test --manifest-path core\\Cargo.toml
- pwsh -NoProfile -File scripts\\audit-public-surface.ps1
- pwsh -NoProfile -File scripts\\git-guard.ps1 -Mode full
- git diff --check
- codex exec review: initial REQUEST_CHANGES addressed; rerun APPROVE

Refs #885