### PR TITLE
chore(hooks): add backlog.yaml deny rules required by session-start gate-check

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,6 +2,7 @@
   "permissions": {
     "deny": [
       "Edit(**/backlog.yaml)",
+      "MultiEdit(**/backlog.yaml)",
       "Write(**/backlog.yaml)"
     ]
   },

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,10 @@
 {
+  "permissions": {
+    "deny": [
+      "Edit(**/backlog.yaml)",
+      "Write(**/backlog.yaml)"
+    ]
+  },
   "hooks": {
     "SessionStart": [
       {


### PR DESCRIPTION
Resolves the standing session-start warning `[gate-check] WARNING: Missing deny rules for: backlog.yaml`.

`sh-session-start.js` check 1b requires `permissions.deny` in the tracked `.claude/settings.json` to contain a rule including `backlog.yaml` (`REQUIRED_DENY_PATTERNS`, line 49-51). The tracked settings had no `permissions` key at all, so the warning fired on every session since the check landed.

This adds the `Edit(**/backlog.yaml)` / `Write(**/backlog.yaml)` deny pair: the operator session must not mutate the external planning backlog directly — backlog changes stay in the owner-approval loop. Hook configuration is unchanged (byte-identical `hooks` block).

The sibling warning (`CLAUDE.md not found`, check 1a) is a hook path-expectation bug tracked separately in #1123.

Found and fixed as part of the 2026-07-03 harness/global config audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)