### PR TITLE
ci(release): add common contract drift gates

### DIFF
--- a/.github/workflows/release-core.yml
+++ b/.github/workflows/release-core.yml
@@ -41,10 +41,21 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: winsmux-app/package-lock.json
       - uses: actions/download-artifact@v8
       - name: Bootstrap repo hooks
         shell: pwsh
         run: ./scripts/bootstrap-git-guard.ps1
+      - name: Install frontend dependencies
+        working-directory: winsmux-app
+        run: npm ci
+      - name: Check common contract package drift
+        working-directory: winsmux-app
+        run: npm run test:common-contract-package
       - name: Create Release Assets
         run: |
           mkdir -p release

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -35,6 +35,10 @@ jobs:
         working-directory: winsmux-app
         run: npm ci
 
+      - name: Check common contract package drift
+        working-directory: winsmux-app
+        run: npm run test:common-contract-package
+
       - name: Require desktop release signing secrets
         if: github.event_name == 'push' || inputs.release_tag != ''
         shell: pwsh

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -28,6 +28,14 @@ jobs:
         with:
           node-version: 24
 
+      - name: Install frontend dependencies
+        working-directory: winsmux-app
+        run: npm ci
+
+      - name: Check common contract package drift
+        working-directory: winsmux-app
+        run: npm run test:common-contract-package
+
       - name: Stage npm package
         id: stage
         shell: pwsh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,6 +64,27 @@ jobs:
         shell: pwsh
         run: pwsh -NoProfile -File scripts/audit-public-surface.ps1
 
+  common-contract-drift:
+    name: Common Contract Drift Gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: winsmux-app/package-lock.json
+
+      - name: Install frontend dependencies
+        working-directory: winsmux-app
+        run: npm ci
+
+      - name: Check common contract package drift
+        working-directory: winsmux-app
+        run: npm run test:common-contract-package
+
   pester:
     name: Pester Tests (${{ matrix.name }})
     runs-on: windows-latest
@@ -361,6 +382,7 @@ jobs:
     needs:
       - secret-scan
       - public-surface
+      - common-contract-drift
       - pester
       - core-build-test
       - desktop-build-test
@@ -373,6 +395,7 @@ jobs:
           for result in \
             "${{ needs.secret-scan.result }}" \
             "${{ needs.public-surface.result }}" \
+            "${{ needs.common-contract-drift.result }}" \
             "${{ needs.pester.result }}" \
             "${{ needs.core-build-test.result }}" \
             "${{ needs.desktop-build-test.result }}"; do

--- a/docs/project/DETAILED_DESIGN.md
+++ b/docs/project/DETAILED_DESIGN.md
@@ -132,6 +132,7 @@ Core contract change:
 ```powershell
 git diff --check
 cargo test --manifest-path core\Cargo.toml
+cmd /c "cd winsmux-app && npm run test:common-contract-package"
 pwsh -NoProfile -File scripts\audit-public-surface.ps1
 pwsh -NoProfile -File scripts\git-guard.ps1 -Mode full
 ```
@@ -153,6 +154,7 @@ git diff --check
 Invoke-Pester -Path tests\winsmux-bridge.Tests.ps1 -PassThru
 Invoke-Pester -Path tests\PublicSurfacePolicy.Tests.ps1 -PassThru
 cargo test --manifest-path core\Cargo.toml
+cmd /c "cd winsmux-app && npm run test:common-contract-package"
 cmd /c npm run build
 cargo check --manifest-path winsmux-app\src-tauri\Cargo.toml --locked
 pwsh -NoProfile -File scripts\audit-public-surface.ps1

--- a/docs/project/contract-source-of-truth-inventory.md
+++ b/docs/project/contract-source-of-truth-inventory.md
@@ -28,6 +28,13 @@ same enum or list is hand-declared in TypeScript, PowerShell, Rust, and JSON,
 kept in sync only by convention. No codegen, no shared schema, and the
 per-layer copies have already drifted in at least three confirmed cases (below).
 
+Update for v0.36.25: the common provider/readiness/manifest/route/capsule/mailbox/settings
+payload now has one public payload source: `winsmux-app/src/modelCapabilities.ts`
+exports `commonContractPackage`. The drift gate is
+`npm run test:common-contract-package` in `winsmux-app`; it checks generated
+PowerShell bindings, Rust parity fixtures, and the previous-version fixture
+against that source before merge or release.
+
 ## Confirmed drift (hand-verified)
 
 Three duplications have already diverged in the tree today:


### PR DESCRIPTION
## Summary
- Add a dedicated `Common Contract Drift Gate` job to the main `Tests` workflow and include it in `Merge Gate`.
- Run the same common contract package check before core, desktop, and npm release workflows proceed.
- Document `winsmux-app/src/modelCapabilities.ts` `commonContractPackage` as the v0.36.25 common contract payload source and add the check to release gate docs.

## Verification
- `npm run test:common-contract-package`
- `cargo test --manifest-path core\Cargo.toml --test common_contract`
- `git diff --cached --check`
- `pwsh -NoProfile -File scripts\audit-public-surface.ps1`
- `pwsh -NoProfile -File .githooks\pre-commit-whitelist.ps1`
- `pwsh -NoProfile -File scripts\git-guard.ps1 -Mode full`
- Bernoulli staged-diff review: PASS

## Notes
- TASK-638 for v0.36.25.
- Local `.codex/`, `.winsmux/`, and `.references/` operating files are intentionally not included.