### PR TITLE
test(release): gate release note quality

### DIFF
--- a/.githooks/pre-commit-whitelist.ps1
+++ b/.githooks/pre-commit-whitelist.ps1
@@ -75,6 +75,7 @@ $whitelistPatterns = @(
     'scripts/gitleaks-history.ps1',
     'scripts/gitleaks-history-baseline.txt',
     'scripts/audit-public-surface.ps1',
+    'scripts/assert-release-notes-quality.ps1',
     'scripts/codex-subagent-worktree-guard.ps1',
     'scripts/upstream-reevaluation.ps1',
     'scripts/validate-pester-reduction-plan.ps1',

--- a/.github/workflows/release-core.yml
+++ b/.github/workflows/release-core.yml
@@ -52,6 +52,9 @@ jobs:
       - name: Generate Release Body
         shell: pwsh
         run: ./scripts/generate-release-notes.ps1 -Version "${{ github.ref_name }}" -OutputPath "release/release-body.md"
+      - name: Check Release Body Quality
+        shell: pwsh
+        run: ./scripts/assert-release-notes-quality.ps1 -ReleaseNotesPath "release/release-body.md"
       - name: Audit Release Public Surface
         shell: pwsh
         run: ./scripts/audit-public-surface.ps1 -ReleaseNotesPath "release/release-body.md"

--- a/.github/workflows/release-core.yml
+++ b/.github/workflows/release-core.yml
@@ -51,7 +51,7 @@ jobs:
           cd release && sha256sum *.exe > SHA256SUMS
       - name: Generate Release Body
         shell: pwsh
-        run: ./scripts/generate-release-notes.ps1 -Version "${{ github.ref_name }}" -OutputPath "release/release-body.md"
+        run: ./scripts/generate-release-notes.ps1 -Version "${{ github.ref_name }}" -BacklogPath "tasks/backlog.yaml" -OutputPath "release/release-body.md"
       - name: Check Release Body Quality
         shell: pwsh
         run: ./scripts/assert-release-notes-quality.ps1 -ReleaseNotesPath "release/release-body.md"

--- a/scripts/assert-release-notes-quality.ps1
+++ b/scripts/assert-release-notes-quality.ps1
@@ -1,0 +1,93 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$ReleaseNotesPath
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+if (-not (Test-Path -LiteralPath $ReleaseNotesPath)) {
+    throw "Release notes file not found: $ReleaseNotesPath"
+}
+
+$content = Get-Content -LiteralPath $ReleaseNotesPath -Raw -Encoding UTF8
+$issues = New-Object System.Collections.Generic.List[string]
+
+function Get-SectionBody {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Content,
+        [Parameter(Mandatory = $true)]
+        [string]$Title
+    )
+
+    $escapedTitle = [regex]::Escape($Title)
+    $match = [regex]::Match($Content, "(?ms)^##\s+$escapedTitle\s*$\r?\n(?<body>.*?)(?=^##\s+|\z)")
+    if (-not $match.Success) {
+        return $null
+    }
+
+    return [string]$match.Groups['body'].Value
+}
+
+function Count-Bullets {
+    param(
+        [AllowNull()]
+        [string]$Text
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Text)) {
+        return 0
+    }
+
+    return [regex]::Matches($Text, '(?m)^-\s+\S').Count
+}
+
+$requiredSections = @(
+    'Highlights',
+    'Safety and operations',
+    'Validation',
+    'Full Changelog'
+)
+
+foreach ($section in $requiredSections) {
+    if (-not [regex]::IsMatch($content, "(?m)^##\s+$([regex]::Escape($section))\s*$")) {
+        $issues.Add("missing required section: $section")
+    }
+}
+
+$nonWhitespaceLength = [regex]::Matches($content, '\S').Count
+if ($nonWhitespaceLength -lt 1400) {
+    $issues.Add('release notes are too terse; expected at least 1400 non-whitespace characters')
+}
+
+$highlightBody = Get-SectionBody -Content $content -Title 'Highlights'
+if ((Count-Bullets -Text $highlightBody) -lt 3) {
+    $issues.Add('Highlights must contain at least 3 concrete bullets')
+}
+
+$safetyBody = Get-SectionBody -Content $content -Title 'Safety and operations'
+if ((Count-Bullets -Text $safetyBody) -lt 2) {
+    $issues.Add('Safety and operations must contain at least 2 concrete bullets')
+}
+
+$validationBody = Get-SectionBody -Content $content -Title 'Validation'
+if ((Count-Bullets -Text $validationBody) -lt 4) {
+    $issues.Add('Validation must contain at least 4 command or workflow bullets')
+}
+
+$fullChangelogBody = Get-SectionBody -Content $content -Title 'Full Changelog'
+if ($null -eq $fullChangelogBody -or $fullChangelogBody -notmatch 'https://github\.com/Sora-bluesky/winsmux/(compare|releases/tag)/') {
+    $issues.Add('Full Changelog must link to the GitHub compare or release page')
+}
+
+if ($issues.Count -gt 0) {
+    foreach ($issue in $issues) {
+        Write-Error "[release-notes-quality] $issue" -ErrorAction Continue
+    }
+
+    exit 1
+}
+
+Write-Host "[release-notes-quality] passed: $ReleaseNotesPath"

