### PR TITLE
feat: add enterprise approval chain baseline

### DIFF
--- a/core/src/ledger.rs
+++ b/core/src/ledger.rs
@@ -1200,11 +1200,7 @@ impl LedgerSnapshot {
                 .enumerate()
                 .filter(|(_, event)| run.matches_event(event))
                 .collect();
-            matching_events.sort_by(|(left_index, left), (right_index, right)| {
-                left.timestamp
-                    .cmp(&right.timestamp)
-                    .then_with(|| left_index.cmp(right_index))
-            });
+            matching_events.sort_by(compare_event_record_order);
             for (_, event) in matching_events {
                 run.apply_event(event);
             }
@@ -1266,12 +1262,7 @@ impl LedgerSnapshot {
             .enumerate()
             .filter(|(_, event)| event_matches_explain_run(event, &evidence_digest, &panes))
             .collect();
-        recent_events.sort_by(|(left_index, left), (right_index, right)| {
-            right
-                .timestamp
-                .cmp(&left.timestamp)
-                .then_with(|| right_index.cmp(left_index))
-        });
+        recent_events.sort_by(compare_event_record_order_desc);
         let recent_event_records = recent_events.clone();
         let recent_events: Vec<_> = recent_events
             .into_iter()
@@ -2144,11 +2135,7 @@ fn run_phase_gate_value(
     let mut stop_reason = String::new();
     let mut stop_stage = String::new();
     let mut ordered_events = events.to_vec();
-    ordered_events.sort_by(|(left_index, left), (right_index, right)| {
-        left.timestamp
-            .cmp(&right.timestamp)
-            .then_with(|| left_index.cmp(right_index))
-    });
+    ordered_events.sort_by(compare_event_record_order);
 
     for (_, event) in ordered_events {
         match event.event.as_str() {
@@ -2363,11 +2350,7 @@ fn run_requires_tdd_gate(run: &LedgerExplainRun) -> bool {
 fn run_tdd_gate_value(run: &LedgerExplainRun, events: &[(usize, &EventRecord)]) -> Value {
     let required = run_requires_tdd_gate(run);
     let mut ordered_events = events.to_vec();
-    ordered_events.sort_by(|(left_index, left), (right_index, right)| {
-        left.timestamp
-            .cmp(&right.timestamp)
-            .then_with(|| left_index.cmp(right_index))
-    });
+    ordered_events.sort_by(compare_event_record_order);
 
     let red_event = ordered_events.iter().find(|(_, event)| {
         matches!(
@@ -2558,18 +2541,297 @@ fn run_draft_pr_handoff_package_value(run: &LedgerExplainRun, draft_pr_url: &str
     })
 }
 
+fn run_enterprise_approval_chain_required(run: &LedgerExplainRun) -> bool {
+    if !run.review_required {
+        return false;
+    }
+
+    let context_mode = value_field_string(&run.context_contract, "context_mode");
+    let mut execution_profile = value_field_string(&run.security_policy, "execution_profile");
+    if execution_profile.trim().is_empty() {
+        execution_profile = value_field_string(&run.security_policy, "profile");
+    }
+    let provider_target = run.provider_target.to_ascii_lowercase();
+
+    context_mode.eq_ignore_ascii_case("enterprise")
+        || execution_profile.eq_ignore_ascii_case("isolated-enterprise")
+        || provider_target.contains("enterprise")
+}
+
+fn latest_audit_event_by_name<'a>(
+    events: &'a [(usize, &EventRecord)],
+    names: &[&str],
+) -> Option<&'a EventRecord> {
+    events
+        .iter()
+        .filter(|(_, event)| names.contains(&event.event.as_str()))
+        .max_by(|left, right| compare_event_record_order(*left, *right))
+        .map(|(_, event)| *event)
+}
+
+fn is_final_approval_denied_event(event: &str) -> bool {
+    matches!(
+        event,
+        "operator.final_approval_denied"
+            | "operator.approval_denied"
+            | "operator.human_approval_denied"
+    )
+}
+
+fn approval_actor_separated(run: &LedgerExplainRun, event: Option<&EventRecord>) -> bool {
+    let Some(event) = event else {
+        return false;
+    };
+
+    if event.label.trim().is_empty()
+        && event.pane_id.trim().is_empty()
+        && event.role.trim().is_empty()
+    {
+        return false;
+    }
+
+    if !run.primary_label.trim().is_empty() && run.primary_label.eq_ignore_ascii_case(&event.label)
+    {
+        return false;
+    }
+    if !run.primary_pane_id.trim().is_empty()
+        && run.primary_pane_id.eq_ignore_ascii_case(&event.pane_id)
+    {
+        return false;
+    }
+    if event.role.eq_ignore_ascii_case("Builder") {
+        return false;
+    }
+    if !run.primary_role.trim().is_empty() && run.primary_role.eq_ignore_ascii_case(&event.role) {
+        return false;
+    }
+    true
+}
+
+fn approval_stage_value(
+    name: &str,
+    state: &str,
+    required: bool,
+    evidence: &str,
+    requested_event: &str,
+    decided_event: &str,
+    actor_separation_required: bool,
+    actor_separation_satisfied: bool,
+) -> Value {
+    json!({
+        "name": name,
+        "required": required,
+        "state": state,
+        "evidence": evidence,
+        "requested_event": requested_event,
+        "decided_event": decided_event,
+        "actor_separation_required": actor_separation_required,
+        "actor_separation_satisfied": actor_separation_satisfied,
+        "builder_can_approve_itself": false,
+    })
+}
+
+fn approval_stage_blocked_reasons(approval: &Value) -> Vec<String> {
+    approval
+        .get("stages")
+        .and_then(Value::as_array)
+        .map(|stages| {
+            stages
+                .iter()
+                .filter(|stage| {
+                    stage
+                        .get("required")
+                        .and_then(Value::as_bool)
+                        .unwrap_or(false)
+                })
+                .filter_map(|stage| {
+                    let stage_name = value_field_string(stage, "name");
+                    if stage_name == "static_verification" {
+                        return None;
+                    }
+                    let state = value_field_string(stage, "state");
+                    if state == "missing" {
+                        Some(format!("approval stage {stage_name} is missing"))
+                    } else if state == "failed" {
+                        let actor_separation_required = stage
+                            .get("actor_separation_required")
+                            .and_then(Value::as_bool)
+                            .unwrap_or(false);
+                        let actor_separation_satisfied = stage
+                            .get("actor_separation_satisfied")
+                            .and_then(Value::as_bool)
+                            .unwrap_or(false);
+                        if actor_separation_required && !actor_separation_satisfied {
+                            Some(format!(
+                                "approval stage {stage_name} violates actor separation"
+                            ))
+                        } else {
+                            Some(format!("approval stage {stage_name} failed"))
+                        }
+                    } else {
+                        None
+                    }
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn aggregate_enterprise_approval_state(stages: &[Value]) -> &'static str {
+    let mut has_required_stage = false;
+    let mut has_missing_stage = false;
+    let mut has_pending_stage = false;
+
+    for stage in stages {
+        let required = stage
+            .get("required")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        if !required {
+            continue;
+        }
+        has_required_stage = true;
+        match value_field_string(stage, "state").as_str() {
+            "approved" => {}
+            "failed" => return "failed",
+            "missing" | "" => has_missing_stage = true,
+            "pending" => has_pending_stage = true,
+            _ => has_pending_stage = true,
+        }
+    }
+
+    if has_missing_stage {
+        "missing"
+    } else if has_pending_stage {
+        "pending"
+    } else if has_required_stage {
+        "approved"
+    } else {
+        "not_required"
+    }
+}
+
 fn run_audit_chain_value(run: &LedgerExplainRun, events: &[(usize, &EventRecord)]) -> Value {
     let mut ordered_events = events.to_vec();
-    ordered_events.sort_by(|(left_index, left), (right_index, right)| {
-        left.timestamp
-            .cmp(&right.timestamp)
-            .then_with(|| left_index.cmp(right_index))
-    });
+    ordered_events.sort_by(compare_event_record_order);
     let review_request = ordered_events
         .iter()
         .map(|(_, event)| *event)
         .find(|event| event.event == "operator.review_requested");
     let decision_event = run_audit_chain_decision_event(run, &ordered_events);
+    let final_approval_decision = latest_audit_event_by_name(
+        &ordered_events,
+        &[
+            "operator.final_approval_granted",
+            "operator.final_approval_denied",
+            "operator.approval_granted",
+            "operator.approval_denied",
+            "operator.human_approval_granted",
+            "operator.human_approval_denied",
+        ],
+    );
+    let enterprise_approval_required = run_enterprise_approval_chain_required(run);
+    let review_approval_state = audit_chain_approval_state(&run.review_state, run.review_required);
+    let verification_outcome = value_field_string(&run.verification_result, "outcome");
+    let security_verdict = first_non_empty(
+        &value_field_string(&run.security_verdict, "verdict"),
+        run.security_verdict.as_str().unwrap_or_default(),
+    )
+    .to_string();
+    let final_approval_separated = approval_actor_separated(run, final_approval_decision);
+    let operator_review_separated = approval_actor_separated(run, decision_event);
+    let final_approval_state = if final_approval_decision
+        .map(|event| is_final_approval_denied_event(&event.event))
+        .unwrap_or(false)
+    {
+        "failed"
+    } else if final_approval_decision.is_some() && final_approval_separated {
+        "approved"
+    } else if final_approval_decision.is_some() {
+        "failed"
+    } else {
+        "missing"
+    };
+    let operator_review_stage_state =
+        if review_approval_state == "approved" && !operator_review_separated {
+            "failed"
+        } else {
+            review_approval_state
+        };
+    let review_requested_event = review_request
+        .map(|event| event.event.clone())
+        .unwrap_or_default();
+    let review_decided_event = decision_event
+        .map(|event| event.event.clone())
+        .unwrap_or_default();
+    let final_decided_event = final_approval_decision
+        .map(|event| event.event.clone())
+        .unwrap_or_default();
+    let approval_stages = if enterprise_approval_required {
+        let verification_stage_state = if verification_outcome.trim().is_empty() {
+            "missing"
+        } else if verification_outcome == "PASS" {
+            "approved"
+        } else {
+            "failed"
+        };
+        let policy_stage_state = if security_verdict == "BLOCK" {
+            "failed"
+        } else if security_verdict.trim().is_empty() {
+            "missing"
+        } else {
+            "approved"
+        };
+        vec![
+            approval_stage_value(
+                "static_verification",
+                verification_stage_state,
+                true,
+                "verification_result.outcome",
+                "",
+                "pipeline.verify.*",
+                false,
+                false,
+            ),
+            approval_stage_value(
+                "policy_gate",
+                policy_stage_state,
+                true,
+                "security_verdict.verdict",
+                "",
+                "pipeline.security.*",
+                false,
+                false,
+            ),
+            approval_stage_value(
+                "operator_review",
+                operator_review_stage_state,
+                run.review_required,
+                "review_state",
+                &review_requested_event,
+                &review_decided_event,
+                true,
+                operator_review_separated,
+            ),
+            approval_stage_value(
+                "human_final_approval",
+                final_approval_state,
+                true,
+                "operator.final_approval_granted",
+                "",
+                &final_decided_event,
+                true,
+                final_approval_separated,
+            ),
+        ]
+    } else {
+        Vec::new()
+    };
+    let approval_state = if enterprise_approval_required {
+        aggregate_enterprise_approval_state(&approval_stages)
+    } else {
+        review_approval_state
+    };
     let chain_events: Vec<_> = ordered_events
         .iter()
         .filter(|(_, event)| is_audit_chain_event(&event.event))
@@ -2601,8 +2863,11 @@ fn run_audit_chain_value(run: &LedgerExplainRun, events: &[(usize, &EventRecord)
         },
         "approval": {
             "required": run.review_required,
-            "state": audit_chain_approval_state(&run.review_state, run.review_required),
+            "state": approval_state,
             "verdict": run.review_state,
+            "mode": if enterprise_approval_required { "enterprise_multi_stage" } else { "single_review" },
+            "chain_required": enterprise_approval_required,
+            "final_approval_required": enterprise_approval_required,
             "requested_at": review_request.map(|event| event_timestamp_text(&event.timestamp)).unwrap_or_default(),
             "requested_event": review_request.map(|event| event.event.clone()).unwrap_or_default(),
             "requested_reviewer_label": review_request.map(|event| event.label.clone()).unwrap_or_default(),
@@ -2612,6 +2877,8 @@ fn run_audit_chain_value(run: &LedgerExplainRun, events: &[(usize, &EventRecord)
             "decided_event": decision_event.map(|event| event.event.clone()).unwrap_or_default(),
             "human_judgement_required": run.review_required,
             "automatic_merge_allowed": false,
+            "builder_can_approve_itself": false,
+            "stages": approval_stages,
         },
         "events": chain_events,
     })
@@ -2652,8 +2919,9 @@ fn run_audit_chain_decision_event<'a>(
 
     events
         .iter()
+        .filter(|(_, event)| decision_events.contains(&event.event.as_str()))
+        .max_by(|left, right| compare_event_record_order(*left, *right))
         .map(|(_, event)| *event)
-        .find(|event| decision_events.contains(&event.event.as_str()))
 }
 
 fn is_audit_chain_event(event: &str) -> bool {
@@ -2662,6 +2930,12 @@ fn is_audit_chain_event(event: &str) -> bool {
         "operator.review_requested"
             | "operator.review_passed"
             | "operator.review_failed"
+            | "operator.final_approval_granted"
+            | "operator.final_approval_denied"
+            | "operator.approval_granted"
+            | "operator.approval_denied"
+            | "operator.human_approval_granted"
+            | "operator.human_approval_denied"
             | "review.pass"
             | "review.fail"
             | "pane.approval_waiting"
@@ -2762,6 +3036,7 @@ fn run_verification_envelope_value(run: &LedgerExplainRun) -> Value {
             first_non_empty(&approval_state, &run.review_state)
         ));
     }
+    blocked_reasons.extend(approval_stage_blocked_reasons(&approval));
     if !draft_pr_gate_state.trim().is_empty() && draft_pr_gate_state != "passed" {
         blocked_reasons.push(format!("draft PR gate is {draft_pr_gate_state}"));
     }
@@ -2860,6 +3135,32 @@ fn event_timestamp_text(timestamp: &str) -> String {
                 .to_rfc3339_opts(SecondsFormat::Secs, true)
         })
         .unwrap_or_else(|_| timestamp.to_string())
+}
+
+fn event_timestamp_sort_key(timestamp: &str) -> String {
+    DateTime::parse_from_rfc3339(timestamp)
+        .map(|value| {
+            value
+                .with_timezone(&Utc)
+                .to_rfc3339_opts(SecondsFormat::Nanos, true)
+        })
+        .unwrap_or_else(|_| timestamp.to_string())
+}
+
+fn compare_event_record_order(
+    left: &(usize, &EventRecord),
+    right: &(usize, &EventRecord),
+) -> Ordering {
+    event_timestamp_sort_key(&left.1.timestamp)
+        .cmp(&event_timestamp_sort_key(&right.1.timestamp))
+        .then_with(|| left.0.cmp(&right.0))
+}
+
+fn compare_event_record_order_desc(
+    left: &(usize, &EventRecord),
+    right: &(usize, &EventRecord),
+) -> Ordering {
+    compare_event_record_order(right, left)
 }
 
 fn run_outcome_value(run: &LedgerExplainRun, phase_gate: &Value, draft_pr_gate: &Value) -> Value {
@@ -4243,7 +4544,10 @@ fn compare_inbox_items(left: &LedgerInboxItem, right: &LedgerInboxItem) -> Order
     left.priority
         .cmp(&right.priority)
         .then_with(|| inbox_source_rank(&left.source).cmp(&inbox_source_rank(&right.source)))
-        .then_with(|| right.timestamp.cmp(&left.timestamp))
+        .then_with(|| {
+            event_timestamp_sort_key(&right.timestamp)
+                .cmp(&event_timestamp_sort_key(&left.timestamp))
+        })
         .then_with(|| left.label.cmp(&right.label))
 }
 

--- a/core/tests-rs/ledger_contract.rs
+++ b/core/tests-rs/ledger_contract.rs
@@ -1118,11 +1118,13 @@ panes:
         explain.run.verification_envelope["static_gates"]["required_fields"][0],
         "verification_evidence"
     );
-    assert!(explain.run.verification_envelope["static_gates"]["required_fields"]
-        .as_array()
-        .expect("required fields should be an array")
-        .iter()
-        .any(|item| item.as_str().unwrap_or_default() == "architecture_contract"));
+    assert!(
+        explain.run.verification_envelope["static_gates"]["required_fields"]
+            .as_array()
+            .expect("required fields should be an array")
+            .iter()
+            .any(|item| item.as_str().unwrap_or_default() == "architecture_contract")
+    );
     assert_eq!(
         explain.run.verification_envelope["dynamic_gates"]["context"]["context_mode"],
         "isolated"
@@ -1166,16 +1168,20 @@ panes:
             .iter()
             .any(|reason| reason == "draft PR gate is blocked")
     );
-    assert!(explain.run.verification_envelope["release_decision"]["blocked_reasons"]
-        .as_array()
-        .expect("blocked reasons should be an array")
-        .iter()
-        .any(|reason| reason == "architecture baseline mismatch requires review"));
-    assert!(explain.run.draft_pr_gate["handoff_package"]["blocked_reasons"]
-        .as_array()
-        .expect("draft PR blocked reasons should be an array")
-        .iter()
-        .any(|reason| reason == "architecture baseline mismatch requires review"));
+    assert!(
+        explain.run.verification_envelope["release_decision"]["blocked_reasons"]
+            .as_array()
+            .expect("blocked reasons should be an array")
+            .iter()
+            .any(|reason| reason == "architecture baseline mismatch requires review")
+    );
+    assert!(
+        explain.run.draft_pr_gate["handoff_package"]["blocked_reasons"]
+            .as_array()
+            .expect("draft PR blocked reasons should be an array")
+            .iter()
+            .any(|reason| reason == "architecture baseline mismatch requires review")
+    );
     assert!(explain.run.audit_chain["events"]
         .as_array()
         .expect("audit chain events should be an array")
@@ -1252,10 +1258,7 @@ panes:
         explain.run.architecture_contract["status"],
         "baseline_match"
     );
-    assert_eq!(
-        explain.run.architecture_contract["score_regression"],
-        false
-    );
+    assert_eq!(explain.run.architecture_contract["score_regression"], false);
 }
 
 #[test]
@@ -1684,6 +1687,323 @@ panes:
         gated_run["verification_envelope"]["dynamic_gates"]["phase"]["stop_stage"],
         "package"
     );
+}
+
+#[test]
+fn ledger_contract_requires_final_human_approval_for_enterprise_chain() {
+    let manifest = r#"
+version: 1
+session:
+  name: winsmux-orchestra
+panes:
+  builder-1:
+    pane_id: "%2"
+    role: Builder
+    task_id: task-enterprise-approval
+    task: Implement enterprise approval chain
+    task_state: completed
+    review_state: PASS
+    branch: worktree-enterprise-approval
+    head_sha: abc1234def5678
+    review_required: true
+    provider_target: enterprise:isolated
+    verification_plan: ["cargo test"]
+"#;
+    let events = r#"{"timestamp":"2026-05-16T12:00:00+09:00","session":"winsmux-orchestra","event":"operator.review_requested","message":"review requested","label":"reviewer-1","pane_id":"%3","role":"Reviewer","data":{"task_id":"task-enterprise-approval"}}
+{"timestamp":"2026-05-16T12:01:00+09:00","session":"winsmux-orchestra","event":"operator.review_passed","message":"review passed","label":"reviewer-1","pane_id":"%3","role":"Reviewer","data":{"task_id":"task-enterprise-approval"}}
+{"timestamp":"2026-05-16T12:02:00+09:00","session":"winsmux-orchestra","event":"pipeline.verify.pass","message":"verification passed","status":"completed","data":{"task_id":"task-enterprise-approval","verification_result":{"outcome":"PASS","summary":"tests passed"}}}
+{"timestamp":"2026-05-16T12:03:00+09:00","session":"winsmux-orchestra","event":"pipeline.security.allowed","message":"security allowed","status":"ALLOW","data":{"task_id":"task-enterprise-approval","security_verdict":{"verdict":"ALLOW","reason":"policy passed"}}}
+"#;
+
+    let snapshot = ledger::LedgerSnapshot::from_manifest_and_events(manifest, events)
+        .expect("ledger snapshot should load enterprise approval inputs");
+    let explain = snapshot
+        .explain_projection("task:task-enterprise-approval")
+        .expect("enterprise run should explain");
+
+    assert_eq!(
+        explain.run.audit_chain["approval"]["mode"],
+        "enterprise_multi_stage"
+    );
+    assert_eq!(explain.run.audit_chain["approval"]["chain_required"], true);
+    assert_eq!(explain.run.audit_chain["approval"]["state"], "missing");
+    let stages = explain.run.audit_chain["approval"]["stages"]
+        .as_array()
+        .expect("approval stages should be an array");
+    assert_eq!(stages.len(), 4);
+    assert!(stages
+        .iter()
+        .any(|stage| stage["name"] == "human_final_approval" && stage["state"] == "missing"));
+    let reasons = explain.run.verification_envelope["release_decision"]["blocked_reasons"]
+        .as_array()
+        .expect("blocked reasons should be an array");
+    assert!(reasons
+        .iter()
+        .any(|reason| reason == "approval stage human_final_approval is missing"));
+}
+
+#[test]
+fn ledger_contract_rejects_builder_as_enterprise_final_approver() {
+    let manifest = r#"
+version: 1
+session:
+  name: winsmux-orchestra
+panes:
+  builder-1:
+    pane_id: "%2"
+    role: Builder
+    task_id: task-enterprise-self-approval
+    task: Implement enterprise approval chain
+    task_state: completed
+    review_state: PASS
+    branch: worktree-enterprise-approval
+    head_sha: abc1234def5678
+    review_required: true
+    provider_target: enterprise:isolated
+    verification_plan: ["cargo test"]
+"#;
+    let events = r#"{"timestamp":"2026-05-16T12:00:00+09:00","session":"winsmux-orchestra","event":"operator.review_requested","message":"review requested","label":"reviewer-1","pane_id":"%3","role":"Reviewer","data":{"task_id":"task-enterprise-self-approval"}}
+{"timestamp":"2026-05-16T12:01:00+09:00","session":"winsmux-orchestra","event":"operator.review_passed","message":"review passed","label":"reviewer-1","pane_id":"%3","role":"Reviewer","data":{"task_id":"task-enterprise-self-approval"}}
+{"timestamp":"2026-05-16T12:02:00+09:00","session":"winsmux-orchestra","event":"pipeline.verify.pass","message":"verification passed","status":"completed","data":{"task_id":"task-enterprise-self-approval","verification_result":{"outcome":"PASS","summary":"tests passed"}}}
+{"timestamp":"2026-05-16T12:03:00+09:00","session":"winsmux-orchestra","event":"pipeline.security.allowed","message":"security allowed","status":"ALLOW","data":{"task_id":"task-enterprise-self-approval","security_verdict":{"verdict":"ALLOW","reason":"policy passed"}}}
+{"timestamp":"2026-05-16T12:04:00+09:00","session":"winsmux-orchestra","event":"operator.final_approval_granted","message":"final approval granted","label":"builder-1","pane_id":"%2","role":"Builder","data":{"task_id":"task-enterprise-self-approval"}}
+"#;
+
+    let snapshot = ledger::LedgerSnapshot::from_manifest_and_events(manifest, events)
+        .expect("ledger snapshot should load enterprise self-approval inputs");
+    let explain = snapshot
+        .explain_projection("task:task-enterprise-self-approval")
+        .expect("enterprise self-approval run should explain");
+
+    let stages = explain.run.audit_chain["approval"]["stages"]
+        .as_array()
+        .expect("approval stages should be an array");
+    assert_eq!(explain.run.audit_chain["approval"]["state"], "failed");
+    assert!(stages.iter().any(|stage| {
+        stage["name"] == "human_final_approval"
+            && stage["state"] == "failed"
+            && stage["actor_separation_satisfied"] == false
+    }));
+    let reasons = explain.run.verification_envelope["release_decision"]["blocked_reasons"]
+        .as_array()
+        .expect("blocked reasons should be an array");
+    assert!(reasons
+        .iter()
+        .any(|reason| reason == "approval stage human_final_approval violates actor separation"));
+}
+
+#[test]
+fn ledger_contract_rejects_blank_enterprise_final_approver() {
+    let manifest = r#"
+version: 1
+session:
+  name: winsmux-orchestra
+panes:
+  builder-1:
+    pane_id: "%2"
+    role: Builder
+    task_id: task-enterprise-blank-final-approval
+    task: Implement enterprise approval chain
+    task_state: completed
+    review_state: PASS
+    branch: worktree-enterprise-approval
+    head_sha: abc1234def5678
+    review_required: true
+    provider_target: enterprise:isolated
+    verification_plan: ["cargo test"]
+"#;
+    let events = r#"{"timestamp":"2026-05-16T12:00:00+09:00","session":"winsmux-orchestra","event":"operator.review_requested","message":"review requested","label":"reviewer-1","pane_id":"%3","role":"Reviewer","data":{"task_id":"task-enterprise-blank-final-approval"}}
+{"timestamp":"2026-05-16T12:01:00+09:00","session":"winsmux-orchestra","event":"operator.review_passed","message":"review passed","label":"reviewer-1","pane_id":"%3","role":"Reviewer","data":{"task_id":"task-enterprise-blank-final-approval"}}
+{"timestamp":"2026-05-16T12:02:00+09:00","session":"winsmux-orchestra","event":"pipeline.verify.pass","message":"verification passed","status":"completed","data":{"task_id":"task-enterprise-blank-final-approval","verification_result":{"outcome":"PASS","summary":"tests passed"}}}
+{"timestamp":"2026-05-16T12:03:00+09:00","session":"winsmux-orchestra","event":"pipeline.security.allowed","message":"security allowed","status":"ALLOW","data":{"task_id":"task-enterprise-blank-final-approval","security_verdict":{"verdict":"ALLOW","reason":"policy passed"}}}
+{"timestamp":"2026-05-16T12:04:00+09:00","session":"winsmux-orchestra","event":"operator.final_approval_granted","message":"final approval granted","data":{"task_id":"task-enterprise-blank-final-approval"}}
+"#;
+
+    let snapshot = ledger::LedgerSnapshot::from_manifest_and_events(manifest, events)
+        .expect("ledger snapshot should load blank final approver inputs");
+    let explain = snapshot
+        .explain_projection("task:task-enterprise-blank-final-approval")
+        .expect("enterprise blank final approval run should explain");
+
+    let stages = explain.run.audit_chain["approval"]["stages"]
+        .as_array()
+        .expect("approval stages should be an array");
+    assert_eq!(explain.run.audit_chain["approval"]["state"], "failed");
+    assert!(stages.iter().any(|stage| {
+        stage["name"] == "human_final_approval"
+            && stage["state"] == "failed"
+            && stage["actor_separation_satisfied"] == false
+    }));
+    let reasons = explain.run.verification_envelope["release_decision"]["blocked_reasons"]
+        .as_array()
+        .expect("blocked reasons should be an array");
+    assert!(reasons
+        .iter()
+        .any(|reason| reason == "approval stage human_final_approval violates actor separation"));
+}
+
+#[test]
+fn ledger_contract_rejects_builder_as_enterprise_review_approver() {
+    let manifest = r#"
+version: 1
+session:
+  name: winsmux-orchestra
+panes:
+  builder-1:
+    pane_id: "%2"
+    role: Builder
+    task_id: task-enterprise-review-self-approval
+    task: Implement enterprise approval chain
+    task_state: commit_ready
+    review_state: PASS
+    branch: worktree-enterprise-approval
+    head_sha: abc1234def5678
+    review_required: true
+    provider_target: enterprise:isolated
+    verification_plan: ["cargo test"]
+"#;
+    let events = r#"{"timestamp":"2026-05-16T12:00:00+09:00","session":"winsmux-orchestra","event":"operator.review_requested","message":"review requested","label":"reviewer-1","pane_id":"%3","role":"Reviewer","data":{"task_id":"task-enterprise-review-self-approval"}}
+{"timestamp":"2026-05-16T12:01:00+09:00","session":"winsmux-orchestra","event":"operator.review_passed","message":"review passed","label":"builder-1","pane_id":"%2","role":"Builder","data":{"task_id":"task-enterprise-review-self-approval"}}
+{"timestamp":"2026-05-16T12:02:00+09:00","session":"winsmux-orchestra","event":"pipeline.verify.pass","message":"verification passed","status":"completed","data":{"task_id":"task-enterprise-review-self-approval","verification_result":{"outcome":"PASS","summary":"tests passed"}}}
+{"timestamp":"2026-05-16T12:03:00+09:00","session":"winsmux-orchestra","event":"pipeline.security.allowed","message":"security allowed","status":"ALLOW","data":{"task_id":"task-enterprise-review-self-approval","security_verdict":{"verdict":"ALLOW","reason":"policy passed"}}}
+{"timestamp":"2026-05-16T12:04:00+09:00","session":"winsmux-orchestra","event":"operator.final_approval_granted","message":"final approval granted","label":"operator-1","pane_id":"%1","role":"Operator","data":{"task_id":"task-enterprise-review-self-approval"}}
+{"timestamp":"2026-05-16T12:05:00+09:00","session":"winsmux-orchestra","event":"operator.draft_pr.created","message":"draft PR created","head_sha":"abc1234def5678","data":{"task_id":"task-enterprise-review-self-approval","draft_pr_url":"https://github.com/Sora-bluesky/winsmux/pull/999"}}
+"#;
+
+    let snapshot = ledger::LedgerSnapshot::from_manifest_and_events(manifest, events)
+        .expect("ledger snapshot should load enterprise review self-approval inputs");
+    let explain = snapshot
+        .explain_projection("task:task-enterprise-review-self-approval")
+        .expect("enterprise review self-approval run should explain");
+
+    let stages = explain.run.audit_chain["approval"]["stages"]
+        .as_array()
+        .expect("approval stages should be an array");
+    assert_eq!(explain.run.audit_chain["approval"]["state"], "failed");
+    assert!(stages.iter().any(|stage| {
+        stage["name"] == "operator_review"
+            && stage["state"] == "failed"
+            && stage["actor_separation_satisfied"] == false
+    }));
+    let reasons = explain.run.verification_envelope["release_decision"]["blocked_reasons"]
+        .as_array()
+        .expect("blocked reasons should be an array");
+    assert!(reasons
+        .iter()
+        .any(|reason| reason == "approval stage operator_review violates actor separation"));
+}
+
+#[test]
+fn ledger_contract_allows_separated_enterprise_final_approver() {
+    let manifest = r#"
+version: 1
+session:
+  name: winsmux-orchestra
+panes:
+  builder-1:
+    pane_id: "%2"
+    role: Builder
+    task_id: task-enterprise-separated-approval
+    task: Implement enterprise approval chain
+    task_state: commit_ready
+    review_state: PASS
+    branch: worktree-enterprise-approval
+    head_sha: abc1234def5678
+    review_required: true
+    provider_target: enterprise:isolated
+    verification_plan: ["cargo test"]
+"#;
+    let events = r#"{"timestamp":"2026-05-16T12:00:00+09:00","session":"winsmux-orchestra","event":"operator.review_requested","message":"review requested","label":"reviewer-1","pane_id":"%3","role":"Reviewer","data":{"task_id":"task-enterprise-separated-approval"}}
+{"timestamp":"2026-05-16T12:01:00+09:00","session":"winsmux-orchestra","event":"operator.review_passed","message":"review passed","label":"builder-1","pane_id":"%2","role":"Builder","data":{"task_id":"task-enterprise-separated-approval"}}
+{"timestamp":"2026-05-16T03:02:00Z","session":"winsmux-orchestra","event":"operator.review_passed","message":"review passed","label":"reviewer-1","pane_id":"%3","role":"Reviewer","data":{"task_id":"task-enterprise-separated-approval"}}
+{"timestamp":"2026-05-16T12:03:00+09:00","session":"winsmux-orchestra","event":"pipeline.verify.pass","message":"verification passed","status":"completed","data":{"task_id":"task-enterprise-separated-approval","verification_result":{"outcome":"PASS","summary":"tests passed"}}}
+{"timestamp":"2026-05-16T12:04:00+09:00","session":"winsmux-orchestra","event":"pipeline.security.allowed","message":"security allowed","status":"ALLOW","data":{"task_id":"task-enterprise-separated-approval","security_verdict":{"verdict":"ALLOW","reason":"policy passed"}}}
+{"timestamp":"2026-05-16T12:05:00+09:00","session":"winsmux-orchestra","event":"operator.final_approval_denied","message":"final approval denied","label":"operator-1","pane_id":"%1","role":"Operator","data":{"task_id":"task-enterprise-separated-approval"}}
+{"timestamp":"2026-05-16T03:06:00Z","session":"winsmux-orchestra","event":"operator.final_approval_granted","message":"final approval granted","label":"operator-1","pane_id":"%1","role":"Operator","data":{"task_id":"task-enterprise-separated-approval"}}
+{"timestamp":"2026-05-16T12:07:00+09:00","session":"winsmux-orchestra","event":"operator.draft_pr.created","message":"draft PR created","head_sha":"abc1234def5678","data":{"task_id":"task-enterprise-separated-approval","draft_pr_url":"https://github.com/Sora-bluesky/winsmux/pull/999"}}
+"#;
+
+    let snapshot = ledger::LedgerSnapshot::from_manifest_and_events(manifest, events)
+        .expect("ledger snapshot should load separated enterprise approval inputs");
+    let explain = snapshot
+        .explain_projection("task:task-enterprise-separated-approval")
+        .expect("enterprise separated approval run should explain");
+
+    let stages = explain.run.audit_chain["approval"]["stages"]
+        .as_array()
+        .expect("approval stages should be an array");
+    assert_eq!(explain.run.audit_chain["approval"]["state"], "approved");
+    assert!(stages.iter().any(|stage| {
+        stage["name"] == "operator_review"
+            && stage["state"] == "approved"
+            && stage["actor_separation_satisfied"] == true
+    }));
+    assert!(stages.iter().any(|stage| {
+        stage["name"] == "human_final_approval"
+            && stage["state"] == "approved"
+            && stage["decided_event"] == "operator.final_approval_granted"
+            && stage["actor_separation_satisfied"] == true
+    }));
+    assert_eq!(
+        explain.run.verification_envelope["release_decision"]["status"], "approved",
+        "blocked reasons: {:?}",
+        explain.run.verification_envelope["release_decision"]["blocked_reasons"]
+    );
+    assert_eq!(
+        explain.run.verification_envelope["release_decision"]["blocked_reasons"]
+            .as_array()
+            .expect("blocked reasons should be an array")
+            .len(),
+        0
+    );
+}
+
+#[test]
+fn ledger_contract_marks_failed_enterprise_verification_stage_failed() {
+    let manifest = r#"
+version: 1
+session:
+  name: winsmux-orchestra
+panes:
+  builder-1:
+    pane_id: "%2"
+    role: Builder
+    task_id: task-enterprise-verify-fail
+    task: Implement enterprise approval chain
+    task_state: commit_ready
+    review_state: PASS
+    branch: worktree-enterprise-approval
+    head_sha: abc1234def5678
+    review_required: true
+    provider_target: enterprise:isolated
+    verification_plan: ["cargo test"]
+"#;
+    let events = r#"{"timestamp":"2026-05-16T12:00:00+09:00","session":"winsmux-orchestra","event":"operator.review_requested","message":"review requested","label":"reviewer-1","pane_id":"%3","role":"Reviewer","data":{"task_id":"task-enterprise-verify-fail"}}
+{"timestamp":"2026-05-16T12:01:00+09:00","session":"winsmux-orchestra","event":"operator.review_passed","message":"review passed","label":"reviewer-1","pane_id":"%3","role":"Reviewer","data":{"task_id":"task-enterprise-verify-fail"}}
+{"timestamp":"2026-05-16T12:02:00+09:00","session":"winsmux-orchestra","event":"pipeline.verify.fail","message":"verification failed","status":"failed","data":{"task_id":"task-enterprise-verify-fail","verification_result":{"outcome":"FAIL","summary":"tests failed"}}}
+{"timestamp":"2026-05-16T12:03:00+09:00","session":"winsmux-orchestra","event":"pipeline.security.allowed","message":"security allowed","status":"ALLOW","data":{"task_id":"task-enterprise-verify-fail","security_verdict":{"verdict":"ALLOW","reason":"policy passed"}}}
+{"timestamp":"2026-05-16T12:04:00+09:00","session":"winsmux-orchestra","event":"operator.final_approval_granted","message":"final approval granted","label":"operator-1","pane_id":"%1","role":"Operator","data":{"task_id":"task-enterprise-verify-fail"}}
+"#;
+
+    let snapshot = ledger::LedgerSnapshot::from_manifest_and_events(manifest, events)
+        .expect("ledger snapshot should load failed verification enterprise inputs");
+    let explain = snapshot
+        .explain_projection("task:task-enterprise-verify-fail")
+        .expect("enterprise failed verification run should explain");
+
+    let stages = explain.run.audit_chain["approval"]["stages"]
+        .as_array()
+        .expect("approval stages should be an array");
+    assert_eq!(explain.run.audit_chain["approval"]["state"], "failed");
+    assert!(stages
+        .iter()
+        .any(|stage| stage["name"] == "static_verification" && stage["state"] == "failed"));
+    let reasons = explain.run.verification_envelope["release_decision"]["blocked_reasons"]
+        .as_array()
+        .expect("blocked reasons should be an array");
+    assert!(reasons
+        .iter()
+        .any(|reason| reason == "verification outcome is FAIL"));
 }
 
 #[test]

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -11027,6 +11027,184 @@ function ConvertTo-RunAuditChainApprovalState {
     return 'not_required'
 }
 
+function Test-RunEnterpriseApprovalChainRequired {
+    param([Parameter(Mandatory = $true)]$Run)
+
+    if (-not [bool]$Run.review_required) {
+        return $false
+    }
+
+    $contextContract = Get-RunContractField -InputObject $Run -Name 'context_contract'
+    $contextMode = [string](Get-RunContractField -InputObject $contextContract -Name 'context_mode')
+    $securityPolicy = Get-RunContractField -InputObject $Run -Name 'security_policy'
+    $executionProfile = [string](Get-RunContractField -InputObject $securityPolicy -Name 'execution_profile')
+    if ([string]::IsNullOrWhiteSpace($executionProfile)) {
+        $executionProfile = [string](Get-RunContractField -InputObject $securityPolicy -Name 'profile')
+    }
+    $providerTarget = [string](Get-RunContractField -InputObject $Run -Name 'provider_target')
+
+    return (
+        [string]::Equals($contextMode, 'enterprise', [System.StringComparison]::OrdinalIgnoreCase) -or
+        [string]::Equals($executionProfile, 'isolated-enterprise', [System.StringComparison]::OrdinalIgnoreCase) -or
+        $providerTarget.IndexOf('enterprise', [System.StringComparison]::OrdinalIgnoreCase) -ge 0
+    )
+}
+
+function Get-LatestRunAuditEventByName {
+    param(
+        [object[]]$EventRecords = @(),
+        [string[]]$EventNames = @()
+    )
+
+    $matches = @(
+        $EventRecords |
+            Where-Object { [string]$_['event'] -in $EventNames } |
+            Sort-Object @{ Expression = { Get-RunEventTimestampSortKey -Value $_['timestamp'] }; Descending = $true }, @{ Expression = { [int]$_['line_number'] }; Descending = $true } |
+            Select-Object -First 1
+    )
+    if ($matches.Count -gt 0) {
+        return $matches[0]
+    }
+    return $null
+}
+
+function Test-RunFinalApprovalDeniedEvent {
+    param([string]$EventName = '')
+
+    return [string]$EventName -in @(
+        'operator.final_approval_denied',
+        'operator.approval_denied',
+        'operator.human_approval_denied'
+    )
+}
+
+function Test-RunApprovalActorSeparated {
+    param(
+        [Parameter(Mandatory = $true)]$Run,
+        $EventRecord = $null
+    )
+
+    if ($null -eq $EventRecord) {
+        return $false
+    }
+
+    $actorLabel = [string]$Run.primary_label
+    $actorPane = [string]$Run.primary_pane_id
+    $actorRole = [string]$Run.primary_role
+    $approverLabel = [string]$EventRecord['label']
+    $approverPane = [string]$EventRecord['pane_id']
+    $approverRole = [string]$EventRecord['role']
+
+    if ([string]::IsNullOrWhiteSpace($approverLabel) -and [string]::IsNullOrWhiteSpace($approverPane) -and [string]::IsNullOrWhiteSpace($approverRole)) {
+        return $false
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($actorLabel) -and [string]::Equals($actorLabel, $approverLabel, [System.StringComparison]::OrdinalIgnoreCase)) {
+        return $false
+    }
+    if (-not [string]::IsNullOrWhiteSpace($actorPane) -and [string]::Equals($actorPane, $approverPane, [System.StringComparison]::OrdinalIgnoreCase)) {
+        return $false
+    }
+    if ([string]::Equals($approverRole, 'Builder', [System.StringComparison]::OrdinalIgnoreCase)) {
+        return $false
+    }
+    if (-not [string]::IsNullOrWhiteSpace($actorRole) -and [string]::Equals($actorRole, $approverRole, [System.StringComparison]::OrdinalIgnoreCase)) {
+        return $false
+    }
+    return $true
+}
+
+function New-RunApprovalStageRecord {
+    param(
+        [Parameter(Mandatory = $true)][string]$Name,
+        [Parameter(Mandatory = $true)][string]$State,
+        [bool]$Required = $true,
+        [string]$Evidence = '',
+        [string]$RequestedEvent = '',
+        [string]$DecidedEvent = '',
+        [bool]$ActorSeparationRequired = $false,
+        [bool]$ActorSeparationSatisfied = $false
+    )
+
+    return [ordered]@{
+        name                         = $Name
+        required                     = $Required
+        state                        = $State
+        evidence                     = $Evidence
+        requested_event              = $RequestedEvent
+        decided_event                = $DecidedEvent
+        actor_separation_required    = $ActorSeparationRequired
+        actor_separation_satisfied   = $ActorSeparationSatisfied
+        builder_can_approve_itself   = $false
+    }
+}
+
+function Get-RunApprovalStageBlockedReasons {
+    param($Approval = $null)
+
+    $reasons = [System.Collections.Generic.List[string]]::new()
+    if ($null -eq $Approval -or $null -eq $Approval.stages) {
+        return @()
+    }
+
+    foreach ($stage in @($Approval.stages)) {
+        if (-not [bool](Get-RunContractField -InputObject $stage -Name 'required')) {
+            continue
+        }
+        $stageName = [string](Get-RunContractField -InputObject $stage -Name 'name')
+        if ($stageName -eq 'static_verification') {
+            continue
+        }
+        $state = [string](Get-RunContractField -InputObject $stage -Name 'state')
+        if ($state -eq 'missing') {
+            $reasons.Add("approval stage $stageName is missing") | Out-Null
+        } elseif ($state -eq 'failed') {
+            if ([bool](Get-RunContractField -InputObject $stage -Name 'actor_separation_required') -and -not [bool](Get-RunContractField -InputObject $stage -Name 'actor_separation_satisfied')) {
+                $reasons.Add("approval stage $stageName violates actor separation") | Out-Null
+            } else {
+                $reasons.Add("approval stage $stageName failed") | Out-Null
+            }
+        }
+    }
+    return @($reasons)
+}
+
+function Get-RunAggregateApprovalState {
+    param($ApprovalStages = @())
+
+    $hasRequiredStage = $false
+    $hasMissingStage = $false
+    $hasPendingStage = $false
+
+    foreach ($stage in @($ApprovalStages)) {
+        if (-not [bool](Get-RunContractField -InputObject $stage -Name 'required')) {
+            continue
+        }
+        $hasRequiredStage = $true
+        $state = [string](Get-RunContractField -InputObject $stage -Name 'state')
+        if ($state -eq 'approved') {
+            continue
+        } elseif ($state -eq 'failed') {
+            return 'failed'
+        } elseif ([string]::IsNullOrWhiteSpace($state) -or $state -eq 'missing') {
+            $hasMissingStage = $true
+        } else {
+            $hasPendingStage = $true
+        }
+    }
+
+    if ($hasMissingStage) {
+        return 'missing'
+    }
+    if ($hasPendingStage) {
+        return 'pending'
+    }
+    if ($hasRequiredStage) {
+        return 'approved'
+    }
+    return 'not_required'
+}
+
 function Get-RunAuditChainDecisionEvent {
     param(
         [object[]]$EventRecords = @(),
@@ -11049,7 +11227,7 @@ function Get-RunAuditChainDecisionEvent {
         $EventRecords |
             Where-Object { [string]$_['event'] -in $decisionEvents } |
             Sort-Object @{ Expression = { Get-RunEventTimestampSortKey -Value $_['timestamp'] } }, @{ Expression = { [int]$_['line_number'] } } |
-            Select-Object -First 1
+            Select-Object -Last 1
     )
     if ($matches.Count -gt 0) {
         return $matches[0]
@@ -11102,6 +11280,61 @@ function New-RunAuditChainContract {
     )
     $reviewRequest = if ($reviewRequests.Count -gt 0) { $reviewRequests[0] } else { $null }
     $decisionEvent = Get-RunAuditChainDecisionEvent -EventRecords $orderedEvents -ReviewState ([string]$Run.review_state)
+    $finalApprovalDecision = Get-LatestRunAuditEventByName -EventRecords $orderedEvents -EventNames @('operator.final_approval_granted', 'operator.final_approval_denied', 'operator.approval_granted', 'operator.approval_denied', 'operator.human_approval_granted', 'operator.human_approval_denied')
+    $enterpriseApprovalRequired = Test-RunEnterpriseApprovalChainRequired -Run $Run
+    $reviewApprovalState = ConvertTo-RunAuditChainApprovalState -ReviewState ([string]$Run.review_state) -ReviewRequired ([bool]$Run.review_required)
+    $verificationOutcome = [string](Get-RunContractField -InputObject $Run.verification_result -Name 'outcome')
+    $securityVerdict = [string](Get-RunContractField -InputObject $Run.security_verdict -Name 'verdict')
+    if ([string]::IsNullOrWhiteSpace($securityVerdict) -and $Run.security_verdict -is [string]) {
+        $securityVerdict = [string]$Run.security_verdict
+    }
+    $finalApprovalSeparated = Test-RunApprovalActorSeparated -Run $Run -EventRecord $finalApprovalDecision
+    $operatorReviewSeparated = Test-RunApprovalActorSeparated -Run $Run -EventRecord $decisionEvent
+    $finalApprovalState = if ($null -ne $finalApprovalDecision -and (Test-RunFinalApprovalDeniedEvent -EventName ([string]$finalApprovalDecision['event']))) {
+        'failed'
+    } elseif ($null -ne $finalApprovalDecision -and $finalApprovalSeparated) {
+        'approved'
+    } elseif ($null -ne $finalApprovalDecision) {
+        'failed'
+    } else {
+        'missing'
+    }
+    $operatorReviewStageState = if ($reviewApprovalState -eq 'approved' -and -not $operatorReviewSeparated) {
+        'failed'
+    } else {
+        $reviewApprovalState
+    }
+    $reviewRequestedEvent = if ($null -ne $reviewRequest) { [string]$reviewRequest['event'] } else { '' }
+    $reviewDecidedEvent = if ($null -ne $decisionEvent) { [string]$decisionEvent['event'] } else { '' }
+    $finalDecidedEvent = if ($null -ne $finalApprovalDecision) {
+        [string]$finalApprovalDecision['event']
+    } else {
+        ''
+    }
+    $approvalStages = @()
+    if ($enterpriseApprovalRequired) {
+        $verificationStageState = if ([string]::IsNullOrWhiteSpace($verificationOutcome)) {
+            'missing'
+        } elseif ($verificationOutcome -eq 'PASS') {
+            'approved'
+        } else {
+            'failed'
+        }
+        $policyStageState = if ($securityVerdict -eq 'BLOCK') {
+            'failed'
+        } elseif ([string]::IsNullOrWhiteSpace($securityVerdict)) {
+            'missing'
+        } else {
+            'approved'
+        }
+        $approvalStages = @(
+            (New-RunApprovalStageRecord -Name 'static_verification' -State $verificationStageState -Evidence 'verification_result.outcome' -DecidedEvent 'pipeline.verify.*'),
+            (New-RunApprovalStageRecord -Name 'policy_gate' -State $policyStageState -Evidence 'security_verdict.verdict' -DecidedEvent 'pipeline.security.*'),
+            (New-RunApprovalStageRecord -Name 'operator_review' -State $operatorReviewStageState -Required ([bool]$Run.review_required) -Evidence 'review_state' -RequestedEvent $reviewRequestedEvent -DecidedEvent $reviewDecidedEvent -ActorSeparationRequired $true -ActorSeparationSatisfied $operatorReviewSeparated),
+            (New-RunApprovalStageRecord -Name 'human_final_approval' -State $finalApprovalState -Evidence 'operator.final_approval_granted' -DecidedEvent $finalDecidedEvent -ActorSeparationRequired $true -ActorSeparationSatisfied $finalApprovalSeparated)
+        )
+    }
+    $approvalState = if ($enterpriseApprovalRequired) { Get-RunAggregateApprovalState -ApprovalStages $approvalStages } else { $reviewApprovalState }
     $chainEvents = @(
         $orderedEvents |
             Where-Object {
@@ -11109,6 +11342,12 @@ function New-RunAuditChainContract {
                     'operator.review_requested',
                     'operator.review_passed',
                     'operator.review_failed',
+                    'operator.final_approval_granted',
+                    'operator.final_approval_denied',
+                    'operator.approval_granted',
+                    'operator.approval_denied',
+                    'operator.human_approval_granted',
+                    'operator.human_approval_denied',
                     'review.pass',
                     'review.fail',
                     'pane.approval_waiting',
@@ -11149,8 +11388,11 @@ function New-RunAuditChainContract {
         }
         approval = [ordered]@{
             required                 = [bool]$Run.review_required
-            state                    = ConvertTo-RunAuditChainApprovalState -ReviewState ([string]$Run.review_state) -ReviewRequired ([bool]$Run.review_required)
+            state                    = $approvalState
             verdict                  = [string]$Run.review_state
+            mode                     = if ($enterpriseApprovalRequired) { 'enterprise_multi_stage' } else { 'single_review' }
+            chain_required           = $enterpriseApprovalRequired
+            final_approval_required  = $enterpriseApprovalRequired
             requested_at             = if ($null -ne $reviewRequest) { ConvertTo-RunEventTimestampText -Value $reviewRequest['timestamp'] } else { '' }
             requested_event          = if ($null -ne $reviewRequest) { [string]$reviewRequest['event'] } else { '' }
             requested_reviewer_label = if ($null -ne $reviewRequest) { [string]$reviewRequest['label'] } else { '' }
@@ -11160,6 +11402,8 @@ function New-RunAuditChainContract {
             decided_event            = if ($null -ne $decisionEvent) { [string]$decisionEvent['event'] } else { '' }
             human_judgement_required = [bool]$Run.review_required
             automatic_merge_allowed  = $false
+            builder_can_approve_itself = $false
+            stages                   = @($approvalStages)
         }
         events   = @($chainEvents)
     }
@@ -12180,6 +12424,9 @@ function New-RunVerificationEnvelope {
     if ([bool]$Run.review_required -and $approvalState -ne 'approved') {
         $stateText = if (-not [string]::IsNullOrWhiteSpace($approvalState)) { $approvalState } else { [string]$Run.review_state }
         $blockedReasons.Add("approval state is unresolved: $stateText") | Out-Null
+    }
+    foreach ($stageReason in @(Get-RunApprovalStageBlockedReasons -Approval $approval)) {
+        $blockedReasons.Add($stageReason) | Out-Null
     }
     if (-not [string]::IsNullOrWhiteSpace($draftPrGateState) -and $draftPrGateState -ne 'passed') {
         $blockedReasons.Add("draft PR gate is $draftPrGateState") | Out-Null

--- a/tests/fixtures/rust-parity/explain.json
+++ b/tests/fixtures/rust-parity/explain.json
@@ -366,6 +366,9 @@
           "required": true,
           "state": "pending",
           "verdict": "PENDING",
+          "mode": "single_review",
+          "chain_required": false,
+          "final_approval_required": false,
           "requested_at": "2026-04-10T03:01:00Z",
           "requested_event": "operator.review_requested",
           "requested_reviewer_label": "reviewer-1",
@@ -374,7 +377,9 @@
           "decided_at": "",
           "decided_event": "",
           "human_judgement_required": true,
-          "automatic_merge_allowed": false
+          "automatic_merge_allowed": false,
+          "builder_can_approve_itself": false,
+          "stages": []
         },
         "context": {
           "contract_version": 1,
@@ -700,6 +705,9 @@
           "required": true,
           "state": "pending",
           "verdict": "PENDING",
+          "mode": "single_review",
+          "chain_required": false,
+          "final_approval_required": false,
           "requested_at": "2026-04-10T03:01:00Z",
           "requested_event": "operator.review_requested",
           "requested_reviewer_label": "reviewer-1",
@@ -708,7 +716,9 @@
           "decided_at": "",
           "decided_event": "",
           "human_judgement_required": true,
-          "automatic_merge_allowed": false
+          "automatic_merge_allowed": false,
+          "builder_can_approve_itself": false,
+          "stages": []
         },
         "events": [
           {
@@ -849,6 +859,9 @@
         "required": true,
         "state": "pending",
         "verdict": "PENDING",
+        "mode": "single_review",
+        "chain_required": false,
+        "final_approval_required": false,
         "requested_at": "2026-04-10T03:01:00Z",
         "requested_event": "operator.review_requested",
         "requested_reviewer_label": "reviewer-1",
@@ -857,7 +870,9 @@
         "decided_at": "",
         "decided_event": "",
         "human_judgement_required": true,
-        "automatic_merge_allowed": false
+        "automatic_merge_allowed": false,
+        "builder_can_approve_itself": false,
+        "stages": []
       },
       "events": [
         {

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -12498,6 +12498,297 @@ panes:
         $gate.handoff_package.suggested_next_action | Should -Be 'resolve blocked reasons before creating or merging a draft PR'
     }
 
+    It 'requires final human approval for enterprise approval chains' {
+        $run = [PSCustomObject]@{
+            run_id                = 'task:task-359'
+            task_id               = 'TASK-359'
+            task                  = 'Enterprise approval chain'
+            task_type             = 'feature'
+            priority              = 'P1'
+            branch                = 'worktree-builder-1'
+            head_sha              = 'abc1234def5678'
+            changed_files         = @('scripts/winsmux-core.ps1')
+            primary_label         = 'builder-1'
+            primary_pane_id       = '%2'
+            primary_role          = 'Builder'
+            provider_target       = 'codex:gpt-5.5'
+            agent_role            = 'worker'
+            review_required       = $true
+            review_state          = 'PASS'
+            verification_plan     = @('Invoke-Pester')
+            verification_result   = [ordered]@{ outcome = 'PASS'; summary = 'tests passed' }
+            verification_evidence = [ordered]@{ packet_type = 'verification_evidence' }
+            context_contract      = [ordered]@{ context_mode = 'isolated' }
+            security_policy       = [ordered]@{ execution_profile = 'isolated-enterprise' }
+            security_verdict      = [ordered]@{ verdict = 'ALLOW'; reason = 'policy passed' }
+            draft_pr_gate         = [ordered]@{ state = 'passed' }
+            phase_gate            = [ordered]@{ stop_reason = ''; stop_stage = '' }
+            architecture_contract = [ordered]@{
+                score_regression = $false
+                baseline = [ordered]@{ review_required_on_drift = $true }
+            }
+            last_event            = 'operator.review_passed'
+        }
+        $events = @(
+            [ordered]@{ timestamp = '2026-05-16T12:00:00+09:00'; line_number = 1; event = 'operator.review_requested'; label = 'reviewer-1'; pane_id = '%3'; role = 'Reviewer'; data = [ordered]@{} },
+            [ordered]@{ timestamp = '2026-05-16T12:05:00+09:00'; line_number = 2; event = 'operator.review_passed'; label = 'reviewer-1'; pane_id = '%3'; role = 'Reviewer'; data = [ordered]@{} }
+        )
+
+        $run | Add-Member -NotePropertyName audit_chain -NotePropertyValue (New-RunAuditChainContract -Run $run -EventRecords $events)
+        $envelope = New-RunVerificationEnvelope -Run $run
+
+        $run.audit_chain.approval.mode | Should -Be 'enterprise_multi_stage'
+        $run.audit_chain.approval.chain_required | Should -Be $true
+        $run.audit_chain.approval.state | Should -Be 'missing'
+        $run.audit_chain.approval.final_approval_required | Should -Be $true
+        @($run.audit_chain.approval.stages | ForEach-Object { $_.name }) | Should -Be @('static_verification', 'policy_gate', 'operator_review', 'human_final_approval')
+        ($run.audit_chain.approval.stages | Where-Object { $_.name -eq 'human_final_approval' } | Select-Object -First 1).state | Should -Be 'missing'
+        $envelope.release_decision.status | Should -Be 'blocked'
+        $envelope.release_decision.blocked_reasons | Should -Contain 'approval stage human_final_approval is missing'
+    }
+
+    It 'rejects enterprise final approval from the builder actor' {
+        $run = [PSCustomObject]@{
+            run_id                = 'task:task-359-self'
+            task_id               = 'TASK-359'
+            task                  = 'Enterprise approval chain'
+            task_type             = 'feature'
+            priority              = 'P1'
+            branch                = 'worktree-builder-1'
+            head_sha              = 'abc1234def5678'
+            changed_files         = @('scripts/winsmux-core.ps1')
+            primary_label         = 'builder-1'
+            primary_pane_id       = '%2'
+            primary_role          = 'Builder'
+            provider_target       = 'codex:gpt-5.5'
+            agent_role            = 'worker'
+            review_required       = $true
+            review_state          = 'PASS'
+            verification_plan     = @('Invoke-Pester')
+            verification_result   = [ordered]@{ outcome = 'PASS'; summary = 'tests passed' }
+            verification_evidence = [ordered]@{ packet_type = 'verification_evidence' }
+            context_contract      = [ordered]@{ context_mode = 'isolated' }
+            security_policy       = [ordered]@{ execution_profile = 'isolated-enterprise' }
+            security_verdict      = [ordered]@{ verdict = 'ALLOW'; reason = 'policy passed' }
+            draft_pr_gate         = [ordered]@{ state = 'passed' }
+            phase_gate            = [ordered]@{ stop_reason = ''; stop_stage = '' }
+            architecture_contract = [ordered]@{
+                score_regression = $false
+                baseline = [ordered]@{ review_required_on_drift = $true }
+            }
+            last_event            = 'operator.final_approval_granted'
+        }
+        $events = @(
+            [ordered]@{ timestamp = '2026-05-16T12:00:00+09:00'; line_number = 1; event = 'operator.review_requested'; label = 'reviewer-1'; pane_id = '%3'; role = 'Reviewer'; data = [ordered]@{} },
+            [ordered]@{ timestamp = '2026-05-16T12:05:00+09:00'; line_number = 2; event = 'operator.review_passed'; label = 'reviewer-1'; pane_id = '%3'; role = 'Reviewer'; data = [ordered]@{} },
+            [ordered]@{ timestamp = '2026-05-16T12:06:00+09:00'; line_number = 3; event = 'operator.final_approval_granted'; label = 'builder-1'; pane_id = '%2'; role = 'Builder'; data = [ordered]@{} }
+        )
+
+        $run | Add-Member -NotePropertyName audit_chain -NotePropertyValue (New-RunAuditChainContract -Run $run -EventRecords $events)
+        $envelope = New-RunVerificationEnvelope -Run $run
+        $finalStage = $run.audit_chain.approval.stages | Where-Object { $_.name -eq 'human_final_approval' } | Select-Object -First 1
+
+        $run.audit_chain.approval.state | Should -Be 'failed'
+        $finalStage.state | Should -Be 'failed'
+        $finalStage.actor_separation_satisfied | Should -Be $false
+        $envelope.release_decision.blocked_reasons | Should -Contain 'approval stage human_final_approval violates actor separation'
+    }
+
+    It 'rejects enterprise final approval without approver identity' {
+        $run = [PSCustomObject]@{
+            run_id                = 'task:task-359-blank-final'
+            task_id               = 'TASK-359'
+            task                  = 'Enterprise approval chain'
+            task_type             = 'feature'
+            priority              = 'P1'
+            branch                = 'worktree-builder-1'
+            head_sha              = 'abc1234def5678'
+            changed_files         = @('scripts/winsmux-core.ps1')
+            primary_label         = 'builder-1'
+            primary_pane_id       = '%2'
+            primary_role          = 'Builder'
+            provider_target       = 'codex:gpt-5.5'
+            agent_role            = 'worker'
+            review_required       = $true
+            review_state          = 'PASS'
+            verification_plan     = @('Invoke-Pester')
+            verification_result   = [ordered]@{ outcome = 'PASS'; summary = 'tests passed' }
+            verification_evidence = [ordered]@{ packet_type = 'verification_evidence' }
+            context_contract      = [ordered]@{ context_mode = 'isolated' }
+            security_policy       = [ordered]@{ execution_profile = 'isolated-enterprise' }
+            security_verdict      = [ordered]@{ verdict = 'ALLOW'; reason = 'policy passed' }
+            draft_pr_gate         = [ordered]@{ state = 'passed' }
+            phase_gate            = [ordered]@{ stop_reason = ''; stop_stage = '' }
+            architecture_contract = [ordered]@{
+                score_regression = $false
+                baseline = [ordered]@{ review_required_on_drift = $true }
+            }
+            last_event            = 'operator.final_approval_granted'
+        }
+        $events = @(
+            [ordered]@{ timestamp = '2026-05-16T12:00:00+09:00'; line_number = 1; event = 'operator.review_requested'; label = 'reviewer-1'; pane_id = '%3'; role = 'Reviewer'; data = [ordered]@{} },
+            [ordered]@{ timestamp = '2026-05-16T12:05:00+09:00'; line_number = 2; event = 'operator.review_passed'; label = 'reviewer-1'; pane_id = '%3'; role = 'Reviewer'; data = [ordered]@{} },
+            [ordered]@{ timestamp = '2026-05-16T12:06:00+09:00'; line_number = 3; event = 'operator.final_approval_granted'; label = ''; pane_id = ''; role = ''; data = [ordered]@{} }
+        )
+
+        $run | Add-Member -NotePropertyName audit_chain -NotePropertyValue (New-RunAuditChainContract -Run $run -EventRecords $events)
+        $envelope = New-RunVerificationEnvelope -Run $run
+        $finalStage = $run.audit_chain.approval.stages | Where-Object { $_.name -eq 'human_final_approval' } | Select-Object -First 1
+
+        $run.audit_chain.approval.state | Should -Be 'failed'
+        $finalStage.state | Should -Be 'failed'
+        $finalStage.actor_separation_satisfied | Should -Be $false
+        $envelope.release_decision.blocked_reasons | Should -Contain 'approval stage human_final_approval violates actor separation'
+    }
+
+    It 'rejects enterprise review approval from the builder actor' {
+        $run = [PSCustomObject]@{
+            run_id                = 'task:task-359-review-self'
+            task_id               = 'TASK-359'
+            task                  = 'Enterprise approval chain'
+            task_type             = 'feature'
+            priority              = 'P1'
+            branch                = 'worktree-builder-1'
+            head_sha              = 'abc1234def5678'
+            changed_files         = @('scripts/winsmux-core.ps1')
+            primary_label         = 'builder-1'
+            primary_pane_id       = '%2'
+            primary_role          = 'Builder'
+            provider_target       = 'codex:gpt-5.5'
+            agent_role            = 'worker'
+            review_required       = $true
+            review_state          = 'PASS'
+            verification_plan     = @('Invoke-Pester')
+            verification_result   = [ordered]@{ outcome = 'PASS'; summary = 'tests passed' }
+            verification_evidence = [ordered]@{ packet_type = 'verification_evidence' }
+            context_contract      = [ordered]@{ context_mode = 'isolated' }
+            security_policy       = [ordered]@{ execution_profile = 'isolated-enterprise' }
+            security_verdict      = [ordered]@{ verdict = 'ALLOW'; reason = 'policy passed' }
+            draft_pr_gate         = [ordered]@{ state = 'passed' }
+            phase_gate            = [ordered]@{ stop_reason = ''; stop_stage = '' }
+            architecture_contract = [ordered]@{
+                score_regression = $false
+                baseline = [ordered]@{ review_required_on_drift = $true }
+            }
+            last_event            = 'operator.final_approval_granted'
+        }
+        $events = @(
+            [ordered]@{ timestamp = '2026-05-16T12:00:00+09:00'; line_number = 1; event = 'operator.review_requested'; label = 'reviewer-1'; pane_id = '%3'; role = 'Reviewer'; data = [ordered]@{} },
+            [ordered]@{ timestamp = '2026-05-16T12:05:00+09:00'; line_number = 2; event = 'operator.review_passed'; label = 'builder-1'; pane_id = '%2'; role = 'Builder'; data = [ordered]@{} },
+            [ordered]@{ timestamp = '2026-05-16T12:06:00+09:00'; line_number = 3; event = 'operator.final_approval_granted'; label = 'operator-1'; pane_id = '%1'; role = 'Operator'; data = [ordered]@{} }
+        )
+
+        $run | Add-Member -NotePropertyName audit_chain -NotePropertyValue (New-RunAuditChainContract -Run $run -EventRecords $events)
+        $envelope = New-RunVerificationEnvelope -Run $run
+        $reviewStage = $run.audit_chain.approval.stages | Where-Object { $_.name -eq 'operator_review' } | Select-Object -First 1
+
+        $run.audit_chain.approval.state | Should -Be 'failed'
+        $reviewStage.state | Should -Be 'failed'
+        $reviewStage.actor_separation_satisfied | Should -Be $false
+        $envelope.release_decision.blocked_reasons | Should -Contain 'approval stage operator_review violates actor separation'
+    }
+
+    It 'allows enterprise approval chain only after separated final approval' {
+        $run = [PSCustomObject]@{
+            run_id                = 'task:task-359-approved'
+            task_id               = 'TASK-359'
+            task                  = 'Enterprise approval chain'
+            task_type             = 'feature'
+            priority              = 'P1'
+            branch                = 'worktree-builder-1'
+            head_sha              = 'abc1234def5678'
+            changed_files         = @('scripts/winsmux-core.ps1')
+            primary_label         = 'builder-1'
+            primary_pane_id       = '%2'
+            primary_role          = 'Builder'
+            provider_target       = 'codex:gpt-5.5'
+            agent_role            = 'worker'
+            review_required       = $true
+            review_state          = 'PASS'
+            verification_plan     = @('Invoke-Pester')
+            verification_result   = [ordered]@{ outcome = 'PASS'; summary = 'tests passed' }
+            verification_evidence = [ordered]@{ packet_type = 'verification_evidence' }
+            context_contract      = [ordered]@{ context_mode = 'isolated' }
+            security_policy       = [ordered]@{ execution_profile = 'isolated-enterprise' }
+            security_verdict      = [ordered]@{ verdict = 'ALLOW'; reason = 'policy passed' }
+            draft_pr_gate         = [ordered]@{ state = 'passed' }
+            phase_gate            = [ordered]@{ stop_reason = ''; stop_stage = '' }
+            architecture_contract = [ordered]@{
+                score_regression = $false
+                baseline = [ordered]@{ review_required_on_drift = $true }
+            }
+            last_event            = 'operator.final_approval_granted'
+        }
+        $events = @(
+            [ordered]@{ timestamp = '2026-05-16T12:00:00+09:00'; line_number = 1; event = 'operator.review_requested'; label = 'reviewer-1'; pane_id = '%3'; role = 'Reviewer'; data = [ordered]@{} },
+            [ordered]@{ timestamp = '2026-05-16T12:04:00+09:00'; line_number = 2; event = 'operator.review_passed'; label = 'builder-1'; pane_id = '%2'; role = 'Builder'; data = [ordered]@{} },
+            [ordered]@{ timestamp = '2026-05-16T03:05:00Z'; line_number = 3; event = 'operator.review_passed'; label = 'reviewer-1'; pane_id = '%3'; role = 'Reviewer'; data = [ordered]@{} },
+            [ordered]@{ timestamp = '2026-05-16T12:06:00+09:00'; line_number = 4; event = 'operator.final_approval_denied'; label = 'operator-1'; pane_id = '%1'; role = 'Operator'; data = [ordered]@{} },
+            [ordered]@{ timestamp = '2026-05-16T03:07:00Z'; line_number = 5; event = 'operator.final_approval_granted'; label = 'operator-1'; pane_id = '%1'; role = 'Operator'; data = [ordered]@{} }
+        )
+
+        $run | Add-Member -NotePropertyName audit_chain -NotePropertyValue (New-RunAuditChainContract -Run $run -EventRecords $events)
+        $envelope = New-RunVerificationEnvelope -Run $run
+        $reviewStage = $run.audit_chain.approval.stages | Where-Object { $_.name -eq 'operator_review' } | Select-Object -First 1
+        $finalStage = $run.audit_chain.approval.stages | Where-Object { $_.name -eq 'human_final_approval' } | Select-Object -First 1
+
+        $run.audit_chain.approval.state | Should -Be 'approved'
+        $reviewStage.state | Should -Be 'approved'
+        $reviewStage.actor_separation_satisfied | Should -Be $true
+        $finalStage.state | Should -Be 'approved'
+        $finalStage.decided_event | Should -Be 'operator.final_approval_granted'
+        $finalStage.actor_separation_satisfied | Should -Be $true
+        $envelope.release_decision.status | Should -Be 'approved'
+        $envelope.release_decision.blocked_reasons | Should -Be @()
+    }
+
+    It 'marks failed enterprise verification as a failed approval stage' {
+        $run = [PSCustomObject]@{
+            run_id                = 'task:task-359-verify-fail'
+            task_id               = 'TASK-359'
+            task                  = 'Enterprise approval chain'
+            task_type             = 'feature'
+            priority              = 'P1'
+            branch                = 'worktree-builder-1'
+            head_sha              = 'abc1234def5678'
+            changed_files         = @('scripts/winsmux-core.ps1')
+            primary_label         = 'builder-1'
+            primary_pane_id       = '%2'
+            primary_role          = 'Builder'
+            provider_target       = 'codex:gpt-5.5'
+            agent_role            = 'worker'
+            review_required       = $true
+            review_state          = 'PASS'
+            verification_plan     = @('Invoke-Pester')
+            verification_result   = [ordered]@{ outcome = 'FAIL'; summary = 'tests failed' }
+            verification_evidence = [ordered]@{ packet_type = 'verification_evidence' }
+            context_contract      = [ordered]@{ context_mode = 'isolated' }
+            security_policy       = [ordered]@{ execution_profile = 'isolated-enterprise' }
+            security_verdict      = [ordered]@{ verdict = 'ALLOW'; reason = 'policy passed' }
+            draft_pr_gate         = [ordered]@{ state = 'passed' }
+            phase_gate            = [ordered]@{ stop_reason = ''; stop_stage = '' }
+            architecture_contract = [ordered]@{
+                score_regression = $false
+                baseline = [ordered]@{ review_required_on_drift = $true }
+            }
+            last_event            = 'pipeline.verify.fail'
+        }
+        $events = @(
+            [ordered]@{ timestamp = '2026-05-16T12:00:00+09:00'; line_number = 1; event = 'operator.review_requested'; label = 'reviewer-1'; pane_id = '%3'; role = 'Reviewer'; data = [ordered]@{} },
+            [ordered]@{ timestamp = '2026-05-16T12:05:00+09:00'; line_number = 2; event = 'operator.review_passed'; label = 'reviewer-1'; pane_id = '%3'; role = 'Reviewer'; data = [ordered]@{} },
+            [ordered]@{ timestamp = '2026-05-16T12:06:00+09:00'; line_number = 3; event = 'pipeline.verify.fail'; label = 'builder-1'; pane_id = '%2'; role = 'Builder'; data = [ordered]@{} },
+            [ordered]@{ timestamp = '2026-05-16T12:07:00+09:00'; line_number = 4; event = 'operator.final_approval_granted'; label = 'operator-1'; pane_id = '%1'; role = 'Operator'; data = [ordered]@{} }
+        )
+
+        $run | Add-Member -NotePropertyName audit_chain -NotePropertyValue (New-RunAuditChainContract -Run $run -EventRecords $events)
+        $envelope = New-RunVerificationEnvelope -Run $run
+        $verificationStage = $run.audit_chain.approval.stages | Where-Object { $_.name -eq 'static_verification' } | Select-Object -First 1
+
+        $run.audit_chain.approval.state | Should -Be 'failed'
+        $verificationStage.state | Should -Be 'failed'
+        $envelope.release_decision.blocked_reasons | Should -Contain 'verification outcome is FAIL'
+    }
+
     It 'keeps in-progress outcome when draft PR gate is blocked only for missing evidence' {
         $run = [ordered]@{
             task_state            = 'in_progress'

--- a/winsmux-app/src-tauri/src/desktop_backend.rs
+++ b/winsmux-app/src-tauri/src/desktop_backend.rs
@@ -391,6 +391,10 @@ pub struct DesktopExplainRun {
     pub verification_contract: Value,
     pub verification_result: Value,
     #[serde(default)]
+    pub verification_envelope: Value,
+    #[serde(default)]
+    pub audit_chain: Value,
+    #[serde(default)]
     pub changed_files: Vec<String>,
     #[serde(default)]
     pub action_items: Vec<DesktopExplainActionItem>,
@@ -3125,6 +3129,11 @@ mod tests {
         assert!(payload.run.security_verdict.is_null());
         assert!(payload.run.verification_contract.is_null());
         assert!(payload.run.verification_result.is_null());
+        assert_eq!(
+            payload.run.verification_envelope["packet_type"],
+            "verification_envelope"
+        );
+        assert_eq!(payload.run.audit_chain["approval"]["mode"], "single_review");
         assert_eq!(payload.run.worktree, ".worktrees/builder-1");
         assert_eq!(payload.run.action_items.len(), 2);
         assert_eq!(payload.run.action_items[0].kind, "review_pending");

--- a/winsmux-app/src/desktopClient.ts
+++ b/winsmux-app/src/desktopClient.ts
@@ -321,6 +321,8 @@ export interface DesktopExplainPayload {
     security_verdict: Record<string, unknown> | null;
     verification_contract: Record<string, unknown> | null;
     verification_result: Record<string, unknown> | null;
+    verification_envelope?: Record<string, unknown> | null;
+    audit_chain?: Record<string, unknown> | null;
     changed_files: string[];
     action_items: Array<{
       kind: string;


### PR DESCRIPTION
## Summary
- Add an enterprise approval-chain mode with static verification, policy gate, operator review, and final human approval stages.
- Require separated reviewer and final approver identities before enterprise chains can pass.
- Surface approval chain and verification envelope data through the desktop explain payload.

## Validation
- codex review --base main with gpt-5.5 medium: no actionable findings
- git diff --check
- rustfmt --check core\\src\\ledger.rs core\\tests-rs\\ledger_contract.rs winsmux-app\\src-tauri\\src\\desktop_backend.rs
- PowerShell parser check for scripts\\winsmux-core.ps1
- Invoke-Pester -Path tests\\winsmux-bridge.Tests.ps1 -FullName '*enterprise*approval*' -PassThru
- cargo test --manifest-path core\\Cargo.toml
- cargo test -p winsmux --test ledger_contract --quiet
- cargo test -p winsmux --test fixture_comparison --quiet
- cargo test --manifest-path winsmux-app\\src-tauri\\Cargo.toml load_desktop_run_explain
- cmd /c npm run build
- pwsh -NoProfile -File scripts\\audit-public-surface.ps1
- pwsh -NoProfile -File scripts\\git-guard.ps1 -Mode full

Closes #451