### PR TITLE
fix: standardize OpenRouter API key environment

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,7 +117,7 @@ jobs:
             result: bridge-worker-api-agy-exec
             timeout_minutes: 12
             paths: tests/winsmux-bridge.Tests.ps1
-            full_name: "*records blocked api_llm exec artifacts*;*rejects OpenRouter endpoint overrides*;*rejects unsupported and unsafe api_llm runtime metadata*;*marks empty provider completions as malformed*;*redacts provider request ids*;*runs api_llm exec through OpenAI-compatible chat completions*;*uses the legacy OpenRouter env*;*accepts task-json as the api_llm exec input contract*;*rejects ambiguous api_llm script*;*rejects secret-like api_llm prompt input*;*records blocked antigravity exec artifacts*;*runs antigravity exec through agy print mode*;*marks antigravity exec with empty stdout*;*accepts task-json as the antigravity exec input contract*;*rejects ambiguous antigravity script*;*rejects secret-like antigravity prompt input*"
+            full_name: "*records blocked api_llm exec artifacts*;*rejects OpenRouter endpoint overrides*;*rejects unsupported and unsafe api_llm runtime metadata*;*marks empty provider completions as malformed*;*redacts provider request ids*;*runs api_llm exec through OpenAI-compatible chat completions*;*accepts task-json as the api_llm exec input contract*;*rejects ambiguous api_llm script*;*rejects secret-like api_llm prompt input*;*records blocked antigravity exec artifacts*;*runs antigravity exec through agy print mode*;*marks antigravity exec with empty stdout*;*accepts task-json as the antigravity exec input contract*;*rejects ambiguous antigravity script*;*rejects secret-like antigravity prompt input*"
           - name: bridge-worker-colab-transfer
             result: bridge-worker-colab-transfer
             timeout_minutes: 12

--- a/docs/customization.ja.md
+++ b/docs/customization.ja.md
@@ -165,7 +165,6 @@ winsmux はベンダーごとに固定された役割ではなく、スロット
 分けて扱います。たとえば provider に `openrouter`、model に `z-ai/glm-5.2`、
 `prompt-transport: file`、`auth-mode: api-key-env` を指定できます。
 OpenRouter を環境変数で使う場合の既定名は `OPENROUTER_API_KEY` です。
-既存ローカル設定向けに `WINSMUX_OPENROUTER_API_KEY` も明示上書きとして使えますが、
 公開リポジトリの標準手順では provider 側の自然な名前を使います。Windows の
 ユーザー環境変数として保存し、新しい PowerShell を開いてから `winsmux` を実行します。
 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -226,9 +226,7 @@ and each slot can override it with one of the contract values:
 workers. They may declare a provider such as `openrouter`, a model id such as
 `z-ai/glm-5.2`, `prompt-transport: file`, and `auth-mode: api-key-env`.
 Environment-based OpenRouter authentication uses `OPENROUTER_API_KEY`.
-Existing local setups may explicitly keep using `WINSMUX_OPENROUTER_API_KEY`
-as a legacy override, but public setup should use the provider-native name.
-Store it as a Windows user environment variable, then open a new PowerShell
+Public setup should use the provider-native name. Store it as a Windows user environment variable, then open a new PowerShell
 session before running `winsmux`:
 
 ```powershell

--- a/docs/provider-and-model-support.ja.md
+++ b/docs/provider-and-model-support.ja.md
@@ -116,9 +116,8 @@ agent-slots:
 
 OpenRouter 互換の既定 base URL は `https://openrouter.ai/api/v1` です。
 環境変数で認証する場合、既定名は `OPENROUTER_API_KEY` です。
