### PR TITLE
feat(core): add named show-environment queries with secret redaction

### DIFF
--- a/core/docs/configuration.md
+++ b/core/docs/configuration.md
@@ -250,9 +250,13 @@ winsmux set-environment -gu MY_VAR
 # Show all environment variables
 winsmux show-environment
 winsmux show-environment -g
+
+# Show one environment variable
+winsmux show-environment MY_VAR
 ```
 
 Environment variables set this way are injected at the process level when new panes spawn, so they are completely invisible (no commands echoed in the shell).
+When output is displayed, values for secret-like names such as tokens, passwords, passphrases, credentials, and API keys are replaced with `[redacted]`. A named query returns only the requested variable and exits with an error when that variable is not defined.
 
 ## PSReadLine Predictions (Intellisense / Autocompletion)
 

--- a/core/docs/scripting.md
+++ b/core/docs/scripting.md
@@ -129,7 +129,10 @@ winsmux set-environment -gu MY_VAR
 # Show all environment variables
 winsmux show-environment
 winsmux show-environment -g
+winsmux show-environment MY_VAR
 ```
+
+Named queries return only the requested variable and fail when it is not defined. Values for secret-like names, including tokens, passwords, passphrases, credentials, and API keys, are displayed as `[redacted]`.
 
 ## Format Variables
 

--- a/core/src/client.rs
+++ b/core/src/client.rs
@@ -10,7 +10,7 @@ use ratatui::widgets::*;
 use crate::layout::LayoutJson;
 use crate::help;
 use crate::util::{WinTree, base64_encode, quote_arg};
-use crate::session::read_session_key;
+use crate::session::{read_session_key, require_safe_environment_connection};
 use crate::rendering::{dim_predictions_enabled, map_color, dim_color, centered_rect, fix_border_intersections};
 use crate::style::parse_tmux_style_components;
 use crate::config::{parse_key_string, normalize_key_for_binding};
@@ -326,6 +326,7 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
     if !auth_line.trim().starts_with("OK") {
         return Err(io::Error::new(io::ErrorKind::PermissionDenied, "auth failed"));
     }
+    require_safe_environment_connection(&mut reader, &mut writer)?;
 
     // Enter persistent mode + attach
     let _ = writer.write_all(b"PERSISTENT\n");

--- a/core/src/commands.rs
+++ b/core/src/commands.rs
@@ -1,5 +1,8 @@
+use std::collections::HashMap;
 use std::io;
 use std::time::Instant;
+
+use serde::{Deserialize, Serialize};
 
 use std::io::Write;
 use crate::types::{AppState, Mode, Action, FocusDir, LayoutKind, MenuItem, Menu, Node};
@@ -39,6 +42,189 @@ fn show_output_popup(app: &mut AppState, title: &str, output: String) {
         popup_pane: None,
         scroll_offset: 0,
     };
+}
+
+const REDACTED_ENVIRONMENT_VALUE: &str = "[redacted]";
+pub(crate) const SHOW_ENVIRONMENT_SAFE_RESPONSE_FLAG: &str =
+    "--winsmux-safe-environment-response-v1";
+pub(crate) const SHOW_ENVIRONMENT_SAFE_CAPABILITY_FLAG: &str =
+    "--winsmux-safe-environment-capability-v1";
+pub(crate) const SHOW_ENVIRONMENT_SAFE_RESPONSE_PREFIX: &str =
+    "\0winsmux-safe-environment-response-v1 ";
+const INCOMPATIBLE_ENVIRONMENT_RESPONSE_ERROR: &str =
+    "the running server does not support safe show-environment responses; restart the server and retry";
+
+#[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(tag = "status", content = "payload", rename_all = "snake_case", deny_unknown_fields)]
+pub(crate) enum SafeEnvironmentResponse {
+    Ok(String),
+    Error(String),
+}
+
+pub(crate) fn parse_show_environment_name(args: &[&str]) -> Option<String> {
+    let mut index = 0;
+    while index < args.len() {
+        match args[index] {
+            "-t" => index += 2,
+            "-g" | "-h" | "-s" => index += 1,
+            "--" => return args.get(index + 1).map(|value| (*value).to_string()),
+            value if value.starts_with('-') => index += 1,
+            value => return Some(value.to_string()),
+        }
+    }
+    None
+}
+
+fn is_sensitive_environment_name(name: &str) -> bool {
+    let normalized = name.to_ascii_lowercase();
+    let compact = normalized
+        .chars()
+        .filter(|ch| ch.is_ascii_alphanumeric())
+        .collect::<String>();
+    let words = normalized
+        .split(|ch: char| !ch.is_ascii_alphanumeric())
+        .filter(|word| !word.is_empty())
+        .collect::<Vec<_>>();
+    let has_password_alias = words.len() > 1
+        && words
+            .iter()
+            .any(|word| matches!(*word, "pass" | "pwd"));
+    let has_standalone_credential_alias = words.len() == 1
+        && matches!(words[0], "pass" | "pw" | "pin" | "psk" | "otp" | "totp" | "hotp");
+    let has_sensitive_word = words.iter().any(|word| {
+        matches!(
+            *word,
+            "secret"
+                | "secrets"
+                | "token"
+                | "tokens"
+                | "password"
+                | "passwords"
+                | "passwd"
+                | "passphrase"
+                | "passphrases"
+                | "credential"
+                | "credentials"
+                | "authorization"
+                | "bearer"
+                | "jwt"
+                | "pat"
+        )
+    });
+    let has_sensitive_key_kind = words.windows(2).any(|pair| {
+        matches!(
+            (pair[0], pair[1]),
+            ("api", "key")
+                | ("access", "key")
+                | ("private", "key")
+                | ("ssh", "key")
+                | ("signing", "key")
+                | ("session", "key")
+        )
+    });
+    let has_auth_material = words.iter().enumerate().any(|(index, word)| {
+        *word == "auth"
+            && (index + 1 == words.len()
+                || matches!(
+                    words.get(index + 1).copied(),
+                    Some("config" | "header" | "key" | "password" | "secret" | "token")
+                ))
+    });
+    let has_compact_sensitive_suffix = [
+        "secret",
+        "token",
+        "password",
+        "passwd",
+        "passphrase",
+        "credential",
+        "credentials",
+        "privatekey",
+        "sshkey",
+        "signingkey",
+        "accesskey",
+        "apikey",
+        "sessionkey",
+        "authheader",
+        "authorization",
+        "bearer",
+    ]
+    .iter()
+    .any(|suffix| compact == *suffix || compact.ends_with(suffix));
+
+    has_sensitive_word
+        || has_password_alias
+        || has_standalone_credential_alias
+        || has_sensitive_key_kind
+        || has_auth_material
+        || has_compact_sensitive_suffix
+        || compact == "key"
+}
+
+pub(crate) fn encode_safe_environment_response(response: &str) -> String {
+    encode_safe_environment_frame(&SafeEnvironmentResponse::Ok(response.to_string()))
+}
+
+pub(crate) fn encode_safe_environment_error(error: &str) -> String {
+    encode_safe_environment_frame(&SafeEnvironmentResponse::Error(error.to_string()))
+}
+
+fn encode_safe_environment_frame(response: &SafeEnvironmentResponse) -> String {
+    let payload = serde_json::to_string(response)
+        .expect("safe environment response serialization must succeed");
+    format!("{SHOW_ENVIRONMENT_SAFE_RESPONSE_PREFIX}{payload}\n")
+}
+
+pub(crate) fn decode_safe_environment_response(
+    response: &str,
+) -> Result<SafeEnvironmentResponse, String> {
+    // An older server ignores the private safe-response/name flags and writes its
+    // ordinary `NAME=value` lines (potentially the full environment). That legacy
+    // output cannot be confused with this NUL-prefixed, versioned JSON frame.
+    // Do not inspect payload lines here: legitimate values may contain newlines,
+    // `ERROR:` prefixes, CRLF, empty strings, or multibyte UTF-8.
+    let frame = response
+        .strip_prefix(SHOW_ENVIRONMENT_SAFE_RESPONSE_PREFIX)
+        .ok_or_else(|| INCOMPATIBLE_ENVIRONMENT_RESPONSE_ERROR.to_string())?;
+    let frame = frame
+        .strip_suffix("\r\n")
+        .or_else(|| frame.strip_suffix('\n'))
+        .ok_or_else(|| INCOMPATIBLE_ENVIRONMENT_RESPONSE_ERROR.to_string())?;
+    if frame.contains(['\r', '\n']) {
+        return Err(INCOMPATIBLE_ENVIRONMENT_RESPONSE_ERROR.to_string());
+    }
+    serde_json::from_str(frame)
+        .map_err(|_| INCOMPATIBLE_ENVIRONMENT_RESPONSE_ERROR.to_string())
+}
+
+pub(crate) fn incompatible_environment_response_error() -> &'static str {
+    INCOMPATIBLE_ENVIRONMENT_RESPONSE_ERROR
+}
+
+pub(crate) fn format_environment_output(
+    environment: &HashMap<String, String>,
+    requested_name: Option<&str>,
+) -> Result<String, String> {
+    let mut names = match requested_name {
+        Some(name) if environment.contains_key(name) => vec![name.to_string()],
+        Some(name) => return Err(format!("unknown variable: {name}")),
+        None => environment.keys().cloned().collect::<Vec<_>>(),
+    };
+    names.sort();
+
+    if names.is_empty() {
+        return Ok("(no environment variables)\n".to_string());
+    }
+
+    let mut output = String::new();
+    for name in names {
+        let value = if is_sensitive_environment_name(&name) {
+            REDACTED_ENVIRONMENT_VALUE
+        } else {
+            environment.get(&name).map(String::as_str).unwrap_or_default()
+        };
+        output.push_str(&format!("{name}={value}\n"));
+    }
+    Ok(output)
 }
 
 /// Generate list-windows output from AppState (tmux-compatible format).
@@ -1153,11 +1339,12 @@ pub fn execute_command_string(app: &mut AppState, cmd: &str) -> io::Result<()> {
             if let Some(port) = app.control_port {
                 let _ = send_control_to_port(port, &format!("{}\n", cmd), &app.session_key);
             } else {
-                let mut output = String::new();
-                for (key, value) in &app.environment {
-                    output.push_str(&format!("{}={}\n", key, value));
-                }
-                if output.is_empty() { output.push_str("(no environment variables)\n"); }
+                let requested_name = parse_show_environment_name(&parts[1..]);
+                let output = format_environment_output(
+                    &app.environment,
+                    requested_name.as_deref(),
+                )
+                .map_err(|error| io::Error::new(io::ErrorKind::NotFound, error))?;
                 show_output_popup(app, "show-environment", output);
             }
         }

--- a/core/src/commands.rs
+++ b/core/src/commands.rs
@@ -151,8 +151,31 @@ fn is_sensitive_environment_name(name: &str) -> bool {
         "authorization",
         "bearer",
     ];
-    let has_compact_sensitive_marker = compact_sensitive_markers.iter().any(|marker| {
-        compact.ends_with(marker) || words.iter().any(|word| word == marker)
+    let has_compact_sensitive_marker = compact_sensitive_markers.iter().any(|&marker| {
+        compact.ends_with(marker) || words.iter().any(|word| *word == marker)
+    });
+    let compact_key_markers = [
+        "secretkey",
+        "privatekey",
+        "sshkey",
+        "signingkey",
+        "accesskey",
+        "apikey",
+        "sessionkey",
+    ];
+    let benign_compact_key_continuations = [("apikey", "board")];
+    let has_separatorless_compact_key_marker = words.iter().any(|word| {
+        compact_key_markers.iter().any(|&marker| {
+            word.match_indices(marker).any(|(index, _)| {
+                let qualifier = &word[index + marker.len()..];
+                !qualifier.is_empty()
+                    && !benign_compact_key_continuations.iter().any(
+                        |&(benign_marker, continuation)| {
+                            marker == benign_marker && qualifier.starts_with(continuation)
+                        },
+                    )
+            })
+        })
     });
 
     has_sensitive_word
@@ -161,6 +184,7 @@ fn is_sensitive_environment_name(name: &str) -> bool {
         || has_sensitive_key_kind
         || has_auth_material
         || has_compact_sensitive_marker
+        || has_separatorless_compact_key_marker
         || compact == "key"
 }
 

--- a/core/src/commands.rs
+++ b/core/src/commands.rs
@@ -132,7 +132,7 @@ fn is_sensitive_environment_name(name: &str) -> bool {
                     Some("config" | "header" | "key" | "password" | "secret" | "token")
                 ))
     });
