### PR TITLE
docs: clarify npm launch path

### DIFF
--- a/docs/installation.ja.md
+++ b/docs/installation.ja.md
@@ -35,6 +35,15 @@ winsmux version
 winsmux doctor
 ```
 
+その後、エージェントに作業させたいプロジェクトへ移動し、その場所から
+CLI で管理するワークスペースを起動します。
+
+```powershell
+cd <project>
+winsmux init
+winsmux launch
+```
+
 ## デスクトップアプリのインストーラー
 
 デスクトップアプリを使う場合は、対象の GitHub Release から Windows 用インストーラーを取得します。
@@ -70,6 +79,20 @@ winsmux install --profile full
 ```
 
 npm コマンドは同梱されたインストーラーに処理を渡します。インストーラーは npm パッケージと同じ Git tag に固定されます。
+
+インストール後は、作業対象のプロジェクトディレクトリへ移動して、管理対象
+ワークスペースを起動します。
+
+```powershell
+cd <project>
+winsmux init
+winsmux launch
+```
+
+`winsmux launch` が CLI 経路の公開起動コマンドです。初回確認を行い、
+管理された Windows Terminal ワークスペースを起動します。デスクトップアプリは
+別経路です。GitHub Release からデスクトップアプリを入れた場合は、アプリを開き、
+同じプロジェクトフォルダーを選択して画面上の管制面を使います。
 
 ## インストールプロファイル
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -35,6 +35,15 @@ winsmux version
 winsmux doctor
 ```
 
+Then open the project you want agents to work in and start the CLI-managed
+workspace from that project directory:
+
+```powershell
+cd <project>
+winsmux init
+winsmux launch
+```
+
 ## Desktop app installer
 
 For the desktop app, download the Windows installer from the matching GitHub Release:
@@ -73,6 +82,20 @@ winsmux install --profile full
 ```
 
 The npm command delegates to the bundled installer and pins the installer to the same release tag as the npm package.
+
+After the package install finishes, move to the project directory and launch the
+managed workspace:
+
+```powershell
+cd <project>
+winsmux init
+winsmux launch
+```
+
+`winsmux launch` is the public CLI startup path. It runs the first-run checks
+and starts the managed Windows Terminal workspace. The desktop app installer is
+separate: install the desktop app from GitHub Releases, open it, and choose the
+same project folder there when you want the graphical control surface.
 
 ## Installer profiles
 

--- a/packages/winsmux/README.md
+++ b/packages/winsmux/README.md
@@ -53,6 +53,19 @@ winsmux update --profile orchestra
 `install.ps1` accepts the same profile names through `-Profile`. The package
 entrypoint forwards `--profile` to that script as `-Profile`.
 
+After installation, start winsmux from the project directory that agents should
+work in:
+
+```powershell
+cd <project>
+winsmux init
+winsmux launch
+```
+
+`winsmux launch` is the public CLI startup path for the npm package. It is
+separate from the desktop installer path, where users install the desktop app
+from GitHub Releases and choose the same project folder in the app.
+
 Updates keep the previously recorded profile when no new profile is supplied.
 Each install or update records the selected shape in:
 


### PR DESCRIPTION
## Summary
- clarify that `winsmux launch` starts the npm/CLI-managed workspace
- separate the desktop app installer path from the npm CLI startup path
- add the same post-install startup steps to the npm package README

## Verification
- `git diff --check -- docs/installation.md docs/installation.ja.md packages/winsmux/README.md`
- push hook: git-guard full
- push hook: audit-public-surface
- push hook: gitleaks

Fixes #1059