### PR TITLE
fix(roadmap): support four-part release versions

### DIFF
--- a/tests/HarnessContract.Tests.ps1
+++ b/tests/HarnessContract.Tests.ps1
@@ -449,6 +449,7 @@ manual flow
         }
     )
 }
+
 '@
 
             $output = & $script:PwshPath -NoProfile -File $script:SyncInternalDocsPath `
@@ -464,6 +465,25 @@ manual flow
             $manualChecklist = Get-Content -LiteralPath $manualChecklistPath -Raw -Encoding UTF8
             $manualChecklist | Should -Match '\| v1\.0\.0: Release gate \| 進行中 \| partial release gate \| mixed task states \| \[ \] 未 \| \[ \] \| partial \|'
             $manualChecklist | Should -Match '\| v1\.0\.1 \| 公開済み \| complete release gate \| all task states are done \| \[ \] 未 \| \[ \] \| complete \|'
+
+            $sortedVersions = & {
+                . $script:SyncInternalDocsPath `
+                    -BacklogPath $backlogPath `
+                    -RoadmapTitleJaPath $roadmapTitlePath `
+                    -FeatureInventoryPath $featureInventoryPath `
+                    -ManualChecklistPath $manualChecklistPath `
+                    -MetaPath $metaPath | Out-Null
+
+                @('v0.36.29', 'v0.36.28.1', 'v0.36.28') |
+                    Sort-Object `
+                        @{ Expression = { (Get-VersionSortTuple -Version $_)[0] } }, `
+                        @{ Expression = { (Get-VersionSortTuple -Version $_)[1] } }, `
+                        @{ Expression = { (Get-VersionSortTuple -Version $_)[2] } }, `
+                        @{ Expression = { (Get-VersionSortTuple -Version $_)[3] } }
+            }
+            $sortedVersions[0] | Should -Be 'v0.36.28'
+            $sortedVersions[1] | Should -Be 'v0.36.28.1'
+            $sortedVersions[2] | Should -Be 'v0.36.29'
         } finally {
             Remove-Item -LiteralPath $fixtureRoot -Recurse -Force -ErrorAction SilentlyContinue
         }
