### PR TITLE
fix(compat-gate): classify bench runner scripts in legacy-compat inventory

### DIFF
--- a/docs/project/legacy-compat-surface-inventory.json
+++ b/docs/project/legacy-compat-surface-inventory.json
@@ -160,6 +160,17 @@
         "docs/incidents/v03623-session-readiness/00-incident-record.md",
         "scripts/test-v03623-session-readiness.ps1"
       ]
+    },
+    {
+      "class": "intentional-shim",
+      "owner": "harness bench runner documentation",
+      "surface": "desktop bench runner capture-architecture notes",
+      "reason": "The durable bench runner documents why the external psmux capture-pane path cannot read desktop Tauri worker panes and routes capture over the in-app pty_capture command instead; the legacy term appears only in explanatory comments and diagnostics, not as a runtime alias surface.",
+      "target": "keep while the durable bench runner documents the desktop capture path",
+      "paths": [
+        "winsmux-app/scripts/bakeoff-runner-lib.mjs",
+        "winsmux-app/scripts/run-cli-bakeoff.mjs"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Fixes #1132.

`Core Build and Test` has failed deterministically on every PR since #1128 merged, because the two bench runner scripts introduced there reference "psmux" in their capture-architecture comments and were never classified in the legacy-compat inventory. The gate correctly reports them as unclassified and fails, which turns Merge Gate red repo-wide.

## Root cause (reproduced locally on main, 76934a67)

```
> winsmux legacy-compat-gate --json   (exit 1)
"summary": { "passed": false, "unclassified_count": 2 },
"unclassified_files": [
  "winsmux-app/scripts/bakeoff-runner-lib.mjs",
  "winsmux-app/scripts/run-cli-bakeoff.mjs"
]
```

The timeline matches the issue exactly: the failures started with #1128 (the PR that added these scripts) and reproduce 2/2 on rerun — deterministic, not flaky.

## Fix

Add one `intentional-shim` inventory entry covering both scripts. The psmux references are explanatory comments documenting why the external `capture-pane` path cannot read desktop Tauri worker panes (the runner routes capture over the in-app `pty_capture` command instead) — they are not a runtime alias surface, so `intentional-shim` matches the inventory's release rule ("keep until the replacement contract exists"). No change to `legacy-compat-surface-inventory.md` is needed: it is a contract summary, not a per-entry mirror, and its gate-contract section already describes exactly this failure mode.

## Verification

- Local repro of the failing gate on main captured above (the fix targets precisely the two reported files).
- The authoritative verification is this PR's own `Core Build and Test`: it runs `operator_cli_legacy_compat_gate_json_reports_inventory` and `operator_cli_legacy_compat_gate_text_reports_next_action`, the two tests that fail 2/2 on main. Green here = fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)