### PR TITLE
feat(core): add process registry and automation driver pool

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,6 +85,10 @@ jobs:
         working-directory: winsmux-app
         run: npm run test:common-contract-package
 
+      - name: Check automation driver pool
+        working-directory: winsmux-app
+        run: npm run test:automation-driver-pool
+
   pester:
     name: Pester Tests (${{ matrix.name }})
     runs-on: windows-latest

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -5916,6 +5916,7 @@ Describe 'orchestra-start watchdog contract' {
 
     It 'persists the supervisor pid and prints cleanup guidance' {
         $script:orchestraStartContent | Should -Match 'supervisor_pid\s*=\s*\$SupervisorPid'
+        $script:orchestraStartContent | Should -Match 'process_registry\s*=\s*\$processRegistry'
         $script:orchestraStartContent | Should -Match 'Supervisor PID: \$\(\$supervisorProcess\.Id\)'
         $script:orchestraStartContent | Should -Match 'Stop-Process -Id \{0\}'
     }
@@ -6121,6 +6122,39 @@ Describe 'orchestra-start server bootstrap' {
         $pane.worktree_git_dir | Should -Be 'C:\repo\.git\worktrees\worker-1'
         $pane.expected_origin | Should -Be 'https://github.com/example/repo.git'
         $pane.supports_context_reset | Should -Be $false
+    }
+
+    It 'persists background process registry entries with owner lease and recovery policy' {
+        $script:savedManifest = $null
+        Mock Save-WinsmuxManifest {
+            param([string]$ProjectDir, $Manifest)
+            $script:savedManifest = $Manifest
+        }
+
+        Save-OrchestraSessionState `
+            -ProjectDir 'C:\repo' `
+            -SessionName 'winsmux-orchestra' `
+            -Settings ([ordered]@{ agent = 'codex'; model = 'gpt-5.4' }) `
+            -GitWorktreeDir 'C:\repo\.git\worktrees' `
+            -PaneSummaries @() `
+            -StartupToken 'token-123' `
+            -SupervisorPid 707 `
+            -IdleThreshold 180 `
+            -MaxRestartAttempts 4 `
+            -RestartWindowMinutes 12 | Out-Null
+
+        $registry = $script:savedManifest.session.process_registry
+        $registry.version | Should -Be 1
+        @($registry.entries).Count | Should -Be 1
+        $entry = @($registry.entries)[0]
+        $entry.label | Should -Be 'supervisor_pid'
+        $entry.pid | Should -Be 707
+        $entry.owner | Should -Be 'orchestra-start'
+        $entry.lease.token | Should -Be 'token-123'
+        $entry.lease.session_name | Should -Be 'winsmux-orchestra'
+        $entry.lease.manifest_path | Should -Be 'C:\repo\.winsmux\manifest.yaml'
+        $entry.idle.timeout_seconds | Should -Be 0
+        $entry.crash_recovery.policy | Should -Be 'fail_closed'
     }
 
     It 'returns success when the server session already exists' {
@@ -7238,6 +7272,81 @@ Describe 'orchestra-start server bootstrap' {
         @($result.Stopped).Count | Should -Be 3
         @($result.Errors).Count | Should -Be 0
         $script:stoppedProcessIds | Should -Be @(101, 202, 303)
+    }
+
+    It 'stops stale background processes recorded in process_registry before legacy pid fields' {
+        Mock Get-WinsmuxManifest {
+            [PSCustomObject]@{
+                session = [PSCustomObject]@{
+                    startup_token = 'token-123'
+                    supervisor_pid = '999'
+                    process_registry = [PSCustomObject]@{
+                        entries = @(
+                            [PSCustomObject]@{
+                                label = 'supervisor_pid'
+                                pid = 707
+                                script = 'orchestra-supervisor.ps1'
+                            }
+                        )
+                    }
+                }
+            }
+        }
+
+        $script:stoppedProcessIds = @()
+        Mock Get-ProcessSnapshot {
+            [PSCustomObject]@{
+                ById = @{
+                    707 = [PSCustomObject]@{ ProcessId = 707; ParentProcessId = 1; CommandLine = 'pwsh -NoProfile -File orchestra-supervisor.ps1 -ManifestPath C:\repo\.winsmux\manifest.yaml -SessionName winsmux-orchestra -StartupToken token-123'; Name = 'pwsh.exe' }
+                    999 = [PSCustomObject]@{ ProcessId = 999; ParentProcessId = 1; CommandLine = 'pwsh -NoProfile -File old-supervisor.ps1 -ManifestPath C:\repo\.winsmux\manifest.yaml -SessionName winsmux-orchestra -StartupToken token-123'; Name = 'pwsh.exe' }
+                }
+            }
+        }
+        Mock Stop-Process { $script:stoppedProcessIds += $Id }
+
+        $result = Stop-OrchestraBackgroundProcessesFromManifest -ProjectDir 'C:\repo' -GitWorktreeDir 'C:\repo\.git' -BridgeScript 'C:\repo\scripts\winsmux-core.ps1' -SessionName 'winsmux-orchestra'
+
+        @($result.Stopped).Count | Should -Be 1
+        $result.Stopped[0].label | Should -Be 'supervisor_pid'
+        $result.Stopped[0].pid | Should -Be 707
+        @($result.Errors).Count | Should -Be 1
+        $result.Errors[0] | Should -Match '999'
+        $script:stoppedProcessIds | Should -Be @(707)
+    }
+
+    It 'stops process_registry entries after a manifest save and read round trip' {
+        $testProjectDir = Join-Path $TestDrive 'process-registry-roundtrip'
+        New-Item -ItemType Directory -Path $testProjectDir -Force | Out-Null
+
+        Save-OrchestraSessionState `
+            -ProjectDir $testProjectDir `
+            -SessionName 'winsmux-orchestra' `
+            -Settings ([ordered]@{ agent = 'codex'; model = 'gpt-5.4' }) `
+            -GitWorktreeDir (Join-Path $testProjectDir '.git\worktrees') `
+            -PaneSummaries @() `
+            -StartupToken 'token-123' `
+            -SupervisorPid 707 `
+            -IdleThreshold 180 | Out-Null
+
+        $manifestPath = Join-Path $testProjectDir '.winsmux\manifest.yaml'
+        (Get-Content -LiteralPath $manifestPath -Raw -Encoding UTF8) | Should -Match 'process_registry:'
+
+        $script:stoppedProcessIds = @()
+        Mock Get-ProcessSnapshot {
+            [PSCustomObject]@{
+                ById = @{
+                    707 = [PSCustomObject]@{ ProcessId = 707; ParentProcessId = 1; CommandLine = "pwsh -NoProfile -File orchestra-supervisor.ps1 -ManifestPath $manifestPath -SessionName winsmux-orchestra -StartupToken token-123"; Name = 'pwsh.exe' }
+                }
+            }
+        }
+        Mock Stop-Process { $script:stoppedProcessIds += $Id }
+
+        $result = Stop-OrchestraBackgroundProcessesFromManifest -ProjectDir $testProjectDir -GitWorktreeDir (Join-Path $testProjectDir '.git') -BridgeScript (Join-Path $testProjectDir 'scripts\winsmux-core.ps1') -SessionName 'winsmux-orchestra'
+
+        @($result.Stopped).Count | Should -Be 1
+        $result.Stopped[0].pid | Should -Be 707
+        @($result.Errors).Count | Should -Be 0
+        $script:stoppedProcessIds | Should -Be @(707)
     }
 
     It 'treats legacy commander_poll_pid as the operator poll process during manifest cleanup' {

--- a/winsmux-app/package.json
+++ b/winsmux-app/package.json
@@ -18,6 +18,7 @@
     "test:desktop-status-e2e": "node ./scripts/desktop-pane-e2e.mjs --stop-after-worker-status",
     "test:desktop-split-static": "pwsh -NoProfile -File ../scripts/test-v03626-desktop-split-gate.ps1 -Json",
     "test:desktop-split-gate": "pwsh -NoProfile -File ../scripts/test-v03626-desktop-split-gate.ps1 -Json -RequireEvidence",
+    "test:automation-driver-pool": "node ./scripts/automation-driver-pool-check.mjs",
     "test:desktop-summary-scheduler": "node --experimental-strip-types ./scripts/desktop-summary-scheduler-check.mjs",
     "test:editor-targets": "node ./scripts/editor-targets-check.mjs",
     "test:project-explorer-tree": "node ./scripts/project-explorer-tree-check.mjs",

--- a/winsmux-app/scripts/automation-driver-pool-check.mjs
+++ b/winsmux-app/scripts/automation-driver-pool-check.mjs
@@ -1,0 +1,229 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  acquireAutomationDriverLease,
+  getAutomationDriverKey,
+  heartbeatAutomationDriverLease,
+  releaseAutomationDriverLease,
+  tryHeartbeatAutomationDriverLease,
+} from "./automation-driver-pool.mjs";
+
+function createPoolPath(name) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), `winsmux-driver-pool-${name}-`));
+  return {
+    root,
+    poolPath: path.join(root, "automation-driver-pool.json"),
+    cleanup: () => fs.rmSync(root, { recursive: true, force: true }),
+  };
+}
+
+function readPool(poolPath) {
+  return JSON.parse(fs.readFileSync(poolPath, "utf8"));
+}
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+
+{
+  const { poolPath, cleanup } = createPoolPath("reuse");
+  const livePids = new Set([100]);
+  try {
+    const first = acquireAutomationDriverLease({
+      poolPath,
+      target: "http://127.0.0.1:5173/",
+      pid: 100,
+      nowMs: Date.UTC(2026, 6, 8, 0, 0, 0),
+      isProcessAlive: (pid) => livePids.has(pid),
+    });
+    assert.equal(first.acquired, true);
+
+    const second = acquireAutomationDriverLease({
+      poolPath,
+      target: "http://127.0.0.1:5173/",
+      pid: 200,
+      nowMs: Date.UTC(2026, 6, 8, 0, 0, 1),
+      isProcessAlive: (pid) => livePids.has(pid),
+    });
+    assert.equal(second.acquired, false);
+    assert.equal(second.reason, "active_lease");
+    assert.equal(second.lease.owner_pid, 100);
+    assert.equal(readPool(poolPath).leases.length, 1);
+  } finally {
+    cleanup();
+  }
+}
+
+{
+  const { poolPath, cleanup } = createPoolPath("stale");
+  const livePids = new Set([100]);
+  try {
+    acquireAutomationDriverLease({
+      poolPath,
+      target: "http://127.0.0.1:5173/",
+      pid: 100,
+      nowMs: Date.UTC(2026, 6, 8, 0, 0, 0),
+      isProcessAlive: (pid) => livePids.has(pid),
+    });
+    livePids.delete(100);
+    livePids.add(200);
+
+    const replacement = acquireAutomationDriverLease({
+      poolPath,
+      target: "http://127.0.0.1:5173/",
+      pid: 200,
+      nowMs: Date.UTC(2026, 6, 8, 0, 0, 2),
+      isProcessAlive: (pid) => livePids.has(pid),
+    });
+    assert.equal(replacement.acquired, true);
+    assert.equal(readPool(poolPath).leases.length, 1);
+    assert.equal(readPool(poolPath).leases[0].owner_pid, 200);
+  } finally {
+    cleanup();
+  }
+}
+
+{
+  const { poolPath, cleanup } = createPoolPath("limit");
+  const livePids = new Set([100]);
+  try {
+    acquireAutomationDriverLease({
+      poolPath,
+      target: "http://127.0.0.1:5173/",
+      pid: 100,
+      nowMs: Date.UTC(2026, 6, 8, 0, 0, 0),
+      maxActiveLeases: 1,
+      isProcessAlive: (pid) => livePids.has(pid),
+    });
+    const blocked = acquireAutomationDriverLease({
+      poolPath,
+      target: "http://127.0.0.1:8766/",
+      pid: 200,
+      nowMs: Date.UTC(2026, 6, 8, 0, 0, 1),
+      maxActiveLeases: 1,
+      isProcessAlive: (pid) => livePids.has(pid),
+    });
+    assert.equal(blocked.acquired, false);
+    assert.equal(blocked.reason, "pool_full");
+    assert.equal(readPool(poolPath).leases.length, 1);
+  } finally {
+    cleanup();
+  }
+}
+
+{
+  const { poolPath, cleanup } = createPoolPath("heartbeat-release");
+  const livePids = new Set([100]);
+  try {
+    const acquired = acquireAutomationDriverLease({
+      poolPath,
+      target: "http://127.0.0.1:5173/",
+      pid: 100,
+      idleTimeoutMs: 1_000,
+      nowMs: Date.UTC(2026, 6, 8, 0, 0, 0),
+      isProcessAlive: (pid) => livePids.has(pid),
+    });
+    assert.equal(acquired.acquired, true);
+    assert.equal(heartbeatAutomationDriverLease({
+      poolPath,
+      leaseId: acquired.lease.lease_id,
+      nowMs: Date.UTC(2026, 6, 8, 0, 0, 5),
+      idleTimeoutMs: 2_000,
+    }), true);
+    const afterHeartbeat = readPool(poolPath).leases[0];
+    assert.equal(afterHeartbeat.heartbeat_at, "2026-07-08T00:00:05.000Z");
+    assert.equal(afterHeartbeat.expires_at, "2026-07-08T00:00:07.000Z");
+
+    assert.equal(releaseAutomationDriverLease({ poolPath, leaseId: acquired.lease.lease_id }), true);
+    assert.equal(readPool(poolPath).leases.length, 0);
+  } finally {
+    cleanup();
+  }
+}
+
+{
+  const { poolPath, cleanup } = createPoolPath("heartbeat-lock");
+  const livePids = new Set([100]);
+  try {
+    const acquired = acquireAutomationDriverLease({
+      poolPath,
+      target: "http://127.0.0.1:5173/",
+      pid: 100,
+      idleTimeoutMs: 1_000,
+      nowMs: Date.now(),
+      isProcessAlive: (pid) => livePids.has(pid),
+    });
+    assert.equal(acquired.acquired, true);
+
+    const lockPath = `${poolPath}.lock`;
+    fs.writeFileSync(lockPath, JSON.stringify({ owner_pid: 999, acquired_at: new Date().toISOString() }), "utf8");
+    let reportedError = null;
+    const result = tryHeartbeatAutomationDriverLease({
+      poolPath,
+      leaseId: acquired.lease.lease_id,
+      idleTimeoutMs: 2_000,
+    }, {
+      onError: (error) => {
+        reportedError = error;
+      },
+    });
+
+    assert.equal(result.heartbeat, false);
+    assert.match(reportedError.message, /automation driver pool lock/);
+    fs.rmSync(lockPath, { force: true });
+  } finally {
+    cleanup();
+  }
+}
+
+{
+  const { poolPath, cleanup } = createPoolPath("probe-active");
+  const target = "http://127.0.0.1:65535/";
+  try {
+    const nowMs = Date.now();
+    fs.writeFileSync(poolPath, `${JSON.stringify({
+      version: 1,
+      leases: [{
+        lease_id: "active-probe-lease",
+        driver_key: getAutomationDriverKey({ target, headless: true }),
+        owner: "test-owner",
+        owner_pid: process.pid,
+        target,
+        headless: true,
+        status: "leased",
+        acquired_at: new Date(nowMs).toISOString(),
+        heartbeat_at: new Date(nowMs).toISOString(),
+        expires_at: new Date(nowMs + 60_000).toISOString(),
+        idle_timeout_ms: 60_000,
+        crash_recovery: "reclaim_when_owner_pid_exits",
+      }],
+    }, null, 2)}\n`, "utf8");
+
+    assert.throws(() => execFileSync(process.execPath, [
+      path.join(scriptDir, "open-dev-browser.mjs"),
+      "--probe",
+      "--no-server",
+      "--headless",
+      `--url=${target}`,
+      `--driver-pool=${poolPath}`,
+    ], {
+      cwd: path.dirname(scriptDir),
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    }), (error) => {
+      assert.equal(error.status, 1);
+      const payload = JSON.parse(error.stdout);
+      assert.equal(payload.reason, "active_lease_probe_requires_metrics");
+      assert.equal(payload.reusedExistingDriver, false);
+      assert.equal(payload.blocked, true);
+      assert.equal(payload.metrics, undefined);
+      return true;
+    });
+  } finally {
+    cleanup();
+  }
+}
+
+console.log("[automation-driver-pool-check] passed");

