### PR TITLE
fix(app): stabilize view toggles and desktop chrome

### DIFF
--- a/winsmux-app/index.html
+++ b/winsmux-app/index.html
@@ -237,7 +237,7 @@
         </header>
 
         <section id="workspace-body">
-          <section id="conversation-panel">
+          <section id="conversation-panel" class="timeline-collapsed">
             <div id="thread-meta">
               <span>Claude Code</span>
               <span>operator CLI</span>

--- a/winsmux-app/scripts/clickable-coverage-harness.mjs
+++ b/winsmux-app/scripts/clickable-coverage-harness.mjs
@@ -304,6 +304,26 @@ async function clickSelector(page, selector, label, options = {}) {
   await clickLocator(page, page.locator(selector).first(), label, options);
 }
 
+async function waitForElementVisibility(page, selector, expected, label) {
+  await page.waitForFunction(({ selector: targetSelector, expected: expectedVisibility }) => {
+    const element = document.querySelector(targetSelector);
+    if (!(element instanceof HTMLElement)) {
+      return expectedVisibility === false;
+    }
+    const style = getComputedStyle(element);
+    const rect = element.getBoundingClientRect();
+    const visible = !element.hidden &&
+      !element.closest("[hidden]") &&
+      style.display !== "none" &&
+      style.visibility !== "hidden" &&
+      rect.width > 0 &&
+      rect.height > 0;
+    return visible === expectedVisibility;
+  }, { selector, expected }, { timeout: 5_000 }).catch((error) => {
+    throw new Error(`${label}: expected ${selector} visible=${expected}: ${error.message}`);
+  });
+}
+
 async function isSidebarModeOpen(page, mode) {
   return await page.evaluate((targetMode) => {
     const shell = document.getElementById("app-shell");
@@ -323,6 +343,39 @@ async function isSidebarModeOpen(page, mode) {
     const rect = view.getBoundingClientRect();
     return rect.width > 0 && rect.height > 0;
   }, mode);
+}
+
+async function waitForSidebarModeState(page, mode, expected, label) {
+  await page.waitForFunction(({ targetMode, expectedOpen }) => {
+    const shell = document.getElementById("app-shell");
+    const rail = document.getElementById("left-rail");
+    const viewByMode = {
+      explorer: document.getElementById("files-sidebar-section"),
+      source: document.getElementById("source-control-view"),
+      evidence: document.getElementById("evidence-view"),
+      workspace: document.getElementById("session-sidebar-section"),
+    };
+    const view = viewByMode[targetMode];
+    if (!shell || !(rail instanceof HTMLElement) || !(view instanceof HTMLElement)) {
+      return false;
+    }
+    const railStyle = getComputedStyle(rail);
+    const railRect = rail.getBoundingClientRect();
+    const railVisible = !rail.hidden &&
+      !rail.closest("[hidden]") &&
+      railStyle.display !== "none" &&
+      railStyle.visibility !== "hidden" &&
+      railRect.width > 0 &&
+      railRect.height > 0;
+    const modeOpen = shell.classList.contains("sidebar-open") &&
+      railVisible &&
+      !view.hidden &&
+      !view.closest("[hidden]") &&
+      view.getBoundingClientRect().height > 0;
+    return modeOpen === expectedOpen;
+  }, { targetMode: mode, expectedOpen: expected }, { timeout: 5_000 }).catch((error) => {
+    throw new Error(`${label}: expected sidebar mode ${mode} open=${expected}: ${error.message}`);
+  });
 }
 
 async function ensureSidebarMode(page, mode, triggerSelector, label) {
@@ -365,6 +418,19 @@ async function openTopMenu(page, menuId) {
   await page.locator("#top-menu-popover").waitFor({ state: "visible" });
 }
 
+async function clickTopMenuItemMatching(page, menuId, pattern, label) {
+  await openTopMenu(page, menuId);
+  const item = page.locator("#top-menu-popover .top-menu-popover-item").filter({ hasText: pattern }).first();
+  if (!(await item.isVisible({ timeout: 2_000 }).catch(() => false))) {
+    const menuText = (await page.locator("#top-menu-popover .top-menu-popover-item").allTextContents().catch(() => []))
+      .map((text) => text.replace(/\s+/g, " ").trim())
+      .join(" | ");
+    await page.keyboard.press("Escape").catch(() => {});
+    throw new Error(`${label}: menu item not found. Available: ${menuText}`);
+  }
+  await clickLocator(page, item, label, { settleMs: 200 });
+}
+
 async function clickTopMenuItems(page, menuId) {
   await openTopMenu(page, menuId);
   const count = await page.locator("#top-menu-popover .top-menu-popover-item").count();
@@ -382,6 +448,11 @@ async function clickTopMenuItems(page, menuId) {
   }
 }
 
+async function testInitialDefaultChrome(page) {
+  await waitForElementVisibility(page, "#conversation-timeline", false, "default event feed hidden");
+  await waitForElementVisibility(page, "#worker-status-pill-bar", false, "default worker details hidden");
+}
+
 async function ensureWorkerStatusStripVisible(page) {
   const statusPill = page.locator('.worker-status-pill[data-worker-status-target="worker-2"]').first();
   if (await statusPill.isVisible({ timeout: 1_000 }).catch(() => false)) {
@@ -391,7 +462,7 @@ async function ensureWorkerStatusStripVisible(page) {
   await openTopMenu(page, "menu-view-btn");
   const showWorkerStatus = page
     .locator("#top-menu-popover .top-menu-popover-item")
-    .filter({ hasText: /Show worker status|ワーカー状態を表示/ })
+    .filter({ hasText: /Show Worker Details|Show worker status|ワーカー詳細情報を表示|ワーカー状態を表示/ })
     .first();
   if (!(await showWorkerStatus.isVisible({ timeout: 2_000 }).catch(() => false))) {
     const menuText = (await page.locator("#top-menu-popover .top-menu-popover-item").allTextContents().catch(() => []))
@@ -404,6 +475,56 @@ async function ensureWorkerStatusStripVisible(page) {
   await clickLocator(page, showWorkerStatus, "workbench show worker status", { settleMs: 200 });
   await statusPill.waitFor({ state: "visible", timeout: 5_000 });
   return statusPill;
+}
+
+async function testViewMenuStateful(page) {
+  await recoverShell(page);
+  await ensureSidebarMode(page, "explorer", "#activity-explorer-btn", "view state explorer open");
+
+  await clickTopMenuItemMatching(page, "menu-view-btn", /Hide Explorer|エクスプローラーを隠す/, "view hide explorer");
+  await waitForSidebarModeState(page, "explorer", false, "view hide explorer");
+  await clickTopMenuItemMatching(page, "menu-view-btn", /Show Explorer|エクスプローラーを表示/, "view show explorer");
+  await waitForSidebarModeState(page, "explorer", true, "view show explorer");
+
+  await clickTopMenuItemMatching(page, "menu-view-btn", /Show Workspace Overview|作業領域の概要を表示/, "view show workspace overview");
+  await waitForSidebarModeState(page, "workspace", true, "view show workspace overview");
+  await clickTopMenuItemMatching(page, "menu-view-btn", /Hide Workspace Overview|作業領域の概要を隠す/, "view hide workspace overview");
+  await waitForSidebarModeState(page, "workspace", false, "view hide workspace overview");
+
+  await clickTopMenuItemMatching(page, "menu-view-btn", /Show Source Control|ソース管理を表示/, "view show source control");
+  await waitForSidebarModeState(page, "source", true, "view show source control");
+  await clickTopMenuItemMatching(page, "menu-view-btn", /Hide Source Control|ソース管理を隠す/, "view hide source control");
+  await waitForSidebarModeState(page, "source", false, "view hide source control");
+
+  await clickTopMenuItemMatching(page, "menu-view-btn", /Show Evidence|証跡を表示/, "view show evidence");
+  await waitForSidebarModeState(page, "evidence", true, "view show evidence");
+  await clickTopMenuItemMatching(page, "menu-view-btn", /Hide Evidence|証跡を隠す/, "view hide evidence");
+  await waitForSidebarModeState(page, "evidence", false, "view hide evidence");
+
+  await clickTopMenuItemMatching(page, "menu-view-btn", /Hide Details|詳細を隠す/, "view hide details");
+  await waitForElementVisibility(page, "#context-panel", false, "view hide details");
+  await clickTopMenuItemMatching(page, "menu-view-btn", /Show Details|詳細を表示/, "view show details");
+  await waitForElementVisibility(page, "#context-panel", true, "view show details");
+
+  await clickTopMenuItemMatching(page, "menu-view-btn", /Show Agent Vault|Agent Vault を表示/, "view show agent vault");
+  await waitForElementVisibility(page, "#agent-vault-panel", true, "view show agent vault");
+  await clickTopMenuItemMatching(page, "menu-view-btn", /Hide Agent Vault|Agent Vault を隠す/, "view hide agent vault");
+  await waitForElementVisibility(page, "#agent-vault-panel", false, "view hide agent vault");
+
+  await clickTopMenuItemMatching(page, "menu-view-btn", /Show Worker Details|ワーカー詳細情報を表示/, "view show worker details");
+  await waitForElementVisibility(page, "#worker-status-pill-bar", true, "view show worker details");
+  await clickTopMenuItemMatching(page, "menu-view-btn", /Hide Worker Details|ワーカー詳細情報を隠す/, "view hide worker details");
+  await waitForElementVisibility(page, "#worker-status-pill-bar", false, "view hide worker details");
+
+  await clickTopMenuItemMatching(page, "menu-view-btn", /Show Event Feed|イベント欄を表示/, "view show event feed");
+  await waitForElementVisibility(page, "#conversation-timeline", true, "view show event feed");
+  await clickTopMenuItemMatching(page, "menu-view-btn", /Hide Event Feed|イベント欄を隠す/, "view hide event feed");
+  await waitForElementVisibility(page, "#conversation-timeline", false, "view hide event feed");
+
+  await clickTopMenuItemMatching(page, "menu-view-btn", /Hide Worker Panes|ワーカーペインを隠す/, "view hide worker panes");
+  await waitForElementVisibility(page, "#terminal-drawer", false, "view hide worker panes");
+  await clickTopMenuItemMatching(page, "menu-view-btn", /Show Worker Panes|ワーカーペインを表示/, "view show worker panes");
+  await waitForElementVisibility(page, "#terminal-drawer", true, "view show worker panes");
 }
 
 async function testTopMenus(page) {
@@ -471,6 +592,9 @@ async function testSettings(page) {
   await clickAll(page, "#settings-tab-user, #settings-tab-workspace", "settings scope tab");
   await clickAll(page, "#settings-nav .settings-nav-item", "settings nav");
   await clickAll(page, ".settings-option-chip", "settings option chip");
+  await clickSelector(page, "#settings-tab-user", "settings user scope restore");
+  await clickSelector(page, "#settings-nav-common", "settings common nav restore");
+  await page.locator("#editor-font-size-input").scrollIntoViewIfNeeded();
   await page.locator("#editor-font-size-input").fill("15");
   recordClick("settings editor font size input");
   await clickSelector(page, "#editor-font-size-reset-btn", "settings font size reset");
@@ -658,8 +782,10 @@ async function run() {
       await installBrowserStubs(page);
       await page.goto(`${previewUrl}${HARNESS_QUERY}`, { waitUntil: "networkidle" });
       await waitForAppReady(page);
+      await runStep(`${viewport.name}: initial default chrome`, () => testInitialDefaultChrome(page));
       await recordVisibleInteractives(page, "initial");
 
+      await runStep(`${viewport.name}: view menu stateful toggles`, () => testViewMenuStateful(page));
       await runStep(`${viewport.name}: top menus`, () => testTopMenus(page));
       await recordVisibleInteractives(page, "after-top-menus");
       await runStep(`${viewport.name}: navigation and footer`, () => testNavigationAndFooter(page));

--- a/winsmux-app/scripts/desktop-pane-e2e.mjs
+++ b/winsmux-app/scripts/desktop-pane-e2e.mjs
@@ -910,7 +910,9 @@ async function setWorkerStatusStripFromViewMenu(page, visible) {
   if ((await page.locator("#worker-status-pill-bar").isVisible().catch(() => false)) === visible) {
     return;
   }
-  const label = visible ? /Show worker status|ワーカー状態を表示/ : /Hide worker status|ワーカー状態を隠す/;
+  const label = visible
+    ? /Show Worker Details|Show worker status|ワーカー詳細情報を表示|ワーカー状態を表示/
+    : /Hide Worker Details|Hide worker status|ワーカー詳細情報を隠す|ワーカー状態を隠す/;
   let lastError;
   for (let attempt = 0; attempt < 2; attempt += 1) {
     await clickViewMenuItem(page, label, visible ? "show worker status" : "hide worker status");
@@ -1607,7 +1609,8 @@ async function main() {
           visibleFields,
         };
       });
-      if (detailMetrics.width < 220 || detailMetrics.visibleFields.length !== requiredFields.length) {
+      const missingFields = requiredFields.filter((field) => !detailMetrics.visibleFields.includes(field));
+      if (detailMetrics.width < 220 || missingFields.length > 0) {
         throw new Error(`worker status details should stay visible: ${JSON.stringify(detailMetrics)}`);
       }
       const workerTwoPill = page.locator('.worker-status-pill[data-worker-status-target="worker-2"]');

--- a/winsmux-app/src-tauri/src/main.rs
+++ b/winsmux-app/src-tauri/src/main.rs
@@ -1,5 +1,6 @@
-// Prevents additional console window on Windows in release, DO NOT REMOVE!!
-#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+// Prevents an additional console window on Windows. Keep this active in debug
+// builds too because local dogfood and desktop E2E runs must launch only the app.
+#![cfg_attr(target_os = "windows", windows_subsystem = "windows")]
 
 fn main() {
     winsmux_app_lib::run()

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -619,6 +619,7 @@ let statusBarDogfoodRecorded = false;
 let statusBarDogfoodRecording = false;
 let activeSourceFilter: SourceFilter = "all";
 let activeTimelineFilter: TimelineFilter = "all";
+let timelineFeedVisible = false;
 let commandBarOpen = false;
 let commandBarQuery = "";
 let selectedCommandIndex = 0;
@@ -1433,7 +1434,7 @@ const runtimeModelCatalog: RuntimeModelCatalogEntry[] = [
     reasoningEffort: "provider-default",
     promptTransport: "file",
     authMode: "antigravity-official-cli",
-    requiredBackend: "agent-cli",
+    requiredBackend: "antigravity",
     status: "selectable",
     family: "agent-arena",
     speed: "fast",
@@ -1456,7 +1457,7 @@ const runtimeModelCatalog: RuntimeModelCatalogEntry[] = [
     reasoningEffort: "provider-default",
     promptTransport: "file",
     authMode: "antigravity-official-cli",
-    requiredBackend: "agent-cli",
+    requiredBackend: "antigravity",
     status: "selectable",
     family: "agent-arena",
     speed: "fast",
@@ -1479,7 +1480,7 @@ const runtimeModelCatalog: RuntimeModelCatalogEntry[] = [
     reasoningEffort: "provider-default",
     promptTransport: "file",
     authMode: "antigravity-official-cli",
-    requiredBackend: "agent-cli",
+    requiredBackend: "antigravity",
     status: "selectable",
     family: "agent-arena",
     speed: "fast",
@@ -1502,7 +1503,7 @@ const runtimeModelCatalog: RuntimeModelCatalogEntry[] = [
     reasoningEffort: "provider-default",
     promptTransport: "file",
     authMode: "antigravity-official-cli",
-    requiredBackend: "agent-cli",
+    requiredBackend: "antigravity",
     status: "selectable",
     family: "winsmux-local",
     speed: "balanced",
@@ -1525,7 +1526,7 @@ const runtimeModelCatalog: RuntimeModelCatalogEntry[] = [
     reasoningEffort: "provider-default",
     promptTransport: "file",
     authMode: "antigravity-official-cli",
-    requiredBackend: "agent-cli",
+    requiredBackend: "antigravity",
     status: "selectable",
     family: "winsmux-local",
     speed: "balanced",
@@ -1548,7 +1549,7 @@ const runtimeModelCatalog: RuntimeModelCatalogEntry[] = [
     reasoningEffort: "provider-default",
     promptTransport: "file",
     authMode: "antigravity-official-cli",
-    requiredBackend: "agent-cli",
+    requiredBackend: "antigravity",
     status: "selectable",
     family: "winsmux-local",
     speed: "balanced",
@@ -1571,7 +1572,7 @@ const runtimeModelCatalog: RuntimeModelCatalogEntry[] = [
     reasoningEffort: "provider-default",
     promptTransport: "file",
     authMode: "antigravity-official-cli",
-    requiredBackend: "agent-cli",
+    requiredBackend: "antigravity",
     status: "selectable",
     family: "winsmux-local",
     speed: "balanced",
@@ -1594,7 +1595,7 @@ const runtimeModelCatalog: RuntimeModelCatalogEntry[] = [
     reasoningEffort: "provider-default",
     promptTransport: "file",
     authMode: "antigravity-official-cli",
-    requiredBackend: "agent-cli",
+    requiredBackend: "antigravity",
     status: "selectable",
     family: "winsmux-local",
     speed: "balanced",
@@ -1618,7 +1619,7 @@ const runtimeModelCatalog: RuntimeModelCatalogEntry[] = [
     promptTransport: "file",
     authMode: "api-key-env",
     requiredEnv: "OPENROUTER_API_KEY",
-    requiredBackend: "agent-cli",
+    requiredBackend: "api_llm",
     status: "selectable",
     family: "code-arena",
     speed: "hosted",
@@ -1665,7 +1666,7 @@ const runtimeModelCatalog: RuntimeModelCatalogEntry[] = [
     promptTransport: "file",
     authMode: "api-key-env",
     requiredEnv: "OPENROUTER_API_KEY",
-    requiredBackend: "agent-cli",
+    requiredBackend: "api_llm",
     status: "selectable",
     family: "agent-arena",
     speed: "hosted",
@@ -8689,7 +8690,7 @@ function readStoredShellPreferences(): ShellPreferenceState | null {
         ? parsed.agentVaultOpen
         : false;
     const workbenchOpen = typeof parsed.workbenchOpen === "boolean" ? parsed.workbenchOpen : true;
-    const workerStatusStripVisible = typeof parsed.workerStatusStripVisible === "boolean" ? parsed.workerStatusStripVisible : false;
+    const workerStatusStripVisible = false;
     const workbenchLayout = parsed.workbenchLayout === "3x2" || parsed.workbenchLayout === "focus" ? parsed.workbenchLayout : "2x2";
     const storedFocusedWorkbenchPaneId = typeof parsed.focusedWorkbenchPaneId === "string" && getWorkbenchPaneOrdinal(parsed.focusedWorkbenchPaneId) !== null
       ? parsed.focusedWorkbenchPaneId
@@ -9572,7 +9573,7 @@ function createRuntimeCatalogEntry(input: Partial<RuntimeModelCatalogEntry> & Pi
     reasoningEffort: "provider-default",
     promptTransport: "file",
     authMode: "provider-default",
-    requiredBackend: "agent-cli",
+    requiredBackend: "api_llm",
     status: "selectable",
     family: "winsmux-local",
     speed: "configured",
@@ -9610,7 +9611,7 @@ function createOpenRouterApiCatalogEntry(modelId: string, displayName: string): 
     promptTransport: "file",
     authMode: "api-key-env",
     requiredEnv: "OPENROUTER_API_KEY",
-    requiredBackend: "agent-cli",
+    requiredBackend: "api_llm",
     status: "selectable",
     family: "winsmux-local",
     speed: "provider-api",
@@ -10211,16 +10212,26 @@ function renderRuntimeAssignmentModeControls(japanese: boolean) {
   return wrapper;
 }
 
-function renderRuntimeWorkerDefaultControls(japanese: boolean) {
+function renderRuntimeWorkerDefaultControls(japanese: boolean, disabled = false) {
   const preference = getRuntimeWorkerDefaultPreference();
   const selectedProvider = preference.provider;
   const { entry: selectedEntry, entries } = getRuntimePreferenceSelectedEntry(preference);
   const panel = document.createElement("div");
-  panel.className = "runtime-model-shared-default";
+  panel.className = `runtime-model-shared-default ${disabled ? "is-inactive" : ""}`;
+  if (disabled) {
+    panel.setAttribute("aria-disabled", "true");
+  }
+  const disabledTitle = disabled
+    ? (japanese
+        ? "ペインごと設定を選択中のため、この共通既定モデルは使われません。"
+        : "This shared default is not used while per-pane mode is selected.")
+    : "";
 
   const header = document.createElement("div");
   header.className = "runtime-model-default-title";
-  header.textContent = japanese ? "全ペイン共通の既定モデル" : "Default model for all worker panes";
+  header.textContent = disabled
+    ? (japanese ? "全ペイン共通の既定モデル（現在は未使用）" : "Shared default model (not used now)")
+    : (japanese ? "全ペイン共通の既定モデル" : "Default model for all worker panes");
   panel.appendChild(header);
 
   const controls = document.createElement("div");
@@ -10237,6 +10248,7 @@ function renderRuntimeWorkerDefaultControls(japanese: boolean) {
       modelSource: "provider-default",
       reasoningEffort: "provider-default",
     }),
+    { disabled, title: disabledTitle },
   ));
 
   const modelOptions = entries.map((entry) => ({
@@ -10259,6 +10271,7 @@ function renderRuntimeWorkerDefaultControls(japanese: boolean) {
         reasoningEffort: normalizeRuntimeReasoningForEntry(selectedProvider, nextEntry, nextEntry.reasoningEffort),
       });
     },
+    { disabled, title: disabledTitle },
   ));
 
   controls.appendChild(createRuntimeSelect(
@@ -10268,12 +10281,17 @@ function renderRuntimeWorkerDefaultControls(japanese: boolean) {
     getRuntimeReasoningSelectOptionsForProvider(selectedProvider, japanese),
     japanese,
     (reasoningEffort) => updateRuntimeRoleDraft("worker", { reasoningEffort }),
+    { disabled, title: disabledTitle },
   ));
   panel.appendChild(controls);
 
   const note = document.createElement("div");
   note.className = "runtime-access-note";
-  note.textContent = runtimeAccessNote(preference, japanese);
+  note.textContent = disabled
+    ? (japanese
+        ? "現在はペインごと設定が有効です。各ワーカーペインの行でプロバイダー、モデル、思考量を選択してください。"
+        : "Per-pane mode is active. Choose provider, model, and effort from each worker pane row.")
+    : runtimeAccessNote(preference, japanese);
   panel.appendChild(note);
   return panel;
 }
@@ -10294,7 +10312,7 @@ function renderWorkerModelAssignmentPanel(japanese: boolean) {
 
   const assignmentMode = getRuntimeModelAssignmentModeDraft();
   panel.appendChild(renderRuntimeAssignmentModeControls(japanese));
-  panel.appendChild(renderRuntimeWorkerDefaultControls(japanese));
+  panel.appendChild(renderRuntimeWorkerDefaultControls(japanese, assignmentMode !== "shared"));
   if (assignmentMode === "shared") {
     const note = document.createElement("div");
     note.className = "runtime-model-empty";
@@ -12431,13 +12449,49 @@ function renderTimelineFilters() {
   syncActivityButtons();
 }
 
+function syncTimelineFeedVisibility() {
+  const panel = document.getElementById("conversation-panel");
+  const timeline = document.getElementById("conversation-timeline");
+  const toolbar = document.getElementById("timeline-toolbar");
+  panel?.classList.toggle("timeline-collapsed", !timelineFeedVisible);
+  if (timeline) {
+    timeline.hidden = !timelineFeedVisible;
+    timeline.setAttribute("aria-hidden", timelineFeedVisible ? "false" : "true");
+  }
+  if (toolbar) {
+    toolbar.hidden = !timelineFeedVisible;
+    toolbar.setAttribute("aria-hidden", timelineFeedVisible ? "false" : "true");
+  }
+}
+
+function setTimelineFeedVisible(visible: boolean) {
+  timelineFeedVisible = visible;
+  syncTimelineFeedVisibility();
+  if (visible) {
+    renderTimelineFilters();
+    renderRunSummary();
+    renderAgentWorkDashboard();
+    renderConversation(getConversationItems());
+  } else {
+    const selectedRunSummary = document.getElementById("selected-run-summary");
+    const agentWorkDashboard = document.getElementById("agent-work-dashboard");
+    if (selectedRunSummary) {
+      selectedRunSummary.hidden = true;
+    }
+    if (agentWorkDashboard) {
+      agentWorkDashboard.hidden = true;
+    }
+  }
+  renderFooterLane();
+}
+
 function renderRunSummary() {
   const root = document.getElementById("selected-run-summary");
   if (!root) {
     return;
   }
 
-  if (activeTimelineFilter !== "activity") {
+  if (!timelineFeedVisible || activeTimelineFilter !== "activity") {
     root.hidden = true;
     root.innerHTML = "";
     return;
@@ -12536,7 +12590,7 @@ function renderAgentWorkDashboard() {
     return;
   }
 
-  if (activeTimelineFilter !== "activity") {
+  if (!timelineFeedVisible || activeTimelineFilter !== "activity") {
     root.hidden = true;
     root.innerHTML = "";
     return;
@@ -12679,6 +12733,7 @@ function renderConversation(items: ConversationItem[]) {
   if (!timeline) {
     return;
   }
+  syncTimelineFeedVisibility();
 
   timeline.innerHTML = "";
   const visibleItems = getVisibleConversationItems(items);
@@ -13547,6 +13602,12 @@ function getTopMenuItems(menuId: string): TopMenuItem[] {
           action: () => setWorkerStatusStripVisible(!workerStatusStripVisible),
         },
         {
+          label: timelineFeedVisible
+            ? getLanguageText("Hide Event Feed", "イベント欄を隠す")
+            : getLanguageText("Show Event Feed", "イベント欄を表示"),
+          action: () => setTimelineFeedVisible(!timelineFeedVisible),
+        },
+        {
           label: terminalDrawerOpen
             ? getLanguageText("Hide Worker Panes", "ワーカーペインを隠す")
             : getLanguageText("Show Worker Panes", "ワーカーペインを表示"),
@@ -13584,6 +13645,10 @@ function getTopMenuItems(menuId: string): TopMenuItem[] {
 
 function setTimelineFilter(filter: TimelineFilter) {
   activeTimelineFilter = filter;
+  if (!timelineFeedVisible) {
+    timelineFeedVisible = true;
+    syncTimelineFeedVisibility();
+  }
   renderTimelineFilters();
   renderRunSummary();
   renderAgentWorkDashboard();
@@ -16591,7 +16656,7 @@ window.addEventListener("DOMContentLoaded", async () => {
     preferredWideSidebarOpen = storedShellPreferences.wideSidebarOpen;
     preferredWideContextOpen = storedShellPreferences.wideContextOpen;
     agentVaultOpen = storedShellPreferences.agentVaultOpen;
-    workerStatusStripVisible = storedShellPreferences.workerStatusStripVisible;
+    workerStatusStripVisible = false;
     terminalDrawerOpen = true;
     workbenchLayout = storedShellPreferences.workbenchLayout;
     focusedWorkbenchPaneId = storedShellPreferences.focusedWorkbenchPaneId;

--- a/winsmux-app/src/styles.css
+++ b/winsmux-app/src/styles.css
@@ -204,6 +204,17 @@ textarea {
   background: var(--bg-canvas);
 }
 
+#app-shell:not(.sidebar-open) {
+  grid-template-columns: var(--activity-width) minmax(0, 1fr);
+  grid-template-areas:
+    "menu menu"
+    "activity workspace";
+}
+
+#app-shell:not(.sidebar-open) #left-rail {
+  display: none;
+}
+
 #app-shell[data-theme="light"] {
   --ws-bg: #ffffff;
   --ws-bg-elevated: #ffffff;
@@ -537,6 +548,10 @@ textarea {
   min-height: 0;
   overflow-y: auto;
   overflow-x: hidden;
+}
+
+#app-shell.sidebar-open #left-rail {
+  display: flex;
 }
 
 .sidebar-mode-title {
@@ -2019,6 +2034,13 @@ body[data-popout-surface="1"] #editor-surface {
   background: var(--ws-chrome-bg);
   border-top: 1px solid var(--ws-border);
   font-family: var(--font-code);
+}
+
+#conversation-panel.timeline-collapsed #timeline-toolbar,
+#conversation-panel.timeline-collapsed #selected-run-summary,
+#conversation-panel.timeline-collapsed #agent-work-dashboard,
+#conversation-panel.timeline-collapsed #conversation-timeline {
+  display: none;
 }
 
 .timeline-item {
@@ -4803,6 +4825,11 @@ body.is-resizing-workbench {
   border: 1px solid var(--border-muted);
   border-radius: 6px;
   background: var(--bg-surface);
+}
+
+.runtime-model-shared-default.is-inactive {
+  opacity: 0.62;
+  background: color-mix(in srgb, var(--bg-surface) 84%, var(--ws-bg));
 }
 
 .runtime-model-shared-controls {


### PR DESCRIPTION
## Summary

- Hide the conversation event feed and worker details by default so the main desktop surface starts clean.
- Make View menu toggles change real shell state, including Explorer, worker details, event feed, and worker panes.
- Update clickable and desktop E2E coverage so View menu regressions and desktop chrome drift are caught.
- Keep Windows debug launches from opening an extra console window during local dogfood and desktop E2E runs.

## Verification

- `npm run build`
- `npm run test:desktop-status-e2e`
- `npm run test:clickable-coverage`
- `git diff --check`
- push hooks: `git-guard`, `audit-public-surface`, `gitleaks`

## Notes

Only the `winsmux-app` UI/E2E changes are included in this PR. Existing unstaged `core` and `winsmux-core` changes remain local and are intentionally excluded.
