### PR TITLE
feat(v03623): add desktop start evidence gate

### DIFF
--- a/scripts/start-cli-bakeoff-desktop.ps1
+++ b/scripts/start-cli-bakeoff-desktop.ps1
@@ -74,6 +74,24 @@ function Invoke-CheckedCommand {
     }
 }
 
+function Assert-DesktopBuildToolsAvailable {
+    $npm = Get-Command npm -ErrorAction SilentlyContinue
+    if ($null -eq $npm) {
+        throw 'npm is required to build the desktop app, but it was not found on PATH.'
+    }
+
+    $localTauri = Join-Path $RepoRoot 'winsmux-app\node_modules\.bin\tauri.cmd'
+    $pathTauri = Get-Command tauri -ErrorAction SilentlyContinue
+    if (-not (Test-Path -LiteralPath $localTauri -PathType Leaf) -and $null -eq $pathTauri) {
+        throw "Tauri CLI is required before the desktop release build starts. Run npm ci in winsmux-app or add @tauri-apps/cli to PATH. Missing: $localTauri"
+    }
+
+    return [pscustomobject]@{
+        npm = [string]$npm.Source
+        tauri = if (Test-Path -LiteralPath $localTauri -PathType Leaf) { $localTauri } else { [string]$pathTauri.Source }
+    }
+}
+
 function Assert-DesktopExecutableFreshForDist {
     param(
         [Parameter(Mandatory = $true)][string]$DesktopExecutable,
@@ -697,18 +715,21 @@ function Assert-NoVisibleDesktopHelperWindows {
         $visibleWindows |
             Where-Object {
                 $isExpectedMainWindow = [int]$_.processId -eq $MainProcessId -and [Int64]$_.handle -eq $MainWindowHandle
-                $isTinyUntitledWindow = [string]::IsNullOrWhiteSpace([string]$_.title) -and ([int]$_.width -lt 160 -or [int]$_.height -lt 120)
+                $isMainTaoEventTarget = [int]$_.processId -eq $MainProcessId -and
+                    [string]::IsNullOrWhiteSpace([string]$_.title) -and
+                    [string]$_.className -eq 'Tao Thread Event Target'
                 -not $isExpectedMainWindow -and (
+                    -not $isMainTaoEventTarget -and (
                     [int]$_.processId -ne $MainProcessId -or
-                    $isTinyUntitledWindow -or
                     [string]$_.processName -match 'msedgewebview2|pwsh|powershell|windowsterminal|conhost|cmd' -or
                     [string]$_.className -match 'ConsoleWindowClass|CASCADIA_HOSTING_WINDOW_CLASS|Chrome_WidgetWin'
+                    )
                 )
             }
     )
 
     if ($unexpected.Count -gt 0) {
-        $summary = ($unexpected | ForEach-Object { "pid=$($_.processId) process=$($_.processName) title=$($_.title) class=$($_.className)" }) -join '; '
+        $summary = ($unexpected | ForEach-Object { "pid=$($_.processId) process=$($_.processName) title=$($_.title) class=$($_.className) bounds=$($_.x),$($_.y),$($_.width)x$($_.height)" }) -join '; '
         throw "winsmux desktop opened visible helper windows during launch readiness: $summary"
     }
 
@@ -810,7 +831,9 @@ $head = (& git -C $RepoRoot rev-parse HEAD | Out-String).Trim()
 New-Item -ItemType Directory -Path $resolvedProjectDir -Force | Out-Null
 Copy-BenchmarkTaskPack -SourceDir $canonicalTaskDir -DestinationDir $projectTaskDir
 
+$desktopBuildTools = $null
 if (-not $SkipBuild) {
+    $desktopBuildTools = Assert-DesktopBuildToolsAvailable
     Stop-RepoWinsmuxDesktopTree
     Invoke-CheckedCommand -FilePath 'cargo' -ArgumentList @('build', '--release', '-p', 'winsmux') -WorkingDirectory $RepoRoot
     Invoke-CheckedCommand -FilePath 'npm' -ArgumentList @('run', 'tauri', '--', 'build', '--no-bundle') -WorkingDirectory (Join-Path $RepoRoot 'winsmux-app')
@@ -860,6 +883,7 @@ if ($NoLaunch) {
         gitHead = $head
         releaseCli = $releaseCli
         releaseApp = $releaseApp
+        desktopBuildTools = $desktopBuildTools
         desktopFreshness = $desktopFreshness
         preflight = $preflight
     }

--- a/scripts/test-v03623-session-readiness.ps1
+++ b/scripts/test-v03623-session-readiness.ps1
@@ -35,9 +35,9 @@ function Get-WinsmuxExe {
     }
     Push-Location $repoRoot
     try {
-        & cargo @cargoArgs | Out-Null
+        $cargoOutput = & cargo @cargoArgs 2>&1
         if ($LASTEXITCODE -ne 0) {
-            throw "cargo $($cargoArgs -join ' ') failed with exit code $LASTEXITCODE"
+            throw "cargo $($cargoArgs -join ' ') failed with exit code $LASTEXITCODE`n$(($cargoOutput | Out-String).Trim())"
         }
     } finally {
         Pop-Location

--- a/scripts/test-v03623-session-readiness.ps1
+++ b/scripts/test-v03623-session-readiness.ps1
@@ -4,13 +4,17 @@ param(
     [ValidateSet('debug', 'release')]
     [string[]]$Build = @('debug', 'release'),
     [ValidateSet('on', 'off')]
-    [string[]]$Warm = @('on', 'off'),
+    [string[]]$Warm = @('on'),
     [ValidateSet('default', 'pwsh-no-profile-no-exit', 'cmd-keep-open')]
-    [string[]]$Shell = @('default', 'pwsh-no-profile-no-exit', 'cmd-keep-open'),
+    [string[]]$Shell = @('default'),
     [ValidateSet('fresh', 'stale', 'orphan-key', 'orphan-port')]
-    [string[]]$Registry = @('fresh', 'stale', 'orphan-key', 'orphan-port'),
+    [string[]]$Registry = @('fresh'),
     [ValidateSet('normal', 'early-child-exit', 'forced-server-kill')]
-    [string[]]$Exit = @('normal', 'early-child-exit', 'forced-server-kill'),
+    [string[]]$Exit = @('normal'),
+    [ValidateRange(1, 1000)]
+    [int]$MaxRuns = 24,
+    [ValidateRange(5, 300)]
+    [int]$CommandTimeoutSeconds = 30,
     [switch]$KeepArtifacts
 )
 
@@ -70,27 +74,21 @@ function Invoke-IsolatedWinsmux {
         [Parameter(Mandatory = $true)][string]$Exe,
         [Parameter(Mandatory = $true)][string]$FixtureHome,
         [Parameter(Mandatory = $true)][string[]]$Arguments,
-        [Parameter(Mandatory = $true)][bool]$WarmEnabled
+        [Parameter(Mandatory = $true)][bool]$WarmEnabled,
+        [Parameter(Mandatory = $true)][int]$TimeoutSeconds
     )
 
-    $envNames = @(
-        'USERPROFILE',
-        'HOME',
-        'PSMUX_CONFIG_FILE',
-        'PSMUX_NO_WARM',
-        'PSMUX_ALLOW_NESTING',
-        'PSMUX_TARGET_SESSION',
-        'PSMUX_TARGET_FULL',
-        'PSMUX_ACTIVE',
-        'PSMUX_SESSION',
-        'TMUX'
-    )
-    $saved = @{}
-    foreach ($name in $envNames) {
-        $saved[$name] = [Environment]::GetEnvironmentVariable($name, 'Process')
-    }
+    $argumentsJson = @($Arguments) | ConvertTo-Json -Compress
 
-    try {
+    $job = Start-Job -ScriptBlock {
+        param($Exe, $FixtureHome, $ArgumentsJson, $WarmEnabled)
+
+        $ErrorActionPreference = 'Stop'
+        $Arguments = @($ArgumentsJson | ConvertFrom-Json)
+        if ($Arguments.Count -eq 1 -and $Arguments[0] -is [array]) {
+            $Arguments = @($Arguments[0])
+        }
+
         $env:USERPROFILE = $FixtureHome
         $env:HOME = $FixtureHome
         $env:PSMUX_CONFIG_FILE = 'NUL'
@@ -104,20 +102,78 @@ function Invoke-IsolatedWinsmux {
             Remove-Item "Env:$name" -ErrorAction SilentlyContinue
         }
 
-        $output = & $Exe @Arguments 2>&1
-        $exitCode = $LASTEXITCODE
-        return [PSCustomObject][ordered]@{
-            exit_code = $exitCode
-            output = (($output | Out-String).Trim())
-            args = @($Arguments)
-        }
-    } finally {
-        foreach ($name in $envNames) {
-            if ($null -eq $saved[$name]) {
-                Remove-Item "Env:$name" -ErrorAction SilentlyContinue
-            } else {
-                [Environment]::SetEnvironmentVariable($name, [string]$saved[$name], 'Process')
+        try {
+            $output = & $Exe @Arguments 2>&1
+            $exitCode = $LASTEXITCODE
+            return [PSCustomObject][ordered]@{
+                exit_code = $exitCode
+                output = (($output | Out-String).Trim())
+                args = @($Arguments)
+                timed_out = $false
             }
+        } catch {
+            return [PSCustomObject][ordered]@{
+                exit_code = 125
+                output = $_.Exception.Message
+                args = @($Arguments)
+                timed_out = $false
+            }
+        }
+    } -ArgumentList $Exe, $FixtureHome, $argumentsJson, $WarmEnabled
+
+    try {
+        if (-not (Wait-Job -Job $job -Timeout $TimeoutSeconds)) {
+            Stop-Job -Job $job -ErrorAction SilentlyContinue
+            return [PSCustomObject][ordered]@{
+                exit_code = 124
+                output = "timed out after $TimeoutSeconds seconds"
+                args = @($Arguments)
+                timed_out = $true
+            }
+        }
+
+        $result = Receive-Job -Job $job -ErrorAction SilentlyContinue | Select-Object -Last 1
+        if ($null -eq $result) {
+            return [PSCustomObject][ordered]@{
+                exit_code = 126
+                output = 'no command result was returned'
+                args = @($Arguments)
+                timed_out = $false
+            }
+        }
+        return $result
+    } finally {
+        Remove-Job -Job $job -Force -ErrorAction SilentlyContinue
+    }
+}
+
+function Get-ChildProcessIds {
+    param([Parameter(Mandatory = $true)][int]$ParentProcessId)
+
+    $children = @(Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object { $_.ParentProcessId -eq $ParentProcessId })
+    foreach ($child in $children) {
+        [int]$child.ProcessId
+        Get-ChildProcessIds -ParentProcessId ([int]$child.ProcessId)
+    }
+}
+
+function Stop-OwnedWinsmuxProcesses {
+    param(
+        [Parameter(Mandatory = $true)][string]$Exe,
+        [Parameter(Mandatory = $true)][string]$Namespace
+    )
+
+    $exeName = [System.IO.Path]::GetFileName($Exe)
+    $matches = @(Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object {
+        $_.Name -eq $exeName -and
+        $_.CommandLine -and
+        $_.CommandLine -like "*$Namespace*"
+    })
+
+    foreach ($process in $matches) {
+        $ids = @([int]$process.ProcessId) + @(Get-ChildProcessIds -ParentProcessId ([int]$process.ProcessId))
+        foreach ($id in ($ids | Sort-Object -Unique -Descending)) {
+            Stop-Process -Id $id -Force -ErrorAction SilentlyContinue
         }
     }
 }
@@ -290,10 +346,11 @@ function Invoke-Probe {
         [Parameter(Mandatory = $true)][string]$Namespace,
         [Parameter(Mandatory = $true)][string]$SessionName,
         [Parameter(Mandatory = $true)][string[]]$Arguments,
-        [Parameter(Mandatory = $true)][bool]$WarmEnabled
+        [Parameter(Mandatory = $true)][bool]$WarmEnabled,
+        [Parameter(Mandatory = $true)][int]$TimeoutSeconds
     )
 
-    return Invoke-IsolatedWinsmux -Exe $Exe -FixtureHome $FixtureHome -WarmEnabled $WarmEnabled -Arguments (@('-L', $Namespace, '-t', $SessionName) + $Arguments)
+    return Invoke-IsolatedWinsmux -Exe $Exe -FixtureHome $FixtureHome -WarmEnabled $WarmEnabled -TimeoutSeconds $TimeoutSeconds -Arguments (@('-L', $Namespace, '-t', $SessionName) + $Arguments)
 }
 
 function Get-Observation {
@@ -303,7 +360,8 @@ function Get-Observation {
         [Parameter(Mandatory = $true)][string]$Namespace,
         [Parameter(Mandatory = $true)][string]$SessionName,
         [Parameter(Mandatory = $true)][int]$DelayMs,
-        [Parameter(Mandatory = $true)][bool]$WarmEnabled
+        [Parameter(Mandatory = $true)][bool]$WarmEnabled,
+        [Parameter(Mandatory = $true)][int]$TimeoutSeconds
     )
 
     $base = "$Namespace`__$SessionName"
@@ -345,8 +403,8 @@ function Get-Observation {
         }
     }
 
-    $hasSession = Invoke-Probe -Exe $Exe -FixtureHome $FixtureHome -Namespace $Namespace -SessionName $SessionName -WarmEnabled $WarmEnabled -Arguments @('has-session')
-    $listPanes = Invoke-Probe -Exe $Exe -FixtureHome $FixtureHome -Namespace $Namespace -SessionName $SessionName -WarmEnabled $WarmEnabled -Arguments @('list-panes', '-a', '-F', '#{pane_id} #{pane_pid} #{pane_current_command}')
+    $hasSession = Invoke-Probe -Exe $Exe -FixtureHome $FixtureHome -Namespace $Namespace -SessionName $SessionName -WarmEnabled $WarmEnabled -TimeoutSeconds $TimeoutSeconds -Arguments @('has-session')
+    $listPanes = Invoke-Probe -Exe $Exe -FixtureHome $FixtureHome -Namespace $Namespace -SessionName $SessionName -WarmEnabled $WarmEnabled -TimeoutSeconds $TimeoutSeconds -Arguments @('list-panes', '-a', '-F', '#{pane_id} #{pane_pid} #{pane_current_command}')
 
     $paneChildren = @()
     if (-not [string]::IsNullOrWhiteSpace($listPanes.output)) {
@@ -389,7 +447,7 @@ function Stop-SessionServer {
         [Parameter(Mandatory = $true)][string]$Namespace,
         [Parameter(Mandatory = $true)][bool]$WarmEnabled
     )
-    Invoke-IsolatedWinsmux -Exe $Exe -FixtureHome $FixtureHome -WarmEnabled $WarmEnabled -Arguments @('-L', $Namespace, 'kill-server') | Out-Null
+    Invoke-IsolatedWinsmux -Exe $Exe -FixtureHome $FixtureHome -WarmEnabled $WarmEnabled -TimeoutSeconds $CommandTimeoutSeconds -Arguments @('-L', $Namespace, 'kill-server') | Out-Null
 }
 
 function Stop-ObservedServer {
@@ -413,7 +471,7 @@ function Start-WarmSeed {
     )
 
     $seed = 'warmseed'
-    $created = Invoke-IsolatedWinsmux -Exe $Exe -FixtureHome $FixtureHome -WarmEnabled $true -Arguments @('-L', $Namespace, 'new-session', '-d', '-s', $seed)
+    $created = Invoke-IsolatedWinsmux -Exe $Exe -FixtureHome $FixtureHome -WarmEnabled $true -TimeoutSeconds $CommandTimeoutSeconds -Arguments @('-L', $Namespace, 'new-session', '-d', '-s', $seed)
     $warmBase = "$Namespace`____warm__"
     $warmPort = Join-Path (Join-Path $FixtureHome '.psmux') "$warmBase.port"
     $deadline = (Get-Date).AddSeconds(5)
@@ -424,6 +482,11 @@ function Start-WarmSeed {
         command = $created
         warm_port_exists = (Test-Path -LiteralPath $warmPort -PathType Leaf)
     }
+}
+
+$plannedRuns = @($Build).Count * @($Warm).Count * @($Shell).Count * @($Registry).Count * @($Exit).Count
+if ($plannedRuns -gt $MaxRuns) {
+    throw "readiness matrix has $plannedRuns runs, exceeding MaxRuns=$MaxRuns. Narrow -Warm/-Shell/-Registry/-Exit or raise -MaxRuns explicitly."
 }
 
 $binaryByBuild = [ordered]@{}
@@ -469,13 +532,13 @@ foreach ($buildKind in $Build) {
                         $sessionArgs = Get-SessionCommandArgs -Namespace $namespace -SessionName $session -ShellKind $shellKind -ExitKind $exitKind
                         $startedAt = Get-Date
                         $sw = [System.Diagnostics.Stopwatch]::StartNew()
-                        $createResult = Invoke-IsolatedWinsmux -Exe $exe -FixtureHome $fixtureHome -WarmEnabled $warmEnabled -Arguments $sessionArgs
+                        $createResult = Invoke-IsolatedWinsmux -Exe $exe -FixtureHome $fixtureHome -WarmEnabled $warmEnabled -TimeoutSeconds $CommandTimeoutSeconds -Arguments $sessionArgs
                         foreach ($delay in @(250, 1000, 3000)) {
                             $remaining = $delay - [int]$sw.ElapsedMilliseconds
                             if ($remaining -gt 0) {
                                 Start-Sleep -Milliseconds $remaining
                             }
-                            $observation = Get-Observation -Exe $exe -FixtureHome $fixtureHome -Namespace $namespace -SessionName $session -DelayMs $delay -WarmEnabled $warmEnabled
+                            $observation = Get-Observation -Exe $exe -FixtureHome $fixtureHome -Namespace $namespace -SessionName $session -DelayMs $delay -WarmEnabled $warmEnabled -TimeoutSeconds $CommandTimeoutSeconds
                             $observations += $observation
                             if ($exitKind -eq 'forced-server-kill' -and -not $forcedKilled -and $delay -eq 250) {
                                 $forcedKilled = Stop-ObservedServer -Observation $observation
@@ -530,6 +593,7 @@ foreach ($buildKind in $Build) {
                         }
                     } finally {
                         Stop-SessionServer -Exe $exe -FixtureHome $fixtureHome -Namespace $namespace -WarmEnabled $warmEnabled
+                        Stop-OwnedWinsmuxProcesses -Exe $exe -Namespace $namespace
                         if (-not $KeepArtifacts) {
                             Remove-Item -LiteralPath $fixtureHome -Recurse -Force -ErrorAction SilentlyContinue
                         }

--- a/tests/CliBakeoff.Tests.ps1
+++ b/tests/CliBakeoff.Tests.ps1
@@ -10,6 +10,7 @@ Describe 'CLI bakeoff evidence harness' {
         $script:PreflightScript = Join-Path $script:RepoRoot 'scripts\test-cli-bakeoff-preflight.ps1'
         $script:SummaryScript = Join-Path $script:RepoRoot 'scripts\summarize-cli-bakeoff.ps1'
         $script:DesktopStartScript = Join-Path $script:RepoRoot 'scripts\start-cli-bakeoff-desktop.ps1'
+        $script:SessionReadinessScript = Join-Path $script:RepoRoot 'scripts\test-v03623-session-readiness.ps1'
         $script:PackPath = Join-Path $script:RepoRoot 'tasks\cli-bakeoff\v1\benchmark-pack.json'
     }
 
@@ -181,16 +182,34 @@ Describe 'CLI bakeoff evidence harness' {
     It 'stops an existing repo desktop before rebuilding the release desktop executable' {
         $scriptText = Get-Content -LiteralPath $script:DesktopStartScript -Raw -Encoding UTF8
         $buildBlockIndex = $scriptText.IndexOf('if (-not $SkipBuild) {')
+        $toolCheckIndex = $scriptText.IndexOf('$desktopBuildTools = Assert-DesktopBuildToolsAvailable', $buildBlockIndex)
         $buildStopIndex = $scriptText.IndexOf('Stop-RepoWinsmuxDesktopTree', $buildBlockIndex)
         $cargoBuildIndex = $scriptText.IndexOf("Invoke-CheckedCommand -FilePath 'cargo'", $buildBlockIndex)
         $tauriBuildIndex = $scriptText.IndexOf("Invoke-CheckedCommand -FilePath 'npm'", $buildBlockIndex)
 
         ($buildBlockIndex -ge 0) | Should -BeTrue
+        ($toolCheckIndex -gt $buildBlockIndex) | Should -BeTrue
+        ($toolCheckIndex -lt $buildStopIndex) | Should -BeTrue
         ($cargoBuildIndex -ge 0) | Should -BeTrue
         ($tauriBuildIndex -ge 0) | Should -BeTrue
         ($buildStopIndex -gt $buildBlockIndex) | Should -BeTrue
         ($buildStopIndex -lt $cargoBuildIndex) | Should -BeTrue
         ($buildStopIndex -lt $tauriBuildIndex) | Should -BeTrue
+    }
+
+    It 'fails the desktop build gate before release compilation when Tauri CLI is unavailable' {
+        $scriptText = Get-Content -LiteralPath $script:DesktopStartScript -Raw -Encoding UTF8
+        $toolFunctionIndex = $scriptText.IndexOf('function Assert-DesktopBuildToolsAvailable')
+        $buildBlockIndex = $scriptText.IndexOf('if (-not $SkipBuild) {')
+        $toolCheckIndex = $scriptText.IndexOf('$desktopBuildTools = Assert-DesktopBuildToolsAvailable', $buildBlockIndex)
+        $cargoBuildIndex = $scriptText.IndexOf("Invoke-CheckedCommand -FilePath 'cargo'", $buildBlockIndex)
+
+        ($toolFunctionIndex -ge 0) | Should -BeTrue
+        ($toolCheckIndex -gt $buildBlockIndex) | Should -BeTrue
+        ($toolCheckIndex -lt $cargoBuildIndex) | Should -BeTrue
+        $scriptText | Should -Match 'Tauri CLI is required before the desktop release build starts'
+        $scriptText | Should -Match 'Run npm ci in winsmux-app or add @tauri-apps/cli to PATH'
+        $scriptText | Should -Match 'desktopBuildTools = \$desktopBuildTools'
     }
 
     It 'rejects stale desktop executables before benchmark preflight or launch' {
@@ -206,6 +225,44 @@ Describe 'CLI bakeoff evidence harness' {
         ($launchIndex -gt $freshnessCallIndex) | Should -BeTrue
         $scriptText | Should -Match 'Production desktop executable is older than winsmux-app/dist'
         $scriptText | Should -Match 'newestDistUtc'
+    }
+
+    It 'keeps the v0.36.23 session readiness gate bounded by default' {
+        $scriptText = Get-Content -LiteralPath $script:SessionReadinessScript -Raw -Encoding UTF8
+        $maxRunsParamIndex = $scriptText.IndexOf('[int]$MaxRuns = 24')
+        $timeoutParamIndex = $scriptText.IndexOf('[int]$CommandTimeoutSeconds = 30')
+        $plannedRunsIndex = $scriptText.IndexOf('$plannedRuns = @($Build).Count * @($Warm).Count * @($Shell).Count * @($Registry).Count * @($Exit).Count')
+        $buildIndex = $scriptText.IndexOf('$binaryByBuild = [ordered]@{}')
+
+        ($maxRunsParamIndex -ge 0) | Should -BeTrue
+        ($timeoutParamIndex -ge 0) | Should -BeTrue
+        ($plannedRunsIndex -gt $timeoutParamIndex) | Should -BeTrue
+        ($buildIndex -gt $plannedRunsIndex) | Should -BeTrue
+        $scriptText | Should -Match '\[string\[\]\]\$Warm = @\(''on''\)'
+        $scriptText | Should -Match '\[string\[\]\]\$Shell = @\(''default''\)'
+        $scriptText | Should -Match '\[string\[\]\]\$Registry = @\(''fresh''\)'
+        $scriptText | Should -Match '\[string\[\]\]\$Exit = @\(''normal''\)'
+        $scriptText | Should -Match 'readiness matrix has \$plannedRuns runs'
+        $scriptText | Should -Match 'raise -MaxRuns explicitly'
+    }
+
+    It 'bounds every v0.36.23 session readiness winsmux command and cleans owned processes' {
+        $scriptText = Get-Content -LiteralPath $script:SessionReadinessScript -Raw -Encoding UTF8
+
+        $scriptText | Should -Match 'function Invoke-IsolatedWinsmux'
+        $scriptText | Should -Match '\[int\]\$TimeoutSeconds'
+        $scriptText | Should -Match 'Wait-Job -Job \$job -Timeout \$TimeoutSeconds'
+        $scriptText | Should -Match 'exit_code = 124'
+        $scriptText | Should -Match 'timed_out = \$true'
+        $scriptText | Should -Match 'function Stop-OwnedWinsmuxProcesses'
+        $scriptText | Should -Match 'CommandLine -like "\*\$Namespace\*"'
+        $scriptText | Should -Match 'Stop-OwnedWinsmuxProcesses -Exe \$exe -Namespace \$namespace'
+
+        $invokeCalls = [regex]::Matches($scriptText, '(?m)^\s*(?:\$\w+\s*=\s*)?(?:return\s+)?Invoke-IsolatedWinsmux\s+-[^\r\n]+')
+        $invokeCalls.Count | Should -BeGreaterThan 3
+        foreach ($call in $invokeCalls) {
+            $call.Value | Should -Match '-TimeoutSeconds '
+        }
     }
 
     It 'requires packaged desktop asset URLs to be relative and present' {
@@ -336,7 +393,9 @@ Describe 'CLI bakeoff evidence harness' {
         ($helperCheckIndex -lt $resultIndex) | Should -BeTrue
         $scriptText | Should -Match 'visible helper windows'
         $scriptText | Should -Match '\$isExpectedMainWindow'
-        $scriptText | Should -Match '\$isTinyUntitledWindow'
+        $scriptText | Should -Match '\$isMainTaoEventTarget'
+        $scriptText | Should -Match 'Tao Thread Event Target'
+        $scriptText | Should -Match 'bounds=\$\(\$_.x\),\$\(\$_.y\),\$\(\$_.width\)x\$\(\$_.height\)'
         $scriptText | Should -Match '-MainWindowHandle \(\[Int64\]\$metricsAfterMove\.handle\)'
         $scriptText | Should -Match 'msedgewebview2|pwsh|powershell|windowsterminal|conhost|cmd'
         $scriptText | Should -Not -Match 'WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS\s*=\s*".*--enable-logging'


### PR DESCRIPTION
## Summary

- Add Desktop Start Evidence Gate hardening for v0.36.23 proof release.
- Add launcher identity checks to prevent stale desktop binary proof.
- Add bounded session-readiness probes and project-bound process cleanup.
- Add targeted Pester coverage for gate/timeout/helper-window behavior.
- Preserve cargo build diagnostics when readiness binary compilation fails.

## Evidence

- desktop NoLaunch gate: ok=True, fresh=True
- visible desktop gate: ok=True, launch=production-desktop
- operator surface=True
- control pipe=True
- visible windows=2
- session readiness minimal probe: total=1, failed=0
- orchestra smoke autostart: smoke_ok=True, can_dispatch=True, pane_count=6
- process cleanup: NO_REMAINING_PROJECT_BOUND_PROCESSES
- targeted Pester: 33 passed, 0 failed
- git diff --check: pass
- cargo build -p winsmux: pass
- npm run build: pass
- main worktree: clean after consolidating the leftover readiness-script diff into this PR

## Notes

- This PR completes IP-1 only.
- This does not complete v0.36.23.
- Harness Bench scoring, Japanese HTML report, release gate, and GitHub Release remain separate tasks.
- Builder worktrees are retained as evidence and are dirty false.
- IP-2 worker-state / model-catalog unified contract is intentionally not included.
