### PR TITLE
feat(desktop): expose operator control pipe helpers

### DIFF
--- a/docs/external-control-plane.ja.md
+++ b/docs/external-control-plane.ja.md
@@ -36,7 +36,33 @@ named pipe は、現時点で次のデスクトップメソッドを公開しま
 - `desktop.run.compare`
 - `desktop.run.promote`
 - `desktop.run.pick_winner`
+- `desktop.operator.snapshot`
+- `desktop.operator.submit`
 - `desktop.voice.capture_status`
+
+operator メソッドは、外部エージェントが operator と会話するための専用経路です。
+
+- `desktop.operator.snapshot` は operator ペインの直近出力を取得します。
+- `desktop.operator.submit` は operator composer に 1 件のメッセージを書き込み、送信します。この API は常に operator ペインだけを対象にし、`paneId` / `pane_id` の上書きを拒否します。外部エージェントが operator を迂回して worker ペインへ直接書き込む用途には使えません。
+
+外部エージェントは、通常は専用 CLI ヘルパーを使います。
+
+```powershell
+winsmux operator-snapshot --lines 80
+winsmux operator-submit --text "Restore the six-pane orchestra and report can_dispatch."
+```
+
+このヘルパーは `WINSMUX_CONTROL_PIPE_TOKEN` を読み取り、
+`desktop.operator.snapshot` / `desktop.operator.submit` だけを呼びます。
+worker ペインの指定は受け付けません。独自の named pipe クライアントを実装する場合は、次の JSON-RPC を直接送れます。
+
+```json
+{"jsonrpc":"2.0","id":"operator-snapshot","method":"desktop.operator.snapshot","params":{"lines":80},"auth":{"token":"<WINSMUX_CONTROL_PIPE_TOKEN>"}}
+```
+
+```json
+{"jsonrpc":"2.0","id":"operator-submit","method":"desktop.operator.submit","params":{"message":"Restore the six-pane orchestra and report can_dispatch."},"auth":{"token":"<WINSMUX_CONTROL_PIPE_TOKEN>"}}
+```
 
 同じ pipe は、ローカルペイン制御用に次の PTY メソッドも公開します。
 

--- a/docs/external-control-plane.md
+++ b/docs/external-control-plane.md
@@ -44,7 +44,38 @@ The named pipe currently exposes these desktop methods:
 - `desktop.run.compare`
 - `desktop.run.promote`
 - `desktop.run.pick_winner`
+- `desktop.operator.snapshot`
+- `desktop.operator.submit`
 - `desktop.voice.capture_status`
