### PR TITLE
fix(app): start workers inside desktop panes

### DIFF
--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -5836,6 +5836,29 @@ function Get-WorkersStatusRows {
                 $credentialStatus = 'error'
             }
         }
+        $launchCommand = ''
+        $launchCommandStatus = ''
+        $launchCommandError = ''
+        try {
+            $launchGitWorktreeDir = $Context.ProjectDir
+            if (Get-Command Get-PaneControlGitWorktreeDir -ErrorAction SilentlyContinue) {
+                $launchGitWorktreeDir = Get-PaneControlGitWorktreeDir -ProjectDir $Context.ProjectDir
+            }
+            $launchCommand = Get-BridgeProviderLaunchCommand `
+                -ProviderId ([string]$slotConfig.Agent) `
+                -Model ([string]$slotConfig.Model) `
+                -ModelSource ([string]$slotConfig.ModelSource) `
+                -ReasoningEffort ([string]$slotConfig.ReasoningEffort) `
+                -ProjectDir $Context.ProjectDir `
+                -GitWorktreeDir $launchGitWorktreeDir `
+                -RootPath $Context.ProjectDir
+            if (-not [string]::IsNullOrWhiteSpace($launchCommand)) {
+                $launchCommandStatus = 'available'
+            }
+        } catch {
+            $launchCommandStatus = 'error'
+            $launchCommandError = [string]$_.Exception.Message
+        }
 
         $rows.Add([PSCustomObject][ordered]@{
             Slot           = ConvertTo-WorkersSlotAlias -SlotId $slotId
@@ -5874,6 +5897,9 @@ function Get-WorkersStatusRows {
             ApprovedLaunch = $approvedLaunch
             CurrentLaunch  = $currentLaunch
             ApprovalDifferences = @($approvalDifferences)
+            LaunchCommand  = $launchCommand
+            LaunchCommandStatus = $launchCommandStatus
+            LaunchCommandError = $launchCommandError
             Heartbeat      = $heartbeat
             HeartbeatHealth = $heartbeatHealth
             HeartbeatState = $heartbeatState
@@ -5986,6 +6012,9 @@ function ConvertTo-WorkersStatusJsonRows {
             approved_launch = $row.ApprovedLaunch
             current_launch  = $row.CurrentLaunch
             approval_differences = @($row.ApprovalDifferences)
+            launch_command  = [string]$row.LaunchCommand
+            launch_command_status = [string]$row.LaunchCommandStatus
+            launch_command_error = [string]$row.LaunchCommandError
             heartbeat       = $row.Heartbeat
             heartbeat_health = [string]$row.HeartbeatHealth
             heartbeat_state = [string]$row.HeartbeatState

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -10683,6 +10683,10 @@ worker-backend: colab_cli
         $payload.workers[1].current_launch.packet_type | Should -Be 'worker_launch_approval'
         $payload.workers[1].current_launch.source | Should -Be 'user_approved_worker_config'
         @($payload.workers[1].approval_differences).Count | Should -Be 0
+        $payload.workers[0].launch_command_status | Should -Be 'available'
+        $payload.workers[0].launch_command_error | Should -Be ''
+        $payload.workers[0].launch_command | Should -Match '^codex '
+        $payload.workers[0].launch_command | Should -Match '--sandbox danger-full-access'
     }
 
     It 'reports api_llm worker status with provider-hosted model metadata' {
@@ -10706,6 +10710,11 @@ worker-backend: colab_cli
         $row.session | Should -Be ''
         $row.actual_gpu | Should -Be ''
         $row.degraded_reason | Should -Be ''
+        $row.launch_command_status | Should -Be 'available'
+        $row.launch_command_error | Should -Be ''
+        $row.launch_command | Should -Match 'api-llm-pane-worker\.ps1'
+        $row.launch_command | Should -Match "-Provider 'openrouter'"
+        $row.launch_command | Should -Match "-Model 'z-ai/glm-5\.2'"
     }
 
     It 'adds api_llm diagnostics without requiring a Colab adapter fallback' {

--- a/winsmux-app/scripts/desktop-pane-e2e.mjs
+++ b/winsmux-app/scripts/desktop-pane-e2e.mjs
@@ -11,11 +11,15 @@ const LAUNCH_PROJECT_ONLY = process.argv.includes("--launch-project-only")
   || process.env.WINSMUX_DESKTOP_E2E_LAUNCH_PROJECT_ONLY === "1";
 const RELEASE_POPOUT_ONLY = process.argv.includes("--release-popout-only")
   || process.env.WINSMUX_DESKTOP_E2E_RELEASE_POPOUT_ONLY === "1";
+const WORKER_START_ONLY = process.argv.includes("--worker-start-only")
+  || process.env.WINSMUX_DESKTOP_E2E_WORKER_START_ONLY === "1";
 const OUTPUT_DIR = path.join(
   process.cwd(),
   "output",
   "playwright",
-  RELEASE_POPOUT_ONLY
+  WORKER_START_ONLY
+    ? "desktop-worker-start-e2e"
+    : RELEASE_POPOUT_ONLY
     ? "desktop-release-popout-e2e"
     : LAUNCH_PROJECT_ONLY
       ? "desktop-launch-arg-e2e"
@@ -1348,6 +1352,121 @@ async function writeEvidence(ok, extra = {}) {
   await fs.writeFile(path.join(OUTPUT_DIR, "desktop-pane-e2e.json"), JSON.stringify(evidence, null, 2));
 }
 
+async function exerciseWorkerStartButton(page) {
+  const tempProjectDir = path.join(OUTPUT_DIR, "worker-start-project");
+  await fs.rm(tempProjectDir, { recursive: true, force: true });
+  await fs.mkdir(tempProjectDir, { recursive: true });
+  const tempWinsmuxDir = path.join(tempProjectDir, ".winsmux");
+  await fs.mkdir(tempWinsmuxDir, { recursive: true });
+  const markerScriptPath = path.join(tempProjectDir, "desktop-worker-launch-marker.ps1");
+  await fs.writeFile(
+    markerScriptPath,
+    [
+      "Write-Output 'DESKTOP_WORKER_START_OK worker-1'",
+      "Write-Output ($args -join ' ')",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  await fs.writeFile(
+    path.join(tempWinsmuxDir, "provider-capabilities.json"),
+    JSON.stringify({
+      version: 1,
+      providers: {
+        codex: {
+          adapter: "codex",
+          command: markerScriptPath,
+          prompt_transports: ["argv"],
+          auth_modes: ["default"],
+          model_sources: ["provider-default", "operator-override"],
+          reasoning_efforts: ["provider-default", "high"],
+          credential_requirements: "none",
+          execution_backend: "local-cli",
+          analysis_posture: "write",
+        },
+      },
+    }, null, 2),
+    "utf8",
+  );
+  await fs.writeFile(
+    path.join(tempProjectDir, ".winsmux.yaml"),
+    [
+      "agent: codex",
+      "model: gpt-5.4",
+      "agent-slots:",
+      "  - slot-id: worker-1",
+      "    runtime-role: worker",
+      "    worker-backend: local",
+      "    agent: codex",
+      "    model: gpt-5.4",
+      "    model-source: operator-override",
+      "    reasoning-effort: high",
+      "    worktree-mode: managed",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  runWinsmuxCore(
+    [
+      "workers",
+      "heartbeat",
+      "mark",
+      "worker-1",
+      "--run-id",
+      "desktop-heartbeat-e2e",
+      "--state",
+      "approval_waiting",
+      "--message",
+      "desktop e2e approval wait",
+      "--json",
+      "--project-dir",
+      tempProjectDir,
+    ],
+    { WINSMUX_TEST_NOW_UTC: "2026-05-16T00:00:00Z" },
+  );
+  const workerStatus = JSON.parse(runWinsmuxCore([
+    "workers",
+    "status",
+    "worker-1",
+    "--json",
+    "--project-dir",
+    tempProjectDir,
+  ]));
+  const workerRow = Array.isArray(workerStatus?.workers)
+    ? workerStatus.workers.find((row) => row.slot_id === "worker-1" || row.slot === "worker-1" || row.pane_id === "worker-1")
+    : null;
+  const launchCommand = String(workerRow?.launch_command ?? "");
+  if (workerRow?.launch_command_status !== "available") {
+    throw new Error(`worker-1 launch command was not available:\n${JSON.stringify(workerRow, null, 2)}`);
+  }
+  if (!launchCommand.includes("model=gpt-5.4") || !launchCommand.includes("model_reasoning_effort=high")) {
+    throw new Error(`worker-1 launch command did not include the selected model and effort:\n${launchCommand}`);
+  }
+
+  await setActiveProjectDirForUi(page, tempProjectDir);
+  await closePtyIfExists(page, "worker-1");
+  await setWorkbenchLayout(page, "focus");
+  await page.selectOption("#focused-pane-select", "worker-1");
+  await setWorkbenchLayout(page, "3x2");
+  await setWorkerStatusStripFromViewMenu(page, true);
+  await page.locator('.worker-status-detail-strip[data-worker-status-detail="worker-1"] .worker-status-pill-chip[data-status-field="launch"]', { hasText: "launch:not_launched" }).waitFor({ state: "visible", timeout: 60_000 });
+  await page.locator('.worker-status-detail-strip[data-worker-status-detail="worker-1"] .worker-status-pill-chip[data-status-field="heartbeat"]', { hasText: "hb:none" }).waitFor({ state: "visible", timeout: 60_000 });
+  await page.click("#start-worker-btn");
+  await page.locator("#conversation-panel", { hasText: "Worker launch approval" }).waitFor({ state: "visible", timeout: 60_000 });
+  await page.locator("#conversation-panel", { hasText: "Worker start accepted" }).waitFor({ state: "visible", timeout: 60_000 });
+  const workerOutput = await waitForPtyOutput(page, "worker-1", "DESKTOP_WORKER_START_OK", 60_000);
+  const compactWorkerOutput = stripAnsi(workerOutput).replace(/\s+/g, "");
+  if (!compactWorkerOutput.includes("DESKTOP_WORKER_START_OK")) {
+    throw new Error(`worker pane did not run the launch command:\n${workerOutput.slice(-1_200)}`);
+  }
+  const text = await page.locator("#conversation-panel").innerText().catch(() => "");
+  return {
+    conversationTail: text.slice(-1_200),
+    launchCommand,
+    workerOutput: workerOutput.slice(-1_200),
+  };
+}
+
 async function main() {
   await ensureOutputDir();
   const debugPort = await getAvailablePort();
@@ -1385,6 +1504,18 @@ async function main() {
       await waitForAppReady(page);
       return { url: page.url() };
     });
+
+    if (WORKER_START_ONLY) {
+      await resetAppState(page);
+      await runStep("worker start button launches the selected Tauri worker pane", async () => {
+        return await exerciseWorkerStartButton(page);
+      });
+      await ensureOutputDir();
+      await page.screenshot({ path: path.join(OUTPUT_DIR, "desktop-worker-start-e2e-success.png"), fullPage: true });
+      await writeEvidence(true, { debugPort, mode: "worker-start-only" });
+      process.stdout.write(`[desktop-pane-e2e] PASS worker-start-only evidence=${path.join(OUTPUT_DIR, "desktop-pane-e2e.json")}\n`);
+      return;
+    }
 
     if (RELEASE_POPOUT_ONLY) {
       await resetAppState(page);
@@ -1899,65 +2030,8 @@ async function main() {
       return await exerciseTauriNativeSurface(page, browser);
     });
 
-    await runStep("worker start button shows launch approval before lifecycle command", async () => {
-      const tempProjectDir = path.join(OUTPUT_DIR, "worker-start-project");
-      await fs.rm(tempProjectDir, { recursive: true, force: true });
-      await fs.mkdir(tempProjectDir, { recursive: true });
-      await fs.writeFile(
-        path.join(tempProjectDir, ".winsmux.yaml"),
-        [
-          "agent: codex",
-          "model: gpt-5.4",
-          "agent-slots:",
-          "  - slot-id: worker-1",
-          "    runtime-role: worker",
-          "    worker-backend: local",
-          "    agent: codex",
-          "    model: gpt-5.4",
-          "    model-source: operator-override",
-          "    reasoning-effort: high",
-          "    worktree-mode: managed",
-          "",
-        ].join("\n"),
-        "utf8",
-      );
-      runWinsmuxCore(
-        [
-          "workers",
-          "heartbeat",
-          "mark",
-          "worker-1",
-          "--run-id",
-          "desktop-heartbeat-e2e",
-          "--state",
-          "approval_waiting",
-          "--message",
-          "desktop e2e approval wait",
-          "--json",
-          "--project-dir",
-          tempProjectDir,
-        ],
-        { WINSMUX_TEST_NOW_UTC: "2026-05-16T00:00:00Z" },
-      );
-
-      await setActiveProjectDirForUi(page, tempProjectDir);
-      await setWorkbenchLayout(page, "focus");
-      await page.selectOption("#focused-pane-select", "worker-1");
-      await setWorkbenchLayout(page, "3x2");
-      await setWorkerStatusStripFromViewMenu(page, true);
-      await page.locator('.worker-status-detail-strip[data-worker-status-detail="worker-1"] .worker-status-pill-chip[data-status-field="launch"]', { hasText: "launch:not_launched" }).waitFor({ state: "visible", timeout: 60_000 });
-      await page.locator('.worker-status-detail-strip[data-worker-status-detail="worker-1"] .worker-status-pill-chip[data-status-field="heartbeat"]', { hasText: "hb:none" }).waitFor({ state: "visible", timeout: 60_000 });
-      await page.click("#start-worker-btn");
-      await page.locator("#conversation-panel", { hasText: "Worker launch approval" }).waitFor({ state: "visible", timeout: 60_000 });
-      await page.locator("#conversation-panel", { hasText: "Worker start blocked" }).waitFor({ state: "visible", timeout: 60_000 });
-      const text = await page.locator("#conversation-panel").innerText();
-      if (!text.includes("worker-1") || !text.includes("manifest_entry_missing")) {
-        throw new Error(`worker start conversation did not expose the expected launch result:\n${text.slice(-1_200)}`);
-      }
-      if (!text.includes("profile local-windows")) {
-        throw new Error(`worker start conversation did not expose the execution profile:\n${text.slice(-1_200)}`);
-      }
-      return { conversationTail: text.slice(-1_200) };
+    await runStep("worker start button launches the selected Tauri worker pane", async () => {
+      return await exerciseWorkerStartButton(page);
     });
 
     await runStep("close spawned PTYs", async () => {

--- a/winsmux-app/src/desktopClient.ts
+++ b/winsmux-app/src/desktopClient.ts
@@ -722,6 +722,9 @@ export interface DesktopWorkerStatusRow {
   approved_launch: DesktopWorkerLaunchApproval | null;
   current_launch: DesktopWorkerLaunchApproval | null;
   approval_differences: DesktopWorkerApprovalDifference[];
+  launch_command?: string;
+  launch_command_status?: string;
+  launch_command_error?: string;
   heartbeat?: DesktopWorkerHeartbeat | null;
   heartbeat_health?: string;
   heartbeat_state?: string;

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -17,7 +17,6 @@ import {
   pickDesktopRunWinner,
   promoteDesktopRunTactic,
   recordDesktopDogfoodEvent,
-  startDesktopWorker,
   subscribeToDesktopSummaryRefresh,
   switchDesktopProvider,
   type DesktopCompareRunsResult,
@@ -3506,6 +3505,34 @@ function appendWorkerStartResultConversation(
   renderConversation(getConversationItems());
 }
 
+async function startDesktopWorkerPaneWithLaunchCommand(target: string, row: DesktopWorkerStatusRow) {
+  const launchCommand = (row.launch_command ?? "").trim();
+  if (!launchCommand) {
+    throw new Error(row.launch_command_error || `No launch command is available for ${target}.`);
+  }
+  const pane = panes.get(target);
+  if (!pane) {
+    throw new Error(`Pane ${target} not found.`);
+  }
+  if (pane.ptyStarted) {
+    appendWorkerStartResultConversation({ slot_id: target, status: "already_running" }, row);
+    return;
+  }
+  if (pane.ptyStarting || !queuePaneStartupInput(target, `${launchCommand}\r`)) {
+    appendWorkerStartResultConversation({
+      slot_id: target,
+      status: "blocked",
+      reason: "pane_start_in_progress",
+      failed_stage: "desktop_pane_start",
+      recovery_action: "wait-for-pane-start-and-retry",
+    }, row);
+    return;
+  }
+
+  await ensurePanePtyStarted(target);
+  appendWorkerStartResultConversation({ slot_id: target, status: "started" }, row);
+}
+
 async function startFocusedWorkerFromDesktop() {
   const target = getWorkerStartTarget();
   if (!target) {
@@ -3546,12 +3573,10 @@ async function startFocusedWorkerFromDesktop() {
       }
     }
 
-    const startPayload = await startDesktopWorker(target, activeProjectDir);
-    const result = startPayload.results.find((item) => item.slot_id === target || item.slot === target || item.pane_id === target)
-      ?? startPayload.results[0];
-    if (result) {
-      appendWorkerStartResultConversation(result, row);
+    if (!row) {
+      throw new Error(`Worker status for ${target} was not found.`);
     }
+    await startDesktopWorkerPaneWithLaunchCommand(target, row);
     requestDesktopSummaryRefresh(undefined, 500);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
## Summary
- Expose provider launch commands in `workers status` so the desktop app can reuse the same resolved worker command.
- Route the desktop `Start` action into the selected Tauri worker pane instead of invoking the legacy external worker lifecycle.
- Add focused regression coverage for worker launch command reporting and the desktop worker start path.

## Why
The v0.36.23 benchmark run must execute every measured worker inside the visible winsmux desktop worker panes. The previous desktop `Start` path could fall back to the legacy lifecycle command, which is not acceptable evidence for the six-pane benchmark.

## Test Plan
- `npm run build`
- `npm run tauri -- build --no-bundle`
- `node ./scripts/desktop-pane-e2e.mjs --worker-start-only`
- `Invoke-Pester -Path .\tests\winsmux-bridge.Tests.ps1 -FullName '*reports the default six worker slots with aliases and Colab degraded state','*reports api_llm worker status with provider-hosted model metadata' -Output Detailed`
- `git diff --check -- scripts/winsmux-core.ps1 tests/winsmux-bridge.Tests.ps1 winsmux-app/scripts/desktop-pane-e2e.mjs winsmux-app/src/desktopClient.ts winsmux-app/src/main.ts`
