### PR TITLE
fix(desktop): guard public launch readiness

### DIFF
--- a/docs/TROUBLESHOOTING.ja.md
+++ b/docs/TROUBLESHOOTING.ja.md
@@ -8,6 +8,27 @@ winsmux のインストール、起動、ペイン、資格情報、リリース
 Windows Terminal ワークスペースを起動します。デスクトップアプリは開きません。
 画面上の管制面を確認する場合は、インストール済みのデスクトップアプリを直接開きます。
 
+### デスクトップアプリが localhost 接続エラー、空白画面、またはフリーズになる
+
+通常のグラフィカルな入口はデスクトップアプリです。対象の GitHub Release から
+`winsmux_<version>_x64-setup.exe` をインストールし、スタートメニューまたは
+デスクトップショートカットから `winsmux` アプリを開きます。`winsmux launch` は
+CLI の入口であり、デスクトップアプリは開きません。
+
+デスクトップアプリが localhost 接続エラー、空白画面、または応答なしになる場合:
+
+1. `winsmux` デスクトップウィンドウを閉じます。
+2. 古いデスクトッププロセスが残っていないか確認します。
+
+   ```powershell
+   Get-Process winsmux-app -ErrorAction SilentlyContinue |
+     Select-Object Id,ProcessName,Path,StartTime
+   ```
+
+3. 表示されたプロセスが、いま開いたインストール済みの winsmux デスクトップアプリであると確認できる場合だけ、Windows タスク マネージャーから終了して、もう一度 winsmux を開きます。
+4. デスクトップアプリと一緒に黒い PowerShell、Windows Terminal、または WebView2 のコンソールウィンドウが出る場合は、winsmux を閉じて Issue を作成してください。通常のデスクトップ起動で見えるウィンドウは winsmux 本体だけです。
+5. Windows 再起動後も再現する場合は、同じ GitHub Release の最新版デスクトップインストーラーを再インストールし、`.winsmux/startup-journal.log`、`.winsmux/manifest.yaml`、インストーラーのバージョン、スクリーンショットを添えて報告してください。
+
 ### `Orchestra already starting (lock exists)`
 
 原因: 前回の起動がロックファイルを消す前に終了しました。
@@ -15,10 +36,18 @@ Windows Terminal ワークスペースを起動します。デスクトップア
 対処:
 
 ```powershell
+winsmux list
+Get-Process winsmux-app -ErrorAction SilentlyContinue |
+  Select-Object Id,ProcessName,Path,StartTime
+```
+
+このプロジェクトの winsmux セッションが生きておらず、同じプロジェクトを使っているデスクトップアプリも起動していないと確認できた場合だけ、ロックを削除します。
+
+```powershell
 Remove-Item .winsmux/orchestra.lock -Force
 ```
 
-その後、再起動します。
+その後、CLI ワークスペースを再起動します。
 
 ```powershell
 winsmux launch
@@ -102,11 +131,11 @@ sandbox = "unelevated"
 漏れを調べる場合は、停止する前に winsmux が起動したプロセスだけを確認してください。
 
 ```powershell
-Get-Process node,cargo,winsmux-app -ErrorAction SilentlyContinue |
-  Where-Object { $_.Path -like "*winsmux*" -or $_.Path -like "*\\target\\*" }
+Get-Process winsmux-app -ErrorAction SilentlyContinue |
+  Select-Object Id,ProcessName,Path,StartTime
 ```
 
-現在の winsmux デスクトップセッションが起動したと判断できるプロセスだけを停止してください。他のプロジェクトの `node` や `cargo` は停止しないでください。
+現在の winsmux デスクトップセッションだと判断できるプロセスだけを停止してください。無関係なターミナル、パッケージマネージャー、他プロジェクトの開発ツールは停止しないでください。
 
 ## 資格情報の問題
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -9,6 +9,33 @@ They start the managed Windows Terminal workspace. They do not open the desktop
 app; use the installed desktop app directly when troubleshooting the graphical
 control surface.
 
+### Desktop app opens to a localhost connection error, blank page, or frozen window
+
+The desktop app is the recommended graphical entrypoint. Open the installed
+`winsmux` app from the Start menu or desktop shortcut after installing
+`winsmux_<version>_x64-setup.exe` from the matching GitHub Release.
+`winsmux launch` is a CLI entrypoint and does not open the desktop app.
+
+If the desktop app opens but shows a localhost connection error, a blank page, or
+stops responding:
+
+1. Close the `winsmux` desktop window.
+2. Check whether an old desktop process is still running:
+
+   ```powershell
+   Get-Process winsmux-app -ErrorAction SilentlyContinue |
+     Select-Object Id,ProcessName,Path,StartTime
+   ```
+
+3. If the listed process is the installed winsmux desktop app you just opened,
+   close it from Windows Task Manager and open winsmux again.
+4. If a black PowerShell, Windows Terminal, or WebView2 console window appears
+   with the desktop app, close winsmux and file an issue. A normal desktop
+   startup should show the winsmux window only.
+5. If the issue repeats after a reboot, reinstall the current desktop installer
+   from the same GitHub Release and attach `.winsmux/startup-journal.log`,
+   `.winsmux/manifest.yaml`, the installer version, and a screenshot.
+
 ### `Orchestra already starting (lock exists)`
 
 Cause: a previous startup ended before removing the lock file.
@@ -16,10 +43,19 @@ Cause: a previous startup ended before removing the lock file.
 Fix:
 
 ```powershell
