### PR TITLE
Test Tauri native desktop APIs in E2E

### DIFF
--- a/.githooks/pre-commit-whitelist.ps1
+++ b/.githooks/pre-commit-whitelist.ps1
@@ -93,6 +93,7 @@ $whitelistPatterns = @(
     'winsmux-app/src-tauri/Cargo.toml',
     'winsmux-app/src-tauri/Cargo.lock',
     'winsmux-app/src-tauri/tauri.conf.json',
+    'winsmux-app/src-tauri/capabilities/*.json',
     'winsmux-app/src-tauri/src/control_pipe.rs',
     'workers/colab/*.py',
     'winsmux-core/**',

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -264,9 +264,12 @@ When generating or editing a release:
 4. Keep the GitHub Release body aligned with the `/release-notes` structure, but in English and mapped onto the Codex-style headings above.
 5. Link the compare range in `Full Changelog` when the repository and tag range support it.
 6. Local or private post drafts may be Japanese if the task explicitly asks for them, but the public GitHub Release stays English.
-7. Do not name external competing editor, IDE, or workbench products as UI references in public release notes or public documentation.
-   - Describe the behavior generically, such as "familiar developer workbench flow" or "source-control-oriented surface".
-   - Provider/runtime names may appear only when they are needed to explain supported official agent integrations, authentication, or compatibility.
+7. Do not name external competing editor, IDE, terminal, workbench, agent orchestration, or AI coding products anywhere in public release notes or public documentation.
+   - This includes comparisons, migration notes, roadmap examples, UI inspiration notes, screenshots, captions, and attribution-free references.
+   - Describe the behavior generically, such as "terminal-faithful workflow" or "source-control-oriented surface".
+   - Keep competitor and upstream research notes in private or ignored maintainer material only.
+   - Provider/runtime names may appear only when they are needed to explain supported official agent integrations, authentication, model compatibility, or required license notices.
+   - Do not directly reuse competitor assets or code in public-facing work if that would force public competitor naming, unless the user explicitly approves the attribution path first.
 8. When an item maps to a repository issue or PR, preserve that reference inline in the bullet in Codex style.
    - Prefer `(#315)` or `(#315, #318)` at the end of the bullet when the reference is available.
    - Do not strip issue/PR references out of release bullets during summarization if they materially help traceability.

--- a/winsmux-app/scripts/desktop-pane-e2e.mjs
+++ b/winsmux-app/scripts/desktop-pane-e2e.mjs
@@ -271,6 +271,36 @@ async function invokePty(page, method, params) {
   return response?.result;
 }
 
+async function invokeDesktop(page, method, params = {}) {
+  const response = await page.evaluate(
+    async ({ methodName, methodParams }) => {
+      return await window.__TAURI__.core.invoke("desktop_json_rpc", {
+        request: {
+          jsonrpc: "2.0",
+          id: `desktop-native-e2e-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+          method: methodName,
+          params: methodParams,
+        },
+      });
+    },
+    { methodName: method, methodParams: params },
+  );
+
+  if (response?.error) {
+    throw new Error(response.error.message);
+  }
+  return response?.result;
+}
+
+async function invokeTauriCommand(page, command, args = {}) {
+  return await page.evaluate(
+    async ({ commandName, commandArgs }) => {
+      return await window.__TAURI__.core.invoke(commandName, commandArgs);
+    },
+    { commandName: command, commandArgs: args },
+  );
+}
+
 async function capturePty(page, paneId, lines = 120) {
   const result = await invokePty(page, "pty.capture", { paneId, lines });
   return String(result?.output ?? "");
@@ -429,6 +459,107 @@ async function openCommandPaletteAction(page, query, expected) {
   await page.fill("#command-bar-input", query);
   await page.keyboard.press("Enter");
   await expected();
+}
+
+async function waitForTauriPage(browser, predicate, timeoutMs = 20_000) {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    for (const context of browser.contexts()) {
+      for (const candidate of context.pages()) {
+        if (await predicate(candidate)) {
+          return candidate;
+        }
+      }
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+
+  const pages = browser.contexts().flatMap((context) => context.pages()).map((candidate) => candidate.url());
+  throw new Error(`Timed out waiting for a Tauri page. Seen pages: ${pages.join(", ")}`);
+}
+
+async function exerciseTauriNativeSurface(page, browser) {
+  const apiSurface = await page.evaluate(() => {
+    const tauri = window.__TAURI__;
+    return {
+      keys: tauri ? Object.keys(tauri).sort() : [],
+      hasCoreInvoke: typeof tauri?.core?.invoke === "function",
+      hasWebviewWindow: Boolean(tauri?.webviewWindow),
+      hasDialog: Boolean(tauri?.dialog),
+      hasTray: Boolean(tauri?.tray),
+    };
+  });
+  if (!apiSurface.hasCoreInvoke || !apiSurface.hasWebviewWindow) {
+    throw new Error(`Tauri API surface is incomplete: ${JSON.stringify(apiSurface)}`);
+  }
+
+  const contract = await invokeDesktop(page, "desktop.control_plane.contract");
+  if (!Array.isArray(contract?.methods) || !contract.methods.includes("desktop.editor.read")) {
+    throw new Error(`desktop control-plane contract missing editor read: ${JSON.stringify(contract)}`);
+  }
+
+  const editorFile = await invokeDesktop(page, "desktop.editor.read", { path: "winsmux-app/src/main.ts" });
+  if (!String(editorFile?.content ?? "").includes("@tauri-apps/plugin-dialog")) {
+    throw new Error("desktop.editor.read did not return the expected source content");
+  }
+
+  const explorer = await invokeDesktop(page, "desktop.explorer.list");
+  if (!Array.isArray(explorer?.entries) || explorer.entries.length === 0) {
+    throw new Error("desktop.explorer.list returned no project entries");
+  }
+
+  const voiceInitial = await invokeTauriCommand(page, "desktop_voice_capture_status");
+  const voiceStart = await invokeTauriCommand(page, "desktop_voice_capture_start");
+  await page.waitForTimeout(500);
+  const voiceDuring = await invokeTauriCommand(page, "desktop_voice_capture_status");
+  const voiceStop = await invokeTauriCommand(page, "desktop_voice_capture_stop", { cancelled: true });
+
+  const harnessUrl = new URL(page.url());
+  harnessUrl.search = "?viewport-harness=1";
+  await page.goto(harnessUrl.toString(), { waitUntil: "domcontentloaded" });
+  await waitForAppReady(page);
+  await page.waitForFunction(() => Boolean(window.__winsmuxViewportHarness?.openEditorPreview));
+  await page.evaluate(() => {
+    window.__winsmuxViewportHarness.openEditorPreview(
+      "winsmux-app/src/main.ts",
+      "export const tauriNativeE2e = true;\n",
+    );
+  });
+  await page.locator("#editor-surface").waitFor({ state: "visible" });
+  await page.locator("#popout-editor-btn").waitFor({ state: "visible" });
+
+  await page.click("#popout-editor-btn");
+  const popout = await waitForTauriPage(
+    browser,
+    async (candidate) => candidate !== page && candidate.url().includes("popout=1"),
+  );
+  attachPageErrorCapture(popout);
+  await popout.locator("#editor-surface").waitFor({ state: "visible" });
+  await popout.locator("#editor-code", { hasText: "@tauri-apps/plugin-dialog" }).waitFor({ state: "visible" });
+  const popoutLabel = await popout.evaluate(() => window.__TAURI__.webviewWindow.getCurrentWebviewWindow().label);
+  await popout.click("#close-editor-btn");
+  await page.waitForFunction(
+    async (label) => {
+      const windows = await window.__TAURI__.webviewWindow.getAllWebviewWindows();
+      return !windows.some((item) => item.label === label);
+    },
+    popoutLabel,
+    { timeout: 20_000 },
+  );
+
+  return {
+    apiSurface,
+    contractMethods: contract.methods.length,
+    editorLineCount: editorFile.line_count,
+    explorerEntryCount: explorer.entries.length,
+    voiceStates: {
+      initial: voiceInitial?.native?.state,
+      start: voiceStart?.native?.state,
+      during: voiceDuring?.native?.state,
+      stop: voiceStop?.native?.state,
+    },
+    webviewWindow: `created-and-closed:${popoutLabel}`,
+  };
 }
 
 async function writeEvidence(ok, extra = {}) {
@@ -649,6 +780,10 @@ async function main() {
         operatorTail: operatorOutput.slice(-1_200),
         workerTail: workerOutput.slice(-800),
       };
+    });
+
+    await runStep("Tauri native APIs exercise Rust, filesystem, voice, and webview windows", async () => {
+      return await exerciseTauriNativeSurface(page, browser);
     });
 
     await runStep("close spawned PTYs", async () => {

--- a/winsmux-app/src-tauri/capabilities/default.json
+++ b/winsmux-app/src-tauri/capabilities/default.json
@@ -5,6 +5,7 @@
   "windows": ["main"],
   "permissions": [
     "core:default",
+    "core:webview:allow-create-webview-window",
     "dialog:default",
     "opener:default"
   ]

--- a/winsmux-app/src-tauri/capabilities/secondary-surface.json
+++ b/winsmux-app/src-tauri/capabilities/secondary-surface.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "secondary-surface",
+  "description": "Capability for editor and preview popout windows",
+  "windows": ["secondary-surface-*"],
+  "permissions": [
+    "core:default",
+    "core:window:allow-close"
+  ]
+}


### PR DESCRIPTION
## Summary

- Add repeatable desktop E2E checks for real Tauri-native paths: Rust invoke, Rust-backed file reads, native voice capture commands, and WebViewWindow popout create/close.
- Add the minimum Tauri capabilities needed for main-window popout creation and secondary-surface-* popout closing.
- Allow Tauri capability JSON files in the pre-commit whitelist and include the user-approved AGENTS.md public-doc naming rule update.

Closes #924.

## Verification

- 
pm run test:desktop-pane-e2e
- 
pm run build
- cargo check -p winsmux-app
- pre-push: git-guard, udit-public-surface, and gitleaks passed