### PR TITLE
fix: reset desktop SGR mouse tracking after TUI exit (closes #1133)

### DIFF
--- a/winsmux-app/package.json
+++ b/winsmux-app/package.json
@@ -27,6 +27,7 @@
     "test:v03628-packaged-restore-gate": "pwsh -NoProfile -File ../scripts/test-v03628-packaged-restore-gate.ps1 -Json -RequireEvidence",
     "test:automation-driver-pool": "node ./scripts/automation-driver-pool-check.mjs",
     "test:desktop-summary-scheduler": "node --experimental-strip-types ./scripts/desktop-summary-scheduler-check.mjs",
+    "test:terminal-mouse-tracking": "node --experimental-strip-types ./scripts/terminal-mouse-tracking-check.mjs",
     "test:editor-targets": "node ./scripts/editor-targets-check.mjs",
     "test:project-explorer-tree": "node ./scripts/project-explorer-tree-check.mjs",
     "test:settings-preference-options": "node --experimental-strip-types ./scripts/settings-preference-options-check.mjs",

--- a/winsmux-app/scripts/terminal-mouse-tracking-check.mjs
+++ b/winsmux-app/scripts/terminal-mouse-tracking-check.mjs
@@ -4,7 +4,7 @@ import {
   resetTerminalMouseTracking,
 } from "../src/terminalMouseTracking.ts";
 
-const MOUSE_TRACKING_RESET_SEQUENCE = "\x1b[?1006l\x1b[?1003l\x1b[?1002l\x1b[?1000l";
+const MOUSE_TRACKING_RESET_SEQUENCE = "\x1b[?1015l\x1b[?1006l\x1b[?1005l\x1b[?1003l\x1b[?1002l\x1b[?1000l\x1b[?9l";
 
 class FakeTerminal {
   writes = [];

--- a/winsmux-app/scripts/terminal-mouse-tracking-check.mjs
+++ b/winsmux-app/scripts/terminal-mouse-tracking-check.mjs
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import {
+  installTerminalMouseTrackingReset,
+  resetTerminalMouseTracking,
+} from "../src/terminalMouseTracking.ts";
+
+const MOUSE_TRACKING_RESET_SEQUENCE = "\x1b[?1006l\x1b[?1003l\x1b[?1002l\x1b[?1000l";
+
+class FakeTerminal {
+  writes = [];
+  csiHandler = null;
+
+  parser = {
+    registerCsiHandler: (identifier, callback) => {
+      assert.deepEqual(identifier, { prefix: "?", final: "l" });
+      this.csiHandler = callback;
+      return { dispose() {} };
+    },
+  };
+
+  write(data) {
+    this.writes.push(data);
+  }
+}
+
+async function flushMicrotasks() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+for (const alternateScreenMode of [47, 1047, 1049]) {
+  const terminal = new FakeTerminal();
+  installTerminalMouseTrackingReset(terminal);
+  assert.ok(terminal.csiHandler, "expected a DEC private-mode reset handler");
+  assert.equal(terminal.csiHandler([alternateScreenMode]), false, "the xterm fallback handler must still process the TUI exit");
+  await flushMicrotasks();
+  assert.deepEqual(
+    terminal.writes,
+    [MOUSE_TRACKING_RESET_SEQUENCE],
+    "leaving the alternate screen with active mouse tracking must clear every supported tracking mode",
+  );
+}
+
+{
+  const terminal = new FakeTerminal();
+  installTerminalMouseTrackingReset(terminal);
+  terminal.csiHandler([1049]);
+  terminal.csiHandler([1047]);
+  await flushMicrotasks();
+  assert.deepEqual(
+    terminal.writes,
+    [MOUSE_TRACKING_RESET_SEQUENCE],
+    "multiple alternate-screen exits in one parser turn must schedule only one frontend reset",
+  );
+}
+
+{
+  const terminal = new FakeTerminal();
+  installTerminalMouseTrackingReset(terminal);
+  terminal.csiHandler([25]);
+  await flushMicrotasks();
+  assert.deepEqual(terminal.writes, [], "unrelated DEC private-mode resets must not change mouse tracking");
+}
+
+{
+  const terminal = new FakeTerminal();
+  resetTerminalMouseTracking(terminal);
+  assert.deepEqual(terminal.writes, [MOUSE_TRACKING_RESET_SEQUENCE], "lifecycle cleanup must use the same exact reset sequence");
+}
+
+process.stdout.write("[terminal-mouse-tracking] PASS\n");

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -50,6 +50,7 @@ import {
   subscribeToPtyOutput,
   writePtyData,
 } from "./ptyClient";
+import { installTerminalMouseTrackingReset, resetTerminalMouseTracking } from "./terminalMouseTracking";
 import { isComposerCommandText, normalizeComposerPlainTextPaste } from "./composerText";
 import {
   buildProjectExplorerTree,
@@ -1732,6 +1733,8 @@ function createWorkbenchTerminal(options?: { cursorBlink?: boolean; scrollback?:
     scrollback: options?.scrollback ?? 1000,
     theme: getWorkbenchTerminalTheme(),
   });
+  // createWorkbenchTerminal is shared by the operator and every worker pane.
+  installTerminalMouseTrackingReset(terminal);
   attachTerminalCopySelectionGuard(terminal);
   return terminal;
 }
@@ -1816,6 +1819,19 @@ function writeOperatorTerminal(data: string) {
     return;
   }
   operatorTerminal.write(data);
+}
+
+function resetOperatorTerminalMouseTracking() {
+  if (operatorTerminal) {
+    resetTerminalMouseTracking(operatorTerminal);
+  }
+}
+
+function resetPaneTerminalMouseTracking(paneId: string) {
+  const entry = panes.get(paneId);
+  if (entry) {
+    resetTerminalMouseTracking(entry.terminal);
+  }
 }
 
 function markOperatorPtyStartedFromExternalEvent() {
@@ -18038,15 +18054,23 @@ function handleDesktopSummaryLiveRefreshEvent(event: DesktopSummaryRefreshEvent)
   if (event.source === "pty" && event.pane_id) {
     if (event.pane_id === OPERATOR_PTY_ID) {
       if (event.reason === "pty.close") {
+        resetOperatorTerminalMouseTracking();
         markOperatorPtyStoppedFromExternalEvent();
       } else if (event.reason === "pty.spawn" || event.reason === "pty.respawn") {
+        if (event.reason === "pty.respawn") {
+          resetOperatorTerminalMouseTracking();
+        }
         markOperatorPtyStartedFromExternalEvent();
       }
     } else {
       const workbenchPaneId = resolveWorkbenchPaneIdForBackendPaneId(event.pane_id);
       if (workbenchPaneId && event.reason === "pty.close") {
+        resetPaneTerminalMouseTracking(workbenchPaneId);
         markPanePtyStoppedFromExternalEvent(workbenchPaneId);
       } else if (workbenchPaneId && (event.reason === "pty.spawn" || event.reason === "pty.respawn")) {
+        if (event.reason === "pty.respawn") {
+          resetPaneTerminalMouseTracking(workbenchPaneId);
+        }
         markPanePtyStartedFromExternalEvent(workbenchPaneId);
       }
     }

--- a/winsmux-app/src/terminalMouseTracking.ts
+++ b/winsmux-app/src/terminalMouseTracking.ts
@@ -1,0 +1,38 @@
+const MOUSE_TRACKING_RESET_SEQUENCE = "\x1b[?1006l\x1b[?1003l\x1b[?1002l\x1b[?1000l";
+const ALTERNATE_SCREEN_MODES = new Set([47, 1047, 1049]);
+
+type CsiParameter = number | number[];
+
+interface TerminalMouseTrackingTerminal {
+  parser: {
+    registerCsiHandler(
+      identifier: { prefix?: string; final: string },
+      callback: (params: CsiParameter[]) => boolean,
+    ): { dispose(): void };
+  };
+  write(data: string): void;
+}
+
+export function resetTerminalMouseTracking(terminal: TerminalMouseTrackingTerminal) {
+  terminal.write(MOUSE_TRACKING_RESET_SEQUENCE);
+}
+
+export function installTerminalMouseTrackingReset(terminal: TerminalMouseTrackingTerminal) {
+  let resetScheduled = false;
+  return terminal.parser.registerCsiHandler({ prefix: "?", final: "l" }, (params) => {
+    const exitsAlternateScreen = params.some((param) => typeof param === "number" && ALTERNATE_SCREEN_MODES.has(param));
+    if (!exitsAlternateScreen || resetScheduled) {
+      return false;
+    }
+
+    resetScheduled = true;
+    queueMicrotask(() => {
+      resetScheduled = false;
+      // Let xterm process the TUI's DECRST first, then clear every supported
+      // tracking mode in the frontend. xterm does not expose SGR encoding
+      // state separately, so an active-protocol check would miss a leaked 1006.
+      resetTerminalMouseTracking(terminal);
+    });
+    return false;
+  });
+}

--- a/winsmux-app/src/terminalMouseTracking.ts
+++ b/winsmux-app/src/terminalMouseTracking.ts
@@ -1,4 +1,4 @@
-const MOUSE_TRACKING_RESET_SEQUENCE = "\x1b[?1006l\x1b[?1003l\x1b[?1002l\x1b[?1000l";
+const MOUSE_TRACKING_RESET_SEQUENCE = "\x1b[?1015l\x1b[?1006l\x1b[?1005l\x1b[?1003l\x1b[?1002l\x1b[?1000l\x1b[?9l";
 const ALTERNATE_SCREEN_MODES = new Set([47, 1047, 1049]);
 
 type CsiParameter = number | number[];


### PR DESCRIPTION
Closes #1133. Desktop panes left SGR mouse-tracking enabled after a TUI exited, so raw mouse reports spewed into the shell prompt. This resets the SGR mouse-tracking modes when a TUI relinquishes them, so the pane returns to a clean prompt. Includes a red→green regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)