### PR TITLE
test(app): verify benchmark readiness from operator

### DIFF
--- a/winsmux-app/scripts/desktop-pane-e2e.mjs
+++ b/winsmux-app/scripts/desktop-pane-e2e.mjs
@@ -1652,6 +1652,18 @@ async function exerciseOperatorCommandStartsAllWorkerPanes(page) {
   return outputs;
 }
 
+async function exerciseOperatorBenchmarkReadyCheck(page) {
+  await submitWinsmuxComposerCommandWithButton(page, "winsmux benchmark ready-check");
+  await page.locator("#conversation-panel", { hasText: "Benchmark start readiness confirmed" }).waitFor({ state: "visible", timeout: 60_000 });
+  const outputs = {};
+  for (let index = 1; index <= 6; index += 1) {
+    const paneId = `worker-${index}`;
+    const output = await waitForPtyOutputLine(page, paneId, `WINSMUX_BENCH_READY_CHECK ${paneId}`, 60_000);
+    outputs[paneId] = output.slice(-800);
+  }
+  return outputs;
+}
+
 async function main() {
   await ensureOutputDir();
   const debugPort = await getAvailablePort();
@@ -1708,11 +1720,15 @@ async function main() {
 
     if (WORKER_START_ONLY) {
       await resetAppState(page);
+      await enableViewportHarness(page);
       await runStep("worker start button launches the selected Tauri worker pane", async () => {
         return await exerciseWorkerStartButton(page);
       });
       await runStep("operator composer command starts all worker panes", async () => {
         return await exerciseOperatorCommandStartsAllWorkerPanes(page);
+      });
+      await runStep("operator benchmark ready-check verifies all worker write paths", async () => {
+        return await exerciseOperatorBenchmarkReadyCheck(page);
       });
       await ensureOutputDir();
       await page.screenshot({ path: path.join(OUTPUT_DIR, "desktop-worker-start-e2e-success.png"), fullPage: true });

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -3623,6 +3623,18 @@ function isOperatorStartAllWorkersCommand(value: string) {
   return /^\s*winsmux\s+workers\s+start\s+(?:all|\*)\s*$/i.test(value);
 }
 
+function isOperatorBenchmarkReadyCheckCommand(value: string) {
+  return /^\s*winsmux\s+(?:benchmark|harness)\s+ready-check\s*$/i.test(value);
+}
+
+function isOperatorHandledWinsmuxCommand(value: string) {
+  return isOperatorStartAllWorkersCommand(value) || isOperatorBenchmarkReadyCheckCommand(value);
+}
+
+function isViewportHarnessMode() {
+  return new URLSearchParams(window.location.search).get("viewport-harness") === "1";
+}
+
 function getWorkerRowsByTarget(rows: DesktopWorkerStatusRow[]) {
   const byTarget = new Map<string, DesktopWorkerStatusRow>();
   for (const row of rows) {
@@ -3768,16 +3780,162 @@ async function startAllWorkersFromOperatorCommand(timestamp: string): Promise<bo
   }
 }
 
+async function runBenchmarkReadyCheckFromOperatorCommand(timestamp: string): Promise<boolean> {
+  if (workerStartTarget) {
+    appendRuntimeConversation({
+      type: "system",
+      category: "attention",
+      timestamp,
+      actor: "winsmux",
+      title: getLanguageText("Worker start is already running", "ワーカー起動は実行中"),
+      body: getLanguageText(
+        "Wait for the current worker start request to finish before checking benchmark readiness.",
+        "現在のワーカー起動要求が完了してから、ベンチ開始準備を確認してください。",
+      ),
+      tone: "warning",
+    });
+    renderConversation(getConversationItems());
+    return true;
+  }
+  if (!isTauri()) {
+    appendRuntimeConversation({
+      type: "system",
+      category: "attention",
+      timestamp,
+      actor: "winsmux",
+      title: getLanguageText("Benchmark readiness is unavailable", "ベンチ開始準備を確認できません"),
+      body: getLanguageText(
+        "Open winsmux in the desktop runtime. Browser preview cannot verify worker pane PTYs.",
+        "winsmux デスクトップで開いてください。ブラウザー表示ではワーカーペインの PTY を確認できません。",
+      ),
+      tone: "warning",
+    });
+    renderConversation(getConversationItems());
+    return true;
+  }
+
+  workerStartTarget = "all";
+  setTerminalDrawer(true);
+  workbenchLayout = "3x2";
+  ensureWorkbenchPaneCount(MAX_WORKBENCH_PANES);
+  ensureWorkbenchWidthForLayout();
+  updateWorkbenchControls();
+
+  try {
+    const statusPayload = await getDesktopWorkersStatus("all", activeProjectDir);
+    const rowsByTarget = getWorkerRowsByTarget(statusPayload.workers);
+    const targets = getConfiguredWorkerPaneIds();
+    const missingTargets = targets.filter((target) => !rowsByTarget.has(target));
+    if (missingTargets.length > 0) {
+      appendRuntimeConversation({
+        type: "system",
+        category: "attention",
+        timestamp,
+        actor: "winsmux",
+        title: getLanguageText("Benchmark readiness blocked", "ベンチ開始準備を停止"),
+        body: getLanguageText(
+          `Missing worker status rows: ${missingTargets.join(", ")}`,
+          `ワーカー状態行が不足しています: ${missingTargets.join(", ")}`,
+        ),
+        tone: "warning",
+      });
+      renderConversation(getConversationItems());
+      return true;
+    }
+
+    const rows = targets.map((target) => rowsByTarget.get(target)!);
+    const blockedRows = rows.filter((row) => (row.approval_differences ?? []).length > 0);
+    if (blockedRows.length > 0) {
+      appendRuntimeConversation({
+        type: "system",
+        category: "attention",
+        timestamp,
+        actor: "winsmux",
+        title: getLanguageText("Benchmark readiness blocked", "ベンチ開始準備を停止"),
+        body: getLanguageText(
+          `${blockedRows.length} worker panes have launch approval differences. Review settings before starting the benchmark.`,
+          `${blockedRows.length} 件のワーカーペインに起動承認との差分があります。設定を確認してからベンチを開始してください。`,
+        ),
+        tone: "warning",
+      });
+      renderConversation(getConversationItems());
+      return true;
+    }
+
+    for (const row of rows) {
+      const target = getWorkerStatusTarget(row);
+      if (target) {
+        await startDesktopWorkerPaneWithLaunchCommand(target, row);
+      }
+    }
+
+    const harnessProbe = isViewportHarnessMode();
+    const probeId = `ready-${Date.now().toString(36)}`;
+    for (const target of targets) {
+      await ensurePanePtyStarted(target);
+      const data = harnessProbe
+        ? `Write-Output 'WINSMUX_BENCH_READY_CHECK ${target} ${probeId}'\r`
+        : "";
+      await writePtyData(target, data);
+    }
+
+    appendRuntimeConversation({
+      type: "system",
+      category: "activity",
+      timestamp,
+      actor: "winsmux",
+      title: getLanguageText("Benchmark start readiness confirmed", "ベンチ開始準備を確認"),
+      body: getLanguageText(
+        "All six worker panes are running, launch approvals are clean, and the PTY write path was verified. No benchmark task packet was sent.",
+        "6つのワーカーペインが起動済みで、起動承認に差分はありません。書き込み経路も確認しました。正式ベンチ課題はまだ投入していません。",
+      ),
+      details: [
+        { label: getLanguageText("worker panes", "ワーカーペイン"), value: targets.join(", ") },
+        { label: getLanguageText("formal task packets", "正式課題"), value: getLanguageText("not sent", "未投入") },
+        { label: getLanguageText("probe id", "確認ID"), value: probeId },
+      ],
+      tone: "success",
+    });
+    renderConversation(getConversationItems());
+    requestDesktopSummaryRefresh(undefined, 500);
+    return true;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    appendRuntimeConversation({
+      type: "system",
+      category: "attention",
+      timestamp,
+      actor: "winsmux",
+      title: getLanguageText("Benchmark start readiness failed", "ベンチ開始準備に失敗"),
+      body: message,
+      tone: "danger",
+    });
+    renderConversation(getConversationItems());
+    console.warn("Failed to verify benchmark readiness through operator command", error);
+    return true;
+  } finally {
+    workerStartTarget = null;
+    updateWorkbenchControls();
+  }
+}
+
 async function handleOperatorWinsmuxCommand(
   value: string,
   attachments: ComposerAttachment[],
   timestamp: string,
 ): Promise<boolean> {
-  if (attachments.length > 0 || !isOperatorStartAllWorkersCommand(value)) {
+  if (attachments.length > 0) {
     return false;
   }
-  await startAllWorkersFromOperatorCommand(timestamp);
-  return true;
+  if (isOperatorStartAllWorkersCommand(value)) {
+    await startAllWorkersFromOperatorCommand(timestamp);
+    return true;
+  }
+  if (isOperatorBenchmarkReadyCheckCommand(value)) {
+    await runBenchmarkReadyCheckFromOperatorCommand(timestamp);
+    return true;
+  }
+  return false;
 }
 
 function ensureDefaultWorkbenchPanes(options?: { deferWorkbenchUpdate?: boolean }) {
@@ -17274,7 +17432,7 @@ window.addEventListener("DOMContentLoaded", async () => {
       const timestamp = getConversationTimestamp();
       setComposerSubmitInFlight(true);
       try {
-        if (isOperatorStartAllWorkersCommand(value) && submittedAttachments.length === 0) {
+        if (isOperatorHandledWinsmuxCommand(value) && submittedAttachments.length === 0) {
           appendUserMessage(rawValue, submittedAttachments, timestamp);
           await handleOperatorWinsmuxCommand(value, submittedAttachments, timestamp);
           pushComposerHistoryEntry(historyEntry);


### PR DESCRIPTION
## Summary

This PR adds an operator-only benchmark readiness check before the formal v0.36.23 Harness Bench run.

The readiness command starts the configured worker panes, verifies that launch approval state is clean, and checks that each worker pane has a writable PTY path. It does not send benchmark task packets, so it can be used as a safe preflight gate.

## Changes

- Add `winsmux benchmark ready-check` and `winsmux harness ready-check` handling in the operator composer.
- Start all configured worker panes through the existing desktop worker launch path.
- Verify that all six worker panes have status rows and no launch approval differences.
- Check the worker pane PTY write path without sending formal benchmark tasks.
- Extend the desktop worker-start E2E to cover the operator readiness check for all six worker panes.

## Verification

- `npm run build`
- `node ./scripts/desktop-pane-e2e.mjs --worker-start-only`
- `git diff --check`

## Benchmark Boundary

This PR does not include formal Harness Bench task execution or benchmark results. It only proves that the operator path can reach the start-ready state.
