### PR TITLE
feat: add guard mesh parent tracking

### DIFF
--- a/core/src/operator_cli.rs
+++ b/core/src/operator_cli.rs
@@ -9444,7 +9444,7 @@ fn guard_report_payload(project_dir: &Path) -> Value {
     json!({
         "contract_version": 1,
         "command": "guard",
-        "task_ids": [],
+        "task_ids": ["TASK-390", "TASK-382", "TASK-383", "TASK-384"],
         "issue_refs": ["#522", "#523", "#524", "#525", "#685"],
         "target_version": "v1.0.0",
         "generated_at": generated_at(),
@@ -9465,6 +9465,32 @@ fn guard_report_payload(project_dir: &Path) -> Value {
             "gitleaks_baseline_commit": baseline_commit
         },
         "required_checks": required_checks,
+        "parent_tracking": {
+            "task_id": "TASK-390",
+            "issue_ref": "#522",
+            "scope": "coordination_and_acceptance_tracking",
+            "child_tasks": [
+                {
+                    "task_id": "TASK-382",
+                    "issue_ref": "#524",
+                    "area": "architecture",
+                    "status": "done"
+                },
+                {
+                    "task_id": "TASK-383",
+                    "issue_ref": "#523",
+                    "area": "security",
+                    "status": "done"
+                },
+                {
+                    "task_id": "TASK-384",
+                    "issue_ref": "#525",
+                    "area": "release_gating",
+                    "status": "done"
+                }
+            ],
+            "acceptance_policy": "Do not close the parent by child implementation alone; confirm child status, then map any remaining scope to follow-up tasks or issues."
+        },
         "evidence_contract": {
             "run_surfaces": ["winsmux runs --json", "winsmux digest --json", "winsmux explain <run_id> --json"],
             "required_fields": [

--- a/core/tests-rs/operator_cli.rs
+++ b/core/tests-rs/operator_cli.rs
@@ -2381,7 +2381,8 @@ fn operator_cli_guard_json_reports_release_guard_baseline() {
     let json = run_json(&project_dir, &["guard", "--json"]);
 
     assert_eq!(json["command"], "guard");
-    assert_eq!(json["task_ids"].as_array().unwrap().len(), 0);
+    assert_eq!(json["task_ids"][0], "TASK-390");
+    assert_eq!(json["task_ids"][3], "TASK-384");
     assert_eq!(json["issue_refs"][0], "#522");
     assert_eq!(json["issue_refs"][3], "#525");
     assert_eq!(json["issue_refs"][4], "#685");
@@ -2408,6 +2409,19 @@ fn operator_cli_guard_json_reports_release_guard_baseline() {
         "docs/project/pester-suite-reduction-plan.md"
     );
     assert_eq!(json["required_checks"][8]["id"], "desktop_release_workflow");
+    assert_eq!(json["parent_tracking"]["task_id"], "TASK-390");
+    assert_eq!(
+        json["parent_tracking"]["scope"],
+        "coordination_and_acceptance_tracking"
+    );
+    assert_eq!(
+        json["parent_tracking"]["child_tasks"][0]["task_id"],
+        "TASK-382"
+    );
+    assert_eq!(
+        json["parent_tracking"]["child_tasks"][2]["issue_ref"],
+        "#525"
+    );
     assert_eq!(
         json["evidence_contract"]["security_contract"]["provider_token_broker_allowed"],
         false

--- a/scripts/generate-release-notes.ps1
+++ b/scripts/generate-release-notes.ps1
@@ -259,6 +259,9 @@ function ConvertTo-UserBenefit {
         'complete winsmux-surface rename|send buffer overflow' {
             return 'Continued the winsmux naming convergence and stabilized the send pipeline'
         }
+        'guard parent tracking|guard mesh parent|parent_tracking|TASK-390' {
+            return 'Added machine-readable guard mesh parent tracking for architecture, security, evidence, and release gating acceptance'
+        }
         'bump version|sync backlog and roadmap' {
             return $null
         }


### PR DESCRIPTION
## Summary

- Add `TASK-390` and child task IDs to `winsmux guard --json`.
- Add `parent_tracking` metadata for issue `#522` and child issues `#523`, `#524`, and `#525`.
- Teach release note generation to describe guard mesh parent tracking.

## Validation

- `git diff --check`
- PowerShell parser check for `scripts/generate-release-notes.ps1`
- `cargo test --manifest-path core\Cargo.toml --test operator_cli guard --quiet`
- `cargo run --manifest-path core\Cargo.toml -- guard --json`
