### PR TITLE
fix: normalize desktop benchmark launch paths

### DIFF
--- a/scripts/start-cli-bakeoff-desktop.ps1
+++ b/scripts/start-cli-bakeoff-desktop.ps1
@@ -7,6 +7,7 @@ param(
     [switch]$NoLaunch,
     [switch]$AllowDirty,
     [switch]$NoMoveToExtendedDisplay,
+    [switch]$SelfTestPathNormalization,
     [switch]$Json,
     [int]$VisibleWidth = 1440,
     [int]$VisibleHeight = 900
@@ -18,6 +19,33 @@ $ErrorActionPreference = 'Stop'
 $RepoRoot = (& git rev-parse --show-toplevel 2>$null | Out-String).Trim()
 if ([string]::IsNullOrWhiteSpace($RepoRoot)) {
     $RepoRoot = Split-Path $PSScriptRoot -Parent
+}
+$RepoRoot = [System.IO.Path]::GetFullPath($RepoRoot)
+
+function Convert-ToCanonicalPath {
+    param([AllowNull()][string]$Path)
+
+    if ([string]::IsNullOrWhiteSpace($Path)) {
+        return ''
+    }
+
+    return [System.IO.Path]::GetFullPath($Path).TrimEnd([System.IO.Path]::DirectorySeparatorChar, [System.IO.Path]::AltDirectorySeparatorChar)
+}
+
+function Test-PathInsideRepo {
+    param([AllowNull()][string]$Path)
+
+    $candidate = Convert-ToCanonicalPath $Path
+    if ([string]::IsNullOrWhiteSpace($candidate)) {
+        return $false
+    }
+
+    if ($candidate.Equals($RepoRoot, [System.StringComparison]::OrdinalIgnoreCase)) {
+        return $true
+    }
+
+    $repoPrefix = $RepoRoot.TrimEnd([System.IO.Path]::DirectorySeparatorChar, [System.IO.Path]::AltDirectorySeparatorChar) + [System.IO.Path]::DirectorySeparatorChar
+    return $candidate.StartsWith($repoPrefix, [System.StringComparison]::OrdinalIgnoreCase)
 }
 
 function Resolve-RepoPath {
@@ -68,7 +96,7 @@ function Stop-RepoWinsmuxDesktopTree {
         $processes |
             Where-Object {
                 $_.Name -eq 'winsmux-app.exe' -and
-                ([string]$_.ExecutablePath).StartsWith($RepoRoot, [System.StringComparison]::OrdinalIgnoreCase)
+                (Test-PathInsideRepo ([string]$_.ExecutablePath))
             } |
             ForEach-Object { [int]$_.ProcessId }
     )
@@ -96,17 +124,32 @@ function Stop-RepoWinsmuxDesktopTree {
     foreach ($id in (@($ids) | Sort-Object -Descending)) {
         Stop-Process -Id $id -Force -ErrorAction SilentlyContinue
     }
+
+    $deadline = (Get-Date).AddSeconds(15)
+    do {
+        $remaining = @($ids | Where-Object { Get-Process -Id $_ -ErrorAction SilentlyContinue })
+        if ($remaining.Count -eq 0) {
+            return
+        }
+        Start-Sleep -Milliseconds 250
+    } while ((Get-Date) -lt $deadline)
+
+    throw "Existing repo-built winsmux desktop process did not exit: $($remaining -join ', ')"
 }
 
 function Wait-RepoWinsmuxDesktopApp {
-    param([int]$TimeoutSeconds = 120)
+    param(
+        [int]$TimeoutSeconds = 120,
+        [int]$ExpectedProcessId = 0
+    )
 
     $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
     do {
         $candidate = Get-CimInstance Win32_Process |
             Where-Object {
                 $_.Name -eq 'winsmux-app.exe' -and
-                ([string]$_.ExecutablePath).StartsWith($RepoRoot, [System.StringComparison]::OrdinalIgnoreCase)
+                (Test-PathInsideRepo ([string]$_.ExecutablePath)) -and
+                ($ExpectedProcessId -le 0 -or [int]$_.ProcessId -eq $ExpectedProcessId)
             } |
             Sort-Object ProcessId -Descending |
             Select-Object -First 1
@@ -221,6 +264,31 @@ function Move-WindowToVisibleWorkspace {
     return Get-WindowMetrics -ProcessId $ProcessId
 }
 
+if ($SelfTestPathNormalization) {
+    $releaseAppSelfTestPath = Join-Path $RepoRoot 'target\release\winsmux-app.exe'
+    $forwardSlashPath = $releaseAppSelfTestPath -replace '\\', '/'
+    $siblingRepoPath = $RepoRoot.TrimEnd('\', '/') + '-sibling\target\release\winsmux-app.exe'
+
+    $result = [pscustomobject]@{
+        ok = (Test-PathInsideRepo $releaseAppSelfTestPath) -and
+            (Test-PathInsideRepo $forwardSlashPath) -and
+            -not (Test-PathInsideRepo $siblingRepoPath)
+        repoRoot = $RepoRoot
+        releaseAppPath = $releaseAppSelfTestPath
+    }
+
+    if (-not $result.ok) {
+        throw 'Path normalization self-test failed.'
+    }
+
+    if ($Json) {
+        $result | ConvertTo-Json -Depth 4
+    } else {
+        Write-Output 'winsmux desktop path normalization self-test passed.'
+    }
+    exit 0
+}
+
 $resolvedProjectDir = Resolve-RepoPath $ProjectDir
 $resolvedPackPath = Resolve-RepoPath $PackPath
 $canonicalTaskDir = Split-Path $resolvedPackPath -Parent
@@ -311,7 +379,7 @@ $env:WEBVIEW2_USER_DATA_FOLDER = $webviewUserData
 $env:NO_COLOR = '1'
 
 $launcherProcess = Start-Process -FilePath $releaseApp -ArgumentList @('--project-dir', $resolvedProjectDir) -WorkingDirectory $RepoRoot -PassThru
-$app = Wait-RepoWinsmuxDesktopApp
+$app = Wait-RepoWinsmuxDesktopApp -ExpectedProcessId ([int]$launcherProcess.Id)
 $page = Assert-ProductionDesktopPage -Port $DebugPort
 $metricsBeforeMove = Get-WindowMetrics -ProcessId ([int]$app.ProcessId)
 if (-not $NoMoveToExtendedDisplay) {

--- a/tests/CliBakeoff.Tests.ps1
+++ b/tests/CliBakeoff.Tests.ps1
@@ -9,6 +9,7 @@ Describe 'CLI bakeoff evidence harness' {
         }
         $script:PreflightScript = Join-Path $script:RepoRoot 'scripts\test-cli-bakeoff-preflight.ps1'
         $script:SummaryScript = Join-Path $script:RepoRoot 'scripts\summarize-cli-bakeoff.ps1'
+        $script:DesktopStartScript = Join-Path $script:RepoRoot 'scripts\start-cli-bakeoff-desktop.ps1'
         $script:PackPath = Join-Path $script:RepoRoot 'tasks\cli-bakeoff\v1\benchmark-pack.json'
     }
 
@@ -119,6 +120,14 @@ Describe 'CLI bakeoff evidence harness' {
         $cliVersionCheck = $result.checks | Where-Object { $_.name -eq 'candidate CLI reported version matches expected' }
         $cliVersionCheck.pass | Should -BeFalse
         $cliVersionCheck.detail | Should -Match 'reported=0\.36\.16 expected=0\.36\.23'
+    }
+
+    It 'normalizes desktop launcher paths before process matching' {
+        $output = & pwsh -NoProfile -File $script:DesktopStartScript -SelfTestPathNormalization -Json
+        $LASTEXITCODE | Should -Be 0
+        $result = $output | ConvertFrom-Json -Depth 8
+        $result.ok | Should -BeTrue
+        $result.repoRoot | Should -Match '^[A-Z]:\\'
     }
 
     It 'fails when a task packet is missing' {


### PR DESCRIPTION
## Summary
- Normalize repo-owned process matching in the v0.36.23 desktop benchmark launcher.
- Wait for stale repo-built desktop processes to exit before launching a new one.
- Add a launcher path self-test to prevent Windows slash-format mismatches from blocking TASK-575.

## Test Plan
- Invoke-Pester -Path tests\\CliBakeoff.Tests.ps1 -Output Detailed
- pwsh -NoProfile -File scripts\\start-cli-bakeoff-desktop.ps1 -SelfTestPathNormalization -Json
- pwsh -NoProfile -ExecutionPolicy Bypass -File scripts\\start-cli-bakeoff-desktop.ps1 -SkipBuild -AllowDirty
