### PR TITLE
Fix runtime model effort controls in Settings

### DIFF
--- a/winsmux-app/scripts/clickable-coverage-harness.mjs
+++ b/winsmux-app/scripts/clickable-coverage-harness.mjs
@@ -630,7 +630,7 @@ async function testPaneModelSettings(page) {
     const model = document.querySelector("#runtime-worker-default-model");
     const effort = document.querySelector("#runtime-worker-default-effort");
     return provider instanceof HTMLSelectElement && provider.disabled
-      && model instanceof HTMLSelectElement && model.disabled
+      && model instanceof HTMLInputElement && model.disabled
       && effort instanceof HTMLSelectElement && effort.disabled;
   });
   await page.waitForFunction(() => {
@@ -657,7 +657,7 @@ async function testPaneModelSettings(page) {
     return perPane instanceof HTMLElement
       && perPane.getAttribute("aria-pressed") === "true"
       && provider instanceof HTMLSelectElement && provider.disabled
-      && model instanceof HTMLSelectElement && model.disabled
+      && model instanceof HTMLInputElement && model.disabled
       && effort instanceof HTMLSelectElement && effort.disabled;
   });
 
@@ -670,10 +670,77 @@ async function testPaneModelSettings(page) {
     const provider = document.querySelector("#runtime-worker-default-provider");
     const model = document.querySelector("#runtime-worker-default-model");
     const effort = document.querySelector("#runtime-worker-default-effort");
+    const modelOptionsId = model instanceof HTMLInputElement ? model.getAttribute("list") : "";
+    const modelOptions = modelOptionsId ? document.getElementById(modelOptionsId) : null;
     return provider instanceof HTMLSelectElement && !provider.disabled
-      && model instanceof HTMLSelectElement && !model.disabled
+      && model instanceof HTMLInputElement && !model.disabled
+      && modelOptions instanceof HTMLDataListElement
       && effort instanceof HTMLSelectElement && !effort.disabled
       && document.querySelectorAll(".runtime-model-slot-row").length === 0;
+  }).catch(async (error) => {
+    const state = await page.evaluate(() => {
+      const model = document.querySelector("#runtime-worker-default-model");
+      const provider = document.querySelector("#runtime-worker-default-provider");
+      const effort = document.querySelector("#runtime-worker-default-effort");
+      const modelOptionsId = model instanceof HTMLInputElement ? model.getAttribute("list") : "";
+      const modelOptions = modelOptionsId ? document.getElementById(modelOptionsId) : null;
+      return {
+        modeButtons: Array.from(document.querySelectorAll(".runtime-model-mode-option")).map((button) => ({
+          text: button.textContent,
+          pressed: button.getAttribute("aria-pressed"),
+          selected: button instanceof HTMLElement ? button.dataset.selected : undefined,
+        })),
+        providerDisabled: provider instanceof HTMLSelectElement ? provider.disabled : undefined,
+        modelTag: model?.tagName,
+        modelDisabled: model instanceof HTMLInputElement ? model.disabled : undefined,
+        modelList: modelOptionsId,
+        modelOptionCount: modelOptions?.querySelectorAll("option").length,
+        effortTag: effort?.tagName,
+        effortDisabled: effort instanceof HTMLSelectElement || effort instanceof HTMLInputElement ? effort.disabled : undefined,
+        slotRows: document.querySelectorAll(".runtime-model-slot-row").length,
+        emptyText: document.querySelector(".runtime-model-empty")?.textContent,
+      };
+    });
+    throw new Error(`settings pane model shared mode did not expose shared controls: ${JSON.stringify(state)}: ${error.message}`);
+  });
+
+  await page.locator("#runtime-worker-default-provider").selectOption("claude");
+  recordClick("settings pane model shared provider claude");
+  await page.waitForFunction(() => {
+    const provider = document.querySelector("#runtime-worker-default-provider");
+    const model = document.querySelector("#runtime-worker-default-model");
+    const modelOptionsId = model instanceof HTMLInputElement ? model.getAttribute("list") : "";
+    const modelOptions = modelOptionsId ? document.getElementById(modelOptionsId) : null;
+    const effort = document.querySelector("#runtime-worker-default-effort");
+    const claudeEffort = document.querySelector(".runtime-effort-control-claude");
+    return provider instanceof HTMLSelectElement
+      && provider.value === "claude"
+      && model instanceof HTMLInputElement
+      && modelOptions instanceof HTMLDataListElement
+      && Array.from(modelOptions.querySelectorAll("option")).some((option) => /Opus 4\.8/.test(option.value))
+      && effort instanceof HTMLInputElement
+      && effort.classList.contains("runtime-effort-range")
+      && claudeEffort instanceof HTMLElement
+      && claudeEffort.dataset.value;
+  });
+  await clickSelector(page, '.runtime-effort-step[data-effort="xhigh"]', "settings pane model shared claude ultra effort", { settleMs: 100 });
+  await page.waitForFunction(() => {
+    const effort = document.querySelector("#runtime-worker-default-effort");
+    const claudeEffort = document.querySelector(".runtime-effort-control-claude");
+    return effort instanceof HTMLInputElement
+      && claudeEffort instanceof HTMLElement
+      && claudeEffort.dataset.value === "xhigh";
+  });
+  await page.locator("#runtime-worker-default-provider").selectOption("codex");
+  recordClick("settings pane model shared provider codex restore");
+  await page.waitForFunction(() => {
+    const provider = document.querySelector("#runtime-worker-default-provider");
+    const effort = document.querySelector("#runtime-worker-default-effort");
+    return provider instanceof HTMLSelectElement
+      && provider.value === "codex"
+      && effort instanceof HTMLSelectElement
+      && effort.value === "provider-default"
+      && !document.querySelector(".runtime-effort-control-claude");
   });
 }
 

