### PR TITLE
fix(desktop): expose operator approval mode in settings

### DIFF
--- a/winsmux-app/scripts/composer-session-controls-check.mjs
+++ b/winsmux-app/scripts/composer-session-controls-check.mjs
@@ -104,6 +104,18 @@ assert.match(
 );
 
 assert.match(
+  mainSource,
+  /function renderOperatorApprovalModePanel\(japanese: boolean\)[\s\S]*?composerPermissionModeOptions[\s\S]*?setComposerPermissionMode\(option\.value\)/,
+  "Settings must expose the same operator approval mode options as the composer footer.",
+);
+
+assert.match(
+  viewportHarness,
+  /Bypass permissions[\s\S]*?--permission-mode bypassPermissions/,
+  "Viewport harness must verify that Settings can persist Bypass permissions into operator startup input.",
+);
+
+assert.match(
   viewportHarness,
   /model:\s*"fable-5"[\s\S]*?--model claude-opus-4-8/,
   "Viewport harness must verify that unavailable Fable 5 falls back to Opus 4.8.",

--- a/winsmux-app/scripts/viewport-harness.mjs
+++ b/winsmux-app/scripts/viewport-harness.mjs
@@ -1403,6 +1403,27 @@ async function assertComposerSessionControls(page, previewUrl) {
     throw new Error("Plan mode composer state did not persist into the operator startup mode");
   }
 
+  await page.click("#activity-settings-btn");
+  await page.locator("#settings-sheet").waitFor({ state: "visible" });
+  await page.click("#settings-nav-chat");
+  await page.locator(".runtime-operator-approval-panel", { hasText: "Operator approval mode" }).waitFor();
+  await page.locator(".runtime-operator-approval-panel .settings-option-chip", { hasText: "Bypass permissions" }).click();
+  await page.locator(".composer-session-trigger-permission", { hasText: "Bypass permissions" }).waitFor();
+  const bypassStartupInput = await page.evaluate(() => window.__winsmuxViewportHarness?.getOperatorStartupInput());
+  if (!String(bypassStartupInput).includes("--permission-mode bypassPermissions")) {
+    throw new Error("Settings approval mode did not persist Bypass permissions into the operator startup mode");
+  }
+  await page.locator(".runtime-operator-approval-panel .settings-option-chip[aria-checked='true']", { hasText: "Bypass permissions" }).waitFor();
+  await page.locator(".runtime-operator-approval-panel .settings-option-chip", { hasText: "Plan mode" }).click();
+  await page.locator(".composer-session-trigger-permission", { hasText: "Plan mode" }).waitFor();
+  const settingsPlanStartupInput = await page.evaluate(() => window.__winsmuxViewportHarness?.getOperatorStartupInput());
+  if (!String(settingsPlanStartupInput).includes("--permission-mode plan")) {
+    throw new Error("Settings approval mode did not restore Plan mode into the operator startup mode");
+  }
+  await page.locator(".runtime-operator-approval-panel .settings-option-chip[aria-checked='true']", { hasText: "Plan mode" }).waitFor();
+  await page.click("#close-settings-btn");
+  await page.locator("#settings-sheet").waitFor({ state: "hidden" });
+
   await page.click(".composer-session-trigger-model");
   await page.locator("#composer-model-menu", { hasText: "Model" }).waitFor();
   await page.locator("#composer-model-menu", { hasText: "Fast mode" }).waitFor();

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -11328,6 +11328,53 @@ function renderRuntimeWorkerDefaultControls(japanese: boolean, disabled = false)
   return panel;
 }
 
+function renderOperatorApprovalModePanel(japanese: boolean) {
+  const panel = document.createElement("section");
+  panel.className = "runtime-model-panel runtime-operator-approval-panel";
+
+  const title = document.createElement("div");
+  title.className = "runtime-role-title";
+  title.textContent = japanese ? "オペレーター承認モード" : "Operator approval mode";
+  const description = document.createElement("div");
+  description.className = "runtime-role-description";
+  description.textContent = japanese
+    ? "オペレーターペインのcomposerと同じ承認モードを設定します。次回operator起動時の --permission-mode に反映されます。"
+    : "Uses the same approval mode as the operator composer. The next operator launch receives the matching --permission-mode value.";
+  panel.append(title, description);
+
+  const row = document.createElement("div");
+  row.className = "settings-option-row operator-approval-mode-row";
+  row.setAttribute("role", "radiogroup");
+  row.setAttribute("aria-label", japanese ? "オペレーター承認モード" : "Operator approval mode");
+  for (const option of composerPermissionModeOptions) {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = `settings-option-chip ${option.value === activeComposerPermissionMode ? "is-active" : ""}`;
+    button.dataset.permissionMode = option.value;
+    button.setAttribute("role", "radio");
+    button.setAttribute("aria-checked", option.value === activeComposerPermissionMode ? "true" : "false");
+
+    const label = document.createElement("span");
+    label.className = "settings-option-label";
+    label.textContent = japanese ? option.labelJa : option.label;
+    const details = document.createElement("span");
+    details.className = "settings-option-description";
+    details.textContent = japanese ? option.descriptionJa : option.description;
+    button.append(label, details);
+    button.addEventListener("click", () => setComposerPermissionMode(option.value));
+    row.appendChild(button);
+  }
+  panel.appendChild(row);
+
+  const note = document.createElement("div");
+  note.className = "runtime-access-note";
+  note.textContent = japanese
+    ? "この設定はworkerペインのモデル割り当てとは独立しています。実行中のClaude Code内で一時的に変更した場合は、winsmux側の次回起動設定とは分けて扱います。"
+    : "This setting is independent from worker pane model assignment. Temporary in-session Claude Code changes remain separate from the next winsmux startup setting.";
+  panel.appendChild(note);
+  return panel;
+}
+
 function renderWorkerModelAssignmentPanel(japanese: boolean) {
   const panel = document.createElement("section");
   panel.className = "runtime-model-panel runtime-model-assignment-panel";
@@ -11605,6 +11652,7 @@ function renderRuntimeRoleControls() {
   const japanese = (settingsDraftState?.language ?? themeState.language) === "ja";
   root.innerHTML = "";
 
+  root.appendChild(renderOperatorApprovalModePanel(japanese));
   root.appendChild(renderWorkerModelAssignmentPanel(japanese));
 }
 
@@ -13014,6 +13062,9 @@ function setComposerPermissionMode(mode: ComposerPermissionMode) {
   persistComposerSessionControls();
   openComposerSessionMenu = null;
   renderComposerSessionControls();
+  if (settingsSheetOpen) {
+    renderSettingsControls();
+  }
 }
 
 function setComposerModel(model: ComposerModelId) {


### PR DESCRIPTION
## Summary
- add an Operator approval mode panel to Settings that reuses the existing composer permission-mode options
- keep Settings and the composer footer synchronized through the same persisted composer-session state
- add static and viewport coverage for Settings -> `--permission-mode bypassPermissions` and Plan mode propagation

Refs #1043

## Verification
- `npm --prefix winsmux-app run build`
- `npm --prefix winsmux-app run test:composer-session-controls`
- targeted Playwright check against `?viewport-harness=1` for Settings -> Bypass permissions -> Plan mode -> operator startup input
- `git diff --check`

## Notes
- The full `npm --prefix winsmux-app run test:viewport-harness` build step passed, but the existing `desktop editor surface` step timed out before this patch's approval-mode assertions. The targeted approval-mode viewport check passed against the same built preview.
- This does not close #1043 yet. The remaining acceptance items are desktop restart E2E coverage, allowed winsmux inspection command regression coverage, and benchmark progress HTML blocked-state recording.