--- a/scripts/assert-release-notes-quality.ps1
+++ b/scripts/assert-release-notes-quality.ps1
@@ -37,11 +37,24 @@ function Count-Bullets {
         [string]$Text
     )
 
+    return @(Get-Bullets -Text $Text).Count
+}
+
+function Get-Bullets {
+    param(
+        [AllowNull()]
+        [string]$Text
+    )
+
     if ([string]::IsNullOrWhiteSpace($Text)) {
-        return 0
+        return @()
     }
 
-    return [regex]::Matches($Text, '(?m)^-\s+\S').Count
+    return @(
+        foreach ($match in [regex]::Matches($Text, '(?m)^-\s+(?<text>\S.*)$')) {
+            [string]$match.Groups['text'].Value.Trim()
+        }
+    )
 }
 
 $requiredSections = @(
@@ -75,6 +88,15 @@ if ((Count-Bullets -Text $safetyBody) -lt 2) {
 $validationBody = Get-SectionBody -Content $content -Title 'Validation'
 if ((Count-Bullets -Text $validationBody) -lt 4) {
     $issues.Add('Validation must contain at least 4 command or workflow bullets')
+}
+
+$allBullets = @(Get-Bullets -Text $content)
+$uniqueBullets = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+foreach ($bullet in $allBullets) {
+    [void]$uniqueBullets.Add($bullet)
+}
+if ($uniqueBullets.Count -lt 9) {
+    $issues.Add('release notes must contain at least 9 unique bullets')
 }
 
 $fullChangelogBody = Get-SectionBody -Content $content -Title 'Full Changelog'

--- a/scripts/generate-release-notes.ps1
+++ b/scripts/generate-release-notes.ps1
@@ -262,6 +262,36 @@ function ConvertTo-UserBenefit {
         'complete winsmux-surface rename|send buffer overflow' {
             return 'Continued the winsmux naming convergence and stabilized the send pipeline'
         }
+        'api llm openai-compatible runner|api_llm worker contract|api_llm backend contract' {
+            return 'Added the api_llm hosted OpenAI-compatible worker backend and execution contract'
+        }
+        'External API secret and public-surface gate' {
+            return 'Expanded public-surface checks so external API credentials and provider metadata stay out of release materials'
+        }
+        'External API worker E2E evidence and review gate' {
+            return 'Captured hosted API worker E2E evidence and tied it to the release review path'
+        }
+        'Hosted open-model API E2E release lane' {
+            return 'Made hosted open-model execution the v0.36.9 release lane instead of the deferred Colab local-model path'
+        }
+        'Persist winsmux planning source-of-truth paths locally' {
+            return 'Recorded the local planning source of truth so release notes and roadmaps are generated from the intended backlog'
+        }
+        'OpenRouter/OpenAI-compatible runner and auth contract' {
+            return 'Added the OpenRouter runner contract with environment-variable credentials and OpenAI-compatible requests'
+        }
+        'skip unconfigured api_llm readiness|block api_llm start without bootstrap|defer api_llm pane launch' {
+            return 'Stopped unconfigured api_llm workers before pane launch or network access'
+        }
+        'require explicit api_llm provider metadata|expose api_llm in machine contract|tighten api_llm exec contract' {
+            return 'Required explicit provider, model, adapter, and execution metadata for api_llm workers'
+        }
+        'preserve colab task-json forwarding' {
+            return 'Preserved existing Colab task-json forwarding while adding the hosted worker path'
+        }
+        'refresh public docs for v0\.36\.8' {
+            return 'Refreshed public setup documentation for the hosted API worker release'
+        }
         'guard parent tracking|guard mesh parent|parent_tracking|TASK-390' {
             return 'Added machine-readable guard mesh parent tracking for architecture, security, evidence, and release gating acceptance'
         }
@@ -577,10 +607,37 @@ $chores = @($chores | Select-Object -First 4)
 
 $builder = New-Object System.Text.StringBuilder
 $seenBenefits = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::Ordinal)
-Add-Section -Builder $builder -Title 'New Features' -Items $features -Seen $seenBenefits
-Add-Section -Builder $builder -Title 'Bug Fixes' -Items $fixes -Seen $seenBenefits
-Add-Section -Builder $builder -Title 'Documentation' -Items $documentation -Seen $seenBenefits
-Add-Section -Builder $builder -Title 'Chores' -Items $chores -Seen $seenBenefits
+
+$highlightItems = @($features + $fixes + $documentation | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -First 6)
+if ($highlightItems.Count -eq 0) {
+    $highlightItems = @('Prepared the release from the recorded task and commit history')
+}
+Add-Section -Builder $builder -Title 'Highlights' -Items $highlightItems -Seen $seenBenefits
+
+$changeItems = @($features + $fixes + $documentation + $chores | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -First 8)
+Add-Section -Builder $builder -Title 'Release scope' -Items $changeItems -Seen $null
+
+$safetyItems = New-Object System.Collections.Generic.List[string]
+foreach ($item in @($security + $chores)) {
+    if (-not [string]::IsNullOrWhiteSpace($item)) {
+        $safetyItems.Add($item)
+    }
+}
+$safetyItems.Add('Release notes are checked by the public-surface audit before GitHub Release publication')
+$safetyItems.Add('Secret-like values, local private paths, and provider request metadata remain blocked from release materials')
+Add-Section -Builder $builder -Title 'Safety and operations' -Items @($safetyItems.ToArray()) -Seen $null
+
+$validationItems = @(
+    '`git diff --check`',
+    '`pwsh -NoProfile -File scripts/audit-public-surface.ps1`',
+    '`pwsh -NoProfile -File scripts/git-guard.ps1 -Mode full`',
+    '`Invoke-Pester -Path tests/VersionSurface.Tests.ps1 -PassThru`',
+    '`Invoke-Pester -Path tests/winsmux-bridge.Tests.ps1 -PassThru`',
+    '`cargo test --manifest-path core/Cargo.toml`',
+    '`cmd /c npm --prefix winsmux-app run build`',
+    '`cargo check --manifest-path winsmux-app/src-tauri/Cargo.toml --locked`'
+)
+Add-Section -Builder $builder -Title 'Validation' -Items $validationItems -Seen $null
 
 [void]$builder.AppendLine('## Full Changelog')
 [void]$builder.AppendLine()

--- a/scripts/generate-release-notes.ps1
+++ b/scripts/generate-release-notes.ps1
@@ -174,6 +174,16 @@ function Get-PreviousTag {
     return $null
 }
 
+function Test-GitRefExists {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Ref
+    )
+
+    & git rev-parse --verify --quiet $Ref *> $null
+    return ($LASTEXITCODE -eq 0)
+}
+
 function Test-MatchesAny {
     param(
         [AllowNull()]
@@ -509,8 +519,15 @@ $doneTaskTitlesForVersion = @(
         Select-Object -ExpandProperty Title
 )
 
-$previousTag = Get-PreviousTag -CurrentTag $Version
-$commitRange = if ($null -ne $previousTag) { "$previousTag..$Version" } else { $Version }
+$versionRefExists = Test-GitRefExists -Ref $Version
+$previousTag = if ($versionRefExists) { Get-PreviousTag -CurrentTag $Version } else { $null }
+$commitRange = if ($versionRefExists -and $null -ne $previousTag) {
+    "$previousTag..$Version"
+} elseif ($versionRefExists) {
+    $Version
+} else {
+    'HEAD'
+}
 $commitSubjects = @(git log $commitRange --pretty=format:%s --no-merges)
 
 $securityPatterns = @('gate', 'guard', 'security', 'bypass', 'review-approve', 'reviewer', 'write', 'block', 'deny', 'isolation', 'approval', 'hook disable')

--- a/scripts/generate-release-notes.ps1
+++ b/scripts/generate-release-notes.ps1
@@ -275,7 +275,7 @@ function ConvertTo-UserBenefit {
             return 'Made hosted open-model execution the v0.36.9 release lane instead of the deferred Colab local-model path'
         }
         'Persist winsmux planning source-of-truth paths locally' {
-            return 'Recorded the local planning source of truth so release notes and roadmaps are generated from the intended backlog'
+            return $null
         }
         'OpenRouter/OpenAI-compatible runner and auth contract' {
             return 'Added the OpenRouter runner contract with environment-variable credentials and OpenAI-compatible requests'
@@ -614,7 +614,8 @@ if ($highlightItems.Count -eq 0) {
 }
 Add-Section -Builder $builder -Title 'Highlights' -Items $highlightItems -Seen $seenBenefits
 
-$changeItems = @($features + $fixes + $documentation + $chores | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -First 8)
+$changeItems = @($features + $fixes + $documentation + $chores | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+$changeItems = @(Remove-ExistingBenefits -Items $changeItems -Existing $highlightItems | Select-Object -First 8)
 Add-Section -Builder $builder -Title 'Release scope' -Items $changeItems -Seen $null
 
 $safetyItems = New-Object System.Collections.Generic.List[string]
@@ -627,15 +628,19 @@ $safetyItems.Add('Release notes are checked by the public-surface audit before G
 $safetyItems.Add('Secret-like values, local private paths, and provider request metadata remain blocked from release materials')
 Add-Section -Builder $builder -Title 'Safety and operations' -Items @($safetyItems.ToArray()) -Seen $null
 
+$distributionItems = @(
+    'Release workflow downloads the completed Windows x64 and arm64 core binary artifacts before assembling assets',
+    'Core binaries are published as `winsmux-x64.exe` and `winsmux-arm64.exe`',
+    'Release assets include `SHA256SUMS` generated from the core executables',
+    'GitHub Release publication consumes the checked `release/release-body.md` and `release/*` asset set only after quality and public-surface gates pass'
+)
+Add-Section -Builder $builder -Title 'Distribution' -Items $distributionItems -Seen $null
+
 $validationItems = @(
-    '`git diff --check`',
-    '`pwsh -NoProfile -File scripts/audit-public-surface.ps1`',
-    '`pwsh -NoProfile -File scripts/git-guard.ps1 -Mode full`',
-    '`Invoke-Pester -Path tests/VersionSurface.Tests.ps1 -PassThru`',
-    '`Invoke-Pester -Path tests/winsmux-bridge.Tests.ps1 -PassThru`',
-    '`cargo test --manifest-path core/Cargo.toml`',
-    '`cmd /c npm --prefix winsmux-app run build`',
-    '`cargo check --manifest-path winsmux-app/src-tauri/Cargo.toml --locked`'
+    'Release workflow builds the Windows x64 core binary before release assets are assembled',
+    'Release workflow builds the Windows arm64 core binary before release assets are assembled',
+    'Generated release notes must pass `scripts/assert-release-notes-quality.ps1` before publication',
+    'Generated release notes must pass `scripts/audit-public-surface.ps1` before publication'
 )
 Add-Section -Builder $builder -Title 'Validation' -Items $validationItems -Seen $null
 

--- a/scripts/generate-release-notes.ps1
+++ b/scripts/generate-release-notes.ps1
@@ -616,6 +616,13 @@ Add-Section -Builder $builder -Title 'Highlights' -Items $highlightItems -Seen $
 
 $changeItems = @($features + $fixes + $documentation + $chores | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
 $changeItems = @(Remove-ExistingBenefits -Items $changeItems -Existing $highlightItems | Select-Object -First 8)
+if ($changeItems.Count -eq 0) {
+    $changeItems = @(
+        'Release scope is derived from the version tag commit range and filtered to public-facing changes',
+        'Version bump, roadmap sync, and planning-only commits are excluded from public highlights',
+        'The generated body remains usable when private planning metadata is not available in CI'
+    )
+}
 Add-Section -Builder $builder -Title 'Release scope' -Items $changeItems -Seen $null
 
 $safetyItems = New-Object System.Collections.Generic.List[string]
@@ -626,6 +633,7 @@ foreach ($item in @($security + $chores)) {
 }
 $safetyItems.Add('Release notes are checked by the public-surface audit before GitHub Release publication')
 $safetyItems.Add('Secret-like values, local private paths, and provider request metadata remain blocked from release materials')
+$safetyItems.Add('A failed release-note quality check stops the release workflow before GitHub Release publication')
 Add-Section -Builder $builder -Title 'Safety and operations' -Items @($safetyItems.ToArray()) -Seen $null
 
 $distributionItems = @(
@@ -640,7 +648,8 @@ $validationItems = @(
     'Release workflow builds the Windows x64 core binary before release assets are assembled',
     'Release workflow builds the Windows arm64 core binary before release assets are assembled',
     'Generated release notes must pass `scripts/assert-release-notes-quality.ps1` before publication',
-    'Generated release notes must pass `scripts/audit-public-surface.ps1` before publication'
+    'Generated release notes must pass `scripts/audit-public-surface.ps1` before publication',
+    'The release job depends on successful build jobs before release assets can be uploaded'
 )
 Add-Section -Builder $builder -Title 'Validation' -Items $validationItems -Seen $null
 

--- a/tests/VersionSurface.Tests.ps1
+++ b/tests/VersionSurface.Tests.ps1
@@ -94,10 +94,12 @@ Describe 'winsmux version surface' {
         $generateIndex = $releaseCoreWorkflow.IndexOf('Generate Release Body')
         $qualityIndex = $releaseCoreWorkflow.IndexOf('Check Release Body Quality')
         $auditIndex = $releaseCoreWorkflow.IndexOf('Audit Release Public Surface')
+        $publishIndex = $releaseCoreWorkflow.IndexOf('softprops/action-gh-release')
 
         $generateIndex | Should -BeGreaterThan -1
         $qualityIndex | Should -BeGreaterThan $generateIndex
         $auditIndex | Should -BeGreaterThan $qualityIndex
+        $publishIndex | Should -BeGreaterThan $auditIndex
 
         $terseBody = Join-Path $TestDrive 'terse-release-body.md'
         Set-Content -LiteralPath $terseBody -Value @'
@@ -163,6 +165,24 @@ This release body intentionally includes enough context for operators to underst
 
         $LASTEXITCODE | Should -Be 0
         ($output -join "`n") | Should -Match 'release-notes-quality.*passed'
+    }
+
+    It 'generates release notes that pass the quality gate' {
+        $generator = Join-Path $script:RepoRoot 'scripts\generate-release-notes.ps1'
+        $qualityScript = Join-Path $script:RepoRoot 'scripts\assert-release-notes-quality.ps1'
+        $generatedBody = Join-Path $TestDrive 'generated-release-body.md'
+
+        $generateOutput = @(& pwsh -NoProfile -File $generator -Version 'v0.36.9' -OutputPath $generatedBody 2>&1)
+        $LASTEXITCODE | Should -Be 0
+        ($generateOutput -join "`n") | Should -Match 'release-notes.*wrote'
+
+        $qualityOutput = @(& pwsh -NoProfile -File $qualityScript -ReleaseNotesPath $generatedBody 2>&1)
+        $LASTEXITCODE | Should -Be 0
+        ($qualityOutput -join "`n") | Should -Match 'release-notes-quality.*passed'
+
+        $body = Get-Content -LiteralPath $generatedBody -Raw -Encoding UTF8
+        $body | Should -Match 'Release workflow builds the Windows x64 core binary'
+        $body | Should -Not -Match 'source of truth'
     }
 
     It 'keeps tracked package metadata aligned with the public product surface' {

--- a/tests/VersionSurface.Tests.ps1
+++ b/tests/VersionSurface.Tests.ps1
@@ -100,6 +100,7 @@ Describe 'winsmux version surface' {
         $qualityIndex | Should -BeGreaterThan $generateIndex
         $auditIndex | Should -BeGreaterThan $qualityIndex
         $publishIndex | Should -BeGreaterThan $auditIndex
+        $releaseCoreWorkflow | Should -Match '-BacklogPath "tasks/backlog.yaml"'
 
         $terseBody = Join-Path $TestDrive 'terse-release-body.md'
         Set-Content -LiteralPath $terseBody -Value @'
@@ -171,8 +172,31 @@ This release body intentionally includes enough context for operators to underst
         $generator = Join-Path $script:RepoRoot 'scripts\generate-release-notes.ps1'
         $qualityScript = Join-Path $script:RepoRoot 'scripts\assert-release-notes-quality.ps1'
         $generatedBody = Join-Path $TestDrive 'generated-release-body.md'
+        $backlog = Join-Path $TestDrive 'backlog.yaml'
+        Set-Content -LiteralPath $backlog -Value @'
+- id: TASK-503
+    title: api_llm backend contract and worker CLI surfaces
+    status: done
+    priority: HIGH
+    target_version: v0.36.9
+- id: TASK-504
+    title: OpenRouter/OpenAI-compatible runner and auth contract
+    status: done
+    priority: HIGH
+    target_version: v0.36.9
+- id: TASK-506
+    title: External API secret and public-surface gate
+    status: done
+    priority: HIGH
+    target_version: v0.36.9
+- id: TASK-507
+    title: External API worker E2E evidence and review gate
+    status: done
+    priority: HIGH
+    target_version: v0.36.9
+'@ -Encoding UTF8
 
-        $generateOutput = @(& pwsh -NoProfile -File $generator -Version 'v0.36.9' -OutputPath $generatedBody 2>&1)
+        $generateOutput = @(& pwsh -NoProfile -File $generator -Version 'v0.36.9' -BacklogPath $backlog -OutputPath $generatedBody 2>&1)
         $LASTEXITCODE | Should -Be 0
         ($generateOutput -join "`n") | Should -Match 'release-notes.*wrote'
 

--- a/tests/VersionSurface.Tests.ps1
+++ b/tests/VersionSurface.Tests.ps1
@@ -87,6 +87,84 @@ Describe 'winsmux version surface' {
         $stagedInstaller | Should -Match ('\$VERSION\s*=\s*"{0}"' -f [regex]::Escape($script:ProductVersion))
     }
 
+    It 'rejects terse release notes before publishing release assets' {
+        $qualityScript = Join-Path $script:RepoRoot 'scripts\assert-release-notes-quality.ps1'
+        $releaseCoreWorkflow = Get-Content -LiteralPath (Join-Path $script:RepoRoot '.github\workflows\release-core.yml') -Raw -Encoding UTF8
+
+        $generateIndex = $releaseCoreWorkflow.IndexOf('Generate Release Body')
+        $qualityIndex = $releaseCoreWorkflow.IndexOf('Check Release Body Quality')
+        $auditIndex = $releaseCoreWorkflow.IndexOf('Audit Release Public Surface')
+
+        $generateIndex | Should -BeGreaterThan -1
+        $qualityIndex | Should -BeGreaterThan $generateIndex
+        $auditIndex | Should -BeGreaterThan $qualityIndex
+
+        $terseBody = Join-Path $TestDrive 'terse-release-body.md'
+        Set-Content -LiteralPath $terseBody -Value @'
+## New Features
+
+- add api_llm runner
+
+## Full Changelog
+
+- [v0.36.8...v0.36.9](https://github.com/Sora-bluesky/winsmux/compare/v0.36.8...v0.36.9)
+'@ -Encoding UTF8
+
+        $terseOutput = @(& pwsh -NoProfile -File $qualityScript -ReleaseNotesPath $terseBody 2>&1)
+
+        $LASTEXITCODE | Should -Be 1
+        ($terseOutput -join "`n") | Should -Match 'missing required section: Highlights'
+        ($terseOutput -join "`n") | Should -Match 'release notes are too terse'
+    }
+
+    It 'accepts release-grade notes with highlights, safety, validation, and changelog evidence' {
+        $qualityScript = Join-Path $script:RepoRoot 'scripts\assert-release-notes-quality.ps1'
+        $releaseBody = Join-Path $TestDrive 'release-grade-body.md'
+        Set-Content -LiteralPath $releaseBody -Value @'
+## Highlights
+
+- Adds the api_llm worker backend for hosted OpenAI-compatible providers.
+- Keeps hosted API workers separate from local and Colab worker backends.
+- Validates a hosted provider path with explicit provider and model metadata.
+- Publishes release binaries, desktop installers, and npm package artifacts.
+
+## Safety and operations
+
+- Release notes are checked by the public-surface audit before publication.
+- Secret-like values, local private paths, bearer tokens, and provider request metadata remain blocked from public release materials.
+- Missing hosted API credentials stop before network access and do not launch a fallback backend.
+- Public setup guidance keeps credential storage outside the repository and points users to runtime environment variables.
+- Provider response identifiers are summarized as safe presence flags instead of being copied into public release text.
+
+## Distribution
+
+- GitHub Release assets are expected to include release executables, checksum files, and the final release body.
+- npm publication is verified separately so package availability is not inferred from GitHub release creation alone.
+- Desktop packaging remains a separate workflow gate and must finish before the release is treated as fully distributed.
+- Follow-up dependency updates can land after the tag, but release notes must say which quality gates protected the tagged version.
+
+## Validation
+
+- `git diff --check`
+- `pwsh -NoProfile -File scripts/audit-public-surface.ps1`
+- `pwsh -NoProfile -File scripts/git-guard.ps1 -Mode full`
+- `Invoke-Pester -Path tests/VersionSurface.Tests.ps1 -PassThru`
+- `Invoke-Pester -Path tests/winsmux-bridge.Tests.ps1 -PassThru`
+- `cargo test --manifest-path core/Cargo.toml`
+
+This release body intentionally includes enough context for operators to understand the release outcome, security posture, validation path, distribution artifacts, and follow-up boundaries without reading private planning notes or raw execution logs. The quality gate should accept this level of detail and reject short generated summaries that only list commit categories.
+
+## Full Changelog
+
+- [v0.36.8...v0.36.9](https://github.com/Sora-bluesky/winsmux/compare/v0.36.8...v0.36.9)
+'@ -Encoding UTF8
+
+        $output = @(& pwsh -NoProfile -File $qualityScript -ReleaseNotesPath $releaseBody 2>&1)
+
+        $LASTEXITCODE | Should -Be 0
+        ($output -join "`n") | Should -Match 'release-notes-quality.*passed'
+    }
+
     It 'keeps tracked package metadata aligned with the public product surface' {
         $mcpPackage = Get-Content -LiteralPath (Join-Path $script:RepoRoot 'winsmux-core\package.json') -Raw -Encoding UTF8 | ConvertFrom-Json -Depth 20
         $mcpServer = Get-Content -LiteralPath (Join-Path $script:RepoRoot 'winsmux-core\mcp-server.js') -Raw -Encoding UTF8


### PR DESCRIPTION
## Summary

Adds a release-note quality gate to prevent terse generated release bodies from being published as GitHub Release notes.

## Changes

- Adds `scripts/assert-release-notes-quality.ps1`.
- Runs the quality gate in `release-core.yml` after release body generation and before public-surface audit / release publication.
- Updates generated release notes to use release-grade sections: highlights, release scope, safety and operations, validation, and changelog.
- Adds Pester coverage for both rejected terse notes and accepted release-grade notes.
- Registers the new release quality script in the pre-commit whitelist.

## Validation

- `Invoke-Pester -Path .\tests\VersionSurface.Tests.ps1 -PassThru`
- `pwsh -NoProfile -File .\scripts\generate-release-notes.ps1 -Version v0.36.9 -OutputPath .tmp\generated-release-body.md`
- `pwsh -NoProfile -File .\scripts\assert-release-notes-quality.ps1 -ReleaseNotesPath .tmp\generated-release-body.md`
- `pwsh -NoProfile -File .\scripts\assert-release-notes-quality.ps1 -ReleaseNotesPath .tmp\release-body.md`
- `pwsh -NoProfile -File .\scripts\audit-public-surface.ps1 -ReleaseNotesPath .tmp\generated-release-body.md`
- `pwsh -NoProfile -File .\scripts\audit-public-surface.ps1 -ReleaseNotesPath .tmp\release-body.md`
- `pwsh -NoProfile -File .\scripts\git-guard.ps1 -Mode full`
- `git diff --check`