@@ -1389,5 +1409,206 @@ Describe 'desktop PTY event payload contract' {
         $client | Should -Match 'normalizePtyOutputEventPayload\(event\.payload\)'
         $client | Should -Match 'typeof payload === "string"'
         $client | Should -Match 'typeof payload\?\.data === "string"'
+    }
+}
+
+Describe 'sync-roadmap semantic version ordering' {
+    BeforeAll {
+        $repoRoot = Split-Path -Parent $PSScriptRoot
+        $fixtureRoot = Join-Path $TestDrive 'roadmap-fixture'
+        $fixtureScriptRoot = Join-Path $fixtureRoot 'scripts'
+        $backlogPath = Join-Path $fixtureRoot 'backlog.yaml'
+        $roadmapPath = Join-Path $fixtureRoot 'ROADMAP.md'
+        $titlePath = Join-Path $fixtureRoot 'roadmap-title-ja.psd1'
+
+        New-Item -ItemType Directory -Path $fixtureScriptRoot -Force | Out-Null
+        Copy-Item -LiteralPath (Join-Path $repoRoot 'winsmux-core\scripts\sync-roadmap.ps1') -Destination $fixtureScriptRoot
+        Copy-Item -LiteralPath (Join-Path $repoRoot 'winsmux-core\scripts\planning-paths.ps1') -Destination $fixtureScriptRoot
+        Set-Content -LiteralPath (Join-Path $fixtureScriptRoot 'sync-internal-docs.ps1') -Encoding utf8NoBOM -Value @'
+param([string]$BacklogPath, [string]$RoadmapTitleJaPath)
+'@
+        $script:RoadmapFixtureScriptPath = Join-Path $fixtureScriptRoot 'sync-roadmap.ps1'
+
+        Set-Content -LiteralPath $backlogPath -Encoding utf8NoBOM -Value @'
+version: 3
+tasks:
+  # === v0.19.9.1: Four-part backlog heading ===
+  - id: TASK-FOUR-HEADING
+    title: Four-part heading task
+    status: todo
+    priority: P0
+    target_version: "v0.19.9.1"
+    repo: winsmux
+  # === v0.36.28: Three-part current release ===
+  - id: TASK-THREE-CURRENT
+    title: Three-part current task
+    status: todo
+    priority: P0
+    target_version: "v0.36.28"
+    repo: winsmux
+  # === v0.36.28.1: Four-part patch release ===
+  - id: TASK-FOUR-PATCH
+    title: Four-part patch task
+    status: todo
+    priority: P0
+    target_version: "v0.36.28.1"
+    repo: winsmux
+  # === v0.36.29: Three-part next release ===
+  - id: TASK-THREE-NEXT
+    title: Three-part next task
+    status: todo
+    priority: P0
+    target_version: "v0.36.29"
+    repo: winsmux
+'@
+
+        Set-Content -LiteralPath $titlePath -Encoding utf8NoBOM -Value @'
+@{
+    VersionTitles = @{
+        'v0.36.28' = '3要素の現行版'
+        'v0.36.28.1' = '4要素の修正版'
+        'v0.36.29' = '3要素の次版'
+    }
+    TaskTitles = @{
+        'TASK-THREE-CURRENT' = '3要素の現行タスク'
+        'TASK-FOUR-PATCH' = '4要素の修正タスク'
+        'TASK-THREE-NEXT' = '3要素の次タスク'
+    }
+}
+'@
+
+        $syncOutput = @(& pwsh -NoProfile -File $script:RoadmapFixtureScriptPath `
+                -BacklogPath $backlogPath `
+                -RoadmapPath $roadmapPath `
+                -RoadmapTitleJaPath $titlePath 2>&1)
+        $script:SyncExitCode = $LASTEXITCODE
+        $script:SyncOutput = $syncOutput -join "`n"
+        $script:RoadmapLines = @(Get-Content -LiteralPath $roadmapPath -Encoding UTF8)
+    }
+
+    It 'includes a four-component release in the focus detail section' {
+        $script:SyncExitCode | Should -Be 0 -Because $script:SyncOutput
+        $script:RoadmapLines | Should -Contain '### v0.36.28.1: 4要素の修正版'
+        $script:RoadmapLines | Should -Contain '| [ ] | TASK-FOUR-PATCH | 4要素の修正タスク | P0 最優先 | winsmux | todo |'
+        $script:RoadmapLines | Should -Not -Contain '| v0.36.28.1 | TASK-FOUR-PATCH | 4要素の修正タスク | P0 最優先 | winsmux | todo |'
+    }
+
+    It 'discovers a four-component title from the backlog heading without an override' {
+        $script:RoadmapLines | Should -Contain '| v0.19.9.1 | Four-part backlog heading | 1 | [--------------------] 0% (0/1) |'
+    }
+
+    It 'requires a Japanese version-title override for a valid four-component release' {
+        $fixtureRoot = Join-Path $TestDrive 'missing-four-part-version-title'
+        $backlogPath = Join-Path $fixtureRoot 'backlog.yaml'
+        $roadmapPath = Join-Path $fixtureRoot 'ROADMAP.md'
+        $titlePath = Join-Path $fixtureRoot 'roadmap-title-ja.psd1'
+        New-Item -ItemType Directory -Path $fixtureRoot -Force | Out-Null
+        Set-Content -LiteralPath $backlogPath -Encoding utf8NoBOM -Value @'
+version: 3
+tasks:
+  - id: TASK-MISSING-VERSION-TITLE
+    title: Missing version title
+    status: todo
+    priority: P0
+    target_version: "v0.36.28.1"
+    repo: winsmux
+'@
+        Set-Content -LiteralPath $titlePath -Encoding utf8NoBOM -Value @'
+@{
+    VersionTitles = @{}
+    TaskTitles = @{
+        'TASK-MISSING-VERSION-TITLE' = '版タイトル不足の検証'
+    }
+}
+'@
+
+        $output = @(& pwsh -NoProfile -File $script:RoadmapFixtureScriptPath `
+                -BacklogPath $backlogPath `
+                -RoadmapPath $roadmapPath `
+                -RoadmapTitleJaPath $titlePath 2>&1)
+        $LASTEXITCODE | Should -Be 1
+        $expectedError = "Roadmap Japanese version-title gate failed. Add version title overrides to $titlePath for: v0.36.28.1"
+        ($output | Out-String) | Should -Match ([regex]::Escape($expectedError))
+    }
+
+    It 'keeps invalid version shapes out of numeric focus ordering and title gates' {
+        $fixtureRoot = Join-Path $TestDrive 'invalid-roadmap-versions'
+        $backlogPath = Join-Path $fixtureRoot 'backlog.yaml'
+        $roadmapPath = Join-Path $fixtureRoot 'ROADMAP.md'
+        $titlePath = Join-Path $fixtureRoot 'roadmap-title-ja.psd1'
+        New-Item -ItemType Directory -Path $fixtureRoot -Force | Out-Null
+        Set-Content -LiteralPath $backlogPath -Encoding utf8NoBOM -Value @'
+version: 3
+tasks:
+  - id: TASK-VALID
+    title: Valid version task
+    status: todo
+    priority: P0
+    target_version: "v0.36.29"
+    repo: winsmux
+  - id: TASK-TOO-MANY
+    title: Too many version parts
+    status: todo
+    priority: P0
+    target_version: "v0.36.28.1.2"
+    repo: winsmux
+  - id: TASK-PRERELEASE
+    title: Prerelease version
+    status: todo
+    priority: P0
+    target_version: "v0.36.28-alpha"
+    repo: winsmux
+  - id: TASK-TRAILING-DOT
+    title: Trailing dot version
+    status: todo
+    priority: P0
+    target_version: "v0.36.28."
+    repo: winsmux
+'@
+        Set-Content -LiteralPath $titlePath -Encoding utf8NoBOM -Value @'
+@{
+    VersionTitles = @{
+        'v0.36.29' = '有効な版'
+    }
+    TaskTitles = @{
+        'TASK-VALID' = '有効な版のタスク'
+    }
+}
+'@
+
+        $output = @(& pwsh -NoProfile -File $script:RoadmapFixtureScriptPath `
+                -BacklogPath $backlogPath `
+                -RoadmapPath $roadmapPath `
+                -RoadmapTitleJaPath $titlePath 2>&1)
+        $LASTEXITCODE | Should -Be 0 -Because ($output | Out-String)
+        $roadmapLines = @(Get-Content -LiteralPath $roadmapPath -Encoding UTF8)
+        foreach ($invalidVersion in @('v0.36.28.1.2', 'v0.36.28-alpha', 'v0.36.28.')) {
+            @($roadmapLines | Where-Object { $_ -like "### ${invalidVersion}*" }).Count | Should -Be 0
+        }
+
+        $validIndex = [Array]::FindIndex($roadmapLines, [Predicate[string]] { param($line) $line -like '| v0.36.29 |*' })
+        foreach ($invalidVersion in @('v0.36.28.1.2', 'v0.36.28-alpha', 'v0.36.28.')) {
+            $invalidIndex = [Array]::FindIndex($roadmapLines, [Predicate[string]] { param($line) $line -like "| ${invalidVersion} |*" })
+            $invalidIndex | Should -BeGreaterThan $validIndex
+        }
+    }
+
+    It 'orders a four-component patch release between adjacent three-component releases' {
+        $currentIndex = [Array]::IndexOf($script:RoadmapLines, '| v0.36.28 | 3要素の現行版 | 1 | [--------------------] 0% (0/1) |')
+        $patchIndex = [Array]::IndexOf($script:RoadmapLines, '| v0.36.28.1 | 4要素の修正版 | 1 | [--------------------] 0% (0/1) |')
+        $nextIndex = [Array]::IndexOf($script:RoadmapLines, '| v0.36.29 | 3要素の次版 | 1 | [--------------------] 0% (0/1) |')
+
+        $currentIndex | Should -BeGreaterOrEqual 0
+        $patchIndex | Should -BeGreaterThan $currentIndex
+        $patchIndex | Should -BeLessThan $nextIndex
+    }
+
+    It 'preserves focus details and ordering for three-component releases' {
+        $script:RoadmapLines | Should -Contain '### v0.36.28: 3要素の現行版'
+        $script:RoadmapLines | Should -Contain '### v0.36.29: 3要素の次版'
+
+        $currentDetailIndex = [Array]::IndexOf($script:RoadmapLines, '### v0.36.28: 3要素の現行版')
+        $nextDetailIndex = [Array]::IndexOf($script:RoadmapLines, '### v0.36.29: 3要素の次版')
+        $nextDetailIndex | Should -BeGreaterThan $currentDetailIndex
     }
 }

--- a/tests/HarnessContract.Tests.ps1
+++ b/tests/HarnessContract.Tests.ps1
@@ -1531,6 +1531,159 @@ tasks:
         ($output | Out-String) | Should -Match ([regex]::Escape($expectedError))
     }
 
