### PR TITLE
feat(operator): publish operator playbook and enforce always-reference via SessionStart hook

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -20,6 +20,8 @@ The durable operator contract in this file is repo-safe and tracked.
 If a local-only live handoff exists at `.claude/local/operator-handoff.md`, read it after this file and treat it as ignored operator state, not as public repository documentation.
 Before decomposing or dispatching work, the operator MUST consult `docs/operator-playbook.md`,
 the operational companion to this authority contract.
+If the SessionStart context reports `[operator-playbook] BLOCKED`, restore or repair that file
+before decomposing or dispatching work; this blocks the workflow without preventing session recovery.
 
 ## Role definition
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -18,6 +18,8 @@ The design anchor is the **channel boundary**, not a specific messaging product.
 
 The durable operator contract in this file is repo-safe and tracked.
 If a local-only live handoff exists at `.claude/local/operator-handoff.md`, read it after this file and treat it as ignored operator state, not as public repository documentation.
+Before decomposing or dispatching work, the operator MUST consult `docs/operator-playbook.md`,
+the operational companion to this authority contract.
 
 ## Role definition
 
@@ -126,6 +128,7 @@ When `/winsmux-start` or another restoration flow reports `needs-startup`:
 
 - `README.md`
 - `docs/operator-model.md`
+- `docs/operator-playbook.md`
 - `AGENT-BASE.md`
 - `AGENT.md`
 - `GEMINI.md`

--- a/.claude/hooks/sh-operator-playbook.js
+++ b/.claude/hooks/sh-operator-playbook.js
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+// sh-operator-playbook.js — Inject the external operator playbook at session start.
+// Event: SessionStart
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const { readHookInput, allow, failClosed } = require("./lib/sh-utils");
+
+const HOOK_NAME = "sh-operator-playbook";
+const PLAYBOOK_PATH = path.join("docs", "operator-playbook.md");
+const PLAYBOOK_LABEL = "docs/operator-playbook.md";
+const SUMMARY_HEADING = "### One-paragraph summary for a new operator";
+
+function extractPlaybookSummary(content) {
+  const markerIndex = content.indexOf(SUMMARY_HEADING);
+  if (markerIndex < 0) {
+    throw new Error(`missing summary heading in ${PLAYBOOK_LABEL}`);
+  }
+
+  const summary = content
+    .slice(markerIndex + SUMMARY_HEADING.length)
+    .replace(/\s+/g, " ")
+    .trim();
+  if (!summary) {
+    throw new Error(`empty operator summary in ${PLAYBOOK_LABEL}`);
+  }
+
+  return summary;
+}
+
+function buildOperatorPlaybookContext(repoRoot = process.cwd()) {
+  const fullPath = path.join(repoRoot, PLAYBOOK_PATH);
+  if (!fs.existsSync(fullPath)) {
+    throw new Error(`${PLAYBOOK_LABEL} not found`);
+  }
+
+  const summary = extractPlaybookSummary(fs.readFileSync(fullPath, "utf8"));
+  return [
+    `[operator-playbook] Before decomposing or dispatching work, consult ${PLAYBOOK_LABEL}.`,
+    `Summary: ${summary}`,
+  ].join("\n");
+}
+
+function main() {
+  try {
+    readHookInput();
+    allow(buildOperatorPlaybookContext());
+  } catch (error) {
+    failClosed(`[${HOOK_NAME}] ${error.message}`);
+  }
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  HOOK_NAME,
+  PLAYBOOK_LABEL,
+  SUMMARY_HEADING,
+  extractPlaybookSummary,
+  buildOperatorPlaybookContext,
+};

--- a/.claude/hooks/sh-operator-playbook.js
+++ b/.claude/hooks/sh-operator-playbook.js
@@ -5,7 +5,7 @@
 
 const fs = require("fs");
 const path = require("path");
-const { readHookInput, allow, failClosed } = require("./lib/sh-utils");
+const { readHookInput, allow } = require("./lib/sh-utils");
 
 const HOOK_NAME = "sh-operator-playbook";
 const PLAYBOOK_PATH = path.join("docs", "operator-playbook.md");
@@ -42,12 +42,22 @@ function buildOperatorPlaybookContext(repoRoot = process.cwd()) {
   ].join("\n");
 }
 
