### PR TITLE
feat: enforce approved worker launch contract

### DIFF
--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -3048,6 +3048,115 @@ function Get-SendConfigValue {
     return $Default
 }
 
+function Get-WorkersLaunchApprovalFieldNames {
+    return @(
+        'slot_id',
+        'worker_backend',
+        'worker_role',
+        'agent',
+        'model',
+        'model_source',
+        'reasoning_effort',
+        'prompt_transport',
+        'auth_mode',
+        'credential_requirements',
+        'execution_backend',
+        'analysis_posture',
+        'auto_launch'
+    )
+}
+
+function ConvertTo-WorkersLaunchApprovalValue {
+    param([AllowNull()]$Value)
+
+    if ($null -eq $Value) {
+        return ''
+    }
+
+    if ($Value -is [bool]) {
+        if ($Value) {
+            return 'true'
+        }
+
+        return 'false'
+    }
+
+    return ([string]$Value).Trim()
+}
+
+function New-WorkersLaunchApprovalSummary {
+    param(
+        [Parameter(Mandatory = $true)][string]$SlotId,
+        [Parameter(Mandatory = $true)]$SlotConfig,
+        [bool]$AutoLaunch = $false
+    )
+
+    return [ordered]@{
+        packet_type             = 'worker_launch_approval'
+        source                  = 'user_approved_worker_config'
+        slot_id                 = $SlotId
+        worker_backend          = [string]$SlotConfig.WorkerBackend
+        worker_role             = [string]$SlotConfig.WorkerRole
+        agent                   = [string]$SlotConfig.Agent
+        model                   = [string]$SlotConfig.Model
+        model_source            = [string]$SlotConfig.ModelSource
+        reasoning_effort        = [string]$SlotConfig.ReasoningEffort
+        prompt_transport        = [string]$SlotConfig.PromptTransport
+        auth_mode               = [string]$SlotConfig.AuthMode
+        credential_requirements = [string]$SlotConfig.CredentialRequirements
+        execution_backend       = [string]$SlotConfig.ExecutionBackend
+        analysis_posture        = [string]$SlotConfig.AnalysisPosture
+        auto_launch             = [bool]$AutoLaunch
+    }
+}
+
+function Get-WorkersLaunchApprovalDifferences {
+    param(
+        [AllowNull()]$ApprovedLaunch,
+        [AllowNull()]$CurrentLaunch
+    )
+
+    if ($null -eq $ApprovedLaunch) {
+        return @()
+    }
+
+    if ($null -eq $CurrentLaunch) {
+        return @([ordered]@{
+            field    = 'approved_launch'
+            approved = 'present'
+            current  = 'missing'
+        })
+    }
+
+    $differences = [System.Collections.Generic.List[object]]::new()
+    foreach ($field in @(Get-WorkersLaunchApprovalFieldNames)) {
+        $approvedValue = ConvertTo-WorkersLaunchApprovalValue (Get-SendConfigValue -InputObject $ApprovedLaunch -Name $field -Default '')
+        $currentValue = ConvertTo-WorkersLaunchApprovalValue (Get-SendConfigValue -InputObject $CurrentLaunch -Name $field -Default '')
+        if (-not [string]::Equals($approvedValue, $currentValue, [System.StringComparison]::Ordinal)) {
+            $differences.Add([ordered]@{
+                field    = $field
+                approved = $approvedValue
+                current  = $currentValue
+            }) | Out-Null
+        }
+    }
+
+    return @($differences)
+}
+
+function Format-WorkersLaunchApprovalMismatch {
+    param([Parameter(Mandatory = $true)][object[]]$Differences)
+
+    $summary = @($Differences | Select-Object -First 4 | ForEach-Object {
+        "$($_.field): approved='$($_.approved)' current='$($_.current)'"
+    }) -join '; '
+    if ($Differences.Count -gt 4) {
+        $summary = "$summary; +$($Differences.Count - 4) more"
+    }
+
+    return "worker launch approval mismatch: $summary"
+}
+
 function Test-DeferredPaneStartManifestEntry {
     param([AllowNull()]$ManifestEntry)
 
@@ -3162,6 +3271,14 @@ function Start-DeferredPaneFromManifestEntry {
     }
 
     $plan = Get-Content -LiteralPath $planPath -Raw -Encoding UTF8 | ConvertFrom-Json -Depth 8
+    $approvedLaunch = Get-SendConfigValue -InputObject $ManifestEntry -Name 'ApprovedLaunch' -Default $null
+    $candidateLaunch = Get-SendConfigValue -InputObject $plan -Name 'approved_launch' -Default $null
+    $approvalDifferences = @(Get-WorkersLaunchApprovalDifferences -ApprovedLaunch $approvedLaunch -CurrentLaunch $candidateLaunch)
+    if ($approvalDifferences.Count -gt 0) {
+        Set-DeferredPaneStartStatus -ProjectDir $ProjectDir -PaneId $paneId -Status 'deferred_start_failed'
+        Stop-WithError (Format-WorkersLaunchApprovalMismatch -Differences $approvalDifferences)
+    }
+
     $markerPath = [string](Get-SendConfigValue -InputObject $plan -Name 'ready_marker_path' -Default '')
 
     if (@('deferred_start', 'deferred_start_failed') -contains $normalizedStatus) {
@@ -5255,6 +5372,14 @@ function Get-WorkersStatusRows {
             }
         }
 
+        $autoLaunch = $true
+        if ($null -ne $entry -and (Test-DeferredPaneStartManifestEntry -ManifestEntry $entry)) {
+            $autoLaunch = $false
+        }
+        $currentLaunch = New-WorkersLaunchApprovalSummary -SlotId $slotId -SlotConfig $slotConfig -AutoLaunch:$autoLaunch
+        $approvedLaunch = if ($null -ne $entry) { Get-SendConfigValue -InputObject $entry -Name 'ApprovedLaunch' -Default $null } else { $null }
+        $approvalDifferences = @(Get-WorkersLaunchApprovalDifferences -ApprovedLaunch $approvedLaunch -CurrentLaunch $currentLaunch)
+
         $rows.Add([PSCustomObject][ordered]@{
             Slot           = ConvertTo-WorkersSlotAlias -SlotId $slotId
             SlotId         = $slotId
@@ -5270,6 +5395,9 @@ function Get-WorkersStatusRows {
             DegradedReason = $degradedReason
             LastCommand    = $lastCommand
             LastCommandAt  = $lastCommandAt
+            ApprovedLaunch = $approvedLaunch
+            CurrentLaunch  = $currentLaunch
+            ApprovalDifferences = @($approvalDifferences)
         }) | Out-Null
     }
 
@@ -5353,6 +5481,9 @@ function ConvertTo-WorkersStatusJsonRows {
             degraded_reason = [string]$row.DegradedReason
             last_command    = [string]$row.LastCommand
             last_command_at = [string]$row.LastCommandAt
+            approved_launch = $row.ApprovedLaunch
+            current_launch  = $row.CurrentLaunch
+            approval_differences = @($row.ApprovalDifferences)
         }
     }
 }
@@ -5399,6 +5530,9 @@ function New-WorkersLifecycleResult {
         backend       = [string]$Row.Backend
         worker_state  = [string]$Row.State
         last_command  = "$Action"
+        approved_launch = $Row.ApprovedLaunch
+        current_launch  = $Row.CurrentLaunch
+        approval_differences = @($Row.ApprovalDifferences)
     }
 }
 
@@ -6541,6 +6675,11 @@ function Invoke-WorkersStart {
             $results.Add((New-WorkersLifecycleResult -Row $row -Action 'workers.start' -Status 'blocked' -Reason $reason)) | Out-Null
             continue
         }
