### PR TITLE
Add v0.33.0 provider capability catalog

### DIFF
--- a/core/src/operator_cli.rs
+++ b/core/src/operator_cli.rs
@@ -1546,6 +1546,11 @@ pub fn run_provider_switch_command(args: &[&String]) -> io::Result<()> {
         "auth_mode": effective.auth_mode,
         "auth_policy": effective.auth_policy,
         "local_access_note": effective.local_access_note,
+        "harness_availability": effective.harness_availability,
+        "credential_requirements": effective.credential_requirements,
+        "execution_backend": effective.execution_backend,
+        "runtime_requirements": effective.runtime_requirements,
+        "analysis_posture": effective.analysis_posture,
         "source": effective.source,
         "capability_adapter": effective.capability_adapter,
         "capability_command": effective.capability_command,
@@ -1850,6 +1855,11 @@ struct SlotAgentConfig {
     model_sources: Value,
     reasoning_efforts: Value,
     local_access_note: String,
+    harness_availability: String,
+    credential_requirements: String,
+    execution_backend: String,
+    runtime_requirements: String,
+    analysis_posture: String,
     supports_parallel_runs: bool,
     supports_interrupt: bool,
     supports_structured_result: bool,
@@ -2821,6 +2831,11 @@ fn normalize_provider_capability_entry(
         "command",
         "model_catalog_source",
         "local_access_note",
+        "harness_availability",
+        "credential_requirements",
+        "execution_backend",
+        "runtime_requirements",
+        "analysis_posture",
     ];
     let transport_fields = ["prompt_transports"];
     let string_array_fields = [
@@ -3802,6 +3817,11 @@ fn finalize_slot_agent_config(
             .cloned()
             .unwrap_or_else(|| Value::Array(Vec::new())),
         local_access_note: capability_string(capability.as_ref(), "local_access_note"),
+        harness_availability: capability_string(capability.as_ref(), "harness_availability"),
+        credential_requirements: capability_string(capability.as_ref(), "credential_requirements"),
+        execution_backend: capability_string(capability.as_ref(), "execution_backend"),
+        runtime_requirements: capability_string(capability.as_ref(), "runtime_requirements"),
+        analysis_posture: capability_string(capability.as_ref(), "analysis_posture"),
         supports_parallel_runs: capability_bool(capability.as_ref(), "supports_parallel_runs"),
         supports_interrupt: capability_bool(capability.as_ref(), "supports_interrupt"),
         supports_structured_result: capability_bool(

--- a/core/tests-rs/operator_cli.rs
+++ b/core/tests-rs/operator_cli.rs
@@ -1367,9 +1367,37 @@ fn operator_cli_provider_capabilities_json_reads_registry() {
       "model_sources": ["provider-default", "cli-discovery"],
       "reasoning_efforts": ["provider-default", "low", "medium", "high", "xhigh"],
       "local_access_note": "Local Codex CLI catalog and ChatGPT account access.",
+      "harness_availability": "official-cli",
+      "credential_requirements": "local-cli-owned",
+      "execution_backend": "agent-cli",
+      "runtime_requirements": "Codex CLI installed in the pane environment.",
+      "analysis_posture": "read-write-worker",
       "prompt_transports": ["argv", "file", "stdin"],
       "auth_modes": ["local_interactive"],
       "supports_subagents": true
+    },
+    "local-openai-compatible": {
+      "adapter": "openai-compatible",
+      "display_name": "Local OpenAI-compatible endpoint",
+      "command": "winsmux-local-llm",
+      "model_options": [
+        {"id": "operator-selected", "label": "Operator-selected runtime model", "source": "operator-override", "availability": "runtime-discovery"}
+      ],
+      "model_sources": ["operator-override"],
+      "reasoning_efforts": ["provider-default"],
+      "model_catalog_source": "runtime-health-endpoint",
+      "local_access_note": "Local endpoint owns model access and request handling.",
+      "harness_availability": "external-adapter",
+      "credential_requirements": "runtime-owned-local-endpoint",
+      "execution_backend": "openai-compatible-local-endpoint",
+      "runtime_requirements": "127.0.0.1 endpoint; GPU/CPU capacity owned by runtime.",
+      "analysis_posture": "read-only-analysis",
+      "prompt_transports": ["stdin"],
+      "auth_modes": ["none", "local-api-key"],
+      "read_only_launch_args": ["--read-only", "--no-file-edits"],
+      "supports_file_edit": false,
+      "supports_verification": false,
+      "supports_consultation": true
     },
     "claude": {
       "adapter": "claude",
@@ -1404,6 +1432,30 @@ fn operator_cli_provider_capabilities_json_reads_registry() {
     assert_eq!(
         registry["providers"]["codex"]["local_access_note"],
         "Local Codex CLI catalog and ChatGPT account access."
+    );
+    assert_eq!(
+        registry["providers"]["local-openai-compatible"]["analysis_posture"],
+        "read-only-analysis"
+    );
+    assert_eq!(
+        registry["providers"]["local-openai-compatible"]["credential_requirements"],
+        "runtime-owned-local-endpoint"
+    );
+    assert_eq!(
+        registry["providers"]["local-openai-compatible"]["execution_backend"],
+        "openai-compatible-local-endpoint"
+    );
+    assert_eq!(
+        registry["providers"]["local-openai-compatible"]["read_only_launch_args"][1],
+        "--no-file-edits"
+    );
+    assert_eq!(
+        registry["providers"]["local-openai-compatible"]["supports_file_edit"],
+        false
+    );
+    assert_eq!(
+        registry["providers"]["local-openai-compatible"]["supports_consultation"],
+        true
     );
     assert_eq!(
         registry["providers"]["codex"]["prompt_transports"][2],
@@ -2601,6 +2653,14 @@ fn operator_cli_provider_switch_writes_registry_entry() {
     assert_eq!(result["source"], "registry");
     assert_eq!(result["capability_adapter"], "claude");
     assert_eq!(result["capability_command"], "claude");
+    assert_eq!(result["harness_availability"], "official-cli");
+    assert_eq!(result["credential_requirements"], "local-cli-owned");
+    assert_eq!(result["execution_backend"], "agent-cli");
+    assert_eq!(
+        result["runtime_requirements"],
+        "Claude Code CLI installed in the pane environment."
+    );
+    assert_eq!(result["analysis_posture"], "read-write-worker");
     assert_eq!(result["supports_file_edit"], true);
     assert_eq!(result["supports_subagents"], false);
     assert_eq!(result["supports_consultation"], true);
@@ -5253,6 +5313,82 @@ fn operator_cli_dispatch_review_sends_review_request_to_preferred_pane() {
 }
 
 #[test]
+fn operator_cli_dispatch_review_prefers_reviewer_role_over_manifest_order() {
+    let project_dir = make_temp_project_dir("dispatch-review-prefers-reviewer-role");
+    write_manifest(&project_dir);
+    let manifest_path = project_dir.join(".winsmux").join("manifest.yaml");
+    fs::write(
+        &manifest_path,
+        r#"
+version: 1
+session:
+  name: winsmux-orchestra
+panes:
+  worker-1:
+    pane_id: "%2"
+    role: Worker
+    state: idle
+  reviewer-1:
+    pane_id: "%3"
+    role: Reviewer
+    state: idle
+"#,
+    )
+    .expect("test should write manifest with worker before reviewer");
+    init_git_branch(
+        &project_dir,
+        "codex/task266-rust-operator-readmodels-20260424",
+    );
+    set_git_head(
+        &project_dir,
+        "codex/task266-rust-operator-readmodels-20260424",
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    );
+    write_review_state(
+        &project_dir,
+        r#"{
+  "codex/task266-rust-operator-readmodels-20260424": {
+    "status": "PENDING",
+    "branch": "codex/task266-rust-operator-readmodels-20260424",
+    "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  }
+}"#,
+    );
+    let (winsmux_bin, log_path) = write_fake_winsmux_dispatch_review(&project_dir);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .arg("dispatch-review")
+        .env("WINSMUX_BIN", winsmux_bin)
+        .env("WINSMUX_PANE_ID", "%1")
+        .env("WINSMUX_ROLE", "Operator")
+        .env("WINSMUX_ROLE_MAP", r#"{"%1":"Operator"}"#)
+        .env("WINSMUX_DISPATCH_REVIEW_POLL_ATTEMPTS", "0")
+        .current_dir(&project_dir)
+        .output()
+        .expect("winsmux command should run");
+
+    assert!(
+        output.status.success(),
+        "winsmux command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Dispatching review to reviewer-1 [%3]"),
+        "unexpected stdout: {stdout}"
+    );
+    let log = fs::read_to_string(log_path).expect("test should read fake winsmux log");
+    assert!(
+        log.contains("send-keys") && log.contains("%3") && log.contains("winsmux review-request"),
+        "unexpected fake winsmux log: {log}"
+    );
+    assert!(
+        !log.contains("send-keys -t %2"),
+        "review request should not be sent to the worker pane: {log}"
+    );
+}
+
+#[test]
 fn operator_cli_dispatch_review_rejects_stale_pending_review_state() {
     let project_dir = make_temp_project_dir("dispatch-review-stale");
     write_manifest(&project_dir);
@@ -6499,6 +6635,11 @@ agent-slots:
       "model_sources": ["provider-default", "cli-discovery"],
       "reasoning_efforts": ["provider-default", "low", "medium", "high", "xhigh"],
       "local_access_note": "Local Codex CLI catalog and ChatGPT account access.",
+      "harness_availability": "official-cli",
+      "credential_requirements": "local-cli-owned",
+      "execution_backend": "agent-cli",
+      "runtime_requirements": "Codex CLI installed in the pane environment.",
+      "analysis_posture": "read-write-worker",
       "prompt_transports": ["argv", "file", "stdin"],
       "auth_modes": ["api-key", "codex-chatgpt-local"],
       "local_interactive_oauth_modes": ["codex-chatgpt-local"],
@@ -6522,6 +6663,11 @@ agent-slots:
       "model_sources": ["provider-default", "official-doc", "operator-override"],
       "reasoning_efforts": ["provider-default", "low", "medium", "high", "xhigh", "max"],
       "local_access_note": "Local Claude Code account and settings.",
+      "harness_availability": "official-cli",
+      "credential_requirements": "local-cli-owned",
+      "execution_backend": "agent-cli",
+      "runtime_requirements": "Claude Code CLI installed in the pane environment.",
+      "analysis_posture": "read-write-worker",
       "prompt_transports": ["file"],
       "auth_modes": ["api-key", "claude-pro-max-oauth"],
       "local_interactive_oauth_modes": ["claude-pro-max-oauth"],
@@ -6543,6 +6689,11 @@ agent-slots:
       "model_sources": ["provider-default", "operator-override"],
       "reasoning_efforts": ["provider-default"],
       "local_access_note": "Local Gemini CLI account and settings.",
+      "harness_availability": "official-cli",
+      "credential_requirements": "local-cli-owned",
+      "execution_backend": "agent-cli",
+      "runtime_requirements": "Gemini CLI installed in the pane environment.",
+      "analysis_posture": "read-write-worker",
       "prompt_transports": ["argv", "file"],
       "auth_modes": ["gemini-local"],
       "local_interactive_oauth_modes": ["gemini-local"],

--- a/docs/provider-and-model-support.ja.md
+++ b/docs/provider-and-model-support.ja.md
@@ -33,6 +33,29 @@ CLI であることは認証方式や実行方式の列で説明します。
 | ローカル LLM ランタイム | 今後のアダプター候補 | `v0.32.x` の Colab 対応では動作要件にしません。現時点では、通常のローカルツールとしてペインで動かすか、ローカルエンドポイントを使えるエージェント CLI 経由で使います。 |
 | `noop` ワーカーバックエンド | 仮置きスロットとして対応 | スロットを宣言したまま無効にできます。 |
 
+## プロバイダー能力カタログ
+
+`v0.33.0` から、`.winsmux/provider-capabilities.json` をエージェント CLI と
+ローカルエンドポイント用アダプターの能力カタログとして扱います。このカタログでは、
+起動方法、モデル情報、資格情報の境界を分けます。これにより、winsmux は
+ローカル推論エンドポイントを誤って書き込み可能ワーカーとして扱いません。
+
+プロバイダー定義では、次の項目を分けて宣言できます。
+
+- `harness_availability`: 組み込み CLI、外部アダプター、手動ペインツールのどれか。
+- `credential_requirements`: サインイン、API キー、エンドポイントの秘密情報、トークン保存を誰が所有するか。
+- `execution_backend`: エージェント CLI、Colab ワーカー、OpenAI 互換ローカルエンドポイントなどの実行経路。
+- `runtime_requirements`: エンドポイント、実行ファイル、GPU、CPU、メモリ、OS、リモートランタイムの要件。
+- `model_catalog_source` と `model_options`: モデル名の取得元と、オペレーターが選べる候補。
+- `analysis_posture`: 読み取り専用の分析に限るか、通常の書き込み可能ワーカーとして扱えるか。
+
+OpenAI 互換ローカルエンドポイントや GPU 付きローカルランタイムの既定は、
+読み取り専用の分析プロバイダーです。`supports_file_edit: false`、
+`supports_verification: false`、`supports_consultation: true`、
+`analysis_posture: "read-only-analysis"` と宣言します。ローカルランタイムは、
+エンドポイント、モデル、資格情報を自分で所有します。winsmux は OAuth を仲介せず、
+callback URL を受け取らず、プロバイダートークンをペイン間でコピーしません。
+
 ## モデル選択の方針
 
 モデル名は winsmux のリリースより速く変わります。そのため winsmux は、モデルを

--- a/docs/provider-and-model-support.md
+++ b/docs/provider-and-model-support.md
@@ -35,6 +35,35 @@ column.
 | Local LLM runtimes | Planned adapter family | Not a `v0.32.x` Colab-lane runtime requirement. Today, run them as normal local tools or behind an agent CLI that can use a local endpoint. |
 | `noop` worker backend | Supported placeholder | Keeps a slot declared but inactive. |
 
+## Provider capability catalog
+
+From `v0.33.0`, `.winsmux/provider-capabilities.json` is the capability catalog
+for agent CLIs and local endpoint adapters. The catalog separates launch
+mechanics from model metadata and from credential boundaries, so winsmux does
+not treat a local inference endpoint as a write-capable worker by accident.
+
+Provider entries may declare:
+
+- `harness_availability`: whether the provider is a built-in CLI, an external
+  adapter, or a manual pane tool.
+- `credential_requirements`: who owns sign-in, API keys, endpoint secrets, and
+  token storage.
+- `execution_backend`: the runtime path, such as an agent CLI, Colab worker, or
+  OpenAI-compatible local endpoint.
+- `runtime_requirements`: endpoint, executable, GPU, CPU, memory, OS, or remote
+  runtime expectations.
+- `model_catalog_source` and `model_options`: where model names come from and
+  which choices the operator can select.
+- `analysis_posture`: whether the provider is safe only for read-only analysis
+  or can act as a normal write-capable worker.
+
+For OpenAI-compatible local endpoints and GPU-backed local runtimes, the safe
+default is a read-only analysis provider: `supports_file_edit: false`,
+`supports_verification: false`, `supports_consultation: true`, and
+`analysis_posture: "read-only-analysis"`. The local runtime owns its endpoint,
+models, and credentials. winsmux must not broker OAuth, collect callback URLs,
+or copy provider tokens between panes.
+
 ## Model selection policy
 
 Model names change faster than winsmux releases. winsmux therefore treats a

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -3554,6 +3554,11 @@ function Invoke-Role {
             provider_target            = $providerTarget
             capability_adapter         = [string]$roleAgentConfig.CapabilityAdapter
             capability_command         = [string]$roleAgentConfig.CapabilityCommand
+            harness_availability       = [string]$roleAgentConfig.HarnessAvailability
+            credential_requirements    = [string]$roleAgentConfig.CredentialRequirements
+            execution_backend          = [string]$roleAgentConfig.ExecutionBackend
+            runtime_requirements       = [string]$roleAgentConfig.RuntimeRequirements
+            analysis_posture           = [string]$roleAgentConfig.AnalysisPosture
             supports_parallel_runs     = [bool]$roleAgentConfig.SupportsParallelRuns
             supports_interrupt         = [bool]$roleAgentConfig.SupportsInterrupt
             supports_structured_result = [bool]$roleAgentConfig.SupportsStructuredResult
@@ -4111,6 +4116,11 @@ function New-LauncherSlotSummary {
         auth_mode                  = [string]$effective.AuthMode
         auth_policy                = [string]$effective.AuthPolicy
         local_access_note          = [string]$effective.LocalAccessNote
+        harness_availability       = [string]$effective.HarnessAvailability
+        credential_requirements    = [string]$effective.CredentialRequirements
+        execution_backend          = [string]$effective.ExecutionBackend
+        runtime_requirements       = [string]$effective.RuntimeRequirements
+        analysis_posture           = [string]$effective.AnalysisPosture
         source                     = [string]$effective.Source
         capability_adapter         = [string]$effective.CapabilityAdapter
         capability_command         = [string]$effective.CapabilityCommand
@@ -13528,6 +13538,11 @@ function Invoke-ProviderSwitch {
         auth_mode                  = [string]$effective.AuthMode
         auth_policy                = [string]$effective.AuthPolicy
         local_access_note          = [string]$effective.LocalAccessNote
+        harness_availability       = [string]$effective.HarnessAvailability
+        credential_requirements    = [string]$effective.CredentialRequirements
+        execution_backend          = [string]$effective.ExecutionBackend
+        runtime_requirements       = [string]$effective.RuntimeRequirements
+        analysis_posture           = [string]$effective.AnalysisPosture
         source                     = [string]$effective.Source
         capability_adapter         = [string]$effective.CapabilityAdapter
         capability_command         = [string]$effective.CapabilityCommand

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -1232,6 +1232,11 @@ agent-slots:
       "model_sources": ["provider-default", "cli-discovery"],
       "reasoning_efforts": ["provider-default", "low", "medium", "high", "xhigh"],
       "local_access_note": "Local Codex CLI catalog and ChatGPT account access.",
+      "harness_availability": "official-cli",
+      "credential_requirements": "local-cli-owned",
+      "execution_backend": "agent-cli",
+      "runtime_requirements": "Codex CLI installed in the pane environment.",
+      "analysis_posture": "read-write-worker",
       "prompt_transports": ["argv", "file", "stdin"],
       "auth_modes": ["api-key", "codex-chatgpt-local"],
       "local_interactive_oauth_modes": ["codex-chatgpt-local"],
@@ -1255,6 +1260,11 @@ agent-slots:
         $registry.providers.codex.model_sources | Should -Be @('provider-default', 'cli-discovery')
         $registry.providers.codex.reasoning_efforts | Should -Be @('provider-default', 'low', 'medium', 'high', 'xhigh')
         $registry.providers.codex.local_access_note | Should -Be 'Local Codex CLI catalog and ChatGPT account access.'
+        $registry.providers.codex.harness_availability | Should -Be 'official-cli'
+        $registry.providers.codex.credential_requirements | Should -Be 'local-cli-owned'
+        $registry.providers.codex.execution_backend | Should -Be 'agent-cli'
+        $registry.providers.codex.runtime_requirements | Should -Be 'Codex CLI installed in the pane environment.'
+        $registry.providers.codex.analysis_posture | Should -Be 'read-write-worker'
         $registry.providers.codex.auth_modes | Should -Be @('api-key', 'codex-chatgpt-local')
         $registry.providers.codex.local_interactive_oauth_modes | Should -Be @('codex-chatgpt-local')
         $registry.providers.codex.supports_file_edit | Should -Be $true
@@ -1283,6 +1293,11 @@ agent-slots:
       "model_sources": ["provider-default", "cli-discovery"],
       "reasoning_efforts": ["provider-default", "low", "medium", "high", "xhigh"],
       "local_access_note": "Local Codex CLI catalog and ChatGPT account access.",
+      "harness_availability": "official-cli",
+      "credential_requirements": "local-cli-owned",
+      "execution_backend": "agent-cli",
+      "runtime_requirements": "Codex CLI installed in the pane environment.",
+      "analysis_posture": "read-write-worker",
       "prompt_transports": ["argv", "file", "stdin"],
       "auth_modes": ["api-key", "codex-chatgpt-local"],
       "local_interactive_oauth_modes": ["codex-chatgpt-local"],
@@ -1326,6 +1341,11 @@ agent-slots:
         $config.ModelSources | Should -Be @('provider-default', 'cli-discovery')
         $config.ReasoningEfforts | Should -Be @('provider-default', 'low', 'medium', 'high', 'xhigh')
         $config.LocalAccessNote | Should -Be 'Local Codex CLI catalog and ChatGPT account access.'
+        $config.HarnessAvailability | Should -Be 'official-cli'
+        $config.CredentialRequirements | Should -Be 'local-cli-owned'
+        $config.ExecutionBackend | Should -Be 'agent-cli'
+        $config.RuntimeRequirements | Should -Be 'Codex CLI installed in the pane environment.'
+        $config.AnalysisPosture | Should -Be 'read-write-worker'
         $config.AuthMode | Should -Be 'codex-chatgpt-local'
         $config.AuthPolicy | Should -Be 'local_interactive_only'
         $config.SupportsParallelRuns | Should -Be $true
@@ -1711,6 +1731,24 @@ agent-slots:
 }
 '@ | Set-Content -Path $registryPath -Encoding UTF8
         { Read-BridgeProviderCapabilityRegistry -RootPath $script:settingsTempRoot } | Should -Throw "*provider capability field 'supports_file_edit'*"
+
+@'
+{
+  "version": 1,
+  "providers": {
+    "local-openai-compatible": {
+      "adapter": "openai-compatible",
+      "command": "winsmux-local-llm",
+      "prompt_transports": ["stdin"],
+      "read_only_launch_args": [
+        { "arg": "--read-only" }
+      ],
+      "supports_file_edit": false
+    }
+  }
+}
+'@ | Set-Content -Path $registryPath -Encoding UTF8
+        { Read-BridgeProviderCapabilityRegistry -RootPath $script:settingsTempRoot } | Should -Throw "*provider capability field 'read_only_launch_args'*"
 
 @'
 {
@@ -13834,10 +13872,38 @@ Describe 'winsmux provider-capabilities command' {
       "model_sources": ["provider-default", "cli-discovery"],
       "reasoning_efforts": ["provider-default", "low", "medium", "high", "xhigh"],
       "local_access_note": "Local Codex CLI catalog and ChatGPT account access.",
+      "harness_availability": "official-cli",
+      "credential_requirements": "local-cli-owned",
+      "execution_backend": "agent-cli",
+      "runtime_requirements": "Codex CLI installed in the pane environment.",
+      "analysis_posture": "read-write-worker",
       "prompt_transports": ["argv", "file", "stdin"],
       "supports_file_edit": true,
       "supports_verification": true,
       "supports_subagents": true
+    },
+    "local-openai-compatible": {
+      "adapter": "openai-compatible",
+      "display_name": "Local OpenAI-compatible endpoint",
+      "command": "winsmux-local-llm",
+      "model_options": [
+        {"id": "operator-selected", "label": "Operator-selected runtime model", "source": "operator-override", "availability": "runtime-discovery"}
+      ],
+      "model_sources": ["operator-override"],
+      "reasoning_efforts": ["provider-default"],
+      "model_catalog_source": "runtime-health-endpoint",
+      "local_access_note": "Local endpoint owns model access and request handling.",
+      "harness_availability": "external-adapter",
+      "credential_requirements": "runtime-owned-local-endpoint",
+      "execution_backend": "openai-compatible-local-endpoint",
+      "runtime_requirements": "127.0.0.1 endpoint; GPU/CPU capacity owned by runtime.",
+      "analysis_posture": "read-only-analysis",
+      "prompt_transports": ["stdin"],
+      "auth_modes": ["none", "local-api-key"],
+      "read_only_launch_args": ["--read-only", "--no-file-edits"],
+      "supports_file_edit": false,
+      "supports_verification": false,
+      "supports_consultation": true
     }
   }
 }
@@ -13867,8 +13933,14 @@ Describe 'winsmux provider-capabilities command' {
         $payload.providers.codex.model_options[1].source | Should -Be 'cli-discovery'
         $payload.providers.codex.reasoning_efforts | Should -Be @('provider-default', 'low', 'medium', 'high', 'xhigh')
         $payload.providers.codex.local_access_note | Should -Be 'Local Codex CLI catalog and ChatGPT account access.'
+        $payload.providers.codex.harness_availability | Should -Be 'official-cli'
         $payload.providers.codex.prompt_transports | Should -Be @('argv', 'file', 'stdin')
         $payload.providers.codex.supports_file_edit | Should -Be $true
+        $payload.providers.'local-openai-compatible'.analysis_posture | Should -Be 'read-only-analysis'
+        $payload.providers.'local-openai-compatible'.credential_requirements | Should -Be 'runtime-owned-local-endpoint'
+        $payload.providers.'local-openai-compatible'.execution_backend | Should -Be 'openai-compatible-local-endpoint'
+        $payload.providers.'local-openai-compatible'.read_only_launch_args | Should -Be @('--read-only', '--no-file-edits')
+        $payload.providers.'local-openai-compatible'.supports_file_edit | Should -Be $false
     }
 
     It 'reports one provider capability entry' {
@@ -14354,6 +14426,11 @@ agent-slots:
       "model_sources": ["provider-default", "cli-discovery"],
       "reasoning_efforts": ["provider-default", "low", "medium", "high", "xhigh"],
       "local_access_note": "Local Codex CLI catalog and ChatGPT account access.",
+      "harness_availability": "official-cli",
+      "credential_requirements": "local-cli-owned",
+      "execution_backend": "agent-cli",
+      "runtime_requirements": "Codex CLI installed in the pane environment.",
+      "analysis_posture": "read-write-worker",
       "prompt_transports": ["argv", "file", "stdin"],
       "auth_modes": ["api-key", "codex-chatgpt-local"],
       "local_interactive_oauth_modes": ["codex-chatgpt-local"],
@@ -14378,6 +14455,11 @@ agent-slots:
       "model_sources": ["provider-default", "official-doc", "operator-override"],
       "reasoning_efforts": ["provider-default", "low", "medium", "high", "xhigh", "max"],
       "local_access_note": "Local Claude Code account and settings.",
+      "harness_availability": "official-cli",
+      "credential_requirements": "local-cli-owned",
+      "execution_backend": "agent-cli",
+      "runtime_requirements": "Claude Code CLI installed in the pane environment.",
+      "analysis_posture": "read-write-worker",
       "prompt_transports": ["file"],
       "auth_modes": ["api-key", "claude-pro-max-oauth"],
       "local_interactive_oauth_modes": ["claude-pro-max-oauth"],
@@ -14425,6 +14507,11 @@ agent-slots:
         $result.capability_adapter | Should -Be 'claude'
         $result.capability_command | Should -Be 'claude'
         $result.local_access_note | Should -Be 'Local Claude Code account and settings.'
+        $result.harness_availability | Should -Be 'official-cli'
+        $result.credential_requirements | Should -Be 'local-cli-owned'
+        $result.execution_backend | Should -Be 'agent-cli'
+        $result.runtime_requirements | Should -Be 'Claude Code CLI installed in the pane environment.'
+        $result.analysis_posture | Should -Be 'read-write-worker'
         $result.supports_file_edit | Should -Be $true
         $result.supports_subagents | Should -Be $false
         $result.supports_consultation | Should -Be $true

--- a/winsmux-core/scripts/settings.ps1
+++ b/winsmux-core/scripts/settings.ps1
@@ -1063,9 +1063,21 @@ function ConvertTo-BridgeProviderCapabilityEntry {
         return $null
     }
 
-    $stringFields = @('adapter', 'display_name', 'command', 'model_catalog_source', 'local_access_note')
+    $stringFields = @(
+        'adapter',
+        'display_name',
+        'command',
+        'model_catalog_source',
+        'local_access_note',
+        'harness_availability',
+        'credential_requirements',
+        'execution_backend',
+        'runtime_requirements',
+        'analysis_posture'
+    )
     $transportFields = @('prompt_transports')
     $stringArrayFields = @('auth_modes', 'local_interactive_oauth_modes', 'model_sources', 'reasoning_efforts')
+    $rawStringArrayFields = @('read_only_launch_args')
     $modelOptionFields = @('model_options')
     $boolFields = @(
         'supports_parallel_runs',
@@ -1077,7 +1089,7 @@ function ConvertTo-BridgeProviderCapabilityEntry {
         'supports_consultation',
         'supports_context_reset'
     )
-    $allowedFields = @($stringFields + $transportFields + $stringArrayFields + $modelOptionFields + $boolFields)
+    $allowedFields = @($stringFields + $transportFields + $stringArrayFields + $rawStringArrayFields + $modelOptionFields + $boolFields)
 
     $entry = [ordered]@{}
     foreach ($pair in $pairs) {
@@ -1146,6 +1158,32 @@ function ConvertTo-BridgeProviderCapabilityEntry {
                 }
 
                 $items += $normalizedText
+            }
+
+            $entry[$key] = @($items)
+            continue
+        }
+
+        if ($key -in $rawStringArrayFields) {
+            if ($pair.Value -isnot [System.Collections.IEnumerable] -or $pair.Value -is [string]) {
+                throw "Invalid provider capability field '$key'."
+            }
+
+            $items = @()
+            foreach ($item in @($pair.Value)) {
+                if ($item -isnot [string]) {
+                    throw "Invalid provider capability field '$key'."
+                }
+
+                $text = ([string]$item).Trim()
+                if ([string]::IsNullOrWhiteSpace($text)) {
+                    throw "Invalid provider capability field '$key'."
+                }
+
+                $items += $text
+            }
+            if ($items.Count -lt 1) {
+                throw "Invalid provider capability field '$key'."
             }
 
             $entry[$key] = @($items)
@@ -2752,6 +2790,11 @@ function Get-SlotAgentConfig {
         ModelSources             = @(Get-BridgeProviderCapabilityValue -Capability $providerCapability -Name 'model_sources' -Default @())
         ReasoningEfforts         = @(Get-BridgeProviderCapabilityValue -Capability $providerCapability -Name 'reasoning_efforts' -Default @())
         LocalAccessNote          = [string](Get-BridgeProviderCapabilityValue -Capability $providerCapability -Name 'local_access_note' -Default '')
+        HarnessAvailability      = [string](Get-BridgeProviderCapabilityValue -Capability $providerCapability -Name 'harness_availability' -Default '')
+        CredentialRequirements   = [string](Get-BridgeProviderCapabilityValue -Capability $providerCapability -Name 'credential_requirements' -Default '')
+        ExecutionBackend         = [string](Get-BridgeProviderCapabilityValue -Capability $providerCapability -Name 'execution_backend' -Default '')
+        RuntimeRequirements      = [string](Get-BridgeProviderCapabilityValue -Capability $providerCapability -Name 'runtime_requirements' -Default '')
+        AnalysisPosture          = [string](Get-BridgeProviderCapabilityValue -Capability $providerCapability -Name 'analysis_posture' -Default '')
         SupportsParallelRuns     = Get-BridgeProviderCapabilityBoolean -Capability $providerCapability -Name 'supports_parallel_runs'
         SupportsInterrupt        = Get-BridgeProviderCapabilityBoolean -Capability $providerCapability -Name 'supports_interrupt'
         SupportsInterruptDeclared = Test-BridgeProviderCapabilityField -Capability $providerCapability -Name 'supports_interrupt'


### PR DESCRIPTION
Summary: Adds provider capability catalog metadata for v0.33.0, locks reviewer role routing, and documents local OpenAI-compatible read-only analysis support. Validation: cargo test --manifest-path core\Cargo.toml; Invoke-Pester tests\winsmux-bridge.Tests.ps1; Invoke-Pester tests\PublicSurfacePolicy.Tests.ps1; npm run build; cargo check winsmux-app; audit-public-surface; git-guard full.