### PR TITLE
Skip existing npm versions during release reruns

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -76,13 +76,28 @@ jobs:
 
           node scripts/stage-npm-release.mjs --version $version --out output/npm-release/winsmux
 
+      - name: Check whether npm version already exists
+        id: npm-version
+        run: |
+          if npm view "winsmux@${{ needs.verify.outputs.version }}" version >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Skip existing npm version
+        if: steps.npm-version.outputs.exists == 'true'
+        run: echo "winsmux@${{ needs.verify.outputs.version }} is already published; skipping npm publish."
+
       - name: Verify staged package
+        if: steps.npm-version.outputs.exists != 'true'
         working-directory: output/npm-release/winsmux
         run: |
           node --version
           npm pack --dry-run
 
       - name: Publish to npm
+        if: steps.npm-version.outputs.exists != 'true'
         working-directory: output/npm-release/winsmux
         run: npm publish --access public
         env:

--- a/tests/NpmReleasePackage.Tests.ps1
+++ b/tests/NpmReleasePackage.Tests.ps1
@@ -170,6 +170,10 @@ Describe 'winsmux npm release package contract' {
         $releaseWorkflow | Should -Match 'tags:\s*\r?\n\s*-\s*"v\*"'
         $releaseWorkflow | Should -Match 'name:\s+Verify Windows entrypoint'
         $releaseWorkflow | Should -Match 'if:\s+steps\.stage\.outputs\.publish_ready == ''true'''
+        $releaseWorkflow | Should -Match 'name:\s+Check whether npm version already exists'
+        $releaseWorkflow | Should -Match 'npm view "winsmux@\$\{\{\s*needs\.verify\.outputs\.version\s*\}\}" version'
+        $releaseWorkflow | Should -Match 'name:\s+Skip existing npm version'
+        $releaseWorkflow | Should -Match 'if:\s+steps\.npm-version\.outputs\.exists != ''true'''
         $releaseWorkflow | Should -Match 'NODE_AUTH_TOKEN:\s+\$\{\{\s*secrets\.NPM_TOKEN\s*\}\}'
     }
 


### PR DESCRIPTION
## Summary
- Check npm before the release publish step.
- Skip package verification and npm publish when the target version already exists.
- Add a workflow contract assertion for the skip guard.

Closes #897.

## Validation
- Invoke-Pester -Path tests\NpmReleasePackage.Tests.ps1 -PassThru
- pwsh -NoProfile -File scripts\audit-public-surface.ps1
- pwsh -NoProfile -File scripts\git-guard.ps1 -Mode full
- git diff --check