-    let has_compact_sensitive_suffix = [
+    let compact_sensitive_markers = [
         "secret",
         "token",
         "password",
@@ -140,6 +140,7 @@ fn is_sensitive_environment_name(name: &str) -> bool {
         "passphrase",
         "credential",
         "credentials",
+        "secretkey",
         "privatekey",
         "sshkey",
         "signingkey",
@@ -149,16 +150,17 @@ fn is_sensitive_environment_name(name: &str) -> bool {
         "authheader",
         "authorization",
         "bearer",
-    ]
-    .iter()
-    .any(|suffix| compact == *suffix || compact.ends_with(suffix));
+    ];
+    let has_compact_sensitive_marker = compact_sensitive_markers.iter().any(|marker| {
+        compact.ends_with(marker) || words.iter().any(|word| word == marker)
+    });
 
     has_sensitive_word
         || has_password_alias
         || has_standalone_credential_alias
         || has_sensitive_key_kind
         || has_auth_material
-        || has_compact_sensitive_suffix
+        || has_compact_sensitive_marker
         || compact == "key"
 }
 

--- a/core/src/commands.rs
+++ b/core/src/commands.rs
@@ -49,6 +49,8 @@ pub(crate) const SHOW_ENVIRONMENT_SAFE_RESPONSE_FLAG: &str =
     "--winsmux-safe-environment-response-v1";
 pub(crate) const SHOW_ENVIRONMENT_SAFE_CAPABILITY_FLAG: &str =
     "--winsmux-safe-environment-capability-v1";
+pub(crate) const SHOW_ENVIRONMENT_CONTROL_SIGNAL_CAPABILITY_FLAG: &str =
+    "--winsmux-control-safe-environment-signal-v1";
 pub(crate) const SHOW_ENVIRONMENT_SAFE_RESPONSE_PREFIX: &str =
     "\0winsmux-safe-environment-response-v1 ";
 const INCOMPATIBLE_ENVIRONMENT_RESPONSE_ERROR: &str =

--- a/core/src/control.rs
+++ b/core/src/control.rs
@@ -1,62 +1,44 @@
 use crate::types::{AppState, ControlNotification};
-use std::collections::HashMap;
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum ControlClientCommandKind {
-    Ordinary,
-    ShowEnvironment,
-}
+// Preserve winsmux's existing tmux-compatible flags value and reserve one
+// negotiated bit for server-authored safe-environment response metadata.
+pub(crate) const CONTROL_RESPONSE_DEFAULT_FLAGS: u64 = 1;
+pub(crate) const CONTROL_RESPONSE_SAFE_ENVIRONMENT_FLAG: u64 = 1 << 1;
 
 #[derive(Clone, Copy, Debug)]
 struct ActiveControlClientResponse {
     command_number: u64,
-    kind: ControlClientCommandKind,
+    safe_environment: bool,
     payload_handled: bool,
 }
 
 #[derive(Default)]
 pub(crate) struct ControlClientResponseFilter {
-    next_command_number: u64,
-    pending_commands: HashMap<u64, ControlClientCommandKind>,
     active_response: Option<ActiveControlClientResponse>,
     deferred_notifications: String,
 }
 
 impl ControlClientResponseFilter {
-    pub(crate) fn record_command(&mut self, command_line: &str) {
-        let parsed = crate::commands::parse_command_line(command_line.trim());
-        let Some(command_name) = parsed.first() else {
-            return;
-        };
-
-        self.next_command_number += 1;
-        let kind = match command_name.as_str() {
-            "show-environment" | "showenv" => ControlClientCommandKind::ShowEnvironment,
-            _ => ControlClientCommandKind::Ordinary,
-        };
-        self.pending_commands
-            .insert(self.next_command_number, kind);
-    }
-
     pub(crate) fn filter_server_line(&mut self, line: &str) -> String {
-        if let Some(command_number) = control_block_command_number(line, "%begin") {
+        if self.active_response.is_none() {
+            let Some((command_number, flags)) = control_block_metadata(line, "%begin") else {
+                return line.to_string();
+            };
             self.deferred_notifications.clear();
-            self.active_response = self.pending_commands.remove(&command_number).map(|kind| {
-                ActiveControlClientResponse {
-                    command_number,
-                    kind,
-                    payload_handled: false,
-                }
+            self.active_response = Some(ActiveControlClientResponse {
+                command_number,
+                safe_environment: flags & CONTROL_RESPONSE_SAFE_ENVIRONMENT_FLAG != 0,
+                payload_handled: false,
             });
             return line.to_string();
         }
 
-        if let Some(command_number) = control_block_command_number(line, "%end")
-            .or_else(|| control_block_command_number(line, "%error"))
+        if let Some((command_number, _)) = control_block_metadata(line, "%end")
+            .or_else(|| control_block_metadata(line, "%error"))
         {
             let missing_show_environment_frame = self.active_response.is_some_and(|response| {
                 response.command_number == command_number
-                    && response.kind == ControlClientCommandKind::ShowEnvironment
+                    && response.safe_environment
                     && !response.payload_handled
             });
             if self
@@ -79,7 +61,7 @@ impl ControlClientResponseFilter {
         let Some(response) = self.active_response else {
             return line.to_string();
         };
-        if response.kind != ControlClientCommandKind::ShowEnvironment {
+        if !response.safe_environment {
             return line.to_string();
         }
         if !response.payload_handled && line.starts_with('%') {
@@ -94,8 +76,9 @@ impl ControlClientResponseFilter {
             };
         }
 
-        // User-controlled output can start with the safe-frame marker, so only
-        // decode payload in the numbered reply block for a pending show-environment.
+        // The server sets the safe-environment bit only after resolving dispatch
+        // semantics. User-controlled output can match the frame prefix, so the
+        // client must never infer this state from payload or command text.
         self.active_response
             .as_mut()
             .expect("active response was checked above")
@@ -118,18 +101,18 @@ impl ControlClientResponseFilter {
     }
 }
 
-fn control_block_command_number(line: &str, marker: &str) -> Option<u64> {
+fn control_block_metadata(line: &str, marker: &str) -> Option<(u64, u64)> {
     let mut fields = line.trim_end_matches(['\r', '\n']).split_ascii_whitespace();
     if fields.next()? != marker {
         return None;
     }
     fields.next()?.parse::<i64>().ok()?;
     let command_number = fields.next()?.parse::<u64>().ok()?;
-    fields.next()?.parse::<u64>().ok()?;
+    let flags = fields.next()?.parse::<u64>().ok()?;
     if fields.next().is_some() {
         return None;
     }
-    Some(command_number)
+    Some((command_number, flags))
 }
 
 /// Format a control mode notification as a tmux wire-compatible line.
@@ -226,18 +209,18 @@ pub fn escape_output(data: &str) -> String {
 }
 
 /// Format the %begin header for a command response.
-pub fn format_begin(timestamp: i64, cmd_number: u64) -> String {
-    format!("%begin {} {} 1", timestamp, cmd_number)
+pub fn format_begin(timestamp: i64, cmd_number: u64, flags: u64) -> String {
+    format!("%begin {} {} {}", timestamp, cmd_number, flags)
 }
 
 /// Format the %end footer for a successful command response.
-pub fn format_end(timestamp: i64, cmd_number: u64) -> String {
-    format!("%end {} {} 1", timestamp, cmd_number)
+pub fn format_end(timestamp: i64, cmd_number: u64, flags: u64) -> String {
+    format!("%end {} {} {}", timestamp, cmd_number, flags)
 }
 
 /// Format the %error footer for a failed command response.
-pub fn format_error(timestamp: i64, cmd_number: u64) -> String {
-    format!("%error {} {} 1", timestamp, cmd_number)
+pub fn format_error(timestamp: i64, cmd_number: u64, flags: u64) -> String {
+    format!("%error {} {} {}", timestamp, cmd_number, flags)
 }
 
 /// Emit a control notification to all connected control mode clients.
@@ -293,15 +276,23 @@ mod tests {
 
     #[test]
     fn test_format_begin_end_error() {
-        assert_eq!(format_begin(1700000000, 1), "%begin 1700000000 1 1");
-        assert_eq!(format_end(1700000000, 1), "%end 1700000000 1 1");
-        assert_eq!(format_error(1700000000, 1), "%error 1700000000 1 1");
+        assert_eq!(
+            format_begin(1700000000, 1, CONTROL_RESPONSE_DEFAULT_FLAGS),
+            "%begin 1700000000 1 1"
+        );
+        assert_eq!(
+            format_end(1700000000, 1, CONTROL_RESPONSE_DEFAULT_FLAGS),
+            "%end 1700000000 1 1"
+        );
+        assert_eq!(
+            format_error(1700000000, 1, CONTROL_RESPONSE_DEFAULT_FLAGS),
+            "%error 1700000000 1 1"
+        );
     }
 
     #[test]
     fn control_client_preserves_safe_environment_prefix_for_show_buffer() {
         let mut filter = ControlClientResponseFilter::default();
-        filter.record_command("show-buffer");
 
         assert_eq!(
             filter.filter_server_line("%begin 1700000000 1 1\n"),
@@ -321,8 +312,7 @@ mod tests {
     #[test]
     fn control_client_decodes_framed_show_environment_reply() {
         let mut filter = ControlClientResponseFilter::default();
-        filter.record_command("show-environment SYNTHETIC_TARGET");
-        filter.filter_server_line("%begin 1700000000 1 1\n");
+        filter.filter_server_line("%begin 1700000000 1 3\n");
 
         let frame = crate::commands::encode_safe_environment_response(
             "SYNTHETIC_TARGET=synthetic-value\n",
@@ -336,8 +326,7 @@ mod tests {
     #[test]
     fn control_client_refuses_unframed_show_environment_reply() {
         let mut filter = ControlClientResponseFilter::default();
-        filter.record_command("show-environment SYNTHETIC_TARGET");
-        filter.filter_server_line("%begin 1700000000 1 1\n");
+        filter.filter_server_line("%begin 1700000000 1 3\n");
 
         let output = filter.filter_server_line(
             "SYNTHETIC_TARGET=synthetic-value-that-must-not-print\n",

--- a/core/src/control.rs
+++ b/core/src/control.rs
@@ -1,4 +1,136 @@
 use crate::types::{AppState, ControlNotification};
+use std::collections::HashMap;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ControlClientCommandKind {
+    Ordinary,
+    ShowEnvironment,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct ActiveControlClientResponse {
+    command_number: u64,
+    kind: ControlClientCommandKind,
+    payload_handled: bool,
+}
+
+#[derive(Default)]
+pub(crate) struct ControlClientResponseFilter {
+    next_command_number: u64,
+    pending_commands: HashMap<u64, ControlClientCommandKind>,
+    active_response: Option<ActiveControlClientResponse>,
+    deferred_notifications: String,
+}
+
+impl ControlClientResponseFilter {
+    pub(crate) fn record_command(&mut self, command_line: &str) {
+        let parsed = crate::commands::parse_command_line(command_line.trim());
+        let Some(command_name) = parsed.first() else {
+            return;
+        };
+
+        self.next_command_number += 1;
+        let kind = match command_name.as_str() {
+            "show-environment" | "showenv" => ControlClientCommandKind::ShowEnvironment,
+            _ => ControlClientCommandKind::Ordinary,
+        };
+        self.pending_commands
+            .insert(self.next_command_number, kind);
+    }
+
+    pub(crate) fn filter_server_line(&mut self, line: &str) -> String {
+        if let Some(command_number) = control_block_command_number(line, "%begin") {
+            self.deferred_notifications.clear();
+            self.active_response = self.pending_commands.remove(&command_number).map(|kind| {
+                ActiveControlClientResponse {
+                    command_number,
+                    kind,
+                    payload_handled: false,
+                }
+            });
+            return line.to_string();
+        }
+
+        if let Some(command_number) = control_block_command_number(line, "%end")
+            .or_else(|| control_block_command_number(line, "%error"))
+        {
+            let missing_show_environment_frame = self.active_response.is_some_and(|response| {
+                response.command_number == command_number
+                    && response.kind == ControlClientCommandKind::ShowEnvironment
+                    && !response.payload_handled
+            });
+            if self
+                .active_response
+                .is_some_and(|response| response.command_number == command_number)
+            {
+                self.active_response = None;
+            }
+            self.deferred_notifications.clear();
+            if missing_show_environment_frame {
+                return format!(
+                    "{}\n{}",
+                    crate::commands::incompatible_environment_response_error(),
+                    line
+                );
+            }
+            return line.to_string();
+        }
+
+        let Some(response) = self.active_response else {
+            return line.to_string();
+        };
+        if response.kind != ControlClientCommandKind::ShowEnvironment {
+            return line.to_string();
+        }
+        if !response.payload_handled && line.starts_with('%') {
+            self.deferred_notifications.push_str(line);
+            return String::new();
+        }
+        if response.payload_handled {
+            return if line.starts_with('%') {
+                line.to_string()
+            } else {
+                String::new()
+            };
+        }
+
+        // User-controlled output can start with the safe-frame marker, so only
+        // decode payload in the numbered reply block for a pending show-environment.
+        self.active_response
+            .as_mut()
+            .expect("active response was checked above")
+            .payload_handled = true;
+        match crate::commands::decode_safe_environment_response(line) {
+            Ok(crate::commands::SafeEnvironmentResponse::Ok(output)) => {
+                format!("{}{}", std::mem::take(&mut self.deferred_notifications), output)
+            }
+            Ok(crate::commands::SafeEnvironmentResponse::Error(error)) => {
+                format!(
+                    "{}{error}\n",
+                    std::mem::take(&mut self.deferred_notifications)
+                )
+            }
+            Err(error) => {
+                self.deferred_notifications.clear();
+                format!("{error}\n")
+            }
+        }
+    }
+}
+
+fn control_block_command_number(line: &str, marker: &str) -> Option<u64> {
+    let mut fields = line.trim_end_matches(['\r', '\n']).split_ascii_whitespace();
+    if fields.next()? != marker {
+        return None;
+    }
+    fields.next()?.parse::<i64>().ok()?;
+    let command_number = fields.next()?.parse::<u64>().ok()?;
+    fields.next()?.parse::<u64>().ok()?;
+    if fields.next().is_some() {
+        return None;
+    }
+    Some(command_number)
+}
 
 /// Format a control mode notification as a tmux wire-compatible line.
 pub fn format_notification(notif: &ControlNotification) -> String {
@@ -164,6 +296,63 @@ mod tests {
         assert_eq!(format_begin(1700000000, 1), "%begin 1700000000 1 1");
         assert_eq!(format_end(1700000000, 1), "%end 1700000000 1 1");
         assert_eq!(format_error(1700000000, 1), "%error 1700000000 1 1");
+    }
+
+    #[test]
+    fn control_client_preserves_safe_environment_prefix_for_show_buffer() {
+        let mut filter = ControlClientResponseFilter::default();
+        filter.record_command("show-buffer");
+
+        assert_eq!(
+            filter.filter_server_line("%begin 1700000000 1 1\n"),
+            "%begin 1700000000 1 1\n"
+        );
+        let output = format!(
+            "{}synthetic buffer payload\n",
+            crate::commands::SHOW_ENVIRONMENT_SAFE_RESPONSE_PREFIX
+        );
+        assert_eq!(filter.filter_server_line(&output), output);
+        assert_eq!(
+            filter.filter_server_line("%end 1700000000 1 1\n"),
+            "%end 1700000000 1 1\n"
+        );
+    }
+
+    #[test]
+    fn control_client_decodes_framed_show_environment_reply() {
+        let mut filter = ControlClientResponseFilter::default();
+        filter.record_command("show-environment SYNTHETIC_TARGET");
+        filter.filter_server_line("%begin 1700000000 1 1\n");
+
+        let frame = crate::commands::encode_safe_environment_response(
+            "SYNTHETIC_TARGET=synthetic-value\n",
+        );
+        assert_eq!(
+            filter.filter_server_line(&frame),
+            "SYNTHETIC_TARGET=synthetic-value\n"
+        );
+    }
+
+    #[test]
+    fn control_client_refuses_unframed_show_environment_reply() {
+        let mut filter = ControlClientResponseFilter::default();
+        filter.record_command("show-environment SYNTHETIC_TARGET");
+        filter.filter_server_line("%begin 1700000000 1 1\n");
+
+        let output = filter.filter_server_line(
+            "SYNTHETIC_TARGET=synthetic-value-that-must-not-print\n",
+        );
+        assert_eq!(
+            output,
+            format!(
+                "{}\n",
+                crate::commands::incompatible_environment_response_error()
+            )
+        );
+        assert_eq!(
+            filter.filter_server_line("SYNTHETIC_SECOND=also-must-not-print\n"),
+            ""
+        );
     }
 
     #[test]

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -56,7 +56,7 @@ use crate::platform::enable_virtual_terminal_processing;
 use crate::cli::{print_help, print_version, print_commands};
 use crate::session::{cleanup_stale_port_files, read_session_key, send_control,
     send_control_with_response, resolve_last_session_name, resolve_default_session_name,
-    require_safe_environment_connection,
+    require_safe_environment_control_connection,
     kill_remaining_server_processes, request_server_shutdown,
     cleanup_warm_server_for_socket, resolve_last_session_name_with_prefix,
     socket_path_session_base, normalize_socket_selector, remove_session_state_files};
@@ -3196,22 +3196,18 @@ fn run_control_mode(mode: u8) -> io::Result<()> {
     let mut write_stream = reader.get_ref().try_clone()?;
     // Reject stale servers before entering control mode. This protects both named
     // lookups and no-argument full listings without content-sniffing streamed output.
-    require_safe_environment_connection(&mut reader, &mut write_stream)?;
+    require_safe_environment_control_connection(&mut reader, &mut write_stream)?;
 
     // Send CONTROL or CONTROL_NOECHO
     let mode_str = if mode == 1 { "CONTROL" } else { "CONTROL_NOECHO" };
     write!(write_stream, "{}\n", mode_str)?;
     write_stream.flush()?;
 
-    let response_filter = std::sync::Arc::new(std::sync::Mutex::new(
-        crate::control::ControlClientResponseFilter::default(),
-    ));
-
     // Spawn a thread to read server responses/notifications and print to stdout
     let reader_stream = reader.get_ref().try_clone()?;
-    let reader_response_filter = response_filter.clone();
     let reader_thread = std::thread::spawn(move || {
         let mut br = io::BufReader::new(reader_stream);
+        let mut response_filter = crate::control::ControlClientResponseFilter::default();
         let mut line = String::new();
         let stdout = io::stdout();
         loop {
@@ -3219,10 +3215,7 @@ fn run_control_mode(mode: u8) -> io::Result<()> {
             match br.read_line(&mut line) {
                 Ok(0) | Err(_) => break,
                 Ok(_) => {
-                    let output = reader_response_filter
-                        .lock()
-                        .unwrap_or_else(|poisoned| poisoned.into_inner())
-                        .filter_server_line(&line);
+                    let output = response_filter.filter_server_line(&line);
                     let mut out = stdout.lock();
                     let _ = out.write_all(output.as_bytes());
                     let _ = out.flush();
@@ -3240,10 +3233,6 @@ fn run_control_mode(mode: u8) -> io::Result<()> {
             Ok(0) => break, // EOF
             Err(_) => break,
             Ok(_) => {
-                response_filter
-                    .lock()
-                    .unwrap_or_else(|poisoned| poisoned.into_inner())
-                    .record_command(&stdin_line);
                 if write!(write_stream, "{}", stdin_line).is_err() { break; }
                 if write_stream.flush().is_err() { break; }
             }

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -3203,8 +3203,13 @@ fn run_control_mode(mode: u8) -> io::Result<()> {
     write!(write_stream, "{}\n", mode_str)?;
     write_stream.flush()?;
 
+    let response_filter = std::sync::Arc::new(std::sync::Mutex::new(
+        crate::control::ControlClientResponseFilter::default(),
+    ));
+
     // Spawn a thread to read server responses/notifications and print to stdout
     let reader_stream = reader.get_ref().try_clone()?;
+    let reader_response_filter = response_filter.clone();
     let reader_thread = std::thread::spawn(move || {
         let mut br = io::BufReader::new(reader_stream);
         let mut line = String::new();
@@ -3214,19 +3219,10 @@ fn run_control_mode(mode: u8) -> io::Result<()> {
             match br.read_line(&mut line) {
                 Ok(0) | Err(_) => break,
                 Ok(_) => {
-                    let output = if line.starts_with(
-                        crate::commands::SHOW_ENVIRONMENT_SAFE_RESPONSE_PREFIX,
-                    ) {
-                        match crate::commands::decode_safe_environment_response(&line) {
-                            Ok(crate::commands::SafeEnvironmentResponse::Ok(output)) => output,
-                            Ok(crate::commands::SafeEnvironmentResponse::Error(error)) => {
-                                format!("{error}\n")
-                            }
-                            Err(error) => format!("{error}\n"),
-                        }
-                    } else {
-                        line.clone()
-                    };
+                    let output = reader_response_filter
+                        .lock()
+                        .unwrap_or_else(|poisoned| poisoned.into_inner())
+                        .filter_server_line(&line);
                     let mut out = stdout.lock();
                     let _ = out.write_all(output.as_bytes());
                     let _ = out.flush();
@@ -3244,6 +3240,10 @@ fn run_control_mode(mode: u8) -> io::Result<()> {
             Ok(0) => break, // EOF
             Err(_) => break,
             Ok(_) => {
+                response_filter
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner())
+                    .record_command(&stdin_line);
                 if write!(write_stream, "{}", stdin_line).is_err() { break; }
                 if write_stream.flush().is_err() { break; }
             }

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -56,6 +56,7 @@ use crate::platform::enable_virtual_terminal_processing;
 use crate::cli::{print_help, print_version, print_commands};
 use crate::session::{cleanup_stale_port_files, read_session_key, send_control,
     send_control_with_response, resolve_last_session_name, resolve_default_session_name,
+    require_safe_environment_connection,
     kill_remaining_server_processes, request_server_shutdown,
     cleanup_warm_server_for_socket, resolve_last_session_name_with_prefix,
     socket_path_session_base, normalize_socket_selector, remove_session_state_files};
@@ -2543,7 +2544,12 @@ fn run_main() -> io::Result<()> {
             }
             // show-environment / showenv - Show environment variables
             "show-environment" | "showenv" => {
-                let mut cmd = "show-environment".to_string();
+                // The framing flag is unconditional: a no-argument full listing must
+                // have the same structural legacy-server boundary as a named lookup.
+                let mut cmd = format!(
+                    "show-environment {}",
+                    crate::commands::SHOW_ENVIRONMENT_SAFE_RESPONSE_FLAG
+                );
                 let mut i = 1;
                 while i < cmd_args.len() {
                     match cmd_args[i].as_str() {
@@ -2563,7 +2569,15 @@ fn run_main() -> io::Result<()> {
                 }
                 cmd.push('\n');
                 let resp = send_control_with_response(cmd)?;
-                print!("{}", resp);
+                let safe_response = crate::commands::decode_safe_environment_response(&resp)
+                    .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+                match safe_response {
+                    crate::commands::SafeEnvironmentResponse::Ok(output) => print!("{output}"),
+                    crate::commands::SafeEnvironmentResponse::Error(error) => return Err(io::Error::new(
+                        io::ErrorKind::NotFound,
+                        error,
+                    )),
+                }
                 return Ok(());
             }
             // load-buffer - Load a paste buffer from a file
@@ -3179,9 +3193,13 @@ fn run_control_mode(mode: u8) -> io::Result<()> {
         return Err(io::Error::new(io::ErrorKind::PermissionDenied, format!("auth failed: {}", ok_line.trim())));
     }
 
+    let mut write_stream = reader.get_ref().try_clone()?;
+    // Reject stale servers before entering control mode. This protects both named
+    // lookups and no-argument full listings without content-sniffing streamed output.
+    require_safe_environment_connection(&mut reader, &mut write_stream)?;
+
     // Send CONTROL or CONTROL_NOECHO
     let mode_str = if mode == 1 { "CONTROL" } else { "CONTROL_NOECHO" };
-    let mut write_stream = reader.get_ref().try_clone()?;
     write!(write_stream, "{}\n", mode_str)?;
     write_stream.flush()?;
 
@@ -3196,8 +3214,21 @@ fn run_control_mode(mode: u8) -> io::Result<()> {
             match br.read_line(&mut line) {
                 Ok(0) | Err(_) => break,
                 Ok(_) => {
+                    let output = if line.starts_with(
+                        crate::commands::SHOW_ENVIRONMENT_SAFE_RESPONSE_PREFIX,
+                    ) {
+                        match crate::commands::decode_safe_environment_response(&line) {
+                            Ok(crate::commands::SafeEnvironmentResponse::Ok(output)) => output,
+                            Ok(crate::commands::SafeEnvironmentResponse::Error(error)) => {
+                                format!("{error}\n")
+                            }
+                            Err(error) => format!("{error}\n"),
+                        }
+                    } else {
+                        line.clone()
+                    };
                     let mut out = stdout.lock();
-                    let _ = out.write_all(line.as_bytes());
+                    let _ = out.write_all(output.as_bytes());
                     let _ = out.flush();
                 }
             }

--- a/core/src/server/connection.rs
+++ b/core/src/server/connection.rs
@@ -40,6 +40,26 @@ impl ControlCommandResponseSender {
     }
 }
 
+fn write_control_pre_dispatch_error(
+    write_stream: &mut TcpStream,
+    error: &str,
+    timestamp: i64,
+    command_number: u64,
+    response_flags: u64,
+) {
+    if response_flags & control::CONTROL_RESPONSE_SAFE_ENVIRONMENT_FLAG != 0 {
+        let _ = write!(write_stream, "{}", encode_safe_environment_error(error));
+    } else {
+        let _ = writeln!(write_stream, "{error}");
+    }
+    let _ = writeln!(
+        write_stream,
+        "{}",
+        control::format_error(timestamp, command_number, response_flags)
+    );
+    let _ = write_stream.flush();
+}
+
 /// Handle a single TCP connection from a client.
 /// Parses auth, optional TARGET/PERSISTENT flags, then dispatches commands
 /// to the main server event loop via the `tx` channel.
@@ -346,18 +366,26 @@ if control_echo || control_noecho {
                     let (rtx, rrx) = mpsc::channel::<bool>();
                     let _ = tx_ctrl.send(CtrlReq::FocusPaneChecked(pid, rtx));
                     if !rrx.recv_timeout(Duration::from_millis(2000)).unwrap_or(false) {
-                        let _ = writeln!(write_stream, "can't find pane: {}", pid);
-                        let _ = writeln!(write_stream, "{}", control::format_error(ts, cmd_counter, response_flags));
-                        let _ = write_stream.flush();
+                        write_control_pre_dispatch_error(
+                            &mut write_stream,
+                            &format!("can't find pane: {pid}"),
+                            ts,
+                            cmd_counter,
+                            response_flags,
+                        );
                         continue;
                     }
                 } else {
                     let (rtx, rrx) = mpsc::channel::<bool>();
                     let _ = tx_ctrl.send(CtrlReq::FocusPaneByIndexChecked(pid, rtx));
                     if !rrx.recv_timeout(Duration::from_millis(2000)).unwrap_or(false) {
-                        let _ = writeln!(write_stream, "can't find pane index: {}", pid);
-                        let _ = writeln!(write_stream, "{}", control::format_error(ts, cmd_counter, response_flags));
-                        let _ = write_stream.flush();
+                        write_control_pre_dispatch_error(
+                            &mut write_stream,
+                            &format!("can't find pane index: {pid}"),
+                            ts,
+                            cmd_counter,
+                            response_flags,
+                        );
                         continue;
                     }
                 }
@@ -366,18 +394,26 @@ if control_echo || control_noecho {
                     let (rtx, rrx) = mpsc::channel::<bool>();
                     let _ = tx_ctrl.send(CtrlReq::FocusPaneTemp(pid, rtx));
                     if !rrx.recv_timeout(Duration::from_millis(2000)).unwrap_or(false) {
-                        let _ = writeln!(write_stream, "can't find pane: {}", pid);
-                        let _ = writeln!(write_stream, "{}", control::format_error(ts, cmd_counter, response_flags));
-                        let _ = write_stream.flush();
+                        write_control_pre_dispatch_error(
+                            &mut write_stream,
+                            &format!("can't find pane: {pid}"),
+                            ts,
+                            cmd_counter,
+                            response_flags,
+                        );
                         continue;
                     }
                 } else {
                     let (rtx, rrx) = mpsc::channel::<bool>();
                     let _ = tx_ctrl.send(CtrlReq::FocusPaneByIndexTemp(pid, rtx));
                     if !rrx.recv_timeout(Duration::from_millis(2000)).unwrap_or(false) {
-                        let _ = writeln!(write_stream, "can't find pane index: {}", pid);
-                        let _ = writeln!(write_stream, "{}", control::format_error(ts, cmd_counter, response_flags));
-                        let _ = write_stream.flush();
+                        write_control_pre_dispatch_error(
+                            &mut write_stream,
+                            &format!("can't find pane index: {pid}"),
+                            ts,
+                            cmd_counter,
+                            response_flags,
+                        );
                         continue;
                     }
                 }
@@ -2987,6 +3023,54 @@ mod tests {
                     | control::CONTROL_RESPONSE_SAFE_ENVIRONMENT_FLAG
             );
         }
+
+        drop(reader);
+        drop(client);
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn control_safe_environment_target_failure_surfaces_real_error() {
+        let (address, request_rx, server) = spawn_test_server();
+        let (mut client, mut reader) = authenticate(address);
+        negotiate_safe_environment_capability(&mut client, &mut reader, true);
+        enter_control_mode(&mut client, &mut reader, &request_rx);
+
+        writeln!(
+            client,
+            "show-environment -t %999 SYNTHETIC_TARGET"
+        )
+        .unwrap();
+        client.flush().unwrap();
+
+        let mut filter = control::ControlClientResponseFilter::default();
+        let mut begin = String::new();
+        reader.read_line(&mut begin).unwrap();
+        assert_eq!(
+            control_block_flags(&begin, "%begin"),
+            control::CONTROL_RESPONSE_DEFAULT_FLAGS
+                | control::CONTROL_RESPONSE_SAFE_ENVIRONMENT_FLAG
+        );
+        assert_eq!(filter.filter_server_line(&begin), begin);
+
+        match request_rx.recv_timeout(Duration::from_secs(2)).unwrap() {
+            CtrlReq::FocusPaneTemp(pane, response) => {
+                assert_eq!(pane, 999);
+                response.send(false).unwrap();
+            }
+            _ => panic!("expected synthetic temporary pane focus request"),
+        }
+
+        let mut error = String::new();
+        reader.read_line(&mut error).unwrap();
+        let visible_error = filter.filter_server_line(&error);
+        assert_eq!(visible_error, "can't find pane: 999\n");
+        assert!(!visible_error.contains("restart"));
+
+        let mut footer = String::new();
+        reader.read_line(&mut footer).unwrap();
+        assert!(footer.starts_with("%error "), "unexpected footer: {footer:?}");
+        assert_eq!(filter.filter_server_line(&footer), footer);
 
         drop(reader);
         drop(client);

--- a/core/src/server/connection.rs
+++ b/core/src/server/connection.rs
@@ -11,6 +11,7 @@ use crate::control;
 
 static NEXT_CLIENT_ID: AtomicU64 = AtomicU64::new(1);
 const CONTROL_COMMAND_ERROR_SENTINEL: &str = "\u{1e}winsmux-error:";
+const NON_PERSISTENT_BATCH_READ_TIMEOUT: Duration = Duration::from_millis(10);
 use crate::commands::{
     encode_safe_environment_error, encode_safe_environment_response, parse_command_line,
     SHOW_ENVIRONMENT_SAFE_CAPABILITY_FLAG, SHOW_ENVIRONMENT_SAFE_RESPONSE_FLAG,
@@ -375,6 +376,14 @@ if control_echo || control_noecho {
     let _ = tx.send(CtrlReq::ControlDeregister { client_id: ctrl_client_id });
     drop(notif_thread);
     return;
+}
+
+// Capability and mode negotiation is complete. Restore the short batching
+// timeout only for one-shot connections; persistent mode keeps its 5s timeout.
+if !persistent {
+    let _ = r
+        .get_ref()
+        .set_read_timeout(Some(NON_PERSISTENT_BATCH_READ_TIMEOUT));
 }
 
 // Check if this line is a TARGET specification
@@ -2819,5 +2828,60 @@ mod tests {
         drop(reader);
         drop(client);
         server.join().unwrap();
+    }
+
+    #[test]
+    fn capability_probe_restores_short_timeout_for_non_persistent_batching() {
+        let (address, request_rx, server) = spawn_test_server();
+        let (mut client, mut reader) = authenticate(address);
+
+        writeln!(
+            client,
+            "show-environment {SHOW_ENVIRONMENT_SAFE_CAPABILITY_FLAG}"
+        )
+        .unwrap();
+        client.flush().unwrap();
+        let mut capability = String::new();
+        reader.read_line(&mut capability).unwrap();
+        assert_eq!(
+            crate::commands::decode_safe_environment_response(&capability).unwrap(),
+            crate::commands::SafeEnvironmentResponse::Ok(String::new())
+        );
+
+        std::thread::sleep(Duration::from_millis(50));
+        writeln!(
+            client,
+            "set-environment SYNTHETIC_TIMEOUT_KEY synthetic-timeout-value"
+        )
+        .unwrap();
+        client.flush().unwrap();
+        match request_rx.recv_timeout(Duration::from_secs(2)).unwrap() {
+            CtrlReq::SetEnvironment(name, value) => {
+                assert_eq!(name, "SYNTHETIC_TIMEOUT_KEY");
+                assert_eq!(value, "synthetic-timeout-value");
+            }
+            _ => panic!("expected set-environment request"),
+        }
+
+        reader
+            .get_mut()
+            .set_read_timeout(Some(Duration::from_millis(500)))
+            .unwrap();
+        let mut trailing_output = String::new();
+        let batching_result = reader.read_to_string(&mut trailing_output);
+
+        drop(reader);
+        drop(client);
+        server.join().unwrap();
+
+        let batching_closed = match &batching_result {
+            Ok(_) => true,
+            Err(error) => error.kind() == std::io::ErrorKind::ConnectionReset,
+        };
+        assert!(
+            batching_closed,
+            "non-persistent batching should close before the 500ms client timeout: {batching_result:?}"
+        );
+        assert!(trailing_output.is_empty());
     }
 }

--- a/core/src/server/connection.rs
+++ b/core/src/server/connection.rs
@@ -513,6 +513,7 @@ if !skip_pane_focus && targeted_kill_pane_id.is_none() {
                         let _ = write!(write_stream, "can't find pane: {}\n", pid);
                         let _ = write_stream.flush();
                         if !persistent { break; }
+                        line.clear();
                         continue;
                     }
                 } else {
@@ -522,6 +523,7 @@ if !skip_pane_focus && targeted_kill_pane_id.is_none() {
                         let _ = write!(write_stream, "can't find pane index: {}\n", pid);
                         let _ = write_stream.flush();
                         if !persistent { break; }
+                        line.clear();
                         continue;
                     }
                 }
@@ -533,6 +535,7 @@ if !skip_pane_focus && targeted_kill_pane_id.is_none() {
                         let _ = write!(write_stream, "can't find pane: {}\n", pid);
                         let _ = write_stream.flush();
                         if !persistent { break; }
+                        line.clear();
                         continue;
                     }
                 } else {
@@ -542,6 +545,7 @@ if !skip_pane_focus && targeted_kill_pane_id.is_none() {
                         let _ = write!(write_stream, "can't find pane index: {}\n", pid);
                         let _ = write_stream.flush();
                         if !persistent { break; }
+                        line.clear();
                         continue;
                     }
                 }
@@ -1429,6 +1433,7 @@ match cmd {
         if args.contains(&SHOW_ENVIRONMENT_SAFE_CAPABILITY_FLAG) {
             let _ = write!(write_stream, "{}", encode_safe_environment_response(""));
             let _ = write_stream.flush();
+            line.clear();
             continue;
         }
         let safe_response_requested = args.contains(&SHOW_ENVIRONMENT_SAFE_RESPONSE_FLAG);
@@ -2797,6 +2802,128 @@ mod tests {
             )
         );
         assert!(dispatcher.join().unwrap());
+    }
+
+    #[test]
+    fn persistent_in_loop_capability_probe_is_consumed_once() {
+        let (address, request_rx, server) = spawn_test_server();
+        let (mut client, mut reader) = authenticate(address);
+        reader
+            .get_mut()
+            .set_read_timeout(Some(Duration::from_secs(2)))
+            .unwrap();
+
+        write!(
+            client,
+            "PERSISTENT\nshow-environment {SHOW_ENVIRONMENT_SAFE_CAPABILITY_FLAG}\n"
+        )
+        .unwrap();
+        client.flush().unwrap();
+
+        let mut capability = String::new();
+        reader.read_line(&mut capability).unwrap();
+        assert_eq!(
+            crate::commands::decode_safe_environment_response(&capability).unwrap(),
+            crate::commands::SafeEnvironmentResponse::Ok(String::new())
+        );
+
+        reader
+            .get_mut()
+            .set_read_timeout(Some(Duration::from_millis(100)))
+            .unwrap();
+        let mut repeated_capability = String::new();
+        let second_read = reader.read_line(&mut repeated_capability);
+        assert!(
+            matches!(
+                &second_read,
+                Err(error)
+                    if error.kind() == io::ErrorKind::WouldBlock
+                        || error.kind() == io::ErrorKind::TimedOut
+            ),
+            "capability probe must produce exactly one response while the client is idle: {second_read:?}, {} unexpected bytes",
+            repeated_capability.len()
+        );
+        assert!(
+            repeated_capability.is_empty(),
+            "idle connection received {} partial capability bytes",
+            repeated_capability.len()
+        );
+
+        writeln!(client, "client-attach").unwrap();
+        client.flush().unwrap();
+        assert!(matches!(
+            request_rx.recv_timeout(Duration::from_secs(2)).unwrap(),
+            CtrlReq::ClientAttach(_)
+        ));
+
+        drop(reader);
+        drop(client);
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn persistent_focus_failure_lines_are_consumed_before_retry() {
+        let cases = [
+            ("select-pane -t %901", true, true, 901),
+            ("select-pane -t .902", true, false, 902),
+            ("synthetic-noop -t %903", false, true, 903),
+            ("synthetic-noop -t .904", false, false, 904),
+        ];
+
+        for (command, focus_command, pane_is_id, expected_pane) in cases {
+            let (address, request_rx, server) = spawn_test_server();
+            let (mut client, mut reader) = authenticate(address);
+
+            write!(client, "PERSISTENT\n{command}\n").unwrap();
+            client.flush().unwrap();
+
+            let focus_request = request_rx.recv_timeout(Duration::from_secs(2)).unwrap();
+            match (focus_command, pane_is_id, focus_request) {
+                (true, true, CtrlReq::FocusPaneChecked(pane, response)) => {
+                    assert_eq!(pane, expected_pane);
+                    response.send(false).unwrap();
+                }
+                (true, false, CtrlReq::FocusPaneByIndexChecked(pane, response)) => {
+                    assert_eq!(pane, expected_pane);
+                    response.send(false).unwrap();
+                }
+                (false, true, CtrlReq::FocusPaneTemp(pane, response)) => {
+                    assert_eq!(pane, expected_pane);
+                    response.send(false).unwrap();
+                }
+                (false, false, CtrlReq::FocusPaneByIndexTemp(pane, response)) => {
+                    assert_eq!(pane, expected_pane);
+                    response.send(false).unwrap();
+                }
+                _ => panic!("unexpected synthetic focus request for {command}"),
+            }
+
+            let mut error_line = String::new();
+            reader.read_line(&mut error_line).unwrap();
+            assert_eq!(
+                error_line,
+                if pane_is_id {
+                    format!("can't find pane: {expected_pane}\n")
+                } else {
+                    format!("can't find pane index: {expected_pane}\n")
+                }
+            );
+            assert!(matches!(
+                request_rx.recv_timeout(Duration::from_millis(100)),
+                Err(mpsc::RecvTimeoutError::Timeout)
+            ));
+
+            writeln!(client, "client-attach").unwrap();
+            client.flush().unwrap();
+            assert!(matches!(
+                request_rx.recv_timeout(Duration::from_secs(2)).unwrap(),
+                CtrlReq::ClientAttach(_)
+            ));
+
+            drop(reader);
+            drop(client);
+            server.join().unwrap();
+        }
     }
 
     #[test]

--- a/core/src/server/connection.rs
+++ b/core/src/server/connection.rs
@@ -10,13 +10,34 @@ use crate::util::base64_decode;
 use crate::control;
 
 static NEXT_CLIENT_ID: AtomicU64 = AtomicU64::new(1);
-const CONTROL_COMMAND_ERROR_SENTINEL: &str = "\u{1e}winsmux-error:";
 const NON_PERSISTENT_BATCH_READ_TIMEOUT: Duration = Duration::from_millis(10);
 use crate::commands::{
     encode_safe_environment_error, encode_safe_environment_response, parse_command_line,
     SHOW_ENVIRONMENT_SAFE_CAPABILITY_FLAG, SHOW_ENVIRONMENT_SAFE_RESPONSE_FLAG,
 };
 use super::helpers::TMUX_COMMANDS;
+
+#[derive(Debug, Eq, PartialEq)]
+enum ControlCommandResult {
+    Success(String),
+    Error(String),
+}
+
+struct ControlCommandResponseSender(mpsc::Sender<ControlCommandResult>);
+
+impl ControlCommandResponseSender {
+    fn new(sender: mpsc::Sender<ControlCommandResult>) -> Self {
+        Self(sender)
+    }
+
+    fn send(&self, response: String) -> Result<(), mpsc::SendError<ControlCommandResult>> {
+        self.0.send(ControlCommandResult::Success(response))
+    }
+
+    fn send_error(&self, error: String) -> Result<(), mpsc::SendError<ControlCommandResult>> {
+        self.0.send(ControlCommandResult::Error(error))
+    }
+}
 
 /// Handle a single TCP connection from a client.
 /// Parses auth, optional TARGET/PERSISTENT flags, then dispatches commands
@@ -332,9 +353,9 @@ if control_echo || control_noecho {
         }
 
         // Dispatch command (use a oneshot for the response)
-        let (resp_s, resp_r) = mpsc::channel::<String>();
+        let (resp_s, resp_r) = mpsc::channel::<ControlCommandResult>();
         let dispatched = dispatch_control_command(
-            cmd_name, &filtered_args, &tx_ctrl, resp_s,
+            cmd_name, &filtered_args, &tx_ctrl, ControlCommandResponseSender::new(resp_s),
             safe_environment_capability_negotiated,
             ctrl_target_pane, ctrl_pane_is_id, ctrl_raw_target.as_deref(),
             ctrl_client_id,
@@ -343,22 +364,21 @@ if control_echo || control_noecho {
         if dispatched {
             // Wait for response with timeout
             match resp_r.recv_timeout(Duration::from_secs(5)) {
-                Ok(response) => {
-                    if let Some(error) = response.strip_prefix(CONTROL_COMMAND_ERROR_SENTINEL) {
-                        let _ = write!(write_stream, "{error}");
-                        if !error.ends_with('\n') {
+                Ok(ControlCommandResult::Error(error)) => {
+                    let _ = write!(write_stream, "{error}");
+                    if !error.ends_with('\n') {
+                        let _ = writeln!(write_stream);
+                    }
+                    let _ = writeln!(write_stream, "{}", control::format_error(ts, cmd_counter));
+                }
+                Ok(ControlCommandResult::Success(response)) => {
+                    if !response.is_empty() {
+                        let _ = write!(write_stream, "{}", response);
+                        if !response.ends_with('\n') {
                             let _ = writeln!(write_stream);
                         }
-                        let _ = writeln!(write_stream, "{}", control::format_error(ts, cmd_counter));
-                    } else {
-                        if !response.is_empty() {
-                            let _ = write!(write_stream, "{}", response);
-                            if !response.ends_with('\n') {
-                                let _ = writeln!(write_stream);
-                            }
-                        }
-                        let _ = writeln!(write_stream, "{}", control::format_end(ts, cmd_counter));
                     }
+                    let _ = writeln!(write_stream, "{}", control::format_end(ts, cmd_counter));
                 }
                 Err(_) => {
                     let _ = writeln!(write_stream, "command timed out");
@@ -1914,7 +1934,7 @@ fn dispatch_control_command(
     cmd: &str,
     args: &[&str],
     tx: &mpsc::Sender<CtrlReq>,
-    resp_tx: mpsc::Sender<String>,
+    resp_tx: ControlCommandResponseSender,
     safe_environment_capability_negotiated: bool,
     target_pane: Option<usize>,
     pane_is_id: bool,
@@ -2315,18 +2335,20 @@ fn dispatch_control_command(
             let (rtx, rrx) = mpsc::channel::<Result<String, String>>();
             let _ = tx.send(CtrlReq::ShowEnvironment(requested_name, rtx));
             if let Ok(result) = rrx.recv_timeout(Duration::from_secs(5)) {
-                let response = match result {
+                match result {
                     Ok(text) if safe_response_requested => {
-                        encode_safe_environment_response(&text)
+                        let _ = resp_tx.send(encode_safe_environment_response(&text));
                     }
-                    Ok(text) => text,
-                    Err(error) if safe_response_requested => format!(
-                        "{CONTROL_COMMAND_ERROR_SENTINEL}{}",
-                        encode_safe_environment_error(&error)
-                    ),
-                    Err(error) => format!("{CONTROL_COMMAND_ERROR_SENTINEL}{error}"),
-                };
-                let _ = resp_tx.send(response);
+                    Ok(text) => {
+                        let _ = resp_tx.send(text);
+                    }
+                    Err(error) if safe_response_requested => {
+                        let _ = resp_tx.send_error(encode_safe_environment_error(&error));
+                    }
+                    Err(error) => {
+                        let _ = resp_tx.send_error(error);
+                    }
+                }
             }
             true
         }
@@ -2576,6 +2598,23 @@ mod tests {
         }
     }
 
+    fn enter_control_mode(
+        client: &mut std::net::TcpStream,
+        reader: &mut BufReader<std::net::TcpStream>,
+        request_rx: &mpsc::Receiver<CtrlReq>,
+    ) {
+        writeln!(client, "CONTROL_NOECHO").unwrap();
+        client.flush().unwrap();
+
+        let mut ready = String::new();
+        reader.read_line(&mut ready).unwrap();
+        assert_eq!(ready, "\n");
+        assert!(matches!(
+            request_rx.recv_timeout(Duration::from_secs(2)).unwrap(),
+            CtrlReq::ControlRegister { echo: false, .. }
+        ));
+    }
+
     fn synthetic_full_environment_output() -> String {
         let mut environment = HashMap::new();
         environment.insert(
@@ -2721,7 +2760,7 @@ mod tests {
                 "show-environment",
                 &["TARGET_VAR"],
                 &request_tx,
-                response_tx,
+                ControlCommandResponseSender::new(response_tx),
                 true,
                 None,
                 false,
@@ -2731,7 +2770,10 @@ mod tests {
         });
 
         answer_show_environment(&request_rx, Some("TARGET_VAR"), Ok(expected.clone()));
-        let response = response_rx.recv_timeout(Duration::from_secs(2)).unwrap();
+        let response = match response_rx.recv_timeout(Duration::from_secs(2)).unwrap() {
+            ControlCommandResult::Success(response) => response,
+            ControlCommandResult::Error(error) => panic!("unexpected control error: {error}"),
+        };
         assert_eq!(
             crate::commands::decode_safe_environment_response(&response).unwrap(),
             crate::commands::SafeEnvironmentResponse::Ok(expected)
@@ -2749,7 +2791,7 @@ mod tests {
                 "show-environment",
                 &[],
                 &request_tx,
-                response_tx,
+                ControlCommandResponseSender::new(response_tx),
                 true,
                 None,
                 false,
@@ -2759,7 +2801,10 @@ mod tests {
         });
 
         answer_show_environment(&request_rx, None, Ok(expected.clone()));
-        let response = response_rx.recv_timeout(Duration::from_secs(2)).unwrap();
+        let response = match response_rx.recv_timeout(Duration::from_secs(2)).unwrap() {
+            ControlCommandResult::Success(response) => response,
+            ControlCommandResult::Error(error) => panic!("unexpected control error: {error}"),
+        };
         assert_eq!(
             crate::commands::decode_safe_environment_response(&response).unwrap(),
             crate::commands::SafeEnvironmentResponse::Ok(expected)
@@ -2777,7 +2822,7 @@ mod tests {
                 "show-environment",
                 &["MISSING_VAR"],
                 &request_tx,
-                response_tx,
+                ControlCommandResponseSender::new(response_tx),
                 true,
                 None,
                 false,
@@ -2791,10 +2836,12 @@ mod tests {
             Some("MISSING_VAR"),
             Err("unknown variable: MISSING_VAR".to_string()),
         );
-        let response = response_rx.recv_timeout(Duration::from_secs(2)).unwrap();
-        let response = response
-            .strip_prefix(CONTROL_COMMAND_ERROR_SENTINEL)
-            .expect("negotiated control errors must retain control error status");
+        let response = match response_rx.recv_timeout(Duration::from_secs(2)).unwrap() {
+            ControlCommandResult::Error(response) => response,
+            ControlCommandResult::Success(response) => {
+                panic!("expected control error, got success: {response}")
+            }
+        };
         assert_eq!(
             crate::commands::decode_safe_environment_response(&response).unwrap(),
             crate::commands::SafeEnvironmentResponse::Error(
@@ -2802,6 +2849,70 @@ mod tests {
             )
         );
         assert!(dispatcher.join().unwrap());
+    }
+
+    #[test]
+    fn control_output_starting_with_former_error_sentinel_is_success() {
+        let (address, request_rx, server) = spawn_test_server();
+        let (mut client, mut reader) = authenticate(address);
+        enter_control_mode(&mut client, &mut reader, &request_rx);
+
+        writeln!(client, "show-buffer").unwrap();
+        client.flush().unwrap();
+
+        let mut begin = String::new();
+        reader.read_line(&mut begin).unwrap();
+        assert!(begin.starts_with("%begin "), "unexpected begin line: {begin:?}");
+
+        let expected = "\u{1e}winsmux-error:synthetic successful output";
+        match request_rx.recv_timeout(Duration::from_secs(2)).unwrap() {
+            CtrlReq::ShowBuffer(sender) => sender.send(expected.to_string()).unwrap(),
+            _ => panic!("expected show-buffer request"),
+        }
+
+        let mut output = String::new();
+        reader.read_line(&mut output).unwrap();
+        assert_eq!(output, format!("{expected}\n"));
+
+        let mut footer = String::new();
+        reader.read_line(&mut footer).unwrap();
+        assert!(footer.starts_with("%end "), "unexpected footer: {footer:?}");
+
+        drop(reader);
+        drop(client);
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn control_command_error_still_emits_error_footer() {
+        let (address, request_rx, server) = spawn_test_server();
+        let (mut client, mut reader) = authenticate(address);
+        enter_control_mode(&mut client, &mut reader, &request_rx);
+
+        writeln!(client, "show-environment SYNTHETIC_MISSING_VAR").unwrap();
+        client.flush().unwrap();
+
+        let mut begin = String::new();
+        reader.read_line(&mut begin).unwrap();
+        assert!(begin.starts_with("%begin "), "unexpected begin line: {begin:?}");
+
+        answer_show_environment(
+            &request_rx,
+            Some("SYNTHETIC_MISSING_VAR"),
+            Err("unknown variable: SYNTHETIC_MISSING_VAR".to_string()),
+        );
+
+        let mut error = String::new();
+        reader.read_line(&mut error).unwrap();
+        assert_eq!(error, "unknown variable: SYNTHETIC_MISSING_VAR\n");
+
+        let mut footer = String::new();
+        reader.read_line(&mut footer).unwrap();
+        assert!(footer.starts_with("%error "), "unexpected footer: {footer:?}");
+
+        drop(reader);
+        drop(client);
+        server.join().unwrap();
     }
 
     #[test]

--- a/core/src/server/connection.rs
+++ b/core/src/server/connection.rs
@@ -10,7 +10,11 @@ use crate::util::base64_decode;
 use crate::control;
 
 static NEXT_CLIENT_ID: AtomicU64 = AtomicU64::new(1);
-use crate::commands::parse_command_line;
+const CONTROL_COMMAND_ERROR_SENTINEL: &str = "\u{1e}winsmux-error:";
+use crate::commands::{
+    encode_safe_environment_error, encode_safe_environment_response, parse_command_line,
+    SHOW_ENVIRONMENT_SAFE_CAPABILITY_FLAG, SHOW_ENVIRONMENT_SAFE_RESPONSE_FLAG,
+};
 use super::helpers::TMUX_COMMANDS;
 
 /// Handle a single TCP connection from a client.
@@ -59,8 +63,8 @@ if provided_key != session_key {
 let _ = write_stream.write_all(b"OK\n");
 let _ = write_stream.flush();
 
-// Set short read timeout for batched command processing
-let _ = r.get_ref().set_read_timeout(Some(Duration::from_millis(10)));
+// Keep the authentication-scale timeout through capability and mode negotiation.
+// Persistent and control modes install their own steady-state timeout below.
 
 // Check for PERSISTENT flag and optional TARGET line
 let mut persistent = false;
@@ -69,8 +73,22 @@ let mut global_target_win: Option<usize> = None;
 let mut global_target_pane: Option<usize> = None;
 let mut global_pane_is_id = false;
 let mut line = String::new();
+let mut safe_environment_capability_negotiated = false;
 if r.read_line(&mut line).is_err() {
     return;
+}
+
+let safe_capability_command = format!(
+    "show-environment {SHOW_ENVIRONMENT_SAFE_CAPABILITY_FLAG}"
+);
+if line.trim() == safe_capability_command {
+    safe_environment_capability_negotiated = true;
+    let _ = write!(write_stream, "{}", encode_safe_environment_response(""));
+    let _ = write_stream.flush();
+    line.clear();
+    if r.read_line(&mut line).is_err() {
+        return;
+    }
 }
 
 // Check if client requests persistent connection mode
@@ -316,6 +334,7 @@ if control_echo || control_noecho {
         let (resp_s, resp_r) = mpsc::channel::<String>();
         let dispatched = dispatch_control_command(
             cmd_name, &filtered_args, &tx_ctrl, resp_s,
+            safe_environment_capability_negotiated,
             ctrl_target_pane, ctrl_pane_is_id, ctrl_raw_target.as_deref(),
             ctrl_client_id,
         );
@@ -324,13 +343,21 @@ if control_echo || control_noecho {
             // Wait for response with timeout
             match resp_r.recv_timeout(Duration::from_secs(5)) {
                 Ok(response) => {
-                    if !response.is_empty() {
-                        let _ = write!(write_stream, "{}", response);
-                        if !response.ends_with('\n') {
+                    if let Some(error) = response.strip_prefix(CONTROL_COMMAND_ERROR_SENTINEL) {
+                        let _ = write!(write_stream, "{error}");
+                        if !error.ends_with('\n') {
                             let _ = writeln!(write_stream);
                         }
+                        let _ = writeln!(write_stream, "{}", control::format_error(ts, cmd_counter));
+                    } else {
+                        if !response.is_empty() {
+                            let _ = write!(write_stream, "{}", response);
+                            if !response.ends_with('\n') {
+                                let _ = writeln!(write_stream);
+                            }
+                        }
+                        let _ = writeln!(write_stream, "{}", control::format_end(ts, cmd_counter));
                     }
-                    let _ = writeln!(write_stream, "{}", control::format_end(ts, cmd_counter));
                 }
                 Err(_) => {
                     let _ = writeln!(write_stream, "command timed out");
@@ -1390,13 +1417,47 @@ match cmd {
         }
     }
     "show-environment" | "showenv" => {
-        let (rtx, rrx) = mpsc::channel::<String>();
-        let _ = tx.send(CtrlReq::ShowEnvironment(rtx));
-        if let Ok(text) = rrx.recv() {
-            if persistent {
-                let _ = tx.send(CtrlReq::ShowTextPopup("show-environment".to_string(), text));
-            } else {
-                let _ = write!(write_stream, "{}\n", text); let _ = write_stream.flush();
+        if args.contains(&SHOW_ENVIRONMENT_SAFE_CAPABILITY_FLAG) {
+            let _ = write!(write_stream, "{}", encode_safe_environment_response(""));
+            let _ = write_stream.flush();
+            continue;
+        }
+        let safe_response_requested = args.contains(&SHOW_ENVIRONMENT_SAFE_RESPONSE_FLAG);
+        let requested_name = crate::commands::parse_show_environment_name(&args);
+        let (rtx, rrx) = mpsc::channel::<Result<String, String>>();
+        let _ = tx.send(CtrlReq::ShowEnvironment(requested_name, rtx));
+        if let Ok(result) = rrx.recv() {
+            match result {
+                Ok(text) if persistent => {
+                    // Persistent clients already passed the structured capability
+                    // handshake before entering this mode. Keep popup text raw so
+                    // multiline values render normally instead of exposing a wire frame.
+                    let _ = tx.send(CtrlReq::ShowTextPopup("show-environment".to_string(), text));
+                }
+                Ok(text) => {
+                    if safe_response_requested {
+                        let response = encode_safe_environment_response(&text);
+                        let _ = write!(write_stream, "{response}");
+                    } else {
+                        let _ = write!(write_stream, "{}\n", text);
+                    }
+                    let _ = write_stream.flush();
+                }
+                Err(error) if persistent => {
+                    let _ = tx.send(CtrlReq::ShowTextPopup(
+                        "show-environment".to_string(),
+                        format!("error: {error}\n"),
+                    ));
+                }
+                Err(error) => {
+                    let response = if safe_response_requested {
+                        encode_safe_environment_error(&error)
+                    } else {
+                        format!("ERROR: {error}\n")
+                    };
+                    let _ = write!(write_stream, "{response}");
+                    let _ = write_stream.flush();
+                }
             }
         }
         if !persistent { break; }
@@ -1840,6 +1901,7 @@ fn dispatch_control_command(
     args: &[&str],
     tx: &mpsc::Sender<CtrlReq>,
     resp_tx: mpsc::Sender<String>,
+    safe_environment_capability_negotiated: bool,
     target_pane: Option<usize>,
     pane_is_id: bool,
     _raw_target: Option<&str>,
@@ -2227,10 +2289,30 @@ fn dispatch_control_command(
             true
         }
         "show-environment" | "showenv" => {
-            let (rtx, rrx) = mpsc::channel::<String>();
-            let _ = tx.send(CtrlReq::ShowEnvironment(rtx));
-            if let Ok(text) = rrx.recv_timeout(Duration::from_secs(5)) {
-                let _ = resp_tx.send(text);
+            if args.contains(&SHOW_ENVIRONMENT_SAFE_CAPABILITY_FLAG) {
+                let _ = resp_tx.send(encode_safe_environment_response(""));
+                return true;
+            }
+            // Negotiation covers both named lookups and no-argument full listings.
+            // Neither response may fall back to an unframed client-visible payload.
+            let safe_response_requested = safe_environment_capability_negotiated
+                || args.contains(&SHOW_ENVIRONMENT_SAFE_RESPONSE_FLAG);
+            let requested_name = crate::commands::parse_show_environment_name(args);
+            let (rtx, rrx) = mpsc::channel::<Result<String, String>>();
+            let _ = tx.send(CtrlReq::ShowEnvironment(requested_name, rtx));
+            if let Ok(result) = rrx.recv_timeout(Duration::from_secs(5)) {
+                let response = match result {
+                    Ok(text) if safe_response_requested => {
+                        encode_safe_environment_response(&text)
+                    }
+                    Ok(text) => text,
+                    Err(error) if safe_response_requested => format!(
+                        "{CONTROL_COMMAND_ERROR_SENTINEL}{}",
+                        encode_safe_environment_error(&error)
+                    ),
+                    Err(error) => format!("{CONTROL_COMMAND_ERROR_SENTINEL}{error}"),
+                };
+                let _ = resp_tx.send(response);
             }
             true
         }
@@ -2422,5 +2504,320 @@ fn dispatch_control_command(
             let _ = resp_tx.send(format!("unknown command: {}", cmd));
             true
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use std::io::{BufRead, BufReader, Read, Write};
+    use std::sync::{Arc, RwLock};
+
+    fn spawn_test_server() -> (
+        std::net::SocketAddr,
+        mpsc::Receiver<CtrlReq>,
+        std::thread::JoinHandle<()>,
+    ) {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let (request_tx, request_rx) = mpsc::channel();
+        let server = std::thread::spawn(move || {
+            let (stream, _) = listener.accept().unwrap();
+            handle_connection(
+                stream,
+                request_tx,
+                "synthetic-session-key",
+                Arc::new(RwLock::new(HashMap::new())),
+            );
+        });
+        (address, request_rx, server)
+    }
+
+    fn authenticate(address: std::net::SocketAddr) -> (std::net::TcpStream, BufReader<std::net::TcpStream>) {
+        let mut client = std::net::TcpStream::connect(address).unwrap();
+        client
+            .set_read_timeout(Some(Duration::from_secs(2)))
+            .unwrap();
+        let mut reader = BufReader::new(client.try_clone().unwrap());
+        writeln!(client, "AUTH synthetic-session-key").unwrap();
+        client.flush().unwrap();
+        let mut auth = String::new();
+        reader.read_line(&mut auth).unwrap();
+        assert_eq!(auth, "OK\n");
+        (client, reader)
+    }
+
+    fn answer_show_environment(
+        request_rx: &mpsc::Receiver<CtrlReq>,
+        expected_name: Option<&str>,
+        response: Result<String, String>,
+    ) {
+        match request_rx.recv_timeout(Duration::from_secs(2)).unwrap() {
+            CtrlReq::ShowEnvironment(name, sender) => {
+                assert_eq!(name.as_deref(), expected_name);
+                sender.send(response).unwrap();
+            }
+            _ => panic!("expected show-environment request"),
+        }
+    }
+
+    fn synthetic_full_environment_output() -> String {
+        let mut environment = HashMap::new();
+        environment.insert(
+            "SAFE_VAR".to_string(),
+            "first line\r\nsecond 行 🚀\n".to_string(),
+        );
+        environment.insert(
+            "GH_TOKEN".to_string(),
+            "synthetic-secret-value".to_string(),
+        );
+        let output = crate::commands::format_environment_output(&environment, None).unwrap();
+        assert!(output.contains("SAFE_VAR=first line\r\nsecond 行 🚀\n"));
+        assert!(output.contains("GH_TOKEN=[redacted]"));
+        assert!(!output.contains("synthetic-secret-value"));
+        output
+    }
+
+    #[test]
+    fn direct_named_environment_frame_round_trips_multiline_utf8() {
+        let (address, request_rx, server) = spawn_test_server();
+        let (mut client, mut reader) = authenticate(address);
+        let expected = "TARGET_VAR=first line\r\nsecond 行 🚀\n\n".to_string();
+
+        writeln!(
+            client,
+            "show-environment {SHOW_ENVIRONMENT_SAFE_RESPONSE_FLAG} TARGET_VAR"
+        )
+        .unwrap();
+        client.flush().unwrap();
+        answer_show_environment(&request_rx, Some("TARGET_VAR"), Ok(expected.clone()));
+
+        let mut response = String::new();
+        reader.read_to_string(&mut response).unwrap();
+        assert_eq!(
+            crate::commands::decode_safe_environment_response(&response).unwrap(),
+            crate::commands::SafeEnvironmentResponse::Ok(expected)
+        );
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn direct_full_environment_frame_round_trips_redacted_multiline_utf8() {
+        let (address, request_rx, server) = spawn_test_server();
+        let (mut client, mut reader) = authenticate(address);
+        let expected = synthetic_full_environment_output();
+
+        writeln!(
+            client,
+            "show-environment {SHOW_ENVIRONMENT_SAFE_RESPONSE_FLAG}"
+        )
+        .unwrap();
+        client.flush().unwrap();
+        answer_show_environment(&request_rx, None, Ok(expected.clone()));
+
+        let mut response = String::new();
+        reader.read_to_string(&mut response).unwrap();
+        assert_eq!(
+            crate::commands::decode_safe_environment_response(&response).unwrap(),
+            crate::commands::SafeEnvironmentResponse::Ok(expected)
+        );
+        assert!(!response.contains("synthetic-secret-value"));
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn persistent_named_environment_popup_round_trips_multiline_utf8() {
+        let (address, request_rx, server) = spawn_test_server();
+        let (mut client, mut reader) = authenticate(address);
+        let expected = "TARGET_VAR=first line\nsecond 行 🚀\n".to_string();
+
+        writeln!(
+            client,
+            "show-environment {SHOW_ENVIRONMENT_SAFE_CAPABILITY_FLAG}"
+        )
+        .unwrap();
+        client.flush().unwrap();
+        let mut capability = String::new();
+        reader.read_line(&mut capability).unwrap();
+        assert_eq!(
+            crate::commands::decode_safe_environment_response(&capability).unwrap(),
+            crate::commands::SafeEnvironmentResponse::Ok(String::new())
+        );
+
+        write!(client, "PERSISTENT\nshow-environment TARGET_VAR\n").unwrap();
+        client.flush().unwrap();
+        answer_show_environment(&request_rx, Some("TARGET_VAR"), Ok(expected.clone()));
+        match request_rx.recv_timeout(Duration::from_secs(2)).unwrap() {
+            CtrlReq::ShowTextPopup(title, text) => {
+                assert_eq!(title, "show-environment");
+                assert_eq!(text, expected);
+            }
+            _ => panic!("expected persistent show-environment popup"),
+        }
+
+        drop(reader);
+        drop(client);
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn persistent_full_environment_popup_uses_redacted_server_output() {
+        let (address, request_rx, server) = spawn_test_server();
+        let (mut client, mut reader) = authenticate(address);
+        let expected = synthetic_full_environment_output();
+
+        writeln!(
+            client,
+            "show-environment {SHOW_ENVIRONMENT_SAFE_CAPABILITY_FLAG}"
+        )
+        .unwrap();
+        client.flush().unwrap();
+        let mut capability = String::new();
+        reader.read_line(&mut capability).unwrap();
+        assert_eq!(
+            crate::commands::decode_safe_environment_response(&capability).unwrap(),
+            crate::commands::SafeEnvironmentResponse::Ok(String::new())
+        );
+
+        write!(client, "PERSISTENT\nshow-environment\n").unwrap();
+        client.flush().unwrap();
+        answer_show_environment(&request_rx, None, Ok(expected.clone()));
+        match request_rx.recv_timeout(Duration::from_secs(2)).unwrap() {
+            CtrlReq::ShowTextPopup(title, text) => {
+                assert_eq!(title, "show-environment");
+                assert_eq!(text, expected);
+                assert!(!text.contains("synthetic-secret-value"));
+            }
+            _ => panic!("expected persistent show-environment popup"),
+        }
+
+        drop(reader);
+        drop(client);
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn control_named_environment_frame_round_trips_multiline_utf8() {
+        let (request_tx, request_rx) = mpsc::channel();
+        let (response_tx, response_rx) = mpsc::channel();
+        let expected = "TARGET_VAR=first line\nsecond 行 🚀\n".to_string();
+        let dispatcher = std::thread::spawn(move || {
+            dispatch_control_command(
+                "show-environment",
+                &["TARGET_VAR"],
+                &request_tx,
+                response_tx,
+                true,
+                None,
+                false,
+                None,
+                1,
+            )
+        });
+
+        answer_show_environment(&request_rx, Some("TARGET_VAR"), Ok(expected.clone()));
+        let response = response_rx.recv_timeout(Duration::from_secs(2)).unwrap();
+        assert_eq!(
+            crate::commands::decode_safe_environment_response(&response).unwrap(),
+            crate::commands::SafeEnvironmentResponse::Ok(expected)
+        );
+        assert!(dispatcher.join().unwrap());
+    }
+
+    #[test]
+    fn control_full_environment_frame_round_trips_redacted_multiline_utf8() {
+        let (request_tx, request_rx) = mpsc::channel();
+        let (response_tx, response_rx) = mpsc::channel();
+        let expected = synthetic_full_environment_output();
+        let dispatcher = std::thread::spawn(move || {
+            dispatch_control_command(
+                "show-environment",
+                &[],
+                &request_tx,
+                response_tx,
+                true,
+                None,
+                false,
+                None,
+                1,
+            )
+        });
+
+        answer_show_environment(&request_rx, None, Ok(expected.clone()));
+        let response = response_rx.recv_timeout(Duration::from_secs(2)).unwrap();
+        assert_eq!(
+            crate::commands::decode_safe_environment_response(&response).unwrap(),
+            crate::commands::SafeEnvironmentResponse::Ok(expected)
+        );
+        assert!(!response.contains("synthetic-secret-value"));
+        assert!(dispatcher.join().unwrap());
+    }
+
+    #[test]
+    fn control_named_environment_error_uses_structured_status() {
+        let (request_tx, request_rx) = mpsc::channel();
+        let (response_tx, response_rx) = mpsc::channel();
+        let dispatcher = std::thread::spawn(move || {
+            dispatch_control_command(
+                "show-environment",
+                &["MISSING_VAR"],
+                &request_tx,
+                response_tx,
+                true,
+                None,
+                false,
+                None,
+                1,
+            )
+        });
+
+        answer_show_environment(
+            &request_rx,
+            Some("MISSING_VAR"),
+            Err("unknown variable: MISSING_VAR".to_string()),
+        );
+        let response = response_rx.recv_timeout(Duration::from_secs(2)).unwrap();
+        let response = response
+            .strip_prefix(CONTROL_COMMAND_ERROR_SENTINEL)
+            .expect("negotiated control errors must retain control error status");
+        assert_eq!(
+            crate::commands::decode_safe_environment_response(&response).unwrap(),
+            crate::commands::SafeEnvironmentResponse::Error(
+                "unknown variable: MISSING_VAR".to_string()
+            )
+        );
+        assert!(dispatcher.join().unwrap());
+    }
+
+    #[test]
+    fn capability_probe_allows_delayed_persistent_mode_negotiation() {
+        let (address, request_rx, server) = spawn_test_server();
+        let (mut client, mut reader) = authenticate(address);
+
+        writeln!(
+            client,
+            "show-environment {SHOW_ENVIRONMENT_SAFE_CAPABILITY_FLAG}"
+        )
+        .unwrap();
+        client.flush().unwrap();
+        let mut capability = String::new();
+        reader.read_line(&mut capability).unwrap();
+        assert_eq!(
+            crate::commands::decode_safe_environment_response(&capability).unwrap(),
+            crate::commands::SafeEnvironmentResponse::Ok(String::new())
+        );
+
+        std::thread::sleep(Duration::from_millis(50));
+        write!(client, "PERSISTENT\nclient-attach\n").unwrap();
+        client.flush().unwrap();
+        assert!(matches!(
+            request_rx.recv_timeout(Duration::from_secs(2)).unwrap(),
+            CtrlReq::ClientAttach(_)
+        ));
+
+        drop(reader);
+        drop(client);
+        server.join().unwrap();
     }
 }

--- a/core/src/server/connection.rs
+++ b/core/src/server/connection.rs
@@ -40,11 +40,9 @@ impl ControlCommandResponseSender {
     }
 }
 
-fn write_control_pre_dispatch_error(
+fn write_control_error_payload(
     write_stream: &mut TcpStream,
     error: &str,
-    timestamp: i64,
-    command_number: u64,
     response_flags: u64,
 ) {
     if response_flags & control::CONTROL_RESPONSE_SAFE_ENVIRONMENT_FLAG != 0 {
@@ -52,6 +50,16 @@ fn write_control_pre_dispatch_error(
     } else {
         let _ = writeln!(write_stream, "{error}");
     }
+}
+
+fn write_control_pre_dispatch_error(
+    write_stream: &mut TcpStream,
+    error: &str,
+    timestamp: i64,
+    command_number: u64,
+    response_flags: u64,
+) {
+    write_control_error_payload(write_stream, error, response_flags);
     let _ = writeln!(
         write_stream,
         "{}",
@@ -449,7 +457,11 @@ if control_echo || control_noecho {
                     let _ = writeln!(write_stream, "{}", control::format_end(ts, cmd_counter, response_flags));
                 }
                 Err(_) => {
-                    let _ = writeln!(write_stream, "command timed out");
+                    write_control_error_payload(
+                        &mut write_stream,
+                        "command timed out",
+                        response_flags,
+                    );
                     let _ = writeln!(write_stream, "{}", control::format_error(ts, cmd_counter, response_flags));
                 }
             }
@@ -3065,6 +3077,99 @@ mod tests {
         reader.read_line(&mut error).unwrap();
         let visible_error = filter.filter_server_line(&error);
         assert_eq!(visible_error, "can't find pane: 999\n");
+        assert!(!visible_error.contains("restart"));
+
+        let mut footer = String::new();
+        reader.read_line(&mut footer).unwrap();
+        assert!(footer.starts_with("%error "), "unexpected footer: {footer:?}");
+        assert_eq!(filter.filter_server_line(&footer), footer);
+
+        drop(reader);
+        drop(client);
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn control_safe_environment_timeout_surfaces_real_error() {
+        let (address, request_rx, server) = spawn_test_server();
+        let (mut client, mut reader) = authenticate(address);
+        negotiate_safe_environment_capability(&mut client, &mut reader, true);
+        enter_control_mode(&mut client, &mut reader, &request_rx);
+        reader
+            .get_mut()
+            .set_read_timeout(Some(Duration::from_secs(7)))
+            .unwrap();
+
+        writeln!(client, "show-environment SYNTHETIC_TIMEOUT").unwrap();
+        client.flush().unwrap();
+
+        let mut filter = control::ControlClientResponseFilter::default();
+        let mut begin = String::new();
+        reader.read_line(&mut begin).unwrap();
+        assert_eq!(
+            control_block_flags(&begin, "%begin"),
+            control::CONTROL_RESPONSE_DEFAULT_FLAGS
+                | control::CONTROL_RESPONSE_SAFE_ENVIRONMENT_FLAG
+        );
+        assert_eq!(filter.filter_server_line(&begin), begin);
+
+        let _held_response_sender =
+            match request_rx.recv_timeout(Duration::from_secs(2)).unwrap() {
+                CtrlReq::ShowEnvironment(name, sender) => {
+                    assert_eq!(name.as_deref(), Some("SYNTHETIC_TIMEOUT"));
+                    sender
+                }
+                _ => panic!("expected synthetic show-environment request"),
+            };
+
+        let mut error = String::new();
+        reader.read_line(&mut error).unwrap();
+        let visible_error = filter.filter_server_line(&error);
+        assert_eq!(visible_error, "command timed out\n");
+        assert!(!visible_error.contains("restart"));
+
+        let mut footer = String::new();
+        reader.read_line(&mut footer).unwrap();
+        assert!(footer.starts_with("%error "), "unexpected footer: {footer:?}");
+        assert_eq!(filter.filter_server_line(&footer), footer);
+
+        drop(reader);
+        drop(client);
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn control_safe_environment_response_disconnect_surfaces_real_error() {
+        let (address, request_rx, server) = spawn_test_server();
+        let (mut client, mut reader) = authenticate(address);
+        negotiate_safe_environment_capability(&mut client, &mut reader, true);
+        enter_control_mode(&mut client, &mut reader, &request_rx);
+
+        writeln!(client, "show-environment SYNTHETIC_DISCONNECT").unwrap();
+        client.flush().unwrap();
+
+        let mut filter = control::ControlClientResponseFilter::default();
+        let mut begin = String::new();
+        reader.read_line(&mut begin).unwrap();
+        assert_eq!(
+            control_block_flags(&begin, "%begin"),
+            control::CONTROL_RESPONSE_DEFAULT_FLAGS
+                | control::CONTROL_RESPONSE_SAFE_ENVIRONMENT_FLAG
+        );
+        assert_eq!(filter.filter_server_line(&begin), begin);
+
+        match request_rx.recv_timeout(Duration::from_secs(2)).unwrap() {
+            CtrlReq::ShowEnvironment(name, sender) => {
+                assert_eq!(name.as_deref(), Some("SYNTHETIC_DISCONNECT"));
+                drop(sender);
+            }
+            _ => panic!("expected synthetic show-environment request"),
+        }
+
+        let mut error = String::new();
+        reader.read_line(&mut error).unwrap();
+        let visible_error = filter.filter_server_line(&error);
+        assert_eq!(visible_error, "command timed out\n");
         assert!(!visible_error.contains("restart"));
 
         let mut footer = String::new();

--- a/core/src/server/connection.rs
+++ b/core/src/server/connection.rs
@@ -13,7 +13,8 @@ static NEXT_CLIENT_ID: AtomicU64 = AtomicU64::new(1);
 const NON_PERSISTENT_BATCH_READ_TIMEOUT: Duration = Duration::from_millis(10);
 use crate::commands::{
     encode_safe_environment_error, encode_safe_environment_response, parse_command_line,
-    SHOW_ENVIRONMENT_SAFE_CAPABILITY_FLAG, SHOW_ENVIRONMENT_SAFE_RESPONSE_FLAG,
+    SHOW_ENVIRONMENT_CONTROL_SIGNAL_CAPABILITY_FLAG, SHOW_ENVIRONMENT_SAFE_CAPABILITY_FLAG,
+    SHOW_ENVIRONMENT_SAFE_RESPONSE_FLAG,
 };
 use super::helpers::TMUX_COMMANDS;
 
@@ -96,6 +97,7 @@ let mut global_target_pane: Option<usize> = None;
 let mut global_pane_is_id = false;
 let mut line = String::new();
 let mut safe_environment_capability_negotiated = false;
+let mut safe_environment_control_signal_negotiated = false;
 if r.read_line(&mut line).is_err() {
     return;
 }
@@ -103,8 +105,15 @@ if r.read_line(&mut line).is_err() {
 let safe_capability_command = format!(
     "show-environment {SHOW_ENVIRONMENT_SAFE_CAPABILITY_FLAG}"
 );
-if line.trim() == safe_capability_command {
+let safe_control_capability_command = format!(
+    "{safe_capability_command} {SHOW_ENVIRONMENT_CONTROL_SIGNAL_CAPABILITY_FLAG}"
+);
+if matches!(
+    line.trim(),
+    command if command == safe_capability_command || command == safe_control_capability_command
+) {
     safe_environment_capability_negotiated = true;
+    safe_environment_control_signal_negotiated = line.trim() == safe_control_capability_command;
     let _ = write!(write_stream, "{}", encode_safe_environment_response(""));
     let _ = write_stream.flush();
     line.clear();
@@ -234,16 +243,22 @@ if control_echo || control_noecho {
             let _ = write_stream.flush();
         }
 
-        // Send %begin
-        let _ = writeln!(write_stream, "{}", control::format_begin(ts, cmd_counter));
-        let _ = write_stream.flush();
-
         // Dispatch the command
         let parsed = parse_command_line(trimmed);
         let raw_cmd = parsed.first().map(|s| s.as_str()).unwrap_or("");
 
         if raw_cmd.is_empty() {
-            let _ = writeln!(write_stream, "{}", control::format_end(ts, cmd_counter));
+            let flags = control::CONTROL_RESPONSE_DEFAULT_FLAGS;
+            let _ = writeln!(
+                write_stream,
+                "{}",
+                control::format_begin(ts, cmd_counter, flags)
+            );
+            let _ = writeln!(
+                write_stream,
+                "{}",
+                control::format_end(ts, cmd_counter, flags)
+            );
             let _ = write_stream.flush();
             continue;
         }
@@ -261,6 +276,23 @@ if control_echo || control_noecho {
         } else {
             (raw_cmd, parsed.iter().skip(1).map(|s| s.as_str()).collect())
         };
+
+        // This bit is the server's authoritative classification after alias
+        // expansion. The client does not mirror command parsing or dispatch.
+        let response_flags = control::CONTROL_RESPONSE_DEFAULT_FLAGS
+            | if safe_environment_control_signal_negotiated
+                && matches!(cmd_name, "show-environment" | "showenv")
+            {
+                control::CONTROL_RESPONSE_SAFE_ENVIRONMENT_FLAG
+            } else {
+                0
+            };
+        let _ = writeln!(
+            write_stream,
+            "{}",
+            control::format_begin(ts, cmd_counter, response_flags)
+        );
+        let _ = write_stream.flush();
 
         // Parse -t from command args
         let mut ctrl_target_win: Option<usize> = None;
@@ -315,7 +347,7 @@ if control_echo || control_noecho {
                     let _ = tx_ctrl.send(CtrlReq::FocusPaneChecked(pid, rtx));
                     if !rrx.recv_timeout(Duration::from_millis(2000)).unwrap_or(false) {
                         let _ = writeln!(write_stream, "can't find pane: {}", pid);
-                        let _ = writeln!(write_stream, "{}", control::format_error(ts, cmd_counter));
+                        let _ = writeln!(write_stream, "{}", control::format_error(ts, cmd_counter, response_flags));
                         let _ = write_stream.flush();
                         continue;
                     }
@@ -324,7 +356,7 @@ if control_echo || control_noecho {
                     let _ = tx_ctrl.send(CtrlReq::FocusPaneByIndexChecked(pid, rtx));
                     if !rrx.recv_timeout(Duration::from_millis(2000)).unwrap_or(false) {
                         let _ = writeln!(write_stream, "can't find pane index: {}", pid);
-                        let _ = writeln!(write_stream, "{}", control::format_error(ts, cmd_counter));
+                        let _ = writeln!(write_stream, "{}", control::format_error(ts, cmd_counter, response_flags));
                         let _ = write_stream.flush();
                         continue;
                     }
@@ -335,7 +367,7 @@ if control_echo || control_noecho {
                     let _ = tx_ctrl.send(CtrlReq::FocusPaneTemp(pid, rtx));
                     if !rrx.recv_timeout(Duration::from_millis(2000)).unwrap_or(false) {
                         let _ = writeln!(write_stream, "can't find pane: {}", pid);
-                        let _ = writeln!(write_stream, "{}", control::format_error(ts, cmd_counter));
+                        let _ = writeln!(write_stream, "{}", control::format_error(ts, cmd_counter, response_flags));
                         let _ = write_stream.flush();
                         continue;
                     }
@@ -344,7 +376,7 @@ if control_echo || control_noecho {
                     let _ = tx_ctrl.send(CtrlReq::FocusPaneByIndexTemp(pid, rtx));
                     if !rrx.recv_timeout(Duration::from_millis(2000)).unwrap_or(false) {
                         let _ = writeln!(write_stream, "can't find pane index: {}", pid);
-                        let _ = writeln!(write_stream, "{}", control::format_error(ts, cmd_counter));
+                        let _ = writeln!(write_stream, "{}", control::format_error(ts, cmd_counter, response_flags));
                         let _ = write_stream.flush();
                         continue;
                     }
@@ -369,7 +401,7 @@ if control_echo || control_noecho {
                     if !error.ends_with('\n') {
                         let _ = writeln!(write_stream);
                     }
-                    let _ = writeln!(write_stream, "{}", control::format_error(ts, cmd_counter));
+                    let _ = writeln!(write_stream, "{}", control::format_error(ts, cmd_counter, response_flags));
                 }
                 Ok(ControlCommandResult::Success(response)) => {
                     if !response.is_empty() {
@@ -378,16 +410,16 @@ if control_echo || control_noecho {
                             let _ = writeln!(write_stream);
                         }
                     }
-                    let _ = writeln!(write_stream, "{}", control::format_end(ts, cmd_counter));
+                    let _ = writeln!(write_stream, "{}", control::format_end(ts, cmd_counter, response_flags));
                 }
                 Err(_) => {
                     let _ = writeln!(write_stream, "command timed out");
-                    let _ = writeln!(write_stream, "{}", control::format_error(ts, cmd_counter));
+                    let _ = writeln!(write_stream, "{}", control::format_error(ts, cmd_counter, response_flags));
                 }
             }
         } else {
             // Command dispatched without response channel (fire and forget)
-            let _ = writeln!(write_stream, "{}", control::format_end(ts, cmd_counter));
+            let _ = writeln!(write_stream, "{}", control::format_end(ts, cmd_counter, response_flags));
         }
         let _ = write_stream.flush();
     }
@@ -2555,6 +2587,16 @@ mod tests {
         mpsc::Receiver<CtrlReq>,
         std::thread::JoinHandle<()>,
     ) {
+        spawn_test_server_with_aliases(HashMap::new())
+    }
+
+    fn spawn_test_server_with_aliases(
+        aliases: HashMap<String, String>,
+    ) -> (
+        std::net::SocketAddr,
+        mpsc::Receiver<CtrlReq>,
+        std::thread::JoinHandle<()>,
+    ) {
         let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
         let address = listener.local_addr().unwrap();
         let (request_tx, request_rx) = mpsc::channel();
@@ -2564,7 +2606,7 @@ mod tests {
                 stream,
                 request_tx,
                 "synthetic-session-key",
-                Arc::new(RwLock::new(HashMap::new())),
+                Arc::new(RwLock::new(aliases)),
             );
         });
         (address, request_rx, server)
@@ -2613,6 +2655,41 @@ mod tests {
             request_rx.recv_timeout(Duration::from_secs(2)).unwrap(),
             CtrlReq::ControlRegister { echo: false, .. }
         ));
+    }
+
+    fn negotiate_safe_environment_capability(
+        client: &mut std::net::TcpStream,
+        reader: &mut BufReader<std::net::TcpStream>,
+        control_signal: bool,
+    ) {
+        if control_signal {
+            writeln!(
+                client,
+                "show-environment {SHOW_ENVIRONMENT_SAFE_CAPABILITY_FLAG} {SHOW_ENVIRONMENT_CONTROL_SIGNAL_CAPABILITY_FLAG}"
+            )
+            .unwrap();
+        } else {
+            writeln!(
+                client,
+                "show-environment {SHOW_ENVIRONMENT_SAFE_CAPABILITY_FLAG}"
+            )
+            .unwrap();
+        }
+        client.flush().unwrap();
+
+        let mut capability = String::new();
+        reader.read_line(&mut capability).unwrap();
+        assert_eq!(
+            crate::commands::decode_safe_environment_response(&capability).unwrap(),
+            crate::commands::SafeEnvironmentResponse::Ok(String::new())
+        );
+    }
+
+    fn control_block_flags(line: &str, expected_marker: &str) -> u64 {
+        let fields = line.split_ascii_whitespace().collect::<Vec<_>>();
+        assert_eq!(fields.len(), 4, "unexpected control line: {line:?}");
+        assert_eq!(fields[0], expected_marker, "unexpected control line: {line:?}");
+        fields[3].parse().unwrap()
     }
 
     fn synthetic_full_environment_output() -> String {
@@ -2849,6 +2926,109 @@ mod tests {
             )
         );
         assert!(dispatcher.join().unwrap());
+    }
+
+    #[test]
+    fn control_safe_environment_signal_covers_server_dispatch_reach_paths() {
+        let aliases = HashMap::from([
+            (
+                "synthetic-alias".to_string(),
+                "show-environment".to_string(),
+            ),
+            ("Synthetic-Case-Alias".to_string(), "showenv".to_string()),
+        ]);
+        let (address, request_rx, server) = spawn_test_server_with_aliases(aliases);
+        let (mut client, mut reader) = authenticate(address);
+        negotiate_safe_environment_capability(&mut client, &mut reader, true);
+        enter_control_mode(&mut client, &mut reader, &request_rx);
+
+        let cases = [
+            ("synthetic-alias SYNTHETIC_ALIAS", "SYNTHETIC_ALIAS"),
+            ("showenv SYNTHETIC_SHORTHAND", "SYNTHETIC_SHORTHAND"),
+            (
+                "show-environment -g SYNTHETIC_DUPLICATE SYNTHETIC_DUPLICATE",
+                "SYNTHETIC_DUPLICATE",
+            ),
+            (
+                "   show-environment SYNTHETIC_WHITESPACE",
+                "SYNTHETIC_WHITESPACE",
+            ),
+            ("Synthetic-Case-Alias SYNTHETIC_CASE", "SYNTHETIC_CASE"),
+        ];
+
+        for (command, expected_name) in cases {
+            writeln!(client, "{command}").unwrap();
+            client.flush().unwrap();
+
+            let mut begin = String::new();
+            reader.read_line(&mut begin).unwrap();
+            assert_eq!(
+                control_block_flags(&begin, "%begin"),
+                control::CONTROL_RESPONSE_DEFAULT_FLAGS
+                    | control::CONTROL_RESPONSE_SAFE_ENVIRONMENT_FLAG,
+                "server did not mark resolved show-environment dispatch: {command:?}"
+            );
+
+            let expected_output = format!("{expected_name}=synthetic-value\n");
+            answer_show_environment(&request_rx, Some(expected_name), Ok(expected_output.clone()));
+
+            let mut response = String::new();
+            reader.read_line(&mut response).unwrap();
+            assert_eq!(
+                crate::commands::decode_safe_environment_response(&response).unwrap(),
+                crate::commands::SafeEnvironmentResponse::Ok(expected_output)
+            );
+
+            let mut footer = String::new();
+            reader.read_line(&mut footer).unwrap();
+            assert_eq!(
+                control_block_flags(&footer, "%end"),
+                control::CONTROL_RESPONSE_DEFAULT_FLAGS
+                    | control::CONTROL_RESPONSE_SAFE_ENVIRONMENT_FLAG
+            );
+        }
+
+        drop(reader);
+        drop(client);
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn control_v1_capability_preserves_legacy_control_flags() {
+        let (address, request_rx, server) = spawn_test_server();
+        let (mut client, mut reader) = authenticate(address);
+        negotiate_safe_environment_capability(&mut client, &mut reader, false);
+        enter_control_mode(&mut client, &mut reader, &request_rx);
+
+        writeln!(client, "show-environment SYNTHETIC_LEGACY").unwrap();
+        client.flush().unwrap();
+
+        let mut begin = String::new();
+        reader.read_line(&mut begin).unwrap();
+        assert_eq!(
+            control_block_flags(&begin, "%begin"),
+            control::CONTROL_RESPONSE_DEFAULT_FLAGS
+        );
+
+        answer_show_environment(
+            &request_rx,
+            Some("SYNTHETIC_LEGACY"),
+            Ok("SYNTHETIC_LEGACY=synthetic-value\n".to_string()),
+        );
+        let mut response = String::new();
+        reader.read_line(&mut response).unwrap();
+        assert!(crate::commands::decode_safe_environment_response(&response).is_ok());
+
+        let mut footer = String::new();
+        reader.read_line(&mut footer).unwrap();
+        assert_eq!(
+            control_block_flags(&footer, "%end"),
+            control::CONTROL_RESPONSE_DEFAULT_FLAGS
+        );
+
+        drop(reader);
+        drop(client);
+        server.join().unwrap();
     }
 
     #[test]

--- a/core/src/server/mod.rs
+++ b/core/src/server/mod.rs
@@ -40,7 +40,10 @@ use crate::window_ops::{toggle_zoom, remote_mouse_down, remote_mouse_drag, remot
     handle_pane_mouse, handle_pane_scroll, handle_split_set_sizes, handle_split_resize_done};
 use crate::config::{load_config, parse_key_string, format_key_binding, normalize_key_for_binding,
     parse_config_content};
-use crate::commands::{parse_command_to_action, format_action, parse_menu_definition, execute_command_string};
+use crate::commands::{
+    execute_command_string, format_action, format_environment_output, parse_command_to_action,
+    parse_menu_definition,
+};
 use crate::util::{list_windows_json, list_tree_json, list_windows_tmux, base64_encode};
 use crate::control;
 use crate::format::{expand_format, format_list_windows, format_list_panes, set_buffer_idx_override};
@@ -3221,18 +3224,18 @@ pub fn run_server(session_name: String, socket_name: Option<String>, initial_com
                         }
                     }
                 }
-                CtrlReq::ShowEnvironment(resp) => {
-                    let mut output = String::new();
-                    // Show psmux/tmux-specific environment vars
-                    for (key, value) in &app.environment {
-                        output.push_str(&format!("{}={}\n", key, value));
-                    }
+                CtrlReq::ShowEnvironment(requested_name, resp) => {
+                    let mut display_environment = app.environment.clone();
                     // Also show inherited PSMUX_/TMUX_ vars from process env
                     for (key, value) in env::vars() {
-                        if (key.starts_with("PSMUX") || key.starts_with("TMUX")) && !app.environment.contains_key(&key) {
-                            output.push_str(&format!("{}={}\n", key, value));
+                        if key.starts_with("PSMUX") || key.starts_with("TMUX") {
+                            display_environment.entry(key).or_insert(value);
                         }
                     }
+                    let output = format_environment_output(
+                        &display_environment,
+                        requested_name.as_deref(),
+                    );
                     let _ = resp.send(output);
                 }
                 CtrlReq::SetHook(hook, cmd) => {

--- a/core/src/session.rs
+++ b/core/src/session.rs
@@ -982,10 +982,33 @@ pub fn require_safe_environment_connection(
     reader: &mut impl io::BufRead,
     writer: &mut impl Write,
 ) -> io::Result<()> {
+    require_safe_environment_capabilities(reader, writer, None)
+}
+
+pub fn require_safe_environment_control_connection(
+    reader: &mut impl io::BufRead,
+    writer: &mut impl Write,
+) -> io::Result<()> {
+    require_safe_environment_capabilities(
+        reader,
+        writer,
+        Some(crate::commands::SHOW_ENVIRONMENT_CONTROL_SIGNAL_CAPABILITY_FLAG),
+    )
+}
+
+fn require_safe_environment_capabilities(
+    reader: &mut impl io::BufRead,
+    writer: &mut impl Write,
+    additional_capability: Option<&str>,
+) -> io::Result<()> {
+    let additional_capability = additional_capability
+        .map(|capability| format!(" {capability}"))
+        .unwrap_or_default();
     writeln!(
         writer,
-        "show-environment {}",
-        crate::commands::SHOW_ENVIRONMENT_SAFE_CAPABILITY_FLAG
+        "show-environment {}{}",
+        crate::commands::SHOW_ENVIRONMENT_SAFE_CAPABILITY_FLAG,
+        additional_capability,
     )?;
     writer.flush()?;
 
@@ -1291,7 +1314,10 @@ mod tests {
 
     static ENV_LOCK: Mutex<()> = Mutex::new(());
 
-    fn serve_capability_probe(response: String) -> (u16, std::thread::JoinHandle<()>) {
+    fn serve_capability_probe(
+        response: String,
+        expected_additional_capability: Option<&'static str>,
+    ) -> (u16, std::thread::JoinHandle<()>) {
         let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
         let port = listener.local_addr().unwrap().port();
         let handle = std::thread::spawn(move || {
@@ -1305,6 +1331,9 @@ mod tests {
             std::io::BufRead::read_line(&mut reader, &mut command).unwrap();
             assert_eq!(auth, "AUTH synthetic-session-key\n");
             assert!(command.contains(crate::commands::SHOW_ENVIRONMENT_SAFE_CAPABILITY_FLAG));
+            if let Some(capability) = expected_additional_capability {
+                assert!(command.contains(capability));
+            }
             write!(stream, "{response}").unwrap();
             stream.flush().unwrap();
         });
@@ -1315,6 +1344,7 @@ mod tests {
     fn safe_environment_capability_probe_accepts_marked_server() {
         let (port, server) = serve_capability_probe(
             crate::commands::encode_safe_environment_response(""),
+            None,
         );
         let mut stream = std::net::TcpStream::connect(("127.0.0.1", port)).unwrap();
         write!(stream, "AUTH synthetic-session-key\n").unwrap();
@@ -1328,9 +1358,27 @@ mod tests {
     }
 
     #[test]
+    fn control_capability_probe_requests_server_classification_signal() {
+        let (port, server) = serve_capability_probe(
+            crate::commands::encode_safe_environment_response(""),
+            Some(crate::commands::SHOW_ENVIRONMENT_CONTROL_SIGNAL_CAPABILITY_FLAG),
+        );
+        let mut stream = std::net::TcpStream::connect(("127.0.0.1", port)).unwrap();
+        write!(stream, "AUTH synthetic-session-key\n").unwrap();
+        stream.flush().unwrap();
+        let mut reader = std::io::BufReader::new(stream.try_clone().unwrap());
+        let mut auth = String::new();
+        std::io::BufRead::read_line(&mut reader, &mut auth).unwrap();
+        assert_eq!(auth, "OK\n");
+        require_safe_environment_control_connection(&mut reader, &mut stream).unwrap();
+        server.join().unwrap();
+    }
+
+    #[test]
     fn safe_environment_capability_probe_refuses_unmarked_legacy_output() {
         let (port, server) = serve_capability_probe(
             "TARGET_VAR=synthetic-target\nSECRET_VAR=synthetic-secret\n".to_string(),
+            None,
         );
         let mut stream = std::net::TcpStream::connect(("127.0.0.1", port)).unwrap();
         write!(stream, "AUTH synthetic-session-key\n").unwrap();

--- a/core/src/session.rs
+++ b/core/src/session.rs
@@ -978,6 +978,30 @@ pub fn send_control_with_response(line: String) -> io::Result<String> {
     Ok(result)
 }
 
+pub fn require_safe_environment_connection(
+    reader: &mut impl io::BufRead,
+    writer: &mut impl Write,
+) -> io::Result<()> {
+    writeln!(
+        writer,
+        "show-environment {}",
+        crate::commands::SHOW_ENVIRONMENT_SAFE_CAPABILITY_FLAG
+    )?;
+    writer.flush()?;
+
+    let mut response = String::new();
+    reader.read_line(&mut response)?;
+    let decoded = crate::commands::decode_safe_environment_response(&response)
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+    if decoded != crate::commands::SafeEnvironmentResponse::Ok(String::new()) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            crate::commands::incompatible_environment_response_error(),
+        ));
+    }
+    Ok(())
+}
+
 /// Send a control message to a specific port with authentication
 pub fn send_control_to_port(port: u16, msg: &str, session_key: &str) -> io::Result<()> {
     let addr = format!("127.0.0.1:{}", port);
@@ -1266,6 +1290,63 @@ mod tests {
     use std::time::{SystemTime, UNIX_EPOCH};
 
     static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn serve_capability_probe(response: String) -> (u16, std::thread::JoinHandle<()>) {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let handle = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut reader = std::io::BufReader::new(stream.try_clone().unwrap());
+            let mut auth = String::new();
+            let mut command = String::new();
+            std::io::BufRead::read_line(&mut reader, &mut auth).unwrap();
+            write!(stream, "OK\n").unwrap();
+            stream.flush().unwrap();
+            std::io::BufRead::read_line(&mut reader, &mut command).unwrap();
+            assert_eq!(auth, "AUTH synthetic-session-key\n");
+            assert!(command.contains(crate::commands::SHOW_ENVIRONMENT_SAFE_CAPABILITY_FLAG));
+            write!(stream, "{response}").unwrap();
+            stream.flush().unwrap();
+        });
+        (port, handle)
+    }
+
+    #[test]
+    fn safe_environment_capability_probe_accepts_marked_server() {
+        let (port, server) = serve_capability_probe(
+            crate::commands::encode_safe_environment_response(""),
+        );
+        let mut stream = std::net::TcpStream::connect(("127.0.0.1", port)).unwrap();
+        write!(stream, "AUTH synthetic-session-key\n").unwrap();
+        stream.flush().unwrap();
+        let mut reader = std::io::BufReader::new(stream.try_clone().unwrap());
+        let mut auth = String::new();
+        std::io::BufRead::read_line(&mut reader, &mut auth).unwrap();
+        assert_eq!(auth, "OK\n");
+        require_safe_environment_connection(&mut reader, &mut stream).unwrap();
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn safe_environment_capability_probe_refuses_unmarked_legacy_output() {
+        let (port, server) = serve_capability_probe(
+            "TARGET_VAR=synthetic-target\nSECRET_VAR=synthetic-secret\n".to_string(),
+        );
+        let mut stream = std::net::TcpStream::connect(("127.0.0.1", port)).unwrap();
+        write!(stream, "AUTH synthetic-session-key\n").unwrap();
+        stream.flush().unwrap();
+        let mut reader = std::io::BufReader::new(stream.try_clone().unwrap());
+        let mut auth = String::new();
+        std::io::BufRead::read_line(&mut reader, &mut auth).unwrap();
+        assert_eq!(auth, "OK\n");
+        let error = require_safe_environment_connection(&mut reader, &mut stream)
+            .expect_err("an unmarked legacy response must be refused");
+        server.join().unwrap();
+
+        assert!(error.to_string().contains("restart"));
+        assert!(!error.to_string().contains("synthetic-target"));
+        assert!(!error.to_string().contains("synthetic-secret"));
+    }
 
     #[test]
     fn warm_session_base_matches_namespace_encoding() {

--- a/core/src/types.rs
+++ b/core/src/types.rs
@@ -983,7 +983,7 @@ pub enum CtrlReq {
     LoadBuffer(String),
     SetEnvironment(String, String),
     UnsetEnvironment(String),
-    ShowEnvironment(mpsc::Sender<String>),
+    ShowEnvironment(Option<String>, mpsc::Sender<Result<String, String>>),
     SetHook(String, String),
     AppendHook(String, String),
     ShowHooks(mpsc::Sender<String>),

--- a/core/tests-rs/test_commands_audit.rs
+++ b/core/tests-rs/test_commands_audit.rs
@@ -239,6 +239,38 @@ fn show_environment_redacts_sensitive_values() {
 }
 
 #[test]
+fn show_environment_redacts_compact_key_markers_before_qualifiers() {
+    let mut app = mock_app_with_window();
+    app.environment.insert(
+        "APIKEY_PROD".to_string(),
+        "synthetic-api-key-value".to_string(),
+    );
+    app.environment.insert(
+        "PRIVATEKEY_PEM".to_string(),
+        "synthetic-private-key-value".to_string(),
+    );
+    app.environment.insert(
+        "SECRETKEY_ROTATION".to_string(),
+        "synthetic-secret-key-value".to_string(),
+    );
+    app.environment.insert(
+        "API_KEYBOARD_LAYOUT".to_string(),
+        "synthetic-keyboard-layout".to_string(),
+    );
+
+    execute_command_string(&mut app, "show-environment").unwrap();
+    let (_, out) = extract_popup(&app);
+
+    assert!(out.contains("APIKEY_PROD=[redacted]"));
+    assert!(out.contains("PRIVATEKEY_PEM=[redacted]"));
+    assert!(out.contains("SECRETKEY_ROTATION=[redacted]"));
+    assert!(out.contains("API_KEYBOARD_LAYOUT=synthetic-keyboard-layout"));
+    assert!(!out.contains("synthetic-api-key-value"));
+    assert!(!out.contains("synthetic-private-key-value"));
+    assert!(!out.contains("synthetic-secret-key-value"));
+}
+
+#[test]
 fn showenv_named_secret_query_is_redacted() {
     let mut app = mock_app_with_window();
     app.environment.insert("SESSION_SECRET".to_string(), "synthetic-secret-value".to_string());

--- a/core/tests-rs/test_commands_audit.rs
+++ b/core/tests-rs/test_commands_audit.rs
@@ -173,6 +173,255 @@ fn show_environment_displays_vars_in_popup() {
 }
 
 #[test]
+fn show_environment_named_query_returns_only_requested_variable() {
+    let mut app = mock_app_with_window();
+    app.environment.insert("TARGET_VAR".to_string(), "target-value".to_string());
+    app.environment.insert("OTHER_VAR".to_string(), "other-value".to_string());
+    execute_command_string(&mut app, "show-environment -g -t test-session TARGET_VAR").unwrap();
+    let (_, out) = extract_popup(&app);
+    assert_eq!(out, "TARGET_VAR=target-value\n");
+    assert!(!out.contains("OTHER_VAR"));
+    assert!(!out.contains("other-value"));
+}
+
+#[test]
+fn show_environment_named_query_preserves_multiline_utf8_value() {
+    let mut app = mock_app_with_window();
+    app.environment.insert(
+        "TARGET_VAR".to_string(),
+        "first line\r\nsecond 行 🚀\n".to_string(),
+    );
+
+    execute_command_string(&mut app, "show-environment TARGET_VAR").unwrap();
+    let (_, out) = extract_popup(&app);
+
+    assert_eq!(out, "TARGET_VAR=first line\r\nsecond 行 🚀\n\n");
+}
+
+#[test]
+fn show_environment_redacts_sensitive_values() {
+    let mut app = mock_app_with_window();
+    app.environment.insert("SAFE_VAR".to_string(), "visible-value".to_string());
+    app.environment.insert("GH_TOKEN".to_string(), "synthetic-token-value".to_string());
+    app.environment.insert("SERVICE_API_KEY".to_string(), "synthetic-key-value".to_string());
+    app.environment.insert("LOGIN_PASSWORD".to_string(), "synthetic-password-value".to_string());
+    app.environment.insert("MYSQL_PWD".to_string(), "synthetic-mysql-password".to_string());
+    app.environment.insert("DB_PASS".to_string(), "synthetic-db-password".to_string());
+    app.environment.insert("SSH_PASSPHRASE".to_string(), "synthetic-passphrase".to_string());
+    app.environment.insert("GITHUB_PAT".to_string(), "synthetic-pat-value".to_string());
+    app.environment.insert("CI_JOB_JWT".to_string(), "synthetic-jwt-value".to_string());
+    app.environment.insert("NPM_CONFIG__AUTH".to_string(), "synthetic-auth-value".to_string());
+    app.environment.insert("TOKENIZERS_PARALLELISM".to_string(), "false".to_string());
+    app.environment.insert("SSH_AUTH_SOCK".to_string(), "synthetic-socket-path".to_string());
+    execute_command_string(&mut app, "show-environment").unwrap();
+    let (_, out) = extract_popup(&app);
+    assert!(out.contains("SAFE_VAR=visible-value"));
+    assert!(out.contains("GH_TOKEN=[redacted]"));
+    assert!(out.contains("SERVICE_API_KEY=[redacted]"));
+    assert!(out.contains("LOGIN_PASSWORD=[redacted]"));
+    assert!(out.contains("MYSQL_PWD=[redacted]"));
+    assert!(out.contains("DB_PASS=[redacted]"));
+    assert!(out.contains("SSH_PASSPHRASE=[redacted]"));
+    assert!(out.contains("GITHUB_PAT=[redacted]"));
+    assert!(out.contains("CI_JOB_JWT=[redacted]"));
+    assert!(out.contains("NPM_CONFIG__AUTH=[redacted]"));
+    assert!(out.contains("TOKENIZERS_PARALLELISM=false"));
+    assert!(out.contains("SSH_AUTH_SOCK=synthetic-socket-path"));
+    assert!(!out.contains("synthetic-token-value"));
+    assert!(!out.contains("synthetic-key-value"));
+    assert!(!out.contains("synthetic-password-value"));
+    assert!(!out.contains("synthetic-mysql-password"));
+    assert!(!out.contains("synthetic-db-password"));
+    assert!(!out.contains("synthetic-passphrase"));
+    assert!(!out.contains("synthetic-pat-value"));
+    assert!(!out.contains("synthetic-jwt-value"));
+    assert!(!out.contains("synthetic-auth-value"));
+}
+
+#[test]
+fn showenv_named_secret_query_is_redacted() {
+    let mut app = mock_app_with_window();
+    app.environment.insert("SESSION_SECRET".to_string(), "synthetic-secret-value".to_string());
+    app.environment.insert("OTHER_VAR".to_string(), "other-value".to_string());
+    execute_command_string(&mut app, "showenv SESSION_SECRET").unwrap();
+    let (cmd, out) = extract_popup(&app);
+    assert_eq!(cmd, "show-environment");
+    assert_eq!(out, "SESSION_SECRET=[redacted]\n");
+    assert!(!out.contains("synthetic-secret-value"));
+    assert!(!out.contains("OTHER_VAR"));
+}
+
+#[test]
+fn show_environment_named_password_alias_is_redacted() {
+    let mut app = mock_app_with_window();
+    app.environment.insert("MYSQL_PWD".to_string(), "synthetic-mysql-password".to_string());
+    execute_command_string(&mut app, "show-environment MYSQL_PWD").unwrap();
+    let (_, out) = extract_popup(&app);
+    assert_eq!(out, "MYSQL_PWD=[redacted]\n");
+    assert!(!out.contains("synthetic-mysql-password"));
+}
+
+#[test]
+fn show_environment_standalone_pass_is_redacted_but_pwd_remains_visible() {
+    let mut app = mock_app_with_window();
+    app.environment
+        .insert("PASS".to_string(), "synthetic-pass-value".to_string());
+    app.environment
+        .insert("PWD".to_string(), "C:\\synthetic\\workspace".to_string());
+    for name in ["PW", "PIN", "PSK", "OTP", "TOTP", "HOTP"] {
+        app.environment
+            .insert(name.to_string(), format!("synthetic-{name}-value"));
+    }
+
+    execute_command_string(&mut app, "show-environment").unwrap();
+    let (_, out) = extract_popup(&app);
+
+    assert!(out.contains("PASS=[redacted]"));
+    assert!(out.contains("PWD=C:\\synthetic\\workspace"));
+    assert!(!out.contains("synthetic-pass-value"));
+    for name in ["PW", "PIN", "PSK", "OTP", "TOTP", "HOTP"] {
+        assert!(out.contains(&format!("{name}=[redacted]")));
+        assert!(!out.contains(&format!("synthetic-{name}-value")));
+    }
+}
+
+#[test]
+fn show_environment_safe_response_refuses_unframed_named_response() {
+    let error = decode_safe_environment_response("TARGET_VAR=synthetic-target\n")
+        .expect_err("an unframed legacy named response must be refused");
+
+    assert!(error.contains("restart"));
+    assert!(!error.contains("synthetic-target"));
+}
+
+#[test]
+fn show_environment_safe_response_refuses_unframed_full_listing() {
+    let response = "SAFE_VAR=synthetic-visible\nGH_TOKEN=synthetic-secret\n";
+    let error = decode_safe_environment_response(response)
+        .expect_err("an unframed legacy full listing must be refused");
+
+    assert!(error.contains("restart"));
+    assert!(!error.contains("synthetic-visible"));
+    assert!(!error.contains("synthetic-secret"));
+}
+
+#[test]
+fn show_environment_safe_response_rejects_unmarked_error_payload() {
+    let error = decode_safe_environment_response("ERROR: GH_TOKEN=synthetic-secret-value\n")
+    .expect_err("an unmarked legacy error-shaped response must be refused");
+
+    assert!(error.contains("restart"));
+    assert!(!error.contains("synthetic-secret-value"));
+}
+
+#[test]
+fn show_environment_safe_response_accepts_framed_server_error() {
+    let response = encode_safe_environment_error("unknown variable: MISSING_VAR");
+    assert_eq!(
+        decode_safe_environment_response(&response).unwrap(),
+        SafeEnvironmentResponse::Error("unknown variable: MISSING_VAR".to_string())
+    );
+}
+
+#[test]
+fn show_environment_safe_response_accepts_exact_marked_named_result() {
+    let response = encode_safe_environment_response("TARGET_VAR=synthetic-target\n");
+
+    assert_eq!(
+        decode_safe_environment_response(&response).unwrap(),
+        SafeEnvironmentResponse::Ok("TARGET_VAR=synthetic-target\n".to_string())
+    );
+}
+
+#[test]
+fn show_environment_safe_response_round_trips_named_value_edge_cases() {
+    let payloads = [
+        "TARGET_VAR=first line\nsecond line\n",
+        "TARGET_VAR=ERROR: synthetic value\n",
+        "TARGET_VAR=\n",
+        "TARGET_VAR=synthetic value\n\n",
+        "TARGET_VAR=first line\r\nsecond line\r\n",
+        "TARGET_VAR=synthetic-値-🚀\n",
+    ];
+
+    for payload in payloads {
+        let response = encode_safe_environment_response(payload);
+        assert_eq!(
+            decode_safe_environment_response(&response).unwrap(),
+            SafeEnvironmentResponse::Ok(payload.to_string())
+        );
+    }
+}
+
+#[test]
+fn show_environment_safe_response_round_trips_redacted_full_listing_with_multiline_utf8() {
+    let mut environment = HashMap::new();
+    environment.insert(
+        "SAFE_VAR".to_string(),
+        "first line\r\nsecond 行 🚀\n".to_string(),
+    );
+    environment.insert(
+        "GH_TOKEN".to_string(),
+        "synthetic-secret-value".to_string(),
+    );
+    let listing = format_environment_output(&environment, None).unwrap();
+    let response = encode_safe_environment_response(&listing);
+
+    assert!(listing.contains("SAFE_VAR=first line\r\nsecond 行 🚀\n"));
+    assert!(listing.contains("GH_TOKEN=[redacted]"));
+    assert!(!listing.contains("synthetic-secret-value"));
+    assert_eq!(
+        decode_safe_environment_response(&response).unwrap(),
+        SafeEnvironmentResponse::Ok(listing)
+    );
+}
+
+#[test]
+fn show_environment_safe_response_rejects_malformed_frames() {
+    let responses = [
+        format!("{SHOW_ENVIRONMENT_SAFE_RESPONSE_PREFIX}not-json\n"),
+        format!("{SHOW_ENVIRONMENT_SAFE_RESPONSE_PREFIX}{{\"status\":\"unknown\",\"payload\":\"value\"}}\n"),
+        format!("{SHOW_ENVIRONMENT_SAFE_RESPONSE_PREFIX}{{\"status\":\"ok\",\"payload\":\"value\",\"extra\":true}}\n"),
+        format!("{SHOW_ENVIRONMENT_SAFE_RESPONSE_PREFIX}{{\"status\":\"ok\",\"payload\":\"value\"}}\ntrailing-data"),
+    ];
+
+    for response in responses {
+        let error = decode_safe_environment_response(&response)
+            .expect_err("malformed response frames must fail closed");
+        assert!(error.contains("restart"));
+        assert!(!error.contains("TARGET_VAR=value"));
+    }
+}
+
+#[test]
+fn show_environment_safe_response_preserves_equals_and_accepts_crlf_header() {
+    let response = encode_safe_environment_response("TARGET_VAR=value=with=equals\r\n\r\n")
+        .replacen('\n', "\r\n", 1);
+    assert_eq!(
+        decode_safe_environment_response(&response).unwrap(),
+        SafeEnvironmentResponse::Ok("TARGET_VAR=value=with=equals\r\n\r\n".to_string())
+    );
+}
+
+#[test]
+fn show_environment_missing_named_query_returns_error() {
+    let mut app = mock_app_with_window();
+    let error = execute_command_string(&mut app, "show-environment MISSING_VAR")
+        .expect_err("a missing named variable must fail");
+    assert_eq!(error.kind(), std::io::ErrorKind::NotFound);
+    assert_eq!(error.to_string(), "unknown variable: MISSING_VAR");
+}
+
+#[test]
+fn show_environment_name_parser_skips_supported_flags_and_target_value() {
+    assert_eq!(
+        parse_show_environment_name(&["-h", "-s", "-t", "test-session", "TARGET_VAR"]),
+        Some("TARGET_VAR".to_string())
+    );
+    assert_eq!(parse_show_environment_name(&["-g"]), None);
+}
+
+#[test]
 fn show_environment_empty_shows_message() {
     let mut app = mock_app_with_window();
     execute_command_string(&mut app, "show-environment").unwrap();

--- a/core/tests-rs/test_commands_audit.rs
+++ b/core/tests-rs/test_commands_audit.rs
@@ -271,6 +271,92 @@ fn show_environment_redacts_compact_key_markers_before_qualifiers() {
 }
 
 #[test]
+fn show_environment_compact_marker_acceptance_matrix() {
+    let mut app = mock_app_with_window();
+    let redacted_names = [
+        "APIKEYPROD",
+        "PRIVATEKEYPEM",
+        "SECRETKEYV2",
+        "APIKEY_PROD",
+        "PRIVATEKEY_PEM",
+        "PASS",
+    ];
+    let visible_names = [
+        "TOKENIZERS_PARALLELISM",
+        "TOKENIZERS",
+        "API_KEYBOARD_LAYOUT",
+        "PWD",
+        "SSH_AUTH_SOCK",
+    ];
+
+    for name in redacted_names {
+        app.environment
+            .insert(name.to_string(), format!("synthetic-{name}-value"));
+    }
+    for name in visible_names {
+        app.environment
+            .insert(name.to_string(), format!("synthetic-{name}-value"));
+    }
+
+    execute_command_string(&mut app, "show-environment").unwrap();
+    let (_, out) = extract_popup(&app);
+
+    for name in redacted_names {
+        assert!(out.contains(&format!("{name}=[redacted]")));
+        assert!(!out.contains(&format!("synthetic-{name}-value")));
+    }
+    for name in visible_names {
+        assert!(out.contains(&format!("{name}=synthetic-{name}-value")));
+    }
+}
+
+#[test]
+fn show_environment_redacts_separatorless_compact_markers_in_other_positions() {
+    let mut app = mock_app_with_window();
+    let redacted_names = [
+        "SERVICEAPIKEY",
+        "SERVICEAPIKEYPROD",
+        "APIKEYPROD1",
+        "PRIVATEKEYPEM01",
+        "SECRETKEYV2026",
+        "TOKENIZERSSECRETKEYV2",
+        "SERVICE_APIKEYPROD",
+        "APIKEYPROD_SERVICE",
+        "SERVICE_APIKEYPROD1",
+        "APIKEYPROD1_SERVICE",
+    ];
+    for name in redacted_names {
+        app.environment
+            .insert(name.to_string(), format!("synthetic-{name}-value"));
+    }
+
+    execute_command_string(&mut app, "show-environment").unwrap();
+    let (_, out) = extract_popup(&app);
+
+    for name in redacted_names {
+        assert!(out.contains(&format!("{name}=[redacted]")));
+        assert!(!out.contains(&format!("synthetic-{name}-value")));
+    }
+}
+
+#[test]
+fn show_environment_keeps_benign_single_token_marker_continuations_visible() {
+    let mut app = mock_app_with_window();
+    let visible_names = ["TOKENIZERS", "SECRETARY", "APIKEYBOARD"];
+    for name in visible_names {
+        app.environment
+            .insert(name.to_string(), format!("synthetic-{name}-value"));
+    }
+
+    execute_command_string(&mut app, "show-environment").unwrap();
+    let (_, out) = extract_popup(&app);
+
+    for name in visible_names {
+        assert!(out.contains(&format!("{name}=synthetic-{name}-value")));
+    }
+}
+
+#[test]
 fn showenv_named_secret_query_is_redacted() {
     let mut app = mock_app_with_window();
     app.environment.insert("SESSION_SECRET".to_string(), "synthetic-secret-value".to_string());


### PR DESCRIPTION
## Summary

- Support `show-environment [VARIABLE]` across the direct CLI, persistent, and control paths; unknown names exit 1 on direct CLI, `%error` in control mode, and error display in popups.
- Redact secret-like variable names (`[redacted]`) in both full listings and named queries, on every path. Benign names (e.g. `PWD`, `SSH_AUTH_SOCK`, `TOKENIZERS_PARALLELISM`) stay visible; standalone `PASS` is redacted.
- Frame server responses as a NUL-prefixed, versioned single-line JSON structure (`SafeEnvironmentResponse`) on both named and full-listing paths, so clients parse by structure — never by value content. Unframed legacy-server responses are refused with a restart hint at the decode layer and at the persistent/control connection boundary (structured capability probe).
- Regression tests cover multiline values, CRLF/LF, UTF-8 multibyte, empty values, trailing newlines, `ERROR:`-prefixed values, malformed frames, and legacy refusal on named and full-listing paths.

## Validation

- `cargo test --manifest-path core/Cargo.toml --lib --quiet`: 787 passed / 0 failed at repo root; in the worktree used for the commit, the single known environment-dependent flake `server::tests::warm_server_is_allowed_for_normal_sessions` failed (fails on unmodified main too while a live orchestra session is running) — non-blocking.
- `cargo fmt --check`, `cargo check --all-targets`, `git diff --check`: pass.
- `scripts/audit-public-surface.ps1`, `scripts/git-guard.ps1 -Mode full`: pass.
- Independent headless review: 3 rounds, final verdict PASS (rounds 1–2 findings — content-sniffing on multiline values, unframed full-listing path — were fixed and re-verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)