### PR TITLE
fix(hooks): make session token budget opt-in

### DIFF
--- a/.claude/hooks/sh-output-control.js
+++ b/.claude/hooks/sh-output-control.js
@@ -109,6 +109,15 @@ function estimateTokens(charCount) {
   return Math.ceil(charCount / CHARS_PER_TOKEN);
 }
 
+function getExplicitBudgetLimit(tokenBudget) {
+  const limit = Number(tokenBudget.session_limit);
+  if (!Number.isFinite(limit) || limit <= 0) {
+    return null;
+  }
+
+  return limit;
+}
+
 /**
  * Track token budget and return warning context if thresholds are crossed.
  * @param {number} outputSize - Size of tool output in characters
@@ -118,10 +127,10 @@ function trackTokenBudget(outputSize) {
   try {
     const session = readSession();
     const tokenBudget = session.token_budget;
-    if (!tokenBudget || !tokenBudget.session_limit) return null; // No budget configured
+    if (!tokenBudget || typeof tokenBudget !== "object") return null;
 
-    const budgetLimit = tokenBudget.session_limit;
-    const currentUsage = tokenBudget.used || 0;
+    const budgetLimit = getExplicitBudgetLimit(tokenBudget);
+    const currentUsage = Number(tokenBudget.used) || 0;
     const newTokens = estimateTokens(outputSize);
     const updatedUsage = currentUsage + newTokens;
 
@@ -133,6 +142,10 @@ function trackTokenBudget(outputSize) {
         used: updatedUsage,
       },
     });
+
+    if (budgetLimit === null) {
+      return null;
+    }
 
     const ratio = updatedUsage / budgetLimit;
 
@@ -235,6 +248,7 @@ module.exports = {
   truncateOutput,
   estimateTokens,
   getLimits,
+  getExplicitBudgetLimit,
   trackTokenBudget,
   isMcpTool,
 };

--- a/.claude/hooks/sh-session-start.js
+++ b/.claude/hooks/sh-session-start.js
@@ -56,10 +56,18 @@ const MIN_HOOK_COUNT = 10; // Wave 0+1+2 = 10 hooks minimum
 
 // Token budget defaults (§5.1.2, ADR-026)
 const DEFAULT_TOKEN_BUDGET = {
-  session_limit: 200000,
+  session_limit: null,
   tool_output_limit: 50000,
   used: 0,
 };
+
+function normalizeTokenBudget(tokenBudget) {
+  return (
+    tokenBudget && typeof tokenBudget === "object" && !Array.isArray(tokenBudget)
+      ? { ...DEFAULT_TOKEN_BUDGET, ...tokenBudget }
+      : { ...DEFAULT_TOKEN_BUDGET }
+  );
+}
 
 function findUpFile(startDir, relativeSegments) {
   if (!startDir) {
@@ -343,9 +351,7 @@ try {
     rawSession && typeof rawSession === "object" && !Array.isArray(rawSession)
       ? rawSession
       : {};
-  if (!session.token_budget) {
-    session.token_budget = { ...DEFAULT_TOKEN_BUDGET };
-  }
+  session.token_budget = normalizeTokenBudget(session.token_budget);
   session.session_start = new Date().toISOString();
   session.retry_count = 0;
   session.stop_hook_active = false;
@@ -377,7 +383,7 @@ try {
       ? winsmuxResumeContext.planningState.backlogPath
       : null;
   }
-  contextParts.push("[env-check] Session initialized, token budget set");
+  contextParts.push("[env-check] Session initialized, token budget config loaded");
   contextParts.push(
     `[winsmux] Hook profile: ${winsmuxHookProfile}, governance mode: ${winsmuxGovernanceMode}`,
   );

--- a/.claude/hooks/sh-subagent.js
+++ b/.claude/hooks/sh-subagent.js
@@ -24,12 +24,17 @@ const SUBAGENT_BUDGET_RATIO = 0.25; // 25% cap per subagent
 /**
  * Calculate subagent token budget from session state.
  * @param {Object} session
- * @returns {number}
+ * @returns {number|null}
  */
 function calculateSubagentBudget(session) {
-  const budget =
-    (session.token_budget && session.token_budget.session_limit) || 200000;
-  const used = (session.token_budget && session.token_budget.used) || 0;
+  const budget = Number(
+    session && session.token_budget && session.token_budget.session_limit,
+  );
+  if (!Number.isFinite(budget) || budget <= 0) {
+    return null;
+  }
+
+  const used = Number((session.token_budget && session.token_budget.used) || 0);
   const remaining = Math.max(0, budget - used);
   return Math.floor(remaining * SUBAGENT_BUDGET_RATIO);
 }