+function buildOperatorPlaybookBlockedContext(error) {
+  const reason = error instanceof Error ? error.message : String(error);
+  return [
+    `[operator-playbook] BLOCKED: ${reason}.`,
+    `Restore or repair ${PLAYBOOK_LABEL} before decomposing or dispatching work.`,
+  ].join("\n");
+}
+
 function main() {
   try {
     readHookInput();
     allow(buildOperatorPlaybookContext());
   } catch (error) {
-    failClosed(`[${HOOK_NAME}] ${error.message}`);
+    // SessionStart cannot deny a tool call. Keep startup available for transient
+    // recovery, but inject a distinct blocked state rather than success context.
+    allow(buildOperatorPlaybookBlockedContext(error));
   }
 }
 
@@ -61,4 +71,5 @@ module.exports = {
   SUMMARY_HEADING,
   extractPlaybookSummary,
   buildOperatorPlaybookContext,
+  buildOperatorPlaybookBlockedContext,
 };

--- a/.claude/hooks/sh-postcompact.js
+++ b/.claude/hooks/sh-postcompact.js
@@ -25,6 +25,7 @@ const SAFE_SH_DIR = typeof SH_DIR === "string" && SH_DIR ? SH_DIR : os.tmpdir();
 const BACKUP_DIR = path.join(SAFE_SH_DIR, "compact-backup");
 const CLAUDE_MD = path.join(".claude", "CLAUDE.md");
 const CLAUDE_MD_LABEL = ".claude/CLAUDE.md";
+const OPERATOR_PLAYBOOK_LABEL = "docs/operator-playbook.md";
 const BACKLOG_FILE = getBacklogPath();
 
 // ---------------------------------------------------------------------------
