### PR TITLE
fix(app): treat prompt-ready MCP notices as warnings

### DIFF
--- a/winsmux-app/scripts/desktop-pane-e2e.mjs
+++ b/winsmux-app/scripts/desktop-pane-e2e.mjs
@@ -1697,6 +1697,12 @@ async function exerciseOperatorBenchmarkReadyCheckAllowsPromptReadyMcpWarning(pa
     scriptName: "operator-start-all-worker-mcp-warning.ps1",
     scriptLines: [
       "Write-Output 'DESKTOP_ALL_WORKERS_START_OK'",
+      "Write-Output 'claude --permission-mode bypassPermissions'",
+      "Write-Output 'Claude Code v2.1.195'",
+      "Write-Output '❯ Try \"fix typecheck errors\"'",
+      "Write-Output 'OpenAI Codex (v0.142.3)'",
+      "Write-Output '⚠ MCP startup incomplete (failed: figma)'",
+      "Write-Output '› Improve documentation in @filename'",
       "Write-Output 'MCP startup incomplete (failed: figma)'",
       "Write-Output '3 MCP servers need authentication - run /mcp'",
       "Write-Output '‼3MCPserversneedauthentication·run/mcp'",
@@ -1781,6 +1787,9 @@ async function exerciseOperatorBenchmarkDispatchAllowsPromptReadyMcpWarning(page
     scriptName: "operator-dispatch-mcp-warning.ps1",
     scriptLines: [
       "Write-Output 'DESKTOP_ALL_WORKERS_START_OK'",
+      "Write-Output 'OpenAI Codex (v0.142.3)'",
+      "Write-Output '⚠ MCP startup incomplete (failed: figma)'",
+      "Write-Output '› Improve documentation in @filename'",
       "Write-Output 'MCP startup incomplete (failed: figma)'",
       "Write-Output '3 MCP servers need authentication - run /mcp'",
       "Write-Output ($args -join ' ')",

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -3804,8 +3804,11 @@ function hasWorkerReadyPrompt(text: string) {
     .map((line) => line.trim())
     .filter(Boolean)
     .slice(-10);
-  return recentLines.some((line) => /^(?:[>›❯]|PS\s+.+>|.*>\s*)$/.test(line))
-    || /(?:Claude Code v|OpenAI Codex|Antigravity CLI|Grok Build)[\s\S]{0,1200}(?:^|\n)\s*[>›❯]\s*$/i.test(text)
+  return recentLines.some((line) => /^(?:[>›❯])/.test(line)
+      || /^api_llm\[worker\]>\s*$/i.test(line)
+      || /Grok\s+Build/i.test(line))
+    || /(?:Claude Code v|OpenAI Codex|Antigravity CLI|Grok Build)[\s\S]{0,1200}(?:^|\n)\s*[>›❯]/i.test(text)
+    || (compactText.includes("claudecodev") && compactText.includes("❯try"))
     || (compactText.includes("grokbuild") && /[>›❯]/.test(text));
 }
 
@@ -3861,6 +3864,16 @@ async function inspectWorkerPaneReadiness(
     return { target, state: "blocked", reason: blocker, evidence, warnings };
   }
 
+  if (hasWorkerReadyPrompt(text)) {
+    return {
+      target,
+      state: "ready",
+      reason: getLanguageText("Worker prompt is available", "ワーカーの入力待ちを確認しました"),
+      evidence,
+      warnings,
+    };
+  }
+
   const pendingReason = detectWorkerReadinessPendingReason(text);
   if (pendingReason) {
     return { target, state: "pending", reason: pendingReason, evidence, warnings };
@@ -3876,7 +3889,7 @@ async function inspectWorkerPaneReadiness(
     };
   }
 
-  if (/DESKTOP_(?:ALL_WORKERS_START|WORKER_START)_OK/.test(text) || hasWorkerReadyPrompt(text)) {
+  if (/DESKTOP_(?:ALL_WORKERS_START|WORKER_START)_OK/.test(text)) {
     return {
       target,
       state: "ready",


### PR DESCRIPTION
## Summary
- Treat prompt-ready MCP notices as warnings instead of hard blockers.
- Keep MCP startup, confirmation prompts, missing credentials, quota warnings, and setup blockers as hard stops.
- Extend desktop pane E2E coverage for realistic prompt-ready MCP warning output.

## Why
The v0.36.23 benchmark preflight can only start when the operator can determine that all six worker panes are ready from the operator lane. Claude/Codex workers can show MCP warning text while still exposing an input prompt. Those cases should be recorded as warnings, not mistaken for blocked workers.

## Test Plan
- `npm run build`
- `node scripts/desktop-pane-e2e.mjs --worker-start-only`
- `git diff --check HEAD~1..HEAD`
- Production desktop smoke through `scripts\start-cli-bakeoff-desktop.ps1 -Json -VisibleWidth 1440 -VisibleHeight 900`
- Operator-only smoke: `winsmux workers start all` then `winsmux benchmark ready-check`

## Benchmark Status
Formal Harness Bench tasks were not dispatched in this PR. The operator-only readiness path has been verified and the goal remains paused before benchmark dispatch.
