### PR TITLE
docs(project): declarative workspace + resumable workflow architecture (TASK-657)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ docs/project/*
 !docs/project/v03621-local-router-shadow-profile.md
 !docs/project/v03622-context-continuity.md
 !docs/project/v03622-context-continuity.ja.md
+!docs/project/v03629-declarative-workspace-architecture.md
 # Public-safe planning sync notes may be referenced from release history.
 !docs/project/pre-ga-v10-planning-sync.md
 docs/*-research*.md

--- a/docs/project/v03629-declarative-workspace-architecture.md
+++ b/docs/project/v03629-declarative-workspace-architecture.md
@@ -1,0 +1,561 @@
+# v0.36.29 Declarative Workspace and Resumable Workflow Architecture
+
+This document is the foundation contract for TASK-658 through TASK-662. It
+defines how reusable workspace recipes, resumable workflows, and bounded
+repository context packs extend the current winsmux operator and evidence
+model. It does not implement those child tasks and does not replace the
+existing one-shot operator flow.
+
+## 1. Architectural position
+
+The control chain remains the one defined in `docs/operator-model.md`:
+
+`User -> external operator -> managed pane agents`
+
+The operator remains responsible for decomposition, dispatch approval, review
+interpretation, escalation, and final judgement. Declarative configuration may
+prepare a workspace and advance an operator-approved workflow, but it must not
+turn a recipe, preset, worker, or gate into an independent approval authority.
+
+The new layer is additive:
+
+```mermaid
+flowchart LR
+    C[".winsmux.yaml\nuser-authored intent"] --> N["Normalize and validate"]
+    N --> P["Dry-run execution plan"]
+    P --> O["External operator approval"]
+    O --> R["Workspace and workflow runtime"]
+    R --> M[".winsmux/manifest.yaml\nruntime state and refs"]
+    R --> E["Ledger events and evidence"]
+    E --> X["Bounded repo context pack"]
+    X --> R
+    M --> K["Checkpoint and resume gate"]
+    K --> R
+```
+
+The implementation must extend these concrete contracts rather than create a
+parallel control plane:
+
+- `docs/operator-model.md` defines the operator/pane responsibility boundary,
+  evidence-based verification, Context Capsule v1, Checkpoint package v1, and
+  the prohibition on raw transcripts and private paths.
+- `winsmux-core/scripts/settings.ps1` owns project settings normalization. Its
+  `BridgeSettingsSchema`, `Get-BridgeSettings`, and
+  `Get-BridgeSettingsMetadata` are the PowerShell compatibility path for
+  `.winsmux.yaml`.
+- `core/src/operator_cli.rs` contains the Rust `.winsmux.yaml` reader and the
+  CLI paths that consume `.winsmux/manifest.yaml`. The Rust and PowerShell
+  readers must share fixtures for every new public key.
+- `winsmux-core/scripts/orchestra-start.ps1` owns workspace startup and
+  `Save-OrchestraSessionState`; `winsmux-core/scripts/orchestra-layout.ps1`
+  owns the current deterministic pane layout.
+- `winsmux-core/scripts/manifest.ps1` owns the PowerShell serialization of the
+  current `session`, `panes`, `tasks`, and `worktrees` runtime sections.
+- `core/src/manifest_contract.rs` defines `WinsmuxManifest`,
+  `ManifestSession`, `ManifestPane`, and `NormalizedManifestPane`, which feed
+  the Rust read model.
+- `winsmux-core/scripts/team-pipeline.ps1` is the existing operator-mediated
+  plan/build/verify loop. Resumable execution wraps or evolves this path; it
+  must not introduce a second, behaviorally different dispatch loop.
+- `core/src/ledger.rs` builds verification evidence, the context budget
+  contract, Context Capsule v1, and Checkpoint package v1. Repository context
+  packs extend those evidence references and privacy rules.
+- `docs/project/v03622-context-continuity.md` fixes the current recovery
+  behavior: invalid or stale capsules are not routable, mailbox delivery is
+  idempotent, restore discovery is enumerate-only, and completed work is not
+  automatically resumed.
+
+## 2. Sources of truth and lifecycle
+
+There are three separate sources of truth. They must not be collapsed into one
+file or inferred from one another after execution starts.
+
+| Layer | Source of truth | Responsibility |
+| --- | --- | --- |
+| User intent | `.winsmux.yaml` | Versioned recipes, workflow definitions, bounded context-pack policies, and Lane B team/slot settings. |
+| Effective runtime | `.winsmux/manifest.yaml` plus run-scoped state under `.winsmux/` | The normalized recipe selection, resolved slot bindings, workflow node state, idempotency records, checkpoint refs, and cleanup/rollback journal for the active run. |
+| Verification history | Existing ledger events and evidence refs | Attributable checks, review state, context-pack refs, decisions, and resume evidence. |
+
+`.winsmux.yaml` is declarative intent, not a live workflow journal. A resume
+operation uses the persisted normalized snapshot and config fingerprint from
+the run manifest. If the current config has a different fingerprint, resume
+must stop for an operator decision or start a new run; it must not silently
+reinterpret completed nodes using new configuration.
+
+`.winsmux/manifest.yaml` remains generated runtime state. Users and migration
+tools must not treat it as the authoring surface. Large context-pack bodies,
+raw tool output, and command output do not belong in the manifest; the manifest
+stores bounded metadata and durable evidence references.
+
+## 3. Declarative data model
+
+### 3.1 Shared `.winsmux.yaml` boundary with Lane B
+
+Lane A and Lane B share the physical `.winsmux.yaml` file but own disjoint
+logical namespaces.
+
+| Namespace | Owner | May contain | Must not contain |
+| --- | --- | --- | --- |
+| `team_profile`, `agent_slots` | Lane B, especially TASK-713/TASK-715 | Slot identity, provider, model, reasoning effort, role profile, lifecycle, task classes, and provider capability settings. | Workspace geometry, workflow DAG state, context-pack content, or run checkpoints. |
+| `workspace_recipes`, `workflows`, `context_packs` | Lane A, TASK-658/TASK-660 | Pane geometry, logical workflow roles, slot/capability references, worktree policy, typed startup actions, DAG nodes, resume/cleanup policy, and bounded repository projections. | Provider/model assignment, secrets, prompt bodies, raw transcripts, or a copy of `agent_slots`. |
+
+Resolution order is fixed:
+
+1. Lane B normalizes `team_profile` and `agent_slots` into the effective slot
+   catalog.
+2. Lane A validates recipe bindings against slot IDs and capabilities from
+   that catalog.
+3. A recipe may require a provider capability or refer to `slot_id`; it may not
+   override a slot's provider, model, reasoning effort, role profile,
+   lifecycle, or task classes.
+4. The dry-run output shows the resolved slot for every logical recipe role.
+   A missing, ambiguous, unavailable, or capability-incompatible binding fails
+   closed before pane creation.
+
+This boundary prevents two sources of truth for worker assignment. Until Lane
+B lands, Lane A uses the effective slots already produced from current
+`agent_slots`; future Lane B fields are optional inputs, not a prerequisite for
+parsing Lane A configuration. TASK-662 cannot declare the v0.36.29 release
+gate complete until TASK-718 has verified the combined desktop/CLI behavior.
+
+### 3.2 Schema sketch
+
+Public YAML uses the repository's existing hyphenated spelling; normalized
+runtime objects use snake_case. The sketch is illustrative, but the ownership,
+reference, and fail-closed rules are normative.
+
+```yaml
+config-version: 1
+
+# Lane B-owned; shown only to make the reference boundary explicit.
+team-profile: default
+agent-slots:
+  - slot-id: worker-1
+    provider: provider-default
+    model: provider-default
+
+# Lane A-owned.
+workspace-recipes:
+  bugfix-two-slot:
+    schema-version: 1
+    panes:
+      - pane-key: implement
+        workflow-role: implementer
+        slot-ref: worker-1
+        requires-capabilities: [file-edit]
+        region: main
+        worktree:
+          mode: managed
+          name-template: "{{workflow-id}}-implement"
+      - pane-key: verify
+        workflow-role: verifier
+        slot-selector:
+          requires-capabilities: [review]
+        region: side
+        worktree:
+          mode: read-only-reference
+    startup-actions:
+      - action-id: prepare-implement-worktree
+        kind: ensure-managed-worktree
+        pane-ref: implement
+      - action-id: start-verify-slot
+        kind: ensure-slot-ready
+        pane-ref: verify
+
+workflows:
+  bugfix:
+    schema-version: 1
+    recipe-ref: bugfix-two-slot
+    nodes:
+      - node-id: inspect
+        pane-ref: implement
+        action: operator-dispatch
+        idempotency-key: "{{run-id}}:inspect"
+      - node-id: implement
+        pane-ref: implement
+        depends-on: [inspect]
+        action: operator-dispatch
+        idempotency-key: "{{run-id}}:implement"
+      - node-id: verify
+        pane-ref: verify
+        depends-on: [implement]
+        action: verification
+        context-pack-ref: review-pack
+        idempotency-key: "{{run-id}}:verify"
+    resume-policy:
+      mode: operator-confirmed
+      reject-completed-runs: true
+    cleanup-policy:
+      mode: compensating-actions
+      on: [success, failure, cancel]
+
+context-packs:
+  review-pack:
+    schema-version: 1
+    include: [code-map, changed-files, tests, evidence-refs]
+    limits:
+      max-files: 100
+      max-bytes: 262144
+      max-evidence-refs: 50
+    privacy:
+      raw-transcript: false
+      prompt-bodies: false
+      secrets: false
+      private-local-paths: false
+```
+
+Normative field rules:
+
+- Every definition has an independent `schema-version`. Adding these
+  contracts does not require changing the current top-level manifest version
+  from `1` or invalidating current `.winsmux.yaml` files.
+- IDs are stable ASCII identifiers and unique within their containing map.
+- `slot-ref` is an exact Lane B slot reference. `slot-selector` is a
+  deterministic capability constraint and must produce exactly one effective
+  slot after availability masking.
+- `workflow-role` is a role in this workflow only. It is not Lane B's persistent
+  slot `role_profile` and cannot rewrite it.
+- Startup actions are a closed typed enum with schema-validated arguments.
+  Arbitrary shell text, inline credentials, and provider prompt bodies are not
+  valid startup actions.
+- Worktree paths are derived by runtime policy. Config may provide a safe name
+  template but not an absolute private path or an escape outside the managed
+  worktree root.
+- DAG dependencies must be acyclic. Each side-effecting node has a stable
+  idempotency key and an explicit compensation or cleanup classification.
+- Context-pack `include` values are allowlisted projections. Omitted limits use
+  conservative defaults; disabling privacy exclusions is not supported.
+
+### 3.3 Runtime manifest projection
+
+TASK-658 and TASK-659 add optional versioned sections to the existing
+`.winsmux/manifest.yaml` instead of replacing `session`, `panes`, `tasks`, or
+`worktrees`:
+
+```yaml
+declarative_workspace:
+  schema_version: 1
+  config_fingerprint: sha256:...
+  recipe_id: bugfix-two-slot
+  resolved_bindings:
+    implement: worker-1
+    verify: worker-2
+  dry_run_plan_ref: evidence:...
+
+workflow_runs:
+  run-123:
+    schema_version: 1
+    workflow_id: bugfix
+    state: blocked
+    config_fingerprint: sha256:...
+    nodes:
+      inspect:
+        state: succeeded
+        attempt: 1
+        idempotency_key: run-123:inspect
+        evidence_refs: [evidence:...]
+      implement:
+        state: blocked
+        attempt: 1
+        checkpoint_ref: checkpoint:...
+    cleanup_journal: []
+    rollback_state: not_requested
+    context_pack_refs: [context-pack:...]
+```
+
+The PowerShell writer in `winsmux-core/scripts/manifest.ps1` currently emits a
+fixed section set, so child implementation must preserve unknown additive
+sections on read/write and add focused round-trip tests. The Rust
+`WinsmuxManifest`/`NormalizedManifestPane` path must continue to accept a
+manifest containing these sections even before every consumer uses them.
+
+Runtime values are projections, not re-parsed intent:
+
+- pane entries receive resolved slot, workflow role, worktree reference, task
+  identity, capabilities, and current state;
+- workflow entries receive the normalized DAG, node states, attempts,
+  idempotency records, checkpoint refs, and cleanup journal;
+- ledger events receive state transitions and attributable evidence refs;
+- context packs receive public repository-relative refs and digests only;
+- Context Capsule and Checkpoint package receive the context-pack ref and
+  freshness/config fingerprint needed to judge safe resume.
+
+## 4. Resumable workflow state model
+
+A workflow run has an explicit state: `planned`, `ready`, `running`, `blocked`,
+`failed`, `cleanup_pending`, `succeeded`, `cancelled`, or `rolled_back`. A node
+has `pending`, `ready`, `dispatching`, `running`, `blocked`, `failed`,
+`succeeded`, `cleanup_pending`, `cleaned`, or `rolled_back`.
+
+State transitions are driven by structured runtime results and recorded
+acknowledgements, never by sniffing pane text for success words. Dispatch
+success requires the existing mailbox/acknowledgement contract; a process exit
+code or successful write is not sufficient proof.
+
+For every side effect, runtime must persist the transition intent and
+idempotency key before dispatch and persist the acknowledgement/evidence before
+unlocking dependent nodes. On restart:
+
+1. load and validate the manifest and ledger evidence;
+2. verify the workflow schema version, config fingerprint, source head, slot
+   bindings, checkpoint freshness, and privacy gate;
+3. reconcile `dispatching` or `running` nodes with mailbox and pane state;
+4. skip nodes whose matching idempotency record is already `succeeded`;
+5. surface ambiguous work as `blocked` for operator judgement;
+6. resume only unfinished nodes after explicit operator confirmation; and
+7. reject automatic resume of `succeeded`, `cancelled`, or `rolled_back` runs.
+
+Cleanup is a journaled sequence of typed compensating actions. Each action has
+its own idempotency key and terminal status, so interruption during cleanup is
+resumable without repeating a completed destructive action. Rollback means
+running those declared compensations in reverse dependency order; it does not
+mean `git reset --hard`, deleting an unverified worktree, or undoing external
+effects that the workflow never declared.
+
+## 5. Repository context pack
+
+The repository context pack is a bounded projection layered on the context
+budget contract in `core/src/ledger.rs`. It is not a transcript summary and is
+not a replacement for Context Capsule v1 or Checkpoint package v1.
+
+Required projection groups are:
+
+- `code_map`: repository-relative modules or symbols selected by deterministic
+  rules, with source head and optional digests;
+- `changed_files`: public repository-relative paths and bounded diff summaries,
+  reusing the current `public_changed_files` privacy behavior;
+- `tests`: check identifiers, commands when public-safe, outcomes, timestamps,
+  and evidence refs rather than raw output;
+- `evidence_refs`: allowlisted durable refs already attributable through the
+  ledger; and
+- `freshness`: source head, config fingerprint, creation time, limits applied,
+  omissions, and redaction counts.
+
+Generation is deterministic for the same source head, policy, and evidence
+set. When a limit is reached, the pack reports truncation and omitted counts;
+it does not silently exceed the budget. The pack is invalid if it contains a
+raw terminal transcript, prompt body, secret, credential material, provider
+hidden metadata, an absolute private path, or a reference outside the allowed
+project/evidence namespaces.
+
+The manifest stores only pack ID, schema version, digest, freshness, limits,
+and durable reference. The ledger's context contract carries the ref and the
+summary quality/privacy result. A stale, invalid, source-head-mismatched, or
+over-budget pack is not routable and cannot authorize resume.
+
+## 6. Child task contracts
+
+Each child is a separate implementation and PR unit. A child may use fixtures
+for later contracts, but it must not absorb another child's production scope.
+The merge order remains TASK-658, TASK-659, TASK-660, TASK-661, then TASK-662.
+
+### 6.1 TASK-658: workspace layout and recipe definitions
+
+**Owns:** the Lane A `.winsmux.yaml` schema and normalization for
+`workspace_recipes`; logical pane geometry; workflow-role-to-slot references;
+capability validation; managed-worktree policy; the closed startup-action
+enum; dry-run workspace planning; and projection of the selected recipe and
+resolved bindings into the runtime manifest.
+
+**Does not own:** provider/model/reasoning assignment, `team_profile`,
+`agent_slots`, workflow execution state, context-pack generation, presets, or
+desktop release parity.
+
+**Acceptance gate:**
+
+- valid recipe fixtures round-trip through both PowerShell and Rust readers;
+- duplicate IDs, unknown actions, path escapes, ambiguous selectors, missing
+  slots, and capability mismatches fail before pane/worktree creation;
+- existing `.winsmux.yaml` files without Lane A keys produce the current
+  layout and startup behavior unchanged;
+- Lane B-owned fields survive normalization and manifest projection without
+  being copied into Lane A definitions;
+- dry-run emits a deterministic, secret-free plan containing resolved slots,
+  pane geometry, worktrees, startup actions, and zero side effects; and
+- manifest round-trip preserves both existing and additive sections.
+
+### 6.2 TASK-659: resumable workflow and pipeline
+
+**Owns:** workflow DAG validation; the run/node state machines; dependency
+release; persisted idempotency records; operator-confirmed resume; structured
+dispatch acknowledgement; retry accounting; checkpoint reconciliation;
+journaled cleanup; and declared rollback. It evolves or wraps
+`winsmux-core/scripts/team-pipeline.ps1` so the current pipeline remains the
+single dispatch behavior.
+
+**Does not own:** recipe parsing beyond consuming TASK-658's normalized plan,
+repository context selection, gallery content, or final desktop/CLI parity.
+
+**Acceptance gate:**
+
+- cyclic or missing dependencies fail before dispatch;
+- an interruption is simulated at every side-effect boundary and resume
+  continues only unfinished nodes;
+- repeating the same idempotency key cannot repeat a completed side effect;
+- ambiguous `dispatching`/`running` state becomes `blocked`, not guessed
+  success or failure;
+- cleanup can itself be interrupted and resumed, and each compensation runs at
+  most once;
+- completed/cancelled/rolled-back runs reject automatic resume; and
+- the existing non-declarative team pipeline still passes its focused tests
+  and uses the same operator approval/review boundaries.
+
+### 6.3 TASK-660: repository context package
+
+**Owns:** the `context_packs` schema; deterministic `code_map`, changed-file,
+test, and evidence-ref projections; byte/item budgets; freshness and source-head
+checks; redaction; pack digests; and integration with the existing ledger
+context contract, Context Capsule, and Checkpoint package.
+
+**Does not own:** raw transcript capture, general-purpose repository indexing,
+prompt storage, provider memory, workflow state transitions, or preset UX.
+
+**Acceptance gate:**
+
+- identical public inputs produce the same digest and bounded ordering;
+- every projection enforces file, byte, and reference limits and reports
+  truncation/omissions;
+- synthetic secrets, absolute private paths, prompt bodies, raw transcripts,
+  and refs outside allowlisted namespaces are rejected or redacted with a
+  failing privacy result where required;
+- changed files and tests remain attributable to source head and evidence refs;
+- stale/source-mismatched/invalid packs are not routable and cannot satisfy a
+  resume gate; and
+- context-pack metadata round-trips without persisting raw diff/tool output in
+  `.winsmux/manifest.yaml`.
+
+### 6.4 TASK-661: templates, gallery, and migration path
+
+**Owns:** four public presets (`bugfix`, `review`, `research`, `benchmark`),
+examples and gallery metadata, schema validation for shipped presets, and an
+explicit preview/apply migration path from current operator settings to Lane A
+declarations.
+
+**Does not own:** new execution semantics, provider/model pins, rewriting Lane
+B team profiles, silent config mutation, or removal of the current operator
+flow.
+
+**Acceptance gate:**
+
+- all four presets validate against TASK-658/TASK-659/TASK-660 contracts and
+  contain no secrets, private paths, provider-specific model pins, or prompt
+  bodies;
+- preset selection resolves through capabilities/slot refs and produces a
+  deterministic dry-run;
+- migration preview is side-effect free and reports additions, preserved
+  fields, unsupported inputs, and rollback instructions;
+- apply is explicit, creates a reversible backup or equivalent atomic replace,
+  preserves Lane B-owned and unknown compatible fields, and is idempotent; and
+- users may continue the existing operator flow without migrating.
+
+### 6.5 TASK-662: workflow pre-release gate
+
+**Owns:** the aggregate release gate for declarative workflows: dry-run purity,
+rollback/cleanup recovery, interruption/resume, docs/examples, public-surface
+audit, and desktop/CLI parity. It also verifies the combined Lane A/Lane B
+config after TASK-718.
+
+**Does not own:** feature implementation hidden inside gate code, weakening
+tests to obtain a pass, GitHub Release publication without the separate release
+approval, or automatic merge/release authority.
+
+**Acceptance gate:**
+
+- CLI and desktop load the same config fixture and report the same normalized
+  recipe, workflow, resolved slots, context-pack metadata, run state, and
+  blocking reasons;
+- dry-run proves no panes, worktrees, messages, workflow state, or cleanup
+  actions were mutated;
+- restart tests cover interruption before dispatch, after dispatch/before ack,
+  after ack/before dependent release, during cleanup, and after terminal state;
+- rollback evidence identifies each declared compensation and proves completed
+  compensations are not repeated;
+- legacy/no-Lane-A configuration passes regression coverage;
+- all shipped presets and migration examples are schema-checked in CI;
+- public-surface and privacy scans prove no planning files, raw transcripts,
+  secrets, private paths, or internal prompt bodies are exposed; and
+- TASK-718's team-profile/agent-slot desktop gate is green before TASK-662 can
+  mark the v0.36.29 combined release gate complete.
+
+## 7. Pre-release gate wiring
+
+TASK-662 should expose one aggregate result with separately attributable
+sub-gates. A single green unit-test command is not sufficient release evidence.
+
+| Gate | Required evidence | Failure behavior |
+| --- | --- | --- |
+| Dry-run | Normalized config fingerprint, resolved bindings, planned panes/worktrees/actions, and before/after runtime-state equality. | Fail if any runtime mutation or unresolved binding occurs. |
+| Resume | Interruption matrix, checkpoint freshness, source/config match, mailbox reconciliation, and node/idempotency states. | Block for operator decision on stale, ambiguous, terminal, or mismatched state. |
+| Rollback/cleanup | Compensation plan, reverse dependency order, per-action idempotency result, and remaining external effects. | Stop on an unsafe/unknown compensation and preserve the journal for resume. |
+| Documentation/examples | Schema validation for every documented snippet and all four shipped presets; migration preview/apply/rollback evidence. | Fail on drift between docs, CLI, desktop, or schema. |
+| CLI/desktop parity | Golden normalized contract plus equivalent visible state, blocking reasons, and actions from both surfaces. | Fail closed; neither surface may claim the workflow is ready. |
+| Compatibility/privacy | Current operator-flow regressions, manifest round-trip, public-surface audit, and bounded-context privacy fixtures. | Preserve the old path and reject unsafe new artifacts. |
+
+The aggregate gate reports `pass`, `fail`, `blocked`, or `not_applicable` per
+sub-gate, with evidence refs and a reason. `blocked` is not converted to
+`pass`. Desktop rendering is evidence of parity only when the CLI and desktop
+consume the same normalized contract, not when their labels merely look
+similar.
+
+## 8. Migration, compatibility, and old-path treatment
+
+The current `.winsmux.yaml` keys, default external-operator layout,
+`agent_slots` behavior, `orchestra-start.ps1` entrypoint, one-shot
+`team-pipeline.ps1` path, and operator-owned decisions are intentionally
+preserved.
+
+Lane A keys are opt-in. Absence of `workspace_recipes`, `workflows`, and
+`context_packs` selects current behavior. The gallery may generate a proposal,
+but no existing project is rewritten until an explicit migration apply.
+Unknown incompatible schema versions fail with an actionable error; they do
+not fall back to a partially understood workflow.
+
+Rollback for adoption means restoring the prior `.winsmux.yaml` and removing
+or archiving the new run-scoped runtime state after safety checks. Runtime
+rollback never edits the external planning backlog and never removes a user
+worktree merely because a workflow record is incomplete.
+
+## 9. Risks and mitigations
+
+| Risk | Required mitigation |
+| --- | --- |
+| Lane A and Lane B both redefine slot/provider assignment. | Enforce namespace ownership and resolve Lane B slots before Lane A bindings; add shared cross-lane fixtures. |
+| Config changes make an old checkpoint unsafe. | Persist normalized snapshot/config fingerprint and block resume on mismatch. |
+| Duplicate dispatch after crash. | Persist intent/idempotency before dispatch and reconcile mailbox acknowledgement before retry. |
+| Manifest writers drop new or unknown sections. | Add lossless additive-section round-trip tests to PowerShell and Rust paths. |
+| Arbitrary startup actions become a command-injection surface. | Closed action enum, schema-validated arguments, managed-path checks, no inline shell or credentials. |
+| Context packs leak private content or grow without bound. | Allowlisted projections, hard limits, public refs, deterministic redaction, and fail-closed privacy gate. |
+| Cleanup repeats destructive work. | Journal each compensation with a stable idempotency key and require explicit operator handling for ambiguity. |
+| Desktop and CLI implement different semantics. | One normalized contract and golden parity fixtures; UI does not rederive runtime meaning. |
+| TASK-662 runs before Lane B is complete. | Allow Lane A-only gate development, but keep the combined release result blocked until TASK-718 evidence is present. |
+| Declarative automation weakens operator authority. | Operator-confirmed start/resume/rollback and evidence-based final judgement remain mandatory. |
+
+## 10. Non-goals
+
+- implementing TASK-658 through TASK-662 in this parent task
+- replacing the external operator or existing operator/pane responsibility
+  boundary
+- removing or silently migrating the current layout and one-shot pipeline
+- owning Lane B's `team_profile`, `agent_slots`, provider, model, reasoning,
+  role-profile, lifecycle, or task-class configuration
+- storing raw transcripts, prompt bodies, secrets, credential material,
+  provider hidden metadata, raw tool output, or private absolute paths
+- using freeform pane text or in-band sentinels as workflow truth
+- automatic merge, release, rollback, or destructive worktree cleanup
+- general-purpose repository indexing or unbounded long-term agent memory
+- changing external planning files as part of workflow execution
+
+## 11. Decision record
+
+Status: foundation design accepted for child implementation.
+
+Decision: extend the existing operator/evidence control plane with additive,
+versioned Lane A namespaces in `.winsmux.yaml`, project normalized runtime state
+into `.winsmux/manifest.yaml` and ledger evidence, and keep Lane B as the sole
+owner of persistent team/slot/provider assignment.
+
+Consequence: TASK-658 through TASK-662 have independent implementation and
+verification boundaries, current projects retain their existing behavior, and
+the v0.36.29 release can require safe dry-run, resume, rollback, bounded
+context, migration, and desktop/CLI parity without creating a second operator
+or evidence model.


### PR DESCRIPTION
## Summary

Foundation design for v0.36.29 Lane A (TASK-657, umbrella for TASK-658..662): adds reusable workspace **layout / workflow / context pack** concepts on top of the existing operator + evidence model, and fixes each child task's scope, responsibility boundary, and verification gate.

Doc-only: `docs/project/v03629-declarative-workspace-architecture.md`. No runtime code changes. The `.winsmux.yaml` schema boundary is explicitly reconciled with Lane B (TASK-713/715) so the two lanes compose in one config file without collision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)