+    It 'requires Japanese version-title overrides for supported symbolic release slugs' {
+        $fixtureRoot = Join-Path $TestDrive 'missing-symbolic-version-titles'
+        $backlogPath = Join-Path $fixtureRoot 'backlog.yaml'
+        $roadmapPath = Join-Path $fixtureRoot 'ROADMAP.md'
+        $titlePath = Join-Path $fixtureRoot 'roadmap-title-ja.psd1'
+        New-Item -ItemType Directory -Path $fixtureRoot -Force | Out-Null
+        Set-Content -LiteralPath $backlogPath -Encoding utf8NoBOM -Value @'
+version: 3
+tasks:
+  - id: TASK-GOVERNANCE
+    title: Governance task
+    status: todo
+    priority: P0
+    target_version: "post-v1.0.0-governance"
+    repo: winsmux
+  - id: TASK-SECURITY-HARDENING
+    title: Security hardening task
+    status: todo
+    priority: P0
+    target_version: "post-v1.0.0-security-hardening"
+    repo: winsmux
+'@
+        Set-Content -LiteralPath $titlePath -Encoding utf8NoBOM -Value @'
+@{
+    VersionTitles = @{}
+    TaskTitles = @{
+        'TASK-GOVERNANCE' = 'ガバナンス対応'
+        'TASK-SECURITY-HARDENING' = 'セキュリティ強化'
+    }
+}
+'@
+
+        $output = @(& pwsh -NoProfile -File $script:RoadmapFixtureScriptPath `
+                -BacklogPath $backlogPath `
+                -RoadmapPath $roadmapPath `
+                -RoadmapTitleJaPath $titlePath 2>&1)
+        $LASTEXITCODE | Should -Be 1
+        $expectedError = "Roadmap Japanese version-title gate failed. Add version title overrides to $titlePath for: post-v1.0.0-governance, post-v1.0.0-security-hardening"
+        ($output | Out-String) | Should -Match ([regex]::Escape($expectedError))
+    }
+
+    It 'requires Japanese task-title overrides for supported symbolic release slugs' {
+        $fixtureRoot = Join-Path $TestDrive 'missing-symbolic-task-titles'
+        $backlogPath = Join-Path $fixtureRoot 'backlog.yaml'
+        $roadmapPath = Join-Path $fixtureRoot 'ROADMAP.md'
+        $titlePath = Join-Path $fixtureRoot 'roadmap-title-ja.psd1'
+        New-Item -ItemType Directory -Path $fixtureRoot -Force | Out-Null
+        Set-Content -LiteralPath $backlogPath -Encoding utf8NoBOM -Value @'
+version: 3
+tasks:
+  - id: TASK-GOVERNANCE
+    title: Governance task
+    status: todo
+    priority: P0
+    target_version: "post-v1.0.0-governance"
+    repo: winsmux
+  - id: TASK-SECURITY-HARDENING
+    title: Security hardening task
+    status: todo
+    priority: P0
+    target_version: "post-v1.0.0-security-hardening"
+    repo: winsmux
+'@
+        Set-Content -LiteralPath $titlePath -Encoding utf8NoBOM -Value @'
+@{
+    VersionTitles = @{
+        'post-v1.0.0-governance' = 'ガバナンス版'
+        'post-v1.0.0-security-hardening' = 'セキュリティ強化版'
+    }
+    TaskTitles = @{}
+}
+'@
+
+        $output = @(& pwsh -NoProfile -File $script:RoadmapFixtureScriptPath `
+                -BacklogPath $backlogPath `
+                -RoadmapPath $roadmapPath `
+                -RoadmapTitleJaPath $titlePath 2>&1)
+        $LASTEXITCODE | Should -Be 1
+        $expectedError = "Roadmap Japanese title gate failed. Add task title overrides to $titlePath for: TASK-GOVERNANCE (Governance task), TASK-SECURITY-HARDENING (Security hardening task)"
+        ($output | Out-String) | Should -Match ([regex]::Escape($expectedError))
+    }
+
+    It 'requires a Japanese task-title override for a supported post-v1 bucket' {
+        $fixtureRoot = Join-Path $TestDrive 'missing-post-v1-task-title'
+        $backlogPath = Join-Path $fixtureRoot 'backlog.yaml'
+        $roadmapPath = Join-Path $fixtureRoot 'ROADMAP.md'
+        $titlePath = Join-Path $fixtureRoot 'roadmap-title-ja.psd1'
+        New-Item -ItemType Directory -Path $fixtureRoot -Force | Out-Null
+        Set-Content -LiteralPath $backlogPath -Encoding utf8NoBOM -Value @'
+version: 3
+tasks:
+  - id: TASK-POST-V1
+    title: Post v1 task title
+    status: todo
+    priority: P0
+    target_version: "post-v1.0.0-fixture"
+    repo: winsmux
+'@
+        Set-Content -LiteralPath $titlePath -Encoding utf8NoBOM -Value @'
+@{
+    VersionTitles = @{
+        'post-v1.0.0-fixture' = 'v1以降の対応版'
+    }
+    TaskTitles = @{}
+}
+'@
+
+        $output = @(& pwsh -NoProfile -File $script:RoadmapFixtureScriptPath `
+                -BacklogPath $backlogPath `
+                -RoadmapPath $roadmapPath `
+                -RoadmapTitleJaPath $titlePath 2>&1)
+        $LASTEXITCODE | Should -Be 1
+        $expectedError = "Roadmap Japanese title gate failed. Add task title overrides to $titlePath for: TASK-POST-V1 (Post v1 task title)"
+        ($output | Out-String) | Should -Match ([regex]::Escape($expectedError))
+    }
+
+    It 'preserves an explicit Japanese version title for an all-done post-v1 bucket' {
+        $fixtureRoot = Join-Path $TestDrive 'completed-post-v1-title'
+        $backlogPath = Join-Path $fixtureRoot 'backlog.yaml'
+        $roadmapPath = Join-Path $fixtureRoot 'ROADMAP.md'
+        $titlePath = Join-Path $fixtureRoot 'roadmap-title-ja.psd1'
+        New-Item -ItemType Directory -Path $fixtureRoot -Force | Out-Null
+        Set-Content -LiteralPath $backlogPath -Encoding utf8NoBOM -Value @'
+version: 3
+tasks:
+  - id: TASK-POST-V1-DONE
+    title: Completed post v1 task
+    status: done
+    priority: P0
+    target_version: "post-v1.0.0-completed"
+    repo: winsmux
+'@
+        Set-Content -LiteralPath $titlePath -Encoding utf8NoBOM -Value @'
+@{
+    VersionTitles = @{
+        'post-v1.0.0-completed' = 'v1以降の完了版'
+    }
+    TaskTitles = @{
+        'TASK-POST-V1-DONE' = 'v1以降の完了タスク'
+    }
+}
+'@
+
+        $output = @(& pwsh -NoProfile -File $script:RoadmapFixtureScriptPath `
+                -BacklogPath $backlogPath `
+                -RoadmapPath $roadmapPath `
+                -RoadmapTitleJaPath $titlePath 2>&1)
+        $LASTEXITCODE | Should -Be 0 -Because ($output | Out-String)
+        $roadmapLines = @(Get-Content -LiteralPath $roadmapPath -Encoding UTF8)
+        $roadmapLines | Should -Contain '| post-v1.0.0-completed | v1以降の完了版 | 1 | [====================] 100% (1/1) |'
+        $roadmapLines | Should -Not -Contain '| post-v1.0.0-completed | 完了済み | 1 | [====================] 100% (1/1) |'
+    }
+
     It 'keeps invalid version shapes out of numeric focus ordering and title gates' {
         $fixtureRoot = Join-Path $TestDrive 'invalid-roadmap-versions'
         $backlogPath = Join-Path $fixtureRoot 'backlog.yaml'
@@ -1564,6 +1717,42 @@ tasks:
     priority: P0
     target_version: "v0.36.28."
     repo: winsmux
+  - id: TASK-SYMBOLIC-MISSING-SLUG
+    title: Symbolic version without a slug
+    status: todo
+    priority: P0
+    target_version: "post-v1.0.0"
+    repo: winsmux
+  - id: TASK-SYMBOLIC-EMPTY-SLUG
+    title: Symbolic version with an empty slug
+    status: todo
+    priority: P0
+    target_version: "post-v1.0.0-"
+    repo: winsmux
+  - id: TASK-SYMBOLIC-MISSING-SEPARATOR
+    title: Symbolic version without a separator
+    status: todo
+    priority: P0
+    target_version: "post-v1.0.0oops"
+    repo: winsmux
+  - id: TASK-SYMBOLIC-DOUBLE-HYPHEN
+    title: Symbolic version with a double hyphen
+    status: todo
+    priority: P0
+    target_version: "post-v1.0.0--bad"
+    repo: winsmux
+  - id: TASK-SYMBOLIC-UPPERCASE
+    title: Symbolic version with uppercase letters
+    status: todo
+    priority: P0
+    target_version: "post-v1.0.0-Governance"
+    repo: winsmux
+  - id: TASK-SYMBOLIC-PREFIX-SMUGGLING
+    title: Symbolic version with a smuggled prefix
+    status: todo
+    priority: P0
+    target_version: "xpost-v1.0.0-governance"
+    repo: winsmux
 '@
         Set-Content -LiteralPath $titlePath -Encoding utf8NoBOM -Value @'
 @{
@@ -1581,13 +1770,25 @@ tasks:
                 -RoadmapPath $roadmapPath `
                 -RoadmapTitleJaPath $titlePath 2>&1)
         $LASTEXITCODE | Should -Be 0 -Because ($output | Out-String)
+        ($output | Out-String) | Should -Not -Match 'Roadmap Japanese (version-)?title gate failed'
         $roadmapLines = @(Get-Content -LiteralPath $roadmapPath -Encoding UTF8)
-        foreach ($invalidVersion in @('v0.36.28.1.2', 'v0.36.28-alpha', 'v0.36.28.')) {
+        $invalidVersions = @(
+            'v0.36.28.1.2',
+            'v0.36.28-alpha',
+            'v0.36.28.',
+            'post-v1.0.0',
+            'post-v1.0.0-',
+            'post-v1.0.0oops',
+            'post-v1.0.0--bad',
+            'post-v1.0.0-Governance',
+            'xpost-v1.0.0-governance'
+        )
+        foreach ($invalidVersion in $invalidVersions) {
             @($roadmapLines | Where-Object { $_ -like "### ${invalidVersion}*" }).Count | Should -Be 0
         }
 
         $validIndex = [Array]::FindIndex($roadmapLines, [Predicate[string]] { param($line) $line -like '| v0.36.29 |*' })
-        foreach ($invalidVersion in @('v0.36.28.1.2', 'v0.36.28-alpha', 'v0.36.28.')) {
+        foreach ($invalidVersion in $invalidVersions) {
             $invalidIndex = [Array]::FindIndex($roadmapLines, [Predicate[string]] { param($line) $line -like "| ${invalidVersion} |*" })
             $invalidIndex | Should -BeGreaterThan $validIndex
         }

--- a/winsmux-core/scripts/sync-internal-docs.ps1
+++ b/winsmux-core/scripts/sync-internal-docs.ps1
@@ -249,18 +249,40 @@ function Get-RoadmapLocalizationMap {
     }
 }
 
+function ConvertFrom-PlanningVersion {
+    param([AllowNull()][string]$Version)
+
+    if ($Version -notmatch '^v(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)(?:\.(?<revision>\d+))?$') {
+        return $null
+    }
+
+    $revision = 0
+    if (-not [string]::IsNullOrWhiteSpace($Matches['revision'])) {
+        $revision = [int]$Matches['revision']
+    }
+
+    return [pscustomobject]@{
+        Major    = [int]$Matches['major']
+        Minor    = [int]$Matches['minor']
+        Patch    = [int]$Matches['patch']
+        Revision = $revision
+        Raw      = $Version
+    }
+}
+
 function Get-VersionSortTuple {
     param([AllowNull()][string]$Version)
 
-    if ($Version -match '^v(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)$') {
-        return @([int]$Matches['major'], [int]$Matches['minor'], [int]$Matches['patch'], $Version)
+    $parsedVersion = ConvertFrom-PlanningVersion -Version $Version
+    if ($null -ne $parsedVersion) {
+        return @($parsedVersion.Major, $parsedVersion.Minor, $parsedVersion.Patch, $parsedVersion.Revision, $parsedVersion.Raw)
     }
 
     if ($Version -eq 'pending') {
-        return @(9998, 0, 0, $Version)
+        return @(9998, 0, 0, 0, $Version)
     }
 
-    return @(9997, 0, 0, (ConvertTo-StringOrEmpty -Value $Version))
+    return @(9997, 0, 0, 0, (ConvertTo-StringOrEmpty -Value $Version))
 }
 
 function Get-PlanningState {

--- a/winsmux-core/scripts/sync-roadmap.ps1
+++ b/winsmux-core/scripts/sync-roadmap.ps1
@@ -169,8 +169,12 @@ function Get-VersionTitleMap {
     $versionTitles = [ordered]@{}
 
     foreach ($line in ($normalized -split "`n")) {
-        if ($line -match '^[ \t]*#[ \t]*===[ \t]*(?<version>v\d+\.\d+\.\d+):[ \t]*(?<title>.+?)[ \t]*===[ \t]*$') {
-            $versionTitles[$Matches['version']] = $Matches['title'].Trim()
+        if ($line -match '^[ \t]*#[ \t]*===[ \t]*(?<version>v[^:\s]+):[ \t]*(?<title>.+?)[ \t]*===[ \t]*$') {
+            $version = $Matches['version']
+            $title = $Matches['title'].Trim()
+            if ($null -ne (ConvertFrom-PlanningVersion -Version $version)) {
+                $versionTitles[$version] = $title
+            }
         }
     }
 
@@ -197,17 +201,42 @@ function Get-RoadmapLocalizationMap {
     }
 }
 
+function ConvertFrom-PlanningVersion {
+    param(
+        [AllowNull()]
+        [string]$Version
+    )
+
+    if ($Version -notmatch '^v(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)(?:\.(?<revision>\d+))?$') {
+        return $null
+    }
+
+    $revision = 0
+    if (-not [string]::IsNullOrWhiteSpace($Matches['revision'])) {
+        $revision = [int]$Matches['revision']
+    }
+
+    return [pscustomobject]@{
+        Major    = [int]$Matches['major']
+        Minor    = [int]$Matches['minor']
+        Patch    = [int]$Matches['patch']
+        Revision = $revision
+        Raw      = $Version
+    }
+}
+
 function Get-VersionSortTuple {
     param(
         [AllowNull()]
         [string]$Version
     )
 
-    if ($Version -match '^v(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)$') {
-        return @([int]$Matches['major'], [int]$Matches['minor'], [int]$Matches['patch'])
+    $parsedVersion = ConvertFrom-PlanningVersion -Version $Version
+    if ($null -ne $parsedVersion) {
+        return @($parsedVersion.Major, $parsedVersion.Minor, $parsedVersion.Patch, $parsedVersion.Revision)
     }
 
-    return @([int]::MaxValue, [int]::MaxValue, [int]::MaxValue)
+    return
 }
 
 function Test-VersionGreaterOrEqual {
@@ -219,10 +248,13 @@ function Test-VersionGreaterOrEqual {
         [string]$MinimumVersion
     )
 
-    $left = Get-VersionSortTuple -Version $Version
-    $right = Get-VersionSortTuple -Version $MinimumVersion
+    $left = @(Get-VersionSortTuple -Version $Version)
+    $right = @(Get-VersionSortTuple -Version $MinimumVersion)
+    if ($left.Count -ne 4 -or $right.Count -ne 4) {
+        return $false
+    }
 
-    for ($index = 0; $index -lt 3; $index++) {
+    for ($index = 0; $index -lt 4; $index++) {
         if ($left[$index] -gt $right[$index]) {
             return $true
         }
@@ -245,7 +277,7 @@ function Test-RequiresJapaneseVersionTitle {
         return $true
     }
 
-    if ($Version -match '^v\d+\.\d+\.\d+$') {
+    if ($null -ne (ConvertFrom-PlanningVersion -Version $Version)) {
         return Test-VersionGreaterOrEqual -Version $Version -MinimumVersion 'v0.20.0'
     }
 
@@ -687,7 +719,7 @@ function Test-RoadmapVersionInFocusRange {
         [string]$Version
     )
 
-    if (-not ($Version -match '^v\d+\.\d+\.\d+$')) {
+    if ($null -eq (ConvertFrom-PlanningVersion -Version $Version)) {
         return $false
     }
 
@@ -701,20 +733,23 @@ function Get-VersionSortKey {
         [string]$Version
     )
 
-    if ($Version -match '^v(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)$') {
+    $parsedVersion = ConvertFrom-PlanningVersion -Version $Version
+    if ($null -ne $parsedVersion) {
         return [pscustomobject]@{
-            Major = [int]$Matches['major']
-            Minor = [int]$Matches['minor']
-            Patch = [int]$Matches['patch']
-            Raw   = $Version
+            Major    = $parsedVersion.Major
+            Minor    = $parsedVersion.Minor
+            Patch    = $parsedVersion.Patch
+            Revision = $parsedVersion.Revision
+            Raw      = $parsedVersion.Raw
         }
     }
 
     return [pscustomobject]@{
-        Major = [int]::MaxValue
-        Minor = [int]::MaxValue
-        Patch = [int]::MaxValue
-        Raw   = (ConvertTo-StringOrEmpty -Value $Version)
+        Major    = [int]::MaxValue
+        Minor    = [int]::MaxValue
+        Patch    = [int]::MaxValue
+        Revision = [int]::MaxValue
+        Raw      = (ConvertTo-StringOrEmpty -Value $Version)
     }
 }
 
@@ -853,7 +888,7 @@ foreach ($version in $versionTitles.Keys) {
 }
 
 $versionGroups = @($versionGroupMap.Values) |
-    Sort-Object @{ Expression = { (Get-VersionSortKey -Version $_.Name).Major } }, @{ Expression = { (Get-VersionSortKey -Version $_.Name).Minor } }, @{ Expression = { (Get-VersionSortKey -Version $_.Name).Patch } }, @{ Expression = { (Get-VersionSortKey -Version $_.Name).Raw } }
+    Sort-Object @{ Expression = { (Get-VersionSortKey -Version $_.Name).Major } }, @{ Expression = { (Get-VersionSortKey -Version $_.Name).Minor } }, @{ Expression = { (Get-VersionSortKey -Version $_.Name).Patch } }, @{ Expression = { (Get-VersionSortKey -Version $_.Name).Revision } }, @{ Expression = { (Get-VersionSortKey -Version $_.Name).Raw } }
 
 $builder = [System.Text.StringBuilder]::new()
 

--- a/winsmux-core/scripts/sync-roadmap.ps1
+++ b/winsmux-core/scripts/sync-roadmap.ps1
@@ -273,7 +273,7 @@ function Test-RequiresJapaneseVersionTitle {
         [string]$Version
     )
 
-    if ($Version -like 'post-v1.0.0*') {
+    if ($Version -cmatch '\Apost-v1[.]0[.]0-[a-z0-9]+(?:-[a-z0-9]+)*\z') {
         return $true
     }
 
@@ -915,7 +915,7 @@ foreach ($versionGroup in $versionGroups) {
     $progress = New-ProgressBar -DoneCount $doneCount -TotalCount $totalCount
     $defaultVersionTitle = if ($versionTitles.Contains($versionGroup.Name)) { $versionTitles[$versionGroup.Name] } else { '' }
     $localizedVersionTitle = Get-RoadmapVersionTitle -Version $versionGroup.Name -DefaultTitle $defaultVersionTitle -Localization $roadmapLocalization.VersionTitles
-    if ($doneCount -eq $totalCount -and -not (Test-VersionGreaterOrEqual -Version $versionGroup.Name -MinimumVersion 'v0.20.0')) {
+    if ($doneCount -eq $totalCount -and -not (Test-RequiresJapaneseVersionTitle -Version $versionGroup.Name)) {
         $localizedVersionTitle = '完了済み'
     }
     [void]$builder.AppendLine(('| {0} | {1} | {2} | {3} |' -f $versionGroup.Name, $localizedVersionTitle, $totalCount, $progress))
@@ -1008,7 +1008,7 @@ foreach ($warning in $validationWarnings) {
 }
 
 foreach ($task in $tasksWithTargetVersion) {
-    if (-not (Test-VersionGreaterOrEqual -Version $task.TargetVersion -MinimumVersion 'v0.20.0')) {
+    if (-not (Test-RequiresJapaneseVersionTitle -Version $task.TargetVersion)) {
         continue
     }
 


### PR DESCRIPTION
## Summary

Allow the planning generators to treat stabilization releases such as `v0.36.28.1` as numeric releases. Previously the summary row was emitted, but focus details, title validation, and semantic ordering only accepted three numeric components.

## Changes

- Centralize optional revision parsing in `sync-roadmap.ps1`.
- Apply the same comparison contract to focus ranges, title discovery, Japanese title validation, and version ordering.
- Align `sync-internal-docs.ps1` ordering with the same optional revision component.
- Add isolated fixtures for four-component ordering, title discovery, required localization, invalid shapes, and three-component compatibility.

## Review

- Independent review: PASS after adding coverage for all initially missed contracts and the internal-docs sibling path.

## Test plan

- `Invoke-Pester -Path tests/HarnessContract.Tests.ps1 -Output Detailed` — 48/48 passed.
- PowerShell parser checks for both modified scripts — passed.
- `git diff --check origin/main...HEAD` — passed.

