### PR TITLE
fix(core): restore terminal mouse state on client exit

### DIFF
--- a/core/src/client.rs
+++ b/core/src/client.rs
@@ -19,6 +19,13 @@ use crate::debug_log::{client_log, client_log_enabled, input_log, input_log_enab
 use crate::layout::RowRunsJson;
 use crate::tree::split_with_gaps;
 
+pub(crate) fn should_refresh_managed_mouse_reporting(
+    managed_vt_input: bool,
+    elapsed: Duration,
+) -> bool {
+    managed_vt_input && elapsed >= Duration::from_secs(30)
+}
+
 /// Build a send-key name with modifier prefix (e.g. "C-Left", "S-Right", "C-S-Up").
 fn modified_key_name(base: &str, mods: KeyModifiers) -> String {
     let mut prefix = String::new();
@@ -750,10 +757,10 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
     // avoid corrupting ratatui's output buffer.
     let mut pending_osc52: Option<String> = None;
     let mut pending_bell = false;
-    // VT input mode: periodically re-send mouse-enable escape sequences.
-    // Covers SSH sessions and JetBrains JediTerm (which sends VT mouse
-    // sequences through ConPTY instead of native MOUSE_EVENT records).
-    let is_ssh_mode = crate::ssh_input::needs_vt_input();
+    // VT input mode: periodically re-send mouse-enable escape sequences only
+    // after winsmux installed its managed reader. Environment variables alone
+    // must not affect unrelated terminal tabs.
+    let managed_vt_input = input.uses_managed_vt_input();
     let mut last_mouse_enable = Instant::now();
     // ── Cursor blink stabilisation ──────────────────────────────────
     // Cache the last-sent DECSCUSR code so we only write it when it
@@ -2240,7 +2247,7 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
                 }
                 // SSH: re-send mouse-enable on resize — terminal may reset
                 // mouse reporting mode after a window size change.
-                if is_ssh_mode {
+                if managed_vt_input {
                     crate::ssh_input::send_mouse_enable();
                     last_mouse_enable = Instant::now();
                 }
@@ -3694,7 +3701,7 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
         // ── SSH: periodic mouse-enable refresh ───────────────────────
         // ConPTY or terminal resize can silently disable mouse reporting.
         // Re-send every 30 seconds to keep mouse working reliably.
-        if is_ssh_mode && last_mouse_enable.elapsed().as_secs() >= 30 {
+        if should_refresh_managed_mouse_reporting(managed_vt_input, last_mouse_enable.elapsed()) {
             crate::ssh_input::send_mouse_enable();
             last_mouse_enable = Instant::now();
         }
@@ -3788,7 +3795,7 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
             // Update Win32 system caret for accessibility / speech-to-text
             // tools (e.g. Wispr Flow).  Skip for SSH sessions — no local
             // console window.
-            if !is_ssh_mode {
+            if !managed_vt_input {
                 if let Some((cx, cy)) = cursor_visible {
                     crate::platform::caret::update(cx, cy);
                 }

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -37,12 +37,17 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::Duration;
 use std::env;
+#[cfg(windows)]
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Once,
+};
 
 use ratatui::backend::CrosstermBackend;
 use ratatui::Terminal;
 use crossterm::terminal::{enable_raw_mode, disable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen};
 use crossterm::{execute};
-use crossterm::cursor::{EnableBlinking, DisableBlinking};
+use crossterm::cursor::{EnableBlinking, DisableBlinking, Show};
 use crossterm::event::{EnableMouseCapture, DisableMouseCapture, EnableBracketedPaste, DisableBracketedPaste};
 
 use crate::platform::enable_virtual_terminal_processing;
@@ -55,6 +60,89 @@ use crate::session::{cleanup_stale_port_files, read_session_key, send_control,
 use crate::rendering::apply_cursor_style;
 use crate::client::run_remote;
 use crate::ssh_input::{send_mouse_enable, InputSource};
+
+#[cfg(windows)]
+static TERMINAL_EXIT_CLEANUP_ARMED: AtomicBool = AtomicBool::new(false);
+#[cfg(windows)]
+static TERMINAL_EXIT_CLEANUP_HANDLER_INSTALLED: Once = Once::new();
+
+fn restore_terminal_state_for_client_exit() {
+    let _ = disable_raw_mode();
+    crate::ssh_input::send_mouse_disable();
+    crate::ssh_input::restore_registered_console_mode();
+
+    let mut out = crate::platform::create_writer();
+    let _ = execute!(
+        out,
+        crossterm::style::Print("\x1b[0m"),
+        crossterm::style::Print("\x1b[0 q"),
+        DisableBlinking,
+        DisableMouseCapture,
+        DisableBracketedPaste,
+        LeaveAlternateScreen,
+        Show,
+    );
+}
+
+#[cfg(windows)]
+fn is_terminal_cleanup_ctrl_event(ctrl_type: u32) -> bool {
+    matches!(ctrl_type, 0 | 1 | 2 | 5 | 6)
+}
+
+#[cfg(windows)]
+unsafe extern "system" fn terminal_exit_cleanup_ctrl_handler(ctrl_type: u32) -> i32 {
+    if is_terminal_cleanup_ctrl_event(ctrl_type)
+        && TERMINAL_EXIT_CLEANUP_ARMED.swap(false, Ordering::SeqCst)
+    {
+        restore_terminal_state_for_client_exit();
+    }
+    0
+}
+
+#[cfg(windows)]
+fn install_terminal_exit_cleanup_handler() {
+    type HandlerRoutine = unsafe extern "system" fn(u32) -> i32;
+
+    #[link(name = "kernel32")]
+    extern "system" {
+        fn SetConsoleCtrlHandler(handler: Option<HandlerRoutine>, add: i32) -> i32;
+    }
+
+    TERMINAL_EXIT_CLEANUP_HANDLER_INSTALLED.call_once(|| unsafe {
+        SetConsoleCtrlHandler(Some(terminal_exit_cleanup_ctrl_handler), 1);
+    });
+}
+
+#[cfg(not(windows))]
+fn install_terminal_exit_cleanup_handler() {}
+
+struct TerminalExitCleanupGuard {
+    armed: bool,
+}
+
+impl TerminalExitCleanupGuard {
+    fn arm() -> Self {
+        install_terminal_exit_cleanup_handler();
+        #[cfg(windows)]
+        TERMINAL_EXIT_CLEANUP_ARMED.store(true, Ordering::SeqCst);
+        Self { armed: true }
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+        #[cfg(windows)]
+        TERMINAL_EXIT_CLEANUP_ARMED.store(false, Ordering::SeqCst);
+    }
+}
+
+impl Drop for TerminalExitCleanupGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            restore_terminal_state_for_client_exit();
+            self.disarm();
+        }
+    }
+}
 
 pub fn main() {
     if let Err(e) = run_main() {
@@ -295,6 +383,15 @@ mod tests {
     #[test]
     fn workers_command_is_forwarded_to_core_bridge() {
         assert!(is_winsmux_core_bridge_command("workers"));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_terminal_abnormal_exit_events_trigger_cleanup() {
+        for ctrl_type in [0, 1, 2, 5, 6] {
+            assert!(super::is_terminal_cleanup_ctrl_event(ctrl_type));
+        }
+        assert!(!super::is_terminal_cleanup_ctrl_event(99));
     }
 
     #[test]
@@ -2978,6 +3075,7 @@ fn run_main() -> io::Result<()> {
     let mut stdout = crate::platform::create_writer();
     enable_virtual_terminal_processing();
     enable_raw_mode()?;
+    let mut terminal_exit_guard = TerminalExitCleanupGuard::arm();
 
     // Detect terminal type for input handling.
     // Use VT input parsing for SSH sessions and terminals that send VT mouse
@@ -3001,7 +3099,7 @@ fn run_main() -> io::Result<()> {
     // For VT input mode (SSH / JetBrains), explicitly (re-)send mouse-enable
     // escape sequences.  ConPTY may have consumed crossterm's
     // EnableMouseCapture output without forwarding it.
-    if use_vt_input {
+    if input.uses_managed_vt_input() {
         send_mouse_enable();
     }
 
@@ -3026,18 +3124,9 @@ fn run_main() -> io::Result<()> {
 
     // Terminal cleanup — always runs, even on error, to prevent leaked
     // SGR attributes (invisible text), stuck raw mode, or stale cursor style.
-    let _ = disable_raw_mode();
-    let out = terminal.backend_mut();
-    // Reset all SGR attributes (fg/bg color, bold, hidden, etc.) BEFORE
-    // leaving the alternate screen.  SGR state is global and NOT restored
-    // by the alternate-screen save/restore mechanism (\x1b[?1049l).
-    // Without this, the last ratatui frame's foreground color can persist
-    // into the main screen, making typed text invisible.
-    let _ = execute!(out, crossterm::style::Print("\x1b[0m"));
-    // Reset cursor style to terminal default (\x1b[0 q)
-    let _ = execute!(out, crossterm::style::Print("\x1b[0 q"));
-    let _ = execute!(out, DisableBlinking, DisableMouseCapture, DisableBracketedPaste, LeaveAlternateScreen);
+    restore_terminal_state_for_client_exit();
     let _ = terminal.show_cursor();
+    terminal_exit_guard.disarm();
     result
 }
 

--- a/core/src/ssh_input.rs
+++ b/core/src/ssh_input.rs
@@ -49,12 +49,75 @@
 //! and emitted event to `~/.psmux/ssh_input.log`.
 
 use std::io;
+#[cfg(windows)]
+use std::sync::{
+    atomic::{AtomicBool, AtomicU32, AtomicUsize, Ordering},
+    Arc,
+};
 use std::time::Duration;
 
 use crossterm::event::{
     Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers,
     MouseButton, MouseEvent, MouseEventKind,
 };
+
+const MOUSE_DISABLE: &[u8] =
+    b"\x1b[?1006l\x1b[?1015l\x1b[?1003l\x1b[?1002l\x1b[?1000l\x1b[?25h";
+
+/// VT sequence used to restore normal terminal mouse behavior.
+pub fn mouse_disable_sequence() -> &'static [u8] {
+    MOUSE_DISABLE
+}
+
+#[cfg(windows)]
+fn write_stdout_vt(bytes: &[u8], label: &str) {
+    unsafe {
+        #[link(name = "kernel32")]
+        extern "system" {
+            fn GetStdHandle(nStdHandle: u32) -> *mut std::ffi::c_void;
+            fn WriteFile(
+                hFile: *mut std::ffi::c_void,
+                lpBuffer: *const u8,
+                nNumberOfBytesToWrite: u32,
+                lpNumberOfBytesWritten: *mut u32,
+                lpOverlapped: *mut std::ffi::c_void,
+            ) -> i32;
+        }
+        const STD_OUTPUT_HANDLE: u32 = (-11i32) as u32;
+        let h = GetStdHandle(STD_OUTPUT_HANDLE);
+        if !h.is_null() && h != (-1isize) as *mut std::ffi::c_void {
+            let mut written: u32 = 0;
+            let ok = WriteFile(
+                h,
+                bytes.as_ptr(),
+                bytes.len() as u32,
+                &mut written,
+                std::ptr::null_mut(),
+            );
+            ssh_debug_log(&format!("{label}: WriteFile ok={ok} written={written}"));
+        } else {
+            ssh_debug_log(&format!("{label}: GetStdHandle(STDOUT) failed"));
+        }
+    }
+
+    use std::io::Write;
+    let mut out = io::stdout().lock();
+    let _ = out.write_all(bytes);
+    let _ = out.flush();
+    ssh_debug_log(&format!("{label}: stdout write_all done"));
+}
+
+/// Explicitly restore terminal mouse reporting to the user's normal terminal.
+#[cfg(windows)]
+pub fn send_mouse_disable() {
+    ssh_debug_log("send_mouse_disable: writing mouse-disable VT sequences to stdout");
+    write_stdout_vt(mouse_disable_sequence(), "send_mouse_disable");
+}
+
+#[cfg(not(windows))]
+pub fn send_mouse_disable() {
+    // On Unix, crossterm's DisableMouseCapture already works correctly.
+}
 
 /// Explicitly (re-)send the VT mouse-enable escape sequences to stdout.
 ///
@@ -79,52 +142,17 @@ pub fn send_mouse_enable() {
     // Approach 1: WriteFile on the raw output handle.
     // This uses the Win32 file I/O path rather than WriteConsole, which
     // may behave differently under ConPTY.
-    unsafe {
-        #[link(name = "kernel32")]
-        extern "system" {
-            fn GetStdHandle(nStdHandle: u32) -> *mut std::ffi::c_void;
-            fn WriteFile(
-                hFile: *mut std::ffi::c_void,
-                lpBuffer: *const u8,
-                nNumberOfBytesToWrite: u32,
-                lpNumberOfBytesWritten: *mut u32,
-                lpOverlapped: *mut std::ffi::c_void,
-            ) -> i32;
-        }
-        const STD_OUTPUT_HANDLE: u32 = (-11i32) as u32;
-        let h = GetStdHandle(STD_OUTPUT_HANDLE);
-        if !h.is_null() && h != (-1isize) as *mut std::ffi::c_void {
-            let mut written: u32 = 0;
-            let ok = WriteFile(
-                h,
-                MOUSE_ENABLE.as_ptr(),
-                MOUSE_ENABLE.len() as u32,
-                &mut written,
-                std::ptr::null_mut(),
-            );
-            ssh_debug_log(&format!(
-                "send_mouse_enable: WriteFile ok={} written={}",
-                ok, written,
-            ));
-        } else {
-            ssh_debug_log("send_mouse_enable: GetStdHandle(STDOUT) failed");
-        }
-    }
+    write_stdout_vt(MOUSE_ENABLE, "send_mouse_enable");
 
-    // Approach 2: standard Rust stdout write (goes through ConPTY normally).
-    use std::io::Write;
-    let mut out = io::stdout().lock();
-    let _ = out.write_all(MOUSE_ENABLE);
-    let _ = out.flush();
-    ssh_debug_log("send_mouse_enable: stdout write_all done");
-
-    // Approach 3: Also send a Device Status Report (DSR) probe.
+    // Approach 2: Also send a Device Status Report (DSR) probe.
     // If ConPTY is in VT pass-through mode, the query \x1b[5n should reach
     // the client terminal, which responds with \x1b[0n.  If we later see
     // that response in our reader thread (as KEY_EVENT chars: ESC [ 0 n),
     // it proves output→client→input roundtrip works through ConPTY.
     // If we don't see it, ConPTY is consuming VT queries (Windows 10).
     const DSR_PROBE: &[u8] = b"\x1b[5n";
+    use std::io::Write;
+    let mut out = io::stdout().lock();
     let _ = out.write_all(DSR_PROBE);
     let _ = out.flush();
     ssh_debug_log("send_mouse_enable: DSR probe \\x1b[5n sent (expect \\x1b[0n response)");
@@ -253,6 +281,8 @@ pub enum InputSource {
     #[cfg(windows)]
     Ssh {
         rx: std::sync::mpsc::Receiver<Event>,
+        stop: Arc<AtomicBool>,
+        _console_mode: ConsoleModeGuard,
     },
 }
 
@@ -270,7 +300,11 @@ impl InputSource {
         #[cfg(windows)]
         {
             match start_ssh_reader() {
-                Ok(rx) => Ok(InputSource::Ssh { rx }),
+                Ok((rx, stop, console_mode)) => Ok(InputSource::Ssh {
+                    rx,
+                    stop,
+                    _console_mode: console_mode,
+                }),
                 Err(e) => {
                     // Log to file instead of stderr (raw mode garbles eprintln).
                     ssh_debug_log(&format!("SSH VT input init failed: {}; falling back to crossterm", e));
@@ -299,7 +333,7 @@ impl InputSource {
                 }
             }
             #[cfg(windows)]
-            InputSource::Ssh { rx } => match rx.recv_timeout(timeout) {
+            InputSource::Ssh { rx, .. } => match rx.recv_timeout(timeout) {
                 Ok(evt) => Ok(Some(evt)),
                 Err(std::sync::mpsc::RecvTimeoutError::Timeout) => Ok(None),
                 Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => Ok(None),
@@ -319,10 +353,33 @@ impl InputSource {
                 }
             }
             #[cfg(windows)]
-            InputSource::Ssh { rx } => match rx.try_recv() {
+            InputSource::Ssh { rx, .. } => match rx.try_recv() {
                 Ok(evt) => Ok(Some(evt)),
                 Err(_) => Ok(None),
             },
+        }
+    }
+
+    /// Returns true only when winsmux successfully installed its managed VT
+    /// input reader. Environment variables alone are not enough to keep
+    /// sending mouse-enable sequences.
+    pub fn uses_managed_vt_input(&self) -> bool {
+        #[cfg(windows)]
+        {
+            matches!(self, InputSource::Ssh { .. })
+        }
+        #[cfg(not(windows))]
+        {
+            false
+        }
+    }
+}
+
+impl Drop for InputSource {
+    fn drop(&mut self) {
+        #[cfg(windows)]
+        if let InputSource::Ssh { stop, .. } = self {
+            stop.store(true, Ordering::SeqCst);
         }
     }
 }
@@ -1053,12 +1110,14 @@ fn ssh_verbose() -> bool {
 // ─── Windows: SSH reader thread + Win32 FFI ──────────────────────────────────
 
 #[cfg(windows)]
-fn start_ssh_reader() -> io::Result<std::sync::mpsc::Receiver<Event>> {
-    use std::ffi::c_void;
-    use std::sync::mpsc;
+static REGISTERED_CONSOLE_HANDLE: AtomicUsize = AtomicUsize::new(0);
+#[cfg(windows)]
+static REGISTERED_CONSOLE_MODE: AtomicU32 = AtomicU32::new(0);
+#[cfg(windows)]
+static REGISTERED_CONSOLE_MODE_ACTIVE: AtomicBool = AtomicBool::new(false);
 
-    // ── Win32 constants ──────────────────────────────────────────────────
-    const STD_INPUT_HANDLE: u32 = (-10i32) as u32;
+#[cfg(windows)]
+fn ssh_vt_input_mode(orig_mode: u32) -> u32 {
     const ENABLE_VIRTUAL_TERMINAL_INPUT: u32 = 0x0200;
     const ENABLE_WINDOW_INPUT: u32          = 0x0008;
     const ENABLE_MOUSE_INPUT: u32           = 0x0010;
@@ -1067,6 +1126,76 @@ fn start_ssh_reader() -> io::Result<std::sync::mpsc::Receiver<Event>> {
     const ENABLE_ECHO_INPUT: u32            = 0x0004;
     const ENABLE_PROCESSED_INPUT: u32       = 0x0001;
     const ENABLE_QUICK_EDIT_MODE: u32       = 0x0040;
+
+    (orig_mode
+        & !(ENABLE_LINE_INPUT | ENABLE_ECHO_INPUT | ENABLE_PROCESSED_INPUT | ENABLE_QUICK_EDIT_MODE))
+        | ENABLE_VIRTUAL_TERMINAL_INPUT
+        | ENABLE_WINDOW_INPUT
+        | ENABLE_MOUSE_INPUT
+        | ENABLE_EXTENDED_FLAGS
+}
+
+#[cfg(windows)]
+pub fn restore_registered_console_mode() {
+    if !REGISTERED_CONSOLE_MODE_ACTIVE.swap(false, Ordering::SeqCst) {
+        return;
+    }
+
+    let handle = REGISTERED_CONSOLE_HANDLE.load(Ordering::SeqCst) as *mut std::ffi::c_void;
+    let mode = REGISTERED_CONSOLE_MODE.load(Ordering::SeqCst);
+    if handle.is_null() || handle == (-1isize) as *mut std::ffi::c_void {
+        return;
+    }
+
+    unsafe {
+        #[link(name = "kernel32")]
+        extern "system" {
+            fn SetConsoleMode(h: *mut std::ffi::c_void, mode: u32) -> i32;
+        }
+        let ok = SetConsoleMode(handle, mode);
+        ssh_debug_log(&format!(
+            "restore_registered_console_mode: SetConsoleMode ok={} mode=0x{:04X}",
+            ok, mode,
+        ));
+    }
+}
+
+#[cfg(not(windows))]
+pub fn restore_registered_console_mode() {}
+
+#[cfg(windows)]
+pub(crate) struct ConsoleModeGuard {
+    active: bool,
+}
+
+#[cfg(windows)]
+impl ConsoleModeGuard {
+    fn new(handle: *mut std::ffi::c_void, original_mode: u32) -> Self {
+        REGISTERED_CONSOLE_HANDLE.store(handle as usize, Ordering::SeqCst);
+        REGISTERED_CONSOLE_MODE.store(original_mode, Ordering::SeqCst);
+        REGISTERED_CONSOLE_MODE_ACTIVE.store(true, Ordering::SeqCst);
+        Self { active: true }
+    }
+}
+
+#[cfg(windows)]
+impl Drop for ConsoleModeGuard {
+    fn drop(&mut self) {
+        if self.active {
+            restore_registered_console_mode();
+            self.active = false;
+        }
+    }
+}
+
+#[cfg(windows)]
+fn start_ssh_reader() -> io::Result<(std::sync::mpsc::Receiver<Event>, Arc<AtomicBool>, ConsoleModeGuard)> {
+    use std::ffi::c_void;
+    use std::sync::mpsc;
+
+    // ── Win32 constants ──────────────────────────────────────────────────
+    const STD_INPUT_HANDLE: u32 = (-10i32) as u32;
+    const ENABLE_VIRTUAL_TERMINAL_INPUT: u32 = 0x0200;
 
     const KEY_EVENT: u16                     = 0x0001;
     const MOUSE_EVENT: u16                   = 0x0002;
@@ -1254,12 +1383,7 @@ fn start_ssh_reader() -> io::Result<std::sync::mpsc::Receiver<Event>> {
     //
     // This must run AFTER crossterm's enable_raw_mode() and
     // EnableMouseCapture so our SetConsoleMode has the final word.
-    let new_mode = (orig_mode
-        & !(ENABLE_LINE_INPUT | ENABLE_ECHO_INPUT | ENABLE_PROCESSED_INPUT | ENABLE_QUICK_EDIT_MODE))
-        | ENABLE_VIRTUAL_TERMINAL_INPUT
-        | ENABLE_WINDOW_INPUT
-        | ENABLE_MOUSE_INPUT
-        | ENABLE_EXTENDED_FLAGS;
+    let new_mode = ssh_vt_input_mode(orig_mode);
 
     if unsafe { SetConsoleMode(handle, new_mode) } == 0 {
         return Err(io::Error::new(
@@ -1291,6 +1415,9 @@ fn start_ssh_reader() -> io::Result<std::sync::mpsc::Receiver<Event>> {
     // The console handle is process-global and remains
     // valid for the entire process lifetime.  We pass it as usize (which is
     // Send) and cast back inside the thread.
+    let console_mode = ConsoleModeGuard::new(handle, orig_mode);
+    let stop = Arc::new(AtomicBool::new(false));
+    let thread_stop = Arc::clone(&stop);
     let handle_val = handle as usize;
     std::thread::Builder::new()
         .name("ssh-vt-input".into())
@@ -1314,12 +1441,18 @@ fn start_ssh_reader() -> io::Result<std::sync::mpsc::Receiver<Event>> {
             ssh_debug_log(&format!("Reader thread started (verbose={})", verbose));
 
             loop {
+                if thread_stop.load(Ordering::SeqCst) {
+                    break;
+                }
                 loop_count += 1;
                 // Dynamic timeout: short when the parser has a pending Esc.
                 let wait_ms = if parser.has_pending_escape() { ESC_TIMEOUT_MS } else { 500 };
                 let wait = unsafe { WaitForSingleObject(handle, wait_ms) };
 
                 if wait == WAIT_TIMEOUT {
+                    if thread_stop.load(Ordering::SeqCst) {
+                        break;
+                    }
                     // Heartbeat every ~60 loops (≈30 s at 500 ms timeout)
                     if loop_count % 60 == 0 {
                         ssh_debug_log(&format!(
@@ -1332,7 +1465,7 @@ fn start_ssh_reader() -> io::Result<std::sync::mpsc::Receiver<Event>> {
                         if unsafe { GetConsoleMode(handle, &mut cur_mode) } != 0 {
                             if cur_mode & ENABLE_VIRTUAL_TERMINAL_INPUT == 0 {
                                 ssh_debug_log("WARNING: VTI cleared! Re-enabling...");
-                                let fixed = cur_mode | ENABLE_VIRTUAL_TERMINAL_INPUT | ENABLE_MOUSE_INPUT;
+                                let fixed = ssh_vt_input_mode(cur_mode);
                                 unsafe { SetConsoleMode(handle, fixed) };
                             }
                         }
@@ -1455,5 +1588,60 @@ fn start_ssh_reader() -> io::Result<std::sync::mpsc::Receiver<Event>> {
             }
         })?;
 
-    Ok(rx)
+    Ok((rx, stop, console_mode))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn windows_terminal_winsmux_profile_cleanup_disables_mouse_reporting() {
+        let seq = std::str::from_utf8(mouse_disable_sequence()).unwrap();
+        for mode in ["1000", "1002", "1003", "1006", "1015"] {
+            assert!(
+                seq.contains(&format!("\x1b[?{}l", mode)),
+                "missing mouse disable for DECSET {mode}",
+            );
+        }
+        assert!(seq.contains("\x1b[?25h"), "cursor must be shown on cleanup");
+    }
+
+    #[test]
+    fn windows_terminal_normal_powershell_is_not_managed_vt_input() {
+        let input = InputSource::Crossterm;
+        assert!(!input.uses_managed_vt_input());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn ssh_vt_mode_preserves_unrelated_flags_and_clears_line_input() {
+        const ENABLE_PROCESSED_INPUT: u32 = 0x0001;
+        const ENABLE_LINE_INPUT: u32 = 0x0002;
+        const ENABLE_ECHO_INPUT: u32 = 0x0004;
+        const ENABLE_WINDOW_INPUT: u32 = 0x0008;
+        const ENABLE_MOUSE_INPUT: u32 = 0x0010;
+        const ENABLE_QUICK_EDIT_MODE: u32 = 0x0040;
+        const ENABLE_EXTENDED_FLAGS: u32 = 0x0080;
+        const ENABLE_VIRTUAL_TERMINAL_INPUT: u32 = 0x0200;
+        const UNRELATED_FLAG: u32 = 0x4000;
+
+        let mode = ssh_vt_input_mode(
+            ENABLE_PROCESSED_INPUT
+                | ENABLE_LINE_INPUT
+                | ENABLE_ECHO_INPUT
+                | ENABLE_QUICK_EDIT_MODE
+                | UNRELATED_FLAG,
+        );
+
+        assert_eq!(mode & ENABLE_PROCESSED_INPUT, 0);
+        assert_eq!(mode & ENABLE_LINE_INPUT, 0);
+        assert_eq!(mode & ENABLE_ECHO_INPUT, 0);
+        assert_eq!(mode & ENABLE_QUICK_EDIT_MODE, 0);
+        assert_ne!(mode & ENABLE_WINDOW_INPUT, 0);
+        assert_ne!(mode & ENABLE_MOUSE_INPUT, 0);
+        assert_ne!(mode & ENABLE_EXTENDED_FLAGS, 0);
+        assert_ne!(mode & ENABLE_VIRTUAL_TERMINAL_INPUT, 0);
+        assert_ne!(mode & UNRELATED_FLAG, 0);
+    }
 }

--- a/core/tests-rs/test_client.rs
+++ b/core/tests-rs/test_client.rs
@@ -3,6 +3,28 @@ use super::*;
 
 #[cfg(windows)]
 #[test]
+fn windows_terminal_normal_ssh_env_only_does_not_refresh_mouse_reporting() {
+    assert!(!should_refresh_managed_mouse_reporting(
+        false,
+        std::time::Duration::from_secs(31),
+    ));
+}
+
+#[cfg(windows)]
+#[test]
+fn mouse_refresh_waits_for_30_seconds_inside_managed_vt_input() {
+    assert!(!should_refresh_managed_mouse_reporting(
+        true,
+        std::time::Duration::from_secs(29),
+    ));
+    assert!(should_refresh_managed_mouse_reporting(
+        true,
+        std::time::Duration::from_secs(30),
+    ));
+}
+
+#[cfg(windows)]
+#[test]
 fn ime_detection_ascii_only() {
     // Pure ASCII text should NOT be detected as IME input
     assert!(!paste_buffer_has_non_ascii("abc"));


### PR DESCRIPTION
## Summary

Fixes the Windows Terminal cleanup path for winsmux SSH/VT input sessions.

Closes #1004

## Changes

- Adds an explicit mouse-reporting disable sequence and calls it during client cleanup.
- Saves the original Windows console input mode before enabling VT input and restores it from a guard.
- Limits the 30-second mouse-enable refresh to the managed SSH/VT input reader.
- Adds tests for normal PowerShell, ordinary SSH env-only behavior, winsmux profile cleanup, and abnormal-exit event coverage.

## Test plan

- `cargo test --manifest-path core/Cargo.toml windows_terminal --lib`
- `cargo test --manifest-path core/Cargo.toml --lib`
- `git diff --check`
