### PR TITLE
fix(bench): wait for exact dispatch echo receipt (closes #1134)

### DIFF
--- a/winsmux-app/scripts/bakeoff-runner-check.mjs
+++ b/winsmux-app/scripts/bakeoff-runner-check.mjs
@@ -356,6 +356,16 @@ assert.deepEqual(
   { beginCount: 0, endCount: 0 },
   "the receipt itself must establish a no-completion baseline after the full packet echo",
 );
+assert.deepEqual(
+  countCliMarkersAfterEchoReceipt(
+    `BAKEOFF_ROUND_A_BEGIN\nBAKEOFF_ROUND_A_END\n${dispatchReceipt}\nBAKEOFF_ROUND_A_BEGIN\nBAKEOFF_ROUND_A_END\n${dispatchReceipt}\nwaiting for worker output`,
+    dispatchReceipt,
+    "BAKEOFF_ROUND_A_BEGIN",
+    "BAKEOFF_ROUND_A_END",
+  ),
+  { beginCount: 0, endCount: 0 },
+  "a repeated dispatch echo must anchor the suffix on the last receipt, not treat the earlier echoed END marker as worker output",
+);
 
 // --- selectNewRunDir ------------------------------------------------------
 

--- a/winsmux-app/scripts/bakeoff-runner-check.mjs
+++ b/winsmux-app/scripts/bakeoff-runner-check.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
 import {
   parseManifestPaneIds,
   collectReadyWorkers,
@@ -9,6 +10,10 @@ import {
   classifyApiOutcome,
   getPacketMarkers,
   classifyCliWorker,
+  buildCliDispatchEchoMarker,
+  extractLatestDispatchId,
+  countCliMarkersAfterEchoReceipt,
+  hasTaskTimedOut,
   selectNewRunDir,
   buildReadyCheckCommand,
   buildDispatchCommand,
@@ -89,19 +94,16 @@ assert.deepEqual(collectReadyWorkers(undefined), new Set(), "collectReadyWorkers
 
 // --- countEndMarkers -------------------------------------------------------
 //
-// Strategy note (round-7 fix, baseline-timing updated round-8): completion
-// detection is no longer line-shape filtering. Every packet instructs the
+// Strategy note (round-7 fix, baseline-timing updated round-8/#1134):
+// completion detection is no longer line-shape filtering. Every packet instructs the
 // worker to return a numbered list whose item 5 IS the round END marker
 // (e.g. "5. BAKEOFF_ROUND_A_END", often backtick-wrapped) -- a compliant
 // completion is therefore indistinguishable, by line shape, from the
 // dispatch echo of that same packet text. countEndMarkers is now an honest
 // raw substring occurrence count; echo disambiguation happens in the RUNNER
-// by seeding its baseline AFTER dispatch has been CONFIRMED via the
-// conversation-panel poll (countSha256Occurrences /
-// countDispatchBlockedNotices, plus ECHO_RENDER_SETTLE_MS in
-// run-cli-bakeoff.mjs), once the echo is already on screen -- not by
-// filtering line shapes here. Do not reintroduce line filtering in this
-// function.
+// by seeding its baseline only after dispatch has been confirmed and its
+// exact receipt appears at the end of the packet echo. Do not reintroduce
+// line filtering in this function.
 
 assert.equal(countEndMarkers(""), 0, "countEndMarkers must return 0 for empty text");
 assert.equal(countEndMarkers("no marker here"), 0, "countEndMarkers must return 0 when marker absent");
@@ -264,6 +266,95 @@ assert.equal(
   classifyCliWorker(1, 2, 3700, 3600),
   "completed",
   "classifyCliWorker must prefer completed over timeout when the marker count did increase, even past the timeout boundary",
+);
+assert.equal(hasTaskTimedOut(3599.9, 3600), false, "hasTaskTimedOut must keep a task active before its deadline");
+assert.equal(hasTaskTimedOut(3600, 3600), true, "hasTaskTimedOut must reject an outcome first observed at its deadline");
+
+// --- CLI dispatch echo receipt ------------------------------------------
+
+const dispatchReceipt = buildCliDispatchEchoMarker("dispatch-abc123");
+
+assert.equal(
+  dispatchReceipt,
+  "WINSMUX_BENCH_DISPATCH dispatch-abc123",
+  "buildCliDispatchEchoMarker must create the exact receipt appended after a CLI prompt",
+);
+assert.equal(
+  extractLatestDispatchId("dispatch-old\ndispatch-new42"),
+  "dispatch-new42",
+  "extractLatestDispatchId must select the latest desktop dispatch receipt",
+);
+assert.equal(
+  extractLatestDispatchId("no receipt"),
+  "",
+  "extractLatestDispatchId must return empty when the desktop did not expose a receipt",
+);
+const desktopMainSource = readFileSync(new URL("../src/main.ts", import.meta.url), "utf8");
+const runnerSource = readFileSync(new URL("./run-cli-bakeoff.mjs", import.meta.url), "utf8");
+assert.ok(
+    desktopMainSource.includes("WINSMUX_BENCH_DISPATCH ${dispatchId}") &&
+    desktopMainSource.includes("const promptWithDispatchReceipt") &&
+    desktopMainSource.includes("const cliDispatchPromptSha = await sha256Hex") &&
+    desktopMainSource.includes('`${packet.prompt}\\n\\n${buildCliBenchmarkDispatchEchoMarker(probeId)}`') &&
+    desktopMainSource.includes('{ label: "dispatch_id", value: probeId }'),
+  "main.ts must emit the same receipt, publish dispatch_id, and hash the receipt-inclusive CLI prompt",
+);
+assert.ok(
+  runnerSource.includes("countCliMarkersAfterEchoReceipt") &&
+    runnerSource.includes("beginObserved[w] = receiptMarkerCounts.beginCount > 0"),
+  "run-cli-bakeoff must preserve a receipt-observed BEGIN before a later END",
+);
+const fastWorkerMarkers = countCliMarkersAfterEchoReceipt(
+  `${dispatchReceipt}\nBAKEOFF_ROUND_A_BEGIN\nwork complete\nBAKEOFF_ROUND_A_END`,
+  dispatchReceipt,
+  "BAKEOFF_ROUND_A_BEGIN",
+  "BAKEOFF_ROUND_A_END",
+);
+assert.deepEqual(
+  fastWorkerMarkers,
+  { beginCount: 1, endCount: 1 },
+  "countCliMarkersAfterEchoReceipt must isolate a fast worker result printed after the echo receipt",
+);
+assert.equal(
+  classifyCliOutcome("completed", fastWorkerMarkers.beginCount > 0),
+  "completed",
+  "a fast completion after the receipt must be terminal instead of becoming a baseline",
+);
+const beginBeforeEndMarkers = countCliMarkersAfterEchoReceipt(
+  `${dispatchReceipt}\nBAKEOFF_ROUND_A_BEGIN\nworking`,
+  dispatchReceipt,
+  "BAKEOFF_ROUND_A_BEGIN",
+  "BAKEOFF_ROUND_A_END",
+);
+assert.deepEqual(
+  beginBeforeEndMarkers,
+  { beginCount: 1, endCount: 0 },
+  "countCliMarkersAfterEchoReceipt must preserve a BEGIN printed before a later END",
+);
+assert.equal(
+  classifyCliOutcome("completed", beginBeforeEndMarkers.beginCount > 0),
+  "completed",
+  "a BEGIN observed after the receipt must remain valid when the END arrives later",
+);
+assert.equal(
+  countCliMarkersAfterEchoReceipt(
+    "BAKEOFF_ROUND_A_BEGIN\nBAKEOFF_ROUND_A_END",
+    dispatchReceipt,
+    "BAKEOFF_ROUND_A_BEGIN",
+    "BAKEOFF_ROUND_A_END",
+  ),
+  null,
+  "countCliMarkersAfterEchoReceipt must not treat markers from before this dispatch's receipt as completion",
+);
+assert.deepEqual(
+  countCliMarkersAfterEchoReceipt(
+      `${dispatchReceipt}\npacket echo only`,
+      dispatchReceipt,
+      "BAKEOFF_ROUND_A_BEGIN",
+      "BAKEOFF_ROUND_A_END",
+    ),
+  { beginCount: 0, endCount: 0 },
+  "the receipt itself must establish a no-completion baseline after the full packet echo",
 );
 
 // --- selectNewRunDir ------------------------------------------------------

--- a/winsmux-app/scripts/bakeoff-runner-lib.mjs
+++ b/winsmux-app/scripts/bakeoff-runner-lib.mjs
@@ -136,13 +136,11 @@ export function taskIdToEndMarker(taskId) {
  * (the previous strategy here) also rejects every compliant worker's actual
  * completion output, which is why that strategy is gone.
  *
- * Echo disambiguation is handled by the CALLER, not by this function: the
- * runner seeds its baseline count AFTER dispatch has been CONFIRMED (via the
- * conversation-panel poll gating on countSha256Occurrences /
- * countDispatchBlockedNotices, plus ECHO_RENDER_SETTLE_MS in
- * run-cli-bakeoff.mjs), once the echoed packet text is already on screen.
- * Because the echo is already included in the seeded baseline, only a
- * marker occurrence beyond that baseline -- i.e. the worker's own
+ * Echo disambiguation is handled by the CALLER, not by this function: after
+ * dispatch confirmation, the runner waits until an exact, per-dispatch echo
+ * receipt is visible before it seeds a baseline. The receipt is appended
+ * after the complete packet, so the echo is already included in that
+ * baseline; only a later marker occurrence -- i.e. the worker's own
  * completion output -- can register as an increase. This function's only
  * job is an honest raw count; do not reintroduce line-shape filtering here.
  *
@@ -158,6 +156,53 @@ export function countEndMarkers(paneText, marker = "BAKEOFF_ROUND_A_END") {
   const escaped = target.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const matches = String(paneText).match(new RegExp(escaped, "g"));
   return matches ? matches.length : 0;
+}
+
+/**
+ * Build the exact per-dispatch receipt appended after a CLI packet's prompt.
+ * This must stay in sync with writeWorkerBenchmarkSubmission in main.ts.
+ *
+ * @param {string} dispatchId
+ * @returns {string}
+ */
+export function buildCliDispatchEchoMarker(dispatchId) {
+  const id = typeof dispatchId === "string" ? dispatchId.trim() : "";
+  return id ? `WINSMUX_BENCH_DISPATCH ${id}` : "";
+}
+
+/**
+ * Extract the latest desktop-generated dispatch id from conversation text.
+ *
+ * @param {string} text
+ * @returns {string}
+ */
+export function extractLatestDispatchId(text) {
+  const matches = [...String(text || "").matchAll(/\bdispatch-[0-9a-z]+\b/gi)];
+  return matches.length > 0 ? matches[matches.length - 1][0] : "";
+}
+
+/**
+ * Count packet markers that appear after this dispatch's receipt in a pane
+ * capture. The receipt is appended after the echoed packet, so markers in
+ * this suffix are worker output rather than echoed instructions.
+ *
+ * @param {string} paneText
+ * @param {string} receipt
+ * @param {string} beginMarker
+ * @param {string} endMarker
+ * @returns {{beginCount: number, endCount: number}|null}
+ */
+export function countCliMarkersAfterEchoReceipt(paneText, receipt, beginMarker, endMarker) {
+  const text = typeof paneText === "string" ? paneText : "";
+  const marker = typeof receipt === "string" ? receipt : "";
+  const receiptIndex = marker ? text.indexOf(marker) : -1;
+  if (receiptIndex < 0) return null;
+
+  const suffix = text.slice(receiptIndex + marker.length);
+  return {
+    beginCount: beginMarker ? countEndMarkers(suffix, beginMarker) : 0,
+    endCount: countEndMarkers(suffix, endMarker),
+  };
 }
 
 /**
@@ -256,6 +301,20 @@ export function classifyApiOutcome(runJsonText, responseText, markers) {
 }
 
 /**
+ * Return true when an outcome is first observed at or after its configured
+ * task deadline.
+ *
+ * @param {number} elapsedSeconds
+ * @param {number} timeoutSeconds
+ * @returns {boolean}
+ */
+export function hasTaskTimedOut(elapsedSeconds, timeoutSeconds) {
+  return Number.isFinite(elapsedSeconds) &&
+    Number.isFinite(timeoutSeconds) &&
+    elapsedSeconds >= timeoutSeconds;
+}
+
+/**
  * Classify a CLI worker's progress on a single dispatched task by comparing
  * the current marker occurrence count against the lowest count observed
  * since the post-dispatch baseline was seeded.
@@ -271,10 +330,9 @@ export function classifyApiOutcome(runJsonText, responseText, markers) {
  * completion.
  *
  * @param {number} minObservedCount lowest marker count observed since the
- *   baseline was seeded (after dispatch confirmation + the short echo
- *   render settle -- see DISPATCH_CONFIRM_TIMEOUT_MS / ECHO_RENDER_SETTLE_MS
- *   in run-cli-bakeoff.mjs -- and lowered by the caller whenever a
- *   successful poll observes a smaller count)
+ *   baseline was seeded after dispatch confirmation and its exact echo
+ *   receipt, then lowered by the caller whenever a successful poll observes
+ *   a smaller count)
  * @param {number} currCount marker count observed at the current poll tick
  * @param {number} elapsedSeconds seconds since this task was dispatched
  * @param {number} timeoutSeconds this task's configured timeout
@@ -284,7 +342,7 @@ export function classifyCliWorker(minObservedCount, currCount, elapsedSeconds, t
   const prev = Number.isFinite(minObservedCount) ? minObservedCount : 0;
   const curr = Number.isFinite(currCount) ? currCount : 0;
   if (curr > prev) return "completed";
-  if (Number.isFinite(elapsedSeconds) && Number.isFinite(timeoutSeconds) && elapsedSeconds >= timeoutSeconds) {
+  if (hasTaskTimedOut(elapsedSeconds, timeoutSeconds)) {
     return "timeout";
   }
   return "pending";
@@ -332,15 +390,13 @@ export function selectNewRunDir(entries, sinceEpochMs) {
 }
 
 /**
- * Reproduce, byte-for-byte, the prompt string the desktop app builds and
- * hashes for a benchmark task dispatch (buildHarnessTaskPrompt in
- * winsmux-app/src/main.ts, ~lines 4143-4157). The desktop computes
- * packet.sha256 = sha256 hex over exactly this string and shows it in the
- * dispatch conversation entry (writeWorkerBenchmarkSubmission /
- * dispatchBenchmarkTaskFromOperatorCommand, ~lines 4703-4740) under a detail
- * labeled "sha256". This function must be kept byte-for-byte in sync with
- * that upstream implementation -- any drift (header order, join character,
- * trim behavior) silently breaks hash verification.
+ * Reproduce, byte-for-byte, the base prompt the desktop app builds for a
+ * benchmark task dispatch (buildHarnessTaskPrompt in
+ * winsmux-app/src/main.ts, ~lines 4143-4157). The desktop then appends its
+ * per-dispatch echo receipt before hashing and sending the interactive CLI
+ * prompt; the runner obtains that receipt from the confirmed conversation
+ * entry and appends the same value before comparing the displayed sha256.
+ * This function must stay in sync with the base app-side builder.
  *
  * Pure/dependency-free by design: the actual sha256 digest is computed by
  * the CALLER (run-cli-bakeoff.mjs) using node:crypto, not here, so this
@@ -374,8 +430,8 @@ export function buildHarnessPromptMirror(pack, task, packetContent) {
 /**
  * Extract the last 64-char lowercase hex string appearing near a "sha256"
  * label in a conversation-panel innerText blob, mirroring how the desktop
- * displays the dispatch packet's hash as a labeled conversation detail
- * (`{ label: "sha256", value: packet.sha256 }`).
+ * displays the full interactive prompt hash as a labeled conversation detail
+ * (`{ label: "sha256", value: cliDispatchPromptSha }`).
  *
  * Deliberately liberal: tries a "sha256" label followed (within a short
  * distance) by a 64-hex-char run first; if that finds nothing, falls back to

--- a/winsmux-app/scripts/bakeoff-runner-lib.mjs
+++ b/winsmux-app/scripts/bakeoff-runner-lib.mjs
@@ -184,7 +184,8 @@ export function extractLatestDispatchId(text) {
 /**
  * Count packet markers that appear after this dispatch's receipt in a pane
  * capture. The receipt is appended after the echoed packet, so markers in
- * this suffix are worker output rather than echoed instructions.
+ * the suffix after its last visible copy are worker output rather than
+ * repeated echoed instructions.
  *
  * @param {string} paneText
  * @param {string} receipt
@@ -195,7 +196,7 @@ export function extractLatestDispatchId(text) {
 export function countCliMarkersAfterEchoReceipt(paneText, receipt, beginMarker, endMarker) {
   const text = typeof paneText === "string" ? paneText : "";
   const marker = typeof receipt === "string" ? receipt : "";
-  const receiptIndex = marker ? text.indexOf(marker) : -1;
+  const receiptIndex = marker ? text.lastIndexOf(marker) : -1;
   if (receiptIndex < 0) return null;
 
   const suffix = text.slice(receiptIndex + marker.length);

--- a/winsmux-app/scripts/run-cli-bakeoff.mjs
+++ b/winsmux-app/scripts/run-cli-bakeoff.mjs
@@ -90,6 +90,10 @@ import {
   getPacketMarkers,
   classifyCliWorker,
   classifyCliOutcome,
+  buildCliDispatchEchoMarker,
+  extractLatestDispatchId,
+  countCliMarkersAfterEchoReceipt,
+  hasTaskTimedOut,
   selectNewRunDir,
   buildReadyCheckCommand,
   buildDispatchCommand,
@@ -149,14 +153,11 @@ function sha256Hex(text) {
 // after that readiness wait.
 const DISPATCH_CONFIRM_POLL_MS = 3000;
 const DISPATCH_CONFIRM_TIMEOUT_MS = 90_000 + 60_000; // WORKER_READINESS_TIMEOUT_MS (90_000) + 60_000 headroom
-// Small settle window AFTER dispatch confirmation, before the first pane
-// capture that seeds the CLI marker-count baseline. Per the main.ts flow
-// cited above, the echoed packet text is written into each pane BEFORE the
-// success conversation entry is appended, so by the time this runner has
-// observed the success entry the echo is already on screen -- this sleep is
-// only to let that terminal render settle, not to wait out the dispatch
-// itself (that waiting is now done by the confirmation poll above).
-const ECHO_RENDER_SETTLE_MS = 3000;
+// Dispatch confirmation proves the desktop accepted the packet, but does not
+// prove the pane echo has finished rendering. Poll each CLI pane at this
+// cadence until its exact per-dispatch echo receipt appears before allowing
+// completion classification.
+const ECHO_BASELINE_SETTLE_POLL_MS = 3000;
 
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(SCRIPT_DIR, "..", "..");
@@ -786,12 +787,12 @@ async function main() {
       }
     }
 
-    // Independently reconstruct the exact prompt the desktop builds and
-    // hashes for this dispatch (buildHarnessTaskPrompt mirror), then hash it
-    // ourselves. Compared below (after dispatch) against the sha256 the
-    // desktop itself displays in the conversation panel.
-    const expectedSha = packetText !== null
-      ? sha256Hex(buildHarnessPromptMirror(pack, taskEntry || {}, packetText))
+    // Independently reconstruct the base prompt the desktop builds for this
+    // dispatch. After confirmation exposes the per-dispatch echo receipt,
+    // append that exact receipt and hash the full interactive prompt for the
+    // comparison against the desktop conversation entry below.
+    const expectedPrompt = packetText !== null
+      ? buildHarnessPromptMirror(pack, taskEntry || {}, packetText)
       : "";
 
     const dispatchStartMs = Date.now();
@@ -810,7 +811,6 @@ async function main() {
     }
     const preSha256Count = countSha256Occurrences(preConversationText);
     const preBlockedCount = countDispatchBlockedNotices(preConversationText);
-
     const submitResult = await submitComposerCommand(args.port, buildDispatchCommand(taskId));
 
     async function emitDispatchFailedArtifacts(dispatchFailReason) {
@@ -899,61 +899,54 @@ async function main() {
       continue;
     }
 
-    // Dispatch confirmed successful (this dispatch's own success entry
-    // rendered). Per the main.ts flow, the echoed packet text is written
-    // into each pane BEFORE that success entry is appended, so the echo is
-    // already on screen -- this sleep only lets the terminal render settle,
-    // it is not waiting out the dispatch itself anymore (see
-    // ECHO_RENDER_SETTLE_MS's doc comment above).
-    await sleep(ECHO_RENDER_SETTLE_MS);
-
     // Read the desktop-displayed sha256 for this dispatch now that success
     // is confirmed, and compare it to our independently computed
     // expectedSha.
     let displayedSha = "";
+    let dispatchId = "";
     try {
       const conversationText = await readConversationText(args.port);
       displayedSha = extractLatestSha256(conversationText);
+      dispatchId = extractLatestDispatchId(conversationText);
     } catch {
       displayedSha = "";
+      dispatchId = "";
     }
+    if (!dispatchId) {
+      const reason = "confirmed dispatch did not expose a dispatch_id receipt";
+      await appendLogLine(logPath, { event: "dispatch_unconfirmed", ts: nowIso(), taskId, reason });
+      await emitDispatchFailedArtifacts(reason);
+      continue;
+    }
+    const expectedSha = expectedPrompt
+      ? sha256Hex(`${expectedPrompt}\n\n${buildCliDispatchEchoMarker(dispatchId)}`)
+      : "";
     const packetHashMatch = expectedSha !== "" && displayedSha !== "" && displayedSha === expectedSha;
 
-    // Seed the baseline marker count for this task's own round marker AFTER
-    // dispatch confirmation + settle. This is required both to cross round
-    // boundaries (e.g. WB-009 -> WB-010 switches from counting
-    // BAKEOFF_ROUND_A_END to BAKEOFF_ROUND_B_END) and to make sure the
-    // echoed packet text (which itself contains the marker literal, per
-    // every packet's step 5) is already folded into the baseline before
-    // polling starts. A failed capture must NOT seed 0: if the pane still
-    // visibly holds markers, a 0 baseline would let the next successful
-    // poll misread them as an instant completion. null marks "baseline
-    // unknown -- adopt the first successful poll observation as the
-    // baseline instead".
-    //
-    // FIX B: also seed a begin-marker baseline in parallel (same null
-    // semantics), used below to gate CLI completion on BOTH round markers
-    // having been observed, mirroring classifyApiOutcome's both-markers
-    // contract for the api_llm path.
+    // A dispatch-confirmed echo can still be streaming. A worker gets a
+    // baseline only after its exact per-dispatch echo receipt appears. The
+    // receipt is appended after the full packet, so it is a stronger settle
+    // proof than a timing guess. Each worker still progresses independently
+    // through this state in the normal poll loop.
     const priorMarkerCounts = {};
     const priorBeginCounts = {};
+    const dispatchEchoMarkers = {};
     const beginObserved = {};
     for (const w of CLI_WORKERS) {
-      const captured = await capturePane(args.port, w);
-      priorMarkerCounts[w] = typeof captured === "string"
-        ? countEndMarkers(captured, endMarker)
-        : null;
-      priorBeginCounts[w] = typeof captured === "string" && packetMarkers.begin
-        ? countEndMarkers(captured, packetMarkers.begin)
-        : (typeof captured === "string" ? 0 : null);
+      priorMarkerCounts[w] = null;
+      priorBeginCounts[w] = null;
+      dispatchEchoMarkers[w] = buildCliDispatchEchoMarker(dispatchId);
       beginObserved[w] = false;
     }
+
+    const deadlineMs = dispatchStartMs + defaultTimeout * 1000;
 
     await appendLogLine(logPath, {
       event: "task_dispatch",
       ts: dispatchStartIso,
       taskId,
       endMarker,
+      dispatchId,
       priorMarkerCounts,
       priorBeginCounts,
       submitOk: true,
@@ -971,7 +964,6 @@ async function main() {
       perWorkerEndMarkerPresent[w] = false;
     }
 
-    const deadlineMs = dispatchStartMs + defaultTimeout * 1000;
     while (Date.now() < deadlineMs) {
       const elapsedSeconds = (Date.now() - dispatchStartMs) / 1000;
 
@@ -988,50 +980,67 @@ async function main() {
         }
         const paneText = captured;
         const currCount = countEndMarkers(paneText, endMarker);
+        const currBeginCount = packetMarkers.begin
+          ? countEndMarkers(paneText, packetMarkers.begin)
+          : 0;
 
-        // FIX B: track the begin-marker running-minimum in parallel with
-        // the end-marker one above, using the identical scroll-off-tolerant
-        // logic, and set the sticky beginObserved[w] flag whenever a
-        // successful capture shows the begin count rise above its running
-        // minimum. packetMarkers.begin === "" means this packet had no
-        // extractable begin-marker literal at all (see getPacketMarkers) --
-        // beginObserved can then never become true, which is intentional
-        // (see classifyCliOutcome's doc comment).
-        if (packetMarkers.begin) {
-          const currBeginCount = countEndMarkers(paneText, packetMarkers.begin);
-          if (priorBeginCounts[w] === null) {
-            priorBeginCounts[w] = currBeginCount;
-          } else {
-            if (currBeginCount < priorBeginCounts[w]) {
-              priorBeginCounts[w] = currBeginCount;
-            }
-            if (currBeginCount > priorBeginCounts[w]) {
-              beginObserved[w] = true;
-            }
+        let status = null;
+        if (priorMarkerCounts[w] === null || priorBeginCounts[w] === null) {
+          const receiptMarkerCounts = countCliMarkersAfterEchoReceipt(
+            paneText,
+            dispatchEchoMarkers[w],
+            packetMarkers.begin,
+            endMarker,
+          );
+          if (receiptMarkerCounts === null) {
+            continue;
           }
-        }
+          if (receiptMarkerCounts.endCount > 0) {
+            // The receipt is appended after the packet echo. An END marker
+            // after it is therefore real worker output, including a worker
+            // that completed before a second settle sample was available.
+            status = classifyCliOutcome(
+              "completed",
+              receiptMarkerCounts.beginCount > 0,
+            );
+          } else {
+            // The receipt follows the entire packet echo, so this first
+            // receipt-visible capture is the echo-safe baseline. Do not
+            // classify it: any later marker increase is worker output.
+            priorBeginCounts[w] = currBeginCount;
+            priorMarkerCounts[w] = currCount;
+            beginObserved[w] = receiptMarkerCounts.beginCount > 0;
+            continue;
+          }
+        } else {
+          // FIX B: track the begin-marker running-minimum in parallel with
+          // the end-marker one above, using the identical scroll-off-tolerant
+          // logic, and set the sticky beginObserved[w] flag whenever a
+          // successful capture shows the begin count rise above its running
+          // minimum. packetMarkers.begin === "" means this packet had no
+          // extractable begin-marker literal at all (see getPacketMarkers) --
+          // beginObserved can then never become true, which is intentional
+          // (see classifyCliOutcome's doc comment).
+          if (currBeginCount < priorBeginCounts[w]) {
+            priorBeginCounts[w] = currBeginCount;
+          }
+          if (currBeginCount > priorBeginCounts[w]) {
+            beginObserved[w] = true;
+          }
 
-        if (priorMarkerCounts[w] === null) {
-          // Baseline capture failed at dispatch time. Adopt the first
-          // successful observation as the baseline: a leftover marker and
-          // this task's own marker are indistinguishable here, so require a
-          // further increase before declaring completion (conservative --
-          // the worst case is a timeout, never a false completion).
-          priorMarkerCounts[w] = currCount;
-          continue;
+          if (currCount < priorMarkerCounts[w]) {
+            // A leftover marker from the previous task scrolled off the
+            // visible screen; adopt the smaller count as the new baseline so
+            // this task's own marker still registers as an increase.
+            priorMarkerCounts[w] = currCount;
+          }
+          const endStatus = classifyCliWorker(priorMarkerCounts[w], currCount, elapsedSeconds, defaultTimeout);
+          // FIX B: gate CLI completion on BOTH round markers, mirroring
+          // classifyApiOutcome's both-markers contract for the api_llm path.
+          // An END-increment alone (begin never observed) downgrades to
+          // invalid_output instead of being accepted as completed.
+          status = classifyCliOutcome(endStatus, beginObserved[w]);
         }
-        if (currCount < priorMarkerCounts[w]) {
-          // A leftover marker from the previous task scrolled off the
-          // visible screen; adopt the smaller count as the new baseline so
-          // this task's own marker still registers as an increase.
-          priorMarkerCounts[w] = currCount;
-        }
-        const endStatus = classifyCliWorker(priorMarkerCounts[w], currCount, elapsedSeconds, defaultTimeout);
-        // FIX B: gate CLI completion on BOTH round markers, mirroring
-        // classifyApiOutcome's both-markers contract for the api_llm path.
-        // An END-increment alone (begin never observed) downgrades to
-        // invalid_output instead of being accepted as completed.
-        const status = classifyCliOutcome(endStatus, beginObserved[w]);
         if (status === "completed") {
           perWorkerStatus[w] = "completed";
           perWorkerElapsedSeconds[w] = elapsedSeconds;
@@ -1061,12 +1070,24 @@ async function main() {
 
       for (const w of API_LLM_WORKERS) {
         if (perWorkerStatus[w] !== "pending") continue;
+        let apiElapsedSeconds = (Date.now() - dispatchStartMs) / 1000;
+        if (hasTaskTimedOut(apiElapsedSeconds, defaultTimeout)) {
+          perWorkerStatus[w] = "timeout";
+          perWorkerElapsedSeconds[w] = apiElapsedSeconds;
+          continue;
+        }
         const runInfo = await readRunJsonForTask(evidenceProjectRoot, w, dispatchStartMs);
+        apiElapsedSeconds = (Date.now() - dispatchStartMs) / 1000;
+        if (hasTaskTimedOut(apiElapsedSeconds, defaultTimeout)) {
+          perWorkerStatus[w] = "timeout";
+          perWorkerElapsedSeconds[w] = apiElapsedSeconds;
+          continue;
+        }
         if (runInfo.found) {
           const cls = classifyApiOutcome(runInfo.text, runInfo.responseText, packetMarkers);
           if (cls === "completed" || cls === "failed" || cls === "blocked" || cls === "invalid_output") {
             perWorkerStatus[w] = cls;
-            perWorkerElapsedSeconds[w] = elapsedSeconds;
+            perWorkerElapsedSeconds[w] = apiElapsedSeconds;
             // Only a fully-validated completed outcome (run.json succeeded
             // AND both round markers found in response.txt) counts as the
             // marker having been verified present; invalid_output means the
@@ -1075,14 +1096,13 @@ async function main() {
             perWorkerEndMarkerPresent[w] = cls === "completed";
           }
         }
-        if (perWorkerStatus[w] === "pending" && elapsedSeconds >= defaultTimeout) {
-          perWorkerStatus[w] = "timeout";
-          perWorkerElapsedSeconds[w] = elapsedSeconds;
-        }
       }
 
       if (Object.values(perWorkerStatus).every((s) => s !== "pending")) break;
-      await sleep(args.poll * 1000);
+      const pollDelayMs = [...CLI_WORKERS].some((w) => priorMarkerCounts[w] === null)
+        ? ECHO_BASELINE_SETTLE_POLL_MS
+        : args.poll * 1000;
+      await sleep(pollDelayMs);
     }
 
     for (const w of WORKER_LABELS) {

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -4206,6 +4206,10 @@ function getBenchmarkSubmissionRunId(dispatchId: string, target: string) {
   return `${dispatchId}-${target}`.replace(/[^A-Za-z0-9._-]/g, "-");
 }
 
+function buildCliBenchmarkDispatchEchoMarker(dispatchId: string) {
+  return `WINSMUX_BENCH_DISPATCH ${dispatchId}`;
+}
+
 async function writeWorkerBenchmarkSubmission(
   target: string,
   row: DesktopWorkerStatusRow,
@@ -4224,7 +4228,11 @@ async function writeWorkerBenchmarkSubmission(
     return "api_llm exec";
   }
 
-  await writePtyData(target, encodePtySubmission(packet.prompt));
+  // Keep this receipt at the end of the interactive prompt so a bounded PTY
+  // tail can prove that this exact dispatch's echo finished rendering. The
+  // runner matches the same literal via buildCliDispatchEchoMarker.
+  const promptWithDispatchReceipt = `${packet.prompt}\n\n${buildCliBenchmarkDispatchEchoMarker(dispatchId)}`;
+  await writePtyData(target, encodePtySubmission(promptWithDispatchReceipt));
   if (packet.prompt.includes("\n")) {
     await waitForOperatorSubmitDelay();
     await writePtyData(target, "\r");
@@ -4706,6 +4714,9 @@ async function dispatchBenchmarkTaskFromOperatorCommand(
     }
 
     const packet = await loadHarnessBenchmarkTaskPacket(taskId);
+    const cliDispatchPromptSha = await sha256Hex(
+      `${packet.prompt}\n\n${buildCliBenchmarkDispatchEchoMarker(probeId)}`,
+    );
     const submissionDetails: ConversationDetail[] = [];
     for (const row of rows) {
       const target = getWorkerStatusTarget(row);
@@ -4731,9 +4742,10 @@ async function dispatchBenchmarkTaskFromOperatorCommand(
       ),
       details: [
         { label: getLanguageText("task", "課題"), value: `${packet.taskId} - ${packet.taskTitle}` },
+        { label: "dispatch_id", value: probeId },
         { label: getLanguageText("pack", "パック"), value: packet.packId },
         { label: getLanguageText("packet", "課題ファイル"), value: packet.packetPath },
-        { label: "sha256", value: packet.sha256 },
+        { label: "sha256", value: cliDispatchPromptSha },
         { label: getLanguageText("worker panes", "ワーカーペイン"), value: targets.join(", ") },
         { label: getLanguageText("timeout", "制限時間"), value: `${packet.timeoutSeconds}s` },
         ...submissionDetails,


### PR DESCRIPTION
Closes #1134. The bench-runner classified CLI completion prematurely due to an echo-race in marker-baseline seeding (a dispatch was treated as complete ~30s early while the pane was still working). This waits for the exact dispatch echo receipt before baselining, so completion is not misclassified. Includes a red→green regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)