### PR TITLE
Fix operator composer submission before coordination benchmarks

### DIFF
--- a/winsmux-app/scripts/desktop-pane-e2e.mjs
+++ b/winsmux-app/scripts/desktop-pane-e2e.mjs
@@ -13,12 +13,16 @@ const RELEASE_POPOUT_ONLY = process.argv.includes("--release-popout-only")
   || process.env.WINSMUX_DESKTOP_E2E_RELEASE_POPOUT_ONLY === "1";
 const WORKER_START_ONLY = process.argv.includes("--worker-start-only")
   || process.env.WINSMUX_DESKTOP_E2E_WORKER_START_ONLY === "1";
+const COMPOSER_ONLY = process.argv.includes("--composer-only")
+  || process.env.WINSMUX_DESKTOP_E2E_COMPOSER_ONLY === "1";
 const OUTPUT_DIR = path.join(
   process.cwd(),
   "output",
   "playwright",
   WORKER_START_ONLY
     ? "desktop-worker-start-e2e"
+    : COMPOSER_ONLY
+    ? "desktop-composer-e2e"
     : RELEASE_POPOUT_ONLY
     ? "desktop-release-popout-e2e"
     : LAUNCH_PROJECT_ONLY
@@ -34,7 +38,9 @@ const WORKER_UI_MARKER = "WORKER_1_UI_E2E_READY";
 const WORKER_ARROW_MARKER = "RAW_ABC";
 const WORKER_PASTE_MARKER = "WORKER_PASTE_E2E_READY";
 const OPERATOR_MARKER = "OP_E2E_READY";
+const OPERATOR_SHELL_READY_MARKER = "OPERATOR_SHELL_E2E_READY";
 const COMPOSER_TO_OPERATOR_MARKER = "BTN_E2E_READY";
+const COMPOSER_MULTILINE_MARKER = "BTN_MULTI_E2E_READY";
 const COMPOSER_ENTER_MARKER = "ENT_E2E_READY";
 const COMPOSER_ATTACHMENT_MARKER = "ATT_E2E_READY";
 const OPERATOR_TO_WORKER_MARKER = "W2_E2E_READY";
@@ -288,6 +294,25 @@ async function setActiveProjectDirForUi(page, projectDir) {
 async function reloadAppPage(page) {
   await page.reload({ waitUntil: "domcontentloaded", timeout: 60_000 }).catch(() => {});
   await waitForAppReady(page);
+}
+
+async function enableViewportHarness(page) {
+  const harnessUrl = new URL(page.url());
+  harnessUrl.search = "?viewport-harness=1";
+  if (page.url() !== harnessUrl.toString()) {
+    await page.goto(harnessUrl.toString(), { waitUntil: "domcontentloaded" });
+    await waitForAppReady(page);
+  }
+  await page.waitForFunction(() => Boolean(window.__winsmuxViewportHarness?.setOperatorStartupInputForTest), undefined, {
+    timeout: 30_000,
+  });
+}
+
+async function configureOperatorShellForTest(page) {
+  const startupInput = `pwsh -NoLogo -NoProfile -NoExit -Command "Write-Output '${OPERATOR_SHELL_READY_MARKER}'"\r`;
+  await page.evaluate((value) => {
+    window.__winsmuxViewportHarness?.setOperatorStartupInputForTest(value);
+  }, startupInput);
 }
 
 async function assertDrawerVisible(page, expected) {
@@ -698,24 +723,37 @@ async function waitForClaudeOperatorReady(page, timeoutMs = 90_000) {
   throw new Error(`Timed out waiting for Claude Code readiness in operator. Last visible text:\n${lastVisibleText}\nLast output:\n${lastOutput}`);
 }
 
+async function clickTerminalPanel(page, selector) {
+  const panel = page.locator(selector);
+  await panel.waitFor({ state: "visible", timeout: 10_000 });
+  await panel.scrollIntoViewIfNeeded();
+  await panel.click({ timeout: 10_000, force: true });
+}
+
 async function startOperatorFromUiAndWaitForClaude(page) {
-  await page.click("#operator-terminal-panel", { timeout: 10_000 });
+  await clickTerminalPanel(page, "#operator-terminal-panel");
   return await waitForClaudeOperatorReady(page);
 }
 
+async function startOperatorShellFromUiAndWaitForPrompt(page) {
+  await clickTerminalPanel(page, "#operator-terminal-panel");
+  await waitForPtyOutputLine(page, "operator", OPERATOR_SHELL_READY_MARKER, 30_000);
+  return await waitForPtyPrompt(page, "operator", 30_000);
+}
+
 async function typeIntoTerminal(page, selector, text) {
-  await page.click(selector, { timeout: 10_000 });
+  await clickTerminalPanel(page, selector);
   await page.keyboard.type(text, { delay: 8 });
   await page.keyboard.press("Enter");
 }
 
 async function typeTerminalDraft(page, selector, text) {
-  await page.click(selector, { timeout: 10_000 });
+  await clickTerminalPanel(page, selector);
   await page.keyboard.type(text, { delay: 2 });
 }
 
 async function pasteIntoTerminal(page, selector, text) {
-  await page.click(selector, { timeout: 10_000 });
+  await clickTerminalPanel(page, selector);
   let mode;
   if (process.platform === "win32") {
     try {
@@ -820,14 +858,14 @@ async function pasteViaTerminalClipboardEvent(page, selector, text) {
 }
 
 async function clearOperatorInputFromUi(page) {
-  await page.click("#operator-terminal-panel", { timeout: 10_000 });
+  await clickTerminalPanel(page, "#operator-terminal-panel");
   await page.keyboard.press("Control+C");
   await page.waitForTimeout(750);
   await waitForClaudeOperatorReady(page);
 }
 
 async function startPaneFromUiAndWaitForPrompt(page, paneId, selector) {
-  await page.click(selector, { timeout: 10_000 });
+  await clickTerminalPanel(page, selector);
   await page.keyboard.press("Enter");
   await waitForPtyPrompt(page, paneId);
 }
@@ -904,6 +942,23 @@ async function submitComposerWithButton(page, command, expectedMarker) {
     throw new Error("submitted composer message was not rendered in the conversation panel");
   }
   return await waitForPtyOutput(page, "operator", expectedMarker);
+}
+
+async function submitComposerShellWithButton(page, command, expectedMarker) {
+  await startOperatorShellFromUiAndWaitForPrompt(page);
+  await page.fill("#composer-input", command);
+  await page.click("#send-btn");
+  await page.waitForFunction(() => {
+    const input = document.querySelector("#composer-input");
+    return input instanceof HTMLTextAreaElement && input.value === "";
+  });
+  const conversationContainsMessage = await page.locator("#conversation-panel", { hasText: command }).count();
+  if (conversationContainsMessage < 1) {
+    throw new Error("submitted composer message was not rendered in the conversation panel");
+  }
+  const output = await waitForPtyOutputLine(page, "operator", expectedMarker, 30_000);
+  await waitForPtyPrompt(page, "operator", 30_000);
+  return output;
 }
 
 async function submitComposerWithEnter(page, command, expectedMarker) {
@@ -1545,11 +1600,21 @@ async function main() {
       return { url: page.url() };
     });
 
-    await runStep("desktop main window starts at a visible size", async () => {
-      const metrics = await readStartupWindowMetrics(page);
-      assertVisibleStartupGeometry(metrics);
-      return metrics;
-    });
+    if (COMPOSER_ONLY) {
+      await runStep("composer-only surface is visible", async () => {
+        await page.locator("#operator-terminal-panel").waitFor({ state: "visible" });
+        await page.locator("#composer").waitFor({ state: "visible" });
+        await page.locator("#composer-input").waitFor({ state: "visible" });
+        await page.locator("#send-btn").waitFor({ state: "visible" });
+        return await readViewportFillMetrics(page);
+      });
+    } else {
+      await runStep("desktop main window starts at a visible size", async () => {
+        const metrics = await readStartupWindowMetrics(page);
+        assertVisibleStartupGeometry(metrics);
+        return metrics;
+      });
+    }
 
     if (WORKER_START_ONLY) {
       await resetAppState(page);
@@ -1623,6 +1688,48 @@ async function main() {
     }
 
     await resetAppState(page);
+
+    if (COMPOSER_ONLY) {
+      await runStep("configure deterministic operator shell", async () => {
+        await enableViewportHarness(page);
+        await configureOperatorShellForTest(page);
+        return await page.evaluate(() => window.__winsmuxViewportHarness?.getOperatorStartupInput());
+      });
+
+      await runStep("operator pane starts local shell and accepts input", async () => {
+        const readyOutput = await startOperatorShellFromUiAndWaitForPrompt(page);
+        const visibleText = await waitForVisibleTerminalText(page, "#operator-terminal", OPERATOR_SHELL_READY_MARKER);
+        const output = await capturePty(page, "operator");
+        return { readyTail: readyOutput.slice(-800), visibleTextTail: visibleText.slice(-400), outputTail: output.slice(-800) };
+      });
+
+      await runStep("composer send button writes user message to operator pane", async () => {
+        const command = `Write-Output '${COMPOSER_TO_OPERATOR_MARKER}'`;
+        const output = await submitComposerShellWithButton(page, command, COMPOSER_TO_OPERATOR_MARKER);
+        return { outputTail: output.slice(-800) };
+      });
+
+      await runStep("composer send button writes multi-line run-control message to operator pane", async () => {
+        const command = [
+          "Write-Output 'TASK-575 operator-managed benchmark start'",
+          `Write-Output '${COMPOSER_MULTILINE_MARKER}'`,
+          "Write-Output 'Dispatch the same task packet to every worker pane.'",
+          "Write-Output 'Stop and report a blocker if operator-to-worker dispatch is unavailable.'",
+        ].join("\n");
+        const output = await submitComposerShellWithButton(page, command, COMPOSER_MULTILINE_MARKER);
+        return { outputTail: output.slice(-1_000) };
+      });
+
+      await runStep("close spawned PTYs", async () => {
+        await closePtyIfExists(page, "operator");
+      });
+
+      await ensureOutputDir();
+      await page.screenshot({ path: path.join(OUTPUT_DIR, "desktop-composer-e2e-success.png"), fullPage: true });
+      await writeEvidence(true, { debugPort, mode: "composer-only" });
+      process.stdout.write(`[desktop-pane-e2e] PASS composer-only evidence=${path.join(OUTPUT_DIR, "desktop-pane-e2e.json")}\n`);
+      return;
+    }
 
     await runStep("desktop app fills the native WebView without fixed viewport emulation", async () => {
       const metrics = await readViewportFillMetrics(page);
@@ -1978,6 +2085,18 @@ async function main() {
       const output = await submitComposerWithButton(page, command, COMPOSER_TO_OPERATOR_MARKER);
       await clearOperatorInputFromUi(page);
       return { outputTail: output.slice(-800) };
+    });
+
+    await runStep("composer send button writes multi-line run-control message to operator pane", async () => {
+      const command = [
+        "TASK-575 operator-managed benchmark start",
+        COMPOSER_MULTILINE_MARKER,
+        "Dispatch the same task packet to every worker pane.",
+        "Stop and report a blocker if operator-to-worker dispatch is unavailable.",
+      ].join("\n");
+      const output = await submitComposerWithButton(page, command, COMPOSER_MULTILINE_MARKER);
+      await clearOperatorInputFromUi(page);
+      return { outputTail: output.slice(-1_000) };
     });
 
     await runStep("composer keyboard behavior preserves newline and Enter sends", async () => {

--- a/winsmux-app/scripts/viewport-harness.mjs
+++ b/winsmux-app/scripts/viewport-harness.mjs
@@ -834,7 +834,20 @@ async function assertDesktopVoiceLongSessionPrivacy(page) {
     return input instanceof HTMLTextAreaElement && input.value === "recover this long voice draft";
   });
   await page.click("#send-btn");
-  await page.waitForFunction((key) => window.localStorage.getItem(key) === null, recoveryKey);
+  await page.waitForFunction((expectedValue) => {
+    const input = document.querySelector("#composer-input");
+    const panel = document.querySelector("#conversation-panel");
+    return input instanceof HTMLTextAreaElement &&
+      input.value === expectedValue &&
+      panel instanceof HTMLElement &&
+      panel.textContent?.includes("desktop runtime");
+  }, "recover this long voice draft");
+  await page.waitForFunction((key) => {
+    const rawValue = window.localStorage.getItem(key);
+    return rawValue !== null && JSON.parse(rawValue).value === "recover this long voice draft";
+  }, recoveryKey);
+  await composer.fill("");
+  await page.evaluate((key) => window.localStorage.removeItem(key), recoveryKey);
 
   await page.evaluate((key) => {
     window.localStorage.setItem(key, JSON.stringify({

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -236,6 +236,7 @@ declare global {
       setContextPanel: (open: boolean) => void;
       setTerminalDrawer: (open: boolean) => void;
       getOperatorStartupInput: () => string;
+      setOperatorStartupInputForTest: (value: string | null) => void;
       setVoiceNow: (timestamp: number | null) => void;
     };
   }
@@ -660,6 +661,8 @@ let operatorOutputBuffer = "";
 let operatorOutputFlushTimer: number | null = null;
 let operatorAttentionFingerprint = "";
 let operatorClaudeSessionId = createOperatorSessionId();
+let composerSubmitInFlight = false;
+let viewportHarnessOperatorStartupInputOverride: string | null = null;
 let voiceRecognition: SpeechRecognitionLike | null = null;
 let voiceListening = false;
 let voiceTranscriptBase = "";
@@ -1894,6 +1897,10 @@ function createOperatorSessionId() {
 }
 
 function getOperatorStartupInput() {
+  if (viewportHarnessOperatorStartupInputOverride !== null) {
+    return viewportHarnessOperatorStartupInputOverride;
+  }
+
   const args = ["claude", "--permission-mode", activeComposerPermissionMode, "--session-id", operatorClaudeSessionId];
   const modelOption = getComposerModelOption();
   if (modelOption.cliModel) {
@@ -14246,6 +14253,11 @@ function appendRuntimeConversation(item: ConversationItem) {
   }
 }
 
+function getConversationTimestamp() {
+  const now = new Date();
+  return `${`${now.getHours()}`.padStart(2, "0")}:${`${now.getMinutes()}`.padStart(2, "0")}`;
+}
+
 function stripTerminalControlSequences(value: string) {
   return value
     .replace(/\x1b\][^\x07]*(?:\x07|\x1b\\)/g, "")
@@ -15413,6 +15425,9 @@ function installViewportHarnessHooks() {
       setTerminalDrawer(open);
     },
     getOperatorStartupInput: () => getOperatorStartupInput(),
+    setOperatorStartupInputForTest: (value: string | null) => {
+      viewportHarnessOperatorStartupInputOverride = value;
+    },
     setVoiceNow: (timestamp: number | null) => {
       viewportHarnessVoiceNow = typeof timestamp === "number" && Number.isFinite(timestamp) ? timestamp : null;
       updateVoiceInputButton();
@@ -15420,7 +15435,11 @@ function installViewportHarnessHooks() {
   };
 }
 
-function appendUserMessage(message: string, attachments: ComposerAttachment[]) {
+function appendUserMessage(
+  message: string,
+  attachments: ComposerAttachment[],
+  timestamp?: string,
+) {
   const dogfoodInputSource = composerInputSource;
   const dogfoodStartedAt = composerDraftStartedAt || Date.now();
   const dogfoodDraft = {
@@ -15428,12 +15447,11 @@ function appendUserMessage(message: string, attachments: ComposerAttachment[]) {
     voiceStartedAt: composerVoiceStartedAt,
     keyboardAfterVoiceAt: composerKeyboardAfterVoiceAt,
   };
-  const now = new Date();
-  const timestamp = `${`${now.getHours()}`.padStart(2, "0")}:${`${now.getMinutes()}`.padStart(2, "0")}`;
+  const messageTimestamp = timestamp ?? getConversationTimestamp();
   appendRuntimeConversation({
     type: "user",
     category: "user",
-    timestamp,
+    timestamp: messageTimestamp,
     actor: "User",
     body: message || "Attached files for dispatch.",
     attachments: attachments.map((attachment) => ({
@@ -15442,7 +15460,6 @@ function appendUserMessage(message: string, attachments: ComposerAttachment[]) {
       sizeLabel: attachment.sizeLabel,
     })),
   });
-  void forwardComposerMessageToOperatorPane(message, attachments, timestamp);
   void recordComposerDogfoodEvent(message, attachments, dogfoodInputSource, dogfoodStartedAt, dogfoodDraft);
   resetComposerDogfoodDraft();
   renderRunSummary();
@@ -15495,6 +15512,18 @@ function updateOperatorStatusIndicator() {
   if (hint) {
     hint.textContent = getLanguageText("Esc to interrupt", "Esc で中断");
   }
+}
+
+function setComposerSubmitInFlight(active: boolean) {
+  composerSubmitInFlight = active;
+  const button = document.getElementById("send-btn") as HTMLButtonElement | null;
+  if (!button) {
+    return;
+  }
+
+  button.disabled = active;
+  button.classList.toggle("is-busy", active);
+  button.setAttribute("aria-busy", active ? "true" : "false");
 }
 
 function startOperatorStatusTimer() {
@@ -15651,26 +15680,27 @@ async function forwardComposerMessageToOperatorPane(
   message: string,
   attachments: ComposerAttachment[],
   timestamp: string,
-) {
+): Promise<boolean> {
   const payload = formatComposerMessageForPty(message, attachments);
   if (!payload.trim()) {
     setOperatorRequestActive(false);
-    return;
+    return false;
   }
 
   const requestGeneration = beginOperatorRequest();
   try {
     await withOperatorTimeout(ensureOperatorPtyStarted(), "operator PTY startup");
     if (!isCurrentOperatorRequest(requestGeneration)) {
-      return;
+      return false;
     }
     await writeOperatorSubmission(payload, requestGeneration);
     if (!isCurrentOperatorRequest(requestGeneration)) {
-      return;
+      return false;
     }
+    return true;
   } catch (error) {
     if (!isCurrentOperatorRequest(requestGeneration)) {
-      return;
+      return false;
     }
     setOperatorRequestActive(false);
     const errorMessage = error instanceof Error ? error.message : String(error);
@@ -15690,6 +15720,7 @@ async function forwardComposerMessageToOperatorPane(
       tone: "warning",
     });
     renderConversation(getConversationItems());
+    return false;
   }
 }
 
@@ -16894,6 +16925,7 @@ window.addEventListener("DOMContentLoaded", async () => {
   const composerInput = document.getElementById("composer-input") as HTMLTextAreaElement | null;
   const composerFileInput = document.getElementById("composer-file-input") as HTMLInputElement | null;
   const attachButton = document.getElementById("attach-btn") as HTMLButtonElement | null;
+  const sendButton = document.getElementById("send-btn") as HTMLButtonElement | null;
   const voiceInputButton = document.getElementById("voice-input-btn") as HTMLButtonElement | null;
   const interruptOperatorButton = document.getElementById("interrupt-operator-btn") as HTMLButtonElement | null;
   if (composer && composerInput) {
@@ -16976,6 +17008,11 @@ window.addEventListener("DOMContentLoaded", async () => {
       composer.requestSubmit();
     });
 
+    sendButton?.addEventListener("click", (event) => {
+      event.preventDefault();
+      composer.requestSubmit();
+    });
+
     composerInput.addEventListener("input", () => {
       if (composerHistoryIndex !== -1) {
         composerHistoryIndex = -1;
@@ -17035,8 +17072,11 @@ window.addEventListener("DOMContentLoaded", async () => {
       appendAttachments(files);
     });
 
-    composer.addEventListener("submit", (event) => {
+    composer.addEventListener("submit", async (event) => {
       event.preventDefault();
+      if (composerSubmitInFlight) {
+        return;
+      }
       const slashModeCommand = getComposerModeSlashCommand(composerInput.value);
       if (slashModeCommand) {
         applyComposerSlashCommand(slashModeCommand);
@@ -17062,17 +17102,29 @@ window.addEventListener("DOMContentLoaded", async () => {
           file: new File([], item.label),
         })),
       ];
-      appendUserMessage(rawValue, submittedAttachments);
-      pushComposerHistoryEntry(historyEntry);
-      composerInput.value = "";
-      clearVoiceDraftRecoveryStorage();
-      syncComposerInputHeight(composerInput);
-      syncComposerSlashState(composerInput.value);
-      clearPendingAttachments();
-      selectedComposerRemoteReferenceIds.clear();
-      renderComposerRemoteReferences();
-      renderAttachmentTray();
-      requestDesktopSummaryRefresh(undefined, 750);
+      const timestamp = getConversationTimestamp();
+      setComposerSubmitInFlight(true);
+      try {
+        const sent = await forwardComposerMessageToOperatorPane(rawValue, submittedAttachments, timestamp);
+        if (!sent) {
+          syncComposerInputHeight(composerInput);
+          syncComposerSlashState(composerInput.value);
+          return;
+        }
+        appendUserMessage(rawValue, submittedAttachments, timestamp);
+        pushComposerHistoryEntry(historyEntry);
+        composerInput.value = "";
+        clearVoiceDraftRecoveryStorage();
+        syncComposerInputHeight(composerInput);
+        syncComposerSlashState(composerInput.value);
+        clearPendingAttachments();
+        selectedComposerRemoteReferenceIds.clear();
+        renderComposerRemoteReferences();
+        renderAttachmentTray();
+        requestDesktopSummaryRefresh(undefined, 750);
+      } finally {
+        setComposerSubmitInFlight(false);
+      }
     });
 
     syncComposerInputHeight(composerInput);


### PR DESCRIPTION
## Summary

- wait for the operator PTY write before clearing composer input
- preserve the draft and show a persistent warning when operator submission fails
- add deterministic desktop coverage for one-line and multi-line operator submissions

## Verification

- `npm run build`
- `npm run test:viewport-harness`
- `node ./scripts/desktop-pane-e2e.mjs --composer-only`
- `git diff --check`

Closes #1017
