### PR TITLE
refactor(app): extract conversation timeline helpers

### DIFF
--- a/winsmux-app/package.json
+++ b/winsmux-app/package.json
@@ -9,6 +9,7 @@
     "build": "tsc && vite build",
     "test:composer-session-controls": "node ./scripts/composer-session-controls-check.mjs",
     "test:composer-text": "node ./scripts/composer-text-check.mjs",
+    "test:conversation-timeline": "node ./scripts/conversation-timeline-check.mjs",
     "test:clickable-coverage": "npm run build && node ./scripts/clickable-coverage-harness.mjs",
     "test:desktop-pane-e2e": "node ./scripts/desktop-pane-e2e.mjs",
     "test:desktop-launch-arg-e2e": "node ./scripts/desktop-pane-e2e.mjs --launch-project-only",

--- a/winsmux-app/scripts/conversation-timeline-check.mjs
+++ b/winsmux-app/scripts/conversation-timeline-check.mjs
@@ -1,0 +1,167 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import ts from "typescript";
+
+async function loadConversationTimelineModule() {
+  const sourcePath = path.resolve("src/conversationTimeline.ts");
+  const source = await readFile(sourcePath, "utf8");
+  const transpiled = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.ESNext,
+      target: ts.ScriptTarget.ES2020,
+    },
+    fileName: sourcePath,
+  });
+
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "winsmux-conversation-timeline-"));
+  const modulePath = path.join(tempDir, "conversationTimeline.mjs");
+  await writeFile(modulePath, transpiled.outputText, "utf8");
+
+  try {
+    return await import(pathToFileURL(modulePath).href);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+const {
+  buildDesktopSummaryConversation,
+  getVisibleConversationItems,
+  shouldShowTimelineDetails,
+} = await loadConversationTimelineModule();
+
+const snapshot = {
+  generated_at: "2026-07-07T12:34:56.000Z",
+  project_dir: "C:/workspace/winsmux",
+  board: {
+    summary: { pane_count: 6 },
+    panes: [],
+  },
+  inbox: {
+    summary: { item_count: 3 },
+    items: [
+      {
+        pane_id: "worker-1",
+        label: "Worker 1",
+        kind: "review-request",
+        message: "Review is waiting.",
+        branch: "codex/task-a",
+        review_state: "PENDING",
+        task_state: "reviewing",
+      },
+      {
+        pane_id: "worker-2",
+        label: "",
+        kind: "blocked",
+        message: "Worker is blocked.",
+        branch: "",
+        review_state: "",
+        task_state: "blocked",
+      },
+      {
+        pane_id: "worker-3",
+        label: "Hidden third",
+        kind: "info",
+        message: "This should be trimmed.",
+        branch: "codex/task-c",
+        review_state: "PASS",
+        task_state: "done",
+      },
+    ],
+  },
+  digest: {
+    summary: { item_count: 4 },
+    items: [],
+  },
+  run_projections: [
+    {
+      run_id: "run-pass",
+      pane_id: "worker-1",
+      label: "Worker 1",
+      task: "Passing run",
+      branch: "codex/pass",
+      next_action: "",
+      changed_files: ["src/a.ts"],
+      review_state: "PASS",
+      verification_outcome: "PASS",
+    },
+    {
+      run_id: "run-pending",
+      pane_id: "worker-2",
+      label: "Worker 2",
+      task: "Pending review",
+      branch: "",
+      next_action: "review",
+      changed_files: [],
+      review_state: "PENDING",
+      verification_outcome: "",
+    },
+    {
+      run_id: "run-fail",
+      pane_id: "worker-3",
+      label: "",
+      task: "",
+      branch: "codex/fail",
+      next_action: "fix",
+      changed_files: ["src/fail.ts", "src/test.ts"],
+      review_state: "FAILED",
+      verification_outcome: "FAIL",
+    },
+    {
+      run_id: "run-hidden",
+      pane_id: "worker-4",
+      label: "Hidden fourth",
+      task: "Hidden run",
+      branch: "codex/hidden",
+      next_action: "ship",
+      changed_files: [],
+      review_state: "",
+      verification_outcome: "",
+    },
+  ],
+};
+
+const items = buildDesktopSummaryConversation(snapshot, { formatTimestamp: () => "12:34" });
+
+assert.equal(items.length, 6, "summary + top 2 inbox + top 3 digest items should be rendered");
+assert.deepEqual(items[0].details, [
+  { label: "panes", value: "6" },
+  { label: "notifications", value: "3" },
+  { label: "runs", value: "4" },
+]);
+assert.equal(items[0].timestamp, "12:34");
+
+assert.equal(items[1].category, "attention");
+assert.equal(items[1].actor, "Worker 1");
+assert.equal(items[2].actor, "worker-2", "inbox actor should fall back to pane id");
+assert.equal(items.some((item) => item.actor === "Hidden third"), false, "only top two inbox items are included");
+
+const passRun = items.find((item) => item.runId === "run-pass");
+assert.equal(passRun.category, "activity");
+assert.equal(passRun.tone, "success");
+assert.equal(passRun.body, "Next idle · 1 changed files · review PASS.");
+assert.deepEqual(passRun.chips.map((chip) => chip.action), ["open-explain", "open-source-context"]);
+
+const pendingRun = items.find((item) => item.runId === "run-pending");
+assert.equal(pendingRun.category, "review");
+assert.equal(pendingRun.tone, "warning");
+assert.equal(pendingRun.statusLabel, "PENDING");
+
+const failedRun = items.find((item) => item.runId === "run-fail");
+assert.equal(failedRun.category, "review");
+assert.equal(failedRun.actor, "worker-3", "digest actor should fall back to pane id");
+
+assert.deepEqual(getVisibleConversationItems(items, "attention").map((item) => item.category), ["attention", "attention"]);
+assert.deepEqual(getVisibleConversationItems(items, "review").map((item) => item.runId), ["run-pending", "run-fail"]);
+assert.equal(getVisibleConversationItems(items, "activity").every((item) => item.category === "activity" || item.type === "operator"), true);
+assert.equal(getVisibleConversationItems(items, "all").length, items.length);
+
+assert.equal(shouldShowTimelineDetails(passRun, "comfortable", null), true);
+assert.equal(shouldShowTimelineDetails(passRun, "focused", "run-pass"), true);
+assert.equal(shouldShowTimelineDetails(passRun, "focused", "other-run"), false);
+assert.equal(shouldShowTimelineDetails(pendingRun, "focused", "other-run"), true);
+
+console.log("conversation-timeline-check: ok");

--- a/winsmux-app/src/conversationTimeline.ts
+++ b/winsmux-app/src/conversationTimeline.ts
@@ -1,0 +1,160 @@
+import type { DesktopSummarySnapshot } from "./desktopClient";
+
+export type ChipAction =
+  | "open-explain"
+  | "open-editor"
+  | "open-source-context"
+  | "toggle-context"
+  | "open-terminal";
+
+export type TimelineFilter = "all" | "attention" | "review" | "activity";
+export type ConversationCategory = "user" | "attention" | "review" | "activity";
+export type SurfaceTone = "default" | "accent" | "success" | "warning" | "danger" | "info" | "focus";
+
+export interface ConversationChip {
+  label: string;
+  action: ChipAction;
+}
+
+export interface ConversationDetail {
+  label: string;
+  value: string;
+}
+
+export interface ConversationItem {
+  type: "user" | "operator" | "system";
+  category: ConversationCategory;
+  timestamp: string;
+  actor: string;
+  title?: string;
+  body: string;
+  details?: ConversationDetail[];
+  chips?: ConversationChip[];
+  attachments?: Array<{ name: string; kind: "image" | "file"; sizeLabel: string }>;
+  tone?: SurfaceTone;
+  runId?: string;
+  statusLabel?: string;
+}
+
+export interface BuildDesktopSummaryConversationOptions {
+  formatTimestamp?: (value: string) => string;
+}
+
+export function formatDesktopSummaryConversationTimestamp(value: string) {
+  return new Date(value).toLocaleTimeString([], {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  });
+}
+
+function getDigestConversationCategory(reviewState: string): ConversationCategory {
+  return reviewState === "PENDING" || reviewState === "FAIL" || reviewState === "FAILED"
+    ? "review"
+    : "activity";
+}
+
+function getDigestConversationTone(reviewState: string): SurfaceTone {
+  return reviewState === "PASS" ? "success" : reviewState === "PENDING" ? "warning" : "info";
+}
+
+export function buildDesktopSummaryConversation(
+  snapshot: DesktopSummarySnapshot,
+  options: BuildDesktopSummaryConversationOptions = {},
+): ConversationItem[] {
+  const board = snapshot.board.summary;
+  const digest = snapshot.digest.summary;
+  const inbox = snapshot.inbox.summary;
+  const topInboxItems = snapshot.inbox.items.slice(0, 2);
+  const topDigestItems = snapshot.run_projections.slice(0, 3);
+  const timestamp = (options.formatTimestamp ?? formatDesktopSummaryConversationTimestamp)(snapshot.generated_at);
+
+  const items: ConversationItem[] = [
+    {
+      type: "operator",
+      category: "activity",
+      timestamp,
+      actor: "Operator",
+      title: "Summary stream connected",
+      body: "Tauri is reading board, notifications, and digest surfaces from the backend adapter instead of treating raw PTY output as the primary UI source.",
+      details: [
+        { label: "panes", value: `${board.pane_count}` },
+        { label: "notifications", value: `${inbox.item_count}` },
+        { label: "runs", value: `${digest.item_count}` },
+      ],
+      tone: "info",
+    },
+  ];
+
+  for (const topInboxItem of topInboxItems) {
+    items.push({
+      type: "system",
+      category: "attention",
+      timestamp,
+      actor: topInboxItem.label || topInboxItem.pane_id || "System",
+      title: `Notification: ${topInboxItem.kind}`,
+      body: topInboxItem.message,
+      details: [
+        { label: "branch", value: topInboxItem.branch || "no branch" },
+        { label: "review", value: topInboxItem.review_state || "n/a" },
+        { label: "task", value: topInboxItem.task_state || "n/a" },
+      ],
+      tone: "warning",
+      statusLabel: topInboxItem.kind,
+    });
+  }
+
+  for (const digestItem of topDigestItems) {
+    items.push({
+      type: "operator",
+      category: getDigestConversationCategory(digestItem.review_state),
+      timestamp,
+      actor: digestItem.label || digestItem.pane_id || "Operator",
+      title: digestItem.task || "Projected run",
+      body: `Next ${digestItem.next_action || "idle"} · ${digestItem.changed_files.length} changed files · review ${digestItem.review_state || "n/a"}.`,
+      details: [
+        { label: "run", value: digestItem.run_id },
+        { label: "branch", value: digestItem.branch || "no branch" },
+        { label: "verify", value: digestItem.verification_outcome || "n/a" },
+      ],
+      tone: getDigestConversationTone(digestItem.review_state),
+      runId: digestItem.run_id,
+      statusLabel: digestItem.review_state || digestItem.next_action || undefined,
+      chips: [
+        { label: "Open Explain", action: "open-explain" },
+        { label: "Source Context", action: "open-source-context" },
+      ],
+    });
+  }
+
+  return items;
+}
+
+export function getVisibleConversationItems(items: ConversationItem[], filter: TimelineFilter) {
+  switch (filter) {
+    case "attention":
+      return items.filter((item) => item.category === "attention");
+    case "review":
+      return items.filter((item) => item.category === "review");
+    case "activity":
+      return items.filter((item) => item.category === "activity" || item.type === "operator");
+    default:
+      return items;
+  }
+}
+
+export function shouldShowTimelineDetails(
+  item: ConversationItem,
+  focusMode: string,
+  selectedRunId?: string | null,
+) {
+  if (focusMode !== "focused") {
+    return true;
+  }
+
+  if (item.category === "attention" || item.category === "review") {
+    return true;
+  }
+
+  return Boolean(item.runId && item.runId === selectedRunId);
+}

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -57,6 +57,15 @@ import {
   type ProjectExplorerTreeNode,
 } from "./projectExplorerTree";
 import {
+  buildDesktopSummaryConversation,
+  getVisibleConversationItems,
+  shouldShowTimelineDetails,
+  type ChipAction,
+  type ConversationDetail,
+  type ConversationItem,
+  type TimelineFilter,
+} from "./conversationTimeline";
+import {
   getRuntimeCatalogEntries,
   openRouterModelsApiUrl,
   type AgentVaultCommandProviderId,
@@ -132,20 +141,6 @@ interface HarnessBenchmarkTaskPacket {
   sha256: string;
 }
 
-type ChipAction =
-  | "open-explain"
-  | "open-editor"
-  | "open-source-context"
-  | "toggle-context"
-  | "open-terminal";
-
-interface ConversationChip {
-  label: string;
-  action: ChipAction;
-}
-
-type TimelineFilter = "all" | "attention" | "review" | "activity";
-type ConversationCategory = "user" | "attention" | "review" | "activity";
 type WorkPipelineStage = "open" | "triaged" | "planning" | "implementing" | "reviewing" | "shipped";
 
 interface WorkDashboardRecord {
@@ -161,26 +156,6 @@ interface WorkDashboardRecord {
   traceRefs: string[];
   summary: string;
   tone: SurfaceTone;
-}
-
-interface ConversationDetail {
-  label: string;
-  value: string;
-}
-
-interface ConversationItem {
-  type: "user" | "operator" | "system";
-  category: ConversationCategory;
-  timestamp: string;
-  actor: string;
-  title?: string;
-  body: string;
-  details?: ConversationDetail[];
-  chips?: ConversationChip[];
-  attachments?: Array<{ name: string; kind: "image" | "file"; sizeLabel: string }>;
-  tone?: SurfaceTone;
-  runId?: string;
-  statusLabel?: string;
 }
 
 interface SessionItem {
@@ -14128,31 +14103,6 @@ async function readClipboardImageFiles() {
   }
 }
 
-function getVisibleConversationItems(items: ConversationItem[]) {
-  switch (activeTimelineFilter) {
-    case "attention":
-      return items.filter((item) => item.category === "attention");
-    case "review":
-      return items.filter((item) => item.category === "review");
-    case "activity":
-      return items.filter((item) => item.category === "activity" || item.type === "operator");
-    default:
-      return items;
-  }
-}
-
-function shouldShowTimelineDetails(item: ConversationItem) {
-  if (themeState.focusMode !== "focused") {
-    return true;
-  }
-
-  if (item.category === "attention" || item.category === "review") {
-    return true;
-  }
-
-  return Boolean(item.runId && item.runId === getSelectedRunId());
-}
-
 function updateTimelineFeedHint() {
   const hint = document.getElementById("timeline-feed-hint");
   if (!hint) {
@@ -14472,7 +14422,7 @@ function renderConversation(items: ConversationItem[]) {
   syncTimelineFeedVisibility();
 
   timeline.innerHTML = "";
-  const visibleItems = getVisibleConversationItems(items);
+  const visibleItems = getVisibleConversationItems(items, activeTimelineFilter);
 
   if (visibleItems.length === 0) {
     const empty = document.createElement("div");
@@ -14518,7 +14468,7 @@ function renderConversation(items: ConversationItem[]) {
     body.textContent = item.body;
     article.appendChild(body);
 
-    if (item.details?.length && shouldShowTimelineDetails(item)) {
+    if (item.details?.length && shouldShowTimelineDetails(item, themeState.focusMode, getSelectedRunId())) {
       const detailRow = document.createElement("div");
       detailRow.className = "timeline-detail-row";
       for (const detail of item.details) {
@@ -17826,74 +17776,6 @@ function inferLanguageFromPath(path: string) {
     return "YAML";
   }
   return "Text";
-}
-
-function buildDesktopSummaryConversation(snapshot: DesktopSummarySnapshot): ConversationItem[] {
-  const board = snapshot.board.summary;
-  const digest = snapshot.digest.summary;
-  const inbox = snapshot.inbox.summary;
-  const topInboxItems = snapshot.inbox.items.slice(0, 2);
-  const topDigestItems = snapshot.run_projections.slice(0, 3);
-
-  const items: ConversationItem[] = [
-    {
-      type: "operator",
-      category: "activity",
-      timestamp: new Date(snapshot.generated_at).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", hour12: false }),
-      actor: "Operator",
-      title: "Summary stream connected",
-      body: "Tauri is reading board, notifications, and digest surfaces from the backend adapter instead of treating raw PTY output as the primary UI source.",
-      details: [
-        { label: "panes", value: `${board.pane_count}` },
-        { label: "notifications", value: `${inbox.item_count}` },
-        { label: "runs", value: `${digest.item_count}` },
-      ],
-      tone: "info",
-    },
-  ];
-
-  for (const topInboxItem of topInboxItems) {
-    items.push({
-      type: "system",
-      category: "attention",
-      timestamp: new Date(snapshot.generated_at).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", hour12: false }),
-      actor: topInboxItem.label || topInboxItem.pane_id || "System",
-      title: `Notification: ${topInboxItem.kind}`,
-      body: topInboxItem.message,
-      details: [
-        { label: "branch", value: topInboxItem.branch || "no branch" },
-        { label: "review", value: topInboxItem.review_state || "n/a" },
-        { label: "task", value: topInboxItem.task_state || "n/a" },
-      ],
-      tone: "warning",
-      statusLabel: topInboxItem.kind,
-    });
-  }
-
-  for (const digestItem of topDigestItems) {
-    items.push({
-      type: "operator",
-      category: digestItem.review_state === "PENDING" || digestItem.review_state === "FAIL" || digestItem.review_state === "FAILED" ? "review" : "activity",
-      timestamp: new Date(snapshot.generated_at).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", hour12: false }),
-      actor: digestItem.label || digestItem.pane_id || "Operator",
-      title: digestItem.task || "Projected run",
-      body: `Next ${digestItem.next_action || "idle"} · ${digestItem.changed_files.length} changed files · review ${digestItem.review_state || "n/a"}.`,
-      details: [
-        { label: "run", value: digestItem.run_id },
-        { label: "branch", value: digestItem.branch || "no branch" },
-        { label: "verify", value: digestItem.verification_outcome || "n/a" },
-      ],
-      tone: digestItem.review_state === "PASS" ? "success" : digestItem.review_state === "PENDING" ? "warning" : "info",
-      runId: digestItem.run_id,
-      statusLabel: digestItem.review_state || digestItem.next_action || undefined,
-      chips: [
-        { label: "Open Explain", action: "open-explain" },
-        { label: "Source Context", action: "open-source-context" },
-      ],
-    });
-  }
-
-  return items;
 }
 
 function pruneExplainCache(snapshot: DesktopSummarySnapshot, preservedRunId?: string | null) {


### PR DESCRIPTION
## Summary
- Extracted mailbox-backed desktop summary conversation generation into `conversationTimeline.ts`.
- Moved timeline filtering and focused-detail visibility helpers out of `main.ts`.
- Added a focused Node check for summary conversation rows, review categorization, timeline filters, and focus-mode detail visibility.

## Test Plan
- `npm run test:conversation-timeline`
- `npm run test:desktop-summary-scheduler`
- `npm run test:common-contract-package`
- `npm run test:worker-pane-routing`
- `npm run test:worker-start-planning`
- `npm run test:bakeoff-runner`
- `npm run test:worker-readiness-prompt`
- `npm run build`
- `git diff --check`
- `git diff --cached --check`
- `pwsh -NoProfile -File scripts\audit-public-surface.ps1`
- `pwsh -NoProfile -File scripts\git-guard.ps1 -Mode full`
- `pwsh -NoProfile -File scripts\git-guard.ps1 -Mode staged`

## Review
- Subagent staged diff review: no findings.