+
+The operator methods are the only external methods intended for agent-to-operator
+conversation:
+
+- `desktop.operator.snapshot` captures recent output from the operator pane.
+- `desktop.operator.submit` writes one message to the operator composer and
+  submits it. The API always targets the operator pane and rejects `paneId` /
+  `pane_id` overrides so external agents cannot bypass the operator and write
+  directly to worker panes.
+
+Prefer the dedicated CLI helpers for external agents:
+
+```powershell
+winsmux operator-snapshot --lines 80
+winsmux operator-submit --text "Restore the six-pane orchestra and report can_dispatch."
+```
+
+Those helpers read `WINSMUX_CONTROL_PIPE_TOKEN`, call only
+`desktop.operator.snapshot` / `desktop.operator.submit`, and never accept a
+worker pane target. Raw JSON-RPC remains available for clients that implement
+their own named-pipe transport:
+
+```json
+{"jsonrpc":"2.0","id":"operator-snapshot","method":"desktop.operator.snapshot","params":{"lines":80},"auth":{"token":"<WINSMUX_CONTROL_PIPE_TOKEN>"}}
+```
+
+```json
+{"jsonrpc":"2.0","id":"operator-submit","method":"desktop.operator.submit","params":{"message":"Restore the six-pane orchestra and report can_dispatch."},"auth":{"token":"<WINSMUX_CONTROL_PIPE_TOKEN>"}}
+```
 
 The same pipe also exposes these PTY methods for local pane control:
 

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -19167,6 +19167,8 @@ promote-tactic <run_id> [--title <text>] [--kind <playbook|prewarm|verification>
   mailbox-send <ch> <json>  Send JSON message to mailbox channel
   mailbox-listen <ch>       Alias for mailbox-create
   control-rpc <json>        Send JSON-RPC to \\.\pipe\winsmux-control
+  operator-submit <text>    Submit one message to the desktop operator via control pipe
+  operator-snapshot [--lines <n>]  Capture recent desktop operator output via control pipe
   kill <target>             Stop pane process and respawn its shell
   restart <target>          Restart the pane agent using manifest context
   rebind-worktree <target> <path>  Update a Builder/Worker pane to use a new worktree path
@@ -19263,6 +19265,90 @@ function Invoke-ControlRpc {
 
     $jsonText = (@($ControlTarget) + @($ControlRest) | Where-Object { $null -ne $_ }) -join ' '
     $payload = ConvertTo-ControlRpcPayload -JsonText $jsonText
+    Invoke-ControlRpcPipeExchange -Payload $payload | Write-Output
+}
+
+function New-ControlRpcRequestPayload {
+    param(
+        [Parameter(Mandatory = $true)][string]$Method,
+        [Parameter(Mandatory = $true)]$Params,
+        [string]$Id = "winsmux-$([guid]::NewGuid().ToString('N'))"
+    )
+
+    $payload = [pscustomobject][ordered]@{
+        jsonrpc = '2.0'
+        id      = $Id
+        method  = $Method
+        params   = $Params
+    }
+
+    $payload = Add-ControlRpcAuthToPayload -Payload $payload
+    return ($payload | ConvertTo-Json -Depth 100 -Compress)
+}
+
+function Invoke-OperatorSnapshot {
+    param(
+        [AllowEmptyString()][string]$ControlTarget = $Target,
+        [string[]]$ControlRest = $Rest
+    )
+
+    $arguments = @(@($ControlTarget) + @($ControlRest) | Where-Object { -not [string]::IsNullOrWhiteSpace([string]$_) })
+    $lines = 80
+    for ($index = 0; $index -lt $arguments.Count; $index++) {
+        switch ($arguments[$index]) {
+            '--lines' {
+                $index++
+                if ($index -ge $arguments.Count -or -not [int]::TryParse([string]$arguments[$index], [ref]$lines)) {
+                    Stop-WithError "usage: winsmux operator-snapshot [--lines <n>]"
+                }
+            }
+            default {
+                Stop-WithError "usage: winsmux operator-snapshot [--lines <n>]"
+            }
+        }
+    }
+
+    if ($lines -lt 1) {
+        Stop-WithError "operator-snapshot --lines must be greater than 0"
+    }
+
+    $payload = New-ControlRpcRequestPayload `
+        -Method 'desktop.operator.snapshot' `
+        -Id 'operator-snapshot' `
+        -Params ([ordered]@{ lines = $lines })
+
+    Invoke-ControlRpcPipeExchange -Payload $payload | Write-Output
+}
+
+function Invoke-OperatorSubmit {
+    param(
+        [AllowEmptyString()][string]$ControlTarget = $Target,
+        [string[]]$ControlRest = $Rest
+    )
+
+    $arguments = @(@($ControlTarget) + @($ControlRest) | Where-Object { $null -ne $_ })
+    $message = ''
+    if ($arguments.Count -ge 2 -and [string]$arguments[0] -eq '--file') {
+        $messagePath = [string]$arguments[1]
+        if (-not (Test-Path -LiteralPath $messagePath -PathType Leaf)) {
+            Stop-WithError "operator-submit file not found: $messagePath"
+        }
+        $message = Get-Content -LiteralPath $messagePath -Raw -Encoding UTF8
+    } elseif ($arguments.Count -ge 2 -and [string]$arguments[0] -eq '--text') {
+        $message = (@($arguments | Select-Object -Skip 1) -join ' ')
+    } else {
+        $message = (@($arguments | Where-Object { -not [string]::IsNullOrWhiteSpace([string]$_) }) -join ' ')
+    }
+
+    if ([string]::IsNullOrWhiteSpace($message)) {
+        Stop-WithError "usage: winsmux operator-submit <text> | --text <text> | --file <path>"
+    }
+
+    $payload = New-ControlRpcRequestPayload `
+        -Method 'desktop.operator.submit' `
+        -Id 'operator-submit' `
+        -Params ([ordered]@{ message = $message })
+
     Invoke-ControlRpcPipeExchange -Payload $payload | Write-Output
 }
 
@@ -19830,6 +19916,8 @@ switch ($Command) {
     'mailbox-send'    { Invoke-MailboxSend }
     'mailbox-listen'  { Invoke-MailboxListen }
     'control-rpc'     { Invoke-ControlRpc }
+    'operator-submit' { Invoke-OperatorSubmit }
+    'operator-snapshot' { Invoke-OperatorSnapshot }
     'watch'           { Invoke-Watch }
     'profile'         { Invoke-Profile }
     'doctor'          { Invoke-Doctor }

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -20635,6 +20635,10 @@ Describe 'winsmux control-rpc command' {
     It 'documents control-rpc in usage and fixes the named pipe endpoint' {
         $script:controlRpcBridgeContent | Should -Match 'control-rpc <json>'
         $script:controlRpcBridgeContent | Should -Match "'control-rpc'\s*\{\s*Invoke-ControlRpc\s*\}"
+        $script:controlRpcBridgeContent | Should -Match 'operator-submit <text>'
+        $script:controlRpcBridgeContent | Should -Match 'operator-snapshot \[--lines <n>\]'
+        $script:controlRpcBridgeContent | Should -Match "'operator-submit'\s*\{\s*Invoke-OperatorSubmit\s*\}"
+        $script:controlRpcBridgeContent | Should -Match "'operator-snapshot'\s*\{\s*Invoke-OperatorSnapshot\s*\}"
         $script:controlRpcBridgeContent | Should -Match '\$client\.ReadAsync\(\$buffer, 0, \$buffer\.Length\)'
         $script:controlRpcBridgeContent | Should -Match 'timed out waiting for response'
         $script:controlRpcBridgeContent | Should -Match 'WINSMUX_CONTROL_PIPE_TOKEN'
@@ -20690,6 +20694,46 @@ Describe 'winsmux control-rpc command' {
     It 'rejects JSON-RPC requests without a method' {
         { ConvertTo-ControlRpcPayload -JsonText '{"jsonrpc":"2.0","id":1}' } |
             Should -Throw 'control-rpc payload must include a non-empty method'
+    }
+
+    It 'submits operator messages through the dedicated operator control API' {
+        $env:WINSMUX_CONTROL_PIPE_TOKEN = 'test-control-token'
+        Mock Invoke-ControlRpcPipeExchange {
+            param([string]$Payload)
+            $script:operatorSubmitPayload = $Payload
+            return '{"jsonrpc":"2.0","id":"operator-submit","result":{"ok":true}}'
+        }
+
+        $script:operatorSubmitPayload = ''
+        $output = Invoke-OperatorSubmit -ControlTarget '--text' -ControlRest @('Restore', 'the', 'six-pane', 'orchestra')
+
+        Should -Invoke Invoke-ControlRpcPipeExchange -Times 1 -Exactly
+        $request = $script:operatorSubmitPayload | ConvertFrom-Json
+        $request.method | Should -Be 'desktop.operator.submit'
+        $request.params.message | Should -Be 'Restore the six-pane orchestra'
+        $request.auth.token | Should -Be 'test-control-token'
+        $request.PSObject.Properties.Name | Should -Not -Contain 'paneId'
+        $output | Should -Be '{"jsonrpc":"2.0","id":"operator-submit","result":{"ok":true}}'
+    }
+
+    It 'captures operator output through the dedicated operator control API' {
+        $env:WINSMUX_CONTROL_PIPE_TOKEN = 'test-control-token'
+        Mock Invoke-ControlRpcPipeExchange {
+            param([string]$Payload)
+            $script:operatorSnapshotPayload = $Payload
+            return '{"jsonrpc":"2.0","id":"operator-snapshot","result":{"paneId":"operator","output":"ready"}}'
+        }
+
+        $script:operatorSnapshotPayload = ''
+        $output = Invoke-OperatorSnapshot -ControlTarget '--lines' -ControlRest @('40')
+
+        Should -Invoke Invoke-ControlRpcPipeExchange -Times 1 -Exactly
+        $request = $script:operatorSnapshotPayload | ConvertFrom-Json
+        $request.method | Should -Be 'desktop.operator.snapshot'
+        $request.params.lines | Should -Be 40
+        $request.auth.token | Should -Be 'test-control-token'
+        $request.PSObject.Properties.Name | Should -Not -Contain 'paneId'
+        $output | Should -Be '{"jsonrpc":"2.0","id":"operator-snapshot","result":{"paneId":"operator","output":"ready"}}'
     }
 }
 

--- a/winsmux-app/src-tauri/src/control_pipe.rs
+++ b/winsmux-app/src-tauri/src/control_pipe.rs
@@ -2,7 +2,8 @@ use crate::desktop_backend::{
     handle_desktop_json_rpc, DesktopCommandTransport, DesktopJsonRpcRequest, PwshScriptTransport,
 };
 use crate::pty_backend::{
-    handle_pty_json_rpc, PtyCommandTransport, PtyJsonRpcRequest, PTY_CONTROL_PIPE_METHODS,
+    handle_pty_json_rpc, PtyCommandTransport, PtyJsonRpcRequest, OPERATOR_CONTROL_PIPE_METHODS,
+    PTY_CONTROL_PIPE_METHODS,
 };
 use serde_json::{json, Value};
 use std::sync::Arc;
@@ -159,13 +160,14 @@ pub fn handle_control_pipe_payload(
 }
 
 fn is_pty_control_pipe_method(method: &str) -> bool {
-    PTY_CONTROL_PIPE_METHODS.contains(&method)
+    PTY_CONTROL_PIPE_METHODS.contains(&method) || OPERATOR_CONTROL_PIPE_METHODS.contains(&method)
 }
 
 fn control_pipe_methods() -> Vec<&'static str> {
     DESKTOP_CONTROL_PIPE_METHODS
         .iter()
         .chain(PTY_CONTROL_PIPE_METHODS.iter())
+        .chain(OPERATOR_CONTROL_PIPE_METHODS.iter())
         .copied()
         .collect()
 }
@@ -187,6 +189,7 @@ fn control_pipe_contract() -> Value {
     "methods": control_pipe_methods(),
     "desktop_methods": DESKTOP_CONTROL_PIPE_METHODS,
     "pty_methods": PTY_CONTROL_PIPE_METHODS,
+    "operator_methods": OPERATOR_CONTROL_PIPE_METHODS,
     "internal_desktop_methods_excluded": CONTROL_PIPE_EXCLUDED_INTERNAL_DESKTOP_METHODS,
     })
 }
@@ -527,6 +530,10 @@ mod tests {
             value["result"]["pty_methods"],
             json!(PTY_CONTROL_PIPE_METHODS)
         );
+        assert_eq!(
+            value["result"]["operator_methods"],
+            json!(OPERATOR_CONTROL_PIPE_METHODS)
+        );
         assert_eq!(value["result"]["methods"], json!(control_pipe_methods()));
         assert!(!value["result"]["methods"]
             .as_array()
@@ -543,6 +550,16 @@ mod tests {
             .expect("methods")
             .iter()
             .any(|method| method.as_str() == Some("pty.capture")));
+        assert!(value["result"]["methods"]
+            .as_array()
+            .expect("methods")
+            .iter()
+            .any(|method| method.as_str() == Some("desktop.operator.snapshot")));
+        assert!(value["result"]["methods"]
+            .as_array()
+            .expect("methods")
+            .iter()
+            .any(|method| method.as_str() == Some("desktop.operator.submit")));
     }
 
     #[test]
@@ -681,6 +698,53 @@ mod tests {
                 lines: None
             }]
         );