--- a/winsmux-app/scripts/composer-session-controls-check.mjs
+++ b/winsmux-app/scripts/composer-session-controls-check.mjs
@@ -3,6 +3,7 @@ import { readFile } from "node:fs/promises";
 
 const mainSource = await readFile("src/main.ts", "utf8");
 const viewportHarness = await readFile("scripts/viewport-harness.mjs", "utf8");
+const modelCapabilitiesSource = await readFile("src/modelCapabilities.ts", "utf8");
 
 assert.match(
   mainSource,
@@ -108,6 +109,46 @@ assert.match(
   /function renderOperatorApprovalModePanel\(japanese: boolean\)[\s\S]*?composerPermissionModeOptions[\s\S]*?setComposerPermissionMode\(option\.value\)/,
   "Settings must expose the same operator approval mode options as the composer footer.",
 );
+
+assert.match(
+  mainSource,
+  /function createRuntimeEffortControl\([\s\S]*?runtime-effort-control-claude[\s\S]*?runtime-effort-range[\s\S]*?runtime-effort-step/,
+  "Settings must expose a Claude-specific effort control instead of a plain select-only UI.",
+);
+
+assert.match(
+  mainSource,
+  /claude:\s*\["provider-default",\s*"low",\s*"medium",\s*"high",\s*"max",\s*"xhigh"\]/,
+  "Claude runtime effort order must keep Ultra/xhigh as the highest option.",
+);
+
+assert.match(
+  mainSource,
+  /codex:\s*\["provider-default",\s*"low",\s*"medium",\s*"high",\s*"xhigh"\]/,
+  "Codex runtime effort choices must not expose Claude-only Max.",
+);
+
+for (const provider of ["antigravity", "grok-build", "openrouter"]) {
+  assert.match(
+    mainSource,
+    new RegExp(`["']?${provider.replace("-", "\\-")}["']?:\\s*\\["provider-default"\\]`),
+    `${provider} must stay provider-default only in desktop runtime effort filtering.`,
+  );
+}
+
+assert.match(
+  modelCapabilitiesSource,
+  /id:\s*"claude"[\s\S]*?supportedEffortIds:\s*\["provider-default",\s*"low",\s*"medium",\s*"high",\s*"max",\s*"xhigh"\]/,
+  "Claude provider capabilities must include Max and Ultra/xhigh only for Claude.",
+);
+
+for (const provider of ["antigravity", "grok-build", "openrouter"]) {
+  assert.match(
+    modelCapabilitiesSource,
+    new RegExp(`id:\\s*"${provider}"[\\s\\S]*?supportedEffortIds:\\s*\\["provider-default"\\]`),
+    `${provider} capabilities must not claim explicit effort overrides.`,
+  );
+}
 
 assert.match(
   viewportHarness,

--- a/winsmux-app/scripts/desktop-pane-e2e.mjs
+++ b/winsmux-app/scripts/desktop-pane-e2e.mjs
@@ -1630,7 +1630,7 @@ async function assertSettingsReflectPaneSpecificWorkerAssignment(page) {
       perPaneMode.getAttribute("aria-pressed") === "true" &&
       provider instanceof HTMLSelectElement &&
       provider.disabled &&
-      model instanceof HTMLSelectElement &&
+      model instanceof HTMLInputElement &&
       model.disabled &&
       effort instanceof HTMLSelectElement &&
       effort.disabled &&

--- a/winsmux-app/scripts/viewport-harness.mjs
+++ b/winsmux-app/scripts/viewport-harness.mjs
@@ -888,9 +888,9 @@ async function installSpeechRecognitionStub(page) {
     if (!window.localStorage.getItem("winsmux.runtime-role.preferences.v1")) {
       window.localStorage.setItem("winsmux.runtime-role.preferences.v1", JSON.stringify(runtimePreferences));
     }
-    if (!window.localStorage.getItem("winsmux.runtime-model.assignment-mode.v1")) {
-      window.localStorage.setItem("winsmux.runtime-model.assignment-mode.v1", "shared");
-    }
+    window.localStorage.setItem("winsmux.runtime-model.assignment-mode.v1", "shared");
+    window.localStorage.removeItem("winsmux.runtime-model.worker-default.v1");
+    window.localStorage.removeItem("winsmux.runtime-model.slot-overrides.v1");
     const speechRecognitionState = {
       aborts: 0,
       instances: [],
@@ -1007,8 +1007,8 @@ async function assertSettingsRoundtrip(page, returnSelector) {
       provider instanceof HTMLSelectElement &&
       provider.value === "codex" &&
       !provider.disabled &&
-      model instanceof HTMLSelectElement &&
-      model.value === "codex-provider-default" &&
+      model instanceof HTMLInputElement &&
+      model.value === "Auto" &&
       !model.disabled &&
       effort instanceof HTMLSelectElement &&
       effort.value === "provider-default" &&
@@ -1724,6 +1724,7 @@ async function assertSourceControlChrome(page) {
       svg.getBoundingClientRect().width <= 80;
   });
   await page.waitForFunction(() => {
+    const rows = Array.from(document.querySelectorAll("#source-control-graph-list .source-control-graph-row"));
     const path = Array.from(document.querySelectorAll("#source-control-graph-list .source-control-graph-lane-path"))
       .find((candidate) => (candidate.getAttribute("d") ?? "").includes(" C "));
     const pillar = Array.from(document.querySelectorAll("#source-control-graph-list .source-control-graph-lane-path.is-pillar"))
@@ -1732,7 +1733,9 @@ async function assertSourceControlChrome(page) {
       .find((candidate) => (candidate.getAttribute("d") ?? "").includes(" A "));
     const parentLane = Array.from(document.querySelectorAll("#source-control-graph-list .source-control-graph-lanes"))
       .find((lane) => (lane instanceof HTMLElement) && (lane.dataset.graphParents ?? "").length > 0);
-    return Boolean(path && pillar && parentLane && !arcPath);
+    const hasBranchCurve = Boolean(path && parentLane);
+    const hasLinearHistory = Boolean(pillar && rows.length >= 2);
+    return Boolean(pillar && !arcPath && (hasBranchCurve || hasLinearHistory));
   });
   await page.click("#activity-explorer-btn");
   await page.locator("#explorer-list").waitFor({ state: "visible" });
@@ -1920,15 +1923,15 @@ async function verifyDesktopViewport(page, previewUrl) {
   });
 
   await runStep("desktop editor surface", async () => {
-    await assertSourceControlChrome(page);
-    await assertExplorerFolderExpandsInline(page);
-    await assertExplorerFileOpensMainEditor(page);
-    await ensureContextPanelOpen(page);
-    await openFirstSourceContextEntry(page);
-    await assertEditorPopout(page);
-    await assertCommandBarRoundtrip(page, "#editor-surface");
-    await assertSettingsRoundtrip(page, "#editor-surface");
-    await assertTerminalDrawerWithSourceContext(page, "#editor-surface", "#context-panel");
+    await runStep("editor source control chrome", () => assertSourceControlChrome(page));
+    await runStep("editor explorer folder expands", () => assertExplorerFolderExpandsInline(page));
+    await runStep("editor explorer file opens", () => assertExplorerFileOpensMainEditor(page));
+    await runStep("editor context panel opens", () => ensureContextPanelOpen(page));
+    await runStep("editor source context opens", () => openFirstSourceContextEntry(page));
+    await runStep("editor popout roundtrip", () => assertEditorPopout(page));
+    await runStep("editor command bar roundtrip", () => assertCommandBarRoundtrip(page, "#editor-surface"));
+    await runStep("editor settings roundtrip", () => assertSettingsRoundtrip(page, "#editor-surface"));
+    await runStep("editor terminal drawer source context", () => assertTerminalDrawerWithSourceContext(page, "#editor-surface", "#context-panel"));
   });
 
   await runStep("desktop browser surface", async () => {

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -10449,6 +10449,158 @@ function createRuntimeSelect<T extends string>(
   return group;
 }
 
+function getRuntimeReasoningOptionHelp(value: RuntimeReasoningEffort, provider: RuntimeProviderId, japanese: boolean) {
+  if (provider !== "claude") {
+    return "";
+  }
+  const descriptions: Record<RuntimeReasoningEffort, { label: string; labelJa: string }> = {
+    "provider-default": {
+      label: "Use the Claude Code account default.",
+      labelJa: "Claude Code 側の既定値を使います。",
+    },
+    low: {
+      label: "Fastest responses with lighter reasoning.",
+      labelJa: "速さを優先した軽い推論です。",
+    },
+    medium: {
+      label: "Balanced speed and reasoning depth.",
+      labelJa: "速さと思考量のバランスを取ります。",
+    },
+    high: {
+      label: "Use deeper reasoning for complex work.",
+      labelJa: "複雑な作業向けに深く考えます。",
+    },
+    max: {
+      label: "Use a very high reasoning budget.",
+      labelJa: "より大きい思考量を使います。",
+    },
+    xhigh: {
+      label: "Use the maximum available Claude Code effort.",
+      labelJa: "Claude Code で利用できる最大の思考量を使います。",
+    },
+  };
+  return japanese ? descriptions[value].labelJa : descriptions[value].label;
+}
+
+function createRuntimeEffortControl(
+  id: string,
+  label: string,
+  provider: RuntimeProviderId,
+  entry: RuntimeModelCatalogEntry | undefined | null,
+  value: RuntimeReasoningEffort,
+  japanese: boolean,
+  onChange: (value: RuntimeReasoningEffort) => void,
+  controlOptions: { disabled?: boolean; title?: string } = {},
+) {
+  const options = getRuntimeReasoningOptionsForEntry(provider, entry);
+  const normalizedValue = normalizeRuntimeReasoningForEntry(provider, entry, value);
+  const selectOptions = options.map((option) => ({
+    value: option.value,
+    label: getRuntimeReasoningOptionLabel(option, provider, false),
+    labelJa: getRuntimeReasoningOptionLabel(option, provider, true),
+  }));
+  if (provider !== "claude" || options.length <= 1) {
+    return createRuntimeSelect(
+      id,
+      label,
+      normalizedValue,
+      selectOptions,
+      japanese,
+      onChange,
+      controlOptions,
+    );
+  }
+
+  const group = document.createElement("div");
+  group.className = `runtime-control-group runtime-effort-control runtime-effort-control-claude ${controlOptions.disabled ? "is-disabled" : ""}`;
+  group.dataset.provider = provider;
+  group.dataset.value = normalizedValue;
+  if (controlOptions.title) {
+    group.setAttribute("title", controlOptions.title);
+  }
+
+  const header = document.createElement("div");
+  header.className = "runtime-effort-header";
+  const caption = document.createElement("span");
+  caption.className = "runtime-control-caption";
+  caption.textContent = label;
+  const current = document.createElement("span");
+  current.className = "runtime-effort-current";
+  header.append(caption, current);
+  group.appendChild(header);
+
+  const scaleLabels = document.createElement("div");
+  scaleLabels.className = "runtime-effort-scale-labels";
+  const fastLabel = document.createElement("span");
+  fastLabel.textContent = japanese ? "速い" : "Faster";
+  const deepLabel = document.createElement("span");
+  deepLabel.textContent = japanese ? "賢い" : "Deeper";
+  scaleLabels.append(fastLabel, deepLabel);
+  group.appendChild(scaleLabels);
+
+  const range = document.createElement("input");
+  range.id = id;
+  range.className = "runtime-effort-range";
+  range.type = "range";
+  range.min = "0";
+  range.max = String(options.length - 1);
+  range.step = "1";
+  range.disabled = Boolean(controlOptions.disabled);
+  range.setAttribute("aria-label", label);
+  group.appendChild(range);
+
+  const steps = document.createElement("div");
+  steps.className = "runtime-effort-steps";
+  const stepButtons = new Map<RuntimeReasoningEffort, HTMLButtonElement>();
+  for (const option of options) {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "runtime-effort-step";
+    button.dataset.effort = option.value;
+    button.disabled = Boolean(controlOptions.disabled);
+    button.textContent = getRuntimeReasoningOptionLabel(option, provider, japanese);
+    button.title = getRuntimeReasoningOptionHelp(option.value, provider, japanese);
+    button.addEventListener("click", () => {
+      setSelected(option.value);
+      onChange(option.value);
+    });
+    stepButtons.set(option.value, button);
+    steps.appendChild(button);
+  }
+  group.appendChild(steps);
+
+  const help = document.createElement("div");
+  help.className = "runtime-effort-help";
+  group.appendChild(help);
+
+  function setSelected(nextValue: RuntimeReasoningEffort) {
+    const normalized = normalizeRuntimeReasoningForEntry(provider, entry, nextValue);
+    const selectedIndex = Math.max(0, options.findIndex((option) => option.value === normalized));
+    range.value = String(selectedIndex);
+    group.dataset.value = normalized;
+    const selectedOption = options[selectedIndex] ?? options[0];
+    current.textContent = selectedOption
+      ? getRuntimeReasoningOptionLabel(selectedOption, provider, japanese)
+      : "";
+    help.textContent = selectedOption
+      ? getRuntimeReasoningOptionHelp(selectedOption.value, provider, japanese)
+      : "";
+    for (const [effort, button] of stepButtons) {
+      const selected = effort === normalized;
+      button.classList.toggle("is-selected", selected);
+      button.setAttribute("aria-pressed", selected ? "true" : "false");
+    }
+  }
+
+  range.addEventListener("input", () => {
+    const next = options[Number(range.value)]?.value ?? normalizedValue;
+    setSelected(next);
+    onChange(next);
+  });
+  setSelected(normalizedValue);
+  return group;
+}
+
 function findRuntimeModelCatalogEntry(id: string) {
   if (!id) {
     return null;
@@ -10938,6 +11090,25 @@ function getRuntimeModelSelectEntries(
   return limited;
 }
 
+function getRuntimeModelFilterText(
+  inputValue: string,
+  selectedEntry: RuntimeModelCatalogEntry,
+  japanese: boolean,
+) {
+  const trimmed = inputValue.trim();
+  if (!trimmed) {
+    return "";
+  }
+  const selectedLabels = [
+    getRuntimeCatalogOptionLabel(selectedEntry, japanese),
+    selectedEntry.label,
+    selectedEntry.labelJa,
+    selectedEntry.model,
+    selectedEntry.id,
+  ].filter(Boolean).map((label) => label.toLowerCase());
+  return selectedLabels.includes(trimmed.toLowerCase()) ? "" : trimmed;
+}
+
 function getRuntimeModelSourceDisplayLabel(source: string, japanese: boolean) {
   const normalized = source.trim().toLowerCase();
   const option = runtimeModelSourceOptions.find((item) => item.value === normalized);
@@ -11019,14 +11190,6 @@ function getRuntimeReasoningOptionsForEntry(provider: RuntimeProviderId, entry?:
     provider,
     runtimeReasoningOptions.filter((item) => allowed.includes(item.value)),
   );
-}
-
-function getRuntimeReasoningSelectOptionsForProvider(provider: RuntimeProviderId, japanese: boolean) {
-  return getRuntimeReasoningOptionsForProvider(provider).map((option) => ({
-    value: option.value,
-    label: getRuntimeReasoningOptionLabel(option, provider, false),
-    labelJa: getRuntimeReasoningOptionLabel(option, provider, japanese),
-  }));
 }
 
 function normalizeRuntimeReasoningForEntry(provider: RuntimeProviderId, entry: RuntimeModelCatalogEntry | undefined | null, effort: string | undefined) {
@@ -11282,7 +11445,12 @@ function renderRuntimeWorkerDefaultControls(japanese: boolean, disabled = false)
     }) ?? selectedEntry;
   };
   const renderSharedModelOptions = () => {
-    const displayEntries = getRuntimeModelSelectEntries(entries, selectedEntry, modelInput.value, japanese);
+    const displayEntries = getRuntimeModelSelectEntries(
+      entries,
+      selectedEntry,
+      getRuntimeModelFilterText(modelInput.value, selectedEntry, japanese),
+      japanese,
+    );
     modelOptions.innerHTML = "";
     for (const entry of displayEntries) {
       const option = document.createElement("option");
@@ -11306,11 +11474,12 @@ function renderRuntimeWorkerDefaultControls(japanese: boolean, disabled = false)
   modelField.append(modelCaption, modelInput, modelOptions);
   controls.appendChild(modelField);
 
-  controls.appendChild(createRuntimeSelect(
+  controls.appendChild(createRuntimeEffortControl(
     "runtime-worker-default-effort",
     japanese ? "思考量" : "Effort",
+    selectedProvider,
+    selectedEntry,
     normalizeRuntimeReasoningForEntry(selectedProvider, selectedEntry, preference.reasoningEffort),
-    getRuntimeReasoningSelectOptionsForProvider(selectedProvider, japanese),
     japanese,
     (reasoningEffort) => updateRuntimeRoleDraft("worker", { reasoningEffort }),
     { disabled, title: disabledTitle },
@@ -11468,15 +11637,8 @@ function renderWorkerModelAssignmentPanel(japanese: boolean) {
     modelOptions.id = modelOptionsId;
     modelField.append(modelCaption, modelInput, modelOptions);
 
-    const effortField = document.createElement("label");
-    effortField.className = "runtime-model-slot-field";
-    const effortCaption = document.createElement("span");
-    effortCaption.className = "runtime-control-caption";
-    effortCaption.textContent = japanese ? "思考量" : "Effort";
-    const effortSelect = document.createElement("select");
-    effortSelect.className = "runtime-control-select runtime-model-slot-effort";
-    effortSelect.setAttribute("aria-label", japanese ? `${slotId} の思考量` : `${slotId} effort`);
-    effortField.append(effortCaption, effortSelect);
+    const effortField = document.createElement("div");
+    effortField.className = "runtime-model-slot-field runtime-model-slot-effort-host";
 
     const control = document.createElement("div");
     control.className = "runtime-model-slot-control";
@@ -11498,21 +11660,31 @@ function renderWorkerModelAssignmentPanel(japanese: boolean) {
       : (japanese ? "適用" : "Apply");
 
     let currentEntries: RuntimeModelCatalogEntry[] = [];
+    let selectedRuntimeEffort: RuntimeReasoningEffort = "provider-default";
     const renderEffortOptions = (provider: RuntimeProviderId, entry?: RuntimeModelCatalogEntry | null, preferredEffort?: RuntimeReasoningEffort) => {
       const options = getRuntimeReasoningOptionsForEntry(provider, entry);
-      const normalizedEffort = normalizeRuntimeReasoningForEntry(provider, entry, preferredEffort ?? effortSelect.value);
-      effortSelect.innerHTML = "";
-      for (const option of options) {
-        const element = document.createElement("option");
-        element.value = option.value;
-        element.textContent = getRuntimeReasoningOptionLabel(option, provider, japanese);
-        element.selected = option.value === normalizedEffort;
-        effortSelect.appendChild(element);
-      }
-      effortSelect.disabled = Boolean(workerProviderSwitchInFlight) || options.length <= 1;
-      effortSelect.title = options.length <= 1
+      selectedRuntimeEffort = normalizeRuntimeReasoningForEntry(provider, entry, preferredEffort ?? selectedRuntimeEffort);
+      const disabledReason = options.length <= 1
         ? (japanese ? "このプロバイダーは思考量の明示指定に未対応です。" : "This provider does not expose a supported effort override.")
         : "";
+      const effortControl = createRuntimeEffortControl(
+        `runtime-model-slot-effort-${slotId}`,
+        japanese ? "思考量" : "Effort",
+        provider,
+        entry,
+        selectedRuntimeEffort,
+        japanese,
+        (reasoningEffort) => {
+          selectedRuntimeEffort = reasoningEffort;
+          updateActionState();
+        },
+        {
+          disabled: Boolean(workerProviderSwitchInFlight) || options.length <= 1,
+          title: disabledReason,
+        },
+      );
+      effortControl.classList.add("runtime-model-slot-effort");
+      effortField.replaceChildren(effortControl);
     };
     const findModelEntryFromInput = (provider: RuntimeProviderId, inputValue: string) => {
       const normalizedValue = inputValue.trim().toLowerCase();
@@ -11528,7 +11700,12 @@ function renderWorkerModelAssignmentPanel(japanese: boolean) {
       }) ?? createRuntimeCustomModelEntry(provider, inputValue.trim());
     };
     const renderModelOptionList = (selectedEntry: RuntimeModelCatalogEntry) => {
-      const displayEntries = getRuntimeModelSelectEntries(currentEntries, selectedEntry, modelInput.value, japanese);
+      const displayEntries = getRuntimeModelSelectEntries(
+        currentEntries,
+        selectedEntry,
+        getRuntimeModelFilterText(modelInput.value, selectedEntry, japanese),
+        japanese,
+      );
       modelOptions.innerHTML = "";
       for (const entry of displayEntries) {
         const option = document.createElement("option");
@@ -11540,7 +11717,7 @@ function renderWorkerModelAssignmentPanel(japanese: boolean) {
     const resolveSelection = (): RuntimePaneModelSelection | null => {
       const provider = normalizeRuntimeProviderId(providerSelect.value) ?? inferredProvider;
       const entry = findModelEntryFromInput(provider, modelInput.value);
-      const effort = normalizeRuntimeReasoningForEntry(provider, entry, effortSelect.value || entry.reasoningEffort);
+      const effort = normalizeRuntimeReasoningForEntry(provider, entry, selectedRuntimeEffort || entry.reasoningEffort);
       return { entry, reasoningEffort: effort };
     };
 
@@ -11622,7 +11799,6 @@ function renderWorkerModelAssignmentPanel(japanese: boolean) {
       }
       updateActionState();
     });
-    effortSelect.addEventListener("change", updateActionState);
     action.addEventListener("click", () => {
       const selection = resolveSelection();
       if (selection) {

--- a/winsmux-app/src/styles.css
+++ b/winsmux-app/src/styles.css
@@ -4757,6 +4757,75 @@ body.is-resizing-workbench {
   border-color: var(--status-focus-border);
 }
 
+.runtime-effort-control {
+  min-width: 0;
+}
+
+.runtime-effort-header {
+  display: flex;
+  min-width: 0;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.runtime-effort-current {
+  color: var(--text-primary);
+  font-size: var(--text-xs);
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.runtime-effort-scale-labels {
+  display: flex;
+  justify-content: space-between;
+  color: var(--text-muted);
+  font-size: var(--text-2xs);
+}
+
+.runtime-effort-range {
+  width: 100%;
+  accent-color: var(--status-focus-border);
+}
+
+.runtime-effort-steps {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(42px, 1fr));
+  gap: 4px;
+}
+
+.runtime-effort-step {
+  min-width: 0;
+  border: 1px solid var(--border-muted);
+  border-radius: 999px;
+  background: var(--bg-surface);
+  color: var(--text-secondary);
+  padding: 2px 6px;
+  font: inherit;
+  font-size: var(--text-2xs);
+  line-height: var(--leading-tight);
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.runtime-effort-step.is-selected {
+  color: var(--status-focus);
+  border-color: var(--status-focus-border);
+  background: color-mix(in srgb, var(--status-focus) 13%, var(--bg-surface));
+}
+
+.runtime-effort-step:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.runtime-effort-help {
+  min-height: 1.2em;
+  color: var(--text-muted);
+  font-size: var(--text-2xs);
+  line-height: var(--leading-normal);
+}
+
 .runtime-model-panel {
   display: grid;
   gap: 8px;
@@ -4912,7 +4981,7 @@ body.is-resizing-workbench {
 
 .runtime-model-slot-control {
   display: grid;
-  grid-template-columns: minmax(120px, 0.9fr) minmax(160px, 1.2fr) minmax(92px, 0.65fr);
+  grid-template-columns: minmax(120px, 0.8fr) minmax(180px, 1.1fr) minmax(190px, 1fr);
   gap: 5px;
   min-width: 0;
 }
@@ -4921,6 +4990,10 @@ body.is-resizing-workbench {
   display: grid;
   gap: 3px;
   min-width: 0;
+}
+
+.runtime-model-slot-effort-host .runtime-effort-help {
+  display: none;
 }
 
 .runtime-model-slot-state {


### PR DESCRIPTION
## Summary
- Fixes #1045.
- Replace the plain Claude effort select in Settings with a Claude-specific effort control that matches provider semantics.
- Keep unsupported effort overrides hidden for providers that do not expose them: Antigravity, Grok Build, and OpenRouter stay on provider default; Codex no longer exposes Claude-only Max.
- Update desktop UI harnesses for the searchable model picker and deterministic Settings round-trips.

## Verification
- `npm --prefix winsmux-app run test:composer-session-controls`
- `node --check winsmux-app\scripts\clickable-coverage-harness.mjs; node --check winsmux-app\scripts\desktop-pane-e2e.mjs; node --check winsmux-app\scripts\viewport-harness.mjs`
- `git diff --check`
- `npm --prefix winsmux-app run test:viewport-harness`
- `npm --prefix winsmux-app run test:clickable-coverage`
- `git-guard` pre-commit and pre-push checks
- `gitleaks` pre-push scan

## Notes
- This PR is limited to the Settings runtime model/effort controls and related harness coverage. Operator live model-state synchronization remains separate from this fix.