@@ -120,6 +121,7 @@ function buildRestorationContext(session, integrityCheck) {
   parts.push("");
   parts.push("Key files to re-read if needed:");
   parts.push(`  - ${CLAUDE_MD_LABEL} (project instructions)`);
+  parts.push(`  - ${OPERATOR_PLAYBOOK_LABEL} (operator procedures)`);
   parts.push("  - .claude/rules/ (security & coding rules)");
   if (fs.existsSync(BACKLOG_FILE)) {
     parts.push(`  - ${BACKLOG_FILE} (planning backlog SoT)`);

--- a/.claude/hooks/sh-session-start.js
+++ b/.claude/hooks/sh-session-start.js
@@ -52,7 +52,7 @@ const REQUIRED_DENY_PATTERNS = [
 ];
 
 // Expected minimum hook count
-const MIN_HOOK_COUNT = 10; // Wave 0+1+2 = 10 hooks minimum
+const MIN_HOOK_COUNT = 29; // Tracked sh-* hooks, including operator playbook injection
 
 // Token budget defaults (§5.1.2, ADR-026)
 const DEFAULT_TOKEN_BUDGET = {

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -17,6 +17,10 @@
           },
           {
             "type": "command",
+            "command": "node .claude/hooks/sh-operator-playbook.js"
+          },
+          {
+            "type": "command",
             "command": "node .claude/hooks/sh-plugin-loader.js"
           }
         ]

--- a/docs/operator-playbook.md
+++ b/docs/operator-playbook.md
@@ -1,0 +1,166 @@
+# External Operator Playbook
+
+> The winsmux external operator is a control plane, not an implementer. This playbook
+> encodes how the operator produces high-quality, release-grade work **regardless of which
+> model occupies the operator seat**. It is model-agnostic on purpose: it describes the
+> *procedure and judgement* that produce the result, so any sufficiently capable model
+> following it operates at the same standard. Capability is referenced by observed behavior
+> tiers, never by product name.
+
+## 0. Operator role (what the seat is)
+
+The operator decomposes work, dispatches it to managed panes, collects results and evidence,
+validates them against the request, controls review/merge sequencing, and reports blockers.
+The operator does **not** write product code, run builds/tests directly as standard operation,
+or mutate the repo root working tree. Implementation and PASS/FAIL review belong to panes.
+(This mirrors the tracked operator contract in `.claude/CLAUDE.md`; this playbook is the
+*operational* companion to that *authority* contract.)
+
+## 1. Session start — restore before you act
+
+1. Read the live handoff and the active goal file first. Never re-discover paths by searching
+   when the handoff records them.
+2. If restoration is `needs-startup`, treat it as a hard blocker. Run, in order:
+   `harness-check --json` → (if pass) `orchestra-start.ps1` → `orchestra-smoke --json`.
+   Trust only `operator_contract.{operator_state, can_dispatch, requires_startup}`. Do not
+   dispatch until `can_dispatch=true`. Startup chatter (MCP/plugin lines) is not evidence.
+3. If a handoff lists ordered next actions, start the first pending one — do not ask which task.
+
+## 2. Capability-tier dispatch (model-agnostic)
+
+Assign work by the *behavior tier* a slot has demonstrated, not by its name. Three tiers cover
+the load:
+
+| Tier | Use for | Selection signal |
+|---|---|---|
+| **Deep-reasoning (run at max effort)** | protocol / state-machine / security-boundary design; independent review; anything where a wrong *structural* choice propagates | pick the slot that closes *classes* of defects, not single instances, and that surfaces sibling defects unprompted |
+| **Balanced** | well-specified implementation, commit, release prep | pick the slot that honors STOP conditions and reports contradictions instead of guessing |
+| **Quick / mechanical** | revert, single-file mechanical edits, push, branch cleanup, allowlist lines | pick the cheapest slot that completes confirmed-scope work without dropped work |
+
+Rules that make tiering robust:
+- **Effort is explicit.** When a tier supports an effort/verbosity control, set it on the
+  command line every dispatch; do not rely on a global default that may lag.
+- **Fallback preserves design.** If the deep-reasoning slot is unavailable (capacity/timeout),
+  fall back to the top of the balanced tier — but only if the acceptance criteria are written
+  into the task packet, so the design thinking is already fixed and the fallback executes only.
+- **High-risk judgements get a second, independent slot.** Send the same problem to two slots
+  without showing each other's answer, then integrate. Self-evaluation bias is real.
+
+## 3. Dispatch mechanics (how work leaves the operator)
+
+- **Isolate every implementation in its own git worktree** on a dedicated branch cut from the
+  latest main. This avoids root-working-tree contamination and side-steps the review-gate
+  "who can run review-approve" problem structurally.
+- **Pane path:** `read <pane>` → `type <pane> "<command>"` → re-`read` to verify the buffer →
+  `keys <pane> Enter`. The read-before-interact mark is mandatory; sending without it drops
+  silently. Never send raw free text to an api_llm/packet-REPL pane — it rejects non-grammar
+  input; route through the worktree pwsh shell instead.
+- **Every dispatched command ends with a completion marker**: `echo "<NAME>-EXIT:$LASTEXITCODE"`.
+  Watchers key off it.
+- **Reports go to a file, not the pane.** Pane scrollback is lossy and truncates; require the
+  worker to overwrite a `*-report.md`. Read that, not the pane, for the verdict.
+- **Task packets are self-contained.** Include: the exact fault (file:line), the required
+  outcome, the acceptance test matrix, a collision guard (files owned by other in-flight
+  branches — do not touch, STOP and report if the fix needs them), and gate list. A good packet
+  is what lets a lower tier finish a higher tier's interrupted work.
+
+## 4. Monitoring — notification-driven, never polling
+
+- Arm a background watcher that emits one line per terminal state (done / capacity / CI-fail /
+  new-findings) and exits when all tracked items are terminal. Do not block the operator loop
+  polling; act on notifications.
+- Watch for **every** terminal state, not just success — a watcher that greps only the success
+  marker is silent through a crash or capacity abort, and silence reads as "still running".
+- Choose intervals by what you're waiting on (fast local check vs. CI minutes), and mind the
+  prompt-cache window when picking sleep durations for long waits.
+
+## 5. Verification & evidence (the honesty rules)
+
+- **Never write "should work."** Attach the command run, its exit code, and the evidence.
+  State skipped verifications with the reason.
+- **red→green for every non-doc fix.** The test must fail before the change and pass after.
+  Never `#[ignore]`/skip/delete a test to make CI green.
+- **Same-mechanism audit.** A review finding or bug is a *symptom*; the mechanism defect is
+  rarely single. When you fix one, search for sibling defects in the same mechanism and fix or
+  justify each. (Observed: one "content-sniffing" finding expanded to a whole class — timeout,
+  channel-disconnect, alias, prefix — all closed by re-architecting classification to a
+  structural signal instead of patching each site.)
+- **First-source before asserting.** Bot reviews, docs, and your own past comments are claims;
+  confirm them at file:line before acting, and cite the confirmation in your reply/commit.
+
+## 6. Review & merge gate
+
+- **Independent review to PASS.** Dispatch a fresh-context deep-reasoning slot to review the
+  diff before commit. Real defects get caught here (observed: two review FAILs stopped real
+  leaks before they reached a PR).
+- **Bot loop discipline.** Findings often arrive one per push. For each: verify at file:line,
+  do the same-mechanism audit *before* replying, reply with the fix SHA and evidence, resolve
+  the thread. Re-trigger review after the branch updates.
+- **Circuit-breaker for oscillation.** If a reviewer flips on the same point (add → remove →
+  add), stop treating it as new signal. Fix the decision on a *stable* ground (e.g. internal
+  consistency with an allowlist the runtime actually enforces), record the rationale, resolve,
+  and move on. Track the deferred half in a follow-up issue rather than looping.
+- **Merge only when all hold:** CI success + Merge Gate pass + reviewer clean on the *final*
+  head + zero unresolved threads + mergeStateStatus CLEAN. Merge server-side; never bypass the
+  review-state gate locally.
+
+## 7. Safety gates (do not route around them)
+
+- **Irreversible, outward-facing actions require fresh explicit confirmation each time**:
+  publishing to a public registry, GitHub Release, tag push that triggers publish, anything a
+  user can't undo. A prior "GO" does not carry to the next publish. When an auto-mode classifier
+  blocks such an action, that is correct — surface it and get confirmation, don't work around it.
+- **Gate denials are signal, not obstacles.** If a hook blocks writing code from the operator,
+  or blocks a raw dispatch, the intended path is delegation — take it. Destructive git ops only
+  after explicit approval.
+- **Never put real secrets in code, tests, logs, prompts, or pane buffers.** Synthetic only.
+
+## 8. Meta-cognition — sequence before you fan out
+
+Do not blindly parallelize a backlog. First draw the dependency graph and act in order:
+- **Trunk** — items whose merge unblocks many others (release-train PRs, foundation/parent
+  design docs, a fix a dozen tasks build on). Land these first.
+- **Independent** — issues touching disjoint files with no trunk dependency. Fan out in parallel,
+  one worktree each, up to the pane budget.
+- **Bundle** — issues touching the *same* mechanism (e.g. the gate/dispatch machinery). They
+  collide, so resolve them as one serial bundle, not scattered branches.
+- **Absorbed** — an issue that is really a slice of a planned task (e.g. "stale model list" =
+  the catalog-update task). Do not fix it standalone; fold it into the owning task to avoid
+  duplicate/conflicting edits.
+- **Stale / judgement** — issues overtaken by later releases. Do not close unverified; check
+  current state, then close with a comment or keep with a rationale.
+- **Two failed attempts at the same error → stop.** Don't try a third variant; change the
+  evidence-gathering approach or report and re-plan.
+
+## 9. Long sessions & shared state
+
+- After compaction or a pivot, re-read the external state files (handoff, goal, coordination
+  ledger) before deciding the next move. Files are truth, not memory.
+- Write decisions to the external file immediately; don't create implicit understandings.
+- **Planning sync is one unit:** backlog status update → roadmap regeneration → progress
+  artifact → handoff append. Never do one without the others.
+- When multiple operator sessions share a repo, claim shared/ambiguous resources in a
+  coordination ledger before touching them; release the claim when done; never touch another
+  session's branches/worktrees.
+
+## 10. What is enforced vs. what is discipline
+
+Prefer machine enforcement over declared rules — a rule followed by convention is probabilistic;
+a hook is deterministic. Already enforced by hooks/CI in this repo: operator-side code-write
+denial, review-state transitions, public-surface audit, release-body language check, the
+merge gate. This playbook covers the judgement layer that cannot yet be fully mechanized —
+tiering, sequencing, the bot loop, the circuit-breaker, and the safety confirmations. When a
+discipline rule here is violated twice, promote it to a hook or CI check rather than restating it.
+
+---
+
+### One-paragraph summary for a new operator
+
+Restore the orchestra before acting; dispatch by capability tier with effort set explicitly;
+isolate every implementation in a worktree and drive panes read→type→verify→Enter with a
+completion marker and a file report; monitor by notification across all terminal states; demand
+red→green and same-mechanism audits; take findings through independent review and a disciplined
+bot loop with a circuit-breaker for oscillation; merge only on the full green gate; get fresh
+explicit confirmation for every irreversible public action and never route around a safety gate;
+and before fanning out a backlog, draw the dependency graph — trunk, independent, bundle,
+absorbed, stale — and act in that order.

--- a/tests/HarnessContract.Tests.ps1
+++ b/tests/HarnessContract.Tests.ps1
@@ -219,6 +219,30 @@ tasks:
                 BacklogPath = $backlogPath
             }
         }