+winsmux list
+Get-Process winsmux-app -ErrorAction SilentlyContinue |
+  Select-Object Id,ProcessName,Path,StartTime
+```
+
+Only remove the lock when there is no live winsmux session for this project and
+no running desktop app using it:
+
+```powershell
 Remove-Item .winsmux/orchestra.lock -Force
 ```
 
-Then run:
+Then run the CLI workspace startup again:
 
 ```powershell
 winsmux launch
@@ -109,11 +145,13 @@ When debugging a suspected leak, check for winsmux-owned processes before
 killing anything:
 
 ```powershell
-Get-Process node,cargo,winsmux-app -ErrorAction SilentlyContinue |
-  Where-Object { $_.Path -like "*winsmux*" -or $_.Path -like "*\\target\\*" }
+Get-Process winsmux-app -ErrorAction SilentlyContinue |
+  Select-Object Id,ProcessName,Path,StartTime
 ```
 
-Stop only the processes you can identify as started by the current winsmux desktop session. Do not stop unrelated `node` or `cargo` processes from other projects.
+Stop only the process you can identify as the current winsmux desktop session.
+Do not stop unrelated terminals, package manager processes, or other projects'
+development tools.
 
 ## Credential problems
 

--- a/docs/installation.ja.md
+++ b/docs/installation.ja.md
@@ -5,6 +5,14 @@
 - 推奨経路: GitHub Release から入手するデスクトップアプリのインストーラー
 - 別経路: CLI 中心の利用やスクリプト導入に使う Windows 向け npm パッケージ
 
+| 用途 | インストール経路 | 起動経路 |
+| --- | --- | --- |
+| 通常の画面操作でオペレーターとワーカーを使う | GitHub Release の `winsmux_<version>_x64-setup.exe` を実行 | インストール済みの `winsmux` デスクトップアプリを開き、プロジェクトフォルダーを選択 |
+| CLI 中心、ヘッドレス、スクリプト運用 | `npm install -g winsmux` の後に `winsmux install --profile full` | プロジェクトディレクトリで `winsmux init` と `winsmux launch` を実行 |
+| デスクトップオペレーターを外部自動化から使う | 先にデスクトップアプリをインストールして起動 | デスクトップオペレーターが表示された後、ローカル control pipe に接続 |
+
+`winsmux launch` は管理対象の Windows Terminal ワークスペースを起動します。デスクトップアプリは開きません。
+
 ## 動作要件
 
 - Windows 10 または Windows 11
@@ -78,7 +86,7 @@ npm install -g winsmux
 winsmux install --profile full
 ```
 
-npm コマンドは同梱されたインストーラーに処理を渡します。インストーラーは npm パッケージと同じ Git tag に固定されます。
+npm コマンドは同梱されたインストーラーに処理を渡します。インストーラーは npm パッケージと同じ Git tag に固定されます。リポジトリ内の `packages/winsmux` ディレクトリを直接 publish するのではなく、リリース時に `scripts/stage-npm-release.mjs` が npm 用 tarball を作成し、その段階で release tag に固定した `install.ps1` を追加します。
 
 インストール後は、作業対象のプロジェクトディレクトリへ移動して、管理対象
 ワークスペースを起動します。

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -7,6 +7,15 @@ CLI-first, scripted, or headless setups.
 - recommended: a desktop app installer from GitHub Releases
 - separate CLI path: a Windows-first npm package for CLI-first setups and scripted installs
 
+| Use case | Install path | Startup path |
+| --- | --- | --- |
+| Normal graphical operator/worker use | Download and run `winsmux_<version>_x64-setup.exe` from GitHub Releases | Open the installed `winsmux` desktop app and choose the project folder |
+| CLI-first or headless orchestration | `npm install -g winsmux`, then `winsmux install --profile full` | Run `winsmux init` and `winsmux launch` from the project directory |
+| External automation against the desktop operator | Install and open the desktop app first | Use the local control pipe after the desktop operator is visible |
+
+`winsmux launch` starts the managed Windows Terminal workspace. It does not open
+the desktop app.
+
 ## Requirements
 
 - Windows 10 or Windows 11
@@ -84,6 +93,9 @@ winsmux install --profile full
 ```
 
 The npm command delegates to the bundled installer and pins the installer to the same release tag as the npm package.
