### PR TITLE
fix(config): restore worker-1 Codex reviewer defaults

### DIFF
--- a/.winsmux.yaml
+++ b/.winsmux.yaml
@@ -5,7 +5,13 @@ worker-backend: local
 agent-slots:
   - slot-id: worker-1
     runtime-role: worker
-    worker-backend: local
+    agent: codex
+    model: provider-default
+    model-source: provider-default
+    worker-backend: codex
+    worker-role: reviewer
+    fallback-model: gpt-5.3-codex-spark
+    pane-title: W1 Codex Reviewer
     worktree-mode: managed
   - slot-id: worker-2
     runtime-role: worker

--- a/tests/Integration.MultiAgent.Tests.ps1
+++ b/tests/Integration.MultiAgent.Tests.ps1
@@ -79,6 +79,35 @@ Describe 'Get-BridgeSettings defaults' {
     }
 }
 
+Describe 'tracked worker-1 defaults' {
+    BeforeAll {
+        . (Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\settings.ps1')
+        $script:repositoryRoot = Split-Path -Parent $PSScriptRoot
+    }
+
+    It 'matches the canonical managed Codex reviewer contract' {
+        Mock Get-WinsmuxOption { param($Name, $Default) return $null }
+
+        Test-Path -LiteralPath (Join-Path $script:repositoryRoot '.winsmux.yaml') | Should -BeTrue
+
+        $settings = Get-BridgeSettings -RootPath $script:repositoryRoot
+        $actualWorkers = @($settings.agent_slots | Where-Object { $_.slot_id -eq 'worker-1' })
+        $canonicalWorker = @(New-BridgeManagedAgentSlots -Count 1 -Agent 'claude' -Model 'opus')[0]
+
+        $actualWorkers.Count | Should -Be 1
+        $actualKeys = @($actualWorkers[0].Keys | ForEach-Object { $_.ToString().Trim().ToLowerInvariant() } | Sort-Object -Unique)
+        $canonicalKeys = @($canonicalWorker.Keys | ForEach-Object { $_.ToString().Trim().ToLowerInvariant() } | Sort-Object -Unique)
+        $missingKeys = @($canonicalKeys | Where-Object { $_ -notin $actualKeys })
+        $extraKeys = @($actualKeys | Where-Object { $_ -notin $canonicalKeys })
+
+        $missingKeys.Count | Should -Be 0
+        $extraKeys.Count | Should -Be 0
+        foreach ($key in $canonicalWorker.Keys) {
+            $actualWorkers[0][$key] | Should -Be $canonicalWorker[$key]
+        }
+    }
+}
+
 Describe 'Get-RoleAgentConfig with fallback' {
     BeforeAll {
         . (Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\settings.ps1')


### PR DESCRIPTION
## Summary

Restore the tracked `worker-1` configuration to the canonical Codex reviewer contract. The explicit project slot previously replaced the generated defaults with a generic local worker, which allowed a stale OpenRouter/GLM slot override to become the effective launch.

## Changes

- Pin `worker-1` to the canonical Codex reviewer values in `.winsmux.yaml`.
- Add a regression test that compares the tracked slot with `New-BridgeManagedAgentSlots`, including missing and extra keys.
- Isolate the regression test from machine-local global winsmux options.

## Review

- Independent review: PASS after two test-hardening findings were fixed.
- The ignored provider registry remains a higher-precedence local override by design; operators clear it once when adopting this tracked default.

## Test plan

- `Invoke-Pester -Path tests/Integration.MultiAgent.Tests.ps1 -Output Detailed` — 27/27 passed.
- `git diff --check origin/main...HEAD` — passed.

