### PR TITLE
test(contract): add readiness vocabulary fixtures

### DIFF
--- a/core/src/common_contract.rs
+++ b/core/src/common_contract.rs
@@ -85,6 +85,29 @@ impl CommonContractPackage {
                 "worker pane readiness must not contain model state selectable".to_string(),
             );
         }
+        assert_exact_values(
+            "model readiness",
+            model_readiness,
+            &[
+                "selectable",
+                "candidate",
+                "setup-required",
+                "runnable",
+                "blocked",
+                "reference-only",
+                "unavailable",
+            ],
+        )?;
+        assert_exact_values(
+            "runtime worker readiness",
+            runtime_worker,
+            &["runnable", "setup-required", "blocked"],
+        )?;
+        assert_exact_values(
+            "worker pane readiness",
+            worker_pane,
+            &["ready", "blocked", "pending"],
+        )?;
 
         assert_order(
             "reasoning efforts",

--- a/core/tests-rs/common_contract.rs
+++ b/core/tests-rs/common_contract.rs
@@ -25,6 +25,13 @@ fn previous_fixture_value() -> Value {
     .expect("previous fixture should be valid JSON")
 }
 
+fn readiness_vocabulary_fixture_value() -> Value {
+    serde_json::from_str(include_str!(
+        "../../tests/fixtures/rust-parity/common-contract-readiness-vocabulary-fixtures.json"
+    ))
+    .expect("readiness vocabulary fixtures should be valid JSON")
+}
+
 fn parse_value(value: Value) -> CommonContractPackage {
     CommonContractPackage::from_json(&value.to_string()).expect("contract should parse")
 }
@@ -33,6 +40,38 @@ fn parse_error(value: Value) -> String {
     CommonContractPackage::from_json(&value.to_string())
         .expect_err("contract should fail to parse")
         .to_string()
+}
+
+fn apply_readiness_vocabulary_mutation(mut package: Value, mutation: &Value) -> Value {
+    if let Some(copy) = mutation.get("copyVocabularyValues") {
+        let from = copy["from"]
+            .as_str()
+            .expect("copyVocabularyValues.from should be a string");
+        let to = copy["to"]
+            .as_str()
+            .expect("copyVocabularyValues.to should be a string");
+        let values = package["vocabularies"][from]["values"].clone();
+        package["vocabularies"][to]["values"] = values;
+        return package;
+    }
+
+    if let Some(remove) = mutation.get("removeVocabularyValue") {
+        let vocabulary = remove["vocabulary"]
+            .as_str()
+            .expect("removeVocabularyValue.vocabulary should be a string");
+        let value = remove["value"]
+            .as_str()
+            .expect("removeVocabularyValue.value should be a string");
+        let values = package["vocabularies"][vocabulary]["values"]
+            .as_array_mut()
+            .expect("readiness vocabulary values should be an array");
+        let before = values.len();
+        values.retain(|item| item.as_str() != Some(value));
+        assert_ne!(before, values.len(), "fixture should remove {}", value);
+        return package;
+    }
+
+    panic!("unsupported readiness vocabulary mutation: {}", mutation);
 }
 
 #[test]
@@ -130,6 +169,36 @@ fn common_contract_rejects_conflated_readiness_vocabularies() {
         .validate()
         .expect_err("worker pane readiness must not copy model readiness");
     assert!(error.contains("must stay separate"));
+}
+
+#[test]
+fn common_contract_rejects_task722_readiness_vocabulary_fixtures() {
+    let fixtures = readiness_vocabulary_fixture_value();
+    assert_eq!(fixtures["version"], "0.36.25");
+
+    for fixture in fixtures["fixtures"]
+        .as_array()
+        .expect("fixtures should be an array")
+    {
+        let id = fixture["id"]
+            .as_str()
+            .expect("fixture id should be a string");
+        let expected_error = fixture["expectedError"]
+            .as_str()
+            .expect("fixture expectedError should be a string");
+        let mutated = apply_readiness_vocabulary_mutation(fixture_value(), &fixture["mutation"]);
+        let contract = parse_value(mutated);
+        let error = contract
+            .validate()
+            .expect_err("readiness vocabulary fixture should fail validation");
+        assert!(
+            error.contains(expected_error),
+            "{} expected error containing {:?}, got {:?}",
+            id,
+            expected_error,
+            error
+        );
+    }
 }
 
 #[test]

--- a/docs/project/contract-source-of-truth-inventory.md
+++ b/docs/project/contract-source-of-truth-inventory.md
@@ -35,6 +35,12 @@ exports `commonContractPackage`. The drift gate is
 PowerShell bindings, Rust parity fixtures, and the previous-version fixture
 against that source before merge or release.
 
+Update for TASK-722: `tests/fixtures/rust-parity/common-contract-readiness-vocabulary-fixtures.json`
+keeps two negative readiness fixtures tied to the common package. One fixture
+copies the model availability vocabulary into worker-pane readiness; the other
+removes the runtime worker `blocked` repair-action state. Both the JS drift
+check and Rust validator must reject those mutations.
+
 ## Confirmed drift (hand-verified)
 
 Three duplications have already diverged in the tree today:
@@ -120,6 +126,10 @@ Three duplications have already diverged in the tree today:
   pane idle) vs `modelCapabilities.ts` `ReadinessState`
   (`selectable|candidate|setup-required|runnable|blocked|reference-only|unavailable`,
   is the model available).