--- a/winsmux-app/scripts/automation-driver-pool.mjs
+++ b/winsmux-app/scripts/automation-driver-pool.mjs
@@ -1,0 +1,225 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+export const DEFAULT_DRIVER_IDLE_TIMEOUT_MS = 15 * 60 * 1000;
+const POOL_FILENAME = "automation-driver-pool.json";
+const LOCK_STALE_MS = 10_000;
+const LOCK_WAIT_MS = 2_000;
+
+export function getDefaultAutomationDriverPoolPath(cwd = process.cwd()) {
+  return path.join(cwd, "output", POOL_FILENAME);
+}
+
+export function getAutomationDriverKey({ target, headless = false }) {
+  return crypto.createHash("sha256").update(`${target}\0${headless ? "headless" : "headed"}`).digest("hex").slice(0, 16);
+}
+
+export function defaultIsProcessAlive(pid) {
+  if (!Number.isInteger(pid) || pid < 1) {
+    return false;
+  }
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error?.code === "EPERM";
+  }
+}
+
+function readPoolState(poolPath) {
+  try {
+    const raw = fs.readFileSync(poolPath, "utf8");
+    const parsed = JSON.parse(raw);
+    return {
+      version: 1,
+      leases: Array.isArray(parsed?.leases) ? parsed.leases : [],
+    };
+  } catch (error) {
+    if (error?.code === "ENOENT") {
+      return { version: 1, leases: [] };
+    }
+    throw error;
+  }
+}
+
+function writePoolState(poolPath, state) {
+  fs.mkdirSync(path.dirname(poolPath), { recursive: true });
+  const tempPath = `${poolPath}.${process.pid}.tmp`;
+  fs.writeFileSync(tempPath, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+  fs.renameSync(tempPath, poolPath);
+}
+
+function sleepSync(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+function withPoolLock(poolPath, callback, nowMs = Date.now()) {
+  fs.mkdirSync(path.dirname(poolPath), { recursive: true });
+  const lockPath = `${poolPath}.lock`;
+  const deadline = Date.now() + LOCK_WAIT_MS;
+  while (true) {
+    let fd = null;
+    try {
+      fd = fs.openSync(lockPath, "wx");
+      fs.writeFileSync(fd, JSON.stringify({ owner_pid: process.pid, acquired_at: new Date(nowMs).toISOString() }));
+      return callback();
+    } catch (error) {
+      if (error?.code !== "EEXIST") {
+        throw error;
+      }
+      try {
+        const lockStat = fs.statSync(lockPath);
+        if (Date.now() - lockStat.mtimeMs > LOCK_STALE_MS) {
+          fs.unlinkSync(lockPath);
+          continue;
+        }
+      } catch (statError) {
+        if (statError?.code !== "ENOENT") {
+          throw statError;
+        }
+        continue;
+      }
+      if (Date.now() >= deadline) {
+        throw new Error(`Timed out waiting for automation driver pool lock: ${lockPath}`);
+      }
+      sleepSync(50);
+    } finally {
+      if (fd !== null) {
+        fs.closeSync(fd);
+        fs.rmSync(lockPath, { force: true });
+      }
+    }
+  }
+}
+
+function normalizeIdleTimeoutMs(value) {
+  const parsed = Number.parseInt(`${value ?? ""}`, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_DRIVER_IDLE_TIMEOUT_MS;
+}
+
+function pruneActiveLeases(leases, { nowMs, isProcessAlive }) {
+  return leases.filter((lease) => {
+    const expiresAt = Date.parse(`${lease.expires_at ?? ""}`);
+    const ownerPid = Number.parseInt(`${lease.owner_pid ?? ""}`, 10);
+    return Number.isFinite(expiresAt) && expiresAt > nowMs && isProcessAlive(ownerPid);
+  });
+}
+
+export function acquireAutomationDriverLease({
+  poolPath = getDefaultAutomationDriverPoolPath(),
+  owner = "open-dev-browser",
+  target,
+  headless = false,
+  pid = process.pid,
+  idleTimeoutMs = DEFAULT_DRIVER_IDLE_TIMEOUT_MS,
+  maxActiveLeases = 4,
+  nowMs = Date.now(),
+  isProcessAlive = defaultIsProcessAlive,
+} = {}) {
+  if (!target) {
+    throw new Error("target is required to acquire an automation driver lease");
+  }
+
+  const normalizedIdleTimeoutMs = normalizeIdleTimeoutMs(idleTimeoutMs);
+  const driverKey = getAutomationDriverKey({ target, headless });
+  return withPoolLock(poolPath, () => {
+    const state = readPoolState(poolPath);
+    const activeLeases = pruneActiveLeases(state.leases, { nowMs, isProcessAlive });
+    const existing = activeLeases.find((lease) => lease.driver_key === driverKey);
+    if (existing) {
+      const nextState = { version: 1, leases: activeLeases };
+      writePoolState(poolPath, nextState);
+      return { acquired: false, reason: "active_lease", lease: existing, state: nextState };
+    }
+
+    if (activeLeases.length >= maxActiveLeases) {
+      const nextState = { version: 1, leases: activeLeases };
+      writePoolState(poolPath, nextState);
+      return { acquired: false, reason: "pool_full", lease: null, state: nextState };
+    }
+
+    const nowIso = new Date(nowMs).toISOString();
+    const lease = {
+      lease_id: `${driverKey}-${pid}-${nowMs}`,
+      driver_key: driverKey,
+      owner,
+      owner_pid: pid,
+      target,
+      headless,
+      status: "leased",
+      acquired_at: nowIso,
+      heartbeat_at: nowIso,
+      expires_at: new Date(nowMs + normalizedIdleTimeoutMs).toISOString(),
+      idle_timeout_ms: normalizedIdleTimeoutMs,
+      crash_recovery: "reclaim_when_owner_pid_exits",
+    };
+    const nextState = { version: 1, leases: [...activeLeases, lease] };
+    writePoolState(poolPath, nextState);
+    return { acquired: true, reason: "acquired", lease, state: nextState };
+  }, nowMs);
+}
+
+export function heartbeatAutomationDriverLease({
+  poolPath = getDefaultAutomationDriverPoolPath(),
+  leaseId,
+  nowMs = Date.now(),
+  idleTimeoutMs,
+} = {}) {
+  if (!leaseId) {
+    return false;
+  }
+  return withPoolLock(poolPath, () => {
+    const state = readPoolState(poolPath);
+    let updated = false;
+    const nextLeases = state.leases.map((lease) => {
+      if (lease.lease_id !== leaseId) {
+        return lease;
+      }
+      updated = true;
+      const timeoutMs = normalizeIdleTimeoutMs(idleTimeoutMs ?? lease.idle_timeout_ms);
+      return {
+        ...lease,
+        heartbeat_at: new Date(nowMs).toISOString(),
+        expires_at: new Date(nowMs + timeoutMs).toISOString(),
+        idle_timeout_ms: timeoutMs,
+      };
+    });
+    if (updated) {
+      writePoolState(poolPath, { version: 1, leases: nextLeases });
+    }
+    return updated;
+  }, nowMs);
+}
+
+export function tryHeartbeatAutomationDriverLease(options = {}, { onError = null } = {}) {
+  try {
+    return {
+      heartbeat: heartbeatAutomationDriverLease(options),
+      error: null,
+    };
+  } catch (error) {
+    if (typeof onError === "function") {
+      onError(error);
+    }
+    return {
+      heartbeat: false,
+      error,
+    };
+  }
+}
+
+export function releaseAutomationDriverLease({ poolPath = getDefaultAutomationDriverPoolPath(), leaseId } = {}) {
+  if (!leaseId) {
+    return false;
+  }
+  return withPoolLock(poolPath, () => {
+    const state = readPoolState(poolPath);
+    const nextLeases = state.leases.filter((lease) => lease.lease_id !== leaseId);
+    const released = nextLeases.length !== state.leases.length;
+    if (released) {
+      writePoolState(poolPath, { version: 1, leases: nextLeases });
+    }
+    return released;
+  });
+}

--- a/winsmux-app/scripts/open-dev-browser.mjs
+++ b/winsmux-app/scripts/open-dev-browser.mjs
@@ -1,5 +1,12 @@
 import { chromium } from "playwright";
 import { spawn } from "node:child_process";
+import {
+  DEFAULT_DRIVER_IDLE_TIMEOUT_MS,
+  acquireAutomationDriverLease,
+  getDefaultAutomationDriverPoolPath,
+  releaseAutomationDriverLease,
+  tryHeartbeatAutomationDriverLease,
+} from "./automation-driver-pool.mjs";
 
 const DEFAULT_URL = "http://127.0.0.1:5173/";
 const DEFAULT_WINDOW_WIDTH = 2048;
@@ -51,6 +58,15 @@ const height = parsePositiveInteger(
 const headless = hasFlag("headless") || process.env.WINSMUX_DEV_BROWSER_HEADLESS === "1";
 const closeAfterProbe = hasFlag("probe");
 const skipServer = hasFlag("no-server") || process.env.WINSMUX_DEV_BROWSER_NO_SERVER === "1";
+const driverPoolPath = readOption("driver-pool") || process.env.WINSMUX_AUTOMATION_DRIVER_POOL_PATH || getDefaultAutomationDriverPoolPath();
+const driverIdleTimeoutMs = parsePositiveInteger(
+  readOption("driver-idle-timeout-ms") || process.env.WINSMUX_AUTOMATION_DRIVER_IDLE_TIMEOUT_MS,
+  DEFAULT_DRIVER_IDLE_TIMEOUT_MS,
+);
+const driverMaxActiveLeases = parsePositiveInteger(
+  readOption("driver-max-active") || process.env.WINSMUX_AUTOMATION_DRIVER_MAX_ACTIVE,
+  4,
+);
 
 async function canReachDevServer(targetUrl) {
   try {
@@ -130,23 +146,73 @@ async function stopDevServer(child) {
   ]);
 }
 
+let driverLease = null;
+let driverLeaseHeartbeat = null;
+let driverLeaseHeartbeatWarningLogged = false;
 let devServer = null;
-if (!(await canReachDevServer(url))) {
-  devServer = startDevServerIfNeeded(url);
-  if (!devServer) {
-    throw new Error(`Dev server is not reachable at ${url}`);
-  }
-  try {
-    await waitForDevServer(url, devServer);
-  } catch (err) {
-    await stopDevServer(devServer);
-    throw err;
-  }
-}
-
 let browser = null;
 
-try {
+main: try {
+  const leaseResult = acquireAutomationDriverLease({
+    poolPath: driverPoolPath,
+    owner: "open-dev-browser",
+    target: url,
+    headless,
+    idleTimeoutMs: driverIdleTimeoutMs,
+    maxActiveLeases: driverMaxActiveLeases,
+  });
+  if (!leaseResult.acquired) {
+    const reason = closeAfterProbe && leaseResult.reason === "active_lease"
+      ? "active_lease_probe_requires_metrics"
+      : leaseResult.reason;
+    console.log(JSON.stringify({
+      url,
+      headless,
+      driverPoolPath,
+      reusedExistingDriver: reason === "active_lease",
+      blocked: reason === "pool_full" || reason === "active_lease_probe_requires_metrics",
+      reason,
+      lease: leaseResult.lease,
+    }, null, 2));
+    process.exitCode = reason === "active_lease" ? 0 : 1;
+    break main;
+  }
+  driverLease = leaseResult.lease;
+  driverLeaseHeartbeat = setInterval(() => {
+    tryHeartbeatAutomationDriverLease({
+      poolPath: driverPoolPath,
+      leaseId: driverLease?.lease_id,
+      idleTimeoutMs: driverIdleTimeoutMs,
+    }, {
+      onError: (error) => {
+        if (driverLeaseHeartbeatWarningLogged) {
+          return;
+        }
+        driverLeaseHeartbeatWarningLogged = true;
+        console.warn(JSON.stringify({
+          event: "automation_driver_heartbeat_failed",
+          driverPoolPath,
+          leaseId: driverLease?.lease_id ?? null,
+          error: error?.message ?? String(error),
+        }));
+      },
+    });
+  }, Math.min(60_000, Math.max(5_000, Math.floor(driverIdleTimeoutMs / 3))));
+  driverLeaseHeartbeat.unref?.();
+
+  if (!(await canReachDevServer(url))) {
+    devServer = startDevServerIfNeeded(url);
+    if (!devServer) {
+      throw new Error(`Dev server is not reachable at ${url}`);
+    }
+    try {
+      await waitForDevServer(url, devServer);
+    } catch (err) {
+      await stopDevServer(devServer);
+      throw err;
+    }
+  }
+
   browser = await chromium.launch({
     headless,
     args: headless ? [] : [`--window-size=${width},${height}`],
@@ -170,7 +236,16 @@ try {
     };
   });
 
-  console.log(JSON.stringify({ url, headless, startedServer: Boolean(devServer), width, height, metrics }, null, 2));
+  console.log(JSON.stringify({
+    url,
+    headless,
+    startedServer: Boolean(devServer),
+    width,
+    height,
+    driverPoolPath,
+    driverLease,
+    metrics,
+  }, null, 2));
 
   if (closeAfterProbe) {
     await browser.close();
@@ -178,8 +253,12 @@ try {
     await new Promise((resolve) => browser.on("disconnected", resolve));
   }
 } finally {
+  if (driverLeaseHeartbeat) {
+    clearInterval(driverLeaseHeartbeat);
+  }
   if (browser) {
     await browser.close().catch(() => {});
   }
   await stopDevServer(devServer);
+  releaseAutomationDriverLease({ poolPath: driverPoolPath, leaseId: driverLease?.lease_id });
 }

--- a/winsmux-core/scripts/orchestra-start.ps1
+++ b/winsmux-core/scripts/orchestra-start.ps1
@@ -896,6 +896,27 @@ function Get-OrchestraObjectPropertyValue {
     return $Default
 }
 
+function ConvertFrom-OrchestraProcessRegistryValue {
+    param([AllowNull()]$Value)
+
+    if ($null -eq $Value) {
+        return $null
+    }
+
+    if ($Value -is [string]) {
+        $text = $Value.Trim()
+        if ([string]::IsNullOrWhiteSpace($text)) {
+            return $null
+        }
+
+        if ($text.StartsWith('{') -or $text.StartsWith('[')) {
+            return ($text | ConvertFrom-Json)
+        }
+    }
+
+    return $Value
+}
+
 function Test-OrchestraProviderInterruptAvailable {
     param([AllowNull()]$SlotAgentConfig)
 
@@ -1253,6 +1274,87 @@ function Get-OrchestraManifestPath {
     return (Join-Path (Join-Path $ProjectDir '.winsmux') 'manifest.yaml')
 }
 
+function New-OrchestraProcessRegistryEntry {
+    param(
+        [Parameter(Mandatory = $true)][string]$Label,
+        [Parameter(Mandatory = $true)][string]$Name,
+        [Parameter(Mandatory = $true)][AllowEmptyString()][string]$ScriptName,
+        [Parameter(Mandatory = $true)][AllowEmptyString()][string]$Owner,
+        [Parameter(Mandatory = $true)][AllowEmptyString()][string]$SessionName,
+        [Parameter(Mandatory = $true)][AllowEmptyString()][string]$StartupToken,
+        [Parameter(Mandatory = $true)][AllowEmptyString()][string]$ManifestPath,
+        [Parameter(Mandatory = $true)][AllowEmptyString()][string]$StartedAt,
+        [Nullable[int]]$ProcessId = $null,
+        [int]$IdleTimeoutSeconds = 0,
+        [ValidateSet('none', 'stop_after_idle')][string]$IdlePolicy = 'none',
+        [ValidateSet('none', 'restart', 'fail_closed')][string]$CrashRecoveryPolicy = 'none',
+        [int]$MaxRestartAttempts = 0,
+        [int]$RestartWindowMinutes = 0
+    )
+
+    if ($null -eq $ProcessId -or [int]$ProcessId -lt 1) {
+        return $null
+    }
+
+    return [PSCustomObject][ordered]@{
+        label          = $Label
+        name           = $Name
+        kind           = 'background_process'
+        pid            = [int]$ProcessId
+        owner          = $Owner
+        script         = $ScriptName
+        status         = 'running'
+        lease          = [PSCustomObject][ordered]@{
+            token         = $StartupToken
+            session_name  = $SessionName
+            manifest_path = $ManifestPath
+            acquired_at   = $StartedAt
+        }
+        idle           = [PSCustomObject][ordered]@{
+            timeout_seconds = $IdleTimeoutSeconds
+            policy          = $IdlePolicy
+        }
+        crash_recovery = [PSCustomObject][ordered]@{
+            policy         = $CrashRecoveryPolicy
+            max_attempts   = $MaxRestartAttempts
+            window_minutes = $RestartWindowMinutes
+        }
+    }
+}
+
+function New-OrchestraProcessRegistry {
+    param(
+        [Parameter(Mandatory = $true)][string]$SessionName,
+        [Parameter(Mandatory = $true)][AllowEmptyString()][string]$StartupToken,
+        [Parameter(Mandatory = $true)][string]$ManifestPath,
+        [Parameter(Mandatory = $true)][string]$SavedAt,
+        [Nullable[int]]$OperatorPollPid = $null,
+        [Nullable[int]]$WatchdogPid = $null,
+        [Nullable[int]]$ServerWatchdogPid = $null,
+        [Nullable[int]]$SupervisorPid = $null,
+        [int]$IdleThreshold = 120,
+        [int]$MaxRestartAttempts = 3,
+        [int]$RestartWindowMinutes = 10
+    )
+
+    $entries = [System.Collections.Generic.List[object]]::new()
+    foreach ($entry in @(
+            (New-OrchestraProcessRegistryEntry -Label 'operator_poll_pid' -Name 'operator-poll' -ScriptName 'operator-poll.ps1' -Owner 'orchestra-supervisor' -SessionName $SessionName -StartupToken $StartupToken -ManifestPath $ManifestPath -StartedAt $SavedAt -ProcessId $OperatorPollPid -IdleTimeoutSeconds $IdleThreshold -IdlePolicy 'none' -CrashRecoveryPolicy 'restart' -MaxRestartAttempts $MaxRestartAttempts -RestartWindowMinutes $RestartWindowMinutes),
+            (New-OrchestraProcessRegistryEntry -Label 'watchdog_pid' -Name 'agent-watchdog' -ScriptName 'agent-watchdog.ps1' -Owner 'orchestra-supervisor' -SessionName $SessionName -StartupToken $StartupToken -ManifestPath $ManifestPath -StartedAt $SavedAt -ProcessId $WatchdogPid -IdleTimeoutSeconds $IdleThreshold -IdlePolicy 'none' -CrashRecoveryPolicy 'restart' -MaxRestartAttempts $MaxRestartAttempts -RestartWindowMinutes $RestartWindowMinutes),
+            (New-OrchestraProcessRegistryEntry -Label 'server_watchdog_pid' -Name 'server-watchdog' -ScriptName 'server-watchdog.ps1' -Owner 'orchestra-supervisor' -SessionName $SessionName -StartupToken $StartupToken -ManifestPath $ManifestPath -StartedAt $SavedAt -ProcessId $ServerWatchdogPid -IdleTimeoutSeconds 0 -IdlePolicy 'none' -CrashRecoveryPolicy 'restart' -MaxRestartAttempts $MaxRestartAttempts -RestartWindowMinutes $RestartWindowMinutes),
+            (New-OrchestraProcessRegistryEntry -Label 'supervisor_pid' -Name 'orchestra-supervisor' -ScriptName 'orchestra-supervisor.ps1' -Owner 'orchestra-start' -SessionName $SessionName -StartupToken $StartupToken -ManifestPath $ManifestPath -StartedAt $SavedAt -ProcessId $SupervisorPid -IdleTimeoutSeconds 0 -IdlePolicy 'none' -CrashRecoveryPolicy 'fail_closed' -MaxRestartAttempts 0 -RestartWindowMinutes 0)
+        )) {
+        if ($null -ne $entry) {
+            $entries.Add($entry) | Out-Null
+        }
+    }
+
+    return [PSCustomObject][ordered]@{
+        version = 1
+        entries = @($entries)
+    }
+}
+
 function Save-OrchestraSessionState {
     param(
         [Parameter(Mandatory = $true)][string]$ProjectDir,
@@ -1274,10 +1376,15 @@ function Save-OrchestraSessionState {
         [AllowEmptyString()][string]$UiAttachSource = 'none',
         [AllowEmptyString()][string]$UiHostKind = '',
         [AllowEmptyString()][string]$AttachRequestId = '',
-        [AllowEmptyCollection()]$AttachAdapterTrace = @()
+        [AllowEmptyCollection()]$AttachAdapterTrace = @(),
+        [int]$IdleThreshold = 120,
+        [int]$MaxRestartAttempts = 3,
+        [int]$RestartWindowMinutes = 10
     )
 
     $manifestPath = Get-OrchestraManifestPath -ProjectDir $ProjectDir
+    $savedAt = Get-Date -Format o
+    $processRegistry = New-OrchestraProcessRegistry -SessionName $SessionName -StartupToken $StartupToken -ManifestPath $manifestPath -SavedAt $savedAt -OperatorPollPid $OperatorPollPid -WatchdogPid $WatchdogPid -ServerWatchdogPid $ServerWatchdogPid -SupervisorPid $SupervisorPid -IdleThreshold $IdleThreshold -MaxRestartAttempts $MaxRestartAttempts -RestartWindowMinutes $RestartWindowMinutes
     $paneMap = [ordered]@{}
     foreach ($paneSummary in @($PaneSummaries)) {
         $paneEntry = [PSCustomObject]@{
@@ -1318,7 +1425,7 @@ function Save-OrchestraSessionState {
 
     $manifest = [PSCustomObject]@{
         version  = 1
-        saved_at = (Get-Date -Format o)
+        saved_at = $savedAt
         session  = [PSCustomObject]@{
             name                = $SessionName
             status              = 'running'
@@ -1331,6 +1438,7 @@ function Save-OrchestraSessionState {
             watchdog_pid        = $WatchdogPid
             server_watchdog_pid = $ServerWatchdogPid
             supervisor_pid      = $SupervisorPid
+            process_registry    = $processRegistry
             bootstrap_mode      = $BootstrapMode
             session_ready       = $SessionReady
             ui_attach_launched  = $UiAttachLaunched
@@ -1391,32 +1499,56 @@ function Stop-OrchestraBackgroundProcessesFromManifest {
     }
 
     $pidMap = [ordered]@{}
-    foreach ($propertyName in @('supervisor_pid', 'operator_poll_pid', 'commander_poll_pid', 'watchdog_pid', 'server_watchdog_pid')) {
-        $rawPid = $null
-        if ($manifest.session -is [System.Collections.IDictionary]) {
-            if ($manifest.session.Contains($propertyName)) {
-                $rawPid = $manifest.session[$propertyName]
-            }
-        } elseif ($null -ne $manifest.session.PSObject -and $manifest.session.PSObject.Properties.Name -contains $propertyName) {
-            $rawPid = $manifest.session.$propertyName
-        }
-
+    function Add-OrchestraBackgroundPidMapEntry {
+        param(
+            $RawPid,
+            [Parameter(Mandatory = $true)][string]$Label,
+            [AllowEmptyString()][string]$RequiredScript = ''
+        )
         $resolvedPid = 0
-        if ($null -eq $rawPid -or -not [int]::TryParse(([string]$rawPid), [ref]$resolvedPid) -or $resolvedPid -lt 1) {
-            continue
+        if ($null -eq $RawPid -or -not [int]::TryParse(([string]$RawPid), [ref]$resolvedPid) -or $resolvedPid -lt 1) {
+            return
         }
 
         $resolvedPidKey = [string]$resolvedPid
         if (-not $pidMap.Contains($resolvedPidKey)) {
-            $pidMap[$resolvedPidKey] = if ($propertyName -eq 'commander_poll_pid') { 'operator_poll_pid' } else { $propertyName }
+            $pidMap[$resolvedPidKey] = [PSCustomObject][ordered]@{
+                Label          = if ($Label -eq 'commander_poll_pid') { 'operator_poll_pid' } else { $Label }
+                RequiredScript = $RequiredScript
+            }
         }
+    }
+
+    $registry = ConvertFrom-OrchestraProcessRegistryValue -Value (Get-OrchestraObjectPropertyValue -InputObject $manifest.session -Name 'process_registry' -Default $null)
+    $registryEntries = @(Get-OrchestraObjectPropertyValue -InputObject $registry -Name 'entries' -Default @())
+    foreach ($registryEntry in $registryEntries) {
+        $registryPid = Get-OrchestraObjectPropertyValue -InputObject $registryEntry -Name 'pid' -Default $null
+        $registryLabel = [string](Get-OrchestraObjectPropertyValue -InputObject $registryEntry -Name 'label' -Default '')
+        $registryScript = [string](Get-OrchestraObjectPropertyValue -InputObject $registryEntry -Name 'script' -Default '')
+        if ([string]::IsNullOrWhiteSpace($registryLabel)) {
+            continue
+        }
+        Add-OrchestraBackgroundPidMapEntry -RawPid $registryPid -Label $registryLabel -RequiredScript $registryScript
+    }
+
+    foreach ($propertyName in @('supervisor_pid', 'operator_poll_pid', 'commander_poll_pid', 'watchdog_pid', 'server_watchdog_pid')) {
+        $rawPid = Get-OrchestraObjectPropertyValue -InputObject $manifest.session -Name $propertyName -Default $null
+        $requiredScript = switch ($propertyName) {
+            'supervisor_pid' { 'orchestra-supervisor.ps1' }
+            'operator_poll_pid' { 'operator-poll.ps1' }
+            'commander_poll_pid' { 'operator-poll.ps1' }
+            'watchdog_pid' { 'agent-watchdog.ps1' }
+            'server_watchdog_pid' { 'server-watchdog.ps1' }
+            default { '' }
+        }
+        Add-OrchestraBackgroundPidMapEntry -RawPid $rawPid -Label $propertyName -RequiredScript $requiredScript
     }
 
     $manifestPath = Get-OrchestraManifestPath -ProjectDir $ProjectDir
     $snapshot = Get-ProcessSnapshot
     foreach ($entry in $pidMap.GetEnumerator()) {
         $processId = [int]$entry.Key
-        $label = [string]$entry.Value
+        $label = [string]$entry.Value.Label
         try {
             if (-not $snapshot.ById.ContainsKey($processId)) {
                 continue
@@ -1424,13 +1556,7 @@ function Stop-OrchestraBackgroundProcessesFromManifest {
 
             $process = $snapshot.ById[$processId]
             $commandLine = [string]$process.CommandLine
-            $requiredScript = switch ($label) {
-                'supervisor_pid' { 'orchestra-supervisor.ps1' }
-                'operator_poll_pid' { 'operator-poll.ps1' }
-                'watchdog_pid' { 'agent-watchdog.ps1' }
-                'server_watchdog_pid' { 'server-watchdog.ps1' }
-                default { '' }
-            }
+            $requiredScript = [string]$entry.Value.RequiredScript
             $matchesExactMarkers = -not [string]::IsNullOrWhiteSpace($commandLine)
             foreach ($marker in @($requiredScript, $manifestPath, $SessionName, $startupToken) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }) {
                 if ($commandLine.IndexOf($marker, [System.StringComparison]::OrdinalIgnoreCase) -lt 0) {


### PR DESCRIPTION
## Summary
- persist an orchestra `process_registry` with ownership, lease, idle, and crash-recovery metadata while preserving legacy PID fields
- prefer `process_registry` during stale background cleanup, with legacy PID fields as fallback
- add an automation driver lease pool for `open-dev-browser`, including active-lease reuse, pool-full blocking, heartbeat/release, stale owner reclamation, and probe-safe active-lease handling
- wire the automation driver pool check into the visible CI gate

## Validation
- `node --check winsmux-app/scripts/automation-driver-pool.mjs`
- `node --check winsmux-app/scripts/automation-driver-pool-check.mjs`
- `node --check winsmux-app/scripts/open-dev-browser.mjs`
- `npm --prefix winsmux-app run test:automation-driver-pool`
- `Invoke-Pester -Path tests/winsmux-bridge.Tests.ps1 -FullName '*persists background process registry entries*','*stops stale background processes recorded in process_registry*','*stops process_registry entries after a manifest save and read round trip*','*treats legacy commander_poll_pid*' -PassThru`
- `git diff --cached --check`
- `pwsh -NoProfile -File scripts/audit-public-surface.ps1`
- `scripts/git-guard.ps1 -Mode full`