### PR TITLE
fix(hooks): read Claude contract from tracked path

### DIFF
--- a/.claude/hooks/sh-instructions.js
+++ b/.claude/hooks/sh-instructions.js
@@ -15,7 +15,8 @@ const {
 } = require("./lib/sh-utils");
 
 const HOOK_NAME = "sh-instructions";
-const CLAUDE_MD = "CLAUDE.md";
+const CLAUDE_MD = path.join(".claude", "CLAUDE.md");
+const CLAUDE_MD_LABEL = ".claude/CLAUDE.md";
 const RULES_DIR = path.join(".claude", "rules");
 const HASHES_FILE = path.join(".claude", "logs", "instructions-hashes.json");
 
@@ -43,9 +44,9 @@ function hashFile(filePath) {
 function collectCurrentHashes() {
   const hashes = {};
 
-  // CLAUDE.md
+  // Project instructions contract.
   if (fs.existsSync(CLAUDE_MD)) {
-    hashes[CLAUDE_MD] = hashFile(CLAUDE_MD);
+    hashes[CLAUDE_MD_LABEL] = hashFile(CLAUDE_MD);
   }
 
   // .claude/rules/*.md

--- a/.claude/hooks/sh-postcompact.js
+++ b/.claude/hooks/sh-postcompact.js
@@ -23,7 +23,8 @@ const {
 const HOOK_NAME = "sh-postcompact";
 const SAFE_SH_DIR = typeof SH_DIR === "string" && SH_DIR ? SH_DIR : os.tmpdir();
 const BACKUP_DIR = path.join(SAFE_SH_DIR, "compact-backup");
-const CLAUDE_MD = "CLAUDE.md";
+const CLAUDE_MD = path.join(".claude", "CLAUDE.md");
+const CLAUDE_MD_LABEL = ".claude/CLAUDE.md";
 const BACKLOG_FILE = getBacklogPath();
 
 // ---------------------------------------------------------------------------
@@ -58,13 +59,13 @@ function restoreSessionState() {
 }
 
 /**
- * Verify CLAUDE.md integrity after compaction.
+ * Verify .claude/CLAUDE.md integrity after compaction.
  * @param {Object} session - Session with baseline hash
  * @returns {{ valid: boolean, message: string }}
  */
 function verifyCLAUDEMD(session) {
   if (!fs.existsSync(CLAUDE_MD)) {
-    return { valid: false, message: "CLAUDE.md not found" };
+    return { valid: false, message: `${CLAUDE_MD_LABEL} not found` };
   }
 
   const currentHash = sha256(fs.readFileSync(CLAUDE_MD, "utf8"));
@@ -73,18 +74,18 @@ function verifyCLAUDEMD(session) {
   if (!session.claude_md_hash) {
     return {
       valid: true,
-      message: `CLAUDE.md hash recorded: ${currentHash.slice(0, 12)}...`,
+      message: `${CLAUDE_MD_LABEL} hash recorded: ${currentHash.slice(0, 12)}...`,
     };
   }
 
   if (currentHash !== session.claude_md_hash) {
     return {
       valid: false,
-      message: `WARNING: CLAUDE.md has been modified since session start! Expected: ${session.claude_md_hash.slice(0, 12)}..., Got: ${currentHash.slice(0, 12)}...`,
+      message: `WARNING: ${CLAUDE_MD_LABEL} has been modified since session start! Expected: ${session.claude_md_hash.slice(0, 12)}..., Got: ${currentHash.slice(0, 12)}...`,
     };
   }
 
-  return { valid: true, message: "CLAUDE.md integrity verified" };
+  return { valid: true, message: `${CLAUDE_MD_LABEL} integrity verified` };
 }
 
 /**
@@ -118,7 +119,7 @@ function buildRestorationContext(session, integrityCheck) {
   // Key reminders
   parts.push("");
   parts.push("Key files to re-read if needed:");
-  parts.push("  - CLAUDE.md (project instructions)");
+  parts.push(`  - ${CLAUDE_MD_LABEL} (project instructions)`);
   parts.push("  - .claude/rules/ (security & coding rules)");
   if (fs.existsSync(BACKLOG_FILE)) {
     parts.push(`  - ${BACKLOG_FILE} (planning backlog SoT)`);
@@ -142,7 +143,7 @@ try {
   // Restore session state from backup
   const session = restoreSessionState();
 
-  // Verify CLAUDE.md integrity
+  // Verify .claude/CLAUDE.md integrity
   const integrityCheck = verifyCLAUDEMD(session);
 
   // Update and save session

--- a/.claude/hooks/sh-session-start.js
+++ b/.claude/hooks/sh-session-start.js
@@ -28,7 +28,8 @@ try { checkPolicyDrift = require("./lib/policy-drift").checkPolicyDrift; } catch
 try { detectAutoMode = require("./lib/automode-detect").detectAutoMode; } catch {}
 
 const HOOK_NAME = "sh-session-start";
-const CLAUDE_MD = "CLAUDE.md";
+const CLAUDE_MD = path.join(".claude", "CLAUDE.md");
+const CLAUDE_MD_LABEL = ".claude/CLAUDE.md";
 const SETTINGS_FILE = path.join(".claude", "settings.json");
 const RULES_DIR = path.join(".claude", "rules");
 const HOOKS_DIR = path.join(".claude", "hooks");
@@ -241,16 +242,16 @@ try {
 
   // --- Module 1: Gate Check (§5.1.1) ---
 
-  // 1a: CLAUDE.md baseline hash
+  // 1a: .claude/CLAUDE.md baseline hash
   let claudeMdHash = null;
   if (fs.existsSync(CLAUDE_MD)) {
     const content = fs.readFileSync(CLAUDE_MD, "utf8");
     claudeMdHash = sha256(content);
     contextParts.push(
-      `[gate-check] CLAUDE.md baseline: ${claudeMdHash.slice(0, 12)}...`,
+      `[gate-check] ${CLAUDE_MD_LABEL} baseline: ${claudeMdHash.slice(0, 12)}...`,
     );
   } else {
-    contextParts.push("[gate-check] WARNING: CLAUDE.md not found");
+    contextParts.push(`[gate-check] WARNING: ${CLAUDE_MD_LABEL} not found`);
   }
 
   // 1b: settings.json deny rules check
@@ -349,6 +350,7 @@ try {
   session.retry_count = 0;
   session.stop_hook_active = false;
   session.deny_tracker = {};
+  session.claude_md_hash = claudeMdHash;
   session.winsmux_contract = {
     hook_profile: winsmuxHookProfile,
     governance_mode: winsmuxGovernanceMode,
@@ -516,7 +518,7 @@ try {
   // Store baseline hashes for instructions monitoring
   const hashes = {};
   if (fs.existsSync(CLAUDE_MD)) {
-    hashes[CLAUDE_MD] = claudeMdHash;
+    hashes[CLAUDE_MD_LABEL] = claudeMdHash;
   }
   if (fs.existsSync(RULES_DIR)) {
     try {

--- a/tests/HarnessContract.Tests.ps1
+++ b/tests/HarnessContract.Tests.ps1
@@ -41,6 +41,18 @@ Describe 'harness-check contract' {
             [System.IO.File]::WriteAllText($Path, $Content, $utf8NoBom)
         }
 
+        function Get-TestSha256 {
+            param([Parameter(Mandatory = $true)][string]$Content)
+
+            $bytes = [System.Text.Encoding]::UTF8.GetBytes($Content)
+            $sha256 = [System.Security.Cryptography.SHA256]::Create()
+            try {
+                return -join ($sha256.ComputeHash($bytes) | ForEach-Object { $_.ToString('x2') })
+            } finally {
+                $sha256.Dispose()
+            }
+        }
+
         function Remove-TestSettingsLocal {
             if (Test-Path -LiteralPath $script:SettingsLocalPath -PathType Leaf) {
                 Remove-Item -LiteralPath $script:SettingsLocalPath -Force
@@ -177,7 +189,7 @@ Describe 'harness-check contract' {
             Copy-Item -LiteralPath (Join-Path $script:RepoRoot '.claude\hooks\sh-session-start.js') -Destination (Join-Path $hooksDir 'sh-session-start.js') -Force
             Copy-Item -LiteralPath (Join-Path $script:RepoRoot '.claude\hooks\lib\sh-utils.js') -Destination (Join-Path $libDir 'sh-utils.js') -Force
 
-            Write-TestFileWithCmd -Path (Join-Path $fixtureRoot 'CLAUDE.md') -Content '# Fixture'
+            Write-TestFileWithCmd -Path (Join-Path $fixtureRoot '.claude\CLAUDE.md') -Content '# Fixture'
             Write-TestFileWithCmd -Path (Join-Path $fixtureRoot '.claude\settings.json') -Content '{"permissions":{"deny":["backlog.yaml"]}}'
             Write-TestFileWithCmd -Path (Join-Path $patternsDir 'injection-patterns.json') -Content '{}'
             Write-TestFileWithCmd -Path (Join-Path $winsmuxDir 'manifest.yaml') -Content @"
@@ -703,6 +715,80 @@ require("./sh-session-end-real.js");
             $context | Should -Match '\[winsmux-resume\] Managed panes: 1'
             $context | Should -Match '\[winsmux-resume\] Pane: builder-1 TASK-154 in_progress - Resume session context'
             $context | Should -Match '\[winsmux-resume\] Planning: TASK-154 v0.24.1 - Manifest-aware session resume / context injection'
+            $context | Should -Match '\[gate-check\] \.claude/CLAUDE\.md baseline:'
+            $context | Should -Not -Match 'WARNING: CLAUDE\.md not found'
+        } finally {
+            if (Test-Path -LiteralPath $fixture.Root) {
+                Remove-Item -LiteralPath $fixture.Root -Recurse -Force
+            }
+        }
+    }
+
+    It 'uses .claude/CLAUDE.md for instruction hashes without treating the contract as removed' {
+        $fixture = New-SessionStartFixture
+        try {
+            $hooksDir = Join-Path $fixture.Root '.claude\hooks'
+            Copy-Item -LiteralPath (Join-Path $script:RepoRoot '.claude\hooks\sh-instructions.js') -Destination (Join-Path $hooksDir 'sh-instructions.js') -Force
+
+            $payload = [ordered]@{
+                session_id      = 'session-start-instruction-hashes'
+                hook_event_name = 'SessionStart'
+            }
+
+            $startResult = Invoke-NodeHookJson -RepoRoot $fixture.Root -HookRelativePath '.claude\hooks\sh-session-start.js' -Payload $payload -EnvironmentVariables @{
+                WINSMUX_BACKLOG_PATH = $fixture.BacklogPath
+            }
+            $startResult.ExitCode | Should -Be 0
+
+            $hashesPath = Join-Path $fixture.Root '.claude\logs\instructions-hashes.json'
+            $hashes = Get-Content -LiteralPath $hashesPath -Raw -Encoding UTF8 | ConvertFrom-Json -Depth 20
+            $hashNames = @($hashes.PSObject.Properties.Name)
+            $hashNames | Should -Contain '.claude/CLAUDE.md'
+            $hashNames | Should -Not -Contain 'CLAUDE.md'
+
+            $sessionPath = Join-Path $fixture.Root '.shield-harness\session.json'
+            $session = Get-Content -LiteralPath $sessionPath -Raw -Encoding UTF8 | ConvertFrom-Json -Depth 20
+            $session.claude_md_hash | Should -Be (Get-TestSha256 -Content '# Fixture')
+
+            $instructionResult = Invoke-NodeHookJson -RepoRoot $fixture.Root -HookRelativePath '.claude\hooks\sh-instructions.js' -Payload ([ordered]@{
+                session_id      = 'instructions-loaded-no-removal'
+                hook_event_name = 'InstructionsLoaded'
+            })
+
+            $instructionResult.ExitCode | Should -Be 0
+            $instructionResult.StdErr | Should -Be ''
+            $instructionResult.StdOut | Should -Be ''
+        } finally {
+            if (Test-Path -LiteralPath $fixture.Root) {
+                Remove-Item -LiteralPath $fixture.Root -Recurse -Force
+            }
+        }
+    }
+
+    It 'verifies .claude/CLAUDE.md integrity during PostCompact' {
+        $fixture = New-SessionStartFixture
+        try {
+            $hooksDir = Join-Path $fixture.Root '.claude\hooks'
+            Copy-Item -LiteralPath (Join-Path $script:RepoRoot '.claude\hooks\sh-postcompact.js') -Destination (Join-Path $hooksDir 'sh-postcompact.js') -Force
+
+            $contractContent = '# Fixture'
+            $contractHash = Get-TestSha256 -Content $contractContent
+
+            Write-TestFileWithCmd -Path (Join-Path $fixture.Root '.shield-harness\session.json') -Content (@{
+                claude_md_hash = $contractHash
+            } | ConvertTo-Json -Compress)
+
+            $result = Invoke-NodeHookJson -RepoRoot $fixture.Root -HookRelativePath '.claude\hooks\sh-postcompact.js' -Payload ([ordered]@{
+                session_id      = 'postcompact-contract-hash'
+                hook_event_name = 'PostCompact'
+            })
+
+            $result.ExitCode | Should -Be 0
+            $result.StdErr | Should -Be ''
+            $context = [string]$result.Json.hookSpecificOutput.additionalContext
+            $context | Should -Match '\.claude/CLAUDE\.md integrity verified'
+            $context | Should -Match '  - \.claude/CLAUDE\.md \(project instructions\)'
+            $context | Should -Not -Match 'CLAUDE\.md not found'
         } finally {
             if (Test-Path -LiteralPath $fixture.Root) {
                 Remove-Item -LiteralPath $fixture.Root -Recurse -Force


### PR DESCRIPTION
## Summary

- Point the hook contract probe at `.claude/CLAUDE.md` instead of a missing root `CLAUDE.md`.
- Keep the instruction hash flow aligned across `sh-session-start`, `sh-instructions`, and `sh-postcompact`.
- Add harness tests for the tracked contract path, instruction hash continuity, and post-compaction integrity verification.

## Test Plan

- `Invoke-Pester -Path tests\HarnessContract.Tests.ps1 -Name '*CLAUDE*' -PassThru`
- `git -C . diff --check`
- `pwsh -NoProfile -File scripts\audit-public-surface.ps1`
- `pwsh -NoProfile -File scripts\git-guard.ps1 -Mode full`

Note: full local `HarnessContract.Tests.ps1` still has two environment-dependent failures in `harness-check` because this desktop session reports `ui_attached=true` while `session_ready=false`; the changed CLAUDE-related tests pass.

Closes #1123.
