### PR TITLE
fix(core): keep unhealthy orchestra sessions intact

### DIFF
--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -5355,27 +5355,33 @@ session:
         $events[0].data.health_status | Should -Be 'Missing'
     }
 
-    It 'treats unhealthy strict health as a restartable server failure' {
+    It 'does not restart an existing session on unhealthy strict health' {
         $state = New-ServerWatchdogState
 
         Mock Get-ServerWatchdogHealthStatus { 'Unhealthy' }
         Mock Invoke-ServerWatchdogWinsmux {
-            [ordered]@{
-                ExitCode = 0
-                Output   = @()
-            }
+            throw 'restart should not run for unhealthy strict health'
         } -ParameterFilter {
             $AllowFailure -and $Arguments[0] -eq 'new-session'
         }
 
         $result = Invoke-ServerWatchdogCycle -ManifestPath $script:serverWatchdogManifestPath -SessionName 'winsmux-orchestra' -State $state
 
-        $result.RestartAttempted | Should -Be $true
-        $result.RestartSucceeded | Should -Be $true
+        $result.SessionAlive | Should -Be $true
+        $result.RestartAttempted | Should -Be $false
+        $result.RestartSucceeded | Should -Be $false
         $result.HealthStatus | Should -Be 'Unhealthy'
+        $result.Event | Should -Be 'server.healthcheck_failed'
+        $state.RestartAttempts.Count | Should -Be 0
+        Should -Invoke Invoke-ServerWatchdogWinsmux -Times 0 -Exactly -ParameterFilter {
+            $AllowFailure -and $Arguments[0] -eq 'new-session'
+        }
 
         $eventsPath = Join-Path $script:serverWatchdogTempRoot '.winsmux\events.jsonl'
         $events = @(Get-Content -Path $eventsPath -Encoding UTF8 | Where-Object { $_ } | ForEach-Object { $_ | ConvertFrom-Json })
+        $events.Count | Should -Be 1
+        $events[0].event | Should -Be 'server.healthcheck_failed'
+        $events[0].status | Should -Be 'warning'
         $events[0].exit_reason | Should -Be 'healthcheck_failed'
         $events[0].data.health_status | Should -Be 'Unhealthy'
     }

--- a/winsmux-core/scripts/server-watchdog.ps1
+++ b/winsmux-core/scripts/server-watchdog.ps1
@@ -268,8 +268,27 @@ function Invoke-ServerWatchdogCycle {
         return $result
     }
 
+    if ($healthStatus -eq 'Unhealthy') {
+        $result['Event'] = 'server.healthcheck_failed'
+        $result['Message'] = "Server session $SessionName failed strict health; leaving session intact."
+
+        Write-ServerWatchdogEvent -ProjectDir $projectDir -SessionName $SessionName `
+            -Event 'server.healthcheck_failed' `
+            -Message $result.Message `
+            -Status 'warning' `
+            -ExitReason 'healthcheck_failed' `
+            -Data ([ordered]@{
+                attempt_count          = $activeAttempts.Count
+                max_restart_attempts   = [int]$State.MaxRestartAttempts
+                restart_window_minutes = [int]$State.RestartWindowMinutes
+                health_status          = $healthStatus
+            }) | Out-Null
+
+        return $result
+    }
+
     $result['SessionAlive'] = $false
-    $exitReason = if ($healthStatus -eq 'Unhealthy') { 'healthcheck_failed' } else { 'session_missing' }
+    $exitReason = 'session_missing'
 
     if ($activeAttempts.Count -ge [int]$State.MaxRestartAttempts) {
         $State['Degraded'] = $true


### PR DESCRIPTION
## Summary

Fixes #1052.

This change prevents the server watchdog from destroying a live six-pane orchestra session when strict health temporarily reports `Unhealthy`.

## Changes

- Treat `Missing` sessions as restartable, preserving the existing recovery path.
- Treat `Unhealthy` strict-health results as a warning event (`server.healthcheck_failed`) and leave the current session intact.
- Update the watchdog Pester coverage so `Unhealthy` no longer calls `winsmux new-session`.

## Verification

- `Invoke-Pester -Path tests/winsmux-bridge.Tests.ps1 -FullName '*server-watchdog helpers*' -Output Detailed`
- `git diff --cached --check`
- `git diff --check`
- push hooks: `git-guard`, `audit-public-surface`, `gitleaks`

## Notes

The full `tests/winsmux-bridge.Tests.ps1` run was started but did not complete in a reasonable time. I stopped that broader run and did not repeat it; the targeted watchdog coverage passed and CI should run the broader matrix.
