### PR TITLE
Fix Harness Bench launcher rebuild ordering

### DIFF
--- a/scripts/start-cli-bakeoff-desktop.ps1
+++ b/scripts/start-cli-bakeoff-desktop.ps1
@@ -302,6 +302,7 @@ New-Item -ItemType Directory -Path $resolvedProjectDir -Force | Out-Null
 Copy-BenchmarkTaskPack -SourceDir $canonicalTaskDir -DestinationDir $projectTaskDir
 
 if (-not $SkipBuild) {
+    Stop-RepoWinsmuxDesktopTree
     Invoke-CheckedCommand -FilePath 'cargo' -ArgumentList @('build', '--release', '-p', 'winsmux') -WorkingDirectory $RepoRoot
     Invoke-CheckedCommand -FilePath 'npm' -ArgumentList @('run', 'tauri', '--', 'build', '--no-bundle') -WorkingDirectory (Join-Path $RepoRoot 'winsmux-app')
 }

--- a/tests/CliBakeoff.Tests.ps1
+++ b/tests/CliBakeoff.Tests.ps1
@@ -130,6 +130,21 @@ Describe 'CLI bakeoff evidence harness' {
         $result.repoRoot | Should -Match '^[A-Z]:\\'
     }
 
+    It 'stops an existing repo desktop before rebuilding the release desktop executable' {
+        $scriptText = Get-Content -LiteralPath $script:DesktopStartScript -Raw -Encoding UTF8
+        $buildBlockIndex = $scriptText.IndexOf('if (-not $SkipBuild) {')
+        $buildStopIndex = $scriptText.IndexOf('Stop-RepoWinsmuxDesktopTree', $buildBlockIndex)
+        $cargoBuildIndex = $scriptText.IndexOf("Invoke-CheckedCommand -FilePath 'cargo'", $buildBlockIndex)
+        $tauriBuildIndex = $scriptText.IndexOf("Invoke-CheckedCommand -FilePath 'npm'", $buildBlockIndex)
+
+        ($buildBlockIndex -ge 0) | Should -BeTrue
+        ($cargoBuildIndex -ge 0) | Should -BeTrue
+        ($tauriBuildIndex -ge 0) | Should -BeTrue
+        ($buildStopIndex -gt $buildBlockIndex) | Should -BeTrue
+        ($buildStopIndex -lt $cargoBuildIndex) | Should -BeTrue
+        ($buildStopIndex -lt $tauriBuildIndex) | Should -BeTrue
+    }
+
     It 'fails when a task packet is missing' {
         $badRoot = Join-Path $TestDrive 'bad-pack'
         New-Item -ItemType Directory -Path $badRoot -Force | Out-Null


### PR DESCRIPTION
## Summary

- stop any repo-built winsmux desktop process before rebuilding the release desktop executable
- prevent `target/release/winsmux-app.exe` from being locked by the currently running desktop app
- add a Pester guard for the launcher build-order contract

## Verification

- `Invoke-Pester -Path tests\CliBakeoff.Tests.ps1 -Output Detailed`
- `git diff --check`

## Context

The formal Harness Bench launcher must be able to rebuild and relaunch the production desktop path in one pass. A running repo-built desktop app can hold `target/release/winsmux-app.exe`, so the launcher must stop it before invoking the release desktop build.