+        $approvalDifferences = @($row.ApprovalDifferences)
+        if ($approvalDifferences.Count -gt 0) {
+            $results.Add((New-WorkersLifecycleResult -Row $row -Action 'workers.start' -Status 'blocked' -Reason (Format-WorkersLaunchApprovalMismatch -Differences $approvalDifferences))) | Out-Null
+            continue
+        }
 
         try {
             if (Test-DeferredPaneStartManifestEntry -ManifestEntry $entry) {
@@ -6553,7 +6692,9 @@ function Invoke-WorkersStart {
                 $results.Add((New-WorkersLifecycleResult -Row $row -Action 'workers.start' -Status 'already_running')) | Out-Null
             }
         } catch {
-            $results.Add((New-WorkersLifecycleResult -Row $row -Action 'workers.start' -Status 'failed' -Reason $_.Exception.Message)) | Out-Null
+            $reason = [string]$_.Exception.Message
+            $status = if ($reason -like 'worker launch approval mismatch:*') { 'blocked' } else { 'failed' }
+            $results.Add((New-WorkersLifecycleResult -Row $row -Action 'workers.start' -Status $status -Reason $reason)) | Out-Null
         }
     }
 

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -5372,12 +5372,15 @@ function Get-WorkersStatusRows {
             }
         }
 
+        $approvedLaunch = if ($null -ne $entry) { Get-SendConfigValue -InputObject $entry -Name 'ApprovedLaunch' -Default $null } else { $null }
+        $approvedAutoLaunch = ConvertTo-WorkersLaunchApprovalValue (Get-SendConfigValue -InputObject $approvedLaunch -Name 'auto_launch' -Default $null)
         $autoLaunch = $true