+The repository `packages/winsmux` directory is not published directly. Release
+automation stages the npm tarball with `scripts/stage-npm-release.mjs`, which
+adds the release-pinned `install.ps1` before publication.
 
 After the package install finishes, move to the project directory and launch the
 managed workspace:

--- a/docs/operator-model.md
+++ b/docs/operator-model.md
@@ -42,6 +42,21 @@ being appended to only some product names.
 
 The important abstraction is the **channel boundary**, not Telegram, Discord, or another single product.
 
+### Public entrypoints
+
+The operator model is shared by the desktop app, CLI workspace, and automation
+API, but their startup paths are separate:
+
+| Entry point | How users start it | What it opens | Primary validation |
+| --- | --- | --- | --- |
+| Desktop app | Install `winsmux_<version>_x64-setup.exe`, open the installed `winsmux` app, then choose a project folder | Graphical operator and worker pane surface | visible winsmux window, rendered operator UI, and reachable local operator control API |
+| npm/CLI workspace | `npm install -g winsmux`, `winsmux install --profile full`, `winsmux init`, then `winsmux launch` in a project directory | Managed Windows Terminal workspace | CLI doctor checks, project manifest, and pane session state |
+| External automation | Connect to the local control pipe after the desktop app starts | Programmatic operator snapshot/submit and desktop control methods | authenticated control pipe, `desktop.operator.snapshot`, and `desktop.operator.submit` |
+
+`winsmux launch` does not open the desktop app. A desktop smoke test is not
+complete until the installed or repo-built desktop app has a visible main
+window, no visible helper console window, and a reachable operator API.
+
 In the standard winsmux operating model, the operator is responsible for:
 
 - decomposition

--- a/packages/winsmux/README.md
+++ b/packages/winsmux/README.md
@@ -8,6 +8,11 @@ The npm package name is `winsmux`.
 Repository publishing is tag-driven and uses the staged package from
 `scripts/stage-npm-release.mjs`.
 
