### PR TITLE
test(release): gate signed desktop updater artifacts

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -39,16 +39,66 @@ jobs:
         working-directory: winsmux-app
         run: npm run tauri -- build
 
+      - name: Require desktop updater signing secrets
+        if: github.event_name == 'push' || inputs.release_tag != ''
+        shell: pwsh
+        env:
+          WINDOWS_SIGNING_CERTIFICATE_BASE64: ${{ secrets.WINDOWS_SIGNING_CERTIFICATE_BASE64 }}
+          WINDOWS_SIGNING_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_SIGNING_CERTIFICATE_PASSWORD }}
+          TAURI_UPDATER_PRIVATE_KEY: ${{ secrets.TAURI_UPDATER_PRIVATE_KEY }}
+          TAURI_UPDATER_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_UPDATER_PRIVATE_KEY_PASSWORD }}
+        run: |
+          $requiredSecrets = @(
+            'WINDOWS_SIGNING_CERTIFICATE_BASE64',
+            'WINDOWS_SIGNING_CERTIFICATE_PASSWORD',
+            'TAURI_UPDATER_PRIVATE_KEY',
+            'TAURI_UPDATER_PRIVATE_KEY_PASSWORD'
+          )
+          foreach ($name in $requiredSecrets) {
+            if ([string]::IsNullOrWhiteSpace([Environment]::GetEnvironmentVariable($name))) {
+              throw "Missing required desktop updater signing secret: $name"
+            }
+          }
+
+      - name: Sign desktop installer assets
+        if: github.event_name == 'push' || inputs.release_tag != ''
+        shell: pwsh
+        env:
+          WINDOWS_SIGNING_CERTIFICATE_BASE64: ${{ secrets.WINDOWS_SIGNING_CERTIFICATE_BASE64 }}
+          WINDOWS_SIGNING_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_SIGNING_CERTIFICATE_PASSWORD }}
+        run: |
+          $certPath = Join-Path $env:RUNNER_TEMP "winsmux-signing.pfx"
+          [IO.File]::WriteAllBytes($certPath, [Convert]::FromBase64String($env:WINDOWS_SIGNING_CERTIFICATE_BASE64))
+          $signtool = Get-ChildItem -Path "${env:ProgramFiles(x86)}\Windows Kits\10\bin" -Recurse -Filter signtool.exe |
+            Where-Object { $_.FullName -match '\\x64\\signtool\.exe$' } |
+            Select-Object -First 1 -ExpandProperty FullName
+          if ([string]::IsNullOrWhiteSpace($signtool)) {
+            throw "signtool.exe was not found on the GitHub Actions runner"
+          }
+          $assets = @(
+            Get-ChildItem -LiteralPath target/release/bundle/nsis -Filter *.exe -File
+            Get-ChildItem -LiteralPath target/release/bundle/msi -Filter *.msi -File
+          )
+          foreach ($asset in $assets) {
+            & $signtool sign /fd SHA256 /td SHA256 /tr http://timestamp.digicert.com /f $certPath /p $env:WINDOWS_SIGNING_CERTIFICATE_PASSWORD $asset.FullName
+            if ($LASTEXITCODE -ne 0) {
+              throw "signtool failed for $($asset.Name)"
+            }
+          }
+
       - name: Collect desktop release assets
         shell: pwsh
         run: |
           New-Item -ItemType Directory -Force -Path output/desktop-release | Out-Null
           Copy-Item target/release/bundle/msi/*.msi output/desktop-release/
           Copy-Item target/release/bundle/nsis/*.exe output/desktop-release/
+          Copy-Item target/release/bundle/nsis/*.sig output/desktop-release/ -ErrorAction SilentlyContinue
+          Copy-Item target/release/bundle/latest.json output/desktop-release/ -ErrorAction SilentlyContinue
           $version = (Get-Content -LiteralPath VERSION -Raw).Trim()
           $requiredAssets = @(
             "winsmux_${version}_x64-setup.exe",
-            "winsmux_${version}_x64_en-US.msi"
+            "winsmux_${version}_x64_en-US.msi",
+            "latest.json"
           )
           foreach ($assetName in $requiredAssets) {
             $assetPath = Join-Path "output/desktop-release" $assetName
@@ -56,6 +106,10 @@ jobs:
               $actualAssets = @(Get-ChildItem -LiteralPath output/desktop-release -File | Select-Object -ExpandProperty Name)
               throw "Required desktop release asset '$assetName' was not collected. Actual assets: $($actualAssets -join ', ')"
             }
+          }
+          $signatureAssets = @(Get-ChildItem -LiteralPath output/desktop-release -Filter *.sig -File)
+          if ($signatureAssets.Count -eq 0) {
+            throw "Required signed updater metadata was not collected. Expected at least one .sig file next to the desktop release assets."
           }
           Push-Location output/desktop-release
           Get-ChildItem -File |
@@ -65,6 +119,19 @@ jobs:
               "$hash  $($_.Name)"
             } | Set-Content -Encoding ascii SHA256SUMS-desktop
           Pop-Location
+
+      - name: Verify desktop installer signatures
+        if: github.event_name == 'push' || inputs.release_tag != ''
+        shell: pwsh
+        run: |
+          $assets = Get-ChildItem -LiteralPath output/desktop-release -File |
+            Where-Object { $_.Extension -in @('.exe', '.msi') }
+          foreach ($asset in $assets) {
+            $signature = Get-AuthenticodeSignature -LiteralPath $asset.FullName
+            if ($signature.Status -ne 'Valid') {
+              throw "Desktop release asset '$($asset.Name)' is not Authenticode signed with a valid signature. Status: $($signature.Status)"
+            }
+          }
 
       - name: Upload desktop artifact
         uses: actions/upload-artifact@v7

--- a/docs/project/v1-release-gate.md
+++ b/docs/project/v1-release-gate.md
@@ -12,6 +12,8 @@ Required public artifacts:
 - `winsmux_<version>_x64-setup.exe` as the normal installer
 - `winsmux_<version>_x64_en-US.msi` for MSI deployment tooling
 - `SHA256SUMS-desktop` for checksum verification
+- signed updater metadata, including `latest.json` and at least one `.sig`
+  file next to the desktop release assets
 - npm package and CLI installer path for CLI-first users
 - release notes that state the signing posture and update path
 - English and Japanese installer UI for the setup executable, with the language
@@ -23,9 +25,18 @@ binary or the npm package.
 
 ## Signing and update posture
 
-Until a stable code-signing certificate is available, every release note must
-state the signing posture. Users should verify installer downloads against
-`SHA256SUMS-desktop` when Windows shows publisher or SmartScreen warnings.
+`TASK-720` is the signed desktop updater release assets gate. Starting with
+`v0.36.23`, the release workflow must require signing secrets
+`WINDOWS_SIGNING_CERTIFICATE_BASE64`, `WINDOWS_SIGNING_CERTIFICATE_PASSWORD`,
+`TAURI_UPDATER_PRIVATE_KEY`, and `TAURI_UPDATER_PRIVATE_KEY_PASSWORD` before it
+uploads desktop bundles to a GitHub Release. The normal setup executable and MSI
+must be Authenticode signed, and the updater metadata must include `latest.json`
+plus `.sig` files. An unsigned installer or missing signed updater metadata must
+not be published as a release artifact.
+
+Each release note must still state the signing posture. Users should verify
+installer downloads against `SHA256SUMS-desktop` when Windows shows publisher or
+SmartScreen warnings.
 
 The desktop update path is installing the newer desktop release over the
 existing installation. This keeps project repositories, agent CLI

--- a/tests/CliBakeoff.Tests.ps1
+++ b/tests/CliBakeoff.Tests.ps1
@@ -527,6 +527,33 @@ Describe 'CLI bakeoff evidence harness' {
         $styles | Should -Not -Match '--ws-panel-bg'
     }
 
+    It 'gates desktop releases on signed updater artifacts' {
+        $workflow = Get-Content -LiteralPath (Join-Path $script:RepoRoot '.github\workflows\release-desktop.yml') -Raw -Encoding UTF8
+        $releaseGate = Get-Content -LiteralPath (Join-Path $script:RepoRoot 'docs\project\v1-release-gate.md') -Raw -Encoding UTF8
+
+        $workflow | Should -Match 'Require desktop updater signing secrets'
+        $workflow | Should -Match 'WINDOWS_SIGNING_CERTIFICATE_BASE64'
+        $workflow | Should -Match 'WINDOWS_SIGNING_CERTIFICATE_PASSWORD'
+        $workflow | Should -Match 'TAURI_UPDATER_PRIVATE_KEY'
+        $workflow | Should -Match 'TAURI_UPDATER_PRIVATE_KEY_PASSWORD'
+        $workflow | Should -Match 'Sign desktop installer assets'
+        $workflow | Should -Match 'signtool\.exe'
+        $workflow | Should -Match 'Get-AuthenticodeSignature'
+        $workflow | Should -Match 'latest\.json'
+        $workflow | Should -Match '\.sig'
+        $workflow | Should -Match 'Required signed updater metadata'
+        $workflow | Should -Match 'not Authenticode signed with a valid signature'
+
+        $releaseGate | Should -Match 'TASK-720'
+        $releaseGate | Should -Match 'signed desktop updater release assets'
+        $releaseGate | Should -Match 'latest\.json'
+        $releaseGate | Should -Match '\.sig'
+        $releaseGate | Should -Match 'WINDOWS_SIGNING_CERTIFICATE_BASE64'
+        $releaseGate | Should -Match 'TAURI_UPDATER_PRIVATE_KEY'
+        $releaseGate | Should -Match 'unsigned installer'
+        $releaseGate | Should -Match 'must\s+not\s+be\s+published'
+    }
+
     It 'filters content-clean status noise before enforcing the candidate clean gate' {
         $scriptText = Get-Content -LiteralPath $script:PreflightScript -Raw -Encoding UTF8
         $scriptText | Should -Match 'function Get-GitContentDirtyStatus'


### PR DESCRIPTION
## Summary
- Add a release workflow gate that requires Windows signing and Tauri updater signing secrets before desktop release upload.
- Sign the setup executable and MSI with signtool, then verify Authenticode signatures before publishing release assets.
- Require updater metadata (`latest.json` and `.sig`) and document the TASK-720 release gate.

## Why
This closes the remaining v0.36.23 release gap tracked by #1089: desktop update UX must not be published without signed installer assets and signed updater metadata.

## Verification
- `Invoke-Pester -Path tests\CliBakeoff.Tests.ps1 -FullName '*signed updater*' -Output Detailed`
- `Invoke-Pester -Path tests\CliBakeoff.Tests.ps1 -Output Minimal`
- `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File scripts\test-v03619-repo-audit.ps1`
- `git diff --check`

Fixes #1089
TASK-720
