### PR TITLE
fix(desktop): recognize codex idle banner in worker readiness gate

### DIFF
--- a/winsmux-app/package.json
+++ b/winsmux-app/package.json
@@ -17,6 +17,7 @@
     "test:desktop-status-e2e": "node ./scripts/desktop-pane-e2e.mjs --stop-after-worker-status",
     "test:editor-targets": "node ./scripts/editor-targets-check.mjs",
     "test:worker-pane-routing": "node ./scripts/worker-pane-routing-check.mjs",
+    "test:worker-readiness-prompt": "node ./scripts/worker-readiness-prompt-check.mjs",
     "test:worker-start-planning": "node ./scripts/worker-start-planning-check.mjs",
     "test:source-graph": "node ./scripts/source-graph-check.mjs",
     "test:windows-context-menu": "pwsh -NoProfile -ExecutionPolicy Bypass -File ./scripts/windows-context-menu-e2e.ps1",

--- a/winsmux-app/scripts/worker-readiness-prompt-check.mjs
+++ b/winsmux-app/scripts/worker-readiness-prompt-check.mjs
@@ -74,4 +74,21 @@ const midLaunchBanner = [
 ].join("\n");
 assert.equal(hasWorkerReadyPrompt(midLaunchBanner), false, "mid-launch banner must not classify as ready");
 
+// #1115 (P2 follow-up): the launch command echo and the "Starting Codex..."
+// marker can still be present in the recent-lines window *alongside* an
+// eventual idle-shaped footer line (e.g. capture happened to land right as
+// the footer first rendered, before the echo/marker scrolled out of the
+// tail window). The footer text alone must not be trusted while a
+// pending-launch marker is still visible -- this must remain not-ready.
+const midLaunchBannerWithTrailingIdleFooter = [
+  "> codex --model gpt-5.5 --dangerously-bypass-approvals-and-sandbox",
+  "Starting Codex...",
+  "gpt-5.5 xhigh fast",
+].join("\n");
+assert.equal(
+  hasWorkerReadyPrompt(midLaunchBannerWithTrailingIdleFooter),
+  false,
+  "mid-launch banner with a trailing idle-shaped footer line must not classify as ready",
+);
+
 console.log("worker-readiness-prompt-check: ok");

--- a/winsmux-app/scripts/worker-readiness-prompt-check.mjs
+++ b/winsmux-app/scripts/worker-readiness-prompt-check.mjs
@@ -91,4 +91,31 @@ assert.equal(
   "mid-launch banner with a trailing idle-shaped footer line must not classify as ready",
 );
 
+// #1115 (P3 follow-up): once enough ordinary lines have scrolled between a
+// stale launch echo/"Starting Codex..." marker and the current footer, the
+// pane must resolve to ready again. hasPendingWorkerLaunchMarker must only
+// suppress readiness for a marker near the footer (a genuine fresh launch),
+// not for a marker still technically present somewhere in the buffered
+// scrollback history that inspectWorkerPaneReadiness feeds in ahead of the
+// live capture (see entry.outputBuffer in main.ts). Simulate 7 ordinary
+// dialogue lines (a normal assistant response) scrolling past between the
+// stale echo/marker and the eventual idle footer.
+const staleLaunchMarkerWithIdleFooterAfterScrollback = [
+  "> codex --model gpt-5.5 --dangerously-bypass-approvals-and-sandbox",
+  "Starting Codex...",
+  "I looked at the repository structure and found the entry point.",
+  "The main module wires up the CLI argument parser first.",
+  "Then it loads the configuration file from the working directory.",
+  "After that it initializes the worker pool for parallel tasks.",
+  "Finally it prints a short summary of what changed.",
+  "Let me know if you would like me to explain any part in more detail.",
+  "Is there anything else you would like me to look into?",
+  "gpt-5.5 xhigh fast",
+].join("\n");
+assert.equal(
+  hasWorkerReadyPrompt(staleLaunchMarkerWithIdleFooterAfterScrollback),
+  true,
+  "idle footer must classify as ready once a stale launch marker has scrolled out of the near-footer window",
+);
+
 console.log("worker-readiness-prompt-check: ok");

