### PR TITLE
Fix installer release lookup before v0.32.0 publish

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -28,17 +28,12 @@ $PROFILE_MATRIX = @{
     security = "Core profile plus vault, redaction, and audit-oriented scripts."
     full = "Core, orchestra, and security profile contents."
 }
-$EffectiveReleaseTag = if ([string]::IsNullOrWhiteSpace($ReleaseTag)) { $env:WINSMUX_RELEASE_TAG } else { $ReleaseTag }
-if ([string]::IsNullOrWhiteSpace($EffectiveReleaseTag)) {
-    $BASE_URL = "https://raw.githubusercontent.com/Sora-bluesky/winsmux/main"
-    $RELEASE_API_URL = "https://api.github.com/repos/Sora-bluesky/winsmux/releases/latest"
-    $RELEASE_LABEL = "latest"
-} else {
-    $BASE_URL = "https://raw.githubusercontent.com/Sora-bluesky/winsmux/$EffectiveReleaseTag"
-    $escapedTag = [Uri]::EscapeDataString($EffectiveReleaseTag)
-    $RELEASE_API_URL = "https://api.github.com/repos/Sora-bluesky/winsmux/releases/tags/$escapedTag"
-    $RELEASE_LABEL = $EffectiveReleaseTag
-}
+$requestedReleaseTag = if ([string]::IsNullOrWhiteSpace($ReleaseTag)) { $env:WINSMUX_RELEASE_TAG } else { $ReleaseTag }
+$EffectiveReleaseTag = if ([string]::IsNullOrWhiteSpace($requestedReleaseTag)) { "v$VERSION" } else { $requestedReleaseTag.Trim() }
+$BASE_URL = "https://raw.githubusercontent.com/Sora-bluesky/winsmux/$EffectiveReleaseTag"
+$escapedTag = [Uri]::EscapeDataString($EffectiveReleaseTag)
+$RELEASE_API_URL = "https://api.github.com/repos/Sora-bluesky/winsmux/releases/tags/$escapedTag"
+$RELEASE_LABEL = $EffectiveReleaseTag
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/VersionSurface.Tests.ps1
+++ b/tests/VersionSurface.Tests.ps1
@@ -21,6 +21,9 @@ Describe 'winsmux version surface' {
         $coreLock = Get-Content -LiteralPath (Join-Path $script:RepoRoot 'core\Cargo.lock') -Raw -Encoding UTF8
 
         $installScript | Should -Match ('\$VERSION\s*=\s*"{0}"' -f [regex]::Escape($script:ProductVersion))
+        $installScript | Should -Match '\$EffectiveReleaseTag\s*=\s*if \(\[string\]::IsNullOrWhiteSpace\(\$requestedReleaseTag\)\) \{ "v\$VERSION" \}'
+        $installScript | Should -Match 'releases/tags/\$escapedTag'
+        $installScript | Should -Not -Match 'releases/latest'
         $installScript | Should -Match 'function Get-WinsmuxCommandVersion'
         $installScript | Should -Match 'does not match installer version'
         $installScript | Should -Match 'Reinstalling release binary'


### PR DESCRIPTION
## Summary
- Pin the default installer release lookup to v$VERSION instead of releases/latest.
- Keep raw file downloads on the same effective release tag.
- Add a version-surface test so releases/latest does not return.

Closes #895.

## Validation
- Invoke-Pester -Path tests\VersionSurface.Tests.ps1 -PassThru
- Invoke-Pester -Path tests\NpmReleasePackage.Tests.ps1 -PassThru
- pwsh -NoProfile -File scripts\audit-public-surface.ps1
- pwsh -NoProfile -File scripts\git-guard.ps1 -Mode full
- git diff --check