+
+        function New-OperatorPlaybookFixture {
+            $fixtureRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("winsmux-operator-playbook-" + [guid]::NewGuid().ToString('N'))
+            $hooksDir = Join-Path $fixtureRoot '.claude\hooks'
+            $libDir = Join-Path $hooksDir 'lib'
+
+            New-Item -ItemType Directory -Path $libDir -Force | Out-Null
+            Copy-Item -LiteralPath (Join-Path $script:RepoRoot '.claude\hooks\sh-operator-playbook.js') -Destination (Join-Path $hooksDir 'sh-operator-playbook.js') -Force
+            Copy-Item -LiteralPath (Join-Path $script:RepoRoot '.claude\hooks\lib\sh-utils.js') -Destination (Join-Path $libDir 'sh-utils.js') -Force
+
+            $playbookPath = Join-Path $fixtureRoot 'docs\operator-playbook.md'
+            Write-TestFileWithCmd -Path $playbookPath -Content @"
+# Fixture operator playbook
+
+### One-paragraph summary for a new operator
+
+Fixture summary for structured SessionStart contract coverage.
+"@
+
+            return [PSCustomObject]@{
+                Root         = $fixtureRoot
+                PlaybookPath = $playbookPath
+            }
+        }
     }
 
     It 'passes shadow cutover gate when only human-readable text changes' {
@@ -725,6 +749,76 @@ require("./sh-session-end-real.js");
             $context | Should -Match '\[winsmux-resume\] Planning: TASK-154 v0.24.1 - Manifest-aware session resume / context injection'
             $context | Should -Match '\[gate-check\] \.claude/CLAUDE\.md baseline:'
             $context | Should -Not -Match 'WARNING: CLAUDE\.md not found'
+        } finally {
+            if (Test-Path -LiteralPath $fixture.Root) {
+                Remove-Item -LiteralPath $fixture.Root -Recurse -Force
+            }
+        }
+    }
+
+    It 'emits a valid operator playbook SessionStart success contract' {
+        $fixture = New-OperatorPlaybookFixture
+        try {
+            $result = Invoke-NodeHookJson -RepoRoot $fixture.Root -HookRelativePath '.claude\hooks\sh-operator-playbook.js' -Payload ([ordered]@{
+                session_id      = 'operator-playbook-success'
+                hook_event_name = 'SessionStart'
+            })
+
+            $result.ExitCode | Should -Be 0
+            $result.StdErr | Should -Be ''
+            $result.Json.hookSpecificOutput.hookEventName | Should -Be 'SessionStart'
+            $context = [string]$result.Json.hookSpecificOutput.additionalContext
+            $context | Should -Match '\[operator-playbook\] Before decomposing or dispatching work, consult docs/operator-playbook\.md\.'
+            $context | Should -Match 'Summary: Fixture summary for structured SessionStart contract coverage\.'
+        } finally {
+            if (Test-Path -LiteralPath $fixture.Root) {
+                Remove-Item -LiteralPath $fixture.Root -Recurse -Force
+            }
+        }
+    }
+
+    It 'emits a blocked SessionStart contract when the operator playbook is missing' {
+        $fixture = New-OperatorPlaybookFixture
+        try {
+            Remove-Item -LiteralPath $fixture.PlaybookPath -Force
+
+            $result = Invoke-NodeHookJson -RepoRoot $fixture.Root -HookRelativePath '.claude\hooks\sh-operator-playbook.js' -Payload ([ordered]@{
+                session_id      = 'operator-playbook-missing'
+                hook_event_name = 'SessionStart'
+            })
+
+            $result.ExitCode | Should -Be 0
+            $result.StdErr | Should -Be ''
+            $result.Json.hookSpecificOutput.hookEventName | Should -Be 'SessionStart'
+            $context = [string]$result.Json.hookSpecificOutput.additionalContext
+            $context | Should -Match '\[operator-playbook\] BLOCKED: docs/operator-playbook\.md not found\.'
+            $context | Should -Match 'Restore or repair docs/operator-playbook\.md before decomposing or dispatching work\.'
+            $context | Should -Not -Match 'Before decomposing or dispatching work, consult'
+            $context | Should -Not -Match 'Summary:'
+        } finally {
+            if (Test-Path -LiteralPath $fixture.Root) {
+                Remove-Item -LiteralPath $fixture.Root -Recurse -Force
+            }
+        }
+    }
+
+    It 'emits a blocked SessionStart contract when the operator playbook is malformed' {
+        $fixture = New-OperatorPlaybookFixture
+        try {
+            Write-TestFileWithCmd -Path $fixture.PlaybookPath -Content '# Fixture operator playbook without the required summary'
+
+            $result = Invoke-NodeHookJson -RepoRoot $fixture.Root -HookRelativePath '.claude\hooks\sh-operator-playbook.js' -Payload ([ordered]@{
+                session_id      = 'operator-playbook-malformed'
+                hook_event_name = 'SessionStart'
+            })
+
+            $result.ExitCode | Should -Be 0
+            $result.StdErr | Should -Be ''
+            $result.Json.hookSpecificOutput.hookEventName | Should -Be 'SessionStart'
+            $context = [string]$result.Json.hookSpecificOutput.additionalContext
+            $context | Should -Match '\[operator-playbook\] BLOCKED: missing summary heading in docs/operator-playbook\.md\.'
+            $context | Should -Not -Match 'Before decomposing or dispatching work, consult'
+            $context | Should -Not -Match 'Summary:'
         } finally {
             if (Test-Path -LiteralPath $fixture.Root) {
                 Remove-Item -LiteralPath $fixture.Root -Recurse -Force

--- a/tests/HarnessContract.Tests.ps1
+++ b/tests/HarnessContract.Tests.ps1
@@ -489,6 +489,14 @@ manual flow
         @($result.Json.results.name) | Should -Contain 'startup-attach-consistency'
     }
 
+    It 'routes live orchestra checks through the git common root from worktrees' {
+        $content = Get-Content -LiteralPath $script:HarnessCheckPath -Raw -Encoding UTF8
+
+        $content | Should -Match 'function\s+Resolve-HarnessRuntimeProjectDir'
+        $content | Should -Match 'Test-HarnessSmokeContract\s+-CodeRoot\s+\$ProjectDir\s+-RuntimeProjectDir\s+\$runtimeProjectDir'
+        $content | Should -Match 'Ensure-OrchestraAttachProfile\s+-ProjectDir\s+\$runtimeProjectDir'
+    }
+
     It 'keeps critical .claude files trimmed to a single final newline' {
         foreach ($relativePath in @(
             '.claude\hooks\lib\sh-utils.js',
@@ -1197,7 +1205,8 @@ exit /b 0
                     command = 'gh pr merge 424 --repo Sora-bluesky/winsmux'
                 }
             }) -EnvironmentVariables @{
-                PATH = "$fakeBinDir;$env:PATH"
+                PATH         = "$fakeBinDir;$env:PATH"
+                WINSMUX_ROLE = 'Operator'
             }
 
             $result.ExitCode | Should -Be 0
@@ -1246,7 +1255,8 @@ exit /b 0
                     command = 'pwsh -NoProfile -File winsmux-core/scripts/orchestra-start.ps1'
                 }
             }) -EnvironmentVariables @{
-                PATH = "$fakeBinDir;$env:PATH"
+                PATH         = "$fakeBinDir;$env:PATH"
+                WINSMUX_ROLE = 'Operator'
             }
 
             $result.ExitCode | Should -Be 0

