### PR TITLE
test(core): add common contract compatibility fixtures

### DIFF
--- a/core/tests-rs/common_contract.rs
+++ b/core/tests-rs/common_contract.rs
@@ -11,14 +11,90 @@ fn fixture_value() -> Value {
     .expect("fixture should be valid JSON")
 }
 
+fn versioned_fixture_value() -> Value {
+    serde_json::from_str(include_str!(
+        "../../tests/fixtures/rust-parity/common-contract-package-v0.36.25.json"
+    ))
+    .expect("versioned fixture should be valid JSON")
+}
+
+fn previous_fixture_value() -> Value {
+    serde_json::from_str(include_str!(
+        "../../tests/fixtures/rust-parity/common-contract-package-v0.36.24.json"
+    ))
+    .expect("previous fixture should be valid JSON")
+}
+
 fn parse_value(value: Value) -> CommonContractPackage {
     CommonContractPackage::from_json(&value.to_string()).expect("contract should parse")
+}
+
+fn parse_error(value: Value) -> String {
+    CommonContractPackage::from_json(&value.to_string())
+        .expect_err("contract should fail to parse")
+        .to_string()
 }
 
 #[test]
 fn common_contract_fixture_deserializes_and_validates() {
     let contract = parse_value(fixture_value());
     contract.validate().expect("contract should validate");
+}
+
+#[test]
+fn common_contract_versioned_fixture_matches_baseline() {
+    assert_eq!(versioned_fixture_value(), fixture_value());
+    let contract = parse_value(versioned_fixture_value());
+    contract
+        .validate()
+        .expect("versioned contract fixture should validate");
+}
+
+#[test]
+fn common_contract_previous_fixture_only_differs_by_version() {
+    let mut previous = previous_fixture_value();
+    let current = versioned_fixture_value();
+    previous["version"] = current["version"].clone();
+    assert_eq!(previous, current);
+}
+
+#[test]
+fn common_contract_rejects_previous_version_without_migration() {
+    let contract = parse_value(previous_fixture_value());
+    let error = contract
+        .validate()
+        .expect_err("previous version must not migrate implicitly");
+    assert!(error.contains("unsupported common contract version: 0.36.24"));
+}
+
+#[test]
+fn common_contract_rejects_unknown_top_level_field() {
+    let mut fixture = fixture_value();
+    fixture["unexpected"] = json!(true);
+    let error = parse_error(fixture);
+    assert!(error.contains("unknown field"));
+    assert!(error.contains("unexpected"));
+}
+
+#[test]
+fn common_contract_rejects_unknown_vocabulary_collection() {
+    let mut fixture = fixture_value();
+    fixture["vocabularies"]["unexpectedVocabulary"] = json!({
+        "owner": "tests",
+        "values": ["unexpected"]
+    });
+    let error = parse_error(fixture);
+    assert!(error.contains("unknown field"));
+    assert!(error.contains("unexpectedVocabulary"));
+}
+
+#[test]
+fn common_contract_rejects_unknown_vocabulary_field() {
+    let mut fixture = fixture_value();
+    fixture["vocabularies"]["modelReadiness"]["unexpected"] = json!("field");
+    let error = parse_error(fixture);
+    assert!(error.contains("unknown field"));
+    assert!(error.contains("unexpected"));
 }
 
 #[test]

