### PR TITLE
fix(desktop): register operator pty for control pipe clients

### DIFF
--- a/winsmux-app/package.json
+++ b/winsmux-app/package.json
@@ -11,6 +11,7 @@
     "test:clickable-coverage": "npm run build && node ./scripts/clickable-coverage-harness.mjs",
     "test:desktop-pane-e2e": "node ./scripts/desktop-pane-e2e.mjs",
     "test:desktop-launch-arg-e2e": "node ./scripts/desktop-pane-e2e.mjs --launch-project-only",
+    "test:desktop-operator-snapshot-e2e": "node ./scripts/desktop-pane-e2e.mjs --operator-snapshot-only",
     "test:desktop-release-popout-e2e": "node ./scripts/desktop-pane-e2e.mjs --release-popout-only",
     "test:desktop-status-e2e": "node ./scripts/desktop-pane-e2e.mjs --stop-after-worker-status",
     "test:editor-targets": "node ./scripts/editor-targets-check.mjs",

--- a/winsmux-app/scripts/desktop-pane-e2e.mjs
+++ b/winsmux-app/scripts/desktop-pane-e2e.mjs
@@ -15,6 +15,8 @@ const WORKER_START_ONLY = process.argv.includes("--worker-start-only")
   || process.env.WINSMUX_DESKTOP_E2E_WORKER_START_ONLY === "1";
 const COMPOSER_ONLY = process.argv.includes("--composer-only")
   || process.env.WINSMUX_DESKTOP_E2E_COMPOSER_ONLY === "1";
