### PR TITLE
refactor(core): extract workers workspace command module

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -111,6 +111,10 @@ function Write-InstallProfileManifest {
     $manifest | ConvertTo-Json -Depth 8 | Set-Content -Path $PROFILE_MANIFEST_FILE -Encoding UTF8
 }
 
+function Install-CoreSupportScripts {
+    Download-File "winsmux-core/scripts/control-plane-workers.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "control-plane-workers.ps1")
+}
+
 function Install-OrchestraSupportScripts {
     Download-File "winsmux-core/scripts/agent-launch.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "agent-launch.ps1")
     Download-File "winsmux-core/scripts/agent-monitor.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "agent-monitor.ps1")
@@ -122,7 +126,6 @@ function Install-OrchestraSupportScripts {
     Download-File "winsmux-core/scripts/common-contract.generated.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "common-contract.generated.ps1")
     Download-File "winsmux-core/scripts/control-plane-commands.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "control-plane-commands.ps1")
     Download-File "winsmux-core/scripts/control-plane-dispatch.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "control-plane-dispatch.ps1")
-    Download-File "winsmux-core/scripts/control-plane-workers.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "control-plane-workers.ps1")
     Download-File "winsmux-core/scripts/operator-poll.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "operator-poll.ps1")
     Download-File "winsmux-core/scripts/doctor.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "doctor.ps1")
     Download-File "winsmux-core/scripts/logger.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "logger.ps1")
@@ -167,7 +170,6 @@ function Remove-ProfileExcludedSupportScripts {
                 "common-contract.generated.ps1",
                 "control-plane-commands.ps1",
                 "control-plane-dispatch.ps1",
-                "control-plane-workers.ps1",
                 "operator-poll.ps1",
                 "doctor.ps1",
                 "logger.ps1",
@@ -463,6 +465,8 @@ function Invoke-Install {
 
     # winsmux.ps1 CLI
     Download-File "winsmux.ps1" (Join-Path $BIN_DIR "winsmux.ps1")
+
+    Install-CoreSupportScripts
 
     if (Test-InstallProfileContent -Profile $resolvedInstallProfile -Content "orchestration_scripts") {
         Install-OrchestraSupportScripts

--- a/install.ps1
+++ b/install.ps1
@@ -112,7 +112,7 @@ function Write-InstallProfileManifest {
 }
 
 function Install-CoreSupportScripts {
-    Download-File "winsmux-core/scripts/control-plane-workers.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "control-plane-workers.ps1")
+    Download-OptionalFile "winsmux-core/scripts/control-plane-workers.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "control-plane-workers.ps1")
 }
 
 function Install-OrchestraSupportScripts {
@@ -426,6 +426,32 @@ function Download-File($relativeUrl, $destPath) {
         Write-Error "[winsmux] Failed to download $url : $_"
         exit 1
     }
+}
+
+function Test-RemoteFileExists($relativeUrl) {
+    $url = "$BASE_URL/$relativeUrl"
+    try {
+        Invoke-WebRequest -Uri $url -Method Head -UseBasicParsing -ErrorAction Stop | Out-Null
+        return $true
+    } catch {
+        $statusCode = $null
+        if ($_.Exception.Response -and $_.Exception.Response.StatusCode) {
+            $statusCode = [int]$_.Exception.Response.StatusCode
+        }
+        if ($statusCode -eq 404 -or $_.Exception.Message -match '404|Not Found') {
+            return $false
+        }
+        Write-Error "[winsmux] Failed to probe $url : $_"
+        exit 1
+    }
+}
+
+function Download-OptionalFile($relativeUrl, $destPath) {
+    if (Test-RemoteFileExists $relativeUrl) {
+        Download-File $relativeUrl $destPath
+        return
+    }
+    Write-Status "Skipping optional $relativeUrl; it is not present in $RELEASE_LABEL."
 }
 
 # ---------------------------------------------------------------------------

--- a/install.ps1
+++ b/install.ps1
@@ -122,6 +122,7 @@ function Install-OrchestraSupportScripts {
     Download-File "winsmux-core/scripts/common-contract.generated.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "common-contract.generated.ps1")
     Download-File "winsmux-core/scripts/control-plane-commands.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "control-plane-commands.ps1")
     Download-File "winsmux-core/scripts/control-plane-dispatch.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "control-plane-dispatch.ps1")
+    Download-File "winsmux-core/scripts/control-plane-workers.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "control-plane-workers.ps1")
     Download-File "winsmux-core/scripts/operator-poll.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "operator-poll.ps1")
     Download-File "winsmux-core/scripts/doctor.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "doctor.ps1")
     Download-File "winsmux-core/scripts/logger.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "logger.ps1")
@@ -166,6 +167,7 @@ function Remove-ProfileExcludedSupportScripts {
                 "common-contract.generated.ps1",
                 "control-plane-commands.ps1",
                 "control-plane-dispatch.ps1",
+                "control-plane-workers.ps1",
                 "operator-poll.ps1",
                 "doctor.ps1",
                 "logger.ps1",

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -70,6 +70,7 @@ $PublicFirstRunScript = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '
 $ConflictPreflightScript = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\winsmux-core\scripts\conflict-preflight.ps1'))
 $ControlPlaneDispatchScript = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\winsmux-core\scripts\control-plane-dispatch.ps1'))
 $ControlPlaneCommandsScript = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\winsmux-core\scripts\control-plane-commands.ps1'))
+$ControlPlaneWorkersScript = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\winsmux-core\scripts\control-plane-workers.ps1'))
 
 # Adapter module owns external script calls: github-write-preflight.ps1, dispatch-router.ps1,
 # task-splitter.ps1, team-pipeline.ps1, builder-queue.ps1, orchestra-smoke.ps1,
@@ -77,6 +78,7 @@ $ControlPlaneCommandsScript = [System.IO.Path]::GetFullPath((Join-Path $PSScript
 # powershell-deescalation.ps1, assignment-policy.ps1.
 # Command module owns typed command result helpers and command argument/output handling
 # for launcher, provider-capabilities, and provider-switch.
+# Workers module owns workers workspace argument and output handling.
 
 if (Test-Path $BridgeSettingsScript -PathType Leaf) {
     . $BridgeSettingsScript
@@ -120,6 +122,10 @@ if (Test-Path $ControlPlaneDispatchScript -PathType Leaf) {
 
 if (Test-Path $ControlPlaneCommandsScript -PathType Leaf) {
     . $ControlPlaneCommandsScript
+}
+
+if (Test-Path $ControlPlaneWorkersScript -PathType Leaf) {
+    . $ControlPlaneWorkersScript
 }
 
 # --- Windows Credential Manager P/Invoke ---
@@ -7784,86 +7790,6 @@ function Read-WorkersLogsOptions {
     }
 }
 
-function Read-WorkersWorkspaceOptions {
-    param([Parameter(Mandatory = $true)][string]$Usage)
-
-    $projectDir = (Get-Location).Path
-    $asJson = $false
-    $workspaceAction = ''
-    $targetValue = ''
-    $runId = ''
-    $profile = 'isolated-enterprise'
-    $includes = [System.Collections.Generic.List[string]]::new()
-    $items = @($Rest)
-
-    if ($items.Count -ge 1) {
-        $workspaceAction = [string]$items[0]
-    }
-    if ($items.Count -ge 2) {
-        $targetValue = [string]$items[1]
-    }
-    if ([string]::IsNullOrWhiteSpace($workspaceAction) -or [string]::IsNullOrWhiteSpace($targetValue)) {
-        Stop-WithError $Usage
-    }
-
-    for ($index = 2; $index -lt $items.Count; $index++) {
-        $token = [string]$items[$index]
-        switch ($token) {
-            '--json' { $asJson = $true }
-            '--project-dir' {
-                if ($index + 1 -ge $items.Count) { Stop-WithError $Usage }
-                $projectDir = [string]$items[$index + 1]
-                $index++
-            }
-            '--run-id' {
-                if ($index + 1 -ge $items.Count) { Stop-WithError $Usage }
-                $runId = [string]$items[$index + 1]
-                $index++
-            }
-            '--profile' {
-                if ($index + 1 -ge $items.Count) { Stop-WithError $Usage }
-                $profile = [string]$items[$index + 1]
-                $index++
-            }
-            '--include' {
-                if ($index + 1 -ge $items.Count) { Stop-WithError $Usage }
-                $includes.Add([string]$items[$index + 1]) | Out-Null
-                $index++
-            }
-            default {
-                Stop-WithError $Usage
-            }
-        }
-    }
-
-    if ($workspaceAction -notin @('prepare', 'cleanup')) {
-        Stop-WithError $Usage
-    }
-    if (Get-Command Test-BridgeExecutionProfileKind -ErrorAction SilentlyContinue) {
-        if (-not (Test-BridgeExecutionProfileKind -Value $profile)) {
-            Stop-WithError "unsupported execution profile for isolated workspace: $profile"
-        }
-    }
-    if (-not [string]::Equals($profile, 'isolated-enterprise', [System.StringComparison]::OrdinalIgnoreCase)) {
-        Stop-WithError 'isolated workspace requires execution profile isolated-enterprise'
-    }
-    if ($workspaceAction -eq 'prepare' -and $includes.Count -lt 1) {
-        Stop-WithError 'isolated workspace prepare requires at least one --include path'
-    }
-    if ($workspaceAction -eq 'cleanup' -and [string]::IsNullOrWhiteSpace($runId)) {
-        Stop-WithError 'isolated workspace cleanup requires --run-id'
-    }
-
-    return [PSCustomObject]@{
-        ProjectDir = $projectDir
-        Json       = $asJson
-        Action     = $workspaceAction
-        Target     = $targetValue
-        RunId      = $runId
-        Profile    = $profile.Trim().ToLowerInvariant()
-        Includes   = @($includes)
-    }
-}
 
 function Read-WorkersSecretMapSpec {
     param(
@@ -8432,211 +8358,8 @@ function Get-WorkersSingleSlotContext {
     }
 }
 
-function Invoke-WorkersWorkspacePrepare {
-    param([Parameter(Mandatory = $true)]$Options)
 
-    $slot = Get-WorkersSingleSlotContext -ProjectDir $Options.ProjectDir -Target $Options.Target
-    $slotProfile = [string]$slot.SlotConfig.ExecutionProfile
-    if (-not [string]::Equals($slotProfile, [string]$Options.Profile, [System.StringComparison]::OrdinalIgnoreCase)) {
-        Stop-WithError "worker slot $($slot.Row.SlotId) uses execution profile '$slotProfile', not isolated-enterprise"
-    }
 
-    $runId = Assert-WorkersRunId -RunId ([string]$Options.RunId)
-    if ([string]::IsNullOrWhiteSpace($runId)) {
-        $runId = New-WorkersRunId -SlotId ([string]$slot.Row.SlotId)
-    }
-
-    $runDir = Get-WorkersIsolatedWorkspaceRunDirectory -ProjectDir $Options.ProjectDir -SlotId ([string]$slot.Row.SlotId) -RunId $runId
-    Assert-WorkersIsolatedWorkspaceCleanupTarget -ProjectDir $Options.ProjectDir -RunDir $runDir
-    if (Test-Path -LiteralPath $runDir) {
-        Stop-WithError "isolated workspace run already exists: $runId"
-    }
-
-    $sources = [System.Collections.Generic.List[object]]::new()
-    foreach ($includePath in @($Options.Includes)) {
-        $source = Resolve-WorkersIsolatedProjectionPath -ProjectDir $Options.ProjectDir -Path ([string]$includePath)
-        if ([bool]$source.IsDirectory) {
-            Assert-WorkersDirectoryContainsOnlyIsolatedSafeFiles -ProjectDir $Options.ProjectDir -SourceInfo $source
-        }
-        $sources.Add($source) | Out-Null
-    }
-
-    $workspaceDir = Join-Path $runDir 'workspace'
-    $downloadsDir = Join-Path $runDir 'downloads'
-    $artifactsDir = Join-Path $runDir 'artifacts'
-    New-Item -ItemType Directory -Path $workspaceDir -Force | Out-Null
-    New-Item -ItemType Directory -Path $downloadsDir -Force | Out-Null
-    New-Item -ItemType Directory -Path $artifactsDir -Force | Out-Null
-
-    $projections = [System.Collections.Generic.List[object]]::new()
-    foreach ($source in @($sources)) {
-        $projections.Add((Copy-WorkersIsolatedProjection -ProjectDir $Options.ProjectDir -WorkspaceDir $workspaceDir -SourceInfo $source)) | Out-Null
-    }
-
-    $manifestPath = Join-Path $runDir 'workspace.json'
-    $runReference = Get-WorkersArtifactReference -ProjectDir $Options.ProjectDir -Path $runDir
-    $workspaceReference = Get-WorkersArtifactReference -ProjectDir $Options.ProjectDir -Path $workspaceDir
-    $downloadsReference = Get-WorkersArtifactReference -ProjectDir $Options.ProjectDir -Path $downloadsDir
-    $artifactsReference = Get-WorkersArtifactReference -ProjectDir $Options.ProjectDir -Path $artifactsDir
-    $manifestReference = Get-WorkersArtifactReference -ProjectDir $Options.ProjectDir -Path $manifestPath
-
-    $payload = [ordered]@{
-        version       = 1
-        project_ref   = '.'
-        generated_at  = (Get-Date).ToUniversalTime().ToString('o')
-        command       = 'workers.workspace.prepare'
-        status        = 'prepared'
-        slot          = [string]$slot.Row.Slot
-        slot_id       = [string]$slot.Row.SlotId
-        run_id        = $runId
-        execution_profile = 'isolated-enterprise'
-        workspace_lifecycle = 'disposable'
-        policy        = [ordered]@{
-            direct_project_write = 'prohibited'
-            projection           = 'explicit-includes-only'
-            cleanup              = 'delete-isolated-run-directory'
-            rejects              = @('path_traversal', 'absolute_escape', 'reparse_point', 'windows_reserved_name', 'excluded_or_secret_like_path')
-        }
-        locations     = [ordered]@{
-            project_root = New-WinsmuxLocationIdentity -Kind 'local_directory' -DisplayName 'project root' -Backend 'local-windows' -AccessMethod 'project_root' -Reference '.' -Provenance 'workers.workspace.project_root'
-            run_root     = New-WinsmuxLocationIdentity -Kind 'local_directory' -DisplayName $runReference -Backend 'local-windows' -AccessMethod 'isolated_run_root' -Reference $runReference -Provenance 'workers.workspace.run_root'
-            workspace    = New-WinsmuxLocationIdentity -Kind 'local_directory' -DisplayName $workspaceReference -Backend 'local-windows' -AccessMethod 'isolated_workspace' -Reference $workspaceReference -Provenance 'workers.workspace.workspace'
-            downloads    = New-WinsmuxLocationIdentity -Kind 'local_directory' -DisplayName $downloadsReference -Backend 'local-windows' -AccessMethod 'isolated_downloads' -Reference $downloadsReference -Provenance 'workers.workspace.downloads'
-            artifacts    = New-WinsmuxLocationIdentity -Kind 'local_directory' -DisplayName $artifactsReference -Backend 'local-windows' -AccessMethod 'isolated_artifacts' -Reference $artifactsReference -Provenance 'workers.workspace.artifacts'
-            manifest     = New-WinsmuxLocationIdentity -Kind 'local_file' -DisplayName 'workspace.json' -Backend 'local-windows' -AccessMethod 'artifact_ref' -Reference $manifestReference -Provenance 'workers.workspace.manifest'
-        }
-        projections   = @($projections)
-        exit_code     = 0
-    }
-
-    Write-WorkersJsonArtifact -Path $manifestPath -Data $payload | Out-Null
-    if ($null -ne $slot.Entry) {
-        Set-WorkersManifestLifecycleCommand -Entry $slot.Entry -CommandName 'workers.workspace.prepare' -ExtraProperties ([ordered]@{
-            last_workspace_run_id = $runId
-            last_workspace_profile = 'isolated-enterprise'
-            last_workspace_status = 'prepared'
-            last_workspace_lifecycle = 'disposable'
-            last_workspace_root = $workspaceReference
-            last_workspace_manifest = $manifestReference
-            last_secret_run_id = ''
-            last_secret_profile = ''
-            last_secret_status = ''
-            last_secret_binding = ''
-            last_secret_projection_count = ''
-            last_secret_manifest = ''
-            last_broker_run_id = ''
-            last_broker_profile = ''
-            last_broker_status = ''
-            last_broker_node_id = ''
-            last_broker_endpoint = ''
-            last_broker_manifest = ''
-            last_broker_token_status = ''
-            last_broker_token_health = ''
-            last_broker_token_expires_at = ''
-            last_broker_token_manifest = ''
-            last_policy_run_id = ''
-            last_policy_profile = ''
-            last_policy_status = ''
-            last_policy_health = ''
-            last_policy_reason = ''
-            last_policy_network = ''
-            last_policy_write = ''
-            last_policy_provider = ''
-            last_policy_mandatory_checks = ''
-            last_policy_required_evidence = ''
-            last_policy_manifest = ''
-        })
-    }
-
-    Write-WorkersOperationOutput -Payload $payload -Json:([bool]$Options.Json) -Text "prepared $runId"
-}
-
-function Invoke-WorkersWorkspaceCleanup {
-    param([Parameter(Mandatory = $true)]$Options)
-
-    $slot = Get-WorkersSingleSlotContext -ProjectDir $Options.ProjectDir -Target $Options.Target
-    $runId = Assert-WorkersRunId -RunId ([string]$Options.RunId)
-    $runDir = Get-WorkersIsolatedWorkspaceRunDirectory -ProjectDir $Options.ProjectDir -SlotId ([string]$slot.Row.SlotId) -RunId $runId
-    Assert-WorkersIsolatedWorkspaceCleanupTarget -ProjectDir $Options.ProjectDir -RunDir $runDir
-    $existed = Test-Path -LiteralPath $runDir
-    if ($existed) {
-        Remove-WorkersIsolatedWorkspaceRunDirectory -ProjectDir $Options.ProjectDir -RunDir $runDir
-    }
-
-    $runReference = Get-WorkersArtifactReference -ProjectDir $Options.ProjectDir -Path $runDir
-    $payload = [ordered]@{
-        version       = 1
-        project_ref   = '.'
-        generated_at  = (Get-Date).ToUniversalTime().ToString('o')
-        command       = 'workers.workspace.cleanup'
-        status        = if ($existed) { 'cleaned' } else { 'not_found' }
-        slot          = [string]$slot.Row.Slot
-        slot_id       = [string]$slot.Row.SlotId
-        run_id        = $runId
-        execution_profile = 'isolated-enterprise'
-        workspace_lifecycle = 'disposable'
-        locations     = [ordered]@{
-            run_root = New-WinsmuxLocationIdentity -Kind 'local_directory' -DisplayName $runReference -Backend 'local-windows' -AccessMethod 'isolated_run_root' -Reference $runReference -Provenance 'workers.workspace.cleanup'
-        }
-        existed       = [bool]$existed
-        exit_code     = 0
-    }
-    if ($null -ne $slot.Entry) {
-        $activeWorkspaceRunId = [string](Get-SendConfigValue -InputObject $slot.Entry -Name 'LastWorkspaceRunId' -Default '')
-        $cleanupIsActiveWorkspace = [string]::Equals($activeWorkspaceRunId, $runId, [System.StringComparison]::Ordinal)
-    }
-    if ($null -ne $slot.Entry -and $cleanupIsActiveWorkspace) {
-        Set-WorkersManifestLifecycleCommand -Entry $slot.Entry -CommandName 'workers.workspace.cleanup' -ExtraProperties ([ordered]@{
-            last_workspace_run_id = $runId
-            last_workspace_profile = 'isolated-enterprise'
-            last_workspace_status = [string]$payload['status']
-            last_workspace_lifecycle = 'disposable'
-            last_workspace_root = ''
-            last_workspace_manifest = ''
-            last_secret_run_id = ''
-            last_secret_profile = ''
-            last_secret_status = ''
-            last_secret_binding = ''
-            last_secret_projection_count = ''
-            last_secret_manifest = ''
-            last_broker_run_id = ''
-            last_broker_profile = ''
-            last_broker_status = ''
-            last_broker_node_id = ''
-            last_broker_endpoint = ''
-            last_broker_manifest = ''
-            last_broker_token_status = ''
-            last_broker_token_health = ''
-            last_broker_token_expires_at = ''
-            last_broker_token_manifest = ''
-            last_policy_run_id = ''
-            last_policy_profile = ''
-            last_policy_status = ''
-            last_policy_health = ''
-            last_policy_reason = ''
-            last_policy_network = ''
-            last_policy_write = ''
-            last_policy_provider = ''
-            last_policy_mandatory_checks = ''
-            last_policy_required_evidence = ''
-            last_policy_manifest = ''
-        })
-    } elseif ($null -ne $slot.Entry) {
-        Set-WorkersManifestLifecycleCommand -Entry $slot.Entry -CommandName 'workers.workspace.cleanup'
-    }
-
-    Write-WorkersOperationOutput -Payload $payload -Json:([bool]$Options.Json) -Text "$($payload['status']) $runId"
-}
-
-function Invoke-WorkersWorkspace {
-    $usage = "usage: winsmux workers workspace <prepare|cleanup> <slot> [--include <path>] [--run-id <id>] [--profile isolated-enterprise] [--json] [--project-dir <path>]"
-    $options = Read-WorkersWorkspaceOptions -Usage $usage
-    switch ([string]$options.Action) {
-        'prepare' { Invoke-WorkersWorkspacePrepare -Options $options }
-        'cleanup' { Invoke-WorkersWorkspaceCleanup -Options $options }
-        default { Stop-WithError $usage }
-    }
-}
 
 function Invoke-WorkersSecretsProject {
     param([Parameter(Mandatory = $true)]$Options)
@@ -11398,7 +11121,7 @@ function Invoke-Workers {
         'attach' { Invoke-WorkersAttach }
         'stop'   { Invoke-WorkersStop }
         'doctor' { Invoke-WorkersDoctor }
-        'workspace' { Invoke-WorkersWorkspace }
+        'workspace' { Invoke-WinsmuxWorkersWorkspaceCommand -CommandRest $Rest }
         'secrets' { Invoke-WorkersSecrets }
         'heartbeat' { Invoke-WorkersHeartbeat }
         'sandbox' { Invoke-WorkersSandbox }

--- a/tests/PublicSurfacePolicy.Tests.ps1
+++ b/tests/PublicSurfacePolicy.Tests.ps1
@@ -199,6 +199,7 @@ Describe 'Public surface policy' {
         $installer | Should -Not -Match "WINSMUX_AGENT_NAME = 'claude'"
         $installerSingleLine | Should -Match '"orchestra".*"vault"'
         $installer | Should -Match 'Test-InstallProfileContent -Profile \$resolvedInstallProfile -Content "orchestration_scripts"'
+        $installer | Should -Match 'Install-CoreSupportScripts'
         $installer | Should -Match 'winsmux-core/scripts/public-first-run\.ps1'
         $installer | Should -Match 'winsmux-core/scripts/control-plane-commands\.ps1'
         $installer | Should -Match 'winsmux-core/scripts/control-plane-dispatch\.ps1'
@@ -216,8 +217,10 @@ Describe 'Public surface policy' {
         $installer | Should -Match 'winsmux-core/scripts/pane-border\.ps1'
         $installer | Should -Match 'winsmux-core/scripts/common-contract\.generated\.ps1'
         $installer | Should -Match '"control-plane-commands\.ps1"'
-        $installer | Should -Match '"control-plane-workers\.ps1"'
         $installer | Should -Match '"common-contract\.generated\.ps1"'
+        $orchestrationRemovalFiles = [regex]::Match($installer, '(?s)Content = "orchestration_scripts".*?Files = @\((?<files>.*?)\)\s*\}')
+        $orchestrationRemovalFiles.Success | Should -BeTrue
+        $orchestrationRemovalFiles.Groups['files'].Value | Should -Not -Match '"control-plane-workers\.ps1"'
     }
 
     It 'keeps public install and OAuth wording aligned with the current policy' {

--- a/tests/PublicSurfacePolicy.Tests.ps1
+++ b/tests/PublicSurfacePolicy.Tests.ps1
@@ -202,6 +202,7 @@ Describe 'Public surface policy' {
         $installer | Should -Match 'winsmux-core/scripts/public-first-run\.ps1'
         $installer | Should -Match 'winsmux-core/scripts/control-plane-commands\.ps1'
         $installer | Should -Match 'winsmux-core/scripts/control-plane-dispatch\.ps1'
+        $installer | Should -Match 'winsmux-core/scripts/control-plane-workers\.ps1'
         $installer | Should -Match 'winsmux-core/scripts/orchestra-smoke\.ps1'
         $installer | Should -Match 'winsmux-core/scripts/doctor\.ps1'
         $installer | Should -Match 'winsmux-core/scripts/orchestra-attach-confirm\.ps1'
@@ -215,6 +216,7 @@ Describe 'Public surface policy' {
         $installer | Should -Match 'winsmux-core/scripts/pane-border\.ps1'
         $installer | Should -Match 'winsmux-core/scripts/common-contract\.generated\.ps1'
         $installer | Should -Match '"control-plane-commands\.ps1"'
+        $installer | Should -Match '"control-plane-workers\.ps1"'
         $installer | Should -Match '"common-contract\.generated\.ps1"'
     }
 

--- a/tests/PublicSurfacePolicy.Tests.ps1
+++ b/tests/PublicSurfacePolicy.Tests.ps1
@@ -204,6 +204,13 @@ Describe 'Public surface policy' {
         $installer | Should -Match 'winsmux-core/scripts/control-plane-commands\.ps1'
         $installer | Should -Match 'winsmux-core/scripts/control-plane-dispatch\.ps1'
         $installer | Should -Match 'winsmux-core/scripts/control-plane-workers\.ps1'
+        $installer | Should -Match 'function Test-RemoteFileExists'
+        $installer | Should -Match 'function Download-OptionalFile'
+        $installer | Should -Match 'Skipping optional \$relativeUrl'
+        $coreSupportFiles = [regex]::Match($installer, '(?s)function Install-CoreSupportScripts \{(?<files>.*?)\n\}')
+        $coreSupportFiles.Success | Should -BeTrue
+        $coreSupportFiles.Groups['files'].Value | Should -Match 'Download-OptionalFile'
+        $coreSupportFiles.Groups['files'].Value | Should -Not -Match 'Download-File "winsmux-core/scripts/control-plane-workers\.ps1"'
         $installer | Should -Match 'winsmux-core/scripts/orchestra-smoke\.ps1'
         $installer | Should -Match 'winsmux-core/scripts/doctor\.ps1'
         $installer | Should -Match 'winsmux-core/scripts/orchestra-attach-confirm\.ps1'

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -9731,7 +9731,7 @@ agent-slots:
         $script:winsmuxWorkersCoreRawContent | Should -Match "'exec'\s*\{\s*Invoke-WorkersExec\s*\}"
         $script:winsmuxWorkersCoreRawContent | Should -Match "'attach'\s*\{\s*Invoke-WorkersAttach\s*\}"
         $script:winsmuxWorkersCoreRawContent | Should -Match "'download'\s*\{\s*Invoke-WorkersDownload\s*\}"
-        $script:winsmuxWorkersCoreRawContent | Should -Match "'workspace'\s*\{\s*Invoke-WorkersWorkspace\s*\}"
+        $script:winsmuxWorkersCoreRawContent | Should -Match "'workspace'\s*\{\s*Invoke-WinsmuxWorkersWorkspaceCommand"
         $script:winsmuxWorkersCoreRawContent | Should -Match "'secrets'\s*\{\s*Invoke-WorkersSecrets\s*\}"
         $script:winsmuxWorkersCoreRawContent | Should -Match "'heartbeat'\s*\{\s*Invoke-WorkersHeartbeat\s*\}"
         $script:winsmuxWorkersCoreRawContent | Should -Match "'sandbox'\s*\{\s*Invoke-WorkersSandbox\s*\}"
@@ -16980,6 +16980,8 @@ Describe 'winsmux control-plane command module' {
         $script:winsmuxCoreCommandRawContent = Get-Content -Path $script:winsmuxCoreCommandRawPath -Raw -Encoding UTF8
         $script:controlPlaneCommandsPath = Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\control-plane-commands.ps1'
         $script:controlPlaneCommandsContent = Get-Content -Path $script:controlPlaneCommandsPath -Raw -Encoding UTF8
+        $script:controlPlaneWorkersPath = Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\control-plane-workers.ps1'
+        $script:controlPlaneWorkersContent = Get-Content -Path $script:controlPlaneWorkersPath -Raw -Encoding UTF8
         . $script:controlPlaneCommandsPath
     }
 
@@ -16989,6 +16991,20 @@ Describe 'winsmux control-plane command module' {
         $script:controlPlaneCommandsContent | Should -Match 'function New-WinsmuxCommandResult'
         $script:controlPlaneCommandsContent | Should -Match 'function New-WinsmuxCommandError'
         $script:controlPlaneCommandsContent | Should -Match 'function Write-WinsmuxCommandResult'
+    }
+
+    It 'keeps workers workspace parsing in the workers command module' {
+        $script:winsmuxCoreCommandRawContent | Should -Match 'control-plane-workers\.ps1'
+        $script:winsmuxCoreCommandRawContent | Should -Match '\. \$ControlPlaneWorkersScript'
+        $script:winsmuxCoreCommandRawContent | Should -Match "'workspace'\s*\{\s*Invoke-WinsmuxWorkersWorkspaceCommand"
+        $script:winsmuxCoreCommandRawContent | Should -Not -Match 'function Read-WorkersWorkspaceOptions\s*\{'
+        $script:winsmuxCoreCommandRawContent | Should -Not -Match 'function Invoke-WorkersWorkspacePrepare\s*\{'
+        $script:winsmuxCoreCommandRawContent | Should -Not -Match 'function Invoke-WorkersWorkspaceCleanup\s*\{'
+        $script:winsmuxCoreCommandRawContent | Should -Not -Match 'function Invoke-WorkersWorkspace\s*\{'
+        $script:controlPlaneWorkersContent | Should -Match 'function Read-WinsmuxWorkersWorkspaceOptions'
+        $script:controlPlaneWorkersContent | Should -Match 'function Invoke-WinsmuxWorkersWorkspacePrepare'
+        $script:controlPlaneWorkersContent | Should -Match 'function Invoke-WinsmuxWorkersWorkspaceCleanup'
+        $script:controlPlaneWorkersContent | Should -Match 'function Invoke-WinsmuxWorkersWorkspaceCommand'
     }
 
     It 'keeps launcher and provider command parsing outside the top-level command table' {

--- a/winsmux-core/scripts/control-plane-workers.ps1
+++ b/winsmux-core/scripts/control-plane-workers.ps1
@@ -1,0 +1,295 @@
+$ErrorActionPreference = 'Stop'
+
+# Workers command module owns workers workspace argument and output handling.
+
+function Read-WinsmuxWorkersWorkspaceOptions {
+    param(
+        [Parameter(Mandatory = $true)][string]$Usage,
+        [AllowNull()][string[]]$CommandRest
+    )
+
+    $projectDir = (Get-Location).Path
+    $asJson = $false
+    $workspaceAction = ''
+    $targetValue = ''
+    $runId = ''
+    $profile = 'isolated-enterprise'
+    $includes = [System.Collections.Generic.List[string]]::new()
+    $items = @($CommandRest)
+
+    if ($items.Count -ge 1) {
+        $workspaceAction = [string]$items[0]
+    }
+    if ($items.Count -ge 2) {
+        $targetValue = [string]$items[1]
+    }
+    if ([string]::IsNullOrWhiteSpace($workspaceAction) -or [string]::IsNullOrWhiteSpace($targetValue)) {
+        Stop-WithError $Usage
+    }
+
+    for ($index = 2; $index -lt $items.Count; $index++) {
+        $token = [string]$items[$index]
+        switch ($token) {
+            '--json' { $asJson = $true }
+            '--project-dir' {
+                if ($index + 1 -ge $items.Count) { Stop-WithError $Usage }
+                $projectDir = [string]$items[$index + 1]
+                $index++
+            }
+            '--run-id' {
+                if ($index + 1 -ge $items.Count) { Stop-WithError $Usage }
+                $runId = [string]$items[$index + 1]
+                $index++
+            }
+            '--profile' {
+                if ($index + 1 -ge $items.Count) { Stop-WithError $Usage }
+                $profile = [string]$items[$index + 1]
+                $index++
+            }
+            '--include' {
+                if ($index + 1 -ge $items.Count) { Stop-WithError $Usage }
+                $includes.Add([string]$items[$index + 1]) | Out-Null
+                $index++
+            }
+            default {
+                Stop-WithError $Usage
+            }
+        }
+    }
+
+    if ($workspaceAction -notin @('prepare', 'cleanup')) {
+        Stop-WithError $Usage
+    }
+    if (Get-Command Test-BridgeExecutionProfileKind -ErrorAction SilentlyContinue) {
+        if (-not (Test-BridgeExecutionProfileKind -Value $profile)) {
+            Stop-WithError "unsupported execution profile for isolated workspace: $profile"
+        }
+    }
+    if (-not [string]::Equals($profile, 'isolated-enterprise', [System.StringComparison]::OrdinalIgnoreCase)) {
+        Stop-WithError 'isolated workspace requires execution profile isolated-enterprise'
+    }
+    if ($workspaceAction -eq 'prepare' -and $includes.Count -lt 1) {
+        Stop-WithError 'isolated workspace prepare requires at least one --include path'
+    }
+    if ($workspaceAction -eq 'cleanup' -and [string]::IsNullOrWhiteSpace($runId)) {
+        Stop-WithError 'isolated workspace cleanup requires --run-id'
+    }
+
+    return [PSCustomObject]@{
+        ProjectDir = $projectDir
+        Json       = $asJson
+        Action     = $workspaceAction
+        Target     = $targetValue
+        RunId      = $runId
+        Profile    = $profile.Trim().ToLowerInvariant()
+        Includes   = @($includes)
+    }
+}
+
+function Invoke-WinsmuxWorkersWorkspacePrepare {
+    param([Parameter(Mandatory = $true)]$Options)
+
+    $slot = Get-WorkersSingleSlotContext -ProjectDir $Options.ProjectDir -Target $Options.Target
+    $slotProfile = [string]$slot.SlotConfig.ExecutionProfile
+    if (-not [string]::Equals($slotProfile, [string]$Options.Profile, [System.StringComparison]::OrdinalIgnoreCase)) {
+        Stop-WithError "worker slot $($slot.Row.SlotId) uses execution profile '$slotProfile', not isolated-enterprise"
+    }
+
+    $runId = Assert-WorkersRunId -RunId ([string]$Options.RunId)
+    if ([string]::IsNullOrWhiteSpace($runId)) {
+        $runId = New-WorkersRunId -SlotId ([string]$slot.Row.SlotId)
+    }
+
+    $runDir = Get-WorkersIsolatedWorkspaceRunDirectory -ProjectDir $Options.ProjectDir -SlotId ([string]$slot.Row.SlotId) -RunId $runId
+    Assert-WorkersIsolatedWorkspaceCleanupTarget -ProjectDir $Options.ProjectDir -RunDir $runDir
+    if (Test-Path -LiteralPath $runDir) {
+        Stop-WithError "isolated workspace run already exists: $runId"
+    }
+
+    $sources = [System.Collections.Generic.List[object]]::new()
+    foreach ($includePath in @($Options.Includes)) {
+        $source = Resolve-WorkersIsolatedProjectionPath -ProjectDir $Options.ProjectDir -Path ([string]$includePath)
+        if ([bool]$source.IsDirectory) {
+            Assert-WorkersDirectoryContainsOnlyIsolatedSafeFiles -ProjectDir $Options.ProjectDir -SourceInfo $source
+        }
+        $sources.Add($source) | Out-Null
+    }
+
+    $workspaceDir = Join-Path $runDir 'workspace'
+    $downloadsDir = Join-Path $runDir 'downloads'
+    $artifactsDir = Join-Path $runDir 'artifacts'
+    New-Item -ItemType Directory -Path $workspaceDir -Force | Out-Null
+    New-Item -ItemType Directory -Path $downloadsDir -Force | Out-Null
+    New-Item -ItemType Directory -Path $artifactsDir -Force | Out-Null
+
+    $projections = [System.Collections.Generic.List[object]]::new()
+    foreach ($source in @($sources)) {
+        $projections.Add((Copy-WorkersIsolatedProjection -ProjectDir $Options.ProjectDir -WorkspaceDir $workspaceDir -SourceInfo $source)) | Out-Null
+    }
+
+    $manifestPath = Join-Path $runDir 'workspace.json'
+    $runReference = Get-WorkersArtifactReference -ProjectDir $Options.ProjectDir -Path $runDir
+    $workspaceReference = Get-WorkersArtifactReference -ProjectDir $Options.ProjectDir -Path $workspaceDir
+    $downloadsReference = Get-WorkersArtifactReference -ProjectDir $Options.ProjectDir -Path $downloadsDir
+    $artifactsReference = Get-WorkersArtifactReference -ProjectDir $Options.ProjectDir -Path $artifactsDir
+    $manifestReference = Get-WorkersArtifactReference -ProjectDir $Options.ProjectDir -Path $manifestPath
+
+    $payload = [ordered]@{
+        version       = 1
+        project_ref   = '.'
+        generated_at  = (Get-Date).ToUniversalTime().ToString('o')
+        command       = 'workers.workspace.prepare'
+        status        = 'prepared'
+        slot          = [string]$slot.Row.Slot
+        slot_id       = [string]$slot.Row.SlotId
+        run_id        = $runId
+        execution_profile = 'isolated-enterprise'
+        workspace_lifecycle = 'disposable'
+        policy        = [ordered]@{
+            direct_project_write = 'prohibited'
+            projection           = 'explicit-includes-only'
+            cleanup              = 'delete-isolated-run-directory'
+            rejects              = @('path_traversal', 'absolute_escape', 'reparse_point', 'windows_reserved_name', 'excluded_or_secret_like_path')
+        }
+        locations     = [ordered]@{
+            project_root = New-WinsmuxLocationIdentity -Kind 'local_directory' -DisplayName 'project root' -Backend 'local-windows' -AccessMethod 'project_root' -Reference '.' -Provenance 'workers.workspace.project_root'
+            run_root     = New-WinsmuxLocationIdentity -Kind 'local_directory' -DisplayName $runReference -Backend 'local-windows' -AccessMethod 'isolated_run_root' -Reference $runReference -Provenance 'workers.workspace.run_root'
+            workspace    = New-WinsmuxLocationIdentity -Kind 'local_directory' -DisplayName $workspaceReference -Backend 'local-windows' -AccessMethod 'isolated_workspace' -Reference $workspaceReference -Provenance 'workers.workspace.workspace'
+            downloads    = New-WinsmuxLocationIdentity -Kind 'local_directory' -DisplayName $downloadsReference -Backend 'local-windows' -AccessMethod 'isolated_downloads' -Reference $downloadsReference -Provenance 'workers.workspace.downloads'
+            artifacts    = New-WinsmuxLocationIdentity -Kind 'local_directory' -DisplayName $artifactsReference -Backend 'local-windows' -AccessMethod 'isolated_artifacts' -Reference $artifactsReference -Provenance 'workers.workspace.artifacts'
+            manifest     = New-WinsmuxLocationIdentity -Kind 'local_file' -DisplayName 'workspace.json' -Backend 'local-windows' -AccessMethod 'artifact_ref' -Reference $manifestReference -Provenance 'workers.workspace.manifest'
+        }
+        projections   = @($projections)
+        exit_code     = 0
+    }
+
+    Write-WorkersJsonArtifact -Path $manifestPath -Data $payload | Out-Null
+    if ($null -ne $slot.Entry) {
+        Set-WorkersManifestLifecycleCommand -Entry $slot.Entry -CommandName 'workers.workspace.prepare' -ExtraProperties ([ordered]@{
+            last_workspace_run_id = $runId
+            last_workspace_profile = 'isolated-enterprise'
+            last_workspace_status = 'prepared'
+            last_workspace_lifecycle = 'disposable'
+            last_workspace_root = $workspaceReference
+            last_workspace_manifest = $manifestReference
+            last_secret_run_id = ''
+            last_secret_profile = ''
+            last_secret_status = ''
+            last_secret_binding = ''
+            last_secret_projection_count = ''
+            last_secret_manifest = ''
+            last_broker_run_id = ''
+            last_broker_profile = ''
+            last_broker_status = ''
+            last_broker_node_id = ''
+            last_broker_endpoint = ''
+            last_broker_manifest = ''
+            last_broker_token_status = ''
+            last_broker_token_health = ''
+            last_broker_token_expires_at = ''
+            last_broker_token_manifest = ''
+            last_policy_run_id = ''
+            last_policy_profile = ''
+            last_policy_status = ''
+            last_policy_health = ''
+            last_policy_reason = ''
+            last_policy_network = ''
+            last_policy_write = ''
+            last_policy_provider = ''
+            last_policy_mandatory_checks = ''
+            last_policy_required_evidence = ''
+            last_policy_manifest = ''
+        })
+    }
+
+    Write-WorkersOperationOutput -Payload $payload -Json:([bool]$Options.Json) -Text "prepared $runId"
+}
+
+function Invoke-WinsmuxWorkersWorkspaceCleanup {
+    param([Parameter(Mandatory = $true)]$Options)
+
+    $slot = Get-WorkersSingleSlotContext -ProjectDir $Options.ProjectDir -Target $Options.Target
+    $runId = Assert-WorkersRunId -RunId ([string]$Options.RunId)
+    $runDir = Get-WorkersIsolatedWorkspaceRunDirectory -ProjectDir $Options.ProjectDir -SlotId ([string]$slot.Row.SlotId) -RunId $runId
+    Assert-WorkersIsolatedWorkspaceCleanupTarget -ProjectDir $Options.ProjectDir -RunDir $runDir
+    $existed = Test-Path -LiteralPath $runDir
+    if ($existed) {
+        Remove-WorkersIsolatedWorkspaceRunDirectory -ProjectDir $Options.ProjectDir -RunDir $runDir
+    }
+
+    $runReference = Get-WorkersArtifactReference -ProjectDir $Options.ProjectDir -Path $runDir
+    $payload = [ordered]@{
+        version       = 1
+        project_ref   = '.'
+        generated_at  = (Get-Date).ToUniversalTime().ToString('o')
+        command       = 'workers.workspace.cleanup'
+        status        = if ($existed) { 'cleaned' } else { 'not_found' }
+        slot          = [string]$slot.Row.Slot
+        slot_id       = [string]$slot.Row.SlotId
+        run_id        = $runId
+        execution_profile = 'isolated-enterprise'
+        workspace_lifecycle = 'disposable'
+        locations     = [ordered]@{
+            run_root = New-WinsmuxLocationIdentity -Kind 'local_directory' -DisplayName $runReference -Backend 'local-windows' -AccessMethod 'isolated_run_root' -Reference $runReference -Provenance 'workers.workspace.cleanup'
+        }
+        existed       = [bool]$existed
+        exit_code     = 0
+    }
+    if ($null -ne $slot.Entry) {
+        $activeWorkspaceRunId = [string](Get-SendConfigValue -InputObject $slot.Entry -Name 'LastWorkspaceRunId' -Default '')
+        $cleanupIsActiveWorkspace = [string]::Equals($activeWorkspaceRunId, $runId, [System.StringComparison]::Ordinal)
+    }
+    if ($null -ne $slot.Entry -and $cleanupIsActiveWorkspace) {
+        Set-WorkersManifestLifecycleCommand -Entry $slot.Entry -CommandName 'workers.workspace.cleanup' -ExtraProperties ([ordered]@{
+            last_workspace_run_id = $runId
+            last_workspace_profile = 'isolated-enterprise'
+            last_workspace_status = [string]$payload['status']
+            last_workspace_lifecycle = 'disposable'
+            last_workspace_root = ''
+            last_workspace_manifest = ''
+            last_secret_run_id = ''
+            last_secret_profile = ''
+            last_secret_status = ''
+            last_secret_binding = ''
+            last_secret_projection_count = ''
+            last_secret_manifest = ''
+            last_broker_run_id = ''
+            last_broker_profile = ''
+            last_broker_status = ''
+            last_broker_node_id = ''
+            last_broker_endpoint = ''
+            last_broker_manifest = ''
+            last_broker_token_status = ''
+            last_broker_token_health = ''
+            last_broker_token_expires_at = ''
+            last_broker_token_manifest = ''
+            last_policy_run_id = ''
+            last_policy_profile = ''
+            last_policy_status = ''
+            last_policy_health = ''
+            last_policy_reason = ''
+            last_policy_network = ''
+            last_policy_write = ''
+            last_policy_provider = ''
+            last_policy_mandatory_checks = ''
+            last_policy_required_evidence = ''
+            last_policy_manifest = ''
+        })
+    } elseif ($null -ne $slot.Entry) {
+        Set-WorkersManifestLifecycleCommand -Entry $slot.Entry -CommandName 'workers.workspace.cleanup'
+    }
+
+    Write-WorkersOperationOutput -Payload $payload -Json:([bool]$Options.Json) -Text "$($payload['status']) $runId"
+}
+
+function Invoke-WinsmuxWorkersWorkspaceCommand {
+    param([AllowNull()][string[]]$CommandRest)
+
+    $usage = "usage: winsmux workers workspace <prepare|cleanup> <slot> [--include <path>] [--run-id <id>] [--profile isolated-enterprise] [--json] [--project-dir <path>]"
+    $options = Read-WinsmuxWorkersWorkspaceOptions -Usage $usage -CommandRest $CommandRest
+    switch ([string]$options.Action) {
+        'prepare' { Invoke-WinsmuxWorkersWorkspacePrepare -Options $options }
+        'cleanup' { Invoke-WinsmuxWorkersWorkspaceCleanup -Options $options }
+        default { Stop-WithError $usage }
+    }
+}


### PR DESCRIPTION
## Summary

- Extract `winsmux workers workspace <prepare|cleanup>` parsing and handling into `winsmux-core/scripts/control-plane-workers.ps1`.
- Keep the root `workers` command table as the compatibility shim, delegating only the `workspace` subcommand to the new module.
- Add installer/public-surface coverage so the new support script is downloaded and retained with orchestration scripts.

## Verification

- `Invoke-Pester -Path tests\winsmux-bridge.Tests.ps1 -FullNameFilter '*winsmux control-plane command module*' -PassThru -Output Detailed`
- `Invoke-Pester -Path tests\winsmux-bridge.Tests.ps1 -FullNameFilter '*winsmux workers command*' -PassThru -Output Detailed`
- `Invoke-Pester -Path tests\PublicSurfacePolicy.Tests.ps1 -FullNameFilter '*installer*' -PassThru -Output Detailed`
- `pwsh -NoProfile -File scripts\winsmux-core.ps1 workers workspace cleanup worker-1 --run-id smoke-missing --json --project-dir .`
- `git diff --check`
- `scripts\audit-public-surface.ps1`
- `scripts\git-guard.ps1 -Mode full`

## Notes

This is a small `TASK-647` follow-up after #1172. `TASK-647` remains in progress; worker/worktree/ledger boundaries still have follow-up work.
