### PR TITLE
fix(core): rotate orchestra log with retention

### DIFF
--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -3805,6 +3805,179 @@ Describe 'logger helpers' {
         $records[1].data.finding_count | Should -Be 2
     }
 
+    It 'rotates before append and keeps retained records as valid jsonl' {
+        $logPath = Initialize-OrchestraLogger -ProjectDir $script:loggerTempRoot -SessionName 'session-rotation'
+
+        1..8 | ForEach-Object {
+            Write-OrchestraLog -ProjectDir $script:loggerTempRoot -SessionName 'session-rotation' -Event 'rotation.boundary' -Message ('x' * 180) -Data ([ordered]@{ index = $_; payload = ('y' * 180) }) -MaxBytes 700 -RetentionCount 20 | Out-Null
+        }
+
+        $rotatedFiles = @(Get-OrchestraLogRotatedFiles -Path $logPath)
+        ($rotatedFiles.Count -gt 0) | Should -Be $true
+        ((Get-Item -LiteralPath $logPath).Length -le 700) | Should -Be $true
+
+        $allRecords = @()
+        $allPaths = @($rotatedFiles | Sort-Object Name | ForEach-Object { $_.FullName }) + @($logPath)
+        foreach ($path in $allPaths) {
+            foreach ($line in (Get-Content -LiteralPath $path -Encoding UTF8 | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })) {
+                $allRecords += ($line | ConvertFrom-Json -ErrorAction Stop)
+            }
+        }
+
+        $allRecords.Count | Should -Be 8
+        @($allRecords | Where-Object { $_.event -eq 'rotation.boundary' }).Count | Should -Be 8
+
+        $readRecords = Read-OrchestraLog -ProjectDir $script:loggerTempRoot -SessionName 'session-rotation'
+        $readRecords.Count | Should -Be 8
+        @($readRecords | ForEach-Object { [int]$_.data.index }) | Should -Be @(1, 2, 3, 4, 5, 6, 7, 8)
+    }
+
+    It 'does not treat similarly named active session logs as rotations' {
+        $baseSession = 'session-cross'
+        $lookalikeSession = 'session-cross.rotated.20260707221249000.000000'
+        $baseLogPath = Initialize-OrchestraLogger -ProjectDir $script:loggerTempRoot -SessionName $baseSession
+        Write-OrchestraLog -ProjectDir $script:loggerTempRoot -SessionName $baseSession -Event 'base.tail' | Out-Null
+        Write-OrchestraLog -ProjectDir $script:loggerTempRoot -SessionName $lookalikeSession -Event 'other.active' | Out-Null
+
+        $lookalikeLogPath = Get-OrchestraLogPath -ProjectDir $script:loggerTempRoot -SessionName $lookalikeSession
+        Invoke-OrchestraLogRetentionPrune -Path $baseLogPath -RetentionCount 0
+
+        Test-Path -LiteralPath $lookalikeLogPath -PathType Leaf | Should -Be $true
+        @(Get-OrchestraLogRotatedFiles -Path $baseLogPath | ForEach-Object { $_.FullName }) | Should -Not -Contain $lookalikeLogPath
+        @(Read-OrchestraLog -ProjectDir $script:loggerTempRoot -SessionName $baseSession | ForEach-Object { $_.event }) | Should -Not -Contain 'other.active'
+    }
+
+    It 'preserves order for same-millisecond rotated logs' {
+        $logPath = Initialize-OrchestraLogger -ProjectDir $script:loggerTempRoot -SessionName 'session-same-millisecond'
+        $fixedTime = [datetime]'2026-07-07T22:12:49.000Z'
+        $firstRotatedPath = New-OrchestraLogRotatedPath -Path $logPath -Now $fixedTime
+        '{"event":"rotated.first","data":{"index":1}}' | Set-Content -Path $firstRotatedPath -Encoding UTF8
+        $secondRotatedPath = New-OrchestraLogRotatedPath -Path $logPath -Now $fixedTime
+        '{"event":"rotated.second","data":{"index":2}}' | Set-Content -Path $secondRotatedPath -Encoding UTF8
+        Write-OrchestraLog -ProjectDir $script:loggerTempRoot -SessionName 'session-same-millisecond' -Event 'active.tail' -Data ([ordered]@{ index = 3 }) | Out-Null
+
+        $records = Read-OrchestraLog -ProjectDir $script:loggerTempRoot -SessionName 'session-same-millisecond'
+        @($records | ForEach-Object { [int]$_.data.index }) | Should -Be @(1, 2, 3)
+    }
+
+    It 'reads rotated and active logs under the writer file lock' {
+        $logPath = Initialize-OrchestraLogger -ProjectDir $script:loggerTempRoot -SessionName 'session-read-lock'
+        Write-OrchestraLog -ProjectDir $script:loggerTempRoot -SessionName 'session-read-lock' -Event 'read.locked' | Out-Null
+        $script:readLockPath = $null
+        Mock Invoke-WinsmuxWithFileLock {
+            param(
+                [string]$Path,
+                [scriptblock]$Action
+            )
+
+            $script:readLockPath = $Path
+            & $Action
+        }
+
+        $records = Read-OrchestraLog -ProjectDir $script:loggerTempRoot -SessionName 'session-read-lock'
+
+        $records.Count | Should -Be 1
+        $records[0].event | Should -Be 'read.locked'
+        $script:readLockPath | Should -Be $logPath
+        Assert-MockCalled Invoke-WinsmuxWithFileLock -Times 1 -Exactly
+    }
+
+    It 'skips rotated logs pruned between enumeration and read' {
+        $logPath = Initialize-OrchestraLogger -ProjectDir $script:loggerTempRoot -SessionName 'session-read-pruned'
+        Write-OrchestraLog -ProjectDir $script:loggerTempRoot -SessionName 'session-read-pruned' -Event 'read.tail' -Data ([ordered]@{ index = 2 }) | Out-Null
+
+        $missingRotatedPath = New-OrchestraLogRotatedPath -Path $logPath -Now (Get-Date).AddSeconds(-1)
+        '{"event":"read.rotated","data":{"index":1}}' | Set-Content -Path $missingRotatedPath -Encoding UTF8
+        $missingRotatedFile = Get-Item -LiteralPath $missingRotatedPath
+        Remove-Item -LiteralPath $missingRotatedPath -Force
+        Mock Get-OrchestraLogRotatedFiles { @($missingRotatedFile) }
+
+        $records = Read-OrchestraLog -ProjectDir $script:loggerTempRoot -SessionName 'session-read-pruned'
+        $records.Count | Should -Be 1
+        $records[0].event | Should -Be 'read.tail'
+    }
+
+    It 'prunes rotated logs to the configured retention count' {
+        $logPath = Initialize-OrchestraLogger -ProjectDir $script:loggerTempRoot -SessionName 'session-retention'
+
+        1..10 | ForEach-Object {
+            Write-OrchestraLog -ProjectDir $script:loggerTempRoot -SessionName 'session-retention' -Event 'rotation.retention' -Message ('r' * 180) -Data ([ordered]@{ index = $_; payload = ('s' * 180) }) -MaxBytes 700 -RetentionCount 1 | Out-Null
+        }
+
+        $rotatedFiles = @(Get-OrchestraLogRotatedFiles -Path $logPath)
+        $rotatedFiles.Count | Should -Be 1
+        Test-Path -LiteralPath $logPath -PathType Leaf | Should -Be $true
+    }
+
+    It 'does not truncate an active log created while initialization waits for the file lock' {
+        $logPath = Get-OrchestraLogPath -ProjectDir $script:loggerTempRoot -SessionName 'session-init-race'
+        $logDir = Split-Path -Parent $logPath
+        New-Item -ItemType Directory -Path $logDir -Force | Out-Null
+
+        $lockDir = Get-WinsmuxFileLockDir -Path $logPath
+        New-Item -ItemType Directory -Path $lockDir -Force | Out-Null
+
+        $workerScriptPath = Join-Path $script:loggerTempRoot 'init-worker.ps1'
+        $loggerPath = Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\logger.ps1'
+        $workerScript = (@'
+param(
+    [Parameter(Mandatory = $true)][string]$ProjectDir
+)
+
+. '{0}'
+Initialize-OrchestraLogger -ProjectDir $ProjectDir -SessionName 'session-init-race' | Out-Null
+'@) -f ($loggerPath -replace "'", "''")
+
+        Set-Content -Path $workerScriptPath -Value $workerScript -Encoding UTF8
+        $process = Start-Process -FilePath $script:loggerPwshPath -ArgumentList @('-NoProfile', '-File', $workerScriptPath, '-ProjectDir', $script:loggerTempRoot) -PassThru -WindowStyle Hidden
+
+        Start-Sleep -Milliseconds 500
+        Set-Content -Path $logPath -Value 'preserve-this-line' -Encoding UTF8
+        Remove-WinsmuxFileLock -Path $logPath
+
+        $process.WaitForExit(180000) | Should -Be $true
+        $process.ExitCode | Should -Be 0
+
+        $lines = @(Get-Content -Path $logPath -Encoding UTF8 | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+        $lines.Count | Should -Be 1
+        $lines[0] | Should -Be 'preserve-this-line'
+    }
+
+    It 'appends to the active log when rotation rename is blocked by a reader' {
+        $logPath = Initialize-OrchestraLogger -ProjectDir $script:loggerTempRoot -SessionName 'session-rename-blocked'
+        Write-OrchestraLog -ProjectDir $script:loggerTempRoot -SessionName 'session-rename-blocked' -Event 'rotation.seed' -Message ('a' * 180) -Data ([ordered]@{ index = 1 }) -MaxBytes 1000 | Out-Null
+
+        $stream = [System.IO.File]::Open($logPath, [System.IO.FileMode]::Open, [System.IO.FileAccess]::Read, [System.IO.FileShare]::ReadWrite)
+        try {
+            Write-OrchestraLog -ProjectDir $script:loggerTempRoot -SessionName 'session-rename-blocked' -Event 'rotation.rename_blocked' -Message ('b' * 180) -Data ([ordered]@{ index = 2 }) -MaxBytes 100 -RetentionCount 1 | Out-Null
+        } finally {
+            $stream.Dispose()
+        }
+
+        $records = Read-OrchestraLog -ProjectDir $script:loggerTempRoot -SessionName 'session-rename-blocked'
+        $records.Count | Should -Be 2
+        $records[1].event | Should -Be 'rotation.rename_blocked'
+        @(Get-OrchestraLogRotatedFiles -Path $logPath).Count | Should -Be 0
+    }
+
+    It 'keeps the current record when retention pruning cannot delete a rotated log' {
+        $logPath = Initialize-OrchestraLogger -ProjectDir $script:loggerTempRoot -SessionName 'session-prune-blocked'
+        Write-OrchestraLog -ProjectDir $script:loggerTempRoot -SessionName 'session-prune-blocked' -Event 'rotation.seed' -Message ('c' * 180) -Data ([ordered]@{ index = 1 }) -MaxBytes 1000 | Out-Null
+
+        $lockedRotatedPath = New-OrchestraLogRotatedPath -Path $logPath -Now (Get-Date).AddSeconds(-1)
+        '{"event":"locked"}' | Set-Content -Path $lockedRotatedPath -Encoding UTF8
+        $stream = [System.IO.File]::Open($lockedRotatedPath, [System.IO.FileMode]::Open, [System.IO.FileAccess]::Read, [System.IO.FileShare]::ReadWrite)
+        try {
+            Write-OrchestraLog -ProjectDir $script:loggerTempRoot -SessionName 'session-prune-blocked' -Event 'rotation.prune_blocked' -Message ('d' * 180) -Data ([ordered]@{ index = 2 }) -MaxBytes 100 -RetentionCount 0 | Out-Null
+        } finally {
+            $stream.Dispose()
+        }
+
+        $records = Read-OrchestraLog -ProjectDir $script:loggerTempRoot -SessionName 'session-prune-blocked'
+        ($records.Count -ge 2) | Should -Be $true
+        $records[-1].event | Should -Be 'rotation.prune_blocked'
+    }
+
     It 'serializes concurrent jsonl appends across multiple PowerShell processes' {
         $logPath = Join-Path $script:loggerTempRoot '.winsmux\logs\concurrent.jsonl'
         $workerScriptPath = Join-Path $script:loggerTempRoot 'append-worker.ps1'

--- a/winsmux-core/scripts/logger.ps1
+++ b/winsmux-core/scripts/logger.ps1
@@ -12,6 +12,8 @@ param(
     [string]$PaneId,
     [string]$Target,
     [string]$DataJson,
+    [long]$MaxBytes = 0,
+    [int]$RetentionCount = -1,
     [switch]$AsJson
 )
 
@@ -22,8 +24,14 @@ Set-StrictMode -Version Latest
 
 $script:OrchestraLogDirName = '.winsmux\logs'
 $script:OrchestraLogExtension = '.jsonl'
+$script:OrchestraLogDefaultMaxBytes = 10MB
+$script:OrchestraLogDefaultRetentionCount = 5
 $script:WinsmuxLogProjectDir = (Get-Location).Path
 $script:WinsmuxLogSessionName = 'winsmux-orchestra'
+
+# Consumer contract: writers may rotate the active session log to a per-session
+# history directory before an append. Consumers should keep tailing the active
+# <session>.jsonl path and use Read-OrchestraLog when retained history is needed.
 
 function Get-OrchestraLogDir {
     param([Parameter(Mandatory = $true)][string]$ProjectDir)
@@ -46,6 +54,146 @@ function Get-OrchestraLogPath {
     return Join-Path (Get-OrchestraLogDir -ProjectDir $ProjectDir) ($safeSessionName + $script:OrchestraLogExtension)
 }
 
+function Get-OrchestraLogMaxBytes {
+    param([long]$MaxBytes = 0)
+
+    if ($MaxBytes -gt 0) {
+        return $MaxBytes
+    }
+
+    $parsed = 0L
+    if (-not [string]::IsNullOrWhiteSpace($env:WINSMUX_ORCHESTRA_LOG_MAX_BYTES) -and [long]::TryParse($env:WINSMUX_ORCHESTRA_LOG_MAX_BYTES, [ref]$parsed) -and $parsed -gt 0) {
+        return $parsed
+    }
+
+    return $script:OrchestraLogDefaultMaxBytes
+}
+
+function Get-OrchestraLogRetentionCount {
+    param([int]$RetentionCount = -1)
+
+    if ($RetentionCount -ge 0) {
+        return $RetentionCount
+    }
+
+    $parsed = 0
+    if (-not [string]::IsNullOrWhiteSpace($env:WINSMUX_ORCHESTRA_LOG_RETENTION_COUNT) -and [int]::TryParse($env:WINSMUX_ORCHESTRA_LOG_RETENTION_COUNT, [ref]$parsed) -and $parsed -ge 0) {
+        return $parsed
+    }
+
+    return $script:OrchestraLogDefaultRetentionCount
+}
+
+function Test-OrchestraLogRotationNeeded {
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [long]$MaxBytes = 0,
+        [AllowEmptyString()][string]$PendingContent = ''
+    )
+
+    $resolvedMaxBytes = Get-OrchestraLogMaxBytes -MaxBytes $MaxBytes
+    if ($resolvedMaxBytes -le 0 -or -not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        return $false
+    }
+
+    $currentLength = (Get-Item -LiteralPath $Path).Length
+    if ($currentLength -le 0) {
+        return $false
+    }
+
+    $pendingBytes = 0
+    if (-not [string]::IsNullOrEmpty($PendingContent)) {
+        $pendingBytes = [System.Text.Encoding]::UTF8.GetByteCount($PendingContent) + 2
+    }
+
+    return (($currentLength + $pendingBytes) -gt $resolvedMaxBytes)
+}
+
+function Get-OrchestraLogRotationDir {
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    $directory = Split-Path -Parent $Path
+    $activeFileName = [System.IO.Path]::GetFileName($Path)
+    return Join-Path (Join-Path $directory '.rotated') $activeFileName
+}
+
+function New-OrchestraLogRotatedPath {
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [datetime]$Now = (Get-Date)
+    )
+
+    $directory = Get-OrchestraLogRotationDir -Path $Path
+    $extension = [System.IO.Path]::GetExtension($Path)
+    $stamp = $Now.ToString('yyyyMMddHHmmssfff')
+
+    if (-not (Test-Path -LiteralPath $directory -PathType Container)) {
+        New-Item -ItemType Directory -Path $directory -Force | Out-Null
+    }
+
+    for ($sequence = 0; $sequence -lt 1000000; $sequence++) {
+        $candidate = Join-Path $directory ('{0}.{1:D6}{2}' -f $stamp, $sequence, $extension)
+        if (-not (Test-Path -LiteralPath $candidate)) {
+            return $candidate
+        }
+    }
+
+    throw "Unable to allocate rotated log path for $Path at $stamp."
+}
+
+function Get-OrchestraLogRotatedFiles {
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    $directory = Get-OrchestraLogRotationDir -Path $Path
+    if ([string]::IsNullOrWhiteSpace($directory) -or -not (Test-Path -LiteralPath $directory -PathType Container)) {
+        return @()
+    }
+
+    $extension = [regex]::Escape([System.IO.Path]::GetExtension($Path))
+    $namePattern = '^\d{17}\.\d{6}' + $extension + '$'
+
+    return @(Get-ChildItem -LiteralPath $directory -File | Where-Object { $_.Name -match $namePattern } | Sort-Object -Property @{ Expression = 'Name'; Descending = $true })
+}
+
+function Invoke-OrchestraLogRetentionPrune {
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [int]$RetentionCount = -1
+    )
+
+    $resolvedRetentionCount = Get-OrchestraLogRetentionCount -RetentionCount $RetentionCount
+    $rotatedFiles = @(Get-OrchestraLogRotatedFiles -Path $Path)
+    if ($resolvedRetentionCount -lt 0 -or $rotatedFiles.Count -le $resolvedRetentionCount) {
+        return
+    }
+
+    $rotatedFiles | Select-Object -Skip $resolvedRetentionCount | ForEach-Object {
+        Remove-Item -LiteralPath $_.FullName -Force
+    }
+}
+
+function Invoke-OrchestraLogRotationIfNeeded {
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [long]$MaxBytes = 0,
+        [int]$RetentionCount = -1,
+        [AllowEmptyString()][string]$PendingContent = ''
+    )
+
+    if (-not (Test-OrchestraLogRotationNeeded -Path $Path -MaxBytes $MaxBytes -PendingContent $PendingContent)) {
+        return $null
+    }
+
+    $rotatedPath = New-OrchestraLogRotatedPath -Path $Path
+    try {
+        Move-Item -LiteralPath $Path -Destination $rotatedPath -Force -ErrorAction Stop
+    } catch {
+        return $null
+    }
+
+    return $rotatedPath
+}
+
 function Initialize-OrchestraLogger {
     param(
         [Parameter(Mandatory = $true)][string]$ProjectDir,
@@ -59,7 +207,15 @@ function Initialize-OrchestraLogger {
 
     $logPath = Get-OrchestraLogPath -ProjectDir $ProjectDir -SessionName $SessionName
     if (-not (Test-Path $logPath)) {
-        Write-WinsmuxTextFile -Path $logPath -Content ''
+        $escapedPath = $logPath -replace '"', '""'
+        Invoke-WinsmuxWithFileLock -Path $logPath -Action {
+            if (-not (Test-Path -LiteralPath $logPath -PathType Leaf)) {
+                cmd /d /c ('type nul > "{0}"' -f $escapedPath) | Out-Null
+                if ($LASTEXITCODE -ne 0) {
+                    throw "cmd.exe failed to initialize active log $logPath"
+                }
+            }
+        }
     }
 
     return $logPath
@@ -144,13 +300,31 @@ function Write-OrchestraLog {
         [string]$Role,
         [string]$PaneId,
         [string]$Target,
-        [AllowNull()]$Data
+        [AllowNull()]$Data,
+        [long]$MaxBytes = 0,
+        [int]$RetentionCount = -1
     )
 
     $logPath = Initialize-OrchestraLogger -ProjectDir $ProjectDir -SessionName $SessionName
     $record = New-OrchestraLogRecord -SessionName $SessionName -Event $Event -Level $Level -Message $Message -Role $Role -PaneId $PaneId -Target $Target -Data $Data
     $line = ($record | ConvertTo-Json -Compress -Depth 10)
-    Write-WinsmuxTextFile -Path $logPath -Content $line -Append
+    $escapedPath = $logPath -replace '"', '""'
+    Invoke-WinsmuxWithFileLock -Path $logPath -Action {
+        $rotatedPath = Invoke-OrchestraLogRotationIfNeeded -Path $logPath -MaxBytes $MaxBytes -RetentionCount $RetentionCount -PendingContent $line
+        $line | cmd /d /c ('more >> "{0}"' -f $escapedPath) | Out-Null
+        if ($LASTEXITCODE -ne 0) {
+            throw "cmd.exe failed to append $logPath"
+        }
+
+        if (-not [string]::IsNullOrWhiteSpace($rotatedPath)) {
+            try {
+                Invoke-OrchestraLogRetentionPrune -Path $logPath -RetentionCount $RetentionCount
+            } catch {
+                # Retention cleanup must not drop the current log record.
+            }
+        }
+    }
+
     return [PSCustomObject]$record
 }
 
@@ -164,7 +338,9 @@ function Write-WinsmuxLog {
         [string]$Target,
         [AllowNull()]$Data,
         [string]$ProjectDir,
-        [string]$SessionName
+        [string]$SessionName,
+        [long]$MaxBytes = 0,
+        [int]$RetentionCount = -1
     )
 
     $resolvedProjectDir = if ([string]::IsNullOrWhiteSpace($ProjectDir)) {
@@ -188,7 +364,7 @@ function Write-WinsmuxLog {
         default { throw "Unsupported log level: $Level" }
     }
 
-    return Write-OrchestraLog -ProjectDir $resolvedProjectDir -SessionName $resolvedSessionName -Event $Event -Level $normalizedLevel -Message $Message -Role $Role -PaneId $PaneId -Target $Target -Data $Data
+    return Write-OrchestraLog -ProjectDir $resolvedProjectDir -SessionName $resolvedSessionName -Event $Event -Level $normalizedLevel -Message $Message -Role $Role -PaneId $PaneId -Target $Target -Data $Data -MaxBytes $MaxBytes -RetentionCount $RetentionCount
 }
 
 function Read-OrchestraLog {
@@ -197,18 +373,38 @@ function Read-OrchestraLog {
         [string]$SessionName = 'winsmux-orchestra'
     )
 
-    $logPath = Get-OrchestraLogPath -ProjectDir $ProjectDir -SessionName $SessionName
-    if (-not (Test-Path $logPath -PathType Leaf)) {
-        return @()
-    }
-
     $records = [System.Collections.Generic.List[object]]::new()
-    foreach ($line in (Get-Content -Path $logPath -Encoding UTF8)) {
-        if ([string]::IsNullOrWhiteSpace($line)) {
-            continue
+    $logPath = Get-OrchestraLogPath -ProjectDir $ProjectDir -SessionName $SessionName
+    Invoke-WinsmuxWithFileLock -Path $logPath -Action {
+        $readPaths = @(
+            Get-OrchestraLogRotatedFiles -Path $logPath |
+                Sort-Object -Property @{ Expression = 'Name'; Descending = $false } |
+                ForEach-Object { $_.FullName }
+        )
+
+        if (Test-Path -LiteralPath $logPath -PathType Leaf) {
+            $readPaths += $logPath
         }
 
-        $records.Add(($line | ConvertFrom-Json -ErrorAction Stop)) | Out-Null
+        foreach ($path in $readPaths) {
+            try {
+                $lines = @(Get-Content -LiteralPath $path -Encoding UTF8 -ErrorAction Stop)
+            } catch [System.Management.Automation.ItemNotFoundException] {
+                continue
+            } catch [System.IO.FileNotFoundException] {
+                continue
+            } catch [System.IO.DirectoryNotFoundException] {
+                continue
+            }
+
+            foreach ($line in $lines) {
+                if ([string]::IsNullOrWhiteSpace($line)) {
+                    continue
+                }
+
+                $records.Add(($line | ConvertFrom-Json -ErrorAction Stop)) | Out-Null
+            }
+        }
     }
 
     return @($records)
@@ -243,7 +439,7 @@ if ($MyInvocation.InvocationName -ne '.') {
         }
         'write' {
             $data = ConvertFrom-OrchestraLogDataJson -DataJson $DataJson
-            $record = Write-OrchestraLog -ProjectDir $ProjectDir -SessionName $SessionName -Event $Event -Level $Level -Message $Message -Role $Role -PaneId $PaneId -Target $Target -Data $data
+            $record = Write-OrchestraLog -ProjectDir $ProjectDir -SessionName $SessionName -Event $Event -Level $Level -Message $Message -Role $Role -PaneId $PaneId -Target $Target -Data $data -MaxBytes $MaxBytes -RetentionCount $RetentionCount
             if ($AsJson) {
                 $record | ConvertTo-Json -Depth 10
             } else {


### PR DESCRIPTION
## Summary

- Add size-based rotation and retention controls for orchestra JSONL logs.
- Keep appends under the existing file lock so concurrent writers preserve valid JSONL records.
- Add focused tests for rotation, retention pruning, lock contention, and blocked rename/prune cases.

Closes #1147.

## Validation

- `Invoke-Pester -Path tests/winsmux-bridge.Tests.ps1 -FullName 'logger helpers' -PassThru`
- `Invoke-Pester -Path tests/winsmux-bridge.Tests.ps1 -FullName 'agent-monitor helpers' -PassThru`
- `Invoke-Pester -Path tests/Integration.MultiAgent.Tests.ps1 -PassThru`
- `pwsh -NoProfile -File scripts/audit-public-surface.ps1`
- `pwsh -NoProfile -File scripts/git-guard.ps1 -Mode full`
- `git diff --check origin/main..HEAD`