### PR TITLE
fix(desktop): suppress external orchestra attach hosts

### DIFF
--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -35,8 +35,8 @@ function Resolve-WinsmuxRawCommand {
 
     $repoRoot = Split-Path $PSScriptRoot -Parent
     foreach ($candidate in @(
-        (Join-Path $repoRoot 'target\debug\winsmux.exe'),
-        (Join-Path $repoRoot 'target\release\winsmux.exe')
+        (Join-Path $repoRoot 'target\release\winsmux.exe'),
+        (Join-Path $repoRoot 'target\debug\winsmux.exe')
     )) {
         if (Test-Path -LiteralPath $candidate -PathType Leaf) {
             return [System.IO.Path]::GetFullPath($candidate)

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -21667,3 +21667,39 @@ Describe 'watermark helpers' {
         (Test-WatermarkChanged -PaneId '%7' -CurrentContent 'updated') | Should -Be $true
     }
 }
+
+Describe 'desktop orchestra launcher contracts' {
+    BeforeAll {
+        $script:repoRoot = Split-Path -Parent $PSScriptRoot
+        $script:settingsContent = Get-Content -LiteralPath (Join-Path $script:repoRoot 'winsmux-core\scripts\settings.ps1') -Raw -Encoding UTF8
+        $script:bridgeContent = Get-Content -LiteralPath (Join-Path $script:repoRoot 'scripts\winsmux-core.ps1') -Raw -Encoding UTF8
+        $script:attachContent = Get-Content -LiteralPath (Join-Path $script:repoRoot 'winsmux-core\scripts\orchestra-attach.ps1') -Raw -Encoding UTF8
+        $script:uiAttachContent = Get-Content -LiteralPath (Join-Path $script:repoRoot 'winsmux-core\scripts\orchestra-ui-attach.ps1') -Raw -Encoding UTF8
+    }
+
+    It 'prefers the release winsmux executable before debug fallback' {
+        $settingsReleaseIndex = $script:settingsContent.IndexOf("target\release\winsmux.exe")
+        $settingsDebugIndex = $script:settingsContent.IndexOf("target\debug\winsmux.exe")
+        $bridgeReleaseIndex = $script:bridgeContent.IndexOf("target\release\winsmux.exe")
+        $bridgeDebugIndex = $script:bridgeContent.IndexOf("target\debug\winsmux.exe")
+
+        $settingsReleaseIndex | Should -BeGreaterThan -1
+        $settingsDebugIndex | Should -BeGreaterThan -1
+        $settingsReleaseIndex | Should -BeLessThan $settingsDebugIndex
+        $bridgeReleaseIndex | Should -BeGreaterThan -1
+        $bridgeDebugIndex | Should -BeGreaterThan -1
+        $bridgeReleaseIndex | Should -BeLessThan $bridgeDebugIndex
+    }
+
+    It 'uses the shared winsmux executable resolver for orchestra attach' {
+        $script:attachContent | Should -Match "\. \(Join-Path [`$]scriptsRoot 'settings\.ps1'\)"
+        $script:attachContent | Should -Match '\$winsmuxPath\s*=\s*Get-WinsmuxBin'
+        $script:attachContent | Should -Not -Match "Get-Command 'winsmux'"
+    }
+
+    It 'can disable Windows Terminal visible attach from desktop child processes' {
+        $script:uiAttachContent | Should -Match 'WINSMUX_ORCHESTRA_DISABLE_WINDOWS_TERMINAL_ATTACH'
+        $script:uiAttachContent | Should -Match 'windows_terminal_attach_disabled'
+        $script:uiAttachContent | Should -Match 'WINSMUX_ORCHESTRA_DISABLE_POWERSHELL_ATTACH'
+    }
+}

--- a/winsmux-app/src-tauri/src/desktop_backend.rs
+++ b/winsmux-app/src-tauri/src/desktop_backend.rs
@@ -39,11 +39,49 @@ const PROVIDER_SWITCH_SELECTOR_PARAM_KEYS: &[&str] = &[
 ];
 #[cfg(windows)]
 const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+const WINSMUX_ATTACH_MODE_ENV: &str = "WINSMUX_ORCHESTRA_ATTACH_MODE";
+const WINSMUX_DESKTOP_APP_PID_ENV: &str = "WINSMUX_DESKTOP_APP_PID";
+const WINSMUX_DISABLE_POWERSHELL_ATTACH_ENV: &str = "WINSMUX_ORCHESTRA_DISABLE_POWERSHELL_ATTACH";
+const WINSMUX_DISABLE_WINDOWS_TERMINAL_ATTACH_ENV: &str =
+    "WINSMUX_ORCHESTRA_DISABLE_WINDOWS_TERMINAL_ATTACH";
+const WINSMUX_BIN_ENV: &str = "WINSMUX_BIN";
+const WINSMUX_RAW_EXE_ENV: &str = "WINSMUX_RAW_EXE";
 
 fn hide_subprocess_window(command: &mut Command) {
     #[cfg(windows)]
     {
         command.creation_flags(CREATE_NO_WINDOW);
+    }
+}
+
+fn resolve_companion_winsmux_cli_from_exe_path(current_exe: &Path) -> Option<PathBuf> {
+    let parent = current_exe.parent()?;
+    let candidate = parent.join("winsmux.exe");
+    candidate.is_file().then_some(candidate)
+}
+
+fn resolve_companion_winsmux_cli() -> Option<PathBuf> {
+    std::env::current_exe()
+        .ok()
+        .and_then(|current_exe| resolve_companion_winsmux_cli_from_exe_path(&current_exe))
+}
+
+fn apply_desktop_winsmux_child_env(
+    command: &mut Command,
+    companion_cli: Option<&Path>,
+    app_pid: u32,
+) {
+    command
+        .env(WINSMUX_ATTACH_MODE_ENV, "desktop-app")
+        .env(WINSMUX_DESKTOP_APP_PID_ENV, app_pid.to_string())
+        .env(WINSMUX_DISABLE_POWERSHELL_ATTACH_ENV, "1")
+        .env(WINSMUX_DISABLE_WINDOWS_TERMINAL_ATTACH_ENV, "1");
+
+    if let Some(path) = companion_cli {
+        let path_value = path.to_string_lossy().to_string();
+        command
+            .env(WINSMUX_BIN_ENV, &path_value)
+            .env(WINSMUX_RAW_EXE_ENV, path_value);
     }
 }
 
@@ -2061,6 +2099,8 @@ where
     let script_path = repo_root.join("scripts").join("winsmux-core.ps1");
     let command_text = build_winsmux_command_text(&script_path, &command.winsmux_args());
     let source = command.source_name().to_string();
+    let companion_cli = resolve_companion_winsmux_cli();
+    let app_pid = std::process::id();
 
     thread::spawn(move || {
         let mut quick_failure_count = 0usize;
@@ -2077,6 +2117,7 @@ where
                 .env("WINSMUX_DESKTOP_SUMMARY_STREAM_POLL_SECONDS", "5")
                 .stdout(Stdio::piped())
                 .stderr(Stdio::piped());
+            apply_desktop_winsmux_child_env(&mut process, companion_cli.as_deref(), app_pid);
             hide_subprocess_window(&mut process);
 
             let mut child = match process.spawn() {
@@ -2509,6 +2550,7 @@ fn run_winsmux_json(project_dir: Option<String>, args: &[String]) -> Result<Valu
     let effective_project_dir = resolve_effective_project_dir(project_dir)?;
     let script_path = repo_root.join("scripts").join("winsmux-core.ps1");
     let command_text = build_winsmux_command_text(&script_path, args);
+    let companion_cli = resolve_companion_winsmux_cli();
 
     let mut command = Command::new("pwsh");
     command
@@ -2518,6 +2560,7 @@ fn run_winsmux_json(project_dir: Option<String>, args: &[String]) -> Result<Valu
         .arg("-Command")
         .arg(command_text)
         .current_dir(&effective_project_dir);
+    apply_desktop_winsmux_child_env(&mut command, companion_cli.as_deref(), std::process::id());
     hide_subprocess_window(&mut command);
 
     let output = command
@@ -2617,6 +2660,64 @@ mod tests {
                 "consultation_ref": ".winsmux/consultations/consult-result-__ID__.json"
             }
         })
+    }
+
+    fn command_env_value(command: &Command, key: &str) -> Option<String> {
+        command
+            .get_envs()
+            .find(|(name, _)| name.to_string_lossy() == key)
+            .and_then(|(_, value)| value.map(|value| value.to_string_lossy().to_string()))
+    }
+
+    #[test]
+    fn companion_winsmux_cli_resolves_next_to_desktop_exe() {
+        let temp_dir =
+            std::env::temp_dir().join(format!("winsmux-companion-cli-test-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&temp_dir);
+        fs::create_dir_all(&temp_dir).unwrap();
+        let cli_path = temp_dir.join("winsmux.exe");
+        fs::write(&cli_path, b"").unwrap();
+
+        let desktop_exe = temp_dir.join("winsmux-app.exe");
+        assert_eq!(
+            resolve_companion_winsmux_cli_from_exe_path(&desktop_exe),
+            Some(cli_path)
+        );
+
+        let _ = fs::remove_dir_all(&temp_dir);
+    }
+
+    #[test]
+    fn desktop_winsmux_children_disable_external_attach_hosts_and_pin_companion_cli() {
+        let companion = PathBuf::from(r"C:\repo\target\release\winsmux.exe");
+        let mut command = Command::new("pwsh");
+
+        apply_desktop_winsmux_child_env(&mut command, Some(&companion), 4242);
+
+        assert_eq!(
+            command_env_value(&command, WINSMUX_ATTACH_MODE_ENV).as_deref(),
+            Some("desktop-app")
+        );
+        assert_eq!(
+            command_env_value(&command, WINSMUX_DESKTOP_APP_PID_ENV).as_deref(),
+            Some("4242")
+        );
+        assert_eq!(
+            command_env_value(&command, WINSMUX_DISABLE_POWERSHELL_ATTACH_ENV).as_deref(),
+            Some("1")
+        );
+        assert_eq!(
+            command_env_value(&command, WINSMUX_DISABLE_WINDOWS_TERMINAL_ATTACH_ENV).as_deref(),
+            Some("1")
+        );
+        assert_eq!(
+            command_env_value(&command, WINSMUX_BIN_ENV).as_deref(),
+            Some(r"C:\repo\target\release\winsmux.exe")
+        );
+        assert_eq!(
+            command_env_value(&command, WINSMUX_RAW_EXE_ENV).as_deref(),
+            Some(r"C:\repo\target\release\winsmux.exe")
+        );
     }
 
     fn desktop_compare_runs_payload() -> Value {
@@ -5233,9 +5334,7 @@ mod tests {
             DesktopJsonRpcResponse::Success { result, .. } => {
                 assert_eq!(result["path"], "tasks/cli-bakeoff/v1/benchmark-pack.json");
                 assert_eq!(result["truncated"], true);
-                assert!(
-                    result["content"].as_str().unwrap_or_default().len() < large_content.len()
-                );
+                assert!(result["content"].as_str().unwrap_or_default().len() < large_content.len());
             }
             DesktopJsonRpcResponse::Error { error, .. } => {
                 panic!("expected preview success, got {:?}", error);

--- a/winsmux-core/scripts/orchestra-attach.ps1
+++ b/winsmux-core/scripts/orchestra-attach.ps1
@@ -17,6 +17,7 @@ $ProjectDir = [System.IO.Path]::GetFullPath($ProjectDir)
 $scriptsRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
 
 . (Join-Path $scriptsRoot 'orchestra-ui-attach.ps1')
+. (Join-Path $scriptsRoot 'settings.ps1')
 
 function New-OrchestraAttachResult {
     param(
@@ -56,7 +57,12 @@ function New-OrchestraAttachResult {
     }
 }
 
-$winsmuxPath = Get-Command 'winsmux' -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source -ErrorAction SilentlyContinue
+$winsmuxPath = ''
+try {
+    $winsmuxPath = Get-WinsmuxBin
+} catch {
+    $winsmuxPath = ''
+}
 $result = $null
 if ([string]::IsNullOrWhiteSpace($winsmuxPath)) {
     $result = New-OrchestraAttachResult -SessionName $SessionName -SessionExists $false -RequiresStartup $true -Attempted $false -Launched $false -Attached $false -Status 'winsmux_unresolved' -Reason 'winsmux executable could not be resolved.'

--- a/winsmux-core/scripts/orchestra-ui-attach.ps1
+++ b/winsmux-core/scripts/orchestra-ui-attach.ps1
@@ -574,6 +574,10 @@ function Get-OrchestraVisibleAttachHostCandidates {
     $terminalInfo = Get-OrchestraWindowsTerminalInfo
     $windowsTerminalAvailable = [bool]$terminalInfo.Available
     $windowsTerminalReason = [string]$terminalInfo.Reason
+    if (Test-OrchestraTruthyEnvValue -Value $env:WINSMUX_ORCHESTRA_DISABLE_WINDOWS_TERMINAL_ATTACH) {
+        $windowsTerminalAvailable = $false
+        $windowsTerminalReason = 'windows_terminal_attach_disabled'
+    }
     if ([string]$terminalInfo.PathSource -eq 'appx') {
         $windowsTerminalAvailable = $false
         $windowsTerminalReason = 'wt_appx_direct_launch_unsupported'

--- a/winsmux-core/scripts/settings.ps1
+++ b/winsmux-core/scripts/settings.ps1
@@ -155,8 +155,8 @@ if (-not (Get-Command Get-WinsmuxBin -ErrorAction SilentlyContinue)) {
 
         $repoRoot = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
         foreach ($candidatePath in @(
-            (Join-Path $repoRoot 'target\debug\winsmux.exe'),
-            (Join-Path $repoRoot 'target\release\winsmux.exe')
+            (Join-Path $repoRoot 'target\release\winsmux.exe'),
+            (Join-Path $repoRoot 'target\debug\winsmux.exe')
         )) {
             if (Test-Path -LiteralPath $candidatePath -PathType Leaf) {
                 return [System.IO.Path]::GetFullPath($candidatePath)


### PR DESCRIPTION
## Summary
- Resolve desktop-launched winsmux child commands through the companion release CLI before debug fallback.
- Disable visible PowerShell and Windows Terminal attach hosts for desktop-owned orchestra child processes.
- Add focused tests for CLI resolution and desktop child-process environment contracts.

Closes #1056

## Tests
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Path tests/winsmux-bridge.Tests.ps1 -FullName 'desktop orchestra launcher contracts*' -Output Minimal"`
- `cargo test --manifest-path winsmux-app/src-tauri/Cargo.toml companion_winsmux_cli_resolves_next_to_desktop_exe --lib`
- `cargo test --manifest-path winsmux-app/src-tauri/Cargo.toml desktop_winsmux_children_disable_external_attach_hosts_and_pin_companion_cli --lib`
- `cargo fmt --manifest-path winsmux-app/src-tauri/Cargo.toml --check`
- `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File scripts\git-guard.ps1 -Mode full`
- `git diff --check`