+- **TASK-722 fixture gate:** the named readiness fixture file above is the
+  regression input for this split. It prevents a future edit from treating pane
+  idle-state labels as model availability, and it prevents dropping the
+  `blocked` runtime worker state that carries the remediation path.
 
 ### Manifest schema
 

--- a/tests/fixtures/rust-parity/common-contract-readiness-vocabulary-fixtures.json
+++ b/tests/fixtures/rust-parity/common-contract-readiness-vocabulary-fixtures.json
@@ -1,0 +1,27 @@
+{
+  "version": "0.36.25",
+  "fixtures": [
+    {
+      "id": "model-readiness-worker-pane-conflation",
+      "description": "Worker pane readiness must not copy the model availability vocabulary.",
+      "mutation": {
+        "copyVocabularyValues": {
+          "from": "modelReadiness",
+          "to": "workerPaneReadiness"
+        }
+      },
+      "expectedError": "model readiness and worker pane readiness must stay separate"
+    },
+    {
+      "id": "runtime-worker-repair-action-missing",
+      "description": "Runtime worker readiness must keep the blocked repair-action state.",
+      "mutation": {
+        "removeVocabularyValue": {
+          "vocabulary": "runtimeWorkerReadiness",
+          "value": "blocked"
+        }
+      },
+      "expectedError": "runtime worker readiness diverged"
+    }
+  ]
+}

