### PR TITLE
refactor(app): extract desktop summary scheduler

### DIFF
--- a/winsmux-app/package.json
+++ b/winsmux-app/package.json
@@ -15,6 +15,7 @@
     "test:desktop-operator-snapshot-e2e": "node ./scripts/desktop-pane-e2e.mjs --operator-snapshot-only",
     "test:desktop-release-popout-e2e": "node ./scripts/desktop-pane-e2e.mjs --release-popout-only",
     "test:desktop-status-e2e": "node ./scripts/desktop-pane-e2e.mjs --stop-after-worker-status",
+    "test:desktop-summary-scheduler": "node --experimental-strip-types ./scripts/desktop-summary-scheduler-check.mjs",
     "test:editor-targets": "node ./scripts/editor-targets-check.mjs",
     "test:worker-pane-routing": "node ./scripts/worker-pane-routing-check.mjs",
     "test:worker-readiness-prompt": "node ./scripts/worker-readiness-prompt-check.mjs",

--- a/winsmux-app/scripts/desktop-summary-scheduler-check.mjs
+++ b/winsmux-app/scripts/desktop-summary-scheduler-check.mjs
@@ -1,0 +1,209 @@
+import assert from "node:assert/strict";
+import { DesktopSummaryRefreshScheduler } from "../src/desktopSummaryScheduler.ts";
+
+class FakeWindow {
+  constructor() {
+    this.nextTimerId = 1;
+    this.timeouts = new Map();
+    this.intervals = [];
+    this.focusListeners = [];
+  }
+
+  setTimeout(callback, delayMs) {
+    const timerId = this.nextTimerId;
+    this.nextTimerId += 1;
+    this.timeouts.set(timerId, { callback, delayMs });
+    return timerId;
+  }
+
+  clearTimeout(timerId) {
+    this.timeouts.delete(timerId);
+  }
+
+  setInterval(callback, delayMs) {
+    const timerId = this.nextTimerId;
+    this.nextTimerId += 1;
+    this.intervals.push({ timerId, callback, delayMs });
+    return timerId;
+  }
+
+  addEventListener(type, listener) {
+    if (type === "focus") {
+      this.focusListeners.push(listener);
+    }
+  }
+
+  runNextTimeout() {
+    const next = this.timeouts.entries().next();
+    assert.equal(next.done, false, "expected a pending timeout");
+    const [timerId, timeout] = next.value;
+    this.timeouts.delete(timerId);
+    timeout.callback();
+  }
+
+  fireInterval(index = 0) {
+    assert.ok(this.intervals[index], "expected a registered interval");
+    this.intervals[index].callback();
+  }
+
+  fireFocus() {
+    for (const listener of this.focusListeners) {
+      listener();
+    }
+  }
+}
+
+class FakeDocument {
+  constructor() {
+    this.visibilityState = "visible";
+    this.visibilityListeners = [];
+  }
+
+  addEventListener(type, listener) {
+    if (type === "visibilitychange") {
+      this.visibilityListeners.push(listener);
+    }
+  }
+
+  fireVisibilityChange() {
+    for (const listener of this.visibilityListeners) {
+      listener();
+    }
+  }
+}
+
+async function flushMicrotasks() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+function createScheduler(overrides = {}) {
+  const fakeWindow = new FakeWindow();
+  const fakeDocument = new FakeDocument();
+  const refreshCalls = [];
+  let now = 0;
+  let emitLiveEvent = () => {
+    throw new Error("live subscription was not registered");
+  };
+  const scheduler = new DesktopSummaryRefreshScheduler({
+    window: fakeWindow,
+    document: fakeDocument,
+    fallbackIntervalMs: 15_000,
+    streamStaleMs: 60_000,
+    getRefreshTarget: () => ({ projectDir: null, projectKey: "" }),
+    refresh: async (context) => {
+      refreshCalls.push(context.forceExplainRunId);
+      context.markSuccessfulRefresh();
+    },
+    subscribe: async (onRefresh) => {
+      emitLiveEvent = onRefresh;
+      return () => {};
+    },
+    now: () => now,
+    logger: console,
+    ...overrides,
+  });
+  return {
+    scheduler,
+    fakeWindow,
+    fakeDocument,
+    refreshCalls,
+    setNow: (value) => {
+      now = value;
+    },
+    emitLiveEvent: (event) => emitLiveEvent(event),
+  };
+}
+
+{
+  const { scheduler, fakeWindow, refreshCalls } = createScheduler();
+
+  scheduler.request("run-a", 150);
+  scheduler.request("run-b", 150);
+
+  assert.equal(fakeWindow.timeouts.size, 1, "debounce should keep only the newest timeout");
+  fakeWindow.runNextTimeout();
+  await flushMicrotasks();
+
+  assert.deepEqual(refreshCalls, ["run-b"], "debounce should keep the newest forced run id");
+}
+
+{
+  let finishFirstRefresh = () => {};
+  const refreshCalls = [];
+  const fakeWindow = new FakeWindow();
+  const fakeDocument = new FakeDocument();
+  const scheduler = new DesktopSummaryRefreshScheduler({
+    window: fakeWindow,
+    document: fakeDocument,
+    fallbackIntervalMs: 15_000,
+    streamStaleMs: 60_000,
+    getRefreshTarget: () => ({ projectDir: null, projectKey: "" }),
+    refresh: async (context) => {
+      refreshCalls.push(context.forceExplainRunId);
+      if (refreshCalls.length === 1) {
+        await new Promise((resolve) => {
+          finishFirstRefresh = resolve;
+        });
+      }
+      context.markSuccessfulRefresh();
+    },
+    subscribe: async () => () => {},
+    logger: console,
+  });
+
+  scheduler.request("first", 0);
+  fakeWindow.runNextTimeout();
+  await flushMicrotasks();
+  scheduler.request("second", 0);
+  fakeWindow.runNextTimeout();
+  await flushMicrotasks();
+
+  assert.deepEqual(refreshCalls, ["first"], "in-flight refresh should defer the queued request");
+  finishFirstRefresh();
+  await flushMicrotasks();
+  await flushMicrotasks();
+
+  assert.deepEqual(refreshCalls, ["first", "second"], "queued request should run after the in-flight refresh finishes");
+}
+
+{
+  const {
+    scheduler,
+    fakeWindow,
+    fakeDocument,
+    refreshCalls,
+    setNow,
+    emitLiveEvent,
+  } = createScheduler();
+
+  scheduler.registerLiveRefresh();
+  await flushMicrotasks();
+
+  assert.equal(fakeWindow.intervals.length, 1, "fallback interval should be registered once");
+  assert.equal(fakeWindow.focusListeners.length, 1, "focus fallback listener should be registered once");
+  assert.equal(fakeDocument.visibilityListeners.length, 1, "visibility fallback listener should be registered once");
+
+  setNow(100);
+  emitLiveEvent({ source: "desktop", run_id: "live-run" });
+  fakeWindow.runNextTimeout();
+  await flushMicrotasks();
+
+  assert.deepEqual(refreshCalls, ["live-run"], "live refresh event should request an immediate refresh");
+  assert.equal(scheduler.shouldRunFallbackRefresh(60_099), false, "fresh live activity should suppress fallback");
+  assert.equal(scheduler.shouldRunFallbackRefresh(60_100), true, "stale live activity should allow fallback");
+
+  fakeDocument.visibilityState = "hidden";
+  fakeWindow.fireInterval();
+  await flushMicrotasks();
+  assert.deepEqual(refreshCalls, ["live-run"], "hidden document should not run fallback refresh");
+
+  fakeDocument.visibilityState = "visible";
+  setNow(60_100);
+  fakeDocument.fireVisibilityChange();
+  fakeWindow.runNextTimeout();
+  await flushMicrotasks();
+  assert.deepEqual(refreshCalls, ["live-run", null], "visible stale fallback should request a refresh");
+}
+
+console.log("desktop-summary-scheduler-check passed");

