### PR TITLE
fix(core): diagnose builder worktree lock owners

### DIFF
--- a/tests/BuilderWorktree.Tests.ps1
+++ b/tests/BuilderWorktree.Tests.ps1
@@ -63,3 +63,97 @@ branch refs/heads/worktree-builder-2
         )
     }
 }
+
+Describe 'Get-BuilderWorktreeLockDiagnosticText' {
+    BeforeAll {
+        . (Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\builder-worktree.ps1')
+    }
+
+    It 'reports a process whose command line references the locked worktree and excludes live desktop pollers' {
+        $projectDir = Join-Path $TestDrive 'repo'
+        $worktreePath = Join-Path $projectDir '.worktrees\builder-1'
+
+        Mock Get-CimInstance {
+            @(
+                [PSCustomObject]@{
+                    ProcessId   = 111
+                    Name        = 'pwsh.exe'
+                    CommandLine = "pwsh -NoProfile -File worker.ps1 -ProjectDir `"$worktreePath`""
+                },
+                [PSCustomObject]@{
+                    ProcessId   = 222
+                    Name        = 'pwsh.exe'
+                    CommandLine = "pwsh -NoProfile -Command winsmux desktop-summary --stream --project `"$projectDir`""
+                },
+                [PSCustomObject]@{
+                    ProcessId   = 333
+                    Name        = 'pwsh.exe'
+                    CommandLine = "pwsh -NoProfile -Command winsmux workers status all --project `"$projectDir`""
+                }
+            )
+        }
+
+        $text = Get-BuilderWorktreeLockDiagnosticText -WorktreePath $worktreePath -ProjectDir $projectDir
+
+        $text | Should -Match 'owner candidates: pid=111 name=pwsh\.exe reason=command_line_matches_worktree'
+        $text | Should -Not -Match 'pid=222'
+        $text | Should -Not -Match 'pid=333'
+    }
+
+    It 'reports branch marker matches for registered builder worktrees' {
+        $projectDir = Join-Path $TestDrive 'repo'
+        $worktreePath = Join-Path $projectDir '.worktrees\builder-2'
+
+        Mock Get-CimInstance {
+            @(
+                [PSCustomObject]@{
+                    ProcessId   = 444
+                    Name        = 'git.exe'
+                    CommandLine = 'git worktree remove --force worktree-builder-2'
+                }
+            )
+        }
+
+        $text = Get-BuilderWorktreeLockDiagnosticText -WorktreePath $worktreePath -ProjectDir $projectDir
+
+        $text | Should -Match 'owner candidates: pid=444 name=git\.exe reason=branch_or_worktree_marker'
+    }
+
+    It 'does not treat live desktop status pollers as lock owners' {
+        $projectDir = Join-Path $TestDrive 'repo'
+        $worktreePath = Join-Path $projectDir '.worktrees\builder-3'
+
+        Mock Get-CimInstance {
+            @(
+                [PSCustomObject]@{
+                    ProcessId   = 555
+                    Name        = 'pwsh.exe'
+                    CommandLine = "pwsh -NoProfile -Command winsmux desktop-summary --stream --project `"$projectDir`""
+                },
+                [PSCustomObject]@{
+                    ProcessId   = 666
+                    Name        = 'pwsh.exe'
+                    CommandLine = "pwsh -NoProfile -Command winsmux workers status all --project `"$projectDir`""
+                }
+            )
+        }
+
+        $text = Get-BuilderWorktreeLockDiagnosticText -WorktreePath $worktreePath -ProjectDir $projectDir
+
+        $text | Should -Match 'owner candidates: none by command line'
+        $text | Should -Match 'excluded live desktop poller count=2'
+    }
+
+    It 'keeps cleanup diagnostics non-fatal when process inventory is unavailable' {
+        $projectDir = Join-Path $TestDrive 'repo'
+        $worktreePath = Join-Path $projectDir '.worktrees\builder-4'
+
+        Mock Get-CimInstance {
+            throw 'process inventory unavailable'
+        }
+
+        $text = Get-BuilderWorktreeLockDiagnosticText -WorktreePath $worktreePath -ProjectDir $projectDir
+
+        $text | Should -Match 'owner candidates unavailable: process inventory unavailable'
+    }
+}

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -5834,11 +5834,22 @@ Describe 'orchestra-start server bootstrap' {
             $global:LASTEXITCODE = 0
         }
 
+        Mock Get-CimInstance {
+            @(
+                [PSCustomObject]@{
+                    ProcessId   = 12345
+                    Name        = 'pwsh.exe'
+                    CommandLine = "pwsh -NoProfile -File worker.ps1 -ProjectDir `"$lockedWorktreePath`""
+                }
+            )
+        }
+
         try {
             $cleanup = Invoke-StaleBuilderWorktreeCleanup -ProjectDir $testProjectDir
 
             @($cleanup.RemovedWorktreePaths).Count | Should -Be 0
             @($cleanup.CleanupErrors | Where-Object { $_ -like "worktree remove $lockedWorktreePath failed:*" }).Count | Should -Be 1
+            @($cleanup.CleanupErrors | Where-Object { $_ -like '*owner candidates: pid=12345 name=pwsh.exe reason=command_line_matches_worktree*' }).Count | Should -Be 1
             @($cleanup.CleanupErrors | Where-Object { $_ -like 'branch delete worktree-builder-1 failed:*' }).Count | Should -Be 1
             (Test-Path -LiteralPath $lockedWorktreePath) | Should -Be $true
         } finally {

--- a/winsmux-core/scripts/builder-worktree.ps1
+++ b/winsmux-core/scripts/builder-worktree.ps1
@@ -156,19 +156,108 @@ function Get-OrchestraBuilderWorktreeInventory {
     }
 }
 
+function Get-BuilderWorktreeLockDiagnosticText {
+    param(
+        [Parameter(Mandatory = $true)][string]$WorktreePath,
+        [Parameter(Mandatory = $true)][string]$ProjectDir
+    )
+
+    $resolvedWorktreePath = [System.IO.Path]::GetFullPath($WorktreePath).TrimEnd('\', '/')
+    $resolvedProjectDir = [System.IO.Path]::GetFullPath($ProjectDir).TrimEnd('\', '/')
+    $worktreeSlashPath = $resolvedWorktreePath -replace '\\', '/'
+    $leafName = Split-Path -Leaf $resolvedWorktreePath
+    $builderIndex = ''
+    if ($leafName -match '^builder-(\d+)$') {
+        $builderIndex = $Matches[1]
+    }
+    $branchName = if ([string]::IsNullOrWhiteSpace($builderIndex)) { '' } else { "worktree-builder-$builderIndex" }
+
+    try {
+        $processes = @(Get-CimInstance Win32_Process -OperationTimeoutSec 10)
+    } catch {
+        return "owner candidates unavailable: $($_.Exception.Message)"
+    }
+
+    $candidates = [System.Collections.Generic.List[string]]::new()
+    $excludedPollers = 0
+    foreach ($process in $processes) {
+        $commandLine = [string]$process.CommandLine
+        if ([string]::IsNullOrWhiteSpace($commandLine)) {
+            continue
+        }
+
+        $matchesWorktree =
+            $commandLine.IndexOf($resolvedWorktreePath, [System.StringComparison]::OrdinalIgnoreCase) -ge 0 -or
+            $commandLine.IndexOf($worktreeSlashPath, [System.StringComparison]::OrdinalIgnoreCase) -ge 0 -or
+            ((-not [string]::IsNullOrWhiteSpace($branchName)) -and $commandLine.IndexOf($branchName, [System.StringComparison]::OrdinalIgnoreCase) -ge 0)
+
+        $matchesLivePoller =
+            $commandLine.IndexOf($resolvedProjectDir, [System.StringComparison]::OrdinalIgnoreCase) -ge 0 -and
+            ($commandLine.IndexOf('desktop-summary', [System.StringComparison]::OrdinalIgnoreCase) -ge 0 -or
+                ($commandLine.IndexOf('workers', [System.StringComparison]::OrdinalIgnoreCase) -ge 0 -and
+                    $commandLine.IndexOf('status', [System.StringComparison]::OrdinalIgnoreCase) -ge 0))
+
+        if (-not $matchesWorktree) {
+            if ($matchesLivePoller) {
+                $excludedPollers++
+            }
+            continue
+        }
+
+        $pidText = [string]$process.ProcessId
+        $nameText = [string]$process.Name
+        $reason = if (-not [string]::IsNullOrWhiteSpace($branchName) -and $commandLine.IndexOf($branchName, [System.StringComparison]::OrdinalIgnoreCase) -ge 0) {
+            'branch_or_worktree_marker'
+        } else {
+            'command_line_matches_worktree'
+        }
+        $candidates.Add("pid=$pidText name=$nameText reason=$reason") | Out-Null
+    }
+
+    if ($candidates.Count -gt 0) {
+        return "owner candidates: $($candidates -join '; ')"
+    }
+
+    if ($excludedPollers -gt 0) {
+        return "owner candidates: none by command line; excluded live desktop poller count=$excludedPollers; lock may be a process current directory or open file handle"
+    }
+
+    return 'owner candidates: none by command line; lock may be a process current directory or open file handle'
+}
+
+function Format-BuilderWorktreeCleanupError {
+    param(
+        [Parameter(Mandatory = $true)][string]$Prefix,
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $true)][string]$Message,
+        [Parameter(Mandatory = $true)][string]$ProjectDir
+    )
+
+    $diagnostic = Get-BuilderWorktreeLockDiagnosticText -WorktreePath $Path -ProjectDir $ProjectDir
+    return "${Prefix}: $Message ($diagnostic)"
+}
+
 function Invoke-StaleBuilderWorktreeCleanup {
     param([Parameter(Mandatory = $true)][string]$ProjectDir)
 
     $worktreeRoot = Join-Path $ProjectDir '.worktrees'
     $resolvedProjectDir = [System.IO.Path]::GetFullPath($ProjectDir).TrimEnd('\', '/')
 
-    Invoke-BuilderWorktreeGit -ProjectDir $ProjectDir -Arguments @('worktree', 'prune') | Out-Null
+    $pruneResult = Invoke-BuilderWorktreeGit -ProjectDir $ProjectDir -Arguments @('worktree', 'prune') -AllowFailure
+    $cleanupErrors = [System.Collections.Generic.List[string]]::new()
+    if ($pruneResult.ExitCode -ne 0) {
+        $message = if ([string]::IsNullOrWhiteSpace($pruneResult.Output)) {
+            'unknown git worktree prune error'
+        } else {
+            $pruneResult.Output
+        }
+        $cleanupErrors.Add("worktree prune failed: $message") | Out-Null
+    }
     $inventory = Get-OrchestraBuilderWorktreeInventory -ProjectDir $ProjectDir
 
     $removedWorktreePaths = [System.Collections.Generic.List[string]]::new()
     $removedDirectoryPaths = [System.Collections.Generic.List[string]]::new()
     $removedBranches = [System.Collections.Generic.List[string]]::new()
-    $cleanupErrors = [System.Collections.Generic.List[string]]::new()
 
     foreach ($entry in @($inventory.RegisteredWorktrees | Sort-Object WorktreePath -Unique)) {
         $worktreePath = [System.IO.Path]::GetFullPath($entry.WorktreePath)
@@ -191,7 +280,7 @@ function Invoke-StaleBuilderWorktreeCleanup {
                 } else {
                     $removeResult.Output
                 }
-                $cleanupErrors.Add("worktree remove $worktreePath failed: $message") | Out-Null
+                $cleanupErrors.Add((Format-BuilderWorktreeCleanupError -Prefix "worktree remove $worktreePath failed" -Path $worktreePath -Message $message -ProjectDir $ProjectDir)) | Out-Null
             }
         }
 
@@ -221,7 +310,7 @@ function Invoke-StaleBuilderWorktreeCleanup {
                 Remove-Item -LiteralPath $resolvedDirectoryPath -Recurse -Force
                 $removedDirectoryPaths.Add($resolvedDirectoryPath) | Out-Null
             } catch {
-                $cleanupErrors.Add("directory remove $resolvedDirectoryPath failed: $($_.Exception.Message)") | Out-Null
+                $cleanupErrors.Add((Format-BuilderWorktreeCleanupError -Prefix "directory remove $resolvedDirectoryPath failed" -Path $resolvedDirectoryPath -Message $_.Exception.Message -ProjectDir $ProjectDir)) | Out-Null
             }
         }
     }

--- a/winsmux-core/scripts/orchestra-start.ps1
+++ b/winsmux-core/scripts/orchestra-start.ps1
@@ -2194,7 +2194,19 @@ if ($MyInvocation.InvocationName -ne '.') {
         $zombieCleanup = Remove-OrchestraZombieProcesses -SessionName $sessionName -ProjectDir $projectDir -GitWorktreeDir $gitWorktreeDir -BridgeScript $bridgeScript -WinsmuxBin $winsmuxBin
         if (@($zombieCleanup.Killed).Count -gt 0) {
             Write-WinsmuxLog -Level INFO -Event 'preflight.git_worktree.prune_after_zombie_cleanup' -Message 'Pruning git worktree metadata after zombie cleanup.' -Data @{ killed_count = @($zombieCleanup.Killed).Count } | Out-Null
-            Invoke-BuilderWorktreeGit -ProjectDir $projectDir -Arguments @('worktree', 'prune') | Out-Null
+            $postZombiePrune = Invoke-BuilderWorktreeGit -ProjectDir $projectDir -Arguments @('worktree', 'prune') -AllowFailure
+            if ($postZombiePrune.ExitCode -ne 0) {
+                $message = if ([string]::IsNullOrWhiteSpace($postZombiePrune.Output)) {
+                    'unknown git worktree prune error'
+                } else {
+                    $postZombiePrune.Output
+                }
+                Write-Warning "Preflight: git worktree prune after zombie cleanup skipped: $message"
+                Write-WinsmuxLog -Level WARN -Event 'preflight.git_worktree.prune_after_zombie_cleanup.failed' -Message 'Git worktree prune after zombie cleanup failed without aborting orchestra startup.' -Data ([ordered]@{
+                    killed_count = @($zombieCleanup.Killed).Count
+                    error        = $message
+                }) | Out-Null
+            }
         }
 
         $sessionServerCleanup = Remove-OrchestraSessionServerProcesses -SessionName $sessionName -WinsmuxBin $winsmuxBin -IncludeExpectedBinary


### PR DESCRIPTION
## Summary
- Adds bounded builder worktree lock diagnostics for Issue #1049.
- Keeps stale builder cleanup non-fatal when `git worktree prune` or `git worktree remove` encounters a lock.
- Distinguishes real worktree owner candidates from live desktop status pollers so operator recovery does not misclassify active app pollers as orphans.

## Why
During v0.36.23 dogfooding, orchestra recovery moved past the previous layout failure but then blocked on a locked `builder-1` worktree. The prior output only reported a generic file access failure, which made it easy to retry or kill the wrong process. This change preserves the normal startup path while making the first blocking owner visible.

## Verification
- `Invoke-Pester -Path tests\BuilderWorktree.Tests.ps1 -Output Minimal` — 7 passed.
- `Invoke-Pester -Path tests\winsmux-bridge.Tests.ps1 -FullName '*keeps stale builder cleanup non-fatal when a registered worktree is locked*' -Output Minimal` — 1 passed, 573 not run.
- PowerShell parser check passed for `winsmux-core/scripts/orchestra-start.ps1` and `winsmux-core/scripts/builder-worktree.ps1`.
- `git diff --check` passed.
- Push hook: git-guard, public-surface audit, and gitleaks passed.

Closes #1049.
