### PR TITLE
fix(git): block stale dirty main checkouts

### DIFF
--- a/.githooks/pre-commit-whitelist.ps1
+++ b/.githooks/pre-commit-whitelist.ps1
@@ -106,6 +106,7 @@ $whitelistPatterns = @(
     '.githooks/**',
     '.gitattributes',
     'tests/PublicSurfacePolicy.Tests.ps1',
+    'tests/GitGuard.Tests.ps1',
     'tests/GitHubWritePreflight.Tests.ps1',
     'tests/McpServerContract.Tests.ps1',
     'tests/codex-subagent-worktree-guard.Tests.ps1',

--- a/.gitignore
+++ b/.gitignore
@@ -93,6 +93,7 @@ tests/*
 !tests/BuilderWorktree.Tests.ps1
 !tests/codex-subagent-worktree-guard.Tests.ps1
 !tests/PublicSurfacePolicy.Tests.ps1
+!tests/GitGuard.Tests.ps1
 !tests/GitHubWritePreflight.Tests.ps1
 !tests/McpServerContract.Tests.ps1
 !tests/HarnessContract.Tests.ps1

--- a/scripts/git-guard.ps1
+++ b/scripts/git-guard.ps1
@@ -25,6 +25,64 @@ function Get-TrackedOrStagedFiles {
     return @($output | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
 }
 
+function Invoke-GitGuardText {
+    param([Parameter(Mandatory = $true)][string[]]$Arguments)
+
+    $output = & git @Arguments 2>$null
+    if ($LASTEXITCODE -ne 0) {
+        return $null
+    }
+
+    return ($output | Out-String).Trim()
+}
+
+function Test-StaleMainDirtyState {
+    param([Parameter(Mandatory = $true)][string]$RepoRoot)
+
+    $gitRoot = Invoke-GitGuardText -Arguments @('rev-parse', '--show-toplevel')
+    if ([string]::IsNullOrWhiteSpace($gitRoot)) {
+        return $null
+    }
+
+    $resolvedRepoRoot = (Resolve-Path -LiteralPath $RepoRoot).Path
+    $resolvedGitRoot = (Resolve-Path -LiteralPath $gitRoot).Path
+    if (-not [string]::Equals($resolvedRepoRoot, $resolvedGitRoot, [System.StringComparison]::OrdinalIgnoreCase)) {
+        return $null
+    }
+
+    $branch = Invoke-GitGuardText -Arguments @('rev-parse', '--abbrev-ref', 'HEAD')
+    if ($branch -ne 'main') {
+        return $null
+    }
+
+    $upstream = Invoke-GitGuardText -Arguments @('rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{upstream}')
+    if ([string]::IsNullOrWhiteSpace($upstream)) {
+        return $null
+    }
+
+    $counts = Invoke-GitGuardText -Arguments @('rev-list', '--left-right', '--count', 'HEAD...@{upstream}')
+    if ([string]::IsNullOrWhiteSpace($counts)) {
+        return $null
+    }
+
+    $parts = @($counts -split '\s+' | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+    if ($parts.Count -lt 2) {
+        return $null
+    }
+
+    $behind = 0
+    if (-not [int]::TryParse($parts[1], [ref]$behind) -or $behind -le 0) {
+        return $null
+    }
+
+    $trackedStatus = Invoke-GitGuardText -Arguments @('status', '--porcelain', '--untracked-files=no')
+    if ([string]::IsNullOrWhiteSpace($trackedStatus)) {
+        return $null
+    }
+
+    return "local main is $behind commit(s) behind $upstream while tracked files are modified; fetch and fast-forward main before interpreting or committing local diffs"
+}
+
 function Test-PathLikeSecretPattern {
     param([Parameter(Mandatory = $true)][string]$Path)
 
@@ -190,6 +248,11 @@ function Test-ExcessTrailingBlankLines {
 $repoRoot = (Resolve-Path '.').Path
 $files = Get-TrackedOrStagedFiles -SelectedMode $Mode
 $failures = [System.Collections.Generic.List[string]]::new()
+
+$staleMainDirtyFailure = Test-StaleMainDirtyState -RepoRoot $repoRoot
+if ($staleMainDirtyFailure) {
+    $failures.Add($staleMainDirtyFailure) | Out-Null
+}
 
 $roadmapFreshnessFailure = Test-ExternalRoadmapFreshness -RepoRoot $repoRoot
 if ($roadmapFreshnessFailure) {

--- a/tests/GitGuard.Tests.ps1
+++ b/tests/GitGuard.Tests.ps1
@@ -1,0 +1,87 @@
+$ErrorActionPreference = 'Stop'
+
+Describe 'git-guard stale main protection' {
+    BeforeAll {
+        $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+        $script:GitGuard = Join-Path $script:RepoRoot 'scripts/git-guard.ps1'
+
+        function Invoke-TestGit {
+            param(
+                [Parameter(Mandatory = $true)][string]$Cwd,
+                [Parameter(Mandatory = $true)][string[]]$Arguments
+            )
+
+            $output = & git -C $Cwd @Arguments 2>&1
+            if ($LASTEXITCODE -ne 0) {
+                throw "git $($Arguments -join ' ') failed in ${Cwd}: $($output -join "`n")"
+            }
+            return $output
+        }
+
+        function Initialize-GuardRepoPair {
+            $root = Join-Path $TestDrive ([System.Guid]::NewGuid().ToString('N'))
+            $remote = Join-Path $root 'remote.git'
+            $operator = Join-Path $root 'operator'
+            $peer = Join-Path $root 'peer'
+
+            New-Item -ItemType Directory -Force -Path $root | Out-Null
+            & git init --bare $remote | Out-Null
+            if ($LASTEXITCODE -ne 0) { throw 'failed to initialize bare remote' }
+
+            & git clone $remote $operator | Out-Null
+            if ($LASTEXITCODE -ne 0) { throw 'failed to clone operator repo' }
+            Invoke-TestGit -Cwd $operator -Arguments @('config', 'user.email', 'winsmux-tests@example.invalid') | Out-Null
+            Invoke-TestGit -Cwd $operator -Arguments @('config', 'user.name', 'winsmux tests') | Out-Null
+            Set-Content -LiteralPath (Join-Path $operator 'tracked.txt') -Value 'one' -Encoding UTF8
+            Invoke-TestGit -Cwd $operator -Arguments @('add', 'tracked.txt') | Out-Null
+            Invoke-TestGit -Cwd $operator -Arguments @('commit', '-m', 'test: seed repo') | Out-Null
+            Invoke-TestGit -Cwd $operator -Arguments @('branch', '-M', 'main') | Out-Null
+            Invoke-TestGit -Cwd $operator -Arguments @('push', '-u', 'origin', 'main') | Out-Null
+
+            & git clone $remote $peer | Out-Null
+            if ($LASTEXITCODE -ne 0) { throw 'failed to clone peer repo' }
+            Invoke-TestGit -Cwd $peer -Arguments @('config', 'user.email', 'winsmux-tests@example.invalid') | Out-Null
+            Invoke-TestGit -Cwd $peer -Arguments @('config', 'user.name', 'winsmux tests') | Out-Null
+            Set-Content -LiteralPath (Join-Path $peer 'tracked.txt') -Value 'two' -Encoding UTF8
+            Invoke-TestGit -Cwd $peer -Arguments @('add', 'tracked.txt') | Out-Null
+            Invoke-TestGit -Cwd $peer -Arguments @('commit', '-m', 'test: advance remote') | Out-Null
+            Invoke-TestGit -Cwd $peer -Arguments @('push', 'origin', 'main') | Out-Null
+            Invoke-TestGit -Cwd $operator -Arguments @('fetch', 'origin') | Out-Null
+
+            return [pscustomobject]@{
+                Root     = $root
+                Remote   = $remote
+                Operator = $operator
+                Peer     = $peer
+            }
+        }
+    }
+
+    It 'blocks local main when upstream is ahead and tracked files are modified' {
+        $repos = Initialize-GuardRepoPair
+        Set-Content -LiteralPath (Join-Path $repos.Operator 'tracked.txt') -Value 'local stale edit' -Encoding UTF8
+
+        Push-Location -LiteralPath $repos.Operator
+        try {
+            $output = @(& pwsh -NoProfile -File $script:GitGuard -Mode staged 2>&1)
+            $LASTEXITCODE | Should -Be 1
+            ($output -join "`n") | Should -Match 'local main is 1 commit\(s\) behind origin/main'
+            ($output -join "`n") | Should -Match 'fast-forward main before interpreting or committing local diffs'
+        } finally {
+            Pop-Location
+        }
+    }
+
+    It 'allows clean local main even when upstream is ahead' {
+        $repos = Initialize-GuardRepoPair
+
+        Push-Location -LiteralPath $repos.Operator
+        try {
+            $output = @(& pwsh -NoProfile -File $script:GitGuard -Mode staged 2>&1)
+            $LASTEXITCODE | Should -Be 0
+            ($output -join "`n") | Should -Match 'git-guard passed'
+        } finally {
+            Pop-Location
+        }
+    }
+}

--- a/tests/PublicSurfacePolicy.Tests.ps1
+++ b/tests/PublicSurfacePolicy.Tests.ps1
@@ -372,6 +372,8 @@ Describe 'Public surface policy' {
         $gitGuard | Should -Match 'GitHub token'
         $gitGuard | Should -Match 'function Test-ExternalRoadmapFreshness'
         $gitGuard | Should -Match 'external ROADMAP is older than backlog.yaml'
+        $gitGuard | Should -Match 'function Test-StaleMainDirtyState'
+        $gitGuard | Should -Match 'fast-forward main before interpreting or committing local diffs'
         $publicAudit | Should -Match 'function Test-IsEvidenceAuthScanSurface'
         $publicAudit | Should -Match 'function Add-ForbiddenEvidenceAuthFailures'
         $publicAudit | Should -Match 'evidence/auth surface'


### PR DESCRIPTION
## Summary
- Add a `git-guard` check that blocks shared `main` checkouts when `origin/main` is ahead and tracked files are modified.
- Add focused Pester coverage that reproduces the stale-main dirty state using a temporary remote and operator checkout.
- Wire the new test into the tracked test allowlists and public-surface policy assertions.

## Why
A stale local `main` checkout can show old tracked diffs in VS Code after `origin/main` has advanced. This guard prevents those stale diffs from being mistaken for new work before commit or push.

## Test Plan
- `Invoke-Pester -Path tests/GitGuard.Tests.ps1 -Output Detailed`
- `Invoke-Pester -Path tests/GitGuard.Tests.ps1,tests/PublicSurfacePolicy.Tests.ps1 -Output Detailed`
- `pwsh -NoProfile -File scripts/git-guard.ps1 -Mode full`
- `pwsh -NoProfile -File scripts/git-guard.ps1 -Mode staged`
- `git diff --check`