+    }
+
+    #[test]
+    fn control_pipe_routes_operator_methods_to_operator_pane_only() {
+        let _guard = set_control_pipe_token_for_test(Some("test-control-token"));
+        let payload = br#"{"jsonrpc":"2.0","id":1,"method":"desktop.operator.submit","params":{"message":"Run the approved cleanup once"},"auth":{"token":"test-control-token"}}"#;
+        let pty_transport = StubPtyTransport::new();
+        let response =
+            handle_control_pipe_payload(&StubDesktopTransport, &pty_transport, payload, None);
+        let value: Value = serde_json::from_slice(&response).expect("response should be JSON");
+
+        assert_eq!(value["jsonrpc"], "2.0");
+        assert_eq!(value["id"], 1);
+        assert_eq!(value["result"]["ok"], true);
+        assert_eq!(
+            pty_transport
+                .commands
+                .lock()
+                .expect("commands lock")
+                .as_slice(),
+            [PtyCommand::OperatorSubmit {
+                text: "Run the approved cleanup once\r".to_string()
+            }]
+        );
+    }
+
+    #[test]
+    fn control_pipe_rejects_operator_method_pane_override() {
+        let _guard = set_control_pipe_token_for_test(Some("test-control-token"));
+        let payload = br#"{"jsonrpc":"2.0","id":1,"method":"desktop.operator.snapshot","params":{"paneId":"worker-1","lines":40},"auth":{"token":"test-control-token"}}"#;
+        let pty_transport = StubPtyTransport::new();
+        let response =
+            handle_control_pipe_payload(&StubDesktopTransport, &pty_transport, payload, None);
+        let value: Value = serde_json::from_slice(&response).expect("response should be JSON");
+
+        assert_eq!(value["jsonrpc"], "2.0");
+        assert_eq!(value["id"], 1);
+        assert_eq!(value["error"]["code"], JSON_RPC_INVALID_PARAMS);
+        assert!(value["error"]["message"]
+            .as_str()
+            .expect("error message")
+            .contains("operator pane"));
+        assert!(pty_transport
+            .commands
+            .lock()
+            .expect("commands lock")
+            .is_empty());
     }
 
     #[test]

