### PR TITLE
test(app): wait for benchmark dispatch worker output

### DIFF
--- a/winsmux-app/scripts/desktop-pane-e2e.mjs
+++ b/winsmux-app/scripts/desktop-pane-e2e.mjs
@@ -2004,7 +2004,8 @@ async function exerciseOperatorBenchmarkDispatchRecordsPromptReadyWarnings(page)
   const outputs = {};
   for (let index = 1; index <= 6; index += 1) {
     const paneId = `worker-${index}`;
-    outputs[paneId] = (await capturePty(page, paneId).catch(() => "")).slice(-1_200);
+    const output = await waitForPtyOutputLine(page, paneId, `WINSMUX_BENCH_TASK_PACKET WB-001 ${paneId}`, 60_000);
+    outputs[paneId] = output.slice(-1_200);
   }
   const combined = `${text ?? ""}\n${JSON.stringify(outputs)}`;
   if (!combined.includes("MCP warning is present")) {


### PR DESCRIPTION
## Summary
- Wait for each worker pane to render its benchmark task packet in the prompt-ready warning dispatch E2E.
- Align the warning-specific dispatch assertion with the normal benchmark dispatch assertion.

## Verification
- npm run test:desktop-pane-e2e -- --worker-start-only
- git diff --check

Closes #1036