### PR TITLE
refactor(app): extract project explorer tree builder

### DIFF
--- a/winsmux-app/package.json
+++ b/winsmux-app/package.json
@@ -17,6 +17,7 @@
     "test:desktop-status-e2e": "node ./scripts/desktop-pane-e2e.mjs --stop-after-worker-status",
     "test:desktop-summary-scheduler": "node --experimental-strip-types ./scripts/desktop-summary-scheduler-check.mjs",
     "test:editor-targets": "node ./scripts/editor-targets-check.mjs",
+    "test:project-explorer-tree": "node ./scripts/project-explorer-tree-check.mjs",
     "test:settings-preference-options": "node --experimental-strip-types ./scripts/settings-preference-options-check.mjs",
     "test:worker-pane-routing": "node ./scripts/worker-pane-routing-check.mjs",
     "test:worker-readiness-prompt": "node ./scripts/worker-readiness-prompt-check.mjs",

--- a/winsmux-app/scripts/project-explorer-tree-check.mjs
+++ b/winsmux-app/scripts/project-explorer-tree-check.mjs
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import ts from "typescript";
+
+async function loadProjectExplorerTreeModule() {
+  const sourcePath = path.resolve("src/projectExplorerTree.ts");
+  const source = await readFile(sourcePath, "utf8");
+  const transpiled = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.ESNext,
+      target: ts.ScriptTarget.ES2020,
+    },
+    fileName: sourcePath,
+  });
+
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "winsmux-project-explorer-tree-"));
+  const modulePath = path.join(tempDir, "projectExplorerTree.mjs");
+  await writeFile(modulePath, transpiled.outputText, "utf8");
+
+  try {
+    return await import(pathToFileURL(modulePath).href);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+const {
+  buildProjectExplorerTree,
+  compareProjectExplorerNodes,
+  createProjectExplorerTreeNode,
+  getProjectExplorerChildKey,
+} = await loadProjectExplorerTreeModule();
+
+assert.equal(getProjectExplorerChildKey("SRC"), "src");
+
+const tree = buildProjectExplorerTree([
+  { path: "src/main.ts", kind: "file" },
+  { path: "src/components/App.ts", kind: "file", ignored: true },
+  { path: "README.md", kind: "file" },
+  { path: "src", kind: "directory", has_children: true },
+  { path: "Src/ignored.log", kind: "file", ignored: true },
+]);
+
+const src = tree.get("src");
+assert.equal(src.kind, "directory");
+assert.equal(src.hasChildren, true);
+assert.equal(src.path, "src");
+assert.equal(src.children.get("main.ts").kind, "file");
+assert.equal(src.children.get("components").kind, "directory");
+assert.equal(src.children.get("components").children.get("app.ts").ignored, true);
+assert.equal(src.children.get("ignored.log").ignored, true);
+
+const sorted = [
+  createProjectExplorerTreeNode("z-file.ts", "z-file.ts", "file"),
+  createProjectExplorerTreeNode("App", "App", "directory"),
+  createProjectExplorerTreeNode("readme.md", "readme.md", "file"),
+].sort(compareProjectExplorerNodes);
+
+assert.deepEqual(sorted.map((node) => node.label), ["App", "readme.md", "z-file.ts"]);
+
+console.log("project-explorer-tree-check: ok");

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -52,6 +52,11 @@ import {
 } from "./ptyClient";
 import { isComposerCommandText, normalizeComposerPlainTextPaste } from "./composerText";
 import {
+  buildProjectExplorerTree,
+  compareProjectExplorerNodes,
+  type ProjectExplorerTreeNode,
+} from "./projectExplorerTree";
+import {
   getRuntimeCatalogEntries,
   openRouterModelsApiUrl,
   type AgentVaultCommandProviderId,
@@ -245,15 +250,6 @@ interface EditorFile {
   modified?: boolean;
   origin: "explorer" | "context";
   active?: boolean;
-}
-
-interface ProjectExplorerTreeNode {
-  label: string;
-  path: string;
-  kind: "directory" | "file";
-  hasChildren?: boolean;
-  ignored?: boolean;
-  children: Map<string, ProjectExplorerTreeNode>;
 }
 
 interface EditorTarget {
@@ -6015,71 +6011,6 @@ function getExplorerRootLabel(worktreeKey: string) {
   const normalized = activeProject?.replace(/\\/g, "/").replace(/\/+$/, "");
   const name = normalized?.split("/").filter(Boolean).pop();
   return (name || "winsmux").toUpperCase();
-}
-
-function compareProjectExplorerNodes(left: ProjectExplorerTreeNode, right: ProjectExplorerTreeNode) {
-  const leftIsFile = left.kind === "file";
-  const rightIsFile = right.kind === "file";
-  if (leftIsFile !== rightIsFile) {
-    return leftIsFile ? 1 : -1;
-  }
-  return left.label.localeCompare(right.label, undefined, { sensitivity: "base" });
-}
-
-function getProjectExplorerChildKey(label: string) {
-  return label.toLocaleLowerCase();
-}
-
-function createProjectExplorerTreeNode(
-  label: string,
-  path: string,
-  kind: "directory" | "file",
-  hasChildren?: boolean,
-  ignored?: boolean,
-): ProjectExplorerTreeNode {
-  return {
-    label,
-    path,
-    kind,
-    hasChildren,
-    ignored,
-    children: new Map<string, ProjectExplorerTreeNode>(),
-  };
-}
-
-function buildProjectExplorerTree(entries: DesktopExplorerEntry[]) {
-  const rootChildren = new Map<string, ProjectExplorerTreeNode>();
-
-  for (const entry of entries) {
-    const segments = entry.path.split("/").filter(Boolean);
-    let currentChildren = rootChildren;
-    let currentPath = "";
-
-    segments.forEach((segment, index) => {
-      currentPath = currentPath ? `${currentPath}/${segment}` : segment;
-      const isFinalSegment = index === segments.length - 1;
-      const nodeKind = isFinalSegment ? entry.kind : "directory";
-      const childKey = getProjectExplorerChildKey(segment);
-      let node = currentChildren.get(childKey);
-
-      if (!node) {
-        node = createProjectExplorerTreeNode(segment, currentPath, nodeKind, isFinalSegment ? entry.has_children : true, isFinalSegment ? entry.ignored : false);
-        currentChildren.set(childKey, node);
-      } else if (nodeKind === "directory") {
-        node.kind = "directory";
-      }
-      if (node.kind === "directory") {
-        node.hasChildren = node.hasChildren || !isFinalSegment || entry.has_children;
-      }
-      if (isFinalSegment && entry.ignored) {
-        node.ignored = true;
-      }
-
-      currentChildren = node.children;
-    });
-  }
-
-  return rootChildren;
 }
 
 function appendProjectExplorerTreeItems(

--- a/winsmux-app/src/projectExplorerTree.ts
+++ b/winsmux-app/src/projectExplorerTree.ts
@@ -1,0 +1,86 @@
+export interface ProjectExplorerEntryLike {
+  path: string;
+  kind: "directory" | "file";
+  has_children?: boolean;
+  ignored?: boolean;
+}
+
+export interface ProjectExplorerTreeNode {
+  label: string;
+  path: string;
+  kind: "directory" | "file";
+  hasChildren?: boolean;
+  ignored?: boolean;
+  children: Map<string, ProjectExplorerTreeNode>;
+}
+
+export function compareProjectExplorerNodes(left: ProjectExplorerTreeNode, right: ProjectExplorerTreeNode) {
+  const leftIsFile = left.kind === "file";
+  const rightIsFile = right.kind === "file";
+  if (leftIsFile !== rightIsFile) {
+    return leftIsFile ? 1 : -1;
+  }
+  return left.label.localeCompare(right.label, undefined, { sensitivity: "base" });
+}
+
+export function getProjectExplorerChildKey(label: string) {
+  return label.toLocaleLowerCase();
+}
+
+export function createProjectExplorerTreeNode(
+  label: string,
+  path: string,
+  kind: "directory" | "file",
+  hasChildren?: boolean,
+  ignored?: boolean,
+): ProjectExplorerTreeNode {
+  return {
+    label,
+    path,
+    kind,
+    hasChildren,
+    ignored,
+    children: new Map<string, ProjectExplorerTreeNode>(),
+  };
+}
+
+export function buildProjectExplorerTree(entries: ProjectExplorerEntryLike[]) {
+  const rootChildren = new Map<string, ProjectExplorerTreeNode>();
+
+  for (const entry of entries) {
+    const segments = entry.path.split("/").filter(Boolean);
+    let currentChildren = rootChildren;
+    let currentPath = "";
+
+    segments.forEach((segment, index) => {
+      currentPath = currentPath ? `${currentPath}/${segment}` : segment;
+      const isFinalSegment = index === segments.length - 1;
+      const nodeKind = isFinalSegment ? entry.kind : "directory";
+      const childKey = getProjectExplorerChildKey(segment);
+      let node = currentChildren.get(childKey);
+
+      if (!node) {
+        node = createProjectExplorerTreeNode(
+          segment,
+          currentPath,
+          nodeKind,
+          isFinalSegment ? entry.has_children : true,
+          isFinalSegment ? entry.ignored : false,
+        );
+        currentChildren.set(childKey, node);
+      } else if (nodeKind === "directory") {
+        node.kind = "directory";
+      }
+      if (node.kind === "directory") {
+        node.hasChildren = node.hasChildren || !isFinalSegment || entry.has_children;
+      }
+      if (isFinalSegment && entry.ignored) {
+        node.ignored = true;
+      }
+
+      currentChildren = node.children;
+    });
+  }
+
+  return rootChildren;
+}


### PR DESCRIPTION
## Summary
- Extract project explorer tree construction from the desktop entrypoint into `projectExplorerTree.ts`
- Add a focused project explorer tree check for hierarchy building, case-insensitive child keys, ignored state, and folder-first sorting
- Wire the focused check into `package.json`

## Test Plan
- `npm run test:project-explorer-tree`
- `npm run test:editor-targets`
- `npm run test:source-graph`
- `npm run test:worker-pane-routing`
- `npm run test:worker-start-planning`
- `npm run build`
- `pwsh -NoProfile -File scripts\audit-public-surface.ps1`
- `pwsh -NoProfile -File scripts\git-guard.ps1 -Mode full`

## Review
- Subagent staged diff review: no findings
