### PR TITLE
fix(desktop): make operator submit deterministic

### DIFF
--- a/winsmux-app/src-tauri/src/control_pipe.rs
+++ b/winsmux-app/src-tauri/src/control_pipe.rs
@@ -719,7 +719,8 @@ mod tests {
                 .expect("commands lock")
                 .as_slice(),
             [PtyCommand::OperatorSubmit {
-                text: "Run the approved cleanup once\r".to_string()
+                text: "Run the approved cleanup once\r".to_string(),
+                submit_after_paste: false,
             }]
         );
     }

--- a/winsmux-app/src-tauri/src/lib.rs
+++ b/winsmux-app/src-tauri/src/lib.rs
@@ -981,6 +981,30 @@ fn capture_pty(
     }))
 }
 
+fn submit_operator_text_with(
+    mut write: impl FnMut(&str) -> Result<(), String>,
+    text: &str,
+    submit_after_paste: bool,
+) -> Result<(), String> {
+    write(text)?;
+    if submit_after_paste {
+        write("\r")?;
+    }
+    Ok(())
+}
+
+fn submit_operator_text(
+    app: &AppHandle,
+    text: &str,
+    submit_after_paste: bool,
+) -> Result<(), String> {
+    submit_operator_text_with(
+        |data| write_pty(app, pty_backend::OPERATOR_PANE_ID, data),
+        text,
+        submit_after_paste,
+    )
+}
+
 fn respawn_pty(app: &AppHandle, pane_id: &str) -> Result<(), String> {
     let manager = app.state::<PtyManager>();
     let (cols, rows) = {
@@ -1184,8 +1208,11 @@ impl PtyCommandTransport for TauriPtyTransport {
             PtyCommand::OperatorSnapshot { lines } => {
                 capture_pty(&self.app, pty_backend::OPERATOR_PANE_ID, *lines)
             }
-            PtyCommand::OperatorSubmit { text } => {
-                write_pty(&self.app, pty_backend::OPERATOR_PANE_ID, text)?;
+            PtyCommand::OperatorSubmit {
+                text,
+                submit_after_paste,
+            } => {
+                submit_operator_text(&self.app, text, *submit_after_paste)?;
                 Ok(serde_json::json!({
                     "paneId": pty_backend::OPERATOR_PANE_ID,
                     "submitted": true
@@ -1355,6 +1382,62 @@ mod tests {
         let output = limit_pty_capture_output("one\ntwo\nthree\nfour\n", Some(2));
 
         assert_eq!(output, "three\nfour");
+    }
+
+    #[test]
+    fn submit_operator_text_writes_single_line_as_one_submit_write() {
+        let mut writes = Vec::new();
+
+        submit_operator_text_with(
+            |data| {
+                writes.push(data.to_string());
+                Ok(())
+            },
+            "Continue with option 1\r",
+            false,
+        )
+        .expect("single line submit should write");
+
+        assert_eq!(writes, ["Continue with option 1\r"]);
+    }
+
+    #[test]
+    fn submit_operator_text_writes_multiline_paste_then_enter() {
+        let mut writes = Vec::new();
+
+        submit_operator_text_with(
+            |data| {
+                writes.push(data.to_string());
+                Ok(())
+            },
+            "\x1b[200~Line one\nLine two\x1b[201~",
+            true,
+        )
+        .expect("multiline submit should write paste and enter");
+
+        assert_eq!(writes, ["\x1b[200~Line one\nLine two\x1b[201~", "\r"]);
+    }
+
+    #[test]
+    fn submit_operator_text_returns_error_when_enter_write_fails() {
+        let mut writes = Vec::new();
+
+        let err = submit_operator_text_with(
+            |data| {
+                writes.push(data.to_string());
+                if data == "\r" {
+                    Err("enter write failed".to_string())
+                } else {
+                    Ok(())
+                }
+            },
+            "\x1b[200~Line one\nLine two\x1b[201~",
+            true,
+        )
+        .expect_err("enter failure should fail submit");
+
+        assert_eq!(err, "enter write failed");
+        assert_eq!(writes, ["\x1b[200~Line one\nLine two\x1b[201~", "\r"]);
     }
 
     #[test]

--- a/winsmux-app/src-tauri/src/pty_backend.rs
+++ b/winsmux-app/src-tauri/src/pty_backend.rs
@@ -77,6 +77,7 @@ pub enum PtyCommand {
     },
     OperatorSubmit {
         text: String,
+        submit_after_paste: bool,
     },
     Respawn {
         pane_id: String,
@@ -153,11 +154,12 @@ fn parse_command(method: &str, params: Option<&Value>) -> Result<PtyCommand, Par
         }
         "desktop.operator.submit" => {
             reject_operator_pane_override(params)?;
+            let (text, submit_after_paste) = normalize_operator_submit_text(
+                get_required_pty_data_param(params, &["text", "message", "data"])?,
+            );
             Ok(PtyCommand::OperatorSubmit {
-                text: normalize_operator_submit_text(get_required_pty_data_param(
-                    params,
-                    &["text", "message", "data"],
-                )?),
+                text,
+                submit_after_paste,
             })
         }
         "pty.respawn" => Ok(PtyCommand::Respawn {
@@ -189,11 +191,14 @@ fn reject_operator_pane_override(params: Option<&Value>) -> Result<(), ParseErro
     Ok(())
 }
 
-fn normalize_operator_submit_text(mut text: String) -> String {
-    if !text.ends_with('\r') && !text.ends_with('\n') {
-        text.push('\r');
+fn normalize_operator_submit_text(text: String) -> (String, bool) {
+    let text = text
+        .trim_end_matches(|character| character == '\r' || character == '\n')
+        .to_string();
+    if text.contains('\r') || text.contains('\n') {
+        return (format!("\x1b[200~{text}\x1b[201~"), true);
     }
-    text
+    (format!("{text}\r"), false)
 }
 
 fn get_required_string_param(params: Option<&Value>, keys: &[&str]) -> Result<String, ParseError> {
@@ -532,7 +537,49 @@ mod tests {
         assert_eq!(
             transport.commands.borrow().as_slice(),
             [PtyCommand::OperatorSubmit {
-                text: "Continue with option 1\r".to_string()
+                text: "Continue with option 1\r".to_string(),
+                submit_after_paste: false,
+            }]
+        );
+    }
+
+    #[test]
+    fn handle_pty_json_rpc_routes_multiline_operator_submit_with_bracketed_paste_and_enter() {
+        let transport = FakeTransport {
+            commands: RefCell::new(Vec::new()),
+            response: serde_json::json!({
+                "paneId": "operator",
+                "submitted": true
+            }),
+        };
+
+        let response = handle_pty_json_rpc(
+            &transport,
+            PtyJsonRpcRequest {
+                jsonrpc: "2.0".to_string(),
+                id: serde_json::json!("req-operator-submit"),
+                method: "desktop.operator.submit".to_string(),
+                params: Some(serde_json::json!({
+                    "text": "Line one\nLine two\n"
+                })),
+            },
+        );
+
+        match response {
+            PtyJsonRpcResponse::Success { result, .. } => {
+                assert_eq!(result["paneId"], "operator");
+                assert_eq!(result["submitted"], true);
+            }
+            PtyJsonRpcResponse::Error { error, .. } => {
+                panic!("expected success, got {:?}", error);
+            }
+        }
+
+        assert_eq!(
+            transport.commands.borrow().as_slice(),
+            [PtyCommand::OperatorSubmit {
+                text: "\x1b[200~Line one\nLine two\x1b[201~".to_string(),
+                submit_after_paste: true,
             }]
         );
     }


### PR DESCRIPTION
## Summary
- Normalize multiline `desktop.operator.submit` payloads into bracketed paste.
- Write the paste payload and submit Enter separately so the control pipe only reports success after Enter is written.
- Add Rust regression coverage for single-line submit, multiline paste+Enter, Enter write failure, and control-pipe routing expectations.

## Verification
- `cargo test --lib operator_submit`
- `cargo test --lib submit_operator_text`
- `cargo test --lib control_pipe_routes_operator_methods_to_operator_pane_only`
- `cargo test --lib` (190 tests, run by subagent)
- `git diff --check -- winsmux-app/src-tauri/src/control_pipe.rs winsmux-app/src-tauri/src/lib.rs winsmux-app/src-tauri/src/pty_backend.rs`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/git-guard.ps1 -Mode full`

## Notes
- Part of #1058.
- `cargo fmt --check` still reports an existing formatting issue in `winsmux-app/src-tauri/src/desktop_backend.rs`, which is outside this PR scope and was not modified.
- Desktop dogfooding evidence is still required before closing #1058.
