### PR TITLE
fix(app): preserve selected operator Claude model

### DIFF
--- a/winsmux-app/package.json
+++ b/winsmux-app/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "dev:browser": "node ./scripts/open-dev-browser.mjs",
     "build": "tsc && vite build",
+    "test:composer-session-controls": "node ./scripts/composer-session-controls-check.mjs",
     "test:composer-text": "node ./scripts/composer-text-check.mjs",
     "test:clickable-coverage": "npm run build && node ./scripts/clickable-coverage-harness.mjs",
     "test:desktop-pane-e2e": "node ./scripts/desktop-pane-e2e.mjs",

--- a/winsmux-app/scripts/composer-session-controls-check.mjs
+++ b/winsmux-app/scripts/composer-session-controls-check.mjs
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const mainSource = await readFile("src/main.ts", "utf8");
+const viewportHarness = await readFile("scripts/viewport-harness.mjs", "utf8");
+
+assert.match(
+  mainSource,
+  /value:\s*"opus-4\.7"[\s\S]*?cliModel:\s*"claude-opus-4-7"/,
+  "Opus 4.7 must remain a selectable Claude Code model with its CLI model id.",
+);
+
+assert.match(
+  mainSource,
+  /value:\s*"fable-5"[\s\S]*?disabled:\s*true/,
+  "Fable 5 must stay visible but disabled while it is unavailable.",
+);
+
+assert.match(
+  mainSource,
+  /const storedModelOption = composerModelOptions\.find\(\(item\) => item\.value === storedModel\);[\s\S]*?const model = storedModelOption && !storedModelOption\.disabled \? storedModelOption\.value : fallback\.model;/,
+  "Stored composer models must be accepted when they are present and not disabled.",
+);
+
+assert.doesNotMatch(
+  mainSource,
+  /storedModel === "opus-4\.7"/,
+  "Opus 4.7 must not be migrated back to the Opus 4.8 fallback.",
+);
+
+assert.match(
+  viewportHarness,
+  /model:\s*"opus-4\.7"[\s\S]*?--model claude-opus-4-7/,
+  "Viewport harness must verify that stored Opus 4.7 reaches operator startup input.",
+);
+
+assert.match(
+  viewportHarness,
+  /model:\s*"fable-5"[\s\S]*?--model claude-opus-4-8/,
+  "Viewport harness must verify that unavailable Fable 5 falls back to Opus 4.8.",
+);
+
+console.log("composer-session-controls-check: ok");

--- a/winsmux-app/scripts/viewport-harness.mjs
+++ b/winsmux-app/scripts/viewport-harness.mjs
@@ -1302,7 +1302,7 @@ async function assertComposerSessionControls(page, previewUrl) {
   await page.evaluate(() => {
     localStorage.setItem("winsmux.composer-session.v1", JSON.stringify({
       permissionMode: "default",
-      model: "opus-4.7-1m",
+      model: "opus-4.7",
       effort: "xhigh",
       fastModeEnabled: false,
     }));
@@ -1313,7 +1313,7 @@ async function assertComposerSessionControls(page, previewUrl) {
   await page.evaluate(() => {
     localStorage.setItem("winsmux.composer-session.v1", JSON.stringify({
       permissionMode: "auto",
-      model: "opus-4.7-1m",
+      model: "opus-4.7",
       effort: "xhigh",
       fastModeEnabled: false,
     }));
@@ -1324,17 +1324,32 @@ async function assertComposerSessionControls(page, previewUrl) {
   await page.evaluate(() => {
     localStorage.setItem("winsmux.composer-session.v1", JSON.stringify({
       permissionMode: "acceptEdits",
-      model: "opus-4.7-1m",
+      model: "opus-4.7",
       effort: "xhigh",
       fastModeEnabled: false,
     }));
   });
   await page.reload({ waitUntil: "networkidle" });
   await page.locator(".composer-session-trigger-permission", { hasText: "Approve edits" }).waitFor();
+  await page.locator(".composer-session-trigger-model", { hasText: "Opus 4.7" }).waitFor();
+  const restoredStartupInput = await page.evaluate(() => window.__winsmuxViewportHarness?.getOperatorStartupInput());
+  if (!String(restoredStartupInput).includes("--model claude-opus-4-7")) {
+    throw new Error("Opus 4.7 composer state did not persist into the operator startup model");
+  }
+
+  await page.evaluate(() => {
+    localStorage.setItem("winsmux.composer-session.v1", JSON.stringify({
+      permissionMode: "acceptEdits",
+      model: "fable-5",
+      effort: "xhigh",
+      fastModeEnabled: false,
+    }));
+  });
+  await page.reload({ waitUntil: "networkidle" });
   await page.locator(".composer-session-trigger-model", { hasText: "Opus 4.8" }).waitFor();
-  const migratedStartupInput = await page.evaluate(() => window.__winsmuxViewportHarness?.getOperatorStartupInput());
-  if (!String(migratedStartupInput).includes("--model claude-opus-4-8")) {
-    throw new Error("Legacy Opus 4.7 composer state did not migrate to Opus 4.8 startup model");
+  const unavailableStartupInput = await page.evaluate(() => window.__winsmuxViewportHarness?.getOperatorStartupInput());
+  if (!String(unavailableStartupInput).includes("--model claude-opus-4-8")) {
+    throw new Error("Unavailable Fable 5 composer state did not fall back to the Opus 4.8 startup model");
   }
 
   await page.click(".composer-session-trigger-permission");

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -9449,10 +9449,8 @@ function defaultComposerSessionControls(): ComposerSessionControlState {
 function normalizeComposerSessionControls(value: Partial<ComposerSessionControlState> | null | undefined) {
   const fallback = defaultComposerSessionControls();
   const storedModel = value?.model;
-  const migratedModel = storedModel === "opus-4.7" || storedModel === "opus-4.7-1m" || storedModel === "fable-5"
-    ? fallback.model
-    : storedModel;
-  const model = composerModelOptions.find((item) => item.value === migratedModel && !item.disabled)?.value ?? fallback.model;
+  const storedModelOption = composerModelOptions.find((item) => item.value === storedModel);
+  const model = storedModelOption && !storedModelOption.disabled ? storedModelOption.value : fallback.model;
   const fastModeCompatible = isComposerFastModeCompatible(model);
   const storedFastModeEnabled =
     typeof value?.fastModeEnabled === "boolean" ? value.fastModeEnabled : fallback.fastModeEnabled;


### PR DESCRIPTION
## Summary

Preserve supported operator Claude model selections instead of migrating them back to Opus 4.8.

## Changes

- Keep stored `opus-4.7` composer model state when it is still selectable.
- Continue falling back from unavailable `fable-5` to Opus 4.8.
- Add a focused regression check for composer model persistence and operator startup arguments.
- Update the existing viewport harness expectation for the new Opus 4.7 behavior.

## Tests

- `npm --prefix winsmux-app run test:composer-session-controls`
- `npm --prefix winsmux-app run build`
- `npm --prefix winsmux-app run test:viewport-harness` *(fails before the updated composer model step at existing `desktop editor surface: page.waitForFunction: Timeout 30000ms exceeded`; kept as a known unrelated harness blocker for this PR)*

Refs #1048.
Refs #1051.
