### PR TITLE
fix(orchestra): detect openai-compatible pane readiness

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -161,7 +161,7 @@ jobs:
           - name: shell-support
             result: shell-support
             timeout_minutes: 15
-            paths: tests/BuilderWorktree.Tests.ps1;tests/codex-subagent-worktree-guard.Tests.ps1;tests/OrchestraPreflight.Tests.ps1;tests/PaneBorder.Tests.ps1;tests/V03618ReleaseHardening.Tests.ps1
+            paths: tests/BuilderWorktree.Tests.ps1;tests/codex-subagent-worktree-guard.Tests.ps1;tests/OrchestraPreflight.Tests.ps1;tests/PaneBorder.Tests.ps1;tests/V03618ReleaseHardening.Tests.ps1;tests/AgentReadiness.Tests.ps1
             full_name: ""
           - name: repo-audit-v03619
             result: repo-audit-v03619

--- a/.gitignore
+++ b/.gitignore
@@ -104,6 +104,7 @@ tests/*
 !tests/V03618ReleaseHardening.Tests.ps1
 !tests/CliBakeoff.Tests.ps1
 !tests/ThreatModelContract.Tests.ps1
+!tests/AgentReadiness.Tests.ps1
 !tests/README.md
 !tests/fixtures/
 tests/fixtures/*

--- a/tests/AgentReadiness.Tests.ps1
+++ b/tests/AgentReadiness.Tests.ps1
@@ -80,6 +80,27 @@ Describe 'agent readiness prompt detection' {
 
             Test-AgentPromptText -Text $text -Agent 'openai-compatible' | Should -BeFalse
         }
+
+        It 'rejects a busy pane where the prompt is followed by an executing command' {
+            # Codex review P1 on PR #1106: while a command runs, the pane
+            # still contains the submitted `api_llm[worker-1]> exec ...` line
+            # because api-llm-pane-worker.ps1 reads input after printing the
+            # prompt and runs the command synchronously. A prompt that is not
+            # at the end of the capture must not count as ready. Task output
+            # has scrolled the startup banner out of the recent-line window.
+            $text = @(
+                'commands: exec <task-packet-path> [task-id] [run-id], status, help, quit'
+                'api_llm[worker-1]> exec C:\packets\task-001.json'
+                '[worker-1] loading packet task-001'
+                '[worker-1] contacting provider openrouter'
+                '[worker-1] streaming response tokens'
+                '[worker-1] writing structured result'
+                '[worker-1] run 1 of 1 in progress'
+                '[worker-1] elapsed 00:12'
+            ) -join "`n"
+
+            Test-AgentPromptText -Text $text -Agent 'openai-compatible' | Should -BeFalse
+        }
     }
 
     Context 'existing agent detection is unaffected (no cross-agent regression)' {

--- a/tests/AgentReadiness.Tests.ps1
+++ b/tests/AgentReadiness.Tests.ps1
@@ -101,6 +101,23 @@ Describe 'agent readiness prompt detection' {
 
             Test-AgentPromptText -Text $text -Agent 'openai-compatible' | Should -BeFalse
         }
+
+        It 'rejects a just-dispatched pane while the startup banner is still visible' {
+            # Codex review P1 (second pass) on PR #1106: immediately after a
+            # dispatch, the banner's 'status: ready' line can still sit inside
+            # the recent-line window while the worker runs its first command.
+            # The fallback must not mark such a pane idle.
+            $text = @(
+                'provider: openrouter'
+                'model: z-ai/glm-5.2'
+                'project: C:\repo'
+                'status: ready'
+                'commands: exec <task-packet-path> [task-id] [run-id], status, help, quit'
+                'api_llm[worker-1]> exec C:\packets\task-001.json'
+            ) -join "`n"
+
+            Test-AgentPromptText -Text $text -Agent 'openai-compatible' | Should -BeFalse
+        }
     }
 
     Context 'existing agent detection is unaffected (no cross-agent regression)' {

--- a/tests/AgentReadiness.Tests.ps1
+++ b/tests/AgentReadiness.Tests.ps1
@@ -5,6 +5,24 @@ Describe 'agent readiness prompt detection' {
         . (Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\agent-readiness.ps1')
     }
 
+    Context 'readiness agent name normalization' {
+        It 'round-trips the openai-compatible adapter through ConvertTo-ReadinessAgentName' {
+            # Codex review P2 (third pass) on PR #1106: the manifest-driven
+            # CLI paths (wait-ready, health-check, status) normalize the
+            # adapter before the prompt check; openai-compatible must survive
+            # that normalization or the api_llm switch case never fires there.
+            ConvertTo-ReadinessAgentName -Value 'openai-compatible' | Should -Be 'openai-compatible'
+        }
+
+        It 'normalizes case and surrounding whitespace for openai-compatible' {
+            ConvertTo-ReadinessAgentName -Value '  OpenAI-Compatible  ' | Should -Be 'openai-compatible'
+        }
+
+        It 'still returns codex for codex-prefixed values' {
+            ConvertTo-ReadinessAgentName -Value 'codex-gpt-5.5' | Should -Be 'codex'
+        }
+    }
+
     Context 'openai-compatible (api_llm) banner' {
         It 'accepts an unwrapped api_llm ready banner' {
             $text = @(

--- a/tests/AgentReadiness.Tests.ps1
+++ b/tests/AgentReadiness.Tests.ps1
@@ -1,0 +1,106 @@
+$ErrorActionPreference = 'Stop'
+
+Describe 'agent readiness prompt detection' {
+    BeforeAll {
+        . (Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\agent-readiness.ps1')
+    }
+
+    Context 'openai-compatible (api_llm) banner' {
+        It 'accepts an unwrapped api_llm ready banner' {
+            $text = @(
+                'winsmux api_llm pane worker'
+                'slot: worker-1'
+                'provider: openrouter'
+                'model: z-ai/glm-5.2'
+                'project: C:\repo'
+                'status: ready'
+                'commands: exec <task-packet-path> [task-id] [run-id], status, help, quit'
+                'api_llm[worker-1]> '
+            ) -join "`n"
+
+            Test-AgentPromptText -Text $text -Agent 'openai-compatible' | Should -BeTrue
+        }
+
+        It 'accepts a banner whose prompt line is wrapped mid-token by a narrow pane' {
+            # Reproduces the issue #1103 capture: `capture-pane -S -80` wraps the
+            # prompt line so 'api_llm[worker-1]> ' is split across two physical
+            # lines inside the pane id brackets.
+            $text = @(
+                'winsmux api_llm pane worker'
+                'slot: worker-1'
+                'provider: openrouter'
+                'model: z-ai/glm-5.2'
+                'project: C:\repo'
+                'status: ready'
+                'commands: exec <task-packet-path> [task-id] [run-id], status, hel'
+                'p, quit'
+                'api_llm[work'
+                'er-1]> '
+            ) -join "`n"
+
+            Test-AgentPromptText -Text $text -Agent 'openai-compatible' | Should -BeTrue
+        }
+
+        It 'accepts the banner via the status: ready anchor even if the prompt line is dropped entirely' {
+            # Defense in depth: if pane capture truncates the trailing
+            # no-newline prompt line, the fixed 'status: ready' line (emitted
+            # with a real newline by api-llm-pane-worker.ps1) must still be
+            # enough to flip readiness.
+            $text = @(
+                'winsmux api_llm pane worker'
+                'slot: worker-1'
+                'provider: openrouter'
+                'model: z-ai/glm-5.2'
+                'project: C:\repo'
+                'status: ready'
+                'commands: exec <task-packet-path> [task-id] [run-id], status, help, quit'
+            ) -join "`n"
+
+            Test-AgentPromptText -Text $text -Agent 'openai-compatible' | Should -BeTrue
+        }
+
+        It 'still rejects a pane that is not ready yet (regression guard against false positives)' {
+            $text = @(
+                'winsmux api_llm pane worker'
+                'slot: worker-1'
+                'provider: openrouter'
+                'model: z-ai/glm-5.2'
+                'project: C:\repo'
+                'status: starting'
+            ) -join "`n"
+
+            Test-AgentPromptText -Text $text -Agent 'openai-compatible' | Should -BeFalse
+        }
+
+        It 'rejects blocked-pattern text even when status: ready appears earlier in scrollback' {
+            $text = @(
+                'status: ready'
+                'unable to connect to openrouter'
+            ) -join "`n"
+
+            Test-AgentPromptText -Text $text -Agent 'openai-compatible' | Should -BeFalse
+        }
+    }
+
+    Context 'existing agent detection is unaffected (no cross-agent regression)' {
+        It 'still detects a codex-ready banner' {
+            $text = 'gpt-5.4-codex  73% context left'
+            Test-AgentPromptText -Text $text -Agent 'codex' | Should -BeTrue
+        }
+
+        It 'still detects a claude-ready banner' {
+            $text = 'Welcome to Claude Code!'
+            Test-AgentPromptText -Text $text -Agent 'claude' | Should -BeTrue
+        }
+
+        It 'still detects a gemini-ready banner' {
+            $text = 'Type your message or @path/to/file'
+            Test-AgentPromptText -Text $text -Agent 'gemini' | Should -BeTrue
+        }
+
+        It 'does not let openai-compatible pattern leak into an unrelated agent name' {
+            $text = 'api_llm[worker-1]> '
+            Test-AgentPromptText -Text $text -Agent 'codex' | Should -BeFalse
+        }
+    }
+}

--- a/winsmux-core/scripts/agent-readiness.ps1
+++ b/winsmux-core/scripts/agent-readiness.ps1
@@ -80,6 +80,7 @@ function Test-AgentPromptText {
     }
 
     $tailText = $recentLines -join [Environment]::NewLine
+    $normalizedTailText = ($tailText -replace '\s+', '')
     $blockedPatterns = @(
         '(?im)\bmissing api key\b',
         '(?im)\brun /login\b',
@@ -135,6 +136,15 @@ function Test-AgentPromptText {
             }
 
             if ($tailText -match '(?im)\bgemini-[A-Za-z0-9._-]+\b.*\b\d+%\s+context\s+left\b') {
+                return $true
+            }
+        }
+        'openai-compatible' {
+            if ($normalizedTailText -match '(?im)api_llm\[[^\]]+\]>') {
+                return $true
+            }
+
+            if ($tailText -match '(?im)^\s*status:\s*ready\s*$') {
                 return $true
             }
         }

--- a/winsmux-core/scripts/agent-readiness.ps1
+++ b/winsmux-core/scripts/agent-readiness.ps1
@@ -147,7 +147,12 @@ function Test-AgentPromptText {
                 return $true
             }
 
-            if ($tailText -match '(?im)^\s*status:\s*ready\s*$') {
+            # The status: ready line is only trustworthy while no command has
+            # been submitted after a prompt in the same capture window; right
+            # after a dispatch the startup banner can still be visible while
+            # the worker is busy.
+            $promptFollowedByInput = $normalizedTailText -match '(?i)api_llm\[[^\]]+\]>.'
+            if (-not $promptFollowedByInput -and $tailText -match '(?im)^\s*status:\s*ready\s*$') {
                 return $true
             }
         }

--- a/winsmux-core/scripts/agent-readiness.ps1
+++ b/winsmux-core/scripts/agent-readiness.ps1
@@ -50,7 +50,7 @@ function ConvertTo-ReadinessAgentName {
     param([AllowNull()][string]$Value)
 
     $lowered = if ($null -eq $Value) { '' } else { $Value.Trim().ToLowerInvariant() }
-    foreach ($name in @('codex', 'claude', 'gemini')) {
+    foreach ($name in @('codex', 'claude', 'gemini', 'openai-compatible')) {
         if ($lowered -eq $name `
             -or $lowered.StartsWith("${name}:") `
             -or $lowered.StartsWith("${name}-") `

--- a/winsmux-core/scripts/agent-readiness.ps1
+++ b/winsmux-core/scripts/agent-readiness.ps1
@@ -140,7 +140,10 @@ function Test-AgentPromptText {
             }
         }
         'openai-compatible' {
-            if ($normalizedTailText -match '(?im)api_llm\[[^\]]+\]>') {
+            # Anchored to the end of the whitespace-normalized capture so a
+            # busy pane (`api_llm[worker-1]> exec ...`) is not treated as an
+            # idle prompt waiting for input.
+            if ($normalizedTailText -match '(?i)api_llm\[[^\]]+\]>$') {
                 return $true
             }
 


### PR DESCRIPTION
Fixes #1103.

## Root cause

`Test-AgentPromptText` (winsmux-core/scripts/agent-readiness.ps1) only had switch cases for codex/claude/gemini. The api_llm backend's CapabilityAdapter value `openai-compatible` had no case, and the generic line-start `>` marker never matches the trailing-prompt format `api_llm[worker-1]> `. Narrow-pane line wrapping was a compounding factor, not the root cause. (The `[%2]` token in the timeout message is a legitimate tmux-style pane id, not an unsubstituted placeholder — the original hypothesis in #1103 was corrected in the issue thread.)

## Fix

Add an `openai-compatible` case: a whitespace-normalized match for the bracket prompt (wrap-tolerant), plus a line-anchored `status: ready` fallback. `blockedPatterns` are still evaluated first; existing codex/claude/gemini/default branches are untouched.

## Evidence

- GPT-5.5 read-only review: PASS (root cause verified against sources; wrap-tolerant; low false-ready risk; no cross-backend impact)
- End-to-end: with this fix applied, `orchestra-start.ps1` completes and `orchestra-smoke` reports `session_ready=true` with `can_dispatch=true` (previously failed 2/2 with worker-1 readiness timeout)
- Regression tests (`tests/AgentReadiness.Tests.ps1`, added to the .gitignore allowlist): 9/9 pass on the fixed code; run against a pre-fix snapshot, exactly the 3 fix-specific fixtures fail and the 6 guard/cross-agent fixtures pass, proving the suite actually pins the fix

Refs #1104 (review-flow defect found in the same session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)