### PR TITLE
ci: notify winsmux.dev on release publish

### DIFF
--- a/.github/workflows/notify-site.yml
+++ b/.github/workflows/notify-site.yml
@@ -1,0 +1,14 @@
+name: Notify site
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger winsmux.dev rebuild
+        run: gh api repos/Sora-bluesky/winsmux.dev/dispatches -f event_type=winsmux-release
+        env:
+          GH_TOKEN: ${{ secrets.SITE_DISPATCH_TOKEN }}


### PR DESCRIPTION
## Summary
Adds a standalone workflow (no changes to existing release workflows) that fires on `release: published` and sends a `repository_dispatch` (`winsmux-release`) to Sora-bluesky/winsmux.dev, triggering a site rebuild that picks up the new version from the latest release.

Companion PR: https://github.com/Sora-bluesky/winsmux.dev/pull/4

## Required secret
`SITE_DISPATCH_TOKEN` — PAT with repo access to winsmux.dev (default `GITHUB_TOKEN` cannot dispatch cross-repo). Note for rotation: when the PAT is rotated, this secret must be updated too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)