### PR TITLE
docs: document Windows MSVC build tools requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,10 @@ If you only need a terminal multiplexer, see the runtime docs under [`core/docs`
 - Windows Terminal
 - The official agent CLIs you want to run, such as Claude Code, Codex, Antigravity CLI, or Grok Build
 
-Rust is only needed when you build the runtime from source.
+Rust is only needed when you build the runtime from source. On Windows, source
+builds also need Visual Studio Build Tools with the Desktop development with C++
+workload; see [Installation](docs/installation.md#source-build-prerequisites-on-windows)
+for the install command and shell notes.
 
 ## Get Started
 

--- a/docs/installation.ja.md
+++ b/docs/installation.ja.md
@@ -22,6 +22,20 @@
 
 Rust は、ランタイムをソースからビルドする時だけ必要です。
 
+### Windows でソースからビルドする場合の前提条件
+
+Windows でソースからビルドする場合は、[Visual Studio Build Tools](https://learn.microsoft.com/en-us/visualstudio/install/use-command-line-parameters-to-install-visual-studio?view=vs-2022)
+と [Desktop development with C++](https://learn.microsoft.com/en-us/visualstudio/install/workload-component-id-vs-build-tools?view=vs-2022)
+ワークロードも必要です。Rust の既定の MSVC toolchain は、Windows 向けのネイティブ成果物をビルドする時に MSVC の linker と Windows SDK を使います。
+
+Visual Studio Installer からこのワークロードを入れるか、workload ID を使って `winget` で入れます。
+
+```powershell
+winget install Microsoft.VisualStudio.2022.BuildTools --override "--quiet --wait --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended"
+```
+
+`cargo build` や `npm run tauri build` は、Git Bash などの MSYS shell ではなく、PowerShell または `cmd` から実行してください。MSYS 環境では MSVC の `link.exe` より前に別の `link` コマンドが `PATH` に入ることがあり、原因が分かりにくいリンカーエラーにつながります。
+
 Colab 対応のモデルワーカーを使う場合は、`H100` または `A100` へ接続した
 Colab ノートブック、またはアダプターが管理する同等の実行環境も用意します。
 この経路では、Windows PC 側にローカル LLM ランタイムは不要です。

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -25,6 +25,24 @@ the desktop app.
 
 Rust is only required when building the runtime from source.
 
+### Source build prerequisites on Windows
+
+Windows source builds also require [Visual Studio Build Tools](https://learn.microsoft.com/en-us/visualstudio/install/use-command-line-parameters-to-install-visual-studio?view=vs-2022)
+with the [Desktop development with C++](https://learn.microsoft.com/en-us/visualstudio/install/workload-component-id-vs-build-tools?view=vs-2022)
+workload. Rust's default MSVC toolchain uses the MSVC linker and Windows SDK
+when building native Windows artifacts.
+
+Install the Build Tools workload from Visual Studio Installer, or use `winget`
+with the official workload ID:
+
+```powershell
+winget install Microsoft.VisualStudio.2022.BuildTools --override "--quiet --wait --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended"
+```
+
+Run `cargo build` or `npm run tauri build` from PowerShell or `cmd`, not Git
+Bash or another MSYS shell. MSYS environments can put their own `link` command
+before MSVC `link.exe` on `PATH`, which causes confusing linker failures.
+
 For Colab-backed model workers, also prepare a Colab notebook or an
 adapter-managed equivalent connected to `H100` or `A100`. The Windows PC does
 not need a local LLM runtime for that path.


### PR DESCRIPTION
## Summary

- Document that Windows source builds need Visual Studio Build Tools with the Desktop development with C++ workload.
- Add the `winget` command using `Microsoft.VisualStudio.Workload.VCTools`.
- Warn users to run `cargo build` / `npm run tauri build` from PowerShell or `cmd` so Git Bash/MSYS does not shadow MSVC `link.exe`.

## Sources

- Microsoft Learn: Visual Studio command-line parameters and `winget --override`
- Microsoft Learn: Build Tools workload ID `Microsoft.VisualStudio.Workload.VCTools`

## Test Plan

- `git diff --check`
- `pwsh -NoProfile -File scripts\audit-public-surface.ps1`
- `pwsh -NoProfile -File scripts\git-guard.ps1 -Mode full`
- `pwsh -NoProfile -Command "Invoke-Pester -Path tests\PublicSurfacePolicy.Tests.ps1 -PassThru"`

Closes #1125.
