### PR TITLE
fix(app): keep benchmark checks waiting for worker readiness

### DIFF
--- a/winsmux-app/scripts/desktop-pane-e2e.mjs
+++ b/winsmux-app/scripts/desktop-pane-e2e.mjs
@@ -1725,6 +1725,31 @@ async function exerciseOperatorBenchmarkReadyCheckBlocksOnMcpWarning(page) {
   };
 }
 
+async function exerciseOperatorBenchmarkReadyCheckWaitsForMcpStartup(page) {
+  await exerciseOperatorCommandStartsAllWorkerPanes(page, {
+    projectName: "operator-ready-check-mcp-starting-project",
+    scriptName: "operator-start-all-worker-mcp-starting.ps1",
+    scriptLines: [
+      "Write-Output 'DESKTOP_ALL_WORKERS_START_OK'",
+      "Write-Output 'Starting MCP servers (0/2): codex-security, performance'",
+      "Write-Output ($args -join ' ')",
+      "",
+    ],
+  });
+  await submitWinsmuxComposerCommandWithButton(page, "winsmux benchmark ready-check");
+  await page.locator("#conversation-panel", { hasText: "Benchmark start readiness blocked" }).waitFor({ state: "visible", timeout: 120_000 });
+  const text = await page.locator("#conversation-panel").textContent();
+  if (!(text ?? "").includes("MCP servers are still starting")) {
+    throw new Error(`ready-check did not report MCP startup as a pending state:\n${(text ?? "").slice(-1_800)}`);
+  }
+  if ((text ?? "").includes("Benchmark task packet dispatched")) {
+    throw new Error(`ready-check should not dispatch a task packet while MCP startup is pending:\n${(text ?? "").slice(-1_800)}`);
+  }
+  return {
+    conversationTail: (text ?? "").slice(-1_200),
+  };
+}
+
 async function exerciseOperatorBenchmarkReadyCheckBlocksOnConfirmationPrompt(page) {
   await exerciseOperatorCommandStartsAllWorkerPanes(page, {
     projectName: "operator-ready-check-confirmation-prompt-project",
@@ -1873,6 +1898,9 @@ async function main() {
       });
       await runStep("operator benchmark ready-check stops on worker MCP warnings", async () => {
         return await exerciseOperatorBenchmarkReadyCheckBlocksOnMcpWarning(page);
+      });
+      await runStep("operator benchmark ready-check waits for Codex MCP startup", async () => {
+        return await exerciseOperatorBenchmarkReadyCheckWaitsForMcpStartup(page);
       });
       await runStep("operator benchmark ready-check stops on confirmation prompts", async () => {
         return await exerciseOperatorBenchmarkReadyCheckBlocksOnConfirmationPrompt(page);

--- a/winsmux-app/src-tauri/src/lib.rs
+++ b/winsmux-app/src-tauri/src/lib.rs
@@ -783,6 +783,8 @@ fn build_pty_command(workspace_dir: &Path) -> CommandBuilder {
     let mut cmd = CommandBuilder::new("pwsh");
     cmd.arg("-NoLogo");
     cmd.cwd(workspace_dir.as_os_str());
+    cmd.env("TERM", "xterm-256color");
+    cmd.env("COLORTERM", "truecolor");
     cmd.env_remove(WINSMUX_CONTROL_PIPE_TOKEN_ENV);
     cmd
 }
@@ -1318,6 +1320,16 @@ mod tests {
         assert_eq!(
             command.get_cwd().and_then(|value| value.to_str()),
             Some("C:\\repo\\winsmux")
+        );
+        assert_eq!(
+            command.get_env("TERM").and_then(|value| value.to_str()),
+            Some("xterm-256color")
+        );
+        assert_eq!(
+            command
+                .get_env("COLORTERM")
+                .and_then(|value| value.to_str()),
+            Some("truecolor")
         );
         assert!(command.get_env(WINSMUX_CONTROL_PIPE_TOKEN_ENV).is_none());
     }

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -3720,6 +3720,11 @@ function compactWorkerReadinessOutput(output: string) {
   return output.replace(/[\s\u00a0·•∙・]+/g, "").toLowerCase();
 }
 
+function workerReadinessOutputContains(text: string, expected: string) {
+  return text.includes(expected)
+    || compactWorkerReadinessOutput(text).includes(compactWorkerReadinessOutput(expected));
+}
+
 function appendPaneOutputBuffer(entry: PaneEntry, data: string) {
   entry.outputBuffer += data;
   if (entry.outputBuffer.length > 16_000) {
@@ -3749,6 +3754,32 @@ function detectWorkerReadinessBlocker(text: string) {
       reason: getLanguageText("Worker is waiting for a user decision", "ワーカーがユーザー判断待ちです"),
       pattern: /(?:waiting\s+for\s+(?:approval|confirmation)|continue\s+anyway\?\s+\[y\/n\]|continue\?|確認待ち|どう進めますか)/i,
       compactPattern: /(?:waitingfor(?:approval|confirmation)|continueanyway\?\[y\/n\]|continue\?)/,
+    },
+  ];
+
+  return checks.find((check) => check.pattern.test(text) || check.compactPattern.test(compactText))?.reason ?? "";
+}
+
+function detectWorkerReadinessPendingReason(text: string) {
+  const compactText = compactWorkerReadinessOutput(text);
+  const checks = [
+    {
+      reason: getLanguageText("MCP servers are still starting", "MCP サーバー起動中です"),
+      pattern: /(?:starting\s+mcp\s+servers?\s+\(\d+\/\d+\)|starting\s+mcp\s+servers?)/i,
+      compactPattern: /startingmcpservers?(?:\(\d+\/\d+\))?/,
+    },
+  ];
+
+  return checks.find((check) => check.pattern.test(text) || check.compactPattern.test(compactText))?.reason ?? "";
+}
+
+function detectWorkerLaunchPendingReason(text: string) {
+  const compactText = compactWorkerReadinessOutput(text);
+  const checks = [
+    {
+      reason: getLanguageText("Agent CLI launch is still in progress", "エージェント CLI の起動中です"),
+      pattern: /(?:\b(?:agy|codex|claude|grok)\b\s+(?:--model|-c|--dangerously|--print|--permission-mode)|PowerShell\s+\d+\.\d+\.\d+)/i,
+      compactPattern: /(?:\bagy\b|\bcodex\b|\bclaude\b|\bgrok\b)(?:--model|-c|--dangerously|--print|--permission-mode)/,
     },
   ];
 
@@ -3817,7 +3848,12 @@ async function inspectWorkerPaneReadiness(
     return { target, state: "blocked", reason: blocker, evidence };
   }
 
-  if (expectedProbeLine && text.includes(expectedProbeLine)) {
+  const pendingReason = detectWorkerReadinessPendingReason(text);
+  if (pendingReason) {
+    return { target, state: "pending", reason: pendingReason, evidence };
+  }
+
+  if (expectedProbeLine && workerReadinessOutputContains(text, expectedProbeLine)) {
     return {
       target,
       state: "ready",
@@ -3833,6 +3869,11 @@ async function inspectWorkerPaneReadiness(
       reason: getLanguageText("Worker prompt is available", "ワーカーの入力待ちを確認しました"),
       evidence,
     };
+  }
+
+  const launchPendingReason = detectWorkerLaunchPendingReason(text);
+  if (launchPendingReason) {
+    return { target, state: "pending", reason: launchPendingReason, evidence };
   }
 
   return {
@@ -3963,13 +4004,17 @@ async function waitForWorkerPaneReadiness(
     await new Promise((resolve) => window.setTimeout(resolve, WORKER_READINESS_POLL_MS));
   }
 
-  return latest.map((item) => item.state === "ready"
-    ? item
-    : {
-        ...item,
-        state: "pending",
-        reason: getLanguageText("Timed out while checking worker readiness", "ワーカー投入前確認がタイムアウトしました"),
-      });
+  return latest.map((item) => {
+    if (item.state === "ready") {
+      return item;
+    }
+    const timeoutReason = getLanguageText("Timed out while checking worker readiness", "ワーカー投入前確認がタイムアウトしました");
+    return {
+      ...item,
+      state: "pending",
+      reason: item.reason ? `${timeoutReason}: ${item.reason}` : timeoutReason,
+    };
+  });
 }
 
 async function startAllWorkersFromOperatorCommand(timestamp: string): Promise<boolean> {
@@ -17962,7 +18007,6 @@ window.addEventListener("DOMContentLoaded", async () => {
       try {
         if (isOperatorHandledWinsmuxCommand(value) && submittedAttachments.length === 0) {
           appendUserMessage(rawValue, submittedAttachments, timestamp);
-          await handleOperatorWinsmuxCommand(value, submittedAttachments, timestamp);
           pushComposerHistoryEntry(historyEntry);
           composerInput.value = "";
           clearVoiceDraftRecoveryStorage();
@@ -17972,6 +18016,7 @@ window.addEventListener("DOMContentLoaded", async () => {
           selectedComposerRemoteReferenceIds.clear();
           renderComposerRemoteReferences();
           renderAttachmentTray();
+          await handleOperatorWinsmuxCommand(value, submittedAttachments, timestamp);
           requestDesktopSummaryRefresh(undefined, 750);
           return;
         }


### PR DESCRIPTION
## Summary
- Set `TERM=xterm-256color` and `COLORTERM=truecolor` for Tauri PTY worker sessions so Codex workers do not pause on terminal capability prompts.
- Keep operator benchmark readiness blocked while worker MCP servers are still starting, and preserve the concrete pending reason when the readiness check times out.
- Add desktop E2E coverage for the MCP-starting state before benchmark dispatch.

## Validation
- `npm run build`
- `git diff --check`
- `node scripts/desktop-pane-e2e.mjs --worker-start-only` passed before this commit and produced `winsmux-app/output/playwright/desktop-worker-start-e2e/desktop-pane-e2e.json` with `ok: true`.
- `cargo test build_pty_command_sets_workspace_cwd` passed for the PTY environment test before this commit.

## Benchmark Status
No official Harness Bench task packet was dispatched by this PR. The operator readiness path now stops before dispatch if any worker is still waiting on MCP startup, authentication, quota, API setup, or a user decision.

## Risk
Low. The PTY environment change only affects worker session startup, and the readiness changes make benchmark dispatch stricter rather than more permissive.
