### PR TITLE
v0.33.3 worker status pills

### DIFF
--- a/winsmux-app/index.html
+++ b/winsmux-app/index.html
@@ -372,6 +372,7 @@
                 <button id="close-terminal-drawer-btn" type="button" aria-label="Hide worker panes" title="Hide worker panes">×</button>
               </div>
             </div>
+            <div id="worker-status-pill-bar" aria-label="Worker status"></div>
             <div id="panes-container"></div>
           </section>
         </section>

--- a/winsmux-app/scripts/clickable-coverage-harness.mjs
+++ b/winsmux-app/scripts/clickable-coverage-harness.mjs
@@ -558,6 +558,15 @@ async function testWorkbench(page) {
     await page.selectOption("#focused-pane-select", value ?? "worker-1");
     recordClick("workbench focused pane select");
   }
+  const statusPill = page.locator('.worker-status-pill[data-worker-status-target="worker-2"]').first();
+  await statusPill.waitFor({ state: "visible" });
+  await clickLocator(page, statusPill, "workbench worker status pill");
+  await page.waitForFunction(() => {
+    const drawer = document.querySelector("#terminal-drawer");
+    const detail = document.querySelector(".worker-status-detail-strip");
+    return drawer?.getAttribute("data-focused-pane") === "worker-2"
+      && detail?.getAttribute("data-worker-status-detail") === "worker-2";
+  });
   await clickWorkbenchLayoutUntil(page, "2x2");
   await clickSelector(page, "#add-pane-btn", "workbench add pane");
   await clickLocator(page, page.locator("#panes-container .pane-close").last(), "workbench pane close");

--- a/winsmux-app/scripts/desktop-pane-e2e.mjs
+++ b/winsmux-app/scripts/desktop-pane-e2e.mjs
@@ -234,6 +234,56 @@ async function clickWorkerPanesFooterToggle(page) {
   await page.locator(".footer-pill", { hasText: "Worker panes" }).first().click({ timeout: 10_000 });
 }
 
+async function readViewportFillMetrics(page) {
+  return await page.evaluate(() => ({
+    innerWidth: window.innerWidth,
+    innerHeight: window.innerHeight,
+    screenWidth: window.screen.width,
+    screenHeight: window.screen.height,
+    bodyWidth: Math.round(document.body.getBoundingClientRect().width),
+    bodyHeight: Math.round(document.body.getBoundingClientRect().height),
+  }));
+}
+
+function assertNoFixedViewportBlank(metrics) {
+  if (
+    metrics.innerWidth === 1600
+    && metrics.innerHeight === 900
+    && metrics.screenWidth >= 1800
+    && metrics.screenHeight >= 1000
+  ) {
+    throw new Error(`WebView is stuck at the old test viewport: ${JSON.stringify(metrics)}`);
+  }
+  if (Math.abs(metrics.bodyWidth - metrics.innerWidth) > 2 || Math.abs(metrics.bodyHeight - metrics.innerHeight) > 2) {
+    throw new Error(`document body should fill the WebView viewport: ${JSON.stringify(metrics)}`);
+  }
+}
+
+async function maximizeNativeWindowAndReadMetrics(page) {
+  const beforeMetrics = await readViewportFillMetrics(page);
+  await page.evaluate(async () => {
+    const currentWindow = window.__TAURI__.webviewWindow.getCurrentWebviewWindow();
+    await currentWindow.maximize();
+  });
+  await page.waitForFunction((before) => {
+    const body = document.body;
+    if (!body) {
+      return false;
+    }
+    const bodyRect = body.getBoundingClientRect();
+    const fillsViewport = Math.abs(bodyRect.width - window.innerWidth) <= 2
+      && Math.abs(bodyRect.height - window.innerHeight) <= 2;
+    const sizeChanged = Math.abs(window.innerWidth - before.innerWidth) > 2
+      || Math.abs(window.innerHeight - before.innerHeight) > 2;
+    const alreadyAtScreenLimit = window.screen.width <= before.innerWidth + 2
+      || window.screen.height <= before.innerHeight + 80;
+    return fillsViewport && (sizeChanged || alreadyAtScreenLimit);
+  }, beforeMetrics, {
+    timeout: 10_000,
+  });
+  return await readViewportFillMetrics(page);
+}
+
 async function getWorkbenchLayout(page) {
   return await page.locator("#terminal-drawer").getAttribute("data-layout");
 }