--- a/winsmux-app/src/desktopSummaryScheduler.ts
+++ b/winsmux-app/src/desktopSummaryScheduler.ts
@@ -1,0 +1,208 @@
+export interface DesktopSummaryRefreshEventLike {
+  source?: string;
+  reason?: string;
+  pane_id?: string;
+  run_id?: string;
+}
+
+export interface DesktopSummaryRefreshTarget {
+  projectDir: string | null;
+  projectKey: string;
+}
+
+export interface DesktopSummaryRefreshContext {
+  forceExplainRunId: string | null;
+  requestProjectDir: string | null;
+  requestProjectKey: string;
+  isCurrent: (currentProjectKey?: string) => boolean;
+  markSuccessfulRefresh: () => void;
+}
+
+export interface DesktopSummarySchedulerWindow {
+  setTimeout(callback: () => void, delayMs: number): number;
+  clearTimeout(timerId: number): void;
+  setInterval(callback: () => void, delayMs: number): number;
+  addEventListener(type: "focus", listener: () => void): void;
+}
+
+export interface DesktopSummarySchedulerDocument {
+  readonly visibilityState: DocumentVisibilityState;
+  addEventListener(type: "visibilitychange", listener: () => void): void;
+}
+
+export interface DesktopSummaryRefreshSchedulerOptions<
+  TEvent extends DesktopSummaryRefreshEventLike = DesktopSummaryRefreshEventLike,
+> {
+  window: DesktopSummarySchedulerWindow;
+  document: DesktopSummarySchedulerDocument;
+  fallbackIntervalMs: number;
+  streamStaleMs: number;
+  getRefreshTarget: () => DesktopSummaryRefreshTarget;
+  refresh: (context: DesktopSummaryRefreshContext) => Promise<void>;
+  subscribe: (onRefresh: (event: TEvent) => void) => Promise<unknown>;
+  handleLiveEvent?: (event: TEvent) => void;
+  now?: () => number;
+  logger?: Pick<Console, "warn">;
+}
+
+export class DesktopSummaryRefreshScheduler<
+  TEvent extends DesktopSummaryRefreshEventLike = DesktopSummaryRefreshEventLike,
+> {
+  private readonly options: DesktopSummaryRefreshSchedulerOptions<TEvent>;
+  private refreshInFlight: Promise<void> | null = null;
+  private refreshInFlightProjectKey = "";
+  private refreshTimeout: number | null = null;
+  private queuedRunId: string | null = null;
+  private requestedVersion = 0;
+  private runningVersion = 0;
+  private refreshSequence = 0;
+  private fallbackRefreshRegistered = false;
+  private liveRefreshAvailable = false;
+  private lastSuccessfulRefreshAt = 0;
+  private lastStreamSignalAt = 0;
+
+  constructor(options: DesktopSummaryRefreshSchedulerOptions<TEvent>) {
+    this.options = options;
+  }
+
+  refresh(forceExplainRunId?: string | null) {
+    const target = this.options.getRefreshTarget();
+    if (this.refreshInFlight && this.refreshInFlightProjectKey === target.projectKey) {
+      return this.refreshInFlight;
+    }
+
+    const requestSequence = ++this.refreshSequence;
+    this.refreshInFlightProjectKey = target.projectKey;
+    this.refreshInFlight = (async () => {
+      try {
+        await this.options.refresh({
+          forceExplainRunId: forceExplainRunId ?? null,
+          requestProjectDir: target.projectDir,
+          requestProjectKey: target.projectKey,
+          isCurrent: (currentProjectKey?: string) =>
+            requestSequence === this.refreshSequence &&
+            (currentProjectKey === undefined || currentProjectKey === target.projectKey),
+          markSuccessfulRefresh: () => {
+            this.markSuccessfulRefresh();
+          },
+        });
+      } finally {
+        if (requestSequence !== this.refreshSequence) {
+          return;
+        }
+        this.refreshInFlight = null;
+        this.refreshInFlightProjectKey = "";
+        if (this.runningVersion < this.requestedVersion) {
+          this.flushQueue();
+        }
+      }
+    })();
+
+    return this.refreshInFlight;
+  }
+
+  request(forceExplainRunId?: string | null, delayMs = 150) {
+    this.requestedVersion += 1;
+    if (forceExplainRunId) {
+      this.queuedRunId = forceExplainRunId;
+    }
+    if (this.refreshTimeout !== null) {
+      this.options.window.clearTimeout(this.refreshTimeout);
+    }
+
+    this.refreshTimeout = this.options.window.setTimeout(() => {
+      this.refreshTimeout = null;
+      if (this.refreshInFlight) {
+        return;
+      }
+      this.flushQueue();
+    }, delayMs);
+  }
+
+  shouldRunFallbackRefresh(now = this.now()) {
+    if (!this.liveRefreshAvailable) {
+      return true;
+    }
+
+    const lastLiveActivityAt = Math.max(
+      this.lastSuccessfulRefreshAt,
+      this.lastStreamSignalAt,
+    );
+    return now - lastLiveActivityAt >= this.options.streamStaleMs;
+  }
+
+  registerFallbackRefresh() {
+    if (this.fallbackRefreshRegistered) {
+      return;
+    }
+
+    this.fallbackRefreshRegistered = true;
+
+    this.options.window.setInterval(() => {
+      if (this.options.document.visibilityState !== "visible") {
+        return;
+      }
+      if (!this.shouldRunFallbackRefresh()) {
+        return;
+      }
+      this.request(undefined, 0);
+    }, this.options.fallbackIntervalMs);
+
+    this.options.window.addEventListener("focus", () => {
+      if (!this.shouldRunFallbackRefresh()) {
+        return;
+      }
+      this.request(undefined, 0);
+    });
+
+    this.options.document.addEventListener("visibilitychange", () => {
+      if (this.options.document.visibilityState !== "visible") {
+        return;
+      }
+      if (!this.shouldRunFallbackRefresh()) {
+        return;
+      }
+      this.request(undefined, 0);
+    });
+  }
+
+  registerLiveRefresh() {
+    this.registerFallbackRefresh();
+
+    void this.options.subscribe((event) => {
+      this.options.handleLiveEvent?.(event);
+      if (event.source !== "pty") {
+        this.lastStreamSignalAt = this.now();
+      }
+      this.request(event.run_id, 0);
+    }).then(() => {
+      this.liveRefreshAvailable = true;
+    }).catch((error) => {
+      this.options.logger?.warn("Failed to subscribe to desktop summary refresh events", error);
+      this.liveRefreshAvailable = false;
+    });
+  }
+
+  private flushQueue() {
+    if (this.refreshInFlight) {
+      return;
+    }
+
+    if (this.runningVersion >= this.requestedVersion) {
+      return;
+    }
+
+    const queuedRunId = this.queuedRunId;
+    this.queuedRunId = null;
+    this.runningVersion = this.requestedVersion;
+    void this.refresh(queuedRunId);
+  }
+
+  private markSuccessfulRefresh() {
+    this.lastSuccessfulRefreshAt = this.now();
+  }
+
+  private now() {
+    return this.options.now?.() ?? Date.now();
+  }
+}

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -31,6 +31,7 @@ import {
   type DesktopEditorFilePayload,
   type DesktopExplorerEntry,
   type DesktopExplainPayload,
+  type DesktopSummaryRefreshEvent,
   type DesktopRunProjection,
   type DesktopSummarySnapshot,
   type DesktopRuntimeRolePreference,
@@ -73,6 +74,10 @@ import {
   selectConfiguredWorkerStartRoster,
 } from "./workerStartPlanning";
 import { hasWorkerReadyPromptInAnySource } from "./workerReadinessPrompt";
+import {
+  DesktopSummaryRefreshScheduler,
+  type DesktopSummaryRefreshContext,
+} from "./desktopSummaryScheduler";
 
 interface PaneEntry {
   terminal: Terminal;
@@ -771,17 +776,6 @@ const detectedPreviewTargets = new Map<string, PreviewTarget>();
 const PREVIEW_FRESHNESS_WINDOW_MS = 30_000;
 const PANE_META_REFRESH_INTERVAL_MS = 30_000;
 let desktopSummarySnapshot: DesktopSummarySnapshot | null = null;
-let desktopSummaryRefreshInFlight: Promise<void> | null = null;
-let desktopSummaryRefreshInFlightProjectKey = "";
-let desktopSummaryRefreshTimeout: number | null = null;
-let desktopSummaryQueuedRunId: string | null = null;
-let desktopSummaryRefreshRequestedVersion = 0;
-let desktopSummaryRefreshRunningVersion = 0;
-let desktopSummaryRefreshSequence = 0;
-let desktopSummaryFallbackRefreshRegistered = false;
-let desktopSummaryLiveRefreshAvailable = false;
-let desktopSummaryLastSuccessfulRefreshAt = 0;
-let desktopSummaryLastStreamSignalAt = 0;
 let desktopSummaryRefreshSerial = 0;
 const desktopExplainCache = new Map<string, DesktopExplainPayload>();
 const desktopRunCompareCache = new Map<string, DesktopCompareRunsResult>();
@@ -816,6 +810,23 @@ const backendConversation: ConversationItem[] = [];
 const runtimeConversation: ConversationItem[] = [];
 const DESKTOP_SUMMARY_REFRESH_FALLBACK_INTERVAL_MS = 15_000;
 const DESKTOP_SUMMARY_STREAM_STALE_MS = 60_000;
+const desktopSummaryRefreshScheduler = new DesktopSummaryRefreshScheduler<DesktopSummaryRefreshEvent>({
+  window,
+  document,
+  fallbackIntervalMs: DESKTOP_SUMMARY_REFRESH_FALLBACK_INTERVAL_MS,
+  streamStaleMs: DESKTOP_SUMMARY_STREAM_STALE_MS,
+  getRefreshTarget: () => {
+    const projectDir = getActiveProjectDirPayload();
+    return {
+      projectDir: projectDir ?? null,
+      projectKey: normalizeProjectDirInput(projectDir) || "",
+    };
+  },
+  refresh: refreshDesktopSummaryFromScheduler,
+  subscribe: subscribeToDesktopSummaryRefresh,
+  handleLiveEvent: handleDesktopSummaryLiveRefreshEvent,
+  logger: console,
+});
 const MAX_RUNTIME_CONVERSATION_ITEMS = 80;
 const OPERATOR_PTY_ID = "operator";
 const OPERATOR_PTY_COLS = 120;
@@ -18121,22 +18132,22 @@ function renderPaneMetadata() {
   });
 }
 