+const OPERATOR_SNAPSHOT_ONLY = process.argv.includes("--operator-snapshot-only")
+  || process.env.WINSMUX_DESKTOP_E2E_OPERATOR_SNAPSHOT_ONLY === "1";
 const ASSERT_DUPLICATE_GUARD_ONLY = process.argv.includes("--assert-duplicate-launch-guard")
   || process.env.WINSMUX_DESKTOP_E2E_ASSERT_DUPLICATE_GUARD_ONLY === "1";
 const OUTPUT_DIR = path.join(
@@ -25,6 +27,8 @@ const OUTPUT_DIR = path.join(
     ? "desktop-worker-start-e2e"
     : COMPOSER_ONLY
     ? "desktop-composer-e2e"
+    : OPERATOR_SNAPSHOT_ONLY
+    ? "desktop-operator-snapshot-e2e"
     : RELEASE_POPOUT_ONLY
     ? "desktop-release-popout-e2e"
     : LAUNCH_PROJECT_ONLY
@@ -224,6 +228,32 @@ function runWinsmuxCore(args, env = {}) {
     throw new Error(`winsmux-core.ps1 ${args.join(" ")} failed (${result.status}): ${result.stdout}\n${result.stderr}`);
   }
   return result.stdout.trim();
+}
+
+async function waitForOperatorSnapshotFromControlPipe(timeoutMs = 60_000) {
+  const startedAt = Date.now();
+  let lastError = "";
+  let lastOutput = "";
+  while (Date.now() - startedAt < timeoutMs) {
+    try {
+      lastOutput = runWinsmuxCore(["operator-snapshot", "--lines", "20"], {
+        WINSMUX_CONTROL_PIPE_TOKEN: CONTROL_PIPE_TOKEN,
+      });
+      if (/Pane operator not found/i.test(lastOutput)) {
+        throw new Error(lastOutput);
+      }
+      return {
+        outputTail: lastOutput.slice(-1_200),
+      };
+    } catch (error) {
+      lastError = error instanceof Error ? error.message : String(error);
+      if (!/Pane operator not found|failed \(|pipe|connect|timed out|timeout/i.test(lastError)) {
+        throw error;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 1_000));
+    }
+  }
+  throw new Error(`operator-snapshot did not become available. Last output: ${lastOutput}\nLast error: ${lastError}`);
 }
 
 async function stopProcessTree(child) {
@@ -2109,6 +2139,17 @@ async function main() {
       await waitForAppReady(page);
       return { url: page.url() };
     });
+
+    if (OPERATOR_SNAPSHOT_ONLY) {
+      await runStep("operator control pipe snapshot works without composer interaction", async () => {
+        return await waitForOperatorSnapshotFromControlPipe();
+      });
+      await ensureOutputDir();
+      await page.screenshot({ path: path.join(OUTPUT_DIR, "desktop-operator-snapshot-e2e-success.png"), fullPage: true });
+      await writeEvidence(true, { debugPort, mode: "operator-snapshot-only" });
+      process.stdout.write(`[desktop-pane-e2e] PASS operator-snapshot-only evidence=${path.join(OUTPUT_DIR, "desktop-pane-e2e.json")}\n`);
+      return;
+    }
 
     if (COMPOSER_ONLY) {
       await runStep("composer-only surface is visible", async () => {

--- a/winsmux-app/src-tauri/src/lib.rs
+++ b/winsmux-app/src-tauri/src/lib.rs
@@ -110,6 +110,11 @@ fn desktop_initial_project_dir() -> Option<String> {
     resolve_initial_project_dir_from_args(std::env::args())
 }
 
+#[tauri::command]
+fn desktop_control_pipe_enabled() -> bool {
+    std::env::var_os(WINSMUX_CONTROL_PIPE_TOKEN_ENV).is_some()
+}
+
 struct SinglePty {
     writer: Arc<Mutex<Box<dyn Write + Send>>>,
     master: Arc<Mutex<Box<dyn portable_pty::MasterPty + Send>>>,
@@ -1235,6 +1240,7 @@ pub fn run() {
             desktop_voice_capture_start,
             desktop_voice_capture_stop,
             desktop_initial_project_dir,
+            desktop_control_pipe_enabled,
             pty_json_rpc,
             pty_spawn,
             pty_write,

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -255,6 +255,11 @@ type PopoutSurfaceState =
 
 declare global {
   interface Window {
+    __TAURI__?: {
+      core?: {
+        invoke?: (command: string, args?: Record<string, unknown>) => Promise<unknown>;
+      };
+    };
     __winsmuxViewportHarness?: {
       registerPreviewTarget: (sourceLabel: string, url: string) => void;
       openPreviewTarget: (url: string) => void;
@@ -1986,6 +1991,31 @@ function ensureOperatorPtyStarted() {
     });
 
   return operatorPtyStarting;
+}
+
+async function isControlPipeEnabled() {
+  try {
+    return Boolean(await window.__TAURI__?.core?.invoke?.("desktop_control_pipe_enabled"));
+  } catch (error) {
+    console.warn("Failed to read control pipe status", error);
+    return false;
+  }
+}
+
+function ensureOperatorPtyStartedForControlPipe() {
+  if (!isTauri()) {
+    return;
+  }
+  window.setTimeout(() => {
+    void (async () => {
+      if (!(await isControlPipeEnabled())) {
+        return;
+      }
+      await ensureOperatorPtyStarted();
+    })().catch((error) => {
+      console.warn("Failed to register operator PTY for control pipe", error);
+    });
+  }, 0);
 }
 
 function ensurePanePtyStarted(paneId: string) {
@@ -17729,6 +17759,7 @@ window.addEventListener("DOMContentLoaded", async () => {
   }).catch((error) => {
     console.warn("Failed to subscribe to PTY output events", error);
   });
+  ensureOperatorPtyStartedForControlPipe();
 
   renderSessions();
   renderExplorer();


### PR DESCRIPTION
## Summary
- Register the real operator PTY automatically when the external control pipe is enabled.
- Keep normal desktop launches lazy by checking the control-pipe token before starting the operator PTY.
- Add a focused desktop E2E mode that verifies `operator-snapshot` works without clicking the operator composer first.

Closes #1054

## Test Plan
- [x] `cargo test -p winsmux-app control_pipe_routes_operator_methods_to_operator_pane_only`
- [x] `cargo test -p winsmux-app control_pipe_rejects_operator_method_pane_override`
- [x] `npm run build`
- [x] `npm run test:desktop-operator-snapshot-e2e`
- [x] `git diff --check`