@@ -367,15 +417,27 @@ function stripAnsi(value) {
   return value.replace(/\u001B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~]|\][^\u0007]*(?:\u0007|\u001B\\))/g, "");
 }
 
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function removePtyCommandEchoes(value, marker) {
+  const escapedMarker = escapeRegExp(marker);
+  return value
+    .replace(new RegExp(`Write-Output\\s+['"]${escapedMarker}['"]`, "g"), "")
+    .replace(new RegExp(`echo\\s+['"]?${escapedMarker}['"]?`, "g"), "");
+}
+
 async function waitForPtyOutputLine(page, paneId, line, timeoutMs = 45_000) {
   const startedAt = Date.now();
   let lastOutput = "";
   while (Date.now() - startedAt < timeoutMs) {
     lastOutput = await capturePty(page, paneId).catch((error) => `capture failed: ${error.message}`);
-    const strippedLines = stripAnsi(lastOutput)
+    const stripped = removePtyCommandEchoes(stripAnsi(lastOutput), line);
+    const strippedLines = stripped
       .split(/\r?\n/)
       .map((item) => item.trim());
-    if (strippedLines.includes(line)) {
+    if (strippedLines.includes(line) || stripped.includes(line)) {
       return lastOutput;
     }
     await new Promise((resolve) => setTimeout(resolve, 500));
@@ -704,12 +766,23 @@ async function main() {
     browser = await chromium.connectOverCDP(`http://127.0.0.1:${debugPort}`);
     page = await resolveAppPage(browser);
     attachPageErrorCapture(page);
-    await page.setViewportSize({ width: 1600, height: 900 }).catch(() => {});
 
     await runStep("wait for desktop app chrome", async () => {
       await waitForAppReady(page);
       await resetAppState(page);
       return { url: page.url() };
+    });
+
+    await runStep("desktop app fills the native WebView without fixed viewport emulation", async () => {
+      const metrics = await readViewportFillMetrics(page);
+      assertNoFixedViewportBlank(metrics);
+      return metrics;
+    });
+
+    await runStep("maximized desktop window still fills the WebView", async () => {
+      const metrics = await maximizeNativeWindowAndReadMetrics(page);
+      assertNoFixedViewportBlank(metrics);
+      return metrics;
     });
 
     await runStep("default center keeps operator and composer unobstructed", async () => {
@@ -782,6 +855,71 @@ async function main() {
       await typeIntoTerminal(page, "#pane-worker-1 .pane-terminal", `Write-Output '${WORKER_UI_MARKER}'`);
       const output = await waitForPtyOutputLine(page, "worker-1", WORKER_UI_MARKER);
       return { outputTail: output.slice(-800) };
+    });
+
+    await runStep("worker status pills mirror native state and focus panes", async () => {
+      await ensureDrawerOpen(page);
+      await page.locator("#worker-status-pill-bar").waitFor({ state: "visible", timeout: 10_000 });
+      const workerOnePill = page.locator('.worker-status-pill[data-worker-status-target="worker-1"]');
+      await workerOnePill.waitFor({ state: "visible", timeout: 10_000 });
+      await workerOnePill.click();
+      await page.waitForFunction(() => {
+        const detail = document.querySelector(".worker-status-detail-strip");
+        return detail?.getAttribute("data-worker-status-detail") === "worker-1";
+      }, undefined, { timeout: 10_000 });
+      const requiredFields = ["role", "backend", "auth", "model-source", "launch", "blocked", "remote", "elapsed", "focus"];
+      for (const field of requiredFields) {
+        const count = await page.locator(`.worker-status-detail-strip[data-worker-status-detail="worker-1"] .worker-status-pill-chip[data-status-field="${field}"]`).count();
+        if (count !== 1) {
+          throw new Error(`worker-1 status pill should expose ${field}, saw ${count}`);
+        }
+      }
+      const detailMetrics = await page.locator('.worker-status-detail-strip[data-worker-status-detail="worker-1"]').evaluate((detail) => {
+        const detailRect = detail.getBoundingClientRect();
+        const visibleFields = Array.from(detail.querySelectorAll(".worker-status-pill-chip"))
+          .filter((chip) => {
+            const chipRect = chip.getBoundingClientRect();
+            return chipRect.width > 0
+              && chipRect.height > 0
+              && chipRect.left >= detailRect.left
+              && chipRect.right <= detailRect.right
+              && chipRect.top >= detailRect.top
+              && chipRect.bottom <= detailRect.bottom;
+          })
+          .map((chip) => chip.getAttribute("data-status-field"));
+        return {
+          width: detailRect.width,
+          height: detailRect.height,
+          visibleFields,
+        };
+      });
+      if (detailMetrics.width < 220 || detailMetrics.visibleFields.length !== requiredFields.length) {
+        throw new Error(`worker status details should stay visible: ${JSON.stringify(detailMetrics)}`);
+      }
+      const workerTwoPill = page.locator('.worker-status-pill[data-worker-status-target="worker-2"]');
+      await workerTwoPill.waitFor({ state: "visible", timeout: 10_000 });
+      await workerTwoPill.click();
+      await page.waitForFunction(() => {
+        const drawer = document.querySelector("#terminal-drawer");
+        const pill = document.querySelector('.worker-status-pill[data-worker-status-target="worker-2"]');
+        const detail = document.querySelector(".worker-status-detail-strip");
+        return drawer?.getAttribute("data-focused-pane") === "worker-2"
+          && pill?.getAttribute("data-focused") === "true"
+          && detail?.getAttribute("data-worker-status-detail") === "worker-2";
+      }, undefined, { timeout: 10_000 });
+      const workerPaneVisible = await page.locator("#pane-worker-2").isVisible();
+      if (!workerPaneVisible) {
+        throw new Error("worker-2 pane should remain visible after status pill focus");
+      }
+      const statusBarMetrics = await page.locator("#worker-status-pill-bar").evaluate((bar) => ({
+        clientWidth: bar.clientWidth,
+        scrollWidth: bar.scrollWidth,
+        clientHeight: bar.clientHeight,
+        scrollHeight: bar.scrollHeight,
+      }));
+      if (statusBarMetrics.scrollWidth > statusBarMetrics.clientWidth + 2) {
+        throw new Error(`worker status surface should not require horizontal scrolling: ${JSON.stringify(statusBarMetrics)}`);
+      }
     });
 
     await runStep("worker terminal keeps shortcuts, arrows, and paste in the PTY", async () => {

--- a/winsmux-app/src-tauri/capabilities/default.json
+++ b/winsmux-app/src-tauri/capabilities/default.json
@@ -5,6 +5,7 @@
   "windows": ["main"],
   "permissions": [
     "core:default",
+    "core:window:allow-maximize",
     "core:webview:allow-create-webview-window",
     "dialog:default",
     "opener:default"

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -651,6 +651,10 @@ let settingsFontFamilyMenuOpen = false;
 let runtimeRolePreferences: RuntimeRolePreference[] = [];
 let runtimeRoleDraftState: RuntimeRolePreference[] | null = null;
 let workerStartTarget: string | null = null;
+let workerStatusRows: DesktopWorkerStatusRow[] = [];
+let workerStatusError = "";
+let workerStatusRefreshInFlight: Promise<void> | null = null;
+let workerStatusRefreshSequence = 0;
 let preferredWideSidebarOpen = true;
 let preferredWideContextOpen = false;
 const SHELL_PREFERENCES_STORAGE_KEY = "winsmux.shell.preferences.v1";
@@ -1490,6 +1494,7 @@ function markPanePtyStartedFromExternalEvent(paneId: string) {
     return;
   }
 
+  const wasStarted = entry.ptyStarted;
   entry.ptyStarted = true;
   entry.ptyStarting = null;
   entry.metaElement.textContent = getLanguageText("shell active", "シェル起動済み");
@@ -1497,6 +1502,9 @@ function markPanePtyStartedFromExternalEvent(paneId: string) {
     "This pane was started by the desktop control pipe.",
     "このペインはデスクトップ制御パイプから起動されました。",
   );
+  if (!wasStarted) {
+    void refreshWorkerStatusSurface();
+  }
 }
 
 function markPanePtyStoppedFromExternalEvent(paneId: string) {
@@ -1505,10 +1513,14 @@ function markPanePtyStoppedFromExternalEvent(paneId: string) {
     return;
   }
 
+  const wasRunning = entry.ptyStarted || Boolean(entry.ptyStarting);
   entry.ptyStarted = false;
   entry.ptyStarting = null;
   entry.metaElement.textContent = getLanguageText("not started", "未起動");
   entry.metaElement.removeAttribute("title");
+  if (wasRunning) {
+    void refreshWorkerStatusSurface();
+  }
 }
 
 function createPane(paneId?: string): string {
@@ -1688,20 +1700,24 @@ function ensurePanePtyStarted(paneId: string) {
 
   const { cols, rows } = { cols: entry.terminal.cols, rows: entry.terminal.rows };
   entry.metaElement.textContent = getLanguageText("starting shell", "シェル起動中");
+  renderWorkerStatusSurface();
   entry.ptyStarting = spawnPtyPane(paneId, cols, rows, getPaneStartupInput(paneId))
     .then(() => {
       entry.ptyStarted = true;
       entry.metaElement.textContent = getLanguageText("waiting for summary", "要約待ち");
       requestDesktopSummaryRefresh(undefined, 500);
+      void refreshWorkerStatusSurface();
     })
     .catch((error) => {
       entry.ptyStarted = false;
       entry.metaElement.textContent = getLanguageText("shell start failed", "シェル起動失敗");
       entry.metaElement.title = error instanceof Error ? error.message : String(error);
+      void refreshWorkerStatusSurface();
       throw error;
     })
     .finally(() => {
       entry.ptyStarting = null;
+      renderWorkerStatusSurface();
     });
 
   return entry.ptyStarting;
@@ -1741,6 +1757,315 @@ function closePane(id: string) {
 
 function getWorkerStartTarget() {
   return getFocusedWorkbenchPaneId() ?? getWorkbenchPaneIds()[0] ?? null;
+}
+
+function getWorkerStatusTarget(row: DesktopWorkerStatusRow) {
+  return row.slot_id || row.slot || row.pane_id || "";
+}
+
+function getWorkerStatusLaunch(row: DesktopWorkerStatusRow) {
+  return row.current_launch ?? row.approved_launch ?? null;
+}
+
+function getWorkerStatusRowsForSurface() {
+  const currentRows = workerStatusRows.length > 0 ? workerStatusRows : getFallbackWorkerStatusRows();
+  return currentRows.slice().sort((left, right) => {
+    const leftOrdinal = getWorkbenchPaneOrdinal(getWorkerStatusTarget(left)) ?? Number.MAX_SAFE_INTEGER;
+    const rightOrdinal = getWorkbenchPaneOrdinal(getWorkerStatusTarget(right)) ?? Number.MAX_SAFE_INTEGER;
+    if (leftOrdinal !== rightOrdinal) {
+      return leftOrdinal - rightOrdinal;
+    }
+    return getWorkerStatusTarget(left).localeCompare(getWorkerStatusTarget(right));
+  });
+}
+
+function getFallbackWorkerStatusRows(): DesktopWorkerStatusRow[] {
+  return getWorkbenchPaneIds().map((paneId) => {
+    const entry = panes.get(paneId);
+    const state = entry?.ptyStarted ? "running" : entry?.ptyStarting ? "starting" : "not_started";
+    return {
+      slot: paneId,
+      slot_id: paneId,
+      pane_id: paneId,
+      state,
+      pane_state: state,
+      manifest_status: "",
+      backend: "local",
+      role: "worker",
+      session: "desktop",
+      requested_gpu: "none",
+      actual_gpu: "none",
+      degraded_reason: "",
+      last_command: "",
+      last_command_at: "",
+      approved_launch: null,
+      current_launch: null,
+      approval_differences: [],
+    };
+  });
+}
+
+function formatWorkerCommandElapsed(timestamp: string) {
+  const parsed = Date.parse(timestamp);
+  if (Number.isNaN(parsed)) {
+    return getLanguageText("idle", "待機");
+  }
+
+  const elapsedMinutes = Math.max(0, Math.floor((Date.now() - parsed) / 60000));
+  if (elapsedMinutes < 1) {
+    return getLanguageText("<1m", "1分未満");
+  }
+  if (elapsedMinutes < 60) {
+    return getLanguageText(`${elapsedMinutes}m`, `${elapsedMinutes}分`);
+  }
+
+  const hours = Math.floor(elapsedMinutes / 60);
+  const minutes = elapsedMinutes % 60;
+  if (minutes === 0) {
+    return getLanguageText(`${hours}h`, `${hours}時間`);
+  }
+  return getLanguageText(`${hours}h${minutes}m`, `${hours}時間${minutes}分`);
+}
+
+function getWorkerAuthState(row: DesktopWorkerStatusRow) {
+  const launch = getWorkerStatusLaunch(row);
+  return getLaunchApprovalField(launch, "auth_mode")
+    || getLaunchApprovalField(launch, "credential_requirements")
+    || "default";
+}
+
+function getWorkerModelSource(row: DesktopWorkerStatusRow) {
+  const launch = getWorkerStatusLaunch(row);
+  return getLaunchApprovalField(launch, "model_source")
+    || (getLaunchApprovalField(launch, "model") ? "configured" : "provider-default");
+}
+
+function getConcreteWorkerStatusValue(...values: Array<string | null | undefined>) {
+  for (const value of values) {
+    const normalized = (value ?? "").trim();
+    if (normalized && normalized !== "unknown") {
+      return normalized;
+    }
+  }
+  return "";
+}
+
+function getWorkerLaunchState(row: DesktopWorkerStatusRow) {
+  return getConcreteWorkerStatusValue(row.state, row.pane_state, row.manifest_status) || "unknown";
+}
+
+function getWorkerRemoteState(row: DesktopWorkerStatusRow) {
+  const launch = getWorkerStatusLaunch(row);
+  const executionBackend = getLaunchApprovalField(launch, "execution_backend") || row.session || "local";
+  const requestedGpu = (row.requested_gpu || "none").trim();
+  const actualGpu = (row.actual_gpu || requestedGpu || "none").trim();
+  if (requestedGpu && requestedGpu !== "none" && actualGpu !== requestedGpu) {
+    return `${executionBackend} gpu:${actualGpu || "none"}`;
+  }
+  if (actualGpu && actualGpu !== "none") {
+    return `${executionBackend} gpu:${actualGpu}`;
+  }
+  return executionBackend;
+}
+
+function isWorkerStatusBlocked(row: DesktopWorkerStatusRow) {
+  const stateText = `${row.state} ${row.pane_state} ${row.manifest_status}`.toLowerCase();
+  return Boolean(row.degraded_reason)
+    || (row.approval_differences ?? []).length > 0
+    || stateText.includes("block")
+    || stateText.includes("fail")
+    || stateText.includes("error")
+    || stateText.includes("degraded");
+}
+
+function getWorkerStatusTone(row: DesktopWorkerStatusRow): SurfaceTone {
+  const stateText = `${row.state} ${row.pane_state} ${row.manifest_status}`.toLowerCase();
+  if (stateText.includes("fail") || stateText.includes("error")) {
+    return "danger";
+  }
+  if (isWorkerStatusBlocked(row) || stateText.includes("pending") || stateText.includes("start")) {
+    return "warning";
+  }
+  if (stateText.includes("run") || stateText.includes("active") || stateText.includes("live")) {
+    return "success";
+  }
+  return "info";
+}
+
+function createWorkerStatusChip(field: string, label: string, value: string) {
+  const chip = document.createElement("span");
+  chip.className = "worker-status-pill-chip";
+  chip.dataset.statusField = field;
+  chip.textContent = `${label}:${value || "unknown"}`;
+  chip.title = `${label}: ${value || "unknown"}`;
+  return chip;
+}
+
+function getWorkerStatusPillTitle(row: DesktopWorkerStatusRow, target: string) {
+  const launch = getWorkerStatusLaunch(row);
+  return [
+    `${target}: ${getWorkerLaunchState(row)}`,
+    `role=${row.role || getLaunchApprovalField(launch, "worker_role") || "worker"}`,
+    `backend=${getLaunchApprovalField(launch, "worker_backend") || row.backend || "unknown"}`,
+    `auth=${getWorkerAuthState(row)}`,
+    `model=${getLaunchApprovalField(launch, "model") || "provider-default"}`,
+    `model_source=${getWorkerModelSource(row)}`,
+    `remote=${getWorkerRemoteState(row)}`,
+    `elapsed=${formatWorkerCommandElapsed(row.last_command_at)}`,
+    isWorkerStatusBlocked(row) ? `blocked=${row.degraded_reason || "requires attention"}` : "blocked=no",
+  ].join(" · ");
+}
+
+function focusWorkerPaneFromStatus(target: string) {
+  if (!target) {
+    return;
+  }
+
+  setTerminalDrawer(true);
+  const targetOrdinal = getWorkbenchPaneOrdinal(target);
+  if (targetOrdinal !== null) {
+    ensureWorkbenchPaneCount(Math.min(6, Math.max(1, targetOrdinal)));
+  }
+  if (!panes.has(target)) {
+    createPane(target);
+  }
+  if (workbenchLayout === "2x2" && targetOrdinal !== null && targetOrdinal > 4) {
+    workbenchLayout = "3x2";
+  }
+  focusedWorkbenchPaneId = target;
+  updateWorkbenchControls();
+  void refreshWorkerStatusSurface();
+  void persistThemeState();
+  window.requestAnimationFrame(() => {
+    const entry = panes.get(target);
+    if (!entry) {
+      return;
+    }
+    if (!entry.container.hidden) {
+      entry.fitAddon.fit();
+    }
+    entry.terminal.focus();
+  });
+}
+
+function renderWorkerStatusSurface() {
+  const bar = document.getElementById("worker-status-pill-bar");
+  if (!bar) {
+    return;
+  }
+
+  const focusedPaneId = getFocusedWorkbenchPaneId();
+  const rows = getWorkerStatusRowsForSurface();
+  const focusedRow = rows.find((row) => getWorkerStatusTarget(row) === focusedPaneId) ?? rows[0] ?? null;
+  bar.replaceChildren();
+  bar.dataset.statusError = workerStatusError;
+  bar.title = workerStatusError || getLanguageText("Worker status mirrors native runtime state.", "ワーカー状態はネイティブ実行状態を反映します。");
+
+  const pillList = document.createElement("div");
+  pillList.className = "worker-status-pill-list";
+  const detailStrip = document.createElement("div");
+  detailStrip.className = "worker-status-detail-strip";
+  detailStrip.dataset.workerStatusDetail = focusedRow ? getWorkerStatusTarget(focusedRow) : "";
+
+  for (const row of rows) {
+    const target = getWorkerStatusTarget(row);
+    if (!target) {
+      continue;
+    }
+    const launchState = getWorkerLaunchState(row);
+    const blocked = isWorkerStatusBlocked(row);
+    const pill = document.createElement("button");
+    pill.type = "button";
+    pill.className = "worker-status-pill";
+    pill.dataset.workerStatusTarget = target;
+    pill.dataset.tone = workerStatusError ? "warning" : getWorkerStatusTone(row);
+    pill.dataset.focused = String(target === focusedPaneId);
+    pill.setAttribute(
+      "aria-label",
+      getLanguageText(`Focus ${getPaneDisplayLabel(target)} status`, `${getPaneDisplayLabel(target)} の状態へフォーカス`),
+    );
+    pill.title = getWorkerStatusPillTitle(row, target);
+    pill.onclick = () => focusWorkerPaneFromStatus(target);
+
+    const main = document.createElement("span");
+    main.className = "worker-status-pill-main";
+    main.textContent = getPaneDisplayLabel(target);
+    pill.appendChild(main);
+    pill.appendChild(createWorkerStatusChip("launch", "launch", launchState));
+    if (blocked) {
+      pill.appendChild(createWorkerStatusChip("blocked", "block", "yes"));
+    }
+    pillList.appendChild(pill);
+  }
+
+  if (focusedRow) {
+    const launch = getWorkerStatusLaunch(focusedRow);
+    const target = getWorkerStatusTarget(focusedRow);
+    detailStrip.appendChild(createWorkerStatusChip("role", "role", focusedRow.role || getLaunchApprovalField(launch, "worker_role") || "worker"));
+    detailStrip.appendChild(createWorkerStatusChip("backend", "backend", getLaunchApprovalField(launch, "worker_backend") || focusedRow.backend || "unknown"));
+    detailStrip.appendChild(createWorkerStatusChip("auth", "auth", getWorkerAuthState(focusedRow)));
+    detailStrip.appendChild(createWorkerStatusChip("model-source", "model-src", getWorkerModelSource(focusedRow)));
+    detailStrip.appendChild(createWorkerStatusChip("launch", "launch", getWorkerLaunchState(focusedRow)));
+    detailStrip.appendChild(createWorkerStatusChip("blocked", "blocked", isWorkerStatusBlocked(focusedRow) ? "yes" : "no"));
+    detailStrip.appendChild(createWorkerStatusChip("remote", "remote", getWorkerRemoteState(focusedRow)));
+    detailStrip.appendChild(createWorkerStatusChip("elapsed", "elapsed", formatWorkerCommandElapsed(focusedRow.last_command_at)));
+    detailStrip.appendChild(createWorkerStatusChip("focus", "focus", target === focusedPaneId ? "yes" : "target"));
+  } else {
+    const empty = document.createElement("span");
+    empty.className = "worker-status-detail-empty";
+    empty.textContent = getLanguageText("No worker status yet", "ワーカー状態はまだありません");
+    detailStrip.appendChild(empty);
+  }
+
+  bar.appendChild(pillList);
+  bar.appendChild(detailStrip);
+}
+
+async function refreshWorkerStatusSurface() {
+  if (workerStatusRefreshInFlight) {
+    return workerStatusRefreshInFlight;
+  }
+  if (!isTauri()) {
+    workerStatusRows = getFallbackWorkerStatusRows();
+    workerStatusError = "";
+    renderWorkerStatusSurface();
+    return Promise.resolve();
+  }
+
+  const requestProjectDir = getActiveProjectDirPayload();
+  const requestProjectKey = normalizeProjectDirInput(requestProjectDir) || "";
+  const requestSequence = ++workerStatusRefreshSequence;
+  const isCurrentWorkerStatusRequest = (responseProjectDir?: string | null) => {
+    const currentProjectKey = normalizeProjectDirInput(getActiveProjectDirPayload()) || "";
+    const responseProjectKey = normalizeProjectDirInput(responseProjectDir) || "";
+    return requestSequence === workerStatusRefreshSequence
+      && currentProjectKey === requestProjectKey
+      && (!requestProjectKey || !responseProjectKey || responseProjectKey === requestProjectKey);
+  };
+
+  workerStatusRefreshInFlight = getDesktopWorkersStatus("all", requestProjectDir)
+    .then((payload) => {
+      if (!isCurrentWorkerStatusRequest(payload.project_dir)) {
+        return;
+      }
+      workerStatusRows = payload.workers;
+      workerStatusError = payload.manifest_error ?? "";
+    })
+    .catch((error) => {
+      if (!isCurrentWorkerStatusRequest()) {
+        return;
+      }
+      workerStatusRows = getFallbackWorkerStatusRows();
+      workerStatusError = error instanceof Error ? error.message : String(error);
+      console.warn("Failed to refresh worker status surface", error);
+    })
+    .finally(() => {
+      if (requestSequence === workerStatusRefreshSequence) {
+        workerStatusRefreshInFlight = null;
+        renderWorkerStatusSurface();
+      }
+    });
+  return workerStatusRefreshInFlight;
 }
 
 function getLaunchApprovalField(
@@ -2008,6 +2333,7 @@ function updateWorkbenchControls() {
   const menuLayoutStatus = document.getElementById("menu-layout-status");
 
   drawer?.setAttribute("data-layout", workbenchLayout);
+  drawer?.setAttribute("data-focused-pane", getFocusedWorkbenchPaneId() ?? "");
   syncWorkbenchPaneVisibility();
   syncFocusedPaneSelect();
   if (addButton) {
@@ -2043,6 +2369,7 @@ function updateWorkbenchControls() {
     const paneLabel = paneCount === 1 ? "pane" : "panes";
     menuLayoutStatus.textContent = getLanguageText(`${workbenchLayout} · ${paneCount} ${paneLabel}`, `${workbenchLayout}・${paneCount} ペイン`);
   }
+  renderWorkerStatusSurface();
 }
 
 function normalizeProjectDirInput(value: string | null | undefined) {
@@ -2144,6 +2471,10 @@ function rememberProjectSession(projectDir: string) {
 
 function resetDesktopProjectState() {
   desktopSummarySnapshot = null;
+  workerStatusRows = [];
+  workerStatusError = "";
+  workerStatusRefreshInFlight = null;
+  workerStatusRefreshSequence += 1;
   selectedRunId = null;
   selectedEditorKey = "";
   selectedPreviewUrl = "";
@@ -2188,6 +2519,7 @@ function setActiveProjectDir(projectDir: string | null) {
   renderDesktopSurfaces();
   void refreshProjectExplorerEntries();
   void refreshBrowserSourceControl();
+  void refreshWorkerStatusSurface();
   requestDesktopSummaryRefresh(undefined, 0);
 }
 
@@ -12761,6 +13093,7 @@ function pruneExplainCache(snapshot: DesktopSummarySnapshot, preservedRunId?: st
 
 function renderDesktopSurfaces() {
   renderPaneMetadata();
+  renderWorkerStatusSurface();
   renderSessions();
   renderFooterLane();
   renderRunSummary();
@@ -12973,6 +13306,7 @@ async function refreshDesktopSummary(forceExplainRunId?: string | null) {
       appendRuntimeConversation(item);
     }
     renderDesktopSurfaces();
+    void refreshWorkerStatusSurface();
     } catch (error) {
       console.warn("Failed to load desktop summary snapshot", error);
     } finally {
@@ -13325,12 +13659,15 @@ window.addEventListener("DOMContentLoaded", async () => {
   setTerminalDrawer(true);
   applyPopoutSurfaceState(popoutSurfaceState);
   registerDesktopSummaryLiveRefresh();
+  renderWorkerStatusSurface();
+  void refreshWorkerStatusSurface();
   void refreshDesktopSummary();
   initializeSidebarResize();
   initializeWorkbenchResize();
   initializeSourceControlSplitResize();
   window.setInterval(() => {
     renderPaneMetadata();
+    void refreshWorkerStatusSurface();
   }, PANE_META_REFRESH_INTERVAL_MS);
 
   for (const menuButton of document.querySelectorAll<HTMLButtonElement>(".menu-bar-item")) {

--- a/winsmux-app/src/styles.css
+++ b/winsmux-app/src/styles.css
@@ -3518,7 +3518,7 @@ body[data-popout-surface="1"] #editor-surface {
   z-index: 5;
   overflow: hidden;
   display: grid;
-  grid-template-rows: auto minmax(0, 1fr);
+  grid-template-rows: auto auto minmax(0, 1fr);
   min-width: 0;
   min-height: 0;
   background: #08090b;
@@ -4298,6 +4298,135 @@ body.is-resizing-workbench {
 
 #focused-pane-select[hidden] {
   display: none;
+}
+
+#worker-status-pill-bar {
+  display: grid;
+  grid-template-columns: minmax(176px, 0.55fr) minmax(260px, 1fr);
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  min-height: 38px;
+  padding: 5px 8px;
+  border-bottom: 1px solid #20242d;
+  background: #0c0e12;
+  overflow: hidden;
+}
+
+.worker-status-pill-list,
+.worker-status-detail-strip {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  min-width: 0;
+}
+
+.worker-status-pill-list {
+  flex-wrap: wrap;
+}
+
+.worker-status-detail-strip {
+  flex-wrap: wrap;
+  justify-content: flex-start;
+  overflow: hidden;
+}
+
+@media (max-width: 900px) {
+  #worker-status-pill-bar {
+    grid-template-columns: minmax(0, 1fr);
+    align-items: stretch;
+  }
+}
+
+.worker-status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  flex: 0 0 auto;
+  max-width: 140px;
+  min-height: 26px;
+  border: 1px solid var(--border-muted);
+  border-radius: 4px;
+  background: #111318;
+  color: var(--text-secondary);
+  padding: 3px 5px;
+  font-family: var(--font-code);
+  font-size: var(--text-2xs);
+  line-height: 1.25;
+  cursor: pointer;
+}
+
+.worker-status-pill:hover,
+.worker-status-pill:focus-visible,
+.worker-status-pill[data-focused="true"] {
+  border-color: var(--status-focus-border);
+  background: #151820;
+  color: var(--text-primary);
+}
+
+.worker-status-pill:focus-visible {
+  outline: 1px solid var(--status-focus-border);
+  outline-offset: -1px;
+}
+
+.worker-status-pill[data-tone="success"] {
+  border-color: var(--status-success-border);
+}
+
+.worker-status-pill[data-tone="warning"] {
+  border-color: var(--status-warning-border);
+}
+
+.worker-status-pill[data-tone="danger"] {
+  border-color: var(--status-danger-border);
+}
+
+.worker-status-pill[data-tone="info"] {
+  border-color: var(--status-info-border);
+}
+
+.worker-status-pill-main {
+  font-weight: 700;
+  color: var(--text-primary);
+  white-space: nowrap;
+}
+
+.worker-status-pill-chip {
+  display: inline-flex;
+  align-items: center;
+  min-width: 0;
+  max-width: 116px;
+  border: 1px solid var(--border-muted);
+  border-radius: 3px;
+  background: #1a1d24;
+  color: var(--text-secondary);
+  padding: 1px 5px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.worker-status-pill-chip[data-status-field="blocked"] {
+  color: var(--status-warning);
+  border-color: var(--status-warning-border);
+  background: var(--status-warning-bg);
+}
+
+.worker-status-pill-chip[data-status-field="focus"] {
+  color: var(--status-focus);
+  border-color: var(--status-focus-border);
+  background: var(--status-focus-bg);
+}
+
+.worker-status-pill-chip[data-status-field="remote"] {
+  color: var(--status-info);
+  border-color: var(--status-info-border);
+}
+
+.worker-status-detail-empty {
+  color: var(--text-muted);
+  font-family: var(--font-code);
+  font-size: var(--text-2xs);
 }
 
 #panes-container {


### PR DESCRIPTION
## Summary
- Add a compact worker status surface above the worker panes.
- Show focused-worker detail chips for role, backend, auth, model source, launch state, blocked state, remote/GPU state, elapsed time, and focus target.
- Add real Tauri GUI E2E coverage for fixed viewport blank space, maximize behavior, status pill focus, and PTY output robustness.

## Verification
- cmd /c npm run build
- cargo check --manifest-path winsmux-app\\src-tauri\\Cargo.toml --locked
- cmd /c npm run test:desktop-pane-e2e
- cmd /c npm run test:clickable-coverage
- Invoke-Pester -Path tests\\winsmux-bridge.Tests.ps1 -PassThru
- git diff --check