### PR TITLE
fix(release): add updater plugin config required by createUpdaterArtifacts

### DIFF
--- a/winsmux-app/src-tauri/tauri.ci.conf.json
+++ b/winsmux-app/src-tauri/tauri.ci.conf.json
@@ -4,5 +4,13 @@
     "windows": {
       "signCommand": "pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File ./scripts/sign-windows-bundle.ps1 %1"
     }
+  },
+  "plugins": {
+    "updater": {
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDEyODk5MUU5NUU1NDk4NDcKUldSSG1GUmU2WkdKRXZRbFphL1RWWkhVZ2hrbzFVZnVnRlU3RUhnYjgxVXNQQ3JBNnB3Qy9tU3kK",
+      "endpoints": [
+        "https://github.com/Sora-bluesky/winsmux/releases/latest/download/latest.json"
+      ]
+    }
   }
 }


### PR DESCRIPTION
## Summary

Part of #1140. Second latent defect exposed as the desktop release pipeline progresses past the secrets gate for the first time.

The `workflow_dispatch` run for `release_tag=v0.36.23` (run 28743369013, on main with #1141 merged) passed the signing-secrets gate and the certificate trust-import, built the app, then failed at bundling:

```
failed to build bundler settings: failed to get updater configuration: plugins > updater doesn't exist
```

`createUpdaterArtifacts: true` (introduced with the signed-updater gate, #1089) requires the `plugins.updater` configuration; it was never added because every previous run failed earlier at the missing-secrets gate.

## Change

Add `plugins.updater` to `tauri.ci.conf.json` (CI release overlay only, same scope as the existing signing config):

- `pubkey`: the Tauri updater public key matching the registered `TAURI_SIGNING_PRIVATE_KEY` (public information; generated 2026-07-05, backed up with the signing material).
- `endpoints`: the `latest.json` published to the GitHub Release by this same workflow.

## Verification

- The existing gate test (`CliBakeoff.Tests.ps1` "gates desktop releases on signed updater artifacts") asserts `createUpdaterArtifacts`, `signCommand`, and the sign-script path on this file — all assertions still match the new content.
- End-to-end proof is the re-dispatched `release-desktop.yml` run with `release_tag=v0.36.23` after merge; not verifiable headlessly before that. This is the last missing piece between the build step and the already-tested collect/verify/upload steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)