### PR TITLE
fix(core): codify shell restore exit matrix

### DIFF
--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -9,6 +9,7 @@ mod style;
 mod rendering;
 mod config;
 mod commands;
+mod shell_lifecycle;
 mod pane;
 mod popup;
 mod copy_mode;

--- a/core/src/pane.rs
+++ b/core/src/pane.rs
@@ -7,6 +7,7 @@ use portable_pty::{CommandBuilder, PtySize, native_pty_system};
 
 use crate::types::{AppState, Pane, Node, LayoutKind, Window};
 use crate::tree::{replace_leaf_with_split, active_pane_mut, kill_leaf};
+use crate::shell_lifecycle::ShellSpawnRoute;
 
 /// Sentinel value for cursor_shape: means "no DECSCUSR received from child yet".
 /// When ConPTY passthrough mode is unavailable, DECSCUSR sequences from child
@@ -68,10 +69,16 @@ fn default_shell_name(command: Option<&str>, configured_shell: Option<&str>) -> 
 }
 
 pub fn create_window(pty_system: &dyn portable_pty::PtySystem, app: &mut AppState, command: Option<&str>, start_dir: Option<&str>) -> io::Result<()> {
+    let should_use_warm_pane = crate::shell_lifecycle::should_transplant_warm_default_shell(
+        command.is_some(),
+        start_dir.is_some(),
+        app.warm_pane.is_some(),
+    );
+
     // ── Fast path: use pre-spawned warm pane when creating a default shell ──
     // The warm pane has its shell already loaded (~470ms for pwsh), so the
     // prompt appears instantly — matching wezterm's "instant tab" feel.
-    if command.is_none() && start_dir.is_none() && app.warm_pane.is_some() {
+    if should_use_warm_pane {
         let wp = app.warm_pane.take().unwrap();
         // Resize to current terminal dimensions if they changed since pre-spawn
         let area = app.last_window_area;
@@ -111,14 +118,20 @@ pub fn create_window(pty_system: &dyn portable_pty::PtySystem, app: &mut AppStat
 
     // When no explicit command is given, use the configured default-shell
     // (from `set -g default-shell` / `default-command`).
-    // Expand format variables like #{pane_current_path} at spawn time (#111).
+    // Expand only on the cold path: the warm path returns with an already
+    // spawned shell and must not re-run #() substitutions.
     let expanded_shell = crate::format::expand_format(&app.default_shell, app);
-    let mut shell_cmd = if command.is_some() {
-        build_command(command, app.env_shim, app.allow_predictions)
-    } else if !expanded_shell.is_empty() {
-        build_default_shell(&expanded_shell, app.env_shim, app.allow_predictions)
-    } else {
-        build_command(None, app.env_shim, app.allow_predictions)
+    let spawn_route = crate::shell_lifecycle::classify_shell_spawn(
+        command.is_some(),
+        !expanded_shell.is_empty(),
+        start_dir.is_some(),
+        false,
+    );
+    let mut shell_cmd = match spawn_route {
+        ShellSpawnRoute::ExplicitCommand => build_command(command, app.env_shim, app.allow_predictions),
+        ShellSpawnRoute::ConfiguredDefaultShell => build_default_shell(&expanded_shell, app.env_shim, app.allow_predictions),
+        ShellSpawnRoute::FreshDefaultShell => build_command(None, app.env_shim, app.allow_predictions),
+        ShellSpawnRoute::WarmDefaultShell => unreachable!("warm default shell route returns before cold spawn"),
     };
     // Override CWD if -c start_dir was specified
     if let Some(dir) = start_dir {
@@ -345,6 +358,11 @@ pub fn split_active_with_command(app: &mut AppState, kind: LayoutKind, command: 
         }
     };
     let size = PtySize { rows, cols, pixel_width: 0, pixel_height: 0 };
+    let should_use_warm_pane = crate::shell_lifecycle::should_transplant_warm_default_shell(
+        command.is_some(),
+        start_dir.is_some(),
+        app.warm_pane.is_some(),
+    );
 
     // ── Fast path: transplant warm pane for default-shell splits ─────
     // The warm pane has its shell already loaded (~470ms for pwsh).  Even
@@ -353,7 +371,7 @@ pub fn split_active_with_command(app: &mut AppState, kind: LayoutKind, command: 
     // cold spawn (~500ms).  Net result: split feels nearly instant.
     // Skip warm pane when start_dir is set — the warm pane was spawned
     // in the server's CWD, not the requested directory (#107).
-    if command.is_none() && start_dir.is_none() && app.warm_pane.is_some() {
+    if should_use_warm_pane {
         let wp = app.warm_pane.take().unwrap();
         // Resize ConPTY + parser to the split dimensions
         if rows != wp.rows || cols != wp.cols {
@@ -379,14 +397,20 @@ pub fn split_active_with_command(app: &mut AppState, kind: LayoutKind, command: 
     // ── Normal path: cold-spawn a new ConPTY + shell ────────────────
     let pair = pty_system.openpty(size).map_err(|e| io::Error::new(io::ErrorKind::Other, format!("openpty error: {e}")))?;
     // When no explicit command is given, use the configured default-shell.
-    // Expand format variables like #{pane_current_path} at spawn time (#111).
+    // Expand only on the cold path: the warm path returns with an already
+    // spawned shell and must not re-run #() substitutions.
     let expanded_shell = crate::format::expand_format(&app.default_shell, app);
-    let mut shell_cmd = if command.is_some() {
-        build_command(command, app.env_shim, app.allow_predictions)
-    } else if !expanded_shell.is_empty() {
-        build_default_shell(&expanded_shell, app.env_shim, app.allow_predictions)
-    } else {
-        build_command(None, app.env_shim, app.allow_predictions)
+    let spawn_route = crate::shell_lifecycle::classify_shell_spawn(
+        command.is_some(),
+        !expanded_shell.is_empty(),
+        start_dir.is_some(),
+        false,
+    );
+    let mut shell_cmd = match spawn_route {
+        ShellSpawnRoute::ExplicitCommand => build_command(command, app.env_shim, app.allow_predictions),
+        ShellSpawnRoute::ConfiguredDefaultShell => build_default_shell(&expanded_shell, app.env_shim, app.allow_predictions),
+        ShellSpawnRoute::FreshDefaultShell => build_command(None, app.env_shim, app.allow_predictions),
+        ShellSpawnRoute::WarmDefaultShell => unreachable!("warm default shell route returns before cold spawn"),
     };
     // Override CWD if -c start_dir was specified
     if let Some(dir) = start_dir {
@@ -1008,7 +1032,7 @@ pub fn spawn_reader_thread(
         // If parser is still in alt-screen the TUI crashed without
         // sending RMCUP — force cleanup now (TUI is guaranteed dead).
         if let Ok(mut parser) = term_reader.lock() {
-            if parser.screen().alternate_screen() {
+            if crate::shell_lifecycle::should_restore_terminal_after_reader_exit(parser.screen().alternate_screen()) {
                 parser.process(b"\x1b[?25h\x1b[?1049l");
                 cursor_shape.store(0, std::sync::atomic::Ordering::Release);
                 dv_writer.fetch_add(1, std::sync::atomic::Ordering::Release);

--- a/core/src/server/mod.rs
+++ b/core/src/server/mod.rs
@@ -2521,7 +2521,10 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                     apply_set_option(&mut app, &option, &value, quiet);
                     // If default-shell changed, kill the warm pane so the next
                     // new-window spawns the correct shell (fixes #99).
-                    if app.default_shell != old_shell {
+                    if crate::shell_lifecycle::should_reset_warm_pane_after_default_shell_change(
+                        &old_shell,
+                        &app.default_shell,
+                    ) {
                         if let Some(mut wp) = app.warm_pane.take() {
                             wp.child.kill().ok();
                         }
@@ -3977,7 +3980,7 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                 if let Some(cmds) = app.hooks.get("pane-died") { let cmds = cmds.clone(); for cmd in &cmds { let _ = execute_command_string(&mut app, cmd); } }
                 if let Some(cmds) = app.hooks.get("pane-exited") { let cmds = cmds.clone(); for cmd in &cmds { let _ = execute_command_string(&mut app, cmd); } }
             }
-            if app.exit_empty && all_empty {
+            if crate::shell_lifecycle::should_stop_server_after_reap(app.exit_empty, all_empty) {
                 remove_current_session_state(&app);
                 crate::types::shutdown_persistent_streams();
                 // Kill warm pane's child (process::exit skips Drop)

--- a/core/src/shell_lifecycle.rs
+++ b/core/src/shell_lifecycle.rs
@@ -1,0 +1,172 @@
+// Shell restore/exit matrix:
+// - default shell + warm pane + no start_dir -> transplant warm pane.
+// - default shell + start_dir -> cold-spawn in that directory.
+// - configured default-shell without warm pane -> cold-spawn configured shell.
+// - explicit command -> bypass default-shell restore.
+// - exited pane + remain-on-exit off -> prune pane.
+// - exited pane + remain-on-exit on -> keep a dead pane.
+// - reader closes while in alt-screen -> synthesize terminal restore.
+// - exit-empty + all panes removed -> stop the server.
+// - default-shell changes -> reset warm pane before the next spawn.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ShellSpawnRoute {
+    WarmDefaultShell,
+    FreshDefaultShell,
+    ConfiguredDefaultShell,
+    ExplicitCommand,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PaneExitAction {
+    PrunePane,
+    MarkDeadPane,
+}
+
+pub fn classify_shell_spawn(
+    command_present: bool,
+    configured_default_shell_present: bool,
+    start_dir_present: bool,
+    warm_pane_available: bool,
+) -> ShellSpawnRoute {
+    if command_present {
+        return ShellSpawnRoute::ExplicitCommand;
+    }
+
+    if !start_dir_present && warm_pane_available {
+        return ShellSpawnRoute::WarmDefaultShell;
+    }
+
+    if configured_default_shell_present {
+        ShellSpawnRoute::ConfiguredDefaultShell
+    } else {
+        ShellSpawnRoute::FreshDefaultShell
+    }
+}
+
+pub fn should_transplant_warm_default_shell(
+    command_present: bool,
+    start_dir_present: bool,
+    warm_pane_available: bool,
+) -> bool {
+    matches!(
+        classify_shell_spawn(command_present, false, start_dir_present, warm_pane_available),
+        ShellSpawnRoute::WarmDefaultShell
+    )
+}
+
+pub fn classify_pane_exit(remain_on_exit: bool) -> PaneExitAction {
+    if remain_on_exit {
+        PaneExitAction::MarkDeadPane
+    } else {
+        PaneExitAction::PrunePane
+    }
+}
+
+pub fn should_restore_terminal_after_reader_exit(in_alternate_screen: bool) -> bool {
+    in_alternate_screen
+}
+
+pub fn should_stop_server_after_reap(exit_empty: bool, all_empty: bool) -> bool {
+    exit_empty && all_empty
+}
+
+pub fn should_reset_warm_pane_after_default_shell_change(old_shell: &str, new_shell: &str) -> bool {
+    old_shell != new_shell
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn spawn_matrix_covers_default_shell_routes() {
+        let cases = [
+            (
+                "default shell uses warm pane when no cwd override is requested",
+                false,
+                false,
+                false,
+                true,
+                ShellSpawnRoute::WarmDefaultShell,
+            ),
+            (
+                "default shell with start_dir bypasses warm pane and spawns fresh",
+                false,
+                false,
+                true,
+                true,
+                ShellSpawnRoute::FreshDefaultShell,
+            ),
+            (
+                "configured default shell cold-spawns when no warm pane is available",
+                false,
+                true,
+                false,
+                false,
+                ShellSpawnRoute::ConfiguredDefaultShell,
+            ),
+            (
+                "explicit command always bypasses default-shell restore path",
+                true,
+                true,
+                false,
+                true,
+                ShellSpawnRoute::ExplicitCommand,
+            ),
+        ];
+
+        for (name, command, configured, start_dir, warm, expected) in cases {
+            assert_eq!(
+                classify_shell_spawn(command, configured, start_dir, warm),
+                expected,
+                "{name}"
+            );
+        }
+
+        assert!(
+            should_transplant_warm_default_shell(false, false, true),
+            "warm route must not need configured default-shell expansion"
+        );
+        assert!(
+            !should_transplant_warm_default_shell(false, true, true),
+            "start_dir bypasses warm route before configured default-shell expansion"
+        );
+    }
+
+    #[test]
+    fn exit_matrix_covers_normal_and_abnormal_return_paths() {
+        assert_eq!(
+            classify_pane_exit(false),
+            PaneExitAction::PrunePane,
+            "normal or abnormal pane exit prunes the pane when remain-on-exit is off"
+        );
+        assert_eq!(
+            classify_pane_exit(true),
+            PaneExitAction::MarkDeadPane,
+            "normal or abnormal pane exit leaves a dead pane when remain-on-exit is on"
+        );
+        assert!(
+            should_restore_terminal_after_reader_exit(true),
+            "abnormal TUI exit while in alt-screen restores the terminal surface"
+        );
+        assert!(
+            !should_restore_terminal_after_reader_exit(false),
+            "plain shell exit does not synthesize an alt-screen restore"
+        );
+        assert!(
+            should_stop_server_after_reap(true, true),
+            "exit-empty stops the server only after the last pane is gone"
+        );
+        assert!(
+            !should_stop_server_after_reap(true, false),
+            "exit-empty does not stop the server while any pane remains"
+        );
+    }
+
+    #[test]
+    fn restart_matrix_resets_warm_pane_only_when_default_shell_changes() {
+        assert!(should_reset_warm_pane_after_default_shell_change("pwsh", "cmd"));
+        assert!(!should_reset_warm_pane_after_default_shell_change("pwsh", "pwsh"));
+    }
+}

--- a/core/src/tree.rs
+++ b/core/src/tree.rs
@@ -369,11 +369,12 @@ pub fn prune_exited(n: Node, remain_on_exit: bool) -> Option<Node> {
             if p.dead { return Some(Node::Leaf(p)); }
             match p.child.try_wait() {
                 Ok(Some(_)) => {
-                    if remain_on_exit {
-                        p.dead = true;
-                        Some(Node::Leaf(p))
-                    } else {
-                        None
+                    match crate::shell_lifecycle::classify_pane_exit(remain_on_exit) {
+                        crate::shell_lifecycle::PaneExitAction::MarkDeadPane => {
+                            p.dead = true;
+                            Some(Node::Leaf(p))
+                        }
+                        crate::shell_lifecycle::PaneExitAction::PrunePane => None,
                     }
                 }
                 _ => Some(Node::Leaf(p)),


### PR DESCRIPTION
## Summary

- Add a core shell lifecycle matrix that fixes default shell, warm-pane, restart, and exit return-path decisions in one place.
- Route existing pane spawn, pane reap, alt-screen crash restore, warm-pane reset, and exit-empty checks through the matrix helpers.
- Add Rust tests for default shell routing, remain-on-exit return paths, abnormal alt-screen restore, exit-empty behavior, and default-shell restart handling.

## Surface Classification

- [x] Public product surface
- [x] Runtime contract surface
- [ ] Contributor/test surface
- [ ] Generated/runtime artifact not tracked
- [ ] Not sure; reviewer help requested

Reference: Repository surface policy.

## Responsibility And Cutover

- Replaced behavior, workflow, config path, or responsibility: scattered shell restore and exit condition checks are centralized behind core lifecycle helpers.
- Expected outcome: default shells, explicit commands, cwd overrides, restart after default-shell changes, and normal/abnormal exits keep their existing behavior but are covered by a single tested matrix.
- Source of truth: core lifecycle code and Rust tests.
- Old paths preserved, redirected, deprecated, or removed: existing CLI options, command names, runtime paths, and launch flows are preserved.

## Verification

- `cargo fmt --check`
- `cargo test --lib shell_lifecycle`
- `cargo test --lib tree::`
- `cargo check`
- `cargo test --lib`
- `git diff --check`
- `pwsh -NoProfile -File scripts\audit-public-surface.ps1`
- `pwsh -NoProfile -File scripts\git-guard.ps1 -Mode full`

## Security And Privacy

- [x] No secrets, credentials, private local paths, browser profile paths, account IDs, customer data, or raw private logs are included.
- [x] Security issues are reported through `SECURITY.md`, not this public pull request.
- [x] Rollback is clear: revert the shell lifecycle helper and call-site refactor commit.