### PR TITLE
[codex] Add GitHub community profile files

### DIFF
--- a/.githooks/pre-commit-whitelist.ps1
+++ b/.githooks/pre-commit-whitelist.ps1
@@ -13,6 +13,8 @@ Set-Location -LiteralPath $repoRoot
 $whitelistPatterns = @(
     'README.md',
     'README.ja.md',
+    'CODE_OF_CONDUCT.md',
+    'CONTRIBUTING.md',
     'VERSION',
     'Cargo.toml',
     'Cargo.lock',
@@ -24,6 +26,8 @@ $whitelistPatterns = @(
     'core/tests-rs/*.rs',
     'git-graph/**',
     '.github/workflows/test.yml',
+    '.github/ISSUE_TEMPLATE/**',
+    '.github/PULL_REQUEST_TEMPLATE.md',
     '.gitignore',
     'GUARDRAILS.md',
     '.winsmux.conf',

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,80 @@
+name: Bug report
+description: Report reproducible winsmux behavior that looks broken.
+title: "[Bug]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug. Do not include secrets, credentials, customer data, private local paths, browser profile paths, or raw private logs.
+        Security vulnerabilities must be reported through SECURITY.md instead of a public issue.
+  - type: input
+    id: version
+    attributes:
+      label: winsmux version or commit
+      description: Use a release version, `winsmux version`, or a commit SHA.
+      placeholder: "v0.36.23 or commit SHA"
+    validations:
+      required: true
+  - type: dropdown
+    id: install_surface
+    attributes:
+      label: Install or run surface
+      options:
+        - Desktop installer
+        - npm package
+        - Source build
+        - GitHub Actions
+        - Documentation only
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Include Windows version, PowerShell version, Windows Terminal version, and relevant agent CLI names.
+      placeholder: |
+        Windows:
+        PowerShell:
+        Windows Terminal:
+        Agent CLI:
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Provide the smallest workflow or command sequence that triggers the issue.
+      placeholder: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Sanitized evidence
+      description: Paste short sanitized output, screenshots, or links to public artifacts. Redact private paths, tokens, IDs, and raw logs.
+      render: text
+  - type: checkboxes
+    id: safety
+    attributes:
+      label: Public report safety check
+      options:
+        - label: I have not included secrets, credentials, private local paths, browser profile paths, customer data, or raw private logs.
+          required: true
+        - label: This is not a security vulnerability report.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability report
+    url: https://github.com/Sora-bluesky/winsmux/security/advisories/new
+    about: Report vulnerabilities privately. Do not open public issues for security reports.
+  - name: Documentation overview
+    url: https://github.com/Sora-bluesky/winsmux/blob/main/docs/README.md
+    about: Start here for setup, operation, and troubleshooting links.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,53 @@
+name: Feature request
+description: Propose a scoped winsmux improvement.
+title: "[Feature]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for public product, documentation, workflow, or contributor-surface proposals. Do not include private planning notes or local-only paths.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or workflow
+      description: What user or maintainer workflow should improve?
+    validations:
+      required: true
+  - type: textarea
+    id: outcome
+    attributes:
+      label: Desired outcome
+      description: What should change for the user, product, or repository workflow?
+    validations:
+      required: true
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Affected surface
+      options:
+        - Desktop app
+        - CLI or installer
+        - Worker orchestration
+        - Documentation
+        - GitHub Actions or release workflow
+        - Contributor/test surface
+        - Not sure
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed approach
+      description: Include constraints, alternatives, or compatibility concerns if known.
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence or examples
+      description: Link to public examples or paste sanitized evidence. Do not include private data.
+  - type: checkboxes
+    id: safety
+    attributes:
+      label: Public proposal safety check
+      options:
+        - label: I have not included secrets, credentials, private local paths, browser profile paths, customer data, or raw private logs.
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,30 @@
+## Summary
+
+-
+
+## Surface Classification
+
+- [ ] Public product surface
+- [ ] Runtime contract surface
+- [ ] Contributor/test surface
+- [ ] Generated/runtime artifact not tracked
+- [ ] Not sure; reviewer help requested
+
+Reference: [Repository surface policy](../docs/repo-surface-policy.md)
+
+## Responsibility And Cutover
+
+- Replaced behavior, workflow, config path, or responsibility:
+- Expected outcome:
+- Source of truth:
+- Old paths preserved, redirected, deprecated, or removed:
+
+## Verification
+
+-
+
+## Security And Privacy
+
+- [ ] No secrets, credentials, private local paths, browser profile paths, account IDs, customer data, or raw private logs are included.
+- [ ] Security issues are reported through `SECURITY.md`, not this public pull request.
+- [ ] Rollback is clear for any configuration, automation, release, or routing change.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,39 @@
+# Code of Conduct
+
+## Purpose
+
+winsmux discussions should stay useful for people reporting bugs, asking for
+support, proposing changes, and reviewing repository work. Treat every public
+thread as part of the project record.
+
+## Expected Behavior
+
+- Be respectful and specific.
+- Assume contributors may have different Windows, shell, editor, and agent CLI
+  setups.
+- Keep feedback focused on reproducible behavior, project scope, evidence, and
+  the change under review.
+- Redact secrets, credentials, private local paths, account identifiers, and
+  customer data before posting.
+- Use the security reporting process in [SECURITY.md](SECURITY.md) for
+  vulnerabilities.
+
+## Unacceptable Behavior
+
+- Harassment, threats, insults, or discriminatory language.
+- Posting another person's private information.
+- Publishing secrets, credentials, raw private logs, or exploit details in
+  public issues or pull requests.
+- Repeatedly derailing issue or pull request threads after maintainers have
+  redirected the discussion.
+
+## Enforcement
+
+Maintainers may edit or remove comments, close or lock threads, block users, or
+escalate to GitHub moderation when behavior makes the project unsafe or
+unusable for others.
+
+If you need to report a conduct issue, contact a maintainer through a private
+GitHub channel when available. If the report involves platform abuse or urgent
+safety concerns, use GitHub's abuse reporting tools. Do not include sensitive
+personal details in a public issue.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,60 @@
+# Contributing
+
+Thanks for helping improve winsmux. This repository accepts public bug reports,
+support discussion, feature requests, documentation fixes, and scoped pull
+requests that fit the repository surface policy.
+
+## Before You Start
+
+- Read [Repository surface policy](docs/repo-surface-policy.md) before adding or
+  changing tracked files.
+- Read [Public distribution boundary](docs/source-access.md) before proposing
+  changes that affect release packaging, redistribution, or source access.
+- Use [SECURITY.md](SECURITY.md) for vulnerabilities. Do not file public GitHub
+  issues for security reports.
+- Do not include secrets, credentials, private local paths, browser profiles,
+  account IDs, customer data, or raw private logs in issues, pull requests, or
+  test artifacts.
+
+## Issues
+
+Use the issue templates when possible. A good issue includes:
+
+- the winsmux version or commit
+- Windows version and install path, such as desktop installer, npm package, or
+  source build
+- the exact command or workflow that failed
+- expected behavior and actual behavior
+- the smallest reproducible example or sanitized evidence
+
+For support questions, start with [Documentation overview](docs/README.md) and
+[Troubleshooting](docs/TROUBLESHOOTING.md). Security reports belong in the
+private vulnerability reporting flow described in [SECURITY.md](SECURITY.md).
+
+## Pull Requests
+
+Keep pull requests narrow and reviewable.
+
+1. Classify changed files using [Repository surface policy](docs/repo-surface-policy.md).
+2. Explain the behavior or responsibility being replaced.
+3. Describe the user-visible or maintainer-visible outcome.
+4. Identify the source of truth for the changed behavior.
+5. State which old paths are preserved, redirected, deprecated, or removed.
+6. Include verification evidence beyond "it compiles" when the change affects
+   release behavior, user workflows, routing, automation, security, privacy, or
+   public documentation.
+
+## Local Validation
+
+Use the narrowest relevant checks for your change. Common entry points include:
+
+```powershell
+cargo test --workspace
+pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/run-tests.ps1
+npm --prefix winsmux-app run build
+npm --prefix winsmux-app run test:composer-text
+```
+
+For desktop or release-surface changes, include the relevant E2E, package, or
+release-gate evidence in the pull request. Do not claim release readiness from a
+partial local check.


### PR DESCRIPTION
## Summary

Adds the missing GitHub community profile files so the repository has explicit public contribution, issue, pull request, and conduct guidance.

## Changes

- Add `CODE_OF_CONDUCT.md` and `CONTRIBUTING.md`.
- Add issue forms for bug reports and feature requests, plus contact links for security and documentation.
- Add a pull request template with surface classification, responsibility/cutover, verification, and security/privacy checks.
- Allow these standard community paths in the pre-commit new-file whitelist.

## Validation

- `git diff --check`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/audit-public-surface.ps1`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/git-guard.ps1`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File .githooks/pre-commit-whitelist.ps1`
- Commit hook: `git-guard passed (staged)`
- Push hook: `git-guard passed (full)`, `audit-public-surface passed`, `gitleaks ... no leaks found`

## Notes

The original checkout had an unrelated user-owned change in `winsmux-app/src/main.ts`, so this work was isolated in `.worktrees/community-profile` from `origin/main`.