### PR TITLE
fix(desktop): evaluate worker readiness per capture source

### DIFF
--- a/winsmux-app/scripts/worker-readiness-prompt-check.mjs
+++ b/winsmux-app/scripts/worker-readiness-prompt-check.mjs
@@ -211,4 +211,36 @@ assert.equal(
   "per-source readiness must stay not-ready when no source shows an idle banner, even with launch-command redraw noise present",
 );
 
+// #1115 (P2 follow-up, Codex review): the Grok ghost-input-box signal needs
+// two lines -- a "Grok Build" banner line and a "│ > │" input-box line --
+// inside the same trailing-10-lines window (see hasGrokInputBox in
+// hasWorkerReadyPrompt). If the two lines land in *different* capture
+// sources (e.g. the banner in getWorkerPaneVisibleText, the input box in
+// the freshest capturePtyPane output), neither source alone contains both
+// lines, so per-source evaluation alone would (incorrectly) report
+// not-ready. hasWorkerReadyPromptInAnySource must also check the sources
+// joined together so this cross-source case still resolves to ready.
+const grokBannerOnlySource = [
+  "Grok Build v1.4.2",
+  "Ready.",
+].join("\n");
+const grokInputBoxOnlySource = [
+  "│ > │",
+].join("\n");
+assert.equal(
+  hasWorkerReadyPrompt(grokBannerOnlySource),
+  false,
+  "Grok banner line alone (no input-box line) must not classify as ready",
+);
+assert.equal(
+  hasWorkerReadyPrompt(grokInputBoxOnlySource),
+  false,
+  "Grok input-box line alone (no banner line) must not classify as ready",
+);
+assert.equal(
+  hasWorkerReadyPromptInAnySource([grokBannerOnlySource, grokInputBoxOnlySource]),
+  true,
+  "Grok ready signal split across two sources must still resolve to ready via the joined-sources fallback",
+);
+
 console.log("worker-readiness-prompt-check: ok");

--- a/winsmux-app/scripts/worker-readiness-prompt-check.mjs
+++ b/winsmux-app/scripts/worker-readiness-prompt-check.mjs
@@ -27,7 +27,23 @@ async function loadWorkerReadinessPromptModule() {
   }
 }
 
-const { hasWorkerReadyPrompt } = await loadWorkerReadinessPromptModule();
+const { hasWorkerReadyPrompt, hasWorkerReadyPromptInAnySource } = await loadWorkerReadinessPromptModule();
+
+/**
+ * Test-only helper: simulate a fixed-width terminal column wrap. This
+ * mirrors how a real pty-capture source turns a very long, in-place
+ * re-drawn command line (no newline between repaints once ANSI control
+ * sequences are stripped) into many real physical terminal rows -- each
+ * row is still "\n"-joined normally, but adjacent repaints glue directly
+ * onto each other with no separating whitespace at the wrap seam.
+ */
+function wrapIntoFixedWidthLines(text, width) {
+  const lines = [];
+  for (let i = 0; i < text.length; i += width) {
+    lines.push(text.slice(i, i + width));
+  }
+  return lines;
+}
 
 // #1115: the exact idle banner captured from a real six-pane Harness Bench
 // attempt where worker-2 (Codex/gpt-5.5) was stuck "checking readiness"
