### PR TITLE
fix(app): classify worker readiness blockers

### DIFF
--- a/winsmux-app/scripts/desktop-pane-e2e.mjs
+++ b/winsmux-app/scripts/desktop-pane-e2e.mjs
@@ -1699,6 +1699,7 @@ async function exerciseOperatorBenchmarkReadyCheckBlocksOnMcpWarning(page) {
       "Write-Output 'DESKTOP_ALL_WORKERS_START_OK'",
       "Write-Output 'MCP startup incomplete (failed: figma)'",
       "Write-Output '3 MCP servers need authentication - run /mcp'",
+      "Write-Output '‼3MCPserversneedauthentication·run/mcp'",
       "Write-Output ($args -join ' ')",
       "",
     ],
@@ -1721,6 +1722,28 @@ async function exerciseOperatorBenchmarkReadyCheckBlocksOnMcpWarning(page) {
   return {
     conversationTail: (text ?? "").slice(-1_200),
     metaState,
+  };
+}
+
+async function exerciseOperatorBenchmarkReadyCheckBlocksOnConfirmationPrompt(page) {
+  await exerciseOperatorCommandStartsAllWorkerPanes(page, {
+    projectName: "operator-ready-check-confirmation-prompt-project",
+    scriptName: "operator-start-all-worker-confirmation-prompt.ps1",
+    scriptLines: [
+      "Write-Output 'DESKTOP_ALL_WORKERS_START_OK'",
+      "Write-Output 'Continue anyway? [y/N]:'",
+      "Write-Output ($args -join ' ')",
+      "",
+    ],
+  });
+  await submitWinsmuxComposerCommandWithButton(page, "winsmux benchmark ready-check");
+  await page.locator("#conversation-panel", { hasText: "Benchmark start readiness blocked" }).waitFor({ state: "visible", timeout: 60_000 });
+  const text = await page.locator("#conversation-panel").textContent();
+  if (!(text ?? "").includes("Worker is waiting for a user decision")) {
+    throw new Error(`ready-check did not report the confirmation prompt blocker:\n${(text ?? "").slice(-1_800)}`);
+  }
+  return {
+    conversationTail: (text ?? "").slice(-1_200),
   };
 }
 
@@ -1850,6 +1873,9 @@ async function main() {
       });
       await runStep("operator benchmark ready-check stops on worker MCP warnings", async () => {
         return await exerciseOperatorBenchmarkReadyCheckBlocksOnMcpWarning(page);
+      });
+      await runStep("operator benchmark ready-check stops on confirmation prompts", async () => {
+        return await exerciseOperatorBenchmarkReadyCheckBlocksOnConfirmationPrompt(page);
       });
       await runStep("operator benchmark dispatch stops on worker MCP warnings", async () => {
         return await exerciseOperatorBenchmarkDispatchBlocksOnMcpWarning(page);

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -3716,6 +3716,10 @@ function normalizeWorkerReadinessOutput(output: string) {
   return stripTerminalControlSequences(output).replace(/\u00a0/g, " ").trim();
 }
 
+function compactWorkerReadinessOutput(output: string) {
+  return output.replace(/[\s\u00a0·•∙・]+/g, "").toLowerCase();
+}
+
 function appendPaneOutputBuffer(entry: PaneEntry, data: string) {
   entry.outputBuffer += data;
   if (entry.outputBuffer.length > 16_000) {
@@ -3724,36 +3728,43 @@ function appendPaneOutputBuffer(entry: PaneEntry, data: string) {
 }
 
 function detectWorkerReadinessBlocker(text: string) {
+  const compactText = compactWorkerReadinessOutput(text);
   const checks = [
     {
       reason: getLanguageText("MCP authentication required", "MCP 認証が必要です"),
       pattern: /(?:mcp\s+startup\s+incomplete|mcp\s+servers?\s+need\s+authentication|mcp\s+server\s+is\s+not\s+logged\s+in|run\s+\/mcp)/i,
+      compactPattern: /(?:mcpstartupincomplete|mcpservers?needauthentication|mcpserverisnotloggedin|run\/mcp)/,
     },
     {
       reason: getLanguageText("Provider credentials or API setup required", "プロバイダーの資格情報または API 設定が必要です"),
       pattern: /(?:setup\s+required|missing\s+api\s+key|requires?\s+(?:an?\s+)?(?:api|credential|key)|OPENROUTER_API_KEY)/i,
+      compactPattern: /(?:setuprequired|missingapikey|requires?(?:an?)?(?:api|credential|key)|openrouter_api_key)/,
     },
     {
       reason: getLanguageText("Quota or rate-limit warning", "利用枠またはレート制限の警告があります"),
       pattern: /(?:less\s+than\s+\d+%\s+of\s+your\s+.*limit|rate\s+limit|quota\s+(?:exceeded|warning))/i,
+      compactPattern: /(?:lessthan\d+%ofyour.*limit|ratelimit|quota(?:exceeded|warning))/,
     },
     {
       reason: getLanguageText("Worker is waiting for a user decision", "ワーカーがユーザー判断待ちです"),
-      pattern: /(?:waiting\s+for\s+(?:approval|confirmation)|continue\?|確認待ち|どう進めますか)/i,
+      pattern: /(?:waiting\s+for\s+(?:approval|confirmation)|continue\s+anyway\?\s+\[y\/n\]|continue\?|確認待ち|どう進めますか)/i,
+      compactPattern: /(?:waitingfor(?:approval|confirmation)|continueanyway\?\[y\/n\]|continue\?)/,
     },
   ];
 
-  return checks.find((check) => check.pattern.test(text))?.reason ?? "";
+  return checks.find((check) => check.pattern.test(text) || check.compactPattern.test(compactText))?.reason ?? "";
 }
 
 function hasWorkerReadyPrompt(text: string) {
+  const compactText = compactWorkerReadinessOutput(text);
   const recentLines = text
     .split("\n")
     .map((line) => line.trim())
     .filter(Boolean)
     .slice(-10);
   return recentLines.some((line) => /^(?:[>›❯]|PS\s+.+>|.*>\s*)$/.test(line))
-    || /(?:Claude Code v|OpenAI Codex|Antigravity CLI|Grok Build)[\s\S]{0,1200}(?:^|\n)\s*[>›❯]\s*$/i.test(text);
+    || /(?:Claude Code v|OpenAI Codex|Antigravity CLI|Grok Build)[\s\S]{0,1200}(?:^|\n)\s*[>›❯]\s*$/i.test(text)
+    || (compactText.includes("grokbuild") && /[>›❯]/.test(text));
 }
 
 async function inspectWorkerPaneReadiness(


### PR DESCRIPTION
## Summary
- classify compressed MCP authentication warnings from worker panes before benchmark dispatch
- classify Codex confirmation prompts as operator-visible blockers instead of generic readiness timeouts
- recognize Grok Build prompt output as a ready worker prompt when no blocker is present
- extend desktop worker-pane E2E coverage for compressed MCP warnings and confirmation prompts

## Test Plan
- npm run build
- node scripts/desktop-pane-e2e.mjs --worker-start-only
- git diff --check

## Benchmark Safety
The operator still sends no benchmark task packet unless all six worker panes pass readiness. MCP/auth/quota/confirmation blockers stop dispatch with actionable status.
