### PR TITLE
fix(release): trust the release signing certificate on the runner for signature verification

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -67,10 +67,10 @@ jobs:
           [IO.File]::WriteAllBytes($certPath, [Convert]::FromBase64String($env:WINDOWS_SIGNING_CERTIFICATE_BASE64))
           "WINSMUX_WINDOWS_SIGNING_CERTIFICATE_PATH=$certPath" | Add-Content -LiteralPath $env:GITHUB_ENV -Encoding utf8
           # Trust the release signing certificate on this ephemeral runner so
-          # the "Verify desktop installer signatures" step can validate the
-          # chain to a trusted root. Required while the release is signed with
-          # a self-signed certificate (#1140); harmless for a CA-issued
-          # certificate. The verification step still rejects unsigned or
+          # the later Authenticode verification can validate the chain to a
+          # trusted root. Required while the release is signed with a
+          # self-signed certificate (#1140); harmless for a CA-issued
+          # certificate. The later verification still rejects unsigned or
           # tampered assets because the Authenticode check covers integrity,
           # not only trust.
           $pfxPassword = ConvertTo-SecureString $env:WINDOWS_SIGNING_CERTIFICATE_PASSWORD -AsPlainText -Force

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -61,10 +61,23 @@ jobs:
         shell: pwsh
         env:
           WINDOWS_SIGNING_CERTIFICATE_BASE64: ${{ secrets.WINDOWS_SIGNING_CERTIFICATE_BASE64 }}
+          WINDOWS_SIGNING_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_SIGNING_CERTIFICATE_PASSWORD }}
         run: |
           $certPath = Join-Path $env:RUNNER_TEMP "winsmux-signing.pfx"
           [IO.File]::WriteAllBytes($certPath, [Convert]::FromBase64String($env:WINDOWS_SIGNING_CERTIFICATE_BASE64))
           "WINSMUX_WINDOWS_SIGNING_CERTIFICATE_PATH=$certPath" | Add-Content -LiteralPath $env:GITHUB_ENV -Encoding utf8
+          # Trust the release signing certificate on this ephemeral runner so
+          # the "Verify desktop installer signatures" step can validate the
+          # chain to a trusted root. Required while the release is signed with
+          # a self-signed certificate (#1140); harmless for a CA-issued
+          # certificate. The verification step still rejects unsigned or
+          # tampered assets because the Authenticode check covers integrity,
+          # not only trust.
+          $pfxPassword = ConvertTo-SecureString $env:WINDOWS_SIGNING_CERTIFICATE_PASSWORD -AsPlainText -Force
+          $imported = Import-PfxCertificate -FilePath $certPath -CertStoreLocation Cert:\LocalMachine\My -Password $pfxPassword
+          $publicCertPath = Join-Path $env:RUNNER_TEMP "winsmux-signing.cer"
+          Export-Certificate -Cert $imported -FilePath $publicCertPath | Out-Null
+          Import-Certificate -FilePath $publicCertPath -CertStoreLocation Cert:\LocalMachine\Root | Out-Null
           $signtool = Get-ChildItem -Path "${env:ProgramFiles(x86)}\Windows Kits\10\bin" -Recurse -Filter signtool.exe |
             Where-Object { $_.FullName -match '\\x64\\signtool\.exe$' } |
             Select-Object -First 1 -ExpandProperty FullName


### PR DESCRIPTION
## Summary

Part of #1140.

The "Verify desktop installer signatures" step requires `Get-AuthenticodeSignature` to report `Valid`, which needs the signing certificate's chain to terminate in a trusted root on the runner. With a self-signed release signing certificate (the decision for v0.36.23 until a CA-issued certificate is procured), the chain would end in an untrusted root and the verification would fail even though the assets are correctly signed.

## Change

In "Prepare Windows signing certificate", after materializing the PFX: import it into the runner's `Cert:\LocalMachine\My`, export the public certificate, and import that into `Cert:\LocalMachine\Root`. The runner is ephemeral, so the trust import affects only the build machine for the duration of the job.

- Harmless for a future CA-issued certificate (the chain then validates with or without the import).
- The verification step remains a real gate: Authenticode validation still rejects unsigned or tampered assets; only the trust anchor is provided.
- One env addition to that step (`WINDOWS_SIGNING_CERTIFICATE_PASSWORD`) needed for `Import-PfxCertificate`. The password is not printed.

## Verification

- Diff is limited to the one step (env + trust-import block); verified against the failing run 28742250894 whose only failure is the secrets gate followed by (would-be) chain validation.
- End-to-end proof happens on the `workflow_dispatch` run with `release_tag=v0.36.23` after the four signing secrets are registered — that run exercises this exact path and uploads the desktop assets to the existing release. Not possible to verify headlessly before the secrets exist; stated explicitly per the operator contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)