### PR TITLE
docs: route benchmark evidence to v0.36.23

### DIFF
--- a/docs/benchmarks/v03617-harness-bench-report.ja.html
+++ b/docs/benchmarks/v03617-harness-bench-report.ja.html
@@ -151,8 +151,8 @@
   <header>
     <div class="header-inner">
       <h1>winsmux v0.36.17 Harness Bench Contract</h1>
-      <p class="lead">v0.36.17 は正式ベンチマーク測定版ではない。このHTMLは、v0.36.22 で行う正式 Harness Bench 測定の条件、除外規則、6 worker pane の割り当てを固定するための契約メモである。</p>
-      <p class="meta">更新: 2026-06-24 JST / 状態: v0.36.22 測定待ち / 既存run: <code>v03617-openrouter-full4-20260621t064138z</code> はwinsmux worker pane外で取得した部分証跡 / pack: <code>winsmux-cli-bakeoff-v1</code></p>
+      <p class="lead">v0.36.17 は正式ベンチマーク測定版ではない。このHTMLは、v0.36.23 で行う正式 Harness Bench 測定の条件、除外規則、6 worker pane の割り当てを固定するための契約メモである。</p>
+      <p class="meta">更新: 2026-06-25 JST / 状態: v0.36.23 測定待ち / 既存run: <code>v03617-openrouter-full4-20260621t064138z</code> はwinsmux worker pane外で取得した部分証跡 / pack: <code>winsmux-cli-bakeoff-v1</code></p>
     </div>
   </header>
 
@@ -164,7 +164,7 @@
           <span class="badge good">v0.36.17の範囲</span>
           <div class="metric"><strong>8/11</strong><span>source tasks complete</span></div>
           <div class="bar"><i style="--w:73%"></i></div>
-          <p>正本ロードマップは73%。v0.36.17は主要モデル設定、起動信頼性、正式測定の契約までを扱う。6ペイン実測とレポート再作成は v0.36.22 で実施する。</p>
+          <p>正本ロードマップは73%。v0.36.17は主要モデル設定、起動信頼性、正式測定の契約までを扱う。6ペイン実測とレポート再作成は v0.36.23 で実施する。</p>
         </div>
         <div class="card">
           <span class="badge warn">既存runの扱い</span>
@@ -173,7 +173,7 @@
           <p><code>v03617-openrouter-full4</code> は Kimi K2.7 Code と GLM-5.2 だけの部分証跡。winsmux worker pane上の6ペイン比較ではないため、正式結果には使わない。</p>
         </div>
       </div>
-      <p class="note">v0.36.22 の正式版では、6 worker の pass rate、median wall time、pass rate と wall time の散布図、difficulty別成功率を、winsmux自身の実測値から生成する。</p>
+      <p class="note">v0.36.23 の正式版では、6 worker の pass rate、median wall time、pass rate と wall time の散布図、difficulty別成功率を、winsmux自身の実測値から生成する。</p>
     </section>
 
     <section class="span-8">

--- a/docs/cli-comparison-bakeoff.md
+++ b/docs/cli-comparison-bakeoff.md
@@ -6,8 +6,8 @@ workers as winsmux worker-pane candidates.
 
 `v0.36.17` ships the model setup, readiness, and desktop reliability groundwork.
 The official six-pane benchmark run and Japanese HTML result report belong to
-`v0.36.22`, after the intervening UX, process-lifecycle, audit, coordinator, and
-router work has stabilized.
+`v0.36.23`, after the context-continuity, process-lifecycle, audit,
+coordinator, and router groundwork has stabilized.
 
 The bakeoff is not a model leaderboard. It is an operator evidence workflow for
 deciding which CLI is suitable for a task class inside winsmux.
@@ -51,7 +51,7 @@ cleanup after every run, zero owned orphan processes, and zero stale session
 state files. The evidence file stays local under `.winsmux/evidence/` and is not
 committed.
 
-Before publishing v0.36.22, the official benchmark evidence must additionally
+Before publishing v0.36.23, the official benchmark evidence must additionally
 come from the visible winsmux desktop app. The operator pane must manage all six
 worker panes, including the OpenRouter workers through the in-app `api_llm`
 pane route. App-external batch runs are retained only as reference evidence.

--- a/tests/CliBakeoff.Tests.ps1
+++ b/tests/CliBakeoff.Tests.ps1
@@ -27,6 +27,16 @@ Describe 'CLI bakeoff evidence harness' {
         ($output -join "`n") | Should -Not -Match 'C:\\Users\\'
     }
 
+    It 'routes the formal six-pane benchmark evidence to v0.36.23' {
+        $contractDoc = Get-Content -LiteralPath (Join-Path $script:RepoRoot 'docs\cli-comparison-bakeoff.md') -Raw -Encoding UTF8
+        $contractDoc | Should -Match 'v0\.36\.23'
+        $contractDoc | Should -Not -Match 'publishing v0\.36\.22|Before publishing v0\.36\.22|official benchmark evidence.*v0\.36\.22'
+
+        $contractHtml = Get-Content -LiteralPath (Join-Path $script:RepoRoot 'docs\benchmarks\v03617-harness-bench-report.ja.html') -Raw -Encoding UTF8
+        $contractHtml | Should -Match 'v0\.36\.23'
+        $contractHtml | Should -Not -Match 'v0\.36\.22 測定待ち|v0\.36\.22 で行う正式|6ペイン実測とレポート再作成は v0\.36\.22'
+    }
+
     It 'fails when a task packet is missing' {
         $badRoot = Join-Path $TestDrive 'bad-pack'
         New-Item -ItemType Directory -Path $badRoot -Force | Out-Null


### PR DESCRIPTION
## Summary

Align the public Harness Bench contract with the current v0.36.23 benchmark lane.

This PR does not claim that the formal six-pane benchmark has started or completed. It only removes stale v0.36.22 routing from the benchmark contract and locks that behavior with a focused regression test.

## Changes

- Update the CLI bakeoff contract to point the official six-pane benchmark evidence to v0.36.23.
- Update the existing v0.36.17 benchmark contract HTML so it states that the formal run remains pending for v0.36.23.
- Add a Pester regression test that fails if stale v0.36.22 formal benchmark routing returns.

## Verification

- `pwsh -NoProfile -Command "Invoke-Pester -Path .\tests\CliBakeoff.Tests.ps1 -Output Detailed"`
- `pwsh -NoProfile -File scripts\test-cli-bakeoff-preflight.ps1 -Json`
- `git diff --check`
- push hook: `git-guard`
- push hook: public surface audit
- push hook: `gitleaks`

## Claim Boundary

- Proven: the tracked benchmark contract and contract memo now route the formal benchmark lane to v0.36.23.
- Not proven: the formal six-pane desktop benchmark run, published benchmark report, v0.36.23 release gate, and post-release smoke are still pending.
