### PR TITLE
docs: use English public planning metadata

### DIFF
--- a/.githooks/pre-commit-whitelist.ps1
+++ b/.githooks/pre-commit-whitelist.ps1
@@ -9,6 +9,7 @@ if ([string]::IsNullOrWhiteSpace($repoRoot)) {
 
 Set-Location -LiteralPath $repoRoot
 
+# Keep routine public maintenance paths explicit so non-interactive commits fail closed.
 $whitelistPatterns = @(
     'README.md',
     'README.ja.md',

--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ docs/project/*
 !docs/project/v03621-local-router-shadow-profile.md
 !docs/project/v03622-context-continuity.md
 !docs/project/v03622-context-continuity.ja.md
+# Public-safe planning sync notes may be referenced from release history.
 !docs/project/pre-ga-v10-planning-sync.md
 docs/*-research*.md
 docs/review-notes*.md

--- a/docs/project/pre-ga-v10-planning-sync.md
+++ b/docs/project/pre-ga-v10-planning-sync.md
@@ -1,28 +1,28 @@
-# GA前 v10 計画同期メモ
+# Pre-GA v10 Planning Sync Note
 
-このメモは、GA前 v10 計画同期のうち公開してよい結果だけを記録する。
+This note records only the public-safe outcome of the pre-GA v10 planning sync.
 
-## リリース列
+## Release Sequence
 
-- `v0.36.22` は完了し、公開済み。
-- `v0.36.23` は現在の作業版で、名称は「6ペイン実測と連携信頼性ベンチマーク」。
-- `v0.36.23` の対象タスクは `TASK-575`、`TASK-576`、`TASK-617`、`TASK-618`。
-- `v0.36.24` から `v0.36.33` は、GA前の設計、実行基盤、操作性、API、セキュリティ、配布、保守運用の強化に使う。
-- 旧 `v0.36.24` の6件は `v0.36.34` へ移動した。ID、タスク名、本文、優先度は変えていない。
-- `TASK-545` は `v1.0.0` GA リリースタスクのまま。依存先は `v0.36.34` の公開前ゲートである `TASK-615`。
+- `v0.36.22` is complete and published.
+- `v0.36.23` is the current working release, titled "Six-pane measurement and coordination reliability benchmark".
+- `v0.36.23` covers `TASK-575`, `TASK-576`, `TASK-617`, and `TASK-618`.
+- `v0.36.24` through `v0.36.33` cover pre-GA design, execution foundation, usability, API, security, distribution, and maintenance hardening.
+- The six former `v0.36.24` tasks were moved to `v0.36.34` without changing their IDs, titles, bodies, or priorities.
+- `TASK-545` remains the `v1.0.0` GA release task. Its dependency now points to the `v0.36.34` release gate, `TASK-615`.
 
-## 確認結果
+## Validation Results
 
-- タスクIDの重複: 0件。
-- 存在しないタスクへの依存: 0件。
-- `v0.36.23` から `v0.36.34` と `v1.0.0` のリリース名欠落: 0件。
-- `v0.36.14` から `v0.36.23` の状態ずれ: 0件。
-- `v0.36.34` へ移動した旧 `v0.36.24` タスクのタスク名、本文、優先度の変更: 0件。
+- Duplicate task IDs: 0.
+- Orphan task dependencies: 0.
+- Missing release titles for `v0.36.23` through `v0.36.34` and `v1.0.0`: 0.
+- Unintended status changes in `v0.36.14` through `v0.36.23`: 0.
+- Title, body, or priority changes in the six former `v0.36.24` tasks moved to `v0.36.34`: 0.
 
-## 運用ルール
+## Operating Rules
 
-- 生成ROADMAPはバックログ正本から再生成する。
-- 計画状態の修正として、生成済みROADMAPを直接手編集しない。
-- ブラウザー表示、デスクトップE2E、パッケージ版E2E、正式ベンチマーク結果は別々の証跡として扱う。
-- モック実行や診断用の上書き実行は、正式なベンチマーク結果に含めない。
-- 公開物には、生プロンプト、秘密情報、個人環境のパス、生ログを含めない。
+- Regenerate the generated roadmap from the canonical backlog.
+- Do not hand-edit the generated roadmap as a planning-state fix.
+- Treat browser previews, desktop E2E, packaged-app E2E, and official benchmark results as separate evidence.
+- Do not mix mock runs or diagnostic overrides into official benchmark results.
+- Do not include raw prompts, secrets, private environment paths, or raw logs in public artifacts.


### PR DESCRIPTION
## Summary
- Convert the public-safe pre-GA v10 planning sync note to English.
- Touch the Git hook whitelist and `.gitignore` with English comments so GitHub directory listings advance to an English latest commit.
- Preserve existing Git history instead of rewriting the earlier Japanese commit subject.

## Verification
- `git diff --check`
- `rg -n "[ぁ-んァ-ヶ一-龠]" docs/project/pre-ga-v10-planning-sync.md .gitignore .githooks/pre-commit-whitelist.ps1` returned no matches
- Push hooks: `git-guard`, `audit-public-surface`, and `gitleaks` passed