+The source directory is not the publish artifact. Do not publish
+`packages/winsmux` directly from a checkout. The published npm tarball is
+produced by `scripts/stage-npm-release.mjs`; `install.ps1` is added during
+staging and pinned to the same release tag as the npm package.
+
 Install it on Windows with:
 
 ```powershell
@@ -33,6 +38,8 @@ User-facing setup docs:
 - `winsmux version`
 - `winsmux help`
 - the npm package version will pin `install.ps1` to the same GitHub release tag
+- the package source directory is not the publish artifact; the staged package
+  contains the generated release-pinned `install.ps1`
 
 ## Installer profiles
 

--- a/scripts/start-cli-bakeoff-desktop.ps1
+++ b/scripts/start-cli-bakeoff-desktop.ps1
@@ -418,23 +418,34 @@ function Assert-ProductionDesktopPage {
     throw "Could not verify the production desktop operator UI on port $Port. Last error: $lastError"
 }
 
-function Get-WindowMetrics {
-    param([Parameter(Mandatory = $true)][int]$ProcessId)
-
+function Initialize-WinsmuxBenchmarkUser32 {
     Add-Type -AssemblyName System.Windows.Forms
     if (-not ('WinsmuxBenchmarkUser32' -as [type])) {
         Add-Type @"
 using System;
 using System.Runtime.InteropServices;
+using System.Text;
 public static class WinsmuxBenchmarkUser32 {
+  public delegate bool EnumWindowsProc(IntPtr hWnd, IntPtr lParam);
   [StructLayout(LayoutKind.Sequential)]
   public struct RECT { public int Left; public int Top; public int Right; public int Bottom; }
+  [DllImport("user32.dll")] public static extern bool EnumWindows(EnumWindowsProc enumProc, IntPtr lParam);
+  [DllImport("user32.dll")] public static extern bool IsWindowVisible(IntPtr hWnd);
+  [DllImport("user32.dll")] public static extern uint GetWindowThreadProcessId(IntPtr hWnd, out int processId);
+  [DllImport("user32.dll", CharSet = CharSet.Unicode)] public static extern int GetWindowText(IntPtr hWnd, StringBuilder text, int count);
+  [DllImport("user32.dll", CharSet = CharSet.Unicode)] public static extern int GetClassName(IntPtr hWnd, StringBuilder text, int count);
   [DllImport("user32.dll")] public static extern bool GetWindowRect(IntPtr hWnd, out RECT rect);
   [DllImport("user32.dll")] public static extern bool MoveWindow(IntPtr hWnd, int X, int Y, int nWidth, int nHeight, bool bRepaint);
   [DllImport("user32.dll")] public static extern bool ShowWindow(IntPtr hWnd, int nCmdShow);
 }
 "@
     }
+}
+
+function Get-WindowMetrics {
+    param([Parameter(Mandatory = $true)][int]$ProcessId)
+
+    Initialize-WinsmuxBenchmarkUser32
 
     $deadline = (Get-Date).AddSeconds(30)
     $handle = [IntPtr]::Zero
@@ -463,6 +474,155 @@ public static class WinsmuxBenchmarkUser32 {
         width = [int]($rect.Right - $rect.Left)
         height = [int]($rect.Bottom - $rect.Top)
     }
+}
+
+function Get-ProcessTreeIds {
+    param([Parameter(Mandatory = $true)][int]$RootProcessId)
+
+    $processes = @(Get-CimInstance Win32_Process)
+    $ids = [System.Collections.Generic.HashSet[int]]::new()
+    [void]$ids.Add($RootProcessId)
+
+    $changed = $true
+    while ($changed) {
+        $changed = $false
+        foreach ($process in $processes) {
+            if ($null -ne $process.ParentProcessId -and $ids.Contains([int]$process.ParentProcessId)) {
+                if ($ids.Add([int]$process.ProcessId)) {
+                    $changed = $true
+                }
+            }
+        }
+    }
+
+    return @($ids)
+}
+
+function Get-VisibleTopLevelWindowsForProcessTree {
+    param([Parameter(Mandatory = $true)][int[]]$ProcessIds)
+
+    Initialize-WinsmuxBenchmarkUser32
+
+    $processIdSet = [System.Collections.Generic.HashSet[int]]::new()
+    foreach ($processId in $ProcessIds) {
+        [void]$processIdSet.Add([int]$processId)
+    }
+
+    $processNames = @{}
+    foreach ($processId in $ProcessIds) {
+        $process = Get-Process -Id $processId -ErrorAction SilentlyContinue
+        if ($null -ne $process) {
+            $processNames[[int]$processId] = [string]$process.ProcessName
+        }
+    }
+
+    $windows = [System.Collections.Generic.List[object]]::new()
+    $callback = [WinsmuxBenchmarkUser32+EnumWindowsProc]{
+        param([IntPtr]$hWnd, [IntPtr]$lParam)
+
+        if (-not [WinsmuxBenchmarkUser32]::IsWindowVisible($hWnd)) {
+            return $true
+        }
+
+        $windowProcessId = 0
+        [void][WinsmuxBenchmarkUser32]::GetWindowThreadProcessId($hWnd, [ref]$windowProcessId)
+        if (-not $processIdSet.Contains([int]$windowProcessId)) {
+            return $true
+        }
+
+        $titleBuilder = [System.Text.StringBuilder]::new(512)
+        $classBuilder = [System.Text.StringBuilder]::new(256)
+        [void][WinsmuxBenchmarkUser32]::GetWindowText($hWnd, $titleBuilder, $titleBuilder.Capacity)
+        [void][WinsmuxBenchmarkUser32]::GetClassName($hWnd, $classBuilder, $classBuilder.Capacity)
+        $rect = New-Object WinsmuxBenchmarkUser32+RECT
+        [void][WinsmuxBenchmarkUser32]::GetWindowRect($hWnd, [ref]$rect)
+
+        $processName = ''
+        if ($processNames.ContainsKey([int]$windowProcessId)) {
+            $processName = $processNames[[int]$windowProcessId]
+        }
+
+        $windows.Add([pscustomobject]@{
+            processId = [int]$windowProcessId
+            processName = $processName
+            handle = $hWnd.ToInt64()
+            title = $titleBuilder.ToString()
+            className = $classBuilder.ToString()
+            x = [int]$rect.Left
+            y = [int]$rect.Top
+            width = [int]($rect.Right - $rect.Left)
+            height = [int]($rect.Bottom - $rect.Top)
+        }) | Out-Null
+
+        return $true
+    }
+
+    [void][WinsmuxBenchmarkUser32]::EnumWindows($callback, [IntPtr]::Zero)
+    return @($windows)
+}
+
+function Assert-NoVisibleDesktopHelperWindows {
+    param(
+        [Parameter(Mandatory = $true)][int]$RootProcessId,
+        [Parameter(Mandatory = $true)][int]$MainProcessId
+    )
+
+    $processIds = [System.Collections.Generic.HashSet[int]]::new()
+    foreach ($processId in @(Get-ProcessTreeIds -RootProcessId $RootProcessId)) {
+        [void]$processIds.Add([int]$processId)
+    }
+    [void]$processIds.Add($MainProcessId)
+
+    $visibleWindows = @(Get-VisibleTopLevelWindowsForProcessTree -ProcessIds @($processIds))
+    $unexpected = @(
+        $visibleWindows |
+            Where-Object {
+                [int]$_.processId -ne $MainProcessId -and (
+                    [string]$_.processName -match 'msedgewebview2|pwsh|powershell|windowsterminal|conhost|cmd' -or
+                    [string]$_.className -match 'ConsoleWindowClass|CASCADIA_HOSTING_WINDOW_CLASS'
+                )
+            }
+    )
+
+    if ($unexpected.Count -gt 0) {
+        $summary = ($unexpected | ForEach-Object { "pid=$($_.processId) process=$($_.processName) title=$($_.title) class=$($_.className)" }) -join '; '
+        throw "winsmux desktop opened visible helper windows during launch readiness: $summary"
+    }
+
+    return $visibleWindows
+}
+
+function Assert-WebViewArgumentsDoNotOpenConsole {
+    param([Parameter(Mandatory = $true)][string]$Arguments)
+
+    if ($Arguments -match '--enable-logging|--v=') {
+        throw "WebView2 launch arguments would open or amplify diagnostic console output: $Arguments"
+    }
+}
+
+function Assert-DesktopOperatorControlPipe {
+    param([int]$TimeoutSeconds = 30)
+
+    $coreScript = Join-Path $RepoRoot 'scripts\winsmux-core.ps1'
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    $lastOutput = ''
+
+    do {
+        $output = (& pwsh -NoProfile -ExecutionPolicy Bypass -File $coreScript operator-snapshot --lines 5 2>&1 | Out-String).Trim()
+        $exitCode = $LASTEXITCODE
+        if ($exitCode -eq 0 -and -not [string]::IsNullOrWhiteSpace($output)) {
+            $normalizedOutput = $output -replace '\s+', ' '
+            return [pscustomobject]@{
+                ok = $true
+                command = 'operator-snapshot --lines 5'
+                outputSnippet = $normalizedOutput.Substring(0, [Math]::Min(240, $normalizedOutput.Length))
+            }
+        }
+        $lastOutput = $output
+        Start-Sleep -Milliseconds 500
+    } while ((Get-Date) -lt $deadline)
+
+    throw "winsmux desktop operator API was not reachable through the control pipe. Last output: $lastOutput"
 }
 
 function Move-WindowToVisibleWorkspace {
@@ -605,7 +765,9 @@ $env:WINSMUX_BIN = $releaseCli
 $env:WINSMUX_ORCHESTRA_PROJECT_DIR = $resolvedProjectDir
 $env:WINSMUX_ORCHESTRA_ATTACH_MODE = 'desktop-app'
 $env:WINSMUX_ORCHESTRA_DISABLE_POWERSHELL_ATTACH = '1'
+$env:WINSMUX_CONTROL_PIPE_TOKEN = "winsmux-desktop-launch-$([guid]::NewGuid().ToString('N'))"
 $env:WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS = "--remote-debugging-port=$DebugPort --remote-allow-origins=*"
+Assert-WebViewArgumentsDoNotOpenConsole -Arguments $env:WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS
 $env:WEBVIEW2_USER_DATA_FOLDER = $webviewUserData
 $env:NO_COLOR = '1'
 
@@ -615,6 +777,7 @@ try {
     $launcherProcess = Start-Process -FilePath $releaseApp -ArgumentList @('--project-dir', $resolvedProjectDir) -WorkingDirectory $RepoRoot -PassThru
     $app = Wait-RepoWinsmuxDesktopApp -ExpectedProcessId ([int]$launcherProcess.Id)
     $page = Assert-ProductionDesktopPage -Port $DebugPort
+    $operatorControlPipe = Assert-DesktopOperatorControlPipe
     $metricsBeforeMove = Get-WindowMetrics -ProcessId ([int]$app.ProcessId)
     if (-not $NoMoveToExtendedDisplay) {
         $metricsAfterMove = Move-WindowToVisibleWorkspace -ProcessId ([int]$app.ProcessId) -Width $VisibleWidth -Height $VisibleHeight
@@ -625,6 +788,7 @@ try {
     if ([int]$metricsAfterMove.width -lt $VisibleWidth -or [int]$metricsAfterMove.height -lt $VisibleHeight) {
         throw "winsmux desktop window is smaller than required after launch: $($metricsAfterMove.width)x$($metricsAfterMove.height)"
     }
+    $visibleWindows = Assert-NoVisibleDesktopHelperWindows -RootProcessId ([int]$launcherProcess.Id) -MainProcessId ([int]$app.ProcessId)
 } catch {
     $reason = $_.Exception.Message
     Stop-RepoWinsmuxDesktopTree
@@ -643,8 +807,10 @@ $result = [pscustomobject]@{
     desktopFreshness = $desktopFreshness
     debugPort = $DebugPort
     page = $page
+    operatorControlPipe = $operatorControlPipe
     windowBeforeMove = $metricsBeforeMove
     windowAfterMove = $metricsAfterMove
+    visibleWindows = $visibleWindows
     attachMode = $env:WINSMUX_ORCHESTRA_ATTACH_MODE
     powershellAttach = 'disabled'
     preflight = $preflight

--- a/tests/CliBakeoff.Tests.ps1
+++ b/tests/CliBakeoff.Tests.ps1
@@ -83,6 +83,34 @@ Describe 'CLI bakeoff evidence harness' {
         $warningFunction | Should -Match 'usage\\s\+limit\\s\+resets'
     }
 
+    It 'keeps the operator runtime model and next startup setting distinct in the composer UI' {
+        $mainTs = Get-Content -LiteralPath (Join-Path $script:RepoRoot 'winsmux-app\src\main.ts') -Raw -Encoding UTF8
+        $detectIndex = $mainTs.IndexOf('function detectComposerModelFromOperatorText')
+        $observeIndex = $mainTs.IndexOf('function updateObservedOperatorRuntimeModelFromOutput')
+        $displayIndex = $mainTs.IndexOf('function getComposerModelControlDisplay')
+        $menuIndex = $mainTs.IndexOf('function createComposerModelMenu')
+        $persistIndex = $mainTs.IndexOf('function persistComposerSessionControls')
+        $startupModelOptionIndex = $mainTs.IndexOf('const modelOption = getComposerModelOption()')
+        $startupArgsIndex = $mainTs.IndexOf('args.push("--model", modelOption.cliModel)', $startupModelOptionIndex)
+
+        ($detectIndex -ge 0) | Should -BeTrue
+        ($observeIndex -gt $detectIndex) | Should -BeTrue
+        ($displayIndex -gt $observeIndex) | Should -BeTrue
+        ($menuIndex -gt $displayIndex) | Should -BeTrue
+        ($persistIndex -ge 0) | Should -BeTrue
+        ($startupModelOptionIndex -ge 0) | Should -BeTrue
+        ($startupArgsIndex -gt $startupModelOptionIndex) | Should -BeTrue
+        $mainTs | Should -Match 'observedOperatorRuntimeModel'
+        $mainTs | Should -Match 'Current operator runtime model'
+        $mainTs | Should -Match 'Next startup setting'
+        $mainTs | Should -Match 'The operator is currently running'
+        $mainTs | Should -Match 'Choices here change the next startup setting'
+        $mainTs | Should -Match 'activeComposerModel'
+        $mainTs | Should -Match 'activeComposerEffort'
+        $mainTs | Should -Match 'args\.push\("--model", modelOption\.cliModel\)'
+        $mainTs | Should -Match 'args\.push\("--effort", activeComposerEffort\)'
+    }
+
     It 'benchmark_readiness_gate_rejects_mismatched_candidate_identity' {
         $missingDesktopBinary = Join-Path $TestDrive 'missing-winsmux-app.exe'
         $missingCliBinary = Join-Path $TestDrive 'missing-winsmux.exe'
@@ -224,6 +252,71 @@ Describe 'CLI bakeoff evidence harness' {
         $scriptText | Should -Match 'ERR_CONNECTION_REFUSED'
         $scriptText | Should -Match 'browserError='
         $scriptText | Should -Match 'operatorSurface = \$operatorSurface'
+    }
+
+    It 'requires desktop operator API reachability before desktop launch readiness passes' {
+        $scriptText = Get-Content -LiteralPath $script:DesktopStartScript -Raw -Encoding UTF8
+        $launchIndex = $scriptText.IndexOf('$launcherProcess = Start-Process -FilePath $releaseApp')
+        $tokenEnvIndex = $scriptText.IndexOf('$env:WINSMUX_CONTROL_PIPE_TOKEN =')
+        $pageCheckIndex = $scriptText.IndexOf('$page = Assert-ProductionDesktopPage -Port $DebugPort', $launchIndex)
+        $controlFunctionIndex = $scriptText.IndexOf('function Assert-DesktopOperatorControlPipe')
+        $snapshotMethodIndex = $scriptText.IndexOf('operator-snapshot', $controlFunctionIndex)
+        $controlCheckIndex = $scriptText.IndexOf('$operatorControlPipe = Assert-DesktopOperatorControlPipe', $pageCheckIndex)
+        $windowMetricsIndex = $scriptText.IndexOf('$metricsBeforeMove = Get-WindowMetrics -ProcessId ([int]$app.ProcessId)', $controlCheckIndex)
+
+        ($launchIndex -ge 0) | Should -BeTrue
+        ($tokenEnvIndex -ge 0) | Should -BeTrue
+        ($launchIndex -gt $tokenEnvIndex) | Should -BeTrue
+        ($pageCheckIndex -gt $launchIndex) | Should -BeTrue
+        ($controlFunctionIndex -ge 0) | Should -BeTrue
+        ($snapshotMethodIndex -gt $controlFunctionIndex) | Should -BeTrue
+        ($controlCheckIndex -gt $pageCheckIndex) | Should -BeTrue
+        ($controlCheckIndex -lt $windowMetricsIndex) | Should -BeTrue
+        $scriptText | Should -Match 'desktop operator API was not reachable'
+        $scriptText | Should -Match 'operatorControlPipe = \$operatorControlPipe'
+    }
+
+    It 'rejects visible helper windows and WebView console logging before desktop readiness passes' {
+        $scriptText = Get-Content -LiteralPath $script:DesktopStartScript -Raw -Encoding UTF8
+        $windowEnumerationIndex = $scriptText.IndexOf('function Get-VisibleTopLevelWindowsForProcessTree')
+        $helperFunctionIndex = $scriptText.IndexOf('function Assert-NoVisibleDesktopHelperWindows')
+        $webviewArgsIndex = $scriptText.IndexOf('$env:WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS =')
+        $webviewArgGuardIndex = $scriptText.IndexOf('Assert-WebViewArgumentsDoNotOpenConsole', $webviewArgsIndex)
+        $moveIndex = $scriptText.IndexOf('$metricsAfterMove = Move-WindowToVisibleWorkspace')
+        $helperCheckIndex = $scriptText.IndexOf('$visibleWindows = Assert-NoVisibleDesktopHelperWindows', $moveIndex)
+        $resultIndex = $scriptText.IndexOf('$result = [pscustomobject]@{', $helperCheckIndex)
+
+        ($windowEnumerationIndex -ge 0) | Should -BeTrue
+        ($helperFunctionIndex -gt $windowEnumerationIndex) | Should -BeTrue
+        ($webviewArgsIndex -ge 0) | Should -BeTrue
+        ($webviewArgGuardIndex -gt $webviewArgsIndex) | Should -BeTrue
+        ($moveIndex -ge 0) | Should -BeTrue
+        ($helperCheckIndex -gt $moveIndex) | Should -BeTrue
+        ($helperCheckIndex -lt $resultIndex) | Should -BeTrue
+        $scriptText | Should -Match 'visible helper windows'
+        $scriptText | Should -Match 'msedgewebview2|pwsh|powershell|windowsterminal|conhost|cmd'
+        $scriptText | Should -Not -Match 'WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS\s*=\s*".*--enable-logging'
+        $scriptText | Should -Not -Match 'WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS\s*=\s*".*--v='
+        $scriptText | Should -Match 'visibleWindows = \$visibleWindows'
+    }
+
+    It 'documents public desktop startup troubleshooting without repo-build process assumptions' {
+        $troubleshooting = Get-Content -LiteralPath (Join-Path $script:RepoRoot 'docs\TROUBLESHOOTING.md') -Raw -Encoding UTF8
+        $troubleshootingJa = Get-Content -LiteralPath (Join-Path $script:RepoRoot 'docs\TROUBLESHOOTING.ja.md') -Raw -Encoding UTF8
+        $installation = Get-Content -LiteralPath (Join-Path $script:RepoRoot 'docs\installation.md') -Raw -Encoding UTF8
+
+        $troubleshooting | Should -Match 'Desktop app opens to a localhost connection error'
+        $troubleshooting | Should -Match 'winsmux_<version>_x64-setup\.exe'
+        $troubleshooting | Should -Match 'Get-Process winsmux-app'
+        $troubleshooting | Should -Match 'black PowerShell, Windows Terminal, or WebView2 console window'
+        $troubleshooting | Should -Not -Match 'Get-Process node,cargo,winsmux-app'
+        $troubleshooting | Should -Not -Match '\\target\\'
+        $troubleshootingJa | Should -Match 'デスクトップアプリが localhost 接続エラー'
+        $troubleshootingJa | Should -Match 'Get-Process winsmux-app'
+        $troubleshootingJa | Should -Not -Match 'Get-Process node,cargo,winsmux-app'
+        $troubleshootingJa | Should -Not -Match '\\target\\'
+        $installation | Should -Match 'External automation against the desktop operator'
+        $installation | Should -Match 'winsmux launch.*does not open\s+the desktop app'
     }
 
     It 'filters content-clean status noise before enforcing the candidate clean gate' {

--- a/tests/NpmReleasePackage.Tests.ps1
+++ b/tests/NpmReleasePackage.Tests.ps1
@@ -140,6 +140,9 @@ Describe 'winsmux npm release package contract' {
         $packageReadme | Should -Match 'winsmux version'
         $packageReadme | Should -Match 'winsmux help'
         $packageReadme | Should -Match 'same GitHub release tag'
+        $packageReadme | Should -Match 'source directory is not the publish artifact'
+        $packageReadme | Should -Match 'staged package'
+        $packageReadme | Should -Match 'added during\s+staging'
         $packageReadme | Should -Match '## Installer profiles'
         $packageReadme | Should -Match 'winsmux install --profile full'
         $packageReadme | Should -Match 'winsmux update --profile orchestra'
@@ -175,6 +178,17 @@ Describe 'winsmux npm release package contract' {
         $releaseWorkflow | Should -Match 'name:\s+Skip existing npm version'
         $releaseWorkflow | Should -Match 'if:\s+steps\.npm-version\.outputs\.exists != ''true'''
         $releaseWorkflow | Should -Match 'NODE_AUTH_TOKEN:\s+\$\{\{\s*secrets\.NPM_TOKEN\s*\}\}'
+    }
+
+    It 'keeps the package source and staged publish artifact separate' {
+        $packageReadme = Get-Content -LiteralPath $script:PackageReadmePath -Raw -Encoding UTF8
+        $stageScript = Get-Content -LiteralPath $script:StageScriptPath -Raw -Encoding UTF8
+
+        Test-Path -LiteralPath (Join-Path $script:PackageRoot 'install.ps1') | Should -BeFalse
+        $stageScript | Should -Match 'installScriptSource = path\.join\(repoRoot, "install\.ps1"\)'
+        $stageScript | Should -Match 'fs\.writeFileSync\(path\.join\(targetDir, "install\.ps1"\), versionPatched\)'
+        $packageReadme | Should -Match 'source directory is not the publish artifact'
+        $packageReadme | Should -Match 'published npm tarball is\s+produced by'
     }
 
     It 'skips staging only if the package source is explicitly gated' {
@@ -234,6 +248,8 @@ Describe 'winsmux npm release package contract' {
         $stagedReadme | Should -Match 'winsmux version'
         $stagedReadme | Should -Match 'winsmux help'
         $stagedReadme | Should -Match 'same GitHub release tag'
+        $stagedReadme | Should -Match 'source directory is not the publish artifact'
+        $stagedReadme | Should -Match 'added during\s+staging'
         $stagedReadme | Should -Match '## Installer profiles'
         $stagedReadme | Should -Match 'winsmux install --profile full'
         $stagedReadme | Should -Match 'winsmux update --profile orchestra'


### PR DESCRIPTION
## Summary
- Document the public desktop app path separately from the npm CLI launch path.
- Add desktop readiness guards for operator API reachability and visible helper/WebView console windows.
- Cover operator runtime model vs next-startup setting synchronization in the CLI bakeoff tests.
- Clarify that the staged npm package is the publish artifact, not packages/winsmux directly.

## Verification
- pwsh -NoProfile -Command "Invoke-Pester -Path tests\CliBakeoff.Tests.ps1,tests\NpmReleasePackage.Tests.ps1 -Output Minimal"
- git diff --cached --check
- PowerShell parser check for scripts/start-cli-bakeoff-desktop.ps1
- Claude Opus headless docs review: PASS, no P0/P1 findings
- Claude Opus headless product guard review: PASS, no P0/P1 findings

## Remaining risk
- Formal Harness Bench is still blocked by #1080: the production desktop launch can open a blank WebView instead of rendering the operator UI.