-`WINSMUX_OPENROUTER_API_KEY` は既存ローカル設定向けの明示上書き名としてだけ
-引き続き受け付けます。winsmux はどちらの値もリポジトリ、公開ドキュメント、
-PR 本文、生成レポート、ワーカーログ、リリース証跡に保存しません。
+winsmux はこの値をリポジトリ、公開ドキュメント、PR 本文、
+生成レポート、ワーカーログ、リリース証跡に保存しません。
 公開リポジトリでの標準手順では、Windows のユーザー環境変数として保存し、
 新しい PowerShell を開いてから `winsmux` を実行します。
 

--- a/docs/provider-and-model-support.md
+++ b/docs/provider-and-model-support.md
@@ -120,10 +120,9 @@ agent-slots:
 ```
 
 The default OpenRouter-compatible base URL is
-`https://openrouter.ai/api/v1`. The default environment variable name is
+`https://openrouter.ai/api/v1`. The environment variable name is
 `OPENROUTER_API_KEY` when the operator chooses environment-based
-authentication. `WINSMUX_OPENROUTER_API_KEY` is still accepted as an explicit
-legacy override for existing local setups. winsmux must not write either value
+authentication. winsmux must not write this value
 to repository files, public docs, PR text, generated reports, worker logs, or
 release evidence.
 For public setup on Windows, store the key as a user environment variable and

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -9920,9 +9920,8 @@ function Resolve-WorkersApiLlmRuntimeConfig {
         if (-not [string]::IsNullOrWhiteSpace($declaredBaseUrl) -and -not [string]::Equals($declaredBaseUrl.Trim().TrimEnd('/'), $defaultBaseUrl, [System.StringComparison]::OrdinalIgnoreCase)) {
             throw 'api_llm provider openrouter uses a built-in endpoint; api_base_url overrides are not allowed.'
         }
-        $openRouterApiKeyEnvs = @('OPENROUTER_API_KEY', 'WINSMUX_OPENROUTER_API_KEY')
-        if (-not [string]::IsNullOrWhiteSpace($declaredApiKeyEnv) -and -not ($openRouterApiKeyEnvs | Where-Object { [string]::Equals($_, $declaredApiKeyEnv.Trim(), [System.StringComparison]::OrdinalIgnoreCase) } | Select-Object -First 1)) {
-            throw 'api_llm provider openrouter supports OPENROUTER_API_KEY by default and WINSMUX_OPENROUTER_API_KEY as an explicit legacy override.'
+        if (-not [string]::IsNullOrWhiteSpace($declaredApiKeyEnv) -and -not [string]::Equals($declaredApiKeyEnv.Trim(), 'OPENROUTER_API_KEY', [System.StringComparison]::OrdinalIgnoreCase)) {
+            throw 'api_llm provider openrouter supports OPENROUTER_API_KEY only.'
         }
         $baseUrl = $defaultBaseUrl
         if ([string]::IsNullOrWhiteSpace($apiKeyEnv)) {
@@ -9990,18 +9989,6 @@ function Resolve-WorkersApiLlmCredential {
 
     $apiKeyEnv = [string](Get-SendConfigValue -InputObject $RuntimeConfig -Name 'ApiKeyEnv' -Default '')
     $apiKey = Get-WorkersApiLlmEnvValue -Name $apiKeyEnv
-    if (
-        [string]::Equals([string](Get-SendConfigValue -InputObject $RuntimeConfig -Name 'Provider' -Default ''), 'openrouter', [System.StringComparison]::OrdinalIgnoreCase) -and
-        [string]::Equals($apiKeyEnv, 'OPENROUTER_API_KEY', [System.StringComparison]::OrdinalIgnoreCase) -and
-        [string]::IsNullOrWhiteSpace($apiKey)
-    ) {
-        $legacyKey = Get-WorkersApiLlmEnvValue -Name 'WINSMUX_OPENROUTER_API_KEY'
-        if (-not [string]::IsNullOrWhiteSpace($legacyKey)) {
-            $apiKeyEnv = 'WINSMUX_OPENROUTER_API_KEY'
-            $apiKey = $legacyKey
-        }
-    }
-
     return [pscustomobject]@{
         ApiKeyEnv = $apiKeyEnv
         ApiKey    = $apiKey

--- a/tasks/cli-bakeoff/v1/WB-010-openrouter-api-worker-readiness.md
+++ b/tasks/cli-bakeoff/v1/WB-010-openrouter-api-worker-readiness.md
@@ -16,5 +16,4 @@ Return exactly this structure:
 Quality bar:
 
 - Treat `OPENROUTER_API_KEY` as the public setup path.
-- Mention legacy `WINSMUX_OPENROUTER_API_KEY` only as compatibility evidence.
 - Separate missing credential evidence from model-quality evidence.

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -9106,7 +9106,6 @@ Describe 'winsmux workers command' {
         $script:previousColabGpu = $env:WINSMUX_COLAB_AVAILABLE_GPUS
         $script:previousWorkersNow = $env:WINSMUX_TEST_NOW_UTC
         $script:previousPublicOpenRouterApiKey = $env:OPENROUTER_API_KEY
-        $script:previousOpenRouterApiKey = $env:WINSMUX_OPENROUTER_API_KEY
         $script:previousAntigravityCli = $env:WINSMUX_ANTIGRAVITY_CLI
         $script:previousAntigravityPrintTimeout = $env:WINSMUX_ANTIGRAVITY_PRINT_TIMEOUT
         $env:WINSMUX_COLAB_CLI = 'winsmux-test-missing-google-colab-cli'
@@ -9114,7 +9113,6 @@ Describe 'winsmux workers command' {
         $env:WINSMUX_COLAB_AVAILABLE_GPUS = ''
         $env:WINSMUX_TEST_NOW_UTC = ''
         $env:OPENROUTER_API_KEY = ''
-        $env:WINSMUX_OPENROUTER_API_KEY = ''
         $env:WINSMUX_ANTIGRAVITY_CLI = ''
         $env:WINSMUX_ANTIGRAVITY_PRINT_TIMEOUT = ''
     }
@@ -9125,7 +9123,6 @@ Describe 'winsmux workers command' {
         $env:WINSMUX_COLAB_AVAILABLE_GPUS = $script:previousColabGpu
         $env:WINSMUX_TEST_NOW_UTC = $script:previousWorkersNow
         $env:OPENROUTER_API_KEY = $script:previousPublicOpenRouterApiKey
-        $env:WINSMUX_OPENROUTER_API_KEY = $script:previousOpenRouterApiKey
         $env:WINSMUX_ANTIGRAVITY_CLI = $script:previousAntigravityCli
         $env:WINSMUX_ANTIGRAVITY_PRINT_TIMEOUT = $script:previousAntigravityPrintTimeout
         if ($script:workersTempRoot -and (Test-Path -LiteralPath $script:workersTempRoot)) {
@@ -11507,7 +11504,7 @@ worker-backend: colab_cli
                 provider = 'local-openai-compatible'
                 auth_mode = 'api-key-env'
                 api_base_url = 'http://127.0.0.1:8080/v1'
-                api_key_env = 'WINSMUX_OPENROUTER_API_KEY'
+                api_key_env = 'OPENROUTER_API_KEY'
             }) } | Should -Throw '*custom provider api_key_env must be provider-scoped*'
     }
 
@@ -11615,40 +11612,6 @@ worker-backend: colab_cli
         $responsePath = Join-Path $script:workersTempRoot ($payload.response -replace '/', '\')
         (Get-Content -LiteralPath $responsePath -Raw -Encoding UTF8) | Should -Match 'External model response'
         (Get-Content -LiteralPath $responsePath -Raw -Encoding UTF8) | Should -Not -Match 'test-openrouter-key'
-    }
-
-    It 'uses the legacy OpenRouter env only as an explicit compatibility fallback' {
-        Write-WorkersApiLlmProjectConfig
-        'Summarize the repository status.' | Set-Content -Path (Join-Path $script:workersTempRoot 'prompt.md') -Encoding UTF8
-        $env:OPENROUTER_API_KEY = ''
-        $env:WINSMUX_OPENROUTER_API_KEY = 'legacy-openrouter-key'
-        $script:apiLlmCapturedHeaders = $null
-
-        Mock Invoke-RestMethod {
-            param(
-                [string]$Uri,
-                [string]$Method,
-                [hashtable]$Headers,
-                [string]$Body,
-                [string]$ContentType,
-                [int]$TimeoutSec
-            )
-            $script:apiLlmCapturedHeaders = $Headers
-            return [pscustomobject]@{
-                id = 'chatcmpl-legacy'
-                choices = @([pscustomobject]@{ message = [pscustomobject]@{ content = 'Legacy key path response.' } })
-            }
-        }
-
-        $Rest = @('w1', '--script', 'prompt.md', '--run-id', 'api-legacy-run', '--json', '--project-dir', $script:workersTempRoot)
-        $output = Invoke-WorkersExec
-        $payload = ($output | Select-Object -Last 1) | ConvertFrom-Json
-
-        $payload.status | Should -Be 'succeeded'
-        $payload.api_key_env | Should -Be 'WINSMUX_OPENROUTER_API_KEY'
-        $payload.api_llm.api_key_env | Should -Be 'WINSMUX_OPENROUTER_API_KEY'
-        $script:apiLlmCapturedHeaders.Authorization | Should -Be 'Bearer legacy-openrouter-key'
-        ($output | Out-String) | Should -Not -Match 'legacy-openrouter-key'
     }
 
     It 'accepts task-json as the api_llm exec input contract' {

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -9653,11 +9653,7 @@ function normalizeRuntimeCredentialStatus(value: string) {
 }
 
 function getRuntimeModelAcceptedEnvNames(entry: RuntimeModelCatalogEntry) {
-  const names = [entry.requiredEnv].filter(Boolean) as string[];
-  if (entry.agent.toLowerCase() === "openrouter" && entry.requiredEnv === "OPENROUTER_API_KEY") {
-    names.push("WINSMUX_OPENROUTER_API_KEY");
-  }
-  return names;
+  return [entry.requiredEnv].filter(Boolean) as string[];
 }
 
 function getRuntimeWorkerReadinessLabel(state: RuntimeModelWorkerReadinessState, japanese: boolean) {


### PR DESCRIPTION
Closes #1007.

## Summary

Standardizes the OpenRouter API key path on `OPENROUTER_API_KEY` and removes the project-specific `WINSMUX_OPENROUTER_API_KEY` compatibility alias.

## Changes

- Remove the legacy OpenRouter env fallback in the core worker credential path.
- Keep OpenRouter runtime validation restricted to `OPENROUTER_API_KEY`.
- Remove the alias from the desktop model readiness logic.
- Update public docs and benchmark task guidance to show only the provider-native env var.
- Remove the Pester case that asserted the legacy fallback path.

## Verification

- `rg -n "WINSMUX_OPENROUTER_API_KEY" . --glob '!target/**' --glob '!node_modules/**' --glob '!dist/**' --glob '!*.png'`
- `pwsh -NoProfile -Command '& { $result = Invoke-Pester -Path .\tests\winsmux-bridge.Tests.ps1 -FullNameFilter "*api_llm*" -PassThru; $result | Select-Object Result,PassedCount,FailedCount,SkippedCount,Duration | Format-List; if ($result.FailedCount -gt 0) { exit 1 } }'`
- `npm run build` in `winsmux-app`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File .\scripts\audit-public-surface.ps1`
- `pwsh -NoProfile -Command '& { $result = Invoke-Pester -Path .\tests\PublicSurfacePolicy.Tests.ps1 -PassThru; $result | Select-Object Result,PassedCount,FailedCount,SkippedCount,Duration | Format-List; if ($result.FailedCount -gt 0) { exit 1 } }'`
- `git diff --check`

