### PR TITLE
fix: stabilize v0.36.23 benchmark preflight

### DIFF
--- a/.githooks/pre-commit-whitelist.ps1
+++ b/.githooks/pre-commit-whitelist.ps1
@@ -92,6 +92,7 @@ $whitelistPatterns = @(
     'scripts/codex-subagent-worktree-guard.ps1',
     'scripts/run-cli-bakeoff-openrouter.ps1',
     'scripts/run-cli-bakeoff-local-workers.ps1',
+    'scripts/start-cli-bakeoff-desktop.ps1',
     'scripts/summarize-cli-bakeoff.ps1',
     'scripts/test-cli-bakeoff-preflight.ps1',
     'scripts/test-v03617-reliability-gate.ps1',

--- a/docs/cli-comparison-bakeoff.md
+++ b/docs/cli-comparison-bakeoff.md
@@ -31,6 +31,28 @@ The tracked task pack lives in `tasks/cli-bakeoff/v1/`.
 The required local evidence directory is `.winsmux/evidence/cli-bakeoff/<run-id>/`.
 That directory is intentionally not committed.
 
+## One-command desktop preparation
+
+Use the desktop preparation entrypoint before any official six-pane run:
+
+```powershell
+pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/start-cli-bakeoff-desktop.ps1
+```
+
+The script builds the current release CLI and desktop app, copies the tracked
+task pack into the local benchmark project, verifies that the release binaries
+match the repository version and Git head, launches the production desktop app,
+and moves the visible window to the test display. It does not use the Start menu,
+installed shortcuts, stale installed binaries, or the Tauri dev server unless the
+caller explicitly edits the command.
+
+For a dry run that proves the pack and binary identity without launching the
+desktop app:
+
+```powershell
+pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/start-cli-bakeoff-desktop.ps1 -SkipBuild -NoLaunch
+```
+
 ## Gates
 
 Before recording or scoring a run:

--- a/scripts/start-cli-bakeoff-desktop.ps1
+++ b/scripts/start-cli-bakeoff-desktop.ps1
@@ -1,0 +1,354 @@
+[CmdletBinding()]
+param(
+    [string]$ProjectDir = '.winsmux/evidence/v03623-coordination-benchmark-project',
+    [string]$PackPath = 'tasks/cli-bakeoff/v1/benchmark-pack.json',
+    [int]$DebugPort = 9237,
+    [switch]$SkipBuild,
+    [switch]$NoLaunch,
+    [switch]$AllowDirty,
+    [switch]$NoMoveToExtendedDisplay,
+    [switch]$Json,
+    [int]$VisibleWidth = 1440,
+    [int]$VisibleHeight = 900
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$RepoRoot = (& git rev-parse --show-toplevel 2>$null | Out-String).Trim()
+if ([string]::IsNullOrWhiteSpace($RepoRoot)) {
+    $RepoRoot = Split-Path $PSScriptRoot -Parent
+}
+
+function Resolve-RepoPath {
+    param([Parameter(Mandatory = $true)][string]$Path)
+    if ([System.IO.Path]::IsPathRooted($Path)) {
+        return [System.IO.Path]::GetFullPath($Path)
+    }
+    return [System.IO.Path]::GetFullPath((Join-Path $RepoRoot $Path))
+}
+
+function Invoke-CheckedCommand {
+    param(
+        [Parameter(Mandatory = $true)][string]$FilePath,
+        [Parameter(Mandatory = $true)][string[]]$ArgumentList,
+        [string]$WorkingDirectory = $RepoRoot
+    )
+
+    Push-Location -LiteralPath $WorkingDirectory
+    try {
+        & $FilePath @ArgumentList
+        if ($LASTEXITCODE -ne 0) {
+            throw "Command failed with exit code ${LASTEXITCODE}: $FilePath $($ArgumentList -join ' ')"
+        }
+    } finally {
+        Pop-Location
+    }
+}
+
+function Copy-BenchmarkTaskPack {
+    param(
+        [Parameter(Mandatory = $true)][string]$SourceDir,
+        [Parameter(Mandatory = $true)][string]$DestinationDir
+    )
+
+    if (-not (Test-Path -LiteralPath $SourceDir -PathType Container)) {
+        throw "Benchmark task pack source was not found: $SourceDir"
+    }
+
+    New-Item -ItemType Directory -Path $DestinationDir -Force | Out-Null
+    Get-ChildItem -LiteralPath $SourceDir -File | ForEach-Object {
+        Copy-Item -LiteralPath $_.FullName -Destination (Join-Path $DestinationDir $_.Name) -Force
+    }
+}
+
+function Stop-RepoWinsmuxDesktopTree {
+    $processes = @(Get-CimInstance Win32_Process)
+    $appPids = @(
+        $processes |
+            Where-Object {
+                $_.Name -eq 'winsmux-app.exe' -and
+                ([string]$_.ExecutablePath).StartsWith($RepoRoot, [System.StringComparison]::OrdinalIgnoreCase)
+            } |
+            ForEach-Object { [int]$_.ProcessId }
+    )
+
+    if ($appPids.Count -eq 0) {
+        return
+    }
+
+    $ids = [System.Collections.Generic.HashSet[int]]::new()
+    foreach ($pidValue in $appPids) {
+        [void]$ids.Add($pidValue)
+    }
+
+    $changed = $true
+    while ($changed) {
+        $changed = $false
+        foreach ($process in $processes) {
+            if ($ids.Contains([int]$process.ParentProcessId) -and -not $ids.Contains([int]$process.ProcessId)) {
+                [void]$ids.Add([int]$process.ProcessId)
+                $changed = $true
+            }
+        }
+    }
+
+    foreach ($id in (@($ids) | Sort-Object -Descending)) {
+        Stop-Process -Id $id -Force -ErrorAction SilentlyContinue
+    }
+}
+
+function Wait-RepoWinsmuxDesktopApp {
+    param([int]$TimeoutSeconds = 120)
+
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    do {
+        $candidate = Get-CimInstance Win32_Process |
+            Where-Object {
+                $_.Name -eq 'winsmux-app.exe' -and
+                ([string]$_.ExecutablePath).StartsWith($RepoRoot, [System.StringComparison]::OrdinalIgnoreCase)
+            } |
+            Sort-Object ProcessId -Descending |
+            Select-Object -First 1
+        if ($null -ne $candidate) {
+            return $candidate
+        }
+        Start-Sleep -Milliseconds 500
+    } while ((Get-Date) -lt $deadline)
+
+    throw "winsmux desktop app did not start within $TimeoutSeconds seconds."
+}
+
+function Assert-ProductionDesktopPage {
+    param([int]$Port, [int]$TimeoutSeconds = 30)
+
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    $lastError = ''
+    do {
+        try {
+            $pages = @(Invoke-RestMethod -Uri "http://127.0.0.1:$Port/json/list" -TimeoutSec 2)
+            $urls = @($pages | ForEach-Object { [string]$_.url })
+            if ($urls.Count -gt 0) {
+                if ($urls | Where-Object { $_ -match '^http://(localhost|127\.0\.0\.1):1420/?' }) {
+                    throw 'winsmux desktop is using the Tauri dev server URL instead of the production page.'
+                }
+                if (-not ($urls | Where-Object { $_ -match 'tauri\.localhost|tauri://localhost' })) {
+                    throw "winsmux desktop did not expose a production Tauri page. urls=$($urls -join ', ')"
+                }
+                return @{
+                    mode = 'production'
+                    urls = $urls
+                }
+            }
+        } catch {
+            $lastError = $_.Exception.Message
+        }
+        Start-Sleep -Milliseconds 500
+    } while ((Get-Date) -lt $deadline)
+
+    throw "Could not verify the production desktop page on port $Port. Last error: $lastError"
+}
+
+function Get-WindowMetrics {
+    param([Parameter(Mandatory = $true)][int]$ProcessId)
+
+    Add-Type -AssemblyName System.Windows.Forms
+    if (-not ('WinsmuxBenchmarkUser32' -as [type])) {
+        Add-Type @"
+using System;
+using System.Runtime.InteropServices;
+public static class WinsmuxBenchmarkUser32 {
+  [StructLayout(LayoutKind.Sequential)]
+  public struct RECT { public int Left; public int Top; public int Right; public int Bottom; }
+  [DllImport("user32.dll")] public static extern bool GetWindowRect(IntPtr hWnd, out RECT rect);
+  [DllImport("user32.dll")] public static extern bool MoveWindow(IntPtr hWnd, int X, int Y, int nWidth, int nHeight, bool bRepaint);
+  [DllImport("user32.dll")] public static extern bool ShowWindow(IntPtr hWnd, int nCmdShow);
+}
+"@
+    }
+
+    $deadline = (Get-Date).AddSeconds(30)
+    $handle = [IntPtr]::Zero
+    do {
+        $process = Get-Process -Id $ProcessId -ErrorAction SilentlyContinue
+        if ($null -ne $process) {
+            $process.Refresh()
+            $handle = $process.MainWindowHandle
+            if ($handle -ne [IntPtr]::Zero) {
+                break
+            }
+        }
+        Start-Sleep -Milliseconds 500
+    } while ((Get-Date) -lt $deadline)
+
+    if ($handle -eq [IntPtr]::Zero) {
+        throw 'winsmux desktop app started, but no visible window handle was found.'
+    }
+
+    $rect = New-Object WinsmuxBenchmarkUser32+RECT
+    [void][WinsmuxBenchmarkUser32]::GetWindowRect($handle, [ref]$rect)
+    return [pscustomobject]@{
+        handle = $handle.ToInt64()
+        x = [int]$rect.Left
+        y = [int]$rect.Top
+        width = [int]($rect.Right - $rect.Left)
+        height = [int]($rect.Bottom - $rect.Top)
+    }
+}
+
+function Move-WindowToVisibleWorkspace {
+    param(
+        [Parameter(Mandatory = $true)][int]$ProcessId,
+        [int]$Width,
+        [int]$Height
+    )
+
+    $metrics = Get-WindowMetrics -ProcessId $ProcessId
+    $handle = [IntPtr]$metrics.handle
+    $screens = @([System.Windows.Forms.Screen]::AllScreens)
+    $targetScreen = $screens | Where-Object { -not $_.Primary } | Select-Object -First 1
+    if ($null -eq $targetScreen) {
+        $targetScreen = $screens | Select-Object -First 1
+    }
+    $area = $targetScreen.WorkingArea
+    $targetWidth = [Math]::Max([int]$area.Width, $Width)
+    $targetHeight = [Math]::Max([int]$area.Height, $Height)
+
+    [void][WinsmuxBenchmarkUser32]::ShowWindow($handle, 9)
+    [void][WinsmuxBenchmarkUser32]::MoveWindow($handle, [int]$area.X, [int]$area.Y, $targetWidth, $targetHeight, $true)
+    [void][WinsmuxBenchmarkUser32]::ShowWindow($handle, 3)
+    Start-Sleep -Milliseconds 500
+    return Get-WindowMetrics -ProcessId $ProcessId
+}
+
+$resolvedProjectDir = Resolve-RepoPath $ProjectDir
+$resolvedPackPath = Resolve-RepoPath $PackPath
+$canonicalTaskDir = Split-Path $resolvedPackPath -Parent
+$projectTaskDir = Join-Path $resolvedProjectDir 'tasks\cli-bakeoff\v1'
+$releaseCli = Join-Path $RepoRoot 'target\release\winsmux.exe'
+$releaseApp = Join-Path $RepoRoot 'target\release\winsmux-app.exe'
+$version = (Get-Content -LiteralPath (Join-Path $RepoRoot 'VERSION') -Raw -Encoding UTF8).Trim()
+$head = (& git -C $RepoRoot rev-parse HEAD | Out-String).Trim()
+
+New-Item -ItemType Directory -Path $resolvedProjectDir -Force | Out-Null
+Copy-BenchmarkTaskPack -SourceDir $canonicalTaskDir -DestinationDir $projectTaskDir
+
+if (-not $SkipBuild) {
+    Invoke-CheckedCommand -FilePath 'cargo' -ArgumentList @('build', '--release', '-p', 'winsmux') -WorkingDirectory $RepoRoot
+    Invoke-CheckedCommand -FilePath 'npm' -ArgumentList @('run', 'tauri', '--', 'build', '--no-bundle') -WorkingDirectory (Join-Path $RepoRoot 'winsmux-app')
+}
+
+$preflightArgs = @(
+    '-NoProfile',
+    '-ExecutionPolicy',
+    'Bypass',
+    '-File',
+    (Join-Path $RepoRoot 'scripts\test-cli-bakeoff-preflight.ps1'),
+    '-PackPath',
+    $resolvedProjectDir,
+    '-Json',
+    '-RequireCandidateIdentity',
+    '-ExpectedVersion',
+    $version,
+    '-ExpectedGitHead',
+    $head,
+    '-CandidateDesktopBinary',
+    $releaseApp,
+    '-CandidateCliBinary',
+    $releaseCli
+)
+if ($AllowDirty) {
+    $preflightArgs += '-AllowDirty'
+}
+$preflightJson = (& pwsh @preflightArgs | Out-String).Trim()
+if ($LASTEXITCODE -ne 0) {
+    throw "Benchmark preflight failed before desktop launch.`n$preflightJson"
+}
+$preflight = $preflightJson | ConvertFrom-Json -Depth 100
+if (-not [bool]$preflight.all_pass) {
+    throw "Benchmark preflight did not pass before desktop launch.`n$preflightJson"
+}
+
+if ($NoLaunch) {
+    $result = [pscustomobject]@{
+        ok = $true
+        launch = 'skipped'
+        projectDir = $resolvedProjectDir
+        packPath = $resolvedPackPath
+        projectPackPath = Join-Path $projectTaskDir 'benchmark-pack.json'
+        version = $version
+        gitHead = $head
+        releaseCli = $releaseCli
+        releaseApp = $releaseApp
+        preflight = $preflight
+    }
+    if ($Json) {
+        $result | ConvertTo-Json -Depth 100
+    } else {
+        Write-Output "winsmux Harness Bench desktop path is ready."
+        Write-Output "launch: skipped"
+        Write-Output "version: $version"
+        Write-Output "pack: $($result.projectPackPath)"
+        Write-Output "preflight: $($preflight.check_count) checks, $($preflight.failed_count) failures"
+    }
+    exit 0
+}
+
+if (-not (Test-Path -LiteralPath $releaseApp -PathType Leaf)) {
+    throw "Production desktop executable was not found: $releaseApp"
+}
+
+Stop-RepoWinsmuxDesktopTree
+
+$webviewUserData = Join-Path $RepoRoot '.winsmux\tmp\webview2-v03623-harness'
+New-Item -ItemType Directory -Path $webviewUserData -Force | Out-Null
+$env:WINSMUX_BIN = $releaseCli
+$env:WINSMUX_ORCHESTRA_PROJECT_DIR = $resolvedProjectDir
+$env:WINSMUX_ORCHESTRA_ATTACH_MODE = 'desktop-app'
+$env:WINSMUX_ORCHESTRA_DISABLE_POWERSHELL_ATTACH = '1'
+$env:WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS = "--remote-debugging-port=$DebugPort --remote-allow-origins=*"
+$env:WEBVIEW2_USER_DATA_FOLDER = $webviewUserData
+$env:NO_COLOR = '1'
+
+$launcherProcess = Start-Process -FilePath $releaseApp -ArgumentList @('--project-dir', $resolvedProjectDir) -WorkingDirectory $RepoRoot -PassThru
+$app = Wait-RepoWinsmuxDesktopApp
+$page = Assert-ProductionDesktopPage -Port $DebugPort
+$metricsBeforeMove = Get-WindowMetrics -ProcessId ([int]$app.ProcessId)
+if (-not $NoMoveToExtendedDisplay) {
+    $metricsAfterMove = Move-WindowToVisibleWorkspace -ProcessId ([int]$app.ProcessId) -Width $VisibleWidth -Height $VisibleHeight
+} else {
+    $metricsAfterMove = $metricsBeforeMove
+}
+
+if ([int]$metricsAfterMove.width -lt $VisibleWidth -or [int]$metricsAfterMove.height -lt $VisibleHeight) {
+    throw "winsmux desktop window is smaller than required after launch: $($metricsAfterMove.width)x$($metricsAfterMove.height)"
+}
+
+$result = [pscustomobject]@{
+    ok = $true
+    launch = 'production-desktop'
+    launcherPid = [int]$launcherProcess.Id
+    appPid = [int]$app.ProcessId
+    projectDir = $resolvedProjectDir
+    projectPackPath = Join-Path $projectTaskDir 'benchmark-pack.json'
+    releaseCli = $releaseCli
+    releaseApp = $releaseApp
+    debugPort = $DebugPort
+    page = $page
+    windowBeforeMove = $metricsBeforeMove
+    windowAfterMove = $metricsAfterMove
+    attachMode = $env:WINSMUX_ORCHESTRA_ATTACH_MODE
+    powershellAttach = 'disabled'
+    preflight = $preflight
+}
+if ($Json) {
+    $result | ConvertTo-Json -Depth 100
+} else {
+    Write-Output "winsmux Harness Bench desktop path is ready."
+    Write-Output "launch: production desktop"
+    Write-Output "app pid: $($result.appPid)"
+    Write-Output "version: $version"
+    Write-Output "pack: $($result.projectPackPath)"
+    Write-Output "window: $($metricsAfterMove.width)x$($metricsAfterMove.height)"
+    Write-Output "preflight: $($preflight.check_count) checks, $($preflight.failed_count) failures"
+}

--- a/scripts/test-cli-bakeoff-preflight.ps1
+++ b/scripts/test-cli-bakeoff-preflight.ps1
@@ -30,6 +30,76 @@ function Resolve-LocalPath {
     return [System.IO.Path]::GetFullPath((Join-Path $RepoRoot $Path))
 }
 
+function Resolve-BenchmarkPackInput {
+    param(
+        [Parameter(Mandatory = $true)][string]$InputPath,
+        [AllowNull()][string]$ExplicitTaskRoot
+    )
+
+    $resolvedInput = Resolve-LocalPath $InputPath
+    $resolvedTaskRoot = ''
+
+    if (Test-Path -LiteralPath $resolvedInput -PathType Leaf) {
+        $resolvedTaskRoot = if ([string]::IsNullOrWhiteSpace($ExplicitTaskRoot)) {
+            Split-Path $resolvedInput -Parent
+        } else {
+            Resolve-LocalPath $ExplicitTaskRoot
+        }
+
+        return [pscustomobject]@{
+            PackPath = $resolvedInput
+            TaskRoot = $resolvedTaskRoot
+            Source = 'file'
+            Candidates = @($resolvedInput)
+        }
+    }
+
+    if (Test-Path -LiteralPath $resolvedInput -PathType Container) {
+        $candidateRelativePaths = @(
+            'benchmark-pack.json',
+            'tasks\cli-bakeoff\v1\benchmark-pack.json',
+            'cli-bakeoff\v1\benchmark-pack.json',
+            'v1\benchmark-pack.json'
+        )
+        $candidates = @(
+            $candidateRelativePaths |
+                ForEach-Object { Join-Path $resolvedInput $_ } |
+                Where-Object { Test-Path -LiteralPath $_ -PathType Leaf } |
+                ForEach-Object { [System.IO.Path]::GetFullPath($_) } |
+                Sort-Object -Unique
+        )
+
+        if ($candidates.Count -eq 1) {
+            $resolvedTaskRoot = if ([string]::IsNullOrWhiteSpace($ExplicitTaskRoot)) {
+                Split-Path $candidates[0] -Parent
+            } else {
+                Resolve-LocalPath $ExplicitTaskRoot
+            }
+
+            return [pscustomobject]@{
+                PackPath = $candidates[0]
+                TaskRoot = $resolvedTaskRoot
+                Source = 'directory'
+                Candidates = @($candidates)
+            }
+        }
+
+        return [pscustomobject]@{
+            PackPath = $resolvedInput
+            TaskRoot = if ([string]::IsNullOrWhiteSpace($ExplicitTaskRoot)) { $resolvedInput } else { Resolve-LocalPath $ExplicitTaskRoot }
+            Source = 'directory-unresolved'
+            Candidates = @($candidates)
+        }
+    }
+
+    return [pscustomobject]@{
+        PackPath = $resolvedInput
+        TaskRoot = if ([string]::IsNullOrWhiteSpace($ExplicitTaskRoot)) { Split-Path $resolvedInput -Parent } else { Resolve-LocalPath $ExplicitTaskRoot }
+        Source = 'missing'
+        Candidates = @()
+    }
+}
+
 function ConvertTo-SafeDetail {
     param([AllowNull()][object]$Value)
     if ($null -eq $Value) { return '' }
@@ -93,6 +163,23 @@ function Get-FileSha256 {
     }
 }
 
+function Get-CliReportedVersion {
+    param([AllowNull()][string]$Path)
+    if ([string]::IsNullOrWhiteSpace($Path) -or -not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        return ''
+    }
+    try {
+        $output = (& $Path --version 2>&1 | Out-String).Trim()
+        $match = [regex]::Match($output, '(\d+\.\d+\.\d+)')
+        if ($match.Success) {
+            return $match.Groups[1].Value
+        }
+        return $output
+    } catch {
+        return ''
+    }
+}
+
 function Get-ProjectVersionMetadata {
     $versionPath = Join-Path $RepoRoot 'VERSION'
     $cargoPath = Join-Path $RepoRoot 'core\Cargo.toml'
@@ -144,14 +231,14 @@ function Test-VersionSetMatches {
 }
 
 $checks = [System.Collections.Generic.List[object]]::new()
-$resolvedPackPath = Resolve-LocalPath $PackPath
-$resolvedTaskRoot = if ([string]::IsNullOrWhiteSpace($TaskRoot)) {
-    Split-Path $resolvedPackPath -Parent
-} else {
-    Resolve-LocalPath $TaskRoot
-}
+$resolvedPackInput = Resolve-BenchmarkPackInput -InputPath $PackPath -ExplicitTaskRoot $TaskRoot
+$resolvedPackPath = [string]$resolvedPackInput.PackPath
+$resolvedTaskRoot = [string]$resolvedPackInput.TaskRoot
 
 Add-Check 'benchmark pack exists' (Test-Path -LiteralPath $resolvedPackPath -PathType Leaf) $resolvedPackPath
+Add-Check 'benchmark pack input resolves unambiguously' (
+    [string]$resolvedPackInput.Source -ne 'directory-unresolved'
+) "source=$($resolvedPackInput.Source); candidates=$(@($resolvedPackInput.Candidates).Count)"
 
 if ($RequireCandidateIdentity) {
     $actualHead = Get-GitOutput -Arguments @('rev-parse', 'HEAD')
@@ -163,6 +250,7 @@ if ($RequireCandidateIdentity) {
     $cliBinaryExists = -not [string]::IsNullOrWhiteSpace($resolvedCliBinary) -and (Test-Path -LiteralPath $resolvedCliBinary -PathType Leaf)
     $desktopProductVersion = Get-FileProductVersion -Path $resolvedDesktopBinary
     $desktopSha256 = Get-FileSha256 -Path $resolvedDesktopBinary
+    $cliReportedVersion = Get-CliReportedVersion -Path $resolvedCliBinary
     $cliSha256 = Get-FileSha256 -Path $resolvedCliBinary
     $expectedHeadMatches = -not [string]::IsNullOrWhiteSpace($ExpectedGitHead) -and
         -not [string]::IsNullOrWhiteSpace($actualHead) -and
@@ -193,6 +281,11 @@ if ($RequireCandidateIdentity) {
     }
     Add-Check 'candidate CLI binary path is provided' (-not [string]::IsNullOrWhiteSpace($resolvedCliBinary))
     Add-Check 'candidate CLI binary exists' $cliBinaryExists $resolvedCliBinary
+    Add-Check 'candidate CLI reported version matches expected' (
+        $cliBinaryExists -and
+        -not [string]::IsNullOrWhiteSpace($ExpectedVersion) -and
+        [string]$cliReportedVersion -eq $ExpectedVersion
+    ) "reported=$cliReportedVersion expected=$ExpectedVersion"
     Add-Check 'candidate CLI binary sha256 is readable' (
         $cliBinaryExists -and -not [string]::IsNullOrWhiteSpace($cliSha256)
     ) "sha256=$cliSha256"
@@ -351,6 +444,9 @@ $failed = @($checks | Where-Object { -not $_.pass })
 $result = [pscustomobject]@{
     version      = 1
     pack_id      = if ($null -ne $pack) { [string]$pack.pack_id } else { '' }
+    pack_path    = ConvertTo-SafeDetail $resolvedPackPath
+    task_root    = ConvertTo-SafeDetail $resolvedTaskRoot
+    pack_source  = [string]$resolvedPackInput.Source
     all_pass     = ($failed.Count -eq 0)
     check_count  = $checks.Count
     failed_count = $failed.Count

--- a/tests/CliBakeoff.Tests.ps1
+++ b/tests/CliBakeoff.Tests.ps1
@@ -27,6 +27,31 @@ Describe 'CLI bakeoff evidence harness' {
         ($output -join "`n") | Should -Not -Match 'C:\\Users\\'
     }
 
+    It 'resolves the benchmark pack when given the repository root' {
+        $output = & pwsh -NoProfile -File $script:PreflightScript -PackPath $script:RepoRoot -Json
+        $LASTEXITCODE | Should -Be 0
+        $result = $output | ConvertFrom-Json -Depth 20
+        $result.all_pass | Should -BeTrue
+        $result.pack_id | Should -Be 'winsmux-cli-bakeoff-v1'
+        $result.pack_source | Should -Be 'directory'
+        $result.pack_path | Should -Be '<local-path>'
+        ($result.checks | Where-Object { $_.name -eq 'benchmark pack input resolves unambiguously' }).pass | Should -BeTrue
+        ($output -join "`n") | Should -Not -Match 'C:\\Users\\'
+    }
+
+    It 'resolves the benchmark pack when given the task packet directory' {
+        $taskRoot = Split-Path $script:PackPath -Parent
+        $output = & pwsh -NoProfile -File $script:PreflightScript -PackPath $taskRoot -Json
+        $LASTEXITCODE | Should -Be 0
+        $result = $output | ConvertFrom-Json -Depth 20
+        $result.all_pass | Should -BeTrue
+        $result.pack_id | Should -Be 'winsmux-cli-bakeoff-v1'
+        $result.pack_source | Should -Be 'directory'
+        $result.task_root | Should -Be '<local-path>'
+        ($result.checks | Where-Object { $_.name -eq 'benchmark pack input resolves unambiguously' }).pass | Should -BeTrue
+        ($output -join "`n") | Should -Not -Match 'C:\\Users\\'
+    }
+
     It 'routes the formal six-pane benchmark evidence to v0.36.23' {
         $contractDoc = Get-Content -LiteralPath (Join-Path $script:RepoRoot 'docs\cli-comparison-bakeoff.md') -Raw -Encoding UTF8
         $contractDoc | Should -Match 'v0\.36\.23'
@@ -61,13 +86,39 @@ Describe 'CLI bakeoff evidence harness' {
         $checkNames | Should -Contain 'candidate desktop binary exists'
         $checkNames | Should -Contain 'candidate desktop binary sha256 is readable'
         $checkNames | Should -Contain 'candidate CLI binary exists'
+        $checkNames | Should -Contain 'candidate CLI reported version matches expected'
         $checkNames | Should -Contain 'candidate CLI binary sha256 is readable'
         ($result.checks | Where-Object { $_.name -eq 'candidate git head matches expected' }).pass | Should -BeFalse
         ($result.checks | Where-Object { $_.name -eq 'candidate version metadata matches expected' }).pass | Should -BeFalse
         ($result.checks | Where-Object { $_.name -eq 'candidate desktop binary exists' }).pass | Should -BeFalse
         ($result.checks | Where-Object { $_.name -eq 'candidate desktop binary sha256 is readable' }).pass | Should -BeFalse
         ($result.checks | Where-Object { $_.name -eq 'candidate CLI binary exists' }).pass | Should -BeFalse
+        ($result.checks | Where-Object { $_.name -eq 'candidate CLI reported version matches expected' }).pass | Should -BeFalse
         ($result.checks | Where-Object { $_.name -eq 'candidate CLI binary sha256 is readable' }).pass | Should -BeFalse
+    }
+
+    It 'rejects a stale CLI candidate even when the file exists' {
+        $fakeCliBinary = Join-Path $TestDrive 'winsmux-stale.cmd'
+        Set-Content -LiteralPath $fakeCliBinary -Value '@echo winsmux 0.36.16' -Encoding Ascii
+        $missingDesktopBinary = Join-Path $TestDrive 'missing-winsmux-app.exe'
+        $head = (& git -C $script:RepoRoot rev-parse HEAD | Out-String).Trim()
+
+        $output = & pwsh -NoProfile -File $script:PreflightScript `
+            -PackPath $script:PackPath `
+            -Json `
+            -RequireCandidateIdentity `
+            -AllowDirty `
+            -ExpectedVersion '0.36.23' `
+            -ExpectedGitHead $head `
+            -CandidateDesktopBinary $missingDesktopBinary `
+            -CandidateCliBinary $fakeCliBinary 2>$null
+
+        $LASTEXITCODE | Should -Be 1
+        $result = $output | ConvertFrom-Json -Depth 20
+        $result.all_pass | Should -BeFalse
+        $cliVersionCheck = $result.checks | Where-Object { $_.name -eq 'candidate CLI reported version matches expected' }
+        $cliVersionCheck.pass | Should -BeFalse
+        $cliVersionCheck.detail | Should -Match 'reported=0\.36\.16 expected=0\.36\.23'
     }
 
     It 'fails when a task packet is missing' {

--- a/winsmux-app/scripts/desktop-pane-e2e.mjs
+++ b/winsmux-app/scripts/desktop-pane-e2e.mjs
@@ -337,6 +337,46 @@ function assertNoFixedViewportBlank(metrics) {
   }
 }
 
+async function readStartupWindowMetrics(page) {
+  return await page.evaluate(async () => {
+    const tauri = window.__TAURI__;
+    const currentWindow = tauri?.window?.getCurrentWindow?.()
+      ?? tauri?.webviewWindow?.getCurrentWebviewWindow?.();
+    const outerSize = currentWindow && typeof currentWindow.outerSize === "function"
+      ? await currentWindow.outerSize().catch((error) => ({ error: error instanceof Error ? error.message : String(error) }))
+      : null;
+    return {
+      title: document.title,
+      innerWidth: window.innerWidth,
+      innerHeight: window.innerHeight,
+      outerWidth: typeof outerSize?.width === "number" ? outerSize.width : null,
+      outerHeight: typeof outerSize?.height === "number" ? outerSize.height : null,
+      outerSizeError: typeof outerSize?.error === "string" ? outerSize.error : null,
+      bodyWidth: Math.round(document.body.getBoundingClientRect().width),
+      bodyHeight: Math.round(document.body.getBoundingClientRect().height),
+    };
+  });
+}
+
+function assertVisibleStartupGeometry(metrics) {
+  if (metrics.title !== "winsmux") {
+    throw new Error(`desktop window title should be stable for UI automation: ${JSON.stringify(metrics)}`);
+  }
+  if (metrics.innerWidth < 640 || metrics.innerHeight < 480) {
+    throw new Error(`desktop window should start at a visible size: ${JSON.stringify(metrics)}`);
+  }
+  if (
+    metrics.outerWidth !== null
+    && metrics.outerHeight !== null
+    && (metrics.outerWidth < 640 || metrics.outerHeight < 480)
+  ) {
+    throw new Error(`native desktop window should not restore as a tiny window: ${JSON.stringify(metrics)}`);
+  }
+  if (Math.abs(metrics.bodyWidth - metrics.innerWidth) > 2 || Math.abs(metrics.bodyHeight - metrics.innerHeight) > 2) {
+    throw new Error(`document body should fill the startup viewport: ${JSON.stringify(metrics)}`);
+  }
+}
+
 async function waitForNativeWindowResize(page, beforeMetrics, timeoutMs = 12_000) {
   await page.waitForFunction((before) => {
     const body = document.body;
@@ -1503,6 +1543,12 @@ async function main() {
     await runStep("wait for desktop app chrome", async () => {
       await waitForAppReady(page);
       return { url: page.url() };
+    });
+
+    await runStep("desktop main window starts at a visible size", async () => {
+      const metrics = await readStartupWindowMetrics(page);
+      assertVisibleStartupGeometry(metrics);
+      return metrics;
     });
 
     if (WORKER_START_ONLY) {

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -2,6 +2,7 @@ import { Terminal } from "xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import "xterm/css/xterm.css";
 import { isTauri } from "@tauri-apps/api/core";
+import { LogicalSize } from "@tauri-apps/api/dpi";
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
 import { WebviewWindow, getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
 import {
@@ -582,6 +583,12 @@ let sidebarOpen = true;
 let sidebarMode: SidebarMode = "explorer";
 let agentVaultOpen = false;
 let mainWindowRevealStarted = false;
+const MAIN_WINDOW_MIN_LOGICAL_WIDTH = 1024;
+const MAIN_WINDOW_MIN_LOGICAL_HEIGHT = 720;
+const MAIN_WINDOW_RESTORE_LOGICAL_WIDTH = 1440;
+const MAIN_WINDOW_RESTORE_LOGICAL_HEIGHT = 900;
+const MAIN_WINDOW_TOO_SMALL_WIDTH = 640;
+const MAIN_WINDOW_TOO_SMALL_HEIGHT = 480;
 let agentVaultQuery = "";
 let agentVaultProjectOnly = true;
 let agentVaultProviderFilter: AgentVaultProviderFilter = "all";
@@ -3955,6 +3962,34 @@ function nextStartupTick() {
   });
 }
 
+async function ensureMainWindowVisibleGeometry(currentWindow: WebviewWindow) {
+  await currentWindow.setTitle("winsmux").catch((error) => {
+    console.warn("Failed to set main window title", error);
+  });
+  await currentWindow
+    .setMinSize(new LogicalSize(MAIN_WINDOW_MIN_LOGICAL_WIDTH, MAIN_WINDOW_MIN_LOGICAL_HEIGHT))
+    .catch((error) => {
+      console.warn("Failed to set main window minimum size", error);
+    });
+
+  const outerSize = await currentWindow.outerSize().catch(() => null);
+  if (
+    outerSize
+    && outerSize.width >= MAIN_WINDOW_TOO_SMALL_WIDTH
+    && outerSize.height >= MAIN_WINDOW_TOO_SMALL_HEIGHT
+  ) {
+    return;
+  }
+
+  await currentWindow.unminimize().catch(() => {});
+  await currentWindow.unmaximize().catch(() => {});
+  await currentWindow
+    .setSize(new LogicalSize(MAIN_WINDOW_RESTORE_LOGICAL_WIDTH, MAIN_WINDOW_RESTORE_LOGICAL_HEIGHT))
+    .catch((error) => {
+      console.warn("Failed to restore visible main window size", error);
+    });
+}
+
 async function revealMainWindowAfterInitialPaint() {
   if (!isTauri() || mainWindowRevealStarted) {
     return;
@@ -3963,7 +3998,10 @@ async function revealMainWindowAfterInitialPaint() {
   mainWindowRevealStarted = true;
   await nextStartupTick();
   try {
-    await getCurrentWebviewWindow().show();
+    const currentWindow = getCurrentWebviewWindow();
+    await ensureMainWindowVisibleGeometry(currentWindow);
+    await currentWindow.show();
+    await currentWindow.setFocus();
   } catch (error) {
     console.warn("Failed to reveal main window", error);
   }


### PR DESCRIPTION
## Summary
- restore the desktop main window to a visible size during startup
- reject stale release CLI candidates during benchmark preflight
- resolve benchmark packs from repository, task-pack, or benchmark project directories
- add a one-command desktop preparation path for official Harness Bench runs

## Verification
- `pwsh -NoProfile -Command "Invoke-Pester -Path tests\CliBakeoff.Tests.ps1 -Output Detailed"`
- `pwsh -NoProfile -File scripts\test-v03619-repo-audit.ps1 -Json`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts\start-cli-bakeoff-desktop.ps1 -SkipBuild -NoLaunch -AllowDirty`
- `git diff --cached --check`