### PR TITLE
feat(review): bind approvals to live reviewer identity

### DIFF
--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -1494,6 +1494,75 @@ function Save-ReviewState {
     Write-ClmSafeTextFile -Path $path -Content ($State | ConvertTo-Json -Depth 5)
 }
 
+function Invoke-WithReviewStateLock {
+    param(
+        [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [Parameter(Mandatory = $true)][scriptblock]$Action,
+        [ValidateRange(1, 30)][int]$TimeoutSeconds = 5
+    )
+
+    $statePath = Get-ReviewStatePath -ProjectDir $ProjectDir
+    $stateDir = Split-Path $statePath -Parent
+    if (-not (Test-Path -LiteralPath $stateDir)) {
+        New-Item -ItemType Directory -Path $stateDir -Force | Out-Null
+    }
+    $lockPath = $statePath + '.lock'
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    $stream = $null
+    do {
+        try {
+            $stream = [IO.File]::Open($lockPath, [IO.FileMode]::OpenOrCreate, [IO.FileAccess]::ReadWrite, [IO.FileShare]::None)
+        } catch [IO.IOException] {
+            if ((Get-Date) -ge $deadline) {
+                Stop-WithError "timed out waiting for review-state lock: $lockPath"
+            }
+            Start-Sleep -Milliseconds 50
+        }
+    } while ($null -eq $stream)
+
+    try {
+        return & $Action
+    } finally {
+        if ($null -ne $stream) {
+            $stream.Dispose()
+        }
+    }
+}
+
+function Get-ReviewStateEntryFingerprint {
+    param([AllowNull()]$Entry)
+
+    if ($null -eq $Entry) {
+        return '<absent>'
+    }
+    return ($Entry | ConvertTo-Json -Compress -Depth 12)
+}
+
+function Save-VerifiedReviewStateTransition {
+    param(
+        [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [Parameter(Mandatory = $true)][string]$Branch,
+        [Parameter(Mandatory = $true)][string]$HeadSha,
+        [Parameter(Mandatory = $true)]$Context,
+        [Parameter(Mandatory = $true)][string]$ExpectedEntryFingerprint,
+        [Parameter(Mandatory = $true)][System.Collections.Specialized.OrderedDictionary]$NewRecord
+    )
+
+    return Invoke-WithReviewStateLock -ProjectDir $ProjectDir -Action {
+        $lockedState = Get-ReviewState -ProjectDir $ProjectDir
+        $lockedEntry = if ($lockedState.Contains($Branch)) { $lockedState[$Branch] } else { $null }
+        $lockedFingerprint = Get-ReviewStateEntryFingerprint -Entry $lockedEntry
+        if (-not [string]::Equals($lockedFingerprint, $ExpectedEntryFingerprint, [System.StringComparison]::Ordinal)) {
+            Stop-WithError "review state changed concurrently for $Branch; retry from the current state"
+        }
+
+        $freshContext = Confirm-ReviewWriteContext -Context $Context -ProjectDir $ProjectDir -Branch $Branch -HeadSha $HeadSha
+        $lockedState[$Branch] = $NewRecord
+        Save-ReviewState -ProjectDir $ProjectDir -State $lockedState
+        return $freshContext
+    }
+}
+
 function Assert-WinsmuxRolePermission {
     param(
         [Parameter(Mandatory = $true)][string]$CommandName,
@@ -1518,25 +1587,69 @@ function Get-CurrentReviewPaneManifestContext {
     }
 
     try {
-        $context = Get-PaneControlManifestContext -ProjectDir $ProjectDir -PaneId $env:WINSMUX_PANE_ID
+        return Get-PaneControlVerifiedReviewIdentity -ProjectDir $ProjectDir -PaneId $env:WINSMUX_PANE_ID
+    } catch {
+        Stop-WithError $_.Exception.Message
+    }
+}
+
+function Confirm-ReviewWriteContext {
+    param(
+        [Parameter(Mandatory = $true)]$Context,
+        [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [Parameter(Mandatory = $true)][string]$Branch,
+        [Parameter(Mandatory = $true)][string]$HeadSha
+    )
+
+    try {
+        $fresh = Get-PaneControlVerifiedReviewIdentity -ProjectDir $ProjectDir -PaneId ([string]$Context.PaneId) `
+            -ExpectedGenerationId ([string]$Context.GenerationId)
     } catch {
         Stop-WithError $_.Exception.Message
     }
 
-    if ([string]$context.Role -notin @('Reviewer', 'Worker')) {
-        Stop-WithError "pane $($env:WINSMUX_PANE_ID) is not registered as a review-capable pane in .winsmux/manifest.yaml"
+    foreach ($propertyName in @('GenerationId', 'ServerSessionId', 'SlotId', 'PaneId', 'Role', 'AgentName', 'Backend')) {
+        if (-not [string]::Equals([string]$fresh.$propertyName, [string]$Context.$propertyName, [System.StringComparison]::Ordinal)) {
+            Stop-WithError "review identity changed before the review-state write: $propertyName"
+        }
     }
 
-    return [ordered]@{
-        ManifestPath        = [string]$context.ManifestPath
-        GenerationId        = [string]$context.GenerationId
-        ProjectDir          = [string]$context.ProjectDir
-        Label               = [string]$context.Label
-        PaneId              = [string]$context.PaneId
-        Role                = [string]$context.Role
-        LaunchDir           = [string]$context.LaunchDir
-        BuilderWorktreePath = [string]$context.BuilderWorktreePath
-        GitWorktreeDir      = [string]$context.GitWorktreeDir
+    $freshBranch = Get-CurrentGitBranch -ProjectDir $ProjectDir
+    $freshHeadSha = Get-CurrentGitHead -ProjectDir $ProjectDir
+    if (-not [string]::Equals($freshBranch, $Branch, [System.StringComparison]::Ordinal)) {
+        Stop-WithError "review branch changed before the review-state write: expected $Branch, got $freshBranch"
+    }
+    if (-not [string]::Equals($freshHeadSha, $HeadSha, [System.StringComparison]::Ordinal)) {
+        Stop-WithError "review HEAD changed before the review-state write: expected $HeadSha, got $freshHeadSha"
+    }
+
+    return $fresh
+}
+
+function Assert-ReviewRequestIdentityBinding {
+    param(
+        [Parameter(Mandatory = $true)]$Request,
+        [Parameter(Mandatory = $true)]$Context,
+        [Parameter(Mandatory = $true)][string]$Branch
+    )
+
+    $bindings = [ordered]@{
+        generation_id    = [string]$Context.GenerationId
+        server_session_id = [string]$Context.ServerSessionId
+        slot_id          = [string]$Context.SlotId
+        pane_id          = [string]$Context.PaneId
+        role             = [string]$Context.Role
+        backend          = [string]$Context.Backend
+        agent_name       = [string]$Context.AgentName
+    }
+    foreach ($name in $bindings.Keys) {
+        $requestedValue = [string](Get-ReviewRequestTargetValue -Request $Request -Name $name)
+        if ([string]::IsNullOrWhiteSpace($requestedValue)) {
+            Stop-WithError "pending review request for $Branch is missing runtime identity '$name'. Re-run: winsmux review-request"
+        }
+        if (-not [string]::Equals($requestedValue, [string]$bindings[$name], [System.StringComparison]::Ordinal)) {
+            Stop-WithError "pending review request identity mismatch for ${name}: expected $requestedValue, got $($bindings[$name])"
+        }
     }
 }
 
@@ -17271,9 +17384,14 @@ function Invoke-ReviewRequest {
         id                      = New-ReviewRequestId
         branch                  = $branch
         head_sha                = $headSha
+        target_review_generation_id = $context.GenerationId
+        target_review_server_session_id = $context.ServerSessionId
+        target_review_slot_id   = $context.SlotId
         target_review_pane_id   = $context.PaneId
         target_review_label     = $context.Label
         target_review_role      = $context.Role
+        target_review_backend   = $context.Backend
+        target_review_agent_name = $context.AgentName
         target_reviewer_pane_id = $context.PaneId
         target_reviewer_label   = $context.Label
         target_reviewer_role    = $context.Role
@@ -17282,14 +17400,21 @@ function Invoke-ReviewRequest {
     }
 
     $reviewer = [ordered]@{
-        pane_id    = $context.PaneId
-        label      = $context.Label
-        role       = $context.Role
-        agent_name = [string]$env:WINSMUX_AGENT_NAME
+        generation_id    = $context.GenerationId
+        server_session_id = $context.ServerSessionId
+        slot_id          = $context.SlotId
+        pane_id          = $context.PaneId
+        label            = $context.Label
+        role             = $context.Role
+        backend          = $context.Backend
+        agent_name       = $context.AgentName
     }
 
-    $state[$branch] = New-ReviewerStateRecord -Status 'PENDING' -Request $request -Reviewer $reviewer -Evidence $null -UpdatedAt $timestamp
-    Save-ReviewState -ProjectDir $projectDir -State $state
+    $previousEntry = if ($state.Contains($branch)) { $state[$branch] } else { $null }
+    $expectedFingerprint = Get-ReviewStateEntryFingerprint -Entry $previousEntry
+    $newRecord = New-ReviewerStateRecord -Status 'PENDING' -Request $request -Reviewer $reviewer -Evidence $null -UpdatedAt $timestamp
+    $context = Save-VerifiedReviewStateTransition -ProjectDir $projectDir -Branch $branch -HeadSha $headSha -Context $context `
+        -ExpectedEntryFingerprint $expectedFingerprint -NewRecord $newRecord
     Update-ReviewPaneManifestState -Context $context -Properties ([ordered]@{
         review_state = 'pending'
         task_owner   = $context.Role
@@ -17344,22 +17469,31 @@ function Invoke-ReviewApprove {
     if ($requestHeadSha -ne $headSha) {
         Stop-WithError "pending review request head mismatch: expected $requestHeadSha, got $headSha"
     }
+    Assert-ReviewRequestIdentityBinding -Request $request -Context $context -Branch $branch
 
     $timestamp = (Get-Date).ToString('o')
     $reviewer = [ordered]@{
-        pane_id    = $context.PaneId
-        label      = $context.Label
-        role       = $context.Role
-        agent_name = [string]$env:WINSMUX_AGENT_NAME
+        generation_id    = $context.GenerationId
+        server_session_id = $context.ServerSessionId
+        slot_id          = $context.SlotId
+        pane_id          = $context.PaneId
+        label            = $context.Label
+        role             = $context.Role
+        backend          = $context.Backend
+        agent_name       = $context.AgentName
     }
     $evidence = [ordered]@{
         approved_at             = $timestamp
         approved_via            = 'winsmux review-approve'
+        runtime_generation_id   = $context.GenerationId
+        runtime_server_session_id = $context.ServerSessionId
         review_contract_snapshot = Get-ReviewStatePropertyValue -InputObject $request -Name 'review_contract'
     }
 
-    $state[$branch] = New-ReviewerStateRecord -Status 'PASS' -Request $request -Reviewer $reviewer -Evidence $evidence -UpdatedAt $timestamp
-    Save-ReviewState -ProjectDir $projectDir -State $state
+    $expectedFingerprint = Get-ReviewStateEntryFingerprint -Entry $entry
+    $newRecord = New-ReviewerStateRecord -Status 'PASS' -Request $request -Reviewer $reviewer -Evidence $evidence -UpdatedAt $timestamp
+    $context = Save-VerifiedReviewStateTransition -ProjectDir $projectDir -Branch $branch -HeadSha $headSha -Context $context `
+        -ExpectedEntryFingerprint $expectedFingerprint -NewRecord $newRecord
     Update-ReviewPaneManifestState -Context $context -Properties ([ordered]@{
         review_state = 'pass'
         task_owner   = 'Operator'
@@ -17414,22 +17548,31 @@ function Invoke-ReviewFail {
     if ($requestHeadSha -ne $headSha) {
         Stop-WithError "pending review request head mismatch: expected $requestHeadSha, got $headSha"
     }
+    Assert-ReviewRequestIdentityBinding -Request $request -Context $context -Branch $branch
 
     $timestamp = (Get-Date).ToString('o')
     $reviewer = [ordered]@{
-        pane_id    = $context.PaneId
-        label      = $context.Label
-        role       = $context.Role
-        agent_name = [string]$env:WINSMUX_AGENT_NAME
+        generation_id    = $context.GenerationId
+        server_session_id = $context.ServerSessionId
+        slot_id          = $context.SlotId
+        pane_id          = $context.PaneId
+        label            = $context.Label
+        role             = $context.Role
+        backend          = $context.Backend
+        agent_name       = $context.AgentName
     }
     $evidence = [ordered]@{
         failed_at               = $timestamp
         failed_via              = 'winsmux review-fail'
+        runtime_generation_id   = $context.GenerationId
+        runtime_server_session_id = $context.ServerSessionId
         review_contract_snapshot = Get-ReviewStatePropertyValue -InputObject $request -Name 'review_contract'
     }
 
-    $state[$branch] = New-ReviewerStateRecord -Status 'FAIL' -Request $request -Reviewer $reviewer -Evidence $evidence -UpdatedAt $timestamp
-    Save-ReviewState -ProjectDir $projectDir -State $state
+    $expectedFingerprint = Get-ReviewStateEntryFingerprint -Entry $entry
+    $newRecord = New-ReviewerStateRecord -Status 'FAIL' -Request $request -Reviewer $reviewer -Evidence $evidence -UpdatedAt $timestamp
+    $context = Save-VerifiedReviewStateTransition -ProjectDir $projectDir -Branch $branch -HeadSha $headSha -Context $context `
+        -ExpectedEntryFingerprint $expectedFingerprint -NewRecord $newRecord
     Update-ReviewPaneManifestState -Context $context -Properties ([ordered]@{
         review_state = 'fail'
         task_owner   = 'Operator'
@@ -17454,12 +17597,13 @@ function Invoke-ReviewReset {
     } catch {
         # Review-state persistence is authoritative; manifest sync remains best-effort.
     }
-    $state = Get-ReviewState -ProjectDir $projectDir
-    if ($state.Contains($branch)) {
-        $state.Remove($branch)
-    }
-
-    Save-ReviewState -ProjectDir $projectDir -State $state
+    Invoke-WithReviewStateLock -ProjectDir $projectDir -Action {
+        $state = Get-ReviewState -ProjectDir $projectDir
+        if ($state.Contains($branch)) {
+            $state.Remove($branch)
+        }
+        Save-ReviewState -ProjectDir $projectDir -State $state
+    } | Out-Null
     Update-ReviewPaneManifestState -Context $context -Properties ([ordered]@{
         review_state = ''
         branch       = ''

--- a/tests/Integration.GateEnforcement.Tests.ps1
+++ b/tests/Integration.GateEnforcement.Tests.ps1
@@ -137,6 +137,10 @@ Describe 'sh-orchestra-gate integration' {
             foreach ($entry in $Environment.GetEnumerator()) {
                 $startInfo.Environment[$entry.Key] = [string]$entry.Value
             }
+            $fixtureBin = Join-Path $RepoRoot '.winsmux-test-bin'
+            if (Test-Path -LiteralPath $fixtureBin -PathType Container) {
+                $startInfo.Environment['PATH'] = $fixtureBin + [System.IO.Path]::PathSeparator + $startInfo.Environment['PATH']
+            }
             if ($DisableStartupGate) {
                 $startInfo.Environment['WINSMUX_DISABLE_ORCHESTRA_STARTUP_GATE'] = '1'
             }
@@ -178,15 +182,70 @@ Describe 'sh-orchestra-gate integration' {
             & git -C $repoRoot -c user.name='Test User' -c user.email='test@example.com' commit -m 'init' | Out-Null
             & git -C $repoRoot checkout -b 'feature/review-gate' | Out-Null
             New-Item -ItemType Directory -Path (Join-Path $repoRoot '.winsmux') -Force | Out-Null
+            $fixtureBin = Join-Path $repoRoot '.winsmux-test-bin'
+            New-Item -ItemType Directory -Path $fixtureBin -Force | Out-Null
+            Write-GateTestFile -Path (Join-Path $fixtureBin 'winsmux.cmd') -Content @'
+@echo off
+pwsh -NoProfile -Command "$t=[char]9; [Console]::WriteLine(([char]36).ToString()+'1'+$t+'winsmux-gate'+$t+([char]37).ToString()+'1'+$t+'Bootstrap'); [Console]::WriteLine(([char]36).ToString()+'1'+$t+'winsmux-gate'+$t+([char]37).ToString()+'4'+$t+'Reviewer Pane')"
+'@
+
+            $generationId = 'gate-generation'
+            $serverSessionId = '$1'
+            $bootstrapPid = $PID
+            $bootstrapProcess = Get-CimInstance -ClassName Win32_Process -Filter ("ProcessId = {0}" -f $bootstrapPid) -ErrorAction Stop
+            $bootstrapStartedAt = ([datetime]$bootstrapProcess.CreationDate).ToUniversalTime().ToString('o')
+            $markerPath = Join-Path $repoRoot '.winsmux\reviewer-bootstrap.json'
+            $marker = [ordered]@{
+                state = 'ready'; generation_id = $generationId; server_session_id = $serverSessionId
+                slot_id = 'reviewer-1'; pane_id = '%4'; backend = 'local'; role = 'reviewer'; title = 'Reviewer Pane'
+                bootstrap_pid = $bootstrapPid; bootstrap_process_started_at = $bootstrapStartedAt
+            }
+            Write-GateTestFile -Path $markerPath -Content ($marker | ConvertTo-Json -Depth 8)
+
+            $approvedLaunch = ([ordered]@{ agent = 'local-reviewer'; worker_backend = 'local'; worker_role = 'reviewer' } | ConvertTo-Json -Compress)
             Write-GateTestFile -Path (Join-Path $repoRoot '.winsmux\manifest.yaml') -Content @"
+version: 2
 session:
-  name: 'winsmux-orchestra'
+  name: 'winsmux-gate'
   project_dir: '$repoRoot'
+  generation_id: '$generationId'
+  server_session_id: '$serverSessionId'
+  bootstrap_pane_id: '%1'
+  expected_pane_count: 1
+  session_ready: 'true'
 panes:
   reviewer-1:
+    slot_id: 'reviewer-1'
     pane_id: '%4'
-    role: Reviewer
+    worker_backend: 'local'
+    worker_role: 'reviewer'
+    role: 'Reviewer'
+    title: 'Reviewer Pane'
+    status: 'ready'
+    runtime_ready: 'true'
+    bootstrap_marker_path: '$markerPath'
+    approved_launch: '$approvedLaunch'
+tasks:
+  queued: []
+  in_progress: []
+  completed: []
+worktrees: {}
 "@
+
+            $now = (Get-Date).ToUniversalTime()
+            $registry = [ordered]@{
+                schema_version = 1; status = 'active'; session_name = 'winsmux-gate'; server_session_id = $serverSessionId
+                bootstrap_pane_id = '%1'; generation_id = $generationId; expected_pane_count = 1
+                supervisor = [ordered]@{ pid = $bootstrapPid; process_started_at = $bootstrapStartedAt }
+                lease = [ordered]@{ state = 'active'; expires_at = $now.AddMinutes(5).ToString('o') }
+                panes = @([ordered]@{
+                    label = 'reviewer-1'; slot_id = 'reviewer-1'; pane_id = '%4'; backend = 'local'; role = 'reviewer'
+                    title = 'Reviewer Pane'; state = 'live'; bootstrap_pid = $bootstrapPid
+                    bootstrap_process_started_at = $bootstrapStartedAt; marker_path = $markerPath
+                })
+                updated_at = $now.ToString('o')
+            }
+            Write-GateTestFile -Path (Join-Path $repoRoot '.winsmux\runtime-registry.json') -Content ($registry | ConvertTo-Json -Depth 12)
 
             return [PSCustomObject]@{
                 Root     = $fixtureRoot
@@ -1501,9 +1560,15 @@ EOF
         $result.OutputObject.systemMessage | Should -Match 'review-approve'
     }
 
-    It 'allows git commit after review-approve records PASS for the current branch' {
+    It 'allows and creates one-file git commit after same-head review PASS' {
         $fixture = New-GateFixture
         $script:FixtureRoot = $fixture.Root
+
+        $winsmuxProbe = @(& (Join-Path $fixture.RepoRoot '.winsmux-test-bin\winsmux.cmd') 'list-panes')
+        $winsmuxProbe | Should -Be @(
+            ('$1' + "`t" + 'winsmux-gate' + "`t" + '%1' + "`t" + 'Bootstrap'),
+            ('$1' + "`t" + 'winsmux-gate' + "`t" + '%4' + "`t" + 'Reviewer Pane')
+        )
 
         $reviewerEnv = @{
             WINSMUX_ROLE      = 'Reviewer'
@@ -1512,18 +1577,26 @@ EOF
             WINSMUX_AGENT_NAME = 'codex'
         }
 
+        Write-GateTestFile -Path (Join-Path $fixture.RepoRoot 'approved-change.txt') -Content 'approved change'
+        & git -C $fixture.RepoRoot add -- approved-change.txt
+        $LASTEXITCODE | Should -Be 0
+        @(& git -C $fixture.RepoRoot diff --cached --name-only) | Should -Be @('approved-change.txt')
+
         $requestResult = & $script:InvokeWinsmuxCore -RepoRoot $fixture.RepoRoot -Arguments @('review-request') -Environment $reviewerEnv
-        $requestResult.ExitCode | Should -Be 0
+        $requestResult.ExitCode | Should -Be 0 -Because $requestResult.StdErr
 
         $approveResult = & $script:InvokeWinsmuxCore -RepoRoot $fixture.RepoRoot -Arguments @('review-approve') -Environment $reviewerEnv
-        $approveResult.ExitCode | Should -Be 0
+        $approveResult.ExitCode | Should -Be 0 -Because $approveResult.StdErr
 
         $reviewStatePath = Join-Path $fixture.RepoRoot '.winsmux\review-state.json'
         Test-Path -LiteralPath $reviewStatePath | Should -Be $true
         $reviewState = Get-Content -LiteralPath $reviewStatePath -Raw -Encoding UTF8 | ConvertFrom-Json
         $reviewState.'feature/review-gate'.status | Should -Be 'PASS'
-        $reviewState.'feature/review-gate'.reviewer.role | Should -Be 'Reviewer'
+        $reviewState.'feature/review-gate'.reviewer.role | Should -Be 'reviewer'
         $reviewState.'feature/review-gate'.reviewer.pane_id | Should -Be '%4'
+        $reviewState.'feature/review-gate'.reviewer.agent_name | Should -Be 'local-reviewer'
+        $reviewState.'feature/review-gate'.reviewer.backend | Should -Be 'local'
+        $reviewState.'feature/review-gate'.reviewer.generation_id | Should -Be 'gate-generation'
         $reviewState.'feature/review-gate'.request.head_sha | Should -Not -BeNullOrEmpty
         $reviewState.'feature/review-gate'.request.target_reviewer_pane_id | Should -Be '%4'
         $reviewState.'feature/review-gate'.request.review_contract.source_task | Should -Be 'TASK-210'
@@ -1532,6 +1605,8 @@ EOF
         $reviewState.'feature/review-gate'.evidence.approved_at | Should -Not -BeNullOrEmpty
         $reviewState.'feature/review-gate'.evidence.approved_via | Should -Be 'winsmux review-approve'
         $reviewState.'feature/review-gate'.evidence.review_contract_snapshot.required_scope | Should -Be @('design_impact', 'replacement_coverage', 'orphaned_artifacts', 'pathspec_completeness')
+        $reviewedHead = [string]$reviewState.'feature/review-gate'.request.head_sha
+        $reviewedHead | Should -Be (Get-GateFixtureHeadSha -RepoRoot $fixture.RepoRoot)
 
         $result = & $script:InvokeOrchestraGate -RepoRoot $fixture.RepoRoot -ToolName 'Bash' -ToolInput @{
             command = 'git commit -m "feat: approved"'
@@ -1539,6 +1614,66 @@ EOF
 
         $result.ExitCode | Should -Be 0
         $result.StdErr | Should -Be ''
+
+        & git -C $fixture.RepoRoot -c user.name='Test User' -c user.email='test@example.com' commit -m 'feat: approved'
+        $LASTEXITCODE | Should -Be 0
+
+        $committedHead = Get-GateFixtureHeadSha -RepoRoot $fixture.RepoRoot
+        $committedHead | Should -Not -Be $reviewedHead
+        (& git -C $fixture.RepoRoot rev-parse "$committedHead^").Trim() | Should -Be $reviewedHead
+        @(& git -C $fixture.RepoRoot diff-tree --no-commit-id --name-only -r $committedHead) | Should -Be @('approved-change.txt')
+    }
+
+    It 'rejects approval from a different pane without changing PENDING or HEAD' {
+        $fixture = New-GateFixture
+        $script:FixtureRoot = $fixture.Root
+        $reviewerEnv = @{
+            WINSMUX_ROLE = 'Reviewer'; WINSMUX_PANE_ID = '%4'; WINSMUX_ROLE_MAP = '{"%4":"Reviewer"}'
+            WINSMUX_AGENT_NAME = 'spoofed-agent'
+        }
+        $requestResult = & $script:InvokeWinsmuxCore -RepoRoot $fixture.RepoRoot -Arguments @('review-request') -Environment $reviewerEnv
+        $requestResult.ExitCode | Should -Be 0 -Because $requestResult.StdErr
+
+        $reviewStatePath = Join-Path $fixture.RepoRoot '.winsmux\review-state.json'
+        $beforeState = [Convert]::ToBase64String([IO.File]::ReadAllBytes($reviewStatePath))
+        $beforeHead = Get-GateFixtureHeadSha -RepoRoot $fixture.RepoRoot
+        $otherPaneEnv = @{
+            WINSMUX_ROLE = 'Reviewer'; WINSMUX_PANE_ID = '%9'; WINSMUX_ROLE_MAP = '{"%9":"Reviewer"}'
+            WINSMUX_AGENT_NAME = 'local-reviewer'
+        }
+
+        $approveResult = & $script:InvokeWinsmuxCore -RepoRoot $fixture.RepoRoot -Arguments @('review-approve') -Environment $otherPaneEnv
+        $approveResult.ExitCode | Should -Be 1
+        $approveResult.StdErr | Should -Match 'Pane %9 was not found'
+        [Convert]::ToBase64String([IO.File]::ReadAllBytes($reviewStatePath)) | Should -Be $beforeState
+        (Get-GateFixtureHeadSha -RepoRoot $fixture.RepoRoot) | Should -Be $beforeHead
+    }
+
+    It 'rejects approval after HEAD changes without changing PENDING or the new HEAD' {
+        $fixture = New-GateFixture
+        $script:FixtureRoot = $fixture.Root
+        $reviewerEnv = @{
+            WINSMUX_ROLE = 'Reviewer'; WINSMUX_PANE_ID = '%4'; WINSMUX_ROLE_MAP = '{"%4":"Reviewer"}'
+            WINSMUX_AGENT_NAME = 'spoofed-agent'
+        }
+        $requestResult = & $script:InvokeWinsmuxCore -RepoRoot $fixture.RepoRoot -Arguments @('review-request') -Environment $reviewerEnv
+        $requestResult.ExitCode | Should -Be 0 -Because $requestResult.StdErr
+
+        Write-GateTestFile -Path (Join-Path $fixture.RepoRoot 'head-change.txt') -Content 'new head'
+        & git -C $fixture.RepoRoot add -- head-change.txt
+        $LASTEXITCODE | Should -Be 0
+        $noHooks = Join-Path $fixture.RepoRoot '.git\no-hooks'
+        & git -C $fixture.RepoRoot -c "core.hooksPath=$noHooks" -c user.name='Test User' -c user.email='test@example.com' commit -m 'test: advance head'
+        $LASTEXITCODE | Should -Be 0
+
+        $reviewStatePath = Join-Path $fixture.RepoRoot '.winsmux\review-state.json'
+        $beforeState = [Convert]::ToBase64String([IO.File]::ReadAllBytes($reviewStatePath))
+        $advancedHead = Get-GateFixtureHeadSha -RepoRoot $fixture.RepoRoot
+        $approveResult = & $script:InvokeWinsmuxCore -RepoRoot $fixture.RepoRoot -Arguments @('review-approve') -Environment $reviewerEnv
+        $approveResult.ExitCode | Should -Be 1
+        $approveResult.StdErr | Should -Match 'head mismatch'
+        [Convert]::ToBase64String([IO.File]::ReadAllBytes($reviewStatePath)) | Should -Be $beforeState
+        (Get-GateFixtureHeadSha -RepoRoot $fixture.RepoRoot) | Should -Be $advancedHead
     }
 
     It 'allows git merge after review-approve records PASS for the current branch' {

--- a/tests/Task781RuntimeCompatibility.Tests.ps1
+++ b/tests/Task781RuntimeCompatibility.Tests.ps1
@@ -713,3 +713,150 @@ $afterDelete = Test-VaultKeyExists -Key $key
         $vaultInject.Extent.Text | Should -Match 'Get-WinsmuxVaultCredentialValue'
     }
 }
+
+Describe 'TASK782 verified review identity' {
+    BeforeAll {
+        . (Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\pane-control.ps1')
+    }
+
+    BeforeEach {
+        Mock Get-PaneControlManifestContext {
+            [PSCustomObject][ordered]@{
+                ManifestPath = 'C:\repo\.winsmux\manifest.yaml'; GenerationId = 'generation-current'; ProjectDir = 'C:\repo'
+                Label = 'worker-1'; SlotId = 'worker-1'; PaneId = '%2'; WorkerBackend = 'codex'; WorkerRole = 'reviewer'
+                Role = 'Worker'; Title = 'W1 Codex Reviewer'
+                ApprovedLaunch = [ordered]@{ agent = 'codex'; worker_backend = 'codex'; worker_role = 'reviewer' }
+            }
+        }
+        Mock Test-PaneControlRuntimeContext {
+            New-WinsmuxRuntimeValidationResult -Valid $true -ReasonCode 'live_runtime_verified' -Diagnostic 'verified' -Context ([PSCustomObject][ordered]@{
+                generation_id = 'generation-current'; server_session_id = '$1'; slot_id = 'worker-1'; pane_id = '%2'
+                backend = 'codex'; role = 'reviewer'; title = 'W1 Codex Reviewer'
+            })
+        }
+    }
+
+    It 'binds the manifest-selected reviewer agent to the live runtime generation' {
+        $identity = Get-PaneControlVerifiedReviewIdentity -ProjectDir 'C:\repo' -PaneId '%2'
+        $identity.PaneId | Should -Be '%2'
+        $identity.Role | Should -Be 'reviewer'
+        $identity.AgentName | Should -Be 'codex'
+        $identity.Backend | Should -Be 'codex'
+        $identity.GenerationId | Should -Be 'generation-current'
+        $identity.ServerSessionId | Should -Be '$1'
+        Should -Invoke Test-PaneControlRuntimeContext -Times 1 -Exactly -ParameterFilter { $Operation -eq 'caller_ack' }
+    }
+
+    It 'rejects a mutable pane claim when caller ancestry is not verified' {
+        Mock Test-PaneControlRuntimeContext {
+            New-WinsmuxRuntimeValidationResult -Valid $false -ReasonCode 'caller_identity_mismatch' -Diagnostic 'unrelated caller'
+        }
+        { Get-PaneControlVerifiedReviewIdentity -ProjectDir 'C:\repo' -PaneId '%2' } | Should -Throw '*caller_identity_mismatch*'
+    }
+
+    It 'rejects a live pane that is not review-capable' {
+        Mock Test-PaneControlRuntimeContext {
+            New-WinsmuxRuntimeValidationResult -Valid $true -ReasonCode 'live_runtime_verified' -Diagnostic 'verified' -Context ([PSCustomObject][ordered]@{
+                generation_id = 'generation-current'; server_session_id = '$1'; slot_id = 'worker-1'; pane_id = '%2'
+                backend = 'codex'; role = 'builder'; title = 'Builder'
+            })
+        }
+        { Get-PaneControlVerifiedReviewIdentity -ProjectDir 'C:\repo' -PaneId '%2' } | Should -Throw '*not review-capable*'
+    }
+
+    It 'rejects a backend without authenticated caller ancestry' {
+        Mock Get-PaneControlManifestContext {
+            [PSCustomObject][ordered]@{
+                ManifestPath = 'C:\repo\.winsmux\manifest.yaml'; GenerationId = 'generation-current'; ProjectDir = 'C:\repo'
+                Label = 'worker-1'; SlotId = 'worker-1'; PaneId = '%2'; WorkerBackend = 'api_llm'; WorkerRole = 'reviewer'
+                Role = 'Worker'; Title = 'API Reviewer'
+                ApprovedLaunch = [ordered]@{ agent = 'api-reviewer'; worker_backend = 'api_llm'; worker_role = 'reviewer' }
+            }
+        }
+        Mock Test-PaneControlRuntimeContext {
+            New-WinsmuxRuntimeValidationResult -Valid $true -ReasonCode 'live_runtime_verified' -Diagnostic 'verified' -Context ([PSCustomObject][ordered]@{
+                generation_id = 'generation-current'; server_session_id = '$1'; slot_id = 'worker-1'; pane_id = '%2'
+                backend = 'api_llm'; role = 'reviewer'; title = 'API Reviewer'
+            })
+        }
+        { Get-PaneControlVerifiedReviewIdentity -ProjectDir 'C:\repo' -PaneId '%2' } | Should -Throw '*no authenticated caller-ancestry contract*'
+    }
+
+    It 'rejects approved-launch metadata without an agent identity' {
+        Mock Get-PaneControlManifestContext {
+            [PSCustomObject][ordered]@{
+                ManifestPath = 'C:\repo\.winsmux\manifest.yaml'; GenerationId = 'generation-current'; ProjectDir = 'C:\repo'
+                Label = 'worker-1'; SlotId = 'worker-1'; PaneId = '%2'; WorkerBackend = 'codex'; WorkerRole = 'reviewer'
+                Role = 'Worker'; Title = 'W1 Codex Reviewer'; ApprovedLaunch = [ordered]@{}
+            }
+        }
+        { Get-PaneControlVerifiedReviewIdentity -ProjectDir 'C:\repo' -PaneId '%2' } | Should -Throw '*agent identity*'
+    }
+
+    It 'rejects a generation change before the review-state write' {
+        { Get-PaneControlVerifiedReviewIdentity -ProjectDir 'C:\repo' -PaneId '%2' -ExpectedGenerationId 'generation-old' } |
+            Should -Throw '*generation changed*'
+    }
+}
+
+Describe 'TASK782 review-state compare-and-swap' {
+    BeforeAll {
+        $corePath = Join-Path (Split-Path -Parent $PSScriptRoot) 'scripts\winsmux-core.ps1'
+        $content = [IO.File]::ReadAllText($corePath, [Text.Encoding]::UTF8)
+        $tokens = $null
+        $errors = $null
+        $ast = [Management.Automation.Language.Parser]::ParseInput($content, $corePath, [ref]$tokens, [ref]$errors)
+        $errors.Count | Should -Be 0
+        foreach ($name in @('Get-ReviewStateEntryFingerprint', 'Save-VerifiedReviewStateTransition')) {
+            $functionAst = $ast.Find({
+                param($node)
+                $node -is [Management.Automation.Language.FunctionDefinitionAst] -and $node.Name -ceq $name
+            }, $true)
+            $functionAst | Should -Not -BeNullOrEmpty
+            . ([scriptblock]::Create($functionAst.Extent.Text))
+        }
+        function Stop-WithError { param([string]$Message) throw $Message }
+        function Invoke-WithReviewStateLock { param([string]$ProjectDir, [scriptblock]$Action) & $Action }
+        function Get-ReviewState { param([string]$ProjectDir) [ordered]@{} }
+        function Confirm-ReviewWriteContext {
+            param($Context, [string]$ProjectDir, [string]$Branch, [string]$HeadSha)
+            $Context
+        }
+        function Save-ReviewState { param($State, [string]$ProjectDir) }
+    }
+
+    BeforeEach {
+        $script:lockedState = [ordered]@{}
+        Mock Invoke-WithReviewStateLock { & $Action }
+        Mock Get-ReviewState { $script:lockedState }
+        Mock Confirm-ReviewWriteContext { $Context }
+        Mock Save-ReviewState {}
+    }
+
+    It 'refuses a concurrent same-branch update before validation or save' {
+        $script:lockedState['feature/review-gate'] = [ordered]@{ status = 'PENDING'; updatedAt = 'rival' }
+        $newRecord = [ordered]@{ status = 'PASS'; updatedAt = 'candidate' }
+
+        { Save-VerifiedReviewStateTransition -ProjectDir 'C:\repo' -Branch 'feature/review-gate' -HeadSha ('a' * 40) `
+                -Context ([pscustomobject]@{}) -ExpectedEntryFingerprint '<absent>' -NewRecord $newRecord } |
+            Should -Throw '*changed concurrently*'
+        Should -Invoke Confirm-ReviewWriteContext -Times 0 -Exactly
+        Should -Invoke Save-ReviewState -Times 0 -Exactly
+        $script:lockedState['feature/review-gate'].updatedAt | Should -Be 'rival'
+    }
+
+    It 'preserves concurrent entries for other branches during a verified transition' {
+        $script:lockedState['feature/other'] = [ordered]@{ status = 'PASS'; updatedAt = 'other' }
+        $newRecord = [ordered]@{ status = 'PENDING'; updatedAt = 'candidate' }
+
+        Save-VerifiedReviewStateTransition -ProjectDir 'C:\repo' -Branch 'feature/review-gate' -HeadSha ('a' * 40) `
+            -Context ([pscustomobject]@{}) -ExpectedEntryFingerprint '<absent>' -NewRecord $newRecord | Out-Null
+
+        Should -Invoke Confirm-ReviewWriteContext -Times 1 -Exactly
+        Should -Invoke Save-ReviewState -Times 1 -Exactly -ParameterFilter {
+            $State.Contains('feature/other') -and $State.Contains('feature/review-gate')
+        }
+        $script:lockedState['feature/other'].updatedAt | Should -Be 'other'
+        $script:lockedState['feature/review-gate'].status | Should -Be 'PENDING'
+    }
+}

--- a/winsmux-core/scripts/pane-control.ps1
+++ b/winsmux-core/scripts/pane-control.ps1
@@ -77,8 +77,11 @@ function Get-PaneControlValue {
         return $InputObject[$Name]
     }
 
-    if ($null -ne $InputObject.PSObject -and $InputObject.PSObject.Properties.Name -contains $Name) {
-        return $InputObject.$Name
+    if ($null -ne $InputObject.PSObject) {
+        $property = $InputObject.PSObject.Properties[$Name]
+        if ($null -ne $property) {
+            return $property.Value
+        }
     }
 
     return $Default
@@ -576,6 +579,71 @@ function Get-PaneControlManifestContext {
 
     $manifestPath = Join-Path (Join-Path $ProjectDir '.winsmux') 'manifest.yaml'
     throw "Pane $PaneId was not found in manifest: $manifestPath"
+}
+
+function Get-PaneControlVerifiedReviewIdentity {
+    param(
+        [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [Parameter(Mandatory = $true)][string]$PaneId,
+        [AllowEmptyString()][string]$ExpectedGenerationId = ''
+    )
+
+    $manifestEntry = Get-PaneControlManifestContext -ProjectDir $ProjectDir -PaneId $PaneId
+    $runtimeValidation = Test-PaneControlRuntimeContext -ProjectDir $ProjectDir -ManifestEntry $manifestEntry -Operation caller_ack
+    if ($null -eq $runtimeValidation -or -not [bool](Get-PaneControlValue -InputObject $runtimeValidation -Name 'valid' -Default $false)) {
+        $reasonCode = [string](Get-PaneControlValue -InputObject $runtimeValidation -Name 'reason_code' -Default 'caller_identity_mismatch')
+        $diagnostic = [string](Get-PaneControlValue -InputObject $runtimeValidation -Name 'diagnostic' -Default 'Review caller identity could not be verified.')
+        throw ("review identity refused ({0}): {1}" -f $reasonCode, $diagnostic)
+    }
+
+    $runtime = Get-PaneControlValue -InputObject $runtimeValidation -Name 'context' -Default $null
+    $generationId = [string](Get-PaneControlValue -InputObject $runtime -Name 'generation_id' -Default '')
+    if (-not [string]::IsNullOrWhiteSpace($ExpectedGenerationId) -and
+        -not [string]::Equals($generationId, $ExpectedGenerationId, [System.StringComparison]::Ordinal)) {
+        throw 'review identity refused (caller_identity_mismatch): Runtime generation changed before the review-state write.'
+    }
+
+    $runtimeRole = ([string](Get-PaneControlValue -InputObject $runtime -Name 'role' -Default '')).Trim().ToLowerInvariant()
+    if ($runtimeRole -notin @('reviewer', 'worker')) {
+        throw "review identity refused (caller_identity_mismatch): Pane $PaneId is not review-capable in the live runtime."
+    }
+
+    $approvedLaunch = Get-PaneControlValue -InputObject $manifestEntry -Name 'ApprovedLaunch' -Default $null
+    $agentName = ([string](Get-PaneControlValue -InputObject $approvedLaunch -Name 'agent' -Default '')).Trim()
+    if ([string]::IsNullOrWhiteSpace($agentName)) {
+        throw "review identity refused (manifest_regeneration_required): Pane $PaneId has no approved-launch agent identity."
+    }
+
+    $backend = ([string](Get-PaneControlValue -InputObject $runtime -Name 'backend' -Default '')).Trim().ToLowerInvariant()
+    if ($backend -notin @('local', 'codex')) {
+        throw "review identity refused (caller_identity_mismatch): Backend '$backend' has no authenticated caller-ancestry contract."
+    }
+    $approvedBackend = ([string](Get-PaneControlValue -InputObject $approvedLaunch -Name 'worker_backend' -Default '')).Trim().ToLowerInvariant()
+    if (-not [string]::IsNullOrWhiteSpace($approvedBackend) -and $approvedBackend -cne $backend) {
+        throw 'review identity refused (runtime_target_mismatch): Approved-launch backend does not match the live runtime.'
+    }
+    $approvedRole = ([string](Get-PaneControlValue -InputObject $approvedLaunch -Name 'worker_role' -Default '')).Trim().ToLowerInvariant()
+    if (-not [string]::IsNullOrWhiteSpace($approvedRole) -and $approvedRole -cne $runtimeRole) {
+        throw 'review identity refused (runtime_target_mismatch): Approved-launch role does not match the live runtime.'
+    }
+
+    return [PSCustomObject][ordered]@{
+        ManifestPath        = [string](Get-PaneControlValue -InputObject $manifestEntry -Name 'ManifestPath' -Default '')
+        GenerationId        = $generationId
+        ServerSessionId     = [string](Get-PaneControlValue -InputObject $runtime -Name 'server_session_id' -Default '')
+        ProjectDir          = [string](Get-PaneControlValue -InputObject $manifestEntry -Name 'ProjectDir' -Default $ProjectDir)
+        Label               = [string](Get-PaneControlValue -InputObject $manifestEntry -Name 'Label' -Default '')
+        SlotId              = [string](Get-PaneControlValue -InputObject $runtime -Name 'slot_id' -Default '')
+        PaneId              = [string](Get-PaneControlValue -InputObject $runtime -Name 'pane_id' -Default '')
+        Role                = $runtimeRole
+        CanonicalRole       = [string](Get-PaneControlValue -InputObject $manifestEntry -Name 'Role' -Default '')
+        AgentName           = $agentName
+        Backend             = $backend
+        Title               = [string](Get-PaneControlValue -InputObject $runtime -Name 'title' -Default '')
+        LaunchDir           = [string](Get-PaneControlValue -InputObject $manifestEntry -Name 'LaunchDir' -Default '')
+        BuilderWorktreePath = [string](Get-PaneControlValue -InputObject $manifestEntry -Name 'BuilderWorktreePath' -Default '')
+        GitWorktreeDir      = [string](Get-PaneControlValue -InputObject $manifestEntry -Name 'GitWorktreeDir' -Default '')
+    }
 }
 
 function Get-PaneControlManifestGenerationId {


### PR DESCRIPTION
## Summary

- derive review authority from the v2 manifest, supervisor runtime registry, live pane set, and verified caller ancestry
- bind requests and verdicts to generation, server, slot, pane, role, backend, approved agent, branch, and HEAD
- serialize same-branch review-state transitions with locking and compare-and-swap semantics
- exercise the real one-file review PASS → operator gate → git commit path

## Verification

- exhaustive non-PTY Pester: 1,316 passed; 0 failed, skipped, or not run; CodeCoverage disabled
- Rust workspace check, test, and release build passed; core package fmt passed
- PowerShell 7 and Windows PowerShell 5.1 parsing passed for all four changed files
- public-surface audit, git-guard full, diff check, and gitleaks history scan passed
- isolated live Codex reviewer identity and real one-file commit E2E passed

Closes #1192