### PR TITLE
fix(workers): isolate benchmark panes from MCP startup warnings

### DIFF
--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -3864,6 +3864,7 @@ function Invoke-Role {
         -Model ([string]$roleAgentConfig.Model) `
         -ModelSource ([string]$roleAgentConfig.ModelSource) `
         -ReasoningEffort ([string]$roleAgentConfig.ReasoningEffort) `
+        -McpMode ([string]$roleAgentConfig.McpMode) `
         -ProjectDir $launchDir `
         -GitWorktreeDir $gitDir `
         -RootPath $projectDir
@@ -4456,6 +4457,7 @@ function New-LauncherSlotSummary {
         model_source               = [string]$effective.ModelSource
         reasoning_effort           = [string]$effective.ReasoningEffort
         prompt_transport           = [string]$effective.PromptTransport
+        mcp_mode                   = [string]$effective.McpMode
         auth_mode                  = [string]$effective.AuthMode
         auth_policy                = [string]$effective.AuthPolicy
         local_access_note          = [string]$effective.LocalAccessNote
@@ -5849,6 +5851,7 @@ function Get-WorkersStatusRows {
                 -Model ([string]$slotConfig.Model) `
                 -ModelSource ([string]$slotConfig.ModelSource) `
                 -ReasoningEffort ([string]$slotConfig.ReasoningEffort) `
+                -McpMode ([string]$slotConfig.McpMode) `
                 -ProjectDir $Context.ProjectDir `
                 -GitWorktreeDir $launchGitWorktreeDir `
                 -RootPath $Context.ProjectDir
@@ -5875,6 +5878,7 @@ function Get-WorkersStatusRows {
             ModelSource    = [string]$slotConfig.ModelSource
             ReasoningEffort = [string]$slotConfig.ReasoningEffort
             PromptTransport = [string]$slotConfig.PromptTransport
+            McpMode       = [string]$slotConfig.McpMode
             AuthMode       = [string]$slotConfig.AuthMode
             AuthPolicy     = [string]$slotConfig.AuthPolicy
             CapabilityAdapter = [string]$slotConfig.CapabilityAdapter
@@ -5990,6 +5994,7 @@ function ConvertTo-WorkersStatusJsonRows {
             model_source    = [string]$row.ModelSource
             reasoning_effort = [string]$row.ReasoningEffort
             prompt_transport = [string]$row.PromptTransport
+            mcp_mode        = [string]$row.McpMode
             auth_mode       = [string]$row.AuthMode
             auth_policy     = [string]$row.AuthPolicy
             capability_adapter = [string]$row.CapabilityAdapter

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -1824,6 +1824,40 @@ agent-slots:
             -RootPath $script:settingsTempRoot
 
         $providerDefaultSourceCommand | Should -Not -Match 'model=gpt-5\.4'
+
+        $previousCodexMcpDisableServers = $env:WINSMUX_CODEX_MCP_DISABLE_SERVERS
+        try {
+            $env:WINSMUX_CODEX_MCP_DISABLE_SERVERS = 'cua-driver,node_repl,figma'
+            $mcpDisabledCommand = Get-BridgeProviderLaunchCommand `
+                -ProviderId 'codex-local' `
+                -Model 'gpt-5.5' `
+                -ModelSource 'cli-discovery' `
+                -ReasoningEffort 'high' `
+                -McpMode 'disabled' `
+                -ProjectDir 'C:\Project Root' `
+                -GitWorktreeDir 'C:\Project Root\.git\worktrees\worker-2' `
+                -RootPath $script:settingsTempRoot
+        } finally {
+            $env:WINSMUX_CODEX_MCP_DISABLE_SERVERS = $previousCodexMcpDisableServers
+        }
+
+        $mcpDisabledCommand | Should -Match '--disable plugins'
+        $mcpDisabledCommand | Should -Match "-c 'mcp_servers\.cua-driver\.enabled=false'"
+        $mcpDisabledCommand | Should -Match "-c 'mcp_servers\.node_repl\.enabled=false'"
+        $mcpDisabledCommand | Should -Match "-c 'mcp_servers\.figma\.enabled=false'"
+
+        $mcpEnabledCommand = Get-BridgeProviderLaunchCommand `
+            -ProviderId 'codex-local' `
+            -Model 'gpt-5.5' `
+            -ModelSource 'cli-discovery' `
+            -ReasoningEffort 'high' `
+            -McpMode 'enabled' `
+            -ProjectDir 'C:\Project Root' `
+            -GitWorktreeDir 'C:\Project Root\.git\worktrees\worker-2' `
+            -RootPath $script:settingsTempRoot
+
+        $mcpEnabledCommand | Should -Not -Match '--disable plugins'
+        $mcpEnabledCommand | Should -Not -Match 'mcp_servers\.figma\.enabled=false'
     }
 
     It 'uses built-in launch command metadata for Antigravity and Grok Build providers' {
@@ -1850,6 +1884,34 @@ agent-slots:
 
         $grokCommand | Should -Be "grok --model 'grok-build'"
         $grokCommand | Should -Not -Match '^grok-build '
+    }
+
+    It 'adds Claude strict empty MCP config only when MCP mode is disabled' {
+        $mcpDisabledCommand = Get-BridgeProviderLaunchCommand `
+            -ProviderId 'claude' `
+            -Model 'claude-opus-4-8' `
+            -ModelSource 'operator-override' `
+            -ReasoningEffort 'high' `
+            -McpMode 'disabled' `
+            -ProjectDir 'C:\Project Root' `
+            -GitWorktreeDir 'C:\Project Root\.git\worktrees\worker-1' `
+            -RootPath $script:settingsTempRoot
+
+        $mcpDisabledCommand | Should -Match '--mcp-config'
+        $mcpDisabledCommand | Should -Match 'mcpServers'
+        $mcpDisabledCommand | Should -Match '--strict-mcp-config'
+
+        $mcpDefaultCommand = Get-BridgeProviderLaunchCommand `
+            -ProviderId 'claude' `
+            -Model 'claude-opus-4-8' `
+            -ModelSource 'operator-override' `
+            -ReasoningEffort 'high' `
+            -ProjectDir 'C:\Project Root' `
+            -GitWorktreeDir 'C:\Project Root\.git\worktrees\worker-1' `
+            -RootPath $script:settingsTempRoot
+
+        $mcpDefaultCommand | Should -Not -Match '--mcp-config'
+        $mcpDefaultCommand | Should -Not -Match '--strict-mcp-config'
     }
 
     It 'rejects structurally malformed provider capability registries' {
@@ -10715,6 +10777,66 @@ worker-backend: colab_cli
         $payload.workers[0].launch_command | Should -Match '--sandbox danger-full-access'
     }
 
+    It 'reports MCP-disabled launch commands for benchmark worker slots only when requested' {
+@'
+agent: codex
+model: provider-default
+agent-slots:
+  - slot-id: worker-1
+    runtime-role: worker
+    worker-backend: local
+    agent: claude
+    model: claude-opus-4-8
+    model-source: operator-override
+    reasoning-effort: high
+    mcp-mode: disabled
+    worktree-mode: managed
+  - slot-id: worker-2
+    runtime-role: worker
+    worker-backend: codex
+    agent: codex
+    model: gpt-5.5
+    model-source: operator-override
+    reasoning-effort: high
+    mcp-mode: disabled
+    worktree-mode: managed
+  - slot-id: worker-3
+    runtime-role: worker
+    worker-backend: local
+    agent: codex
+    model: gpt-5.5
+    model-source: operator-override
+    reasoning-effort: high
+    worktree-mode: managed
+'@ | Set-Content -Path (Join-Path $script:workersTempRoot '.winsmux.yaml') -Encoding UTF8
+
+        $previousCodexMcpDisableServers = $env:WINSMUX_CODEX_MCP_DISABLE_SERVERS
+        try {
+            $env:WINSMUX_CODEX_MCP_DISABLE_SERVERS = 'cua-driver,node_repl,figma'
+            $output = & pwsh -NoProfile -File $script:winsmuxWorkersCorePath workers status --json --project-dir $script:workersTempRoot
+        } finally {
+            $env:WINSMUX_CODEX_MCP_DISABLE_SERVERS = $previousCodexMcpDisableServers
+        }
+        $payload = ($output | Select-Object -Last 1) | ConvertFrom-Json
+        $claudeRow = @($payload.workers | Where-Object { $_.slot_id -eq 'worker-1' })[0]
+        $codexRow = @($payload.workers | Where-Object { $_.slot_id -eq 'worker-2' })[0]
+        $defaultMcpRow = @($payload.workers | Where-Object { $_.slot_id -eq 'worker-3' })[0]
+
+        $claudeRow.mcp_mode | Should -Be 'disabled'
+        $claudeRow.launch_command | Should -Match '--mcp-config'
+        $claudeRow.launch_command | Should -Match 'mcpServers'
+        $claudeRow.launch_command | Should -Match '--strict-mcp-config'
+        $codexRow.mcp_mode | Should -Be 'disabled'
+        $codexRow.launch_command | Should -Match '--disable plugins'
+        $codexRow.launch_command | Should -Match "mcp_servers\.cua-driver\.enabled=false"
+        $codexRow.launch_command | Should -Match "mcp_servers\.node_repl\.enabled=false"
+        $codexRow.launch_command | Should -Match "mcp_servers\.figma\.enabled=false"
+        $defaultMcpRow.mcp_mode | Should -Be ''
+        $defaultMcpRow.launch_command | Should -Not -Match '--disable plugins'
+        $defaultMcpRow.launch_command | Should -Not -Match 'mcp_servers\.figma\.enabled=false'
+        $defaultMcpRow.launch_command | Should -Not -Match '--mcp-config'
+    }
+
     It 'reports api_llm worker status with provider-hosted model metadata' {
         Write-WorkersApiLlmProjectConfig
 
@@ -18550,7 +18672,7 @@ Describe 'orchestra pane bootstrap plan' {
 
     It 'builds pane launch commands through provider capability metadata' {
         $script:orchestraStartContent | Should -Match 'Get-BridgeProviderLaunchCommand'
-        $script:orchestraStartContent | Should -Match 'Get-AgentLaunchCommand -Agent \$slotAgentConfig\.Agent -Model \$slotAgentConfig\.Model -ModelSource \$slotAgentConfig\.ModelSource -ReasoningEffort \$slotAgentConfig\.ReasoningEffort -ProjectDir \$launchDir -GitWorktreeDir \$launchGitWorktreeDir -RootPath \$projectDir'
+        $script:orchestraStartContent | Should -Match 'Get-AgentLaunchCommand -Agent \$slotAgentConfig\.Agent -Model \$slotAgentConfig\.Model -ModelSource \$slotAgentConfig\.ModelSource -ReasoningEffort \$slotAgentConfig\.ReasoningEffort -McpMode \$slotAgentConfig\.McpMode -ProjectDir \$launchDir -GitWorktreeDir \$launchGitWorktreeDir -RootPath \$projectDir'
     }
 
     It 'defers one-shot workers before resolving provider launch commands' {

--- a/winsmux-core/scripts/agent-launch.ps1
+++ b/winsmux-core/scripts/agent-launch.ps1
@@ -9,6 +9,7 @@ function Get-AgentLaunchCommand {
         [Parameter(Mandatory = $true)][AllowEmptyString()][string]$Model,
         [AllowEmptyString()][string]$ModelSource = '',
         [AllowEmptyString()][string]$ReasoningEffort = '',
+        [AllowEmptyString()][string]$McpMode = '',
         [Parameter(Mandatory = $true)][string]$ProjectDir,
         [Parameter(Mandatory = $true)][string]$GitWorktreeDir,
         [string]$RootPath,
@@ -20,6 +21,7 @@ function Get-AgentLaunchCommand {
         -Model $Model `
         -ModelSource $ModelSource `
         -ReasoningEffort $ReasoningEffort `
+        -McpMode $McpMode `
         -ProjectDir $ProjectDir `
         -GitWorktreeDir $GitWorktreeDir `
         -RootPath $RootPath `

--- a/winsmux-core/scripts/agent-monitor.ps1
+++ b/winsmux-core/scripts/agent-monitor.ps1
@@ -970,6 +970,7 @@ function Invoke-AgentRespawn {
         [Parameter(Mandatory = $true)][AllowEmptyString()][string]$Model,
         [AllowEmptyString()][string]$ModelSource = '',
         [AllowEmptyString()][string]$ReasoningEffort = '',
+        [AllowEmptyString()][string]$McpMode = '',
         [Parameter(Mandatory = $true)][string]$ProjectDir,
         [Parameter(Mandatory = $true)][string]$GitWorktreeDir,
         [string]$RootPath = '',
@@ -1005,6 +1006,7 @@ function Invoke-AgentRespawn {
             -Model $Model `
             -ModelSource $ModelSource `
             -ReasoningEffort $ReasoningEffort `
+            -McpMode $McpMode `
             -ProjectDir $ProjectDir `
             -GitWorktreeDir $GitWorktreeDir `
             -RootPath $capabilityRootPath
@@ -1588,6 +1590,7 @@ function Invoke-AgentMonitorCycle {
                 -PaneId $paneId `
                 -Agent $agentName `
                 -Model $modelName `
+                -McpMode ([string](Get-MonitorPropertyValue -InputObject $roleAgentConfig -Name 'McpMode' -Default '')) `
                 -ProjectDir $launchDir `
                 -GitWorktreeDir $launchGitWorktreeDir `
                 -RootPath $projectDir `

--- a/winsmux-core/scripts/orchestra-start.ps1
+++ b/winsmux-core/scripts/orchestra-start.ps1
@@ -957,6 +957,7 @@ function Get-AgentLaunchCommand {
         [Parameter(Mandatory = $true)][AllowEmptyString()][string]$Model,
         [AllowEmptyString()][string]$ModelSource = '',
         [AllowEmptyString()][string]$ReasoningEffort = '',
+        [AllowEmptyString()][string]$McpMode = '',
         [Parameter(Mandatory = $true)][string]$ProjectDir,
         [Parameter(Mandatory = $true)][string]$GitWorktreeDir,
         [string]$RootPath,
@@ -968,6 +969,7 @@ function Get-AgentLaunchCommand {
         -Model $Model `
         -ModelSource $ModelSource `
         -ReasoningEffort $ReasoningEffort `
+        -McpMode $McpMode `
         -ProjectDir $ProjectDir `
         -GitWorktreeDir $GitWorktreeDir `
         -RootPath $RootPath `
@@ -2414,7 +2416,7 @@ if ($MyInvocation.InvocationName -ne '.') {
         $oneShotPaneStartDeferred = $apiLlmPaneStartDeferred -or $antigravityPaneStartDeferred
         $launchCommand = ''
         if (-not $oneShotPaneStartDeferred) {
-            $launchCommand = Get-AgentLaunchCommand -Agent $slotAgentConfig.Agent -Model $slotAgentConfig.Model -ModelSource $slotAgentConfig.ModelSource -ReasoningEffort $slotAgentConfig.ReasoningEffort -ProjectDir $launchDir -GitWorktreeDir $launchGitWorktreeDir -RootPath $projectDir -ExecMode $false
+            $launchCommand = Get-AgentLaunchCommand -Agent $slotAgentConfig.Agent -Model $slotAgentConfig.Model -ModelSource $slotAgentConfig.ModelSource -ReasoningEffort $slotAgentConfig.ReasoningEffort -McpMode $slotAgentConfig.McpMode -ProjectDir $launchDir -GitWorktreeDir $launchGitWorktreeDir -RootPath $projectDir -ExecMode $false
         }
         if ([string]::Equals(([string]$slotAgentConfig.WorkerBackend), 'colab_cli', [System.StringComparison]::OrdinalIgnoreCase) -and $colabSessionMap.ContainsKey($label)) {
             $colabSessionEntry = $colabSessionMap[$label]

--- a/winsmux-core/scripts/pane-control.ps1
+++ b/winsmux-core/scripts/pane-control.ps1
@@ -231,6 +231,7 @@ function Get-PaneControlLaunchCommand {
         [Parameter(Mandatory = $true)][AllowEmptyString()][string]$Model,
         [AllowEmptyString()][string]$ModelSource = '',
         [AllowEmptyString()][string]$ReasoningEffort = '',
+        [AllowEmptyString()][string]$McpMode = '',
         [Parameter(Mandatory = $true)][string]$ProjectDir,
         [Parameter(Mandatory = $true)][string]$GitWorktreeDir,
         [string]$RootPath = ''
@@ -241,6 +242,7 @@ function Get-PaneControlLaunchCommand {
         -Model $Model `
         -ModelSource $ModelSource `
         -ReasoningEffort $ReasoningEffort `
+        -McpMode $McpMode `
         -ProjectDir $ProjectDir `
         -GitWorktreeDir $GitWorktreeDir `
         -RootPath $RootPath
@@ -598,7 +600,7 @@ function Get-PaneControlRestartPlan {
         }
     }
 
-    $launchCommand = Get-PaneControlLaunchCommand -Agent $agentConfig.Agent -Model $agentConfig.Model -ModelSource $agentConfig.ModelSource -ReasoningEffort $agentConfig.ReasoningEffort -ProjectDir $context.LaunchDir -GitWorktreeDir $context.GitWorktreeDir -RootPath $ProjectDir
+    $launchCommand = Get-PaneControlLaunchCommand -Agent $agentConfig.Agent -Model $agentConfig.Model -ModelSource $agentConfig.ModelSource -ReasoningEffort $agentConfig.ReasoningEffort -McpMode $agentConfig.McpMode -ProjectDir $context.LaunchDir -GitWorktreeDir $context.GitWorktreeDir -RootPath $ProjectDir
 
     return [ordered]@{
         PaneId         = $context.PaneId

--- a/winsmux-core/scripts/pane-scaler.ps1
+++ b/winsmux-core/scripts/pane-scaler.ps1
@@ -164,6 +164,7 @@ function Get-PaneScalerLaunchCommand {
         [Parameter(Mandatory = $true)][AllowEmptyString()][string]$Model,
         [AllowEmptyString()][string]$ModelSource = '',
         [AllowEmptyString()][string]$ReasoningEffort = '',
+        [AllowEmptyString()][string]$McpMode = '',
         [Parameter(Mandatory = $true)][string]$ProjectDir,
         [Parameter(Mandatory = $true)][string]$GitWorktreeDir,
         [string]$RootPath = ''
@@ -174,6 +175,7 @@ function Get-PaneScalerLaunchCommand {
         -Model $Model `
         -ModelSource $ModelSource `
         -ReasoningEffort $ReasoningEffort `
+        -McpMode $McpMode `
         -ProjectDir $ProjectDir `
         -GitWorktreeDir $GitWorktreeDir `
         -RootPath $RootPath
@@ -436,7 +438,7 @@ function Add-OrchestraPane {
         Invoke-MonitorWinsmux -Arguments @('select-pane', '-t', $newPaneId, '-T', $newLabel) | Out-Null
 
         Wait-MonitorPaneShellReady -PaneId $newPaneId
-        Send-MonitorBridgeCommand -PaneId $newPaneId -Text (Get-PaneScalerLaunchCommand -Agent ([string]$roleAgentConfig.Agent) -Model ([string]$roleAgentConfig.Model) -ModelSource ([string]$roleAgentConfig.ModelSource) -ReasoningEffort ([string]$roleAgentConfig.ReasoningEffort) -ProjectDir $worktree.WorktreePath -GitWorktreeDir $worktree.GitWorktreeDir -RootPath $projectDir)
+        Send-MonitorBridgeCommand -PaneId $newPaneId -Text (Get-PaneScalerLaunchCommand -Agent ([string]$roleAgentConfig.Agent) -Model ([string]$roleAgentConfig.Model) -ModelSource ([string]$roleAgentConfig.ModelSource) -ReasoningEffort ([string]$roleAgentConfig.ReasoningEffort) -McpMode ([string]$roleAgentConfig.McpMode) -ProjectDir $worktree.WorktreePath -GitWorktreeDir $worktree.GitWorktreeDir -RootPath $projectDir)
 
         $newPane = [ordered]@{
             label                = $newLabel

--- a/winsmux-core/scripts/settings.ps1
+++ b/winsmux-core/scripts/settings.ps1
@@ -27,6 +27,7 @@ $script:BridgeSlotScalarKeys = @(
     'model_source',
     'reasoning_effort',
     'prompt_transport',
+    'mcp_mode',
     'auth_mode',
     'worktree_mode',
     'worker_backend',
@@ -428,6 +429,16 @@ function Test-BridgeReasoningEffortValue {
     return ($Value.Trim().ToLowerInvariant() -in @('provider-default', 'low', 'medium', 'high', 'xhigh', 'max'))
 }
 
+function Test-BridgeMcpModeValue {
+    param([AllowNull()][string]$Value)
+
+    if ([string]::IsNullOrWhiteSpace($Value)) {
+        return $false
+    }
+
+    return ($Value.Trim().ToLowerInvariant() -in @('provider-default', 'enabled', 'disabled'))
+}
+
 function ConvertTo-BridgeSlotKey {
     param([Parameter(Mandatory = $true)][string]$Key)
 
@@ -480,6 +491,12 @@ function ConvertTo-BridgeSlotEntry {
             if ($key -eq 'reasoning_effort') {
                 if (-not (Test-BridgeReasoningEffortValue -Value $text)) {
                     throw "Invalid agent_slots configuration: unsupported reasoning_effort '$text' for slot '$($slot.slot_id)'. Supported values: provider-default, low, medium, high, xhigh, max."
+                }
+                $text = $text.Trim().ToLowerInvariant()
+            }
+            if ($key -eq 'mcp_mode') {
+                if (-not (Test-BridgeMcpModeValue -Value $text)) {
+                    throw "Invalid agent_slots configuration: unsupported mcp_mode '$text' for slot '$($slot.slot_id)'. Supported values: provider-default, enabled, disabled."
                 }
                 $text = $text.Trim().ToLowerInvariant()
             }
@@ -1795,12 +1812,67 @@ function Assert-BridgeProviderCapabilitySelection {
     }
 }
 
+function Get-BridgeCodexMcpServerNamesToDisable {
+    param([Parameter(Mandatory = $true)][string]$Command)
+
+    $envValue = [Environment]::GetEnvironmentVariable('WINSMUX_CODEX_MCP_DISABLE_SERVERS')
+    if (-not [string]::IsNullOrWhiteSpace($envValue)) {
+        return @(
+            $envValue -split ',' |
+                ForEach-Object { $_.Trim() } |
+                Where-Object { $_ -match '^[A-Za-z0-9_.-]+$' } |
+                Select-Object -Unique
+        )
+    }
+
+    $cacheVariable = Get-Variable -Name BridgeCodexMcpServerNamesCache -Scope Script -ErrorAction SilentlyContinue
+    if ($null -ne $cacheVariable -and $cacheVariable.Value) {
+        return @($script:BridgeCodexMcpServerNamesCache)
+    }
+
+    $names = @()
+    try {
+        $output = & $Command --disable plugins mcp list 2>$null
+        foreach ($line in @($output)) {
+            $text = [string]$line
+            if ($text -match '^\s*(?<name>[A-Za-z0-9_.-]+)\s{2,}') {
+                $name = $Matches['name']
+                if ($name -ne 'Name') {
+                    $names += $name
+                }
+            }
+        }
+    } catch {
+        $names = @()
+    }
+
+    if ($names.Count -eq 0) {
+        $names = @('cua-driver', 'node_repl', 'playwright', 'mcpvault', 'pencil', 'figma')
+    }
+
+    $script:BridgeCodexMcpServerNamesCache = @($names | Select-Object -Unique)
+    return @($script:BridgeCodexMcpServerNamesCache)
+}
+
+function Get-BridgeCodexMcpSuppressionArguments {
+    param([Parameter(Mandatory = $true)][string]$Command)
+
+    $args = @('--disable', 'plugins')
+    foreach ($serverName in Get-BridgeCodexMcpServerNamesToDisable -Command $Command) {
+        $args += '-c'
+        $args += (ConvertTo-BridgePowerShellLiteral -Value "mcp_servers.$serverName.enabled=false")
+    }
+
+    return @($args)
+}
+
 function Get-BridgeProviderLaunchCommand {
     param(
         [Parameter(Mandatory = $true)][string]$ProviderId,
         [Parameter(Mandatory = $true)][AllowEmptyString()][string]$Model,
         [AllowEmptyString()][string]$ModelSource = '',
         [AllowEmptyString()][string]$ReasoningEffort = '',
+        [AllowEmptyString()][string]$McpMode = '',
         [Parameter(Mandatory = $true)][string]$ProjectDir,
         [Parameter(Mandatory = $true)][string]$GitWorktreeDir,
         [string]$RootPath,
@@ -1824,6 +1896,7 @@ function Get-BridgeProviderLaunchCommand {
     $commandInvocation = ConvertTo-BridgePowerShellCommandInvocation -Value $command
     $modelOverride = Test-BridgeProviderModelOverride -Model $Model -ModelSource $ModelSource
     $effortOverride = -not (Test-BridgeProviderDefaultReasoningEffort -ReasoningEffort $ReasoningEffort)
+    $mcpDisabled = (-not [string]::IsNullOrWhiteSpace($McpMode)) -and [string]::Equals($McpMode.Trim(), 'disabled', [System.StringComparison]::OrdinalIgnoreCase)
     switch ($adapterKey) {
         'codex' {
             if ($ExecMode) {
@@ -1840,6 +1913,9 @@ function Get-BridgeProviderLaunchCommand {
             if ($effortOverride) {
                 $parts += '-c'
                 $parts += (ConvertTo-BridgePowerShellLiteral -Value "model_reasoning_effort=$($ReasoningEffort.Trim().ToLowerInvariant())")
+            }
+            if ($mcpDisabled) {
+                $parts += Get-BridgeCodexMcpSuppressionArguments -Command $command
             }
             $parts += '--sandbox'
             $parts += 'danger-full-access'
@@ -1858,6 +1934,11 @@ function Get-BridgeProviderLaunchCommand {
             if ($effortOverride) {
                 $parts += '--effort'
                 $parts += $ReasoningEffort.Trim().ToLowerInvariant()
+            }
+            if ($mcpDisabled) {
+                $parts += '--mcp-config'
+                $parts += (ConvertTo-BridgePowerShellLiteral -Value '{"mcpServers":{}}')
+                $parts += '--strict-mcp-config'
             }
             $parts += '--permission-mode'
             $parts += 'bypassPermissions'
@@ -2786,6 +2867,7 @@ function Get-SlotAgentConfig {
     $modelSource = [string]$roleAgentConfig.ModelSource
     $reasoningEffort = [string]$roleAgentConfig.ReasoningEffort
     $promptTransport = [string]$roleAgentConfig.PromptTransport
+    $mcpMode = ''
     $authMode = [string]$roleAgentConfig.AuthMode
     $workerBackend = ''
     if ($Settings -is [System.Collections.IDictionary]) {
@@ -2840,6 +2922,7 @@ function Get-SlotAgentConfig {
             $slotModelSource = ''
             $slotReasoningEffort = ''
             $slotPromptTransport = ''
+            $slotMcpMode = ''
             $slotAuthMode = ''
             $slotWorkerBackend = ''
             $slotExecutionProfile = ''
@@ -2874,6 +2957,9 @@ function Get-SlotAgentConfig {
                 }
                 if ($slot.Contains('prompt_transport')) {
                     $slotPromptTransport = [string]$slot['prompt_transport']
+                }
+                if ($slot.Contains('mcp_mode')) {
+                    $slotMcpMode = [string]$slot['mcp_mode']
                 }
                 if ($slot.Contains('auth_mode')) {
                     $slotAuthMode = [string]$slot['auth_mode']
@@ -2928,6 +3014,9 @@ function Get-SlotAgentConfig {
                 }
                 if ($slot.PSObject.Properties.Name -contains 'prompt_transport') {
                     $slotPromptTransport = [string]$slot.prompt_transport
+                }
+                if ($slot.PSObject.Properties.Name -contains 'mcp_mode') {
+                    $slotMcpMode = [string]$slot.mcp_mode
                 }
                 if ($slot.PSObject.Properties.Name -contains 'auth_mode') {
                     $slotAuthMode = [string]$slot.auth_mode
@@ -2994,6 +3083,11 @@ function Get-SlotAgentConfig {
 
             if (-not [string]::IsNullOrWhiteSpace($slotPromptTransport)) {
                 $promptTransport = $slotPromptTransport
+                $source = 'slot'
+            }
+
+            if (-not [string]::IsNullOrWhiteSpace($slotMcpMode)) {
+                $mcpMode = $slotMcpMode
                 $source = 'slot'
             }
 
@@ -3097,6 +3191,7 @@ function Get-SlotAgentConfig {
         ModelSource              = [string]$modelSource
         ReasoningEffort          = [string]$reasoningEffort
         PromptTransport          = [string]$promptTransport
+        McpMode                  = [string]$mcpMode
         AuthMode                 = [string]$authMode
         AuthPolicy               = Get-BridgeProviderAuthPolicy -Capability $providerCapability -AuthMode $authMode
         Source                   = [string]$source


### PR DESCRIPTION
## Summary
- Add an explicit `mcp-mode` slot setting for worker launch configuration.
- Suppress Codex and Claude MCP startup only for slots that request `mcp-mode: disabled`.
- Surface `mcp_mode` in worker status so benchmark readiness can prove which panes are isolated from unrelated MCP warnings.

## Why
The v0.36.23 coordination benchmark needs the operator to start all six worker panes and verify readiness before sending the same Harness Bench task packet. Codex and Claude panes were stopping on unrelated MCP startup warnings, which made readiness checks fail before the benchmark could start.

## Verification
- `Invoke-Pester -Path tests/winsmux-bridge.Tests.ps1 -FullName '*MCP*'`
- `target/release/winsmux.exe workers status --json --project-dir .winsmux/evidence/v03623-coordination-benchmark-project`
- `git diff --check`