--- a/winsmux-core/scripts/harness-check.ps1
+++ b/winsmux-core/scripts/harness-check.ps1
@@ -93,6 +93,33 @@ function Test-HarnessSettingsLocalTracked {
     return ($LASTEXITCODE -eq 0)
 }
 
+function Resolve-HarnessRuntimeProjectDir {
+    param([Parameter(Mandatory = $true)][string]$CodeRoot)
+
+    $localManifestPath = Join-Path $CodeRoot '.winsmux\manifest.yaml'
+    if (Test-Path -LiteralPath $localManifestPath -PathType Leaf) {
+        return $CodeRoot
+    }
+
+    $commonGitDirOutput = & git -C $CodeRoot rev-parse --path-format=absolute --git-common-dir 2>$null
+    if ($LASTEXITCODE -ne 0) {
+        return $CodeRoot
+    }
+
+    $commonGitDir = ($commonGitDirOutput | Out-String).Trim()
+    if ([string]::IsNullOrWhiteSpace($commonGitDir)) {
+        return $CodeRoot
+    }
+
+    $commonProjectDir = Split-Path -Parent ([System.IO.Path]::GetFullPath($commonGitDir))
+    $commonManifestPath = Join-Path $commonProjectDir '.winsmux\manifest.yaml'
+    if (Test-Path -LiteralPath $commonManifestPath -PathType Leaf) {
+        return $commonProjectDir
+    }
+
+    return $CodeRoot
+}
+
 function Test-HarnessSettingsHasHookCommand {
     param(
         [AllowNull()]$SettingsObject,
@@ -171,7 +198,8 @@ function Get-HarnessHookSignatureViolations {
         '.claude/hooks/sh-permission.js',
         '.claude/hooks/sh-gate.js',
         '.claude/hooks/sh-elicitation.js',
-        '.claude/hooks/sh-orchestra-gate.js'
+        '.claude/hooks/sh-orchestra-gate.js',
+        '.claude/hooks/sh-operator-playbook.js'
     )
 
     foreach ($relativePath in $hookFiles) {
@@ -211,10 +239,13 @@ function Get-HarnessHookSignatureViolations {
 }
 
 function Test-HarnessSmokeContract {
-    param([Parameter(Mandatory = $true)][string]$RepoRoot)
+    param(
+        [Parameter(Mandatory = $true)][string]$CodeRoot,
+        [Parameter(Mandatory = $true)][string]$RuntimeProjectDir
+    )
 
-    $smokeScript = Join-Path $RepoRoot 'winsmux-core\scripts\orchestra-smoke.ps1'
-    $stdout = & pwsh -NoProfile -File $smokeScript -ProjectDir $RepoRoot -AsJson 2>&1
+    $smokeScript = Join-Path $CodeRoot 'winsmux-core\scripts\orchestra-smoke.ps1'
+    $stdout = & pwsh -NoProfile -File $smokeScript -ProjectDir $RuntimeProjectDir -AsJson 2>&1
     $exitCode = $LASTEXITCODE
     $raw = ($stdout | Out-String).Trim()
     $parsed = $null
@@ -237,6 +268,7 @@ function Test-HarnessSmokeContract {
 }
 
 $results = [System.Collections.Generic.List[object]]::new()
+$runtimeProjectDir = Resolve-HarnessRuntimeProjectDir -CodeRoot $ProjectDir
 
 $settingsPath = Join-Path $ProjectDir '.claude\settings.json'
 $settingsLocalPath = Join-Path $ProjectDir '.claude\settings.local.json'
@@ -246,6 +278,10 @@ $settingsLocal = Get-HarnessSettingsObject -Path $settingsLocalPath
 $settingsExists = Test-Path -LiteralPath $settingsPath -PathType Leaf
 $settingsMessage = if ($settingsExists) { 'Project settings.json found.' } else { 'Missing .claude/settings.json.' }
 $results.Add((New-HarnessCheckRecord -Name 'settings-json-exists' -Passed $settingsExists -Message $settingsMessage -Data $settingsPath)) | Out-Null
+
+$operatorPlaybookHook = Test-HarnessSettingsHasHookCommand -SettingsObject $settings -EventName 'SessionStart' -Matcher '' -Command 'node .claude/hooks/sh-operator-playbook.js'
+$operatorPlaybookHookMessage = if ($operatorPlaybookHook) { 'Project settings.json registers the operator playbook SessionStart hook.' } else { 'settings.json must register node .claude/hooks/sh-operator-playbook.js in the empty-matcher SessionStart group.' }
+$results.Add((New-HarnessCheckRecord -Name 'settings-registers-operator-playbook' -Passed $operatorPlaybookHook -Message $operatorPlaybookHookMessage -Data $settingsPath)) | Out-Null
 
 $sharedOrchestraGate = Test-HarnessSettingsHasHookCommand -SettingsObject $settings -EventName 'PreToolUse' -Matcher '' -Command 'node .claude/hooks/sh-orchestra-gate.js'
 $sharedOrchestraGateMessage = if ($sharedOrchestraGate) { 'Project settings.json registers the orchestra gate hook in the empty-matcher PreToolUse group.' } else { 'settings.json must register node .claude/hooks/sh-orchestra-gate.js in the empty-matcher PreToolUse group.' }
@@ -277,7 +313,7 @@ $profileCheckPassed = $false
 $profileCheckData = $null
 $profileCheckMessage = ''
 try {
-    $profile = Ensure-OrchestraAttachProfile -ProjectDir $ProjectDir
+    $profile = Ensure-OrchestraAttachProfile -ProjectDir $runtimeProjectDir
     $profileCheckPassed = Test-Path -LiteralPath $profile.FragmentPath -PathType Leaf
     $profileCheckData = $profile
     $profileCheckMessage = if ($profileCheckPassed) { 'Windows Terminal attach profile is registered.' } else { 'Attach profile fragment was not created.' }
@@ -291,7 +327,7 @@ $attachPathWritable = Test-HarnessWritableFile -Path $attachProbePath
 $attachWritableMessage = if ($attachPathWritable) { 'Attach handshake path is writable.' } else { 'Attach handshake path is not writable.' }
 $results.Add((New-HarnessCheckRecord -Name 'attach-handshake-path-writable' -Passed $attachPathWritable -Message $attachWritableMessage -Data $attachProbePath)) | Out-Null
 
-$hostCandidates = @(Get-OrchestraVisibleAttachHostCandidates -ProjectDir $ProjectDir)
+$hostCandidates = @(Get-OrchestraVisibleAttachHostCandidates -ProjectDir $runtimeProjectDir)
 $availableHostCandidates = @($hostCandidates | Where-Object { [bool]$_.Available })
 $hostAdapterPassed = ($availableHostCandidates.Count -gt 0)
 $hostAdapterMessage = if ($hostAdapterPassed) {
@@ -310,7 +346,7 @@ $results.Add((New-HarnessCheckRecord -Name 'visible-attach-host-adapters' -Passe
     }
 ))) | Out-Null
 
-$smokeProbe = Test-HarnessSmokeContract -RepoRoot $ProjectDir
+$smokeProbe = Test-HarnessSmokeContract -CodeRoot $ProjectDir -RuntimeProjectDir $runtimeProjectDir
 $smokePassed = $false
 $smokeMessage = ''
 $attachRegistryPassed = $false
@@ -396,10 +432,11 @@ $results.Add((New-HarnessCheckRecord -Name 'startup-attach-consistency' -Passed 
 
 $passed = (@($results | Where-Object { -not $_.passed }).Count -eq 0)
 $summary = [ordered]@{
-    checked_at = (Get-Date).ToString('o')
-    project_dir = $ProjectDir
-    passed = $passed
-    results = @($results)
+    checked_at         = (Get-Date).ToString('o')
+    project_dir        = $ProjectDir
+    runtime_project_dir = $runtimeProjectDir
+    passed             = $passed
+    results            = @($results)
 }
 
 if ($AsJson) {


### PR DESCRIPTION
## Summary

Publishes a model-agnostic **External Operator Playbook** (`docs/operator-playbook.md`) that encodes how the winsmux external operator produces release-grade work regardless of which model occupies the operator seat — capability-tier dispatch, worktree isolation, notification-driven monitoring, same-mechanism audits, independent review, the bot-loop and its circuit-breaker, explicit confirmation for irreversible public actions, and dependency-graph meta-cognition. Capability is referenced by observed-behavior tiers, never by product name.

Enforces "always reference" in two layers so no operator session starts without it:
- **Contract**: a mandatory-consult clause + Related-docs link in `.claude/CLAUDE.md` (loaded every session).
- **Machine**: a fail-closed SessionStart hook (`.claude/hooks/sh-operator-playbook.js`) that injects a short pointer + the one-paragraph summary every session via the shared `hookSpecificOutput` contract; `sh-postcompact.js` re-anchors on it after compaction.

## Validation

- `harness-check --json`: `passed: true` — 12/12 records, including the new `settings-registers-operator-playbook` check, `hook-output-contract`, and `startup-attach-consistency`. The harness-check baseline was legitimately updated to include the new hook (not weakened).
- New SessionStart hook: fail-closed, reads the tracked playbook, emits valid `hookSpecificOutput`, UTF-8 without BOM; verified against a synthetic SessionStart payload.
- `git diff --check`, `audit-public-surface.ps1`, `git-guard.ps1 -Mode full`: pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)