### PR TITLE
test(core): deterministic run_shell tests (closes #1117)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6378,6 +6378,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha2",
+ "tempfile",
  "unicode-width",
  "vt100-winsmux",
  "which",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -88,3 +88,6 @@ sha2 = "0.10"
 regex = "1"
 glob = "0.3"
 rusqlite = { version = "0.32", features = ["bundled"] }
+
+[dev-dependencies]
+tempfile = "3"

--- a/core/tests-rs/test_commands_new.rs
+++ b/core/tests-rs/test_commands_new.rs
@@ -4,6 +4,50 @@
 
 use super::*;
 use crossterm::event::{KeyCode, KeyModifiers};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Mutex, MutexGuard};
+use std::time::{Duration, Instant};
+
+static RUN_SHELL_TEST_MUTEX: Mutex<()> = Mutex::new(());
+static RUN_SHELL_MARKER_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+fn lock_run_shell_test() -> MutexGuard<'static, ()> {
+    RUN_SHELL_TEST_MUTEX.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+fn unique_run_shell_marker() -> std::path::PathBuf {
+    let sequence = RUN_SHELL_MARKER_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+    std::env::temp_dir().join(format!(
+        "winsmux-run-shell-{}-{sequence}.marker",
+        std::process::id()
+    ))
+}
+
+#[cfg(windows)]
+fn quote_run_shell_marker(path: &std::path::Path) -> String {
+    format!("'{}'", path.display().to_string().replace('\'', "''"))
+}
+
+#[cfg(not(windows))]
+fn quote_run_shell_marker(path: &std::path::Path) -> String {
+    format!("'{}'", path.display().to_string().replace('\'', "'\"'\"'"))
+}
+
+fn wait_for_run_shell_marker(path: &std::path::Path) {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        if matches!(std::fs::read_to_string(path).as_deref(), Ok("background-test")) {
+            std::fs::remove_file(path).expect("run-shell marker should be removable");
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "background run-shell did not complete before timeout: {}",
+            path.display()
+        );
+        std::thread::sleep(Duration::from_millis(10));
+    }
+}
 
 fn mock_app() -> AppState {
     let mut app = AppState::new("test_session".to_string());
@@ -1602,6 +1646,7 @@ fn window_index_prompt_accepts_digits_only() {
 
 #[test]
 fn run_shell_captures_and_displays_output() {
+    let _guard = lock_run_shell_test();
     let mut app = mock_app();
     // Use a simple echo command that produces stdout
     #[cfg(windows)]
@@ -1629,24 +1674,36 @@ fn run_shell_captures_and_displays_output() {
 
 #[test]
 fn run_shell_background_does_not_show_popup() {
+    let _guard = lock_run_shell_test();
     let mut app = mock_app();
-    // With -b flag: should NOT enter PopupMode
+    let marker = unique_run_shell_marker();
+    let marker_arg = quote_run_shell_marker(&marker);
+    // With -b flag: should NOT enter PopupMode. The marker lets this test wait
+    // for the detached child instead of leaking it into the next run-shell test.
     #[cfg(windows)]
-    let cmd = r#"run-shell -b "Write-Output 'background-test'""#;
+    let cmd = format!(
+        r#"run-shell -b "Write-Output 'background-test' | Out-Null; Set-Content -LiteralPath {} -Value 'background-test' -NoNewline""#,
+        marker_arg
+    );
     #[cfg(not(windows))]
-    let cmd = r#"run-shell -b "echo background-test""#;
+    let cmd = format!(
+        r#"run-shell -b "printf '%s' background-test > {}""#,
+        marker_arg
+    );
 
-    let _ = execute_command_string(&mut app, cmd);
+    let _ = execute_command_string(&mut app, &cmd);
 
     assert!(
         !matches!(app.mode, Mode::PopupMode { .. }),
         "run-shell -b should NOT produce a popup, mode = {:?}",
         std::mem::discriminant(&app.mode)
     );
+    wait_for_run_shell_marker(&marker);
 }
 
 #[test]
 fn run_shell_alias_captures_output() {
+    let _guard = lock_run_shell_test();
     let mut app = mock_app();
     // "run" is the short alias for "run-shell"
     #[cfg(windows)]
@@ -1673,6 +1730,7 @@ fn run_shell_alias_captures_output() {
 
 #[test]
 fn run_shell_stderr_is_captured() {
+    let _guard = lock_run_shell_test();
     let mut app = mock_app();
     // Use a command that writes to stderr
     #[cfg(windows)]
@@ -1699,6 +1757,7 @@ fn run_shell_stderr_is_captured() {
 
 #[test]
 fn run_shell_empty_output_no_popup() {
+    let _guard = lock_run_shell_test();
     let mut app = mock_app();
     // A command that produces no output should not show a popup
     #[cfg(windows)]

--- a/core/tests-rs/test_commands_new.rs
+++ b/core/tests-rs/test_commands_new.rs
@@ -4,23 +4,13 @@
 
 use super::*;
 use crossterm::event::{KeyCode, KeyModifiers};
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Mutex, MutexGuard};
 use std::time::{Duration, Instant};
 
 static RUN_SHELL_TEST_MUTEX: Mutex<()> = Mutex::new(());
-static RUN_SHELL_MARKER_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 
 fn lock_run_shell_test() -> MutexGuard<'static, ()> {
     RUN_SHELL_TEST_MUTEX.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
-}
-
-fn unique_run_shell_marker() -> std::path::PathBuf {
-    let sequence = RUN_SHELL_MARKER_SEQUENCE.fetch_add(1, Ordering::Relaxed);
-    std::env::temp_dir().join(format!(
-        "winsmux-run-shell-{}-{sequence}.marker",
-        std::process::id()
-    ))
 }
 
 #[cfg(windows)]
@@ -1676,7 +1666,13 @@ fn run_shell_captures_and_displays_output() {
 fn run_shell_background_does_not_show_popup() {
     let _guard = lock_run_shell_test();
     let mut app = mock_app();
-    let marker = unique_run_shell_marker();
+    // The unique TempDir makes this completion marker invocation-specific across
+    // test processes, and remains alive until the detached child has completed.
+    let marker_dir = tempfile::Builder::new()
+        .prefix("winsmux-run-shell-")
+        .tempdir()
+        .expect("run-shell test marker directory should be creatable");
+    let marker = marker_dir.path().join("background-complete.marker");
     let marker_arg = quote_run_shell_marker(&marker);
     // With -b flag: should NOT enter PopupMode. The marker lets this test wait
     // for the detached child instead of leaking it into the next run-shell test.
@@ -1691,6 +1687,11 @@ fn run_shell_background_does_not_show_popup() {
         marker_arg
     );
 
+    assert!(
+        !marker.exists(),
+        "fresh run-shell marker must not exist before spawning: {}",
+        marker.display()
+    );
     let _ = execute_command_string(&mut app, &cmd);
 
     assert!(


### PR DESCRIPTION
Closes #1117. `commands::tests_new_commands::run_shell_*` failed intermittently in Core Build and Test. Fixes the test isolation deterministically (root cause: shared/racy state across tests) without weakening what the tests assert and without ignoring/skipping any test. Verified with repeated serialized and parallel runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)