--- a/winsmux-app/scripts/common-contract-package-check.mjs
+++ b/winsmux-app/scripts/common-contract-package-check.mjs
@@ -67,9 +67,60 @@ function assertDivergenceIsDetected(name, actual, expected) {
   );
 }
 
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 async function loadRustParityFixture(name = "common-contract-package.json") {
   const fixturePath = path.resolve("..", "tests", "fixtures", "rust-parity", name);
   return JSON.parse(await readFile(fixturePath, "utf8"));
+}
+
+function readinessVocabularyValues(contractPackage, vocabulary) {
+  const values = contractPackage.vocabularies?.[vocabulary]?.values;
+  assert.ok(Array.isArray(values), `Expected ${vocabulary} values`);
+  return values;
+}
+
+function assertReadinessVocabularyContract(contractPackage) {
+  const modelReadiness = readinessVocabularyValues(contractPackage, "modelReadiness");
+  const runtimeWorkerReadiness = readinessVocabularyValues(contractPackage, "runtimeWorkerReadiness");
+  const workerPaneReadiness = readinessVocabularyValues(contractPackage, "workerPaneReadiness");
+
+  for (const state of runtimeWorkerReadiness) {
+    assert.ok(modelReadiness.includes(state), `Runtime worker readiness ${state} must remain a model-readiness subset`);
+  }
+  if (JSON.stringify(modelReadiness) === JSON.stringify(workerPaneReadiness)) {
+    throw new Error("model readiness and worker pane readiness must stay separate");
+  }
+  if (modelReadiness.includes("ready")) {
+    throw new Error("model readiness must not contain pane state ready");
+  }
+  if (workerPaneReadiness.includes("selectable")) {
+    throw new Error("worker pane readiness must not contain model state selectable");
+  }
+
+  assertSameVocabulary("model readiness", modelReadiness, modelReadinessStates);
+  assertSameVocabulary("runtime worker readiness", runtimeWorkerReadiness, runtimeWorkerReadinessStates);
+  assertSameVocabulary("worker pane readiness", workerPaneReadiness, workerPaneReadinessStates);
+}
+
+function applyReadinessVocabularyMutation(contractPackage, mutation) {
+  const mutated = JSON.parse(JSON.stringify(contractPackage));
+  if (mutation.copyVocabularyValues) {
+    const { from, to } = mutation.copyVocabularyValues;
+    mutated.vocabularies[to].values = [...readinessVocabularyValues(mutated, from)];
+    return mutated;
+  }
+  if (mutation.removeVocabularyValue) {
+    const { vocabulary, value } = mutation.removeVocabularyValue;
+    const values = readinessVocabularyValues(mutated, vocabulary);
+    const nextValues = values.filter((item) => item !== value);
+    assert.notEqual(nextValues.length, values.length, `${vocabulary} fixture must remove ${value}`);
+    mutated.vocabularies[vocabulary].values = nextValues;
+    return mutated;
+  }
+  throw new Error(`Unsupported readiness vocabulary mutation: ${JSON.stringify(mutation)}`);
 }
 
 const {
@@ -161,12 +212,7 @@ assert.equal(parsePropertyType(mainSource, "requiredBackend"), "BackendCapabilit
 assert.equal(parseTypeAlias(mainSource, "WorkerPaneReadinessState"), "CommonWorkerPaneReadinessState");
 assert.equal(parseTypeAlias(mainSource, "AgentVaultProviderId"), "AgentVaultCommandProviderId");
 
-for (const state of runtimeWorkerReadinessStates) {
-  assert.ok(modelReadinessStates.includes(state), `Runtime worker readiness ${state} must remain a model-readiness subset`);
-}
-assert.notDeepEqual(modelReadinessStates, workerPaneReadinessStates);
-assert.equal(modelReadinessStates.includes("ready"), false);
-assert.equal(workerPaneReadinessStates.includes("selectable"), false);
+assertReadinessVocabularyContract(commonContractPackage);
 
 assertDivergenceIsDetected(
   "model readiness divergence fixture",
@@ -188,6 +234,17 @@ assertDivergenceIsDetected(
   runtimeWorkerReadinessStates.filter((state) => state !== "blocked"),
   runtimeWorkerReadinessStates,
 );
+
+const readinessVocabularyFixtures = await loadRustParityFixture("common-contract-readiness-vocabulary-fixtures.json");
+assert.equal(readinessVocabularyFixtures.version, commonContractPackageVersion);
+for (const fixture of readinessVocabularyFixtures.fixtures) {
+  const mutated = applyReadinessVocabularyMutation(commonContractPackage, fixture.mutation);
+  assert.throws(
+    () => assertReadinessVocabularyContract(mutated),
+    new RegExp(escapeRegExp(fixture.expectedError)),
+    `${fixture.id} should fail with ${fixture.expectedError}`,
+  );
+}
 
 assert.deepEqual(await loadRustParityFixture(), commonContractPackage);
 assert.deepEqual(await loadRustParityFixture("common-contract-package-v0.36.25.json"), commonContractPackage);


### PR DESCRIPTION
## Summary

- Add TASK-722 readiness vocabulary fixtures for the common contract package.
- Make the JS drift check and Rust validator reject model-readiness / worker-pane readiness conflation.
- Make runtime worker readiness reject a missing `blocked` remediation state.

## Verification

- `npm run test:common-contract-package`
- `cargo test --manifest-path core\Cargo.toml --test common_contract`
- `cargo fmt --manifest-path core\Cargo.toml --check`
- `git diff --cached --check`
- `pwsh -NoProfile -File scripts\audit-public-surface.ps1`
- `pwsh -NoProfile -File .githooks\pre-commit-whitelist.ps1`
- `pwsh -NoProfile -File scripts\git-guard.ps1 -Mode full`

## Review

- Local staged-diff review: PASS, no blocking findings.
