### PR TITLE
refactor(app): extract settings preference controls

### DIFF
--- a/winsmux-app/package.json
+++ b/winsmux-app/package.json
@@ -17,6 +17,7 @@
     "test:desktop-status-e2e": "node ./scripts/desktop-pane-e2e.mjs --stop-after-worker-status",
     "test:desktop-summary-scheduler": "node --experimental-strip-types ./scripts/desktop-summary-scheduler-check.mjs",
     "test:editor-targets": "node ./scripts/editor-targets-check.mjs",
+    "test:settings-preference-options": "node --experimental-strip-types ./scripts/settings-preference-options-check.mjs",
     "test:worker-pane-routing": "node ./scripts/worker-pane-routing-check.mjs",
     "test:worker-readiness-prompt": "node ./scripts/worker-readiness-prompt-check.mjs",
     "generate:common-contract-bindings": "node ./scripts/generate-common-contract-bindings.mjs",

--- a/winsmux-app/scripts/settings-preference-options-check.mjs
+++ b/winsmux-app/scripts/settings-preference-options-check.mjs
@@ -1,0 +1,139 @@
+import assert from "node:assert/strict";
+import {
+  getSettingsPreferenceDescription,
+  getSettingsPreferenceLabel,
+  renderSettingsPreferenceOptions,
+} from "../src/settingsPreferenceOptions.ts";
+import {
+  filterSettingsSections,
+  getSettingsSectionScope,
+  getSettingsTabScope,
+  shouldDisableSettingsNavItem,
+} from "../src/settingsNavigation.ts";
+
+class FakeElement {
+  constructor(tagName, ownerDocument) {
+    this.tagName = tagName;
+    this.ownerDocument = ownerDocument;
+    this.children = [];
+    this.attributes = new Map();
+    this.listeners = new Map();
+    this.className = "";
+    this.textContent = "";
+    this.type = "";
+  }
+
+  set innerHTML(_value) {
+    this.children = [];
+  }
+
+  setAttribute(name, value) {
+    this.attributes.set(name, String(value));
+  }
+
+  getAttribute(name) {
+    return this.attributes.get(name) ?? null;
+  }
+
+  replaceChildren(...children) {
+    this.children = children;
+  }
+
+  appendChild(child) {
+    this.children.push(child);
+  }
+
+  addEventListener(type, listener) {
+    this.listeners.set(type, listener);
+  }
+
+  click() {
+    this.listeners.get("click")?.();
+  }
+}
+
+class FakeDocument {
+  createElement(tagName) {
+    return new FakeElement(tagName, this);
+  }
+}
+
+const options = [
+  {
+    value: "system",
+    label: "System",
+    labelJa: "システム",
+    description: "Follow the operating system appearance.",
+    descriptionJa: "OS の外観設定に合わせます。",
+  },
+  {
+    value: "light",
+    label: "Light",
+    description: "Use a bright workspace.",
+  },
+];
+
+assert.equal(getSettingsPreferenceLabel(options[0], true), "システム");
+assert.equal(getSettingsPreferenceLabel(options[1], true), "Light", "Japanese labels should fall back to the English label");
+assert.equal(getSettingsPreferenceDescription(options[0], true), "OS の外観設定に合わせます。");
+assert.equal(
+  getSettingsPreferenceDescription(options[1], true),
+  "Use a bright workspace.",
+  "Japanese descriptions should fall back to the English description",
+);
+
+const fakeDocument = new FakeDocument();
+const root = fakeDocument.createElement("div");
+const selectedValues = [];
+
+const rendered = renderSettingsPreferenceOptions(root, options, "system", true, (value) => {
+  selectedValues.push(value);
+});
+
+assert.equal(rendered, true);
+assert.equal(root.children.length, 2, "all preference options should render");
+assert.equal(root.children[0].className, "settings-option-chip is-active");
+assert.equal(root.children[0].getAttribute("aria-pressed"), "true");
+assert.equal(root.children[0].children[0].textContent, "システム");
+assert.equal(root.children[0].children[1].textContent, "OS の外観設定に合わせます。");
+assert.equal(root.children[1].className, "settings-option-chip ");
+assert.equal(root.children[1].getAttribute("aria-pressed"), "false");
+assert.equal(root.children[1].children[0].textContent, "Light");
+root.children[1].click();
+assert.deepEqual(selectedValues, ["light"], "clicking an option should report its value");
+
+assert.equal(
+  renderSettingsPreferenceOptions(null, options, "system", false, () => {}),
+  false,
+  "missing roots should be treated as a no-op",
+);
+
+assert.equal(getSettingsSectionScope("settings-section-workspace"), "workspace");
+assert.equal(getSettingsSectionScope("settings-section-common"), "user");
+assert.equal(getSettingsTabScope("settings-tab-workspace"), "workspace");
+assert.equal(getSettingsTabScope("settings-tab-user"), "user");
+
+const filtered = filterSettingsSections(
+  [
+    { id: "settings-section-common", text: "Theme Density" },
+    { id: "settings-section-workspace", text: "Project directory" },
+    { id: "settings-section-runtime", text: "Provider model" },
+  ],
+  "user",
+  "model",
+);
+
+assert.equal(filtered.firstVisibleId, "settings-section-runtime");
+assert.deepEqual(
+  filtered.items.map((item) => [item.id, item.scope, item.visible]),
+  [
+    ["settings-section-common", "user", false],
+    ["settings-section-workspace", "workspace", false],
+    ["settings-section-runtime", "user", true],
+  ],
+);
+assert.equal(shouldDisableSettingsNavItem("user", "user", "model", true), true);
+assert.equal(shouldDisableSettingsNavItem("workspace", "user", "model", true), false);
+assert.equal(shouldDisableSettingsNavItem("user", "user", "", true), false);
+
+console.log("settings-preference-options-check passed");

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -17105,9 +17105,11 @@ function updateSettingsSearchFilter() {
   document.querySelectorAll<HTMLButtonElement>(".settings-nav-item").forEach((button) => {
     const targetId = button.dataset.settingsTarget ?? "";
     const target = document.getElementById(targetId);
-    const inScope = getSettingsSectionScope(targetId) === settingsScope;
+    const targetScope = getSettingsSectionScope(targetId);
+    const inScope = targetScope === settingsScope;
     button.hidden = !inScope;
-    const disabled = shouldDisableSettingsNavItem(getSettingsSectionScope(targetId), settingsScope, query, target instanceof HTMLElement && target.hidden);
+    const targetHidden = target instanceof HTMLElement ? Boolean(target.hidden) : false;
+    const disabled = shouldDisableSettingsNavItem(targetScope, settingsScope, query, targetHidden);
     button.disabled = disabled;
     button.setAttribute("aria-disabled", disabled ? "true" : "false");
   });

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -78,6 +78,17 @@ import {
   DesktopSummaryRefreshScheduler,
   type DesktopSummaryRefreshContext,
 } from "./desktopSummaryScheduler";
+import {
+  renderSettingsPreferenceOptions,
+  type SettingsPreferenceOption,
+} from "./settingsPreferenceOptions";
+import {
+  filterSettingsSections,
+  getSettingsSectionScope,
+  getSettingsTabScope,
+  shouldDisableSettingsNavItem,
+  type SettingsScope,
+} from "./settingsNavigation";
 
 interface PaneEntry {
   terminal: Terminal;
@@ -401,7 +412,6 @@ type WrapMode = "balanced" | "compact";
 type CodeFontMode = "system" | "google-sans-code" | "jetbrains-mono";
 type FocusMode = "standard" | "focused";
 type LanguageMode = "en" | "ja";
-type SettingsScope = "user" | "workspace";
 type WorkbenchLayoutMode = "2x2" | "3x2" | "focus";
 type RuntimeRoleId = "operator" | "worker" | "reviewer";
 type RuntimeProviderId = ProviderCapabilityId;
@@ -1315,34 +1325,34 @@ const timelineFilterLabelsJa: Record<TimelineFilter, string> = {
   activity: "活動",
 };
 
-const themeOptions: Array<{ value: ThemeMode; label: string; description: string; labelJa?: string; descriptionJa?: string }> = [
+const themeOptions: SettingsPreferenceOption<ThemeMode>[] = [
   { value: "system", label: "System", labelJa: "システム", description: "Follow the operating system appearance.", descriptionJa: "OS の外観設定に合わせます。" },
   { value: "light", label: "Light", labelJa: "ライト", description: "Use a bright Codex-style workspace.", descriptionJa: "明るい Codex 風の作業領域にします。" },
   { value: "dark", label: "Dark", labelJa: "ダーク", description: "Use a dark Codex-style workspace.", descriptionJa: "暗い Codex 風の作業領域にします。" },
 ];
 
-const densityOptions: Array<{ value: DensityMode; label: string; description: string; labelJa?: string; descriptionJa?: string }> = [
+const densityOptions: SettingsPreferenceOption<DensityMode>[] = [
   { value: "comfortable", label: "Comfortable", labelJa: "標準", description: "Default shell spacing for conversation and context.", descriptionJa: "会話と文脈パネルを読みやすくする標準の余白。" },
   { value: "compact", label: "Compact", labelJa: "コンパクト", description: "Tighter panel spacing and smaller composer height.", descriptionJa: "パネル間隔と入力欄を詰めた表示。" },
 ];
 
-const wrapOptions: Array<{ value: WrapMode; label: string; description: string; labelJa?: string; descriptionJa?: string }> = [
+const wrapOptions: SettingsPreferenceOption<WrapMode>[] = [
   { value: "balanced", label: "Balanced", labelJa: "読みやすさ優先", description: "Preferred readability for timeline, code, and footer lanes.", descriptionJa: "タイムライン、コード、下部ステータスを読みやすく折り返します。" },
   { value: "compact", label: "Compact", labelJa: "密度優先", description: "Denser wrapping for narrow windows and long traces.", descriptionJa: "狭い画面や長いログで情報量を優先します。" },
 ];
 
-const codeFontOptions: Array<{ value: CodeFontMode; label: string; description: string; labelJa?: string; descriptionJa?: string }> = [
+const codeFontOptions: SettingsPreferenceOption<CodeFontMode>[] = [
   { value: "system", label: "Consolas / Courier New", labelJa: "Consolas / Courier New", description: "Windows developer default: Consolas, 'Courier New', monospace.", descriptionJa: "Windows 開発環境の既定値: Consolas, 'Courier New', monospace。" },
   { value: "google-sans-code", label: "Google Sans Code", labelJa: "Google Sans Code", description: "Use Google Sans Code when it is installed.", descriptionJa: "インストール済みの時に Google Sans Code を使います。" },
   { value: "jetbrains-mono", label: "JetBrains Mono", labelJa: "JetBrains Mono", description: "Use JetBrains Mono when it is installed.", descriptionJa: "インストール済みの時に JetBrains Mono を使います。" },
 ];
 
-const focusModeOptions: Array<{ value: FocusMode; label: string; description: string; labelJa?: string; descriptionJa?: string }> = [
+const focusModeOptions: SettingsPreferenceOption<FocusMode>[] = [
   { value: "standard", label: "Standard", labelJa: "標準", description: "Show timeline detail chips on every event.", descriptionJa: "すべての出来事に詳細チップを表示します。" },
   { value: "focused", label: "Focus", labelJa: "集中", description: "Keep details for selected, review, and attention events.", descriptionJa: "選択中、レビュー、注意が必要な出来事だけ詳細を残します。" },
 ];
 
-const languageOptions: Array<{ value: LanguageMode; label: string; description: string; labelJa?: string; descriptionJa?: string }> = [
+const languageOptions: SettingsPreferenceOption<LanguageMode>[] = [
   { value: "en", label: "English", labelJa: "English", description: "Use English for the workspace chrome and controls.", descriptionJa: "作業領域と操作部品を英語で表示します。" },
   { value: "ja", label: "Japanese", labelJa: "日本語", description: "Use Japanese for the main workspace chrome and settings.", descriptionJa: "主要な操作部品と設定を日本語で表示します。" },
 ];
@@ -10532,29 +10542,13 @@ function applyCodeFontToPanes(state: ThemeState = themeState) {
 
 function renderPreferenceOptions<T extends string>(
   rootId: string,
-  options: Array<{ value: T; label: string; description: string; labelJa?: string; descriptionJa?: string }>,
+  options: readonly SettingsPreferenceOption<T>[],
   selected: T,
   onSelect: (value: T) => void,
 ) {
   const root = document.getElementById(rootId);
-  if (!root) {
-    return;
-  }
-
-  root.innerHTML = "";
   const japanese = (settingsDraftState?.language ?? themeState.language) === "ja";
-  for (const option of options) {
-    const button = document.createElement("button");
-    button.type = "button";
-    button.className = `settings-option-chip ${option.value === selected ? "is-active" : ""}`;
-    button.setAttribute("aria-pressed", option.value === selected ? "true" : "false");
-    button.replaceChildren(
-      createTextElement("span", "settings-option-label", japanese ? (option.labelJa ?? option.label) : option.label),
-      createTextElement("span", "settings-option-description", japanese ? (option.descriptionJa ?? option.description) : option.description),
-    );
-    button.addEventListener("click", () => onSelect(option.value));
-    root.appendChild(button);
-  }
+  renderSettingsPreferenceOptions(root, options, selected, japanese, onSelect);
 }
 
 function getSettingsDraftState() {
@@ -17065,13 +17059,9 @@ function getSettingsSections() {
   return Array.from(document.querySelectorAll<HTMLElement>("#settings-content .settings-section"));
 }
 
-function getSettingsSectionScope(sectionId: string): SettingsScope {
-  return sectionId === "settings-section-workspace" ? "workspace" : "user";
-}
-
 function syncSettingsScopeControls() {
   document.querySelectorAll<HTMLButtonElement>(".settings-tab").forEach((button) => {
-    const scope: SettingsScope = button.id === "settings-tab-workspace" ? "workspace" : "user";
+    const scope = getSettingsTabScope(button.id);
     const selected = scope === settingsScope;
     button.classList.toggle("is-active", selected);
     button.setAttribute("aria-selected", selected ? "true" : "false");
@@ -17099,15 +17089,17 @@ function updateSettingsSearchFilter() {
   const input = document.getElementById("settings-search-input") as HTMLInputElement | null;
   const query = input?.value.trim().toLowerCase() ?? "";
   const sections = getSettingsSections();
-  let firstVisibleId = "";
+  const visibility = filterSettingsSections(
+    sections.map((section) => ({
+      id: section.id,
+      text: section.textContent ?? "",
+    })),
+    settingsScope,
+    query,
+  );
+  const visibilityById = new Map(visibility.items.map((item) => [item.id, item]));
   for (const section of sections) {
-    const text = section.textContent?.toLowerCase() ?? "";
-    const inScope = getSettingsSectionScope(section.id) === settingsScope;
-    const visible = inScope && (!query || text.includes(query));
-    section.hidden = !visible;
-    if (visible && !firstVisibleId) {
-      firstVisibleId = section.id;
-    }
+    section.hidden = !visibilityById.get(section.id)?.visible;
   }
 
   document.querySelectorAll<HTMLButtonElement>(".settings-nav-item").forEach((button) => {
@@ -17115,13 +17107,13 @@ function updateSettingsSearchFilter() {
     const target = document.getElementById(targetId);
     const inScope = getSettingsSectionScope(targetId) === settingsScope;
     button.hidden = !inScope;
-    const disabled = inScope && Boolean(query && target instanceof HTMLElement && target.hidden);
+    const disabled = shouldDisableSettingsNavItem(getSettingsSectionScope(targetId), settingsScope, query, target instanceof HTMLElement && target.hidden);
     button.disabled = disabled;
     button.setAttribute("aria-disabled", disabled ? "true" : "false");
   });
 
-  if (firstVisibleId) {
-    setActiveSettingsNav(firstVisibleId);
+  if (visibility.firstVisibleId) {
+    setActiveSettingsNav(visibility.firstVisibleId);
   }
 }
 
@@ -17194,7 +17186,7 @@ function initializeSettingsDialogControls() {
 
   document.querySelectorAll<HTMLButtonElement>(".settings-tab").forEach((button) => {
     button.addEventListener("click", () => {
-      setSettingsScope(button.id === "settings-tab-workspace" ? "workspace" : "user");
+      setSettingsScope(getSettingsTabScope(button.id));
     });
   });
 }

--- a/winsmux-app/src/settingsNavigation.ts
+++ b/winsmux-app/src/settingsNavigation.ts
@@ -1,0 +1,53 @@
+export type SettingsScope = "user" | "workspace";
+
+export interface SettingsSectionCandidate {
+  id: string;
+  text: string;
+}
+
+export interface SettingsSectionVisibility {
+  id: string;
+  scope: SettingsScope;
+  visible: boolean;
+}
+
+export function getSettingsSectionScope(sectionId: string): SettingsScope {
+  return sectionId === "settings-section-workspace" ? "workspace" : "user";
+}
+
+export function getSettingsTabScope(tabId: string): SettingsScope {
+  return tabId === "settings-tab-workspace" ? "workspace" : "user";
+}
+
+export function filterSettingsSections(
+  sections: readonly SettingsSectionCandidate[],
+  scope: SettingsScope,
+  query: string,
+) {
+  const normalizedQuery = query.trim().toLowerCase();
+  let firstVisibleId = "";
+  const items: SettingsSectionVisibility[] = sections.map((section) => {
+    const sectionScope = getSettingsSectionScope(section.id);
+    const visible = sectionScope === scope && (!normalizedQuery || section.text.toLowerCase().includes(normalizedQuery));
+    if (visible && !firstVisibleId) {
+      firstVisibleId = section.id;
+    }
+    return {
+      id: section.id,
+      scope: sectionScope,
+      visible,
+    };
+  });
+
+  return {
+    firstVisibleId,
+    items,
+  };
+}
+
+export function shouldDisableSettingsNavItem(targetScope: SettingsScope, currentScope: SettingsScope, query: string, targetHidden: boolean) {
+  if (targetScope !== currentScope) {
+    return false;
+  }
+  return Boolean(query.trim() && targetHidden);
+}

--- a/winsmux-app/src/settingsPreferenceOptions.ts
+++ b/winsmux-app/src/settingsPreferenceOptions.ts
@@ -1,0 +1,50 @@
+export interface SettingsPreferenceOption<T extends string> {
+  value: T;
+  label: string;
+  description: string;
+  labelJa?: string;
+  descriptionJa?: string;
+}
+
+export function getSettingsPreferenceLabel<T extends string>(option: SettingsPreferenceOption<T>, japanese: boolean) {
+  return japanese ? (option.labelJa ?? option.label) : option.label;
+}
+
+export function getSettingsPreferenceDescription<T extends string>(option: SettingsPreferenceOption<T>, japanese: boolean) {
+  return japanese ? (option.descriptionJa ?? option.description) : option.description;
+}
+
+export function renderSettingsPreferenceOptions<T extends string>(
+  root: HTMLElement | null,
+  options: readonly SettingsPreferenceOption<T>[],
+  selected: T,
+  japanese: boolean,
+  onSelect: (value: T) => void,
+) {
+  if (!root) {
+    return false;
+  }
+
+  root.innerHTML = "";
+  const doc = root.ownerDocument;
+  for (const option of options) {
+    const button = doc.createElement("button");
+    button.type = "button";
+    button.className = `settings-option-chip ${option.value === selected ? "is-active" : ""}`;
+    button.setAttribute("aria-pressed", option.value === selected ? "true" : "false");
+
+    const label = doc.createElement("span");
+    label.className = "settings-option-label";
+    label.textContent = getSettingsPreferenceLabel(option, japanese);
+
+    const description = doc.createElement("span");
+    description.className = "settings-option-description";
+    description.textContent = getSettingsPreferenceDescription(option, japanese);
+
+    button.replaceChildren(label, description);
+    button.addEventListener("click", () => onSelect(option.value));
+    root.appendChild(button);
+  }
+
+  return true;
+}


### PR DESCRIPTION
## Summary

- Extract settings preference option rendering into a focused helper.
- Extract settings section scope, tab scope, search filtering, and navigation disabled-state logic into a focused helper.
- Add a Node check that covers Japanese fallbacks, option rendering, click callbacks, scope selection, filtering, and disabled-state behavior.

## Test Plan

- `git diff --cached --check`
- `npm run test:settings-preference-options`
- `npm run test:composer-session-controls`
- `npm run test:common-contract-package`
- `npm run build`
- `pwsh -NoProfile -File scripts\audit-public-surface.ps1`
- `pwsh -NoProfile -File scripts\git-guard.ps1 -Mode full`
