### PR TITLE
fix(app): restart worker panes when launch commands change

### DIFF
--- a/winsmux-app/scripts/desktop-pane-e2e.mjs
+++ b/winsmux-app/scripts/desktop-pane-e2e.mjs
@@ -1841,6 +1841,51 @@ async function exerciseOperatorCommandStartsAllWorkerPanes(page, options = {}) {
     outputs[paneId] = output.slice(-800);
   }
   assertAllSixWorkerOutputs(fullOutputs, () => new RegExp(startMarker));
+  return {
+    tempProjectDir,
+    markerScriptPath,
+    startMarker,
+    outputs,
+    fullOutputs,
+  };
+}
+
+async function exerciseOperatorCommandRestartsWorkersWhenLaunchCommandsChange(page) {
+  const result = await exerciseOperatorCommandStartsAllWorkerPanes(page, {
+    projectName: "operator-start-all-workers-restart-project",
+    startMarker: "RESTART_OK",
+    scriptLines: [
+      "Write-Output 'RESTART_OK'",
+      "$modelArg = $args[1]",
+      "if ($modelArg -like 'model=gpt-5.5-restart-worker-*') {",
+      "  Write-Output ($modelArg -replace 'model=gpt-5.5-restart-worker-', 'RESTART_MODEL_')",
+      "} else {",
+      "  Write-Output $modelArg",
+      "}",
+      "",
+    ],
+  });
+  const configPath = path.join(result.tempProjectDir, ".winsmux.yaml");
+  const originalConfig = await fs.readFile(configPath, "utf8");
+  const updatedConfig = originalConfig.replaceAll("gpt-5.4-worker-", "gpt-5.5-restart-worker-");
+  if (updatedConfig === originalConfig) {
+    throw new Error("test setup did not update worker launch models");
+  }
+  await fs.writeFile(configPath, updatedConfig, "utf8");
+
+  await submitWinsmuxComposerCommandWithButton(page, "winsmux workers start all");
+  await page.locator("#conversation-panel", { hasText: "All worker panes were started" }).waitFor({ state: "visible", timeout: 60_000 });
+
+  const outputs = {};
+  for (let index = 1; index <= 6; index += 1) {
+    const paneId = `worker-${index}`;
+    const output = await waitForPtyOutput(page, paneId, `RESTART_MODEL_${index}`, 60_000);
+    const compactOutput = stripAnsi(output).replace(/\s+/g, "");
+    if (!compactOutput.includes(`RESTART_MODEL_${index}`)) {
+      throw new Error(`worker ${paneId} did not restart with updated launch command:\n${output.slice(-1_200)}`);
+    }
+    outputs[paneId] = output.slice(-1_200);
+  }
   return outputs;
 }
 