--- a/tests/fixtures/rust-parity/common-contract-package-v0.36.24.json
+++ b/tests/fixtures/rust-parity/common-contract-package-v0.36.24.json
@@ -1,0 +1,113 @@
+{
+  "version": "0.36.24",
+  "surfaces": [
+    "provider",
+    "readiness",
+    "manifest",
+    "route",
+    "capsule",
+    "mailbox",
+    "settings"
+  ],
+  "vocabularies": {
+    "runtimeProviderIds": {
+      "owner": "winsmux-app/src/modelCapabilities.ts",
+      "values": [
+        "provider-default",
+        "codex",
+        "claude",
+        "antigravity",
+        "grok-build",
+        "openrouter"
+      ]
+    },
+    "modelSources": {
+      "owner": "winsmux-app/src/modelCapabilities.ts",
+      "values": [
+        "provider-default",
+        "cli-discovery",
+        "provider-api",
+        "official-doc",
+        "operator-override"
+      ]
+    },
+    "reasoningEfforts": {
+      "owner": "winsmux-app/src/modelCapabilities.ts",
+      "values": [
+        "provider-default",
+        "low",
+        "medium",
+        "high",
+        "max",
+        "xhigh"
+      ]
+    },
+    "backendCapabilities": {
+      "owner": "winsmux-app/src/modelCapabilities.ts",
+      "values": [
+        "any",
+        "agent-cli",
+        "antigravity",
+        "api_llm",
+        "colab_cli"
+      ],
+      "note": "Capability categories, not concrete worker_backend values."
+    },
+    "promptTransports": {
+      "owner": "winsmux-app/src/modelCapabilities.ts",
+      "values": [
+        "argv",
+        "file",
+        "stdin"
+      ]
+    },
+    "modelReadiness": {
+      "owner": "winsmux-app/src/modelCapabilities.ts",
+      "values": [
+        "selectable",
+        "candidate",
+        "setup-required",
+        "runnable",
+        "blocked",
+        "reference-only",
+        "unavailable"
+      ],
+      "note": "Model availability vocabulary. Do not merge with worker pane readiness."
+    },
+    "runtimeWorkerReadiness": {
+      "owner": "winsmux-app/src/main.ts",
+      "values": [
+        "runnable",
+        "setup-required",
+        "blocked"
+      ],
+      "note": "Startability summary derived from model availability plus credential/backend state."
+    },
+    "workerPaneReadiness": {
+      "owner": "winsmux-app/src/main.ts",
+      "values": [
+        "ready",
+        "blocked",
+        "pending"
+      ],
+      "note": "Pane idle-state vocabulary. Do not merge with model availability."
+    },
+    "agentVaultCommandProviders": {
+      "owner": "winsmux-app/src/main.ts",
+      "values": [
+        "claude",
+        "codex",
+        "opencode"
+      ],
+      "note": "Command-provider vocabulary kept separate from runtime provider IDs."
+    },
+    "benchmarkFamilies": {
+      "owner": "winsmux-app/src/modelCapabilities.ts",
+      "values": [
+        "agent-arena",
+        "code-arena",
+        "winsmux-local"
+      ]
+    }
+  }
+}

