### PR TITLE
fix(desktop): reflect observed operator model

### DIFF
--- a/winsmux-app/scripts/composer-session-controls-check.mjs
+++ b/winsmux-app/scripts/composer-session-controls-check.mjs
@@ -42,8 +42,10 @@ assert.match(
 
 assert.ok(
   mainSource.includes("function detectComposerModelFromOperatorText(text: string)")
-    && mainSource.includes("Opus 4\\.7")
-    && mainSource.includes("new RegExp(`\\\\bmodel\\\\s*:\\\\s*"),
+    && mainSource.includes("runtimeModelCandidates")
+    && mainSource.includes("statusLinePattern")
+    && mainSource.includes("new RegExp(`\\\\bmodel\\\\s*:\\\\s*")
+    && mainSource.includes("runtimeModelCandidates[runtimeModelCandidates.length - 1]?.value"),
   "Operator PTY output must be able to report the current runtime model, including Opus 4.7.",
 );
 
@@ -63,6 +65,12 @@ assert.match(
   mainSource,
   /setOperatorRuntimeOutputForTest:[\s\S]*?updateObservedOperatorRuntimeModelFromOutput\(value\)/,
   "Viewport harness must expose a test hook for operator runtime model observations.",
+);
+
+assert.match(
+  mainSource,
+  /function appendOperatorPtyOutput\(data: string\)[\s\S]*?updateObservedOperatorRuntimeModelFromOutput\(body\)/,
+  "Real operator PTY output must update the observed runtime model, not only the viewport test hook.",
 );
 
 assert.doesNotMatch(

--- a/winsmux-app/scripts/composer-session-controls-check.mjs
+++ b/winsmux-app/scripts/composer-session-controls-check.mjs
@@ -6,6 +6,24 @@ const viewportHarness = await readFile("scripts/viewport-harness.mjs", "utf8");
 
 assert.match(
   mainSource,
+  /type ComposerPermissionMode = "auto" \| "default" \| "acceptEdits" \| "plan" \| "bypassPermissions";/,
+  "Composer permission modes must stay aligned with Claude Code CLI permission-mode values.",
+);
+
+assert.match(
+  mainSource,
+  /function defaultComposerSessionControls\(\): ComposerSessionControlState \{[\s\S]*?permissionMode:\s*"auto"/,
+  "New operator sessions must default to Claude Code auto permission mode.",
+);
+
+assert.doesNotMatch(
+  mainSource,
+  /value === "auto"[\s\S]*?return "default"/,
+  "Stored auto permission mode must not be normalized back to default.",
+);
+
+assert.match(
+  mainSource,
   /value:\s*"opus-4\.7"[\s\S]*?cliModel:\s*"claude-opus-4-7"/,
   "Opus 4.7 must remain a selectable Claude Code model with its CLI model id.",
 );
@@ -57,6 +75,24 @@ assert.match(
   viewportHarness,
   /model:\s*"opus-4\.7"[\s\S]*?--model claude-opus-4-7/,
   "Viewport harness must verify that stored Opus 4.7 reaches operator startup input.",
+);
+
+assert.match(
+  viewportHarness,
+  /permissionMode:\s*"auto"[\s\S]*?--permission-mode auto/,
+  "Viewport harness must verify that auto permission mode reaches operator startup input.",
+);
+
+assert.match(
+  viewportHarness,
+  /permissionMode:\s*"default"[\s\S]*?--permission-mode default/,
+  "Viewport harness must verify that confirm-permissions mode reaches operator startup input.",
+);
+
+assert.match(
+  viewportHarness,
+  /Plan mode[\s\S]*?--permission-mode plan/,
+  "Viewport harness must verify that Plan mode reaches operator startup input.",
 );
 
 assert.match(

--- a/winsmux-app/scripts/viewport-harness.mjs
+++ b/winsmux-app/scripts/viewport-harness.mjs
@@ -1296,8 +1296,12 @@ async function setShellLanguage(page, language) {
 
 async function assertComposerSessionControls(page, previewUrl) {
   await page.locator("#composer-mode-row").waitFor({ state: "hidden" });
-  await page.locator(".composer-session-trigger-permission", { hasText: "Approve edits" }).waitFor();
+  await page.locator(".composer-session-trigger-permission", { hasText: "Auto mode" }).waitFor();
   await page.locator(".composer-session-trigger-model", { hasText: "Opus 4.8" }).waitFor();
+  const defaultStartupInput = await page.evaluate(() => window.__winsmuxViewportHarness?.getOperatorStartupInput());
+  if (!String(defaultStartupInput).includes("--permission-mode auto")) {
+    throw new Error("Default composer permission mode did not start the operator in auto mode");
+  }
 
   await page.evaluate(() => {
     localStorage.setItem("winsmux.composer-session.v1", JSON.stringify({
@@ -1308,7 +1312,11 @@ async function assertComposerSessionControls(page, previewUrl) {
     }));
   });
   await page.reload({ waitUntil: "networkidle" });
-  await page.locator(".composer-session-trigger-permission", { hasText: "Ask before edits" }).waitFor();
+  await page.locator(".composer-session-trigger-permission", { hasText: "Confirm permissions" }).waitFor();
+  const confirmStartupInput = await page.evaluate(() => window.__winsmuxViewportHarness?.getOperatorStartupInput());
+  if (!String(confirmStartupInput).includes("--permission-mode default")) {
+    throw new Error("Confirm permissions composer state did not persist into the operator startup mode");
+  }
 
   await page.evaluate(() => {
     localStorage.setItem("winsmux.composer-session.v1", JSON.stringify({
@@ -1319,7 +1327,11 @@ async function assertComposerSessionControls(page, previewUrl) {
     }));
   });
   await page.reload({ waitUntil: "networkidle" });
-  await page.locator(".composer-session-trigger-permission", { hasText: "Ask before edits" }).waitFor();
+  await page.locator(".composer-session-trigger-permission", { hasText: "Auto mode" }).waitFor();
+  const autoStartupInput = await page.evaluate(() => window.__winsmuxViewportHarness?.getOperatorStartupInput());
+  if (!String(autoStartupInput).includes("--permission-mode auto")) {
+    throw new Error("Auto mode composer state did not persist into the operator startup mode");
+  }
 
   await page.evaluate(() => {
     localStorage.setItem("winsmux.composer-session.v1", JSON.stringify({
@@ -1365,8 +1377,15 @@ async function assertComposerSessionControls(page, previewUrl) {
 
   await page.click(".composer-session-trigger-permission");
   await page.locator("#composer-permission-menu", { hasText: "Mode" }).waitFor();
+  await page.locator("#composer-permission-menu .composer-session-option", { hasText: "Auto mode" }).waitFor();
+  await page.locator("#composer-permission-menu .composer-session-option", { hasText: "Confirm permissions" }).waitFor();
+  await page.locator("#composer-permission-menu .composer-session-option", { hasText: "Bypass permissions" }).waitFor();
   await page.locator("#composer-permission-menu .composer-session-option", { hasText: "Plan mode" }).click();
   await page.locator(".composer-session-trigger-permission", { hasText: "Plan mode" }).waitFor();
+  const planStartupInput = await page.evaluate(() => window.__winsmuxViewportHarness?.getOperatorStartupInput());
+  if (!String(planStartupInput).includes("--permission-mode plan")) {
+    throw new Error("Plan mode composer state did not persist into the operator startup mode");
+  }
 
   await page.click(".composer-session-trigger-model");
   await page.locator("#composer-model-menu", { hasText: "Model" }).waitFor();

--- a/winsmux-app/scripts/viewport-harness.mjs
+++ b/winsmux-app/scripts/viewport-harness.mjs
@@ -1365,12 +1365,28 @@ async function assertComposerSessionControls(page, previewUrl) {
   }
 
   await page.evaluate(() => {
-    window.__winsmuxViewportHarness?.setOperatorRuntimeOutputForTest("\nOpus 4.7 | ctx 12% | 5h | 1% | 7d\n");
+    localStorage.setItem("winsmux.composer-session.v1", JSON.stringify({
+      permissionMode: "acceptEdits",
+      model: "opus-4.8",
+      effort: "xhigh",
+      fastModeEnabled: false,
+    }));
+  });
+  await page.reload({ waitUntil: "networkidle" });
+  await page.locator(".composer-session-trigger-model", { hasText: "Opus 4.8" }).waitFor();
+  await page.evaluate(() => {
+    window.__winsmuxViewportHarness?.setOperatorRuntimeOutputForTest(
+      "\x1b[2KOpus 4.8 | ctx 10% | 5h | 1% | 7d\r\x1b[2K› Opus 4.7 | ctx 12% | 5h | 1% | 7d",
+    );
   });
   await page.locator(".composer-session-trigger-model", { hasText: "Opus 4.7・Running" }).waitFor();
   const runtimeLabel = await page.evaluate(() => window.__winsmuxViewportHarness?.getComposerModelControlLabelForTest());
   if (runtimeLabel !== "Opus 4.7・Running") {
     throw new Error(`Operator runtime model label did not reflect the observed runtime model: ${runtimeLabel}`);
+  }
+  const runtimeStoredState = await page.evaluate(() => JSON.parse(localStorage.getItem("winsmux.composer-session.v1") || "{}"));
+  if (runtimeStoredState?.model !== "opus-4.8") {
+    throw new Error("Operator runtime observation must not rewrite the next startup model setting");
   }
   await page.reload({ waitUntil: "networkidle" });
   await page.locator(".composer-session-trigger-model", { hasText: "Opus 4.8" }).waitFor();

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -383,7 +383,7 @@ type RuntimeModelAssignmentMode = "shared" | "per-pane";
 type RuntimeModelCatalogStatus = "selectable" | "candidate" | "setup-required" | "runnable" | "blocked" | "reference-only" | "unavailable";
 type RuntimeModelWorkerReadinessState = "runnable" | "setup-required" | "blocked";
 type RuntimeModelBenchmarkFamily = "agent-arena" | "code-arena" | "winsmux-local";
-type ComposerPermissionMode = "auto" | "default" | "acceptEdits" | "plan";
+type ComposerPermissionMode = "auto" | "default" | "acceptEdits" | "plan" | "bypassPermissions";
 type ComposerEffortLevel = "auto" | "low" | "medium" | "high" | "xhigh" | "max";
 type ComposerModelId = "fable-5" | "opus-4.8" | "opus-4.7" | "opus-4.7-1m" | "opus-4.6" | "sonnet-4.6" | "haiku-4.5";
 type VoiceDraftMode = "raw" | "cleaned" | "operator_request";
@@ -651,7 +651,7 @@ let detachedSurfaceRunLabel = "";
 let detachedSurfaceSession: DetachedSurfaceSessionState | null = null;
 let detachedSurfacePollTimer: number | null = null;
 let activeComposerMode: ComposerMode = "dispatch";
-let activeComposerPermissionMode: ComposerPermissionMode = "acceptEdits";
+let activeComposerPermissionMode: ComposerPermissionMode = "auto";
 let activeComposerModel: ComposerModelId = "opus-4.8";
 let activeComposerEffort: ComposerEffortLevel = "xhigh";
 let observedOperatorRuntimeModel: ComposerModelId | null = null;
@@ -899,14 +899,15 @@ const composerPermissionModeOptions: Array<{
   description: string;
   descriptionJa: string;
   shortcut: string;
+  shortcutJa?: string;
 }> = [
   {
     value: "default",
-    label: "Ask before edits",
-    labelJa: "編集前に確認",
-    description: "Ask before file edits while keeping normal conversation flow.",
-    descriptionJa: "通常の会話を保ちながら、ファイル編集前に確認します。",
-    shortcut: "0",
+    label: "Confirm permissions",
+    labelJa: "許可を確認",
+    description: "Ask before commands, tools, or edits that require permission.",
+    descriptionJa: "許可が必要なコマンド、ツール、編集の前に確認します。",
+    shortcut: "1",
   },
   {
     value: "acceptEdits",
@@ -914,7 +915,7 @@ const composerPermissionModeOptions: Array<{
     labelJa: "編集を承認",
     description: "Allow Claude to edit without prompting for each change.",
     descriptionJa: "変更ごとの確認を省き、編集を承認します。",
-    shortcut: "1",
+    shortcut: "2",
   },
   {
     value: "plan",
@@ -922,7 +923,24 @@ const composerPermissionModeOptions: Array<{
     labelJa: "プランモード",
     description: "Explore and prepare a plan before editing.",
     descriptionJa: "編集前に調査し、計画を作ります。",
-    shortcut: "2",
+    shortcut: "3",
+  },
+  {
+    value: "auto",
+    label: "Auto mode",
+    labelJa: "自動モード",
+    description: "Let Claude decide when a tool or edit needs confirmation.",
+    descriptionJa: "ツール実行や編集で確認が必要かをClaudeに判断させます。",
+    shortcut: "4",
+  },
+  {
+    value: "bypassPermissions",
+    label: "Bypass permissions",
+    labelJa: "許可をバイパス",
+    description: "Skip permission prompts only when the user explicitly enables it.",
+    descriptionJa: "ユーザーが明示的に有効化した場合のみ、許可確認を省略します。",
+    shortcut: "Enable",
+    shortcutJa: "有効にする",
   },
 ];
 
@@ -9440,7 +9458,7 @@ function persistRuntimeModelAssignmentMode() {
 
 function defaultComposerSessionControls(): ComposerSessionControlState {
   return {
-    permissionMode: "acceptEdits",
+    permissionMode: "auto",
     model: "opus-4.8",
     effort: "xhigh",
     voiceDraftMode: "raw",
@@ -9477,9 +9495,6 @@ function normalizeComposerSessionControls(value: Partial<ComposerSessionControlS
 }
 
 function normalizeComposerPermissionMode(value: string | null | undefined, fallback: ComposerPermissionMode) {
-  if (value === "auto" || value === "default") {
-    return "default";
-  }
   return composerPermissionModeOptions.find((item) => item.value === value)?.value ?? fallback;
 }
 
@@ -13083,7 +13098,7 @@ function appendComposerMenuSeparator(menu: HTMLElement) {
 
 function appendComposerOptionButton<T extends string>(
   menu: HTMLElement,
-  option: { value: T; label: string; labelJa: string; description?: string; descriptionJa?: string; shortcut?: string; disabled?: boolean },
+  option: { value: T; label: string; labelJa: string; description?: string; descriptionJa?: string; shortcut?: string; shortcutJa?: string; disabled?: boolean },
   selectedValue: T,
   onSelect: (value: T) => void,
 ) {
@@ -13107,8 +13122,9 @@ function appendComposerOptionButton<T extends string>(
   label.className = "composer-session-option-label";
   label.textContent = japanese ? option.labelJa : option.label;
   labelRow.appendChild(label);
-  if (option.shortcut) {
-    labelRow.appendChild(createComposerShortcut(option.shortcut));
+  const shortcut = japanese && option.shortcutJa ? option.shortcutJa : option.shortcut;
+  if (shortcut) {
+    labelRow.appendChild(createComposerShortcut(shortcut));
   } else if (option.value === selectedValue && !option.disabled) {
     labelRow.appendChild(createComposerShortcut("✓"));
   }

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -12940,11 +12940,20 @@ function detectComposerModelFromOperatorText(text: string): ComposerModelId | nu
     return null;
   }
 
-  const statusLineMatches = Array.from(normalized.matchAll(/(?:^|\n)\s*(Opus 4\.8|Opus 4\.7|Opus 4\.6|Sonnet 4\.6|Haiku 4\.5)\s*(?:\||$)/gm));
-  const statusLineMatch = statusLineMatches[statusLineMatches.length - 1];
-  if (statusLineMatch?.[1]) {
-    const label = statusLineMatch[1];
-    return composerModelOptions.find((item) => !item.disabled && (item.label === label || item.labelJa === label))?.value ?? null;
+  const runtimeModelCandidates: Array<{ index: number; value: ComposerModelId }> = [];
+  const modelLabels = composerModelOptions
+    .filter((item) => !item.disabled)
+    .flatMap((item) => [item.label, item.labelJa])
+    .filter((label, index, labels) => Boolean(label) && labels.indexOf(label) === index)
+    .map(escapeRegExp)
+    .join("|");
+  const statusLinePattern = new RegExp(`(?:^|\\n)[^\\n]{0,40}\\b(${modelLabels})\\b\\s*(?:\\||ctx\\b|コンテキスト\\b)`, "gm");
+  for (const match of normalized.matchAll(statusLinePattern)) {
+    const label = match[1];
+    const option = composerModelOptions.find((item) => !item.disabled && (item.label === label || item.labelJa === label));
+    if (option) {
+      runtimeModelCandidates.push({ index: match.index ?? 0, value: option.value });
+    }
   }
 
   for (const option of composerModelOptions) {
@@ -12953,13 +12962,14 @@ function detectComposerModelFromOperatorText(text: string): ComposerModelId | nu
     }
     const cliPattern = escapeRegExp(option.cliModel);
     const labelPattern = escapeRegExp(option.label);
-    const modelLine = new RegExp(`\\bmodel\\s*:\\s*(?:${cliPattern}|${labelPattern})\\b`, "i");
-    if (modelLine.test(normalized)) {
-      return option.value;
+    const modelLine = new RegExp(`\\bmodel\\s*:\\s*(?:${cliPattern}|${labelPattern})\\b`, "gi");
+    for (const match of normalized.matchAll(modelLine)) {
+      runtimeModelCandidates.push({ index: match.index ?? 0, value: option.value });
     }
   }
 
-  return null;
+  runtimeModelCandidates.sort((left, right) => left.index - right.index);
+  return runtimeModelCandidates[runtimeModelCandidates.length - 1]?.value ?? null;
 }
 
 function updateObservedOperatorRuntimeModelFromOutput(text: string) {


### PR DESCRIPTION
## Summary
- track the latest observed Claude Code runtime model from operator PTY output instead of only the saved startup model
- tolerate terminal redraw/status-line output when Claude Code switches models in-session
- keep runtime observation separate from the saved next-startup composer model setting

## Verification
- npm run test:composer-session-controls
- npm run build
- targeted Playwright check: Opus 4.8 saved startup remains unchanged while terminal redraw output switches the footer to Opus 4.7・Running
- git diff --check

Refs #1048