### PR TITLE
fix(desktop): complete dogfood release gates

### DIFF
--- a/core/src/event_contract.rs
+++ b/core/src/event_contract.rs
@@ -56,6 +56,11 @@ pub fn parse_event_jsonl(content: &str) -> Result<Vec<EventRecord>, String> {
             continue;
         }
 
+        let line = if index == 0 {
+            line.trim_start_matches('\u{feff}')
+        } else {
+            line
+        };
         let record: EventRecord = serde_json::from_str(line)
             .map_err(|err| format!("failed to parse event line {}: {}", index + 1, err))?;
         record

--- a/core/src/ledger.rs
+++ b/core/src/ledger.rs
@@ -3568,6 +3568,11 @@ fn build_evidence_chain(
         .filter(|line| !line.trim().is_empty())
         .enumerate()
     {
+        let line = if index == 0 {
+            line.trim_start_matches('\u{feff}')
+        } else {
+            line
+        };
         let event_value: Value = serde_json::from_str(line)
             .map_err(|err| format!("failed to parse event line {}: {}", index + 1, err))?;
         let event = events

--- a/core/src/operator_cli.rs
+++ b/core/src/operator_cli.rs
@@ -879,6 +879,12 @@ pub fn run_manual_checklist_command(args: &[&String]) -> io::Result<()> {
     }
 
     let options = parse_options("manual-checklist", args, 0)?;
+    let manual_checklist_document = options
+        .project_dir
+        .join("docs")
+        .join("internal")
+        .join("winsmux-manual-checklist-by-version.md");
+    let manual_checklist_document_exists = manual_checklist_document.is_file();
     let payload = json!({
         "contract_version": 1,
         "task_id": "TASK-416",
@@ -890,6 +896,8 @@ pub fn run_manual_checklist_command(args: &[&String]) -> io::Result<()> {
             "path": "docs/internal/winsmux-manual-checklist-by-version.md",
             "source": "winsmux-core/scripts/sync-internal-docs.ps1",
             "tracked": false,
+            "exists": manual_checklist_document_exists,
+            "storage_policy": "internal_untracked",
         },
         "required_result_values": ["未", "合格", "不合格", "保留"],
         "release_gates": [
@@ -897,9 +905,13 @@ pub fn run_manual_checklist_command(args: &[&String]) -> io::Result<()> {
             "desktop_bundle_artifacts_verified",
             "desktop_installer_smoke_recorded",
             "first_launch_project_selection_recorded",
+            "project_explorer_accuracy_recorded",
+            "operator_composer_editing_recorded",
+            "meta_plan_multi_pane_flow_recorded",
             "operator_worker_flow_recorded",
             "clipboard_image_flow_recorded",
             "settings_language_flow_recorded",
+            "status_bar_fit_recorded",
             "native_voice_dictation_or_fallback_contract_recorded",
             "release_docs_and_checksums_verified",
             "no_critical_unchecked_items",
@@ -912,7 +924,7 @@ pub fn run_manual_checklist_command(args: &[&String]) -> io::Result<()> {
             "operator_composer_editing",
             "meta_plan_multi_pane_flow",
             "clipboard_image_input",
-            "status_bar_overflow",
+            "status_bar_fit",
             "settings_language_control",
             "native_voice_dictation_or_fallback_contract",
             "startup_diagnostics",
@@ -921,38 +933,54 @@ pub fn run_manual_checklist_command(args: &[&String]) -> io::Result<()> {
         "desktop_manual_items": [
             {
                 "id": "installer_artifacts",
+                "evidence_source": "release_artifact",
                 "required_evidence": "Release contains MSI, NSIS, and SHA256 artifacts from the desktop workflow."
             },
             {
                 "id": "first_launch_project_selection",
+                "evidence_source": "dogfood_task_class",
+                "dogfood_task_class": "first_launch_project_selection",
                 "required_evidence": "A new user can select a project folder without typing an absolute path."
             },
             {
                 "id": "project_explorer_accuracy",
+                "evidence_source": "dogfood_task_class",
+                "dogfood_task_class": "project_explorer_accuracy",
                 "required_evidence": "The desktop explorer reflects the selected folder and does not show stale repository entries."
             },
             {
                 "id": "operator_composer_editing",
+                "evidence_source": "dogfood_task_class",
+                "dogfood_task_class": "operator_composer_editing",
                 "required_evidence": "Pasted Japanese text can be edited across wrapped lines without deleting the wrong character."
             },
             {
                 "id": "meta_plan_multi_pane_flow",
+                "evidence_source": "dogfood_task_class",
+                "dogfood_task_class": "meta_plan_multi_pane_flow",
                 "required_evidence": "A non-trivial meta-plan task shows operator and worker-pane activity with usable status feedback."
             },
             {
                 "id": "clipboard_image_input",
+                "evidence_source": "dogfood_task_class",
+                "dogfood_task_class": "clipboard_image_input",
                 "required_evidence": "A screenshot can be selected or pasted without forcing the user to type a temp file path."
             },
             {
                 "id": "settings_language_control",
+                "evidence_source": "dogfood_task_class",
+                "dogfood_task_class": "settings_language_control",
                 "required_evidence": "The language setting is visible, understandable, and persisted across desktop restarts."
             },
             {
                 "id": "native_voice_dictation_or_fallback_contract",
+                "evidence_source": "fallback_contract",
                 "required_evidence": "Native Windows microphone capture either produces editable composer text, or the release evidence records the supported fallback contract separately from microphone metering."
             },
             {
                 "id": "status_bar_fit",
+                "evidence_source": "dogfood_task_class",
+                "dogfood_task_class": "status_bar_fit",
                 "required_evidence": "Long processing and notification text remains visible or intentionally truncated at common desktop widths."
             }
         ],
@@ -985,6 +1013,8 @@ pub fn run_manual_checklist_command(args: &[&String]) -> io::Result<()> {
             "missing_native_voice_dictation_or_fallback_contract",
             "public_surface_drift"
         ],
+        "blocking_condition_scope": "release_blocker_classes",
+        "blocking_condition_note": "blocking_conditions lists release gate classes to evaluate; document.exists reports the current local document availability.",
         "next_action": "Record v1.0.0 desktop manual validation results before the v1.0.0 release and feed any failed or blocked item back into backlog."
     });
 

--- a/core/tests-rs/event_contract.rs
+++ b/core/tests-rs/event_contract.rs
@@ -80,6 +80,17 @@ fn event_fixture_deserializes_and_validates() {
 }
 
 #[test]
+fn event_accepts_utf8_bom_on_first_line() {
+    let records = parse_event_jsonl(
+        "\u{feff}{\"timestamp\":\"2026-05-12T20:58:00+09:00\",\"event\":\"pane.completed\"}",
+    )
+    .expect("BOM-prefixed event stream should parse");
+
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].event, "pane.completed");
+}
+
+#[test]
 fn event_accepts_sparse_legacy_poll_event_shape() {
     let record = parse_single_record(
         r#"{"timestamp":"2026-04-07T09:00:00.0000000+09:00","event":"pane.completed","pane_id":"%2","label":"builder-1"}"#,

--- a/core/tests-rs/ledger_contract.rs
+++ b/core/tests-rs/ledger_contract.rs
@@ -2319,6 +2319,19 @@ fn ledger_contract_loads_live_winsmux_files() {
 }
 
 #[test]
+fn ledger_contract_accepts_bom_prefixed_live_events_file() {
+    let fixture = TempProject::new("bom-events");
+    fixture.write_winsmux_file("manifest.yaml", MANIFEST_FIXTURE);
+    fixture.write_winsmux_file("events.jsonl", &format!("\u{feff}{EVENTS_FIXTURE}"));
+
+    let snapshot = ledger::LedgerSnapshot::from_project_dir(fixture.path())
+        .expect("BOM-prefixed events.jsonl should load");
+
+    assert_eq!(snapshot.event_count(), 5);
+    assert_eq!(snapshot.evidence_chain_projection().summary.entry_count, 5);
+}
+
+#[test]
 fn ledger_contract_allows_missing_live_events_file() {
     let fixture = TempProject::new("missing-events");
     fixture.write_winsmux_file("manifest.yaml", MANIFEST_FIXTURE);

--- a/core/tests-rs/operator_cli.rs
+++ b/core/tests-rs/operator_cli.rs
@@ -1822,6 +1822,8 @@ fn operator_cli_manual_checklist_json_reports_release_gate() {
         "docs/internal/winsmux-manual-checklist-by-version.md"
     );
     assert_eq!(json["document"]["tracked"], false);
+    assert_eq!(json["document"]["exists"], false);
+    assert_eq!(json["document"]["storage_policy"], "internal_untracked");
     assert_eq!(json["required_result_values"][0], "未");
     assert_eq!(json["required_result_values"][1], "合格");
     assert_eq!(json["required_result_values"][2], "不合格");
@@ -1838,15 +1840,136 @@ fn operator_cli_manual_checklist_json_reports_release_gate() {
         json["release_gates"][3],
         "first_launch_project_selection_recorded"
     );
-    assert_eq!(
-        json["release_gates"][7],
-        "native_voice_dictation_or_fallback_contract_recorded"
-    );
+    let release_gates = json["release_gates"]
+        .as_array()
+        .expect("release_gates should be an array");
+    for gate in [
+        "project_explorer_accuracy_recorded",
+        "operator_composer_editing_recorded",
+        "meta_plan_multi_pane_flow_recorded",
+        "status_bar_fit_recorded",
+        "native_voice_dictation_or_fallback_contract_recorded",
+    ] {
+        assert!(
+            release_gates.iter().any(|item| item == gate),
+            "release_gates should contain {gate}"
+        );
+    }
+    let focus_items = json["v1_desktop_focus"]
+        .as_array()
+        .expect("v1_desktop_focus should be an array");
+    for item_id in [
+        "first_launch_project_selection",
+        "project_explorer_accuracy",
+        "operator_composer_editing",
+        "meta_plan_multi_pane_flow",
+        "clipboard_image_input",
+        "settings_language_control",
+        "status_bar_fit",
+        "native_voice_dictation_or_fallback_contract",
+    ] {
+        assert!(
+            focus_items.iter().any(|item| item == item_id),
+            "v1_desktop_focus should contain {item_id}"
+        );
+    }
+    for (item_id, gate) in [
+        ("installer_artifacts", "desktop_bundle_artifacts_verified"),
+        (
+            "first_launch_project_selection",
+            "first_launch_project_selection_recorded",
+        ),
+        (
+            "project_explorer_accuracy",
+            "project_explorer_accuracy_recorded",
+        ),
+        (
+            "operator_composer_editing",
+            "operator_composer_editing_recorded",
+        ),
+        (
+            "meta_plan_multi_pane_flow",
+            "meta_plan_multi_pane_flow_recorded",
+        ),
+        ("clipboard_image_input", "clipboard_image_flow_recorded"),
+        ("settings_language_control", "settings_language_flow_recorded"),
+        ("status_bar_fit", "status_bar_fit_recorded"),
+        (
+            "native_voice_dictation_or_fallback_contract",
+            "native_voice_dictation_or_fallback_contract_recorded",
+        ),
+    ] {
+        assert!(
+            json["desktop_manual_items"]
+                .as_array()
+                .expect("desktop_manual_items should be an array")
+                .iter()
+                .any(|item| item["id"] == item_id),
+            "desktop_manual_items should contain {item_id}"
+        );
+        assert!(
+            release_gates.iter().any(|item| item == gate),
+            "release_gates should contain gate {gate} for {item_id}"
+        );
+    }
+    for (item_id, evidence_source, dogfood_task_class) in [
+        ("installer_artifacts", "release_artifact", None),
+        (
+            "first_launch_project_selection",
+            "dogfood_task_class",
+            Some("first_launch_project_selection"),
+        ),
+        (
+            "project_explorer_accuracy",
+            "dogfood_task_class",
+            Some("project_explorer_accuracy"),
+        ),
+        (
+            "operator_composer_editing",
+            "dogfood_task_class",
+            Some("operator_composer_editing"),
+        ),
+        (
+            "meta_plan_multi_pane_flow",
+            "dogfood_task_class",
+            Some("meta_plan_multi_pane_flow"),
+        ),
+        (
+            "clipboard_image_input",
+            "dogfood_task_class",
+            Some("clipboard_image_input"),
+        ),
+        (
+            "settings_language_control",
+            "dogfood_task_class",
+            Some("settings_language_control"),
+        ),
+        (
+            "native_voice_dictation_or_fallback_contract",
+            "fallback_contract",
+            None,
+        ),
+        ("status_bar_fit", "dogfood_task_class", Some("status_bar_fit")),
+    ] {
+        let item = json["desktop_manual_items"]
+            .as_array()
+            .expect("desktop_manual_items should be an array")
+            .iter()
+            .find(|item| item["id"] == item_id)
+            .unwrap_or_else(|| panic!("desktop_manual_items should contain {item_id}"));
+        assert_eq!(item["evidence_source"], evidence_source);
+        if let Some(expected_task_class) = dogfood_task_class {
+            assert_eq!(item["dogfood_task_class"], expected_task_class);
+        } else {
+            assert!(item["dogfood_task_class"].is_null());
+        }
+    }
     assert_eq!(
         json["v1_desktop_focus"][0],
         "desktop_installer_distribution"
     );
     assert_eq!(json["v1_desktop_focus"][4], "meta_plan_multi_pane_flow");
+    assert_eq!(json["v1_desktop_focus"][6], "status_bar_fit");
     assert_eq!(
         json["v1_desktop_focus"][8],
         "native_voice_dictation_or_fallback_contract"
@@ -1921,6 +2044,32 @@ fn operator_cli_manual_checklist_json_reports_release_gate() {
         json["blocking_conditions"][6],
         "missing_native_voice_dictation_or_fallback_contract"
     );
+    assert_eq!(
+        json["blocking_condition_scope"],
+        "release_blocker_classes"
+    );
+    assert!(json["blocking_condition_note"]
+        .as_str()
+        .unwrap_or_default()
+        .contains("document.exists"));
+}
+
+#[test]
+fn operator_cli_manual_checklist_json_reports_existing_internal_document() {
+    let project_dir = make_temp_project_dir("manual-checklist-existing-document");
+    let document_dir = project_dir.join("docs").join("internal");
+    fs::create_dir_all(&document_dir).expect("test should create manual checklist directory");
+    fs::write(
+        document_dir.join("winsmux-manual-checklist-by-version.md"),
+        "# manual checklist\n",
+    )
+    .expect("test should write manual checklist document");
+
+    let json = run_json(&project_dir, &["manual-checklist", "--json"]);
+
+    assert_eq!(json["document"]["tracked"], false);
+    assert_eq!(json["document"]["exists"], true);
+    assert_eq!(json["document"]["storage_policy"], "internal_untracked");
 }
 
 #[test]

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -8744,6 +8744,10 @@ function New-DesktopRunProjection {
     } else {
         'Projected run'
     }
+    $reasons = @()
+    if ($null -ne $explanation) {
+        $reasons = @($explanation.reasons)
+    }
 
     return [ordered]@{
         run_id               = $runId
@@ -8768,7 +8772,7 @@ function New-DesktopRunProjection {
         changed_files        = @($changedFiles)
         next_action          = if ($null -ne $explanation -and -not [string]::IsNullOrWhiteSpace([string]$explanation.next_action)) { [string]$explanation.next_action } else { [string]$DigestItem.next_action }
         summary              = $summary
-        reasons              = if ($null -ne $explanation) { @($explanation.reasons) } else { @() }
+        reasons              = @($reasons)
         hypothesis           = [string]$DigestItem.hypothesis
         confidence           = $DigestItem.confidence
         observation_pack_ref = [string]$DigestItem.observation_pack_ref
@@ -8785,17 +8789,7 @@ function Get-DesktopSummaryPayload {
     $runProjections = @()
 
     foreach ($digestItem in @($digest.items)) {
-        $explainPayload = $null
-        $runId = [string]$digestItem.run_id
-        if (-not [string]::IsNullOrWhiteSpace($runId)) {
-            try {
-                $explainPayload = Get-ExplainPayload -ProjectDir $ProjectDir -RunId $runId
-            } catch {
-                $explainPayload = $null
-            }
-        }
-
-        $runProjections += @(New-DesktopRunProjection -DigestItem $digestItem -ExplainPayload $explainPayload)
+        $runProjections += @(New-DesktopRunProjection -DigestItem $digestItem -ExplainPayload $null)
     }
 
     return [ordered]@{

--- a/tests/HarnessContract.Tests.ps1
+++ b/tests/HarnessContract.Tests.ps1
@@ -8,6 +8,7 @@ Describe 'harness-check contract' {
         $script:PowerShellDeescalationPath = Join-Path $script:RepoRoot 'winsmux-core\scripts\powershell-deescalation.ps1'
         $script:WinsmuxCorePath = Join-Path $script:RepoRoot 'scripts\winsmux-core.ps1'
         $script:InternalDocsMetaPath = Join-Path $script:RepoRoot 'winsmux-core\scripts\internal-docs-meta.psd1'
+        $script:SyncInternalDocsPath = Join-Path $script:RepoRoot 'winsmux-core\scripts\sync-internal-docs.ps1'
         $script:DesktopMainPath = Join-Path $script:RepoRoot 'winsmux-app\src\main.ts'
         $script:TauriLibPath = Join-Path $script:RepoRoot 'winsmux-app\src-tauri\src\lib.rs'
         $script:SettingsLocalPath = Join-Path $script:RepoRoot '.claude\settings.local.json'
@@ -309,6 +310,129 @@ tasks:
         $voiceEntry[0].Memo | Should -Match 'TASK-468'
     }
 
+    It 'keeps future manual checklist metadata after earlier release lanes' {
+        $meta = Import-PowerShellDataFile -LiteralPath $script:InternalDocsMetaPath
+        $orders = @($meta.ManualChecklistEntries | ForEach-Object { $_.Order })
+        $uniqueOrders = @($orders | Select-Object -Unique)
+        $v160Entry = @($meta.ManualChecklistEntries | Where-Object { $_.Version -eq 'v1.6.0' })
+        $v161Entry = @($meta.ManualChecklistEntries | Where-Object { $_.Version -eq 'v1.6.1' })
+
+        $uniqueOrders.Count | Should -Be $orders.Count
+        $v160Entry.Count | Should -Be 1
+        $v161Entry.Count | Should -Be 1
+        $v161Entry[0].Order | Should -BeGreaterThan $v160Entry[0].Order
+    }
+
+    It 'keeps generated internal docs from marking partial task groups as published' {
+        $fixtureRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("winsmux-internal-docs-" + [guid]::NewGuid().ToString('N'))
+        try {
+            $backlogPath = Join-Path $fixtureRoot 'backlog.yaml'
+            $roadmapTitlePath = Join-Path $fixtureRoot 'roadmap-title-ja.psd1'
+            $featureInventoryPath = Join-Path $fixtureRoot 'feature-inventory.md'
+            $manualChecklistPath = Join-Path $fixtureRoot 'manual-checklist.md'
+            $metaPath = Join-Path $fixtureRoot 'internal-docs-meta.psd1'
+
+            Write-TestFileWithCmd -Path $backlogPath -Content @'
+# === v1.0.0: Release gate ===
+tasks:
+  - id: TASK-DONE
+    title: Done task
+    status: done
+    target_version: v1.0.0
+  - id: TASK-ACTIVE
+    title: Active task
+    status: active
+    target_version: v1.0.0
+  - id: TASK-DONE2
+    title: Another done task
+    status: done
+    target_version: v1.0.1
+'@
+            Write-TestFileWithCmd -Path $roadmapTitlePath -Content '@{ VersionTitles = @{}; TaskTitles = @{} }'
+            Write-TestFileWithCmd -Path $featureInventoryPath -Content @'
+# Feature Inventory
+
+更新日: 2026-01-01
+
+## 進行中（未公開）
+
+old active
+
+## 今後実装予定
+
+old planned
+
+## 付録
+
+appendix
+'@
+            Write-TestFileWithCmd -Path $manualChecklistPath -Content @'
+# Manual Checklist
+
+更新日: 2026-01-01
+
+## 進行中・今後予定の確認表
+
+old checklist
+
+## 総合確認の進め方
+
+manual flow
+'@
+            Write-TestFileWithCmd -Path $metaPath -Content @'
+@{
+    FeatureInventoryEntries = @(
+        @{
+            Order = 10
+            Category = 'fixture category'
+            Title = 'fixture feature'
+            UserValue = 'fixture user value'
+            UseCase = 'fixture use case'
+            ImplementationVersion = 'v1.0.0'
+            TaskIds = @('TASK-ACTIVE')
+            AppendixName = 'fixture appendix'
+            TestFocus = 'fixture focus'
+        }
+    )
+    ManualChecklistEntries = @(
+        @{
+            Order = 10
+            Version = 'v1.0.0'
+            TaskIds = @('TASK-DONE', 'TASK-ACTIVE')
+            Focus = 'partial release gate'
+            Example = 'mixed task states'
+            Memo = 'partial'
+        }
+        @{
+            Order = 20
+            Version = 'v1.0.1'
+            TaskIds = @('TASK-DONE', 'TASK-DONE2')
+            Focus = 'complete release gate'
+            Example = 'all task states are done'
+            Memo = 'complete'
+        }
+    )
+}
+'@
+
+            $output = & $script:PwshPath -NoProfile -File $script:SyncInternalDocsPath `
+                -BacklogPath $backlogPath `
+                -RoadmapTitleJaPath $roadmapTitlePath `
+                -FeatureInventoryPath $featureInventoryPath `
+                -ManualChecklistPath $manualChecklistPath `
+                -MetaPath $metaPath
+
+            $LASTEXITCODE | Should -Be 0
+            ($output | Out-String) | Should -Match 'Generated internal docs'
+
+            $manualChecklist = Get-Content -LiteralPath $manualChecklistPath -Raw -Encoding UTF8
+            $manualChecklist | Should -Match '\| v1\.0\.0: Release gate \| 進行中 \| partial release gate \| mixed task states \| \[ \] 未 \| \[ \] \| partial \|'
+            $manualChecklist | Should -Match '\| v1\.0\.1 \| 公開済み \| complete release gate \| all task states are done \| \[ \] 未 \| \[ \] \| complete \|'
+        } finally {
+            Remove-Item -LiteralPath $fixtureRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
     It 'does not treat native microphone metering as composer dictation' {
         $desktopMain = Get-Content -LiteralPath $script:DesktopMainPath -Raw -Encoding UTF8
         $tauriLib = Get-Content -LiteralPath $script:TauriLibPath -Raw -Encoding UTF8
@@ -316,6 +440,8 @@ tasks:
         $desktopMain | Should -Match 'const supported = browserSupported;'
         $desktopMain | Should -Not -Match 'if \(!SpeechRecognition\)[\s\S]{0,300}startNativeVoiceInput'
         $desktopMain | Should -Match 'does not convert native audio into composer text'
+        $desktopMain | Should -Not -Match 'voiceCaptureStatus\.native\.state === "stopped"[\s\S]{0,300}getNativeVoiceMeterOnlyMessage'
+        $desktopMain | Should -Match 'button\.setAttribute\("title", title\);'
         $tauriLib | Should -Match 'Native microphone capture does not transcribe audio into text'
         $tauriLib | Should -Match 'capture_mode = "browser_fallback"'
     }

--- a/tests/Integration.MultiAgent.Tests.ps1
+++ b/tests/Integration.MultiAgent.Tests.ps1
@@ -351,6 +351,33 @@ panes:
         $traceEntries[1].host_kind | Should -Be 'powershell-window'
         $traceEntries[1].launch_result | Should -Be 'attach_confirmed'
     }
+
+    It 'keeps multiline session scalar values on one YAML line' {
+        $manifest = [PSCustomObject]@{
+            version  = 1
+            saved_at = '2026-05-12T20:50:00+09:00'
+            session  = [PSCustomObject]@{
+                name             = 'winsmux-orchestra'
+                status           = 'running'
+                ui_attach_reason = "Visible attach confirmed`nafter client identity changed."
+            }
+            panes = [ordered]@{}
+            tasks = [PSCustomObject]@{
+                queued      = @()
+                in_progress = @()
+                completed   = @()
+            }
+            worktrees = [ordered]@{}
+        }
+
+        Save-WinsmuxManifest -ProjectDir $script:manifestTempRoot -Manifest $manifest
+        $content = Get-Content -Path (Get-ManifestPath -ProjectDir $script:manifestTempRoot) -Raw -Encoding UTF8
+        $loaded = Get-WinsmuxManifest -ProjectDir $script:manifestTempRoot
+
+        $content | Should -Match "ui_attach_reason: 'Visible attach confirmed after client identity changed\.'"
+        $content | Should -Not -Match "ui_attach_reason: .*`r?`nafter client identity changed"
+        $loaded.session.ui_attach_reason | Should -Be 'Visible attach confirmed after client identity changed.'
+    }
 }
 
 Describe 'orchestra state model' {

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -10426,6 +10426,8 @@ Set-Location '__DIGEST_TEMP_ROOT__'
         @($result.run_projections).Count | Should -Be 1
         $result.run_projections[0].run_id | Should -Be 'task:task-246'
         $result.run_projections[0].worktree | Should -Be '.worktrees/builder-1'
+        $result.run_projections[0].Contains('reasons') | Should -Be $true
+        @($result.run_projections[0]['reasons']).Count | Should -Be 0
     }
 
     It 'converts event records into desktop summary refresh items' {

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -7540,25 +7540,22 @@ function getVoiceCaptureStatusMessage() {
   }
 
   if (!voiceCaptureStatus) {
-    return getLanguageText(
-      "Checking native microphone status...",
-      "ネイティブのマイク状態を確認中...",
-    );
+    return "";
   }
 
   if (voiceCaptureStatus.native.state === "recording") {
     const meter = getVoiceCaptureMeterPercent();
     return getLanguageText(
-      `Native microphone metering is running. Meter ${meter}%. It does not write text into the composer.`,
-      `ネイティブのマイクメーターは動作中です。メーターは ${meter}% です。入力欄へ文字は入りません。`,
+      `Mic meter ${meter}%`,
+      `マイクメーター ${meter}%`,
     );
   }
 
   if (voiceCaptureStatus.native.state === "silence") {
     const meter = getVoiceCaptureMeterPercent();
     return getLanguageText(
-      `Native microphone metering is running, but speech is not detected. Meter ${meter}%. It does not write text into the composer.`,
-      `ネイティブのマイクメーターは動作中ですが、発話を検出していません。メーターは ${meter}% です。入力欄へ文字は入りません。`,
+      `Mic meter ${meter}%`,
+      `マイクメーター ${meter}%`,
     );
   }
 
@@ -7577,12 +7574,7 @@ function getVoiceCaptureStatusMessage() {
   }
 
   if (voiceCaptureStatus.native.state === "stopped") {
-    return isNativeVoiceCaptureAvailable()
-      ? getNativeVoiceMeterOnlyMessage()
-      : getLanguageText(
-        "Browser voice input is the supported dictation fallback.",
-        "音声入力の対応済みフォールバックはブラウザーの音声認識です。",
-      );
+    return "";
   }
 
   if (voiceCaptureStatus.native.state === "permission_denied") {
@@ -7593,7 +7585,7 @@ function getVoiceCaptureStatusMessage() {
   }
 
   if (voiceCaptureStatus.native.available) {
-    return getNativeVoiceMeterOnlyMessage();
+    return "";
   }
 
   if (voiceCaptureStatus.native.state === "no_microphone") {
@@ -7604,16 +7596,10 @@ function getVoiceCaptureStatusMessage() {
   }
 
   if (isBrowserVoiceInputSupported()) {
-    return getLanguageText(
-      "Native microphone capture is not ready; browser voice input is active.",
-      "ネイティブのマイク入力は準備中です。ブラウザーの音声入力を使います。",
-    );
+    return "";
   }
 
-  return getLanguageText(
-    "Native microphone capture is not ready, and browser voice input is unavailable.",
-    "ネイティブのマイク入力は準備中です。この環境ではブラウザーの音声入力も使えません。",
-  );
+  return "";
 }
 
 function renderVoiceCaptureStatus() {
@@ -7678,8 +7664,11 @@ function updateVoiceInputButton() {
       ? getLanguageText("Stop voice input", "音声入力を停止")
       : getLanguageText("Start voice input", "音声入力を開始");
   const labelWithShortcut = supported ? `${label} (${normalizeVoiceShortcut(themeState.voiceShortcut)})` : label;
+  const title = !supported && isTauri() && isNativeVoiceCaptureAvailable()
+    ? getNativeVoiceMeterOnlyMessage()
+    : labelWithShortcut;
   button.setAttribute("aria-label", labelWithShortcut);
-  button.setAttribute("title", labelWithShortcut);
+  button.setAttribute("title", title);
   renderVoiceCaptureStatus();
 }
 

--- a/winsmux-core/scripts/internal-docs-meta.psd1
+++ b/winsmux-core/scripts/internal-docs-meta.psd1
@@ -165,7 +165,7 @@
             Memo = ''
         }
         @{
-            Order = 20
+            Order = 160
             Version = 'v1.6.1'
             TaskIds = @('TASK-315')
             Focus = '自己進化'

--- a/winsmux-core/scripts/manifest.ps1
+++ b/winsmux-core/scripts/manifest.ps1
@@ -27,6 +27,7 @@ function ConvertTo-ManifestYamlScalar {
     }
 
     $text = [string]$Value
+    $text = $text -replace "(\r\n|\r|\n)+", ' '
     if ($text.Length -eq 0) {
         return "''"
     }

--- a/winsmux-core/scripts/sync-internal-docs.ps1
+++ b/winsmux-core/scripts/sync-internal-docs.ps1
@@ -190,6 +190,8 @@ function Get-PlanningState {
     foreach ($taskId in $TaskIds) {
         if ($TasksById.ContainsKey($taskId)) {
             $statuses += ($TasksById[$taskId].Status ?? '')
+        } else {
+            $statuses += ''
         }
     }
 
@@ -197,16 +199,20 @@ function Get-PlanningState {
         return '今後予定'
     }
 
-    foreach ($status in $statuses) {
-        if ($status -eq 'done') {
-            return '公開済み'
-        }
+    $nonEmptyStatuses = @($statuses | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+    $doneStatuses = @($nonEmptyStatuses | Where-Object { $_ -eq 'done' })
+    if ($nonEmptyStatuses.Count -eq $TaskIds.Count -and $doneStatuses.Count -eq $TaskIds.Count) {
+        return '公開済み'
     }
 
     foreach ($status in $statuses) {
         if ($status -in @('active', 'review', 'in-progress', 'in_progress', 'doing')) {
             return '進行中'
         }
+    }
+
+    if ($doneStatuses.Count -gt 0) {
+        return '進行中'
     }
 
     return '今後予定'


### PR DESCRIPTION
## Summary

Completes the desktop dogfood release-gate evidence path and keeps the native microphone fallback explanation out of the visible composer UI.

## Changes

- Add explicit dogfood task-class metadata to the v1 manual checklist payload.
- Keep partial internal-doc task groups marked in progress instead of published.
- Move `v1.6.1` manual checklist metadata after the earlier release lanes.
- Normalize multiline manifest scalar values before writing local runtime YAML.
- Accept a UTF-8 BOM on the first runtime event-log line in both event parsing paths.
- Make `desktop-summary --json` avoid per-digest explain hydration so the desktop summary returns promptly on large local logs.
- Hide the long native microphone fallback explanation from visible `voice-input-status` text while keeping concise metering text.

## Review

- `codex review --uncommitted`: no discrete actionable bugs found.

## Test Plan

- `Invoke-Pester -Path tests\HarnessContract.Tests.ps1 -FullName '*manual checklist*' -PassThru`
- `Invoke-Pester -Path tests\HarnessContract.Tests.ps1 -FullName '*internal docs*' -PassThru`
- `Invoke-Pester -Path tests\HarnessContract.Tests.ps1 -FullName '*native microphone metering*' -PassThru`
- `Invoke-Pester -Path tests\Integration.MultiAgent.Tests.ps1 -FullName '*manifest round-trip*' -PassThru`
- `Invoke-Pester -Path tests\winsmux-bridge.Tests.ps1 -FullName '*desktop-summary --json*' -PassThru`
- `cargo test --manifest-path core\Cargo.toml --test operator_cli manual_checklist`
- `cargo test --manifest-path core\Cargo.toml --test event_contract event_accepts_utf8_bom_on_first_line`
- `cargo test --manifest-path core\Cargo.toml --test ledger_contract ledger_contract_accepts_bom_prefixed_live_events_file`
- `cargo run --manifest-path core\Cargo.toml -- manual-checklist --json`
- `cargo run --manifest-path core\Cargo.toml -- dogfood stats --since 2026-01-01 --json`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts\winsmux-core.ps1 desktop-summary --json`
- `cmd /c npm run build`
- `git diff --check`
- `pwsh -NoProfile -File scripts\audit-public-surface.ps1`
- `pwsh -NoProfile -File scripts\git-guard.ps1 -Mode full`

## Dogfood Evidence

- `desktop_manual_evidence.complete=true`
- Recorded classes: `first_launch_project_selection`, `project_explorer_accuracy`, `operator_composer_editing`, `meta_plan_multi_pane_flow`, `clipboard_image_input`, `settings_language_control`, `status_bar_fit`
- Latest export: `C:\Users\komei\AppData\Roaming\winsmux\dogfood\exports\dogfood-stats-2026-05-12T12-48-28Z.json`
