### PR TITLE
fix(runtime): enforce manifest freshness across worker operations

### DIFF
--- a/.githooks/pre-commit-whitelist.ps1
+++ b/.githooks/pre-commit-whitelist.ps1
@@ -135,6 +135,7 @@ $whitelistPatterns = @(
     'tests/UpstreamReevaluation.Tests.ps1',
     'tests/EnterpriseStrategyAlignment.Tests.ps1',
     'tests/ReviewLatencyHardening.Tests.ps1',
+    'tests/Task781RuntimeCompatibility.Tests.ps1',
     'tests/V03618ReleaseHardening.Tests.ps1',
     'tests/V03619RepoAudit.Tests.ps1',
     'tests/V03620CoordinatorFoundation.Tests.ps1',

--- a/.gitignore
+++ b/.gitignore
@@ -95,6 +95,7 @@ tests/*
 !tests/UpstreamReevaluation.Tests.ps1
 !tests/EnterpriseStrategyAlignment.Tests.ps1
 !tests/ReviewLatencyHardening.Tests.ps1
+!tests/Task781RuntimeCompatibility.Tests.ps1
 !tests/V03619RepoAudit.Tests.ps1
 !tests/V03620CoordinatorFoundation.Tests.ps1
 !tests/V03621LocalRouterShadow.Tests.ps1

--- a/core/tests-rs/operator_cli.rs
+++ b/core/tests-rs/operator_cli.rs
@@ -5987,7 +5987,7 @@ fn operator_cli_review_request_records_pending_state_and_manifest_pane() {
 }
 
 #[test]
-fn operator_cli_dispatch_review_refuses_without_strong_caller_identity() {
+fn operator_cli_dispatch_review_requires_runtime_manifest_regeneration_before_pane_send() {
     let project_dir = make_temp_project_dir("dispatch-review");
     write_manifest(&project_dir);
     init_git_branch(
@@ -6030,12 +6030,18 @@ fn operator_cli_dispatch_review_refuses_without_strong_caller_identity() {
     assert_eq!(receipt["status"], "unavailable");
     assert_eq!(receipt["backend"], "local");
     assert_eq!(receipt["target"]["label"], "reviewer-1");
-    assert_eq!(receipt["reason_code"], "caller_identity_unavailable");
+    assert_eq!(receipt["reason_code"], "manifest_regeneration_required");
+    assert!(
+        receipt["diagnostic"]
+            .as_str()
+            .is_some_and(|diagnostic| diagnostic.contains("regenerate")),
+        "runtime refusal should explain that regeneration is required: {receipt}"
+    );
     assert!(!log_path.exists(), "refusal must happen before pane send");
 }
 
 #[test]
-fn operator_cli_dispatch_review_prefers_reviewer_for_typed_packet() {
+fn operator_cli_dispatch_review_retains_reviewer_target_in_runtime_regeneration_receipt() {
     let project_dir = make_temp_project_dir("dispatch-review-prefers-reviewer-role");
     write_manifest(&project_dir);
     let manifest_path = project_dir.join(".winsmux").join("manifest.yaml");
@@ -6094,12 +6100,18 @@ panes:
     let receipt: serde_json::Value = serde_json::from_str(stdout.trim()).expect("typed receipt");
     assert_eq!(receipt["status"], "unavailable");
     assert_eq!(receipt["target"]["label"], "reviewer-1");
-    assert_eq!(receipt["reason_code"], "caller_identity_unavailable");
+    assert_eq!(receipt["reason_code"], "manifest_regeneration_required");
+    assert!(
+        receipt["diagnostic"]
+            .as_str()
+            .is_some_and(|diagnostic| diagnostic.contains("regenerate")),
+        "runtime refusal should explain that regeneration is required: {receipt}"
+    );
     assert!(!log_path.exists(), "refusal must happen before pane send");
 }
 
 #[test]
-fn operator_cli_dispatch_review_does_not_accept_stale_pending_review_state() {
+fn operator_cli_dispatch_review_refuses_before_review_state_dispatch_when_runtime_is_stale() {
     let project_dir = make_temp_project_dir("dispatch-review-stale");
     write_manifest(&project_dir);
     init_git_branch(
@@ -6121,7 +6133,7 @@ fn operator_cli_dispatch_review_does_not_accept_stale_pending_review_state() {
   }
 }"#,
     );
-    let (winsmux_bin, _log_path) = write_fake_winsmux_dispatch_review(&project_dir);
+    let (winsmux_bin, log_path) = write_fake_winsmux_dispatch_review(&project_dir);
 
     let output = Command::new(env!("CARGO_BIN_EXE_winsmux"))
         .arg("dispatch-review")
@@ -6138,7 +6150,15 @@ fn operator_cli_dispatch_review_does_not_accept_stale_pending_review_state() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     let receipt: serde_json::Value = serde_json::from_str(stdout.trim()).expect("typed refusal");
     assert_eq!(receipt["status"], "unavailable");
-    assert_eq!(receipt["reason_code"], "caller_identity_unavailable");
+    assert_eq!(receipt["target"]["label"], "reviewer-1");
+    assert_eq!(receipt["reason_code"], "manifest_regeneration_required");
+    assert!(
+        receipt["diagnostic"]
+            .as_str()
+            .is_some_and(|diagnostic| diagnostic.contains("regenerate")),
+        "runtime refusal should explain that regeneration is required: {receipt}"
+    );
+    assert!(!log_path.exists(), "refusal must happen before pane send");
 }
 
 #[test]

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -4,6 +4,8 @@
     [Parameter(Position=2, ValueFromRemainingArguments=$true)][string[]]$Rest
 )
 
+$script:WinsmuxBridgeWasDotSourced = $MyInvocation.InvocationName -eq '.'
+$script:WinsmuxRequestedProcessExitCode = 0
 $script:WinsmuxRawGlobalArgs = @()
 if (-not [string]::IsNullOrWhiteSpace($env:WINSMUX_BRIDGE_NAMESPACE_L)) {
     $script:WinsmuxRawGlobalArgs += @('-L', $env:WINSMUX_BRIDGE_NAMESPACE_L)
@@ -59,6 +61,8 @@ $WatermarkDir   = Join-Path $env:TEMP "winsmux\watermarks"
 $LockDir        = Join-Path $env:TEMP "winsmux\locks"
 $FocusPolicyFile = Join-Path $env:TEMP "winsmux\focus-policy-stack.json"
 $LabelsFile     = Join-Path $env:APPDATA "winsmux\labels.json"
+$JsonCompatScript = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\winsmux-core\scripts\json-compat.ps1'))
+$CredentialMetadataScript = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\winsmux-core\scripts\credential-metadata.ps1'))
 $BridgeSettingsScript = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\winsmux-core\scripts\settings.ps1'))
 $PaneControlScript = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\winsmux-core\scripts\pane-control.ps1'))
 $PaneStatusScript = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\winsmux-core\scripts\pane-status.ps1'))
@@ -81,6 +85,14 @@ $ControlPlaneLedgerScript = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRo
 # for launcher, provider-capabilities, and provider-switch.
 # Workers module owns workers workspace argument and output handling.
 # Ledger module owns run ledger payload builders and related read-only projections.
+
+if (Test-Path $JsonCompatScript -PathType Leaf) {
+    . $JsonCompatScript
+}
+
+if (Test-Path $CredentialMetadataScript -PathType Leaf) {
+    . $CredentialMetadataScript
+}
 
 if (Test-Path $BridgeSettingsScript -PathType Leaf) {
     . $BridgeSettingsScript
@@ -135,11 +147,12 @@ if (Test-Path $ControlPlaneLedgerScript -PathType Leaf) {
 }
 
 # --- Windows Credential Manager P/Invoke ---
-Add-Type -TypeDefinition @'
+if (-not ('WinsmuxBridgeCredentialNative' -as [type])) {
+    Add-Type -TypeDefinition @'
 using System;
 using System.Runtime.InteropServices;
 
-public class WinCred {
+public class WinsmuxBridgeCredentialNative {
     [DllImport("advapi32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
     public static extern bool CredWrite(ref CREDENTIAL credential, uint flags);
 
@@ -171,7 +184,8 @@ public class WinCred {
     public const uint CRED_TYPE_GENERIC = 1;
     public const uint CRED_PERSIST_LOCAL_MACHINE = 2;
 }
-'@ -ErrorAction SilentlyContinue
+'@ -ErrorAction Stop
+}
 
 # --- Helper: Stop-WithError ---
 function Stop-WithError {
@@ -262,7 +276,7 @@ function Invoke-TerminalJsonRpc {
     $payload = New-TerminalJsonRpcPayload -Method $Method -Params $Params
     $responseText = Invoke-ControlRpcPipeExchange -Payload $payload
     try {
-        $response = $responseText | ConvertFrom-Json -Depth 100 -ErrorAction Stop
+        $response = $responseText | ConvertFrom-WinsmuxJson -Depth 100 -ErrorAction Stop
     } catch {
         Stop-WithError "terminal Tauri request $Method returned invalid JSON: $($_.Exception.Message)"
     }
@@ -424,10 +438,160 @@ function New-TaskPromptFile {
         New-Item -ItemType Directory -Path $parent -Force | Out-Null
     }
 
-    $tempPath = '{0}.tmp' -f $path
-    Write-ClmSafeTextFile -Path $tempPath -Content $Content
-    Move-Item -LiteralPath $tempPath -Destination $path -Force
+    $tempPath = '{0}.tmp-{1}' -f $path, ([guid]::NewGuid().ToString('N'))
+    try {
+        Write-ClmSafeTextFile -Path $tempPath -Content $Content
+        Move-Item -LiteralPath $tempPath -Destination $path -Force
+    } finally {
+        Remove-Item -LiteralPath $tempPath -Force -ErrorAction SilentlyContinue
+    }
     return $path
+}
+
+function New-SendPromptArtifactCheckpoint {
+    param(
+        [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [Parameter(Mandatory = $true)]$Intent
+    )
+
+    if (-not [bool](Get-SendConfigValue -InputObject $Intent -Name 'IsFileBacked' -Default $false)) {
+        return $null
+    }
+
+    $taskSlug = [string](Get-SendConfigValue -InputObject $Intent -Name 'TaskSlug' -Default '')
+    $expectedPath = ''
+    $parentPath = Get-DispatchPromptDirectory -ProjectDir $ProjectDir
+    if (-not [string]::IsNullOrWhiteSpace($taskSlug)) {
+        $expectedPath = [System.IO.Path]::GetFullPath((Get-TaskPromptPath -TaskSlug $taskSlug -ProjectDir $ProjectDir))
+        $parentPath = Split-Path -Parent $expectedPath
+    } else {
+        $parentPath = [System.IO.Path]::GetFullPath($parentPath)
+    }
+
+    $parentExisted = Test-Path -LiteralPath $parentPath -PathType Container
+    $leasePath = ''
+    $leaseStream = $null
+    if (-not [string]::IsNullOrWhiteSpace($expectedPath)) {
+        if (-not $parentExisted) {
+            New-Item -ItemType Directory -Path $parentPath -Force | Out-Null
+        }
+        $leasePath = $expectedPath + '.send.lock'
+        $deadline = (Get-Date).AddSeconds(30)
+        do {
+            try {
+                $leaseStream = [System.IO.File]::Open($leasePath, [System.IO.FileMode]::OpenOrCreate, [System.IO.FileAccess]::ReadWrite, [System.IO.FileShare]::None)
+                break
+            } catch [System.IO.IOException] {
+                if ((Get-Date) -ge $deadline) {
+                    throw "Timed out waiting for task prompt lease: $expectedPath"
+                }
+                Start-Sleep -Milliseconds 50
+            }
+        } while ($null -eq $leaseStream)
+    }
+
+    $existed = -not [string]::IsNullOrWhiteSpace($expectedPath) -and (Test-Path -LiteralPath $expectedPath -PathType Leaf)
+    # Keep the prior task prompt byte-exact in memory. A text round trip changes
+    # newline bytes and would corrupt the evidence this rollback is preserving.
+    $content = if ($existed) { [System.IO.File]::ReadAllBytes($expectedPath) } else { [byte[]]@() }
+    return [PSCustomObject][ordered]@{
+        ExpectedPath  = $expectedPath
+        ParentPath    = $parentPath
+        ParentExisted = $parentExisted
+        Existed       = $existed
+        Content       = $content
+        LeasePath     = $leasePath
+        LeaseStream   = $leaseStream
+        Closed        = $false
+    }
+}
+
+function Exit-SendPromptArtifactCheckpoint {
+    param([AllowNull()]$Checkpoint)
+
+    if ($null -eq $Checkpoint) {
+        return
+    }
+    if ([bool](Get-SendConfigValue -InputObject $Checkpoint -Name 'Closed' -Default $false)) {
+        return
+    }
+
+    $leaseStream = Get-SendConfigValue -InputObject $Checkpoint -Name 'LeaseStream' -Default $null
+    if ($null -ne $leaseStream) {
+        try { $leaseStream.Dispose() } catch {}
+        try { $Checkpoint.LeaseStream = $null } catch {}
+    }
+
+    $leasePath = [string](Get-SendConfigValue -InputObject $Checkpoint -Name 'LeasePath' -Default '')
+    if (-not [string]::IsNullOrWhiteSpace($leasePath)) {
+        Remove-Item -LiteralPath $leasePath -Force -ErrorAction SilentlyContinue
+    }
+
+    $parentExisted = [bool](Get-SendConfigValue -InputObject $Checkpoint -Name 'ParentExisted' -Default $true)
+    $parentPath = [string](Get-SendConfigValue -InputObject $Checkpoint -Name 'ParentPath' -Default '')
+    if (-not $parentExisted -and -not [string]::IsNullOrWhiteSpace($parentPath) -and
+        (Test-Path -LiteralPath $parentPath -PathType Container) -and
+        @(Get-ChildItem -LiteralPath $parentPath -Force).Count -eq 0) {
+        Remove-Item -LiteralPath $parentPath -Force
+    }
+    try { $Checkpoint.Closed = $true } catch {}
+}
+
+function Restore-SendPromptArtifactCheckpoint {
+    param(
+        [AllowNull()]$Checkpoint,
+        [AllowEmptyString()][string]$MaterializedPromptPath = ''
+    )
+
+    if ($null -eq $Checkpoint) {
+        return
+    }
+    if ([bool](Get-SendConfigValue -InputObject $Checkpoint -Name 'Closed' -Default $false)) {
+        return
+    }
+
+    try {
+        $expectedPath = [string](Get-SendConfigValue -InputObject $Checkpoint -Name 'ExpectedPath' -Default '')
+        $promptPath = if (-not [string]::IsNullOrWhiteSpace($expectedPath)) { $expectedPath } else { $MaterializedPromptPath }
+        if ([string]::IsNullOrWhiteSpace($promptPath)) {
+            return
+        }
+        $promptPath = [System.IO.Path]::GetFullPath($promptPath)
+        if (-not [string]::IsNullOrWhiteSpace($expectedPath) -and
+            -not [string]::Equals($promptPath, [System.IO.Path]::GetFullPath($expectedPath), [System.StringComparison]::OrdinalIgnoreCase)) {
+            throw 'Materialized task prompt path does not match its rollback checkpoint.'
+        }
+
+    $parentPath = [string](Get-SendConfigValue -InputObject $Checkpoint -Name 'ParentPath' -Default '')
+    if ([string]::IsNullOrWhiteSpace($parentPath)) {
+        throw 'Prompt rollback checkpoint is missing its parent path.'
+    }
+    $parentPath = [System.IO.Path]::GetFullPath($parentPath)
+    if ([string]::IsNullOrWhiteSpace($expectedPath)) {
+        $promptParent = [System.IO.Path]::GetFullPath((Split-Path -Parent $promptPath))
+        $promptName = [System.IO.Path]::GetFileName($promptPath)
+        if (-not [string]::Equals($promptParent, $parentPath, [System.StringComparison]::OrdinalIgnoreCase) -or
+            $promptName -cnotmatch '^send-command-[0-9a-f]{32}\.txt$') {
+            throw 'Materialized prompt path is outside its rollback checkpoint.'
+        }
+    }
+
+    $existed = [bool](Get-SendConfigValue -InputObject $Checkpoint -Name 'Existed' -Default $false)
+    if ($existed) {
+        $tempPath = '{0}.rollback-{1}.tmp' -f $promptPath, ([guid]::NewGuid().ToString('N'))
+        try {
+            [System.IO.File]::WriteAllBytes($tempPath, [byte[]](Get-SendConfigValue -InputObject $Checkpoint -Name 'Content' -Default ([byte[]]@())))
+            Move-Item -LiteralPath $tempPath -Destination $promptPath -Force
+        } finally {
+            Remove-Item -LiteralPath $tempPath -Force -ErrorAction SilentlyContinue
+        }
+    } elseif (Test-Path -LiteralPath $promptPath -PathType Leaf) {
+        Remove-Item -LiteralPath $promptPath -Force
+    }
+
+    } finally {
+        Exit-SendPromptArtifactCheckpoint -Checkpoint $Checkpoint
+    }
 }
 
 function Get-DispatchPromptReference {
@@ -744,7 +908,7 @@ function Read-WinsmuxArtifactJson {
 
     try {
         $content = Get-Content -LiteralPath $fullPath -Raw -Encoding UTF8
-        $parsed = $content | ConvertFrom-Json -AsHashtable -Depth 12
+        $parsed = $content | ConvertFrom-WinsmuxJson -AsHashtable -Depth 12
     } catch {
         return $null
     }
@@ -974,7 +1138,7 @@ function ConvertTo-DispatchPowerShellCommandInvocation {
     return '& ' + (ConvertTo-DispatchPowerShellLiteral -Value $Value)
 }
 
-function Resolve-SendTransportPlan {
+function Resolve-SendTransportIntent {
     param(
         [Parameter(Mandatory = $true)][string]$Text,
         [string]$ProjectDir = (Get-Location).Path,
@@ -989,6 +1153,60 @@ function Resolve-SendTransportPlan {
     )
 
     $resolvedPromptTransport = Resolve-SupportedPromptTransport -PromptTransport $PromptTransport
+    $normalizedTaskSlug = if ([string]::IsNullOrWhiteSpace($TaskSlug)) {
+        ''
+    } else {
+        ConvertTo-TaskPromptSlug -TaskSlug $TaskSlug
+    }
+    $mode = if ($ExecMode) {
+        'codex_exec_file'
+    } elseif (-not [string]::IsNullOrWhiteSpace($normalizedTaskSlug)) {
+        'pointer'
+    } elseif ($resolvedPromptTransport -eq 'stdin') {
+        'inline'
+    } elseif ($resolvedPromptTransport -eq 'argv' -and $Text.Length -le $LengthLimit) {
+        'inline'
+    } else {
+        'pointer'
+    }
+
+    return [ordered]@{
+        Mode            = $mode
+        IsFileBacked    = ($mode -ne 'inline')
+        TextLength      = $Text.Length
+        LengthLimit     = $LengthLimit
+        PromptTransport = $resolvedPromptTransport
+        TaskSlug        = $normalizedTaskSlug
+        ExecMode        = $ExecMode
+        ProjectDir      = $ProjectDir
+        LaunchDir       = $LaunchDir
+        GitWorktreeDir  = $GitWorktreeDir
+        Model           = $Model
+        ExecCommand     = $ExecCommand
+    }
+}
+
+function New-SendTransportPlan {
+    param(
+        [Parameter(Mandatory = $true)][string]$Text,
+        [string]$ProjectDir = (Get-Location).Path,
+        [int]$LengthLimit = 4000,
+        [string]$PromptTransport = 'argv',
+        [string]$TaskSlug = '',
+        [bool]$ExecMode = $false,
+        [string]$LaunchDir,
+        [string]$GitWorktreeDir,
+        [string]$Model,
+        [string]$ExecCommand = 'codex',
+        [AllowNull()]$Intent = $null
+    )
+
+    if ($null -eq $Intent) {
+        $Intent = Resolve-SendTransportIntent -Text $Text -ProjectDir $ProjectDir -LengthLimit $LengthLimit `
+            -PromptTransport $PromptTransport -TaskSlug $TaskSlug -ExecMode $ExecMode -LaunchDir $LaunchDir `
+            -GitWorktreeDir $GitWorktreeDir -Model $Model -ExecCommand $ExecCommand
+    }
+    $resolvedPromptTransport = [string]$Intent['PromptTransport']
     if (-not $ExecMode) {
         $payload = Resolve-SendDispatchPayload -Text $Text -ProjectDir $ProjectDir -LengthLimit $LengthLimit -PromptTransport $resolvedPromptTransport -TaskSlug $TaskSlug
         return [ordered]@{
@@ -1042,6 +1260,23 @@ function Resolve-SendTransportPlan {
         TaskSlug        = $normalizedTaskSlug
         ExecInstruction = $execInstruction
     }
+}
+
+function Resolve-SendTransportPlan {
+    param(
+        [Parameter(Mandatory = $true)][string]$Text,
+        [string]$ProjectDir = (Get-Location).Path,
+        [int]$LengthLimit = 4000,
+        [string]$PromptTransport = 'argv',
+        [string]$TaskSlug = '',
+        [bool]$ExecMode = $false,
+        [string]$LaunchDir,
+        [string]$GitWorktreeDir,
+        [string]$Model,
+        [string]$ExecCommand = 'codex'
+    )
+
+    return New-SendTransportPlan @PSBoundParameters
 }
 
 function Convert-MsysTmpPathToWindowsPath {
@@ -1294,6 +1529,7 @@ function Get-CurrentReviewPaneManifestContext {
 
     return [ordered]@{
         ManifestPath        = [string]$context.ManifestPath
+        GenerationId        = [string]$context.GenerationId
         ProjectDir          = [string]$context.ProjectDir
         Label               = [string]$context.Label
         PaneId              = [string]$context.PaneId
@@ -1327,6 +1563,7 @@ function Get-CurrentPaneManifestContext {
 
     return [ordered]@{
         ManifestPath        = [string]$context.ManifestPath
+        GenerationId        = [string]$context.GenerationId
         ProjectDir          = [string]$context.ProjectDir
         SessionName         = [string]$sessionName
         Label               = [string]$context.Label
@@ -1352,17 +1589,21 @@ function Get-CurrentPaneManifestContext {
 
 function Update-ReviewPaneManifestState {
     param(
-        [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [AllowNull()]$Context,
         [Parameter(Mandatory = $true)][System.Collections.IDictionary]$Properties
     )
 
     if (-not (Get-Command Set-PaneControlManifestPaneProperties -ErrorAction SilentlyContinue)) {
         return
     }
+    if ($null -eq $Context) {
+        return
+    }
 
     try {
-        $context = Get-CurrentReviewPaneManifestContext -ProjectDir $ProjectDir
-        Set-PaneControlManifestPaneProperties -ManifestPath $context.ManifestPath -PaneId $context.PaneId -Properties $Properties
+        $expectedGenerationId = [string]$Context.GenerationId
+        Set-PaneControlManifestPaneProperties -ManifestPath ([string]$Context.ManifestPath) -PaneId ([string]$Context.PaneId) `
+            -Properties $Properties -ExpectedGenerationId $expectedGenerationId
     } catch {
         # Review-state persistence remains the source of truth. Manifest sync is best-effort.
     }
@@ -1641,6 +1882,12 @@ function Write-ConsultationCommandRecord {
         [string]$ProjectDir = (Get-Location).Path
     )
 
+    $manifestContext = $null
+    try {
+        $manifestContext = Get-CurrentReviewPaneManifestContext -ProjectDir $ProjectDir
+    } catch {
+        # Consultation persistence is authoritative; manifest enrichment remains best-effort.
+    }
     $context = Get-ConsultationCommandContext -ProjectDir $ProjectDir -RunId $RunId
     $timestamp = (Get-Date).ToString('o')
     $packet = [ordered]@{
@@ -1733,7 +1980,7 @@ function Write-ConsultationCommandRecord {
 
     Write-BridgeEventRecord -ProjectDir $ProjectDir -EventRecord $eventRecord | Out-Null
 
-    Update-ReviewPaneManifestState -ProjectDir $ProjectDir -Properties ([ordered]@{
+    Update-ReviewPaneManifestState -Context $manifestContext -Properties ([ordered]@{
         last_event    = ($Kind -replace '_', '.')
         last_event_at = $timestamp
     })
@@ -2065,8 +2312,79 @@ function Save-Labels {
 }
 
 # --- Helper: Resolve-Target ---
+function Resolve-ManagedManifestTarget {
+    param(
+        [Parameter(Mandatory = $true)][string]$RawTarget,
+        [string]$StartPath = (Get-Location).Path
+    )
+
+    if (-not (Get-Command Get-PaneControlManifestEntries -ErrorAction SilentlyContinue)) {
+        return [PSCustomObject]@{ Managed = $false; PaneId = $null; ManifestPath = $null }
+    }
+
+    try {
+        $currentPath = [System.IO.Path]::GetFullPath($StartPath)
+        if (Test-Path -LiteralPath $currentPath -PathType Leaf) {
+            $currentPath = Split-Path -Parent $currentPath
+        }
+    } catch {
+        return [PSCustomObject]@{ Managed = $false; PaneId = $null; ManifestPath = $null }
+    }
+
+    while (-not [string]::IsNullOrWhiteSpace($currentPath)) {
+        $manifestPath = Join-Path (Join-Path $currentPath '.winsmux') 'manifest.yaml'
+        if (Test-Path -LiteralPath $manifestPath -PathType Leaf) {
+            try {
+                $entries = @(Get-PaneControlManifestEntries -ProjectDir $currentPath)
+            } catch {
+                Stop-WithError 'runtime dispatch refused (manifest_regeneration_required): managed manifest target mapping is unavailable'
+            }
+
+            $matches = @($entries | Where-Object {
+                foreach ($candidate in @($_.PaneId, $_.Label, $_.SlotId, $_.Title)) {
+                    if ([string]::Equals([string]$candidate, $RawTarget, [System.StringComparison]::OrdinalIgnoreCase)) {
+                        return $true
+                    }
+                }
+                return $false
+            })
+            if ($matches.Count -gt 1) {
+                Stop-WithError 'runtime dispatch refused (manifest_regeneration_required): managed target mapping is ambiguous'
+            }
+            if ($matches.Count -eq 1 -and -not [string]::IsNullOrWhiteSpace([string]$matches[0].PaneId)) {
+                return [PSCustomObject]@{ Managed = $true; PaneId = [string]$matches[0].PaneId; ManifestPath = $manifestPath }
+            }
+            return [PSCustomObject]@{ Managed = $true; PaneId = $null; ManifestPath = $manifestPath }
+        }
+
+        $parent = Split-Path -Parent $currentPath
+        if ([string]::IsNullOrWhiteSpace($parent) -or [string]::Equals($parent, $currentPath, [System.StringComparison]::OrdinalIgnoreCase)) {
+            break
+        }
+        $currentPath = $parent
+    }
+
+    return [PSCustomObject]@{ Managed = $false; PaneId = $null; ManifestPath = $null }
+}
+
 function Resolve-Target {
     param([string]$RawTarget)
+    $managedResolution = Resolve-ManagedManifestTarget -RawTarget $RawTarget
+    if ([bool]$managedResolution.Managed) {
+        if (-not [string]::IsNullOrWhiteSpace([string]$managedResolution.PaneId)) {
+            return [string]$managedResolution.PaneId
+        }
+        # A nearest managed manifest is authoritative. Do not let a stale
+        # process-global label redirect this target into another live pane.
+        # Explicit pane IDs still proceed to the runtime identity guard, which
+        # decides whether they belong to the managed session. Labels and titles
+        # omitted by the manifest cannot safely identify a pane.
+        if ($RawTarget -match '^%\d+$') {
+            return $RawTarget
+        }
+        throw 'runtime dispatch refused (manifest_regeneration_required): managed manifest does not contain target'
+    }
+
     $labels = Get-Labels
     if ($labels.ContainsKey($RawTarget)) {
         return $labels[$RawTarget]
@@ -2082,6 +2400,260 @@ function Get-TargetSessionName {
     }
 
     return ''
+}
+
+function ConvertTo-WinsmuxCanonicalProjectPath {
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    $fullPath = [System.IO.Path]::GetFullPath($Path)
+    if (Test-Path -LiteralPath $fullPath -PathType Container) {
+        $fullPath = (Get-Item -LiteralPath $fullPath -Force).FullName
+    }
+
+    $root = [System.IO.Path]::GetPathRoot($fullPath)
+    if (-not [string]::Equals($fullPath, $root, [System.StringComparison]::OrdinalIgnoreCase)) {
+        $fullPath = $fullPath.TrimEnd([char[]]@('\', '/'))
+    }
+    return $fullPath
+}
+
+function Test-WinsmuxRuntimeRegistryMapsPane {
+    param(
+        [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [Parameter(Mandatory = $true)][string]$PaneId
+    )
+
+    $registryPath = Join-Path (Join-Path $ProjectDir '.winsmux') 'runtime-registry.json'
+    if (-not (Test-Path -LiteralPath $registryPath -PathType Leaf)) {
+        return $false
+    }
+
+    try {
+        $registry = Get-Content -LiteralPath $registryPath -Raw -Encoding UTF8 | ConvertFrom-Json -ErrorAction Stop
+        foreach ($pane in @($registry.panes)) {
+            $candidatePaneId = [string](Get-PaneControlValue -InputObject $pane -Name 'pane_id' -Default '')
+            if ([string]::Equals($candidatePaneId, $PaneId, [System.StringComparison]::Ordinal)) {
+                return $true
+            }
+        }
+    } catch {
+        return $false
+    }
+
+    return $false
+}
+
+function Test-WinsmuxManifestMapsPane {
+    param(
+        [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [Parameter(Mandatory = $true)][string]$PaneId
+    )
+
+    $manifestPath = Join-Path (Join-Path $ProjectDir '.winsmux') 'manifest.yaml'
+    if (-not (Test-Path -LiteralPath $manifestPath -PathType Leaf)) {
+        return $false
+    }
+
+    try {
+        foreach ($entry in @(Get-PaneControlManifestEntries -ProjectDir $ProjectDir)) {
+            if ([string]::Equals([string]$entry.PaneId, $PaneId, [System.StringComparison]::Ordinal)) {
+                return $true
+            }
+        }
+    } catch {
+        return $false
+    }
+
+    return $false
+}
+
+function Get-WinsmuxAncestorManagedRoot {
+    param(
+        [Parameter(Mandatory = $true)][string]$StartPath,
+        [Parameter(Mandatory = $true)][string]$PaneId
+    )
+
+    try {
+        $cursor = [System.IO.DirectoryInfo]::new([System.IO.Path]::GetFullPath($StartPath))
+    } catch {
+        return ''
+    }
+
+    while ($null -ne $cursor) {
+        if ((Test-WinsmuxManifestMapsPane -ProjectDir $cursor.FullName -PaneId $PaneId) -or
+            (Test-WinsmuxRuntimeRegistryMapsPane -ProjectDir $cursor.FullName -PaneId $PaneId)) {
+            return $cursor.FullName
+        }
+        $cursor = $cursor.Parent
+    }
+
+    return ''
+}
+
+function New-WinsmuxManagedTargetResolution {
+    param(
+        [Parameter(Mandatory = $true)][bool]$Managed,
+        [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [AllowNull()]$Context,
+        [AllowNull()]$Validation,
+        [Parameter(Mandatory = $true)][string]$Operation,
+        [AllowEmptyString()][string]$GenerationId = ''
+    )
+
+    return [PSCustomObject][ordered]@{
+        Managed      = $Managed
+        ProjectDir   = $ProjectDir
+        Context      = $Context
+        Validation   = $Validation
+        Operation    = $Operation
+        GenerationId = $GenerationId
+    }
+}
+
+function Resolve-WinsmuxManagedTargetContext {
+    param(
+        [Parameter(Mandatory = $true)][string]$PaneId,
+        [string]$CurrentProjectDir = (Get-Location).Path,
+        [ValidateSet('auto', 'dispatch', 'start_deferred', 'stop_transition')][string]$Operation = 'dispatch',
+        [AllowEmptyString()][string]$ExpectedGenerationId = ''
+    )
+
+    $invalidResolution = {
+        param([string]$Diagnostic, [string]$ProjectDir = $CurrentProjectDir)
+        $validation = New-WinsmuxRuntimeValidationResult -Valid $false -ReasonCode 'manifest_regeneration_required' -Diagnostic $Diagnostic
+        New-WinsmuxManagedTargetResolution -Managed $true -ProjectDir $ProjectDir -Context $null -Validation $validation -Operation $Operation
+    }
+
+    try {
+        $sessionOutput = Invoke-WinsmuxRaw -Arguments @('display-message', '-t', $PaneId, '-p', '#{session_name}') 2>$null
+        $sessionName = ((@($sessionOutput) | ForEach-Object { [string]$_ }) -join "`n").Trim()
+        if ($sessionName -match "`r?`n") {
+            $sessionName = ($sessionName -split "`r?`n" | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Last 1).Trim()
+        }
+    } catch {
+        return & $invalidResolution 'Target session identity is unavailable; regenerate the orchestra session.'
+    }
+    if ([string]::IsNullOrWhiteSpace($sessionName)) {
+        return & $invalidResolution 'Target session identity is unavailable; regenerate the orchestra session.'
+    }
+
+    $sessionProjectDir = ''
+    try {
+        $environmentOutput = Invoke-WinsmuxRaw -Arguments @('show-environment', '-t', $sessionName, 'WINSMUX_ORCHESTRA_PROJECT_DIR') 2>$null
+        foreach ($line in @($environmentOutput)) {
+            $text = ([string]$line).Trim()
+            if ($text.StartsWith('WINSMUX_ORCHESTRA_PROJECT_DIR=', [System.StringComparison]::Ordinal)) {
+                $sessionProjectDir = $text.Substring('WINSMUX_ORCHESTRA_PROJECT_DIR='.Length)
+                break
+            }
+        }
+    } catch {
+        return & $invalidResolution 'Target session project identity is unavailable; regenerate the orchestra session.'
+    }
+
+    $processProjectDir = ''
+    if (-not [string]::IsNullOrWhiteSpace([string]$env:WINSMUX_ORCHESTRA_PROJECT_DIR)) {
+        try {
+            $candidateProcessProjectDir = ConvertTo-WinsmuxCanonicalProjectPath -Path ([string]$env:WINSMUX_ORCHESTRA_PROJECT_DIR)
+            if ((Test-WinsmuxManifestMapsPane -ProjectDir $candidateProcessProjectDir -PaneId $PaneId) -or
+                (Test-WinsmuxRuntimeRegistryMapsPane -ProjectDir $candidateProcessProjectDir -PaneId $PaneId)) {
+                $processProjectDir = $candidateProcessProjectDir
+            }
+        } catch {
+            $processProjectDir = ''
+        }
+    }
+
+    $rawCandidates = [System.Collections.Generic.List[string]]::new()
+    foreach ($candidate in @(
+        $sessionProjectDir,
+        $processProjectDir,
+        (Get-WinsmuxAncestorManagedRoot -StartPath $CurrentProjectDir -PaneId $PaneId)
+    )) {
+        if (-not [string]::IsNullOrWhiteSpace($candidate)) {
+            $rawCandidates.Add($candidate.Trim()) | Out-Null
+        }
+    }
+
+    $candidateSet = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+    $candidates = [System.Collections.Generic.List[string]]::new()
+    foreach ($candidate in $rawCandidates) {
+        try {
+            $canonical = ConvertTo-WinsmuxCanonicalProjectPath -Path $candidate
+        } catch {
+            return & $invalidResolution 'Managed project candidate is invalid; regenerate the orchestra session.'
+        }
+        if ($candidateSet.Add($canonical)) {
+            $candidates.Add($canonical) | Out-Null
+        }
+    }
+
+    if ($candidates.Count -eq 0) {
+        if (-not [string]::IsNullOrWhiteSpace($ExpectedGenerationId)) {
+            $validation = New-WinsmuxRuntimeValidationResult -Valid $false `
+                -ReasonCode 'invalid_supervisor_identity' `
+                -Diagnostic 'Managed runtime candidate disappeared before the write operation completed.'
+            return New-WinsmuxManagedTargetResolution -Managed $true `
+                -ProjectDir (ConvertTo-WinsmuxCanonicalProjectPath -Path $CurrentProjectDir) `
+                -Context $null -Validation $validation `
+                -Operation $(if ($Operation -eq 'auto') { 'dispatch' } else { $Operation }) `
+                -GenerationId $ExpectedGenerationId
+        }
+        return New-WinsmuxManagedTargetResolution -Managed $false `
+            -ProjectDir (ConvertTo-WinsmuxCanonicalProjectPath -Path $CurrentProjectDir) `
+            -Context $null -Validation $null -Operation $(if ($Operation -eq 'auto') { 'dispatch' } else { $Operation })
+    }
+    if ($candidates.Count -ne 1) {
+        return & $invalidResolution 'Managed project candidates conflict; regenerate the orchestra session.'
+    }
+
+    $projectDir = [string]$candidates[0]
+    if (-not (Get-Command Get-PaneControlManifestContext -ErrorAction SilentlyContinue) -or
+        -not (Get-Command Test-PaneControlRuntimeContext -ErrorAction SilentlyContinue)) {
+        return & $invalidResolution 'Runtime identity validation is unavailable; regenerate the orchestra session.' $projectDir
+    }
+
+    try {
+        $context = Get-PaneControlManifestContext -ProjectDir $projectDir -PaneId $PaneId
+    } catch {
+        return & $invalidResolution 'Managed pane context is unavailable; regenerate the orchestra session.' $projectDir
+    }
+
+    $runtimeOperation = $Operation
+    if ($runtimeOperation -eq 'auto') {
+        $status = [string](Get-PaneControlValue -InputObject $context -Name 'Status' -Default '')
+        $runtimeOperation = [string](Get-WinsmuxRuntimeStatusClassification -Status $status).RuntimeOperation
+    }
+
+    $validation = Test-PaneControlRuntimeContext -ProjectDir $projectDir -ManifestEntry $context -Operation $runtimeOperation
+    $generationId = ''
+    if ($null -ne $validation -and $null -ne $validation.context) {
+        $generationId = [string](Get-PaneControlValue -InputObject $validation.context -Name 'generation_id' -Default '')
+    }
+    if ([bool]$validation.valid -and -not [string]::IsNullOrWhiteSpace($ExpectedGenerationId) -and
+        -not [string]::Equals($generationId, $ExpectedGenerationId, [System.StringComparison]::Ordinal)) {
+        $validation = New-WinsmuxRuntimeValidationResult -Valid $false -ReasonCode 'invalid_supervisor_identity' `
+            -Diagnostic 'Runtime generation changed before the write operation completed.'
+    }
+
+    return New-WinsmuxManagedTargetResolution -Managed $true -ProjectDir $projectDir -Context $context `
+        -Validation $validation -Operation $runtimeOperation -GenerationId $generationId
+}
+
+function Assert-WinsmuxTargetRuntimeWriteAllowed {
+    param(
+        [Parameter(Mandatory = $true)][string]$PaneId,
+        [string]$CurrentProjectDir = (Get-Location).Path,
+        [ValidateSet('auto', 'dispatch', 'start_deferred', 'stop_transition')][string]$Operation = 'dispatch',
+        [AllowEmptyString()][string]$ExpectedGenerationId = ''
+    )
+
+    $resolution = Resolve-WinsmuxManagedTargetContext -PaneId $PaneId -CurrentProjectDir $CurrentProjectDir `
+        -Operation $Operation -ExpectedGenerationId $ExpectedGenerationId
+    if ($resolution.Managed -and (-not [bool]$resolution.Validation.valid)) {
+        Stop-WithError ("runtime dispatch refused ({0}): {1}" -f [string]$resolution.Validation.reason_code, [string]$resolution.Validation.diagnostic)
+    }
+    return $resolution
 }
 
 # --- Helper: Confirm-Target ---
@@ -2268,13 +2840,39 @@ function Test-PaneContainsCommandFragment {
     return $normalizedPaneText.Contains($fragment)
 }
 
+function Assert-SendPaneRuntimeLease {
+    param(
+        [Parameter(Mandatory = $true)][string]$PaneId,
+        [AllowEmptyString()][string]$RuntimeProjectDir = '',
+        [ValidateSet('dispatch', 'start_deferred')][string]$RuntimeOperation = 'dispatch',
+        [AllowEmptyString()][string]$ExpectedGenerationId = ''
+    )
+
+    if ([string]::IsNullOrWhiteSpace($RuntimeProjectDir) -and [string]::IsNullOrWhiteSpace($ExpectedGenerationId)) {
+        return
+    }
+    if ([string]::IsNullOrWhiteSpace($RuntimeProjectDir) -or [string]::IsNullOrWhiteSpace($ExpectedGenerationId)) {
+        Stop-WithError 'runtime dispatch refused (manifest_regeneration_required): managed send lease identity is incomplete'
+    }
+
+    Assert-WinsmuxTargetRuntimeWriteAllowed -PaneId $PaneId -CurrentProjectDir $RuntimeProjectDir `
+        -Operation $RuntimeOperation -ExpectedGenerationId $ExpectedGenerationId | Out-Null
+}
+
 function Send-TextToPane {
     param(
         [Parameter(Mandatory = $true)][string]$PaneId,
         [Parameter(Mandatory = $true)][string]$CommandText,
-        [AllowEmptyString()][string]$PromptTransport = 'argv'
+        [AllowEmptyString()][string]$PromptTransport = 'argv',
+        [AllowEmptyString()][string]$RuntimeProjectDir = '',
+        [ValidateSet('dispatch', 'start_deferred')][string]$RuntimeOperation = 'dispatch',
+        [AllowEmptyString()][string]$ExpectedGenerationId = '',
+        [AllowNull()][System.Collections.IDictionary]$DeliveryState = $null
     )
 
+    if ($null -ne $DeliveryState) {
+        $DeliveryState['SubmissionCommitted'] = $false
+    }
     $resolvedPromptTransport = Resolve-SupportedPromptTransport -PromptTransport $PromptTransport
     $terminalBackend = Resolve-TerminalBackend
     $targetCandidates = if ($terminalBackend -eq 'tauri') {
@@ -2287,6 +2885,8 @@ function Send-TextToPane {
     foreach ($sendTarget in $targetCandidates) {
         $preSendText = Get-PaneSnapshotText -PaneId $PaneId -Lines 200
         if ($resolvedPromptTransport -eq 'stdin') {
+            Assert-SendPaneRuntimeLease -PaneId $PaneId -RuntimeProjectDir $RuntimeProjectDir `
+                -RuntimeOperation $RuntimeOperation -ExpectedGenerationId $ExpectedGenerationId
             $pasteResult = Invoke-WinsmuxSendPaste -Target $sendTarget -Text $CommandText
             if ($pasteResult.ExitCode -ne 0) {
                 $detail = if ([string]::IsNullOrWhiteSpace($pasteResult.Output)) { 'send-paste failed' } else { $pasteResult.Output }
@@ -2298,6 +2898,8 @@ function Send-TextToPane {
 
             # Type text directly (no header; headers break TUI agents like Claude Code)
             for ($chunkIndex = 0; $chunkIndex -lt $literalChunks.Count; $chunkIndex++) {
+                Assert-SendPaneRuntimeLease -PaneId $PaneId -RuntimeProjectDir $RuntimeProjectDir `
+                    -RuntimeOperation $RuntimeOperation -ExpectedGenerationId $ExpectedGenerationId
                 $literalResult = Invoke-WinsmuxSendKeys -Target $sendTarget -Keys @($literalChunks[$chunkIndex]) -Literal
                 if ($literalResult.ExitCode -ne 0) {
                     $detail = if ([string]::IsNullOrWhiteSpace($literalResult.Output)) { 'send-keys literal failed' } else { $literalResult.Output }
@@ -2318,27 +2920,36 @@ function Send-TextToPane {
             continue
         }
 
+        Assert-SendPaneRuntimeLease -PaneId $PaneId -RuntimeProjectDir $RuntimeProjectDir `
+            -RuntimeOperation $RuntimeOperation -ExpectedGenerationId $ExpectedGenerationId
         $enterResult = Invoke-WinsmuxSendKeys -Target $sendTarget -Keys @('Enter')
         if ($enterResult.ExitCode -ne 0) {
             $detail = if ([string]::IsNullOrWhiteSpace($enterResult.Output)) { 'send-keys Enter failed' } else { $enterResult.Output }
             $attemptFailures.Add("target ${sendTarget}: $detail") | Out-Null
             continue
         }
+        if ($null -ne $DeliveryState) {
+            $DeliveryState['SubmissionCommitted'] = $true
+        }
 
         Start-Sleep -Milliseconds 500
         $postEnterText = Get-PaneSnapshotText -PaneId $PaneId -Lines 200
         if ($postEnterText -match '\[Pasted Content') {
+            Assert-SendPaneRuntimeLease -PaneId $PaneId -RuntimeProjectDir $RuntimeProjectDir `
+                -RuntimeOperation $RuntimeOperation -ExpectedGenerationId $ExpectedGenerationId
             $secondEnterResult = Invoke-WinsmuxSendKeys -Target $sendTarget -Keys @('Enter')
             if ($secondEnterResult.ExitCode -ne 0) {
                 $detail = if ([string]::IsNullOrWhiteSpace($secondEnterResult.Output)) { 'send-keys second Enter failed' } else { $secondEnterResult.Output }
-                $attemptFailures.Add("target ${sendTarget}: $detail") | Out-Null
-                continue
+                throw "failed to send to ${PaneId} after submission commit via ${sendTarget}: $detail"
             }
         }
-
         Start-Sleep -Milliseconds 800
         $snapshotText = Get-PaneSnapshotText -PaneId $PaneId -Lines 200
+        Assert-SendPaneRuntimeLease -PaneId $PaneId -RuntimeProjectDir $RuntimeProjectDir `
+            -RuntimeOperation $RuntimeOperation -ExpectedGenerationId $ExpectedGenerationId
         Save-Watermark $PaneId $snapshotText
+        Assert-SendPaneRuntimeLease -PaneId $PaneId -RuntimeProjectDir $RuntimeProjectDir `
+            -RuntimeOperation $RuntimeOperation -ExpectedGenerationId $ExpectedGenerationId
         Set-ReadMark $PaneId
 
         Write-Output "sent to $PaneId via $sendTarget"
@@ -3161,11 +3772,18 @@ function Invoke-Type {
     $text = $Rest -join ' '
     $paneId = Resolve-Target $Target
     $paneId = Confirm-Target $paneId
+    $projectDir = (Get-Location).Path
+
+    $runtimeAccess = Assert-WinsmuxTargetRuntimeWriteAllowed -PaneId $paneId -CurrentProjectDir $projectDir -Operation dispatch
 
     Assert-ReadMark $paneId
 
+    Assert-WinsmuxTargetRuntimeWriteAllowed -PaneId $paneId -CurrentProjectDir $projectDir -Operation dispatch `
+        -ExpectedGenerationId ([string]$runtimeAccess.GenerationId) | Out-Null
     Invoke-WinsmuxRaw -Arguments @('send-keys', '-t', $paneId, '-l', '--', "$text")
 
+    Assert-WinsmuxTargetRuntimeWriteAllowed -PaneId $paneId -CurrentProjectDir $projectDir -Operation dispatch `
+        -ExpectedGenerationId ([string]$runtimeAccess.GenerationId) | Out-Null
     Clear-ReadMark $paneId
 }
 
@@ -3175,13 +3793,20 @@ function Invoke-Keys {
 
     $paneId = Resolve-Target $Target
     $paneId = Confirm-Target $paneId
+    $projectDir = (Get-Location).Path
+
+    $runtimeAccess = Assert-WinsmuxTargetRuntimeWriteAllowed -PaneId $paneId -CurrentProjectDir $projectDir -Operation dispatch
 
     Assert-ReadMark $paneId
 
     foreach ($key in $Rest) {
+        Assert-WinsmuxTargetRuntimeWriteAllowed -PaneId $paneId -CurrentProjectDir $projectDir -Operation dispatch `
+            -ExpectedGenerationId ([string]$runtimeAccess.GenerationId) | Out-Null
         Invoke-WinsmuxRaw -Arguments @('send-keys', '-t', $paneId, $key)
     }
 
+    Assert-WinsmuxTargetRuntimeWriteAllowed -PaneId $paneId -CurrentProjectDir $projectDir -Operation dispatch `
+        -ExpectedGenerationId ([string]$runtimeAccess.GenerationId) | Out-Null
     Clear-ReadMark $paneId
 }
 
@@ -3192,6 +3817,9 @@ function Invoke-Message {
     $text = $Rest -join ' '
     $paneId = Resolve-Target $Target
     $paneId = Confirm-Target $paneId
+    $projectDir = (Get-Location).Path
+
+    $runtimeAccess = Assert-WinsmuxTargetRuntimeWriteAllowed -PaneId $paneId -CurrentProjectDir $projectDir -Operation dispatch
 
     Assert-ReadMark $paneId
 
@@ -3200,8 +3828,12 @@ function Invoke-Message {
     $agentName = if ($env:WINSMUX_AGENT_NAME) { $env:WINSMUX_AGENT_NAME } else { "unknown" }
 
     $header = "[winsmux from:$agentName pane:$myId at:$myCoord -- load the winsmux skill to reply]"
+    Assert-WinsmuxTargetRuntimeWriteAllowed -PaneId $paneId -CurrentProjectDir $projectDir -Operation dispatch `
+        -ExpectedGenerationId ([string]$runtimeAccess.GenerationId) | Out-Null
     Invoke-WinsmuxRaw -Arguments @('send-keys', '-t', $paneId, '-l', '--', "$header $text")
 
+    Assert-WinsmuxTargetRuntimeWriteAllowed -PaneId $paneId -CurrentProjectDir $projectDir -Operation dispatch `
+        -ExpectedGenerationId ([string]$runtimeAccess.GenerationId) | Out-Null
     Clear-ReadMark $paneId
 }
 
@@ -3360,11 +3992,7 @@ function Test-DeferredPaneStartManifestEntry {
     }
 
     $status = [string](Get-SendConfigValue -InputObject $ManifestEntry -Name 'Status' -Default '')
-    if ([string]::IsNullOrWhiteSpace($status)) {
-        return $false
-    }
-
-    return @('deferred_start', 'deferred_starting', 'deferred_start_failed', 'api_llm_runner_unconfigured', 'antigravity_runner_unconfigured') -contains $status.Trim().ToLowerInvariant()
+    return [bool](Get-WinsmuxRuntimeStatusClassification -Status $status).IsDeferred
 }
 
 function Get-WorkersRecoveryActionForFailureStage {
@@ -3427,7 +4055,9 @@ function Set-DeferredPaneStartStatus {
         [AllowEmptyString()][string]$MarkerPath = '',
         [AllowEmptyString()][string]$FailedStage = '',
         [AllowEmptyString()][string]$FailureReason = '',
-        [AllowEmptyString()][string]$RecoveryAction = ''
+        [AllowEmptyString()][string]$RecoveryAction = '',
+        [AllowEmptyString()][string]$ExpectedGenerationId = '',
+        [ValidateSet('start_deferred', 'dispatch')][string]$RuntimeOperation = 'start_deferred'
     )
 
     if (-not (Get-Command Set-PaneControlManifestPaneProperties -ErrorAction SilentlyContinue)) {
@@ -3436,7 +4066,8 @@ function Set-DeferredPaneStartStatus {
 
     $manifestPath = Join-Path (Join-Path $ProjectDir '.winsmux') 'manifest.yaml'
     $properties = [ordered]@{
-        status = $Status
+        status        = $Status
+        runtime_ready = ($Status -ceq 'ready')
     }
     if (-not [string]::IsNullOrWhiteSpace($MarkerPath)) {
         $properties['bootstrap_marker_path'] = $MarkerPath
@@ -3451,7 +4082,8 @@ function Set-DeferredPaneStartStatus {
         }
     }
 
-    Set-PaneControlManifestPaneProperties -ManifestPath $manifestPath -PaneId $PaneId -Properties $properties
+    Set-PaneControlManifestPaneProperties -ManifestPath $manifestPath -PaneId $PaneId -Properties $properties `
+        -ExpectedGenerationId $ExpectedGenerationId -RuntimeOperation $RuntimeOperation
 }
 
 function Wait-DeferredPaneReady {
@@ -3494,13 +4126,19 @@ function Send-PromptPointerWhenAgentReady {
         [Parameter(Mandatory = $true)][string]$PointerText,
         [AllowEmptyString()][string]$Agent = '',
         [string]$PromptTransport = 'argv',
-        [int]$TimeoutSeconds = 60
+        [int]$TimeoutSeconds = 60,
+        [AllowEmptyString()][string]$RuntimeProjectDir = '',
+        [ValidateSet('dispatch', 'start_deferred')][string]$RuntimeOperation = 'dispatch',
+        [AllowEmptyString()][string]$ExpectedGenerationId = '',
+        [AllowNull()][System.Collections.IDictionary]$DeliveryState = $null
     )
 
     $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
     while ((Get-Date) -lt $deadline) {
         if (Test-AgentReadyPrompt -PaneId $PaneId -Agent $Agent) {
-            return Send-TextToPane -PaneId $PaneId -CommandText $PointerText -PromptTransport $PromptTransport
+            return Send-TextToPane -PaneId $PaneId -CommandText $PointerText -PromptTransport $PromptTransport `
+                -RuntimeProjectDir $RuntimeProjectDir -RuntimeOperation $RuntimeOperation `
+                -ExpectedGenerationId $ExpectedGenerationId -DeliveryState $DeliveryState
         }
 
         Start-Sleep -Milliseconds 250
@@ -3517,7 +4155,11 @@ function Send-ResolvedTransportPlan {
         [ValidateSet('prompt', 'launch')][string]$DeliveryClass = 'prompt',
         [Parameter(Mandatory = $true)][string]$Target,
         [Parameter(Mandatory = $true)][string]$ProjectDir,
-        [Parameter(Mandatory = $true)]$AgentConfig
+        [Parameter(Mandatory = $true)]$AgentConfig,
+        [AllowEmptyString()][string]$RuntimeProjectDir = '',
+        [ValidateSet('dispatch', 'start_deferred')][string]$RuntimeOperation = 'dispatch',
+        [AllowEmptyString()][string]$ExpectedGenerationId = '',
+        [AllowNull()][System.Collections.IDictionary]$DeliveryState = $null
     )
 
     if (Test-SendTransportRequiresPointerReadiness -TransportPlan $TransportPlan -DeliveryClass $DeliveryClass) {
@@ -3530,7 +4172,11 @@ function Send-ResolvedTransportPlan {
             -PaneId $PaneId `
             -PointerText ([string]$TransportPlan['TextToSend']) `
             -Agent $pointerReadinessAgent `
-            -PromptTransport ([string]$TransportPlan['PromptTransport'])
+            -PromptTransport ([string]$TransportPlan['PromptTransport']) `
+            -RuntimeProjectDir $RuntimeProjectDir `
+            -RuntimeOperation $RuntimeOperation `
+            -ExpectedGenerationId $ExpectedGenerationId `
+            -DeliveryState $DeliveryState
     }
 
     $commandText = [string]$TransportPlan['TextToSend']
@@ -3545,7 +4191,11 @@ function Send-ResolvedTransportPlan {
     return Send-TextToPane `
         -PaneId $PaneId `
         -CommandText $commandText `
-        -PromptTransport ([string]$TransportPlan['PromptTransport'])
+        -PromptTransport ([string]$TransportPlan['PromptTransport']) `
+        -RuntimeProjectDir $RuntimeProjectDir `
+        -RuntimeOperation $RuntimeOperation `
+        -ExpectedGenerationId $ExpectedGenerationId `
+        -DeliveryState $DeliveryState
 }
 
 function Resolve-SendInvocationArguments {
@@ -3581,7 +4231,8 @@ function Resolve-SendInvocationArguments {
 function Start-DeferredPaneFromManifestEntry {
     param(
         [Parameter(Mandatory = $true)][string]$ProjectDir,
-        [AllowNull()]$ManifestEntry
+        [AllowNull()]$ManifestEntry,
+        [AllowEmptyString()][string]$ExpectedGenerationId = ''
     )
 
     if (-not (Test-DeferredPaneStartManifestEntry -ManifestEntry $ManifestEntry)) {
@@ -3595,50 +4246,121 @@ function Start-DeferredPaneFromManifestEntry {
     }
 
     $status = [string](Get-SendConfigValue -InputObject $ManifestEntry -Name 'Status' -Default '')
-    $normalizedStatus = $status.Trim().ToLowerInvariant()
+    $statusClassification = Get-WinsmuxRuntimeStatusClassification -Status $status
+    $normalizedStatus = [string]$statusClassification.NormalizedStatus
+    if (-not [bool]$statusClassification.CanStartDeferred -and -not [bool]$statusClassification.IsStarting) {
+        return $false
+    }
     $readinessAgent = ConvertTo-ReadinessAgentName ([string](Get-SendConfigValue -InputObject $ManifestEntry -Name 'CapabilityAdapter' -Default ''))
     if ([string]::IsNullOrWhiteSpace($readinessAgent)) {
         $readinessAgent = ConvertTo-ReadinessAgentName ([string](Get-SendConfigValue -InputObject $ManifestEntry -Name 'ProviderTarget' -Default ''))
     }
 
-    if ($normalizedStatus -eq 'deferred_start_failed') {
-        try {
-            if (Test-AgentReadyPrompt -PaneId $paneId -Agent $readinessAgent) {
-                Set-DeferredPaneStartStatus -ProjectDir $ProjectDir -PaneId $paneId -Status 'ready'
-                return $true
-            }
-        } catch {
-            # Fall through to the bootstrap retry path when the pane cannot be probed.
-        }
-    }
-
     $planPath = [string](Get-SendConfigValue -InputObject $ManifestEntry -Name 'BootstrapPlanPath' -Default '')
     if ([string]::IsNullOrWhiteSpace($planPath)) {
-        Set-DeferredPaneStartStatus -ProjectDir $ProjectDir -PaneId $paneId -Status 'deferred_start_failed' -FailedStage 'bootstrap_plan_missing' -FailureReason "missing bootstrap plan path"
+        Assert-WinsmuxTargetRuntimeWriteAllowed -PaneId $paneId -CurrentProjectDir $ProjectDir `
+            -Operation start_deferred -ExpectedGenerationId $ExpectedGenerationId | Out-Null
+        Set-DeferredPaneStartStatus -ProjectDir $ProjectDir -PaneId $paneId -Status 'deferred_start_failed' `
+            -FailedStage 'bootstrap_plan_missing' -FailureReason "missing bootstrap plan path" `
+            -ExpectedGenerationId $ExpectedGenerationId -RuntimeOperation start_deferred
         throw "deferred pane '$label' is missing bootstrap plan path"
     }
     if (-not [System.IO.Path]::IsPathRooted($planPath)) {
         $planPath = [System.IO.Path]::GetFullPath((Join-Path $ProjectDir $planPath))
     }
     if (-not (Test-Path -LiteralPath $planPath -PathType Leaf)) {
-        Set-DeferredPaneStartStatus -ProjectDir $ProjectDir -PaneId $paneId -Status 'deferred_start_failed' -FailedStage 'bootstrap_plan_not_found' -FailureReason "bootstrap plan not found: $planPath"
+        Assert-WinsmuxTargetRuntimeWriteAllowed -PaneId $paneId -CurrentProjectDir $ProjectDir `
+            -Operation start_deferred -ExpectedGenerationId $ExpectedGenerationId | Out-Null
+        Set-DeferredPaneStartStatus -ProjectDir $ProjectDir -PaneId $paneId -Status 'deferred_start_failed' `
+            -FailedStage 'bootstrap_plan_not_found' -FailureReason "bootstrap plan not found: $planPath" `
+            -ExpectedGenerationId $ExpectedGenerationId -RuntimeOperation start_deferred
         throw "deferred pane '$label' bootstrap plan not found: $planPath"
     }
 
-    $plan = Get-Content -LiteralPath $planPath -Raw -Encoding UTF8 | ConvertFrom-Json -Depth 8
+    $plan = Get-Content -LiteralPath $planPath -Raw -Encoding UTF8 | ConvertFrom-WinsmuxJson -Depth 8
     $approvedLaunch = Get-SendConfigValue -InputObject $ManifestEntry -Name 'ApprovedLaunch' -Default $null
     $candidateLaunch = Get-SendConfigValue -InputObject $plan -Name 'approved_launch' -Default $null
     $approvalDifferences = @(Get-WorkersLaunchApprovalDifferences -ApprovedLaunch $approvedLaunch -CurrentLaunch $candidateLaunch)
     if ($approvalDifferences.Count -gt 0) {
         $mismatchReason = Format-WorkersLaunchApprovalMismatch -Differences $approvalDifferences
-        Set-DeferredPaneStartStatus -ProjectDir $ProjectDir -PaneId $paneId -Status 'deferred_start_failed' -FailedStage 'launch_approval' -FailureReason $mismatchReason -RecoveryAction 'review-worker-settings-and-rerun-launch'
+        Assert-WinsmuxTargetRuntimeWriteAllowed -PaneId $paneId -CurrentProjectDir $ProjectDir `
+            -Operation start_deferred -ExpectedGenerationId $ExpectedGenerationId | Out-Null
+        Set-DeferredPaneStartStatus -ProjectDir $ProjectDir -PaneId $paneId -Status 'deferred_start_failed' `
+            -FailedStage 'launch_approval' -FailureReason $mismatchReason -RecoveryAction 'review-worker-settings-and-rerun-launch' `
+            -ExpectedGenerationId $ExpectedGenerationId -RuntimeOperation start_deferred
         throw $mismatchReason
     }
 
     $markerPath = [string](Get-SendConfigValue -InputObject $plan -Name 'ready_marker_path' -Default '')
+    $reuseExistingRetryMarker = $false
+    if ($normalizedStatus -eq 'deferred_start_failed') {
+        $retryResolution = Assert-WinsmuxTargetRuntimeWriteAllowed -PaneId $paneId -CurrentProjectDir $ProjectDir `
+            -Operation start_deferred -ExpectedGenerationId $ExpectedGenerationId
+        $retryValidation = Get-SendConfigValue -InputObject $retryResolution -Name 'Validation' -Default $null
+        $retryValidationContext = Get-SendConfigValue -InputObject $retryValidation -Name 'context' -Default $null
+        $retryMarkerState = [string](Get-SendConfigValue -InputObject $retryValidationContext `
+            -Name 'retry_marker_state' -Default '')
+        if (-not [string]::IsNullOrWhiteSpace($retryMarkerState)) {
+            $manifestRetryMarkerPath = [string](Get-SendConfigValue -InputObject $ManifestEntry `
+                -Name 'BootstrapMarkerPath' -Default '')
+            if ([string]::IsNullOrWhiteSpace($manifestRetryMarkerPath) -or [string]::IsNullOrWhiteSpace($markerPath)) {
+                throw 'failed deferred retry marker path is missing from the manifest or bootstrap plan'
+            }
+            $manifestRetryMarkerFull = if ([System.IO.Path]::IsPathRooted($manifestRetryMarkerPath)) {
+                [System.IO.Path]::GetFullPath($manifestRetryMarkerPath)
+            } else {
+                [System.IO.Path]::GetFullPath((Join-Path $ProjectDir $manifestRetryMarkerPath))
+            }
+            $planRetryMarkerFull = if ([System.IO.Path]::IsPathRooted($markerPath)) {
+                [System.IO.Path]::GetFullPath($markerPath)
+            } else {
+                [System.IO.Path]::GetFullPath((Join-Path $ProjectDir $markerPath))
+            }
+            if (-not [string]::Equals($manifestRetryMarkerFull, $planRetryMarkerFull, [System.StringComparison]::OrdinalIgnoreCase)) {
+                throw 'failed deferred retry marker path does not match the approved bootstrap plan'
+            }
+        }
+        if ($retryMarkerState -ceq 'live') {
+            $liveRetryResolution = Assert-WinsmuxTargetRuntimeWriteAllowed -PaneId $paneId -CurrentProjectDir $ProjectDir `
+                -Operation start_deferred -ExpectedGenerationId $ExpectedGenerationId
+            $liveRetryValidation = Get-SendConfigValue -InputObject $liveRetryResolution -Name 'Validation' -Default $null
+            $liveRetryContext = Get-SendConfigValue -InputObject $liveRetryValidation -Name 'context' -Default $null
+            $liveRetryMarkerState = [string](Get-SendConfigValue -InputObject $liveRetryContext `
+                -Name 'retry_marker_state' -Default '')
+            if ($liveRetryMarkerState -cne 'live') {
+                throw 'deferred retry marker changed before deferred retry manifest update'
+            }
+            Set-DeferredPaneStartStatus -ProjectDir $ProjectDir -PaneId $paneId -Status 'deferred_starting' -MarkerPath $markerPath `
+                -ExpectedGenerationId $ExpectedGenerationId -RuntimeOperation start_deferred
+            $reuseExistingRetryMarker = $true
+        } elseif ($retryMarkerState -ceq 'stale') {
+            $preCleanupResolution = Assert-WinsmuxTargetRuntimeWriteAllowed -PaneId $paneId -CurrentProjectDir $ProjectDir `
+                -Operation start_deferred -ExpectedGenerationId $ExpectedGenerationId
+            $preCleanupValidation = Get-SendConfigValue -InputObject $preCleanupResolution -Name 'Validation' -Default $null
+            $preCleanupContext = Get-SendConfigValue -InputObject $preCleanupValidation -Name 'context' -Default $null
+            $preCleanupMarkerState = [string](Get-SendConfigValue -InputObject $preCleanupContext `
+                -Name 'retry_marker_state' -Default '')
+            if ($preCleanupMarkerState -cne 'stale') {
+                throw 'deferred retry marker changed before bounded stale-marker cleanup'
+            }
+            Remove-WorkersBootstrapMarker -ProjectDir $ProjectDir -Entry $ManifestEntry | Out-Null
+            $postCleanupResolution = Assert-WinsmuxTargetRuntimeWriteAllowed -PaneId $paneId -CurrentProjectDir $ProjectDir `
+                -Operation start_deferred -ExpectedGenerationId $ExpectedGenerationId
+            $postCleanupValidation = Get-SendConfigValue -InputObject $postCleanupResolution -Name 'Validation' -Default $null
+            $postCleanupContext = Get-SendConfigValue -InputObject $postCleanupValidation -Name 'context' -Default $null
+            $postCleanupMarkerState = [string](Get-SendConfigValue -InputObject $postCleanupContext `
+                -Name 'retry_marker_state' -Default '')
+            if (-not [string]::IsNullOrWhiteSpace($postCleanupMarkerState)) {
+                throw 'stale deferred retry marker remained observable after bounded cleanup'
+            }
+        }
+    }
 
-    if (@('deferred_start', 'deferred_start_failed') -contains $normalizedStatus) {
-        Set-DeferredPaneStartStatus -ProjectDir $ProjectDir -PaneId $paneId -Status 'deferred_starting' -MarkerPath $markerPath
+    if (@('deferred_start', 'deferred_start_failed') -contains $normalizedStatus -and -not $reuseExistingRetryMarker) {
+        Assert-WinsmuxTargetRuntimeWriteAllowed -PaneId $paneId -CurrentProjectDir $ProjectDir `
+            -Operation start_deferred -ExpectedGenerationId $ExpectedGenerationId | Out-Null
+        Set-DeferredPaneStartStatus -ProjectDir $ProjectDir -PaneId $paneId -Status 'deferred_starting' -MarkerPath $markerPath `
+            -ExpectedGenerationId $ExpectedGenerationId -RuntimeOperation start_deferred
         $bootstrapScriptPath = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\winsmux-core\scripts\orchestra-pane-bootstrap.ps1'))
         $bootstrapCommand = "pwsh -NoProfile -File {0} -PlanFile {1}" -f `
             (ConvertTo-DispatchPowerShellLiteral -Value $bootstrapScriptPath), `
@@ -3658,11 +4380,26 @@ function Start-DeferredPaneFromManifestEntry {
 
     try {
         Wait-DeferredPaneReady -PaneId $paneId -Agent $readinessAgent -TimeoutSeconds 90
-        Set-DeferredPaneStartStatus -ProjectDir $ProjectDir -PaneId $paneId -Status 'ready' -MarkerPath $markerPath
+        $dispatchEntry = Get-PaneControlManifestContext -ProjectDir $ProjectDir -PaneId $paneId
+        $dispatchRuntime = Wait-PaneControlRuntimeContext -ProjectDir $ProjectDir -ManifestEntry $dispatchEntry -Operation dispatch
+        if (-not [bool]$dispatchRuntime.valid) {
+            Stop-WithError ("runtime dispatch refused ({0}): {1}" -f [string]$dispatchRuntime.reason_code, [string]$dispatchRuntime.diagnostic)
+        }
+        Assert-WinsmuxTargetRuntimeWriteAllowed -PaneId $paneId -CurrentProjectDir $ProjectDir `
+            -Operation dispatch -ExpectedGenerationId $ExpectedGenerationId | Out-Null
+        Set-DeferredPaneStartStatus -ProjectDir $ProjectDir -PaneId $paneId -Status 'ready' -MarkerPath $markerPath `
+            -ExpectedGenerationId $ExpectedGenerationId -RuntimeOperation dispatch
         return $true
     } catch {
         $failureReason = [string]$_.Exception.Message
-        Set-DeferredPaneStartStatus -ProjectDir $ProjectDir -PaneId $paneId -Status 'deferred_start_failed' -MarkerPath $markerPath -FailedStage 'readiness_probe' -FailureReason $failureReason -RecoveryAction 'inspect-pane-log-and-run-workers-start'
+        if ($failureReason -match '^runtime dispatch refused \([^)]+\):') {
+            throw
+        }
+        Assert-WinsmuxTargetRuntimeWriteAllowed -PaneId $paneId -CurrentProjectDir $ProjectDir `
+            -Operation start_deferred -ExpectedGenerationId $ExpectedGenerationId | Out-Null
+        Set-DeferredPaneStartStatus -ProjectDir $ProjectDir -PaneId $paneId -Status 'deferred_start_failed' -MarkerPath $markerPath `
+            -FailedStage 'readiness_probe' -FailureReason $failureReason -RecoveryAction 'inspect-pane-log-and-run-workers-start' `
+            -ExpectedGenerationId $ExpectedGenerationId -RuntimeOperation start_deferred
         throw
     }
 }
@@ -3688,7 +4425,7 @@ function Invoke-Send {
 
     # Normalize Git Bash /tmp paths before dispatching PowerShell-oriented commands.
     $text = Normalize-DispatchText -Text ($messageParts -join ' ')
-    $projectDir = (Get-Location).Path
+    $currentProjectDir = (Get-Location).Path
     $paneId = Resolve-Target $SendTarget
     if ((Resolve-TerminalBackend) -eq 'cli') {
         $paneId = Confirm-Target $paneId
@@ -3701,57 +4438,71 @@ function Invoke-Send {
     }
     $execMode = $false
 
+    $paneControlLoadError = ''
+    $bridgeSettingsLoadError = ''
     try {
         if (Test-Path $PaneControlScript -PathType Leaf) {
             . $PaneControlScript
         }
-
+    } catch {
+        $paneControlLoadError = [string]$_.Exception.Message
+    }
+    try {
         if (Test-Path $BridgeSettingsScript -PathType Leaf) {
             . $BridgeSettingsScript
         }
     } catch {
+        $bridgeSettingsLoadError = [string]$_.Exception.Message
     }
 
-    $hasManifestHelper = Get-Command Get-PaneControlManifestContext -ErrorAction SilentlyContinue
+    $runtimeAccess = Assert-WinsmuxTargetRuntimeWriteAllowed -PaneId $paneId -CurrentProjectDir $currentProjectDir -Operation auto
+    $projectDir = [string]$runtimeAccess.ProjectDir
+    $context = $runtimeAccess.Context
     $hasRoleConfigHelper = Get-Command Get-RoleAgentConfig -ErrorAction SilentlyContinue
-    $manifestPath = Join-Path $projectDir '.winsmux\manifest.yaml'
-    if ($null -ne $hasManifestHelper -and $null -ne $hasRoleConfigHelper -and (Test-Path $manifestPath -PathType Leaf)) {
+    if ($runtimeAccess.Managed -and (
+            -not [string]::IsNullOrWhiteSpace($paneControlLoadError) -or
+            -not [string]::IsNullOrWhiteSpace($bridgeSettingsLoadError) -or
+            $null -eq $hasRoleConfigHelper)) {
+        Stop-WithError 'runtime dispatch refused (manifest_regeneration_required): managed runtime validation helpers are unavailable'
+    }
+    if ($null -ne $context) {
         try {
-            $context = Get-PaneControlManifestContext -ProjectDir $projectDir -PaneId $paneId
-            if ($null -ne $context -and -not [string]::IsNullOrWhiteSpace([string]$context.ManifestPath)) {
-                $manifestContent = Get-Content -LiteralPath $context.ManifestPath -Raw -Encoding UTF8
-                $manifest = ConvertFrom-PaneControlManifestContent -Content $manifestContent
-                $manifestPane = $null
-                if ($null -ne $manifest -and $null -ne $manifest.Panes -and $manifest.Panes.Contains([string]$context.Label)) {
-                    $manifestPane = $manifest.Panes[[string]$context.Label]
-                }
-
-                if (Get-Command Get-SlotAgentConfig -ErrorAction SilentlyContinue) {
-                    $agentConfig = Get-SlotAgentConfig -Role $context.Role -SlotId $context.Label -RootPath $projectDir
-                } else {
-                    $agentConfig = Get-RoleAgentConfig -Role $context.Role
-                }
-
-                $execModeValue = ''
-                if ($null -ne $manifestPane) {
-                    if ($manifestPane -is [System.Collections.IDictionary] -and $manifestPane.Contains('exec_mode')) {
-                        $execModeValue = [string]$manifestPane['exec_mode']
-                    } elseif ($null -ne $manifestPane.PSObject -and $manifestPane.PSObject.Properties.Name -contains 'exec_mode') {
-                        $execModeValue = [string]$manifestPane.exec_mode
-                    }
-                }
-
-                $capabilityAdapter = [string](Get-SendConfigValue -InputObject $agentConfig -Name 'CapabilityAdapter' -Default '')
-                if ([string]::IsNullOrWhiteSpace($capabilityAdapter)) {
-                    $capabilityAdapter = [string]$agentConfig.Agent
-                }
-                $execModeAgent = ConvertTo-ReadinessAgentName $capabilityAdapter
-                $execMode = $execModeValue.Trim().ToLowerInvariant() -eq 'true' -and $execModeAgent -eq 'codex'
+            if ($null -eq $context -or [string]::IsNullOrWhiteSpace([string]$context.ManifestPath)) {
+                throw 'managed pane context did not resolve exactly once'
             }
+            $manifestContent = Get-Content -LiteralPath $context.ManifestPath -Raw -Encoding UTF8
+            $manifest = ConvertFrom-PaneControlManifestContent -Content $manifestContent
+            $manifestPane = $null
+            if ($null -ne $manifest -and $null -ne $manifest.Panes -and $manifest.Panes.Contains([string]$context.Label)) {
+                $manifestPane = $manifest.Panes[[string]$context.Label]
+            }
+
+            if (Get-Command Get-SlotAgentConfig -ErrorAction SilentlyContinue) {
+                $agentConfig = Get-SlotAgentConfig -Role $context.Role -SlotId $context.Label -RootPath $projectDir
+            } else {
+                $agentConfig = Get-RoleAgentConfig -Role $context.Role
+            }
+
+            $execModeValue = ''
+            if ($null -ne $manifestPane) {
+                if ($manifestPane -is [System.Collections.IDictionary] -and $manifestPane.Contains('exec_mode')) {
+                    $execModeValue = [string]$manifestPane['exec_mode']
+                } elseif ($null -ne $manifestPane.PSObject -and $manifestPane.PSObject.Properties.Name -contains 'exec_mode') {
+                    $execModeValue = [string]$manifestPane.exec_mode
+                }
+            }
+
+            $capabilityAdapter = [string](Get-SendConfigValue -InputObject $agentConfig -Name 'CapabilityAdapter' -Default '')
+            if ([string]::IsNullOrWhiteSpace($capabilityAdapter)) {
+                $capabilityAdapter = [string]$agentConfig.Agent
+            }
+            $execModeAgent = ConvertTo-ReadinessAgentName $capabilityAdapter
+            $execMode = $execModeValue.Trim().ToLowerInvariant() -eq 'true' -and $execModeAgent -eq 'codex'
         } catch {
             if ($_.Exception.Message -match 'Provider capability') {
                 throw
             }
+            Stop-WithError ("runtime dispatch refused (manifest_regeneration_required): {0}" -f $_.Exception.Message)
         }
     }
 
@@ -3779,13 +4530,28 @@ function Invoke-Send {
                     target      = $SendTarget
                 }
             }
+            if ([bool]$runtimeAccess.Managed) {
+                Assert-WinsmuxTargetRuntimeWriteAllowed -PaneId $paneId -CurrentProjectDir $projectDir `
+                    -Operation ([string]$runtimeAccess.Operation) -ExpectedGenerationId ([string]$runtimeAccess.GenerationId) | Out-Null
+            }
             Write-BridgeEventRecord -ProjectDir $projectDir -EventRecord $eventRecord | Out-Null
             Stop-WithError ([string]$policyViolation['reason'])
         }
     }
 
-    if (-not $SkipDeferredPaneStart) {
-        Start-DeferredPaneFromManifestEntry -ProjectDir $projectDir -ManifestEntry $context | Out-Null
+    if ($null -ne $context) {
+        $runtimeOperation = [string]$runtimeAccess.Operation
+        if (-not $SkipDeferredPaneStart) {
+            Start-DeferredPaneFromManifestEntry -ProjectDir $projectDir -ManifestEntry $context `
+                -ExpectedGenerationId ([string]$runtimeAccess.GenerationId) | Out-Null
+            if ($runtimeOperation -ceq 'start_deferred') {
+                $context = Get-PaneControlManifestContext -ProjectDir $projectDir -PaneId $paneId
+                $runtimeResult = Wait-PaneControlRuntimeContext -ProjectDir $projectDir -ManifestEntry $context -Operation dispatch
+                if (-not $runtimeResult.valid) {
+                    Stop-WithError ("runtime dispatch refused ({0}): {1}" -f $runtimeResult.reason_code, $runtimeResult.diagnostic)
+                }
+            }
+        }
     }
 
     $contextLaunchDir = $projectDir
@@ -3808,34 +4574,85 @@ function Invoke-Send {
         }
     }
 
-    $transportPlan = Resolve-SendTransportPlan `
-        -Text $text `
-        -ProjectDir $projectDir `
-        -LengthLimit 4000 `
-        -PromptTransport ([string]$agentConfig.PromptTransport) `
-        -TaskSlug $taskSlug `
-        -ExecMode:$execMode `
-        -LaunchDir $contextLaunchDir `
-        -GitWorktreeDir $contextGitWorktreeDir `
-        -Model ([string]$agentConfig.Model) `
-        -ExecCommand ([string](Get-SendConfigValue -InputObject $agentConfig -Name 'CapabilityCommand' -Default $agentConfig.Agent))
-
-    if ($transportPlan['Mode'] -eq 'codex_exec_file') {
-        Send-TextToPane -PaneId $paneId -CommandText ([string]$transportPlan['ExecInstruction'])
-        return
+    $transportPlanRequest = [ordered]@{
+        Text               = $text
+        ProjectDir         = $projectDir
+        LengthLimit        = 4000
+        PromptTransport    = [string]$agentConfig.PromptTransport
+        TaskSlug           = $taskSlug
+        ExecMode           = $execMode
+        LaunchDir          = $contextLaunchDir
+        GitWorktreeDir     = $contextGitWorktreeDir
+        Model              = [string]$agentConfig.Model
+        ExecCommand        = [string](Get-SendConfigValue -InputObject $agentConfig -Name 'CapabilityCommand' -Default $agentConfig.Agent)
     }
 
-    if ($transportPlan['IsFileBacked']) {
-        Write-Warning ("send target '{0}' used prompt_transport={1}; wrote full text to {2} and sent a prompt-file pointer instead." -f $SendTarget, $transportPlan['PromptTransport'], $transportPlan['PromptPath'])
+    # Resolve the complete delivery shape without touching the filesystem. The
+    # runtime lease is revalidated only after this pure planning step; prompt
+    # artifacts are materialized below the guard.
+    $transportIntent = Resolve-SendTransportIntent @transportPlanRequest
+    $sendRuntimeOperation = if ($SkipDeferredPaneStart) { 'start_deferred' } else { 'dispatch' }
+    $sendRuntimeProjectDir = if ($null -ne $context) { $projectDir } else { '' }
+    $sendExpectedGenerationId = if ($null -ne $context) { [string]$runtimeAccess.GenerationId } else { '' }
+
+    if ($null -ne $context) {
+        Assert-WinsmuxTargetRuntimeWriteAllowed -PaneId $paneId -CurrentProjectDir $projectDir `
+            -Operation $sendRuntimeOperation -ExpectedGenerationId $sendExpectedGenerationId | Out-Null
     }
 
-    Send-ResolvedTransportPlan `
-        -PaneId $paneId `
-        -TransportPlan $transportPlan `
-        -DeliveryClass $DeliveryClass `
-        -Target $SendTarget `
-        -ProjectDir $projectDir `
-        -AgentConfig $agentConfig
+    $artifactCheckpoint = New-SendPromptArtifactCheckpoint -ProjectDir $projectDir -Intent $transportIntent
+    $transportPlan = $null
+    $materializationBegan = $false
+    $deliveryState = [ordered]@{ SubmissionCommitted = $false }
+    try {
+        # The checkpoint may wait for another materializer. Revalidate the
+        # captured runtime only after that lease is held and before any prompt
+        # artifact can be created or replaced.
+        Assert-SendPaneRuntimeLease -PaneId $paneId -RuntimeProjectDir $sendRuntimeProjectDir `
+            -RuntimeOperation $sendRuntimeOperation -ExpectedGenerationId $sendExpectedGenerationId
+        $materializationBegan = $true
+        $transportPlan = New-SendTransportPlan @transportPlanRequest -Intent $transportIntent
+        Assert-SendPaneRuntimeLease -PaneId $paneId -RuntimeProjectDir $sendRuntimeProjectDir `
+            -RuntimeOperation $sendRuntimeOperation -ExpectedGenerationId $sendExpectedGenerationId
+
+        if ($transportPlan['Mode'] -eq 'codex_exec_file') {
+            Send-TextToPane -PaneId $paneId -CommandText ([string]$transportPlan['ExecInstruction']) `
+                -RuntimeProjectDir $sendRuntimeProjectDir -RuntimeOperation $sendRuntimeOperation `
+                -ExpectedGenerationId $sendExpectedGenerationId -DeliveryState $deliveryState
+            return
+        }
+
+        if ($transportPlan['IsFileBacked']) {
+            Write-Warning ("send target '{0}' used prompt_transport={1}; wrote full text to {2} and sent a prompt-file pointer instead." -f $SendTarget, $transportPlan['PromptTransport'], $transportPlan['PromptPath'])
+        }
+
+        Send-ResolvedTransportPlan `
+            -PaneId $paneId `
+            -TransportPlan $transportPlan `
+            -DeliveryClass $DeliveryClass `
+            -Target $SendTarget `
+            -ProjectDir $projectDir `
+            -AgentConfig $agentConfig `
+            -RuntimeProjectDir $sendRuntimeProjectDir `
+            -RuntimeOperation $sendRuntimeOperation `
+            -ExpectedGenerationId $sendExpectedGenerationId `
+            -DeliveryState $deliveryState
+    } catch {
+        $failureMessage = [string]$_.Exception.Message
+        $submissionCommitted = [bool](Get-SendConfigValue -InputObject $deliveryState -Name 'SubmissionCommitted' -Default $false)
+        if ($null -ne $context -and $materializationBegan -and -not $submissionCommitted -and
+            $failureMessage -match '^runtime dispatch refused \([^)]+\):') {
+            $materializedPromptPath = if ($null -eq $transportPlan) { '' } else { [string]$transportPlan['PromptPath'] }
+            try {
+                Restore-SendPromptArtifactCheckpoint -Checkpoint $artifactCheckpoint -MaterializedPromptPath $materializedPromptPath
+            } catch {
+                Write-Warning ("send artifact rollback failed after runtime refusal: {0}" -f $_.Exception.Message)
+            }
+        }
+        throw
+    } finally {
+        Exit-SendPromptArtifactCheckpoint -Checkpoint $artifactCheckpoint
+    }
 }
 
 function Invoke-Name {
@@ -3845,6 +4662,11 @@ function Invoke-Name {
     $label = $Rest[0]
     $paneId = Resolve-Target $Target
     $paneId = Confirm-Target $paneId
+
+    $lifecycleRefusal = Get-ManagedPaneLifecycleMutationRefusal -ProjectDir (Get-Location).Path -PaneId $paneId -OperationName name -RequestedLabel $label
+    if ($null -ne $lifecycleRefusal) {
+        Stop-WithError ("{0}: {1}" -f [string]$lifecycleRefusal.reason_code, [string]$lifecycleRefusal.diagnostic)
+    }
 
     $labels = Get-Labels
     $labels[$label] = $paneId
@@ -3907,6 +4729,37 @@ function Invoke-AutoRebalance {
     if ($idleBuilders.Count -gt 0) { Write-Output "アイドル: $($idleBuilders -join ', ')" }
 }
 
+function Get-ManagedPaneLifecycleMutationRefusal {
+    param(
+        [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [Parameter(Mandatory = $true)][string]$PaneId,
+        [Parameter(Mandatory = $true)][ValidateSet('role', 'restart', 'name', 'kill')][string]$OperationName,
+        [AllowEmptyString()][string]$RequestedLabel = ''
+    )
+
+    try {
+        $resolution = Resolve-WinsmuxManagedTargetContext -PaneId $PaneId -CurrentProjectDir $ProjectDir -Operation dispatch
+    } catch {
+        return [PSCustomObject][ordered]@{
+            valid       = $false
+            reason_code = 'manifest_regeneration_required'
+            diagnostic  = 'Runtime identity evidence is unavailable; regenerate the orchestra session.'
+        }
+    }
+    if (-not [bool]$resolution.Managed) {
+        return $null
+    }
+    if (-not [bool]$resolution.Validation.valid) {
+        return $resolution.Validation
+    }
+
+    return [PSCustomObject][ordered]@{
+        valid       = $false
+        reason_code = 'manifest_regeneration_required'
+        diagnostic  = "$OperationName is blocked for supervisor-managed panes because it would replace the registered bootstrap identity; regenerate the orchestra session."
+    }
+}
+
 function Invoke-Role {
     if (-not $Target -or -not $Rest -or $Rest.Count -lt 1) {
         Stop-WithError "usage: winsmux role <pane_label_or_id> <new_role>`n  roles: worker, builder, researcher, reviewer"
@@ -3917,19 +4770,21 @@ function Invoke-Role {
         Stop-WithError "invalid role: $newRole. Must be worker, builder, researcher, or reviewer."
     }
 
-    # Resolve pane ID
-    $paneId = $Target
-    $labels = Get-Labels
-    if ($labels.ContainsKey($Target)) {
-        $paneId = $labels[$Target]
-    } elseif ($Target -notmatch '^%\d+$') {
+    $projectDir = (Get-Location).Path
+    $paneId = Resolve-Target $Target
+    if ($paneId -notmatch '^%\d+$') {
         Stop-WithError "unknown pane: $Target"
     }
+    $labels = Get-Labels
 
     # Read manifest to find current label
-    $projectDir = (Get-Location).Path
     $manifestPath = Join-Path $projectDir ".winsmux\manifest.yaml"
     $oldLabel = $Target
+
+    $lifecycleRefusal = Get-ManagedPaneLifecycleMutationRefusal -ProjectDir $projectDir -PaneId $paneId -OperationName role
+    if ($null -ne $lifecycleRefusal) {
+        Stop-WithError ("{0}: {1}" -f [string]$lifecycleRefusal.reason_code, [string]$lifecycleRefusal.diagnostic)
+    }
 
     # Count existing panes with new role to generate label number
     $existingLabels = @()
@@ -4053,7 +4908,9 @@ function Invoke-Role {
             $manifestProperties['builder_worktree_path'] = ''
             $manifestProperties['builder_branch'] = ''
         }
-        Set-PaneControlManifestPaneProperties -ManifestPath $manifestPath -PaneId $paneId -Properties $manifestProperties
+        $expectedGenerationId = if ($null -eq $manifestEntry) { '' } else { [string]$manifestEntry.GenerationId }
+        Set-PaneControlManifestPaneProperties -ManifestPath $manifestPath -PaneId $paneId -Properties $manifestProperties `
+            -ExpectedGenerationId $expectedGenerationId
     }
 
     $sessionName = [string]$env:WINSMUX_ORCHESTRA_SESSION
@@ -4654,7 +5511,7 @@ function Read-LauncherTemplateStore {
     }
 
     try {
-        $parsed = Get-Content -LiteralPath $path -Raw -Encoding UTF8 | ConvertFrom-Json -AsHashtable -Depth 32
+        $parsed = Get-Content -LiteralPath $path -Raw -Encoding UTF8 | ConvertFrom-WinsmuxJson -AsHashtable -Depth 32
     } catch {
         Stop-WithError "launcher template store is not valid JSON: $path"
     }
@@ -4752,7 +5609,7 @@ function Read-LauncherWorkspaceLifecycleOverride {
     }
 
     try {
-        return Get-Content -LiteralPath $Path -Raw -Encoding UTF8 | ConvertFrom-Json -AsHashtable -Depth 32
+        return Get-Content -LiteralPath $Path -Raw -Encoding UTF8 | ConvertFrom-WinsmuxJson -AsHashtable -Depth 32
     } catch {
         Stop-WithError "workspace lifecycle override is not valid JSON: $Path"
     }
@@ -4989,6 +5846,9 @@ function Invoke-ImeInput {
 
     $paneId = Resolve-Target $Target
     $paneId = Confirm-Target $paneId
+    $projectDir = (Get-Location).Path
+
+    $runtimeAccess = Assert-WinsmuxTargetRuntimeWriteAllowed -PaneId $paneId -CurrentProjectDir $projectDir -Operation dispatch
 
     Assert-ReadMark $paneId
 
@@ -5006,9 +5866,71 @@ function Invoke-ImeInput {
         return
     }
 
+    Assert-WinsmuxTargetRuntimeWriteAllowed -PaneId $paneId -CurrentProjectDir $projectDir -Operation dispatch `
+        -ExpectedGenerationId ([string]$runtimeAccess.GenerationId) | Out-Null
     Invoke-WinsmuxRaw -Arguments @('send-keys', '-t', $paneId, '-l', '--', "$text")
+    Assert-WinsmuxTargetRuntimeWriteAllowed -PaneId $paneId -CurrentProjectDir $projectDir -Operation dispatch `
+        -ExpectedGenerationId ([string]$runtimeAccess.GenerationId) | Out-Null
     Clear-ReadMark $paneId
     Write-Output "sent to $paneId"
+}
+
+function Write-WinsmuxClipboardImageArtifact {
+    param(
+        [Parameter(Mandatory = $true)]$Image,
+        [Parameter(Mandatory = $true)][string]$DirectoryPath
+    )
+
+    $createdDirectory = $false
+    if (-not (Test-Path -LiteralPath $DirectoryPath -PathType Container)) {
+        New-Item -ItemType Directory -Path $DirectoryPath -Force | Out-Null
+        $createdDirectory = $true
+    }
+
+    for ($attempt = 0; $attempt -lt 8; $attempt++) {
+        $timestamp = Get-Date -Format 'yyyyMMdd_HHmmss'
+        $artifactName = '{0}-{1}.png' -f $timestamp, ([guid]::NewGuid().ToString('N'))
+        $artifactPath = Join-Path $DirectoryPath $artifactName
+        $stream = $null
+        try {
+            $stream = [System.IO.File]::Open(
+                $artifactPath,
+                [System.IO.FileMode]::CreateNew,
+                [System.IO.FileAccess]::Write,
+                [System.IO.FileShare]::None
+            )
+        } catch [System.IO.IOException] {
+            continue
+        }
+
+        try {
+            $Image.Save($stream, [System.Drawing.Imaging.ImageFormat]::Png)
+            $stream.Flush($true)
+            return [PSCustomObject]@{
+                Path             = $artifactPath
+                DirectoryPath    = $DirectoryPath
+                CreatedDirectory = $createdDirectory
+                Owned            = $true
+            }
+        } catch {
+            $stream.Dispose()
+            $stream = $null
+            Remove-Item -LiteralPath $artifactPath -Force -ErrorAction SilentlyContinue
+            if ($createdDirectory -and (Test-Path -LiteralPath $DirectoryPath -PathType Container) -and
+                @(Get-ChildItem -LiteralPath $DirectoryPath -Force -ErrorAction SilentlyContinue).Count -eq 0) {
+                Remove-Item -LiteralPath $DirectoryPath -Force -ErrorAction SilentlyContinue
+            }
+            throw
+        } finally {
+            if ($null -ne $stream) { $stream.Dispose() }
+        }
+    }
+
+    if ($createdDirectory -and (Test-Path -LiteralPath $DirectoryPath -PathType Container) -and
+        @(Get-ChildItem -LiteralPath $DirectoryPath -Force -ErrorAction SilentlyContinue).Count -eq 0) {
+        Remove-Item -LiteralPath $DirectoryPath -Force -ErrorAction SilentlyContinue
+    }
+    throw 'could not reserve a unique image artifact path'
 }
 
 function Invoke-ImagePaste {
@@ -5016,6 +5938,9 @@ function Invoke-ImagePaste {
 
     $paneId = Resolve-Target $Target
     $paneId = Confirm-Target $paneId
+    $projectDir = (Get-Location).Path
+
+    $runtimeAccess = Assert-WinsmuxTargetRuntimeWriteAllowed -PaneId $paneId -CurrentProjectDir $projectDir -Operation dispatch
 
     Assert-ReadMark $paneId
 
@@ -5026,18 +5951,40 @@ function Invoke-ImagePaste {
         Stop-WithError "no image in clipboard"
     }
 
-    $imgDir = Join-Path $env:TEMP "winsmux\images"
-    if (-not (Test-Path $imgDir)) {
-        New-Item -ItemType Directory -Path $imgDir -Force | Out-Null
+    try {
+        Assert-WinsmuxTargetRuntimeWriteAllowed -PaneId $paneId -CurrentProjectDir $projectDir -Operation dispatch `
+            -ExpectedGenerationId ([string]$runtimeAccess.GenerationId) | Out-Null
+    } catch {
+        $img.Dispose()
+        throw
     }
-
-    $timestamp = Get-Date -Format "yyyyMMdd_HHmmss"
-    $imgPath = Join-Path $imgDir "$timestamp.png"
-    $img.Save($imgPath, [System.Drawing.Imaging.ImageFormat]::Png)
-    $img.Dispose()
+    $imgDir = Join-Path $env:TEMP 'winsmux\images'
+    $artifact = $null
+    try {
+        $artifact = Write-WinsmuxClipboardImageArtifact -Image $img -DirectoryPath $imgDir
+    } finally {
+        $img.Dispose()
+    }
+    $imgPath = [string]$artifact.Path
+    $createdImageDirectory = [bool]$artifact.CreatedDirectory
 
     # Send file path as text to the target pane
+    try {
+        Assert-WinsmuxTargetRuntimeWriteAllowed -PaneId $paneId -CurrentProjectDir $projectDir -Operation dispatch `
+            -ExpectedGenerationId ([string]$runtimeAccess.GenerationId) | Out-Null
+    } catch {
+        if ([bool]$artifact.Owned) {
+            Remove-Item -LiteralPath $imgPath -Force -ErrorAction SilentlyContinue
+        }
+        if ($createdImageDirectory -and (Test-Path -LiteralPath $imgDir -PathType Container) -and
+            @(Get-ChildItem -LiteralPath $imgDir -Force -ErrorAction SilentlyContinue).Count -eq 0) {
+            Remove-Item -LiteralPath $imgDir -Force -ErrorAction SilentlyContinue
+        }
+        throw
+    }
     Invoke-WinsmuxRaw -Arguments @('send-keys', '-t', $paneId, '-l', '--', "$imgPath")
+    Assert-WinsmuxTargetRuntimeWriteAllowed -PaneId $paneId -CurrentProjectDir $projectDir -Operation dispatch `
+        -ExpectedGenerationId ([string]$runtimeAccess.GenerationId) | Out-Null
     Clear-ReadMark $paneId
     Write-Output "image saved: $imgPath"
     Write-Output "path sent to $paneId"
@@ -5048,6 +5995,9 @@ function Invoke-ClipboardPaste {
 
     $paneId = Resolve-Target $Target
     $paneId = Confirm-Target $paneId
+    $projectDir = (Get-Location).Path
+
+    $runtimeAccess = Assert-WinsmuxTargetRuntimeWriteAllowed -PaneId $paneId -CurrentProjectDir $projectDir -Operation dispatch
 
     Assert-ReadMark $paneId
 
@@ -5056,7 +6006,11 @@ function Invoke-ClipboardPaste {
         Stop-WithError "clipboard is empty"
     }
 
+    Assert-WinsmuxTargetRuntimeWriteAllowed -PaneId $paneId -CurrentProjectDir $projectDir -Operation dispatch `
+        -ExpectedGenerationId ([string]$runtimeAccess.GenerationId) | Out-Null
     Invoke-WinsmuxRaw -Arguments @('send-keys', '-t', $paneId, '-l', '--', "$text")
+    Assert-WinsmuxTargetRuntimeWriteAllowed -PaneId $paneId -CurrentProjectDir $projectDir -Operation dispatch `
+        -ExpectedGenerationId ([string]$runtimeAccess.GenerationId) | Out-Null
     Clear-ReadMark $paneId
     Write-Output "sent to $paneId"
 }
@@ -5835,6 +6789,33 @@ function Get-WorkersStatusRows {
     return @($rows)
 }
 
+function Add-WorkersRuntimeValidity {
+    param(
+        [Parameter(Mandatory = $true)]$Context,
+        [Parameter(Mandatory = $true)][object[]]$Rows
+    )
+
+    foreach ($row in @($Rows)) {
+        $entry = if ($Context.EntriesBySlot.ContainsKey([string]$row.SlotId)) { $Context.EntriesBySlot[[string]$row.SlotId] } else { $null }
+        if ($null -eq $entry) {
+            $runtimeResult = New-WinsmuxRuntimeValidationResult -Valid $false -ReasonCode 'runtime_target_mismatch' -Diagnostic 'Worker status has no matching manifest entry.'
+        } else {
+            $runtimeOperation = if (Test-DeferredPaneStartManifestEntry -ManifestEntry $entry) { 'start_deferred' } else { 'dispatch' }
+            try {
+                $runtimeResult = Test-PaneControlRuntimeContext -ProjectDir $Context.ProjectDir -ManifestEntry $entry -Operation $runtimeOperation
+            } catch {
+                $runtimeResult = New-WinsmuxRuntimeValidationResult -Valid $false -ReasonCode 'manifest_regeneration_required' -Diagnostic 'Runtime identity evidence is unavailable; regenerate the orchestra session.'
+            }
+        }
+        $runtimeValid = [bool]$runtimeResult.valid
+        $row | Add-Member -NotePropertyName RuntimeValid -NotePropertyValue $runtimeValid -Force
+        $row | Add-Member -NotePropertyName RuntimeState -NotePropertyValue $(if ($runtimeValid) { [string]$row.State } else { 'runtime_invalid' }) -Force
+        $row | Add-Member -NotePropertyName RuntimeReasonCode -NotePropertyValue ([string]$runtimeResult.reason_code) -Force
+        $row | Add-Member -NotePropertyName RuntimeDiagnostic -NotePropertyValue ([string]$runtimeResult.diagnostic) -Force
+    }
+    return @($Rows)
+}
+
 function Select-WorkersRows {
     param(
         [Parameter(Mandatory = $true)][object[]]$Rows,
@@ -5858,10 +6839,27 @@ function Select-WorkersRows {
     return @($selected)
 }
 
+function Test-WorkersRuntimeRowsValid {
+    param(
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyCollection()]
+        [object[]]$Rows
+    )
+
+    return @($Rows).Count -gt 0 -and @($Rows | Where-Object { -not [bool]$_.RuntimeValid }).Count -eq 0
+}
+
+function Set-WorkersRuntimeProcessExitCode {
+    param([Parameter(Mandatory = $true)][bool]$RuntimeValid)
+
+    $script:WinsmuxRequestedProcessExitCode = if ($RuntimeValid) { 0 } else { 1 }
+}
+
 function Write-WorkersStatusOutput {
     param(
         [Parameter(Mandatory = $true)]$Context,
         [Parameter(Mandatory = $true)][object[]]$Rows,
+        [Parameter(Mandatory = $true)][bool]$RuntimeValid,
         [switch]$Json
     )
 
@@ -5870,6 +6868,7 @@ function Write-WorkersStatusOutput {
             project_dir     = $Context.ProjectDir
             generated_at    = (Get-Date).ToUniversalTime().ToString('o')
             manifest_error  = $Context.ManifestError
+            runtime_valid   = $RuntimeValid
             workers         = @(ConvertTo-WorkersStatusJsonRows -Rows $Rows)
         } | ConvertTo-Json -Depth 20 -Compress | Write-Output
         return
@@ -5881,7 +6880,7 @@ function Write-WorkersStatusOutput {
     }
 
     $table = $Rows |
-        Select-Object Slot, SlotId, State, Backend, Role, Provider, Model, LastCommand |
+        Select-Object Slot, SlotId, RuntimeState, Backend, Role, Provider, Model, RuntimeValid, LastCommand |
         Format-Table -AutoSize |
         Out-String
     Write-Output ($table.TrimEnd())
@@ -5898,6 +6897,10 @@ function ConvertTo-WorkersStatusJsonRows {
             state           = [string]$row.State
             pane_state      = [string]$row.PaneState
             manifest_status = [string]$row.ManifestStatus
+            runtime_valid   = [bool]$row.RuntimeValid
+            runtime_state   = [string]$row.RuntimeState
+            runtime_reason_code = [string]$row.RuntimeReasonCode
+            runtime_diagnostic = [string]$row.RuntimeDiagnostic
             backend         = [string]$row.Backend
             role            = [string]$row.Role
             execution_profile = [string]$row.ExecutionProfile
@@ -5944,7 +6947,9 @@ function Set-WorkersManifestLifecycleCommand {
         [Parameter(Mandatory = $true)]$Entry,
         [Parameter(Mandatory = $true)][string]$CommandName,
         [AllowEmptyString()][string]$Status = '',
-        [AllowNull()][System.Collections.IDictionary]$ExtraProperties = $null
+        [AllowNull()][System.Collections.IDictionary]$ExtraProperties = $null,
+        [AllowEmptyString()][string]$ExpectedGenerationId = '',
+        [ValidateSet('auto', 'dispatch', 'start_deferred', 'stop_transition')][string]$RuntimeOperation = 'auto'
     )
 
     if ($null -eq $Entry -or [string]::IsNullOrWhiteSpace([string]$Entry.PaneId)) {
@@ -5967,7 +6972,11 @@ function Set-WorkersManifestLifecycleCommand {
         }
     }
 
-    Set-PaneControlManifestPaneProperties -ManifestPath $Entry.ManifestPath -PaneId $Entry.PaneId -Properties $properties
+    if ([string]::IsNullOrWhiteSpace($ExpectedGenerationId)) {
+        $ExpectedGenerationId = [string]$Entry.GenerationId
+    }
+    Set-PaneControlManifestPaneProperties -ManifestPath $Entry.ManifestPath -PaneId $Entry.PaneId -Properties $properties `
+        -ExpectedGenerationId $ExpectedGenerationId -RuntimeOperation $RuntimeOperation
 }
 
 function New-WorkersLifecycleResult {
@@ -7068,7 +8077,7 @@ function Resolve-WorkersVaultSecretValue {
 
     $credTarget = "winsmux:$safeKey"
     $credPtr = [IntPtr]::Zero
-    $ok = [WinCred]::CredRead($credTarget, [WinCred]::CRED_TYPE_GENERIC, 0, [ref]$credPtr)
+    $ok = [WinsmuxBridgeCredentialNative]::CredRead($credTarget, [WinsmuxBridgeCredentialNative]::CRED_TYPE_GENERIC, 0, [ref]$credPtr)
     if (-not $ok) {
         $errCode = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
         if ($errCode -eq 1168) {
@@ -7078,7 +8087,7 @@ function Resolve-WorkersVaultSecretValue {
     }
 
     try {
-        $cred = [Runtime.InteropServices.Marshal]::PtrToStructure($credPtr, [Type][WinCred+CREDENTIAL])
+        $cred = [Runtime.InteropServices.Marshal]::PtrToStructure($credPtr, [Type][WinsmuxBridgeCredentialNative+CREDENTIAL])
         if ($cred.CredentialBlobSize -le 0) {
             return ''
         }
@@ -7086,7 +8095,7 @@ function Resolve-WorkersVaultSecretValue {
         [Runtime.InteropServices.Marshal]::Copy($cred.CredentialBlob, $bytes, 0, $cred.CredentialBlobSize)
         return [System.Text.Encoding]::Unicode.GetString($bytes)
     } finally {
-        [WinCred]::CredFree($credPtr) | Out-Null
+        [WinsmuxBridgeCredentialNative]::CredFree($credPtr) | Out-Null
     }
 }
 
@@ -10149,7 +11158,37 @@ function Invoke-WorkersStatus {
     $options = Read-WorkersOptions -Tokens $Rest -Usage $usage -DefaultTarget 'all'
     $context = Get-WorkersLifecycleContext -ProjectDir $options.ProjectDir
     $rows = Select-WorkersRows -Rows (Get-WorkersStatusRows -Context $context) -Target $options.Target
-    Write-WorkersStatusOutput -Context $context -Rows $rows -Json:([bool]$options.Json)
+    $rows = @(Add-WorkersRuntimeValidity -Context $context -Rows @($rows))
+    $runtimeValid = Test-WorkersRuntimeRowsValid -Rows $rows
+    Set-WorkersRuntimeProcessExitCode -RuntimeValid $runtimeValid
+    Write-WorkersStatusOutput -Context $context -Rows $rows -RuntimeValid $runtimeValid -Json:([bool]$options.Json)
+}
+
+function ConvertFrom-WorkersRuntimeRefusal {
+    param([AllowEmptyString()][string]$Message = '')
+
+    if ($Message -notmatch '^runtime dispatch refused \(([^)]+)\):\s*(.*)$') {
+        return $null
+    }
+    return [PSCustomObject][ordered]@{
+        reason_code = [string]$Matches[1]
+        diagnostic  = [string]$Matches[2]
+    }
+}
+
+function Assert-WorkersStartRuntimeLease {
+    param(
+        [Parameter(Mandatory = $true)]$Entry,
+        [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [ValidateSet('dispatch', 'start_deferred')][string]$Operation,
+        [Parameter(Mandatory = $true)][string]$ExpectedGenerationId
+    )
+
+    if ([string]::IsNullOrWhiteSpace($ExpectedGenerationId)) {
+        throw 'runtime dispatch refused (manifest_regeneration_required): validated workers start runtime did not provide a generation_id'
+    }
+    Assert-WinsmuxTargetRuntimeWriteAllowed -PaneId ([string]$Entry.PaneId) -CurrentProjectDir $ProjectDir `
+        -Operation $Operation -ExpectedGenerationId $ExpectedGenerationId | Out-Null
 }
 
 function Invoke-WorkersStart {
@@ -10169,45 +11208,93 @@ function Invoke-WorkersStart {
             $results.Add((New-WorkersLifecycleResult -Row $row -Action 'workers.start' -Status 'failed' -Reason 'pane_id_missing')) | Out-Null
             continue
         }
-        $approvalDifferences = @($row.ApprovalDifferences)
-        if ($approvalDifferences.Count -gt 0) {
-            $reason = Format-WorkersLaunchApprovalMismatch -Differences $approvalDifferences
-            $repairProperties = New-WorkersRepairProperties -FailedStage 'launch_approval' -FailureReason $reason -RecoveryAction 'review-worker-settings-and-rerun-launch'
-            Set-WorkersManifestLifecycleCommand -Entry $entry -CommandName 'workers.start' -ExtraProperties $repairProperties
-            $results.Add((New-WorkersLifecycleResult -Row $row -Action 'workers.start' -Status 'blocked' -Reason $reason -FailedStage ([string]$repairProperties['last_failure_stage']) -RecoveryAction ([string]$repairProperties['recovery_action']))) | Out-Null
+        $runtimeOperation = if (Test-DeferredPaneStartManifestEntry -ManifestEntry $entry) { 'start_deferred' } else { 'dispatch' }
+        $runtimeResult = Test-PaneControlRuntimeContext -ProjectDir $options.ProjectDir -ManifestEntry $entry -Operation $runtimeOperation
+        if (-not $runtimeResult.valid) {
+            $runtimeFailure = New-WorkersLifecycleResult -Row $row -Action 'workers.start' -Status 'blocked' -Reason ([string]$runtimeResult.reason_code)
+            $runtimeFailure['reason_code'] = [string]$runtimeResult.reason_code
+            $runtimeFailure['diagnostic'] = [string]$runtimeResult.diagnostic
+            $results.Add($runtimeFailure) | Out-Null
             continue
         }
-        if ([string]::Equals(([string]$entry.Status), 'api_llm_runner_unconfigured', [System.StringComparison]::OrdinalIgnoreCase)) {
-            $repairProperties = New-WorkersRepairProperties -FailedStage 'runner_config' -FailureReason 'api_llm_runner_unconfigured' -RecoveryAction 'set-api-llm-slot-and-api-key-env'
-            Set-WorkersManifestLifecycleCommand -Entry $entry -CommandName 'workers.start' -Status 'api_llm_runner_unconfigured' -ExtraProperties $repairProperties
-            $results.Add((New-WorkersLifecycleResult -Row $row -Action 'workers.start' -Status 'blocked' -Reason 'api_llm_runner_unconfigured' -FailedStage ([string]$repairProperties['last_failure_stage']) -RecoveryAction ([string]$repairProperties['recovery_action']))) | Out-Null
-            continue
-        }
-        if ([string]::Equals(([string]$entry.Status), 'antigravity_runner_unconfigured', [System.StringComparison]::OrdinalIgnoreCase)) {
-            $repairProperties = New-WorkersRepairProperties -FailedStage 'runner_config' -FailureReason 'antigravity_runner_unconfigured' -RecoveryAction 'install-or-configure-antigravity-cli'
-            Set-WorkersManifestLifecycleCommand -Entry $entry -CommandName 'workers.start' -Status 'antigravity_runner_unconfigured' -ExtraProperties $repairProperties
-            $results.Add((New-WorkersLifecycleResult -Row $row -Action 'workers.start' -Status 'blocked' -Reason 'antigravity_runner_unconfigured' -FailedStage ([string]$repairProperties['last_failure_stage']) -RecoveryAction ([string]$repairProperties['recovery_action']))) | Out-Null
+        $runtimeGenerationId = [string](Get-SendConfigValue -InputObject $runtimeResult.context -Name 'generation_id' -Default '')
+        if ([string]::IsNullOrWhiteSpace($runtimeGenerationId)) {
+            $runtimeFailure = New-WorkersLifecycleResult -Row $row -Action 'workers.start' -Status 'blocked' -Reason 'manifest_regeneration_required'
+            $runtimeFailure['reason_code'] = 'manifest_regeneration_required'
+            $runtimeFailure['diagnostic'] = 'Validated workers start runtime did not provide a generation_id; regenerate the orchestra session.'
+            $results.Add($runtimeFailure) | Out-Null
             continue
         }
 
         try {
+            $approvalDifferences = @($row.ApprovalDifferences)
+            if ($approvalDifferences.Count -gt 0) {
+                $reason = Format-WorkersLaunchApprovalMismatch -Differences $approvalDifferences
+                $repairProperties = New-WorkersRepairProperties -FailedStage 'launch_approval' -FailureReason $reason -RecoveryAction 'review-worker-settings-and-rerun-launch'
+                Assert-WorkersStartRuntimeLease -Entry $entry -ProjectDir $options.ProjectDir `
+                    -Operation $runtimeOperation -ExpectedGenerationId $runtimeGenerationId
+                Set-WorkersManifestLifecycleCommand -Entry $entry -CommandName 'workers.start' -ExtraProperties $repairProperties `
+                    -ExpectedGenerationId $runtimeGenerationId -RuntimeOperation $runtimeOperation
+                $results.Add((New-WorkersLifecycleResult -Row $row -Action 'workers.start' -Status 'blocked' -Reason $reason -FailedStage ([string]$repairProperties['last_failure_stage']) -RecoveryAction ([string]$repairProperties['recovery_action']))) | Out-Null
+                continue
+            }
+            if ([string]::Equals(([string]$entry.Status), 'api_llm_runner_unconfigured', [System.StringComparison]::OrdinalIgnoreCase)) {
+                $repairProperties = New-WorkersRepairProperties -FailedStage 'runner_config' -FailureReason 'api_llm_runner_unconfigured' -RecoveryAction 'set-api-llm-slot-and-api-key-env'
+                $blocked = New-WorkersLifecycleResult -Row $row -Action 'workers.start' -Status 'blocked' -Reason 'api_llm_runner_unconfigured' -FailedStage ([string]$repairProperties['last_failure_stage']) -RecoveryAction ([string]$repairProperties['recovery_action'])
+                $blocked['reason_code'] = 'api_llm_runner_unconfigured'
+                $blocked['diagnostic'] = 'Configure the api_llm runner before retrying workers start.'
+                $results.Add($blocked) | Out-Null
+                continue
+            }
+            if ([string]::Equals(([string]$entry.Status), 'antigravity_runner_unconfigured', [System.StringComparison]::OrdinalIgnoreCase)) {
+                $repairProperties = New-WorkersRepairProperties -FailedStage 'runner_config' -FailureReason 'antigravity_runner_unconfigured' -RecoveryAction 'install-or-configure-antigravity-cli'
+                $blocked = New-WorkersLifecycleResult -Row $row -Action 'workers.start' -Status 'blocked' -Reason 'antigravity_runner_unconfigured' -FailedStage ([string]$repairProperties['last_failure_stage']) -RecoveryAction ([string]$repairProperties['recovery_action'])
+                $blocked['reason_code'] = 'antigravity_runner_unconfigured'
+                $blocked['diagnostic'] = 'Configure the antigravity runner before retrying workers start.'
+                $results.Add($blocked) | Out-Null
+                continue
+            }
+
             if (Test-DeferredPaneStartManifestEntry -ManifestEntry $entry) {
-                $started = Start-DeferredPaneFromManifestEntry -ProjectDir $options.ProjectDir -ManifestEntry $entry
+                $started = Start-DeferredPaneFromManifestEntry -ProjectDir $options.ProjectDir -ManifestEntry $entry `
+                    -ExpectedGenerationId $runtimeGenerationId
+                $entry = Get-PaneControlManifestContext -ProjectDir $options.ProjectDir -PaneId ([string]$entry.PaneId)
+                $runtimeResult = Wait-PaneControlRuntimeContext -ProjectDir $options.ProjectDir -ManifestEntry $entry -Operation dispatch
+                if (-not $runtimeResult.valid) {
+                    $runtimeFailure = New-WorkersLifecycleResult -Row $row -Action 'workers.start' -Status 'blocked' -Reason ([string]$runtimeResult.reason_code)
+                    $runtimeFailure['reason_code'] = [string]$runtimeResult.reason_code
+                    $runtimeFailure['diagnostic'] = [string]$runtimeResult.diagnostic
+                    $results.Add($runtimeFailure) | Out-Null
+                    continue
+                }
+                Assert-WorkersStartRuntimeLease -Entry $entry -ProjectDir $options.ProjectDir `
+                    -Operation dispatch -ExpectedGenerationId $runtimeGenerationId
                 Set-WorkersManifestLifecycleCommand -Entry $entry -CommandName 'workers.start' -Status 'ready' -ExtraProperties ([ordered]@{
                     last_heartbeat_run_id  = ''
                     last_heartbeat_profile = ''
                     last_failure_stage     = ''
                     last_failure_reason    = ''
                     recovery_action        = ''
-                })
+                }) -ExpectedGenerationId $runtimeGenerationId -RuntimeOperation dispatch
                 $status = if ($started) { 'started' } else { 'unchanged' }
                 $results.Add((New-WorkersLifecycleResult -Row $row -Action 'workers.start' -Status $status)) | Out-Null
             } else {
-                Set-WorkersManifestLifecycleCommand -Entry $entry -CommandName 'workers.start'
+                Assert-WorkersStartRuntimeLease -Entry $entry -ProjectDir $options.ProjectDir `
+                    -Operation dispatch -ExpectedGenerationId $runtimeGenerationId
+                Set-WorkersManifestLifecycleCommand -Entry $entry -CommandName 'workers.start' `
+                    -ExpectedGenerationId $runtimeGenerationId -RuntimeOperation dispatch
                 $results.Add((New-WorkersLifecycleResult -Row $row -Action 'workers.start' -Status 'already_running')) | Out-Null
             }
         } catch {
             $reason = [string]$_.Exception.Message
+            $runtimeRefusal = ConvertFrom-WorkersRuntimeRefusal -Message $reason
+            if ($null -ne $runtimeRefusal) {
+                $runtimeFailure = New-WorkersLifecycleResult -Row $row -Action 'workers.start' -Status 'blocked' -Reason ([string]$runtimeRefusal.reason_code)
+                $runtimeFailure['reason_code'] = [string]$runtimeRefusal.reason_code
+                $runtimeFailure['diagnostic'] = [string]$runtimeRefusal.diagnostic
+                $results.Add($runtimeFailure) | Out-Null
+                continue
+            }
             $status = if (
                 $reason -like 'worker launch approval mismatch:*' -or
                 $reason -like 'api_llm_runner_unconfigured*' -or
@@ -10215,13 +11302,119 @@ function Invoke-WorkersStart {
             ) { 'blocked' } else { 'failed' }
             $repairProperties = Get-WorkersFailureMetadataFromReason -Reason $reason
             if ($null -ne $entry) {
-                Set-WorkersManifestLifecycleCommand -Entry $entry -CommandName 'workers.start' -ExtraProperties $repairProperties
+                try {
+                    Assert-WorkersStartRuntimeLease -Entry $entry -ProjectDir $options.ProjectDir `
+                        -Operation $runtimeOperation -ExpectedGenerationId $runtimeGenerationId
+                    Set-WorkersManifestLifecycleCommand -Entry $entry -CommandName 'workers.start' -ExtraProperties $repairProperties `
+                        -ExpectedGenerationId $runtimeGenerationId -RuntimeOperation $runtimeOperation
+                } catch {
+                    $repairRefusal = ConvertFrom-WorkersRuntimeRefusal -Message ([string]$_.Exception.Message)
+                    if ($null -ne $repairRefusal) {
+                        $runtimeFailure = New-WorkersLifecycleResult -Row $row -Action 'workers.start' -Status 'blocked' -Reason ([string]$repairRefusal.reason_code)
+                        $runtimeFailure['reason_code'] = [string]$repairRefusal.reason_code
+                        $runtimeFailure['diagnostic'] = [string]$repairRefusal.diagnostic
+                        $results.Add($runtimeFailure) | Out-Null
+                        continue
+                    }
+                    throw
+                }
             }
             $results.Add((New-WorkersLifecycleResult -Row $row -Action 'workers.start' -Status $status -Reason $reason -FailedStage ([string]$repairProperties['last_failure_stage']) -RecoveryAction ([string]$repairProperties['recovery_action']))) | Out-Null
         }
     }
 
     Write-WorkersLifecycleOutput -ProjectDir $options.ProjectDir -Results @($results) -Json:([bool]$options.Json)
+}
+
+function Resolve-WorkersBootstrapMarkerPath {
+    param(
+        [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [Parameter(Mandatory = $true)]$Entry
+    )
+
+    $markerPath = [string](Get-SendConfigValue -InputObject $Entry -Name 'BootstrapMarkerPath' -Default '')
+    $planPath = [string](Get-SendConfigValue -InputObject $Entry -Name 'BootstrapPlanPath' -Default '')
+    if ([string]::IsNullOrWhiteSpace($markerPath) -or [string]::IsNullOrWhiteSpace($planPath)) {
+        throw 'worker bootstrap marker or plan path is missing'
+    }
+
+    $projectRoot = [System.IO.Path]::GetFullPath($ProjectDir)
+    $bootstrapRoot = [System.IO.Path]::GetFullPath((Join-Path (Join-Path $projectRoot '.winsmux') 'orchestra-bootstrap'))
+    $markerFull = if ([System.IO.Path]::IsPathRooted($markerPath)) {
+        [System.IO.Path]::GetFullPath($markerPath)
+    } else {
+        [System.IO.Path]::GetFullPath((Join-Path $projectRoot $markerPath))
+    }
+    $planFull = if ([System.IO.Path]::IsPathRooted($planPath)) {
+        [System.IO.Path]::GetFullPath($planPath)
+    } else {
+        [System.IO.Path]::GetFullPath((Join-Path $projectRoot $planPath))
+    }
+
+    if (-not (Test-WorkersPathIsUnderDirectory -Path $markerFull -Directory $bootstrapRoot) -or
+        -not (Test-WorkersPathIsUnderDirectory -Path $planFull -Directory $bootstrapRoot) -or
+        [string]::Equals($markerFull, $bootstrapRoot, [System.StringComparison]::OrdinalIgnoreCase) -or
+        [string]::Equals($planFull, $bootstrapRoot, [System.StringComparison]::OrdinalIgnoreCase) -or
+        -not [string]::Equals((Split-Path -Parent $markerFull), $bootstrapRoot, [System.StringComparison]::OrdinalIgnoreCase) -or
+        -not [string]::Equals((Split-Path -Parent $planFull), $bootstrapRoot, [System.StringComparison]::OrdinalIgnoreCase)) {
+        throw 'worker bootstrap marker cleanup path escaped the orchestra bootstrap directory'
+    }
+
+    $planBaseName = [System.IO.Path]::GetFileNameWithoutExtension($planFull)
+    $markerName = [System.IO.Path]::GetFileName($markerFull)
+    if (-not $markerName.StartsWith($planBaseName + '-', [System.StringComparison]::OrdinalIgnoreCase) -or
+        -not $markerName.EndsWith('.ready.json', [System.StringComparison]::OrdinalIgnoreCase)) {
+        throw 'worker bootstrap marker cleanup path does not match its bootstrap plan'
+    }
+
+    if (-not (Test-Path -LiteralPath $bootstrapRoot -PathType Container)) {
+        throw 'worker orchestra bootstrap directory is missing'
+    }
+    $rootItem = Get-Item -LiteralPath $bootstrapRoot -Force -ErrorAction Stop
+    if (([int]($rootItem.Attributes -band [System.IO.FileAttributes]::ReparsePoint)) -ne 0) {
+        throw 'worker orchestra bootstrap directory must not be a reparse point'
+    }
+
+    return $markerFull
+}
+
+function Resolve-WorkersStoppedBootstrapMarkerPath {
+    param(
+        [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [Parameter(Mandatory = $true)]$Entry
+    )
+
+    return Resolve-WorkersBootstrapMarkerPath -ProjectDir $ProjectDir -Entry $Entry
+}
+
+function Remove-WorkersBootstrapMarker {
+    param(
+        [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [Parameter(Mandatory = $true)]$Entry
+    )
+
+    $markerPath = Resolve-WorkersBootstrapMarkerPath -ProjectDir $ProjectDir -Entry $Entry
+    if (-not (Test-Path -LiteralPath $markerPath -PathType Leaf)) {
+        return $false
+    }
+    $markerItem = Get-Item -LiteralPath $markerPath -Force -ErrorAction Stop
+    if ($markerItem.PSIsContainer -or
+        ([int]($markerItem.Attributes -band [System.IO.FileAttributes]::ReparsePoint)) -ne 0 -or
+        -not [string]::Equals([System.IO.Path]::GetFullPath([string]$markerItem.FullName), $markerPath, [System.StringComparison]::OrdinalIgnoreCase)) {
+        throw 'worker bootstrap marker cleanup target is not a regular file'
+    }
+
+    Remove-Item -LiteralPath $markerPath -Force -ErrorAction Stop
+    return $true
+}
+
+function Remove-WorkersStoppedBootstrapMarker {
+    param(
+        [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [Parameter(Mandatory = $true)]$Entry
+    )
+
+    return Remove-WorkersBootstrapMarker -ProjectDir $ProjectDir -Entry $Entry
 }
 
 function Invoke-WorkersStop {
@@ -10242,17 +11435,106 @@ function Invoke-WorkersStop {
             continue
         }
 
+        $runtimeOperation = if (Test-DeferredPaneStartManifestEntry -ManifestEntry $entry) { 'start_deferred' } else { 'dispatch' }
+        $runtimeResult = Test-PaneControlRuntimeContext -ProjectDir $options.ProjectDir -ManifestEntry $entry -Operation $runtimeOperation
+        if (-not $runtimeResult.valid) {
+            $runtimeFailure = New-WorkersLifecycleResult -Row $row -Action 'workers.stop' -Status 'blocked' -Reason ([string]$runtimeResult.reason_code)
+            $runtimeFailure['reason_code'] = [string]$runtimeResult.reason_code
+            $runtimeFailure['diagnostic'] = [string]$runtimeResult.diagnostic
+            $results.Add($runtimeFailure) | Out-Null
+            continue
+        }
+        $runtimeGenerationId = [string](Get-PaneControlValue -InputObject $runtimeResult.context -Name 'generation_id' -Default '')
+        if ([string]::IsNullOrWhiteSpace($runtimeGenerationId)) {
+            $runtimeFailure = New-WorkersLifecycleResult -Row $row -Action 'workers.stop' -Status 'blocked' `
+                -Reason 'manifest_regeneration_required'
+            $runtimeFailure['reason_code'] = 'manifest_regeneration_required'
+            $runtimeFailure['diagnostic'] = 'Validated runtime did not provide a generation_id; regenerate the orchestra session.'
+            $results.Add($runtimeFailure) | Out-Null
+            continue
+        }
+
         try {
-            Invoke-WinsmuxRaw -Arguments @('respawn-pane', '-k', '-t', [string]$entry.PaneId) | Out-Null
-            $nativeExitCode = Get-SafeLastExitCode
-            if ($null -ne $nativeExitCode -and $nativeExitCode -ne 0) {
-                throw "failed to stop pane process: $($entry.PaneId)"
+            Resolve-WorkersStoppedBootstrapMarkerPath -ProjectDir $options.ProjectDir -Entry $entry | Out-Null
+
+            try {
+                try {
+                    Assert-WinsmuxTargetRuntimeWriteAllowed -PaneId ([string]$entry.PaneId) `
+                        -CurrentProjectDir $options.ProjectDir -Operation $runtimeOperation `
+                        -ExpectedGenerationId $runtimeGenerationId | Out-Null
+                } catch {
+                    $runtimeMessage = [string]$_.Exception.Message
+                    $runtimeReasonCode = 'manifest_regeneration_required'
+                    $runtimeDiagnostic = $runtimeMessage
+                    if ($runtimeMessage -match '^runtime dispatch refused \(([^)]+)\):\s*(.*)$') {
+                        $runtimeReasonCode = [string]$Matches[1]
+                        $runtimeDiagnostic = [string]$Matches[2]
+                    }
+                    $runtimeFailure = New-WorkersLifecycleResult -Row $row -Action 'workers.stop' -Status 'blocked' -Reason $runtimeReasonCode
+                    $runtimeFailure['reason_code'] = $runtimeReasonCode
+                    $runtimeFailure['diagnostic'] = $runtimeDiagnostic
+                    $results.Add($runtimeFailure) | Out-Null
+                    continue
+                }
+                Invoke-WinsmuxRaw -Arguments @('respawn-pane', '-k', '-t', [string]$entry.PaneId) | Out-Null
+                $nativeExitCode = Get-SafeLastExitCode
+                if ($null -ne $nativeExitCode -and $nativeExitCode -ne 0) {
+                    throw "failed to stop pane process: $($entry.PaneId)"
+                }
+            } catch {
+                $results.Add((New-WorkersLifecycleResult -Row $row -Action 'workers.stop' -Status 'failed' `
+                    -Reason 'stop_respawn_failed' -FailedStage 'pane_stop' `
+                    -RecoveryAction 'inspect-pane-and-rerun-workers-stop')) | Out-Null
+                continue
             }
 
-            Clear-ReadMark ([string]$entry.PaneId)
-            Clear-Watermark ([string]$entry.PaneId)
+            Assert-WinsmuxTargetRuntimeWriteAllowed -PaneId ([string]$entry.PaneId) `
+                -CurrentProjectDir $options.ProjectDir -Operation stop_transition `
+                -ExpectedGenerationId $runtimeGenerationId | Out-Null
+            try {
+                Remove-WorkersStoppedBootstrapMarker -ProjectDir $options.ProjectDir -Entry $entry | Out-Null
+            } catch {
+                $recoveryAction = 'inspect-bootstrap-marker-and-rerun-workers-stop'
+                $repairProperties = New-WorkersRepairProperties -FailedStage 'marker_cleanup' `
+                    -FailureReason 'worker bootstrap marker cleanup failed after pane stop' `
+                    -RecoveryAction $recoveryAction
+                $failureProperties = [ordered]@{ runtime_ready = $false }
+                foreach ($propertyEntry in $repairProperties.GetEnumerator()) {
+                    $failureProperties[[string]$propertyEntry.Key] = $propertyEntry.Value
+                }
+                Assert-WinsmuxTargetRuntimeWriteAllowed -PaneId ([string]$entry.PaneId) `
+                    -CurrentProjectDir $options.ProjectDir -Operation stop_transition `
+                    -ExpectedGenerationId $runtimeGenerationId | Out-Null
+                Set-WorkersManifestLifecycleCommand -Entry $entry -CommandName 'workers.stop' `
+                    -Status 'deferred_start_failed' -ExtraProperties $failureProperties `
+                    -ExpectedGenerationId $runtimeGenerationId -RuntimeOperation stop_transition
+                $results.Add((New-WorkersLifecycleResult -Row $row -Action 'workers.stop' -Status 'failed' `
+                    -Reason 'stop_marker_cleanup_failed' -FailedStage 'marker_cleanup' `
+                    -RecoveryAction $recoveryAction)) | Out-Null
+                continue
+            }
+
             $nextStatus = 'deferred_start'
-            Set-WorkersManifestLifecycleCommand -Entry $entry -CommandName 'workers.stop' -Status $nextStatus
+            Assert-WinsmuxTargetRuntimeWriteAllowed -PaneId ([string]$entry.PaneId) `
+                -CurrentProjectDir $options.ProjectDir -Operation stop_transition `
+                -ExpectedGenerationId $runtimeGenerationId | Out-Null
+            Set-WorkersManifestLifecycleCommand -Entry $entry -CommandName 'workers.stop' -Status $nextStatus -ExtraProperties ([ordered]@{
+                runtime_ready = $false
+            }) -ExpectedGenerationId $runtimeGenerationId -RuntimeOperation stop_transition
+            $deferredEntry = Get-PaneControlManifestContext -ProjectDir $options.ProjectDir -PaneId ([string]$entry.PaneId)
+            $deferredRuntime = Wait-PaneControlRuntimeContext -ProjectDir $options.ProjectDir -ManifestEntry $deferredEntry -Operation start_deferred
+            if (-not [bool]$deferredRuntime.valid) {
+                throw ("{0}: {1}" -f [string]$deferredRuntime.reason_code, [string]$deferredRuntime.diagnostic)
+            }
+
+            Assert-WinsmuxTargetRuntimeWriteAllowed -PaneId ([string]$entry.PaneId) `
+                -CurrentProjectDir $options.ProjectDir -Operation start_deferred `
+                -ExpectedGenerationId $runtimeGenerationId | Out-Null
+            Clear-ReadMark ([string]$entry.PaneId)
+            Assert-WinsmuxTargetRuntimeWriteAllowed -PaneId ([string]$entry.PaneId) `
+                -CurrentProjectDir $options.ProjectDir -Operation start_deferred `
+                -ExpectedGenerationId $runtimeGenerationId | Out-Null
+            Clear-Watermark ([string]$entry.PaneId)
             $results.Add((New-WorkersLifecycleResult -Row $row -Action 'workers.stop' -Status 'stopped' -Reason $nextStatus)) | Out-Null
         } catch {
             $results.Add((New-WorkersLifecycleResult -Row $row -Action 'workers.stop' -Status 'failed' -Reason $_.Exception.Message)) | Out-Null
@@ -10433,9 +11715,9 @@ function Invoke-WorkersDoctor {
 
     $manifestPath = Join-Path (Join-Path $options.ProjectDir '.winsmux') 'manifest.yaml'
     if (Test-Path -LiteralPath $manifestPath -PathType Leaf) {
-        $checks.Add((New-WorkersDoctorCheck -Status 'pass' -Label 'manifest' -Detail $manifestPath -Action '')) | Out-Null
+        $checks.Add((New-WorkersDoctorCheck -Status 'warn' -Label 'manifest desired state' -Detail "desired-state file present; runtime authorization is evaluated separately: $manifestPath" -Action '')) | Out-Null
     } else {
-        $checks.Add((New-WorkersDoctorCheck -Status 'warn' -Label 'manifest' -Detail "manifest not found: $manifestPath" -Action 'Run winsmux launch before workers start or stop.')) | Out-Null
+        $checks.Add((New-WorkersDoctorCheck -Status 'warn' -Label 'manifest desired state' -Detail "manifest not found: $manifestPath" -Action 'Run winsmux launch before workers start or stop.')) | Out-Null
     }
 
     $uvCommand = Get-Command uv -ErrorAction SilentlyContinue | Select-Object -First 1
@@ -10445,11 +11727,22 @@ function Invoke-WorkersDoctor {
         $checks.Add((New-WorkersDoctorCheck -Status 'fail' -Label 'uv' -Detail 'uv not found on PATH' -Action 'Install uv or add it to PATH before launching managed workers.')) | Out-Null
     }
 
-    $rows = if ($null -ne $context) { Get-WorkersStatusRows -Context $context } else { @() }
+    $rows = if ($null -ne $context) { @(Add-WorkersRuntimeValidity -Context $context -Rows @(Get-WorkersStatusRows -Context $context)) } else { @() }
+    $runtimeInvalidRows = @($rows | Where-Object { -not [bool]$_.RuntimeValid })
+    $runtimeValid = Test-WorkersRuntimeRowsValid -Rows $rows
+    Set-WorkersRuntimeProcessExitCode -RuntimeValid $runtimeValid
+    if ($runtimeValid) {
+        $checks.Add((New-WorkersDoctorCheck -Status 'pass' -Label 'runtime identity' -Detail "$(@($rows).Count) worker runtime identities verified" -Action '')) | Out-Null
+    } else {
+        $runtimeReasons = @($runtimeInvalidRows | ForEach-Object { [string]$_.RuntimeReasonCode } | Where-Object { $_ } | Select-Object -Unique)
+        if ($runtimeReasons.Count -lt 1) { $runtimeReasons = @('manifest_regeneration_required') }
+        $checks.Add((New-WorkersDoctorCheck -Status 'fail' -Label 'runtime identity' -Detail ($runtimeReasons -join ', ') -Action 'Regenerate the orchestra session before runtime operations.')) | Out-Null
+    }
     if ($options.Json) {
         [ordered]@{
             project_dir  = $options.ProjectDir
             generated_at = (Get-Date).ToUniversalTime().ToString('o')
+            runtime_valid = $runtimeValid
             checks       = @($checks)
             workers      = @(ConvertTo-WorkersStatusJsonRows -Rows @($rows))
         } | ConvertTo-Json -Depth 20 -Compress | Write-Output
@@ -10467,6 +11760,7 @@ function Invoke-WorkersDoctor {
 }
 
 function Invoke-Workers {
+    $script:WinsmuxRequestedProcessExitCode = 0
     $action = [string]$Target
     if ([string]::IsNullOrWhiteSpace($action)) {
         Stop-WithError (Get-WorkersUsage)
@@ -10732,7 +12026,7 @@ function Get-BridgeEventRecords {
         }
 
         try {
-            $record = $line | ConvertFrom-Json -AsHashtable -ErrorAction Stop
+            $record = $line | ConvertFrom-WinsmuxJson -AsHashtable -ErrorAction Stop
             if ($null -eq $record) {
                 continue
             }
@@ -15562,7 +16856,7 @@ function Invoke-PollEvents {
     $events = [System.Collections.Generic.List[object]]::new()
     for ($i = $cursor; $i -lt $lines.Count; $i++) {
         try {
-            $events.Add(($lines[$i] | ConvertFrom-Json -AsHashtable -ErrorAction Stop)) | Out-Null
+            $events.Add(($lines[$i] | ConvertFrom-WinsmuxJson -AsHashtable -ErrorAction Stop)) | Out-Null
         } catch {
             Stop-WithError "failed to parse event log line $($i + 1): $($_.Exception.Message)"
         }
@@ -15745,16 +17039,16 @@ function Invoke-VaultSet {
     $blobPtr = [Runtime.InteropServices.Marshal]::AllocHGlobal($valueBytes.Length)
     [Runtime.InteropServices.Marshal]::Copy($valueBytes, 0, $blobPtr, $valueBytes.Length)
 
-    $cred = New-Object WinCred+CREDENTIAL
-    $cred.Type = [WinCred]::CRED_TYPE_GENERIC
+    $cred = New-Object WinsmuxBridgeCredentialNative+CREDENTIAL
+    $cred.Type = [WinsmuxBridgeCredentialNative]::CRED_TYPE_GENERIC
     $cred.TargetName = $credTarget
     $cred.UserName = "winsmux"
     $cred.CredentialBlobSize = $valueBytes.Length
     $cred.CredentialBlob = $blobPtr
-    $cred.Persist = [WinCred]::CRED_PERSIST_LOCAL_MACHINE
+    $cred.Persist = [WinsmuxBridgeCredentialNative]::CRED_PERSIST_LOCAL_MACHINE
 
     try {
-        $ok = [WinCred]::CredWrite([ref]$cred, 0)
+        $ok = [WinsmuxBridgeCredentialNative]::CredWrite([ref]$cred, 0)
         if (-not $ok) {
             $errCode = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
             Stop-WithError "CredWrite failed (error $errCode)"
@@ -15772,7 +17066,7 @@ function Invoke-VaultGet {
     $credTarget = "winsmux:$key"
     $credPtr = [IntPtr]::Zero
 
-    $ok = [WinCred]::CredRead($credTarget, [WinCred]::CRED_TYPE_GENERIC, 0, [ref]$credPtr)
+    $ok = [WinsmuxBridgeCredentialNative]::CredRead($credTarget, [WinsmuxBridgeCredentialNative]::CRED_TYPE_GENERIC, 0, [ref]$credPtr)
     if (-not $ok) {
         $errCode = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
         if ($errCode -eq 1168) {
@@ -15782,7 +17076,7 @@ function Invoke-VaultGet {
     }
 
     try {
-        $cred = [Runtime.InteropServices.Marshal]::PtrToStructure($credPtr, [Type][WinCred+CREDENTIAL])
+        $cred = [Runtime.InteropServices.Marshal]::PtrToStructure($credPtr, [Type][WinsmuxBridgeCredentialNative+CREDENTIAL])
         if ($cred.CredentialBlobSize -gt 0) {
             $bytes = New-Object byte[] $cred.CredentialBlobSize
             [Runtime.InteropServices.Marshal]::Copy($cred.CredentialBlob, $bytes, 0, $cred.CredentialBlobSize)
@@ -15790,35 +17084,46 @@ function Invoke-VaultGet {
             Write-Output $value
         }
     } finally {
-        [WinCred]::CredFree($credPtr) | Out-Null
+        [WinsmuxBridgeCredentialNative]::CredFree($credPtr) | Out-Null
     }
 }
 
 function Invoke-VaultList {
-    $filter = "winsmux:*"
-    $count = 0
-    $credsPtr = [IntPtr]::Zero
+    $names = @(Get-WinsmuxCredentialTargetNames)
+    if ($names.Count -eq 0) {
+        Write-Output "(no credentials stored)"
+        return
+    }
+    Write-Output $names
+}
 
-    $ok = [WinCred]::CredEnumerate($filter, 0, [ref]$count, [ref]$credsPtr)
+function Get-WinsmuxVaultCredentialNamesInternal {
+    return @(Get-WinsmuxCredentialTargetNames)
+}
+
+function Get-WinsmuxVaultCredentialValueInternal {
+    param([Parameter(Mandatory = $true)][string]$Name)
+
+    $credPtr = [IntPtr]::Zero
+    $ok = [WinsmuxBridgeCredentialNative]::CredRead("winsmux:$Name", [WinsmuxBridgeCredentialNative]::CRED_TYPE_GENERIC, 0, [ref]$credPtr)
     if (-not $ok) {
         $errCode = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
         if ($errCode -eq 1168) {
-            Write-Output "(no credentials stored)"
-            return
+            Stop-WithError 'credential no longer exists'
         }
-        Stop-WithError "CredEnumerate failed (error $errCode)"
+        Stop-WithError "CredRead failed (error $errCode)"
     }
 
     try {
-        $ptrSize = [Runtime.InteropServices.Marshal]::SizeOf([Type][IntPtr])
-        for ($i = 0; $i -lt $count; $i++) {
-            $entryPtr = [Runtime.InteropServices.Marshal]::ReadIntPtr($credsPtr, $i * $ptrSize)
-            $cred = [Runtime.InteropServices.Marshal]::PtrToStructure($entryPtr, [Type][WinCred+CREDENTIAL])
-            $name = $cred.TargetName -replace '^winsmux:', ''
-            Write-Output $name
+        $cred = [Runtime.InteropServices.Marshal]::PtrToStructure($credPtr, [Type][WinsmuxBridgeCredentialNative+CREDENTIAL])
+        if ($cred.CredentialBlobSize -le 0) {
+            return ''
         }
+        $bytes = New-Object byte[] $cred.CredentialBlobSize
+        [Runtime.InteropServices.Marshal]::Copy($cred.CredentialBlob, $bytes, 0, $cred.CredentialBlobSize)
+        return [System.Text.Encoding]::Unicode.GetString($bytes)
     } finally {
-        [WinCred]::CredFree($credsPtr) | Out-Null
+        [WinsmuxBridgeCredentialNative]::CredFree($credPtr) | Out-Null
     }
 }
 
@@ -15827,50 +17132,44 @@ function Invoke-VaultInject {
 
     $paneId = Resolve-Target $Target
     $paneId = Confirm-Target $paneId
+    $projectDir = (Get-Location).Path
+    $initialRuntime = Assert-WinsmuxTargetRuntimeWriteAllowed -PaneId $paneId -CurrentProjectDir $projectDir -Operation dispatch
     Assert-ReadMark $paneId
 
-    # Enumerate all winsmux:* credentials
-    $filter = "winsmux:*"
-    $count = 0
-    $credsPtr = [IntPtr]::Zero
-
-    $ok = [WinCred]::CredEnumerate($filter, 0, [ref]$count, [ref]$credsPtr)
-    if (-not $ok) {
-        $errCode = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
-        if ($errCode -eq 1168) {
-            Write-Output "no credentials to inject"
-            return
-        }
-        Stop-WithError "CredEnumerate failed (error $errCode)"
+    $credentialNames = @(Get-WinsmuxVaultCredentialNamesInternal)
+    if ($credentialNames.Count -eq 0) {
+        Write-Output "no credentials to inject"
+        return
     }
 
     $injected = 0
-    try {
-        $ptrSize = [Runtime.InteropServices.Marshal]::SizeOf([Type][IntPtr])
-        for ($i = 0; $i -lt $count; $i++) {
-            $entryPtr = [Runtime.InteropServices.Marshal]::ReadIntPtr($credsPtr, $i * $ptrSize)
-            $cred = [Runtime.InteropServices.Marshal]::PtrToStructure($entryPtr, [Type][WinCred+CREDENTIAL])
-            $envName = $cred.TargetName -replace '^winsmux:', ''
+    foreach ($envName in $credentialNames) {
+        Assert-WinsmuxTargetRuntimeWriteAllowed -PaneId $paneId -CurrentProjectDir $projectDir -Operation dispatch `
+            -ExpectedGenerationId ([string]$initialRuntime.GenerationId) | Out-Null
+        $value = [string](Get-WinsmuxVaultCredentialValueInternal -Name ([string]$envName))
 
-            $value = ''
-            if ($cred.CredentialBlobSize -gt 0) {
-                $bytes = New-Object byte[] $cred.CredentialBlobSize
-                [Runtime.InteropServices.Marshal]::Copy($cred.CredentialBlob, $bytes, 0, $cred.CredentialBlobSize)
-                $value = [System.Text.Encoding]::Unicode.GetString($bytes)
-            }
-
-            # Escape single quotes in value for safe injection
+        try {
+            # Escape single quotes in value for safe injection.
             $escapedValue = $value -replace "'", "''"
             $setCmd = "`$env:$envName = '$escapedValue'"
+            Assert-WinsmuxTargetRuntimeWriteAllowed -PaneId $paneId -CurrentProjectDir $projectDir -Operation dispatch `
+                -ExpectedGenerationId ([string]$initialRuntime.GenerationId) | Out-Null
             Invoke-WinsmuxRaw -Arguments @('send-keys', '-t', $paneId, '-l', '--', "$setCmd")
-            Invoke-WinsmuxRaw -Arguments @('send-keys', '-t', $paneId, 'Enter')
-            Start-Sleep -Milliseconds 100
-            $injected++
+        } finally {
+            $value = $null
+            $escapedValue = $null
+            $setCmd = $null
         }
-    } finally {
-        [WinCred]::CredFree($credsPtr) | Out-Null
+
+        Assert-WinsmuxTargetRuntimeWriteAllowed -PaneId $paneId -CurrentProjectDir $projectDir -Operation dispatch `
+            -ExpectedGenerationId ([string]$initialRuntime.GenerationId) | Out-Null
+        Invoke-WinsmuxRaw -Arguments @('send-keys', '-t', $paneId, 'Enter')
+        Start-Sleep -Milliseconds 100
+        $injected++
     }
 
+    Assert-WinsmuxTargetRuntimeWriteAllowed -PaneId $paneId -CurrentProjectDir $projectDir -Operation dispatch `
+        -ExpectedGenerationId ([string]$initialRuntime.GenerationId) | Out-Null
     Clear-ReadMark $paneId
     Write-Output "injected $injected credential(s) into $paneId"
 }
@@ -15900,6 +17199,41 @@ function Invoke-DispatchReview {
         $receipt = New-WinsmuxSubmissionReceipt -Kind review -Status unavailable -Backend noop -SubmissionId $submissionId -ReasonCode 'review_target_unavailable' -Diagnostic 'No review-capable pane was found in the manifest.'
         ConvertTo-WinsmuxSubmissionReceiptJson -Receipt $receipt | Write-Output
         exit 1
+    }
+
+    $reviewBackend = ([string](Get-SendConfigValue -InputObject $reviewPaneEntry -Name 'WorkerBackend' -Default 'noop')).Trim().ToLowerInvariant()
+    if ($reviewBackend -notin @('local', 'codex', 'api_llm', 'antigravity')) { $reviewBackend = 'noop' }
+    $reviewTarget = [ordered]@{
+        label   = [string](Get-SendConfigValue -InputObject $reviewPaneEntry -Name 'Label' -Default '')
+        pane_id = [string](Get-SendConfigValue -InputObject $reviewPaneEntry -Name 'PaneId' -Default '')
+        role    = [string](Get-SendConfigValue -InputObject $reviewPaneEntry -Name 'Role' -Default '')
+    }
+    $runtimeOperation = if (Test-DeferredPaneStartManifestEntry -ManifestEntry $reviewPaneEntry) { 'start_deferred' } else { 'dispatch' }
+    $runtimeResult = Test-PaneControlRuntimeContext -ProjectDir $projectDir -ManifestEntry $reviewPaneEntry -Operation $runtimeOperation
+    if (-not $runtimeResult.valid) {
+        $receipt = New-WinsmuxSubmissionReceipt -Kind review -Status unavailable -Backend $reviewBackend -SubmissionId $submissionId `
+            -ReasonCode ([string]$runtimeResult.reason_code) -Diagnostic ([string]$runtimeResult.diagnostic) -Target $reviewTarget
+        ConvertTo-WinsmuxSubmissionReceiptJson -Receipt $receipt | Write-Output
+        exit 1
+    }
+    if ($runtimeOperation -ceq 'start_deferred') {
+        try {
+            Start-DeferredPaneFromManifestEntry -ProjectDir $projectDir -ManifestEntry $reviewPaneEntry `
+                -ExpectedGenerationId ([string](Get-SendConfigValue -InputObject $runtimeResult.context -Name 'generation_id' -Default '')) | Out-Null
+        } catch {
+            $receipt = New-WinsmuxDeferredStartFailureReceipt -Kind review -Backend $reviewBackend `
+                -SubmissionId $submissionId -PaneId ([string]$reviewPaneEntry.PaneId) -Failure $_ -Target $reviewTarget
+            ConvertTo-WinsmuxSubmissionReceiptJson -Receipt $receipt | Write-Output
+            exit 1
+        }
+        $reviewPaneEntry = Get-PaneControlManifestContext -ProjectDir $projectDir -PaneId ([string]$reviewPaneEntry.PaneId)
+        $runtimeResult = Wait-PaneControlRuntimeContext -ProjectDir $projectDir -ManifestEntry $reviewPaneEntry -Operation dispatch
+        if (-not $runtimeResult.valid) {
+            $receipt = New-WinsmuxSubmissionReceipt -Kind review -Status unavailable -Backend $reviewBackend -SubmissionId $submissionId `
+                -ReasonCode ([string]$runtimeResult.reason_code) -Diagnostic ([string]$runtimeResult.diagnostic) -Target $reviewTarget
+            ConvertTo-WinsmuxSubmissionReceiptJson -Receipt $receipt | Write-Output
+            exit 1
+        }
     }
 
     $branch = Get-CurrentGitBranch -ProjectDir $projectDir
@@ -15956,7 +17290,7 @@ function Invoke-ReviewRequest {
 
     $state[$branch] = New-ReviewerStateRecord -Status 'PENDING' -Request $request -Reviewer $reviewer -Evidence $null -UpdatedAt $timestamp
     Save-ReviewState -ProjectDir $projectDir -State $state
-    Update-ReviewPaneManifestState -ProjectDir $projectDir -Properties ([ordered]@{
+    Update-ReviewPaneManifestState -Context $context -Properties ([ordered]@{
         review_state = 'pending'
         task_owner   = $context.Role
         branch       = $branch
@@ -16026,7 +17360,7 @@ function Invoke-ReviewApprove {
 
     $state[$branch] = New-ReviewerStateRecord -Status 'PASS' -Request $request -Reviewer $reviewer -Evidence $evidence -UpdatedAt $timestamp
     Save-ReviewState -ProjectDir $projectDir -State $state
-    Update-ReviewPaneManifestState -ProjectDir $projectDir -Properties ([ordered]@{
+    Update-ReviewPaneManifestState -Context $context -Properties ([ordered]@{
         review_state = 'pass'
         task_owner   = 'Operator'
         branch       = $branch
@@ -16096,7 +17430,7 @@ function Invoke-ReviewFail {
 
     $state[$branch] = New-ReviewerStateRecord -Status 'FAIL' -Request $request -Reviewer $reviewer -Evidence $evidence -UpdatedAt $timestamp
     Save-ReviewState -ProjectDir $projectDir -State $state
-    Update-ReviewPaneManifestState -ProjectDir $projectDir -Properties ([ordered]@{
+    Update-ReviewPaneManifestState -Context $context -Properties ([ordered]@{
         review_state = 'fail'
         task_owner   = 'Operator'
         branch       = $branch
@@ -16114,13 +17448,19 @@ function Invoke-ReviewReset {
 
     $projectDir = (Get-Location).Path
     $branch = Get-CurrentGitBranch -ProjectDir $projectDir
+    $context = $null
+    try {
+        $context = Get-CurrentReviewPaneManifestContext -ProjectDir $projectDir
+    } catch {
+        # Review-state persistence is authoritative; manifest sync remains best-effort.
+    }
     $state = Get-ReviewState -ProjectDir $projectDir
     if ($state.Contains($branch)) {
         $state.Remove($branch)
     }
 
     Save-ReviewState -ProjectDir $projectDir -State $state
-    Update-ReviewPaneManifestState -ProjectDir $projectDir -Properties ([ordered]@{
+    Update-ReviewPaneManifestState -Context $context -Properties ([ordered]@{
         review_state = ''
         branch       = ''
         head_sha     = ''
@@ -16411,7 +17751,7 @@ function Invoke-RuntimeRoles {
     }
 
     try {
-        $roles = $rolesJson | ConvertFrom-Json -Depth 16 -ErrorAction Stop
+        $roles = $rolesJson | ConvertFrom-WinsmuxJson -Depth 16 -ErrorAction Stop
     } catch {
         Stop-WithError 'runtime-roles apply received invalid JSON.'
     }
@@ -16554,7 +17894,7 @@ function ConvertTo-ControlRpcPayload {
     }
 
     try {
-        $payload = $JsonText | ConvertFrom-Json -Depth 100
+        $payload = $JsonText | ConvertFrom-WinsmuxJson -Depth 100
     } catch {
         Stop-WithError "control-rpc payload must be valid JSON: $($_.Exception.Message)"
     }
@@ -16863,7 +18203,9 @@ function Set-PaneReadinessManifestFromRestartPlan {
             capability_adapter = [string]$Plan.CapabilityAdapter
         }
 
-        Set-PaneControlManifestPaneProperties -ManifestPath $context.ManifestPath -PaneId $PaneId -Properties $properties
+        $expectedGenerationId = [string]$Plan.GenerationId
+        Set-PaneControlManifestPaneProperties -ManifestPath $context.ManifestPath -PaneId $PaneId -Properties $properties `
+            -ExpectedGenerationId $expectedGenerationId
     } catch {
         # Restart has already changed the running process; readiness metadata sync is best-effort.
     }
@@ -16875,6 +18217,11 @@ function Invoke-Kill {
 
     $paneId = Resolve-Target $Target
     $paneId = Confirm-Target $paneId
+
+    $lifecycleRefusal = Get-ManagedPaneLifecycleMutationRefusal -ProjectDir (Get-Location).Path -PaneId $paneId -OperationName kill
+    if ($null -ne $lifecycleRefusal) {
+        Stop-WithError ("{0}: {1}" -f [string]$lifecycleRefusal.reason_code, [string]$lifecycleRefusal.diagnostic)
+    }
 
     Invoke-WinsmuxRaw -Arguments @('respawn-pane', '-k', '-t', $paneId)
     $nativeExitCode = Get-SafeLastExitCode
@@ -16892,6 +18239,11 @@ function Invoke-RestartPane {
         [Parameter(Mandatory = $true)][string]$PaneId,
         [Parameter(Mandatory = $true)][string]$ProjectDir
     )
+
+    $lifecycleRefusal = Get-ManagedPaneLifecycleMutationRefusal -ProjectDir $ProjectDir -PaneId $PaneId -OperationName restart
+    if ($null -ne $lifecycleRefusal) {
+        Stop-WithError ("{0}: {1}" -f [string]$lifecycleRefusal.reason_code, [string]$lifecycleRefusal.diagnostic)
+    }
 
     $settings = $null
     if (Get-Command Get-BridgeSettings -ErrorAction SilentlyContinue) {
@@ -17086,5 +18438,9 @@ switch ($Command) {
     'rebind-worktree' { Invoke-RebindWorktree }
     ''                { Show-Usage }
     default           { Stop-WithError "unknown command: $Command. Run without arguments for usage." }
+}
+
+if (-not $script:WinsmuxBridgeWasDotSourced -and $script:WinsmuxRequestedProcessExitCode -ne 0) {
+    exit $script:WinsmuxRequestedProcessExitCode
 }
 

--- a/tests/HarnessContract.Tests.ps1
+++ b/tests/HarnessContract.Tests.ps1
@@ -1392,6 +1392,30 @@ exit /b 0
         $exitCode | Should -Be 0
         $json.passed | Should -Be $true
     }
+
+    It 'propagates a failed harness-check exit code through winsmux-core' {
+        $settingsPath = Join-Path $script:RepoRoot '.claude\settings.json'
+        $original = Backup-TestFile -Path $settingsPath
+        try {
+            $settings = $original | ConvertFrom-Json -Depth 32
+            $group = @($settings.hooks.PreToolUse) | Where-Object {
+                @($_.hooks | Where-Object { $_.command -eq 'node .claude/hooks/sh-orchestra-gate.js' }).Count -gt 0
+            } | Select-Object -First 1
+            $group.matcher = 'Bash'
+            Write-TestFileWithCmd -Path $settingsPath -Content ($settings | ConvertTo-Json -Depth 32)
+
+            $stdout = & $script:PwshPath -NoProfile -File $script:WinsmuxCorePath harness-check --json --project-dir $script:RepoRoot 2>&1
+            $exitCode = $LASTEXITCODE
+            $json = (($stdout | Out-String).Trim() | ConvertFrom-Json -Depth 16)
+            $record = $json.results | Where-Object { $_.name -eq 'settings-shared-registers-orchestra-gate' } | Select-Object -First 1
+
+            $exitCode | Should -Be 1
+            $json.passed | Should -BeFalse
+            $record.passed | Should -BeFalse
+        } finally {
+            Restore-TestFile -Path $settingsPath -Content $original
+        }
+    }
 }
 
 Describe 'desktop PTY event payload contract' {

--- a/tests/Runtime.VaultInject.Tests.ps1
+++ b/tests/Runtime.VaultInject.Tests.ps1
@@ -25,6 +25,16 @@ Describe 'Runtime vault helpers' {
             param([string]$PaneId)
         }
 
+        function Assert-WinsmuxTargetRuntimeWriteAllowed {
+            param(
+                [string]$PaneId,
+                [string]$CurrentProjectDir,
+                [string]$Operation,
+                [string]$ExpectedGenerationId = ''
+            )
+            return [PSCustomObject]@{ GenerationId = 'generation-vault' }
+        }
+
         . (Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\vault.ps1')
 
         if (-not ('WinCredDeleteNative' -as [type])) {
@@ -35,6 +45,8 @@ using System.Runtime.InteropServices;
 public static class WinCredDeleteNative {
     [DllImport("advapi32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
     public static extern bool CredDelete(string target, uint type, uint flags);
+
+    public const uint CRED_TYPE_GENERIC = 1;
 }
 '@
         }
@@ -42,38 +54,17 @@ public static class WinCredDeleteNative {
         function Get-StoredCredentialTargets {
             param([Parameter(Mandatory = $true)][string]$Filter)
 
-            $count = 0
-            $credsPtr = [IntPtr]::Zero
-            $ok = [WinCred]::CredEnumerate($Filter, 0, [ref]$count, [ref]$credsPtr)
-            if (-not $ok) {
-                $errCode = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
-                if ($errCode -eq 1168) {
-                    return @()
-                }
-
-                throw "CredEnumerate failed (error $errCode)"
-            }
-
-            try {
-                $targets = [System.Collections.Generic.List[string]]::new()
-                $ptrSize = [Runtime.InteropServices.Marshal]::SizeOf([Type][IntPtr])
-                for ($i = 0; $i -lt $count; $i++) {
-                    $entryPtr = [Runtime.InteropServices.Marshal]::ReadIntPtr($credsPtr, $i * $ptrSize)
-                    $cred = [Runtime.InteropServices.Marshal]::PtrToStructure($entryPtr, [Type][WinCred+CREDENTIAL])
-                    $targets.Add($cred.TargetName) | Out-Null
-                }
-
-                return $targets.ToArray()
-            } finally {
-                [WinCred]::CredFree($credsPtr) | Out-Null
-            }
+            $nameFilter = $Filter -replace '^winsmux:', ''
+            return @(Get-WinsmuxCredentialTargetNames |
+                Where-Object { [string]$_ -like $nameFilter } |
+                ForEach-Object { 'winsmux:{0}' -f [string]$_ })
         }
 
         function Remove-StoredCredentialTargets {
             param([Parameter(Mandatory = $true)][string[]]$Targets)
 
             foreach ($target in $Targets) {
-                $ok = [WinCredDeleteNative]::CredDelete($target, [WinCred]::CRED_TYPE_GENERIC, 0)
+                $ok = [WinCredDeleteNative]::CredDelete($target, [WinCredDeleteNative]::CRED_TYPE_GENERIC, 0)
                 if (-not $ok) {
                     $errCode = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
                     if ($errCode -ne 1168) {
@@ -131,5 +122,53 @@ public static class WinCredDeleteNative {
         $listedKeys = @(Invoke-VaultList)
 
         $listedKeys | Should -Contain $script:Target
+    }
+
+    It 'revalidates one captured generation before every modular Vault secret read and mutation' {
+        $script:Target = '%2'
+        $script:VaultGuardSequence = [System.Collections.Generic.List[string]]::new()
+        Mock Resolve-Target { return $RawTarget }
+        Mock Confirm-Target { return $PaneId }
+        Mock Assert-WinsmuxTargetRuntimeWriteAllowed {
+            $script:VaultGuardSequence.Add(('guard:{0}' -f [string]$ExpectedGenerationId)) | Out-Null
+            return [PSCustomObject]@{ GenerationId = 'generation-vault' }
+        }
+        Mock Assert-ReadMark { $script:VaultGuardSequence.Add('mark') | Out-Null }
+        Mock Get-WinsmuxCredentialTargetNames {
+            $script:VaultGuardSequence.Add('names') | Out-Null
+            return @('FIRST', 'SECOND')
+        }
+        Mock Get-WinsmuxSessionNameForPane {
+            $script:VaultGuardSequence.Add('session') | Out-Null
+            return 'winsmux-orchestra'
+        }
+        Mock Get-WinsmuxVaultCredentialValue {
+            $script:VaultGuardSequence.Add(('read:{0}' -f $Name)) | Out-Null
+            return ('value-{0}' -f $Name)
+        }
+        Mock Invoke-WinsmuxSourceFile {
+            $script:VaultGuardSequence.Add('mutate') | Out-Null
+            return [PSCustomObject]@{ Success = $true; ExitCode = 0; Output = '' }
+        }
+        Mock Clear-ReadMark { $script:VaultGuardSequence.Add('clear') | Out-Null }
+
+        Invoke-VaultInject | Should -Be 'injected 2 credential(s) into %2'
+
+        @($script:VaultGuardSequence) | Should -Be @(
+            'guard:'
+            'mark'
+            'names'
+            'session'
+            'guard:generation-vault'
+            'read:FIRST'
+            'guard:generation-vault'
+            'mutate'
+            'guard:generation-vault'
+            'read:SECOND'
+            'guard:generation-vault'
+            'mutate'
+            'guard:generation-vault'
+            'clear'
+        )
     }
 }

--- a/tests/Task781RuntimeCompatibility.Tests.ps1
+++ b/tests/Task781RuntimeCompatibility.Tests.ps1
@@ -1,0 +1,715 @@
+Describe 'TASK781 Windows PowerShell runtime compatibility' -Tag @('Integration', 'Stateful') {
+    BeforeAll {
+        $script:Task781RepoRoot = Split-Path -Parent $PSScriptRoot
+        $script:Task781RuntimeScriptsDir = Join-Path $script:Task781RepoRoot 'winsmux-core\scripts'
+    }
+
+    It 'accepts valid managed runtime evidence through every PS5.1 JSON boundary' {
+        $caseRoot = Join-Path $TestDrive 'task781-ps51-runtime'
+        New-Item -ItemType Directory -Path $caseRoot -Force | Out-Null
+        $childScriptPath = Join-Path $caseRoot 'validate-runtime.ps1'
+        $projectDir = Join-Path $caseRoot 'project'
+
+        $childScript = @'
+param(
+    [Parameter(Mandatory = $true)][string]$ScriptsDir,
+    [Parameter(Mandatory = $true)][string]$ProjectDir
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+
+function Get-Utf8ProductionScriptBlock {
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [switch]$RemoveDotSourcePrelude
+    )
+
+    $content = [System.IO.File]::ReadAllText($Path, [System.Text.Encoding]::UTF8)
+    if ($RemoveDotSourcePrelude) {
+        $content = (@($content -split "\r?\n") |
+            Where-Object { $_ -cnotmatch '^\. \(Join-Path \$PSScriptRoot ' }) -join "`n"
+    }
+    return [scriptblock]::Create($content)
+}
+
+function Get-Utf8ProductionFunctionBlock {
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $true)][string]$Name
+    )
+
+    $content = [System.IO.File]::ReadAllText($Path, [System.Text.Encoding]::UTF8)
+    $tokens = $null
+    $errors = $null
+    $ast = [System.Management.Automation.Language.Parser]::ParseInput(
+        $content,
+        $Path,
+        [ref]$tokens,
+        [ref]$errors
+    )
+    if ($errors.Count -ne 0) { throw "UTF-8 parse failed for $Path" }
+    $function = $ast.Find({
+        param($node)
+        $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and $node.Name -ceq $Name
+    }, $true)
+    if ($null -eq $function) { throw "Function $Name not found in $Path" }
+    return [scriptblock]::Create($function.Extent.Text)
+}
+
+$jsonCompatBlock = Get-Utf8ProductionScriptBlock -Path (Join-Path $ScriptsDir 'json-compat.ps1')
+. $jsonCompatBlock
+$clmSafeIoBlock = Get-Utf8ProductionScriptBlock -Path (Join-Path $ScriptsDir 'clm-safe-io.ps1')
+. $clmSafeIoBlock
+$manifestBlock = Get-Utf8ProductionScriptBlock -Path (Join-Path $ScriptsDir 'manifest.ps1') -RemoveDotSourcePrelude
+. $manifestBlock
+$paneControlBlock = Get-Utf8ProductionScriptBlock -Path (Join-Path $ScriptsDir 'pane-control.ps1') -RemoveDotSourcePrelude
+. $paneControlBlock
+
+New-Item -ItemType Directory -Path $ProjectDir -Force | Out-Null
+$markerPath = Join-Path $ProjectDir 'worker-1-bootstrap.json'
+$supervisorStartedAt = '2026-07-15T00:00:00.0000000Z'
+$bootstrapStartedAt = '2026-07-15T00:00:01.0000000Z'
+$marker = [PSCustomObject][ordered]@{
+                state                        = 'bootstrap_pending'
+    generation_id                = 'generation-ps51'
+    server_session_id            = '$9'
+    slot_id                      = 'worker-1'
+    pane_id                      = '%2'
+    backend                      = 'codex'
+    role                         = 'reviewer'
+    title                        = 'W1 Codex Reviewer'
+    bootstrap_pid                = 4200
+    bootstrap_process_started_at = $bootstrapStartedAt
+}
+[System.IO.File]::WriteAllText(
+    $markerPath,
+    ($marker | ConvertTo-Json -Depth 8),
+    [System.Text.UTF8Encoding]::new($false)
+)
+
+$manifest = [PSCustomObject][ordered]@{
+    version  = 2
+    saved_at = '2026-07-15T00:00:02.0000000Z'
+    session  = [PSCustomObject][ordered]@{
+        name                = 'winsmux-task781-ps51'
+        generation_id       = 'generation-ps51'
+        server_session_id   = '$9'
+        bootstrap_pane_id   = '%1'
+        expected_pane_count = 1
+        session_ready       = $true
+    }
+    panes = [ordered]@{
+        'worker-1' = [ordered]@{
+            slot_id               = 'worker-1'
+            pane_id               = '%2'
+            worker_backend        = 'codex'
+            worker_role           = 'reviewer'
+            role                  = 'Reviewer'
+            title                 = 'W1 Codex Reviewer'
+            status                = 'starting'
+            runtime_ready         = $false
+            bootstrap_marker_path = $markerPath
+        }
+    }
+    tasks = [PSCustomObject][ordered]@{
+        queued      = @()
+        in_progress = @()
+        completed   = @()
+    }
+    worktrees = [ordered]@{}
+}
+Save-WinsmuxManifest -ProjectDir $ProjectDir -Manifest $manifest | Out-Null
+
+        $runtimePane = [PSCustomObject][ordered]@{
+    label                        = 'worker-1'
+    slot_id                      = 'worker-1'
+    pane_id                      = '%2'
+    backend                      = 'codex'
+    role                         = 'reviewer'
+    title                        = 'W1 Codex Reviewer'
+            state                        = 'live'
+    bootstrap_pid                = 4200
+    bootstrap_process_started_at = $bootstrapStartedAt
+    marker_path                  = $markerPath
+}
+$registry = New-WinsmuxRuntimeRegistryDocument `
+    -SessionName 'winsmux-task781-ps51' `
+    -ServerSessionId '$9' `
+    -BootstrapPaneId '%1' `
+    -GenerationId 'generation-ps51' `
+    -SupervisorPid 4100 `
+    -SupervisorProcessStartedAt $supervisorStartedAt `
+    -ExpectedPaneCount 1 `
+    -Panes @($runtimePane) `
+    -Now (Get-Date) `
+    -LeaseSeconds 300
+Save-WinsmuxRuntimeRegistry -ProjectDir $ProjectDir -Registry $registry | Out-Null
+
+$processResolver = {
+    param([int]$Id)
+    switch ($Id) {
+        4100 { return [PSCustomObject]@{ Id = 4100; StartTime = [datetime]'2026-07-15T00:00:00Z'; ParentProcessId = 1; Name = 'powershell.exe' } }
+        4200 { return [PSCustomObject]@{ Id = 4200; StartTime = [datetime]'2026-07-15T00:00:01Z'; ParentProcessId = 1; Name = 'powershell.exe' } }
+        default { return $null }
+    }
+}
+
+$results = [System.Collections.Generic.List[object]]::new()
+try {
+    $read = Read-WinsmuxRuntimeRegistry -ProjectDir $ProjectDir
+    if ([string]$read.generation_id -cne 'generation-ps51') { throw 'registry generation mismatch' }
+    $results.Add([PSCustomObject]@{ surface = 'registry'; passed = $true; diagnostic = '' }) | Out-Null
+} catch {
+    $results.Add([PSCustomObject]@{ surface = 'registry'; passed = $false; diagnostic = $_.Exception.Message }) | Out-Null
+}
+
+function Invoke-PaneControlWinsmux {
+    param([Parameter(Mandatory = $true)][string[]]$Arguments)
+    return @(
+        ('$9' + "`t" + 'winsmux-task781-ps51' + "`t" + '%1' + "`t" + 'winsmux-orchestra-bootstrap'),
+        ('$9' + "`t" + 'winsmux-task781-ps51' + "`t" + '%2' + "`t" + 'W1 Codex Reviewer')
+    )
+}
+$manifestEntry = [PSCustomObject][ordered]@{
+    Label               = 'worker-1'
+    SlotId              = 'worker-1'
+    PaneId              = '%2'
+    WorkerBackend       = 'codex'
+    WorkerRole          = 'reviewer'
+    Role                = 'Reviewer'
+    Title               = 'W1 Codex Reviewer'
+    Status              = 'starting'
+    BootstrapMarkerPath = $markerPath
+}
+try {
+    $validation = Test-PaneControlRuntimeContext -ProjectDir $ProjectDir -ManifestEntry $manifestEntry `
+        -Operation dispatch -ProcessResolver $processResolver
+    if (-not $validation.valid) { throw $validation.diagnostic }
+    $results.Add([PSCustomObject]@{ surface = 'pane-control'; passed = $true; diagnostic = '' }) | Out-Null
+} catch {
+    $results.Add([PSCustomObject]@{ surface = 'pane-control'; passed = $false; diagnostic = $_.Exception.Message }) | Out-Null
+}
+
+try {
+    $policy = ConvertFrom-PaneControlSecurityPolicy -Value '{"allow":["send"]}'
+    if ($policy -isnot [System.Collections.IDictionary] -or
+        @($policy['allow']).Count -ne 1 -or [string]@($policy['allow'])[0] -cne 'send') {
+        throw 'pane-control policy projection mismatch'
+    }
+    $results.Add([PSCustomObject]@{ surface = 'pane-control-policy'; passed = $true; diagnostic = '' }) | Out-Null
+} catch {
+    $results.Add([PSCustomObject]@{ surface = 'pane-control-policy'; passed = $false; diagnostic = $_.Exception.Message }) | Out-Null
+}
+
+$supervisorFunctionBlock = Get-Utf8ProductionFunctionBlock `
+    -Path (Join-Path $ScriptsDir 'orchestra-supervisor.ps1') `
+    -Name 'New-OrchestraSupervisorRuntimePanes'
+. $supervisorFunctionBlock
+try {
+    $supervisorPanes = @(New-OrchestraSupervisorRuntimePanes -Manifest $manifest `
+        -GenerationId 'generation-ps51' -ServerSessionId '$9' -ProcessResolver $processResolver)
+    if ($supervisorPanes.Count -ne 1 -or [string]$supervisorPanes[0].pane_id -cne '%2') {
+        throw 'supervisor pane projection mismatch'
+    }
+    $results.Add([PSCustomObject]@{ surface = 'supervisor'; passed = $true; diagnostic = '' }) | Out-Null
+} catch {
+    $results.Add([PSCustomObject]@{ surface = 'supervisor'; passed = $false; diagnostic = $_.Exception.Message }) | Out-Null
+}
+
+$failed = @($results | Where-Object { -not $_.passed }).Count
+[PSCustomObject][ordered]@{
+    host_version = $PSVersionTable.PSVersion.ToString()
+    passed       = ($failed -eq 0)
+    results      = @($results)
+} | ConvertTo-Json -Depth 6 -Compress
+if ($failed -ne 0) { exit 1 }
+'@
+        [System.IO.File]::WriteAllText($childScriptPath, $childScript, [System.Text.UTF8Encoding]::new($false))
+
+        $output = @(& powershell.exe -NoProfile -File $childScriptPath `
+            -ScriptsDir $script:Task781RuntimeScriptsDir -ProjectDir $projectDir 2>&1)
+        $exitCode = $LASTEXITCODE
+        $jsonLine = @($output | Where-Object { ([string]$_).TrimStart().StartsWith('{') } | Select-Object -Last 1)
+        $jsonLine.Count | Should -Be 1 -Because (($output | Out-String).Trim())
+        $result = ([string]$jsonLine[0]) | ConvertFrom-Json
+
+        $result.host_version | Should -Match '^5\.1\.'
+        $result.passed | Should -BeTrue -Because (($result.results | ConvertTo-Json -Depth 6) + "`nexit=$exitCode")
+        @($result.results | Where-Object passed).Count | Should -Be 4
+        $exitCode | Should -Be 0
+    }
+
+    It 'accepts a valid production deferred-start plan under PowerShell 5.1' {
+        $caseRoot = Join-Path $TestDrive 'task781-ps51-deferred-plan'
+        New-Item -ItemType Directory -Path $caseRoot -Force | Out-Null
+        $childScriptPath = Join-Path $caseRoot 'validate-deferred-plan.ps1'
+        $bridgePath = Join-Path $script:Task781RepoRoot 'scripts\winsmux-core.ps1'
+        $planPath = Join-Path $caseRoot 'deferred-plan.json'
+
+        [System.IO.File]::WriteAllText(
+            $planPath,
+            (([ordered]@{
+                approved_launch  = [ordered]@{ agent = 'codex'; command = @('codex') }
+                ready_marker_path = (Join-Path $caseRoot 'ready.json')
+                agent             = 'codex'
+            }) | ConvertTo-Json -Depth 6),
+            [System.Text.UTF8Encoding]::new($false)
+        )
+
+        $childScript = @'
+param(
+    [Parameter(Mandatory = $true)][string]$BridgePath,
+    [Parameter(Mandatory = $true)][string]$JsonCompatPath,
+    [Parameter(Mandatory = $true)][string]$ProjectDir,
+    [Parameter(Mandatory = $true)][string]$PlanPath
+)
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+
+. $JsonCompatPath
+
+function Get-SendConfigValue {
+    param($InputObject, [string]$Name, $Default = $null)
+    if ($null -eq $InputObject) { return $Default }
+    if ($InputObject -is [System.Collections.IDictionary] -and $InputObject.Contains($Name)) {
+        return $InputObject[$Name]
+    }
+    $property = $InputObject.PSObject.Properties[$Name]
+    if ($null -ne $property) { return $property.Value }
+    return $Default
+}
+function Test-DeferredPaneStartManifestEntry { return $true }
+function Get-WinsmuxRuntimeStatusClassification {
+    [PSCustomObject]@{ NormalizedStatus = 'deferred_starting'; CanStartDeferred = $false; IsStarting = $true }
+}
+function ConvertTo-ReadinessAgentName { param([string]$Agent) return $Agent }
+function Get-WorkersLaunchApprovalDifferences { return @() }
+function Format-WorkersLaunchApprovalMismatch { return 'unexpected mismatch' }
+function Wait-DeferredPaneReady { }
+function Assert-WinsmuxTargetRuntimeWriteAllowed {
+    [PSCustomObject]@{ GenerationId = 'generation-ps51' }
+}
+function Get-PaneControlManifestContext { return $script:ManifestEntry }
+function Wait-PaneControlRuntimeContext {
+    [PSCustomObject]@{ valid = $true; reason_code = ''; diagnostic = '' }
+}
+function Set-DeferredPaneStartStatus {
+    param([string]$Status)
+    $script:LastDeferredStatus = $Status
+}
+
+$content = [System.IO.File]::ReadAllText($BridgePath, [System.Text.Encoding]::UTF8)
+$tokens = $null
+$errors = $null
+$ast = [System.Management.Automation.Language.Parser]::ParseInput(
+    $content,
+    $BridgePath,
+    [ref]$tokens,
+    [ref]$errors
+)
+if ($errors.Count -ne 0) { throw 'bridge UTF-8 parse failed' }
+$function = $ast.Find({
+    param($node)
+    $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+        $node.Name -ceq 'Start-DeferredPaneFromManifestEntry'
+}, $true)
+if ($null -eq $function) { throw 'production deferred-start function not found' }
+. ([scriptblock]::Create($function.Extent.Text))
+
+$script:LastDeferredStatus = ''
+$script:ManifestEntry = [PSCustomObject][ordered]@{
+    Label             = 'worker-1'
+    PaneId            = '%2'
+    Status            = 'deferred_starting'
+    BootstrapPlanPath = $PlanPath
+    CapabilityAdapter = 'codex'
+    ApprovedLaunch    = [PSCustomObject][ordered]@{ agent = 'codex'; command = @('codex') }
+}
+$started = Start-DeferredPaneFromManifestEntry `
+    -ProjectDir $ProjectDir `
+    -ManifestEntry $script:ManifestEntry `
+    -ExpectedGenerationId 'generation-ps51'
+
+[PSCustomObject]@{
+    host_version = $PSVersionTable.PSVersion.ToString()
+    started = $started
+    final_status = $script:LastDeferredStatus
+} | ConvertTo-Json -Compress
+if (-not $started -or $script:LastDeferredStatus -cne 'ready') { exit 1 }
+'@
+        [System.IO.File]::WriteAllText($childScriptPath, $childScript, [System.Text.UTF8Encoding]::new($false))
+        $output = @(& powershell.exe -NoProfile -File $childScriptPath `
+            -BridgePath $bridgePath `
+            -JsonCompatPath (Join-Path $script:Task781RuntimeScriptsDir 'json-compat.ps1') `
+            -ProjectDir $caseRoot `
+            -PlanPath $planPath 2>&1)
+        $exitCode = $LASTEXITCODE
+        $jsonLine = @($output | Where-Object { ([string]$_).TrimStart().StartsWith('{') } | Select-Object -Last 1)
+        $jsonLine.Count | Should -Be 1 -Because (($output | Out-String).Trim())
+        $result = ([string]$jsonLine[0]) | ConvertFrom-Json
+        $result.host_version | Should -Match '^5\.1\.'
+        $result.started | Should -BeTrue -Because (($output | Out-String).Trim())
+        $result.final_status | Should -Be 'ready'
+        $exitCode | Should -Be 0
+    }
+
+    It 'accepts a valid orchestra-start bootstrap marker under PowerShell 5.1' {
+        $caseRoot = Join-Path $TestDrive 'task781-ps51-orchestra-start'
+        New-Item -ItemType Directory -Path $caseRoot -Force | Out-Null
+        $childScriptPath = Join-Path $caseRoot 'validate-orchestra-start.ps1'
+        $childScript = @'
+param(
+    [Parameter(Mandatory = $true)][string]$ScriptsDir,
+    [Parameter(Mandatory = $true)][string]$CaseRoot
+)
+$ErrorActionPreference = 'Stop'
+. (Join-Path $ScriptsDir 'json-compat.ps1')
+$path = Join-Path $ScriptsDir 'orchestra-start.ps1'
+$text = [System.IO.File]::ReadAllText($path, [System.Text.Encoding]::UTF8)
+$tokens = $null
+$errors = $null
+$ast = [System.Management.Automation.Language.Parser]::ParseInput(
+    $text,
+    $path,
+    [ref]$tokens,
+    [ref]$errors
+)
+if ($errors.Count -ne 0) { throw 'orchestra-start UTF-8 parse failed' }
+$function = $ast.Find({
+    param($node)
+    $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+        $node.Name -ceq 'Test-OrchestraBootstrapMarker'
+}, $true)
+if ($null -eq $function) { throw 'orchestra-start marker function not found' }
+. ([scriptblock]::Create($function.Extent.Text))
+
+$markerPath = Join-Path $CaseRoot 'marker.json'
+[System.IO.File]::WriteAllText(
+    $markerPath,
+    (([ordered]@{ launch_dir = $CaseRoot }) | ConvertTo-Json),
+    [System.Text.UTF8Encoding]::new($false)
+)
+$valid = Test-OrchestraBootstrapMarker `
+    -BootstrapMarkerPath $markerPath `
+    -ExpectedLaunchDir $CaseRoot
+[PSCustomObject]@{
+    host_version = $PSVersionTable.PSVersion.ToString()
+    valid = $valid
+} | ConvertTo-Json -Compress
+if (-not $valid) { exit 1 }
+'@
+        [System.IO.File]::WriteAllText($childScriptPath, $childScript, [System.Text.UTF8Encoding]::new($false))
+        $output = @(& powershell.exe -NoProfile -File $childScriptPath `
+            -ScriptsDir $script:Task781RuntimeScriptsDir -CaseRoot $caseRoot 2>&1)
+        $exitCode = $LASTEXITCODE
+        $jsonLine = @($output | Where-Object { ([string]$_).TrimStart().StartsWith('{') } | Select-Object -Last 1)
+        $jsonLine.Count | Should -Be 1 -Because (($output | Out-String).Trim())
+        $result = ([string]$jsonLine[0]) | ConvertFrom-Json
+        $result.host_version | Should -Match '^5\.1\.'
+        $result.valid | Should -BeTrue -Because (($output | Out-String).Trim())
+        $exitCode | Should -Be 0
+    }
+
+    It 'accepts a valid production submission acknowledgement under PowerShell 5.1' {
+        $caseRoot = Join-Path $TestDrive 'task781-ps51-submission-ack'
+        New-Item -ItemType Directory -Path $caseRoot -Force | Out-Null
+        $childScriptPath = Join-Path $caseRoot 'validate-submission-ack.ps1'
+        $projectDir = Join-Path $caseRoot 'project'
+        $submissionContractPath = Join-Path $script:Task781RuntimeScriptsDir 'submission-contract.ps1'
+
+        $childScript = @'
+param(
+    [Parameter(Mandatory = $true)][string]$SubmissionContractPath,
+    [Parameter(Mandatory = $true)][string]$ProjectDir
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+
+. $SubmissionContractPath
+
+function Get-PaneControlManifestEntries {
+    return @([PSCustomObject][ordered]@{
+        Label         = 'worker-1'
+        SlotId        = 'worker-1'
+        PaneId        = '%2'
+        Role          = 'Worker'
+        WorkerRole    = 'worker'
+        WorkerBackend = 'codex'
+        Title         = 'W1 Codex Worker'
+        Status        = 'ready'
+    })
+}
+
+function Test-PaneControlRuntimeContext {
+    return [PSCustomObject][ordered]@{
+        valid       = $true
+        reason_code = 'live_runtime_verified'
+        diagnostic = 'verified by the PS5.1 boundary fixture'
+    }
+}
+
+New-Item -ItemType Directory -Path $ProjectDir -Force | Out-Null
+$submissionId = 'submission-task781-ps51-ack'
+New-WinsmuxSubmissionPacket `
+    -ProjectDir $ProjectDir `
+    -Kind task `
+    -Content ([ordered]@{
+        title = 'TASK781 PS5.1 acknowledgement'
+        request = 'Exercise the production acknowledgement JSON boundary.'
+    }) `
+    -SubmissionId $submissionId `
+    -TargetLabel worker-1 | Out-Null
+
+$receipt = Invoke-WinsmuxSubmissionAcknowledge `
+    -ProjectDir $ProjectDir `
+    -SlotId worker-1 `
+    -SubmissionId $submissionId `
+    -RunId $submissionId `
+    -Kind task `
+    -Backend codex
+
+[PSCustomObject][ordered]@{
+    host_version = $PSVersionTable.PSVersion.ToString()
+    status       = [string]$receipt.status
+    reason_code  = [string]$receipt.reason_code
+} | ConvertTo-Json -Compress
+if ([string]$receipt.status -cne 'accepted') { exit 1 }
+'@
+        [System.IO.File]::WriteAllText($childScriptPath, $childScript, [System.Text.UTF8Encoding]::new($false))
+
+        $output = @(& powershell.exe -NoProfile -File $childScriptPath `
+            -SubmissionContractPath $submissionContractPath -ProjectDir $projectDir 2>&1)
+        $exitCode = $LASTEXITCODE
+        $jsonLine = @($output | Where-Object { ([string]$_).TrimStart().StartsWith('{') } | Select-Object -Last 1)
+        $jsonLine.Count | Should -Be 1 -Because (($output | Out-String).Trim())
+        $result = ([string]$jsonLine[0]) | ConvertFrom-Json
+
+        $result.host_version | Should -Match '^5\.1\.'
+        $result.status | Should -Be 'accepted' -Because (($output | Out-String).Trim())
+        $result.reason_code | Should -Be ''
+        $exitCode | Should -Be 0
+    }
+
+    It 'has no PS5.1-incompatible native JSON parameters outside the shared boundary' {
+        $productionPaths = @(
+            (Join-Path $script:Task781RepoRoot 'scripts\winsmux-core.ps1')
+            (Get-ChildItem -LiteralPath $script:Task781RuntimeScriptsDir -Filter '*.ps1' -File |
+                Select-Object -ExpandProperty FullName)
+        )
+        $incompatible = [System.Collections.Generic.List[string]]::new()
+        foreach ($path in $productionPaths) {
+            $content = [System.IO.File]::ReadAllText($path, [System.Text.Encoding]::UTF8)
+            $tokens = $null
+            $parseErrors = $null
+            $ast = [System.Management.Automation.Language.Parser]::ParseInput(
+                $content,
+                $path,
+                [ref]$tokens,
+                [ref]$parseErrors
+            )
+            @($parseErrors).Count | Should -Be 0 -Because $path
+            foreach ($command in @($ast.FindAll({
+                param($node)
+                $node -is [System.Management.Automation.Language.CommandAst] -and
+                    $node.GetCommandName() -ceq 'ConvertFrom-Json'
+            }, $true))) {
+                $unsupported = @($command.CommandElements |
+                    Where-Object {
+                        $_ -is [System.Management.Automation.Language.CommandParameterAst] -and
+                        $_.ParameterName -in @('Depth', 'AsHashtable')
+                    })
+                if ($unsupported.Count -gt 0) {
+                    $incompatible.Add(('{0}:{1}' -f $path, $command.Extent.StartLineNumber)) | Out-Null
+                }
+            }
+        }
+        @($incompatible) | Should -Be @()
+
+        $submissionContent = [System.IO.File]::ReadAllText(
+            (Join-Path $script:Task781RuntimeScriptsDir 'submission-contract.ps1'),
+            [System.Text.Encoding]::UTF8
+        )
+        $submissionContent | Should -Not -Match '\|\s*ConvertFrom-Json'
+        $submissionContent | Should -Match 'ConvertFrom-WinsmuxJson -Depth 16'
+    }
+
+    It 'uses explicit ordinal equality for every production generation identity comparison' {
+        $productionPaths = @(
+            (Join-Path $script:Task781RepoRoot 'scripts\winsmux-core.ps1')
+            (Get-ChildItem -LiteralPath $script:Task781RuntimeScriptsDir -Filter '*.ps1' -File |
+                Select-Object -ExpandProperty FullName)
+        )
+        $implicitComparisons = [System.Collections.Generic.List[string]]::new()
+        foreach ($path in $productionPaths) {
+            $content = [System.IO.File]::ReadAllText($path, [System.Text.Encoding]::UTF8)
+            $tokens = $null
+            $parseErrors = $null
+            $ast = [System.Management.Automation.Language.Parser]::ParseInput(
+                $content,
+                $path,
+                [ref]$tokens,
+                [ref]$parseErrors
+            )
+            @($parseErrors).Count | Should -Be 0 -Because $path
+            foreach ($comparison in @($ast.FindAll({
+                param($node)
+                $node -is [System.Management.Automation.Language.BinaryExpressionAst] -and
+                    $node.Operator -in @('Ieq', 'Ceq', 'Ine', 'Cne') -and
+                    $node.Extent.Text -match '(?i)generation'
+            }, $true))) {
+                $implicitComparisons.Add(('{0}:{1}:{2}' -f
+                    $path,
+                    $comparison.Extent.StartLineNumber,
+                    $comparison.Extent.Text.Trim())) | Out-Null
+            }
+        }
+
+        @($implicitComparisons) | Should -Be @() `
+            -Because 'generation IDs are exact identity tokens and must use StringComparison.Ordinal'
+    }
+
+    It 'provides nested hashtables through the shared JSON boundary on PowerShell 5.1' {
+        $jsonCompatPath = Join-Path $script:Task781RuntimeScriptsDir 'json-compat.ps1'
+        $childScriptPath = Join-Path $TestDrive 'validate-json-compat.ps1'
+        $childScript = @'
+param([string]$JsonCompatPath)
+. $JsonCompatPath
+$value = '{"outer":{"items":[{"name":"one"}]}}' | ConvertFrom-WinsmuxJson -AsHashtable -Depth 8
+[PSCustomObject]@{
+    host = $PSVersionTable.PSVersion.ToString()
+    root_dictionary = ($value -is [System.Collections.IDictionary])
+    nested_dictionary = ($value['outer'] -is [System.Collections.IDictionary])
+    name = [string]$value['outer']['items'][0]['name']
+} | ConvertTo-Json -Compress
+'@
+        [System.IO.File]::WriteAllText($childScriptPath, $childScript, [System.Text.UTF8Encoding]::new($false))
+        $output = @(& powershell.exe -NoProfile -File $childScriptPath -JsonCompatPath $jsonCompatPath 2>&1)
+        $exitCode = $LASTEXITCODE
+        $jsonLine = @($output | Where-Object { ([string]$_).TrimStart().StartsWith('{') } | Select-Object -Last 1)
+        $jsonLine.Count | Should -Be 1 -Because (($output | Out-String).Trim())
+        $result = ([string]$jsonLine[0]) | ConvertFrom-Json
+        $result.host | Should -Match '^5\.1\.'
+        $result.root_dictionary | Should -BeTrue
+        $result.nested_dictionary | Should -BeTrue
+        $result.name | Should -Be 'one'
+        $exitCode | Should -Be 0
+    }
+
+    It 'loads orchestra-start Vault preflight through the modular native type in a fresh process' {
+        $caseRoot = Join-Path $TestDrive 'task781-fresh-vault-preflight'
+        New-Item -ItemType Directory -Path $caseRoot -Force | Out-Null
+        $childScriptPath = Join-Path $caseRoot 'fresh-vault-preflight.ps1'
+        $childScript = @'
+param([Parameter(Mandatory = $true)][string]$ScriptsDir)
+$ErrorActionPreference = 'Stop'
+. (Join-Path $ScriptsDir 'orchestra-start.ps1')
+
+if (-not ('Task781VaultCleanupNative' -as [type])) {
+    Add-Type -TypeDefinition @"
+using System.Runtime.InteropServices;
+
+public static class Task781VaultCleanupNative {
+    [DllImport("advapi32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    public static extern bool CredDelete(string target, uint type, uint flags);
+}
+"@
+}
+
+$key = 'winsmux-test:task781-fresh-{0}' -f [guid]::NewGuid().ToString('N')
+$target = 'winsmux:{0}' -f $key
+$before = Test-VaultKeyExists -Key $key
+$afterSet = $false
+$deleted = $false
+try {
+    Set-VaultKey -Key $key -Value 'fresh-process-value'
+    $afterSet = Test-VaultKeyExists -Key $key
+} finally {
+    $deleted = [Task781VaultCleanupNative]::CredDelete($target, 1, 0)
+}
+$afterDelete = Test-VaultKeyExists -Key $key
+
+[PSCustomObject]@{
+    modular_type = ('WinsmuxVaultCredentialNative' -as [type]).FullName
+    legacy_type_absent = ($null -eq ('WinCred' -as [type]))
+    before = $before
+    after_set = $afterSet
+    deleted = $deleted
+    after_delete = $afterDelete
+} | ConvertTo-Json -Compress
+'@
+        [System.IO.File]::WriteAllText($childScriptPath, $childScript, [System.Text.UTF8Encoding]::new($false))
+
+        $output = @(& pwsh.exe -NoProfile -File $childScriptPath -ScriptsDir $script:Task781RuntimeScriptsDir 2>&1)
+        $exitCode = $LASTEXITCODE
+        $jsonLine = @($output | Where-Object { ([string]$_).TrimStart().StartsWith('{') } | Select-Object -Last 1)
+        $jsonLine.Count | Should -Be 1 -Because (($output | Out-String).Trim())
+        $result = ([string]$jsonLine[0]) | ConvertFrom-Json
+        $result.modular_type | Should -Be 'WinsmuxVaultCredentialNative'
+        $result.legacy_type_absent | Should -BeTrue
+        $result.before | Should -BeFalse
+        $result.after_set | Should -BeTrue
+        $result.deleted | Should -BeTrue
+        $result.after_delete | Should -BeFalse
+        $exitCode | Should -Be 0
+    }
+
+    It 'enumerates Vault names through a metadata-only boundary' {
+        $metadataPath = Join-Path $script:Task781RuntimeScriptsDir 'credential-metadata.ps1'
+        . $metadataPath
+        Mock Invoke-WinsmuxCredentialMetadataCommand {
+            @(
+                'Target: LegacyGeneric:target=winsmux:BETA'
+                'ターゲット: LegacyGeneric:target=winsmux:ALPHA'
+                'User: private-user'
+                'Target: LegacyGeneric:target=other:IGNORED'
+            )
+        }
+        @(Get-WinsmuxCredentialTargetNames) | Should -Be @('ALPHA', 'BETA')
+
+        $metadataContent = [System.IO.File]::ReadAllText($metadataPath, [System.Text.Encoding]::UTF8)
+        $metadataContent | Should -Not -Match 'CredEnumerate|CredRead|CredentialBlob'
+
+        $bridgePath = Join-Path $script:Task781RepoRoot 'scripts\winsmux-core.ps1'
+        $bridgeContent = [System.IO.File]::ReadAllText($bridgePath, [System.Text.Encoding]::UTF8)
+        $tokens = $null
+        $parseErrors = $null
+        $bridgeAst = [System.Management.Automation.Language.Parser]::ParseInput(
+            $bridgeContent,
+            $bridgePath,
+            [ref]$tokens,
+            [ref]$parseErrors
+        )
+        $nameReader = $bridgeAst.Find({
+            param($node)
+            $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+                $node.Name -ceq 'Get-WinsmuxVaultCredentialNamesInternal'
+        }, $true)
+        $nameReader.Extent.Text | Should -Match 'Get-WinsmuxCredentialTargetNames'
+        $nameReader.Extent.Text | Should -Not -Match 'CredEnumerate|CredRead|CredentialBlob'
+
+        $vaultModulePath = Join-Path $script:Task781RuntimeScriptsDir 'vault.ps1'
+        $vaultModuleContent = [System.IO.File]::ReadAllText($vaultModulePath, [System.Text.Encoding]::UTF8)
+        $vaultModuleContent | Should -Not -Match 'CredEnumerate|CredentialBlob.*foreach|foreach.*CredentialBlob'
+        $vaultTokens = $null
+        $vaultParseErrors = $null
+        $vaultAst = [System.Management.Automation.Language.Parser]::ParseInput(
+            $vaultModuleContent,
+            $vaultModulePath,
+            [ref]$vaultTokens,
+            [ref]$vaultParseErrors
+        )
+        $vaultInject = $vaultAst.Find({
+            param($node)
+            $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+                $node.Name -ceq 'Invoke-VaultInject'
+        }, $true)
+        $vaultInject.Extent.Text | Should -Match 'Get-WinsmuxCredentialTargetNames'
+        $vaultInject.Extent.Text | Should -Match '(?s)foreach.*credentialNames'
+        $vaultInject.Extent.Text | Should -Match 'Get-WinsmuxVaultCredentialValue'
+    }
+}

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -2345,6 +2345,42 @@ Describe 'Vault helpers' {
         }
 
         . (Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\vault.ps1')
+
+        if (-not ('WinsmuxVaultTestCleanupNative' -as [type])) {
+            Add-Type -TypeDefinition @'
+using System;
+using System.Runtime.InteropServices;
+
+public static class WinsmuxVaultTestCleanupNative {
+    [DllImport("advapi32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    public static extern bool CredEnumerate(string filter, uint flags, out int count, out IntPtr credentials);
+
+    [DllImport("advapi32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    public static extern bool CredDelete(string target, uint type, uint flags);
+
+    [DllImport("advapi32.dll", SetLastError = true)]
+    public static extern bool CredFree(IntPtr credential);
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    public struct CREDENTIAL {
+        public uint Flags;
+        public uint Type;
+        public string TargetName;
+        public string Comment;
+        public System.Runtime.InteropServices.ComTypes.FILETIME LastWritten;
+        public int CredentialBlobSize;
+        public IntPtr CredentialBlob;
+        public uint Persist;
+        public int AttributeCount;
+        public IntPtr Attributes;
+        public string TargetAlias;
+        public string UserName;
+    }
+
+    public const uint CRED_TYPE_GENERIC = 1;
+}
+'@ -ErrorAction Stop
+        }
     }
 
     BeforeEach {
@@ -2363,17 +2399,17 @@ Describe 'Vault helpers' {
         $count = 0
         $credsPtr = [IntPtr]::Zero
 
-        $ok = [WinCred]::CredEnumerate($filter, 0, [ref]$count, [ref]$credsPtr)
+        $ok = [WinsmuxVaultTestCleanupNative]::CredEnumerate($filter, 0, [ref]$count, [ref]$credsPtr)
         if ($ok) {
             try {
                 $ptrSize = [Runtime.InteropServices.Marshal]::SizeOf([Type][IntPtr])
                 for ($i = 0; $i -lt $count; $i++) {
                     $entryPtr = [Runtime.InteropServices.Marshal]::ReadIntPtr($credsPtr, $i * $ptrSize)
-                    $cred = [Runtime.InteropServices.Marshal]::PtrToStructure($entryPtr, [Type][WinCred+CREDENTIAL])
-                    [WinCred]::CredDelete($cred.TargetName, [WinCred]::CRED_TYPE_GENERIC, 0) | Out-Null
+                    $cred = [Runtime.InteropServices.Marshal]::PtrToStructure($entryPtr, [Type][WinsmuxVaultTestCleanupNative+CREDENTIAL])
+                    [WinsmuxVaultTestCleanupNative]::CredDelete($cred.TargetName, [WinsmuxVaultTestCleanupNative]::CRED_TYPE_GENERIC, 0) | Out-Null
                 }
             } finally {
-                [WinCred]::CredFree($credsPtr) | Out-Null
+                [WinsmuxVaultTestCleanupNative]::CredFree($credsPtr) | Out-Null
             }
         }
 
@@ -3030,6 +3066,1796 @@ Describe 'manifest worker isolation metadata' {
     }
 }
 
+Describe 'TASK781 runtime identity registry' {
+    BeforeAll {
+        . (Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\manifest.ps1')
+
+        function New-Task781RuntimeFixture {
+            $supervisorStart = '2026-07-15T00:00:00.0000000Z'
+            $bootstrapStart = '2026-07-15T00:00:01.0000000Z'
+            return [PSCustomObject]@{
+                Manifest = [PSCustomObject]@{
+                    version = 2
+                    session = [PSCustomObject]@{
+                        name              = 'winsmux-task781-test'
+                        generation_id     = 'generation-1'
+                        server_session_id = '$9'
+                        bootstrap_pane_id = '%1'
+                        expected_pane_count = 1
+                        session_ready     = $true
+                    }
+                    panes = [ordered]@{
+                        'worker-1' = [ordered]@{
+                            slot_id        = 'worker-1'
+                            pane_id        = '%2'
+                            worker_backend = 'codex'
+                            worker_role    = 'reviewer'
+                            role           = 'Reviewer'
+                            title          = 'W1 Codex Reviewer'
+                            status         = 'ready'
+                        }
+                    }
+                }
+                Registry = [PSCustomObject]@{
+                    schema_version    = 1
+                    status            = 'active'
+                    session_name      = 'winsmux-task781-test'
+                    generation_id     = 'generation-1'
+                    server_session_id = '$9'
+                    bootstrap_pane_id = '%1'
+                    supervisor        = [PSCustomObject]@{
+                        pid                = 4100
+                        process_started_at = $supervisorStart
+                    }
+                    lease = [PSCustomObject]@{
+                        state      = 'active'
+                        expires_at = '2026-07-15T00:10:00.0000000Z'
+                    }
+                    expected_pane_count = 1
+                    panes = @(
+                        [PSCustomObject]@{
+                            label                        = 'worker-1'
+                            slot_id                      = 'worker-1'
+                            pane_id                      = '%2'
+                            backend                      = 'codex'
+                            role                         = 'reviewer'
+                            title                        = 'W1 Codex Reviewer'
+                            state                        = 'live'
+                            bootstrap_pid                = 4200
+                            bootstrap_process_started_at = $bootstrapStart
+                        }
+                    )
+                }
+                Entry = [PSCustomObject]@{
+                    Label         = 'worker-1'
+                    SlotId        = 'worker-1'
+                    PaneId        = '%2'
+                    WorkerBackend = 'codex'
+                    WorkerRole    = 'reviewer'
+                    Role          = 'Reviewer'
+                    Title         = 'W1 Codex Reviewer'
+                    Status        = 'ready'
+                }
+                Marker = [PSCustomObject]@{
+                    generation_id             = 'generation-1'
+                    server_session_id         = '$9'
+                    slot_id                   = 'worker-1'
+                    pane_id                   = '%2'
+                    backend                   = 'codex'
+                    role                      = 'reviewer'
+                    title                     = 'W1 Codex Reviewer'
+                    bootstrap_pid             = 4200
+                    bootstrap_process_started_at = $bootstrapStart
+                }
+                Caller = [PSCustomObject]@{
+                    process_id                   = 4300
+                    process_started_at           = '2026-07-15T00:00:02.0000000Z'
+                    generation_id                = 'generation-1'
+                    server_session_id            = '$9'
+                    slot_id                      = 'worker-1'
+                    pane_id                      = '%2'
+                    backend                      = 'codex'
+                    ancestry                     = @(
+                        [PSCustomObject]@{ pid = 4300; process_started_at = '2026-07-15T00:00:02.0000000Z' }
+                        [PSCustomObject]@{ pid = 4200; process_started_at = $bootstrapStart }
+                    )
+                }
+                ObservedPanes = @(
+                    [PSCustomObject]@{ pane_id = '%2'; title = 'W1 Codex Reviewer' }
+                    [PSCustomObject]@{ pane_id = '%1'; title = 'winsmux-orchestra-bootstrap' }
+                )
+                ProcessResolver = {
+                    param([int]$Id)
+                    switch ($Id) {
+                        4100 { return [PSCustomObject]@{ Id = 4100; StartTime = [datetime]'2026-07-15T00:00:00Z'; ParentProcessId = 1; Name = 'pwsh.exe' } }
+                        4200 { return [PSCustomObject]@{ Id = 4200; StartTime = [datetime]'2026-07-15T00:00:01Z'; ParentProcessId = 1; Name = 'pwsh.exe' } }
+                        4300 { return [PSCustomObject]@{ Id = 4300; StartTime = [datetime]'2026-07-15T00:00:02Z'; ParentProcessId = 4200; Name = 'codex.exe' } }
+                        default { return $null }
+                    }
+                }
+            }
+        }
+
+        function Invoke-Task781RuntimeFixture {
+            param(
+                [Parameter(Mandatory = $true)]$Fixture,
+                [ValidateSet('dispatch', 'start_deferred', 'caller_ack', 'stop_transition')][string]$Operation = 'dispatch'
+            )
+
+            return Test-WinsmuxRuntimeContext -Manifest $Fixture.Manifest -Registry $Fixture.Registry `
+                -ObservedServerSessionId '$9' -ObservedPanes $Fixture.ObservedPanes `
+                -ManifestEntry $Fixture.Entry -PaneMarker $Fixture.Marker `
+                -CallerIdentity $Fixture.Caller -ProcessResolver $Fixture.ProcessResolver `
+                -Operation $Operation -Now ([datetime]'2026-07-15T00:05:00Z')
+        }
+
+        function Add-Task781UnrelatedRuntimeSlot {
+            param([Parameter(Mandatory = $true)]$Fixture)
+
+            $Fixture.Manifest.panes['worker-2'] = [ordered]@{
+                slot_id        = 'worker-2'
+                pane_id        = '%3'
+                worker_backend = 'api_llm'
+                worker_role    = 'worker'
+                role           = 'Worker'
+                title          = 'W2 API Worker'
+                status         = 'ready'
+            }
+            $Fixture.Registry.panes += [PSCustomObject]@{
+                label                        = 'worker-2'
+                slot_id                      = 'worker-2'
+                pane_id                      = '%3'
+                backend                      = 'api_llm'
+                role                         = 'worker'
+                title                        = 'W2 API Worker'
+                state                        = 'live'
+                bootstrap_pid                = 4400
+                bootstrap_process_started_at = '2026-07-15T00:00:04.0000000Z'
+            }
+            $Fixture.ObservedPanes += [PSCustomObject]@{ pane_id = '%3'; title = 'W2 API Worker' }
+            $Fixture.Manifest.session.expected_pane_count = 2
+            $Fixture.Registry.expected_pane_count = 2
+            return $Fixture
+        }
+    }
+
+    BeforeEach {
+        $script:task781TempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('winsmux-task781-' + [guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path (Join-Path $script:task781TempRoot '.winsmux') -Force | Out-Null
+    }
+
+    AfterEach {
+        if ($script:task781TempRoot -and (Test-Path -LiteralPath $script:task781TempRoot)) {
+            Remove-Item -LiteralPath $script:task781TempRoot -Recurse -Force
+        }
+    }
+
+    It 'TASK781 refuses invalid supervisor identity' {
+        $fixture = New-Task781RuntimeFixture
+        $fixture.Registry.supervisor.process_started_at = '2026-07-15T00:00:05.0000000Z'
+
+        $result = Test-WinsmuxRuntimeContext -Manifest $fixture.Manifest -Registry $fixture.Registry `
+            -ObservedServerSessionId '$9' -ManifestEntry $fixture.Entry -PaneMarker $fixture.Marker `
+            -CallerIdentity $fixture.Caller -ObservedPanes $fixture.ObservedPanes -ProcessResolver $fixture.ProcessResolver `
+            -Operation caller_ack -Now ([datetime]'2026-07-15T00:05:00Z')
+
+        $result.valid | Should -BeFalse
+        $result.reason_code | Should -Be 'invalid_supervisor_identity'
+    }
+
+    It 'TASK781 requires manifest regeneration for unverified or stale session' {
+        $fixture = New-Task781RuntimeFixture
+        $fixture.Manifest.version = 1
+
+        $result = Test-WinsmuxRuntimeContext -Manifest $fixture.Manifest -Registry $fixture.Registry `
+            -ObservedServerSessionId '$9' -ManifestEntry $fixture.Entry -PaneMarker $fixture.Marker `
+            -CallerIdentity $fixture.Caller -ObservedPanes $fixture.ObservedPanes -ProcessResolver $fixture.ProcessResolver `
+            -Now ([datetime]'2026-07-15T00:05:00Z')
+
+        $result.valid | Should -BeFalse
+        $result.reason_code | Should -Be 'manifest_regeneration_required'
+    }
+
+    It 'TASK781 refuses mismatched runtime target before deferred start' {
+        $fixture = New-Task781RuntimeFixture
+        $fixture.Registry.panes[0].backend = 'api_llm'
+
+        $result = Test-WinsmuxRuntimeContext -Manifest $fixture.Manifest -Registry $fixture.Registry `
+            -ObservedServerSessionId '$9' -ManifestEntry $fixture.Entry -PaneMarker $fixture.Marker `
+            -CallerIdentity $fixture.Caller -ObservedPanes $fixture.ObservedPanes -ProcessResolver $fixture.ProcessResolver `
+            -Now ([datetime]'2026-07-15T00:05:00Z')
+
+        $result.valid | Should -BeFalse
+        $result.reason_code | Should -Be 'runtime_target_mismatch'
+    }
+
+    It 'TASK781 C42 refuses a consistently incomplete runtime pane set' {
+        $fixture = New-Task781RuntimeFixture
+        $fixture.Manifest.session.expected_pane_count = 6
+        $fixture.Registry.expected_pane_count = 6
+
+        $result = Invoke-Task781RuntimeFixture -Fixture $fixture
+
+        $result.valid | Should -BeFalse
+        $result.reason_code | Should -Be 'runtime_target_mismatch'
+        $result.diagnostic | Should -Match 'pane sets do not match exactly'
+    }
+
+    It 'TASK781 C42 requires matching authoritative expected pane counts for <Mode>' -ForEach @(
+        @{ Mode = 'missing_manifest_count' }
+        @{ Mode = 'registry_count_mismatch' }
+    ) {
+        $fixture = New-Task781RuntimeFixture
+        if ($Mode -eq 'missing_manifest_count') {
+            $fixture.Manifest.session.PSObject.Properties.Remove('expected_pane_count')
+        } else {
+            $fixture.Registry.expected_pane_count = 2
+        }
+
+        $result = Invoke-Task781RuntimeFixture -Fixture $fixture
+
+        $result.valid | Should -BeFalse
+        $result.reason_code | Should -Be 'manifest_regeneration_required'
+    }
+
+    It 'TASK781 refuses spoofed local or Codex caller' {
+        $fixture = New-Task781RuntimeFixture
+        $fixture.Caller.process_id = 4999
+
+        $result = Test-WinsmuxRuntimeContext -Manifest $fixture.Manifest -Registry $fixture.Registry `
+            -ObservedServerSessionId '$9' -ManifestEntry $fixture.Entry -PaneMarker $fixture.Marker `
+            -CallerIdentity $fixture.Caller -ObservedPanes $fixture.ObservedPanes -ProcessResolver $fixture.ProcessResolver `
+            -Operation caller_ack -Now ([datetime]'2026-07-15T00:05:00Z')
+
+        $result.valid | Should -BeFalse
+        $result.reason_code | Should -Be 'caller_identity_mismatch'
+    }
+
+    It 'TASK781 accepts fully matched live runtime context' {
+        $fixture = New-Task781RuntimeFixture
+
+        $result = Test-WinsmuxRuntimeContext -Manifest $fixture.Manifest -Registry $fixture.Registry `
+            -ObservedServerSessionId '$9' -ManifestEntry $fixture.Entry -PaneMarker $fixture.Marker `
+            -CallerIdentity $fixture.Caller -ObservedPanes $fixture.ObservedPanes -ProcessResolver $fixture.ProcessResolver `
+            -Now ([datetime]'2026-07-15T00:05:00Z')
+
+        $result.valid | Should -BeTrue
+        $result.reason_code | Should -Be 'live_runtime_verified'
+        $result.context.pane_id | Should -Be '%2'
+        $result.context.generation_id | Should -Be 'generation-1'
+    }
+
+    It 'TASK781 C46 authorizes an intentional stop transition without the terminated bootstrap process' {
+        $fixture = New-Task781RuntimeFixture
+        $fixture.ProcessResolver = {
+            param([int]$Id)
+            if ($Id -eq 4100) {
+                return [PSCustomObject]@{ Id = 4100; StartTime = [datetime]'2026-07-15T00:00:00Z'; ParentProcessId = 1; Name = 'pwsh.exe' }
+            }
+            return $null
+        }
+
+        $transition = Invoke-Task781RuntimeFixture -Fixture $fixture -Operation stop_transition
+        $dispatch = Invoke-Task781RuntimeFixture -Fixture $fixture -Operation dispatch
+
+        $transition.valid | Should -BeTrue
+        $transition.reason_code | Should -Be 'stop_transition_verified'
+        $transition.context.generation_id | Should -Be 'generation-1'
+        $dispatch.valid | Should -BeFalse
+        $dispatch.reason_code | Should -Be 'runtime_target_mismatch'
+    }
+
+    It 'TASK781 C49 rejects duplicate v2 pane labels' {
+        $content = @'
+version: 2
+saved_at: '2026-07-15T00:00:00Z'
+session:
+  name: 'winsmux-orchestra'
+panes:
+  worker-1:
+    pane_id: '%2'
+  worker-1:
+    pane_id: '%3'
+'@
+
+        { ConvertFrom-ManifestYaml -Content $content } | Should -Throw '*duplicate*panes.worker-1*'
+    }
+
+    It 'TASK781 C49 rejects duplicate v2 pane identity properties' {
+        $content = @'
+version: 2
+saved_at: '2026-07-15T00:00:00Z'
+session:
+  name: 'winsmux-orchestra'
+panes:
+  worker-1:
+    pane_id: '%2'
+    pane_id: '%3'
+'@
+
+        { ConvertFrom-ManifestYaml -Content $content } | Should -Throw '*duplicate*panes.worker-1.pane_id*'
+    }
+
+    It 'TASK781 C58 rejects case-variant v2 duplicate <Case>' -ForEach @(
+        @{
+            Case = 'top-level section'
+            Content = @'
+version: 2
+session:
+  name: winsmux-orchestra
+Session:
+  generation_id: generation-58
+'@
+        }
+        @{
+            Case = 'session property'
+            Content = @'
+version: 2
+session:
+  name: winsmux-orchestra
+  Name: overwritten
+'@
+        }
+        @{
+            Case = 'pane label'
+            Content = @'
+version: 2
+panes:
+  worker-1:
+    pane_id: '%2'
+  Worker-1:
+    pane_id: '%3'
+'@
+        }
+        @{
+            Case = 'pane property'
+            Content = @'
+version: 2
+panes:
+  worker-1:
+    pane_id: '%2'
+    PANE_ID: '%3'
+'@
+        }
+        @{
+            Case = 'worktree label'
+            Content = @'
+version: 2
+worktrees:
+  worker-1:
+    path: C:\repo\one
+  Worker-1:
+    path: C:\repo\two
+'@
+        }
+        @{
+            Case = 'worktree property'
+            Content = @'
+version: 2
+worktrees:
+  worker-1:
+    path: C:\repo\one
+    PATH: C:\repo\two
+'@
+        }
+    ) {
+        { ConvertFrom-ManifestYaml -Content $Content } | Should -Throw '*duplicate manifest key*'
+    }
+
+    It 'TASK781 C58 preserves case-insensitive last-value parsing for legacy v1 diagnostics' {
+        $content = @'
+version: 1
+panes:
+  worker-1:
+    pane_id: '%2'
+    PANE_ID: '%3'
+'@
+
+        $legacy = ConvertFrom-ManifestYaml -Content $content
+
+        $legacy.version | Should -Be 1
+        $legacy.panes['worker-1'].pane_id | Should -Be '%3'
+    }
+
+    It 'TASK781 C49 preserves v1 diagnostic parsing when a legacy property is duplicated' {
+        $content = @'
+version: 1
+saved_at: '2026-07-15T00:00:00Z'
+session:
+  name: 'winsmux-orchestra'
+panes:
+  worker-1:
+    pane_id: '%2'
+    pane_id: '%3'
+'@
+
+        $legacy = ConvertFrom-ManifestYaml -Content $content
+
+        $legacy.version | Should -Be 1
+        $legacy.panes['worker-1'].pane_id | Should -Be '%3'
+    }
+
+    It 'TASK781 enforces the full desired runtime and observed pane set for <Mode>' -ForEach @(
+        @{ Mode = 'registry_missing' }
+        @{ Mode = 'registry_extra' }
+        @{ Mode = 'backend_drift' }
+        @{ Mode = 'role_drift' }
+        @{ Mode = 'title_drift' }
+        @{ Mode = 'pane_drift' }
+        @{ Mode = 'observed_missing' }
+        @{ Mode = 'observed_extra' }
+        @{ Mode = 'observed_title_drift' }
+        @{ Mode = 'bootstrap_missing' }
+        @{ Mode = 'bootstrap_duplicate' }
+        @{ Mode = 'canonical' }
+    ) {
+        $fixture = Add-Task781UnrelatedRuntimeSlot -Fixture (New-Task781RuntimeFixture)
+        switch ($Mode) {
+            'registry_missing'     { $fixture.Registry.panes = @($fixture.Registry.panes[0]) }
+            'registry_extra'       {
+                $extra = $fixture.Registry.panes[1].PSObject.Copy()
+                $extra.label = 'worker-3'; $extra.slot_id = 'worker-3'; $extra.pane_id = '%4'
+                $fixture.Registry.panes += $extra
+            }
+            'backend_drift'        { $fixture.Registry.panes[1].backend = 'codex' }
+            'role_drift'           { $fixture.Registry.panes[1].role = 'reviewer' }
+            'title_drift'          { $fixture.Registry.panes[1].title = 'wrong title' }
+            'pane_drift'           { $fixture.Registry.panes[1].pane_id = '%7' }
+            'observed_missing'     { $fixture.ObservedPanes = @($fixture.ObservedPanes[0]) }
+            'observed_extra'       { $fixture.ObservedPanes += [PSCustomObject]@{ pane_id = '%9'; title = 'unexpected pane' } }
+            'observed_title_drift' { @($fixture.ObservedPanes | Where-Object pane_id -EQ '%3')[0].title = 'wrong title' }
+            'bootstrap_missing'    { $fixture.ObservedPanes = @($fixture.ObservedPanes | Where-Object pane_id -NE '%1') }
+            'bootstrap_duplicate'  { $fixture.ObservedPanes += [PSCustomObject]@{ pane_id = '%1'; title = 'duplicate bootstrap' } }
+        }
+
+        $result = Invoke-Task781RuntimeFixture -Fixture $fixture
+        if ($Mode -eq 'canonical') {
+            $result.valid | Should -BeTrue
+            $result.reason_code | Should -Be 'live_runtime_verified'
+        } else {
+            $result.valid | Should -BeFalse
+            $result.reason_code | Should -Be 'runtime_target_mismatch'
+        }
+    }
+
+    It 'TASK781 requires matching manifest and registry bootstrap pane identity' {
+        $fixture = New-Task781RuntimeFixture
+        $fixture.Registry.bootstrap_pane_id = '%8'
+
+        $result = Invoke-Task781RuntimeFixture -Fixture $fixture
+
+        $result.valid | Should -BeFalse
+        $result.reason_code | Should -Be 'manifest_regeneration_required'
+    }
+
+    It 'TASK781 preserves a verified v2 manifest against <Mode> replacement' -ForEach @(
+        @{ Mode = 'schema_downgrade' }
+        @{ Mode = 'generation_drift' }
+    ) {
+        $current = (New-Task781RuntimeFixture).Manifest
+        Save-WinsmuxManifest -ProjectDir $script:task781TempRoot -Manifest $current
+        $path = Get-ManifestPath -ProjectDir $script:task781TempRoot
+        $before = (Get-FileHash -LiteralPath $path -Algorithm SHA256).Hash
+        $replacement = ConvertFrom-ManifestYaml -Content (ConvertTo-ManifestYaml -Manifest $current)
+        if ($Mode -eq 'schema_downgrade') {
+            $replacement.version = 1
+        } else {
+            $replacement.session.generation_id = 'generation-stale'
+        }
+
+        { Save-WinsmuxManifest -ProjectDir $script:task781TempRoot -Manifest $replacement } | Should -Throw '*Refusing to replace a verified v2 runtime manifest*'
+
+        (Get-FileHash -LiteralPath $path -Algorithm SHA256).Hash | Should -Be $before
+        (Get-WinsmuxManifest -ProjectDir $script:task781TempRoot).version | Should -Be 2
+    }
+
+    It 'TASK781 refuses a missing supervisor process' {
+        $fixture = New-Task781RuntimeFixture
+        $fixture.Registry.supervisor.pid = 4999
+
+        $result = Invoke-Task781RuntimeFixture -Fixture $fixture -Operation caller_ack
+
+        $result.valid | Should -BeFalse
+        $result.reason_code | Should -Be 'invalid_supervisor_identity'
+    }
+
+    It 'TASK781 refuses missing or malformed supervisor StartTime' -ForEach @('', 'not-a-time') {
+        $fixture = New-Task781RuntimeFixture
+        $fixture.Registry.supervisor.process_started_at = $_
+
+        $result = Invoke-Task781RuntimeFixture -Fixture $fixture -Operation caller_ack
+
+        $result.valid | Should -BeFalse
+        $result.reason_code | Should -Be 'invalid_supervisor_identity'
+    }
+
+    It 'TASK781 refuses an expired supervisor lease' {
+        $fixture = New-Task781RuntimeFixture
+        $fixture.Registry.lease.expires_at = '2026-07-15T00:04:59.0000000Z'
+
+        $result = Invoke-Task781RuntimeFixture -Fixture $fixture -Operation caller_ack
+
+        $result.valid | Should -BeFalse
+        $result.reason_code | Should -Be 'invalid_supervisor_identity'
+    }
+
+    It 'TASK781 requires regeneration when the registry is missing' {
+        $fixture = New-Task781RuntimeFixture
+        $fixture.Registry = $null
+
+        $result = Invoke-Task781RuntimeFixture -Fixture $fixture -Operation caller_ack
+
+        $result.valid | Should -BeFalse
+        $result.reason_code | Should -Be 'manifest_regeneration_required'
+    }
+
+    It 'TASK781 requires regeneration for a stale generation' {
+        $fixture = New-Task781RuntimeFixture
+        $fixture.Registry.generation_id = 'generation-old'
+
+        $result = Invoke-Task781RuntimeFixture -Fixture $fixture -Operation caller_ack
+
+        $result.valid | Should -BeFalse
+        $result.reason_code | Should -Be 'manifest_regeneration_required'
+    }
+
+    It 'TASK781 requires regeneration for a stale observed server session' {
+        $fixture = New-Task781RuntimeFixture
+
+        $result = Test-WinsmuxRuntimeContext -Manifest $fixture.Manifest -Registry $fixture.Registry `
+            -ObservedServerSessionId '$8' -ObservedPanes $fixture.ObservedPanes `
+            -ManifestEntry $fixture.Entry -PaneMarker $fixture.Marker `
+            -CallerIdentity $fixture.Caller -ProcessResolver $fixture.ProcessResolver `
+            -Now ([datetime]'2026-07-15T00:05:00Z')
+
+        $result.valid | Should -BeFalse
+        $result.reason_code | Should -Be 'manifest_regeneration_required'
+    }
+
+    It 'TASK781 refuses duplicate runtime slots' {
+        $fixture = New-Task781RuntimeFixture
+        $fixture.Registry.panes = @($fixture.Registry.panes[0], $fixture.Registry.panes[0].PSObject.Copy())
+        $fixture.Registry.panes[1].pane_id = '%3'
+
+        $result = Invoke-Task781RuntimeFixture -Fixture $fixture -Operation caller_ack
+
+        $result.valid | Should -BeFalse
+        $result.reason_code | Should -Be 'runtime_target_mismatch'
+    }
+
+    It 'TASK781 refuses duplicate runtime panes' {
+        $fixture = New-Task781RuntimeFixture
+        $fixture.Registry.panes = @($fixture.Registry.panes[0], $fixture.Registry.panes[0].PSObject.Copy())
+        $fixture.Registry.panes[1].label = 'worker-2'
+        $fixture.Registry.panes[1].slot_id = 'worker-2'
+
+        $result = Invoke-Task781RuntimeFixture -Fixture $fixture
+
+        $result.valid | Should -BeFalse
+        $result.reason_code | Should -Be 'runtime_target_mismatch'
+    }
+
+    It 'TASK781 refuses pane role title or live-state drift' -ForEach @(
+        @{ Property = 'pane_id'; Value = '%7' }
+        @{ Property = 'role'; Value = 'builder' }
+        @{ Property = 'title'; Value = 'wrong title' }
+        @{ Property = 'state'; Value = 'deferred' }
+    ) {
+        $fixture = New-Task781RuntimeFixture
+        $fixture.Registry.panes[0].$($_.Property) = $_.Value
+
+        $result = Invoke-Task781RuntimeFixture -Fixture $fixture
+
+        $result.valid | Should -BeFalse
+        $result.reason_code | Should -Be 'runtime_target_mismatch'
+    }
+
+    It 'TASK781 refuses a marker from an old generation' {
+        $fixture = New-Task781RuntimeFixture
+        $fixture.Marker.generation_id = 'generation-old'
+
+        $result = Invoke-Task781RuntimeFixture -Fixture $fixture
+
+        $result.valid | Should -BeFalse
+        $result.reason_code | Should -Be 'runtime_target_mismatch'
+    }
+
+    It 'TASK781 refuses environment-only caller evidence' {
+        $fixture = New-Task781RuntimeFixture
+        $fixture.Caller = [PSCustomObject]@{ pane_id = '%2'; backend = 'codex' }
+
+        $result = Invoke-Task781RuntimeFixture -Fixture $fixture -Operation caller_ack
+
+        $result.valid | Should -BeFalse
+        $result.reason_code | Should -Be 'caller_identity_mismatch'
+    }
+
+    It 'TASK781 refuses a caller with the same PID and a different StartTime' {
+        $fixture = New-Task781RuntimeFixture
+        $fixture.Caller.process_started_at = '2026-07-15T00:00:03.0000000Z'
+
+        $result = Invoke-Task781RuntimeFixture -Fixture $fixture -Operation caller_ack
+
+        $result.valid | Should -BeFalse
+        $result.reason_code | Should -Be 'caller_identity_mismatch'
+    }
+
+    It 'TASK781 refuses a caller from another backend or generation' -ForEach @(
+        @{ Property = 'backend'; Value = 'api_llm' }
+        @{ Property = 'generation_id'; Value = 'generation-old' }
+    ) {
+        $fixture = New-Task781RuntimeFixture
+        $fixture.Caller.$($_.Property) = $_.Value
+
+        $result = Invoke-Task781RuntimeFixture -Fixture $fixture -Operation caller_ack
+
+        $result.valid | Should -BeFalse
+        $result.reason_code | Should -Be 'caller_identity_mismatch'
+    }
+
+    It 'TASK781 accepts six of six uniquely matched live slots' {
+        $fixture = New-Task781RuntimeFixture
+        $fixture.Manifest.panes = [ordered]@{}
+        $fixture.Registry.panes = @()
+        $fixture.Manifest.session.expected_pane_count = 6
+        $fixture.Registry.expected_pane_count = 6
+        $fixture.ObservedPanes = @([PSCustomObject]@{ pane_id = '%1'; title = 'winsmux-orchestra-bootstrap' })
+        $processes = @{
+            4100 = [PSCustomObject]@{ Id = 4100; StartTime = [datetime]'2026-07-15T00:00:00Z'; ParentProcessId = 1; Name = 'pwsh.exe' }
+        }
+
+        foreach ($index in 1..6) {
+            $label = "worker-$index"
+            $paneId = "%$($index + 1)"
+            $title = "W$index Codex Reviewer"
+            $bootstrapPid = 4200 + $index
+            $callerPid = 4300 + $index
+            $bootstrapStartedAt = "2026-07-15T00:00:$('{0:D2}' -f $index).0000000Z"
+            $callerStartedAt = "2026-07-15T00:01:$('{0:D2}' -f $index).0000000Z"
+            $fixture.Manifest.panes[$label] = [ordered]@{
+                slot_id = $label; pane_id = $paneId; worker_backend = 'codex'; worker_role = 'reviewer'
+                role = 'Reviewer'; title = $title; status = 'ready'
+            }
+            $fixture.Registry.panes += [PSCustomObject]@{
+                label = $label; slot_id = $label; pane_id = $paneId; backend = 'codex'; role = 'reviewer'
+                title = $title; state = 'live'; bootstrap_pid = $bootstrapPid
+                bootstrap_process_started_at = $bootstrapStartedAt
+            }
+            $fixture.ObservedPanes += [PSCustomObject]@{ pane_id = $paneId; title = $title }
+            $processes[$bootstrapPid] = [PSCustomObject]@{ Id = $bootstrapPid; StartTime = [datetime]$bootstrapStartedAt; ParentProcessId = 1; Name = 'pwsh.exe' }
+            $processes[$callerPid] = [PSCustomObject]@{ Id = $callerPid; StartTime = [datetime]$callerStartedAt; ParentProcessId = $bootstrapPid; Name = 'codex.exe' }
+        }
+        $fixture.ProcessResolver = { param([int]$Id) return $processes[$Id] }
+
+        $verified = 0
+        foreach ($index in 1..6) {
+            $label = "worker-$index"
+            $pane = $fixture.Manifest.panes[$label]
+            $runtimePane = $fixture.Registry.panes[$index - 1]
+            $callerPid = 4300 + $index
+            $callerStartedAt = "2026-07-15T00:01:$('{0:D2}' -f $index).0000000Z"
+            $fixture.Entry = [PSCustomObject]@{
+                Label = $label; SlotId = $label; PaneId = $pane.pane_id; WorkerBackend = 'codex'
+                WorkerRole = 'reviewer'; Role = 'Reviewer'; Title = $pane.title; Status = 'ready'
+            }
+            $fixture.Marker = [PSCustomObject]@{
+                generation_id = 'generation-1'; server_session_id = '$9'; slot_id = $label
+                pane_id = $pane.pane_id; backend = 'codex'; role = 'reviewer'; title = $pane.title
+                bootstrap_pid = $runtimePane.bootstrap_pid
+                bootstrap_process_started_at = $runtimePane.bootstrap_process_started_at
+            }
+            $fixture.Caller = [PSCustomObject]@{
+                process_id = $callerPid; process_started_at = $callerStartedAt; generation_id = 'generation-1'
+                server_session_id = '$9'; slot_id = $label; pane_id = $pane.pane_id; backend = 'codex'
+                ancestry = @(
+                    [PSCustomObject]@{ pid = $callerPid; process_started_at = $callerStartedAt }
+                    [PSCustomObject]@{ pid = $runtimePane.bootstrap_pid; process_started_at = $runtimePane.bootstrap_process_started_at }
+                )
+            }
+
+            $result = Invoke-Task781RuntimeFixture -Fixture $fixture
+            if ($result.valid) { $verified++ }
+        }
+
+        $verified | Should -Be 6
+        (($verified / 6) * 100) | Should -Be 100
+    }
+
+    It 'TASK781 rejects unknown future and malformed manifest schemas without throwing' -ForEach @(3, 'future') {
+        $fixture = New-Task781RuntimeFixture
+        $fixture.Manifest.version = $_
+
+        $result = Invoke-Task781RuntimeFixture -Fixture $fixture
+
+        $result.valid | Should -BeFalse
+        $result.reason_code | Should -Be 'manifest_regeneration_required'
+    }
+
+    It 'TASK781 refuses supervisor identity when process observation throws' {
+        $fixture = New-Task781RuntimeFixture
+        $fixture.ProcessResolver = { param([int]$Id) throw "process unavailable: $Id" }
+
+        $result = Invoke-Task781RuntimeFixture -Fixture $fixture
+
+        $result.valid | Should -BeFalse
+        $result.reason_code | Should -Be 'invalid_supervisor_identity'
+    }
+
+    It 'TASK781 writes and reads a separate supervisor-owned runtime registry' {
+        $fixture = New-Task781RuntimeFixture
+        $registry = New-WinsmuxRuntimeRegistryDocument -SessionName 'winsmux-task781-test' -ServerSessionId '$9' `
+            -GenerationId 'generation-1' -SupervisorPid 4100 `
+            -SupervisorProcessStartedAt '2026-07-15T00:00:00.0000000Z' -ExpectedPaneCount 1 -Panes $fixture.Registry.panes `
+            -Now ([datetime]'2026-07-15T00:05:00Z') -LeaseSeconds 15
+
+        $path = Save-WinsmuxRuntimeRegistry -ProjectDir $script:task781TempRoot -Registry $registry
+        $read = Read-WinsmuxRuntimeRegistry -ProjectDir $script:task781TempRoot
+
+        $path | Should -Be (Join-Path $script:task781TempRoot '.winsmux\runtime-registry.json')
+        $read.schema_version | Should -Be 1
+        $read.generation_id | Should -Be 'generation-1'
+        $read.expected_pane_count | Should -Be 1
+        $read.supervisor.process_started_at | Should -Be '2026-07-15T00:00:00.0000000Z'
+        ($read | ConvertTo-Json -Depth 20) | Should -Not -Match 'startup_token|credential|launch_command'
+    }
+
+    It 'TASK781 refreshes only the exact generation owner and closes its lease' {
+        $fixture = New-Task781RuntimeFixture
+        $registry = New-WinsmuxRuntimeRegistryDocument -SessionName 'winsmux-task781-test' -ServerSessionId '$9' `
+            -GenerationId 'generation-1' -SupervisorPid 4100 `
+            -SupervisorProcessStartedAt '2026-07-15T00:00:00.0000000Z' -ExpectedPaneCount 1 -Panes $fixture.Registry.panes `
+            -Now ([datetime]'2026-07-15T00:05:00Z') -LeaseSeconds 15
+        Save-WinsmuxRuntimeRegistry -ProjectDir $script:task781TempRoot -Registry $registry | Out-Null
+
+        { Update-WinsmuxRuntimeRegistryLease -ProjectDir $script:task781TempRoot -GenerationId 'generation-old' `
+            -SupervisorPid 4100 -SupervisorProcessStartedAt '2026-07-15T00:00:00.0000000Z' `
+            -Now ([datetime]'2026-07-15T00:05:05Z') } | Should -Throw '*does not own this generation*'
+
+        $refreshed = Update-WinsmuxRuntimeRegistryLease -ProjectDir $script:task781TempRoot -GenerationId 'generation-1' `
+            -SupervisorPid 4100 -SupervisorProcessStartedAt '2026-07-15T00:00:00.0000000Z' `
+            -Now ([datetime]'2026-07-15T00:05:05Z') -LeaseSeconds 15
+        $refreshed.lease.expires_at | Should -Be '2026-07-15T00:05:20.0000000Z'
+
+        $closed = Close-WinsmuxRuntimeRegistry -ProjectDir $script:task781TempRoot -GenerationId 'generation-1' `
+            -SupervisorPid 4100 -SupervisorProcessStartedAt '2026-07-15T00:00:00.0000000Z' `
+            -Now ([datetime]'2026-07-15T00:05:06Z')
+        $closed | Should -BeTrue
+        $ended = Read-WinsmuxRuntimeRegistry -ProjectDir $script:task781TempRoot
+        $ended.status | Should -Be 'ended'
+        $ended.lease.state | Should -Be 'ended'
+        $ended.lease.expires_at | Should -Be '2026-07-15T00:05:06.0000000Z'
+    }
+
+    It 'TASK781 allows operator dispatch without treating the operator PID as the pane caller' {
+        $fixture = New-Task781RuntimeFixture
+        $fixture.Caller = $null
+
+        $result = Invoke-Task781RuntimeFixture -Fixture $fixture -Operation dispatch
+
+        $result.valid | Should -BeTrue
+        $result.reason_code | Should -Be 'live_runtime_verified'
+    }
+
+    It 'TASK781 accepts caller acknowledgement only with observed ancestry to the bootstrap' {
+        $fixture = New-Task781RuntimeFixture
+
+        $result = Invoke-Task781RuntimeFixture -Fixture $fixture -Operation caller_ack
+
+        $result.valid | Should -BeTrue
+        $result.reason_code | Should -Be 'live_runtime_verified'
+    }
+
+    It 'TASK781 ignores self-reported ancestry when the OS parent chain does not reach bootstrap' {
+        $fixture = New-Task781RuntimeFixture
+        $fixture.ProcessResolver = {
+            param([int]$Id)
+            switch ($Id) {
+                4100 { [PSCustomObject]@{ Id = 4100; StartTime = [datetime]'2026-07-15T00:00:00Z'; ParentProcessId = 1; Name = 'pwsh.exe' } }
+                4200 { [PSCustomObject]@{ Id = 4200; StartTime = [datetime]'2026-07-15T00:00:01Z'; ParentProcessId = 1; Name = 'pwsh.exe' } }
+                4300 { [PSCustomObject]@{ Id = 4300; StartTime = [datetime]'2026-07-15T00:00:02Z'; ParentProcessId = 4999; Name = 'codex.exe' } }
+                default { $null }
+            }
+        }
+
+        $result = Invoke-Task781RuntimeFixture -Fixture $fixture -Operation caller_ack
+
+        $result.valid | Should -BeFalse
+        $result.reason_code | Should -Be 'caller_identity_mismatch'
+    }
+
+    It 'TASK781 refuses Codex acknowledgement without a Codex process in the observed chain' {
+        $fixture = New-Task781RuntimeFixture
+        $fixture.ProcessResolver = {
+            param([int]$Id)
+            switch ($Id) {
+                4100 { [PSCustomObject]@{ Id = 4100; StartTime = [datetime]'2026-07-15T00:00:00Z'; ParentProcessId = 1; Name = 'pwsh.exe' } }
+                4200 { [PSCustomObject]@{ Id = 4200; StartTime = [datetime]'2026-07-15T00:00:01Z'; ParentProcessId = 1; Name = 'pwsh.exe' } }
+                4300 { [PSCustomObject]@{ Id = 4300; StartTime = [datetime]'2026-07-15T00:00:02Z'; ParentProcessId = 4200; Name = 'pwsh.exe' } }
+                default { $null }
+            }
+        }
+
+        $result = Invoke-Task781RuntimeFixture -Fixture $fixture -Operation caller_ack
+
+        $result.valid | Should -BeFalse
+        $result.reason_code | Should -Be 'caller_identity_mismatch'
+    }
+
+    It 'TASK781 allows deferred start only for a verified deferred registry entry' {
+        $fixture = New-Task781RuntimeFixture
+        $fixture.Registry.panes[0].state = 'deferred'
+        $fixture.Registry.panes[0].bootstrap_pid = 0
+        $fixture.Registry.panes[0].bootstrap_process_started_at = ''
+        $fixture.Manifest.panes['worker-1'].status = 'deferred_start'
+        $fixture.Entry.Status = 'deferred_start'
+        $fixture.Marker = $null
+
+        $result = Invoke-Task781RuntimeFixture -Fixture $fixture -Operation start_deferred
+
+        $result.valid | Should -BeTrue
+        $result.reason_code | Should -Be 'deferred_runtime_verified'
+    }
+
+    It 'TASK781 C15 allows retry start for a verified failed deferred registry entry' {
+        $fixture = New-Task781RuntimeFixture
+        $fixture.Registry.panes[0].state = 'deferred'
+        $fixture.Registry.panes[0].bootstrap_pid = 0
+        $fixture.Registry.panes[0].bootstrap_process_started_at = ''
+        $fixture.Manifest.panes['worker-1'].status = 'deferred_start_failed'
+        $fixture.Entry.Status = 'deferred_start_failed'
+        $fixture.Marker = $null
+
+        $result = Invoke-Task781RuntimeFixture -Fixture $fixture -Operation start_deferred
+
+        $result.reason_code | Should -Be 'deferred_runtime_verified'
+        $result.valid | Should -BeTrue
+        $fixture.Registry.lease.state | Should -Be 'active'
+        $fixture.Registry.panes[0].state | Should -Be 'deferred'
+    }
+
+    It 'TASK781 C32 allows an authenticated current-generation failed marker to be reused without duplicate bootstrap' {
+        $fixture = New-Task781RuntimeFixture
+        $fixture.Registry.panes[0].state = 'deferred'
+        $fixture.Registry.panes[0].bootstrap_pid = 0
+        $fixture.Registry.panes[0].bootstrap_process_started_at = ''
+        $fixture.Manifest.panes['worker-1'].status = 'deferred_start_failed'
+        $fixture.Entry.Status = 'deferred_start_failed'
+        $fixture.Marker | Add-Member -NotePropertyName state -NotePropertyValue 'bootstrap_pending'
+
+        $result = Invoke-Task781RuntimeFixture -Fixture $fixture -Operation start_deferred
+
+        $result.valid | Should -BeTrue
+        $result.reason_code | Should -Be 'deferred_retry_marker_verified'
+        [string]$result.context.retry_marker_state | Should -Be 'live'
+        $fixture.Registry.panes[0].state | Should -Be 'deferred'
+    }
+
+    It 'TASK781 C32 refuses a failed deferred retry marker with a different generation' {
+        $fixture = New-Task781RuntimeFixture
+        $fixture.Registry.panes[0].state = 'deferred'
+        $fixture.Registry.panes[0].bootstrap_pid = 0
+        $fixture.Registry.panes[0].bootstrap_process_started_at = ''
+        $fixture.Manifest.panes['worker-1'].status = 'deferred_start_failed'
+        $fixture.Entry.Status = 'deferred_start_failed'
+        $fixture.Marker | Add-Member -NotePropertyName state -NotePropertyValue 'bootstrap_pending'
+        $fixture.Marker.generation_id = 'generation-stale'
+
+        $result = Invoke-Task781RuntimeFixture -Fixture $fixture -Operation start_deferred
+
+        $result.valid | Should -BeFalse
+        $result.reason_code | Should -Be 'runtime_target_mismatch'
+    }
+
+    It 'TASK781 keeps bootstrap-pending panes unavailable to dispatch' {
+        $fixture = New-Task781RuntimeFixture
+        $fixture.Registry.panes[0].state = 'bootstrap_pending'
+
+        $result = Invoke-Task781RuntimeFixture -Fixture $fixture -Operation dispatch
+
+        $result.valid | Should -BeFalse
+        $result.reason_code | Should -Be 'runtime_target_mismatch'
+    }
+
+    It 'TASK781 refuses live registry overwrite and permits only ended or expired-dead replacement' {
+        $fixture = New-Task781RuntimeFixture
+        (Test-WinsmuxRuntimeRegistryReplacementAllowed -Registry $fixture.Registry -ProcessResolver $fixture.ProcessResolver `
+            -Now ([datetime]'2026-07-15T00:05:00Z')) | Should -BeFalse
+
+        $fixture.Registry.lease.expires_at = '2026-07-15T00:04:00.0000000Z'
+        (Test-WinsmuxRuntimeRegistryReplacementAllowed -Registry $fixture.Registry -ProcessResolver $fixture.ProcessResolver `
+            -Now ([datetime]'2026-07-15T00:05:00Z')) | Should -BeFalse
+
+        $fixture.Registry.supervisor.pid = 4999
+        (Test-WinsmuxRuntimeRegistryReplacementAllowed -Registry $fixture.Registry -ProcessResolver $fixture.ProcessResolver `
+            -Now ([datetime]'2026-07-15T00:05:00Z')) | Should -BeTrue
+
+        $fixture.Registry.status = 'ended'
+        (Test-WinsmuxRuntimeRegistryReplacementAllowed -Registry $fixture.Registry -ProcessResolver $fixture.ProcessResolver `
+            -Now ([datetime]'2026-07-15T00:05:00Z')) | Should -BeTrue
+    }
+
+    It 'TASK781 builds an ancestry resolver from a single secret-free CIM snapshot' {
+        $resolver = New-WinsmuxProcessSnapshotResolver -Snapshots @(
+            [PSCustomObject]@{ ProcessId = 4200; ParentProcessId = 1; CreationDate = [datetime]'2026-07-15T00:00:01Z'; Name = 'pwsh.exe' }
+            [PSCustomObject]@{ ProcessId = 4300; ParentProcessId = 4200; CreationDate = [datetime]'2026-07-15T00:00:02Z'; Name = 'codex.exe' }
+        )
+
+        $snapshot = & $resolver 4300
+        $snapshot.Id | Should -Be 4300
+        $snapshot.ParentProcessId | Should -Be 4200
+        $snapshot.StartTime | Should -Be '2026-07-15T00:00:02.0000000Z'
+        ($snapshot.PSObject.Properties.Name) | Should -Not -Contain 'CommandLine'
+    }
+
+    It 'TASK781 normalizes six default worker roles identically across manifest marker and registry' {
+        $roles = foreach ($index in 1..6) {
+            Resolve-WinsmuxRuntimeRole -WorkerRole '' -CanonicalRole 'Worker'
+        }
+
+        $roles.Count | Should -Be 6
+        @($roles | Where-Object { $_ -cne 'worker' }).Count | Should -Be 0
+    }
+
+    It 'TASK781 skips unrelated incomplete process rows but rejects duplicate process IDs' {
+        $resolver = New-WinsmuxProcessSnapshotResolver -Snapshots @(
+            [PSCustomObject]@{ ProcessId = 999; ParentProcessId = $null; CreationDate = $null; Name = '' }
+            [PSCustomObject]@{ ProcessId = 4300; ParentProcessId = 4200; CreationDate = [datetime]'2026-07-15T00:00:02Z'; Name = 'codex.exe' }
+        )
+        (& $resolver 4300).Id | Should -Be 4300
+        (& $resolver 999) | Should -BeNullOrEmpty
+
+        { New-WinsmuxProcessSnapshotResolver -Snapshots @(
+                [PSCustomObject]@{ ProcessId = 4300; ParentProcessId = 4200; CreationDate = [datetime]'2026-07-15T00:00:02Z'; Name = 'codex.exe' }
+                [PSCustomObject]@{ ProcessId = 4300; ParentProcessId = 1; CreationDate = [datetime]'2026-07-15T00:00:03Z'; Name = 'codex.exe' }
+            ) } | Should -Throw '*duplicate process identity*'
+    }
+}
+
+Describe 'TASK781 supervisor deferred runtime promotion' {
+    BeforeAll {
+        $script:task781SupervisorPath = Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\orchestra-supervisor.ps1'
+        $script:task781SupervisorContent = Get-Content -LiteralPath $script:task781SupervisorPath -Raw -Encoding UTF8
+        . $script:task781SupervisorPath -ManifestPath 'synthetic-manifest' -GenerationId 'generation-1' -ServerSessionId '$9'
+    }
+
+    BeforeEach {
+        $script:task781PromotionRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('winsmux-task781-promotion-' + [guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $script:task781PromotionRoot -Force | Out-Null
+        $script:task781PromotionMarkerPath = Join-Path $script:task781PromotionRoot 'worker-1.ready.json'
+        $script:task781PromotionManifest = [PSCustomObject]@{
+            panes = [ordered]@{
+                'worker-1' = [ordered]@{
+                    slot_id = 'worker-1'; pane_id = '%2'; worker_backend = 'codex'; worker_role = 'reviewer'
+                    role = 'Reviewer'; title = 'W1 Codex Reviewer'; status = 'deferred_starting'; runtime_ready = $false
+                    bootstrap_marker_path = $script:task781PromotionMarkerPath
+                }
+            }
+        }
+        $script:task781PromotionProcessResolver = {
+            param([int]$Id)
+            if ($Id -eq 4200) {
+                return [PSCustomObject]@{
+                    Id = 4200; StartTime = [datetime]'2026-07-15T00:00:01Z'; ParentProcessId = 1; Name = 'pwsh.exe'
+                }
+            }
+            return $null
+        }
+    }
+
+    AfterEach {
+        Remove-Item -LiteralPath $script:task781PromotionRoot -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    It 'TASK781 C42 carries the manifest expected pane count into the supervisor registry' {
+        $script:task781SupervisorContent | Should -Match "-Name 'expected_pane_count'"
+        $script:task781SupervisorContent | Should -Match '-ExpectedPaneCount \$expectedPaneCount -Panes \$runtimePanes'
+    }
+
+    It 'TASK781 C29 keeps deferred_starting deferred until its marker exists' {
+        $panes = @(New-OrchestraSupervisorRuntimePanes -Manifest $script:task781PromotionManifest `
+            -GenerationId 'generation-1' -ServerSessionId '$9' -ProcessResolver $script:task781PromotionProcessResolver)
+
+        $panes.Count | Should -Be 1
+        $panes[0].state | Should -Be 'deferred'
+        $panes[0].bootstrap_pid | Should -Be 0
+    }
+
+    It 'TASK781 C29 promotes deferred_starting only from an authenticated current-generation marker' {
+        ([ordered]@{
+            state = 'bootstrap_pending'; generation_id = 'generation-1'; server_session_id = '$9'
+            slot_id = 'worker-1'; pane_id = '%2'; backend = 'codex'; role = 'reviewer'; title = 'W1 Codex Reviewer'
+            bootstrap_pid = 4200; bootstrap_process_started_at = '2026-07-15T00:00:01.0000000Z'
+        } | ConvertTo-Json -Depth 6) | Set-Content -LiteralPath $script:task781PromotionMarkerPath -Encoding UTF8
+
+        $panes = @(New-OrchestraSupervisorRuntimePanes -Manifest $script:task781PromotionManifest `
+            -GenerationId 'generation-1' -ServerSessionId '$9' -ProcessResolver $script:task781PromotionProcessResolver)
+
+        $panes.Count | Should -Be 1
+        $panes[0].state | Should -Be 'live'
+        $panes[0].bootstrap_pid | Should -Be 4200
+        $panes[0].bootstrap_process_started_at | Should -Be '2026-07-15T00:00:01.0000000Z'
+    }
+
+    It 'TASK781 C29 rejects a stale marker instead of publishing a live registry row' {
+        ([ordered]@{
+            state = 'bootstrap_pending'; generation_id = 'generation-old'; server_session_id = '$9'
+            slot_id = 'worker-1'; pane_id = '%2'; backend = 'codex'; role = 'reviewer'; title = 'W1 Codex Reviewer'
+            bootstrap_pid = 4200; bootstrap_process_started_at = '2026-07-15T00:00:01.0000000Z'
+        } | ConvertTo-Json -Depth 6) | Set-Content -LiteralPath $script:task781PromotionMarkerPath -Encoding UTF8
+
+        {
+            New-OrchestraSupervisorRuntimePanes -Manifest $script:task781PromotionManifest `
+                -GenerationId 'generation-1' -ServerSessionId '$9' -ProcessResolver $script:task781PromotionProcessResolver
+        } | Should -Throw '*marker identity does not match*'
+    }
+
+    It 'TASK781 C47 contains a transient dead-marker snapshot without terminating the supervisor loop' {
+        ([ordered]@{
+            state = 'bootstrap_pending'; generation_id = 'generation-1'; server_session_id = '$9'
+            slot_id = 'worker-1'; pane_id = '%2'; backend = 'codex'; role = 'reviewer'; title = 'W1 Codex Reviewer'
+            bootstrap_pid = 4200; bootstrap_process_started_at = '2026-07-15T00:00:01.0000000Z'
+        } | ConvertTo-Json -Depth 6) | Set-Content -LiteralPath $script:task781PromotionMarkerPath -Encoding UTF8
+        $deadProcessResolver = { param([int]$Id) return $null }
+
+        $contained = Get-OrchestraSupervisorRuntimePaneSnapshot -Manifest $script:task781PromotionManifest `
+            -GenerationId 'generation-1' -ServerSessionId '$9' -ProcessResolver $deadProcessResolver
+        $healthy = Get-OrchestraSupervisorRuntimePaneSnapshot -Manifest $script:task781PromotionManifest `
+            -GenerationId 'generation-1' -ServerSessionId '$9' -ProcessResolver $script:task781PromotionProcessResolver
+
+        $contained.valid | Should -BeFalse
+        $contained.panes.Count | Should -Be 0
+        $contained.diagnostic | Should -Match 'marker identity does not match'
+        $healthy.valid | Should -BeTrue
+        $healthy.panes.Count | Should -Be 1
+    }
+}
+
+Describe 'TASK781 caller acknowledgement side effects' {
+    BeforeAll {
+        . (Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\pane-control.ps1')
+        . (Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\submission-contract.ps1')
+
+        function Send-TextToPane {
+            param(
+                [string]$PaneId,
+                [string]$CommandText,
+                [string]$PromptTransport = 'argv',
+                [string]$RuntimeProjectDir = '',
+                [string]$RuntimeOperation = 'dispatch',
+                [string]$ExpectedGenerationId = ''
+            )
+        }
+
+        function New-Task781SyntheticAckCandidate {
+            param(
+                [Parameter(Mandatory = $true)][string]$ProjectDir,
+                [Parameter(Mandatory = $true)][string]$SubmissionId,
+                [Parameter(Mandatory = $true)][string]$Challenge
+            )
+            $packet = Read-WinsmuxSubmissionPacket -Path (Join-Path $ProjectDir ".winsmux\submissions\$SubmissionId.json")
+            $record = New-WinsmuxSubmissionRunRecord -SubmissionId $SubmissionId -RunId $SubmissionId `
+                -TaskId ([string]$packet.task_id) -Kind task -TaskTitle ([string]$packet.title) -SlotId worker-1 `
+                -Backend codex -Status started -RequestConsumed -RequestDigest ([string]$packet.request_digest)
+            $receipt = New-WinsmuxSubmissionReceipt -Kind task -Status accepted -Backend codex -SubmissionId $SubmissionId `
+                -Target ([ordered]@{ label = 'worker-1'; pane_id = '%2'; role = 'Worker' }) -Acknowledgement $record
+            return [PSCustomObject]@{
+                record = $record
+                receipt = $receipt
+                envelope = New-WinsmuxSubmissionAcknowledgementEnvelope -Phase candidate -Challenge $Challenge -Receipt $receipt
+            }
+        }
+    }
+
+    BeforeEach {
+        $script:task781AckRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('winsmux-task781-ack-' + [guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path (Join-Path $script:task781AckRoot '.winsmux') -Force | Out-Null
+        $script:task781AckEntry = [PSCustomObject]@{
+            Label = 'worker-1'; SlotId = 'worker-1'; PaneId = '%2'; Role = 'Worker'; WorkerRole = 'worker'
+            WorkerBackend = 'codex'; Title = 'W1 Codex Reviewer'; Status = 'ready'
+        }
+        $script:task781AckPipeState = [PSCustomObject]@{
+            pipe_name = 'winsmux-submission-ack-33333333333333333333333333333333'
+            challenge = ('c' * 64)
+            server = $null
+        }
+        Mock Get-PaneControlManifestEntries { @($script:task781AckEntry) }
+        Mock New-WinsmuxSubmissionAcknowledgementServer { $script:task781AckPipeState }
+        Mock Complete-WinsmuxSubmissionAcknowledgement { $true }
+        Mock Write-WinsmuxSubmissionAcknowledgementControl { }
+        Mock Test-PaneControlRuntimeContext {
+            param($ProjectDir, $ManifestEntry, $Operation, $CallerIdentity, $ProcessResolver)
+            $context = [PSCustomObject]@{
+                generation_id = 'generation-1'; server_session_id = '$9'; slot_id = 'worker-1'
+                pane_id = '%2'; backend = 'codex'
+            }
+            New-WinsmuxRuntimeValidationResult -Valid $true -ReasonCode 'live_runtime_verified' -Diagnostic 'verified' -Context $context
+        }
+        Mock New-WinsmuxSubmissionPipeCallerEvidence {
+            [PSCustomObject]@{
+                caller_identity = [PSCustomObject]@{
+                    process_id = 4300; process_started_at = '2026-07-15T00:00:02.0000000Z'
+                    generation_id = 'generation-1'; server_session_id = '$9'; slot_id = 'worker-1'
+                    pane_id = '%2'; backend = 'codex'
+                }
+                process_resolver = { param([int]$Id) $null }
+            }
+        }
+    }
+
+    AfterEach {
+        if ($script:task781AckRoot -and (Test-Path -LiteralPath $script:task781AckRoot)) {
+            Remove-Item -LiteralPath $script:task781AckRoot -Recurse -Force
+        }
+    }
+
+    It 'TASK781 refuses spoofed caller acknowledgement before any run record write' {
+        Mock Test-PaneControlRuntimeContext {
+            New-WinsmuxRuntimeValidationResult -Valid $false -ReasonCode 'caller_identity_mismatch' -Diagnostic 'synthetic caller mismatch'
+        }
+        Mock Write-WinsmuxSubmissionRunRecord { throw 'run record write must not occur' }
+
+        $receipt = Invoke-WinsmuxSubmissionAcknowledge -ProjectDir $script:task781AckRoot -SlotId worker-1 `
+            -SubmissionId submission-task781-refused -RunId submission-task781-refused -Kind task -Backend codex
+
+        $receipt.status | Should -Be 'unavailable'
+        $receipt.reason_code | Should -Be 'caller_identity_mismatch'
+        Assert-MockCalled Write-WinsmuxSubmissionRunRecord -Times 0 -Exactly
+        (Test-Path -LiteralPath (Join-Path $script:task781AckRoot '.winsmux\worker-runs\worker-1\submission-task781-refused\run.json')) | Should -BeFalse
+    }
+
+    It 'TASK781 keeps a strong caller acknowledgement in memory until commit authorization' {
+        Mock Test-PaneControlRuntimeContext {
+            New-WinsmuxRuntimeValidationResult -Valid $true -ReasonCode 'live_runtime_verified' -Diagnostic 'verified'
+        }
+        New-WinsmuxSubmissionPacket -ProjectDir $script:task781AckRoot -Kind task `
+            -Content ([ordered]@{ title = 'TASK781 ack'; request = 'Consume only after caller validation.' }) `
+            -SubmissionId submission-task781-accepted -TargetLabel worker-1 | Out-Null
+
+        $receipt = Invoke-WinsmuxSubmissionAcknowledge -ProjectDir $script:task781AckRoot -SlotId worker-1 `
+            -SubmissionId submission-task781-accepted -RunId submission-task781-accepted -Kind task -Backend codex
+
+        $receipt.status | Should -Be 'accepted'
+        $receipt.reason_code | Should -Be ''
+        $receipt.acknowledgement.slot_id | Should -Be 'worker-1'
+        (Test-Path -LiteralPath (Join-Path $script:task781AckRoot '.winsmux\worker-runs\worker-1\submission-task781-accepted\run.json')) | Should -BeFalse
+    }
+
+    It 'TASK781 completes the canonical Codex packet to strong acknowledgement path' {
+        Mock Test-PaneControlRuntimeContext {
+            param($ProjectDir, $ManifestEntry, $Operation, $CallerIdentity, $ProcessResolver)
+            $context = [PSCustomObject]@{
+                generation_id = 'generation-1'; server_session_id = '$9'; slot_id = 'worker-1'
+                pane_id = '%2'; backend = 'codex'
+            }
+            New-WinsmuxRuntimeValidationResult -Valid $true -ReasonCode 'live_runtime_verified' -Diagnostic 'verified' -Context $context
+        }
+        Mock New-WinsmuxSubmissionPipeCallerEvidence {
+            [PSCustomObject]@{
+                caller_identity = [PSCustomObject]@{
+                    process_id = 4300; process_started_at = '2026-07-15T00:00:02.0000000Z'
+                    generation_id = 'generation-1'; server_session_id = '$9'; slot_id = 'worker-1'
+                    pane_id = '%2'; backend = 'codex'
+                }
+                process_resolver = { param([int]$Id) $null }
+            }
+        }
+        $script:task781DispatchPrompt = ''
+        $script:task781AckReceiveCount = 0
+        $script:task781CandidateRecord = $null
+        $script:task781CandidateReceipt = $null
+        $sendAction = {
+            param([string]$PaneId, [string]$Text)
+            $script:task781DispatchPrompt = $Text
+        }
+        Mock Receive-WinsmuxSubmissionAcknowledgement {
+            $script:task781AckReceiveCount++
+            if ($script:task781AckReceiveCount -eq 1) {
+                $packet = Read-WinsmuxSubmissionPacket -Path (Join-Path $script:task781AckRoot '.winsmux\submissions\submission-task781-e2e.json')
+                $script:task781CandidateRecord = New-WinsmuxSubmissionRunRecord -SubmissionId submission-task781-e2e `
+                    -RunId submission-task781-e2e -TaskId ([string]$packet.task_id) -Kind task -TaskTitle ([string]$packet.title) `
+                    -SlotId worker-1 -Backend codex -Status started -RequestConsumed -RequestDigest ([string]$packet.request_digest)
+                $script:task781CandidateReceipt = New-WinsmuxSubmissionReceipt -Kind task -Status accepted -Backend codex `
+                    -SubmissionId submission-task781-e2e -Target ([ordered]@{ label = 'worker-1'; pane_id = '%2'; role = 'Worker' }) `
+                    -Acknowledgement $script:task781CandidateRecord
+                return [PSCustomObject]@{
+                    client_process_id = 4300
+                    payload = New-WinsmuxSubmissionAcknowledgementEnvelope -Phase candidate `
+                        -Challenge $script:task781AckPipeState.challenge -Receipt $script:task781CandidateReceipt
+                }
+            }
+            return [PSCustomObject]@{
+                client_process_id = 4300
+                payload = New-WinsmuxSubmissionAcknowledgementEnvelope -Phase committed `
+                    -Challenge $script:task781AckPipeState.challenge -Receipt $script:task781CandidateReceipt
+            }
+        }
+        Mock Write-WinsmuxSubmissionAcknowledgementControl { }
+
+        $receipt = Invoke-WinsmuxSubmissionAdapter -ProjectDir $script:task781AckRoot -ManifestEntry $script:task781AckEntry `
+            -Kind task -Content ([ordered]@{ title = 'TASK781 canonical ack'; request = 'Use the typed packet and acknowledge it.' }) `
+            -SubmissionId submission-task781-e2e -SendAction $sendAction
+
+        $receipt.status | Should -Be 'accepted'
+        $receipt.acknowledgement.status | Should -Be 'started'
+        $persistedRun = Get-Content -LiteralPath (Get-WinsmuxSubmissionRunPath -ProjectDir $script:task781AckRoot -SlotId worker-1 -RunId submission-task781-e2e) -Raw -Encoding UTF8 | ConvertFrom-Json -Depth 16
+        $persistedRun.request_consumed | Should -BeTrue
+        $script:task781DispatchPrompt | Should -Match "\.winsmux[/\\]submissions[/\\]submission-task781-e2e\.json"
+        $script:task781DispatchPrompt | Should -Match 'winsmux submission-ack --submission-id submission-task781-e2e'
+        $script:task781DispatchPrompt | Should -Match '--ack-pipe winsmux-submission-ack-33333333333333333333333333333333'
+        $script:task781AckReceiveCount | Should -Be 2
+        Should -Invoke Write-WinsmuxSubmissionAcknowledgementControl -Times 1 -Exactly -ParameterFilter { $Status -eq 'commit' }
+        Should -Invoke Complete-WinsmuxSubmissionAcknowledgement -Times 1 -Exactly -ParameterFilter { $Verified }
+    }
+
+    It 'TASK781 C34 binds the canonical Codex production send to the captured generation lease' {
+        $script:c34ReceiveCount = 0
+        Mock Send-TextToPane {
+            param($PaneId, $CommandText, $PromptTransport, $RuntimeProjectDir, $RuntimeOperation, $ExpectedGenerationId)
+            if ($RuntimeProjectDir -cne $script:task781AckRoot -or $RuntimeOperation -cne 'dispatch' -or
+                $ExpectedGenerationId -cne 'generation-1') {
+                throw 'production submission send omitted the captured runtime lease'
+            }
+        }
+        Mock Receive-WinsmuxSubmissionAcknowledgement {
+            $script:c34ReceiveCount++
+            $candidate = New-Task781SyntheticAckCandidate -ProjectDir $script:task781AckRoot `
+                -SubmissionId submission-task781-c34-codex -Challenge $script:task781AckPipeState.challenge
+            if ($script:c34ReceiveCount -eq 1) {
+                return [PSCustomObject]@{ client_process_id = 4300; payload = $candidate.envelope }
+            }
+            return [PSCustomObject]@{
+                client_process_id = 4300
+                payload = New-WinsmuxSubmissionAcknowledgementEnvelope -Phase committed `
+                    -Challenge $script:task781AckPipeState.challenge -Receipt $candidate.receipt
+            }
+        }
+
+        $receipt = Invoke-WinsmuxSubmissionAdapter -ProjectDir $script:task781AckRoot -ManifestEntry $script:task781AckEntry `
+            -Kind task -Content 'Bind the production send to generation one.' -SubmissionId submission-task781-c34-codex
+
+        $receipt.status | Should -Be 'accepted'
+        Should -Invoke Send-TextToPane -Times 1 -Exactly -ParameterFilter {
+            $PaneId -eq '%2' -and $RuntimeProjectDir -ceq $script:task781AckRoot -and
+            $RuntimeOperation -ceq 'dispatch' -and $ExpectedGenerationId -ceq 'generation-1'
+        }
+    }
+
+    It 'TASK781 C34 binds the api_llm production send to the captured generation lease' {
+        $entry = [PSCustomObject]@{
+            Label = 'worker-1'; SlotId = 'worker-1'; PaneId = '%2'; Role = 'Worker'; WorkerRole = 'worker'
+            WorkerBackend = 'api_llm'; Title = 'W1 API Reviewer'; Status = 'ready'
+        }
+        Mock Send-TextToPane {
+            param($PaneId, $CommandText, $PromptTransport, $RuntimeProjectDir, $RuntimeOperation, $ExpectedGenerationId)
+            if ($RuntimeProjectDir -cne $script:task781AckRoot -or $RuntimeOperation -cne 'dispatch' -or
+                $ExpectedGenerationId -cne 'generation-1') {
+                throw 'api_llm production send omitted the captured runtime lease'
+            }
+        }
+        $runResultAction = {
+            param($ProjectDir, $SlotId, $RunId)
+            $packet = Read-WinsmuxSubmissionPacket -Path (Join-Path $ProjectDir ".winsmux\submissions\$RunId.json")
+            New-WinsmuxSubmissionRunRecord -SubmissionId $RunId -RunId $RunId -TaskId ([string]$packet.task_id) `
+                -Kind task -TaskTitle ([string]$packet.title) -SlotId $SlotId -Backend api_llm -Status started `
+                -RequestConsumed -RequestDigest ([string]$packet.request_digest)
+        }
+
+        $receipt = Invoke-WinsmuxSubmissionAdapter -ProjectDir $script:task781AckRoot -ManifestEntry $entry `
+            -Kind task -Content 'Bind api_llm production send to generation one.' `
+            -SubmissionId submission-task781-c34-api -RunResultAction $runResultAction
+
+        $receipt.status | Should -Be 'accepted'
+        Should -Invoke Send-TextToPane -Times 1 -Exactly -ParameterFilter {
+            $PaneId -eq '%2' -and $RuntimeProjectDir -ceq $script:task781AckRoot -and
+            $RuntimeOperation -ceq 'dispatch' -and $ExpectedGenerationId -ceq 'generation-1'
+        }
+    }
+
+    It 'TASK781 accepts only with an adapter-owned durable run when final control delivery fails' {
+        $script:task781FinalControlReceiveCount = 0
+        Mock Receive-WinsmuxSubmissionAcknowledgement {
+            $script:task781FinalControlReceiveCount++
+            $candidate = New-Task781SyntheticAckCandidate -ProjectDir $script:task781AckRoot `
+                -SubmissionId submission-task781-final-control-failure -Challenge $script:task781AckPipeState.challenge
+            if ($script:task781FinalControlReceiveCount -eq 1) {
+                return [PSCustomObject]@{ client_process_id = 4300; payload = $candidate.envelope }
+            }
+            return [PSCustomObject]@{
+                client_process_id = 4300
+                payload = New-WinsmuxSubmissionAcknowledgementEnvelope -Phase committed `
+                    -Challenge $script:task781AckPipeState.challenge -Receipt $candidate.receipt
+            }
+        }
+        Mock Complete-WinsmuxSubmissionAcknowledgement { $false }
+
+        $receipt = Invoke-WinsmuxSubmissionAdapter -ProjectDir $script:task781AckRoot -ManifestEntry $script:task781AckEntry `
+            -Kind task -Content 'Final control delivery is not the durable authorization boundary.' `
+            -SubmissionId submission-task781-final-control-failure -SendAction { param($PaneId, $Text) }
+        $runPath = Get-WinsmuxSubmissionRunPath -ProjectDir $script:task781AckRoot -SlotId worker-1 `
+            -RunId submission-task781-final-control-failure
+
+        $receipt.status | Should -Be 'accepted'
+        Test-Path -LiteralPath $runPath -PathType Leaf | Should -BeTrue
+        Test-WinsmuxSubmissionRunRecord -Record (
+            Get-Content -LiteralPath $runPath -Raw -Encoding UTF8 | ConvertFrom-Json -Depth 16
+        ) -SubmissionId submission-task781-final-control-failure -Kind task -Backend codex `
+            -ExpectedSlotId worker-1 | Should -BeTrue
+        Test-Path -LiteralPath (Join-Path $script:task781AckRoot '.winsmux\submissions\submission-task781-final-control-failure.json') `
+            -PathType Leaf | Should -BeTrue
+        Should -Invoke Complete-WinsmuxSubmissionAcknowledgement -Times 1 -Exactly -ParameterFilter { $Verified }
+    }
+
+    It 'TASK781 leaves no run record when the acknowledgement pipe times out' {
+        Mock Receive-WinsmuxSubmissionAcknowledgement { throw 'synthetic pipe timeout' }
+
+        $receipt = Invoke-WinsmuxSubmissionAdapter -ProjectDir $script:task781AckRoot -ManifestEntry $script:task781AckEntry `
+            -Kind task -Content 'Timeout must not authorize a run.' -SubmissionId submission-task781-timeout `
+            -SendAction { param($PaneId, $Text) }
+
+        $receipt.status | Should -Be 'rejected'
+        $receipt.reason_code | Should -Be 'backend_acknowledgement_missing'
+        (Test-Path -LiteralPath (Get-WinsmuxSubmissionRunPath -ProjectDir $script:task781AckRoot -SlotId worker-1 -RunId submission-task781-timeout)) | Should -BeFalse
+        (Test-Path -LiteralPath (Join-Path $script:task781AckRoot '.winsmux\submissions\submission-task781-timeout.json')) | Should -BeTrue
+        Should -Invoke Write-WinsmuxSubmissionAcknowledgementControl -Times 0 -Exactly
+        Should -Invoke Complete-WinsmuxSubmissionAcknowledgement -Times 1 -Exactly -ParameterFilter { -not $Verified }
+    }
+
+    It 'TASK781 rejects a mismatched challenge before commit and leaves no run record' {
+        Mock Receive-WinsmuxSubmissionAcknowledgement {
+            $candidate = New-Task781SyntheticAckCandidate -ProjectDir $script:task781AckRoot `
+                -SubmissionId submission-task781-wrong-challenge -Challenge ('d' * 64)
+            [PSCustomObject]@{ client_process_id = 4300; payload = $candidate.envelope }
+        }
+
+        $receipt = Invoke-WinsmuxSubmissionAdapter -ProjectDir $script:task781AckRoot -ManifestEntry $script:task781AckEntry `
+            -Kind task -Content 'Wrong challenge must fail.' -SubmissionId submission-task781-wrong-challenge `
+            -SendAction { param($PaneId, $Text) }
+
+        $receipt.status | Should -Be 'rejected'
+        $receipt.reason_code | Should -Be 'runner_evidence_invalid'
+        (Test-Path -LiteralPath (Get-WinsmuxSubmissionRunPath -ProjectDir $script:task781AckRoot -SlotId worker-1 -RunId submission-task781-wrong-challenge)) | Should -BeFalse
+        (Test-Path -LiteralPath (Join-Path $script:task781AckRoot '.winsmux\submissions\submission-task781-wrong-challenge.json')) | Should -BeTrue
+        Should -Invoke Write-WinsmuxSubmissionAcknowledgementControl -Times 0 -Exactly
+    }
+
+    It 'TASK781 rejects a different pipe client PID before commit and leaves no run record' {
+        Mock Receive-WinsmuxSubmissionAcknowledgement {
+            $candidate = New-Task781SyntheticAckCandidate -ProjectDir $script:task781AckRoot `
+                -SubmissionId submission-task781-wrong-pid -Challenge $script:task781AckPipeState.challenge
+            [PSCustomObject]@{ client_process_id = 4999; payload = $candidate.envelope }
+        }
+        Mock New-WinsmuxSubmissionPipeCallerEvidence {
+            [PSCustomObject]@{
+                caller_identity = [PSCustomObject]@{
+                    process_id = 4999; process_started_at = '2026-07-15T00:00:03.0000000Z'
+                    generation_id = 'generation-1'; server_session_id = '$9'; slot_id = 'worker-1'
+                    pane_id = '%2'; backend = 'codex'
+                }
+                process_resolver = { param([int]$Id) $null }
+            }
+        }
+        Mock Test-PaneControlRuntimeContext {
+            param($ProjectDir, $ManifestEntry, $Operation, $CallerIdentity, $ProcessResolver)
+            if ($Operation -eq 'caller_ack') {
+                return New-WinsmuxRuntimeValidationResult -Valid $false -ReasonCode 'caller_identity_mismatch' -Diagnostic 'different pipe client'
+            }
+            $context = [PSCustomObject]@{
+                generation_id = 'generation-1'; server_session_id = '$9'; slot_id = 'worker-1'; pane_id = '%2'; backend = 'codex'
+            }
+            New-WinsmuxRuntimeValidationResult -Valid $true -ReasonCode 'live_runtime_verified' -Diagnostic 'verified' -Context $context
+        }
+
+        $receipt = Invoke-WinsmuxSubmissionAdapter -ProjectDir $script:task781AckRoot -ManifestEntry $script:task781AckEntry `
+            -Kind task -Content 'Different PID must fail.' -SubmissionId submission-task781-wrong-pid `
+            -SendAction { param($PaneId, $Text) }
+
+        $receipt.status | Should -Be 'unavailable'
+        $receipt.reason_code | Should -Be 'caller_identity_mismatch'
+        (Test-Path -LiteralPath (Get-WinsmuxSubmissionRunPath -ProjectDir $script:task781AckRoot -SlotId worker-1 -RunId submission-task781-wrong-pid)) | Should -BeFalse
+        (Test-Path -LiteralPath (Join-Path $script:task781AckRoot '.winsmux\submissions\submission-task781-wrong-pid.json')) | Should -BeTrue
+        Should -Invoke Write-WinsmuxSubmissionAcknowledgementControl -Times 0 -Exactly
+    }
+
+    It 'TASK781 rejects a stale caller generation before commit and leaves no run record' {
+        Mock Receive-WinsmuxSubmissionAcknowledgement {
+            $candidate = New-Task781SyntheticAckCandidate -ProjectDir $script:task781AckRoot `
+                -SubmissionId submission-task781-stale-generation -Challenge $script:task781AckPipeState.challenge
+            [PSCustomObject]@{ client_process_id = 4300; payload = $candidate.envelope }
+        }
+        Mock New-WinsmuxSubmissionPipeCallerEvidence {
+            [PSCustomObject]@{
+                caller_identity = [PSCustomObject]@{
+                    process_id = 4300; process_started_at = '2026-07-15T00:00:02.0000000Z'
+                    generation_id = 'generation-old'; server_session_id = '$9'; slot_id = 'worker-1'
+                    pane_id = '%2'; backend = 'codex'
+                }
+                process_resolver = { param([int]$Id) $null }
+            }
+        }
+        Mock Test-PaneControlRuntimeContext {
+            param($ProjectDir, $ManifestEntry, $Operation, $CallerIdentity, $ProcessResolver)
+            if ($Operation -eq 'caller_ack') {
+                return New-WinsmuxRuntimeValidationResult -Valid $false -ReasonCode 'caller_identity_mismatch' -Diagnostic 'stale generation'
+            }
+            $context = [PSCustomObject]@{
+                generation_id = 'generation-1'; server_session_id = '$9'; slot_id = 'worker-1'; pane_id = '%2'; backend = 'codex'
+            }
+            New-WinsmuxRuntimeValidationResult -Valid $true -ReasonCode 'live_runtime_verified' -Diagnostic 'verified' -Context $context
+        }
+
+        $receipt = Invoke-WinsmuxSubmissionAdapter -ProjectDir $script:task781AckRoot -ManifestEntry $script:task781AckEntry `
+            -Kind task -Content 'Stale generation must fail.' -SubmissionId submission-task781-stale-generation `
+            -SendAction { param($PaneId, $Text) }
+
+        $receipt.status | Should -Be 'unavailable'
+        $receipt.reason_code | Should -Be 'caller_identity_mismatch'
+        (Test-Path -LiteralPath (Get-WinsmuxSubmissionRunPath -ProjectDir $script:task781AckRoot -SlotId worker-1 -RunId submission-task781-stale-generation)) | Should -BeFalse
+        (Test-Path -LiteralPath (Join-Path $script:task781AckRoot '.winsmux\submissions\submission-task781-stale-generation.json')) | Should -BeTrue
+        Should -Invoke Write-WinsmuxSubmissionAcknowledgementControl -Times 0 -Exactly
+    }
+
+    It 'TASK781 rejects a pipe-only acknowledgement when no committed frame or run record arrives' {
+        $script:task781PipeOnlyReceiveCount = 0
+        Mock Receive-WinsmuxSubmissionAcknowledgement {
+            $script:task781PipeOnlyReceiveCount++
+            if ($script:task781PipeOnlyReceiveCount -eq 1) {
+                $candidate = New-Task781SyntheticAckCandidate -ProjectDir $script:task781AckRoot `
+                    -SubmissionId submission-task781-pipe-only -Challenge $script:task781AckPipeState.challenge
+                return [PSCustomObject]@{ client_process_id = 4300; payload = $candidate.envelope }
+            }
+            throw 'synthetic committed frame timeout'
+        }
+        Mock Write-WinsmuxSubmissionAcknowledgementControl { }
+
+        $receipt = Invoke-WinsmuxSubmissionAdapter -ProjectDir $script:task781AckRoot -ManifestEntry $script:task781AckEntry `
+            -Kind task -Content 'Pipe candidate alone must fail.' -SubmissionId submission-task781-pipe-only `
+            -SendAction { param($PaneId, $Text) }
+
+        $receipt.status | Should -Be 'rejected'
+        $receipt.reason_code | Should -Be 'runner_evidence_invalid'
+        (Test-Path -LiteralPath (Get-WinsmuxSubmissionRunPath -ProjectDir $script:task781AckRoot -SlotId worker-1 -RunId submission-task781-pipe-only)) | Should -BeFalse
+        (Test-Path -LiteralPath (Join-Path $script:task781AckRoot '.winsmux\submissions\submission-task781-pipe-only.json')) | Should -BeTrue
+        Should -Invoke Write-WinsmuxSubmissionAcknowledgementControl -Times 1 -Exactly -ParameterFilter { $Status -eq 'commit' }
+        Should -Invoke Complete-WinsmuxSubmissionAcknowledgement -Times 1 -Exactly -ParameterFilter { -not $Verified }
+    }
+
+    It 'TASK781 revalidates runtime after commit and retains the committed packet on expired lease' {
+        $script:task781PostCommitReceiveCount = 0
+        $script:task781PostCommitCallerChecks = 0
+        Mock Receive-WinsmuxSubmissionAcknowledgement {
+            $script:task781PostCommitReceiveCount++
+            $candidate = New-Task781SyntheticAckCandidate -ProjectDir $script:task781AckRoot `
+                -SubmissionId submission-task781-post-commit-expiry -Challenge $script:task781AckPipeState.challenge
+            if ($script:task781PostCommitReceiveCount -eq 1) {
+                return [PSCustomObject]@{ client_process_id = 4300; payload = $candidate.envelope }
+            }
+            return [PSCustomObject]@{
+                client_process_id = 4300
+                payload = New-WinsmuxSubmissionAcknowledgementEnvelope -Phase committed `
+                    -Challenge $script:task781AckPipeState.challenge -Receipt $candidate.receipt
+            }
+        }
+        Mock Test-PaneControlRuntimeContext {
+            param($ProjectDir, $ManifestEntry, $Operation, $CallerIdentity, $ProcessResolver)
+            $context = [PSCustomObject]@{
+                generation_id = 'generation-1'; server_session_id = '$9'; slot_id = 'worker-1'; pane_id = '%2'; backend = 'codex'
+            }
+            if ($Operation -eq 'caller_ack') {
+                $script:task781PostCommitCallerChecks++
+                if ($script:task781PostCommitCallerChecks -gt 1) {
+                    return New-WinsmuxRuntimeValidationResult -Valid $false -ReasonCode 'invalid_supervisor_identity' -Diagnostic 'lease expired after commit'
+                }
+            }
+            New-WinsmuxRuntimeValidationResult -Valid $true -ReasonCode 'live_runtime_verified' -Diagnostic 'verified' -Context $context
+        }
+        Mock Write-WinsmuxSubmissionRunRecord { throw 'adapter write must not occur after failed fresh caller validation' }
+        Mock Write-WinsmuxSubmissionAcknowledgementControl { }
+
+        $receipt = Invoke-WinsmuxSubmissionAdapter -ProjectDir $script:task781AckRoot -ManifestEntry $script:task781AckEntry `
+            -Kind task -Content 'Lease expiry after commit must revoke acceptance.' `
+            -SubmissionId submission-task781-post-commit-expiry -SendAction { param($PaneId, $Text) }
+
+        $receipt.status | Should -Be 'unavailable'
+        $receipt.reason_code | Should -Be 'invalid_supervisor_identity'
+        $script:task781PostCommitCallerChecks | Should -Be 2
+        (Test-Path -LiteralPath (Get-WinsmuxSubmissionRunPath -ProjectDir $script:task781AckRoot -SlotId worker-1 -RunId submission-task781-post-commit-expiry)) | Should -BeFalse
+        (Test-Path -LiteralPath (Join-Path $script:task781AckRoot '.winsmux\submissions\submission-task781-post-commit-expiry.json')) | Should -BeTrue
+        Should -Invoke Write-WinsmuxSubmissionRunRecord -Times 0 -Exactly
+        Should -Invoke Complete-WinsmuxSubmissionAcknowledgement -Times 1 -Exactly -ParameterFilter { -not $Verified }
+    }
+
+    It 'TASK781 preserves a racing run record and returns typed commit conflict without overwrite' {
+        $script:task781ConflictReceiveCount = 0
+        Mock Receive-WinsmuxSubmissionAcknowledgement {
+            $script:task781ConflictReceiveCount++
+            $candidate = New-Task781SyntheticAckCandidate -ProjectDir $script:task781AckRoot `
+                -SubmissionId submission-task781-commit-conflict -Challenge $script:task781AckPipeState.challenge
+            if ($script:task781ConflictReceiveCount -eq 1) {
+                return [PSCustomObject]@{ client_process_id = 4300; payload = $candidate.envelope }
+            }
+            $runPath = Get-WinsmuxSubmissionRunPath -ProjectDir $script:task781AckRoot -SlotId worker-1 -RunId submission-task781-commit-conflict
+            New-Item -ItemType Directory -Path (Split-Path -Parent $runPath) -Force | Out-Null
+            [IO.File]::WriteAllText($runPath, 'race-winner', [Text.UTF8Encoding]::new($false))
+            return [PSCustomObject]@{
+                client_process_id = 4300
+                payload = New-WinsmuxSubmissionAcknowledgementEnvelope -Phase committed `
+                    -Challenge $script:task781AckPipeState.challenge -Receipt $candidate.receipt
+            }
+        }
+        Mock Write-WinsmuxSubmissionAcknowledgementControl { }
+
+        $receipt = Invoke-WinsmuxSubmissionAdapter -ProjectDir $script:task781AckRoot -ManifestEntry $script:task781AckEntry `
+            -Kind task -Content 'A racing record must win without overwrite.' -SubmissionId submission-task781-commit-conflict `
+            -SendAction { param($PaneId, $Text) }
+        $runPath = Get-WinsmuxSubmissionRunPath -ProjectDir $script:task781AckRoot -SlotId worker-1 -RunId submission-task781-commit-conflict
+
+        $receipt.status | Should -Be 'rejected'
+        $receipt.reason_code | Should -Be 'run_record_already_exists'
+        (Get-Content -LiteralPath $runPath -Raw -Encoding UTF8) | Should -BeExactly 'race-winner'
+        (Test-Path -LiteralPath (Join-Path $script:task781AckRoot '.winsmux\submissions\submission-task781-commit-conflict.json')) | Should -BeTrue
+        Should -Invoke Complete-WinsmuxSubmissionAcknowledgement -Times 1 -Exactly -ParameterFilter { -not $Verified }
+    }
+
+    It 'TASK781 creates no packet when runtime identity expires before publication' {
+        $script:task781DispatchValidationCount = 0
+        Mock Test-PaneControlRuntimeContext {
+            $script:task781DispatchValidationCount++
+            if ($script:task781DispatchValidationCount -eq 1) {
+                return New-WinsmuxRuntimeValidationResult -Valid $true -ReasonCode 'live_runtime_verified' -Diagnostic 'verified'
+            }
+            return New-WinsmuxRuntimeValidationResult -Valid $false -ReasonCode 'invalid_supervisor_identity' -Diagnostic 'lease expired before send'
+        }
+        $script:task781UnexpectedSendCount = 0
+        $sendAction = {
+            param([string]$PaneId, [string]$Text)
+            $script:task781UnexpectedSendCount++
+            throw 'send must not occur'
+        }
+
+        $receipt = Invoke-WinsmuxSubmissionAdapter -ProjectDir $script:task781AckRoot -ManifestEntry $script:task781AckEntry `
+            -Kind task -Content ([ordered]@{ title = 'TASK781 stale lease'; request = 'Do not send after lease expiry.' }) `
+            -SubmissionId submission-task781-stale-before-send -SendAction $sendAction
+
+        $receipt.status | Should -Be 'unavailable'
+        $receipt.reason_code | Should -Be 'invalid_supervisor_identity'
+        $script:task781UnexpectedSendCount | Should -Be 0
+        (Test-Path -LiteralPath (Join-Path $script:task781AckRoot '.winsmux\submissions\submission-task781-stale-before-send.json')) | Should -BeFalse
+    }
+}
+
+Describe 'TASK781 acknowledgement pipe integration' {
+    BeforeAll {
+        . (Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\pane-control.ps1')
+        . (Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\submission-contract.ps1')
+        $script:task781PipeContractPath = Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\submission-contract.ps1'
+    }
+
+    BeforeEach {
+        $script:task781PipeRoot = Join-Path ([IO.Path]::GetTempPath()) ('winsmux-task781-pipe-' + [guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $script:task781PipeRoot -Force | Out-Null
+        $script:task781PipeClientScript = Join-Path $script:task781PipeRoot 'ack-client.ps1'
+        $script:task781PipeClient = $null
+        $script:task781PipeCallerChecks = 0
+        $script:task781PipeObservedPids = [Collections.Generic.List[int]]::new()
+        $script:task781PipePreviousTimeout = $env:WINSMUX_SUBMISSION_ACK_TIMEOUT_MS
+        $env:WINSMUX_SUBMISSION_ACK_TIMEOUT_MS = '10000'
+        [IO.File]::WriteAllText($script:task781PipeClientScript, @'
+param(
+    [string]$ContractPath,
+    [string]$PipeName,
+    [string]$Challenge,
+    [string]$SubmissionId,
+    [string]$RequestDigest,
+    [switch]$DisconnectBeforeFinal
+)
+$ErrorActionPreference = 'Stop'
+. $ContractPath
+$record = New-WinsmuxSubmissionRunRecord -SubmissionId $SubmissionId -RunId $SubmissionId -Kind task `
+    -TaskTitle 'Actual pipe client' -SlotId worker-1 -Backend local -Status started -RequestConsumed -RequestDigest $RequestDigest
+$receipt = New-WinsmuxSubmissionReceipt -Kind task -Status accepted -Backend local -SubmissionId $SubmissionId `
+    -Target ([ordered]@{ label = 'worker-1'; pane_id = '%2'; role = 'Worker' }) -Acknowledgement $record
+if ($DisconnectBeforeFinal) {
+    $client = [System.IO.Pipes.NamedPipeClientStream]::new(
+        '.', $PipeName, [System.IO.Pipes.PipeDirection]::InOut, [System.IO.Pipes.PipeOptions]::Asynchronous
+    )
+    try {
+        $client.Connect(10000)
+        $candidate = New-WinsmuxSubmissionAcknowledgementEnvelope -Phase candidate -Challenge $Challenge -Receipt $receipt
+        Write-WinsmuxSubmissionPipeFrame -Stream $client -Json ($candidate | ConvertTo-Json -Depth 14 -Compress)
+        $control = Read-WinsmuxSubmissionPipeJson -Stream $client -TimeoutMilliseconds 10000
+        if (-not (Test-WinsmuxSubmissionAcknowledgementControl -Control $control -ExpectedStatus commit)) { exit 2 }
+        $committed = New-WinsmuxSubmissionAcknowledgementEnvelope -Phase committed -Challenge $Challenge -Receipt $receipt
+        Write-WinsmuxSubmissionPipeFrame -Stream $client -Json ($committed | ConvertTo-Json -Depth 14 -Compress)
+    } finally {
+        $client.Dispose()
+    }
+    Start-Sleep -Milliseconds 2000
+    exit 0
+}
+$result = Invoke-WinsmuxSubmissionAcknowledgementClientHandshake `
+    -PipeName $PipeName -Challenge $Challenge -Receipt $receipt
+if ([string]$result.status -eq 'accepted') { exit 0 }
+exit 1
+'@, [Text.UTF8Encoding]::new($false))
+    }
+
+    AfterEach {
+        if ($null -ne $script:task781PipeClient -and -not $script:task781PipeClient.HasExited) {
+            Stop-Process -Id $script:task781PipeClient.Id -Force -ErrorAction SilentlyContinue
+        }
+        if ($null -eq $script:task781PipePreviousTimeout) {
+            Remove-Item Env:WINSMUX_SUBMISSION_ACK_TIMEOUT_MS -ErrorAction SilentlyContinue
+        } else {
+            $env:WINSMUX_SUBMISSION_ACK_TIMEOUT_MS = $script:task781PipePreviousTimeout
+        }
+        if ($script:task781PipeRoot -and (Test-Path -LiteralPath $script:task781PipeRoot)) {
+            Remove-Item -LiteralPath $script:task781PipeRoot -Recurse -Force
+        }
+    }
+
+    It 'TASK781 uses an actual <ClientHost> pipe client for <Mode>' -ForEach @(
+        @{ ClientHost = 'pwsh'; Mode = 'success' }
+        @{ ClientHost = 'powershell.exe'; Mode = 'success' }
+        @{ ClientHost = 'pwsh'; Mode = 'post_commit_reject' }
+        @{ ClientHost = 'powershell.exe'; Mode = 'post_commit_reject' }
+        @{ ClientHost = 'pwsh'; Mode = 'create_new_conflict' }
+        @{ ClientHost = 'pwsh'; Mode = 'client_receive_failure' }
+    ) {
+        $script:task781PipeMode = $Mode
+        $clientHolder = [PSCustomObject]@{ Process = $null }
+        $clientScriptPath = $script:task781PipeClientScript
+        $contractPath = $script:task781PipeContractPath
+        $clientHost = $ClientHost
+        $submissionId = 'submission-task781-actual-' + ($Mode -replace '_', '-') + '-' + ($ClientHost -replace '[^A-Za-z0-9]', '-')
+        $request = 'Actual two-phase pipe request for ' + $Mode + ' on ' + $ClientHost
+        $requestDigest = Get-WinsmuxSubmissionRequestDigest -Request $request
+        $entry = [PSCustomObject]@{
+            Label = 'worker-1'; SlotId = 'worker-1'; PaneId = '%2'; Role = 'Worker'; WorkerRole = 'worker'
+            WorkerBackend = 'local'; Title = 'W1 Local Worker'; Status = 'ready'
+        }
+        Mock Test-PaneControlRuntimeContext {
+            param($ProjectDir, $ManifestEntry, $Operation, $CallerIdentity, $ProcessResolver)
+            $context = [PSCustomObject]@{
+                generation_id = 'generation-actual'; server_session_id = '$9'; slot_id = 'worker-1'
+                pane_id = '%2'; backend = 'local'
+            }
+            if ($Operation -eq 'caller_ack') {
+                $script:task781PipeCallerChecks++
+                $script:task781PipeObservedPids.Add([int]$CallerIdentity.process_id) | Out-Null
+                if ($script:task781PipeMode -eq 'create_new_conflict' -and $script:task781PipeCallerChecks -eq 1) {
+                    $racePath = Get-WinsmuxSubmissionRunPath -ProjectDir $script:task781PipeRoot -SlotId worker-1 -RunId $submissionId
+                    New-Item -ItemType Directory -Path (Split-Path -Parent $racePath) -Force | Out-Null
+                    [IO.File]::WriteAllText($racePath, 'race-winner', [Text.UTF8Encoding]::new($false))
+                }
+                if ($script:task781PipeMode -eq 'post_commit_reject' -and $script:task781PipeCallerChecks -gt 1) {
+                    return New-WinsmuxRuntimeValidationResult -Valid $false -ReasonCode 'invalid_supervisor_identity' -Diagnostic 'synthetic post-commit expiry'
+                }
+            }
+            New-WinsmuxRuntimeValidationResult -Valid $true -ReasonCode 'live_runtime_verified' -Diagnostic 'verified' -Context $context
+        }
+        $sendAction = {
+            param([string]$PaneId, [string]$Text)
+            if ($Text -notmatch '--ack-pipe (?<pipe>winsmux-submission-ack-[0-9a-f]{32}) --challenge (?<challenge>[0-9a-f]{64})') {
+                throw 'actual acknowledgement command is missing pipe identity'
+            }
+            $arguments = @(
+                '-NoProfile', '-File', $clientScriptPath,
+                '-ContractPath', $contractPath,
+                '-PipeName', $Matches.pipe,
+                '-Challenge', $Matches.challenge,
+                '-SubmissionId', $submissionId,
+                '-RequestDigest', $requestDigest
+            )
+            if ($Mode -eq 'client_receive_failure') { $arguments += '-DisconnectBeforeFinal' }
+            $clientHolder.Process = Start-Process -FilePath $clientHost `
+                -ArgumentList $arguments -PassThru -WindowStyle Hidden
+        }.GetNewClosure()
+
+        $receipt = Invoke-WinsmuxSubmissionAdapter -ProjectDir $script:task781PipeRoot -ManifestEntry $entry `
+            -Kind task -Content $request -SubmissionId $submissionId -SendAction $sendAction
+        $script:task781PipeClient = $clientHolder.Process
+        $script:task781PipeClient | Should -Not -BeNullOrEmpty -Because (
+            'the adapter receipt was {0}/{1}' -f [string]$receipt.status, [string]$receipt.reason_code)
+        $script:task781PipeClient.WaitForExit(15000) | Should -BeTrue
+        $runPath = Get-WinsmuxSubmissionRunPath -ProjectDir $script:task781PipeRoot -SlotId worker-1 -RunId $submissionId
+        $packetPath = Join-Path $script:task781PipeRoot ".winsmux\submissions\$submissionId.json"
+
+        @($script:task781PipeObservedPids | Select-Object -Unique) | Should -Be @($script:task781PipeClient.Id)
+        if ($Mode -in @('success', 'client_receive_failure')) {
+            $receipt.status | Should -Be 'accepted' -Because (
+                'the acknowledgement reason was {0}: {1}' -f [string]$receipt.reason_code, [string]$receipt.diagnostic)
+            $script:task781PipeClient.ExitCode | Should -Be 0
+            Test-Path -LiteralPath $runPath -PathType Leaf | Should -BeTrue
+            Test-Path -LiteralPath $packetPath -PathType Leaf | Should -BeTrue
+            $script:task781PipeCallerChecks | Should -Be 2
+        } elseif ($Mode -eq 'post_commit_reject') {
+            $receipt.status | Should -Be 'unavailable'
+            $receipt.reason_code | Should -Be 'invalid_supervisor_identity'
+            $script:task781PipeClient.ExitCode | Should -Be 1
+            Test-Path -LiteralPath $runPath -PathType Leaf | Should -BeFalse
+            Test-Path -LiteralPath $packetPath -PathType Leaf | Should -BeTrue
+            $committedPacketText = Get-Content -LiteralPath $packetPath -Raw -Encoding UTF8
+            $duplicate = Invoke-WinsmuxSubmissionAdapter -ProjectDir $script:task781PipeRoot -ManifestEntry $entry `
+                -Kind task -Content 'replacement must not overwrite committed packet' -SubmissionId $submissionId `
+                -SendAction { throw 'duplicate must stop before delivery' }
+            $duplicate.status | Should -Be 'rejected'
+            $duplicate.reason_code | Should -Be 'run_record_already_exists'
+            (Get-Content -LiteralPath $packetPath -Raw -Encoding UTF8) | Should -BeExactly $committedPacketText
+            $script:task781PipeCallerChecks | Should -Be 2
+        } else {
+            $receipt.status | Should -Be 'rejected'
+            $receipt.reason_code | Should -Be 'run_record_already_exists'
+            $script:task781PipeClient.ExitCode | Should -Be 1
+            (Get-Content -LiteralPath $runPath -Raw -Encoding UTF8) | Should -BeExactly 'race-winner'
+            Test-Path -LiteralPath $packetPath -PathType Leaf | Should -BeTrue
+            $committedPacketText = Get-Content -LiteralPath $packetPath -Raw -Encoding UTF8
+            $duplicate = Invoke-WinsmuxSubmissionAdapter -ProjectDir $script:task781PipeRoot -ManifestEntry $entry `
+                -Kind task -Content 'replacement must not overwrite committed packet' -SubmissionId $submissionId `
+                -SendAction { throw 'duplicate must stop before delivery' }
+            $duplicate.status | Should -Be 'rejected'
+            $duplicate.reason_code | Should -Be 'run_record_already_exists'
+            (Get-Content -LiteralPath $packetPath -Raw -Encoding UTF8) | Should -BeExactly $committedPacketText
+            $script:task781PipeCallerChecks | Should -Be 2
+        }
+        @(Get-ChildItem -LiteralPath (Join-Path $script:task781PipeRoot '.winsmux') -Recurse -File -ErrorAction SilentlyContinue |
+            Where-Object { $_.Name -match '\.(tmp|partial)$' }).Count | Should -Be 0
+    }
+}
+
+Describe 'TASK781 atomic acknowledgement run records' {
+    BeforeAll {
+        . (Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\submission-contract.ps1')
+    }
+
+    BeforeEach {
+        $script:task781AtomicRoot = Join-Path ([IO.Path]::GetTempPath()) ('winsmux-task781-atomic-' + [guid]::NewGuid().ToString('N'))
+        $script:task781AtomicId = 'submission-task781-atomic'
+        $script:task781AtomicRecord = New-WinsmuxSubmissionRunRecord -SubmissionId $script:task781AtomicId `
+            -RunId $script:task781AtomicId -Kind task -TaskTitle 'Atomic acknowledgement record' -SlotId worker-1 `
+            -Backend codex -Status started -RequestConsumed -RequestDigest ('a' * 64)
+    }
+
+    AfterEach {
+        Remove-Item -LiteralPath $script:task781AtomicRoot -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    It 'TASK781 leaves no partial run artifact after <Mode>' -ForEach @(
+        @{ Mode = 'write_failure' }
+        @{ Mode = 'flush_failure' }
+        @{ Mode = 'move_failure' }
+        @{ Mode = 'existing_winner' }
+    ) {
+        $runPath = Get-WinsmuxSubmissionRunPath -ProjectDir $script:task781AtomicRoot -SlotId worker-1 `
+            -RunId $script:task781AtomicId
+        if ($Mode -in @('write_failure', 'flush_failure')) {
+            Mock Write-WinsmuxSubmissionRunRecordTempFile {
+                param([string]$Path, [byte[]]$Bytes)
+                $length = if ($Mode -eq 'write_failure') { [Math]::Min(8, $Bytes.Length) } else { $Bytes.Length }
+                [IO.File]::WriteAllBytes($Path, $Bytes[0..($length - 1)])
+                throw "synthetic $Mode"
+            }
+        } elseif ($Mode -eq 'move_failure') {
+            Mock Move-WinsmuxSubmissionRunRecordFile { throw 'synthetic move failure' }
+        } else {
+            New-Item -ItemType Directory -Path (Split-Path -Parent $runPath) -Force | Out-Null
+            [IO.File]::WriteAllText($runPath, 'race-winner', [Text.UTF8Encoding]::new($false))
+        }
+
+        {
+            Write-WinsmuxSubmissionRunRecord -ProjectDir $script:task781AtomicRoot -SlotId worker-1 `
+                -Record $script:task781AtomicRecord
+        } | Should -Throw
+
+        if ($Mode -eq 'existing_winner') {
+            (Get-Content -LiteralPath $runPath -Raw -Encoding UTF8) | Should -BeExactly 'race-winner'
+        } else {
+            Test-Path -LiteralPath $runPath -PathType Leaf | Should -BeFalse
+        }
+        @(Get-ChildItem -LiteralPath (Split-Path -Parent $runPath) -Filter '.run-*.tmp' -File `
+            -ErrorAction SilentlyContinue).Count | Should -Be 0
+    }
+}
+
 Describe 'winsmux pane env contract' {
     BeforeAll {
         . (Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\pane-env.ps1')
@@ -3514,6 +5340,63 @@ panes:
         $manifestContent | Should -Match $([regex]::Escape("'builder-2':"))
     }
 
+    It 'TASK781 C19 threads the generation captured with the label context into the setter' {
+        $script:capturedWrapperGeneration = ''
+        Mock Get-PaneControlManifestContext {
+            [pscustomobject]@{
+                ManifestPath = 'C:\repo\.winsmux\manifest.yaml'
+                Label = 'builder-1'
+                GenerationId = 'generation-initial'
+            }
+        }
+        Mock Get-PaneControlPaneTitle { 'builder-2' }
+        Mock Get-PaneControlManifestGenerationId { 'generation-replacement' }
+        Mock Set-PaneControlManifestPaneProperties {
+            param($ManifestPath, $PaneId, $Properties, $ExpectedGenerationId)
+            $script:capturedWrapperGeneration = [string]$ExpectedGenerationId
+        }
+
+        Update-PaneControlManifestPaneLabel -ProjectDir 'C:\repo' -PaneId '%2' | Should -BeTrue
+
+        $script:capturedWrapperGeneration | Should -BeExactly 'generation-initial'
+        Should -Invoke Get-PaneControlManifestGenerationId -Times 0 -Exactly
+    }
+
+    It 'TASK781 C19 threads the generation captured with the path context into the setter' {
+        $script:capturedWrapperGeneration = ''
+        Mock Get-PaneControlManifestContext {
+            [pscustomobject]@{
+                ManifestPath = 'C:\repo\.winsmux\manifest.yaml'
+                GenerationId = 'generation-initial'
+            }
+        }
+        Mock Get-PaneControlManifestGenerationId { 'generation-replacement' }
+        Mock Set-PaneControlManifestPaneProperties {
+            param($ManifestPath, $PaneId, $Properties, $ExpectedGenerationId)
+            $script:capturedWrapperGeneration = [string]$ExpectedGenerationId
+        }
+
+        Set-PaneControlManifestPanePaths -ProjectDir 'C:\repo' -PaneId '%2' `
+            -LaunchDir 'C:\repo\.worktrees\builder-9'
+
+        $script:capturedWrapperGeneration | Should -BeExactly 'generation-initial'
+        Should -Invoke Get-PaneControlManifestGenerationId -Times 0 -Exactly
+    }
+
+    It 'TASK781 C19 forbids generation recapture in manifest mutation callers' {
+        $repoRoot = Split-Path -Parent $PSScriptRoot
+        foreach ($relativePath in @(
+            'scripts\winsmux-core.ps1',
+            'winsmux-core\scripts\agent-monitor.ps1',
+            'winsmux-core\scripts\builder-queue.ps1',
+            'winsmux-core\scripts\operator-poll.ps1',
+            'winsmux-core\scripts\pane-scaler.ps1'
+        )) {
+            $source = Get-Content -LiteralPath (Join-Path $repoRoot $relativePath) -Raw -Encoding UTF8
+            $source | Should -Not -Match '\bGet-PaneControlManifestGenerationId\b' -Because "$relativePath must thread the generation captured with its manifest snapshot"
+        }
+    }
+
     It 'reads pane titles through the pane-control winsmux wrapper' {
         Mock Invoke-PaneControlWinsmux { @('ignored', 'builder-7') } -ParameterFilter {
             $Arguments.Count -eq 5 -and
@@ -3573,6 +5456,275 @@ panes:
         $entry.SecurityPolicy.mode | Should -Be 'blocklist'
         @($entry.SecurityPolicy.allow_patterns) | Should -Be @('Invoke-Pester')
         @($entry.SecurityPolicy.block_patterns) | Should -Be @('git reset --hard')
+    }
+
+    It 'TASK781 C48 refuses a stale v2 manifest mutation before Save-WinsmuxManifest' {
+        $manifestPath = Join-Path $script:paneControlManifestDir 'manifest.yaml'
+        'synthetic v2 manifest' | Set-Content -LiteralPath $manifestPath -Encoding UTF8
+        $manifest = [PSCustomObject]@{
+            version = 2
+            session = [PSCustomObject]@{ generation_id = 'generation-1' }
+            panes = [ordered]@{
+                'worker-1' = [ordered]@{
+                    slot_id = 'worker-1'; pane_id = '%2'; worker_backend = 'codex'; worker_role = 'reviewer'
+                    role = 'Reviewer'; title = 'W1 Codex Reviewer'; status = 'ready'
+                }
+            }
+        }
+        $entry = [PSCustomObject]@{
+            Label = 'worker-1'; SlotId = 'worker-1'; PaneId = '%2'; WorkerBackend = 'codex'
+            WorkerRole = 'reviewer'; Role = 'Reviewer'; Title = 'W1 Codex Reviewer'; Status = 'ready'
+        }
+        Mock Get-WinsmuxManifest { $manifest }
+        Mock Get-PaneControlManifestContext { $entry }
+        Mock Test-PaneControlRuntimeContext {
+            New-WinsmuxRuntimeValidationResult -Valid $false -ReasonCode 'invalid_supervisor_identity' `
+                -Diagnostic 'generation expired immediately before manifest save'
+        }
+        Mock Save-WinsmuxManifest { throw 'save must not run after lease expiry' }
+
+        {
+            Set-PaneControlManifestPaneProperties -ManifestPath $manifestPath -PaneId '%2' `
+                -Properties ([ordered]@{ status = 'ready' }) -ExpectedGenerationId 'generation-1'
+        } | Should -Throw '*invalid_supervisor_identity*generation expired immediately before manifest save*'
+
+        Assert-MockCalled Save-WinsmuxManifest -Times 0 -Exactly
+    }
+
+    It 'TASK781 C48 requires a captured generation for every v2 manifest mutation' {
+        $manifestPath = Join-Path $script:paneControlManifestDir 'manifest.yaml'
+        'synthetic v2 manifest' | Set-Content -LiteralPath $manifestPath -Encoding UTF8
+        $manifest = [PSCustomObject]@{
+            version = 2
+            session = [PSCustomObject]@{ generation_id = 'generation-1' }
+            panes = [ordered]@{
+                'worker-1' = [ordered]@{ pane_id = '%2'; status = 'ready' }
+            }
+        }
+        Mock Get-WinsmuxManifest { $manifest }
+        Mock Save-WinsmuxManifest { throw 'save must not run without a captured generation' }
+
+        {
+            Set-PaneControlManifestPaneProperties -ManifestPath $manifestPath -PaneId '%2' `
+                -Properties ([ordered]@{ status = 'ready' })
+        } | Should -Throw '*ExpectedGenerationId is required*'
+
+        Assert-MockCalled Save-WinsmuxManifest -Times 0 -Exactly
+    }
+
+    It 'TASK781 C52 validates the captured v2 generation and live lease in the shared document save path' {
+        $manifestPath = Join-Path $script:paneControlManifestDir 'manifest.yaml'
+        'synthetic v2 manifest' | Set-Content -LiteralPath $manifestPath -Encoding UTF8
+        $manifest = [PSCustomObject]@{
+            version = 2
+            session = [PSCustomObject]@{
+                name = 'winsmux-orchestra'; generation_id = 'generation-52'; server_session_id = '$52'; bootstrap_pane_id = '%1'
+            }
+            panes = [ordered]@{
+                'worker-1' = [ordered]@{ pane_id = '%2'; status = 'ready' }
+            }
+        }
+        $entry = [PSCustomObject]@{
+            Label = 'worker-1'; SlotId = 'worker-1'; PaneId = '%2'; WorkerBackend = 'codex'; Status = 'ready'
+        }
+        Mock Get-WinsmuxManifest { $manifest }
+        Mock Get-PaneControlManifestContext { $entry }
+        Mock Test-PaneControlRuntimeContext {
+            [PSCustomObject]@{
+                valid = $true
+                reason_code = 'runtime_valid'
+                diagnostic = 'synthetic live lease'
+                context = [PSCustomObject]@{ generation_id = 'generation-52' }
+            }
+        }
+        Mock Save-WinsmuxManifest {}
+
+        Save-PaneControlManifestDocument -ManifestPath $manifestPath -Manifest $manifest -ExpectedGenerationId 'generation-52'
+
+        Assert-MockCalled Test-PaneControlRuntimeContext -Times 1 -Exactly -ParameterFilter {
+            $ProjectDir -eq $script:paneControlTempRoot -and $ManifestEntry.PaneId -eq '%2'
+        }
+        Assert-MockCalled Save-WinsmuxManifest -Times 1 -Exactly
+    }
+
+    It 'TASK781 C57 refuses a guarded v2 document save after current manifest becomes <Case>' -ForEach @(
+        @{ Case = 'v1'; CurrentManifest = [PSCustomObject]@{ version = 1; panes = [ordered]@{} } }
+        @{ Case = 'unknown schema'; CurrentManifest = [PSCustomObject]@{ version = 99; panes = [ordered]@{} } }
+        @{ Case = 'empty'; CurrentManifest = $null }
+    ) {
+        $manifestPath = Join-Path $script:paneControlManifestDir 'manifest.yaml'
+        'synthetic manifest' | Set-Content -LiteralPath $manifestPath -Encoding UTF8
+        $nextManifest = [PSCustomObject]@{
+            version = 2
+            session = [PSCustomObject]@{
+                name = 'winsmux-orchestra'; generation_id = 'generation-57'; server_session_id = '$57'; bootstrap_pane_id = '%1'
+            }
+            panes = [ordered]@{
+                'worker-1' = [ordered]@{ pane_id = '%2'; status = 'ready' }
+            }
+        }
+        $script:c57CurrentManifest = $CurrentManifest
+        Mock Get-WinsmuxManifest { $script:c57CurrentManifest }
+        Mock Save-WinsmuxManifest { throw 'save must not run after a guarded v2 schema transition' }
+
+        {
+            Save-PaneControlManifestDocument -ManifestPath $manifestPath -Manifest $nextManifest `
+                -ExpectedGenerationId 'generation-57'
+        } | Should -Throw '*manifest_regeneration_required*'
+
+        Assert-MockCalled Save-WinsmuxManifest -Times 0 -Exactly
+    }
+
+    It 'TASK781 C57 preserves an unguarded pure v1 document save' {
+        $manifestPath = Join-Path $script:paneControlManifestDir 'manifest.yaml'
+        'synthetic v1 manifest' | Set-Content -LiteralPath $manifestPath -Encoding UTF8
+        $v1Manifest = [PSCustomObject]@{ version = 1; panes = [ordered]@{} }
+        Mock Get-WinsmuxManifest { $v1Manifest }
+        Mock Save-WinsmuxManifest {}
+
+        Save-PaneControlManifestDocument -ManifestPath $manifestPath -Manifest $v1Manifest
+
+        Assert-MockCalled Save-WinsmuxManifest -Times 1 -Exactly
+    }
+
+    It 'TASK781 C60 rejects a guarded v2 save when the locked document becomes <Case>' -ForEach @(
+        @{ Case = 'v1'; ExpectedReason = 'manifest_regeneration_required' }
+        @{ Case = 'unknown schema'; ExpectedReason = 'manifest_regeneration_required' }
+        @{ Case = 'empty'; ExpectedReason = 'manifest_regeneration_required' }
+        @{ Case = 'deleted'; ExpectedReason = 'manifest_regeneration_required' }
+        @{ Case = 'another generation'; ExpectedReason = 'invalid_supervisor_identity' }
+    ) {
+        $current = [ordered]@{
+            version = 2
+            saved_at = '2026-07-15T19:40:00+09:00'
+            session = [ordered]@{
+                name = 'winsmux-orchestra'
+                generation_id = 'generation-1'
+                server_session_id = '$60'
+                bootstrap_pane_id = '%1'
+                expected_pane_count = 1
+            }
+            panes = [ordered]@{
+                'worker-1' = [ordered]@{ pane_id = '%2'; slot_id = 'worker-1'; status = 'ready' }
+            }
+            tasks = [ordered]@{ queued = @(); in_progress = @(); completed = @() }
+            worktrees = [ordered]@{}
+        }
+        Save-WinsmuxManifest -ProjectDir $script:paneControlTempRoot -Manifest $current
+        $path = Get-ManifestPath -ProjectDir $script:paneControlTempRoot
+        $next = ConvertFrom-ManifestYaml -Content (ConvertTo-ManifestYaml -Manifest $current)
+
+        switch ($Case) {
+            'v1' { $script:c60CompetingContent = "version: 1`nsession:`n  name: legacy`n" }
+            'unknown schema' { $script:c60CompetingContent = "version: 99`nsession:`n  name: unknown`n" }
+            'empty' { $script:c60CompetingContent = '' }
+            'deleted' { $script:c60CompetingContent = $null }
+            'another generation' {
+                $competing = ConvertFrom-ManifestYaml -Content (ConvertTo-ManifestYaml -Manifest $current)
+                $competing.session.generation_id = 'generation-competing'
+                $script:c60CompetingContent = ConvertTo-ManifestYaml -Manifest $competing
+            }
+        }
+
+        Mock Invoke-WinsmuxWithFileLock {
+            param([string]$Path, [scriptblock]$Action)
+            if ($null -eq $script:c60CompetingContent) {
+                Remove-Item -LiteralPath $Path -Force
+            } else {
+                [System.IO.File]::WriteAllText($Path, [string]$script:c60CompetingContent, [System.Text.UTF8Encoding]::new($false))
+            }
+            & $Action
+        }
+
+        {
+            Save-WinsmuxManifest -ProjectDir $script:paneControlTempRoot -Manifest $next `
+                -ExpectedGenerationId 'generation-1'
+        } | Should -Throw ('*' + $ExpectedReason + '*')
+
+        if ($null -eq $script:c60CompetingContent) {
+            Test-Path -LiteralPath $path | Should -BeFalse
+        } else {
+            [System.IO.File]::ReadAllText($path) | Should -Be ([string]$script:c60CompetingContent)
+        }
+    }
+
+    It 'TASK781 C60 atomically saves a same-generation v2 document with an explicit guard' {
+        $current = [ordered]@{
+            version = 2
+            saved_at = '2026-07-15T19:40:00+09:00'
+            session = [ordered]@{
+                name = 'winsmux-orchestra'
+                generation_id = 'generation-1'
+                server_session_id = '$60'
+                bootstrap_pane_id = '%1'
+                expected_pane_count = 1
+            }
+            panes = [ordered]@{
+                'worker-1' = [ordered]@{ pane_id = '%2'; slot_id = 'worker-1'; status = 'ready' }
+            }
+            tasks = [ordered]@{ queued = @(); in_progress = @(); completed = @() }
+            worktrees = [ordered]@{}
+        }
+        Save-WinsmuxManifest -ProjectDir $script:paneControlTempRoot -Manifest $current
+        $next = ConvertFrom-ManifestYaml -Content (ConvertTo-ManifestYaml -Manifest $current)
+        $next.saved_at = '2026-07-15T19:45:00+09:00'
+
+        Save-WinsmuxManifest -ProjectDir $script:paneControlTempRoot -Manifest $next `
+            -ExpectedGenerationId 'generation-1'
+
+        (Get-WinsmuxManifest -ProjectDir $script:paneControlTempRoot).saved_at | Should -Be '2026-07-15T19:45:00+09:00'
+    }
+
+    It 'TASK781 C60 preserves an unguarded first-write v2 diagnostic document' {
+        $diagnostic = [ordered]@{
+            version = 2
+            saved_at = '2026-07-15T19:46:00+09:00'
+            session = [ordered]@{ name = 'diagnostic-only' }
+            panes = [ordered]@{}
+            tasks = [ordered]@{ queued = @(); in_progress = @(); completed = @() }
+            worktrees = [ordered]@{}
+        }
+
+        Save-WinsmuxManifest -ProjectDir $script:paneControlTempRoot -Manifest $diagnostic
+
+        $saved = Get-WinsmuxManifest -ProjectDir $script:paneControlTempRoot
+        $saved.version | Should -Be 2
+        $saved.session.name | Should -Be 'diagnostic-only'
+    }
+
+    It 'TASK781 C54 refuses a v2 whole-document save when no managed runtime pane exists' {
+        $manifestPath = Join-Path $script:paneControlManifestDir 'manifest.yaml'
+        'synthetic v2 manifest' | Set-Content -LiteralPath $manifestPath -Encoding UTF8
+        $manifest = [PSCustomObject]@{
+            version = 2
+            session = [PSCustomObject]@{
+                name = 'winsmux-orchestra'; generation_id = 'generation-54'; server_session_id = '$54'; bootstrap_pane_id = '%1'
+            }
+            panes = [ordered]@{}
+        }
+        Mock Get-WinsmuxManifest { $manifest }
+        Mock Get-PaneControlManifestContext { throw 'bootstrap pane must not be selected as a managed runtime pane' }
+        Mock Save-WinsmuxManifest { throw 'save must not run without a managed runtime pane' }
+
+        {
+            Save-PaneControlManifestDocument -ManifestPath $manifestPath -Manifest $manifest -ExpectedGenerationId 'generation-54'
+        } | Should -Throw '*managed runtime pane*'
+
+        Assert-MockCalled Get-PaneControlManifestContext -Times 0 -Exactly
+        Assert-MockCalled Save-WinsmuxManifest -Times 0 -Exactly
+    }
+
+    It 'TASK781 C52 routes every production whole-document mutation caller through the guarded save path' {
+        $repoRoot = Split-Path -Parent $PSScriptRoot
+        foreach ($relativePath in @(
+            'winsmux-core\scripts\orchestra-state.ps1',
+            'winsmux-core\scripts\builder-queue.ps1',
+            'winsmux-core\scripts\pane-scaler.ps1'
+        )) {
+            $content = Get-Content -LiteralPath (Join-Path $repoRoot $relativePath) -Raw -Encoding UTF8
+            $content | Should -Match 'Save-PaneControlManifestDocument'
+            $content | Should -Not -Match '(?m)^\s*Save-WinsmuxManifest\s'
+        }
     }
 
 }
@@ -3906,6 +6058,54 @@ Describe 'agent-monitor helpers' {
 
     BeforeEach {
         Mock Send-MonitorOperatorMailboxMessage { return $true }
+    }
+
+    It 'TASK781 C19 threads the respawn snapshot generation into its label update' {
+        $script:capturedMonitorGeneration = ''
+        Mock Test-Path { $true }
+        Mock Get-PaneControlManifestContext {
+            [pscustomobject]@{ GenerationId = 'generation-replacement' }
+        }
+        Mock Set-PaneControlManifestPaneProperties {
+            param($ManifestPath, $PaneId, $Properties, $ExpectedGenerationId)
+            $script:capturedMonitorGeneration = [string]$ExpectedGenerationId
+        }
+
+        Update-MonitorManifestPaneLabel -ManifestPath 'C:\repo\.winsmux\manifest.yaml' -PaneId '%2' `
+            -Label 'builder-2' -ExpectedGenerationId 'generation-initial' | Should -BeTrue
+
+        $script:capturedMonitorGeneration | Should -BeExactly 'generation-initial'
+        Should -Invoke Get-PaneControlManifestContext -Times 0 -Exactly
+    }
+
+    It 'TASK781 C19 carries the cycle generation through the production respawn caller' {
+        $manifestPath = Join-Path $TestDrive 'respawn-manifest.yaml'
+        'invalid-but-existing' | Set-Content -LiteralPath $manifestPath -Encoding UTF8
+        $script:respawnCallerGeneration = ''
+        Mock Invoke-MonitorWinsmux { }
+        Mock Wait-MonitorPaneShellReady { }
+        Mock Send-MonitorBridgeCommand { }
+        Mock Start-Sleep { }
+        Mock Get-PaneAgentStatus {
+            [pscustomobject]@{ Status = 'ready'; PaneId = '%2'; SnapshotTail = ''; ExitReason = '' }
+        }
+        Mock Get-MonitorPaneTitle { 'builder-2' }
+        Mock Get-PaneControlManifestContext {
+            [pscustomobject]@{ GenerationId = 'generation-replacement' }
+        }
+        Mock Update-MonitorManifestPaneLabel {
+            $script:respawnCallerGeneration = [string]$ExpectedGenerationId
+            return $true
+        }
+
+        $result = Invoke-AgentRespawn -PaneId '%2' -Agent 'codex' -Model 'gpt-5.4' `
+            -ProjectDir $TestDrive -GitWorktreeDir (Join-Path $TestDrive '.git\worktrees\builder-2') `
+            -RootPath $TestDrive -ManifestPath $manifestPath -ExpectedGenerationId 'generation-initial' `
+            -ReadyTimeoutSeconds 1
+
+        $result.Success | Should -BeTrue
+        $script:respawnCallerGeneration | Should -BeExactly 'generation-initial'
+        Should -Invoke Get-PaneControlManifestContext -Times 0 -Exactly
     }
 
     It 'builds v2 mailbox envelope metadata before sending monitor messages' {
@@ -5550,6 +7750,217 @@ session:
 Describe 'orchestra-preflight health contract' {
     BeforeAll {
         . (Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\orchestra-preflight.ps1')
+
+        function New-C66ServerProcessSnapshot {
+            param([switch]$IncludeServer)
+
+            $processes = @()
+            $byId = @{}
+            if ($IncludeServer) {
+                $server = [PSCustomObject]@{
+                    ProcessId       = 41001
+                    ParentProcessId = 0
+                    Name            = 'winsmux.exe'
+                    CommandLine     = 'winsmux server -s winsmux-orchestra'
+                    ExecutablePath  = 'C:\tools\winsmux.exe'
+                }
+                $processes = @($server)
+                $byId[41001] = $server
+            }
+            return [PSCustomObject]@{
+                Processes        = $processes
+                ById             = $byId
+                ChildrenByParent = @{}
+            }
+        }
+    }
+
+    It 'TASK781 C66 propagates a matched server stop failure even when the session is absent' {
+        $snapshot = New-C66ServerProcessSnapshot -IncludeServer
+        Mock Stop-Process { throw 'synthetic access denied' }
+
+        {
+            Remove-OrchestraSessionServerProcesses `
+                -SessionName 'winsmux-orchestra' `
+                -WinsmuxBin 'C:\tools\winsmux.exe' `
+                -IncludeExpectedBinary `
+                -ProcessSnapshot $snapshot `
+                -PostStopSnapshotResolver { New-C66ServerProcessSnapshot }
+        } | Should -Throw '*synthetic access denied*'
+    }
+
+    It 'TASK781 C66 rejects a matched server that remains after a successful stop request' {
+        $snapshot = New-C66ServerProcessSnapshot -IncludeServer
+        Mock Stop-Process { }
+
+        {
+            Remove-OrchestraSessionServerProcesses `
+                -SessionName 'winsmux-orchestra' `
+                -WinsmuxBin 'C:\tools\winsmux.exe' `
+                -IncludeExpectedBinary `
+                -ProcessSnapshot $snapshot `
+                -PostStopSnapshotResolver { New-C66ServerProcessSnapshot -IncludeServer } `
+                -VerificationAttempts 1 `
+                -VerificationIntervalMilliseconds 0
+        } | Should -Throw '*server processes remain*'
+    }
+
+    It 'TASK781 C66 rejects a matching server that appears after an initially empty snapshot' {
+        Mock Stop-Process { throw 'no stop should occur for the empty initial snapshot' }
+
+        {
+            Remove-OrchestraSessionServerProcesses `
+                -SessionName 'winsmux-orchestra' `
+                -WinsmuxBin 'C:\tools\winsmux.exe' `
+                -IncludeExpectedBinary `
+                -ProcessSnapshot (New-C66ServerProcessSnapshot) `
+                -PostStopSnapshotResolver { New-C66ServerProcessSnapshot -IncludeServer } `
+                -VerificationAttempts 1 `
+                -VerificationIntervalMilliseconds 0
+        } | Should -Throw '*server processes remain*'
+    }
+
+    It 'TASK781 C66 succeeds only after a fresh snapshot proves matching server absence' {
+        $snapshot = New-C66ServerProcessSnapshot -IncludeServer
+        Mock Stop-Process { }
+
+        $result = Remove-OrchestraSessionServerProcesses `
+            -SessionName 'winsmux-orchestra' `
+            -WinsmuxBin 'C:\tools\winsmux.exe' `
+            -IncludeExpectedBinary `
+            -ProcessSnapshot $snapshot `
+            -PostStopSnapshotResolver { New-C66ServerProcessSnapshot } `
+            -VerificationAttempts 1 `
+            -VerificationIntervalMilliseconds 0
+
+        @($result.SessionProcesses).Count | Should -Be 1
+        @($result.Killed).Count | Should -Be 1
+        @($result.RemainingSessionProcesses).Count | Should -Be 0
+        @($result.Errors).Count | Should -Be 0
+    }
+
+    It 'isolates stale session server matching to the resolved bridge namespace' {
+        $previousNamespace = $env:WINSMUX_BRIDGE_NAMESPACE_L
+        $previousSocket = $env:WINSMUX_BRIDGE_SOCKET_S
+        $previousSessionNamespace = $env:WINSMUX_BRIDGE_SESSION_NAMESPACE
+        try {
+            $env:WINSMUX_BRIDGE_SESSION_NAMESPACE = 'task781-smoke-20260715'
+            $env:WINSMUX_BRIDGE_SOCKET_S = 'lower-priority-socket'
+            $env:WINSMUX_BRIDGE_NAMESPACE_L = 'lower-priority-L'
+            $matching = [pscustomobject]@{ Name = 'winsmux.exe'; CommandLine = 'winsmux server -s winsmux-orchestra -L task781-smoke-20260715' }
+            $different = [pscustomobject]@{ Name = 'winsmux.exe'; CommandLine = 'winsmux server -s winsmux-orchestra -L other-namespace' }
+            $missing = [pscustomobject]@{ Name = 'winsmux.exe'; CommandLine = 'winsmux server -s winsmux-orchestra' }
+
+            (Test-OrchestraSessionServerProcess -Process $matching -SessionName 'winsmux-orchestra') | Should -BeTrue
+            (Test-OrchestraSessionServerProcess -Process $different -SessionName 'winsmux-orchestra') | Should -BeFalse
+            (Test-OrchestraSessionServerProcess -Process $missing -SessionName 'winsmux-orchestra') | Should -BeFalse
+
+            Remove-Item Env:\WINSMUX_BRIDGE_SESSION_NAMESPACE -ErrorAction SilentlyContinue
+            Remove-Item Env:\WINSMUX_BRIDGE_SOCKET_S -ErrorAction SilentlyContinue
+            Remove-Item Env:\WINSMUX_BRIDGE_NAMESPACE_L -ErrorAction SilentlyContinue
+            (Test-OrchestraSessionServerProcess -Process $missing -SessionName 'winsmux-orchestra') | Should -BeTrue
+            (Test-OrchestraSessionServerProcess -Process $matching -SessionName 'winsmux-orchestra') | Should -BeFalse
+        } finally {
+            if ($null -eq $previousNamespace) { Remove-Item Env:\WINSMUX_BRIDGE_NAMESPACE_L -ErrorAction SilentlyContinue } else { $env:WINSMUX_BRIDGE_NAMESPACE_L = $previousNamespace }
+            if ($null -eq $previousSocket) { Remove-Item Env:\WINSMUX_BRIDGE_SOCKET_S -ErrorAction SilentlyContinue } else { $env:WINSMUX_BRIDGE_SOCKET_S = $previousSocket }
+            if ($null -eq $previousSessionNamespace) { Remove-Item Env:\WINSMUX_BRIDGE_SESSION_NAMESPACE -ErrorAction SilentlyContinue } else { $env:WINSMUX_BRIDGE_SESSION_NAMESPACE = $previousSessionNamespace }
+        }
+    }
+
+    It 'TASK781 C41 resolves server socket selectors before namespace comparison' {
+        $matchingNamespace = Get-WinsmuxSocketNamespaceBase -SocketSelector 'C:\tmp\task781.sock'
+
+        (Test-OrchestraServerProcessNamespace `
+            -CommandLine 'winsmux -S "C:\tmp\task781.sock" server -s winsmux-orchestra' `
+            -Namespace $matchingNamespace) | Should -BeTrue
+        (Test-OrchestraServerProcessNamespace `
+            -CommandLine 'winsmux -S "C:\tmp\other.sock" server -s winsmux-orchestra' `
+            -Namespace $matchingNamespace) | Should -BeFalse
+        (Test-OrchestraServerProcessNamespace `
+            -CommandLine 'winsmux -S "C:\tmp\task781.sock" server -s winsmux-orchestra' `
+            -Namespace '') | Should -BeFalse
+        (Test-OrchestraServerProcessNamespace `
+            -CommandLine 'winsmux server -s winsmux-orchestra -- tool -S "C:\tmp\task781.sock"' `
+            -Namespace '') | Should -BeTrue
+    }
+
+    It 'rejects server option lookalike <Case>' -ForEach @(
+        @{
+            Case = 'namespace option after raw command separator'
+            CommandLine = 'winsmux server -s winsmux-orchestra -- tool -L task781-smoke-20260715'
+        }
+        @{
+            Case = 'session name prefix collision'
+            CommandLine = 'winsmux server -s winsmux-orchestra-other -L task781-smoke-20260715'
+        }
+        @{
+            Case = 'server subcommand prefix collision'
+            CommandLine = 'winsmux server-helper -s winsmux-orchestra -L task781-smoke-20260715'
+        }
+        @{
+            Case = 'duplicate identical session selectors'
+            CommandLine = 'winsmux server -s winsmux-orchestra --session winsmux-orchestra -L task781-smoke-20260715'
+        }
+        @{
+            Case = 'conflicting session selectors'
+            CommandLine = 'winsmux server -s winsmux-orchestra --session other-session -L task781-smoke-20260715'
+        }
+        @{
+            Case = 'conflicting socket and literal namespace selectors'
+            CommandLine = 'winsmux -S task781-smoke-20260715 -L task781-smoke-20260715 server -s winsmux-orchestra'
+        }
+        @{
+            Case = 'duplicate literal namespace selectors'
+            CommandLine = 'winsmux server -s winsmux-orchestra -L task781-smoke-20260715 -L task781-smoke-20260715'
+        }
+        @{
+            Case = 'quoted raw separator text before a conflicting selector'
+            CommandLine = 'winsmux server -s winsmux-orchestra -L task781-smoke-20260715 --flag "value -- payload" --session other-session'
+        }
+        @{
+            Case = 'unmatched quote after raw command separator'
+            CommandLine = 'winsmux server -s winsmux-orchestra -L task781-smoke-20260715 -- tool "unterminated'
+        }
+    ) {
+        $previousNamespace = $env:WINSMUX_BRIDGE_SESSION_NAMESPACE
+        $previousSocket = $env:WINSMUX_BRIDGE_SOCKET_S
+        $previousNamespaceL = $env:WINSMUX_BRIDGE_NAMESPACE_L
+        try {
+            $env:WINSMUX_BRIDGE_SESSION_NAMESPACE = 'task781-smoke-20260715'
+            Remove-Item Env:\WINSMUX_BRIDGE_SOCKET_S -ErrorAction SilentlyContinue
+            Remove-Item Env:\WINSMUX_BRIDGE_NAMESPACE_L -ErrorAction SilentlyContinue
+            $process = [pscustomobject]@{ Name = 'winsmux.exe'; CommandLine = $CommandLine }
+
+            (Test-OrchestraSessionServerProcess -Process $process -SessionName 'winsmux-orchestra') | Should -BeFalse
+        } finally {
+            if ($null -eq $previousNamespace) { Remove-Item Env:\WINSMUX_BRIDGE_SESSION_NAMESPACE -ErrorAction SilentlyContinue } else { $env:WINSMUX_BRIDGE_SESSION_NAMESPACE = $previousNamespace }
+            if ($null -eq $previousSocket) { Remove-Item Env:\WINSMUX_BRIDGE_SOCKET_S -ErrorAction SilentlyContinue } else { $env:WINSMUX_BRIDGE_SOCKET_S = $previousSocket }
+            if ($null -eq $previousNamespaceL) { Remove-Item Env:\WINSMUX_BRIDGE_NAMESPACE_L -ErrorAction SilentlyContinue } else { $env:WINSMUX_BRIDGE_NAMESPACE_L = $previousNamespaceL }
+        }
+    }
+
+    It 'TASK781 C41 never stops a server hidden by quoted raw separator text' {
+        $previousNamespace = $env:WINSMUX_BRIDGE_SESSION_NAMESPACE
+        $server = [pscustomobject]@{
+            ProcessId = 41002; ParentProcessId = 0; Name = 'winsmux.exe'
+            CommandLine = 'winsmux server -s winsmux-orchestra -L task781-smoke-20260715 --flag "value -- payload" --session other-session'
+            ExecutablePath = 'C:\tools\winsmux.exe'
+        }
+        $snapshot = [pscustomobject]@{ Processes = @($server); ById = @{ 41002 = $server }; ChildrenByParent = @{} }
+        Mock Stop-Process { }
+        try {
+            $env:WINSMUX_BRIDGE_SESSION_NAMESPACE = 'task781-smoke-20260715'
+            $result = Remove-OrchestraSessionServerProcesses -SessionName 'winsmux-orchestra' `
+                -WinsmuxBin 'C:\tools\winsmux.exe' -IncludeExpectedBinary -ProcessSnapshot $snapshot `
+                -PostStopSnapshotResolver { New-C66ServerProcessSnapshot } -VerificationAttempts 1 `
+                -VerificationIntervalMilliseconds 0
+
+            @($result.SessionProcesses).Count | Should -Be 0
+            Should -Invoke Stop-Process -Times 0 -Exactly
+        } finally {
+            if ($null -eq $previousNamespace) { Remove-Item Env:\WINSMUX_BRIDGE_SESSION_NAMESPACE -ErrorAction SilentlyContinue }
+            else { $env:WINSMUX_BRIDGE_SESSION_NAMESPACE = $previousNamespace }
+        }
     }
 
     It 'uses the plain session registry path when no bridge namespace is selected' {
@@ -5989,9 +8400,11 @@ Describe 'orchestra-start server bootstrap' {
                 SupportsSubagents      = $true
                 SupportsVerification   = $true
                 SupportsConsultation   = $true
-            }) | Out-Null
+            }) `
+            -ExpectedPaneCount 1 | Out-Null
 
         $script:savedManifest | Should -Not -BeNullOrEmpty
+        $script:savedManifest.session.expected_pane_count | Should -Be 1
         $pane = $script:savedManifest.panes.'worker-1'
         $pane.slot_id | Should -Be 'worker-1'
         $pane.project_dir | Should -Be 'C:\repo'
@@ -6013,6 +8426,7 @@ Describe 'orchestra-start server bootstrap' {
             -Settings ([ordered]@{ agent = 'codex'; model = 'gpt-5.4' }) `
             -GitWorktreeDir 'C:\repo\.git\worktrees' `
             -PaneSummaries @() `
+            -ExpectedPaneCount 1 `
             -StartupToken 'token-123' `
             -SupervisorPid 707 `
             -IdleThreshold 180 `
@@ -6925,6 +9339,134 @@ Describe 'orchestra-start server bootstrap' {
         $script:ensureExpectedPaneCount | Should -Be 1
     }
 
+    It 'TASK781 C66 routes manifest-owning reset through fail-closed retirement before bootstrap' {
+        Mock Test-OrchestraServerSession { $true }
+        Mock Invoke-Winsmux { throw 'manifest-owning reset must not kill outside the retirement helper' }
+        Mock Wait-OrchestraServerSessionAbsent { throw 'manifest-owning reset must not wait outside the retirement helper' }
+        Mock Clear-OrchestraManifestAfterServerRetirement {
+            param($ProjectDir, $GitWorktreeDir, $BridgeScript, $SessionName, $WinsmuxBin)
+            $WinsmuxBin | Should -BeExactly 'winsmux'
+            [PSCustomObject]@{ Stopped = @(); Errors = @(); Cleared = $true }
+        }
+        Mock Stop-OrchestraBackgroundProcessesFromManifest { throw 'direct background cleanup is forbidden' }
+        Mock Clear-WinsmuxManifest { throw 'direct manifest clear is forbidden' }
+        Mock Clear-OrchestraSessionRegistration { }
+        Mock Ensure-OrchestraBootstrapSession {
+            [PSCustomObject]@{
+                SessionName = 'winsmux-orchestra'; BootstrapReady = $true
+                StartupReady = $false; BootstrapMode = 'detached_primary'
+            }
+        }
+
+        $result = Reset-OrchestraServerSession -SessionName 'winsmux-orchestra' -WinsmuxBin 'winsmux' `
+            -ProjectDir 'C:\project' -GitWorktreeDir 'C:\project' `
+            -BridgeScript 'C:\project\scripts\winsmux-core.ps1' -Reason 'test'
+
+        $result.BootstrapReady | Should -BeTrue
+        Should -Invoke Clear-OrchestraManifestAfterServerRetirement -Times 1 -Exactly
+        Should -Invoke Invoke-Winsmux -Times 0 -Exactly
+        Should -Invoke Wait-OrchestraServerSessionAbsent -Times 0 -Exactly
+        Should -Invoke Stop-OrchestraBackgroundProcessesFromManifest -Times 0 -Exactly
+        Should -Invoke Clear-WinsmuxManifest -Times 0 -Exactly
+        Should -Invoke Ensure-OrchestraBootstrapSession -Times 1 -Exactly
+    }
+
+    It 'TASK781 C66 does not bootstrap reset when fail-closed retirement fails' {
+        Mock Test-OrchestraServerSession { $false }
+        Mock Clear-OrchestraManifestAfterServerRetirement { throw 'synthetic reset retirement failure' }
+        Mock Clear-OrchestraSessionRegistration { }
+        Mock Ensure-OrchestraBootstrapSession { throw 'replacement bootstrap must not run' }
+
+        {
+            Reset-OrchestraServerSession -SessionName 'winsmux-orchestra' -WinsmuxBin 'winsmux' `
+                -ProjectDir 'C:\project' -GitWorktreeDir 'C:\project' `
+                -BridgeScript 'C:\project\scripts\winsmux-core.ps1' -Reason 'test'
+        } | Should -Throw '*reset retirement failure*'
+
+        Should -Invoke Ensure-OrchestraBootstrapSession -Times 0 -Exactly
+    }
+
+    It 'retires background state and deletes the old manifest before replacement generation creation' {
+        $script:retiredManifestSequence = [System.Collections.Generic.List[string]]::new()
+        Mock Remove-OrchestraSessionServerProcesses {
+            $script:retiredManifestSequence.Add('matched-processes-retired') | Out-Null
+            return [PSCustomObject]@{ SessionProcesses = @(); Killed = @(); RemainingSessionProcesses = @(); Errors = @() }
+        }
+        Mock Wait-OrchestraServerSessionAbsent {
+            $script:retiredManifestSequence.Add('server-absent') | Out-Null
+            return [PSCustomObject]@{ Ready = $true; PollAttempt = 1 }
+        }
+        Mock Stop-OrchestraBackgroundProcessesFromManifest {
+            $script:retiredManifestSequence.Add('backgrounds-retired') | Out-Null
+            return [PSCustomObject]@{ Stopped = @([PSCustomObject]@{ pid = 42 }); Errors = @() }
+        }
+        Mock Clear-WinsmuxManifest {
+            $script:retiredManifestSequence.Add('manifest-cleared') | Out-Null
+            return $true
+        }
+
+        $result = Clear-OrchestraManifestAfterServerRetirement `
+            -ProjectDir 'C:\project' -GitWorktreeDir 'C:\project' `
+            -BridgeScript 'C:\project\scripts\winsmux-core.ps1' -SessionName 'winsmux-orchestra' -WinsmuxBin 'winsmux'
+
+        @($script:retiredManifestSequence) | Should -Be @('matched-processes-retired', 'server-absent', 'backgrounds-retired', 'manifest-cleared')
+        $result.Cleared | Should -BeTrue
+        @($result.Stopped).Count | Should -Be 1
+        @($result.Errors).Count | Should -Be 0
+    }
+
+    It 'does not clear the old manifest while the retired server remains observable' {
+        Mock Remove-OrchestraSessionServerProcesses {
+            [PSCustomObject]@{ SessionProcesses = @(); Killed = @(); RemainingSessionProcesses = @(); Errors = @() }
+        }
+        Mock Wait-OrchestraServerSessionAbsent { throw 'synthetic server still present' }
+        Mock Stop-OrchestraBackgroundProcessesFromManifest { throw 'must not inspect backgrounds before server absence' }
+        Mock Clear-WinsmuxManifest { throw 'must not clear manifest before server absence' }
+
+        {
+            Clear-OrchestraManifestAfterServerRetirement `
+                -ProjectDir 'C:\project' -GitWorktreeDir 'C:\project' `
+                -BridgeScript 'C:\project\scripts\winsmux-core.ps1' -SessionName 'winsmux-orchestra' -WinsmuxBin 'winsmux'
+        } | Should -Throw '*server still present*'
+        Should -Invoke Stop-OrchestraBackgroundProcessesFromManifest -Times 0 -Exactly
+        Should -Invoke Clear-WinsmuxManifest -Times 0 -Exactly
+    }
+
+    It 'does not clear the old manifest when owned background retirement is incomplete' {
+        Mock Remove-OrchestraSessionServerProcesses {
+            [PSCustomObject]@{ SessionProcesses = @(); Killed = @(); RemainingSessionProcesses = @(); Errors = @() }
+        }
+        Mock Wait-OrchestraServerSessionAbsent { [PSCustomObject]@{ Ready = $true; PollAttempt = 1 } }
+        Mock Stop-OrchestraBackgroundProcessesFromManifest {
+            [PSCustomObject]@{ Stopped = @(); Errors = @('supervisor identity could not be retired') }
+        }
+        Mock Clear-WinsmuxManifest { throw 'must not clear manifest with unresolved background ownership' }
+
+        {
+            Clear-OrchestraManifestAfterServerRetirement `
+                -ProjectDir 'C:\project' -GitWorktreeDir 'C:\project' `
+                -BridgeScript 'C:\project\scripts\winsmux-core.ps1' -SessionName 'winsmux-orchestra' -WinsmuxBin 'winsmux'
+        } | Should -Throw '*background cleanup is incomplete*'
+        Should -Invoke Clear-WinsmuxManifest -Times 0 -Exactly
+    }
+
+    It 'TASK781 C66 keeps the old manifest when complete server-process retirement fails' {
+        Mock Remove-OrchestraSessionServerProcesses { throw 'synthetic matched server remains' }
+        Mock Wait-OrchestraServerSessionAbsent { throw 'logical-session check must not run' }
+        Mock Stop-OrchestraBackgroundProcessesFromManifest { throw 'background cleanup must not run' }
+        Mock Clear-WinsmuxManifest { throw 'old manifest must be preserved' }
+
+        {
+            Clear-OrchestraManifestAfterServerRetirement `
+                -ProjectDir 'C:\project' -GitWorktreeDir 'C:\project' `
+                -BridgeScript 'C:\project\scripts\winsmux-core.ps1' -SessionName 'winsmux-orchestra' -WinsmuxBin 'winsmux'
+        } | Should -Throw '*matched server remains*'
+
+        Should -Invoke Wait-OrchestraServerSessionAbsent -Times 0 -Exactly
+        Should -Invoke Stop-OrchestraBackgroundProcessesFromManifest -Times 0 -Exactly
+        Should -Invoke Clear-WinsmuxManifest -Times 0 -Exactly
+    }
+
     It 'throws when the layout leaves the session below the expected pane count' {
         Mock Get-OrchestraSessionPaneIds { @('%1') }
 
@@ -7200,6 +9742,7 @@ Describe 'orchestra-start server bootstrap' {
             -Settings ([ordered]@{ agent = 'codex'; model = 'gpt-5.4' }) `
             -GitWorktreeDir (Join-Path $testProjectDir '.git\worktrees') `
             -PaneSummaries @() `
+            -ExpectedPaneCount 1 `
             -StartupToken 'token-123' `
             -SupervisorPid 707 `
             -IdleThreshold 180 | Out-Null
@@ -7301,6 +9844,14 @@ Describe 'orchestra-start session reuse contract' {
         $script:orchestraStartContent | Should -Match 'Save-OrchestraSessionState[^\r\n]+SupervisorPid \$supervisorProcess\.Id[^\r\n]+SessionReady \$true'
     }
 
+    It 'TASK781 C42 persists the authoritative expected pane count in both runtime manifests' {
+        $script:orchestraStartContent | Should -Match 'expected_pane_count\s*=\s*\$ExpectedPaneCount'
+        ([regex]::Matches(
+            $script:orchestraStartContent,
+            'Save-OrchestraSessionState[^\r\n]+-ExpectedPaneCount \$expectedPaneCount'
+        )).Count | Should -Be 2
+    }
+
     It 'keeps detached startup on the session-ready path even when visible attach still needs retry' {
         $script:orchestraStartContent | Should -Match '\$successfulAttachStatuses\s*=\s*@\(''attach_confirmed'', ''attach_already_present''\)'
         $script:orchestraStartContent | Should -Match 'if \(\$successfulAttachStatuses -notcontains \[string\]\$uiAttachResult\.Status\) \{\s*Write-Warning'
@@ -7331,14 +9882,85 @@ Describe 'orchestra-start session reuse contract' {
         $preLayoutAttachIndex = $script:orchestraStartContent.IndexOf('$preLayoutUiAttachResult = Try-StartOrchestraUiAttach -SessionName $sessionName')
         $livenessIndex = $script:orchestraStartContent.IndexOf('if (-not (Test-OrchestraServerSession -SessionName $sessionName)) {')
         $layoutIndex = $script:orchestraStartContent.IndexOf('$layout = . $layoutScript -SessionName $sessionName')
-        $paneNameIndex = $script:orchestraStartContent.IndexOf("Invoke-Bridge -Arguments @('name', `$paneId, `$label)")
+        $rawPaneTitleIndex = $script:orchestraStartContent.IndexOf("Invoke-Winsmux -Arguments @('select-pane', '-t', [string]`$paneSummary.PaneId, '-T', [string]`$paneSummary.Title) -TargetSessionName `$sessionName")
         $postLayoutAttachIndex = $script:orchestraStartContent.LastIndexOf('$uiAttachResult = Try-StartOrchestraUiAttach -SessionName $sessionName')
 
         $preLayoutAttachIndex | Should -BeGreaterThan -1
         $livenessIndex | Should -BeGreaterThan $preLayoutAttachIndex
         $layoutIndex | Should -BeGreaterThan $livenessIndex
-        $paneNameIndex | Should -BeGreaterThan $layoutIndex
-        $postLayoutAttachIndex | Should -BeGreaterThan $paneNameIndex
+        $postLayoutAttachIndex | Should -BeGreaterThan $layoutIndex
+        $rawPaneTitleIndex | Should -BeGreaterThan $postLayoutAttachIndex
+    }
+
+    It 'publishes all orchestra labels with one atomic map update while preserving existing labels' {
+        $tempAppData = Join-Path ([System.IO.Path]::GetTempPath()) ('winsmux-label-publish-' + [guid]::NewGuid().ToString('N'))
+        $previousAppData = $env:APPDATA
+        try {
+            $env:APPDATA = $tempAppData
+            $labelsPath = Join-Path $tempAppData 'winsmux\labels.json'
+            New-Item -ItemType Directory -Path (Split-Path -Parent $labelsPath) -Force | Out-Null
+            [System.IO.File]::WriteAllText($labelsPath, '{"existing":"%9"}', [System.Text.UTF8Encoding]::new($false))
+
+            $result = Publish-OrchestraPaneLabels -PaneSummaries @(
+                [ordered]@{ PaneId = '%2'; Title = 'W1 Codex Reviewer' }
+                [ordered]@{ PaneId = '%3'; Title = 'worker-2' }
+            )
+            $published = Get-Content -LiteralPath $labelsPath -Raw -Encoding UTF8 | ConvertFrom-Json
+
+            $result.PublishedCount | Should -Be 2
+            $published.existing | Should -Be '%9'
+            $published.'W1 Codex Reviewer' | Should -Be '%2'
+            $published.'worker-2' | Should -Be '%3'
+        } finally {
+            $env:APPDATA = $previousAppData
+            if (Test-Path -LiteralPath $tempAppData) { Remove-Item -LiteralPath $tempAppData -Recurse -Force }
+        }
+    }
+
+    It 'rejects duplicate orchestra titles before creating a label file' {
+        $tempAppData = Join-Path ([System.IO.Path]::GetTempPath()) ('winsmux-label-reject-' + [guid]::NewGuid().ToString('N'))
+        $previousAppData = $env:APPDATA
+        try {
+            $env:APPDATA = $tempAppData
+            {
+                Publish-OrchestraPaneLabels -PaneSummaries @(
+                    [ordered]@{ PaneId = '%2'; Title = 'worker' }
+                    [ordered]@{ PaneId = '%3'; Title = 'worker' }
+                )
+            } | Should -Throw '*unique non-empty titles*'
+            Test-Path -LiteralPath (Join-Path $tempAppData 'winsmux\labels.json') | Should -BeFalse
+        } finally {
+            $env:APPDATA = $previousAppData
+            if (Test-Path -LiteralPath $tempAppData) { Remove-Item -LiteralPath $tempAppData -Recurse -Force }
+        }
+    }
+
+    It 'publishes the complete label map atomically only after runtime freshness is established' {
+        $bootstrapVerificationIndex = $script:orchestraStartContent.IndexOf('Assert-OrchestraBootstrapVerification -PaneSummaries @($paneSummaries) -InvalidCount $invalidCount -ReadyCount $readyCount')
+        $rawPaneTitleIndex = $script:orchestraStartContent.IndexOf("Invoke-Winsmux -Arguments @('select-pane', '-t', [string]`$paneSummary.PaneId, '-T', [string]`$paneSummary.Title) -TargetSessionName `$sessionName")
+        $pendingManifestIndex = $script:orchestraStartContent.IndexOf('Save-OrchestraSessionState -ProjectDir $projectDir -SessionName $sessionName -Settings $settings -GitWorktreeDir $gitWorktreeDir -PaneSummaries $validPaneSummaries -GenerationId $runtimeGenerationId -ServerSessionId $serverSessionId -BootstrapPaneId $bootstrapPaneId -StartupToken $startupToken -BootstrapMode ([string]$orchestraServer.BootstrapMode) -SessionReady $false')
+        $registryReadyIndex = $script:orchestraStartContent.IndexOf('Wait-OrchestraRuntimeRegistryReady -ProjectDir $projectDir')
+        $sessionReadyManifestIndex = $script:orchestraStartContent.IndexOf('Save-OrchestraSessionState -ProjectDir $projectDir -SessionName $sessionName -Settings $settings -GitWorktreeDir $gitWorktreeDir -PaneSummaries $validPaneSummaries -GenerationId $runtimeGenerationId -ServerSessionId $serverSessionId -BootstrapPaneId $bootstrapPaneId -StartupToken $startupToken -SupervisorPid $supervisorProcess.Id -BootstrapMode ([string]$orchestraServer.BootstrapMode) -SessionReady $true')
+        $labelPublicationIndex = $script:orchestraStartContent.IndexOf('Publish-OrchestraPaneLabels -PaneSummaries $validPaneSummaries')
+        $sessionReadyLogIndex = $script:orchestraStartContent.IndexOf("Write-WinsmuxLog -Level INFO -Event 'orchestra.startup.session_ready'")
+
+        $bootstrapVerificationIndex | Should -BeGreaterThan -1
+        $rawPaneTitleIndex | Should -BeGreaterThan $bootstrapVerificationIndex
+        $pendingManifestIndex | Should -BeGreaterThan $rawPaneTitleIndex
+        $registryReadyIndex | Should -BeGreaterThan $pendingManifestIndex
+        $sessionReadyManifestIndex | Should -BeGreaterThan $registryReadyIndex
+        $labelPublicationIndex | Should -BeGreaterThan $sessionReadyManifestIndex
+        $sessionReadyLogIndex | Should -BeGreaterThan $labelPublicationIndex
+        $script:orchestraStartContent | Should -Not -Match "Invoke-Bridge -Arguments @\('name'"
+        $script:orchestraStartContent | Should -Not -Match '\$env:WINSMUX_[A-Z0-9_]*(?:BOOTSTRAP|BYPASS)[A-Z0-9_]*'
+    }
+
+    It 'excludes exactly one known bootstrap pane from the runtime worker handshake' {
+        $script:orchestraStartContent | Should -Match '\[Parameter\(Mandatory = \$true\)\]\[string\]\$BootstrapPaneId'
+        $script:orchestraStartContent | Should -Match '\$bootstrapMatches\s*=\s*@\(\$serverPanes \| Where-Object \{ \[string\]\$_\.pane_id -ceq \$BootstrapPaneId \}\)'
+        $script:orchestraStartContent | Should -Match '\$observedPanes\s*=\s*@\(\$serverPanes \| Where-Object \{ \[string\]\$_\.pane_id -cne \$BootstrapPaneId \}\)'
+        $script:orchestraStartContent | Should -Match '\$bootstrapMatches\.Count -ne 1 -or \$serverPanes\.Count -ne \(\$summaries\.Count \+ 1\)'
+        $script:orchestraStartContent | Should -Match '-BootstrapPaneId \$bootstrapPaneId -SupervisorProcess \$supervisorProcess'
     }
 
     It 'checks the expected pane count before layout and requires a pre-layout liveness gate' {
@@ -7359,26 +9981,30 @@ Describe 'orchestra-start session reuse contract' {
         $script:orchestraStartContent | Should -Match 'BootstrapMarkerPath'
     }
 
-    It 'clears stale manifest state before zombie cleanup and bootstrap' {
+    It 'TASK781 C66 routes every replacement startup through one fail-closed retirement helper' {
         $script:orchestraStartContent | Should -Match 'Acquire-OrchestraStartupLock -ProjectDir \$projectDir -SessionName \$sessionName'
-        $script:orchestraStartContent | Should -Match 'Stop-OrchestraBackgroundProcessesFromManifest -ProjectDir \$projectDir -GitWorktreeDir \$gitWorktreeDir -BridgeScript \$bridgeScript -SessionName \$sessionName'
-        $script:orchestraStartContent | Should -Match 'if \(Clear-WinsmuxManifest -ProjectDir \$projectDir\)'
         $script:orchestraStartContent | Should -Match 'startup_token\s*=\s*\$StartupToken'
 
         $lockAcquireIndex = $script:orchestraStartContent.IndexOf('$startupLock = Acquire-OrchestraStartupLock -ProjectDir $projectDir -SessionName $sessionName')
-        $manifestCleanupIndex = $script:orchestraStartContent.IndexOf('$manifestBackgroundCleanup = Stop-OrchestraBackgroundProcessesFromManifest -ProjectDir $projectDir -GitWorktreeDir $gitWorktreeDir -BridgeScript $bridgeScript -SessionName $sessionName')
-        $clearManifestIndex = $script:orchestraStartContent.IndexOf('if (Clear-WinsmuxManifest -ProjectDir $projectDir) {')
-        $zombieCleanupIndex = $script:orchestraStartContent.IndexOf('$zombieCleanup = Remove-OrchestraZombieProcesses -SessionName $sessionName -ProjectDir $projectDir -GitWorktreeDir $gitWorktreeDir -BridgeScript $bridgeScript -WinsmuxBin $winsmuxBin')
         $sessionExistsIndex = $script:orchestraStartContent.IndexOf('$sessionExistedAtStart = Test-OrchestraServerSession -SessionName $sessionName')
+        $retiredManifestIndex = $script:orchestraStartContent.IndexOf('$retiredManifest = Clear-OrchestraManifestAfterServerRetirement')
+        $replacementBootstrapIndex = $script:orchestraStartContent.IndexOf('$orchestraServer = Ensure-OrchestraBootstrapSession -SessionName $sessionName -TimeoutSeconds 60')
         $lockAcquireIndex | Should -BeGreaterThan -1
-        $manifestCleanupIndex | Should -BeGreaterThan -1
-        $clearManifestIndex | Should -BeGreaterThan -1
-        $zombieCleanupIndex | Should -BeGreaterThan -1
         $sessionExistsIndex | Should -BeGreaterThan -1
+        $retiredManifestIndex | Should -BeGreaterThan $sessionExistsIndex
+        $replacementBootstrapIndex | Should -BeGreaterThan $retiredManifestIndex
         $lockAcquireIndex | Should -BeLessThan $sessionExistsIndex
-        $sessionExistsIndex | Should -BeLessThan $manifestCleanupIndex
-        $manifestCleanupIndex | Should -BeLessThan $clearManifestIndex
-        $clearManifestIndex | Should -BeLessThan $zombieCleanupIndex
+
+        $startupSequence = $script:orchestraStartContent.Substring(
+            $sessionExistsIndex,
+            $replacementBootstrapIndex - $sessionExistsIndex
+        )
+        $startupSequence | Should -Not -Match 'Stop-OrchestraBackgroundProcessesFromManifest'
+        $startupSequence | Should -Not -Match 'Clear-WinsmuxManifest'
+        $startupSequence | Should -Not -Match 'Remove-OrchestraSessionServerProcesses'
+        $startupSequence | Should -Not -Match '\$requiresManifestRetirement'
+        ([regex]::Matches($startupSequence, 'Clear-OrchestraManifestAfterServerRetirement')).Count | Should -Be 1
+        $script:orchestraStartContent | Should -Match '(?s)function Clear-OrchestraManifestAfterServerRetirement.*?Remove-OrchestraSessionServerProcesses.*?Wait-OrchestraServerSessionAbsent.*?Stop-OrchestraBackgroundProcessesFromManifest.*?Clear-WinsmuxManifest'
     }
 
     It 'suppresses warm servers and trims excess warm processes during managed startup' {
@@ -7474,9 +10100,113 @@ Describe 'orchestra-start session reuse contract' {
     }
 }
 
+Describe 'TASK781 C18 startup token diagnostic boundary' {
+    BeforeAll {
+        $script:c18RepoRoot = Split-Path -Parent $PSScriptRoot
+        $script:c18OrchestraStartPath = Join-Path $script:c18RepoRoot 'winsmux-core\scripts\orchestra-start.ps1'
+        . $script:c18OrchestraStartPath
+
+        function New-Task781C18BootstrapPlan {
+            param(
+                [Parameter(Mandatory = $true)][string]$ProjectDir,
+                [Parameter(Mandatory = $true)][string]$StartupToken
+            )
+
+            New-OrchestraPaneBootstrapPlan `
+                -ProjectDir $ProjectDir `
+                -PaneId '%2' `
+                -Label 'worker-1' `
+                -SlotId 'worker-1' `
+                -Role 'Worker' `
+                -WorkerBackend 'local' `
+                -WorkerRole 'worker' `
+                -PaneTitle 'worker-1' `
+                -GenerationId 'generation-c18-safe' `
+                -ServerSessionId '$18' `
+                -Agent 'codex' `
+                -Model 'gpt-5.4' `
+                -StartupToken $StartupToken `
+                -LaunchDir $ProjectDir `
+                -CleanPtyEnv ([pscustomobject]@{ Environment = [ordered]@{} }) `
+                -LaunchCommand 'codex --help'
+        }
+    }
+
+    BeforeEach {
+        $script:c18StartupToken = 'C18-STARTUP-TOKEN-SENTINEL'
+        $script:c18TempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('winsmux-c18-' + [guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $script:c18TempRoot -Force | Out-Null
+    }
+
+    AfterEach {
+        if ($script:c18TempRoot -and (Test-Path -LiteralPath $script:c18TempRoot)) {
+            Remove-Item -LiteralPath $script:c18TempRoot -Recurse -Force
+        }
+    }
+
+    It 'TASK781 C18 keeps the generated bootstrap marker path on the safe generation identity' {
+        $planPath = New-Task781C18BootstrapPlan -ProjectDir $script:c18TempRoot -StartupToken $script:c18StartupToken
+        $planText = Get-Content -LiteralPath $planPath -Raw -Encoding UTF8
+        $plan = $planText | ConvertFrom-Json
+
+        [System.IO.Path]::GetFileName([string]$plan.ready_marker_path) | Should -Be '2-generation-c18-safe.ready.json'
+    }
+
+    It 'TASK781 C18 keeps the runtime registry JSON free of the startup token' {
+        $planPath = New-Task781C18BootstrapPlan -ProjectDir $script:c18TempRoot -StartupToken $script:c18StartupToken
+        $plan = Get-Content -LiteralPath $planPath -Raw -Encoding UTF8 | ConvertFrom-Json
+        $registry = New-WinsmuxRuntimeRegistryDocument `
+            -SessionName 'winsmux-c18' `
+            -ServerSessionId '$18' `
+            -GenerationId 'generation-c18-safe' `
+            -SupervisorPid 1818 `
+            -SupervisorProcessStartedAt '2026-07-15T00:00:00.0000000Z' `
+            -ExpectedPaneCount 1 `
+            -Panes @([pscustomobject][ordered]@{
+                slot_id = 'worker-1'; pane_id = '%2'; backend = 'local'; role = 'worker'; title = 'worker-1'
+                state = 'bootstrap_pending'; bootstrap_pid = 1819; bootstrap_process_started_at = '2026-07-15T00:00:01.0000000Z'
+                marker_path = [string]$plan.ready_marker_path
+            })
+
+        ($registry | ConvertTo-Json -Depth 20) | Should -Not -Match ([regex]::Escape($script:c18StartupToken))
+    }
+
+    It 'TASK781 C18 keeps smoke doctor and harness diagnostic serialization token free' {
+        $diagnosticSurfaces = [ordered]@{
+            smoke = [ordered]@{
+                runtime_valid = $true
+                runtime_identity = [ordered]@{ valid = $true; expected = 1; verified = 1; entries = @() }
+            }
+            doctor = [ordered]@{ status = 'pass'; label = 'Orchestra process contract'; detail = 'runtime identity registry verified' }
+            harness = [ordered]@{ passed = $true; message = 'orchestra smoke contract verified' }
+        }
+
+        ($diagnosticSurfaces | ConvertTo-Json -Depth 12) | Should -Not -Match ([regex]::Escape($script:c18StartupToken))
+        foreach ($relativePath in @(
+            'winsmux-core\scripts\orchestra-smoke.ps1',
+            'winsmux-core\scripts\doctor.ps1',
+            'winsmux-core\scripts\harness-check.ps1'
+        )) {
+            (Get-Content -LiteralPath (Join-Path $script:c18RepoRoot $relativePath) -Raw -Encoding UTF8) | Should -Not -Match '(?i)startup_token'
+        }
+    }
+
+    It 'TASK781 C18 keeps startup log and journal Data free of the startup token' {
+        $source = Get-Content -LiteralPath $script:c18OrchestraStartPath -Raw -Encoding UTF8
+        $logCall = [regex]::Match(
+            $source,
+            "(?m)^\s*Write-WinsmuxLog -Level INFO -Event 'preflight\.startup_lock\.acquired'.*$"
+        )
+
+        $logCall.Success | Should -BeTrue
+        $logCall.Value | Should -Not -Match 'startup_token'
+    }
+}
+
 Describe 'orchestra-start rollback helpers' {
     BeforeAll {
-        . (Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\orchestra-start.ps1')
+        $script:orchestraStartPath = Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\orchestra-start.ps1'
+        . $script:orchestraStartPath
     }
 
     BeforeEach {
@@ -7568,7 +10298,7 @@ Describe 'orchestra-start rollback helpers' {
         $events[0].data.removed_worktrees[0].BranchName | Should -Be 'worktree-builder-1'
     }
 
-    It 'clears a stale manifest when startup rollback runs' {
+    It 'TASK781 C66 preserves a retired or competing manifest when rollback did not publish a generation' {
         $manifestDir = Join-Path $script:orchestraStartTempRoot '.winsmux'
         New-Item -ItemType Directory -Path $manifestDir -Force | Out-Null
         Set-Content -Path (Join-Path $manifestDir 'manifest.yaml') -Value "version: '1'" -Encoding UTF8
@@ -7591,7 +10321,93 @@ Describe 'orchestra-start rollback helpers' {
             -FailureMessage 'health timeout'
 
         $rollback.RollbackErrors.Count | Should -Be 0
-        (Test-Path (Join-Path $manifestDir 'manifest.yaml')) | Should -Be $false
+        (Test-Path (Join-Path $manifestDir 'manifest.yaml')) | Should -Be $true
+    }
+
+    It 'TASK781 C66 clears only the manifest generation published by this startup attempt' {
+        Mock Invoke-Winsmux { @('%1') } -ParameterFilter {
+            $Arguments[0] -eq 'list-panes'
+        }
+        Mock Invoke-Winsmux { } -ParameterFilter {
+            $Arguments[0] -eq 'respawn-pane'
+        }
+        Mock Wait-PaneShellReady { }
+        Mock Remove-OrchestraCreatedWorktrees { @() }
+        Mock Clear-WinsmuxManifest { $true }
+
+        $rollback = Invoke-OrchestraStartupRollback `
+            -ProjectDir $script:orchestraStartTempRoot `
+            -SessionName 'winsmux-orchestra' `
+            -BootstrapPaneId '%1' `
+            -CreatedPaneIds @('%1') `
+            -CreatedWorktrees @() `
+            -FailureMessage 'post-publication failure' `
+            -ManifestPublished `
+            -OwnedGenerationId 'owned-generation'
+
+        $rollback.RollbackErrors.Count | Should -Be 0
+        Should -Invoke Clear-WinsmuxManifest -Times 1 -Exactly -ParameterFilter {
+            $ProjectDir -eq $script:orchestraStartTempRoot -and
+            $ExpectedGenerationId -ceq 'owned-generation'
+        }
+    }
+
+    It 'TASK781 C66 guarded manifest clear preserves a competing generation' {
+        $manifest = [PSCustomObject][ordered]@{
+            version = 2
+            session = [PSCustomObject][ordered]@{
+                name              = 'winsmux-orchestra'
+                generation_id     = 'competing-generation'
+                server_session_id = '$9'
+                bootstrap_pane_id = '%1'
+            }
+            panes = [ordered]@{}
+        }
+        Save-WinsmuxManifest -ProjectDir $script:orchestraStartTempRoot -Manifest $manifest
+        $manifestPath = Get-ManifestPath -ProjectDir $script:orchestraStartTempRoot
+
+        { Clear-WinsmuxManifest -ProjectDir $script:orchestraStartTempRoot -ExpectedGenerationId 'owned-generation' } |
+            Should -Throw '*generation changed*'
+        (Test-Path -LiteralPath $manifestPath -PathType Leaf) | Should -BeTrue
+        (Get-WinsmuxVerifiedManifestIdentity -Manifest (Get-WinsmuxManifest -ProjectDir $script:orchestraStartTempRoot)).generation_id |
+            Should -BeExactly 'competing-generation'
+    }
+
+    It 'TASK781 C66 guarded manifest clear deletes the exactly owned generation' {
+        $manifest = [PSCustomObject][ordered]@{
+            version = 2
+            session = [PSCustomObject][ordered]@{
+                name              = 'winsmux-orchestra'
+                generation_id     = 'owned-generation'
+                server_session_id = '$9'
+                bootstrap_pane_id = '%1'
+            }
+            panes = [ordered]@{}
+        }
+        Save-WinsmuxManifest -ProjectDir $script:orchestraStartTempRoot -Manifest $manifest
+        $manifestPath = Get-ManifestPath -ProjectDir $script:orchestraStartTempRoot
+
+        (Clear-WinsmuxManifest -ProjectDir $script:orchestraStartTempRoot -ExpectedGenerationId 'owned-generation') |
+            Should -BeTrue
+        (Test-Path -LiteralPath $manifestPath -PathType Leaf) | Should -BeFalse
+    }
+
+    It 'TASK781 C66 guarded manifest clear preserves an unverifiable manifest' {
+        $manifestDir = Join-Path $script:orchestraStartTempRoot '.winsmux'
+        New-Item -ItemType Directory -Path $manifestDir -Force | Out-Null
+        $manifestPath = Join-Path $manifestDir 'manifest.yaml'
+        [System.IO.File]::WriteAllText($manifestPath, "version: '1'`n", [System.Text.UTF8Encoding]::new($false))
+
+        { Clear-WinsmuxManifest -ProjectDir $script:orchestraStartTempRoot -ExpectedGenerationId 'owned-generation' } |
+            Should -Throw '*cannot be verified*'
+        (Test-Path -LiteralPath $manifestPath -PathType Leaf) | Should -BeTrue
+    }
+
+    It 'TASK781 C66 passes published-generation ownership into startup rollback' {
+        $source = [System.IO.File]::ReadAllText($script:orchestraStartPath, [System.Text.Encoding]::UTF8)
+        $source | Should -Match '\$manifestPublished\s*=\s*\$false'
+        $source | Should -Match '\$manifestPublished\s*=\s*\$true'
+        $source | Should -Match 'Invoke-OrchestraStartupRollback[^\r\n]+-ManifestPublished:\$manifestPublished[^\r\n]+-OwnedGenerationId \$runtimeGenerationId'
     }
 
     It 'continues rollback when listing session panes fails and still removes created non-bootstrap panes' {
@@ -7801,7 +10617,13 @@ Describe 'orchestra-start rollback helpers' {
             -ProjectDir $script:orchestraStartTempRoot `
             -PaneId '%2' `
             -Label 'worker-1' `
+            -SlotId 'worker-1' `
             -Role 'Worker' `
+            -WorkerBackend 'local' `
+            -WorkerRole 'worker' `
+            -PaneTitle 'worker-1' `
+            -GenerationId 'generation-bootstrap-123' `
+            -ServerSessionId '$123' `
             -Agent 'codex' `
             -Model 'gpt-5.4' `
             -StartupToken 'token-123' `
@@ -7827,7 +10649,7 @@ Describe 'orchestra-start rollback helpers' {
         [string]$plan.approved_launch.model | Should -Be 'gpt-5.4'
         [string]$plan.approved_launch.execution_profile | Should -Be 'local-windows'
         [string]$plan.startup_token | Should -Be 'token-123'
-        [string]$plan.ready_marker_path | Should -Match '[\\/]2-token-123\.ready\.json$'
+        [string]$plan.ready_marker_path | Should -Match '[\\/]2-generation-bootstrap-123\.ready\.json$'
         $bridgeCalls.Count | Should -Be 1
         @($bridgeCalls[0].Arguments) | Should -Be @('keys', '%2', 'C-c')
         $sentCommands.Count | Should -Be 1
@@ -7869,7 +10691,13 @@ Describe 'orchestra-start rollback helpers' {
             -ProjectDir $script:orchestraStartTempRoot `
             -PaneId '%2' `
             -Label 'worker-1' `
+            -SlotId 'worker-1' `
             -Role 'Worker' `
+            -WorkerBackend 'example' `
+            -WorkerRole 'worker' `
+            -PaneTitle 'worker-1' `
+            -GenerationId 'generation-bootstrap-456' `
+            -ServerSessionId '$456' `
             -Agent 'example' `
             -Model 'example-model' `
             -StartupToken 'token-456' `
@@ -8093,6 +10921,26 @@ Describe 'doctor bridge config metadata check' {
         $result.Detail | Should -Match 'stale_processes=1/0'
         $result.Detail | Should -Match 'worker shell count 7 exceeds budget 6'
         $result.Detail | Should -Match 'stale managed process count 1 exceeds budget 0'
+    }
+
+    It 'TASK781 fails a parsed orchestra smoke result with invalid runtime identity' {
+        Mock Invoke-DoctorOrchestraSmokeJson {
+            [pscustomobject]@{
+                Ok       = $false
+                ExitCode = 0
+                Error    = 'orchestra-smoke did not verify the supervisor-owned runtime identity registry'
+                Data     = [pscustomobject]@{
+                    smoke_ok      = $true
+                    runtime_valid = $false
+                }
+            }
+        }
+
+        $result = Test-OrchestraProcessContractCheck
+
+        $result.Status | Should -Be 'fail'
+        $result.Label | Should -Be 'Orchestra process contract'
+        $result.Detail | Should -Match 'runtime identity registry'
     }
 
     It 'handles a single orchestra process contract warning from smoke' {
@@ -8527,6 +11375,185 @@ Describe 'pane scaler helpers' {
     AfterEach {
         if ($script:paneScalerTempRoot -and (Test-Path $script:paneScalerTempRoot)) {
             Remove-Item -Path $script:paneScalerTempRoot -Recurse -Force
+        }
+    }
+
+    It 'TASK781 C56 refuses v2 pane-count changes before any pane worktree or manifest mutation' {
+        @"
+version: 2
+saved_at: 2026-07-15T17:30:00+09:00
+session:
+  name: winsmux-orchestra
+  project_dir: $script:paneScalerTempRoot
+  generation_id: generation-56
+  server_session_id: `$56
+  bootstrap_pane_id: '%1'
+  expected_pane_count: 3
+panes:
+  builder-1:
+    slot_id: builder-1
+    pane_id: '%2'
+    role: Builder
+    worker_role: builder
+    worker_backend: codex
+    title: Builder-1
+  builder-2:
+    slot_id: builder-2
+    pane_id: '%3'
+    role: Builder
+    worker_role: builder
+    worker_backend: codex
+    title: Builder-2
+  builder-3:
+    slot_id: builder-3
+    pane_id: '%4'
+    role: Builder
+    worker_role: builder
+    worker_backend: codex
+    title: Builder-3
+"@ | Set-Content -LiteralPath $script:paneScalerManifestPath -Encoding UTF8
+
+        Mock New-PaneScalerBuilderWorktree { throw 'worktree creation must not run for v2 scaling' }
+        Mock Get-PaneWorkload { throw 'workload probing must not run before the v2 scaling refusal' }
+        Mock Invoke-MonitorWinsmux { throw 'pane mutation must not run for v2 scaling' }
+        Mock Remove-PaneScalerBuilderWorktree { throw 'worktree removal must not run for v2 scaling' }
+        Mock Save-PaneScalerManifest { throw 'manifest save must not run for v2 scaling' }
+
+        { Add-OrchestraPane -ManifestPath $script:paneScalerManifestPath } |
+            Should -Throw '*manifest_regeneration_required*supervisor-owned*'
+        { Remove-OrchestraPane -ManifestPath $script:paneScalerManifestPath } |
+            Should -Throw '*manifest_regeneration_required*supervisor-owned*'
+
+        Should -Invoke New-PaneScalerBuilderWorktree -Times 0 -Exactly
+        Should -Invoke Get-PaneWorkload -Times 0 -Exactly
+        Should -Invoke Invoke-MonitorWinsmux -Times 0 -Exactly
+        Should -Invoke Remove-PaneScalerBuilderWorktree -Times 0 -Exactly
+        Should -Invoke Save-PaneScalerManifest -Times 0 -Exactly
+    }
+
+    It 'TASK781 C59 persists a v1 scale-down transition before destructive cleanup' {
+        @"
+version: 1
+session:
+  name: winsmux-orchestra
+  project_dir: $script:paneScalerTempRoot
+panes:
+  builder-1:
+    pane_id: '%2'
+"@ | Set-Content -LiteralPath $script:paneScalerManifestPath -Encoding UTF8
+        $manifest = [PSCustomObject]@{
+            Version = 1
+            SavedAt = '2026-07-15T19:45:00+09:00'
+            Session = [PSCustomObject]@{ project_dir = $script:paneScalerTempRoot }
+            Panes = [ordered]@{
+                'builder-1' = [ordered]@{ pane_id = '%2' }
+                'builder-2' = [ordered]@{ pane_id = '%3' }
+                'builder-3' = [ordered]@{ pane_id = '%4' }
+                'builder-4' = [ordered]@{
+                    pane_id = '%5'
+                    builder_worktree_path = (Join-Path $script:paneScalerTempRoot '.worktrees\builder-4')
+                    builder_branch = 'worktree-builder-4'
+                }
+            }
+        }
+        Mock Get-PaneWorkload {
+            [PSCustomObject]@{
+                BuilderCount = 4
+                Results = @(
+                    [PSCustomObject]@{ Label = 'builder-1'; Status = 'busy' }
+                    [PSCustomObject]@{ Label = 'builder-2'; Status = 'ready' }
+                    [PSCustomObject]@{ Label = 'builder-3'; Status = 'ready' }
+                    [PSCustomObject]@{ Label = 'builder-4'; Status = 'ready' }
+                )
+                Manifest = $manifest
+                ProjectDir = $script:paneScalerTempRoot
+            }
+        }
+        Mock Get-PaneControlManifestGenerationId { '' }
+        Mock Save-PaneScalerManifest { throw 'injected manifest save failure' }
+        Mock Invoke-MonitorWinsmux { throw 'pane kill must not run before a successful save' }
+        Mock Remove-PaneScalerBuilderWorktree { throw 'worktree cleanup must not run before a successful save' }
+
+        { Remove-OrchestraPane -ManifestPath $script:paneScalerManifestPath } |
+            Should -Throw '*injected manifest save failure*'
+
+        Should -Invoke Save-PaneScalerManifest -Times 1 -Exactly
+        Should -Invoke Invoke-MonitorWinsmux -Times 0 -Exactly
+        Should -Invoke Remove-PaneScalerBuilderWorktree -Times 0 -Exactly
+    }
+
+    It 'TASK781 C59 orders a successful v1 scale-down as save then kill then cleanup' {
+        @"
+version: 1
+session:
+  name: winsmux-orchestra
+  project_dir: $script:paneScalerTempRoot
+panes:
+  builder-1:
+    pane_id: '%2'
+"@ | Set-Content -LiteralPath $script:paneScalerManifestPath -Encoding UTF8
+        $manifest = [PSCustomObject]@{
+            Version = 1
+            SavedAt = '2026-07-15T19:45:00+09:00'
+            Session = [PSCustomObject]@{ project_dir = $script:paneScalerTempRoot }
+            Panes = [ordered]@{
+                'builder-1' = [ordered]@{ pane_id = '%2' }
+                'builder-2' = [ordered]@{ pane_id = '%3' }
+                'builder-3' = [ordered]@{ pane_id = '%4' }
+                'builder-4' = [ordered]@{
+                    pane_id = '%5'
+                    builder_worktree_path = (Join-Path $script:paneScalerTempRoot '.worktrees\builder-4')
+                    builder_branch = 'worktree-builder-4'
+                }
+            }
+        }
+        Mock Get-PaneWorkload {
+            [PSCustomObject]@{
+                BuilderCount = 4
+                Results = @(
+                    [PSCustomObject]@{ Label = 'builder-1'; Status = 'busy' }
+                    [PSCustomObject]@{ Label = 'builder-2'; Status = 'ready' }
+                    [PSCustomObject]@{ Label = 'builder-3'; Status = 'ready' }
+                    [PSCustomObject]@{ Label = 'builder-4'; Status = 'ready' }
+                )
+                Manifest = $manifest
+                ProjectDir = $script:paneScalerTempRoot
+            }
+        }
+        $script:c59Order = [System.Collections.Generic.List[string]]::new()
+        Mock Get-PaneControlManifestGenerationId { '' }
+        Mock Save-PaneScalerManifest { $script:c59Order.Add('save') | Out-Null }
+        Mock Invoke-MonitorWinsmux { $script:c59Order.Add('kill') | Out-Null }
+        Mock Remove-PaneScalerBuilderWorktree { $script:c59Order.Add('cleanup') | Out-Null }
+
+        $result = Remove-OrchestraPane -ManifestPath $script:paneScalerManifestPath
+
+        $result.Changed | Should -BeTrue
+        @($script:c59Order) | Should -Be @('save', 'kill', 'cleanup')
+    }
+
+    It 'TASK781 C56 preserves a dirty Builder worktree and never force-deletes its branch' {
+        $worktreePath = Join-Path $script:paneScalerTempRoot '.worktrees\builder-9'
+        New-Item -ItemType Directory -Path $worktreePath -Force | Out-Null
+        $paneScalerSource = Get-Content -LiteralPath (Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\pane-scaler.ps1') -Raw -Encoding UTF8
+        $paneScalerSource.Contains("'--force'") | Should -BeFalse
+        $paneScalerSource.Contains("'-D'") | Should -BeFalse
+        Mock Invoke-BuilderWorktreeGit {
+            param($ProjectDir, $Arguments, [switch]$AllowFailure)
+            if ($ProjectDir -eq $worktreePath -and $Arguments[0] -eq 'status') {
+                return [PSCustomObject]@{ ExitCode = 0; Output = ' M user-owned.txt'; Lines = @(' M user-owned.txt') }
+            }
+            throw 'destructive git cleanup must not run for a dirty worktree'
+        }
+
+        {
+            Remove-PaneScalerBuilderWorktree -ProjectDir $script:paneScalerTempRoot `
+                -WorktreePath $worktreePath -BranchName 'worktree-builder-9'
+        } | Should -Throw '*uncommitted changes*'
+
+        Test-Path -LiteralPath $worktreePath -PathType Container | Should -Be $true
+        Should -Invoke Invoke-BuilderWorktreeGit -Times 1 -Exactly -ParameterFilter {
+            $ProjectDir -eq $worktreePath -and $Arguments[0] -eq 'status'
         }
     }
 
@@ -9396,15 +12423,63 @@ panes:
     }
 }
 
+Describe 'orchestra-start namespaced object targeting' {
+    BeforeAll {
+        . (Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\orchestra-start.ps1')
+        $script:previousStartWinsmuxBin = $script:winsmuxBin
+        $script:previousStartBridgeNamespace = $env:WINSMUX_BRIDGE_NAMESPACE_L
+    }
+
+    BeforeEach {
+        $script:winsmuxBin = 'winsmux'
+        $env:WINSMUX_BRIDGE_NAMESPACE_L = 'task781-start-test'
+        $global:startWinsmuxCalls = [System.Collections.Generic.List[string]]::new()
+        function global:winsmux {
+            $global:LASTEXITCODE = 0
+            $global:startWinsmuxCalls.Add((($args | ForEach-Object { [string]$_ }) -join ' ')) | Out-Null
+            return 'ok'
+        }
+    }
+
+    AfterEach {
+        $script:winsmuxBin = $script:previousStartWinsmuxBin
+        if ($null -ne $script:previousStartBridgeNamespace) {
+            $env:WINSMUX_BRIDGE_NAMESPACE_L = $script:previousStartBridgeNamespace
+        } else {
+            Remove-Item Env:\WINSMUX_BRIDGE_NAMESPACE_L -ErrorAction SilentlyContinue
+        }
+        Remove-Item Function:\global:winsmux -ErrorAction SilentlyContinue
+    }
+
+    It 'qualifies a pane target before invoking the namespaced CLI' {
+        $result = Invoke-Winsmux -Arguments @('display-message', '-t', '%2', '-p', '#{pane_id}') -CaptureOutput -TargetSessionName 'winsmux-orchestra'
+
+        $result | Should -Be 'ok'
+        @($global:startWinsmuxCalls) | Should -Be @('-L task781-start-test display-message -t winsmux-orchestra:%2 -p #{pane_id}')
+    }
+
+    It 'preserves explicit session and already-qualified targets' {
+        Invoke-Winsmux -Arguments @('has-session', '-t', 'winsmux-orchestra') -TargetSessionName 'winsmux-orchestra'
+        Invoke-Winsmux -Arguments @('display-message', '-t', 'winsmux-orchestra:%2', '-p', '#{pane_id}') -TargetSessionName 'winsmux-orchestra'
+
+        @($global:startWinsmuxCalls) | Should -Be @(
+            '-L task781-start-test has-session -t winsmux-orchestra',
+            '-L task781-start-test display-message -t winsmux-orchestra:%2 -p #{pane_id}'
+        )
+    }
+}
+
 Describe 'orchestra layout script' {
     BeforeAll {
         $script:orchestraLayoutPath = Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\orchestra-layout.ps1'
         $script:previousWinsmuxBinForLayout = $env:WINSMUX_BIN
+        $script:previousBridgeNamespaceForLayout = $env:WINSMUX_BRIDGE_NAMESPACE_L
     }
 
     BeforeEach {
         Mock Start-Sleep { }
         $env:WINSMUX_BIN = 'winsmux'
+        Remove-Item Env:\WINSMUX_BRIDGE_NAMESPACE_L -ErrorAction SilentlyContinue
     }
 
     AfterEach {
@@ -9415,6 +12490,11 @@ Describe 'orchestra layout script' {
         }
 
         Remove-Item Function:\global:winsmux -ErrorAction SilentlyContinue
+        if ($null -ne $script:previousBridgeNamespaceForLayout) {
+            $env:WINSMUX_BRIDGE_NAMESPACE_L = $script:previousBridgeNamespaceForLayout
+        } else {
+            Remove-Item Env:\WINSMUX_BRIDGE_NAMESPACE_L -ErrorAction SilentlyContinue
+        }
     }
 
     It 'creates a single labeled pane through the orchestra wrapper' {
@@ -9486,6 +12566,96 @@ Describe 'orchestra layout script' {
         @($global:winsmuxCalls) | Should -Contain 'split-window -t %2 -h -p 50'
         @($global:winsmuxCalls) | Should -Contain 'select-pane -t %3 -T Builder-2'
     }
+
+    It 'qualifies pane and window targets when a bridge namespace is active' {
+        $env:WINSMUX_BRIDGE_NAMESPACE_L = 'task781-layout-test'
+        $global:winsmuxCalls = [System.Collections.Generic.List[string]]::new()
+        $global:layoutPaneIds = @('%2')
+
+        function global:winsmux {
+            $global:LASTEXITCODE = 0
+            $commandLine = ($args | ForEach-Object { [string]$_ }) -join ' '
+            $global:winsmuxCalls.Add($commandLine) | Out-Null
+
+            switch -Regex ($commandLine) {
+                '^-L task781-layout-test has-session ' { return @() }
+                '^-L task781-layout-test new-window ' { return '@1 %2' }
+                '^-L task781-layout-test set-option ' { return @() }
+                '^-L task781-layout-test display-message -t winsmux-orchestra:%2 -p #\{window_id\}$' { return '@1' }
+                '^-L task781-layout-test display-message -t winsmux-orchestra:%2 -p #\{pane_width\}x#\{pane_height\}$' { return '120x40' }
+                '^-L task781-layout-test split-window -t winsmux-orchestra:%2 -h -p 50$' {
+                    $global:layoutPaneIds = @('%2', '%3')
+                    return @()
+                }
+                '^-L task781-layout-test list-panes -t winsmux-orchestra:@1 -F #\{pane_id\}$' { return $global:layoutPaneIds }
+                '^-L task781-layout-test select-pane -t winsmux-orchestra:%2$' { return @() }
+                '^-L task781-layout-test select-pane -t winsmux-orchestra:%2 -T Builder-1$' { return @() }
+                '^-L task781-layout-test select-pane -t winsmux-orchestra:%3 -T Builder-2$' { return @() }
+                default { throw "unexpected winsmux call: $commandLine" }
+            }
+        }
+
+        $result = & $script:orchestraLayoutPath -SessionName 'winsmux-orchestra' -Builders 2
+
+        $result.Total | Should -Be 2
+        @($global:winsmuxCalls) | Should -Contain '-L task781-layout-test display-message -t winsmux-orchestra:%2 -p #{window_id}'
+        @($global:winsmuxCalls) | Should -Contain '-L task781-layout-test list-panes -t winsmux-orchestra:@1 -F #{pane_id}'
+        @($global:winsmuxCalls | Where-Object { $_ -match ' -t [%@]' }).Count | Should -Be 0
+    }
+
+    It 'retries Windows connection refused for a read-only layout query' {
+        $global:layoutWindowQueryCalls = 0
+        $global:layoutPaneIds = @('%2')
+        function global:winsmux {
+            $commandLine = ($args | ForEach-Object { [string]$_ }) -join ' '
+            switch -Regex ($commandLine) {
+                '^has-session ' { $global:LASTEXITCODE = 0; return @() }
+                '^new-window ' { $global:LASTEXITCODE = 0; return '@1 %2' }
+                '^set-option ' { $global:LASTEXITCODE = 0; return @() }
+                '^display-message -t %2 -p #\{window_id\}$' {
+                    $global:layoutWindowQueryCalls++
+                    if ($global:layoutWindowQueryCalls -eq 1) {
+                        $global:LASTEXITCODE = 1
+                        return '対象のコンピューターによって拒否されました。 (os error 10061)'
+                    }
+                    $global:LASTEXITCODE = 0
+                    return '@1'
+                }
+                '^display-message -t %2 -p #\{pane_width\}x#\{pane_height\}$' { $global:LASTEXITCODE = 0; return '120x40' }
+                '^split-window -t %2 -h -p 50$' { $global:LASTEXITCODE = 0; $global:layoutPaneIds = @('%2', '%3'); return @() }
+                '^list-panes -t @1 -F #\{pane_id\}$' { $global:LASTEXITCODE = 0; return $global:layoutPaneIds }
+                '^select-pane ' { $global:LASTEXITCODE = 0; return @() }
+                default { throw "unexpected winsmux call: $commandLine" }
+            }
+        }
+
+        $result = & $script:orchestraLayoutPath -SessionName 'winsmux-orchestra' -Builders 2
+
+        $result.Total | Should -Be 2
+        $global:layoutWindowQueryCalls | Should -Be 2
+    }
+
+    It 'does not retry a mutating layout command after Windows connection refused' {
+        $global:layoutMutationCalls = 0
+        function global:winsmux {
+            $commandLine = ($args | ForEach-Object { [string]$_ }) -join ' '
+            switch -Regex ($commandLine) {
+                '^has-session ' { $global:LASTEXITCODE = 0; return @() }
+                '^new-window ' { $global:LASTEXITCODE = 0; return '@1 %2' }
+                '^list-panes -t @1 -F #\{pane_id\}$' { $global:LASTEXITCODE = 0; return '%2' }
+                '^set-option ' { $global:LASTEXITCODE = 0; return @() }
+                '^select-pane ' {
+                    $global:layoutMutationCalls++
+                    $global:LASTEXITCODE = 1
+                    return 'connection refused (os error 10061)'
+                }
+                default { throw "unexpected winsmux call: $commandLine" }
+            }
+        }
+
+        { & $script:orchestraLayoutPath -SessionName 'winsmux-orchestra' -Builders 1 } | Should -Throw '*os error 10061*'
+        $global:layoutMutationCalls | Should -Be 1
+    }
 }
 
 Describe 'winsmux status command' {
@@ -9515,7 +12685,8 @@ Describe 'winsmux status command' {
 
     It 'parses both list and dictionary pane formats' {
         $manifest = ConvertFrom-PaneControlManifestContent -Content @'
-version: 1
+version: 2
+saved_at: '2026-07-15T00:00:00Z'
 session:
   project_dir: C:\repo
 panes:
@@ -9527,6 +12698,8 @@ panes:
     role: Reviewer
 '@
 
+        $manifest.version | Should -Be 2
+        $manifest.saved_at | Should -Be '2026-07-15T00:00:00Z'
         $manifest.Session.project_dir | Should -Be 'C:\repo'
         $manifest.Panes['builder-1'].pane_id | Should -Be '%2'
         $manifest.Panes['reviewer'].role | Should -Be 'Reviewer'
@@ -9601,6 +12774,32 @@ Describe 'winsmux workers command' {
         $script:winsmuxWorkersCorePath = Join-Path (Split-Path -Parent $PSScriptRoot) 'scripts\winsmux-core.ps1'
         $script:winsmuxWorkersCoreRawContent = Get-Content -LiteralPath $script:winsmuxWorkersCorePath -Raw -Encoding UTF8
         . $script:winsmuxWorkersCorePath 'version' *> $null
+
+        function New-Task781WorkersStopFixture {
+            param([Parameter(Mandatory = $true)][string]$ProjectDir)
+
+            $bootstrapRoot = Join-Path (Join-Path $ProjectDir '.winsmux') 'orchestra-bootstrap'
+            New-Item -ItemType Directory -Path $bootstrapRoot -Force | Out-Null
+            $planPath = Join-Path $bootstrapRoot '_2.json'
+            $markerPath = Join-Path $bootstrapRoot '_2-synthetic.ready.json'
+            '{}' | Set-Content -LiteralPath $planPath -Encoding UTF8
+            '{}' | Set-Content -LiteralPath $markerPath -Encoding UTF8
+
+            $entry = [PSCustomObject]@{
+                Label = 'worker-1'; SlotId = 'worker-1'; PaneId = '%2'; Status = 'ready'; RuntimeReady = $true
+                ManifestPath = 'synthetic-manifest'; BootstrapPlanPath = $planPath; BootstrapMarkerPath = $markerPath
+            }
+            $row = [PSCustomObject]@{
+                Slot = 'w1'; SlotId = 'worker-1'; PaneId = '%2'; Backend = 'codex'; State = 'ready'
+                LastFailureStage = ''; RecoveryAction = ''; ApprovedLaunch = $null; CurrentLaunch = $null; ApprovalDifferences = @()
+            }
+            $entriesBySlot = @{}
+            $entriesBySlot['worker-1'] = $entry
+
+            return [PSCustomObject]@{
+                Entry = $entry; Row = $row; EntriesBySlot = $entriesBySlot; MarkerPath = $markerPath
+            }
+        }
     }
 
     BeforeEach {
@@ -9614,6 +12813,705 @@ Describe 'winsmux workers command' {
         $env:OPENROUTER_API_KEY = ''
         $env:WINSMUX_ANTIGRAVITY_CLI = ''
         $env:WINSMUX_ANTIGRAVITY_PRINT_TIMEOUT = ''
+        Mock Test-PaneControlRuntimeContext {
+            param($ProjectDir, $ManifestEntry, $Operation)
+            New-WinsmuxRuntimeValidationResult -Valid $true -ReasonCode ("{0}_verified" -f $Operation) `
+                -Diagnostic 'synthetic worker runtime verified' -Context ([ordered]@{ generation_id = 'generation-workers' })
+        }
+        Mock Assert-WinsmuxTargetRuntimeWriteAllowed {
+            [PSCustomObject]@{ Managed = $true; Operation = 'dispatch'; GenerationId = 'generation-workers' }
+        }
+    }
+
+    It 'TASK781 C55 passes the initially captured generation and operation to every workers-start lifecycle write' {
+        $startIndex = $script:winsmuxWorkersCoreRawContent.IndexOf('function Invoke-WorkersStart {', [System.StringComparison]::Ordinal)
+        $stopIndex = $script:winsmuxWorkersCoreRawContent.IndexOf('function Invoke-WorkersStop {', [System.StringComparison]::Ordinal)
+        $startIndex | Should -BeGreaterOrEqual 0
+        $stopIndex | Should -BeGreaterThan $startIndex
+        $functionText = $script:winsmuxWorkersCoreRawContent.Substring($startIndex, $stopIndex - $startIndex)
+        $tokens = $null
+        $parseErrors = $null
+        $ast = [System.Management.Automation.Language.Parser]::ParseInput($functionText, [ref]$tokens, [ref]$parseErrors)
+        @($parseErrors).Count | Should -Be 0
+        $commands = @($ast.FindAll({
+            param($node)
+            $node -is [System.Management.Automation.Language.CommandAst] -and
+                $node.GetCommandName() -ceq 'Set-WorkersManifestLifecycleCommand'
+        }, $true))
+
+        $commands.Count | Should -Be 4
+        foreach ($command in $commands) {
+            $command.Extent.Text | Should -Match '-ExpectedGenerationId\s+\$runtimeGenerationId'
+            $command.Extent.Text | Should -Match '-RuntimeOperation\s+(?:\$runtimeOperation|dispatch)'
+        }
+    }
+
+    It 'TASK781 blocks workers start before pane launch or manifest writes when runtime identity is invalid' {
+        $entry = [PSCustomObject]@{ Label = 'worker-1'; SlotId = 'worker-1'; PaneId = '%2'; Status = 'deferred_start'; ManifestPath = 'synthetic-manifest' }
+        $row = [PSCustomObject]@{
+            Slot = 'w1'; SlotId = 'worker-1'; PaneId = '%2'; Backend = 'codex'; State = 'deferred_start'
+            LastFailureStage = ''; RecoveryAction = ''; ApprovedLaunch = $null; CurrentLaunch = $null; ApprovalDifferences = @()
+        }
+        $entriesBySlot = @{}; $entriesBySlot['worker-1'] = $entry
+        Mock Read-WorkersOptions { [PSCustomObject]@{ ProjectDir = $script:workersTempRoot; Target = 'all'; Json = $true } }
+        Mock Get-WorkersLifecycleContext { [PSCustomObject]@{ ProjectDir = $script:workersTempRoot; EntriesBySlot = $entriesBySlot } }
+        Mock Get-WorkersStatusRows { @($row) }
+        Mock Test-PaneControlRuntimeContext { New-WinsmuxRuntimeValidationResult -Valid $false -ReasonCode 'invalid_supervisor_identity' -Diagnostic 'stale supervisor' }
+        Mock Start-DeferredPaneFromManifestEntry { throw 'pane start must not occur' }
+        Mock Set-WorkersManifestLifecycleCommand { throw 'manifest write must not occur' }
+        Mock Write-WorkersLifecycleOutput { param($ProjectDir, $Results, [switch]$Json) $script:task781WorkersResult = @($Results) }
+
+        Invoke-WorkersStart
+
+        $script:task781WorkersResult.Count | Should -Be 1
+        $script:task781WorkersResult[0].status | Should -Be 'blocked'
+        $script:task781WorkersResult[0].reason_code | Should -Be 'invalid_supervisor_identity'
+        Assert-MockCalled Start-DeferredPaneFromManifestEntry -Times 0 -Exactly
+        Assert-MockCalled Set-WorkersManifestLifecycleCommand -Times 0 -Exactly
+    }
+
+    It 'TASK781 C29 preserves a runtime refusal from deferred workers start without repair metadata writes' {
+        $entry = [PSCustomObject]@{
+            Label = 'worker-1'; SlotId = 'worker-1'; PaneId = '%2'; Status = 'deferred_start'; ManifestPath = 'synthetic-manifest'
+        }
+        $row = [PSCustomObject]@{
+            Slot = 'w1'; SlotId = 'worker-1'; PaneId = '%2'; Backend = 'codex'; State = 'deferred_start'
+            LastFailureStage = ''; RecoveryAction = ''; ApprovedLaunch = $null; CurrentLaunch = $null; ApprovalDifferences = @()
+        }
+        $entriesBySlot = @{}; $entriesBySlot['worker-1'] = $entry
+        $script:task781WorkersStartWrites = 0
+        Mock Read-WorkersOptions { [PSCustomObject]@{ ProjectDir = $script:workersTempRoot; Target = 'all'; Json = $true } }
+        Mock Get-WorkersLifecycleContext { [PSCustomObject]@{ ProjectDir = $script:workersTempRoot; EntriesBySlot = $entriesBySlot } }
+        Mock Get-WorkersStatusRows { @($row) }
+        Mock Start-DeferredPaneFromManifestEntry {
+            throw 'runtime dispatch refused (invalid_supervisor_identity): generation expired during deferred startup'
+        }
+        Mock Set-WorkersManifestLifecycleCommand { $script:task781WorkersStartWrites++ }
+        Mock Write-WorkersLifecycleOutput {
+            param($ProjectDir, $Results, [switch]$Json)
+            $script:task781WorkersResult = @($Results)
+        }
+
+        Invoke-WorkersStart
+
+        $script:task781WorkersResult.Count | Should -Be 1
+        $script:task781WorkersResult[0].status | Should -Be 'blocked'
+        $script:task781WorkersResult[0].reason_code | Should -Be 'invalid_supervisor_identity'
+        $script:task781WorkersResult[0].diagnostic | Should -Be 'generation expired during deferred startup'
+        $script:task781WorkersStartWrites | Should -Be 0
+    }
+
+    It 'TASK781 blocks workers stop before respawn or manifest writes when runtime identity is invalid' {
+        $entry = [PSCustomObject]@{ Label = 'worker-1'; SlotId = 'worker-1'; PaneId = '%2'; Status = 'ready'; ManifestPath = 'synthetic-manifest' }
+        $row = [PSCustomObject]@{
+            Slot = 'w1'; SlotId = 'worker-1'; PaneId = '%2'; Backend = 'codex'; State = 'ready'
+            LastFailureStage = ''; RecoveryAction = ''; ApprovedLaunch = $null; CurrentLaunch = $null; ApprovalDifferences = @()
+        }
+        $entriesBySlot = @{}; $entriesBySlot['worker-1'] = $entry
+        Mock Read-WorkersOptions { [PSCustomObject]@{ ProjectDir = $script:workersTempRoot; Target = 'all'; Json = $true } }
+        Mock Get-WorkersLifecycleContext { [PSCustomObject]@{ ProjectDir = $script:workersTempRoot; EntriesBySlot = $entriesBySlot } }
+        Mock Get-WorkersStatusRows { @($row) }
+        Mock Test-PaneControlRuntimeContext { New-WinsmuxRuntimeValidationResult -Valid $false -ReasonCode 'runtime_target_mismatch' -Diagnostic 'stale pane mapping' }
+        Mock Invoke-WinsmuxRaw { throw 'respawn must not occur' }
+        Mock Set-WorkersManifestLifecycleCommand { throw 'manifest write must not occur' }
+        Mock Write-WorkersLifecycleOutput { param($ProjectDir, $Results, [switch]$Json) $script:task781WorkersResult = @($Results) }
+
+        Invoke-WorkersStop
+
+        $script:task781WorkersResult.Count | Should -Be 1
+        $script:task781WorkersResult[0].status | Should -Be 'blocked'
+        $script:task781WorkersResult[0].reason_code | Should -Be 'runtime_target_mismatch'
+        Assert-MockCalled Invoke-WinsmuxRaw -Times 0 -Exactly
+        Assert-MockCalled Set-WorkersManifestLifecycleCommand -Times 0 -Exactly
+    }
+
+    It 'TASK781 C28 blocks workers stop when the runtime generation expires immediately before respawn' {
+        $fixture = New-Task781WorkersStopFixture -ProjectDir $script:workersTempRoot
+        $script:c28Results = @()
+
+        Mock Read-WorkersOptions { [PSCustomObject]@{ ProjectDir = $script:workersTempRoot; Target = 'all'; Json = $true } }
+        Mock Get-WorkersLifecycleContext {
+            [PSCustomObject]@{ ProjectDir = $script:workersTempRoot; EntriesBySlot = $fixture.EntriesBySlot }
+        }
+        Mock Get-WorkersStatusRows { @($fixture.Row) }
+        Mock Assert-WinsmuxTargetRuntimeWriteAllowed {
+            throw 'runtime dispatch refused (invalid_supervisor_identity): generation expired before workers stop respawn'
+        }
+        Mock Invoke-WinsmuxRaw { throw 'respawn must not occur after lease expiry' }
+        Mock Set-WorkersManifestLifecycleCommand { throw 'manifest write must not occur after lease expiry' }
+        Mock Write-WorkersLifecycleOutput {
+            param($ProjectDir, $Results, [switch]$Json)
+            $script:c28Results = @($Results)
+        }
+
+        Invoke-WorkersStop
+
+        $script:c28Results.Count | Should -Be 1
+        $script:c28Results[0].status | Should -Be 'blocked'
+        $script:c28Results[0].reason_code | Should -Be 'invalid_supervisor_identity'
+        $script:c28Results[0].diagnostic | Should -Be 'generation expired before workers stop respawn'
+        Assert-MockCalled Assert-WinsmuxTargetRuntimeWriteAllowed -Times 1 -Exactly -ParameterFilter {
+            $PaneId -eq '%2' -and
+            $CurrentProjectDir -eq $script:workersTempRoot -and
+            $Operation -eq 'dispatch' -and
+            $ExpectedGenerationId -eq 'generation-workers'
+        }
+        Assert-MockCalled Invoke-WinsmuxRaw -Times 0 -Exactly
+        Assert-MockCalled Set-WorkersManifestLifecycleCommand -Times 0 -Exactly
+    }
+
+    It 'TASK781 C43 blocks the marker-cleanup failure write when the generation expires after respawn' {
+        $fixture = New-Task781WorkersStopFixture -ProjectDir $script:workersTempRoot
+        $script:c43GuardCount = 0
+        $script:c43LifecycleWriteCount = 0
+        $script:c43Results = @()
+
+        Mock Read-WorkersOptions { [PSCustomObject]@{ ProjectDir = $script:workersTempRoot; Target = 'all'; Json = $true } }
+        Mock Get-WorkersLifecycleContext {
+            [PSCustomObject]@{ ProjectDir = $script:workersTempRoot; EntriesBySlot = $fixture.EntriesBySlot }
+        }
+        Mock Get-WorkersStatusRows { @($fixture.Row) }
+        Mock Assert-WinsmuxTargetRuntimeWriteAllowed {
+            $script:c43GuardCount++
+            if ($script:c43GuardCount -eq 3) {
+                throw 'runtime dispatch refused (invalid_supervisor_identity): generation expired before marker-failure state write'
+            }
+            [PSCustomObject]@{ Managed = $true; Operation = 'dispatch'; GenerationId = 'generation-workers' }
+        }
+        Mock Invoke-WinsmuxRaw { $null }
+        Mock Get-SafeLastExitCode { 0 }
+        Mock Remove-WorkersStoppedBootstrapMarker { throw 'synthetic marker cleanup failure' }
+        Mock Set-WorkersManifestLifecycleCommand { $script:c43LifecycleWriteCount++ }
+        Mock Write-WorkersLifecycleOutput {
+            param($ProjectDir, $Results, [switch]$Json)
+            $script:c43Results = @($Results)
+        }
+
+        Invoke-WorkersStop
+
+        $script:c43GuardCount | Should -Be 3
+        $script:c43LifecycleWriteCount | Should -Be 0
+        $script:c43Results.Count | Should -Be 1
+        $script:c43Results[0].status | Should -Be 'failed'
+        $script:c43Results[0].reason | Should -Match 'generation expired before marker-failure state write'
+        Assert-MockCalled Invoke-WinsmuxRaw -Times 1 -Exactly
+    }
+
+    It 'TASK781 C43 blocks the deferred-state write when the generation expires after marker cleanup' {
+        $fixture = New-Task781WorkersStopFixture -ProjectDir $script:workersTempRoot
+        $script:c43GuardCount = 0
+        $script:c43LifecycleWriteCount = 0
+        $script:c43Results = @()
+
+        Mock Read-WorkersOptions { [PSCustomObject]@{ ProjectDir = $script:workersTempRoot; Target = 'all'; Json = $true } }
+        Mock Get-WorkersLifecycleContext {
+            [PSCustomObject]@{ ProjectDir = $script:workersTempRoot; EntriesBySlot = $fixture.EntriesBySlot }
+        }
+        Mock Get-WorkersStatusRows { @($fixture.Row) }
+        Mock Assert-WinsmuxTargetRuntimeWriteAllowed {
+            $script:c43GuardCount++
+            if ($script:c43GuardCount -eq 3) {
+                throw 'runtime dispatch refused (invalid_supervisor_identity): generation expired before deferred-state write'
+            }
+            [PSCustomObject]@{ Managed = $true; Operation = 'dispatch'; GenerationId = 'generation-workers' }
+        }
+        Mock Invoke-WinsmuxRaw { $null }
+        Mock Get-SafeLastExitCode { 0 }
+        Mock Remove-WorkersStoppedBootstrapMarker { $true }
+        Mock Set-WorkersManifestLifecycleCommand { $script:c43LifecycleWriteCount++ }
+        Mock Write-WorkersLifecycleOutput {
+            param($ProjectDir, $Results, [switch]$Json)
+            $script:c43Results = @($Results)
+        }
+
+        Invoke-WorkersStop
+
+        $script:c43GuardCount | Should -Be 3
+        $script:c43LifecycleWriteCount | Should -Be 0
+        $script:c43Results.Count | Should -Be 1
+        $script:c43Results[0].status | Should -Be 'failed'
+        $script:c43Results[0].reason | Should -Match 'generation expired before deferred-state write'
+    }
+
+    It 'TASK781 C43 revalidates separately before read-mark and watermark cleanup' {
+        $fixture = New-Task781WorkersStopFixture -ProjectDir $script:workersTempRoot
+        $script:c43GuardCount = 0
+        $script:c43LifecycleWriteCount = 0
+        $script:c43ReadClearCount = 0
+        $script:c43WatermarkClearCount = 0
+        $script:c43Results = @()
+
+        Mock Read-WorkersOptions { [PSCustomObject]@{ ProjectDir = $script:workersTempRoot; Target = 'all'; Json = $true } }
+        Mock Get-WorkersLifecycleContext {
+            [PSCustomObject]@{ ProjectDir = $script:workersTempRoot; EntriesBySlot = $fixture.EntriesBySlot }
+        }
+        Mock Get-WorkersStatusRows { @($fixture.Row) }
+        Mock Assert-WinsmuxTargetRuntimeWriteAllowed {
+            $script:c43GuardCount++
+            if ($script:c43GuardCount -eq 5) {
+                throw 'runtime dispatch refused (invalid_supervisor_identity): generation expired before watermark cleanup'
+            }
+            [PSCustomObject]@{ Managed = $true; Operation = 'dispatch'; GenerationId = 'generation-workers' }
+        }
+        Mock Invoke-WinsmuxRaw { $null }
+        Mock Get-SafeLastExitCode { 0 }
+        Mock Remove-WorkersStoppedBootstrapMarker { $true }
+        Mock Set-WorkersManifestLifecycleCommand { $script:c43LifecycleWriteCount++ }
+        Mock Get-PaneControlManifestContext { $fixture.Entry }
+        Mock Wait-PaneControlRuntimeContext {
+            New-WinsmuxRuntimeValidationResult -Valid $true -ReasonCode 'start_deferred_verified' `
+                -Diagnostic 'synthetic deferred runtime verified' -Context ([ordered]@{ generation_id = 'generation-workers' })
+        }
+        Mock Clear-ReadMark { $script:c43ReadClearCount++ }
+        Mock Clear-Watermark { $script:c43WatermarkClearCount++ }
+        Mock Write-WorkersLifecycleOutput {
+            param($ProjectDir, $Results, [switch]$Json)
+            $script:c43Results = @($Results)
+        }
+
+        Invoke-WorkersStop
+
+        $script:c43GuardCount | Should -Be 5
+        $script:c43LifecycleWriteCount | Should -Be 1
+        $script:c43ReadClearCount | Should -Be 1
+        $script:c43WatermarkClearCount | Should -Be 0
+        $script:c43Results.Count | Should -Be 1
+        $script:c43Results[0].status | Should -Be 'failed'
+        $script:c43Results[0].reason | Should -Match 'generation expired before watermark cleanup'
+    }
+
+    It 'TASK781 C46 uses stop-transition guards only after respawn and deferred guards after the manifest transition' {
+        $fixture = New-Task781WorkersStopFixture -ProjectDir $script:workersTempRoot
+        $script:c46Operations = [System.Collections.Generic.List[string]]::new()
+        $script:c46Results = @()
+
+        Mock Read-WorkersOptions { [PSCustomObject]@{ ProjectDir = $script:workersTempRoot; Target = 'all'; Json = $true } }
+        Mock Get-WorkersLifecycleContext {
+            [PSCustomObject]@{ ProjectDir = $script:workersTempRoot; EntriesBySlot = $fixture.EntriesBySlot }
+        }
+        Mock Get-WorkersStatusRows { @($fixture.Row) }
+        Mock Assert-WinsmuxTargetRuntimeWriteAllowed {
+            param($PaneId, $CurrentProjectDir, $Operation, $ExpectedGenerationId)
+            $script:c46Operations.Add([string]$Operation)
+            [PSCustomObject]@{
+                Managed = $true
+                Operation = [string]$Operation
+                GenerationId = 'generation-workers'
+            }
+        }
+        Mock Invoke-WinsmuxRaw { $null }
+        Mock Get-SafeLastExitCode { 0 }
+        Mock Remove-WorkersStoppedBootstrapMarker { $true }
+        Mock Set-WorkersManifestLifecycleCommand {}
+        Mock Get-PaneControlManifestContext { $fixture.Entry }
+        Mock Wait-PaneControlRuntimeContext {
+            New-WinsmuxRuntimeValidationResult -Valid $true -ReasonCode 'start_deferred_verified' `
+                -Diagnostic 'synthetic deferred runtime verified' -Context ([ordered]@{ generation_id = 'generation-workers' })
+        }
+        Mock Clear-ReadMark {}
+        Mock Clear-Watermark {}
+        Mock Write-WorkersLifecycleOutput {
+            param($ProjectDir, $Results, [switch]$Json)
+            $script:c46Results = @($Results)
+        }
+
+        Invoke-WorkersStop
+
+        ($script:c46Operations.ToArray() | ConvertTo-Json -Compress) |
+            Should -Be ((@('dispatch', 'stop_transition', 'stop_transition', 'start_deferred', 'start_deferred') | ConvertTo-Json -Compress))
+        $script:c46Results.Count | Should -Be 1
+        $script:c46Results[0].status | Should -Be 'stopped'
+    }
+
+    It 'TASK781 C13 preserves ready state when workers stop respawn fails before the stop boundary' {
+        $fixture = New-Task781WorkersStopFixture -ProjectDir $script:workersTempRoot
+        $script:c13LifecycleWrites = [System.Collections.Generic.List[object]]::new()
+        $script:c13ReadClearCount = 0
+        $script:c13WatermarkClearCount = 0
+        $script:c13Results = @()
+
+        Mock Read-WorkersOptions { [PSCustomObject]@{ ProjectDir = $script:workersTempRoot; Target = 'all'; Json = $true } }
+        Mock Get-WorkersLifecycleContext {
+            [PSCustomObject]@{ ProjectDir = $script:workersTempRoot; EntriesBySlot = $fixture.EntriesBySlot }
+        }
+        Mock Get-WorkersStatusRows { @($fixture.Row) }
+        Mock Set-WorkersManifestLifecycleCommand {
+            param($Entry, $CommandName, $Status, $ExtraProperties)
+            $runtimeReady = if ($null -ne $ExtraProperties -and $ExtraProperties.Contains('runtime_ready')) {
+                [bool]$ExtraProperties['runtime_ready']
+            } else {
+                $null
+            }
+            $script:c13LifecycleWrites.Add([PSCustomObject][ordered]@{
+                command_name = [string]$CommandName
+                status = [string]$Status
+                runtime_ready = $runtimeReady
+            }) | Out-Null
+            if (-not [string]::IsNullOrWhiteSpace([string]$Status)) {
+                $Entry.Status = [string]$Status
+            }
+            if ($null -ne $runtimeReady) {
+                $Entry.RuntimeReady = [bool]$runtimeReady
+            }
+        }
+        Mock Invoke-WinsmuxRaw { throw 'synthetic respawn failure before stop boundary' }
+        Mock Clear-ReadMark { $script:c13ReadClearCount++ }
+        Mock Clear-Watermark { $script:c13WatermarkClearCount++ }
+        Mock Write-WorkersLifecycleOutput {
+            param($ProjectDir, $Results, [switch]$Json)
+            $script:c13Results = @($Results)
+        }
+
+        Invoke-WorkersStop
+
+        $actual = [ordered]@{
+            result_status = [string]$script:c13Results[0].status
+            reason = [string]$script:c13Results[0].reason
+            failed_stage = [string]$script:c13Results[0].failed_stage
+            recovery_action = [string]$script:c13Results[0].recovery_action
+            lifecycle_writes = @($script:c13LifecycleWrites)
+            entry_status = [string]$fixture.Entry.Status
+            runtime_ready = [bool]$fixture.Entry.RuntimeReady
+            marker_exists = Test-Path -LiteralPath $fixture.MarkerPath -PathType Leaf
+            read_clears = $script:c13ReadClearCount
+            watermark_clears = $script:c13WatermarkClearCount
+        }
+        $expected = [ordered]@{
+            result_status = 'failed'
+            reason = 'stop_respawn_failed'
+            failed_stage = 'pane_stop'
+            recovery_action = 'inspect-pane-and-rerun-workers-stop'
+            lifecycle_writes = @()
+            entry_status = 'ready'
+            runtime_ready = $true
+            marker_exists = $true
+            read_clears = 0
+            watermark_clears = 0
+        }
+        ($actual | ConvertTo-Json -Depth 8 -Compress) | Should -Be ($expected | ConvertTo-Json -Depth 8 -Compress)
+    }
+
+    It 'TASK781 C13 records explicit failed state when marker cleanup fails after the stop boundary' {
+        $fixture = New-Task781WorkersStopFixture -ProjectDir $script:workersTempRoot
+        $script:c13LifecycleWrites = [System.Collections.Generic.List[object]]::new()
+        $script:c13WaitCount = 0
+        $script:c13ReadClearCount = 0
+        $script:c13WatermarkClearCount = 0
+        $script:c13Results = @()
+
+        Mock Read-WorkersOptions { [PSCustomObject]@{ ProjectDir = $script:workersTempRoot; Target = 'all'; Json = $true } }
+        Mock Get-WorkersLifecycleContext {
+            [PSCustomObject]@{ ProjectDir = $script:workersTempRoot; EntriesBySlot = $fixture.EntriesBySlot }
+        }
+        Mock Get-WorkersStatusRows { @($fixture.Row) }
+        Mock Set-WorkersManifestLifecycleCommand {
+            param($Entry, $CommandName, $Status, $ExtraProperties)
+            $runtimeReady = if ($null -ne $ExtraProperties -and $ExtraProperties.Contains('runtime_ready')) {
+                [bool]$ExtraProperties['runtime_ready']
+            } else {
+                $null
+            }
+            $failureStage = if ($null -ne $ExtraProperties -and $ExtraProperties.Contains('last_failure_stage')) {
+                [string]$ExtraProperties['last_failure_stage']
+            } else {
+                ''
+            }
+            $recoveryAction = if ($null -ne $ExtraProperties -and $ExtraProperties.Contains('recovery_action')) {
+                [string]$ExtraProperties['recovery_action']
+            } else {
+                ''
+            }
+            $script:c13LifecycleWrites.Add([PSCustomObject][ordered]@{
+                command_name = [string]$CommandName
+                status = [string]$Status
+                runtime_ready = $runtimeReady
+                last_failure_stage = $failureStage
+                recovery_action = $recoveryAction
+            }) | Out-Null
+            if (-not [string]::IsNullOrWhiteSpace([string]$Status)) {
+                $Entry.Status = [string]$Status
+            }
+            if ($null -ne $runtimeReady) {
+                $Entry.RuntimeReady = [bool]$runtimeReady
+            }
+        }
+        Mock Invoke-WinsmuxRaw { @() }
+        Mock Get-SafeLastExitCode { 0 }
+        Mock Remove-WorkersStoppedBootstrapMarker { throw 'synthetic marker cleanup failure after stop boundary' }
+        Mock Wait-PaneControlRuntimeContext {
+            $script:c13WaitCount++
+            throw 'deferred runtime wait must not occur after marker cleanup failure'
+        }
+        Mock Clear-ReadMark { $script:c13ReadClearCount++ }
+        Mock Clear-Watermark { $script:c13WatermarkClearCount++ }
+        Mock Write-WorkersLifecycleOutput {
+            param($ProjectDir, $Results, [switch]$Json)
+            $script:c13Results = @($Results)
+        }
+
+        Invoke-WorkersStop
+
+        $actual = [ordered]@{
+            result_status = [string]$script:c13Results[0].status
+            reason = [string]$script:c13Results[0].reason
+            failed_stage = [string]$script:c13Results[0].failed_stage
+            recovery_action = [string]$script:c13Results[0].recovery_action
+            lifecycle_writes = @($script:c13LifecycleWrites)
+            entry_status = [string]$fixture.Entry.Status
+            runtime_ready = [bool]$fixture.Entry.RuntimeReady
+            runtime_waits = $script:c13WaitCount
+            read_clears = $script:c13ReadClearCount
+            watermark_clears = $script:c13WatermarkClearCount
+        }
+        $expected = [ordered]@{
+            result_status = 'failed'
+            reason = 'stop_marker_cleanup_failed'
+            failed_stage = 'marker_cleanup'
+            recovery_action = 'inspect-bootstrap-marker-and-rerun-workers-stop'
+            lifecycle_writes = @([PSCustomObject][ordered]@{
+                command_name = 'workers.stop'
+                status = 'deferred_start_failed'
+                runtime_ready = $false
+                last_failure_stage = 'marker_cleanup'
+                recovery_action = 'inspect-bootstrap-marker-and-rerun-workers-stop'
+            })
+            entry_status = 'deferred_start_failed'
+            runtime_ready = $false
+            runtime_waits = 0
+            read_clears = 0
+            watermark_clears = 0
+        }
+        ($actual | ConvertTo-Json -Depth 8 -Compress) | Should -Be ($expected | ConvertTo-Json -Depth 8 -Compress)
+    }
+
+    It 'TASK781 removes the stopped bootstrap marker and permits the default stop then start sequence' {
+        $bootstrapRoot = Join-Path (Join-Path $script:workersTempRoot '.winsmux') 'orchestra-bootstrap'
+        New-Item -ItemType Directory -Path $bootstrapRoot -Force | Out-Null
+        $planPath = Join-Path $bootstrapRoot '_2.json'
+        $markerPath = Join-Path $bootstrapRoot '_2-synthetic.ready.json'
+        '{}' | Set-Content -LiteralPath $planPath -Encoding UTF8
+        '{}' | Set-Content -LiteralPath $markerPath -Encoding UTF8
+
+        $entry = [PSCustomObject]@{
+            Label = 'worker-1'; SlotId = 'worker-1'; PaneId = '%2'; Status = 'ready'; RuntimeReady = $true
+            ManifestPath = 'synthetic-manifest'; BootstrapPlanPath = $planPath; BootstrapMarkerPath = $markerPath
+        }
+        $row = [PSCustomObject]@{
+            Slot = 'w1'; SlotId = 'worker-1'; PaneId = '%2'; Backend = 'codex'; State = 'ready'
+            LastFailureStage = ''; RecoveryAction = ''; ApprovedLaunch = $null; CurrentLaunch = $null; ApprovalDifferences = @()
+        }
+        $entriesBySlot = @{}; $entriesBySlot['worker-1'] = $entry
+        $script:task781RuntimeOperations = [System.Collections.Generic.List[string]]::new()
+        $script:task781LifecycleStatuses = [System.Collections.Generic.List[string]]::new()
+        $script:task781StartSawMarkerAbsent = $false
+        Mock Read-WorkersOptions { [PSCustomObject]@{ ProjectDir = $script:workersTempRoot; Target = 'all'; Json = $true } }
+        Mock Get-WorkersLifecycleContext { [PSCustomObject]@{ ProjectDir = $script:workersTempRoot; EntriesBySlot = $entriesBySlot } }
+        Mock Get-WorkersStatusRows { @($row) }
+        Mock Test-PaneControlRuntimeContext {
+            param($ProjectDir, $ManifestEntry, $Operation)
+            $script:task781RuntimeOperations.Add([string]$Operation) | Out-Null
+            New-WinsmuxRuntimeValidationResult -Valid $true -ReasonCode ("{0}_verified" -f $Operation) `
+                -Diagnostic 'verified' -Context ([ordered]@{ generation_id = 'generation-workers' })
+        }
+        Mock Set-WorkersManifestLifecycleCommand {
+            param($Entry, $CommandName, $Status, $ExtraProperties)
+            if (-not [string]::IsNullOrWhiteSpace([string]$Status)) {
+                $Entry.Status = [string]$Status
+                $script:task781LifecycleStatuses.Add([string]$Status) | Out-Null
+            }
+            if ($null -ne $ExtraProperties -and $ExtraProperties.Contains('runtime_ready')) {
+                $Entry.RuntimeReady = [bool]$ExtraProperties['runtime_ready']
+            }
+        }
+        Mock Invoke-WinsmuxRaw { @() }
+        Mock Get-SafeLastExitCode { 0 }
+        Mock Get-PaneControlManifestContext { $entry }
+        Mock Clear-ReadMark {}
+        Mock Clear-Watermark {}
+        Mock Start-DeferredPaneFromManifestEntry {
+            $script:task781StartSawMarkerAbsent = -not (Test-Path -LiteralPath $markerPath -PathType Leaf)
+            $entry.Status = 'ready'
+            $entry.RuntimeReady = $true
+            return $true
+        }
+        Mock Write-WorkersLifecycleOutput {}
+
+        Invoke-WorkersStop
+        $runtimeReadyAfterStop = $entry.RuntimeReady
+        Invoke-WorkersStart
+
+        Test-Path -LiteralPath $markerPath -PathType Leaf | Should -BeFalse
+        $script:task781StartSawMarkerAbsent | Should -BeTrue
+        @($script:task781RuntimeOperations) | Should -Be @('dispatch', 'start_deferred', 'start_deferred', 'dispatch')
+        @($script:task781LifecycleStatuses) | Should -Be @('deferred_start', 'ready')
+        $runtimeReadyAfterStop | Should -BeFalse
+        $entry.RuntimeReady | Should -BeTrue
+        Assert-MockCalled Invoke-WinsmuxRaw -Times 1 -Exactly -ParameterFilter { $Arguments[0] -eq 'respawn-pane' }
+        Assert-MockCalled Start-DeferredPaneFromManifestEntry -Times 1 -Exactly
+    }
+
+    It 'TASK781 rejects bootstrap marker cleanup outside the managed bootstrap directory' {
+        $bootstrapRoot = Join-Path (Join-Path $script:workersTempRoot '.winsmux') 'orchestra-bootstrap'
+        New-Item -ItemType Directory -Path $bootstrapRoot -Force | Out-Null
+        $planPath = Join-Path $bootstrapRoot '_2.json'
+        $outsideMarker = Join-Path $script:workersTempRoot '_2-synthetic.ready.json'
+        '{}' | Set-Content -LiteralPath $planPath -Encoding UTF8
+        '{}' | Set-Content -LiteralPath $outsideMarker -Encoding UTF8
+        $entry = [pscustomobject]@{
+            BootstrapPlanPath = $planPath
+            BootstrapMarkerPath = $outsideMarker
+        }
+
+        { Resolve-WorkersStoppedBootstrapMarkerPath -ProjectDir $script:workersTempRoot -Entry $entry } |
+            Should -Throw '*escaped the orchestra bootstrap directory*'
+        Test-Path -LiteralPath $outsideMarker -PathType Leaf | Should -BeTrue
+    }
+
+    It 'TASK781 C12 returns process exit <ExpectedExitCode> for workers <Action> with <RuntimeState> runtime and parseable <OutputMode> output' -ForEach @(
+        @{ Action = 'status'; RuntimeValid = $false; RuntimeState = 'invalid'; OutputMode = 'json'; ExpectedExitCode = 1 }
+        @{ Action = 'status'; RuntimeValid = $true; RuntimeState = 'valid'; OutputMode = 'text'; ExpectedExitCode = 0 }
+        @{ Action = 'doctor'; RuntimeValid = $false; RuntimeState = 'invalid'; OutputMode = 'json'; ExpectedExitCode = 1 }
+        @{ Action = 'doctor'; RuntimeValid = $true; RuntimeState = 'valid'; OutputMode = 'text'; ExpectedExitCode = 0 }
+    ) {
+        $dispatchMarker = '# --- Dispatch ---'
+        ([regex]::Matches($script:winsmuxWorkersCoreRawContent, [regex]::Escape($dispatchMarker))).Count | Should -Be 1
+        $syntheticOverrides = @'
+$script:syntheticRuntimeValid = [bool]::Parse([string]$env:WINSMUX_C12_RUNTIME_VALID)
+$script:syntheticRow = [pscustomobject][ordered]@{
+    Slot                   = 'w1'
+    SlotId                 = 'worker-1'
+    PaneId                 = '%2'
+    State                  = 'ready'
+    PaneState              = 'ready'
+    ManifestStatus         = 'ready'
+    Backend                = 'codex'
+    Role                   = 'reviewer'
+    ExecutionProfile       = 'local-windows'
+    Provider               = 'codex'
+    Model                  = 'gpt-5.5'
+    ModelSource            = 'operator-override'
+    ReasoningEffort        = 'high'
+    PromptTransport        = 'argv'
+    McpMode                = ''
+    AuthMode               = 'local-cli'
+    AuthPolicy             = ''
+    CapabilityAdapter      = ''
+    CredentialRequirements = 'local-cli-owned'
+    ExecutionBackend       = 'local'
+    ApiBaseUrl             = ''
+    ApiKeyEnv              = ''
+    ApiKeyEnvStatus        = ''
+    CredentialStatus       = ''
+    AnalysisPosture        = 'read-only-review'
+    LastFailureStage       = ''
+    LastFailureReason      = ''
+    RecoveryAction         = ''
+    LastCommand            = ''
+    LastCommandAt          = ''
+    ApprovedLaunch         = $null
+    CurrentLaunch          = $null
+    ApprovalDifferences    = @()
+    LaunchCommand          = ''
+    LaunchCommandStatus    = 'available'
+    LaunchCommandError     = ''
+    Heartbeat              = $null
+    HeartbeatHealth        = ''
+    HeartbeatState         = ''
+    Workspace              = $null
+    SecretProjection       = $null
+    Broker                 = $null
+    Policy                 = $null
+}
+
+function Read-WorkersOptions {
+    param([string[]]$Tokens, [string]$Usage, [string]$DefaultTarget)
+
+    return [pscustomobject]@{
+        ProjectDir = 'C:\synthetic-winsmux'
+        Target     = if ([string]::IsNullOrWhiteSpace($DefaultTarget)) { '' } else { $DefaultTarget }
+        Json       = @($Tokens) -contains '--json'
+    }
+}
+
+function Get-WorkersLifecycleContext {
+    param([string]$ProjectDir)
+
+    return [pscustomobject]@{
+        ProjectDir    = $ProjectDir
+        Slots         = @()
+        EntriesBySlot = @{}
+        ManifestError = ''
+    }
+}
+
+function Get-WorkersStatusRows {
+    param($Context)
+    return @($script:syntheticRow)
+}
+
+function Add-WorkersRuntimeValidity {
+    param($Context, [object[]]$Rows)
+
+    $reasonCode = if ($script:syntheticRuntimeValid) { 'dispatch_verified' } else { 'invalid_supervisor_identity' }
+    $diagnostic = if ($script:syntheticRuntimeValid) { 'synthetic runtime verified' } else { 'synthetic supervisor is stale' }
+    foreach ($row in @($Rows)) {
+        $row | Add-Member -NotePropertyName RuntimeValid -NotePropertyValue $script:syntheticRuntimeValid -Force
+        $row | Add-Member -NotePropertyName RuntimeState -NotePropertyValue $(if ($script:syntheticRuntimeValid) { [string]$row.State } else { 'runtime_invalid' }) -Force
+        $row | Add-Member -NotePropertyName RuntimeReasonCode -NotePropertyValue $reasonCode -Force
+        $row | Add-Member -NotePropertyName RuntimeDiagnostic -NotePropertyValue $diagnostic -Force
+    }
+    return @($Rows)
+}
+'@
+        $syntheticCorePath = Join-Path (
+            Split-Path -Parent $script:winsmuxWorkersCorePath
+        ) ('winsmux-core.c12-' + [guid]::NewGuid().ToString('N') + '.ps1')
+        $syntheticCoreContent = $script:winsmuxWorkersCoreRawContent.Replace(
+            $dispatchMarker,
+            "$syntheticOverrides`r`n$dispatchMarker"
+        )
+        $previousRuntimeValid = $env:WINSMUX_C12_RUNTIME_VALID
+        try {
+            [IO.File]::WriteAllText($syntheticCorePath, $syntheticCoreContent, [Text.UTF8Encoding]::new($false))
+            $env:WINSMUX_C12_RUNTIME_VALID = ([bool]$RuntimeValid).ToString()
+            $childArguments = @('-NoProfile', '-File', $syntheticCorePath, 'workers', $Action)
+            if ($OutputMode -eq 'json') {
+                $childArguments += '--json'
+            }
+            $output = @(& pwsh @childArguments 2>&1 | ForEach-Object { [string]$_ })
+            $exitCode = $LASTEXITCODE
+        } finally {
+            $env:WINSMUX_C12_RUNTIME_VALID = $previousRuntimeValid
+            Remove-Item -LiteralPath $syntheticCorePath -Force -ErrorAction SilentlyContinue
+        }
+
+        $outputText = ($output -join "`n").Trim()
+        if ($OutputMode -eq 'json') {
+            $payload = $outputText | ConvertFrom-Json -ErrorAction Stop
+            [bool]$payload.runtime_valid | Should -Be ([bool]$RuntimeValid)
+            if ($Action -eq 'status') {
+                @($payload.workers).Count | Should -Be 1
+                [bool]$payload.workers[0].runtime_valid | Should -Be ([bool]$RuntimeValid)
+            } else {
+                $runtimeCheck = @($payload.checks | Where-Object { $_.label -eq 'runtime identity' })
+                $runtimeCheck.Count | Should -Be 1
+                $runtimeCheck[0].status | Should -Be $(if ($RuntimeValid) { 'pass' } else { 'fail' })
+            }
+        } elseif ($Action -eq 'status') {
+            $lines = @($outputText -split '\r?\n')
+            @($lines | Where-Object { $_ -match '^Slot\s+SlotId\s+RuntimeState\s+' }).Count | Should -Be 1
+            $workerLine = @($lines | Where-Object { $_ -match '^w1\s+worker-1\s+' })
+            $workerLine.Count | Should -Be 1
+            $workerLine[0] | Should -Match '\sTrue(?:\s|$)'
+        } else {
+            $lines = @($outputText -split '\r?\n')
+            $lines[0] | Should -Be '=== winsmux workers doctor ==='
+            $runtimeLine = @($lines | Where-Object { $_ -match '^\[PASS\] runtime identity: ' })
+            $runtimeLine.Count | Should -Be 1
+            $runtimeLine[0] | Should -Match '1 worker runtime identities verified$'
+        }
+
+        $exitCode | Should -Be $ExpectedExitCode -Because "$Action with $RuntimeState runtime emitted parseable $OutputMode output: $outputText"
     }
 
     AfterEach {
@@ -11354,13 +15252,23 @@ agent-slots:
     worktree-mode: managed
 '@ | Set-Content -Path (Join-Path $script:workersTempRoot '.winsmux.yaml') -Encoding UTF8
         New-Item -ItemType Directory -Path (Join-Path $script:workersTempRoot '.winsmux') -Force | Out-Null
+        $bootstrapRoot = Join-Path (Join-Path $script:workersTempRoot '.winsmux') 'orchestra-bootstrap'
+        New-Item -ItemType Directory -Path $bootstrapRoot -Force | Out-Null
+        $planPath = Join-Path $bootstrapRoot '_2.json'
+        $markerPath = Join-Path $bootstrapRoot '_2-test.ready.json'
+        '{}' | Set-Content -LiteralPath $planPath -Encoding UTF8
+        '{}' | Set-Content -LiteralPath $markerPath -Encoding UTF8
         Save-WinsmuxManifest -ProjectDir $script:workersTempRoot -Manifest ([ordered]@{
-            version = 1
+            version = 2
             saved_at = '2026-05-13T00:00:00Z'
             session = [ordered]@{
                 name = 'winsmux-orchestra'
                 project_dir = $script:workersTempRoot
                 git_worktree_dir = (Join-Path $script:workersTempRoot '.git')
+                generation_id = 'generation-workers'
+                server_session_id = '$workers'
+                bootstrap_pane_id = '%1'
+                expected_pane_count = 1
             }
             panes = [ordered]@{
                 'worker-1' = [ordered]@{
@@ -11371,6 +15279,9 @@ agent-slots:
                     exec_mode = $false
                     launch_dir = $script:workersTempRoot
                     status = 'ready'
+                    runtime_ready = $true
+                    bootstrap_plan_path = $planPath
+                    bootstrap_marker_path = $markerPath
                     task = $null
                 }
             }
@@ -11398,7 +15309,9 @@ agent-slots:
         $payload.results[0].slot_id | Should -Be 'worker-1'
         $payload.results[0].status | Should -Be 'stopped'
         $entry.Status | Should -Be 'deferred_start'
+        $entry.RuntimeReady | Should -BeFalse
         $entry.LastCommand | Should -Be 'workers.stop'
+        Test-Path -LiteralPath $markerPath -PathType Leaf | Should -BeFalse
         Should -Invoke Invoke-WinsmuxRaw -Times 1 -Exactly -ParameterFilter {
             $Arguments[0] -eq 'respawn-pane' -and $Arguments -contains '%2'
         }
@@ -11453,6 +15366,8 @@ agent-slots:
 
         Mock Send-TextToPane { throw 'bootstrap should not be dispatched' }
 
+        $manifestPath = Join-Path $script:workersTempRoot '.winsmux\manifest.yaml'
+        $manifestHashBefore = (Get-FileHash -LiteralPath $manifestPath -Algorithm SHA256).Hash
         $Rest = @('worker-1', '--json', '--project-dir', $script:workersTempRoot)
         $output = Invoke-WorkersStart
         $payload = ($output | Select-Object -Last 1) | ConvertFrom-Json
@@ -11464,10 +15379,11 @@ agent-slots:
         $payload.results[0].failed_stage | Should -Be 'runner_config'
         $payload.results[0].recovery_action | Should -Be 'set-api-llm-slot-and-api-key-env'
         $entry.Status | Should -Be 'api_llm_runner_unconfigured'
-        $entry.LastCommand | Should -Be 'workers.start'
-        $entry.LastFailureStage | Should -Be 'runner_config'
-        $entry.LastFailureReason | Should -Be 'api_llm_runner_unconfigured'
-        $entry.RecoveryAction | Should -Be 'set-api-llm-slot-and-api-key-env'
+        $entry.LastCommand | Should -BeNullOrEmpty
+        $entry.LastFailureStage | Should -BeNullOrEmpty
+        $entry.LastFailureReason | Should -BeNullOrEmpty
+        $entry.RecoveryAction | Should -BeNullOrEmpty
+        (Get-FileHash -LiteralPath $manifestPath -Algorithm SHA256).Hash | Should -Be $manifestHashBefore
         Should -Invoke Send-TextToPane -Times 0 -Exactly
     }
 
@@ -11520,6 +15436,8 @@ agent-slots:
 
         Mock Send-TextToPane { throw 'bootstrap should not be dispatched' }
 
+        $manifestPath = Join-Path $script:workersTempRoot '.winsmux\manifest.yaml'
+        $manifestHashBefore = (Get-FileHash -LiteralPath $manifestPath -Algorithm SHA256).Hash
         $Rest = @('worker-1', '--json', '--project-dir', $script:workersTempRoot)
         $output = Invoke-WorkersStart
         $payload = ($output | Select-Object -Last 1) | ConvertFrom-Json
@@ -11531,10 +15449,11 @@ agent-slots:
         $payload.results[0].failed_stage | Should -Be 'runner_config'
         $payload.results[0].recovery_action | Should -Be 'install-or-configure-antigravity-cli'
         $entry.Status | Should -Be 'antigravity_runner_unconfigured'
-        $entry.LastCommand | Should -Be 'workers.start'
-        $entry.LastFailureStage | Should -Be 'runner_config'
-        $entry.LastFailureReason | Should -Be 'antigravity_runner_unconfigured'
-        $entry.RecoveryAction | Should -Be 'install-or-configure-antigravity-cli'
+        $entry.LastCommand | Should -BeNullOrEmpty
+        $entry.LastFailureStage | Should -BeNullOrEmpty
+        $entry.LastFailureReason | Should -BeNullOrEmpty
+        $entry.RecoveryAction | Should -BeNullOrEmpty
+        (Get-FileHash -LiteralPath $manifestPath -Algorithm SHA256).Hash | Should -Be $manifestHashBefore
         Should -Invoke Send-TextToPane -Times 0 -Exactly
     }
 
@@ -11556,12 +15475,16 @@ agent-slots:
         New-Item -ItemType Directory -Path (Join-Path $script:workersTempRoot '.winsmux') -Force | Out-Null
         $planPath = Join-Path $script:workersTempRoot 'worker-1.json'
         Save-WinsmuxManifest -ProjectDir $script:workersTempRoot -Manifest ([ordered]@{
-            version = 1
+            version = 2
             saved_at = '2026-05-13T00:00:00Z'
             session = [ordered]@{
                 name = 'winsmux-orchestra'
                 project_dir = $script:workersTempRoot
                 git_worktree_dir = (Join-Path $script:workersTempRoot '.git')
+                generation_id = 'generation-workers'
+                server_session_id = '$workers'
+                bootstrap_pane_id = '%1'
+                expected_pane_count = 1
             }
             panes = [ordered]@{
                 'worker-1' = [ordered]@{
@@ -11654,12 +15577,16 @@ agent-slots:
         New-Item -ItemType Directory -Path (Join-Path $script:workersTempRoot '.winsmux') -Force | Out-Null
         $planPath = Join-Path $script:workersTempRoot 'worker-1.json'
         Save-WinsmuxManifest -ProjectDir $script:workersTempRoot -Manifest ([ordered]@{
-            version = 1
+            version = 2
             saved_at = '2026-05-13T00:00:00Z'
             session = [ordered]@{
                 name = 'winsmux-orchestra'
                 project_dir = $script:workersTempRoot
                 git_worktree_dir = (Join-Path $script:workersTempRoot '.git')
+                generation_id = 'generation-workers'
+                server_session_id = '$workers'
+                bootstrap_pane_id = '%1'
+                expected_pane_count = 1
             }
             panes = [ordered]@{
                 'worker-1' = [ordered]@{
@@ -11708,6 +15635,18 @@ agent-slots:
         Mock Wait-PaneShellReady { }
         Mock Invoke-Send { return $true }
         Mock Wait-DeferredPaneReady { }
+        Mock Assert-WinsmuxTargetRuntimeWriteAllowed {
+            [pscustomobject]@{
+                Managed      = $true
+                ProjectDir   = $script:workersTempRoot
+                GenerationId = 'generation-workers-stale-heartbeat'
+                Validation   = [pscustomobject]@{
+                    valid       = $true
+                    reason_code = 'dispatch_verified'
+                    diagnostic  = 'synthetic deferred worker runtime verified'
+                }
+            }
+        }
 
         $Rest = @('worker-1', '--json', '--project-dir', $script:workersTempRoot)
         $output = Invoke-WorkersStart
@@ -11755,12 +15694,16 @@ agent-slots:
 '@ | Set-Content -Path (Join-Path $script:workersTempRoot '.winsmux.yaml') -Encoding UTF8
         New-Item -ItemType Directory -Path (Join-Path $script:workersTempRoot '.winsmux') -Force | Out-Null
         Save-WinsmuxManifest -ProjectDir $script:workersTempRoot -Manifest ([ordered]@{
-            version = 1
+            version = 2
             saved_at = '2026-05-13T00:00:00Z'
             session = [ordered]@{
                 name = 'winsmux-orchestra'
                 project_dir = $script:workersTempRoot
                 git_worktree_dir = (Join-Path $script:workersTempRoot '.git')
+                generation_id = 'generation-workers'
+                server_session_id = '$workers'
+                bootstrap_pane_id = '%1'
+                expected_pane_count = 1
             }
             panes = [ordered]@{
                 'worker-1' = [ordered]@{
@@ -15251,6 +19194,27 @@ Describe 'winsmux dispatch-task routing' {
         . $script:dispatchRouterPath
     }
 
+    BeforeEach {
+        $script:dispatchTaskTempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('winsmux-dispatch-task-' + [guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $script:dispatchTaskTempRoot -Force | Out-Null
+        Mock Test-PaneControlRuntimeContext {
+            param($ProjectDir, $ManifestEntry, $Operation)
+            New-WinsmuxRuntimeValidationResult -Valid $true -ReasonCode ("{0}_verified" -f $Operation) `
+                -Diagnostic 'synthetic dispatch runtime verified' -Context ([ordered]@{ generation_id = 'generation-dispatch' })
+        }
+        Mock New-WinsmuxSubmissionAcknowledgementServer {
+            [PSCustomObject]@{ pipe_name = 'winsmux-submission-ack-11111111111111111111111111111111'; challenge = ('a' * 64); server = $null }
+        }
+        Mock Receive-WinsmuxSubmissionAcknowledgement { throw 'synthetic acknowledgement absent' }
+        Mock Complete-WinsmuxSubmissionAcknowledgement { $true }
+    }
+
+    AfterEach {
+        if ($script:dispatchTaskTempRoot -and (Test-Path -LiteralPath $script:dispatchTaskTempRoot -PathType Container)) {
+            Remove-Item -LiteralPath $script:dispatchTaskTempRoot -Recurse -Force
+        }
+    }
+
     It 'keeps reviewer worker slots out of generic worker dispatch targets' {
         Mock Get-PaneControlManifestEntries {
             @(
@@ -15299,22 +19263,25 @@ Describe 'winsmux dispatch-task routing' {
 
     It 'does not accept shell or Codex send success without a backend run record' {
         $entry = [PSCustomObject]@{ Label = 'worker-2'; PaneId = '%2'; Role = 'Worker'; WorkerBackend = 'codex' }
-        $receipt = Invoke-WinsmuxSubmissionAdapter -ProjectDir 'C:\repo' -ManifestEntry $entry -Kind task -Content 'implement the focused change' -SubmissionId 'submission-test-2' `
+        $receipt = Invoke-WinsmuxSubmissionAdapter -ProjectDir $script:dispatchTaskTempRoot -ManifestEntry $entry -Kind task -Content 'implement the focused change' -SubmissionId 'submission-test-2' `
             -SendAction { param($paneId, $commandText) } `
             -RunResultAction { param($projectDir, $slotId, $runId) $null }
 
-        $receipt.status | Should -Be 'unavailable'
-        $receipt.reason_code | Should -Be 'caller_identity_unavailable'
+        $receipt.status | Should -Be 'rejected'
+        $receipt.reason_code | Should -Be 'backend_acknowledgement_missing'
     }
 
     It 'refuses shell or Codex even when mutable local evidence claims a matching run record' {
         $entry = [PSCustomObject]@{ Label = 'worker-2'; PaneId = '%2'; Role = 'Worker'; WorkerBackend = 'local' }
-        $receipt = Invoke-WinsmuxSubmissionAdapter -ProjectDir 'C:\repo' -ManifestEntry $entry -Kind task -Content 'implement the focused change' -SubmissionId 'submission-test-3' `
+        $script:mutableRunResultRead = $false
+        $receipt = Invoke-WinsmuxSubmissionAdapter -ProjectDir $script:dispatchTaskTempRoot -ManifestEntry $entry -Kind task -Content 'implement the focused change' -SubmissionId 'submission-test-3' `
             -SendAction { param($paneId, $commandText) } `
-            -RunResultAction { param($projectDir, $slotId, $runId) New-WinsmuxSubmissionRunRecord -SubmissionId $runId -RunId $runId -Kind task -TaskTitle 'Test task' -SlotId $slotId -Backend local -Status started -RequestConsumed -RequestDigest (Get-WinsmuxSubmissionRequestDigest -Request 'implement the focused change') }
+            -RunResultAction { param($projectDir, $slotId, $runId) $script:mutableRunResultRead = $true; New-WinsmuxSubmissionRunRecord -SubmissionId $runId -RunId $runId -Kind task -TaskTitle 'Test task' -SlotId $slotId -Backend local -Status started -RequestConsumed -RequestDigest (Get-WinsmuxSubmissionRequestDigest -Request 'implement the focused change') }
 
-        $receipt.status | Should -Be 'unavailable'
-        $receipt.reason_code | Should -Be 'caller_identity_unavailable'
+        $receipt.status | Should -Be 'rejected'
+        $receipt.reason_code | Should -Be 'backend_acknowledgement_missing'
+        $receipt.acknowledgement | Should -BeNullOrEmpty
+        $script:mutableRunResultRead | Should -BeFalse
     }
 
     It 'sends api_llm an exec packet and converts runner refusal to typed rejected' {
@@ -15397,6 +19364,33 @@ Describe 'winsmux dispatch-task routing' {
         $receipt.routing.rule_id | Should -Be 'route.operator_owned.v1'
         $receipt.routing.next_shape | Should -Not -BeNullOrEmpty
     }
+
+    It 'TASK781 C50/C51 preserves typed deferred runtime refusals for task and review receipts' {
+        $taskReceipt = New-WinsmuxDeferredStartFailureReceipt -Kind task -SubmissionId 'submission-task-c50' `
+            -PaneId '%2' -Failure ([System.InvalidOperationException]::new(
+                'runtime dispatch refused (invalid_supervisor_identity): generation expired before deferred start'))
+        $reviewReceipt = New-WinsmuxDeferredStartFailureReceipt -Kind review -SubmissionId 'submission-review-c51' `
+            -PaneId '%3' -Failure ([System.InvalidOperationException]::new(
+                'runtime dispatch refused (runtime_target_mismatch): deferred pane belongs to another session'))
+        $genericReceipt = New-WinsmuxDeferredStartFailureReceipt -Kind task -SubmissionId 'submission-task-generic' `
+            -PaneId '%4' -Failure ([System.InvalidOperationException]::new('synthetic untyped failure'))
+
+        $taskReceipt.status | Should -Be 'unavailable'
+        $taskReceipt.reason_code | Should -Be 'invalid_supervisor_identity'
+        $taskReceipt.diagnostic | Should -Be 'generation expired before deferred start'
+        $reviewReceipt.status | Should -Be 'unavailable'
+        $reviewReceipt.reason_code | Should -Be 'runtime_target_mismatch'
+        $reviewReceipt.diagnostic | Should -Be 'deferred pane belongs to another session'
+        $genericReceipt.reason_code | Should -Be 'deferred_start_failed'
+        $genericReceipt.diagnostic | Should -Be 'synthetic untyped failure'
+
+        $controlPlaneContent = Get-Content -LiteralPath (
+            Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\control-plane-dispatch.ps1'
+        ) -Raw -Encoding UTF8
+        $coreContent = Get-Content -LiteralPath $script:dispatchCorePath -Raw -Encoding UTF8
+        $controlPlaneContent | Should -Match 'New-WinsmuxDeferredStartFailureReceipt\s+-Kind\s+task'
+        $coreContent | Should -Match 'New-WinsmuxDeferredStartFailureReceipt\s+-Kind\s+review'
+    }
 }
 
 Describe 'TASK-780 typed submission review fixes' {
@@ -15415,12 +19409,95 @@ Describe 'TASK-780 typed submission review fixes' {
     BeforeEach {
         $script:task780TempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('winsmux-task780-review-' + [guid]::NewGuid().ToString('N'))
         New-Item -ItemType Directory -Path $script:task780TempRoot -Force | Out-Null
+        Mock Test-PaneControlRuntimeContext {
+            param($ProjectDir, $ManifestEntry, $Operation)
+            if ([string]$Operation -ceq 'caller_ack') {
+                return New-WinsmuxRuntimeValidationResult -Valid $false -ReasonCode 'caller_identity_mismatch' -Diagnostic 'synthetic caller ancestry is not authoritative'
+            }
+            return New-WinsmuxRuntimeValidationResult -Valid $true -ReasonCode 'dispatch_runtime_verified' `
+                -Diagnostic 'synthetic dispatch runtime verified' -Context ([ordered]@{ generation_id = 'generation-1' })
+        }
+        Mock New-WinsmuxSubmissionAcknowledgementServer {
+            [PSCustomObject]@{ pipe_name = 'winsmux-submission-ack-22222222222222222222222222222222'; challenge = ('b' * 64); server = $null }
+        }
+        Mock Receive-WinsmuxSubmissionAcknowledgement { throw 'synthetic acknowledgement absent' }
+        Mock Complete-WinsmuxSubmissionAcknowledgement { $true }
     }
 
     AfterEach {
         if ($script:task780TempRoot -and (Test-Path -LiteralPath $script:task780TempRoot)) {
             Remove-Item -LiteralPath $script:task780TempRoot -Recurse -Force
         }
+    }
+
+    It 'TASK781 C19 derives the builder queue write guard from the loaded manifest snapshot' {
+        $manifest = [PSCustomObject]@{
+            session = [PSCustomObject]@{ generation_id = 'generation-initial' }
+        }
+        Mock Get-PaneControlManifestGenerationId { 'generation-replacement' }
+
+        Get-BuilderQueueExpectedGenerationId -Manifest $manifest | Should -BeExactly 'generation-initial'
+
+        Should -Invoke Get-PaneControlManifestGenerationId -Times 0 -Exactly
+    }
+
+    It 'TASK781 C19 threads the queue snapshot through its pane state follow-up' {
+        $snapshot = [ordered]@{
+            ManifestPath = 'C:\repo\.winsmux\manifest.yaml'
+            PaneId = '%2'
+            GenerationId = 'generation-initial'
+        }
+        $script:capturedQueueGeneration = ''
+        Mock Get-PaneControlManifestEntries {
+            @([pscustomobject]@{ ManifestPath = 'replacement'; PaneId = '%9'; GenerationId = 'generation-replacement' })
+        }
+        Mock Set-PaneControlManifestPaneProperties {
+            param($ManifestPath, $PaneId, $Properties, $ExpectedGenerationId)
+            $script:capturedQueueGeneration = [string]$ExpectedGenerationId
+        }
+
+        Update-BuilderQueuePaneState -PaneContext $snapshot -Properties ([ordered]@{ task_state = 'completed' })
+
+        $script:capturedQueueGeneration | Should -BeExactly 'generation-initial'
+        Should -Invoke Get-PaneControlManifestEntries -Times 0 -Exactly
+    }
+
+    It 'TASK781 C19 carries the loaded generation through the production queue completion caller' {
+        $rawEntry = 'task-301|builder-1|bounded queue task'
+        $manifest = [pscustomobject]@{
+            session = [pscustomobject]@{ generation_id = 'generation-initial' }
+            panes = [ordered]@{ 'builder-1' = [pscustomobject]@{ pane_id = '%2' } }
+            tasks = [pscustomobject]@{ queued = @(); in_progress = @($rawEntry); completed = @() }
+        }
+        $script:queueCallerGeneration = ''
+        Mock Get-BuilderQueueManifest { $manifest }
+        Mock Get-BuilderQueueEntries {
+            if ($State -ceq 'in_progress') {
+                return @([pscustomobject]@{
+                    TaskId = 'task-301'
+                    BuilderLabel = 'builder-1'
+                    Task = 'bounded queue task'
+                    RawEntry = $rawEntry
+                })
+            }
+            return @()
+        }
+        Mock Save-BuilderQueueManifest { }
+        Mock Unlock-DispatchFiles { $true }
+        Mock Set-PaneControlManifestPaneProperties {
+            $script:queueCallerGeneration = [string]$ExpectedGenerationId
+        }
+        Mock Get-PaneControlManifestGenerationId { 'generation-replacement' }
+        Mock Dispatch-NextBuilderQueueTask {
+            [pscustomobject]@{ Dispatched = $false; CurrentTask = $null }
+        }
+        Mock Get-BuilderQueueSnapshot { [pscustomobject]@{} }
+
+        $result = Complete-BuilderQueueTask -ProjectDir $script:task780TempRoot -BuilderLabel 'builder-1'
+
+        $result.CompletedTask | Should -BeExactly 'bounded queue task'
+        $script:queueCallerGeneration | Should -BeExactly 'generation-initial'
+        Should -Invoke Get-PaneControlManifestGenerationId -Times 0 -Exactly
     }
 
     It 'P1 refuses pane input echo when strong caller identity is unavailable' {
@@ -15432,8 +19509,10 @@ Describe 'TASK-780 typed submission review fixes' {
             -RunResultAction { param($projectDir, $slotId, $runId) $null }
 
         $receipt.GetType().Name | Should -Not -Be 'Object[]'
-        $receipt.status | Should -Be 'unavailable'
-        $receipt.reason_code | Should -Be 'caller_identity_unavailable'
+        $receipt.status | Should -Be 'rejected'
+        $receipt.reason_code | Should -Be 'backend_acknowledgement_missing'
+        $script:echoedPrompt | Should -Match 'typed submission packet'
+        $script:echoedPrompt | Should -Not -Match 'synthetic implementation request'
     }
 
     It 'P1 rejects unsafe target labels before composing a pane command' {
@@ -15557,14 +19636,14 @@ panes:
             $env:WINSMUX_PANE_ID = '%2'
             $receipt = Invoke-WinsmuxSubmissionAcknowledge -ProjectDir $script:task780TempRoot -SlotId worker-1 -SubmissionId 'submission-ack-bound' -RunId 'submission-ack-bound' -Kind task -Backend codex
             $receipt.status | Should -Be 'unavailable'
-            $receipt.reason_code | Should -Be 'caller_identity_unavailable'
+            $receipt.reason_code | Should -Be 'caller_identity_mismatch'
 
             New-WinsmuxSubmissionPacket -ProjectDir $script:task780TempRoot -Kind task -Content ([ordered]@{ title = 'Wrong pane'; request = 'Reject wrong pane.' }) -SubmissionId 'submission-ack-wrong-pane' -TargetLabel worker-1 | Out-Null
             $env:WINSMUX_PANE_ID = '%9'
             (Invoke-WinsmuxSubmissionAcknowledge -ProjectDir $script:task780TempRoot -SlotId worker-1 -SubmissionId 'submission-ack-wrong-pane' -RunId 'submission-ack-wrong-pane' -Kind task -Backend codex).status | Should -Be 'unavailable'
 
             $env:WINSMUX_PANE_ID = '%2'
-            (Invoke-WinsmuxSubmissionAcknowledge -ProjectDir $script:task780TempRoot -SlotId worker-1 -SubmissionId 'submission-ack-wrong-pane' -RunId 'submission-ack-wrong-pane' -Kind task -Backend local).reason_code | Should -Be 'caller_identity_unavailable'
+            (Invoke-WinsmuxSubmissionAcknowledge -ProjectDir $script:task780TempRoot -SlotId worker-1 -SubmissionId 'submission-ack-wrong-pane' -RunId 'submission-ack-wrong-pane' -Kind task -Backend local).reason_code | Should -Be 'caller_identity_mismatch'
         } finally {
             $env:WINSMUX_PANE_ID = $previousPaneId
         }
@@ -15797,6 +19876,9 @@ agent-slots:
     It 'ROUND2 P2 refuses forged local or Codex pane identity until TASK-781 authority exists' {
         $previousPaneId = $env:WINSMUX_PANE_ID
         try {
+            Mock Test-PaneControlRuntimeContext {
+                New-WinsmuxRuntimeValidationResult -Valid $false -ReasonCode 'caller_identity_mismatch' -Diagnostic 'synthetic mutable pane identity is not authoritative'
+            }
             $env:WINSMUX_PANE_ID = '%2'
             $entry = [PSCustomObject]@{ Label = 'worker-1'; PaneId = '%2'; Role = 'Worker'; WorkerBackend = 'codex' }
             $script:round2LocalSendCalled = $false
@@ -15804,7 +19886,7 @@ agent-slots:
                 -SendAction { $script:round2LocalSendCalled = $true } `
                 -RunResultAction { throw 'must not request optimistic evidence' }
             $receipt.status | Should -Be 'unavailable'
-            $receipt.reason_code | Should -Be 'caller_identity_unavailable'
+            $receipt.reason_code | Should -Be 'caller_identity_mismatch'
             $script:round2LocalSendCalled | Should -Be $false
         } finally {
             $env:WINSMUX_PANE_ID = $previousPaneId
@@ -15846,7 +19928,7 @@ agent-slots:
         $exitCode | Should -Be 1
         $payload.Dispatched | Should -Be $false
         $payload.DispatchResult.status | Should -Be 'unavailable'
-        $payload.DispatchResult.reason_code | Should -Be 'caller_identity_unavailable'
+        $payload.DispatchResult.reason_code | Should -Be 'manifest_regeneration_required'
         @($saved.tasks.queued).Count | Should -Be 1
         @($saved.tasks.in_progress).Count | Should -Be 0
         @(Get-DispatchLedger -ProjectDir $script:task780TempRoot).Count | Should -Be 0
@@ -16102,6 +20184,160 @@ agent-slots:
         $packetAfterRetryText | Should -BeExactly $originalPacketText
         $packetAfterRetry.request | Should -BeExactly $originalPacket.request
         $packetAfterRetry.request_digest | Should -BeExactly $originalPacket.request_digest
+    }
+
+    It 'TASK781 preserves a local packet when delivery commits before post-Enter failure' {
+        $taskId = 'task-task781-local-committed-packet'
+        $attemptId = 'attempt-task781-local-committed-packet-1'
+        $entry = [PSCustomObject]@{ Label = 'worker-1'; PaneId = '%2'; Role = 'Worker'; WorkerBackend = 'codex' }
+        Mock Test-PaneControlRuntimeContext {
+            [PSCustomObject]@{
+                valid = $true
+                reason_code = 'dispatch_runtime_verified'
+                diagnostic = ''
+                context = [PSCustomObject]@{ generation_id = 'generation-task781' }
+            }
+        }
+        Mock Send-TextToPane {
+            $DeliveryState['SubmissionCommitted'] = $true
+            throw 'synthetic post-Enter watermark failure'
+        }
+
+        $first = Invoke-WinsmuxSubmissionAdapter -ProjectDir $script:task780TempRoot -ManifestEntry $entry -Kind task `
+            -Content 'Preserve the exact committed packet.' -SubmissionId $attemptId -TaskId $taskId
+        $packetPath = Join-Path $script:task780TempRoot ".winsmux\submissions\$attemptId.json"
+        $originalPacketText = Get-Content -LiteralPath $packetPath -Raw -Encoding UTF8
+
+        $duplicate = Invoke-WinsmuxSubmissionAdapter -ProjectDir $script:task780TempRoot -ManifestEntry $entry -Kind task `
+            -Content 'Do not replace the committed packet.' -SubmissionId $attemptId -TaskId $taskId `
+            -SendAction { throw 'duplicate must stop before delivery' }
+
+        $first.status | Should -Be 'unavailable'
+        $first.reason_code | Should -Be 'packet_repl_unavailable'
+        $duplicate.status | Should -Be 'rejected'
+        $duplicate.reason_code | Should -Be 'run_record_already_exists'
+        (Get-Content -LiteralPath $packetPath -Raw -Encoding UTF8) | Should -BeExactly $originalPacketText
+        Should -Invoke Send-TextToPane -Times 1 -Exactly -ParameterFilter {
+            $null -ne $DeliveryState -and [bool]$DeliveryState['SubmissionCommitted']
+        }
+    }
+
+    It 'TASK781 C19 refuses stale runtime before creating a submission packet' {
+        $attemptId = 'attempt-task781-prepublication-refusal-1'
+        $entry = [PSCustomObject]@{ Label = 'worker-1'; PaneId = '%2'; Role = 'Worker'; WorkerBackend = 'api_llm' }
+        $script:task781PrepublicationChecks = 0
+        Mock Test-PaneControlRuntimeContext {
+            $script:task781PrepublicationChecks++
+            if ($script:task781PrepublicationChecks -eq 1) {
+                return [PSCustomObject]@{
+                    valid = $true
+                    reason_code = 'dispatch_runtime_verified'
+                    diagnostic = ''
+                    context = [PSCustomObject]@{ generation_id = 'generation-before-publication' }
+                }
+            }
+            return New-WinsmuxRuntimeValidationResult -Valid $false `
+                -ReasonCode 'invalid_supervisor_identity' -Diagnostic 'synthetic lease expired before packet publication'
+        }
+        Mock New-WinsmuxSubmissionPacket { throw 'packet creation must not be reached' }
+
+        $receipt = Invoke-WinsmuxSubmissionAdapter -ProjectDir $script:task780TempRoot -ManifestEntry $entry -Kind task `
+            -Content 'Never persist this request after lease expiry.' -SubmissionId $attemptId -TaskId 'task-task781-prepublication-refusal' `
+            -SendAction { throw 'send must not be reached' } -RunResultAction { throw 'run polling must not be reached' }
+
+        $receipt.status | Should -Be 'unavailable'
+        $receipt.reason_code | Should -Be 'invalid_supervisor_identity'
+        $script:task781PrepublicationChecks | Should -Be 2
+        Should -Invoke New-WinsmuxSubmissionPacket -Times 0 -Exactly
+        Test-Path -LiteralPath (Join-Path $script:task780TempRoot ".winsmux\submissions\$attemptId.json") | Should -BeFalse
+    }
+
+    It 'TASK781 C19 refuses a missing captured generation before creating a submission packet' {
+        $attemptId = 'attempt-task781-missing-generation-refusal-1'
+        $entry = [PSCustomObject]@{ Label = 'worker-1'; PaneId = '%2'; Role = 'Worker'; WorkerBackend = 'api_llm' }
+        $script:task781MissingGenerationChecks = 0
+        Mock Test-PaneControlRuntimeContext {
+            $script:task781MissingGenerationChecks++
+            $generationId = if ($script:task781MissingGenerationChecks -eq 1) { '' } else { 'generation-fresh' }
+            return [PSCustomObject]@{
+                valid = $true
+                reason_code = 'dispatch_runtime_verified'
+                diagnostic = ''
+                context = [PSCustomObject]@{ generation_id = $generationId }
+            }
+        }
+        Mock New-WinsmuxSubmissionPacket { throw 'packet creation must not be reached' }
+
+        $receipt = Invoke-WinsmuxSubmissionAdapter -ProjectDir $script:task780TempRoot -ManifestEntry $entry -Kind task `
+            -Content 'Never persist this request without an exact generation.' -SubmissionId $attemptId `
+            -TaskId 'task-task781-missing-generation-refusal' -SendAction { throw 'send must not be reached' } `
+            -RunResultAction { throw 'run polling must not be reached' }
+
+        $receipt.status | Should -Be 'unavailable'
+        $receipt.reason_code | Should -Be 'manifest_regeneration_required'
+        $script:task781MissingGenerationChecks | Should -Be 2
+        Should -Invoke New-WinsmuxSubmissionPacket -Times 0 -Exactly
+        Test-Path -LiteralPath (Join-Path $script:task780TempRoot ".winsmux\submissions\$attemptId.json") | Should -BeFalse
+    }
+
+    It 'TASK781 C19 refuses a missing fresh generation before creating a submission packet' {
+        $attemptId = 'attempt-task781-missing-fresh-generation-refusal-1'
+        $entry = [PSCustomObject]@{ Label = 'worker-1'; PaneId = '%2'; Role = 'Worker'; WorkerBackend = 'api_llm' }
+        $script:task781MissingFreshGenerationChecks = 0
+        Mock Test-PaneControlRuntimeContext {
+            $script:task781MissingFreshGenerationChecks++
+            $generationId = if ($script:task781MissingFreshGenerationChecks -eq 1) { 'generation-captured' } else { '' }
+            return [PSCustomObject]@{
+                valid = $true
+                reason_code = 'dispatch_runtime_verified'
+                diagnostic = ''
+                context = [PSCustomObject]@{ generation_id = $generationId }
+            }
+        }
+        Mock New-WinsmuxSubmissionPacket { throw 'packet creation must not be reached' }
+
+        $receipt = Invoke-WinsmuxSubmissionAdapter -ProjectDir $script:task780TempRoot -ManifestEntry $entry -Kind task `
+            -Content 'Never persist this request without a fresh generation.' -SubmissionId $attemptId `
+            -TaskId 'task-task781-missing-fresh-generation-refusal' -SendAction { throw 'send must not be reached' } `
+            -RunResultAction { throw 'run polling must not be reached' }
+
+        $receipt.status | Should -Be 'unavailable'
+        $receipt.reason_code | Should -Be 'manifest_regeneration_required'
+        $script:task781MissingFreshGenerationChecks | Should -Be 2
+        Should -Invoke New-WinsmuxSubmissionPacket -Times 0 -Exactly
+        Test-Path -LiteralPath (Join-Path $script:task780TempRoot ".winsmux\submissions\$attemptId.json") | Should -BeFalse
+    }
+
+    It 'TASK781 C19 uses ordinal generation identity before creating a submission packet' {
+        $attemptId = 'attempt-task781-ordinal-generation-refusal-1'
+        $entry = [PSCustomObject]@{ Label = 'worker-1'; PaneId = '%2'; Role = 'Worker'; WorkerBackend = 'api_llm' }
+        $script:task781OrdinalGenerationChecks = 0
+        Mock Test-PaneControlRuntimeContext {
+            $script:task781OrdinalGenerationChecks++
+            $generationId = if ($script:task781OrdinalGenerationChecks -eq 1) {
+                "generation-$([char]0x00E9)"
+            } else {
+                "generation-e$([char]0x0301)"
+            }
+            return [PSCustomObject]@{
+                valid = $true
+                reason_code = 'dispatch_runtime_verified'
+                diagnostic = ''
+                context = [PSCustomObject]@{ generation_id = $generationId }
+            }
+        }
+        Mock New-WinsmuxSubmissionPacket { throw 'packet creation must not be reached' }
+
+        $receipt = Invoke-WinsmuxSubmissionAdapter -ProjectDir $script:task780TempRoot -ManifestEntry $entry -Kind task `
+            -Content 'Never persist this request for a non-ordinal generation match.' -SubmissionId $attemptId `
+            -TaskId 'task-task781-ordinal-generation-refusal' -SendAction { throw 'send must not be reached' } `
+            -RunResultAction { throw 'run polling must not be reached' }
+
+        $receipt.status | Should -Be 'unavailable'
+        $receipt.reason_code | Should -Be 'invalid_supervisor_identity'
+        $script:task781OrdinalGenerationChecks | Should -Be 2
+        Should -Invoke New-WinsmuxSubmissionPacket -Times 0 -Exactly
+        Test-Path -LiteralPath (Join-Path $script:task780TempRoot ".winsmux\submissions\$attemptId.json") | Should -BeFalse
     }
 
     It 'ROUND3 P2 converts an atomic packet-create collision to typed duplicate refusal' {
@@ -17363,6 +21599,641 @@ panes:
     }
 }
 
+Describe 'TASK781 managed target mutation guard' {
+    BeforeAll {
+        $script:c08CorePath = Join-Path (Split-Path -Parent $PSScriptRoot) 'scripts\winsmux-core.ps1'
+        $null = . $script:c08CorePath version
+        $script:c08CoreContent = Get-Content -LiteralPath $script:c08CorePath -Raw -Encoding UTF8
+    }
+
+    BeforeEach {
+        $script:c08Root = Join-Path ([IO.Path]::GetTempPath()) ('winsmux-c08-' + [guid]::NewGuid().ToString('N'))
+        $script:c08ManagedA = Join-Path $script:c08Root 'managed-a'
+        $script:c08ManagedB = Join-Path $script:c08Root 'managed-b'
+        $script:c08Unmanaged = Join-Path $script:c08Root 'unmanaged'
+        foreach ($root in @($script:c08ManagedA, $script:c08ManagedB)) {
+            New-Item -ItemType Directory -Path (Join-Path $root '.winsmux') -Force | Out-Null
+            Save-WinsmuxManifest -ProjectDir $root -Manifest ([ordered]@{
+                version = 2
+                session = [ordered]@{ name = 'winsmux-c08'; generation_id = 'generation-c08'; server_session_id = '$80'; session_ready = $true }
+                panes = [ordered]@{
+                    'worker-1' = [ordered]@{ slot_id = 'worker-1'; pane_id = '%2'; worker_backend = 'codex'; role = 'Worker'; title = 'W1'; status = 'ready'; runtime_ready = $true }
+                }
+                tasks = [ordered]@{ queued = @(); in_progress = @(); completed = @() }
+                worktrees = [ordered]@{}
+            })
+            '{}' | Set-Content -LiteralPath (Join-Path $root '.winsmux\runtime-registry.json') -Encoding UTF8
+        }
+        New-Item -ItemType Directory -Path $script:c08Unmanaged -Force | Out-Null
+        New-Item -ItemType Directory -Path (Join-Path $script:c08ManagedA 'nested\work') -Force | Out-Null
+
+        $script:c08PreviousProjectDir = $env:WINSMUX_ORCHESTRA_PROJECT_DIR
+        Remove-Item Env:WINSMUX_ORCHESTRA_PROJECT_DIR -ErrorAction SilentlyContinue
+        $script:c08SessionProjectDir = $script:c08ManagedA
+        $script:c08MissingContext = $false
+        $script:c08SecurityPolicy = $null
+        $script:c08SideEffects = 0
+        $script:c08Trace = [Collections.Generic.List[string]]::new()
+        $script:c08StatusWrites = 0
+        $script:c08ValidationCount = 0
+        $script:Target = '%2'
+        $script:Rest = @('payload')
+
+        Mock Stop-WithError { param([string]$Message) throw $Message }
+        Mock Resolve-Target { '%2' }
+        Mock Confirm-Target { '%2' }
+        Mock Resolve-TerminalBackend { 'tauri' }
+        Mock Get-Labels { @{} }
+        Mock Save-Labels { $script:c08Trace.Add('mutation') | Out-Null; $script:c08SideEffects++ }
+        Mock Clear-ReadMark { }
+        Mock Clear-Watermark { }
+        Mock Assert-ReadMark {
+            $script:c08Trace.Add('mutation') | Out-Null
+            $script:c08SideEffects++
+            throw 'synthetic downstream side effect'
+        }
+        Mock Get-SlotAgentConfig {
+            [pscustomobject]@{ Agent = 'codex'; Model = ''; PromptTransport = 'argv'; CapabilityAdapter = 'codex'; CapabilityCommand = 'codex' }
+        }
+        Mock Get-PaneControlManifestContext {
+            param([string]$ProjectDir, [string]$PaneId)
+            if ($script:c08MissingContext) { throw 'managed pane context missing' }
+            [pscustomobject]@{
+                ManifestPath = Join-Path $ProjectDir '.winsmux\manifest.yaml'
+                ProjectDir = $ProjectDir; SessionName = 'winsmux-c08'; Label = 'worker-1'; PaneId = $PaneId
+                Role = 'Worker'; Status = 'ready'; SecurityPolicy = $script:c08SecurityPolicy
+                LaunchDir = $ProjectDir; GitWorktreeDir = (Join-Path $ProjectDir '.git')
+                Branch = 'codex/task-781'; HeadSha = 'abc781'
+            }
+        }
+        Mock Test-PaneControlRuntimeContext {
+            $script:c08ValidationCount++
+            $script:c08Trace.Add('runtime') | Out-Null
+            New-WinsmuxRuntimeValidationResult -Valid $false -ReasonCode 'invalid_supervisor_identity' -Diagnostic 'synthetic stale managed runtime'
+        }
+        Mock Write-BridgeEventRecord {
+            $script:c08Trace.Add('policy_event') | Out-Null
+            $script:c08SideEffects++
+        }
+        Mock Set-PaneControlManifestPaneProperties { $script:c08StatusWrites++; $script:c08SideEffects++ }
+        Mock Wait-PaneShellReady { }
+        Mock Test-AgentReadyPrompt { $true }
+        Mock Invoke-WinsmuxRaw {
+            param([string[]]$Arguments)
+            switch ([string]$Arguments[0]) {
+                'display-message' {
+                    if ($Arguments[-1] -eq '#{session_name}') { return 'winsmux-c08' }
+                    if ($Arguments[-1] -like '*pane_id*') { return '%1' }
+                    return 'winsmux-c08:0.0'
+                }
+                'show-environment' {
+                    if ([string]::IsNullOrWhiteSpace($script:c08SessionProjectDir)) { return @() }
+                    return "WINSMUX_ORCHESTRA_PROJECT_DIR=$script:c08SessionProjectDir"
+                }
+                'list-panes' { return '%2' }
+                default {
+                    $script:c08Trace.Add('mutation') | Out-Null
+                    $script:c08SideEffects++
+                    return @()
+                }
+            }
+        }
+    }
+
+    AfterEach {
+        if ($null -eq $script:c08PreviousProjectDir) {
+            Remove-Item Env:WINSMUX_ORCHESTRA_PROJECT_DIR -ErrorAction SilentlyContinue
+        } else {
+            $env:WINSMUX_ORCHESTRA_PROJECT_DIR = $script:c08PreviousProjectDir
+        }
+        Remove-Item -LiteralPath $script:c08Root -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    It 'TASK781 C08 blocks stale managed target from <Name> cwd' -ForEach @(
+        @{ Name = 'root'; Kind = 'root' }
+        @{ Name = 'subdirectory'; Kind = 'subdir' }
+        @{ Name = 'unrelated'; Kind = 'unrelated' }
+    ) {
+        $Target = '%2'
+        $Rest = @('payload')
+        $cwd = switch ($Kind) {
+            'root' { $script:c08ManagedA }
+            'subdir' { Join-Path $script:c08ManagedA 'nested\work' }
+            default { $script:c08Unmanaged }
+        }
+        $errorText = ''
+        Push-Location $cwd
+        try { Invoke-Type } catch { $errorText = [string]$_.Exception.Message } finally { Pop-Location }
+
+        $script:c08SideEffects | Should -Be 0
+        $errorText | Should -Match 'invalid_supervisor_identity'
+    }
+
+    It 'TASK781 C08 refuses conflicting managed root candidates' {
+        $Target = '%2'
+        $Rest = @('payload')
+        $env:WINSMUX_ORCHESTRA_PROJECT_DIR = $script:c08ManagedB
+        $errorText = ''
+        Push-Location $script:c08Unmanaged
+        try { Invoke-Type } catch { $errorText = [string]$_.Exception.Message } finally { Pop-Location }
+
+        $script:c08SideEffects | Should -Be 0
+        $errorText | Should -Match 'manifest_regeneration_required'
+    }
+
+    It 'TASK781 C08 refuses a managed session root with missing pane context' {
+        $Target = '%2'
+        $Rest = @('payload')
+        $script:c08MissingContext = $true
+        $errorText = ''
+        Push-Location $script:c08Unmanaged
+        try { Invoke-Type } catch { $errorText = [string]$_.Exception.Message } finally { Pop-Location }
+
+        $script:c08SideEffects | Should -Be 0
+        $errorText | Should -Match 'manifest_regeneration_required'
+    }
+
+    It 'TASK781 C16 refuses managed writes when runtime freshness validators are unavailable' {
+        $script:c16TransportPlans = 0
+        $script:c16ResolvedSends = 0
+        $script:c16TextSends = 0
+        Mock Get-Command { $null } -ParameterFilter {
+            $Name -contains 'Get-PaneControlManifestContext' -or
+            $Name -contains 'Test-PaneControlRuntimeContext'
+        }
+        Mock Resolve-SendTransportPlan { $script:c16TransportPlans++ }
+        Mock Send-ResolvedTransportPlan { $script:c16ResolvedSends++ }
+        Mock Send-TextToPane { $script:c16TextSends++ }
+
+        $errorText = ''
+        Push-Location $script:c08Unmanaged
+        try {
+            try {
+                Assert-WinsmuxTargetRuntimeWriteAllowed -PaneId '%2' -CurrentProjectDir $script:c08Unmanaged -Operation dispatch | Out-Null
+            } catch {
+                $errorText = [string]$_.Exception.Message
+            }
+        } finally {
+            Pop-Location
+        }
+
+        $promptDir = Join-Path (Join-Path $script:c08ManagedA '.winsmux') 'dispatch-prompts'
+        $actual = [ordered]@{
+            error = $errorText
+            mutation_side_effects = $script:c08SideEffects
+            manifest_status_writes = $script:c08StatusWrites
+            validator_calls = $script:c08ValidationCount
+            transport_plans = $script:c16TransportPlans
+            resolved_sends = $script:c16ResolvedSends
+            text_sends = $script:c16TextSends
+            prompt_dir_exists = Test-Path -LiteralPath $promptDir -PathType Container
+        }
+        $expected = [ordered]@{
+            error = 'runtime dispatch refused (manifest_regeneration_required): Runtime identity validation is unavailable; regenerate the orchestra session.'
+            mutation_side_effects = 0
+            manifest_status_writes = 0
+            validator_calls = 0
+            transport_plans = 0
+            resolved_sends = 0
+            text_sends = 0
+            prompt_dir_exists = $false
+        }
+        ($actual | ConvertTo-Json -Compress) | Should -Be ($expected | ConvertTo-Json -Compress)
+    }
+
+    It 'TASK781 C09 preserves plain unmanaged delivery when no managed candidate exists' {
+        $Target = '%2'
+        $Rest = @('payload')
+        $script:c08SessionProjectDir = ''
+        Mock Assert-ReadMark { }
+        Push-Location $script:c08Unmanaged
+        try { Invoke-Type } finally { Pop-Location }
+
+        $script:c08SideEffects | Should -Be 1
+        $script:c08ValidationCount | Should -Be 0
+    }
+
+    It 'TASK781 C19 keeps a captured managed write managed when every current candidate disappears' {
+        $script:c08SessionProjectDir = ''
+
+        $resolution = Resolve-WinsmuxManagedTargetContext -PaneId '%2' `
+            -CurrentProjectDir $script:c08Unmanaged -Operation dispatch `
+            -ExpectedGenerationId 'generation-c08'
+
+        $resolution.Managed | Should -BeTrue
+        $resolution.Validation.valid | Should -BeFalse
+        $resolution.Validation.reason_code | Should -Be 'invalid_supervisor_identity'
+    }
+
+    It 'TASK781 C09 ignores cwd and process managed roots that do not map the target pane' {
+        $Target = '%99'
+        $Rest = @('payload')
+        $script:c08SessionProjectDir = ''
+        $env:WINSMUX_ORCHESTRA_PROJECT_DIR = $script:c08ManagedB
+        Mock Resolve-Target { '%99' }
+        Mock Confirm-Target { '%99' }
+        Mock Assert-ReadMark { }
+
+        Push-Location $script:c08ManagedA
+        try { Invoke-Type } finally { Pop-Location }
+
+        $script:c08SideEffects | Should -Be 1
+        $script:c08ValidationCount | Should -Be 0
+    }
+
+    It 'TASK781 C15 maps failed deferred target auto validation to start_deferred' {
+        $script:c15RuntimeOperation = ''
+        Mock Get-PaneControlManifestContext {
+            param([string]$ProjectDir, [string]$PaneId)
+            [pscustomobject]@{
+                ManifestPath = Join-Path $ProjectDir '.winsmux\manifest.yaml'
+                ProjectDir = $ProjectDir; SessionName = 'winsmux-c08'; Label = 'worker-1'; PaneId = $PaneId
+                Role = 'Worker'; Status = 'deferred_start_failed'; SecurityPolicy = $null
+                LaunchDir = $ProjectDir; GitWorktreeDir = (Join-Path $ProjectDir '.git')
+                Branch = 'codex/task-781'; HeadSha = 'abc781'
+            }
+        }
+        Mock Test-PaneControlRuntimeContext {
+            param([string]$ProjectDir, $ManifestEntry, [string]$Operation)
+            $script:c15RuntimeOperation = $Operation
+            New-WinsmuxRuntimeValidationResult -Valid $true -ReasonCode 'deferred_runtime_verified' -Diagnostic 'synthetic failed deferred runtime verified'
+        }
+
+        $resolution = Assert-WinsmuxTargetRuntimeWriteAllowed -PaneId '%2' `
+            -CurrentProjectDir $script:c08ManagedA -Operation auto
+
+        $script:c15RuntimeOperation | Should -Be 'start_deferred'
+        $resolution.Operation | Should -Be 'start_deferred'
+    }
+
+    It 'TASK781 C10 blocks invalid managed <CommandName> before any side effect' -ForEach @(
+        @{ CommandName = 'send' }
+        @{ CommandName = 'type' }
+        @{ CommandName = 'keys' }
+        @{ CommandName = 'message' }
+        @{ CommandName = 'ime' }
+        @{ CommandName = 'image' }
+        @{ CommandName = 'clipboard' }
+        @{ CommandName = 'vault' }
+    ) {
+        $Target = '%2'
+        $Rest = @('payload')
+        $errorText = ''
+        Push-Location $script:c08ManagedA
+        try {
+            switch ($CommandName) {
+                'send' { Invoke-Send -SendTarget '%2' -SendArguments @('payload') }
+                'type' { Invoke-Type }
+                'keys' { $Rest = @('Enter'); Invoke-Keys }
+                'message' { Invoke-Message }
+                'ime' { Invoke-ImeInput }
+                'image' { Invoke-ImagePaste }
+                'clipboard' { Invoke-ClipboardPaste }
+                'vault' { Invoke-VaultInject }
+            }
+        } catch { $errorText = [string]$_.Exception.Message } finally { Pop-Location }
+
+        $script:c08SideEffects | Should -Be 0
+        $errorText | Should -Match 'invalid_supervisor_identity'
+    }
+
+    It 'TASK781 C28 revalidates <CommandName> after preparation and refuses an expired generation before pane mutation' -ForEach @(
+        @{ CommandName = 'type' }
+        @{ CommandName = 'keys' }
+        @{ CommandName = 'message' }
+    ) {
+        $Target = '%2'
+        if ($CommandName -eq 'keys') {
+            $Rest = @('Enter')
+        } else {
+            $Rest = @('payload')
+        }
+        $script:c28GuardCount = 0
+        $script:c28PaneMutationCount = 0
+        Mock Assert-ReadMark { }
+        Mock Assert-WinsmuxTargetRuntimeWriteAllowed {
+            param($PaneId, $CurrentProjectDir, $Operation, $ExpectedGenerationId)
+            $script:c28GuardCount++
+            if ($script:c28GuardCount -eq 1) {
+                return [PSCustomObject]@{ Managed = $true; Operation = 'dispatch'; GenerationId = 'generation-c08' }
+            }
+            throw 'runtime dispatch refused (invalid_supervisor_identity): generation expired after command preparation'
+        }
+        Mock Invoke-WinsmuxRaw {
+            param([string[]]$Arguments)
+            if ($Arguments[0] -eq 'display-message') {
+                if ($Arguments -contains '#{pane_id}') { return '%1' }
+                return 'winsmux-c08:0.0'
+            }
+            $script:c28PaneMutationCount++
+        }
+
+        $errorText = ''
+        Push-Location $script:c08ManagedA
+        try {
+            switch ($CommandName) {
+                'type' { Invoke-Type }
+                'keys' { Invoke-Keys }
+                'message' { Invoke-Message }
+            }
+        } catch {
+            $errorText = [string]$_.Exception.Message
+        } finally {
+            Pop-Location
+        }
+
+        $errorText | Should -Match 'invalid_supervisor_identity'
+        $script:c28GuardCount | Should -Be 2
+        $script:c28PaneMutationCount | Should -Be 0
+    }
+
+    It 'TASK781 C28 revalidates every interactive pane mutation with the original generation' {
+        foreach ($functionName in @('Invoke-Type', 'Invoke-Keys', 'Invoke-Message', 'Invoke-ImeInput', 'Invoke-ImagePaste', 'Invoke-ClipboardPaste')) {
+            $functionSource = [regex]::Match(
+                $script:c08CoreContent,
+                ('(?s)function {0} \{{.*?(?=\r?\nfunction |\z)' -f [regex]::Escape($functionName))
+            ).Value
+            $functionSource | Should -Not -BeNullOrEmpty
+            ([regex]::Matches($functionSource, 'Assert-WinsmuxTargetRuntimeWriteAllowed')).Count | Should -BeGreaterOrEqual 2
+            $functionSource | Should -Match ([regex]::Escape('-ExpectedGenerationId ([string]$runtimeAccess.GenerationId)'))
+            $sendIndex = $functionSource.LastIndexOf("Invoke-WinsmuxRaw -Arguments @('send-keys'", [System.StringComparison]::Ordinal)
+            $sendIndex | Should -BeGreaterThan 0
+            $sourceBeforeSend = $functionSource.Substring(0, $sendIndex)
+            $sendGuardIndex = $sourceBeforeSend.LastIndexOf('Assert-WinsmuxTargetRuntimeWriteAllowed', [System.StringComparison]::Ordinal)
+            $sendGuardIndex | Should -BeGreaterThan 0
+            $sendGuardIndex | Should -BeLessThan $sendIndex
+        }
+    }
+
+    It 'TASK781 C44 revalidates after pane send and refuses read-mark cleanup on lease expiry' {
+        $Target = '%2'
+        $Rest = @('payload')
+        $script:c44GuardCount = 0
+        $script:c44PaneSends = 0
+        $script:c44ReadClears = 0
+        Mock Assert-ReadMark { }
+        Mock Assert-WinsmuxTargetRuntimeWriteAllowed {
+            $script:c44GuardCount++
+            if ($script:c44GuardCount -eq 1) {
+                return [pscustomobject]@{ Managed = $true; Operation = 'dispatch'; GenerationId = 'generation-c08' }
+            }
+            if ($script:c44GuardCount -eq 3) {
+                throw 'runtime dispatch refused (invalid_supervisor_identity): generation expired before read-mark cleanup'
+            }
+            return [pscustomobject]@{ Managed = $true; Operation = 'dispatch'; GenerationId = 'generation-c08' }
+        }
+        Mock Invoke-WinsmuxRaw { $script:c44PaneSends++ }
+        Mock Clear-ReadMark { $script:c44ReadClears++ }
+
+        $errorText = ''
+        Push-Location $script:c08ManagedA
+        try { Invoke-Type } catch { $errorText = [string]$_.Exception.Message } finally { Pop-Location }
+
+        $script:c44GuardCount | Should -Be 3
+        $script:c44PaneSends | Should -Be 1
+        $script:c44ReadClears | Should -Be 0
+        $errorText | Should -Match 'invalid_supervisor_identity'
+    }
+
+    It 'TASK781 C44 places the captured-generation guard immediately before every interactive read-mark cleanup' {
+        foreach ($functionName in @('Invoke-Type', 'Invoke-Keys', 'Invoke-Message', 'Invoke-ImeInput', 'Invoke-ImagePaste', 'Invoke-ClipboardPaste', 'Invoke-VaultInject')) {
+            $functionSource = [regex]::Match(
+                $script:c08CoreContent,
+                ('(?s)function {0} \{{.*?(?=\r?\nfunction |\z)' -f [regex]::Escape($functionName))
+            ).Value
+            $functionSource | Should -Not -BeNullOrEmpty
+            $functionSource | Should -Match '(?s)Assert-WinsmuxTargetRuntimeWriteAllowed.*?-ExpectedGenerationId.*?\| Out-Null\s*Clear-ReadMark'
+        }
+    }
+
+    It 'TASK781 C11 validates then blocks managed <CommandName> without identity mutation' -ForEach @(
+        @{ CommandName = 'role' }
+        @{ CommandName = 'restart' }
+        @{ CommandName = 'name' }
+        @{ CommandName = 'kill' }
+    ) {
+        $Target = '%2'
+        $Rest = @('payload')
+        Mock Test-PaneControlRuntimeContext {
+            $script:c08Trace.Add('runtime') | Out-Null
+            New-WinsmuxRuntimeValidationResult -Valid $true -ReasonCode 'valid' -Diagnostic 'runtime valid'
+        }
+        $errorText = ''
+        Push-Location $script:c08ManagedA
+        try {
+            switch ($CommandName) {
+                'role' { $Rest = @('worker'); Invoke-Role }
+                'restart' { $Rest = @(); Invoke-Restart }
+                'name' { $Rest = @('renamed'); Invoke-Name }
+                'kill' { $Rest = @(); Invoke-Kill }
+            }
+        } catch { $errorText = [string]$_.Exception.Message } finally { Pop-Location }
+
+        @($script:c08Trace) | Should -Be @('runtime')
+        $script:c08SideEffects | Should -Be 0
+        $errorText | Should -Match 'manifest_regeneration_required'
+    }
+
+    It 'TASK781 C19 validates runtime before emitting a security BLOCK event' {
+        $script:c08SecurityPolicy = [ordered]@{ mode = 'enforce' }
+        Mock Find-SendSecurityPolicyViolation {
+            [ordered]@{ verdict = 'BLOCK'; reason = 'synthetic policy block'; pattern = 'payload'; mode = 'enforce'; allow = @(); block = @('payload'); next_action = 'stop' }
+        }
+        $errorText = ''
+        Push-Location $script:c08ManagedA
+        try { Invoke-Send -SendTarget '%2' -SendArguments @('payload') } catch { $errorText = [string]$_.Exception.Message } finally { Pop-Location }
+
+        $script:c08SideEffects | Should -Be 0
+        @($script:c08Trace) | Should -Be @('runtime')
+        $errorText | Should -Match 'invalid_supervisor_identity'
+    }
+
+    It 'TASK781 C33 revalidates the captured generation immediately before persisting a security BLOCK event' {
+        $script:c08SecurityPolicy = [ordered]@{ mode = 'enforce' }
+        Mock Find-SendSecurityPolicyViolation {
+            [ordered]@{ verdict = 'BLOCK'; reason = 'synthetic policy block'; pattern = 'payload'; mode = 'enforce'; allow = @(); block = @('payload'); next_action = 'stop' }
+        }
+        Mock Test-PaneControlRuntimeContext {
+            $script:c08ValidationCount++
+            $script:c08Trace.Add('runtime') | Out-Null
+            if ($script:c08ValidationCount -eq 1) {
+                return New-WinsmuxRuntimeValidationResult -Valid $true -ReasonCode 'live_runtime_verified' `
+                    -Diagnostic 'synthetic initial runtime' -Context ([ordered]@{ generation_id = 'generation-c08' })
+            }
+            return New-WinsmuxRuntimeValidationResult -Valid $false -ReasonCode 'invalid_supervisor_identity' `
+                -Diagnostic 'generation changed before security event persistence'
+        }
+        $errorText = ''
+        Push-Location $script:c08ManagedA
+        try { Invoke-Send -SendTarget '%2' -SendArguments @('payload') } catch { $errorText = [string]$_.Exception.Message } finally { Pop-Location }
+
+        @($script:c08Trace) | Should -Be @('runtime', 'runtime')
+        $script:c08SideEffects | Should -Be 0
+        Should -Invoke Write-BridgeEventRecord -Times 0 -Exactly
+        $errorText | Should -Match 'invalid_supervisor_identity'
+    }
+
+    It 'TASK781 C33 persists exactly one security BLOCK event when both runtime validations remain current' {
+        $script:c08SecurityPolicy = [ordered]@{ mode = 'enforce' }
+        Mock Find-SendSecurityPolicyViolation {
+            [ordered]@{ verdict = 'BLOCK'; reason = 'synthetic policy block'; pattern = 'payload'; mode = 'enforce'; allow = @(); block = @('payload'); next_action = 'stop' }
+        }
+        Mock Test-PaneControlRuntimeContext {
+            $script:c08ValidationCount++
+            $script:c08Trace.Add('runtime') | Out-Null
+            New-WinsmuxRuntimeValidationResult -Valid $true -ReasonCode 'live_runtime_verified' `
+                -Diagnostic 'synthetic current runtime' -Context ([ordered]@{ generation_id = 'generation-c08' })
+        }
+        $errorText = ''
+        Push-Location $script:c08ManagedA
+        try { Invoke-Send -SendTarget '%2' -SendArguments @('payload') } catch { $errorText = [string]$_.Exception.Message } finally { Pop-Location }
+
+        @($script:c08Trace) | Should -Be @('runtime', 'runtime', 'policy_event')
+        $script:c08SideEffects | Should -Be 1
+        Should -Invoke Write-BridgeEventRecord -Times 1 -Exactly
+        $errorText | Should -Match 'synthetic policy block'
+    }
+
+    It 'TASK781 C19 revalidates deferred start immediately before its first persistent mutation' {
+        $planPath = Join-Path $script:c08ManagedA 'worker-1.json'
+        ([ordered]@{ agent = 'codex'; ready_marker_path = (Join-Path $script:c08ManagedA 'worker-1.ready.json') } | ConvertTo-Json) |
+            Set-Content -LiteralPath $planPath -Encoding UTF8
+        $entry = [pscustomobject]@{
+            Label = 'worker-1'; PaneId = '%2'; Status = 'deferred_start'; BootstrapPlanPath = $planPath
+            CapabilityAdapter = 'codex'; ProviderTarget = ''; ApprovedLaunch = $null
+        }
+        Mock Test-PaneControlRuntimeContext {
+            $script:c08ValidationCount++
+            if ($script:c08ValidationCount -eq 1) { return New-WinsmuxRuntimeValidationResult -Valid $true -ReasonCode 'valid' -Diagnostic 'runtime valid' }
+            return New-WinsmuxRuntimeValidationResult -Valid $false -ReasonCode 'invalid_supervisor_identity' -Diagnostic 'generation changed before deferred mutation'
+        }
+        $initial = Test-PaneControlRuntimeContext -ProjectDir $script:c08ManagedA -ManifestEntry $entry -Operation start_deferred
+        $initial.valid | Should -BeTrue
+        $errorText = ''
+        Push-Location $script:c08ManagedA
+        try { Start-DeferredPaneFromManifestEntry -ProjectDir $script:c08ManagedA -ManifestEntry $entry } catch { $errorText = [string]$_.Exception.Message } finally { Pop-Location }
+
+        $script:c08StatusWrites | Should -Be 0
+        $script:c08SideEffects | Should -Be 0
+        $errorText | Should -Match 'invalid_supervisor_identity'
+    }
+
+    It 'TASK781 C19 does not enumerate vault credential names or values when initial runtime validation fails' {
+        $Target = '%2'
+        Mock Get-WinsmuxVaultCredentialNamesInternal { throw 'credential name enumeration must not run' }
+        Mock Get-WinsmuxVaultCredentialValueInternal { throw 'credential value read must not run' }
+        $errorText = ''
+
+        Push-Location $script:c08ManagedA
+        try { Invoke-VaultInject } catch { $errorText = [string]$_.Exception.Message } finally { Pop-Location }
+
+        Should -Invoke Get-WinsmuxVaultCredentialNamesInternal -Times 0 -Exactly
+        Should -Invoke Get-WinsmuxVaultCredentialValueInternal -Times 0 -Exactly
+        $script:c08SideEffects | Should -Be 0
+        $errorText | Should -Match 'invalid_supervisor_identity'
+    }
+
+    It 'TASK781 C40 stops vault injection before reading a second secret when the generation changes' {
+        $Target = '%2'
+        $script:c19GuardCalls = 0
+        $script:c19VaultSends = [Collections.Generic.List[string]]::new()
+        $script:c19SecretReads = [Collections.Generic.List[string]]::new()
+        Mock Assert-ReadMark { }
+        Mock Start-Sleep { }
+        Mock Get-WinsmuxVaultCredentialNamesInternal { @('SYNTH_ONE', 'SYNTH_TWO') }
+        Mock Get-WinsmuxVaultCredentialValueInternal {
+            param([string]$Name)
+            $script:c19SecretReads.Add($Name) | Out-Null
+            if ($Name -eq 'SYNTH_ONE') { return 'synthetic-value-one' }
+            return 'synthetic-value-two'
+        }
+        Mock Assert-WinsmuxTargetRuntimeWriteAllowed {
+            param([string]$PaneId, [string]$CurrentProjectDir, [string]$Operation, [string]$ExpectedGenerationId)
+            $script:c19GuardCalls++
+            if ($script:c19GuardCalls -eq 5) {
+                throw 'runtime dispatch refused (invalid_supervisor_identity): generation changed before second secret read'
+            }
+            [pscustomobject]@{ Managed = $true; ProjectDir = $CurrentProjectDir; GenerationId = 'generation-G1' }
+        }
+        Mock Invoke-WinsmuxRaw {
+            param([string[]]$Arguments)
+            if ($Arguments[0] -ne 'send-keys') { throw "unexpected vault command: $($Arguments -join ' ')" }
+            $script:c19VaultSends.Add(($Arguments -join '|')) | Out-Null
+        }
+        $errorText = ''
+
+        Push-Location $script:c08ManagedA
+        try { Invoke-VaultInject } catch { $errorText = [string]$_.Exception.Message } finally { Pop-Location }
+
+        $script:c19GuardCalls | Should -Be 5
+        @($script:c19SecretReads) | Should -Be @('SYNTH_ONE')
+        $script:c19VaultSends.Count | Should -Be 2
+        $script:c19VaultSends[0] | Should -Match 'SYNTH_ONE'
+        $script:c19VaultSends[0] | Should -Not -Match 'SYNTH_TWO'
+        $script:c19VaultSends[1] | Should -Match 'Enter$'
+        $errorText | Should -Match 'invalid_supervisor_identity'
+    }
+
+    It 'TASK781 C35 revalidates the captured generation immediately before Vault Enter' {
+        $Target = '%2'
+        $script:c35GuardCalls = 0
+        $script:c35VaultSends = [Collections.Generic.List[string]]::new()
+        Mock Assert-ReadMark { }
+        Mock Start-Sleep { }
+        Mock Get-WinsmuxVaultCredentialNamesInternal { @('SYNTH_ONE') }
+        Mock Get-WinsmuxVaultCredentialValueInternal { 'synthetic-value-one' }
+        Mock Assert-WinsmuxTargetRuntimeWriteAllowed {
+            param([string]$PaneId, [string]$CurrentProjectDir, [string]$Operation, [string]$ExpectedGenerationId)
+            $script:c35GuardCalls++
+            if ($script:c35GuardCalls -eq 4) {
+                throw 'runtime dispatch refused (invalid_supervisor_identity): generation changed before Vault Enter'
+            }
+            [pscustomobject]@{ Managed = $true; ProjectDir = $CurrentProjectDir; GenerationId = 'generation-G1' }
+        }
+        Mock Invoke-WinsmuxRaw {
+            param([string[]]$Arguments)
+            if ($Arguments[0] -ne 'send-keys') { throw "unexpected vault command: $($Arguments -join ' ')" }
+            $script:c35VaultSends.Add(($Arguments -join '|')) | Out-Null
+        }
+        $errorText = ''
+
+        Push-Location $script:c08ManagedA
+        try { Invoke-VaultInject } catch { $errorText = [string]$_.Exception.Message } finally { Pop-Location }
+
+        $script:c35GuardCalls | Should -Be 4
+        $script:c35VaultSends.Count | Should -Be 1
+        $script:c35VaultSends[0] | Should -Match 'SYNTH_ONE'
+        $script:c35VaultSends | Should -Not -Match 'Enter'
+        $errorText | Should -Match 'invalid_supervisor_identity'
+    }
+
+    It 'TASK781 C37 creates collision-proof owned image artifacts without overwriting a sibling' {
+        $imageDir = Join-Path ([System.IO.Path]::GetTempPath()) ('winsmux-c37-images-' + [guid]::NewGuid().ToString('N'))
+        Add-Type -AssemblyName System.Drawing
+        $imageA = [System.Drawing.Bitmap]::new(1, 1)
+        $imageB = [System.Drawing.Bitmap]::new(1, 1)
+        try {
+            $artifactA = Write-WinsmuxClipboardImageArtifact -Image $imageA -DirectoryPath $imageDir
+            $artifactB = Write-WinsmuxClipboardImageArtifact -Image $imageB -DirectoryPath $imageDir
+
+            $artifactA.Path | Should -Not -BeExactly $artifactB.Path
+            Test-Path -LiteralPath $artifactA.Path -PathType Leaf | Should -BeTrue
+            Test-Path -LiteralPath $artifactB.Path -PathType Leaf | Should -BeTrue
+            $artifactA.Owned | Should -BeTrue
+            $artifactB.Owned | Should -BeTrue
+            $writerSource = [regex]::Match(
+                $script:c08CoreContent,
+                '(?s)function Write-WinsmuxClipboardImageArtifact \{.*?(?=\r?\nfunction |\z)'
+            ).Value
+            $writerSource | Should -Match '\[System\.IO\.FileMode\]::CreateNew'
+        } finally {
+            $imageA.Dispose()
+            $imageB.Dispose()
+            Remove-Item -LiteralPath $imageDir -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
 Describe 'winsmux send dispatch payload' {
     BeforeAll {
         $script:winsmuxCorePath = Join-Path (Split-Path -Parent $PSScriptRoot) 'scripts\winsmux-core.ps1'
@@ -17373,9 +22244,33 @@ Describe 'winsmux send dispatch payload' {
     BeforeEach {
         $script:sendTempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('winsmux-send-tests-' + [guid]::NewGuid().ToString('N'))
         New-Item -ItemType Directory -Path $script:sendTempRoot -Force | Out-Null
+        $script:sendHadPreviousProjectDir = Test-Path Env:WINSMUX_ORCHESTRA_PROJECT_DIR
+        $script:sendPreviousProjectDir = [string]$env:WINSMUX_ORCHESTRA_PROJECT_DIR
+        Remove-Item Env:WINSMUX_ORCHESTRA_PROJECT_DIR -ErrorAction SilentlyContinue
+        $script:sendSessionProjectDir = ''
+        Mock Invoke-WinsmuxRaw {
+            param([string[]]$Arguments)
+
+            if ($Arguments[0] -eq 'display-message' -and $Arguments[-1] -eq '#{session_name}') {
+                return 'winsmux-send-tests'
+            }
+            if ($Arguments[0] -eq 'show-environment') {
+                if (-not [string]::IsNullOrWhiteSpace($script:sendSessionProjectDir)) {
+                    return "WINSMUX_ORCHESTRA_PROJECT_DIR=$($script:sendSessionProjectDir)"
+                }
+                return @()
+            }
+
+            throw "unexpected Invoke-WinsmuxRaw arguments: $($Arguments -join ' ')"
+        }
     }
 
     AfterEach {
+        if ($script:sendHadPreviousProjectDir) {
+            $env:WINSMUX_ORCHESTRA_PROJECT_DIR = $script:sendPreviousProjectDir
+        } else {
+            Remove-Item Env:WINSMUX_ORCHESTRA_PROJECT_DIR -ErrorAction SilentlyContinue
+        }
         if ($script:sendTempRoot -and (Test-Path $script:sendTempRoot)) {
             Remove-Item -Path $script:sendTempRoot -Recurse -Force
         }
@@ -17395,6 +22290,477 @@ Describe 'winsmux send dispatch payload' {
         $script:winsmuxCoreSendRawContent | Should -Match 'Provider capability'
         $script:winsmuxCoreSendRawContent | Should -Match 'CapabilityAdapter'
         $script:winsmuxCoreSendRawContent | Should -Match 'CapabilityCommand'
+    }
+
+    It 'TASK781 resolves a managed slot target from the nearest ancestor manifest for <Name>' -ForEach @(
+        @{ Name = 'project root'; RelativeCwd = '.' }
+        @{ Name = 'project subdirectory'; RelativeCwd = 'nested\work' }
+    ) {
+        New-Item -ItemType Directory -Path (Join-Path $script:sendTempRoot '.winsmux') -Force | Out-Null
+        New-Item -ItemType Directory -Path (Join-Path $script:sendTempRoot 'nested\work') -Force | Out-Null
+        Save-WinsmuxManifest -ProjectDir $script:sendTempRoot -Manifest ([ordered]@{
+            version = 2
+            session = [ordered]@{ name = 'winsmux-orchestra'; generation_id = 'generation-send'; server_session_id = '$41'; session_ready = $true }
+            panes = [ordered]@{
+                'worker-1' = [ordered]@{ slot_id = 'worker-1'; pane_id = '%2'; worker_backend = 'codex'; worker_role = 'reviewer'; role = 'Worker'; title = 'W1 Codex Reviewer'; status = 'ready'; runtime_ready = $true }
+            }
+            tasks = [ordered]@{ queued = @(); in_progress = @(); completed = @() }
+            worktrees = [ordered]@{}
+        })
+        Mock Get-Labels { @{} }
+
+        Push-Location (Join-Path $script:sendTempRoot $RelativeCwd)
+        try {
+            Resolve-Target 'worker-1' | Should -BeExactly '%2'
+        } finally {
+            Pop-Location
+        }
+    }
+
+    It 'TASK781 C27 prefers the nearest managed manifest over a stale global label mapping' {
+        New-Item -ItemType Directory -Path (Join-Path $script:sendTempRoot '.winsmux') -Force | Out-Null
+        Save-WinsmuxManifest -ProjectDir $script:sendTempRoot -Manifest ([ordered]@{
+            version = 2
+            session = [ordered]@{ name = 'winsmux-orchestra'; generation_id = 'generation-send'; server_session_id = '$41'; session_ready = $true }
+            panes = [ordered]@{
+                'worker-1' = [ordered]@{ slot_id = 'worker-1'; pane_id = '%2'; worker_backend = 'codex'; worker_role = 'reviewer'; role = 'Worker'; title = 'W1 Codex Reviewer'; status = 'ready'; runtime_ready = $true }
+            }
+            tasks = [ordered]@{ queued = @(); in_progress = @(); completed = @() }
+            worktrees = [ordered]@{}
+        })
+        Mock Get-Labels { @{ 'worker-1' = '%99' } }
+
+        Push-Location $script:sendTempRoot
+        try {
+            Resolve-Target 'worker-1' | Should -BeExactly '%2'
+        } finally {
+            Pop-Location
+        }
+    }
+
+    It 'TASK781 C27 refuses a label omitted by the nearest managed manifest instead of returning the raw target' {
+        New-Item -ItemType Directory -Path (Join-Path $script:sendTempRoot '.winsmux') -Force | Out-Null
+        Save-WinsmuxManifest -ProjectDir $script:sendTempRoot -Manifest ([ordered]@{
+            version = 2
+            session = [ordered]@{ name = 'winsmux-orchestra'; generation_id = 'generation-send'; server_session_id = '$41'; session_ready = $true }
+            panes = [ordered]@{
+                'worker-2' = [ordered]@{ slot_id = 'worker-2'; pane_id = '%3'; worker_backend = 'codex'; role = 'Worker'; title = 'W2'; status = 'ready'; runtime_ready = $true }
+            }
+            tasks = [ordered]@{ queued = @(); in_progress = @(); completed = @() }
+            worktrees = [ordered]@{}
+        })
+        Mock Get-Labels { @{ 'worker-1' = '%99' } }
+
+        Push-Location $script:sendTempRoot
+        try {
+            { Resolve-Target 'worker-1' } | Should -Throw '*managed manifest does not contain target*'
+        } finally {
+            Pop-Location
+        }
+    }
+
+    It 'TASK781 C38 refuses an omitted managed label before creating an artifact or sending' {
+        New-Item -ItemType Directory -Path (Join-Path $script:sendTempRoot '.winsmux') -Force | Out-Null
+        Save-WinsmuxManifest -ProjectDir $script:sendTempRoot -Manifest ([ordered]@{
+            version = 2
+            session = [ordered]@{ name = 'winsmux-orchestra'; generation_id = 'generation-send'; server_session_id = '$41'; session_ready = $true }
+            panes = [ordered]@{
+                'worker-2' = [ordered]@{ slot_id = 'worker-2'; pane_id = '%3'; worker_backend = 'codex'; role = 'Worker'; title = 'W2'; status = 'ready'; runtime_ready = $true }
+            }
+            tasks = [ordered]@{ queued = @(); in_progress = @(); completed = @() }
+            worktrees = [ordered]@{}
+        })
+        Mock Get-Labels { @{ 'worker-1' = '%99' } }
+        Mock Resolve-TerminalBackend { 'tauri' }
+        Mock Stop-WithError { param([string]$Message) throw $Message }
+        Mock Send-ResolvedTransportPlan { throw 'send must not occur' }
+
+        Push-Location $script:sendTempRoot
+        try {
+            { Invoke-Send -SendTarget 'worker-1' -SendArguments @(('x' * 5000)) } |
+                Should -Throw '*managed manifest does not contain target*'
+        } finally {
+            Pop-Location
+        }
+
+        Test-Path -LiteralPath (Join-Path $script:sendTempRoot '.winsmux\dispatch-prompts') | Should -BeFalse
+        Assert-MockCalled Send-ResolvedTransportPlan -Times 0 -Exactly
+    }
+
+    It 'TASK781 C39 refuses a stale role label before pane or persistent-state mutation' {
+        New-Item -ItemType Directory -Path (Join-Path $script:sendTempRoot '.winsmux') -Force | Out-Null
+        Save-WinsmuxManifest -ProjectDir $script:sendTempRoot -Manifest ([ordered]@{
+            version = 2
+            session = [ordered]@{ name = 'winsmux-orchestra'; generation_id = 'generation-role'; server_session_id = '$41'; session_ready = $true }
+            panes = [ordered]@{
+                'worker-2' = [ordered]@{ slot_id = 'worker-2'; pane_id = '%3'; worker_backend = 'codex'; role = 'Worker'; title = 'W2'; status = 'ready'; runtime_ready = $true }
+            }
+            tasks = [ordered]@{ queued = @(); in_progress = @(); completed = @() }
+            worktrees = [ordered]@{}
+        })
+        $script:c39MutationAttempts = 0
+        Mock Get-Labels { @{ 'worker-1' = '%99' } }
+        Mock Stop-WithError { param([string]$Message) throw $Message }
+        Mock Get-ManagedPaneLifecycleMutationRefusal { $null }
+        Mock Get-BridgeSettings { [ordered]@{} }
+        Mock Get-SlotAgentConfig {
+            [pscustomobject]@{
+                Agent = 'codex'; Model = ''; ModelSource = 'provider-default'; ReasoningEffort = '';
+                McpMode = ''; CapabilityAdapter = 'codex'; CapabilityCommand = 'codex';
+                HarnessAvailability = ''; CredentialRequirements = ''; ExecutionBackend = '';
+                RuntimeRequirements = ''; AnalysisPosture = ''; SupportsParallelRuns = $false;
+                SupportsInterrupt = $false; SupportsStructuredResult = $false; SupportsFileEdit = $true;
+                SupportsSubagents = $false; SupportsVerification = $true; SupportsConsultation = $false;
+                SupportsContextReset = $false
+            }
+        }
+        Mock Get-BridgeProviderLaunchCommand { 'codex' }
+        Mock Invoke-WinsmuxRaw {
+            $script:c39MutationAttempts++
+            throw 'pane mutation must not occur'
+        }
+        Mock Save-Labels {
+            $script:c39MutationAttempts++
+            throw 'label mutation must not occur'
+        }
+        Mock Set-PaneControlManifestPaneProperties {
+            $script:c39MutationAttempts++
+            throw 'manifest mutation must not occur'
+        }
+
+        $Target = 'worker-1'
+        $Rest = @('reviewer')
+        Push-Location $script:sendTempRoot
+        try {
+            { Invoke-Role } | Should -Throw '*managed manifest does not contain target*'
+        } finally {
+            Pop-Location
+        }
+
+        $script:c39MutationAttempts | Should -Be 0
+        Assert-MockCalled Save-Labels -Times 0 -Exactly
+        Assert-MockCalled Set-PaneControlManifestPaneProperties -Times 0 -Exactly
+    }
+
+    It 'TASK781 refuses a managed direct pane send when manifest context does not resolve' {
+        $script:sendSessionProjectDir = $script:sendTempRoot
+        New-Item -ItemType Directory -Path (Join-Path $script:sendTempRoot '.winsmux') -Force | Out-Null
+        Save-WinsmuxManifest -ProjectDir $script:sendTempRoot -Manifest ([ordered]@{
+            version = 2
+            session = [ordered]@{ name = 'winsmux-orchestra'; generation_id = 'generation-send'; server_session_id = '$41'; session_ready = $true }
+            panes = [ordered]@{
+                'worker-1' = [ordered]@{ slot_id = 'worker-1'; pane_id = '%2'; worker_backend = 'codex'; role = 'Worker'; title = 'W1'; status = 'ready'; runtime_ready = $true }
+            }
+            tasks = [ordered]@{ queued = @(); in_progress = @(); completed = @() }
+            worktrees = [ordered]@{}
+        })
+        Mock Resolve-Target { '%99' }
+        Mock Resolve-TerminalBackend { 'tauri' }
+        Mock Stop-WithError { param([string]$Message) throw $Message }
+        Mock Send-ResolvedTransportPlan { throw 'send must not occur' }
+
+        Push-Location $script:sendTempRoot
+        try {
+            { Invoke-Send -SendTarget '%99' -SendArguments @('typed payload') } | Should -Throw '*manifest_regeneration_required*'
+        } finally {
+            Pop-Location
+        }
+        Assert-MockCalled Send-ResolvedTransportPlan -Times 0 -Exactly
+    }
+
+    It 'TASK781 revalidates deferred bootstrap delivery even when recursive start is skipped' {
+        $script:sendSessionProjectDir = $script:sendTempRoot
+        New-Item -ItemType Directory -Path (Join-Path $script:sendTempRoot '.winsmux') -Force | Out-Null
+        Save-WinsmuxManifest -ProjectDir $script:sendTempRoot -Manifest ([ordered]@{
+            version = 2
+            session = [ordered]@{ name = 'winsmux-orchestra'; generation_id = 'generation-send'; server_session_id = '$41'; session_ready = $true }
+            panes = [ordered]@{
+                'worker-1' = [ordered]@{ slot_id = 'worker-1'; pane_id = '%2'; worker_backend = 'codex'; role = 'Worker'; title = 'W1'; status = 'deferred_starting'; runtime_ready = $false }
+            }
+            tasks = [ordered]@{ queued = @(); in_progress = @(); completed = @() }
+            worktrees = [ordered]@{}
+        })
+        Mock Resolve-Target { '%2' }
+        Mock Resolve-TerminalBackend { 'tauri' }
+        Mock Get-SlotAgentConfig { [PSCustomObject]@{ Agent = 'codex'; Model = 'gpt-5.5'; PromptTransport = 'argv'; CapabilityAdapter = 'codex'; CapabilityCommand = 'codex' } }
+        Mock Test-PaneControlRuntimeContext { New-WinsmuxRuntimeValidationResult -Valid $false -ReasonCode 'invalid_supervisor_identity' -Diagnostic 'lease expired before bootstrap delivery' }
+        Mock Stop-WithError { param([string]$Message) throw $Message }
+        Mock Send-ResolvedTransportPlan { throw 'send must not occur' }
+
+        Push-Location $script:sendTempRoot
+        try {
+            { Invoke-Send -SendTarget '%2' -SendArguments @('bootstrap') -DeliveryClass launch -SkipDeferredPaneStart } | Should -Throw '*invalid_supervisor_identity*'
+        } finally {
+            Pop-Location
+        }
+        Assert-MockCalled Send-ResolvedTransportPlan -Times 0 -Exactly
+    }
+
+    It 'TASK781 C14 validates final runtime before creating a long prompt artifact' {
+        $script:sendSessionProjectDir = $script:sendTempRoot
+        New-Item -ItemType Directory -Path (Join-Path $script:sendTempRoot '.winsmux') -Force | Out-Null
+        Save-WinsmuxManifest -ProjectDir $script:sendTempRoot -Manifest ([ordered]@{
+            version = 2
+            session = [ordered]@{ name = 'winsmux-orchestra'; generation_id = 'G1'; server_session_id = '$41'; session_ready = $true }
+            panes = [ordered]@{
+                'worker-1' = [ordered]@{
+                    slot_id = 'worker-1'; pane_id = '%2'; worker_backend = 'codex'; role = 'Worker'; title = 'W1'
+                    status = 'ready'; runtime_ready = $true; exec_mode = $false
+                }
+            }
+            tasks = [ordered]@{ queued = @(); in_progress = @(); completed = @() }
+            worktrees = [ordered]@{}
+        })
+        $manifestPath = Join-Path (Join-Path $script:sendTempRoot '.winsmux') 'manifest.yaml'
+        $script:c14Context = [PSCustomObject]@{
+            ManifestPath = $manifestPath; ProjectDir = $script:sendTempRoot; SessionName = 'winsmux-orchestra'
+            Label = 'worker-1'; PaneId = '%2'; Role = 'Worker'; Status = 'ready'; SecurityPolicy = $null
+            LaunchDir = $script:sendTempRoot; GitWorktreeDir = (Join-Path $script:sendTempRoot '.git')
+            Branch = 'codex/task-781'; HeadSha = 'abc781'
+        }
+        $script:c14GuardCalls = [System.Collections.Generic.List[object]]::new()
+        $script:c14DeferredStartCalls = 0
+        $script:c14ResolvedSendCount = 0
+        $script:c14TextSendCount = 0
+        $script:c14RestoreCalls = 0
+        $taskPromptPath = Get-TaskPromptPath -TaskSlug 'lease-before-materialization' -ProjectDir $script:sendTempRoot
+        Write-ClmSafeTextFile -Path $taskPromptPath -Content 'existing prompt evidence'
+        $taskPromptHashBefore = (Get-FileHash -LiteralPath $taskPromptPath -Algorithm SHA256).Hash
+        $taskPromptMtimeBefore = (Get-Item -LiteralPath $taskPromptPath).LastWriteTimeUtc
+
+        Mock Resolve-Target { '%2' }
+        Mock Resolve-TerminalBackend { 'tauri' }
+        Mock Get-SlotAgentConfig {
+            [PSCustomObject]@{
+                Agent = 'codex'; Model = 'gpt-5.5'; PromptTransport = 'argv'
+                CapabilityAdapter = 'codex'; CapabilityCommand = 'codex'
+            }
+        }
+        Mock Get-RoleAgentConfig {
+            [PSCustomObject]@{
+                Agent = 'codex'; Model = 'gpt-5.5'; PromptTransport = 'argv'
+                CapabilityAdapter = 'codex'; CapabilityCommand = 'codex'
+            }
+        }
+        Mock Assert-WinsmuxTargetRuntimeWriteAllowed {
+            param($PaneId, $CurrentProjectDir, $Operation, $ExpectedGenerationId)
+            $script:c14GuardCalls.Add([PSCustomObject][ordered]@{
+                operation = [string]$Operation
+                expected_generation_id = [string]$ExpectedGenerationId
+            }) | Out-Null
+            if ($script:c14GuardCalls.Count -le 2) {
+                return [PSCustomObject]@{
+                    Managed = $true; ProjectDir = $script:sendTempRoot; Context = $script:c14Context
+                    Operation = 'dispatch'; GenerationId = 'G1'
+                    Validation = (New-WinsmuxRuntimeValidationResult -Valid $true -ReasonCode 'dispatch_verified' -Diagnostic 'synthetic runtime verified')
+                }
+            }
+            throw 'runtime dispatch refused (invalid_supervisor_identity): lease expired before final send validation'
+        }
+        Mock Start-DeferredPaneFromManifestEntry {
+            $script:c14DeferredStartCalls++
+            return $false
+        }
+        Mock Send-ResolvedTransportPlan { $script:c14ResolvedSendCount++ }
+        Mock Send-TextToPane { $script:c14TextSendCount++ }
+        Mock Restore-SendPromptArtifactCheckpoint { $script:c14RestoreCalls++ }
+
+        $errorText = ''
+        Push-Location $script:sendTempRoot
+        try {
+            try {
+                Invoke-Send -SendTarget '%2' -SendArguments @('--task-slug', 'lease-before-materialization', ('x' * 5000))
+            } catch {
+                $errorText = [string]$_.Exception.Message
+            }
+        } finally {
+            Pop-Location
+        }
+
+        $invokeSendSource = [regex]::Match(
+            $script:winsmuxCoreSendRawContent,
+            '(?s)function Invoke-Send \{.*?\r?\n\}\r?\n\r?\nfunction Invoke-Name'
+        ).Value
+        $transportIntentIndex = $invokeSendSource.IndexOf('Resolve-SendTransportIntent', [System.StringComparison]::Ordinal)
+        $transportMaterializationIndex = $invokeSendSource.IndexOf('New-SendTransportPlan', [System.StringComparison]::Ordinal)
+        $checkpointIndex = $invokeSendSource.IndexOf('New-SendPromptArtifactCheckpoint', [System.StringComparison]::Ordinal)
+        $postCheckpointGuardIndex = $invokeSendSource.IndexOf('Assert-SendPaneRuntimeLease', $checkpointIndex, [System.StringComparison]::Ordinal)
+        $promptDir = Join-Path (Join-Path $script:sendTempRoot '.winsmux') 'dispatch-prompts'
+        $actual = [ordered]@{
+            error = $errorText
+            prompt_dir_exists = Test-Path -LiteralPath $promptDir -PathType Container
+            resolved_send_count = $script:c14ResolvedSendCount
+            text_send_count = $script:c14TextSendCount
+            guard_calls = $script:c14GuardCalls.Count
+            guard_sequence = @($script:c14GuardCalls)
+            deferred_start_calls = $script:c14DeferredStartCalls
+            restore_calls = $script:c14RestoreCalls
+            prompt_hash_unchanged = ((Get-FileHash -LiteralPath $taskPromptPath -Algorithm SHA256).Hash -ceq $taskPromptHashBefore)
+            prompt_mtime_unchanged = ((Get-Item -LiteralPath $taskPromptPath).LastWriteTimeUtc -eq $taskPromptMtimeBefore)
+            pure_intent_precedes_checkpoint = (
+                $transportIntentIndex -ge 0 -and $checkpointIndex -ge 0 -and $transportIntentIndex -lt $checkpointIndex
+            )
+            checkpoint_guard_precedes_materialization = (
+                $checkpointIndex -ge 0 -and $postCheckpointGuardIndex -gt $checkpointIndex -and
+                $transportMaterializationIndex -gt $postCheckpointGuardIndex
+            )
+        }
+        $expected = [ordered]@{
+            error = 'runtime dispatch refused (invalid_supervisor_identity): lease expired before final send validation'
+            prompt_dir_exists = $false
+            resolved_send_count = 0
+            text_send_count = 0
+            guard_calls = 3
+            guard_sequence = @(
+                [PSCustomObject][ordered]@{ operation = 'auto'; expected_generation_id = '' }
+                [PSCustomObject][ordered]@{ operation = 'dispatch'; expected_generation_id = 'G1' }
+                [PSCustomObject][ordered]@{ operation = 'dispatch'; expected_generation_id = 'G1' }
+            )
+            deferred_start_calls = 1
+            restore_calls = 0
+            prompt_hash_unchanged = $true
+            prompt_mtime_unchanged = $true
+            pure_intent_precedes_checkpoint = $true
+            checkpoint_guard_precedes_materialization = $true
+        }
+        ($actual | ConvertTo-Json -Depth 8 -Compress) | Should -Be ($expected | ConvertTo-Json -Depth 8 -Compress)
+    }
+
+    It 'TASK781 C29 restores an existing task prompt when the lease expires after materialization' {
+        $script:sendSessionProjectDir = $script:sendTempRoot
+        New-Item -ItemType Directory -Path (Join-Path $script:sendTempRoot '.winsmux') -Force | Out-Null
+        Save-WinsmuxManifest -ProjectDir $script:sendTempRoot -Manifest ([ordered]@{
+            version = 2
+            session = [ordered]@{ name = 'winsmux-orchestra'; generation_id = 'G1'; server_session_id = '$41'; session_ready = $true }
+            panes = [ordered]@{
+                'worker-1' = [ordered]@{
+                    slot_id = 'worker-1'; pane_id = '%2'; worker_backend = 'codex'; role = 'Worker'; title = 'W1'
+                    status = 'ready'; runtime_ready = $true; exec_mode = $false
+                }
+            }
+            tasks = [ordered]@{ queued = @(); in_progress = @(); completed = @() }
+            worktrees = [ordered]@{}
+        })
+        $manifestPath = Join-Path (Join-Path $script:sendTempRoot '.winsmux') 'manifest.yaml'
+        $script:c29SendContext = [PSCustomObject]@{
+            ManifestPath = $manifestPath; ProjectDir = $script:sendTempRoot; SessionName = 'winsmux-orchestra'
+            Label = 'worker-1'; PaneId = '%2'; Role = 'Worker'; Status = 'ready'; SecurityPolicy = $null
+            LaunchDir = $script:sendTempRoot; GitWorktreeDir = (Join-Path $script:sendTempRoot '.git')
+            Branch = 'codex/task-781'; HeadSha = 'abc781'
+        }
+        $taskPromptPath = Get-TaskPromptPath -TaskSlug 'lease-rollback' -ProjectDir $script:sendTempRoot
+        Write-ClmSafeTextFile -Path $taskPromptPath -Content 'previous prompt evidence'
+        $taskPromptHashBefore = (Get-FileHash -LiteralPath $taskPromptPath -Algorithm SHA256).Hash
+        $script:c29SendGuardCalls = 0
+
+        Mock Resolve-Target { '%2' }
+        Mock Resolve-TerminalBackend { 'tauri' }
+        Mock Get-SlotAgentConfig {
+            [PSCustomObject]@{
+                Agent = 'codex'; Model = 'gpt-5.5'; PromptTransport = 'argv'
+                CapabilityAdapter = 'codex'; CapabilityCommand = 'codex'
+            }
+        }
+        Mock Assert-WinsmuxTargetRuntimeWriteAllowed {
+            param($PaneId, $CurrentProjectDir, $Operation, $ExpectedGenerationId)
+            $script:c29SendGuardCalls++
+            if ($script:c29SendGuardCalls -eq 1) {
+                return [PSCustomObject]@{
+                    Managed = $true; ProjectDir = $script:sendTempRoot; Context = $script:c29SendContext
+                    Operation = 'dispatch'; GenerationId = 'G1'
+                }
+            }
+            if ($script:c29SendGuardCalls -eq 2) {
+                return [PSCustomObject]@{ Managed = $true; ProjectDir = $script:sendTempRoot; Operation = 'dispatch'; GenerationId = 'G1' }
+            }
+            throw 'runtime dispatch refused (invalid_supervisor_identity): generation expired after prompt materialization'
+        }
+        Mock Start-DeferredPaneFromManifestEntry { return $false }
+        Mock Send-ResolvedTransportPlan {
+            throw 'runtime dispatch refused (invalid_supervisor_identity): generation expired after prompt materialization'
+        }
+
+        $errorText = ''
+        Push-Location $script:sendTempRoot
+        try {
+            try {
+                Invoke-Send -SendTarget '%2' -SendArguments @('--task-slug', 'lease-rollback', 'replacement prompt')
+            } catch {
+                $errorText = [string]$_.Exception.Message
+            }
+        } finally {
+            Pop-Location
+        }
+
+        $errorText | Should -Match 'invalid_supervisor_identity'
+        $script:c29SendGuardCalls | Should -BeGreaterOrEqual 3
+        (Get-Content -LiteralPath $taskPromptPath -Raw -Encoding UTF8).TrimEnd("`r", "`n") | Should -BeExactly 'previous prompt evidence'
+        (Get-FileHash -LiteralPath $taskPromptPath -Algorithm SHA256).Hash | Should -Be $taskPromptHashBefore
+        Test-Path -LiteralPath ($taskPromptPath + '.tmp') | Should -BeFalse
+    }
+
+    It 'TASK781 C29 removes a newly materialized unique prompt artifact during rollback' {
+        $intent = Resolve-SendTransportIntent -Text ('x' * 5000) -ProjectDir $script:sendTempRoot `
+            -LengthLimit 4000 -PromptTransport argv
+        $checkpoint = New-SendPromptArtifactCheckpoint -ProjectDir $script:sendTempRoot -Intent $intent
+        $plan = New-SendTransportPlan -Text ('x' * 5000) -ProjectDir $script:sendTempRoot `
+            -LengthLimit 4000 -PromptTransport argv -Intent $intent
+        $promptDir = Get-DispatchPromptDirectory -ProjectDir $script:sendTempRoot
+
+        Test-Path -LiteralPath ([string]$plan['PromptPath']) -PathType Leaf | Should -BeTrue
+        Restore-SendPromptArtifactCheckpoint -Checkpoint $checkpoint -MaterializedPromptPath ([string]$plan['PromptPath'])
+
+        Test-Path -LiteralPath ([string]$plan['PromptPath']) | Should -BeFalse
+        Test-Path -LiteralPath $promptDir | Should -BeFalse
+    }
+
+    It 'TASK781 C29 refuses rollback cleanup outside its dispatch prompt directory' {
+        $intent = Resolve-SendTransportIntent -Text ('x' * 5000) -ProjectDir $script:sendTempRoot `
+            -LengthLimit 4000 -PromptTransport argv
+        $checkpoint = New-SendPromptArtifactCheckpoint -ProjectDir $script:sendTempRoot -Intent $intent
+        $outsidePath = Join-Path $script:sendTempRoot 'outside-evidence.txt'
+        Write-ClmSafeTextFile -Path $outsidePath -Content 'preserve outside evidence'
+
+        {
+            Restore-SendPromptArtifactCheckpoint -Checkpoint $checkpoint -MaterializedPromptPath $outsidePath
+        } | Should -Throw '*outside its rollback checkpoint*'
+
+        (Get-Content -LiteralPath $outsidePath -Raw -Encoding UTF8).TrimEnd("`r", "`n") | Should -BeExactly 'preserve outside evidence'
+    }
+
+    It 'TASK781 C53 serializes same-slug materialization and makes an expired rollback ownership-safe' {
+        $taskPromptPath = Get-TaskPromptPath -TaskSlug 'concurrent-owner' -ProjectDir $script:sendTempRoot
+        Write-ClmSafeTextFile -Path $taskPromptPath -Content 'original evidence'
+        $intent = Resolve-SendTransportIntent -Text 'first materialization' -ProjectDir $script:sendTempRoot `
+            -LengthLimit 4000 -PromptTransport argv -TaskSlug 'concurrent-owner'
+        $firstCheckpoint = New-SendPromptArtifactCheckpoint -ProjectDir $script:sendTempRoot -Intent $intent
+        $firstPlan = New-SendTransportPlan -Text 'first materialization' -ProjectDir $script:sendTempRoot `
+            -LengthLimit 4000 -PromptTransport argv -TaskSlug 'concurrent-owner' -Intent $intent
+
+        {
+            $competingLease = [System.IO.File]::Open(
+                [string]$firstCheckpoint.LeasePath,
+                [System.IO.FileMode]::OpenOrCreate,
+                [System.IO.FileAccess]::ReadWrite,
+                [System.IO.FileShare]::None
+            )
+            $competingLease.Dispose()
+        } | Should -Throw
+
+        Restore-SendPromptArtifactCheckpoint -Checkpoint $firstCheckpoint -MaterializedPromptPath ([string]$firstPlan['PromptPath'])
+
+        $secondIntent = Resolve-SendTransportIntent -Text 'second materialization' -ProjectDir $script:sendTempRoot `
+            -LengthLimit 4000 -PromptTransport argv -TaskSlug 'concurrent-owner'
+        $secondCheckpoint = New-SendPromptArtifactCheckpoint -ProjectDir $script:sendTempRoot -Intent $secondIntent
+        $secondPlan = New-SendTransportPlan -Text 'second materialization' -ProjectDir $script:sendTempRoot `
+            -LengthLimit 4000 -PromptTransport argv -TaskSlug 'concurrent-owner' -Intent $secondIntent
+
+        Restore-SendPromptArtifactCheckpoint -Checkpoint $firstCheckpoint -MaterializedPromptPath ([string]$firstPlan['PromptPath'])
+        (Get-Content -LiteralPath $taskPromptPath -Raw -Encoding UTF8).TrimEnd("`r", "`n") | Should -BeExactly 'second materialization'
+
+        Restore-SendPromptArtifactCheckpoint -Checkpoint $secondCheckpoint -MaterializedPromptPath ([string]$secondPlan['PromptPath'])
+        (Get-Content -LiteralPath $taskPromptPath -Raw -Encoding UTF8).TrimEnd("`r", "`n") | Should -BeExactly 'original evidence'
+        Test-Path -LiteralPath ($taskPromptPath + '.send.lock') | Should -BeFalse
     }
 
     It 'resolves restart readiness through dictionary capability adapters' {
@@ -18793,6 +24159,58 @@ Describe 'winsmux role command provider routing' {
     BeforeAll {
         $script:winsmuxRoleRawPath = Join-Path (Split-Path -Parent $PSScriptRoot) 'scripts\winsmux-core.ps1'
         $script:winsmuxRoleRawContent = Get-Content -Raw -Path $script:winsmuxRoleRawPath -Encoding UTF8
+
+        function Invoke-TestManagedPaneLifecycleMutationRefusal {
+            param(
+                [Parameter(Mandatory = $true)][bool]$HasManifest,
+                [AllowNull()]$Validation,
+                [ValidateSet('role', 'restart', 'name', 'kill')][string]$OperationName = 'role',
+                [AllowEmptyString()][string]$RequestedLabel = '',
+                [AllowNull()]$Context = $null
+            )
+
+            $helperSource = [regex]::Match(
+                $script:winsmuxRoleRawContent,
+                '(?s)function Get-ManagedPaneLifecycleMutationRefusal \{.*?\r?\n\}\r?\n\r?\nfunction Invoke-Role'
+            ).Value
+            if ([string]::IsNullOrWhiteSpace($helperSource)) {
+                throw 'Failed to extract Get-ManagedPaneLifecycleMutationRefusal from winsmux-core.ps1.'
+            }
+            $helperSource = $helperSource -replace '\r?\n\r?\nfunction Invoke-Role$', ''
+
+            & {
+                param($HelperSource, $HasManifest, $Validation, $OperationName, $RequestedLabel, $Context)
+                Set-StrictMode -Version Latest
+
+                function Test-Path {
+                    param([string]$LiteralPath, [string]$PathType)
+                    return $HasManifest
+                }
+
+                function Get-PaneControlManifestContext {
+                    param([string]$ProjectDir, [string]$PaneId)
+                    return [pscustomobject]@{ ProjectDir = $ProjectDir; PaneId = $PaneId }
+                }
+
+                function Test-PaneControlRuntimeContext {
+                    param([string]$ProjectDir, $ManifestEntry, [string]$Operation)
+                    return $Validation
+                }
+
+                function Resolve-WinsmuxManagedTargetContext {
+                    param([string]$PaneId, [string]$CurrentProjectDir, [string]$Operation)
+                    return [pscustomobject]@{
+                        Managed    = $HasManifest
+                        Validation = $Validation
+                        Context    = $Context
+                    }
+                }
+
+                Invoke-Expression $HelperSource
+                Get-ManagedPaneLifecycleMutationRefusal -ProjectDir 'C:\synthetic-winsmux' -PaneId '%1' `
+                    -OperationName $OperationName -RequestedLabel $RequestedLabel
+            } $helperSource $HasManifest $Validation $OperationName $RequestedLabel $Context
+        }
     }
 
     It 'builds reassigned role launch commands through provider capabilities' {
@@ -18836,6 +24254,55 @@ Describe 'winsmux role command provider routing' {
         $manifestUpdateIndex | Should -BeLessThan $respawnIndex
         $environmentClearIndex | Should -BeLessThan $environmentIndex
         $environmentIndex | Should -BeLessThan $respawnIndex
+    }
+
+    It 'TASK781 preserves unmanaged role and restart paths' {
+        $result = Invoke-TestManagedPaneLifecycleMutationRefusal -HasManifest $false -Validation $null
+
+        $result | Should -BeNullOrEmpty
+    }
+
+    It 'TASK781 blocks managed lifecycle replacement after validating the current runtime identity' {
+        $result = Invoke-TestManagedPaneLifecycleMutationRefusal -HasManifest $true -Validation ([pscustomobject]@{
+            valid       = $true
+            reason_code = ''
+            diagnostic  = 'verified'
+        })
+
+        $result.valid | Should -BeFalse
+        $result.reason_code | Should -Be 'manifest_regeneration_required'
+        $result.diagnostic | Should -Match 'replace the registered bootstrap identity'
+        $script:winsmuxRoleRawContent | Should -Match '(?s)function Invoke-Role.*?Get-ManagedPaneLifecycleMutationRefusal.*?Stop-WithError.*?select-pane'
+        $script:winsmuxRoleRawContent | Should -Match '(?s)function Invoke-RestartPane.*?Get-ManagedPaneLifecycleMutationRefusal.*?Stop-WithError.*?respawn-pane'
+    }
+
+    It 'TASK781 refuses every managed name publication after runtime validation' {
+        $validation = [pscustomobject]@{ valid = $true; reason_code = ''; diagnostic = 'verified' }
+        $context = [pscustomobject]@{ Title = 'W1 Codex Reviewer' }
+
+        $exact = Invoke-TestManagedPaneLifecycleMutationRefusal -HasManifest $true -Validation $validation `
+            -OperationName name -RequestedLabel 'W1 Codex Reviewer' -Context $context
+        $replacement = Invoke-TestManagedPaneLifecycleMutationRefusal -HasManifest $true -Validation $validation `
+            -OperationName name -RequestedLabel 'renamed' -Context $context
+
+        $exact.valid | Should -BeFalse
+        $exact.reason_code | Should -Be 'manifest_regeneration_required'
+        $replacement.valid | Should -BeFalse
+        $replacement.reason_code | Should -Be 'manifest_regeneration_required'
+        $script:winsmuxRoleRawContent | Should -Match 'Invoke-Name[\s\S]*?-OperationName name -RequestedLabel \$label'
+        $script:winsmuxRoleRawContent | Should -Not -Match '(?s)function Get-ManagedPaneLifecycleMutationRefusal.*?OperationName -eq ''name''.*?return \$null.*?function Invoke-Role'
+    }
+
+    It 'TASK781 preserves the central runtime refusal reason for managed lifecycle changes' {
+        $result = Invoke-TestManagedPaneLifecycleMutationRefusal -HasManifest $true -Validation ([pscustomobject]@{
+            valid       = $false
+            reason_code = 'invalid_supervisor_identity'
+            diagnostic  = 'supervisor start time mismatch'
+        })
+
+        $result.valid | Should -BeFalse
+        $result.reason_code | Should -Be 'invalid_supervisor_identity'
+        $result.diagnostic | Should -Be 'supervisor start time mismatch'
     }
 }
 
@@ -19398,6 +24865,89 @@ Describe 'winsmux orchestra-smoke command' {
         $script:winsmuxCoreRawContent = Get-Content -Path $script:winsmuxCoreRawPath -Raw -Encoding UTF8
         $script:orchestraSmokePath = Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\orchestra-smoke.ps1'
         $script:orchestraSmokeContent = Get-Content -Path $script:orchestraSmokePath -Raw -Encoding UTF8
+        $script:runtimeManifestPath = Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\manifest.ps1'
+        $script:harnessCheckContent = Get-Content -Path (Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\harness-check.ps1') -Raw -Encoding UTF8
+
+        function Invoke-TestOrchestraRuntimeValidity {
+            param(
+                [Parameter(Mandatory = $true)][object[]]$Entries,
+                [Parameter(Mandatory = $true)][object[]]$Validations,
+                [int]$ExpectedPaneCount = 6
+            )
+
+            $runtimeSource = [regex]::Match(
+                $script:orchestraSmokeContent,
+                '(?s)function Get-OrchestraSmokeRuntimeValidity \{.*?\r?\n\}\r?\n\r?\nfunction ConvertTo-OrchestraSmokeInt'
+            ).Value
+            if ([string]::IsNullOrWhiteSpace($runtimeSource)) {
+                throw 'Failed to extract Get-OrchestraSmokeRuntimeValidity from orchestra-smoke.ps1.'
+            }
+            $runtimeSource = $runtimeSource -replace '\r?\n\r?\nfunction ConvertTo-OrchestraSmokeInt$', ''
+
+            & {
+                param($RuntimeSource, $RuntimeManifestPath, $Entries, $Validations, $ExpectedPaneCount)
+
+                Set-StrictMode -Version Latest
+                . $RuntimeManifestPath
+                $validationQueue = [System.Collections.Queue]::new()
+                foreach ($validation in $Validations) {
+                    $validationQueue.Enqueue($validation)
+                }
+
+                function Get-PaneControlManifestEntries {
+                    param([string]$ProjectDir)
+                    return @($Entries)
+                }
+
+                function Get-PaneControlValue {
+                    param($InputObject, [string]$Name, $Default)
+                    if ($InputObject -is [System.Collections.IDictionary] -and $InputObject.Contains($Name)) {
+                        return $InputObject[$Name]
+                    }
+                    if ($null -ne $InputObject -and $null -ne $InputObject.PSObject.Properties[$Name]) {
+                        return $InputObject.$Name
+                    }
+                    return $Default
+                }
+
+                function Test-PaneControlRuntimeContext {
+                    param([string]$ProjectDir, $ManifestEntry, [string]$Operation)
+                    if ($validationQueue.Count -eq 0) {
+                        throw 'Missing synthetic runtime validation result.'
+                    }
+                    return $validationQueue.Dequeue()
+                }
+
+                Invoke-Expression $RuntimeSource
+                Get-OrchestraSmokeRuntimeValidity -ProjectDir 'C:\synthetic-winsmux' -ExpectedPaneCount $ExpectedPaneCount
+            } $runtimeSource $script:runtimeManifestPath $Entries $Validations $ExpectedPaneCount
+        }
+
+        function Invoke-TestHarnessSmokeContractEvaluation {
+            param([Parameter(Mandatory = $true)]$SmokeProbe)
+
+            $propertySource = [regex]::Match(
+                $script:harnessCheckContent,
+                '(?s)function Test-HarnessHasProperty \{.*?\r?\n\}\r?\n\r?\nfunction Test-HarnessSettingsLocalTracked'
+            ).Value
+            $evaluationSource = [regex]::Match(
+                $script:harnessCheckContent,
+                '(?s)function Get-HarnessSmokeContractEvaluation \{.*?\r?\n\}\r?\n\r?\n\$results ='
+            ).Value
+            if ([string]::IsNullOrWhiteSpace($propertySource) -or [string]::IsNullOrWhiteSpace($evaluationSource)) {
+                throw 'Failed to extract harness smoke contract helpers.'
+            }
+            $propertySource = $propertySource -replace '\r?\n\r?\nfunction Test-HarnessSettingsLocalTracked$', ''
+            $evaluationSource = $evaluationSource -replace '\r?\n\r?\n\$results =$', ''
+
+            & {
+                param($PropertySource, $EvaluationSource, $SmokeProbe)
+                Set-StrictMode -Version Latest
+                Invoke-Expression $PropertySource
+                Invoke-Expression $EvaluationSource
+                Get-HarnessSmokeContractEvaluation -SmokeProbe $SmokeProbe
+            } $propertySource $evaluationSource $SmokeProbe
+        }
 
         function Invoke-TestOrchestraOperatorContract {
             param(
@@ -19932,6 +25482,162 @@ Describe 'winsmux orchestra-smoke command' {
         $script:orchestraSmokeContent | Should -Match 'manifest read failed during startup convergence'
     }
 
+    It 'TASK781 makes smoke readiness depend on structured runtime identity validity' {
+        $script:orchestraSmokeContent | Should -Match 'function Get-OrchestraSmokeRuntimeValidity'
+        $script:orchestraSmokeContent | Should -Match 'Test-PaneControlRuntimeContext'
+        $script:orchestraSmokeContent | Should -Match '\$sessionAlreadyHealthy = .*RuntimeValid'
+        $script:orchestraSmokeContent | Should -Match "runtime identity invalid"
+        $script:orchestraSmokeContent | Should -Match 'runtime_valid\s+=\s+\$runtimeValid'
+        $script:orchestraSmokeContent | Should -Match 'runtime_identity\s+=\s+\$runtimeIdentity'
+    }
+
+    It 'TASK781 verifies all six expected runtime identities before smoke can pass' {
+        $entries = @(
+            1..6 | ForEach-Object {
+                [pscustomobject]@{
+                    SlotId        = "worker-$_"
+                    PaneId        = "%$_"
+                    WorkerBackend = 'codex'
+                    Role          = 'Worker'
+                    Title         = "worker-$_"
+                    Status        = 'ready'
+                }
+            }
+        )
+        $validations = @(
+            1..6 | ForEach-Object {
+                [pscustomobject]@{ valid = $true; reason_code = ''; diagnostic = 'verified' }
+            }
+        )
+
+        $result = Invoke-TestOrchestraRuntimeValidity -Entries $entries -Validations $validations
+
+        $result.valid | Should -BeTrue
+        $result.expected | Should -Be 6
+        $result.verified | Should -Be 6
+        $result.entries.Count | Should -Be 6
+    }
+
+    It 'TASK781 makes one invalid supervisor identity fail the six-pane smoke contract' {
+        $entries = @(
+            1..6 | ForEach-Object {
+                [pscustomobject]@{
+                    SlotId        = "worker-$_"
+                    PaneId        = "%$_"
+                    WorkerBackend = 'codex'
+                    Role          = 'Worker'
+                    Title         = "worker-$_"
+                    Status        = 'ready'
+                }
+            }
+        )
+        $validations = @(
+            1..5 | ForEach-Object {
+                [pscustomobject]@{ valid = $true; reason_code = ''; diagnostic = 'verified' }
+            }
+        ) + @(
+            [pscustomobject]@{
+                valid       = $false
+                reason_code = 'invalid_supervisor_identity'
+                diagnostic  = 'supervisor start time mismatch'
+            }
+        )
+
+        $result = Invoke-TestOrchestraRuntimeValidity -Entries $entries -Validations $validations
+
+        $result.valid | Should -BeFalse
+        $result.reason_code | Should -Be 'invalid_supervisor_identity'
+        $result.verified | Should -Be 5
+    }
+
+    It 'TASK781 rejects each parseable but invalid harness smoke result' {
+        $validContract = [pscustomobject]@{
+            operator_state  = 'ready'
+            can_dispatch    = $true
+            requires_startup = $false
+        }
+        $invalidCases = @(
+            [pscustomobject]@{
+                Name  = 'nonzero exit'
+                Probe = [pscustomobject]@{
+                    exit_code = 1
+                    parsed    = [pscustomobject]@{ smoke_ok = $true; runtime_valid = $true; runtime_identity = @{}; operator_contract = $validContract }
+                    error     = ''
+                }
+                Message = 'exited with code 1'
+            }
+            [pscustomobject]@{
+                Name  = 'smoke false'
+                Probe = [pscustomobject]@{
+                    exit_code = 0
+                    parsed    = [pscustomobject]@{ smoke_ok = $false; runtime_valid = $true; runtime_identity = @{}; operator_contract = $validContract }
+                    error     = ''
+                }
+                Message = 'smoke_ok=false'
+            }
+            [pscustomobject]@{
+                Name  = 'missing runtime identity'
+                Probe = [pscustomobject]@{
+                    exit_code = 0
+                    parsed    = [pscustomobject]@{ smoke_ok = $true; runtime_valid = $true; operator_contract = $validContract }
+                    error     = ''
+                }
+                Message = 'runtime identity registry'
+            }
+            [pscustomobject]@{
+                Name  = 'runtime invalid'
+                Probe = [pscustomobject]@{
+                    exit_code = 0
+                    parsed    = [pscustomobject]@{ smoke_ok = $true; runtime_valid = $false; runtime_identity = @{}; operator_contract = $validContract }
+                    error     = ''
+                }
+                Message = 'runtime identity registry'
+            }
+        )
+
+        foreach ($case in $invalidCases) {
+            $result = Invoke-TestHarnessSmokeContractEvaluation -SmokeProbe $case.Probe
+            $result.passed | Should -BeFalse -Because $case.Name
+            $result.message | Should -Match ([regex]::Escape($case.Message)) -Because $case.Name
+        }
+    }
+
+    It 'TASK781 accepts a complete valid harness smoke result' {
+        $probe = [pscustomobject]@{
+            exit_code = 0
+            error     = ''
+            parsed    = [pscustomobject]@{
+                smoke_ok              = $true
+                runtime_valid         = $true
+                runtime_identity      = [pscustomobject]@{ verified = 6; expected = 6 }
+                external_operator_mode = $false
+                session_ready         = $true
+                ui_attached           = $false
+                operator_contract     = [pscustomobject]@{
+                    operator_state   = 'ready-with-ui-warning'
+                    can_dispatch     = $true
+                    requires_startup = $false
+                }
+            }
+        }
+
+        $result = Invoke-TestHarnessSmokeContractEvaluation -SmokeProbe $probe
+
+        $result.passed | Should -BeTrue
+    }
+
+    It 'TASK781 makes harness and doctor fail when smoke or runtime identity is invalid' {
+        $harnessContent = Get-Content -LiteralPath (Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\harness-check.ps1') -Raw -Encoding UTF8
+        $doctorContent = Get-Content -LiteralPath (Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\doctor.ps1') -Raw -Encoding UTF8
+
+        $harnessContent | Should -Match 'function Get-HarnessSmokeContractEvaluation'
+        $harnessContent | Should -Match '\$exitCode -ne 0'
+        $harnessContent | Should -Match 'smoke_ok=false'
+        $harnessContent | Should -Match 'runtime_valid'
+        $doctorContent | Should -Match '\$resultOk = \$exitCode -eq 0 -and \$smokeOk -and \$runtimeValid'
+        $doctorContent | Should -Match '\$status = if \(\$null -ne \$smoke\.Data\) \{ ''fail'' \} else \{ ''warn'' \}'
+    }
+
     It 'refreshes the attached client snapshot after startup convergence before resolving attach state' {
         $script:orchestraSmokeContent | Should -Match 'function Get-OrchestraSmokeClientProbe'
         $script:orchestraSmokeContent | Should -Match '(?s)Wait-OrchestraSmokeConvergence -ProjectDir \$ProjectDir -SessionName \$SessionName.*?\$clientSnapshot = Get-OrchestraSmokeClientProbe -WinsmuxBin \$winsmuxBin -SessionName \$SessionName.*?Resolve-OrchestraSmokeAttachState'
@@ -20141,6 +25847,62 @@ Describe 'orchestra pane bootstrap plan' {
         $script:orchestraPaneBootstrapContent | Should -Match '\[winsmux\] pane bootstrap:'
         $script:orchestraPaneBootstrapContent | Should -Match 'launch_command'
         $script:orchestraPaneBootstrapContent | Should -Match 'Invoke-Expression \$launchCommand'
+    }
+
+    It 'TASK781 clean-imports pane bootstrap and writes process identity with <HostName>' -ForEach @(
+        @{ HostName = 'pwsh' }
+        @{ HostName = 'powershell.exe' }
+    ) {
+        $root = Join-Path ([IO.Path]::GetTempPath()) ('winsmux-task781-bootstrap-' + [guid]::NewGuid().ToString('N'))
+        $planPath = Join-Path $root 'plan.json'
+        $markerPath = Join-Path $root 'worker-1.ready.json'
+        New-Item -ItemType Directory -Path $root -Force | Out-Null
+        try {
+            $plan = [ordered]@{
+                launch_dir       = $root
+                launch_command   = "[Console]::WriteLine('bootstrap-launch-ok')"
+                ready_marker_path = $markerPath
+                generation_id    = 'generation-bootstrap-clean-import'
+                server_session_id = '$99'
+                slot_id          = 'worker-1'
+                pane_id          = '%2'
+                worker_backend   = 'codex'
+                worker_role      = 'reviewer'
+                pane_title       = 'W1 Codex Reviewer'
+                role             = 'Reviewer'
+                label            = 'worker-1'
+                model            = 'gpt-5'
+                environment      = [ordered]@{}
+            }
+            [IO.File]::WriteAllText($planPath, ($plan | ConvertTo-Json -Depth 6), [Text.UTF8Encoding]::new($false))
+
+            $output = @(& $HostName -NoProfile -File $script:orchestraPaneBootstrapPath -PlanFile $planPath 2>&1 |
+                ForEach-Object { [string]$_ })
+            $exitCode = $LASTEXITCODE
+
+            $exitCode | Should -Be 0 -Because ($output -join [Environment]::NewLine)
+            Test-Path -LiteralPath $markerPath -PathType Leaf | Should -BeTrue
+            $markerJson = Get-Content -LiteralPath $markerPath -Raw -Encoding UTF8
+            $marker = $markerJson | ConvertFrom-Json -Depth 8
+            [int]$marker.bootstrap_pid | Should -BeGreaterThan 0
+            [string]$marker.bootstrap_process_started_at | Should -Not -BeNullOrEmpty
+            $startedAtMatch = [regex]::Match(
+                $markerJson,
+                '"bootstrap_process_started_at"\s*:\s*"(?<value>[^"]+)"'
+            )
+            $startedAtMatch.Success | Should -BeTrue
+            $startedAt = [DateTimeOffset]::MinValue
+            [DateTimeOffset]::TryParseExact(
+                $startedAtMatch.Groups['value'].Value,
+                'o',
+                [Globalization.CultureInfo]::InvariantCulture,
+                [Globalization.DateTimeStyles]::RoundtripKind,
+                [ref]$startedAt
+            ) | Should -BeTrue
+            $output | Should -Contain 'bootstrap-launch-ok'
+        } finally {
+            Remove-Item -LiteralPath $root -Recurse -Force -ErrorAction SilentlyContinue
+        }
     }
 }
 
@@ -21461,6 +27223,62 @@ panes:
         }
     }
 
+    It 'TASK781 C19 threads the caller snapshot through review state updates' {
+        $snapshot = [ordered]@{
+            ManifestPath = 'C:\repo\.winsmux\manifest.yaml'
+            PaneId = '%2'
+            GenerationId = 'generation-initial'
+        }
+        $script:capturedReviewGeneration = ''
+        Mock Get-CurrentReviewPaneManifestContext {
+            [pscustomobject]@{ ManifestPath = 'replacement'; PaneId = '%9'; GenerationId = 'generation-replacement' }
+        }
+        Mock Set-PaneControlManifestPaneProperties {
+            param($ManifestPath, $PaneId, $Properties, $ExpectedGenerationId)
+            $script:capturedReviewGeneration = [string]$ExpectedGenerationId
+        }
+
+        Update-ReviewPaneManifestState -Context $snapshot -Properties ([ordered]@{ review_state = 'pending' })
+
+        $script:capturedReviewGeneration | Should -BeExactly 'generation-initial'
+        Should -Invoke Get-CurrentReviewPaneManifestContext -Times 0 -Exactly
+    }
+
+    It 'TASK781 C19 clears authoritative review state when manifest context is unavailable' {
+        $script:reviewResetState = [ordered]@{ 'codex/test-review-reset' = [ordered]@{ status = 'PASS' } }
+        Save-ReviewState -State $script:reviewResetState -ProjectDir $script:consultTempRoot
+        Mock Get-CurrentGitBranch { 'codex/test-review-reset' }
+        Mock Get-CurrentReviewPaneManifestContext { throw 'manifest unavailable' }
+        Mock Set-PaneControlManifestPaneProperties { throw 'must not sync without a snapshot' }
+
+        $output = & { $Target = $null; $Rest = @(); Invoke-ReviewReset }
+
+        $output | Should -Match 'review PASS cleared'
+        (Get-ReviewState -ProjectDir $script:consultTempRoot).Contains('codex/test-review-reset') | Should -BeFalse
+        Should -Invoke Set-PaneControlManifestPaneProperties -Times 0 -Exactly
+    }
+
+    It 'TASK781 C19 carries the initial snapshot through the production consultation caller' {
+        $script:consultCallerGeneration = ''
+        Mock Get-CurrentReviewPaneManifestContext {
+            [pscustomobject]@{
+                ManifestPath = $script:consultManifestPath
+                PaneId = '%2'
+                GenerationId = 'generation-initial'
+            }
+        }
+        Mock Get-PaneControlManifestGenerationId { 'generation-replacement' }
+        Mock Set-PaneControlManifestPaneProperties {
+            $script:consultCallerGeneration = [string]$ExpectedGenerationId
+        }
+
+        Write-ConsultationCommandRecord -Kind 'consult_request' -Mode 'early' -Message 'verify snapshot' `
+            -ProjectDir $script:consultTempRoot | Out-Null
+
+        $script:consultCallerGeneration | Should -BeExactly 'generation-initial'
+        Should -Invoke Get-PaneControlManifestGenerationId -Times 0 -Exactly
+    }
+
     It 'records a consult request as a file-backed packet and event' {
         $args = Parse-ConsultCommandArgs -Mode 'early' -Args @('--target-slot', 'slot-review-1', '--message', 'sanity-check the current hypothesis')
 
@@ -21622,6 +27440,59 @@ panes:
         if ($script:operatorPollTempRoot -and (Test-Path $script:operatorPollTempRoot)) {
             Remove-Item -Path $script:operatorPollTempRoot -Recurse -Force
         }
+    }
+
+    It 'TASK781 C19 threads the event manifest snapshot through pane state updates' {
+        $paneContext = [ordered]@{
+            project_dir = $script:operatorPollTempRoot
+            manifest_path = $script:operatorPollManifestPath
+            pane_id = '%2'
+            generation_id = 'generation-initial'
+        }
+        $script:capturedPollGeneration = ''
+        Mock Get-PaneControlManifestEntries {
+            @([pscustomobject]@{ ManifestPath = 'replacement'; PaneId = '%9'; GenerationId = 'generation-replacement' })
+        }
+        Mock Set-PaneControlManifestPaneProperties {
+            param($ManifestPath, $PaneId, $Properties, $ExpectedGenerationId)
+            $script:capturedPollGeneration = [string]$ExpectedGenerationId
+        }
+
+        Update-OperatorPollPaneState -PaneContext $paneContext -Properties ([ordered]@{ task_state = 'completed' })
+
+        $script:capturedPollGeneration | Should -BeExactly 'generation-initial'
+        Should -Invoke Get-PaneControlManifestEntries -Times 0 -Exactly
+    }
+
+    It 'TASK781 C19 carries the event snapshot through the production poll caller' {
+        $manifest = [ordered]@{
+            Session = [ordered]@{
+                name = 'winsmux-orchestra'
+                project_dir = $script:operatorPollTempRoot
+                generation_id = 'generation-initial'
+            }
+            Panes = [ordered]@{
+                'builder-1' = [ordered]@{ pane_id = '%2'; role = 'Builder'; launch_dir = $script:operatorPollTempRoot }
+            }
+        }
+        $event = [ordered]@{ event = 'pane.idle'; pane_id = '%2'; label = 'builder-1'; role = 'Builder' }
+        $summary = [ordered]@{ new_events = 0; dispatches = 0; completions = 0; approvals = 0; errors = 0; messages = @() }
+        $script:pollCallerGeneration = ''
+        Mock Write-OperatorPollLog { }
+        Mock Send-OperatorTelegramNotification { }
+        Mock Get-PaneControlManifestEntries {
+            @([pscustomobject]@{ ManifestPath = 'replacement'; PaneId = '%9'; GenerationId = 'generation-replacement' })
+        }
+        Mock Set-PaneControlManifestPaneProperties {
+            $script:pollCallerGeneration = [string]$ExpectedGenerationId
+        }
+
+        Invoke-OperatorPollEventRecord -Manifest $manifest -ManifestPath $script:operatorPollManifestPath `
+            -EventRecord $event -Summary $summary
+
+        $summary.dispatches | Should -Be 1
+        $script:pollCallerGeneration | Should -BeExactly 'generation-initial'
+        Should -Invoke Get-PaneControlManifestEntries -Times 0 -Exactly
     }
 
     It 'processes mailbox idle messages and logs dispatch-needed guidance' {
@@ -22439,6 +28310,14 @@ Describe 'deferred worker startup' {
         $script:deferredPreRetryProbeApplies = $false
         $script:deferredPreRetryReady = $false
 
+        Mock Assert-WinsmuxTargetRuntimeWriteAllowed {
+            [pscustomobject]@{
+                Managed      = $true
+                ProjectDir   = $script:deferredTempRoot
+                GenerationId = 'generation-deferred'
+                Validation   = [pscustomobject]@{ valid = $true }
+            }
+        }
         Mock Wait-PaneShellReady { }
         Mock Invoke-Send {
             param(
@@ -22477,6 +28356,18 @@ Describe 'deferred worker startup' {
                 Properties = $capturedProperties
             }) | Out-Null
         }
+        Mock Get-PaneControlManifestContext {
+            param([string]$ProjectDir, [string]$PaneId)
+            [PSCustomObject]@{
+                Label = 'worker-2'; SlotId = 'worker-2'; PaneId = $PaneId; WorkerBackend = 'codex'
+                WorkerRole = 'worker'; Role = 'Worker'; Title = 'W2'; Status = 'deferred_starting'
+                BootstrapMarkerPath = $script:deferredMarkerPath
+            }
+        }
+        Mock Wait-PaneControlRuntimeContext {
+            New-WinsmuxRuntimeValidationResult -Valid $true -ReasonCode 'live_runtime_verified' `
+                -Diagnostic 'synthetic promoted runtime verified' -Context ([ordered]@{ generation_id = 'generation-deferred' })
+        }
     }
 
     AfterEach {
@@ -22512,6 +28403,34 @@ Describe 'deferred worker startup' {
         $script:deferredStatusWrites | Should -Be @('deferred_starting', 'ready')
     }
 
+    It 'TASK781 C29 waits for supervisor live promotion before publishing ready' {
+        $entry = [PSCustomObject]@{
+            Label = 'worker-2'; PaneId = '%3'; Status = 'deferred_starting'; BootstrapPlanPath = $script:deferredPlanPath
+            CapabilityAdapter = 'codex'; ProviderTarget = ''; ApprovedLaunch = $null
+        }
+        $script:c29DeferredTrace = [System.Collections.Generic.List[string]]::new()
+        Mock Wait-DeferredPaneReady { $script:c29DeferredTrace.Add('marker-ready') | Out-Null }
+        Mock Wait-PaneControlRuntimeContext {
+            $script:c29DeferredTrace.Add('registry-live') | Out-Null
+            New-WinsmuxRuntimeValidationResult -Valid $true -ReasonCode 'live_runtime_verified' `
+                -Diagnostic 'synthetic promoted runtime verified' -Context ([ordered]@{ generation_id = 'generation-deferred' })
+        }
+        Mock Assert-WinsmuxTargetRuntimeWriteAllowed {
+            param($PaneId, $CurrentProjectDir, $Operation, $ExpectedGenerationId)
+            if ($Operation -eq 'dispatch') { $script:c29DeferredTrace.Add('final-guard') | Out-Null }
+            [PSCustomObject]@{ Managed = $true; ProjectDir = $script:deferredTempRoot; GenerationId = 'generation-deferred' }
+        }
+        Mock Set-PaneControlManifestPaneProperties {
+            param([string]$ManifestPath, [string]$PaneId, [System.Collections.IDictionary]$Properties)
+            if ([string]$Properties['status'] -eq 'ready') { $script:c29DeferredTrace.Add('manifest-ready') | Out-Null }
+        }
+
+        Start-DeferredPaneFromManifestEntry -ProjectDir $script:deferredTempRoot -ManifestEntry $entry `
+            -ExpectedGenerationId 'generation-deferred' | Should -BeTrue
+
+        @($script:c29DeferredTrace) | Should -Be @('marker-ready', 'registry-live', 'final-guard', 'manifest-ready')
+    }
+
     It 'waits for an already-starting deferred pane without launching a duplicate bootstrap' {
         $entry = [PSCustomObject]@{
             Label             = 'worker-2'
@@ -22528,6 +28447,25 @@ Describe 'deferred worker startup' {
         Should -Invoke Wait-PaneShellReady -Times 0 -Exactly
         $script:deferredSendCommands.Count | Should -Be 0
         $script:deferredStatusWrites | Should -Be @('ready')
+    }
+
+    It 'TASK781 C29 leaves non-retryable unconfigured deferred states unchanged' -ForEach @(
+        'api_llm_runner_unconfigured',
+        'antigravity_runner_unconfigured'
+    ) {
+        $entry = [PSCustomObject]@{
+            Label = 'worker-2'; PaneId = '%3'; Status = [string]$_; BootstrapPlanPath = $script:deferredPlanPath
+            CapabilityAdapter = 'codex'; ProviderTarget = ''; ApprovedLaunch = $null
+        }
+
+        $started = Start-DeferredPaneFromManifestEntry -ProjectDir $script:deferredTempRoot -ManifestEntry $entry
+
+        $started | Should -BeFalse
+        (Get-WinsmuxRuntimeStatusClassification -Status ([string]$_)).Retryable | Should -BeFalse
+        $script:deferredSendCommands.Count | Should -Be 0
+        $script:deferredStatusWrites.Count | Should -Be 0
+        Should -Invoke Wait-PaneShellReady -Times 0 -Exactly
+        Should -Invoke Wait-PaneControlRuntimeContext -Times 0 -Exactly
     }
 
     It 'retries a previously failed deferred pane instead of sending task text to the shell' {
@@ -22557,7 +28495,110 @@ Describe 'deferred worker startup' {
         $script:deferredStatusWrites | Should -Be @('deferred_starting', 'ready')
     }
 
-    It 'marks a previously failed deferred pane ready when the delayed bootstrap already reached an agent prompt' {
+    It 'TASK781 C32 reuses a live authenticated failed marker without launching a duplicate bootstrap' {
+        $entry = [PSCustomObject]@{
+            Label = 'worker-2'; PaneId = '%3'; Status = 'deferred_start_failed'
+            BootstrapPlanPath = $script:deferredPlanPath; BootstrapMarkerPath = $script:deferredMarkerPath
+            CapabilityAdapter = 'codex'; ProviderTarget = ''
+        }
+        Mock Assert-WinsmuxTargetRuntimeWriteAllowed {
+            [pscustomobject]@{
+                Managed = $true; ProjectDir = $script:deferredTempRoot; GenerationId = 'generation-deferred'
+                Validation = [pscustomobject]@{
+                    valid = $true
+                    context = [pscustomobject]@{ retry_marker_state = 'live'; generation_id = 'generation-deferred' }
+                }
+            }
+        }
+
+        $started = Start-DeferredPaneFromManifestEntry -ProjectDir $script:deferredTempRoot -ManifestEntry $entry `
+            -ExpectedGenerationId 'generation-deferred'
+
+        $started | Should -BeTrue
+        Should -Invoke Wait-PaneShellReady -Times 0 -Exactly
+        $script:deferredSendCommands.Count | Should -Be 0
+        $script:deferredStatusWrites | Should -Be @('deferred_starting', 'ready')
+    }
+
+    It 'TASK781 C36 refuses a live retry manifest write when the marker changes after validation' {
+        $entry = [PSCustomObject]@{
+            Label = 'worker-2'; PaneId = '%3'; Status = 'deferred_start_failed'
+            BootstrapPlanPath = $script:deferredPlanPath; BootstrapMarkerPath = $script:deferredMarkerPath
+            CapabilityAdapter = 'codex'; ProviderTarget = ''
+        }
+        $script:c36GuardCalls = 0
+        Mock Assert-WinsmuxTargetRuntimeWriteAllowed {
+            $script:c36GuardCalls++
+            $markerState = if ($script:c36GuardCalls -eq 1) { 'live' } else { 'stale' }
+            [pscustomobject]@{
+                Managed = $true; ProjectDir = $script:deferredTempRoot; GenerationId = 'generation-deferred'
+                Validation = [pscustomobject]@{
+                    valid = $true
+                    context = [pscustomobject]@{ retry_marker_state = $markerState; generation_id = 'generation-deferred' }
+                }
+            }
+        }
+        $errorText = ''
+
+        try {
+            Start-DeferredPaneFromManifestEntry -ProjectDir $script:deferredTempRoot -ManifestEntry $entry `
+                -ExpectedGenerationId 'generation-deferred' | Out-Null
+        } catch {
+            $errorText = [string]$_.Exception.Message
+        }
+
+        $script:c36GuardCalls | Should -Be 2
+        $script:deferredStatusWrites.Count | Should -Be 0
+        $script:deferredSendCommands.Count | Should -Be 0
+        $errorText | Should -Match 'changed before deferred retry manifest update'
+    }
+
+    It 'TASK781 C32 safely removes a stale authenticated failed marker before one bootstrap retry' {
+        $bootstrapRoot = Join-Path (Join-Path $script:deferredTempRoot '.winsmux') 'orchestra-bootstrap'
+        New-Item -ItemType Directory -Path $bootstrapRoot -Force | Out-Null
+        $planPath = Join-Path $bootstrapRoot '2.json'
+        $markerPath = Join-Path $bootstrapRoot '2-generation-deferred.ready.json'
+        ([ordered]@{ agent = 'codex'; ready_marker_path = $markerPath } | ConvertTo-Json) |
+            Set-Content -LiteralPath $planPath -Encoding UTF8
+        '{}' | Set-Content -LiteralPath $markerPath -Encoding UTF8
+        $entry = [PSCustomObject]@{
+            Label = 'worker-2'; PaneId = '%3'; Status = 'deferred_start_failed'
+            BootstrapPlanPath = $planPath; BootstrapMarkerPath = $markerPath
+            CapabilityAdapter = 'codex'; ProviderTarget = ''
+        }
+        $script:c32RetryGuardCount = 0
+        $script:c32MarkerAbsentAtLaunch = $false
+        Mock Assert-WinsmuxTargetRuntimeWriteAllowed {
+            $script:c32RetryGuardCount++
+            $markerState = if ($script:c32RetryGuardCount -le 2) { 'stale' } else { '' }
+            [pscustomobject]@{
+                Managed = $true; ProjectDir = $script:deferredTempRoot; GenerationId = 'generation-deferred'
+                Validation = [pscustomobject]@{
+                    valid = $true
+                    context = [pscustomobject]@{ retry_marker_state = $markerState; generation_id = 'generation-deferred' }
+                }
+            }
+        }
+        Mock Invoke-Send {
+            param([string]$SendTarget, [string[]]$SendArguments, [string]$DeliveryClass, [switch]$SkipDeferredPaneStart)
+            $script:c32MarkerAbsentAtLaunch = -not (Test-Path -LiteralPath $markerPath -PathType Leaf)
+            $script:deferredSendCommands.Add([string]$SendArguments[-1]) | Out-Null
+            return "sent to $SendTarget"
+        }
+        $script:deferredPreRetryProbeApplies = $true
+        $script:deferredPreRetryReady = $false
+
+        $started = Start-DeferredPaneFromManifestEntry -ProjectDir $script:deferredTempRoot -ManifestEntry $entry `
+            -ExpectedGenerationId 'generation-deferred'
+
+        $started | Should -BeTrue
+        $script:c32MarkerAbsentAtLaunch | Should -BeTrue
+        $script:deferredSendCommands.Count | Should -Be 1
+        $script:c32RetryGuardCount | Should -BeGreaterOrEqual 2
+        $script:deferredStatusWrites | Should -Be @('deferred_starting', 'ready')
+    }
+
+    It 'does not trust a delayed prompt without an authenticated marker and launches one retry' {
         $script:deferredPreRetryProbeApplies = $true
         $script:deferredPreRetryReady = $true
         $entry = [PSCustomObject]@{
@@ -22572,10 +28613,10 @@ Describe 'deferred worker startup' {
         $started = Start-DeferredPaneFromManifestEntry -ProjectDir $script:deferredTempRoot -ManifestEntry $entry
 
         $started | Should -Be $true
-        Should -Invoke Wait-PaneShellReady -Times 0 -Exactly
-        $script:deferredSendCommands.Count | Should -Be 0
+        Should -Invoke Wait-PaneShellReady -Times 1 -Exactly
+        $script:deferredSendCommands.Count | Should -Be 1
         $script:deferredReadyProbeCount | Should -Be 1
-        $script:deferredStatusWrites | Should -Be @('ready')
+        $script:deferredStatusWrites | Should -Be @('deferred_starting', 'ready')
     }
 
     It 'blocks a previously failed deferred pane when the bootstrap plan is still missing' {
@@ -22735,6 +28776,137 @@ Describe 'winsmux send fallback' {
                 }
             }
         }
+    }
+
+    It 'TASK781 C29 revalidates the captured generation immediately before every pane mutation' {
+        $script:c29SendLeaseTrace = [System.Collections.Generic.List[string]]::new()
+        $script:c29SendSnapshotCount = 0
+        $deliveryState = [ordered]@{}
+        Mock Resolve-TerminalBackend { 'tauri' }
+        Mock Split-SendKeysLiteralChunks { @('echo ', 'test') }
+        Mock Get-PaneSnapshotText {
+            $script:c29SendSnapshotCount++
+            switch ($script:c29SendSnapshotCount) {
+                1 { return '> ' }
+                2 { return '> echo test' }
+                3 { return "> echo test`nresult" }
+                default { return "> echo test`nresult" }
+            }
+        }
+        Mock Assert-WinsmuxTargetRuntimeWriteAllowed {
+            param($PaneId, $CurrentProjectDir, $Operation, $ExpectedGenerationId)
+            $script:c29SendLeaseTrace.Add("guard:${Operation}:${ExpectedGenerationId}") | Out-Null
+            [PSCustomObject]@{ Managed = $true; ProjectDir = $CurrentProjectDir; GenerationId = $ExpectedGenerationId }
+        }
+        Mock Invoke-WinsmuxSendKeys {
+            param($Target, $Keys, [switch]$Literal)
+            $kind = if ($Literal) { 'literal' } else { [string]$Keys[0] }
+            $script:c29SendLeaseTrace.Add("mutation:$kind") | Out-Null
+            [PSCustomObject]@{ ExitCode = 0; Output = '' }
+        }
+        Mock Save-Watermark { }
+        Mock Set-ReadMark { }
+
+        $result = Send-TextToPane -PaneId '%7' -CommandText 'echo test' `
+            -RuntimeProjectDir 'C:\synthetic-project' -RuntimeOperation dispatch `
+            -ExpectedGenerationId 'generation-G1' -DeliveryState $deliveryState
+
+        $result | Should -Be 'sent to %7 via %7'
+        $mutations = @($script:c29SendLeaseTrace | Where-Object { $_ -like 'mutation:*' })
+        $mutations | Should -Be @('mutation:literal', 'mutation:literal', 'mutation:Enter')
+        for ($index = 0; $index -lt $script:c29SendLeaseTrace.Count; $index++) {
+            if ($script:c29SendLeaseTrace[$index] -like 'mutation:*') {
+                $index | Should -BeGreaterThan 0
+                $script:c29SendLeaseTrace[$index - 1] | Should -Be 'guard:dispatch:generation-G1'
+            }
+        }
+        $deliveryState['SubmissionCommitted'] | Should -BeTrue
+    }
+
+    It 'TASK781 C68 marks packet retention at the first successful Enter before snapshot failure' {
+        $deliveryState = [ordered]@{}
+        $script:c68SnapshotCount = 0
+        Mock Resolve-TerminalBackend { 'tauri' }
+        Mock Split-SendKeysLiteralChunks { @('echo test') }
+        Mock Get-PaneSnapshotText {
+            $script:c68SnapshotCount++
+            switch ($script:c68SnapshotCount) {
+                1 { return '> ' }
+                2 { return '> echo test' }
+                default { throw 'synthetic post-Enter snapshot failure' }
+            }
+        }
+        Mock Assert-SendPaneRuntimeLease { }
+        Mock Invoke-WinsmuxSendKeys { [PSCustomObject]@{ ExitCode = 0; Output = '' } }
+
+        { Send-TextToPane -PaneId '%7' -CommandText 'echo test' -DeliveryState $deliveryState } |
+            Should -Throw '*post-Enter snapshot failure*'
+
+        $deliveryState['SubmissionCommitted'] | Should -BeTrue
+        Should -Invoke Invoke-WinsmuxSendKeys -Times 1 -Exactly -ParameterFilter {
+            -not $Literal -and [string]$Keys[0] -ceq 'Enter'
+        }
+    }
+
+    It 'TASK781 C68 aborts fallback after committed Enter when pasted-content confirmation fails' {
+        $deliveryState = [ordered]@{}
+        $script:c68SecondEnterCount = 0
+        $script:c68FallbackTargetCalls = 0
+        Mock Resolve-TerminalBackend { 'cli' }
+        Mock Get-PaneTargetCandidates { @('%7', 'default:0.3') }
+        Mock Split-SendKeysLiteralChunks { @('echo test') }
+        Mock Get-PaneSnapshotText {
+            if ($script:sendBuffer -eq '') { return '> ' }
+            if ($script:sendBuffer -eq 'typed') { return '> echo test' }
+            if ($script:sendBuffer -eq 'pasted') { return '> [Pasted Content 1 lines]' }
+            return '> '
+        }
+        Mock Invoke-WinsmuxSendKeys {
+            param($Target, $Keys, [switch]$Literal)
+            if ($Target -eq 'default:0.3') {
+                $script:c68FallbackTargetCalls++
+                throw 'committed attempt must not reach fallback target'
+            }
+            if ($Literal) {
+                $script:sendBuffer = 'typed'
+                return [PSCustomObject]@{ ExitCode = 0; Output = '' }
+            }
+            $script:c68SecondEnterCount++
+            if ($script:c68SecondEnterCount -eq 1) {
+                $script:sendBuffer = 'pasted'
+                return [PSCustomObject]@{ ExitCode = 0; Output = '' }
+            }
+            return [PSCustomObject]@{ ExitCode = 1; Output = 'synthetic second Enter failed' }
+        }
+
+        { Send-TextToPane -PaneId '%7' -CommandText 'echo test' -DeliveryState $deliveryState } |
+            Should -Throw '*second Enter failed*'
+
+        $deliveryState['SubmissionCommitted'] | Should -BeTrue
+        $script:c68FallbackTargetCalls | Should -Be 0
+    }
+
+    It 'TASK781 C68 has no control-flow continue after the committed boundary' {
+        $content = [System.IO.File]::ReadAllText($bridgePath, [System.Text.Encoding]::UTF8)
+        $tokens = $null
+        $errors = $null
+        $ast = [System.Management.Automation.Language.Parser]::ParseInput(
+            $content,
+            $bridgePath,
+            [ref]$tokens,
+            [ref]$errors
+        )
+        @($errors).Count | Should -Be 0
+        $sendFunction = $ast.Find({
+            param($node)
+            $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+                $node.Name -ceq 'Send-TextToPane'
+        }, $true)
+        $source = $sendFunction.Extent.Text
+        $committedIndex = $source.IndexOf("`$DeliveryState['SubmissionCommitted'] = `$true", [System.StringComparison]::Ordinal)
+        $committedIndex | Should -BeGreaterThan -1
+        $postCommitSource = $source.Substring($committedIndex)
+        $postCommitSource | Should -Not -Match '(?m)^\s*continue\b'
     }
 
     It 'adds a coordinate target as a fallback candidate for a pane id' {

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -3816,8 +3816,21 @@ panes:
             -Now ([datetime]'2026-07-15T00:05:05Z') -LeaseSeconds 15
         $refreshed.lease.expires_at | Should -Be '2026-07-15T00:05:20.0000000Z'
 
+        $foreignSessionClose = Close-WinsmuxRuntimeRegistry -ProjectDir $script:task781TempRoot -GenerationId 'generation-1' `
+            -SupervisorPid 4100 -SupervisorProcessStartedAt '2026-07-15T00:00:00.0000000Z' `
+            -ExpectedSessionName 'winsmux-other' -ExpectedServerSessionId '$9'
+        $foreignSessionClose | Should -BeFalse
+        (Read-WinsmuxRuntimeRegistry -ProjectDir $script:task781TempRoot).status | Should -Be 'active'
+
+        $foreignServerClose = Close-WinsmuxRuntimeRegistry -ProjectDir $script:task781TempRoot -GenerationId 'generation-1' `
+            -SupervisorPid 4100 -SupervisorProcessStartedAt '2026-07-15T00:00:00.0000000Z' `
+            -ExpectedSessionName 'winsmux-task781-test' -ExpectedServerSessionId '$10'
+        $foreignServerClose | Should -BeFalse
+        (Read-WinsmuxRuntimeRegistry -ProjectDir $script:task781TempRoot).status | Should -Be 'active'
+
         $closed = Close-WinsmuxRuntimeRegistry -ProjectDir $script:task781TempRoot -GenerationId 'generation-1' `
             -SupervisorPid 4100 -SupervisorProcessStartedAt '2026-07-15T00:00:00.0000000Z' `
+            -ExpectedSessionName 'winsmux-task781-test' -ExpectedServerSessionId '$9' `
             -Now ([datetime]'2026-07-15T00:05:06Z')
         $closed | Should -BeTrue
         $ended = Read-WinsmuxRuntimeRegistry -ProjectDir $script:task781TempRoot
@@ -3930,6 +3943,23 @@ panes:
         $fixture.Registry.panes[0].state | Should -Be 'deferred'
     }
 
+    It 'TASK781 C73 authenticates a deferred-starting marker so readiness failure can become retryable' {
+        $fixture = New-Task781RuntimeFixture
+        $fixture.Registry.panes[0].state = 'deferred'
+        $fixture.Registry.panes[0].bootstrap_pid = 0
+        $fixture.Registry.panes[0].bootstrap_process_started_at = ''
+        $fixture.Manifest.panes['worker-1'].status = 'deferred_starting'
+        $fixture.Entry.Status = 'deferred_starting'
+        $fixture.Marker | Add-Member -NotePropertyName state -NotePropertyValue 'bootstrap_pending'
+
+        $result = Invoke-Task781RuntimeFixture -Fixture $fixture -Operation start_deferred
+
+        $result.valid | Should -BeTrue
+        $result.reason_code | Should -Be 'deferred_starting_marker_verified'
+        [string]$result.context.marker_process_state | Should -Be 'live'
+        $fixture.Registry.panes[0].state | Should -Be 'deferred'
+    }
+
     It 'TASK781 C32 refuses a failed deferred retry marker with a different generation' {
         $fixture = New-Task781RuntimeFixture
         $fixture.Registry.panes[0].state = 'deferred'
@@ -3996,18 +4026,36 @@ panes:
         @($roles | Where-Object { $_ -cne 'worker' }).Count | Should -Be 0
     }
 
-    It 'TASK781 skips unrelated incomplete process rows but rejects duplicate process IDs' {
+    It 'TASK781 retains incomplete live process rows as unverifiable identities and rejects duplicate process IDs' {
         $resolver = New-WinsmuxProcessSnapshotResolver -Snapshots @(
             [PSCustomObject]@{ ProcessId = 999; ParentProcessId = $null; CreationDate = $null; Name = '' }
             [PSCustomObject]@{ ProcessId = 4300; ParentProcessId = 4200; CreationDate = [datetime]'2026-07-15T00:00:02Z'; Name = 'codex.exe' }
         )
         (& $resolver 4300).Id | Should -Be 4300
-        (& $resolver 999) | Should -BeNullOrEmpty
+        $incomplete = & $resolver 999
+        $incomplete.Id | Should -Be 999
+        (Test-WinsmuxStrictProcessIdentity -ProcessId 999 -ExpectedStartTime '2026-07-15T00:00:01.0000000Z' -ProcessResolver $resolver) |
+            Should -BeFalse
 
         { New-WinsmuxProcessSnapshotResolver -Snapshots @(
                 [PSCustomObject]@{ ProcessId = 4300; ParentProcessId = 4200; CreationDate = [datetime]'2026-07-15T00:00:02Z'; Name = 'codex.exe' }
                 [PSCustomObject]@{ ProcessId = 4300; ParentProcessId = 1; CreationDate = [datetime]'2026-07-15T00:00:03Z'; Name = 'codex.exe' }
             ) } | Should -Throw '*duplicate process identity*'
+    }
+
+    It 'TASK781 refuses expired registry replacement when the live owner identity is incomplete' {
+        $fixture = New-Task781RuntimeFixture
+        $fixture.Registry.lease.expires_at = '2026-07-15T00:04:00.0000000Z'
+        $fixture.ProcessResolver = {
+            param([int]$Id)
+            if ($Id -eq 4100) {
+                return [PSCustomObject]@{ Id = 4100; ParentProcessId = 1; StartTime = ''; Name = 'pwsh.exe' }
+            }
+            return $null
+        }
+
+        (Test-WinsmuxRuntimeRegistryReplacementAllowed -Registry $fixture.Registry -ProcessResolver $fixture.ProcessResolver `
+            -Now ([datetime]'2026-07-15T00:05:00Z')) | Should -BeFalse
     }
 }
 
@@ -9388,6 +9436,29 @@ Describe 'orchestra-start server bootstrap' {
 
     It 'retires background state and deletes the old manifest before replacement generation creation' {
         $script:retiredManifestSequence = [System.Collections.Generic.List[string]]::new()
+        $script:retiredRegistryClosed = $false
+        Mock Get-WinsmuxManifest {
+            [PSCustomObject]@{
+                session = [PSCustomObject]@{
+                    name = 'winsmux-orchestra'; generation_id = 'generation-retired'
+                    server_session_id = '$41'; supervisor_pid = 4201
+                }
+            }
+        }
+        Mock Read-WinsmuxRuntimeRegistry {
+            [PSCustomObject]@{
+                status = if ($script:retiredRegistryClosed) { 'ended' } else { 'active' }
+                session_name = 'winsmux-orchestra'; generation_id = 'generation-retired'; server_session_id = '$41'
+                supervisor = [PSCustomObject]@{ pid = 4201; process_started_at = '2026-07-16T04:00:00.0000000Z' }
+                lease = [PSCustomObject]@{ state = if ($script:retiredRegistryClosed) { 'ended' } else { 'active' }; expires_at = '2026-07-16T04:00:15.0000000Z' }
+            }
+        }
+        Mock New-WinsmuxProcessSnapshotResolver {
+            {
+                param([int]$Id)
+                [PSCustomObject]@{ Id = $Id; StartTime = '2026-07-16T04:00:00.0000000Z' }
+            }
+        }
         Mock Remove-OrchestraSessionServerProcesses {
             $script:retiredManifestSequence.Add('matched-processes-retired') | Out-Null
             return [PSCustomObject]@{ SessionProcesses = @(); Killed = @(); RemainingSessionProcesses = @(); Errors = @() }
@@ -9400,6 +9471,17 @@ Describe 'orchestra-start server bootstrap' {
             $script:retiredManifestSequence.Add('backgrounds-retired') | Out-Null
             return [PSCustomObject]@{ Stopped = @([PSCustomObject]@{ pid = 42 }); Errors = @() }
         }
+        Mock Close-WinsmuxRuntimeRegistry {
+            param($ProjectDir, $GenerationId, $SupervisorPid, $SupervisorProcessStartedAt, $ExpectedSessionName, $ExpectedServerSessionId)
+            $GenerationId | Should -BeExactly 'generation-retired'
+            $SupervisorPid | Should -Be 4201
+            $SupervisorProcessStartedAt | Should -BeExactly '2026-07-16T04:00:00.0000000Z'
+            $ExpectedSessionName | Should -BeExactly 'winsmux-orchestra'
+            $ExpectedServerSessionId | Should -BeExactly '$41'
+            $script:retiredRegistryClosed = $true
+            $script:retiredManifestSequence.Add('registry-ended') | Out-Null
+            return $true
+        }
         Mock Clear-WinsmuxManifest {
             $script:retiredManifestSequence.Add('manifest-cleared') | Out-Null
             return $true
@@ -9409,10 +9491,335 @@ Describe 'orchestra-start server bootstrap' {
             -ProjectDir 'C:\project' -GitWorktreeDir 'C:\project' `
             -BridgeScript 'C:\project\scripts\winsmux-core.ps1' -SessionName 'winsmux-orchestra' -WinsmuxBin 'winsmux'
 
-        @($script:retiredManifestSequence) | Should -Be @('matched-processes-retired', 'server-absent', 'backgrounds-retired', 'manifest-cleared')
+        @($script:retiredManifestSequence) | Should -Be @('matched-processes-retired', 'server-absent', 'backgrounds-retired', 'registry-ended', 'manifest-cleared')
+        $result.RegistryClosed | Should -BeTrue
         $result.Cleared | Should -BeTrue
         @($result.Stopped).Count | Should -Be 1
         @($result.Errors).Count | Should -Be 0
+    }
+
+    It 'TASK781 C71 refuses a competing active runtime registry before retiring any process' {
+        Mock Get-WinsmuxManifest {
+            [PSCustomObject]@{
+                session = [PSCustomObject]@{
+                    name = 'winsmux-orchestra'; generation_id = 'generation-retired'
+                    server_session_id = '$41'; supervisor_pid = 4201
+                }
+            }
+        }
+        Mock Read-WinsmuxRuntimeRegistry {
+            [PSCustomObject]@{
+                status = 'active'; session_name = 'winsmux-orchestra'
+                generation_id = 'generation-competing'; server_session_id = '$41'
+                supervisor = [PSCustomObject]@{ pid = 4201; process_started_at = '2026-07-16T04:00:00.0000000Z' }
+                lease = [PSCustomObject]@{ state = 'active'; expires_at = '2026-07-16T04:00:15.0000000Z' }
+            }
+        }
+        Mock Remove-OrchestraSessionServerProcesses { throw 'process retirement must not start' }
+        Mock Wait-OrchestraServerSessionAbsent { throw 'logical retirement must not start' }
+        Mock Stop-OrchestraBackgroundProcessesFromManifest { throw 'background retirement must not start' }
+        Mock Close-WinsmuxRuntimeRegistry { throw 'competing registry must not be closed' }
+        Mock Clear-WinsmuxManifest { throw 'manifest must be preserved' }
+
+        {
+            Clear-OrchestraManifestAfterServerRetirement `
+                -ProjectDir 'C:\project' -GitWorktreeDir 'C:\project' `
+                -BridgeScript 'C:\project\scripts\winsmux-core.ps1' -SessionName 'winsmux-orchestra' -WinsmuxBin 'winsmux'
+        } | Should -Throw '*runtime registry identity does not match*'
+
+        Should -Invoke Remove-OrchestraSessionServerProcesses -Times 0 -Exactly
+        Should -Invoke Stop-OrchestraBackgroundProcessesFromManifest -Times 0 -Exactly
+        Should -Invoke Close-WinsmuxRuntimeRegistry -Times 0 -Exactly
+        Should -Invoke Clear-WinsmuxManifest -Times 0 -Exactly
+    }
+
+    It 'TASK781 C71 refuses a foreign manifest session before retiring any process even without a registry' {
+        Mock Get-WinsmuxManifest {
+            [PSCustomObject]@{
+                session = [PSCustomObject]@{
+                    name = 'winsmux-foreign'; generation_id = 'generation-retired'
+                    server_session_id = '$41'; supervisor_pid = 4201
+                }
+            }
+        }
+        Mock Read-WinsmuxRuntimeRegistry { $null }
+        Mock Remove-OrchestraSessionServerProcesses { throw 'process retirement must not start' }
+        Mock Wait-OrchestraServerSessionAbsent { throw 'logical retirement must not start' }
+        Mock Stop-OrchestraBackgroundProcessesFromManifest { throw 'background retirement must not start' }
+        Mock Clear-WinsmuxManifest { throw 'foreign manifest must be preserved' }
+
+        {
+            Clear-OrchestraManifestAfterServerRetirement `
+                -ProjectDir 'C:\project' -GitWorktreeDir 'C:\project' `
+                -BridgeScript 'C:\project\scripts\winsmux-core.ps1' -SessionName 'winsmux-orchestra' -WinsmuxBin 'winsmux'
+        } | Should -Throw '*manifest session identity does not match*'
+
+        Should -Invoke Remove-OrchestraSessionServerProcesses -Times 0 -Exactly
+        Should -Invoke Stop-OrchestraBackgroundProcessesFromManifest -Times 0 -Exactly
+        Should -Invoke Clear-WinsmuxManifest -Times 0 -Exactly
+    }
+
+    It 'TASK781 C71 refuses a reused supervisor PID before retiring any process' {
+        Mock Get-WinsmuxManifest {
+            [PSCustomObject]@{
+                session = [PSCustomObject]@{
+                    name = 'winsmux-orchestra'; generation_id = 'generation-retired'
+                    server_session_id = '$41'; supervisor_pid = 4201
+                }
+            }
+        }
+        Mock Read-WinsmuxRuntimeRegistry {
+            [PSCustomObject]@{
+                status = 'active'; session_name = 'winsmux-orchestra'
+                generation_id = 'generation-retired'; server_session_id = '$41'
+                supervisor = [PSCustomObject]@{ pid = 4201; process_started_at = '2026-07-16T04:00:00.0000000Z' }
+                lease = [PSCustomObject]@{ state = 'active'; expires_at = '2026-07-16T04:00:15.0000000Z' }
+            }
+        }
+        Mock New-WinsmuxProcessSnapshotResolver {
+            {
+                param([int]$Id)
+                [PSCustomObject]@{ Id = $Id; StartTime = '2026-07-16T04:00:01.0000000Z' }
+            }
+        }
+        Mock Remove-OrchestraSessionServerProcesses { throw 'process retirement must not start' }
+        Mock Wait-OrchestraServerSessionAbsent { throw 'logical retirement must not start' }
+        Mock Stop-OrchestraBackgroundProcessesFromManifest { throw 'background retirement must not start' }
+        Mock Close-WinsmuxRuntimeRegistry { throw 'reused PID registry must not be closed' }
+        Mock Clear-WinsmuxManifest { throw 'manifest must be preserved' }
+
+        {
+            Clear-OrchestraManifestAfterServerRetirement `
+                -ProjectDir 'C:\project' -GitWorktreeDir 'C:\project' `
+                -BridgeScript 'C:\project\scripts\winsmux-core.ps1' -SessionName 'winsmux-orchestra' -WinsmuxBin 'winsmux'
+        } | Should -Throw '*OS process identity does not match*'
+
+        Should -Invoke Remove-OrchestraSessionServerProcesses -Times 0 -Exactly
+        Should -Invoke Close-WinsmuxRuntimeRegistry -Times 0 -Exactly
+        Should -Invoke Clear-WinsmuxManifest -Times 0 -Exactly
+    }
+
+    It 'TASK781 C71 refuses an incomplete live supervisor identity before retiring any process' {
+        Mock Get-WinsmuxManifest {
+            [PSCustomObject]@{
+                session = [PSCustomObject]@{
+                    name = 'winsmux-orchestra'; generation_id = 'generation-retired'
+                    server_session_id = '$41'; supervisor_pid = 4201
+                }
+            }
+        }
+        Mock Read-WinsmuxRuntimeRegistry {
+            [PSCustomObject]@{
+                status = 'active'; session_name = 'winsmux-orchestra'
+                generation_id = 'generation-retired'; server_session_id = '$41'
+                supervisor = [PSCustomObject]@{ pid = 4201; process_started_at = '2026-07-16T04:00:00.0000000Z' }
+                lease = [PSCustomObject]@{ state = 'active'; expires_at = '2026-07-16T04:00:15.0000000Z' }
+            }
+        }
+        Mock Get-CimInstance {
+            [PSCustomObject]@{ ProcessId = 4201; ParentProcessId = 1; CreationDate = $null; Name = 'pwsh.exe' }
+        } -ParameterFilter { $ClassName -eq 'Win32_Process' }
+        Mock Remove-OrchestraSessionServerProcesses { throw 'process retirement must not start' }
+        Mock Wait-OrchestraServerSessionAbsent { throw 'logical retirement must not start' }
+        Mock Stop-OrchestraBackgroundProcessesFromManifest { throw 'background retirement must not start' }
+        Mock Close-WinsmuxRuntimeRegistry { throw 'unverifiable registry must not be closed' }
+        Mock Clear-WinsmuxManifest { throw 'manifest must be preserved' }
+
+        {
+            Clear-OrchestraManifestAfterServerRetirement `
+                -ProjectDir 'C:\project' -GitWorktreeDir 'C:\project' `
+                -BridgeScript 'C:\project\scripts\winsmux-core.ps1' -SessionName 'winsmux-orchestra' -WinsmuxBin 'winsmux'
+        } | Should -Throw '*OS process identity does not match*'
+
+        Should -Invoke Remove-OrchestraSessionServerProcesses -Times 0 -Exactly
+        Should -Invoke Close-WinsmuxRuntimeRegistry -Times 0 -Exactly
+        Should -Invoke Clear-WinsmuxManifest -Times 0 -Exactly
+    }
+
+    It 'TASK781 C71 preserves the manifest when the matched runtime registry close is refused' {
+        Mock Get-WinsmuxManifest {
+            [PSCustomObject]@{
+                session = [PSCustomObject]@{
+                    name = 'winsmux-orchestra'; generation_id = 'generation-retired'
+                    server_session_id = '$41'; supervisor_pid = 4201
+                }
+            }
+        }
+        Mock Read-WinsmuxRuntimeRegistry {
+            [PSCustomObject]@{
+                status = 'active'; session_name = 'winsmux-orchestra'
+                generation_id = 'generation-retired'; server_session_id = '$41'
+                supervisor = [PSCustomObject]@{ pid = 4201; process_started_at = '2026-07-16T04:00:00.0000000Z' }
+                lease = [PSCustomObject]@{ state = 'active'; expires_at = '2026-07-16T04:00:15.0000000Z' }
+            }
+        }
+        Mock New-WinsmuxProcessSnapshotResolver { { param([int]$Id) $null } }
+        Mock Remove-OrchestraSessionServerProcesses {
+            [PSCustomObject]@{ SessionProcesses = @(); Killed = @(); RemainingSessionProcesses = @(); Errors = @() }
+        }
+        Mock Wait-OrchestraServerSessionAbsent { [PSCustomObject]@{ Ready = $true; PollAttempt = 1 } }
+        Mock Stop-OrchestraBackgroundProcessesFromManifest {
+            [PSCustomObject]@{ Stopped = @([PSCustomObject]@{ pid = 4201 }); Errors = @() }
+        }
+        Mock Close-WinsmuxRuntimeRegistry { $false }
+        Mock Clear-WinsmuxManifest { throw 'manifest must be preserved after close refusal' }
+
+        {
+            Clear-OrchestraManifestAfterServerRetirement `
+                -ProjectDir 'C:\project' -GitWorktreeDir 'C:\project' `
+                -BridgeScript 'C:\project\scripts\winsmux-core.ps1' -SessionName 'winsmux-orchestra' -WinsmuxBin 'winsmux'
+        } | Should -Throw '*retirement was refused because ownership changed*'
+
+        Should -Invoke Close-WinsmuxRuntimeRegistry -Times 1 -Exactly
+        Should -Invoke Clear-WinsmuxManifest -Times 0 -Exactly
+    }
+
+    It 'TASK781 C71 accepts an absent registry as the legacy retirement path' {
+        Mock Get-WinsmuxManifest { $null }
+        Mock Read-WinsmuxRuntimeRegistry { $null }
+        Mock Remove-OrchestraSessionServerProcesses {
+            [PSCustomObject]@{ SessionProcesses = @(); Killed = @(); RemainingSessionProcesses = @(); Errors = @() }
+        }
+        Mock Wait-OrchestraServerSessionAbsent { [PSCustomObject]@{ Ready = $true; PollAttempt = 1 } }
+        Mock Stop-OrchestraBackgroundProcessesFromManifest {
+            [PSCustomObject]@{ Stopped = @(); Errors = @() }
+        }
+        Mock Close-WinsmuxRuntimeRegistry { throw 'absent registry must not be closed' }
+        Mock Clear-WinsmuxManifest { $false }
+
+        $result = Clear-OrchestraManifestAfterServerRetirement `
+            -ProjectDir 'C:\project' -GitWorktreeDir 'C:\project' `
+            -BridgeScript 'C:\project\scripts\winsmux-core.ps1' -SessionName 'winsmux-orchestra' -WinsmuxBin 'winsmux'
+
+        $result.RegistryPresent | Should -BeFalse
+        $result.RegistryClosed | Should -BeFalse
+        Should -Invoke Close-WinsmuxRuntimeRegistry -Times 0 -Exactly
+        Should -Invoke Clear-WinsmuxManifest -Times 1 -Exactly
+    }
+
+    It 'TASK781 C72 retires a nameless v1 manifest as an explicit upgrade compatibility path' {
+        $script:c72Sequence = [System.Collections.Generic.List[string]]::new()
+        Mock Get-WinsmuxManifest {
+            [PSCustomObject]@{
+                version = 1
+                session = [PSCustomObject]@{
+                    started = '2026-07-01T00:00:00Z'
+                    project_dir = 'C:\project'
+                }
+                panes = [ordered]@{}
+            }
+        }
+        Mock Read-WinsmuxRuntimeRegistry { $null }
+        Mock Remove-OrchestraSessionServerProcesses {
+            $script:c72Sequence.Add('server-processes-retired') | Out-Null
+            [PSCustomObject]@{ SessionProcesses = @(); Killed = @(); RemainingSessionProcesses = @(); Errors = @() }
+        }
+        Mock Wait-OrchestraServerSessionAbsent {
+            $script:c72Sequence.Add('server-absent') | Out-Null
+            [PSCustomObject]@{ Ready = $true; PollAttempt = 1 }
+        }
+        Mock Stop-OrchestraBackgroundProcessesFromManifest {
+            $script:c72Sequence.Add('backgrounds-retired') | Out-Null
+            [PSCustomObject]@{ Stopped = @(); Errors = @() }
+        }
+        Mock Close-WinsmuxRuntimeRegistry { throw 'v1 upgrade path has no registry to close' }
+        Mock Clear-WinsmuxManifest {
+            $script:c72Sequence.Add('manifest-cleared') | Out-Null
+            $true
+        }
+
+        $result = Clear-OrchestraManifestAfterServerRetirement `
+            -ProjectDir 'C:\project' -GitWorktreeDir 'C:\project' `
+            -BridgeScript 'C:\project\scripts\winsmux-core.ps1' -SessionName 'winsmux-orchestra' -WinsmuxBin 'winsmux'
+
+        @($script:c72Sequence) | Should -Be @('server-processes-retired', 'server-absent', 'backgrounds-retired', 'manifest-cleared')
+        $result.RegistryPresent | Should -BeFalse
+        $result.Cleared | Should -BeTrue
+        Should -Invoke Close-WinsmuxRuntimeRegistry -Times 0 -Exactly
+    }
+
+    It 'TASK781 C72 keeps the nameless legacy exception version-scoped and target-scoped' {
+        Mock Get-WinsmuxManifest { $script:c72RejectedManifest }
+        Mock Read-WinsmuxRuntimeRegistry { $null }
+        Mock Remove-OrchestraSessionServerProcesses { throw 'rejected manifest must not retire processes' }
+        Mock Wait-OrchestraServerSessionAbsent { throw 'rejected manifest must not wait for retirement' }
+        Mock Stop-OrchestraBackgroundProcessesFromManifest { throw 'rejected manifest must not retire backgrounds' }
+        Mock Clear-WinsmuxManifest { throw 'rejected manifest must be preserved' }
+
+        $cases = @(
+            [PSCustomObject]@{ version = 1; session = [PSCustomObject]@{ name = 'foreign-session' } }
+            [PSCustomObject]@{ version = 2; session = [PSCustomObject]@{} }
+            [PSCustomObject]@{ version = 99; session = [PSCustomObject]@{} }
+            [PSCustomObject]@{ session = [PSCustomObject]@{} }
+        )
+        foreach ($case in $cases) {
+            $script:c72RejectedManifest = $case
+            {
+                Clear-OrchestraManifestAfterServerRetirement `
+                    -ProjectDir 'C:\project' -GitWorktreeDir 'C:\project' `
+                    -BridgeScript 'C:\project\scripts\winsmux-core.ps1' -SessionName 'winsmux-orchestra' -WinsmuxBin 'winsmux'
+            } | Should -Throw '*manifest session identity does not match*'
+        }
+
+        Should -Invoke Remove-OrchestraSessionServerProcesses -Times 0 -Exactly
+        Should -Invoke Stop-OrchestraBackgroundProcessesFromManifest -Times 0 -Exactly
+        Should -Invoke Clear-WinsmuxManifest -Times 0 -Exactly
+    }
+
+    It 'TASK781 C72 refuses a nameless v1 manifest when an active registry cannot be ownership-matched' {
+        Mock Get-WinsmuxManifest {
+            [PSCustomObject]@{ version = 1; session = [PSCustomObject]@{ started = '2026-07-01T00:00:00Z' } }
+        }
+        Mock Read-WinsmuxRuntimeRegistry {
+            [PSCustomObject]@{
+                status = 'active'; session_name = 'winsmux-orchestra'
+                generation_id = 'unverifiable-generation'; server_session_id = '$72'
+                supervisor = [PSCustomObject]@{ pid = 4272; process_started_at = '2026-07-16T06:00:00.0000000Z' }
+                lease = [PSCustomObject]@{ state = 'active'; expires_at = '2026-07-16T06:00:15.0000000Z' }
+            }
+        }
+        Mock Remove-OrchestraSessionServerProcesses { throw 'unmatched active registry must block process retirement' }
+        Mock Stop-OrchestraBackgroundProcessesFromManifest { throw 'unmatched active registry must block background retirement' }
+        Mock Clear-WinsmuxManifest { throw 'unmatched active registry must preserve the manifest' }
+
+        {
+            Clear-OrchestraManifestAfterServerRetirement `
+                -ProjectDir 'C:\project' -GitWorktreeDir 'C:\project' `
+                -BridgeScript 'C:\project\scripts\winsmux-core.ps1' -SessionName 'winsmux-orchestra' -WinsmuxBin 'winsmux'
+        } | Should -Throw '*runtime registry identity does not match*'
+
+        Should -Invoke Remove-OrchestraSessionServerProcesses -Times 0 -Exactly
+        Should -Invoke Stop-OrchestraBackgroundProcessesFromManifest -Times 0 -Exactly
+        Should -Invoke Clear-WinsmuxManifest -Times 0 -Exactly
+    }
+
+    It 'TASK781 C72 completes the production background-cleanup boundary for a tokenless v1 upgrade' {
+        Mock Get-WinsmuxManifest {
+            [PSCustomObject]@{
+                version = 1
+                session = [PSCustomObject]@{ started = '2026-07-01T00:00:00Z'; project_dir = 'C:\project' }
+                panes = [ordered]@{}
+            }
+        }
+        Mock Read-WinsmuxRuntimeRegistry { $null }
+        Mock Remove-OrchestraSessionServerProcesses {
+            [PSCustomObject]@{ SessionProcesses = @(); Killed = @(); RemainingSessionProcesses = @(); Errors = @() }
+        }
+        Mock Wait-OrchestraServerSessionAbsent { [PSCustomObject]@{ Ready = $true; PollAttempt = 1 } }
+        Mock Get-ProcessSnapshot { throw 'tokenless v1 cleanup must not inspect arbitrary processes' }
+        Mock Stop-Process { throw 'tokenless v1 cleanup must not stop arbitrary processes' }
+        Mock Clear-WinsmuxManifest { $true }
+
+        $result = Clear-OrchestraManifestAfterServerRetirement `
+            -ProjectDir 'C:\project' -GitWorktreeDir 'C:\project' `
+            -BridgeScript 'C:\project\scripts\winsmux-core.ps1' -SessionName 'winsmux-orchestra' -WinsmuxBin 'winsmux'
+
+        $result.Cleared | Should -BeTrue
+        @($result.Stopped).Count | Should -Be 0
+        @($result.Errors).Count | Should -Be 0
+        Should -Invoke Get-ProcessSnapshot -Times 0 -Exactly
+        Should -Invoke Stop-Process -Times 0 -Exactly
+        Should -Invoke Clear-WinsmuxManifest -Times 1 -Exactly
     }
 
     It 'does not clear the old manifest while the retired server remains observable' {
@@ -9899,16 +10306,17 @@ Describe 'orchestra-start session reuse contract' {
             $env:APPDATA = $tempAppData
             $labelsPath = Join-Path $tempAppData 'winsmux\labels.json'
             New-Item -ItemType Directory -Path (Split-Path -Parent $labelsPath) -Force | Out-Null
-            [System.IO.File]::WriteAllText($labelsPath, '{"existing":"%9"}', [System.Text.UTF8Encoding]::new($false))
+            [System.IO.File]::WriteAllText($labelsPath, '{"existing":"%9","worker-1":"%99"}', [System.Text.UTF8Encoding]::new($false))
 
             $result = Publish-OrchestraPaneLabels -PaneSummaries @(
-                [ordered]@{ PaneId = '%2'; Title = 'W1 Codex Reviewer' }
-                [ordered]@{ PaneId = '%3'; Title = 'worker-2' }
+                [ordered]@{ Label = 'worker-1'; SlotId = 'worker-1'; PaneId = '%2'; Title = 'W1 Codex Reviewer' }
+                [ordered]@{ Label = 'worker-2'; SlotId = 'worker-2'; PaneId = '%3'; Title = 'worker-2' }
             )
             $published = Get-Content -LiteralPath $labelsPath -Raw -Encoding UTF8 | ConvertFrom-Json
 
             $result.PublishedCount | Should -Be 2
             $published.existing | Should -Be '%9'
+            $published.'worker-1' | Should -Be '%2'
             $published.'W1 Codex Reviewer' | Should -Be '%2'
             $published.'worker-2' | Should -Be '%3'
         } finally {
@@ -9924,14 +10332,51 @@ Describe 'orchestra-start session reuse contract' {
             $env:APPDATA = $tempAppData
             {
                 Publish-OrchestraPaneLabels -PaneSummaries @(
-                    [ordered]@{ PaneId = '%2'; Title = 'worker' }
-                    [ordered]@{ PaneId = '%3'; Title = 'worker' }
+                    [ordered]@{ Label = 'worker-1'; SlotId = 'worker-1'; PaneId = '%2'; Title = 'worker' }
+                    [ordered]@{ Label = 'worker-2'; SlotId = 'worker-2'; PaneId = '%3'; Title = 'worker' }
                 )
             } | Should -Throw '*unique non-empty titles*'
             Test-Path -LiteralPath (Join-Path $tempAppData 'winsmux\labels.json') | Should -BeFalse
         } finally {
             $env:APPDATA = $previousAppData
             if (Test-Path -LiteralPath $tempAppData) { Remove-Item -LiteralPath $tempAppData -Recurse -Force }
+        }
+    }
+
+    It 'TASK781 C74 rejects a slot alias collision before creating a label file' {
+        $tempAppData = Join-Path ([System.IO.Path]::GetTempPath()) ('winsmux-slot-label-reject-' + [guid]::NewGuid().ToString('N'))
+        $previousAppData = $env:APPDATA
+        try {
+            $env:APPDATA = $tempAppData
+            {
+                Publish-OrchestraPaneLabels -PaneSummaries @(
+                    [ordered]@{ Label = 'worker'; SlotId = 'worker-1'; PaneId = '%2'; Title = 'W1' }
+                    [ordered]@{ Label = 'WORKER'; SlotId = 'worker-2'; PaneId = '%3'; Title = 'W2' }
+                )
+            } | Should -Throw '*unique non-empty titles and slot labels*'
+            Test-Path -LiteralPath (Join-Path $tempAppData 'winsmux\labels.json') | Should -BeFalse
+        } finally {
+            $env:APPDATA = $previousAppData
+            if (Test-Path -LiteralPath $tempAppData) { Remove-Item -LiteralPath $tempAppData -Recurse -Force }
+        }
+    }
+
+    It 'TASK781 C74 rejects a missing Label or SlotId before publishing any alias' {
+        $previousAppData = $env:APPDATA
+        try {
+            foreach ($case in @(
+                    [ordered]@{ Label = ''; SlotId = 'worker-1'; PaneId = '%2'; Title = 'W1' },
+                    [ordered]@{ Label = 'worker-1'; SlotId = ''; PaneId = '%2'; Title = 'W1' }
+                )) {
+                $tempAppData = Join-Path ([System.IO.Path]::GetTempPath()) ('winsmux-slot-label-missing-' + [guid]::NewGuid().ToString('N'))
+                $env:APPDATA = $tempAppData
+                { Publish-OrchestraPaneLabels -PaneSummaries @($case) } |
+                    Should -Throw '*non-empty slot labels*'
+                Test-Path -LiteralPath (Join-Path $tempAppData 'winsmux\labels.json') | Should -BeFalse
+                if (Test-Path -LiteralPath $tempAppData) { Remove-Item -LiteralPath $tempAppData -Recurse -Force }
+            }
+        } finally {
+            $env:APPDATA = $previousAppData
         }
     }
 
@@ -10004,7 +10449,7 @@ Describe 'orchestra-start session reuse contract' {
         $startupSequence | Should -Not -Match 'Remove-OrchestraSessionServerProcesses'
         $startupSequence | Should -Not -Match '\$requiresManifestRetirement'
         ([regex]::Matches($startupSequence, 'Clear-OrchestraManifestAfterServerRetirement')).Count | Should -Be 1
-        $script:orchestraStartContent | Should -Match '(?s)function Clear-OrchestraManifestAfterServerRetirement.*?Remove-OrchestraSessionServerProcesses.*?Wait-OrchestraServerSessionAbsent.*?Stop-OrchestraBackgroundProcessesFromManifest.*?Clear-WinsmuxManifest'
+        $script:orchestraStartContent | Should -Match '(?s)function Clear-OrchestraManifestAfterServerRetirement.*?Get-OrchestraRuntimeRegistryRetirementPlan.*?Remove-OrchestraSessionServerProcesses.*?Wait-OrchestraServerSessionAbsent.*?Stop-OrchestraBackgroundProcessesFromManifest.*?Complete-OrchestraRuntimeRegistryRetirement.*?Clear-WinsmuxManifest'
     }
 
     It 'suppresses warm servers and trims excess warm processes during managed startup' {
@@ -10325,6 +10770,8 @@ Describe 'orchestra-start rollback helpers' {
     }
 
     It 'TASK781 C66 clears only the manifest generation published by this startup attempt' {
+        $script:rollbackSequence = [System.Collections.Generic.List[string]]::new()
+        $script:rollbackRegistryClosed = $false
         Mock Invoke-Winsmux { @('%1') } -ParameterFilter {
             $Arguments[0] -eq 'list-panes'
         }
@@ -10333,7 +10780,24 @@ Describe 'orchestra-start rollback helpers' {
         }
         Mock Wait-PaneShellReady { }
         Mock Remove-OrchestraCreatedWorktrees { @() }
-        Mock Clear-WinsmuxManifest { $true }
+        Mock Read-WinsmuxRuntimeRegistry {
+            [PSCustomObject]@{
+                status = if ($script:rollbackRegistryClosed) { 'ended' } else { 'active' }
+                session_name = 'winsmux-orchestra'; generation_id = 'owned-generation'; server_session_id = '$41'
+                supervisor = [PSCustomObject]@{ pid = 4201; process_started_at = '2026-07-16T04:00:00.0000000Z' }
+                lease = [PSCustomObject]@{ state = if ($script:rollbackRegistryClosed) { 'ended' } else { 'active' }; expires_at = '2026-07-16T04:00:15.0000000Z' }
+            }
+        }
+        Mock New-WinsmuxProcessSnapshotResolver { { param([int]$Id) $null } }
+        Mock Close-WinsmuxRuntimeRegistry {
+            $script:rollbackRegistryClosed = $true
+            $script:rollbackSequence.Add('registry-ended') | Out-Null
+            return $true
+        }
+        Mock Clear-WinsmuxManifest {
+            $script:rollbackSequence.Add('manifest-cleared') | Out-Null
+            return $true
+        }
 
         $rollback = Invoke-OrchestraStartupRollback `
             -ProjectDir $script:orchestraStartTempRoot `
@@ -10343,9 +10807,19 @@ Describe 'orchestra-start rollback helpers' {
             -CreatedWorktrees @() `
             -FailureMessage 'post-publication failure' `
             -ManifestPublished `
-            -OwnedGenerationId 'owned-generation'
+            -OwnedGenerationId 'owned-generation' `
+            -OwnedServerSessionId '$41' `
+            -OwnedSupervisorPid 4201 `
+            -OwnedSupervisorProcessStartedAt '2026-07-16T04:00:00.0000000Z'
 
         $rollback.RollbackErrors.Count | Should -Be 0
+        $rollback.RegistryClosed | Should -BeTrue
+        @($script:rollbackSequence) | Should -Be @('registry-ended', 'manifest-cleared')
+        Should -Invoke Close-WinsmuxRuntimeRegistry -Times 1 -Exactly -ParameterFilter {
+            $GenerationId -ceq 'owned-generation' -and $SupervisorPid -eq 4201 -and
+            $SupervisorProcessStartedAt -ceq '2026-07-16T04:00:00.0000000Z' -and
+            $ExpectedSessionName -ceq 'winsmux-orchestra' -and $ExpectedServerSessionId -ceq '$41'
+        }
         Should -Invoke Clear-WinsmuxManifest -Times 1 -Exactly -ParameterFilter {
             $ProjectDir -eq $script:orchestraStartTempRoot -and
             $ExpectedGenerationId -ceq 'owned-generation'
@@ -10407,7 +10881,7 @@ Describe 'orchestra-start rollback helpers' {
         $source = [System.IO.File]::ReadAllText($script:orchestraStartPath, [System.Text.Encoding]::UTF8)
         $source | Should -Match '\$manifestPublished\s*=\s*\$false'
         $source | Should -Match '\$manifestPublished\s*=\s*\$true'
-        $source | Should -Match 'Invoke-OrchestraStartupRollback[^\r\n]+-ManifestPublished:\$manifestPublished[^\r\n]+-OwnedGenerationId \$runtimeGenerationId'
+        $source | Should -Match 'Invoke-OrchestraStartupRollback[^\r\n]+-ManifestPublished:\$manifestPublished[^\r\n]+-OwnedGenerationId \$runtimeGenerationId[^\r\n]+-OwnedServerSessionId \$serverSessionId[^\r\n]+-OwnedSupervisorPid \$rollbackSupervisorPid[^\r\n]+-OwnedSupervisorProcessStartedAt \$supervisorProcessStartedAt'
     }
 
     It 'continues rollback when listing session panes fails and still removes created non-bootstrap panes' {
@@ -28522,6 +28996,25 @@ Describe 'deferred worker startup' {
         Should -Invoke Wait-PaneShellReady -Times 0 -Exactly
         $script:deferredSendCommands.Count | Should -Be 0
         $script:deferredStatusWrites | Should -Be @('ready')
+    }
+
+    It 'TASK781 C73 records readiness timeout as retryable after one deferred bootstrap launch' {
+        $entry = [PSCustomObject]@{
+            Label = 'worker-2'; PaneId = '%3'; Status = 'deferred_start'; BootstrapPlanPath = $script:deferredPlanPath
+            CapabilityAdapter = 'codex'; ProviderTarget = ''; ApprovedLaunch = $null
+        }
+        Mock Wait-DeferredPaneReady { throw 'synthetic deferred readiness timeout' }
+
+        {
+            Start-DeferredPaneFromManifestEntry -ProjectDir $script:deferredTempRoot -ManifestEntry $entry `
+                -ExpectedGenerationId 'generation-deferred'
+        } | Should -Throw '*synthetic deferred readiness timeout*'
+
+        $script:deferredSendCommands.Count | Should -Be 1
+        $script:deferredStatusWrites | Should -Be @('deferred_starting', 'deferred_start_failed')
+        $failure = $script:deferredPropertyWrites[$script:deferredPropertyWrites.Count - 1].Properties
+        $failure['last_failure_stage'] | Should -Be 'readiness_probe'
+        $failure['last_failure_reason'] | Should -Match 'synthetic deferred readiness timeout'
     }
 
     It 'TASK781 C29 leaves non-retryable unconfigured deferred states unchanged' -ForEach @(

--- a/tests/winsmux-bridge.Tests.ps1
+++ b/tests/winsmux-bridge.Tests.ps1
@@ -25626,6 +25626,80 @@ Describe 'winsmux orchestra-smoke command' {
         $result.passed | Should -BeTrue
     }
 
+    It 'TASK781 accepts only known typed safe pre-start blocked harness reasons' {
+        foreach ($reasonCode in @(
+            'manifest_regeneration_required'
+            'invalid_supervisor_identity'
+            'caller_identity_mismatch'
+            'runtime_target_mismatch'
+        )) {
+            $probe = [pscustomobject]@{
+                exit_code = 1
+                error     = ''
+                parsed    = [pscustomobject]@{
+                    smoke_ok               = $false
+                    runtime_valid          = $false
+                    runtime_identity       = [pscustomobject]@{
+                        valid       = $false
+                        reason_code = $reasonCode
+                        diagnostic  = 'regenerate the orchestra session'
+                    }
+                    external_operator_mode = $true
+                    session_ready          = $false
+                    ui_attached            = $false
+                    operator_contract      = [pscustomobject]@{
+                        operator_state   = 'blocked'
+                        can_dispatch     = $false
+                        requires_startup = $true
+                    }
+                }
+            }
+
+            $result = Invoke-TestHarnessSmokeContractEvaluation -SmokeProbe $probe
+
+            $result.passed | Should -BeTrue -Because $reasonCode
+            $result.message | Should -Match 'safe pre-start blocked state' -Because $reasonCode
+        }
+    }
+
+    It 'TASK781 rejects inconsistent pre-start blocked harness states' {
+        $cases = @(
+            [pscustomobject]@{ Name = 'dispatch enabled'; State = 'blocked'; CanDispatch = $true; RequiresStartup = $true; Reason = 'manifest_regeneration_required' }
+            [pscustomobject]@{ Name = 'ready claim'; State = 'ready'; CanDispatch = $false; RequiresStartup = $true; Reason = 'manifest_regeneration_required' }
+            [pscustomobject]@{ Name = 'startup not required'; State = 'blocked'; CanDispatch = $false; RequiresStartup = $false; Reason = 'manifest_regeneration_required' }
+            [pscustomobject]@{ Name = 'missing typed reason'; State = 'blocked'; CanDispatch = $false; RequiresStartup = $true; Reason = '' }
+            [pscustomobject]@{ Name = 'unknown typed reason'; State = 'blocked'; CanDispatch = $false; RequiresStartup = $true; Reason = 'unexpected_runtime_reason' }
+        )
+
+        foreach ($case in $cases) {
+            $probe = [pscustomobject]@{
+                exit_code = 1
+                error     = ''
+                parsed    = [pscustomobject]@{
+                    smoke_ok         = $false
+                    runtime_valid    = $false
+                    runtime_identity = [pscustomobject]@{
+                        valid       = $false
+                        reason_code = $case.Reason
+                    }
+                    external_operator_mode = $true
+                    session_ready   = $false
+                    ui_attached     = $false
+                    operator_contract = [pscustomobject]@{
+                        operator_state   = $case.State
+                        can_dispatch     = $case.CanDispatch
+                        requires_startup = $case.RequiresStartup
+                    }
+                }
+            }
+
+            $result = Invoke-TestHarnessSmokeContractEvaluation -SmokeProbe $probe
+
+            $result.passed | Should -BeFalse -Because $case.Name
+            $result.message | Should -Match 'not a safe pre-start blocked state' -Because $case.Name
+        }
+    }
+
     It 'TASK781 makes harness and doctor fail when smoke or runtime identity is invalid' {
         $harnessContent = Get-Content -LiteralPath (Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\harness-check.ps1') -Raw -Encoding UTF8
         $doctorContent = Get-Content -LiteralPath (Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\doctor.ps1') -Raw -Encoding UTF8
@@ -25634,6 +25708,7 @@ Describe 'winsmux orchestra-smoke command' {
         $harnessContent | Should -Match '\$exitCode -ne 0'
         $harnessContent | Should -Match 'smoke_ok=false'
         $harnessContent | Should -Match 'runtime_valid'
+        $harnessContent | Should -Match 'safe pre-start blocked state'
         $doctorContent | Should -Match '\$resultOk = \$exitCode -eq 0 -and \$smokeOk -and \$runtimeValid'
         $doctorContent | Should -Match '\$status = if \(\$null -ne \$smoke\.Data\) \{ ''fail'' \} else \{ ''warn'' \}'
     }

--- a/winsmux-core/scripts/agent-monitor.ps1
+++ b/winsmux-core/scripts/agent-monitor.ps1
@@ -1015,6 +1015,7 @@ function Invoke-AgentRespawn {
         [Parameter(Mandatory = $true)][string]$GitWorktreeDir,
         [string]$RootPath = '',
         [string]$ManifestPath = '',
+        [AllowEmptyString()][string]$ExpectedGenerationId = '',
         [int]$ReadyTimeoutSeconds = 60
     )
 
@@ -1118,7 +1119,8 @@ function Invoke-AgentRespawn {
                 try {
                     $paneLabel = Get-MonitorPaneTitle -PaneId $PaneId
                     if (-not [string]::IsNullOrWhiteSpace($paneLabel)) {
-                        Update-MonitorManifestPaneLabel -ManifestPath $ManifestPath -PaneId $PaneId -Label $paneLabel | Out-Null
+                        Update-MonitorManifestPaneLabel -ManifestPath $ManifestPath -PaneId $PaneId -Label $paneLabel `
+                            -ExpectedGenerationId $ExpectedGenerationId | Out-Null
                     }
                 } catch {
                 }
@@ -1196,7 +1198,8 @@ function Update-MonitorManifestPaneLabel {
     param(
         [Parameter(Mandatory = $true)][string]$ManifestPath,
         [Parameter(Mandatory = $true)][string]$PaneId,
-        [Parameter(Mandatory = $true)][string]$Label
+        [Parameter(Mandatory = $true)][string]$Label,
+        [AllowEmptyString()][string]$ExpectedGenerationId = ''
     )
 
     if ([string]::IsNullOrWhiteSpace($Label) -or -not (Test-Path -LiteralPath $ManifestPath -PathType Leaf)) {
@@ -1204,7 +1207,8 @@ function Update-MonitorManifestPaneLabel {
     }
 
     try {
-        Set-PaneControlManifestPaneProperties -ManifestPath $ManifestPath -PaneId $PaneId -Properties ([ordered]@{ label = $Label })
+        Set-PaneControlManifestPaneProperties -ManifestPath $ManifestPath -PaneId $PaneId `
+            -Properties ([ordered]@{ label = $Label }) -ExpectedGenerationId $ExpectedGenerationId
         return $true
     } catch {
         return $false
@@ -1245,6 +1249,7 @@ function Invoke-AgentMonitorCycle {
 
     # Parse manifest (orchestra-start format: session + panes list)
     $manifest = ConvertFrom-MonitorManifest -Content $content
+    $expectedGenerationId = [string](Get-MonitorPropertyValue -InputObject $manifest.Session -Name 'generation_id' -Default '')
 
     if ($null -eq $manifest -or $manifest.Panes.Count -eq 0) {
         return [ordered]@{
@@ -1636,7 +1641,8 @@ function Invoke-AgentMonitorCycle {
                 -ProjectDir $launchDir `
                 -GitWorktreeDir $launchGitWorktreeDir `
                 -RootPath $projectDir `
-                -ManifestPath $ManifestPath
+                -ManifestPath $ManifestPath `
+                -ExpectedGenerationId $expectedGenerationId
 
             $result['Respawned'] = $respawnResult.Success
             $result['Message'] = $respawnResult.Message

--- a/winsmux-core/scripts/builder-queue.ps1
+++ b/winsmux-core/scripts/builder-queue.ps1
@@ -12,6 +12,7 @@ $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
 [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
 
+. (Join-Path $PSScriptRoot 'json-compat.ps1')
 . (Join-Path $PSScriptRoot 'manifest.ps1')
 . (Join-Path $PSScriptRoot 'clm-safe-io.ps1')
 . (Join-Path $PSScriptRoot 'submission-contract.ps1')
@@ -109,14 +110,61 @@ function Get-BuilderQueueManifest {
     return $manifest
 }
 
+function Get-BuilderQueueExpectedGenerationId {
+    param([Parameter(Mandatory = $true)]$Manifest)
+
+    if ($null -eq $Manifest) {
+        return ''
+    }
+    $session = Get-PaneControlValue -InputObject $Manifest -Name 'session' -Default $null
+    return [string](Get-PaneControlValue -InputObject $session -Name 'generation_id' -Default '')
+}
+
+function Get-BuilderQueuePaneContext {
+    param(
+        [Parameter(Mandatory = $true)]$Manifest,
+        [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [Parameter(Mandatory = $true)][string]$BuilderLabel
+    )
+
+    $panes = Get-PaneControlValue -InputObject $Manifest -Name 'panes' -Default $null
+    $pane = $null
+    if ($panes -is [System.Collections.IDictionary]) {
+        if ($panes.Contains($BuilderLabel)) {
+            $pane = $panes[$BuilderLabel]
+        }
+    } elseif ($null -ne $panes -and $null -ne $panes.PSObject) {
+        $paneProperty = $panes.PSObject.Properties[$BuilderLabel]
+        if ($null -ne $paneProperty) {
+            $pane = $paneProperty.Value
+        }
+    }
+    if ($null -eq $pane) {
+        return $null
+    }
+    $paneId = [string](Get-PaneControlValue -InputObject $pane -Name 'pane_id' -Default '')
+    if ([string]::IsNullOrWhiteSpace($paneId)) {
+        return $null
+    }
+
+    return [ordered]@{
+        ManifestPath = Join-Path (Join-Path $ProjectDir '.winsmux') 'manifest.yaml'
+        PaneId = $paneId
+        GenerationId = Get-BuilderQueueExpectedGenerationId -Manifest $Manifest
+    }
+}
+
 function Save-BuilderQueueManifest {
     param(
         [Parameter(Mandatory = $true)][string]$ProjectDir,
-        [Parameter(Mandatory = $true)]$Manifest
+        [Parameter(Mandatory = $true)]$Manifest,
+        [AllowEmptyString()][string]$ExpectedGenerationId = ''
     )
 
     Ensure-ManifestTasksShape -Manifest $Manifest
-    Save-WinsmuxManifest -ProjectDir $ProjectDir -Manifest $Manifest
+    $manifestPath = Join-Path (Join-Path $ProjectDir '.winsmux') 'manifest.yaml'
+    Save-PaneControlManifestDocument -ManifestPath $manifestPath -Manifest $Manifest `
+        -ExpectedGenerationId $ExpectedGenerationId
 }
 
 function Get-BuilderQueueEntries {
@@ -157,23 +205,24 @@ function Remove-BuilderQueueRawEntry {
 
 function Update-BuilderQueuePaneState {
     param(
-        [Parameter(Mandatory = $true)][string]$ProjectDir,
-        [Parameter(Mandatory = $true)][string]$BuilderLabel,
+        [AllowNull()]$PaneContext,
         [Parameter(Mandatory = $true)][System.Collections.IDictionary]$Properties
     )
 
-    if (-not (Get-Command Get-PaneControlManifestEntries -ErrorAction SilentlyContinue) -or
-        -not (Get-Command Set-PaneControlManifestPaneProperties -ErrorAction SilentlyContinue)) {
+    if (-not (Get-Command Set-PaneControlManifestPaneProperties -ErrorAction SilentlyContinue) -or
+        $null -eq $PaneContext) {
         return
     }
 
     try {
-        $entry = @(Get-PaneControlManifestEntries -ProjectDir $ProjectDir | Where-Object { $_.Label -eq $BuilderLabel } | Select-Object -First 1)[0]
-        if ($null -eq $entry -or [string]::IsNullOrWhiteSpace([string]$entry.PaneId)) {
+        if ([string]::IsNullOrWhiteSpace([string]$PaneContext.PaneId) -or
+            [string]::IsNullOrWhiteSpace([string]$PaneContext.ManifestPath)) {
             return
         }
 
-        Set-PaneControlManifestPaneProperties -ManifestPath ([string]$entry.ManifestPath) -PaneId ([string]$entry.PaneId) -Properties $Properties
+        $expectedGenerationId = [string]$PaneContext.GenerationId
+        Set-PaneControlManifestPaneProperties -ManifestPath ([string]$PaneContext.ManifestPath) -PaneId ([string]$PaneContext.PaneId) `
+            -Properties $Properties -ExpectedGenerationId $expectedGenerationId
     } catch {
         # Pane state enrichment is best-effort and must not break queue operation.
     }
@@ -393,9 +442,10 @@ function Add-BuilderQueueTask {
     )
 
     $manifest = Get-BuilderQueueManifest -ProjectDir $ProjectDir
+    $expectedGenerationId = Get-BuilderQueueExpectedGenerationId -Manifest $manifest
     $entry = ConvertTo-BuilderQueueEntry -BuilderLabel $BuilderLabel -Task $Task
     $manifest.tasks.queued = @($manifest.tasks.queued) + @($entry)
-    Save-BuilderQueueManifest -ProjectDir $ProjectDir -Manifest $manifest
+    Save-BuilderQueueManifest -ProjectDir $ProjectDir -Manifest $manifest -ExpectedGenerationId $expectedGenerationId
 
     return [PSCustomObject]@{
         TaskId       = (ConvertFrom-BuilderQueueEntry -Entry $entry).TaskId
@@ -469,7 +519,7 @@ function Test-BuilderQueueDispatchEvidence {
     }
     try {
         $packet = Read-WinsmuxSubmissionPacket -Path $packetPath
-        $runRecord = Get-Content -LiteralPath $runPath -Raw -Encoding UTF8 | ConvertFrom-Json -Depth 16
+        $runRecord = Get-Content -LiteralPath $runPath -Raw -Encoding UTF8 | ConvertFrom-WinsmuxJson -Depth 16
     } catch {
         return $false
     }
@@ -494,6 +544,8 @@ function Dispatch-NextBuilderQueueTask {
     )
 
     $manifest = Get-BuilderQueueManifest -ProjectDir $ProjectDir
+    $expectedGenerationId = Get-BuilderQueueExpectedGenerationId -Manifest $manifest
+    $paneContext = Get-BuilderQueuePaneContext -Manifest $manifest -ProjectDir $ProjectDir -BuilderLabel $BuilderLabel
     $current = @(Get-BuilderQueueEntries -Manifest $manifest -State 'in_progress' -BuilderLabel $BuilderLabel)
     if ($current.Count -gt 0) {
         return [PSCustomObject]@{
@@ -568,8 +620,8 @@ function Dispatch-NextBuilderQueueTask {
             Where-Object { (ConvertFrom-BuilderQueueEntry -Entry ([string]$_)).TaskId -cne $nextEntry.TaskId }
     )
     $manifest.tasks.in_progress = (@($manifest.tasks.in_progress) + @($nextEntry.RawEntry))
-    Save-BuilderQueueManifest -ProjectDir $ProjectDir -Manifest $manifest
-    Update-BuilderQueuePaneState -ProjectDir $ProjectDir -BuilderLabel $BuilderLabel -Properties ([ordered]@{
+    Save-BuilderQueueManifest -ProjectDir $ProjectDir -Manifest $manifest -ExpectedGenerationId $expectedGenerationId
+    Update-BuilderQueuePaneState -PaneContext $paneContext -Properties ([ordered]@{
         task_id            = $nextEntry.TaskId
         task               = $nextEntry.Task
         task_state         = 'in_progress'
@@ -599,6 +651,8 @@ function Complete-BuilderQueueTask {
     )
 
     $manifest = Get-BuilderQueueManifest -ProjectDir $ProjectDir
+    $expectedGenerationId = Get-BuilderQueueExpectedGenerationId -Manifest $manifest
+    $paneContext = Get-BuilderQueuePaneContext -Manifest $manifest -ProjectDir $ProjectDir -BuilderLabel $BuilderLabel
     $inProgress = @(Get-BuilderQueueEntries -Manifest $manifest -State 'in_progress' -BuilderLabel $BuilderLabel)
 
     $completedEntry = if ([string]::IsNullOrWhiteSpace($Task)) {
@@ -615,9 +669,9 @@ function Complete-BuilderQueueTask {
     if (@($manifest.tasks.completed | Where-Object { [string]$_ -eq $completedEntry.RawEntry }).Count -eq 0) {
         $manifest.tasks.completed = (@($manifest.tasks.completed) + @($completedEntry.RawEntry))
     }
-    Save-BuilderQueueManifest -ProjectDir $ProjectDir -Manifest $manifest
+    Save-BuilderQueueManifest -ProjectDir $ProjectDir -Manifest $manifest -ExpectedGenerationId $expectedGenerationId
     Unlock-DispatchFiles -TaskId $completedEntry.TaskId -ProjectDir $ProjectDir | Out-Null
-    Update-BuilderQueuePaneState -ProjectDir $ProjectDir -BuilderLabel $BuilderLabel -Properties ([ordered]@{
+    Update-BuilderQueuePaneState -PaneContext $paneContext -Properties ([ordered]@{
         task_id       = $completedEntry.TaskId
         task          = $completedEntry.Task
         task_state    = 'completed'

--- a/winsmux-core/scripts/clm-safe-io.ps1
+++ b/winsmux-core/scripts/clm-safe-io.ps1
@@ -184,6 +184,7 @@ function Write-WinsmuxTextFile {
     param(
         [Parameter(Mandatory = $true)][string]$Path,
         [AllowEmptyString()][string]$Content = '',
+        [AllowNull()][scriptblock]$ValidateLocked = $null,
         [switch]$Append
     )
 
@@ -194,6 +195,10 @@ function Write-WinsmuxTextFile {
 
     $escapedPath = $Path -replace '"', '""'
     Invoke-WinsmuxWithFileLock -Path $Path -Action {
+        if ($null -ne $ValidateLocked) {
+            & $ValidateLocked
+        }
+
         if ($Append) {
             if ([string]::IsNullOrEmpty($Content)) {
                 return

--- a/winsmux-core/scripts/control-plane-dispatch.ps1
+++ b/winsmux-core/scripts/control-plane-dispatch.ps1
@@ -490,7 +490,8 @@ function Invoke-WinsmuxHarnessCheckCommand {
 
     Invoke-WinsmuxControlPlaneScript `
         -ScriptPath (Get-WinsmuxControlPlaneScriptPath -BridgeScriptRoot $BridgeScriptRoot -ScriptName 'harness-check.ps1') `
-        -Arguments $checkArgs
+        -Arguments $checkArgs `
+        -PropagateExitCode
 }
 
 function Invoke-WinsmuxShadowCutoverGateCommand {

--- a/winsmux-core/scripts/control-plane-dispatch.ps1
+++ b/winsmux-core/scripts/control-plane-dispatch.ps1
@@ -94,9 +94,9 @@ function Invoke-WinsmuxSubmissionAckCommand {
         [AllowNull()][string[]]$CommandRest
     )
 
-    $usage = 'usage: winsmux submission-ack --submission-id <id> --run-id <id> --kind <task|review> --backend <local|codex> --slot <slot>'
+    $usage = 'usage: winsmux submission-ack --submission-id <id> --run-id <id> --kind <task|review> --backend <local|codex> --slot <slot> --ack-pipe <pipe> --challenge <hex>'
     $tokens = @(@($CommandTarget) + @($CommandRest) | Where-Object { $_ })
-    $values = [ordered]@{ submission_id = ''; run_id = ''; kind = ''; backend = ''; slot = '' }
+    $values = [ordered]@{ submission_id = ''; run_id = ''; kind = ''; backend = ''; slot = ''; ack_pipe = ''; challenge = '' }
     for ($index = 0; $index -lt $tokens.Count; $index++) {
         $name = switch ([string]$tokens[$index]) {
             '--submission-id' { 'submission_id' }
@@ -104,20 +104,29 @@ function Invoke-WinsmuxSubmissionAckCommand {
             '--kind' { 'kind' }
             '--backend' { 'backend' }
             '--slot' { 'slot' }
+            '--ack-pipe' { 'ack_pipe' }
+            '--challenge' { 'challenge' }
             default { '' }
         }
         if ([string]::IsNullOrWhiteSpace($name) -or $index + 1 -ge $tokens.Count) {
             Stop-WithError $usage
         }
+        if (-not [string]::IsNullOrWhiteSpace([string]$values[$name])) { Stop-WithError $usage }
         $index++
         $values[$name] = [string]$tokens[$index]
     }
     foreach ($required in $values.Keys) {
         if ([string]::IsNullOrWhiteSpace([string]$values[$required])) { Stop-WithError $usage }
     }
+    if (-not (Test-WinsmuxSubmissionAckPipeName -Value $values.ack_pipe) -or
+        -not (Test-WinsmuxSubmissionAckChallenge -Value $values.challenge)) {
+        Stop-WithError $usage
+    }
     $projectDir = [string]$env:WINSMUX_ORCHESTRA_PROJECT_DIR
     if ([string]::IsNullOrWhiteSpace($projectDir)) { $projectDir = (Get-Location).Path }
-    $receipt = Invoke-WinsmuxSubmissionAcknowledge -ProjectDir $projectDir -SlotId $values.slot -SubmissionId $values.submission_id -RunId $values.run_id -Kind $values.kind -Backend $values.backend
+    $receipt = Invoke-WinsmuxSubmissionAcknowledge -ProjectDir $projectDir -SlotId $values.slot `
+        -SubmissionId $values.submission_id -RunId $values.run_id -Kind $values.kind -Backend $values.backend `
+        -AckPipe $values.ack_pipe -Challenge $values.challenge
     ConvertTo-WinsmuxSubmissionReceiptJson -Receipt $receipt | Write-Output
     if ([string]$receipt.status -ne 'accepted') { exit 1 }
 }
@@ -258,14 +267,43 @@ function Invoke-WinsmuxDispatchTaskCommand {
         $paneId = [string]$manifestEntry.PaneId
     }
 
+    $entryStatus = [string](Get-WinsmuxSubmissionValue -InputObject $manifestEntry -Name 'Status' -Default '')
+    $runtimeOperation = [string](Get-WinsmuxRuntimeStatusClassification -Status $entryStatus).RuntimeOperation
+    $runtimeResult = Test-PaneControlRuntimeContext -ProjectDir $projectDir -ManifestEntry $manifestEntry -Operation $runtimeOperation
+    if (-not $runtimeResult.valid) {
+        $backend = [string](Get-WinsmuxSubmissionValue -InputObject $manifestEntry -Name 'WorkerBackend' -Default 'local')
+        if ($backend -notin @('local', 'codex', 'api_llm', 'antigravity', 'noop')) { $backend = 'noop' }
+        $receipt = New-WinsmuxSubmissionReceipt -Kind task -Status unavailable -Backend $backend -SubmissionId $submissionId `
+            -ReasonCode ([string]$runtimeResult.reason_code) -Diagnostic ([string]$runtimeResult.diagnostic) `
+            -Target ([ordered]@{ label = $selectedLabel; pane_id = $paneId; role = $resolvedRole })
+        ConvertTo-WinsmuxSubmissionReceiptJson -Receipt $receipt | Write-Output
+        exit 1
+    }
+
     try {
-        Start-DeferredPaneFromManifestEntry -ProjectDir $projectDir -ManifestEntry $manifestEntry | Out-Null
+        Start-DeferredPaneFromManifestEntry -ProjectDir $projectDir -ManifestEntry $manifestEntry `
+            -ExpectedGenerationId ([string](Get-WinsmuxSubmissionValue -InputObject $runtimeResult.context -Name 'generation_id' -Default '')) | Out-Null
     } catch {
         $backend = [string](Get-WinsmuxSubmissionValue -InputObject $manifestEntry -Name 'WorkerBackend' -Default 'local')
         if ($backend -notin @('local', 'codex', 'api_llm', 'antigravity', 'noop')) { $backend = 'noop' }
-        $receipt = New-WinsmuxSubmissionReceipt -Kind task -Status unavailable -Backend $backend -SubmissionId $submissionId -ReasonCode 'deferred_start_failed' -Diagnostic $_.Exception.Message -Target ([ordered]@{ label = $selectedLabel; pane_id = $paneId; role = $resolvedRole })
+        $receipt = New-WinsmuxDeferredStartFailureReceipt -Kind task -Backend $backend -SubmissionId $submissionId `
+            -PaneId $paneId -Failure $_ -Target ([ordered]@{ label = $selectedLabel; pane_id = $paneId; role = $resolvedRole })
         ConvertTo-WinsmuxSubmissionReceiptJson -Receipt $receipt | Write-Output
         exit 1
+    }
+
+    if ($runtimeOperation -ceq 'start_deferred') {
+        $manifestEntry = Get-DispatchTaskManifestEntry -ProjectDir $projectDir -Label $selectedLabel
+        $runtimeResult = Wait-PaneControlRuntimeContext -ProjectDir $projectDir -ManifestEntry $manifestEntry -Operation dispatch
+        if (-not $runtimeResult.valid) {
+            $backend = [string](Get-WinsmuxSubmissionValue -InputObject $manifestEntry -Name 'WorkerBackend' -Default 'local')
+            if ($backend -notin @('local', 'codex', 'api_llm', 'antigravity', 'noop')) { $backend = 'noop' }
+            $receipt = New-WinsmuxSubmissionReceipt -Kind task -Status unavailable -Backend $backend -SubmissionId $submissionId `
+                -ReasonCode ([string]$runtimeResult.reason_code) -Diagnostic ([string]$runtimeResult.diagnostic) `
+                -Target ([ordered]@{ label = $selectedLabel; pane_id = $paneId; role = $resolvedRole })
+            ConvertTo-WinsmuxSubmissionReceiptJson -Receipt $receipt | Write-Output
+            exit 1
+        }
     }
 
     $receipt = Invoke-WinsmuxSubmissionAdapter -ProjectDir $projectDir -ManifestEntry $manifestEntry -Kind task -Content $taskText -SubmissionId $submissionId

--- a/winsmux-core/scripts/credential-metadata.ps1
+++ b/winsmux-core/scripts/credential-metadata.ps1
@@ -1,0 +1,25 @@
+function Invoke-WinsmuxCredentialMetadataCommand {
+    $command = Get-Command cmdkey.exe -CommandType Application -ErrorAction Stop
+    $output = @(& $command.Source /list 2>$null)
+    if ($LASTEXITCODE -ne 0) {
+        throw "cmdkey metadata enumeration failed (exit $LASTEXITCODE)"
+    }
+    return @($output | ForEach-Object { [string]$_ })
+}
+
+function Get-WinsmuxCredentialTargetNames {
+    [CmdletBinding()]
+    param([string]$Prefix = 'winsmux:')
+
+    $marker = 'LegacyGeneric:target=' + $Prefix
+    $names = [System.Collections.Generic.List[string]]::new()
+    foreach ($line in @(Invoke-WinsmuxCredentialMetadataCommand)) {
+        $index = $line.IndexOf($marker, [System.StringComparison]::OrdinalIgnoreCase)
+        if ($index -lt 0) { continue }
+        $name = $line.Substring($index + $marker.Length).Trim()
+        if (-not [string]::IsNullOrWhiteSpace($name)) {
+            $names.Add($name) | Out-Null
+        }
+    }
+    return @($names | Sort-Object -Unique)
+}

--- a/winsmux-core/scripts/doctor.ps1
+++ b/winsmux-core/scripts/doctor.ps1
@@ -737,11 +737,23 @@ function Invoke-DoctorOrchestraSmokeJson {
         }
     }
 
+    $smokeOk = [bool](Get-DoctorObjectPropertyValue -InputObject $data -Name 'smoke_ok' -Default $false)
+    $runtimeValid = [bool](Get-DoctorObjectPropertyValue -InputObject $data -Name 'runtime_valid' -Default $false)
+    $resultOk = $exitCode -eq 0 -and $smokeOk -and $runtimeValid
+    $resultError = if ($exitCode -ne 0) {
+        "orchestra-smoke exited with code $exitCode"
+    } elseif (-not $smokeOk) {
+        'orchestra-smoke reported smoke_ok=false'
+    } elseif (-not $runtimeValid) {
+        'orchestra-smoke did not verify the supervisor-owned runtime identity registry'
+    } else {
+        ''
+    }
     return [PSCustomObject]@{
-        Ok       = $true
+        Ok       = $resultOk
         ExitCode = $exitCode
         Data     = $data
-        Error    = ''
+        Error    = $resultError
     }
 }
 
@@ -780,7 +792,8 @@ function New-OrchestraProcessContractDoctorResult {
 function Test-OrchestraProcessContractCheck {
     $smoke = Invoke-DoctorOrchestraSmokeJson
     if (-not [bool]$smoke.Ok) {
-        return New-DoctorResult -Status warn -Label 'Orchestra process contract' -Detail "unavailable; $($smoke.Error)"
+        $status = if ($null -ne $smoke.Data) { 'fail' } else { 'warn' }
+        return New-DoctorResult -Status $status -Label 'Orchestra process contract' -Detail "unavailable; $($smoke.Error)"
     }
 
     $contract = Get-DoctorObjectPropertyValue -InputObject $smoke.Data -Name 'process_contract'

--- a/winsmux-core/scripts/harness-check.ps1
+++ b/winsmux-core/scripts/harness-check.ps1
@@ -14,6 +14,7 @@ if ([string]::IsNullOrWhiteSpace($ProjectDir)) {
 
 $ProjectDir = [System.IO.Path]::GetFullPath($ProjectDir)
 $scriptsRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+. (Join-Path $scriptsRoot 'json-compat.ps1')
 . (Join-Path $scriptsRoot 'orchestra-ui-attach.ps1')
 
 function New-HarnessCheckRecord {
@@ -66,7 +67,7 @@ function Get-HarnessSettingsObject {
         return @{}
     }
 
-    return ($raw | ConvertFrom-Json -Depth 32)
+    return ($raw | ConvertFrom-WinsmuxJson -Depth 32)
 }
 
 function Test-HarnessHasProperty {
@@ -253,7 +254,7 @@ function Test-HarnessSmokeContract {
 
     try {
         if (-not [string]::IsNullOrWhiteSpace($raw)) {
-            $parsed = $raw | ConvertFrom-Json -Depth 16
+            $parsed = $raw | ConvertFrom-WinsmuxJson -Depth 16
         }
     } catch {
         $error = $_.Exception.Message
@@ -265,6 +266,52 @@ function Test-HarnessSmokeContract {
         parsed    = $parsed
         error     = $error
     }
+}
+
+function Get-HarnessSmokeContractEvaluation {
+    param([Parameter(Mandatory = $true)]$SmokeProbe)
+
+    if (-not (Test-HarnessHasProperty -Object $SmokeProbe -Name 'parsed') -or $null -eq $SmokeProbe.parsed) {
+        $parseError = if (Test-HarnessHasProperty -Object $SmokeProbe -Name 'error') { [string]$SmokeProbe.error } else { '' }
+        $message = if ([string]::IsNullOrWhiteSpace($parseError)) {
+            'orchestra-smoke did not return JSON.'
+        } else {
+            "orchestra-smoke JSON parse failed: $parseError"
+        }
+        return [ordered]@{ passed = $false; message = $message }
+    }
+
+    $parsed = $SmokeProbe.parsed
+    $exitCode = if (Test-HarnessHasProperty -Object $SmokeProbe -Name 'exit_code') { [int]$SmokeProbe.exit_code } else { 1 }
+    if ($exitCode -ne 0) {
+        return [ordered]@{ passed = $false; message = "orchestra-smoke exited with code $exitCode." }
+    }
+    if (-not (Test-HarnessHasProperty -Object $parsed -Name 'smoke_ok') -or -not [bool]$parsed.smoke_ok) {
+        return [ordered]@{ passed = $false; message = 'orchestra-smoke reported smoke_ok=false.' }
+    }
+    if (-not (Test-HarnessHasProperty -Object $parsed -Name 'runtime_valid') -or
+        -not (Test-HarnessHasProperty -Object $parsed -Name 'runtime_identity') -or
+        -not [bool]$parsed.runtime_valid) {
+        return [ordered]@{ passed = $false; message = 'orchestra-smoke did not verify the supervisor-owned runtime identity registry.' }
+    }
+
+    $contract = if (Test-HarnessHasProperty -Object $parsed -Name 'operator_contract') { $parsed.operator_contract } else { $null }
+    $hasContract = $null -ne $contract -and
+        (Test-HarnessHasProperty -Object $contract -Name 'operator_state') -and
+        (Test-HarnessHasProperty -Object $contract -Name 'can_dispatch') -and
+        (Test-HarnessHasProperty -Object $contract -Name 'requires_startup')
+    if (-not $hasContract) {
+        return [ordered]@{ passed = $false; message = 'orchestra-smoke result is missing operator_contract fields.' }
+    }
+
+    $externalOperatorMode = (Test-HarnessHasProperty -Object $parsed -Name 'external_operator_mode') -and [bool]$parsed.external_operator_mode
+    $sessionReady = (Test-HarnessHasProperty -Object $parsed -Name 'session_ready') -and [bool]$parsed.session_ready
+    $uiAttached = (Test-HarnessHasProperty -Object $parsed -Name 'ui_attached') -and [bool]$parsed.ui_attached
+    if ($externalOperatorMode -and $sessionReady -and -not $uiAttached -and [bool]$contract.can_dispatch) {
+        return [ordered]@{ passed = $false; message = 'operator_contract.can_dispatch must stay false until attached-client confirmation is recorded.' }
+    }
+
+    return [ordered]@{ passed = $true; message = 'orchestra-smoke contract is structurally consistent.' }
 }
 
 $results = [System.Collections.Generic.List[object]]::new()
@@ -347,8 +394,9 @@ $results.Add((New-HarnessCheckRecord -Name 'visible-attach-host-adapters' -Passe
 ))) | Out-Null
 
 $smokeProbe = Test-HarnessSmokeContract -CodeRoot $ProjectDir -RuntimeProjectDir $runtimeProjectDir
-$smokePassed = $false
-$smokeMessage = ''
+$smokeEvaluation = Get-HarnessSmokeContractEvaluation -SmokeProbe $smokeProbe
+$smokePassed = [bool]$smokeEvaluation.passed
+$smokeMessage = [string]$smokeEvaluation.message
 $attachRegistryPassed = $false
 $attachRegistryMessage = ''
 $attachConsistencyPassed = $false
@@ -358,7 +406,7 @@ if ($null -eq $smokeProbe.parsed) {
     $attachRegistryMessage = $smokeMessage
     $attachConsistencyMessage = $smokeMessage
 } else {
-    $contract = $smokeProbe.parsed.operator_contract
+    $contract = if (Test-HarnessHasProperty -Object $smokeProbe.parsed -Name 'operator_contract') { $smokeProbe.parsed.operator_contract } else { $null }
     $hasContract = $null -ne $contract -and
         (Test-HarnessHasProperty -Object $contract -Name 'operator_state') -and
         (Test-HarnessHasProperty -Object $contract -Name 'can_dispatch') -and
@@ -375,15 +423,8 @@ if ($null -eq $smokeProbe.parsed) {
     ) | ForEach-Object {
         Test-HarnessHasProperty -Object $smokeProbe.parsed -Name $_
     }
-    if (-not $hasContract) {
-        $smokeMessage = 'orchestra-smoke result is missing operator_contract fields.'
+    if (-not $smokePassed) {
         $attachConsistencyMessage = $smokeMessage
-    } elseif ($smokeProbe.parsed.external_operator_mode -and $smokeProbe.parsed.session_ready -and -not $smokeProbe.parsed.ui_attached -and $contract.can_dispatch) {
-        $smokeMessage = 'operator_contract.can_dispatch must stay false until attached-client confirmation is recorded.'
-        $attachConsistencyMessage = $smokeMessage
-    } else {
-        $smokePassed = $true
-        $smokeMessage = 'orchestra-smoke contract is structurally consistent.'
     }
 
     if ($hasAttachRegistryFields -contains $false) {
@@ -393,7 +434,9 @@ if ($null -eq $smokeProbe.parsed) {
         $attachRegistryMessage = 'orchestra-smoke exposes attached-client registry and attach-source fields.'
     }
 
-    if (-not (Test-HarnessHasProperty -Object $smokeProbe.parsed -Name 'session_ready') -or
+    if (-not $hasContract) {
+        $attachConsistencyMessage = 'orchestra-smoke result is missing operator_contract fields.'
+    } elseif (-not (Test-HarnessHasProperty -Object $smokeProbe.parsed -Name 'session_ready') -or
         -not (Test-HarnessHasProperty -Object $smokeProbe.parsed -Name 'ui_attached') -or
         -not (Test-HarnessHasProperty -Object $smokeProbe.parsed -Name 'ui_attach_launched')) {
         $attachConsistencyMessage = 'orchestra-smoke result is missing startup/attach consistency fields.'
@@ -411,6 +454,7 @@ if ($null -eq $smokeProbe.parsed) {
 $results.Add((New-HarnessCheckRecord -Name 'orchestra-smoke-contract' -Passed $smokePassed -Message $smokeMessage -Data ([ordered]@{
     exit_code = $smokeProbe.exit_code
     smoke_ok  = $(if ($null -ne $smokeProbe.parsed) { $smokeProbe.parsed.smoke_ok } else { $null })
+    runtime_valid = $(if ($null -ne $smokeProbe.parsed -and (Test-HarnessHasProperty -Object $smokeProbe.parsed -Name 'runtime_valid')) { $smokeProbe.parsed.runtime_valid } else { $null })
     ui_attached = $(if ($null -ne $smokeProbe.parsed) { $smokeProbe.parsed.ui_attached } else { $null })
     external_operator_mode = $(if ($null -ne $smokeProbe.parsed) { $smokeProbe.parsed.external_operator_mode } else { $null })
     can_dispatch = $(if ($null -ne $smokeProbe.parsed -and $null -ne $smokeProbe.parsed.operator_contract) { $smokeProbe.parsed.operator_contract.can_dispatch } else { $null })

--- a/winsmux-core/scripts/harness-check.ps1
+++ b/winsmux-core/scripts/harness-check.ps1
@@ -282,19 +282,6 @@ function Get-HarnessSmokeContractEvaluation {
     }
 
     $parsed = $SmokeProbe.parsed
-    $exitCode = if (Test-HarnessHasProperty -Object $SmokeProbe -Name 'exit_code') { [int]$SmokeProbe.exit_code } else { 1 }
-    if ($exitCode -ne 0) {
-        return [ordered]@{ passed = $false; message = "orchestra-smoke exited with code $exitCode." }
-    }
-    if (-not (Test-HarnessHasProperty -Object $parsed -Name 'smoke_ok') -or -not [bool]$parsed.smoke_ok) {
-        return [ordered]@{ passed = $false; message = 'orchestra-smoke reported smoke_ok=false.' }
-    }
-    if (-not (Test-HarnessHasProperty -Object $parsed -Name 'runtime_valid') -or
-        -not (Test-HarnessHasProperty -Object $parsed -Name 'runtime_identity') -or
-        -not [bool]$parsed.runtime_valid) {
-        return [ordered]@{ passed = $false; message = 'orchestra-smoke did not verify the supervisor-owned runtime identity registry.' }
-    }
-
     $contract = if (Test-HarnessHasProperty -Object $parsed -Name 'operator_contract') { $parsed.operator_contract } else { $null }
     $hasContract = $null -ne $contract -and
         (Test-HarnessHasProperty -Object $contract -Name 'operator_state') -and
@@ -302,6 +289,66 @@ function Get-HarnessSmokeContractEvaluation {
         (Test-HarnessHasProperty -Object $contract -Name 'requires_startup')
     if (-not $hasContract) {
         return [ordered]@{ passed = $false; message = 'orchestra-smoke result is missing operator_contract fields.' }
+    }
+
+    if (-not (Test-HarnessHasProperty -Object $parsed -Name 'smoke_ok')) {
+        return [ordered]@{ passed = $false; message = 'orchestra-smoke result is missing smoke_ok.' }
+    }
+    if (-not (Test-HarnessHasProperty -Object $parsed -Name 'runtime_valid') -or
+        -not (Test-HarnessHasProperty -Object $parsed -Name 'runtime_identity')) {
+        return [ordered]@{ passed = $false; message = 'orchestra-smoke did not expose the supervisor-owned runtime identity registry.' }
+    }
+
+    $exitCode = if (Test-HarnessHasProperty -Object $SmokeProbe -Name 'exit_code') { [int]$SmokeProbe.exit_code } else { 1 }
+    $smokeOk = [bool]$parsed.smoke_ok
+    $runtimeValid = [bool]$parsed.runtime_valid
+    $operatorState = [string]$contract.operator_state
+    $canDispatch = [bool]$contract.can_dispatch
+    $requiresStartup = [bool]$contract.requires_startup
+    $runtimeIdentity = $parsed.runtime_identity
+    $runtimeReasonCode = if ($null -ne $runtimeIdentity -and (Test-HarnessHasProperty -Object $runtimeIdentity -Name 'reason_code')) {
+        [string]$runtimeIdentity.reason_code
+    } else {
+        ''
+    }
+    $knownPreStartReasonCodes = @(
+        'manifest_regeneration_required'
+        'invalid_supervisor_identity'
+        'caller_identity_mismatch'
+        'runtime_target_mismatch'
+    )
+    $hasTypedRuntimeRefusal = $null -ne $runtimeIdentity -and
+        (Test-HarnessHasProperty -Object $runtimeIdentity -Name 'valid') -and
+        -not [bool]$runtimeIdentity.valid -and
+        $knownPreStartReasonCodes -ccontains $runtimeReasonCode
+    $safePreStart = $exitCode -eq 1 -and
+        -not $smokeOk -and
+        -not $runtimeValid -and
+        $hasTypedRuntimeRefusal -and
+        $operatorState -ceq 'blocked' -and
+        -not $canDispatch -and
+        $requiresStartup
+
+    if ($safePreStart) {
+        return [ordered]@{
+            passed  = $true
+            message = 'orchestra-smoke reported a safe pre-start blocked state; runtime regeneration is required before dispatch.'
+        }
+    }
+    if ($exitCode -ne 0) {
+        return [ordered]@{ passed = $false; message = "orchestra-smoke exited with code $exitCode and the result was not a safe pre-start blocked state." }
+    }
+    if (-not $smokeOk) {
+        return [ordered]@{ passed = $false; message = 'orchestra-smoke reported smoke_ok=false.' }
+    }
+    if (-not $runtimeValid) {
+        return [ordered]@{ passed = $false; message = 'orchestra-smoke did not verify the supervisor-owned runtime identity registry.' }
+    }
+    if ($requiresStartup) {
+        return [ordered]@{ passed = $false; message = 'operator_contract.requires_startup must be false after a successful orchestra smoke.' }
+    }
+    if ($operatorState -ceq 'blocked' -and $canDispatch) {
+        return [ordered]@{ passed = $false; message = 'operator_state=blocked must not allow dispatch.' }
     }
 
     $externalOperatorMode = (Test-HarnessHasProperty -Object $parsed -Name 'external_operator_mode') -and [bool]$parsed.external_operator_mode
@@ -455,9 +502,12 @@ $results.Add((New-HarnessCheckRecord -Name 'orchestra-smoke-contract' -Passed $s
     exit_code = $smokeProbe.exit_code
     smoke_ok  = $(if ($null -ne $smokeProbe.parsed) { $smokeProbe.parsed.smoke_ok } else { $null })
     runtime_valid = $(if ($null -ne $smokeProbe.parsed -and (Test-HarnessHasProperty -Object $smokeProbe.parsed -Name 'runtime_valid')) { $smokeProbe.parsed.runtime_valid } else { $null })
+    runtime_reason_code = $(if ($null -ne $smokeProbe.parsed -and (Test-HarnessHasProperty -Object $smokeProbe.parsed -Name 'runtime_identity') -and $null -ne $smokeProbe.parsed.runtime_identity -and (Test-HarnessHasProperty -Object $smokeProbe.parsed.runtime_identity -Name 'reason_code')) { $smokeProbe.parsed.runtime_identity.reason_code } else { $null })
     ui_attached = $(if ($null -ne $smokeProbe.parsed) { $smokeProbe.parsed.ui_attached } else { $null })
     external_operator_mode = $(if ($null -ne $smokeProbe.parsed) { $smokeProbe.parsed.external_operator_mode } else { $null })
+    operator_state = $(if ($null -ne $smokeProbe.parsed -and $null -ne $smokeProbe.parsed.operator_contract) { $smokeProbe.parsed.operator_contract.operator_state } else { $null })
     can_dispatch = $(if ($null -ne $smokeProbe.parsed -and $null -ne $smokeProbe.parsed.operator_contract) { $smokeProbe.parsed.operator_contract.can_dispatch } else { $null })
+    requires_startup = $(if ($null -ne $smokeProbe.parsed -and $null -ne $smokeProbe.parsed.operator_contract) { $smokeProbe.parsed.operator_contract.requires_startup } else { $null })
 })) ) | Out-Null
 $results.Add((New-HarnessCheckRecord -Name 'attached-client-registry-contract' -Passed $attachRegistryPassed -Message $attachRegistryMessage -Data ([ordered]@{
     client_probe_ok = $(if ($null -ne $smokeProbe.parsed) { $smokeProbe.parsed.client_probe_ok } else { $null })

--- a/winsmux-core/scripts/json-compat.ps1
+++ b/winsmux-core/scripts/json-compat.ps1
@@ -1,0 +1,28 @@
+$script:WinsmuxJsonCommand = Get-Command ConvertFrom-Json -CommandType Cmdlet -ErrorAction Stop
+$script:WinsmuxJsonSupportsDepth = $script:WinsmuxJsonCommand.Parameters.ContainsKey('Depth')
+$script:WinsmuxJsonSupportsHashtable = $script:WinsmuxJsonCommand.Parameters.ContainsKey('AsHashtable')
+
+function ConvertFrom-WinsmuxJson {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true)][string]$Json,
+        [ValidateRange(1, 1024)][int]$Depth = 1024,
+        [switch]$AsHashtable
+    )
+
+    process {
+        if ($AsHashtable -and -not $script:WinsmuxJsonSupportsHashtable) {
+            Add-Type -AssemblyName System.Web.Extensions -ErrorAction Stop
+            $serializer = [System.Web.Script.Serialization.JavaScriptSerializer]::new()
+            $serializer.MaxJsonLength = [int]::MaxValue
+            $serializer.RecursionLimit = $Depth
+            return $serializer.DeserializeObject($Json)
+        }
+        $arguments = @{}
+        if ($script:WinsmuxJsonSupportsDepth) { $arguments['Depth'] = $Depth }
+        if ($AsHashtable -and $script:WinsmuxJsonSupportsHashtable) {
+            $arguments['AsHashtable'] = $true
+        }
+        return ($Json | ConvertFrom-Json @arguments)
+    }
+}

--- a/winsmux-core/scripts/manifest.ps1
+++ b/winsmux-core/scripts/manifest.ps1
@@ -432,7 +432,33 @@ function Test-WinsmuxRuntimeRegistryReplacementAllowed {
     if ($null -eq $ownerPid) {
         return $false
     }
-    return (-not (Test-WinsmuxStrictProcessIdentity -ProcessId $ownerPid -ExpectedStartTime $ownerStartedAt -ProcessResolver $ProcessResolver))
+    try {
+        $observedOwner = & $ProcessResolver $ownerPid
+    } catch {
+        return $false
+    }
+    if ($null -eq $observedOwner) {
+        return $true
+    }
+
+    $observedPid = ConvertTo-WinsmuxRuntimeInteger -Value (
+        Get-WinsmuxRuntimeValue -InputObject $observedOwner -Name 'Id' -Default (
+            Get-WinsmuxRuntimeValue -InputObject $observedOwner -Name 'ProcessId' -Default $null
+        )
+    )
+    $observedStartedAt = ConvertTo-WinsmuxRuntimeUtcIdentity -Value (
+        Get-WinsmuxRuntimeValue -InputObject $observedOwner -Name 'StartTime' -Default (
+            Get-WinsmuxRuntimeValue -InputObject $observedOwner -Name 'CreationDate' -Default $null
+        )
+    )
+    $expectedStartedAt = ConvertTo-WinsmuxRuntimeUtcIdentity -Value $ownerStartedAt
+    if ($null -eq $observedPid -or $observedPid -ne $ownerPid -or
+        [string]::IsNullOrWhiteSpace($observedStartedAt) -or
+        [string]::IsNullOrWhiteSpace($expectedStartedAt)) {
+        return $false
+    }
+
+    return ($observedStartedAt -cne $expectedStartedAt)
 }
 
 function Update-WinsmuxRuntimeRegistryLease {
@@ -479,6 +505,8 @@ function Close-WinsmuxRuntimeRegistry {
         [Parameter(Mandatory = $true)][string]$GenerationId,
         [Parameter(Mandatory = $true)][int]$SupervisorPid,
         [Parameter(Mandatory = $true)][string]$SupervisorProcessStartedAt,
+        [AllowEmptyString()][string]$ExpectedSessionName = '',
+        [AllowEmptyString()][string]$ExpectedServerSessionId = '',
         [datetime]$Now = (Get-Date)
     )
 
@@ -495,6 +523,10 @@ function Close-WinsmuxRuntimeRegistry {
             [string](Get-WinsmuxRuntimeValue -InputObject $registry -Name 'generation_id' -Default ''),
             $GenerationId,
             [System.StringComparison]::Ordinal) -or
+        ((-not [string]::IsNullOrWhiteSpace($ExpectedSessionName)) -and
+            [string](Get-WinsmuxRuntimeValue -InputObject $registry -Name 'session_name' -Default '') -cne $ExpectedSessionName) -or
+        ((-not [string]::IsNullOrWhiteSpace($ExpectedServerSessionId)) -and
+            [string](Get-WinsmuxRuntimeValue -InputObject $registry -Name 'server_session_id' -Default '') -cne $ExpectedServerSessionId) -or
         $null -eq $ownerPid -or $ownerPid -ne $SupervisorPid -or $ownerStartedAt -cne $expectedStartedAt) {
         return $false
     }
@@ -650,9 +682,6 @@ function New-WinsmuxProcessSnapshotResolver {
         }
         if ($snapshotMap.ContainsKey($processId)) {
             throw 'OS process ancestry snapshot contains a duplicate process identity.'
-        }
-        if ($null -eq $parentProcessId -or [string]::IsNullOrWhiteSpace($startedAt) -or [string]::IsNullOrWhiteSpace($name)) {
-            continue
         }
         $snapshotMap[$processId] = [PSCustomObject][ordered]@{
             Id              = $processId
@@ -944,7 +973,10 @@ function Test-WinsmuxRuntimeContext {
             return & $targetMismatch 'Only an explicitly deferred target may enter deferred startup.'
         }
         if ($null -ne $PaneMarker) {
-            if ([string]$statusClassification.NormalizedStatus -cne 'deferred_start_failed') {
+            $normalizedDeferredStatus = [string]$statusClassification.NormalizedStatus
+            $isFailedDeferredRetry = $normalizedDeferredStatus -ceq 'deferred_start_failed'
+            $isDeferredStartingObservation = $normalizedDeferredStatus -ceq 'deferred_starting'
+            if (-not $isFailedDeferredRetry -and -not $isDeferredStartingObservation) {
                 return & $targetMismatch 'A pane marker already exists; deferred startup would duplicate or overwrite a bootstrap identity.'
             }
 
@@ -965,19 +997,31 @@ function Test-WinsmuxRuntimeContext {
                 return & $targetMismatch 'Failed deferred retry marker does not match the current runtime target identity.'
             }
 
-            $retryMarkerState = if (Test-WinsmuxStrictProcessIdentity -ProcessId $retryMarkerPid `
+            $markerProcessState = if (Test-WinsmuxStrictProcessIdentity -ProcessId $retryMarkerPid `
                     -ExpectedStartTime $retryMarkerStartedAt -ProcessResolver $ProcessResolver) {
                 'live'
             } else {
                 'stale'
             }
-            return New-WinsmuxRuntimeValidationResult -Valid $true -ReasonCode 'deferred_retry_marker_verified' `
-                -Diagnostic 'Failed deferred retry marker is authenticated for bounded reuse or stale-marker recovery.' `
+            $markerReasonCode = if ($isFailedDeferredRetry) {
+                'deferred_retry_marker_verified'
+            } else {
+                'deferred_starting_marker_verified'
+            }
+            $markerDiagnostic = if ($isFailedDeferredRetry) {
+                'Failed deferred retry marker is authenticated for bounded reuse or stale-marker recovery.'
+            } else {
+                'Deferred-starting marker is authenticated for readiness observation or failure recording.'
+            }
+            return New-WinsmuxRuntimeValidationResult -Valid $true -ReasonCode $markerReasonCode `
+                -Diagnostic $markerDiagnostic `
                 -Context ([PSCustomObject][ordered]@{
                     session_name = $registrySessionName; server_session_id = $registryServerSession
                     generation_id = $registryGeneration; label = $label; slot_id = $slotId; pane_id = $paneId
                     backend = $backend; role = $role; title = $title; runtime_state = 'deferred'
-                    retry_marker_state = $retryMarkerState; retry_marker_pid = $retryMarkerPid
+                    marker_process_state = $markerProcessState
+                    retry_marker_state = if ($isFailedDeferredRetry) { $markerProcessState } else { '' }
+                    retry_marker_pid = $retryMarkerPid
                     retry_marker_process_started_at = $retryMarkerStartedAt
                 })
         }

--- a/winsmux-core/scripts/manifest.ps1
+++ b/winsmux-core/scripts/manifest.ps1
@@ -3,9 +3,9 @@
 Session manifest reader/writer for winsmux Orchestra.
 
 .DESCRIPTION
-Manages .winsmux/manifest.yaml as the single source of truth for a running
-Orchestra session. Supports both the legacy list-style pane schema and the
-current dictionary-style pane schema used by orchestra-start.ps1.
+Manages .winsmux/manifest.yaml as desired state and diagnostics for an Orchestra
+session. Live authorization uses the separately owned runtime registry; raw
+manifest parsing remains available for cleanup and historical diagnostics.
 #>
 
 $ErrorActionPreference = 'Stop'
@@ -14,6 +14,30 @@ Set-StrictMode -Version Latest
 
 $script:ManifestFileName = 'manifest.yaml'
 $script:ManifestDirName = '.winsmux'
+$script:RuntimeRegistryFileName = 'runtime-registry.json'
+
+function Get-WinsmuxRuntimeStatusClassification {
+    param([AllowNull()][AllowEmptyString()][string]$Status = '')
+
+    $normalizedStatus = if ($null -eq $Status) { '' } else { $Status.Trim().ToLowerInvariant() }
+    $retryable = $normalizedStatus -ceq 'deferred_start_failed'
+    $isDeferred = $normalizedStatus -in @(
+        'deferred_start',
+        'deferred_starting',
+        'deferred_start_failed',
+        'api_llm_runner_unconfigured',
+        'antigravity_runner_unconfigured'
+    )
+
+    return [PSCustomObject][ordered]@{
+        NormalizedStatus = $normalizedStatus
+        RuntimeOperation = if ($isDeferred) { 'start_deferred' } else { 'dispatch' }
+        IsDeferred       = $isDeferred
+        IsStarting       = $normalizedStatus -ceq 'deferred_starting'
+        Retryable        = $retryable
+        CanStartDeferred = ($normalizedStatus -ceq 'deferred_start' -or $retryable)
+    }
+}
 
 function ConvertTo-ManifestYamlScalar {
     param([AllowNull()]$Value)
@@ -219,10 +243,11 @@ function ConvertTo-ManifestKeyName {
 function Write-ManifestTextFile {
     param(
         [Parameter(Mandatory = $true)][string]$Path,
-        [AllowEmptyString()][string]$Content = ''
+        [AllowEmptyString()][string]$Content = '',
+        [AllowNull()][scriptblock]$ValidateLocked = $null
     )
 
-    Write-WinsmuxTextFile -Path $Path -Content $Content
+    Write-WinsmuxTextFile -Path $Path -Content $Content -ValidateLocked $ValidateLocked
 }
 
 function Get-ManifestDir {
@@ -237,16 +262,866 @@ function Get-ManifestPath {
     return Join-Path (Get-ManifestDir -ProjectDir $ProjectDir) $script:ManifestFileName
 }
 
-function Clear-WinsmuxManifest {
+function Get-WinsmuxRuntimeRegistryPath {
     param([Parameter(Mandatory = $true)][string]$ProjectDir)
 
-    $path = Get-ManifestPath -ProjectDir $ProjectDir
+    return Join-Path (Get-ManifestDir -ProjectDir $ProjectDir) $script:RuntimeRegistryFileName
+}
+
+function Read-WinsmuxRuntimeRegistry {
+    param([Parameter(Mandatory = $true)][string]$ProjectDir)
+
+    $path = Get-WinsmuxRuntimeRegistryPath -ProjectDir $ProjectDir
     if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
+        return $null
+    }
+
+    $raw = Get-Content -LiteralPath $path -Raw -Encoding UTF8
+    if ([string]::IsNullOrWhiteSpace($raw)) {
+        throw "Runtime registry is empty: $path"
+    }
+
+    try {
+        $registry = $raw | ConvertFrom-Json
+        if ($null -ne $registry.supervisor) {
+            $registry.supervisor.process_started_at = [string](ConvertTo-WinsmuxRuntimeUtcIdentity -Value $registry.supervisor.process_started_at)
+        }
+        if ($null -ne $registry.lease) {
+            $registry.lease.expires_at = [string](ConvertTo-WinsmuxRuntimeUtcIdentity -Value $registry.lease.expires_at)
+        }
+        if ($null -ne $registry.updated_at) {
+            $registry.updated_at = [string](ConvertTo-WinsmuxRuntimeUtcIdentity -Value $registry.updated_at)
+        }
+        foreach ($pane in @($registry.panes)) {
+            if ($null -ne $pane.bootstrap_process_started_at) {
+                $pane.bootstrap_process_started_at = [string](ConvertTo-WinsmuxRuntimeUtcIdentity -Value $pane.bootstrap_process_started_at)
+            }
+        }
+        return $registry
+    } catch {
+        throw "Runtime registry is malformed: $path"
+    }
+}
+
+function Save-WinsmuxRuntimeRegistry {
+    param(
+        [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [Parameter(Mandatory = $true)]$Registry
+    )
+
+    $path = Get-WinsmuxRuntimeRegistryPath -ProjectDir $ProjectDir
+    $json = $Registry | ConvertTo-Json -Depth 20
+    Write-ManifestTextFile -Path $path -Content ($json + "`n")
+    return $path
+}
+
+function New-WinsmuxRuntimeRegistryDocument {
+    param(
+        [Parameter(Mandatory = $true)][string]$SessionName,
+        [Parameter(Mandatory = $true)][string]$ServerSessionId,
+        [AllowEmptyString()][string]$BootstrapPaneId = '',
+        [Parameter(Mandatory = $true)][string]$GenerationId,
+        [Parameter(Mandatory = $true)][int]$SupervisorPid,
+        [Parameter(Mandatory = $true)][string]$SupervisorProcessStartedAt,
+        [Parameter(Mandatory = $true)][ValidateRange(1, 1024)][int]$ExpectedPaneCount,
+        [Parameter(Mandatory = $true)][AllowEmptyCollection()][object[]]$Panes,
+        [datetime]$Now = (Get-Date),
+        [ValidateRange(5, 300)][int]$LeaseSeconds = 15
+    )
+
+    $startedAt = ConvertTo-WinsmuxRuntimeUtcIdentity -Value $SupervisorProcessStartedAt
+    $updatedAt = ConvertTo-WinsmuxRuntimeUtcIdentity -Value $Now
+    if ([string]::IsNullOrWhiteSpace($SessionName) -or
+        [string]::IsNullOrWhiteSpace($ServerSessionId) -or
+        [string]::IsNullOrWhiteSpace($GenerationId) -or
+        $SupervisorPid -lt 1 -or
+        [string]::IsNullOrWhiteSpace($startedAt) -or
+        [string]::IsNullOrWhiteSpace($updatedAt)) {
+        throw 'Runtime registry seed is missing a required session, generation, supervisor, or timestamp identity.'
+    }
+
+    $expiresAt = $Now.ToUniversalTime().AddSeconds($LeaseSeconds).ToString('o', [System.Globalization.CultureInfo]::InvariantCulture)
+    return [PSCustomObject][ordered]@{
+        schema_version    = 1
+        status            = 'active'
+        session_name      = $SessionName
+        server_session_id = $ServerSessionId
+        bootstrap_pane_id = $BootstrapPaneId
+        generation_id     = $GenerationId
+        expected_pane_count = $ExpectedPaneCount
+        supervisor        = [PSCustomObject][ordered]@{
+            pid                = $SupervisorPid
+            process_started_at = $startedAt
+        }
+        lease             = [PSCustomObject][ordered]@{
+            state      = 'active'
+            expires_at = $expiresAt
+        }
+        panes             = @($Panes)
+        updated_at        = $updatedAt
+    }
+}
+
+function Test-WinsmuxRuntimeRegistryOwner {
+    param(
+        [AllowNull()]$Registry,
+        [Parameter(Mandatory = $true)][string]$GenerationId,
+        [Parameter(Mandatory = $true)][int]$SupervisorPid,
+        [Parameter(Mandatory = $true)][string]$SupervisorProcessStartedAt,
+        [scriptblock]$ProcessResolver = { param([int]$Id) Get-CimInstance -ClassName Win32_Process -Filter ("ProcessId = {0}" -f $Id) -ErrorAction SilentlyContinue },
+        [datetime]$Now = (Get-Date)
+    )
+
+    if ($null -eq $Registry -or
+        [string](Get-WinsmuxRuntimeValue -InputObject $Registry -Name 'status' -Default '') -cne 'active' -or
+        -not [string]::Equals(
+            [string](Get-WinsmuxRuntimeValue -InputObject $Registry -Name 'generation_id' -Default ''),
+            $GenerationId,
+            [System.StringComparison]::Ordinal)) {
         return $false
     }
 
-    Remove-Item -LiteralPath $path -Force -ErrorAction Stop
+    $supervisor = Get-WinsmuxRuntimeValue -InputObject $Registry -Name 'supervisor'
+    $ownerPid = ConvertTo-WinsmuxRuntimeInteger -Value (Get-WinsmuxRuntimeValue -InputObject $supervisor -Name 'pid' -Default $null)
+    $ownerStartedAt = ConvertTo-WinsmuxRuntimeUtcIdentity -Value (Get-WinsmuxRuntimeValue -InputObject $supervisor -Name 'process_started_at' -Default '')
+    $expectedStartedAt = ConvertTo-WinsmuxRuntimeUtcIdentity -Value $SupervisorProcessStartedAt
+    if ($null -eq $ownerPid -or $ownerPid -ne $SupervisorPid -or
+        [string]::IsNullOrWhiteSpace($ownerStartedAt) -or $ownerStartedAt -cne $expectedStartedAt -or
+        -not (Test-WinsmuxStrictProcessIdentity -ProcessId $ownerPid -ExpectedStartTime $ownerStartedAt -ProcessResolver $ProcessResolver)) {
+        return $false
+    }
+
+    $lease = Get-WinsmuxRuntimeValue -InputObject $Registry -Name 'lease'
+    $leaseExpires = ConvertTo-WinsmuxRuntimeUtcIdentity -Value (Get-WinsmuxRuntimeValue -InputObject $lease -Name 'expires_at' -Default '')
+    $nowUtc = ConvertTo-WinsmuxRuntimeUtcIdentity -Value $Now
+    return (
+        [string](Get-WinsmuxRuntimeValue -InputObject $lease -Name 'state' -Default '') -ceq 'active' -and
+        -not [string]::IsNullOrWhiteSpace($leaseExpires) -and
+        $leaseExpires -cgt $nowUtc
+    )
+}
+
+function Test-WinsmuxRuntimeRegistryReplacementAllowed {
+    param(
+        [AllowNull()]$Registry,
+        [scriptblock]$ProcessResolver = { param([int]$Id) Get-CimInstance -ClassName Win32_Process -Filter ("ProcessId = {0}" -f $Id) -ErrorAction SilentlyContinue },
+        [datetime]$Now = (Get-Date)
+    )
+
+    if ($null -eq $Registry) {
+        return $true
+    }
+    $status = [string](Get-WinsmuxRuntimeValue -InputObject $Registry -Name 'status' -Default '')
+    if ($status -ceq 'ended') {
+        return $true
+    }
+    if ($status -cne 'active') {
+        return $false
+    }
+
+    $lease = Get-WinsmuxRuntimeValue -InputObject $Registry -Name 'lease'
+    $leaseExpires = ConvertTo-WinsmuxRuntimeUtcIdentity -Value (Get-WinsmuxRuntimeValue -InputObject $lease -Name 'expires_at' -Default '')
+    $nowUtc = ConvertTo-WinsmuxRuntimeUtcIdentity -Value $Now
+    if ([string]::IsNullOrWhiteSpace($leaseExpires) -or $leaseExpires -cgt $nowUtc) {
+        return $false
+    }
+
+    $supervisor = Get-WinsmuxRuntimeValue -InputObject $Registry -Name 'supervisor'
+    $ownerPid = ConvertTo-WinsmuxRuntimeInteger -Value (Get-WinsmuxRuntimeValue -InputObject $supervisor -Name 'pid' -Default $null)
+    $ownerStartedAt = [string](Get-WinsmuxRuntimeValue -InputObject $supervisor -Name 'process_started_at' -Default '')
+    if ($null -eq $ownerPid) {
+        return $false
+    }
+    return (-not (Test-WinsmuxStrictProcessIdentity -ProcessId $ownerPid -ExpectedStartTime $ownerStartedAt -ProcessResolver $ProcessResolver))
+}
+
+function Update-WinsmuxRuntimeRegistryLease {
+    param(
+        [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [Parameter(Mandatory = $true)][string]$GenerationId,
+        [Parameter(Mandatory = $true)][int]$SupervisorPid,
+        [Parameter(Mandatory = $true)][string]$SupervisorProcessStartedAt,
+        [AllowNull()][object[]]$Panes = $null,
+        [datetime]$Now = (Get-Date),
+        [ValidateRange(5, 300)][int]$LeaseSeconds = 15
+    )
+
+    $registry = Read-WinsmuxRuntimeRegistry -ProjectDir $ProjectDir
+    $supervisor = Get-WinsmuxRuntimeValue -InputObject $registry -Name 'supervisor'
+    $ownerPid = ConvertTo-WinsmuxRuntimeInteger -Value (Get-WinsmuxRuntimeValue -InputObject $supervisor -Name 'pid' -Default $null)
+    $ownerStartedAt = ConvertTo-WinsmuxRuntimeUtcIdentity -Value (Get-WinsmuxRuntimeValue -InputObject $supervisor -Name 'process_started_at' -Default '')
+    $expectedStartedAt = ConvertTo-WinsmuxRuntimeUtcIdentity -Value $SupervisorProcessStartedAt
+    if ($null -eq $registry -or
+        [string](Get-WinsmuxRuntimeValue -InputObject $registry -Name 'status' -Default '') -cne 'active' -or
+        -not [string]::Equals(
+            [string](Get-WinsmuxRuntimeValue -InputObject $registry -Name 'generation_id' -Default ''),
+            $GenerationId,
+            [System.StringComparison]::Ordinal) -or
+        $null -eq $ownerPid -or $ownerPid -ne $SupervisorPid -or
+        [string]::IsNullOrWhiteSpace($ownerStartedAt) -or $ownerStartedAt -cne $expectedStartedAt) {
+        throw 'Runtime registry lease update refused because the writer does not own this generation.'
+    }
+
+    $updatedAt = ConvertTo-WinsmuxRuntimeUtcIdentity -Value $Now
+    $registry.lease.state = 'active'
+    $registry.lease.expires_at = $Now.ToUniversalTime().AddSeconds($LeaseSeconds).ToString('o', [System.Globalization.CultureInfo]::InvariantCulture)
+    $registry.updated_at = $updatedAt
+    if ($null -ne $Panes) {
+        $registry.panes = @($Panes)
+    }
+    Save-WinsmuxRuntimeRegistry -ProjectDir $ProjectDir -Registry $registry | Out-Null
+    return $registry
+}
+
+function Close-WinsmuxRuntimeRegistry {
+    param(
+        [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [Parameter(Mandatory = $true)][string]$GenerationId,
+        [Parameter(Mandatory = $true)][int]$SupervisorPid,
+        [Parameter(Mandatory = $true)][string]$SupervisorProcessStartedAt,
+        [datetime]$Now = (Get-Date)
+    )
+
+    $registry = Read-WinsmuxRuntimeRegistry -ProjectDir $ProjectDir
+    if ($null -eq $registry) {
+        return $false
+    }
+
+    $supervisor = Get-WinsmuxRuntimeValue -InputObject $registry -Name 'supervisor'
+    $ownerPid = ConvertTo-WinsmuxRuntimeInteger -Value (Get-WinsmuxRuntimeValue -InputObject $supervisor -Name 'pid' -Default $null)
+    $ownerStartedAt = ConvertTo-WinsmuxRuntimeUtcIdentity -Value (Get-WinsmuxRuntimeValue -InputObject $supervisor -Name 'process_started_at' -Default '')
+    $expectedStartedAt = ConvertTo-WinsmuxRuntimeUtcIdentity -Value $SupervisorProcessStartedAt
+    if (-not [string]::Equals(
+            [string](Get-WinsmuxRuntimeValue -InputObject $registry -Name 'generation_id' -Default ''),
+            $GenerationId,
+            [System.StringComparison]::Ordinal) -or
+        $null -eq $ownerPid -or $ownerPid -ne $SupervisorPid -or $ownerStartedAt -cne $expectedStartedAt) {
+        return $false
+    }
+
+    $endedAt = ConvertTo-WinsmuxRuntimeUtcIdentity -Value $Now
+    $registry.status = 'ended'
+    $registry.lease.state = 'ended'
+    $registry.lease.expires_at = $endedAt
+    $registry.updated_at = $endedAt
+    Save-WinsmuxRuntimeRegistry -ProjectDir $ProjectDir -Registry $registry | Out-Null
     return $true
+}
+
+function Get-WinsmuxRuntimeValue {
+    param(
+        [AllowNull()]$InputObject,
+        [Parameter(Mandatory = $true)][string]$Name,
+        [AllowNull()]$Default = $null
+    )
+
+    if ($null -eq $InputObject) {
+        return $Default
+    }
+
+    if ($InputObject -is [System.Collections.IDictionary]) {
+        foreach ($key in $InputObject.Keys) {
+            if ([string]$key -ieq $Name) {
+                return $InputObject[$key]
+            }
+        }
+        return $Default
+    }
+
+    if ($null -ne $InputObject.PSObject) {
+        foreach ($property in $InputObject.PSObject.Properties) {
+            if ($property.Name -ieq $Name) {
+                return $property.Value
+            }
+        }
+    }
+
+    return $Default
+}
+
+function ConvertTo-WinsmuxRuntimeUtcIdentity {
+    param([AllowNull()]$Value)
+
+    if ($null -eq $Value -or [string]::IsNullOrWhiteSpace([string]$Value)) {
+        return $null
+    }
+
+    try {
+        if ($Value -is [datetimeoffset]) {
+            return $Value.UtcDateTime.ToString('o', [System.Globalization.CultureInfo]::InvariantCulture)
+        }
+
+        if ($Value -is [datetime]) {
+            return $Value.ToUniversalTime().ToString('o', [System.Globalization.CultureInfo]::InvariantCulture)
+        }
+
+        $parsed = [datetimeoffset]::Parse(
+            [string]$Value,
+            [System.Globalization.CultureInfo]::InvariantCulture,
+            [System.Globalization.DateTimeStyles]::RoundtripKind
+        )
+        return $parsed.UtcDateTime.ToString('o', [System.Globalization.CultureInfo]::InvariantCulture)
+    } catch {
+        return $null
+    }
+}
+
+function ConvertTo-WinsmuxRuntimeInteger {
+    param([AllowNull()]$Value)
+
+    if ($null -eq $Value) {
+        return $null
+    }
+
+    $parsed = 0
+    if (-not [int]::TryParse(
+            [string]$Value,
+            [System.Globalization.NumberStyles]::Integer,
+            [System.Globalization.CultureInfo]::InvariantCulture,
+            [ref]$parsed)) {
+        return $null
+    }
+
+    return $parsed
+}
+
+function Resolve-WinsmuxRuntimeRole {
+    param(
+        [AllowEmptyString()][string]$WorkerRole = '',
+        [AllowEmptyString()][string]$CanonicalRole = ''
+    )
+
+    $resolved = $WorkerRole.Trim().ToLowerInvariant()
+    if ([string]::IsNullOrWhiteSpace($resolved)) {
+        $resolved = $CanonicalRole.Trim().ToLowerInvariant()
+    }
+    return $resolved
+}
+
+function Test-WinsmuxStrictProcessIdentity {
+    param(
+        [Parameter(Mandatory = $true)][int]$ProcessId,
+        [Parameter(Mandatory = $true)][AllowEmptyString()][string]$ExpectedStartTime,
+        [scriptblock]$ProcessResolver = { param([int]$Id) Get-CimInstance -ClassName Win32_Process -Filter ("ProcessId = {0}" -f $Id) -ErrorAction SilentlyContinue }
+    )
+
+    if ($ProcessId -lt 1) {
+        return $false
+    }
+
+    $expected = ConvertTo-WinsmuxRuntimeUtcIdentity -Value $ExpectedStartTime
+    if ([string]::IsNullOrWhiteSpace($expected)) {
+        return $false
+    }
+
+    try {
+        $process = & $ProcessResolver $ProcessId
+        if ($null -eq $process) {
+            return $false
+        }
+
+        $actualSource = Get-WinsmuxRuntimeValue -InputObject $process -Name 'StartTime' -Default (Get-WinsmuxRuntimeValue -InputObject $process -Name 'CreationDate' -Default $null)
+        $actual = ConvertTo-WinsmuxRuntimeUtcIdentity -Value $actualSource
+        return (-not [string]::IsNullOrWhiteSpace($actual) -and $actual -ceq $expected)
+    } catch {
+        return $false
+    }
+}
+
+function New-WinsmuxProcessSnapshotResolver {
+    param([AllowNull()][object[]]$Snapshots = $null)
+
+    if ($null -eq $Snapshots) {
+        try {
+            $Snapshots = @(Get-CimInstance -ClassName Win32_Process -ErrorAction Stop | Select-Object ProcessId, ParentProcessId, CreationDate, Name)
+        } catch {
+            throw 'OS process ancestry snapshot is unavailable.'
+        }
+    }
+
+    $snapshotMap = @{}
+    foreach ($snapshot in @($Snapshots)) {
+        $processId = ConvertTo-WinsmuxRuntimeInteger -Value (Get-WinsmuxRuntimeValue -InputObject $snapshot -Name 'ProcessId' -Default (Get-WinsmuxRuntimeValue -InputObject $snapshot -Name 'Id' -Default $null))
+        $parentProcessId = ConvertTo-WinsmuxRuntimeInteger -Value (Get-WinsmuxRuntimeValue -InputObject $snapshot -Name 'ParentProcessId' -Default $null)
+        $startedAt = ConvertTo-WinsmuxRuntimeUtcIdentity -Value (Get-WinsmuxRuntimeValue -InputObject $snapshot -Name 'CreationDate' -Default (Get-WinsmuxRuntimeValue -InputObject $snapshot -Name 'StartTime' -Default $null))
+        $name = [string](Get-WinsmuxRuntimeValue -InputObject $snapshot -Name 'Name' -Default (Get-WinsmuxRuntimeValue -InputObject $snapshot -Name 'ProcessName' -Default ''))
+        if ($null -eq $processId -or $processId -lt 1) {
+            continue
+        }
+        if ($snapshotMap.ContainsKey($processId)) {
+            throw 'OS process ancestry snapshot contains a duplicate process identity.'
+        }
+        if ($null -eq $parentProcessId -or [string]::IsNullOrWhiteSpace($startedAt) -or [string]::IsNullOrWhiteSpace($name)) {
+            continue
+        }
+        $snapshotMap[$processId] = [PSCustomObject][ordered]@{
+            Id              = $processId
+            ParentProcessId = $parentProcessId
+            StartTime       = $startedAt
+            Name            = $name
+        }
+    }
+
+    return { param([int]$Id) return $snapshotMap[$Id] }.GetNewClosure()
+}
+
+function Get-WinsmuxRuntimeProcessStartedAt {
+    param([Parameter(Mandatory = $true)][int]$ProcessId)
+
+    try {
+        $snapshot = Get-CimInstance -ClassName Win32_Process -Filter ("ProcessId = {0}" -f $ProcessId) -ErrorAction Stop
+        if ($null -eq $snapshot) { return $null }
+        return ConvertTo-WinsmuxRuntimeUtcIdentity -Value (Get-WinsmuxRuntimeValue -InputObject $snapshot -Name 'CreationDate' -Default $null)
+    } catch {
+        return $null
+    }
+}
+
+function New-WinsmuxRuntimeValidationResult {
+    param(
+        [Parameter(Mandatory = $true)][bool]$Valid,
+        [Parameter(Mandatory = $true)][string]$ReasonCode,
+        [Parameter(Mandatory = $true)][string]$Diagnostic,
+        [AllowNull()]$Context = $null
+    )
+
+    return [PSCustomObject][ordered]@{
+        valid       = $Valid
+        reason_code = $ReasonCode
+        diagnostic  = $Diagnostic
+        context     = $Context
+    }
+}
+
+function Test-WinsmuxRuntimePaneSet {
+    param(
+        [Parameter(Mandatory = $true)]$ManifestPanes,
+        [AllowNull()][object[]]$RegistryPanes,
+        [AllowNull()][object[]]$ObservedPanes,
+        [Parameter(Mandatory = $true)][ValidateRange(1, 1024)][int]$ExpectedPaneCount,
+        [AllowEmptyString()][string]$BootstrapPaneId = ''
+    )
+
+    if ($null -eq $ObservedPanes) { return $false }
+    $manifestLabels = @($ManifestPanes.Keys | ForEach-Object { [string]$_ })
+    $registryItems = @($RegistryPanes)
+    $allObservedItems = @($ObservedPanes)
+    if ([string]::IsNullOrWhiteSpace($BootstrapPaneId)) {
+        $observedItems = @($allObservedItems)
+    } else {
+        if ($BootstrapPaneId -cnotmatch '^%[0-9]+$') { return $false }
+        $bootstrapMatches = @($allObservedItems | Where-Object {
+                [string](Get-WinsmuxRuntimeValue -InputObject $_ -Name 'pane_id' -Default '') -ceq $BootstrapPaneId
+            })
+        if ($bootstrapMatches.Count -ne 1 -or
+            [string]::IsNullOrWhiteSpace([string](Get-WinsmuxRuntimeValue -InputObject $bootstrapMatches[0] -Name 'title' -Default ''))) {
+            return $false
+        }
+        $observedItems = @($allObservedItems | Where-Object {
+                [string](Get-WinsmuxRuntimeValue -InputObject $_ -Name 'pane_id' -Default '') -cne $BootstrapPaneId
+            })
+    }
+    if ($manifestLabels.Count -ne $ExpectedPaneCount -or
+        $registryItems.Count -ne $manifestLabels.Count -or
+        $observedItems.Count -ne $manifestLabels.Count) {
+        return $false
+    }
+
+    $desiredByLabel = [System.Collections.Generic.Dictionary[string, object]]::new([System.StringComparer]::Ordinal)
+    $desiredByPane = [System.Collections.Generic.Dictionary[string, object]]::new([System.StringComparer]::Ordinal)
+    $desiredSlots = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::Ordinal)
+    foreach ($label in $manifestLabels) {
+        $pane = $ManifestPanes[$label]
+        $slotId = [string](Get-WinsmuxRuntimeValue -InputObject $pane -Name 'slot_id' -Default '')
+        $paneId = [string](Get-WinsmuxRuntimeValue -InputObject $pane -Name 'pane_id' -Default '')
+        $backend = [string](Get-WinsmuxRuntimeValue -InputObject $pane -Name 'worker_backend' -Default '')
+        $role = Resolve-WinsmuxRuntimeRole `
+            -WorkerRole ([string](Get-WinsmuxRuntimeValue -InputObject $pane -Name 'worker_role' -Default '')) `
+            -CanonicalRole ([string](Get-WinsmuxRuntimeValue -InputObject $pane -Name 'role' -Default ''))
+        $title = [string](Get-WinsmuxRuntimeValue -InputObject $pane -Name 'title' -Default '')
+        if ([string]::IsNullOrWhiteSpace($label) -or [string]::IsNullOrWhiteSpace($slotId) -or
+            [string]::IsNullOrWhiteSpace($paneId) -or [string]::IsNullOrWhiteSpace($backend) -or
+            [string]::IsNullOrWhiteSpace($role) -or [string]::IsNullOrWhiteSpace($title) -or
+            $desiredByLabel.ContainsKey($label) -or -not $desiredSlots.Add($slotId) -or
+            $desiredByPane.ContainsKey($paneId)) {
+            return $false
+        }
+        $expected = [PSCustomObject][ordered]@{
+            label = $label; slot_id = $slotId; pane_id = $paneId; backend = $backend; role = $role; title = $title
+        }
+        $desiredByLabel.Add($label, $expected)
+        $desiredByPane.Add($paneId, $expected)
+    }
+    if (-not [string]::IsNullOrWhiteSpace($BootstrapPaneId) -and $desiredByPane.ContainsKey($BootstrapPaneId)) {
+        return $false
+    }
+
+    $registryLabels = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::Ordinal)
+    $registrySlots = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::Ordinal)
+    $registryPaneIds = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::Ordinal)
+    foreach ($runtimePane in $registryItems) {
+        $label = [string](Get-WinsmuxRuntimeValue -InputObject $runtimePane -Name 'label' -Default '')
+        $slotId = [string](Get-WinsmuxRuntimeValue -InputObject $runtimePane -Name 'slot_id' -Default '')
+        $paneId = [string](Get-WinsmuxRuntimeValue -InputObject $runtimePane -Name 'pane_id' -Default '')
+        if ([string]::IsNullOrWhiteSpace($label) -or [string]::IsNullOrWhiteSpace($slotId) -or
+            [string]::IsNullOrWhiteSpace($paneId) -or -not $registryLabels.Add($label) -or
+            -not $registrySlots.Add($slotId) -or -not $registryPaneIds.Add($paneId) -or
+            -not $desiredByLabel.ContainsKey($label)) {
+            return $false
+        }
+        $expected = $desiredByLabel[$label]
+        if ($slotId -cne [string]$expected.slot_id -or $paneId -cne [string]$expected.pane_id -or
+            [string](Get-WinsmuxRuntimeValue -InputObject $runtimePane -Name 'backend' -Default '') -cne [string]$expected.backend -or
+            [string](Get-WinsmuxRuntimeValue -InputObject $runtimePane -Name 'role' -Default '') -cne [string]$expected.role -or
+            [string](Get-WinsmuxRuntimeValue -InputObject $runtimePane -Name 'title' -Default '') -cne [string]$expected.title) {
+            return $false
+        }
+    }
+
+    $observedPaneIds = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::Ordinal)
+    foreach ($observedPane in $observedItems) {
+        $paneId = [string](Get-WinsmuxRuntimeValue -InputObject $observedPane -Name 'pane_id' -Default '')
+        $title = [string](Get-WinsmuxRuntimeValue -InputObject $observedPane -Name 'title' -Default '')
+        if ([string]::IsNullOrWhiteSpace($paneId) -or [string]::IsNullOrWhiteSpace($title) -or
+            -not $observedPaneIds.Add($paneId) -or -not $desiredByPane.ContainsKey($paneId) -or
+            $title -cne [string]$desiredByPane[$paneId].title) {
+            return $false
+        }
+    }
+    return $true
+}
+
+function Test-WinsmuxRuntimeContext {
+    param(
+        [AllowNull()]$Manifest,
+        [AllowNull()]$Registry,
+        [Parameter(Mandatory = $true)][AllowEmptyString()][string]$ObservedServerSessionId,
+        [AllowNull()]$ManifestEntry,
+        [AllowNull()]$PaneMarker,
+        [AllowNull()]$CallerIdentity,
+        [AllowNull()][object[]]$ObservedPanes = $null,
+        [ValidateSet('dispatch', 'start_deferred', 'caller_ack', 'stop_transition')][string]$Operation = 'dispatch',
+        [scriptblock]$ProcessResolver = { param([int]$Id) Get-CimInstance -ClassName Win32_Process -Filter ("ProcessId = {0}" -f $Id) -ErrorAction SilentlyContinue },
+        [datetime]$Now = (Get-Date)
+    )
+
+    $regeneration = {
+        param([string]$Message)
+        New-WinsmuxRuntimeValidationResult -Valid $false -ReasonCode 'manifest_regeneration_required' -Diagnostic $Message
+    }
+    $invalidSupervisor = {
+        param([string]$Message)
+        New-WinsmuxRuntimeValidationResult -Valid $false -ReasonCode 'invalid_supervisor_identity' -Diagnostic $Message
+    }
+    $targetMismatch = {
+        param([string]$Message)
+        New-WinsmuxRuntimeValidationResult -Valid $false -ReasonCode 'runtime_target_mismatch' -Diagnostic $Message
+    }
+    $callerMismatch = {
+        param([string]$Message)
+        New-WinsmuxRuntimeValidationResult -Valid $false -ReasonCode 'caller_identity_mismatch' -Diagnostic $Message
+    }
+
+    $manifestVersion = ConvertTo-WinsmuxRuntimeInteger -Value (Get-WinsmuxRuntimeValue -InputObject $Manifest -Name 'version' -Default $null)
+    $manifestSession = Get-WinsmuxRuntimeValue -InputObject $Manifest -Name 'session'
+    if ($null -eq $manifestVersion -or $manifestVersion -ne 2 -or $null -eq $manifestSession) {
+        return & $regeneration 'Manifest does not carry a verified runtime identity.'
+    }
+
+    $registryVersion = ConvertTo-WinsmuxRuntimeInteger -Value (Get-WinsmuxRuntimeValue -InputObject $Registry -Name 'schema_version' -Default $null)
+    if ($null -eq $registryVersion -or $registryVersion -ne 1 -or [string](Get-WinsmuxRuntimeValue -InputObject $Registry -Name 'status' -Default '') -cne 'active') {
+        return & $regeneration 'Runtime registry is missing, inactive, or uses an unsupported schema.'
+    }
+
+    $manifestSessionName = [string](Get-WinsmuxRuntimeValue -InputObject $manifestSession -Name 'name' -Default '')
+    $manifestGeneration = [string](Get-WinsmuxRuntimeValue -InputObject $manifestSession -Name 'generation_id' -Default '')
+    $manifestServerSession = [string](Get-WinsmuxRuntimeValue -InputObject $manifestSession -Name 'server_session_id' -Default '')
+    $manifestBootstrapPane = [string](Get-WinsmuxRuntimeValue -InputObject $manifestSession -Name 'bootstrap_pane_id' -Default '')
+    $manifestExpectedPaneCount = ConvertTo-WinsmuxRuntimeInteger -Value (Get-WinsmuxRuntimeValue -InputObject $manifestSession -Name 'expected_pane_count' -Default $null)
+    $registrySessionName = [string](Get-WinsmuxRuntimeValue -InputObject $Registry -Name 'session_name' -Default '')
+    $registryGeneration = [string](Get-WinsmuxRuntimeValue -InputObject $Registry -Name 'generation_id' -Default '')
+    $registryServerSession = [string](Get-WinsmuxRuntimeValue -InputObject $Registry -Name 'server_session_id' -Default '')
+    $registryBootstrapPane = [string](Get-WinsmuxRuntimeValue -InputObject $Registry -Name 'bootstrap_pane_id' -Default '')
+    $registryExpectedPaneCount = ConvertTo-WinsmuxRuntimeInteger -Value (Get-WinsmuxRuntimeValue -InputObject $Registry -Name 'expected_pane_count' -Default $null)
+
+    if ([string]::IsNullOrWhiteSpace($manifestSessionName) -or
+        [string]::IsNullOrWhiteSpace($manifestGeneration) -or
+        [string]::IsNullOrWhiteSpace($manifestServerSession) -or
+        $manifestSessionName -cne $registrySessionName -or
+        -not [string]::Equals($manifestGeneration, $registryGeneration, [System.StringComparison]::Ordinal) -or
+        $manifestServerSession -cne $registryServerSession -or
+        $manifestBootstrapPane -cne $registryBootstrapPane -or
+        $null -eq $manifestExpectedPaneCount -or $manifestExpectedPaneCount -lt 1 -or
+        $null -eq $registryExpectedPaneCount -or $registryExpectedPaneCount -ne $manifestExpectedPaneCount -or
+        ((-not [string]::IsNullOrWhiteSpace($manifestBootstrapPane)) -and $manifestBootstrapPane -cnotmatch '^%[0-9]+$') -or
+        $registryServerSession -cne $ObservedServerSessionId) {
+        return & $regeneration 'Manifest, registry, generation, or observed server session identity does not match.'
+    }
+
+    $supervisor = Get-WinsmuxRuntimeValue -InputObject $Registry -Name 'supervisor'
+    $supervisorPid = ConvertTo-WinsmuxRuntimeInteger -Value (Get-WinsmuxRuntimeValue -InputObject $supervisor -Name 'pid' -Default $null)
+    $supervisorStartedAt = [string](Get-WinsmuxRuntimeValue -InputObject $supervisor -Name 'process_started_at' -Default '')
+    if ($null -eq $supervisorPid -or -not (Test-WinsmuxStrictProcessIdentity -ProcessId $supervisorPid -ExpectedStartTime $supervisorStartedAt -ProcessResolver $ProcessResolver)) {
+        return & $invalidSupervisor 'Supervisor PID and exact UTC process StartTime could not be verified.'
+    }
+
+    $lease = Get-WinsmuxRuntimeValue -InputObject $Registry -Name 'lease'
+    $leaseState = [string](Get-WinsmuxRuntimeValue -InputObject $lease -Name 'state' -Default '')
+    $leaseExpiresAt = ConvertTo-WinsmuxRuntimeUtcIdentity -Value (Get-WinsmuxRuntimeValue -InputObject $lease -Name 'expires_at' -Default '')
+    $nowUtc = ConvertTo-WinsmuxRuntimeUtcIdentity -Value $Now
+    if ($leaseState -cne 'active' -or [string]::IsNullOrWhiteSpace($leaseExpiresAt) -or $leaseExpiresAt -cle $nowUtc) {
+        return & $invalidSupervisor 'Supervisor ownership lease is missing, malformed, inactive, or expired.'
+    }
+
+    $registryPanes = @(Get-WinsmuxRuntimeValue -InputObject $Registry -Name 'panes' -Default @())
+    $manifestPanes = ConvertTo-ManifestPropertyMap -Value (Get-WinsmuxRuntimeValue -InputObject $Manifest -Name 'panes' -Default $null)
+    if (-not (Test-WinsmuxRuntimePaneSet -ManifestPanes $manifestPanes -RegistryPanes $registryPanes `
+            -ObservedPanes $ObservedPanes -ExpectedPaneCount $manifestExpectedPaneCount `
+            -BootstrapPaneId $manifestBootstrapPane)) {
+        return & $targetMismatch 'Desired manifest, runtime registry, and observed pane sets do not match exactly.'
+    }
+
+    if ($null -eq $ManifestEntry) {
+        return & $targetMismatch 'Target manifest entry is missing.'
+    }
+
+    $label = [string](Get-WinsmuxRuntimeValue -InputObject $ManifestEntry -Name 'Label' -Default '')
+    $slotId = [string](Get-WinsmuxRuntimeValue -InputObject $ManifestEntry -Name 'SlotId' -Default '')
+    $paneId = [string](Get-WinsmuxRuntimeValue -InputObject $ManifestEntry -Name 'PaneId' -Default '')
+    $backend = [string](Get-WinsmuxRuntimeValue -InputObject $ManifestEntry -Name 'WorkerBackend' -Default '')
+    $role = Resolve-WinsmuxRuntimeRole `
+        -WorkerRole ([string](Get-WinsmuxRuntimeValue -InputObject $ManifestEntry -Name 'WorkerRole' -Default '')) `
+        -CanonicalRole ([string](Get-WinsmuxRuntimeValue -InputObject $ManifestEntry -Name 'Role' -Default ''))
+    $title = [string](Get-WinsmuxRuntimeValue -InputObject $ManifestEntry -Name 'Title' -Default '')
+
+    $registryPane = @($registryPanes | Where-Object {
+        [string](Get-WinsmuxRuntimeValue -InputObject $_ -Name 'label' -Default '') -ceq $label
+    })
+    if ($registryPane.Count -ne 1) {
+        return & $targetMismatch 'Target does not resolve to exactly one runtime registry entry.'
+    }
+    $registryPane = $registryPane[0]
+
+    if (-not $manifestPanes.Contains($label)) {
+        return & $targetMismatch 'Target is not present in the desired manifest pane map.'
+    }
+    $manifestPane = $manifestPanes[$label]
+    $manifestRole = Resolve-WinsmuxRuntimeRole `
+        -WorkerRole ([string](Get-WinsmuxRuntimeValue -InputObject $manifestPane -Name 'worker_role' -Default '')) `
+        -CanonicalRole ([string](Get-WinsmuxRuntimeValue -InputObject $manifestPane -Name 'role' -Default ''))
+    if ([string](Get-WinsmuxRuntimeValue -InputObject $manifestPane -Name 'slot_id' -Default '') -cne $slotId -or
+        [string](Get-WinsmuxRuntimeValue -InputObject $manifestPane -Name 'pane_id' -Default '') -cne $paneId -or
+        [string](Get-WinsmuxRuntimeValue -InputObject $manifestPane -Name 'worker_backend' -Default '') -cne $backend -or
+        $manifestRole -cne $role -or
+        [string](Get-WinsmuxRuntimeValue -InputObject $manifestPane -Name 'title' -Default '') -cne $title) {
+        return & $targetMismatch 'Target entry does not match the desired manifest pane map.'
+    }
+
+    $registryState = [string](Get-WinsmuxRuntimeValue -InputObject $registryPane -Name 'state' -Default '')
+    if ([string](Get-WinsmuxRuntimeValue -InputObject $registryPane -Name 'slot_id' -Default '') -cne $slotId -or
+        [string](Get-WinsmuxRuntimeValue -InputObject $registryPane -Name 'pane_id' -Default '') -cne $paneId -or
+        [string](Get-WinsmuxRuntimeValue -InputObject $registryPane -Name 'backend' -Default '') -cne $backend -or
+        [string](Get-WinsmuxRuntimeValue -InputObject $registryPane -Name 'role' -Default '') -cne $role -or
+        [string](Get-WinsmuxRuntimeValue -InputObject $registryPane -Name 'title' -Default '') -cne $title) {
+        return & $targetMismatch 'Runtime target state, slot, pane, backend, role, or title does not match the manifest target.'
+    }
+
+    if ($Operation -ceq 'stop_transition') {
+        return New-WinsmuxRuntimeValidationResult -Valid $true -ReasonCode 'stop_transition_verified' `
+            -Diagnostic 'Captured runtime generation and target identity verified for an intentional stop transition.' `
+            -Context ([PSCustomObject][ordered]@{
+                session_name = $registrySessionName; server_session_id = $registryServerSession
+                generation_id = $registryGeneration; label = $label; slot_id = $slotId; pane_id = $paneId
+                backend = $backend; role = $role; title = $title; runtime_state = $registryState
+            })
+    }
+
+    if ($Operation -ceq 'start_deferred') {
+        $manifestStatus = [string](Get-WinsmuxRuntimeValue -InputObject $ManifestEntry -Name 'Status' -Default '')
+        $statusClassification = Get-WinsmuxRuntimeStatusClassification -Status $manifestStatus
+        if ($registryState -cne 'deferred' -or
+            -not [bool]$statusClassification.IsDeferred) {
+            return & $targetMismatch 'Only an explicitly deferred target may enter deferred startup.'
+        }
+        if ($null -ne $PaneMarker) {
+            if ([string]$statusClassification.NormalizedStatus -cne 'deferred_start_failed') {
+                return & $targetMismatch 'A pane marker already exists; deferred startup would duplicate or overwrite a bootstrap identity.'
+            }
+
+            $retryMarkerPid = ConvertTo-WinsmuxRuntimeInteger -Value (Get-WinsmuxRuntimeValue -InputObject $PaneMarker -Name 'bootstrap_pid' -Default $null)
+            $retryMarkerStartedAt = ConvertTo-WinsmuxRuntimeUtcIdentity -Value (Get-WinsmuxRuntimeValue -InputObject $PaneMarker -Name 'bootstrap_process_started_at' -Default '')
+            if ([string](Get-WinsmuxRuntimeValue -InputObject $PaneMarker -Name 'state' -Default '') -cne 'bootstrap_pending' -or
+                -not [string]::Equals(
+                    [string](Get-WinsmuxRuntimeValue -InputObject $PaneMarker -Name 'generation_id' -Default ''),
+                    $registryGeneration,
+                    [System.StringComparison]::Ordinal) -or
+                [string](Get-WinsmuxRuntimeValue -InputObject $PaneMarker -Name 'server_session_id' -Default '') -cne $registryServerSession -or
+                [string](Get-WinsmuxRuntimeValue -InputObject $PaneMarker -Name 'slot_id' -Default '') -cne $slotId -or
+                [string](Get-WinsmuxRuntimeValue -InputObject $PaneMarker -Name 'pane_id' -Default '') -cne $paneId -or
+                [string](Get-WinsmuxRuntimeValue -InputObject $PaneMarker -Name 'backend' -Default '') -cne $backend -or
+                [string](Get-WinsmuxRuntimeValue -InputObject $PaneMarker -Name 'role' -Default '') -cne $role -or
+                [string](Get-WinsmuxRuntimeValue -InputObject $PaneMarker -Name 'title' -Default '') -cne $title -or
+                $null -eq $retryMarkerPid -or [string]::IsNullOrWhiteSpace($retryMarkerStartedAt)) {
+                return & $targetMismatch 'Failed deferred retry marker does not match the current runtime target identity.'
+            }
+
+            $retryMarkerState = if (Test-WinsmuxStrictProcessIdentity -ProcessId $retryMarkerPid `
+                    -ExpectedStartTime $retryMarkerStartedAt -ProcessResolver $ProcessResolver) {
+                'live'
+            } else {
+                'stale'
+            }
+            return New-WinsmuxRuntimeValidationResult -Valid $true -ReasonCode 'deferred_retry_marker_verified' `
+                -Diagnostic 'Failed deferred retry marker is authenticated for bounded reuse or stale-marker recovery.' `
+                -Context ([PSCustomObject][ordered]@{
+                    session_name = $registrySessionName; server_session_id = $registryServerSession
+                    generation_id = $registryGeneration; label = $label; slot_id = $slotId; pane_id = $paneId
+                    backend = $backend; role = $role; title = $title; runtime_state = 'deferred'
+                    retry_marker_state = $retryMarkerState; retry_marker_pid = $retryMarkerPid
+                    retry_marker_process_started_at = $retryMarkerStartedAt
+                })
+        }
+        return New-WinsmuxRuntimeValidationResult -Valid $true -ReasonCode 'deferred_runtime_verified' `
+            -Diagnostic 'Deferred runtime target identity verified before startup.' -Context ([PSCustomObject][ordered]@{
+                session_name = $registrySessionName; server_session_id = $registryServerSession
+                generation_id = $registryGeneration; label = $label; slot_id = $slotId; pane_id = $paneId
+                backend = $backend; role = $role; title = $title; runtime_state = 'deferred'
+            })
+    }
+
+    if ($registryState -cne 'live') {
+        return & $targetMismatch 'Dispatch requires a live runtime target established after bootstrap readiness.'
+    }
+
+    if ($null -eq $PaneMarker) {
+        return & $targetMismatch 'Live target bootstrap marker is missing.'
+    }
+
+    $bootstrapPid = ConvertTo-WinsmuxRuntimeInteger -Value (Get-WinsmuxRuntimeValue -InputObject $registryPane -Name 'bootstrap_pid' -Default $null)
+    $bootstrapStartedAt = [string](Get-WinsmuxRuntimeValue -InputObject $registryPane -Name 'bootstrap_process_started_at' -Default '')
+    $markerBootstrapPid = ConvertTo-WinsmuxRuntimeInteger -Value (Get-WinsmuxRuntimeValue -InputObject $PaneMarker -Name 'bootstrap_pid' -Default $null)
+    if ($null -eq $bootstrapPid -or $null -eq $markerBootstrapPid -or
+        -not [string]::Equals(
+            [string](Get-WinsmuxRuntimeValue -InputObject $PaneMarker -Name 'generation_id' -Default ''),
+            $registryGeneration,
+            [System.StringComparison]::Ordinal) -or
+        [string](Get-WinsmuxRuntimeValue -InputObject $PaneMarker -Name 'server_session_id' -Default '') -cne $registryServerSession -or
+        [string](Get-WinsmuxRuntimeValue -InputObject $PaneMarker -Name 'slot_id' -Default '') -cne $slotId -or
+        [string](Get-WinsmuxRuntimeValue -InputObject $PaneMarker -Name 'pane_id' -Default '') -cne $paneId -or
+        [string](Get-WinsmuxRuntimeValue -InputObject $PaneMarker -Name 'backend' -Default '') -cne $backend -or
+        [string](Get-WinsmuxRuntimeValue -InputObject $PaneMarker -Name 'role' -Default '') -cne $role -or
+        [string](Get-WinsmuxRuntimeValue -InputObject $PaneMarker -Name 'title' -Default '') -cne $title -or
+        $markerBootstrapPid -ne $bootstrapPid -or
+        (ConvertTo-WinsmuxRuntimeUtcIdentity -Value (Get-WinsmuxRuntimeValue -InputObject $PaneMarker -Name 'bootstrap_process_started_at' -Default '')) -cne (ConvertTo-WinsmuxRuntimeUtcIdentity -Value $bootstrapStartedAt) -or
+        -not (Test-WinsmuxStrictProcessIdentity -ProcessId $bootstrapPid -ExpectedStartTime $bootstrapStartedAt -ProcessResolver $ProcessResolver)) {
+        return & $targetMismatch 'Live pane marker does not match the runtime registry and current bootstrap process identity.'
+    }
+
+    $requiresCallerIdentity = $Operation -ceq 'caller_ack' -and $backend -in @('local', 'codex')
+    $callerPid = ConvertTo-WinsmuxRuntimeInteger -Value (Get-WinsmuxRuntimeValue -InputObject $CallerIdentity -Name 'process_id' -Default $null)
+    $callerStartedAt = [string](Get-WinsmuxRuntimeValue -InputObject $CallerIdentity -Name 'process_started_at' -Default '')
+    if ($requiresCallerIdentity -and ($null -eq $CallerIdentity -or $null -eq $callerPid -or
+        -not [string]::Equals(
+            [string](Get-WinsmuxRuntimeValue -InputObject $CallerIdentity -Name 'generation_id' -Default ''),
+            $registryGeneration,
+            [System.StringComparison]::Ordinal) -or
+        [string](Get-WinsmuxRuntimeValue -InputObject $CallerIdentity -Name 'server_session_id' -Default '') -cne $registryServerSession -or
+        [string](Get-WinsmuxRuntimeValue -InputObject $CallerIdentity -Name 'slot_id' -Default '') -cne $slotId -or
+        [string](Get-WinsmuxRuntimeValue -InputObject $CallerIdentity -Name 'pane_id' -Default '') -cne $paneId -or
+        [string](Get-WinsmuxRuntimeValue -InputObject $CallerIdentity -Name 'backend' -Default '') -cne $backend -or
+        -not (Test-WinsmuxStrictProcessIdentity -ProcessId $callerPid -ExpectedStartTime $callerStartedAt -ProcessResolver $ProcessResolver))) {
+        return & $callerMismatch 'Caller evidence does not bind to the verified pane bootstrap identity.'
+    }
+
+    $visitedCallerPids = [System.Collections.Generic.HashSet[int]]::new()
+    $nextCallerPid = if ($null -eq $callerPid) { 0 } else { $callerPid }
+    $reachedBootstrap = $false
+    $sawCodexProcess = $false
+    foreach ($depth in 0..63) {
+        if ($nextCallerPid -lt 1 -or -not $visitedCallerPids.Add($nextCallerPid)) {
+            break
+        }
+
+        try {
+            $processSnapshot = & $ProcessResolver $nextCallerPid
+        } catch {
+            $processSnapshot = $null
+        }
+        if ($null -eq $processSnapshot) {
+            break
+        }
+
+        $snapshotPid = ConvertTo-WinsmuxRuntimeInteger -Value (Get-WinsmuxRuntimeValue -InputObject $processSnapshot -Name 'Id' -Default (Get-WinsmuxRuntimeValue -InputObject $processSnapshot -Name 'ProcessId' -Default $null))
+        $snapshotStartedAt = ConvertTo-WinsmuxRuntimeUtcIdentity -Value (Get-WinsmuxRuntimeValue -InputObject $processSnapshot -Name 'StartTime' -Default (Get-WinsmuxRuntimeValue -InputObject $processSnapshot -Name 'CreationDate' -Default ''))
+        $snapshotName = [string](Get-WinsmuxRuntimeValue -InputObject $processSnapshot -Name 'Name' -Default (Get-WinsmuxRuntimeValue -InputObject $processSnapshot -Name 'ProcessName' -Default ''))
+        if ($null -eq $snapshotPid -or $snapshotPid -ne $nextCallerPid -or [string]::IsNullOrWhiteSpace($snapshotStartedAt)) {
+            break
+        }
+
+        if ($snapshotName -match '^(?i:codex)(\.exe)?$') {
+            $sawCodexProcess = $true
+        }
+        if ($snapshotPid -eq $bootstrapPid) {
+            if ($snapshotStartedAt -ceq (ConvertTo-WinsmuxRuntimeUtcIdentity -Value $bootstrapStartedAt)) {
+                $reachedBootstrap = $true
+            }
+            break
+        }
+
+        $parentPid = ConvertTo-WinsmuxRuntimeInteger -Value (Get-WinsmuxRuntimeValue -InputObject $processSnapshot -Name 'ParentProcessId' -Default $null)
+        if ($null -eq $parentPid -or $parentPid -lt 1) {
+            break
+        }
+        $nextCallerPid = $parentPid
+    }
+
+    if ($requiresCallerIdentity -and (-not $reachedBootstrap -or ($backend -ceq 'codex' -and -not $sawCodexProcess))) {
+        return & $callerMismatch 'Observed OS process ancestry does not reach the verified pane bootstrap identity for this backend.'
+    }
+
+    $context = [PSCustomObject][ordered]@{
+        session_name      = $registrySessionName
+        server_session_id = $registryServerSession
+        generation_id     = $registryGeneration
+        label             = $label
+        slot_id           = $slotId
+        pane_id           = $paneId
+        backend           = $backend
+        role              = $role
+        title             = $title
+    }
+    return New-WinsmuxRuntimeValidationResult -Valid $true -ReasonCode 'live_runtime_verified' -Diagnostic 'Runtime identity verified.' -Context $context
+}
+
+function Clear-WinsmuxManifest {
+    param(
+        [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [AllowEmptyString()][string]$ExpectedGenerationId = ''
+    )
+
+    $path = Get-ManifestPath -ProjectDir $ProjectDir
+    return [bool](Invoke-WinsmuxWithFileLock -Path $path -Action {
+        if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
+            return $false
+        }
+
+        if (-not [string]::IsNullOrWhiteSpace($ExpectedGenerationId)) {
+            $currentManifest = Get-WinsmuxManifest -ProjectDir $ProjectDir
+            $currentIdentity = Get-WinsmuxVerifiedManifestIdentity -Manifest $currentManifest
+            if ($null -eq $currentIdentity) {
+                throw 'runtime dispatch refused (manifest_regeneration_required): Current manifest cannot be verified at the locked clear boundary.'
+            }
+            if (-not [string]::Equals(
+                    [string]$currentIdentity.generation_id,
+                    $ExpectedGenerationId,
+                    [System.StringComparison]::Ordinal)) {
+                throw 'runtime dispatch refused (invalid_supervisor_identity): Runtime generation changed at the locked manifest clear boundary.'
+            }
+        }
+
+        Remove-Item -LiteralPath $path -Force -ErrorAction Stop
+        return $true
+    })
 }
 
 function New-WinsmuxManifest {
@@ -289,15 +1164,98 @@ function Get-WinsmuxManifest {
     return ConvertFrom-ManifestYaml -Content $raw
 }
 
+function Get-WinsmuxVerifiedManifestIdentity {
+    param([AllowNull()]$Manifest)
+
+    if ($null -eq $Manifest) { return $null }
+    $version = ConvertTo-WinsmuxRuntimeInteger -Value (Get-WinsmuxRuntimeValue -InputObject $Manifest -Name 'version' -Default $null)
+    $session = Get-WinsmuxRuntimeValue -InputObject $Manifest -Name 'session'
+    if ($null -eq $version -or $version -ne 2 -or $null -eq $session) { return $null }
+
+    $identity = [PSCustomObject][ordered]@{
+        session_name      = [string](Get-WinsmuxRuntimeValue -InputObject $session -Name 'name' -Default '')
+        generation_id     = [string](Get-WinsmuxRuntimeValue -InputObject $session -Name 'generation_id' -Default '')
+        server_session_id = [string](Get-WinsmuxRuntimeValue -InputObject $session -Name 'server_session_id' -Default '')
+        bootstrap_pane_id = [string](Get-WinsmuxRuntimeValue -InputObject $session -Name 'bootstrap_pane_id' -Default '')
+    }
+    if ([string]::IsNullOrWhiteSpace($identity.session_name) -or
+        [string]::IsNullOrWhiteSpace($identity.generation_id) -or
+        [string]::IsNullOrWhiteSpace($identity.server_session_id) -or
+        $identity.bootstrap_pane_id -cnotmatch '^%[0-9]+$') {
+        return $null
+    }
+    return $identity
+}
+
 function Save-WinsmuxManifest {
     param(
         [Parameter(Mandatory = $true)][string]$ProjectDir,
-        [Parameter(Mandatory = $true)]$Manifest
+        [Parameter(Mandatory = $true)]$Manifest,
+        [AllowEmptyString()][string]$ExpectedGenerationId = ''
     )
 
     $path = Get-ManifestPath -ProjectDir $ProjectDir
+    $nextVersion = ConvertTo-WinsmuxRuntimeInteger -Value (Get-WinsmuxRuntimeValue -InputObject $Manifest -Name 'version' -Default $null)
+    $nextIdentity = Get-WinsmuxVerifiedManifestIdentity -Manifest $Manifest
     $yaml = ConvertTo-ManifestYaml -Manifest $Manifest
-    Write-ManifestTextFile -Path $path -Content $yaml
+    $validateLocked = {
+        $currentExists = Test-Path -LiteralPath $path -PathType Leaf
+        if (-not $currentExists) {
+            if (-not [string]::IsNullOrWhiteSpace($ExpectedGenerationId)) {
+                throw 'runtime dispatch refused (manifest_regeneration_required): Guarded v2 manifest mutation requires an existing verified document.'
+            }
+            return
+        }
+
+        $currentRaw = Get-Content -LiteralPath $path -Raw -Encoding UTF8
+        $currentManifest = $null
+        if (-not [string]::IsNullOrWhiteSpace($currentRaw)) {
+            try {
+                $currentManifest = ConvertFrom-ManifestYaml -Content $currentRaw
+            }
+            catch {
+                throw 'runtime dispatch refused (manifest_regeneration_required): Current manifest cannot be verified at the locked save boundary.'
+            }
+        }
+        $currentVersion = ConvertTo-WinsmuxRuntimeInteger -Value (Get-WinsmuxRuntimeValue -InputObject $currentManifest -Name 'version' -Default $null)
+
+        $isPureV1Save = $currentVersion -eq 1 -and
+            $nextVersion -eq 1 -and
+            [string]::IsNullOrWhiteSpace($ExpectedGenerationId)
+        if ($isPureV1Save) {
+            return
+        }
+        if ($currentVersion -ne 2 -or $nextVersion -ne 2) {
+            if ($currentVersion -eq 2) {
+                throw 'runtime dispatch refused (manifest_regeneration_required): Refusing to replace a verified v2 runtime manifest with an unverified or downgraded document.'
+            }
+            throw 'runtime dispatch refused (manifest_regeneration_required): Refusing to replace a runtime manifest unless both locked current and next documents are schema v2.'
+        }
+
+        $currentIdentity = Get-WinsmuxVerifiedManifestIdentity -Manifest $currentManifest
+        if ($null -eq $currentIdentity -or $null -eq $nextIdentity) {
+            throw 'runtime dispatch refused (manifest_regeneration_required): Refusing to replace a verified v2 runtime manifest with an unverified document.'
+        }
+        if ([string]::IsNullOrWhiteSpace($ExpectedGenerationId)) {
+            throw 'runtime dispatch refused (invalid_supervisor_identity): Refusing to replace a verified v2 runtime manifest without ExpectedGenerationId.'
+        }
+        if (-not [string]::Equals(
+                [string]$currentIdentity.generation_id,
+                $ExpectedGenerationId,
+                [System.StringComparison]::Ordinal) -or
+            -not [string]::Equals(
+                [string]$nextIdentity.generation_id,
+                $ExpectedGenerationId,
+                [System.StringComparison]::Ordinal)) {
+            throw 'runtime dispatch refused (invalid_supervisor_identity): Runtime generation changed at the locked manifest save boundary.'
+        }
+        if ($currentIdentity.session_name -cne $nextIdentity.session_name -or
+            $currentIdentity.server_session_id -cne $nextIdentity.server_session_id -or
+            $currentIdentity.bootstrap_pane_id -cne $nextIdentity.bootstrap_pane_id) {
+            throw 'runtime dispatch refused (runtime_target_mismatch): Refusing to replace a verified v2 runtime manifest with a different runtime identity.'
+        }
+    }
+    Write-ManifestTextFile -Path $path -Content $yaml -ValidateLocked $validateLocked
 }
 
 function ConvertTo-ManifestPaneEntry {
@@ -447,6 +1405,22 @@ function ConvertFrom-ManifestYaml {
     $currentLabel = ''
     $currentMode = ''
     $taskListKey = ''
+    $observedVersion2 = $false
+    $seenTopLevel = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+    $seenSessionKeys = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+    $seenPaneLabels = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+    $seenPaneKeys = [ordered]@{}
+    $seenWorktreeLabels = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+    $seenWorktreeKeys = [ordered]@{}
+    $duplicatePaths = [System.Collections.Generic.List[string]]::new()
+    $seenDuplicatePaths = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+
+    $recordDuplicate = {
+        param([Parameter(Mandatory = $true)][string]$Path)
+        if ($seenDuplicatePaths.Add($Path)) {
+            $duplicatePaths.Add($Path) | Out-Null
+        }
+    }
 
     foreach ($rawLine in ($Content -split "\r?\n")) {
         $line = $rawLine.TrimEnd()
@@ -455,17 +1429,21 @@ function ConvertFrom-ManifestYaml {
         }
 
         if ($line -match '^version:\s*(.*?)\s*$') {
+            if (-not $seenTopLevel.Add('version')) { & $recordDuplicate 'version' }
             $manifest.version = [int](ConvertFrom-ManifestYamlScalar $Matches[1])
+            if ($manifest.version -eq 2) { $observedVersion2 = $true }
             continue
         }
 
         if ($line -match '^saved_at:\s*(.*?)\s*$') {
+            if (-not $seenTopLevel.Add('saved_at')) { & $recordDuplicate 'saved_at' }
             $manifest.saved_at = [string](ConvertFrom-ManifestYamlScalar $Matches[1])
             continue
         }
 
         if ($line -match '^(session|panes|tasks|worktrees):\s*(\{\})?\s*$') {
             $section = $Matches[1]
+            if (-not $seenTopLevel.Add($section)) { & $recordDuplicate $section }
             $currentLabel = ''
             $currentMode = ''
             $taskListKey = ''
@@ -473,15 +1451,21 @@ function ConvertFrom-ManifestYaml {
         }
 
         if ($section -eq 'session' -and $line -match '^\s{2}([A-Za-z0-9_.-]+):\s*(.*?)\s*$') {
-            $manifest.session | Add-Member -NotePropertyName $Matches[1] -NotePropertyValue (ConvertFrom-ManifestYamlValue $Matches[2]) -Force
+            $propertyName = [string]$Matches[1]
+            if (-not $seenSessionKeys.Add($propertyName)) { & $recordDuplicate ("session.{0}" -f $propertyName) }
+            $manifest.session | Add-Member -NotePropertyName $propertyName -NotePropertyValue (ConvertFrom-ManifestYamlValue $Matches[2]) -Force
             continue
         }
 
         if ($section -eq 'panes') {
             if ($line -match '^\s{2}-\s+label:\s*(.*?)\s*$') {
                 $currentLabel = [string](ConvertFrom-ManifestYamlScalar $Matches[1])
+                if (-not $seenPaneLabels.Add($currentLabel)) { & $recordDuplicate ("panes.{0}" -f $currentLabel) }
                 if (-not $manifest.panes.Contains($currentLabel)) {
                     $manifest.panes[$currentLabel] = [ordered]@{ label = $currentLabel }
+                }
+                if (-not $seenPaneKeys.Contains($currentLabel)) {
+                    $seenPaneKeys[$currentLabel] = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
                 }
                 $currentMode = 'list'
                 continue
@@ -489,15 +1473,23 @@ function ConvertFrom-ManifestYaml {
 
             if ($line -match '^\s{2}(.+?):\s*$') {
                 $currentLabel = [string](ConvertFrom-ManifestYamlScalar $Matches[1])
+                if (-not $seenPaneLabels.Add($currentLabel)) { & $recordDuplicate ("panes.{0}" -f $currentLabel) }
                 if (-not $manifest.panes.Contains($currentLabel)) {
                     $manifest.panes[$currentLabel] = [ordered]@{}
+                }
+                if (-not $seenPaneKeys.Contains($currentLabel)) {
+                    $seenPaneKeys[$currentLabel] = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
                 }
                 $currentMode = 'dict'
                 continue
             }
 
             if (-not [string]::IsNullOrWhiteSpace($currentLabel) -and $line -match '^\s{4}([A-Za-z0-9_.-]+):\s*(.*?)\s*$') {
-                $manifest.panes[$currentLabel][$Matches[1]] = ConvertFrom-ManifestYamlValue $Matches[2]
+                $propertyName = [string]$Matches[1]
+                if (-not $seenPaneKeys[$currentLabel].Add($propertyName)) {
+                    & $recordDuplicate ("panes.{0}.{1}" -f $currentLabel, $propertyName)
+                }
+                $manifest.panes[$currentLabel][$propertyName] = ConvertFrom-ManifestYamlValue $Matches[2]
                 continue
             }
         }
@@ -518,17 +1510,29 @@ function ConvertFrom-ManifestYaml {
         if ($section -eq 'worktrees') {
             if ($line -match '^\s{2}(.+?):\s*$') {
                 $currentLabel = [string](ConvertFrom-ManifestYamlScalar $Matches[1])
+                if (-not $seenWorktreeLabels.Add($currentLabel)) { & $recordDuplicate ("worktrees.{0}" -f $currentLabel) }
                 if (-not $manifest.worktrees.Contains($currentLabel)) {
                     $manifest.worktrees[$currentLabel] = [ordered]@{}
+                }
+                if (-not $seenWorktreeKeys.Contains($currentLabel)) {
+                    $seenWorktreeKeys[$currentLabel] = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
                 }
                 continue
             }
 
             if (-not [string]::IsNullOrWhiteSpace($currentLabel) -and $line -match '^\s{4}([A-Za-z0-9_.-]+):\s*(.*?)\s*$') {
-                $manifest.worktrees[$currentLabel][$Matches[1]] = ConvertFrom-ManifestYamlValue $Matches[2]
+                $propertyName = [string]$Matches[1]
+                if (-not $seenWorktreeKeys[$currentLabel].Add($propertyName)) {
+                    & $recordDuplicate ("worktrees.{0}.{1}" -f $currentLabel, $propertyName)
+                }
+                $manifest.worktrees[$currentLabel][$propertyName] = ConvertFrom-ManifestYamlValue $Matches[2]
                 continue
             }
         }
+    }
+
+    if (($observedVersion2 -or $manifest.version -eq 2) -and $duplicatePaths.Count -gt 0) {
+        throw ("duplicate manifest key: {0}" -f [string]$duplicatePaths[0])
     }
 
     foreach ($label in @($manifest.panes.Keys)) {

--- a/winsmux-core/scripts/operator-poll.ps1
+++ b/winsmux-core/scripts/operator-poll.ps1
@@ -8,6 +8,7 @@ param(
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
 [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+. (Join-Path $PSScriptRoot 'json-compat.ps1')
 . (Join-Path $PSScriptRoot 'manifest.ps1')
 . (Join-Path $PSScriptRoot 'clm-safe-io.ps1')
 . (Join-Path $PSScriptRoot 'pane-control.ps1')
@@ -174,6 +175,8 @@ function Get-OperatorPollPaneContext {
     $eventLabel = [string](Get-OperatorPollValue -InputObject $EventRecord -Name 'label' -Default '')
     $eventRole = [string](Get-OperatorPollValue -InputObject $EventRecord -Name 'role' -Default '')
     $projectDir = Get-OperatorPollProjectDir -Manifest $Manifest -ManifestPath $ManifestPath
+    $manifestSession = Get-OperatorPollValue -InputObject $Manifest -Name 'Session' -Default $null
+    $generationId = [string](Get-OperatorPollValue -InputObject $manifestSession -Name 'generation_id' -Default '')
 
     $matchedLabel = $eventLabel
     $matchedPane = $null
@@ -225,6 +228,8 @@ function Get-OperatorPollPaneContext {
 
     return [ordered]@{
         project_dir   = $projectDir
+        manifest_path = $ManifestPath
+        generation_id = $generationId
         session_name  = Get-OperatorPollSessionName -Manifest $Manifest
         pane_id       = $resolvedPaneId
         label         = $matchedLabel
@@ -251,12 +256,14 @@ function Update-OperatorPollPaneState {
     }
 
     try {
-        $entry = @(Get-PaneControlManifestEntries -ProjectDir ([string]$PaneContext['project_dir']) | Where-Object { $_.PaneId -eq [string]$PaneContext['pane_id'] } | Select-Object -First 1)[0]
-        if ($null -eq $entry) {
+        $manifestPath = [string]$PaneContext['manifest_path']
+        if ([string]::IsNullOrWhiteSpace($manifestPath)) {
             return
         }
 
-        Set-PaneControlManifestPaneProperties -ManifestPath ([string]$entry.ManifestPath) -PaneId ([string]$entry.PaneId) -Properties $Properties
+        $expectedGenerationId = [string]$PaneContext['generation_id']
+        Set-PaneControlManifestPaneProperties -ManifestPath $manifestPath -PaneId ([string]$PaneContext['pane_id']) `
+            -Properties $Properties -ExpectedGenerationId $expectedGenerationId
     } catch {
         # Pane state enrichment is best-effort.
     }
@@ -564,7 +571,7 @@ function Receive-OperatorPollMailboxMessages {
 
             $mailboxMessage = $null
             try {
-                $mailboxMessage = $payload | ConvertFrom-Json -AsHashtable -ErrorAction Stop
+                $mailboxMessage = $payload | ConvertFrom-WinsmuxJson -AsHashtable -ErrorAction Stop
             } catch {
                 continue
             }
@@ -867,7 +874,7 @@ function Invoke-OperatorPollCycle {
             }
 
             try {
-                $eventRecord = $line | ConvertFrom-Json -AsHashtable -ErrorAction Stop
+                $eventRecord = $line | ConvertFrom-WinsmuxJson -AsHashtable -ErrorAction Stop
                 $eventRecord['source'] = 'events_jsonl'
                 $eventRecords.Add($eventRecord)
             } catch {
@@ -959,7 +966,7 @@ function Test-OperatorDraftPrCreated {
         }
 
         try {
-            $record = $line | ConvertFrom-Json -AsHashtable -ErrorAction Stop
+            $record = $line | ConvertFrom-WinsmuxJson -AsHashtable -ErrorAction Stop
         } catch {
             continue
         }
@@ -1076,7 +1083,7 @@ function Invoke-OperatorStateMachine {
                 if (Test-Path $rsp -PathType Leaf) {
                     $branch = (git -C $ProjectDir rev-parse --abbrev-ref HEAD 2>$null)
                     $headSha = (git -C $ProjectDir rev-parse HEAD 2>$null)
-                    $rs = Get-Content $rsp -Raw -Encoding UTF8 | ConvertFrom-Json -AsHashtable -ErrorAction Stop
+                    $rs = Get-Content $rsp -Raw -Encoding UTF8 | ConvertFrom-WinsmuxJson -AsHashtable -ErrorAction Stop
                     if ($rs.Contains($branch)) {
                         $e = $rs[$branch]
                         $st = [string]$e['status']

--- a/winsmux-core/scripts/orchestra-layout.ps1
+++ b/winsmux-core/scripts/orchestra-layout.ps1
@@ -25,6 +25,31 @@ if (-not $script:winsmuxBin) {
 function Invoke-OrchestraLayoutWinsmux {
     param([Parameter(Mandatory = $true)][string[]]$Arguments)
 
+    function Resolve-OrchestraLayoutTargetArguments {
+        param([Parameter(Mandatory = $true)][string[]]$InputArguments)
+
+        $resolved = @($InputArguments)
+        $namespaceActive = -not [string]::IsNullOrWhiteSpace($env:WINSMUX_BRIDGE_SESSION_NAMESPACE) -or
+            -not [string]::IsNullOrWhiteSpace($env:WINSMUX_BRIDGE_NAMESPACE_L) -or
+            -not [string]::IsNullOrWhiteSpace($env:WINSMUX_BRIDGE_SOCKET_S)
+        if (-not $namespaceActive -or [string]::IsNullOrWhiteSpace($SessionName)) {
+            return @($resolved)
+        }
+
+        for ($index = 0; $index -lt ($resolved.Count - 1); $index++) {
+            if ($resolved[$index] -ne '-t') {
+                continue
+            }
+
+            $target = [string]$resolved[$index + 1]
+            if ($target -match '^[%@]') {
+                $resolved[$index + 1] = "${SessionName}:$target"
+            }
+            break
+        }
+        return @($resolved)
+    }
+
     function Test-OrchestraLayoutRetrySafeCommand {
         param([Parameter(Mandatory = $true)][string[]]$InputArguments)
 
@@ -32,9 +57,10 @@ function Invoke-OrchestraLayoutWinsmux {
             return $false
         }
 
-        return $InputArguments[0] -in @('display-message', 'has-session', 'list-panes', 'select-pane')
+        return $InputArguments[0] -in @('display-message', 'has-session', 'list-panes')
     }
 
+    $effectiveArguments = @(Resolve-OrchestraLayoutTargetArguments -InputArguments $Arguments)
     $previousPsmuxTargetSession = $env:PSMUX_TARGET_SESSION
     $previousWinsmuxTargetSession = $env:WINSMUX_TARGET_SESSION
     try {
@@ -43,9 +69,9 @@ function Invoke-OrchestraLayoutWinsmux {
             $env:WINSMUX_TARGET_SESSION = $SessionName
         }
 
-        $attemptLimit = if (Test-OrchestraLayoutRetrySafeCommand -InputArguments $Arguments) { 5 } else { 1 }
+        $attemptLimit = if (Test-OrchestraLayoutRetrySafeCommand -InputArguments $effectiveArguments) { 5 } else { 1 }
         for ($attempt = 1; $attempt -le $attemptLimit; $attempt++) {
-            $output = Invoke-WinsmuxBridgeCommand -WinsmuxBin $script:winsmuxBin -Arguments $Arguments 2>&1
+            $output = Invoke-WinsmuxBridgeCommand -WinsmuxBin $script:winsmuxBin -Arguments $effectiveArguments 2>&1
             if ($LASTEXITCODE -eq 0) {
                 return $output
             }
@@ -55,13 +81,13 @@ function Invoke-OrchestraLayoutWinsmux {
                 $message = 'unknown winsmux error'
             }
 
-            $retryable = $message -match 'connection timed out|no server running'
+            $retryable = $message -match 'connection timed out|no server running|os error 10061'
             if ($attempt -lt $attemptLimit -and $retryable) {
                 Start-Sleep -Milliseconds (250 * $attempt)
                 continue
             }
 
-            throw "winsmux $($Arguments -join ' ') failed: $message"
+            throw "winsmux $($effectiveArguments -join ' ') failed: $message"
         }
     } finally {
         if ($null -eq $previousPsmuxTargetSession) {
@@ -226,7 +252,14 @@ if ($newPaneId -notmatch '^%\d+$') {
     throw "winsmux new-window returned an unexpected pane id: '$newPaneId'."
 }
 
-if (-not (Set-OrchestraPaneBorderOptions -WindowId $newWindowId -WinsmuxBin $script:winsmuxBin)) {
+$borderWindowTarget = $newWindowId
+$namespaceActive = -not [string]::IsNullOrWhiteSpace($env:WINSMUX_BRIDGE_SESSION_NAMESPACE) -or
+    -not [string]::IsNullOrWhiteSpace($env:WINSMUX_BRIDGE_NAMESPACE_L) -or
+    -not [string]::IsNullOrWhiteSpace($env:WINSMUX_BRIDGE_SOCKET_S)
+if ($namespaceActive) {
+    $borderWindowTarget = "${SessionName}:$newWindowId"
+}
+if (-not (Set-OrchestraPaneBorderOptions -WindowId $borderWindowTarget -WinsmuxBin $script:winsmuxBin)) {
     Write-Warning "Could not enable pane border labels for window $newWindowId."
 }
 

--- a/winsmux-core/scripts/orchestra-pane-bootstrap.ps1
+++ b/winsmux-core/scripts/orchestra-pane-bootstrap.ps1
@@ -6,13 +6,13 @@ param(
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
 [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
-. (Join-Path $PSScriptRoot 'clm-safe-io.ps1')
+. (Join-Path $PSScriptRoot 'manifest.ps1')
 
 if (-not (Test-Path -LiteralPath $PlanFile)) {
     throw "Orchestra pane bootstrap plan not found: $PlanFile"
 }
 
-$plan = Get-Content -LiteralPath $PlanFile -Raw -Encoding UTF8 | ConvertFrom-Json -Depth 8
+$plan = Get-Content -LiteralPath $PlanFile -Raw -Encoding UTF8 | ConvertFrom-Json
 
 if ([string]::IsNullOrWhiteSpace([string]$plan.launch_dir)) {
     throw "launch_dir missing in orchestra pane bootstrap plan: $PlanFile"
@@ -60,11 +60,19 @@ if (-not [string]::IsNullOrWhiteSpace($readyMarkerPath)) {
     }
 
     $markerJson = ([ordered]@{
-        pane_id       = [string]$plan.pane_id
-        startup_token = [string]$plan.startup_token
-        launch_dir    = $launchDir
-        current_dir   = (Get-Location).Path
-        written_at    = (Get-Date).ToString('o')
+        state                       = 'bootstrap_pending'
+        generation_id               = [string]$plan.generation_id
+        server_session_id           = [string]$plan.server_session_id
+        slot_id                      = [string]$plan.slot_id
+        pane_id                      = [string]$plan.pane_id
+        backend                      = [string]$plan.worker_backend
+        role                         = [string]$plan.worker_role
+        title                        = [string]$plan.pane_title
+        bootstrap_pid                = $PID
+        bootstrap_process_started_at = Get-WinsmuxRuntimeProcessStartedAt -ProcessId $PID
+        launch_dir                   = $launchDir
+        current_dir                  = (Get-Location).Path
+        written_at                   = (Get-Date).ToUniversalTime().ToString('o', [System.Globalization.CultureInfo]::InvariantCulture)
     } | ConvertTo-Json -Depth 6)
     Write-WinsmuxTextFile -Path $readyMarkerPath -Content $markerJson
 }

--- a/winsmux-core/scripts/orchestra-preflight.ps1
+++ b/winsmux-core/scripts/orchestra-preflight.ps1
@@ -292,10 +292,192 @@ function Remove-OrchestraZombieProcesses {
     }
 }
 
+function Get-OrchestraBridgeSessionNamespace {
+    $namespace = $env:WINSMUX_BRIDGE_SESSION_NAMESPACE
+    if ([string]::IsNullOrWhiteSpace($namespace)) {
+        if (-not [string]::IsNullOrWhiteSpace($env:WINSMUX_BRIDGE_SOCKET_S)) {
+            $namespace = Get-WinsmuxSocketNamespaceBase -SocketSelector $env:WINSMUX_BRIDGE_SOCKET_S
+        } elseif (-not [string]::IsNullOrWhiteSpace($env:WINSMUX_BRIDGE_NAMESPACE_L)) {
+            $namespace = $env:WINSMUX_BRIDGE_NAMESPACE_L
+        }
+    }
+
+    if ([string]::IsNullOrWhiteSpace($namespace)) {
+        return ''
+    }
+    return $namespace.Trim()
+}
+
+function ConvertFrom-OrchestraCommandLineTokens {
+    param([Parameter(Mandatory = $true)][string]$CommandLine)
+
+    $tokens = [System.Collections.Generic.List[string]]::new()
+    $token = [System.Text.StringBuilder]::new()
+    $quote = [char]0
+    $tokenWasQuoted = $false
+    $malformed = $false
+    $optionParsingStopped = $false
+
+    for ($index = 0; $index -lt $CommandLine.Length; $index++) {
+        $character = $CommandLine[$index]
+        if ($quote -ne [char]0) {
+            if ($character -eq $quote) {
+                $quote = [char]0
+                $tokenWasQuoted = $true
+                continue
+            }
+            if ($quote -eq '"' -and $character -eq '\' -and $index + 1 -lt $CommandLine.Length -and
+                $CommandLine[$index + 1] -eq '"') {
+                [void]$token.Append('"')
+                $index++
+                continue
+            }
+            [void]$token.Append($character)
+            continue
+        }
+
+        if ($character -eq '"' -or $character -eq "'") {
+            $quote = $character
+            $tokenWasQuoted = $true
+            continue
+        }
+        if ([char]::IsWhiteSpace($character)) {
+            if ($token.Length -eq 0 -and -not $tokenWasQuoted) {
+                continue
+            }
+            $value = $token.ToString()
+            if (-not $optionParsingStopped -and -not $tokenWasQuoted -and
+                [string]::Equals($value, '--', [System.StringComparison]::Ordinal)) {
+                $optionParsingStopped = $true
+            } elseif (-not $optionParsingStopped) {
+                $tokens.Add($value) | Out-Null
+            }
+            [void]$token.Clear()
+            $tokenWasQuoted = $false
+            continue
+        }
+        [void]$token.Append($character)
+    }
+
+    if ($quote -ne [char]0) {
+        $malformed = $true
+    } elseif ($token.Length -gt 0 -or $tokenWasQuoted) {
+        $value = $token.ToString()
+        if (-not $optionParsingStopped -and -not $tokenWasQuoted -and
+            [string]::Equals($value, '--', [System.StringComparison]::Ordinal)) {
+            $optionParsingStopped = $true
+        } elseif (-not $optionParsingStopped) {
+            $tokens.Add($value) | Out-Null
+        }
+    }
+
+    return [PSCustomObject]@{ Tokens = @($tokens); Malformed = $malformed }
+}
+
+function Get-OrchestraServerCommandSelectors {
+    param([Parameter(Mandatory = $true)][string]$CommandLine)
+
+    $tokenization = ConvertFrom-OrchestraCommandLineTokens -CommandLine $CommandLine
+    $tokens = @($tokenization.Tokens)
+
+    $serverCount = 0
+    $sessions = [System.Collections.Generic.List[string]]::new()
+    $namespaces = [System.Collections.Generic.List[object]]::new()
+    $malformed = [bool]$tokenization.Malformed
+    for ($index = 0; $index -lt $tokens.Count; $index++) {
+        $token = [string]$tokens[$index]
+        if ([string]::Equals($token, 'server', [System.StringComparison]::OrdinalIgnoreCase)) {
+            $serverCount++
+            continue
+        }
+
+        $kind = ''
+        $value = $null
+        if ([string]::Equals($token, '-s', [System.StringComparison]::Ordinal) -or
+            [string]::Equals($token, '--session', [System.StringComparison]::OrdinalIgnoreCase)) {
+            $kind = 'session'
+        } elseif ($token.StartsWith('-s=', [System.StringComparison]::Ordinal)) {
+            $kind = 'session'; $value = $token.Substring(3)
+        } elseif ($token.StartsWith('--session=', [System.StringComparison]::OrdinalIgnoreCase)) {
+            $kind = 'session'; $value = $token.Substring('--session='.Length)
+        } elseif ([string]::Equals($token, '-S', [System.StringComparison]::Ordinal)) {
+            $kind = 'socket'
+        } elseif ($token.StartsWith('-S=', [System.StringComparison]::Ordinal)) {
+            $kind = 'socket'; $value = $token.Substring(3)
+        } elseif ([string]::Equals($token, '-L', [System.StringComparison]::Ordinal)) {
+            $kind = 'literal'
+        } elseif ($token.StartsWith('-L=', [System.StringComparison]::Ordinal)) {
+            $kind = 'literal'; $value = $token.Substring(3)
+        } else {
+            continue
+        }
+
+        if ($null -eq $value) {
+            if ($index + 1 -ge $tokens.Count) {
+                $malformed = $true
+                break
+            }
+            $index++
+            $value = [string]$tokens[$index]
+        }
+        if ([string]::IsNullOrWhiteSpace([string]$value)) {
+            $malformed = $true
+            break
+        }
+        if ($kind -eq 'session') {
+            $sessions.Add([string]$value) | Out-Null
+        } else {
+            $namespaces.Add([PSCustomObject]@{ Kind = $kind; Value = [string]$value }) | Out-Null
+        }
+    }
+
+    return [PSCustomObject]@{
+        Malformed = $malformed
+        ServerCount = $serverCount
+        Sessions = @($sessions)
+        Namespaces = @($namespaces)
+    }
+}
+
+function Test-OrchestraServerProcessNamespace {
+    param(
+        [Parameter(Mandatory = $true)][string]$CommandLine,
+        [AllowEmptyString()][string]$Namespace = ''
+    )
+
+    $selectors = Get-OrchestraServerCommandSelectors -CommandLine $CommandLine
+    if ([bool]$selectors.Malformed) {
+        return $false
+    }
+    $namespaceSelectors = @($selectors.Namespaces)
+    if ([string]::IsNullOrWhiteSpace($Namespace)) {
+        return $namespaceSelectors.Count -eq 0
+    }
+    if ($namespaceSelectors.Count -ne 1) {
+        return $false
+    }
+
+    $selector = $namespaceSelectors[0]
+    if ([string]$selector.Kind -eq 'socket') {
+        $socketNamespace = Get-WinsmuxSocketNamespaceBase -SocketSelector ([string]$selector.Value)
+        return [string]::Equals(
+            [string]$socketNamespace,
+            $Namespace.Trim(),
+            [System.StringComparison]::OrdinalIgnoreCase
+        )
+    }
+    return [string]::Equals(
+        [string]$selector.Value,
+        $Namespace.Trim(),
+        [System.StringComparison]::OrdinalIgnoreCase
+    )
+}
+
 function Test-OrchestraSessionServerProcess {
     param(
         [AllowNull()]$Process,
-        [Parameter(Mandatory = $true)][string]$SessionName
+        [Parameter(Mandatory = $true)][string]$SessionName,
+        [AllowEmptyString()][string]$Namespace = (Get-OrchestraBridgeSessionNamespace)
     )
 
     if ($null -eq $Process) {
@@ -312,25 +494,17 @@ function Test-OrchestraSessionServerProcess {
         return $false
     }
 
-    if ($commandLine.IndexOf(' server', [System.StringComparison]::OrdinalIgnoreCase) -lt 0 -and
-        $commandLine.IndexOf('"server"', [System.StringComparison]::OrdinalIgnoreCase) -lt 0) {
+    $selectors = Get-OrchestraServerCommandSelectors -CommandLine $commandLine
+    if ([bool]$selectors.Malformed -or [int]$selectors.ServerCount -ne 1) {
+        return $false
+    }
+    $sessions = @($selectors.Sessions)
+    if ($sessions.Count -ne 1 -or
+        -not [string]::Equals([string]$sessions[0], $SessionName, [System.StringComparison]::Ordinal)) {
         return $false
     }
 
-    foreach ($marker in @(
-        "-s $SessionName",
-        "-s `"$SessionName`"",
-        "-s '$SessionName'",
-        "--session $SessionName",
-        "--session `"$SessionName`"",
-        "--session '$SessionName'"
-    )) {
-        if ($commandLine.IndexOf($marker, [System.StringComparison]::OrdinalIgnoreCase) -ge 0) {
-            return $true
-        }
-    }
-
-    return $false
+    return Test-OrchestraServerProcessNamespace -CommandLine $commandLine -Namespace $Namespace
 }
 
 function Remove-OrchestraSessionServerProcesses {
@@ -338,7 +512,10 @@ function Remove-OrchestraSessionServerProcesses {
         [Parameter(Mandatory = $true)][string]$SessionName,
         [Parameter(Mandatory = $true)][string]$WinsmuxBin,
         [switch]$IncludeExpectedBinary,
-        [AllowNull()]$ProcessSnapshot = $null
+        [AllowNull()]$ProcessSnapshot = $null,
+        [scriptblock]$PostStopSnapshotResolver = { Get-ProcessSnapshot },
+        [ValidateRange(1, 100)][int]$VerificationAttempts = 20,
+        [ValidateRange(0, 5000)][int]$VerificationIntervalMilliseconds = 100
     )
 
     $snapshot = if ($null -ne $ProcessSnapshot) { $ProcessSnapshot } else { Get-ProcessSnapshot }
@@ -356,14 +533,33 @@ function Remove-OrchestraSessionServerProcesses {
         }
     }
 
+    $sessionNamespace = Get-OrchestraBridgeSessionNamespace
+    $selectRetirementCandidates = {
+        param([Parameter(Mandatory = $true)]$InputSnapshot)
+
+        return @(
+            $InputSnapshot.Processes |
+                Where-Object { Test-OrchestraSessionServerProcess -Process $_ -SessionName $SessionName -Namespace $sessionNamespace } |
+                Where-Object {
+                    $candidatePath = if ($null -ne $_.PSObject.Properties['ExecutablePath']) { [string]$_.ExecutablePath } else { '' }
+                    $isExpectedBinary = -not [string]::IsNullOrWhiteSpace($candidatePath) -and
+                        -not [string]::IsNullOrWhiteSpace($expectedWinsmuxPath) -and
+                        [string]::Equals($candidatePath, $expectedWinsmuxPath, [System.StringComparison]::OrdinalIgnoreCase)
+                    return ($IncludeExpectedBinary -or -not $isExpectedBinary)
+                } |
+                Sort-Object -Property ProcessId
+        )
+    }
     $serverProcesses = @(
         $snapshot.Processes |
-            Where-Object { Test-OrchestraSessionServerProcess -Process $_ -SessionName $SessionName } |
+            Where-Object { Test-OrchestraSessionServerProcess -Process $_ -SessionName $SessionName -Namespace $sessionNamespace } |
             Sort-Object -Property ProcessId
     )
+    $retirementCandidates = @(& $selectRetirementCandidates $snapshot)
     $killed = [System.Collections.Generic.List[object]]::new()
+    $stopErrors = [System.Collections.Generic.List[string]]::new()
 
-    foreach ($serverProcess in $serverProcesses) {
+    foreach ($serverProcess in $retirementCandidates) {
         $serverPid = [int]$serverProcess.ProcessId
         if ($protectedIds.Contains($serverPid)) {
             continue
@@ -373,13 +569,6 @@ function Remove-OrchestraSessionServerProcesses {
         if ($null -ne $serverProcess.PSObject.Properties['ExecutablePath']) {
             $actualPath = [string]$serverProcess.ExecutablePath
         }
-        $matchesExpectedPath = -not [string]::IsNullOrWhiteSpace($actualPath) -and
-            -not [string]::IsNullOrWhiteSpace($expectedWinsmuxPath) -and
-            [string]::Equals($actualPath, $expectedWinsmuxPath, [System.StringComparison]::OrdinalIgnoreCase)
-        if ($matchesExpectedPath -and -not $IncludeExpectedBinary) {
-            continue
-        }
-
         $idsToStop = @(Get-DescendantProcessIds -Snapshot $snapshot -RootProcessIds @($serverPid)) |
             Sort-Object -Descending
         foreach ($processId in $idsToStop) {
@@ -405,14 +594,45 @@ function Remove-OrchestraSessionServerProcesses {
                     } | Out-Null
                 }
             } catch {
+                $stopError = "process $([int]$processId): $($_.Exception.Message)"
+                $stopErrors.Add($stopError) | Out-Null
                 Write-Warning ("Preflight: failed to kill stale session process {0}: {1}" -f [int]$processId, $_.Exception.Message)
             }
         }
     }
 
+    $remaining = @()
+    foreach ($attempt in 1..$VerificationAttempts) {
+        $postStopSnapshot = & $PostStopSnapshotResolver
+        if ($null -eq $postStopSnapshot) {
+            throw 'Preflight: post-stop process snapshot is unavailable.'
+        }
+        $remaining = @(& $selectRetirementCandidates $postStopSnapshot)
+        if ($remaining.Count -eq 0) {
+            break
+        }
+        if ($attempt -lt $VerificationAttempts -and $VerificationIntervalMilliseconds -gt 0) {
+            Start-Sleep -Milliseconds $VerificationIntervalMilliseconds
+        }
+    }
+
+    if ($stopErrors.Count -gt 0 -or $remaining.Count -gt 0) {
+        $parts = [System.Collections.Generic.List[string]]::new()
+        if ($stopErrors.Count -gt 0) {
+            $parts.Add('stop failures: ' + ($stopErrors -join '; ')) | Out-Null
+        }
+        if ($remaining.Count -gt 0) {
+            $remainingIds = @($remaining | ForEach-Object { [string][int]$_.ProcessId }) -join ', '
+            $parts.Add("server processes remain after retirement: $remainingIds") | Out-Null
+        }
+        throw ('Preflight: session server retirement incomplete: ' + ($parts -join ' | '))
+    }
+
     return [PSCustomObject]@{
-        SessionProcesses = @($serverProcesses)
-        Killed           = @($killed)
+        SessionProcesses         = @($serverProcesses)
+        Killed                   = @($killed)
+        RemainingSessionProcesses = @($remaining)
+        Errors                   = @($stopErrors)
     }
 }
 
@@ -545,14 +765,7 @@ function Get-WinsmuxSocketNamespaceBase {
 function Get-OrchestraSessionRegistryBaseName {
     param([Parameter(Mandatory = $true)][string]$SessionName)
 
-    $namespace = $env:WINSMUX_BRIDGE_SESSION_NAMESPACE
-    if ([string]::IsNullOrWhiteSpace($namespace)) {
-        if (-not [string]::IsNullOrWhiteSpace($env:WINSMUX_BRIDGE_SOCKET_S)) {
-            $namespace = Get-WinsmuxSocketNamespaceBase -SocketSelector $env:WINSMUX_BRIDGE_SOCKET_S
-        } elseif (-not [string]::IsNullOrWhiteSpace($env:WINSMUX_BRIDGE_NAMESPACE_L)) {
-            $namespace = $env:WINSMUX_BRIDGE_NAMESPACE_L.Trim()
-        }
-    }
+    $namespace = Get-OrchestraBridgeSessionNamespace
 
     if ([string]::IsNullOrWhiteSpace($namespace)) {
         return $SessionName

--- a/winsmux-core/scripts/orchestra-smoke.ps1
+++ b/winsmux-core/scripts/orchestra-smoke.ps1
@@ -12,6 +12,7 @@ Set-StrictMode -Version Latest
 $scriptsRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
 . (Join-Path $scriptsRoot 'settings.ps1')
 . (Join-Path $scriptsRoot 'manifest.ps1')
+. (Join-Path $scriptsRoot 'pane-control.ps1')
 . (Join-Path $scriptsRoot 'orchestra-ui-attach.ps1')
 . (Join-Path $scriptsRoot 'worker-isolation.ps1')
 
@@ -77,6 +78,80 @@ function ConvertTo-OrchestraSmokeBoolean {
         '0' { return $false }
         '' { return $false }
         default { return [bool]$Value }
+    }
+}
+
+function Get-OrchestraSmokeRuntimeValidity {
+    param(
+        [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [Parameter(Mandatory = $true)][int]$ExpectedPaneCount
+    )
+
+    $entryResults = [System.Collections.Generic.List[object]]::new()
+    try {
+        $entries = @(Get-PaneControlManifestEntries -ProjectDir $ProjectDir)
+    } catch {
+        return [ordered]@{
+            valid        = $false
+            reason_code  = 'manifest_regeneration_required'
+            diagnostic   = 'Runtime manifest is unavailable or malformed; regenerate the orchestra session.'
+            expected     = $ExpectedPaneCount
+            verified     = 0
+            entries      = @()
+        }
+    }
+
+    foreach ($entry in $entries) {
+        $status = [string](Get-PaneControlValue -InputObject $entry -Name 'Status' -Default '')
+        $operation = [string](Get-WinsmuxRuntimeStatusClassification -Status $status).RuntimeOperation
+        try {
+            $validation = Test-PaneControlRuntimeContext -ProjectDir $ProjectDir -ManifestEntry $entry -Operation $operation
+        } catch {
+            $validation = New-WinsmuxRuntimeValidationResult -Valid $false -ReasonCode 'manifest_regeneration_required' -Diagnostic 'Runtime identity evidence is unavailable; regenerate the orchestra session.'
+        }
+        $entryResults.Add([ordered]@{
+            slot_id      = [string](Get-PaneControlValue -InputObject $entry -Name 'SlotId' -Default '')
+            pane_id      = [string](Get-PaneControlValue -InputObject $entry -Name 'PaneId' -Default '')
+            backend      = [string](Get-PaneControlValue -InputObject $entry -Name 'WorkerBackend' -Default '')
+            role         = [string](Get-PaneControlValue -InputObject $entry -Name 'Role' -Default '')
+            title        = [string](Get-PaneControlValue -InputObject $entry -Name 'Title' -Default '')
+            valid        = [bool]$validation.valid
+            reason_code  = [string]$validation.reason_code
+            diagnostic   = [string]$validation.diagnostic
+        }) | Out-Null
+    }
+
+    $invalidEntries = @($entryResults | Where-Object { -not [bool]$_.valid })
+    $verifiedCount = @($entryResults | Where-Object { [bool]$_.valid }).Count
+    $countMatches = $entryResults.Count -eq $ExpectedPaneCount
+    $overallValid = $countMatches -and $invalidEntries.Count -eq 0
+    $reasonCode = ''
+    $diagnostic = 'Every expected runtime slot is bound to the live supervisor registry and server observation.'
+    if (-not $overallValid) {
+        $reasonCodes = @($invalidEntries | ForEach-Object { [string]$_.reason_code })
+        if ($reasonCodes -contains 'invalid_supervisor_identity') {
+            $reasonCode = 'invalid_supervisor_identity'
+        } elseif ($reasonCodes -contains 'manifest_regeneration_required' -or -not $countMatches) {
+            $reasonCode = 'manifest_regeneration_required'
+        } elseif ($reasonCodes -contains 'caller_identity_mismatch') {
+            $reasonCode = 'caller_identity_mismatch'
+        } else {
+            $reasonCode = 'runtime_target_mismatch'
+        }
+        $diagnostic = if (-not $countMatches) {
+            "Runtime registry verification covered $($entryResults.Count) entries; expected $ExpectedPaneCount."
+        } else {
+            'One or more runtime identities failed supervisor, generation, server, or pane mapping validation.'
+        }
+    }
+
+    return [ordered]@{
+        valid        = $overallValid
+        reason_code  = $reasonCode
+        diagnostic   = $diagnostic
+        expected     = $ExpectedPaneCount
+        verified     = $verifiedCount
+        entries      = @($entryResults)
     }
 }
 
@@ -603,6 +678,7 @@ function Get-OrchestraSmokeProbeState {
             $manifestReadError = $_.Exception.Message
         }
     }
+    $runtimeIdentity = Get-OrchestraSmokeRuntimeValidity -ProjectDir $ProjectDir -ExpectedPaneCount $ExpectedPaneCount
 
     return [ordered]@{
         ManifestPath      = $manifestPath
@@ -613,6 +689,8 @@ function Get-OrchestraSmokeProbeState {
         PaneProbeOk       = $paneProbeOk
         PaneProbeError    = $paneProbeError
         SessionReady      = $sessionReady
+        RuntimeValid      = [bool]$runtimeIdentity.valid
+        RuntimeIdentity   = $runtimeIdentity
         UiAttachLaunched  = $uiAttachLaunched
         UiAttached        = $uiAttached
         UiAttachStatus    = $uiAttachStatus
@@ -635,7 +713,7 @@ function Wait-OrchestraSmokeConvergence {
     )
 
     $state = Get-OrchestraSmokeProbeState -ProjectDir $ProjectDir -SessionName $SessionName -ExpectedPaneCount $ExpectedPaneCount -WinsmuxBin $WinsmuxBin
-    $needsConvergence = (-not $state.ManifestFound) -or (-not $state.ManifestReadable) -or (-not $state.SessionReady) -or ((-not [string]::IsNullOrWhiteSpace($WinsmuxBin)) -and ((-not $state.PaneProbeOk) -or ($state.PaneCount -lt $ExpectedPaneCount)))
+    $needsConvergence = (-not $state.ManifestFound) -or (-not $state.ManifestReadable) -or (-not $state.SessionReady) -or (-not $state.RuntimeValid) -or ((-not [string]::IsNullOrWhiteSpace($WinsmuxBin)) -and ((-not $state.PaneProbeOk) -or ($state.PaneCount -lt $ExpectedPaneCount)))
     if (-not $needsConvergence) {
         return $state
     }
@@ -644,7 +722,7 @@ function Wait-OrchestraSmokeConvergence {
     while ((Get-Date) -lt $deadline) {
         Start-Sleep -Seconds 1
         $state = Get-OrchestraSmokeProbeState -ProjectDir $ProjectDir -SessionName $SessionName -ExpectedPaneCount $ExpectedPaneCount -WinsmuxBin $WinsmuxBin
-        if ($state.ManifestFound -and $state.ManifestReadable -and $state.SessionReady -and $state.PaneProbeOk -and $state.PaneCount -ge $ExpectedPaneCount) {
+        if ($state.ManifestFound -and $state.ManifestReadable -and $state.SessionReady -and $state.RuntimeValid -and $state.PaneProbeOk -and $state.PaneCount -ge $ExpectedPaneCount) {
             return $state
         }
     }
@@ -796,7 +874,7 @@ $attachedClientCount = [int]$clientSnapshot.Count
 
 $startOutput = ''
 $startExitCode = 0
-$sessionAlreadyHealthy = $paneProbeOk -and $paneCount -ge $expectedPaneCount -and $manifestFound -and $manifestReadable
+$sessionAlreadyHealthy = $paneProbeOk -and $paneCount -ge $expectedPaneCount -and $manifestFound -and $manifestReadable -and [bool]$probeState.SessionReady -and [bool]$probeState.RuntimeValid
 if ($sessionAlreadyHealthy) {
     $startOutput = 'Skipped orchestra-start; existing orchestra session already meets the smoke prerequisites.'
 } elseif ($AutoStart) {
@@ -830,6 +908,8 @@ $clientProbeError = [string]$clientSnapshot.Error
 $attachedClientCount = [int]$clientSnapshot.Count
 
 $sessionReady = [bool]$probeState.SessionReady
+$runtimeIdentity = $probeState.RuntimeIdentity
+$runtimeValid = [bool]$probeState.RuntimeValid
 $uiAttachLaunched = [bool]$probeState.UiAttachLaunched
 $attachState = Read-OrchestraAttachState -SessionName $SessionName
 $attachResolution = Resolve-OrchestraSmokeAttachState -ProbeState ([pscustomobject]@{
@@ -877,6 +957,9 @@ if (-not $manifestFound) {
     $smokeErrors.Add("manifest read failed during startup convergence: $manifestReadError") | Out-Null
 }
 if (-not $sessionReady) { $smokeErrors.Add('session_ready is false.') | Out-Null }
+if (-not $runtimeValid) {
+    $smokeErrors.Add(("runtime identity invalid ({0}): {1}" -f [string]$runtimeIdentity.reason_code, [string]$runtimeIdentity.diagnostic)) | Out-Null
+}
 if (-not $paneProbeOk) { $smokeErrors.Add("pane probe failed: $paneProbeError") | Out-Null }
 if ($paneProbeOk -and $paneCount -lt $expectedPaneCount) { $smokeErrors.Add("pane count $paneCount is below expected $expectedPaneCount.") | Out-Null }
 if (-not [bool]$workerIsolation.ok) {
@@ -929,6 +1012,8 @@ $result = [ordered]@{
     expected_pane_count = $expectedPaneCount
     manifest_found      = $manifestFound
     session_ready       = $sessionReady
+    runtime_valid       = $runtimeValid
+    runtime_identity    = $runtimeIdentity
     ui_attach_launched  = $uiAttachLaunched
     ui_attached         = $uiAttached
     ui_attach_status    = $uiAttachStatus

--- a/winsmux-core/scripts/orchestra-start.ps1
+++ b/winsmux-core/scripts/orchestra-start.ps1
@@ -61,18 +61,35 @@ function Publish-OrchestraPaneLabels {
         }
     }
 
-    $seenTitles = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::Ordinal)
+    $publishedAliases = [System.Collections.Generic.Dictionary[string, string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+    $publishedPaneCount = 0
     foreach ($paneSummary in @($PaneSummaries)) {
+        $label = [string](Get-OrchestraObjectPropertyValue -InputObject $paneSummary -Name 'Label' -Default '')
+        $slotId = [string](Get-OrchestraObjectPropertyValue -InputObject $paneSummary -Name 'SlotId' -Default '')
         $title = [string](Get-OrchestraObjectPropertyValue -InputObject $paneSummary -Name 'Title' -Default '')
         $paneId = [string](Get-OrchestraObjectPropertyValue -InputObject $paneSummary -Name 'PaneId' -Default '')
-        if ([string]::IsNullOrWhiteSpace($title) -or $paneId -cnotmatch '^%[0-9]+$' -or -not $seenTitles.Add($title)) {
-            throw 'Orchestra label publication requires unique non-empty titles and valid pane ids.'
+        if ([string]::IsNullOrWhiteSpace($label) -or [string]::IsNullOrWhiteSpace($slotId) -or
+            [string]::IsNullOrWhiteSpace($title) -or $paneId -cnotmatch '^%[0-9]+$') {
+            throw 'Orchestra label publication requires non-empty slot labels and titles with valid pane ids.'
         }
-        $labels[$title] = $paneId
+
+        $paneAliases = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+        foreach ($alias in @($label, $slotId, $title)) {
+            if (-not $paneAliases.Add($alias)) { continue }
+            if ($publishedAliases.ContainsKey($alias) -and $publishedAliases[$alias] -cne $paneId) {
+                throw 'Orchestra label publication requires unique non-empty titles and slot labels.'
+            }
+            $publishedAliases[$alias] = $paneId
+        }
+        $publishedPaneCount++
+    }
+
+    foreach ($alias in $publishedAliases.Keys) {
+        $labels[$alias] = $publishedAliases[$alias]
     }
 
     Write-OrchestraTextFile -Path $labelsPath -Content (($labels | ConvertTo-Json -Depth 5) + "`n")
-    return [PSCustomObject][ordered]@{ Path = $labelsPath; PublishedCount = $seenTitles.Count }
+    return [PSCustomObject][ordered]@{ Path = $labelsPath; PublishedCount = $publishedPaneCount }
 }
 
 function Invoke-Winsmux {
@@ -416,6 +433,145 @@ function Reset-OrchestraServerSession {
     }
 }
 
+function Get-OrchestraRuntimeRegistryRetirementPlan {
+    param(
+        [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [Parameter(Mandatory = $true)][string]$ExpectedSessionName,
+        [AllowEmptyString()][string]$ExpectedGenerationId = '',
+        [AllowEmptyString()][string]$ExpectedServerSessionId = '',
+        [Nullable[int]]$ExpectedSupervisorPid = $null,
+        [AllowEmptyString()][string]$ExpectedSupervisorProcessStartedAt = ''
+    )
+
+    $registry = Read-WinsmuxRuntimeRegistry -ProjectDir $ProjectDir
+    if ($null -eq $registry) {
+        return [PSCustomObject][ordered]@{
+            Present                    = $false
+            RequiresClose              = $false
+            GenerationId               = ''
+            SupervisorPid              = 0
+            SupervisorProcessStartedAt = ''
+        }
+    }
+
+    $status = [string](Get-WinsmuxRuntimeValue -InputObject $registry -Name 'status' -Default '')
+    if ($status -ceq 'ended') {
+        return [PSCustomObject][ordered]@{
+            Present                    = $true
+            RequiresClose              = $false
+            GenerationId               = [string](Get-WinsmuxRuntimeValue -InputObject $registry -Name 'generation_id' -Default '')
+            SupervisorPid              = 0
+            SupervisorProcessStartedAt = ''
+        }
+    }
+    if ($status -cne 'active') {
+        throw "Runtime registry status cannot be retired safely: '$status'."
+    }
+
+    $supervisor = Get-WinsmuxRuntimeValue -InputObject $registry -Name 'supervisor'
+    $registrySupervisorPid = ConvertTo-WinsmuxRuntimeInteger -Value (
+        Get-WinsmuxRuntimeValue -InputObject $supervisor -Name 'pid' -Default $null
+    )
+    $registrySupervisorStartedAt = ConvertTo-WinsmuxRuntimeUtcIdentity -Value (
+        Get-WinsmuxRuntimeValue -InputObject $supervisor -Name 'process_started_at' -Default ''
+    )
+    $expectedSupervisorStartedAt = ConvertTo-WinsmuxRuntimeUtcIdentity -Value $ExpectedSupervisorProcessStartedAt
+    $identityMatches = (
+        -not [string]::IsNullOrWhiteSpace($ExpectedSessionName) -and
+        -not [string]::IsNullOrWhiteSpace($ExpectedGenerationId) -and
+        -not [string]::IsNullOrWhiteSpace($ExpectedServerSessionId) -and
+        $null -ne $ExpectedSupervisorPid -and [int]$ExpectedSupervisorPid -gt 0 -and
+        $null -ne $registrySupervisorPid -and
+        -not [string]::IsNullOrWhiteSpace($registrySupervisorStartedAt) -and
+        [string](Get-WinsmuxRuntimeValue -InputObject $registry -Name 'session_name' -Default '') -ceq $ExpectedSessionName -and
+        [string]::Equals(
+            [string](Get-WinsmuxRuntimeValue -InputObject $registry -Name 'generation_id' -Default ''),
+            $ExpectedGenerationId,
+            [System.StringComparison]::Ordinal
+        ) -and
+        [string](Get-WinsmuxRuntimeValue -InputObject $registry -Name 'server_session_id' -Default '') -ceq $ExpectedServerSessionId -and
+        [int]$registrySupervisorPid -eq [int]$ExpectedSupervisorPid
+    )
+    if ($identityMatches -and -not [string]::IsNullOrWhiteSpace($ExpectedSupervisorProcessStartedAt)) {
+        $identityMatches = (
+            -not [string]::IsNullOrWhiteSpace($expectedSupervisorStartedAt) -and
+            $registrySupervisorStartedAt -ceq $expectedSupervisorStartedAt
+        )
+    }
+    if (-not $identityMatches) {
+        throw 'Active runtime registry identity does not match the retired runtime.'
+    }
+
+    $processResolver = New-WinsmuxProcessSnapshotResolver
+    try {
+        $observedSupervisor = & $processResolver ([int]$registrySupervisorPid)
+    } catch {
+        throw 'Active runtime registry OS process identity is unavailable.'
+    }
+    if ($null -ne $observedSupervisor -and
+        -not (Test-WinsmuxStrictProcessIdentity -ProcessId ([int]$registrySupervisorPid) `
+            -ExpectedStartTime $registrySupervisorStartedAt -ProcessResolver $processResolver)) {
+        throw 'Active runtime registry OS process identity does not match the recorded supervisor.'
+    }
+
+    return [PSCustomObject][ordered]@{
+        Present                    = $true
+        RequiresClose              = $true
+        SessionName                = $ExpectedSessionName
+        ServerSessionId            = $ExpectedServerSessionId
+        GenerationId               = $ExpectedGenerationId
+        SupervisorPid              = [int]$registrySupervisorPid
+        SupervisorProcessStartedAt = $registrySupervisorStartedAt
+    }
+}
+
+function Complete-OrchestraRuntimeRegistryRetirement {
+    param(
+        [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [Parameter(Mandatory = $true)]$Plan
+    )
+
+    if (-not [bool]$Plan.RequiresClose) {
+        return $false
+    }
+
+    $closed = Close-WinsmuxRuntimeRegistry -ProjectDir $ProjectDir `
+        -GenerationId ([string]$Plan.GenerationId) `
+        -SupervisorPid ([int]$Plan.SupervisorPid) `
+        -SupervisorProcessStartedAt ([string]$Plan.SupervisorProcessStartedAt) `
+        -ExpectedSessionName ([string]$Plan.SessionName) `
+        -ExpectedServerSessionId ([string]$Plan.ServerSessionId)
+    if (-not $closed) {
+        throw 'Runtime registry retirement was refused because ownership changed.'
+    }
+
+    $verified = Read-WinsmuxRuntimeRegistry -ProjectDir $ProjectDir
+    $verifiedSupervisor = Get-WinsmuxRuntimeValue -InputObject $verified -Name 'supervisor'
+    $verifiedLease = Get-WinsmuxRuntimeValue -InputObject $verified -Name 'lease'
+    $verifiedPid = ConvertTo-WinsmuxRuntimeInteger -Value (
+        Get-WinsmuxRuntimeValue -InputObject $verifiedSupervisor -Name 'pid' -Default $null
+    )
+    $verifiedStartedAt = ConvertTo-WinsmuxRuntimeUtcIdentity -Value (
+        Get-WinsmuxRuntimeValue -InputObject $verifiedSupervisor -Name 'process_started_at' -Default ''
+    )
+    if ($null -eq $verified -or
+        [string](Get-WinsmuxRuntimeValue -InputObject $verified -Name 'status' -Default '') -cne 'ended' -or
+        [string](Get-WinsmuxRuntimeValue -InputObject $verifiedLease -Name 'state' -Default '') -cne 'ended' -or
+        [string](Get-WinsmuxRuntimeValue -InputObject $verified -Name 'session_name' -Default '') -cne [string]$Plan.SessionName -or
+        [string](Get-WinsmuxRuntimeValue -InputObject $verified -Name 'server_session_id' -Default '') -cne [string]$Plan.ServerSessionId -or
+        -not [string]::Equals(
+            [string](Get-WinsmuxRuntimeValue -InputObject $verified -Name 'generation_id' -Default ''),
+            [string]$Plan.GenerationId,
+            [System.StringComparison]::Ordinal
+        ) -or
+        $null -eq $verifiedPid -or [int]$verifiedPid -ne [int]$Plan.SupervisorPid -or
+        $verifiedStartedAt -cne [string]$Plan.SupervisorProcessStartedAt) {
+        throw 'Runtime registry retirement could not be verified after the close operation.'
+    }
+
+    return $true
+}
+
 function Clear-OrchestraManifestAfterServerRetirement {
     param(
         [Parameter(Mandatory = $true)][string]$ProjectDir,
@@ -425,15 +581,45 @@ function Clear-OrchestraManifestAfterServerRetirement {
         [Parameter(Mandatory = $true)][string]$WinsmuxBin
     )
 
+    $retiredManifest = Get-WinsmuxManifest -ProjectDir $ProjectDir
+    $retiredSession = Get-WinsmuxRuntimeValue -InputObject $retiredManifest -Name 'session'
+    $retiredManifestVersion = ConvertTo-WinsmuxRuntimeInteger -Value (
+        Get-WinsmuxRuntimeValue -InputObject $retiredManifest -Name 'version' -Default $null
+    )
+    $retiredSessionName = [string](Get-WinsmuxRuntimeValue -InputObject $retiredSession -Name 'name' -Default '')
+    $isNamelessLegacyManifest = (
+        $retiredManifestVersion -eq 1 -and [string]::IsNullOrWhiteSpace($retiredSessionName)
+    )
+    $isCompatibleLegacyManifest = (
+        $retiredManifestVersion -eq 1 -and
+        ([string]::IsNullOrWhiteSpace($retiredSessionName) -or $retiredSessionName -ceq $SessionName)
+    )
+    if ($null -ne $retiredManifest -and
+        -not $isNamelessLegacyManifest -and
+        ([string]::IsNullOrWhiteSpace($retiredSessionName) -or $retiredSessionName -cne $SessionName)) {
+        throw 'Retired manifest session identity does not match the requested session.'
+    }
+    $registryRetirementPlan = Get-OrchestraRuntimeRegistryRetirementPlan `
+        -ProjectDir $ProjectDir `
+        -ExpectedSessionName $SessionName `
+        -ExpectedGenerationId ([string](Get-WinsmuxRuntimeValue -InputObject $retiredSession -Name 'generation_id' -Default '')) `
+        -ExpectedServerSessionId ([string](Get-WinsmuxRuntimeValue -InputObject $retiredSession -Name 'server_session_id' -Default '')) `
+        -ExpectedSupervisorPid (ConvertTo-WinsmuxRuntimeInteger -Value (
+            Get-WinsmuxRuntimeValue -InputObject $retiredSession -Name 'supervisor_pid' -Default $null
+        ))
+
     $sessionServerCleanup = Remove-OrchestraSessionServerProcesses `
         -SessionName $SessionName -WinsmuxBin $WinsmuxBin -IncludeExpectedBinary
     Wait-OrchestraServerSessionAbsent -SessionName $SessionName -TimeoutSeconds 20 | Out-Null
     $cleanup = Stop-OrchestraBackgroundProcessesFromManifest `
         -ProjectDir $ProjectDir -GitWorktreeDir $GitWorktreeDir `
-        -BridgeScript $BridgeScript -SessionName $SessionName
+        -BridgeScript $BridgeScript -SessionName $SessionName `
+        -AllowMissingStartupToken:$isCompatibleLegacyManifest
     if (@($cleanup.Errors).Count -gt 0) {
         throw ('Retired-session background cleanup is incomplete: ' + (@($cleanup.Errors) -join '; '))
     }
+    $registryClosed = Complete-OrchestraRuntimeRegistryRetirement `
+        -ProjectDir $ProjectDir -Plan $registryRetirementPlan
     $cleared = [bool](Clear-WinsmuxManifest -ProjectDir $ProjectDir)
     return [PSCustomObject][ordered]@{
         SessionProcesses          = @($sessionServerCleanup.SessionProcesses)
@@ -441,6 +627,8 @@ function Clear-OrchestraManifestAfterServerRetirement {
         RemainingSessionProcesses = @($sessionServerCleanup.RemainingSessionProcesses)
         Stopped                   = @($cleanup.Stopped)
         Errors                    = @($cleanup.Errors)
+        RegistryPresent           = [bool]$registryRetirementPlan.Present
+        RegistryClosed            = [bool]$registryClosed
         Cleared                   = $cleared
     }
 }
@@ -1616,7 +1804,8 @@ function Stop-OrchestraBackgroundProcessesFromManifest {
         [Parameter(Mandatory = $true)][string]$ProjectDir,
         [Parameter(Mandatory = $true)][string]$GitWorktreeDir,
         [Parameter(Mandatory = $true)][string]$BridgeScript,
-        [Parameter(Mandatory = $true)][string]$SessionName
+        [Parameter(Mandatory = $true)][string]$SessionName,
+        [switch]$AllowMissingStartupToken
     )
 
     $stopped = [System.Collections.Generic.List[object]]::new()
@@ -1639,6 +1828,12 @@ function Stop-OrchestraBackgroundProcessesFromManifest {
     }
 
     if ([string]::IsNullOrWhiteSpace($startupToken)) {
+        if ($AllowMissingStartupToken) {
+            return [ordered]@{
+                Stopped = @()
+                Errors  = @()
+            }
+        }
         $errors.Add('manifest does not contain startup_token; skipping targeted background cleanup') | Out-Null
         return [ordered]@{
             Stopped = @()
@@ -2163,13 +2358,17 @@ function Invoke-OrchestraStartupRollback {
         [Parameter(Mandatory = $true)][System.Collections.IEnumerable]$CreatedWorktrees,
         [Parameter(Mandatory = $true)][string]$FailureMessage,
         [switch]$ManifestPublished,
-        [AllowEmptyString()][string]$OwnedGenerationId = ''
+        [AllowEmptyString()][string]$OwnedGenerationId = '',
+        [AllowEmptyString()][string]$OwnedServerSessionId = '',
+        [Nullable[int]]$OwnedSupervisorPid = $null,
+        [AllowEmptyString()][string]$OwnedSupervisorProcessStartedAt = ''
     )
 
     $removedPaneIds = [System.Collections.Generic.List[string]]::new()
     $rollbackErrors = [System.Collections.Generic.List[string]]::new()
     $bootstrapRespawned = $false
     $manifestCleared = $false
+    $registryClosed = $false
     $removedWorktrees = @()
     $trackedPaneIds = [System.Collections.Generic.List[string]]::new()
 
@@ -2208,6 +2407,13 @@ function Invoke-OrchestraStartupRollback {
                 $rollbackErrors.Add('clear manifest refused: published manifest generation is unavailable') | Out-Null
             } else {
                 try {
+                    $registryRetirementPlan = Get-OrchestraRuntimeRegistryRetirementPlan `
+                        -ProjectDir $ProjectDir -ExpectedSessionName $SessionName `
+                        -ExpectedGenerationId $OwnedGenerationId -ExpectedServerSessionId $OwnedServerSessionId `
+                        -ExpectedSupervisorPid $OwnedSupervisorPid `
+                        -ExpectedSupervisorProcessStartedAt $OwnedSupervisorProcessStartedAt
+                    $registryClosed = Complete-OrchestraRuntimeRegistryRetirement `
+                        -ProjectDir $ProjectDir -Plan $registryRetirementPlan
                     $manifestCleared = [bool](Clear-WinsmuxManifest -ProjectDir $ProjectDir -ExpectedGenerationId $OwnedGenerationId)
                 } catch {
                     $rollbackErrors.Add("clear manifest failed: $($_.Exception.Message)") | Out-Null
@@ -2273,6 +2479,7 @@ function Invoke-OrchestraStartupRollback {
         RemovedPaneIds    = @($removedPaneIds)
         RemovedWorktrees  = @($removedWorktrees)
         BootstrapRespawned = $bootstrapRespawned
+        RegistryClosed      = $registryClosed
         ManifestCleared    = $manifestCleared
         RollbackErrors    = @($rollbackErrors)
     }
@@ -2449,6 +2656,7 @@ if ($MyInvocation.InvocationName -ne '.') {
     $watchdogProcess = $null
     $serverWatchdogProcess = $null
     $supervisorProcess = $null
+    $supervisorProcessStartedAt = ''
     $projectDir = $null
     $gitWorktreeDir = $null
     $expectedOrigin = ''
@@ -3006,6 +3214,10 @@ if ($MyInvocation.InvocationName -ne '.') {
     $supervisorScriptPath = Join-Path $scriptDir 'orchestra-supervisor.ps1'
     $supervisorProcess = Start-OrchestraSupervisorJob -SupervisorScriptPath $supervisorScriptPath -ManifestPath $manifestPath -SessionName $sessionName -GenerationId $runtimeGenerationId -ServerSessionId $serverSessionId -StartupToken $startupToken
     Assert-OrchestraBackgroundProcessStarted -Process $supervisorProcess -Name 'Orchestra supervisor job'
+    $supervisorProcessStartedAt = Get-WinsmuxRuntimeProcessStartedAt -ProcessId $supervisorProcess.Id
+    if ([string]::IsNullOrWhiteSpace($supervisorProcessStartedAt)) {
+        throw 'Supervisor process StartTime is unavailable before runtime registry publication.'
+    }
     Wait-OrchestraRuntimeRegistryReady -ProjectDir $projectDir -SessionName $sessionName -GenerationId $runtimeGenerationId `
         -ServerSessionId $serverSessionId -BootstrapPaneId $bootstrapPaneId -SupervisorProcess $supervisorProcess -PaneSummaries $validPaneSummaries | Out-Null
     $manifestPath = Save-OrchestraSessionState -ProjectDir $projectDir -SessionName $sessionName -Settings $settings -GitWorktreeDir $gitWorktreeDir -PaneSummaries $validPaneSummaries -GenerationId $runtimeGenerationId -ServerSessionId $serverSessionId -BootstrapPaneId $bootstrapPaneId -StartupToken $startupToken -SupervisorPid $supervisorProcess.Id -BootstrapMode ([string]$orchestraServer.BootstrapMode) -SessionReady $true -UiAttachLaunched ([bool]$uiAttachResult.Launched) -UiAttached ([bool]$uiAttachResult.Attached) -UiAttachStatus ([string]$uiAttachResult.Status) -UiAttachReason ([string]$uiAttachResult.Reason) -UiAttachSource ([string]$uiAttachResult.Source) -UiHostKind ([string]$uiAttachResult.ui_host_kind) -AttachRequestId ([string]$uiAttachResult.attach_request_id) -AttachAdapterTrace @($uiAttachResult.attach_adapter_trace) -ExpectedPaneCount $expectedPaneCount
@@ -3090,11 +3302,13 @@ if ($MyInvocation.InvocationName -ne '.') {
     if ($null -ne $serverWatchdogProcess) {
         try { Stop-Process -Id $serverWatchdogProcess.Id -Force -ErrorAction SilentlyContinue } catch {}
     }
+    $rollbackSupervisorPid = $null
     if ($null -ne $supervisorProcess) {
+        $rollbackSupervisorPid = [int]$supervisorProcess.Id
         try { Stop-Process -Id $supervisorProcess.Id -Force -ErrorAction SilentlyContinue } catch {}
     }
 
-    $rollback = Invoke-OrchestraStartupRollback -ProjectDir $projectDir -SessionName $sessionName -BootstrapPaneId $bootstrapPaneId -CreatedPaneIds $createdPaneIds -CreatedWorktrees $createdWorktrees -FailureMessage $_.Exception.Message -ManifestPublished:$manifestPublished -OwnedGenerationId $runtimeGenerationId
+    $rollback = Invoke-OrchestraStartupRollback -ProjectDir $projectDir -SessionName $sessionName -BootstrapPaneId $bootstrapPaneId -CreatedPaneIds $createdPaneIds -CreatedWorktrees $createdWorktrees -FailureMessage $_.Exception.Message -ManifestPublished:$manifestPublished -OwnedGenerationId $runtimeGenerationId -OwnedServerSessionId $serverSessionId -OwnedSupervisorPid $rollbackSupervisorPid -OwnedSupervisorProcessStartedAt $supervisorProcessStartedAt
     $rollbackSuffix = if ($rollback.BootstrapRespawned) { 'session preserved' } else { 'rollback attempted' }
     Write-Error "Orchestra startup failed ($rollbackSuffix): $($_.Exception.Message)"
     exit 1

--- a/winsmux-core/scripts/orchestra-start.ps1
+++ b/winsmux-core/scripts/orchestra-start.ps1
@@ -6,6 +6,7 @@ param(
 
 $ErrorActionPreference = 'Stop'
 $scriptDir = $PSScriptRoot
+. "$scriptDir/json-compat.ps1"
 . "$scriptDir/settings.ps1"
 . "$scriptDir/vault.ps1"
 . "$scriptDir/builder-worktree.ps1"
@@ -41,6 +42,39 @@ function Write-OrchestraTextFile {
     Write-WinsmuxTextFile -Path $Path -Content $Content -Append:$Append
 }
 
+function Publish-OrchestraPaneLabels {
+    param([Parameter(Mandatory = $true)][System.Collections.IEnumerable]$PaneSummaries)
+
+    if ([string]::IsNullOrWhiteSpace($env:APPDATA)) {
+        throw 'APPDATA is unavailable for orchestra label publication.'
+    }
+
+    $labelsPath = Join-Path $env:APPDATA 'winsmux\labels.json'
+    $labels = @{}
+    if (Test-Path -LiteralPath $labelsPath -PathType Leaf) {
+        $raw = Get-Content -LiteralPath $labelsPath -Raw -Encoding UTF8
+        if (-not [string]::IsNullOrWhiteSpace($raw)) {
+            $parsed = $raw | ConvertFrom-Json
+            foreach ($property in @($parsed.PSObject.Properties)) {
+                $labels[[string]$property.Name] = [string]$property.Value
+            }
+        }
+    }
+
+    $seenTitles = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::Ordinal)
+    foreach ($paneSummary in @($PaneSummaries)) {
+        $title = [string](Get-OrchestraObjectPropertyValue -InputObject $paneSummary -Name 'Title' -Default '')
+        $paneId = [string](Get-OrchestraObjectPropertyValue -InputObject $paneSummary -Name 'PaneId' -Default '')
+        if ([string]::IsNullOrWhiteSpace($title) -or $paneId -cnotmatch '^%[0-9]+$' -or -not $seenTitles.Add($title)) {
+            throw 'Orchestra label publication requires unique non-empty titles and valid pane ids.'
+        }
+        $labels[$title] = $paneId
+    }
+
+    Write-OrchestraTextFile -Path $labelsPath -Content (($labels | ConvertTo-Json -Depth 5) + "`n")
+    return [PSCustomObject][ordered]@{ Path = $labelsPath; PublishedCount = $seenTitles.Count }
+}
+
 function Invoke-Winsmux {
     param(
         [Parameter(Mandatory = $true)]
@@ -63,7 +97,36 @@ function Invoke-Winsmux {
         return ($safeArguments -join ' ')
     }
 
-    $safeArgumentText = Format-WinsmuxArgumentsForError -InputArguments $Arguments
+    function Resolve-OrchestraWinsmuxTargetArguments {
+        param(
+            [Parameter(Mandatory = $true)][string[]]$InputArguments,
+            [AllowEmptyString()][string]$ExplicitSessionName = ''
+        )
+
+        $resolved = @($InputArguments)
+        $namespaceActive = -not [string]::IsNullOrWhiteSpace($env:WINSMUX_BRIDGE_SESSION_NAMESPACE) -or
+            -not [string]::IsNullOrWhiteSpace($env:WINSMUX_BRIDGE_NAMESPACE_L) -or
+            -not [string]::IsNullOrWhiteSpace($env:WINSMUX_BRIDGE_SOCKET_S)
+        if (-not $namespaceActive -or [string]::IsNullOrWhiteSpace($ExplicitSessionName)) {
+            return @($resolved)
+        }
+
+        for ($index = 0; $index -lt ($resolved.Count - 1); $index++) {
+            if ($resolved[$index] -ne '-t') {
+                continue
+            }
+
+            $target = [string]$resolved[$index + 1]
+            if ($target -match '^[%@]') {
+                $resolved[$index + 1] = "${ExplicitSessionName}:$target"
+            }
+            break
+        }
+        return @($resolved)
+    }
+
+    $effectiveArguments = @(Resolve-OrchestraWinsmuxTargetArguments -InputArguments $Arguments -ExplicitSessionName $TargetSessionName)
+    $safeArgumentText = Format-WinsmuxArgumentsForError -InputArguments $effectiveArguments
 
     $previousPsmuxTargetSession = $env:PSMUX_TARGET_SESSION
     $previousWinsmuxTargetSession = $env:WINSMUX_TARGET_SESSION
@@ -74,7 +137,7 @@ function Invoke-Winsmux {
         }
 
         if ($CaptureOutput) {
-            $output = Invoke-WinsmuxBridgeCommand -WinsmuxBin $script:winsmuxBin -Arguments $Arguments 2>&1
+            $output = Invoke-WinsmuxBridgeCommand -WinsmuxBin $script:winsmuxBin -Arguments $effectiveArguments 2>&1
             $exitCode = $LASTEXITCODE
             if ($exitCode -ne 0) {
                 $message = ($output | Out-String).Trim()
@@ -88,7 +151,7 @@ function Invoke-Winsmux {
             return $output
         }
 
-        Invoke-WinsmuxBridgeCommand -WinsmuxBin $script:winsmuxBin -Arguments $Arguments | Out-Null
+        Invoke-WinsmuxBridgeCommand -WinsmuxBin $script:winsmuxBin -Arguments $effectiveArguments | Out-Null
         if ($LASTEXITCODE -ne 0) {
             throw "winsmux $safeArgumentText failed with exit code $LASTEXITCODE."
         }
@@ -316,7 +379,12 @@ function Reset-OrchestraServerSession {
         [int]$ExpectedPaneCount = 1
     )
 
-    if (Test-OrchestraServerSession -SessionName $SessionName) {
+    if (-not [string]::IsNullOrWhiteSpace($ProjectDir)) {
+        if ([string]::IsNullOrWhiteSpace($GitWorktreeDir) -or [string]::IsNullOrWhiteSpace($BridgeScript)) {
+            throw 'Reset-OrchestraServerSession: GitWorktreeDir and BridgeScript are required when ProjectDir owns a runtime manifest.'
+        }
+        [void](Clear-OrchestraManifestAfterServerRetirement -ProjectDir $ProjectDir -GitWorktreeDir $GitWorktreeDir -BridgeScript $BridgeScript -SessionName $SessionName -WinsmuxBin $WinsmuxBin)
+    } elseif (Test-OrchestraServerSession -SessionName $SessionName) {
         try {
             Invoke-Winsmux -Arguments @('kill-session', '-t', $SessionName)
             Wait-OrchestraServerSessionAbsent -SessionName $SessionName -TimeoutSeconds 20 | Out-Null
@@ -325,17 +393,7 @@ function Reset-OrchestraServerSession {
         }
     }
 
-    if (-not [string]::IsNullOrWhiteSpace($ProjectDir) -and -not [string]::IsNullOrWhiteSpace($GitWorktreeDir) -and -not [string]::IsNullOrWhiteSpace($BridgeScript)) {
-        $cleanup = Stop-OrchestraBackgroundProcessesFromManifest -ProjectDir $ProjectDir -GitWorktreeDir $GitWorktreeDir -BridgeScript $BridgeScript -SessionName $SessionName
-        foreach ($cleanupError in @($cleanup.Errors)) {
-            Write-Warning "Reset-OrchestraServerSession: stale orchestra background cleanup error: $cleanupError"
-        }
-    }
-
     Clear-OrchestraSessionRegistration -SessionName $SessionName
-    if (-not [string]::IsNullOrWhiteSpace($ProjectDir)) {
-        [void](Clear-WinsmuxManifest -ProjectDir $ProjectDir)
-    }
     $server = Ensure-OrchestraBootstrapSession -SessionName $SessionName -TimeoutSeconds 60 -ExpectedPaneCount $ExpectedPaneCount
     $bootstrapMode = if ($null -ne $server.PSObject -and $server.PSObject.Properties.Name -contains 'BootstrapMode') {
         [string]$server.BootstrapMode
@@ -355,6 +413,35 @@ function Reset-OrchestraServerSession {
         StartupReady   = $false
         BootstrapMode  = $bootstrapMode
         Health         = $health
+    }
+}
+
+function Clear-OrchestraManifestAfterServerRetirement {
+    param(
+        [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [Parameter(Mandatory = $true)][string]$GitWorktreeDir,
+        [Parameter(Mandatory = $true)][string]$BridgeScript,
+        [Parameter(Mandatory = $true)][string]$SessionName,
+        [Parameter(Mandatory = $true)][string]$WinsmuxBin
+    )
+
+    $sessionServerCleanup = Remove-OrchestraSessionServerProcesses `
+        -SessionName $SessionName -WinsmuxBin $WinsmuxBin -IncludeExpectedBinary
+    Wait-OrchestraServerSessionAbsent -SessionName $SessionName -TimeoutSeconds 20 | Out-Null
+    $cleanup = Stop-OrchestraBackgroundProcessesFromManifest `
+        -ProjectDir $ProjectDir -GitWorktreeDir $GitWorktreeDir `
+        -BridgeScript $BridgeScript -SessionName $SessionName
+    if (@($cleanup.Errors).Count -gt 0) {
+        throw ('Retired-session background cleanup is incomplete: ' + (@($cleanup.Errors) -join '; '))
+    }
+    $cleared = [bool](Clear-WinsmuxManifest -ProjectDir $ProjectDir)
+    return [PSCustomObject][ordered]@{
+        SessionProcesses          = @($sessionServerCleanup.SessionProcesses)
+        Killed                    = @($sessionServerCleanup.Killed)
+        RemainingSessionProcesses = @($sessionServerCleanup.RemainingSessionProcesses)
+        Stopped                   = @($cleanup.Stopped)
+        Errors                    = @($cleanup.Errors)
+        Cleared                   = $cleared
     }
 }
 
@@ -833,7 +920,13 @@ function New-OrchestraPaneBootstrapPlan {
         [Parameter(Mandatory = $true)][string]$ProjectDir,
         [Parameter(Mandatory = $true)][string]$PaneId,
         [Parameter(Mandatory = $true)][string]$Label,
+        [Parameter(Mandatory = $true)][string]$SlotId,
         [Parameter(Mandatory = $true)][string]$Role,
+        [Parameter(Mandatory = $true)][string]$WorkerBackend,
+        [Parameter(Mandatory = $true)][string]$WorkerRole,
+        [Parameter(Mandatory = $true)][string]$PaneTitle,
+        [Parameter(Mandatory = $true)][string]$GenerationId,
+        [Parameter(Mandatory = $true)][string]$ServerSessionId,
         [Parameter(Mandatory = $true)][string]$Agent,
         [Parameter(Mandatory = $true)][AllowEmptyString()][string]$Model,
         [Parameter(Mandatory = $true)][string]$StartupToken,
@@ -855,11 +948,17 @@ function New-OrchestraPaneBootstrapPlan {
     }
 
     $planPath = Join-Path $bootstrapDir ("{0}.json" -f $safePaneId)
-    $readyMarkerPath = Join-Path $bootstrapDir ("{0}-{1}.ready.json" -f $safePaneId, $StartupToken)
+    $readyMarkerPath = Get-OrchestraPaneBootstrapMarkerPath -PlanPath $planPath -GenerationId $GenerationId
     $plan = [ordered]@{
         pane_id        = $PaneId
         label          = $Label
+        slot_id        = $SlotId
         role           = $Role
+        worker_backend = $WorkerBackend
+        worker_role    = $WorkerRole
+        pane_title     = $PaneTitle
+        generation_id  = $GenerationId
+        server_session_id = $ServerSessionId
         agent          = $Agent
         model          = $Model
         startup_token  = $StartupToken
@@ -976,12 +1075,16 @@ function Test-OrchestraProviderInterruptAvailable {
 function Get-OrchestraPaneBootstrapMarkerPath {
     param(
         [Parameter(Mandatory = $true)][string]$PlanPath,
-        [Parameter(Mandatory = $true)][string]$StartupToken
+        [Parameter(Mandatory = $true)][string]$GenerationId
     )
+
+    if ($GenerationId -cnotmatch '^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$') {
+        throw 'Runtime generation identity is not safe for a bootstrap marker basename.'
+    }
 
     $planDirectory = Split-Path -Parent $PlanPath
     $planBaseName = [System.IO.Path]::GetFileNameWithoutExtension($PlanPath)
-    return Join-Path $planDirectory ("{0}-{1}.ready.json" -f $planBaseName, $StartupToken)
+    return Join-Path $planDirectory ("{0}-{1}.ready.json" -f $planBaseName, $GenerationId)
 }
 
 function Test-OrchestraPaneDeferredStart {
@@ -1010,11 +1113,7 @@ function Test-OrchestraPaneBootstrapVerificationDeferred {
     param([AllowNull()]$PaneSummary)
 
     $status = [string](Get-OrchestraObjectPropertyValue -InputObject $PaneSummary -Name 'Status' -Default '')
-    if ([string]::IsNullOrWhiteSpace($status)) {
-        return $false
-    }
-
-    return @('deferred_start', 'deferred_starting', 'api_llm_runner_unconfigured', 'antigravity_runner_unconfigured') -contains $status.Trim().ToLowerInvariant()
+    return [bool](Get-WinsmuxRuntimeStatusClassification -Status $status).IsDeferred
 }
 
 function Get-AgentLaunchCommand {
@@ -1065,9 +1164,9 @@ function Test-VaultKeyExists {
 
     $credTarget = "winsmux:$Key"
     $credPtr = [IntPtr]::Zero
-    $ok = [WinCred]::CredRead($credTarget, [WinCred]::CRED_TYPE_GENERIC, 0, [ref]$credPtr)
+    $ok = [WinsmuxVaultCredentialNative]::CredRead($credTarget, [WinsmuxVaultCredentialNative]::CRED_TYPE_GENERIC, 0, [ref]$credPtr)
     if ($ok) {
-        [WinCred]::CredFree($credPtr) | Out-Null
+        [WinsmuxVaultCredentialNative]::CredFree($credPtr) | Out-Null
         return $true
     }
 
@@ -1085,16 +1184,16 @@ function Set-VaultKey {
     $blobPtr = [Runtime.InteropServices.Marshal]::AllocHGlobal($valueBytes.Length)
     [Runtime.InteropServices.Marshal]::Copy($valueBytes, 0, $blobPtr, $valueBytes.Length)
 
-    $cred = New-Object WinCred+CREDENTIAL
-    $cred.Type = [WinCred]::CRED_TYPE_GENERIC
+    $cred = New-Object WinsmuxVaultCredentialNative+CREDENTIAL
+    $cred.Type = [WinsmuxVaultCredentialNative]::CRED_TYPE_GENERIC
     $cred.TargetName = $credTarget
     $cred.UserName = 'winsmux'
     $cred.CredentialBlobSize = $valueBytes.Length
     $cred.CredentialBlob = $blobPtr
-    $cred.Persist = [WinCred]::CRED_PERSIST_LOCAL_MACHINE
+    $cred.Persist = [WinsmuxVaultCredentialNative]::CRED_PERSIST_LOCAL_MACHINE
 
     try {
-        $ok = [WinCred]::CredWrite([ref]$cred, 0)
+        $ok = [WinsmuxVaultCredentialNative]::CredWrite([ref]$cred, 0)
         if (-not $ok) {
             $errCode = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
             throw "CredWrite failed for '$Key' (error $errCode)"
@@ -1397,6 +1496,10 @@ function Save-OrchestraSessionState {
         [Parameter(Mandatory = $true)]$Settings,
         [Parameter(Mandatory = $true)][string]$GitWorktreeDir,
         [Parameter(Mandatory = $true)][System.Collections.IEnumerable]$PaneSummaries,
+        [Parameter(Mandatory = $true)][ValidateRange(1, 1024)][int]$ExpectedPaneCount,
+        [AllowEmptyString()][string]$GenerationId = '',
+        [AllowEmptyString()][string]$ServerSessionId = '',
+        [AllowEmptyString()][string]$BootstrapPaneId = '',
         [AllowEmptyString()][string]$StartupToken = '',
         [Nullable[int]]$OperatorPollPid = $null,
         [Nullable[int]]$WatchdogPid = $null,
@@ -1427,6 +1530,8 @@ function Save-OrchestraSessionState {
             slot_id                    = $paneSummary.SlotId
             worker_backend             = [string](Get-OrchestraObjectPropertyValue -InputObject $paneSummary -Name 'WorkerBackend' -Default 'local')
             worker_role                = [string](Get-OrchestraObjectPropertyValue -InputObject $paneSummary -Name 'WorkerRole' -Default '')
+            title                      = [string](Get-OrchestraObjectPropertyValue -InputObject $paneSummary -Name 'Title' -Default '')
+            runtime_ready              = [bool](Get-OrchestraObjectPropertyValue -InputObject $paneSummary -Name 'RuntimeReady' -Default $false)
             role                       = $paneSummary.Role
             exec_mode                  = [bool]$paneSummary.ExecMode
             project_dir                = $paneSummary.ProjectDir
@@ -1458,10 +1563,14 @@ function Save-OrchestraSessionState {
     }
 
     $manifest = [PSCustomObject]@{
-        version  = 1
+        version  = 2
         saved_at = $savedAt
         session  = [PSCustomObject]@{
             name                = $SessionName
+            generation_id       = $GenerationId
+            server_session_id   = $ServerSessionId
+            bootstrap_pane_id   = $BootstrapPaneId
+            expected_pane_count = $ExpectedPaneCount
             status              = 'running'
             agent               = $Settings.agent
             model               = $Settings.model
@@ -1493,7 +1602,12 @@ function Save-OrchestraSessionState {
         worktrees = [ordered]@{}
     }
 
-    Save-WinsmuxManifest -ProjectDir $ProjectDir -Manifest $manifest
+    if ((Test-Path -LiteralPath $manifestPath -PathType Leaf) -and
+        -not [string]::IsNullOrWhiteSpace($GenerationId)) {
+        Save-WinsmuxManifest -ProjectDir $ProjectDir -Manifest $manifest -ExpectedGenerationId $GenerationId
+    } else {
+        Save-WinsmuxManifest -ProjectDir $ProjectDir -Manifest $manifest
+    }
     return $manifestPath
 }
 
@@ -1738,6 +1852,8 @@ function Start-OrchestraSupervisorJob {
         [Parameter(Mandatory = $true)][string]$SupervisorScriptPath,
         [Parameter(Mandatory = $true)][string]$ManifestPath,
         [Parameter(Mandatory = $true)][string]$SessionName,
+        [Parameter(Mandatory = $true)][string]$GenerationId,
+        [Parameter(Mandatory = $true)][string]$ServerSessionId,
         [AllowEmptyString()][string]$StartupToken = '',
         [int]$OperatorPollInterval = 20,
         [int]$AgentWatchdogInterval = 30,
@@ -1755,6 +1871,10 @@ function Start-OrchestraSupervisorJob {
             $ManifestPath,
             '-SessionName',
             $SessionName,
+            '-GenerationId',
+            $GenerationId,
+            '-ServerSessionId',
+            $ServerSessionId,
             '-StartupToken',
             $StartupToken,
             '-OperatorPollInterval',
@@ -1798,6 +1918,99 @@ function Assert-OrchestraBackgroundProcessStarted {
             throw
         }
     }
+}
+
+function Wait-OrchestraRuntimeRegistryReady {
+    param(
+        [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [Parameter(Mandatory = $true)][string]$SessionName,
+        [Parameter(Mandatory = $true)][string]$GenerationId,
+        [Parameter(Mandatory = $true)][string]$ServerSessionId,
+        [Parameter(Mandatory = $true)][string]$BootstrapPaneId,
+        [Parameter(Mandatory = $true)]$SupervisorProcess,
+        [Parameter(Mandatory = $true)][System.Collections.IEnumerable]$PaneSummaries,
+        [int]$TimeoutSeconds = 30
+    )
+
+    if ($ServerSessionId -cnotmatch '^\$[0-9]+$') {
+        throw "Server session identity is malformed for $SessionName."
+    }
+    $supervisorStartedAt = Get-WinsmuxRuntimeProcessStartedAt -ProcessId $SupervisorProcess.Id
+    if ([string]::IsNullOrWhiteSpace($supervisorStartedAt)) {
+        throw 'Supervisor process StartTime is unavailable during runtime registry handshake.'
+    }
+
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    $lastFailure = 'runtime registry was not created'
+    while ((Get-Date) -lt $deadline) {
+        if ($SupervisorProcess.HasExited) {
+            throw "Orchestra supervisor exited before runtime registry handshake completed (exit=$($SupervisorProcess.ExitCode))."
+        }
+        try {
+            $registry = Read-WinsmuxRuntimeRegistry -ProjectDir $ProjectDir
+            $processResolver = New-WinsmuxProcessSnapshotResolver
+            if (-not (Test-WinsmuxRuntimeRegistryOwner -Registry $registry -GenerationId $GenerationId `
+                    -SupervisorPid $SupervisorProcess.Id -SupervisorProcessStartedAt $supervisorStartedAt -ProcessResolver $processResolver)) {
+                throw 'runtime registry owner or lease is not valid'
+            }
+            if ([string]$registry.session_name -cne $SessionName -or [string]$registry.server_session_id -cne $ServerSessionId) {
+                throw 'runtime registry session identity does not match'
+            }
+
+            $observedOutput = Invoke-Winsmux -Arguments @('list-panes', '-a', '-t', $SessionName, '-F', "#{session_id}`t#{session_name}`t#{pane_id}`t#{pane_title}") -CaptureOutput -TargetSessionName $SessionName
+            $serverPanes = [System.Collections.Generic.List[object]]::new()
+            foreach ($line in @(($observedOutput | Out-String).Trim() -split "\r?\n")) {
+                if ([string]::IsNullOrWhiteSpace($line)) { continue }
+                $parts = $line -split "`t", 4
+                if ($parts.Count -ne 4 -or $parts[0] -cne $ServerSessionId -or $parts[1] -cne $SessionName -or
+                    [string]::IsNullOrWhiteSpace($parts[2]) -or [string]::IsNullOrWhiteSpace($parts[3])) {
+                    throw 'server pane snapshot contains malformed or foreign-session evidence'
+                }
+                $serverPanes.Add([PSCustomObject]@{ pane_id = $parts[2]; title = $parts[3] }) | Out-Null
+            }
+
+            $summaries = @($PaneSummaries)
+            $bootstrapMatches = @($serverPanes | Where-Object { [string]$_.pane_id -ceq $BootstrapPaneId })
+            $observedPanes = @($serverPanes | Where-Object { [string]$_.pane_id -cne $BootstrapPaneId })
+            if ($bootstrapMatches.Count -ne 1 -or $serverPanes.Count -ne ($summaries.Count + 1)) {
+                throw 'server pane snapshot must contain exactly one known bootstrap pane and no foreign panes'
+            }
+            if (@($registry.panes).Count -ne $summaries.Count -or $observedPanes.Count -ne $summaries.Count) {
+                throw 'runtime registry, desired slots, and server pane counts do not match'
+            }
+            $seenSlots = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::Ordinal)
+            $seenPaneIds = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::Ordinal)
+            foreach ($summary in $summaries) {
+                $label = [string](Get-OrchestraObjectPropertyValue -InputObject $summary -Name 'Label' -Default '')
+                $paneId = [string](Get-OrchestraObjectPropertyValue -InputObject $summary -Name 'PaneId' -Default '')
+                $slotId = [string](Get-OrchestraObjectPropertyValue -InputObject $summary -Name 'SlotId' -Default '')
+                $backend = [string](Get-OrchestraObjectPropertyValue -InputObject $summary -Name 'WorkerBackend' -Default '')
+                $role = [string](Get-OrchestraObjectPropertyValue -InputObject $summary -Name 'WorkerRole' -Default '')
+                if ([string]::IsNullOrWhiteSpace($role)) {
+                    $role = [string](Get-OrchestraObjectPropertyValue -InputObject $summary -Name 'Role' -Default '')
+                }
+                $role = $role.Trim().ToLowerInvariant()
+                $title = [string](Get-OrchestraObjectPropertyValue -InputObject $summary -Name 'Title' -Default '')
+                if (-not $seenSlots.Add($slotId) -or -not $seenPaneIds.Add($paneId)) {
+                    throw 'desired runtime mapping contains duplicate slots or panes'
+                }
+                $runtimeMatches = @($registry.panes | Where-Object { [string]$_.label -ceq $label })
+                $observedMatches = @($observedPanes | Where-Object { [string]$_.pane_id -ceq $paneId })
+                if ($runtimeMatches.Count -ne 1 -or $observedMatches.Count -ne 1 -or
+                    [string]$runtimeMatches[0].slot_id -cne $slotId -or [string]$runtimeMatches[0].pane_id -cne $paneId -or
+                    [string]$runtimeMatches[0].backend -cne $backend -or [string]$runtimeMatches[0].role -cne $role -or
+                    [string]$runtimeMatches[0].title -cne $title -or [string]$observedMatches[0].title -cne $title) {
+                    throw "runtime mapping does not match desired/server evidence for $label"
+                }
+            }
+            return $registry
+        } catch {
+            $lastFailure = $_.Exception.Message
+        }
+        Start-Sleep -Milliseconds 200
+    }
+
+    throw "Runtime registry handshake timed out for ${SessionName}: $lastFailure"
 }
 
 function Get-OrchestraEventsPath {
@@ -1948,12 +2161,15 @@ function Invoke-OrchestraStartupRollback {
         [AllowNull()][string]$BootstrapPaneId,
         [Parameter(Mandatory = $true)][System.Collections.IEnumerable]$CreatedPaneIds,
         [Parameter(Mandatory = $true)][System.Collections.IEnumerable]$CreatedWorktrees,
-        [Parameter(Mandatory = $true)][string]$FailureMessage
+        [Parameter(Mandatory = $true)][string]$FailureMessage,
+        [switch]$ManifestPublished,
+        [AllowEmptyString()][string]$OwnedGenerationId = ''
     )
 
     $removedPaneIds = [System.Collections.Generic.List[string]]::new()
     $rollbackErrors = [System.Collections.Generic.List[string]]::new()
     $bootstrapRespawned = $false
+    $manifestCleared = $false
     $removedWorktrees = @()
     $trackedPaneIds = [System.Collections.Generic.List[string]]::new()
 
@@ -1987,10 +2203,16 @@ function Invoke-OrchestraStartupRollback {
 
         $timestamp = Get-Date -Format 'yyyy-MM-ddTHH:mm:sszzz'
         Write-OrchestraTextFile -Path $journalPath -Content "[$timestamp] FAILED: $FailureMessage" -Append
-        try {
-            [void](Clear-WinsmuxManifest -ProjectDir $ProjectDir)
-        } catch {
-            $rollbackErrors.Add("clear manifest failed: $($_.Exception.Message)") | Out-Null
+        if ($ManifestPublished) {
+            if ([string]::IsNullOrWhiteSpace($OwnedGenerationId)) {
+                $rollbackErrors.Add('clear manifest refused: published manifest generation is unavailable') | Out-Null
+            } else {
+                try {
+                    $manifestCleared = [bool](Clear-WinsmuxManifest -ProjectDir $ProjectDir -ExpectedGenerationId $OwnedGenerationId)
+                } catch {
+                    $rollbackErrors.Add("clear manifest failed: $($_.Exception.Message)") | Out-Null
+                }
+            }
         }
     }
 
@@ -2051,6 +2273,7 @@ function Invoke-OrchestraStartupRollback {
         RemovedPaneIds    = @($removedPaneIds)
         RemovedWorktrees  = @($removedWorktrees)
         BootstrapRespawned = $bootstrapRespawned
+        ManifestCleared    = $manifestCleared
         RollbackErrors    = @($rollbackErrors)
     }
 }
@@ -2125,7 +2348,7 @@ function Test-OrchestraBootstrapMarker {
     }
 
     try {
-        $marker = Get-Content -LiteralPath $BootstrapMarkerPath -Raw -Encoding UTF8 | ConvertFrom-Json -Depth 6
+        $marker = Get-Content -LiteralPath $BootstrapMarkerPath -Raw -Encoding UTF8 | ConvertFrom-WinsmuxJson -Depth 6
         $normalizedExpected = $ExpectedLaunchDir.Replace('/', '\').ToLowerInvariant()
         foreach ($candidate in @([string]$marker.launch_dir, [string]$marker.current_dir)) {
             if (-not [string]::IsNullOrWhiteSpace($candidate)) {
@@ -2231,6 +2454,9 @@ if ($MyInvocation.InvocationName -ne '.') {
     $expectedOrigin = ''
     $startupToken = ''
     $orchestraServer = $null
+    $runtimeGenerationId = ''
+    $manifestPublished = $false
+    $serverSessionId = ''
     $createdPaneIds = @()
     $bootstrapPaneId = $null
     $createdWorktrees = @()
@@ -2276,7 +2502,7 @@ if ($MyInvocation.InvocationName -ne '.') {
         }
         $startupLock = Acquire-OrchestraStartupLock -ProjectDir $projectDir -SessionName $sessionName
         $startupToken = [string]$startupLock.StartupToken
-        Write-WinsmuxLog -Level INFO -Event 'preflight.startup_lock.acquired' -Message "Acquired orchestra startup lock for $sessionName." -Data @{ session_name = $sessionName; startup_token = $startupToken } | Out-Null
+        Write-WinsmuxLog -Level INFO -Event 'preflight.startup_lock.acquired' -Message "Acquired orchestra startup lock for $sessionName." -Data @{ session_name = $sessionName } | Out-Null
         $sessionExistedAtStart = Test-OrchestraServerSession -SessionName $sessionName
         Write-WinsmuxLog -Level INFO -Event 'preflight.vault.start' -Message 'Running vault preflight.' | Out-Null
         Invoke-VaultPreflight -Settings $settings
@@ -2295,28 +2521,6 @@ if ($MyInvocation.InvocationName -ne '.') {
             } catch {
                 Write-Error "Missing required vault key '$key': $($_.Exception.Message)"
                 exit 1
-            }
-        }
-
-        if (-not $sessionExistedAtStart) {
-            Write-WinsmuxLog -Level INFO -Event 'preflight.manifest_cleanup.start' -Message 'Stopping stale orchestra background processes and clearing stale manifest before fresh startup.' | Out-Null
-            $manifestBackgroundCleanup = Stop-OrchestraBackgroundProcessesFromManifest -ProjectDir $projectDir -GitWorktreeDir $gitWorktreeDir -BridgeScript $bridgeScript -SessionName $sessionName
-            foreach ($stoppedProcess in @($manifestBackgroundCleanup.Stopped)) {
-                Write-WinsmuxLog -Level INFO -Event 'preflight.manifest_cleanup.process_stopped' -Message "Stopped stale orchestra background process $($stoppedProcess.label) ($($stoppedProcess.pid))." -Data ([ordered]@{
-                    label = $stoppedProcess.label
-                    pid   = $stoppedProcess.pid
-                }) | Out-Null
-            }
-            foreach ($cleanupError in @($manifestBackgroundCleanup.Errors)) {
-                Write-Warning "Preflight: stale orchestra background cleanup error: $cleanupError"
-                Write-WinsmuxLog -Level WARN -Event 'preflight.manifest_cleanup.process_error' -Message "Stale orchestra background cleanup error: $cleanupError" -Data ([ordered]@{
-                    error = $cleanupError
-                }) | Out-Null
-            }
-            if (Clear-WinsmuxManifest -ProjectDir $projectDir) {
-                Write-WinsmuxLog -Level INFO -Event 'preflight.manifest_cleanup.cleared' -Message "Cleared stale orchestra manifest for $projectDir." -Data ([ordered]@{
-                    project_dir = $projectDir
-                }) | Out-Null
             }
         }
 
@@ -2339,13 +2543,23 @@ if ($MyInvocation.InvocationName -ne '.') {
             }
         }
 
-        $sessionServerCleanup = Remove-OrchestraSessionServerProcesses -SessionName $sessionName -WinsmuxBin $winsmuxBin -IncludeExpectedBinary
-        if (@($sessionServerCleanup.Killed).Count -gt 0) {
-            Write-WinsmuxLog -Level INFO -Event 'preflight.session_process.cleanup' -Message 'Removed stale session server processes before orchestra startup.' -Data ([ordered]@{
+        $retiredManifest = Clear-OrchestraManifestAfterServerRetirement `
+            -ProjectDir $projectDir -GitWorktreeDir $gitWorktreeDir `
+            -BridgeScript $bridgeScript -SessionName $sessionName -WinsmuxBin $winsmuxBin
+        Write-WinsmuxLog -Level INFO -Event 'preflight.session_process.cleanup' -Message 'Verified complete retirement of the previous session before orchestra startup.' -Data ([ordered]@{
+            session_name     = $sessionName
+            existed_at_start = [bool]$sessionExistedAtStart
+            observed_count   = @($retiredManifest.SessionProcesses).Count
+            killed_count     = @($retiredManifest.Killed).Count
+        }) | Out-Null
+        Write-WinsmuxLog -Level INFO -Event 'preflight.retired_manifest.cleared' `
+            -Message 'Cleared the retired session manifest before creating the replacement generation.' `
+            -Data ([ordered]@{
                 session_name = $sessionName
-                killed_count = @($sessionServerCleanup.Killed).Count
+                cleared      = [bool]$retiredManifest.Cleared
+                stopped      = @($retiredManifest.Stopped).Count
+                errors       = @($retiredManifest.Errors).Count
             }) | Out-Null
-        }
 
         $warmCleanup = Remove-OrchestraExcessWarmProcesses -MaxWarmProcesses 1
         if (@($warmCleanup.Killed).Count -gt 0) {
@@ -2445,6 +2659,11 @@ if ($MyInvocation.InvocationName -ne '.') {
         }) | Out-Null
         $bootstrapPaneId = Get-OrchestraBootstrapPaneId -SessionName $sessionName
         $createdPaneIds = @($bootstrapPaneId)
+        $runtimeGenerationId = [guid]::NewGuid().ToString('N')
+        $serverSessionId = ((Invoke-Winsmux -Arguments @('display-message', '-t', $sessionName, '-p', '#{session_id}') -CaptureOutput -TargetSessionName $sessionName | Out-String).Trim() -split "\r?\n" | Select-Object -Last 1).Trim()
+        if ([string]::IsNullOrWhiteSpace($serverSessionId)) {
+            throw "Server session identity is unavailable for $sessionName."
+        }
 
         # TASK-231: preserve failed panes for debug inspection
         try {
@@ -2588,7 +2807,11 @@ if ($MyInvocation.InvocationName -ne '.') {
         if (-not $oneShotPaneStartDeferred) {
             $launchCommand = Get-AgentLaunchCommand -Agent $slotAgentConfig.Agent -Model $slotAgentConfig.Model -ModelSource $slotAgentConfig.ModelSource -ReasoningEffort $slotAgentConfig.ReasoningEffort -McpMode $slotAgentConfig.McpMode -SlotId $label -ProjectDir $launchDir -GitWorktreeDir $launchGitWorktreeDir -RootPath $projectDir -ExecMode $false
         }
-        Invoke-Bridge -Arguments @('name', $paneId, $label)
+        $runtimePaneTitle = [string]$slotAgentConfig.PaneTitle
+        if ([string]::IsNullOrWhiteSpace($runtimePaneTitle)) {
+            $runtimePaneTitle = $label
+        }
+        $runtimeWorkerRole = Resolve-WinsmuxRuntimeRole -WorkerRole ([string]$slotAgentConfig.WorkerRole) -CanonicalRole $canonicalRole
         $approvedLaunch = $null
         try {
             $paneEnvironment = Get-WinsmuxPaneEnvironment -Role $canonicalRole -PaneId $paneId -SessionName $sessionName -ProjectDir $projectDir -RoleMapJson $sessionRoleMapJson -BuilderWorktreePath $builderWorktreePath -SlotId $label -AssignedBranch $builderBranch -GitWorktreeDir $launchGitWorktreeDir -ExpectedOrigin $expectedOrigin
@@ -2629,7 +2852,13 @@ if ($MyInvocation.InvocationName -ne '.') {
                     -ProjectDir $projectDir `
                     -PaneId $paneId `
                     -Label $label `
+                    -SlotId $label `
                     -Role $canonicalRole `
+                    -WorkerBackend ([string]$slotAgentConfig.WorkerBackend) `
+                    -WorkerRole $runtimeWorkerRole `
+                    -PaneTitle $runtimePaneTitle `
+                    -GenerationId $runtimeGenerationId `
+                    -ServerSessionId $serverSessionId `
                     -Agent ([string]$slotAgentConfig.Agent) `
                     -Model ([string]$slotAgentConfig.Model) `
                     -StartupToken $startupToken `
@@ -2658,7 +2887,7 @@ if ($MyInvocation.InvocationName -ne '.') {
                     }) | Out-Null
                 } else {
                     Start-OrchestraPaneBootstrap -PaneId $paneId -PlanPath $bootstrapPlanPath -SessionName $sessionName
-                    $bootstrapMarkerPath = Get-OrchestraPaneBootstrapMarkerPath -PlanPath $bootstrapPlanPath -StartupToken $startupToken
+                    $bootstrapMarkerPath = Get-OrchestraPaneBootstrapMarkerPath -PlanPath $bootstrapPlanPath -GenerationId $runtimeGenerationId
                 }
                 # TASK-231: verify pane exists after respawn
                 try {
@@ -2682,7 +2911,8 @@ if ($MyInvocation.InvocationName -ne '.') {
             SlotId = $label
             Role = $canonicalRole
             WorkerBackend = [string]$slotAgentConfig.WorkerBackend
-            WorkerRole = [string]$slotAgentConfig.WorkerRole
+            WorkerRole = $runtimeWorkerRole
+            Title = $runtimePaneTitle
             Agent = [string]$slotAgentConfig.Agent
             Model = [string]$slotAgentConfig.Model
             CapabilityAdapter = [string]$slotAgentConfig.CapabilityAdapter
@@ -2706,6 +2936,7 @@ if ($MyInvocation.InvocationName -ne '.') {
             BootstrapPlanPath = $bootstrapPlanPath
             BootstrapMarkerPath = $bootstrapMarkerPath
             Status = $paneStatus
+            RuntimeReady = $false
         })
     }
 
@@ -2717,6 +2948,7 @@ if ($MyInvocation.InvocationName -ne '.') {
         try {
             $readinessAgent = Get-OrchestraReadinessAgentName -PaneSummary $paneSummary
             Wait-AgentReady -PaneId $paneSummary.PaneId -Agent $readinessAgent -SessionName $sessionName -TimeoutSeconds 60
+            $paneSummary['RuntimeReady'] = $true
         } catch {
             Write-Error "Agent readiness timeout for $($paneSummary.Label) [$($paneSummary.PaneId)]: $($_.Exception.Message)"
             exit 1
@@ -2763,11 +2995,24 @@ if ($MyInvocation.InvocationName -ne '.') {
         Write-Warning "Orchestra UI attach status for ${sessionName}: $($uiAttachResult.Status) ($($uiAttachResult.Reason))"
     }
 
-    $manifestPath = Save-OrchestraSessionState -ProjectDir $projectDir -SessionName $sessionName -Settings $settings -GitWorktreeDir $gitWorktreeDir -PaneSummaries $validPaneSummaries -StartupToken $startupToken -BootstrapMode ([string]$orchestraServer.BootstrapMode) -SessionReady $false -UiAttachLaunched ([bool]$uiAttachResult.Launched) -UiAttached ([bool]$uiAttachResult.Attached) -UiAttachStatus ([string]$uiAttachResult.Status) -UiAttachReason ([string]$uiAttachResult.Reason) -UiAttachSource ([string]$uiAttachResult.Source) -UiHostKind ([string]$uiAttachResult.ui_host_kind) -AttachRequestId ([string]$uiAttachResult.attach_request_id) -AttachAdapterTrace @($uiAttachResult.attach_adapter_trace)
+    # Set server-owned titles only after every respawn/readiness check. The global
+    # label map is published once, atomically, after registry and session-ready
+    # convergence so startup never exposes a partially labeled managed session.
+    foreach ($paneSummary in $validPaneSummaries) {
+        Invoke-Winsmux -Arguments @('select-pane', '-t', [string]$paneSummary.PaneId, '-T', [string]$paneSummary.Title) -TargetSessionName $sessionName
+    }
+    $manifestPath = Save-OrchestraSessionState -ProjectDir $projectDir -SessionName $sessionName -Settings $settings -GitWorktreeDir $gitWorktreeDir -PaneSummaries $validPaneSummaries -GenerationId $runtimeGenerationId -ServerSessionId $serverSessionId -BootstrapPaneId $bootstrapPaneId -StartupToken $startupToken -BootstrapMode ([string]$orchestraServer.BootstrapMode) -SessionReady $false -UiAttachLaunched ([bool]$uiAttachResult.Launched) -UiAttached ([bool]$uiAttachResult.Attached) -UiAttachStatus ([string]$uiAttachResult.Status) -UiAttachReason ([string]$uiAttachResult.Reason) -UiAttachSource ([string]$uiAttachResult.Source) -UiHostKind ([string]$uiAttachResult.ui_host_kind) -AttachRequestId ([string]$uiAttachResult.attach_request_id) -AttachAdapterTrace @($uiAttachResult.attach_adapter_trace) -ExpectedPaneCount $expectedPaneCount
+    $manifestPublished = $true
     $supervisorScriptPath = Join-Path $scriptDir 'orchestra-supervisor.ps1'
-    $supervisorProcess = Start-OrchestraSupervisorJob -SupervisorScriptPath $supervisorScriptPath -ManifestPath $manifestPath -SessionName $sessionName -StartupToken $startupToken
+    $supervisorProcess = Start-OrchestraSupervisorJob -SupervisorScriptPath $supervisorScriptPath -ManifestPath $manifestPath -SessionName $sessionName -GenerationId $runtimeGenerationId -ServerSessionId $serverSessionId -StartupToken $startupToken
     Assert-OrchestraBackgroundProcessStarted -Process $supervisorProcess -Name 'Orchestra supervisor job'
-    $manifestPath = Save-OrchestraSessionState -ProjectDir $projectDir -SessionName $sessionName -Settings $settings -GitWorktreeDir $gitWorktreeDir -PaneSummaries $validPaneSummaries -StartupToken $startupToken -SupervisorPid $supervisorProcess.Id -BootstrapMode ([string]$orchestraServer.BootstrapMode) -SessionReady $true -UiAttachLaunched ([bool]$uiAttachResult.Launched) -UiAttached ([bool]$uiAttachResult.Attached) -UiAttachStatus ([string]$uiAttachResult.Status) -UiAttachReason ([string]$uiAttachResult.Reason) -UiAttachSource ([string]$uiAttachResult.Source) -UiHostKind ([string]$uiAttachResult.ui_host_kind) -AttachRequestId ([string]$uiAttachResult.attach_request_id) -AttachAdapterTrace @($uiAttachResult.attach_adapter_trace)
+    Wait-OrchestraRuntimeRegistryReady -ProjectDir $projectDir -SessionName $sessionName -GenerationId $runtimeGenerationId `
+        -ServerSessionId $serverSessionId -BootstrapPaneId $bootstrapPaneId -SupervisorProcess $supervisorProcess -PaneSummaries $validPaneSummaries | Out-Null
+    $manifestPath = Save-OrchestraSessionState -ProjectDir $projectDir -SessionName $sessionName -Settings $settings -GitWorktreeDir $gitWorktreeDir -PaneSummaries $validPaneSummaries -GenerationId $runtimeGenerationId -ServerSessionId $serverSessionId -BootstrapPaneId $bootstrapPaneId -StartupToken $startupToken -SupervisorPid $supervisorProcess.Id -BootstrapMode ([string]$orchestraServer.BootstrapMode) -SessionReady $true -UiAttachLaunched ([bool]$uiAttachResult.Launched) -UiAttached ([bool]$uiAttachResult.Attached) -UiAttachStatus ([string]$uiAttachResult.Status) -UiAttachReason ([string]$uiAttachResult.Reason) -UiAttachSource ([string]$uiAttachResult.Source) -UiHostKind ([string]$uiAttachResult.ui_host_kind) -AttachRequestId ([string]$uiAttachResult.attach_request_id) -AttachAdapterTrace @($uiAttachResult.attach_adapter_trace) -ExpectedPaneCount $expectedPaneCount
+    $labelPublication = Publish-OrchestraPaneLabels -PaneSummaries $validPaneSummaries
+    Write-WinsmuxLog -Level INFO -Event 'preflight.labels.published' -Message "Published $($labelPublication.PublishedCount) orchestra labels atomically." -Data ([ordered]@{
+        published_count = [int]$labelPublication.PublishedCount
+    }) | Out-Null
     Write-WinsmuxLog -Level INFO -Event 'preflight.supervisor.started' -Message "Started orchestra supervisor for session $sessionName." -Data @{ session_name = $sessionName; manifest_path = $manifestPath; supervisor_pid = $supervisorProcess.Id; process_name = $supervisorProcess.ProcessName } | Out-Null
     Write-WinsmuxLog -Level INFO -Event 'orchestra.startup.session_ready' -Message "Orchestra session $sessionName reached session-ready; UI attach remains a separate state." -Data ([ordered]@{
         session_name       = $sessionName
@@ -2849,7 +3094,7 @@ if ($MyInvocation.InvocationName -ne '.') {
         try { Stop-Process -Id $supervisorProcess.Id -Force -ErrorAction SilentlyContinue } catch {}
     }
 
-    $rollback = Invoke-OrchestraStartupRollback -ProjectDir $projectDir -SessionName $sessionName -BootstrapPaneId $bootstrapPaneId -CreatedPaneIds $createdPaneIds -CreatedWorktrees $createdWorktrees -FailureMessage $_.Exception.Message
+    $rollback = Invoke-OrchestraStartupRollback -ProjectDir $projectDir -SessionName $sessionName -BootstrapPaneId $bootstrapPaneId -CreatedPaneIds $createdPaneIds -CreatedWorktrees $createdWorktrees -FailureMessage $_.Exception.Message -ManifestPublished:$manifestPublished -OwnedGenerationId $runtimeGenerationId
     $rollbackSuffix = if ($rollback.BootstrapRespawned) { 'session preserved' } else { 'rollback attempted' }
     Write-Error "Orchestra startup failed ($rollbackSuffix): $($_.Exception.Message)"
     exit 1

--- a/winsmux-core/scripts/orchestra-state.ps1
+++ b/winsmux-core/scripts/orchestra-state.ps1
@@ -1,7 +1,9 @@
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
 
+. (Join-Path $PSScriptRoot 'json-compat.ps1')
 . (Join-Path $PSScriptRoot 'manifest.ps1')
+. (Join-Path $PSScriptRoot 'pane-control.ps1')
 
 function Get-OrchestraStateValue {
     param(
@@ -171,7 +173,7 @@ function Get-OrchestraReviewState {
     }
 
     try {
-        $parsed = $raw | ConvertFrom-Json -AsHashtable -ErrorAction Stop
+        $parsed = $raw | ConvertFrom-WinsmuxJson -AsHashtable -ErrorAction Stop
         $ordered = [ordered]@{}
         foreach ($key in $parsed.Keys) {
             $ordered[[string]$key] = $parsed[$key]
@@ -470,6 +472,12 @@ function Sync-OrchestraPaneStateModels {
         $Manifest = Get-WinsmuxManifest -ProjectDir $ProjectDir
     }
 
+    $manifestPath = Join-Path (Join-Path $ProjectDir '.winsmux') 'manifest.yaml'
+    $expectedGenerationId = if ($null -eq $Manifest) { '' } else {
+        $session = Get-OrchestraStateValue -InputObject $Manifest -Name 'session' -Default $null
+        [string](Get-OrchestraStateValue -InputObject $session -Name 'generation_id' -Default '')
+    }
+
     $models = Get-OrchestraPaneStateModels -ProjectDir $ProjectDir -Manifest $Manifest
     if ($null -eq $Manifest) {
         return $models
@@ -494,6 +502,7 @@ function Sync-OrchestraPaneStateModels {
         }
     }
 
-    Save-WinsmuxManifest -ProjectDir $ProjectDir -Manifest $Manifest
+    Save-PaneControlManifestDocument -ManifestPath $manifestPath -Manifest $Manifest `
+        -ExpectedGenerationId $expectedGenerationId
     return $models
 }

--- a/winsmux-core/scripts/orchestra-supervisor.ps1
+++ b/winsmux-core/scripts/orchestra-supervisor.ps1
@@ -2,6 +2,8 @@
 param(
     [Parameter(Mandatory = $true)][string]$ManifestPath,
     [string]$SessionName = 'winsmux-orchestra',
+    [Parameter(Mandatory = $true)][string]$GenerationId,
+    [Parameter(Mandatory = $true)][string]$ServerSessionId,
     [string]$StartupToken = '',
     [int]$OperatorPollInterval = 20,
     [int]$AgentWatchdogInterval = 30,
@@ -16,6 +18,7 @@ Set-StrictMode -Version Latest
 [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
 
 $scriptDir = $PSScriptRoot
+. (Join-Path $scriptDir 'manifest.ps1')
 . (Join-Path $scriptDir 'operator-poll.ps1') -ManifestPath $ManifestPath -StartupToken $StartupToken -Interval $OperatorPollInterval
 . (Join-Path $scriptDir 'agent-watchdog.ps1') -ManifestPath $ManifestPath -SessionName $SessionName -StartupToken $StartupToken -IdleThreshold $IdleThreshold -PollInterval $AgentWatchdogInterval
 . (Join-Path $scriptDir 'server-watchdog.ps1') -ManifestPath $ManifestPath -SessionName $SessionName -StartupToken $StartupToken -PollInterval $ServerWatchdogInterval -MaxRestartAttempts $MaxRestartAttempts -RestartWindowMinutes $RestartWindowMinutes
@@ -27,6 +30,159 @@ function Write-OrchestraSupervisorWarning {
     )
 
     Write-Warning ("Orchestra supervisor {0} failed for session {1}: {2}" -f $Component, $SessionName, $Message)
+}
+
+function New-OrchestraSupervisorRuntimePanes {
+    param(
+        [Parameter(Mandatory = $true)]$Manifest,
+        [Parameter(Mandatory = $true)][string]$GenerationId,
+        [Parameter(Mandatory = $true)][string]$ServerSessionId,
+        [Parameter(Mandatory = $true)][scriptblock]$ProcessResolver
+    )
+
+    $runtimePanes = [System.Collections.Generic.List[object]]::new()
+    $paneMap = ConvertTo-ManifestPropertyMap -Value (Get-WinsmuxRuntimeValue -InputObject $Manifest -Name 'panes' -Default $null)
+    foreach ($label in $paneMap.Keys) {
+        $pane = $paneMap[$label]
+        $slotId = [string](Get-WinsmuxRuntimeValue -InputObject $pane -Name 'slot_id' -Default '')
+        $paneId = [string](Get-WinsmuxRuntimeValue -InputObject $pane -Name 'pane_id' -Default '')
+        $backend = [string](Get-WinsmuxRuntimeValue -InputObject $pane -Name 'worker_backend' -Default '')
+        $role = Resolve-WinsmuxRuntimeRole `
+            -WorkerRole ([string](Get-WinsmuxRuntimeValue -InputObject $pane -Name 'worker_role' -Default '')) `
+            -CanonicalRole ([string](Get-WinsmuxRuntimeValue -InputObject $pane -Name 'role' -Default ''))
+        $title = [string](Get-WinsmuxRuntimeValue -InputObject $pane -Name 'title' -Default '')
+        $status = [string](Get-WinsmuxRuntimeValue -InputObject $pane -Name 'status' -Default '')
+        $runtimeReady = (Get-WinsmuxRuntimeValue -InputObject $pane -Name 'runtime_ready' -Default $false) -eq $true
+        if ([string]::IsNullOrWhiteSpace($slotId) -or [string]::IsNullOrWhiteSpace($paneId) -or
+            [string]::IsNullOrWhiteSpace($backend) -or [string]::IsNullOrWhiteSpace($role) -or
+            [string]::IsNullOrWhiteSpace($title)) {
+            throw "Runtime pane seed is incomplete for $label."
+        }
+
+        $statusClassification = Get-WinsmuxRuntimeStatusClassification -Status $status
+        $deferred = [bool]$statusClassification.IsDeferred
+        $markerPath = [string](Get-WinsmuxRuntimeValue -InputObject $pane -Name 'bootstrap_marker_path' -Default '')
+        $markerExists = -not [string]::IsNullOrWhiteSpace($markerPath) -and (Test-Path -LiteralPath $markerPath -PathType Leaf)
+        $promoteDeferredStarting = [bool]$statusClassification.IsStarting -and $markerExists
+        $runtimeState = if ($promoteDeferredStarting) {
+            'live'
+        } elseif ($deferred) {
+            'deferred'
+        } elseif ($runtimeReady) {
+            'live'
+        } else {
+            'bootstrap_pending'
+        }
+        $runtimePane = [PSCustomObject][ordered]@{
+            label                        = [string]$label
+            slot_id                      = $slotId
+            pane_id                      = $paneId
+            backend                      = $backend
+            role                         = $role
+            title                        = $title
+            state                        = $runtimeState
+            bootstrap_pid                = 0
+            bootstrap_process_started_at = ''
+            marker_path                  = $markerPath
+        }
+
+        if (-not $deferred -or $promoteDeferredStarting) {
+            if ([string]::IsNullOrWhiteSpace($runtimePane.marker_path) -or -not (Test-Path -LiteralPath $runtimePane.marker_path -PathType Leaf)) {
+                throw "Live runtime pane marker is missing for $label."
+            }
+            try {
+                $marker = Get-Content -LiteralPath $runtimePane.marker_path -Raw -Encoding UTF8 | ConvertFrom-Json
+            } catch {
+                throw "Live runtime pane marker is malformed for $label."
+            }
+            $markerPid = ConvertTo-WinsmuxRuntimeInteger -Value (Get-WinsmuxRuntimeValue -InputObject $marker -Name 'bootstrap_pid' -Default $null)
+            $markerStartedAt = ConvertTo-WinsmuxRuntimeUtcIdentity -Value (Get-WinsmuxRuntimeValue -InputObject $marker -Name 'bootstrap_process_started_at' -Default '')
+            if ([string](Get-WinsmuxRuntimeValue -InputObject $marker -Name 'state' -Default '') -cne 'bootstrap_pending' -or
+                -not [string]::Equals(
+                    [string](Get-WinsmuxRuntimeValue -InputObject $marker -Name 'generation_id' -Default ''),
+                    $GenerationId,
+                    [System.StringComparison]::Ordinal) -or
+                [string](Get-WinsmuxRuntimeValue -InputObject $marker -Name 'server_session_id' -Default '') -cne $ServerSessionId -or
+                [string](Get-WinsmuxRuntimeValue -InputObject $marker -Name 'slot_id' -Default '') -cne $slotId -or
+                [string](Get-WinsmuxRuntimeValue -InputObject $marker -Name 'pane_id' -Default '') -cne $paneId -or
+                [string](Get-WinsmuxRuntimeValue -InputObject $marker -Name 'backend' -Default '') -cne $backend -or
+                [string](Get-WinsmuxRuntimeValue -InputObject $marker -Name 'role' -Default '') -cne $role -or
+                [string](Get-WinsmuxRuntimeValue -InputObject $marker -Name 'title' -Default '') -cne $title -or
+                $null -eq $markerPid -or [string]::IsNullOrWhiteSpace($markerStartedAt) -or
+                -not (Test-WinsmuxStrictProcessIdentity -ProcessId $markerPid -ExpectedStartTime $markerStartedAt -ProcessResolver $ProcessResolver)) {
+                throw "Live runtime pane marker identity does not match $label."
+            }
+            $runtimePane.bootstrap_pid = $markerPid
+            $runtimePane.bootstrap_process_started_at = $markerStartedAt
+        }
+        $runtimePanes.Add($runtimePane) | Out-Null
+    }
+
+    return @($runtimePanes)
+}
+
+function Get-OrchestraSupervisorRuntimePaneSnapshot {
+    param(
+        [Parameter(Mandatory = $true)]$Manifest,
+        [Parameter(Mandatory = $true)][string]$GenerationId,
+        [Parameter(Mandatory = $true)][string]$ServerSessionId,
+        [Parameter(Mandatory = $true)][scriptblock]$ProcessResolver
+    )
+
+    try {
+        $panes = @(New-OrchestraSupervisorRuntimePanes -Manifest $Manifest -GenerationId $GenerationId `
+            -ServerSessionId $ServerSessionId -ProcessResolver $ProcessResolver)
+        return [PSCustomObject][ordered]@{
+            valid      = $true
+            panes      = $panes
+            diagnostic = ''
+        }
+    } catch {
+        return [PSCustomObject][ordered]@{
+            valid      = $false
+            panes      = @()
+            diagnostic = [string]$_.Exception.Message
+        }
+    }
+}
+
+function Initialize-OrchestraSupervisorRuntimeRegistry {
+    param(
+        [Parameter(Mandatory = $true)][string]$ManifestPath,
+        [Parameter(Mandatory = $true)][string]$SessionName,
+        [Parameter(Mandatory = $true)][string]$GenerationId,
+        [Parameter(Mandatory = $true)][string]$ServerSessionId,
+        [Parameter(Mandatory = $true)][string]$SupervisorProcessStartedAt
+    )
+
+    $projectDir = Split-Path (Split-Path $ManifestPath -Parent) -Parent
+    $manifest = Get-WinsmuxManifest -ProjectDir $projectDir
+    $session = Get-WinsmuxRuntimeValue -InputObject $manifest -Name 'session'
+    $bootstrapPaneId = [string](Get-WinsmuxRuntimeValue -InputObject $session -Name 'bootstrap_pane_id' -Default '')
+    $expectedPaneCount = ConvertTo-WinsmuxRuntimeInteger -Value (Get-WinsmuxRuntimeValue -InputObject $session -Name 'expected_pane_count' -Default $null)
+    if ($null -eq $manifest -or
+        [string](Get-WinsmuxRuntimeValue -InputObject $session -Name 'name' -Default '') -cne $SessionName -or
+        -not [string]::Equals(
+            [string](Get-WinsmuxRuntimeValue -InputObject $session -Name 'generation_id' -Default ''),
+            $GenerationId,
+            [System.StringComparison]::Ordinal) -or
+        [string](Get-WinsmuxRuntimeValue -InputObject $session -Name 'server_session_id' -Default '') -cne $ServerSessionId -or
+        $null -eq $expectedPaneCount -or $expectedPaneCount -lt 1 -or
+        ((-not [string]::IsNullOrWhiteSpace($bootstrapPaneId)) -and $bootstrapPaneId -cnotmatch '^%[0-9]+$')) {
+        throw 'Supervisor runtime seed does not match the manifest session identity.'
+    }
+
+    $processResolver = New-WinsmuxProcessSnapshotResolver
+    $runtimePanes = New-OrchestraSupervisorRuntimePanes -Manifest $manifest -GenerationId $GenerationId -ServerSessionId $ServerSessionId -ProcessResolver $processResolver
+    $existingRegistry = Read-WinsmuxRuntimeRegistry -ProjectDir $projectDir
+    if (-not (Test-WinsmuxRuntimeRegistryReplacementAllowed -Registry $existingRegistry -ProcessResolver $processResolver)) {
+        throw 'A live or unverifiable runtime registry owner already controls this project.'
+    }
+    $registry = New-WinsmuxRuntimeRegistryDocument -SessionName $SessionName -ServerSessionId $ServerSessionId -BootstrapPaneId $bootstrapPaneId `
+        -GenerationId $GenerationId -SupervisorPid $PID -SupervisorProcessStartedAt $SupervisorProcessStartedAt `
+        -ExpectedPaneCount $expectedPaneCount -Panes $runtimePanes -LeaseSeconds 15
+    Save-WinsmuxRuntimeRegistry -ProjectDir $projectDir -Registry $registry | Out-Null
+    return $projectDir
 }
 
 function Invoke-OrchestraSupervisorLoop {
@@ -65,9 +221,26 @@ function Invoke-OrchestraSupervisorLoop {
     $nextOperatorPollAt = Get-Date
     $nextAgentWatchdogAt = Get-Date
     $nextServerWatchdogAt = Get-Date
+    $supervisorProcessStartedAt = Get-WinsmuxRuntimeProcessStartedAt -ProcessId $PID
+    if ([string]::IsNullOrWhiteSpace($supervisorProcessStartedAt)) {
+        throw 'Supervisor process StartTime is unavailable.'
+    }
+    $runtimeProjectDir = Initialize-OrchestraSupervisorRuntimeRegistry -ManifestPath $ManifestPath -SessionName $SessionName `
+        -GenerationId $GenerationId -ServerSessionId $ServerSessionId -SupervisorProcessStartedAt $supervisorProcessStartedAt
 
     while ($true) {
         $now = Get-Date
+        $runtimeManifest = Get-WinsmuxManifest -ProjectDir $runtimeProjectDir
+        $processResolver = New-WinsmuxProcessSnapshotResolver
+        $runtimeSnapshot = Get-OrchestraSupervisorRuntimePaneSnapshot -Manifest $runtimeManifest `
+            -GenerationId $GenerationId -ServerSessionId $ServerSessionId -ProcessResolver $processResolver
+        if ([bool]$runtimeSnapshot.valid) {
+            Update-WinsmuxRuntimeRegistryLease -ProjectDir $runtimeProjectDir -GenerationId $GenerationId `
+                -SupervisorPid $PID -SupervisorProcessStartedAt $supervisorProcessStartedAt -Panes @($runtimeSnapshot.panes) `
+                -Now $now -LeaseSeconds 15 | Out-Null
+        } else {
+            Write-OrchestraSupervisorWarning -Component 'runtime-registry' -Message ([string]$runtimeSnapshot.diagnostic)
+        }
 
         if ($now -ge $nextOperatorPollAt) {
             try {
@@ -135,13 +308,26 @@ function Invoke-OrchestraSupervisorLoop {
 }
 
 if ($MyInvocation.InvocationName -ne '.') {
-    Invoke-OrchestraSupervisorLoop `
-        -ManifestPath $ManifestPath `
-        -SessionName $SessionName `
-        -OperatorPollInterval $OperatorPollInterval `
-        -AgentWatchdogInterval $AgentWatchdogInterval `
-        -ServerWatchdogInterval $ServerWatchdogInterval `
-        -IdleThreshold $IdleThreshold `
-        -MaxRestartAttempts $MaxRestartAttempts `
-        -RestartWindowMinutes $RestartWindowMinutes
+    $supervisorProcessStartedAt = Get-WinsmuxRuntimeProcessStartedAt -ProcessId $PID
+    try {
+        Invoke-OrchestraSupervisorLoop `
+            -ManifestPath $ManifestPath `
+            -SessionName $SessionName `
+            -OperatorPollInterval $OperatorPollInterval `
+            -AgentWatchdogInterval $AgentWatchdogInterval `
+            -ServerWatchdogInterval $ServerWatchdogInterval `
+            -IdleThreshold $IdleThreshold `
+            -MaxRestartAttempts $MaxRestartAttempts `
+            -RestartWindowMinutes $RestartWindowMinutes
+    } finally {
+        if (-not [string]::IsNullOrWhiteSpace($supervisorProcessStartedAt)) {
+            $runtimeProjectDir = Split-Path (Split-Path $ManifestPath -Parent) -Parent
+            try {
+                Close-WinsmuxRuntimeRegistry -ProjectDir $runtimeProjectDir -GenerationId $GenerationId `
+                    -SupervisorPid $PID -SupervisorProcessStartedAt $supervisorProcessStartedAt | Out-Null
+            } catch {
+                Write-OrchestraSupervisorWarning -Component 'runtime-registry-close' -Message $_.Exception.Message
+            }
+        }
+    }
 }

--- a/winsmux-core/scripts/orchestra-ui-attach.ps1
+++ b/winsmux-core/scripts/orchestra-ui-attach.ps1
@@ -1,6 +1,7 @@
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
 
+. (Join-Path $PSScriptRoot 'json-compat.ps1')
 . (Join-Path $PSScriptRoot 'clm-safe-io.ps1')
 if (-not (Get-Command Invoke-WinsmuxBridgeCommand -ErrorAction SilentlyContinue)) {
     $settingsScript = Join-Path $PSScriptRoot 'settings.ps1'
@@ -72,7 +73,7 @@ function Read-OrchestraAttachState {
     }
 
     try {
-        return $raw | ConvertFrom-Json -Depth 8
+        return $raw | ConvertFrom-WinsmuxJson -Depth 8
     } catch {
         return $null
     }
@@ -504,7 +505,7 @@ function Get-OrchestraAttachTraceEntries {
             $rawText = ([string]$rawEntry).Trim()
             if (-not [string]::IsNullOrWhiteSpace($rawText) -and $rawText.StartsWith('{') -and $rawText.EndsWith('}')) {
                 try {
-                    $jsonEntry = $rawText | ConvertFrom-Json -Depth 8
+                    $jsonEntry = $rawText | ConvertFrom-WinsmuxJson -Depth 8
                     foreach ($property in $jsonEntry.PSObject.Properties) {
                         $normalized[$property.Name] = $property.Value
                     }

--- a/winsmux-core/scripts/pane-control.ps1
+++ b/winsmux-core/scripts/pane-control.ps1
@@ -1,3 +1,4 @@
+. (Join-Path $PSScriptRoot 'json-compat.ps1')
 . (Join-Path $PSScriptRoot 'settings.ps1')
 . (Join-Path $PSScriptRoot 'manifest.ps1')
 
@@ -255,6 +256,8 @@ function ConvertFrom-PaneControlManifestContent {
 
     $parsed = ConvertFrom-ManifestYaml -Content $Content
     return [ordered]@{
+        version = $parsed.version
+        saved_at = $parsed.saved_at
         Session = $parsed.session
         Panes   = $parsed.panes
         Tasks   = $parsed.tasks
@@ -285,7 +288,7 @@ function ConvertFrom-PaneControlSecurityPolicy {
 
     foreach ($candidate in $parseCandidates | Select-Object -Unique) {
         try {
-            return ($candidate | ConvertFrom-Json -AsHashtable -Depth 8)
+            return ($candidate | ConvertFrom-WinsmuxJson -AsHashtable -Depth 8)
         } catch {
         }
     }
@@ -307,6 +310,8 @@ function Get-PaneControlManifestEntries {
     }
 
     $manifest = ConvertFrom-PaneControlManifestContent -Content $content
+    $manifestVersion = ConvertTo-WinsmuxRuntimeInteger -Value (Get-PaneControlValue -InputObject $manifest -Name 'Version' -Default $null)
+    $manifestGenerationId = [string](Get-PaneControlValue -InputObject $manifest.Session -Name 'generation_id' -Default '')
     $projectRoot = [string](Get-PaneControlValue -InputObject $manifest.Session -Name 'project_dir' -Default '')
     if ([string]::IsNullOrWhiteSpace($projectRoot)) {
         $projectRoot = $ProjectDir
@@ -351,12 +356,17 @@ function Get-PaneControlManifestEntries {
 
         $entries += [PSCustomObject][ordered]@{
             ManifestPath        = $manifestPath
+            ManifestVersion     = $manifestVersion
+            GenerationId        = $manifestGenerationId
             ProjectDir          = $projectRoot
             Label               = $label
+            SlotId              = [string](Get-PaneControlValue -InputObject $pane -Name 'slot_id' -Default $label)
             PaneId              = [string](Get-PaneControlValue -InputObject $pane -Name 'pane_id' -Default '')
             WorkerBackend       = [string](Get-PaneControlValue -InputObject $pane -Name 'worker_backend' -Default 'local')
             WorkerRole          = [string](Get-PaneControlValue -InputObject $pane -Name 'worker_role' -Default '')
             Role                = $role
+            Title               = [string](Get-PaneControlValue -InputObject $pane -Name 'title' -Default '')
+            RuntimeReady        = ConvertFrom-PaneControlBoolean -Value (Get-PaneControlValue -InputObject $pane -Name 'runtime_ready' -Default $false) -Default $false
             LaunchDir           = $launchDir
             BuilderBranch       = $builderBranch
             BuilderWorktreePath = $builderWorktreePath
@@ -440,6 +450,115 @@ function Get-PaneControlManifestEntries {
     return @($entries)
 }
 
+function Test-PaneControlRuntimeContext {
+    param(
+        [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [Parameter(Mandatory = $true)]$ManifestEntry,
+        [ValidateSet('dispatch', 'start_deferred', 'caller_ack', 'stop_transition')][string]$Operation = 'dispatch',
+        [AllowNull()]$CallerIdentity = $null,
+        [AllowNull()][scriptblock]$ProcessResolver = $null
+    )
+
+    try {
+        $manifest = Get-WinsmuxManifest -ProjectDir $ProjectDir
+        $registry = Read-WinsmuxRuntimeRegistry -ProjectDir $ProjectDir
+    } catch {
+        return New-WinsmuxRuntimeValidationResult -Valid $false -ReasonCode 'manifest_regeneration_required' `
+            -Diagnostic 'Runtime manifest or registry is missing or malformed; regenerate the orchestra session.'
+    }
+    if ($null -eq $registry) {
+        return New-WinsmuxRuntimeValidationResult -Valid $false -ReasonCode 'manifest_regeneration_required' `
+            -Diagnostic 'Runtime registry is missing; regenerate the orchestra session.'
+    }
+
+    $sessionName = [string](Get-WinsmuxRuntimeValue -InputObject $registry -Name 'session_name' -Default '')
+    $serverSessionId = [string](Get-WinsmuxRuntimeValue -InputObject $registry -Name 'server_session_id' -Default '')
+    if ([string]::IsNullOrWhiteSpace($sessionName) -or $serverSessionId -cnotmatch '^\$[0-9]+$') {
+        return New-WinsmuxRuntimeValidationResult -Valid $false -ReasonCode 'manifest_regeneration_required' `
+            -Diagnostic 'Runtime registry session identity is malformed; regenerate the orchestra session.'
+    }
+
+    try {
+        $format = "#{session_id}`t#{session_name}`t#{pane_id}`t#{pane_title}"
+        $snapshotOutput = Invoke-PaneControlWinsmux -Arguments @('list-panes', '-a', '-t', $sessionName, '-F', $format)
+        $observedPanes = [System.Collections.Generic.List[object]]::new()
+        $observedSessionId = ''
+        foreach ($line in @((($snapshotOutput | Out-String).Trim()) -split "\r?\n")) {
+            if ([string]::IsNullOrWhiteSpace($line)) { continue }
+            $parts = $line -split "`t", 4
+            if ($parts.Count -ne 4 -or $parts[0] -cnotmatch '^\$[0-9]+$' -or $parts[1] -cne $sessionName -or
+                [string]::IsNullOrWhiteSpace($parts[2]) -or [string]::IsNullOrWhiteSpace($parts[3])) {
+                throw 'server pane snapshot is malformed or belongs to another session'
+            }
+            if ([string]::IsNullOrWhiteSpace($observedSessionId)) { $observedSessionId = $parts[0] }
+            if ($observedSessionId -cne $parts[0]) { throw 'server pane snapshot mixes session identities' }
+            $observedPanes.Add([PSCustomObject]@{ pane_id = $parts[2]; title = $parts[3] }) | Out-Null
+        }
+        if ([string]::IsNullOrWhiteSpace($observedSessionId)) { throw 'server pane snapshot is empty' }
+    } catch {
+        return New-WinsmuxRuntimeValidationResult -Valid $false -ReasonCode 'manifest_regeneration_required' `
+            -Diagnostic 'Live server session evidence is unavailable; regenerate the orchestra session.'
+    }
+
+    $marker = $null
+    $markerPath = [string](Get-PaneControlValue -InputObject $ManifestEntry -Name 'BootstrapMarkerPath' -Default '')
+    if (-not [string]::IsNullOrWhiteSpace($markerPath) -and (Test-Path -LiteralPath $markerPath -PathType Leaf)) {
+        try { $marker = Get-Content -LiteralPath $markerPath -Raw -Encoding UTF8 | ConvertFrom-Json }
+        catch {
+            return New-WinsmuxRuntimeValidationResult -Valid $false -ReasonCode 'runtime_target_mismatch' `
+                -Diagnostic 'Pane bootstrap marker is malformed.'
+        }
+    }
+
+    $backend = ([string](Get-PaneControlValue -InputObject $ManifestEntry -Name 'WorkerBackend' -Default '')).Trim().ToLowerInvariant()
+    if ($null -eq $ProcessResolver) {
+        try { $ProcessResolver = New-WinsmuxProcessSnapshotResolver }
+        catch {
+            $reasonCode = if ($Operation -ceq 'caller_ack') { 'caller_identity_mismatch' } else { 'invalid_supervisor_identity' }
+            return New-WinsmuxRuntimeValidationResult -Valid $false -ReasonCode $reasonCode `
+                -Diagnostic 'OS process identity evidence is unavailable.'
+        }
+    }
+    if ($null -eq $CallerIdentity -and $Operation -ceq 'caller_ack' -and $backend -in @('local', 'codex')) {
+        $callerSnapshot = & $ProcessResolver $PID
+        $callerStartedAt = ConvertTo-WinsmuxRuntimeUtcIdentity -Value (Get-WinsmuxRuntimeValue -InputObject $callerSnapshot -Name 'StartTime' -Default (Get-WinsmuxRuntimeValue -InputObject $callerSnapshot -Name 'CreationDate' -Default ''))
+        $CallerIdentity = [PSCustomObject][ordered]@{
+            process_id        = $PID
+            process_started_at = $callerStartedAt
+            generation_id    = [string](Get-WinsmuxRuntimeValue -InputObject $registry -Name 'generation_id' -Default '')
+            server_session_id = $serverSessionId
+            slot_id          = [string](Get-PaneControlValue -InputObject $ManifestEntry -Name 'SlotId' -Default '')
+            pane_id          = [string](Get-PaneControlValue -InputObject $ManifestEntry -Name 'PaneId' -Default '')
+            backend          = $backend
+        }
+    }
+
+    return Test-WinsmuxRuntimeContext -Manifest $manifest -Registry $registry -ObservedServerSessionId $observedSessionId `
+        -ObservedPanes @($observedPanes) -ManifestEntry $ManifestEntry -PaneMarker $marker -CallerIdentity $CallerIdentity `
+        -ProcessResolver $ProcessResolver -Operation $Operation
+}
+
+function Wait-PaneControlRuntimeContext {
+    param(
+        [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [Parameter(Mandatory = $true)]$ManifestEntry,
+        [ValidateSet('dispatch', 'start_deferred', 'caller_ack', 'stop_transition')][string]$Operation = 'dispatch',
+        [int]$TimeoutSeconds = 15
+    )
+
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    $lastResult = $null
+    do {
+        $lastResult = Test-PaneControlRuntimeContext -ProjectDir $ProjectDir -ManifestEntry $ManifestEntry -Operation $Operation
+        if ($lastResult.valid) { return $lastResult }
+        if ($lastResult.reason_code -notin @('runtime_target_mismatch', 'manifest_regeneration_required')) {
+            return $lastResult
+        }
+        Start-Sleep -Milliseconds 200
+    } while ((Get-Date) -lt $deadline)
+    return $lastResult
+}
+
 function Get-PaneControlManifestContext {
     param(
         [Parameter(Mandatory = $true)][string]$ProjectDir,
@@ -459,11 +578,131 @@ function Get-PaneControlManifestContext {
     throw "Pane $PaneId was not found in manifest: $manifestPath"
 }
 
+function Get-PaneControlManifestGenerationId {
+    param([Parameter(Mandatory = $true)][string]$ManifestPath)
+
+    if (-not (Test-Path -LiteralPath $ManifestPath -PathType Leaf)) {
+        throw "Manifest not found: $ManifestPath"
+    }
+    $projectDir = Split-Path (Split-Path $ManifestPath -Parent) -Parent
+    $manifest = Get-WinsmuxManifest -ProjectDir $projectDir
+    $version = ConvertTo-WinsmuxRuntimeInteger -Value (Get-WinsmuxRuntimeValue -InputObject $manifest -Name 'version' -Default $null)
+    if ($version -ne 2) { return '' }
+
+    $session = Get-WinsmuxRuntimeValue -InputObject $manifest -Name 'session' -Default $null
+    $generationId = [string](Get-WinsmuxRuntimeValue -InputObject $session -Name 'generation_id' -Default '')
+    if ([string]::IsNullOrWhiteSpace($generationId)) {
+        throw 'runtime dispatch refused (manifest_regeneration_required): v2 manifest generation_id is missing.'
+    }
+    return $generationId
+}
+
+function Save-PaneControlManifestDocument {
+    param(
+        [Parameter(Mandatory = $true)][string]$ManifestPath,
+        [Parameter(Mandatory = $true)]$Manifest,
+        [AllowEmptyString()][string]$ExpectedGenerationId = '',
+        [AllowEmptyString()][string]$RuntimePaneId = '',
+        [ValidateSet('auto', 'dispatch', 'start_deferred', 'caller_ack', 'stop_transition')][string]$RuntimeOperation = 'auto'
+    )
+
+    $projectDir = Split-Path (Split-Path $ManifestPath -Parent) -Parent
+    $nextVersion = ConvertTo-WinsmuxRuntimeInteger -Value (Get-WinsmuxRuntimeValue -InputObject $Manifest -Name 'version' -Default $null)
+    if (-not (Test-Path -LiteralPath $ManifestPath -PathType Leaf)) {
+        if ($nextVersion -eq 2) {
+            throw "Manifest not found: $ManifestPath"
+        }
+        Save-WinsmuxManifest -ProjectDir $projectDir -Manifest $Manifest
+        return
+    }
+
+    $currentManifest = Get-WinsmuxManifest -ProjectDir $projectDir
+    $currentVersion = ConvertTo-WinsmuxRuntimeInteger -Value (Get-WinsmuxRuntimeValue -InputObject $currentManifest -Name 'version' -Default $null)
+    if ($currentVersion -ne 2) {
+        $isPureV1Save = $currentVersion -eq 1 -and
+            $nextVersion -eq 1 -and
+            [string]::IsNullOrWhiteSpace($ExpectedGenerationId)
+        if (-not $isPureV1Save) {
+            throw 'runtime dispatch refused (manifest_regeneration_required): Current manifest schema is not v2 for a guarded v2 document mutation.'
+        }
+        Save-WinsmuxManifest -ProjectDir $projectDir -Manifest $Manifest
+        return
+    }
+
+    if ([string]::IsNullOrWhiteSpace($ExpectedGenerationId)) {
+        throw 'runtime dispatch refused (invalid_supervisor_identity): ExpectedGenerationId is required for a v2 manifest mutation.'
+    }
+
+    $currentSession = Get-WinsmuxRuntimeValue -InputObject $currentManifest -Name 'session' -Default $null
+    $currentGenerationId = [string](Get-WinsmuxRuntimeValue -InputObject $currentSession -Name 'generation_id' -Default '')
+    if (-not [string]::Equals($currentGenerationId, $ExpectedGenerationId, [System.StringComparison]::Ordinal)) {
+        throw 'runtime dispatch refused (invalid_supervisor_identity): Runtime generation changed before the manifest mutation began.'
+    }
+
+    $bootstrapPaneId = [string](Get-WinsmuxRuntimeValue -InputObject $currentSession -Name 'bootstrap_pane_id' -Default '')
+    $paneMap = ConvertTo-ManifestPropertyMap -Value (Get-WinsmuxRuntimeValue -InputObject $currentManifest -Name 'panes' -Default $null)
+    $managedPaneIds = [System.Collections.Generic.List[string]]::new()
+    $seenPaneIds = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::Ordinal)
+    foreach ($label in @($paneMap.Keys | Sort-Object)) {
+        $paneId = [string](Get-WinsmuxRuntimeValue -InputObject $paneMap[$label] -Name 'pane_id' -Default '')
+        if ($paneId -cnotmatch '^%[0-9]+$' -or
+            [string]::Equals($paneId, $bootstrapPaneId, [System.StringComparison]::Ordinal)) {
+            continue
+        }
+        if (-not $seenPaneIds.Add($paneId)) {
+            throw 'runtime dispatch refused (runtime_target_mismatch): Managed runtime pane IDs must be unique for a v2 manifest mutation.'
+        }
+        $managedPaneIds.Add($paneId) | Out-Null
+    }
+
+    if ([string]::IsNullOrWhiteSpace($RuntimePaneId)) {
+        if ($managedPaneIds.Count -eq 0) {
+            throw 'runtime dispatch refused (runtime_target_mismatch): A live managed runtime pane is required for a v2 manifest mutation.'
+        }
+        $RuntimePaneId = $managedPaneIds[0]
+    } elseif ($RuntimePaneId -cnotmatch '^%[0-9]+$' -or -not $seenPaneIds.Contains($RuntimePaneId)) {
+        throw 'runtime dispatch refused (runtime_target_mismatch): RuntimePaneId must identify a managed non-bootstrap pane in the current v2 manifest.'
+    }
+
+    $manifestEntry = Get-PaneControlManifestContext -ProjectDir $projectDir -PaneId $RuntimePaneId
+    $effectiveOperation = $RuntimeOperation
+    if ($effectiveOperation -ceq 'auto') {
+        $status = [string](Get-PaneControlValue -InputObject $manifestEntry -Name 'Status' -Default '')
+        $effectiveOperation = [string](Get-WinsmuxRuntimeStatusClassification -Status $status).RuntimeOperation
+    }
+    $runtimeValidation = Test-PaneControlRuntimeContext -ProjectDir $projectDir -ManifestEntry $manifestEntry -Operation $effectiveOperation
+    if ($null -eq $runtimeValidation -or -not [bool]$runtimeValidation.valid) {
+        $reasonCode = [string](Get-PaneControlValue -InputObject $runtimeValidation -Name 'reason_code' -Default 'invalid_supervisor_identity')
+        $diagnostic = [string](Get-PaneControlValue -InputObject $runtimeValidation -Name 'diagnostic' -Default 'Runtime identity validation failed immediately before manifest save.')
+        throw ("runtime dispatch refused ({0}): {1}" -f $reasonCode, $diagnostic)
+    }
+    $validatedGenerationId = [string](Get-PaneControlValue -InputObject $runtimeValidation.context -Name 'generation_id' -Default '')
+    if (-not [string]::Equals($validatedGenerationId, $ExpectedGenerationId, [System.StringComparison]::Ordinal)) {
+        throw 'runtime dispatch refused (invalid_supervisor_identity): Runtime generation changed immediately before manifest save.'
+    }
+
+    $freshManifest = Get-WinsmuxManifest -ProjectDir $projectDir
+    $freshVersion = ConvertTo-WinsmuxRuntimeInteger -Value (Get-WinsmuxRuntimeValue -InputObject $freshManifest -Name 'version' -Default $null)
+    $freshSession = Get-WinsmuxRuntimeValue -InputObject $freshManifest -Name 'session' -Default $null
+    $freshGenerationId = [string](Get-WinsmuxRuntimeValue -InputObject $freshSession -Name 'generation_id' -Default '')
+    $nextIdentity = Get-WinsmuxVerifiedManifestIdentity -Manifest $Manifest
+    if ($freshVersion -ne 2 -or
+        -not [string]::Equals($freshGenerationId, $ExpectedGenerationId, [System.StringComparison]::Ordinal) -or
+        $null -eq $nextIdentity -or
+        -not [string]::Equals([string]$nextIdentity.generation_id, $ExpectedGenerationId, [System.StringComparison]::Ordinal)) {
+        throw 'runtime dispatch refused (invalid_supervisor_identity): Runtime generation changed immediately before manifest save.'
+    }
+
+    Save-WinsmuxManifest -ProjectDir $projectDir -Manifest $Manifest -ExpectedGenerationId $ExpectedGenerationId
+}
+
 function Set-PaneControlManifestPaneProperties {
     param(
         [Parameter(Mandatory = $true)][string]$ManifestPath,
         [Parameter(Mandatory = $true)][string]$PaneId,
-        [Parameter(Mandatory = $true)][System.Collections.IDictionary]$Properties
+        [Parameter(Mandatory = $true)][System.Collections.IDictionary]$Properties,
+        [AllowEmptyString()][string]$ExpectedGenerationId = '',
+        [ValidateSet('auto', 'dispatch', 'start_deferred', 'caller_ack', 'stop_transition')][string]$RuntimeOperation = 'auto'
     )
 
     if (-not (Test-Path $ManifestPath -PathType Leaf)) {
@@ -474,6 +713,45 @@ function Set-PaneControlManifestPaneProperties {
     $manifest = Get-WinsmuxManifest -ProjectDir $projectDir
     if ($null -eq $manifest) {
         throw "Pane $PaneId was not found in manifest: $ManifestPath"
+    }
+
+    $manifestVersion = ConvertTo-WinsmuxRuntimeInteger -Value (Get-WinsmuxRuntimeValue -InputObject $manifest -Name 'version' -Default $null)
+    if ($manifestVersion -eq 2) {
+        if ([string]::IsNullOrWhiteSpace($ExpectedGenerationId)) {
+            throw 'runtime dispatch refused (invalid_supervisor_identity): ExpectedGenerationId is required for a v2 manifest mutation.'
+        }
+
+        $manifestSession = Get-WinsmuxRuntimeValue -InputObject $manifest -Name 'session' -Default $null
+        $initialGenerationId = [string](Get-WinsmuxRuntimeValue -InputObject $manifestSession -Name 'generation_id' -Default '')
+        if (-not [string]::Equals($initialGenerationId, $ExpectedGenerationId, [System.StringComparison]::Ordinal)) {
+            throw 'runtime dispatch refused (invalid_supervisor_identity): Runtime generation changed before the manifest mutation began.'
+        }
+
+        $manifestEntry = Get-PaneControlManifestContext -ProjectDir $projectDir -PaneId $PaneId
+        $effectiveOperation = $RuntimeOperation
+        if ($effectiveOperation -ceq 'auto') {
+            $status = [string](Get-PaneControlValue -InputObject $manifestEntry -Name 'Status' -Default '')
+            $effectiveOperation = [string](Get-WinsmuxRuntimeStatusClassification -Status $status).RuntimeOperation
+        }
+        $runtimeValidation = Test-PaneControlRuntimeContext -ProjectDir $projectDir -ManifestEntry $manifestEntry -Operation $effectiveOperation
+        if ($null -eq $runtimeValidation -or -not [bool]$runtimeValidation.valid) {
+            $reasonCode = [string](Get-PaneControlValue -InputObject $runtimeValidation -Name 'reason_code' -Default 'invalid_supervisor_identity')
+            $diagnostic = [string](Get-PaneControlValue -InputObject $runtimeValidation -Name 'diagnostic' -Default 'Runtime identity validation failed immediately before manifest save.')
+            throw ("runtime dispatch refused ({0}): {1}" -f $reasonCode, $diagnostic)
+        }
+        $validatedGenerationId = [string](Get-PaneControlValue -InputObject $runtimeValidation.context -Name 'generation_id' -Default '')
+        if (-not [string]::Equals($validatedGenerationId, $ExpectedGenerationId, [System.StringComparison]::Ordinal)) {
+            throw 'runtime dispatch refused (invalid_supervisor_identity): Runtime generation changed immediately before manifest save.'
+        }
+
+        # Re-read after runtime validation so a concurrent generation replacement cannot be overwritten by an older document.
+        $manifest = Get-WinsmuxManifest -ProjectDir $projectDir
+        $freshVersion = ConvertTo-WinsmuxRuntimeInteger -Value (Get-WinsmuxRuntimeValue -InputObject $manifest -Name 'version' -Default $null)
+        $freshSession = Get-WinsmuxRuntimeValue -InputObject $manifest -Name 'session' -Default $null
+        $freshGenerationId = [string](Get-WinsmuxRuntimeValue -InputObject $freshSession -Name 'generation_id' -Default '')
+        if ($freshVersion -ne 2 -or -not [string]::Equals($freshGenerationId, $ExpectedGenerationId, [System.StringComparison]::Ordinal)) {
+            throw 'runtime dispatch refused (invalid_supervisor_identity): Runtime generation changed immediately before manifest save.'
+        }
     }
 
     $originalLabel = $null
@@ -510,7 +788,8 @@ function Set-PaneControlManifestPaneProperties {
     }
 
     $manifest.panes = $updatedPanes
-    Save-WinsmuxManifest -ProjectDir $projectDir -Manifest $manifest
+    Save-PaneControlManifestDocument -ManifestPath $ManifestPath -Manifest $manifest `
+        -ExpectedGenerationId $ExpectedGenerationId -RuntimePaneId $PaneId -RuntimeOperation $RuntimeOperation
 }
 
 function Get-PaneControlPaneTitle {
@@ -545,7 +824,9 @@ function Update-PaneControlManifestPaneLabel {
     $properties = [ordered]@{
         label = $resolvedLabel
     }
-    Set-PaneControlManifestPaneProperties -ManifestPath $context.ManifestPath -PaneId $PaneId -Properties $properties
+    $expectedGenerationId = [string]$context.GenerationId
+    Set-PaneControlManifestPaneProperties -ManifestPath $context.ManifestPath -PaneId $PaneId -Properties $properties `
+        -ExpectedGenerationId $expectedGenerationId
     return $true
 }
 
@@ -557,7 +838,8 @@ function Set-PaneControlManifestPanePaths {
         [AllowNull()][string]$BuilderWorktreePath = $null
     )
 
-    $manifestPath = Join-Path (Join-Path $ProjectDir '.winsmux') 'manifest.yaml'
+    $context = Get-PaneControlManifestContext -ProjectDir $ProjectDir -PaneId $PaneId
+    $manifestPath = [string]$context.ManifestPath
     $properties = [ordered]@{
         launch_dir = $LaunchDir
     }
@@ -566,7 +848,9 @@ function Set-PaneControlManifestPanePaths {
         $properties['builder_worktree_path'] = $BuilderWorktreePath
     }
 
-    Set-PaneControlManifestPaneProperties -ManifestPath $manifestPath -PaneId $PaneId -Properties $properties
+    $expectedGenerationId = [string]$context.GenerationId
+    Set-PaneControlManifestPaneProperties -ManifestPath $manifestPath -PaneId $PaneId -Properties $properties `
+        -ExpectedGenerationId $expectedGenerationId
 }
 
 function Get-PaneControlRestartPlan {
@@ -605,6 +889,7 @@ function Get-PaneControlRestartPlan {
 
     return [ordered]@{
         PaneId         = $context.PaneId
+        GenerationId   = [string]$context.GenerationId
         Label          = $context.Label
         Role           = $context.Role
         ProjectDir     = $context.ProjectDir

--- a/winsmux-core/scripts/pane-scaler.ps1
+++ b/winsmux-core/scripts/pane-scaler.ps1
@@ -104,7 +104,8 @@ function Read-PaneScalerManifest {
 function Save-PaneScalerManifest {
     param(
         [Parameter(Mandatory = $true)][string]$ManifestPath,
-        [Parameter(Mandatory = $true)]$Manifest
+        [Parameter(Mandatory = $true)]$Manifest,
+        [AllowEmptyString()][string]$ExpectedGenerationId = ''
     )
 
     $projectDir = Split-Path (Split-Path $ManifestPath -Parent) -Parent
@@ -123,7 +124,17 @@ function Save-PaneScalerManifest {
         worktrees = Get-MonitorPropertyValue -InputObject $Manifest -Name 'Worktrees' -Default (Get-MonitorPropertyValue -InputObject $Manifest -Name 'worktrees' -Default ([ordered]@{}))
     }
 
-    Save-WinsmuxManifest -ProjectDir $projectDir -Manifest $canonicalManifest
+    Save-PaneControlManifestDocument -ManifestPath $ManifestPath -Manifest $canonicalManifest `
+        -ExpectedGenerationId $ExpectedGenerationId
+}
+
+function Assert-PaneScalerPaneCountMutationSupported {
+    param([Parameter(Mandatory = $true)]$Manifest)
+
+    $version = Get-MonitorPropertyValue -InputObject $Manifest -Name 'Version' -Default (Get-MonitorPropertyValue -InputObject $Manifest -Name 'version' -Default 1)
+    if ([int]$version -eq 2) {
+        throw 'runtime dispatch refused (manifest_regeneration_required): v2 pane-count changes require a supervisor-owned manifest, registry, and server transition.'
+    }
 }
 
 function Get-PaneScalerProjectDir {
@@ -307,15 +318,20 @@ function Remove-PaneScalerBuilderWorktree {
         }
 
         if (Test-Path -LiteralPath $resolvedPath -PathType Container) {
-            Invoke-BuilderWorktreeGit -ProjectDir $ProjectDir -Arguments @('worktree', 'remove', '--force', $resolvedPath) -AllowFailure | Out-Null
+            $status = Invoke-BuilderWorktreeGit -ProjectDir $resolvedPath -Arguments @('status', '--porcelain', '--untracked-files=all')
+            if (-not [string]::IsNullOrWhiteSpace([string]$status.Output)) {
+                throw "Refusing to remove Builder worktree with uncommitted changes: $resolvedPath"
+            }
+
+            Invoke-BuilderWorktreeGit -ProjectDir $ProjectDir -Arguments @('worktree', 'remove', $resolvedPath) | Out-Null
             if (Test-Path -LiteralPath $resolvedPath -PathType Container) {
-                Remove-Item -LiteralPath $resolvedPath -Recurse -Force
+                throw "Builder worktree removal did not remove the directory: $resolvedPath"
             }
         }
     }
 
     if (-not [string]::IsNullOrWhiteSpace($BranchName)) {
-        Invoke-BuilderWorktreeGit -ProjectDir $ProjectDir -Arguments @('branch', '-D', $BranchName) -AllowFailure | Out-Null
+        Invoke-BuilderWorktreeGit -ProjectDir $ProjectDir -Arguments @('branch', '-d', $BranchName) | Out-Null
     }
 }
 
@@ -403,6 +419,8 @@ function Add-OrchestraPane {
     )
 
     $manifest = Read-PaneScalerManifest -ManifestPath $ManifestPath
+    Assert-PaneScalerPaneCountMutationSupported -Manifest $manifest
+    $expectedGenerationId = [string](Get-MonitorPropertyValue -InputObject $manifest.Session -Name 'generation_id' -Default '')
     $projectDir = Get-PaneScalerProjectDir -Manifest $manifest -ManifestPath $ManifestPath
     if ($null -eq $Settings) {
         $Settings = Get-BridgeSettings -RootPath $projectDir
@@ -460,7 +478,7 @@ function Add-OrchestraPane {
 
         $manifest.Panes[$newLabel] = $paneObject
         $manifest.SavedAt = Get-Date -Format o
-        Save-PaneScalerManifest -ManifestPath $ManifestPath -Manifest $manifest
+        Save-PaneScalerManifest -ManifestPath $ManifestPath -Manifest $manifest -ExpectedGenerationId $expectedGenerationId
 
         return [PSCustomObject]@{
             Changed      = $true
@@ -496,6 +514,8 @@ function Remove-OrchestraPane {
         [int]$MinimumBuilders = 2
     )
 
+    $currentManifest = Read-PaneScalerManifest -ManifestPath $ManifestPath
+    Assert-PaneScalerPaneCountMutationSupported -Manifest $currentManifest
     $workload = Get-PaneWorkload -ManifestPath $ManifestPath -Settings $Settings
     if ($workload.BuilderCount -le $MinimumBuilders) {
         return [PSCustomObject]@{
@@ -519,20 +539,22 @@ function Remove-OrchestraPane {
     }
 
     $manifest = $workload.Manifest
+    $expectedGenerationId = [string](Get-MonitorPropertyValue -InputObject $manifest.Session -Name 'generation_id' -Default '')
     $projectDir = $workload.ProjectDir
     $pane = $manifest.Panes[[string]$idleBuilder.Label]
     $paneId = [string](Get-MonitorPropertyValue -InputObject $pane -Name 'pane_id' -Default '')
     $worktreePath = [string](Get-MonitorPropertyValue -InputObject $pane -Name 'builder_worktree_path' -Default '')
     $branchName = [string](Get-MonitorPropertyValue -InputObject $pane -Name 'builder_branch' -Default '')
 
+    [void]$manifest.Panes.Remove([string]$idleBuilder.Label)
+    $manifest.SavedAt = Get-Date -Format o
+    Save-PaneScalerManifest -ManifestPath $ManifestPath -Manifest $manifest -ExpectedGenerationId $expectedGenerationId
+
     if (-not [string]::IsNullOrWhiteSpace($paneId)) {
         Invoke-MonitorWinsmux -Arguments @('kill-pane', '-t', $paneId) | Out-Null
     }
 
     Remove-PaneScalerBuilderWorktree -ProjectDir $projectDir -WorktreePath $worktreePath -BranchName $branchName
-    [void]$manifest.Panes.Remove([string]$idleBuilder.Label)
-    $manifest.SavedAt = Get-Date -Format o
-    Save-PaneScalerManifest -ManifestPath $ManifestPath -Manifest $manifest
 
     return [PSCustomObject]@{
         Changed      = $true

--- a/winsmux-core/scripts/settings.ps1
+++ b/winsmux-core/scripts/settings.ps1
@@ -13,6 +13,8 @@ Dot-source this script to load the helpers:
     . "$PSScriptRoot/settings.ps1"
 #>
 
+. (Join-Path $PSScriptRoot 'json-compat.ps1')
+
 $script:BridgeSettingsFileName = '.winsmux.yaml'
 $script:BridgeProviderRegistryFileName = 'provider-registry.json'
 $script:BridgeProviderCapabilityRegistryFileName = 'provider-capabilities.json'
@@ -704,7 +706,7 @@ function Read-BridgeProviderRegistry {
     }
 
     try {
-        $parsed = $raw | ConvertFrom-Json -Depth 16 -ErrorAction Stop
+        $parsed = $raw | ConvertFrom-WinsmuxJson -Depth 16 -ErrorAction Stop
     } catch {
         throw "Invalid provider registry JSON at '$path'."
     }
@@ -1076,7 +1078,7 @@ function Read-BridgeRuntimeRolePreferences {
     }
 
     try {
-        $parsed = $raw | ConvertFrom-Json -Depth 16 -ErrorAction Stop
+        $parsed = $raw | ConvertFrom-WinsmuxJson -Depth 16 -ErrorAction Stop
     } catch {
         throw "Invalid runtime role preferences JSON at '$path'."
     }
@@ -1596,7 +1598,7 @@ function Read-BridgeProviderCapabilityRegistry {
     }
 
     try {
-        $parsed = $raw | ConvertFrom-Json -Depth 16 -ErrorAction Stop
+        $parsed = $raw | ConvertFrom-WinsmuxJson -Depth 16 -ErrorAction Stop
     } catch {
         throw "Invalid provider capability registry JSON at '$path'."
     }

--- a/winsmux-core/scripts/shadow-cutover-gate.ps1
+++ b/winsmux-core/scripts/shadow-cutover-gate.ps1
@@ -15,6 +15,8 @@ $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
 [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
 
+. (Join-Path $PSScriptRoot 'json-compat.ps1')
+
 function Stop-GateError {
     param([Parameter(Mandatory = $true)][string]$Message)
 
@@ -35,7 +37,7 @@ function Read-GateJson {
     }
 
     try {
-        return ($raw | ConvertFrom-Json -Depth 64)
+        return ($raw | ConvertFrom-WinsmuxJson -Depth 64)
     } catch {
         Stop-GateError "shadow-cutover-gate input is not valid JSON: $Path"
     }

--- a/winsmux-core/scripts/submission-contract.ps1
+++ b/winsmux-core/scripts/submission-contract.ps1
@@ -1,4 +1,5 @@
 $ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot 'json-compat.ps1')
 
 $script:WinsmuxSubmissionProtocolVersion = 1
 $script:WinsmuxSubmissionStatuses = @('accepted', 'rejected', 'unsupported', 'unavailable')
@@ -7,7 +8,8 @@ $script:WinsmuxSubmissionBackends = @('local', 'codex', 'api_llm', 'antigravity'
 $script:WinsmuxSubmissionEvidenceTypes = @('backend_run_record')
 $script:WinsmuxSubmissionRunStatuses = @('started', 'running', 'succeeded')
 $script:WinsmuxSubmissionBridgeScript = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\..\scripts\winsmux-core.ps1'))
-
+$script:WinsmuxSubmissionAckFrameLimit = 16384
+$script:WinsmuxSubmissionAckTimeoutMilliseconds = 30000
 function ConvertTo-WinsmuxSubmissionDiagnostic {
     param([AllowEmptyString()][string]$Text = '')
 
@@ -252,7 +254,7 @@ function New-WinsmuxSubmissionPacket {
 function Read-WinsmuxSubmissionPacket {
     param([Parameter(Mandatory = $true)][string]$Path)
 
-    $packet = Get-Content -LiteralPath $Path -Raw -Encoding UTF8 | ConvertFrom-Json -Depth 16
+    $packet = Get-Content -LiteralPath $Path -Raw -Encoding UTF8 | ConvertFrom-WinsmuxJson -Depth 16
     if (-not (Test-WinsmuxSubmissionPacket -Packet $packet)) {
         throw 'submission packet is malformed or uses an unknown protocol version, kind, or id'
     }
@@ -262,7 +264,7 @@ function Read-WinsmuxSubmissionPacket {
 function Read-WinsmuxSubmissionPacketIfPresent {
     param([Parameter(Mandatory = $true)][string]$Path)
 
-    $candidate = Get-Content -LiteralPath $Path -Raw -Encoding UTF8 | ConvertFrom-Json -Depth 16
+    $candidate = Get-Content -LiteralPath $Path -Raw -Encoding UTF8 | ConvertFrom-WinsmuxJson -Depth 16
     $hasProtocol = $null -ne $candidate.PSObject.Properties['protocol_version']
     $hasSubmissionId = $null -ne $candidate.PSObject.Properties['submission_id']
     if (-not $hasProtocol -and -not $hasSubmissionId) { return $null }
@@ -438,6 +440,52 @@ function New-WinsmuxSubmissionReceipt {
     }
 }
 
+function ConvertFrom-WinsmuxRuntimeRefusal {
+    param([Parameter(Mandatory = $true)]$Failure)
+
+    $failureException = Get-WinsmuxSubmissionValue -InputObject $Failure -Name 'Exception' -Default $null
+    $message = if ($Failure -is [System.Exception]) {
+        [string]$Failure.Message
+    } elseif ($failureException -is [System.Exception]) {
+        [string]$failureException.Message
+    } else {
+        [string]$Failure
+    }
+    $reasonCode = 'deferred_start_failed'
+    $diagnostic = $message
+    if ($message -match '^runtime dispatch refused \(([a-z][a-z0-9_]*)\):\s*(.*)$') {
+        $reasonCode = [string]$Matches[1]
+        $diagnostic = [string]$Matches[2]
+    }
+    return [PSCustomObject][ordered]@{
+        reason_code = $reasonCode
+        diagnostic  = $diagnostic
+    }
+}
+
+function New-WinsmuxDeferredStartFailureReceipt {
+    param(
+        [Parameter(Mandatory = $true)][ValidateSet('task', 'review')][string]$Kind,
+        [Parameter(Mandatory = $true)][string]$SubmissionId,
+        [AllowEmptyString()][string]$PaneId = '',
+        [string]$Backend = 'noop',
+        [AllowNull()]$Target = $null,
+        [Parameter(Mandatory = $true)]$Failure
+    )
+
+    $normalizedBackend = $Backend.Trim().ToLowerInvariant()
+    if ($normalizedBackend -notin @('local', 'codex', 'api_llm', 'antigravity', 'noop')) {
+        $normalizedBackend = 'noop'
+    }
+    if ($null -eq $Target) {
+        $Target = [ordered]@{ label = ''; pane_id = $PaneId; role = '' }
+    }
+    $refusal = ConvertFrom-WinsmuxRuntimeRefusal -Failure $Failure
+    return New-WinsmuxSubmissionReceipt -Kind $Kind -Status unavailable -Backend $normalizedBackend `
+        -SubmissionId $SubmissionId -ReasonCode ([string]$refusal.reason_code) `
+        -Diagnostic ([string]$refusal.diagnostic) -Target $Target
+}
+
 function Test-WinsmuxSubmissionReceipt {
     param([AllowNull()]$Receipt)
 
@@ -542,6 +590,30 @@ function Get-WinsmuxSubmissionRunPath {
     return Join-Path (Join-Path (Join-Path (Join-Path $ProjectDir '.winsmux') 'worker-runs') $SlotId) (Join-Path $RunId 'run.json')
 }
 
+function Write-WinsmuxSubmissionRunRecordTempFile {
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $true)][byte[]]$Bytes
+    )
+
+    $stream = [System.IO.File]::Open($Path, [System.IO.FileMode]::CreateNew, [System.IO.FileAccess]::Write, [System.IO.FileShare]::None)
+    try {
+        $stream.Write($Bytes, 0, $Bytes.Length)
+        $stream.Flush($true)
+    } finally {
+        $stream.Dispose()
+    }
+}
+
+function Move-WinsmuxSubmissionRunRecordFile {
+    param(
+        [Parameter(Mandatory = $true)][string]$SourcePath,
+        [Parameter(Mandatory = $true)][string]$DestinationPath
+    )
+
+    [System.IO.File]::Move($SourcePath, $DestinationPath)
+}
+
 function Write-WinsmuxSubmissionRunRecord {
     param(
         [Parameter(Mandatory = $true)][string]$ProjectDir,
@@ -554,7 +626,16 @@ function Write-WinsmuxSubmissionRunRecord {
     if (-not (Test-Path -LiteralPath $directory -PathType Container)) {
         New-Item -ItemType Directory -Path $directory -Force | Out-Null
     }
-    [System.IO.File]::WriteAllText($runPath, ($Record | ConvertTo-Json -Depth 12), [System.Text.UTF8Encoding]::new($false))
+    $bytes = [System.Text.UTF8Encoding]::new($false).GetBytes(($Record | ConvertTo-Json -Depth 12))
+    $tempPath = Join-Path $directory ('.run-' + [guid]::NewGuid().ToString('N') + '.tmp')
+    try {
+        Write-WinsmuxSubmissionRunRecordTempFile -Path $tempPath -Bytes $bytes
+        Move-WinsmuxSubmissionRunRecordFile -SourcePath $tempPath -DestinationPath $runPath
+    } finally {
+        if (Test-Path -LiteralPath $tempPath -PathType Leaf) {
+            Remove-Item -LiteralPath $tempPath -Force -ErrorAction SilentlyContinue
+        }
+    }
     return $runPath
 }
 
@@ -570,7 +651,7 @@ function Get-WinsmuxSubmissionRunResult {
     if ($env:WINSMUX_SUBMISSION_POLL_ATTEMPTS -match '^\d+$') { $attempts = [int]$env:WINSMUX_SUBMISSION_POLL_ATTEMPTS }
     for ($attempt = 0; $attempt -le $attempts; $attempt++) {
         if (Test-Path -LiteralPath $runPath -PathType Leaf) {
-            try { return (Get-Content -LiteralPath $runPath -Raw -Encoding UTF8 | ConvertFrom-Json -Depth 16) }
+            try { return (Get-Content -LiteralPath $runPath -Raw -Encoding UTF8 | ConvertFrom-WinsmuxJson -Depth 16) }
             catch { return [ordered]@{ status = 'failed'; reason = 'runner_receipt_malformed'; exit_code = 1 } }
         }
         if ($attempt -lt $attempts) { Start-Sleep -Milliseconds 500 }
@@ -585,11 +666,500 @@ function Invoke-WinsmuxSubmissionAcknowledge {
         [Parameter(Mandatory = $true)][string]$SubmissionId,
         [Parameter(Mandatory = $true)][string]$RunId,
         [Parameter(Mandatory = $true)][ValidateSet('task', 'review')][string]$Kind,
-        [Parameter(Mandatory = $true)][ValidateSet('local', 'codex')][string]$Backend
+        [Parameter(Mandatory = $true)][ValidateSet('local', 'codex')][string]$Backend,
+        [AllowNull()]$CallerIdentity = $null,
+        [AllowNull()][scriptblock]$ProcessResolver = $null,
+        [AllowEmptyString()][string]$AckPipe = '',
+        [AllowEmptyString()][string]$Challenge = ''
     )
 
-    return New-WinsmuxSubmissionReceipt -Kind $Kind -Status unavailable -Backend $Backend -SubmissionId $SubmissionId `
-        -ReasonCode 'caller_identity_unavailable' -Target ([ordered]@{ label = $SlotId })
+    $target = [ordered]@{ label = $SlotId }
+    $hasAckChannel = -not [string]::IsNullOrWhiteSpace($AckPipe) -or -not [string]::IsNullOrWhiteSpace($Challenge)
+    if ($hasAckChannel -and (-not (Test-WinsmuxSubmissionAckPipeName -Value $AckPipe) -or
+            -not (Test-WinsmuxSubmissionAckChallenge -Value $Challenge))) {
+        throw 'submission acknowledgement channel is invalid'
+    }
+    $finish = {
+        param($Receipt)
+        if (-not $hasAckChannel) { return $Receipt }
+        return Invoke-WinsmuxSubmissionAcknowledgementClientHandshake `
+            -PipeName $AckPipe -Challenge $Challenge -Receipt $Receipt
+    }.GetNewClosure()
+    if (-not (Get-Command Get-PaneControlManifestEntries -ErrorAction SilentlyContinue) -or
+        -not (Get-Command Test-PaneControlRuntimeContext -ErrorAction SilentlyContinue)) {
+        return & $finish (New-WinsmuxSubmissionReceipt -Kind $Kind -Status unavailable -Backend $Backend -SubmissionId $SubmissionId `
+            -ReasonCode 'caller_identity_unavailable' -Target $target)
+    }
+
+    $entries = @(Get-PaneControlManifestEntries -ProjectDir $ProjectDir | Where-Object { [string]$_.Label -ceq $SlotId })
+    if ($entries.Count -ne 1) {
+        return & $finish (New-WinsmuxSubmissionReceipt -Kind $Kind -Status unavailable -Backend $Backend -SubmissionId $SubmissionId `
+            -ReasonCode 'runtime_target_mismatch' -Target $target)
+    }
+    $manifestEntry = $entries[0]
+    $target['pane_id'] = [string](Get-WinsmuxSubmissionValue -InputObject $manifestEntry -Name 'PaneId' -Default '')
+    $target['role'] = [string](Get-WinsmuxSubmissionValue -InputObject $manifestEntry -Name 'Role' -Default '')
+    if ([string](Get-WinsmuxSubmissionValue -InputObject $manifestEntry -Name 'WorkerBackend' -Default '') -cne $Backend) {
+        return & $finish (New-WinsmuxSubmissionReceipt -Kind $Kind -Status unavailable -Backend $Backend -SubmissionId $SubmissionId `
+            -ReasonCode 'caller_identity_mismatch' -Target $target)
+    }
+
+    $runtimeArguments = @{
+        ProjectDir     = $ProjectDir
+        ManifestEntry = $manifestEntry
+        Operation     = 'caller_ack'
+    }
+    if ($null -ne $CallerIdentity) { $runtimeArguments['CallerIdentity'] = $CallerIdentity }
+    if ($null -ne $ProcessResolver) { $runtimeArguments['ProcessResolver'] = $ProcessResolver }
+    $runtimeResult = Test-PaneControlRuntimeContext @runtimeArguments
+    if (-not $runtimeResult.valid) {
+        return & $finish (New-WinsmuxSubmissionReceipt -Kind $Kind -Status unavailable -Backend $Backend -SubmissionId $SubmissionId `
+            -ReasonCode ([string]$runtimeResult.reason_code) -Diagnostic ([string]$runtimeResult.diagnostic) -Target $target)
+    }
+
+    if ($RunId -cne $SubmissionId) {
+        return & $finish (New-WinsmuxSubmissionReceipt -Kind $Kind -Status rejected -Backend $Backend -SubmissionId $SubmissionId `
+            -ReasonCode 'runner_evidence_invalid' -Target $target)
+    }
+    $runPath = Get-WinsmuxSubmissionRunPath -ProjectDir $ProjectDir -SlotId $SlotId -RunId $RunId
+    if (Test-Path -LiteralPath $runPath -PathType Leaf) {
+        return & $finish (New-WinsmuxSubmissionReceipt -Kind $Kind -Status rejected -Backend $Backend -SubmissionId $SubmissionId `
+            -ReasonCode 'run_record_already_exists' -Target $target)
+    }
+
+    $packetPath = (Resolve-WinsmuxSubmissionPacketPath -ProjectDir $ProjectDir -SubmissionId $SubmissionId).FullPath
+    if (-not (Test-Path -LiteralPath $packetPath -PathType Leaf)) {
+        return & $finish (New-WinsmuxSubmissionReceipt -Kind $Kind -Status unavailable -Backend $Backend -SubmissionId $SubmissionId `
+            -ReasonCode 'runner_acknowledgement_missing' -Target $target)
+    }
+    try { $packet = Get-Content -LiteralPath $packetPath -Raw -Encoding UTF8 | ConvertFrom-WinsmuxJson -Depth 16 }
+    catch {
+        return & $finish (New-WinsmuxSubmissionReceipt -Kind $Kind -Status rejected -Backend $Backend -SubmissionId $SubmissionId `
+            -ReasonCode 'runner_receipt_malformed' -Target $target)
+    }
+    if (-not (Test-WinsmuxSubmissionPacket -Packet $packet) -or
+        [string]$packet.submission_id -cne $SubmissionId -or [string]$packet.run_id -cne $RunId -or
+        [string]$packet.kind -cne $Kind -or [string]$packet.target -cne $SlotId) {
+        return & $finish (New-WinsmuxSubmissionReceipt -Kind $Kind -Status rejected -Backend $Backend -SubmissionId $SubmissionId `
+            -ReasonCode 'runner_evidence_invalid' -Target $target)
+    }
+
+    $record = New-WinsmuxSubmissionRunRecord -SubmissionId $SubmissionId -RunId $RunId -TaskId ([string]$packet.task_id) `
+        -Kind $Kind -TaskTitle ([string]$packet.title) -SlotId $SlotId -Backend $Backend -Status started `
+        -RequestConsumed -RequestDigest ([string]$packet.request_digest)
+    $receipt = New-WinsmuxSubmissionReceipt -Kind $Kind -Status accepted -Backend $Backend -SubmissionId $SubmissionId `
+        -Target $target -Acknowledgement $record
+    return & $finish $receipt
+}
+
+function Get-WinsmuxSubmissionAckTimeoutMilliseconds {
+    $configured = 0
+    if ([int]::TryParse([string]$env:WINSMUX_SUBMISSION_ACK_TIMEOUT_MS, [ref]$configured) -and
+        $configured -ge 1 -and $configured -le 300000) {
+        return $configured
+    }
+    return $script:WinsmuxSubmissionAckTimeoutMilliseconds
+}
+
+function Test-WinsmuxSubmissionAckPipeName {
+    param([AllowEmptyString()][string]$Value = '')
+
+    return $Value -cmatch '^winsmux-submission-ack-[0-9a-f]{32}$'
+}
+
+function Test-WinsmuxSubmissionAckChallenge {
+    param([AllowEmptyString()][string]$Value = '')
+
+    return $Value -cmatch '^[0-9a-f]{64}$'
+}
+
+function New-WinsmuxSubmissionAckChallenge {
+    $bytes = New-Object byte[] 32
+    $algorithm = [System.Security.Cryptography.RandomNumberGenerator]::Create()
+    try {
+        $algorithm.GetBytes($bytes)
+    } finally {
+        $algorithm.Dispose()
+    }
+    return ([System.BitConverter]::ToString($bytes).Replace('-', '').ToLowerInvariant())
+}
+
+function New-WinsmuxSubmissionAckPipeServerStream {
+    param([Parameter(Mandatory = $true)][string]$PipeName)
+
+    if (-not (Test-WinsmuxSubmissionAckPipeName -Value $PipeName)) {
+        throw 'submission acknowledgement pipe name is invalid'
+    }
+
+    $direction = [System.IO.Pipes.PipeDirection]::InOut
+    $transmission = [System.IO.Pipes.PipeTransmissionMode]::Byte
+    $options = [System.IO.Pipes.PipeOptions]::Asynchronous
+    if ([enum]::GetNames([System.IO.Pipes.PipeOptions]) -contains 'CurrentUserOnly') {
+        $options = $options -bor [System.IO.Pipes.PipeOptions]::CurrentUserOnly
+        return [System.IO.Pipes.NamedPipeServerStream]::new($PipeName, $direction, 1, $transmission, $options, 4096, 4096)
+    }
+
+    $identity = [System.Security.Principal.WindowsIdentity]::GetCurrent()
+    try {
+        $security = [System.IO.Pipes.PipeSecurity]::new()
+        $security.SetAccessRuleProtection($true, $false)
+        $rule = [System.IO.Pipes.PipeAccessRule]::new(
+            $identity.User,
+            [System.IO.Pipes.PipeAccessRights]::ReadWrite,
+            [System.Security.AccessControl.AccessControlType]::Allow
+        )
+        $security.AddAccessRule($rule)
+        return [System.IO.Pipes.NamedPipeServerStream]::new($PipeName, $direction, 1, $transmission, $options, 4096, 4096, $security)
+    } finally {
+        $identity.Dispose()
+    }
+}
+
+function New-WinsmuxSubmissionAcknowledgementServer {
+    $pipeName = 'winsmux-submission-ack-' + [guid]::NewGuid().ToString('N')
+    return [PSCustomObject][ordered]@{
+        pipe_name = $pipeName
+        challenge = New-WinsmuxSubmissionAckChallenge
+        server    = New-WinsmuxSubmissionAckPipeServerStream -PipeName $pipeName
+    }
+}
+
+function Wait-WinsmuxSubmissionPipeTask {
+    param(
+        [Parameter(Mandatory = $true)][System.Threading.Tasks.Task]$Task,
+        [Parameter(Mandatory = $true)][int]$TimeoutMilliseconds,
+        [Parameter(Mandatory = $true)][System.IDisposable]$TimeoutTarget
+    )
+
+    $delay = [System.Threading.Tasks.Task]::Delay($TimeoutMilliseconds)
+    $winner = [System.Threading.Tasks.Task]::WaitAny([System.Threading.Tasks.Task[]]@($Task, $delay))
+    if ($winner -ne 0) {
+        $TimeoutTarget.Dispose()
+        try { $Task.GetAwaiter().GetResult() | Out-Null } catch { }
+        throw [System.TimeoutException]::new('submission acknowledgement pipe timed out')
+    }
+    return $Task.GetAwaiter().GetResult()
+}
+
+function Write-WinsmuxSubmissionPipeFrame {
+    param(
+        [Parameter(Mandatory = $true)][System.IO.Stream]$Stream,
+        [Parameter(Mandatory = $true)][string]$Json
+    )
+
+    $payload = [System.Text.UTF8Encoding]::new($false).GetBytes($Json)
+    if ($payload.Length -lt 2 -or $payload.Length -gt $script:WinsmuxSubmissionAckFrameLimit) {
+        throw 'submission acknowledgement frame length is invalid'
+    }
+    $header = [System.BitConverter]::GetBytes([int]$payload.Length)
+    $Stream.Write($header, 0, $header.Length)
+    $Stream.Write($payload, 0, $payload.Length)
+    $Stream.Flush()
+}
+
+function Read-WinsmuxSubmissionPipeBytes {
+    param(
+        [Parameter(Mandatory = $true)][System.IO.Stream]$Stream,
+        [Parameter(Mandatory = $true)][int]$Length,
+        [Parameter(Mandatory = $true)][int]$TimeoutMilliseconds
+    )
+
+    $buffer = New-Object byte[] $Length
+    $offset = 0
+    while ($offset -lt $Length) {
+        $readTask = $Stream.ReadAsync($buffer, $offset, $Length - $offset)
+        $read = Wait-WinsmuxSubmissionPipeTask -Task $readTask -TimeoutMilliseconds $TimeoutMilliseconds -TimeoutTarget $Stream
+        if ($read -lt 1) { throw 'submission acknowledgement pipe closed before a complete frame was received' }
+        $offset += [int]$read
+    }
+    return ,$buffer
+}
+
+function Read-WinsmuxSubmissionPipeFrame {
+    param(
+        [Parameter(Mandatory = $true)][System.IO.Stream]$Stream,
+        [Parameter(Mandatory = $true)][int]$TimeoutMilliseconds
+    )
+
+    $header = Read-WinsmuxSubmissionPipeBytes -Stream $Stream -Length 4 -TimeoutMilliseconds $TimeoutMilliseconds
+    $length = [System.BitConverter]::ToInt32($header, 0)
+    if ($length -lt 2 -or $length -gt $script:WinsmuxSubmissionAckFrameLimit) {
+        throw 'submission acknowledgement frame length is invalid'
+    }
+    $payload = Read-WinsmuxSubmissionPipeBytes -Stream $Stream -Length $length -TimeoutMilliseconds $TimeoutMilliseconds
+    return [System.Text.UTF8Encoding]::new($false, $true).GetString($payload)
+}
+
+function Read-WinsmuxSubmissionPipeJson {
+    param(
+        [Parameter(Mandatory = $true)][System.IO.Stream]$Stream,
+        [int]$TimeoutMilliseconds = (Get-WinsmuxSubmissionAckTimeoutMilliseconds)
+    )
+
+    $json = Read-WinsmuxSubmissionPipeFrame -Stream $Stream -TimeoutMilliseconds $TimeoutMilliseconds
+    try { return ($json | ConvertFrom-WinsmuxJson -Depth 16) }
+    catch { throw 'submission acknowledgement frame is not valid JSON' }
+}
+
+function Initialize-WinsmuxSubmissionPipeInterop {
+    if ('WinsmuxSubmissionPipeNative' -as [type]) { return }
+
+    Add-Type -TypeDefinition @'
+using System;
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+
+public static class WinsmuxSubmissionPipeNative
+{
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool GetNamedPipeClientProcessId(SafePipeHandle pipe, out uint clientProcessId);
+
+    public static int GetClientProcessId(SafePipeHandle pipe)
+    {
+        uint processId;
+        if (!GetNamedPipeClientProcessId(pipe, out processId))
+        {
+            throw new Win32Exception(Marshal.GetLastWin32Error());
+        }
+        return checked((int)processId);
+    }
+}
+'@
+}
+
+function Get-WinsmuxSubmissionPipeClientProcessId {
+    param([Parameter(Mandatory = $true)][System.IO.Pipes.NamedPipeServerStream]$Server)
+
+    if (-not $Server.IsConnected) {
+        throw 'submission acknowledgement pipe is not connected'
+    }
+    Initialize-WinsmuxSubmissionPipeInterop
+    return [WinsmuxSubmissionPipeNative]::GetClientProcessId($Server.SafePipeHandle)
+}
+
+function Receive-WinsmuxSubmissionAcknowledgement {
+    param(
+        [Parameter(Mandatory = $true)]$ServerState,
+        [int]$TimeoutMilliseconds = (Get-WinsmuxSubmissionAckTimeoutMilliseconds)
+    )
+
+    $server = Get-WinsmuxSubmissionValue -InputObject $ServerState -Name 'server' -Default $null
+    if ($server -isnot [System.IO.Pipes.NamedPipeServerStream]) {
+        throw 'submission acknowledgement server state is invalid'
+    }
+    if (-not $server.IsConnected) {
+        $waitTask = $server.WaitForConnectionAsync()
+        Wait-WinsmuxSubmissionPipeTask -Task $waitTask -TimeoutMilliseconds $TimeoutMilliseconds -TimeoutTarget $server | Out-Null
+    }
+    $clientProcessId = Get-WinsmuxSubmissionPipeClientProcessId -Server $server
+    return [PSCustomObject][ordered]@{
+        client_process_id = $clientProcessId
+        payload           = Read-WinsmuxSubmissionPipeJson -Stream $server -TimeoutMilliseconds $TimeoutMilliseconds
+    }
+}
+
+function Write-WinsmuxSubmissionAcknowledgementControl {
+    param(
+        [Parameter(Mandatory = $true)]$ServerState,
+        [Parameter(Mandatory = $true)][ValidateSet('commit', 'verified', 'rejected')][string]$Status
+    )
+
+    $server = Get-WinsmuxSubmissionValue -InputObject $ServerState -Name 'server' -Default $null
+    if ($server -isnot [System.IO.Pipes.NamedPipeServerStream] -or -not $server.IsConnected) {
+        throw 'submission acknowledgement pipe is not connected'
+    }
+    $response = [ordered]@{ protocol_version = 1; status = $Status }
+    Write-WinsmuxSubmissionPipeFrame -Stream $server -Json ($response | ConvertTo-Json -Compress)
+}
+
+function Test-WinsmuxSubmissionAcknowledgementControl {
+    param(
+        [AllowNull()]$Control,
+        [Parameter(Mandatory = $true)][ValidateSet('commit', 'verified', 'rejected')][string]$ExpectedStatus
+    )
+
+    if ($null -eq $Control) { return $false }
+    $names = if ($Control -is [System.Collections.IDictionary]) { @($Control.Keys) } else { @($Control.PSObject.Properties.Name) }
+    $version = Get-WinsmuxSubmissionRawValue -InputObject $Control -Name 'protocol_version' -Default $null
+    return (
+        $names.Count -eq 2 -and @($names | Where-Object { [string]$_ -cnotin @('protocol_version', 'status') }).Count -eq 0 -and
+        (Test-WinsmuxSubmissionInteger -Value $version) -and [int64]$version -eq 1 -and
+        [string](Get-WinsmuxSubmissionValue -InputObject $Control -Name 'status' -Default '') -ceq $ExpectedStatus
+    )
+}
+
+function Complete-WinsmuxSubmissionAcknowledgement {
+    param(
+        [Parameter(Mandatory = $true)]$ServerState,
+        [Parameter(Mandatory = $true)][bool]$Verified
+    )
+
+    $server = Get-WinsmuxSubmissionValue -InputObject $ServerState -Name 'server' -Default $null
+    if ($server -isnot [System.IO.Pipes.NamedPipeServerStream]) { return $false }
+    try {
+        if ($server.IsConnected) {
+            $status = if ($Verified) { 'verified' } else { 'rejected' }
+            Write-WinsmuxSubmissionAcknowledgementControl -ServerState $ServerState -Status $status
+        }
+        return $true
+    } catch {
+        return $false
+    } finally {
+        $server.Dispose()
+    }
+}
+
+function New-WinsmuxSubmissionAcknowledgementEnvelope {
+    param(
+        [Parameter(Mandatory = $true)][ValidateSet('candidate', 'committed')][string]$Phase,
+        [Parameter(Mandatory = $true)][string]$Challenge,
+        [Parameter(Mandatory = $true)]$Receipt
+    )
+
+    if (-not (Test-WinsmuxSubmissionAckChallenge -Value $Challenge) -or
+        -not (Test-WinsmuxSubmissionReceipt -Receipt $Receipt)) {
+        throw 'submission acknowledgement envelope input is invalid'
+    }
+    return [ordered]@{
+        protocol_version = 1
+        phase            = $Phase
+        challenge        = $Challenge
+        receipt          = $Receipt
+    }
+}
+
+function Test-WinsmuxSubmissionAcknowledgementEnvelope {
+    param(
+        [AllowNull()]$Envelope,
+        [Parameter(Mandatory = $true)][ValidateSet('candidate', 'committed')][string]$ExpectedPhase,
+        [Parameter(Mandatory = $true)][string]$ExpectedChallenge,
+        [Parameter(Mandatory = $true)][string]$SubmissionId,
+        [Parameter(Mandatory = $true)][ValidateSet('task', 'review')][string]$Kind,
+        [Parameter(Mandatory = $true)][ValidateSet('local', 'codex')][string]$Backend,
+        [Parameter(Mandatory = $true)][string]$SlotId
+    )
+
+    if ($null -eq $Envelope) { return $false }
+    $allowedNames = @('protocol_version', 'phase', 'challenge', 'receipt')
+    $actualNames = if ($Envelope -is [System.Collections.IDictionary]) {
+        @($Envelope.Keys | ForEach-Object { [string]$_ })
+    } else {
+        @($Envelope.PSObject.Properties.Name)
+    }
+    if ($actualNames.Count -ne $allowedNames.Count -or @($actualNames | Where-Object { $_ -cnotin $allowedNames }).Count -gt 0) {
+        return $false
+    }
+    $version = Get-WinsmuxSubmissionRawValue -InputObject $Envelope -Name 'protocol_version' -Default $null
+    $phase = Get-WinsmuxSubmissionRawValue -InputObject $Envelope -Name 'phase' -Default $null
+    $challenge = Get-WinsmuxSubmissionRawValue -InputObject $Envelope -Name 'challenge' -Default $null
+    $receipt = Get-WinsmuxSubmissionRawValue -InputObject $Envelope -Name 'receipt' -Default $null
+    if (-not (Test-WinsmuxSubmissionInteger -Value $version) -or [int64]$version -ne 1 -or
+        $phase -isnot [string] -or [string]$phase -cne $ExpectedPhase -or
+        $challenge -isnot [string] -or -not [string]::Equals([string]$challenge, $ExpectedChallenge, [System.StringComparison]::Ordinal) -or
+        -not (Test-WinsmuxSubmissionAckChallenge -Value ([string]$challenge)) -or
+        -not (Test-WinsmuxSubmissionReceipt -Receipt $receipt)) {
+        return $false
+    }
+    $target = Get-WinsmuxSubmissionValue -InputObject $receipt -Name 'target' -Default $null
+    return (
+        [string](Get-WinsmuxSubmissionValue -InputObject $receipt -Name 'submission_id' -Default '') -ceq $SubmissionId -and
+        [string](Get-WinsmuxSubmissionValue -InputObject $receipt -Name 'kind' -Default '') -ceq $Kind -and
+        [string](Get-WinsmuxSubmissionValue -InputObject $receipt -Name 'backend' -Default '') -ceq $Backend -and
+        [string](Get-WinsmuxSubmissionValue -InputObject $target -Name 'label' -Default '') -ceq $SlotId
+    )
+}
+
+function Invoke-WinsmuxSubmissionAcknowledgementClientHandshake {
+    param(
+        [Parameter(Mandatory = $true)][string]$PipeName,
+        [Parameter(Mandatory = $true)][string]$Challenge,
+        [Parameter(Mandatory = $true)]$Receipt,
+        [int]$TimeoutMilliseconds = (Get-WinsmuxSubmissionAckTimeoutMilliseconds)
+    )
+
+    if (-not (Test-WinsmuxSubmissionAckPipeName -Value $PipeName)) {
+        throw 'submission acknowledgement pipe name is invalid'
+    }
+    $candidate = New-WinsmuxSubmissionAcknowledgementEnvelope -Phase candidate -Challenge $Challenge -Receipt $Receipt
+    $client = [System.IO.Pipes.NamedPipeClientStream]::new(
+        '.', $PipeName, [System.IO.Pipes.PipeDirection]::InOut, [System.IO.Pipes.PipeOptions]::Asynchronous
+    )
+    try {
+        $client.Connect($TimeoutMilliseconds)
+        Write-WinsmuxSubmissionPipeFrame -Stream $client -Json ($candidate | ConvertTo-Json -Depth 14 -Compress)
+        $control = Read-WinsmuxSubmissionPipeJson -Stream $client -TimeoutMilliseconds $TimeoutMilliseconds
+        if ([string](Get-WinsmuxSubmissionValue -InputObject $Receipt -Name 'status' -Default '') -cne 'accepted') {
+            return $Receipt
+        }
+        if (-not (Test-WinsmuxSubmissionAcknowledgementControl -Control $control -ExpectedStatus commit)) {
+            return New-WinsmuxSubmissionReceipt -Kind ([string]$Receipt.kind) -Status rejected -Backend ([string]$Receipt.backend) `
+                -SubmissionId ([string]$Receipt.submission_id) -ReasonCode 'runner_evidence_invalid' -Target $Receipt.target
+        }
+
+        $committed = New-WinsmuxSubmissionAcknowledgementEnvelope -Phase committed -Challenge $Challenge -Receipt $Receipt
+        Write-WinsmuxSubmissionPipeFrame -Stream $client -Json ($committed | ConvertTo-Json -Depth 14 -Compress)
+        $finalControl = Read-WinsmuxSubmissionPipeJson -Stream $client -TimeoutMilliseconds $TimeoutMilliseconds
+        if (Test-WinsmuxSubmissionAcknowledgementControl -Control $finalControl -ExpectedStatus verified) { return $Receipt }
+        return New-WinsmuxSubmissionReceipt -Kind ([string]$Receipt.kind) -Status rejected -Backend ([string]$Receipt.backend) `
+            -SubmissionId ([string]$Receipt.submission_id) -ReasonCode 'runner_evidence_invalid' -Target $Receipt.target
+    } finally {
+        $client.Dispose()
+    }
+}
+
+function New-WinsmuxSubmissionPipeCallerEvidence {
+    param(
+        [Parameter(Mandatory = $true)][int]$ClientProcessId,
+        [Parameter(Mandatory = $true)]$RuntimeResult
+    )
+
+    if (-not (Get-Command New-WinsmuxProcessSnapshotResolver -ErrorAction SilentlyContinue)) {
+        throw 'OS process ancestry resolver is unavailable'
+    }
+    $context = Get-WinsmuxSubmissionValue -InputObject $RuntimeResult -Name 'context' -Default $null
+    $generationId = [string](Get-WinsmuxSubmissionValue -InputObject $context -Name 'generation_id' -Default '')
+    $serverSessionId = [string](Get-WinsmuxSubmissionValue -InputObject $context -Name 'server_session_id' -Default '')
+    $slotId = [string](Get-WinsmuxSubmissionValue -InputObject $context -Name 'slot_id' -Default '')
+    $paneId = [string](Get-WinsmuxSubmissionValue -InputObject $context -Name 'pane_id' -Default '')
+    $backend = [string](Get-WinsmuxSubmissionValue -InputObject $context -Name 'backend' -Default '')
+    if ([string]::IsNullOrWhiteSpace($generationId) -or $serverSessionId -cnotmatch '^\$[0-9]+$' -or
+        -not (Test-WinsmuxSubmissionIdentifier -Value $slotId) -or [string]::IsNullOrWhiteSpace($paneId) -or
+        $backend -notin @('local', 'codex')) {
+        throw 'dispatch runtime context is incomplete for caller acknowledgement'
+    }
+
+    $resolver = New-WinsmuxProcessSnapshotResolver
+    $snapshot = & $resolver $ClientProcessId
+    $startedAt = [string](Get-WinsmuxSubmissionValue -InputObject $snapshot -Name 'StartTime' -Default '')
+    if ($null -eq $snapshot -or [int](Get-WinsmuxSubmissionValue -InputObject $snapshot -Name 'Id' -Default 0) -ne $ClientProcessId -or
+        [string]::IsNullOrWhiteSpace($startedAt)) {
+        throw 'acknowledgement pipe client process identity is unavailable'
+    }
+    return [PSCustomObject][ordered]@{
+        caller_identity = [PSCustomObject][ordered]@{
+            process_id         = $ClientProcessId
+            process_started_at = $startedAt
+            generation_id      = $generationId
+            server_session_id  = $serverSessionId
+            slot_id            = $slotId
+            pane_id            = $paneId
+            backend            = $backend
+        }
+        process_resolver = $resolver
+    }
+}
+
+function Test-WinsmuxSubmissionAcknowledgementMatchesRunRecord {
+    param(
+        [AllowNull()]$Acknowledgement,
+        [AllowNull()]$RunRecord
+    )
+
+    if ($null -eq $Acknowledgement -or $null -eq $RunRecord) { return $false }
+    $expected = ConvertTo-WinsmuxPublicAcknowledgement -Acknowledgement $RunRecord
+    $actual = ConvertTo-WinsmuxPublicAcknowledgement -Acknowledgement $Acknowledgement
+    return (($expected | ConvertTo-Json -Compress) -ceq ($actual | ConvertTo-Json -Compress))
 }
 
 function Invoke-WinsmuxSubmissionCliRun {
@@ -611,8 +1181,47 @@ function Invoke-WinsmuxSubmissionCliRun {
     if ($jsonLine.Count -lt 1) {
         return [ordered]@{ status = 'unavailable'; reason = 'cli_command_missing'; exit_code = if ($exitCode) { $exitCode } else { 1 } }
     }
-    try { return ($jsonLine[0] | ConvertFrom-Json -Depth 16) }
+    try { return ($jsonLine[0] | ConvertFrom-WinsmuxJson -Depth 16) }
     catch { return [ordered]@{ status = 'unavailable'; reason = 'cli_receipt_malformed'; exit_code = 1 } }
+}
+
+function Test-WinsmuxSubmissionRuntimeFreshness {
+    param(
+        [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [Parameter(Mandatory = $true)]$ManifestEntry,
+        [AllowEmptyString()][string]$ExpectedGenerationId = ''
+    )
+
+    try {
+        $result = Test-PaneControlRuntimeContext `
+            -ProjectDir $ProjectDir -ManifestEntry $ManifestEntry -Operation dispatch
+    } catch {
+        return New-WinsmuxRuntimeValidationResult -Valid $false `
+            -ReasonCode 'manifest_regeneration_required' `
+            -Diagnostic 'Runtime identity evidence is unavailable; regenerate the orchestra session.'
+    }
+    if (-not $result.valid) {
+        return $result
+    }
+    if ([string]::IsNullOrWhiteSpace($ExpectedGenerationId)) {
+        return New-WinsmuxRuntimeValidationResult -Valid $false `
+            -ReasonCode 'manifest_regeneration_required' `
+            -Diagnostic 'Captured runtime generation identity is missing; regenerate the orchestra session.'
+    }
+
+    $context = Get-WinsmuxSubmissionValue -InputObject $result -Name 'context' -Default $null
+    $actualGenerationId = [string](Get-WinsmuxSubmissionValue -InputObject $context -Name 'generation_id' -Default '')
+    if ([string]::IsNullOrWhiteSpace($actualGenerationId)) {
+        return New-WinsmuxRuntimeValidationResult -Valid $false `
+            -ReasonCode 'manifest_regeneration_required' `
+            -Diagnostic 'Fresh runtime generation identity is missing; regenerate the orchestra session.'
+    }
+    if (-not [string]::Equals($actualGenerationId, $ExpectedGenerationId, [System.StringComparison]::Ordinal)) {
+        return New-WinsmuxRuntimeValidationResult -Valid $false `
+            -ReasonCode 'invalid_supervisor_identity' `
+            -Diagnostic 'Runtime generation changed before submission packet publication.'
+    }
+    return $result
 }
 
 function Invoke-WinsmuxSubmissionAdapter {
@@ -646,16 +1255,37 @@ function Invoke-WinsmuxSubmissionAdapter {
         return New-WinsmuxSubmissionReceipt -Kind $Kind -Status rejected -Backend noop -SubmissionId $SubmissionId -ReasonCode 'target_identifier_invalid' -Target $target
     }
 
+    if (-not (Get-Command Test-PaneControlRuntimeContext -ErrorAction SilentlyContinue)) {
+        return New-WinsmuxSubmissionReceipt -Kind $Kind -Status unavailable -Backend $backend -SubmissionId $SubmissionId `
+            -ReasonCode 'manifest_regeneration_required' -Diagnostic 'Runtime identity validator is unavailable.' -Target $target
+    }
+    try {
+        $runtimeResult = Test-PaneControlRuntimeContext -ProjectDir $ProjectDir -ManifestEntry $ManifestEntry -Operation dispatch
+    } catch {
+        $runtimeResult = New-WinsmuxRuntimeValidationResult -Valid $false -ReasonCode 'manifest_regeneration_required' `
+            -Diagnostic 'Runtime identity evidence is unavailable; regenerate the orchestra session.'
+    }
+    if (-not $runtimeResult.valid) {
+        return New-WinsmuxSubmissionReceipt -Kind $Kind -Status unavailable -Backend $backend -SubmissionId $SubmissionId `
+            -ReasonCode ([string]$runtimeResult.reason_code) -Diagnostic ([string]$runtimeResult.diagnostic) -Target $target
+    }
+    $initialRuntimeContext = Get-WinsmuxSubmissionValue -InputObject $runtimeResult -Name 'context' -Default $null
+    $initialGenerationId = [string](Get-WinsmuxSubmissionValue -InputObject $initialRuntimeContext -Name 'generation_id' -Default '')
+
     $existingRunPath = Get-WinsmuxSubmissionRunPath -ProjectDir $ProjectDir -SlotId $label -RunId $SubmissionId
     if (Test-Path -LiteralPath $existingRunPath -PathType Leaf) {
         return New-WinsmuxSubmissionReceipt -Kind $Kind -Status rejected -Backend $backend -SubmissionId $SubmissionId -ReasonCode 'run_record_already_exists' -Target $target
     }
-    if ($backend -in @('local', 'codex')) {
-        return New-WinsmuxSubmissionReceipt -Kind $Kind -Status unavailable -Backend $backend -SubmissionId $SubmissionId -ReasonCode 'caller_identity_unavailable' -Target $target
-    }
     $packetPath = (Resolve-WinsmuxSubmissionPacketPath -ProjectDir $ProjectDir -SubmissionId $SubmissionId).FullPath
     if (Test-Path -LiteralPath $packetPath -PathType Leaf) {
         return New-WinsmuxSubmissionReceipt -Kind $Kind -Status rejected -Backend $backend -SubmissionId $SubmissionId -ReasonCode 'run_record_already_exists' -Target $target
+    }
+    $prePublicationRuntime = Test-WinsmuxSubmissionRuntimeFreshness `
+        -ProjectDir $ProjectDir -ManifestEntry $ManifestEntry -ExpectedGenerationId $initialGenerationId
+    if (-not $prePublicationRuntime.valid) {
+        return New-WinsmuxSubmissionReceipt -Kind $Kind -Status unavailable -Backend $backend -SubmissionId $SubmissionId `
+            -ReasonCode ([string]$prePublicationRuntime.reason_code) `
+            -Diagnostic ([string]$prePublicationRuntime.diagnostic) -Target $target
     }
     try {
         $packet = New-WinsmuxSubmissionPacket -ProjectDir $ProjectDir -Kind $Kind -Content $Content -SubmissionId $SubmissionId -TargetLabel $label -TaskId $TaskId
@@ -665,14 +1295,191 @@ function Invoke-WinsmuxSubmissionAdapter {
         }
         throw
     }
-    if ($backend -eq 'api_llm') {
+    $runtimeResult = Test-WinsmuxSubmissionRuntimeFreshness `
+        -ProjectDir $ProjectDir -ManifestEntry $ManifestEntry -ExpectedGenerationId $initialGenerationId
+    if (-not $runtimeResult.valid) {
+        Remove-Item -LiteralPath ([string]$packet.FullPath) -Force -ErrorAction SilentlyContinue
+        return New-WinsmuxSubmissionReceipt -Kind $Kind -Status unavailable -Backend $backend -SubmissionId $SubmissionId `
+            -ReasonCode ([string]$runtimeResult.reason_code) -Diagnostic ([string]$runtimeResult.diagnostic) -Target $target
+    }
+    $runtimeContext = Get-WinsmuxSubmissionValue -InputObject $runtimeResult -Name 'context' -Default $null
+    $capturedGenerationId = [string](Get-WinsmuxSubmissionValue -InputObject $runtimeContext -Name 'generation_id' -Default '')
+    if ($backend -in @('local', 'codex', 'api_llm') -and $null -eq $SendAction -and
+        [string]::IsNullOrWhiteSpace($capturedGenerationId)) {
+        Remove-Item -LiteralPath ([string]$packet.FullPath) -Force -ErrorAction SilentlyContinue
+        return New-WinsmuxSubmissionReceipt -Kind $Kind -Status unavailable -Backend $backend -SubmissionId $SubmissionId `
+            -ReasonCode 'manifest_regeneration_required' `
+            -Diagnostic 'Runtime generation identity is missing; regenerate the orchestra session.' -Target $target
+    }
+    if ($backend -in @('local', 'codex')) {
+        if ([string]::IsNullOrWhiteSpace($paneId)) {
+            Remove-Item -LiteralPath ([string]$packet.FullPath) -Force -ErrorAction SilentlyContinue
+            return New-WinsmuxSubmissionReceipt -Kind $Kind -Status unavailable -Backend $backend -SubmissionId $SubmissionId -ReasonCode 'pane_unavailable' -Target $target
+        }
+        $ackServer = $null
+        $acknowledgementVerified = $false
+        $submissionAccepted = $false
+        $adapterCreatedRunPath = ''
+        $durableCommitValidated = $false
+        $deliveryState = [ordered]@{ SubmissionCommitted = $false }
+        try {
+            try {
+                $ackServer = New-WinsmuxSubmissionAcknowledgementServer
+            } catch {
+                return New-WinsmuxSubmissionReceipt -Kind $Kind -Status rejected -Backend $backend -SubmissionId $SubmissionId `
+                    -ReasonCode 'backend_acknowledgement_missing' -Target $target
+            }
+            $ackCommand = "winsmux submission-ack --submission-id $SubmissionId --run-id $SubmissionId --kind $Kind --backend $backend --slot $label --ack-pipe $($ackServer.pipe_name) --challenge $($ackServer.challenge)"
+            $packetInstruction = "Read and execute the typed submission packet at '$($packet.RelativePath)'. After accepting that exact packet from this pane, run: $ackCommand"
+            try {
+                if ($null -ne $SendAction) {
+                    & $SendAction $paneId $packetInstruction | Out-Null
+                    $deliveryState['SubmissionCommitted'] = $true
+                }
+                else {
+                    Send-TextToPane -PaneId $paneId -CommandText $packetInstruction `
+                        -RuntimeProjectDir $ProjectDir -RuntimeOperation dispatch `
+                        -ExpectedGenerationId $capturedGenerationId -DeliveryState $deliveryState | Out-Null
+                }
+            } catch {
+                return New-WinsmuxSubmissionReceipt -Kind $Kind -Status unavailable -Backend $backend -SubmissionId $SubmissionId -ReasonCode 'packet_repl_unavailable' -Diagnostic $_.Exception.Message -Target $target
+            }
+
+            try {
+                $pipeAcknowledgement = Receive-WinsmuxSubmissionAcknowledgement -ServerState $ackServer
+                $callerEvidence = New-WinsmuxSubmissionPipeCallerEvidence `
+                    -ClientProcessId ([int]$pipeAcknowledgement.client_process_id) -RuntimeResult $runtimeResult
+            } catch {
+                return New-WinsmuxSubmissionReceipt -Kind $Kind -Status rejected -Backend $backend -SubmissionId $SubmissionId `
+                    -ReasonCode 'backend_acknowledgement_missing' -Target $target
+            }
+
+            try {
+                $callerRuntimeResult = Test-PaneControlRuntimeContext -ProjectDir $ProjectDir -ManifestEntry $ManifestEntry `
+                    -Operation caller_ack -CallerIdentity $callerEvidence.caller_identity -ProcessResolver $callerEvidence.process_resolver
+            } catch {
+                $callerRuntimeResult = New-WinsmuxRuntimeValidationResult -Valid $false -ReasonCode 'caller_identity_mismatch' `
+                    -Diagnostic 'Acknowledgement caller identity could not be verified.'
+            }
+            if (-not $callerRuntimeResult.valid) {
+                return New-WinsmuxSubmissionReceipt -Kind $Kind -Status unavailable -Backend $backend -SubmissionId $SubmissionId `
+                    -ReasonCode ([string]$callerRuntimeResult.reason_code) -Diagnostic ([string]$callerRuntimeResult.diagnostic) -Target $target
+            }
+
+            if (-not (Test-WinsmuxSubmissionAcknowledgementEnvelope -Envelope $pipeAcknowledgement.payload `
+                    -ExpectedPhase candidate -ExpectedChallenge ([string]$ackServer.challenge) `
+                    -SubmissionId $SubmissionId -Kind $Kind -Backend $backend -SlotId $label)) {
+                return New-WinsmuxSubmissionReceipt -Kind $Kind -Status rejected -Backend $backend -SubmissionId $SubmissionId `
+                    -ReasonCode 'runner_evidence_invalid' -Target $target
+            }
+            $candidateReceipt = Get-WinsmuxSubmissionRawValue -InputObject $pipeAcknowledgement.payload -Name 'receipt' -Default $null
+            if ([string](Get-WinsmuxSubmissionValue -InputObject $candidateReceipt -Name 'status' -Default '') -cne 'accepted') {
+                $acknowledgementVerified = $true
+                return $candidateReceipt
+            }
+            $canonicalRunRecord = New-WinsmuxSubmissionRunRecord -SubmissionId $SubmissionId -RunId $SubmissionId `
+                -TaskId ([string]$packet.Packet.task_id) -Kind $Kind -TaskTitle ([string]$packet.Packet.title) `
+                -SlotId $label -Backend $backend -Status started -RequestConsumed `
+                -RequestDigest ([string]$packet.Packet.request_digest)
+            if (-not (Test-WinsmuxSubmissionAcknowledgementMatchesRunRecord `
+                    -Acknowledgement (Get-WinsmuxSubmissionRawValue -InputObject $candidateReceipt -Name 'acknowledgement' -Default $null) `
+                    -RunRecord $canonicalRunRecord)) {
+                return New-WinsmuxSubmissionReceipt -Kind $Kind -Status rejected -Backend $backend -SubmissionId $SubmissionId `
+                    -ReasonCode 'runner_evidence_invalid' -Target $target
+            }
+
+            Write-WinsmuxSubmissionAcknowledgementControl -ServerState $ackServer -Status commit
+            $committedAcknowledgement = Receive-WinsmuxSubmissionAcknowledgement -ServerState $ackServer
+            if ([int]$committedAcknowledgement.client_process_id -ne [int]$pipeAcknowledgement.client_process_id) {
+                return New-WinsmuxSubmissionReceipt -Kind $Kind -Status unavailable -Backend $backend -SubmissionId $SubmissionId `
+                    -ReasonCode 'caller_identity_mismatch' -Target $target
+            }
+            if (-not (Test-WinsmuxSubmissionAcknowledgementEnvelope -Envelope $committedAcknowledgement.payload `
+                    -ExpectedPhase committed -ExpectedChallenge ([string]$ackServer.challenge) `
+                    -SubmissionId $SubmissionId -Kind $Kind -Backend $backend -SlotId $label)) {
+                return New-WinsmuxSubmissionReceipt -Kind $Kind -Status rejected -Backend $backend -SubmissionId $SubmissionId `
+                    -ReasonCode 'runner_evidence_invalid' -Target $target
+            }
+            try {
+                $freshCallerEvidence = New-WinsmuxSubmissionPipeCallerEvidence `
+                    -ClientProcessId ([int]$committedAcknowledgement.client_process_id) -RuntimeResult $runtimeResult
+                $freshCallerResult = Test-PaneControlRuntimeContext -ProjectDir $ProjectDir -ManifestEntry $ManifestEntry `
+                    -Operation caller_ack -CallerIdentity $freshCallerEvidence.caller_identity `
+                    -ProcessResolver $freshCallerEvidence.process_resolver
+            } catch {
+                $freshCallerResult = New-WinsmuxRuntimeValidationResult -Valid $false -ReasonCode 'caller_identity_mismatch' `
+                    -Diagnostic 'Committed acknowledgement caller identity could not be revalidated.'
+            }
+            if (-not $freshCallerResult.valid) {
+                return New-WinsmuxSubmissionReceipt -Kind $Kind -Status unavailable -Backend $backend -SubmissionId $SubmissionId `
+                    -ReasonCode ([string]$freshCallerResult.reason_code) -Diagnostic ([string]$freshCallerResult.diagnostic) -Target $target
+            }
+            $committedReceipt = Get-WinsmuxSubmissionRawValue -InputObject $committedAcknowledgement.payload -Name 'receipt' -Default $null
+            if (-not (Test-WinsmuxSubmissionAcknowledgementMatchesRunRecord `
+                    -Acknowledgement (Get-WinsmuxSubmissionRawValue -InputObject $committedReceipt -Name 'acknowledgement' -Default $null) `
+                    -RunRecord $canonicalRunRecord)) {
+                return New-WinsmuxSubmissionReceipt -Kind $Kind -Status rejected -Backend $backend -SubmissionId $SubmissionId `
+                    -ReasonCode 'runner_evidence_invalid' -Target $target
+            }
+
+            try {
+                $adapterCreatedRunPath = Write-WinsmuxSubmissionRunRecord -ProjectDir $ProjectDir -SlotId $label -Record $canonicalRunRecord
+            } catch {
+                $reasonCode = if (Test-Path -LiteralPath $existingRunPath -PathType Leaf) {
+                    'run_record_already_exists'
+                } else {
+                    'runner_evidence_invalid'
+                }
+                return New-WinsmuxSubmissionReceipt -Kind $Kind -Status rejected -Backend $backend -SubmissionId $SubmissionId `
+                    -ReasonCode $reasonCode -Target $target
+            }
+            try { $runner = Get-Content -LiteralPath $adapterCreatedRunPath -Raw -Encoding UTF8 | ConvertFrom-WinsmuxJson -Depth 16 }
+            catch {
+                return New-WinsmuxSubmissionReceipt -Kind $Kind -Status rejected -Backend $backend -SubmissionId $SubmissionId `
+                    -ReasonCode 'runner_receipt_malformed' -Target $target
+            }
+            if ((Test-WinsmuxSubmissionRunRecord -Record $runner -SubmissionId $SubmissionId -Kind $Kind -Backend $backend `
+                    -ExpectedSlotId $label -ExpectedRequestDigest ([string]$packet.Packet.request_digest) `
+                    -ExpectedTaskId ([string]$packet.Packet.task_id)) -and
+                (Test-WinsmuxSubmissionAcknowledgementMatchesRunRecord `
+                    -Acknowledgement (Get-WinsmuxSubmissionRawValue -InputObject $committedReceipt -Name 'acknowledgement' -Default $null) `
+                    -RunRecord $runner)) {
+                $durableCommitValidated = $true
+                $acknowledgementVerified = $true
+                $submissionAccepted = $true
+                return New-WinsmuxSubmissionReceipt -Kind $Kind -Status accepted -Backend $backend -SubmissionId $SubmissionId -Target $target -Acknowledgement $runner
+            }
+            return New-WinsmuxSubmissionReceipt -Kind $Kind -Status rejected -Backend $backend -SubmissionId $SubmissionId `
+                -ReasonCode 'runner_evidence_invalid' -Target $target
+        } catch {
+            return New-WinsmuxSubmissionReceipt -Kind $Kind -Status rejected -Backend $backend -SubmissionId $SubmissionId `
+                -ReasonCode 'runner_evidence_invalid' -Target $target
+        } finally {
+            if ($null -ne $ackServer) {
+                Complete-WinsmuxSubmissionAcknowledgement -ServerState $ackServer -Verified $acknowledgementVerified | Out-Null
+            }
+            if (-not $submissionAccepted) {
+                if (-not $durableCommitValidated -and -not [string]::IsNullOrWhiteSpace($adapterCreatedRunPath) -and
+                    (Test-Path -LiteralPath $adapterCreatedRunPath -PathType Leaf)) {
+                    Remove-Item -LiteralPath $adapterCreatedRunPath -Force -ErrorAction SilentlyContinue
+                }
+                if (-not [bool]$deliveryState['SubmissionCommitted']) {
+                    Remove-Item -LiteralPath ([string]$packet.FullPath) -Force -ErrorAction SilentlyContinue
+                }
+            }
+        }
+    } elseif ($backend -eq 'api_llm') {
         if ([string]::IsNullOrWhiteSpace($paneId)) {
             return New-WinsmuxSubmissionReceipt -Kind $Kind -Status unavailable -Backend $backend -SubmissionId $SubmissionId -ReasonCode 'pane_unavailable' -Target $target
         }
         $execCommand = "exec $($packet.RelativePath)"
         try {
             if ($null -ne $SendAction) { & $SendAction $paneId $execCommand | Out-Null }
-            else { Send-TextToPane -PaneId $paneId -CommandText $execCommand | Out-Null }
+            else {
+                Send-TextToPane -PaneId $paneId -CommandText $execCommand `
+                    -RuntimeProjectDir $ProjectDir -RuntimeOperation dispatch `
+                    -ExpectedGenerationId $capturedGenerationId | Out-Null
+            }
         } catch {
             return New-WinsmuxSubmissionReceipt -Kind $Kind -Status unavailable -Backend $backend -SubmissionId $SubmissionId -ReasonCode 'packet_repl_unavailable' -Diagnostic $_.Exception.Message -Target $target
         }

--- a/winsmux-core/scripts/vault.ps1
+++ b/winsmux-core/scripts/vault.ps1
@@ -20,13 +20,19 @@ if (-not (Get-Command Invoke-WinsmuxBridgeCommand -ErrorAction SilentlyContinue)
     }
 }
 
-if (-not ('WinCred' -as [type])) {
+$credentialMetadataScript = Join-Path $PSScriptRoot 'credential-metadata.ps1'
+if (-not (Get-Command Get-WinsmuxCredentialTargetNames -ErrorAction SilentlyContinue) -and
+    (Test-Path -LiteralPath $credentialMetadataScript -PathType Leaf)) {
+    . $credentialMetadataScript
+}
+
+if (-not ('WinsmuxVaultCredentialNative' -as [type])) {
     # --- Windows Credential Manager P/Invoke ---
     Add-Type -TypeDefinition @'
 using System;
 using System.Runtime.InteropServices;
 
-public class WinCred {
+public class WinsmuxVaultCredentialNative {
     [DllImport("advapi32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
     public static extern bool CredWrite(ref CREDENTIAL credential, uint flags);
 
@@ -35,9 +41,6 @@ public class WinCred {
 
     [DllImport("advapi32.dll", SetLastError = true)]
     public static extern bool CredFree(IntPtr credential);
-
-    [DllImport("advapi32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
-    public static extern bool CredEnumerate(string filter, uint flags, out int count, out IntPtr credentials);
 
     [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
     public struct CREDENTIAL {
@@ -85,16 +88,16 @@ function Invoke-VaultSet {
     $blobPtr = [Runtime.InteropServices.Marshal]::AllocHGlobal($valueBytes.Length)
     [Runtime.InteropServices.Marshal]::Copy($valueBytes, 0, $blobPtr, $valueBytes.Length)
 
-    $cred = New-Object WinCred+CREDENTIAL
-    $cred.Type = [WinCred]::CRED_TYPE_GENERIC
+    $cred = New-Object WinsmuxVaultCredentialNative+CREDENTIAL
+    $cred.Type = [WinsmuxVaultCredentialNative]::CRED_TYPE_GENERIC
     $cred.TargetName = $credTarget
     $cred.UserName = "winsmux"
     $cred.CredentialBlobSize = $valueBytes.Length
     $cred.CredentialBlob = $blobPtr
-    $cred.Persist = [WinCred]::CRED_PERSIST_LOCAL_MACHINE
+    $cred.Persist = [WinsmuxVaultCredentialNative]::CRED_PERSIST_LOCAL_MACHINE
 
     try {
-        $ok = [WinCred]::CredWrite([ref]$cred, 0)
+        $ok = [WinsmuxVaultCredentialNative]::CredWrite([ref]$cred, 0)
         if (-not $ok) {
             $errCode = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
             Stop-WithError "CredWrite failed (error $errCode)"
@@ -112,7 +115,7 @@ function Invoke-VaultGet {
     $credTarget = "winsmux:$key"
     $credPtr = [IntPtr]::Zero
 
-    $ok = [WinCred]::CredRead($credTarget, [WinCred]::CRED_TYPE_GENERIC, 0, [ref]$credPtr)
+    $ok = [WinsmuxVaultCredentialNative]::CredRead($credTarget, [WinsmuxVaultCredentialNative]::CRED_TYPE_GENERIC, 0, [ref]$credPtr)
     if (-not $ok) {
         $errCode = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
         if ($errCode -eq 1168) {
@@ -122,7 +125,7 @@ function Invoke-VaultGet {
     }
 
     try {
-        $cred = [Runtime.InteropServices.Marshal]::PtrToStructure($credPtr, [Type][WinCred+CREDENTIAL])
+        $cred = [Runtime.InteropServices.Marshal]::PtrToStructure($credPtr, [Type][WinsmuxVaultCredentialNative+CREDENTIAL])
         if ($cred.CredentialBlobSize -gt 0) {
             $bytes = New-Object byte[] $cred.CredentialBlobSize
             [Runtime.InteropServices.Marshal]::Copy($cred.CredentialBlob, $bytes, 0, $cred.CredentialBlobSize)
@@ -130,35 +133,42 @@ function Invoke-VaultGet {
             Write-Output $value
         }
     } finally {
-        [WinCred]::CredFree($credPtr) | Out-Null
+        [WinsmuxVaultCredentialNative]::CredFree($credPtr) | Out-Null
     }
 }
 
 function Invoke-VaultList {
-    $filter = "winsmux:*"
-    $count = 0
-    $credsPtr = [IntPtr]::Zero
+    $names = @(Get-WinsmuxCredentialTargetNames)
+    if ($names.Count -eq 0) {
+        Write-Output "(no credentials stored)"
+        return
+    }
+    Write-Output $names
+}
 
-    $ok = [WinCred]::CredEnumerate($filter, 0, [ref]$count, [ref]$credsPtr)
+function Get-WinsmuxVaultCredentialValue {
+    param([Parameter(Mandatory = $true)][string]$Name)
+
+    $credPtr = [IntPtr]::Zero
+    $ok = [WinsmuxVaultCredentialNative]::CredRead("winsmux:$Name", [WinsmuxVaultCredentialNative]::CRED_TYPE_GENERIC, 0, [ref]$credPtr)
     if (-not $ok) {
         $errCode = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
         if ($errCode -eq 1168) {
-            Write-Output "(no credentials stored)"
-            return
+            Stop-WithError 'credential no longer exists'
         }
-        Stop-WithError "CredEnumerate failed (error $errCode)"
+        Stop-WithError "CredRead failed (error $errCode)"
     }
 
     try {
-        $ptrSize = [Runtime.InteropServices.Marshal]::SizeOf([Type][IntPtr])
-        for ($i = 0; $i -lt $count; $i++) {
-            $entryPtr = [Runtime.InteropServices.Marshal]::ReadIntPtr($credsPtr, $i * $ptrSize)
-            $cred = [Runtime.InteropServices.Marshal]::PtrToStructure($entryPtr, [Type][WinCred+CREDENTIAL])
-            $name = $cred.TargetName -replace '^winsmux:', ''
-            Write-Output $name
+        $cred = [Runtime.InteropServices.Marshal]::PtrToStructure($credPtr, [Type][WinsmuxVaultCredentialNative+CREDENTIAL])
+        if ($cred.CredentialBlobSize -le 0) {
+            return ''
         }
+        $bytes = New-Object byte[] $cred.CredentialBlobSize
+        [Runtime.InteropServices.Marshal]::Copy($cred.CredentialBlob, $bytes, 0, $cred.CredentialBlobSize)
+        return [System.Text.Encoding]::Unicode.GetString($bytes)
     } finally {
-        [WinCred]::CredFree($credsPtr) | Out-Null
+        [WinsmuxVaultCredentialNative]::CredFree($credPtr) | Out-Null
     }
 }
 
@@ -227,68 +237,57 @@ function Invoke-VaultInject {
 
     $paneId = Resolve-Target $Target
     $paneId = Confirm-Target $paneId
+    $projectDir = (Get-Location).Path
+    $initialRuntime = Assert-WinsmuxTargetRuntimeWriteAllowed `
+        -PaneId $paneId -CurrentProjectDir $projectDir -Operation dispatch
     Assert-ReadMark $paneId
     try {
-        # Enumerate all winsmux:* credentials
-        $filter = "winsmux:*"
-        $count = 0
-        $credsPtr = [IntPtr]::Zero
-
-        $ok = [WinCred]::CredEnumerate($filter, 0, [ref]$count, [ref]$credsPtr)
-        if (-not $ok) {
-            $errCode = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
-            if ($errCode -eq 1168) {
-                Write-Output "no credentials to inject"
-                return
-            }
-            Stop-WithError "CredEnumerate failed (error $errCode)"
-        }
-
-        $entries = [System.Collections.Generic.List[object]]::new()
-        try {
-            $ptrSize = [Runtime.InteropServices.Marshal]::SizeOf([Type][IntPtr])
-            for ($i = 0; $i -lt $count; $i++) {
-                $entryPtr = [Runtime.InteropServices.Marshal]::ReadIntPtr($credsPtr, $i * $ptrSize)
-                $cred = [Runtime.InteropServices.Marshal]::PtrToStructure($entryPtr, [Type][WinCred+CREDENTIAL])
-                $envName = $cred.TargetName -replace '^winsmux:', ''
-
-                $value = ''
-                if ($cred.CredentialBlobSize -gt 0) {
-                    $bytes = New-Object byte[] $cred.CredentialBlobSize
-                    [Runtime.InteropServices.Marshal]::Copy($cred.CredentialBlob, $bytes, 0, $cred.CredentialBlobSize)
-                    $value = [System.Text.Encoding]::Unicode.GetString($bytes)
-                }
-
-                $entries.Add([PSCustomObject]@{
-                    Name  = $envName
-                    Value = $value
-                }) | Out-Null
-            }
-        } finally {
-            [WinCred]::CredFree($credsPtr) | Out-Null
+        $credentialNames = @(Get-WinsmuxCredentialTargetNames)
+        if ($credentialNames.Count -eq 0) {
+            Write-Output "no credentials to inject"
+            return
         }
 
         $sessionName = Get-WinsmuxSessionNameForPane -PaneId $paneId
-        $commands = foreach ($entry in $entries) {
-            'set-environment -t {0} {1} {2}' -f `
-                (ConvertTo-WinsmuxConfigString -Value $sessionName), `
-                (ConvertTo-WinsmuxConfigString -Value $entry.Name), `
-                (ConvertTo-WinsmuxConfigString -Value $entry.Value)
-        }
-
-        $sourceResult = Invoke-WinsmuxSourceFile -Commands $commands
-        if (-not $sourceResult.Success) {
-            # source-file keeps secrets out of argv; direct set-environment remains a last-resort fallback.
-            foreach ($entry in $entries) {
-                $setResult = Invoke-WinsmuxCommand -Arguments @('set-environment', '-t', $sessionName, $entry.Name, $entry.Value)
-                if (-not $setResult.Success) {
-                    Stop-WithError "winsmux set-environment failed while injecting credentials into $paneId."
+        $injected = 0
+        foreach ($envName in $credentialNames) {
+            Assert-WinsmuxTargetRuntimeWriteAllowed `
+                -PaneId $paneId -CurrentProjectDir $projectDir -Operation dispatch `
+                -ExpectedGenerationId ([string]$initialRuntime.GenerationId) | Out-Null
+            $value = [string](Get-WinsmuxVaultCredentialValue -Name ([string]$envName))
+            try {
+                $command = 'set-environment -t {0} {1} {2}' -f `
+                    (ConvertTo-WinsmuxConfigString -Value $sessionName), `
+                    (ConvertTo-WinsmuxConfigString -Value ([string]$envName)), `
+                    (ConvertTo-WinsmuxConfigString -Value $value)
+                Assert-WinsmuxTargetRuntimeWriteAllowed `
+                    -PaneId $paneId -CurrentProjectDir $projectDir -Operation dispatch `
+                    -ExpectedGenerationId ([string]$initialRuntime.GenerationId) | Out-Null
+                $sourceResult = Invoke-WinsmuxSourceFile -Commands @($command)
+                if (-not $sourceResult.Success) {
+                    # source-file keeps secrets out of argv; direct set-environment remains a last-resort fallback.
+                    Assert-WinsmuxTargetRuntimeWriteAllowed `
+                        -PaneId $paneId -CurrentProjectDir $projectDir -Operation dispatch `
+                        -ExpectedGenerationId ([string]$initialRuntime.GenerationId) | Out-Null
+                    $setResult = Invoke-WinsmuxCommand -Arguments @('set-environment', '-t', $sessionName, $envName, $value)
+                    if (-not $setResult.Success) {
+                        Stop-WithError "winsmux set-environment failed while injecting credentials into $paneId."
+                    }
                 }
+                $injected++
+            } finally {
+                $value = $null
+                $command = $null
+                $sourceResult = $null
+                $setResult = $null
             }
         }
 
-        Write-Output "injected $($entries.Count) credential(s) into $paneId"
+        Write-Output "injected $injected credential(s) into $paneId"
     } finally {
+        Assert-WinsmuxTargetRuntimeWriteAllowed `
+            -PaneId $paneId -CurrentProjectDir $projectDir -Operation dispatch `
+            -ExpectedGenerationId ([string]$initialRuntime.GenerationId) | Out-Null
         Clear-ReadMark $paneId
     }
 }


### PR DESCRIPTION
## Summary

- bind managed worker reads and mutations to a versioned manifest generation and live supervisor identity
- reject stale, ambiguous, or mismatched runtime state across dispatch, lifecycle, polling, and desktop-facing status paths
- preserve typed submission receipts while validating caller ancestry and durable backend acknowledgement
- isolate Windows credential and JSON compatibility surfaces across fresh PowerShell processes

## Why

A manifest that outlives its supervisor must not remain authoritative, and successful keystroke delivery must not be reported as accepted work. This change makes the active runtime generation the shared authority across the PowerShell and Rust surfaces.

## Verification

- Pester: 1,288 passed; 0 failed, skipped, or not run
- Rust workspace/all-target checks and tests passed, including `operator_cli` 141/141
- release build passed
- isolated six-worker runtime smoke verified 6/6 workers and rejected stale runtime paths
- PowerShell 7 and Windows PowerShell 5.1 parsing passed
- public-surface audit, staged/full git guard, history secret scan, and `git diff --check` passed
- two independent read-only reviews passed on the final Git tree

Closes #1109
Closes #1189
