### PR TITLE
fix(orchestra): verify liveness before worker layout

### DIFF
--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -7003,12 +7003,30 @@ Describe 'orchestra-start session reuse contract' {
         $rollbackIndex | Should -BeGreaterThan $sessionReadyLogIndex
     }
 
-    It 'checks the expected pane count before layout without requiring strict health metadata' {
+    It 'attaches UI and checks session liveness before layout creates worker panes' {
+        $script:orchestraStartContent | Should -Match 'refusing to create worker panes'
+
+        $preLayoutAttachIndex = $script:orchestraStartContent.IndexOf('$preLayoutUiAttachResult = Try-StartOrchestraUiAttach -SessionName $sessionName')
+        $livenessIndex = $script:orchestraStartContent.IndexOf('if (-not (Test-OrchestraServerSession -SessionName $sessionName)) {')
+        $layoutIndex = $script:orchestraStartContent.IndexOf('$layout = . $layoutScript -SessionName $sessionName')
+        $paneNameIndex = $script:orchestraStartContent.IndexOf("Invoke-Bridge -Arguments @('name', `$paneId, `$label)")
+        $postLayoutAttachIndex = $script:orchestraStartContent.LastIndexOf('$uiAttachResult = Try-StartOrchestraUiAttach -SessionName $sessionName')
+
+        $preLayoutAttachIndex | Should -BeGreaterThan -1
+        $livenessIndex | Should -BeGreaterThan $preLayoutAttachIndex
+        $layoutIndex | Should -BeGreaterThan $livenessIndex
+        $paneNameIndex | Should -BeGreaterThan $layoutIndex
+        $postLayoutAttachIndex | Should -BeGreaterThan $paneNameIndex
+    }
+
+    It 'checks the expected pane count before layout and requires a pre-layout liveness gate' {
         $script:orchestraStartContent | Should -Match '\$expectedPaneCount\s*=\s*Get-OrchestraExpectedPaneCount -LayoutSettings \$layoutSettings'
         $script:orchestraStartContent | Should -Match '\$bootstrapPaneCount\s*=\s*1'
         $script:orchestraStartContent | Should -Match 'Test-OrchestraServerHealth -SessionName \$sessionName -WinsmuxBin \$winsmuxBin -ExpectedPaneCount \$expectedPaneCount'
         $script:orchestraStartContent | Should -Match 'Reset-OrchestraServerSession -SessionName \$sessionName -WinsmuxBin \$winsmuxBin -ProjectDir \$projectDir -GitWorktreeDir \$gitWorktreeDir -BridgeScript \$bridgeScript -Reason ''healthy_existing_session'' -ExpectedPaneCount \$bootstrapPaneCount'
-        $script:orchestraStartContent | Should -Match 'proceeding without strict pre-layout health metadata gate'
+        $script:orchestraStartContent | Should -Match 'strict health metadata wait is unavailable, so session liveness will be verified before layout'
+        $script:orchestraStartContent | Should -Not -Match 'proceeding without strict pre-layout health metadata gate'
+        $script:orchestraStartContent | Should -Not -Match 'skipping strict pre-layout health wait'
     }
 
     It 'uses pane capture evidence when pane_current_path lags behind the builder worktree' {

--- a/winsmux-core/scripts/orchestra-start.ps1
+++ b/winsmux-core/scripts/orchestra-start.ps1
@@ -345,9 +345,9 @@ function Reset-OrchestraServerSession {
     }
     $health = 'BootstrapOnly'
     if ($bootstrapMode -eq 'detached_fallback') {
-        Write-Warning "Reset-OrchestraServerSession: detached bootstrap fallback used for $SessionName; skipping strict health wait and continuing to layout startup."
+        Write-Warning "Reset-OrchestraServerSession: detached bootstrap fallback used for $SessionName; strict health metadata wait is unavailable, so session liveness will be verified before layout."
     } else {
-        Write-Warning "Reset-OrchestraServerSession: bootstrap mode $bootstrapMode used for $SessionName; skipping strict pre-layout health wait and continuing to layout startup."
+        Write-Warning "Reset-OrchestraServerSession: bootstrap mode $bootstrapMode used for $SessionName; strict health metadata wait is unavailable, so session liveness will be verified before layout."
     }
 
     return [PSCustomObject][ordered]@{
@@ -2255,9 +2255,9 @@ if ($MyInvocation.InvocationName -ne '.') {
             'windows_terminal'
         }
         if ($bootstrapMode -eq 'detached_fallback') {
-            Write-Warning "Preflight: detached bootstrap fallback active for $sessionName; proceeding without strict pre-layout health metadata gate."
+            Write-Warning "Preflight: detached bootstrap fallback active for $sessionName; strict health metadata wait is unavailable, so session liveness will be verified before layout."
         } else {
-            Write-Warning "Preflight: bootstrap mode $bootstrapMode active for $sessionName; proceeding without strict pre-layout health metadata gate."
+            Write-Warning "Preflight: bootstrap mode $bootstrapMode active for $sessionName; strict health metadata wait is unavailable, so session liveness will be verified before layout."
         }
         Write-WinsmuxLog -Level INFO -Event 'preflight.session.reuse' -Message "Reusing server-created session $sessionName." -Data ([ordered]@{
             session_name    = $sessionName
@@ -2303,6 +2303,19 @@ if ($MyInvocation.InvocationName -ne '.') {
         }
         Set-OrchestraSessionEnvironment -SessionName $sessionName -Name 'GIT_EDITOR' -Value 'true'
         Write-WinsmuxLog -Level INFO -Event 'preflight.session_env.git_editor_set' -Message 'Set GIT_EDITOR=true for orchestra session.' -Data ([ordered]@{ session_name = $sessionName; key = 'GIT_EDITOR'; value = 'true' }) | Out-Null
+
+    $successfulAttachStatuses = @('attach_confirmed', 'attach_already_present')
+    $preLayoutUiAttachResult = Try-StartOrchestraUiAttach -SessionName $sessionName
+    if ($successfulAttachStatuses -notcontains [string]$preLayoutUiAttachResult.Status) {
+        Write-Warning "Pre-layout orchestra UI attach status for ${sessionName}: $($preLayoutUiAttachResult.Status) ($($preLayoutUiAttachResult.Reason))"
+    }
+    if (-not (Test-OrchestraServerSession -SessionName $sessionName)) {
+        throw "Orchestra session '$sessionName' is not alive after pre-layout UI attach; refusing to create worker panes."
+    }
+    Write-WinsmuxLog -Level INFO -Event 'preflight.session.pre_layout_liveness' -Message "Verified session $sessionName is alive before layout." -Data ([ordered]@{
+        session_name      = $sessionName
+        ui_attach_status = [string]$preLayoutUiAttachResult.Status
+    }) | Out-Null
 
     $previousTargetSession = $env:WINSMUX_ORCHESTRA_SESSION
     $previousProjectDir = $env:WINSMUX_ORCHESTRA_PROJECT_DIR
@@ -2608,7 +2621,6 @@ if ($MyInvocation.InvocationName -ne '.') {
     Assert-OrchestraBootstrapVerification -PaneSummaries @($paneSummaries) -InvalidCount $invalidCount -ReadyCount $readyCount
 
     $uiAttachResult = Try-StartOrchestraUiAttach -SessionName $sessionName
-    $successfulAttachStatuses = @('attach_confirmed', 'attach_already_present')
     if ($successfulAttachStatuses -notcontains [string]$uiAttachResult.Status) {
         Write-Warning "Orchestra UI attach status for ${sessionName}: $($uiAttachResult.Status) ($($uiAttachResult.Reason))"
     }


### PR DESCRIPTION
## Summary
- attach the orchestra UI before worker pane layout when detached bootstrap cannot provide strict health metadata
- fail closed with a liveness gate before worker panes are created if the winsmux-orchestra session is gone
- keep the existing post-layout attach path for session-ready reporting
- update focused Pester coverage to lock attach/liveness before pane naming

Fixes part of #1047.

## Verification
- Invoke-Pester -Path tests\\winsmux-bridge.Tests.ps1 -FullName '*orchestra-start session reuse contract*' -Output Minimal
- Invoke-Pester -Path tests\\winsmux-bridge.Tests.ps1 -FullName '*orchestra-start server bootstrap*' -Output Minimal
- git diff --check
- pwsh -NoProfile -File scripts\\git-guard.ps1 -Mode full