### PR TITLE
refactor(core): extract command result handlers

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -120,6 +120,7 @@ function Install-OrchestraSupportScripts {
     Download-File "winsmux-core/scripts/clm-safe-io.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "clm-safe-io.ps1")
     Download-File "winsmux-core/scripts/colab-backend.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "colab-backend.ps1")
     Download-File "winsmux-core/scripts/common-contract.generated.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "common-contract.generated.ps1")
+    Download-File "winsmux-core/scripts/control-plane-commands.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "control-plane-commands.ps1")
     Download-File "winsmux-core/scripts/control-plane-dispatch.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "control-plane-dispatch.ps1")
     Download-File "winsmux-core/scripts/operator-poll.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "operator-poll.ps1")
     Download-File "winsmux-core/scripts/doctor.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "doctor.ps1")
@@ -163,6 +164,7 @@ function Remove-ProfileExcludedSupportScripts {
                 "clm-safe-io.ps1",
                 "colab-backend.ps1",
                 "common-contract.generated.ps1",
+                "control-plane-commands.ps1",
                 "control-plane-dispatch.ps1",
                 "operator-poll.ps1",
                 "doctor.ps1",

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -69,11 +69,14 @@ $PaneEnvScript = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\wins
 $PublicFirstRunScript = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\winsmux-core\scripts\public-first-run.ps1'))
 $ConflictPreflightScript = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\winsmux-core\scripts\conflict-preflight.ps1'))
 $ControlPlaneDispatchScript = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\winsmux-core\scripts\control-plane-dispatch.ps1'))
+$ControlPlaneCommandsScript = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\winsmux-core\scripts\control-plane-commands.ps1'))
 
 # Adapter module owns external script calls: github-write-preflight.ps1, dispatch-router.ps1,
 # task-splitter.ps1, team-pipeline.ps1, builder-queue.ps1, orchestra-smoke.ps1,
 # orchestra-attach.ps1, harness-check.ps1, shadow-cutover-gate.ps1,
 # powershell-deescalation.ps1, assignment-policy.ps1.
+# Command module owns typed command result helpers and command argument/output handling
+# for launcher, provider-capabilities, and provider-switch.
 
 if (Test-Path $BridgeSettingsScript -PathType Leaf) {
     . $BridgeSettingsScript
@@ -113,6 +116,10 @@ if (Test-Path $ConflictPreflightScript -PathType Leaf) {
 
 if (Test-Path $ControlPlaneDispatchScript -PathType Leaf) {
     . $ControlPlaneDispatchScript
+}
+
+if (Test-Path $ControlPlaneCommandsScript -PathType Leaf) {
+    . $ControlPlaneCommandsScript
 }
 
 # --- Windows Credential Manager P/Invoke ---
@@ -4863,143 +4870,6 @@ function Get-LauncherTemplateListPayload {
         template_count = @($store.templates).Count
         templates      = @($store.templates)
     }
-}
-
-function Invoke-Launcher {
-    $tokens = @(@($Target) + @($Rest) | Where-Object { $_ })
-    $mode = 'presets'
-    $templateName = ''
-    $lifecyclePreset = ''
-    $clearLifecycleOverride = $false
-    $jsonOutput = $false
-
-    for ($index = 0; $index -lt $tokens.Count; $index++) {
-        switch ($tokens[$index]) {
-            '--json' {
-                $jsonOutput = $true
-            }
-            '--clear' {
-                $clearLifecycleOverride = $true
-            }
-            '--lifecycle' {
-                $index++
-                if ($index -ge $tokens.Count -or [string]::IsNullOrWhiteSpace([string]$tokens[$index])) {
-                    Stop-WithError "usage: winsmux launcher <presets|lifecycle|list|save> [name] [--lifecycle <preset>] [--json]"
-                }
-
-                $lifecyclePreset = [string]$tokens[$index]
-            }
-            'presets' {
-                $mode = 'presets'
-            }
-            'lifecycle' {
-                $mode = 'lifecycle'
-            }
-            'list' {
-                $mode = 'list'
-            }
-            'save' {
-                $mode = 'save'
-            }
-            default {
-                if ([string]::Equals($mode, 'save', [System.StringComparison]::OrdinalIgnoreCase) -and [string]::IsNullOrWhiteSpace($templateName)) {
-                    $templateName = [string]$tokens[$index]
-                } elseif ([string]::Equals($mode, 'lifecycle', [System.StringComparison]::OrdinalIgnoreCase) -and [string]::IsNullOrWhiteSpace($lifecyclePreset)) {
-                    $lifecyclePreset = [string]$tokens[$index]
-                } else {
-                    Stop-WithError "usage: winsmux launcher <presets|lifecycle|list|save> [name] [--lifecycle <preset>] [--json]"
-                }
-            }
-        }
-    }
-
-    if ($clearLifecycleOverride -and -not [string]::Equals($mode, 'lifecycle', [System.StringComparison]::OrdinalIgnoreCase)) {
-        Stop-WithError "usage: winsmux launcher lifecycle [preset|--clear] [--json]"
-    }
-
-    if ($clearLifecycleOverride -and -not [string]::IsNullOrWhiteSpace($lifecyclePreset)) {
-        Stop-WithError "usage: winsmux launcher lifecycle [preset|--clear] [--json]"
-    }
-
-    $projectDir = (Get-Location).Path
-    if ([string]::Equals($mode, 'save', [System.StringComparison]::OrdinalIgnoreCase)) {
-        if ([string]::IsNullOrWhiteSpace($templateName)) {
-            Stop-WithError "usage: winsmux launcher save <name> [--json]"
-        }
-
-        $saveResult = Save-LauncherTemplate -ProjectDir $projectDir -Name $templateName -LifecyclePreset $lifecyclePreset
-        if ($jsonOutput) {
-            $saveResult | ConvertTo-Json -Depth 32 -Compress | Write-Output
-            return
-        }
-
-        Write-Output "launcher template saved: $($saveResult.name)"
-        Write-Output "templates: $($saveResult.templates_path)"
-        return
-    }
-
-    if ([string]::Equals($mode, 'list', [System.StringComparison]::OrdinalIgnoreCase)) {
-        $listResult = Get-LauncherTemplateListPayload -ProjectDir $projectDir
-        if ($jsonOutput) {
-            $listResult | ConvertTo-Json -Depth 32 -Compress | Write-Output
-            return
-        }
-
-        Write-Output "launcher templates: $($listResult.template_count)"
-        foreach ($template in @($listResult.templates)) {
-            Write-Output "  $($template.name)"
-        }
-        Write-Output "templates: $($listResult.templates_path)"
-        return
-    }
-
-    if ([string]::Equals($mode, 'lifecycle', [System.StringComparison]::OrdinalIgnoreCase)) {
-        if ($clearLifecycleOverride) {
-            $clearedPath = Clear-LauncherWorkspaceLifecycleOverride -ProjectDir $projectDir
-            $lifecycleResult = Get-LauncherWorkspaceLifecyclePayload -ProjectDir $projectDir
-            $lifecycleResult['override_cleared'] = $true
-            $lifecycleResult['cleared_path'] = $clearedPath
-        } elseif (-not [string]::IsNullOrWhiteSpace($lifecyclePreset)) {
-            $lifecycleResult = Get-LauncherWorkspaceLifecyclePayload -ProjectDir $projectDir -SelectedPreset $lifecyclePreset
-            $overridePath = Set-LauncherWorkspaceLifecycleOverride -ProjectDir $projectDir -Preset $lifecyclePreset
-            $lifecycleResult['override_saved'] = $true
-            $lifecycleResult['saved_path'] = $overridePath
-        } else {
-            $lifecycleResult = Get-LauncherWorkspaceLifecyclePayload -ProjectDir $projectDir
-        }
-
-        if ($jsonOutput) {
-            $lifecycleResult | ConvertTo-Json -Depth 32 -Compress | Write-Output
-            return
-        }
-
-        Write-Output "workspace lifecycle presets: $(@($lifecycleResult.presets).Count)"
-        Write-Output "selected: $($lifecycleResult.selected_preset)"
-        foreach ($preset in @($lifecycleResult.presets)) {
-            Write-Output "  $($preset.name): setup=$($preset.setup_policy) teardown=$($preset.teardown_policy)"
-        }
-        Write-Output "project default: $($lifecycleResult.project_default)"
-        Write-Output "user override: $($lifecycleResult.user_override)"
-        Write-Output "override path: $($lifecycleResult.override_path)"
-        return
-    }
-
-    $result = Get-LauncherPresetPayload -ProjectDir $projectDir -LifecyclePreset $lifecyclePreset
-    if ($jsonOutput) {
-        $result | ConvertTo-Json -Depth 16 -Compress | Write-Output
-        return
-    }
-
-    Write-Output "launcher presets: $(@($result.presets).Count)"
-    foreach ($preset in @($result.presets)) {
-        Write-Output "  $($preset.name): $($preset.slot_ids -join ',')"
-    }
-    Write-Output "pair templates: $(@($result.pair_templates).Count)"
-    foreach ($pair in @($result.pair_templates)) {
-        Write-Output "  $($pair.name): $($pair.left_slot_id),$($pair.right_slot_id)"
-    }
-    Write-Output "workspace lifecycle: $($result.workspace_lifecycle.selected_preset)"
-    Write-Output "templates: $($result.templates_path)"
 }
 
 function Invoke-ImeInput {
@@ -18427,77 +18297,6 @@ function Invoke-ConsultError {
     Write-ConsultationCommandRecord -Kind 'consult_error' -Mode ([string]$args.mode) -Message ([string]$args.message) -TargetSlot ([string]$args.target_slot)
 }
 
-function Invoke-ProviderCapabilities {
-    $tokens = @(@($Target) + @($Rest) | Where-Object { $_ })
-    $providerId = ''
-    $jsonOutput = $false
-
-    for ($index = 0; $index -lt $tokens.Count; $index++) {
-        switch ($tokens[$index]) {
-            '--json' {
-                $jsonOutput = $true
-            }
-            default {
-                if ([string]::IsNullOrWhiteSpace($providerId)) {
-                    $providerId = [string]$tokens[$index]
-                    continue
-                }
-
-                Stop-WithError "usage: winsmux provider-capabilities [provider] [--json]"
-            }
-        }
-    }
-
-    $projectDir = (Get-Location).Path
-    $registry = Read-BridgeProviderCapabilityRegistry -RootPath $projectDir
-    if (-not [string]::IsNullOrWhiteSpace($providerId)) {
-        $capabilities = Get-BridgeProviderCapability -RootPath $projectDir -ProviderId $providerId
-        if ($null -eq $capabilities) {
-            Stop-WithError "provider capability '$providerId' was not found."
-        }
-
-        $result = [ordered]@{
-            provider_id   = $providerId
-            capabilities  = $capabilities
-            registry_path = Get-BridgeProviderCapabilityRegistryPath -RootPath $projectDir
-        }
-        if ($jsonOutput) {
-            $result | ConvertTo-Json -Depth 16 -Compress | Write-Output
-            return
-        }
-
-        Write-Output "provider capability $providerId"
-        foreach ($property in $capabilities.GetEnumerator()) {
-            $value = $property.Value
-            if ($value -is [System.Array]) {
-                $value = ($value -join ',')
-            }
-            Write-Output "  $($property.Key): $value"
-        }
-        return
-    }
-
-    $result = [ordered]@{
-        version       = [int]$registry.version
-        registry_path = Get-BridgeProviderCapabilityRegistryPath -RootPath $projectDir
-        providers     = $registry.providers
-    }
-    if ($jsonOutput) {
-        $result | ConvertTo-Json -Depth 16 -Compress | Write-Output
-        return
-    }
-
-    if ($registry.providers.Count -lt 1) {
-        Write-Output 'provider capabilities: none'
-        return
-    }
-
-    Write-Output 'provider capabilities'
-    foreach ($entry in $registry.providers.GetEnumerator()) {
-        Write-Output "  $($entry.Key)"
-    }
-}
-
 function Invoke-MetaPlan {
     param(
         [AllowNull()][string]$MetaPlanTarget = $Target,
@@ -18725,195 +18524,6 @@ function Invoke-Guard {
     }
 
     $output | Write-Output
-}
-
-function Invoke-ProviderSwitch {
-    $tokens = @(@($Target) + @($Rest) | Where-Object { $_ })
-    if ($tokens.Count -lt 1) {
-        Stop-WithError "usage: winsmux provider-switch <slot> [--agent <name>] [--model <name>] [--model-source <source>] [--reasoning-effort <level>] [--prompt-transport <argv|file|stdin>] [--auth-mode <mode>] [--reason <text>] [--restart] [--clear] [--json]"
-    }
-
-    $slotId = [string]$tokens[0]
-    $agent = ''
-    $model = ''
-    $modelSource = ''
-    $reasoningEffort = ''
-    $promptTransport = ''
-    $authMode = ''
-    $reason = ''
-    $restartRequested = $false
-    $clearRequested = $false
-    $jsonOutput = $false
-
-    for ($index = 1; $index -lt $tokens.Count; $index++) {
-        switch ($tokens[$index]) {
-            '--agent' {
-                if ($index + 1 -ge $tokens.Count) {
-                    Stop-WithError '--agent requires a value'
-                }
-                $agent = [string]$tokens[$index + 1]
-                $index++
-            }
-            '--model' {
-                if ($index + 1 -ge $tokens.Count) {
-                    Stop-WithError '--model requires a value'
-                }
-                $model = [string]$tokens[$index + 1]
-                $index++
-            }
-            '--model-source' {
-                if ($index + 1 -ge $tokens.Count) {
-                    Stop-WithError '--model-source requires a value'
-                }
-                $modelSource = [string]$tokens[$index + 1]
-                $index++
-            }
-            '--reasoning-effort' {
-                if ($index + 1 -ge $tokens.Count) {
-                    Stop-WithError '--reasoning-effort requires a value'
-                }
-                $reasoningEffort = [string]$tokens[$index + 1]
-                $index++
-            }
-            '--prompt-transport' {
-                if ($index + 1 -ge $tokens.Count) {
-                    Stop-WithError '--prompt-transport requires a value'
-                }
-                $promptTransport = [string]$tokens[$index + 1]
-                $index++
-            }
-            '--auth-mode' {
-                if ($index + 1 -ge $tokens.Count) {
-                    Stop-WithError '--auth-mode requires a value'
-                }
-                $authMode = [string]$tokens[$index + 1]
-                $index++
-            }
-            '--reason' {
-                if ($index + 1 -ge $tokens.Count) {
-                    Stop-WithError '--reason requires a value'
-                }
-                $reason = [string]$tokens[$index + 1]
-                $index++
-            }
-            '--json' {
-                $jsonOutput = $true
-            }
-            '--restart' {
-                $restartRequested = $true
-            }
-            '--clear' {
-                $clearRequested = $true
-            }
-            default {
-                Stop-WithError "usage: winsmux provider-switch <slot> [--agent <name>] [--model <name>] [--model-source <source>] [--reasoning-effort <level>] [--prompt-transport <argv|file|stdin>] [--auth-mode <mode>] [--reason <text>] [--restart] [--clear] [--json]"
-            }
-        }
-    }
-
-    if ($clearRequested -and (-not [string]::IsNullOrWhiteSpace($agent) -or -not [string]::IsNullOrWhiteSpace($model) -or -not [string]::IsNullOrWhiteSpace($modelSource) -or -not [string]::IsNullOrWhiteSpace($reasoningEffort) -or -not [string]::IsNullOrWhiteSpace($promptTransport) -or -not [string]::IsNullOrWhiteSpace($authMode))) {
-        Stop-WithError 'provider-switch --clear cannot be combined with --agent, --model, --model-source, --reasoning-effort, --prompt-transport, or --auth-mode.'
-    }
-
-    $projectDir = (Get-Location).Path
-    $settings = Get-BridgeSettings -RootPath $projectDir
-    $knownSlot = $false
-    foreach ($slot in @($settings.agent_slots)) {
-        if ([string]::Equals([string]$slot.slot_id, $slotId, [System.StringComparison]::OrdinalIgnoreCase)) {
-            $knownSlot = $true
-            break
-        }
-    }
-    if (-not $knownSlot) {
-        Stop-WithError "provider-switch target slot '$slotId' is not present in agent_slots."
-    }
-
-    $restartPaneId = ''
-    if ($restartRequested) {
-        $manifestEntry = @(Get-PaneControlManifestEntries -ProjectDir $projectDir | Where-Object {
-            [string]::Equals([string]$_.Label, $slotId, [System.StringComparison]::OrdinalIgnoreCase)
-        } | Select-Object -First 1)
-
-        if ($manifestEntry.Count -lt 1) {
-            Stop-WithError "provider-switch --restart target slot '$slotId' is not present in the orchestra manifest."
-        }
-
-        $restartPaneId = Confirm-Target ([string]$manifestEntry[0].PaneId)
-    }
-
-    $entry = $null
-    $cleared = $false
-    if ($clearRequested) {
-        $clearResult = Remove-BridgeProviderRegistryEntry -RootPath $projectDir -SlotId $slotId
-        $cleared = [bool]$clearResult.Removed
-    } else {
-        $candidateInput = [ordered]@{}
-        if (-not [string]::IsNullOrWhiteSpace($agent)) { $candidateInput.agent = $agent }
-        if (-not [string]::IsNullOrWhiteSpace($model)) { $candidateInput.model = $model }
-        if (-not [string]::IsNullOrWhiteSpace($modelSource)) { $candidateInput.model_source = $modelSource }
-        if (-not [string]::IsNullOrWhiteSpace($reasoningEffort)) { $candidateInput.reasoning_effort = $reasoningEffort }
-        if (-not [string]::IsNullOrWhiteSpace($promptTransport)) { $candidateInput.prompt_transport = $promptTransport }
-        if (-not [string]::IsNullOrWhiteSpace($authMode)) { $candidateInput.auth_mode = $authMode }
-        $candidateEntry = ConvertTo-BridgeProviderRegistryEntry $candidateInput
-        $null = Get-SlotAgentConfig -Role 'Worker' -SlotId $slotId -Settings $settings -RootPath $projectDir -ProviderRegistryEntryOverride $candidateEntry
-        $entry = Write-BridgeProviderRegistryEntry -RootPath $projectDir -SlotId $slotId -Agent $agent -Model $model -ModelSource $modelSource -ReasoningEffort $reasoningEffort -PromptTransport $promptTransport -AuthMode $authMode -Reason $reason
-    }
-    $effective = Get-SlotAgentConfig -Role 'Worker' -SlotId $slotId -Settings $settings -RootPath $projectDir
-    $result = [ordered]@{
-        slot_id                    = $slotId
-        agent                      = [string]$effective.Agent
-        model                      = [string]$effective.Model
-        model_source               = [string]$effective.ModelSource
-        reasoning_effort           = [string]$effective.ReasoningEffort
-        prompt_transport           = [string]$effective.PromptTransport
-        auth_mode                  = [string]$effective.AuthMode
-        auth_policy                = [string]$effective.AuthPolicy
-        local_access_note          = [string]$effective.LocalAccessNote
-        harness_availability       = [string]$effective.HarnessAvailability
-        credential_requirements    = [string]$effective.CredentialRequirements
-        execution_backend          = [string]$effective.ExecutionBackend
-        api_base_url               = [string]$effective.ApiBaseUrl
-        api_key_env                = [string]$effective.ApiKeyEnv
-        runtime_requirements       = [string]$effective.RuntimeRequirements
-        analysis_posture           = [string]$effective.AnalysisPosture
-        source                     = [string]$effective.Source
-        capability_adapter         = [string]$effective.CapabilityAdapter
-        capability_command         = [string]$effective.CapabilityCommand
-        supports_parallel_runs     = [bool]$effective.SupportsParallelRuns
-        supports_interrupt         = [bool]$effective.SupportsInterrupt
-        supports_structured_result = [bool]$effective.SupportsStructuredResult
-        supports_file_edit         = [bool]$effective.SupportsFileEdit
-        supports_subagents         = [bool]$effective.SupportsSubagents
-        supports_verification      = [bool]$effective.SupportsVerification
-        supports_consultation      = [bool]$effective.SupportsConsultation
-        supports_context_reset     = [bool]$effective.SupportsContextReset
-        registry_path              = Get-BridgeProviderRegistryPath -RootPath $projectDir
-        updated_at_utc             = if ($clearRequested) { [string]$clearResult.UpdatedAtUtc } else { [string]$entry.updated_at_utc }
-        reason                     = if ((-not $clearRequested) -and $entry.Contains('reason')) { [string]$entry.reason } else { '' }
-        clear_requested            = $clearRequested
-        cleared                    = $cleared
-        restart_requested          = $restartRequested
-        restarted                  = $false
-        restart_pane_id            = ''
-    }
-
-    if ($restartRequested) {
-        $restartResult = Invoke-RestartPane -PaneId $restartPaneId -ProjectDir $projectDir
-        $result['restarted'] = $true
-        $result['restart_pane_id'] = [string]$restartResult.PaneId
-    }
-
-    if ($jsonOutput) {
-        $result | ConvertTo-Json -Depth 8 -Compress | Write-Output
-        return
-    }
-
-    if ($clearRequested) {
-        Write-Output "provider switch cleared for ${slotId}: $($result.agent) / $($result.model) ($($result.prompt_transport), $($result.auth_policy))"
-        return
-    }
-
-    Write-Output "provider switched for ${slotId}: $($result.agent) / $($result.model) ($($result.prompt_transport), $($result.auth_policy))"
 }
 
 function Invoke-RuntimeRoles {
@@ -19604,9 +19214,9 @@ switch ($Command) {
     'consult-request' { Invoke-ConsultRequest }
     'consult-result'  { Invoke-ConsultResult }
     'consult-error'   { Invoke-ConsultError }
-    'launcher'        { Invoke-Launcher }
+    'launcher'        { Invoke-WinsmuxLauncherCommand -CommandTarget $Target -CommandRest $Rest }
     'meta-plan'       { Invoke-MetaPlan }
-    'provider-capabilities' { Invoke-ProviderCapabilities }
+    'provider-capabilities' { Invoke-WinsmuxProviderCapabilitiesCommand -CommandTarget $Target -CommandRest $Rest }
     'skills' { Invoke-Skills }
     'machine-contract' { Invoke-MachineContract }
     'rust-canary' { Invoke-RustCanary }
@@ -19615,7 +19225,7 @@ switch ($Command) {
     'legacy-compat-gate' { Invoke-LegacyCompatGate }
     'guard' { Invoke-Guard }
     'assign' { Invoke-WinsmuxAssignCommand -BridgeScriptRoot $PSScriptRoot -CommandTarget $Target -CommandRest $Rest }
-    'provider-switch' { Invoke-ProviderSwitch }
+    'provider-switch' { Invoke-WinsmuxProviderSwitchCommand -CommandTarget $Target -CommandRest $Rest }
     'runtime-roles' { Invoke-RuntimeRoles }
     'rebind-worktree' { Invoke-RebindWorktree }
     ''                { Show-Usage }

--- a/tests/PublicSurfacePolicy.Tests.ps1
+++ b/tests/PublicSurfacePolicy.Tests.ps1
@@ -200,6 +200,7 @@ Describe 'Public surface policy' {
         $installerSingleLine | Should -Match '"orchestra".*"vault"'
         $installer | Should -Match 'Test-InstallProfileContent -Profile \$resolvedInstallProfile -Content "orchestration_scripts"'
         $installer | Should -Match 'winsmux-core/scripts/public-first-run\.ps1'
+        $installer | Should -Match 'winsmux-core/scripts/control-plane-commands\.ps1'
         $installer | Should -Match 'winsmux-core/scripts/control-plane-dispatch\.ps1'
         $installer | Should -Match 'winsmux-core/scripts/orchestra-smoke\.ps1'
         $installer | Should -Match 'winsmux-core/scripts/doctor\.ps1'
@@ -213,6 +214,7 @@ Describe 'Public surface policy' {
         $installer | Should -Match 'winsmux-core/scripts/server-watchdog\.ps1'
         $installer | Should -Match 'winsmux-core/scripts/pane-border\.ps1'
         $installer | Should -Match 'winsmux-core/scripts/common-contract\.generated\.ps1'
+        $installer | Should -Match '"control-plane-commands\.ps1"'
         $installer | Should -Match '"common-contract\.generated\.ps1"'
     }
 

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -16974,6 +16974,52 @@ Describe 'winsmux control-plane dispatch module' {
     }
 }
 
+Describe 'winsmux control-plane command module' {
+    BeforeAll {
+        $script:winsmuxCoreCommandRawPath = Join-Path (Split-Path -Parent $PSScriptRoot) 'scripts\winsmux-core.ps1'
+        $script:winsmuxCoreCommandRawContent = Get-Content -Path $script:winsmuxCoreCommandRawPath -Raw -Encoding UTF8
+        $script:controlPlaneCommandsPath = Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\control-plane-commands.ps1'
+        $script:controlPlaneCommandsContent = Get-Content -Path $script:controlPlaneCommandsPath -Raw -Encoding UTF8
+        . $script:controlPlaneCommandsPath
+    }
+
+    It 'loads typed command helpers from the bridge script' {
+        $script:winsmuxCoreCommandRawContent | Should -Match 'control-plane-commands\.ps1'
+        $script:winsmuxCoreCommandRawContent | Should -Match '\. \$ControlPlaneCommandsScript'
+        $script:controlPlaneCommandsContent | Should -Match 'function New-WinsmuxCommandResult'
+        $script:controlPlaneCommandsContent | Should -Match 'function New-WinsmuxCommandError'
+        $script:controlPlaneCommandsContent | Should -Match 'function Write-WinsmuxCommandResult'
+    }
+
+    It 'keeps launcher and provider command parsing outside the top-level command table' {
+        $script:winsmuxCoreCommandRawContent | Should -Match "'launcher'\s*\{\s*Invoke-WinsmuxLauncherCommand"
+        $script:winsmuxCoreCommandRawContent | Should -Match "'provider-capabilities'\s*\{\s*Invoke-WinsmuxProviderCapabilitiesCommand"
+        $script:winsmuxCoreCommandRawContent | Should -Match "'provider-switch'\s*\{\s*Invoke-WinsmuxProviderSwitchCommand"
+        $script:winsmuxCoreCommandRawContent | Should -Not -Match 'function Invoke-Launcher\s*\{'
+        $script:winsmuxCoreCommandRawContent | Should -Not -Match 'function Invoke-ProviderCapabilities\s*\{'
+        $script:winsmuxCoreCommandRawContent | Should -Not -Match 'function Invoke-ProviderSwitch\s*\{'
+        $script:controlPlaneCommandsContent | Should -Match 'function Invoke-WinsmuxLauncherCommand'
+        $script:controlPlaneCommandsContent | Should -Match 'function Invoke-WinsmuxProviderCapabilitiesCommand'
+        $script:controlPlaneCommandsContent | Should -Match 'function Invoke-WinsmuxProviderSwitchCommand'
+    }
+
+    It 'creates typed command result and error envelopes without changing public payload shape' {
+        $result = New-WinsmuxCommandResult -CommandName 'provider-switch' -Status 'updated' -Data ([ordered]@{ slot_id = 'worker-1'; model = 'gpt-5.4' })
+        $result.command | Should -Be 'provider-switch'
+        $result.ok | Should -Be $true
+        $result.status | Should -Be 'updated'
+        $result.exit_code | Should -Be 0
+        $result.data.slot_id | Should -Be 'worker-1'
+
+        $error = New-WinsmuxCommandError -CommandName 'launcher' -Reason 'invalid_argument' -Message 'usage: winsmux launcher'
+        $error.command | Should -Be 'launcher'
+        $error.ok | Should -Be $false
+        $error.status | Should -Be 'error'
+        $error.reason | Should -Be 'invalid_argument'
+        $error.exit_code | Should -Be 1
+    }
+}
+
 Describe 'winsmux profile command' {
     BeforeAll {
         $script:winsmuxCoreRawPath = Join-Path (Split-Path -Parent $PSScriptRoot) 'scripts\winsmux-core.ps1'
@@ -18015,6 +18061,7 @@ Describe 'winsmux provider-switch command' {
     BeforeAll {
         $script:winsmuxCoreRawPath = Join-Path (Split-Path -Parent $PSScriptRoot) 'scripts\winsmux-core.ps1'
         $script:winsmuxCoreRawContent = Get-Content -Path $script:winsmuxCoreRawPath -Raw -Encoding UTF8
+        $script:controlPlaneProviderSwitchCommandsContent = Get-Content -Path (Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\control-plane-commands.ps1') -Raw -Encoding UTF8
     }
 
     BeforeEach {
@@ -18286,18 +18333,18 @@ agent-slots:
     }
 
     It 'documents provider-switch restart and routes it through the manifest-backed restart helper' {
-        $script:winsmuxCoreRawContent | Should -Match "'--restart'\s*\{"
-        $script:winsmuxCoreRawContent | Should -Match "'--clear'\s*\{"
-        $script:winsmuxCoreRawContent | Should -Match 'Get-PaneControlManifestEntries -ProjectDir \$projectDir'
-        $script:winsmuxCoreRawContent | Should -Match 'Confirm-Target \(\[string\]\$manifestEntry\[0\]\.PaneId\)'
+        $script:controlPlaneProviderSwitchCommandsContent | Should -Match "'--restart'\s*\{"
+        $script:controlPlaneProviderSwitchCommandsContent | Should -Match "'--clear'\s*\{"
+        $script:controlPlaneProviderSwitchCommandsContent | Should -Match 'Get-PaneControlManifestEntries -ProjectDir \$projectDir'
+        $script:controlPlaneProviderSwitchCommandsContent | Should -Match 'Confirm-Target \(\[string\]\$manifestEntry\[0\]\.PaneId\)'
         $script:winsmuxCoreRawContent | Should -Match 'Invoke-RestartPane -PaneId'
         $script:winsmuxCoreRawContent | Should -Match '\$restartReadinessAgent\s*=\s*Get-RestartReadinessAgentName -Plan \$plan'
         $script:winsmuxCoreRawContent | Should -Match 'Test-AgentReadyPrompt -PaneId \$PaneId -Agent \$restartReadinessAgent'
         $script:winsmuxCoreRawContent | Should -Not -Match 'timed out waiting for Codex after restart'
-        $script:winsmuxCoreRawContent | Should -Match 'Remove-BridgeProviderRegistryEntry -RootPath \$projectDir -SlotId \$slotId'
-        $script:winsmuxCoreRawContent | Should -Match 'clear_requested'
-        $script:winsmuxCoreRawContent | Should -Match 'restart_requested'
-        $script:winsmuxCoreRawContent | Should -Match 'restart_pane_id'
+        $script:controlPlaneProviderSwitchCommandsContent | Should -Match 'Remove-BridgeProviderRegistryEntry -RootPath \$projectDir -SlotId \$slotId'
+        $script:controlPlaneProviderSwitchCommandsContent | Should -Match 'clear_requested'
+        $script:controlPlaneProviderSwitchCommandsContent | Should -Match 'restart_requested'
+        $script:controlPlaneProviderSwitchCommandsContent | Should -Match 'restart_pane_id'
     }
 
     It 'keeps Confirm-Target compatible with whitespace-separated pane lists' {

--- a/winsmux-core/scripts/control-plane-commands.ps1
+++ b/winsmux-core/scripts/control-plane-commands.ps1
@@ -1,0 +1,493 @@
+$ErrorActionPreference = 'Stop'
+
+function New-WinsmuxCommandResult {
+    param(
+        [Parameter(Mandatory = $true)][string]$CommandName,
+        [AllowEmptyString()][string]$Status = 'ok',
+        [AllowNull()]$Data = $null,
+        [AllowEmptyString()][string]$Reason = '',
+        [int]$ExitCode = 0
+    )
+
+    $ok = ($ExitCode -eq 0 -and $Status -notin @('blocked', 'failed', 'error'))
+    return [ordered]@{
+        command   = $CommandName
+        ok        = [bool]$ok
+        status    = $Status
+        reason    = $Reason
+        exit_code = $ExitCode
+        data      = $Data
+    }
+}
+
+function New-WinsmuxCommandError {
+    param(
+        [Parameter(Mandatory = $true)][string]$CommandName,
+        [Parameter(Mandatory = $true)][string]$Reason,
+        [Parameter(Mandatory = $true)][string]$Message,
+        [AllowEmptyString()][string]$Usage = '',
+        [int]$ExitCode = 1
+    )
+
+    return [ordered]@{
+        command   = $CommandName
+        ok        = $false
+        status    = 'error'
+        reason    = $Reason
+        message   = $Message
+        usage     = $Usage
+        exit_code = $ExitCode
+    }
+}
+
+function Stop-WinsmuxCommandError {
+    param(
+        [Parameter(Mandatory = $true)][string]$CommandName,
+        [Parameter(Mandatory = $true)][string]$Reason,
+        [Parameter(Mandatory = $true)][string]$Message,
+        [AllowEmptyString()][string]$Usage = ''
+    )
+
+    $script:LastWinsmuxCommandError = New-WinsmuxCommandError -CommandName $CommandName -Reason $Reason -Message $Message -Usage $Usage
+    Stop-WithError $Message
+}
+
+function Write-WinsmuxCommandResult {
+    param(
+        [Parameter(Mandatory = $true)]$Result,
+        [switch]$Json,
+        [int]$JsonDepth = 16,
+        [scriptblock]$TextWriter
+    )
+
+    $payload = if ($Result -is [System.Collections.IDictionary] -and $Result.Contains('data')) {
+        $Result['data']
+    } else {
+        $Result.data
+    }
+
+    if ($Json) {
+        $payload | ConvertTo-Json -Depth $JsonDepth -Compress | Write-Output
+        return
+    }
+
+    if ($null -ne $TextWriter) {
+        & $TextWriter $payload
+        return
+    }
+
+    $payload | Write-Output
+}
+
+function Invoke-WinsmuxLauncherCommand {
+    param(
+        [AllowNull()][string]$CommandTarget,
+        [AllowNull()][string[]]$CommandRest
+    )
+
+    $usage = "usage: winsmux launcher <presets|lifecycle|list|save> [name] [--lifecycle <preset>] [--json]"
+    $tokens = @(@($CommandTarget) + @($CommandRest) | Where-Object { $_ })
+    $mode = 'presets'
+    $templateName = ''
+    $lifecyclePreset = ''
+    $clearLifecycleOverride = $false
+    $jsonOutput = $false
+
+    for ($index = 0; $index -lt $tokens.Count; $index++) {
+        switch ($tokens[$index]) {
+            '--json' {
+                $jsonOutput = $true
+            }
+            '--clear' {
+                $clearLifecycleOverride = $true
+            }
+            '--lifecycle' {
+                $index++
+                if ($index -ge $tokens.Count -or [string]::IsNullOrWhiteSpace([string]$tokens[$index])) {
+                    Stop-WinsmuxCommandError -CommandName 'launcher' -Reason 'missing_lifecycle_preset' -Message $usage -Usage $usage
+                }
+
+                $lifecyclePreset = [string]$tokens[$index]
+            }
+            'presets' {
+                $mode = 'presets'
+            }
+            'lifecycle' {
+                $mode = 'lifecycle'
+            }
+            'list' {
+                $mode = 'list'
+            }
+            'save' {
+                $mode = 'save'
+            }
+            default {
+                if ([string]::Equals($mode, 'save', [System.StringComparison]::OrdinalIgnoreCase) -and [string]::IsNullOrWhiteSpace($templateName)) {
+                    $templateName = [string]$tokens[$index]
+                } elseif ([string]::Equals($mode, 'lifecycle', [System.StringComparison]::OrdinalIgnoreCase) -and [string]::IsNullOrWhiteSpace($lifecyclePreset)) {
+                    $lifecyclePreset = [string]$tokens[$index]
+                } else {
+                    Stop-WinsmuxCommandError -CommandName 'launcher' -Reason 'invalid_argument' -Message $usage -Usage $usage
+                }
+            }
+        }
+    }
+
+    if ($clearLifecycleOverride -and -not [string]::Equals($mode, 'lifecycle', [System.StringComparison]::OrdinalIgnoreCase)) {
+        $lifecycleUsage = "usage: winsmux launcher lifecycle [preset|--clear] [--json]"
+        Stop-WinsmuxCommandError -CommandName 'launcher' -Reason 'clear_requires_lifecycle_mode' -Message $lifecycleUsage -Usage $lifecycleUsage
+    }
+
+    if ($clearLifecycleOverride -and -not [string]::IsNullOrWhiteSpace($lifecyclePreset)) {
+        $lifecycleUsage = "usage: winsmux launcher lifecycle [preset|--clear] [--json]"
+        Stop-WinsmuxCommandError -CommandName 'launcher' -Reason 'clear_conflicts_with_lifecycle_preset' -Message $lifecycleUsage -Usage $lifecycleUsage
+    }
+
+    $projectDir = (Get-Location).Path
+    if ([string]::Equals($mode, 'save', [System.StringComparison]::OrdinalIgnoreCase)) {
+        if ([string]::IsNullOrWhiteSpace($templateName)) {
+            $saveUsage = "usage: winsmux launcher save <name> [--json]"
+            Stop-WinsmuxCommandError -CommandName 'launcher' -Reason 'missing_template_name' -Message $saveUsage -Usage $saveUsage
+        }
+
+        $saveResult = Save-LauncherTemplate -ProjectDir $projectDir -Name $templateName -LifecyclePreset $lifecyclePreset
+        $result = New-WinsmuxCommandResult -CommandName 'launcher' -Status 'saved' -Data $saveResult
+        Write-WinsmuxCommandResult -Result $result -Json:([bool]$jsonOutput) -JsonDepth 32 -TextWriter {
+            param($data)
+            Write-Output "launcher template saved: $($data.name)"
+            Write-Output "templates: $($data.templates_path)"
+        }
+        return
+    }
+
+    if ([string]::Equals($mode, 'list', [System.StringComparison]::OrdinalIgnoreCase)) {
+        $listResult = Get-LauncherTemplateListPayload -ProjectDir $projectDir
+        $result = New-WinsmuxCommandResult -CommandName 'launcher' -Status 'listed' -Data $listResult
+        Write-WinsmuxCommandResult -Result $result -Json:([bool]$jsonOutput) -JsonDepth 32 -TextWriter {
+            param($data)
+            Write-Output "launcher templates: $($data.template_count)"
+            foreach ($template in @($data.templates)) {
+                Write-Output "  $($template.name)"
+            }
+            Write-Output "templates: $($data.templates_path)"
+        }
+        return
+    }
+
+    if ([string]::Equals($mode, 'lifecycle', [System.StringComparison]::OrdinalIgnoreCase)) {
+        if ($clearLifecycleOverride) {
+            $clearedPath = Clear-LauncherWorkspaceLifecycleOverride -ProjectDir $projectDir
+            $lifecycleResult = Get-LauncherWorkspaceLifecyclePayload -ProjectDir $projectDir
+            $lifecycleResult['override_cleared'] = $true
+            $lifecycleResult['cleared_path'] = $clearedPath
+        } elseif (-not [string]::IsNullOrWhiteSpace($lifecyclePreset)) {
+            $lifecycleResult = Get-LauncherWorkspaceLifecyclePayload -ProjectDir $projectDir -SelectedPreset $lifecyclePreset
+            $overridePath = Set-LauncherWorkspaceLifecycleOverride -ProjectDir $projectDir -Preset $lifecyclePreset
+            $lifecycleResult['override_saved'] = $true
+            $lifecycleResult['saved_path'] = $overridePath
+        } else {
+            $lifecycleResult = Get-LauncherWorkspaceLifecyclePayload -ProjectDir $projectDir
+        }
+
+        $result = New-WinsmuxCommandResult -CommandName 'launcher' -Status 'lifecycle' -Data $lifecycleResult
+        Write-WinsmuxCommandResult -Result $result -Json:([bool]$jsonOutput) -JsonDepth 32 -TextWriter {
+            param($data)
+            Write-Output "workspace lifecycle presets: $(@($data.presets).Count)"
+            Write-Output "selected: $($data.selected_preset)"
+            foreach ($preset in @($data.presets)) {
+                Write-Output "  $($preset.name): setup=$($preset.setup_policy) teardown=$($preset.teardown_policy)"
+            }
+            Write-Output "project default: $($data.project_default)"
+            Write-Output "user override: $($data.user_override)"
+            Write-Output "override path: $($data.override_path)"
+        }
+        return
+    }
+
+    $presetPayload = Get-LauncherPresetPayload -ProjectDir $projectDir -LifecyclePreset $lifecyclePreset
+    $result = New-WinsmuxCommandResult -CommandName 'launcher' -Status 'presets' -Data $presetPayload
+    Write-WinsmuxCommandResult -Result $result -Json:([bool]$jsonOutput) -JsonDepth 16 -TextWriter {
+        param($data)
+        Write-Output "launcher presets: $(@($data.presets).Count)"
+        foreach ($preset in @($data.presets)) {
+            Write-Output "  $($preset.name): $($preset.slot_ids -join ',')"
+        }
+        Write-Output "pair templates: $(@($data.pair_templates).Count)"
+        foreach ($pair in @($data.pair_templates)) {
+            Write-Output "  $($pair.name): $($pair.left_slot_id),$($pair.right_slot_id)"
+        }
+        Write-Output "workspace lifecycle: $($data.workspace_lifecycle.selected_preset)"
+        Write-Output "templates: $($data.templates_path)"
+    }
+}
+
+function Invoke-WinsmuxProviderCapabilitiesCommand {
+    param(
+        [AllowNull()][string]$CommandTarget,
+        [AllowNull()][string[]]$CommandRest
+    )
+
+    $usage = "usage: winsmux provider-capabilities [provider] [--json]"
+    $tokens = @(@($CommandTarget) + @($CommandRest) | Where-Object { $_ })
+    $providerId = ''
+    $jsonOutput = $false
+
+    for ($index = 0; $index -lt $tokens.Count; $index++) {
+        switch ($tokens[$index]) {
+            '--json' {
+                $jsonOutput = $true
+            }
+            default {
+                if ([string]::IsNullOrWhiteSpace($providerId)) {
+                    $providerId = [string]$tokens[$index]
+                    continue
+                }
+
+                Stop-WinsmuxCommandError -CommandName 'provider-capabilities' -Reason 'invalid_argument' -Message $usage -Usage $usage
+            }
+        }
+    }
+
+    $projectDir = (Get-Location).Path
+    $registry = Read-BridgeProviderCapabilityRegistry -RootPath $projectDir
+    if (-not [string]::IsNullOrWhiteSpace($providerId)) {
+        $capabilities = Get-BridgeProviderCapability -RootPath $projectDir -ProviderId $providerId
+        if ($null -eq $capabilities) {
+            Stop-WinsmuxCommandError -CommandName 'provider-capabilities' -Reason 'provider_not_found' -Message "provider capability '$providerId' was not found."
+        }
+
+        $payload = [ordered]@{
+            provider_id   = $providerId
+            capabilities  = $capabilities
+            registry_path = Get-BridgeProviderCapabilityRegistryPath -RootPath $projectDir
+        }
+        $result = New-WinsmuxCommandResult -CommandName 'provider-capabilities' -Status 'found' -Data $payload
+        Write-WinsmuxCommandResult -Result $result -Json:([bool]$jsonOutput) -JsonDepth 16 -TextWriter {
+            param($data)
+            Write-Output "provider capability $($data.provider_id)"
+            foreach ($property in $data.capabilities.GetEnumerator()) {
+                $value = $property.Value
+                if ($value -is [System.Array]) {
+                    $value = ($value -join ',')
+                }
+                Write-Output "  $($property.Key): $value"
+            }
+        }
+        return
+    }
+
+    $payload = [ordered]@{
+        version       = [int]$registry.version
+        registry_path = Get-BridgeProviderCapabilityRegistryPath -RootPath $projectDir
+        providers     = $registry.providers
+    }
+    $result = New-WinsmuxCommandResult -CommandName 'provider-capabilities' -Status 'listed' -Data $payload
+    Write-WinsmuxCommandResult -Result $result -Json:([bool]$jsonOutput) -JsonDepth 16 -TextWriter {
+        param($data)
+        if ($data.providers.Count -lt 1) {
+            Write-Output 'provider capabilities: none'
+            return
+        }
+
+        Write-Output 'provider capabilities'
+        foreach ($entry in $data.providers.GetEnumerator()) {
+            Write-Output "  $($entry.Key)"
+        }
+    }
+}
+
+function Invoke-WinsmuxProviderSwitchCommand {
+    param(
+        [AllowNull()][string]$CommandTarget,
+        [AllowNull()][string[]]$CommandRest
+    )
+
+    $usage = "usage: winsmux provider-switch <slot> [--agent <name>] [--model <name>] [--model-source <source>] [--reasoning-effort <level>] [--prompt-transport <argv|file|stdin>] [--auth-mode <mode>] [--reason <text>] [--restart] [--clear] [--json]"
+    $tokens = @(@($CommandTarget) + @($CommandRest) | Where-Object { $_ })
+    if ($tokens.Count -lt 1) {
+        Stop-WinsmuxCommandError -CommandName 'provider-switch' -Reason 'missing_slot' -Message $usage -Usage $usage
+    }
+
+    $slotId = [string]$tokens[0]
+    $agent = ''
+    $model = ''
+    $modelSource = ''
+    $reasoningEffort = ''
+    $promptTransport = ''
+    $authMode = ''
+    $reason = ''
+    $restartRequested = $false
+    $clearRequested = $false
+    $jsonOutput = $false
+
+    for ($index = 1; $index -lt $tokens.Count; $index++) {
+        switch ($tokens[$index]) {
+            '--agent' {
+                if ($index + 1 -ge $tokens.Count) {
+                    Stop-WinsmuxCommandError -CommandName 'provider-switch' -Reason 'missing_agent' -Message '--agent requires a value' -Usage $usage
+                }
+                $agent = [string]$tokens[$index + 1]
+                $index++
+            }
+            '--model' {
+                if ($index + 1 -ge $tokens.Count) {
+                    Stop-WinsmuxCommandError -CommandName 'provider-switch' -Reason 'missing_model' -Message '--model requires a value' -Usage $usage
+                }
+                $model = [string]$tokens[$index + 1]
+                $index++
+            }
+            '--model-source' {
+                if ($index + 1 -ge $tokens.Count) {
+                    Stop-WinsmuxCommandError -CommandName 'provider-switch' -Reason 'missing_model_source' -Message '--model-source requires a value' -Usage $usage
+                }
+                $modelSource = [string]$tokens[$index + 1]
+                $index++
+            }
+            '--reasoning-effort' {
+                if ($index + 1 -ge $tokens.Count) {
+                    Stop-WinsmuxCommandError -CommandName 'provider-switch' -Reason 'missing_reasoning_effort' -Message '--reasoning-effort requires a value' -Usage $usage
+                }
+                $reasoningEffort = [string]$tokens[$index + 1]
+                $index++
+            }
+            '--prompt-transport' {
+                if ($index + 1 -ge $tokens.Count) {
+                    Stop-WinsmuxCommandError -CommandName 'provider-switch' -Reason 'missing_prompt_transport' -Message '--prompt-transport requires a value' -Usage $usage
+                }
+                $promptTransport = [string]$tokens[$index + 1]
+                $index++
+            }
+            '--auth-mode' {
+                if ($index + 1 -ge $tokens.Count) {
+                    Stop-WinsmuxCommandError -CommandName 'provider-switch' -Reason 'missing_auth_mode' -Message '--auth-mode requires a value' -Usage $usage
+                }
+                $authMode = [string]$tokens[$index + 1]
+                $index++
+            }
+            '--reason' {
+                if ($index + 1 -ge $tokens.Count) {
+                    Stop-WinsmuxCommandError -CommandName 'provider-switch' -Reason 'missing_reason' -Message '--reason requires a value' -Usage $usage
+                }
+                $reason = [string]$tokens[$index + 1]
+                $index++
+            }
+            '--json' {
+                $jsonOutput = $true
+            }
+            '--restart' {
+                $restartRequested = $true
+            }
+            '--clear' {
+                $clearRequested = $true
+            }
+            default {
+                Stop-WinsmuxCommandError -CommandName 'provider-switch' -Reason 'invalid_argument' -Message $usage -Usage $usage
+            }
+        }
+    }
+
+    if ($clearRequested -and (-not [string]::IsNullOrWhiteSpace($agent) -or -not [string]::IsNullOrWhiteSpace($model) -or -not [string]::IsNullOrWhiteSpace($modelSource) -or -not [string]::IsNullOrWhiteSpace($reasoningEffort) -or -not [string]::IsNullOrWhiteSpace($promptTransport) -or -not [string]::IsNullOrWhiteSpace($authMode))) {
+        Stop-WinsmuxCommandError -CommandName 'provider-switch' -Reason 'clear_conflicts_with_selector' -Message 'provider-switch --clear cannot be combined with --agent, --model, --model-source, --reasoning-effort, --prompt-transport, or --auth-mode.' -Usage $usage
+    }
+
+    $projectDir = (Get-Location).Path
+    $settings = Get-BridgeSettings -RootPath $projectDir
+    $knownSlot = $false
+    foreach ($slot in @($settings.agent_slots)) {
+        if ([string]::Equals([string]$slot.slot_id, $slotId, [System.StringComparison]::OrdinalIgnoreCase)) {
+            $knownSlot = $true
+            break
+        }
+    }
+    if (-not $knownSlot) {
+        Stop-WinsmuxCommandError -CommandName 'provider-switch' -Reason 'unknown_slot' -Message "provider-switch target slot '$slotId' is not present in agent_slots."
+    }
+
+    $restartPaneId = ''
+    if ($restartRequested) {
+        $manifestEntry = @(Get-PaneControlManifestEntries -ProjectDir $projectDir | Where-Object {
+            [string]::Equals([string]$_.Label, $slotId, [System.StringComparison]::OrdinalIgnoreCase)
+        } | Select-Object -First 1)
+
+        if ($manifestEntry.Count -lt 1) {
+            Stop-WinsmuxCommandError -CommandName 'provider-switch' -Reason 'restart_slot_missing' -Message "provider-switch --restart target slot '$slotId' is not present in the orchestra manifest."
+        }
+
+        $restartPaneId = Confirm-Target ([string]$manifestEntry[0].PaneId)
+    }
+
+    $entry = $null
+    $cleared = $false
+    if ($clearRequested) {
+        $clearResult = Remove-BridgeProviderRegistryEntry -RootPath $projectDir -SlotId $slotId
+        $cleared = [bool]$clearResult.Removed
+    } else {
+        $candidateInput = [ordered]@{}
+        if (-not [string]::IsNullOrWhiteSpace($agent)) { $candidateInput.agent = $agent }
+        if (-not [string]::IsNullOrWhiteSpace($model)) { $candidateInput.model = $model }
+        if (-not [string]::IsNullOrWhiteSpace($modelSource)) { $candidateInput.model_source = $modelSource }
+        if (-not [string]::IsNullOrWhiteSpace($reasoningEffort)) { $candidateInput.reasoning_effort = $reasoningEffort }
+        if (-not [string]::IsNullOrWhiteSpace($promptTransport)) { $candidateInput.prompt_transport = $promptTransport }
+        if (-not [string]::IsNullOrWhiteSpace($authMode)) { $candidateInput.auth_mode = $authMode }
+        $candidateEntry = ConvertTo-BridgeProviderRegistryEntry $candidateInput
+        $null = Get-SlotAgentConfig -Role 'Worker' -SlotId $slotId -Settings $settings -RootPath $projectDir -ProviderRegistryEntryOverride $candidateEntry
+        $entry = Write-BridgeProviderRegistryEntry -RootPath $projectDir -SlotId $slotId -Agent $agent -Model $model -ModelSource $modelSource -ReasoningEffort $reasoningEffort -PromptTransport $promptTransport -AuthMode $authMode -Reason $reason
+    }
+
+    $effective = Get-SlotAgentConfig -Role 'Worker' -SlotId $slotId -Settings $settings -RootPath $projectDir
+    $payload = [ordered]@{
+        slot_id                    = $slotId
+        agent                      = [string]$effective.Agent
+        model                      = [string]$effective.Model
+        model_source               = [string]$effective.ModelSource
+        reasoning_effort           = [string]$effective.ReasoningEffort
+        prompt_transport           = [string]$effective.PromptTransport
+        auth_mode                  = [string]$effective.AuthMode
+        auth_policy                = [string]$effective.AuthPolicy
+        local_access_note          = [string]$effective.LocalAccessNote
+        harness_availability       = [string]$effective.HarnessAvailability
+        credential_requirements    = [string]$effective.CredentialRequirements
+        execution_backend          = [string]$effective.ExecutionBackend
+        api_base_url               = [string]$effective.ApiBaseUrl
+        api_key_env                = [string]$effective.ApiKeyEnv
+        runtime_requirements       = [string]$effective.RuntimeRequirements
+        analysis_posture           = [string]$effective.AnalysisPosture
+        source                     = [string]$effective.Source
+        capability_adapter         = [string]$effective.CapabilityAdapter
+        capability_command         = [string]$effective.CapabilityCommand
+        supports_parallel_runs     = [bool]$effective.SupportsParallelRuns
+        supports_interrupt         = [bool]$effective.SupportsInterrupt
+        supports_structured_result = [bool]$effective.SupportsStructuredResult
+        supports_file_edit         = [bool]$effective.SupportsFileEdit
+        supports_subagents         = [bool]$effective.SupportsSubagents
+        supports_verification      = [bool]$effective.SupportsVerification
+        supports_consultation      = [bool]$effective.SupportsConsultation
+        supports_context_reset     = [bool]$effective.SupportsContextReset
+        registry_path              = Get-BridgeProviderRegistryPath -RootPath $projectDir
+        updated_at_utc             = if ($clearRequested) { [string]$clearResult.UpdatedAtUtc } else { [string]$entry.updated_at_utc }
+        reason                     = if ((-not $clearRequested) -and $entry.Contains('reason')) { [string]$entry.reason } else { '' }
+        clear_requested            = $clearRequested
+        cleared                    = $cleared
+        restart_requested          = $restartRequested
+        restarted                  = $false
+        restart_pane_id            = ''
+    }
+
+    if ($restartRequested) {
+        $restartResult = Invoke-RestartPane -PaneId $restartPaneId -ProjectDir $projectDir
+        $payload['restarted'] = $true
+        $payload['restart_pane_id'] = [string]$restartResult.PaneId
+    }
+
+    $status = if ($clearRequested) { 'cleared' } else { 'updated' }
+    $result = New-WinsmuxCommandResult -CommandName 'provider-switch' -Status $status -Data $payload
+    Write-WinsmuxCommandResult -Result $result -Json:([bool]$jsonOutput) -JsonDepth 8 -TextWriter {
+        param($data)
+        if ([bool]$data.clear_requested) {
+            Write-Output "provider switch cleared for $($data.slot_id): $($data.agent) / $($data.model) ($($data.prompt_transport), $($data.auth_policy))"
+            return
+        }
+
+        Write-Output "provider switched for $($data.slot_id): $($data.agent) / $($data.model) ($($data.prompt_transport), $($data.auth_policy))"
+    }
+}


### PR DESCRIPTION
## Summary

Extract the `launcher`, `provider-capabilities`, and `provider-switch` command handlers from the root bridge script into `winsmux-core/scripts/control-plane-commands.ps1`.

The new module adds typed result/error helpers for internal command handling while preserving the existing public JSON/text payload shape.

## Changes

- Dot-source the new command module from `scripts/winsmux-core.ps1`.
- Move launcher and provider command parsing/output into `control-plane-commands.ps1`.
- Keep public CLI JSON output as the existing payload, not the internal typed envelope.
- Add installer coverage for the new support script.
- Add Pester coverage for module loading, command delegation, typed envelopes, and provider restart routing after the responsibility move.

## Verification

- `Invoke-Pester -Path tests\winsmux-bridge.Tests.ps1 -FullNameFilter *control-plane* -PassThru -Output Detailed`
- `Invoke-Pester -Path tests\winsmux-bridge.Tests.ps1 -FullNameFilter *provider-capabilities* -PassThru -Output Detailed`
- `Invoke-Pester -Path tests\winsmux-bridge.Tests.ps1 -FullNameFilter *provider-switch* -PassThru -Output Minimal`
- `Invoke-Pester -Path tests\winsmux-bridge.Tests.ps1 -FullNameFilter *launcher* -PassThru -Output Detailed`
- `Invoke-Pester -Path tests\winsmux-bridge.Tests.ps1 -FullNameFilter *role* -PassThru -Output Detailed`
- `Invoke-Pester -Path tests\PublicSurfacePolicy.Tests.ps1 -FullNameFilter *installer* -PassThru -Output Detailed`
- `pwsh -NoProfile -File scripts\winsmux-core.ps1 provider-capabilities --json`
- `pwsh -NoProfile -File scripts\winsmux-core.ps1 launcher --json`
- `git diff --check`
- `pwsh -NoProfile -File scripts\audit-public-surface.ps1`
- `pwsh -NoProfile -File scripts\git-guard.ps1 -Mode full`

Full `tests\winsmux-bridge.Tests.ps1` was started and then stopped after several minutes without additional output during bootstrap-heavy coverage; the focused command-module and affected command tests above passed.
