### PR TITLE
Gate benchmark dispatch on worker readiness

### DIFF
--- a/winsmux-app/scripts/desktop-pane-e2e.mjs
+++ b/winsmux-app/scripts/desktop-pane-e2e.mjs
@@ -1581,12 +1581,46 @@ async function closeAllWorkerPtys(page) {
   }
 }
 
+async function writeMinimalHarnessBenchmarkPack(projectDir) {
+  const packDir = path.join(projectDir, "tasks", "cli-bakeoff", "v1");
+  await fs.mkdir(packDir, { recursive: true });
+  await fs.writeFile(
+    path.join(packDir, "WB-001-desktop-worker-pane-launch-diagnosis.md"),
+    [
+      "# WB-001: Desktop worker-pane launch diagnosis",
+      "",
+      "Return BAKEOFF_ROUND_A_BEGIN, a concise diagnosis, and BAKEOFF_ROUND_A_END.",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  await fs.writeFile(
+    path.join(packDir, "benchmark-pack.json"),
+    JSON.stringify({
+      version: 1,
+      pack_id: "winsmux-cli-bakeoff-v1",
+      title: "desktop pane e2e benchmark pack",
+      default_timeout_seconds: 3600,
+      tasks: [
+        {
+          task_id: "WB-001",
+          title: "Desktop worker-pane launch diagnosis",
+          packet_path: "WB-001-desktop-worker-pane-launch-diagnosis.md",
+          timeout_seconds: 3600,
+        },
+      ],
+    }, null, 2),
+    "utf8",
+  );
+}
+
 async function exerciseOperatorCommandStartsAllWorkerPanes(page, options = {}) {
   const tempProjectDir = path.join(OUTPUT_DIR, options.projectName ?? "operator-start-all-workers-project");
   await fs.rm(tempProjectDir, { recursive: true, force: true });
   await fs.mkdir(tempProjectDir, { recursive: true });
   const tempWinsmuxDir = path.join(tempProjectDir, ".winsmux");
   await fs.mkdir(tempWinsmuxDir, { recursive: true });
+  await writeMinimalHarnessBenchmarkPack(tempProjectDir);
   const markerScriptPath = path.join(tempProjectDir, options.scriptName ?? "operator-start-all-worker-marker.ps1");
   const startMarker = options.startMarker ?? "DESKTOP_ALL_WORKERS_START_OK";
   await fs.writeFile(
@@ -1690,6 +1724,39 @@ async function exerciseOperatorBenchmarkReadyCheckBlocksOnMcpWarning(page) {
   };
 }
 
+async function exerciseOperatorBenchmarkDispatchBlocksOnMcpWarning(page) {
+  await exerciseOperatorCommandStartsAllWorkerPanes(page, {
+    projectName: "operator-dispatch-mcp-warning-project",
+    scriptName: "operator-dispatch-mcp-warning.ps1",
+    scriptLines: [
+      "Write-Output 'DESKTOP_ALL_WORKERS_START_OK'",
+      "Write-Output 'MCP startup incomplete (failed: figma)'",
+      "Write-Output '3 MCP servers need authentication - run /mcp'",
+      "Write-Output ($args -join ' ')",
+      "",
+    ],
+  });
+  await submitWinsmuxComposerCommandWithButton(page, "winsmux benchmark dispatch WB-001");
+  await page.locator("#conversation-panel", { hasText: "Benchmark dispatch blocked" }).waitFor({ state: "visible", timeout: 60_000 });
+  const text = await page.locator("#conversation-panel").textContent();
+  const outputs = {};
+  for (let index = 1; index <= 6; index += 1) {
+    const paneId = `worker-${index}`;
+    outputs[paneId] = (await capturePty(page, paneId).catch(() => "")).slice(-1_200);
+  }
+  const combined = `${text ?? ""}\n${JSON.stringify(outputs)}`;
+  if (!combined.includes("MCP authentication required")) {
+    throw new Error(`benchmark dispatch did not report the MCP blocker:\n${combined.slice(-1_800)}`);
+  }
+  if (combined.includes("WINSMUX_BENCH_TASK_PACKET")) {
+    throw new Error(`benchmark dispatch sent a task packet despite MCP warnings:\n${combined.slice(-1_800)}`);
+  }
+  return {
+    conversationTail: (text ?? "").slice(-1_200),
+    outputs,
+  };
+}
+
 async function exerciseOperatorBenchmarkReadyCheck(page) {
   await submitWinsmuxComposerCommandWithButton(page, "winsmux benchmark ready-check");
   await page.locator("#conversation-panel", { hasText: "Benchmark start readiness confirmed" }).waitFor({ state: "visible", timeout: 60_000 });
@@ -1700,6 +1767,25 @@ async function exerciseOperatorBenchmarkReadyCheck(page) {
     outputs[paneId] = output.slice(-800);
   }
   return outputs;
+}
+
+async function exerciseOperatorBenchmarkDispatch(page) {
+  await submitWinsmuxComposerCommandWithButton(page, "winsmux benchmark dispatch WB-001");
+  await page.locator("#conversation-panel", { hasText: "Benchmark task packet dispatched" }).waitFor({ state: "visible", timeout: 60_000 });
+  const outputs = {};
+  for (let index = 1; index <= 6; index += 1) {
+    const paneId = `worker-${index}`;
+    const output = await waitForPtyOutputLine(page, paneId, `WINSMUX_BENCH_TASK_PACKET WB-001 ${paneId}`, 60_000);
+    outputs[paneId] = output.slice(-800);
+  }
+  const text = await page.locator("#conversation-panel").textContent();
+  if (!(text ?? "").includes("sha256")) {
+    throw new Error(`benchmark dispatch did not record the packet hash:\n${(text ?? "").slice(-1_200)}`);
+  }
+  return {
+    conversationTail: (text ?? "").slice(-1_200),
+    outputs,
+  };
 }
 
 async function main() {
@@ -1765,11 +1851,17 @@ async function main() {
       await runStep("operator benchmark ready-check stops on worker MCP warnings", async () => {
         return await exerciseOperatorBenchmarkReadyCheckBlocksOnMcpWarning(page);
       });
+      await runStep("operator benchmark dispatch stops on worker MCP warnings", async () => {
+        return await exerciseOperatorBenchmarkDispatchBlocksOnMcpWarning(page);
+      });
       await runStep("operator composer command starts all worker panes", async () => {
         return await exerciseOperatorCommandStartsAllWorkerPanes(page);
       });
       await runStep("operator benchmark ready-check verifies all worker write paths", async () => {
         return await exerciseOperatorBenchmarkReadyCheck(page);
+      });
+      await runStep("operator benchmark dispatch writes the same task packet to all workers", async () => {
+        return await exerciseOperatorBenchmarkDispatch(page);
       });
       await ensureOutputDir();
       await page.screenshot({ path: path.join(OUTPUT_DIR, "desktop-worker-start-e2e-success.png"), fullPage: true });

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -58,6 +58,30 @@ interface PaneEntry {
   ptyStarting: Promise<void> | null;
 }
 
+interface HarnessBenchmarkPackTask {
+  task_id?: string;
+  title?: string;
+  packet_path?: string;
+  timeout_seconds?: number;
+}
+
+interface HarnessBenchmarkPack {
+  pack_id?: string;
+  title?: string;
+  default_timeout_seconds?: number;
+  tasks?: HarnessBenchmarkPackTask[];
+}
+
+interface HarnessBenchmarkTaskPacket {
+  packId: string;
+  taskId: string;
+  taskTitle: string;
+  packetPath: string;
+  timeoutSeconds: number;
+  prompt: string;
+  sha256: string;
+}
+
 type ChipAction =
   | "open-explain"
   | "open-editor"
@@ -3631,8 +3655,19 @@ function isOperatorBenchmarkReadyCheckCommand(value: string) {
   return /^\s*winsmux\s+(?:benchmark|harness)\s+ready-check\s*$/i.test(value);
 }
 
+function isOperatorBenchmarkDispatchCommand(value: string) {
+  return /^\s*winsmux\s+(?:benchmark|harness)\s+(?:dispatch|start)\s+(?:task\s+)?[A-Za-z0-9._-]+\s*$/i.test(value);
+}
+
+function getOperatorBenchmarkDispatchTaskId(value: string) {
+  const match = value.match(/^\s*winsmux\s+(?:benchmark|harness)\s+(?:dispatch|start)\s+(?:task\s+)?([A-Za-z0-9._-]+)\s*$/i);
+  return match?.[1]?.trim() || "";
+}
+
 function isOperatorHandledWinsmuxCommand(value: string) {
-  return isOperatorStartAllWorkersCommand(value) || isOperatorBenchmarkReadyCheckCommand(value);
+  return isOperatorStartAllWorkersCommand(value)
+    || isOperatorBenchmarkReadyCheckCommand(value)
+    || isOperatorBenchmarkDispatchCommand(value);
 }
 
 function isViewportHarnessMode() {
@@ -3819,6 +3854,82 @@ function readinessDetails(readiness: WorkerPaneReadiness[]): ConversationDetail[
     label: item.target,
     value: `${item.state}: ${item.reason}${item.evidence ? ` (${item.evidence})` : ""}`,
   }));
+}
+
+function parseHarnessBenchmarkPack(raw: string): HarnessBenchmarkPack {
+  const parsed = JSON.parse(raw) as HarnessBenchmarkPack;
+  if (!parsed || !Array.isArray(parsed.tasks)) {
+    throw new Error("benchmark-pack.json does not contain a tasks array.");
+  }
+  return parsed;
+}
+
+function buildHarnessTaskPrompt(pack: HarnessBenchmarkPack, task: HarnessBenchmarkPackTask, packetContent: string) {
+  const packId = String(pack.pack_id || "winsmux-cli-bakeoff-v1");
+  const taskId = String(task.task_id || "").trim();
+  const taskTitle = String(task.title || taskId).trim();
+  const timeoutSeconds = Number(task.timeout_seconds || pack.default_timeout_seconds || 3600);
+  return [
+    `Harness Bench task packet`,
+    `Pack: ${packId}`,
+    `Task: ${taskId}`,
+    `Title: ${taskTitle}`,
+    `Timeout seconds: ${Number.isFinite(timeoutSeconds) ? timeoutSeconds : 3600}`,
+    "",
+    "Instructions:",
+    packetContent.trim(),
+    "",
+  ].join("\n");
+}
+
+async function loadHarnessBenchmarkTaskPacket(taskId: string): Promise<HarnessBenchmarkTaskPacket> {
+  const normalizedTaskId = taskId.trim();
+  if (!normalizedTaskId) {
+    throw new Error("Benchmark task id is required.");
+  }
+  const packPath = "tasks/cli-bakeoff/v1/benchmark-pack.json";
+  const packFile = await getDesktopEditorFile(packPath, undefined, activeProjectDir);
+  if (packFile.truncated) {
+    throw new Error(`${packPath} is truncated and cannot be used for benchmark dispatch.`);
+  }
+  const pack = parseHarnessBenchmarkPack(packFile.content);
+  const task = (pack.tasks ?? []).find((item) => String(item.task_id || "").trim().toLowerCase() === normalizedTaskId.toLowerCase());
+  if (!task) {
+    throw new Error(`Benchmark task ${normalizedTaskId} was not found in ${packPath}.`);
+  }
+  const packetPath = String(task.packet_path || "").trim();
+  if (!packetPath || packetPath.includes("..") || packetPath.startsWith("/") || /^[A-Za-z]:[\\/]/.test(packetPath)) {
+    throw new Error(`Benchmark task ${normalizedTaskId} has an invalid packet_path.`);
+  }
+  const packetRelativePath = `tasks/cli-bakeoff/v1/${packetPath}`;
+  const packetFile = await getDesktopEditorFile(packetRelativePath, undefined, activeProjectDir);
+  if (packetFile.truncated) {
+    throw new Error(`${packetRelativePath} is truncated and cannot be used for benchmark dispatch.`);
+  }
+  const prompt = buildHarnessTaskPrompt(pack, task, packetFile.content);
+  const timeoutSeconds = Number(task.timeout_seconds || pack.default_timeout_seconds || 3600);
+  return {
+    packId: String(pack.pack_id || "winsmux-cli-bakeoff-v1"),
+    taskId: String(task.task_id || normalizedTaskId),
+    taskTitle: String(task.title || normalizedTaskId),
+    packetPath: packetRelativePath,
+    timeoutSeconds: Number.isFinite(timeoutSeconds) ? timeoutSeconds : 3600,
+    prompt,
+    sha256: await sha256Hex(prompt),
+  };
+}
+
+async function writeWorkerBenchmarkSubmission(target: string, packet: HarnessBenchmarkTaskPacket) {
+  await ensurePanePtyStarted(target);
+  if (isViewportHarnessMode()) {
+    await writePtyData(target, `Write-Output 'WINSMUX_BENCH_TASK_PACKET ${packet.taskId} ${target} ${packet.sha256.slice(0, 12)}'\r`);
+    return;
+  }
+  await writePtyData(target, encodePtySubmission(packet.prompt));
+  if (packet.prompt.includes("\n")) {
+    await waitForOperatorSubmitDelay();
+    await writePtyData(target, "\r");
+  }
 }
 
 async function waitForWorkerPaneReadiness(
@@ -4144,6 +4255,181 @@ async function runBenchmarkReadyCheckFromOperatorCommand(timestamp: string): Pro
   }
 }
 
+async function dispatchBenchmarkTaskFromOperatorCommand(
+  taskId: string,
+  timestamp: string,
+): Promise<boolean> {
+  if (workerStartTarget) {
+    appendRuntimeConversation({
+      type: "system",
+      category: "attention",
+      timestamp,
+      actor: "winsmux",
+      title: getLanguageText("Worker start is already running", "ワーカー起動は実行中"),
+      body: getLanguageText(
+        "Wait for the current worker start request to finish before dispatching a benchmark task.",
+        "現在のワーカー起動要求が完了してから、ベンチ課題を投入してください。",
+      ),
+      tone: "warning",
+    });
+    renderConversation(getConversationItems());
+    return true;
+  }
+  if (!isTauri()) {
+    appendRuntimeConversation({
+      type: "system",
+      category: "attention",
+      timestamp,
+      actor: "winsmux",
+      title: getLanguageText("Benchmark dispatch is unavailable", "ベンチ課題を投入できません"),
+      body: getLanguageText(
+        "Open winsmux in the desktop runtime. Browser preview cannot verify and dispatch worker pane PTYs.",
+        "winsmux デスクトップで開いてください。ブラウザー表示ではワーカーペインの PTY 確認と課題投入はできません。",
+      ),
+      tone: "warning",
+    });
+    renderConversation(getConversationItems());
+    return true;
+  }
+
+  workerStartTarget = "all";
+  setTerminalDrawer(true);
+  workbenchLayout = "3x2";
+  ensureWorkbenchPaneCount(MAX_WORKBENCH_PANES);
+  ensureWorkbenchWidthForLayout();
+  updateWorkbenchControls();
+
+  try {
+    const statusPayload = await getDesktopWorkersStatus("all", activeProjectDir);
+    const rowsByTarget = getWorkerRowsByTarget(statusPayload.workers);
+    const targets = getConfiguredWorkerPaneIds();
+    const missingTargets = targets.filter((target) => !rowsByTarget.has(target));
+    if (missingTargets.length > 0) {
+      appendRuntimeConversation({
+        type: "system",
+        category: "attention",
+        timestamp,
+        actor: "winsmux",
+        title: getLanguageText("Benchmark dispatch blocked", "ベンチ課題投入を停止"),
+        body: getLanguageText(
+          `Missing worker status rows: ${missingTargets.join(", ")}`,
+          `ワーカー状態行が不足しています: ${missingTargets.join(", ")}`,
+        ),
+        tone: "warning",
+      });
+      renderConversation(getConversationItems());
+      return true;
+    }
+
+    const rows = targets.map((target) => rowsByTarget.get(target)!);
+    const blockedRows = rows.filter((row) => (row.approval_differences ?? []).length > 0);
+    if (blockedRows.length > 0) {
+      appendRuntimeConversation({
+        type: "system",
+        category: "attention",
+        timestamp,
+        actor: "winsmux",
+        title: getLanguageText("Benchmark dispatch blocked", "ベンチ課題投入を停止"),
+        body: getLanguageText(
+          `${blockedRows.length} worker panes have launch approval differences. Review settings before dispatching the benchmark task.`,
+          `${blockedRows.length} 件のワーカーペインに起動承認との差分があります。設定を確認してからベンチ課題を投入してください。`,
+        ),
+        tone: "warning",
+      });
+      renderConversation(getConversationItems());
+      return true;
+    }
+
+    for (const row of rows) {
+      const target = getWorkerStatusTarget(row);
+      if (target) {
+        await startDesktopWorkerPaneWithLaunchCommand(target, row);
+      }
+    }
+
+    const harnessProbe = isViewportHarnessMode();
+    const probeId = `dispatch-${Date.now().toString(36)}`;
+    const expectedProbeLines = new Map<string, string>();
+    for (const target of targets) {
+      await ensurePanePtyStarted(target);
+      if (harnessProbe) {
+        const expectedLine = `WINSMUX_BENCH_READY_CHECK ${target} ${probeId}`;
+        expectedProbeLines.set(target, expectedLine);
+        await writePtyData(target, `Write-Output '${expectedLine}'\r`);
+      }
+    }
+
+    const readiness = await waitForWorkerPaneReadiness(targets, expectedProbeLines);
+    const notReady = readiness.filter((item) => item.state !== "ready");
+    if (notReady.length > 0) {
+      appendRuntimeConversation({
+        type: "system",
+        category: "attention",
+        timestamp,
+        actor: "winsmux",
+        title: getLanguageText("Benchmark dispatch blocked", "ベンチ課題投入を停止"),
+        body: getLanguageText(
+          `${notReady.length} worker pane(s) are not ready. Resolve MCP/auth/quota warnings or pending prompts, then run the operator dispatch command again. No benchmark task packet was sent.`,
+          `${notReady.length} 件のワーカーペインが投入可能な状態ではありません。MCP 認証、資格情報、利用枠、確認待ちを解消してから、オペレーターの投入コマンドを再実行してください。正式ベンチ課題は投入していません。`,
+        ),
+        details: readinessDetails(readiness),
+        tone: "warning",
+      });
+      renderConversation(getConversationItems());
+      requestDesktopSummaryRefresh(undefined, 500);
+      renderWorkerStatusSurface();
+      return true;
+    }
+
+    const packet = await loadHarnessBenchmarkTaskPacket(taskId);
+    for (const target of targets) {
+      await writeWorkerBenchmarkSubmission(target, packet);
+    }
+
+    appendRuntimeConversation({
+      type: "system",
+      category: "activity",
+      timestamp,
+      actor: "winsmux",
+      title: getLanguageText("Benchmark task packet dispatched", "ベンチ課題を投入しました"),
+      body: getLanguageText(
+        `The same Harness Bench task packet was sent to all six worker panes after readiness confirmation.`,
+        `投入前確認の通過後、同一の Harness Bench 課題パケットを6つのワーカーペインすべてへ送信しました。`,
+      ),
+      details: [
+        { label: getLanguageText("task", "課題"), value: `${packet.taskId} - ${packet.taskTitle}` },
+        { label: getLanguageText("pack", "パック"), value: packet.packId },
+        { label: getLanguageText("packet", "課題ファイル"), value: packet.packetPath },
+        { label: "sha256", value: packet.sha256 },
+        { label: getLanguageText("worker panes", "ワーカーペイン"), value: targets.join(", ") },
+        { label: getLanguageText("timeout", "制限時間"), value: `${packet.timeoutSeconds}s` },
+        ...readinessDetails(readiness),
+      ],
+      tone: "success",
+    });
+    renderConversation(getConversationItems());
+    requestDesktopSummaryRefresh(undefined, 500);
+    return true;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    appendRuntimeConversation({
+      type: "system",
+      category: "attention",
+      timestamp,
+      actor: "winsmux",
+      title: getLanguageText("Benchmark dispatch failed", "ベンチ課題投入に失敗"),
+      body: message,
+      tone: "danger",
+    });
+    renderConversation(getConversationItems());
+    console.warn("Failed to dispatch benchmark task through operator command", error);
+    return true;
+  } finally {
+    workerStartTarget = null;
+    updateWorkbenchControls();
+  }
+}
+
 async function handleOperatorWinsmuxCommand(
   value: string,
   attachments: ComposerAttachment[],
@@ -4158,6 +4444,10 @@ async function handleOperatorWinsmuxCommand(
   }
   if (isOperatorBenchmarkReadyCheckCommand(value)) {
     await runBenchmarkReadyCheckFromOperatorCommand(timestamp);
+    return true;
+  }
+  if (isOperatorBenchmarkDispatchCommand(value)) {
+    await dispatchBenchmarkTaskFromOperatorCommand(getOperatorBenchmarkDispatchTaskId(value), timestamp);
     return true;
   }
   return false;


### PR DESCRIPTION
## Summary
- Add an operator command for winsmux benchmark dispatch <task> that reruns six-pane readiness checks before sending any Harness Bench task packet.
- Load the benchmark pack through the existing desktop file-read boundary and send the same packet hash to all six worker panes only after readiness passes.
- Extend desktop E2E coverage for MCP-warning dispatch blocking and successful six-pane task dispatch.

## Verification
- 
pm run build
- git diff --check
- 
ode scripts/desktop-pane-e2e.mjs --worker-start-only

## Notes
- Formal Harness Bench measurement has not started in this PR.
- The operator remains the only formal entry point for dispatching the benchmark task packet.