### PR TITLE
fix(release): harden core release notes fallback

### DIFF
--- a/.github/workflows/release-core.yml
+++ b/.github/workflows/release-core.yml
@@ -51,7 +51,7 @@ jobs:
           cd release && sha256sum *.exe > SHA256SUMS
       - name: Generate Release Body
         shell: pwsh
-        run: ./scripts/generate-release-notes.ps1 -Version "${{ github.ref_name }}" -BacklogPath "tasks/backlog.yaml" -OutputPath "release/release-body.md"
+        run: ./scripts/generate-release-notes.ps1 -Version "${{ github.ref_name }}" -OutputPath "release/release-body.md"
       - name: Check Release Body Quality
         shell: pwsh
         run: ./scripts/assert-release-notes-quality.ps1 -ReleaseNotesPath "release/release-body.md"

--- a/scripts/generate-release-notes.ps1
+++ b/scripts/generate-release-notes.ps1
@@ -272,6 +272,15 @@ function ConvertTo-UserBenefit {
         'complete winsmux-surface rename|send buffer overflow' {
             return 'Continued the winsmux naming convergence and stabilized the send pipeline'
         }
+        'migrate worker path to Antigravity CLI|Antigravity CLI' {
+            return 'Migrated one-shot worker execution to the Antigravity CLI route while preserving explicit backend metadata'
+        }
+        'harden operator runtime controls|operator runtime controls' {
+            return 'Hardened desktop operator runtime controls used by managed worker sessions'
+        }
+        'release note quality|release body quality|release notes quality' {
+            return 'Kept GitHub Release publication behind concrete release-note quality gates'
+        }
         'api llm openai-compatible runner|api_llm worker contract|api_llm backend contract' {
             return 'Added the api_llm hosted OpenAI-compatible worker backend and execution contract'
         }
@@ -569,6 +578,7 @@ $fixSource += Get-MatchedCommits -Subjects $commitSubjects -Patterns @('Monitori
 $fixSource += Get-MatchedCommits -Subjects $commitSubjects -Patterns @('false success', 'pane creation does not actually occur', 'detached orchestra layout reliability')
 $fixSource += Get-MatchedCommits -Subjects $commitSubjects -Patterns @('Manifest convergence', 'CLM-safe writes')
 $fixSource += Get-MatchedCommits -Subjects $commitSubjects -Patterns @('native-exit handling', 'fixture temp dirs out of repo root', 'review-gate CI')
+$fixSource += Get-MatchedCommits -Subjects $commitSubjects -Patterns @('release note quality', 'release body quality', 'release notes quality')
 $fixSource += @(
     $commitSubjects |
         Where-Object {

--- a/tests/VersionSurface.Tests.ps1
+++ b/tests/VersionSurface.Tests.ps1
@@ -100,7 +100,7 @@ Describe 'winsmux version surface' {
         $qualityIndex | Should -BeGreaterThan $generateIndex
         $auditIndex | Should -BeGreaterThan $qualityIndex
         $publishIndex | Should -BeGreaterThan $auditIndex
-        $releaseCoreWorkflow | Should -Match '-BacklogPath "tasks/backlog.yaml"'
+        $releaseCoreWorkflow | Should -Not -Match '-BacklogPath "tasks/backlog.yaml"'
 
         $terseBody = Join-Path $TestDrive 'terse-release-body.md'
         Set-Content -LiteralPath $terseBody -Value @'
@@ -206,6 +206,51 @@ This release body intentionally includes enough context for operators to underst
 
         $body = Get-Content -LiteralPath $generatedBody -Raw -Encoding UTF8
         $body | Should -Match 'Release workflow builds the Windows x64 core binary'
+        $body | Should -Not -Match 'source of truth'
+    }
+
+    It 'generates release notes from public git history when backlog is unavailable' {
+        $generator = Join-Path $script:RepoRoot 'scripts\generate-release-notes.ps1'
+        $qualityScript = Join-Path $script:RepoRoot 'scripts\assert-release-notes-quality.ps1'
+        $generatedBody = Join-Path $TestDrive 'generated-release-body-no-backlog.md'
+        $gitShimDir = Join-Path $TestDrive 'bin'
+        New-Item -ItemType Directory -Path $gitShimDir -Force | Out-Null
+        Set-Content -LiteralPath (Join-Path $gitShimDir 'git.cmd') -Value @'
+@echo off
+if "%~1"=="rev-parse" exit /b 0
+if "%~1"=="tag" (
+  echo v0.36.10
+  echo v0.36.9
+  exit /b 0
+)
+if "%~1"=="log" (
+  echo feat^(workers^): migrate worker path to Antigravity CLI ^(#982^)
+  echo test^(release^): gate release note quality ^(#981^)
+  echo fix^(desktop^): harden operator runtime controls ^(#975^)
+  echo chore^(deps-dev^): bump vite from 6.4.2 to 6.4.3 in /winsmux-app
+  exit /b 0
+)
+exit /b 1
+'@ -Encoding ascii
+
+        $previousPath = $env:PATH
+        try {
+            $env:PATH = "$gitShimDir;$previousPath"
+            $generateOutput = @(& pwsh -NoProfile -File $generator -Version 'v0.36.10' -BacklogPath (Join-Path $TestDrive 'missing-backlog.yaml') -OutputPath $generatedBody 2>&1)
+            $LASTEXITCODE | Should -Be 0
+            ($generateOutput -join "`n") | Should -Match 'backlog not found'
+            ($generateOutput -join "`n") | Should -Match 'release-notes.*wrote'
+
+            $qualityOutput = @(& pwsh -NoProfile -File $qualityScript -ReleaseNotesPath $generatedBody 2>&1)
+            $LASTEXITCODE | Should -Be 0
+            ($qualityOutput -join "`n") | Should -Match 'release-notes-quality.*passed'
+        } finally {
+            $env:PATH = $previousPath
+        }
+
+        $body = Get-Content -LiteralPath $generatedBody -Raw -Encoding UTF8
+        $body | Should -Match 'Antigravity CLI route'
+        $body | Should -Match 'release-note quality gates'
         $body | Should -Not -Match 'source of truth'
     }
 


### PR DESCRIPTION
## Summary

- Fixes the core release workflow so generated release notes no longer force the missing public `tasks/backlog.yaml` path.
- Adds public-git-history mappings for the v0.36.10 Antigravity migration, operator hardening, and release-note quality commits.
- Adds a VersionSurface regression test for the exact no-backlog release-note generation path that failed on the v0.36.10 core release workflow.

## Validation

- `pwsh -NoProfile -File scripts/generate-release-notes.ps1 -Version v0.36.10 -BacklogPath <missing> -OutputPath <temp>`
- `pwsh -NoProfile -File scripts/assert-release-notes-quality.ps1 -ReleaseNotesPath <temp>`
- `pwsh -NoProfile -File scripts/audit-public-surface.ps1 -ReleaseNotesPath <temp>`
- `Invoke-Pester -Path tests/VersionSurface.Tests.ps1 -Output Minimal -PassThru`
- `Invoke-Pester -Path tests/PublicSurfacePolicy.Tests.ps1 -Output Minimal -PassThru`
- `git diff --check`
- `pwsh -NoProfile -File scripts/audit-public-surface.ps1`
- `pwsh -NoProfile -File scripts/git-guard.ps1 -Mode full`

## Notes

The existing `v0.36.10` release page and core assets were already manually repaired. This PR fixes the workflow path so future tag releases do not repeat the same release-body quality failure when private planning metadata is unavailable in public CI.
