### PR TITLE
fix(desktop): route backend worker output to visible panes

### DIFF
--- a/.githooks/pre-commit-whitelist.ps1
+++ b/.githooks/pre-commit-whitelist.ps1
@@ -144,6 +144,7 @@ $whitelistPatterns = @(
     'winsmux-app/src/composerText.ts',
     'winsmux-app/src/modelCapabilities.ts',
     'winsmux-app/src/sourceGraph.ts',
+    'winsmux-app/src/workerPaneRouting.ts',
     'winsmux-app/src/styles.css',
     'winsmux-app/src-tauri/Cargo.toml',
     'winsmux-app/src-tauri/Cargo.lock',

--- a/winsmux-app/package.json
+++ b/winsmux-app/package.json
@@ -15,6 +15,7 @@
     "test:desktop-release-popout-e2e": "node ./scripts/desktop-pane-e2e.mjs --release-popout-only",
     "test:desktop-status-e2e": "node ./scripts/desktop-pane-e2e.mjs --stop-after-worker-status",
     "test:editor-targets": "node ./scripts/editor-targets-check.mjs",
+    "test:worker-pane-routing": "node ./scripts/worker-pane-routing-check.mjs",
     "test:source-graph": "node ./scripts/source-graph-check.mjs",
     "test:windows-context-menu": "pwsh -NoProfile -ExecutionPolicy Bypass -File ./scripts/windows-context-menu-e2e.ps1",
     "test:viewport-harness": "npm run build && node ./scripts/viewport-harness.mjs",

--- a/winsmux-app/scripts/worker-pane-routing-check.mjs
+++ b/winsmux-app/scripts/worker-pane-routing-check.mjs
@@ -1,0 +1,124 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import ts from "typescript";
+
+async function loadWorkerPaneRoutingModule() {
+  const sourcePath = path.resolve("src/workerPaneRouting.ts");
+  const source = await readFile(sourcePath, "utf8");
+  const transpiled = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.ESNext,
+      target: ts.ScriptTarget.ES2020,
+    },
+    fileName: sourcePath,
+  });
+
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "winsmux-worker-pane-routing-"));
+  const modulePath = path.join(tempDir, "workerPaneRouting.mjs");
+  await writeFile(modulePath, transpiled.outputText, "utf8");
+
+  try {
+    return await import(pathToFileURL(modulePath).href);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+const {
+  findBoardPaneForWorkbenchPane,
+  findWorkerStatusRowByPaneAlias,
+  getWorkerStatusPaneAliases,
+  resolveWorkbenchPaneIdForBackendPaneId,
+} = await loadWorkerPaneRoutingModule();
+
+const rows = [
+  { slot_id: "worker-1", slot: "worker-1", pane_id: "%2" },
+  { slot_id: "worker-2", slot: "worker-2", pane_id: "%5" },
+];
+const visiblePaneIds = new Set(["worker-1", "worker-2"]);
+
+assert.deepEqual(getWorkerStatusPaneAliases(rows[0]), ["worker-1", "%2"]);
+assert.equal(findWorkerStatusRowByPaneAlias(rows, "%2"), rows[0]);
+assert.equal(findWorkerStatusRowByPaneAlias(rows, "worker-2"), rows[1]);
+assert.equal(findWorkerStatusRowByPaneAlias(rows, "unknown"), null);
+
+assert.equal(resolveWorkbenchPaneIdForBackendPaneId("%2", rows, visiblePaneIds), "worker-1");
+assert.equal(resolveWorkbenchPaneIdForBackendPaneId("worker-2", rows, visiblePaneIds), "worker-2");
+assert.equal(resolveWorkbenchPaneIdForBackendPaneId(" %5 ", rows, visiblePaneIds), "worker-2");
+assert.equal(resolveWorkbenchPaneIdForBackendPaneId("%9", rows, visiblePaneIds), null);
+assert.equal(resolveWorkbenchPaneIdForBackendPaneId("   ", rows, visiblePaneIds), null);
+
+const boardPanes = [
+  { pane_id: "worker-1", label: "worker-1" },
+  { pane_id: "worker-2", label: "worker-2" },
+];
+
+assert.equal(findBoardPaneForWorkbenchPane(boardPanes, "%2", rows), boardPanes[0]);
+assert.equal(findBoardPaneForWorkbenchPane(boardPanes, "worker-2", rows), boardPanes[1]);
+assert.equal(findBoardPaneForWorkbenchPane(boardPanes, "%9", rows), null);
+
+const paneBuffers = new Map([
+  ["worker-1", ""],
+  ["worker-2", ""],
+]);
+
+function appendBackendOutputToVisiblePane(backendPaneId, data) {
+  const visiblePaneId = resolveWorkbenchPaneIdForBackendPaneId(backendPaneId, rows, visiblePaneIds);
+  if (!visiblePaneId || !paneBuffers.has(visiblePaneId)) {
+    return false;
+  }
+  paneBuffers.set(visiblePaneId, `${paneBuffers.get(visiblePaneId)}${data}`);
+  return true;
+}
+
+assert.equal(appendBackendOutputToVisiblePane("%2", "WORKER1_RESULT"), true);
+assert.equal(paneBuffers.get("worker-1"), "WORKER1_RESULT");
+assert.equal(paneBuffers.get("worker-2"), "");
+
+assert.equal(appendBackendOutputToVisiblePane("%5", "WORKER2_RESULT"), true);
+assert.equal(paneBuffers.get("worker-1"), "WORKER1_RESULT");
+assert.equal(paneBuffers.get("worker-2"), "WORKER2_RESULT");
+
+assert.equal(appendBackendOutputToVisiblePane("%9", "UNKNOWN_RESULT"), false);
+assert.equal(paneBuffers.get("worker-1"), "WORKER1_RESULT");
+assert.equal(paneBuffers.get("worker-2"), "WORKER2_RESULT");
+
+const paneLifecycle = new Map([
+  ["worker-1", "not_started"],
+  ["worker-2", "not_started"],
+]);
+
+function applyBackendLifecycleEvent(backendPaneId, reason) {
+  const visiblePaneId = resolveWorkbenchPaneIdForBackendPaneId(backendPaneId, rows, visiblePaneIds);
+  if (!visiblePaneId || !paneLifecycle.has(visiblePaneId)) {
+    return false;
+  }
+  if (reason === "pty.spawn" || reason === "pty.respawn") {
+    paneLifecycle.set(visiblePaneId, "running");
+    return true;
+  }
+  if (reason === "pty.close") {
+    paneLifecycle.set(visiblePaneId, "stopped");
+    return true;
+  }
+  return false;
+}
+
+assert.equal(applyBackendLifecycleEvent("%2", "pty.spawn"), true);
+assert.equal(paneLifecycle.get("worker-1"), "running");
+assert.equal(paneLifecycle.get("worker-2"), "not_started");
+
+assert.equal(applyBackendLifecycleEvent("%5", "pty.respawn"), true);
+assert.equal(paneLifecycle.get("worker-2"), "running");
+
+assert.equal(applyBackendLifecycleEvent("%2", "pty.close"), true);
+assert.equal(paneLifecycle.get("worker-1"), "stopped");
+
+assert.equal(applyBackendLifecycleEvent("%9", "pty.spawn"), false);
+assert.equal(paneLifecycle.get("worker-1"), "stopped");
+assert.equal(paneLifecycle.get("worker-2"), "running");
+
+console.log("worker-pane-routing-check: ok");

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -46,6 +46,10 @@ import {
 } from "./ptyClient";
 import { isComposerCommandText, normalizeComposerPlainTextPaste } from "./composerText";
 import { getRuntimeCatalogEntries, openRouterModelsApiUrl } from "./modelCapabilities";
+import {
+  findBoardPaneForWorkbenchPane as findBoardPaneForWorkbenchPaneFromRows,
+  resolveWorkbenchPaneIdForBackendPaneId as resolveWorkbenchPaneIdFromRows,
+} from "./workerPaneRouting";
 
 interface PaneEntry {
   terminal: Terminal;
@@ -2096,6 +2100,14 @@ function getWorkerStartTarget() {
 
 function getWorkerStatusTarget(row: DesktopWorkerStatusRow) {
   return row.slot_id || row.slot || row.pane_id || "";
+}
+
+function resolveWorkbenchPaneIdForBackendPaneId(paneId: string) {
+  const normalizedPaneId = (paneId || "").trim();
+  if (!normalizedPaneId) {
+    return null;
+  }
+  return resolveWorkbenchPaneIdFromRows(normalizedPaneId, getWorkerStatusRowsForSurface(), new Set(panes.keys()));
 }
 
 function getWorkerStatusLaunch(row: DesktopWorkerStatusRow) {
@@ -17296,12 +17308,16 @@ function summarizeBoardPaneStatus(pane: DesktopBoardPane | null) {
   return role;
 }
 
+function findBoardPaneForWorkbenchPane(boardPanes: DesktopBoardPane[], paneId: string) {
+  return findBoardPaneForWorkbenchPaneFromRows(boardPanes, paneId, getWorkerStatusRowsForSurface());
+}
+
 function renderPaneMetadata() {
   const boardPanes = desktopSummarySnapshot?.board.panes ?? [];
   const now = Date.now();
 
   panes.forEach((pane, paneId) => {
-    const paneRecord = boardPanes.find((item) => item.pane_id === paneId) ?? null;
+    const paneRecord = findBoardPaneForWorkbenchPane(boardPanes, paneId);
     const paneLabel = getPaneDisplayLabel(paneId, paneRecord?.label);
     pane.labelElement.textContent = paneLabel;
 
@@ -17533,10 +17549,13 @@ function registerDesktopSummaryLiveRefresh() {
         } else if (event.reason === "pty.spawn" || event.reason === "pty.respawn") {
           markOperatorPtyStartedFromExternalEvent();
         }
-      } else if (event.reason === "pty.close") {
-        markPanePtyStoppedFromExternalEvent(event.pane_id);
-      } else if (event.reason === "pty.spawn" || event.reason === "pty.respawn") {
-        markPanePtyStartedFromExternalEvent(event.pane_id);
+      } else {
+        const workbenchPaneId = resolveWorkbenchPaneIdForBackendPaneId(event.pane_id);
+        if (workbenchPaneId && event.reason === "pty.close") {
+          markPanePtyStoppedFromExternalEvent(workbenchPaneId);
+        } else if (workbenchPaneId && (event.reason === "pty.spawn" || event.reason === "pty.respawn")) {
+          markPanePtyStartedFromExternalEvent(workbenchPaneId);
+        }
       }
     }
     if (event.source !== "pty") {
@@ -17734,10 +17753,11 @@ window.addEventListener("DOMContentLoaded", async () => {
       appendOperatorPtyOutput(payload.data);
       return;
     }
-    registerPreviewTargets(payload.pane_id, payload.data);
-    const entry = payload.pane_id ? panes.get(payload.pane_id) : undefined;
-    if (entry) {
-      markPanePtyStartedFromExternalEvent(payload.pane_id);
+    const workbenchPaneId = payload.pane_id ? resolveWorkbenchPaneIdForBackendPaneId(payload.pane_id) : null;
+    registerPreviewTargets(workbenchPaneId ?? payload.pane_id, payload.data);
+    const entry = workbenchPaneId ? panes.get(workbenchPaneId) : undefined;
+    if (workbenchPaneId && entry) {
+      markPanePtyStartedFromExternalEvent(workbenchPaneId);
       entry.lastOutputAt = Date.now();
       appendPaneOutputBuffer(entry, payload.data);
       entry.terminal.write(payload.data);

--- a/winsmux-app/src/workerPaneRouting.ts
+++ b/winsmux-app/src/workerPaneRouting.ts
@@ -1,0 +1,65 @@
+import type { DesktopBoardPane, DesktopWorkerStatusRow } from "./desktopClient";
+
+function compactPaneAlias(value: string | null | undefined) {
+  return (value || "").trim();
+}
+
+export function getWorkerStatusPaneAliases(row: DesktopWorkerStatusRow) {
+  const target = compactPaneAlias(row.slot_id) || compactPaneAlias(row.slot) || compactPaneAlias(row.pane_id);
+  const aliases = [
+    row.slot_id,
+    row.slot,
+    row.pane_id,
+    target,
+  ].map(compactPaneAlias).filter((value) => Boolean(value));
+  return Array.from(new Set(aliases));
+}
+
+export function findWorkerStatusRowByPaneAlias(rows: DesktopWorkerStatusRow[], paneId: string) {
+  const normalizedPaneId = compactPaneAlias(paneId);
+  if (!normalizedPaneId) {
+    return null;
+  }
+  return rows.find((row) => getWorkerStatusPaneAliases(row).includes(normalizedPaneId)) ?? null;
+}
+
+export function resolveWorkbenchPaneIdForBackendPaneId(
+  paneId: string,
+  rows: DesktopWorkerStatusRow[],
+  visiblePaneIds: ReadonlySet<string>,
+) {
+  const normalizedPaneId = compactPaneAlias(paneId);
+  if (!normalizedPaneId) {
+    return null;
+  }
+  if (visiblePaneIds.has(normalizedPaneId)) {
+    return normalizedPaneId;
+  }
+
+  const row = findWorkerStatusRowByPaneAlias(rows, normalizedPaneId);
+  if (!row) {
+    return null;
+  }
+
+  const aliases = getWorkerStatusPaneAliases(row);
+  return aliases.find((alias) => visiblePaneIds.has(alias)) ?? null;
+}
+
+export function findBoardPaneForWorkbenchPane(
+  boardPanes: DesktopBoardPane[],
+  paneId: string,
+  rows: DesktopWorkerStatusRow[],
+) {
+  const direct = boardPanes.find((item) => item.pane_id === paneId || item.label === paneId);
+  if (direct) {
+    return direct;
+  }
+
+  const workerRow = findWorkerStatusRowByPaneAlias(rows, paneId);
+  if (!workerRow) {
+    return null;
+  }
+
+  const aliases = getWorkerStatusPaneAliases(workerRow);
+  return boardPanes.find((item) => aliases.includes(item.pane_id) || aliases.includes(item.label)) ?? null;
+}


### PR DESCRIPTION
## Summary
- Resolve backend PTY pane ids such as `%2` through worker-status aliases before updating visible desktop panes.
- Route PTY output, lifecycle state, preview labels, and metadata lookup to the corresponding `worker-N` pane.
- Add a focused worker-pane routing regression check.

## Verification
- `npm run test:worker-pane-routing`
- `node --check scripts/worker-pane-routing-check.mjs`
- `npm run build`
- `git diff --check`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/git-guard.ps1 -Mode full`

Part of #1057. This PR does not close #1057 until a patched desktop build shows delegated worker output in the matching visible pane.
