### PR TITLE
test: enforce bakeoff preflight governance invariants

### DIFF
--- a/docs/cli-comparison-bakeoff.md
+++ b/docs/cli-comparison-bakeoff.md
@@ -23,11 +23,20 @@ The tracked task pack lives in `tasks/cli-bakeoff/v1/`.
 - `benchmark-pack.json` defines workers, task classes, scoring axes, and quality gates.
 - `WB-*.md` files are shared task packets.
 - Every worker in a run must receive the same task packet content.
+- Every scored worker must use the same task set, timeout, and workspace
+  baseline; per-worker task, timeout, or workspace overrides fail preflight.
 - A worker result is scoreable only when it completed and the desktop recording evidence is publishable.
 - The official task target is 27 tasks with a 60 minute timeout per task.
 - The operator is not scored. The operator may assign panes, run commands,
   collect logs, mark exclusions, update reports, and manage release gates, but
   must not improve a worker answer mid-run.
+- Worker-to-worker messaging is disabled for official runs. Run manifests must
+  disclose the messaging state, operator intervention count, and execution
+  surface so the run can be audited after collection.
+- Official scoreable evidence must report
+  `run_governance.execution_surface = "visible_desktop_worker_panes"` together
+  with publishable desktop worker-pane recording evidence. App-external API or
+  local CLI batch outputs are reference evidence only.
 - Blocked runs, missing API keys, timeouts, crashes, empty stdout, invalid
   output, missing end markers, packet hash mismatches, and missing recordings
   are kept as evidence but are excluded from model scoring.

--- a/scripts/run-cli-bakeoff-local-workers.ps1
+++ b/scripts/run-cli-bakeoff-local-workers.ps1
@@ -604,6 +604,12 @@ foreach ($worker in $workerSet) {
     $preflight[[string]$worker.pane] = New-PreflightResult -Worker $worker -RunDir $runDir
 }
 
