### PR TITLE
Fix Harness Bench clean gate status noise

### DIFF
--- a/scripts/test-cli-bakeoff-preflight.ps1
+++ b/scripts/test-cli-bakeoff-preflight.ps1
@@ -139,6 +139,55 @@ function Get-GitOutput {
     }
 }
 
+function Get-GitContentDirtyStatus {
+    param([AllowNull()][string]$StatusShort)
+
+    if ([string]::IsNullOrWhiteSpace($StatusShort)) {
+        return [pscustomobject]@{ DirtyStatus = ''; IgnoredStatus = '' }
+    }
+
+    $dirtyLines = [System.Collections.Generic.List[string]]::new()
+    $ignoredLines = [System.Collections.Generic.List[string]]::new()
+    foreach ($rawLine in ($StatusShort -split "`r?`n")) {
+        $line = [string]$rawLine
+        if ([string]::IsNullOrWhiteSpace($line)) {
+            continue
+        }
+
+        if ($line.Length -lt 4 -or $line.StartsWith('??', [System.StringComparison]::Ordinal)) {
+            $dirtyLines.Add($line) | Out-Null
+            continue
+        }
+
+        $statusCode = $line.Substring(0, 2)
+        $pathSpec = $line.Substring(3)
+        if ($pathSpec.Contains(' -> ')) {
+            $dirtyLines.Add($line) | Out-Null
+            continue
+        }
+
+        if ($statusCode -notmatch '^[ M]+$') {
+            $dirtyLines.Add($line) | Out-Null
+            continue
+        }
+
+        & git -C $RepoRoot diff --quiet -- $pathSpec 2>$null
+        $hasWorktreeDiff = ($LASTEXITCODE -ne 0)
+        & git -C $RepoRoot diff --cached --quiet -- $pathSpec 2>$null
+        $hasIndexDiff = ($LASTEXITCODE -ne 0)
+        if ($hasWorktreeDiff -or $hasIndexDiff) {
+            $dirtyLines.Add($line) | Out-Null
+        } else {
+            $ignoredLines.Add($line) | Out-Null
+        }
+    }
+
+    return [pscustomobject]@{
+        DirtyStatus = ($dirtyLines -join "`n")
+        IgnoredStatus = ($ignoredLines -join "`n")
+    }
+}
+
 function Get-FileProductVersion {
     param([AllowNull()][string]$Path)
     if ([string]::IsNullOrWhiteSpace($Path) -or -not (Test-Path -LiteralPath $Path -PathType Leaf)) {
@@ -243,6 +292,7 @@ Add-Check 'benchmark pack input resolves unambiguously' (
 if ($RequireCandidateIdentity) {
     $actualHead = Get-GitOutput -Arguments @('rev-parse', 'HEAD')
     $statusShort = Get-GitOutput -Arguments @('status', '--porcelain')
+    $contentDirtyStatus = Get-GitContentDirtyStatus -StatusShort $statusShort
     $versionMetadata = Get-ProjectVersionMetadata
     $resolvedDesktopBinary = if ([string]::IsNullOrWhiteSpace($CandidateDesktopBinary)) { '' } else { Resolve-LocalPath $CandidateDesktopBinary }
     $resolvedCliBinary = if ([string]::IsNullOrWhiteSpace($CandidateCliBinary)) { '' } else { Resolve-LocalPath $CandidateCliBinary }
@@ -256,10 +306,20 @@ if ($RequireCandidateIdentity) {
         -not [string]::IsNullOrWhiteSpace($actualHead) -and
         $actualHead.StartsWith($ExpectedGitHead, [System.StringComparison]::OrdinalIgnoreCase)
 
+    $candidateCleanDetail = if ([string]::IsNullOrWhiteSpace([string]$contentDirtyStatus.DirtyStatus)) {
+        if ([string]::IsNullOrWhiteSpace([string]$contentDirtyStatus.IgnoredStatus)) {
+            ''
+        } else {
+            "ignored content-clean status:`n$($contentDirtyStatus.IgnoredStatus)"
+        }
+    } else {
+        [string]$contentDirtyStatus.DirtyStatus
+    }
+
     Add-Check 'candidate expected version is present' (-not [string]::IsNullOrWhiteSpace($ExpectedVersion)) $ExpectedVersion
     Add-Check 'candidate expected git head is present' (-not [string]::IsNullOrWhiteSpace($ExpectedGitHead)) $ExpectedGitHead
     Add-Check 'candidate git head matches expected' $expectedHeadMatches "actual=$actualHead expected=$ExpectedGitHead"
-    Add-Check 'candidate worktree is clean' ([bool]$AllowDirty -or [string]::IsNullOrWhiteSpace($statusShort)) $statusShort
+    Add-Check 'candidate worktree is clean' ([bool]$AllowDirty -or [string]::IsNullOrWhiteSpace([string]$contentDirtyStatus.DirtyStatus)) $candidateCleanDetail
     Add-Check 'candidate version metadata matches expected' (Test-VersionSetMatches -Metadata $versionMetadata -Expected $ExpectedVersion) (
         "VERSION=$($versionMetadata.VERSION); Cargo.toml=$($versionMetadata.CargoToml); tauri.conf.json=$($versionMetadata.TauriConf); expected=$ExpectedVersion"
     )

--- a/tests/CliBakeoff.Tests.ps1
+++ b/tests/CliBakeoff.Tests.ps1
@@ -145,6 +145,15 @@ Describe 'CLI bakeoff evidence harness' {
         ($buildStopIndex -lt $tauriBuildIndex) | Should -BeTrue
     }
 
+    It 'filters content-clean status noise before enforcing the candidate clean gate' {
+        $scriptText = Get-Content -LiteralPath $script:PreflightScript -Raw -Encoding UTF8
+        $scriptText | Should -Match 'function Get-GitContentDirtyStatus'
+        $scriptText | Should -Match 'git -C \$RepoRoot diff --quiet -- \$pathSpec'
+        $scriptText | Should -Match 'git -C \$RepoRoot diff --cached --quiet -- \$pathSpec'
+        $scriptText | Should -Match 'candidate worktree is clean'
+        $scriptText.Contains("Add-Check 'candidate worktree is clean' ([bool]`$AllowDirty -or [string]::IsNullOrWhiteSpace(`$statusShort))") | Should -BeFalse
+    }
+
     It 'fails when a task packet is missing' {
         $badRoot = Join-Path $TestDrive 'bad-pack'
         New-Item -ItemType Directory -Path $badRoot -Force | Out-Null


### PR DESCRIPTION
## Summary
- Filter content-clean git status noise before enforcing the Harness Bench candidate clean gate.
- Keep real content changes, untracked files, renames, deletes, and staged changes as blocking dirty state.
- Add a Pester contract so the preflight no longer uses raw git status as the candidate clean decision.

## Verification
- Invoke-Pester -Path tests\\CliBakeoff.Tests.ps1 -Output Detailed
- git diff --check -- scripts\\test-cli-bakeoff-preflight.ps1 tests\\CliBakeoff.Tests.ps1
- scripts\\test-cli-bakeoff-preflight.ps1 candidate identity preflight: all_pass=true, failed_count=0, 349 checks