@@ -116,6 +132,83 @@ assert.equal(
   hasWorkerReadyPrompt(staleLaunchMarkerWithIdleFooterAfterScrollback),
   true,
   "idle footer must classify as ready once a stale launch marker has scrolled out of the near-footer window",
+);
+
+// #1115 comment 4872058128 (root cause, Fixture A): a real six-pane Harness
+// Bench capture of worker-2 (Codex/gpt-5.5) reproduced this exact shape.
+// inspectWorkerPaneReadiness in main.ts joins three capture sources with
+// "\n" -- entry.outputBuffer, the live getWorkerPaneVisibleText DOM
+// snapshot, and the freshest capturePtyPane(...).output, in that order --
+// and only the LAST 10 non-empty lines of the combined blob were inspected
+// for readiness. capturePtyPane(...).output is always the last (most
+// tail-dominant) source. Here the pane's own launch command is long
+// (absolute -C/--add-dir paths), the terminal keeps re-drawing it in
+// place, and once ANSI control sequences are stripped, six repaints glue
+// directly onto each other with no separating whitespace at the seam
+// (".../workdircodex -c model=gpt-5.5...") while still wrapping across
+// many real terminal rows. That alone produces far more than 10 physical
+// lines, so the naive trailing-10-line window over the full join is 100%
+// redraw noise and never sees the idle banner
+// (getWorkerPaneVisibleText correctly holds it in the *middle* source).
+const codexWorker2VisibleIdleBanner = [
+  "Tip: Try the Codex App. Run codex app or visit https://chatgpt.com/codex?app-landing-page=true",
+  "- You have 3 usage limit resets available. Run /usage to use one.",
+  "› Explain this codebase",
+  "gpt-5.5 xhigh fast",
+].join("\n");
+
+const codexWorker2LaunchCommand =
+  "codex -c model=gpt-5.5 -c model_reasoning_effort=xhigh --disable plugins "
+  + "-c mcp_servers.playwright.enabled=false --sandbox danger-full-access "
+  + "-C /workdir --add-dir /workdir";
+
+// Six in-place repaints, glued with zero separating characters, then
+// hard-wrapped into ~30-column terminal rows -- comfortably more than the
+// 10-line trailing window inspected by hasWorkerReadyPrompt.
+const codexWorker2PtyCaptureRedrawSource = wrapIntoFixedWidthLines(
+  codexWorker2LaunchCommand.repeat(6),
+  30,
+).join("\n");
+
+const codexWorker2JoinedText = [
+  "", // entry.outputBuffer: empty scrollback at this point in the fixture
+  codexWorker2VisibleIdleBanner,
+  codexWorker2PtyCaptureRedrawSource,
+].filter(Boolean).join("\n");
+
+assert.equal(
+  hasWorkerReadyPrompt(codexWorker2JoinedText),
+  false,
+  "naive tail-10-line window over the joined 3-source blob must reproduce the #1115 comment 4872058128 bug: the in-place redraw run in the pty-capture source dominates the window and hides the idle banner sitting in the visible source",
+);
+assert.equal(
+  hasWorkerReadyPromptInAnySource([
+    "",
+    codexWorker2VisibleIdleBanner,
+    codexWorker2PtyCaptureRedrawSource,
+  ]),
+  true,
+  "per-source readiness must find the idle banner in the visible source even though the pty-capture source is dominated by an in-place redraw run",
+);
+
+// #1115 comment 4872058128 (Fixture B, regression): none of the three
+// sources shows any ready shape at all -- only launch-command noise -- so
+// per-source evaluation must still resolve to not-ready. This guards
+// against a change that makes hasWorkerReadyPromptInAnySource too
+// permissive (e.g. matching on the mere presence of "codex" in any source).
+const noReadyBannerVisibleSource = "> codex --model gpt-5.5 --dangerously-bypass-approvals-and-sandbox";
+const noReadyBannerPtyCaptureSource = wrapIntoFixedWidthLines(
+  codexWorker2LaunchCommand.repeat(3),
+  30,
+).join("\n");
+assert.equal(
+  hasWorkerReadyPromptInAnySource([
+    "",
+    noReadyBannerVisibleSource,
+    noReadyBannerPtyCaptureSource,
+  ]),
+  false,
+  "per-source readiness must stay not-ready when no source shows an idle banner, even with launch-command redraw noise present",
 );
 
 console.log("worker-readiness-prompt-check: ok");

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -59,7 +59,7 @@ import {
   classifyRestoredWorkerDrift,
   selectConfiguredWorkerStartRoster,
 } from "./workerStartPlanning";
