### PR TITLE
test(bench): require candidate identity before Harness Bench

### DIFF
--- a/scripts/test-cli-bakeoff-preflight.ps1
+++ b/scripts/test-cli-bakeoff-preflight.ps1
@@ -3,6 +3,14 @@ param(
     [string]$PackPath = 'tasks/cli-bakeoff/v1/benchmark-pack.json',
     [string]$TaskRoot = '',
     [string]$RunDir = '',
+    [switch]$RequireCandidateIdentity,
+    [string]$ExpectedVersion = '',
+    [string]$ExpectedGitHead = '',
+    [string]$CandidateDesktopBinary = '',
+    [string]$CandidateCliBinary = '',
+    [string]$ExpectedDesktopSha256 = '',
+    [string]$ExpectedCliSha256 = '',
+    [switch]$AllowDirty,
     [switch]$Json
 )
 
@@ -52,6 +60,89 @@ function Add-Check {
     $script:checks.Add([pscustomobject]@{ name = $Name; pass = $Pass; detail = (ConvertTo-SafeDetail $Detail) }) | Out-Null
 }
 
+function Get-GitOutput {
+    param([Parameter(Mandatory = $true)][string[]]$Arguments)
+    try {
+        return (& git -C $RepoRoot @Arguments 2>$null | Out-String).Trim()
+    } catch {
+        return ''
+    }
+}
+
+function Get-FileProductVersion {
+    param([AllowNull()][string]$Path)
+    if ([string]::IsNullOrWhiteSpace($Path) -or -not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        return ''
+    }
+    try {
+        return [string]([System.Diagnostics.FileVersionInfo]::GetVersionInfo($Path).ProductVersion)
+    } catch {
+        return ''
+    }
+}
+
+function Get-FileSha256 {
+    param([AllowNull()][string]$Path)
+    if ([string]::IsNullOrWhiteSpace($Path) -or -not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        return ''
+    }
+    try {
+        return [string]((Get-FileHash -LiteralPath $Path -Algorithm SHA256).Hash).ToLowerInvariant()
+    } catch {
+        return ''
+    }
+}
+
+function Get-ProjectVersionMetadata {
+    $versionPath = Join-Path $RepoRoot 'VERSION'
+    $cargoPath = Join-Path $RepoRoot 'core\Cargo.toml'
+    $tauriConfigPath = Join-Path $RepoRoot 'winsmux-app\src-tauri\tauri.conf.json'
+
+    $version = if (Test-Path -LiteralPath $versionPath -PathType Leaf) {
+        (Get-Content -LiteralPath $versionPath -Raw -Encoding UTF8).Trim()
+    } else {
+        ''
+    }
+
+    $cargoVersion = ''
+    if (Test-Path -LiteralPath $cargoPath -PathType Leaf) {
+        $cargoText = Get-Content -LiteralPath $cargoPath -Raw -Encoding UTF8
+        $match = [regex]::Match($cargoText, '(?m)^\s*version\s*=\s*"([^"]+)"')
+        if ($match.Success) {
+            $cargoVersion = $match.Groups[1].Value
+        }
+    }
+
+    $tauriVersion = ''
+    if (Test-Path -LiteralPath $tauriConfigPath -PathType Leaf) {
+        try {
+            $tauriConfig = Get-Content -LiteralPath $tauriConfigPath -Raw -Encoding UTF8 | ConvertFrom-Json -Depth 20
+            $tauriVersion = [string]$tauriConfig.version
+        } catch {
+            $tauriVersion = ''
+        }
+    }
+
+    return [pscustomobject]@{
+        VERSION    = $version
+        CargoToml  = $cargoVersion
+        TauriConf  = $tauriVersion
+    }
+}
+
+function Test-VersionSetMatches {
+    param(
+        [Parameter(Mandatory = $true)]$Metadata,
+        [Parameter(Mandatory = $true)][string]$Expected
+    )
+    if ([string]::IsNullOrWhiteSpace($Expected)) {
+        return $false
+    }
+    return [string]$Metadata.VERSION -eq $Expected -and
+        [string]$Metadata.CargoToml -eq $Expected -and
+        [string]$Metadata.TauriConf -eq $Expected
+}
+
 $checks = [System.Collections.Generic.List[object]]::new()
 $resolvedPackPath = Resolve-LocalPath $PackPath
 $resolvedTaskRoot = if ([string]::IsNullOrWhiteSpace($TaskRoot)) {
@@ -61,6 +152,57 @@ $resolvedTaskRoot = if ([string]::IsNullOrWhiteSpace($TaskRoot)) {
 }
 
 Add-Check 'benchmark pack exists' (Test-Path -LiteralPath $resolvedPackPath -PathType Leaf) $resolvedPackPath
+
+if ($RequireCandidateIdentity) {
+    $actualHead = Get-GitOutput -Arguments @('rev-parse', 'HEAD')
+    $statusShort = Get-GitOutput -Arguments @('status', '--porcelain')
+    $versionMetadata = Get-ProjectVersionMetadata
+    $resolvedDesktopBinary = if ([string]::IsNullOrWhiteSpace($CandidateDesktopBinary)) { '' } else { Resolve-LocalPath $CandidateDesktopBinary }
+    $resolvedCliBinary = if ([string]::IsNullOrWhiteSpace($CandidateCliBinary)) { '' } else { Resolve-LocalPath $CandidateCliBinary }
+    $desktopBinaryExists = -not [string]::IsNullOrWhiteSpace($resolvedDesktopBinary) -and (Test-Path -LiteralPath $resolvedDesktopBinary -PathType Leaf)
+    $cliBinaryExists = -not [string]::IsNullOrWhiteSpace($resolvedCliBinary) -and (Test-Path -LiteralPath $resolvedCliBinary -PathType Leaf)
+    $desktopProductVersion = Get-FileProductVersion -Path $resolvedDesktopBinary
+    $desktopSha256 = Get-FileSha256 -Path $resolvedDesktopBinary
+    $cliSha256 = Get-FileSha256 -Path $resolvedCliBinary
+    $expectedHeadMatches = -not [string]::IsNullOrWhiteSpace($ExpectedGitHead) -and
+        -not [string]::IsNullOrWhiteSpace($actualHead) -and
+        $actualHead.StartsWith($ExpectedGitHead, [System.StringComparison]::OrdinalIgnoreCase)
+
+    Add-Check 'candidate expected version is present' (-not [string]::IsNullOrWhiteSpace($ExpectedVersion)) $ExpectedVersion
+    Add-Check 'candidate expected git head is present' (-not [string]::IsNullOrWhiteSpace($ExpectedGitHead)) $ExpectedGitHead
+    Add-Check 'candidate git head matches expected' $expectedHeadMatches "actual=$actualHead expected=$ExpectedGitHead"
+    Add-Check 'candidate worktree is clean' ([bool]$AllowDirty -or [string]::IsNullOrWhiteSpace($statusShort)) $statusShort
+    Add-Check 'candidate version metadata matches expected' (Test-VersionSetMatches -Metadata $versionMetadata -Expected $ExpectedVersion) (
+        "VERSION=$($versionMetadata.VERSION); Cargo.toml=$($versionMetadata.CargoToml); tauri.conf.json=$($versionMetadata.TauriConf); expected=$ExpectedVersion"
+    )
+    Add-Check 'candidate desktop binary path is provided' (-not [string]::IsNullOrWhiteSpace($resolvedDesktopBinary))
+    Add-Check 'candidate desktop binary exists' $desktopBinaryExists $resolvedDesktopBinary
+    Add-Check 'candidate desktop binary version matches expected' (
+        $desktopBinaryExists -and
+        -not [string]::IsNullOrWhiteSpace($ExpectedVersion) -and
+        [string]$desktopProductVersion -eq $ExpectedVersion
+    ) "ProductVersion=$desktopProductVersion expected=$ExpectedVersion"
+    Add-Check 'candidate desktop binary sha256 is readable' (
+        $desktopBinaryExists -and -not [string]::IsNullOrWhiteSpace($desktopSha256)
+    ) "sha256=$desktopSha256"
+    if (-not [string]::IsNullOrWhiteSpace($ExpectedDesktopSha256)) {
+        Add-Check 'candidate desktop binary sha256 matches expected' (
+            -not [string]::IsNullOrWhiteSpace($desktopSha256) -and
+            [string]$desktopSha256 -eq [string]$ExpectedDesktopSha256.ToLowerInvariant()
+        ) "actual=$desktopSha256 expected=$ExpectedDesktopSha256"
+    }
+    Add-Check 'candidate CLI binary path is provided' (-not [string]::IsNullOrWhiteSpace($resolvedCliBinary))
+    Add-Check 'candidate CLI binary exists' $cliBinaryExists $resolvedCliBinary
+    Add-Check 'candidate CLI binary sha256 is readable' (
+        $cliBinaryExists -and -not [string]::IsNullOrWhiteSpace($cliSha256)
+    ) "sha256=$cliSha256"
+    if (-not [string]::IsNullOrWhiteSpace($ExpectedCliSha256)) {
+        Add-Check 'candidate CLI binary sha256 matches expected' (
+            -not [string]::IsNullOrWhiteSpace($cliSha256) -and
+            [string]$cliSha256 -eq [string]$ExpectedCliSha256.ToLowerInvariant()
+        ) "actual=$cliSha256 expected=$ExpectedCliSha256"
+    }
+}
 
 $pack = $null
 if (Test-Path -LiteralPath $resolvedPackPath -PathType Leaf) {

--- a/tests/CliBakeoff.Tests.ps1
+++ b/tests/CliBakeoff.Tests.ps1
@@ -37,6 +37,39 @@ Describe 'CLI bakeoff evidence harness' {
         $contractHtml | Should -Not -Match 'v0\.36\.22 測定待ち|v0\.36\.22 で行う正式|6ペイン実測とレポート再作成は v0\.36\.22'
     }
 
+    It 'benchmark_readiness_gate_rejects_mismatched_candidate_identity' {
+        $missingDesktopBinary = Join-Path $TestDrive 'missing-winsmux-app.exe'
+        $missingCliBinary = Join-Path $TestDrive 'missing-winsmux.exe'
+
+        $output = & pwsh -NoProfile -File $script:PreflightScript `
+            -PackPath $script:PackPath `
+            -Json `
+            -RequireCandidateIdentity `
+            -AllowDirty `
+            -ExpectedVersion '0.0.0' `
+            -ExpectedGitHead 'deadbeef' `
+            -CandidateDesktopBinary $missingDesktopBinary `
+            -CandidateCliBinary $missingCliBinary 2>$null
+
+        $LASTEXITCODE | Should -Be 1
+        $result = $output | ConvertFrom-Json -Depth 20
+        $result | Should -Not -BeNullOrEmpty
+        $result.all_pass | Should -BeFalse
+        $checkNames = @($result.checks | ForEach-Object { $_.name })
+        $checkNames | Should -Contain 'candidate git head matches expected'
+        $checkNames | Should -Contain 'candidate version metadata matches expected'
+        $checkNames | Should -Contain 'candidate desktop binary exists'
+        $checkNames | Should -Contain 'candidate desktop binary sha256 is readable'
+        $checkNames | Should -Contain 'candidate CLI binary exists'
+        $checkNames | Should -Contain 'candidate CLI binary sha256 is readable'
+        ($result.checks | Where-Object { $_.name -eq 'candidate git head matches expected' }).pass | Should -BeFalse
+        ($result.checks | Where-Object { $_.name -eq 'candidate version metadata matches expected' }).pass | Should -BeFalse
+        ($result.checks | Where-Object { $_.name -eq 'candidate desktop binary exists' }).pass | Should -BeFalse
+        ($result.checks | Where-Object { $_.name -eq 'candidate desktop binary sha256 is readable' }).pass | Should -BeFalse
+        ($result.checks | Where-Object { $_.name -eq 'candidate CLI binary exists' }).pass | Should -BeFalse
+        ($result.checks | Where-Object { $_.name -eq 'candidate CLI binary sha256 is readable' }).pass | Should -BeFalse
+    }
+
     It 'fails when a task packet is missing' {
         $badRoot = Join-Path $TestDrive 'bad-pack'
         New-Item -ItemType Directory -Path $badRoot -Force | Out-Null

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -1826,6 +1826,32 @@ agent-slots:
         $providerDefaultSourceCommand | Should -Not -Match 'model=gpt-5\.4'
     }
 
+    It 'uses built-in launch command metadata for Antigravity and Grok Build providers' {
+        $antigravityCommand = Get-BridgeProviderLaunchCommand `
+            -ProviderId 'antigravity' `
+            -Model 'Gemini 3.5 Flash (High)' `
+            -ModelSource 'cli-discovery' `
+            -ReasoningEffort 'provider-default' `
+            -ProjectDir 'C:\Project Root' `
+            -GitWorktreeDir 'C:\Project Root\.git\worktrees\worker-3' `
+            -RootPath $script:settingsTempRoot
+
+        $antigravityCommand | Should -Be "agy --model 'Gemini 3.5 Flash (High)'"
+        $antigravityCommand | Should -Not -Match '^antigravity '
+
+        $grokCommand = Get-BridgeProviderLaunchCommand `
+            -ProviderId 'grok-build' `
+            -Model 'grok-build' `
+            -ModelSource 'cli-discovery' `
+            -ReasoningEffort 'provider-default' `
+            -ProjectDir 'C:\Project Root' `
+            -GitWorktreeDir 'C:\Project Root\.git\worktrees\worker-4' `
+            -RootPath $script:settingsTempRoot
+
+        $grokCommand | Should -Be "grok --model 'grok-build'"
+        $grokCommand | Should -Not -Match '^grok-build '
+    }
+
     It 'rejects structurally malformed provider capability registries' {
         $registryPath = Get-BridgeProviderCapabilityRegistryPath -RootPath $script:settingsTempRoot
         $registryDir = Split-Path -Parent $registryPath

--- a/winsmux-core/scripts/settings.ps1
+++ b/winsmux-core/scripts/settings.ps1
@@ -1414,6 +1414,74 @@ function Get-BridgeBuiltinProviderCapability {
                 supports_context_reset   = $true
             })
         }
+        'antigravity' {
+            return ConvertTo-BridgeProviderCapabilityEntry ([ordered]@{
+                adapter                  = 'antigravity'
+                display_name             = 'Antigravity'
+                command                  = 'agy'
+                model_options            = @(
+                    [ordered]@{ id = 'provider-default'; label = 'Provider default'; source = 'provider-default' },
+                    [ordered]@{ id = 'Gemini 3.5 Flash (High)'; label = 'Gemini 3.5 Flash (High)'; source = 'cli-discovery'; availability = 'Antigravity CLI model picker' },
+                    [ordered]@{ id = 'Gemini 3.5 Flash (Medium)'; label = 'Gemini 3.5 Flash (Medium)'; source = 'cli-discovery'; availability = 'Antigravity CLI model picker' },
+                    [ordered]@{ id = 'Gemini 3.5 Flash (Low)'; label = 'Gemini 3.5 Flash (Low)'; source = 'cli-discovery'; availability = 'Antigravity CLI model picker' },
+                    [ordered]@{ id = 'Gemini 3.1 Pro (High)'; label = 'Gemini 3.1 Pro (High)'; source = 'cli-discovery'; availability = 'Antigravity CLI model picker' },
+                    [ordered]@{ id = 'Gemini 3.1 Pro (Low)'; label = 'Gemini 3.1 Pro (Low)'; source = 'cli-discovery'; availability = 'Antigravity CLI model picker' },
+                    [ordered]@{ id = 'Claude Sonnet 4.6 (Thinking)'; label = 'Claude Sonnet 4.6 (Thinking)'; source = 'cli-discovery'; availability = 'Antigravity CLI model picker' },
+                    [ordered]@{ id = 'Claude Opus 4.6 (Thinking)'; label = 'Claude Opus 4.6 (Thinking)'; source = 'cli-discovery'; availability = 'Antigravity CLI model picker' },
+                    [ordered]@{ id = 'GPT-OSS 120B (Medium)'; label = 'GPT-OSS 120B (Medium)'; source = 'cli-discovery'; availability = 'Antigravity CLI model picker' }
+                )
+                model_sources            = @('provider-default', 'cli-discovery', 'operator-override')
+                reasoning_efforts        = @('provider-default')
+                local_access_note        = 'Local Antigravity CLI account and model picker access.'
+                harness_availability     = 'official-cli'
+                credential_requirements  = 'local-cli-owned'
+                execution_backend        = 'antigravity-cli-print'
+                runtime_requirements     = 'Antigravity CLI agy installed in the pane environment.'
+                analysis_posture         = 'read-write-worker'
+                prompt_transports        = @('argv', 'file')
+                auth_modes               = @('antigravity-official-cli')
+                local_interactive_oauth_modes = @('antigravity-official-cli')
+                supports_parallel_runs   = $true
+                supports_interrupt       = $false
+                supports_structured_result = $true
+                supports_file_edit       = $false
+                supports_subagents       = $false
+                supports_verification    = $true
+                supports_consultation    = $true
+                supports_context_reset   = $true
+            })
+        }
+        'grok-build' {
+            return ConvertTo-BridgeProviderCapabilityEntry ([ordered]@{
+                adapter                  = 'grok-build'
+                display_name             = 'Grok Build'
+                command                  = 'grok'
+                model_options            = @(
+                    [ordered]@{ id = 'provider-default'; label = 'Provider default'; source = 'provider-default' },
+                    [ordered]@{ id = 'grok-build'; label = 'Grok 4.3'; source = 'cli-discovery'; availability = 'Grok Build models' },
+                    [ordered]@{ id = 'grok-composer-2.5-fast'; label = 'Composer 2.5 Fast'; source = 'cli-discovery'; availability = 'Grok Build models' }
+                )
+                model_sources            = @('provider-default', 'cli-discovery', 'operator-override')
+                reasoning_efforts        = @('provider-default')
+                local_access_note        = 'Local Grok Build account and model picker access.'
+                harness_availability     = 'official-cli'
+                credential_requirements  = 'local-cli-owned'
+                execution_backend        = 'agent-cli'
+                runtime_requirements     = 'Grok Build CLI grok installed in the pane environment.'
+                analysis_posture         = 'read-write-worker'
+                prompt_transports        = @('argv', 'file')
+                auth_modes               = @('grok-build-local')
+                local_interactive_oauth_modes = @('grok-build-local')
+                supports_parallel_runs   = $true
+                supports_interrupt       = $false
+                supports_structured_result = $true
+                supports_file_edit       = $true
+                supports_subagents       = $false
+                supports_verification    = $true
+                supports_consultation    = $true
+                supports_context_reset   = $true
+            })
+        }
         default {
             return $null
         }


### PR DESCRIPTION
## Summary
- Use real built-in CLI launch metadata for Antigravity and Grok Build benchmark workers.
- Add a formal benchmark candidate identity preflight gate before Harness Bench can be treated as start-ready.
- Check expected version, git head, desktop binary version, and desktop/CLI binary SHA-256 evidence.

## Issue
Closes #1012

## Test Plan
- `pwsh -NoProfile -File scripts\test-cli-bakeoff-preflight.ps1 -PackPath tasks\cli-bakeoff\v1\benchmark-pack.json -Json`
- `pwsh -NoProfile -File scripts\test-cli-bakeoff-preflight.ps1 -PackPath tasks\cli-bakeoff\v1\benchmark-pack.json -Json -RequireCandidateIdentity -AllowDirty -ExpectedVersion 0.36.23 -ExpectedGitHead d9ddcdc5e2e6046844fa27d72db4806c65a43a2f -CandidateDesktopBinary target\release\winsmux-app.exe -CandidateCliBinary target\release\winsmux.exe -ExpectedDesktopSha256 728d4c5fc5d3ff2ef8f4eff113ed1d72fbe3190406b0f199216b0ba2491103ae -ExpectedCliSha256 d6db0a9ec918bdec4c286aa0ed0fdea15ac4aa31bd264fc1798c31fbd62cb76a`
- `pwsh -NoProfile -Command "Invoke-Pester -Path tests\CliBakeoff.Tests.ps1 -Output Detailed"`
- `pwsh -NoProfile -Command "Invoke-Pester -Path tests\CliBakeoff.Tests.ps1,tests\winsmux-bridge.Tests.ps1 -Output Detailed"` (573 passed)
- `cargo build --release -p winsmux`
- `git diff --check`

## Notes
- Formal Harness Bench measurement has not started in this PR.
- This PR only hardens the launch/readiness gates that must pass before benchmark evidence can be accepted.