-        if ($null -ne $entry -and (Test-DeferredPaneStartManifestEntry -ManifestEntry $entry)) {
+        if ($approvedAutoLaunch -in @('true', 'false')) {
+            $autoLaunch = [string]::Equals($approvedAutoLaunch, 'true', [System.StringComparison]::OrdinalIgnoreCase)
+        } elseif ($null -ne $entry -and (Test-DeferredPaneStartManifestEntry -ManifestEntry $entry)) {
             $autoLaunch = $false
         }
         $currentLaunch = New-WorkersLaunchApprovalSummary -SlotId $slotId -SlotConfig $slotConfig -AutoLaunch:$autoLaunch
-        $approvedLaunch = if ($null -ne $entry) { Get-SendConfigValue -InputObject $entry -Name 'ApprovedLaunch' -Default $null } else { $null }
         $approvalDifferences = @(Get-WorkersLaunchApprovalDifferences -ApprovedLaunch $approvedLaunch -CurrentLaunch $currentLaunch)
 
         $rows.Add([PSCustomObject][ordered]@{

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -7102,6 +7102,23 @@ Describe 'orchestra-start rollback helpers' {
                 WINSMUX_GOVERNANCE_MODE = 'enhanced'
             }
         }
+        $approvedLaunch = [ordered]@{
+            packet_type = 'worker_launch_approval'
+            source = 'user_approved_worker_config'
+            slot_id = 'worker-1'
+            worker_backend = 'local'
+            worker_role = 'worker'
+            agent = 'codex'
+            model = 'gpt-5.4'
+            model_source = 'operator-override'
+            reasoning_effort = 'high'
+            prompt_transport = 'argv'
+            auth_mode = 'local-cli'
+            credential_requirements = 'local-cli-owned'
+            execution_backend = 'local'
+            analysis_posture = 'read-write-worker'
+            auto_launch = $false
+        }
 
         Mock Wait-PaneShellReady { }
         Mock Invoke-Bridge {
@@ -7132,7 +7149,8 @@ Describe 'orchestra-start rollback helpers' {
             -StartupToken 'token-123' `
             -LaunchDir 'C:\repo\.worktrees\builder-1' `
             -CleanPtyEnv $cleanPtyEnv `
-            -LaunchCommand 'codex --help'
+            -LaunchCommand 'codex --help' `
+            -ApprovedLaunch $approvedLaunch
 
         Start-OrchestraPaneBootstrap -PaneId '%2' -PlanPath $planPath
 
@@ -7147,6 +7165,8 @@ Describe 'orchestra-start rollback helpers' {
         [string]$plan.environment.WINSMUX_GOVERNANCE_MODE | Should -Be 'enhanced'
         [string]$plan.launch_command | Should -Be 'codex --help'
         [bool]$plan.supports_interrupt | Should -Be $true
+        [string]$plan.approved_launch.packet_type | Should -Be 'worker_launch_approval'
+        [string]$plan.approved_launch.model | Should -Be 'gpt-5.4'
         [string]$plan.startup_token | Should -Be 'token-123'
         [string]$plan.ready_marker_path | Should -Match '[\\/]2-token-123\.ready\.json$'
         $bridgeCalls.Count | Should -Be 1
@@ -8950,6 +8970,9 @@ worker-backend: colab_cli
         $payload.workers[1].actual_gpu | Should -Be 'CPU'
         $payload.workers[1].degraded_reason | Should -Match 'colab_cli_missing'
         $payload.workers[1].state | Should -Be 'not_launched'
+        $payload.workers[1].current_launch.packet_type | Should -Be 'worker_launch_approval'
+        $payload.workers[1].current_launch.source | Should -Be 'user_approved_worker_config'
+        @($payload.workers[1].approval_differences).Count | Should -Be 0
     }
 
     It 'stops one worker by slot alias and records the lifecycle command in the manifest' {
@@ -9071,6 +9094,102 @@ agent-slots:
         $payload.results[0].slot_id | Should -Be 'worker-2'
         $payload.results[0].status | Should -Be 'blocked'
         $payload.results[0].reason | Should -Be 'colab_cli_missing'
+        Should -Invoke Send-TextToPane -Times 0 -Exactly
+    }
+
+    It 'blocks start when the manifest approval no longer matches the worker config' {
+@'
+agent: codex
+model: gpt-5.5
+agent-slots:
+  - slot-id: worker-1
+    runtime-role: worker
+    worker-backend: local
+    agent: codex
+    model: gpt-5.5
+    model-source: operator-override
+    reasoning-effort: high
+    worktree-mode: managed
+'@ | Set-Content -Path (Join-Path $script:workersTempRoot '.winsmux.yaml') -Encoding UTF8
+        New-Item -ItemType Directory -Path (Join-Path $script:workersTempRoot '.winsmux') -Force | Out-Null
+        $planPath = Join-Path $script:workersTempRoot 'worker-1.json'
+        Save-WinsmuxManifest -ProjectDir $script:workersTempRoot -Manifest ([ordered]@{
+            version = 1
+            saved_at = '2026-05-13T00:00:00Z'
+            session = [ordered]@{
+                name = 'winsmux-orchestra'
+                project_dir = $script:workersTempRoot
+                git_worktree_dir = (Join-Path $script:workersTempRoot '.git')
+            }
+            panes = [ordered]@{
+                'worker-1' = [ordered]@{
+                    pane_id = '%2'
+                    slot_id = 'worker-1'
+                    worker_backend = 'local'
+                    role = 'Worker'
+                    exec_mode = $false
+                    launch_dir = $script:workersTempRoot
+                    status = 'deferred_start'
+                    bootstrap_plan_path = $planPath
+                    approved_launch = [ordered]@{
+                        packet_type = 'worker_launch_approval'
+                        source = 'user_approved_worker_config'
+                        slot_id = 'worker-1'
+                        worker_backend = 'local'
+                        worker_role = 'worker'
+                        agent = 'codex'
+                        model = 'gpt-5.4'
+                        model_source = 'operator-override'
+                        reasoning_effort = 'high'
+                        prompt_transport = 'argv'
+                        auth_mode = 'local-cli'
+                        credential_requirements = 'local-cli-owned'
+                        execution_backend = 'local'
+                        analysis_posture = 'read-write-worker'
+                        auto_launch = $false
+                    }
+                    task = $null
+                }
+            }
+            tasks = [ordered]@{
+                queued = @()
+                in_progress = @()
+                completed = @()
+            }
+            worktrees = [ordered]@{}
+        })
+        ([ordered]@{
+            agent = 'codex'
+            ready_marker_path = (Join-Path $script:workersTempRoot 'worker-1.ready.json')
+            approved_launch = [ordered]@{
+                packet_type = 'worker_launch_approval'
+                source = 'user_approved_worker_config'
+                slot_id = 'worker-1'
+                worker_backend = 'local'
+                worker_role = 'worker'
+                agent = 'codex'
+                model = 'gpt-5.5'
+                model_source = 'operator-override'
+                reasoning_effort = 'high'
+                prompt_transport = 'argv'
+                auth_mode = 'local-cli'
+                credential_requirements = 'local-cli-owned'
+                execution_backend = 'local'
+                analysis_posture = 'read-write-worker'
+                auto_launch = $false
+            }
+        } | ConvertTo-Json -Depth 8) | Set-Content -Path $planPath -Encoding UTF8
+
+        Mock Send-TextToPane { throw 'bootstrap should not be dispatched' }
+
+        $Rest = @('worker-1', '--json', '--project-dir', $script:workersTempRoot)
+        $output = Invoke-WorkersStart
+        $payload = ($output | Select-Object -Last 1) | ConvertFrom-Json
+
+        $payload.results[0].slot_id | Should -Be 'worker-1'
+        $payload.results[0].status | Should -Be 'blocked'
+        $payload.results[0].reason | Should -Match 'worker launch approval mismatch'
+        @($payload.results[0].approval_differences | Where-Object { $_.field -eq 'model' }).Count | Should -Be 1
         Should -Invoke Send-TextToPane -Times 0 -Exactly
     }
 
@@ -15410,6 +15529,8 @@ Describe 'orchestra pane bootstrap plan' {
         $script:orchestraStartContent | Should -Match 'deferred_start'
         $script:orchestraStartContent | Should -Match 'preflight\.worker\.deferred_start'
         $script:orchestraStartContent | Should -Match 'ready_marker_path'
+        $script:orchestraStartContent | Should -Match 'function New-OrchestraWorkerLaunchApproval'
+        $script:orchestraStartContent | Should -Match 'approved_launch'
         $script:orchestraStartContent | Should -Match 'Wait-OrchestraServerSessionAbsent -SessionName \$SessionName -TimeoutSeconds 20'
     }
 
@@ -17686,6 +17807,62 @@ Describe 'deferred worker startup' {
         { Start-DeferredPaneFromManifestEntry -ProjectDir $script:deferredTempRoot -ManifestEntry $entry } |
             Should -Throw "*bootstrap plan not found*"
 
+        $script:deferredSendCommands.Count | Should -Be 0
+        $script:deferredStatusWrites | Should -Be @('deferred_start_failed')
+    }
+
+    It 'blocks a deferred pane when its bootstrap plan does not match the approved launch' {
+        $entry = [PSCustomObject]@{
+            Label             = 'worker-2'
+            PaneId            = '%3'
+            Status            = 'deferred_start'
+            BootstrapPlanPath = $script:deferredPlanPath
+            CapabilityAdapter = 'codex'
+            ProviderTarget    = ''
+            ApprovedLaunch    = [PSCustomObject]@{
+                packet_type = 'worker_launch_approval'
+                source = 'user_approved_worker_config'
+                slot_id = 'worker-2'
+                worker_backend = 'local'
+                worker_role = 'worker'
+                agent = 'codex'
+                model = 'gpt-5.4'
+                model_source = 'operator-override'
+                reasoning_effort = 'high'
+                prompt_transport = 'argv'
+                auth_mode = 'local-cli'
+                credential_requirements = 'local-cli-owned'
+                execution_backend = 'local'
+                analysis_posture = 'read-write-worker'
+                auto_launch = $false
+            }
+        }
+        ([ordered]@{
+            agent = 'codex'
+            ready_marker_path = $script:deferredMarkerPath
+            approved_launch = [ordered]@{
+                packet_type = 'worker_launch_approval'
+                source = 'user_approved_worker_config'
+                slot_id = 'worker-2'
+                worker_backend = 'local'
+                worker_role = 'worker'
+                agent = 'codex'
+                model = 'gpt-5.5'
+                model_source = 'operator-override'
+                reasoning_effort = 'high'
+                prompt_transport = 'argv'
+                auth_mode = 'local-cli'
+                credential_requirements = 'local-cli-owned'
+                execution_backend = 'local'
+                analysis_posture = 'read-write-worker'
+                auto_launch = $false
+            }
+        } | ConvertTo-Json -Depth 8) | Set-Content -Path $script:deferredPlanPath -Encoding UTF8
+
+        { Start-DeferredPaneFromManifestEntry -ProjectDir $script:deferredTempRoot -ManifestEntry $entry } |
+            Should -Throw "*worker launch approval mismatch*"
+
+        Should -Invoke Wait-PaneShellReady -Times 0 -Exactly
         $script:deferredSendCommands.Count | Should -Be 0
         $script:deferredStatusWrites | Should -Be @('deferred_start_failed')
     }

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -9105,6 +9105,7 @@ agent-slots:
   - slot-id: worker-1
     runtime-role: worker
     worker-backend: local
+    worker-role: worker
     agent: codex
     model: gpt-5.5
     model-source: operator-override
@@ -9190,6 +9191,81 @@ agent-slots:
         $payload.results[0].status | Should -Be 'blocked'
         $payload.results[0].reason | Should -Match 'worker launch approval mismatch'
         @($payload.results[0].approval_differences | Where-Object { $_.field -eq 'model' }).Count | Should -Be 1
+        Should -Invoke Send-TextToPane -Times 0 -Exactly
+    }
+
+    It 'keeps a ready deferred worker idempotent when its approved launch was manual' {
+@'
+agent: codex
+model: gpt-5.5
+agent-slots:
+  - slot-id: worker-1
+    runtime-role: worker
+    worker-backend: local
+    worker-role: worker
+    agent: codex
+    model: gpt-5.5
+    model-source: operator-override
+    reasoning-effort: high
+    worktree-mode: managed
+'@ | Set-Content -Path (Join-Path $script:workersTempRoot '.winsmux.yaml') -Encoding UTF8
+        New-Item -ItemType Directory -Path (Join-Path $script:workersTempRoot '.winsmux') -Force | Out-Null
+        Save-WinsmuxManifest -ProjectDir $script:workersTempRoot -Manifest ([ordered]@{
+            version = 1
+            saved_at = '2026-05-13T00:00:00Z'
+            session = [ordered]@{
+                name = 'winsmux-orchestra'
+                project_dir = $script:workersTempRoot
+                git_worktree_dir = (Join-Path $script:workersTempRoot '.git')
+            }
+            panes = [ordered]@{
+                'worker-1' = [ordered]@{
+                    pane_id = '%2'
+                    slot_id = 'worker-1'
+                    worker_backend = 'local'
+                    role = 'Worker'
+                    exec_mode = $false
+                    launch_dir = $script:workersTempRoot
+                    status = 'ready'
+                    bootstrap_plan_path = (Join-Path $script:workersTempRoot 'worker-1.json')
+                    approved_launch = [ordered]@{
+                        packet_type = 'worker_launch_approval'
+                        source = 'user_approved_worker_config'
+                        slot_id = 'worker-1'
+                        worker_backend = 'local'
+                        worker_role = 'worker'
+                        agent = 'codex'
+                        model = 'gpt-5.5'
+                        model_source = 'operator-override'
+                        reasoning_effort = 'high'
+                        prompt_transport = 'argv'
+                        auth_mode = ''
+                        credential_requirements = ''
+                        execution_backend = ''
+                        analysis_posture = ''
+                        auto_launch = $false
+                    }
+                    task = $null
+                }
+            }
+            tasks = [ordered]@{
+                queued = @()
+                in_progress = @()
+                completed = @()
+            }
+            worktrees = [ordered]@{}
+        })
+
+        Mock Send-TextToPane { throw 'bootstrap should not be dispatched' }
+
+        $Rest = @('worker-1', '--json', '--project-dir', $script:workersTempRoot)
+        $output = Invoke-WorkersStart
+        $payload = ($output | Select-Object -Last 1) | ConvertFrom-Json
+
+        $payload.results[0].slot_id | Should -Be 'worker-1'
+        $payload.results[0].status | Should -Be 'already_running'
+        [bool]$payload.results[0].current_launch.auto_launch | Should -Be $false
+        @($payload.results[0].approval_differences).Count | Should -Be 0
         Should -Invoke Send-TextToPane -Times 0 -Exactly
     }
 

--- a/winsmux-app/index.html
+++ b/winsmux-app/index.html
@@ -367,6 +367,7 @@
               <div id="terminal-toolbar-actions">
                 <select id="focused-pane-select" aria-label="Focused worker pane" hidden></select>
                 <button id="workbench-layout-btn" type="button" aria-label="Switch workbench layout">2x2</button>
+                <button id="start-worker-btn" type="button" aria-label="Start selected worker">Start</button>
                 <button id="add-pane-btn" type="button">+ Pane</button>
                 <button id="close-terminal-drawer-btn" type="button" aria-label="Hide worker panes" title="Hide worker panes">×</button>
               </div>

--- a/winsmux-app/scripts/desktop-pane-e2e.mjs
+++ b/winsmux-app/scripts/desktop-pane-e2e.mjs
@@ -202,6 +202,14 @@ async function resetAppState(page) {
   await waitForAppReady(page);
 }
 
+async function setActiveProjectDirForUi(page, projectDir) {
+  await page.evaluate((value) => {
+    localStorage.setItem("winsmux.active-project.v1", value.replace(/\\/g, "/"));
+  }, projectDir);
+  await page.reload({ waitUntil: "domcontentloaded" });
+  await waitForAppReady(page);
+}
+
 async function assertDrawerVisible(page, expected) {
   await page.waitForFunction((visible) => {
     const drawer = document.querySelector("#terminal-drawer");
@@ -870,6 +878,43 @@ async function main() {
 
     await runStep("Tauri native APIs exercise Rust, filesystem, voice, and webview windows", async () => {
       return await exerciseTauriNativeSurface(page, browser);
+    });
+
+    await runStep("worker start button shows launch approval before lifecycle command", async () => {
+      const tempProjectDir = path.join(OUTPUT_DIR, "worker-start-project");
+      await fs.rm(tempProjectDir, { recursive: true, force: true });
+      await fs.mkdir(tempProjectDir, { recursive: true });
+      await fs.writeFile(
+        path.join(tempProjectDir, ".winsmux.yaml"),
+        [
+          "agent: codex",
+          "model: gpt-5.4",
+          "agent-slots:",
+          "  - slot-id: worker-1",
+          "    runtime-role: worker",
+          "    worker-backend: local",
+          "    agent: codex",
+          "    model: gpt-5.4",
+          "    model-source: operator-override",
+          "    reasoning-effort: high",
+          "    worktree-mode: managed",
+          "",
+        ].join("\n"),
+        "utf8",
+      );
+
+      await setActiveProjectDirForUi(page, tempProjectDir);
+      await setWorkbenchLayout(page, "focus");
+      await page.selectOption("#focused-pane-select", "worker-1");
+      await setWorkbenchLayout(page, "3x2");
+      await page.click("#start-worker-btn");
+      await page.locator("#conversation-panel", { hasText: "Worker launch approval" }).waitFor({ state: "visible", timeout: 60_000 });
+      await page.locator("#conversation-panel", { hasText: "Worker start blocked" }).waitFor({ state: "visible", timeout: 60_000 });
+      const text = await page.locator("#conversation-panel").innerText();
+      if (!text.includes("worker-1") || !text.includes("manifest_entry_missing")) {
+        throw new Error(`worker start conversation did not expose the expected launch result:\n${text.slice(-1_200)}`);
+      }
+      return { conversationTail: text.slice(-1_200) };
     });
 
     await runStep("close spawned PTYs", async () => {

--- a/winsmux-app/src-tauri/src/desktop_backend.rs
+++ b/winsmux-app/src-tauri/src/desktop_backend.rs
@@ -708,6 +708,14 @@ pub enum DesktopCommand {
         next_test: String,
         project_dir: Option<String>,
     },
+    WorkersStatus {
+        target: String,
+        project_dir: Option<String>,
+    },
+    WorkersStart {
+        target: String,
+        project_dir: Option<String>,
+    },
     RuntimeRolesApply {
         roles_json: String,
         project_dir: Option<String>,
@@ -841,6 +849,8 @@ impl DesktopCommand {
             DesktopCommand::RunCompare { project_dir, .. } => project_dir.as_deref(),
             DesktopCommand::RunPromote { project_dir, .. } => project_dir.as_deref(),
             DesktopCommand::RunPickWinner { project_dir, .. } => project_dir.as_deref(),
+            DesktopCommand::WorkersStatus { project_dir, .. } => project_dir.as_deref(),
+            DesktopCommand::WorkersStart { project_dir, .. } => project_dir.as_deref(),
             DesktopCommand::RuntimeRolesApply { project_dir, .. } => project_dir.as_deref(),
             DesktopCommand::DogfoodEvent { project_dir, .. } => project_dir.as_deref(),
         }
@@ -900,6 +910,18 @@ impl DesktopCommand {
                 }
                 args
             }
+            DesktopCommand::WorkersStatus { target, .. } => vec![
+                "workers".to_string(),
+                "status".to_string(),
+                target.clone(),
+                "--json".to_string(),
+            ],
+            DesktopCommand::WorkersStart { target, .. } => vec![
+                "workers".to_string(),
+                "start".to_string(),
+                target.clone(),
+                "--json".to_string(),
+            ],
             DesktopCommand::RuntimeRolesApply { roles_json, .. } => vec![
                 "runtime-roles".to_string(),
                 "apply".to_string(),
@@ -1285,6 +1307,28 @@ pub fn apply_desktop_runtime_roles(
     })
 }
 
+pub fn load_desktop_workers_status(
+    transport: &dyn DesktopCommandTransport,
+    target: String,
+    project_dir: Option<String>,
+) -> Result<Value, String> {
+    transport.request_json(&DesktopCommand::WorkersStatus {
+        target,
+        project_dir,
+    })
+}
+
+pub fn start_desktop_worker(
+    transport: &dyn DesktopCommandTransport,
+    target: String,
+    project_dir: Option<String>,
+) -> Result<Value, String> {
+    transport.request_json(&DesktopCommand::WorkersStart {
+        target,
+        project_dir,
+    })
+}
+
 pub fn load_desktop_editor_file(
     path: String,
     worktree: Option<String>,
@@ -1362,6 +1406,8 @@ pub fn handle_desktop_json_rpc(
                     "desktop.run.compare",
                     "desktop.run.promote",
                     "desktop.run.pick_winner",
+                    "desktop.workers.status",
+                    "desktop.workers.start",
                     "desktop.runtime.roles.apply",
                     "desktop.voice.capture_status",
                     "desktop.dogfood.event",
@@ -1500,6 +1546,26 @@ pub fn handle_desktop_json_rpc(
                         format!("Failed to serialize desktop pick-winner payload: {err}"),
                     ),
                 },
+                Err(err) => json_rpc_error(request_id, JSON_RPC_SERVER_ERROR, err),
+            }
+        }
+        "desktop.workers.status" => {
+            let target = get_optional_string_param(params.as_ref(), &["target", "slot"])
+                .unwrap_or_else(|| "all".to_string());
+            match load_desktop_workers_status(transport, target, resolved_project_dir) {
+                Ok(result) => json_rpc_result(request_id, result),
+                Err(err) => json_rpc_error(request_id, JSON_RPC_SERVER_ERROR, err),
+            }
+        }
+        "desktop.workers.start" => {
+            let target = match get_required_string_param(params.as_ref(), &["target", "slot"]) {
+                Ok(value) => value,
+                Err(err) => {
+                    return json_rpc_error(request_id, JSON_RPC_INVALID_PARAMS, err);
+                }
+            };
+            match start_desktop_worker(transport, target, resolved_project_dir) {
+                Ok(result) => json_rpc_result(request_id, result),
                 Err(err) => json_rpc_error(request_id, JSON_RPC_SERVER_ERROR, err),
             }
         }
@@ -4912,6 +4978,12 @@ mod tests {
                     .any(|method| { method.as_str() == Some("desktop.runtime.roles.apply") }));
                 assert!(methods
                     .iter()
+                    .any(|method| { method.as_str() == Some("desktop.workers.status") }));
+                assert!(methods
+                    .iter()
+                    .any(|method| { method.as_str() == Some("desktop.workers.start") }));
+                assert!(methods
+                    .iter()
                     .any(|method| { method.as_str() == Some("desktop.dogfood.event") }));
                 assert!(methods
                     .iter()
@@ -4960,6 +5032,119 @@ mod tests {
             }
             DesktopJsonRpcResponse::Error { error, .. } => {
                 panic!("expected success, got {:?}", error);
+            }
+        }
+        assert!(transport.requests.borrow().is_empty());
+    }
+
+    #[test]
+    fn handle_desktop_json_rpc_routes_workers_status() {
+        let transport = FakeTransport {
+            requests: RefCell::new(Vec::new()),
+            response: serde_json::json!({
+                "workers": [
+                    {
+                        "slot_id": "worker-2",
+                        "approved_launch": {"agent": "codex"},
+                        "current_launch": {"agent": "codex"},
+                        "approval_differences": []
+                    }
+                ]
+            }),
+        };
+        let response = handle_desktop_json_rpc(
+            &transport,
+            DesktopJsonRpcRequest {
+                jsonrpc: "2.0".to_string(),
+                id: serde_json::json!("req-workers-status"),
+                method: "desktop.workers.status".to_string(),
+                params: Some(serde_json::json!({
+                    "target": "worker-2",
+                    "projectDir": r"C:\repo",
+                })),
+            },
+            None,
+        );
+
+        match response {
+            DesktopJsonRpcResponse::Success { id, result, .. } => {
+                assert_eq!(id, serde_json::json!("req-workers-status"));
+                assert_eq!(result["workers"][0]["slot_id"], "worker-2");
+            }
+            DesktopJsonRpcResponse::Error { error, .. } => {
+                panic!("expected success, got {:?}", error);
+            }
+        }
+        assert_eq!(
+            transport.requests.borrow().as_slice(),
+            ["workers status worker-2 --json"]
+        );
+    }
+
+    #[test]
+    fn handle_desktop_json_rpc_routes_workers_start() {
+        let transport = FakeTransport {
+            requests: RefCell::new(Vec::new()),
+            response: serde_json::json!({
+                "results": [
+                    {
+                        "slot_id": "worker-2",
+                        "status": "started",
+                        "approval_differences": []
+                    }
+                ]
+            }),
+        };
+        let response = handle_desktop_json_rpc(
+            &transport,
+            DesktopJsonRpcRequest {
+                jsonrpc: "2.0".to_string(),
+                id: serde_json::json!("req-workers-start"),
+                method: "desktop.workers.start".to_string(),
+                params: Some(serde_json::json!({
+                    "slot": "worker-2",
+                })),
+            },
+            None,
+        );
+
+        match response {
+            DesktopJsonRpcResponse::Success { id, result, .. } => {
+                assert_eq!(id, serde_json::json!("req-workers-start"));
+                assert_eq!(result["results"][0]["status"], "started");
+            }
+            DesktopJsonRpcResponse::Error { error, .. } => {
+                panic!("expected success, got {:?}", error);
+            }
+        }
+        assert_eq!(
+            transport.requests.borrow().as_slice(),
+            ["workers start worker-2 --json"]
+        );
+    }
+
+    #[test]
+    fn handle_desktop_json_rpc_rejects_workers_start_without_target() {
+        let transport = FakeTransport {
+            requests: RefCell::new(Vec::new()),
+            response: serde_json::json!({}),
+        };
+        let response = handle_desktop_json_rpc(
+            &transport,
+            DesktopJsonRpcRequest {
+                jsonrpc: "2.0".to_string(),
+                id: serde_json::json!("req-workers-start-missing"),
+                method: "desktop.workers.start".to_string(),
+                params: Some(serde_json::json!({})),
+            },
+            None,
+        );
+
+        match response {
+            DesktopJsonRpcResponse::Success { .. } => panic!("expected error"),
+            DesktopJsonRpcResponse::Error { error, .. } => {
+                assert_eq!(error.code, JSON_RPC_INVALID_PARAMS);
+                assert!(error.message.contains("target"));
             }
         }
         assert!(transport.requests.borrow().is_empty());

--- a/winsmux-app/src/desktopClient.ts
+++ b/winsmux-app/src/desktopClient.ts
@@ -7,6 +7,8 @@ type DesktopCommandName =
   | "desktop_run_compare"
   | "desktop_run_promote"
   | "desktop_run_pick_winner"
+  | "desktop_workers_status"
+  | "desktop_workers_start"
   | "desktop_runtime_roles_apply"
   | "desktop_voice_capture_status"
   | "desktop_voice_capture_start"
@@ -20,6 +22,8 @@ type DesktopJsonRpcMethod =
   | "desktop.run.compare"
   | "desktop.run.promote"
   | "desktop.run.pick_winner"
+  | "desktop.workers.status"
+  | "desktop.workers.start"
   | "desktop.runtime.roles.apply"
   | "desktop.voice.capture_status"
   | "desktop.dogfood.event"
@@ -571,6 +575,80 @@ export interface DesktopCompareRunsResult {
   recommend: DesktopCompareRecommendation;
 }
 
+export interface DesktopWorkerLaunchApproval {
+  packet_type?: string;
+  source?: string;
+  slot_id?: string;
+  worker_backend?: string;
+  worker_role?: string;
+  agent?: string;
+  model?: string;
+  model_source?: string;
+  reasoning_effort?: string;
+  prompt_transport?: string;
+  auth_mode?: string;
+  credential_requirements?: string;
+  execution_backend?: string;
+  analysis_posture?: string;
+  auto_launch?: boolean;
+  [key: string]: unknown;
+}
+
+export interface DesktopWorkerApprovalDifference {
+  field: string;
+  approved: string;
+  current: string;
+}
+
+export interface DesktopWorkerStatusRow {
+  slot: string;
+  slot_id: string;
+  pane_id: string;
+  state: string;
+  pane_state: string;
+  manifest_status: string;
+  backend: string;
+  role: string;
+  session: string;
+  requested_gpu: string;
+  actual_gpu: string;
+  degraded_reason: string;
+  last_command: string;
+  last_command_at: string;
+  approved_launch: DesktopWorkerLaunchApproval | null;
+  current_launch: DesktopWorkerLaunchApproval | null;
+  approval_differences: DesktopWorkerApprovalDifference[];
+}
+
+export interface DesktopWorkersStatusResult {
+  project_dir: string;
+  generated_at: string;
+  manifest_error?: string;
+  colab_state?: Record<string, unknown>;
+  workers: DesktopWorkerStatusRow[];
+}
+
+export interface DesktopWorkerLifecycleResult {
+  slot_id: string;
+  slot: string;
+  pane_id: string;
+  action: string;
+  status: string;
+  reason: string;
+  backend: string;
+  worker_state: string;
+  last_command: string;
+  approved_launch: DesktopWorkerLaunchApproval | null;
+  current_launch: DesktopWorkerLaunchApproval | null;
+  approval_differences: DesktopWorkerApprovalDifference[];
+}
+
+export interface DesktopWorkersStartResult {
+  project_dir: string;
+  generated_at: string;
+  results: DesktopWorkerLifecycleResult[];
+}
+
 let nextDesktopJsonRpcId = 0;
 
 function normalizeDesktopError(action: string, error: unknown) {
@@ -593,6 +671,10 @@ function getDesktopJsonRpcMethod(command: DesktopCommandName): DesktopJsonRpcMet
       return "desktop.run.promote";
     case "desktop_run_pick_winner":
       return "desktop.run.pick_winner";
+    case "desktop_workers_status":
+      return "desktop.workers.status";
+    case "desktop_workers_start":
+      return "desktop.workers.start";
     case "desktop_runtime_roles_apply":
       return "desktop.runtime.roles.apply";
     case "desktop_voice_capture_status":
@@ -784,6 +866,34 @@ export async function applyDesktopRuntimeRolePreferences(
     );
   } catch (error) {
     throw normalizeDesktopError("desktop_runtime_roles_apply", error);
+  }
+}
+
+export async function getDesktopWorkersStatus(
+  target = "all",
+  projectDir?: string | null,
+) {
+  try {
+    return await desktopCommandTransport.request<DesktopWorkersStatusResult>(
+      "desktop_workers_status",
+      { target, ...buildProjectDirPayload(projectDir) },
+    );
+  } catch (error) {
+    throw normalizeDesktopError(`desktop_workers_status(${target})`, error);
+  }
+}
+
+export async function startDesktopWorker(
+  target: string,
+  projectDir?: string | null,
+) {
+  try {
+    return await desktopCommandTransport.request<DesktopWorkersStartResult>(
+      "desktop_workers_start",
+      { target, ...buildProjectDirPayload(projectDir) },
+    );
+  } catch (error) {
+    throw normalizeDesktopError(`desktop_workers_start(${target})`, error);
   }
 }
 

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -11,10 +11,12 @@ import {
   getDesktopRunExplain,
   getDesktopExplorerEntries,
   getDesktopSummarySnapshot,
+  getDesktopWorkersStatus,
   getDesktopVoiceCaptureStatus,
   pickDesktopRunWinner,
   promoteDesktopRunTactic,
   recordDesktopDogfoodEvent,
+  startDesktopWorker,
   subscribeToDesktopSummaryRefresh,
   type DesktopCompareRunsResult,
   type DesktopBoardPane,
@@ -25,6 +27,9 @@ import {
   type DesktopRunProjection,
   type DesktopSummarySnapshot,
   type DesktopRuntimeRolePreference,
+  type DesktopWorkerApprovalDifference,
+  type DesktopWorkerLaunchApproval,
+  type DesktopWorkerStatusRow,
   type DesktopVoiceCaptureStatus,
 } from "./desktopClient";
 import { getEditorFileKey, getSourceChangeKey, pickEditorPathCandidate, pickSourceChangeKeyCandidate } from "./editorTargets";
@@ -645,6 +650,7 @@ let settingsDraftState: ThemeState | null = null;
 let settingsFontFamilyMenuOpen = false;
 let runtimeRolePreferences: RuntimeRolePreference[] = [];
 let runtimeRoleDraftState: RuntimeRolePreference[] | null = null;
+let workerStartTarget: string | null = null;
 let preferredWideSidebarOpen = true;
 let preferredWideContextOpen = false;
 const SHELL_PREFERENCES_STORAGE_KEY = "winsmux.shell.preferences.v1";
@@ -1733,6 +1739,173 @@ function closePane(id: string) {
   fitVisibleWorkbenchPanes();
 }
 
+function getWorkerStartTarget() {
+  return getFocusedWorkbenchPaneId() ?? getWorkbenchPaneIds()[0] ?? null;
+}
+
+function getLaunchApprovalField(
+  launch: DesktopWorkerLaunchApproval | null | undefined,
+  field: keyof DesktopWorkerLaunchApproval,
+) {
+  const value = launch?.[field];
+  if (typeof value === "boolean") {
+    return value ? "true" : "false";
+  }
+  if (typeof value === "string") {
+    return value.trim();
+  }
+  if (typeof value === "number") {
+    return String(value);
+  }
+  return "";
+}
+
+function summarizeWorkerLaunchApproval(row: DesktopWorkerStatusRow) {
+  const launch = row.current_launch ?? row.approved_launch;
+  const agent = getLaunchApprovalField(launch, "agent") || row.backend || "unknown";
+  const model = getLaunchApprovalField(launch, "model") || "provider-default";
+  const backend = getLaunchApprovalField(launch, "worker_backend") || row.backend || "unknown";
+  const effort = getLaunchApprovalField(launch, "reasoning_effort") || "provider-default";
+  const credential = getLaunchApprovalField(launch, "credential_requirements") || "default";
+  return getLanguageText(
+    `${row.slot_id}: ${agent} / ${model} / ${backend} / effort ${effort} / credential ${credential}`,
+    `${row.slot_id}: ${agent} / ${model} / ${backend} / 思考量 ${effort} / 認証 ${credential}`,
+  );
+}
+
+function summarizeWorkerApprovalDifferences(differences: DesktopWorkerApprovalDifference[]) {
+  if (differences.length === 0) {
+    return getLanguageText("No approval differences.", "承認内容との差分はありません。");
+  }
+
+  return differences.slice(0, 4).map((difference) => {
+    return `${difference.field}: ${difference.approved || "(empty)"} -> ${difference.current || "(empty)"}`;
+  }).join(" · ");
+}
+
+function buildWorkerLaunchDetails(row: DesktopWorkerStatusRow, differences: DesktopWorkerApprovalDifference[]): ConversationDetail[] {
+  const launch = row.current_launch ?? row.approved_launch;
+  return [
+    { label: getLanguageText("slot", "スロット"), value: row.slot_id },
+    { label: getLanguageText("state", "状態"), value: row.state || row.manifest_status || "unknown" },
+    { label: getLanguageText("agent", "エージェント"), value: getLaunchApprovalField(launch, "agent") || row.backend || "unknown" },
+    { label: getLanguageText("model", "モデル"), value: getLaunchApprovalField(launch, "model") || "provider-default" },
+    { label: getLanguageText("backend", "バックエンド"), value: getLaunchApprovalField(launch, "worker_backend") || row.backend || "unknown" },
+    { label: getLanguageText("differences", "差分"), value: String(differences.length) },
+  ];
+}
+
+function appendWorkerLaunchConversation(
+  row: DesktopWorkerStatusRow,
+  title: string,
+  tone: SurfaceTone,
+) {
+  const differences = row.approval_differences ?? [];
+  appendRuntimeConversation({
+    type: "system",
+    category: differences.length > 0 ? "attention" : "activity",
+    timestamp: new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", hour12: false }),
+    actor: "winsmux",
+    title,
+    body: `${summarizeWorkerLaunchApproval(row)}. ${summarizeWorkerApprovalDifferences(differences)}`,
+    details: buildWorkerLaunchDetails(row, differences),
+    tone,
+  });
+  renderConversation(getConversationItems());
+}
+
+function appendWorkerStartResultConversation(
+  result: { slot_id: string; status: string; reason?: string; approval_differences?: DesktopWorkerApprovalDifference[] },
+  row?: DesktopWorkerStatusRow,
+) {
+  const differences = result.approval_differences ?? [];
+  const blocked = result.status === "blocked" || result.status === "failed" || differences.length > 0;
+  const reason = result.reason ? ` ${result.reason}` : "";
+  appendRuntimeConversation({
+    type: "system",
+    category: blocked ? "attention" : "activity",
+    timestamp: new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", hour12: false }),
+    actor: "winsmux",
+    title: blocked
+      ? getLanguageText("Worker start blocked", "ワーカー起動を停止")
+      : getLanguageText("Worker start accepted", "ワーカー起動を受理"),
+    body: row
+      ? `${summarizeWorkerLaunchApproval(row)}. ${result.status}${reason}`
+      : `${result.slot_id}: ${result.status}${reason}`,
+    details: row
+      ? buildWorkerLaunchDetails(row, differences)
+      : [{ label: getLanguageText("slot", "スロット"), value: result.slot_id }, { label: getLanguageText("status", "状態"), value: result.status }],
+    tone: blocked ? "warning" : "success",
+  });
+  renderConversation(getConversationItems());
+}
+
+async function startFocusedWorkerFromDesktop() {
+  const target = getWorkerStartTarget();
+  if (!target) {
+    return;
+  }
+  if (workerStartTarget) {
+    return;
+  }
+  if (!isTauri()) {
+    appendRuntimeConversation({
+      type: "system",
+      category: "attention",
+      timestamp: new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", hour12: false }),
+      actor: "winsmux",
+      title: getLanguageText("Desktop worker start is unavailable", "デスクトップのワーカー起動は使えません"),
+      body: getLanguageText("Open the Tauri desktop app to start workers through the native control plane.", "Tauri デスクトップアプリで、ネイティブ制御経由のワーカー起動を使ってください。"),
+      tone: "warning",
+    });
+    renderConversation(getConversationItems());
+    return;
+  }
+
+  workerStartTarget = target;
+  updateWorkbenchControls();
+  try {
+    const statusPayload = await getDesktopWorkersStatus(target, activeProjectDir);
+    const row = statusPayload.workers.find((item) => item.slot_id === target || item.slot === target || item.pane_id === target)
+      ?? statusPayload.workers[0];
+    if (row) {
+      const differenceCount = (row.approval_differences ?? []).length;
+      appendWorkerLaunchConversation(
+        row,
+        getLanguageText("Worker launch approval", "ワーカー起動の承認内容"),
+        differenceCount > 0 ? "warning" : "info",
+      );
+      if (differenceCount > 0) {
+        return;
+      }
+    }
+
+    const startPayload = await startDesktopWorker(target, activeProjectDir);
+    const result = startPayload.results.find((item) => item.slot_id === target || item.slot === target || item.pane_id === target)
+      ?? startPayload.results[0];
+    if (result) {
+      appendWorkerStartResultConversation(result, row);
+    }
+    requestDesktopSummaryRefresh(undefined, 500);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    appendRuntimeConversation({
+      type: "system",
+      category: "attention",
+      timestamp: new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", hour12: false }),
+      actor: "winsmux",
+      title: getLanguageText("Worker start failed", "ワーカー起動に失敗"),
+      body: message,
+      tone: "danger",
+    });
+    renderConversation(getConversationItems());
+    console.warn("Failed to start worker through desktop runtime", error);
+  } finally {
+    workerStartTarget = null;
+    updateWorkbenchControls();
+  }
+}
+
 function ensureDefaultWorkbenchPanes() {
   const defaultPaneIds = ["worker-1", "worker-2", "worker-3", "worker-4"];
   for (const id of defaultPaneIds) {
@@ -1830,6 +2003,7 @@ function fitVisibleWorkbenchPanes() {
 function updateWorkbenchControls() {
   const drawer = document.getElementById("terminal-drawer");
   const addButton = document.getElementById("add-pane-btn") as HTMLButtonElement | null;
+  const startButton = document.getElementById("start-worker-btn") as HTMLButtonElement | null;
   const layoutButton = document.getElementById("workbench-layout-btn");
   const menuLayoutStatus = document.getElementById("menu-layout-status");
 
@@ -1846,6 +2020,23 @@ function updateWorkbenchControls() {
   }
   if (layoutButton) {
     layoutButton.textContent = workbenchLayout;
+  }
+  if (startButton) {
+    const targetPane = getFocusedWorkbenchPaneId();
+    startButton.disabled = !targetPane || Boolean(workerStartTarget);
+    startButton.textContent = workerStartTarget ? getLanguageText("Starting", "起動中") : getLanguageText("Start", "起動");
+    startButton.setAttribute(
+      "aria-label",
+      targetPane
+        ? getLanguageText(`Start ${getPaneDisplayLabel(targetPane)}`, `${getPaneDisplayLabel(targetPane)} を起動`)
+        : getLanguageText("Start selected worker", "選択中のワーカーを起動"),
+    );
+    startButton.setAttribute(
+      "title",
+      targetPane
+        ? getLanguageText(`Show launch approval, then start ${getPaneDisplayLabel(targetPane)}`, `${getPaneDisplayLabel(targetPane)} の起動承認を確認して起動`)
+        : getLanguageText("Select a worker pane first", "先にワーカーペインを選択"),
+    );
   }
   if (menuLayoutStatus) {
     const paneCount = terminalDrawerOpen ? getVisibleWorkbenchPaneIds().length : panes.size;
@@ -6641,6 +6832,7 @@ function applyLanguageChrome() {
   setElementText("evidence-title", japanese ? "証跡" : "Evidence");
   setElementText("workbench-title", japanese ? "ワーカーペイン" : "Worker panes");
   setElementText("close-terminal-drawer-btn", "×");
+  setButtonLabel("start-worker-btn", japanese ? "起動" : "Start", japanese ? "選択中のワーカーを起動" : "Start selected worker");
   document.getElementById("close-terminal-drawer-btn")?.setAttribute("aria-label", japanese ? "ワーカーペインを隠す" : "Hide worker panes");
   document.getElementById("close-terminal-drawer-btn")?.setAttribute("title", japanese ? "ワーカーペインを隠す" : "Hide worker panes");
   document.getElementById("terminal-drawer")?.setAttribute("aria-label", japanese ? "ワーカーペイン" : "Worker panes");
@@ -13194,6 +13386,10 @@ window.addEventListener("DOMContentLoaded", async () => {
 
   document.getElementById("close-terminal-drawer-btn")?.addEventListener("click", () => {
     setTerminalDrawer(false);
+  });
+
+  document.getElementById("start-worker-btn")?.addEventListener("click", () => {
+    void startFocusedWorkerFromDesktop();
   });
 
   document.getElementById("browser-reload-btn")?.addEventListener("click", () => {

--- a/winsmux-app/src/styles.css
+++ b/winsmux-app/src/styles.css
@@ -4262,6 +4262,7 @@ body.is-resizing-workbench {
 
 #add-pane-btn,
 #workbench-layout-btn,
+#start-worker-btn,
 #focused-pane-select,
 #close-terminal-drawer-btn {
   border: 1px solid var(--border-strong);
@@ -4276,6 +4277,7 @@ body.is-resizing-workbench {
 
 #add-pane-btn:hover,
 #workbench-layout-btn:hover,
+#start-worker-btn:hover,
 #focused-pane-select:hover,
 #close-terminal-drawer-btn:hover {
   background: var(--bg-panel);

--- a/winsmux-core/scripts/orchestra-start.ps1
+++ b/winsmux-core/scripts/orchestra-start.ps1
@@ -663,6 +663,32 @@ function Send-OrchestraBridgeCommand {
     Invoke-Bridge -Arguments @('send', $Target, $Text)
 }
 
+function New-OrchestraWorkerLaunchApproval {
+    param(
+        [Parameter(Mandatory = $true)][string]$SlotId,
+        [Parameter(Mandatory = $true)]$SlotAgentConfig,
+        [bool]$AutoLaunch = $false
+    )
+
+    return [ordered]@{
+        packet_type             = 'worker_launch_approval'
+        source                  = 'user_approved_worker_config'
+        slot_id                 = $SlotId
+        worker_backend          = [string]$SlotAgentConfig.WorkerBackend
+        worker_role             = [string]$SlotAgentConfig.WorkerRole
+        agent                   = [string]$SlotAgentConfig.Agent
+        model                   = [string]$SlotAgentConfig.Model
+        model_source            = [string]$SlotAgentConfig.ModelSource
+        reasoning_effort        = [string]$SlotAgentConfig.ReasoningEffort
+        prompt_transport        = [string]$SlotAgentConfig.PromptTransport
+        auth_mode               = [string]$SlotAgentConfig.AuthMode
+        credential_requirements = [string]$SlotAgentConfig.CredentialRequirements
+        execution_backend       = [string]$SlotAgentConfig.ExecutionBackend
+        analysis_posture        = [string]$SlotAgentConfig.AnalysisPosture
+        auto_launch             = [bool]$AutoLaunch
+    }
+}
+
 function New-OrchestraPaneBootstrapPlan {
     param(
         [Parameter(Mandatory = $true)][string]$ProjectDir,
@@ -675,7 +701,8 @@ function New-OrchestraPaneBootstrapPlan {
         [Parameter(Mandatory = $true)][string]$LaunchDir,
         [Parameter(Mandatory = $true)]$CleanPtyEnv,
         [Parameter(Mandatory = $true)][string]$LaunchCommand,
-        [bool]$SupportsInterrupt = $true
+        [bool]$SupportsInterrupt = $true,
+        [AllowNull()]$ApprovedLaunch = $null
     )
 
     $bootstrapDir = Join-Path (Join-Path $ProjectDir '.winsmux') 'orchestra-bootstrap'
@@ -702,6 +729,9 @@ function New-OrchestraPaneBootstrapPlan {
         supports_interrupt = $SupportsInterrupt
         ready_marker_path = $readyMarkerPath
         environment    = $CleanPtyEnv.Environment
+    }
+    if ($null -ne $ApprovedLaunch) {
+        $plan['approved_launch'] = $ApprovedLaunch
     }
 
     $planJson = ($plan | ConvertTo-Json -Depth 8)
@@ -1159,6 +1189,7 @@ function Save-OrchestraSessionState {
             supports_verification      = [bool]$paneSummary.SupportsVerification
             supports_consultation      = [bool]$paneSummary.SupportsConsultation
             supports_context_reset     = [bool](Get-OrchestraObjectPropertyValue -InputObject $paneSummary -Name 'SupportsContextReset' -Default $false)
+            approved_launch            = (Get-OrchestraObjectPropertyValue -InputObject $paneSummary -Name 'ApprovedLaunch' -Default $null)
             bootstrap_plan_path        = [string](Get-OrchestraObjectPropertyValue -InputObject $paneSummary -Name 'BootstrapPlanPath' -Default '')
             bootstrap_marker_path      = [string](Get-OrchestraObjectPropertyValue -InputObject $paneSummary -Name 'BootstrapMarkerPath' -Default '')
             task                       = $null
@@ -2268,6 +2299,7 @@ if ($MyInvocation.InvocationName -ne '.') {
         }
 
         Invoke-Bridge -Arguments @('name', $paneId, $label)
+        $approvedLaunch = $null
         try {
             $paneEnvironment = Get-WinsmuxPaneEnvironment -Role $canonicalRole -PaneId $paneId -SessionName $sessionName -ProjectDir $projectDir -RoleMapJson $sessionRoleMapJson -BuilderWorktreePath $builderWorktreePath -SlotId $label -AssignedBranch $builderBranch -GitWorktreeDir $launchGitWorktreeDir -ExpectedOrigin $expectedOrigin
             $cleanPtyEnv = Get-CleanPtyEnv -AllowedEnvironment $paneEnvironment
@@ -2280,6 +2312,9 @@ if ($MyInvocation.InvocationName -ne '.') {
             if ([string]::IsNullOrWhiteSpace($launchCommand)) {
                 Write-Warning "TASK-231: empty launch command for pane $paneId ($label, role=$canonicalRole, execMode=$execMode). Agent will not start automatically."
             } else {
+                if ($canonicalRole -eq 'Worker') {
+                    $approvedLaunch = New-OrchestraWorkerLaunchApproval -SlotId $label -SlotAgentConfig $slotAgentConfig -AutoLaunch:(!$deferPaneStart)
+                }
                 $bootstrapPlanPath = New-OrchestraPaneBootstrapPlan `
                     -ProjectDir $projectDir `
                     -PaneId $paneId `
@@ -2291,7 +2326,8 @@ if ($MyInvocation.InvocationName -ne '.') {
                     -LaunchDir $launchDir `
                     -CleanPtyEnv $cleanPtyEnv `
                     -LaunchCommand $launchCommand `
-                    -SupportsInterrupt $supportsInterrupt
+                    -SupportsInterrupt $supportsInterrupt `
+                    -ApprovedLaunch $approvedLaunch
                 if ($deferPaneStart) {
                     $paneStatus = $deferredPaneStatus
                     $eventName = if ($paneStatus -eq 'backend_degraded') { 'preflight.worker.backend_degraded' } else { 'preflight.worker.deferred_start' }
@@ -2350,6 +2386,7 @@ if ($MyInvocation.InvocationName -ne '.') {
             BuilderWorktreePath = $builderWorktreePath
             WorktreeGitDir = $launchGitWorktreeDir
             ExpectedOrigin = $expectedOrigin
+            ApprovedLaunch = $approvedLaunch
             BootstrapPlanPath = $bootstrapPlanPath
             BootstrapMarkerPath = $bootstrapMarkerPath
             Status = $paneStatus

--- a/winsmux-core/scripts/pane-control.ps1
+++ b/winsmux-core/scripts/pane-control.ps1
@@ -386,6 +386,7 @@ function Get-PaneControlManifestEntries {
             CapabilityAdapter   = [string](Get-PaneControlValue -InputObject $pane -Name 'capability_adapter' -Default '')
             Status              = [string](Get-PaneControlValue -InputObject $pane -Name 'status' -Default '')
             ColabSession        = ConvertFrom-PaneControlSecurityPolicy -Value (Get-PaneControlValue -InputObject $pane -Name 'colab_session' -Default $null)
+            ApprovedLaunch      = ConvertFrom-PaneControlSecurityPolicy -Value (Get-PaneControlValue -InputObject $pane -Name 'approved_launch' -Default $null)
             BootstrapPlanPath   = [string](Get-PaneControlValue -InputObject $pane -Name 'bootstrap_plan_path' -Default '')
             BootstrapMarkerPath = [string](Get-PaneControlValue -InputObject $pane -Name 'bootstrap_marker_path' -Default '')
             TimeoutPolicy       = [string](Get-PaneControlValue -InputObject $pane -Name 'timeout_policy' -Default '')


### PR DESCRIPTION
## Summary
- Enforce a user-approved worker launch packet across orchestra bootstrap, manifest reads, worker status, and worker start.
- Block worker starts when backend, model, execution, auth, or other approved launch fields no longer match.
- Expose `desktop.workers.status` and `desktop.workers.start` through the Tauri JSON-RPC surface.
- Add a desktop Start control that shows the worker launch summary and approval differences before calling the lifecycle command.

## Verification
- `Invoke-Pester -Path tests\winsmux-bridge.Tests.ps1 -PassThru`
- `cargo test --manifest-path winsmux-app\src-tauri\Cargo.toml --locked`
- `npm run build` in `winsmux-app`
- `npm run test:desktop-pane-e2e` in `winsmux-app`

## Evidence
- Real Tauri GUI E2E evidence: `winsmux-app/output/playwright/desktop-pane-e2e/desktop-pane-e2e.json`
- `TASK-482` is marked done in the external backlog.
- `ROADMAP.md` shows `v0.33.1` as 100% complete.
