### PR TITLE
fix: propagate worker backend defaults

### DIFF
--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -342,6 +342,25 @@ agent-slots:
         $settings.agent_slots[2].model | Should -Be 'gemini-2.5-pro'
     }
 
+    It 'propagates top-level worker backend into generated managed slots' {
+@'
+agent: codex
+model: provider-default
+worker-backend: Codex
+worker_count: 2
+'@ | Set-Content -Path (Join-Path $script:settingsTempRoot '.winsmux.yaml') -Encoding UTF8
+
+        Mock Get-WinsmuxOption { param($Name, $Default) return $null }
+
+        $settings = Get-BridgeSettings
+
+        $settings.worker_backend | Should -Be 'codex'
+        $settings.worker_count | Should -Be 2
+        $settings.agent_slots.Count | Should -Be 2
+        $settings.agent_slots[0].worker_backend | Should -Be 'codex'
+        $settings.agent_slots[1].worker_backend | Should -Be 'codex'
+    }
+
     It 'parses WorkerBackend metadata for six-slot worker configs without runtime dispatch' {
 @'
 agent: codex

--- a/winsmux-core/scripts/settings.ps1
+++ b/winsmux-core/scripts/settings.ps1
@@ -430,8 +430,15 @@ function New-BridgeManagedAgentSlots {
     param(
         [Parameter(Mandatory = $true)][int]$Count,
         [Parameter(Mandatory = $true)][string]$Agent,
-        [Parameter(Mandatory = $true)][AllowEmptyString()][string]$Model
+        [Parameter(Mandatory = $true)][AllowEmptyString()][string]$Model,
+        [string]$WorkerBackend = 'local'
     )
+
+    $normalizedWorkerBackend = if (Test-BridgeWorkerBackendKind -Value $WorkerBackend) {
+        $WorkerBackend.Trim().ToLowerInvariant()
+    } else {
+        'local'
+    }
 
     $slots = @()
     for ($index = 1; $index -le $Count; $index++) {
@@ -440,7 +447,7 @@ function New-BridgeManagedAgentSlots {
             runtime_role   = 'worker'
             agent          = $Agent
             worktree_mode  = 'managed'
-            worker_backend = 'local'
+            worker_backend = $normalizedWorkerBackend
         }
         if (-not [string]::IsNullOrWhiteSpace($Model)) {
             $slot.model = $Model
@@ -2212,7 +2219,7 @@ function Get-BridgeSettings {
     }
 
     if (@($settings.agent_slots).Count -eq 0 -and -not $useLegacyLayout -and [bool]$settings.external_operator -and [int]$settings.worker_count -gt 0) {
-        $settings.agent_slots = New-BridgeManagedAgentSlots -Count ([int]$settings.worker_count) -Agent ([string]$settings.agent) -Model ([string]$settings.model)
+        $settings.agent_slots = New-BridgeManagedAgentSlots -Count ([int]$settings.worker_count) -Agent ([string]$settings.agent) -Model ([string]$settings.model) -WorkerBackend ([string]$settings.worker_backend)
     }
 
     if (@($settings.agent_slots).Count -gt 0 -and -not $useLegacyLayout) {


### PR DESCRIPTION
## Summary

- Propagate the top-level `worker_backend` setting into generated managed slots when `agent-slots` is omitted.
- Add regression coverage for the generated-slot path found by the tag preflight `/review`.

Closes #890.

## Validation

- `Invoke-Pester -Path tests\winsmux-bridge.Tests.ps1 -FullName '*propagates top-level worker backend into generated managed slots*','*parses WorkerBackend metadata*','*returns built-in defaults*' -PassThru`
- `Invoke-Pester -Path tests\winsmux-bridge.Tests.ps1 -PassThru`
- `Invoke-Pester -Path tests\Integration.MultiAgent.Tests.ps1 -PassThru`
- `git diff --check`
- `pwsh -NoProfile -File scripts\audit-public-surface.ps1`
- `pwsh -NoProfile -File scripts\git-guard.ps1 -Mode full`

## Review

- Fixes the P2 finding from the GPT-5.3-Codex-Spark tag preflight `/review`.
