### PR TITLE
fix(desktop): clean up failed benchmark launches

### DIFF
--- a/scripts/start-cli-bakeoff-desktop.ps1
+++ b/scripts/start-cli-bakeoff-desktop.ps1
@@ -431,18 +431,26 @@ $env:WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS = "--remote-debugging-port=$DebugPort
 $env:WEBVIEW2_USER_DATA_FOLDER = $webviewUserData
 $env:NO_COLOR = '1'
 
-$launcherProcess = Start-Process -FilePath $releaseApp -ArgumentList @('--project-dir', $resolvedProjectDir) -WorkingDirectory $RepoRoot -PassThru
-$app = Wait-RepoWinsmuxDesktopApp -ExpectedProcessId ([int]$launcherProcess.Id)
-$page = Assert-ProductionDesktopPage -Port $DebugPort
-$metricsBeforeMove = Get-WindowMetrics -ProcessId ([int]$app.ProcessId)
-if (-not $NoMoveToExtendedDisplay) {
-    $metricsAfterMove = Move-WindowToVisibleWorkspace -ProcessId ([int]$app.ProcessId) -Width $VisibleWidth -Height $VisibleHeight
-} else {
-    $metricsAfterMove = $metricsBeforeMove
-}
+$launcherProcess = $null
+$app = $null
+try {
+    $launcherProcess = Start-Process -FilePath $releaseApp -ArgumentList @('--project-dir', $resolvedProjectDir) -WorkingDirectory $RepoRoot -PassThru
+    $app = Wait-RepoWinsmuxDesktopApp -ExpectedProcessId ([int]$launcherProcess.Id)
+    $page = Assert-ProductionDesktopPage -Port $DebugPort
+    $metricsBeforeMove = Get-WindowMetrics -ProcessId ([int]$app.ProcessId)
+    if (-not $NoMoveToExtendedDisplay) {
+        $metricsAfterMove = Move-WindowToVisibleWorkspace -ProcessId ([int]$app.ProcessId) -Width $VisibleWidth -Height $VisibleHeight
+    } else {
+        $metricsAfterMove = $metricsBeforeMove
+    }
 
-if ([int]$metricsAfterMove.width -lt $VisibleWidth -or [int]$metricsAfterMove.height -lt $VisibleHeight) {
-    throw "winsmux desktop window is smaller than required after launch: $($metricsAfterMove.width)x$($metricsAfterMove.height)"
+    if ([int]$metricsAfterMove.width -lt $VisibleWidth -or [int]$metricsAfterMove.height -lt $VisibleHeight) {
+        throw "winsmux desktop window is smaller than required after launch: $($metricsAfterMove.width)x$($metricsAfterMove.height)"
+    }
+} catch {
+    $reason = $_.Exception.Message
+    Stop-RepoWinsmuxDesktopTree
+    throw "winsmux desktop launch failed before a usable operator UI was verified. The repo-built desktop process tree was stopped to avoid leaving a frozen WebView window. Reason: $reason"
 }
 
 $result = [pscustomobject]@{

--- a/tests/CliBakeoff.Tests.ps1
+++ b/tests/CliBakeoff.Tests.ps1
@@ -187,6 +187,22 @@ Describe 'CLI bakeoff evidence harness' {
         $scriptText | Should -Match 'allowDevServer: !RELEASE_POPOUT_ONLY'
     }
 
+    It 'stops the repo desktop when launch readiness fails before the operator UI is usable' {
+        $scriptText = Get-Content -LiteralPath $script:DesktopStartScript -Raw -Encoding UTF8
+        $launchIndex = $scriptText.IndexOf('$launcherProcess = Start-Process -FilePath $releaseApp')
+        $pageCheckIndex = $scriptText.IndexOf('$page = Assert-ProductionDesktopPage -Port $DebugPort', $launchIndex)
+        $readinessCatchIndex = $scriptText.IndexOf('winsmux desktop launch failed before a usable operator UI was verified', $pageCheckIndex)
+        $cleanupIndex = $scriptText.IndexOf('Stop-RepoWinsmuxDesktopTree', $pageCheckIndex)
+        $resultIndex = $scriptText.IndexOf('$result = [pscustomobject]@{', $pageCheckIndex)
+
+        ($launchIndex -ge 0) | Should -BeTrue
+        ($pageCheckIndex -gt $launchIndex) | Should -BeTrue
+        ($readinessCatchIndex -gt $pageCheckIndex) | Should -BeTrue
+        ($cleanupIndex -gt $pageCheckIndex) | Should -BeTrue
+        ($cleanupIndex -lt $resultIndex) | Should -BeTrue
+        $scriptText | Should -Match 'frozen WebView window'
+    }
+
     It 'filters content-clean status noise before enforcing the candidate clean gate' {
         $scriptText = Get-Content -LiteralPath $script:PreflightScript -Raw -Encoding UTF8
         $scriptText | Should -Match 'function Get-GitContentDirtyStatus'


### PR DESCRIPTION
## Summary
- stop the repo-built desktop process tree when benchmark launch readiness fails before a usable operator UI is verified
- keep frozen WebView localhost failure windows from being left behind after packaged desktop launch checks fail
- add a Pester guard for the cleanup path

Fixes part of #1061.

## Verification
- Invoke-Pester -Path tests\\CliBakeoff.Tests.ps1 -Output Minimal
- git diff --check
- pwsh -NoProfile -File scripts\\git-guard.ps1 -Mode full