--- a/winsmux-app/src-tauri/src/lib.rs
+++ b/winsmux-app/src-tauri/src/lib.rs
@@ -1176,6 +1176,16 @@ impl PtyCommandTransport for TauriPtyTransport {
                 Ok(serde_json::json!({ "paneId": pane_id }))
             }
             PtyCommand::Capture { pane_id, lines } => capture_pty(&self.app, pane_id, *lines),
+            PtyCommand::OperatorSnapshot { lines } => {
+                capture_pty(&self.app, pty_backend::OPERATOR_PANE_ID, *lines)
+            }
+            PtyCommand::OperatorSubmit { text } => {
+                write_pty(&self.app, pty_backend::OPERATOR_PANE_ID, text)?;
+                Ok(serde_json::json!({
+                    "paneId": pty_backend::OPERATOR_PANE_ID,
+                    "submitted": true
+                }))
+            }
             PtyCommand::Respawn { pane_id } => {
                 respawn_pty(&self.app, pane_id)?;
                 Ok(serde_json::json!({ "paneId": pane_id }))

--- a/winsmux-app/src-tauri/src/pty_backend.rs
+++ b/winsmux-app/src-tauri/src/pty_backend.rs
@@ -7,6 +7,11 @@ const JSON_RPC_METHOD_NOT_FOUND: i32 = -32601;
 const JSON_RPC_INVALID_PARAMS: i32 = -32602;
 const JSON_RPC_SERVER_ERROR: i32 = -32000;
 
+pub const OPERATOR_PANE_ID: &str = "operator";
+
+pub const OPERATOR_CONTROL_PIPE_METHODS: &[&str] =
+    &["desktop.operator.snapshot", "desktop.operator.submit"];
+
 pub const PTY_CONTROL_PIPE_METHODS: &[&str] = &[
     "pty.spawn",
     "pty.write",
@@ -66,6 +71,12 @@ pub enum PtyCommand {
     Capture {
         pane_id: String,
         lines: Option<u16>,
+    },
+    OperatorSnapshot {
+        lines: Option<u16>,
+    },
+    OperatorSubmit {
+        text: String,
     },
     Respawn {
         pane_id: String,
@@ -134,6 +145,21 @@ fn parse_command(method: &str, params: Option<&Value>) -> Result<PtyCommand, Par
             pane_id: get_required_string_param(params, &["paneId", "pane_id"])?,
             lines: get_optional_u16_param(params, &["lines"])?,
         }),
+        "desktop.operator.snapshot" => {
+            reject_operator_pane_override(params)?;
+            Ok(PtyCommand::OperatorSnapshot {
+                lines: get_optional_u16_param(params, &["lines"])?,
+            })
+        }
+        "desktop.operator.submit" => {
+            reject_operator_pane_override(params)?;
+            Ok(PtyCommand::OperatorSubmit {
+                text: normalize_operator_submit_text(get_required_pty_data_param(
+                    params,
+                    &["text", "message", "data"],
+                )?),
+            })
+        }
         "pty.respawn" => Ok(PtyCommand::Respawn {
             pane_id: get_required_string_param(params, &["paneId", "pane_id"])?,
         }),
@@ -144,6 +170,30 @@ fn parse_command(method: &str, params: Option<&Value>) -> Result<PtyCommand, Par
             "Unknown pty JSON-RPC method: {method}"
         ))),
     }