+$runGovernance = [ordered]@{
+    messaging_state              = 'worker_to_worker_disabled'
+    operator_intervention_count  = 0
+    execution_surface            = 'local_cli_batch'
+}
+
 $manifest = [ordered]@{
     run_id             = $runIdSlug
     pack_id            = [string]$pack.pack_id
@@ -628,6 +634,7 @@ $manifest = [ordered]@{
     preflight          = $preflight
     workspace_policy   = $pack.workspace_policy
     operator           = $pack.operator
+    run_governance     = $runGovernance
 }
 Write-JsonFile -Path (Join-Path $runDir 'manifest.json') -Data $manifest
 

--- a/scripts/run-cli-bakeoff-openrouter.ps1
+++ b/scripts/run-cli-bakeoff-openrouter.ps1
@@ -199,6 +199,12 @@ $scorecardLines.Add('| Worker | Task | Status | Deterministic score | Tokens | E
 $scorecardLines.Add('| --- | --- | --- | ---: | ---: | --- |') | Out-Null
 [System.IO.File]::WriteAllLines($scorecardPath, $scorecardLines, [System.Text.UTF8Encoding]::new($false))
 
+$runGovernance = [ordered]@{
+    messaging_state              = 'worker_to_worker_disabled'
+    operator_intervention_count  = 0
+    execution_surface            = 'api_worker_batch'
+}
+
 $initialManifest = [ordered]@{
     run_id                = $runIdSlug
     pack_id               = [string]$pack.pack_id
@@ -224,6 +230,7 @@ $initialManifest = [ordered]@{
     worker_assignments    = $workerAssignments
     workspace_policy      = $pack.workspace_policy
     operator              = $pack.operator
+    run_governance        = $runGovernance
 }
 Write-JsonFile -Path (Join-Path $runDir 'manifest.json') -Data $initialManifest
 
@@ -371,6 +378,7 @@ $manifest = [ordered]@{
     worker_assignments    = $workerAssignments
     workspace_policy      = $pack.workspace_policy
     operator              = $pack.operator
+    run_governance        = $runGovernance
 }
 Write-JsonFile -Path (Join-Path $runDir 'manifest.json') -Data $manifest
 $commands | ForEach-Object { $_ | ConvertTo-Json -Depth 40 -Compress } | Set-Content -LiteralPath (Join-Path $runDir 'commands.jsonl') -Encoding UTF8

--- a/scripts/summarize-cli-bakeoff.ps1
+++ b/scripts/summarize-cli-bakeoff.ps1
@@ -89,6 +89,19 @@ function ConvertTo-NormalizedReason {
     return ([string]$Value).Trim().ToLowerInvariant() -replace '[\s-]+', '_'
 }
 
+function Test-NumericZero {
+    param([AllowNull()][object]$Value)
+
+    if ($null -eq $Value) { return $false }
+    if ($Value -is [string] -or $Value -is [char] -or $Value -is [bool]) { return $false }
+
+    try {
+        return [decimal]$Value -eq 0
+    } catch {
+        return $false
+    }
+}
+
 function Get-ScoreabilityDecision {
     param(
         [Parameter(Mandatory = $true)][string]$Cli,
@@ -97,6 +110,10 @@ function Get-ScoreabilityDecision {
         [Parameter(Mandatory = $true)][bool]$EndMarkerPresent,
         [Parameter(Mandatory = $true)][bool]$PacketHashMatch,
         [Parameter(Mandatory = $true)][bool]$StdoutEmpty,
+        [AllowEmptyString()][string]$RecordingStatus = '',
+        [AllowEmptyString()][string]$MessagingState = '',
+        [AllowNull()][object]$OperatorInterventionCount = $null,
+        [AllowEmptyString()][string]$ExecutionSurface = '',
         [bool]$OperatorRun = $false,
         [AllowEmptyString()][string]$FailureClass = '',
         [AllowEmptyString()][string]$ExclusionReason = '',
@@ -117,6 +134,10 @@ function Get-ScoreabilityDecision {
     if ($InvalidOutput -or $normalizedStatus -in @('invalid_output', 'invalid_json', 'malformed') -or $normalizedFailureClass -in @('invalid_output', 'invalid_json', 'malformed') -or $normalizedExclusionReason -in @('invalid_output', 'invalid_json', 'malformed')) { $reasons.Add('invalid_output') | Out-Null }
     if ($Status -ne 'completed') { $reasons.Add('not_completed') | Out-Null }
     if (-not $RecordingPublishable) { $reasons.Add('recording_not_publishable') | Out-Null }
+    if ($RecordingStatus -notin @('desktop_app_screen_recording', 'visible_desktop_worker_pane_recording', 'manual_desktop_worker_pane_recording')) { $reasons.Add('non_desktop_recording_status') | Out-Null }
+    if ($MessagingState -ne 'worker_to_worker_disabled') { $reasons.Add('worker_to_worker_messaging_not_disabled') | Out-Null }
+    if (-not (Test-NumericZero -Value $OperatorInterventionCount)) { $reasons.Add('operator_intervention_nonzero') | Out-Null }
+    if ($ExecutionSurface -ne 'visible_desktop_worker_panes') { $reasons.Add('non_desktop_execution_surface') | Out-Null }
     if (-not $EndMarkerPresent) { $reasons.Add('missing_end_marker') | Out-Null }
     if (-not $PacketHashMatch) { $reasons.Add('packet_hash_mismatch') | Out-Null }
     if ($StdoutEmpty) { $reasons.Add('empty_stdout') | Out-Null }
@@ -188,6 +209,9 @@ if (Test-Path -LiteralPath $resolvedRunRoot -PathType Container) {
                 packet_hash_match     = $false
                 stdout_empty          = $false
                 operator_run          = $false
+                messaging_state       = ''
+                operator_intervention_count = ''
+                execution_surface     = ''
                 scoreable             = $false
                 score_exclusion       = $manifestResult.error
                 axis_scores           = @{}
@@ -200,8 +224,12 @@ if (Test-Path -LiteralPath $resolvedRunRoot -PathType Container) {
         $taskClassValue = Get-ObjectProperty $manifest 'task_class' ''
         $recording = Get-ObjectProperty $manifest 'recording' $null
         $evidence = Get-ObjectProperty $manifest 'evidence' $null
+        $runGovernance = Get-ObjectProperty $manifest 'run_governance' $null
         $runId = if (-not [string]::IsNullOrWhiteSpace([string]$runIdValue)) { [string]$runIdValue } else { $dir.Name }
         $taskClass = if (-not [string]::IsNullOrWhiteSpace([string]$taskClassValue)) { [string]$taskClassValue } else { 'unknown' }
+        $messagingState = [string](Get-ObjectProperty $runGovernance 'messaging_state' '')
+        $operatorInterventionCount = Get-ObjectProperty $runGovernance 'operator_intervention_count' ''
+        $executionSurface = [string](Get-ObjectProperty $runGovernance 'execution_surface' '')
         $recordingStatusValue = Get-ObjectProperty $recording 'status' ''
         $recordingStatus = if (-not [string]::IsNullOrWhiteSpace([string]$recordingStatusValue)) { [string]$recordingStatusValue } else { 'not_declared' }
         $recordingPublishable = $false
@@ -263,6 +291,10 @@ if (Test-Path -LiteralPath $resolvedRunRoot -PathType Container) {
                 -EndMarkerPresent $endMarkerPresent `
                 -PacketHashMatch $packetHashMatch `
                 -StdoutEmpty $stdoutEmpty `
+                -RecordingStatus $recordingStatus `
+                -MessagingState $messagingState `
+                -OperatorInterventionCount $operatorInterventionCount `
+                -ExecutionSurface $executionSurface `
                 -OperatorRun $operatorRun `
                 -FailureClass ([string](Get-ObjectProperty $command 'failure_class' '')) `
                 -ExclusionReason ([string](Get-ObjectProperty $command 'exclusion_reason' '')) `
@@ -287,6 +319,9 @@ if (Test-Path -LiteralPath $resolvedRunRoot -PathType Container) {
                 packet_hash_match     = $packetHashMatch
                 stdout_empty          = $stdoutEmpty
                 operator_run          = $operatorRun
+                messaging_state       = $messagingState
+                operator_intervention_count = $operatorInterventionCount
+                execution_surface     = $executionSurface
                 scoreable             = $decision.scoreable
                 score_exclusion       = $decision.reason
                 axis_scores           = $axisScores
@@ -298,7 +333,7 @@ if (Test-Path -LiteralPath $resolvedRunRoot -PathType Container) {
 New-Item -ItemType Directory -Path $resolvedOutputDir -Force | Out-Null
 
 $csvLines = [System.Collections.Generic.List[string]]::new()
-$csvLines.Add('"run_id","cli","model","task_class","axis","score","verdict","recording_status","recording_publishable","score_exclusion"') | Out-Null
+$csvLines.Add('"run_id","cli","model","task_class","axis","score","verdict","recording_status","recording_publishable","score_exclusion","messaging_state","operator_intervention_count","execution_surface"') | Out-Null
 foreach ($run in $runs) {
     foreach ($axis in $allAxes) {
         $verdict = if ($run.scoreable) { 'scoreable' } elseif ($run.status -ne 'completed') { 'blocked' } else { 'evidence_incomplete' }
@@ -312,7 +347,10 @@ foreach ($run in $runs) {
             (ConvertTo-CsvCell $verdict),
             (ConvertTo-CsvCell $run.recording_status),
             (ConvertTo-CsvCell $run.recording_publishable),
-            (ConvertTo-CsvCell $run.score_exclusion)
+            (ConvertTo-CsvCell $run.score_exclusion),
+            (ConvertTo-CsvCell $run.messaging_state),
+            (ConvertTo-CsvCell $run.operator_intervention_count),
+            (ConvertTo-CsvCell $run.execution_surface)
         ) -join ',')) | Out-Null
     }
 }

--- a/scripts/test-cli-bakeoff-preflight.ps1
+++ b/scripts/test-cli-bakeoff-preflight.ps1
@@ -130,6 +130,81 @@ function Add-Check {
     $script:checks.Add([pscustomobject]@{ name = $Name; pass = $Pass; detail = (ConvertTo-SafeDetail $Detail) }) | Out-Null
 }
 
+function Test-JsonProperty {
+    param(
+        [AllowNull()][object]$InputObject,
+        [Parameter(Mandatory = $true)][string]$Name
+    )
+    return $null -ne $InputObject -and $InputObject.PSObject.Properties.Name -contains $Name
+}
+
+function Get-JsonProperty {
+    param(
+        [AllowNull()][object]$InputObject,
+        [Parameter(Mandatory = $true)][string]$Name,
+        [AllowNull()][object]$Default = $null
+    )
+    if (Test-JsonProperty -InputObject $InputObject -Name $Name) {
+        return $InputObject.$Name
+    }
+    return $Default
+}
+
+function Test-JsonBooleanTrue {
+    param([AllowNull()][object]$Value)
+
+    return $Value -is [bool] -and $Value
+}
+
+function Test-JsonNumericZero {
+    param([AllowNull()][object]$Value)
+
+    if ($null -eq $Value) {
+        return $false
+    }
+
+    if ($Value -is [string] -or $Value -is [char] -or $Value -is [bool]) {
+        return $false
+    }
+
+    $numericTypes = @(
+        'System.Byte',
+        'System.SByte',
+        'System.Int16',
+        'System.UInt16',
+        'System.Int32',
+        'System.UInt32',
+        'System.Int64',
+        'System.UInt64',
+        'System.Single',
+        'System.Double',
+        'System.Decimal'
+    )
+    if ($Value.GetType().FullName -notin $numericTypes) {
+        return $false
+    }
+
+    try {
+        return [decimal]$Value -eq 0
+    } catch {
+        return $false
+    }
+}
+
+function Test-ScoredWorker {
+    param([AllowNull()][object]$Worker)
+
+    if ($null -eq $Worker) {
+        return $false
+    }
+
+    if (Test-JsonProperty -InputObject $Worker -Name 'scored') {
+        return [bool]$Worker.scored
+    }
+
+    return $true
+}
+
 function Get-GitOutput {
     param([Parameter(Mandatory = $true)][string[]]$Arguments)
     try {
@@ -374,8 +449,12 @@ if ($null -ne $pack) {
     $requiredGates = @(
         'same_task_packet_sha256_for_all_workers',
         'same_timeout_for_all_workers',
+        'same_workspace_for_all_workers',
         'preflight_all_pass_before_recording',
         'desktop_app_screen_recording_required',
+        'operator_intervention_zero_required',
+        'worker_to_worker_messaging_disabled',
+        'run_governance_fields_required',
         'non_completed_worker_results_excluded_from_scoring',
         'antigravity_empty_stdout_excluded_from_machine_scoring',
         'harness_bench_27_tasks_required',
@@ -447,10 +526,54 @@ if ($null -ne $pack) {
     Add-Check 'operator role is declared' ($null -ne $operator)
     Add-Check 'operator is not scored' ($null -ne $operator -and -not [bool]$operator.scored)
 
+    $governance = Get-JsonProperty -InputObject $pack -Name 'run_governance' -Default $null
+    $sameTaskSetForAllWorkers = Get-JsonProperty -InputObject $governance -Name 'same_task_set_for_all_workers' -Default $null
+    $sameTimeoutForAllWorkers = Get-JsonProperty -InputObject $governance -Name 'same_timeout_for_all_workers' -Default $null
+    $sameWorkspaceForAllWorkers = Get-JsonProperty -InputObject $governance -Name 'same_workspace_for_all_workers' -Default $null
+    $workerToWorkerMessaging = Get-JsonProperty -InputObject $governance -Name 'worker_to_worker_messaging' -Default ''
+    $executionSurface = Get-JsonProperty -InputObject $governance -Name 'execution_surface' -Default ''
+    Add-Check 'run governance policy exists' ($null -ne $governance)
+    Add-Check 'run governance requires same task set' ($null -ne $governance -and (Test-JsonProperty -InputObject $governance -Name 'same_task_set_for_all_workers') -and (Test-JsonBooleanTrue -Value $sameTaskSetForAllWorkers))
+    Add-Check 'run governance requires same timeout' ($null -ne $governance -and (Test-JsonProperty -InputObject $governance -Name 'same_timeout_for_all_workers') -and (Test-JsonBooleanTrue -Value $sameTimeoutForAllWorkers))
+    Add-Check 'run governance requires same workspace' ($null -ne $governance -and (Test-JsonProperty -InputObject $governance -Name 'same_workspace_for_all_workers') -and (Test-JsonBooleanTrue -Value $sameWorkspaceForAllWorkers))
+    $operatorInterventionLimit = Get-JsonProperty -InputObject $governance -Name 'operator_intervention_limit' -Default $null
+    Add-Check 'operator intervention limit is zero' ($null -ne $governance -and (Test-JsonProperty -InputObject $governance -Name 'operator_intervention_limit') -and (Test-JsonNumericZero -Value $operatorInterventionLimit)) "limit=$operatorInterventionLimit"
+    Add-Check 'worker-to-worker messaging is disabled' ($null -ne $governance -and (Test-JsonProperty -InputObject $governance -Name 'worker_to_worker_messaging') -and [string]$workerToWorkerMessaging -eq 'disabled') "messaging=$workerToWorkerMessaging"
+    Add-Check 'execution surface is visible desktop worker panes' ($null -ne $governance -and (Test-JsonProperty -InputObject $governance -Name 'execution_surface') -and [string]$executionSurface -eq 'visible_desktop_worker_panes') "surface=$executionSurface"
+    $requiredRunFields = @('messaging_state', 'operator_intervention_count', 'execution_surface')
+    $declaredRunFields = if ($null -ne $governance) { @((Get-JsonProperty -InputObject $governance -Name 'required_run_fields' -Default @()) | ForEach-Object { [string]$_ }) } else { @() }
+    foreach ($field in $requiredRunFields) {
+        Add-Check "run governance field $field is required" ($declaredRunFields -contains $field) ($declaredRunFields -join ',')
+    }
+
     $workspacePolicy = $pack.workspace_policy
     Add-Check 'sanitized workspace policy exists' ($null -ne $workspacePolicy -and [bool]$workspacePolicy.sanitized_workspace_required)
     Add-Check 'same workspace conditions required' ($null -ne $workspacePolicy -and [bool]$workspacePolicy.same_workspace_conditions_for_all_workers)
     Add-Check 'default timeout is 3600 seconds' ([int]$pack.default_timeout_seconds -eq 3600) "timeout=$($pack.default_timeout_seconds)"
+    $scoredWorkersWithTaskOverrides = @($workers | Where-Object {
+        (Test-ScoredWorker -Worker $_) -and (
+            (Test-JsonProperty -InputObject $_ -Name 'task_ids') -or
+            (Test-JsonProperty -InputObject $_ -Name 'task_filter') -or
+            (Test-JsonProperty -InputObject $_ -Name 'tasks')
+        )
+    })
+    $scoredWorkersWithTimeoutOverrides = @($workers | Where-Object {
+        (Test-ScoredWorker -Worker $_) -and (Test-JsonProperty -InputObject $_ -Name 'timeout_seconds')
+    })
+    $scoredWorkersWithWorkspaceOverrides = @($workers | Where-Object {
+        (Test-ScoredWorker -Worker $_) -and (
+            (Test-JsonProperty -InputObject $_ -Name 'workspace') -or
+            (Test-JsonProperty -InputObject $_ -Name 'workspace_root') -or
+            (Test-JsonProperty -InputObject $_ -Name 'project_dir') -or
+            (Test-JsonProperty -InputObject $_ -Name 'worktree') -or
+            (Test-JsonProperty -InputObject $_ -Name 'worktree_root') -or
+            (Test-JsonProperty -InputObject $_ -Name 'worktree_path') -or
+            (Test-JsonProperty -InputObject $_ -Name 'worktree_dir')
+        )
+    })
+    Add-Check 'scored workers do not override task set' ($scoredWorkersWithTaskOverrides.Count -eq 0) ((@($scoredWorkersWithTaskOverrides | ForEach-Object { [string]$_.pane }) | Sort-Object) -join ',')
+    Add-Check 'scored workers do not override timeout' ($scoredWorkersWithTimeoutOverrides.Count -eq 0) ((@($scoredWorkersWithTimeoutOverrides | ForEach-Object { [string]$_.pane }) | Sort-Object) -join ',')
+    Add-Check 'scored workers do not override workspace' ($scoredWorkersWithWorkspaceOverrides.Count -eq 0) ((@($scoredWorkersWithWorkspaceOverrides | ForEach-Object { [string]$_.pane }) | Sort-Object) -join ',')
 
     $tasks = @($pack.tasks)
     $minimumTaskCount = [int]$pack.minimum_task_count_for_directional_findings
@@ -505,6 +628,32 @@ if (-not [string]::IsNullOrWhiteSpace($RunDir)) {
     Add-Check 'run dir exists' (Test-Path -LiteralPath $resolvedRunDir -PathType Container) $resolvedRunDir
     foreach ($requiredFile in @('manifest.json', 'commands.jsonl', 'scorecard.md')) {
         Add-Check "run file $requiredFile" (Test-Path -LiteralPath (Join-Path $resolvedRunDir $requiredFile) -PathType Leaf)
+    }
+
+    $manifestPath = Join-Path $resolvedRunDir 'manifest.json'
+    if (Test-Path -LiteralPath $manifestPath -PathType Leaf) {
+        try {
+            $manifest = Get-Content -LiteralPath $manifestPath -Raw -Encoding UTF8 | ConvertFrom-Json -Depth 80
+            $recording = Get-JsonProperty -InputObject $manifest -Name 'recording' -Default $null
+            $recordingStatus = [string](Get-JsonProperty -InputObject $recording -Name 'status' -Default '')
+            $recordingPublishable = Get-JsonProperty -InputObject $recording -Name 'publishable' -Default $false
+            $desktopRecordingStatuses = @(
+                'desktop_app_screen_recording',
+                'visible_desktop_worker_pane_recording',
+                'manual_desktop_worker_pane_recording'
+            )
+            $runGovernance = Get-JsonProperty -InputObject $manifest -Name 'run_governance' -Default $null
+            $runMessagingState = Get-JsonProperty -InputObject $runGovernance -Name 'messaging_state' -Default ''
+            $runExecutionSurface = Get-JsonProperty -InputObject $runGovernance -Name 'execution_surface' -Default ''
+            Add-Check 'run governance fields are disclosed' ($null -ne $runGovernance)
+            Add-Check 'run messaging state disables worker-to-worker' ($null -ne $runGovernance -and (Test-JsonProperty -InputObject $runGovernance -Name 'messaging_state') -and [string]$runMessagingState -eq 'worker_to_worker_disabled') "messaging_state=$runMessagingState"
+            $operatorInterventionCount = Get-JsonProperty -InputObject $runGovernance -Name 'operator_intervention_count' -Default $null
+            Add-Check 'run operator intervention count is zero' ($null -ne $runGovernance -and (Test-JsonProperty -InputObject $runGovernance -Name 'operator_intervention_count') -and (Test-JsonNumericZero -Value $operatorInterventionCount)) "operator_intervention_count=$operatorInterventionCount"
+            Add-Check 'run execution surface is visible desktop worker panes' ($null -ne $runGovernance -and (Test-JsonProperty -InputObject $runGovernance -Name 'execution_surface') -and [string]$runExecutionSurface -eq 'visible_desktop_worker_panes') "execution_surface=$runExecutionSurface"
+            Add-Check 'run recording evidence is publishable desktop worker pane evidence' ($null -ne $recording -and $desktopRecordingStatuses -contains $recordingStatus -and [bool]$recordingPublishable) "recording_status=$recordingStatus; publishable=$recordingPublishable"
+        } catch {
+            Add-Check 'run manifest is valid JSON' $false $manifestPath
+        }
     }
 }
 

--- a/tasks/cli-bakeoff/v1/benchmark-pack.json
+++ b/tasks/cli-bakeoff/v1/benchmark-pack.json
@@ -44,9 +44,13 @@
   "qc_gates": [
     "same_task_packet_sha256_for_all_workers",
     "same_timeout_for_all_workers",
+    "same_workspace_for_all_workers",
     "preflight_all_pass_before_recording",
     "desktop_app_screen_recording_required",
     "visible_worker_pane_required_for_every_scored_worker",
+    "operator_intervention_zero_required",
+    "worker_to_worker_messaging_disabled",
+    "run_governance_fields_required",
     "non_completed_worker_results_excluded_from_scoring",
     "antigravity_empty_stdout_excluded_from_machine_scoring",
     "harness_bench_27_tasks_required",
@@ -56,6 +60,19 @@
     "missing_key_timeout_crash_empty_stdout_invalid_output_excluded_from_scoring"
   ],
   "default_timeout_seconds": 3600,
+  "run_governance": {
+    "same_task_set_for_all_workers": true,
+    "same_timeout_for_all_workers": true,
+    "same_workspace_for_all_workers": true,
+    "operator_intervention_limit": 0,
+    "worker_to_worker_messaging": "disabled",
+    "execution_surface": "visible_desktop_worker_panes",
+    "required_run_fields": [
+      "messaging_state",
+      "operator_intervention_count",
+      "execution_surface"
+    ]
+  },
   "default_workers": [
     {
       "pane": "worker-1",

--- a/tests/CliBakeoff.Tests.ps1
+++ b/tests/CliBakeoff.Tests.ps1
@@ -12,6 +12,39 @@ Describe 'CLI bakeoff evidence harness' {
         $script:DesktopStartScript = Join-Path $script:RepoRoot 'scripts\start-cli-bakeoff-desktop.ps1'
         $script:SessionReadinessScript = Join-Path $script:RepoRoot 'scripts\test-v03623-session-readiness.ps1'
         $script:PackPath = Join-Path $script:RepoRoot 'tasks\cli-bakeoff\v1\benchmark-pack.json'
+
+        function Copy-TrackedBakeoffPack {
+            Get-Content -LiteralPath $script:PackPath -Raw -Encoding UTF8 | ConvertFrom-Json -Depth 80
+        }
+
+        function Write-PackFixture {
+            param(
+                [Parameter(Mandatory = $true)][object]$Pack,
+                [Parameter(Mandatory = $true)][string]$Name
+            )
+            $fixtureRoot = Join-Path $TestDrive $Name
+            New-Item -ItemType Directory -Path $fixtureRoot -Force | Out-Null
+            $fixturePath = Join-Path $fixtureRoot 'benchmark-pack.json'
+            $Pack | ConvertTo-Json -Depth 80 | Set-Content -LiteralPath $fixturePath -Encoding UTF8
+            return $fixturePath
+        }
+
+        function Invoke-PreflightFixture {
+            param(
+                [Parameter(Mandatory = $true)][string]$PackPath,
+                [string]$RunDir = ''
+            )
+            $taskRoot = Split-Path $script:PackPath -Parent
+            $args = @('-NoProfile', '-File', $script:PreflightScript, '-PackPath', $PackPath, '-TaskRoot', $taskRoot, '-Json')
+            if (-not [string]::IsNullOrWhiteSpace($RunDir)) {
+                $args += @('-RunDir', $RunDir)
+            }
+            $output = & pwsh @args 2>$null
+            return [pscustomobject]@{
+                ExitCode = $LASTEXITCODE
+                Result   = ($output | ConvertFrom-Json -Depth 80)
+            }
+        }
     }
 
     It 'validates the tracked bakeoff task pack' {
@@ -24,9 +57,300 @@ Describe 'CLI bakeoff evidence harness' {
         ($result.checks | Where-Object { $_.name -eq 'official Harness Bench task count is met' }).pass | Should -BeTrue
         ($result.checks | Where-Object { $_.name -eq 'default timeout is 3600 seconds' }).pass | Should -BeTrue
         ($result.checks | Where-Object { $_.name -eq 'operator is not scored' }).pass | Should -BeTrue
+        ($result.checks | Where-Object { $_.name -eq 'run governance requires same task set' }).pass | Should -BeTrue
+        ($result.checks | Where-Object { $_.name -eq 'scored workers do not override task set' }).pass | Should -BeTrue
+        ($result.checks | Where-Object { $_.name -eq 'scored workers do not override timeout' }).pass | Should -BeTrue
+        ($result.checks | Where-Object { $_.name -eq 'scored workers do not override workspace' }).pass | Should -BeTrue
+        ($result.checks | Where-Object { $_.name -eq 'operator intervention limit is zero' }).pass | Should -BeTrue
+        ($result.checks | Where-Object { $_.name -eq 'worker-to-worker messaging is disabled' }).pass | Should -BeTrue
+        ($result.checks | Where-Object { $_.name -eq 'run governance field messaging_state is required' }).pass | Should -BeTrue
+        ($result.checks | Where-Object { $_.name -eq 'run governance field operator_intervention_count is required' }).pass | Should -BeTrue
+        ($result.checks | Where-Object { $_.name -eq 'run governance field execution_surface is required' }).pass | Should -BeTrue
         ($result.checks | Where-Object { $_.name -eq 'OpenRouter Sakana Fugu Ultra worker profile exists' }).pass | Should -BeTrue
         ($result.checks | Where-Object { $_.name -eq 'OpenRouter GLM worker profile exists' }).pass | Should -BeTrue
         ($output -join "`n") | Should -Not -Match 'C:\\Users\\'
+    }
+
+    It 'rejects a scored operator in the benchmark pack' {
+        $pack = Copy-TrackedBakeoffPack
+        $pack.operator.scored = $true
+        $fixturePath = Write-PackFixture -Pack $pack -Name 'operator-scored-pack'
+
+        $result = Invoke-PreflightFixture -PackPath $fixturePath
+        $result.ExitCode | Should -Be 1
+        $result.Result.all_pass | Should -BeFalse
+        ($result.Result.checks | Where-Object { $_.name -eq 'operator is not scored' }).pass | Should -BeFalse
+    }
+
+    It 'rejects per-worker task timeout and workspace overrides' {
+        $pack = Copy-TrackedBakeoffPack
+        $pack.default_workers[0] | Add-Member -NotePropertyName task_ids -NotePropertyValue @('WB-001') -Force
+        $pack.default_workers[1] | Add-Member -NotePropertyName timeout_seconds -NotePropertyValue 1800 -Force
+        $pack.default_workers[2] | Add-Member -NotePropertyName workspace_root -NotePropertyValue 'different-workspace' -Force
+        $fixturePath = Write-PackFixture -Pack $pack -Name 'worker-override-pack'
+
+        $result = Invoke-PreflightFixture -PackPath $fixturePath
+        $result.ExitCode | Should -Be 1
+        ($result.Result.checks | Where-Object { $_.name -eq 'scored workers do not override task set' }).pass | Should -BeFalse
+        ($result.Result.checks | Where-Object { $_.name -eq 'scored workers do not override timeout' }).pass | Should -BeFalse
+        ($result.Result.checks | Where-Object { $_.name -eq 'scored workers do not override workspace' }).pass | Should -BeFalse
+    }
+
+    It 'rejects per-worker worktree workspace overrides' {
+        $pack = Copy-TrackedBakeoffPack
+        $pack.default_workers[0] | Add-Member -NotePropertyName worktree -NotePropertyValue 'worker-a' -Force
+        $pack.default_workers[1] | Add-Member -NotePropertyName worktree_path -NotePropertyValue 'C:\tmp\worker-b' -Force
+        $fixturePath = Write-PackFixture -Pack $pack -Name 'worker-worktree-override-pack'
+
+        $result = Invoke-PreflightFixture -PackPath $fixturePath
+        $result.ExitCode | Should -Be 1
+        ($result.Result.checks | Where-Object { $_.name -eq 'scored workers do not override workspace' }).pass | Should -BeFalse
+    }
+
+    It 'rejects overrides on workers that omit scored and are scoreable by default' {
+        $pack = Copy-TrackedBakeoffPack
+        $pack.default_workers[0].PSObject.Properties.Remove('scored')
+        $pack.default_workers[0] | Add-Member -NotePropertyName task_ids -NotePropertyValue @('WB-001') -Force
+        $fixturePath = Write-PackFixture -Pack $pack -Name 'worker-override-scored-default-pack'
+
+        $result = Invoke-PreflightFixture -PackPath $fixturePath
+        $result.ExitCode | Should -Be 1
+        ($result.Result.checks | Where-Object { $_.name -eq 'scored workers do not override task set' }).pass | Should -BeFalse
+    }
+
+    It 'rejects nonzero operator intervention in the benchmark governance policy' {
+        $pack = Copy-TrackedBakeoffPack
+        $pack.run_governance.operator_intervention_limit = 1
+        $fixturePath = Write-PackFixture -Pack $pack -Name 'operator-intervention-pack'
+
+        $result = Invoke-PreflightFixture -PackPath $fixturePath
+        $result.ExitCode | Should -Be 1
+        ($result.Result.checks | Where-Object { $_.name -eq 'operator intervention limit is zero' }).pass | Should -BeFalse
+    }
+
+    It 'rejects nonnumeric operator intervention limits in the benchmark governance policy' {
+        $pack = Copy-TrackedBakeoffPack
+        $pack.run_governance.operator_intervention_limit = $null
+        $nullFixturePath = Write-PackFixture -Pack $pack -Name 'operator-intervention-null-pack'
+
+        $nullResult = Invoke-PreflightFixture -PackPath $nullFixturePath
+        $nullResult.ExitCode | Should -Be 1
+        ($nullResult.Result.checks | Where-Object { $_.name -eq 'operator intervention limit is zero' }).pass | Should -BeFalse
+
+        $pack = Copy-TrackedBakeoffPack
+        $pack.run_governance.operator_intervention_limit = ''
+        $blankFixturePath = Write-PackFixture -Pack $pack -Name 'operator-intervention-blank-pack'
+
+        $blankResult = Invoke-PreflightFixture -PackPath $blankFixturePath
+        $blankResult.ExitCode | Should -Be 1
+        ($blankResult.Result.checks | Where-Object { $_.name -eq 'operator intervention limit is zero' }).pass | Should -BeFalse
+    }
+
+    It 'rejects worker-to-worker messaging in the benchmark governance policy' {
+        $pack = Copy-TrackedBakeoffPack
+        $pack.run_governance.worker_to_worker_messaging = 'enabled'
+        $fixturePath = Write-PackFixture -Pack $pack -Name 'worker-messaging-pack'
+
+        $result = Invoke-PreflightFixture -PackPath $fixturePath
+        $result.ExitCode | Should -Be 1
+        ($result.Result.checks | Where-Object { $_.name -eq 'worker-to-worker messaging is disabled' }).pass | Should -BeFalse
+    }
+
+    It 'reports missing governance policy fields as structured preflight failures' {
+        $pack = Copy-TrackedBakeoffPack
+        $pack.PSObject.Properties.Remove('run_governance')
+        $missingPolicyPath = Write-PackFixture -Pack $pack -Name 'missing-governance-policy-pack'
+
+        $missingPolicyResult = Invoke-PreflightFixture -PackPath $missingPolicyPath
+        $missingPolicyResult.ExitCode | Should -Be 1
+        $missingPolicyResult.Result.all_pass | Should -BeFalse
+        ($missingPolicyResult.Result.checks | Where-Object { $_.name -eq 'run governance policy exists' }).pass | Should -BeFalse
+
+        $pack = Copy-TrackedBakeoffPack
+        $pack.run_governance.PSObject.Properties.Remove('same_task_set_for_all_workers')
+        $pack.run_governance.PSObject.Properties.Remove('same_timeout_for_all_workers')
+        $pack.run_governance.PSObject.Properties.Remove('same_workspace_for_all_workers')
+        $missingBooleanPath = Write-PackFixture -Pack $pack -Name 'missing-governance-booleans-pack'
+
+        $missingBooleanResult = Invoke-PreflightFixture -PackPath $missingBooleanPath
+        $missingBooleanResult.ExitCode | Should -Be 1
+        $missingBooleanResult.Result.all_pass | Should -BeFalse
+        ($missingBooleanResult.Result.checks | Where-Object { $_.name -eq 'run governance requires same task set' }).pass | Should -BeFalse
+        ($missingBooleanResult.Result.checks | Where-Object { $_.name -eq 'run governance requires same timeout' }).pass | Should -BeFalse
+        ($missingBooleanResult.Result.checks | Where-Object { $_.name -eq 'run governance requires same workspace' }).pass | Should -BeFalse
+    }
+
+    It 'rejects non-boolean governance invariants in the benchmark policy' {
+        $pack = Copy-TrackedBakeoffPack
+        $pack.run_governance.same_task_set_for_all_workers = 'false'
+        $pack.run_governance.same_timeout_for_all_workers = 'false'
+        $pack.run_governance.same_workspace_for_all_workers = 'false'
+        $fixturePath = Write-PackFixture -Pack $pack -Name 'string-governance-booleans-pack'
+
+        $result = Invoke-PreflightFixture -PackPath $fixturePath
+        $result.ExitCode | Should -Be 1
+        $result.Result.all_pass | Should -BeFalse
+        ($result.Result.checks | Where-Object { $_.name -eq 'run governance requires same task set' }).pass | Should -BeFalse
+        ($result.Result.checks | Where-Object { $_.name -eq 'run governance requires same timeout' }).pass | Should -BeFalse
+        ($result.Result.checks | Where-Object { $_.name -eq 'run governance requires same workspace' }).pass | Should -BeFalse
+    }
+
+    It 'validates run governance disclosure fields for a completed run directory' {
+        $runDir = Join-Path $TestDrive 'governed-run'
+        New-Item -ItemType Directory -Path $runDir -Force | Out-Null
+        Set-Content -LiteralPath (Join-Path $runDir 'manifest.json') -Value @'
+{
+  "version": 1,
+  "run_id": "governed-run",
+  "task_class": "readonly_diagnostic",
+  "recording": {
+    "status": "visible_desktop_worker_pane_recording",
+    "publishable": true
+  },
+  "run_governance": {
+    "messaging_state": "worker_to_worker_disabled",
+    "operator_intervention_count": 0,
+    "execution_surface": "visible_desktop_worker_panes"
+  }
+}
+'@ -Encoding UTF8
+        Set-Content -LiteralPath (Join-Path $runDir 'commands.jsonl') -Value @'
+{"cli":"Codex","model":"gpt-5.5","status":"completed","end_marker_present":true,"packet_hash_match":true,"stdout_empty":false}
+'@ -Encoding UTF8
+        Set-Content -LiteralPath (Join-Path $runDir 'scorecard.md') -Value '# Scorecard' -Encoding UTF8
+
+        $result = Invoke-PreflightFixture -PackPath $script:PackPath -RunDir $runDir
+        $result.ExitCode | Should -Be 0
+        ($result.Result.checks | Where-Object { $_.name -eq 'run governance fields are disclosed' }).pass | Should -BeTrue
+        ($result.Result.checks | Where-Object { $_.name -eq 'run operator intervention count is zero' }).pass | Should -BeTrue
+        ($result.Result.checks | Where-Object { $_.name -eq 'run messaging state disables worker-to-worker' }).pass | Should -BeTrue
+        ($result.Result.checks | Where-Object { $_.name -eq 'run execution surface is visible desktop worker panes' }).pass | Should -BeTrue
+        ($result.Result.checks | Where-Object { $_.name -eq 'run recording evidence is publishable desktop worker pane evidence' }).pass | Should -BeTrue
+    }
+
+    It 'rejects run governance disclosure violations in a run directory' {
+        $runDir = Join-Path $TestDrive 'bad-governed-run'
+        New-Item -ItemType Directory -Path $runDir -Force | Out-Null
+        Set-Content -LiteralPath (Join-Path $runDir 'manifest.json') -Value @'
+{
+  "version": 1,
+  "run_id": "bad-governed-run",
+  "task_class": "readonly_diagnostic",
+  "recording": {
+    "status": "api_worker_redacted_artifact",
+    "publishable": true
+  },
+  "run_governance": {
+    "messaging_state": "worker_to_worker_enabled",
+    "operator_intervention_count": 1,
+    "execution_surface": "hidden_batch_runner"
+  }
+}
+'@ -Encoding UTF8
+        Set-Content -LiteralPath (Join-Path $runDir 'commands.jsonl') -Value @'
+{"cli":"Codex","model":"gpt-5.5","status":"completed","end_marker_present":true,"packet_hash_match":true,"stdout_empty":false}
+'@ -Encoding UTF8
+        Set-Content -LiteralPath (Join-Path $runDir 'scorecard.md') -Value '# Scorecard' -Encoding UTF8
+
+        $result = Invoke-PreflightFixture -PackPath $script:PackPath -RunDir $runDir
+        $result.ExitCode | Should -Be 1
+        ($result.Result.checks | Where-Object { $_.name -eq 'run messaging state disables worker-to-worker' }).pass | Should -BeFalse
+        ($result.Result.checks | Where-Object { $_.name -eq 'run operator intervention count is zero' }).pass | Should -BeFalse
+        ($result.Result.checks | Where-Object { $_.name -eq 'run execution surface is visible desktop worker panes' }).pass | Should -BeFalse
+        ($result.Result.checks | Where-Object { $_.name -eq 'run recording evidence is publishable desktop worker pane evidence' }).pass | Should -BeFalse
+    }
+
+    It 'reports missing run governance fields as structured run directory failures' {
+        $runDir = Join-Path $TestDrive 'missing-run-governance-fields'
+        New-Item -ItemType Directory -Path $runDir -Force | Out-Null
+        Set-Content -LiteralPath (Join-Path $runDir 'manifest.json') -Value @'
+{
+  "version": 1,
+  "run_id": "missing-run-governance-fields",
+  "task_class": "readonly_diagnostic",
+  "recording": {
+    "status": "visible_desktop_worker_pane_recording",
+    "publishable": true
+  },
+  "run_governance": {
+    "operator_intervention_count": 0
+  }
+}
+'@ -Encoding UTF8
+        Set-Content -LiteralPath (Join-Path $runDir 'commands.jsonl') -Value @'
+{"cli":"Codex","model":"gpt-5.5","status":"completed","end_marker_present":true,"packet_hash_match":true,"stdout_empty":false}
+'@ -Encoding UTF8
+        Set-Content -LiteralPath (Join-Path $runDir 'scorecard.md') -Value '# Scorecard' -Encoding UTF8
+
+        $result = Invoke-PreflightFixture -PackPath $script:PackPath -RunDir $runDir
+        $result.ExitCode | Should -Be 1
+        ($result.Result.checks | Where-Object { $_.name -eq 'run governance fields are disclosed' }).pass | Should -BeTrue
+        ($result.Result.checks | Where-Object { $_.name -eq 'run messaging state disables worker-to-worker' }).pass | Should -BeFalse
+        ($result.Result.checks | Where-Object { $_.name -eq 'run operator intervention count is zero' }).pass | Should -BeTrue
+        ($result.Result.checks | Where-Object { $_.name -eq 'run execution surface is visible desktop worker panes' }).pass | Should -BeFalse
+    }
+
+    It 'rejects API artifact evidence that claims the visible desktop worker pane surface' {
+        $runDir = Join-Path $TestDrive 'contradictory-api-run'
+        New-Item -ItemType Directory -Path $runDir -Force | Out-Null
+        Set-Content -LiteralPath (Join-Path $runDir 'manifest.json') -Value @'
+{
+  "version": 1,
+  "run_id": "contradictory-api-run",
+  "task_class": "readonly_diagnostic",
+  "recording": {
+    "status": "api_worker_redacted_artifact",
+    "publishable": true
+  },
+  "run_governance": {
+    "messaging_state": "worker_to_worker_disabled",
+    "operator_intervention_count": 0,
+    "execution_surface": "visible_desktop_worker_panes"
+  }
+}
+'@ -Encoding UTF8
+        Set-Content -LiteralPath (Join-Path $runDir 'commands.jsonl') -Value @'
+{"cli":"Codex","model":"gpt-5.5","status":"completed","end_marker_present":true,"packet_hash_match":true,"stdout_empty":false}
+'@ -Encoding UTF8
+        Set-Content -LiteralPath (Join-Path $runDir 'scorecard.md') -Value '# Scorecard' -Encoding UTF8
+
+        $result = Invoke-PreflightFixture -PackPath $script:PackPath -RunDir $runDir
+        $result.ExitCode | Should -Be 1
+        ($result.Result.checks | Where-Object { $_.name -eq 'run messaging state disables worker-to-worker' }).pass | Should -BeTrue
+        ($result.Result.checks | Where-Object { $_.name -eq 'run operator intervention count is zero' }).pass | Should -BeTrue
+        ($result.Result.checks | Where-Object { $_.name -eq 'run execution surface is visible desktop worker panes' }).pass | Should -BeTrue
+        ($result.Result.checks | Where-Object { $_.name -eq 'run recording evidence is publishable desktop worker pane evidence' }).pass | Should -BeFalse
+    }
+
+    It 'rejects nonnumeric operator intervention counts in a run directory' {
+        $runDir = Join-Path $TestDrive 'bad-count-run'
+        New-Item -ItemType Directory -Path $runDir -Force | Out-Null
+        Set-Content -LiteralPath (Join-Path $runDir 'manifest.json') -Value @'
+{
+  "version": 1,
+  "run_id": "bad-count-run",
+  "task_class": "readonly_diagnostic",
+  "recording": {
+    "status": "visible_desktop_worker_pane_recording",
+    "publishable": true
+  },
+  "run_governance": {
+    "messaging_state": "worker_to_worker_disabled",
+    "operator_intervention_count": "",
+    "execution_surface": "visible_desktop_worker_panes"
+  }
+}
+'@ -Encoding UTF8
+        Set-Content -LiteralPath (Join-Path $runDir 'commands.jsonl') -Value @'
+{"cli":"Codex","model":"gpt-5.5","status":"completed","end_marker_present":true,"packet_hash_match":true,"stdout_empty":false}
+'@ -Encoding UTF8
+        Set-Content -LiteralPath (Join-Path $runDir 'scorecard.md') -Value '# Scorecard' -Encoding UTF8
+
+        $result = Invoke-PreflightFixture -PackPath $script:PackPath -RunDir $runDir
+        $result.ExitCode | Should -Be 1
+        ($result.Result.checks | Where-Object { $_.name -eq 'run messaging state disables worker-to-worker' }).pass | Should -BeTrue
+        ($result.Result.checks | Where-Object { $_.name -eq 'run operator intervention count is zero' }).pass | Should -BeFalse
+        ($result.Result.checks | Where-Object { $_.name -eq 'run execution surface is visible desktop worker panes' }).pass | Should -BeTrue
     }
 
     It 'resolves the benchmark pack when given the repository root' {
@@ -823,8 +1147,13 @@ BAKEOFF_ROUND_A_END
   "run_id": "sample-run",
   "task_class": "readonly_diagnostic",
   "recording": {
-    "status": "publishable",
+    "status": "visible_desktop_worker_pane_recording",
     "publishable": true
+  },
+  "run_governance": {
+    "messaging_state": "worker_to_worker_disabled",
+    "operator_intervention_count": 0,
+    "execution_surface": "visible_desktop_worker_panes"
   },
   "active_workers": [
     {
@@ -855,6 +1184,76 @@ BAKEOFF_ROUND_A_END
         $combined | Should -Match '"overall","100","scoreable"'
         $combined | Should -Not -Match [regex]::Escape($TestDrive)
         $combined | Should -Not -Match '[A-Za-z]:\\Users\\'
+    }
+
+    It 'excludes non-desktop governance surfaces from model scoring' {
+        $runRoot = Join-Path $TestDrive 'runs-nondesktop'
+        $runDir = Join-Path $runRoot 'api-batch-run'
+        $outputDir = Join-Path $TestDrive 'summary-nondesktop'
+        New-Item -ItemType Directory -Path $runDir -Force | Out-Null
+        Set-Content -LiteralPath (Join-Path $runDir 'manifest.json') -Value @'
+{
+  "version": 1,
+  "run_id": "api-batch-run",
+  "task_class": "readonly_diagnostic",
+  "recording": {
+    "status": "api_worker_redacted_artifact",
+    "publishable": true
+  },
+  "run_governance": {
+    "messaging_state": "worker_to_worker_disabled",
+    "operator_intervention_count": 0,
+    "execution_surface": "api_worker_batch"
+  }
+}
+'@ -Encoding UTF8
+        Set-Content -LiteralPath (Join-Path $runDir 'commands.jsonl') -Value @'
+{"cli":"OpenRouter API","model":"OpenRouter / GLM-5.2","status":"completed","end_marker_present":true,"packet_hash_match":true,"stdout_empty":false}
+'@ -Encoding UTF8
+
+        $output = & pwsh -NoProfile -File $script:SummaryScript -RunRoot $runRoot -OutputDir $outputDir -PackPath $script:PackPath -Json
+        $LASTEXITCODE | Should -Be 0
+        $result = $output | ConvertFrom-Json -Depth 20
+        $result.scoreable_runs | Should -Be 0
+
+        $raw = Get-Content -LiteralPath (Join-Path $outputDir 'raw-score-matrix.csv') -Raw -Encoding UTF8
+        $raw | Should -Match 'non_desktop_execution_surface'
+        $raw | Should -Match 'api_worker_batch'
+    }
+
+    It 'excludes non-desktop recording statuses from model scoring' {
+        $runRoot = Join-Path $TestDrive 'runs-nondesktop-recording'
+        $runDir = Join-Path $runRoot 'api-recording-run'
+        $outputDir = Join-Path $TestDrive 'summary-nondesktop-recording'
+        New-Item -ItemType Directory -Path $runDir -Force | Out-Null
+        Set-Content -LiteralPath (Join-Path $runDir 'manifest.json') -Value @'
+{
+  "version": 1,
+  "run_id": "api-recording-run",
+  "task_class": "readonly_diagnostic",
+  "recording": {
+    "status": "api_worker_redacted_artifact",
+    "publishable": true
+  },
+  "run_governance": {
+    "messaging_state": "worker_to_worker_disabled",
+    "operator_intervention_count": 0,
+    "execution_surface": "visible_desktop_worker_panes"
+  }
+}
+'@ -Encoding UTF8
+        Set-Content -LiteralPath (Join-Path $runDir 'commands.jsonl') -Value @'
+{"cli":"OpenRouter API","model":"OpenRouter / GLM-5.2","status":"completed","end_marker_present":true,"packet_hash_match":true,"stdout_empty":false}
+'@ -Encoding UTF8
+
+        $output = & pwsh -NoProfile -File $script:SummaryScript -RunRoot $runRoot -OutputDir $outputDir -PackPath $script:PackPath -Json
+        $LASTEXITCODE | Should -Be 0
+        $result = $output | ConvertFrom-Json -Depth 20
+        $result.scoreable_runs | Should -Be 0
+
+        $raw = Get-Content -LiteralPath (Join-Path $outputDir 'raw-score-matrix.csv') -Raw -Encoding UTF8
+        $raw | Should -Match 'non_desktop_recording_status'
+        $raw | Should -Match 'api_worker_redacted_artifact'
     }
 
     It 'excludes incomplete scoreability evidence from model scoring' {

--- a/winsmux-app/scripts/bakeoff-runner-check.mjs
+++ b/winsmux-app/scripts/bakeoff-runner-check.mjs
@@ -13,6 +13,7 @@ import {
   buildReadyCheckCommand,
   buildDispatchCommand,
   resolveTaskSelection,
+  isOfficialTaskSelection,
   buildRunId,
   mapRunnerStatusToCommandStatus,
   buildRunManifest,
@@ -333,6 +334,16 @@ assert.deepEqual(
   { taskIds: ["WB-001"], unknown: [] },
   "resolveTaskSelection must de-duplicate repeated requested ids",
 );
+assert.equal(
+  isOfficialTaskSelection(["WB-003", "WB-001", "WB-002"], allTaskIds),
+  true,
+  "isOfficialTaskSelection must accept an explicit full-task selection regardless of order",
+);
+assert.equal(
+  isOfficialTaskSelection(["WB-001", "WB-002"], allTaskIds),
+  false,
+  "isOfficialTaskSelection must reject partial task selections",
+);
 
 // --- getPacketMarkers -----------------------------------------------------
 
@@ -458,6 +469,15 @@ assert.deepEqual(manifestObj.recording, { status: "not_declared", publishable: f
 assert.equal(manifestObj.evidence.end_marker_present, true, "buildRunManifest must set evidence.end_marker_present from input");
 assert.equal(manifestObj.evidence.packet_hash_match, false, "buildRunManifest must default packet_hash_match to false when not passed true");
 assert.equal(manifestObj.execution.status, "completed", "buildRunManifest must set execution.status from input");
+assert.deepEqual(
+  manifestObj.run_governance,
+  {
+    messaging_state: "worker_to_worker_disabled",
+    operator_intervention_count: 0,
+    execution_surface: "visible_desktop_worker_panes",
+  },
+  "buildRunManifest must disclose run governance fields for external audit",
+);
 assert.equal(manifestObj.active_workers.length, 1, "buildRunManifest must carry through active_workers array");
 
 const manifestHashTrue = buildRunManifest({
@@ -472,7 +492,19 @@ assert.equal(manifestDefaults.task_class, "unknown", "buildRunManifest must defa
 assert.equal(manifestDefaults.recording.status, "not_declared", "buildRunManifest must default recording.status to not_declared");
 assert.equal(manifestDefaults.recording.publishable, false, "buildRunManifest must default recording.publishable to false");
 assert.equal(manifestDefaults.execution.status, "unknown", "buildRunManifest must default execution.status to unknown");
+assert.equal(manifestDefaults.run_governance.operator_intervention_count, 0, "buildRunManifest must default operator_intervention_count to zero");
 assert.deepEqual(manifestDefaults.active_workers, [], "buildRunManifest must default active_workers to an empty array");
+
+const partialManifest = buildRunManifest({
+  runId: "partial",
+  taskId: "WB-001",
+  scoreableGovernance: false,
+});
+assert.equal(
+  partialManifest.run_governance.execution_surface,
+  "partial_visible_desktop_worker_panes",
+  "buildRunManifest must withhold scoreable execution_surface for partial or custom desktop runs",
+);
 
 // --- buildCommandRow ----------------------------------------------------
 

--- a/winsmux-app/scripts/bakeoff-runner-lib.mjs
+++ b/winsmux-app/scripts/bakeoff-runner-lib.mjs
@@ -539,6 +539,22 @@ export function resolveTaskSelection(allTaskIds, requested) {
 }
 
 /**
+ * True when the resolved task selection contains the complete official task set,
+ * regardless of the order requested on the command line.
+ *
+ * @param {string[]} taskIds
+ * @param {string[]} allTaskIds
+ * @returns {boolean}
+ */
+export function isOfficialTaskSelection(taskIds, allTaskIds) {
+  if (!Array.isArray(taskIds) || !Array.isArray(allTaskIds) || taskIds.length !== allTaskIds.length) {
+    return false;
+  }
+  const selected = new Set(taskIds);
+  return selected.size === allTaskIds.length && allTaskIds.every((id) => selected.has(id));
+}
+
+/**
  * Build a filesystem-safe, deterministic run_id for a single dispatched
  * task's summarize-compatible run directory, derived from the runner run
  * timestamp (already filesystem-safe, e.g. "runner-20260703T041530Z") and the
@@ -596,7 +612,7 @@ export function mapRunnerStatusToCommandStatus(runnerStatus) {
  * Build the summarize-compatible manifest.json object for one dispatched
  * task's run directory, mirroring the field shapes written by
  * run-cli-bakeoff-openrouter.ps1's final manifest (run_id, task_class,
- * recording, evidence, active_workers, execution) as read by
+ * recording, evidence, active_workers, execution, run_governance) as read by
  * summarize-cli-bakeoff.ps1 (lines ~160-260).
  *
  * cli/model metadata is not knowable to this runner today: worker rows are
@@ -626,6 +642,7 @@ export function mapRunnerStatusToCommandStatus(runnerStatus) {
  *   recordingPublishable: boolean,
  *   executionStatus: string,
  *   generatedAtIso: string,
+ *   scoreableGovernance: boolean,
  * }} input
  * @returns {object}
  */
@@ -641,7 +658,11 @@ export function buildRunManifest(input) {
     recordingPublishable,
     executionStatus,
     generatedAtIso,
+    scoreableGovernance = true,
   } = input || {};
+  const governanceExecutionSurface = scoreableGovernance
+    ? "visible_desktop_worker_panes"
+    : "partial_visible_desktop_worker_panes";
 
   return {
     run_id: runId,
@@ -666,6 +687,11 @@ export function buildRunManifest(input) {
     },
     execution: {
       status: executionStatus || "unknown",
+    },
+    run_governance: {
+      messaging_state: "worker_to_worker_disabled",
+      operator_intervention_count: 0,
+      execution_surface: governanceExecutionSurface,
     },
   };
 }

--- a/winsmux-app/scripts/run-cli-bakeoff.mjs
+++ b/winsmux-app/scripts/run-cli-bakeoff.mjs
@@ -94,6 +94,7 @@ import {
   buildReadyCheckCommand,
   buildDispatchCommand,
   resolveTaskSelection,
+  isOfficialTaskSelection,
   buildRunId,
   mapRunnerStatusToCommandStatus,
   buildRunManifest,
@@ -522,7 +523,8 @@ async function main() {
 
   const pack = JSON.parse(packText);
   const allTaskIds = pack.tasks.map((t) => t.task_id);
-  const defaultTimeout = args.timeout || pack.default_timeout_seconds || 3600;
+  const packDefaultTimeout = Number(pack.default_timeout_seconds || 3600);
+  const defaultTimeout = args.timeout || packDefaultTimeout;
   const { taskIds, unknown } = resolveTaskSelection(allTaskIds, args.tasks);
   if (unknown.length > 0) {
     console.error(`run-cli-bakeoff: ignoring unknown task ids: ${unknown.join(", ")}`);
@@ -531,6 +533,7 @@ async function main() {
     console.error("run-cli-bakeoff: no valid task ids to run");
     process.exit(EXIT_BAD_ARGS);
   }
+  const scoreableGovernance = isOfficialTaskSelection(taskIds, allTaskIds) && defaultTimeout === packDefaultTimeout;
 
   // paneIds is informational only now (manifest pane_id roster for
   // logging/commands.jsonl metadata) -- it is never used to address a
@@ -721,6 +724,7 @@ async function main() {
       recordingPublishable: args.recordingPublishable,
       executionStatus,
       generatedAtIso: nowIso(),
+      scoreableGovernance,
     });
     const commandRows = WORKER_LABELS.map((w) => buildCommandRow({
       worker: w,


### PR DESCRIPTION
## Summary

Implements the TASK-723 preflight fairness guards for the CLI bakeoff before v0.36.24 release prep.

## Changes

- Add benchmark-pack governance requirements for shared task set, timeout, workspace, zero operator intervention, disabled worker-to-worker messaging, and disclosed run fields.
- Extend `scripts/test-cli-bakeoff-preflight.ps1` to reject per-worker task/timeout/workspace overrides, nonnumeric intervention values, non-desktop official evidence, and missing run governance disclosure.
- Emit and summarize run governance fields in the OpenRouter, local worker, and desktop runner paths.
- Document that app-external batch outputs are reference evidence only, not official scoreable desktop worker-pane evidence.
- Add Pester coverage for accepted and rejected governance states.

## Validation

- `pwsh -NoProfile -File scripts/test-cli-bakeoff-preflight.ps1 -Json`
- `Import-Module Pester -MinimumVersion 5.0; Invoke-Pester -Path tests\CliBakeoff.Tests.ps1 -PassThru`
- `npm run test:bakeoff-runner --prefix winsmux-app`
- `pwsh -NoProfile -File scripts/audit-public-surface.ps1`
- `pwsh -NoProfile -File scripts/git-guard.ps1 -Mode full`
- `git diff --cached --check`

## Review

- Local reviewer pass recorded through `winsmux review-approve` for `codex/task-723-bench-preflight-fairness`.