--- a/winsmux-app/scripts/worker-readiness-prompt-check.mjs
+++ b/winsmux-app/scripts/worker-readiness-prompt-check.mjs
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import ts from "typescript";
+
+async function loadWorkerReadinessPromptModule() {
+  const sourcePath = path.resolve("src/workerReadinessPrompt.ts");
+  const source = await readFile(sourcePath, "utf8");
+  const transpiled = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.ESNext,
+      target: ts.ScriptTarget.ES2020,
+    },
+    fileName: sourcePath,
+  });
+
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "winsmux-worker-readiness-prompt-"));
+  const modulePath = path.join(tempDir, "workerReadinessPrompt.mjs");
+  await writeFile(modulePath, transpiled.outputText, "utf8");
+
+  try {
+    return await import(pathToFileURL(modulePath).href);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+const { hasWorkerReadyPrompt } = await loadWorkerReadinessPromptModule();
+
+// #1115: the exact idle banner captured from a real six-pane Harness Bench
+// attempt where worker-2 (Codex/gpt-5.5) was stuck "checking readiness"
+// forever. The pane is genuinely idle at its ghost-text prompt with no
+// percent-context readout and no enter-send glyph -- only the ghost marker
+// line and a footer status line ("gpt-5.5 xhigh fast"). This must resolve
+// to ready.
+const codexGpt55IdleBanner = [
+  "Tip: Try the Codex App. Run codex app or visit https://chatgpt.com/codex?app-landing-page=true",
+  "- You have 3 usage limit resets available. Run /usage to use one.",
+  "› Explain this codebase",
+  "gpt-5.5 xhigh fast",
+].join("\n");
+assert.equal(hasWorkerReadyPrompt(codexGpt55IdleBanner), true, "codex gpt-5.5 idle banner must classify as ready");
+
+// The same footer status line must still be recognized as ready even when
+// the ghost-prompt marker line above it did not survive intact (covers a
+// buffer/DOM-normalization edge case, not just the marker-line path).
+const codexGpt55IdleBannerWithoutGhostMarker = [
+  "Tip: Try the Codex App. Run codex app or visit https://chatgpt.com/codex?app-landing-page=true",
+  "- You have 3 usage limit resets available. Run /usage to use one.",
+  "Explain this codebase",
+  "gpt-5.5 xhigh fast",
+].join("\n");
+assert.equal(
+  hasWorkerReadyPrompt(codexGpt55IdleBannerWithoutGhostMarker),
+  true,
+  "codex gpt-5.5 status line alone must classify as ready even without the ghost marker line",
+);
+
+// Existing generic ghost-marker behavior (Claude-style "> " prompt with
+// user-entered text) must be unaffected by the new Codex-specific check.
+const genericGhostMarkerBanner = [
+  "Welcome to Claude Code!",
+  "> write a function to reverse a string",
+].join("\n");
+assert.equal(hasWorkerReadyPrompt(genericGhostMarkerBanner), true, "generic ghost marker banner must remain ready");
+
+// A pane still mid-launch (command echoed, no idle prompt yet) must remain
+// not-ready.
+const midLaunchBanner = [
+  "> codex --model gpt-5.5 --dangerously-bypass-approvals-and-sandbox",
+  "Starting Codex...",
+].join("\n");
+assert.equal(hasWorkerReadyPrompt(midLaunchBanner), false, "mid-launch banner must not classify as ready");
+
+console.log("worker-readiness-prompt-check: ok");

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -59,6 +59,7 @@ import {
   classifyRestoredWorkerDrift,
   selectConfiguredWorkerStartRoster,
 } from "./workerStartPlanning";
+import { hasWorkerReadyPrompt } from "./workerReadinessPrompt";
 
 interface PaneEntry {
   terminal: Terminal;
@@ -3984,26 +3985,6 @@ function detectWorkerLaunchPendingReason(text: string) {
   ];
 
   return checks.find((check) => check.pattern.test(text) || check.compactPattern.test(compactText))?.reason ?? "";
-}
-
-function isWorkerLaunchCommandEcho(line: string) {
-  return /^[>›❯]\s*(?:claude|codex|agy|grok|pwsh|powershell)\b/i.test(line)
-    || /^PS\s+.+>\s*(?:claude|codex|agy|grok|pwsh|powershell)\b/i.test(line);
-}
-
-function hasWorkerReadyPrompt(text: string) {
-  const recentLines = text
-    .split("\n")
-    .map((line) => line.trim())
-    .filter(Boolean)
-    .slice(-10);
-  const hasGrokInputBox = recentLines.some((line) => /^│\s*>\s*│?$/.test(line))
-    && recentLines.some((line) => /Grok\s+Build/i.test(line));
-  return hasGrokInputBox
-    || recentLines.some((line) => !isWorkerLaunchCommandEcho(line)
-      && (/^api_llm\[[a-z0-9._-]+\]>\s*$/i.test(line)
-        || /^(?:[>›❯])\s*$/.test(line)
-        || /^(?:[>›❯])\s*(?!(?:claude|codex|agy|grok|pwsh|powershell)\b)\S/i.test(line)));
 }
 
 async function inspectWorkerPaneReadiness(

--- a/winsmux-app/src/workerReadinessPrompt.ts
+++ b/winsmux-app/src/workerReadinessPrompt.ts
@@ -33,14 +33,27 @@ export function hasCodexIdleStatusLine(line: string): boolean {
 /**
  * #1115 (P2 follow-up): a pane that is still mid-launch can print the launch
  * command echo (`> codex --model ...`) and/or a "Starting Codex..." style
- * marker *above* the eventual idle footer line within the same captured
- * window. If any recent line still shows that pending/mid-launch shape, the
- * footer line must not be trusted as idle evidence yet, even though the
- * footer text itself matches the idle-status shape.
+ * marker line before the eventual idle footer line appears. Within a single
+ * fresh-launch sequence (echo -> "Starting..." -> spinner frames -> footer)
+ * that marker always lands within a few lines of the footer, so only the
+ * near-footer window needs to be inspected for it.
+ *
+ * #1115 (P3 follow-up): this must NOT scan the entire recent-lines window.
+ * `recentLines` mixes buffered scrollback history with the current capture
+ * (see inspectWorkerPaneReadiness in main.ts), so a launch echo/marker from
+ * a much earlier launch can still be sitting many lines above an otherwise
+ * genuinely idle footer. Scanning the full window would keep treating that
+ * pane as not-ready forever. Limiting the scan to the trailing lines next
+ * to the footer keeps the fresh-launch suppression intact while letting
+ * stale history age out once enough lines have scrolled past it.
  */
+const PENDING_LAUNCH_MARKER_WINDOW = 6;
+
 function hasPendingWorkerLaunchMarker(lines: readonly string[]): boolean {
-  return lines.some((line) => isWorkerLaunchCommandEcho(line)
-    || /\b(?:starting|launching|initializing)\b/i.test(line));
+  return lines
+    .slice(-PENDING_LAUNCH_MARKER_WINDOW)
+    .some((line) => isWorkerLaunchCommandEcho(line)
+      || /\b(?:starting|launching|initializing)\b/i.test(line));
 }
 
 export function hasWorkerReadyPrompt(text: string): boolean {

--- a/winsmux-app/src/workerReadinessPrompt.ts
+++ b/winsmux-app/src/workerReadinessPrompt.ts
@@ -30,6 +30,19 @@ export function hasCodexIdleStatusLine(line: string): boolean {
   return /^(?:gpt|codex|gpt-oss|o[0-9])[A-Za-z0-9._/-]*\s+(?:provider-default|low|medium|high|xhigh|max)\s+(?:minimal|low|medium|high|fast|turbo|slow)\b/i.test(line);
 }
 
+/**
+ * #1115 (P2 follow-up): a pane that is still mid-launch can print the launch
+ * command echo (`> codex --model ...`) and/or a "Starting Codex..." style
+ * marker *above* the eventual idle footer line within the same captured
+ * window. If any recent line still shows that pending/mid-launch shape, the
+ * footer line must not be trusted as idle evidence yet, even though the
+ * footer text itself matches the idle-status shape.
+ */
+function hasPendingWorkerLaunchMarker(lines: readonly string[]): boolean {
+  return lines.some((line) => isWorkerLaunchCommandEcho(line)
+    || /\b(?:starting|launching|initializing)\b/i.test(line));
+}
+
 export function hasWorkerReadyPrompt(text: string): boolean {
   const recentLines = text
     .split("\n")
@@ -50,5 +63,7 @@ export function hasWorkerReadyPrompt(text: string): boolean {
     return true;
   }
   const lastLine = recentLines[recentLines.length - 1];
-  return Boolean(lastLine) && hasCodexIdleStatusLine(lastLine) && !isWorkerLaunchCommandEcho(lastLine);
+  return Boolean(lastLine)
+    && hasCodexIdleStatusLine(lastLine)
+    && !hasPendingWorkerLaunchMarker(recentLines);
 }

--- a/winsmux-app/src/workerReadinessPrompt.ts
+++ b/winsmux-app/src/workerReadinessPrompt.ts
@@ -1,0 +1,54 @@
+/**
+ * Pure text-shape heuristics for deciding whether a worker pane's captured
+ * terminal output shows an idle prompt (ready for benchmark dispatch) or is
+ * still mid-launch/mid-response. Extracted from main.ts so the exact banner
+ * shapes reported against real agent CLIs can be covered by a fixture-based
+ * regression test (see scripts/worker-readiness-prompt-check.mjs) without
+ * needing to boot the full desktop webview.
+ */
+
+/**
+ * A line that merely echoes a not-yet-submitted launch/command invocation
+ * (e.g. the shell prompt showing `> codex --model ...` right after a pane
+ * was spawned) must never be mistaken for an idle ghost-text input prompt.
+ */
+export function isWorkerLaunchCommandEcho(line: string): boolean {
+  return /^[>›❯]\s*(?:claude|codex|agy|grok|pwsh|powershell)\b/i.test(line)
+    || /^PS\s+.+>\s*(?:claude|codex|agy|grok|pwsh|powershell)\b/i.test(line);
+}
+
+/**
+ * #1115: Codex/GPT-5.5 idle panes render a footer status line such as
+ * "gpt-5.5 xhigh fast" below the ghost-text input prompt instead of the
+ * "NN% context left" readout the generic marker heuristics in
+ * hasWorkerReadyPrompt expect. When that status line is the most recent
+ * non-empty line and it is not itself a pending launch/command echo, the
+ * pane is idle at its prompt and ready, independent of whether the
+ * ghost-prompt marker line above it survived buffer normalization intact.
+ */
+export function hasCodexIdleStatusLine(line: string): boolean {
+  return /^(?:gpt|codex|gpt-oss|o[0-9])[A-Za-z0-9._/-]*\s+(?:provider-default|low|medium|high|xhigh|max)\s+(?:minimal|low|medium|high|fast|turbo|slow)\b/i.test(line);
+}
+
+export function hasWorkerReadyPrompt(text: string): boolean {
+  const recentLines = text
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .slice(-10);
+  const hasGrokInputBox = recentLines.some((line) => /^│\s*>\s*│?$/.test(line))
+    && recentLines.some((line) => /Grok\s+Build/i.test(line));
+  if (hasGrokInputBox) {
+    return true;
+  }
+  if (
+    recentLines.some((line) => !isWorkerLaunchCommandEcho(line)
+      && (/^api_llm\[[a-z0-9._-]+\]>\s*$/i.test(line)
+        || /^(?:[>›❯])\s*$/.test(line)
+        || /^(?:[>›❯])\s*(?!(?:claude|codex|agy|grok|pwsh|powershell)\b)\S/i.test(line)))
+  ) {
+    return true;
+  }
+  const lastLine = recentLines[recentLines.length - 1];
+  return Boolean(lastLine) && hasCodexIdleStatusLine(lastLine) && !isWorkerLaunchCommandEcho(lastLine);
+}


### PR DESCRIPTION
Unblocks the v0.36.23 six-pane Harness Bench: worker-2 (Codex / gpt-5.5) stayed at "checking readiness" forever, so benchmark ready-check never completed and dispatch was blocked for the whole roster.

## Root cause (empirically verified)

Two independent, non-communicating readiness classifiers exist:

- **CLI layer** (`winsmux-core/scripts/agent-readiness.ps1` `Test-AgentPromptText`): its generic ghost-marker pre-check already classifies the exact captured worker-2 idle banner as ready (verified by live execution, RESULT=True). This layer was never broken for this banner and is untouched.
- **Desktop layer** (`hasWorkerReadyPrompt` in `main.ts`, the gate actually used by `winsmux benchmark ready-check`/dispatch): an independent implementation with no Codex-specific fallback. The GPT-5.5 idle banner ends with a `gpt-5.5 xhigh fast` status footer and a ghost-text suggestion line; none of the desktop heuristics accepted it, so the pane never left "checking readiness".

## Changes

- New `winsmux-app/src/workerReadinessPrompt.ts`: extracts `hasWorkerReadyPrompt`/`isWorkerLaunchCommandEcho` into a pure, testable module and adds `hasCodexIdleStatusLine` (model + effort + speed footer, e.g. `gpt-5.5 xhigh fast`) as a final independent ready signal, guarded against launch-command echoes.
- `winsmux-app/src/main.ts`: imports the shared module; inline copies removed.
- New `worker-readiness-prompt-check.mjs` (+ npm script): 4 fixtures — the exact real worker-2 banner (ready), the same banner without the ghost-marker line (ready via the new signal alone), a generic Claude-style banner (regression, ready), a mid-launch echo banner (correctly NOT ready).

## Verification

- `npm run test:worker-readiness-prompt` 4/4 pass; `test:worker-start-planning` and `test:worker-pane-routing` pass (no regression); `npx tsc --noEmit` clean.

## Follow-up note

The PowerShell and TS classifiers remain parallel implementations; unifying them (e.g. passing agent identity through the desktop call chain) is deliberately out of scope for this hotfix.

Fixes #1115. Refs #1103.

🤖 Generated with [Claude Code](https://claude.com/claude-code)