### PR TITLE
feat(workers): add api_llm OpenAI-compatible runner

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -117,7 +117,7 @@ winsmux skills --json
 | `winsmux workers status` | ワーカースロットのバックエンド、状態、GPU、セッション、直近コマンドを表示 |
 | `winsmux workers attach` | Colab 対応ワーカーを、長時間ループを始めずにデスクトップ表示へ準備 |
 | `winsmux workers doctor` | ワーカー設定、Colab CLI、認証、uv、状態ファイルの場所を診断 |
-| `winsmux workers exec` | Colab 対応タスクを実行する。`api_llm` は hosted runner 設定まで診断付き停止として記録する |
+| `winsmux workers exec` | Colab 対応タスク、または OpenAI 互換 API 経由の `api_llm` タスクを実行する。API key の環境変数がない場合は通信前に停止する |
 | `winsmux workers logs` | ワーカー実行の保存済みログを読む。必要に応じて Colab CLI から取得 |
 | `winsmux workers upload` | 明示したファイル、または許可したディレクトリだけをアップロード |
 | `winsmux workers download` | リモート成果物をプロジェクト配下へダウンロード |

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ winsmux skills --json
 | `winsmux workers status` | Show backend, state, GPU, session, and last command for worker slots |
 | `winsmux workers attach` | Prepare a Colab-backed worker slot for desktop visibility without starting an unbounded loop |
 | `winsmux workers doctor` | Diagnose worker config, Colab CLI, auth, uv, and session-state paths |
-| `winsmux workers exec` | Run Colab-backed tasks, or record a blocked `api_llm` run until the hosted runner is configured |
+| `winsmux workers exec` | Run Colab-backed tasks or hosted `api_llm` tasks through an OpenAI-compatible API; missing API key env vars stop before network access |
 | `winsmux workers logs` | Read the stored log for a worker run, or ask the Colab CLI for it |
 | `winsmux workers upload` | Upload explicit files or allowlisted directories while excluding unsafe paths |
 | `winsmux workers download` | Download a remote artifact into a project-local output directory |

