### PR TITLE
fix(orchestra): tolerate locked builder worktrees

### DIFF
--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -5741,6 +5741,111 @@ Describe 'orchestra-start server bootstrap' {
             Should -Be 'git@example.com:org/repo.git'
     }
 
+    It 'allocates the next free builder worktree slot when the first slot is locked' {
+        $testProjectDir = Join-Path ([System.IO.Path]::GetTempPath()) ('winsmux-builder-slot-tests-' + [guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $testProjectDir -Force | Out-Null
+        $lockedWorktreePath = Join-Path $testProjectDir '.worktrees\builder-1'
+        New-Item -ItemType Directory -Path $lockedWorktreePath -Force | Out-Null
+        $script:builderWorktreeGitCalls = [System.Collections.Generic.List[object]]::new()
+        $originalGitFunction = Get-Item -Path Function:\git -ErrorAction SilentlyContinue
+
+        function global:git {
+            param([Parameter(ValueFromRemainingArguments = $true)]$Args)
+
+            $script:builderWorktreeGitCalls.Add(@($Args)) | Out-Null
+            if ($Args[2] -eq 'branch' -and $Args[3] -eq '--list') {
+                $global:LASTEXITCODE = 0
+                return ''
+            }
+
+            if ($Args[2] -eq 'worktree' -and $Args[3] -eq 'add') {
+                $global:LASTEXITCODE = 0
+                return ''
+            }
+
+            $global:LASTEXITCODE = 0
+        }
+
+        try {
+            $worktree = New-BuilderWorktree -ProjectDir $testProjectDir -BuilderIndex 1
+
+            $worktree.BranchName | Should -Be 'worktree-builder-2'
+            $worktree.WorktreePath | Should -Be (Join-Path $testProjectDir '.worktrees\builder-2')
+            @($script:builderWorktreeGitCalls | Where-Object { $_[2] -eq 'worktree' -and $_[3] -eq 'add' -and $_[4] -eq '.worktrees/builder-2' -and $_[6] -eq 'worktree-builder-2' }).Count | Should -Be 1
+        } finally {
+            Remove-Item -Path Function:\git -ErrorAction SilentlyContinue
+            if ($null -ne $originalGitFunction) {
+                Set-Item -Path Function:\git -Value $originalGitFunction.ScriptBlock
+            }
+            if (Test-Path -LiteralPath $testProjectDir) {
+                Remove-Item -LiteralPath $testProjectDir -Recurse -Force
+            }
+        }
+    }
+
+    It 'keeps stale builder cleanup non-fatal when a registered worktree is locked' {
+        $testProjectDir = Join-Path ([System.IO.Path]::GetTempPath()) ('winsmux-builder-cleanup-tests-' + [guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $testProjectDir -Force | Out-Null
+        $lockedWorktreePath = Join-Path $testProjectDir '.worktrees\builder-1'
+        New-Item -ItemType Directory -Path $lockedWorktreePath -Force | Out-Null
+        $originalGitFunction = Get-Item -Path Function:\git -ErrorAction SilentlyContinue
+
+        function global:git {
+            param([Parameter(ValueFromRemainingArguments = $true)]$Args)
+
+            if ($Args[2] -eq 'worktree' -and $Args[3] -eq 'prune') {
+                $global:LASTEXITCODE = 0
+                return ''
+            }
+
+            if ($Args[2] -eq 'worktree' -and $Args[3] -eq 'list') {
+                $global:LASTEXITCODE = 0
+                return @(
+                    "worktree $testProjectDir",
+                    'branch refs/heads/main',
+                    '',
+                    "worktree $lockedWorktreePath",
+                    'branch refs/heads/worktree-builder-1',
+                    ''
+                )
+            }
+
+            if ($Args[2] -eq 'branch' -and $Args[3] -eq '--list') {
+                $global:LASTEXITCODE = 0
+                return 'worktree-builder-1'
+            }
+
+            if ($Args[2] -eq 'worktree' -and $Args[3] -eq 'remove') {
+                $global:LASTEXITCODE = 1
+                return 'permission denied'
+            }
+
+            if ($Args[2] -eq 'branch' -and $Args[3] -eq '-D') {
+                $global:LASTEXITCODE = 1
+                return 'branch is checked out'
+            }
+
+            $global:LASTEXITCODE = 0
+        }
+
+        try {
+            $cleanup = Invoke-StaleBuilderWorktreeCleanup -ProjectDir $testProjectDir
+
+            @($cleanup.RemovedWorktreePaths).Count | Should -Be 0
+            @($cleanup.CleanupErrors | Where-Object { $_ -like "worktree remove $lockedWorktreePath failed:*" }).Count | Should -Be 1
+            @($cleanup.CleanupErrors | Where-Object { $_ -like 'branch delete worktree-builder-1 failed:*' }).Count | Should -Be 1
+            (Test-Path -LiteralPath $lockedWorktreePath) | Should -Be $true
+        } finally {
+            Remove-Item -Path Function:\git -ErrorAction SilentlyContinue
+            if ($null -ne $originalGitFunction) {
+                Set-Item -Path Function:\git -Value $originalGitFunction.ScriptBlock
+            }
+            if (Test-Path -LiteralPath $testProjectDir) {
+                Remove-Item -LiteralPath $testProjectDir -Recurse -Force
+            }
+        }
+    }
+
     It 'persists worker isolation metadata through Save-OrchestraSessionState' {
         $script:savedManifest = $null
         Mock Save-WinsmuxManifest {

--- a/winsmux-core/scripts/builder-worktree.ps1
+++ b/winsmux-core/scripts/builder-worktree.ps1
@@ -168,6 +168,7 @@ function Invoke-StaleBuilderWorktreeCleanup {
     $removedWorktreePaths = [System.Collections.Generic.List[string]]::new()
     $removedDirectoryPaths = [System.Collections.Generic.List[string]]::new()
     $removedBranches = [System.Collections.Generic.List[string]]::new()
+    $cleanupErrors = [System.Collections.Generic.List[string]]::new()
 
     foreach ($entry in @($inventory.RegisteredWorktrees | Sort-Object WorktreePath -Unique)) {
         $worktreePath = [System.IO.Path]::GetFullPath($entry.WorktreePath)
@@ -176,18 +177,35 @@ function Invoke-StaleBuilderWorktreeCleanup {
         }
 
         if (-not (Test-BuilderWorktreePathUnderRoot -Path $worktreePath -Root $worktreeRoot)) {
-            throw "Refusing to remove Builder worktree outside ${worktreeRoot}: $worktreePath"
+            $cleanupErrors.Add("external Builder worktree outside ${worktreeRoot} was left untouched: $worktreePath") | Out-Null
+            continue
         }
 
         if (Test-Path -LiteralPath $worktreePath -PathType Container) {
-            Invoke-BuilderWorktreeGit -ProjectDir $ProjectDir -Arguments @('worktree', 'remove', '--force', $worktreePath) | Out-Null
-            $removedWorktreePaths.Add($worktreePath) | Out-Null
+            $removeResult = Invoke-BuilderWorktreeGit -ProjectDir $ProjectDir -Arguments @('worktree', 'remove', '--force', $worktreePath) -AllowFailure
+            if ($removeResult.ExitCode -eq 0) {
+                $removedWorktreePaths.Add($worktreePath) | Out-Null
+            } else {
+                $message = if ([string]::IsNullOrWhiteSpace($removeResult.Output)) {
+                    'unknown git worktree remove error'
+                } else {
+                    $removeResult.Output
+                }
+                $cleanupErrors.Add("worktree remove $worktreePath failed: $message") | Out-Null
+            }
         }
 
         if (-not [string]::IsNullOrWhiteSpace($entry.BranchName)) {
             $deleteResult = Invoke-BuilderWorktreeGit -ProjectDir $ProjectDir -Arguments @('branch', '-D', $entry.BranchName) -AllowFailure
             if ($deleteResult.ExitCode -eq 0) {
                 $removedBranches.Add($entry.BranchName) | Out-Null
+            } else {
+                $message = if ([string]::IsNullOrWhiteSpace($deleteResult.Output)) {
+                    'unknown git branch delete error'
+                } else {
+                    $deleteResult.Output
+                }
+                $cleanupErrors.Add("branch delete $($entry.BranchName) failed: $message") | Out-Null
             }
         }
     }
@@ -199,8 +217,12 @@ function Invoke-StaleBuilderWorktreeCleanup {
         }
 
         if (Test-Path -LiteralPath $resolvedDirectoryPath -PathType Container) {
-            Remove-Item -LiteralPath $resolvedDirectoryPath -Recurse -Force
-            $removedDirectoryPaths.Add($resolvedDirectoryPath) | Out-Null
+            try {
+                Remove-Item -LiteralPath $resolvedDirectoryPath -Recurse -Force
+                $removedDirectoryPaths.Add($resolvedDirectoryPath) | Out-Null
+            } catch {
+                $cleanupErrors.Add("directory remove $resolvedDirectoryPath failed: $($_.Exception.Message)") | Out-Null
+            }
         }
     }
 
@@ -215,5 +237,6 @@ function Invoke-StaleBuilderWorktreeCleanup {
         RemovedWorktreePaths  = @($removedWorktreePaths)
         RemovedDirectoryPaths = @($removedDirectoryPaths)
         RemovedBranches       = @($removedBranches | Sort-Object -Unique)
+        CleanupErrors         = @($cleanupErrors)
     }
 }

--- a/winsmux-core/scripts/orchestra-start.ps1
+++ b/winsmux-core/scripts/orchestra-start.ps1
@@ -554,20 +554,30 @@ function New-BuilderWorktree {
         [Parameter(Mandatory = $true)][int]$BuilderIndex
     )
 
-    $branchName = "worktree-builder-$BuilderIndex"
     $worktreeRoot = Join-Path $ProjectDir '.worktrees'
-    $worktreeRelativePath = ".worktrees/builder-$BuilderIndex"
-    $worktreePath = Join-Path $ProjectDir '.worktrees' "builder-$BuilderIndex"
-
     New-Item -ItemType Directory -Path $worktreeRoot -Force | Out-Null
 
-    if (Test-Path -LiteralPath $worktreePath) {
-        throw "Builder worktree path already exists: $worktreePath. Clean it up before restarting orchestra."
+    $probeIndex = $BuilderIndex
+    $maxProbeIndex = $BuilderIndex + 128
+    $branchName = ''
+    $worktreeRelativePath = ''
+    $worktreePath = ''
+
+    while ($probeIndex -le $maxProbeIndex) {
+        $branchName = "worktree-builder-$probeIndex"
+        $worktreeRelativePath = ".worktrees/builder-$probeIndex"
+        $worktreePath = Join-Path $ProjectDir '.worktrees' "builder-$probeIndex"
+        $existingBranch = (& git -C $ProjectDir branch --list --format '%(refname:short)' $branchName 2>$null | Out-String).Trim()
+
+        if (-not (Test-Path -LiteralPath $worktreePath) -and [string]::IsNullOrWhiteSpace($existingBranch)) {
+            break
+        }
+
+        $probeIndex++
     }
 
-    $existingBranch = (& git -C $ProjectDir branch --list --format '%(refname:short)' $branchName 2>$null | Out-String).Trim()
-    if (-not [string]::IsNullOrWhiteSpace($existingBranch)) {
-        throw "Builder worktree branch already exists: $branchName. Clean it up before restarting orchestra."
+    if ($probeIndex -gt $maxProbeIndex) {
+        throw "Could not allocate a free Builder worktree slot starting at builder-$BuilderIndex."
     }
 
     $output = (& git -C $ProjectDir worktree add $worktreeRelativePath -b $branchName 2>&1 | Out-String).Trim()
@@ -2279,6 +2289,10 @@ if ($MyInvocation.InvocationName -ne '.') {
     foreach ($removedBranch in @($builderCleanup.RemovedBranches)) {
         Write-Output "Preflight: removed stale Builder branch $removedBranch"
         Write-WinsmuxLog -Level INFO -Event 'preflight.builder_worktree_cleanup.branch_removed' -Message "Removed stale Builder branch $removedBranch." -Data ([ordered]@{ branch_name = $removedBranch }) | Out-Null
+    }
+    foreach ($cleanupError in @($builderCleanup.CleanupErrors)) {
+        Write-Warning "Preflight: stale Builder cleanup skipped a locked resource: $cleanupError"
+        Write-WinsmuxLog -Level WARN -Event 'preflight.builder_worktree_cleanup.skipped' -Message 'Skipped a locked stale Builder resource during cleanup.' -Data ([ordered]@{ error = $cleanupError }) | Out-Null
     }
 
         Write-WinsmuxLog -Level INFO -Event 'preflight.bootstrap.ready' -Message "Bootstrap session $sessionName created by Ensure-OrchestraBootstrapSession." -Data ([ordered]@{


### PR DESCRIPTION
## Summary
- keep stale Builder worktree cleanup non-fatal when a registered worktree is locked
- allocate the next available Builder worktree slot instead of failing on a locked builder-1 path
- log skipped cleanup diagnostics so orchestra startup can continue without blind retries

## Verification
- Invoke-Pester -Path tests/winsmux-bridge.Tests.ps1 -FullName '*allocates the next free builder worktree slot when the first slot is locked*' -Output Minimal
- Invoke-Pester -Path tests/winsmux-bridge.Tests.ps1 -FullName '*keeps stale builder cleanup non-fatal when a registered worktree is locked*' -Output Minimal
- git diff --check
- scripts/git-guard.ps1 -Mode full

Fixes #1050