### PR TITLE
fix(desktop): reject stale benchmark launch targets

### DIFF
--- a/scripts/start-cli-bakeoff-desktop.ps1
+++ b/scripts/start-cli-bakeoff-desktop.ps1
@@ -74,6 +74,38 @@ function Invoke-CheckedCommand {
     }
 }
 
+function Assert-DesktopExecutableFreshForDist {
+    param(
+        [Parameter(Mandatory = $true)][string]$DesktopExecutable,
+        [string]$DistDir = (Join-Path $RepoRoot 'winsmux-app\dist')
+    )
+
+    if (-not (Test-Path -LiteralPath $DesktopExecutable -PathType Leaf)) {
+        throw "Production desktop executable was not found: $DesktopExecutable"
+    }
+    if (-not (Test-Path -LiteralPath $DistDir -PathType Container)) {
+        throw "Desktop dist directory was not found: $DistDir"
+    }
+
+    $newestDistFile = Get-ChildItem -LiteralPath $DistDir -Recurse -File |
+        Sort-Object LastWriteTimeUtc -Descending |
+        Select-Object -First 1
+    if ($null -eq $newestDistFile) {
+        throw "Desktop dist directory is empty: $DistDir"
+    }
+
+    $desktopFile = Get-Item -LiteralPath $DesktopExecutable
+    if ($desktopFile.LastWriteTimeUtc -lt $newestDistFile.LastWriteTimeUtc) {
+        throw "Production desktop executable is older than winsmux-app/dist. Rebuild the desktop app before launch. exeUtc=$($desktopFile.LastWriteTimeUtc.ToString('o')) newestDistUtc=$($newestDistFile.LastWriteTimeUtc.ToString('o')) newestDistFile=$($newestDistFile.FullName)"
+    }
+
+    return [pscustomobject]@{
+        desktopExecutableUtc = $desktopFile.LastWriteTimeUtc.ToString('o')
+        newestDistUtc = $newestDistFile.LastWriteTimeUtc.ToString('o')
+        newestDistFile = $newestDistFile.FullName
+    }
+}
+
 function Copy-BenchmarkTaskPack {
     param(
         [Parameter(Mandatory = $true)][string]$SourceDir,
@@ -135,6 +167,22 @@ function Stop-RepoWinsmuxDesktopTree {
     } while ((Get-Date) -lt $deadline)
 
     throw "Existing repo-built winsmux desktop process did not exit: $($remaining -join ', ')"
+}
+
+function Assert-NoExternalWinsmuxDesktopApp {
+    $externalApps = @(
+        Get-CimInstance Win32_Process |
+            Where-Object {
+                $_.Name -eq 'winsmux-app.exe' -and
+                -not (Test-PathInsideRepo ([string]$_.ExecutablePath))
+            } |
+            Select-Object ProcessId, ExecutablePath, CommandLine
+    )
+
+    if ($externalApps.Count -gt 0) {
+        $details = ($externalApps | ForEach-Object { "pid=$($_.ProcessId) exe=$($_.ExecutablePath)" }) -join '; '
+        throw "External winsmux desktop app is already running. Close it before benchmark launch. $details"
+    }
 }
 
 function Wait-RepoWinsmuxDesktopApp {
@@ -307,6 +355,8 @@ if (-not $SkipBuild) {
     Invoke-CheckedCommand -FilePath 'npm' -ArgumentList @('run', 'tauri', '--', 'build', '--no-bundle') -WorkingDirectory (Join-Path $RepoRoot 'winsmux-app')
 }
 
+$desktopFreshness = Assert-DesktopExecutableFreshForDist -DesktopExecutable $releaseApp
+
 $preflightArgs = @(
     '-NoProfile',
     '-ExecutionPolicy',
@@ -349,6 +399,7 @@ if ($NoLaunch) {
         gitHead = $head
         releaseCli = $releaseCli
         releaseApp = $releaseApp
+        desktopFreshness = $desktopFreshness
         preflight = $preflight
     }
     if ($Json) {
@@ -368,6 +419,7 @@ if (-not (Test-Path -LiteralPath $releaseApp -PathType Leaf)) {
 }
 
 Stop-RepoWinsmuxDesktopTree
+Assert-NoExternalWinsmuxDesktopApp
 
 $webviewUserData = Join-Path $RepoRoot '.winsmux\tmp\webview2-v03623-harness'
 New-Item -ItemType Directory -Path $webviewUserData -Force | Out-Null
@@ -402,6 +454,7 @@ $result = [pscustomobject]@{
     projectPackPath = Join-Path $projectTaskDir 'benchmark-pack.json'
     releaseCli = $releaseCli
     releaseApp = $releaseApp
+    desktopFreshness = $desktopFreshness
     debugPort = $DebugPort
     page = $page
     windowBeforeMove = $metricsBeforeMove

--- a/tests/CliBakeoff.Tests.ps1
+++ b/tests/CliBakeoff.Tests.ps1
@@ -165,6 +165,28 @@ Describe 'CLI bakeoff evidence harness' {
         ($buildStopIndex -lt $tauriBuildIndex) | Should -BeTrue
     }
 
+    It 'rejects stale desktop executables before benchmark preflight or launch' {
+        $scriptText = Get-Content -LiteralPath $script:DesktopStartScript -Raw -Encoding UTF8
+        $freshnessFunctionIndex = $scriptText.IndexOf('function Assert-DesktopExecutableFreshForDist')
+        $freshnessCallIndex = $scriptText.IndexOf('$desktopFreshness = Assert-DesktopExecutableFreshForDist -DesktopExecutable $releaseApp')
+        $preflightArgsIndex = $scriptText.IndexOf('$preflightArgs = @(')
+        $launchIndex = $scriptText.IndexOf('$launcherProcess = Start-Process -FilePath $releaseApp')
+
+        ($freshnessFunctionIndex -ge 0) | Should -BeTrue
+        ($freshnessCallIndex -gt $freshnessFunctionIndex) | Should -BeTrue
+        ($preflightArgsIndex -gt $freshnessCallIndex) | Should -BeTrue
+        ($launchIndex -gt $freshnessCallIndex) | Should -BeTrue
+        $scriptText | Should -Match 'Production desktop executable is older than winsmux-app/dist'
+        $scriptText | Should -Match 'newestDistUtc'
+    }
+
+    It 'rejects the Tauri dev server URL during packaged desktop E2E' {
+        $scriptText = Get-Content -LiteralPath (Join-Path $script:RepoRoot 'winsmux-app\scripts\desktop-pane-e2e.mjs') -Raw -Encoding UTF8
+        $scriptText | Should -Match 'allowDevServer'
+        $scriptText | Should -Match 'Packaged desktop resolved to the Tauri dev server URL'
+        $scriptText | Should -Match 'allowDevServer: !RELEASE_POPOUT_ONLY'
+    }
+
     It 'filters content-clean status noise before enforcing the candidate clean gate' {
         $scriptText = Get-Content -LiteralPath $script:PreflightScript -Raw -Encoding UTF8
         $scriptText | Should -Match 'function Get-GitContentDirtyStatus'

--- a/winsmux-app/scripts/desktop-pane-e2e.mjs
+++ b/winsmux-app/scripts/desktop-pane-e2e.mjs
@@ -296,12 +296,15 @@ async function waitForCdp(debugPort, child, timeoutMs = 180_000) {
   throw new Error(`WebView2 remote debugging did not start within ${timeoutMs}ms on port ${debugPort}`);
 }
 
-async function resolveAppPage(browser, timeoutMs = 60_000) {
+async function resolveAppPage(browser, timeoutMs = 60_000, { allowDevServer = true } = {}) {
   const startedAt = Date.now();
   while (Date.now() - startedAt < timeoutMs) {
     for (const context of browser.contexts()) {
       for (const page of context.pages()) {
         if (APP_URL_PATTERN.test(page.url())) {
+          if (!allowDevServer) {
+            throw new Error(`Packaged desktop resolved to the Tauri dev server URL instead of the production page: ${page.url()}`);
+          }
           return page;
         }
         const hasAppShell = await page.evaluate(() => Boolean(document.querySelector("#app-shell"))).catch(() => false);
@@ -2132,7 +2135,7 @@ async function main() {
     });
 
     browser = await chromium.connectOverCDP(`http://127.0.0.1:${debugPort}`);
-    page = await resolveAppPage(browser);
+    page = await resolveAppPage(browser, 60_000, { allowDevServer: !RELEASE_POPOUT_ONLY });
     attachPageErrorCapture(page);
 
     await runStep("wait for desktop app chrome", async () => {


### PR DESCRIPTION
## Summary
- Reject stale `winsmux-app.exe` builds before benchmark preflight or launch.
- Reject already-running external `winsmux-app.exe` processes before starting the benchmark desktop path.
- Fail packaged desktop E2E when it resolves to the Tauri dev server URL instead of the production page.

## Verification
- `Invoke-Pester -Path tests/CliBakeoff.Tests.ps1 -Output Minimal` (19 passed)
- `git diff --check`
- `node --check winsmux-app/scripts/desktop-pane-e2e.mjs`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/git-guard.ps1 -Mode full`

## Issue
- Part of #1061. This does not claim the WebView freeze is fully resolved; it prevents stale/dev launch paths from being accepted as valid benchmark evidence.