### PR TITLE
fix(submission): harden typed receipt and retry handling

### DIFF
--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -185,6 +185,7 @@ fn is_winsmux_core_bridge_command(command: &str) -> bool {
             | "verify"
             | "dispatch-task"
             | "dispatch-review"
+            | "submission-ack"
             | "dispatch-route"
             | "task-split"
             | "pipeline"
@@ -215,9 +216,6 @@ fn is_winsmux_core_bridge_command(command: &str) -> bool {
 }
 
 fn find_winsmux_core_script() -> Option<PathBuf> {
-    if env::var("WINSMUX_DISABLE_CORE_BRIDGE").as_deref() == Ok("1") {
-        return None;
-    }
     let mut candidates: Vec<PathBuf> = Vec::new();
 
     if let Ok(path) = env::var("WINSMUX_CORE_SCRIPT") {

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -184,6 +184,7 @@ fn is_winsmux_core_bridge_command(command: &str) -> bool {
             | "github-preflight"
             | "verify"
             | "dispatch-task"
+            | "dispatch-review"
             | "dispatch-route"
             | "task-split"
             | "pipeline"
@@ -214,6 +215,9 @@ fn is_winsmux_core_bridge_command(command: &str) -> bool {
 }
 
 fn find_winsmux_core_script() -> Option<PathBuf> {
+    if env::var("WINSMUX_DISABLE_CORE_BRIDGE").as_deref() == Ok("1") {
+        return None;
+    }
     let mut candidates: Vec<PathBuf> = Vec::new();
 
     if let Ok(path) = env::var("WINSMUX_CORE_SCRIPT") {
@@ -386,6 +390,12 @@ mod tests {
     #[test]
     fn workers_command_is_forwarded_to_core_bridge() {
         assert!(is_winsmux_core_bridge_command("workers"));
+    }
+
+    #[test]
+    fn typed_submission_commands_are_forwarded_to_the_shared_core_bridge() {
+        assert!(is_winsmux_core_bridge_command("dispatch-task"));
+        assert!(is_winsmux_core_bridge_command("dispatch-review"));
     }
 
     #[cfg(windows)]

--- a/core/src/operator_cli.rs
+++ b/core/src/operator_cli.rs
@@ -4757,19 +4757,56 @@ pub fn run_dispatch_review_command(args: &[&String]) -> io::Result<()> {
     let branch = current_git_branch(&project_dir)?;
     let head_sha = current_git_head(&project_dir)?;
     let context = preferred_review_pane_context(&project_dir)?;
-    let short_head = short_head_sha(&head_sha);
-    println!(
-        "Dispatching review to {} [{}] for branch {} ({})",
-        context.label, context.pane_id, branch, short_head
-    );
+    let submission_id = format!("submission-{}", Utc::now().timestamp_millis());
+    let backend = context.worker_backend.trim().to_ascii_lowercase();
+    let receipt_backend = match backend.as_str() {
+        "local" | "codex" | "api_llm" | "antigravity" | "colab_cli" | "noop" => {
+            backend.as_str()
+        }
+        _ => "noop",
+    };
+    if !matches!(backend.as_str(), "local" | "codex") {
+        let receipt = submission_receipt(
+            &submission_id,
+            "review",
+            "unsupported",
+            receipt_backend,
+            "backend_requires_packet_adapter",
+            &context,
+            Value::Null,
+        );
+        println!("{}", serde_json::to_string(&receipt).unwrap_or_default());
+        return Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "dispatch-review requires the packet adapter for this backend",
+        ));
+    }
 
-    send_review_request_to_pane(&context.pane_id)?;
-    println!(
-        "review-request sent to {}. Waiting for PENDING state...",
-        context.label
-    );
+    if let Err(error) = send_review_request_to_pane(&context.pane_id) {
+        let receipt = submission_receipt(
+            &submission_id,
+            "review",
+            "unavailable",
+            receipt_backend,
+            "pane_send_failed",
+            &context,
+            Value::Null,
+        );
+        println!("{}", serde_json::to_string(&receipt).unwrap_or_default());
+        return Err(error);
+    }
 
     if !wait_for_pending_review_state(&project_dir, &branch, &head_sha)? {
+        let receipt = submission_receipt(
+            &submission_id,
+            "review",
+            "rejected",
+            receipt_backend,
+            "review_pending_acknowledgement_missing",
+            &context,
+            Value::Null,
+        );
+        println!("{}", serde_json::to_string(&receipt).unwrap_or_default());
         return Err(io::Error::new(
             io::ErrorKind::TimedOut,
             format!(
@@ -4780,11 +4817,48 @@ pub fn run_dispatch_review_command(args: &[&String]) -> io::Result<()> {
         ));
     }
 
-    println!(
-        "PENDING confirmed. {} pane will run review-approve or review-fail. Monitor review-state.json for result.",
-        context.role
+    let receipt = submission_receipt(
+        &submission_id,
+        "review",
+        "accepted",
+        receipt_backend,
+        "",
+        &context,
+        json!({
+            "type": "review_pending_state",
+            "branch": branch,
+            "head_sha": head_sha,
+        }),
     );
+    println!("{}", serde_json::to_string(&receipt).unwrap_or_default());
     Ok(())
+}
+
+fn submission_receipt(
+    submission_id: &str,
+    kind: &str,
+    status: &str,
+    backend: &str,
+    reason_code: &str,
+    context: &ReviewPaneContext,
+    acknowledgement: Value,
+) -> Value {
+    json!({
+        "protocol_version": 1,
+        "submission_id": submission_id,
+        "kind": kind,
+        "status": status,
+        "backend": backend,
+        "reason_code": reason_code,
+        "diagnostic": "",
+        "target": {
+            "label": context.label,
+            "pane_id": context.pane_id,
+            "role": context.role,
+        },
+        "routing": Value::Null,
+        "acknowledgement": acknowledgement,
+    })
 }
 
 pub fn run_review_approve_command(args: &[&String]) -> io::Result<()> {
@@ -6849,6 +6923,7 @@ struct ReviewPaneContext {
     label: String,
     pane_id: String,
     role: String,
+    worker_backend: String,
 }
 
 #[derive(Clone)]
@@ -7141,6 +7216,14 @@ fn review_pane_context_from_value(
         label,
         pane_id: actual,
         role: canonical_role.unwrap_or_default(),
+        worker_backend: {
+            let backend = manifest_string(map, "worker_backend");
+            if backend.trim().is_empty() {
+                "local".to_string()
+            } else {
+                backend
+            }
+        },
     })
 }
 

--- a/core/src/operator_cli.rs
+++ b/core/src/operator_cli.rs
@@ -4752,86 +4752,21 @@ pub fn run_dispatch_review_command(args: &[&String]) -> io::Result<()> {
         ));
     }
     assert_dispatch_review_role_permission("dispatch-review")?;
-
-    let project_dir = env::current_dir()?;
-    let branch = current_git_branch(&project_dir)?;
-    let head_sha = current_git_head(&project_dir)?;
-    let context = preferred_review_pane_context(&project_dir)?;
     let submission_id = format!("submission-{}", Utc::now().timestamp_millis());
-    let backend = context.worker_backend.trim().to_ascii_lowercase();
-    let receipt_backend = match backend.as_str() {
-        "local" | "codex" | "api_llm" | "antigravity" | "colab_cli" | "noop" => {
-            backend.as_str()
-        }
-        _ => "noop",
-    };
-    if !matches!(backend.as_str(), "local" | "codex") {
-        let receipt = submission_receipt(
-            &submission_id,
-            "review",
-            "unsupported",
-            receipt_backend,
-            "backend_requires_packet_adapter",
-            &context,
-            Value::Null,
-        );
-        println!("{}", serde_json::to_string(&receipt).unwrap_or_default());
-        return Err(io::Error::new(
-            io::ErrorKind::Unsupported,
-            "dispatch-review requires the packet adapter for this backend",
-        ));
-    }
-
-    if let Err(error) = send_review_request_to_pane(&context.pane_id) {
-        let receipt = submission_receipt(
-            &submission_id,
-            "review",
-            "unavailable",
-            receipt_backend,
-            "pane_send_failed",
-            &context,
-            Value::Null,
-        );
-        println!("{}", serde_json::to_string(&receipt).unwrap_or_default());
-        return Err(error);
-    }
-
-    if !wait_for_pending_review_state(&project_dir, &branch, &head_sha)? {
-        let receipt = submission_receipt(
-            &submission_id,
-            "review",
-            "rejected",
-            receipt_backend,
-            "review_pending_acknowledgement_missing",
-            &context,
-            Value::Null,
-        );
-        println!("{}", serde_json::to_string(&receipt).unwrap_or_default());
-        return Err(io::Error::new(
-            io::ErrorKind::TimedOut,
-            format!(
-                "review-request was not recorded after {} attempts. Check review pane {}.",
-                dispatch_review_poll_attempts(),
-                context.pane_id
-            ),
-        ));
-    }
-
     let receipt = submission_receipt(
         &submission_id,
         "review",
-        "accepted",
-        receipt_backend,
-        "",
-        &context,
-        json!({
-            "type": "review_pending_state",
-            "branch": branch,
-            "head_sha": head_sha,
-        }),
+        "unavailable",
+        "noop",
+        "shared_submission_bridge_unavailable",
+        None,
+        Value::Null,
     );
     println!("{}", serde_json::to_string(&receipt).unwrap_or_default());
-    Ok(())
+    Err(io::Error::new(
+        io::ErrorKind::NotFound,
+        "shared submission bridge is unavailable",
+    ))
 }
 
 fn submission_receipt(
@@ -4840,9 +4775,16 @@ fn submission_receipt(
     status: &str,
     backend: &str,
     reason_code: &str,
-    context: &ReviewPaneContext,
+    context: Option<&ReviewPaneContext>,
     acknowledgement: Value,
 ) -> Value {
+    let target = context.map_or(Value::Null, |context| {
+        json!({
+            "label": context.label,
+            "pane_id": context.pane_id,
+            "role": context.role,
+        })
+    });
     json!({
         "protocol_version": 1,
         "submission_id": submission_id,
@@ -4851,11 +4793,7 @@ fn submission_receipt(
         "backend": backend,
         "reason_code": reason_code,
         "diagnostic": "",
-        "target": {
-            "label": context.label,
-            "pane_id": context.pane_id,
-            "role": context.role,
-        },
+        "target": target,
         "routing": Value::Null,
         "acknowledgement": acknowledgement,
     })
@@ -6923,7 +6861,6 @@ struct ReviewPaneContext {
     label: String,
     pane_id: String,
     role: String,
-    worker_backend: String,
 }
 
 #[derive(Clone)]
@@ -7216,69 +7153,7 @@ fn review_pane_context_from_value(
         label,
         pane_id: actual,
         role: canonical_role.unwrap_or_default(),
-        worker_backend: {
-            let backend = manifest_string(map, "worker_backend");
-            if backend.trim().is_empty() {
-                "local".to_string()
-            } else {
-                backend
-            }
-        },
     })
-}
-
-fn send_review_request_to_pane(pane_id: &str) -> io::Result<()> {
-    let command_text = "winsmux review-request";
-    let pre_send_text = capture_pane_tail(pane_id)?;
-    run_winsmux_command(&["send-keys", "-t", pane_id, "-l", "--", command_text])?;
-    thread::sleep(Duration::from_millis(300));
-    let typed_text = capture_pane_tail(pane_id)?;
-    if typed_text == pre_send_text {
-        return Err(io::Error::new(
-            io::ErrorKind::Other,
-            format!("pane buffer did not change after typing review request into {pane_id}"),
-        ));
-    }
-    if !typed_text.contains(command_text) {
-        return Err(io::Error::new(
-            io::ErrorKind::Other,
-            format!("typed review request was not observed in {pane_id}"),
-        ));
-    }
-    run_winsmux_command(&["send-keys", "-t", pane_id, "Enter"])
-}
-
-fn wait_for_pending_review_state(
-    project_dir: &Path,
-    branch: &str,
-    head_sha: &str,
-) -> io::Result<bool> {
-    let attempts = dispatch_review_poll_attempts();
-    for attempt in 0..=attempts {
-        let state = load_review_state(project_dir)?;
-        if review_state_is_pending_for_head(&state, branch, head_sha) {
-            return Ok(true);
-        }
-        if attempt < attempts {
-            thread::sleep(dispatch_review_poll_delay());
-        }
-    }
-    Ok(false)
-}
-
-fn dispatch_review_poll_attempts() -> usize {
-    env::var("WINSMUX_DISPATCH_REVIEW_POLL_ATTEMPTS")
-        .ok()
-        .and_then(|value| value.parse::<usize>().ok())
-        .unwrap_or(10)
-}
-
-fn dispatch_review_poll_delay() -> Duration {
-    env::var("WINSMUX_DISPATCH_REVIEW_POLL_INTERVAL_MS")
-        .ok()
-        .and_then(|value| value.parse::<u64>().ok())
-        .map(Duration::from_millis)
-        .unwrap_or_else(|| Duration::from_secs(3))
 }
 
 fn review_state_is_pending_for_head(

--- a/core/tests-rs/operator_cli.rs
+++ b/core/tests-rs/operator_cli.rs
@@ -5269,7 +5269,7 @@ fn operator_cli_review_request_records_pending_state_and_manifest_pane() {
 }
 
 #[test]
-fn operator_cli_dispatch_review_sends_review_request_to_preferred_pane() {
+fn operator_cli_dispatch_review_does_not_accept_send_without_run_record() {
     let project_dir = make_temp_project_dir("dispatch-review");
     write_manifest(&project_dir);
     init_git_branch(
@@ -5299,29 +5299,24 @@ fn operator_cli_dispatch_review_sends_review_request_to_preferred_pane() {
         .env("WINSMUX_PANE_ID", "%1")
         .env("WINSMUX_ROLE", "Operator")
         .env("WINSMUX_ROLE_MAP", r#"{"%1":"Operator"}"#)
-        .env("WINSMUX_DISPATCH_REVIEW_POLL_ATTEMPTS", "0")
-        .env("WINSMUX_DISABLE_CORE_BRIDGE", "1")
+        .env("WINSMUX_SUBMISSION_POLL_ATTEMPTS", "0")
         .current_dir(&project_dir)
         .output()
         .expect("winsmux command should run");
 
-    assert!(
-        output.status.success(),
-        "winsmux command failed: {}",
-        String::from_utf8_lossy(&output.stderr)
-    );
+    assert!(!output.status.success());
     let stdout = String::from_utf8_lossy(&output.stdout);
     let receipt: serde_json::Value = serde_json::from_str(stdout.trim()).expect("typed receipt");
     assert_eq!(receipt["protocol_version"], 1);
     assert_eq!(receipt["kind"], "review");
-    assert_eq!(receipt["status"], "accepted");
+    assert_eq!(receipt["status"], "rejected");
     assert_eq!(receipt["backend"], "local");
     assert_eq!(receipt["target"]["label"], "reviewer-1");
-    assert_eq!(receipt["acknowledgement"]["type"], "review_pending_state");
+    assert_eq!(receipt["reason_code"], "backend_acknowledgement_missing");
 
     let log = fs::read_to_string(log_path).expect("test should read fake winsmux log");
     assert!(
-        log.contains("send-keys") && log.contains("%3") && log.contains("winsmux review-request"),
+        log.contains("send-keys") && log.contains("%3") && log.contains("submission-ack"),
         "unexpected fake winsmux log: {log}"
     );
     assert!(
@@ -5331,7 +5326,7 @@ fn operator_cli_dispatch_review_sends_review_request_to_preferred_pane() {
 }
 
 #[test]
-fn operator_cli_dispatch_review_prefers_reviewer_role_over_manifest_order() {
+fn operator_cli_dispatch_review_prefers_reviewer_for_typed_packet() {
     let project_dir = make_temp_project_dir("dispatch-review-prefers-reviewer-role");
     write_manifest(&project_dir);
     let manifest_path = project_dir.join(".winsmux").join("manifest.yaml");
@@ -5380,24 +5375,19 @@ panes:
         .env("WINSMUX_PANE_ID", "%1")
         .env("WINSMUX_ROLE", "Operator")
         .env("WINSMUX_ROLE_MAP", r#"{"%1":"Operator"}"#)
-        .env("WINSMUX_DISPATCH_REVIEW_POLL_ATTEMPTS", "0")
-        .env("WINSMUX_DISABLE_CORE_BRIDGE", "1")
+        .env("WINSMUX_SUBMISSION_POLL_ATTEMPTS", "0")
         .current_dir(&project_dir)
         .output()
         .expect("winsmux command should run");
 
-    assert!(
-        output.status.success(),
-        "winsmux command failed: {}",
-        String::from_utf8_lossy(&output.stderr)
-    );
+    assert!(!output.status.success());
     let stdout = String::from_utf8_lossy(&output.stdout);
     let receipt: serde_json::Value = serde_json::from_str(stdout.trim()).expect("typed receipt");
-    assert_eq!(receipt["status"], "accepted");
+    assert_eq!(receipt["status"], "rejected");
     assert_eq!(receipt["target"]["label"], "reviewer-1");
     let log = fs::read_to_string(log_path).expect("test should read fake winsmux log");
     assert!(
-        log.contains("send-keys") && log.contains("%3") && log.contains("winsmux review-request"),
+        log.contains("send-keys") && log.contains("%3") && log.contains("submission-ack"),
         "unexpected fake winsmux log: {log}"
     );
     assert!(
@@ -5407,7 +5397,7 @@ panes:
 }
 
 #[test]
-fn operator_cli_dispatch_review_rejects_stale_pending_review_state() {
+fn operator_cli_dispatch_review_does_not_accept_stale_pending_review_state() {
     let project_dir = make_temp_project_dir("dispatch-review-stale");
     write_manifest(&project_dir);
     init_git_branch(
@@ -5437,8 +5427,7 @@ fn operator_cli_dispatch_review_rejects_stale_pending_review_state() {
         .env("WINSMUX_PANE_ID", "%1")
         .env("WINSMUX_ROLE", "Operator")
         .env("WINSMUX_ROLE_MAP", r#"{"%1":"Operator"}"#)
-        .env("WINSMUX_DISPATCH_REVIEW_POLL_ATTEMPTS", "0")
-        .env("WINSMUX_DISABLE_CORE_BRIDGE", "1")
+        .env("WINSMUX_SUBMISSION_POLL_ATTEMPTS", "0")
         .current_dir(&project_dir)
         .output()
         .expect("winsmux command should run");
@@ -5447,15 +5436,7 @@ fn operator_cli_dispatch_review_rejects_stale_pending_review_state() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     let receipt: serde_json::Value = serde_json::from_str(stdout.trim()).expect("typed refusal");
     assert_eq!(receipt["status"], "rejected");
-    assert_eq!(
-        receipt["reason_code"],
-        "review_pending_acknowledgement_missing"
-    );
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        stderr.contains("review-request was not recorded after 0 attempts"),
-        "unexpected stderr: {stderr}"
-    );
+    assert_eq!(receipt["reason_code"], "backend_acknowledgement_missing");
 }
 
 #[test]
@@ -5468,7 +5449,6 @@ fn operator_cli_dispatch_review_rejects_non_operator_role() {
         .env("WINSMUX_PANE_ID", "%2")
         .env("WINSMUX_ROLE", "Worker")
         .env("WINSMUX_ROLE_MAP", r#"{"%2":"Worker"}"#)
-        .env("WINSMUX_DISABLE_CORE_BRIDGE", "1")
         .current_dir(&project_dir)
         .output()
         .expect("winsmux command should run");
@@ -5476,7 +5456,7 @@ fn operator_cli_dispatch_review_rejects_non_operator_role() {
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("dispatch-review is not permitted for the current role"),
+        stderr.contains("dispatch-review") && stderr.contains("permitted for the current role"),
         "unexpected stderr: {stderr}"
     );
 }
@@ -6543,14 +6523,9 @@ fn write_fake_winsmux_dispatch_review(
         body.push_str(&log_path.to_string_lossy());
         body.push_str("\"\r\n");
         body.push_str("if \"%1\"==\"capture-pane\" (\r\n");
-        body.push_str("  findstr /c:\"winsmux review-request\" \"");
+        body.push_str("  type \"");
         body.push_str(&log_path.to_string_lossy());
-        body.push_str("\" >nul 2>nul\r\n");
-        body.push_str("  if errorlevel 1 (\r\n");
-        body.push_str("    echo PS C:\\repo^>\r\n");
-        body.push_str("  ) else (\r\n");
-        body.push_str("    echo PS C:\\repo^> winsmux review-request\r\n");
-        body.push_str("  )\r\n");
+        body.push_str("\" 2>nul\r\n");
         body.push_str("  exit /b 0\r\n)\r\n");
         body.push_str("if \"%1\"==\"send-keys\" exit /b 0\r\n");
         body.push_str("exit /b 1\r\n");
@@ -6565,13 +6540,9 @@ fn write_fake_winsmux_dispatch_review(
         body.push_str(&log_path.to_string_lossy());
         body.push_str("'\n");
         body.push_str("if [ \"$1\" = \"capture-pane\" ]; then\n");
-        body.push_str("  if grep -q 'winsmux review-request' '");
+        body.push_str("  cat '");
         body.push_str(&log_path.to_string_lossy());
-        body.push_str("'; then\n");
-        body.push_str("    printf '%s\\n' 'PS /repo> winsmux review-request'\n");
-        body.push_str("  else\n");
-        body.push_str("    printf '%s\\n' 'PS /repo>'\n");
-        body.push_str("  fi\n");
+        body.push_str("' 2>/dev/null\n");
         body.push_str("  exit 0\n");
         body.push_str("fi\n");
         body.push_str("if [ \"$1\" = \"send-keys\" ]; then\n  exit 0\nfi\n");

--- a/core/tests-rs/operator_cli.rs
+++ b/core/tests-rs/operator_cli.rs
@@ -5269,7 +5269,7 @@ fn operator_cli_review_request_records_pending_state_and_manifest_pane() {
 }
 
 #[test]
-fn operator_cli_dispatch_review_does_not_accept_send_without_run_record() {
+fn operator_cli_dispatch_review_refuses_without_strong_caller_identity() {
     let project_dir = make_temp_project_dir("dispatch-review");
     write_manifest(&project_dir);
     init_git_branch(
@@ -5309,20 +5309,11 @@ fn operator_cli_dispatch_review_does_not_accept_send_without_run_record() {
     let receipt: serde_json::Value = serde_json::from_str(stdout.trim()).expect("typed receipt");
     assert_eq!(receipt["protocol_version"], 1);
     assert_eq!(receipt["kind"], "review");
-    assert_eq!(receipt["status"], "rejected");
+    assert_eq!(receipt["status"], "unavailable");
     assert_eq!(receipt["backend"], "local");
     assert_eq!(receipt["target"]["label"], "reviewer-1");
-    assert_eq!(receipt["reason_code"], "backend_acknowledgement_missing");
-
-    let log = fs::read_to_string(log_path).expect("test should read fake winsmux log");
-    assert!(
-        log.contains("send-keys") && log.contains("%3") && log.contains("submission-ack"),
-        "unexpected fake winsmux log: {log}"
-    );
-    assert!(
-        log.contains("send-keys") && log.contains("%3") && log.contains("Enter"),
-        "unexpected fake winsmux log: {log}"
-    );
+    assert_eq!(receipt["reason_code"], "caller_identity_unavailable");
+    assert!(!log_path.exists(), "refusal must happen before pane send");
 }
 
 #[test]
@@ -5383,17 +5374,10 @@ panes:
     assert!(!output.status.success());
     let stdout = String::from_utf8_lossy(&output.stdout);
     let receipt: serde_json::Value = serde_json::from_str(stdout.trim()).expect("typed receipt");
-    assert_eq!(receipt["status"], "rejected");
+    assert_eq!(receipt["status"], "unavailable");
     assert_eq!(receipt["target"]["label"], "reviewer-1");
-    let log = fs::read_to_string(log_path).expect("test should read fake winsmux log");
-    assert!(
-        log.contains("send-keys") && log.contains("%3") && log.contains("submission-ack"),
-        "unexpected fake winsmux log: {log}"
-    );
-    assert!(
-        !log.contains("send-keys -t %2"),
-        "review request should not be sent to the worker pane: {log}"
-    );
+    assert_eq!(receipt["reason_code"], "caller_identity_unavailable");
+    assert!(!log_path.exists(), "refusal must happen before pane send");
 }
 
 #[test]
@@ -5435,8 +5419,8 @@ fn operator_cli_dispatch_review_does_not_accept_stale_pending_review_state() {
     assert!(!output.status.success());
     let stdout = String::from_utf8_lossy(&output.stdout);
     let receipt: serde_json::Value = serde_json::from_str(stdout.trim()).expect("typed refusal");
-    assert_eq!(receipt["status"], "rejected");
-    assert_eq!(receipt["reason_code"], "backend_acknowledgement_missing");
+    assert_eq!(receipt["status"], "unavailable");
+    assert_eq!(receipt["reason_code"], "caller_identity_unavailable");
 }
 
 #[test]

--- a/core/tests-rs/operator_cli.rs
+++ b/core/tests-rs/operator_cli.rs
@@ -5300,6 +5300,7 @@ fn operator_cli_dispatch_review_sends_review_request_to_preferred_pane() {
         .env("WINSMUX_ROLE", "Operator")
         .env("WINSMUX_ROLE_MAP", r#"{"%1":"Operator"}"#)
         .env("WINSMUX_DISPATCH_REVIEW_POLL_ATTEMPTS", "0")
+        .env("WINSMUX_DISABLE_CORE_BRIDGE", "1")
         .current_dir(&project_dir)
         .output()
         .expect("winsmux command should run");
@@ -5310,14 +5311,13 @@ fn operator_cli_dispatch_review_sends_review_request_to_preferred_pane() {
         String::from_utf8_lossy(&output.stderr)
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(
-        stdout.contains("Dispatching review to reviewer-1 [%3]"),
-        "unexpected stdout: {stdout}"
-    );
-    assert!(
-        stdout.contains("PENDING confirmed. Reviewer pane will run review-approve or review-fail."),
-        "unexpected stdout: {stdout}"
-    );
+    let receipt: serde_json::Value = serde_json::from_str(stdout.trim()).expect("typed receipt");
+    assert_eq!(receipt["protocol_version"], 1);
+    assert_eq!(receipt["kind"], "review");
+    assert_eq!(receipt["status"], "accepted");
+    assert_eq!(receipt["backend"], "local");
+    assert_eq!(receipt["target"]["label"], "reviewer-1");
+    assert_eq!(receipt["acknowledgement"]["type"], "review_pending_state");
 
     let log = fs::read_to_string(log_path).expect("test should read fake winsmux log");
     assert!(
@@ -5381,6 +5381,7 @@ panes:
         .env("WINSMUX_ROLE", "Operator")
         .env("WINSMUX_ROLE_MAP", r#"{"%1":"Operator"}"#)
         .env("WINSMUX_DISPATCH_REVIEW_POLL_ATTEMPTS", "0")
+        .env("WINSMUX_DISABLE_CORE_BRIDGE", "1")
         .current_dir(&project_dir)
         .output()
         .expect("winsmux command should run");
@@ -5391,10 +5392,9 @@ panes:
         String::from_utf8_lossy(&output.stderr)
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(
-        stdout.contains("Dispatching review to reviewer-1 [%3]"),
-        "unexpected stdout: {stdout}"
-    );
+    let receipt: serde_json::Value = serde_json::from_str(stdout.trim()).expect("typed receipt");
+    assert_eq!(receipt["status"], "accepted");
+    assert_eq!(receipt["target"]["label"], "reviewer-1");
     let log = fs::read_to_string(log_path).expect("test should read fake winsmux log");
     assert!(
         log.contains("send-keys") && log.contains("%3") && log.contains("winsmux review-request"),
@@ -5438,11 +5438,19 @@ fn operator_cli_dispatch_review_rejects_stale_pending_review_state() {
         .env("WINSMUX_ROLE", "Operator")
         .env("WINSMUX_ROLE_MAP", r#"{"%1":"Operator"}"#)
         .env("WINSMUX_DISPATCH_REVIEW_POLL_ATTEMPTS", "0")
+        .env("WINSMUX_DISABLE_CORE_BRIDGE", "1")
         .current_dir(&project_dir)
         .output()
         .expect("winsmux command should run");
 
     assert!(!output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let receipt: serde_json::Value = serde_json::from_str(stdout.trim()).expect("typed refusal");
+    assert_eq!(receipt["status"], "rejected");
+    assert_eq!(
+        receipt["reason_code"],
+        "review_pending_acknowledgement_missing"
+    );
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
         stderr.contains("review-request was not recorded after 0 attempts"),
@@ -5460,6 +5468,7 @@ fn operator_cli_dispatch_review_rejects_non_operator_role() {
         .env("WINSMUX_PANE_ID", "%2")
         .env("WINSMUX_ROLE", "Worker")
         .env("WINSMUX_ROLE_MAP", r#"{"%2":"Worker"}"#)
+        .env("WINSMUX_DISABLE_CORE_BRIDGE", "1")
         .current_dir(&project_dir)
         .output()
         .expect("winsmux command should run");

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -9950,6 +9950,7 @@ function Invoke-WorkersApiLlmExec {
         $runId = New-WorkersRunId -SlotId ([string]$Worker.Row.SlotId)
     }
     if ($null -ne $submissionPacket -and (
+        [string]$submissionPacket.submission_id -cne $runId -or
         [string]$submissionPacket.task_id -cne $taskId -or
         [string]$submissionPacket.run_id -cne $runId
     )) {
@@ -10005,7 +10006,7 @@ function Invoke-WorkersApiLlmExec {
         } else {
             try {
                 if ($null -ne $submissionPacket) {
-                    $startedRecord = New-WinsmuxSubmissionRunRecord -SubmissionId ([string]$submissionPacket.submission_id) -RunId $runId -Kind ([string]$submissionPacket.kind) -TaskTitle ([string]$submissionPacket.title) -SlotId ([string]$Worker.Row.SlotId) -Backend api_llm -Status started -RequestConsumed -RequestDigest ([string]$submissionPacket.request_digest)
+                    $startedRecord = New-WinsmuxSubmissionRunRecord -SubmissionId ([string]$submissionPacket.submission_id) -RunId $runId -TaskId $taskId -Kind ([string]$submissionPacket.kind) -TaskTitle ([string]$submissionPacket.title) -SlotId ([string]$Worker.Row.SlotId) -Backend api_llm -Status started -RequestConsumed -RequestDigest ([string]$submissionPacket.request_digest)
                     Write-WorkersJsonArtifact -Path $runJsonPath -Data $startedRecord | Out-Null
                 }
                 $network = 'started'
@@ -10313,8 +10314,9 @@ function Invoke-WorkersAntigravityExec {
         $runId = New-WorkersRunId -SlotId ([string]$Worker.Row.SlotId)
     }
     if ($null -ne $submissionPacket -and (
-        [string]$submissionPacket.submission_id -cne [string]$Options.TaskId -or
-        [string]$submissionPacket.run_id -cne $runId
+        [string]$submissionPacket.submission_id -cne $runId -or
+        [string]$submissionPacket.run_id -cne $runId -or
+        [string]$submissionPacket.task_id -cne [string]$Options.TaskId
     )) {
         Stop-WithError 'antigravity submission packet id does not match task-id or run-id'
     }
@@ -10358,7 +10360,7 @@ function Invoke-WorkersAntigravityExec {
             try {
                 $process = 'started'
                 if ($null -ne $submissionPacket) {
-                    $startedRecord = New-WinsmuxSubmissionRunRecord -SubmissionId ([string]$submissionPacket.submission_id) -RunId $runId -Kind ([string]$submissionPacket.kind) -TaskTitle ([string]$submissionPacket.title) -SlotId ([string]$Worker.Row.SlotId) -Backend antigravity -Status started -RequestConsumed -RequestDigest ([string]$submissionPacket.request_digest)
+                    $startedRecord = New-WinsmuxSubmissionRunRecord -SubmissionId ([string]$submissionPacket.submission_id) -RunId $runId -TaskId ([string]$Options.TaskId) -Kind ([string]$submissionPacket.kind) -TaskTitle ([string]$submissionPacket.title) -SlotId ([string]$Worker.Row.SlotId) -Backend antigravity -Status started -RequestConsumed -RequestDigest ([string]$submissionPacket.request_digest)
                     Write-WorkersJsonArtifact -Path $runJsonPath -Data $startedRecord | Out-Null
                 }
                 $cli = Invoke-WorkersAntigravityCli -Arguments $arguments -WorkingDirectory ([string]$Options.ProjectDir)
@@ -10580,8 +10582,19 @@ function Invoke-WorkersExec {
         Stop-WithError 'colab_cli workers exec requires --script'
     }
     $scriptInfo = Resolve-WorkersProjectPath -ProjectDir $options.ProjectDir -Path $options.ScriptPath -MustExist -AllowFile -MaxBytes (Get-WorkersUploadMaxBytes)
+    $taskJsonInfo = $null
+    $submissionPacket = $null
+    $taskJsonContent = ''
+    if (-not [string]::IsNullOrWhiteSpace([string]$options.TaskJsonPath)) {
+        $taskJsonInfo = Resolve-WorkersProjectPath -ProjectDir $options.ProjectDir -Path ([string]$options.TaskJsonPath) -MustExist -AllowFile -AllowSubmissionPacket -MaxBytes (Get-WorkersUploadMaxBytes)
+        $taskJsonContent = Get-Content -LiteralPath ([string]$taskJsonInfo.FullPath) -Raw -Encoding UTF8
+        $submissionPacket = Read-WinsmuxSubmissionPacketIfPresent -Path ([string]$taskJsonInfo.FullPath)
+    }
     $safetyInput = [System.Collections.Generic.List[string]]::new()
-    foreach ($value in @(Get-WorkersExecSafetyInputValues -ProjectDir $options.ProjectDir -ScriptArgs @($options.ScriptArgs) -TaskJsonPath ([string]$options.TaskJsonPath))) {
+    if (-not [string]::IsNullOrWhiteSpace([string]$taskJsonContent)) {
+        $safetyInput.Add([string]$taskJsonContent) | Out-Null
+    }
+    foreach ($value in @(Get-WorkersExecSafetyInputValues -ProjectDir $options.ProjectDir -ScriptArgs @($options.ScriptArgs))) {
         $safetyInput.Add([string]$value) | Out-Null
     }
     if (-not [string]::IsNullOrWhiteSpace([string]$env:WINSMUX_TASK_JSON)) {
@@ -10604,13 +10617,11 @@ function Invoke-WorkersExec {
     if (-not [string]::IsNullOrWhiteSpace([string]$options.TaskId)) {
         $arguments += @('--task-id', [string]$options.TaskId)
     }
-    $submissionPacket = $null
-    if (-not [string]::IsNullOrWhiteSpace([string]$options.TaskJsonPath)) {
-        $taskJsonInfo = Resolve-WorkersProjectPath -ProjectDir $options.ProjectDir -Path ([string]$options.TaskJsonPath) -MustExist -AllowFile -AllowSubmissionPacket -MaxBytes (Get-WorkersUploadMaxBytes)
-        $submissionPacket = Read-WinsmuxSubmissionPacketIfPresent -Path ([string]$taskJsonInfo.FullPath)
+    if ($null -ne $taskJsonInfo) {
         if ($null -ne $submissionPacket -and (
-            [string]$submissionPacket.submission_id -cne [string]$options.TaskId -or
-            [string]$submissionPacket.run_id -cne $runId
+            [string]$submissionPacket.submission_id -cne $runId -or
+            [string]$submissionPacket.run_id -cne $runId -or
+            [string]$submissionPacket.task_id -cne [string]$options.TaskId
         )) {
             Stop-WithError 'colab_cli submission packet id does not match task-id or run-id'
         }

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -6326,7 +6326,9 @@ function ConvertTo-WorkersSafeLogText {
     $safe = [regex]::Replace($safe, '(?i)(?<![A-Za-z0-9_])(["'']?(?:api[_-]?key|access[_-]?token|refresh[_-]?token|oauth[_-]?token|token|password|passwd|secret|credential|credentials)["'']?\s*[:=]\s*["'']?)[^\s"'',;}]+', '$1[REDACTED]')
     $safe = [regex]::Replace($safe, '(?i)(?<![A-Za-z0-9_])(["'']?(?:x-request-id|request[_-]?id|provider[_-]?response[_-]?id)["'']?\s*[:=]\s*["'']?)[^\s"'',;}]+', '$1[REDACTED]')
     $safe = [regex]::Replace($safe, '(?i)/content/drive/(?:MyDrive|Shareddrives)(?:/[^\s"'']*)?', '[DRIVE_PATH_REDACTED]')
+    $safe = [regex]::Replace($safe, '(?i)\\\\[^\\\s]+\\[^\s"'',;}\r\n]+(?:\\[^\s"'',;}\r\n]+)*', '[NETWORK_PATH_REDACTED]')
     $safe = [regex]::Replace($safe, '(?i)\b[A-Z]:\\[^"'',;}\r\n]+', '[LOCAL_PATH_REDACTED]')
+    $safe = [regex]::Replace($safe, '(?i)(?<![:A-Za-z0-9])/(?:home|users|tmp|var|opt|workspace|private)(?:/[^\s"'',;}\r\n]+)+', '[UNIX_PATH_REDACTED]')
     return $safe
 }
 
@@ -6548,6 +6550,7 @@ function Resolve-WorkersProjectPath {
         [switch]$AllowFile,
         [switch]$AllowDirectory,
         [switch]$AllowRuntimePath,
+        [switch]$AllowSubmissionPacket,
         [long]$MaxBytes = 0
     )
 
@@ -6573,6 +6576,9 @@ function Resolve-WorkersProjectPath {
     }
 
     $reason = Get-WorkersPathExclusionReason -RelativePath $relative
+    if ($AllowSubmissionPacket -and $reason -eq 'excluded_segment:.winsmux' -and $relative.Replace('\', '/') -match '^\.winsmux/submissions/[A-Za-z0-9][A-Za-z0-9_.-]{0,127}\.json$') {
+        $reason = ''
+    }
     if ($AllowRuntimePath -and $reason -eq 'excluded_segment:.winsmux') {
         $reason = ''
     }
@@ -9898,10 +9904,20 @@ function Invoke-WorkersApiLlmExec {
         Stop-WithError 'api_llm workers exec requires --task-json or --script'
     }
 
-    $inputInfo = Resolve-WorkersProjectPath -ProjectDir $Options.ProjectDir -Path $inputPath -MustExist -AllowFile -MaxBytes (Get-WorkersUploadMaxBytes)
+    $inputInfo = Resolve-WorkersProjectPath -ProjectDir $Options.ProjectDir -Path $inputPath -MustExist -AllowFile -AllowSubmissionPacket:($inputKind -eq 'task_json') -MaxBytes (Get-WorkersUploadMaxBytes)
     $inputContent = Get-Content -LiteralPath ([string]$inputInfo.FullPath) -Raw -Encoding UTF8
     if ($null -eq $inputContent) {
         $inputContent = ''
+    }
+    $submissionPacket = $null
+    if ($inputKind -eq 'task_json') {
+        $submissionPacket = Read-WinsmuxSubmissionPacketIfPresent -Path ([string]$inputInfo.FullPath)
+    }
+    $taskId = [string]$Options.TaskId
+    $requestedRunId = [string]$Options.RunId
+    if ($null -ne $submissionPacket) {
+        if ([string]::IsNullOrWhiteSpace($taskId)) { $taskId = [string]$submissionPacket.task_id }
+        if ([string]::IsNullOrWhiteSpace($requestedRunId)) { $requestedRunId = [string]$submissionPacket.run_id }
     }
 
     $safetyInput = [System.Collections.Generic.List[string]]::new()
@@ -9914,19 +9930,26 @@ function Invoke-WorkersApiLlmExec {
     if (-not [string]::IsNullOrWhiteSpace([string]$env:WINSMUX_TASK_JSON)) {
         $safetyInput.Add([string]$env:WINSMUX_TASK_JSON) | Out-Null
     }
-    if (-not [string]::IsNullOrWhiteSpace([string]$Options.TaskId)) {
-        $safetyInput.Add([string]$Options.TaskId) | Out-Null
+    if (-not [string]::IsNullOrWhiteSpace($taskId)) {
+        $safetyInput.Add($taskId) | Out-Null
     }
     Assert-WorkersApiLlmSafetyInput -Values @($safetyInput)
 
-    $runId = Assert-WorkersRunId -RunId ([string]$Options.RunId)
+    $runId = Assert-WorkersRunId -RunId $requestedRunId
     if ([string]::IsNullOrWhiteSpace($runId)) {
         $runId = New-WorkersRunId -SlotId ([string]$Worker.Row.SlotId)
+    }
+    if ($null -ne $submissionPacket -and (
+        [string]$submissionPacket.task_id -cne $taskId -or
+        [string]$submissionPacket.run_id -cne $runId
+    )) {
+        Stop-WithError 'api_llm submission packet id does not match task-id or run-id'
     }
     $runDir = Get-WorkersRunDirectory -ProjectDir $Options.ProjectDir -SlotId ([string]$Worker.Row.SlotId) -RunId $runId
     if (-not (Test-Path -LiteralPath $runDir -PathType Container)) {
         New-Item -ItemType Directory -Path $runDir -Force | Out-Null
     }
+    $runJsonPath = Join-Path $runDir 'run.json'
 
     $metadata = New-WorkersApiLlmMetadata -Worker $Worker
     $logPath = Join-Path $runDir 'stdout.log'
@@ -9971,6 +9994,10 @@ function Invoke-WorkersApiLlmExec {
             $reason = 'api_llm_api_key_env_missing'
         } else {
             try {
+                if ($null -ne $submissionPacket) {
+                    $startedRecord = New-WinsmuxSubmissionRunRecord -SubmissionId ([string]$submissionPacket.submission_id) -RunId $runId -Kind ([string]$submissionPacket.kind) -TaskTitle ([string]$submissionPacket.title) -SlotId ([string]$Worker.Row.SlotId) -Backend api_llm -Status started -RequestConsumed
+                    Write-WorkersJsonArtifact -Path $runJsonPath -Data $startedRecord | Out-Null
+                }
                 $network = 'started'
                 $completion = Invoke-WorkersOpenAiCompatibleChatCompletion -RuntimeConfig $runtime -Metadata $metadata -InputKind $inputKind -InputContent ([string]$inputContent) -ApiKey ([string]$credential.ApiKey)
                 $network = 'completed'
@@ -10025,6 +10052,14 @@ function Invoke-WorkersApiLlmExec {
     Write-ClmSafeTextFile -Path $logPath -Content (ConvertTo-WorkersSafeLogText -Text ($logLines -join [Environment]::NewLine))
 
     $payload = [ordered]@{
+        protocol_version = if ($null -ne $submissionPacket) { 1 } else { 0 }
+        type           = if ($null -ne $submissionPacket) { 'backend_run_record' } else { '' }
+        submission_id  = if ($null -ne $submissionPacket) { [string]$submissionPacket.submission_id } else { '' }
+        kind           = if ($null -ne $submissionPacket) { [string]$submissionPacket.kind } else { '' }
+        task_title     = if ($null -ne $submissionPacket) { [string]$submissionPacket.title } else { '' }
+        worker_kind    = if ($null -ne $submissionPacket -and [string]$submissionPacket.kind -eq 'review') { 'critic' } elseif ($null -ne $submissionPacket) { 'implementation' } else { '' }
+        backend_owned  = $true
+        request_consumed = ($null -ne $submissionPacket)
         project_dir    = $Options.ProjectDir
         generated_at   = (Get-Date).ToUniversalTime().ToString('o')
         command        = 'workers.exec'
@@ -10034,7 +10069,7 @@ function Invoke-WorkersApiLlmExec {
         slot           = [string]$Worker.Row.Slot
         slot_id        = [string]$Worker.Row.SlotId
         run_id         = $runId
-        task_id        = [string]$Options.TaskId
+        task_id        = $taskId
         input          = [string]$inputInfo.RelativePath
         input_kind     = $inputKind
         script         = if ($inputKind -eq 'script') { [string]$inputInfo.RelativePath } else { '' }
@@ -10057,7 +10092,6 @@ function Invoke-WorkersApiLlmExec {
     if (-not [string]::IsNullOrWhiteSpace($responseReference)) {
         $payload.locations['response'] = New-WinsmuxLocationIdentity -Kind 'local_file' -DisplayName 'response.txt' -Backend 'local-windows' -AccessMethod 'artifact_ref' -Reference $responseReference -Provenance 'workers.exec.response'
     }
-    $runJsonPath = Join-Path $runDir 'run.json'
     $payload['run_json'] = Get-WorkersArtifactReference -ProjectDir $Options.ProjectDir -Path $runJsonPath
     Write-WorkersJsonArtifact -Path $runJsonPath -Data $payload | Out-Null
     if ($null -ne $Worker.Entry) {
@@ -10238,10 +10272,14 @@ function Invoke-WorkersAntigravityExec {
         Stop-WithError 'antigravity workers exec requires --task-json or --script'
     }
 
-    $inputInfo = Resolve-WorkersProjectPath -ProjectDir $Options.ProjectDir -Path $inputPath -MustExist -AllowFile -MaxBytes (Get-WorkersUploadMaxBytes)
+    $inputInfo = Resolve-WorkersProjectPath -ProjectDir $Options.ProjectDir -Path $inputPath -MustExist -AllowFile -AllowSubmissionPacket:($inputKind -eq 'task_json') -MaxBytes (Get-WorkersUploadMaxBytes)
     $inputContent = Get-Content -LiteralPath ([string]$inputInfo.FullPath) -Raw -Encoding UTF8
     if ($null -eq $inputContent) {
         $inputContent = ''
+    }
+    $submissionPacket = $null
+    if ($inputKind -eq 'task_json') {
+        $submissionPacket = Read-WinsmuxSubmissionPacketIfPresent -Path ([string]$inputInfo.FullPath)
     }
 
     $safetyInput = [System.Collections.Generic.List[string]]::new()
@@ -10263,10 +10301,17 @@ function Invoke-WorkersAntigravityExec {
     if ([string]::IsNullOrWhiteSpace($runId)) {
         $runId = New-WorkersRunId -SlotId ([string]$Worker.Row.SlotId)
     }
+    if ($null -ne $submissionPacket -and (
+        [string]$submissionPacket.submission_id -cne [string]$Options.TaskId -or
+        [string]$submissionPacket.run_id -cne $runId
+    )) {
+        Stop-WithError 'antigravity submission packet id does not match task-id or run-id'
+    }
     $runDir = Get-WorkersRunDirectory -ProjectDir $Options.ProjectDir -SlotId ([string]$Worker.Row.SlotId) -RunId $runId
     if (-not (Test-Path -LiteralPath $runDir -PathType Container)) {
         New-Item -ItemType Directory -Path $runDir -Force | Out-Null
     }
+    $runJsonPath = Join-Path $runDir 'run.json'
 
     $metadata = New-WorkersAntigravityMetadata -Worker $Worker
     $logPath = Join-Path $runDir 'stdout.log'
@@ -10301,6 +10346,10 @@ function Invoke-WorkersAntigravityExec {
             $arguments += @($Options.ScriptArgs)
             try {
                 $process = 'started'
+                if ($null -ne $submissionPacket) {
+                    $startedRecord = New-WinsmuxSubmissionRunRecord -SubmissionId ([string]$submissionPacket.submission_id) -RunId $runId -Kind ([string]$submissionPacket.kind) -TaskTitle ([string]$submissionPacket.title) -SlotId ([string]$Worker.Row.SlotId) -Backend antigravity -Status started -RequestConsumed
+                    Write-WorkersJsonArtifact -Path $runJsonPath -Data $startedRecord | Out-Null
+                }
                 $cli = Invoke-WorkersAntigravityCli -Arguments $arguments -WorkingDirectory ([string]$Options.ProjectDir)
                 $cliCommand = ConvertTo-WorkersSafeLogText -Text ([string]$cli.Command)
                 $recordedArguments = @(ConvertTo-WorkersAntigravityRecordedArguments -Arguments @($cli.Arguments))
@@ -10348,6 +10397,14 @@ function Invoke-WorkersAntigravityExec {
     Write-ClmSafeTextFile -Path $logPath -Content (ConvertTo-WorkersSafeLogText -Text ($logLines -join [Environment]::NewLine))
 
     $payload = [ordered]@{
+        protocol_version = if ($null -ne $submissionPacket) { 1 } else { 0 }
+        type           = if ($null -ne $submissionPacket) { 'backend_run_record' } else { '' }
+        submission_id  = if ($null -ne $submissionPacket) { [string]$submissionPacket.submission_id } else { '' }
+        kind           = if ($null -ne $submissionPacket) { [string]$submissionPacket.kind } else { '' }
+        task_title     = if ($null -ne $submissionPacket) { [string]$submissionPacket.title } else { '' }
+        worker_kind    = if ($null -ne $submissionPacket -and [string]$submissionPacket.kind -eq 'review') { 'critic' } elseif ($null -ne $submissionPacket) { 'implementation' } else { '' }
+        backend_owned  = $true
+        request_consumed = ($null -ne $submissionPacket)
         project_dir    = $Options.ProjectDir
         generated_at   = (Get-Date).ToUniversalTime().ToString('o')
         command        = 'workers.exec'
@@ -10379,7 +10436,6 @@ function Invoke-WorkersAntigravityExec {
     if (-not [string]::IsNullOrWhiteSpace($responseReference)) {
         $payload.locations['response'] = New-WinsmuxLocationIdentity -Kind 'local_file' -DisplayName 'response.txt' -Backend 'local-windows' -AccessMethod 'artifact_ref' -Reference $responseReference -Provenance 'workers.exec.response'
     }
-    $runJsonPath = Join-Path $runDir 'run.json'
     $payload['run_json'] = Get-WorkersArtifactReference -ProjectDir $Options.ProjectDir -Path $runJsonPath
     Write-WorkersJsonArtifact -Path $runJsonPath -Data $payload | Out-Null
     if ($null -ne $Worker.Entry) {
@@ -10472,6 +10528,28 @@ function Invoke-WorkersAntigravityLogs {
     Write-WorkersOperationOutput -Payload $payload -Json:([bool]$Options.Json) -Text $content
 }
 
+function Test-WorkersColabSubmissionResult {
+    param(
+        [Parameter(Mandatory = $true)][string]$Output,
+        [Parameter(Mandatory = $true)]$Packet,
+        [Parameter(Mandatory = $true)][string]$RunId
+    )
+
+    $candidate = $null
+    foreach ($line in @($Output -split "`r?`n" | Where-Object { $_.TrimStart().StartsWith('{') } | Select-Object -Last 1)) {
+        try { $candidate = $line | ConvertFrom-Json -Depth 16 } catch { $candidate = $null }
+    }
+    if ($null -eq $candidate) { return $false }
+    $expectedWorkerKind = if ([string]$Packet.kind -eq 'review') { 'critic' } else { 'implementation' }
+    return (
+        [string]$candidate.status -ceq 'succeeded' -and
+        [string]$candidate.worker_kind -ceq $expectedWorkerKind -and
+        [string]$candidate.run_id -ceq $RunId -and
+        [string]$candidate.task.id -ceq [string]$Packet.task_id -and
+        [string]$candidate.task.title -ceq [string]$Packet.title
+    )
+}
+
 function Invoke-WorkersExec {
     $usage = "usage: winsmux workers exec <slot> --script <path> [--task-json <path>] [--task-id <id>] [--run-id <id>] [--json] [--project-dir <path>]; api_llm and antigravity accept exactly one input: --script or --task-json"
     $options = Read-WorkersExecOptions -Usage $usage
@@ -10513,8 +10591,16 @@ function Invoke-WorkersExec {
     if (-not [string]::IsNullOrWhiteSpace([string]$options.TaskId)) {
         $arguments += @('--task-id', [string]$options.TaskId)
     }
+    $submissionPacket = $null
     if (-not [string]::IsNullOrWhiteSpace([string]$options.TaskJsonPath)) {
-        $taskJsonInfo = Resolve-WorkersProjectPath -ProjectDir $options.ProjectDir -Path ([string]$options.TaskJsonPath) -MustExist -AllowFile -MaxBytes (Get-WorkersUploadMaxBytes)
+        $taskJsonInfo = Resolve-WorkersProjectPath -ProjectDir $options.ProjectDir -Path ([string]$options.TaskJsonPath) -MustExist -AllowFile -AllowSubmissionPacket -MaxBytes (Get-WorkersUploadMaxBytes)
+        $submissionPacket = Read-WinsmuxSubmissionPacketIfPresent -Path ([string]$taskJsonInfo.FullPath)
+        if ($null -ne $submissionPacket -and (
+            [string]$submissionPacket.submission_id -cne [string]$options.TaskId -or
+            [string]$submissionPacket.run_id -cne $runId
+        )) {
+            Stop-WithError 'colab_cli submission packet id does not match task-id or run-id'
+        }
         $arguments += @('--task-json', [string]$taskJsonInfo.FullPath)
     }
     $arguments += @($options.ScriptArgs)
@@ -10523,12 +10609,27 @@ function Invoke-WorkersExec {
     $logPath = Join-Path $runDir 'stdout.log'
     Write-ClmSafeTextFile -Path $logPath -Content $safeCliOutput
     $status = if ([int]$cli.ExitCode -eq 0) { 'succeeded' } else { 'failed' }
+    $reason = ''
+    if ($null -ne $submissionPacket -and $status -eq 'succeeded' -and -not (Test-WorkersColabSubmissionResult -Output ([string]$cli.Output) -Packet $submissionPacket -RunId $runId)) {
+        $status = 'failed'
+        $reason = 'colab_worker_evidence_invalid'
+    }
 
     $payload = [ordered]@{
+        protocol_version = if ($null -ne $submissionPacket) { 1 } else { 0 }
+        type           = if ($null -ne $submissionPacket) { 'backend_run_record' } else { '' }
+        submission_id  = if ($null -ne $submissionPacket) { [string]$submissionPacket.submission_id } else { '' }
+        kind           = if ($null -ne $submissionPacket) { [string]$submissionPacket.kind } else { '' }
+        task_title     = if ($null -ne $submissionPacket) { [string]$submissionPacket.title } else { '' }
+        worker_kind    = if ($null -ne $submissionPacket -and [string]$submissionPacket.kind -eq 'review') { 'critic' } elseif ($null -ne $submissionPacket) { 'implementation' } else { '' }
+        backend        = 'colab_cli'
+        backend_owned  = $true
+        request_consumed = ($null -ne $submissionPacket -and $status -eq 'succeeded')
         project_dir    = $options.ProjectDir
         generated_at   = (Get-Date).ToUniversalTime().ToString('o')
         command        = 'workers.exec'
         status         = $status
+        reason         = $reason
         slot           = [string]$worker.Row.Slot
         slot_id        = [string]$worker.Row.SlotId
         session        = [string]$worker.Session
@@ -16662,70 +16763,36 @@ function Invoke-DispatchReview {
     Assert-WinsmuxRolePermission -CommandName 'dispatch-review'
 
     $projectDir = (Get-Location).Path
-    $branch = Get-CurrentGitBranch -ProjectDir $projectDir
-    $headSha = Get-CurrentGitHead -ProjectDir $projectDir
     $submissionId = 'submission-' + [guid]::NewGuid().ToString('N')
 
-    $reviewPaneEntry = Get-PreferredReviewPaneEntry -ProjectDir $projectDir
+    try {
+        $reviewPaneEntry = Get-PreferredReviewPaneEntry -ProjectDir $projectDir
+    } catch {
+        $receipt = New-WinsmuxSubmissionReceipt -Kind review -Status unavailable -Backend noop -SubmissionId $submissionId -ReasonCode 'review_target_unavailable'
+        ConvertTo-WinsmuxSubmissionReceiptJson -Receipt $receipt | Write-Output
+        exit 1
+    }
     if ($null -eq $reviewPaneEntry) {
         $receipt = New-WinsmuxSubmissionReceipt -Kind review -Status unavailable -Backend noop -SubmissionId $submissionId -ReasonCode 'review_target_unavailable' -Diagnostic 'No review-capable pane was found in the manifest.'
         ConvertTo-WinsmuxSubmissionReceiptJson -Receipt $receipt | Write-Output
         exit 1
     }
 
-    $reviewPaneId = [string]$reviewPaneEntry.PaneId
-    $reviewLabel = [string]$reviewPaneEntry.Label
-    $reviewRole = [string]$reviewPaneEntry.Role
-    $reviewBackend = [string](Get-WinsmuxSubmissionValue -InputObject $reviewPaneEntry -Name 'WorkerBackend' -Default 'local')
-    $reviewBackend = $reviewBackend.Trim().ToLowerInvariant()
+    $branch = Get-CurrentGitBranch -ProjectDir $projectDir
+    $headSha = Get-CurrentGitHead -ProjectDir $projectDir
 
-    if ($reviewBackend -notin @('local', 'codex')) {
-        $reviewPacket = [ordered]@{
-            branch   = $branch
-            head_sha = $headSha
-            request  = 'Review the synthetic or repository change described by this packet. Do not issue PASS or commit authority.'
-        } | ConvertTo-Json -Depth 4 -Compress
-        $receipt = Invoke-WinsmuxSubmissionAdapter -ProjectDir $projectDir -ManifestEntry $reviewPaneEntry -Kind review -Content $reviewPacket -SubmissionId $submissionId
-        ConvertTo-WinsmuxSubmissionReceiptJson -Receipt $receipt | Write-Output
-        if ($receipt.status -ne 'accepted') {
-            exit 1
-        }
-        return
+    $reviewPacket = [ordered]@{
+        title      = "Review branch $branch"
+        request    = 'Review the bounded change described by this packet. Do not issue PASS or commit authority.'
+        files      = @()
+        tests      = @()
+        constraints = @('Review acceptance is not review approval authority.')
+        branch     = $branch
+        head_sha   = $headSha
     }
-
-    try {
-        Send-TextToPane -PaneId $reviewPaneId -CommandText "winsmux review-request"
-    } catch {
-        $receipt = New-WinsmuxSubmissionReceipt -Kind review -Status unavailable -Backend $reviewBackend -SubmissionId $submissionId -ReasonCode 'pane_send_failed' -Diagnostic $_.Exception.Message -Target ([ordered]@{ label = $reviewLabel; pane_id = $reviewPaneId; role = $reviewRole })
-        ConvertTo-WinsmuxSubmissionReceiptJson -Receipt $receipt | Write-Output
-        exit 1
-    }
-
-    # Poll for PENDING state (up to 30 seconds)
-    $maxAttempts = 10
-    $pending = $false
-    for ($i = 0; $i -lt $maxAttempts; $i++) {
-        Start-Sleep -Seconds 3
-        $state = Get-ReviewState -ProjectDir $projectDir
-        if ($state.Contains($branch)) {
-            $stateEntry = ConvertTo-ReviewStateValue -Value $state[$branch]
-            $status = [string](Get-ReviewStatePropertyValue -InputObject $stateEntry -Name 'status')
-            $pendingHead = [string](Get-ReviewStatePropertyValue -InputObject $stateEntry -Name 'head_sha')
-            if ($status -eq 'PENDING' -and $pendingHead -eq $headSha) {
-                $pending = $true
-                break
-            }
-        }
-    }
-
-    if (-not $pending) {
-        $receipt = New-WinsmuxSubmissionReceipt -Kind review -Status rejected -Backend $reviewBackend -SubmissionId $submissionId -ReasonCode 'review_pending_acknowledgement_missing' -Diagnostic "review-request was not recorded for the current head after ${maxAttempts} attempts." -Target ([ordered]@{ label = $reviewLabel; pane_id = $reviewPaneId; role = $reviewRole })
-        ConvertTo-WinsmuxSubmissionReceiptJson -Receipt $receipt | Write-Output
-        exit 1
-    }
-
-    $receipt = New-WinsmuxSubmissionReceipt -Kind review -Status accepted -Backend $reviewBackend -SubmissionId $submissionId -Target ([ordered]@{ label = $reviewLabel; pane_id = $reviewPaneId; role = $reviewRole }) -Acknowledgement ([ordered]@{ type = 'review_pending_state'; branch = $branch; head_sha = $headSha })
+    $receipt = Invoke-WinsmuxSubmissionAdapter -ProjectDir $projectDir -ManifestEntry $reviewPaneEntry -Kind review -Content $reviewPacket -SubmissionId $submissionId
     ConvertTo-WinsmuxSubmissionReceiptJson -Receipt $receipt | Write-Output
+    if ($receipt.status -ne 'accepted') { exit 1 }
 }
 
 function Invoke-ReviewRequest {
@@ -17870,6 +17937,7 @@ switch ($Command) {
     'kill'            { Invoke-Kill }
     'restart'         { Invoke-Restart }
     'dispatch-review' { Invoke-DispatchReview }
+    'submission-ack'  { Invoke-WinsmuxSubmissionAckCommand -CommandTarget $Target -CommandRest $Rest }
     'review-request'  { Invoke-ReviewRequest }
     'review-approve'  { Invoke-ReviewApprove }
     'review-fail'     { Invoke-ReviewFail }

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -6326,10 +6326,20 @@ function ConvertTo-WorkersSafeLogText {
     $safe = [regex]::Replace($safe, '(?i)(?<![A-Za-z0-9_])(["'']?(?:api[_-]?key|access[_-]?token|refresh[_-]?token|oauth[_-]?token|token|password|passwd|secret|credential|credentials)["'']?\s*[:=]\s*["'']?)[^\s"'',;}]+', '$1[REDACTED]')
     $safe = [regex]::Replace($safe, '(?i)(?<![A-Za-z0-9_])(["'']?(?:x-request-id|request[_-]?id|provider[_-]?response[_-]?id)["'']?\s*[:=]\s*["'']?)[^\s"'',;}]+', '$1[REDACTED]')
     $safe = [regex]::Replace($safe, '(?i)/content/drive/(?:MyDrive|Shareddrives)(?:/[^\s"'']*)?', '[DRIVE_PATH_REDACTED]')
-    $safe = [regex]::Replace($safe, '(?i)\\\\[^\\\s]+\\[^\s"'',;}\r\n]+(?:\\[^\s"'',;}\r\n]+)*', '[NETWORK_PATH_REDACTED]')
-    $safe = [regex]::Replace($safe, '(?i)\b[A-Z]:\\[^"'',;}\r\n]+', '[LOCAL_PATH_REDACTED]')
-    $safe = [regex]::Replace($safe, '(?i)(?<![:A-Za-z0-9])/(?:home|users|tmp|var|opt|workspace|private)(?:/[^\s"'',;}\r\n]+)+', '[UNIX_PATH_REDACTED]')
+    $pathBoundary = '(?=\s+(?=(?:[A-Z]:\\|\\\\|/[A-Za-z0-9._~-]+/|[A-Za-z][A-Za-z0-9+.-]*://))|[,;}\r\n]|$)'
+    $safe = [regex]::Replace($safe, '(?i)\\\\[^\\\s]+\\[^"'',;}\r\n]*?' + $pathBoundary, '[NETWORK_PATH_REDACTED]')
+    $safe = [regex]::Replace($safe, '(?i)\b[A-Z]:\\[^"'',;}\r\n]*?' + $pathBoundary, '[LOCAL_PATH_REDACTED]')
+    $safe = [regex]::Replace($safe, '(?i)(?<![:/A-Za-z0-9])/(?!/)[A-Za-z0-9._~-]+(?:/[^\s"'',;}\r\n]+)+', '[UNIX_PATH_REDACTED]')
     return $safe
+}
+
+function ConvertTo-WorkersSafeRemotePath {
+    param([Parameter(Mandatory = $true)][string]$RemotePath)
+
+    if ($RemotePath -match '(?i)^/content/(?!drive(?:/|$))') {
+        return $RemotePath
+    }
+    return ConvertTo-WorkersSafeLogText -Text $RemotePath
 }
 
 function ConvertTo-WorkersSafeArgumentArray {
@@ -9995,7 +10005,7 @@ function Invoke-WorkersApiLlmExec {
         } else {
             try {
                 if ($null -ne $submissionPacket) {
-                    $startedRecord = New-WinsmuxSubmissionRunRecord -SubmissionId ([string]$submissionPacket.submission_id) -RunId $runId -Kind ([string]$submissionPacket.kind) -TaskTitle ([string]$submissionPacket.title) -SlotId ([string]$Worker.Row.SlotId) -Backend api_llm -Status started -RequestConsumed
+                    $startedRecord = New-WinsmuxSubmissionRunRecord -SubmissionId ([string]$submissionPacket.submission_id) -RunId $runId -Kind ([string]$submissionPacket.kind) -TaskTitle ([string]$submissionPacket.title) -SlotId ([string]$Worker.Row.SlotId) -Backend api_llm -Status started -RequestConsumed -RequestDigest ([string]$submissionPacket.request_digest)
                     Write-WorkersJsonArtifact -Path $runJsonPath -Data $startedRecord | Out-Null
                 }
                 $network = 'started'
@@ -10060,6 +10070,7 @@ function Invoke-WorkersApiLlmExec {
         worker_kind    = if ($null -ne $submissionPacket -and [string]$submissionPacket.kind -eq 'review') { 'critic' } elseif ($null -ne $submissionPacket) { 'implementation' } else { '' }
         backend_owned  = $true
         request_consumed = ($null -ne $submissionPacket)
+        request_digest = if ($null -ne $submissionPacket) { [string]$submissionPacket.request_digest } else { '' }
         project_dir    = $Options.ProjectDir
         generated_at   = (Get-Date).ToUniversalTime().ToString('o')
         command        = 'workers.exec'
@@ -10347,7 +10358,7 @@ function Invoke-WorkersAntigravityExec {
             try {
                 $process = 'started'
                 if ($null -ne $submissionPacket) {
-                    $startedRecord = New-WinsmuxSubmissionRunRecord -SubmissionId ([string]$submissionPacket.submission_id) -RunId $runId -Kind ([string]$submissionPacket.kind) -TaskTitle ([string]$submissionPacket.title) -SlotId ([string]$Worker.Row.SlotId) -Backend antigravity -Status started -RequestConsumed
+                    $startedRecord = New-WinsmuxSubmissionRunRecord -SubmissionId ([string]$submissionPacket.submission_id) -RunId $runId -Kind ([string]$submissionPacket.kind) -TaskTitle ([string]$submissionPacket.title) -SlotId ([string]$Worker.Row.SlotId) -Backend antigravity -Status started -RequestConsumed -RequestDigest ([string]$submissionPacket.request_digest)
                     Write-WorkersJsonArtifact -Path $runJsonPath -Data $startedRecord | Out-Null
                 }
                 $cli = Invoke-WorkersAntigravityCli -Arguments $arguments -WorkingDirectory ([string]$Options.ProjectDir)
@@ -10405,6 +10416,7 @@ function Invoke-WorkersAntigravityExec {
         worker_kind    = if ($null -ne $submissionPacket -and [string]$submissionPacket.kind -eq 'review') { 'critic' } elseif ($null -ne $submissionPacket) { 'implementation' } else { '' }
         backend_owned  = $true
         request_consumed = ($null -ne $submissionPacket)
+        request_digest = if ($null -ne $submissionPacket) { [string]$submissionPacket.request_digest } else { '' }
         project_dir    = $Options.ProjectDir
         generated_at   = (Get-Date).ToUniversalTime().ToString('o')
         command        = 'workers.exec'
@@ -10546,7 +10558,8 @@ function Test-WorkersColabSubmissionResult {
         [string]$candidate.worker_kind -ceq $expectedWorkerKind -and
         [string]$candidate.run_id -ceq $RunId -and
         [string]$candidate.task.id -ceq [string]$Packet.task_id -and
-        [string]$candidate.task.title -ceq [string]$Packet.title
+        [string]$candidate.task.title -ceq [string]$Packet.title -and
+        [string]$candidate.request_digest -ceq [string]$Packet.request_digest
     )
 }
 
@@ -10625,6 +10638,7 @@ function Invoke-WorkersExec {
         backend        = 'colab_cli'
         backend_owned  = $true
         request_consumed = ($null -ne $submissionPacket -and $status -eq 'succeeded')
+        request_digest = if ($null -ne $submissionPacket -and $status -eq 'succeeded') { [string]$submissionPacket.request_digest } else { '' }
         project_dir    = $options.ProjectDir
         generated_at   = (Get-Date).ToUniversalTime().ToString('o')
         command        = 'workers.exec'
@@ -10795,7 +10809,7 @@ function Invoke-WorkersUpload {
         run_id       = $runId
         slot_id      = [string]$worker.Row.SlotId
         source       = [string]$source.RelativePath
-        remote       = ConvertTo-WorkersSafeLogText -Text $remote
+        remote       = ConvertTo-WorkersSafeRemotePath -RemotePath $remote
         max_bytes    = [long]$options.MaxBytes
         files        = @($manifestEntries.Files)
         excluded     = @($manifestEntries.Excluded)
@@ -10811,7 +10825,7 @@ function Invoke-WorkersUpload {
     $stagedSourceLocationKind = if ([bool]$uploadSource.Staged) { 'local_directory' } else { $sourceLocationKind }
     $stagedSourceAccessMethod = if ([bool]$uploadSource.Staged) { 'runtime_staging' } else { 'project_path' }
     $stagedSourceProvenance = if ([bool]$uploadSource.Staged) { 'workers.upload.staged_source' } else { 'workers.upload.source' }
-    $safeRemote = ConvertTo-WorkersSafeLogText -Text $remote
+    $safeRemote = ConvertTo-WorkersSafeRemotePath -RemotePath $remote
     $manifestReference = Get-WorkersArtifactReference -ProjectDir $options.ProjectDir -Path $manifestPath
     $arguments = @('upload', '--session', [string]$worker.Session, '--source', [string]$uploadSource.FullPath, '--dest', $remote, '--manifest', $manifestPath, '--run-id', $runId)
     $cli = Invoke-WorkersColabCli -Arguments $arguments
@@ -10889,7 +10903,7 @@ function Invoke-WorkersDownload {
     $arguments = @('download', '--session', [string]$worker.Session, '--source', $remote, '--dest', [string]$outputInfo.FullPath, '--run-id', $runId)
     $cli = Invoke-WorkersColabCli -Arguments $arguments
     $status = if ([int]$cli.ExitCode -eq 0) { 'succeeded' } else { 'failed' }
-    $safeRemote = ConvertTo-WorkersSafeLogText -Text $remote
+    $safeRemote = ConvertTo-WorkersSafeRemotePath -RemotePath $remote
     $outputReference = Get-WorkersArtifactReference -ProjectDir $options.ProjectDir -Path ([string]$outputInfo.FullPath)
     $outputLocationKind = if ($downloadToDirectory) { 'local_directory' } else { 'local_file' }
     $payload = [ordered]@{

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -69,6 +69,7 @@ $PaneEnvScript = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\wins
 $PublicFirstRunScript = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\winsmux-core\scripts\public-first-run.ps1'))
 $ConflictPreflightScript = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\winsmux-core\scripts\conflict-preflight.ps1'))
 $ControlPlaneDispatchScript = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\winsmux-core\scripts\control-plane-dispatch.ps1'))
+$SubmissionContractScript = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\winsmux-core\scripts\submission-contract.ps1'))
 $ControlPlaneCommandsScript = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\winsmux-core\scripts\control-plane-commands.ps1'))
 $ControlPlaneWorkersScript = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\winsmux-core\scripts\control-plane-workers.ps1'))
 $ControlPlaneLedgerScript = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\winsmux-core\scripts\control-plane-ledger.ps1'))
@@ -116,6 +117,10 @@ if (Test-Path $PublicFirstRunScript -PathType Leaf) {
 
 if (Test-Path $ConflictPreflightScript -PathType Leaf) {
     . $ConflictPreflightScript
+}
+
+if (Test-Path $SubmissionContractScript -PathType Leaf) {
+    . $SubmissionContractScript
 }
 
 if (Test-Path $ControlPlaneDispatchScript -PathType Leaf) {
@@ -3599,7 +3604,7 @@ function Start-DeferredPaneFromManifestEntry {
     $label = [string](Get-SendConfigValue -InputObject $ManifestEntry -Name 'Label' -Default '')
     $paneId = [string](Get-SendConfigValue -InputObject $ManifestEntry -Name 'PaneId' -Default '')
     if ([string]::IsNullOrWhiteSpace($paneId)) {
-        Stop-WithError "deferred pane '$label' is missing pane id"
+        throw "deferred pane '$label' is missing pane id"
     }
 
     $status = [string](Get-SendConfigValue -InputObject $ManifestEntry -Name 'Status' -Default '')
@@ -3611,7 +3616,7 @@ function Start-DeferredPaneFromManifestEntry {
             $reason = 'backend_degraded'
         }
         Set-DeferredPaneStartStatus -ProjectDir $ProjectDir -PaneId $paneId -Status 'backend_degraded' -FailedStage 'backend_preflight' -FailureReason $reason -RecoveryAction 'inspect-backend-and-rerun-workers-start'
-        Stop-WithError "worker backend for '$label' is degraded: $reason"
+        throw "worker backend for '$label' is degraded: $reason"
     }
 
     $readinessAgent = ConvertTo-ReadinessAgentName ([string](Get-SendConfigValue -InputObject $ManifestEntry -Name 'CapabilityAdapter' -Default ''))
@@ -3633,14 +3638,14 @@ function Start-DeferredPaneFromManifestEntry {
     $planPath = [string](Get-SendConfigValue -InputObject $ManifestEntry -Name 'BootstrapPlanPath' -Default '')
     if ([string]::IsNullOrWhiteSpace($planPath)) {
         Set-DeferredPaneStartStatus -ProjectDir $ProjectDir -PaneId $paneId -Status 'deferred_start_failed' -FailedStage 'bootstrap_plan_missing' -FailureReason "missing bootstrap plan path"
-        Stop-WithError "deferred pane '$label' is missing bootstrap plan path"
+        throw "deferred pane '$label' is missing bootstrap plan path"
     }
     if (-not [System.IO.Path]::IsPathRooted($planPath)) {
         $planPath = [System.IO.Path]::GetFullPath((Join-Path $ProjectDir $planPath))
     }
     if (-not (Test-Path -LiteralPath $planPath -PathType Leaf)) {
         Set-DeferredPaneStartStatus -ProjectDir $ProjectDir -PaneId $paneId -Status 'deferred_start_failed' -FailedStage 'bootstrap_plan_not_found' -FailureReason "bootstrap plan not found: $planPath"
-        Stop-WithError "deferred pane '$label' bootstrap plan not found: $planPath"
+        throw "deferred pane '$label' bootstrap plan not found: $planPath"
     }
 
     $plan = Get-Content -LiteralPath $planPath -Raw -Encoding UTF8 | ConvertFrom-Json -Depth 8
@@ -3650,7 +3655,7 @@ function Start-DeferredPaneFromManifestEntry {
     if ($approvalDifferences.Count -gt 0) {
         $mismatchReason = Format-WorkersLaunchApprovalMismatch -Differences $approvalDifferences
         Set-DeferredPaneStartStatus -ProjectDir $ProjectDir -PaneId $paneId -Status 'deferred_start_failed' -FailedStage 'launch_approval' -FailureReason $mismatchReason -RecoveryAction 'review-worker-settings-and-rerun-launch'
-        Stop-WithError $mismatchReason
+        throw $mismatchReason
     }
 
     $markerPath = [string](Get-SendConfigValue -InputObject $plan -Name 'ready_marker_path' -Default '')
@@ -16659,20 +16664,42 @@ function Invoke-DispatchReview {
     $projectDir = (Get-Location).Path
     $branch = Get-CurrentGitBranch -ProjectDir $projectDir
     $headSha = Get-CurrentGitHead -ProjectDir $projectDir
+    $submissionId = 'submission-' + [guid]::NewGuid().ToString('N')
 
     $reviewPaneEntry = Get-PreferredReviewPaneEntry -ProjectDir $projectDir
     if ($null -eq $reviewPaneEntry) {
-        Stop-WithError "No review-capable pane found in manifest."
+        $receipt = New-WinsmuxSubmissionReceipt -Kind review -Status unavailable -Backend noop -SubmissionId $submissionId -ReasonCode 'review_target_unavailable' -Diagnostic 'No review-capable pane was found in the manifest.'
+        ConvertTo-WinsmuxSubmissionReceiptJson -Receipt $receipt | Write-Output
+        exit 1
     }
 
     $reviewPaneId = [string]$reviewPaneEntry.PaneId
     $reviewLabel = [string]$reviewPaneEntry.Label
     $reviewRole = [string]$reviewPaneEntry.Role
-    Write-Output "Dispatching review to $reviewLabel [$reviewPaneId] for branch $branch ($($headSha.Substring(0,7)))"
+    $reviewBackend = [string](Get-WinsmuxSubmissionValue -InputObject $reviewPaneEntry -Name 'WorkerBackend' -Default 'local')
+    $reviewBackend = $reviewBackend.Trim().ToLowerInvariant()
 
-    Send-TextToPane -PaneId $reviewPaneId -CommandText "winsmux review-request"
+    if ($reviewBackend -notin @('local', 'codex')) {
+        $reviewPacket = [ordered]@{
+            branch   = $branch
+            head_sha = $headSha
+            request  = 'Review the synthetic or repository change described by this packet. Do not issue PASS or commit authority.'
+        } | ConvertTo-Json -Depth 4 -Compress
+        $receipt = Invoke-WinsmuxSubmissionAdapter -ProjectDir $projectDir -ManifestEntry $reviewPaneEntry -Kind review -Content $reviewPacket -SubmissionId $submissionId
+        ConvertTo-WinsmuxSubmissionReceiptJson -Receipt $receipt | Write-Output
+        if ($receipt.status -ne 'accepted') {
+            exit 1
+        }
+        return
+    }
 
-    Write-Output "review-request sent to $reviewLabel. Waiting for PENDING state..."
+    try {
+        Send-TextToPane -PaneId $reviewPaneId -CommandText "winsmux review-request"
+    } catch {
+        $receipt = New-WinsmuxSubmissionReceipt -Kind review -Status unavailable -Backend $reviewBackend -SubmissionId $submissionId -ReasonCode 'pane_send_failed' -Diagnostic $_.Exception.Message -Target ([ordered]@{ label = $reviewLabel; pane_id = $reviewPaneId; role = $reviewRole })
+        ConvertTo-WinsmuxSubmissionReceiptJson -Receipt $receipt | Write-Output
+        exit 1
+    }
 
     # Poll for PENDING state (up to 30 seconds)
     $maxAttempts = 10
@@ -16683,7 +16710,8 @@ function Invoke-DispatchReview {
         if ($state.Contains($branch)) {
             $stateEntry = ConvertTo-ReviewStateValue -Value $state[$branch]
             $status = [string](Get-ReviewStatePropertyValue -InputObject $stateEntry -Name 'status')
-            if ($status -eq 'PENDING') {
+            $pendingHead = [string](Get-ReviewStatePropertyValue -InputObject $stateEntry -Name 'head_sha')
+            if ($status -eq 'PENDING' -and $pendingHead -eq $headSha) {
                 $pending = $true
                 break
             }
@@ -16691,10 +16719,13 @@ function Invoke-DispatchReview {
     }
 
     if (-not $pending) {
-        Stop-WithError "review-request was not recorded after ${maxAttempts} attempts. Check review pane $reviewPaneId."
+        $receipt = New-WinsmuxSubmissionReceipt -Kind review -Status rejected -Backend $reviewBackend -SubmissionId $submissionId -ReasonCode 'review_pending_acknowledgement_missing' -Diagnostic "review-request was not recorded for the current head after ${maxAttempts} attempts." -Target ([ordered]@{ label = $reviewLabel; pane_id = $reviewPaneId; role = $reviewRole })
+        ConvertTo-WinsmuxSubmissionReceiptJson -Receipt $receipt | Write-Output
+        exit 1
     }
 
-    Write-Output "PENDING confirmed. $reviewRole pane will run review-approve or review-fail. Monitor review-state.json for result."
+    $receipt = New-WinsmuxSubmissionReceipt -Kind review -Status accepted -Backend $reviewBackend -SubmissionId $submissionId -Target ([ordered]@{ label = $reviewLabel; pane_id = $reviewPaneId; role = $reviewRole }) -Acknowledgement ([ordered]@{ type = 'review_pending_state'; branch = $branch; head_sha = $headSha })
+    ConvertTo-WinsmuxSubmissionReceiptJson -Receipt $receipt | Write-Output
 }
 
 function Invoke-ReviewRequest {

--- a/tests/ColabWorkerTemplates.Tests.ps1
+++ b/tests/ColabWorkerTemplates.Tests.ps1
@@ -13,7 +13,7 @@ Describe 'Colab worker templates' {
         }
         $script:PythonCommand = if ($null -ne $pythonCommand) { $pythonCommand.Source } else { '' }
         $script:Templates = @(
-            @{ Path = 'workers\colab\impl_worker.py'; Kind = 'impl'; Artifact = 'implementation-plan.md' },
+            @{ Path = 'workers\colab\impl_worker.py'; Kind = 'implementation'; Artifact = 'implementation-plan.md' },
             @{ Path = 'workers\colab\critic_worker.py'; Kind = 'critic'; Artifact = 'critic-notes.md' },
             @{ Path = 'workers\colab\scout_worker.py'; Kind = 'scout'; Artifact = 'scout-plan.md' },
             @{ Path = 'workers\colab\test_worker.py'; Kind = 'test'; Artifact = 'test-plan.md' },

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -16951,6 +16951,69 @@ agent-slots:
         $packetAfterDuplicate.request_digest | Should -BeExactly $originalPacket.request_digest
     }
 
+    It 'ROUND3 P2 rejects a packet-only retry without overwriting the original request' {
+        $taskId = 'task-round3-packet-only-retry'
+        $attemptId = 'attempt-round3-packet-only-retry-1'
+        $entry = [PSCustomObject]@{ Label = 'worker-1'; PaneId = '%1'; Role = 'Worker'; WorkerBackend = 'api_llm' }
+        $firstContent = [ordered]@{ title = 'Original packet'; request = 'Keep this request after send failure.' }
+        $script:task780PacketRetrySendCount = 0
+
+        $first = Invoke-WinsmuxSubmissionAdapter -ProjectDir $script:task780TempRoot -ManifestEntry $entry -Kind task -Content $firstContent `
+            -SubmissionId $attemptId -TaskId $taskId `
+            -SendAction { $script:task780PacketRetrySendCount++; throw 'synthetic packet send failure' } `
+            -RunResultAction { throw 'send failure must stop before runner polling' }
+        $packetPath = Join-Path $script:task780TempRoot ".winsmux\submissions\$attemptId.json"
+        $runPath = Get-WinsmuxSubmissionRunPath -ProjectDir $script:task780TempRoot -SlotId worker-1 -RunId $attemptId
+        $originalPacketText = Get-Content -LiteralPath $packetPath -Raw -Encoding UTF8
+        $originalPacket = $originalPacketText | ConvertFrom-Json
+
+        $duplicate = Invoke-WinsmuxSubmissionAdapter -ProjectDir $script:task780TempRoot -ManifestEntry $entry -Kind task `
+            -Content ([ordered]@{ title = 'Replacement packet'; request = 'This request must not replace the original.' }) `
+            -SubmissionId $attemptId -TaskId $taskId `
+            -SendAction { $script:task780PacketRetrySendCount++; throw 'duplicate retry must stop before sending' } `
+            -RunResultAction { throw 'duplicate retry must stop before runner polling' }
+        $packetAfterRetryText = Get-Content -LiteralPath $packetPath -Raw -Encoding UTF8
+        $packetAfterRetry = $packetAfterRetryText | ConvertFrom-Json
+
+        $first.status | Should -Be 'unavailable'
+        $first.reason_code | Should -Be 'packet_repl_unavailable'
+        $duplicate.status | Should -Be 'rejected'
+        $duplicate.reason_code | Should -Be 'run_record_already_exists'
+        (Test-WinsmuxSubmissionReceipt -Receipt $duplicate) | Should -Be $true
+        { ConvertTo-WinsmuxSubmissionReceiptJson -Receipt $duplicate | Out-Null } | Should -Not -Throw
+        $script:task780PacketRetrySendCount | Should -Be 1
+        (Test-Path -LiteralPath $runPath -PathType Leaf) | Should -Be $false
+        $packetAfterRetryText | Should -BeExactly $originalPacketText
+        $packetAfterRetry.request | Should -BeExactly $originalPacket.request
+        $packetAfterRetry.request_digest | Should -BeExactly $originalPacket.request_digest
+    }
+
+    It 'ROUND3 P2 converts an atomic packet-create collision to typed duplicate refusal' {
+        $attemptId = 'attempt-round3-atomic-packet-race-1'
+        $entry = [PSCustomObject]@{ Label = 'worker-1'; PaneId = '%1'; Role = 'Worker'; WorkerBackend = 'api_llm' }
+        $packetPath = (Resolve-WinsmuxSubmissionPacketPath -ProjectDir $script:task780TempRoot -SubmissionId $attemptId).FullPath
+        New-Item -ItemType Directory -Path (Split-Path -Parent $packetPath) -Force | Out-Null
+        $script:task780AtomicPacketPath = $packetPath
+        $script:task780AtomicSendCalled = $false
+        Mock New-WinsmuxSubmissionPacket {
+            [System.IO.File]::WriteAllText($script:task780AtomicPacketPath, 'race winner packet', [System.Text.UTF8Encoding]::new($false))
+            throw [System.IO.IOException]::new('synthetic CreateNew collision')
+        }
+
+        $receipt = Invoke-WinsmuxSubmissionAdapter -ProjectDir $script:task780TempRoot -ManifestEntry $entry -Kind task -Content 'Atomic retry loser' `
+            -SubmissionId $attemptId -TaskId 'task-round3-atomic-packet-race' `
+            -SendAction { $script:task780AtomicSendCalled = $true } `
+            -RunResultAction { throw 'atomic collision must stop before runner polling' }
+
+        $receipt.status | Should -Be 'rejected'
+        $receipt.reason_code | Should -Be 'run_record_already_exists'
+        (Test-WinsmuxSubmissionReceipt -Receipt $receipt) | Should -Be $true
+        { ConvertTo-WinsmuxSubmissionReceiptJson -Receipt $receipt | Out-Null } | Should -Not -Throw
+        $script:task780AtomicSendCalled | Should -Be $false
+        (Get-Content -LiteralPath $packetPath -Raw -Encoding UTF8) | Should -BeExactly 'race winner packet'
+        Should -Invoke New-WinsmuxSubmissionPacket -Times 1 -Exactly
+    }
+
     It 'ROUND3 P1 exposes only the finite unavailable and rejected reason allowlists' {
         $cases = @(
             [ordered]@{ backend = 'antigravity'; status = 'blocked'; reason = 'antigravity_cli_missing'; receipt_status = 'unavailable'; expected = 'antigravity_cli_missing' },
@@ -16977,6 +17040,53 @@ agent-slots:
             $receipt.reason_code | Should -Be $case.expected
             $receipt.reason_code | Should -Match '^[a-z][a-z0-9_]*$'
             $json | Should -Not -Match 'sk_synthetic_secret_cli_missing|private_provider_payload'
+        }
+    }
+
+    It 'ROUND3 P2 keeps backend and task-id refusal combinations typed and serializable' {
+        $cases = @(
+            [ordered]@{
+                name             = 'known-backend-invalid-task'
+                backend          = 'antigravity'
+                task_id          = 'invalid task id'
+                expected_status  = 'rejected'
+                expected_backend = 'antigravity'
+                expected_reason  = 'task_identifier_invalid'
+            },
+            [ordered]@{
+                name             = 'unknown-backend-valid-task'
+                backend          = 'unknown_backend'
+                task_id          = 'valid-task-id'
+                expected_status  = 'unsupported'
+                expected_backend = 'noop'
+                expected_reason  = 'backend_unsupported'
+            },
+            [ordered]@{
+                name             = 'unknown-backend-invalid-task'
+                backend          = 'unknown_backend'
+                task_id          = 'invalid task id'
+                expected_status  = 'unsupported'
+                expected_backend = 'noop'
+                expected_reason  = 'backend_unsupported'
+            }
+        )
+
+        foreach ($case in $cases) {
+            $entry = [PSCustomObject]@{ Label = 'worker-3'; PaneId = ''; Role = 'Worker'; WorkerBackend = $case.backend }
+            $receipt = Invoke-WinsmuxSubmissionAdapter -ProjectDir $script:task780TempRoot -ManifestEntry $entry -Kind task -Content 'Input validation matrix' `
+                -SubmissionId ('submission-' + $case.name) -TaskId $case.task_id -CliRunAction { throw 'input refusal must stop before runner invocation' }
+
+            $receipt.status | Should -Be $case.expected_status
+            $receipt.backend | Should -Be $case.expected_backend
+            $receipt.reason_code | Should -Be $case.expected_reason
+            (Test-WinsmuxSubmissionReceipt -Receipt $receipt) | Should -Be $true
+            { ConvertTo-WinsmuxSubmissionReceiptJson -Receipt $receipt | Out-Null } | Should -Not -Throw
+
+            $parsed = ConvertTo-WinsmuxSubmissionReceiptJson -Receipt $receipt | ConvertFrom-Json
+            $parsed.protocol_version | Should -Be 1
+            $parsed.status | Should -Be $case.expected_status
+            $parsed.backend | Should -Be $case.expected_backend
+            $parsed.reason_code | Should -Be $case.expected_reason
         }
     }
 

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -15978,7 +15978,7 @@ Describe 'winsmux dispatch-task routing' {
     }
 
     It 'validates only protocol-v1 submission receipts with the fixed vocabulary' {
-        $evidence = New-WinsmuxSubmissionRunRecord -SubmissionId 'submission-test-1' -RunId 'submission-test-1' -Kind task -TaskTitle 'Test task' -SlotId worker-1 -Backend codex -Status started -RequestConsumed
+        $evidence = New-WinsmuxSubmissionRunRecord -SubmissionId 'submission-test-1' -RunId 'submission-test-1' -Kind task -TaskTitle 'Test task' -SlotId worker-1 -Backend codex -Status started -RequestConsumed -RequestDigest ('a' * 64)
         $receipt = New-WinsmuxSubmissionReceipt -Kind task -Status accepted -Backend codex -SubmissionId 'submission-test-1' -Target ([ordered]@{ label = 'worker-1' }) -Acknowledgement $evidence
 
         (Test-WinsmuxSubmissionReceipt -Receipt $receipt) | Should -Be $true
@@ -15998,18 +15998,18 @@ Describe 'winsmux dispatch-task routing' {
             -SendAction { param($paneId, $commandText) } `
             -RunResultAction { param($projectDir, $slotId, $runId) $null }
 
-        $receipt.status | Should -Be 'rejected'
-        $receipt.reason_code | Should -Be 'backend_acknowledgement_missing'
+        $receipt.status | Should -Be 'unavailable'
+        $receipt.reason_code | Should -Be 'caller_identity_unavailable'
     }
 
-    It 'accepts shell or Codex only after a matching backend run record' {
+    It 'refuses shell or Codex even when mutable local evidence claims a matching run record' {
         $entry = [PSCustomObject]@{ Label = 'worker-2'; PaneId = '%2'; Role = 'Worker'; WorkerBackend = 'local' }
         $receipt = Invoke-WinsmuxSubmissionAdapter -ProjectDir 'C:\repo' -ManifestEntry $entry -Kind task -Content 'implement the focused change' -SubmissionId 'submission-test-3' `
             -SendAction { param($paneId, $commandText) } `
-            -RunResultAction { param($projectDir, $slotId, $runId) New-WinsmuxSubmissionRunRecord -SubmissionId $runId -RunId $runId -Kind task -TaskTitle 'Test task' -SlotId $slotId -Backend local -Status started -RequestConsumed }
+            -RunResultAction { param($projectDir, $slotId, $runId) New-WinsmuxSubmissionRunRecord -SubmissionId $runId -RunId $runId -Kind task -TaskTitle 'Test task' -SlotId $slotId -Backend local -Status started -RequestConsumed -RequestDigest (Get-WinsmuxSubmissionRequestDigest -Request 'implement the focused change') }
 
-        $receipt.status | Should -Be 'accepted'
-        $receipt.acknowledgement.type | Should -Be 'backend_run_record'
+        $receipt.status | Should -Be 'unavailable'
+        $receipt.reason_code | Should -Be 'caller_identity_unavailable'
     }
 
     It 'sends api_llm an exec packet and converts runner refusal to typed rejected' {
@@ -16052,7 +16052,7 @@ Describe 'winsmux dispatch-task routing' {
         try {
             $entry = [PSCustomObject]@{ Label = 'worker-3'; PaneId = '%3'; Role = 'Worker'; WorkerBackend = 'colab_cli' }
             $receipt = Invoke-WinsmuxSubmissionAdapter -ProjectDir $tempRoot -ManifestEntry $entry -Kind review -Content 'review synthetic input' -SubmissionId 'submission-test-7' `
-                -CliRunAction { param($projectDir, $slotId, $packetPath, $submissionId) New-WinsmuxSubmissionRunRecord -SubmissionId $submissionId -RunId $submissionId -Kind review -TaskTitle 'Review test' -SlotId $slotId -Backend colab_cli -Status started -RequestConsumed }
+                -CliRunAction { param($projectDir, $slotId, $packetPath, $submissionId) New-WinsmuxSubmissionRunRecord -SubmissionId $submissionId -RunId $submissionId -Kind review -TaskTitle 'Review test' -SlotId $slotId -Backend colab_cli -Status started -RequestConsumed -RequestDigest (Get-WinsmuxSubmissionRequestDigest -Request 'review synthetic input') }
 
             $receipt.status | Should -Be 'accepted'
             $receipt.acknowledgement.type | Should -Be 'backend_run_record'
@@ -16096,12 +16096,15 @@ Describe 'winsmux dispatch-task routing' {
 
 Describe 'TASK-780 typed submission review fixes' {
     BeforeAll {
+        $script:task780RepoRoot = Split-Path -Parent $PSScriptRoot
         $script:task780CorePath = Join-Path (Split-Path -Parent $PSScriptRoot) 'scripts\winsmux-core.ps1'
         $script:task780ApiWorkerPath = Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\api-llm-pane-worker.ps1'
         $script:task780RouterPath = Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\dispatch-router.ps1'
+        $script:task780BuilderQueuePath = Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\builder-queue.ps1'
         $script:task780RustMainPath = Join-Path (Split-Path -Parent $PSScriptRoot) 'core\src\main.rs'
         . $script:task780CorePath 'version' *> $null
         . $script:task780RouterPath
+        . $script:task780BuilderQueuePath
     }
 
     BeforeEach {
@@ -16115,7 +16118,7 @@ Describe 'TASK-780 typed submission review fixes' {
         }
     }
 
-    It 'P1 rejects pane input echo without a backend-owned run record' {
+    It 'P1 refuses pane input echo when strong caller identity is unavailable' {
         $entry = [PSCustomObject]@{ Label = 'worker-2'; PaneId = '%2'; Role = 'Worker'; WorkerBackend = 'codex' }
         $script:echoedPrompt = ''
         $receipt = Invoke-WinsmuxSubmissionAdapter -ProjectDir $script:task780TempRoot -ManifestEntry $entry -Kind task -Content 'synthetic implementation request' -SubmissionId 'submission-review-echo' `
@@ -16124,8 +16127,8 @@ Describe 'TASK-780 typed submission review fixes' {
             -RunResultAction { param($projectDir, $slotId, $runId) $null }
 
         $receipt.GetType().Name | Should -Not -Be 'Object[]'
-        $receipt.status | Should -Be 'rejected'
-        $receipt.reason_code | Should -Be 'backend_acknowledgement_missing'
+        $receipt.status | Should -Be 'unavailable'
+        $receipt.reason_code | Should -Be 'caller_identity_unavailable'
     }
 
     It 'P1 rejects unsafe target labels before composing a pane command' {
@@ -16153,21 +16156,23 @@ Describe 'TASK-780 typed submission review fixes' {
             (Test-WinsmuxSubmissionReceipt -Receipt $receipt) | Should -Be $false
         }
 
-        $validEvidence = New-WinsmuxSubmissionRunRecord -SubmissionId 'submission-review-evidence' -RunId 'submission-review-evidence' -Kind task -TaskTitle 'Review evidence test' -SlotId worker-1 -Backend codex -Status started -RequestConsumed
+        $validEvidence = New-WinsmuxSubmissionRunRecord -SubmissionId 'submission-review-evidence' -RunId 'submission-review-evidence' -Kind task -TaskTitle 'Review evidence test' -SlotId worker-1 -Backend codex -Status started -RequestConsumed -RequestDigest ('b' * 64)
         $validReceipt = New-WinsmuxSubmissionReceipt -Kind task -Status accepted -Backend codex -SubmissionId 'submission-review-evidence' -Target ([ordered]@{ label = 'worker-1' }) -Acknowledgement $validEvidence
         (Test-WinsmuxSubmissionReceipt -Receipt $validReceipt) | Should -Be $true
         foreach ($evidenceMutation in @(
-            [ordered]@{ name = 'task_id'; value = 'other-task' },
-            [ordered]@{ name = 'task_title'; value = '' },
+            [ordered]@{ name = 'type'; value = 'unknown' },
+            [ordered]@{ name = 'protocol_version'; value = 2 },
+            [ordered]@{ name = 'status'; value = 'failed' },
+            [ordered]@{ name = 'submission_id'; value = 'other-task' },
+            [ordered]@{ name = 'run_id'; value = 'other-run' },
+            [ordered]@{ name = 'kind'; value = 'review' },
+            [ordered]@{ name = 'backend'; value = 'local' },
             [ordered]@{ name = 'worker_kind'; value = 'critic' },
             [ordered]@{ name = 'slot_id'; value = '../escape' },
             [ordered]@{ name = 'slot_id'; value = 'worker-2' },
-            [ordered]@{ name = 'backend_owned'; value = 'false' },
-            [ordered]@{ name = 'request_consumed'; value = 'false' },
-            [ordered]@{ name = 'exit_code'; value = 1 },
-            [ordered]@{ name = 'exit_code'; value = '0' }
+            [ordered]@{ name = 'request_digest'; value = ('c' * 63) }
         )) {
-            $invalidEvidence = New-WinsmuxSubmissionRunRecord -SubmissionId 'submission-review-evidence' -RunId 'submission-review-evidence' -Kind task -TaskTitle 'Review evidence test' -SlotId worker-1 -Backend codex -Status started -RequestConsumed
+            $invalidEvidence = New-WinsmuxSubmissionRunRecord -SubmissionId 'submission-review-evidence' -RunId 'submission-review-evidence' -Kind task -TaskTitle 'Review evidence test' -SlotId worker-1 -Backend codex -Status started -RequestConsumed -RequestDigest ('b' * 64)
             $invalidEvidence[$evidenceMutation.name] = $evidenceMutation.value
             $invalidReceipt = New-WinsmuxSubmissionReceipt -Kind task -Status accepted -Backend codex -SubmissionId 'submission-review-evidence' -Target ([ordered]@{ label = 'worker-1' }) -Acknowledgement $invalidEvidence
             (Test-WinsmuxSubmissionReceipt -Receipt $invalidReceipt) | Should -Be $false
@@ -16227,7 +16232,7 @@ Describe 'TASK-780 typed submission review fixes' {
         }
     }
 
-    It 'P1 binds local acknowledgement to packet target manifest backend and current pane' {
+    It 'P1 refuses local acknowledgement until strong caller authority is available' {
         $manifestDir = Join-Path $script:task780TempRoot '.winsmux'
         New-Item -ItemType Directory -Path $manifestDir -Force | Out-Null
         [IO.File]::WriteAllText((Join-Path $manifestDir 'manifest.yaml'), @'
@@ -16244,15 +16249,16 @@ panes:
         $previousPaneId = $env:WINSMUX_PANE_ID
         try {
             $env:WINSMUX_PANE_ID = '%2'
-            $record = Invoke-WinsmuxSubmissionAcknowledge -ProjectDir $script:task780TempRoot -SlotId worker-1 -SubmissionId 'submission-ack-bound' -RunId 'submission-ack-bound' -Kind task -Backend codex
-            $record.slot_id | Should -Be 'worker-1'
+            $receipt = Invoke-WinsmuxSubmissionAcknowledge -ProjectDir $script:task780TempRoot -SlotId worker-1 -SubmissionId 'submission-ack-bound' -RunId 'submission-ack-bound' -Kind task -Backend codex
+            $receipt.status | Should -Be 'unavailable'
+            $receipt.reason_code | Should -Be 'caller_identity_unavailable'
 
             New-WinsmuxSubmissionPacket -ProjectDir $script:task780TempRoot -Kind task -Content ([ordered]@{ title = 'Wrong pane'; request = 'Reject wrong pane.' }) -SubmissionId 'submission-ack-wrong-pane' -TargetLabel worker-1 | Out-Null
             $env:WINSMUX_PANE_ID = '%9'
-            { Invoke-WinsmuxSubmissionAcknowledge -ProjectDir $script:task780TempRoot -SlotId worker-1 -SubmissionId 'submission-ack-wrong-pane' -RunId 'submission-ack-wrong-pane' -Kind task -Backend codex } | Should -Throw '*caller does not match*'
+            (Invoke-WinsmuxSubmissionAcknowledge -ProjectDir $script:task780TempRoot -SlotId worker-1 -SubmissionId 'submission-ack-wrong-pane' -RunId 'submission-ack-wrong-pane' -Kind task -Backend codex).status | Should -Be 'unavailable'
 
             $env:WINSMUX_PANE_ID = '%2'
-            { Invoke-WinsmuxSubmissionAcknowledge -ProjectDir $script:task780TempRoot -SlotId worker-1 -SubmissionId 'submission-ack-wrong-pane' -RunId 'submission-ack-wrong-pane' -Kind task -Backend local } | Should -Throw '*backend does not match*'
+            (Invoke-WinsmuxSubmissionAcknowledge -ProjectDir $script:task780TempRoot -SlotId worker-1 -SubmissionId 'submission-ack-wrong-pane' -RunId 'submission-ack-wrong-pane' -Kind task -Backend local).reason_code | Should -Be 'caller_identity_unavailable'
         } finally {
             $env:WINSMUX_PANE_ID = $previousPaneId
         }
@@ -16260,7 +16266,7 @@ panes:
 
     It 'P1 rejects a pre-existing run record instead of reusing it as acceptance' {
         $entry = [PSCustomObject]@{ Label = 'worker-1'; PaneId = '%2'; Role = 'Worker'; WorkerBackend = 'codex' }
-        $stale = New-WinsmuxSubmissionRunRecord -SubmissionId 'submission-stale-run' -RunId 'submission-stale-run' -Kind task -TaskTitle 'Stale run' -SlotId worker-1 -Backend codex -Status started -RequestConsumed
+        $stale = New-WinsmuxSubmissionRunRecord -SubmissionId 'submission-stale-run' -RunId 'submission-stale-run' -Kind task -TaskTitle 'Stale run' -SlotId worker-1 -Backend codex -Status started -RequestConsumed -RequestDigest ('d' * 64)
         Write-WinsmuxSubmissionRunRecord -ProjectDir $script:task780TempRoot -SlotId worker-1 -Record $stale | Out-Null
         $script:staleRunSendCalled = $false
         $receipt = Invoke-WinsmuxSubmissionAdapter -ProjectDir $script:task780TempRoot -ManifestEntry $entry -Kind task -Content 'new request' -SubmissionId 'submission-stale-run' `
@@ -16296,7 +16302,7 @@ panes:
     }
 
     It 'P1 requires a durable api_llm started record before accepting a long execution' {
-        $evidence = New-WinsmuxSubmissionRunRecord -SubmissionId 'submission-review-api-start' -RunId 'submission-review-api-start' -Kind task -TaskTitle 'API start test' -SlotId worker-1 -Backend api_llm -Status started -RequestConsumed
+        $evidence = New-WinsmuxSubmissionRunRecord -SubmissionId 'submission-review-api-start' -RunId 'submission-review-api-start' -Kind task -TaskTitle 'API start test' -SlotId worker-1 -Backend api_llm -Status started -RequestConsumed -RequestDigest ('e' * 64)
 
         $evidence.protocol_version | Should -Be 1
         $evidence.status | Should -Be 'started'
@@ -16420,12 +16426,198 @@ agent-slots:
     }
 
     It 'P2 redacts arbitrary Windows UNC and Unix absolute paths from diagnostics' {
-        $diagnostic = ConvertTo-WinsmuxSubmissionDiagnostic -Text 'D:\workspace\secret\file.txt C:\tmp\private.json \\server\share\private.md /home/alice/private.txt'
+        $diagnostic = ConvertTo-WinsmuxSubmissionDiagnostic -Text 'C:\Users\Jane Doe\repo\secret.txt D:\workspace\secret\file.txt C:\tmp\private.json \\server\share\private.md /home/alice/private.txt /srv/private/file /mnt/c/private/file /root/private/file https://example.test/srv/public'
 
         $diagnostic | Should -Not -Match 'D:\\workspace'
         $diagnostic | Should -Not -Match 'C:\\tmp'
         $diagnostic | Should -Not -Match '\\\\server\\share'
         $diagnostic | Should -Not -Match '/home/alice'
+        $diagnostic | Should -Not -Match '/srv/private'
+        $diagnostic | Should -Not -Match '/mnt/c/private'
+        $diagnostic | Should -Not -Match '/root/private'
+        $diagnostic | Should -Not -Match 'Jane Doe|Doe\\repo'
+        $diagnostic | Should -Match 'https://example\.test/srv/public'
+        (ConvertTo-WorkersSafeRemotePath -RemotePath '/content/inputs') | Should -Be '/content/inputs'
+        (ConvertTo-WorkersSafeRemotePath -RemotePath '/content/drive/MyDrive/private/file.txt') | Should -Be '[DRIVE_PATH_REDACTED]'
+        (ConvertTo-WorkersSafeRemotePath -RemotePath '/root/private/file.txt') | Should -Be '[UNIX_PATH_REDACTED]'
+    }
+
+    It 'ROUND2 P1 keeps builder queue queued after raw send success and advances only for a validated receipt' {
+        $queuedEntry = ConvertTo-BuilderQueueEntry -BuilderLabel builder-1 -Task 'Implement typed queue dispatch' -TaskId task-round2-queue
+        $script:round2Manifest = [PSCustomObject]@{
+            tasks = [PSCustomObject]@{ queued = @($queuedEntry); in_progress = @(); completed = @() }
+            panes = [PSCustomObject]@{}
+        }
+        Mock Get-BuilderQueueManifest { $script:round2Manifest }
+        $script:round2SavedManifest = $null
+        Mock Save-BuilderQueueManifest { param($ProjectDir, $Manifest) $script:round2SavedManifest = $Manifest }
+        Mock Get-BuilderQueueTaskFiles { @() }
+        Mock Lock-DispatchFiles { $true }
+        Mock Unlock-DispatchFiles { $true }
+        Mock Update-BuilderQueuePaneState {}
+
+        $rawOutcome = Dispatch-NextBuilderQueueTask -ProjectDir $script:task780TempRoot -BuilderLabel builder-1 -DispatchAction {
+            [PSCustomObject]@{ Output = 'raw bridge send succeeded' }
+        }
+        $rawOutcome.Dispatched | Should -Be $false
+        $rawOutcome.Reason | Should -Be 'runner_evidence_invalid'
+        @($script:round2Manifest.tasks.queued).Count | Should -Be 1
+        @($script:round2Manifest.tasks.in_progress).Count | Should -Be 0
+        Assert-MockCalled Save-BuilderQueueManifest -Times 0 -Exactly
+
+        $request = New-BuilderQueueDispatchPrompt -Task 'Implement typed queue dispatch'
+        $packet = New-WinsmuxSubmissionPacket -ProjectDir $script:task780TempRoot -Kind task -Content $request -SubmissionId task-round2-queue -TargetLabel builder-1
+        $digest = [string]$packet.Packet.request_digest
+        foreach ($mutation in @(
+            [ordered]@{ name = 'backend_owned'; value = $false },
+            [ordered]@{ name = 'request_consumed'; value = $false },
+            [ordered]@{ name = 'task_id'; value = 'other-task' },
+            [ordered]@{ name = 'exit_code'; value = 1 },
+            [ordered]@{ name = 'request_digest'; value = ('0' * 64) }
+        )) {
+            $invalidEvidence = New-WinsmuxSubmissionRunRecord -SubmissionId task-round2-queue -RunId task-round2-queue -Kind task -TaskTitle 'Implement typed queue dispatch' -SlotId builder-1 -Backend api_llm -Status started -RequestConsumed -RequestDigest $digest
+            $invalidEvidence[$mutation.name] = $mutation.value
+            Write-WinsmuxSubmissionRunRecord -ProjectDir $script:task780TempRoot -SlotId builder-1 -Record $invalidEvidence | Out-Null
+            $invalidReceipt = New-WinsmuxSubmissionReceipt -Kind task -Status accepted -Backend api_llm -SubmissionId task-round2-queue -Target ([ordered]@{ label = 'builder-1' }) -Acknowledgement $invalidEvidence
+            $invalidOutcome = Dispatch-NextBuilderQueueTask -ProjectDir $script:task780TempRoot -BuilderLabel builder-1 -DispatchAction { $invalidReceipt }
+            $invalidOutcome.Dispatched | Should -Be $false
+            $invalidOutcome.Reason | Should -Be 'runner_evidence_invalid'
+            Assert-MockCalled Save-BuilderQueueManifest -Times 0 -Exactly
+        }
+
+        $evidence = New-WinsmuxSubmissionRunRecord -SubmissionId task-round2-queue -RunId task-round2-queue -Kind task -TaskTitle 'Implement typed queue dispatch' -SlotId builder-1 -Backend api_llm -Status started -RequestConsumed -RequestDigest $digest
+        Write-WinsmuxSubmissionRunRecord -ProjectDir $script:task780TempRoot -SlotId builder-1 -Record $evidence | Out-Null
+        $receipt = New-WinsmuxSubmissionReceipt -Kind task -Status accepted -Backend api_llm -SubmissionId task-round2-queue -Target ([ordered]@{ label = 'builder-1' }) -Acknowledgement $evidence
+        $acceptedOutcome = Dispatch-NextBuilderQueueTask -ProjectDir $script:task780TempRoot -BuilderLabel builder-1 -DispatchAction { $receipt }
+        $acceptedOutcome.Dispatched | Should -Be $true
+        Assert-MockCalled Save-BuilderQueueManifest -Times 1 -Exactly -ParameterFilter {
+            @($Manifest.tasks.queued).Count -eq 0 -and @($Manifest.tasks.in_progress).Count -eq 1
+        }
+    }
+
+    It 'ROUND2 P1 runs the real implementation worker through the adapter with canonical worker kind' {
+        $entry = [PSCustomObject]@{ Label = 'worker-3'; PaneId = ''; Role = 'Worker'; WorkerBackend = 'colab_cli' }
+        $implPath = Join-Path $script:task780RepoRoot 'workers\colab\impl_worker.py'
+        $cliAction = {
+            param($projectDir, $slotId, $packetPath, $submissionId, $backend, $kind)
+            $fullPacketPath = Join-Path $projectDir $packetPath
+            $artifactRoot = Join-Path $projectDir 'round2-colab-artifacts'
+            $workerOutput = & python $implPath --task-json $fullPacketPath --task-id $submissionId --run-id $submissionId --worker-id $slotId --artifact-root $artifactRoot
+            $worker = $workerOutput | ConvertFrom-Json
+            $packet = Get-Content -LiteralPath $fullPacketPath -Raw -Encoding UTF8 | ConvertFrom-Json
+            return [ordered]@{
+                protocol_version = 1; type = 'backend_run_record'; submission_id = $submissionId; run_id = $submissionId
+                kind = $kind; task_id = $submissionId; task_title = [string]$packet.title; worker_kind = [string]$worker.worker_kind
+                slot_id = $slotId; backend = $backend; status = 'succeeded'; backend_owned = $true; request_consumed = $true
+                request_digest = [string]$worker.request_digest; exit_code = 0
+            }
+        }
+        $valid = Invoke-WinsmuxSubmissionAdapter -ProjectDir $script:task780TempRoot -ManifestEntry $entry -Kind task -Content 'Implement canonical worker kind.' -SubmissionId submission-round2-real-impl -CliRunAction $cliAction
+        $valid.status | Should -Be 'accepted'
+        $valid.acknowledgement.worker_kind | Should -Be 'implementation'
+
+        $wrongKindAction = {
+            param($projectDir, $slotId, $packetPath, $submissionId, $backend, $kind)
+            $record = & $cliAction $projectDir $slotId $packetPath $submissionId $backend $kind
+            $record.worker_kind = 'impl'
+            return $record
+        }
+        $invalid = Invoke-WinsmuxSubmissionAdapter -ProjectDir $script:task780TempRoot -ManifestEntry $entry -Kind task -Content 'Reject wrong worker kind.' -SubmissionId submission-round2-wrong-kind -CliRunAction $wrongKindAction
+        $invalid.status | Should -Be 'rejected'
+    }
+
+    It 'ROUND2 P1 proves real task and review workers consume request tails and bind their digest' {
+        foreach ($case in @(
+            [ordered]@{ kind = 'task'; script = 'workers\colab\impl_worker.py'; worker_kind = 'implementation' },
+            [ordered]@{ kind = 'review'; script = 'workers\colab\critic_worker.py'; worker_kind = 'critic' }
+        )) {
+            $marker = 'ROUND2-TAIL-' + $case.kind.ToUpperInvariant()
+            $request = "  `n" + ('x' * 140) + $marker + "`n  "
+            $submissionId = 'submission-round2-tail-' + $case.kind
+            $packetRef = New-WinsmuxSubmissionPacket -ProjectDir $script:task780TempRoot -Kind $case.kind -Content ([ordered]@{ title = "Whitespace $($case.kind) request"; request = $request }) -SubmissionId $submissionId -TargetLabel worker-3
+            $artifactRoot = Join-Path $script:task780TempRoot ('round2-tail-' + $case.kind)
+            $output = & python (Join-Path $script:task780RepoRoot $case.script) --task-json $packetRef.FullPath --task-id $submissionId --run-id $submissionId --worker-id worker-3 --artifact-root $artifactRoot
+            $LASTEXITCODE | Should -Be 0
+            $payload = $output | ConvertFrom-Json
+            $payload.worker_kind | Should -Be $case.worker_kind
+            $payload.request_digest | Should -Be $packetRef.Packet.request_digest
+            (Get-Content -LiteralPath ([string]$payload.artifacts[0].path) -Raw -Encoding UTF8) | Should -Match $marker
+        }
+    }
+
+    It 'ROUND2 P1 projects accepted acknowledgement through a strict public allowlist' {
+        $digest = ('a' * 64)
+        $record = New-WinsmuxSubmissionRunRecord -SubmissionId submission-round2-public -RunId submission-round2-public -Kind task -TaskTitle 'SECRET REQUEST C:\private\task.txt' -SlotId worker-1 -Backend api_llm -Status started -RequestConsumed -RequestDigest $digest
+        $record['request'] = 'SECRET BODY /srv/private/body.txt'
+        $record['project_dir'] = 'D:\private\repo'
+        $record['command'] = '\\server\share\private.cmd'
+        $record['transcript'] = '/mnt/c/private/transcript.txt'
+        $record['exception'] = '/root/private/error.txt'
+        $record['provider_payload'] = '/home/private/provider.json'
+        $receipt = New-WinsmuxSubmissionReceipt -Kind task -Status accepted -Backend api_llm -SubmissionId submission-round2-public -Target ([ordered]@{ label = 'worker-1' }) -Acknowledgement $record
+        $json = ConvertTo-WinsmuxSubmissionReceiptJson -Receipt $receipt
+        foreach ($secret in @('SECRET', 'task_title', 'project_dir', 'command', 'transcript', 'exception', 'provider_payload', 'C:\\', 'D:\\', '\\\\server', '/home', '/srv', '/mnt', '/root')) {
+            $json | Should -Not -Match ([regex]::Escape($secret))
+        }
+        @($receipt.acknowledgement.Keys) | Should -Be @('type', 'protocol_version', 'status', 'submission_id', 'run_id', 'kind', 'backend', 'slot_id', 'worker_kind', 'request_digest')
+    }
+
+    It 'ROUND2 P2 refuses forged local or Codex pane identity until TASK-781 authority exists' {
+        $previousPaneId = $env:WINSMUX_PANE_ID
+        try {
+            $env:WINSMUX_PANE_ID = '%2'
+            $entry = [PSCustomObject]@{ Label = 'worker-1'; PaneId = '%2'; Role = 'Worker'; WorkerBackend = 'codex' }
+            $script:round2LocalSendCalled = $false
+            $receipt = Invoke-WinsmuxSubmissionAdapter -ProjectDir $script:task780TempRoot -ManifestEntry $entry -Kind task -Content 'Do not trust mutable pane identity.' -SubmissionId submission-round2-forged-local `
+                -SendAction { $script:round2LocalSendCalled = $true } `
+                -RunResultAction { throw 'must not request optimistic evidence' }
+            $receipt.status | Should -Be 'unavailable'
+            $receipt.reason_code | Should -Be 'caller_identity_unavailable'
+            $script:round2LocalSendCalled | Should -Be $false
+        } finally {
+            $env:WINSMUX_PANE_ID = $previousPaneId
+        }
+    }
+
+    It 'ROUND2 P2 rejects matching run identifiers with a different complete-request digest' {
+        $entry = [PSCustomObject]@{ Label = 'worker-1'; PaneId = '%2'; Role = 'Worker'; WorkerBackend = 'api_llm' }
+        $content = 'Complete request identity must match exactly.'
+        $wrong = Invoke-WinsmuxSubmissionAdapter -ProjectDir $script:task780TempRoot -ManifestEntry $entry -Kind task -Content $content -SubmissionId submission-round2-digest-wrong `
+            -SendAction { 'sent' } `
+            -RunResultAction {
+                param($projectDir, $slotId, $runId)
+                New-WinsmuxSubmissionRunRecord -SubmissionId $runId -RunId $runId -Kind task -TaskTitle 'same non-empty title' -SlotId $slotId -Backend api_llm -Status started -RequestConsumed -RequestDigest ('0' * 64)
+            }
+        $wrong.status | Should -Be 'rejected'
+
+        $expectedDigest = Get-WinsmuxSubmissionRequestDigest -Request $content
+        $exact = Invoke-WinsmuxSubmissionAdapter -ProjectDir $script:task780TempRoot -ManifestEntry $entry -Kind task -Content $content -SubmissionId submission-round2-digest-exact `
+            -SendAction { 'sent' } `
+            -RunResultAction {
+                param($projectDir, $slotId, $runId)
+                New-WinsmuxSubmissionRunRecord -SubmissionId $runId -RunId $runId -Kind task -TaskTitle 'different title is not authority' -SlotId $slotId -Backend api_llm -Status started -RequestConsumed -RequestDigest $expectedDigest
+            }
+        $exact.status | Should -Be 'accepted'
+    }
+
+    It 'ROUND2 P1 returns a process-level typed queue refusal with nonzero exit and retained state' {
+        $manifest = New-WinsmuxManifest -ProjectDir $script:task780TempRoot
+        $manifest.panes['builder-1'] = [PSCustomObject]@{ pane_id = '%2'; role = 'Builder'; worker_backend = 'codex' }
+        $manifest.tasks.queued = @(ConvertTo-BuilderQueueEntry -BuilderLabel builder-1 -Task 'Keep queued without TASK-781 authority' -TaskId task-round2-cli)
+        Save-WinsmuxManifest -ProjectDir $script:task780TempRoot -Manifest $manifest
+
+        $output = & pwsh -NoProfile -File $script:task780BuilderQueuePath -Action dispatch-next -ProjectDir $script:task780TempRoot -BuilderLabel builder-1 -AsJson 2>&1
+        $exitCode = $LASTEXITCODE
+        $payload = ($output | Out-String) | ConvertFrom-Json
+        $saved = Get-WinsmuxManifest -ProjectDir $script:task780TempRoot
+
+        $exitCode | Should -Be 1
+        $payload.Dispatched | Should -Be $false
+        $payload.DispatchResult.status | Should -Be 'unavailable'
+        $payload.DispatchResult.reason_code | Should -Be 'caller_identity_unavailable'
+        @($saved.tasks.queued).Count | Should -Be 1
+        @($saved.tasks.in_progress).Count | Should -Be 0
+        @(Get-DispatchLedger -ProjectDir $script:task780TempRoot).Count | Should -Be 0
     }
 }
 

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -12418,6 +12418,118 @@ worker-backend: colab_cli
         $payload.request_consumed | Should -Be $true
     }
 
+    It 'ROUND3 P1 keeps stable task identity through the real api_llm exec path with only the provider call stubbed' {
+        Write-WorkersApiLlmProjectConfig
+        $taskId = 'task-round3-api-stable'
+        $attemptId = 'attempt-round3-api-1'
+        $packetRef = New-WinsmuxSubmissionPacket -ProjectDir $script:workersTempRoot -Kind task -Content ([ordered]@{ title = 'Synthetic API task'; request = 'Consume the API packet.' }) -SubmissionId $attemptId -TaskId $taskId -TargetLabel 'worker-1'
+        $env:OPENROUTER_API_KEY = 'test-openrouter-key'
+        $script:round3ApiStartedTaskId = ''
+
+        Mock Invoke-RestMethod {
+            $runPath = Join-Path $script:workersTempRoot ".winsmux\worker-runs\worker-1\$attemptId\run.json"
+            $started = Get-Content -LiteralPath $runPath -Raw -Encoding UTF8 | ConvertFrom-Json
+            $script:round3ApiStartedTaskId = [string]$started.task_id
+            return [pscustomobject]@{
+                id = 'chatcmpl-round3-api'
+                choices = @([pscustomobject]@{ message = [pscustomobject]@{ content = 'Synthetic API response.' } })
+                usage = [pscustomobject]@{ prompt_tokens = 1; completion_tokens = 1; total_tokens = 2 }
+            }
+        }
+
+        $Rest = @('w1', '--task-json', $packetRef.RelativePath, '--task-id', $taskId, '--run-id', $attemptId, '--json', '--project-dir', $script:workersTempRoot)
+        $payload = (Invoke-WorkersExec | Select-Object -Last 1) | ConvertFrom-Json
+        $runPath = Join-Path $script:workersTempRoot ".winsmux\worker-runs\worker-1\$attemptId\run.json"
+        $run = Get-Content -LiteralPath $runPath -Raw -Encoding UTF8 | ConvertFrom-Json
+
+        $payload.status | Should -Be 'succeeded'
+        $payload.submission_id | Should -Be $attemptId
+        $payload.run_id | Should -Be $attemptId
+        $payload.task_id | Should -Be $taskId
+        $script:round3ApiStartedTaskId | Should -Be $taskId
+        $run.submission_id | Should -Be $attemptId
+        $run.run_id | Should -Be $attemptId
+        $run.task_id | Should -Be $taskId
+        Should -Invoke Invoke-RestMethod -Times 1 -Exactly
+    }
+
+    It 'ROUND3 P1 keeps stable task identity through the real antigravity exec path with only the CLI call stubbed' {
+        Write-WorkersAntigravityProjectConfig
+        New-WorkersFakeAntigravityCli | Out-Null
+        $taskId = 'task-round3-antigravity-stable'
+        $attemptId = 'attempt-round3-antigravity-1'
+        $packetRef = New-WinsmuxSubmissionPacket -ProjectDir $script:workersTempRoot -Kind task -Content ([ordered]@{ title = 'Synthetic Antigravity task'; request = 'Consume the Antigravity packet.' }) -SubmissionId $attemptId -TaskId $taskId -TargetLabel 'worker-1'
+        $script:round3AntigravityStartedTaskId = ''
+
+        Mock Invoke-WorkersAntigravityCli {
+            param([string[]]$Arguments, [string]$WorkingDirectory)
+            $runPath = Join-Path $script:workersTempRoot ".winsmux\worker-runs\worker-1\$attemptId\run.json"
+            $started = Get-Content -LiteralPath $runPath -Raw -Encoding UTF8 | ConvertFrom-Json
+            $script:round3AntigravityStartedTaskId = [string]$started.task_id
+            return [pscustomobject]@{ Command = 'agy'; Arguments = @($Arguments); ExitCode = 0; Output = 'Synthetic Antigravity response.' }
+        }
+
+        $Rest = @('w1', '--task-json', $packetRef.RelativePath, '--task-id', $taskId, '--run-id', $attemptId, '--json', '--project-dir', $script:workersTempRoot)
+        $payload = (Invoke-WorkersExec | Select-Object -Last 1) | ConvertFrom-Json
+        $runPath = Join-Path $script:workersTempRoot ".winsmux\worker-runs\worker-1\$attemptId\run.json"
+        $run = Get-Content -LiteralPath $runPath -Raw -Encoding UTF8 | ConvertFrom-Json
+
+        $payload.status | Should -Be 'succeeded'
+        $payload.submission_id | Should -Be $attemptId
+        $payload.run_id | Should -Be $attemptId
+        $payload.task_id | Should -Be $taskId
+        $script:round3AntigravityStartedTaskId | Should -Be $taskId
+        $run.submission_id | Should -Be $attemptId
+        $run.run_id | Should -Be $attemptId
+        $run.task_id | Should -Be $taskId
+        Should -Invoke Invoke-WorkersAntigravityCli -Times 1 -Exactly
+    }
+
+    It 'ROUND3 P1 keeps stable task identity through the real colab_cli exec path with only the CLI call stubbed' {
+        Write-WorkersColabProjectConfig
+        New-WorkersFakeColabCli | Out-Null
+        New-Item -ItemType Directory -Path (Join-Path $script:workersTempRoot 'workers\colab') -Force | Out-Null
+        'print("round3")' | Set-Content -Path (Join-Path $script:workersTempRoot 'workers\colab\impl_worker.py') -Encoding UTF8
+        $taskId = 'task-round3-colab-stable'
+        $attemptId = 'attempt-round3-colab-1'
+        $packetRef = New-WinsmuxSubmissionPacket -ProjectDir $script:workersTempRoot -Kind task -Content ([ordered]@{ title = 'Synthetic Colab task'; request = 'Consume the Colab packet.' }) -SubmissionId $attemptId -TaskId $taskId -TargetLabel 'worker-2'
+        $script:round3ColabArguments = @()
+        $script:round3ColabPacket = $packetRef.Packet
+
+        Mock Invoke-WorkersColabCli {
+            param([string[]]$Arguments)
+            $script:round3ColabArguments = @($Arguments)
+            $workerOutput = [ordered]@{
+                status = 'succeeded'
+                worker_kind = 'implementation'
+                run_id = $attemptId
+                task = [ordered]@{ id = $taskId; title = [string]$script:round3ColabPacket.title }
+                request_digest = [string]$script:round3ColabPacket.request_digest
+            }
+            return [pscustomobject]@{ Command = 'google-colab-cli'; Arguments = @($Arguments); ExitCode = 0; Output = ($workerOutput | ConvertTo-Json -Compress -Depth 8) }
+        }
+
+        $Rest = @('w2', '--script', 'workers/colab/impl_worker.py', '--task-json', $packetRef.RelativePath, '--task-id', $taskId, '--run-id', $attemptId, '--json', '--project-dir', $script:workersTempRoot)
+        $payload = (Invoke-WorkersExec | Select-Object -Last 1) | ConvertFrom-Json
+        $taskIdIndex = [array]::IndexOf([object[]]$script:round3ColabArguments, '--task-id')
+        $runIdIndex = [array]::IndexOf([object[]]$script:round3ColabArguments, '--run-id')
+        $runPath = Join-Path $script:workersTempRoot ".winsmux\worker-runs\worker-2\$attemptId\run.json"
+        $run = Get-Content -LiteralPath $runPath -Raw -Encoding UTF8 | ConvertFrom-Json
+
+        $payload.status | Should -Be 'succeeded'
+        $payload.submission_id | Should -Be $attemptId
+        $payload.run_id | Should -Be $attemptId
+        $payload.task_id | Should -Be $taskId
+        $taskIdIndex | Should -BeGreaterOrEqual 0
+        $script:round3ColabArguments[$taskIdIndex + 1] | Should -Be $taskId
+        $runIdIndex | Should -BeGreaterOrEqual 0
+        $script:round3ColabArguments[$runIdIndex + 1] | Should -Be $attemptId
+        $run.submission_id | Should -Be $attemptId
+        $run.run_id | Should -Be $attemptId
+        $run.task_id | Should -Be $taskId
+        Should -Invoke Invoke-WorkersColabCli -Times 1 -Exactly
+    }
+
     It 'accepts task-json as the api_llm exec input contract' {
         Write-WorkersApiLlmProjectConfig
         '{"task_id":"api-task-json","title":"Summarize release state"}' | Set-Content -Path (Join-Path $script:workersTempRoot 'task.json') -Encoding UTF8
@@ -16768,6 +16880,148 @@ agent-slots:
         $accepted.status | Should -Be 'accepted'
         @($accepted.acknowledgement.Keys) | Should -Be @('type', 'protocol_version', 'status', 'submission_id', 'run_id', 'task_id', 'kind', 'backend', 'slot_id', 'worker_kind', 'request_digest')
         @($accepted.Keys) | Should -Be @('protocol_version', 'submission_id', 'kind', 'status', 'backend', 'reason_code', 'diagnostic', 'target', 'routing', 'acknowledgement')
+    }
+
+    It 'ROUND3 P1 forwards stable task and attempt identities through the default CLI adapter path' {
+        $taskId = 'task-round3-default-cli'
+        $attemptId = 'attempt-round3-default-cli-1'
+        $entry = [PSCustomObject]@{ Label = 'worker-3'; PaneId = ''; Role = 'Worker'; WorkerBackend = 'colab_cli' }
+        $script:round3BridgeArguments = @()
+
+        function global:pwsh {
+            $script:round3BridgeArguments = @($args)
+            $taskIdIndex = [array]::IndexOf([object[]]$script:round3BridgeArguments, '--task-id')
+            $runIdIndex = [array]::IndexOf([object[]]$script:round3BridgeArguments, '--run-id')
+            $packetIndex = [array]::IndexOf([object[]]$script:round3BridgeArguments, '--task-json')
+            $projectIndex = [array]::IndexOf([object[]]$script:round3BridgeArguments, '--project-dir')
+            $workersIndex = [array]::IndexOf([object[]]$script:round3BridgeArguments, 'workers')
+            $packet = Read-WinsmuxSubmissionPacket -Path (Join-Path $script:round3BridgeArguments[$projectIndex + 1] $script:round3BridgeArguments[$packetIndex + 1])
+            $record = New-WinsmuxSubmissionRunRecord -SubmissionId $script:round3BridgeArguments[$runIdIndex + 1] -RunId $script:round3BridgeArguments[$runIdIndex + 1] `
+                -TaskId $script:round3BridgeArguments[$taskIdIndex + 1] -Kind task -TaskTitle ([string]$packet.title) -SlotId $script:round3BridgeArguments[$workersIndex + 2] `
+                -Backend colab_cli -Status started -RequestConsumed -RequestDigest ([string]$packet.request_digest)
+            return ($record | ConvertTo-Json -Compress -Depth 12)
+        }
+
+        try {
+            $receipt = Invoke-WinsmuxSubmissionAdapter -ProjectDir $script:task780TempRoot -ManifestEntry $entry -Kind task -Content 'Default CLI identity forwarding' -SubmissionId $attemptId -TaskId $taskId
+        } finally {
+            Remove-Item function:\pwsh -ErrorAction SilentlyContinue
+        }
+
+        $taskIdIndex = [array]::IndexOf([object[]]$script:round3BridgeArguments, '--task-id')
+        $runIdIndex = [array]::IndexOf([object[]]$script:round3BridgeArguments, '--run-id')
+        $taskIdIndex | Should -BeGreaterOrEqual 0
+        $script:round3BridgeArguments[$taskIdIndex + 1] | Should -Be $taskId
+        $runIdIndex | Should -BeGreaterOrEqual 0
+        $script:round3BridgeArguments[$runIdIndex + 1] | Should -Be $attemptId
+        $receipt.status | Should -Be 'accepted'
+        $receipt.submission_id | Should -Be $attemptId
+        $receipt.acknowledgement.task_id | Should -Be $taskId
+    }
+
+    It 'ROUND3 P1 rejects duplicate attempts before rewriting the original submission packet' {
+        $taskId = 'task-round3-immutable-packet'
+        $attemptId = 'attempt-round3-immutable-packet-1'
+        $entry = [PSCustomObject]@{ Label = 'worker-3'; PaneId = ''; Role = 'Worker'; WorkerBackend = 'colab_cli' }
+        $firstContent = [ordered]@{ title = 'Original packet'; request = 'Keep this original request.' }
+        $firstAction = {
+            param($projectDir, $slotId, $packetPath, $runId, $backend, $kind)
+            $packet = Read-WinsmuxSubmissionPacket -Path (Join-Path $projectDir $packetPath)
+            $record = New-WinsmuxSubmissionRunRecord -SubmissionId $runId -RunId $runId -TaskId ([string]$packet.task_id) -Kind $kind -TaskTitle ([string]$packet.title) `
+                -SlotId $slotId -Backend $backend -Status failed -RequestConsumed -RequestDigest ([string]$packet.request_digest) -Reason 'runner_rejected_packet'
+            Write-WinsmuxSubmissionRunRecord -ProjectDir $projectDir -SlotId $slotId -Record $record | Out-Null
+            return $record
+        }
+
+        $first = Invoke-WinsmuxSubmissionAdapter -ProjectDir $script:task780TempRoot -ManifestEntry $entry -Kind task -Content $firstContent -SubmissionId $attemptId -TaskId $taskId -CliRunAction $firstAction
+        $packetPath = Join-Path $script:task780TempRoot ".winsmux\submissions\$attemptId.json"
+        $originalPacketText = Get-Content -LiteralPath $packetPath -Raw -Encoding UTF8
+        $originalPacket = $originalPacketText | ConvertFrom-Json
+
+        $duplicate = Invoke-WinsmuxSubmissionAdapter -ProjectDir $script:task780TempRoot -ManifestEntry $entry -Kind task -Content ([ordered]@{ title = 'Replacement packet'; request = 'This must not overwrite the original.' }) `
+            -SubmissionId $attemptId -TaskId $taskId -CliRunAction { throw 'duplicate attempt must stop before runner invocation' }
+        $packetAfterDuplicateText = Get-Content -LiteralPath $packetPath -Raw -Encoding UTF8
+        $packetAfterDuplicate = $packetAfterDuplicateText | ConvertFrom-Json
+
+        $first.reason_code | Should -Be 'runner_rejected_packet'
+        $duplicate.status | Should -Be 'rejected'
+        $duplicate.reason_code | Should -Be 'run_record_already_exists'
+        $packetAfterDuplicateText | Should -BeExactly $originalPacketText
+        $packetAfterDuplicate.request | Should -BeExactly $originalPacket.request
+        $packetAfterDuplicate.request_digest | Should -BeExactly $originalPacket.request_digest
+    }
+
+    It 'ROUND3 P1 exposes only the finite unavailable and rejected reason allowlists' {
+        $cases = @(
+            [ordered]@{ backend = 'antigravity'; status = 'blocked'; reason = 'antigravity_cli_missing'; receipt_status = 'unavailable'; expected = 'antigravity_cli_missing' },
+            [ordered]@{ backend = 'colab_cli'; status = 'unavailable'; reason = 'cli_command_missing'; receipt_status = 'unavailable'; expected = 'cli_command_missing' },
+            [ordered]@{ backend = 'colab_cli'; status = 'unavailable'; reason = 'sk_synthetic_secret_cli_missing'; receipt_status = 'unavailable'; expected = 'backend_unavailable' },
+            [ordered]@{ backend = 'colab_cli'; status = 'blocked'; reason = 'private_provider_payload_cli_missing'; receipt_status = 'unavailable'; expected = 'backend_unavailable' },
+            [ordered]@{ backend = 'colab_cli'; status = 'failed'; reason = 'runner_rejected_packet'; receipt_status = 'rejected'; expected = 'runner_rejected_packet' },
+            [ordered]@{ backend = 'colab_cli'; status = 'failed'; reason = 'private_provider_payload'; receipt_status = 'rejected'; expected = 'runner_evidence_invalid' }
+        )
+
+        $index = 0
+        foreach ($case in $cases) {
+            $index++
+            $entry = [PSCustomObject]@{ Label = 'worker-3'; PaneId = ''; Role = 'Worker'; WorkerBackend = $case.backend }
+            $runnerAction = {
+                param($projectDir, $slotId, $packetPath, $runId, $backend, $kind)
+                return [ordered]@{ status = $case.status; reason = $case.reason; exit_code = 1; run_id = $runId }
+            }
+            $receipt = Invoke-WinsmuxSubmissionAdapter -ProjectDir $script:task780TempRoot -ManifestEntry $entry -Kind task -Content 'Finite reason mapping' `
+                -SubmissionId "attempt-round3-reason-$index" -TaskId "task-round3-reason-$index" -CliRunAction $runnerAction
+            $json = ConvertTo-WinsmuxSubmissionReceiptJson -Receipt $receipt
+
+            $receipt.status | Should -Be $case.receipt_status
+            $receipt.reason_code | Should -Be $case.expected
+            $receipt.reason_code | Should -Match '^[a-z][a-z0-9_]*$'
+            $json | Should -Not -Match 'sk_synthetic_secret_cli_missing|private_provider_payload'
+        }
+    }
+
+    It 'ROUND3 P1 validates the complete public receipt shape for all four statuses' {
+        $submissionId = 'submission-round3-receipt-shape'
+        $record = New-WinsmuxSubmissionRunRecord -SubmissionId $submissionId -RunId $submissionId -TaskId 'task-round3-receipt-shape' -Kind task -TaskTitle 'Receipt shape' `
+            -SlotId worker-1 -Backend api_llm -Status started -RequestConsumed -RequestDigest ('d' * 64)
+        $statuses = @('accepted', 'rejected', 'unavailable', 'unsupported')
+
+        foreach ($status in $statuses) {
+            $receipt = if ($status -eq 'accepted') {
+                New-WinsmuxSubmissionReceipt -Kind task -Status accepted -Backend api_llm -SubmissionId $submissionId -Target ([ordered]@{ label = 'worker-1' }) -Acknowledgement $record
+            } else {
+                New-WinsmuxSubmissionReceipt -Kind task -Status $status -Backend api_llm -SubmissionId $submissionId -ReasonCode ($status + '_test')
+            }
+            (Test-WinsmuxSubmissionReceipt -Receipt $receipt) | Should -Be $true
+            { ConvertTo-WinsmuxSubmissionReceiptJson -Receipt $receipt } | Should -Not -Throw
+
+            $invalidReason = ($receipt | ConvertTo-Json -Depth 12 | ConvertFrom-Json -AsHashtable)
+            $invalidReason['reason_code'] = 'token=sk-synthetic-secret-value'
+            (Test-WinsmuxSubmissionReceipt -Receipt $invalidReason) | Should -Be $false
+            { ConvertTo-WinsmuxSubmissionReceiptJson -Receipt $invalidReason } | Should -Throw
+
+            $invalidDiagnostic = ($receipt | ConvertTo-Json -Depth 12 | ConvertFrom-Json -AsHashtable)
+            $invalidDiagnostic['diagnostic'] = 'token=sk-synthetic-secret-value'
+            (Test-WinsmuxSubmissionReceipt -Receipt $invalidDiagnostic) | Should -Be $false
+            { ConvertTo-WinsmuxSubmissionReceiptJson -Receipt $invalidDiagnostic } | Should -Throw
+
+            $missingAcknowledgement = ($receipt | ConvertTo-Json -Depth 12 | ConvertFrom-Json -AsHashtable)
+            $missingAcknowledgement.Remove('acknowledgement')
+            (Test-WinsmuxSubmissionReceipt -Receipt $missingAcknowledgement) | Should -Be $false
+            { ConvertTo-WinsmuxSubmissionReceiptJson -Receipt $missingAcknowledgement } | Should -Throw
+
+            $extraField = ($receipt | ConvertTo-Json -Depth 12 | ConvertFrom-Json -AsHashtable)
+            $extraField['provider_payload'] = 'private-provider-data'
+            (Test-WinsmuxSubmissionReceipt -Receipt $extraField) | Should -Be $false
+            { ConvertTo-WinsmuxSubmissionReceiptJson -Receipt $extraField } | Should -Throw
+
+            if ($status -ne 'accepted') {
+                $nonNullAcknowledgement = ($receipt | ConvertTo-Json -Depth 12 | ConvertFrom-Json -AsHashtable)
+                $nonNullAcknowledgement['acknowledgement'] = ConvertTo-WinsmuxPublicAcknowledgement -Acknowledgement $record
+                (Test-WinsmuxSubmissionReceipt -Receipt $nonNullAcknowledgement) | Should -Be $false
+                { ConvertTo-WinsmuxSubmissionReceiptJson -Receipt $nonNullAcknowledgement } | Should -Throw
+            }
+        }
     }
 }
 

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -12389,6 +12389,35 @@ worker-backend: colab_cli
         (Get-Content -LiteralPath $responsePath -Raw -Encoding UTF8) | Should -Not -Match 'test-openrouter-key'
     }
 
+    It 'persists a run-bound api_llm started record before the network call' {
+        Write-WorkersApiLlmProjectConfig
+        $submissionId = 'submission-api-start-order'
+        $packetRef = New-WinsmuxSubmissionPacket -ProjectDir $script:workersTempRoot -Kind task -Content ([ordered]@{ title = 'Synthetic API task'; request = 'Consume synthetic task input.' }) -SubmissionId $submissionId -TargetLabel 'worker-1'
+        $env:OPENROUTER_API_KEY = 'test-openrouter-key'
+        $script:apiLlmStatusAtNetworkCall = ''
+
+        Mock Invoke-RestMethod {
+            $runPath = Join-Path $script:workersTempRoot ".winsmux\worker-runs\worker-1\$submissionId\run.json"
+            $started = Get-Content -LiteralPath $runPath -Raw -Encoding UTF8 | ConvertFrom-Json
+            $script:apiLlmStatusAtNetworkCall = [string]$started.status
+            return [pscustomobject]@{
+                id = 'chatcmpl-synthetic-start-order'
+                choices = @([pscustomobject]@{ message = [pscustomobject]@{ content = 'Synthetic response.' } })
+                usage = [pscustomobject]@{ prompt_tokens = 1; completion_tokens = 1; total_tokens = 2 }
+            }
+        }
+
+        $Rest = @('w1', '--task-json', $packetRef.RelativePath, '--task-id', $submissionId, '--run-id', $submissionId, '--json', '--project-dir', $script:workersTempRoot)
+        $output = Invoke-WorkersExec
+        $payload = ($output | Select-Object -Last 1) | ConvertFrom-Json
+
+        $script:apiLlmStatusAtNetworkCall | Should -Be 'started'
+        $payload.status | Should -Be 'succeeded'
+        $payload.submission_id | Should -Be $submissionId
+        $payload.kind | Should -Be 'task'
+        $payload.request_consumed | Should -Be $true
+    }
+
     It 'accepts task-json as the api_llm exec input contract' {
         Write-WorkersApiLlmProjectConfig
         '{"task_id":"api-task-json","title":"Summarize release state"}' | Set-Content -Path (Join-Path $script:workersTempRoot 'task.json') -Encoding UTF8
@@ -12695,7 +12724,7 @@ worker-backend: colab_cli
     It 'redacts secrets and Drive paths from stored Colab logs and payload arguments' {
         $outsideLocalPath = 'D:\work\repo\secret.txt'
         $spacedLocalPath = 'C:\Users\Jane Doe\repo\secret.txt'
-        New-WorkersFakeColabCli -OutputLine 'fake-colab token=ghp_abcdefghijklmnopqrstuvwxyz123456 "Authorization":"Bearer abcdefghijklmnopqrstuvwxyz123456" /content/drive/MyDrive/private/model.bin C:\Users\Example\secret.txt D:\work\repo\secret.txt C:\Users\Jane Doe\repo\secret.txt %*' | Out-Null
+        New-WorkersFakeColabCli -OutputLine 'fake-colab token=ghp_abcdefghijklmnopqrstuvwxyz123456 "Authorization":"Bearer abcdefghijklmnopqrstuvwxyz123456" /content/drive/MyDrive/private/model.bin C:\Users\Example\secret.txt D:\work\repo\secret.txt C:\Users\Jane Doe\repo\secret.txt \\server\share\private.md /home/alice/private.txt %*' | Out-Null
         Write-WorkersColabProjectConfig
         New-Item -ItemType Directory -Path (Join-Path $script:workersTempRoot 'workers\colab') -Force | Out-Null
         'print("hello")' | Set-Content -Path (Join-Path $script:workersTempRoot 'workers\colab\task.py') -Encoding UTF8
@@ -12706,6 +12735,7 @@ worker-backend: colab_cli
         $logText = Get-Content -LiteralPath $logPath -Raw -Encoding UTF8
         $argumentText = @($payload.cli_arguments) -join ' '
         $outsideArgumentText = @(ConvertTo-WorkersSafeArgumentArray -Arguments @('run', '--script', $outsideLocalPath, '--output-dir', $spacedLocalPath)) -join ' '
+        $sharedPathText = ConvertTo-WorkersSafeLogText -Text '\\server\share\private.md /home/alice/private.txt'
 
         ($output | Out-String) | Should -Not -Match 'ghp_abcdefghijklmnopqrstuvwxyz123456'
         ($output | Out-String) | Should -Not -Match 'abcdefghijklmnopqrstuvwxyz123456'
@@ -12717,9 +12747,13 @@ worker-backend: colab_cli
         $logText | Should -Not -Match '/content/drive/MyDrive/private/model.bin'
         $logText | Should -Not -Match ([regex]::Escape($outsideLocalPath))
         $logText | Should -Not -Match 'Jane Doe'
+        $logText | Should -Not -Match '\\\\server\\share'
+        $logText | Should -Not -Match '/home/alice'
         $logText | Should -Not -Match ([regex]::Escape($script:workersTempRoot))
         $logText | Should -Match '\[REDACTED\]'
         $logText | Should -Match '\[DRIVE_PATH_REDACTED\]'
+        $sharedPathText | Should -Match '\[NETWORK_PATH_REDACTED\]'
+        $sharedPathText | Should -Match '\[UNIX_PATH_REDACTED\]'
         $logText | Should -Match '\[LOCAL_PATH_REDACTED\]'
         $argumentText | Should -Not -Match ([regex]::Escape($script:workersTempRoot))
         $argumentText | Should -Not -Match ([regex]::Escape($outsideLocalPath))
@@ -15944,7 +15978,8 @@ Describe 'winsmux dispatch-task routing' {
     }
 
     It 'validates only protocol-v1 submission receipts with the fixed vocabulary' {
-        $receipt = New-WinsmuxSubmissionReceipt -Kind task -Status accepted -Backend codex -SubmissionId 'submission-test-1'
+        $evidence = New-WinsmuxSubmissionRunRecord -SubmissionId 'submission-test-1' -RunId 'submission-test-1' -Kind task -TaskTitle 'Test task' -SlotId worker-1 -Backend codex -Status started -RequestConsumed
+        $receipt = New-WinsmuxSubmissionReceipt -Kind task -Status accepted -Backend codex -SubmissionId 'submission-test-1' -Target ([ordered]@{ label = 'worker-1' }) -Acknowledgement $evidence
 
         (Test-WinsmuxSubmissionReceipt -Receipt $receipt) | Should -Be $true
         $receipt.protocol_version = 2
@@ -15957,24 +15992,24 @@ Describe 'winsmux dispatch-task routing' {
         (Test-WinsmuxSubmissionReceipt -Receipt $receipt) | Should -Be $false
     }
 
-    It 'does not accept shell or Codex send success without a backend acknowledgement marker' {
+    It 'does not accept shell or Codex send success without a backend run record' {
         $entry = [PSCustomObject]@{ Label = 'worker-2'; PaneId = '%2'; Role = 'Worker'; WorkerBackend = 'codex' }
         $receipt = Invoke-WinsmuxSubmissionAdapter -ProjectDir 'C:\repo' -ManifestEntry $entry -Kind task -Content 'implement the focused change' -SubmissionId 'submission-test-2' `
             -SendAction { param($paneId, $commandText) } `
-            -CaptureAction { param($paneId) 'prompt returned without acknowledgement' }
+            -RunResultAction { param($projectDir, $slotId, $runId) $null }
 
         $receipt.status | Should -Be 'rejected'
         $receipt.reason_code | Should -Be 'backend_acknowledgement_missing'
     }
 
-    It 'accepts shell or Codex only after the backend acknowledgement marker' {
+    It 'accepts shell or Codex only after a matching backend run record' {
         $entry = [PSCustomObject]@{ Label = 'worker-2'; PaneId = '%2'; Role = 'Worker'; WorkerBackend = 'local' }
         $receipt = Invoke-WinsmuxSubmissionAdapter -ProjectDir 'C:\repo' -ManifestEntry $entry -Kind task -Content 'implement the focused change' -SubmissionId 'submission-test-3' `
             -SendAction { param($paneId, $commandText) } `
-            -CaptureAction { param($paneId) '[winsmux-submission-accepted:submission-test-3]' }
+            -RunResultAction { param($projectDir, $slotId, $runId) New-WinsmuxSubmissionRunRecord -SubmissionId $runId -RunId $runId -Kind task -TaskTitle 'Test task' -SlotId $slotId -Backend local -Status started -RequestConsumed }
 
         $receipt.status | Should -Be 'accepted'
-        $receipt.acknowledgement.type | Should -Be 'backend_marker'
+        $receipt.acknowledgement.type | Should -Be 'backend_run_record'
     }
 
     It 'sends api_llm an exec packet and converts runner refusal to typed rejected' {
@@ -15989,7 +16024,7 @@ Describe 'winsmux dispatch-task routing' {
 
             $receipt.status | Should -Be 'rejected'
             $receipt.reason_code | Should -Be 'runner_rejected_packet'
-            $script:apiLlmCommand | Should -Match '^exec \.winsmux[\\/]submissions[\\/]submission-test-4\.json submission-test-4 submission-test-4$'
+        $script:apiLlmCommand | Should -Match '^exec \.winsmux[\\/]submissions[\\/]submission-test-4\.json$'
             $script:apiLlmCommand | Should -Not -Match 'review synthetic change'
         } finally {
             Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
@@ -16017,10 +16052,10 @@ Describe 'winsmux dispatch-task routing' {
         try {
             $entry = [PSCustomObject]@{ Label = 'worker-3'; PaneId = '%3'; Role = 'Worker'; WorkerBackend = 'colab_cli' }
             $receipt = Invoke-WinsmuxSubmissionAdapter -ProjectDir $tempRoot -ManifestEntry $entry -Kind review -Content 'review synthetic input' -SubmissionId 'submission-test-7' `
-                -CliRunAction { param($projectDir, $slotId, $packetPath, $submissionId) [ordered]@{ status = 'started'; reason = ''; exit_code = 0; run_id = $submissionId } }
+                -CliRunAction { param($projectDir, $slotId, $packetPath, $submissionId) New-WinsmuxSubmissionRunRecord -SubmissionId $submissionId -RunId $submissionId -Kind review -TaskTitle 'Review test' -SlotId $slotId -Backend colab_cli -Status started -RequestConsumed }
 
             $receipt.status | Should -Be 'accepted'
-            $receipt.acknowledgement.type | Should -Be 'run_receipt'
+            $receipt.acknowledgement.type | Should -Be 'backend_run_record'
             $receipt.acknowledgement.run_id | Should -Be 'submission-test-7'
         } finally {
             Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
@@ -16048,14 +16083,349 @@ Describe 'winsmux dispatch-task routing' {
     }
 
     It 'returns typed router ownership context instead of free-text success' {
-        $route = [PSCustomObject]@{ SelectedRole = 'Operator'; SelectedTarget = $null; MatchedKeywords = @('commit'); Reason = 'operator owned'; HandleLocally = $true }
+        $route = [PSCustomObject]@{ SelectedRole = 'Operator'; SelectedTarget = $null; RuleId = 'route.operator_owned.v1'; MatchedKeywords = @('commit'); Reason = 'operator owned'; HandleLocally = $true }
         $receipt = New-WinsmuxRouterRefusalReceipt -Kind task -Route $route -SubmissionId 'submission-test-6'
 
         $receipt.status | Should -Be 'rejected'
         $receipt.reason_code | Should -Be 'router_operator_owned'
         $receipt.routing.expected_owner | Should -Be 'Operator'
-        $receipt.routing.matched_rule | Should -Be 'commit'
+        $receipt.routing.rule_id | Should -Be 'route.operator_owned.v1'
         $receipt.routing.next_shape | Should -Not -BeNullOrEmpty
+    }
+}
+
+Describe 'TASK-780 typed submission review fixes' {
+    BeforeAll {
+        $script:task780CorePath = Join-Path (Split-Path -Parent $PSScriptRoot) 'scripts\winsmux-core.ps1'
+        $script:task780ApiWorkerPath = Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\api-llm-pane-worker.ps1'
+        $script:task780RouterPath = Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\dispatch-router.ps1'
+        $script:task780RustMainPath = Join-Path (Split-Path -Parent $PSScriptRoot) 'core\src\main.rs'
+        . $script:task780CorePath 'version' *> $null
+        . $script:task780RouterPath
+    }
+
+    BeforeEach {
+        $script:task780TempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('winsmux-task780-review-' + [guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $script:task780TempRoot -Force | Out-Null
+    }
+
+    AfterEach {
+        if ($script:task780TempRoot -and (Test-Path -LiteralPath $script:task780TempRoot)) {
+            Remove-Item -LiteralPath $script:task780TempRoot -Recurse -Force
+        }
+    }
+
+    It 'P1 rejects pane input echo without a backend-owned run record' {
+        $entry = [PSCustomObject]@{ Label = 'worker-2'; PaneId = '%2'; Role = 'Worker'; WorkerBackend = 'codex' }
+        $script:echoedPrompt = ''
+        $receipt = Invoke-WinsmuxSubmissionAdapter -ProjectDir $script:task780TempRoot -ManifestEntry $entry -Kind task -Content 'synthetic implementation request' -SubmissionId 'submission-review-echo' `
+            -SendAction { param($paneId, $commandText) $script:echoedPrompt = $commandText; "sent to $paneId" } `
+            -CaptureAction { param($paneId) $script:echoedPrompt } `
+            -RunResultAction { param($projectDir, $slotId, $runId) $null }
+
+        $receipt.GetType().Name | Should -Not -Be 'Object[]'
+        $receipt.status | Should -Be 'rejected'
+        $receipt.reason_code | Should -Be 'backend_acknowledgement_missing'
+    }
+
+    It 'P1 rejects unsafe target labels before composing a pane command' {
+        $entry = [PSCustomObject]@{ Label = 'worker-1;Write-Output injected'; PaneId = '%2'; Role = 'Worker'; WorkerBackend = 'codex' }
+        $script:unsafeTargetSendCalled = $false
+        $receipt = Invoke-WinsmuxSubmissionAdapter -ProjectDir $script:task780TempRoot -ManifestEntry $entry -Kind task -Content 'synthetic request' -SubmissionId 'submission-unsafe-target' `
+            -SendAction { $script:unsafeTargetSendCalled = $true }
+
+        $receipt.status | Should -Be 'rejected'
+        $receipt.reason_code | Should -Be 'target_identifier_invalid'
+        $script:unsafeTargetSendCalled | Should -Be $false
+    }
+
+    It 'P1 validates accepted evidence type kind and matching submission and run ids' {
+        $missing = New-WinsmuxSubmissionReceipt -Kind task -Status accepted -Backend codex -SubmissionId 'submission-review-evidence'
+        (Test-WinsmuxSubmissionReceipt -Receipt $missing) | Should -Be $false
+
+        foreach ($evidence in @(
+            [ordered]@{ type = 'unknown'; submission_id = 'submission-review-evidence'; run_id = 'submission-review-evidence'; kind = 'task'; status = 'started'; backend_owned = $true; request_consumed = $true },
+            [ordered]@{ type = 'backend_run_record'; submission_id = 'other'; run_id = 'submission-review-evidence'; kind = 'task'; status = 'started'; backend_owned = $true; request_consumed = $true },
+            [ordered]@{ type = 'backend_run_record'; submission_id = 'submission-review-evidence'; run_id = 'other'; kind = 'task'; status = 'started'; backend_owned = $true; request_consumed = $true },
+            [ordered]@{ type = 'backend_run_record'; submission_id = 'submission-review-evidence'; run_id = 'submission-review-evidence'; kind = 'review'; status = 'started'; backend_owned = $true; request_consumed = $true }
+        )) {
+            $receipt = New-WinsmuxSubmissionReceipt -Kind task -Status accepted -Backend codex -SubmissionId 'submission-review-evidence' -Acknowledgement $evidence
+            (Test-WinsmuxSubmissionReceipt -Receipt $receipt) | Should -Be $false
+        }
+
+        $validEvidence = New-WinsmuxSubmissionRunRecord -SubmissionId 'submission-review-evidence' -RunId 'submission-review-evidence' -Kind task -TaskTitle 'Review evidence test' -SlotId worker-1 -Backend codex -Status started -RequestConsumed
+        $validReceipt = New-WinsmuxSubmissionReceipt -Kind task -Status accepted -Backend codex -SubmissionId 'submission-review-evidence' -Target ([ordered]@{ label = 'worker-1' }) -Acknowledgement $validEvidence
+        (Test-WinsmuxSubmissionReceipt -Receipt $validReceipt) | Should -Be $true
+        foreach ($evidenceMutation in @(
+            [ordered]@{ name = 'task_id'; value = 'other-task' },
+            [ordered]@{ name = 'task_title'; value = '' },
+            [ordered]@{ name = 'worker_kind'; value = 'critic' },
+            [ordered]@{ name = 'slot_id'; value = '../escape' },
+            [ordered]@{ name = 'slot_id'; value = 'worker-2' },
+            [ordered]@{ name = 'backend_owned'; value = 'false' },
+            [ordered]@{ name = 'request_consumed'; value = 'false' },
+            [ordered]@{ name = 'exit_code'; value = 1 },
+            [ordered]@{ name = 'exit_code'; value = '0' }
+        )) {
+            $invalidEvidence = New-WinsmuxSubmissionRunRecord -SubmissionId 'submission-review-evidence' -RunId 'submission-review-evidence' -Kind task -TaskTitle 'Review evidence test' -SlotId worker-1 -Backend codex -Status started -RequestConsumed
+            $invalidEvidence[$evidenceMutation.name] = $evidenceMutation.value
+            $invalidReceipt = New-WinsmuxSubmissionReceipt -Kind task -Status accepted -Backend codex -SubmissionId 'submission-review-evidence' -Target ([ordered]@{ label = 'worker-1' }) -Acknowledgement $invalidEvidence
+            (Test-WinsmuxSubmissionReceipt -Receipt $invalidReceipt) | Should -Be $false
+        }
+        foreach ($mutation in @(
+            { param($receipt) $receipt.protocol_version = 2 },
+            { param($receipt) $receipt.protocol_version = '1' },
+            { param($receipt) $receipt.status = 'complete' },
+            { param($receipt) $receipt.kind = 'unknown' },
+            { param($receipt) $receipt.submission_id = '' }
+        )) {
+            $invalid = New-WinsmuxSubmissionReceipt -Kind task -Status accepted -Backend codex -SubmissionId 'submission-review-evidence' -Target ([ordered]@{ label = 'worker-1' }) -Acknowledgement $validEvidence
+            & $mutation $invalid
+            (Test-WinsmuxSubmissionReceipt -Receipt $invalid) | Should -Be $false
+            { ConvertTo-WinsmuxSubmissionReceiptJson -Receipt $invalid } | Should -Throw
+        }
+    }
+
+    It 'P1 emits one packet schema whose real worker fields are top level and not double encoded' {
+        $packetRef = New-WinsmuxSubmissionPacket -ProjectDir $script:task780TempRoot -Kind review -Content ([ordered]@{
+            title = 'Review synthetic change'
+            request = 'Inspect the bounded diff.'
+            files = @('src/example.rs')
+            tests = @('cargo test synthetic')
+            branch = 'synthetic/review'
+            head_sha = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+        }) -SubmissionId 'submission-review-packet' -TargetLabel 'worker-3'
+        $packet = Get-Content -LiteralPath $packetRef.FullPath -Raw -Encoding UTF8 | ConvertFrom-Json
+
+        $packet.protocol_version | Should -Be 1
+        $packet.kind | Should -Be 'review'
+        $packet.run_id | Should -Be 'submission-review-packet'
+        $packet.title | Should -Be 'Review synthetic change'
+        @($packet.files) | Should -Be @('src/example.rs')
+        @($packet.tests) | Should -Be @('cargo test synthetic')
+        $packet.request | Should -Be 'Inspect the bounded diff.'
+        $packet.PSObject.Properties.Name | Should -Not -Contain 'content'
+    }
+
+    It 'P1 rejects malformed packet field types and mismatched ids before backend execution' {
+        $valid = New-WinsmuxSubmissionPacketData -Kind task -Content ([ordered]@{ title = 'Typed packet'; request = 'Consume typed input.' }) -SubmissionId 'submission-schema-check' -TargetLabel worker-1
+        (Test-WinsmuxSubmissionPacket -Packet $valid) | Should -Be $true
+
+        foreach ($mutation in @(
+            { param($packet) $packet.task_id = 'other-task' },
+            { param($packet) $packet.protocol_version = '1' },
+            { param($packet) $packet.target = @('worker-1') },
+            { param($packet) $packet.title = @('not-a-string') },
+            { param($packet) $packet.files = 'not-an-array' },
+            { param($packet) $packet.tests = @([ordered]@{ command = 'cargo test' }) },
+            { param($packet) $packet.branch = @('not-a-string') },
+            { param($packet) $packet.head_sha = 'not-a-sha' }
+        )) {
+            $candidate = New-WinsmuxSubmissionPacketData -Kind task -Content ([ordered]@{ title = 'Typed packet'; request = 'Consume typed input.' }) -SubmissionId 'submission-schema-check' -TargetLabel worker-1
+            & $mutation $candidate
+            (Test-WinsmuxSubmissionPacket -Packet $candidate) | Should -Be $false
+        }
+    }
+
+    It 'P1 binds local acknowledgement to packet target manifest backend and current pane' {
+        $manifestDir = Join-Path $script:task780TempRoot '.winsmux'
+        New-Item -ItemType Directory -Path $manifestDir -Force | Out-Null
+        [IO.File]::WriteAllText((Join-Path $manifestDir 'manifest.yaml'), @'
+version: 1
+session:
+  name: task780-test
+panes:
+  worker-1:
+    pane_id: "%2"
+    role: Worker
+    worker_backend: codex
+'@, [Text.UTF8Encoding]::new($false))
+        New-WinsmuxSubmissionPacket -ProjectDir $script:task780TempRoot -Kind task -Content ([ordered]@{ title = 'Ack target'; request = 'Acknowledge typed input.' }) -SubmissionId 'submission-ack-bound' -TargetLabel worker-1 | Out-Null
+        $previousPaneId = $env:WINSMUX_PANE_ID
+        try {
+            $env:WINSMUX_PANE_ID = '%2'
+            $record = Invoke-WinsmuxSubmissionAcknowledge -ProjectDir $script:task780TempRoot -SlotId worker-1 -SubmissionId 'submission-ack-bound' -RunId 'submission-ack-bound' -Kind task -Backend codex
+            $record.slot_id | Should -Be 'worker-1'
+
+            New-WinsmuxSubmissionPacket -ProjectDir $script:task780TempRoot -Kind task -Content ([ordered]@{ title = 'Wrong pane'; request = 'Reject wrong pane.' }) -SubmissionId 'submission-ack-wrong-pane' -TargetLabel worker-1 | Out-Null
+            $env:WINSMUX_PANE_ID = '%9'
+            { Invoke-WinsmuxSubmissionAcknowledge -ProjectDir $script:task780TempRoot -SlotId worker-1 -SubmissionId 'submission-ack-wrong-pane' -RunId 'submission-ack-wrong-pane' -Kind task -Backend codex } | Should -Throw '*caller does not match*'
+
+            $env:WINSMUX_PANE_ID = '%2'
+            { Invoke-WinsmuxSubmissionAcknowledge -ProjectDir $script:task780TempRoot -SlotId worker-1 -SubmissionId 'submission-ack-wrong-pane' -RunId 'submission-ack-wrong-pane' -Kind task -Backend local } | Should -Throw '*backend does not match*'
+        } finally {
+            $env:WINSMUX_PANE_ID = $previousPaneId
+        }
+    }
+
+    It 'P1 rejects a pre-existing run record instead of reusing it as acceptance' {
+        $entry = [PSCustomObject]@{ Label = 'worker-1'; PaneId = '%2'; Role = 'Worker'; WorkerBackend = 'codex' }
+        $stale = New-WinsmuxSubmissionRunRecord -SubmissionId 'submission-stale-run' -RunId 'submission-stale-run' -Kind task -TaskTitle 'Stale run' -SlotId worker-1 -Backend codex -Status started -RequestConsumed
+        Write-WinsmuxSubmissionRunRecord -ProjectDir $script:task780TempRoot -SlotId worker-1 -Record $stale | Out-Null
+        $script:staleRunSendCalled = $false
+        $receipt = Invoke-WinsmuxSubmissionAdapter -ProjectDir $script:task780TempRoot -ManifestEntry $entry -Kind task -Content 'new request' -SubmissionId 'submission-stale-run' `
+            -SendAction { $script:staleRunSendCalled = $true }
+
+        $receipt.status | Should -Be 'rejected'
+        $receipt.reason_code | Should -Be 'run_record_already_exists'
+        $script:staleRunSendCalled | Should -Be $false
+    }
+
+    It 'P1 feeds the same packet fields to the real Colab implementation and review parsers' {
+        $repoRoot = Split-Path -Parent $PSScriptRoot
+        foreach ($case in @(
+            [ordered]@{ kind = 'task'; script = 'workers\colab\impl_worker.py'; marker = 'src/synthetic.rs'; test = 'cargo test synthetic' },
+            [ordered]@{ kind = 'review'; script = 'workers\colab\critic_worker.py'; marker = 'src/review.rs'; test = 'cargo test review-synthetic' }
+        )) {
+            $submissionId = 'submission-real-parser-' + $case.kind
+            $packetRef = New-WinsmuxSubmissionPacket -ProjectDir $script:task780TempRoot -Kind $case.kind -Content ([ordered]@{
+                title = "Synthetic $($case.kind) request"
+                request = 'Consume the bounded synthetic request.'
+                files = @($case.marker)
+                tests = @($case.test)
+            }) -SubmissionId $submissionId -TargetLabel 'worker-3'
+            $artifactRoot = Join-Path $script:task780TempRoot ('artifacts-' + $case.kind)
+            $output = & python (Join-Path $repoRoot $case.script) --task-json $packetRef.FullPath --task-id $submissionId --run-id $submissionId --worker-id worker-3 --artifact-root $artifactRoot
+            $LASTEXITCODE | Should -Be 0
+            $payload = $output | ConvertFrom-Json
+            $payload.status | Should -Be 'succeeded'
+            $artifact = Get-Content -LiteralPath ([string]$payload.artifacts[0].path) -Raw -Encoding UTF8
+            $artifact | Should -Match ([regex]::Escape($case.marker))
+            $artifact | Should -Match ([regex]::Escape($case.test))
+        }
+    }
+
+    It 'P1 requires a durable api_llm started record before accepting a long execution' {
+        $evidence = New-WinsmuxSubmissionRunRecord -SubmissionId 'submission-review-api-start' -RunId 'submission-review-api-start' -Kind task -TaskTitle 'API start test' -SlotId worker-1 -Backend api_llm -Status started -RequestConsumed
+
+        $evidence.protocol_version | Should -Be 1
+        $evidence.status | Should -Be 'started'
+        $evidence.task_id | Should -Be 'submission-review-api-start'
+        $evidence.task_title | Should -Be 'API start test'
+        $evidence.worker_kind | Should -Be 'implementation'
+        $evidence.slot_id | Should -Be 'worker-1'
+        $evidence.backend_owned | Should -Be $true
+        $evidence.request_consumed | Should -Be $true
+    }
+
+    It 'P1 returns stable and internally consistent router reason codes' {
+        $noTargetRoute = Get-DispatchRoute -Text 'implement the bounded change' -AvailableTargets @()
+        $noTarget = New-WinsmuxRouterRefusalReceipt -Kind task -Route $noTargetRoute -SubmissionId 'submission-review-router-1'
+        $operatorRoute = Get-DispatchRoute -Text 'commit the release' -AvailableTargets @('builder-1')
+        $operator = New-WinsmuxRouterRefusalReceipt -Kind task -Route $operatorRoute -SubmissionId 'submission-review-router-2'
+
+        $noTarget.reason_code | Should -Be 'router_target_unavailable'
+        $noTarget.routing.expected_owner | Should -Be 'Builder'
+        $noTarget.routing.rule_id | Should -Be 'route.no_available_target.v1'
+        $operator.reason_code | Should -Be 'router_operator_owned'
+        $operator.routing.expected_owner | Should -Be 'Operator'
+        $operator.routing.rule_id | Should -Be 'route.operator_owned.v1'
+    }
+
+    It 'P2 sends api_llm REPL packets through task-json parsing rather than script parsing' {
+        $content = Get-Content -LiteralPath $script:task780ApiWorkerPath -Raw -Encoding UTF8
+
+        $content | Should -Match '@\(''workers'', ''exec'', \$slotId, ''--task-json'', \$packetPath'
+        $content | Should -Not -Match '@\(''workers'', ''exec'', \$slotId, ''--script'', \$scriptPath'
+        $content | Should -Match 'usage: exec <task-packet-path>'
+        $content | Should -Not -Match 'exec <task-packet-path> \[task-id\]'
+    }
+
+    It 'P2 routes a real api_llm REPL packet through workers exec and preserves review kind' {
+        @'
+agent: codex
+model: provider-default
+agent-slots:
+  - slot-id: worker-1
+    runtime-role: worker
+    worker-backend: api_llm
+    worker-role: reviewer
+    agent: openrouter
+    model: synthetic/model
+    model-source: operator-override
+    prompt-transport: file
+    auth-mode: api-key-env
+    worktree-mode: managed
+'@ | Set-Content -LiteralPath (Join-Path $script:task780TempRoot '.winsmux.yaml') -Encoding UTF8
+        New-Item -ItemType Directory -Path (Join-Path $script:task780TempRoot '.winsmux') -Force | Out-Null
+@'
+{
+  "version": 1,
+  "providers": {
+    "openrouter": {
+      "adapter": "openai-compatible",
+      "command": "openrouter",
+      "prompt_transports": ["file"],
+      "auth_modes": ["api-key-env"],
+      "model_sources": ["provider-default", "operator-override"],
+      "execution_backend": "openai-compatible-chat-completions",
+      "api_base_url": "https://openrouter.ai/api/v1",
+      "api_key_env": "TASK780_SYNTHETIC_MISSING_KEY",
+      "supports_structured_result": true
+    }
+  }
+}
+'@ | Set-Content -LiteralPath (Join-Path $script:task780TempRoot '.winsmux\provider-capabilities.json') -Encoding UTF8
+        $submissionId = 'submission-real-api-repl'
+        $packetRef = New-WinsmuxSubmissionPacket -ProjectDir $script:task780TempRoot -Kind review -Content ([ordered]@{ title = 'Synthetic API review'; request = 'Review synthetic input.' }) -SubmissionId $submissionId -TargetLabel 'worker-1'
+        $relativePacket = $packetRef.RelativePath
+        $inputLines = "exec $relativePacket`nquit`n"
+        $output = $inputLines | & pwsh -NoProfile -File $script:task780ApiWorkerPath -SlotId worker-1 -Provider openrouter -Model synthetic/model -ProjectDir $script:task780TempRoot 2>&1
+        $runPath = Join-Path $script:task780TempRoot ".winsmux\worker-runs\worker-1\$submissionId\run.json"
+        (Test-Path -LiteralPath $runPath -PathType Leaf) | Should -Be $true -Because ($output | Out-String)
+        $run = Get-Content -LiteralPath $runPath -Raw -Encoding UTF8 | ConvertFrom-Json
+
+        $outputText = $output | Out-String
+        $outputText | Should -Not -Match 'unknown command'
+        $run.protocol_version | Should -Be 1
+        $run.submission_id | Should -Be $submissionId
+        $run.kind | Should -Be 'review'
+        $run.request_consumed | Should -Be $true
+        $run.reason | Should -BeIn @('api_llm_api_key_env_missing', 'api_llm_runtime_config_invalid')
+    }
+
+    It 'P2 has no production environment-variable bypass around the shared bridge contract' {
+        $content = Get-Content -LiteralPath $script:task780RustMainPath -Raw -Encoding UTF8
+
+        $content | Should -Not -Match 'WINSMUX_DISABLE_CORE_BRIDGE'
+        $content | Should -Match 'dispatch-review'
+        $content | Should -Match 'dispatch-task'
+    }
+
+    It 'P2 returns a typed nonzero review refusal before manifest lookup can escape' {
+        $previousRole = $env:WINSMUX_ROLE
+        $previousPane = $env:WINSMUX_PANE_ID
+        $previousRoleMap = $env:WINSMUX_ROLE_MAP
+        try {
+            $env:WINSMUX_ROLE = 'Operator'
+            $env:WINSMUX_PANE_ID = '%1'
+            $env:WINSMUX_ROLE_MAP = '{"%1":"Operator"}'
+            Push-Location $script:task780TempRoot
+            $output = & pwsh -NoProfile -File $script:task780CorePath dispatch-review 2>&1
+            $exitCode = $LASTEXITCODE
+            Pop-Location
+
+            $receipt = @($output | ForEach-Object { [string]$_ } | Where-Object { $_.TrimStart().StartsWith('{') } | Select-Object -Last 1)[0] | ConvertFrom-Json
+            $exitCode | Should -Be 1
+            $receipt.protocol_version | Should -Be 1
+            $receipt.kind | Should -Be 'review'
+            $receipt.status | Should -Be 'unavailable'
+            $receipt.reason_code | Should -Be 'review_target_unavailable'
+        } finally {
+            if ((Get-Location).Path -eq $script:task780TempRoot) { Pop-Location }
+            $env:WINSMUX_ROLE = $previousRole
+            $env:WINSMUX_PANE_ID = $previousPane
+            $env:WINSMUX_ROLE_MAP = $previousRoleMap
+        }
+    }
+
+    It 'P2 redacts arbitrary Windows UNC and Unix absolute paths from diagnostics' {
+        $diagnostic = ConvertTo-WinsmuxSubmissionDiagnostic -Text 'D:\workspace\secret\file.txt C:\tmp\private.json \\server\share\private.md /home/alice/private.txt'
+
+        $diagnostic | Should -Not -Match 'D:\\workspace'
+        $diagnostic | Should -Not -Match 'C:\\tmp'
+        $diagnostic | Should -Not -Match '\\\\server\\share'
+        $diagnostic | Should -Not -Match '/home/alice'
     }
 }
 

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -15942,6 +15942,121 @@ Describe 'winsmux dispatch-task routing' {
         $targets.Count | Should -Be 0
         $route.HandleLocally | Should -Be $true
     }
+
+    It 'validates only protocol-v1 submission receipts with the fixed vocabulary' {
+        $receipt = New-WinsmuxSubmissionReceipt -Kind task -Status accepted -Backend codex -SubmissionId 'submission-test-1'
+
+        (Test-WinsmuxSubmissionReceipt -Receipt $receipt) | Should -Be $true
+        $receipt.protocol_version = 2
+        (Test-WinsmuxSubmissionReceipt -Receipt $receipt) | Should -Be $false
+        $receipt.protocol_version = 1
+        $receipt.status = 'complete'
+        (Test-WinsmuxSubmissionReceipt -Receipt $receipt) | Should -Be $false
+        $receipt.status = 'accepted'
+        $receipt.backend = 'unknown'
+        (Test-WinsmuxSubmissionReceipt -Receipt $receipt) | Should -Be $false
+    }
+
+    It 'does not accept shell or Codex send success without a backend acknowledgement marker' {
+        $entry = [PSCustomObject]@{ Label = 'worker-2'; PaneId = '%2'; Role = 'Worker'; WorkerBackend = 'codex' }
+        $receipt = Invoke-WinsmuxSubmissionAdapter -ProjectDir 'C:\repo' -ManifestEntry $entry -Kind task -Content 'implement the focused change' -SubmissionId 'submission-test-2' `
+            -SendAction { param($paneId, $commandText) } `
+            -CaptureAction { param($paneId) 'prompt returned without acknowledgement' }
+
+        $receipt.status | Should -Be 'rejected'
+        $receipt.reason_code | Should -Be 'backend_acknowledgement_missing'
+    }
+
+    It 'accepts shell or Codex only after the backend acknowledgement marker' {
+        $entry = [PSCustomObject]@{ Label = 'worker-2'; PaneId = '%2'; Role = 'Worker'; WorkerBackend = 'local' }
+        $receipt = Invoke-WinsmuxSubmissionAdapter -ProjectDir 'C:\repo' -ManifestEntry $entry -Kind task -Content 'implement the focused change' -SubmissionId 'submission-test-3' `
+            -SendAction { param($paneId, $commandText) } `
+            -CaptureAction { param($paneId) '[winsmux-submission-accepted:submission-test-3]' }
+
+        $receipt.status | Should -Be 'accepted'
+        $receipt.acknowledgement.type | Should -Be 'backend_marker'
+    }
+
+    It 'sends api_llm an exec packet and converts runner refusal to typed rejected' {
+        $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('winsmux-submission-' + [guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $tempRoot -Force | Out-Null
+        try {
+            $script:apiLlmCommand = ''
+            $entry = [PSCustomObject]@{ Label = 'worker-5'; PaneId = '%5'; Role = 'Worker'; WorkerBackend = 'api_llm' }
+            $receipt = Invoke-WinsmuxSubmissionAdapter -ProjectDir $tempRoot -ManifestEntry $entry -Kind review -Content 'review synthetic change' -SubmissionId 'submission-test-4' `
+                -SendAction { param($paneId, $commandText) $script:apiLlmCommand = $commandText } `
+                -RunResultAction { param($projectDir, $slotId, $runId) [ordered]@{ status = 'failed'; reason = 'runner_rejected_packet'; exit_code = 1; run_id = $runId } }
+
+            $receipt.status | Should -Be 'rejected'
+            $receipt.reason_code | Should -Be 'runner_rejected_packet'
+            $script:apiLlmCommand | Should -Match '^exec \.winsmux[\\/]submissions[\\/]submission-test-4\.json submission-test-4 submission-test-4$'
+            $script:apiLlmCommand | Should -Not -Match 'review synthetic change'
+        } finally {
+            Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'returns unavailable for a CLI backend without a runnable command' {
+        $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('winsmux-submission-' + [guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $tempRoot -Force | Out-Null
+        try {
+            $entry = [PSCustomObject]@{ Label = 'worker-3'; PaneId = '%3'; Role = 'Worker'; WorkerBackend = 'antigravity' }
+            $receipt = Invoke-WinsmuxSubmissionAdapter -ProjectDir $tempRoot -ManifestEntry $entry -Kind task -Content 'analyze synthetic input' -SubmissionId 'submission-test-5' `
+                -CliRunAction { param($projectDir, $slotId, $packetPath, $submissionId) [ordered]@{ status = 'unavailable'; reason = 'cli_command_missing'; exit_code = 1 } }
+
+            $receipt.status | Should -Be 'unavailable'
+            $receipt.reason_code | Should -Be 'cli_command_missing'
+        } finally {
+            Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'accepts a CLI backend only from a confirmed started or completed run receipt' {
+        $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('winsmux-submission-' + [guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $tempRoot -Force | Out-Null
+        try {
+            $entry = [PSCustomObject]@{ Label = 'worker-3'; PaneId = '%3'; Role = 'Worker'; WorkerBackend = 'colab_cli' }
+            $receipt = Invoke-WinsmuxSubmissionAdapter -ProjectDir $tempRoot -ManifestEntry $entry -Kind review -Content 'review synthetic input' -SubmissionId 'submission-test-7' `
+                -CliRunAction { param($projectDir, $slotId, $packetPath, $submissionId) [ordered]@{ status = 'started'; reason = ''; exit_code = 0; run_id = $submissionId } }
+
+            $receipt.status | Should -Be 'accepted'
+            $receipt.acknowledgement.type | Should -Be 'run_receipt'
+            $receipt.acknowledgement.run_id | Should -Be 'submission-test-7'
+        } finally {
+            Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'fails closed without a manifest or configured worker target' {
+        $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('winsmux-submission-' + [guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $tempRoot -Force | Out-Null
+        try {
+            Push-Location $tempRoot
+            $output = & pwsh -NoProfile -File $script:dispatchCorePath dispatch-task implement synthetic change 2>&1
+            $exitCode = $LASTEXITCODE
+            Pop-Location
+
+            $exitCode | Should -Be 1
+            $receipt = @($output | ForEach-Object { [string]$_ } | Where-Object { $_.TrimStart().StartsWith('{') } | Select-Object -Last 1)[0] | ConvertFrom-Json
+            $receipt.protocol_version | Should -Be 1
+            $receipt.status | Should -Be 'rejected'
+            $receipt.status | Should -Not -Be 'accepted'
+        } finally {
+            if ((Get-Location).Path -eq $tempRoot) { Pop-Location }
+            Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'returns typed router ownership context instead of free-text success' {
+        $route = [PSCustomObject]@{ SelectedRole = 'Operator'; SelectedTarget = $null; MatchedKeywords = @('commit'); Reason = 'operator owned'; HandleLocally = $true }
+        $receipt = New-WinsmuxRouterRefusalReceipt -Kind task -Route $route -SubmissionId 'submission-test-6'
+
+        $receipt.status | Should -Be 'rejected'
+        $receipt.reason_code | Should -Be 'router_operator_owned'
+        $receipt.routing.expected_owner | Should -Be 'Operator'
+        $receipt.routing.matched_rule | Should -Be 'commit'
+        $receipt.routing.next_shape | Should -Not -BeNullOrEmpty
+    }
 }
 
 Describe 'winsmux explain command' {

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -16212,12 +16212,13 @@ Describe 'TASK-780 typed submission review fixes' {
         $packet.PSObject.Properties.Name | Should -Not -Contain 'content'
     }
 
-    It 'P1 rejects malformed packet field types and mismatched ids before backend execution' {
+    It 'P1 rejects malformed packet field types and broken submission invariants before backend execution' {
         $valid = New-WinsmuxSubmissionPacketData -Kind task -Content ([ordered]@{ title = 'Typed packet'; request = 'Consume typed input.' }) -SubmissionId 'submission-schema-check' -TargetLabel worker-1
         (Test-WinsmuxSubmissionPacket -Packet $valid) | Should -Be $true
 
         foreach ($mutation in @(
-            { param($packet) $packet.task_id = 'other-task' },
+            { param($packet) $packet.run_id = 'other-run' },
+            { param($packet) $packet.task_id = 'invalid task id' },
             { param($packet) $packet.protocol_version = '1' },
             { param($packet) $packet.target = @('worker-1') },
             { param($packet) $packet.title = @('not-a-string') },
@@ -16465,9 +16466,6 @@ agent-slots:
         @($script:round2Manifest.tasks.in_progress).Count | Should -Be 0
         Assert-MockCalled Save-BuilderQueueManifest -Times 0 -Exactly
 
-        $request = New-BuilderQueueDispatchPrompt -Task 'Implement typed queue dispatch'
-        $packet = New-WinsmuxSubmissionPacket -ProjectDir $script:task780TempRoot -Kind task -Content $request -SubmissionId task-round2-queue -TargetLabel builder-1
-        $digest = [string]$packet.Packet.request_digest
         foreach ($mutation in @(
             [ordered]@{ name = 'backend_owned'; value = $false },
             [ordered]@{ name = 'request_consumed'; value = $false },
@@ -16475,20 +16473,26 @@ agent-slots:
             [ordered]@{ name = 'exit_code'; value = 1 },
             [ordered]@{ name = 'request_digest'; value = ('0' * 64) }
         )) {
-            $invalidEvidence = New-WinsmuxSubmissionRunRecord -SubmissionId task-round2-queue -RunId task-round2-queue -Kind task -TaskTitle 'Implement typed queue dispatch' -SlotId builder-1 -Backend api_llm -Status started -RequestConsumed -RequestDigest $digest
-            $invalidEvidence[$mutation.name] = $mutation.value
-            Write-WinsmuxSubmissionRunRecord -ProjectDir $script:task780TempRoot -SlotId builder-1 -Record $invalidEvidence | Out-Null
-            $invalidReceipt = New-WinsmuxSubmissionReceipt -Kind task -Status accepted -Backend api_llm -SubmissionId task-round2-queue -Target ([ordered]@{ label = 'builder-1' }) -Acknowledgement $invalidEvidence
-            $invalidOutcome = Dispatch-NextBuilderQueueTask -ProjectDir $script:task780TempRoot -BuilderLabel builder-1 -DispatchAction { $invalidReceipt }
+            $invalidOutcome = Dispatch-NextBuilderQueueTask -ProjectDir $script:task780TempRoot -BuilderLabel builder-1 -DispatchAction {
+                param($builderLabel, $task, $prompt, $stableTaskId, $attemptId)
+                $packet = New-WinsmuxSubmissionPacket -ProjectDir $script:task780TempRoot -Kind task -Content $prompt -SubmissionId $attemptId -TaskId $stableTaskId -TargetLabel $builderLabel
+                $invalidEvidence = New-WinsmuxSubmissionRunRecord -SubmissionId $attemptId -RunId $attemptId -TaskId $stableTaskId -Kind task -TaskTitle $task -SlotId $builderLabel -Backend api_llm -Status started -RequestConsumed -RequestDigest ([string]$packet.Packet.request_digest)
+                $invalidEvidence[$mutation.name] = $mutation.value
+                Write-WinsmuxSubmissionRunRecord -ProjectDir $script:task780TempRoot -SlotId $builderLabel -Record $invalidEvidence | Out-Null
+                return New-WinsmuxSubmissionReceipt -Kind task -Status accepted -Backend api_llm -SubmissionId $attemptId -Target ([ordered]@{ label = $builderLabel }) -Acknowledgement $invalidEvidence
+            }
             $invalidOutcome.Dispatched | Should -Be $false
             $invalidOutcome.Reason | Should -Be 'runner_evidence_invalid'
             Assert-MockCalled Save-BuilderQueueManifest -Times 0 -Exactly
         }
 
-        $evidence = New-WinsmuxSubmissionRunRecord -SubmissionId task-round2-queue -RunId task-round2-queue -Kind task -TaskTitle 'Implement typed queue dispatch' -SlotId builder-1 -Backend api_llm -Status started -RequestConsumed -RequestDigest $digest
-        Write-WinsmuxSubmissionRunRecord -ProjectDir $script:task780TempRoot -SlotId builder-1 -Record $evidence | Out-Null
-        $receipt = New-WinsmuxSubmissionReceipt -Kind task -Status accepted -Backend api_llm -SubmissionId task-round2-queue -Target ([ordered]@{ label = 'builder-1' }) -Acknowledgement $evidence
-        $acceptedOutcome = Dispatch-NextBuilderQueueTask -ProjectDir $script:task780TempRoot -BuilderLabel builder-1 -DispatchAction { $receipt }
+        $acceptedOutcome = Dispatch-NextBuilderQueueTask -ProjectDir $script:task780TempRoot -BuilderLabel builder-1 -DispatchAction {
+            param($builderLabel, $task, $prompt, $stableTaskId, $attemptId)
+            $packet = New-WinsmuxSubmissionPacket -ProjectDir $script:task780TempRoot -Kind task -Content $prompt -SubmissionId $attemptId -TaskId $stableTaskId -TargetLabel $builderLabel
+            $evidence = New-WinsmuxSubmissionRunRecord -SubmissionId $attemptId -RunId $attemptId -TaskId $stableTaskId -Kind task -TaskTitle $task -SlotId $builderLabel -Backend api_llm -Status started -RequestConsumed -RequestDigest ([string]$packet.Packet.request_digest)
+            Write-WinsmuxSubmissionRunRecord -ProjectDir $script:task780TempRoot -SlotId $builderLabel -Record $evidence | Out-Null
+            return New-WinsmuxSubmissionReceipt -Kind task -Status accepted -Backend api_llm -SubmissionId $attemptId -Target ([ordered]@{ label = $builderLabel }) -Acknowledgement $evidence
+        }
         $acceptedOutcome.Dispatched | Should -Be $true
         Assert-MockCalled Save-BuilderQueueManifest -Times 1 -Exactly -ParameterFilter {
             @($Manifest.tasks.queued).Count -eq 0 -and @($Manifest.tasks.in_progress).Count -eq 1
@@ -16559,7 +16563,7 @@ agent-slots:
         foreach ($secret in @('SECRET', 'task_title', 'project_dir', 'command', 'transcript', 'exception', 'provider_payload', 'C:\\', 'D:\\', '\\\\server', '/home', '/srv', '/mnt', '/root')) {
             $json | Should -Not -Match ([regex]::Escape($secret))
         }
-        @($receipt.acknowledgement.Keys) | Should -Be @('type', 'protocol_version', 'status', 'submission_id', 'run_id', 'kind', 'backend', 'slot_id', 'worker_kind', 'request_digest')
+        @($receipt.acknowledgement.Keys) | Should -Be @('type', 'protocol_version', 'status', 'submission_id', 'run_id', 'task_id', 'kind', 'backend', 'slot_id', 'worker_kind', 'request_digest')
     }
 
     It 'ROUND2 P2 refuses forged local or Codex pane identity until TASK-781 authority exists' {
@@ -16618,6 +16622,152 @@ agent-slots:
         @($saved.tasks.queued).Count | Should -Be 1
         @($saved.tasks.in_progress).Count | Should -Be 0
         @(Get-DispatchLedger -ProjectDir $script:task780TempRoot).Count | Should -Be 0
+    }
+
+    It 'ROUND3 P1 retries a queued task with a fresh real submission attempt while preserving task identity' {
+        $queueTaskId = 'task-round3-retry'
+        $manifest = New-WinsmuxManifest -ProjectDir $script:task780TempRoot
+        $manifest.panes['builder-1'] = [PSCustomObject]@{ pane_id = '%2'; role = 'Builder'; worker_backend = 'colab_cli' }
+        $manifest.tasks.queued = @(ConvertTo-BuilderQueueEntry -BuilderLabel builder-1 -Task 'Retry typed queue dispatch' -TaskId $queueTaskId)
+        Save-WinsmuxManifest -ProjectDir $script:task780TempRoot -Manifest $manifest
+
+        $script:round3AttemptIds = [System.Collections.Generic.List[string]]::new()
+        $script:round3DispatchCount = 0
+        $dispatchAction = {
+            param($builderLabel, $task, $prompt, $stableTaskId, $attemptId)
+            $script:round3DispatchCount++
+            if ([string]::IsNullOrWhiteSpace([string]$stableTaskId)) { $stableTaskId = $queueTaskId }
+            if ([string]::IsNullOrWhiteSpace([string]$attemptId)) { $attemptId = $stableTaskId }
+            $script:round3AttemptIds.Add([string]$attemptId) | Out-Null
+            $entry = [PSCustomObject]@{ Label = $builderLabel; PaneId = ''; Role = 'Builder'; WorkerBackend = 'colab_cli' }
+            $cliAction = {
+                param($projectDir, $slotId, $packetPath, $submissionId, $backend, $kind)
+                $packet = Read-WinsmuxSubmissionPacket -Path (Join-Path $projectDir $packetPath)
+                $accepted = $script:round3DispatchCount -gt 1
+                $record = [ordered]@{
+                    protocol_version = 1; type = 'backend_run_record'; submission_id = $submissionId; run_id = $submissionId
+                    kind = $kind; task_id = [string]$packet.task_id; task_title = [string]$packet.title; worker_kind = 'implementation'
+                    slot_id = $slotId; backend = $backend; status = if ($accepted) { 'started' } else { 'failed' }
+                    backend_owned = $true; request_consumed = $true; request_digest = [string]$packet.request_digest
+                    reason = if ($accepted) { '' } else { 'runner_rejected_packet' }; exit_code = if ($accepted) { 0 } else { 1 }
+                    generated_at = (Get-Date).ToUniversalTime().ToString('o')
+                }
+                Write-WinsmuxSubmissionRunRecord -ProjectDir $projectDir -SlotId $slotId -Record $record | Out-Null
+                return Get-Content -LiteralPath (Get-WinsmuxSubmissionRunPath -ProjectDir $projectDir -SlotId $slotId -RunId $submissionId) -Raw -Encoding UTF8 | ConvertFrom-Json -Depth 16
+            }
+            $adapterParameters = @{
+                ProjectDir = $script:task780TempRoot; ManifestEntry = $entry; Kind = 'task'; Content = $prompt
+                SubmissionId = $attemptId; CliRunAction = $cliAction
+            }
+            if ((Get-Command Invoke-WinsmuxSubmissionAdapter).Parameters.ContainsKey('TaskId')) {
+                $adapterParameters['TaskId'] = $stableTaskId
+            }
+            return Invoke-WinsmuxSubmissionAdapter @adapterParameters
+        }
+
+        $first = Dispatch-NextBuilderQueueTask -ProjectDir $script:task780TempRoot -BuilderLabel builder-1 -DispatchAction $dispatchAction
+        $afterFirst = Get-WinsmuxManifest -ProjectDir $script:task780TempRoot
+        $first.Dispatched | Should -Be $false
+        $first.DispatchResult.status | Should -Be 'rejected'
+        $first.DispatchResult.reason_code | Should -Be 'runner_rejected_packet'
+        @($afterFirst.tasks.queued).Count | Should -Be 1
+        @($afterFirst.tasks.in_progress).Count | Should -Be 0
+
+        $second = Dispatch-NextBuilderQueueTask -ProjectDir $script:task780TempRoot -BuilderLabel builder-1 -DispatchAction $dispatchAction
+        $afterSecond = Get-WinsmuxManifest -ProjectDir $script:task780TempRoot
+        $second.Dispatched | Should -Be $true
+        $second.DispatchResult.status | Should -Be 'accepted'
+        $script:round3AttemptIds.Count | Should -Be 2
+        $script:round3AttemptIds[0] | Should -Not -Be $script:round3AttemptIds[1]
+        $second.DispatchResult.submission_id | Should -Be $script:round3AttemptIds[1]
+        $second.DispatchResult.acknowledgement.task_id | Should -Be $queueTaskId
+        @($afterSecond.tasks.queued).Count | Should -Be 0
+        @($afterSecond.tasks.in_progress).Count | Should -Be 1
+
+        foreach ($attemptId in @($script:round3AttemptIds)) {
+            $packet = Read-WinsmuxSubmissionPacket -Path (Join-Path $script:task780TempRoot ".winsmux\submissions\$attemptId.json")
+            $run = Get-Content -LiteralPath (Get-WinsmuxSubmissionRunPath -ProjectDir $script:task780TempRoot -SlotId builder-1 -RunId $attemptId) -Raw -Encoding UTF8 | ConvertFrom-Json -Depth 16
+            $packet.submission_id | Should -Be $attemptId
+            $packet.run_id | Should -Be $attemptId
+            $packet.task_id | Should -Be $queueTaskId
+            $run.submission_id | Should -Be $attemptId
+            $run.run_id | Should -Be $attemptId
+            $run.task_id | Should -Be $queueTaskId
+        }
+
+        $duplicateEntry = [PSCustomObject]@{ Label = 'builder-1'; PaneId = ''; Role = 'Builder'; WorkerBackend = 'colab_cli' }
+        $duplicate = Invoke-WinsmuxSubmissionAdapter -ProjectDir $script:task780TempRoot -ManifestEntry $duplicateEntry -Kind task -Content 'Retry typed queue dispatch' `
+            -SubmissionId $script:round3AttemptIds[1] -TaskId $queueTaskId -CliRunAction { throw 'duplicate attempt must stop before runner invocation' }
+        $duplicate.status | Should -Be 'rejected'
+        $duplicate.reason_code | Should -Be 'run_record_already_exists'
+        (ConvertTo-WinsmuxSubmissionReceiptJson -Receipt $second.DispatchResult) | Should -Not -Match 'Retry typed queue dispatch'
+    }
+
+    It 'ROUND3 P1 maps real runner reasons to stable public codes without leaking untrusted text' {
+        $entry = [PSCustomObject]@{ Label = 'worker-3'; PaneId = ''; Role = 'Worker'; WorkerBackend = 'colab_cli' }
+        $knownCases = @(
+            [ordered]@{ status = 'unavailable'; reason = 'cli_command_missing'; expected = 'cli_command_missing' },
+            [ordered]@{ status = 'failed'; reason = 'runner_rejected_packet'; expected = 'runner_rejected_packet' }
+        )
+        $caseIndex = 0
+        foreach ($case in $knownCases) {
+            $caseIndex++
+            $submissionId = "submission-round3-known-$caseIndex"
+            $cliAction = {
+                param($projectDir, $slotId, $packetPath, $runId, $backend, $kind)
+                $record = [ordered]@{ status = $case.status; reason = $case.reason; exit_code = 1; run_id = $runId }
+                Write-WinsmuxSubmissionRunRecord -ProjectDir $projectDir -SlotId $slotId -Record $record | Out-Null
+                return Get-Content -LiteralPath (Get-WinsmuxSubmissionRunPath -ProjectDir $projectDir -SlotId $slotId -RunId $runId) -Raw -Encoding UTF8 | ConvertFrom-Json -Depth 16
+            }
+            $receipt = Invoke-WinsmuxSubmissionAdapter -ProjectDir $script:task780TempRoot -ManifestEntry $entry -Kind task -Content 'Known reason mapping' -SubmissionId $submissionId -CliRunAction $cliAction
+            $receipt.reason_code | Should -Be $case.expected
+            $receipt.reason_code | Should -Match '^[a-z][a-z0-9_]*$'
+        }
+
+        $unsafeReasons = @(
+            'key=sk-synthetic-leak-value',
+            'C:\Users\LeakSubject\private.txt',
+            '\\secret-host\private-share\payload.json',
+            '/home/leaksubject/private.txt',
+            '{"provider":"private-payload"}',
+            "provider failure`nprivate second line",
+            ('control' + [char]1 + 'private')
+        )
+        $unsafeIndex = 0
+        foreach ($unsafeReason in $unsafeReasons) {
+            $unsafeIndex++
+            $submissionId = "submission-round3-unsafe-$unsafeIndex"
+            $cliAction = {
+                param($projectDir, $slotId, $packetPath, $runId, $backend, $kind)
+                $record = [ordered]@{ status = 'failed'; reason = $unsafeReason; exit_code = 1; run_id = $runId }
+                Write-WinsmuxSubmissionRunRecord -ProjectDir $projectDir -SlotId $slotId -Record $record | Out-Null
+                return Get-Content -LiteralPath (Get-WinsmuxSubmissionRunPath -ProjectDir $projectDir -SlotId $slotId -RunId $runId) -Raw -Encoding UTF8 | ConvertFrom-Json -Depth 16
+            }
+            $receipt = Invoke-WinsmuxSubmissionAdapter -ProjectDir $script:task780TempRoot -ManifestEntry $entry -Kind task -Content 'Unsafe reason mapping' -SubmissionId $submissionId -CliRunAction $cliAction
+            $json = ConvertTo-WinsmuxSubmissionReceiptJson -Receipt $receipt
+            $receipt.status | Should -Be 'rejected'
+            $receipt.reason_code | Should -Be 'runner_evidence_invalid'
+            $receipt.reason_code | Should -Match '^[a-z][a-z0-9_]*$'
+            $receipt.reason_code | Should -Not -Match '[\s/\\{}=:]'
+            $receipt.diagnostic | Should -Be ''
+            $receipt.acknowledgement | Should -BeNullOrEmpty
+            foreach ($privateMarker in @('sk-synthetic-leak-value', 'LeakSubject', 'secret-host', 'leaksubject', 'private-payload', 'private second line', 'control')) {
+                $json | Should -Not -Match ([regex]::Escape($privateMarker))
+            }
+        }
+
+        $acceptedId = 'submission-round3-public-ack'
+        $acceptedAction = {
+            param($projectDir, $slotId, $packetPath, $runId, $backend, $kind)
+            $packet = Read-WinsmuxSubmissionPacket -Path (Join-Path $projectDir $packetPath)
+            $record = New-WinsmuxSubmissionRunRecord -SubmissionId $runId -RunId $runId -TaskId ([string]$packet.task_id) -Kind $kind -TaskTitle 'Public acknowledgement' -SlotId $slotId -Backend $backend -Status started -RequestConsumed -RequestDigest ([string]$packet.request_digest)
+            Write-WinsmuxSubmissionRunRecord -ProjectDir $projectDir -SlotId $slotId -Record $record | Out-Null
+            return Get-Content -LiteralPath (Get-WinsmuxSubmissionRunPath -ProjectDir $projectDir -SlotId $slotId -RunId $runId) -Raw -Encoding UTF8 | ConvertFrom-Json -Depth 16
+        }
+        $accepted = Invoke-WinsmuxSubmissionAdapter -ProjectDir $script:task780TempRoot -ManifestEntry $entry -Kind task -Content 'Public acknowledgement allowlist' -SubmissionId $acceptedId -TaskId task-round3-public -CliRunAction $acceptedAction
+        $accepted.status | Should -Be 'accepted'
+        @($accepted.acknowledgement.Keys) | Should -Be @('type', 'protocol_version', 'status', 'submission_id', 'run_id', 'task_id', 'kind', 'backend', 'slot_id', 'worker_kind', 'request_digest')
+        @($accepted.Keys) | Should -Be @('protocol_version', 'submission_id', 'kind', 'status', 'backend', 'reason_code', 'diagnostic', 'target', 'routing', 'acknowledgement')
     }
 }
 

--- a/winsmux-core/scripts/api-llm-pane-worker.ps1
+++ b/winsmux-core/scripts/api-llm-pane-worker.ps1
@@ -41,21 +41,13 @@ function Write-ApiLlmPanePrompt {
 function Invoke-ApiLlmPaneExec {
     param([Parameter(Mandatory = $true)][string[]]$Tokens)
 
-    if ($Tokens.Count -lt 1) {
-        Write-Host 'usage: exec <task-packet-path> [task-id] [run-id]'
+    if ($Tokens.Count -ne 1) {
+        Write-Host 'usage: exec <task-packet-path>'
         return
     }
 
-    $scriptPath = $Tokens[0]
-    $taskId = if ($Tokens.Count -ge 2) { $Tokens[1] } else { '' }
-    $runId = if ($Tokens.Count -ge 3) { $Tokens[2] } else { '' }
-    $args = @('workers', 'exec', $slotId, '--script', $scriptPath, '--json', '--project-dir', $projectRoot)
-    if (-not [string]::IsNullOrWhiteSpace($taskId)) {
-        $args += @('--task-id', $taskId)
-    }
-    if (-not [string]::IsNullOrWhiteSpace($runId)) {
-        $args += @('--run-id', $runId)
-    }
+    $packetPath = $Tokens[0]
+    $args = @('workers', 'exec', $slotId, '--task-json', $packetPath, '--json', '--project-dir', $projectRoot)
 
     & $coreScript @args
 }
@@ -66,7 +58,7 @@ Write-Host ("provider: {0}" -f $(if ([string]::IsNullOrWhiteSpace($Provider)) { 
 Write-Host ("model: {0}" -f $(if ([string]::IsNullOrWhiteSpace($Model)) { 'provider-default' } else { $Model }))
 Write-Host ("project: {0}" -f $projectRoot)
 Write-Host 'status: ready'
-Write-Host 'commands: exec <task-packet-path> [task-id] [run-id], status, help, quit'
+Write-Host 'commands: exec <task-packet-path>, status, help, quit'
 
 while ($true) {
     Write-ApiLlmPanePrompt
@@ -90,8 +82,8 @@ while ($true) {
     }
 
     if ($trimmed -eq 'help') {
-        Write-Host 'exec <task-packet-path> [task-id] [run-id]'
-        Write-Host 'Example: exec tasks/cli-bakeoff/v1/WB-010-openrouter-api-worker-readiness.md WB-010 v03617-w5-wb010'
+        Write-Host 'exec <task-packet-path>'
+        Write-Host 'Example: exec .winsmux/submissions/submission-123.json'
         continue
     }
 

--- a/winsmux-core/scripts/builder-queue.ps1
+++ b/winsmux-core/scripts/builder-queue.ps1
@@ -433,15 +433,16 @@ function Invoke-BuilderQueueDispatch {
         [Parameter(Mandatory = $true)][string]$ProjectDir,
         [Parameter(Mandatory = $true)][string]$BuilderLabel,
         [Parameter(Mandatory = $true)][string]$Task,
+        [Parameter(Mandatory = $true)][string]$AttemptId,
         [Parameter(Mandatory = $true)][string]$Prompt
     )
 
     $manifestEntry = @(Get-PaneControlManifestEntries -ProjectDir $ProjectDir | Where-Object { [string]$_.Label -ceq $BuilderLabel } | Select-Object -First 1)[0]
     if ($null -eq $manifestEntry) {
-        return New-WinsmuxSubmissionReceipt -Kind task -Status unavailable -Backend noop -SubmissionId $Task `
+        return New-WinsmuxSubmissionReceipt -Kind task -Status unavailable -Backend noop -SubmissionId $AttemptId `
             -ReasonCode 'target_manifest_missing' -Target ([ordered]@{ label = $BuilderLabel })
     }
-    return Invoke-WinsmuxSubmissionAdapter -ProjectDir $ProjectDir -ManifestEntry $manifestEntry -Kind task -Content $Prompt -SubmissionId $Task
+    return Invoke-WinsmuxSubmissionAdapter -ProjectDir $ProjectDir -ManifestEntry $manifestEntry -Kind task -Content $Prompt -SubmissionId $AttemptId -TaskId $Task
 }
 
 function Test-BuilderQueueDispatchEvidence {
@@ -449,19 +450,20 @@ function Test-BuilderQueueDispatchEvidence {
         [Parameter(Mandatory = $true)][string]$ProjectDir,
         [Parameter(Mandatory = $true)][string]$BuilderLabel,
         [Parameter(Mandatory = $true)][string]$TaskId,
+        [Parameter(Mandatory = $true)][string]$AttemptId,
         [Parameter(Mandatory = $true)]$Receipt
     )
 
     $target = Get-WinsmuxSubmissionValue -InputObject $Receipt -Name 'target' -Default $null
     if (
-        [string](Get-WinsmuxSubmissionValue -InputObject $Receipt -Name 'submission_id' -Default '') -cne $TaskId -or
+        [string](Get-WinsmuxSubmissionValue -InputObject $Receipt -Name 'submission_id' -Default '') -cne $AttemptId -or
         [string](Get-WinsmuxSubmissionValue -InputObject $Receipt -Name 'kind' -Default '') -cne 'task' -or
         [string](Get-WinsmuxSubmissionValue -InputObject $target -Name 'label' -Default '') -cne $BuilderLabel
     ) {
         return $false
     }
-    $packetPath = Join-Path (Join-Path (Join-Path $ProjectDir '.winsmux') 'submissions') ($TaskId + '.json')
-    $runPath = Get-WinsmuxSubmissionRunPath -ProjectDir $ProjectDir -SlotId $BuilderLabel -RunId $TaskId
+    $packetPath = Join-Path (Join-Path (Join-Path $ProjectDir '.winsmux') 'submissions') ($AttemptId + '.json')
+    $runPath = Get-WinsmuxSubmissionRunPath -ProjectDir $ProjectDir -SlotId $BuilderLabel -RunId $AttemptId
     if (-not (Test-Path -LiteralPath $packetPath -PathType Leaf) -or -not (Test-Path -LiteralPath $runPath -PathType Leaf)) {
         return $false
     }
@@ -472,16 +474,16 @@ function Test-BuilderQueueDispatchEvidence {
         return $false
     }
     if (
-        [string]$packet.submission_id -cne $TaskId -or
-        [string]$packet.run_id -cne $TaskId -or
+        [string]$packet.submission_id -cne $AttemptId -or
+        [string]$packet.run_id -cne $AttemptId -or
         [string]$packet.task_id -cne $TaskId -or
         [string]$packet.kind -cne 'task' -or
         [string]$packet.target -cne $BuilderLabel
     ) {
         return $false
     }
-    return Test-WinsmuxSubmissionRunRecord -Record $runRecord -SubmissionId $TaskId -Kind task `
-        -Backend ([string](Get-WinsmuxSubmissionValue -InputObject $Receipt -Name 'backend' -Default '')) -ExpectedSlotId $BuilderLabel -ExpectedRequestDigest ([string]$packet.request_digest)
+    return Test-WinsmuxSubmissionRunRecord -Record $runRecord -SubmissionId $AttemptId -Kind task `
+        -Backend ([string](Get-WinsmuxSubmissionValue -InputObject $Receipt -Name 'backend' -Default '')) -ExpectedSlotId $BuilderLabel -ExpectedRequestDigest ([string]$packet.request_digest) -ExpectedTaskId $TaskId
 }
 
 function Dispatch-NextBuilderQueueTask {
@@ -515,6 +517,7 @@ function Dispatch-NextBuilderQueueTask {
     }
 
     $nextEntry = $queued[0]
+    $attemptId = 'attempt-' + [guid]::NewGuid().ToString('N')
     $dispatchFiles = @(Get-BuilderQueueTaskFiles -ProjectDir $ProjectDir -Task $nextEntry.Task)
     $locked = Lock-DispatchFiles -TaskId $nextEntry.TaskId -BuilderLabel $BuilderLabel -Files $dispatchFiles -ProjectDir $ProjectDir
     if (-not $locked) {
@@ -531,9 +534,9 @@ function Dispatch-NextBuilderQueueTask {
     $prompt = New-BuilderQueueDispatchPrompt -Task $nextEntry.Task
     try {
         $dispatchResult = if ($null -ne $DispatchAction) {
-            & $DispatchAction $BuilderLabel $nextEntry.Task $prompt
+            & $DispatchAction $BuilderLabel $nextEntry.Task $prompt $nextEntry.TaskId $attemptId
         } else {
-            Invoke-BuilderQueueDispatch -ProjectDir $ProjectDir -BuilderLabel $BuilderLabel -Task $nextEntry.TaskId -Prompt $prompt
+            Invoke-BuilderQueueDispatch -ProjectDir $ProjectDir -BuilderLabel $BuilderLabel -Task $nextEntry.TaskId -AttemptId $attemptId -Prompt $prompt
         }
     } catch {
         Unlock-DispatchFiles -TaskId $nextEntry.TaskId -ProjectDir $ProjectDir | Out-Null
@@ -542,7 +545,7 @@ function Dispatch-NextBuilderQueueTask {
 
     $receiptValid = Test-WinsmuxSubmissionReceipt -Receipt $dispatchResult
     $accepted = $receiptValid -and [string]$dispatchResult.status -ceq 'accepted'
-    $evidenceValid = $accepted -and (Test-BuilderQueueDispatchEvidence -ProjectDir $ProjectDir -BuilderLabel $BuilderLabel -TaskId $nextEntry.TaskId -Receipt $dispatchResult)
+    $evidenceValid = $accepted -and (Test-BuilderQueueDispatchEvidence -ProjectDir $ProjectDir -BuilderLabel $BuilderLabel -TaskId $nextEntry.TaskId -AttemptId $attemptId -Receipt $dispatchResult)
     if (-not $accepted -or -not $evidenceValid) {
         Unlock-DispatchFiles -TaskId $nextEntry.TaskId -ProjectDir $ProjectDir | Out-Null
         $reason = if (-not $accepted -and $receiptValid -and -not [string]::IsNullOrWhiteSpace([string]$dispatchResult.reason_code)) {

--- a/winsmux-core/scripts/builder-queue.ps1
+++ b/winsmux-core/scripts/builder-queue.ps1
@@ -14,6 +14,7 @@ Set-StrictMode -Version Latest
 
 . (Join-Path $PSScriptRoot 'manifest.ps1')
 . (Join-Path $PSScriptRoot 'clm-safe-io.ps1')
+. (Join-Path $PSScriptRoot 'submission-contract.ps1')
 $script:BuilderQueuePaneControlScript = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot 'pane-control.ps1'))
 if (Test-Path $script:BuilderQueuePaneControlScript -PathType Leaf) {
     . $script:BuilderQueuePaneControlScript
@@ -429,33 +430,58 @@ STATUS: BLOCKED
 
 function Invoke-BuilderQueueDispatch {
     param(
+        [Parameter(Mandatory = $true)][string]$ProjectDir,
         [Parameter(Mandatory = $true)][string]$BuilderLabel,
         [Parameter(Mandatory = $true)][string]$Task,
         [Parameter(Mandatory = $true)][string]$Prompt
     )
 
-    if (-not (Test-Path $script:BuilderQueueBridgeScript -PathType Leaf)) {
-        throw "Bridge CLI script not found: $script:BuilderQueueBridgeScript"
+    $manifestEntry = @(Get-PaneControlManifestEntries -ProjectDir $ProjectDir | Where-Object { [string]$_.Label -ceq $BuilderLabel } | Select-Object -First 1)[0]
+    if ($null -eq $manifestEntry) {
+        return New-WinsmuxSubmissionReceipt -Kind task -Status unavailable -Backend noop -SubmissionId $Task `
+            -ReasonCode 'target_manifest_missing' -Target ([ordered]@{ label = $BuilderLabel })
     }
+    return Invoke-WinsmuxSubmissionAdapter -ProjectDir $ProjectDir -ManifestEntry $manifestEntry -Kind task -Content $Prompt -SubmissionId $Task
+}
 
-    $output = & pwsh -NoProfile -File $script:BuilderQueueBridgeScript send $BuilderLabel $Prompt 2>&1
-    $exitCode = $LASTEXITCODE
-    $text = ($output | Out-String).TrimEnd()
+function Test-BuilderQueueDispatchEvidence {
+    param(
+        [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [Parameter(Mandatory = $true)][string]$BuilderLabel,
+        [Parameter(Mandatory = $true)][string]$TaskId,
+        [Parameter(Mandatory = $true)]$Receipt
+    )
 
-    if ($exitCode -ne 0) {
-        if ([string]::IsNullOrWhiteSpace($text)) {
-            $text = 'unknown winsmux error'
-        }
-
-        throw "Failed to dispatch queued task to ${BuilderLabel}: $text"
+    $target = Get-WinsmuxSubmissionValue -InputObject $Receipt -Name 'target' -Default $null
+    if (
+        [string](Get-WinsmuxSubmissionValue -InputObject $Receipt -Name 'submission_id' -Default '') -cne $TaskId -or
+        [string](Get-WinsmuxSubmissionValue -InputObject $Receipt -Name 'kind' -Default '') -cne 'task' -or
+        [string](Get-WinsmuxSubmissionValue -InputObject $target -Name 'label' -Default '') -cne $BuilderLabel
+    ) {
+        return $false
     }
-
-    return [PSCustomObject]@{
-        BuilderLabel = $BuilderLabel
-        Task         = $Task
-        Prompt       = $Prompt
-        Output       = $text
+    $packetPath = Join-Path (Join-Path (Join-Path $ProjectDir '.winsmux') 'submissions') ($TaskId + '.json')
+    $runPath = Get-WinsmuxSubmissionRunPath -ProjectDir $ProjectDir -SlotId $BuilderLabel -RunId $TaskId
+    if (-not (Test-Path -LiteralPath $packetPath -PathType Leaf) -or -not (Test-Path -LiteralPath $runPath -PathType Leaf)) {
+        return $false
     }
+    try {
+        $packet = Read-WinsmuxSubmissionPacket -Path $packetPath
+        $runRecord = Get-Content -LiteralPath $runPath -Raw -Encoding UTF8 | ConvertFrom-Json -Depth 16
+    } catch {
+        return $false
+    }
+    if (
+        [string]$packet.submission_id -cne $TaskId -or
+        [string]$packet.run_id -cne $TaskId -or
+        [string]$packet.task_id -cne $TaskId -or
+        [string]$packet.kind -cne 'task' -or
+        [string]$packet.target -cne $BuilderLabel
+    ) {
+        return $false
+    }
+    return Test-WinsmuxSubmissionRunRecord -Record $runRecord -SubmissionId $TaskId -Kind task `
+        -Backend ([string](Get-WinsmuxSubmissionValue -InputObject $Receipt -Name 'backend' -Default '')) -ExpectedSlotId $BuilderLabel -ExpectedRequestDigest ([string]$packet.request_digest)
 }
 
 function Dispatch-NextBuilderQueueTask {
@@ -507,14 +533,37 @@ function Dispatch-NextBuilderQueueTask {
         $dispatchResult = if ($null -ne $DispatchAction) {
             & $DispatchAction $BuilderLabel $nextEntry.Task $prompt
         } else {
-            Invoke-BuilderQueueDispatch -BuilderLabel $BuilderLabel -Task $nextEntry.Task -Prompt $prompt
+            Invoke-BuilderQueueDispatch -ProjectDir $ProjectDir -BuilderLabel $BuilderLabel -Task $nextEntry.TaskId -Prompt $prompt
         }
     } catch {
         Unlock-DispatchFiles -TaskId $nextEntry.TaskId -ProjectDir $ProjectDir | Out-Null
         throw
     }
 
-    $manifest.tasks.queued = (Remove-BuilderQueueRawEntry -Entries $manifest.tasks.queued -RawEntry $nextEntry.RawEntry)
+    $receiptValid = Test-WinsmuxSubmissionReceipt -Receipt $dispatchResult
+    $accepted = $receiptValid -and [string]$dispatchResult.status -ceq 'accepted'
+    $evidenceValid = $accepted -and (Test-BuilderQueueDispatchEvidence -ProjectDir $ProjectDir -BuilderLabel $BuilderLabel -TaskId $nextEntry.TaskId -Receipt $dispatchResult)
+    if (-not $accepted -or -not $evidenceValid) {
+        Unlock-DispatchFiles -TaskId $nextEntry.TaskId -ProjectDir $ProjectDir | Out-Null
+        $reason = if (-not $accepted -and $receiptValid -and -not [string]::IsNullOrWhiteSpace([string]$dispatchResult.reason_code)) {
+            [string]$dispatchResult.reason_code
+        } else {
+            'runner_evidence_invalid'
+        }
+        return [PSCustomObject]@{
+            BuilderLabel   = $BuilderLabel
+            Dispatched     = $false
+            Reason         = $reason
+            CurrentTask    = $nextEntry.Task
+            DispatchFiles  = @($dispatchFiles)
+            DispatchResult = $dispatchResult
+        }
+    }
+
+    $manifest.tasks.queued = @(
+        @($manifest.tasks.queued) |
+            Where-Object { (ConvertFrom-BuilderQueueEntry -Entry ([string]$_)).TaskId -cne $nextEntry.TaskId }
+    )
     $manifest.tasks.in_progress = (@($manifest.tasks.in_progress) + @($nextEntry.RawEntry))
     Save-BuilderQueueManifest -ProjectDir $ProjectDir -Manifest $manifest
     Update-BuilderQueuePaneState -ProjectDir $ProjectDir -BuilderLabel $BuilderLabel -Properties ([ordered]@{
@@ -630,5 +679,8 @@ if ($MyInvocation.InvocationName -ne '.') {
         $result | ConvertTo-Json -Depth 8
     } else {
         $result
+    }
+    if ($Action -eq 'dispatch-next' -and -not [bool]$result.Dispatched -and [string]$result.Reason -notin @('already_in_progress', 'queue_empty')) {
+        exit 1
     }
 }

--- a/winsmux-core/scripts/control-plane-dispatch.ps1
+++ b/winsmux-core/scripts/control-plane-dispatch.ps1
@@ -95,9 +95,13 @@ function Get-DispatchTaskManifestEntry {
     )
 
     if (Get-Command Get-PaneControlManifestEntries -ErrorAction SilentlyContinue) {
-        $entry = @(Get-PaneControlManifestEntries -ProjectDir $ProjectDir | Where-Object { [string]$_.Label -eq $Label } | Select-Object -First 1)[0]
-        if ($null -ne $entry) {
-            return $entry
+        try {
+            $entry = @(Get-PaneControlManifestEntries -ProjectDir $ProjectDir | Where-Object { [string]$_.Label -eq $Label } | Select-Object -First 1)[0]
+            if ($null -ne $entry) {
+                return $entry
+            }
+        } catch {
+            return $null
         }
     }
 
@@ -147,7 +151,9 @@ function Get-DispatchTaskAvailableTargets {
                     Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
             )
         } catch {
-            $manifestTargetsResolved = $false
+            # A missing or malformed manifest is an explicit unavailable state.
+            # Do not fall back to process-global labels from another workspace.
+            $manifestTargetsResolved = $true
         }
     }
     if (-not $manifestTargetsResolved -and $availableTargets.Count -eq 0) {
@@ -174,6 +180,7 @@ function Invoke-WinsmuxDispatchTaskCommand {
     }
 
     $taskText = $parts -join ' '
+    $submissionId = 'submission-' + [guid]::NewGuid().ToString('N')
     $projectDir = (Get-Location).Path
     $routerScript = Get-WinsmuxControlPlaneScriptPath -BridgeScriptRoot $BridgeScriptRoot -ScriptName 'dispatch-router.ps1'
     if (-not (Test-Path -LiteralPath $routerScript -PathType Leaf)) {
@@ -186,34 +193,57 @@ function Invoke-WinsmuxDispatchTaskCommand {
 
     $route = Get-DispatchRoute -Text $taskText -AvailableTargets $availableTargets -DefaultRole 'Worker'
     if ($route.HandleLocally) {
-        Stop-WithError "dispatch-task routed to Operator. Refine the task text so it can be delegated to a managed pane."
+        $receipt = New-WinsmuxRouterRefusalReceipt -Kind task -Route $route -SubmissionId $submissionId
+        ConvertTo-WinsmuxSubmissionReceiptJson -Receipt $receipt | Write-Output
+        exit 1
     }
 
     $selectedLabel = [string]$route.SelectedTarget
     $paneId = ''
     $resolvedRole = [string]$route.SelectedRole
 
+    $manifestEntry = $null
     if ($resolvedRole -eq 'Reviewer') {
-        $reviewEntry = Get-PreferredReviewPaneEntry -ProjectDir $projectDir
-        if ($null -eq $reviewEntry) {
-            Stop-WithError "No review-capable pane found in manifest."
+        $manifestEntry = Get-PreferredReviewPaneEntry -ProjectDir $projectDir
+        if ($null -eq $manifestEntry) {
+            $receipt = New-WinsmuxSubmissionReceipt -Kind task -Status unavailable -Backend noop -SubmissionId $submissionId -ReasonCode 'review_target_unavailable' -Diagnostic 'No review-capable pane was found in the manifest.'
+            ConvertTo-WinsmuxSubmissionReceiptJson -Receipt $receipt | Write-Output
+            exit 1
         }
 
-        $selectedLabel = [string]$reviewEntry.Label
-        $paneId = [string]$reviewEntry.PaneId
-        Start-DeferredPaneFromManifestEntry -ProjectDir $projectDir -ManifestEntry $reviewEntry | Out-Null
+        $selectedLabel = [string]$manifestEntry.Label
+        $paneId = [string]$manifestEntry.PaneId
     } else {
         $manifestEntry = Get-DispatchTaskManifestEntry -ProjectDir $projectDir -Label $selectedLabel
         if ($null -eq $manifestEntry -or [string]::IsNullOrWhiteSpace([string]$manifestEntry.PaneId)) {
-            Stop-WithError "dispatch-task could not resolve target '$selectedLabel' to a pane."
+            $receipt = New-WinsmuxSubmissionReceipt -Kind task -Status unavailable -Backend noop -SubmissionId $submissionId -ReasonCode 'target_unavailable' -Diagnostic "dispatch-task could not resolve target '$selectedLabel' to a pane."
+            ConvertTo-WinsmuxSubmissionReceiptJson -Receipt $receipt | Write-Output
+            exit 1
         }
 
         $paneId = [string]$manifestEntry.PaneId
-        Start-DeferredPaneFromManifestEntry -ProjectDir $projectDir -ManifestEntry $manifestEntry | Out-Null
     }
 
-    Send-TextToPane -PaneId $paneId -CommandText $taskText
-    Write-Output ("Dispatched to {0} [{1}] as {2}. {3}" -f $selectedLabel, $paneId, $resolvedRole, [string]$route.Reason)
+    try {
+        Start-DeferredPaneFromManifestEntry -ProjectDir $projectDir -ManifestEntry $manifestEntry | Out-Null
+    } catch {
+        $backend = [string](Get-WinsmuxSubmissionValue -InputObject $manifestEntry -Name 'WorkerBackend' -Default 'local')
+        if ($backend -notin @('local', 'codex', 'api_llm', 'antigravity', 'colab_cli', 'noop')) { $backend = 'noop' }
+        $receipt = New-WinsmuxSubmissionReceipt -Kind task -Status unavailable -Backend $backend -SubmissionId $submissionId -ReasonCode 'deferred_start_failed' -Diagnostic $_.Exception.Message -Target ([ordered]@{ label = $selectedLabel; pane_id = $paneId; role = $resolvedRole })
+        ConvertTo-WinsmuxSubmissionReceiptJson -Receipt $receipt | Write-Output
+        exit 1
+    }
+
+    $receipt = Invoke-WinsmuxSubmissionAdapter -ProjectDir $projectDir -ManifestEntry $manifestEntry -Kind task -Content $taskText -SubmissionId $submissionId
+    $receipt.routing = [ordered]@{
+        matched_rule   = if (@($route.MatchedKeywords).Count -gt 0) { @($route.MatchedKeywords) -join ',' } else { 'default_role' }
+        expected_owner = $resolvedRole
+        next_shape     = ''
+    }
+    ConvertTo-WinsmuxSubmissionReceiptJson -Receipt $receipt | Write-Output
+    if ($receipt.status -ne 'accepted') {
+        exit 1
+    }
 }
 
 function Invoke-WinsmuxTaskSplitCommand {

--- a/winsmux-core/scripts/control-plane-dispatch.ps1
+++ b/winsmux-core/scripts/control-plane-dispatch.ps1
@@ -88,6 +88,39 @@ function Invoke-WinsmuxDispatchRouteCommand {
     & $routerScript -Text $fullText
 }
 
+function Invoke-WinsmuxSubmissionAckCommand {
+    param(
+        [AllowNull()][string]$CommandTarget,
+        [AllowNull()][string[]]$CommandRest
+    )
+
+    $usage = 'usage: winsmux submission-ack --submission-id <id> --run-id <id> --kind <task|review> --backend <local|codex> --slot <slot>'
+    $tokens = @(@($CommandTarget) + @($CommandRest) | Where-Object { $_ })
+    $values = [ordered]@{ submission_id = ''; run_id = ''; kind = ''; backend = ''; slot = '' }
+    for ($index = 0; $index -lt $tokens.Count; $index++) {
+        $name = switch ([string]$tokens[$index]) {
+            '--submission-id' { 'submission_id' }
+            '--run-id' { 'run_id' }
+            '--kind' { 'kind' }
+            '--backend' { 'backend' }
+            '--slot' { 'slot' }
+            default { '' }
+        }
+        if ([string]::IsNullOrWhiteSpace($name) -or $index + 1 -ge $tokens.Count) {
+            Stop-WithError $usage
+        }
+        $index++
+        $values[$name] = [string]$tokens[$index]
+    }
+    foreach ($required in $values.Keys) {
+        if ([string]::IsNullOrWhiteSpace([string]$values[$required])) { Stop-WithError $usage }
+    }
+    $projectDir = [string]$env:WINSMUX_ORCHESTRA_PROJECT_DIR
+    if ([string]::IsNullOrWhiteSpace($projectDir)) { $projectDir = (Get-Location).Path }
+    $record = Invoke-WinsmuxSubmissionAcknowledge -ProjectDir $projectDir -SlotId $values.slot -SubmissionId $values.submission_id -RunId $values.run_id -Kind $values.kind -Backend $values.backend
+    $record | ConvertTo-Json -Depth 8 -Compress | Write-Output
+}
+
 function Get-DispatchTaskManifestEntry {
     param(
         [Parameter(Mandatory = $true)][string]$ProjectDir,
@@ -236,7 +269,7 @@ function Invoke-WinsmuxDispatchTaskCommand {
 
     $receipt = Invoke-WinsmuxSubmissionAdapter -ProjectDir $projectDir -ManifestEntry $manifestEntry -Kind task -Content $taskText -SubmissionId $submissionId
     $receipt.routing = [ordered]@{
-        matched_rule   = if (@($route.MatchedKeywords).Count -gt 0) { @($route.MatchedKeywords) -join ',' } else { 'default_role' }
+        matched_rule   = [string]$route.RuleId
         expected_owner = $resolvedRole
         next_shape     = ''
     }

--- a/winsmux-core/scripts/control-plane-dispatch.ps1
+++ b/winsmux-core/scripts/control-plane-dispatch.ps1
@@ -117,8 +117,9 @@ function Invoke-WinsmuxSubmissionAckCommand {
     }
     $projectDir = [string]$env:WINSMUX_ORCHESTRA_PROJECT_DIR
     if ([string]::IsNullOrWhiteSpace($projectDir)) { $projectDir = (Get-Location).Path }
-    $record = Invoke-WinsmuxSubmissionAcknowledge -ProjectDir $projectDir -SlotId $values.slot -SubmissionId $values.submission_id -RunId $values.run_id -Kind $values.kind -Backend $values.backend
-    $record | ConvertTo-Json -Depth 8 -Compress | Write-Output
+    $receipt = Invoke-WinsmuxSubmissionAcknowledge -ProjectDir $projectDir -SlotId $values.slot -SubmissionId $values.submission_id -RunId $values.run_id -Kind $values.kind -Backend $values.backend
+    ConvertTo-WinsmuxSubmissionReceiptJson -Receipt $receipt | Write-Output
+    if ([string]$receipt.status -ne 'accepted') { exit 1 }
 }
 
 function Get-DispatchTaskManifestEntry {
@@ -342,7 +343,7 @@ function Invoke-WinsmuxBuilderQueueCommand {
                 Stop-WithError "usage: winsmux builder-queue dispatch-next <builder-label>"
             }
 
-            Invoke-WinsmuxControlPlaneScript -ScriptPath $queueScript -Arguments @('-Action', 'dispatch-next', '-ProjectDir', $projectDir, '-BuilderLabel', $CommandRest[0])
+            Invoke-WinsmuxControlPlaneScript -ScriptPath $queueScript -Arguments @('-Action', 'dispatch-next', '-ProjectDir', $projectDir, '-BuilderLabel', $CommandRest[0]) -PropagateExitCode
         }
         'complete' {
             if (-not $CommandRest -or $CommandRest.Count -lt 1) {

--- a/winsmux-core/scripts/dispatch-router.ps1
+++ b/winsmux-core/scripts/dispatch-router.ps1
@@ -168,11 +168,22 @@ function Get-DispatchRoute {
         $reason = "$reason Handle this task locally as Operator."
     }
 
+    $ruleId = if ($bestRole -eq 'Operator') {
+        'route.operator_owned.v1'
+    } elseif ($null -eq $selectedTarget) {
+        'route.no_available_target.v1'
+    } elseif ($bestScore -gt 0) {
+        'route.keyword_match.v1'
+    } else {
+        'route.default_role.v1'
+    }
+
     return [PSCustomObject]@{
         Text = $Text
         SelectedRole = $bestRole
         SelectedTarget = $selectedTarget
         HandleLocally = $handleLocally
+        RuleId = $ruleId
         MatchedKeywords = @($bestMatches)
         Scores = $scoreTable
         Reason = $reason

--- a/winsmux-core/scripts/submission-contract.ps1
+++ b/winsmux-core/scripts/submission-contract.ps1
@@ -204,6 +204,22 @@ function Test-WinsmuxSubmissionPacket {
     return $true
 }
 
+function Resolve-WinsmuxSubmissionPacketPath {
+    param(
+        [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [Parameter(Mandatory = $true)][string]$SubmissionId
+    )
+
+    if (-not (Test-WinsmuxSubmissionIdentifier -Value $SubmissionId)) {
+        throw 'submission packet path contains an unsupported submission id'
+    }
+    $relativePath = Join-Path (Join-Path '.winsmux' 'submissions') ($SubmissionId + '.json')
+    return [PSCustomObject]@{
+        RelativePath = $relativePath
+        FullPath     = [System.IO.Path]::GetFullPath((Join-Path $ProjectDir $relativePath))
+    }
+}
+
 function New-WinsmuxSubmissionPacket {
     param(
         [Parameter(Mandatory = $true)][string]$ProjectDir,
@@ -215,13 +231,21 @@ function New-WinsmuxSubmissionPacket {
     )
 
     $packet = New-WinsmuxSubmissionPacketData -Kind $Kind -Content $Content -SubmissionId $SubmissionId -TargetLabel $TargetLabel -TaskId $TaskId
-    $relativePath = Join-Path (Join-Path '.winsmux' 'submissions') ($SubmissionId + '.json')
-    $fullPath = [System.IO.Path]::GetFullPath((Join-Path $ProjectDir $relativePath))
+    $packetPath = Resolve-WinsmuxSubmissionPacketPath -ProjectDir $ProjectDir -SubmissionId $SubmissionId
+    $relativePath = [string]$packetPath.RelativePath
+    $fullPath = [string]$packetPath.FullPath
     $directory = Split-Path -Parent $fullPath
     if (-not (Test-Path -LiteralPath $directory -PathType Container)) {
         New-Item -ItemType Directory -Path $directory -Force | Out-Null
     }
-    [System.IO.File]::WriteAllText($fullPath, ($packet | ConvertTo-Json -Depth 8), [System.Text.UTF8Encoding]::new($false))
+    $bytes = [System.Text.UTF8Encoding]::new($false).GetBytes(($packet | ConvertTo-Json -Depth 8))
+    $stream = $null
+    try {
+        $stream = [System.IO.File]::Open($fullPath, [System.IO.FileMode]::CreateNew, [System.IO.FileAccess]::Write, [System.IO.FileShare]::None)
+        $stream.Write($bytes, 0, $bytes.Length)
+    } finally {
+        if ($null -ne $stream) { $stream.Dispose() }
+    }
     return [PSCustomObject]@{ FullPath = $fullPath; RelativePath = $relativePath; Packet = $packet }
 }
 
@@ -617,15 +641,15 @@ function Invoke-WinsmuxSubmissionAdapter {
     $backend = ([string](Get-WinsmuxSubmissionValue -InputObject $ManifestEntry -Name 'WorkerBackend' -Default 'local')).Trim().ToLowerInvariant()
     $target = [ordered]@{ label = $label; pane_id = $paneId; role = $role }
 
+    if ($backend -notin $script:WinsmuxSubmissionBackends -or $backend -eq 'noop') {
+        return New-WinsmuxSubmissionReceipt -Kind $Kind -Status unsupported -Backend noop -SubmissionId $SubmissionId -ReasonCode 'backend_unsupported' -Target $target
+    }
     if ([string]::IsNullOrWhiteSpace($TaskId)) { $TaskId = $SubmissionId }
     if (-not (Test-WinsmuxSubmissionIdentifier -Value $TaskId)) {
         return New-WinsmuxSubmissionReceipt -Kind $Kind -Status rejected -Backend $backend -SubmissionId $SubmissionId -ReasonCode 'task_identifier_invalid' -Target $target
     }
     if (-not (Test-WinsmuxSubmissionIdentifier -Value $label)) {
         return New-WinsmuxSubmissionReceipt -Kind $Kind -Status rejected -Backend noop -SubmissionId $SubmissionId -ReasonCode 'target_identifier_invalid' -Target $target
-    }
-    if ($backend -notin $script:WinsmuxSubmissionBackends -or $backend -eq 'noop') {
-        return New-WinsmuxSubmissionReceipt -Kind $Kind -Status unsupported -Backend noop -SubmissionId $SubmissionId -ReasonCode 'backend_unsupported' -Target $target
     }
 
     $existingRunPath = Get-WinsmuxSubmissionRunPath -ProjectDir $ProjectDir -SlotId $label -RunId $SubmissionId
@@ -635,7 +659,18 @@ function Invoke-WinsmuxSubmissionAdapter {
     if ($backend -in @('local', 'codex')) {
         return New-WinsmuxSubmissionReceipt -Kind $Kind -Status unavailable -Backend $backend -SubmissionId $SubmissionId -ReasonCode 'caller_identity_unavailable' -Target $target
     }
-    $packet = New-WinsmuxSubmissionPacket -ProjectDir $ProjectDir -Kind $Kind -Content $Content -SubmissionId $SubmissionId -TargetLabel $label -TaskId $TaskId
+    $packetPath = (Resolve-WinsmuxSubmissionPacketPath -ProjectDir $ProjectDir -SubmissionId $SubmissionId).FullPath
+    if (Test-Path -LiteralPath $packetPath -PathType Leaf) {
+        return New-WinsmuxSubmissionReceipt -Kind $Kind -Status rejected -Backend $backend -SubmissionId $SubmissionId -ReasonCode 'run_record_already_exists' -Target $target
+    }
+    try {
+        $packet = New-WinsmuxSubmissionPacket -ProjectDir $ProjectDir -Kind $Kind -Content $Content -SubmissionId $SubmissionId -TargetLabel $label -TaskId $TaskId
+    } catch [System.IO.IOException] {
+        if (Test-Path -LiteralPath $packetPath -PathType Leaf) {
+            return New-WinsmuxSubmissionReceipt -Kind $Kind -Status rejected -Backend $backend -SubmissionId $SubmissionId -ReasonCode 'run_record_already_exists' -Target $target
+        }
+        throw
+    }
     if ($backend -eq 'api_llm') {
         if ([string]::IsNullOrWhiteSpace($paneId)) {
             return New-WinsmuxSubmissionReceipt -Kind $Kind -Status unavailable -Backend $backend -SubmissionId $SubmissionId -ReasonCode 'pane_unavailable' -Target $target

--- a/winsmux-core/scripts/submission-contract.ps1
+++ b/winsmux-core/scripts/submission-contract.ps1
@@ -106,11 +106,16 @@ function New-WinsmuxSubmissionPacketData {
         [Parameter(Mandatory = $true)][ValidateSet('task', 'review')][string]$Kind,
         [Parameter(Mandatory = $true)]$Content,
         [Parameter(Mandatory = $true)][string]$SubmissionId,
-        [Parameter(Mandatory = $true)][string]$TargetLabel
+        [Parameter(Mandatory = $true)][string]$TargetLabel,
+        [AllowEmptyString()][string]$TaskId = ''
     )
 
     if (-not (Test-WinsmuxSubmissionIdentifier -Value $SubmissionId)) {
         throw 'submission id contains unsupported characters'
+    }
+    if ([string]::IsNullOrWhiteSpace($TaskId)) { $TaskId = $SubmissionId }
+    if (-not (Test-WinsmuxSubmissionIdentifier -Value $TaskId)) {
+        throw 'task id contains unsupported characters'
     }
     $title = ''
     $request = ''
@@ -142,7 +147,7 @@ function New-WinsmuxSubmissionPacketData {
         protocol_version = 1
         submission_id    = $SubmissionId
         run_id           = $SubmissionId
-        task_id          = $SubmissionId
+        task_id          = $TaskId
         kind             = $Kind
         target           = $TargetLabel
         title            = $title
@@ -178,7 +183,8 @@ function Test-WinsmuxSubmissionPacket {
     $kind = if ($kindValue -is [string]) { $kindValue } else { '' }
     if ([int64]$version -ne 1) { return $false }
     if (-not (Test-WinsmuxSubmissionIdentifier -Value $submissionId)) { return $false }
-    if ($runId -cne $submissionId -or $taskId -cne $submissionId) { return $false }
+    if ($runId -cne $submissionId) { return $false }
+    if (-not (Test-WinsmuxSubmissionIdentifier -Value $taskId)) { return $false }
     if ($kind -cnotin $script:WinsmuxSubmissionKinds) { return $false }
     if ($targetValue -isnot [string]) { return $false }
     if (-not (Test-WinsmuxSubmissionIdentifier -Value $targetValue)) { return $false }
@@ -204,10 +210,11 @@ function New-WinsmuxSubmissionPacket {
         [Parameter(Mandatory = $true)][ValidateSet('task', 'review')][string]$Kind,
         [Parameter(Mandatory = $true)]$Content,
         [Parameter(Mandatory = $true)][string]$SubmissionId,
-        [Parameter(Mandatory = $true)][string]$TargetLabel
+        [Parameter(Mandatory = $true)][string]$TargetLabel,
+        [AllowEmptyString()][string]$TaskId = ''
     )
 
-    $packet = New-WinsmuxSubmissionPacketData -Kind $Kind -Content $Content -SubmissionId $SubmissionId -TargetLabel $TargetLabel
+    $packet = New-WinsmuxSubmissionPacketData -Kind $Kind -Content $Content -SubmissionId $SubmissionId -TargetLabel $TargetLabel -TaskId $TaskId
     $relativePath = Join-Path (Join-Path '.winsmux' 'submissions') ($SubmissionId + '.json')
     $fullPath = [System.IO.Path]::GetFullPath((Join-Path $ProjectDir $relativePath))
     $directory = Split-Path -Parent $fullPath
@@ -252,16 +259,21 @@ function New-WinsmuxSubmissionRunRecord {
         [Parameter(Mandatory = $true)][ValidateSet('started', 'running', 'succeeded', 'failed')][string]$Status,
         [Parameter(Mandatory = $true)][ValidatePattern('^[0-9a-f]{64}$')][string]$RequestDigest,
         [switch]$RequestConsumed,
-        [AllowEmptyString()][string]$Reason = ''
+        [AllowEmptyString()][string]$Reason = '',
+        [AllowEmptyString()][string]$TaskId = ''
     )
 
+    if ([string]::IsNullOrWhiteSpace($TaskId)) { $TaskId = $SubmissionId }
+    if (-not (Test-WinsmuxSubmissionIdentifier -Value $TaskId)) {
+        throw 'task id contains unsupported characters'
+    }
     return [ordered]@{
         protocol_version = 1
         type             = 'backend_run_record'
         submission_id    = $SubmissionId
         run_id           = $RunId
         kind             = $Kind
-        task_id          = $SubmissionId
+        task_id          = $TaskId
         task_title       = $TaskTitle
         worker_kind      = if ($Kind -eq 'review') { 'critic' } else { 'implementation' }
         slot_id          = $SlotId
@@ -283,7 +295,8 @@ function Test-WinsmuxSubmissionRunRecord {
         [Parameter(Mandatory = $true)][ValidateSet('task', 'review')][string]$Kind,
         [Parameter(Mandatory = $true)][string]$Backend,
         [string]$ExpectedSlotId = '',
-        [string]$ExpectedRequestDigest = ''
+        [string]$ExpectedRequestDigest = '',
+        [string]$ExpectedTaskId = ''
     )
 
     if ($null -eq $Record) { return $false }
@@ -303,7 +316,8 @@ function Test-WinsmuxSubmissionRunRecord {
         [string](Get-WinsmuxSubmissionValue -InputObject $Record -Name 'submission_id' -Default '') -ceq $SubmissionId -and
         [string](Get-WinsmuxSubmissionValue -InputObject $Record -Name 'run_id' -Default '') -ceq $SubmissionId -and
         [string](Get-WinsmuxSubmissionValue -InputObject $Record -Name 'kind' -Default '') -ceq $Kind -and
-        [string](Get-WinsmuxSubmissionValue -InputObject $Record -Name 'task_id' -Default '') -ceq $SubmissionId -and
+        (Test-WinsmuxSubmissionIdentifier -Value ([string](Get-WinsmuxSubmissionValue -InputObject $Record -Name 'task_id' -Default ''))) -and
+        ([string]::IsNullOrWhiteSpace($ExpectedTaskId) -or [string](Get-WinsmuxSubmissionValue -InputObject $Record -Name 'task_id' -Default '') -ceq $ExpectedTaskId) -and
         ($taskTitle -is [string]) -and (-not [string]::IsNullOrWhiteSpace($taskTitle)) -and
         ($workerKind -is [string]) -and $workerKind -ceq $expectedWorkerKind -and
         ($recordSlotId -is [string]) -and (Test-WinsmuxSubmissionIdentifier -Value $recordSlotId) -and
@@ -328,6 +342,7 @@ function ConvertTo-WinsmuxPublicAcknowledgement {
         status           = [string](Get-WinsmuxSubmissionValue -InputObject $Acknowledgement -Name 'status' -Default '')
         submission_id    = [string](Get-WinsmuxSubmissionValue -InputObject $Acknowledgement -Name 'submission_id' -Default '')
         run_id           = [string](Get-WinsmuxSubmissionValue -InputObject $Acknowledgement -Name 'run_id' -Default '')
+        task_id          = [string](Get-WinsmuxSubmissionValue -InputObject $Acknowledgement -Name 'task_id' -Default '')
         kind             = [string](Get-WinsmuxSubmissionValue -InputObject $Acknowledgement -Name 'kind' -Default '')
         backend          = [string](Get-WinsmuxSubmissionValue -InputObject $Acknowledgement -Name 'backend' -Default '')
         slot_id          = [string](Get-WinsmuxSubmissionValue -InputObject $Acknowledgement -Name 'slot_id' -Default '')
@@ -346,7 +361,7 @@ function Test-WinsmuxPublicAcknowledgement {
     )
 
     if ($null -eq $Acknowledgement) { return $false }
-    $allowedNames = @('type', 'protocol_version', 'status', 'submission_id', 'run_id', 'kind', 'backend', 'slot_id', 'worker_kind', 'request_digest')
+    $allowedNames = @('type', 'protocol_version', 'status', 'submission_id', 'run_id', 'task_id', 'kind', 'backend', 'slot_id', 'worker_kind', 'request_digest')
     $actualNames = if ($Acknowledgement -is [System.Collections.IDictionary]) {
         @($Acknowledgement.Keys | ForEach-Object { [string]$_ })
     } else {
@@ -363,6 +378,7 @@ function Test-WinsmuxPublicAcknowledgement {
         [string](Get-WinsmuxSubmissionValue -InputObject $Acknowledgement -Name 'status' -Default '') -cin $script:WinsmuxSubmissionRunStatuses -and
         [string](Get-WinsmuxSubmissionValue -InputObject $Acknowledgement -Name 'submission_id' -Default '') -ceq $SubmissionId -and
         [string](Get-WinsmuxSubmissionValue -InputObject $Acknowledgement -Name 'run_id' -Default '') -ceq $SubmissionId -and
+        (Test-WinsmuxSubmissionIdentifier -Value ([string](Get-WinsmuxSubmissionValue -InputObject $Acknowledgement -Name 'task_id' -Default ''))) -and
         [string](Get-WinsmuxSubmissionValue -InputObject $Acknowledgement -Name 'kind' -Default '') -ceq $Kind -and
         [string](Get-WinsmuxSubmissionValue -InputObject $Acknowledgement -Name 'backend' -Default '') -ceq $Backend -and
         [string](Get-WinsmuxSubmissionValue -InputObject $Acknowledgement -Name 'slot_id' -Default '') -ceq $ExpectedSlotId -and
@@ -562,6 +578,7 @@ function Invoke-WinsmuxSubmissionAdapter {
         [Parameter(Mandatory = $true)][ValidateSet('task', 'review')][string]$Kind,
         [Parameter(Mandatory = $true)]$Content,
         [string]$SubmissionId = ('submission-' + [guid]::NewGuid().ToString('N')),
+        [AllowEmptyString()][string]$TaskId = '',
         [scriptblock]$SendAction,
         [scriptblock]$CaptureAction,
         [scriptblock]$RunResultAction,
@@ -574,6 +591,10 @@ function Invoke-WinsmuxSubmissionAdapter {
     $backend = ([string](Get-WinsmuxSubmissionValue -InputObject $ManifestEntry -Name 'WorkerBackend' -Default 'local')).Trim().ToLowerInvariant()
     $target = [ordered]@{ label = $label; pane_id = $paneId; role = $role }
 
+    if ([string]::IsNullOrWhiteSpace($TaskId)) { $TaskId = $SubmissionId }
+    if (-not (Test-WinsmuxSubmissionIdentifier -Value $TaskId)) {
+        return New-WinsmuxSubmissionReceipt -Kind $Kind -Status rejected -Backend $backend -SubmissionId $SubmissionId -ReasonCode 'task_identifier_invalid' -Target $target
+    }
     if (-not (Test-WinsmuxSubmissionIdentifier -Value $label)) {
         return New-WinsmuxSubmissionReceipt -Kind $Kind -Status rejected -Backend noop -SubmissionId $SubmissionId -ReasonCode 'target_identifier_invalid' -Target $target
     }
@@ -581,7 +602,7 @@ function Invoke-WinsmuxSubmissionAdapter {
         return New-WinsmuxSubmissionReceipt -Kind $Kind -Status unsupported -Backend noop -SubmissionId $SubmissionId -ReasonCode 'backend_unsupported' -Target $target
     }
 
-    $packet = New-WinsmuxSubmissionPacket -ProjectDir $ProjectDir -Kind $Kind -Content $Content -SubmissionId $SubmissionId -TargetLabel $label
+    $packet = New-WinsmuxSubmissionPacket -ProjectDir $ProjectDir -Kind $Kind -Content $Content -SubmissionId $SubmissionId -TargetLabel $label -TaskId $TaskId
     $existingRunPath = Get-WinsmuxSubmissionRunPath -ProjectDir $ProjectDir -SlotId $label -RunId $SubmissionId
     if (Test-Path -LiteralPath $existingRunPath -PathType Leaf) {
         return New-WinsmuxSubmissionReceipt -Kind $Kind -Status rejected -Backend $backend -SubmissionId $SubmissionId -ReasonCode 'run_record_already_exists' -Target $target
@@ -604,18 +625,20 @@ function Invoke-WinsmuxSubmissionAdapter {
         $runner = if ($null -ne $CliRunAction) { & $CliRunAction $ProjectDir $label $packet.RelativePath $SubmissionId $backend $Kind } else { Invoke-WinsmuxSubmissionCliRun -ProjectDir $ProjectDir -SlotId $label -PacketPath $packet.RelativePath -SubmissionId $SubmissionId -Backend $backend -Kind $Kind }
     }
 
-    if (Test-WinsmuxSubmissionRunRecord -Record $runner -SubmissionId $SubmissionId -Kind $Kind -Backend $backend -ExpectedSlotId $label -ExpectedRequestDigest ([string]$packet.Packet.request_digest)) {
+    if (Test-WinsmuxSubmissionRunRecord -Record $runner -SubmissionId $SubmissionId -Kind $Kind -Backend $backend -ExpectedSlotId $label -ExpectedRequestDigest ([string]$packet.Packet.request_digest) -ExpectedTaskId ([string]$packet.Packet.task_id)) {
         return New-WinsmuxSubmissionReceipt -Kind $Kind -Status accepted -Backend $backend -SubmissionId $SubmissionId -Target $target -Acknowledgement $runner
     }
     $runnerStatus = [string](Get-WinsmuxSubmissionValue -InputObject $runner -Name 'status' -Default '')
     $runnerReason = [string](Get-WinsmuxSubmissionValue -InputObject $runner -Name 'reason' -Default '')
-    if ($runnerStatus -eq 'unavailable' -or $runnerReason -match '^(backend_unavailable|cli_command_missing|.*_cli_missing|.*_runner_unconfigured|api_llm_api_key_env_missing)$') {
-        if ([string]::IsNullOrWhiteSpace($runnerReason)) { $runnerReason = 'backend_unavailable' }
-        return New-WinsmuxSubmissionReceipt -Kind $Kind -Status unavailable -Backend $backend -SubmissionId $SubmissionId -ReasonCode $runnerReason -Target $target
+    $unavailableAllow = '^(backend_unavailable|cli_command_missing|cli_receipt_malformed|[a-z0-9]+(_[a-z0-9]+)*_cli_missing|[a-z0-9]+(_[a-z0-9]+)*_runner_unconfigured|api_llm_api_key_env_missing)$'
+    $rejectedAllow = '^(runner_rejected_packet|runner_receipt_malformed|runner_acknowledgement_missing|backend_acknowledgement_missing|run_record_already_exists)$'
+    if ($runnerStatus -eq 'unavailable') {
+        $reasonCode = if ($runnerReason -cmatch $unavailableAllow) { $runnerReason } else { 'backend_unavailable' }
+        return New-WinsmuxSubmissionReceipt -Kind $Kind -Status unavailable -Backend $backend -SubmissionId $SubmissionId -ReasonCode $reasonCode -Target $target
     }
     if (($null -eq $runner -or $runnerReason -eq 'runner_acknowledgement_missing') -and $backend -in @('local', 'codex')) {
         $runnerReason = 'backend_acknowledgement_missing'
     }
-    if ([string]::IsNullOrWhiteSpace($runnerReason)) { $runnerReason = 'runner_evidence_invalid' }
-    return New-WinsmuxSubmissionReceipt -Kind $Kind -Status rejected -Backend $backend -SubmissionId $SubmissionId -ReasonCode $runnerReason -Target $target
+    $reasonCode = if ($runnerReason -cmatch $rejectedAllow) { $runnerReason } else { 'runner_evidence_invalid' }
+    return New-WinsmuxSubmissionReceipt -Kind $Kind -Status rejected -Backend $backend -SubmissionId $SubmissionId -ReasonCode $reasonCode -Target $target
 }

--- a/winsmux-core/scripts/submission-contract.ps1
+++ b/winsmux-core/scripts/submission-contract.ps1
@@ -1,0 +1,303 @@
+$ErrorActionPreference = 'Stop'
+
+$script:WinsmuxSubmissionProtocolVersion = 1
+$script:WinsmuxSubmissionStatuses = @('accepted', 'rejected', 'unsupported', 'unavailable')
+$script:WinsmuxSubmissionKinds = @('task', 'review')
+$script:WinsmuxSubmissionBackends = @('local', 'codex', 'api_llm', 'antigravity', 'colab_cli', 'noop')
+$script:WinsmuxSubmissionBridgeScript = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\..\scripts\winsmux-core.ps1'))
+
+function ConvertTo-WinsmuxSubmissionDiagnostic {
+    param([AllowEmptyString()][string]$Text = '')
+
+    if ([string]::IsNullOrWhiteSpace($Text)) {
+        return ''
+    }
+    $safe = $Text -replace '(?i)[A-Z]:\\Users\\[^,;\r\n]+', '<local-path>'
+    $safe = $safe -replace '(?i)\\\\[^\\\s]+\\[^,;\r\n]+', '<network-path>'
+    return $safe.Trim()
+}
+
+function Get-WinsmuxSubmissionValue {
+    param(
+        [AllowNull()]$InputObject,
+        [Parameter(Mandatory = $true)][string]$Name,
+        [AllowNull()]$Default = $null
+    )
+
+    if ($null -eq $InputObject) {
+        return $Default
+    }
+    if ($InputObject -is [System.Collections.IDictionary]) {
+        if ($InputObject.Contains($Name)) {
+            return $InputObject[$Name]
+        }
+        return $Default
+    }
+    $property = $InputObject.PSObject.Properties[$Name]
+    if ($null -ne $property) {
+        return $property.Value
+    }
+    return $Default
+}
+
+function New-WinsmuxSubmissionReceipt {
+    param(
+        [Parameter(Mandatory = $true)][ValidateSet('task', 'review')][string]$Kind,
+        [Parameter(Mandatory = $true)][ValidateSet('accepted', 'rejected', 'unsupported', 'unavailable')][string]$Status,
+        [Parameter(Mandatory = $true)][string]$Backend,
+        [Parameter(Mandatory = $true)][string]$SubmissionId,
+        [AllowEmptyString()][string]$ReasonCode = '',
+        [AllowEmptyString()][string]$Diagnostic = '',
+        [AllowNull()]$Target = $null,
+        [AllowNull()]$Routing = $null,
+        [AllowNull()]$Acknowledgement = $null
+    )
+
+    return [ordered]@{
+        protocol_version = $script:WinsmuxSubmissionProtocolVersion
+        submission_id    = $SubmissionId
+        kind             = $Kind
+        status           = $Status
+        backend          = $Backend.Trim().ToLowerInvariant()
+        reason_code      = $ReasonCode
+        diagnostic       = ConvertTo-WinsmuxSubmissionDiagnostic -Text $Diagnostic
+        target           = $Target
+        routing          = $Routing
+        acknowledgement  = $Acknowledgement
+    }
+}
+
+function Test-WinsmuxSubmissionReceipt {
+    param([AllowNull()]$Receipt)
+
+    if ($null -eq $Receipt) {
+        return $false
+    }
+    $version = Get-WinsmuxSubmissionValue -InputObject $Receipt -Name 'protocol_version' -Default $null
+    $status = [string](Get-WinsmuxSubmissionValue -InputObject $Receipt -Name 'status' -Default '')
+    $kind = [string](Get-WinsmuxSubmissionValue -InputObject $Receipt -Name 'kind' -Default '')
+    $backend = [string](Get-WinsmuxSubmissionValue -InputObject $Receipt -Name 'backend' -Default '')
+    $submissionId = [string](Get-WinsmuxSubmissionValue -InputObject $Receipt -Name 'submission_id' -Default '')
+
+    $parsedVersion = 0
+    $versionIsInteger = [int]::TryParse(([string]$version), [ref]$parsedVersion)
+    return (
+        $versionIsInteger -and
+        $parsedVersion -eq $script:WinsmuxSubmissionProtocolVersion -and
+        $status -cin $script:WinsmuxSubmissionStatuses -and
+        $kind -cin $script:WinsmuxSubmissionKinds -and
+        $backend -cin $script:WinsmuxSubmissionBackends -and
+        -not [string]::IsNullOrWhiteSpace($submissionId)
+    )
+}
+
+function ConvertTo-WinsmuxSubmissionReceiptJson {
+    param([Parameter(Mandatory = $true)]$Receipt)
+
+    if (-not (Test-WinsmuxSubmissionReceipt -Receipt $Receipt)) {
+        throw 'submission receipt is malformed or uses an unknown protocol version, status, kind, or backend'
+    }
+    return ($Receipt | ConvertTo-Json -Depth 12 -Compress)
+}
+
+function New-WinsmuxRouterRefusalReceipt {
+    param(
+        [Parameter(Mandatory = $true)][ValidateSet('task', 'review')][string]$Kind,
+        [Parameter(Mandatory = $true)]$Route,
+        [Parameter(Mandatory = $true)][string]$SubmissionId
+    )
+
+    $matchedKeywords = @((Get-WinsmuxSubmissionValue -InputObject $Route -Name 'MatchedKeywords' -Default @()))
+    $expectedOwner = [string](Get-WinsmuxSubmissionValue -InputObject $Route -Name 'SelectedRole' -Default 'Operator')
+    if ([string]::IsNullOrWhiteSpace($expectedOwner)) {
+        $expectedOwner = 'Operator'
+    }
+    $matchedRule = if ($matchedKeywords.Count -gt 0) { $matchedKeywords -join ',' } else { 'no_delegable_target' }
+
+    return New-WinsmuxSubmissionReceipt -Kind $Kind -Status rejected -Backend local -SubmissionId $SubmissionId `
+        -ReasonCode 'router_operator_owned' -Diagnostic ([string](Get-WinsmuxSubmissionValue -InputObject $Route -Name 'Reason' -Default 'router retained ownership')) `
+        -Routing ([ordered]@{
+            matched_rule   = $matchedRule
+            expected_owner = $expectedOwner
+            next_shape     = 'Provide a delegable implementation, review, research, or verification packet for an available managed worker.'
+        })
+}
+
+function New-WinsmuxSubmissionPacket {
+    param(
+        [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [Parameter(Mandatory = $true)][ValidateSet('task', 'review')][string]$Kind,
+        [Parameter(Mandatory = $true)][string]$Content,
+        [Parameter(Mandatory = $true)][string]$SubmissionId,
+        [Parameter(Mandatory = $true)][string]$TargetLabel
+    )
+
+    if ($SubmissionId -notmatch '^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$') {
+        throw 'submission id contains unsupported characters'
+    }
+    $relativePath = Join-Path (Join-Path '.winsmux' 'submissions') ($SubmissionId + '.json')
+    $fullPath = [System.IO.Path]::GetFullPath((Join-Path $ProjectDir $relativePath))
+    $directory = Split-Path -Parent $fullPath
+    if (-not (Test-Path -LiteralPath $directory -PathType Container)) {
+        New-Item -ItemType Directory -Path $directory -Force | Out-Null
+    }
+    $packet = [ordered]@{
+        protocol_version = 1
+        submission_id    = $SubmissionId
+        kind             = $Kind
+        target           = $TargetLabel
+        content          = $Content
+    }
+    [System.IO.File]::WriteAllText($fullPath, ($packet | ConvertTo-Json -Depth 8), [System.Text.UTF8Encoding]::new($false))
+    return [PSCustomObject]@{ FullPath = $fullPath; RelativePath = $relativePath }
+}
+
+function Get-WinsmuxSubmissionRunResult {
+    param(
+        [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [Parameter(Mandatory = $true)][string]$SlotId,
+        [Parameter(Mandatory = $true)][string]$RunId
+    )
+
+    $runPath = Join-Path (Join-Path (Join-Path (Join-Path $ProjectDir '.winsmux') 'worker-runs') $SlotId) (Join-Path $RunId 'run.json')
+    $attempts = 60
+    if ($env:WINSMUX_SUBMISSION_POLL_ATTEMPTS -match '^\d+$') {
+        $attempts = [int]$env:WINSMUX_SUBMISSION_POLL_ATTEMPTS
+    }
+    for ($attempt = 0; $attempt -le $attempts; $attempt++) {
+        if (Test-Path -LiteralPath $runPath -PathType Leaf) {
+            try {
+                return (Get-Content -LiteralPath $runPath -Raw -Encoding UTF8 | ConvertFrom-Json -Depth 16)
+            } catch {
+                return [ordered]@{ status = 'failed'; reason = 'runner_receipt_malformed'; exit_code = 1 }
+            }
+        }
+        if ($attempt -lt $attempts) {
+            Start-Sleep -Milliseconds 500
+        }
+    }
+    return [ordered]@{ status = 'failed'; reason = 'runner_acknowledgement_missing'; exit_code = 1 }
+}
+
+function Invoke-WinsmuxSubmissionCliRun {
+    param(
+        [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [Parameter(Mandatory = $true)][string]$SlotId,
+        [Parameter(Mandatory = $true)][string]$PacketPath,
+        [Parameter(Mandatory = $true)][string]$SubmissionId,
+        [Parameter(Mandatory = $true)][string]$Backend,
+        [Parameter(Mandatory = $true)][ValidateSet('task', 'review')][string]$Kind
+    )
+
+    $workerArguments = @('workers', 'exec', $SlotId)
+    if ([string]::Equals($Backend, 'colab_cli', [System.StringComparison]::OrdinalIgnoreCase)) {
+        $workerScript = if ($Kind -eq 'review') { 'workers/colab/critic_worker.py' } else { 'workers/colab/impl_worker.py' }
+        $workerArguments += @('--script', $workerScript, '--task-json', $PacketPath)
+    } else {
+        $workerArguments += @('--task-json', $PacketPath)
+    }
+    $workerArguments += @('--task-id', $SubmissionId, '--run-id', $SubmissionId, '--json', '--project-dir', $ProjectDir)
+    $output = & pwsh -NoProfile -File $script:WinsmuxSubmissionBridgeScript @workerArguments 2>&1
+    $exitCode = $LASTEXITCODE
+    $jsonLine = @($output | ForEach-Object { [string]$_ } | Where-Object { $_.TrimStart().StartsWith('{') } | Select-Object -Last 1)
+    if ($jsonLine.Count -lt 1) {
+        return [ordered]@{ status = 'unavailable'; reason = 'cli_command_missing'; exit_code = if ($exitCode) { $exitCode } else { 1 } }
+    }
+    try {
+        $result = $jsonLine[0] | ConvertFrom-Json -Depth 16
+    } catch {
+        return [ordered]@{ status = 'unavailable'; reason = 'cli_receipt_malformed'; exit_code = 1 }
+    }
+    return $result
+}
+
+function Invoke-WinsmuxSubmissionAdapter {
+    param(
+        [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [Parameter(Mandatory = $true)]$ManifestEntry,
+        [Parameter(Mandatory = $true)][ValidateSet('task', 'review')][string]$Kind,
+        [Parameter(Mandatory = $true)][string]$Content,
+        [string]$SubmissionId = ('submission-' + [guid]::NewGuid().ToString('N')),
+        [scriptblock]$SendAction,
+        [scriptblock]$CaptureAction,
+        [scriptblock]$RunResultAction,
+        [scriptblock]$CliRunAction
+    )
+
+    $label = [string](Get-WinsmuxSubmissionValue -InputObject $ManifestEntry -Name 'Label' -Default '')
+    $paneId = [string](Get-WinsmuxSubmissionValue -InputObject $ManifestEntry -Name 'PaneId' -Default '')
+    $role = [string](Get-WinsmuxSubmissionValue -InputObject $ManifestEntry -Name 'Role' -Default '')
+    $backend = [string](Get-WinsmuxSubmissionValue -InputObject $ManifestEntry -Name 'WorkerBackend' -Default 'local')
+    $backend = $backend.Trim().ToLowerInvariant()
+    $target = [ordered]@{ label = $label; pane_id = $paneId; role = $role }
+
+    if ($backend -notin $script:WinsmuxSubmissionBackends) {
+        return New-WinsmuxSubmissionReceipt -Kind $Kind -Status unsupported -Backend noop -SubmissionId $SubmissionId -ReasonCode 'backend_unsupported' -Diagnostic "Unsupported worker backend '$backend'." -Target $target
+    }
+    if ($backend -eq 'noop') {
+        return New-WinsmuxSubmissionReceipt -Kind $Kind -Status unsupported -Backend noop -SubmissionId $SubmissionId -ReasonCode 'backend_unsupported' -Diagnostic 'The noop backend cannot accept submissions.' -Target $target
+    }
+
+    if ($backend -in @('local', 'codex')) {
+        if ([string]::IsNullOrWhiteSpace($paneId)) {
+            return New-WinsmuxSubmissionReceipt -Kind $Kind -Status unavailable -Backend $backend -SubmissionId $SubmissionId -ReasonCode 'pane_unavailable' -Diagnostic 'The target pane id is missing.' -Target $target
+        }
+        $marker = "[winsmux-submission-accepted:$SubmissionId]"
+        $commandText = "Before doing any other work, print exactly $marker on its own line to acknowledge this $Kind submission.`n`n$Content"
+        try {
+            if ($null -ne $SendAction) {
+                & $SendAction $paneId $commandText
+            } else {
+                Send-TextToPane -PaneId $paneId -CommandText $commandText
+            }
+        } catch {
+            return New-WinsmuxSubmissionReceipt -Kind $Kind -Status unavailable -Backend $backend -SubmissionId $SubmissionId -ReasonCode 'pane_send_failed' -Diagnostic $_.Exception.Message -Target $target
+        }
+
+        $attempts = 10
+        if ($env:WINSMUX_SUBMISSION_POLL_ATTEMPTS -match '^\d+$') {
+            $attempts = [int]$env:WINSMUX_SUBMISSION_POLL_ATTEMPTS
+        }
+        for ($attempt = 0; $attempt -le $attempts; $attempt++) {
+            $snapshot = if ($null -ne $CaptureAction) { & $CaptureAction $paneId } else { Get-PaneSnapshotText -PaneId $paneId -Lines 200 }
+            if ([string]$snapshot -match [regex]::Escape($marker)) {
+                return New-WinsmuxSubmissionReceipt -Kind $Kind -Status accepted -Backend $backend -SubmissionId $SubmissionId -Target $target `
+                    -Acknowledgement ([ordered]@{ type = 'backend_marker'; marker = $marker })
+            }
+            if ($attempt -lt $attempts) {
+                Start-Sleep -Milliseconds 300
+            }
+        }
+        return New-WinsmuxSubmissionReceipt -Kind $Kind -Status rejected -Backend $backend -SubmissionId $SubmissionId -ReasonCode 'backend_acknowledgement_missing' -Diagnostic 'Text delivery was not followed by the required backend acknowledgement marker.' -Target $target
+    }
+
+    $packet = New-WinsmuxSubmissionPacket -ProjectDir $ProjectDir -Kind $Kind -Content $Content -SubmissionId $SubmissionId -TargetLabel $label
+    if ($backend -eq 'api_llm') {
+        if ([string]::IsNullOrWhiteSpace($paneId)) {
+            return New-WinsmuxSubmissionReceipt -Kind $Kind -Status unavailable -Backend $backend -SubmissionId $SubmissionId -ReasonCode 'pane_unavailable' -Diagnostic 'The api_llm packet REPL pane id is missing.' -Target $target
+        }
+        $execCommand = "exec $($packet.RelativePath) $SubmissionId $SubmissionId"
+        try {
+            if ($null -ne $SendAction) { & $SendAction $paneId $execCommand } else { Send-TextToPane -PaneId $paneId -CommandText $execCommand }
+        } catch {
+            return New-WinsmuxSubmissionReceipt -Kind $Kind -Status unavailable -Backend $backend -SubmissionId $SubmissionId -ReasonCode 'packet_repl_unavailable' -Diagnostic $_.Exception.Message -Target $target
+        }
+        $runner = if ($null -ne $RunResultAction) { & $RunResultAction $ProjectDir $label $SubmissionId } else { Get-WinsmuxSubmissionRunResult -ProjectDir $ProjectDir -SlotId $label -RunId $SubmissionId }
+    } else {
+        $runner = if ($null -ne $CliRunAction) { & $CliRunAction $ProjectDir $label $packet.RelativePath $SubmissionId $backend $Kind } else { Invoke-WinsmuxSubmissionCliRun -ProjectDir $ProjectDir -SlotId $label -PacketPath $packet.RelativePath -SubmissionId $SubmissionId -Backend $backend -Kind $Kind }
+    }
+
+    $runnerStatus = [string](Get-WinsmuxSubmissionValue -InputObject $runner -Name 'status' -Default '')
+    $runnerReason = [string](Get-WinsmuxSubmissionValue -InputObject $runner -Name 'reason' -Default '')
+    $runnerExitCode = [int](Get-WinsmuxSubmissionValue -InputObject $runner -Name 'exit_code' -Default 1)
+    if ($runnerStatus -in @('succeeded', 'started', 'running') -and $runnerExitCode -eq 0) {
+        return New-WinsmuxSubmissionReceipt -Kind $Kind -Status accepted -Backend $backend -SubmissionId $SubmissionId -Target $target `
+            -Acknowledgement ([ordered]@{ type = 'run_receipt'; run_id = $SubmissionId; runner_status = $runnerStatus })
+    }
+    if ($runnerStatus -eq 'unavailable' -or $runnerReason -match '(missing|unavailable|unconfigured)') {
+        if ([string]::IsNullOrWhiteSpace($runnerReason)) { $runnerReason = 'backend_unavailable' }
+        return New-WinsmuxSubmissionReceipt -Kind $Kind -Status unavailable -Backend $backend -SubmissionId $SubmissionId -ReasonCode $runnerReason -Diagnostic 'The backend runner did not start.' -Target $target
+    }
+    if ([string]::IsNullOrWhiteSpace($runnerReason)) { $runnerReason = 'runner_rejected_submission' }
+    return New-WinsmuxSubmissionReceipt -Kind $Kind -Status rejected -Backend $backend -SubmissionId $SubmissionId -ReasonCode $runnerReason -Diagnostic 'The backend runner refused or failed the submission.' -Target $target
+}

--- a/winsmux-core/scripts/submission-contract.ps1
+++ b/winsmux-core/scripts/submission-contract.ps1
@@ -89,6 +89,18 @@ function ConvertTo-WinsmuxSubmissionStringArray {
     )
 }
 
+function Get-WinsmuxSubmissionRequestDigest {
+    param([Parameter(Mandatory = $true)][AllowEmptyString()][string]$Request)
+
+    $algorithm = [System.Security.Cryptography.SHA256]::Create()
+    try {
+        $hash = $algorithm.ComputeHash([System.Text.Encoding]::UTF8.GetBytes($Request))
+        return ([System.BitConverter]::ToString($hash).Replace('-', '').ToLowerInvariant())
+    } finally {
+        $algorithm.Dispose()
+    }
+}
+
 function New-WinsmuxSubmissionPacketData {
     param(
         [Parameter(Mandatory = $true)][ValidateSet('task', 'review')][string]$Kind,
@@ -124,6 +136,7 @@ function New-WinsmuxSubmissionPacketData {
     if ([string]::IsNullOrWhiteSpace($request)) {
         $request = $title
     }
+    $requestDigest = Get-WinsmuxSubmissionRequestDigest -Request $request
 
     return [ordered]@{
         protocol_version = 1
@@ -134,6 +147,7 @@ function New-WinsmuxSubmissionPacketData {
         target           = $TargetLabel
         title            = $title
         request          = $request
+        request_digest   = $requestDigest
         files            = @($files)
         tests            = @($tests)
         constraints      = @($constraints)
@@ -155,6 +169,7 @@ function Test-WinsmuxSubmissionPacket {
     $targetValue = Get-WinsmuxSubmissionRawValue -InputObject $Packet -Name 'target' -Default $null
     $titleValue = Get-WinsmuxSubmissionRawValue -InputObject $Packet -Name 'title' -Default $null
     $requestValue = Get-WinsmuxSubmissionRawValue -InputObject $Packet -Name 'request' -Default $null
+    $requestDigestValue = Get-WinsmuxSubmissionRawValue -InputObject $Packet -Name 'request_digest' -Default $null
     $branchValue = Get-WinsmuxSubmissionRawValue -InputObject $Packet -Name 'branch' -Default $null
     $headShaValue = Get-WinsmuxSubmissionRawValue -InputObject $Packet -Name 'head_sha' -Default $null
     $submissionId = if ($submissionIdValue -is [string]) { $submissionIdValue } else { '' }
@@ -171,6 +186,8 @@ function Test-WinsmuxSubmissionPacket {
     if ([string]::IsNullOrWhiteSpace($titleValue)) { return $false }
     if ($requestValue -isnot [string]) { return $false }
     if ([string]::IsNullOrWhiteSpace($requestValue)) { return $false }
+    if ($requestDigestValue -isnot [string] -or $requestDigestValue -cnotmatch '^[0-9a-f]{64}$') { return $false }
+    if ($requestDigestValue -cne (Get-WinsmuxSubmissionRequestDigest -Request $requestValue)) { return $false }
     foreach ($fieldName in @('files', 'tests', 'constraints')) {
         $fieldValue = Get-WinsmuxSubmissionRawValue -InputObject $Packet -Name $fieldName -Default $null
         if (-not (Test-WinsmuxSubmissionStringArray -Value $fieldValue)) { return $false }
@@ -233,6 +250,7 @@ function New-WinsmuxSubmissionRunRecord {
         [Parameter(Mandatory = $true)][string]$SlotId,
         [Parameter(Mandatory = $true)][ValidateSet('local', 'codex', 'api_llm', 'antigravity', 'colab_cli')][string]$Backend,
         [Parameter(Mandatory = $true)][ValidateSet('started', 'running', 'succeeded', 'failed')][string]$Status,
+        [Parameter(Mandatory = $true)][ValidatePattern('^[0-9a-f]{64}$')][string]$RequestDigest,
         [switch]$RequestConsumed,
         [AllowEmptyString()][string]$Reason = ''
     )
@@ -251,6 +269,7 @@ function New-WinsmuxSubmissionRunRecord {
         status           = $Status
         backend_owned    = $true
         request_consumed = [bool]$RequestConsumed
+        request_digest   = $RequestDigest
         reason           = $Reason
         exit_code        = if ($Status -eq 'failed') { 1 } else { 0 }
         generated_at     = (Get-Date).ToUniversalTime().ToString('o')
@@ -263,7 +282,8 @@ function Test-WinsmuxSubmissionRunRecord {
         [Parameter(Mandatory = $true)][string]$SubmissionId,
         [Parameter(Mandatory = $true)][ValidateSet('task', 'review')][string]$Kind,
         [Parameter(Mandatory = $true)][string]$Backend,
-        [string]$ExpectedSlotId = ''
+        [string]$ExpectedSlotId = '',
+        [string]$ExpectedRequestDigest = ''
     )
 
     if ($null -eq $Record) { return $false }
@@ -275,6 +295,7 @@ function Test-WinsmuxSubmissionRunRecord {
     $recordSlotId = Get-WinsmuxSubmissionValue -InputObject $Record -Name 'slot_id' -Default $null
     $backendOwned = Get-WinsmuxSubmissionValue -InputObject $Record -Name 'backend_owned' -Default $null
     $requestConsumed = Get-WinsmuxSubmissionValue -InputObject $Record -Name 'request_consumed' -Default $null
+    $requestDigest = Get-WinsmuxSubmissionValue -InputObject $Record -Name 'request_digest' -Default $null
     $exitCode = Get-WinsmuxSubmissionRawValue -InputObject $Record -Name 'exit_code' -Default $null
     return (
         [int64]$version -eq 1 -and
@@ -291,7 +312,62 @@ function Test-WinsmuxSubmissionRunRecord {
         [string](Get-WinsmuxSubmissionValue -InputObject $Record -Name 'status' -Default '') -cin $script:WinsmuxSubmissionRunStatuses -and
         ($backendOwned -is [bool]) -and $backendOwned -eq $true -and
         ($requestConsumed -is [bool]) -and $requestConsumed -eq $true -and
+        ($requestDigest -is [string]) -and $requestDigest -cmatch '^[0-9a-f]{64}$' -and
+        ([string]::IsNullOrWhiteSpace($ExpectedRequestDigest) -or $requestDigest -ceq $ExpectedRequestDigest) -and
         (Test-WinsmuxSubmissionInteger -Value $exitCode) -and [int64]$exitCode -eq 0
+    )
+}
+
+function ConvertTo-WinsmuxPublicAcknowledgement {
+    param([AllowNull()]$Acknowledgement)
+
+    if ($null -eq $Acknowledgement) { return $null }
+    return [ordered]@{
+        type             = [string](Get-WinsmuxSubmissionValue -InputObject $Acknowledgement -Name 'type' -Default '')
+        protocol_version = Get-WinsmuxSubmissionRawValue -InputObject $Acknowledgement -Name 'protocol_version' -Default $null
+        status           = [string](Get-WinsmuxSubmissionValue -InputObject $Acknowledgement -Name 'status' -Default '')
+        submission_id    = [string](Get-WinsmuxSubmissionValue -InputObject $Acknowledgement -Name 'submission_id' -Default '')
+        run_id           = [string](Get-WinsmuxSubmissionValue -InputObject $Acknowledgement -Name 'run_id' -Default '')
+        kind             = [string](Get-WinsmuxSubmissionValue -InputObject $Acknowledgement -Name 'kind' -Default '')
+        backend          = [string](Get-WinsmuxSubmissionValue -InputObject $Acknowledgement -Name 'backend' -Default '')
+        slot_id          = [string](Get-WinsmuxSubmissionValue -InputObject $Acknowledgement -Name 'slot_id' -Default '')
+        worker_kind      = [string](Get-WinsmuxSubmissionValue -InputObject $Acknowledgement -Name 'worker_kind' -Default '')
+        request_digest   = [string](Get-WinsmuxSubmissionValue -InputObject $Acknowledgement -Name 'request_digest' -Default '')
+    }
+}
+
+function Test-WinsmuxPublicAcknowledgement {
+    param(
+        [AllowNull()]$Acknowledgement,
+        [Parameter(Mandatory = $true)][string]$SubmissionId,
+        [Parameter(Mandatory = $true)][ValidateSet('task', 'review')][string]$Kind,
+        [Parameter(Mandatory = $true)][string]$Backend,
+        [Parameter(Mandatory = $true)][string]$ExpectedSlotId
+    )
+
+    if ($null -eq $Acknowledgement) { return $false }
+    $allowedNames = @('type', 'protocol_version', 'status', 'submission_id', 'run_id', 'kind', 'backend', 'slot_id', 'worker_kind', 'request_digest')
+    $actualNames = if ($Acknowledgement -is [System.Collections.IDictionary]) {
+        @($Acknowledgement.Keys | ForEach-Object { [string]$_ })
+    } else {
+        @($Acknowledgement.PSObject.Properties.Name)
+    }
+    if ($actualNames.Count -ne $allowedNames.Count -or @($actualNames | Where-Object { $_ -cnotin $allowedNames }).Count -gt 0) {
+        return $false
+    }
+    $version = Get-WinsmuxSubmissionRawValue -InputObject $Acknowledgement -Name 'protocol_version' -Default $null
+    $workerKind = if ($Kind -eq 'review') { 'critic' } else { 'implementation' }
+    return (
+        (Test-WinsmuxSubmissionInteger -Value $version) -and [int64]$version -eq 1 -and
+        [string](Get-WinsmuxSubmissionValue -InputObject $Acknowledgement -Name 'type' -Default '') -ceq 'backend_run_record' -and
+        [string](Get-WinsmuxSubmissionValue -InputObject $Acknowledgement -Name 'status' -Default '') -cin $script:WinsmuxSubmissionRunStatuses -and
+        [string](Get-WinsmuxSubmissionValue -InputObject $Acknowledgement -Name 'submission_id' -Default '') -ceq $SubmissionId -and
+        [string](Get-WinsmuxSubmissionValue -InputObject $Acknowledgement -Name 'run_id' -Default '') -ceq $SubmissionId -and
+        [string](Get-WinsmuxSubmissionValue -InputObject $Acknowledgement -Name 'kind' -Default '') -ceq $Kind -and
+        [string](Get-WinsmuxSubmissionValue -InputObject $Acknowledgement -Name 'backend' -Default '') -ceq $Backend -and
+        [string](Get-WinsmuxSubmissionValue -InputObject $Acknowledgement -Name 'slot_id' -Default '') -ceq $ExpectedSlotId -and
+        [string](Get-WinsmuxSubmissionValue -InputObject $Acknowledgement -Name 'worker_kind' -Default '') -ceq $workerKind -and
+        [string](Get-WinsmuxSubmissionValue -InputObject $Acknowledgement -Name 'request_digest' -Default '') -cmatch '^[0-9a-f]{64}$'
     )
 }
 
@@ -318,7 +394,7 @@ function New-WinsmuxSubmissionReceipt {
         diagnostic       = ConvertTo-WinsmuxSubmissionDiagnostic -Text $Diagnostic
         target           = $Target
         routing          = $Routing
-        acknowledgement  = $Acknowledgement
+        acknowledgement  = ConvertTo-WinsmuxPublicAcknowledgement -Acknowledgement $Acknowledgement
     }
 }
 
@@ -346,7 +422,7 @@ function Test-WinsmuxSubmissionReceipt {
         $target = Get-WinsmuxSubmissionValue -InputObject $Receipt -Name 'target' -Default $null
         $targetLabel = [string](Get-WinsmuxSubmissionValue -InputObject $target -Name 'label' -Default '')
         if (-not (Test-WinsmuxSubmissionIdentifier -Value $targetLabel)) { return $false }
-        return Test-WinsmuxSubmissionRunRecord -Record $evidence -SubmissionId $submissionId -Kind $kind -Backend $backend -ExpectedSlotId $targetLabel
+        return Test-WinsmuxPublicAcknowledgement -Acknowledgement $evidence -SubmissionId $submissionId -Kind $kind -Backend $backend -ExpectedSlotId $targetLabel
     }
     return $true
 }
@@ -447,32 +523,8 @@ function Invoke-WinsmuxSubmissionAcknowledge {
         [Parameter(Mandatory = $true)][ValidateSet('local', 'codex')][string]$Backend
     )
 
-    $packetPath = Join-Path (Join-Path (Join-Path $ProjectDir '.winsmux') 'submissions') ($SubmissionId + '.json')
-    $packet = Read-WinsmuxSubmissionPacket -Path $packetPath
-    if ([string]$packet.submission_id -cne $SubmissionId -or [string]$packet.run_id -cne $RunId -or [string]$packet.kind -cne $Kind) {
-        throw 'submission acknowledgement does not match the packet id, run id, or kind'
-    }
-    if ([string]$packet.target -cne $SlotId) {
-        throw 'submission acknowledgement slot does not match the packet target'
-    }
-    if ([string]::IsNullOrWhiteSpace($env:WINSMUX_PANE_ID)) {
-        throw 'submission acknowledgement requires WINSMUX_PANE_ID'
-    }
-    $manifestEntry = @(Get-PaneControlManifestEntries -ProjectDir $ProjectDir | Where-Object { [string]$_.Label -ceq $SlotId }) | Select-Object -First 1
-    if ($null -eq $manifestEntry -or [string]$manifestEntry.PaneId -cne [string]$env:WINSMUX_PANE_ID) {
-        throw 'submission acknowledgement caller does not match the manifest target pane'
-    }
-    $manifestBackend = ([string]$manifestEntry.WorkerBackend).Trim().ToLowerInvariant()
-    if ($manifestBackend -cne $Backend) {
-        throw 'submission acknowledgement backend does not match the manifest target backend'
-    }
-    $runPath = Get-WinsmuxSubmissionRunPath -ProjectDir $ProjectDir -SlotId $SlotId -RunId $RunId
-    if (Test-Path -LiteralPath $runPath -PathType Leaf) {
-        throw 'submission acknowledgement run record already exists'
-    }
-    $record = New-WinsmuxSubmissionRunRecord -SubmissionId $SubmissionId -RunId $RunId -Kind $Kind -TaskTitle ([string]$packet.title) -SlotId $SlotId -Backend $Backend -Status started -RequestConsumed
-    Write-WinsmuxSubmissionRunRecord -ProjectDir $ProjectDir -SlotId $SlotId -Record $record | Out-Null
-    return $record
+    return New-WinsmuxSubmissionReceipt -Kind $Kind -Status unavailable -Backend $Backend -SubmissionId $SubmissionId `
+        -ReasonCode 'caller_identity_unavailable' -Target ([ordered]@{ label = $SlotId })
 }
 
 function Invoke-WinsmuxSubmissionCliRun {
@@ -535,18 +587,7 @@ function Invoke-WinsmuxSubmissionAdapter {
         return New-WinsmuxSubmissionReceipt -Kind $Kind -Status rejected -Backend $backend -SubmissionId $SubmissionId -ReasonCode 'run_record_already_exists' -Target $target
     }
     if ($backend -in @('local', 'codex')) {
-        if ([string]::IsNullOrWhiteSpace($paneId)) {
-            return New-WinsmuxSubmissionReceipt -Kind $Kind -Status unavailable -Backend $backend -SubmissionId $SubmissionId -ReasonCode 'pane_unavailable' -Target $target
-        }
-        $ackCommand = "winsmux submission-ack --submission-id $SubmissionId --run-id $SubmissionId --kind $Kind --backend $backend --slot $label"
-        $commandText = "Read and validate the version-1 submission packet at '$($packet.RelativePath)'. Before other work, execute: $ackCommand"
-        try {
-            if ($null -ne $SendAction) { & $SendAction $paneId $commandText | Out-Null }
-            else { Send-TextToPane -PaneId $paneId -CommandText $commandText | Out-Null }
-        } catch {
-            return New-WinsmuxSubmissionReceipt -Kind $Kind -Status unavailable -Backend $backend -SubmissionId $SubmissionId -ReasonCode 'pane_send_failed' -Diagnostic $_.Exception.Message -Target $target
-        }
-        $runner = if ($null -ne $RunResultAction) { & $RunResultAction $ProjectDir $label $SubmissionId } else { Get-WinsmuxSubmissionRunResult -ProjectDir $ProjectDir -SlotId $label -RunId $SubmissionId }
+        return New-WinsmuxSubmissionReceipt -Kind $Kind -Status unavailable -Backend $backend -SubmissionId $SubmissionId -ReasonCode 'caller_identity_unavailable' -Target $target
     } elseif ($backend -eq 'api_llm') {
         if ([string]::IsNullOrWhiteSpace($paneId)) {
             return New-WinsmuxSubmissionReceipt -Kind $Kind -Status unavailable -Backend $backend -SubmissionId $SubmissionId -ReasonCode 'pane_unavailable' -Target $target
@@ -563,7 +604,7 @@ function Invoke-WinsmuxSubmissionAdapter {
         $runner = if ($null -ne $CliRunAction) { & $CliRunAction $ProjectDir $label $packet.RelativePath $SubmissionId $backend $Kind } else { Invoke-WinsmuxSubmissionCliRun -ProjectDir $ProjectDir -SlotId $label -PacketPath $packet.RelativePath -SubmissionId $SubmissionId -Backend $backend -Kind $Kind }
     }
 
-    if (Test-WinsmuxSubmissionRunRecord -Record $runner -SubmissionId $SubmissionId -Kind $Kind -Backend $backend -ExpectedSlotId $label) {
+    if (Test-WinsmuxSubmissionRunRecord -Record $runner -SubmissionId $SubmissionId -Kind $Kind -Backend $backend -ExpectedSlotId $label -ExpectedRequestDigest ([string]$packet.Packet.request_digest)) {
         return New-WinsmuxSubmissionReceipt -Kind $Kind -Status accepted -Backend $backend -SubmissionId $SubmissionId -Target $target -Acknowledgement $runner
     }
     $runnerStatus = [string](Get-WinsmuxSubmissionValue -InputObject $runner -Name 'status' -Default '')

--- a/winsmux-core/scripts/submission-contract.ps1
+++ b/winsmux-core/scripts/submission-contract.ps1
@@ -418,29 +418,54 @@ function Test-WinsmuxSubmissionReceipt {
     param([AllowNull()]$Receipt)
 
     if ($null -eq $Receipt) { return $false }
+    $allowedNames = @('protocol_version', 'submission_id', 'kind', 'status', 'backend', 'reason_code', 'diagnostic', 'target', 'routing', 'acknowledgement')
+    $actualNames = @(
+        if ($Receipt -is [System.Collections.IDictionary]) {
+            $Receipt.Keys | ForEach-Object { [string]$_ }
+        } else {
+            $Receipt.PSObject.Properties.Name
+        }
+    )
+    if ($actualNames.Count -ne $allowedNames.Count -or @($actualNames | Where-Object { $_ -cnotin $allowedNames }).Count -gt 0) {
+        return $false
+    }
     $version = Get-WinsmuxSubmissionRawValue -InputObject $Receipt -Name 'protocol_version' -Default $null
     if (-not (Test-WinsmuxSubmissionInteger -Value $version)) { return $false }
     $status = [string](Get-WinsmuxSubmissionValue -InputObject $Receipt -Name 'status' -Default '')
     $kind = [string](Get-WinsmuxSubmissionValue -InputObject $Receipt -Name 'kind' -Default '')
     $backend = [string](Get-WinsmuxSubmissionValue -InputObject $Receipt -Name 'backend' -Default '')
     $submissionId = [string](Get-WinsmuxSubmissionValue -InputObject $Receipt -Name 'submission_id' -Default '')
+    $reasonCodeValue = Get-WinsmuxSubmissionRawValue -InputObject $Receipt -Name 'reason_code' -Default $null
+    $diagnosticValue = Get-WinsmuxSubmissionRawValue -InputObject $Receipt -Name 'diagnostic' -Default $null
+    $acknowledgement = Get-WinsmuxSubmissionRawValue -InputObject $Receipt -Name 'acknowledgement' -Default $null
     if (
         [int64]$version -ne 1 -or
         $status -cnotin $script:WinsmuxSubmissionStatuses -or
         $kind -cnotin $script:WinsmuxSubmissionKinds -or
         $backend -cnotin $script:WinsmuxSubmissionBackends -or
-        -not (Test-WinsmuxSubmissionIdentifier -Value $submissionId)
+        -not (Test-WinsmuxSubmissionIdentifier -Value $submissionId) -or
+        $reasonCodeValue -isnot [string] -or
+        $diagnosticValue -isnot [string]
     ) {
         return $false
     }
+    $reasonCode = [string]$reasonCodeValue
+    $diagnostic = [string]$diagnosticValue
     if ($status -eq 'accepted') {
-        $evidence = Get-WinsmuxSubmissionValue -InputObject $Receipt -Name 'acknowledgement' -Default $null
+        if ($reasonCode -cne '') { return $false }
+    } elseif ($reasonCode -cnotmatch '^[a-z][a-z0-9_]*$') {
+        return $false
+    }
+    if ($diagnostic -cne (ConvertTo-WinsmuxSubmissionDiagnostic -Text $diagnostic)) {
+        return $false
+    }
+    if ($status -eq 'accepted') {
         $target = Get-WinsmuxSubmissionValue -InputObject $Receipt -Name 'target' -Default $null
         $targetLabel = [string](Get-WinsmuxSubmissionValue -InputObject $target -Name 'label' -Default '')
         if (-not (Test-WinsmuxSubmissionIdentifier -Value $targetLabel)) { return $false }
-        return Test-WinsmuxPublicAcknowledgement -Acknowledgement $evidence -SubmissionId $submissionId -Kind $kind -Backend $backend -ExpectedSlotId $targetLabel
+        return Test-WinsmuxPublicAcknowledgement -Acknowledgement $acknowledgement -SubmissionId $submissionId -Kind $kind -Backend $backend -ExpectedSlotId $targetLabel
     }
-    return $true
+    return $null -eq $acknowledgement
 }
 
 function ConvertTo-WinsmuxSubmissionReceiptJson {
@@ -549,6 +574,7 @@ function Invoke-WinsmuxSubmissionCliRun {
         [Parameter(Mandatory = $true)][string]$SlotId,
         [Parameter(Mandatory = $true)][string]$PacketPath,
         [Parameter(Mandatory = $true)][string]$SubmissionId,
+        [Parameter(Mandatory = $true)][string]$TaskId,
         [Parameter(Mandatory = $true)][string]$Backend,
         [Parameter(Mandatory = $true)][ValidateSet('task', 'review')][string]$Kind
     )
@@ -560,7 +586,7 @@ function Invoke-WinsmuxSubmissionCliRun {
     } else {
         $workerArguments += @('--task-json', $PacketPath)
     }
-    $workerArguments += @('--task-id', $SubmissionId, '--run-id', $SubmissionId, '--json', '--project-dir', $ProjectDir)
+    $workerArguments += @('--task-id', $TaskId, '--run-id', $SubmissionId, '--json', '--project-dir', $ProjectDir)
     $output = & pwsh -NoProfile -File $script:WinsmuxSubmissionBridgeScript @workerArguments 2>&1
     $exitCode = $LASTEXITCODE
     $jsonLine = @($output | ForEach-Object { [string]$_ } | Where-Object { $_.TrimStart().StartsWith('{') } | Select-Object -Last 1)
@@ -602,14 +628,15 @@ function Invoke-WinsmuxSubmissionAdapter {
         return New-WinsmuxSubmissionReceipt -Kind $Kind -Status unsupported -Backend noop -SubmissionId $SubmissionId -ReasonCode 'backend_unsupported' -Target $target
     }
 
-    $packet = New-WinsmuxSubmissionPacket -ProjectDir $ProjectDir -Kind $Kind -Content $Content -SubmissionId $SubmissionId -TargetLabel $label -TaskId $TaskId
     $existingRunPath = Get-WinsmuxSubmissionRunPath -ProjectDir $ProjectDir -SlotId $label -RunId $SubmissionId
     if (Test-Path -LiteralPath $existingRunPath -PathType Leaf) {
         return New-WinsmuxSubmissionReceipt -Kind $Kind -Status rejected -Backend $backend -SubmissionId $SubmissionId -ReasonCode 'run_record_already_exists' -Target $target
     }
     if ($backend -in @('local', 'codex')) {
         return New-WinsmuxSubmissionReceipt -Kind $Kind -Status unavailable -Backend $backend -SubmissionId $SubmissionId -ReasonCode 'caller_identity_unavailable' -Target $target
-    } elseif ($backend -eq 'api_llm') {
+    }
+    $packet = New-WinsmuxSubmissionPacket -ProjectDir $ProjectDir -Kind $Kind -Content $Content -SubmissionId $SubmissionId -TargetLabel $label -TaskId $TaskId
+    if ($backend -eq 'api_llm') {
         if ([string]::IsNullOrWhiteSpace($paneId)) {
             return New-WinsmuxSubmissionReceipt -Kind $Kind -Status unavailable -Backend $backend -SubmissionId $SubmissionId -ReasonCode 'pane_unavailable' -Target $target
         }
@@ -622,7 +649,7 @@ function Invoke-WinsmuxSubmissionAdapter {
         }
         $runner = if ($null -ne $RunResultAction) { & $RunResultAction $ProjectDir $label $SubmissionId } else { Get-WinsmuxSubmissionRunResult -ProjectDir $ProjectDir -SlotId $label -RunId $SubmissionId }
     } else {
-        $runner = if ($null -ne $CliRunAction) { & $CliRunAction $ProjectDir $label $packet.RelativePath $SubmissionId $backend $Kind } else { Invoke-WinsmuxSubmissionCliRun -ProjectDir $ProjectDir -SlotId $label -PacketPath $packet.RelativePath -SubmissionId $SubmissionId -Backend $backend -Kind $Kind }
+        $runner = if ($null -ne $CliRunAction) { & $CliRunAction $ProjectDir $label $packet.RelativePath $SubmissionId $backend $Kind } else { Invoke-WinsmuxSubmissionCliRun -ProjectDir $ProjectDir -SlotId $label -PacketPath $packet.RelativePath -SubmissionId $SubmissionId -TaskId $TaskId -Backend $backend -Kind $Kind }
     }
 
     if (Test-WinsmuxSubmissionRunRecord -Record $runner -SubmissionId $SubmissionId -Kind $Kind -Backend $backend -ExpectedSlotId $label -ExpectedRequestDigest ([string]$packet.Packet.request_digest) -ExpectedTaskId ([string]$packet.Packet.task_id)) {
@@ -630,9 +657,9 @@ function Invoke-WinsmuxSubmissionAdapter {
     }
     $runnerStatus = [string](Get-WinsmuxSubmissionValue -InputObject $runner -Name 'status' -Default '')
     $runnerReason = [string](Get-WinsmuxSubmissionValue -InputObject $runner -Name 'reason' -Default '')
-    $unavailableAllow = '^(backend_unavailable|cli_command_missing|cli_receipt_malformed|[a-z0-9]+(_[a-z0-9]+)*_cli_missing|[a-z0-9]+(_[a-z0-9]+)*_runner_unconfigured|api_llm_api_key_env_missing)$'
+    $unavailableAllow = '^(backend_unavailable|cli_command_missing|cli_receipt_malformed|api_llm_runner_unconfigured|api_llm_api_key_env_missing|antigravity_runner_unconfigured|antigravity_cli_missing)$'
     $rejectedAllow = '^(runner_rejected_packet|runner_receipt_malformed|runner_acknowledgement_missing|backend_acknowledgement_missing|run_record_already_exists)$'
-    if ($runnerStatus -eq 'unavailable') {
+    if ($runnerStatus -in @('unavailable', 'blocked')) {
         $reasonCode = if ($runnerReason -cmatch $unavailableAllow) { $runnerReason } else { 'backend_unavailable' }
         return New-WinsmuxSubmissionReceipt -Kind $Kind -Status unavailable -Backend $backend -SubmissionId $SubmissionId -ReasonCode $reasonCode -Target $target
     }

--- a/winsmux-core/scripts/submission-contract.ps1
+++ b/winsmux-core/scripts/submission-contract.ps1
@@ -4,6 +4,8 @@ $script:WinsmuxSubmissionProtocolVersion = 1
 $script:WinsmuxSubmissionStatuses = @('accepted', 'rejected', 'unsupported', 'unavailable')
 $script:WinsmuxSubmissionKinds = @('task', 'review')
 $script:WinsmuxSubmissionBackends = @('local', 'codex', 'api_llm', 'antigravity', 'colab_cli', 'noop')
+$script:WinsmuxSubmissionEvidenceTypes = @('backend_run_record')
+$script:WinsmuxSubmissionRunStatuses = @('started', 'running', 'succeeded')
 $script:WinsmuxSubmissionBridgeScript = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\..\scripts\winsmux-core.ps1'))
 
 function ConvertTo-WinsmuxSubmissionDiagnostic {
@@ -12,9 +14,10 @@ function ConvertTo-WinsmuxSubmissionDiagnostic {
     if ([string]::IsNullOrWhiteSpace($Text)) {
         return ''
     }
-    $safe = $Text -replace '(?i)[A-Z]:\\Users\\[^,;\r\n]+', '<local-path>'
-    $safe = $safe -replace '(?i)\\\\[^\\\s]+\\[^,;\r\n]+', '<network-path>'
-    return $safe.Trim()
+    if (-not (Get-Command ConvertTo-WorkersSafeLogText -ErrorAction SilentlyContinue)) {
+        return '[DIAGNOSTIC_REDACTED]'
+    }
+    return (ConvertTo-WorkersSafeLogText -Text $Text).Trim()
 }
 
 function Get-WinsmuxSubmissionValue {
@@ -24,20 +27,272 @@ function Get-WinsmuxSubmissionValue {
         [AllowNull()]$Default = $null
     )
 
-    if ($null -eq $InputObject) {
-        return $Default
-    }
+    if ($null -eq $InputObject) { return $Default }
     if ($InputObject -is [System.Collections.IDictionary]) {
-        if ($InputObject.Contains($Name)) {
-            return $InputObject[$Name]
-        }
+        if ($InputObject.Contains($Name)) { return $InputObject[$Name] }
         return $Default
     }
     $property = $InputObject.PSObject.Properties[$Name]
-    if ($null -ne $property) {
-        return $property.Value
-    }
+    if ($null -ne $property) { return $property.Value }
     return $Default
+}
+
+function Get-WinsmuxSubmissionRawValue {
+    param(
+        [AllowNull()]$InputObject,
+        [Parameter(Mandatory = $true)][string]$Name,
+        [AllowNull()]$Default = $null
+    )
+
+    if ($null -eq $InputObject) { return ,$Default }
+    if ($InputObject -is [System.Collections.IDictionary]) {
+        if ($InputObject.Contains($Name)) { return ,$InputObject[$Name] }
+        return ,$Default
+    }
+    $property = $InputObject.PSObject.Properties[$Name]
+    if ($null -ne $property) { return ,$property.Value }
+    return ,$Default
+}
+
+function Test-WinsmuxSubmissionIdentifier {
+    param([AllowEmptyString()][string]$Value = '')
+    return $Value -match '^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$'
+}
+
+function Test-WinsmuxSubmissionInteger {
+    param([AllowNull()]$Value)
+
+    return ($Value -is [byte]) -or ($Value -is [sbyte]) -or
+        ($Value -is [int16]) -or ($Value -is [uint16]) -or
+        ($Value -is [int32]) -or ($Value -is [uint32]) -or
+        ($Value -is [int64]) -or ($Value -is [uint64])
+}
+
+function Test-WinsmuxSubmissionStringArray {
+    param([AllowNull()]$Value)
+
+    if ($null -eq $Value -or $Value -isnot [System.Array]) { return $false }
+    foreach ($item in $Value) {
+        if ($item -isnot [string]) { return $false }
+    }
+    return $true
+}
+
+function ConvertTo-WinsmuxSubmissionStringArray {
+    param([AllowNull()]$Value)
+
+    return @(
+        @($Value) |
+            ForEach-Object { ([string]$_).Trim() } |
+            Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+            Select-Object -Unique
+    )
+}
+
+function New-WinsmuxSubmissionPacketData {
+    param(
+        [Parameter(Mandatory = $true)][ValidateSet('task', 'review')][string]$Kind,
+        [Parameter(Mandatory = $true)]$Content,
+        [Parameter(Mandatory = $true)][string]$SubmissionId,
+        [Parameter(Mandatory = $true)][string]$TargetLabel
+    )
+
+    if (-not (Test-WinsmuxSubmissionIdentifier -Value $SubmissionId)) {
+        throw 'submission id contains unsupported characters'
+    }
+    $title = ''
+    $request = ''
+    $files = @()
+    $tests = @()
+    $constraints = @()
+    $branch = ''
+    $headSha = ''
+    if ($Content -is [System.Collections.IDictionary] -or $null -ne $Content.PSObject.Properties['request']) {
+        $title = [string](Get-WinsmuxSubmissionValue -InputObject $Content -Name 'title' -Default '')
+        $request = [string](Get-WinsmuxSubmissionValue -InputObject $Content -Name 'request' -Default '')
+        $files = @(ConvertTo-WinsmuxSubmissionStringArray -Value (Get-WinsmuxSubmissionValue -InputObject $Content -Name 'files' -Default @()))
+        $tests = @(ConvertTo-WinsmuxSubmissionStringArray -Value (Get-WinsmuxSubmissionValue -InputObject $Content -Name 'tests' -Default @()))
+        $constraints = @(ConvertTo-WinsmuxSubmissionStringArray -Value (Get-WinsmuxSubmissionValue -InputObject $Content -Name 'constraints' -Default @()))
+        $branch = [string](Get-WinsmuxSubmissionValue -InputObject $Content -Name 'branch' -Default '')
+        $headSha = [string](Get-WinsmuxSubmissionValue -InputObject $Content -Name 'head_sha' -Default '')
+    } else {
+        $request = ([string]$Content).Trim()
+    }
+    if ([string]::IsNullOrWhiteSpace($title)) {
+        $title = if ($request.Length -le 120) { $request } else { $request.Substring(0, 120) }
+    }
+    if ([string]::IsNullOrWhiteSpace($request)) {
+        $request = $title
+    }
+
+    return [ordered]@{
+        protocol_version = 1
+        submission_id    = $SubmissionId
+        run_id           = $SubmissionId
+        task_id          = $SubmissionId
+        kind             = $Kind
+        target           = $TargetLabel
+        title            = $title
+        request          = $request
+        files            = @($files)
+        tests            = @($tests)
+        constraints      = @($constraints)
+        branch           = $branch
+        head_sha         = $headSha
+    }
+}
+
+function Test-WinsmuxSubmissionPacket {
+    param([AllowNull()]$Packet)
+
+    if ($null -eq $Packet) { return $false }
+    $version = Get-WinsmuxSubmissionRawValue -InputObject $Packet -Name 'protocol_version' -Default $null
+    if (-not (Test-WinsmuxSubmissionInteger -Value $version)) { return $false }
+    $submissionIdValue = Get-WinsmuxSubmissionRawValue -InputObject $Packet -Name 'submission_id' -Default $null
+    $runIdValue = Get-WinsmuxSubmissionRawValue -InputObject $Packet -Name 'run_id' -Default $null
+    $taskIdValue = Get-WinsmuxSubmissionRawValue -InputObject $Packet -Name 'task_id' -Default $null
+    $kindValue = Get-WinsmuxSubmissionRawValue -InputObject $Packet -Name 'kind' -Default $null
+    $targetValue = Get-WinsmuxSubmissionRawValue -InputObject $Packet -Name 'target' -Default $null
+    $titleValue = Get-WinsmuxSubmissionRawValue -InputObject $Packet -Name 'title' -Default $null
+    $requestValue = Get-WinsmuxSubmissionRawValue -InputObject $Packet -Name 'request' -Default $null
+    $branchValue = Get-WinsmuxSubmissionRawValue -InputObject $Packet -Name 'branch' -Default $null
+    $headShaValue = Get-WinsmuxSubmissionRawValue -InputObject $Packet -Name 'head_sha' -Default $null
+    $submissionId = if ($submissionIdValue -is [string]) { $submissionIdValue } else { '' }
+    $runId = if ($runIdValue -is [string]) { $runIdValue } else { '' }
+    $taskId = if ($taskIdValue -is [string]) { $taskIdValue } else { '' }
+    $kind = if ($kindValue -is [string]) { $kindValue } else { '' }
+    if ([int64]$version -ne 1) { return $false }
+    if (-not (Test-WinsmuxSubmissionIdentifier -Value $submissionId)) { return $false }
+    if ($runId -cne $submissionId -or $taskId -cne $submissionId) { return $false }
+    if ($kind -cnotin $script:WinsmuxSubmissionKinds) { return $false }
+    if ($targetValue -isnot [string]) { return $false }
+    if (-not (Test-WinsmuxSubmissionIdentifier -Value $targetValue)) { return $false }
+    if ($titleValue -isnot [string]) { return $false }
+    if ([string]::IsNullOrWhiteSpace($titleValue)) { return $false }
+    if ($requestValue -isnot [string]) { return $false }
+    if ([string]::IsNullOrWhiteSpace($requestValue)) { return $false }
+    foreach ($fieldName in @('files', 'tests', 'constraints')) {
+        $fieldValue = Get-WinsmuxSubmissionRawValue -InputObject $Packet -Name $fieldName -Default $null
+        if (-not (Test-WinsmuxSubmissionStringArray -Value $fieldValue)) { return $false }
+    }
+    if ($branchValue -isnot [string]) { return $false }
+    if ($headShaValue -isnot [string]) { return $false }
+    if (-not [string]::IsNullOrWhiteSpace($headShaValue) -and $headShaValue -notmatch '^[0-9a-fA-F]{40}$') { return $false }
+    return $true
+}
+
+function New-WinsmuxSubmissionPacket {
+    param(
+        [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [Parameter(Mandatory = $true)][ValidateSet('task', 'review')][string]$Kind,
+        [Parameter(Mandatory = $true)]$Content,
+        [Parameter(Mandatory = $true)][string]$SubmissionId,
+        [Parameter(Mandatory = $true)][string]$TargetLabel
+    )
+
+    $packet = New-WinsmuxSubmissionPacketData -Kind $Kind -Content $Content -SubmissionId $SubmissionId -TargetLabel $TargetLabel
+    $relativePath = Join-Path (Join-Path '.winsmux' 'submissions') ($SubmissionId + '.json')
+    $fullPath = [System.IO.Path]::GetFullPath((Join-Path $ProjectDir $relativePath))
+    $directory = Split-Path -Parent $fullPath
+    if (-not (Test-Path -LiteralPath $directory -PathType Container)) {
+        New-Item -ItemType Directory -Path $directory -Force | Out-Null
+    }
+    [System.IO.File]::WriteAllText($fullPath, ($packet | ConvertTo-Json -Depth 8), [System.Text.UTF8Encoding]::new($false))
+    return [PSCustomObject]@{ FullPath = $fullPath; RelativePath = $relativePath; Packet = $packet }
+}
+
+function Read-WinsmuxSubmissionPacket {
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    $packet = Get-Content -LiteralPath $Path -Raw -Encoding UTF8 | ConvertFrom-Json -Depth 16
+    if (-not (Test-WinsmuxSubmissionPacket -Packet $packet)) {
+        throw 'submission packet is malformed or uses an unknown protocol version, kind, or id'
+    }
+    return $packet
+}
+
+function Read-WinsmuxSubmissionPacketIfPresent {
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    $candidate = Get-Content -LiteralPath $Path -Raw -Encoding UTF8 | ConvertFrom-Json -Depth 16
+    $hasProtocol = $null -ne $candidate.PSObject.Properties['protocol_version']
+    $hasSubmissionId = $null -ne $candidate.PSObject.Properties['submission_id']
+    if (-not $hasProtocol -and -not $hasSubmissionId) { return $null }
+    if (-not (Test-WinsmuxSubmissionPacket -Packet $candidate)) {
+        throw 'submission packet is malformed or uses an unknown protocol version, kind, or id'
+    }
+    return $candidate
+}
+
+function New-WinsmuxSubmissionRunRecord {
+    param(
+        [Parameter(Mandatory = $true)][string]$SubmissionId,
+        [Parameter(Mandatory = $true)][string]$RunId,
+        [Parameter(Mandatory = $true)][ValidateSet('task', 'review')][string]$Kind,
+        [Parameter(Mandatory = $true)][string]$TaskTitle,
+        [Parameter(Mandatory = $true)][string]$SlotId,
+        [Parameter(Mandatory = $true)][ValidateSet('local', 'codex', 'api_llm', 'antigravity', 'colab_cli')][string]$Backend,
+        [Parameter(Mandatory = $true)][ValidateSet('started', 'running', 'succeeded', 'failed')][string]$Status,
+        [switch]$RequestConsumed,
+        [AllowEmptyString()][string]$Reason = ''
+    )
+
+    return [ordered]@{
+        protocol_version = 1
+        type             = 'backend_run_record'
+        submission_id    = $SubmissionId
+        run_id           = $RunId
+        kind             = $Kind
+        task_id          = $SubmissionId
+        task_title       = $TaskTitle
+        worker_kind      = if ($Kind -eq 'review') { 'critic' } else { 'implementation' }
+        slot_id          = $SlotId
+        backend          = $Backend
+        status           = $Status
+        backend_owned    = $true
+        request_consumed = [bool]$RequestConsumed
+        reason           = $Reason
+        exit_code        = if ($Status -eq 'failed') { 1 } else { 0 }
+        generated_at     = (Get-Date).ToUniversalTime().ToString('o')
+    }
+}
+
+function Test-WinsmuxSubmissionRunRecord {
+    param(
+        [AllowNull()]$Record,
+        [Parameter(Mandatory = $true)][string]$SubmissionId,
+        [Parameter(Mandatory = $true)][ValidateSet('task', 'review')][string]$Kind,
+        [Parameter(Mandatory = $true)][string]$Backend,
+        [string]$ExpectedSlotId = ''
+    )
+
+    if ($null -eq $Record) { return $false }
+    $version = Get-WinsmuxSubmissionRawValue -InputObject $Record -Name 'protocol_version' -Default $null
+    if (-not (Test-WinsmuxSubmissionInteger -Value $version)) { return $false }
+    $expectedWorkerKind = if ($Kind -eq 'review') { 'critic' } else { 'implementation' }
+    $taskTitle = Get-WinsmuxSubmissionValue -InputObject $Record -Name 'task_title' -Default $null
+    $workerKind = Get-WinsmuxSubmissionValue -InputObject $Record -Name 'worker_kind' -Default $null
+    $recordSlotId = Get-WinsmuxSubmissionValue -InputObject $Record -Name 'slot_id' -Default $null
+    $backendOwned = Get-WinsmuxSubmissionValue -InputObject $Record -Name 'backend_owned' -Default $null
+    $requestConsumed = Get-WinsmuxSubmissionValue -InputObject $Record -Name 'request_consumed' -Default $null
+    $exitCode = Get-WinsmuxSubmissionRawValue -InputObject $Record -Name 'exit_code' -Default $null
+    return (
+        [int64]$version -eq 1 -and
+        [string](Get-WinsmuxSubmissionValue -InputObject $Record -Name 'type' -Default '') -cin $script:WinsmuxSubmissionEvidenceTypes -and
+        [string](Get-WinsmuxSubmissionValue -InputObject $Record -Name 'submission_id' -Default '') -ceq $SubmissionId -and
+        [string](Get-WinsmuxSubmissionValue -InputObject $Record -Name 'run_id' -Default '') -ceq $SubmissionId -and
+        [string](Get-WinsmuxSubmissionValue -InputObject $Record -Name 'kind' -Default '') -ceq $Kind -and
+        [string](Get-WinsmuxSubmissionValue -InputObject $Record -Name 'task_id' -Default '') -ceq $SubmissionId -and
+        ($taskTitle -is [string]) -and (-not [string]::IsNullOrWhiteSpace($taskTitle)) -and
+        ($workerKind -is [string]) -and $workerKind -ceq $expectedWorkerKind -and
+        ($recordSlotId -is [string]) -and (Test-WinsmuxSubmissionIdentifier -Value $recordSlotId) -and
+        ([string]::IsNullOrWhiteSpace($ExpectedSlotId) -or $recordSlotId -ceq $ExpectedSlotId) -and
+        [string](Get-WinsmuxSubmissionValue -InputObject $Record -Name 'backend' -Default '') -ceq $Backend -and
+        [string](Get-WinsmuxSubmissionValue -InputObject $Record -Name 'status' -Default '') -cin $script:WinsmuxSubmissionRunStatuses -and
+        ($backendOwned -is [bool]) -and $backendOwned -eq $true -and
+        ($requestConsumed -is [bool]) -and $requestConsumed -eq $true -and
+        (Test-WinsmuxSubmissionInteger -Value $exitCode) -and [int64]$exitCode -eq 0
+    )
 }
 
 function New-WinsmuxSubmissionReceipt {
@@ -54,7 +309,7 @@ function New-WinsmuxSubmissionReceipt {
     )
 
     return [ordered]@{
-        protocol_version = $script:WinsmuxSubmissionProtocolVersion
+        protocol_version = 1
         submission_id    = $SubmissionId
         kind             = $Kind
         status           = $Status
@@ -70,32 +325,37 @@ function New-WinsmuxSubmissionReceipt {
 function Test-WinsmuxSubmissionReceipt {
     param([AllowNull()]$Receipt)
 
-    if ($null -eq $Receipt) {
-        return $false
-    }
-    $version = Get-WinsmuxSubmissionValue -InputObject $Receipt -Name 'protocol_version' -Default $null
+    if ($null -eq $Receipt) { return $false }
+    $version = Get-WinsmuxSubmissionRawValue -InputObject $Receipt -Name 'protocol_version' -Default $null
+    if (-not (Test-WinsmuxSubmissionInteger -Value $version)) { return $false }
     $status = [string](Get-WinsmuxSubmissionValue -InputObject $Receipt -Name 'status' -Default '')
     $kind = [string](Get-WinsmuxSubmissionValue -InputObject $Receipt -Name 'kind' -Default '')
     $backend = [string](Get-WinsmuxSubmissionValue -InputObject $Receipt -Name 'backend' -Default '')
     $submissionId = [string](Get-WinsmuxSubmissionValue -InputObject $Receipt -Name 'submission_id' -Default '')
-
-    $parsedVersion = 0
-    $versionIsInteger = [int]::TryParse(([string]$version), [ref]$parsedVersion)
-    return (
-        $versionIsInteger -and
-        $parsedVersion -eq $script:WinsmuxSubmissionProtocolVersion -and
-        $status -cin $script:WinsmuxSubmissionStatuses -and
-        $kind -cin $script:WinsmuxSubmissionKinds -and
-        $backend -cin $script:WinsmuxSubmissionBackends -and
-        -not [string]::IsNullOrWhiteSpace($submissionId)
-    )
+    if (
+        [int64]$version -ne 1 -or
+        $status -cnotin $script:WinsmuxSubmissionStatuses -or
+        $kind -cnotin $script:WinsmuxSubmissionKinds -or
+        $backend -cnotin $script:WinsmuxSubmissionBackends -or
+        -not (Test-WinsmuxSubmissionIdentifier -Value $submissionId)
+    ) {
+        return $false
+    }
+    if ($status -eq 'accepted') {
+        $evidence = Get-WinsmuxSubmissionValue -InputObject $Receipt -Name 'acknowledgement' -Default $null
+        $target = Get-WinsmuxSubmissionValue -InputObject $Receipt -Name 'target' -Default $null
+        $targetLabel = [string](Get-WinsmuxSubmissionValue -InputObject $target -Name 'label' -Default '')
+        if (-not (Test-WinsmuxSubmissionIdentifier -Value $targetLabel)) { return $false }
+        return Test-WinsmuxSubmissionRunRecord -Record $evidence -SubmissionId $submissionId -Kind $kind -Backend $backend -ExpectedSlotId $targetLabel
+    }
+    return $true
 }
 
 function ConvertTo-WinsmuxSubmissionReceiptJson {
     param([Parameter(Mandatory = $true)]$Receipt)
 
     if (-not (Test-WinsmuxSubmissionReceipt -Receipt $Receipt)) {
-        throw 'submission receipt is malformed or uses an unknown protocol version, status, kind, or backend'
+        throw 'submission receipt is malformed or uses an unknown protocol version, status, kind, backend, or evidence'
     }
     return ($Receipt | ConvertTo-Json -Depth 12 -Compress)
 }
@@ -107,49 +367,54 @@ function New-WinsmuxRouterRefusalReceipt {
         [Parameter(Mandatory = $true)][string]$SubmissionId
     )
 
-    $matchedKeywords = @((Get-WinsmuxSubmissionValue -InputObject $Route -Name 'MatchedKeywords' -Default @()))
-    $expectedOwner = [string](Get-WinsmuxSubmissionValue -InputObject $Route -Name 'SelectedRole' -Default 'Operator')
-    if ([string]::IsNullOrWhiteSpace($expectedOwner)) {
-        $expectedOwner = 'Operator'
+    $selectedRole = [string](Get-WinsmuxSubmissionValue -InputObject $Route -Name 'SelectedRole' -Default '')
+    $operatorOwned = [string]::Equals($selectedRole, 'Operator', [System.StringComparison]::OrdinalIgnoreCase)
+    $reasonCode = if ($operatorOwned) { 'router_operator_owned' } else { 'router_target_unavailable' }
+    $ruleId = [string](Get-WinsmuxSubmissionValue -InputObject $Route -Name 'RuleId' -Default '')
+    if ([string]::IsNullOrWhiteSpace($ruleId)) {
+        throw 'dispatch route is missing its stable rule id'
     }
-    $matchedRule = if ($matchedKeywords.Count -gt 0) { $matchedKeywords -join ',' } else { 'no_delegable_target' }
+    $nextShape = if ($operatorOwned) {
+        'Keep this operation with the operator or provide a non-operator task packet.'
+    } else {
+        "Configure an available $selectedRole worker, then resubmit the same version-1 packet."
+    }
 
     return New-WinsmuxSubmissionReceipt -Kind $Kind -Status rejected -Backend local -SubmissionId $SubmissionId `
-        -ReasonCode 'router_operator_owned' -Diagnostic ([string](Get-WinsmuxSubmissionValue -InputObject $Route -Name 'Reason' -Default 'router retained ownership')) `
-        -Routing ([ordered]@{
-            matched_rule   = $matchedRule
-            expected_owner = $expectedOwner
-            next_shape     = 'Provide a delegable implementation, review, research, or verification packet for an available managed worker.'
+        -ReasonCode $reasonCode -Routing ([ordered]@{
+            rule_id       = $ruleId
+            expected_owner = if ($operatorOwned) { 'Operator' } else { $selectedRole }
+            next_shape    = $nextShape
         })
 }
 
-function New-WinsmuxSubmissionPacket {
+function Get-WinsmuxSubmissionRunPath {
     param(
         [Parameter(Mandatory = $true)][string]$ProjectDir,
-        [Parameter(Mandatory = $true)][ValidateSet('task', 'review')][string]$Kind,
-        [Parameter(Mandatory = $true)][string]$Content,
-        [Parameter(Mandatory = $true)][string]$SubmissionId,
-        [Parameter(Mandatory = $true)][string]$TargetLabel
+        [Parameter(Mandatory = $true)][string]$SlotId,
+        [Parameter(Mandatory = $true)][string]$RunId
     )
 
-    if ($SubmissionId -notmatch '^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$') {
-        throw 'submission id contains unsupported characters'
+    if (-not (Test-WinsmuxSubmissionIdentifier -Value $SlotId) -or -not (Test-WinsmuxSubmissionIdentifier -Value $RunId)) {
+        throw 'submission run path contains an unsupported slot or run id'
     }
-    $relativePath = Join-Path (Join-Path '.winsmux' 'submissions') ($SubmissionId + '.json')
-    $fullPath = [System.IO.Path]::GetFullPath((Join-Path $ProjectDir $relativePath))
-    $directory = Split-Path -Parent $fullPath
+    return Join-Path (Join-Path (Join-Path (Join-Path $ProjectDir '.winsmux') 'worker-runs') $SlotId) (Join-Path $RunId 'run.json')
+}
+
+function Write-WinsmuxSubmissionRunRecord {
+    param(
+        [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [Parameter(Mandatory = $true)][string]$SlotId,
+        [Parameter(Mandatory = $true)]$Record
+    )
+
+    $runPath = Get-WinsmuxSubmissionRunPath -ProjectDir $ProjectDir -SlotId $SlotId -RunId ([string]$Record.run_id)
+    $directory = Split-Path -Parent $runPath
     if (-not (Test-Path -LiteralPath $directory -PathType Container)) {
         New-Item -ItemType Directory -Path $directory -Force | Out-Null
     }
-    $packet = [ordered]@{
-        protocol_version = 1
-        submission_id    = $SubmissionId
-        kind             = $Kind
-        target           = $TargetLabel
-        content          = $Content
-    }
-    [System.IO.File]::WriteAllText($fullPath, ($packet | ConvertTo-Json -Depth 8), [System.Text.UTF8Encoding]::new($false))
-    return [PSCustomObject]@{ FullPath = $fullPath; RelativePath = $relativePath }
+    [System.IO.File]::WriteAllText($runPath, ($Record | ConvertTo-Json -Depth 12), [System.Text.UTF8Encoding]::new($false))
+    return $runPath
 }
 
 function Get-WinsmuxSubmissionRunResult {
@@ -159,24 +424,55 @@ function Get-WinsmuxSubmissionRunResult {
         [Parameter(Mandatory = $true)][string]$RunId
     )
 
-    $runPath = Join-Path (Join-Path (Join-Path (Join-Path $ProjectDir '.winsmux') 'worker-runs') $SlotId) (Join-Path $RunId 'run.json')
+    $runPath = Get-WinsmuxSubmissionRunPath -ProjectDir $ProjectDir -SlotId $SlotId -RunId $RunId
     $attempts = 60
-    if ($env:WINSMUX_SUBMISSION_POLL_ATTEMPTS -match '^\d+$') {
-        $attempts = [int]$env:WINSMUX_SUBMISSION_POLL_ATTEMPTS
-    }
+    if ($env:WINSMUX_SUBMISSION_POLL_ATTEMPTS -match '^\d+$') { $attempts = [int]$env:WINSMUX_SUBMISSION_POLL_ATTEMPTS }
     for ($attempt = 0; $attempt -le $attempts; $attempt++) {
         if (Test-Path -LiteralPath $runPath -PathType Leaf) {
-            try {
-                return (Get-Content -LiteralPath $runPath -Raw -Encoding UTF8 | ConvertFrom-Json -Depth 16)
-            } catch {
-                return [ordered]@{ status = 'failed'; reason = 'runner_receipt_malformed'; exit_code = 1 }
-            }
+            try { return (Get-Content -LiteralPath $runPath -Raw -Encoding UTF8 | ConvertFrom-Json -Depth 16) }
+            catch { return [ordered]@{ status = 'failed'; reason = 'runner_receipt_malformed'; exit_code = 1 } }
         }
-        if ($attempt -lt $attempts) {
-            Start-Sleep -Milliseconds 500
-        }
+        if ($attempt -lt $attempts) { Start-Sleep -Milliseconds 500 }
     }
     return [ordered]@{ status = 'failed'; reason = 'runner_acknowledgement_missing'; exit_code = 1 }
+}
+
+function Invoke-WinsmuxSubmissionAcknowledge {
+    param(
+        [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [Parameter(Mandatory = $true)][string]$SlotId,
+        [Parameter(Mandatory = $true)][string]$SubmissionId,
+        [Parameter(Mandatory = $true)][string]$RunId,
+        [Parameter(Mandatory = $true)][ValidateSet('task', 'review')][string]$Kind,
+        [Parameter(Mandatory = $true)][ValidateSet('local', 'codex')][string]$Backend
+    )
+
+    $packetPath = Join-Path (Join-Path (Join-Path $ProjectDir '.winsmux') 'submissions') ($SubmissionId + '.json')
+    $packet = Read-WinsmuxSubmissionPacket -Path $packetPath
+    if ([string]$packet.submission_id -cne $SubmissionId -or [string]$packet.run_id -cne $RunId -or [string]$packet.kind -cne $Kind) {
+        throw 'submission acknowledgement does not match the packet id, run id, or kind'
+    }
+    if ([string]$packet.target -cne $SlotId) {
+        throw 'submission acknowledgement slot does not match the packet target'
+    }
+    if ([string]::IsNullOrWhiteSpace($env:WINSMUX_PANE_ID)) {
+        throw 'submission acknowledgement requires WINSMUX_PANE_ID'
+    }
+    $manifestEntry = @(Get-PaneControlManifestEntries -ProjectDir $ProjectDir | Where-Object { [string]$_.Label -ceq $SlotId }) | Select-Object -First 1
+    if ($null -eq $manifestEntry -or [string]$manifestEntry.PaneId -cne [string]$env:WINSMUX_PANE_ID) {
+        throw 'submission acknowledgement caller does not match the manifest target pane'
+    }
+    $manifestBackend = ([string]$manifestEntry.WorkerBackend).Trim().ToLowerInvariant()
+    if ($manifestBackend -cne $Backend) {
+        throw 'submission acknowledgement backend does not match the manifest target backend'
+    }
+    $runPath = Get-WinsmuxSubmissionRunPath -ProjectDir $ProjectDir -SlotId $SlotId -RunId $RunId
+    if (Test-Path -LiteralPath $runPath -PathType Leaf) {
+        throw 'submission acknowledgement run record already exists'
+    }
+    $record = New-WinsmuxSubmissionRunRecord -SubmissionId $SubmissionId -RunId $RunId -Kind $Kind -TaskTitle ([string]$packet.title) -SlotId $SlotId -Backend $Backend -Status started -RequestConsumed
+    Write-WinsmuxSubmissionRunRecord -ProjectDir $ProjectDir -SlotId $SlotId -Record $record | Out-Null
+    return $record
 }
 
 function Invoke-WinsmuxSubmissionCliRun {
@@ -203,12 +499,8 @@ function Invoke-WinsmuxSubmissionCliRun {
     if ($jsonLine.Count -lt 1) {
         return [ordered]@{ status = 'unavailable'; reason = 'cli_command_missing'; exit_code = if ($exitCode) { $exitCode } else { 1 } }
     }
-    try {
-        $result = $jsonLine[0] | ConvertFrom-Json -Depth 16
-    } catch {
-        return [ordered]@{ status = 'unavailable'; reason = 'cli_receipt_malformed'; exit_code = 1 }
-    }
-    return $result
+    try { return ($jsonLine[0] | ConvertFrom-Json -Depth 16) }
+    catch { return [ordered]@{ status = 'unavailable'; reason = 'cli_receipt_malformed'; exit_code = 1 } }
 }
 
 function Invoke-WinsmuxSubmissionAdapter {
@@ -216,7 +508,7 @@ function Invoke-WinsmuxSubmissionAdapter {
         [Parameter(Mandatory = $true)][string]$ProjectDir,
         [Parameter(Mandatory = $true)]$ManifestEntry,
         [Parameter(Mandatory = $true)][ValidateSet('task', 'review')][string]$Kind,
-        [Parameter(Mandatory = $true)][string]$Content,
+        [Parameter(Mandatory = $true)]$Content,
         [string]$SubmissionId = ('submission-' + [guid]::NewGuid().ToString('N')),
         [scriptblock]$SendAction,
         [scriptblock]$CaptureAction,
@@ -227,58 +519,42 @@ function Invoke-WinsmuxSubmissionAdapter {
     $label = [string](Get-WinsmuxSubmissionValue -InputObject $ManifestEntry -Name 'Label' -Default '')
     $paneId = [string](Get-WinsmuxSubmissionValue -InputObject $ManifestEntry -Name 'PaneId' -Default '')
     $role = [string](Get-WinsmuxSubmissionValue -InputObject $ManifestEntry -Name 'Role' -Default '')
-    $backend = [string](Get-WinsmuxSubmissionValue -InputObject $ManifestEntry -Name 'WorkerBackend' -Default 'local')
-    $backend = $backend.Trim().ToLowerInvariant()
+    $backend = ([string](Get-WinsmuxSubmissionValue -InputObject $ManifestEntry -Name 'WorkerBackend' -Default 'local')).Trim().ToLowerInvariant()
     $target = [ordered]@{ label = $label; pane_id = $paneId; role = $role }
 
-    if ($backend -notin $script:WinsmuxSubmissionBackends) {
-        return New-WinsmuxSubmissionReceipt -Kind $Kind -Status unsupported -Backend noop -SubmissionId $SubmissionId -ReasonCode 'backend_unsupported' -Diagnostic "Unsupported worker backend '$backend'." -Target $target
+    if (-not (Test-WinsmuxSubmissionIdentifier -Value $label)) {
+        return New-WinsmuxSubmissionReceipt -Kind $Kind -Status rejected -Backend noop -SubmissionId $SubmissionId -ReasonCode 'target_identifier_invalid' -Target $target
     }
-    if ($backend -eq 'noop') {
-        return New-WinsmuxSubmissionReceipt -Kind $Kind -Status unsupported -Backend noop -SubmissionId $SubmissionId -ReasonCode 'backend_unsupported' -Diagnostic 'The noop backend cannot accept submissions.' -Target $target
-    }
-
-    if ($backend -in @('local', 'codex')) {
-        if ([string]::IsNullOrWhiteSpace($paneId)) {
-            return New-WinsmuxSubmissionReceipt -Kind $Kind -Status unavailable -Backend $backend -SubmissionId $SubmissionId -ReasonCode 'pane_unavailable' -Diagnostic 'The target pane id is missing.' -Target $target
-        }
-        $marker = "[winsmux-submission-accepted:$SubmissionId]"
-        $commandText = "Before doing any other work, print exactly $marker on its own line to acknowledge this $Kind submission.`n`n$Content"
-        try {
-            if ($null -ne $SendAction) {
-                & $SendAction $paneId $commandText
-            } else {
-                Send-TextToPane -PaneId $paneId -CommandText $commandText
-            }
-        } catch {
-            return New-WinsmuxSubmissionReceipt -Kind $Kind -Status unavailable -Backend $backend -SubmissionId $SubmissionId -ReasonCode 'pane_send_failed' -Diagnostic $_.Exception.Message -Target $target
-        }
-
-        $attempts = 10
-        if ($env:WINSMUX_SUBMISSION_POLL_ATTEMPTS -match '^\d+$') {
-            $attempts = [int]$env:WINSMUX_SUBMISSION_POLL_ATTEMPTS
-        }
-        for ($attempt = 0; $attempt -le $attempts; $attempt++) {
-            $snapshot = if ($null -ne $CaptureAction) { & $CaptureAction $paneId } else { Get-PaneSnapshotText -PaneId $paneId -Lines 200 }
-            if ([string]$snapshot -match [regex]::Escape($marker)) {
-                return New-WinsmuxSubmissionReceipt -Kind $Kind -Status accepted -Backend $backend -SubmissionId $SubmissionId -Target $target `
-                    -Acknowledgement ([ordered]@{ type = 'backend_marker'; marker = $marker })
-            }
-            if ($attempt -lt $attempts) {
-                Start-Sleep -Milliseconds 300
-            }
-        }
-        return New-WinsmuxSubmissionReceipt -Kind $Kind -Status rejected -Backend $backend -SubmissionId $SubmissionId -ReasonCode 'backend_acknowledgement_missing' -Diagnostic 'Text delivery was not followed by the required backend acknowledgement marker.' -Target $target
+    if ($backend -notin $script:WinsmuxSubmissionBackends -or $backend -eq 'noop') {
+        return New-WinsmuxSubmissionReceipt -Kind $Kind -Status unsupported -Backend noop -SubmissionId $SubmissionId -ReasonCode 'backend_unsupported' -Target $target
     }
 
     $packet = New-WinsmuxSubmissionPacket -ProjectDir $ProjectDir -Kind $Kind -Content $Content -SubmissionId $SubmissionId -TargetLabel $label
-    if ($backend -eq 'api_llm') {
+    $existingRunPath = Get-WinsmuxSubmissionRunPath -ProjectDir $ProjectDir -SlotId $label -RunId $SubmissionId
+    if (Test-Path -LiteralPath $existingRunPath -PathType Leaf) {
+        return New-WinsmuxSubmissionReceipt -Kind $Kind -Status rejected -Backend $backend -SubmissionId $SubmissionId -ReasonCode 'run_record_already_exists' -Target $target
+    }
+    if ($backend -in @('local', 'codex')) {
         if ([string]::IsNullOrWhiteSpace($paneId)) {
-            return New-WinsmuxSubmissionReceipt -Kind $Kind -Status unavailable -Backend $backend -SubmissionId $SubmissionId -ReasonCode 'pane_unavailable' -Diagnostic 'The api_llm packet REPL pane id is missing.' -Target $target
+            return New-WinsmuxSubmissionReceipt -Kind $Kind -Status unavailable -Backend $backend -SubmissionId $SubmissionId -ReasonCode 'pane_unavailable' -Target $target
         }
-        $execCommand = "exec $($packet.RelativePath) $SubmissionId $SubmissionId"
+        $ackCommand = "winsmux submission-ack --submission-id $SubmissionId --run-id $SubmissionId --kind $Kind --backend $backend --slot $label"
+        $commandText = "Read and validate the version-1 submission packet at '$($packet.RelativePath)'. Before other work, execute: $ackCommand"
         try {
-            if ($null -ne $SendAction) { & $SendAction $paneId $execCommand } else { Send-TextToPane -PaneId $paneId -CommandText $execCommand }
+            if ($null -ne $SendAction) { & $SendAction $paneId $commandText | Out-Null }
+            else { Send-TextToPane -PaneId $paneId -CommandText $commandText | Out-Null }
+        } catch {
+            return New-WinsmuxSubmissionReceipt -Kind $Kind -Status unavailable -Backend $backend -SubmissionId $SubmissionId -ReasonCode 'pane_send_failed' -Diagnostic $_.Exception.Message -Target $target
+        }
+        $runner = if ($null -ne $RunResultAction) { & $RunResultAction $ProjectDir $label $SubmissionId } else { Get-WinsmuxSubmissionRunResult -ProjectDir $ProjectDir -SlotId $label -RunId $SubmissionId }
+    } elseif ($backend -eq 'api_llm') {
+        if ([string]::IsNullOrWhiteSpace($paneId)) {
+            return New-WinsmuxSubmissionReceipt -Kind $Kind -Status unavailable -Backend $backend -SubmissionId $SubmissionId -ReasonCode 'pane_unavailable' -Target $target
+        }
+        $execCommand = "exec $($packet.RelativePath)"
+        try {
+            if ($null -ne $SendAction) { & $SendAction $paneId $execCommand | Out-Null }
+            else { Send-TextToPane -PaneId $paneId -CommandText $execCommand | Out-Null }
         } catch {
             return New-WinsmuxSubmissionReceipt -Kind $Kind -Status unavailable -Backend $backend -SubmissionId $SubmissionId -ReasonCode 'packet_repl_unavailable' -Diagnostic $_.Exception.Message -Target $target
         }
@@ -287,17 +563,18 @@ function Invoke-WinsmuxSubmissionAdapter {
         $runner = if ($null -ne $CliRunAction) { & $CliRunAction $ProjectDir $label $packet.RelativePath $SubmissionId $backend $Kind } else { Invoke-WinsmuxSubmissionCliRun -ProjectDir $ProjectDir -SlotId $label -PacketPath $packet.RelativePath -SubmissionId $SubmissionId -Backend $backend -Kind $Kind }
     }
 
+    if (Test-WinsmuxSubmissionRunRecord -Record $runner -SubmissionId $SubmissionId -Kind $Kind -Backend $backend -ExpectedSlotId $label) {
+        return New-WinsmuxSubmissionReceipt -Kind $Kind -Status accepted -Backend $backend -SubmissionId $SubmissionId -Target $target -Acknowledgement $runner
+    }
     $runnerStatus = [string](Get-WinsmuxSubmissionValue -InputObject $runner -Name 'status' -Default '')
     $runnerReason = [string](Get-WinsmuxSubmissionValue -InputObject $runner -Name 'reason' -Default '')
-    $runnerExitCode = [int](Get-WinsmuxSubmissionValue -InputObject $runner -Name 'exit_code' -Default 1)
-    if ($runnerStatus -in @('succeeded', 'started', 'running') -and $runnerExitCode -eq 0) {
-        return New-WinsmuxSubmissionReceipt -Kind $Kind -Status accepted -Backend $backend -SubmissionId $SubmissionId -Target $target `
-            -Acknowledgement ([ordered]@{ type = 'run_receipt'; run_id = $SubmissionId; runner_status = $runnerStatus })
-    }
-    if ($runnerStatus -eq 'unavailable' -or $runnerReason -match '(missing|unavailable|unconfigured)') {
+    if ($runnerStatus -eq 'unavailable' -or $runnerReason -match '^(backend_unavailable|cli_command_missing|.*_cli_missing|.*_runner_unconfigured|api_llm_api_key_env_missing)$') {
         if ([string]::IsNullOrWhiteSpace($runnerReason)) { $runnerReason = 'backend_unavailable' }
-        return New-WinsmuxSubmissionReceipt -Kind $Kind -Status unavailable -Backend $backend -SubmissionId $SubmissionId -ReasonCode $runnerReason -Diagnostic 'The backend runner did not start.' -Target $target
+        return New-WinsmuxSubmissionReceipt -Kind $Kind -Status unavailable -Backend $backend -SubmissionId $SubmissionId -ReasonCode $runnerReason -Target $target
     }
-    if ([string]::IsNullOrWhiteSpace($runnerReason)) { $runnerReason = 'runner_rejected_submission' }
-    return New-WinsmuxSubmissionReceipt -Kind $Kind -Status rejected -Backend $backend -SubmissionId $SubmissionId -ReasonCode $runnerReason -Diagnostic 'The backend runner refused or failed the submission.' -Target $target
+    if (($null -eq $runner -or $runnerReason -eq 'runner_acknowledgement_missing') -and $backend -in @('local', 'codex')) {
+        $runnerReason = 'backend_acknowledgement_missing'
+    }
+    if ([string]::IsNullOrWhiteSpace($runnerReason)) { $runnerReason = 'runner_evidence_invalid' }
+    return New-WinsmuxSubmissionReceipt -Kind $Kind -Status rejected -Backend $backend -SubmissionId $SubmissionId -ReasonCode $runnerReason -Target $target
 }

--- a/workers/colab/critic_worker.py
+++ b/workers/colab/critic_worker.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import datetime as dt
+import hashlib
 import json
 import os
 from pathlib import Path
@@ -56,6 +57,17 @@ def task_title(task: dict[str, Any]) -> str:
 
 def task_id(task: dict[str, Any], fallback: str = "") -> str:
     return text_field(task, "task_id", "id", default=fallback)
+
+
+def task_request(task: dict[str, Any]) -> str:
+    value = task.get("request")
+    if isinstance(value, str) and value:
+        return value
+    return task_title(task)
+
+
+def request_digest(task: dict[str, Any]) -> str:
+    return hashlib.sha256(task_request(task).encode("utf-8")).hexdigest()
 
 
 def unique_text_items(task: dict[str, Any], keys: tuple[str, ...]) -> list[str]:
@@ -141,6 +153,10 @@ def render_artifact(task: dict[str, Any]) -> str:
 
 {task_title(task)}
 
+## Complete Request
+
+{task_request(task)}
+
 ## Review Focus
 
 {bullet_list(files, "Review the supplied diff and changed behavior.")}
@@ -165,6 +181,7 @@ def success_payload(args: argparse.Namespace, worker_id: str, run_id: str, task:
         "worker_kind": WORKER_KIND,
         "worker_id": worker_id,
         "run_id": run_id,
+        "request_digest": request_digest(task),
         "task": {"id": task_id(task, args.task_id), "title": task_title(task)},
         "summary": "prepared a critic review template",
         "actions": ACTIONS,

--- a/workers/colab/impl_worker.py
+++ b/workers/colab/impl_worker.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import datetime as dt
+import hashlib
 import json
 import os
 from pathlib import Path
@@ -15,7 +16,7 @@ from typing import Any
 
 SCHEMA_VERSION = "winsmux.colab.worker.result.v1"
 DEFAULT_ARTIFACT_ROOT = "/content/winsmux_artifacts"
-WORKER_KIND = "impl"
+WORKER_KIND = "implementation"
 ARTIFACT_FILE = "implementation-plan.md"
 ACTIONS = ["inspect target files", "make the smallest useful code change", "run focused verification"]
 RISKS = ["template does not execute model inference by itself"]
@@ -56,6 +57,17 @@ def task_title(task: dict[str, Any]) -> str:
 
 def task_id(task: dict[str, Any], fallback: str = "") -> str:
     return text_field(task, "task_id", "id", default=fallback)
+
+
+def task_request(task: dict[str, Any]) -> str:
+    value = task.get("request")
+    if isinstance(value, str) and value:
+        return value
+    return task_title(task)
+
+
+def request_digest(task: dict[str, Any]) -> str:
+    return hashlib.sha256(task_request(task).encode("utf-8")).hexdigest()
 
 
 def unique_text_items(task: dict[str, Any], keys: tuple[str, ...]) -> list[str]:
@@ -141,6 +153,10 @@ def render_artifact(task: dict[str, Any]) -> str:
 
 {task_title(task)}
 
+## Complete Request
+
+{task_request(task)}
+
 ## Target Files
 
 {bullet_list(files)}
@@ -164,6 +180,7 @@ def success_payload(args: argparse.Namespace, worker_id: str, run_id: str, task:
         "worker_kind": WORKER_KIND,
         "worker_id": worker_id,
         "run_id": run_id,
+        "request_digest": request_digest(task),
         "task": {"id": task_id(task, args.task_id), "title": task_title(task)},
         "summary": "prepared an implementation plan template",
         "actions": ACTIONS,


### PR DESCRIPTION
## Summary

- add typed submission receipts across the submission adapter backends
- reject unsupported backends before task identifier validation
- preserve the first submission packet and digest when an `api_llm` retry reuses an attempt identifier
- keep the existing `colab_cli` backend intact; its removal remains separate work

## Why

Submission success must describe verified acceptance rather than only successful input transport. Duplicate attempts must also preserve the original evidence instead of replacing it after a partial send failure.

## Validation

- Pester: 648 passed, 0 failed
- `cargo test`
- PowerShell 7 and Windows PowerShell 5 parser checks
- `git diff --check`
- public-surface audit
- `git-guard` full scan
- Gitleaks history scan: 529 commits, no leaks found
- Grok 4.5 review: PASS
- Codex read-only/xhigh final review: PASS
