### PR TITLE
fix: parse slot metadata block lists

### DIFF
--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -420,6 +420,29 @@ agent-slots:
         $impl.Packages | Should -Be @('torch', 'transformers', 'accelerate')
     }
 
+    It 'parses block-style slot metadata lists in the manual YAML fallback' {
+        $parsed = ConvertFrom-BridgeManualYaml -Content @'
+agent-slots:
+  - slot-id: worker-2
+    runtime-role: worker
+    worker-backend: colab_cli
+    gpu-preference:
+      - H100
+      - A100
+      - L4
+    packages:
+      - torch
+      - transformers
+      - accelerate
+'@
+
+        $parsed['agent_slots'].Count | Should -Be 1
+        $parsed['agent_slots'][0]['slot_id'] | Should -Be 'worker-2'
+        $parsed['agent_slots'][0]['worker_backend'] | Should -Be 'colab_cli'
+        $parsed['agent_slots'][0]['gpu_preference'] | Should -Be @('H100', 'A100', 'L4')
+        $parsed['agent_slots'][0]['packages'] | Should -Be @('torch', 'transformers', 'accelerate')
+    }
+
     It 'parses per-role agent and model overrides and falls back to global settings' {
         @'
 agent: codex

--- a/winsmux-core/scripts/settings.ps1
+++ b/winsmux-core/scripts/settings.ps1
@@ -1663,6 +1663,7 @@ function ConvertFrom-BridgeManualYaml {
     $currentListKey = $null
     $currentSlotListKey = $null
     $currentSlotEntry = $null
+    $currentSlotEntryListKey = $null
     $currentMapKey = $null
     $currentMapEntryKey = $null
     $lineNumber = 0
@@ -1680,12 +1681,28 @@ function ConvertFrom-BridgeManualYaml {
             $slotEntry[$slotKey] = ConvertFrom-BridgeYamlValue $Matches[2]
             $settings[$currentSlotListKey] += @($slotEntry)
             $currentSlotEntry = $slotEntry
+            $currentSlotEntryListKey = $null
+            continue
+        }
+
+        if ($null -ne $currentSlotListKey -and $null -ne $currentSlotEntry -and $null -ne $currentSlotEntryListKey -and $line -match '^\s{6,}-\s*(.+?)\s*$') {
+            $listValue = ConvertFrom-BridgeYamlScalar $Matches[1]
+            if (-not [string]::IsNullOrWhiteSpace($listValue)) {
+                $currentSlotEntry[$currentSlotEntryListKey] += @($listValue)
+            }
             continue
         }
 
         if ($null -ne $currentSlotListKey -and $null -ne $currentSlotEntry -and $line -match '^\s{4}([A-Za-z_][A-Za-z0-9_-]*)\s*:\s*(.*?)\s*$') {
             $slotKey = ConvertTo-BridgeSlotKey $Matches[1]
-            $currentSlotEntry[$slotKey] = ConvertFrom-BridgeYamlValue $Matches[2]
+            $slotValue = $Matches[2]
+            $currentSlotEntryListKey = $null
+            if ([string]::IsNullOrWhiteSpace($slotValue) -and $slotKey -in $script:BridgeSlotListKeys) {
+                $currentSlotEntry[$slotKey] = @()
+                $currentSlotEntryListKey = $slotKey
+            } else {
+                $currentSlotEntry[$slotKey] = ConvertFrom-BridgeYamlValue $slotValue
+            }
             continue
         }
 
@@ -1701,6 +1718,7 @@ function ConvertFrom-BridgeManualYaml {
         $currentListKey = $null
         $currentSlotListKey = $null
         $currentSlotEntry = $null
+        $currentSlotEntryListKey = $null
         if ($null -ne $currentMapKey -and $line -match '^\s{2}([A-Za-z_][A-Za-z0-9_-]*)\s*:\s*$') {
             $currentMapEntryKey = $Matches[1] -replace '-', '_'
             if (-not $settings[$currentMapKey].Contains($currentMapEntryKey)) {


### PR DESCRIPTION
## Summary

Fixes the `v0.32.0` tag-preflight review finding where the manual YAML fallback dropped block-style slot metadata lists.

Closes #890.

## Changes

- Tracks the active slot metadata list while parsing `agent-slots` in `ConvertFrom-BridgeManualYaml`.
- Preserves block-style list values for `gpu-preference` and `packages` when `ConvertFrom-Yaml` is unavailable.
- Adds a direct fallback parser test for block-style slot metadata lists.

## Validation

- `Invoke-Pester -Path tests\winsmux-bridge.Tests.ps1 -FullName '*block-style slot metadata lists*','*WorkerBackend metadata*','*propagates top-level worker backend*' -PassThru`
- `Invoke-Pester -Path tests\winsmux-bridge.Tests.ps1 -PassThru`
- `git diff --check`
- `pwsh -NoProfile -File scripts\audit-public-surface.ps1`
- `pwsh -NoProfile -File scripts\git-guard.ps1 -Mode full`
