### PR TITLE
fix(tooling): harden roadmap title data loading

### DIFF
--- a/tests/PublicSurfacePolicy.Tests.ps1
+++ b/tests/PublicSurfacePolicy.Tests.ps1
@@ -168,6 +168,12 @@ Describe 'Public surface policy' {
         $syncInternalDocs | Should -Match 'tasks/roadmap-title-ja\.example\.psd1'
     }
 
+    It 'loads roadmap title localization with skip-limit and fail-fast diagnostics' {
+        foreach ($syncScript in @($syncRoadmap, $syncInternalDocs)) {
+            $syncScript | Should -Match 'Import-PowerShellDataFile\s+-LiteralPath\s+\$Path\s+-SkipLimitCheck\s+-ErrorAction\s+Stop'
+        }
+    }
+
     It 'keeps the tracked roadmap title example scrubbed of live planning data' {
         $example = Get-Content (Join-Path $repoRoot 'tasks/roadmap-title-ja.example.psd1') -Raw
 

--- a/winsmux-core/scripts/sync-internal-docs.ps1
+++ b/winsmux-core/scripts/sync-internal-docs.ps1
@@ -242,7 +242,7 @@ function Get-RoadmapLocalizationMap {
         return @{ VersionTitles = @{}; TaskTitles = @{} }
     }
 
-    $data = Import-PowerShellDataFile -LiteralPath $Path
+    $data = Import-PowerShellDataFile -LiteralPath $Path -SkipLimitCheck -ErrorAction Stop
     return @{
         VersionTitles = if ($null -ne $data.VersionTitles) { $data.VersionTitles } else { @{} }
         TaskTitles = if ($null -ne $data.TaskTitles) { $data.TaskTitles } else { @{} }

--- a/winsmux-core/scripts/sync-roadmap.ps1
+++ b/winsmux-core/scripts/sync-roadmap.ps1
@@ -190,7 +190,7 @@ function Get-RoadmapLocalizationMap {
         }
     }
 
-    $data = Import-PowerShellDataFile -LiteralPath $Path
+    $data = Import-PowerShellDataFile -LiteralPath $Path -SkipLimitCheck -ErrorAction Stop
     return @{
         VersionTitles = if ($null -ne $data.VersionTitles) { $data.VersionTitles } else { @{} }
         TaskTitles    = if ($null -ne $data.TaskTitles) { $data.TaskTitles } else { @{} }


### PR DESCRIPTION
## Summary
- Load roadmap title localization files with `-SkipLimitCheck` and `-ErrorAction Stop`.
- Apply the same behavior to `sync-roadmap.ps1` and `sync-internal-docs.ps1`.
- Add a public-surface guard so the two sync paths stay aligned.

## Verification
- `Invoke-Pester -Path tests\PublicSurfacePolicy.Tests.ps1 -PassThru -Output None` => 27 passed, 0 failed
- `git diff --check -- winsmux-core/scripts/sync-roadmap.ps1 winsmux-core/scripts/sync-internal-docs.ps1 tests/PublicSurfacePolicy.Tests.ps1`

Closes #1084