-async function refreshDesktopSummary(forceExplainRunId?: string | null) {
-  const requestProjectDir = getActiveProjectDirPayload();
-  const requestProjectKey = normalizeProjectDirInput(requestProjectDir) || "";
-  if (desktopSummaryRefreshInFlight && desktopSummaryRefreshInFlightProjectKey === requestProjectKey) {
-    return desktopSummaryRefreshInFlight;
-  }
+function refreshDesktopSummary(forceExplainRunId?: string | null) {
+  return desktopSummaryRefreshScheduler.refresh(forceExplainRunId);
+}
 
-  const requestSequence = ++desktopSummaryRefreshSequence;
-  desktopSummaryRefreshInFlightProjectKey = requestProjectKey;
-  desktopSummaryRefreshInFlight = (async () => {
+async function refreshDesktopSummaryFromScheduler(context: DesktopSummaryRefreshContext) {
   try {
+    const {
+      forceExplainRunId,
+      requestProjectDir,
+      requestProjectKey,
+    } = context;
     const previousSnapshot = desktopSummarySnapshot;
     const previousSelectedRunId = selectedRunId;
     const snapshot = await getDesktopSummarySnapshot(requestProjectDir);
     const currentProjectKey = normalizeProjectDirInput(getActiveProjectDirPayload()) || "";
-    if (requestSequence !== desktopSummaryRefreshSequence || currentProjectKey !== requestProjectKey) {
+    if (!context.isCurrent(currentProjectKey)) {
       return;
     }
     const snapshotProjectKey = normalizeProjectDirInput(snapshot.project_dir) || "";
@@ -18172,7 +18183,7 @@ async function refreshDesktopSummary(forceExplainRunId?: string | null) {
     }
     desktopSummaryRefreshSerial += 1;
     desktopSummarySnapshot = snapshot;
-    desktopSummaryLastSuccessfulRefreshAt = Date.now();
+    context.markSuccessfulRefresh();
     selectedRunId = resolveSelectedRunId(snapshot, forceExplainRunId);
     pruneExplainCache(snapshot, forceExplainRunId);
     const selectedRunHasMaterialChange = Boolean(
@@ -18207,133 +18218,36 @@ async function refreshDesktopSummary(forceExplainRunId?: string | null) {
     }
     renderDesktopSurfaces();
     void refreshWorkerStatusSurface();
-    } catch (error) {
-      console.warn("Failed to load desktop summary snapshot", error);
-    } finally {
-      if (requestSequence !== desktopSummaryRefreshSequence) {
-        return;
-      }
-      desktopSummaryRefreshInFlight = null;
-      desktopSummaryRefreshInFlightProjectKey = "";
-      if (desktopSummaryRefreshRunningVersion < desktopSummaryRefreshRequestedVersion) {
-        flushDesktopSummaryRefreshQueue();
-      }
-    }
-  })();
-
-  return desktopSummaryRefreshInFlight;
-}
-
-function flushDesktopSummaryRefreshQueue() {
-  if (desktopSummaryRefreshInFlight) {
-    return;
+  } catch (error) {
+    console.warn("Failed to load desktop summary snapshot", error);
   }
-
-  if (desktopSummaryRefreshRunningVersion >= desktopSummaryRefreshRequestedVersion) {
-    return;
-  }
-
-  const queuedRunId = desktopSummaryQueuedRunId;
-  desktopSummaryQueuedRunId = null;
-  desktopSummaryRefreshRunningVersion = desktopSummaryRefreshRequestedVersion;
-  void refreshDesktopSummary(queuedRunId);
 }
 
 function requestDesktopSummaryRefresh(forceExplainRunId?: string | null, delayMs = 150) {
-  desktopSummaryRefreshRequestedVersion += 1;
-  if (forceExplainRunId) {
-    desktopSummaryQueuedRunId = forceExplainRunId;
-  }
-  if (desktopSummaryRefreshTimeout !== null) {
-    window.clearTimeout(desktopSummaryRefreshTimeout);
-  }
-
-  desktopSummaryRefreshTimeout = window.setTimeout(() => {
-    desktopSummaryRefreshTimeout = null;
-    if (desktopSummaryRefreshInFlight) {
-      return;
-    }
-    flushDesktopSummaryRefreshQueue();
-  }, delayMs);
+  desktopSummaryRefreshScheduler.request(forceExplainRunId, delayMs);
 }
 
-function shouldRunDesktopSummaryFallbackRefresh(now = Date.now()) {
-  if (!desktopSummaryLiveRefreshAvailable) {
-    return true;
+function handleDesktopSummaryLiveRefreshEvent(event: DesktopSummaryRefreshEvent) {
+  if (event.source === "pty" && event.pane_id) {
+    if (event.pane_id === OPERATOR_PTY_ID) {
+      if (event.reason === "pty.close") {
+        markOperatorPtyStoppedFromExternalEvent();
+      } else if (event.reason === "pty.spawn" || event.reason === "pty.respawn") {
+        markOperatorPtyStartedFromExternalEvent();
+      }
+    } else {
+      const workbenchPaneId = resolveWorkbenchPaneIdForBackendPaneId(event.pane_id);
+      if (workbenchPaneId && event.reason === "pty.close") {
+        markPanePtyStoppedFromExternalEvent(workbenchPaneId);
+      } else if (workbenchPaneId && (event.reason === "pty.spawn" || event.reason === "pty.respawn")) {
+        markPanePtyStartedFromExternalEvent(workbenchPaneId);
+      }
+    }
   }
-
-  const lastLiveActivityAt = Math.max(
-    desktopSummaryLastSuccessfulRefreshAt,
-    desktopSummaryLastStreamSignalAt,
-  );
-  return now - lastLiveActivityAt >= DESKTOP_SUMMARY_STREAM_STALE_MS;
-}
-
-function registerDesktopSummaryFallbackRefresh() {
-  if (desktopSummaryFallbackRefreshRegistered) {
-    return;
-  }
-
-  desktopSummaryFallbackRefreshRegistered = true;
-
-  window.setInterval(() => {
-    if (document.visibilityState !== "visible") {
-      return;
-    }
-    if (!shouldRunDesktopSummaryFallbackRefresh()) {
-      return;
-    }
-    requestDesktopSummaryRefresh(undefined, 0);
-  }, DESKTOP_SUMMARY_REFRESH_FALLBACK_INTERVAL_MS);
-
-  window.addEventListener("focus", () => {
-    if (!shouldRunDesktopSummaryFallbackRefresh()) {
-      return;
-    }
-    requestDesktopSummaryRefresh(undefined, 0);
-  });
-
-  document.addEventListener("visibilitychange", () => {
-    if (document.visibilityState !== "visible") {
-      return;
-    }
-    if (!shouldRunDesktopSummaryFallbackRefresh()) {
-      return;
-    }
-    requestDesktopSummaryRefresh(undefined, 0);
-  });
 }
 
 function registerDesktopSummaryLiveRefresh() {
-  registerDesktopSummaryFallbackRefresh();
-
-  void subscribeToDesktopSummaryRefresh((event) => {
-    if (event.source === "pty" && event.pane_id) {
-      if (event.pane_id === OPERATOR_PTY_ID) {
-        if (event.reason === "pty.close") {
-          markOperatorPtyStoppedFromExternalEvent();
-        } else if (event.reason === "pty.spawn" || event.reason === "pty.respawn") {
-          markOperatorPtyStartedFromExternalEvent();
-        }
-      } else {
-        const workbenchPaneId = resolveWorkbenchPaneIdForBackendPaneId(event.pane_id);
-        if (workbenchPaneId && event.reason === "pty.close") {
-          markPanePtyStoppedFromExternalEvent(workbenchPaneId);
-        } else if (workbenchPaneId && (event.reason === "pty.spawn" || event.reason === "pty.respawn")) {
-          markPanePtyStartedFromExternalEvent(workbenchPaneId);
-        }
-      }
-    }
-    if (event.source !== "pty") {
-      desktopSummaryLastStreamSignalAt = Date.now();
-    }
-    requestDesktopSummaryRefresh(event.run_id, 0);
-  }).then(() => {
-    desktopSummaryLiveRefreshAvailable = true;
-  }).catch((error) => {
-    console.warn("Failed to subscribe to desktop summary refresh events", error);
-    desktopSummaryLiveRefreshAvailable = false;
-  });
+  desktopSummaryRefreshScheduler.registerLiveRefresh();
 }
 
 function initializeSidebarResize() {


### PR DESCRIPTION
## Summary

- Extract desktop summary refresh scheduling from `main.ts` into `desktopSummaryScheduler.ts`.
- Keep snapshot loading, diff application, cache invalidation, and DOM rendering in `main.ts`.
- Add a focused scheduler check for debounce, in-flight queueing, live refresh, fallback freshness, and hidden-document suppression.

## Validation

- `npm run test:desktop-summary-scheduler`
- `npm run build`
- `npm run test:worker-start-planning`
- `npm run test:composer-session-controls`
- `npm run test:source-graph`
- `pwsh -NoProfile -File scripts/audit-public-surface.ps1`
- `pwsh -NoProfile -File scripts/git-guard.ps1 -Mode full`
- `git diff --check`

## Review

- Local winsmux review PASS recorded for `codex/task-640-desktop-summary-scheduler`.
- Independent staged-diff review found no blocking issues.