--- a/core/src/machine_contract.rs
+++ b/core/src/machine_contract.rs
@@ -240,7 +240,7 @@ const WORKER_BACKENDS: &[WorkerBackendContract<'static>] = &[
     WorkerBackendContract {
         id: "api_llm",
         description: "hosted OpenAI-compatible API model worker contract with provider metadata, task JSON input, and redacted run artifacts",
-        runtime_available: false,
+        runtime_available: true,
         config_fields: &[
             "worker_backend",
             "worker_role",

--- a/core/src/operator_cli.rs
+++ b/core/src/operator_cli.rs
@@ -2834,6 +2834,8 @@ fn normalize_provider_capability_entry(
         "harness_availability",
         "credential_requirements",
         "execution_backend",
+        "api_base_url",
+        "api_key_env",
         "runtime_requirements",
         "analysis_posture",
     ];

--- a/core/tests-rs/machine_contract.rs
+++ b/core/tests-rs/machine_contract.rs
@@ -58,7 +58,7 @@ fn machine_contract_exposes_worker_backend_contracts() {
         .iter()
         .find(|backend| backend.id == "api_llm")
         .expect("api_llm backend should exist");
-    assert!(!api_llm.runtime_available);
+    assert!(api_llm.runtime_available);
     assert!(api_llm.config_fields.contains(&"agent"));
     assert!(api_llm.config_fields.contains(&"model"));
     assert!(api_llm.config_fields.contains(&"model_source"));
@@ -311,7 +311,7 @@ fn machine_contract_serializes_to_json() {
     assert_eq!(value["worker_backends"][2]["id"], "colab_cli");
     assert_eq!(value["worker_backends"][2]["runtime_available"], true);
     assert_eq!(value["worker_backends"][3]["id"], "api_llm");
-    assert_eq!(value["worker_backends"][3]["runtime_available"], false);
+    assert_eq!(value["worker_backends"][3]["runtime_available"], true);
     assert_eq!(value["worker_backends"][4]["id"], "noop");
     assert_eq!(value["worker_backends"][4]["runtime_available"], false);
     assert_eq!(

--- a/core/tests-rs/operator_cli.rs
+++ b/core/tests-rs/operator_cli.rs
@@ -1390,6 +1390,8 @@ fn operator_cli_provider_capabilities_json_reads_registry() {
       "harness_availability": "external-adapter",
       "credential_requirements": "runtime-owned-local-endpoint",
       "execution_backend": "openai-compatible-local-endpoint",
+      "api_base_url": "http://127.0.0.1:8080/v1",
+      "api_key_env": "WINSMUX_LOCAL_OPENAI_COMPATIBLE_API_KEY",
       "runtime_requirements": "127.0.0.1 endpoint; GPU/CPU capacity owned by runtime.",
       "analysis_posture": "read-only-analysis",
       "prompt_transports": ["stdin"],
@@ -1446,6 +1448,14 @@ fn operator_cli_provider_capabilities_json_reads_registry() {
         "openai-compatible-local-endpoint"
     );
     assert_eq!(
+        registry["providers"]["local-openai-compatible"]["api_base_url"],
+        "http://127.0.0.1:8080/v1"
+    );
+    assert_eq!(
+        registry["providers"]["local-openai-compatible"]["api_key_env"],
+        "WINSMUX_LOCAL_OPENAI_COMPATIBLE_API_KEY"
+    );
+    assert_eq!(
         registry["providers"]["local-openai-compatible"]["read_only_launch_args"][1],
         "--no-file-edits"
     );
@@ -1480,7 +1490,7 @@ fn operator_cli_machine_contract_json_exposes_hook_facing_catalog() {
     assert_eq!(json["worker_backends"][2]["id"], "colab_cli");
     assert_eq!(json["worker_backends"][2]["runtime_available"], true);
     assert_eq!(json["worker_backends"][3]["id"], "api_llm");
-    assert_eq!(json["worker_backends"][3]["runtime_available"], false);
+    assert_eq!(json["worker_backends"][3]["runtime_available"], true);
     assert_eq!(json["worker_backends"][4]["id"], "noop");
     assert_eq!(json["worker_backends"][4]["runtime_available"], false);
     assert_eq!(json["projection_surfaces"][1]["name"], "board");

--- a/docs/customization.ja.md
+++ b/docs/customization.ja.md
@@ -165,9 +165,31 @@ winsmux はベンダーごとに固定された役割ではなく、スロット
 分けて扱います。たとえば provider に `openrouter`、model に `z-ai/glm-5.2`、
 `prompt-transport: file`、`auth-mode: api-key-env` を指定できます。
 OpenRouter を環境変数で使う場合の既定名は `WINSMUX_OPENROUTER_API_KEY` です。
-worker プロセスへ渡す実行時の環境変数として扱います。1Password などのローカルな
-パスワード管理ツールを使う場合も、起動前にその環境へ入れる取得手段として扱います。
-`setx`、シェル起動ファイル、コマンド履歴、リポジトリ内の `.env`、公開ドキュメント、
+公開リポジトリでの標準手順では、Windows のユーザー環境変数として保存し、
+新しい PowerShell を開いてから `winsmux` を実行します。
+
+```powershell
+$secret = Read-Host -AsSecureString "OpenRouter API key"
+$bstr = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($secret)
+try {
+  [Environment]::SetEnvironmentVariable(
+    "WINSMUX_OPENROUTER_API_KEY",
+    [Runtime.InteropServices.Marshal]::PtrToStringBSTR($bstr),
+    "User"
+  )
+} finally {
+  [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr)
+  Remove-Variable secret -ErrorAction SilentlyContinue
+}
+```
+
+反映確認では値を表示せず、設定済みかだけを確認します。
+
+```powershell
+if ([string]::IsNullOrWhiteSpace($env:WINSMUX_OPENROUTER_API_KEY)) { "missing" } else { "configured" }
+```
+
+シェル起動ファイル、コマンド履歴、リポジトリ内の `.env`、公開ドキュメント、PR 本文、
 ログ、リリース証跡へ値を書かないでください。
 
 外部APIワーカーは、タスク JSON ファイルから実行します。

--- a/docs/customization.ja.md
+++ b/docs/customization.ja.md
@@ -177,7 +177,8 @@ winsmux workers exec w1 --task-json tasks/api-worker-task.json --run-id api-demo
 winsmux workers logs w1 --run-id api-demo-1 --json
 ```
 
-外部API runner が未設定の場合、`workers exec` は診断理由付きで停止します。
+API key の環境変数がない場合や、エンドポイント設定が不正な場合、`workers exec`
+は通信前に `api_llm_api_key_env_missing` などの診断理由付きで停止します。
 `local_llm`、`colab_llm`、`colab_cli` へ黙って切り替えません。
 
 `v0.32.4` 以降では、Colab バックエンドの状態を

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -226,11 +226,33 @@ and each slot can override it with one of the contract values:
 workers. They may declare a provider such as `openrouter`, a model id such as
 `z-ai/glm-5.2`, `prompt-transport: file`, and `auth-mode: api-key-env`.
 Environment-based OpenRouter authentication uses
-`WINSMUX_OPENROUTER_API_KEY`. Treat it as a process-scoped runtime environment
-variable for the worker process. A local password manager such as 1Password may
-populate that environment before launch, but do not store the key with `setx`, in
-shell startup files, in command history, in repo-local `.env` files, public docs,
-logs, or release evidence.
+`WINSMUX_OPENROUTER_API_KEY`. For public setup, store it as a Windows user
+environment variable, then open a new PowerShell session before running
+`winsmux`:
+
+```powershell
+$secret = Read-Host -AsSecureString "OpenRouter API key"
+$bstr = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($secret)
+try {
+  [Environment]::SetEnvironmentVariable(
+    "WINSMUX_OPENROUTER_API_KEY",
+    [Runtime.InteropServices.Marshal]::PtrToStringBSTR($bstr),
+    "User"
+  )
+} finally {
+  [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr)
+  Remove-Variable secret -ErrorAction SilentlyContinue
+}
+```
+
+Verify only that the variable is present; do not print the value:
+
+```powershell
+if ([string]::IsNullOrWhiteSpace($env:WINSMUX_OPENROUTER_API_KEY)) { "missing" } else { "configured" }
+```
+
+Do not store the key in shell startup files, command history, repo-local `.env`
+files, public docs, logs, PR text, or release evidence.
 
 Run a hosted API worker from a task JSON file:
 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -239,9 +239,10 @@ winsmux workers exec w1 --task-json tasks/api-worker-task.json --run-id api-demo
 winsmux workers logs w1 --run-id api-demo-1 --json
 ```
 
-If the hosted runner is not configured, `workers exec` returns a blocked result
-with a diagnostic reason instead of falling back to `local_llm`, `colab_llm`, or
-`colab_cli`.
+If the API key environment variable is missing or the endpoint is invalid,
+`workers exec` returns a blocked result such as
+`api_llm_api_key_env_missing` before network access instead of falling back to
+`local_llm`, `colab_llm`, or `colab_cli`.
 
 Starting in `v0.32.4`, winsmux records Colab backend availability under
 `.winsmux/state/colab_sessions.json`. Missing `google-colab-cli`, missing auth,

--- a/docs/provider-and-model-support.ja.md
+++ b/docs/provider-and-model-support.ja.md
@@ -48,7 +48,7 @@ CLI であることは認証方式や実行方式の列で説明します。
 - `execution_backend`: エージェント CLI、Colab ワーカー、OpenAI 互換ローカルエンドポイントなどの実行経路。
 - `runtime_requirements`: エンドポイント、実行ファイル、GPU、CPU、メモリ、OS、リモートランタイムの要件。
 - `model_catalog_source` と `model_options`: モデル名の取得元と、オペレーターが選べる候補。
-- `api_base_url` と `api_key_env`: 外部APIモデルワーカーが使う OpenAI 互換エンドポイントと、API key の環境変数名。
+- `api_base_url` と `api_key_env`: 外部APIモデルワーカーが使う OpenAI 互換エンドポイントと、API key の環境変数名。`openrouter` などの組み込み外部 provider では固定値として扱い、カスタム endpoint は localhost に限定します。
 - `analysis_posture`: 読み取り専用の分析に限るか、通常の書き込み可能ワーカーとして扱えるか。
 
 OpenAI 互換ローカルエンドポイントや GPU 付きローカルランタイムの既定は、
@@ -81,9 +81,32 @@ OpenRouter 互換の既定 base URL は `https://openrouter.ai/api/v1` です。
 環境変数で認証する場合、既定名は `WINSMUX_OPENROUTER_API_KEY` です。
 winsmux はこの値をリポジトリ、公開ドキュメント、PR 本文、生成レポート、
 ワーカーログ、リリース証跡に保存しません。
-1Password などのパスワード管理ツールを使う場合も、worker 起動前に worker
-プロセスの環境へ読み込む手段として扱います。`setx`、シェル起動ファイル、
-コマンド履歴、リポジトリ内の `.env` へこのキーを書かないでください。
+公開リポジトリでの標準手順では、Windows のユーザー環境変数として保存し、
+新しい PowerShell を開いてから `winsmux` を実行します。
+
+```powershell
+$secret = Read-Host -AsSecureString "OpenRouter API key"
+$bstr = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($secret)
+try {
+  [Environment]::SetEnvironmentVariable(
+    "WINSMUX_OPENROUTER_API_KEY",
+    [Runtime.InteropServices.Marshal]::PtrToStringBSTR($bstr),
+    "User"
+  )
+} finally {
+  [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr)
+  Remove-Variable secret -ErrorAction SilentlyContinue
+}
+```
+
+反映確認では値を表示せず、設定済みかだけを確認します。
+
+```powershell
+if ([string]::IsNullOrWhiteSpace($env:WINSMUX_OPENROUTER_API_KEY)) { "missing" } else { "configured" }
+```
+
+シェル起動ファイル、コマンド履歴、リポジトリ内の `.env`、公開ドキュメント、PR 本文、
+生成レポート、ワーカーログ、リリース証跡へ値を書かないでください。
 
 `api_llm` は `local_llm`、`colab_llm`、`colab_cli` と分けて扱います。
 API key の環境変数がない場合や、プロバイダーのエンドポイント設定が不正な場合は、

--- a/docs/provider-and-model-support.ja.md
+++ b/docs/provider-and-model-support.ja.md
@@ -48,6 +48,7 @@ CLI であることは認証方式や実行方式の列で説明します。
 - `execution_backend`: エージェント CLI、Colab ワーカー、OpenAI 互換ローカルエンドポイントなどの実行経路。
 - `runtime_requirements`: エンドポイント、実行ファイル、GPU、CPU、メモリ、OS、リモートランタイムの要件。
 - `model_catalog_source` と `model_options`: モデル名の取得元と、オペレーターが選べる候補。
+- `api_base_url` と `api_key_env`: 外部APIモデルワーカーが使う OpenAI 互換エンドポイントと、API key の環境変数名。
 - `analysis_posture`: 読み取り専用の分析に限るか、通常の書き込み可能ワーカーとして扱えるか。
 
 OpenAI 互換ローカルエンドポイントや GPU 付きローカルランタイムの既定は、
@@ -85,8 +86,9 @@ winsmux はこの値をリポジトリ、公開ドキュメント、PR 本文、
 コマンド履歴、リポジトリ内の `.env` へこのキーを書かないでください。
 
 `api_llm` は `local_llm`、`colab_llm`、`colab_cli` と分けて扱います。
-外部API実行が設定されていない場合、winsmux は診断理由を返し、ローカルや
-Colab の実行経路へ黙って切り替えません。
+API key の環境変数がない場合や、プロバイダーのエンドポイント設定が不正な場合は、
+通信前に `api_llm_api_key_env_missing` などの診断理由を返します。ローカルや
+Colab の実行経路へ黙って切り替えることはありません。
 
 ## 実行プロファイル方針
 

--- a/docs/provider-and-model-support.md
+++ b/docs/provider-and-model-support.md
@@ -56,7 +56,9 @@ Provider entries may declare:
 - `model_catalog_source` and `model_options`: where model names come from and
   which choices the operator can select.
 - `api_base_url` and `api_key_env`: the OpenAI-compatible endpoint and the
-  environment variable name used by hosted `api_llm` workers.
+  environment variable name used by hosted `api_llm` workers. Built-in hosted
+  providers such as `openrouter` keep these values fixed; custom endpoints are
+  limited to localhost.
 - `analysis_posture`: whether the provider is safe only for read-only analysis
   or can act as a normal write-capable worker.
 
@@ -84,10 +86,33 @@ The default OpenRouter-compatible base URL is
 `WINSMUX_OPENROUTER_API_KEY` when the operator chooses environment-based
 authentication. winsmux must not write this value to repository files, public
 docs, PR text, generated reports, worker logs, or release evidence.
-If the operator uses 1Password or another password manager, load the secret into
-the worker process environment before starting the worker. Do not use `setx`,
-shell startup files, inline command assignment, shell history, or repo-local
-`.env` files for this key.
+For public setup on Windows, store the key as a user environment variable and
+open a new PowerShell session before running `winsmux`:
+
+```powershell
+$secret = Read-Host -AsSecureString "OpenRouter API key"
+$bstr = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($secret)
+try {
+  [Environment]::SetEnvironmentVariable(
+    "WINSMUX_OPENROUTER_API_KEY",
+    [Runtime.InteropServices.Marshal]::PtrToStringBSTR($bstr),
+    "User"
+  )
+} finally {
+  [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr)
+  Remove-Variable secret -ErrorAction SilentlyContinue
+}
+```
+
+Verify only that the variable is present; do not print the value:
+
+```powershell
+if ([string]::IsNullOrWhiteSpace($env:WINSMUX_OPENROUTER_API_KEY)) { "missing" } else { "configured" }
+```
+
+Do not store the key in shell startup files, command history, repo-local `.env`
+files, public docs, PR text, generated reports, worker logs, or release
+evidence.
 
 `api_llm` is intentionally separate from `local_llm`, `colab_llm`, and
 `colab_cli`. If the API key environment variable is missing or the provider

--- a/docs/provider-and-model-support.md
+++ b/docs/provider-and-model-support.md
@@ -55,6 +55,8 @@ Provider entries may declare:
   runtime expectations.
 - `model_catalog_source` and `model_options`: where model names come from and
   which choices the operator can select.
+- `api_base_url` and `api_key_env`: the OpenAI-compatible endpoint and the
+  environment variable name used by hosted `api_llm` workers.
 - `analysis_posture`: whether the provider is safe only for read-only analysis
   or can act as a normal write-capable worker.
 
@@ -88,8 +90,10 @@ shell startup files, inline command assignment, shell history, or repo-local
 `.env` files for this key.
 
 `api_llm` is intentionally separate from `local_llm`, `colab_llm`, and
-`colab_cli`. If hosted API execution is not configured, winsmux reports a
-diagnostic reason instead of silently switching to a local or Colab runtime.
+`colab_cli`. If the API key environment variable is missing or the provider
+endpoint is invalid, winsmux reports a diagnostic reason such as
+`api_llm_api_key_env_missing` before network access instead of silently
+switching to a local or Colab runtime.
 
 ## Execution profile policy
 

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -5655,6 +5655,8 @@ function Get-WorkersStatusRows {
             CapabilityAdapter = [string]$slotConfig.CapabilityAdapter
             CredentialRequirements = [string]$slotConfig.CredentialRequirements
             ExecutionBackend = [string]$slotConfig.ExecutionBackend
+            ApiBaseUrl = [string]$slotConfig.ApiBaseUrl
+            ApiKeyEnv = [string]$slotConfig.ApiKeyEnv
             AnalysisPosture = [string]$slotConfig.AnalysisPosture
             Session        = $sessionName
             RequestedGpu   = $requestedGpu
@@ -5760,6 +5762,8 @@ function ConvertTo-WorkersStatusJsonRows {
             capability_adapter = [string]$row.CapabilityAdapter
             credential_requirements = [string]$row.CredentialRequirements
             execution_backend = [string]$row.ExecutionBackend
+            api_base_url    = [string]$row.ApiBaseUrl
+            api_key_env     = [string]$row.ApiKeyEnv
             analysis_posture = [string]$row.AnalysisPosture
             session         = [string]$row.Session
             requested_gpu   = [string]$row.RequestedGpu
@@ -9512,8 +9516,198 @@ function New-WorkersApiLlmMetadata {
         auth_policy             = [string](Get-SendConfigValue -InputObject $row -Name 'AuthPolicy' -Default '')
         credential_requirements = [string](Get-SendConfigValue -InputObject $row -Name 'CredentialRequirements' -Default '')
         execution_backend       = [string](Get-SendConfigValue -InputObject $row -Name 'ExecutionBackend' -Default '')
+        api_base_url            = [string](Get-SendConfigValue -InputObject $row -Name 'ApiBaseUrl' -Default '')
+        api_key_env             = [string](Get-SendConfigValue -InputObject $row -Name 'ApiKeyEnv' -Default '')
         capability_adapter      = [string](Get-SendConfigValue -InputObject $row -Name 'CapabilityAdapter' -Default '')
         analysis_posture        = [string](Get-SendConfigValue -InputObject $row -Name 'AnalysisPosture' -Default '')
+    }
+}
+
+function Get-WorkersApiLlmDefaultApiBaseUrl {
+    param([AllowEmptyString()][string]$Provider)
+
+    if ([string]::Equals(([string]$Provider), 'openrouter', [System.StringComparison]::OrdinalIgnoreCase)) {
+        return 'https://openrouter.ai/api/v1'
+    }
+
+    return ''
+}
+
+function Get-WorkersApiLlmDefaultApiKeyEnv {
+    param([AllowEmptyString()][string]$Provider)
+
+    if ([string]::Equals(([string]$Provider), 'openrouter', [System.StringComparison]::OrdinalIgnoreCase)) {
+        return 'WINSMUX_OPENROUTER_API_KEY'
+    }
+
+    $providerSlug = ([string]$Provider).Trim().ToUpperInvariant() -replace '[^A-Z0-9]+', '_'
+    $providerSlug = $providerSlug.Trim('_')
+    if ([string]::IsNullOrWhiteSpace($providerSlug)) {
+        return 'WINSMUX_API_LLM_API_KEY'
+    }
+
+    return "WINSMUX_${providerSlug}_API_KEY"
+}
+
+function Resolve-WorkersApiLlmRuntimeConfig {
+    param([Parameter(Mandatory = $true)]$Metadata)
+
+    $provider = [string](Get-SendConfigValue -InputObject $Metadata -Name 'provider' -Default '')
+    $baseUrl = [string](Get-SendConfigValue -InputObject $Metadata -Name 'api_base_url' -Default '')
+    if ([string]::IsNullOrWhiteSpace($baseUrl)) {
+        $baseUrl = Get-WorkersApiLlmDefaultApiBaseUrl -Provider $provider
+    }
+    if ([string]::IsNullOrWhiteSpace($baseUrl)) {
+        throw 'api_llm provider capability must declare api_base_url.'
+    }
+
+    $baseUri = $null
+    if (-not [System.Uri]::TryCreate($baseUrl, [System.UriKind]::Absolute, [ref]$baseUri)) {
+        throw "api_llm provider capability has invalid api_base_url: $baseUrl"
+    }
+    if ($baseUri.Scheme -notin @('https', 'http')) {
+        throw "api_llm api_base_url must use http or https: $baseUrl"
+    }
+    if ($baseUri.Scheme -eq 'http' -and $baseUri.Host -notin @('127.0.0.1', 'localhost', '::1')) {
+        throw "api_llm http api_base_url is only allowed for localhost test endpoints: $baseUrl"
+    }
+    if (-not [string]::IsNullOrWhiteSpace($baseUri.UserInfo)) {
+        throw 'api_llm api_base_url must not contain credentials.'
+    }
+
+    $apiKeyEnv = [string](Get-SendConfigValue -InputObject $Metadata -Name 'api_key_env' -Default '')
+    if ([string]::IsNullOrWhiteSpace($apiKeyEnv)) {
+        $apiKeyEnv = Get-WorkersApiLlmDefaultApiKeyEnv -Provider $provider
+    }
+    if ($apiKeyEnv -notmatch '^[A-Za-z_][A-Za-z0-9_]*$') {
+        throw "api_llm api_key_env contains unsupported characters: $apiKeyEnv"
+    }
+
+    $trimmedBase = $baseUri.AbsoluteUri.TrimEnd('/')
+    return [PSCustomObject]@{
+        Provider     = $provider
+        BaseUrl      = $trimmedBase
+        Endpoint     = "$trimmedBase/chat/completions"
+        EndpointHost = $baseUri.Host
+        ApiKeyEnv    = $apiKeyEnv
+    }
+}
+
+function Get-WorkersApiLlmEnvValue {
+    param([Parameter(Mandatory = $true)][string]$Name)
+
+    $item = Get-Item -Path "Env:$Name" -ErrorAction SilentlyContinue
+    if ($null -eq $item) {
+        return ''
+    }
+
+    return [string]$item.Value
+}
+
+function Get-WorkersApiLlmTimeoutSeconds {
+    $raw = [string]$env:WINSMUX_API_LLM_TIMEOUT_SECONDS
+    $parsed = 0
+    if (-not [string]::IsNullOrWhiteSpace($raw) -and [int]::TryParse($raw, [ref]$parsed) -and $parsed -gt 0) {
+        return $parsed
+    }
+
+    return 120
+}
+
+function Get-WorkersApiLlmMaxTokens {
+    $raw = [string]$env:WINSMUX_API_LLM_MAX_TOKENS
+    $parsed = 0
+    if (-not [string]::IsNullOrWhiteSpace($raw) -and [int]::TryParse($raw, [ref]$parsed) -and $parsed -gt 0) {
+        return $parsed
+    }
+
+    return 1024
+}
+
+function New-WorkersApiLlmMessages {
+    param(
+        [Parameter(Mandatory = $true)][string]$InputKind,
+        [AllowEmptyString()][string]$InputContent
+    )
+
+    $inputLabel = if ($InputKind -eq 'task_json') { 'task JSON' } else { 'task prompt file' }
+    return @(
+        [ordered]@{
+            role    = 'system'
+            content = 'You are a winsmux hosted API worker. Return the requested result only. Do not echo secrets, API keys, request IDs, local paths, or the full input prompt.'
+        },
+        [ordered]@{
+            role    = 'user'
+            content = "Complete this winsmux $inputLabel.`n`n$InputContent"
+        }
+    )
+}
+
+function Get-WorkersApiLlmResponseText {
+    param([AllowNull()]$Response)
+
+    $choices = @((Get-SendConfigValue -InputObject $Response -Name 'choices' -Default @()))
+    if ($choices.Count -lt 1) {
+        return ''
+    }
+
+    $firstChoice = $choices[0]
+    $message = Get-SendConfigValue -InputObject $firstChoice -Name 'message' -Default $null
+    $content = Get-SendConfigValue -InputObject $message -Name 'content' -Default ''
+    if ($content -is [string]) {
+        return [string]$content
+    }
+    if ($null -ne $content) {
+        return ($content | ConvertTo-Json -Depth 8)
+    }
+
+    $text = Get-SendConfigValue -InputObject $firstChoice -Name 'text' -Default ''
+    return [string]$text
+}
+
+function Get-WorkersApiLlmUsageMetadata {
+    param([AllowNull()]$Response)
+
+    $usage = Get-SendConfigValue -InputObject $Response -Name 'usage' -Default $null
+    if ($null -eq $usage) {
+        return [ordered]@{}
+    }
+
+    return [ordered]@{
+        prompt_tokens     = Get-SendConfigValue -InputObject $usage -Name 'prompt_tokens' -Default $null
+        completion_tokens = Get-SendConfigValue -InputObject $usage -Name 'completion_tokens' -Default $null
+        total_tokens      = Get-SendConfigValue -InputObject $usage -Name 'total_tokens' -Default $null
+    }
+}
+
+function Invoke-WorkersOpenAiCompatibleChatCompletion {
+    param(
+        [Parameter(Mandatory = $true)]$RuntimeConfig,
+        [Parameter(Mandatory = $true)]$Metadata,
+        [Parameter(Mandatory = $true)][string]$InputKind,
+        [AllowEmptyString()][string]$InputContent,
+        [Parameter(Mandatory = $true)][string]$ApiKey
+    )
+
+    $body = [ordered]@{
+        model       = [string](Get-SendConfigValue -InputObject $Metadata -Name 'model' -Default '')
+        messages    = @(New-WorkersApiLlmMessages -InputKind $InputKind -InputContent $InputContent)
+        temperature = 0
+        max_tokens  = Get-WorkersApiLlmMaxTokens
+    }
+    $jsonBody = $body | ConvertTo-Json -Depth 16
+    $headers = @{
+        Authorization = "Bearer $ApiKey"
+        Accept        = 'application/json'
+    }
+
+    $response = Invoke-RestMethod -Uri ([string]$RuntimeConfig.Endpoint) -Method Post -Headers $headers -Body $jsonBody -ContentType 'application/json' -TimeoutSec (Get-WorkersApiLlmTimeoutSeconds) -ErrorAction Stop
+    $responseText = Get-WorkersApiLlmResponseText -Response $response
+    return [PSCustomObject]@{
+        Response                  = $response
+        Text                      = [string]$responseText
+        Usage                     = Get-WorkersApiLlmUsageMetadata -Response $response
+        ProviderResponseIdPresent = -not [string]::IsNullOrWhiteSpace([string](Get-SendConfigValue -InputObject $response -Name 'id' -Default ''))
     }
 }
 
@@ -9568,24 +9762,95 @@ function Invoke-WorkersApiLlmExec {
     }
 
     $metadata = New-WorkersApiLlmMetadata -Worker $Worker
-    $reason = 'api_llm_runner_unconfigured'
     $logPath = Join-Path $runDir 'stdout.log'
-    $logLines = @(
-        'api_llm runner is not configured.',
-        "reason: $reason",
-        "provider: $($metadata.provider)",
-        "model: $($metadata.model)",
-        "input: $($inputInfo.RelativePath)",
-        'network: not_started',
-        'next: TASK-504 owns OpenRouter/OpenAI-compatible execution and API key binding.'
-    )
+    $responsePath = Join-Path $runDir 'response.txt'
+    $runtime = $null
+    $status = 'blocked'
+    $reason = ''
+    $exitCode = 1
+    $network = 'not_started'
+    $responseReference = ''
+    $usage = [ordered]@{}
+    $providerResponseIdPresent = $false
+    $runtimeError = ''
+    $apiKeyEnv = ''
+    $endpointHost = ''
+
+    if (
+        [string]::IsNullOrWhiteSpace([string]$metadata.provider) -or
+        [string]::IsNullOrWhiteSpace([string]$metadata.model) -or
+        (-not [string]::Equals([string]$metadata.capability_adapter, 'openai-compatible', [System.StringComparison]::OrdinalIgnoreCase)) -or
+        (-not [string]::Equals([string]$metadata.execution_backend, 'openai-compatible-chat-completions', [System.StringComparison]::OrdinalIgnoreCase))
+    ) {
+        $reason = 'api_llm_runner_unconfigured'
+    } else {
+        try {
+            $runtime = Resolve-WorkersApiLlmRuntimeConfig -Metadata $metadata
+            $apiKeyEnv = [string]$runtime.ApiKeyEnv
+            $endpointHost = [string]$runtime.EndpointHost
+        } catch {
+            $reason = 'api_llm_runtime_config_invalid'
+            $runtimeError = [string]$_.Exception.Message
+        }
+    }
+
+    if ([string]::IsNullOrWhiteSpace($reason)) {
+        $apiKey = Get-WorkersApiLlmEnvValue -Name $apiKeyEnv
+        if ([string]::IsNullOrWhiteSpace($apiKey)) {
+            $reason = 'api_llm_api_key_env_missing'
+        } else {
+            try {
+                $network = 'started'
+                $completion = Invoke-WorkersOpenAiCompatibleChatCompletion -RuntimeConfig $runtime -Metadata $metadata -InputKind $inputKind -InputContent ([string]$inputContent) -ApiKey $apiKey
+                $network = 'completed'
+                $status = 'succeeded'
+                $reason = ''
+                $exitCode = 0
+                $usage = $completion.Usage
+                $providerResponseIdPresent = [bool]$completion.ProviderResponseIdPresent
+                Write-ClmSafeTextFile -Path $responsePath -Content (ConvertTo-WorkersSafeLogText -Text ([string]$completion.Text))
+                $responseReference = Get-WorkersArtifactReference -ProjectDir $Options.ProjectDir -Path $responsePath
+            } catch {
+                $status = 'failed'
+                $reason = 'api_llm_request_failed'
+                $network = 'failed'
+                $runtimeError = ConvertTo-WorkersSafeLogText -Text ([string]$_.Exception.Message)
+            }
+        }
+    }
+
+    $logLines = [System.Collections.Generic.List[string]]::new()
+    $logLines.Add('api_llm runner execution summary.') | Out-Null
+    $logLines.Add("status: $status") | Out-Null
+    if (-not [string]::IsNullOrWhiteSpace($reason)) {
+        $logLines.Add("reason: $reason") | Out-Null
+    }
+    $logLines.Add("provider: $($metadata.provider)") | Out-Null
+    $logLines.Add("model: $($metadata.model)") | Out-Null
+    $logLines.Add("input: $($inputInfo.RelativePath)") | Out-Null
+    if (-not [string]::IsNullOrWhiteSpace($apiKeyEnv)) {
+        $logLines.Add("api_key_env: $apiKeyEnv") | Out-Null
+    }
+    if (-not [string]::IsNullOrWhiteSpace($endpointHost)) {
+        $logLines.Add("endpoint_host: $endpointHost") | Out-Null
+    }
+    $logLines.Add("network: $network") | Out-Null
+    if (-not [string]::IsNullOrWhiteSpace($responseReference)) {
+        $logLines.Add("response: $responseReference") | Out-Null
+    }
+    if (-not [string]::IsNullOrWhiteSpace($runtimeError)) {
+        $logLines.Add("detail: $runtimeError") | Out-Null
+    }
+    if ($reason -eq 'api_llm_api_key_env_missing') {
+        $logLines.Add("next: set $apiKeyEnv in the worker process environment before running hosted API E2E.") | Out-Null
+    }
     Write-ClmSafeTextFile -Path $logPath -Content (ConvertTo-WorkersSafeLogText -Text ($logLines -join [Environment]::NewLine))
 
     $payload = [ordered]@{
         project_dir    = $Options.ProjectDir
         generated_at   = (Get-Date).ToUniversalTime().ToString('o')
         command        = 'workers.exec'
-        status         = 'blocked'
+        status         = $status
         reason         = $reason
         backend        = 'api_llm'
         slot           = [string]$Worker.Row.Slot
@@ -9598,18 +9863,34 @@ function Invoke-WorkersApiLlmExec {
         task_json      = if ($inputKind -eq 'task_json') { [string]$inputInfo.RelativePath } else { [string]$Options.TaskJsonPath }
         run_dir        = Get-WorkersArtifactReference -ProjectDir $Options.ProjectDir -Path $runDir
         stdout_log     = Get-WorkersArtifactReference -ProjectDir $Options.ProjectDir -Path $logPath
-        exit_code      = 1
+        response       = $responseReference
+        exit_code      = $exitCode
         prompt_value_output = $false
+        network        = $network
+        api_key_env    = $apiKeyEnv
+        endpoint_host  = $endpointHost
+        usage          = $usage
+        provider_response_id_present = $providerResponseIdPresent
         api_llm        = $metadata
         locations      = [ordered]@{
             input = New-WinsmuxLocationIdentity -Kind 'local_file' -DisplayName ([string]$inputInfo.RelativePath) -Backend 'local-windows' -AccessMethod 'project_path' -Reference ([string]$inputInfo.RelativePath) -Provenance 'workers.exec.input'
         }
     }
+    if (-not [string]::IsNullOrWhiteSpace($responseReference)) {
+        $payload.locations['response'] = New-WinsmuxLocationIdentity -Kind 'local_file' -DisplayName 'response.txt' -Backend 'local-windows' -AccessMethod 'artifact_ref' -Reference $responseReference -Provenance 'workers.exec.response'
+    }
     $runJsonPath = Join-Path $runDir 'run.json'
     $payload['run_json'] = Get-WorkersArtifactReference -ProjectDir $Options.ProjectDir -Path $runJsonPath
     Write-WorkersJsonArtifact -Path $runJsonPath -Data $payload | Out-Null
     if ($null -ne $Worker.Entry) {
-        Set-WorkersManifestLifecycleCommand -Entry $Worker.Entry -CommandName 'workers.exec'
+        Set-WorkersManifestLifecycleCommand -Entry $Worker.Entry -CommandName 'workers.exec' -Status $status -ExtraProperties ([ordered]@{
+            last_api_llm_run_id = $runId
+            last_api_llm_status = $status
+            last_api_llm_reason = $reason
+            last_api_llm_network = $network
+            last_api_llm_stdout_log = [string]$payload.stdout_log
+            last_api_llm_run_json = [string]$payload.run_json
+        })
     }
 
     Write-WorkersOperationOutput -Payload $payload -Json:([bool]$Options.Json)
@@ -10228,6 +10509,9 @@ function Invoke-WorkersDoctor {
     $colabSlotCount = 0
     $apiLlmSlotCount = 0
     $apiLlmMissingMetadataCount = 0
+    $apiLlmRuntimeConfigErrors = [System.Collections.Generic.List[string]]::new()
+    $apiLlmApiKeyEnvNames = [System.Collections.Generic.List[string]]::new()
+    $apiLlmMissingApiKeyEnvNames = [System.Collections.Generic.List[string]]::new()
 
     try {
         $context = Get-WorkersLifecycleContext -ProjectDir $options.ProjectDir
@@ -10251,6 +10535,25 @@ function Invoke-WorkersDoctor {
                     (-not $usesOpenAiCompatibleProvider)
                 ) {
                     $apiLlmMissingMetadataCount++
+                } else {
+                    $apiRuntimeMetadata = [ordered]@{
+                        provider       = [string]$slotConfig.Agent
+                        model          = [string]$slotConfig.Model
+                        api_base_url   = [string]$slotConfig.ApiBaseUrl
+                        api_key_env    = [string]$slotConfig.ApiKeyEnv
+                    }
+                    try {
+                        $runtime = Resolve-WorkersApiLlmRuntimeConfig -Metadata $apiRuntimeMetadata
+                        $apiKeyEnvName = [string]$runtime.ApiKeyEnv
+                        if (-not [string]::IsNullOrWhiteSpace($apiKeyEnvName) -and -not $apiLlmApiKeyEnvNames.Contains($apiKeyEnvName)) {
+                            $apiLlmApiKeyEnvNames.Add($apiKeyEnvName) | Out-Null
+                        }
+                        if ([string]::IsNullOrWhiteSpace((Get-WorkersApiLlmEnvValue -Name $apiKeyEnvName)) -and -not $apiLlmMissingApiKeyEnvNames.Contains($apiKeyEnvName)) {
+                            $apiLlmMissingApiKeyEnvNames.Add($apiKeyEnvName) | Out-Null
+                        }
+                    } catch {
+                        $apiLlmRuntimeConfigErrors.Add([string]$_.Exception.Message) | Out-Null
+                    }
                 }
             }
         }
@@ -10265,7 +10568,18 @@ function Invoke-WorkersDoctor {
         } else {
             $checks.Add((New-WorkersDoctorCheck -Status 'pass' -Label 'api_llm backend' -Detail "$apiLlmSlotCount api_llm worker slots configured" -Action '')) | Out-Null
         }
-        $checks.Add((New-WorkersDoctorCheck -Status 'warn' -Label 'api_llm runner' -Detail 'OpenAI-compatible execution is not configured by TASK-503' -Action 'Implement TASK-504 before real external API execution.')) | Out-Null
+        if ($apiLlmRuntimeConfigErrors.Count -gt 0) {
+            $checks.Add((New-WorkersDoctorCheck -Status 'fail' -Label 'api_llm runner' -Detail ($apiLlmRuntimeConfigErrors -join '; ') -Action 'Fix api_base_url and api_key_env in the provider capability registry.')) | Out-Null
+        } else {
+            $checks.Add((New-WorkersDoctorCheck -Status 'pass' -Label 'api_llm runner' -Detail 'OpenAI-compatible chat completions execution is available; credentials are checked at run time.' -Action '')) | Out-Null
+        }
+        if ($apiLlmApiKeyEnvNames.Count -gt 0) {
+            if ($apiLlmMissingApiKeyEnvNames.Count -gt 0) {
+                $checks.Add((New-WorkersDoctorCheck -Status 'warn' -Label 'api_llm API key env' -Detail ("missing: {0}" -f ($apiLlmMissingApiKeyEnvNames -join ', ')) -Action 'Set the API key in the worker process environment before hosted API E2E.')) | Out-Null
+            } else {
+                $checks.Add((New-WorkersDoctorCheck -Status 'pass' -Label 'api_llm API key env' -Detail ("configured: {0}" -f ($apiLlmApiKeyEnvNames -join ', ')) -Action '')) | Out-Null
+            }
+        }
     }
 
     $manifestPath = Join-Path (Join-Path $options.ProjectDir '.winsmux') 'manifest.yaml'

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -6043,6 +6043,7 @@ function ConvertTo-WorkersSafeLogText {
     $safe = [regex]::Replace($safe, '(?is)-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----.*?-----END [A-Z0-9 ]*PRIVATE KEY-----', '[PRIVATE_KEY_REDACTED]')
     $safe = [regex]::Replace($safe, '(?i)(?<![A-Za-z0-9_])(["'']?authorization["'']?\s*[:=]\s*["'']?\s*bearer\s+)[^\s"'',;}]+', '$1[REDACTED]')
     $safe = [regex]::Replace($safe, '(?i)(?<![A-Za-z0-9_])(["'']?(?:api[_-]?key|access[_-]?token|refresh[_-]?token|oauth[_-]?token|token|password|passwd|secret|credential|credentials)["'']?\s*[:=]\s*["'']?)[^\s"'',;}]+', '$1[REDACTED]')
+    $safe = [regex]::Replace($safe, '(?i)(?<![A-Za-z0-9_])(["'']?(?:x-request-id|request[_-]?id|provider[_-]?response[_-]?id)["'']?\s*[:=]\s*["'']?)[^\s"'',;}]+', '$1[REDACTED]')
     $safe = [regex]::Replace($safe, '(?i)/content/drive/(?:MyDrive|Shareddrives)(?:/[^\s"'']*)?', '[DRIVE_PATH_REDACTED]')
     $safe = [regex]::Replace($safe, '(?i)\b[A-Z]:\\[^"'',;}\r\n]+', '[LOCAL_PATH_REDACTED]')
     return $safe
@@ -9549,14 +9550,59 @@ function Get-WorkersApiLlmDefaultApiKeyEnv {
     return "WINSMUX_${providerSlug}_API_KEY"
 }
 
+function Test-WorkersApiLlmLocalHost {
+    param([AllowEmptyString()][string]$HostName)
+
+    if ([string]::IsNullOrWhiteSpace($HostName)) {
+        return $false
+    }
+
+    $normalized = $HostName.Trim().ToLowerInvariant()
+    return ($normalized -in @('localhost', '127.0.0.1', '::1'))
+}
+
+function Test-WorkersApiLlmCompatibleEndpoint {
+    param(
+        [Parameter(Mandatory = $true)][System.Uri]$Uri,
+        [Parameter(Mandatory = $true)][string]$Provider
+    )
+
+    if ([string]::Equals($Provider, 'openrouter', [System.StringComparison]::OrdinalIgnoreCase)) {
+        return [string]::Equals($Uri.AbsoluteUri.TrimEnd('/'), 'https://openrouter.ai/api/v1', [System.StringComparison]::OrdinalIgnoreCase)
+    }
+
+    return (Test-WorkersApiLlmLocalHost -HostName $Uri.Host)
+}
+
 function Resolve-WorkersApiLlmRuntimeConfig {
     param([Parameter(Mandatory = $true)]$Metadata)
 
-    $provider = [string](Get-SendConfigValue -InputObject $Metadata -Name 'provider' -Default '')
-    $baseUrl = [string](Get-SendConfigValue -InputObject $Metadata -Name 'api_base_url' -Default '')
-    if ([string]::IsNullOrWhiteSpace($baseUrl)) {
-        $baseUrl = Get-WorkersApiLlmDefaultApiBaseUrl -Provider $provider
+    $provider = ([string](Get-SendConfigValue -InputObject $Metadata -Name 'provider' -Default '')).Trim().ToLowerInvariant()
+    $authMode = ([string](Get-SendConfigValue -InputObject $Metadata -Name 'auth_mode' -Default '')).Trim().ToLowerInvariant()
+    if (-not [string]::Equals($authMode, 'api-key-env', [System.StringComparison]::OrdinalIgnoreCase)) {
+        throw "api_llm auth_mode must be api-key-env for hosted API execution: $authMode"
     }
+
+    $declaredBaseUrl = [string](Get-SendConfigValue -InputObject $Metadata -Name 'api_base_url' -Default '')
+    $declaredApiKeyEnv = [string](Get-SendConfigValue -InputObject $Metadata -Name 'api_key_env' -Default '')
+    $defaultBaseUrl = Get-WorkersApiLlmDefaultApiBaseUrl -Provider $provider
+    $defaultApiKeyEnv = Get-WorkersApiLlmDefaultApiKeyEnv -Provider $provider
+
+    $baseUrl = $declaredBaseUrl
+    $apiKeyEnv = $declaredApiKeyEnv
+    if ([string]::Equals($provider, 'openrouter', [System.StringComparison]::OrdinalIgnoreCase)) {
+        if (-not [string]::IsNullOrWhiteSpace($declaredBaseUrl) -and -not [string]::Equals($declaredBaseUrl.Trim().TrimEnd('/'), $defaultBaseUrl, [System.StringComparison]::OrdinalIgnoreCase)) {
+            throw 'api_llm provider openrouter uses a built-in endpoint; api_base_url overrides are not allowed.'
+        }
+        if (-not [string]::IsNullOrWhiteSpace($declaredApiKeyEnv) -and -not [string]::Equals($declaredApiKeyEnv.Trim(), $defaultApiKeyEnv, [System.StringComparison]::OrdinalIgnoreCase)) {
+            throw 'api_llm provider openrouter uses the built-in WINSMUX_OPENROUTER_API_KEY environment variable; api_key_env overrides are not allowed.'
+        }
+        $baseUrl = $defaultBaseUrl
+        $apiKeyEnv = $defaultApiKeyEnv
+    } elseif ([string]::IsNullOrWhiteSpace($apiKeyEnv)) {
+        $apiKeyEnv = $defaultApiKeyEnv
+    }
+
     if ([string]::IsNullOrWhiteSpace($baseUrl)) {
         throw 'api_llm provider capability must declare api_base_url.'
     }
@@ -9574,13 +9620,19 @@ function Resolve-WorkersApiLlmRuntimeConfig {
     if (-not [string]::IsNullOrWhiteSpace($baseUri.UserInfo)) {
         throw 'api_llm api_base_url must not contain credentials.'
     }
-
-    $apiKeyEnv = [string](Get-SendConfigValue -InputObject $Metadata -Name 'api_key_env' -Default '')
-    if ([string]::IsNullOrWhiteSpace($apiKeyEnv)) {
-        $apiKeyEnv = Get-WorkersApiLlmDefaultApiKeyEnv -Provider $provider
+    if (-not (Test-WorkersApiLlmCompatibleEndpoint -Uri $baseUri -Provider $provider)) {
+        throw 'api_llm remote endpoints are only supported for built-in providers; custom OpenAI-compatible endpoints must be localhost.'
     }
     if ($apiKeyEnv -notmatch '^[A-Za-z_][A-Za-z0-9_]*$') {
         throw "api_llm api_key_env contains unsupported characters: $apiKeyEnv"
+    }
+    if (-not [string]::Equals($provider, 'openrouter', [System.StringComparison]::OrdinalIgnoreCase)) {
+        if (-not (
+            [string]::Equals($apiKeyEnv, $defaultApiKeyEnv, [System.StringComparison]::OrdinalIgnoreCase) -or
+            $apiKeyEnv.StartsWith('WINSMUX_API_LLM_', [System.StringComparison]::OrdinalIgnoreCase)
+        )) {
+            throw "api_llm custom provider api_key_env must be provider-scoped ($defaultApiKeyEnv) or WINSMUX_API_LLM_*."
+        }
     }
 
     $trimmedBase = $baseUri.AbsoluteUri.TrimEnd('/')
@@ -9706,6 +9758,7 @@ function Invoke-WorkersOpenAiCompatibleChatCompletion {
     return [PSCustomObject]@{
         Response                  = $response
         Text                      = [string]$responseText
+        ResponseMalformed         = [string]::IsNullOrWhiteSpace([string]$responseText)
         Usage                     = Get-WorkersApiLlmUsageMetadata -Response $response
         ProviderResponseIdPresent = -not [string]::IsNullOrWhiteSpace([string](Get-SendConfigValue -InputObject $response -Name 'id' -Default ''))
     }
@@ -9803,13 +9856,20 @@ function Invoke-WorkersApiLlmExec {
                 $network = 'started'
                 $completion = Invoke-WorkersOpenAiCompatibleChatCompletion -RuntimeConfig $runtime -Metadata $metadata -InputKind $inputKind -InputContent ([string]$inputContent) -ApiKey $apiKey
                 $network = 'completed'
-                $status = 'succeeded'
-                $reason = ''
-                $exitCode = 0
                 $usage = $completion.Usage
                 $providerResponseIdPresent = [bool]$completion.ProviderResponseIdPresent
-                Write-ClmSafeTextFile -Path $responsePath -Content (ConvertTo-WorkersSafeLogText -Text ([string]$completion.Text))
-                $responseReference = Get-WorkersArtifactReference -ProjectDir $Options.ProjectDir -Path $responsePath
+                if ([bool]$completion.ResponseMalformed) {
+                    $status = 'failed'
+                    $reason = 'api_llm_response_malformed'
+                    $exitCode = 1
+                    $runtimeError = 'provider response did not include non-empty choices message content'
+                } else {
+                    $status = 'succeeded'
+                    $reason = ''
+                    $exitCode = 0
+                    Write-ClmSafeTextFile -Path $responsePath -Content (ConvertTo-WorkersSafeLogText -Text ([string]$completion.Text))
+                    $responseReference = Get-WorkersArtifactReference -ProjectDir $Options.ProjectDir -Path $responsePath
+                }
             } catch {
                 $status = 'failed'
                 $reason = 'api_llm_request_failed'
@@ -9942,9 +10002,9 @@ function Invoke-WorkersApiLlmLogs {
                         $exitCode = $storedExitCode
                     }
                 } catch {
-                    $status = 'succeeded'
-                    $reason = ''
-                    $exitCode = 0
+                    $status = 'failed'
+                    $reason = 'api_llm_run_json_invalid'
+                    $exitCode = 1
                 }
             } else {
                 $status = 'succeeded'
@@ -10539,6 +10599,7 @@ function Invoke-WorkersDoctor {
                     $apiRuntimeMetadata = [ordered]@{
                         provider       = [string]$slotConfig.Agent
                         model          = [string]$slotConfig.Model
+                        auth_mode      = [string]$slotConfig.AuthMode
                         api_base_url   = [string]$slotConfig.ApiBaseUrl
                         api_key_env    = [string]$slotConfig.ApiKeyEnv
                     }

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -11141,6 +11141,105 @@ worker-backend: colab_cli
         ($logsOutput | Out-String) | Should -Not -Match 'google-colab-cli'
     }
 
+    It 'rejects OpenRouter endpoint overrides before network access' {
+        Write-WorkersApiLlmProjectConfig
+        'Summarize the repository status.' | Set-Content -Path (Join-Path $script:workersTempRoot 'prompt.md') -Encoding UTF8
+        $env:WINSMUX_OPENROUTER_API_KEY = 'test-openrouter-key'
+@'
+{
+  "version": 1,
+  "providers": {
+    "openrouter": {
+      "adapter": "openai-compatible",
+      "display_name": "OpenRouter",
+      "command": "openrouter",
+      "prompt_transports": ["file"],
+      "auth_modes": ["api-key-env"],
+      "model_sources": ["operator-override"],
+      "credential_requirements": "runtime-owned-api-key",
+      "execution_backend": "openai-compatible-chat-completions",
+      "api_base_url": "https://attacker.example.invalid/api",
+      "api_key_env": "WINSMUX_OPENROUTER_API_KEY",
+      "analysis_posture": "hosted-api-worker"
+    }
+  }
+}
+'@ | Set-Content -Path (Join-Path $script:workersTempRoot '.winsmux\provider-capabilities.json') -Encoding UTF8
+
+        $output = & pwsh -NoProfile -File $script:winsmuxWorkersCorePath workers exec w1 --script prompt.md --run-id api-hostile-run --json --project-dir $script:workersTempRoot 2>&1
+        $payload = ($output | Select-Object -Last 1) | ConvertFrom-Json
+
+        $LASTEXITCODE | Should -Be 1
+        $payload.status | Should -Be 'blocked'
+        $payload.reason | Should -Be 'api_llm_runtime_config_invalid'
+        $payload.network | Should -Be 'not_started'
+        $payload.endpoint_host | Should -Be ''
+        $payload.api_key_env | Should -Be ''
+
+        $logPath = Join-Path $script:workersTempRoot ($payload.stdout_log -replace '/', '\')
+        $logText = Get-Content -LiteralPath $logPath -Raw -Encoding UTF8
+        $logText | Should -Match 'api_base_url overrides are not allowed'
+        $logText | Should -Not -Match 'test-openrouter-key'
+    }
+
+    It 'rejects unsupported and unsafe api_llm runtime metadata' {
+        { Resolve-WorkersApiLlmRuntimeConfig -Metadata ([ordered]@{
+                provider = 'openrouter'
+                auth_mode = 'api-key-vault'
+            }) } | Should -Throw '*auth_mode must be api-key-env*'
+
+        { Resolve-WorkersApiLlmRuntimeConfig -Metadata ([ordered]@{
+                provider = 'custom-remote'
+                auth_mode = 'api-key-env'
+                api_base_url = 'https://attacker.example.invalid/v1'
+                api_key_env = 'WINSMUX_CUSTOM_REMOTE_API_KEY'
+            }) } | Should -Throw '*custom OpenAI-compatible endpoints must be localhost*'
+
+        { Resolve-WorkersApiLlmRuntimeConfig -Metadata ([ordered]@{
+                provider = 'local-openai-compatible'
+                auth_mode = 'api-key-env'
+                api_base_url = 'http://127.0.0.1:8080/v1'
+                api_key_env = 'WINSMUX_OPENROUTER_API_KEY'
+            }) } | Should -Throw '*custom provider api_key_env must be provider-scoped*'
+    }
+
+    It 'marks empty provider completions as malformed' {
+        Mock Invoke-RestMethod {
+            return [pscustomobject]@{
+                id = 'chatcmpl-empty'
+                choices = @(
+                    [pscustomobject]@{
+                        message = [pscustomobject]@{
+                            content = ''
+                        }
+                    }
+                )
+            }
+        }
+
+        $completion = Invoke-WorkersOpenAiCompatibleChatCompletion `
+            -RuntimeConfig ([pscustomobject]@{ Endpoint = 'https://openrouter.ai/api/v1/chat/completions' }) `
+            -Metadata ([ordered]@{ model = 'z-ai/glm-5.2' }) `
+            -InputKind 'script' `
+            -InputContent 'Summarize the repository status.' `
+            -ApiKey 'test-openrouter-key'
+
+        $completion.ResponseMalformed | Should -Be $true
+        $completion.ProviderResponseIdPresent | Should -Be $true
+        Should -Invoke Invoke-RestMethod -Times 1 -Exactly
+    }
+
+    It 'redacts provider request ids from api_llm log details' {
+        $safe = ConvertTo-WorkersSafeLogText -Text 'provider failed: x-request-id=req-123 request_id: req-456 provider_response_id="chatcmpl-789"'
+
+        $safe | Should -Not -Match 'req-123'
+        $safe | Should -Not -Match 'req-456'
+        $safe | Should -Not -Match 'chatcmpl-789'
+        $safe | Should -Match 'x-request-id=\[REDACTED\]'
+        $safe | Should -Match 'request_id: \[REDACTED\]'
+        $safe | Should -Match 'provider_response_id="\[REDACTED\]'
+    }
+
     It 'runs api_llm exec through OpenAI-compatible chat completions with an env key' {
         Write-WorkersApiLlmProjectConfig
         'Summarize the repository status.' | Set-Content -Path (Join-Path $script:workersTempRoot 'prompt.md') -Encoding UTF8

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -8989,10 +8989,12 @@ Describe 'winsmux workers command' {
         $script:previousColabAuth = $env:WINSMUX_COLAB_AUTH_STATE
         $script:previousColabGpu = $env:WINSMUX_COLAB_AVAILABLE_GPUS
         $script:previousWorkersNow = $env:WINSMUX_TEST_NOW_UTC
+        $script:previousOpenRouterApiKey = $env:WINSMUX_OPENROUTER_API_KEY
         $env:WINSMUX_COLAB_CLI = 'winsmux-test-missing-google-colab-cli'
         $env:WINSMUX_COLAB_AUTH_STATE = ''
         $env:WINSMUX_COLAB_AVAILABLE_GPUS = ''
         $env:WINSMUX_TEST_NOW_UTC = ''
+        $env:WINSMUX_OPENROUTER_API_KEY = ''
     }
 
     AfterEach {
@@ -9000,6 +9002,7 @@ Describe 'winsmux workers command' {
         $env:WINSMUX_COLAB_AUTH_STATE = $script:previousColabAuth
         $env:WINSMUX_COLAB_AVAILABLE_GPUS = $script:previousColabGpu
         $env:WINSMUX_TEST_NOW_UTC = $script:previousWorkersNow
+        $env:WINSMUX_OPENROUTER_API_KEY = $script:previousOpenRouterApiKey
         if ($script:workersTempRoot -and (Test-Path -LiteralPath $script:workersTempRoot)) {
             Remove-Item -LiteralPath $script:workersTempRoot -Recurse -Force
         }
@@ -9071,6 +9074,8 @@ agent-slots:
       "reasoning_efforts": ["provider-default", "low", "medium", "high"],
       "credential_requirements": "runtime-owned-api-key",
       "execution_backend": "openai-compatible-chat-completions",
+      "api_base_url": "https://openrouter.ai/api/v1",
+      "api_key_env": "WINSMUX_OPENROUTER_API_KEY",
       "analysis_posture": "hosted-api-worker",
       "supports_file_edit": false,
       "supports_structured_result": true
@@ -10508,6 +10513,8 @@ worker-backend: colab_cli
         $row.auth_mode | Should -Be 'api-key-env'
         $row.credential_requirements | Should -Be 'runtime-owned-api-key'
         $row.execution_backend | Should -Be 'openai-compatible-chat-completions'
+        $row.api_base_url | Should -Be 'https://openrouter.ai/api/v1'
+        $row.api_key_env | Should -Be 'WINSMUX_OPENROUTER_API_KEY'
         $row.capability_adapter | Should -Be 'openai-compatible'
         $row.session | Should -Be ''
         $row.actual_gpu | Should -Be ''
@@ -10521,11 +10528,14 @@ worker-backend: colab_cli
         $payload = ($output | Select-Object -Last 1) | ConvertFrom-Json
         $apiBackend = @($payload.checks | Where-Object { $_.label -eq 'api_llm backend' })[0]
         $apiRunner = @($payload.checks | Where-Object { $_.label -eq 'api_llm runner' })[0]
+        $apiKeyEnv = @($payload.checks | Where-Object { $_.label -eq 'api_llm API key env' })[0]
 
         $apiBackend.status | Should -Be 'pass'
         $apiBackend.detail | Should -Be '1 api_llm worker slots configured'
-        $apiRunner.status | Should -Be 'warn'
-        $apiRunner.detail | Should -Match 'OpenAI-compatible execution'
+        $apiRunner.status | Should -Be 'pass'
+        $apiRunner.detail | Should -Match 'OpenAI-compatible chat completions execution is available'
+        $apiKeyEnv.status | Should -Be 'warn'
+        $apiKeyEnv.detail | Should -Match 'WINSMUX_OPENROUTER_API_KEY'
         ($payload | ConvertTo-Json -Depth 24) | Should -Not -Match 'colab worker worker-1'
     }
 
@@ -11087,7 +11097,7 @@ worker-backend: colab_cli
         }
     }
 
-    It 'records blocked api_llm exec artifacts without invoking Colab' {
+    It 'records blocked api_llm exec artifacts when the API key env is missing without invoking Colab' {
         Write-WorkersApiLlmProjectConfig
         'Summarize the repository status.' | Set-Content -Path (Join-Path $script:workersTempRoot 'prompt.md') -Encoding UTF8
 
@@ -11096,13 +11106,18 @@ worker-backend: colab_cli
 
         $LASTEXITCODE | Should -Be 1
         $payload.status | Should -Be 'blocked'
-        $payload.reason | Should -Be 'api_llm_runner_unconfigured'
+        $payload.reason | Should -Be 'api_llm_api_key_env_missing'
         $payload.backend | Should -Be 'api_llm'
         $payload.slot_id | Should -Be 'worker-1'
         $payload.input | Should -Be 'prompt.md'
         $payload.api_llm.provider | Should -Be 'openrouter'
         $payload.api_llm.model | Should -Be 'z-ai/glm-5.2'
         $payload.api_llm.execution_backend | Should -Be 'openai-compatible-chat-completions'
+        $payload.api_llm.api_key_env | Should -Be 'WINSMUX_OPENROUTER_API_KEY'
+        $payload.network | Should -Be 'not_started'
+        $payload.api_key_env | Should -Be 'WINSMUX_OPENROUTER_API_KEY'
+        $payload.endpoint_host | Should -Be 'openrouter.ai'
+        $payload.provider_response_id_present | Should -Be $false
         $payload.prompt_value_output | Should -Be $false
         $payload.locations.input.local_path | Should -Be ''
         ($output | Out-String) | Should -Not -Match 'google-colab-cli'
@@ -11110,7 +11125,8 @@ worker-backend: colab_cli
 
         $logPath = Join-Path $script:workersTempRoot ($payload.stdout_log -replace '/', '\')
         $logText = Get-Content -LiteralPath $logPath -Raw -Encoding UTF8
-        $logText | Should -Match 'api_llm runner is not configured'
+        $logText | Should -Match 'api_llm_api_key_env_missing'
+        $logText | Should -Match 'network: not_started'
         $logText | Should -Not -Match 'Summarize the repository status'
 
         $logsOutput = & pwsh -NoProfile -File $script:winsmuxWorkersCorePath workers logs w1 --run-id api-run --json --project-dir $script:workersTempRoot 2>&1
@@ -11118,11 +11134,80 @@ worker-backend: colab_cli
 
         $LASTEXITCODE | Should -Be 1
         $logsPayload.status | Should -Be 'blocked'
-        $logsPayload.reason | Should -Be 'api_llm_runner_unconfigured'
+        $logsPayload.reason | Should -Be 'api_llm_api_key_env_missing'
         $logsPayload.backend | Should -Be 'api_llm'
         $logsPayload.source | Should -Be 'local'
-        $logsPayload.log | Should -Match 'api_llm runner is not configured'
+        $logsPayload.log | Should -Match 'api_llm_api_key_env_missing'
         ($logsOutput | Out-String) | Should -Not -Match 'google-colab-cli'
+    }
+
+    It 'runs api_llm exec through OpenAI-compatible chat completions with an env key' {
+        Write-WorkersApiLlmProjectConfig
+        'Summarize the repository status.' | Set-Content -Path (Join-Path $script:workersTempRoot 'prompt.md') -Encoding UTF8
+        $env:WINSMUX_OPENROUTER_API_KEY = 'test-openrouter-key'
+        $script:apiLlmCapturedUri = ''
+        $script:apiLlmCapturedHeaders = $null
+        $script:apiLlmCapturedBody = ''
+
+        Mock Invoke-RestMethod {
+            param(
+                [string]$Uri,
+                [string]$Method,
+                [hashtable]$Headers,
+                [string]$Body,
+                [string]$ContentType,
+                [int]$TimeoutSec
+            )
+
+            $script:apiLlmCapturedUri = $Uri
+            $script:apiLlmCapturedHeaders = $Headers
+            $script:apiLlmCapturedBody = $Body
+            return [pscustomobject]@{
+                id = 'chatcmpl-test-response'
+                choices = @(
+                    [pscustomobject]@{
+                        message = [pscustomobject]@{
+                            content = 'External model response.'
+                        }
+                    }
+                )
+                usage = [pscustomobject]@{
+                    prompt_tokens = 12
+                    completion_tokens = 4
+                    total_tokens = 16
+                }
+            }
+        }
+
+        $Rest = @('w1', '--script', 'prompt.md', '--run-id', 'api-success-run', '--json', '--project-dir', $script:workersTempRoot)
+        $output = Invoke-WorkersExec
+        $payload = ($output | Select-Object -Last 1) | ConvertFrom-Json
+
+        $payload.status | Should -Be 'succeeded'
+        $payload.reason | Should -Be ''
+        $payload.network | Should -Be 'completed'
+        $payload.response | Should -Be '.winsmux/worker-runs/worker-1/api-success-run/response.txt'
+        $payload.api_key_env | Should -Be 'WINSMUX_OPENROUTER_API_KEY'
+        $payload.endpoint_host | Should -Be 'openrouter.ai'
+        $payload.provider_response_id_present | Should -Be $true
+        $payload.usage.total_tokens | Should -Be 16
+        $payload.prompt_value_output | Should -Be $false
+        $script:apiLlmCapturedUri | Should -Be 'https://openrouter.ai/api/v1/chat/completions'
+        $script:apiLlmCapturedHeaders.Authorization | Should -Be 'Bearer test-openrouter-key'
+        $script:apiLlmCapturedBody | Should -Match '"model"'
+        $script:apiLlmCapturedBody | Should -Match 'z-ai/glm-5.2'
+        Should -Invoke Invoke-RestMethod -Times 1 -Exactly
+
+        $logPath = Join-Path $script:workersTempRoot ($payload.stdout_log -replace '/', '\')
+        $logText = Get-Content -LiteralPath $logPath -Raw -Encoding UTF8
+        $logText | Should -Match 'status: succeeded'
+        $logText | Should -Match 'network: completed'
+        $logText | Should -Not -Match 'test-openrouter-key'
+        $logText | Should -Not -Match 'Summarize the repository status'
+
+        $responsePath = Join-Path $script:workersTempRoot ($payload.response -replace '/', '\')
+        (Get-Content -LiteralPath $responsePath -Raw -Encoding UTF8) | Should -Match 'External model response'
+        (Get-Content -LiteralPath $responsePath -Raw -Encoding UTF8) | Should -Not -Match 'test-openrouter-key'
     }
 
     It 'accepts task-json as the api_llm exec input contract' {
@@ -11134,7 +11219,7 @@ worker-backend: colab_cli
 
         $LASTEXITCODE | Should -Be 1
         $payload.status | Should -Be 'blocked'
-        $payload.reason | Should -Be 'api_llm_runner_unconfigured'
+        $payload.reason | Should -Be 'api_llm_api_key_env_missing'
         $payload.backend | Should -Be 'api_llm'
         $payload.input | Should -Be 'task.json'
         $payload.input_kind | Should -Be 'task_json'

--- a/winsmux-core/scripts/settings.ps1
+++ b/winsmux-core/scripts/settings.ps1
@@ -1092,6 +1092,8 @@ function ConvertTo-BridgeProviderCapabilityEntry {
         'harness_availability',
         'credential_requirements',
         'execution_backend',
+        'api_base_url',
+        'api_key_env',
         'runtime_requirements',
         'analysis_posture'
     )
@@ -2856,6 +2858,8 @@ function Get-SlotAgentConfig {
         HarnessAvailability      = [string](Get-BridgeProviderCapabilityValue -Capability $providerCapability -Name 'harness_availability' -Default '')
         CredentialRequirements   = [string](Get-BridgeProviderCapabilityValue -Capability $providerCapability -Name 'credential_requirements' -Default '')
         ExecutionBackend         = [string](Get-BridgeProviderCapabilityValue -Capability $providerCapability -Name 'execution_backend' -Default '')
+        ApiBaseUrl               = [string](Get-BridgeProviderCapabilityValue -Capability $providerCapability -Name 'api_base_url' -Default '')
+        ApiKeyEnv                = [string](Get-BridgeProviderCapabilityValue -Capability $providerCapability -Name 'api_key_env' -Default '')
         RuntimeRequirements      = [string](Get-BridgeProviderCapabilityValue -Capability $providerCapability -Name 'runtime_requirements' -Default '')
         AnalysisPosture          = [string](Get-BridgeProviderCapabilityValue -Capability $providerCapability -Name 'analysis_posture' -Default '')
         SupportsParallelRuns     = Get-BridgeProviderCapabilityBoolean -Capability $providerCapability -Name 'supports_parallel_runs'


### PR DESCRIPTION
## Summary
- Add an OpenAI-compatible chat completions runner for `api_llm` workers.
- Read hosted API credentials from the worker process environment, with OpenRouter defaulting to `WINSMUX_OPENROUTER_API_KEY`.
- Keep missing-key runs blocked before network access and keep API keys, bearer values, raw prompt text, and provider response IDs out of public evidence.
- Update public docs for the environment-variable flow.

## Verification
- `Invoke-Pester -Path .\tests\winsmux-bridge.Tests.ps1 -FullNameFilter '*api_llm*' -Output Detailed` -> 11 passed
- Full Pester suite -> 775 passed, 1 explicit manual Colab acceptance skip
- `pwsh -NoProfile -File .\scripts\audit-public-surface.ps1` -> passed
- `git diff --check` -> passed
- `pwsh -NoProfile -File .\scripts\git-guard.ps1 -Mode full` -> passed
- Push hooks: git-guard, public-surface audit, and gitleaks passed

## Remaining before merge
- Run real hosted API E2E after `WINSMUX_OPENROUTER_API_KEY` is provided in the worker process environment.
- Record redacted `TASK-507` / `TASK-546` evidence.
- Wait for GitHub CI to pass.

## Secret handling
- No API key value is committed or documented.
- No repo-local `.env`, `setx`, shell startup file, or shell-history path is used.
- Provider response IDs are represented only as a presence boolean in run artifacts.
