### PR TITLE
Align per-pane model picker with benchmark assignment

### DIFF
--- a/scripts/test-cli-bakeoff-preflight.ps1
+++ b/scripts/test-cli-bakeoff-preflight.ps1
@@ -391,18 +391,26 @@ if ($null -ne $pack) {
 
     $workers = @($pack.default_workers)
     Add-Check 'Claude worker profile exists' (@($workers | Where-Object { $_.cli -eq 'Claude Code' }).Count -ge 1)
+    Add-Check 'Claude Opus 4.8 worker uses Ultra effort' (@($workers | Where-Object {
+        ($_.PSObject.Properties.Name -contains 'cli') -and
+        ($_.PSObject.Properties.Name -contains 'model') -and
+        ($_.PSObject.Properties.Name -contains 'effort') -and
+        $_.cli -eq 'Claude Code' -and
+        $_.model -eq 'claude-opus-4-8' -and
+        $_.effort -eq 'xhigh'
+    }).Count -ge 1)
     Add-Check 'Codex worker profile exists' (@($workers | Where-Object { $_.cli -eq 'Codex' }).Count -ge 1)
     $scoredWorkerRoles = @($workers | Where-Object { [bool]$_.scored } | ForEach-Object { [string]$_.role } | Sort-Object -Unique)
     Add-Check 'scored workers share one Harness Bench role' (
         $scoredWorkerRoles.Count -eq 1 -and $scoredWorkerRoles[0] -eq 'harness-bench-worker'
     ) ($scoredWorkerRoles -join ',')
-    Add-Check 'Codex worker uses GPT-5.5 High canonical scenario' (@($workers | Where-Object {
+    Add-Check 'Codex worker uses GPT-5.5 xhigh canonical scenario' (@($workers | Where-Object {
         ($_.PSObject.Properties.Name -contains 'cli') -and
         ($_.PSObject.Properties.Name -contains 'model') -and
         ($_.PSObject.Properties.Name -contains 'effort') -and
         $_.cli -eq 'Codex' -and
         $_.model -eq 'gpt-5.5' -and
-        $_.effort -eq 'high'
+        $_.effort -eq 'xhigh'
     }).Count -ge 1)
     Add-Check 'Codex GPT-5.5 worker does not use lower effort' (@($workers | Where-Object {
         ($_.PSObject.Properties.Name -contains 'cli') -and
@@ -410,15 +418,15 @@ if ($null -ne $pack) {
         ($_.PSObject.Properties.Name -contains 'effort') -and
         $_.cli -eq 'Codex' -and
         $_.model -eq 'gpt-5.5' -and
-        $_.effort -ne 'high'
+        $_.effort -ne 'xhigh'
     }).Count -eq 0)
     Add-Check 'Antigravity worker profile exists' (@($workers | Where-Object { $_.cli -eq 'Antigravity CLI' }).Count -ge 1)
-    Add-Check 'OpenRouter Kimi worker profile exists' (@($workers | Where-Object {
+    Add-Check 'OpenRouter Sakana Fugu Ultra worker profile exists' (@($workers | Where-Object {
         ($_.PSObject.Properties.Name -contains 'agent') -and
         ($_.PSObject.Properties.Name -contains 'model') -and
         ($_.PSObject.Properties.Name -contains 'worker_backend') -and
         $_.agent -eq 'openrouter' -and
-        $_.model -eq 'moonshotai/kimi-k2.7-code' -and
+        $_.model -eq 'sakana/fugu-ultra' -and
         $_.worker_backend -eq 'api_llm'
     }).Count -ge 1)
     Add-Check 'OpenRouter GLM worker profile exists' (@($workers | Where-Object {

--- a/tasks/cli-bakeoff/v1/WB-019-open-weight-worker-selection.md
+++ b/tasks/cli-bakeoff/v1/WB-019-open-weight-worker-selection.md
@@ -15,6 +15,6 @@ Return exactly this structure:
 
 Quality bar:
 
-- Include Kimi K2.7 Code and GLM-5.2.
+- Include Sakana Fugu Ultra and GLM-5.2.
 - Treat provider availability as separate from benchmark quality.
 - Do not add models without a verified provider path.

--- a/tasks/cli-bakeoff/v1/benchmark-pack.json
+++ b/tasks/cli-bakeoff/v1/benchmark-pack.json
@@ -62,7 +62,7 @@
       "role": "harness-bench-worker",
       "cli": "Claude Code",
       "model": "claude-opus-4-8",
-      "effort": "high",
+      "effort": "xhigh",
       "display_model": "Claude Code / Claude Opus 4.8",
       "auth_mode": "claude-code-local",
       "scored": true
@@ -72,7 +72,7 @@
       "role": "harness-bench-worker",
       "cli": "Codex",
       "model": "gpt-5.5",
-      "effort": "high",
+      "effort": "xhigh",
       "display_model": "Codex / gpt-5.5",
       "auth_mode": "codex-local",
       "scored": true
@@ -108,9 +108,9 @@
       "cli": "OpenRouter API",
       "worker_backend": "api_llm",
       "agent": "openrouter",
-      "model": "moonshotai/kimi-k2.7-code",
+      "model": "sakana/fugu-ultra",
       "effort": "provider-default",
-      "display_model": "OpenRouter / Kimi K2.7 Code",
+      "display_model": "OpenRouter / Sakana Fugu Ultra",
       "auth_mode": "api-key-env",
       "required_env": "OPENROUTER_API_KEY",
       "scored": true
@@ -667,7 +667,7 @@
         "artifact": "benchmark_evidence"
       },
       "hidden_check_categories": [
-        "includes Kimi K2.7 Code",
+        "includes Sakana Fugu Ultra",
         "includes GLM-5.2",
         "separates provider availability from model score"
       ],

--- a/tests/CliBakeoff.Tests.ps1
+++ b/tests/CliBakeoff.Tests.ps1
@@ -23,7 +23,7 @@ Describe 'CLI bakeoff evidence harness' {
         ($result.checks | Where-Object { $_.name -eq 'official Harness Bench task count is met' }).pass | Should -BeTrue
         ($result.checks | Where-Object { $_.name -eq 'default timeout is 3600 seconds' }).pass | Should -BeTrue
         ($result.checks | Where-Object { $_.name -eq 'operator is not scored' }).pass | Should -BeTrue
-        ($result.checks | Where-Object { $_.name -eq 'OpenRouter Kimi worker profile exists' }).pass | Should -BeTrue
+        ($result.checks | Where-Object { $_.name -eq 'OpenRouter Sakana Fugu Ultra worker profile exists' }).pass | Should -BeTrue
         ($result.checks | Where-Object { $_.name -eq 'OpenRouter GLM worker profile exists' }).pass | Should -BeTrue
         ($output -join "`n") | Should -Not -Match 'C:\\Users\\'
     }

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -1341,18 +1341,6 @@ interface OpenRouterModelsApiResponse {
 let openRouterRuntimeModelEntries: RuntimeModelCatalogEntry[] = [];
 let openRouterModelsLoadState: RuntimeProviderApiLoadState = "idle";
 
-function getRuntimeModelSuggestions() {
-  return Array.from(new Set([
-    "provider-default",
-    ...runtimeModelCatalog
-      .filter((entry) => entry.status === "selectable" || entry.status === "candidate" || entry.status === "setup-required" || entry.status === "runnable")
-      .map((entry) => entry.model),
-    ...openRouterRuntimeModelEntries.map((entry) => entry.model),
-    "default",
-    "opusplan",
-  ]));
-}
-
 runtimeRolePreferences = readStoredRuntimeRolePreferences();
 runtimeModelAssignmentMode = readStoredRuntimeModelAssignmentMode();
 {
@@ -11211,32 +11199,44 @@ function renderRuntimeWorkerDefaultControls(japanese: boolean, disabled = false)
   const modelCaption = document.createElement("span");
   modelCaption.className = "runtime-control-caption";
   modelCaption.textContent = japanese ? "モデル" : "Model";
-  const modelSearchInput = document.createElement("input");
-  modelSearchInput.className = "runtime-control-input runtime-model-search-input";
-  modelSearchInput.type = "search";
-  modelSearchInput.placeholder = japanese ? "モデル名またはIDで検索" : "Search model name or ID";
-  modelSearchInput.disabled = disabled;
-  modelSearchInput.title = disabledTitle;
-  const modelSelect = document.createElement("select");
-  modelSelect.id = "runtime-worker-default-model";
-  modelSelect.className = "runtime-control-select runtime-model-slot-select";
-  modelSelect.disabled = disabled;
-  modelSelect.title = disabledTitle;
-  modelSelect.setAttribute("aria-label", japanese ? "全ペイン共通のモデル" : "Shared worker model");
+  const modelInput = document.createElement("input");
+  modelInput.id = "runtime-worker-default-model";
+  modelInput.className = "runtime-control-input runtime-model-slot-input";
+  modelInput.type = "search";
+  modelInput.placeholder = japanese ? "モデル名またはIDで検索" : "Search model name or ID";
+  modelInput.autocomplete = "off";
+  modelInput.disabled = disabled;
+  modelInput.title = disabledTitle;
+  modelInput.setAttribute("aria-label", japanese ? "全ペイン共通のモデル" : "Shared worker model");
+  const modelOptionsId = "runtime-worker-default-model-options";
+  modelInput.setAttribute("list", modelOptionsId);
+  const modelOptions = document.createElement("datalist");
+  modelOptions.id = modelOptionsId;
+  const resolveSharedModelEntry = () => {
+    const value = modelInput.value.trim().toLowerCase();
+    return entries.find((entry) => {
+      return entry.id.toLowerCase() === value
+        || entry.model.toLowerCase() === value
+        || entry.label.toLowerCase() === value
+        || (entry.labelJa ?? "").toLowerCase() === value
+        || getRuntimeCatalogOptionLabel(entry, japanese).toLowerCase() === value;
+    }) ?? selectedEntry;
+  };
   const renderSharedModelOptions = () => {
-    const displayEntries = getRuntimeModelSelectEntries(entries, selectedEntry, modelSearchInput.value, japanese);
-    modelSelect.innerHTML = "";
+    const displayEntries = getRuntimeModelSelectEntries(entries, selectedEntry, modelInput.value, japanese);
+    modelOptions.innerHTML = "";
     for (const entry of displayEntries) {
       const option = document.createElement("option");
-      option.value = entry.id;
-      option.textContent = getRuntimeCatalogOptionLabel(entry, japanese);
-      option.selected = entry.id === selectedEntry.id;
-      modelSelect.appendChild(option);
+      option.value = getRuntimeCatalogOptionLabel(entry, japanese);
+      option.label = entry.model;
+      modelOptions.appendChild(option);
     }
   };
-  modelSearchInput.addEventListener("input", renderSharedModelOptions);
-  modelSelect.addEventListener("change", () => {
-    const nextEntry = entries.find((entry) => entry.id === modelSelect.value) ?? getRuntimeProviderDefaultEntry(selectedProvider);
+  modelInput.value = getRuntimeCatalogOptionLabel(selectedEntry, japanese);
+  modelInput.addEventListener("input", renderSharedModelOptions);
+  modelInput.addEventListener("change", () => {
+    const nextEntry = resolveSharedModelEntry();
+    modelInput.value = getRuntimeCatalogOptionLabel(nextEntry, japanese);
     updateRuntimeRoleDraft("worker", {
       model: nextEntry.model,
       modelSource: nextEntry.modelSource,
@@ -11244,7 +11244,7 @@ function renderRuntimeWorkerDefaultControls(japanese: boolean, disabled = false)
     });
   });
   renderSharedModelOptions();
-  modelField.append(modelCaption, modelSearchInput, modelSelect);
+  modelField.append(modelCaption, modelInput, modelOptions);
   controls.appendChild(modelField);
 
   controls.appendChild(createRuntimeSelect(
@@ -11350,15 +11350,17 @@ function renderWorkerModelAssignmentPanel(japanese: boolean) {
     const modelCaption = document.createElement("span");
     modelCaption.className = "runtime-control-caption";
     modelCaption.textContent = japanese ? "モデル" : "Model";
-    const modelSelect = document.createElement("select");
-    modelSelect.className = "runtime-control-select runtime-model-slot-select";
-    modelSelect.setAttribute("aria-label", japanese ? `${slotId} のモデル` : `${slotId} model`);
-    const modelSearchInput = document.createElement("input");
-    modelSearchInput.className = "runtime-control-input runtime-model-search-input";
-    modelSearchInput.type = "search";
-    modelSearchInput.placeholder = japanese ? "モデル名またはIDで検索" : "Search model name or ID";
-    modelSearchInput.setAttribute("aria-label", japanese ? `${slotId} のモデル検索` : `${slotId} model search`);
-    modelField.append(modelCaption, modelSearchInput, modelSelect);
+    const modelInput = document.createElement("input");
+    modelInput.className = "runtime-control-input runtime-model-slot-input";
+    modelInput.type = "search";
+    modelInput.placeholder = japanese ? "モデル名またはIDで検索" : "Search model name or ID";
+    modelInput.autocomplete = "off";
+    modelInput.setAttribute("aria-label", japanese ? `${slotId} のモデル` : `${slotId} model`);
+    const modelOptionsId = `runtime-model-options-${slotId}`;
+    modelInput.setAttribute("list", modelOptionsId);
+    const modelOptions = document.createElement("datalist");
+    modelOptions.id = modelOptionsId;
+    modelField.append(modelCaption, modelInput, modelOptions);
 
     const effortField = document.createElement("label");
     effortField.className = "runtime-model-slot-field";
@@ -11406,11 +11408,32 @@ function renderWorkerModelAssignmentPanel(japanese: boolean) {
         ? (japanese ? "このプロバイダーは思考量の明示指定に未対応です。" : "This provider does not expose a supported effort override.")
         : "";
     };
+    const findModelEntryFromInput = (provider: RuntimeProviderId, inputValue: string) => {
+      const normalizedValue = inputValue.trim().toLowerCase();
+      if (!normalizedValue) {
+        return getRuntimeProviderDefaultEntry(provider);
+      }
+      return currentEntries.find((item) => {
+        return item.id.toLowerCase() === normalizedValue
+          || item.model.toLowerCase() === normalizedValue
+          || item.label.toLowerCase() === normalizedValue
+          || (item.labelJa ?? "").toLowerCase() === normalizedValue
+          || getRuntimeCatalogOptionLabel(item, japanese).toLowerCase() === normalizedValue;
+      }) ?? createRuntimeCustomModelEntry(provider, inputValue.trim());
+    };
+    const renderModelOptionList = (selectedEntry: RuntimeModelCatalogEntry) => {
+      const displayEntries = getRuntimeModelSelectEntries(currentEntries, selectedEntry, modelInput.value, japanese);
+      modelOptions.innerHTML = "";
+      for (const entry of displayEntries) {
+        const option = document.createElement("option");
+        option.value = getRuntimeCatalogOptionLabel(entry, japanese);
+        option.label = entry.model;
+        modelOptions.appendChild(option);
+      }
+    };
     const resolveSelection = (): RuntimePaneModelSelection | null => {
       const provider = normalizeRuntimeProviderId(providerSelect.value) ?? inferredProvider;
-      const modelValue = modelSelect.value.trim() || `${provider}-provider-default`;
-      const entry = currentEntries.find((item) => item.id === modelValue || item.model === modelValue)
-        ?? getRuntimeProviderDefaultEntry(provider);
+      const entry = findModelEntryFromInput(provider, modelInput.value);
       const effort = normalizeRuntimeReasoningForEntry(provider, entry, effortSelect.value || entry.reasoningEffort);
       return { entry, reasoningEffort: effort };
     };
@@ -11461,35 +11484,34 @@ function renderWorkerModelAssignmentPanel(japanese: boolean) {
       if (!selectedEntry) {
         selectedEntry = currentEntries.find((entry) => entry.model === "provider-default") ?? getRuntimeProviderDefaultEntry(provider);
       }
-      const displayEntries = getRuntimeModelSelectEntries(currentEntries, selectedEntry, modelSearchInput.value, japanese);
-      modelSelect.innerHTML = "";
-      for (const entry of displayEntries) {
-        const option = document.createElement("option");
-        option.value = entry.id;
-        const readiness = getRuntimeModelReadinessForWorker(entry, row, japanese);
-        option.textContent = getRuntimeCatalogOptionLabel(entry, japanese);
-        option.selected = entry.id === selectedEntry.id;
-        option.title = readiness.reason;
-        option.disabled = !readiness.assignable && entry.status === "unavailable";
-        modelSelect.appendChild(option);
-      }
-      renderEffortOptions(provider, selectedEntry, selectedEntry.reasoningEffort || getWorkerReasoningEffort(row));
+      modelInput.value = getRuntimeCatalogOptionLabel(selectedEntry, japanese);
+      renderModelOptionList(selectedEntry);
+      const currentEffort = runtimeReasoningOptions.find((option) => option.value === getWorkerReasoningEffort(row))?.value;
+      const preferredEffort = currentEffort && currentEffort !== "provider-default"
+        ? currentEffort
+        : selectedEntry.reasoningEffort;
+      renderEffortOptions(provider, selectedEntry, preferredEffort);
       updateActionState();
     };
 
     providerSelect.addEventListener("change", () => {
-      modelSearchInput.value = "";
       renderModelOptions("provider-default");
     });
-    modelSearchInput.addEventListener("input", () => {
+    modelInput.addEventListener("input", () => {
       const selection = resolveSelection();
-      renderModelOptions(selection?.entry.model ?? modelSelect.value);
-    });
-    modelSelect.addEventListener("change", () => {
       const provider = normalizeRuntimeProviderId(providerSelect.value) ?? inferredProvider;
-      const selection = resolveSelection();
       if (selection) {
-        modelSearchInput.value = getRuntimeCatalogOptionLabel(selection.entry, japanese);
+        renderModelOptionList(selection.entry);
+        renderEffortOptions(provider, selection.entry, selection.entry.reasoningEffort);
+      }
+      updateActionState();
+    });
+    modelInput.addEventListener("change", () => {
+      const selection = resolveSelection();
+      const provider = normalizeRuntimeProviderId(providerSelect.value) ?? inferredProvider;
+      if (selection) {
+        modelInput.value = getRuntimeCatalogOptionLabel(selection.entry, japanese);
+        renderModelOptionList(selection.entry);
         renderEffortOptions(provider, selection.entry, selection.entry.reasoningEffort);
       }
       updateActionState();
@@ -11502,8 +11524,7 @@ function renderWorkerModelAssignmentPanel(japanese: boolean) {
       }
     });
     providerSelect.disabled = Boolean(workerProviderSwitchInFlight);
-    modelSearchInput.disabled = Boolean(workerProviderSwitchInFlight);
-    modelSelect.disabled = Boolean(workerProviderSwitchInFlight);
+    modelInput.disabled = Boolean(workerProviderSwitchInFlight);
     renderModelOptions(getWorkerModel(row));
 
     rowElement.append(summary, control, state, action);
@@ -11524,15 +11545,6 @@ function renderRuntimeRoleControls() {
 
   const japanese = (settingsDraftState?.language ?? themeState.language) === "ja";
   root.innerHTML = "";
-
-  const datalist = document.createElement("datalist");
-  datalist.id = "runtime-model-suggestions";
-  for (const model of getRuntimeModelSuggestions()) {
-    const option = document.createElement("option");
-    option.value = model;
-    datalist.appendChild(option);
-  }
-  root.appendChild(datalist);
 
   root.appendChild(renderWorkerModelAssignmentPanel(japanese));
 }

--- a/winsmux-app/src/styles.css
+++ b/winsmux-app/src/styles.css
@@ -4906,7 +4906,6 @@ body.is-resizing-workbench {
   white-space: nowrap;
 }
 
-.runtime-model-slot-select,
 .runtime-model-slot-input {
   height: 30px;
 }


### PR DESCRIPTION
## Summary
- Replace the per-pane model select plus separate search box with a single searchable model input backed by row-local datalist options.
- Update the v0.36.23 benchmark assignment from Kimi K2.7 Code to Sakana Fugu Ultra for the OpenRouter worker.
- Require Claude Opus 4.8 Ultra and Codex GPT-5.5 X High in the benchmark preflight.

## Verification
- `npm run build`
- `npm run tauri -- build --no-bundle`
- `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File scripts\test-cli-bakeoff-preflight.ps1 -PackPath tasks\cli-bakeoff\v1\benchmark-pack.json -ExpectedVersion 0.36.23 -AllowDirty -Json` => 337/337 passed
- `powershell -NoProfile -ExecutionPolicy Bypass -File .winsmux\local\desktop-launch-guard.ps1 -RequireRunning`
- Playwright CDP DOM check: six rows visible, per-pane mode selected, no legacy model select, no separate model search input, worker-5 shows Sakana Fugu Ultra, worker-1 shows Ultra, worker-2 shows X High.

Closes #1038