@@ -48,6 +53,10 @@ try {
   const session = readSession();
 
   const subagentBudget = calculateSubagentBudget(session);
+  const budgetText =
+    subagentBudget === null
+      ? "未設定（セッション予算の制約なし）"
+      : `${subagentBudget.toLocaleString()} tokens（セッション残量の 25%）`;
 
   // Record evidence
   try {
@@ -65,7 +74,7 @@ try {
   // Inject constraints via additionalContext
   const constraints = [
     "【Shield Harness サブエージェント制約】",
-    `- トークン予算: ${subagentBudget.toLocaleString()} tokens（セッション残量の 25%）`,
+    `- トークン予算: ${budgetText}`,
     "- ファイル書込: プロジェクトルート内のみ",
     "- ネットワーク: 禁止（WebFetch 不可）",
     "- 他のサブエージェント起動: 禁止",

--- a/tests/HarnessContract.Tests.ps1
+++ b/tests/HarnessContract.Tests.ps1
@@ -909,8 +909,252 @@ panes:
 
             $sessionPath = Join-Path $shieldDir 'session.json'
             $session = Get-Content -LiteralPath $sessionPath -Raw -Encoding UTF8 | ConvertFrom-Json -Depth 20
-            $session.token_budget.session_limit | Should -Be 200000
+            $session.token_budget.PSObject.Properties.Name | Should -Contain 'session_limit'
+            $session.token_budget.session_limit | Should -Be $null
+            $session.token_budget.tool_output_limit | Should -Be 50000
+            $session.token_budget.used | Should -Be 0
             $session.winsmux_resume.manifest_path | Should -Match 'manifest\.yaml$'
+        } finally {
+            if (Test-Path -LiteralPath $fixture.Root) {
+                Remove-Item -LiteralPath $fixture.Root -Recurse -Force
+            }
+        }
+    }
+
+    It 'preserves an explicitly configured token budget during SessionStart' {
+        $fixture = New-SessionStartFixture
+        try {
+            $shieldDir = Join-Path $fixture.Root '.shield-harness'
+            New-Item -ItemType Directory -Path $shieldDir -Force | Out-Null
+            Write-TestFileWithCmd -Path (Join-Path $shieldDir 'session.json') -Content (@{
+                token_budget = @{
+                    session_limit     = 123456
+                    tool_output_limit = 50000
+                    used              = 789
+                }
+            } | ConvertTo-Json -Compress)
+
+            $result = Invoke-NodeHookJson -RepoRoot $fixture.Root -HookRelativePath '.claude\hooks\sh-session-start.js' -Payload ([ordered]@{
+                session_id      = 'session-start-explicit-budget'
+                hook_event_name = 'SessionStart'
+            }) -EnvironmentVariables @{
+                WINSMUX_BACKLOG_PATH = $fixture.BacklogPath
+            }
+
+            $result.ExitCode | Should -Be 0
+            $result.StdErr | Should -Be ''
+
+            $sessionPath = Join-Path $shieldDir 'session.json'
+            $session = Get-Content -LiteralPath $sessionPath -Raw -Encoding UTF8 | ConvertFrom-Json -Depth 20
+            $session.token_budget.session_limit | Should -Be 123456
+            $session.token_budget.tool_output_limit | Should -Be 50000
+            $session.token_budget.used | Should -Be 789
+            $session.winsmux_resume.manifest_path | Should -Match 'manifest\.yaml$'
+        } finally {
+            if (Test-Path -LiteralPath $fixture.Root) {
+                Remove-Item -LiteralPath $fixture.Root -Recurse -Force
+            }
+        }
+    }
+
+    It 'preserves an existing 200000 token budget during SessionStart' {
+        $fixture = New-SessionStartFixture
+        try {
+            $shieldDir = Join-Path $fixture.Root '.shield-harness'
+            New-Item -ItemType Directory -Path $shieldDir -Force | Out-Null
+            Write-TestFileWithCmd -Path (Join-Path $shieldDir 'session.json') -Content (@{
+                token_budget = @{
+                    session_limit     = 200000
+                    tool_output_limit = 40000
+                    used              = 789
+                }
+            } | ConvertTo-Json -Compress)
+
+            $result = Invoke-NodeHookJson -RepoRoot $fixture.Root -HookRelativePath '.claude\hooks\sh-session-start.js' -Payload ([ordered]@{
+                session_id      = 'session-start-legacy-default-budget'
+                hook_event_name = 'SessionStart'
+            }) -EnvironmentVariables @{
+                WINSMUX_BACKLOG_PATH = $fixture.BacklogPath
+            }
+
+            $result.ExitCode | Should -Be 0
+            $result.StdErr | Should -Be ''
+
+            $sessionPath = Join-Path $shieldDir 'session.json'
+            $session = Get-Content -LiteralPath $sessionPath -Raw -Encoding UTF8 | ConvertFrom-Json -Depth 20
+            $session.token_budget.session_limit | Should -Be 200000
+            $session.token_budget.tool_output_limit | Should -Be 40000
+            $session.token_budget.used | Should -Be 789
+        } finally {
+            if (Test-Path -LiteralPath $fixture.Root) {
+                Remove-Item -LiteralPath $fixture.Root -Recurse -Force
+            }
+        }
+    }
+
+    It 'defaults a missing session limit to null during SessionStart' {
+        $fixture = New-SessionStartFixture
+        try {
+            $shieldDir = Join-Path $fixture.Root '.shield-harness'
+            New-Item -ItemType Directory -Path $shieldDir -Force | Out-Null
+            Write-TestFileWithCmd -Path (Join-Path $shieldDir 'session.json') -Content (@{
+                token_budget = @{
+                    tool_output_limit = 40000
+                    used              = 789
+                }
+                session_id      = 'session-start-missing-session-limit'
+                hook_event_name = 'SessionStart'
+            } | ConvertTo-Json -Compress)
+
+            $result = Invoke-NodeHookJson -RepoRoot $fixture.Root -HookRelativePath '.claude\hooks\sh-session-start.js' -Payload ([ordered]@{
+                session_id      = 'session-start-missing-session-limit'
+                hook_event_name = 'SessionStart'
+            })
+
+            $result.ExitCode | Should -Be 0
+            $result.StdErr | Should -Be ''
+
+            $sessionPath = Join-Path $shieldDir 'session.json'
+            $session = Get-Content -LiteralPath $sessionPath -Raw -Encoding UTF8 | ConvertFrom-Json -Depth 20
+            $session.token_budget.session_limit | Should -Be $null
+            $session.token_budget.tool_output_limit | Should -Be 40000
+            $session.token_budget.used | Should -Be 789
+        } finally {
+            if (Test-Path -LiteralPath $fixture.Root) {
+                Remove-Item -LiteralPath $fixture.Root -Recurse -Force
+            }
+        }
+    }
+
+    It 'does not inject a subagent token budget when the session limit is opt-in' {
+        $fixture = New-SessionStartFixture
+        try {
+            $hooksDir = Join-Path $fixture.Root '.claude\hooks'
+            $shieldDir = Join-Path $fixture.Root '.shield-harness'
+            Copy-Item -LiteralPath (Join-Path $script:RepoRoot '.claude\hooks\sh-subagent.js') -Destination (Join-Path $hooksDir 'sh-subagent.js') -Force
+            New-Item -ItemType Directory -Path $shieldDir -Force | Out-Null
+            Write-TestFileWithCmd -Path (Join-Path $shieldDir 'session.json') -Content (@{
+                token_budget = @{
+                    session_limit     = $null
+                    tool_output_limit = 50000
+                    used              = 0
+                }
+            } | ConvertTo-Json -Compress)
+
+            $result = Invoke-NodeHookJson -RepoRoot $fixture.Root -HookRelativePath '.claude\hooks\sh-subagent.js' -Payload ([ordered]@{
+                session_id      = 'subagent-start-no-session-limit'
+                hook_event_name = 'SubagentStart'
+            })
+
+            $result.ExitCode | Should -Be 0
+            $result.StdErr | Should -Be ''
+            $context = [string]$result.Json.hookSpecificOutput.additionalContext
+            $context | Should -Match 'トークン予算: 未設定'
+            $context | Should -Not -Match '50,000 tokens'
+        } finally {
+            if (Test-Path -LiteralPath $fixture.Root) {
+                Remove-Item -LiteralPath $fixture.Root -Recurse -Force
+            }
+        }
+    }
+
+    It 'injects the subagent token budget when the session limit is explicit' {
+        $fixture = New-SessionStartFixture
+        try {
+            $hooksDir = Join-Path $fixture.Root '.claude\hooks'
+            $shieldDir = Join-Path $fixture.Root '.shield-harness'
+            Copy-Item -LiteralPath (Join-Path $script:RepoRoot '.claude\hooks\sh-subagent.js') -Destination (Join-Path $hooksDir 'sh-subagent.js') -Force
+            New-Item -ItemType Directory -Path $shieldDir -Force | Out-Null
+            Write-TestFileWithCmd -Path (Join-Path $shieldDir 'session.json') -Content (@{
+                token_budget = @{
+                    session_limit     = 200000
+                    tool_output_limit = 50000
+                    used              = 40000
+                }
+            } | ConvertTo-Json -Compress)
+
+            $result = Invoke-NodeHookJson -RepoRoot $fixture.Root -HookRelativePath '.claude\hooks\sh-subagent.js' -Payload ([ordered]@{
+                session_id      = 'subagent-start-explicit-session-limit'
+                hook_event_name = 'SubagentStart'
+            })
+
+            $result.ExitCode | Should -Be 0
+            $result.StdErr | Should -Be ''
+            $context = [string]$result.Json.hookSpecificOutput.additionalContext
+            $context | Should -Match '40,000 tokens'
+        } finally {
+            if (Test-Path -LiteralPath $fixture.Root) {
+                Remove-Item -LiteralPath $fixture.Root -Recurse -Force
+            }
+        }
+    }
+
+    It 'continues token usage accounting when the session limit is opt-in' {
+        $fixture = New-SessionStartFixture
+        try {
+            $hooksDir = Join-Path $fixture.Root '.claude\hooks'
+            $shieldDir = Join-Path $fixture.Root '.shield-harness'
+            Copy-Item -LiteralPath (Join-Path $script:RepoRoot '.claude\hooks\sh-output-control.js') -Destination (Join-Path $hooksDir 'sh-output-control.js') -Force
+            New-Item -ItemType Directory -Path $shieldDir -Force | Out-Null
+            Write-TestFileWithCmd -Path (Join-Path $shieldDir 'session.json') -Content (@{
+                token_budget = @{
+                    session_limit     = $null
+                    tool_output_limit = 50000
+                    used              = 10
+                }
+            } | ConvertTo-Json -Compress)
+
+            $result = Invoke-NodeHookJson -RepoRoot $fixture.Root -HookRelativePath '.claude\hooks\sh-output-control.js' -Payload ([ordered]@{
+                session_id      = 'output-control-no-session-limit'
+                hook_event_name = 'PostToolUse'
+                tool_name       = 'Bash'
+                tool_response   = 'abcd'
+            })
+
+            $result.ExitCode | Should -Be 0
+            $result.StdErr | Should -Be ''
+            $result.StdOut | Should -Be ''
+
+            $session = Get-Content -LiteralPath (Join-Path $shieldDir 'session.json') -Raw -Encoding UTF8 | ConvertFrom-Json -Depth 20
+            $session.token_budget.session_limit | Should -Be $null
+            $session.token_budget.used | Should -Be 11
+        } finally {
+            if (Test-Path -LiteralPath $fixture.Root) {
+                Remove-Item -LiteralPath $fixture.Root -Recurse -Force
+            }
+        }
+    }
+
+    It 'keeps token limit warnings gated by an explicit session limit' {
+        $fixture = New-SessionStartFixture
+        try {
+            $hooksDir = Join-Path $fixture.Root '.claude\hooks'
+            $shieldDir = Join-Path $fixture.Root '.shield-harness'
+            Copy-Item -LiteralPath (Join-Path $script:RepoRoot '.claude\hooks\sh-output-control.js') -Destination (Join-Path $hooksDir 'sh-output-control.js') -Force
+            New-Item -ItemType Directory -Path $shieldDir -Force | Out-Null
+            Write-TestFileWithCmd -Path (Join-Path $shieldDir 'session.json') -Content (@{
+                token_budget = @{
+                    session_limit     = 12
+                    tool_output_limit = 50000
+                    used              = 10
+                }
+            } | ConvertTo-Json -Compress)
+
+            $result = Invoke-NodeHookJson -RepoRoot $fixture.Root -HookRelativePath '.claude\hooks\sh-output-control.js' -Payload ([ordered]@{
+                session_id      = 'output-control-explicit-session-limit'
+                hook_event_name = 'PostToolUse'
+                tool_name       = 'Bash'
+                tool_response   = 'abcdefgh'
+            })
+
+            $result.ExitCode | Should -Be 0
+            $result.StdErr | Should -Be ''
+            $context = [string]$result.Json.hookSpecificOutput.additionalContext
+            $context | Should -Match '12/12 tokens'
+
+            $session = Get-Content -LiteralPath (Join-Path $shieldDir 'session.json') -Raw -Encoding UTF8 | ConvertFrom-Json -Depth 20
+            $session.token_budget.session_limit | Should -Be 12
+            $session.token_budget.used | Should -Be 12
         } finally {
             if (Test-Path -LiteralPath $fixture.Root) {
                 Remove-Item -LiteralPath $fixture.Root -Recurse -Force


### PR DESCRIPTION
## Summary
- Default regenerated `SessionStart` token budgets to `session_limit: null`, making the budget warning gate opt-in.
- Keep `tool_output_limit` and `used` initialized, and preserve explicit configured `session_limit` values.
- Stop `SubagentStart` from restoring the old 200,000-token default when `session_limit` is unset.
- Continue `sh-output-control` usage accounting when the limit is unset, while gating warnings and stops on an explicit positive limit.
- Preserve existing `session_limit: 200000` values because persisted sessions do not record whether that value came from the previous default or a user setting.
- Default missing `session_limit` values to `null` while preserving existing `used` and `tool_output_limit`.
- Update the `SessionStart` message so it no longer claims a budget limit was set by default.

Closes #1129

## Verification
- `node --check .claude\hooks\sh-session-start.js`
- `node --check .claude\hooks\sh-subagent.js`
- `node --check .claude\hooks\sh-output-control.js`
- `Invoke-Pester -Path tests\HarnessContract.Tests.ps1 -FullName '*token budget*','*session limit*','*SessionStart*','*token usage accounting*','*token limit warnings*' -PassThru` (8 passed)
- `git diff --check` (passed; LF-to-CRLF warnings only)
- `pwsh -NoProfile -File scripts\audit-public-surface.ps1` (passed)
- `pwsh -NoProfile -File scripts\git-guard.ps1 -Mode full` (passed)

## Notes
- Full local `HarnessContract.Tests.ps1` remains a live-state check in this environment. Before the `sh-subagent.js`, `sh-output-control.js`, and legacy migration follow-ups, it was 30/32 because `startup-attach-consistency` reported `ui_attached=true` while `session_ready=false`; the #1129 focused tests pass.