+}
+
+fn reject_operator_pane_override(params: Option<&Value>) -> Result<(), ParseError> {
+    let Some(object) = params.and_then(Value::as_object) else {
+        return Ok(());
+    };
+
+    for key in ["paneId", "pane_id"] {
+        if object.contains_key(key) {
+            return Err(ParseError::InvalidParams(
+                "desktop.operator.* methods always target the operator pane; remove paneId"
+                    .to_string(),
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+fn normalize_operator_submit_text(mut text: String) -> String {
+    if !text.ends_with('\r') && !text.ends_with('\n') {
+        text.push('\r');
+    }
+    text
 }
 
 fn get_required_string_param(params: Option<&Value>, keys: &[&str]) -> Result<String, ParseError> {
@@ -407,6 +457,115 @@ mod tests {
                 lines: Some(25)
             }]
         );
+    }
+
+    #[test]
+    fn handle_pty_json_rpc_routes_operator_snapshot_without_pane_override() {
+        let transport = FakeTransport {
+            commands: RefCell::new(Vec::new()),
+            response: serde_json::json!({
+                "paneId": "operator",
+                "output": "operator waiting"
+            }),
+        };
+
+        let response = handle_pty_json_rpc(
+            &transport,
+            PtyJsonRpcRequest {
+                jsonrpc: "2.0".to_string(),
+                id: serde_json::json!("req-operator-snapshot"),
+                method: "desktop.operator.snapshot".to_string(),
+                params: Some(serde_json::json!({
+                    "lines": 80
+                })),
+            },
+        );
+
+        match response {
+            PtyJsonRpcResponse::Success { result, .. } => {
+                assert_eq!(result["paneId"], "operator");
+                assert_eq!(result["output"], "operator waiting");
+            }
+            PtyJsonRpcResponse::Error { error, .. } => {
+                panic!("expected success, got {:?}", error);
+            }
+        }
+
+        assert_eq!(
+            transport.commands.borrow().as_slice(),
+            [PtyCommand::OperatorSnapshot { lines: Some(80) }]
+        );
+    }
+
+    #[test]
+    fn handle_pty_json_rpc_routes_operator_submit_with_enter() {
+        let transport = FakeTransport {
+            commands: RefCell::new(Vec::new()),
+            response: serde_json::json!({
+                "paneId": "operator",
+                "submitted": true
+            }),
+        };
+
+        let response = handle_pty_json_rpc(
+            &transport,
+            PtyJsonRpcRequest {
+                jsonrpc: "2.0".to_string(),
+                id: serde_json::json!("req-operator-submit"),
+                method: "desktop.operator.submit".to_string(),
+                params: Some(serde_json::json!({
+                    "text": "Continue with option 1"
+                })),
+            },
+        );
+
+        match response {
+            PtyJsonRpcResponse::Success { result, .. } => {
+                assert_eq!(result["paneId"], "operator");
+                assert_eq!(result["submitted"], true);
+            }
+            PtyJsonRpcResponse::Error { error, .. } => {
+                panic!("expected success, got {:?}", error);
+            }
+        }
+
+        assert_eq!(
+            transport.commands.borrow().as_slice(),
+            [PtyCommand::OperatorSubmit {
+                text: "Continue with option 1\r".to_string()
+            }]
+        );
+    }
+
+    #[test]
+    fn handle_pty_json_rpc_rejects_operator_pane_override() {
+        let transport = FakeTransport {
+            commands: RefCell::new(Vec::new()),
+            response: serde_json::json!({}),
+        };
+
+        let response = handle_pty_json_rpc(
+            &transport,
+            PtyJsonRpcRequest {
+                jsonrpc: "2.0".to_string(),
+                id: serde_json::json!("req-operator-override"),
+                method: "desktop.operator.submit".to_string(),
+                params: Some(serde_json::json!({
+                    "paneId": "worker-1",
+                    "text": "Do not route to a worker directly"
+                })),
+            },
+        );
+
+        match response {
+            PtyJsonRpcResponse::Error { error, .. } => {
+                assert_eq!(error.code, JSON_RPC_INVALID_PARAMS);
+                assert!(error.message.contains("operator pane"));
+            }
+            PtyJsonRpcResponse::Success { .. } => panic!("expected invalid params error"),
+        }
+
+        assert!(transport.commands.borrow().is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add dedicated operator submit and snapshot helpers for the external control pipe.
- Expose and document `desktop.operator.submit` and `desktop.operator.snapshot` as operator-only methods.
- Keep external agents on the operator path and reject worker pane overrides for these methods.

Closes #1044

## Tests
- `Invoke-Pester -Path .\tests\winsmux-bridge.Tests.ps1 -FullName 'winsmux control-rpc command' -Output Detailed`
- `cargo test --manifest-path .\winsmux-app\src-tauri\Cargo.toml control_pipe_routes_operator_methods_to_operator_pane_only --lib`
- `cargo test --manifest-path .\winsmux-app\src-tauri\Cargo.toml handle_pty_json_rpc_routes_operator_submit_with_enter --lib`
- `cargo test --manifest-path .\winsmux-app\src-tauri\Cargo.toml control_pipe_returns_external_contract_matching_allowlist --lib`
- `git diff --cached --check`
