### PR TITLE
fix(app): harden benchmark dispatch readiness

### DIFF
--- a/winsmux-app/scripts/desktop-pane-e2e.mjs
+++ b/winsmux-app/scripts/desktop-pane-e2e.mjs
@@ -1691,7 +1691,7 @@ async function exerciseOperatorCommandStartsAllWorkerPanes(page, options = {}) {
   return outputs;
 }
 
-async function exerciseOperatorBenchmarkReadyCheckAllowsPromptReadyMcpWarning(page) {
+async function exerciseOperatorBenchmarkReadyCheckBlocksOnPromptReadyMcpWarning(page) {
   await exerciseOperatorCommandStartsAllWorkerPanes(page, {
     projectName: "operator-ready-check-mcp-warning-project",
     scriptName: "operator-start-all-worker-mcp-warning.ps1",
@@ -1711,7 +1711,7 @@ async function exerciseOperatorBenchmarkReadyCheckAllowsPromptReadyMcpWarning(pa
     ],
   });
   await submitWinsmuxComposerCommandWithButton(page, "winsmux benchmark ready-check");
-  await page.locator("#conversation-panel", { hasText: "Benchmark start readiness confirmed" }).waitFor({ state: "visible", timeout: 60_000 });
+  await page.locator("#conversation-panel", { hasText: "Benchmark start readiness blocked" }).waitFor({ state: "visible", timeout: 60_000 });
   const text = await page.locator("#conversation-panel").textContent();
   const metaState = await page.evaluate(() => {
     return Array.from(document.querySelectorAll(".pane")).map((pane) => {
@@ -1725,8 +1725,8 @@ async function exerciseOperatorBenchmarkReadyCheckAllowsPromptReadyMcpWarning(pa
   if (!combined.includes("MCP warning is present")) {
     throw new Error(`ready-check did not record the MCP warning:\n${combined.slice(-1_800)}`);
   }
-  if (combined.includes("Benchmark start readiness blocked")) {
-    throw new Error(`ready-check blocked despite a prompt-ready worker with only MCP warnings:\n${combined.slice(-1_800)}`);
+  if (combined.includes("Benchmark start readiness confirmed")) {
+    throw new Error(`ready-check confirmed despite worker MCP warnings:\n${combined.slice(-1_800)}`);
   }
   return {
     conversationTail: (text ?? "").slice(-1_200),
@@ -1781,7 +1781,7 @@ async function exerciseOperatorBenchmarkReadyCheckBlocksOnConfirmationPrompt(pag
   };
 }
 
-async function exerciseOperatorBenchmarkDispatchAllowsPromptReadyMcpWarning(page) {
+async function exerciseOperatorBenchmarkDispatchBlocksOnPromptReadyMcpWarning(page) {
   await exerciseOperatorCommandStartsAllWorkerPanes(page, {
     projectName: "operator-dispatch-mcp-warning-project",
     scriptName: "operator-dispatch-mcp-warning.ps1",
@@ -1797,7 +1797,7 @@ async function exerciseOperatorBenchmarkDispatchAllowsPromptReadyMcpWarning(page
     ],
   });
   await submitWinsmuxComposerCommandWithButton(page, "winsmux benchmark dispatch WB-001");
-  await page.locator("#conversation-panel", { hasText: "Benchmark task packet dispatched" }).waitFor({ state: "visible", timeout: 60_000 });
+  await page.locator("#conversation-panel", { hasText: "Benchmark dispatch blocked" }).waitFor({ state: "visible", timeout: 60_000 });
   const text = await page.locator("#conversation-panel").textContent();
   const outputs = {};
   for (let index = 1; index <= 6; index += 1) {
@@ -1808,8 +1808,8 @@ async function exerciseOperatorBenchmarkDispatchAllowsPromptReadyMcpWarning(page
   if (!combined.includes("MCP warning is present")) {
     throw new Error(`benchmark dispatch did not record the MCP warning:\n${combined.slice(-1_800)}`);
   }
-  if (!combined.includes("WINSMUX_BENCH_TASK_PACKET")) {
-    throw new Error(`benchmark dispatch did not send a task packet to prompt-ready workers with MCP warnings:\n${combined.slice(-1_800)}`);
+  if (combined.includes("WINSMUX_BENCH_TASK_PACKET")) {
+    throw new Error(`benchmark dispatch sent a task packet despite worker MCP warnings:\n${combined.slice(-1_800)}`);
   }
   return {
     conversationTail: (text ?? "").slice(-1_200),
@@ -1908,8 +1908,8 @@ async function main() {
       await runStep("worker start button launches the selected Tauri worker pane", async () => {
         return await exerciseWorkerStartButton(page);
       });
-      await runStep("operator benchmark ready-check records prompt-ready MCP warnings", async () => {
-        return await exerciseOperatorBenchmarkReadyCheckAllowsPromptReadyMcpWarning(page);
+      await runStep("operator benchmark ready-check blocks on prompt-ready MCP warnings", async () => {
+        return await exerciseOperatorBenchmarkReadyCheckBlocksOnPromptReadyMcpWarning(page);
       });
       await runStep("operator benchmark ready-check waits for Codex MCP startup", async () => {
         return await exerciseOperatorBenchmarkReadyCheckWaitsForMcpStartup(page);
@@ -1917,8 +1917,8 @@ async function main() {
       await runStep("operator benchmark ready-check stops on confirmation prompts", async () => {
         return await exerciseOperatorBenchmarkReadyCheckBlocksOnConfirmationPrompt(page);
       });
-      await runStep("operator benchmark dispatch records prompt-ready MCP warnings", async () => {
-        return await exerciseOperatorBenchmarkDispatchAllowsPromptReadyMcpWarning(page);
+      await runStep("operator benchmark dispatch blocks on prompt-ready MCP warnings", async () => {
+        return await exerciseOperatorBenchmarkDispatchBlocksOnPromptReadyMcpWarning(page);
       });
       await runStep("operator composer command starts all worker panes", async () => {
         return await exerciseOperatorCommandStartsAllWorkerPanes(page);

--- a/winsmux-app/src-tauri/src/desktop_backend.rs
+++ b/winsmux-app/src-tauri/src/desktop_backend.rs
@@ -237,6 +237,14 @@ pub struct DesktopEditorFilePayload {
 }
 
 #[derive(Serialize, Deserialize)]
+pub struct DesktopFullFilePayload {
+    pub path: String,
+    pub content: String,
+    pub byte_count: usize,
+    pub line_count: usize,
+}
+
+#[derive(Serialize, Deserialize)]
 pub struct DesktopExplorerEntry {
     pub path: String,
     pub kind: String,
@@ -1531,6 +1539,7 @@ pub fn handle_desktop_json_rpc(
                     "desktop.dogfood.event",
                     "desktop.explorer.list",
                     "desktop.editor.read",
+                    "desktop.file.read_full",
                 ],
             }),
         ),
@@ -1813,6 +1822,27 @@ pub fn handle_desktop_json_rpc(
                         request_id,
                         JSON_RPC_INTERNAL_ERROR,
                         format!("Failed to serialize desktop editor payload: {err}"),
+                    ),
+                },
+                Err(err) => json_rpc_error(request_id, JSON_RPC_SERVER_ERROR, err),
+            }
+        }
+        "desktop.file.read_full" => {
+            let path = match get_required_string_param(params.as_ref(), &["path"]) {
+                Ok(value) => value,
+                Err(err) => {
+                    return json_rpc_error(request_id, JSON_RPC_INVALID_PARAMS, err);
+                }
+            };
+            let worktree = get_optional_string_param(params.as_ref(), &["worktree"]);
+
+            match read_desktop_full_file(resolved_project_dir, worktree, &path) {
+                Ok(result) => match serde_json::to_value(result) {
+                    Ok(value) => json_rpc_result(request_id, value),
+                    Err(err) => json_rpc_error(
+                        request_id,
+                        JSON_RPC_INTERNAL_ERROR,
+                        format!("Failed to serialize desktop full file payload: {err}"),
                     ),
                 },
                 Err(err) => json_rpc_error(request_id, JSON_RPC_SERVER_ERROR, err),
@@ -2412,6 +2442,65 @@ fn read_desktop_editor_file(
         content,
         line_count,
         truncated,
+    })
+}
+
+fn resolve_desktop_project_relative_file(
+    project_dir: Option<String>,
+    worktree: Option<String>,
+    relative_path: &str,
+    operation: &str,
+) -> Result<(PathBuf, PathBuf), String> {
+    let read_root = resolve_desktop_read_root(project_dir, worktree)?;
+    let requested_path = PathBuf::from(relative_path);
+    if requested_path.is_absolute() {
+        return Err(format!("{operation} expects a project-relative path"));
+    }
+
+    let full_path = read_root.join(&requested_path);
+    let normalized_full_path = full_path
+        .canonicalize()
+        .map_err(|err| format!("Failed to resolve file path: {err}"))?;
+
+    if !normalized_full_path.starts_with(&read_root) {
+        return Err(format!(
+            "{operation} rejected a path outside the selected worktree"
+        ));
+    }
+
+    Ok((requested_path, normalized_full_path))
+}
+
+fn read_desktop_full_file(
+    project_dir: Option<String>,
+    worktree: Option<String>,
+    relative_path: &str,
+) -> Result<DesktopFullFilePayload, String> {
+    let (requested_path, normalized_full_path) = resolve_desktop_project_relative_file(
+        project_dir,
+        worktree,
+        relative_path,
+        "desktop.file.read_full",
+    )?;
+    let bytes = fs::read(&normalized_full_path)
+        .map_err(|err| format!("Failed to read full file: {err}"))?;
+    const MAX_FULL_FILE_BYTES: usize = 1024 * 1024;
+    if bytes.len() > MAX_FULL_FILE_BYTES {
+        return Err(format!(
+            "desktop.file.read_full rejected a file larger than {} bytes",
+            MAX_FULL_FILE_BYTES
+        ));
+    }
+    let content = String::from_utf8(bytes)
+        .map_err(|err| format!("Failed to decode full file as UTF-8: {err}"))?;
+    let line_count = content.lines().count().max(1);
+    let byte_count = content.as_bytes().len();
+
+    Ok(DesktopFullFilePayload {
+        path: requested_path.to_string_lossy().replace('\\', "/"),
+        content,
+        byte_count,
+        line_count,
     })
 }
 
@@ -5098,6 +5187,90 @@ mod tests {
                 panic!("expected success, got {:?}", error);
             }
         }
+
+        let _ = std::fs::remove_dir_all(temp_dir);
+    }
+
+    #[test]
+    fn handle_desktop_json_rpc_full_file_read_is_not_preview_truncated() {
+        let temp_dir = std::env::temp_dir().join(format!(
+            "winsmux-desktop-full-file-read-{}",
+            std::process::id()
+        ));
+        let target_file = temp_dir
+            .join("tasks")
+            .join("cli-bakeoff")
+            .join("v1")
+            .join("benchmark-pack.json");
+        let large_content = format!(
+            "{{\"pack_id\":\"large\",\"payload\":\"{}\"}}\n",
+            "x".repeat(40 * 1024)
+        );
+
+        let _ = std::fs::remove_dir_all(&temp_dir);
+        std::fs::create_dir_all(target_file.parent().unwrap()).unwrap();
+        std::fs::write(&target_file, &large_content).unwrap();
+
+        let transport = FakeTransport {
+            requests: RefCell::new(Vec::new()),
+            response: serde_json::json!({}),
+        };
+
+        let preview_response = handle_desktop_json_rpc(
+            &transport,
+            DesktopJsonRpcRequest {
+                jsonrpc: "2.0".to_string(),
+                id: serde_json::json!("req-preview"),
+                method: "desktop.editor.read".to_string(),
+                params: Some(serde_json::json!({
+                    "path": "tasks/cli-bakeoff/v1/benchmark-pack.json"
+                })),
+            },
+            Some(temp_dir.to_string_lossy().to_string()),
+        );
+
+        match preview_response {
+            DesktopJsonRpcResponse::Success { result, .. } => {
+                assert_eq!(result["path"], "tasks/cli-bakeoff/v1/benchmark-pack.json");
+                assert_eq!(result["truncated"], true);
+                assert!(
+                    result["content"].as_str().unwrap_or_default().len() < large_content.len()
+                );
+            }
+            DesktopJsonRpcResponse::Error { error, .. } => {
+                panic!("expected preview success, got {:?}", error);
+            }
+        }
+
+        let full_response = handle_desktop_json_rpc(
+            &transport,
+            DesktopJsonRpcRequest {
+                jsonrpc: "2.0".to_string(),
+                id: serde_json::json!("req-full"),
+                method: "desktop.file.read_full".to_string(),
+                params: Some(serde_json::json!({
+                    "path": "tasks/cli-bakeoff/v1/benchmark-pack.json"
+                })),
+            },
+            Some(temp_dir.to_string_lossy().to_string()),
+        );
+
+        match full_response {
+            DesktopJsonRpcResponse::Success { id, result, .. } => {
+                assert_eq!(id, serde_json::json!("req-full"));
+                assert_eq!(result["path"], "tasks/cli-bakeoff/v1/benchmark-pack.json");
+                assert_eq!(
+                    result["byte_count"].as_u64(),
+                    Some(large_content.as_bytes().len() as u64)
+                );
+                assert_eq!(result["content"].as_str(), Some(large_content.as_str()));
+            }
+            DesktopJsonRpcResponse::Error { error, .. } => {
+                panic!("expected full file read success, got {:?}", error);
+            }
+        }
+
+        assert!(transport.requests.borrow().is_empty());
 
         let _ = std::fs::remove_dir_all(temp_dir);
     }

--- a/winsmux-app/src/desktopClient.ts
+++ b/winsmux-app/src/desktopClient.ts
@@ -16,6 +16,7 @@ type DesktopCommandName =
   | "desktop_voice_capture_stop"
   | "desktop_dogfood_event"
   | "desktop_editor_read"
+  | "desktop_file_read_full"
   | "desktop_explorer_list";
 type DesktopJsonRpcMethod =
   | "desktop.summary.snapshot"
@@ -30,6 +31,7 @@ type DesktopJsonRpcMethod =
   | "desktop.voice.capture_status"
   | "desktop.dogfood.event"
   | "desktop.editor.read"
+  | "desktop.file.read_full"
   | "desktop.explorer.list";
 
 interface DesktopJsonRpcRequest {
@@ -475,6 +477,13 @@ export interface DesktopEditorFilePayload {
   truncated: boolean;
 }
 
+export interface DesktopFullFilePayload {
+  path: string;
+  content: string;
+  byte_count: number;
+  line_count: number;
+}
+
 export interface DesktopExplorerEntry {
   path: string;
   kind: "directory" | "file";
@@ -816,6 +825,8 @@ function getDesktopJsonRpcMethod(command: DesktopCommandName): DesktopJsonRpcMet
       return "desktop.dogfood.event";
     case "desktop_editor_read":
       return "desktop.editor.read";
+    case "desktop_file_read_full":
+      return "desktop.file.read_full";
     case "desktop_explorer_list":
       return "desktop.explorer.list";
   }
@@ -1106,6 +1117,24 @@ export async function getDesktopEditorFile(
   } catch (error) {
     const worktreeSuffix = worktree ? `, ${worktree}` : "";
     throw normalizeDesktopError(`desktop_editor_read(${path}${worktreeSuffix})`, error);
+  }
+}
+
+export async function getDesktopFullFile(
+  path: string,
+  worktree?: string,
+  projectDir?: string | null,
+) {
+  try {
+    return await desktopCommandTransport.request<DesktopFullFilePayload>(
+      "desktop_file_read_full",
+      worktree
+        ? { path, worktree, ...buildProjectDirPayload(projectDir) }
+        : { path, ...buildProjectDirPayload(projectDir) },
+    );
+  } catch (error) {
+    const worktreeSuffix = worktree ? `, ${worktree}` : "";
+    throw normalizeDesktopError(`desktop_file_read_full(${path}${worktreeSuffix})`, error);
   }
 }
 

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -9,6 +9,7 @@ import {
   applyDesktopRuntimeRolePreferences,
   compareDesktopRuns,
   getDesktopEditorFile,
+  getDesktopFullFile,
   getDesktopInitialProjectDir,
   getDesktopRunExplain,
   getDesktopExplorerEntries,
@@ -3973,10 +3974,7 @@ async function loadHarnessBenchmarkTaskPacket(taskId: string): Promise<HarnessBe
     throw new Error("Benchmark task id is required.");
   }
   const packPath = "tasks/cli-bakeoff/v1/benchmark-pack.json";
-  const packFile = await getDesktopEditorFile(packPath, undefined, activeProjectDir);
-  if (packFile.truncated) {
-    throw new Error(`${packPath} is truncated and cannot be used for benchmark dispatch.`);
-  }
+  const packFile = await getDesktopFullFile(packPath, undefined, activeProjectDir);
   const pack = parseHarnessBenchmarkPack(packFile.content);
   const task = (pack.tasks ?? []).find((item) => String(item.task_id || "").trim().toLowerCase() === normalizedTaskId.toLowerCase());
   if (!task) {
@@ -3987,10 +3985,7 @@ async function loadHarnessBenchmarkTaskPacket(taskId: string): Promise<HarnessBe
     throw new Error(`Benchmark task ${normalizedTaskId} has an invalid packet_path.`);
   }
   const packetRelativePath = `tasks/cli-bakeoff/v1/${packetPath}`;
-  const packetFile = await getDesktopEditorFile(packetRelativePath, undefined, activeProjectDir);
-  if (packetFile.truncated) {
-    throw new Error(`${packetRelativePath} is truncated and cannot be used for benchmark dispatch.`);
-  }
+  const packetFile = await getDesktopFullFile(packetRelativePath, undefined, activeProjectDir);
   const prompt = buildHarnessTaskPrompt(pack, task, packetFile.content);
   const timeoutSeconds = Number(task.timeout_seconds || pack.default_timeout_seconds || 3600);
   return {

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -3734,6 +3734,10 @@ function appendPaneOutputBuffer(entry: PaneEntry, data: string) {
   }
 }
 
+function getWorkerPaneVisibleText(entry: PaneEntry) {
+  return (entry.container.innerText || entry.container.textContent || "").trim();
+}
+
 function detectWorkerReadinessBlocker(text: string) {
   const compactText = compactWorkerReadinessOutput(text);
   const checks = [
@@ -3798,19 +3802,24 @@ function detectWorkerLaunchPendingReason(text: string) {
   return checks.find((check) => check.pattern.test(text) || check.compactPattern.test(compactText))?.reason ?? "";
 }
 
+function isWorkerLaunchCommandEcho(line: string) {
+  return /^[>›❯]\s*(?:claude|codex|agy|grok|pwsh|powershell)\b/i.test(line)
+    || /^PS\s+.+>\s*(?:claude|codex|agy|grok|pwsh|powershell)\b/i.test(line);
+}
+
 function hasWorkerReadyPrompt(text: string) {
-  const compactText = compactWorkerReadinessOutput(text);
   const recentLines = text
     .split("\n")
     .map((line) => line.trim())
     .filter(Boolean)
     .slice(-10);
-  return recentLines.some((line) => /^(?:[>›❯])/.test(line)
-      || /^api_llm\[worker\]>\s*$/i.test(line)
-      || /Grok\s+Build/i.test(line))
-    || /(?:Claude Code v|OpenAI Codex|Antigravity CLI|Grok Build)[\s\S]{0,1200}(?:^|\n)\s*[>›❯]/i.test(text)
-    || (compactText.includes("claudecodev") && compactText.includes("❯try"))
-    || (compactText.includes("grokbuild") && /[>›❯]/.test(text));
+  const hasGrokInputBox = recentLines.some((line) => /^│\s*>\s*│?$/.test(line))
+    && recentLines.some((line) => /Grok\s+Build/i.test(line));
+  return hasGrokInputBox
+    || recentLines.some((line) => !isWorkerLaunchCommandEcho(line)
+      && (/^api_llm\[worker\]>\s*$/i.test(line)
+        || /^(?:[>›❯])\s*$/.test(line)
+        || /^(?:[>›❯])\s*(?!(?:claude|codex|agy|grok|pwsh|powershell)\b)\S/i.test(line)));
 }
 
 async function inspectWorkerPaneReadiness(
@@ -3837,7 +3846,11 @@ async function inspectWorkerPaneReadiness(
 
   let output = "";
   try {
-    output = `${entry.outputBuffer}\n${(await capturePtyPane(target)).output}`;
+    output = [
+      entry.outputBuffer,
+      getWorkerPaneVisibleText(entry),
+      (await capturePtyPane(target)).output,
+    ].filter(Boolean).join("\n");
   } catch (error) {
     return {
       target,
@@ -3865,11 +3878,11 @@ async function inspectWorkerPaneReadiness(
     return { target, state: "blocked", reason: blocker, evidence, warnings };
   }
 
-  if (hasWorkerReadyPrompt(text)) {
+  if (warnings.length > 0) {
     return {
       target,
-      state: "ready",
-      reason: getLanguageText("Worker prompt is available", "ワーカーの入力待ちを確認しました"),
+      state: "blocked",
+      reason: getLanguageText("Worker has startup warnings", "ワーカーに起動警告があります"),
       evidence,
       warnings,
     };
@@ -3878,6 +3891,16 @@ async function inspectWorkerPaneReadiness(
   const pendingReason = detectWorkerReadinessPendingReason(text);
   if (pendingReason) {
     return { target, state: "pending", reason: pendingReason, evidence, warnings };
+  }
+
+  if (hasWorkerReadyPrompt(text)) {
+    return {
+      target,
+      state: "ready",
+      reason: getLanguageText("Worker prompt is available", "ワーカーの入力待ちを確認しました"),
+      evidence,
+      warnings,
+    };
   }
 
   if (expectedProbeLine && workerReadinessOutputContains(text, expectedProbeLine)) {

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -3999,17 +3999,42 @@ async function loadHarnessBenchmarkTaskPacket(taskId: string): Promise<HarnessBe
   };
 }
 
-async function writeWorkerBenchmarkSubmission(target: string, packet: HarnessBenchmarkTaskPacket) {
+function getWorkerBackendForSubmission(row: DesktopWorkerStatusRow) {
+  return (
+    getLaunchApprovalField(getWorkerStatusLaunch(row), "worker_backend")
+    || row.backend
+    || ""
+  ).trim().toLowerCase();
+}
+
+function getBenchmarkSubmissionRunId(dispatchId: string, target: string) {
+  return `${dispatchId}-${target}`.replace(/[^A-Za-z0-9._-]/g, "-");
+}
+
+async function writeWorkerBenchmarkSubmission(
+  target: string,
+  row: DesktopWorkerStatusRow,
+  packet: HarnessBenchmarkTaskPacket,
+  dispatchId: string,
+) {
   await ensurePanePtyStarted(target);
   if (isViewportHarnessMode()) {
     await writePtyData(target, `Write-Output 'WINSMUX_BENCH_TASK_PACKET ${packet.taskId} ${target} ${packet.sha256.slice(0, 12)}'\r`);
-    return;
+    return "viewport marker";
   }
+
+  if (getWorkerBackendForSubmission(row) === "api_llm") {
+    const runId = getBenchmarkSubmissionRunId(dispatchId, target);
+    await writePtyData(target, `exec ${packet.packetPath} ${packet.taskId} ${runId}\r`);
+    return "api_llm exec";
+  }
+
   await writePtyData(target, encodePtySubmission(packet.prompt));
   if (packet.prompt.includes("\n")) {
     await waitForOperatorSubmitDelay();
     await writePtyData(target, "\r");
   }
+  return "interactive prompt";
 }
 
 async function waitForWorkerPaneReadiness(
@@ -4466,8 +4491,17 @@ async function dispatchBenchmarkTaskFromOperatorCommand(
     }
 
     const packet = await loadHarnessBenchmarkTaskPacket(taskId);
-    for (const target of targets) {
-      await writeWorkerBenchmarkSubmission(target, packet);
+    const submissionDetails: ConversationDetail[] = [];
+    for (const row of rows) {
+      const target = getWorkerStatusTarget(row);
+      if (!target) {
+        continue;
+      }
+      const transport = await writeWorkerBenchmarkSubmission(target, row, packet, probeId);
+      submissionDetails.push({
+        label: target,
+        value: `${getWorkerBackendForSubmission(row) || "unknown"} / ${transport}`,
+      });
     }
 
     appendRuntimeConversation({
@@ -4487,6 +4521,7 @@ async function dispatchBenchmarkTaskFromOperatorCommand(
         { label: "sha256", value: packet.sha256 },
         { label: getLanguageText("worker panes", "ワーカーペイン"), value: targets.join(", ") },
         { label: getLanguageText("timeout", "制限時間"), value: `${packet.timeoutSeconds}s` },
+        ...submissionDetails,
         ...readinessDetails(readiness),
       ],
       tone: "success",


### PR DESCRIPTION
## Summary
- read full Harness Bench task packets through the desktop file API
- send API LLM worker benchmark packets through the api_llm exec command
- block benchmark readiness and dispatch when worker panes show MCP warnings or startup prompts
- avoid treating launch command echoes or stale CLI headers as worker-ready prompts

## Verification
- npm run build
- cargo test --manifest-path winsmux-app/src-tauri/Cargo.toml
- node scripts\\desktop-pane-e2e.mjs --worker-start-only
- git diff --check

## Benchmark impact
Formal Harness Bench task packets have not been sent by this PR. This PR only hardens the operator readiness gate and dispatch path before the v0.36.23 measurement run.