### PR TITLE
Fix Tauri GUI E2E operator handoff flows

### DIFF
--- a/winsmux-app/index.html
+++ b/winsmux-app/index.html
@@ -243,8 +243,8 @@
               <div id="timeline-filter-row" aria-label="Timeline filters"></div>
               <div id="timeline-feed-hint">Key events only. Details open when needed.</div>
             </div>
-            <div id="selected-run-summary"></div>
-            <div id="agent-work-dashboard"></div>
+            <div id="selected-run-summary" hidden></div>
+            <div id="agent-work-dashboard" hidden></div>
             <div id="conversation-timeline" role="log" aria-live="polite" aria-relevant="additions text"></div>
             <form id="composer" autocomplete="off">
               <label class="sr-only" for="composer-input">Message the Operator</label>

--- a/winsmux-app/scripts/desktop-pane-e2e.mjs
+++ b/winsmux-app/scripts/desktop-pane-e2e.mjs
@@ -10,11 +10,11 @@ const OUTPUT_DIR = path.join(process.cwd(), "output", "playwright", "desktop-pan
 const APP_URL_PATTERN = /localhost:1420|127\.0\.0\.1:1420/;
 const CONTROL_PIPE_NAME = "winsmux-control";
 const WORKER_UI_MARKER = "WORKER_1_UI_E2E_READY";
-const OPERATOR_MARKER = "OPERATOR_TERMINAL_E2E_READY";
-const COMPOSER_TO_OPERATOR_MARKER = "COMPOSER_TO_OPERATOR_E2E_READY";
-const COMPOSER_ENTER_MARKER = "COMPOSER_ENTER_E2E_READY";
-const COMPOSER_ATTACHMENT_MARKER = "COMPOSER_ATTACHMENT_E2E_READY";
-const OPERATOR_TO_WORKER_MARKER = "OPERATOR_TO_WORKER_E2E_READY";
+const OPERATOR_MARKER = "OP_E2E_READY";
+const COMPOSER_TO_OPERATOR_MARKER = "BTN_E2E_READY";
+const COMPOSER_ENTER_MARKER = "ENT_E2E_READY";
+const COMPOSER_ATTACHMENT_MARKER = "ATT_E2E_READY";
+const OPERATOR_TO_WORKER_MARKER = "W2_E2E_READY";
 
 const steps = [];
 const consoleErrors = [];
@@ -331,10 +331,22 @@ async function spawnPtyIfNeeded(page, paneId) {
 async function waitForPtyOutput(page, paneId, marker, timeoutMs = 45_000) {
   const startedAt = Date.now();
   let lastOutput = "";
+  const compactMarker = marker.replace(/\s+/g, "");
   while (Date.now() - startedAt < timeoutMs) {
     lastOutput = await capturePty(page, paneId).catch((error) => `capture failed: ${error.message}`);
-    if (lastOutput.includes(marker)) {
+    const stripped = stripAnsi(lastOutput);
+    if (
+      lastOutput.includes(marker) ||
+      stripped.includes(marker) ||
+      stripped.replace(/\s+/g, "").includes(compactMarker)
+    ) {
       return lastOutput;
+    }
+    if (
+      paneId === "operator" &&
+      /トークン予算超過|確認待ち|どう進めますか|token budget|continue\?/i.test(stripped)
+    ) {
+      throw new Error(`Operator is waiting for a user decision before ${marker}. Last output:\n${lastOutput}`);
     }
     await new Promise((resolve) => setTimeout(resolve, 500));
   }
@@ -374,10 +386,61 @@ async function waitForPtyPrompt(page, paneId, timeoutMs = 45_000) {
   throw new Error(`Timed out waiting for a PowerShell prompt in ${paneId}. Last output:\n${lastOutput}`);
 }
 
+function isClaudeOperatorReadyText(output) {
+  const stripped = stripAnsi(output)
+    .replace(/\r/g, "\n")
+    .replace(/\u00a0/g, " ");
+  const compact = stripped.replace(/\s+/g, "");
+  if (!compact.includes("ClaudeCode")) {
+    return false;
+  }
+  const tail = stripped.slice(-4000);
+  if (/\b(missing api key|run \/login|unable to connect|failed to connect)\b/i.test(tail)) {
+    return false;
+  }
+  if (
+    /トークン予算超過|確認待ち|どう進めますか|running \d+ shell command|listing \d+ director|wrangling|choreographing|spelunking|thinking with|still thinking|running stop hook|pasted text|paste again to expand/i
+      .test(tail)
+  ) {
+    return false;
+  }
+  return /(?:^|\n)[^\n]*[>›▌❯][^\n]*(?:Try "create|create a util|$)/.test(tail)
+    || /accepteditson/i.test(tail.replace(/\s+/g, ""));
+}
+
+async function waitForClaudeOperatorReady(page, timeoutMs = 90_000) {
+  const startedAt = Date.now();
+  let lastOutput = "";
+  while (Date.now() - startedAt < timeoutMs) {
+    lastOutput = await capturePty(page, "operator").catch((error) => `capture failed: ${error.message}`);
+    if (isClaudeOperatorReadyText(lastOutput)) {
+      return lastOutput;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+  throw new Error(`Timed out waiting for Claude Code readiness in operator. Last output:\n${lastOutput}`);
+}
+
+async function startOperatorFromUiAndWaitForClaude(page) {
+  await page.click("#operator-terminal-panel", { timeout: 10_000 });
+  return await waitForClaudeOperatorReady(page);
+}
+
 async function typeIntoTerminal(page, selector, text) {
   await page.click(selector, { timeout: 10_000 });
   await page.keyboard.type(text, { delay: 2 });
   await page.keyboard.press("Enter");
+}
+
+async function typeTerminalDraft(page, selector, text) {
+  await page.click(selector, { timeout: 10_000 });
+  await page.keyboard.type(text, { delay: 2 });
+}
+
+async function clearOperatorInputFromUi(page) {
+  await page.click("#operator-terminal-panel", { timeout: 10_000 });
+  await page.keyboard.press("Control+C");
+  await page.waitForTimeout(750);
 }
 
 async function startPaneFromUiAndWaitForPrompt(page, paneId, selector) {
@@ -427,7 +490,7 @@ async function writeOperatorPipeScript(scriptPath) {
 }
 
 async function submitComposerWithButton(page, command, expectedMarker) {
-  await waitForPtyPrompt(page, "operator");
+  await startOperatorFromUiAndWaitForClaude(page);
   await page.fill("#composer-input", command);
   await page.click("#send-btn");
   await page.waitForFunction(() => {
@@ -438,11 +501,11 @@ async function submitComposerWithButton(page, command, expectedMarker) {
   if (conversationContainsMessage < 1) {
     throw new Error("submitted composer message was not rendered in the conversation panel");
   }
-  return await waitForPtyOutputLine(page, "operator", expectedMarker);
+  return await waitForPtyOutput(page, "operator", expectedMarker);
 }
 
 async function submitComposerWithEnter(page, command, expectedMarker) {
-  await waitForPtyPrompt(page, "operator");
+  await startOperatorFromUiAndWaitForClaude(page);
   await page.fill("#composer-input", command);
   await page.focus("#composer-input");
   await page.keyboard.press("Enter");
@@ -450,11 +513,16 @@ async function submitComposerWithEnter(page, command, expectedMarker) {
     const input = document.querySelector("#composer-input");
     return input instanceof HTMLTextAreaElement && input.value === "";
   });
-  return await waitForPtyOutputLine(page, "operator", expectedMarker);
+  return await waitForPtyOutput(page, "operator", expectedMarker);
 }
 
 async function openCommandPaletteAction(page, query, expected) {
-  await page.keyboard.press("Control+K");
+  if (await page.locator("#open-command-bar-btn").isVisible().catch(() => false)) {
+    await page.click("#open-command-bar-btn");
+  } else {
+    await page.focus("#composer-input");
+    await page.keyboard.press("Control+K");
+  }
   await page.locator("#command-bar-shell").waitFor({ state: "visible" });
   await page.fill("#command-bar-input", query);
   await page.keyboard.press("Enter");
@@ -606,6 +674,17 @@ async function main() {
       return { url: page.url() };
     });
 
+    await runStep("default center keeps operator and composer unobstructed", async () => {
+      await page.waitForTimeout(2_000);
+      await page.locator("#operator-terminal-panel").waitFor({ state: "visible" });
+      await page.locator("#composer").waitFor({ state: "visible" });
+      const runSummaryVisible = await page.locator("#selected-run-summary").isVisible().catch(() => false);
+      const dashboardVisible = await page.locator("#agent-work-dashboard").isVisible().catch(() => false);
+      if (runSummaryVisible || dashboardVisible) {
+        throw new Error(`default center should not show run summary or dashboard; summary=${runSummaryVisible}, dashboard=${dashboardVisible}`);
+      }
+    });
+
     await runStep("drawer close and reopen controls", async () => {
       await ensureDrawerOpen(page);
       await page.click("#close-terminal-drawer-btn");
@@ -667,17 +746,37 @@ async function main() {
       return { outputTail: output.slice(-800) };
     });
 
-    await runStep("operator pane runs a real terminal command", async () => {
-      await spawnPtyIfNeeded(page, "operator");
-      await waitForPtyPrompt(page, "operator");
-      await typeIntoTerminal(page, "#operator-terminal-panel", `Write-Output '${OPERATOR_MARKER}'`);
-      const output = await waitForPtyOutputLine(page, "operator", OPERATOR_MARKER);
-      return { outputTail: output.slice(-800) };
+    await runStep("operator pane starts Claude Code and accepts real user input", async () => {
+      const readyOutput = await startOperatorFromUiAndWaitForClaude(page);
+      await typeTerminalDraft(page, "#operator-terminal-panel", OPERATOR_MARKER);
+      const output = await waitForPtyOutput(page, "operator", OPERATOR_MARKER);
+      await clearOperatorInputFromUi(page);
+      const timelineText = await page.locator("#conversation-timeline").innerText().catch(() => "");
+      if (/Claude Code v\d|--permission-mode/.test(timelineText)) {
+        throw new Error("operator startup log should stay in the operator pane and not mirror into the chat timeline");
+      }
+      return { readyTail: readyOutput.slice(-800), outputTail: output.slice(-800) };
+    });
+
+    await runStep("operator command writes to worker through desktop control pipe", async () => {
+      await spawnPtyIfNeeded(page, "worker-2");
+      await waitForPtyPrompt(page, "worker-2");
+      await startOperatorFromUiAndWaitForClaude(page);
+      // Claude Code uses `!` as its shell-command prefix; this is typed into the operator, not PowerShell.
+      const claudeShellCommand = `!pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File '${scriptPath.replace(/'/g, "''")}'`;
+      await typeIntoTerminal(page, "#operator-terminal-panel", claudeShellCommand);
+      const operatorOutput = await waitForPtyOutput(page, "operator", "PIPE_RESPONSE:");
+      const workerOutput = await waitForPtyOutputLine(page, "worker-2", OPERATOR_TO_WORKER_MARKER);
+      return {
+        operatorTail: operatorOutput.slice(-1_200),
+        workerTail: workerOutput.slice(-800),
+      };
     });
 
     await runStep("composer send button writes user message to operator pane", async () => {
-      const command = `Write-Output '${COMPOSER_TO_OPERATOR_MARKER}'`;
+      const command = COMPOSER_TO_OPERATOR_MARKER;
       const output = await submitComposerWithButton(page, command, COMPOSER_TO_OPERATOR_MARKER);
+      await clearOperatorInputFromUi(page);
       return { outputTail: output.slice(-800) };
     });
 
@@ -690,8 +789,9 @@ async function main() {
       if (!draft.includes("\n") || !draft.includes("second line")) {
         throw new Error(`Shift+Enter should insert a newline, got ${JSON.stringify(draft)}`);
       }
-      const command = `Write-Output '${COMPOSER_ENTER_MARKER}'`;
+      const command = COMPOSER_ENTER_MARKER;
       const output = await submitComposerWithEnter(page, command, COMPOSER_ENTER_MARKER);
+      await clearOperatorInputFromUi(page);
       return { outputTail: output.slice(-800) };
     });
 
@@ -716,15 +816,14 @@ async function main() {
       await page.locator("#composer-file-input").setInputFiles(attachmentPath);
       await page.locator("#attachment-tray", { hasText: "composer-attachment.txt" }).waitFor({ state: "visible" });
       const message = COMPOSER_ATTACHMENT_MARKER;
-      await waitForPtyPrompt(page, "operator");
+      await startOperatorFromUiAndWaitForClaude(page);
       await page.fill("#composer-input", message);
       await page.click("#send-btn");
       await page.waitForFunction(() => {
         const input = document.querySelector("#composer-input");
         return input instanceof HTMLTextAreaElement && input.value === "";
       });
-      const output = await waitForPtyOutput(page, "operator", COMPOSER_ATTACHMENT_MARKER);
-      await waitForPtyPrompt(page, "operator");
+      const output = await waitForPtyOutput(page, "operator", "Pasted text");
       const attachmentStillVisible = await page.locator("#attachment-tray", { hasText: "composer-attachment.txt" }).isVisible().catch(() => false);
       if (attachmentStillVisible) {
         throw new Error("attachment tray should clear after composer submit");
@@ -767,19 +866,6 @@ async function main() {
         return shell instanceof HTMLElement && shell.dataset.density === "compact";
       });
       await page.click("#close-settings-btn");
-    });
-
-    await runStep("operator command writes to worker through desktop control pipe", async () => {
-      await spawnPtyIfNeeded(page, "worker-2");
-      await waitForPtyPrompt(page, "worker-2");
-      await waitForPtyPrompt(page, "operator");
-      await typeIntoTerminal(page, "#operator-terminal-panel", `& '${scriptPath.replace(/\\/g, "\\\\")}'`);
-      const operatorOutput = await waitForPtyOutput(page, "operator", "PIPE_RESPONSE:");
-      const workerOutput = await waitForPtyOutputLine(page, "worker-2", OPERATOR_TO_WORKER_MARKER);
-      return {
-        operatorTail: operatorOutput.slice(-1_200),
-        workerTail: workerOutput.slice(-800),
-      };
     });
 
     await runStep("Tauri native APIs exercise Rust, filesystem, voice, and webview windows", async () => {

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -524,6 +524,8 @@ let operatorRequestStatusTimer: number | null = null;
 let operatorInterruptInFlight = false;
 let operatorOutputBuffer = "";
 let operatorOutputFlushTimer: number | null = null;
+let operatorAttentionFingerprint = "";
+let operatorClaudeSessionId = createOperatorSessionId();
 let voiceRecognition: SpeechRecognitionLike | null = null;
 let voiceListening = false;
 let voiceTranscriptBase = "";
@@ -588,6 +590,7 @@ const OPERATOR_PTY_ID = "operator";
 const OPERATOR_PTY_COLS = 120;
 const OPERATOR_PTY_ROWS = 32;
 const OPERATOR_PTY_ACTION_TIMEOUT_MS = 15_000;
+const OPERATOR_MULTILINE_SUBMIT_DELAY_MS = 100;
 const DEFAULT_EDITOR_FONT_SIZE = 13;
 const MIN_EDITOR_FONT_SIZE = 8;
 const MAX_EDITOR_FONT_SIZE = 32;
@@ -1470,6 +1473,8 @@ function markOperatorPtyStartedFromExternalEvent() {
 function markOperatorPtyStoppedFromExternalEvent() {
   operatorPtyStarted = false;
   operatorPtyStarting = null;
+  operatorAttentionFingerprint = "";
+  operatorClaudeSessionId = createOperatorSessionId();
   setOperatorRequestActive(false);
 }
 
@@ -1602,8 +1607,18 @@ function getPaneStartupInput(_paneId: string) {
   return undefined;
 }
 
+function createOperatorSessionId() {
+  if (typeof globalThis.crypto?.randomUUID === "function") {
+    return globalThis.crypto.randomUUID();
+  }
+
+  const randomPart = () => Math.floor(Math.random() * 0x10000).toString(16).padStart(4, "0");
+  const variantPart = ((Math.random() * 0x4000) | 0x8000).toString(16);
+  return `${randomPart()}${randomPart()}-${randomPart()}-4${randomPart().slice(1)}-${variantPart}-${randomPart()}${randomPart()}${randomPart()}`;
+}
+
 function getOperatorStartupInput() {
-  const args = ["claude", "--permission-mode", activeComposerPermissionMode];
+  const args = ["claude", "--permission-mode", activeComposerPermissionMode, "--session-id", operatorClaudeSessionId];
   const modelOption = getComposerModelOption();
   if (modelOption.cliModel) {
     args.push("--model", modelOption.cliModel);
@@ -9044,10 +9059,7 @@ function renderTimelineFilters() {
     button.textContent = themeState.language === "ja" ? timelineFilterLabelsJa[item.filter] : item.label;
     button.setAttribute("aria-pressed", item.filter === activeTimelineFilter ? "true" : "false");
     button.addEventListener("click", () => {
-      activeTimelineFilter = item.filter;
-      renderTimelineFilters();
-      renderConversation(getConversationItems());
-      renderRunSummary();
+      setTimelineFilter(item.filter);
     });
     root.appendChild(button);
   }
@@ -9057,6 +9069,12 @@ function renderTimelineFilters() {
 function renderRunSummary() {
   const root = document.getElementById("selected-run-summary");
   if (!root) {
+    return;
+  }
+
+  if (activeTimelineFilter !== "activity") {
+    root.hidden = true;
+    root.innerHTML = "";
     return;
   }
 
@@ -9124,6 +9142,12 @@ function renderRunSummary() {
 function renderAgentWorkDashboard() {
   const root = document.getElementById("agent-work-dashboard");
   if (!root) {
+    return;
+  }
+
+  if (activeTimelineFilter !== "activity") {
+    root.hidden = true;
+    root.innerHTML = "";
     return;
   }
 
@@ -9959,12 +9983,7 @@ function getCommandActions(): CommandAction[] {
       ),
       keywords: getLanguageText("filter attention blocked timeline", "絞り込み 要確認 停止 タイムライン").split(" "),
       tone: "danger",
-      run: () => {
-        activeTimelineFilter = "attention";
-        renderTimelineFilters();
-        renderRunSummary();
-        renderConversation(getConversationItems());
-      },
+      run: () => setTimelineFilter("attention"),
     },
     {
       id: "review-filter",
@@ -9975,12 +9994,7 @@ function getCommandActions(): CommandAction[] {
       ),
       keywords: getLanguageText("filter review timeline approve", "絞り込み レビュー タイムライン 承認").split(" "),
       tone: "warning",
-      run: () => {
-        activeTimelineFilter = "review";
-        renderTimelineFilters();
-        renderRunSummary();
-        renderConversation(getConversationItems());
-      },
+      run: () => setTimelineFilter("review"),
     },
   ];
 }
@@ -10128,6 +10142,7 @@ function setTimelineFilter(filter: TimelineFilter) {
   activeTimelineFilter = filter;
   renderTimelineFilters();
   renderRunSummary();
+  renderAgentWorkDashboard();
   renderConversation(getConversationItems());
 }
 
@@ -10857,24 +10872,55 @@ function stripTerminalControlSequences(value: string) {
     .trim();
 }
 
-function getRecentNonEmptyLines(text: string, maxCount: number) {
-  const lines = text.split(/\r?\n/).filter((line) => line.trim().length > 0);
-  return lines.slice(Math.max(0, lines.length - maxCount));
-}
-
 function isClaudeOperatorReadyText(text: string) {
-  const recentLines = getRecentNonEmptyLines(text, 8);
-  if (recentLines.length === 0) {
+  const stripped = stripTerminalControlSequences(text).replace(/\u00a0/g, " ");
+  if (!stripped) {
     return false;
   }
 
-  const tailText = recentLines.join("\n");
+  const tailText = stripped.slice(-3000);
   if (/\b(missing api key|run \/login|unable to connect|failed to connect)\b/i.test(tailText)) {
     return false;
   }
+  if (
+    /トークン予算超過|確認待ち|どう進めますか|running \d+ shell command|wrangling|choreographing|spelunking|thinking with|still thinking|running stop hook|pasted text|paste again to expand/i
+      .test(tailText)
+  ) {
+    return false;
+  }
 
-  const finalLine = recentLines[recentLines.length - 1]?.trim() ?? "";
-  return /^[>›▌❯]$/.test(finalLine);
+  const compactTail = tailText.replace(/\s+/g, "");
+  const recentLines = tailText.split("\n").map((line) => line.trim()).filter(Boolean).slice(-6);
+  const hasStandalonePrompt = recentLines.slice(-2).some((line) => /^(?:[>›❯]|[>›❯]\s*▌|▌)$/.test(line));
+  const hasStartupPrompt = compactTail.includes("ClaudeCode")
+    && (
+      /accepteditson/i.test(compactTail)
+      || /[>›▌❯].*(?:Try"create|createautil)/i.test(compactTail)
+    );
+  return hasStandalonePrompt || hasStartupPrompt;
+}
+
+function getOperatorAttentionFromText(text: string): { title: string; body: string } | null {
+  const compact = text.replace(/\s+/g, "");
+  if (/トークン予算超過|tokenbudget/i.test(compact)) {
+    return {
+      title: getLanguageText("Operator needs confirmation", "オペレーターが確認待ちです"),
+      body: getLanguageText(
+        "Claude Code is waiting for a token budget or continuation confirmation. Check the operator pane before sending more work.",
+        "Claude Code がトークン予算または続行確認で停止しています。追加で依頼する前にオペレーターペインを確認してください。",
+      ),
+    };
+  }
+  if (/どう進めますか|確認待ち|approval|continue\?/i.test(text)) {
+    return {
+      title: getLanguageText("Operator is waiting", "オペレーターが待機中です"),
+      body: getLanguageText(
+        "Claude Code is asking for a decision in the operator pane.",
+        "Claude Code がオペレーターペインで判断を求めています。",
+      ),
+    };
+  }
+  return null;
 }
 
 function appendOperatorPtyOutput(data: string) {
@@ -10897,15 +10943,24 @@ function appendOperatorPtyOutput(data: string) {
     if (operatorRequestActive && isClaudeOperatorReadyText(body)) {
       setOperatorRequestActive(false);
     }
-    appendRuntimeConversation({
-      type: "operator",
-      category: "activity",
-      timestamp: new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" }),
-      actor: "Claude Code",
-      body,
-      tone: "info",
-    });
-    renderConversation(getConversationItems());
+    const attention = getOperatorAttentionFromText(body);
+    if (attention) {
+      const fingerprint = `${attention.title}:${attention.body}`;
+      if (fingerprint !== operatorAttentionFingerprint) {
+        operatorAttentionFingerprint = fingerprint;
+        setOperatorRequestActive(false);
+        appendRuntimeConversation({
+          type: "system",
+          category: "attention",
+          timestamp: new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" }),
+          actor: "winsmux",
+          title: attention.title,
+          body: attention.body,
+          tone: "warning",
+        });
+        renderConversation(getConversationItems());
+      }
+    }
   }, 350);
 }
 
@@ -12012,6 +12067,7 @@ function setOperatorRequestActive(active: boolean) {
 
 function beginOperatorRequest() {
   operatorRequestGeneration += 1;
+  operatorAttentionFingerprint = "";
   setOperatorRequestActive(true);
   return operatorRequestGeneration;
 }
@@ -12040,6 +12096,12 @@ async function withOperatorTimeout<T>(operation: Promise<T>, label: string): Pro
       window.clearTimeout(timeoutId);
     }
   }
+}
+
+function waitForOperatorSubmitDelay() {
+  return new Promise<void>((resolve) => {
+    window.setTimeout(resolve, OPERATOR_MULTILINE_SUBMIT_DELAY_MS);
+  });
 }
 
 async function interruptOperatorRequest() {
@@ -12103,9 +12165,20 @@ function formatComposerMessageForPty(message: string, attachments: ComposerAttac
 
 function encodePtySubmission(message: string) {
   if (message.includes("\n")) {
-    return `\x1b[200~${message}\x1b[201~\r`;
+    return `\x1b[200~${message}\x1b[201~`;
   }
   return `${message}\r`;
+}
+
+async function writeOperatorSubmission(payload: string, requestGeneration: number) {
+  await withOperatorTimeout(writePtyData(OPERATOR_PTY_ID, encodePtySubmission(payload)), "operator request write");
+  if (payload.includes("\n")) {
+    await waitForOperatorSubmitDelay();
+    if (!isCurrentOperatorRequest(requestGeneration)) {
+      return;
+    }
+    await withOperatorTimeout(writePtyData(OPERATOR_PTY_ID, "\r"), "operator request submit");
+  }
 }
 
 async function forwardComposerMessageToOperatorPane(
@@ -12125,7 +12198,7 @@ async function forwardComposerMessageToOperatorPane(
     if (!isCurrentOperatorRequest(requestGeneration)) {
       return;
     }
-    await withOperatorTimeout(writePtyData(OPERATOR_PTY_ID, encodePtySubmission(payload)), "operator request write");
+    await writeOperatorSubmission(payload, requestGeneration);
     if (!isCurrentOperatorRequest(requestGeneration)) {
       return;
     }

--- a/winsmux-app/src/styles.css
+++ b/winsmux-app/src/styles.css
@@ -1595,7 +1595,8 @@ body[data-popout-surface="1"] #editor-surface {
   display: none;
 }
 
-#agent-work-dashboard[hidden] {
+#agent-work-dashboard[hidden],
+#agent-work-dashboard:empty {
   display: none;
 }
 


### PR DESCRIPTION
## Summary
- keep the default center view focused on the operator pane and composer instead of showing raw logs or the work dashboard
- start the desktop Claude Code operator with a dedicated session ID and surface budget/confirmation waits explicitly
- make the real Tauri GUI E2E prove operator-to-worker handoff before composer signal tests
- submit multi-line composer payloads as paste plus a separate Enter

Closes #927. Maps to TASK-490.

## Validation
- cmd /c npm run build
- cmd /c npm run test:desktop-pane-e2e
- cmd /c npm run test:clickable-coverage
- cmd /c npm run test:viewport-harness
- cargo check --manifest-path winsmux-app\\src-tauri\\Cargo.toml --locked
- git diff --check
- pwsh -NoProfile -File scripts\\audit-public-surface.ps1
- pwsh -NoProfile -File scripts\\git-guard.ps1 -Mode full
- process cleanup check: no matching leftover winsmux/Tauri E2E processes