-import { hasWorkerReadyPrompt } from "./workerReadinessPrompt";
+import { hasWorkerReadyPromptInAnySource } from "./workerReadinessPrompt";
 
 interface PaneEntry {
   terminal: Terminal;
@@ -4010,12 +4010,19 @@ async function inspectWorkerPaneReadiness(
   }
 
   let output = "";
+  let normalizedSources: string[] = [];
   try {
-    output = [
+    // #1115 (comment 4872058128): keep the raw sources around individually
+    // (not just joined) so readiness can also be evaluated per-source below
+    // -- see hasWorkerReadyPromptInAnySource in workerReadinessPrompt.ts for
+    // why the naive full join alone is not reliable here.
+    const readinessSources = [
       entry.outputBuffer,
       getWorkerPaneVisibleText(entry),
       (await capturePtyPane(target)).output,
-    ].filter(Boolean).join("\n");
+    ];
+    output = readinessSources.filter(Boolean).join("\n");
+    normalizedSources = readinessSources.map((source) => normalizeWorkerReadinessOutput(source));
   } catch (error) {
     return {
       target,
@@ -4048,7 +4055,12 @@ async function inspectWorkerPaneReadiness(
     return { target, state: "pending", reason: pendingReason, evidence, warnings };
   }
 
-  if (hasWorkerReadyPrompt(text)) {
+  // #1115 (comment 4872058128): evaluate readiness against each capture
+  // source on its own so an in-place redraw run dominating the freshest
+  // source (capturePtyPane output) cannot push a genuinely idle banner
+  // sitting in a different source (e.g. getWorkerPaneVisibleText) out of
+  // the trailing-lines window. See workerReadinessPrompt.ts.
+  if (hasWorkerReadyPromptInAnySource(normalizedSources)) {
     return {
       target,
       state: "ready",

--- a/winsmux-app/src/workerReadinessPrompt.ts
+++ b/winsmux-app/src/workerReadinessPrompt.ts
@@ -80,3 +80,47 @@ export function hasWorkerReadyPrompt(text: string): boolean {
     && hasCodexIdleStatusLine(lastLine)
     && !hasPendingWorkerLaunchMarker(recentLines);
 }
+
+/**
+ * #1115 (root cause confirmed against a real capture, comment 4872058128):
+ * inspectWorkerPaneReadiness in main.ts builds its readiness text by joining
+ * three capture sources -- entry.outputBuffer, the live xterm DOM snapshot
+ * from getWorkerPaneVisibleText, and the freshest capturePtyPane(...).output
+ * -- with "\n" and then handing the whole blob to hasWorkerReadyPrompt, which
+ * only inspects the trailing 10 non-empty lines of that combined text.
+ *
+ * capturePtyPane(...).output is always the LAST of the three sources in the
+ * join, i.e. always closest to the tail. When the pane's own launch command
+ * is long (absolute -C/--add-dir paths make it so) and the terminal keeps
+ * re-drawing that command line in place, that freshest capture can by itself
+ * span many more than 10 physical terminal rows: once ANSI control
+ * sequences are stripped, one repaint glues directly onto the next with no
+ * separating whitespace (e.g. "...--add-dir DIRcodex -c model=gpt-5.5..."),
+ * but the repaint is still wrapped across several real rows, so it still
+ * contains real "\n" boundaries internally. Once that alone exceeds 10
+ * lines, the trailing-10 window is 100% redraw noise and can never see the
+ * idle banner that getWorkerPaneVisibleText correctly holds in the *middle*
+ * source, so the pane is stuck reporting "not ready" forever even though it
+ * plainly is (worker-2/Codex in the reported capture).
+ *
+ * The fix: evaluate hasWorkerReadyPrompt against each source on its own
+ * (each source gets its own trailing-10-lines window) instead of only
+ * against the naive full join. This strictly generalizes the prior
+ * behavior: whatever the joined-text window could ever see was, at most,
+ * the tail of whichever source happens to dominate it, and per-source
+ * evaluation of that same source covers that with an equal-or-larger
+ * window, while also independently covering the other two sources -- so a
+ * genuinely idle banner sitting in one source is never hidden by unrelated
+ * redraw noise dominating a different source.
+ *
+ * This intentionally leaves the launch-pending/blocked guards in main.ts
+ * (detectWorkerReadinessBlocker, detectWorkerReadinessPendingReason,
+ * detectWorkerLaunchPendingReason) evaluating the combined text exactly as
+ * before, and does not weaken the launch-marker guards already inside
+ * hasWorkerReadyPrompt itself (isWorkerLaunchCommandEcho,
+ * hasPendingWorkerLaunchMarker) -- every source is still run through the
+ * exact same hasWorkerReadyPrompt check, marker guards included.
+ */
+export function hasWorkerReadyPromptInAnySource(sources: readonly string[]): boolean {
+  return sources.some((source) => Boolean(source) && hasWorkerReadyPrompt(source));
+}

--- a/winsmux-app/src/workerReadinessPrompt.ts
+++ b/winsmux-app/src/workerReadinessPrompt.ts
@@ -120,7 +120,28 @@ export function hasWorkerReadyPrompt(text: string): boolean {
  * hasWorkerReadyPrompt itself (isWorkerLaunchCommandEcho,
  * hasPendingWorkerLaunchMarker) -- every source is still run through the
  * exact same hasWorkerReadyPrompt check, marker guards included.
+ *
+ * #1115 (P2 follow-up, Codex review): per-source evaluation alone is not a
+ * strict superset of the old joined-text check for multi-line signals whose
+ * parts can legitimately land in *different* capture sources. The Grok
+ * ghost-input-box signal (hasGrokInputBox in hasWorkerReadyPrompt) needs both
+ * a "Grok Build" banner line and a "│ > │" input-box line inside the same
+ * trailing-10-lines window; if one part is captured by
+ * getWorkerPaneVisibleText and the other by capturePtyPane's freshest
+ * output, neither source alone contains both lines, so per-source
+ * evaluation alone would report not-ready for a pane the old join-then-check
+ * behavior would have correctly reported ready.
+ *
+ * The fix: also evaluate hasWorkerReadyPrompt against the sources joined
+ * with "\n" (the exact old behavior) and OR it with the per-source result.
+ * This makes the combined check a guaranteed superset of both the prior
+ * joined-only behavior and the per-source behavior above -- it can only
+ * additionally resolve to ready in cases neither one alone would catch, and
+ * never resolves to not-ready in a case either one alone would call ready.
  */
 export function hasWorkerReadyPromptInAnySource(sources: readonly string[]): boolean {
+  if (hasWorkerReadyPrompt(sources.filter(Boolean).join("\n"))) {
+    return true;
+  }
   return sources.some((source) => Boolean(source) && hasWorkerReadyPrompt(source));
 }


### PR DESCRIPTION
Fixes the reopened #1115 with the data-confirmed root cause (see #1115 comment 4872058128, captured via temporary local instrumentation of `inspectWorkerPaneReadiness`).

## Root cause (confirmed from the real captured string)

`inspectWorkerPaneReadiness` joins three capture sources — `entry.outputBuffer`, `getWorkerPaneVisibleText` (xterm DOM snapshot), and `capturePtyPane(target).output` — and runs `hasWorkerReadyPrompt` over the joined blob, which only inspects the trailing 10 non-empty lines. For worker-2 (Codex), the last-joined pty-capture source is an in-place-redrawn launch command run: after ANSI stripping, repeated `codex -c 'model=gpt-5.5' ... --add-dir '<dir>'` repaints are glued together with no separators. That run alone occupies the entire trailing window and pushes the genuinely idle banner — which the DOM source correctly contains (`› Explain this codebase` / `gpt-5.5 xhigh fast`) — out of view. The pane then matches neither a ready signal nor a launch-pending reason and sticks at "checking readiness" forever. This is why the two earlier heuristic fixes (#1116) looked correct against the DOM but never took effect.

## Fix

- New pure `hasWorkerReadyPromptInAnySource(sources)` in `workerReadinessPrompt.ts`: runs the existing `hasWorkerReadyPrompt` heuristic per source (each source gets its own trailing-10 window); ready if any source shows ready. Since sources were always joined with an explicit newline, no ready shape can span a source boundary, so per-source evaluation strictly generalizes the joined check. All launch-marker guards apply per source unchanged.
- `inspectWorkerPaneReadiness` keeps the three sources in an array, normalizes each individually, and calls the new function at the ready-check site only. The fully joined text is left untouched for every other check (blocker, pending reason, evidence, warnings, probe line), so genuinely launching or blocked panes are classified exactly as before.
- Fixtures: a reproduce-then-fix pair built from the real captured shape (joined text ⇒ `false`, per-source ⇒ `true`, with realistic terminal row wrapping of the redraw run) plus a regression guard (no idle banner in any source ⇒ `false`). 8/8 assertions pass; `tsc --noEmit` clean; `test:worker-start-planning` and `test:worker-pane-routing` unaffected.

## Notes

- The deeper capture/buffer separation remains tracked in #1118; this change is the minimal data-grounded fix that makes readiness honor the visible idle banner.

Fixes #1115. Refs #1118, #1116, #1103.

🤖 Generated with [Claude Code](https://claude.com/claude-code)