@@ -2100,6 +2145,9 @@ async function main() {
       });
       await runStep("operator composer command starts all worker panes", async () => {
         return await exerciseOperatorCommandStartsAllWorkerPanes(page);
+      });
+      await runStep("operator composer command restarts workers after launch commands change", async () => {
+        return await exerciseOperatorCommandRestartsWorkersWhenLaunchCommandsChange(page);
       });
       await runStep("operator benchmark ready-check verifies all worker write paths", async () => {
         return await exerciseOperatorBenchmarkReadyCheck(page);

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -57,6 +57,7 @@ interface PaneEntry {
   outputBuffer: string;
   ptyStarted: boolean;
   ptyStarting: Promise<void> | null;
+  activeStartupInput: string;
 }
 
 interface HarnessBenchmarkPackTask {
@@ -1776,6 +1777,7 @@ function markPanePtyStartedFromExternalEvent(paneId: string) {
   const wasStarted = entry.ptyStarted;
   entry.ptyStarted = true;
   entry.ptyStarting = null;
+  entry.activeStartupInput = entry.activeStartupInput || "";
   entry.metaElement.textContent = getLanguageText("shell active", "シェル起動済み");
   entry.metaElement.title = getLanguageText(
     "This pane was started by the desktop control pipe.",
@@ -1796,6 +1798,7 @@ function markPanePtyStoppedFromExternalEvent(paneId: string) {
   const wasRunning = entry.ptyStarted || Boolean(entry.ptyStarting);
   entry.ptyStarted = false;
   entry.ptyStarting = null;
+  entry.activeStartupInput = "";
   entry.outputBuffer = "";
   entry.metaElement.textContent = getLanguageText("not started", "未起動");
   entry.metaElement.removeAttribute("title");
@@ -1882,6 +1885,7 @@ function createPane(paneId?: string, options?: { deferWorkbenchUpdate?: boolean 
     outputBuffer: "",
     ptyStarted: false,
     ptyStarting: null,
+    activeStartupInput: "",
   });
   const hasKnownFocusedPane = focusedWorkbenchPaneId && (panes.has(focusedWorkbenchPaneId) || getWorkbenchPaneOrdinal(focusedWorkbenchPaneId) !== null);
   if (!hasKnownFocusedPane || (!paneId && workbenchLayout === "focus")) {
@@ -2011,9 +2015,11 @@ function ensurePanePtyStarted(paneId: string) {
   const { cols, rows } = { cols: entry.terminal.cols, rows: entry.terminal.rows };
   entry.metaElement.textContent = getLanguageText("starting shell", "シェル起動中");
   renderWorkerStatusSurface();
-  entry.ptyStarting = spawnPtyPane(paneId, cols, rows, getPaneStartupInput(paneId))
+  const startupInput = getPaneStartupInput(paneId);
+  entry.ptyStarting = spawnPtyPane(paneId, cols, rows, startupInput)
     .then(() => {
       entry.ptyStarted = true;
+      entry.activeStartupInput = startupInput ?? "";
       entry.metaElement.textContent = getLanguageText("waiting for summary", "要約待ち");
       requestDesktopSummaryRefresh(undefined, 500);
       void refreshWorkerStatusSurface();
@@ -3564,20 +3570,46 @@ function appendWorkerStartResultConversation(
   renderConversation(getConversationItems());
 }
 
+function normalizeWorkerStartupInput(value: string) {
+  return value.replace(/\r\n/g, "\n").replace(/\r/g, "\n").trim();
+}
+
+function isWorkerPaneRunningExpectedStartup(entry: PaneEntry, startupInput: string) {
+  return normalizeWorkerStartupInput(entry.activeStartupInput) === normalizeWorkerStartupInput(startupInput);
+}
+
+async function resetWorkerPaneForStartup(target: string, entry: PaneEntry) {
+  clearPaneStartupInput(target);
+  entry.ptyStarted = false;
+  entry.ptyStarting = null;
+  entry.activeStartupInput = "";
+  entry.outputBuffer = "";
+  entry.metaElement.textContent = getLanguageText("restarting shell", "シェル再起動中");
+  entry.metaElement.title = getLanguageText(
+    "The previous worker command did not match the requested launch command, so the pane is being restarted.",
+    "前回のワーカー起動コマンドが今回の起動コマンドと一致しないため、ペインを再起動しています。",
+  );
+  await closePtyPane(target);
+}
+
 async function startDesktopWorkerPaneWithLaunchCommand(target: string, row: DesktopWorkerStatusRow) {
   const launchCommand = (row.launch_command ?? "").trim();
   if (!launchCommand) {
     throw new Error(row.launch_command_error || `No launch command is available for ${target}.`);
   }
+  const startupInput = `${launchCommand}\r`;
   const pane = panes.get(target);
   if (!pane) {
     throw new Error(`Pane ${target} not found.`);
   }
   if (pane.ptyStarted) {
-    appendWorkerStartResultConversation({ slot_id: target, status: "already_running" }, row);
-    return;
+    if (isWorkerPaneRunningExpectedStartup(pane, startupInput)) {
+      appendWorkerStartResultConversation({ slot_id: target, status: "already_running" }, row);
+      return;
+    }
+    await resetWorkerPaneForStartup(target, pane);
   }
-  if (pane.ptyStarting || !queuePaneStartupInput(target, `${launchCommand}\r`)) {
+  if (pane.ptyStarting || !queuePaneStartupInput(target, startupInput)) {
     appendWorkerStartResultConversation({
       slot_id: target,
       status: "blocked",


### PR DESCRIPTION
## Summary\n\n- Track the startup input used for each desktop worker pane.\n- Restart an already-running worker pane when the requested launch command no longer matches the pane's active startup input.\n- Add desktop E2E coverage for the operator winsmux workers start all path after worker launch commands change.\n\n## Verification\n\n- 
pm run build\n- 
pm run test:desktop-pane-e2e -- --worker-start-only\n\nCloses #1034\n