--- a/tests/fixtures/rust-parity/common-contract-package-v0.36.25.json
+++ b/tests/fixtures/rust-parity/common-contract-package-v0.36.25.json
@@ -1,0 +1,113 @@
+{
+  "version": "0.36.25",
+  "surfaces": [
+    "provider",
+    "readiness",
+    "manifest",
+    "route",
+    "capsule",
+    "mailbox",
+    "settings"
+  ],
+  "vocabularies": {
+    "runtimeProviderIds": {
+      "owner": "winsmux-app/src/modelCapabilities.ts",
+      "values": [
+        "provider-default",
+        "codex",
+        "claude",
+        "antigravity",
+        "grok-build",
+        "openrouter"
+      ]
+    },
+    "modelSources": {
+      "owner": "winsmux-app/src/modelCapabilities.ts",
+      "values": [
+        "provider-default",
+        "cli-discovery",
+        "provider-api",
+        "official-doc",
+        "operator-override"
+      ]
+    },
+    "reasoningEfforts": {
+      "owner": "winsmux-app/src/modelCapabilities.ts",
+      "values": [
+        "provider-default",
+        "low",
+        "medium",
+        "high",
+        "max",
+        "xhigh"
+      ]
+    },
+    "backendCapabilities": {
+      "owner": "winsmux-app/src/modelCapabilities.ts",
+      "values": [
+        "any",
+        "agent-cli",
+        "antigravity",
+        "api_llm",
+        "colab_cli"
+      ],
+      "note": "Capability categories, not concrete worker_backend values."
+    },
+    "promptTransports": {
+      "owner": "winsmux-app/src/modelCapabilities.ts",
+      "values": [
+        "argv",
+        "file",
+        "stdin"
+      ]
+    },
+    "modelReadiness": {
+      "owner": "winsmux-app/src/modelCapabilities.ts",
+      "values": [
+        "selectable",
+        "candidate",
+        "setup-required",
+        "runnable",
+        "blocked",
+        "reference-only",
+        "unavailable"
+      ],
+      "note": "Model availability vocabulary. Do not merge with worker pane readiness."
+    },
+    "runtimeWorkerReadiness": {
+      "owner": "winsmux-app/src/main.ts",
+      "values": [
+        "runnable",
+        "setup-required",
+        "blocked"
+      ],
+      "note": "Startability summary derived from model availability plus credential/backend state."
+    },
+    "workerPaneReadiness": {
+      "owner": "winsmux-app/src/main.ts",
+      "values": [
+        "ready",
+        "blocked",
+        "pending"
+      ],
+      "note": "Pane idle-state vocabulary. Do not merge with model availability."
+    },
+    "agentVaultCommandProviders": {
+      "owner": "winsmux-app/src/main.ts",
+      "values": [
+        "claude",
+        "codex",
+        "opencode"
+      ],
+      "note": "Command-provider vocabulary kept separate from runtime provider IDs."
+    },
+    "benchmarkFamilies": {
+      "owner": "winsmux-app/src/modelCapabilities.ts",
+      "values": [
+        "agent-arena",
+        "code-arena",
+        "winsmux-local"
+      ]
+    }
+  }
+}

--- a/winsmux-app/scripts/common-contract-package-check.mjs
+++ b/winsmux-app/scripts/common-contract-package-check.mjs
@@ -67,8 +67,8 @@ function assertDivergenceIsDetected(name, actual, expected) {
   );
 }
 
-async function loadRustParityFixture() {
-  const fixturePath = path.resolve("..", "tests", "fixtures", "rust-parity", "common-contract-package.json");
+async function loadRustParityFixture(name = "common-contract-package.json") {
+  const fixturePath = path.resolve("..", "tests", "fixtures", "rust-parity", name);
   return JSON.parse(await readFile(fixturePath, "utf8"));
 }
 
@@ -190,5 +190,10 @@ assertDivergenceIsDetected(
 );
 
 assert.deepEqual(await loadRustParityFixture(), commonContractPackage);
+assert.deepEqual(await loadRustParityFixture("common-contract-package-v0.36.25.json"), commonContractPackage);
+
+const previousFixture = await loadRustParityFixture("common-contract-package-v0.36.24.json");
+assert.equal(previousFixture.version, "0.36.24");
+assert.deepEqual({ ...previousFixture, version: commonContractPackageVersion }, commonContractPackage);
 
 console.log("common-contract-package-check: ok");


### PR DESCRIPTION
## Summary
- add explicit v0.36.25 common-contract parity fixture coverage
- add a v0.36.24 negative fixture that differs only by version, so implicit migration remains rejected until a real migration path exists
- pin unknown-field rejection at the package, vocabulary collection, and vocabulary item levels

## Verification
- `npm run test:common-contract-package`
- `cargo test --manifest-path core/Cargo.toml --test common_contract`
- `cargo fmt --manifest-path core/Cargo.toml --check`
- `git diff --check`
- `pwsh -NoProfile -File scripts/audit-public-surface.ps1`
- `pwsh -NoProfile -File .githooks/pre-commit-whitelist.ps1`
- sub-agent staged-diff review: no blocking findings
- `winsmux review-request` -> `worker-2` review PASS

## Notes
- The v0.36.24 fixture is intentionally a previous-version rejection fixture, not a historical schema migration fixture.