### PR TITLE
feat(workflow): add resumable declarative execution

### DIFF
--- a/.githooks/pre-commit-whitelist.ps1
+++ b/.githooks/pre-commit-whitelist.ps1
@@ -132,6 +132,7 @@ $whitelistPatterns = @(
     'tests/McpServerContract.Tests.ps1',
     'tests/codex-subagent-worktree-guard.Tests.ps1',
     'tests/HarnessContract.Tests.ps1',
+    'tests/DeclarativeWorkflow.Tests.ps1',
     'tests/NpmReleasePackage.Tests.ps1',
     'tests/VersionSurface.Tests.ps1',
     'tests/CliBakeoff.Tests.ps1',

--- a/.gitignore
+++ b/.gitignore
@@ -101,6 +101,7 @@ tests/bridge/_helpers/*
 !tests/EnterpriseStrategyAlignment.Tests.ps1
 !tests/ReviewLatencyHardening.Tests.ps1
 !tests/Task781RuntimeCompatibility.Tests.ps1
+!tests/DeclarativeWorkflow.Tests.ps1
 !tests/V03619RepoAudit.Tests.ps1
 !tests/V03620CoordinatorFoundation.Tests.ps1
 !tests/V03621LocalRouterShadow.Tests.ps1

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -55,6 +55,10 @@ name = "workspace_recipe_contract"
 path = "tests-rs/workspace_recipe_contract.rs"
 
 [[test]]
+name = "workflow_contract"
+path = "tests-rs/workflow_contract.rs"
+
+[[test]]
 name = "search_ledger_contract"
 path = "tests-rs/search_ledger_contract.rs"
 

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -23,6 +23,7 @@ mod server;
 mod terminal_engine;
 mod manifest_contract;
 mod workspace_recipe;
+mod workflow;
 mod workspace_project_settings;
 mod event_contract;
 mod ledger;

--- a/core/src/operator_cli.rs
+++ b/core/src/operator_cli.rs
@@ -19,12 +19,11 @@ use crate::ledger::{attach_evidence_chain_to_event, public_changed_files};
 use crate::machine_contract::machine_contract_catalog;
 use crate::read_path;
 use crate::types::VERSION;
+use crate::workflow::normalize_workspace_plan_payload;
 use crate::workspace_project_settings::{self, WorkspacePlanProjectSettings};
 #[cfg(test)]
 use crate::workspace_recipe::normalize_workspace_plan;
-use crate::workspace_recipe::{
-    normalize_workspace_plan_from_value, parse_workspace_yaml, SlotCapabilities,
-};
+use crate::workspace_recipe::{parse_workspace_yaml, SlotCapabilities};
 
 #[path = "workspace_builtin_provider.rs"]
 mod workspace_builtin_provider;
@@ -273,13 +272,14 @@ pub fn run_workspace_plan_command(args: &[&String]) -> io::Result<()> {
             supports_structured_result: effective.supports_structured_result,
         });
     }
-    let plan = normalize_workspace_plan_from_value(
+    let payload = normalize_workspace_plan_payload(
         &root,
         &options.recipe_id,
         options.workflow_id.as_deref(),
+        options.run_id.as_deref(),
         &slots,
     )?;
-    write_json(&plan)
+    write_json(&payload)
 }
 
 pub fn run_operator_jobs_command(args: &[&String]) -> io::Result<()> {
@@ -1742,6 +1742,7 @@ struct ProviderCapabilitiesOptions {
 struct WorkspacePlanOptions {
     recipe_id: String,
     workflow_id: Option<String>,
+    run_id: Option<String>,
     project_dir: PathBuf,
 }
 
@@ -2005,8 +2006,7 @@ fn parse_provider_capabilities_options(
 }
 
 fn parse_workspace_plan_options(args: &[&String]) -> io::Result<WorkspacePlanOptions> {
-    let mut recipe_id: Option<String> = None;
-    let mut workflow_id: Option<String> = None;
+    let mut option_values = BTreeMap::new();
     let mut project_dir = env::current_dir()?;
     let mut project_dir_seen = false;
     let mut json = false;
@@ -2014,24 +2014,14 @@ fn parse_workspace_plan_options(args: &[&String]) -> io::Result<WorkspacePlanOpt
 
     while index < args.len() {
         match args[index].as_str() {
-            "--recipe-id" => {
-                if recipe_id.is_some() {
+            flag @ ("--recipe-id" | "--workflow-id" | "--run-id") => {
+                let value = required_option_value(args, index, flag)?;
+                if option_values.insert(flag, value).is_some() {
                     return Err(io::Error::new(
                         io::ErrorKind::InvalidInput,
-                        "--recipe-id may be specified only once.",
+                        format!("{flag} may be specified only once."),
                     ));
                 }
-                recipe_id = Some(required_option_value(args, index, "--recipe-id")?);
-                index += 2;
-            }
-            "--workflow-id" => {
-                if workflow_id.is_some() {
-                    return Err(io::Error::new(
-                        io::ErrorKind::InvalidInput,
-                        "--workflow-id may be specified only once.",
-                    ));
-                }
-                workflow_id = Some(required_option_value(args, index, "--workflow-id")?);
                 index += 2;
             }
             "--project-dir" => {
@@ -2068,12 +2058,14 @@ fn parse_workspace_plan_options(args: &[&String]) -> io::Result<WorkspacePlanOpt
         }
     }
 
-    let recipe_id = recipe_id.ok_or_else(|| {
+    let recipe_id = option_values.remove("--recipe-id").ok_or_else(|| {
         io::Error::new(
             io::ErrorKind::InvalidInput,
             "workspace-plan requires --recipe-id <id>.",
         )
     })?;
+    let workflow_id = option_values.remove("--workflow-id");
+    let run_id = option_values.remove("--run-id");
     if !json {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
@@ -2083,6 +2075,7 @@ fn parse_workspace_plan_options(args: &[&String]) -> io::Result<WorkspacePlanOpt
     Ok(WorkspacePlanOptions {
         recipe_id,
         workflow_id,
+        run_id,
         project_dir,
     })
 }
@@ -6987,7 +6980,7 @@ fn usage_for(command: &str) -> &'static str {
             "usage: winsmux meta-plan --task <text> [--roles <path>] [--review-rounds <1|2>] [--json] [--project-dir <path>] [--session <name>]"
         }
         "workspace-plan" => {
-            "usage: winsmux workspace-plan --recipe-id <id> [--workflow-id <id>] --json [--project-dir <path>]"
+            "usage: winsmux workspace-plan --recipe-id <id> [--workflow-id <id>] [--run-id <id>] --json [--project-dir <path>]"
         }
         "provider-capabilities" => {
             "usage: winsmux provider-capabilities [provider] [--json] [--project-dir <path>]"

--- a/core/src/workflow.rs
+++ b/core/src/workflow.rs
@@ -2,7 +2,6 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::io;
 
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 
 use crate::workspace_recipe::{
     normalize_workspace_plan_from_value, NormalizedWorkspacePlan, SlotCapabilities,
@@ -29,33 +28,38 @@ pub struct NormalizedWorkflowNode {
     pub idempotency_key: String,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct NormalizedWorkspacePlanPayload {
+    #[serde(flatten)]
+    pub plan: NormalizedWorkspacePlan,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub workflow: Option<NormalizedWorkflow>,
+}
+
 pub fn normalize_workspace_plan_payload(
     root: &serde_yaml::Value,
     recipe_id: &str,
     workflow_id: Option<&str>,
     run_id: Option<&str>,
     slots: &[SlotCapabilities],
-) -> io::Result<Value> {
+) -> io::Result<NormalizedWorkspacePlanPayload> {
     if run_id.is_some() && workflow_id.is_none() {
         return Err(invalid_input(
             "workspace-plan --run-id requires --workflow-id.",
         ));
     }
     let plan = normalize_workspace_plan_from_value(root, recipe_id, workflow_id, slots)?;
-    let mut payload = serde_json::to_value(&plan)
-        .map_err(|error| invalid_data(format!("failed to serialize workspace plan: {error}")))?;
-    if let Some(run_id) = run_id {
-        let workflow = normalize_workflow_from_value(
-            root,
-            workflow_id.expect("validated workflow-id"),
-            run_id,
-            &plan,
-        )?;
-        payload["workflow"] = serde_json::to_value(workflow).map_err(|error| {
-            invalid_data(format!("failed to serialize normalized workflow: {error}"))
-        })?;
-    }
-    Ok(payload)
+    let workflow = run_id
+        .map(|run_id| {
+            normalize_workflow_from_value(
+                root,
+                workflow_id.expect("validated workflow-id"),
+                run_id,
+                &plan,
+            )
+        })
+        .transpose()?;
+    Ok(NormalizedWorkspacePlanPayload { plan, workflow })
 }
 
 #[derive(Debug, Deserialize)]

--- a/core/src/workflow.rs
+++ b/core/src/workflow.rs
@@ -14,6 +14,7 @@ const MAX_WORKFLOW_NODES: usize = 128;
 pub struct NormalizedWorkflow {
     pub schema_version: u64,
     pub workflow_id: String,
+    pub recipe_ref: String,
     pub run_id: String,
     pub topological_order: Vec<String>,
     pub nodes: Vec<NormalizedWorkflowNode>,
@@ -66,6 +67,7 @@ pub fn normalize_workspace_plan_payload(
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 struct WorkflowDefinition {
     schema_version: u64,
+    recipe_ref: String,
     nodes: Vec<WorkflowNodeDefinition>,
 }
 
@@ -105,6 +107,13 @@ pub fn normalize_workflow_from_value(
         return Err(invalid_data(format!(
             "unsupported workflow schema-version '{}'; supported version is {WORKFLOW_SCHEMA_VERSION}.",
             definition.schema_version
+        )));
+    }
+    require_stable_id("recipe-ref", &definition.recipe_ref)?;
+    if definition.recipe_ref != workspace_plan.recipe_id {
+        return Err(invalid_data(format!(
+            "workflow recipe-ref '{}' does not match selected recipe '{}'.",
+            definition.recipe_ref, workspace_plan.recipe_id
         )));
     }
     if definition.nodes.is_empty() || definition.nodes.len() > MAX_WORKFLOW_NODES {
@@ -217,6 +226,7 @@ pub fn normalize_workflow_from_value(
     Ok(NormalizedWorkflow {
         schema_version: WORKFLOW_SCHEMA_VERSION,
         workflow_id: workflow_id.to_string(),
+        recipe_ref: definition.recipe_ref,
         run_id: run_id.to_string(),
         topological_order,
         nodes,

--- a/core/src/workflow.rs
+++ b/core/src/workflow.rs
@@ -1,0 +1,261 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::io;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::workspace_recipe::{
+    normalize_workspace_plan_from_value, NormalizedWorkspacePlan, SlotCapabilities,
+};
+
+const WORKFLOW_SCHEMA_VERSION: u64 = 1;
+const MAX_WORKFLOW_NODES: usize = 128;
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct NormalizedWorkflow {
+    pub schema_version: u64,
+    pub workflow_id: String,
+    pub run_id: String,
+    pub topological_order: Vec<String>,
+    pub nodes: Vec<NormalizedWorkflowNode>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct NormalizedWorkflowNode {
+    pub node_id: String,
+    pub pane_ref: String,
+    pub depends_on: Vec<String>,
+    pub action: String,
+    pub idempotency_key: String,
+}
+
+pub fn normalize_workspace_plan_payload(
+    root: &serde_yaml::Value,
+    recipe_id: &str,
+    workflow_id: Option<&str>,
+    run_id: Option<&str>,
+    slots: &[SlotCapabilities],
+) -> io::Result<Value> {
+    if run_id.is_some() && workflow_id.is_none() {
+        return Err(invalid_input(
+            "workspace-plan --run-id requires --workflow-id.",
+        ));
+    }
+    let plan = normalize_workspace_plan_from_value(root, recipe_id, workflow_id, slots)?;
+    let mut payload = serde_json::to_value(&plan)
+        .map_err(|error| invalid_data(format!("failed to serialize workspace plan: {error}")))?;
+    if let Some(run_id) = run_id {
+        let workflow = normalize_workflow_from_value(
+            root,
+            workflow_id.expect("validated workflow-id"),
+            run_id,
+            &plan,
+        )?;
+        payload["workflow"] = serde_json::to_value(workflow).map_err(|error| {
+            invalid_data(format!("failed to serialize normalized workflow: {error}"))
+        })?;
+    }
+    Ok(payload)
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+struct WorkflowDefinition {
+    schema_version: u64,
+    nodes: Vec<WorkflowNodeDefinition>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+struct WorkflowNodeDefinition {
+    node_id: String,
+    pane_ref: String,
+    #[serde(default)]
+    depends_on: Vec<String>,
+    action: String,
+}
+
+pub fn normalize_workflow_from_value(
+    root: &serde_yaml::Value,
+    workflow_id: &str,
+    run_id: &str,
+    workspace_plan: &NormalizedWorkspacePlan,
+) -> io::Result<NormalizedWorkflow> {
+    require_stable_id("workflow-id", workflow_id)?;
+    require_stable_id("run-id", run_id)?;
+
+    let root = root
+        .as_mapping()
+        .ok_or_else(|| invalid_data(".winsmux.yaml must be a mapping."))?;
+    let workflows = root
+        .get(serde_yaml::Value::String("workflows".to_string()))
+        .ok_or_else(|| invalid_input("workflows is not configured."))?
+        .as_mapping()
+        .ok_or_else(|| invalid_data("workflows must be a mapping."))?;
+    let value = workflows
+        .get(serde_yaml::Value::String(workflow_id.to_string()))
+        .ok_or_else(|| invalid_input(format!("workflow '{workflow_id}' was not found.")))?;
+    let definition: WorkflowDefinition = serde_yaml::from_value(value.clone())
+        .map_err(|_| invalid_data("invalid workflow schema."))?;
+    if definition.schema_version != WORKFLOW_SCHEMA_VERSION {
+        return Err(invalid_data(format!(
+            "unsupported workflow schema-version '{}'; supported version is {WORKFLOW_SCHEMA_VERSION}.",
+            definition.schema_version
+        )));
+    }
+    if definition.nodes.is_empty() || definition.nodes.len() > MAX_WORKFLOW_NODES {
+        return Err(invalid_data(format!(
+            "workflow must contain between 1 and {MAX_WORKFLOW_NODES} nodes."
+        )));
+    }
+
+    let mut definitions = BTreeMap::new();
+    for node in definition.nodes {
+        require_stable_id("node-id", &node.node_id)?;
+        require_stable_id("pane-ref", &node.pane_ref)?;
+        if node.action != "operator-dispatch" {
+            return Err(invalid_data("unknown workflow action."));
+        }
+        if !workspace_plan
+            .resolved_bindings
+            .contains_key(&node.pane_ref)
+        {
+            return Err(invalid_data(format!(
+                "workflow node '{}' references unknown pane '{}'.",
+                node.node_id, node.pane_ref
+            )));
+        }
+        let mut unique_dependencies = BTreeSet::new();
+        for dependency in &node.depends_on {
+            require_stable_id("depends-on", dependency)?;
+            if dependency == &node.node_id || !unique_dependencies.insert(dependency.clone()) {
+                return Err(invalid_data(format!(
+                    "workflow node '{}' has an invalid dependency set.",
+                    node.node_id
+                )));
+            }
+        }
+        if definitions.insert(node.node_id.clone(), node).is_some() {
+            return Err(invalid_data("duplicate workflow node-id."));
+        }
+    }
+
+    for node in definitions.values() {
+        for dependency in &node.depends_on {
+            if !definitions.contains_key(dependency) {
+                return Err(invalid_data(format!(
+                    "workflow node '{}' depends on unknown node '{}'.",
+                    node.node_id, dependency
+                )));
+            }
+        }
+    }
+
+    let mut indegree: BTreeMap<String, usize> = definitions
+        .iter()
+        .map(|(node_id, node)| (node_id.clone(), node.depends_on.len()))
+        .collect();
+    let mut dependents: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    for node in definitions.values() {
+        for dependency in &node.depends_on {
+            dependents
+                .entry(dependency.clone())
+                .or_default()
+                .push(node.node_id.clone());
+        }
+    }
+    for children in dependents.values_mut() {
+        children.sort();
+    }
+
+    let mut ready: BTreeSet<String> = indegree
+        .iter()
+        .filter_map(|(node_id, degree)| (*degree == 0).then_some(node_id.clone()))
+        .collect();
+    let mut topological_order = Vec::with_capacity(definitions.len());
+    while let Some(node_id) = ready.iter().next().cloned() {
+        ready.remove(&node_id);
+        topological_order.push(node_id.clone());
+        if let Some(children) = dependents.get(&node_id) {
+            for child in children {
+                let degree = indegree
+                    .get_mut(child)
+                    .ok_or_else(|| invalid_data("workflow graph identity changed."))?;
+                *degree = degree
+                    .checked_sub(1)
+                    .ok_or_else(|| invalid_data("workflow graph indegree underflow."))?;
+                if *degree == 0 {
+                    ready.insert(child.clone());
+                }
+            }
+        }
+    }
+    if topological_order.len() != definitions.len() {
+        return Err(invalid_data("workflow_cycle"));
+    }
+
+    let nodes = topological_order
+        .iter()
+        .map(|node_id| {
+            let node = &definitions[node_id];
+            let mut depends_on = node.depends_on.clone();
+            depends_on.sort();
+            NormalizedWorkflowNode {
+                node_id: node.node_id.clone(),
+                pane_ref: workspace_plan.resolved_bindings[&node.pane_ref].clone(),
+                depends_on,
+                action: node.action.clone(),
+                idempotency_key: format!("{run_id}:{node_id}"),
+            }
+        })
+        .collect();
+
+    Ok(NormalizedWorkflow {
+        schema_version: WORKFLOW_SCHEMA_VERSION,
+        workflow_id: workflow_id.to_string(),
+        run_id: run_id.to_string(),
+        topological_order,
+        nodes,
+    })
+}
+
+fn require_stable_id(label: &str, value: &str) -> io::Result<()> {
+    if value.len() > 128 || !is_stable_id(value) {
+        return Err(invalid_data(format!(
+            "{label} must be a non-empty stable ASCII identifier."
+        )));
+    }
+    Ok(())
+}
+
+fn is_stable_id(value: &str) -> bool {
+    let mut parts = value.split('-');
+    let Some(first) = parts.next() else {
+        return false;
+    };
+    if first.is_empty()
+        || !first
+            .bytes()
+            .next()
+            .is_some_and(|byte| byte.is_ascii_lowercase())
+        || !first
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit())
+    {
+        return false;
+    }
+    parts.all(|part| {
+        !part.is_empty()
+            && part
+                .bytes()
+                .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit())
+    })
+}
+
+fn invalid_input(message: impl Into<String>) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidInput, message.into())
+}
+
+fn invalid_data(message: impl Into<String>) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, message.into())
+}

--- a/core/tests-rs/workflow_contract.rs
+++ b/core/tests-rs/workflow_contract.rs
@@ -161,6 +161,27 @@ fn public_workspace_plan_requires_run_identity_and_emits_the_normalized_workflow
         "workspace-plan stderr: {}",
         String::from_utf8_lossy(&output.stderr)
     );
+    let output_text =
+        std::str::from_utf8(&output.stdout).expect("workspace-plan JSON must be UTF-8");
+    let top_level_keys = [
+        "\"schema_version\":",
+        "\"config_fingerprint\":",
+        "\"recipe_id\":",
+        "\"workflow_id\":",
+        "\"panes\":",
+        "\"startup_actions\":",
+        "\"resolved_bindings\":",
+        "\"workflow\":",
+    ];
+    let mut previous = None;
+    for key in top_level_keys {
+        let position = output_text.find(key).expect("expected top-level key");
+        assert!(
+            previous.is_none_or(|previous| previous < position),
+            "workspace-plan public key order changed at {key}: {output_text}"
+        );
+        previous = Some(position);
+    }
     let payload: serde_json::Value =
         serde_json::from_slice(&output.stdout).expect("parse workspace-plan JSON");
     assert_eq!(payload["workflow"]["run_id"], "run-task-659");

--- a/core/tests-rs/workflow_contract.rs
+++ b/core/tests-rs/workflow_contract.rs
@@ -1,0 +1,211 @@
+#[path = "../src/workflow.rs"]
+mod workflow;
+#[path = "../src/workspace_recipe.rs"]
+mod workspace_recipe;
+
+use std::fs;
+use std::process::Command;
+
+use workflow::normalize_workflow_from_value;
+use workspace_recipe::{normalize_workspace_plan, parse_workspace_yaml, SlotCapabilities};
+
+const VALID_RECIPE: &str = include_str!("../../tests/fixtures/workspace-recipes/valid-v1.yaml");
+const VALID_PROVIDER_CAPABILITIES: &str =
+    include_str!("../../tests/fixtures/workspace-recipes/valid-v1.provider-capabilities.json");
+
+fn slots() -> Vec<SlotCapabilities> {
+    vec![
+        SlotCapabilities {
+            slot_id: "worker-1".to_string(),
+            supports_file_edit: true,
+            supports_verification: false,
+            supports_structured_result: false,
+        },
+        SlotCapabilities {
+            slot_id: "reviewer-1".to_string(),
+            supports_file_edit: false,
+            supports_verification: true,
+            supports_structured_result: true,
+        },
+    ]
+}
+
+fn workflow_yaml(nodes: &str) -> String {
+    format!("{VALID_RECIPE}\nworkflows:\n  bugfix:\n    schema-version: 1\n    nodes:\n{nodes}")
+}
+
+fn normalize(yaml: &str) -> std::io::Result<workflow::NormalizedWorkflow> {
+    let root = parse_workspace_yaml(yaml)?;
+    let plan = normalize_workspace_plan(yaml, "bugfix-two-slot", Some("bugfix"), &slots())?;
+    normalize_workflow_from_value(&root, "bugfix", "run-task-659", &plan)
+}
+
+#[test]
+fn workflow_normalization_is_deterministic_and_resolves_runtime_slots() {
+    let reverse_order = workflow_yaml(
+        "      - node-id: verify\n        pane-ref: verify\n        depends-on: [build]\n        action: operator-dispatch\n      - node-id: build\n        pane-ref: implement\n        depends-on: []\n        action: operator-dispatch\n",
+    );
+    let forward_order = workflow_yaml(
+        "      - node-id: build\n        pane-ref: implement\n        depends-on: []\n        action: operator-dispatch\n      - node-id: verify\n        pane-ref: verify\n        depends-on: [build]\n        action: operator-dispatch\n",
+    );
+
+    let first = normalize(&reverse_order).expect("reverse source order should normalize");
+    let second = normalize(&forward_order).expect("forward source order should normalize");
+    let first_bytes = serde_json::to_vec(&first).expect("serialize normalized workflow");
+    let second_bytes = serde_json::to_vec(&second).expect("serialize normalized workflow");
+
+    assert_eq!(first_bytes, second_bytes);
+    assert_eq!(first.topological_order, ["build", "verify"]);
+    assert_eq!(first.nodes[0].pane_ref, "worker-1");
+    assert_eq!(first.nodes[1].pane_ref, "reviewer-1");
+    assert_eq!(first.nodes[0].idempotency_key, "run-task-659:build");
+    assert_eq!(first.nodes[1].idempotency_key, "run-task-659:verify");
+}
+
+#[test]
+fn workflow_normalization_rejects_cycles_missing_nodes_and_duplicate_edges() {
+    let cases = [
+        (
+            workflow_yaml(
+                "      - node-id: build\n        pane-ref: implement\n        depends-on: [verify]\n        action: operator-dispatch\n      - node-id: verify\n        pane-ref: verify\n        depends-on: [build]\n        action: operator-dispatch\n",
+            ),
+            "workflow_cycle",
+        ),
+        (
+            workflow_yaml(
+                "      - node-id: build\n        pane-ref: implement\n        depends-on: [missing]\n        action: operator-dispatch\n",
+            ),
+            "depends on unknown node",
+        ),
+        (
+            workflow_yaml(
+                "      - node-id: build\n        pane-ref: implement\n        depends-on: [prepare, prepare]\n        action: operator-dispatch\n      - node-id: prepare\n        pane-ref: implement\n        depends-on: []\n        action: operator-dispatch\n",
+            ),
+            "invalid dependency set",
+        ),
+    ];
+
+    for (yaml, expected) in cases {
+        let error = normalize(&yaml).expect_err("invalid workflow graph must fail closed");
+        assert!(
+            error.to_string().contains(expected),
+            "expected {expected:?}, got {error}"
+        );
+    }
+}
+
+#[test]
+fn workflow_normalization_rejects_unknown_panes_actions_fields_and_duplicate_nodes() {
+    let cases = [
+        workflow_yaml(
+            "      - node-id: build\n        pane-ref: missing\n        depends-on: []\n        action: operator-dispatch\n",
+        ),
+        workflow_yaml(
+            "      - node-id: build\n        pane-ref: implement\n        depends-on: []\n        action: shell\n",
+        ),
+        workflow_yaml(
+            "      - node-id: build\n        pane-ref: implement\n        depends-on: []\n        action: operator-dispatch\n        prompt: private\n",
+        ),
+        workflow_yaml(
+            "      - node-id: build\n        pane-ref: implement\n        depends-on: []\n        action: operator-dispatch\n      - node-id: build\n        pane-ref: implement\n        depends-on: []\n        action: operator-dispatch\n",
+        ),
+    ];
+
+    for yaml in cases {
+        normalize(&yaml).expect_err("unsupported workflow surface must fail closed");
+    }
+}
+
+#[test]
+#[cfg(windows)]
+fn public_workspace_plan_requires_run_identity_and_emits_the_normalized_workflow() {
+    let fixture = tempfile::tempdir().expect("create isolated workflow fixture");
+    let project_dir = fixture.path().join("project");
+    let runtime_dir = project_dir.join(".winsmux");
+    let home_dir = fixture.path().join("home");
+    fs::create_dir_all(&runtime_dir).expect("create runtime directory");
+    fs::create_dir_all(&home_dir).expect("create isolated home");
+    let yaml = workflow_yaml(
+        "      - node-id: verify\n        pane-ref: verify\n        depends-on: [build]\n        action: operator-dispatch\n      - node-id: build\n        pane-ref: implement\n        depends-on: []\n        action: operator-dispatch\n",
+    );
+    fs::write(project_dir.join(".winsmux.yaml"), yaml).expect("write workflow config");
+    fs::write(
+        runtime_dir.join("provider-capabilities.json"),
+        VALID_PROVIDER_CAPABILITIES,
+    )
+    .expect("write provider capabilities");
+
+    let binary = env!("CARGO_BIN_EXE_winsmux");
+    let output = Command::new(binary)
+        .args([
+            "workspace-plan",
+            "--recipe-id",
+            "bugfix-two-slot",
+            "--workflow-id",
+            "bugfix",
+            "--run-id",
+            "run-task-659",
+            "--json",
+            "--project-dir",
+        ])
+        .arg(&project_dir)
+        .env("USERPROFILE", &home_dir)
+        .env("HOME", &home_dir)
+        .env_remove("PSMUX_TARGET_SESSION")
+        .env_remove("PSMUX_TARGET_FULL")
+        .env_remove("TMUX")
+        .output()
+        .expect("run public workspace-plan");
+    assert!(
+        output.status.success(),
+        "workspace-plan stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let payload: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("parse workspace-plan JSON");
+    assert_eq!(payload["workflow"]["run_id"], "run-task-659");
+    assert_eq!(
+        payload["workflow"]["topological_order"],
+        serde_json::json!(["build", "verify"])
+    );
+    assert_eq!(payload["workflow"]["nodes"][0]["pane_ref"], "worker-1");
+
+    let missing_workflow = Command::new(binary)
+        .args([
+            "workspace-plan",
+            "--recipe-id",
+            "bugfix-two-slot",
+            "--run-id",
+            "run-task-659",
+            "--json",
+            "--project-dir",
+        ])
+        .arg(&project_dir)
+        .env("USERPROFILE", &home_dir)
+        .env("HOME", &home_dir)
+        .output()
+        .expect("run incomplete workspace-plan");
+    assert!(!missing_workflow.status.success());
+    assert!(String::from_utf8_lossy(&missing_workflow.stderr)
+        .contains("workspace-plan --run-id requires --workflow-id"));
+
+    let preview = Command::new(binary)
+        .args([
+            "workspace-plan",
+            "--recipe-id",
+            "bugfix-two-slot",
+            "--workflow-id",
+            "bugfix",
+            "--json",
+            "--project-dir",
+        ])
+        .arg(&project_dir)
+        .env("USERPROFILE", &home_dir)
+        .env("HOME", &home_dir)
+        .output()
+        .expect("run legacy recipe preview");
+    assert!(preview.status.success());
+    let preview_payload: serde_json::Value =
+        serde_json::from_slice(&preview.stdout).expect("parse preview JSON");
+    assert!(preview_payload.get("workflow").is_none());
+}

--- a/core/tests-rs/workflow_contract.rs
+++ b/core/tests-rs/workflow_contract.rs
@@ -31,7 +31,9 @@ fn slots() -> Vec<SlotCapabilities> {
 }
 
 fn workflow_yaml(nodes: &str) -> String {
-    format!("{VALID_RECIPE}\nworkflows:\n  bugfix:\n    schema-version: 1\n    nodes:\n{nodes}")
+    format!(
+        "{VALID_RECIPE}\nworkflows:\n  bugfix:\n    schema-version: 1\n    recipe-ref: bugfix-two-slot\n    nodes:\n{nodes}"
+    )
 }
 
 fn normalize(yaml: &str) -> std::io::Result<workflow::NormalizedWorkflow> {
@@ -55,6 +57,7 @@ fn workflow_normalization_is_deterministic_and_resolves_runtime_slots() {
     let second_bytes = serde_json::to_vec(&second).expect("serialize normalized workflow");
 
     assert_eq!(first_bytes, second_bytes);
+    assert_eq!(first.recipe_ref, "bugfix-two-slot");
     assert_eq!(first.topological_order, ["build", "verify"]);
     assert_eq!(first.nodes[0].pane_ref, "worker-1");
     assert_eq!(first.nodes[1].pane_ref, "reviewer-1");
@@ -113,6 +116,21 @@ fn workflow_normalization_rejects_unknown_panes_actions_fields_and_duplicate_nod
 
     for yaml in cases {
         normalize(&yaml).expect_err("unsupported workflow surface must fail closed");
+    }
+
+    let missing_recipe_ref = workflow_yaml(
+        "      - node-id: build\n        pane-ref: implement\n        depends-on: []\n        action: operator-dispatch\n",
+    )
+    .replace("    recipe-ref: bugfix-two-slot\n", "");
+    let mismatched_recipe_ref = workflow_yaml(
+        "      - node-id: build\n        pane-ref: implement\n        depends-on: []\n        action: operator-dispatch\n",
+    )
+    .replace(
+        "    recipe-ref: bugfix-two-slot",
+        "    recipe-ref: review-one-slot",
+    );
+    for yaml in [missing_recipe_ref, mismatched_recipe_ref] {
+        normalize(&yaml).expect_err("workflow recipe binding must fail closed");
     }
 }
 
@@ -185,6 +203,7 @@ fn public_workspace_plan_requires_run_identity_and_emits_the_normalized_workflow
     let payload: serde_json::Value =
         serde_json::from_slice(&output.stdout).expect("parse workspace-plan JSON");
     assert_eq!(payload["workflow"]["run_id"], "run-task-659");
+    assert_eq!(payload["workflow"]["recipe_ref"], "bugfix-two-slot");
     assert_eq!(
         payload["workflow"]["topological_order"],
         serde_json::json!(["build", "verify"])

--- a/core/tests-rs/workflow_contract.rs
+++ b/core/tests-rs/workflow_contract.rs
@@ -12,6 +12,10 @@ use workspace_recipe::{normalize_workspace_plan, parse_workspace_yaml, SlotCapab
 const VALID_RECIPE: &str = include_str!("../../tests/fixtures/workspace-recipes/valid-v1.yaml");
 const VALID_PROVIDER_CAPABILITIES: &str =
     include_str!("../../tests/fixtures/workspace-recipes/valid-v1.provider-capabilities.json");
+const ARCHITECTURE_DOC: &str =
+    include_str!("../../docs/project/v03629-declarative-workspace-architecture.md");
+const RUNNABLE_WORKFLOW_V1_START: &str = "<!-- TASK659-RUNNABLE-WORKFLOW-V1:START -->";
+const RUNNABLE_WORKFLOW_V1_END: &str = "<!-- TASK659-RUNNABLE-WORKFLOW-V1:END -->";
 
 fn slots() -> Vec<SlotCapabilities> {
     vec![
@@ -40,6 +44,66 @@ fn normalize(yaml: &str) -> std::io::Result<workflow::NormalizedWorkflow> {
     let root = parse_workspace_yaml(yaml)?;
     let plan = normalize_workspace_plan(yaml, "bugfix-two-slot", Some("bugfix"), &slots())?;
     normalize_workflow_from_value(&root, "bugfix", "run-task-659", &plan)
+}
+
+fn documented_runnable_workflow_v1() -> &'static str {
+    assert_eq!(
+        ARCHITECTURE_DOC.matches(RUNNABLE_WORKFLOW_V1_START).count(),
+        1,
+        "architecture doc must contain exactly one runnable workflow v1 start marker"
+    );
+    assert_eq!(
+        ARCHITECTURE_DOC.matches(RUNNABLE_WORKFLOW_V1_END).count(),
+        1,
+        "architecture doc must contain exactly one runnable workflow v1 end marker"
+    );
+    let (_, after_start) = ARCHITECTURE_DOC
+        .split_once(RUNNABLE_WORKFLOW_V1_START)
+        .expect("architecture doc must contain the runnable workflow v1 start marker");
+    let (marked_block, _) = after_start
+        .split_once(RUNNABLE_WORKFLOW_V1_END)
+        .expect("architecture doc must contain the runnable workflow v1 end marker");
+    let fenced_block = marked_block.trim();
+    let yaml = fenced_block
+        .strip_prefix("```yaml\r\n")
+        .or_else(|| fenced_block.strip_prefix("```yaml\n"))
+        .expect("runnable workflow v1 must start with a YAML fence");
+    yaml.strip_suffix("\r\n```")
+        .or_else(|| yaml.strip_suffix("\n```"))
+        .expect("runnable workflow v1 must end with a YAML fence")
+}
+
+#[test]
+fn documented_runnable_workflow_v1_matches_the_canonical_normalizer() {
+    let yaml = documented_runnable_workflow_v1();
+    let root = parse_workspace_yaml(yaml).expect("documented workflow v1 must parse as YAML");
+    let plan = normalize_workspace_plan(yaml, "bugfix-two-slot", Some("bugfix"), &slots())
+        .expect("documented workflow v1 recipe must normalize");
+    let workflow = normalize_workflow_from_value(&root, "bugfix", "run-task-659", &plan)
+        .expect("documented workflow v1 must normalize");
+
+    assert_eq!(workflow.schema_version, 1);
+    assert_eq!(workflow.recipe_ref, "bugfix-two-slot");
+    assert_eq!(
+        workflow.topological_order,
+        ["inspect", "implement", "verify"]
+    );
+    assert!(workflow
+        .nodes
+        .iter()
+        .all(|node| node.action == "operator-dispatch"));
+    assert_eq!(
+        workflow
+            .nodes
+            .iter()
+            .map(|node| node.idempotency_key.as_str())
+            .collect::<Vec<_>>(),
+        [
+            "run-task-659:inspect",
+            "run-task-659:implement",
+            "run-task-659:verify"
+        ]
+    );
 }
 
 #[test]

--- a/docs/project/v03629-declarative-workspace-architecture.md
+++ b/docs/project/v03629-declarative-workspace-architecture.md
@@ -127,9 +127,13 @@ gate complete until TASK-718 has verified the combined desktop/CLI behavior.
 ### 3.2 Schema sketch
 
 Public YAML uses the repository's existing hyphenated spelling; normalized
-runtime objects use snake_case. The following is a valid configuration fragment;
-the ownership, reference, and fail-closed rules are normative.
+runtime objects use snake_case. The marker-delimited fragment below is the
+current executable workflow schema-version 1 contract. Its exact bytes are
+consumed by `core/tests-rs/workflow_contract.rs` through the canonical
+workspace/workflow normalizers, so a documented field cannot drift from the
+public parser.
 
+<!-- TASK659-RUNNABLE-WORKFLOW-V1:START -->
 ```yaml
 config-version: 1
 
@@ -181,25 +185,28 @@ workflows:
       - node-id: inspect
         pane-ref: implement
         action: operator-dispatch
-        idempotency-key: "{{run-id}}:inspect"
       - node-id: implement
         pane-ref: implement
         depends-on: [inspect]
         action: operator-dispatch
-        idempotency-key: "{{run-id}}:implement"
       - node-id: verify
         pane-ref: verify
         depends-on: [implement]
-        action: verification
-        context-pack-ref: review-pack
-        idempotency-key: "{{run-id}}:verify"
-    resume-policy:
-      mode: operator-confirmed
-      reject-completed-runs: true
-    cleanup-policy:
-      mode: compensating-actions
-      on: [success, failure, cancel]
+        action: operator-dispatch
+```
+<!-- TASK659-RUNNABLE-WORKFLOW-V1:END -->
 
+The current workflow v1 parser derives every node idempotency key as
+`<run-id>:<node-id>`; it does not accept an authored `idempotency-key`.
+Workflow-level `resume-policy` and `cleanup-policy`, and node-level
+`verification` actions or `context-pack-ref`, are target concepts owned by
+later child tasks. They are not executable TASK-659 fields and require a new
+implemented schema contract before they may appear in a runnable example.
+
+The following context-pack fragment is therefore an illustrative,
+non-executable TASK-660 target, not part of the current workflow v1 contract:
+
+```yaml
 context-packs:
   review-pack:
     schema-version: 1
@@ -239,10 +246,13 @@ Normative field rules:
 - Worktree paths are derived by runtime policy. Config may provide a safe name
   template but not an absolute private path or an escape outside the managed
   worktree root.
-- DAG dependencies must be acyclic. Each side-effecting node has a stable
-  idempotency key and an explicit compensation or cleanup classification.
-- Context-pack `include` values are allowlisted projections. Omitted limits use
-  conservative defaults; disabling privacy exclusions is not supported.
+- DAG dependencies must be acyclic. TASK-659 derives each side-effecting
+  node's stable idempotency key from the public run and node identities;
+  authored idempotency, compensation, and cleanup fields are not workflow v1
+  inputs.
+- For the non-executable TASK-660 target, context-pack `include` values are
+  allowlisted projections. Omitted limits use conservative defaults;
+  disabling privacy exclusions is not supported.
 
 Recipe selection is explicit. The TASK-658 preview entry point is
 `winsmux workspace-plan --recipe-id <id> [--workflow-id <id>] --json

--- a/docs/project/v03629-declarative-workspace-architecture.md
+++ b/docs/project/v03629-declarative-workspace-architecture.md
@@ -406,15 +406,22 @@ desktop release parity.
 
 ### 6.2 TASK-659: resumable workflow and pipeline
 
-**Owns:** workflow DAG validation; the run/node state machines; dependency
-release; persisted idempotency records; operator-confirmed resume; structured
-dispatch acknowledgement; retry accounting; checkpoint reconciliation;
-journaled cleanup; and declared rollback. It evolves or wraps
-`winsmux-core/scripts/team-pipeline.ps1` so the current pipeline remains the
-single dispatch behavior.
+**Owns:** workflow DAG validation; one durable run/node state authority;
+dependency release; content-derived workflow, task, source, and persistent
+session identity; one run-adjacent, machine-wide file lease; operator-confirmed
+`start`/`resume`; structured real-mailbox result reconciliation; and persisted
+idempotency records. The only public declarative entry is
+`winsmux pipeline --workflow-action start|resume`; `task-run` and every
+mailbox channel, including names beginning with `workflow-`, retain their
+legacy contracts. An installed internal `team-pipeline.ps1` result adapter
+derives the complete mailbox envelope from durable run/node state. The same
+adapter and the existing guarded send remain the only result and dispatch
+behaviors.
 
 **Does not own:** recipe parsing beyond consuming TASK-658's normalized plan,
-repository context selection, gallery content, or final desktop/CLI parity.
+repository context selection, gallery content, final desktop/CLI parity,
+public cancel recovery, a separate proof store, cleanup of unrelated runs,
+declared rollback, or a filesystem-sandbox guarantee.
 
 **Acceptance gate:**
 
@@ -422,11 +429,15 @@ repository context selection, gallery content, or final desktop/CLI parity.
 - an interruption is simulated at every side-effect boundary and resume
   continues only unfinished nodes;
 - repeating the same idempotency key cannot repeat a completed side effect;
-- ambiguous `dispatching`/`running` state becomes `blocked`, not guessed
-  success or failure;
-- cleanup can itself be interrupted and resumed, and each compensation runs at
-  most once;
-- completed/cancelled/rolled-back runs reject automatic resume; and
+- ambiguous, missing, malformed, or identity-mismatched mailbox evidence makes
+  `dispatching`/`running` state `blocked` or rejected, never guessed success;
+- every terminal node is bidirectionally bound to exactly one admitted durable
+  mailbox proof, and every admitted proof is owned by exactly one terminal node;
+- the selected project and exact session identity are carried to the child
+  process and reverified immediately before every pane submission;
+- duplicate concurrent `start`/`resume` for one project/run is rejected before
+  another dispatch;
+- terminal runs reject resume; and
 - the existing non-declarative team pipeline still passes its focused tests
   and uses the same operator approval/review boundaries.
 

--- a/install.ps1
+++ b/install.ps1
@@ -259,6 +259,7 @@ function Install-OrchestraSupportScripts {
     Download-File "winsmux-core/scripts/common-contract.generated.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "common-contract.generated.ps1")
     Download-File "winsmux-core/scripts/control-plane-commands.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "control-plane-commands.ps1")
     Download-File "winsmux-core/scripts/control-plane-dispatch.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "control-plane-dispatch.ps1")
+    Download-File "winsmux-core/scripts/declarative-workflow.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "declarative-workflow.ps1")
     Download-File "winsmux-core/scripts/conflict-preflight.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "conflict-preflight.ps1")
     Download-File "winsmux-core/scripts/operator-poll.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "operator-poll.ps1")
     Download-File "winsmux-core/scripts/doctor.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "doctor.ps1")
@@ -320,6 +321,7 @@ function Remove-ProfileExcludedSupportScripts {
                 "conflict-preflight.ps1",
                 "control-plane-commands.ps1",
                 "control-plane-dispatch.ps1",
+                "declarative-workflow.ps1",
                 "dispatch-router.ps1",
                 "operator-poll.ps1",
                 "doctor.ps1",

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -4387,6 +4387,7 @@ function Resolve-SendInvocationArguments {
     param([Parameter(Mandatory = $true)][string[]]$Arguments)
 
     $taskSlug = ''
+    $workflowPromptStdin = $false
     $messageParts = New-Object System.Collections.Generic.List[string]
     for ($index = 0; $index -lt $Arguments.Count; $index++) {
         $token = [string]$Arguments[$index]
@@ -4403,13 +4404,27 @@ function Resolve-SendInvocationArguments {
         if ($token -eq '--delivery-class') {
             throw '--delivery-class is internal-only and cannot be supplied through argv'
         }
+        if ($token -eq '--workflow-prompt-stdin') {
+            if ($workflowPromptStdin) {
+                throw 'workflow_dispatch_transport_invalid: duplicate workflow prompt stdin marker.'
+            }
+            $workflowPromptStdin = $true
+            continue
+        }
 
         $messageParts.Add($token) | Out-Null
     }
+    if ($workflowPromptStdin -and (
+            $messageParts.Count -gt 0 -or
+            -not [string]::IsNullOrWhiteSpace($taskSlug)
+        )) {
+        throw 'workflow_dispatch_transport_invalid: workflow prompt stdin cannot be mixed with message argv.'
+    }
 
     return [ordered]@{
-        TaskSlug     = $taskSlug
-        MessageParts = @($messageParts)
+        TaskSlug            = $taskSlug
+        MessageParts        = @($messageParts)
+        WorkflowPromptStdin = $workflowPromptStdin
     }
 }
 
@@ -4603,6 +4618,29 @@ function Invoke-Send {
     $resolvedSendArguments = Resolve-SendInvocationArguments -Arguments $SendArguments
     $taskSlug = [string]$resolvedSendArguments['TaskSlug']
     $messageParts = @($resolvedSendArguments['MessageParts'])
+    $workflowPromptStdin = [bool]$resolvedSendArguments['WorkflowPromptStdin']
+
+    if ($workflowPromptStdin) {
+        $workflowAuthorityValues = @(
+            [string]$env:WINSMUX_INTERNAL_WORKFLOW_PROJECT_DIR,
+            [string]$env:WINSMUX_INTERNAL_WORKFLOW_SESSION_NAME,
+            [string]$env:WINSMUX_INTERNAL_WORKFLOW_GENERATION_ID,
+            [string]$env:WINSMUX_INTERNAL_WORKFLOW_SERVER_SESSION_ID
+        )
+        if (@(
+                $workflowAuthorityValues |
+                    Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+            ).Count -ne $workflowAuthorityValues.Count) {
+            throw 'workflow_dispatch_transport_invalid: workflow prompt stdin requires the complete authority tuple.'
+        }
+        Assert-WinsmuxWorkflowDispatchAuthority -ProjectDir (Get-Location).Path
+        [Console]::InputEncoding = [System.Text.UTF8Encoding]::new($false, $true)
+        $stdinPrompt = [Console]::In.ReadToEnd()
+        if ([string]::IsNullOrEmpty($stdinPrompt)) {
+            throw 'workflow_dispatch_transport_invalid: workflow prompt stdin is empty.'
+        }
+        $messageParts = @($stdinPrompt)
+    }
 
     if ($messageParts.Count -lt 1) {
         Stop-WithError "usage: winsmux send <target> <text>"

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -4801,6 +4801,7 @@ function Invoke-Send {
             -RuntimeOperation $sendRuntimeOperation -ExpectedGenerationId $sendExpectedGenerationId
 
         if ($transportPlan['Mode'] -eq 'codex_exec_file') {
+            Assert-WinsmuxWorkflowDispatchAuthority -ProjectDir $projectDir
             Send-TextToPane -PaneId $paneId -CommandText ([string]$transportPlan['ExecInstruction']) `
                 -RuntimeProjectDir $sendRuntimeProjectDir -RuntimeOperation $sendRuntimeOperation `
                 -ExpectedGenerationId $sendExpectedGenerationId -DeliveryState $deliveryState
@@ -4811,6 +4812,7 @@ function Invoke-Send {
             Write-Warning ("send target '{0}' used prompt_transport={1}; wrote full text to {2} and sent a prompt-file pointer instead." -f $SendTarget, $transportPlan['PromptTransport'], $transportPlan['PromptPath'])
         }
 
+        Assert-WinsmuxWorkflowDispatchAuthority -ProjectDir $projectDir
         Send-ResolvedTransportPlan `
             -PaneId $paneId `
             -TransportPlan $transportPlan `
@@ -4837,6 +4839,78 @@ function Invoke-Send {
         throw
     } finally {
         Exit-SendPromptArtifactCheckpoint -Checkpoint $artifactCheckpoint
+    }
+}
+
+function Assert-WinsmuxWorkflowDispatchAuthority {
+    param([Parameter(Mandatory = $true)][string]$ProjectDir)
+
+    $expected = [ordered]@{
+        project_dir = [string]$env:WINSMUX_INTERNAL_WORKFLOW_PROJECT_DIR
+        session_name = [string]$env:WINSMUX_INTERNAL_WORKFLOW_SESSION_NAME
+        generation_id = [string]$env:WINSMUX_INTERNAL_WORKFLOW_GENERATION_ID
+        server_session_id = [string]$env:WINSMUX_INTERNAL_WORKFLOW_SERVER_SESSION_ID
+    }
+    $present = @(
+        $expected.Values |
+            Where-Object { -not [string]::IsNullOrWhiteSpace([string]$_) }
+    ).Count
+    if ($present -eq 0) {
+        return
+    }
+    if ($present -ne $expected.Count) {
+        throw 'workflow_dispatch_authority_changed: incomplete workflow authority tuple.'
+    }
+
+    $normalizePath = {
+        param([Parameter(Mandatory = $true)][string]$Value)
+
+        $normalized = [IO.Path]::GetFullPath($Value)
+        if ($normalized.StartsWith('\\?\UNC\', [StringComparison]::OrdinalIgnoreCase)) {
+            $normalized = '\\' + $normalized.Substring(8)
+        } elseif ($normalized.StartsWith('\\?\', [StringComparison]::OrdinalIgnoreCase)) {
+            $normalized = $normalized.Substring(4)
+        }
+        $trimmed = $normalized.TrimEnd(
+            [IO.Path]::DirectorySeparatorChar,
+            [IO.Path]::AltDirectorySeparatorChar
+        )
+        if ($trimmed -match '^[A-Za-z]:$') {
+            $trimmed += [IO.Path]::DirectorySeparatorChar
+        }
+        return $trimmed
+    }
+
+    $expectedProject = & $normalizePath $expected.project_dir
+    $currentProject = & $normalizePath $ProjectDir
+    if (-not [string]::Equals(
+            $expectedProject,
+            $currentProject,
+            [StringComparison]::OrdinalIgnoreCase)) {
+        throw 'workflow_dispatch_authority_changed: selected project changed before pane submission.'
+    }
+    if (-not (Get-Command Get-WinsmuxManifest -CommandType Function -ErrorAction SilentlyContinue) -or
+        -not (Get-Command Get-WinsmuxVerifiedManifestIdentity -CommandType Function -ErrorAction SilentlyContinue)) {
+        throw 'workflow_dispatch_authority_changed: verified manifest helpers are unavailable.'
+    }
+
+    $identity = Get-WinsmuxVerifiedManifestIdentity -Manifest (
+        Get-WinsmuxManifest -ProjectDir $currentProject
+    )
+    if ($null -eq $identity -or
+        -not [string]::Equals(
+            [string]$identity.session_name,
+            $expected.session_name,
+            [StringComparison]::Ordinal) -or
+        -not [string]::Equals(
+            [string]$identity.generation_id,
+            $expected.generation_id,
+            [StringComparison]::Ordinal) -or
+        -not [string]::Equals(
+            [string]$identity.server_session_id,
+            $expected.server_session_id,
+            [StringComparison]::Ordinal)) {
+        throw 'workflow_dispatch_authority_changed: verified session identity changed before pane submission.'
     }
 }
 
@@ -18067,8 +18141,9 @@ promote-tactic <run_id> [--title <text>] [--kind <playbook|prewarm|verification>
   signal <channel>          Send signal to unblock a waiting process
   watch <label> [silence_s] [timeout_s]  Block until pane output is silent
   dispatch-route <text>   Route text to appropriate pane by keyword detection
-  pipeline <task>       Run plan-exec-verify-fix loop for a task
-  task-run <task>       Alias for pipeline; one-shot orchestration entrypoint
+  pipeline <task>       Run the legacy plan-exec-verify-fix loop for a task
+  pipeline --workflow-action start|resume ...  Run or resume a durable declarative workflow
+  task-run <task>       Alias for pipeline; one-shot orchestration entrypoint (legacy task bytes only)
   builder-queue <action> [args]  Manage Builder queue and auto-dispatch next work
   orchestra-smoke [--json] [--auto-start] [--project-dir <path>]  Report structured startup contract + UI attach state (use --auto-start to start if needed)
   orchestra-attach [--json] [--project-dir <path>]  Launch a visible attach window for an existing orchestra session
@@ -18335,12 +18410,13 @@ function Invoke-MailboxCreate {
 
 function Invoke-MailboxSend {
     if (-not $Target) { Stop-WithError "usage: winsmux mailbox-send <channel> <json>" }
-    if (-not $Rest -or $Rest.Count -eq 0) {
+    $mailboxArguments = @($Rest)
+    if ($mailboxArguments.Count -eq 0) {
         Stop-WithError "usage: winsmux mailbox-send <channel> <json>"
     }
 
     $pipeName = Get-MailboxPipeName $Target
-    $payload = $Rest -join ' '
+    $payload = $mailboxArguments -join ' '
 
     # Validate JSON
     try {
@@ -18580,7 +18656,7 @@ switch ($Command) {
     'dispatch-task'   { Invoke-WinsmuxDispatchTaskCommand -BridgeScriptRoot $PSScriptRoot -CommandTarget $Target -CommandRest $Rest }
     'dispatch-route'  { Invoke-WinsmuxDispatchRouteCommand -BridgeScriptRoot $PSScriptRoot -CommandTarget $Target -CommandRest $Rest }
     'task-split'      { Invoke-WinsmuxTaskSplitCommand -BridgeScriptRoot $PSScriptRoot -CommandTarget $Target -CommandRest $Rest }
-    'pipeline'        { Invoke-WinsmuxTeamPipelineCommand -BridgeScriptRoot $PSScriptRoot -CommandTarget $Target -CommandRest $Rest }
+    'pipeline'        { Invoke-WinsmuxTeamPipelineCommand -BridgeScriptRoot $PSScriptRoot -CommandTarget $Target -CommandRest $Rest -AllowDeclarativeWorkflow }
     'task-run'        { Invoke-WinsmuxTeamPipelineCommand -BridgeScriptRoot $PSScriptRoot -CommandTarget $Target -CommandRest $Rest }
     'builder-queue'   { Invoke-WinsmuxBuilderQueueCommand -BridgeScriptRoot $PSScriptRoot -CommandTarget $Target -CommandRest $Rest }
     'orchestra-smoke' { Invoke-WinsmuxOrchestraSmokeCommand -BridgeScriptRoot $PSScriptRoot -CommandTarget $Target -CommandRest $Rest }

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -4827,13 +4827,17 @@ function Invoke-Send {
     } catch {
         $failureMessage = [string]$_.Exception.Message
         $submissionCommitted = [bool](Get-SendConfigValue -InputObject $deliveryState -Name 'SubmissionCommitted' -Default $false)
+        $preSubmissionRefusal = (
+            $failureMessage -match '^runtime dispatch refused \([^)]+\):' -or
+            $failureMessage -match '^workflow_dispatch_authority_changed:'
+        )
         if ($null -ne $context -and $materializationBegan -and -not $submissionCommitted -and
-            $failureMessage -match '^runtime dispatch refused \([^)]+\):') {
+            $preSubmissionRefusal) {
             $materializedPromptPath = if ($null -eq $transportPlan) { '' } else { [string]$transportPlan['PromptPath'] }
             try {
                 Restore-SendPromptArtifactCheckpoint -Checkpoint $artifactCheckpoint -MaterializedPromptPath $materializedPromptPath
             } catch {
-                Write-Warning ("send artifact rollback failed after runtime refusal: {0}" -f $_.Exception.Message)
+                Write-Warning ("send artifact rollback failed after pre-submission refusal: {0}" -f $_.Exception.Message)
             }
         }
         throw

--- a/tests/DeclarativeWorkflow.Tests.ps1
+++ b/tests/DeclarativeWorkflow.Tests.ps1
@@ -75,6 +75,7 @@ BeforeAll {
             workflow = [ordered]@{
                 schema_version = 1
                 workflow_id = 'bugfix'
+                recipe_ref = 'bugfix-two-slot'
                 run_id = $RunId
                 topological_order = @($nodes | ForEach-Object { $_.node_id })
                 nodes = $nodes
@@ -683,7 +684,7 @@ Describe 'TASK-659 v0.36.30 production-path closure' {
         $consumed.Count | Should -Be 1
     }
 
-    It 'DW04 maps an exact nonzero mailbox result to failed without releasing or redispatching a dependent' {
+    It 'DW04 keeps failure resumable until every dispatched sibling settles and never releases a dependent' {
         Assert-Task659RuntimeLoaded
         $fixture = New-Task659Fixture -Name 'dw04' -RunId 'run-dw04'
         $null = Invoke-Task659Start -Fixture $fixture
@@ -699,6 +700,63 @@ Describe 'TASK-659 v0.36.30 production-path closure' {
         $state.nodes.build.exit_code | Should -Be 23
         $state.nodes.verify.state | Should -Be 'pending'
         $fixture.Dispatches.Count | Should -Be 1
+
+        $parallelCases = @(
+            [ordered]@{
+                name = 'failure-first'
+                first_outcome = 'failed'
+                first_exit_code = 23
+                second_outcome = 'succeeded'
+                second_exit_code = 0
+            },
+            [ordered]@{
+                name = 'success-first'
+                first_outcome = 'succeeded'
+                first_exit_code = 0
+                second_outcome = 'failed'
+                second_exit_code = 29
+            }
+        )
+        foreach ($case in $parallelCases) {
+            $parallel = New-Task659Fixture `
+                -Name "dw04-$($case.name)" `
+                -RunId "run-dw04-$($case.name)"
+            $parallel.Plan.workflow.nodes[1].depends_on = @()
+            $null = Invoke-Task659Start -Fixture $parallel
+            $parallel.Dispatches.Count | Should -Be 2
+            $parallelState = Read-DeclarativeWorkflowRunState `
+                -ProjectDir $parallel.ProjectDir -RunId $parallel.RunId
+            $parallelState.nodes.build.state | Should -BeExactly 'running'
+            $parallelState.nodes.verify.state | Should -BeExactly 'running'
+
+            $first = Send-Task659InternalResult `
+                -Fixture $parallel `
+                -NodeId build `
+                -Outcome $case.first_outcome `
+                -ExitCode $case.first_exit_code
+            $first.ExitCode | Should -Be 0 -Because $first.Output
+            $waiting = Invoke-Task659Resume -Fixture $parallel
+            $waiting.state | Should -BeExactly 'blocked'
+            $waiting.nodes.build.state | Should -BeExactly $case.first_outcome
+            $waiting.nodes.verify.state | Should -BeExactly 'blocked'
+            $parallel.Dispatches.Count | Should -Be 2
+            (Get-Task659MailboxFiles -Fixture $parallel -State consumed).Count |
+                Should -Be 1
+
+            $late = Send-Task659InternalResult `
+                -Fixture $parallel `
+                -NodeId verify `
+                -Outcome $case.second_outcome `
+                -ExitCode $case.second_exit_code
+            $late.ExitCode | Should -Be 0 -Because $late.Output
+            $settled = Invoke-Task659Resume -Fixture $parallel
+            $settled.state | Should -BeExactly 'failed'
+            $settled.nodes.build.state | Should -BeExactly $case.first_outcome
+            $settled.nodes.verify.state | Should -BeExactly $case.second_outcome
+            $parallel.Dispatches.Count | Should -Be 2
+            (Get-Task659MailboxFiles -Fixture $parallel -State consumed).Count |
+                Should -Be 2
+        }
     }
 
     It 'DW05 rejects cancel retry rollback and unknown actions before any product subprocess or mutable sink' {
@@ -755,7 +813,7 @@ Describe 'TASK-659 v0.36.30 production-path closure' {
         Should -Invoke Invoke-WinsmuxControlPlaneScript -Times 0 -Exactly
     }
 
-    It 'DW07 rejects a noncanonical DAG from workspace-plan before the lease state mailbox or dispatch sinks' {
+    It 'DW07 rejects a noncanonical DAG or mismatched recipe binding before the lease state mailbox or dispatch sinks' {
         Assert-Task659RuntimeLoaded
         $fixture = New-Task659Fixture -Name 'dw07' -RunId 'run-dw07'
         $workspacePlanProbe = [PSCustomObject]@{ Count = 0 }
@@ -780,6 +838,27 @@ Describe 'TASK-659 v0.36.30 production-path closure' {
         Test-Path -LiteralPath $statePath | Should -BeFalse
         (Get-Task659MailboxFiles -Fixture $fixture -State pending).Count | Should -Be 0
         $fixture.Dispatches.Count | Should -Be 0
+
+        $binding = New-Task659Fixture -Name 'dw07-binding' -RunId 'run-dw07-binding'
+        $binding.Plan.workflow.recipe_ref = 'review-one-slot'
+        $bindingPlanInvoker = {
+            param([string]$RecipeId, [string]$WorkflowId, [string]$RunId, [string]$ProjectDir)
+            return $binding.Plan
+        }.GetNewClosure()
+        $bindingStatePath = Get-DeclarativeWorkflowRunStatePath `
+            -ProjectDir $binding.ProjectDir -RunId $binding.RunId
+        {
+            Invoke-DeclarativeWorkflow `
+                -Action start -RecipeId 'bugfix-two-slot' -WorkflowId 'bugfix' `
+                -RunId $binding.RunId -TaskFile $binding.TaskFile -ProjectDir $binding.ProjectDir `
+                -WorkspacePlanInvoker $bindingPlanInvoker `
+                -ManifestIdentityReader $binding.ManifestIdentityReader `
+                -SourceHeadReader $binding.SourceHeadReader `
+                -DispatchNode $binding.DispatchNode
+        } | Should -Throw '*recipe*'
+        Test-Path -LiteralPath $bindingStatePath | Should -BeFalse
+        (Get-Task659MailboxFiles -Fixture $binding -State pending).Count | Should -Be 0
+        $binding.Dispatches.Count | Should -Be 0
     }
 
     It 'DW08 rejects task source and manifest identity drift before mailbox consume state write or dispatch' {
@@ -1539,15 +1618,170 @@ try { Start-Sleep -Seconds 10 } finally { `$lease.Dispose() }
         $bridgeSource | Should -Not -Match "(?m)^\s*'workflow-result'\s*\{"
     }
 
-    It 'DW19 derives one exact durable envelope in the installed internal result adapter and exposes no public result command' {
+    It 'DW19 carries an executable internal result contract through default guarded dispatch and exposes no public result command' {
         Assert-Task659RuntimeLoaded
         $fixture = New-Task659Fixture -Name 'dw19' -RunId 'run-dw19'
-        $null = Invoke-Task659Start -Fixture $fixture
-        $run = Read-DeclarativeWorkflowRunState -ProjectDir $fixture.ProjectDir -RunId $fixture.RunId
+        $planPath = Join-Path $fixture.ProjectDir 'dw19-plan.json'
+        $runnerPath = Join-Path $fixture.ProjectDir 'dw19-default-dispatch.ps1'
+        $teamPipelinePath = [IO.Path]::GetFullPath($script:Task659TeamPipelinePath)
+        $fixtureProjectDir = [IO.Path]::GetFullPath($fixture.ProjectDir)
+        $fixtureRunId = [string]$fixture.RunId
+        $fixtureTaskFile = [IO.Path]::GetFullPath($fixture.TaskFile)
+        [IO.File]::WriteAllText(
+            $planPath,
+            ($fixture.Plan | ConvertTo-Json -Depth 50 -Compress),
+            [Text.UTF8Encoding]::new($false)
+        )
+        $runnerSource = @'
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string]$TeamPipelinePath,
+    [Parameter(Mandatory = $true)][string]$PlanPath,
+    [Parameter(Mandatory = $true)][string]$ProjectDir,
+    [Parameter(Mandatory = $true)][string]$RunId,
+    [Parameter(Mandatory = $true)][string]$TaskFile,
+    [ValidateSet('start', 'resume')][string]$Action
+)
 
-        $send = Send-Task659InternalResult -Fixture $fixture -Outcome succeeded -ExitCode 0
-        $send.ExitCode | Should -Be 0 -Because $send.Output
-        $receipt = $send.Output | ConvertFrom-Json
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+[Console]::OutputEncoding = [Text.Encoding]::UTF8
+
+$requestedTeamPipelinePath = $TeamPipelinePath
+$requestedPlanPath = $PlanPath
+$requestedProjectDir = $ProjectDir
+$requestedRunId = $RunId
+$requestedTaskFile = $TaskFile
+$requestedAction = $Action
+
+. $requestedTeamPipelinePath
+
+$script:CapturedWorkflowDispatches = [Collections.Generic.List[object]]::new()
+function Invoke-TeamPipelineBridge {
+    param(
+        [string[]]$Arguments,
+        [switch]$AllowFailure,
+        [string]$ProjectDir,
+        [string]$ExpectedSessionName,
+        [string]$ExpectedGenerationId,
+        [string]$ExpectedServerSessionId
+    )
+
+    $script:CapturedWorkflowDispatches.Add([ordered]@{
+            arguments = @($Arguments)
+            project_dir = $ProjectDir
+            session_name = $ExpectedSessionName
+            generation_id = $ExpectedGenerationId
+            server_session_id = $ExpectedServerSessionId
+        }) | Out-Null
+    return [PSCustomObject]@{ ExitCode = 0; Output = '' }
+}
+
+$plan = Get-Content -Raw -LiteralPath $requestedPlanPath |
+    ConvertFrom-Json -AsHashtable -Depth 50
+$identity = [ordered]@{
+    session_name = 'winsmux-orchestra'
+    generation_id = 'generation-dw'
+    server_session_id = '$659'
+}
+$workspacePlanInvoker = {
+    param(
+        [string]$RecipeId,
+        [string]$WorkflowId,
+        [string]$RequestedRunId,
+        [string]$RequestedProjectDir
+    )
+    return $plan
+}.GetNewClosure()
+$manifestIdentityReader = {
+    param([string]$RequestedProjectDir)
+    return $identity
+}.GetNewClosure()
+$sourceHeadReader = {
+    param([string]$RequestedProjectDir)
+    return 'a' * 40
+}.GetNewClosure()
+$invokeParameters = @{
+    Action = $requestedAction
+    RunId = $requestedRunId
+    TaskFile = $requestedTaskFile
+    ProjectDir = $requestedProjectDir
+    WorkspacePlanInvoker = $workspacePlanInvoker
+    ManifestIdentityReader = $manifestIdentityReader
+    SourceHeadReader = $sourceHeadReader
+}
+if ($requestedAction -ceq 'start') {
+    $invokeParameters['RecipeId'] = 'bugfix-two-slot'
+    $invokeParameters['WorkflowId'] = 'bugfix'
+}
+$result = Invoke-DeclarativeWorkflow @invokeParameters
+[ordered]@{
+    result = $result
+    calls = @($script:CapturedWorkflowDispatches)
+} | ConvertTo-Json -Depth 50 -Compress
+'@
+        [IO.File]::WriteAllText(
+            $runnerPath,
+            $runnerSource,
+            [Text.UTF8Encoding]::new($false)
+        )
+        $invokeDefaultRuntime = {
+            param([ValidateSet('start', 'resume')][string]$Action)
+
+            $output = & pwsh -NoProfile -File $runnerPath `
+                -TeamPipelinePath $teamPipelinePath `
+                -PlanPath $planPath `
+                -ProjectDir $fixtureProjectDir `
+                -RunId $fixtureRunId `
+                -TaskFile $fixtureTaskFile `
+                -Action $Action 2>&1
+            $exitCode = $LASTEXITCODE
+            $text = ($output | Out-String).Trim()
+            $exitCode | Should -Be 0 -Because $text
+            return $text | ConvertFrom-Json -Depth 50
+        }.GetNewClosure()
+
+        $startCapture = & $invokeDefaultRuntime -Action start
+        $run = Read-DeclarativeWorkflowRunState -ProjectDir $fixture.ProjectDir -RunId $fixture.RunId
+        @($startCapture.calls).Count | Should -Be 1
+        $firstDispatch = $startCapture.calls[0]
+        $firstDispatch.arguments[0] | Should -BeExactly 'send'
+        $firstDispatch.arguments[1] | Should -BeExactly 'builder-1'
+        $prompt = [string]$firstDispatch.arguments[2]
+        $prompt.Substring(0, $fixture.TaskText.Length) |
+            Should -BeExactly $fixture.TaskText
+        $callbackMatch = [regex]::Match(
+            $prompt,
+            '(?s)<winsmux-workflow-result-v1>\r?\n(?<json>\{[^\r\n]+\})\r?\n'
+        )
+        $callbackMatch.Success | Should -BeTrue -Because $prompt
+        $callback = $callbackMatch.Groups['json'].Value |
+            ConvertFrom-Json
+        [int]$callback.schema_version | Should -Be 1
+        [string]$callback.adapter_path |
+            Should -BeExactly ([IO.Path]::GetFullPath($script:Task659TeamPipelinePath))
+        [string]$callback.project_dir |
+            Should -BeExactly ([IO.Path]::GetFullPath($fixture.ProjectDir))
+        [string]$callback.run_id | Should -BeExactly $fixture.RunId
+        [string]$callback.node_id | Should -BeExactly 'build'
+        [string]$callback.task_digest | Should -BeExactly ([string]$run.task_digest)
+        [string]$callback.workflow_fingerprint |
+            Should -BeExactly ([string]$run.workflow_fingerprint)
+        $prompt | Should -Match '(?m)^Success command: .* -WorkflowResultOutcome succeeded -WorkflowResultExitCode 0 -AsJson$'
+        $prompt | Should -Match '(?m)^Failure command: .* -WorkflowResultOutcome failed -WorkflowResultExitCode 1 -AsJson$'
+
+        $adapterOutput = & pwsh -NoProfile -File ([string]$callback.adapter_path) `
+            -WorkflowResult `
+            -RunId ([string]$callback.run_id) `
+            -WorkflowResultNodeId ([string]$callback.node_id) `
+            -WorkflowResultOutcome succeeded `
+            -WorkflowResultExitCode 0 `
+            -ProjectDir ([string]$callback.project_dir) `
+            -AsJson 2>&1
+        $adapterExitCode = $LASTEXITCODE
+        $adapterText = ($adapterOutput | Out-String).Trim()
+        $adapterExitCode | Should -Be 0 -Because $adapterText
+        $receipt = $adapterText | ConvertFrom-Json
         $receipt.accepted | Should -BeTrue
         $pending = Get-Task659MailboxFiles -Fixture $fixture -State pending
         $pending.Count | Should -Be 1
@@ -1581,11 +1815,13 @@ try { Start-Sleep -Seconds 10 } finally { `$lease.Dispose() }
             [Text.UTF8Encoding]::new($false, $true)
         )
         $bridgeSource | Should -Not -Match "(?m)^\s*'workflow-result'\s*\{"
-        $null = Invoke-Task659Resume -Fixture $fixture
+        $resumeCapture = & $invokeDefaultRuntime -Action resume
         $after = Read-DeclarativeWorkflowRunState -ProjectDir $fixture.ProjectDir -RunId $fixture.RunId
         $after.nodes.build.state | Should -BeExactly 'succeeded'
         $after.nodes.verify.state | Should -BeExactly 'running'
-        $fixture.Dispatches.Count | Should -Be 2
+        @($resumeCapture.calls).Count | Should -Be 1
+        [string]$resumeCapture.calls[0].arguments[2] |
+            Should -Match '"node_id":"verify"'
     }
 
     It 'DW20 preserves one exact result when the dispatch owner exits after the submission effect but before running is durable' {

--- a/tests/DeclarativeWorkflow.Tests.ps1
+++ b/tests/DeclarativeWorkflow.Tests.ps1
@@ -612,6 +612,174 @@ Invoke-DeclarativeWorkflow `
         }
         return [string]$functionAst.Extent.Text
     }
+
+    function New-Task659WorkspacePlanShim {
+        param(
+            [Parameter(Mandatory = $true)][string]$Directory,
+            [Parameter(Mandatory = $true)][string]$FileName
+        )
+
+        [IO.Directory]::CreateDirectory($Directory) | Out-Null
+        $path = Join-Path $Directory $FileName
+        $source = @'
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+[Console]::OutputEncoding = [Text.UTF8Encoding]::new($false)
+
+if ([string]::IsNullOrWhiteSpace([string]$env:TASK659_WORKSPACE_PLAN_LOG)) {
+    throw 'TASK659_WORKSPACE_PLAN_LOG is required.'
+}
+$arguments = @($args | ForEach-Object { [string]$_ })
+$record = [ordered]@{
+    command = [string]$MyInvocation.MyCommand.Name
+    arguments = $arguments
+}
+[IO.File]::AppendAllText(
+    $env:TASK659_WORKSPACE_PLAN_LOG,
+    ($record | ConvertTo-Json -Depth 10 -Compress) + [Environment]::NewLine,
+    [Text.UTF8Encoding]::new($false)
+)
+if ($arguments.Count -lt 1 -or $arguments[0] -cne 'workspace-plan') {
+    throw 'Expected workspace-plan.'
+}
+$values = [ordered]@{}
+for ($index = 1; $index -lt $arguments.Count;) {
+    if ($arguments[$index] -ceq '--json') {
+        $values['--json'] = $true
+        $index++
+        continue
+    }
+    if ($index + 1 -ge $arguments.Count) {
+        throw "Missing value for $($arguments[$index])."
+    }
+    $values[$arguments[$index]] = $arguments[$index + 1]
+    $index += 2
+}
+foreach ($name in @('--recipe-id', '--workflow-id', '--run-id', '--project-dir')) {
+    if (-not $values.Contains($name)) {
+        throw "Missing $name."
+    }
+}
+$runId = [string]$values['--run-id']
+$plan = [ordered]@{
+    schema_version = 1
+    config_fingerprint = 'sha256:' + ('1' * 64)
+    recipe_id = [string]$values['--recipe-id']
+    workflow_id = [string]$values['--workflow-id']
+    panes = @([ordered]@{ pane_key = 'implement'; slot_id = 'builder-1' })
+    resolved_bindings = [ordered]@{ implement = 'builder-1' }
+    workflow = [ordered]@{
+        schema_version = 1
+        workflow_id = [string]$values['--workflow-id']
+        recipe_ref = [string]$values['--recipe-id']
+        run_id = $runId
+        topological_order = @('build')
+        nodes = @(
+            [ordered]@{
+                node_id = 'build'
+                pane_ref = 'builder-1'
+                depends_on = @()
+                action = 'operator-dispatch'
+                idempotency_key = "$runId`:build"
+            }
+        )
+    }
+}
+$global:LASTEXITCODE = 0
+$plan | ConvertTo-Json -Depth 30 -Compress
+'@
+        [IO.File]::WriteAllText(
+            $path,
+            $source,
+            [Text.UTF8Encoding]::new($false)
+        )
+        return $path
+    }
+
+    function Get-Task659WorkspacePlanInvocations {
+        param([Parameter(Mandatory = $true)][string]$Path)
+
+        if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+            return ,@()
+        }
+        return ,@(
+            Get-Content -LiteralPath $Path -Encoding UTF8 |
+                Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+                ForEach-Object { $_ | ConvertFrom-Json -Depth 20 }
+        )
+    }
+
+    function Invoke-Task659PublicWorkflowProcess {
+        param(
+            [Parameter(Mandatory = $true)]
+            [ValidateSet('start', 'resume')]
+            [string]$Action,
+            [Parameter(Mandatory = $true)][string]$RunId,
+            [Parameter(Mandatory = $true)][string]$TaskFile,
+            [Parameter(Mandatory = $true)][string]$ProjectDir
+        )
+
+        $arguments = @(
+            '-NoProfile',
+            '-File',
+            $script:Task659BridgePath,
+            'pipeline',
+            '--workflow-action',
+            $Action
+        )
+        if ($Action -ceq 'start') {
+            $arguments += @(
+                '--recipe-id',
+                'bugfix-two-slot',
+                '--workflow-id',
+                'bugfix'
+            )
+        }
+        $arguments += @(
+            '--run-id',
+            $RunId,
+            '--task-file',
+            $TaskFile,
+            '--project-dir',
+            $ProjectDir,
+            '--json'
+        )
+
+        $startInfo = [Diagnostics.ProcessStartInfo]::new()
+        $startInfo.FileName = (Get-Command pwsh -ErrorAction Stop).Source
+        $startInfo.UseShellExecute = $false
+        $startInfo.CreateNoWindow = $true
+        $startInfo.RedirectStandardOutput = $true
+        $startInfo.RedirectStandardError = $true
+        foreach ($argument in $arguments) {
+            $null = $startInfo.ArgumentList.Add([string]$argument)
+        }
+        $process = [Diagnostics.Process]::new()
+        $process.StartInfo = $startInfo
+        try {
+            if (-not $process.Start()) {
+                throw 'TASK-659 public workflow process did not start.'
+            }
+            $stdout = $process.StandardOutput.ReadToEndAsync()
+            $stderr = $process.StandardError.ReadToEndAsync()
+            if (-not $process.WaitForExit(30000)) {
+                $process.Kill($true)
+                $null = $process.WaitForExit(5000)
+                throw 'TASK-659 public workflow process timed out.'
+            }
+            return [PSCustomObject]@{
+                ExitCode = $process.ExitCode
+                Output = (
+                    @(
+                        $stdout.GetAwaiter().GetResult()
+                        $stderr.GetAwaiter().GetResult()
+                    ) -join [Environment]::NewLine
+                ).Trim()
+            }
+        } finally {
+            $process.Dispose()
+        }
+    }
 }
 
 Describe 'TASK-659 v0.36.30 production-path closure' {
@@ -2321,5 +2489,176 @@ $hash = [Security.Cryptography.SHA256]::Create().ComputeHash($payloadBytes)
             Get-Task659Sha256 -Bytes ([Text.UTF8Encoding]::new($false).GetBytes($largeTask))
         )
         $probe.contains_private_marker | Should -BeTrue
+    }
+
+    It 'DW22 carries command-valued RAW and BIN overrides through public start and resume to one exact child planner' {
+        Assert-Task659RuntimeLoaded
+        $shimDir = Join-Path $TestDrive 'dw22-path'
+        $logPath = Join-Path $TestDrive 'dw22-workspace-plan.jsonl'
+        $rawPath = New-Task659WorkspacePlanShim `
+            -Directory $shimDir -FileName 'task659-dw22-raw.ps1'
+        $binPath = New-Task659WorkspacePlanShim `
+            -Directory $shimDir -FileName 'task659-dw22-bin.ps1'
+        $rawCommandName = [IO.Path]::GetFileName($rawPath)
+        $binCommandName = [IO.Path]::GetFileName($binPath)
+        $previousPath = $env:PATH
+        $previousRaw = $env:WINSMUX_RAW_EXE
+        $previousBin = $env:WINSMUX_BIN
+        $previousLog = $env:TASK659_WORKSPACE_PLAN_LOG
+
+        try {
+            $env:PATH = $shimDir + [IO.Path]::PathSeparator + $previousPath
+            $env:TASK659_WORKSPACE_PLAN_LOG = $logPath
+            $env:WINSMUX_RAW_EXE = $rawCommandName
+            $env:WINSMUX_BIN = $binCommandName
+
+            $startProject = Join-Path $TestDrive 'dw22-start'
+            [IO.Directory]::CreateDirectory((Join-Path $startProject '.winsmux')) | Out-Null
+            $startTaskFile = Join-Path $startProject 'task.txt'
+            [IO.File]::WriteAllText(
+                $startTaskFile,
+                'DW22 public start task',
+                [Text.UTF8Encoding]::new($false)
+            )
+            $startStatePath = Get-DeclarativeWorkflowRunStatePath `
+                -ProjectDir $startProject -RunId 'run-dw22-start'
+            $startResult = Invoke-Task659PublicWorkflowProcess `
+                -Action start -RunId 'run-dw22-start' `
+                -TaskFile $startTaskFile -ProjectDir $startProject
+
+            Remove-Item Env:\WINSMUX_RAW_EXE -ErrorAction SilentlyContinue
+            $resumeFixture = New-Task659Fixture `
+                -Name 'dw22-resume' -RunId 'run-dw22-resume'
+            $null = Invoke-Task659Start -Fixture $resumeFixture
+            $resumeStateBefore = Get-Task659StateBytes -Fixture $resumeFixture
+            $resumeResult = Invoke-Task659PublicWorkflowProcess `
+                -Action resume -RunId $resumeFixture.RunId `
+                -TaskFile $resumeFixture.TaskFile -ProjectDir $resumeFixture.ProjectDir
+
+            $invocations = Get-Task659WorkspacePlanInvocations -Path $logPath
+            @($invocations).Count | Should -Be 2
+            $startInvocation = $invocations[0]
+            $resumeInvocation = $invocations[1]
+            $startInvocation.command | Should -BeExactly $rawCommandName
+            $resumeInvocation.command | Should -BeExactly $binCommandName
+
+            $startArguments = @($startInvocation.arguments | ForEach-Object { [string]$_ })
+            $resumeArguments = @($resumeInvocation.arguments | ForEach-Object { [string]$_ })
+            $startArguments[0] | Should -BeExactly 'workspace-plan'
+            $resumeArguments[0] | Should -BeExactly 'workspace-plan'
+            $startArgumentMap = [ordered]@{}
+            for ($index = 1; $index + 1 -lt $startArguments.Count; $index += 2) {
+                $startArgumentMap[$startArguments[$index]] = $startArguments[$index + 1]
+            }
+            $resumeArgumentMap = [ordered]@{}
+            for ($index = 1; $index + 1 -lt $resumeArguments.Count; $index += 2) {
+                $resumeArgumentMap[$resumeArguments[$index]] = $resumeArguments[$index + 1]
+            }
+            $startArgumentMap['--recipe-id'] | Should -BeExactly 'bugfix-two-slot'
+            $startArgumentMap['--workflow-id'] | Should -BeExactly 'bugfix'
+            $startArgumentMap['--run-id'] | Should -BeExactly 'run-dw22-start'
+            $startArgumentMap['--project-dir'] |
+                Should -BeExactly ([IO.Path]::GetFullPath($startProject))
+            $resumeArgumentMap['--run-id'] | Should -BeExactly $resumeFixture.RunId
+            $resumeArgumentMap['--project-dir'] |
+                Should -BeExactly ([IO.Path]::GetFullPath($resumeFixture.ProjectDir))
+
+            $startResult.ExitCode | Should -Not -Be 0
+            $resumeResult.ExitCode | Should -Not -Be 0
+            $startResult.Output | Should -Not -Match 'workflow_plan_unavailable'
+            $resumeResult.Output | Should -Not -Match 'workflow_plan_unavailable'
+            Test-Path -LiteralPath $startStatePath | Should -BeFalse
+            Get-Task659StateBytes -Fixture $resumeFixture | Should -Be $resumeStateBefore
+            (Get-Task659MailboxFiles -Fixture $resumeFixture -State pending).Count |
+                Should -Be 0
+        } finally {
+            $env:PATH = $previousPath
+            if ($null -eq $previousRaw) {
+                Remove-Item Env:\WINSMUX_RAW_EXE -ErrorAction SilentlyContinue
+            } else {
+                $env:WINSMUX_RAW_EXE = $previousRaw
+            }
+            if ($null -eq $previousBin) {
+                Remove-Item Env:\WINSMUX_BIN -ErrorAction SilentlyContinue
+            } else {
+                $env:WINSMUX_BIN = $previousBin
+            }
+            if ($null -eq $previousLog) {
+                Remove-Item Env:\TASK659_WORKSPACE_PLAN_LOG -ErrorAction SilentlyContinue
+            } else {
+                $env:TASK659_WORKSPACE_PLAN_LOG = $previousLog
+            }
+        }
+    }
+
+    It 'DW23 rejects an invalid RAW override before child launch without BIN fallback or state mutation' {
+        Assert-Task659RuntimeLoaded
+        $shimDir = Join-Path $TestDrive 'dw23-path'
+        $logPath = Join-Path $TestDrive 'dw23-workspace-plan.jsonl'
+        $binPath = New-Task659WorkspacePlanShim `
+            -Directory $shimDir -FileName 'task659-dw23-bin.ps1'
+        $binCommandName = [IO.Path]::GetFileName($binPath)
+        $missingCommand = 'task659-dw23-missing-' + [guid]::NewGuid().ToString('N') + '.ps1'
+        $previousPath = $env:PATH
+        $previousRaw = $env:WINSMUX_RAW_EXE
+        $previousBin = $env:WINSMUX_BIN
+        $previousLog = $env:TASK659_WORKSPACE_PLAN_LOG
+
+        try {
+            $env:PATH = $shimDir + [IO.Path]::PathSeparator + $previousPath
+            $env:TASK659_WORKSPACE_PLAN_LOG = $logPath
+            $env:WINSMUX_RAW_EXE = $missingCommand
+            $env:WINSMUX_BIN = $binCommandName
+
+            $startProject = Join-Path $TestDrive 'dw23-start'
+            [IO.Directory]::CreateDirectory((Join-Path $startProject '.winsmux')) | Out-Null
+            $startTaskFile = Join-Path $startProject 'task.txt'
+            [IO.File]::WriteAllText(
+                $startTaskFile,
+                'DW23 public start task',
+                [Text.UTF8Encoding]::new($false)
+            )
+            $startStatePath = Get-DeclarativeWorkflowRunStatePath `
+                -ProjectDir $startProject -RunId 'run-dw23-start'
+            $startResult = Invoke-Task659PublicWorkflowProcess `
+                -Action start -RunId 'run-dw23-start' `
+                -TaskFile $startTaskFile -ProjectDir $startProject
+
+            $resumeFixture = New-Task659Fixture `
+                -Name 'dw23-resume' -RunId 'run-dw23-resume'
+            $null = Invoke-Task659Start -Fixture $resumeFixture
+            $resumeStateBefore = Get-Task659StateBytes -Fixture $resumeFixture
+            $resumeResult = Invoke-Task659PublicWorkflowProcess `
+                -Action resume -RunId $resumeFixture.RunId `
+                -TaskFile $resumeFixture.TaskFile -ProjectDir $resumeFixture.ProjectDir
+
+            $startResult.ExitCode | Should -Not -Be 0
+            $resumeResult.ExitCode | Should -Not -Be 0
+            $startResult.Output | Should -Match 'configured winsmux executable is missing'
+            $resumeResult.Output | Should -Match 'configured winsmux executable is missing'
+            Test-Path -LiteralPath $startStatePath | Should -BeFalse
+            Get-Task659StateBytes -Fixture $resumeFixture | Should -Be $resumeStateBefore
+            Test-Path -LiteralPath $logPath | Should -BeFalse
+            Test-Path -LiteralPath (
+                Join-Path $startProject '.winsmux\workflow-mailbox\run-dw23-start'
+            ) | Should -BeFalse
+        } finally {
+            $env:PATH = $previousPath
+            if ($null -eq $previousRaw) {
+                Remove-Item Env:\WINSMUX_RAW_EXE -ErrorAction SilentlyContinue
+            } else {
+                $env:WINSMUX_RAW_EXE = $previousRaw
+            }
+            if ($null -eq $previousBin) {
+                Remove-Item Env:\WINSMUX_BIN -ErrorAction SilentlyContinue
+            } else {
+                $env:WINSMUX_BIN = $previousBin
+            }
+            if ($null -eq $previousLog) {
+                Remove-Item Env:\TASK659_WORKSPACE_PLAN_LOG -ErrorAction SilentlyContinue
+            } else {
+                $env:TASK659_WORKSPACE_PLAN_LOG = $previousLog
+            }
+        }
     }
 }

--- a/tests/DeclarativeWorkflow.Tests.ps1
+++ b/tests/DeclarativeWorkflow.Tests.ps1
@@ -1,0 +1,1709 @@
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+BeforeAll {
+    $script:Task659RepoRoot = Split-Path -Parent $PSScriptRoot
+    $script:Task659RuntimePath = Join-Path $script:Task659RepoRoot 'winsmux-core\scripts\declarative-workflow.ps1'
+    $script:Task659DispatchPath = Join-Path $script:Task659RepoRoot 'winsmux-core\scripts\control-plane-dispatch.ps1'
+    $script:Task659TeamPipelinePath = Join-Path $script:Task659RepoRoot 'winsmux-core\scripts\team-pipeline.ps1'
+    $script:Task659BridgePath = Join-Path $script:Task659RepoRoot 'scripts\winsmux-core.ps1'
+
+    function Stop-WithError {
+        param([Parameter(Mandatory = $true)][string]$Message)
+        throw $Message
+    }
+
+    . $script:Task659DispatchPath
+    if (Test-Path -LiteralPath $script:Task659RuntimePath -PathType Leaf) {
+        . $script:Task659RuntimePath
+    }
+    if (Test-Path -LiteralPath $script:Task659TeamPipelinePath -PathType Leaf) {
+        . $script:Task659TeamPipelinePath
+    }
+
+    function Assert-Task659RuntimeLoaded {
+        Get-Command Invoke-DeclarativeWorkflow -CommandType Function -ErrorAction Stop | Should -Not -BeNullOrEmpty
+        Get-Command Set-DeclarativeWorkflowRunState -CommandType Function -ErrorAction Stop | Should -Not -BeNullOrEmpty
+        Get-Command Write-DeclarativeWorkflowMailboxResult -CommandType Function -ErrorAction Stop | Should -Not -BeNullOrEmpty
+    }
+
+    function Get-Task659Sha256 {
+        param([Parameter(Mandatory = $true)][byte[]]$Bytes)
+
+        $hash = [Security.Cryptography.SHA256]::Create().ComputeHash($Bytes)
+        return 'sha256:' + (($hash | ForEach-Object { $_.ToString('x2') }) -join '')
+    }
+
+    function New-Task659WorkflowPlan {
+        param(
+            [string]$RunId = 'run-dw',
+            [switch]$SingleNode
+        )
+
+        $nodes = @(
+            [ordered]@{
+                node_id = 'build'
+                pane_ref = 'builder-1'
+                depends_on = @()
+                action = 'operator-dispatch'
+                idempotency_key = "$RunId`:build"
+            }
+        )
+        if (-not $SingleNode) {
+            $nodes += [ordered]@{
+                node_id = 'verify'
+                pane_ref = 'reviewer'
+                depends_on = @('build')
+                action = 'operator-dispatch'
+                idempotency_key = "$RunId`:verify"
+            }
+        }
+
+        return [ordered]@{
+            schema_version = 1
+            config_fingerprint = 'sha256:' + ('1' * 64)
+            recipe_id = 'bugfix-two-slot'
+            workflow_id = 'bugfix'
+            panes = @(
+                [ordered]@{ pane_key = 'implement'; slot_id = 'builder-1' },
+                [ordered]@{ pane_key = 'verify'; slot_id = 'reviewer' }
+            )
+            resolved_bindings = [ordered]@{
+                implement = 'builder-1'
+                verify = 'reviewer'
+            }
+            workflow = [ordered]@{
+                schema_version = 1
+                workflow_id = 'bugfix'
+                run_id = $RunId
+                topological_order = @($nodes | ForEach-Object { $_.node_id })
+                nodes = $nodes
+            }
+        }
+    }
+
+    function New-Task659Fixture {
+        param(
+            [string]$Name,
+            [string]$RunId = 'run-dw',
+            [switch]$SingleNode
+        )
+
+        $projectDir = Join-Path $TestDrive $Name
+        $winsmuxDir = Join-Path $projectDir '.winsmux'
+        [IO.Directory]::CreateDirectory($winsmuxDir) | Out-Null
+        $taskFile = Join-Path $projectDir 'task.txt'
+        $taskText = "TASK-659 durable task $Name"
+        [IO.File]::WriteAllText($taskFile, $taskText, [Text.UTF8Encoding]::new($false))
+        $plan = New-Task659WorkflowPlan -RunId $RunId -SingleNode:$SingleNode
+        $identity = [ordered]@{
+            session_name = 'winsmux-orchestra'
+            generation_id = 'generation-dw'
+            server_session_id = '$659'
+        }
+        $dispatches = [Collections.Generic.List[object]]::new()
+        $workspacePlanInvoker = {
+            param(
+                [string]$RecipeId,
+                [string]$WorkflowId,
+                [string]$RequestedRunId,
+                [string]$RequestedProjectDir
+            )
+            return $plan
+        }.GetNewClosure()
+        $manifestIdentityReader = {
+            param([string]$RequestedProjectDir)
+            return $identity
+        }.GetNewClosure()
+        $sourceHeadReader = {
+            param([string]$RequestedProjectDir)
+            return 'a' * 40
+        }.GetNewClosure()
+        $dispatchNode = {
+            param(
+                [Parameter(Mandatory = $true)]$Node,
+                [Parameter(Mandatory = $true)][string]$TaskContent,
+                [Parameter(Mandatory = $true)]$Run
+            )
+            $statePath = Join-Path $projectDir ".winsmux\workflow-runs\$RunId.json"
+            $stateAtDispatch = [IO.File]::ReadAllText(
+                $statePath,
+                [Text.UTF8Encoding]::new($false, $true)
+            ) | ConvertFrom-Json -Depth 30
+            $dispatches.Add([ordered]@{
+                    node_id = [string]$Node.node_id
+                    pane_ref = [string]$Node.pane_ref
+                    task_content = $TaskContent
+                    state_exists = Test-Path -LiteralPath $statePath
+                    state_at_dispatch = [string]$stateAtDispatch.nodes.([string]$Node.node_id).state
+                }) | Out-Null
+            return [ordered]@{ accepted = $true }
+        }.GetNewClosure()
+
+        return [PSCustomObject]@{
+            ProjectDir = $projectDir
+            TaskFile = $taskFile
+            TaskText = $taskText
+            RunId = $RunId
+            Plan = $plan
+            Identity = $identity
+            Dispatches = $dispatches
+            WorkspacePlanInvoker = $workspacePlanInvoker
+            ManifestIdentityReader = $manifestIdentityReader
+            SourceHeadReader = $sourceHeadReader
+            DispatchNode = $dispatchNode
+        }
+    }
+
+    function Invoke-Task659Start {
+        param([Parameter(Mandatory = $true)]$Fixture)
+
+        return Invoke-DeclarativeWorkflow `
+            -Action start `
+            -RecipeId 'bugfix-two-slot' `
+            -WorkflowId 'bugfix' `
+            -RunId $Fixture.RunId `
+            -TaskFile $Fixture.TaskFile `
+            -ProjectDir $Fixture.ProjectDir `
+            -WorkspacePlanInvoker $Fixture.WorkspacePlanInvoker `
+            -ManifestIdentityReader $Fixture.ManifestIdentityReader `
+            -SourceHeadReader $Fixture.SourceHeadReader `
+            -DispatchNode $Fixture.DispatchNode
+    }
+
+    function Invoke-Task659Resume {
+        param(
+            [Parameter(Mandatory = $true)]$Fixture,
+            [scriptblock]$WorkspacePlanInvoker = $Fixture.WorkspacePlanInvoker,
+            [scriptblock]$ManifestIdentityReader = $Fixture.ManifestIdentityReader,
+            [scriptblock]$SourceHeadReader = $Fixture.SourceHeadReader
+        )
+
+        return Invoke-DeclarativeWorkflow `
+            -Action resume `
+            -RunId $Fixture.RunId `
+            -TaskFile $Fixture.TaskFile `
+            -ProjectDir $Fixture.ProjectDir `
+            -WorkspacePlanInvoker $WorkspacePlanInvoker `
+            -ManifestIdentityReader $ManifestIdentityReader `
+            -SourceHeadReader $SourceHeadReader `
+            -DispatchNode $Fixture.DispatchNode
+    }
+
+    function New-Task659CompletionEnvelope {
+        param(
+            [Parameter(Mandatory = $true)]$Fixture,
+            [Parameter(Mandatory = $true)]$Run,
+            [string]$NodeId = 'build',
+            [ValidateSet('succeeded', 'failed')][string]$Outcome = 'succeeded',
+            [string]$MessageId = 'msg-dw-success',
+            [int]$ExitCode = 0
+        )
+
+        $node = $Run.nodes.$NodeId
+        return [ordered]@{
+            mailbox_version = 2
+            message_id = $MessageId
+            correlation_id = $MessageId
+            causation_id = $null
+            idempotency_key = "mailbox:v2:$($Fixture.RunId):$NodeId"
+            message_type = 'workflow_result'
+            state = 'created'
+            ttl_seconds = 300
+            ack_required = $true
+            from = [string]$node.pane_ref
+            to = 'Operator'
+            content = [ordered]@{
+                run_id = $Fixture.RunId
+                node_id = $NodeId
+                node_idempotency_key = [string]$node.idempotency_key
+                session_name = [string]$Run.session.session_name
+                generation_id = [string]$Run.session.generation_id
+                server_session_id = [string]$Run.session.server_session_id
+                workflow_fingerprint = [string]$Run.workflow_fingerprint
+                task_digest = [string]$Run.task_digest
+                outcome = $Outcome
+                exit_code = $ExitCode
+                result_digest = Get-Task659Sha256 -Bytes ([Text.Encoding]::UTF8.GetBytes("$Outcome`:$ExitCode`:$NodeId"))
+            }
+            timestamp = [DateTimeOffset]::UtcNow.ToString('o')
+        }
+    }
+
+    function Write-Task659MailboxEnvelope {
+        param(
+            [Parameter(Mandatory = $true)]$Fixture,
+            [Parameter(Mandatory = $true)]$Envelope
+        )
+
+        return Write-DeclarativeWorkflowMailboxResult `
+            -ProjectDir $Fixture.ProjectDir -RunId $Fixture.RunId -Payload $Envelope
+    }
+
+    function Send-Task659InternalResult {
+        param(
+            [Parameter(Mandatory = $true)]$Fixture,
+            [string]$NodeId = 'build',
+            [string]$Outcome = 'succeeded',
+            [int]$ExitCode = 0
+        )
+
+        $output = & pwsh -NoProfile -File $script:Task659TeamPipelinePath `
+            -WorkflowResult `
+            -RunId $Fixture.RunId `
+            -WorkflowResultNodeId $NodeId `
+            -WorkflowResultOutcome $Outcome `
+            -WorkflowResultExitCode $ExitCode `
+            -ProjectDir $Fixture.ProjectDir `
+            -AsJson 2>&1
+        $processExitCode = $LASTEXITCODE
+        return [PSCustomObject]@{
+            ExitCode = $processExitCode
+            Output = ($output | Out-String).Trim()
+        }
+    }
+
+    function Start-Task659InternalResultProcess {
+        param(
+            [Parameter(Mandatory = $true)]$Fixture,
+            [Parameter(Mandatory = $true)][string]$Label,
+            [Parameter(Mandatory = $true)][string]$GoPath,
+            [string]$NodeId = 'build',
+            [string]$Outcome = 'succeeded',
+            [int]$ExitCode = 0
+        )
+
+        $scriptPath = Join-Path $Fixture.ProjectDir "$Label-result-producer.ps1"
+        $readyPath = Join-Path $Fixture.ProjectDir "$Label-result-ready.marker"
+        $producerScript = @'
+param(
+    [Parameter(Mandatory = $true)][string]$TeamPipelinePath,
+    [Parameter(Mandatory = $true)][string]$ProjectDir,
+    [Parameter(Mandatory = $true)][string]$RunId,
+    [Parameter(Mandatory = $true)][string]$NodeId,
+    [Parameter(Mandatory = $true)][string]$Outcome,
+    [Parameter(Mandatory = $true)][int]$ExitCode,
+    [Parameter(Mandatory = $true)][string]$ReadyPath,
+    [Parameter(Mandatory = $true)][string]$GoPath
+)
+
+$ErrorActionPreference = 'Stop'
+[IO.File]::WriteAllText(
+    $ReadyPath,
+    'ready',
+    [Text.UTF8Encoding]::new($false)
+)
+$deadline = [DateTime]::UtcNow.AddSeconds(30)
+while (-not (Test-Path -LiteralPath $GoPath -PathType Leaf)) {
+    if ([DateTime]::UtcNow -ge $deadline) {
+        throw 'result producer start barrier timeout.'
+    }
+    Start-Sleep -Milliseconds 10
+}
+& pwsh -NoProfile -File $TeamPipelinePath `
+    -WorkflowResult `
+    -RunId $RunId `
+    -WorkflowResultNodeId $NodeId `
+    -WorkflowResultOutcome $Outcome `
+    -WorkflowResultExitCode $ExitCode `
+    -ProjectDir $ProjectDir `
+    -AsJson
+exit $LASTEXITCODE
+'@
+        [IO.File]::WriteAllText(
+            $scriptPath,
+            $producerScript,
+            [Text.UTF8Encoding]::new($false)
+        )
+
+        $startInfo = [Diagnostics.ProcessStartInfo]::new()
+        $startInfo.FileName = (Get-Command pwsh -ErrorAction Stop).Source
+        $startInfo.UseShellExecute = $false
+        $startInfo.CreateNoWindow = $true
+        $startInfo.RedirectStandardOutput = $true
+        $startInfo.RedirectStandardError = $true
+        foreach ($argument in @(
+                '-NoProfile',
+                '-File', $scriptPath,
+                '-TeamPipelinePath', $script:Task659TeamPipelinePath,
+                '-ProjectDir', $Fixture.ProjectDir,
+                '-RunId', $Fixture.RunId,
+                '-NodeId', $NodeId,
+                '-Outcome', $Outcome,
+                '-ExitCode', $ExitCode,
+                '-ReadyPath', $readyPath,
+                '-GoPath', $GoPath
+            )) {
+            $startInfo.ArgumentList.Add([string]$argument)
+        }
+        $process = [Diagnostics.Process]::new()
+        $process.StartInfo = $startInfo
+        if (-not $process.Start()) {
+            $process.Dispose()
+            throw "Failed to start TASK-659 result producer $Label."
+        }
+        return [PSCustomObject]@{
+            Process = $process
+            ReadyPath = $readyPath
+            GoPath = $GoPath
+        }
+    }
+
+    function Wait-Task659ResultProducerReady {
+        param(
+            [Parameter(Mandatory = $true)]$Child,
+            [int]$TimeoutSeconds = 10
+        )
+
+        $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
+        while (-not (Test-Path -LiteralPath $Child.ReadyPath -PathType Leaf) -and
+            [DateTime]::UtcNow -lt $deadline) {
+            Start-Sleep -Milliseconds 10
+        }
+        return Test-Path -LiteralPath $Child.ReadyPath -PathType Leaf
+    }
+
+    function Release-Task659ResultProducers {
+        param([Parameter(Mandatory = $true)][string]$GoPath)
+
+        [IO.File]::WriteAllText(
+            $GoPath,
+            'go',
+            [Text.UTF8Encoding]::new($false)
+        )
+    }
+
+    function Complete-Task659ResultProducer {
+        param(
+            [Parameter(Mandatory = $true)]$Child,
+            [int]$TimeoutSeconds = 10
+        )
+
+        if (-not $Child.Process.WaitForExit($TimeoutSeconds * 1000)) {
+            Stop-Process -Id $Child.Process.Id -Force -ErrorAction SilentlyContinue
+            $null = $Child.Process.WaitForExit(5000)
+        }
+        $result = [PSCustomObject]@{
+            ExitCode = $Child.Process.ExitCode
+            StdOut = $Child.Process.StandardOutput.ReadToEnd()
+            StdErr = $Child.Process.StandardError.ReadToEnd()
+        }
+        $Child.Process.Dispose()
+        return $result
+    }
+
+    function Start-Task659DispatchOwnerProcess {
+        param(
+            [Parameter(Mandatory = $true)]$Fixture,
+            [Parameter(Mandatory = $true)]
+            [ValidateSet('crash-after-effect', 'hold-after-effect')]
+            [string]$Mode
+        )
+
+        $planPath = Join-Path $Fixture.ProjectDir "$Mode-plan.json"
+        $identityPath = Join-Path $Fixture.ProjectDir "$Mode-identity.json"
+        $scriptPath = Join-Path $Fixture.ProjectDir "$Mode-owner.ps1"
+        $effectPath = Join-Path $Fixture.ProjectDir "$Mode-effect.marker"
+        $releasePath = Join-Path $Fixture.ProjectDir "$Mode-release.marker"
+        [IO.File]::WriteAllText(
+            $planPath,
+            ($Fixture.Plan | ConvertTo-Json -Depth 50 -Compress),
+            [Text.UTF8Encoding]::new($false)
+        )
+        [IO.File]::WriteAllText(
+            $identityPath,
+            ($Fixture.Identity | ConvertTo-Json -Depth 20 -Compress),
+            [Text.UTF8Encoding]::new($false)
+        )
+        $ownerScript = @'
+param(
+    [Parameter(Mandatory = $true)][string]$RuntimePath,
+    [Parameter(Mandatory = $true)][string]$ProjectDir,
+    [Parameter(Mandatory = $true)][string]$TaskFile,
+    [Parameter(Mandatory = $true)][string]$RunId,
+    [Parameter(Mandatory = $true)][string]$PlanPath,
+    [Parameter(Mandatory = $true)][string]$IdentityPath,
+    [Parameter(Mandatory = $true)][string]$EffectPath,
+    [Parameter(Mandatory = $true)][string]$ReleasePath,
+    [Parameter(Mandatory = $true)]
+    [ValidateSet('crash-after-effect', 'hold-after-effect')]
+    [string]$Mode
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+. $RuntimePath
+$plan = Get-Content -Raw -LiteralPath $PlanPath |
+    ConvertFrom-Json -AsHashtable -Depth 50
+$identity = Get-Content -Raw -LiteralPath $IdentityPath |
+    ConvertFrom-Json -AsHashtable -Depth 20
+$workspacePlanInvoker = {
+    param($RecipeId, $WorkflowId, $RequestedRunId, $RequestedProjectDir)
+    return $plan
+}.GetNewClosure()
+$manifestIdentityReader = {
+    param($RequestedProjectDir)
+    return $identity
+}.GetNewClosure()
+$sourceHeadReader = {
+    param($RequestedProjectDir)
+    return 'a' * 40
+}.GetNewClosure()
+$dispatchNode = {
+    param($Node, $TaskContent, $Run)
+    [IO.File]::WriteAllText(
+        $EffectPath,
+        'submission-effect-crossed',
+        [Text.UTF8Encoding]::new($false)
+    )
+    if ($Mode -ceq 'crash-after-effect') {
+        [Environment]::Exit(93)
+    }
+    $deadline = [DateTime]::UtcNow.AddSeconds(30)
+    while (-not (Test-Path -LiteralPath $ReleasePath -PathType Leaf)) {
+        if ([DateTime]::UtcNow -ge $deadline) {
+            throw 'DW21 release marker timeout.'
+        }
+        Start-Sleep -Milliseconds 25
+    }
+    return [ordered]@{ accepted = $true }
+}.GetNewClosure()
+
+Invoke-DeclarativeWorkflow `
+    -Action start `
+    -RecipeId 'bugfix-two-slot' `
+    -WorkflowId 'bugfix' `
+    -RunId $RunId `
+    -TaskFile $TaskFile `
+    -ProjectDir $ProjectDir `
+    -WorkspacePlanInvoker $workspacePlanInvoker `
+    -ManifestIdentityReader $manifestIdentityReader `
+    -SourceHeadReader $sourceHeadReader `
+    -DispatchNode $dispatchNode |
+    ConvertTo-Json -Depth 50 -Compress
+'@
+        [IO.File]::WriteAllText(
+            $scriptPath,
+            $ownerScript,
+            [Text.UTF8Encoding]::new($false)
+        )
+
+        $startInfo = [Diagnostics.ProcessStartInfo]::new()
+        $startInfo.FileName = (Get-Command pwsh -ErrorAction Stop).Source
+        $startInfo.UseShellExecute = $false
+        $startInfo.CreateNoWindow = $true
+        $startInfo.RedirectStandardOutput = $true
+        $startInfo.RedirectStandardError = $true
+        foreach ($argument in @(
+                '-NoProfile',
+                '-File', $scriptPath,
+                '-RuntimePath', $script:Task659RuntimePath,
+                '-ProjectDir', $Fixture.ProjectDir,
+                '-TaskFile', $Fixture.TaskFile,
+                '-RunId', $Fixture.RunId,
+                '-PlanPath', $planPath,
+                '-IdentityPath', $identityPath,
+                '-EffectPath', $effectPath,
+                '-ReleasePath', $releasePath,
+                '-Mode', $Mode
+            )) {
+            $startInfo.ArgumentList.Add([string]$argument)
+        }
+        $process = [Diagnostics.Process]::new()
+        $process.StartInfo = $startInfo
+        if (-not $process.Start()) {
+            $process.Dispose()
+            throw "Failed to start TASK-659 $Mode owner process."
+        }
+        return [PSCustomObject]@{
+            Process = $process
+            EffectPath = $effectPath
+            ReleasePath = $releasePath
+        }
+    }
+
+    function Wait-Task659EffectMarker {
+        param(
+            [Parameter(Mandatory = $true)]$Child,
+            [int]$TimeoutSeconds = 10
+        )
+
+        $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
+        while (-not (Test-Path -LiteralPath $Child.EffectPath -PathType Leaf) -and
+            [DateTime]::UtcNow -lt $deadline) {
+            Start-Sleep -Milliseconds 25
+        }
+        return Test-Path -LiteralPath $Child.EffectPath -PathType Leaf
+    }
+
+    function Complete-Task659OwnerProcess {
+        param(
+            [Parameter(Mandatory = $true)]$Child,
+            [switch]$Release,
+            [int]$TimeoutSeconds = 10
+        )
+
+        if ($Release -and -not (Test-Path -LiteralPath $Child.ReleasePath -PathType Leaf)) {
+            [IO.File]::WriteAllText(
+                $Child.ReleasePath,
+                'release',
+                [Text.UTF8Encoding]::new($false)
+            )
+        }
+        if (-not $Child.Process.WaitForExit($TimeoutSeconds * 1000)) {
+            Stop-Process -Id $Child.Process.Id -Force -ErrorAction SilentlyContinue
+            $null = $Child.Process.WaitForExit(5000)
+        }
+        $result = [PSCustomObject]@{
+            ExitCode = $Child.Process.ExitCode
+            StdOut = $Child.Process.StandardOutput.ReadToEnd()
+            StdErr = $Child.Process.StandardError.ReadToEnd()
+        }
+        $Child.Process.Dispose()
+        return $result
+    }
+
+    function Get-Task659StateBytes {
+        param([Parameter(Mandatory = $true)]$Fixture)
+
+        $path = Get-DeclarativeWorkflowRunStatePath -ProjectDir $Fixture.ProjectDir -RunId $Fixture.RunId
+        return [IO.File]::ReadAllBytes($path)
+    }
+
+    function Get-Task659MailboxFiles {
+        param(
+            [Parameter(Mandatory = $true)]$Fixture,
+            [ValidateSet('pending', 'consumed')][string]$State
+        )
+
+        $path = Join-Path $Fixture.ProjectDir ".winsmux\workflow-mailbox\$($Fixture.RunId)\$State"
+        if (-not (Test-Path -LiteralPath $path -PathType Container)) {
+            return ,@()
+        }
+        return ,@(Get-ChildItem -LiteralPath $path -File -Filter '*.json')
+    }
+
+    function Get-Task659BridgeFunctionSource {
+        param([Parameter(Mandatory = $true)][string]$Name)
+
+        $tokens = $null
+        $errors = $null
+        $ast = [Management.Automation.Language.Parser]::ParseFile(
+            $script:Task659BridgePath,
+            [ref]$tokens,
+            [ref]$errors
+        )
+        if (@($errors).Count -gt 0) {
+            throw "bridge parser error: $($errors[0].Message)"
+        }
+        $functionAst = @(
+            $ast.FindAll(
+                {
+                    param($candidate)
+                    $candidate -is [Management.Automation.Language.FunctionDefinitionAst] -and
+                        [string]$candidate.Name -ceq $Name
+                },
+                $true
+            )
+        ) | Select-Object -First 1
+        if ($null -eq $functionAst) {
+            throw "bridge function missing: $Name"
+        }
+        return [string]$functionAst.Extent.Text
+    }
+}
+
+Describe 'TASK-659 v0.36.30 production-path closure' {
+    It 'DW01 preserves legacy pipeline bytes while only an enabled pipeline route accepts the exact declarative marker' {
+        $script:capturedLegacyArgs = $null
+        Mock Invoke-WinsmuxControlPlaneScript {
+            param([string]$ScriptPath, [string[]]$Arguments)
+            $script:capturedLegacyArgs = @($Arguments)
+        }
+
+        Invoke-WinsmuxTeamPipelineCommand `
+            -BridgeScriptRoot (Join-Path $script:Task659RepoRoot 'scripts') `
+            -CommandTarget 'legacy task' `
+            -CommandRest @('--workflow-action', 'start') `
+            -AllowDeclarativeWorkflow
+
+        $script:capturedLegacyArgs | Should -Be @('-Task', 'legacy task --workflow-action start')
+        $parsed = ConvertTo-WinsmuxDeclarativePipelineArguments `
+            -CommandTarget '--workflow-action' `
+            -CommandRest @(
+                'start', '--recipe-id', 'bugfix-two-slot', '--workflow-id', 'bugfix',
+                '--run-id', 'run-dw01', '--task-file', 'task.txt', '--project-dir', 'C:\repo', '--json'
+            )
+        $parsed.workflow_action | Should -Be 'start'
+        $parsed.run_id | Should -Be 'run-dw01'
+        Should -Invoke Invoke-WinsmuxControlPlaneScript -Times 1 -Exactly
+    }
+
+    It 'DW02 persists start intent before one guarded dispatch and stores only content-derived identity' {
+        Assert-Task659RuntimeLoaded
+        $fixture = New-Task659Fixture -Name 'dw02' -RunId 'run-dw02'
+
+        $result = Invoke-Task659Start -Fixture $fixture
+        $state = Read-DeclarativeWorkflowRunState -ProjectDir $fixture.ProjectDir -RunId $fixture.RunId
+        $statePath = Get-DeclarativeWorkflowRunStatePath -ProjectDir $fixture.ProjectDir -RunId $fixture.RunId
+        $stateText = [IO.File]::ReadAllText($statePath, [Text.UTF8Encoding]::new($false, $true))
+
+        $result.state | Should -Be 'running'
+        $state.nodes.build.state | Should -Be 'running'
+        $state.nodes.verify.state | Should -Be 'pending'
+        $fixture.Dispatches.Count | Should -Be 1
+        $fixture.Dispatches[0].state_exists | Should -BeTrue
+        $fixture.Dispatches[0].state_at_dispatch | Should -Be 'dispatching'
+        $state.session.session_name | Should -Be 'winsmux-orchestra'
+        $state.workflow_fingerprint | Should -Be (Get-DeclarativeWorkflowContentDigest -Workflow $state.workflow)
+        $state.task_digest | Should -Be (Get-Task659Sha256 -Bytes ([IO.File]::ReadAllBytes($fixture.TaskFile)))
+        $stateText | Should -Not -Match ([regex]::Escape($fixture.TaskText))
+    }
+
+    It 'DW03 resumes from a durable internal result in a new invocation and releases one dependent' {
+        Assert-Task659RuntimeLoaded
+        $fixture = New-Task659Fixture -Name 'dw03' -RunId 'run-dw03'
+        $null = Invoke-Task659Start -Fixture $fixture
+
+        $send = Send-Task659InternalResult -Fixture $fixture
+        $pendingAfterSenderReturn = Get-Task659MailboxFiles -Fixture $fixture -State pending
+        $send.ExitCode | Should -Be 0 -Because $send.Output
+        $pendingAfterSenderReturn.Count | Should -Be 1
+
+        $result = Invoke-Task659Resume -Fixture $fixture
+        $state = Read-DeclarativeWorkflowRunState -ProjectDir $fixture.ProjectDir -RunId $fixture.RunId
+        $consumed = Get-Task659MailboxFiles -Fixture $fixture -State consumed
+
+        $result.state | Should -Be 'running'
+        $state.nodes.build.state | Should -Be 'succeeded'
+        $state.nodes.verify.state | Should -Be 'running'
+        $state.session.server_session_id | Should -Be '$659'
+        $fixture.Dispatches.Count | Should -Be 2
+        $fixture.Dispatches[1].node_id | Should -Be 'verify'
+        $consumed.Count | Should -Be 1
+    }
+
+    It 'DW04 maps an exact nonzero mailbox result to failed without releasing or redispatching a dependent' {
+        Assert-Task659RuntimeLoaded
+        $fixture = New-Task659Fixture -Name 'dw04' -RunId 'run-dw04'
+        $null = Invoke-Task659Start -Fixture $fixture
+
+        $send = Send-Task659InternalResult -Fixture $fixture -Outcome failed -ExitCode 23
+        $send.ExitCode | Should -Be 0
+        (Get-Task659MailboxFiles -Fixture $fixture -State pending).Count | Should -Be 1
+        $result = Invoke-Task659Resume -Fixture $fixture
+        $state = Read-DeclarativeWorkflowRunState -ProjectDir $fixture.ProjectDir -RunId $fixture.RunId
+
+        $result.state | Should -Be 'failed'
+        $state.nodes.build.state | Should -Be 'failed'
+        $state.nodes.build.exit_code | Should -Be 23
+        $state.nodes.verify.state | Should -Be 'pending'
+        $fixture.Dispatches.Count | Should -Be 1
+    }
+
+    It 'DW05 rejects cancel retry rollback and unknown actions before any product subprocess or mutable sink' {
+        $sentinelDir = Join-Path $TestDrive 'dw05\.winsmux'
+        [IO.Directory]::CreateDirectory($sentinelDir) | Out-Null
+        $statePath = Join-Path $sentinelDir 'state.sentinel'
+        $mailboxPath = Join-Path $sentinelDir 'mailbox.sentinel'
+        [IO.File]::WriteAllText($statePath, 'state-before', [Text.UTF8Encoding]::new($false))
+        [IO.File]::WriteAllText($mailboxPath, 'mailbox-before', [Text.UTF8Encoding]::new($false))
+        $stateBefore = [IO.File]::ReadAllBytes($statePath)
+        $mailboxBefore = [IO.File]::ReadAllBytes($mailboxPath)
+        Mock Invoke-WinsmuxControlPlaneScript { throw 'mutable sink must not run' }
+
+        foreach ($action in @('cancel', 'retry', 'rollback', 'unknown')) {
+            {
+                ConvertTo-WinsmuxDeclarativePipelineArguments `
+                    -CommandTarget '--workflow-action' `
+                    -CommandRest @(
+                        $action, '--run-id', 'run-dw05', '--task-file', 'task.txt',
+                        '--project-dir', 'C:\repo', '--json'
+                    )
+            } | Should -Throw '*start or resume*'
+        }
+
+        [IO.File]::ReadAllBytes($statePath) | Should -Be $stateBefore
+        [IO.File]::ReadAllBytes($mailboxPath) | Should -Be $mailboxBefore
+        Should -Invoke Invoke-WinsmuxControlPlaneScript -Times 0 -Exactly
+    }
+
+    It 'DW06 rejects missing duplicate empty unknown and caller-owned identity arguments with byte-exact pre-state' {
+        Assert-Task659RuntimeLoaded
+        $sentinel = Join-Path $TestDrive 'dw06-sentinel'
+        [IO.File]::WriteAllText($sentinel, 'unchanged', [Text.UTF8Encoding]::new($false))
+        $stateBefore = [IO.File]::ReadAllBytes($sentinel)
+        Mock Invoke-WinsmuxControlPlaneScript { throw 'mutable sink must not run' }
+        $cases = @(
+            @('start', '--run-id', 'run-dw06', '--task-file', 'task.txt', '--project-dir', 'C:\repo', '--json'),
+            @('start', '--recipe-id', 'r', '--recipe-id', 'r', '--workflow-id', 'w', '--run-id', 'run-dw06', '--task-file', 'task.txt', '--project-dir', 'C:\repo', '--json'),
+            @('resume', '--run-id', '', '--task-file', 'task.txt', '--project-dir', 'C:\repo', '--json'),
+            @('resume', '--run-id', 'run-dw06', '--task-file', 'task.txt', '--project-dir', 'C:\repo', '--unknown', 'x', '--json'),
+            @('resume', '--run-id', 'run-dw06', '--task-file', 'task.txt', '--project-dir', 'C:\repo', '--source-head', ('a' * 40), '--json'),
+            @('resume', '--run-id', 'run-dw06', '--task-file', 'task.txt', '--project-dir', 'C:\repo', '--config-fingerprint', ('sha256:' + ('1' * 64)), '--json')
+        )
+
+        foreach ($arguments in $cases) {
+            {
+                ConvertTo-WinsmuxDeclarativePipelineArguments `
+                    -CommandTarget '--workflow-action' `
+                    -CommandRest $arguments
+            } | Should -Throw
+        }
+
+        [IO.File]::ReadAllBytes($sentinel) | Should -Be $stateBefore
+        Should -Invoke Invoke-WinsmuxControlPlaneScript -Times 0 -Exactly
+    }
+
+    It 'DW07 rejects a noncanonical DAG from workspace-plan before the lease state mailbox or dispatch sinks' {
+        Assert-Task659RuntimeLoaded
+        $fixture = New-Task659Fixture -Name 'dw07' -RunId 'run-dw07'
+        $workspacePlanProbe = [PSCustomObject]@{ Count = 0 }
+        $invalidPlanInvoker = {
+            param([string]$RecipeId, [string]$WorkflowId, [string]$RunId, [string]$ProjectDir)
+            $workspacePlanProbe.Count++
+            throw 'workflow_cycle'
+        }.GetNewClosure()
+        $statePath = Get-DeclarativeWorkflowRunStatePath -ProjectDir $fixture.ProjectDir -RunId $fixture.RunId
+
+        {
+            Invoke-DeclarativeWorkflow `
+                -Action start -RecipeId 'bugfix-two-slot' -WorkflowId 'bugfix' `
+                -RunId $fixture.RunId -TaskFile $fixture.TaskFile -ProjectDir $fixture.ProjectDir `
+                -WorkspacePlanInvoker $invalidPlanInvoker `
+                -ManifestIdentityReader $fixture.ManifestIdentityReader `
+                -SourceHeadReader $fixture.SourceHeadReader `
+                -DispatchNode $fixture.DispatchNode
+        } | Should -Throw '*workflow_cycle*'
+
+        $workspacePlanProbe.Count | Should -Be 1
+        Test-Path -LiteralPath $statePath | Should -BeFalse
+        (Get-Task659MailboxFiles -Fixture $fixture -State pending).Count | Should -Be 0
+        $fixture.Dispatches.Count | Should -Be 0
+    }
+
+    It 'DW08 rejects task source and manifest identity drift before mailbox consume state write or dispatch' {
+        Assert-Task659RuntimeLoaded
+        $fixture = New-Task659Fixture -Name 'dw08' -RunId 'run-dw08'
+        $null = Invoke-Task659Start -Fixture $fixture
+        $stateBefore = Get-Task659StateBytes -Fixture $fixture
+        $dispatchBefore = $fixture.Dispatches.Count
+
+        [IO.File]::WriteAllText($fixture.TaskFile, 'changed task bytes', [Text.UTF8Encoding]::new($false))
+        { Invoke-Task659Resume -Fixture $fixture } | Should -Throw '*task*'
+        [IO.File]::WriteAllText($fixture.TaskFile, $fixture.TaskText, [Text.UTF8Encoding]::new($false))
+
+        $changedHeadReader = { param([string]$ProjectDir) return 'b' * 40 }
+        { Invoke-Task659Resume -Fixture $fixture -SourceHeadReader $changedHeadReader } | Should -Throw '*source*'
+
+        $changedManifestReader = {
+            param([string]$ProjectDir)
+            return [ordered]@{
+                session_name = 'winsmux-orchestra'
+                generation_id = 'generation-other'
+                server_session_id = '$659'
+            }
+        }
+        { Invoke-Task659Resume -Fixture $fixture -ManifestIdentityReader $changedManifestReader } | Should -Throw '*session*'
+
+        Get-Task659StateBytes -Fixture $fixture | Should -Be $stateBefore
+        (Get-Task659MailboxFiles -Fixture $fixture -State consumed).Count | Should -Be 0
+        $fixture.Dispatches.Count | Should -Be $dispatchBefore
+    }
+
+    It 'DW09 recomputes persisted and current workflow identity instead of trusting copied fingerprint strings' {
+        Assert-Task659RuntimeLoaded
+        $persistedFixture = New-Task659Fixture -Name 'dw09-persisted' -RunId 'run-dw09-a'
+        $null = Invoke-Task659Start -Fixture $persistedFixture
+        $statePath = Get-DeclarativeWorkflowRunStatePath -ProjectDir $persistedFixture.ProjectDir -RunId $persistedFixture.RunId
+        $corrupt = [IO.File]::ReadAllText($statePath, [Text.UTF8Encoding]::new($false, $true)) |
+            ConvertFrom-Json -AsHashtable -Depth 30
+        $corrupt['workflow']['nodes'][0]['pane_ref'] = 'attacker-slot'
+        $corruptText = $corrupt | ConvertTo-Json -Compress -Depth 30
+        [IO.File]::WriteAllText($statePath, $corruptText, [Text.UTF8Encoding]::new($false))
+        $corruptBefore = [IO.File]::ReadAllBytes($statePath)
+
+        { Invoke-Task659Resume -Fixture $persistedFixture } | Should -Throw '*workflow*fingerprint*'
+        [IO.File]::ReadAllBytes($statePath) | Should -Be $corruptBefore
+        $persistedFixture.Dispatches.Count | Should -Be 1
+
+        $currentFixture = New-Task659Fixture -Name 'dw09-current' -RunId 'run-dw09-b'
+        $null = Invoke-Task659Start -Fixture $currentFixture
+        $stateBefore = Get-Task659StateBytes -Fixture $currentFixture
+        $currentFixture.Plan.workflow.nodes[0].pane_ref = 'changed-current-slot'
+
+        { Invoke-Task659Resume -Fixture $currentFixture } | Should -Throw '*workflow*fingerprint*'
+        Get-Task659StateBytes -Fixture $currentFixture | Should -Be $stateBefore
+        $currentFixture.Dispatches.Count | Should -Be 1
+    }
+
+    It 'DW10 rejects automatic resume for succeeded failed and cancelled terminal runs without effect' {
+        Assert-Task659RuntimeLoaded
+        foreach ($terminalState in @('succeeded', 'failed', 'cancelled')) {
+            $fixture = New-Task659Fixture -Name "dw10-$terminalState" -RunId "run-dw10-$terminalState" -SingleNode
+            $null = Invoke-Task659Start -Fixture $fixture
+            $statePath = Get-DeclarativeWorkflowRunStatePath -ProjectDir $fixture.ProjectDir -RunId $fixture.RunId
+            $state = [IO.File]::ReadAllText($statePath, [Text.UTF8Encoding]::new($false, $true)) |
+                ConvertFrom-Json -AsHashtable -Depth 30
+            $state['state'] = $terminalState
+            $state['nodes']['build']['state'] = if ($terminalState -eq 'succeeded') { 'succeeded' } else { 'failed' }
+            $terminalText = $state | ConvertTo-Json -Compress -Depth 30
+            [IO.File]::WriteAllText($statePath, $terminalText, [Text.UTF8Encoding]::new($false))
+            $stateBefore = [IO.File]::ReadAllBytes($statePath)
+            $dispatchBefore = $fixture.Dispatches.Count
+
+            { Invoke-Task659Resume -Fixture $fixture } | Should -Throw '*terminal*'
+
+            [IO.File]::ReadAllBytes($statePath) | Should -Be $stateBefore
+            (Get-Task659MailboxFiles -Fixture $fixture -State consumed).Count | Should -Be 0
+            $fixture.Dispatches.Count | Should -Be $dispatchBefore
+        }
+    }
+
+    It 'DW11 admits exactly one same-run public owner while allowing a different run lease' {
+        Assert-Task659RuntimeLoaded
+        $fixture = New-Task659Fixture -Name 'dw11' -RunId 'run-dw11'
+        $null = Invoke-Task659Start -Fixture $fixture
+        $stateBefore = Get-Task659StateBytes -Fixture $fixture
+        $readyPath = Join-Path $fixture.ProjectDir 'lease-ready'
+        $holderPath = Join-Path $fixture.ProjectDir 'hold-lease.ps1'
+        $holderText = @"
+`$ErrorActionPreference = 'Stop'
+. '$($script:Task659RuntimePath.Replace("'", "''"))'
+`$lease = Enter-DeclarativeWorkflowInvocationLease -ProjectDir '$($fixture.ProjectDir.Replace("'", "''"))' -RunId '$($fixture.RunId)'
+[IO.File]::WriteAllText('$($readyPath.Replace("'", "''"))', 'ready', [Text.UTF8Encoding]::new(`$false))
+try { Start-Sleep -Seconds 10 } finally { `$lease.Dispose() }
+"@
+        [IO.File]::WriteAllText($holderPath, $holderText, [Text.UTF8Encoding]::new($false))
+        $holder = Start-Process pwsh -ArgumentList @('-NoProfile', '-File', $holderPath) -WindowStyle Hidden -PassThru
+        try {
+            $deadline = [DateTime]::UtcNow.AddSeconds(8)
+            while (-not (Test-Path -LiteralPath $readyPath) -and [DateTime]::UtcNow -lt $deadline) {
+                Start-Sleep -Milliseconds 50
+            }
+            Test-Path -LiteralPath $readyPath | Should -BeTrue
+
+            { Invoke-Task659Resume -Fixture $fixture } | Should -Throw '*workflow_run_busy*'
+            $differentRunLease = Enter-DeclarativeWorkflowInvocationLease `
+                -ProjectDir $fixture.ProjectDir -RunId 'run-dw11-other'
+            $differentRunLease | Should -Not -BeNullOrEmpty
+            $differentRunLease.Dispose()
+        } finally {
+            if (-not $holder.HasExited) {
+                Stop-Process -Id $holder.Id -Force -ErrorAction SilentlyContinue
+                $holder.WaitForExit(5000)
+            }
+            $holder.Dispose()
+        }
+
+        Get-Task659StateBytes -Fixture $fixture | Should -Be $stateBefore
+        $fixture.Dispatches.Count | Should -Be 1
+        (Read-DeclarativeWorkflowRunState -ProjectDir $fixture.ProjectDir -RunId $fixture.RunId).state |
+            Should -Be 'running'
+    }
+
+    It 'DW12 blocks missing malformed contradictory wrong-tuple and ambiguous mailbox evidence without dependent release' {
+        Assert-Task659RuntimeLoaded
+        $missing = New-Task659Fixture -Name 'dw12-missing' -RunId 'run-dw12-missing'
+        $null = Invoke-Task659Start -Fixture $missing
+        $missingResult = Invoke-Task659Resume -Fixture $missing
+        $missingState = Read-DeclarativeWorkflowRunState -ProjectDir $missing.ProjectDir -RunId $missing.RunId
+        $missingResult.state | Should -Be 'blocked'
+        $missingState.nodes.build.state | Should -Be 'blocked'
+        $missingState.nodes.verify.state | Should -Be 'pending'
+        $missing.Dispatches.Count | Should -Be 1
+
+        $malformed = New-Task659Fixture -Name 'dw12-malformed' -RunId 'run-dw12-malformed'
+        $null = Invoke-Task659Start -Fixture $malformed
+        $malformedBefore = Get-Task659StateBytes -Fixture $malformed
+        $pendingDir = Join-Path $malformed.ProjectDir ".winsmux\workflow-mailbox\$($malformed.RunId)\pending"
+        [IO.Directory]::CreateDirectory($pendingDir) | Out-Null
+        [IO.File]::WriteAllText((Join-Path $pendingDir 'msg-malformed.json'), '{', [Text.UTF8Encoding]::new($false))
+        { Invoke-Task659Resume -Fixture $malformed } | Should -Throw '*mailbox*'
+        Get-Task659StateBytes -Fixture $malformed | Should -Be $malformedBefore
+        $malformed.Dispatches.Count | Should -Be 1
+
+        $contradictory = New-Task659Fixture -Name 'dw12-contradictory' -RunId 'run-dw12-contradictory'
+        $null = Invoke-Task659Start -Fixture $contradictory
+        $contradictoryState = Read-DeclarativeWorkflowRunState -ProjectDir $contradictory.ProjectDir -RunId $contradictory.RunId
+        $badEnvelope = New-Task659CompletionEnvelope `
+            -Fixture $contradictory -Run $contradictoryState -Outcome succeeded -ExitCode 9 -MessageId 'msg-contradictory'
+        {
+            Write-Task659MailboxEnvelope -Fixture $contradictory -Envelope $badEnvelope
+        } | Should -Throw '*contradictory*'
+        (Get-Task659MailboxFiles -Fixture $contradictory -State pending).Count | Should -Be 0
+        $contradictory.Dispatches.Count | Should -Be 1
+
+        $wrongTuple = New-Task659Fixture -Name 'dw12-wrong-tuple' -RunId 'run-dw12-wrong-tuple'
+        $null = Invoke-Task659Start -Fixture $wrongTuple
+        $wrongTupleState = Read-DeclarativeWorkflowRunState `
+            -ProjectDir $wrongTuple.ProjectDir -RunId $wrongTuple.RunId
+        $wrongTupleEnvelope = New-Task659CompletionEnvelope `
+            -Fixture $wrongTuple -Run $wrongTupleState -MessageId 'msg-wrong-tuple'
+        $wrongTupleEnvelope['content']['run_id'] = 'run-other'
+        {
+            Write-Task659MailboxEnvelope -Fixture $wrongTuple -Envelope $wrongTupleEnvelope
+        } | Should -Throw '*contradictory*'
+        (Get-Task659MailboxFiles -Fixture $wrongTuple -State pending).Count | Should -Be 0
+        $wrongTuple.Dispatches.Count | Should -Be 1
+
+        $ambiguous = New-Task659Fixture -Name 'dw12-ambiguous' -RunId 'run-dw12-ambiguous'
+        $null = Invoke-Task659Start -Fixture $ambiguous
+        $ambiguousState = Read-DeclarativeWorkflowRunState -ProjectDir $ambiguous.ProjectDir -RunId $ambiguous.RunId
+        $first = New-Task659CompletionEnvelope -Fixture $ambiguous -Run $ambiguousState -MessageId 'msg-ambiguous-a'
+        $second = New-Task659CompletionEnvelope -Fixture $ambiguous -Run $ambiguousState -MessageId 'msg-ambiguous-b'
+        (Write-Task659MailboxEnvelope -Fixture $ambiguous -Envelope $first).accepted | Should -BeTrue
+        (Write-Task659MailboxEnvelope -Fixture $ambiguous -Envelope $second).accepted | Should -BeTrue
+        $ambiguousBefore = Get-Task659StateBytes -Fixture $ambiguous
+        { Invoke-Task659Resume -Fixture $ambiguous } | Should -Throw '*ambiguous*'
+        Get-Task659StateBytes -Fixture $ambiguous | Should -Be $ambiguousBefore
+        $ambiguous.Dispatches.Count | Should -Be 1
+
+        $concurrent = New-Task659Fixture `
+            -Name 'dw12-concurrent-conflict' -RunId 'run-dw12-concurrent-conflict'
+        $null = Invoke-Task659Start -Fixture $concurrent
+        $concurrentGo = Join-Path $concurrent.ProjectDir 'conflict-go.marker'
+        $successProducer = $null
+        $failureProducer = $null
+        $successResult = $null
+        $failureResult = $null
+        try {
+            $successProducer = Start-Task659InternalResultProcess `
+                -Fixture $concurrent -Label 'success' -GoPath $concurrentGo
+            $failureProducer = Start-Task659InternalResultProcess `
+                -Fixture $concurrent -Label 'failure' -GoPath $concurrentGo `
+                -Outcome failed -ExitCode 17
+            (Wait-Task659ResultProducerReady -Child $successProducer) |
+                Should -BeTrue
+            (Wait-Task659ResultProducerReady -Child $failureProducer) |
+                Should -BeTrue
+            Release-Task659ResultProducers -GoPath $concurrentGo
+            $successResult = Complete-Task659ResultProducer `
+                -Child $successProducer
+            $successProducer = $null
+            $failureResult = Complete-Task659ResultProducer `
+                -Child $failureProducer
+            $failureProducer = $null
+        } finally {
+            Release-Task659ResultProducers -GoPath $concurrentGo
+            if ($null -ne $successProducer) {
+                $null = Complete-Task659ResultProducer -Child $successProducer
+            }
+            if ($null -ne $failureProducer) {
+                $null = Complete-Task659ResultProducer -Child $failureProducer
+            }
+        }
+        $successResult.ExitCode | Should -Be 0 `
+            -Because "$($successResult.StdOut) $($successResult.StdErr)"
+        $failureResult.ExitCode | Should -Be 0 `
+            -Because "$($failureResult.StdOut) $($failureResult.StdErr)"
+        (Get-Task659MailboxFiles -Fixture $concurrent -State pending).Count |
+            Should -Be 2
+        $concurrentBefore = Get-Task659StateBytes -Fixture $concurrent
+        { Invoke-Task659Resume -Fixture $concurrent } |
+            Should -Throw '*ambiguous*'
+        Get-Task659StateBytes -Fixture $concurrent |
+            Should -Be $concurrentBefore
+        $concurrent.Dispatches.Count | Should -Be 1
+    }
+
+    It 'DW13 makes the same mailbox message byte-idempotent and never repeats its state transition or dispatch' {
+        Assert-Task659RuntimeLoaded
+        $fixture = New-Task659Fixture -Name 'dw13' -RunId 'run-dw13'
+        $null = Invoke-Task659Start -Fixture $fixture
+
+        $exactGo = Join-Path $fixture.ProjectDir 'exact-go.marker'
+        $exactFirst = $null
+        $exactSecond = $null
+        $exactFirstResult = $null
+        $exactSecondResult = $null
+        try {
+            $exactFirst = Start-Task659InternalResultProcess `
+                -Fixture $fixture -Label 'exact-first' -GoPath $exactGo
+            $exactSecond = Start-Task659InternalResultProcess `
+                -Fixture $fixture -Label 'exact-second' -GoPath $exactGo
+            (Wait-Task659ResultProducerReady -Child $exactFirst) |
+                Should -BeTrue
+            (Wait-Task659ResultProducerReady -Child $exactSecond) |
+                Should -BeTrue
+            Release-Task659ResultProducers -GoPath $exactGo
+            $exactFirstResult = Complete-Task659ResultProducer -Child $exactFirst
+            $exactFirst = $null
+            $exactSecondResult = Complete-Task659ResultProducer -Child $exactSecond
+            $exactSecond = $null
+        } finally {
+            Release-Task659ResultProducers -GoPath $exactGo
+            if ($null -ne $exactFirst) {
+                $null = Complete-Task659ResultProducer -Child $exactFirst
+            }
+            if ($null -ne $exactSecond) {
+                $null = Complete-Task659ResultProducer -Child $exactSecond
+            }
+        }
+        $exactFirstResult.ExitCode | Should -Be 0 `
+            -Because "$($exactFirstResult.StdOut) $($exactFirstResult.StdErr)"
+        $exactSecondResult.ExitCode | Should -Be 0 `
+            -Because "$($exactSecondResult.StdOut) $($exactSecondResult.StdErr)"
+        $pending = Get-Task659MailboxFiles -Fixture $fixture -State pending
+        $pending.Count | Should -Be 1
+        $pendingBytes = [IO.File]::ReadAllBytes($pending[0].FullName)
+        [IO.File]::ReadAllBytes($pending[0].FullName) | Should -Be $pendingBytes
+
+        $replayGo = Join-Path $fixture.ProjectDir 'replay-go.marker'
+        $replayProducer = $null
+        $replayResult = $null
+        try {
+            $replayProducer = Start-Task659InternalResultProcess `
+                -Fixture $fixture -Label 'consume-overlap' -GoPath $replayGo
+            (Wait-Task659ResultProducerReady -Child $replayProducer) |
+                Should -BeTrue
+            Release-Task659ResultProducers -GoPath $replayGo
+            $null = Invoke-Task659Resume -Fixture $fixture
+            $replayResult = Complete-Task659ResultProducer `
+                -Child $replayProducer
+            $replayProducer = $null
+        } finally {
+            Release-Task659ResultProducers -GoPath $replayGo
+            if ($null -ne $replayProducer) {
+                $replayResult = Complete-Task659ResultProducer `
+                    -Child $replayProducer
+            }
+        }
+        $replayResult.ExitCode | Should -Be 0 `
+            -Because "$($replayResult.StdOut) $($replayResult.StdErr)"
+        $afterFirstResume = Read-DeclarativeWorkflowRunState -ProjectDir $fixture.ProjectDir -RunId $fixture.RunId
+        $afterFirstResume.nodes.build.state | Should -Be 'succeeded'
+        $afterFirstResume.nodes.verify.state | Should -Be 'running'
+        $fixture.Dispatches.Count | Should -Be 2
+        (Get-Task659MailboxFiles -Fixture $fixture -State pending).Count |
+            Should -Be 0
+        (Get-Task659MailboxFiles -Fixture $fixture -State consumed).Count | Should -Be 1
+
+        (Send-Task659InternalResult -Fixture $fixture).ExitCode | Should -Be 0
+        (Get-Task659MailboxFiles -Fixture $fixture -State pending).Count | Should -Be 0
+        $afterReplay = Read-DeclarativeWorkflowRunState -ProjectDir $fixture.ProjectDir -RunId $fixture.RunId
+        @($afterReplay.admitted_messages).Count | Should -Be 1
+        $afterReplay.nodes.build.message_id | Should -Match '^result-[0-9a-f]{32}$'
+        $fixture.Dispatches.Count | Should -Be 2
+    }
+
+    It 'DW14 rejects proofless terminal node state before releasing a dependent or mutating durable evidence' {
+        Assert-Task659RuntimeLoaded
+        $observations = [Collections.Generic.List[object]]::new()
+        foreach ($outcome in @('succeeded', 'failed')) {
+            $fixture = New-Task659Fixture -Name "dw14-$outcome" -RunId "run-dw14-$outcome"
+            $null = Invoke-Task659Start -Fixture $fixture
+            $statePath = Get-DeclarativeWorkflowRunStatePath `
+                -ProjectDir $fixture.ProjectDir -RunId $fixture.RunId
+            $forged = [IO.File]::ReadAllText(
+                $statePath,
+                [Text.UTF8Encoding]::new($false, $true)
+            ) | ConvertFrom-Json -AsHashtable -Depth 30
+            $forged['nodes']['build']['state'] = $outcome
+            $forged['nodes']['build']['message_id'] = "msg-dw14-$outcome"
+            $forged['nodes']['build']['result_digest'] = Get-Task659Sha256 -Bytes (
+                [Text.Encoding]::UTF8.GetBytes("$outcome`:0:build")
+            )
+            $forged['nodes']['build']['exit_code'] = if ($outcome -ceq 'succeeded') { 0 } else { 17 }
+            $forged['admitted_messages'] = @("msg-dw14-$outcome")
+            [IO.File]::WriteAllText(
+                $statePath,
+                ($forged | ConvertTo-Json -Compress -Depth 30),
+                [Text.UTF8Encoding]::new($false)
+            )
+            $stateBefore = [IO.File]::ReadAllBytes($statePath)
+            $dispatchBefore = $fixture.Dispatches.Count
+            $resumeError = ''
+
+            try {
+                $null = Invoke-Task659Resume -Fixture $fixture
+            } catch {
+                $resumeError = [string]$_.Exception.Message
+            }
+
+            $stateAfter = [IO.File]::ReadAllBytes($statePath)
+            $observations.Add([PSCustomObject]@{
+                    outcome = $outcome
+                    error = $resumeError
+                    state_unchanged = [Linq.Enumerable]::SequenceEqual[byte]($stateBefore, $stateAfter)
+                    pending = (Get-Task659MailboxFiles -Fixture $fixture -State pending).Count
+                    consumed = (Get-Task659MailboxFiles -Fixture $fixture -State consumed).Count
+                    dispatch_before = $dispatchBefore
+                    dispatch_after = $fixture.Dispatches.Count
+                }) | Out-Null
+        }
+
+        foreach ($observation in $observations) {
+            $observation.error | Should -Match 'workflow_(state_proof|mailbox)_invalid'
+            $observation.state_unchanged | Should -BeTrue
+            $observation.pending | Should -Be 0
+            $observation.consumed | Should -Be 0
+            $observation.dispatch_after | Should -Be $observation.dispatch_before
+        }
+    }
+
+    It 'DW15 carries selected project and exact session authority to the child and rechecks it before each pane submission' {
+        $callerDir = Join-Path $TestDrive 'dw15-caller'
+        $selectedProject = Join-Path $TestDrive 'dw15-selected'
+        [IO.Directory]::CreateDirectory($callerDir) | Out-Null
+        [IO.Directory]::CreateDirectory($selectedProject) | Out-Null
+        $probePath = Join-Path $TestDrive 'dw15-bridge-probe.ps1'
+        $probeText = @'
+$ErrorActionPreference = 'Stop'
+[ordered]@{
+    cwd = (Get-Location).Path
+    project_dir = [string]$env:WINSMUX_INTERNAL_WORKFLOW_PROJECT_DIR
+    session_name = [string]$env:WINSMUX_INTERNAL_WORKFLOW_SESSION_NAME
+    generation_id = [string]$env:WINSMUX_INTERNAL_WORKFLOW_GENERATION_ID
+    server_session_id = [string]$env:WINSMUX_INTERNAL_WORKFLOW_SERVER_SESSION_ID
+} | ConvertTo-Json -Compress
+'@
+        [IO.File]::WriteAllText($probePath, $probeText, [Text.UTF8Encoding]::new($false))
+        $originalBridge = $script:TeamPipelineBridgeScript
+        $originalEnvironment = [ordered]@{
+            project_dir = [string]$env:WINSMUX_INTERNAL_WORKFLOW_PROJECT_DIR
+            session_name = [string]$env:WINSMUX_INTERNAL_WORKFLOW_SESSION_NAME
+            generation_id = [string]$env:WINSMUX_INTERNAL_WORKFLOW_GENERATION_ID
+            server_session_id = [string]$env:WINSMUX_INTERNAL_WORKFLOW_SERVER_SESSION_ID
+        }
+        $env:WINSMUX_INTERNAL_WORKFLOW_PROJECT_DIR = 'parent-project-sentinel'
+        $env:WINSMUX_INTERNAL_WORKFLOW_SESSION_NAME = 'parent-session-sentinel'
+        $env:WINSMUX_INTERNAL_WORKFLOW_GENERATION_ID = 'parent-generation-sentinel'
+        $env:WINSMUX_INTERNAL_WORKFLOW_SERVER_SESSION_ID = 'parent-server-sentinel'
+        $bridgeError = ''
+        $bridgeReceipt = $null
+        try {
+            $script:TeamPipelineBridgeScript = $probePath
+            Push-Location $callerDir
+            try {
+                $bridgeReceipt = Invoke-TeamPipelineBridge `
+                    -Arguments @('send', 'builder-1', 'payload') `
+                    -ProjectDir $selectedProject `
+                    -ExpectedSessionName 'winsmux-orchestra' `
+                    -ExpectedGenerationId 'generation-dw15' `
+                    -ExpectedServerSessionId '$659'
+            } catch {
+                $bridgeError = [string]$_.Exception.Message
+            } finally {
+                Pop-Location
+            }
+
+            $env:WINSMUX_INTERNAL_WORKFLOW_PROJECT_DIR | Should -BeExactly 'parent-project-sentinel'
+            $env:WINSMUX_INTERNAL_WORKFLOW_SESSION_NAME | Should -BeExactly 'parent-session-sentinel'
+            $env:WINSMUX_INTERNAL_WORKFLOW_GENERATION_ID | Should -BeExactly 'parent-generation-sentinel'
+            $env:WINSMUX_INTERNAL_WORKFLOW_SERVER_SESSION_ID | Should -BeExactly 'parent-server-sentinel'
+        } finally {
+            $script:TeamPipelineBridgeScript = $originalBridge
+            $env:WINSMUX_INTERNAL_WORKFLOW_PROJECT_DIR = $originalEnvironment.project_dir
+            $env:WINSMUX_INTERNAL_WORKFLOW_SESSION_NAME = $originalEnvironment.session_name
+            $env:WINSMUX_INTERNAL_WORKFLOW_GENERATION_ID = $originalEnvironment.generation_id
+            $env:WINSMUX_INTERNAL_WORKFLOW_SERVER_SESSION_ID = $originalEnvironment.server_session_id
+        }
+
+        $probe = $null
+        if ($null -ne $bridgeReceipt -and
+            -not [string]::IsNullOrWhiteSpace([string]$bridgeReceipt.Output)) {
+            $probe = $bridgeReceipt.Output | ConvertFrom-Json
+        }
+
+        $bridgeSource = [IO.File]::ReadAllText(
+            $script:Task659BridgePath,
+            [Text.UTF8Encoding]::new($false, $true)
+        )
+        $invokeSendSource = [regex]::Match(
+            $bridgeSource,
+            '(?s)function Invoke-Send \{.*?\r?\n\}\r?\n\r?\nfunction Invoke-Name'
+        ).Value
+        $authorityCallCount = (
+            [regex]::Matches($invokeSendSource, 'Assert-WinsmuxWorkflowDispatchAuthority')
+        ).Count
+        $authorityBeforeEverySink = $true
+        foreach ($sinkToken in @('Send-TextToPane -PaneId', 'Send-ResolvedTransportPlan')) {
+            $sinkIndex = $invokeSendSource.IndexOf($sinkToken, [StringComparison]::Ordinal)
+            if ($sinkIndex -le 0) {
+                $authorityBeforeEverySink = $false
+                continue
+            }
+            $authorityIndex = $invokeSendSource.LastIndexOf(
+                'Assert-WinsmuxWorkflowDispatchAuthority',
+                $sinkIndex,
+                [StringComparison]::Ordinal
+            )
+            if ($authorityIndex -le 0) {
+                $authorityBeforeEverySink = $false
+            }
+        }
+
+        $sinkValidationError = ''
+        $sinkEnvironment = [ordered]@{
+            project_dir = [string]$env:WINSMUX_INTERNAL_WORKFLOW_PROJECT_DIR
+            session_name = [string]$env:WINSMUX_INTERNAL_WORKFLOW_SESSION_NAME
+            generation_id = [string]$env:WINSMUX_INTERNAL_WORKFLOW_GENERATION_ID
+            server_session_id = [string]$env:WINSMUX_INTERNAL_WORKFLOW_SERVER_SESSION_ID
+        }
+        try {
+            $validatorSource = Get-Task659BridgeFunctionSource `
+                -Name 'Assert-WinsmuxWorkflowDispatchAuthority'
+            . ([scriptblock]::Create($validatorSource))
+            $env:WINSMUX_INTERNAL_WORKFLOW_PROJECT_DIR = [IO.Path]::GetFullPath($selectedProject)
+            $env:WINSMUX_INTERNAL_WORKFLOW_SESSION_NAME = 'winsmux-orchestra'
+            $env:WINSMUX_INTERNAL_WORKFLOW_GENERATION_ID = 'generation-dw15'
+            $env:WINSMUX_INTERNAL_WORKFLOW_SERVER_SESSION_ID = '$659'
+            Mock Get-WinsmuxVerifiedManifestIdentity {
+                [PSCustomObject]@{
+                    session_name = 'winsmux-orchestra'
+                    generation_id = 'generation-dw15-changed'
+                    server_session_id = '$659'
+                }
+            }
+            try {
+                Assert-WinsmuxWorkflowDispatchAuthority -ProjectDir $selectedProject
+            } catch {
+                $sinkValidationError = [string]$_.Exception.Message
+            }
+        } catch {
+            $sinkValidationError = [string]$_.Exception.Message
+        } finally {
+            $env:WINSMUX_INTERNAL_WORKFLOW_PROJECT_DIR = $sinkEnvironment.project_dir
+            $env:WINSMUX_INTERNAL_WORKFLOW_SESSION_NAME = $sinkEnvironment.session_name
+            $env:WINSMUX_INTERNAL_WORKFLOW_GENERATION_ID = $sinkEnvironment.generation_id
+            $env:WINSMUX_INTERNAL_WORKFLOW_SERVER_SESSION_ID = $sinkEnvironment.server_session_id
+        }
+
+        $authorityDefects = [Collections.Generic.List[string]]::new()
+        if (-not [string]::IsNullOrWhiteSpace($bridgeError)) {
+            $authorityDefects.Add("transport: $bridgeError") | Out-Null
+        }
+        if ($authorityCallCount -lt 2 -or -not $authorityBeforeEverySink) {
+            $authorityDefects.Add(
+                "sink guards: calls=$authorityCallCount before_every_sink=$authorityBeforeEverySink"
+            ) | Out-Null
+        }
+        if ($sinkValidationError -cnotmatch 'workflow_dispatch_authority_changed') {
+            $authorityDefects.Add("sink validation: $sinkValidationError") | Out-Null
+        }
+        $authorityDefects | Should -BeNullOrEmpty
+        $bridgeError | Should -BeNullOrEmpty
+        $probe | Should -Not -BeNullOrEmpty
+        [IO.Path]::GetFullPath([string]$probe.cwd) | Should -BeExactly ([IO.Path]::GetFullPath($selectedProject))
+        $probe.project_dir | Should -BeExactly ([IO.Path]::GetFullPath($selectedProject))
+        $probe.session_name | Should -BeExactly 'winsmux-orchestra'
+        $probe.generation_id | Should -BeExactly 'generation-dw15'
+        $probe.server_session_id | Should -BeExactly '$659'
+        $invokeSendSource | Should -Not -BeNullOrEmpty
+        $authorityCallCount | Should -BeGreaterOrEqual 2
+        $authorityBeforeEverySink | Should -BeTrue
+        $sinkValidationError | Should -Match 'workflow_dispatch_authority_changed'
+    }
+
+    It 'DW16 gives normal and extended path spellings one machine-wide run-adjacent file lease' {
+        Assert-Task659RuntimeLoaded
+        $fixture = New-Task659Fixture -Name 'dw16' -RunId 'run-dw16'
+        $null = Invoke-Task659Start -Fixture $fixture
+        $stateBefore = Get-Task659StateBytes -Fixture $fixture
+        $readyPath = Join-Path $fixture.ProjectDir 'dw16-ready'
+        $holderPath = Join-Path $fixture.ProjectDir 'dw16-hold-lease.ps1'
+        $extendedProject = '\\?\' + [IO.Path]::GetFullPath($fixture.ProjectDir)
+        $holderText = @"
+`$ErrorActionPreference = 'Stop'
+. '$($script:Task659RuntimePath.Replace("'", "''"))'
+`$lease = Enter-DeclarativeWorkflowInvocationLease -ProjectDir '$($extendedProject.Replace("'", "''"))' -RunId '$($fixture.RunId)'
+[IO.File]::WriteAllText('$($readyPath.Replace("'", "''"))', 'ready', [Text.UTF8Encoding]::new(`$false))
+try { Start-Sleep -Seconds 10 } finally { `$lease.Dispose() }
+"@
+        [IO.File]::WriteAllText($holderPath, $holderText, [Text.UTF8Encoding]::new($false))
+        $holder = Start-Process (Get-Command pwsh).Source `
+            -ArgumentList @('-NoProfile', '-File', $holderPath) `
+            -WindowStyle Hidden -PassThru
+        $busyError = ''
+        $unexpectedLease = $null
+        try {
+            $deadline = [DateTime]::UtcNow.AddSeconds(8)
+            while (-not (Test-Path -LiteralPath $readyPath) -and [DateTime]::UtcNow -lt $deadline) {
+                Start-Sleep -Milliseconds 50
+            }
+            Test-Path -LiteralPath $readyPath | Should -BeTrue
+            try {
+                $unexpectedLease = Enter-DeclarativeWorkflowInvocationLease `
+                    -ProjectDir $fixture.ProjectDir -RunId $fixture.RunId
+            } catch {
+                $busyError = [string]$_.Exception.Message
+            }
+            if ($null -ne $unexpectedLease) {
+                $unexpectedLease.Dispose()
+                $unexpectedLease = $null
+            }
+
+            $differentRunLease = Enter-DeclarativeWorkflowInvocationLease `
+                -ProjectDir $fixture.ProjectDir -RunId 'run-dw16-other'
+            $differentRunLease | Should -Not -BeNullOrEmpty
+            $differentRunLease.Dispose()
+        } finally {
+            if ($null -ne $unexpectedLease) {
+                $unexpectedLease.Dispose()
+            }
+            if (-not $holder.HasExited) {
+                Stop-Process -Id $holder.Id -Force -ErrorAction SilentlyContinue
+                $holder.WaitForExit(5000)
+            }
+            $holder.Dispose()
+        }
+
+        $busyError | Should -Match 'workflow_run_busy'
+        Get-Task659StateBytes -Fixture $fixture | Should -Be $stateBefore
+        $fixture.Dispatches.Count | Should -Be 1
+        $leasePath = Join-Path $fixture.ProjectDir ".winsmux\workflow-runs\$($fixture.RunId).lease"
+        Test-Path -LiteralPath $leasePath -PathType Leaf | Should -BeTrue
+    }
+
+    It 'DW17 rejects mixed-case action and outcome enums before state mailbox or dispatch mutation' {
+        Assert-Task659RuntimeLoaded
+        $parserError = ''
+        try {
+            $null = ConvertTo-WinsmuxDeclarativePipelineArguments `
+                -CommandTarget '--workflow-action' `
+                -CommandRest @(
+                    'RESUME', '--run-id', 'run-dw17-parser', '--task-file', 'task.txt',
+                    '--project-dir', 'C:\repo', '--json'
+                )
+        } catch {
+            $parserError = [string]$_.Exception.Message
+        }
+
+        $runtime = New-Task659Fixture -Name 'dw17-runtime' -RunId 'run-dw17-runtime'
+        $null = Invoke-Task659Start -Fixture $runtime
+        $runtimeStateBefore = Get-Task659StateBytes -Fixture $runtime
+        $runtimeDispatchBefore = $runtime.Dispatches.Count
+        $runtimeError = ''
+        try {
+            $null = Invoke-DeclarativeWorkflow `
+                -Action 'RESUME' `
+                -RunId $runtime.RunId `
+                -TaskFile $runtime.TaskFile `
+                -ProjectDir $runtime.ProjectDir `
+                -WorkspacePlanInvoker $runtime.WorkspacePlanInvoker `
+                -ManifestIdentityReader $runtime.ManifestIdentityReader `
+                -SourceHeadReader $runtime.SourceHeadReader `
+                -DispatchNode $runtime.DispatchNode
+        } catch {
+            $runtimeError = [string]$_.Exception.Message
+        }
+
+        $outcome = New-Task659Fixture -Name 'dw17-outcome' -RunId 'run-dw17-outcome'
+        $null = Invoke-Task659Start -Fixture $outcome
+        $outcomeStateBefore = Get-Task659StateBytes -Fixture $outcome
+        $outcomeRun = Read-DeclarativeWorkflowRunState `
+            -ProjectDir $outcome.ProjectDir -RunId $outcome.RunId
+        $mixedEnvelope = New-Task659CompletionEnvelope `
+            -Fixture $outcome -Run $outcomeRun -Outcome 'SUCCEEDED' -ExitCode 0 -MessageId 'msg-dw17-outcome'
+        $outcomeError = ''
+        try {
+            $null = Write-Task659MailboxEnvelope -Fixture $outcome -Envelope $mixedEnvelope
+        } catch {
+            $outcomeError = [string]$_.Exception.Message
+        }
+
+        $enumDefects = [Collections.Generic.List[string]]::new()
+        if ($parserError -cnotmatch 'start or resume') {
+            $enumDefects.Add("parser accepted RESUME: $parserError") | Out-Null
+        }
+        if ($runtimeError -cnotmatch 'workflow_action_invalid') {
+            $enumDefects.Add("runtime accepted RESUME: $runtimeError") | Out-Null
+        }
+        if ($outcomeError -cnotmatch 'workflow_mailbox_invalid') {
+            $enumDefects.Add("writer accepted SUCCEEDED: $outcomeError") | Out-Null
+        }
+        $enumDefects | Should -BeNullOrEmpty
+        $parserError | Should -Match 'start or resume'
+        $runtimeError | Should -Match 'workflow_action_invalid'
+        $outcomeError | Should -Match 'workflow_mailbox_invalid'
+        Get-Task659StateBytes -Fixture $runtime | Should -Be $runtimeStateBefore
+        $runtime.Dispatches.Count | Should -Be $runtimeDispatchBefore
+        Get-Task659StateBytes -Fixture $outcome | Should -Be $outcomeStateBefore
+        (Get-Task659MailboxFiles -Fixture $outcome -State pending).Count | Should -Be 0
+        $outcome.Dispatches.Count | Should -Be 1
+    }
+
+    It 'DW18 keeps task-run and every workflow-named mailbox channel on their legacy public contracts' {
+        $script:capturedLegacyArgs = $null
+        Mock Invoke-WinsmuxControlPlaneScript {
+            param([string]$ScriptPath, [string[]]$Arguments)
+            $script:capturedLegacyArgs = @($Arguments)
+        }
+        $legacyTokens = @(
+            'start', '--recipe-id', 'bugfix-two-slot', '--workflow-id', 'bugfix',
+            '--run-id', 'run-dw18-task', '--task-file', 'task.txt',
+            '--project-dir', 'C:\repo', '--json'
+        )
+        $legacyRouteError = ''
+        try {
+            Invoke-WinsmuxTeamPipelineCommand `
+                -BridgeScriptRoot (Join-Path $script:Task659RepoRoot 'scripts') `
+                -CommandTarget '--workflow-action' `
+                -CommandRest $legacyTokens `
+                -AllowDeclarativeWorkflow:$false
+        } catch {
+            $legacyRouteError = [string]$_.Exception.Message
+        }
+
+        $channel = 'workflow-dw18-' + [guid]::NewGuid().ToString('N')
+        $startInfo = [Diagnostics.ProcessStartInfo]::new()
+        $startInfo.FileName = (Get-Command pwsh).Source
+        $startInfo.UseShellExecute = $false
+        $startInfo.CreateNoWindow = $true
+        $startInfo.RedirectStandardOutput = $true
+        $startInfo.RedirectStandardError = $true
+        foreach ($argument in @(
+                '-NoProfile',
+                '-File',
+                $script:Task659BridgePath,
+                'mailbox-create',
+                $channel
+            )) {
+            $null = $startInfo.ArgumentList.Add($argument)
+        }
+        $server = [Diagnostics.Process]::new()
+        $server.StartInfo = $startInfo
+        $null = $server.Start()
+        $sendExitCode = -1
+        $sendOutput = ''
+        $listenerText = ''
+        try {
+            $readyRead = $server.StandardOutput.ReadLineAsync()
+            if ($readyRead.Wait(8000)) {
+                $listenerText = [string]$readyRead.Result
+            }
+
+            $payload = [ordered]@{
+                from = 'dw18-sender'
+                to = 'dw18-receiver'
+                content = 'dw18-exact-content'
+                timestamp = '2026-07-25T00:00:00Z'
+            } | ConvertTo-Json -Compress
+            $sendLines = & pwsh -NoProfile -File $script:Task659BridgePath `
+                mailbox-send $channel $payload 2>&1
+            $sendExitCode = $LASTEXITCODE
+            $sendOutput = ($sendLines | Out-String).Trim()
+
+            $receiveRead = $server.StandardOutput.ReadLineAsync()
+            if ($receiveRead.Wait(8000)) {
+                $listenerText += "`n$([string]$receiveRead.Result)"
+            }
+        } finally {
+            if (-not $server.HasExited) {
+                $server.Kill($true)
+                $null = $server.WaitForExit(5000)
+            }
+            $server.Dispose()
+        }
+
+        $expectedLegacyArgs = @(
+            '-Task',
+            '--workflow-action start --recipe-id bugfix-two-slot --workflow-id bugfix --run-id run-dw18-task --task-file task.txt --project-dir C:\repo --json'
+        )
+        $surfaceDefects = [Collections.Generic.List[string]]::new()
+        if (-not [string]::IsNullOrWhiteSpace($legacyRouteError)) {
+            $surfaceDefects.Add("task-run route: $legacyRouteError") | Out-Null
+        }
+        if ((@($script:capturedLegacyArgs) -join "`u{1f}") -cne ($expectedLegacyArgs -join "`u{1f}")) {
+            $surfaceDefects.Add(
+                "task-run bytes: $(@($script:capturedLegacyArgs) -join ' | ')"
+            ) | Out-Null
+        }
+        if ($listenerText -cnotmatch 'mailbox listening') {
+            $surfaceDefects.Add('workflow-named pipe listener did not become live') | Out-Null
+        }
+        if ($sendExitCode -ne 0) {
+            $surfaceDefects.Add("workflow-named pipe send exit=$sendExitCode output=$sendOutput") | Out-Null
+        }
+        if ($listenerText -cnotmatch 'dw18-exact-content') {
+            $surfaceDefects.Add('workflow-named pipe did not receive exact content') | Out-Null
+        }
+        $surfaceDefects | Should -BeNullOrEmpty
+        $listenerText | Should -Match 'mailbox listening'
+        $legacyRouteError | Should -BeNullOrEmpty
+        $script:capturedLegacyArgs | Should -Be $expectedLegacyArgs
+        $sendExitCode | Should -Be 0 -Because $sendOutput
+        $receivedLine = @(
+            $listenerText -split '\r?\n' |
+                Where-Object { $_ -match '^\{' -and $_ -match 'dw18-exact-content' }
+        ) | Select-Object -Last 1
+        $received = $receivedLine | ConvertFrom-Json
+        $received.from | Should -BeExactly 'dw18-sender'
+        $received.to | Should -BeExactly 'dw18-receiver'
+        $received.content | Should -BeExactly 'dw18-exact-content'
+        $bridgeSource = [IO.File]::ReadAllText(
+            $script:Task659BridgePath,
+            [Text.UTF8Encoding]::new($false, $true)
+        )
+        $bridgeSource | Should -Not -Match "(?m)^\s*'workflow-result'\s*\{"
+    }
+
+    It 'DW19 derives one exact durable envelope in the installed internal result adapter and exposes no public result command' {
+        Assert-Task659RuntimeLoaded
+        $fixture = New-Task659Fixture -Name 'dw19' -RunId 'run-dw19'
+        $null = Invoke-Task659Start -Fixture $fixture
+        $run = Read-DeclarativeWorkflowRunState -ProjectDir $fixture.ProjectDir -RunId $fixture.RunId
+
+        $send = Send-Task659InternalResult -Fixture $fixture -Outcome succeeded -ExitCode 0
+        $send.ExitCode | Should -Be 0 -Because $send.Output
+        $receipt = $send.Output | ConvertFrom-Json
+        $receipt.accepted | Should -BeTrue
+        $pending = Get-Task659MailboxFiles -Fixture $fixture -State pending
+        $pending.Count | Should -Be 1
+        $envelope = [IO.File]::ReadAllText(
+            $pending[0].FullName,
+            [Text.UTF8Encoding]::new($false, $true)
+        ) | ConvertFrom-Json -AsHashtable -Depth 30
+        [string]$envelope['message_id'] | Should -Match '^result-[0-9a-f]{32}$'
+        [string]$envelope['from'] | Should -BeExactly 'builder-1'
+        [string]$envelope['to'] | Should -BeExactly 'Operator'
+        [string]$envelope['content']['run_id'] | Should -BeExactly $fixture.RunId
+        [string]$envelope['content']['node_id'] | Should -BeExactly 'build'
+        [string]$envelope['content']['node_idempotency_key'] |
+            Should -BeExactly ([string]$run.nodes.build.idempotency_key)
+        [string]$envelope['content']['session_name'] |
+            Should -BeExactly ([string]$run.session.session_name)
+        [string]$envelope['content']['generation_id'] |
+            Should -BeExactly ([string]$run.session.generation_id)
+        [string]$envelope['content']['server_session_id'] |
+            Should -BeExactly ([string]$run.session.server_session_id)
+        [string]$envelope['content']['workflow_fingerprint'] |
+            Should -BeExactly ([string]$run.workflow_fingerprint)
+        [string]$envelope['content']['task_digest'] |
+            Should -BeExactly ([string]$run.task_digest)
+        [string]$envelope['content']['result_digest'] | Should -BeExactly (
+            Get-Task659Sha256 -Bytes ([Text.Encoding]::UTF8.GetBytes('succeeded:0:build'))
+        )
+
+        $bridgeSource = [IO.File]::ReadAllText(
+            $script:Task659BridgePath,
+            [Text.UTF8Encoding]::new($false, $true)
+        )
+        $bridgeSource | Should -Not -Match "(?m)^\s*'workflow-result'\s*\{"
+        $null = Invoke-Task659Resume -Fixture $fixture
+        $after = Read-DeclarativeWorkflowRunState -ProjectDir $fixture.ProjectDir -RunId $fixture.RunId
+        $after.nodes.build.state | Should -BeExactly 'succeeded'
+        $after.nodes.verify.state | Should -BeExactly 'running'
+        $fixture.Dispatches.Count | Should -Be 2
+    }
+
+    It 'DW20 preserves one exact result when the dispatch owner exits after the submission effect but before running is durable' {
+        Assert-Task659RuntimeLoaded
+        $fixture = New-Task659Fixture -Name 'dw20' -RunId 'run-dw20'
+        $child = Start-Task659DispatchOwnerProcess `
+            -Fixture $fixture -Mode crash-after-effect
+        $childResult = $null
+        try {
+            (Wait-Task659EffectMarker -Child $child) | Should -BeTrue
+            $childResult = Complete-Task659OwnerProcess -Child $child
+            $child = $null
+        } finally {
+            if ($null -ne $child -and -not $child.Process.HasExited) {
+                $childResult = Complete-Task659OwnerProcess -Child $child
+                $child = $null
+            }
+        }
+
+        $childResult.ExitCode | Should -Be 93 -Because $childResult.StdErr
+        $beforeProducer = Get-Task659StateBytes -Fixture $fixture
+        $beforeState = Read-DeclarativeWorkflowRunState `
+            -ProjectDir $fixture.ProjectDir -RunId $fixture.RunId
+        $beforeState.nodes.build.state | Should -BeExactly 'dispatching'
+
+        $send = Send-Task659InternalResult `
+            -Fixture $fixture -Outcome succeeded -ExitCode 0
+        $afterProducer = Get-Task659StateBytes -Fixture $fixture
+        $send.ExitCode | Should -Be 0 -Because $send.Output
+        [Linq.Enumerable]::SequenceEqual[byte](
+            [byte[]]$beforeProducer,
+            [byte[]]$afterProducer
+        ) | Should -BeTrue
+        (Get-Task659MailboxFiles -Fixture $fixture -State pending).Count |
+            Should -Be 1
+
+        $result = Invoke-Task659Resume -Fixture $fixture
+        $after = Read-DeclarativeWorkflowRunState `
+            -ProjectDir $fixture.ProjectDir -RunId $fixture.RunId
+        $result.state | Should -BeExactly 'running'
+        $after.nodes.build.state | Should -BeExactly 'succeeded'
+        $after.nodes.verify.state | Should -BeExactly 'running'
+        $fixture.Dispatches.Count | Should -Be 1
+        $fixture.Dispatches[0].node_id | Should -BeExactly 'verify'
+        (Get-Task659MailboxFiles -Fixture $fixture -State consumed).Count |
+            Should -Be 1
+
+        $consumerFirst = New-Task659Fixture `
+            -Name 'dw20-consumer-first' -RunId 'run-dw20-consumer-first'
+        $null = Invoke-Task659Start -Fixture $consumerFirst
+        $blocked = Invoke-Task659Resume -Fixture $consumerFirst
+        $blocked.state | Should -BeExactly 'blocked'
+        $blocked.nodes.build.state | Should -BeExactly 'blocked'
+        $blockedBytes = Get-Task659StateBytes -Fixture $consumerFirst
+        $lateProducer = Send-Task659InternalResult -Fixture $consumerFirst
+        $lateProducer.ExitCode | Should -Be 0 -Because $lateProducer.Output
+        [Linq.Enumerable]::SequenceEqual[byte](
+            [byte[]]$blockedBytes,
+            [byte[]](Get-Task659StateBytes -Fixture $consumerFirst)
+        ) | Should -BeTrue
+        (Get-Task659MailboxFiles -Fixture $consumerFirst -State pending).Count |
+            Should -Be 1
+        $lateResume = Invoke-Task659Resume -Fixture $consumerFirst
+        $lateResume.nodes.build.state | Should -BeExactly 'succeeded'
+        $lateResume.nodes.verify.state | Should -BeExactly 'running'
+        $consumerFirst.Dispatches.Count | Should -Be 2
+        (Get-Task659MailboxFiles -Fixture $consumerFirst -State consumed).Count |
+            Should -Be 1
+    }
+
+    It 'DW21 lets an exact result finish while a live dispatch owner holds the state lease without mutating run bytes' {
+        Assert-Task659RuntimeLoaded
+        $fixture = New-Task659Fixture -Name 'dw21' -RunId 'run-dw21'
+        $child = Start-Task659DispatchOwnerProcess `
+            -Fixture $fixture -Mode hold-after-effect
+        $childResult = $null
+        $send = $null
+        $beforeProducer = $null
+        $afterProducer = $null
+        $ownerAliveAfterProducer = $false
+        try {
+            (Wait-Task659EffectMarker -Child $child) | Should -BeTrue
+            $child.Process.HasExited | Should -BeFalse
+            $beforeProducer = Get-Task659StateBytes -Fixture $fixture
+            $send = Send-Task659InternalResult `
+                -Fixture $fixture -Outcome succeeded -ExitCode 0
+            $ownerAliveAfterProducer = -not $child.Process.HasExited
+            $afterProducer = Get-Task659StateBytes -Fixture $fixture
+        } finally {
+            if ($null -ne $child.Process -and -not $child.Process.HasExited) {
+                $childResult = Complete-Task659OwnerProcess -Child $child -Release
+            } elseif ($null -eq $childResult) {
+                $childResult = Complete-Task659OwnerProcess -Child $child
+            }
+        }
+
+        $send.ExitCode | Should -Be 0 -Because $send.Output
+        $ownerAliveAfterProducer | Should -BeTrue
+        [Linq.Enumerable]::SequenceEqual[byte](
+            [byte[]]$beforeProducer,
+            [byte[]]$afterProducer
+        ) | Should -BeTrue
+        (Get-Task659MailboxFiles -Fixture $fixture -State pending).Count |
+            Should -Be 1
+        $childResult.ExitCode | Should -Be 0 -Because $childResult.StdErr
+        $running = Read-DeclarativeWorkflowRunState `
+            -ProjectDir $fixture.ProjectDir -RunId $fixture.RunId
+        $running.nodes.build.state | Should -BeExactly 'running'
+
+        $result = Invoke-Task659Resume -Fixture $fixture
+        $after = Read-DeclarativeWorkflowRunState `
+            -ProjectDir $fixture.ProjectDir -RunId $fixture.RunId
+        $result.state | Should -BeExactly 'running'
+        $after.nodes.build.state | Should -BeExactly 'succeeded'
+        $after.nodes.verify.state | Should -BeExactly 'running'
+        $fixture.Dispatches.Count | Should -Be 1
+        $fixture.Dispatches[0].node_id | Should -BeExactly 'verify'
+        (Get-Task659MailboxFiles -Fixture $fixture -State consumed).Count |
+            Should -Be 1
+    }
+}

--- a/tests/DeclarativeWorkflow.Tests.ps1
+++ b/tests/DeclarativeWorkflow.Tests.ps1
@@ -1349,6 +1349,152 @@ $ErrorActionPreference = 'Stop'
             $env:WINSMUX_INTERNAL_WORKFLOW_SERVER_SESSION_ID = $sinkEnvironment.server_session_id
         }
 
+        $rollbackProject = Join-Path $TestDrive 'dw15-rollback-project'
+        $rollbackProbePath = Join-Path $TestDrive 'dw15-rollback-probe.ps1'
+        $rollbackProbeSource = @'
+param(
+    [Parameter(Mandatory = $true)][string]$CorePath,
+    [Parameter(Mandatory = $true)][string]$ProjectDir
+)
+
+$ErrorActionPreference = 'Stop'
+$WarningPreference = 'SilentlyContinue'
+[Console]::OutputEncoding = [Text.UTF8Encoding]::new($false)
+. $CorePath 'version' *> $null
+
+[IO.Directory]::CreateDirectory((Join-Path $ProjectDir '.winsmux')) | Out-Null
+$manifest = [ordered]@{
+    version = 2
+    session = [ordered]@{
+        name = 'winsmux-orchestra'
+        generation_id = 'generation-dw15-current'
+        server_session_id = '$659'
+        session_ready = $true
+    }
+    panes = [ordered]@{
+        'worker-1' = [ordered]@{
+            slot_id = 'worker-1'
+            pane_id = '%2'
+            worker_backend = 'codex'
+            role = 'Worker'
+            title = 'W1'
+            status = 'ready'
+            runtime_ready = $true
+            exec_mode = $false
+        }
+    }
+    tasks = [ordered]@{ queued = @(); in_progress = @(); completed = @() }
+    worktrees = [ordered]@{}
+}
+Save-WinsmuxManifest -ProjectDir $ProjectDir -Manifest $manifest
+$manifestPath = Join-Path (Join-Path $ProjectDir '.winsmux') 'manifest.yaml'
+$script:rollbackProjectDir = $ProjectDir
+$script:rollbackContext = [PSCustomObject]@{
+    ManifestPath = $manifestPath
+    ProjectDir = $ProjectDir
+    SessionName = 'winsmux-orchestra'
+    Label = 'worker-1'
+    PaneId = '%2'
+    Role = 'Worker'
+    Status = 'ready'
+    SecurityPolicy = $null
+    LaunchDir = $ProjectDir
+    GitWorktreeDir = (Join-Path $ProjectDir '.git')
+    Branch = 'codex/task-659-red'
+    HeadSha = 'red659'
+}
+$script:rollbackManifest = $manifest
+$script:rollbackSubmissionCount = 0
+
+function Resolve-Target { return '%2' }
+function Resolve-TerminalBackend { return 'tauri' }
+function Get-SlotAgentConfig {
+    return [PSCustomObject]@{
+        Agent = 'codex'
+        Model = 'gpt-5.5'
+        PromptTransport = 'argv'
+        CapabilityAdapter = 'codex'
+        CapabilityCommand = 'codex'
+    }
+}
+function Get-RoleAgentConfig { return Get-SlotAgentConfig }
+function Assert-WinsmuxTargetRuntimeWriteAllowed {
+    return [PSCustomObject]@{
+        Managed = $true
+        ProjectDir = $script:rollbackProjectDir
+        Context = $script:rollbackContext
+        Operation = 'dispatch'
+        GenerationId = 'generation-dw15-current'
+    }
+}
+function Start-DeferredPaneFromManifestEntry { return $false }
+function Get-WinsmuxManifest { return $script:rollbackManifest }
+function Get-WinsmuxVerifiedManifestIdentity {
+    return [PSCustomObject]@{
+        session_name = 'winsmux-orchestra'
+        generation_id = 'generation-dw15-current'
+        server_session_id = '$659'
+    }
+}
+function Send-TextToPane {
+    $script:rollbackSubmissionCount++
+    throw 'pane submission must not occur'
+}
+
+$env:WINSMUX_INTERNAL_WORKFLOW_PROJECT_DIR = [IO.Path]::GetFullPath($ProjectDir)
+$env:WINSMUX_INTERNAL_WORKFLOW_SESSION_NAME = 'winsmux-orchestra'
+$env:WINSMUX_INTERNAL_WORKFLOW_GENERATION_ID = 'generation-dw15-planned'
+$env:WINSMUX_INTERNAL_WORKFLOW_SERVER_SESSION_ID = '$659'
+$marker = 'private-task-callback-dw15'
+$prompt = $marker + ' ' + ('x' * 5000)
+$errorText = ''
+Push-Location $ProjectDir
+try {
+    try {
+        Invoke-Send -SendTarget '%2' -SendArguments @($prompt)
+    } catch {
+        $errorText = [string]$_.Exception.Message
+    }
+} finally {
+    Pop-Location
+}
+
+$promptDir = Join-Path (Join-Path $ProjectDir '.winsmux') 'dispatch-prompts'
+$promptFiles = @(
+    if (Test-Path -LiteralPath $promptDir -PathType Container) {
+        Get-ChildItem -LiteralPath $promptDir -File
+    }
+)
+$containsMarker = @(
+    $promptFiles |
+        Where-Object {
+            [IO.File]::ReadAllText(
+                $_.FullName,
+                [Text.UTF8Encoding]::new($false, $true)
+            ).Contains($marker)
+        }
+).Count -gt 0
+[ordered]@{
+    error = $errorText
+    prompt_file_count = $promptFiles.Count
+    prompt_contains_private_marker = $containsMarker
+    submission_count = $script:rollbackSubmissionCount
+} | ConvertTo-Json -Compress
+'@
+        [IO.File]::WriteAllText(
+            $rollbackProbePath,
+            $rollbackProbeSource,
+            [Text.UTF8Encoding]::new($false)
+        )
+        [IO.Directory]::CreateDirectory($rollbackProject) | Out-Null
+        $rollbackOutput = & pwsh -NoProfile -File $rollbackProbePath `
+            -CorePath $script:Task659BridgePath `
+            -ProjectDir $rollbackProject 2>&1
+        $rollbackExitCode = $LASTEXITCODE
+        $rollbackText = ($rollbackOutput | Out-String).Trim()
+        $rollbackExitCode | Should -Be 0 -Because $rollbackText
+        $rollbackProbe = $rollbackText | ConvertFrom-Json
+
         $authorityDefects = [Collections.Generic.List[string]]::new()
         if (-not [string]::IsNullOrWhiteSpace($bridgeError)) {
             $authorityDefects.Add("transport: $bridgeError") | Out-Null
@@ -1373,6 +1519,10 @@ $ErrorActionPreference = 'Stop'
         $authorityCallCount | Should -BeGreaterOrEqual 2
         $authorityBeforeEverySink | Should -BeTrue
         $sinkValidationError | Should -Match 'workflow_dispatch_authority_changed'
+        $rollbackProbe.error | Should -Match 'workflow_dispatch_authority_changed'
+        $rollbackProbe.prompt_file_count | Should -Be 0
+        $rollbackProbe.prompt_contains_private_marker | Should -BeFalse
+        $rollbackProbe.submission_count | Should -Be 0
     }
 
     It 'DW16 gives normal and extended path spellings one machine-wide run-adjacent file lease' {

--- a/tests/DeclarativeWorkflow.Tests.ps1
+++ b/tests/DeclarativeWorkflow.Tests.ps1
@@ -1810,6 +1810,7 @@ $script:CapturedWorkflowDispatches = [Collections.Generic.List[object]]::new()
 function Invoke-TeamPipelineBridge {
     param(
         [string[]]$Arguments,
+        [AllowNull()][string]$InputText,
         [switch]$AllowFailure,
         [string]$ProjectDir,
         [string]$ExpectedSessionName,
@@ -1819,6 +1820,7 @@ function Invoke-TeamPipelineBridge {
 
     $script:CapturedWorkflowDispatches.Add([ordered]@{
             arguments = @($Arguments)
+            input_text = $InputText
             project_dir = $ProjectDir
             session_name = $ExpectedSessionName
             generation_id = $ExpectedGenerationId
@@ -1897,7 +1899,8 @@ $result = Invoke-DeclarativeWorkflow @invokeParameters
         $firstDispatch = $startCapture.calls[0]
         $firstDispatch.arguments[0] | Should -BeExactly 'send'
         $firstDispatch.arguments[1] | Should -BeExactly 'builder-1'
-        $prompt = [string]$firstDispatch.arguments[2]
+        $firstDispatch.arguments[2] | Should -BeExactly '--workflow-prompt-stdin'
+        $prompt = [string]$firstDispatch.input_text
         $prompt.Substring(0, $fixture.TaskText.Length) |
             Should -BeExactly $fixture.TaskText
         $callbackMatch = [regex]::Match(
@@ -1971,6 +1974,8 @@ $result = Invoke-DeclarativeWorkflow @invokeParameters
         $after.nodes.verify.state | Should -BeExactly 'running'
         @($resumeCapture.calls).Count | Should -Be 1
         [string]$resumeCapture.calls[0].arguments[2] |
+            Should -BeExactly '--workflow-prompt-stdin'
+        [string]$resumeCapture.calls[0].input_text |
             Should -Match '"node_id":"verify"'
     }
 
@@ -2091,5 +2096,230 @@ $result = Invoke-DeclarativeWorkflow @invokeParameters
         $fixture.Dispatches[0].node_id | Should -BeExactly 'verify'
         (Get-Task659MailboxFiles -Fixture $fixture -State consumed).Count |
             Should -Be 1
+    }
+
+    It 'TB01 acknowledges only already-admitted terminal pending proofs across every adjacent move crash cut' {
+        Assert-Task659RuntimeLoaded
+        $cases = @(
+            [ordered]@{
+                name = 'succeeded'
+                outcome = 'succeeded'
+                exit_code = 0
+            },
+            [ordered]@{
+                name = 'failed'
+                outcome = 'failed'
+                exit_code = 23
+            }
+        )
+
+        foreach ($case in $cases) {
+            $fixture = New-Task659Fixture `
+                -Name "tb01-$($case.name)" `
+                -RunId "run-tb01-$($case.name)" `
+                -SingleNode
+            $null = Invoke-Task659Start -Fixture $fixture
+            $send = Send-Task659InternalResult `
+                -Fixture $fixture `
+                -Outcome ([string]$case.outcome) `
+                -ExitCode ([int]$case.exit_code)
+            $send.ExitCode | Should -Be 0 -Because $send.Output
+            (Get-Task659MailboxFiles -Fixture $fixture -State pending).Count |
+                Should -Be 1
+
+            $consumedPath = Join-Path $fixture.ProjectDir (
+                ".winsmux\workflow-mailbox\$($fixture.RunId)\consumed"
+            )
+            if (Test-Path -LiteralPath $consumedPath -PathType Container) {
+                Remove-Item -LiteralPath $consumedPath
+            }
+            [IO.File]::WriteAllText(
+                $consumedPath,
+                'TB01 injected adjacent-cut blocker',
+                [Text.UTF8Encoding]::new($false)
+            )
+
+            { Invoke-Task659Resume -Fixture $fixture } | Should -Throw
+            $terminal = Read-DeclarativeWorkflowRunState `
+                -ProjectDir $fixture.ProjectDir -RunId $fixture.RunId
+            $terminal.state | Should -BeExactly ([string]$case.outcome)
+            $terminal.nodes.build.state | Should -BeExactly ([string]$case.outcome)
+            @($terminal.admitted_messages).Count | Should -Be 1
+            (Get-Task659MailboxFiles -Fixture $fixture -State pending).Count |
+                Should -Be 1
+            (Test-Path -LiteralPath $consumedPath -PathType Container) |
+                Should -BeFalse
+            $fixture.Dispatches.Count | Should -Be 1
+            $stateAfterPersist = Get-Task659StateBytes -Fixture $fixture
+
+            Remove-Item -LiteralPath $consumedPath -Force
+            $reconciled = Invoke-Task659Resume -Fixture $fixture
+            $reconciled.state | Should -BeExactly ([string]$case.outcome)
+            [Linq.Enumerable]::SequenceEqual[byte](
+                [byte[]]$stateAfterPersist,
+                [byte[]](Get-Task659StateBytes -Fixture $fixture)
+            ) | Should -BeTrue
+            (Get-Task659MailboxFiles -Fixture $fixture -State pending).Count |
+                Should -Be 0
+            (Get-Task659MailboxFiles -Fixture $fixture -State consumed).Count |
+                Should -Be 1
+            $fixture.Dispatches.Count | Should -Be 1
+
+            $stateAfterReconciliation = Get-Task659StateBytes -Fixture $fixture
+            { Invoke-Task659Resume -Fixture $fixture } | Should -Throw '*terminal*'
+            [Linq.Enumerable]::SequenceEqual[byte](
+                [byte[]]$stateAfterReconciliation,
+                [byte[]](Get-Task659StateBytes -Fixture $fixture)
+            ) | Should -BeTrue
+            (Get-Task659MailboxFiles -Fixture $fixture -State consumed).Count |
+                Should -Be 1
+            $fixture.Dispatches.Count | Should -Be 1
+        }
+    }
+
+    It 'TB02 carries an unbounded internal workflow payload through real child stdin with metadata-only argv' {
+        Assert-Task659RuntimeLoaded
+        $fixture = New-Task659Fixture -Name 'tb02' -RunId 'run-tb02'
+        $privateMarker = 'TB02-private-task-marker'
+        $largeTask = $privateMarker + "`n" + ('x' * 70000)
+        [IO.File]::WriteAllText(
+            $fixture.TaskFile,
+            $largeTask,
+            [Text.UTF8Encoding]::new($false)
+        )
+        $fixture.TaskText = $largeTask
+        $expectedPayloadBytes = [Text.UTF8Encoding]::new($false).GetByteCount($largeTask)
+        $expectedPayloadBytes | Should -BeGreaterThan 65536
+
+        $probePath = Join-Path $fixture.ProjectDir 'tb02-child-probe.ps1'
+        $corePathLiteral = $script:Task659BridgePath.Replace("'", "''")
+        $probeSource = @'
+param()
+$ErrorActionPreference = 'Stop'
+[Console]::OutputEncoding = [Text.UTF8Encoding]::new($false)
+$requestedArguments = @($args)
+trap {
+    try {
+        $null = [Console]::In.ReadToEnd()
+    } catch {
+    }
+    [Console]::Error.WriteLine(
+        'TB02_CHILD_ERROR: ' + [string]$_.Exception.Message
+    )
+    [Console]::Error.WriteLine(
+        'TB02_CHILD_PROJECT: expected=' +
+        [string]$env:WINSMUX_INTERNAL_WORKFLOW_PROJECT_DIR +
+        '; current=' +
+        [string](Get-Location).Path
+    )
+    exit 97
+}
+. '__TASK659_CORE_PATH__' 'version' *> $null
+
+$script:tb02CapturedText = $null
+$script:tb02Identity = [PSCustomObject]@{
+    session_name = [string]$env:WINSMUX_INTERNAL_WORKFLOW_SESSION_NAME
+    generation_id = [string]$env:WINSMUX_INTERNAL_WORKFLOW_GENERATION_ID
+    server_session_id = [string]$env:WINSMUX_INTERNAL_WORKFLOW_SERVER_SESSION_ID
+}
+function Get-WinsmuxManifest {
+    param([string]$ProjectDir)
+    return [ordered]@{}
+}
+function Get-WinsmuxVerifiedManifestIdentity {
+    param($Manifest)
+    return $script:tb02Identity
+}
+function Resolve-Target {
+    param([string]$Label)
+    return '%2'
+}
+function Resolve-TerminalBackend { return 'tauri' }
+function Assert-WinsmuxTargetRuntimeWriteAllowed {
+    param(
+        [string]$PaneId,
+        [string]$CurrentProjectDir,
+        [string]$Operation,
+        [string]$ExpectedGenerationId
+    )
+    return [PSCustomObject]@{
+        Managed = $false
+        ProjectDir = $CurrentProjectDir
+        Context = $null
+        Operation = 'dispatch'
+        GenerationId = ''
+    }
+}
+function Resolve-SendTransportIntent {
+    param(
+        [string]$Text,
+        [string]$ProjectDir,
+        [int]$LengthLimit,
+        [string]$PromptTransport,
+        [string]$TaskSlug,
+        [bool]$ExecMode,
+        [string]$LaunchDir,
+        [string]$GitWorktreeDir,
+        [string]$Model,
+        [string]$ExecCommand
+    )
+    $script:tb02CapturedText = $Text
+    throw 'TB02_CAPTURED_AFTER_STDIN'
+}
+
+$captureError = ''
+try {
+    Invoke-Send `
+        -SendTarget ([string]$requestedArguments[1]) `
+        -SendArguments @([string]$requestedArguments[2])
+} catch {
+    $captureError = [string]$_.Exception.Message
+}
+if ($captureError -cne 'TB02_CAPTURED_AFTER_STDIN' -or
+    $null -eq $script:tb02CapturedText) {
+    throw "TB02 child consumer did not capture stdin: $captureError"
+}
+$payloadBytes = [Text.UTF8Encoding]::new($false).GetBytes(
+    [string]$script:tb02CapturedText
+)
+$hash = [Security.Cryptography.SHA256]::Create().ComputeHash($payloadBytes)
+[ordered]@{
+    arguments = @($requestedArguments)
+    payload_bytes = $payloadBytes.Length
+    payload_sha256 = 'sha256:' + (($hash | ForEach-Object { $_.ToString('x2') }) -join '')
+    contains_private_marker = ([string]$script:tb02CapturedText).Contains('TB02-private-task-marker')
+} | ConvertTo-Json -Depth 10 -Compress
+'@.Replace('__TASK659_CORE_PATH__', $corePathLiteral)
+        [IO.File]::WriteAllText(
+            $probePath,
+            $probeSource,
+            [Text.UTF8Encoding]::new($false)
+        )
+
+        $originalBridgeScript = $script:TeamPipelineBridgeScript
+        try {
+            $script:TeamPipelineBridgeScript = $probePath
+            $bridgeReceipt = Invoke-TeamPipelineBridge `
+                -Arguments @('send', 'builder-1', '--workflow-prompt-stdin') `
+                -InputText $largeTask `
+                -ProjectDir $fixture.ProjectDir `
+                -ExpectedSessionName ([string]$fixture.Identity.session_name) `
+                -ExpectedGenerationId ([string]$fixture.Identity.generation_id) `
+                -ExpectedServerSessionId ([string]$fixture.Identity.server_session_id)
+        } finally {
+            $script:TeamPipelineBridgeScript = $originalBridgeScript
+        }
+        $bridgeReceipt.ExitCode | Should -Be 0 -Because $bridgeReceipt.Output
+        $probe = $bridgeReceipt.Output | ConvertFrom-Json
+        @($probe.arguments).Count | Should -Be 3
+        [string]$probe.arguments[0] | Should -BeExactly 'send'
+        [string]$probe.arguments[1] | Should -BeExactly 'builder-1'
+        [string]$probe.arguments[2] | Should -BeExactly '--workflow-prompt-stdin'
+        (@($probe.arguments) -join ' ') | Should -Not -Match $privateMarker
+        [int64]$probe.payload_bytes | Should -Be $expectedPayloadBytes
+        [string]$probe.payload_sha256 | Should -BeExactly (
+            Get-Task659Sha256 -Bytes ([Text.UTF8Encoding]::new($false).GetBytes($largeTask))
+        )
+        $probe.contains_private_marker | Should -BeTrue
     }
 }

--- a/tests/NpmReleasePackage.Tests.ps1
+++ b/tests/NpmReleasePackage.Tests.ps1
@@ -697,10 +697,35 @@ param(
     }
 
     It 'verifies every installer download target against the release tree and rejects a missing target' {
+        $candidateIndex = Join-Path $TestDrive 'install-download-candidate.index'
+        $originalIndex = [Environment]::GetEnvironmentVariable(
+            'GIT_INDEX_FILE',
+            [EnvironmentVariableTarget]::Process
+        )
+        try {
+            $env:GIT_INDEX_FILE = $candidateIndex
+            & git -C $script:RepoRoot read-tree HEAD
+            $LASTEXITCODE | Should -Be 0
+            & git -C $script:RepoRoot add -- `
+                install.ps1 `
+                winsmux-core/scripts/declarative-workflow.ps1
+            $LASTEXITCODE | Should -Be 0
+            $candidateTree = [string](& git -C $script:RepoRoot write-tree)
+            $LASTEXITCODE | Should -Be 0
+            $candidateTree = $candidateTree.Trim()
+            $candidateTree | Should -Match '^[0-9a-f]{40}$'
+        } finally {
+            [Environment]::SetEnvironmentVariable(
+                'GIT_INDEX_FILE',
+                $originalIndex,
+                [EnvironmentVariableTarget]::Process
+            )
+        }
+
         $valid = Invoke-PwshProcess -Arguments @(
             '-NoProfile', '-File', $script:InstallDownloadGatePath,
             '-RepositoryRoot', $script:RepoRoot,
-            '-Treeish', 'HEAD'
+            '-Treeish', $candidateTree
         )
         $valid.ExitCode | Should -Be 0
         $valid.StdErr | Should -Be ''
@@ -708,7 +733,9 @@ param(
         $validSummary.download_target_count | Should -BeGreaterThan 0
         $validSummary.runtime_dependency_count | Should -BeGreaterThan 0
         @($validSummary.download_targets) | Should -Contain 'scripts/winsmux-core.ps1'
+        @($validSummary.download_targets) | Should -Contain 'winsmux-core/scripts/declarative-workflow.ps1'
         @($validSummary.download_targets) | Should -Not -Contain 'winsmux.ps1'
+        @($validSummary.runtime_dependencies) | Should -Contain 'declarative-workflow.ps1'
         @($validSummary.runtime_dependencies) | Should -Contain 'json-compat.ps1'
 
         $invalidInstaller = Join-Path $TestDrive 'install-with-missing-download.ps1'
@@ -724,7 +751,7 @@ param(
             '-NoProfile', '-File', $script:InstallDownloadGatePath,
             '-RepositoryRoot', $script:RepoRoot,
             '-InstallScriptPath', $invalidInstaller,
-            '-Treeish', 'HEAD'
+            '-Treeish', $candidateTree
         )
         $missing.ExitCode | Should -Not -Be 0
         $missing.StdErr | Should -Match 'missing/installer-entrypoint\.ps1'
@@ -776,7 +803,7 @@ param(
                 '-NoProfile', '-File', $script:InstallDownloadGatePath,
                 '-RepositoryRoot', $script:RepoRoot,
                 '-InstallScriptPath', $casePath,
-                '-Treeish', 'HEAD'
+                '-Treeish', $candidateTree
             )
             $caseResult.ExitCode | Should -Not -Be 0 -Because $case.Name
             $caseResult.StdErr | Should -Match $case.Error -Because $case.Name

--- a/tests/NpmReleasePackage.Tests.ps1
+++ b/tests/NpmReleasePackage.Tests.ps1
@@ -715,11 +715,16 @@ param(
             $candidateTree = $candidateTree.Trim()
             $candidateTree | Should -Match '^[0-9a-f]{40}$'
         } finally {
-            [Environment]::SetEnvironmentVariable(
-                'GIT_INDEX_FILE',
-                $originalIndex,
-                [EnvironmentVariableTarget]::Process
-            )
+            if ($null -eq $originalIndex) {
+                Remove-Item Env:GIT_INDEX_FILE -ErrorAction SilentlyContinue
+            } else {
+                $env:GIT_INDEX_FILE = $originalIndex
+            }
+        }
+        if ($null -eq $originalIndex) {
+            Test-Path Env:GIT_INDEX_FILE | Should -BeFalse
+        } else {
+            $env:GIT_INDEX_FILE | Should -BeExactly $originalIndex
         }
 
         $valid = Invoke-PwshProcess -Arguments @(

--- a/winsmux-core/scripts/control-plane-dispatch.ps1
+++ b/winsmux-core/scripts/control-plane-dispatch.ps1
@@ -349,11 +349,19 @@ function Invoke-WinsmuxTeamPipelineCommand {
             -CommandTarget $CommandTarget -CommandRest $CommandRest
     }
     if ($null -ne $declarative) {
+        if (-not (Get-Command Resolve-WinsmuxRawCommand -CommandType Function -ErrorAction SilentlyContinue)) {
+            throw 'workflow_plan_unavailable: parent executable resolver is not loaded.'
+        }
+        $workflowPlanCommand = [string](Resolve-WinsmuxRawCommand)
+        if ([string]::IsNullOrWhiteSpace($workflowPlanCommand)) {
+            throw 'workflow_plan_unavailable: parent executable resolver returned an empty command.'
+        }
         $pipelineArgs = @(
             '-WorkflowAction', [string]$declarative.workflow_action,
             '-RunId', [string]$declarative.run_id,
             '-TaskFile', [string]$declarative.task_file,
-            '-ProjectDir', [string]$declarative.project_dir
+            '-ProjectDir', [string]$declarative.project_dir,
+            '-WorkflowPlanCommand', $workflowPlanCommand
         )
         if ($declarative.workflow_action -ceq 'start') {
             $pipelineArgs += @(

--- a/winsmux-core/scripts/control-plane-dispatch.ps1
+++ b/winsmux-core/scripts/control-plane-dispatch.ps1
@@ -339,18 +339,140 @@ function Invoke-WinsmuxTeamPipelineCommand {
     param(
         [Parameter(Mandatory = $true)][string]$BridgeScriptRoot,
         [AllowNull()][string]$CommandTarget,
-        [AllowNull()][string[]]$CommandRest
+        [AllowNull()][string[]]$CommandRest,
+        [switch]$AllowDeclarativeWorkflow
     )
 
-    $taskText = Join-WinsmuxControlPlaneText -Arguments (Get-WinsmuxControlPlaneArguments -CommandTarget $CommandTarget -CommandRest $CommandRest)
-    $pipelineArgs = @()
+    $declarative = $null
+    if ($AllowDeclarativeWorkflow) {
+        $declarative = ConvertTo-WinsmuxDeclarativePipelineArguments `
+            -CommandTarget $CommandTarget -CommandRest $CommandRest
+    }
+    if ($null -ne $declarative) {
+        $pipelineArgs = @(
+            '-WorkflowAction', [string]$declarative.workflow_action,
+            '-RunId', [string]$declarative.run_id,
+            '-TaskFile', [string]$declarative.task_file,
+            '-ProjectDir', [string]$declarative.project_dir
+        )
+        if ($declarative.workflow_action -ceq 'start') {
+            $pipelineArgs += @(
+                '-RecipeId', [string]$declarative.recipe_id,
+                '-WorkflowId', [string]$declarative.workflow_id
+            )
+        }
+        if ($declarative.as_json) {
+            $pipelineArgs += '-AsJson'
+        }
+        Invoke-WinsmuxControlPlaneScript `
+            -ScriptPath (Get-WinsmuxControlPlaneScriptPath -BridgeScriptRoot $BridgeScriptRoot -ScriptName 'team-pipeline.ps1') `
+            -Arguments $pipelineArgs `
+            -PropagateExitCode
+        return
+    }
+
+    $taskText = Join-WinsmuxControlPlaneText -Arguments (
+        Get-WinsmuxControlPlaneArguments -CommandTarget $CommandTarget -CommandRest $CommandRest
+    )
+    $legacyPipelineArgs = @()
     if ($taskText) {
-        $pipelineArgs = @('-Task', $taskText)
+        $legacyPipelineArgs = @('-Task', $taskText)
     }
 
     Invoke-WinsmuxControlPlaneScript `
         -ScriptPath (Get-WinsmuxControlPlaneScriptPath -BridgeScriptRoot $BridgeScriptRoot -ScriptName 'team-pipeline.ps1') `
-        -Arguments $pipelineArgs
+        -Arguments $legacyPipelineArgs
+}
+
+function ConvertTo-WinsmuxDeclarativePipelineArguments {
+    param(
+        [AllowNull()][string]$CommandTarget,
+        [AllowNull()][string[]]$CommandRest
+    )
+
+    if ($CommandTarget -cne '--workflow-action') {
+        return $null
+    }
+
+    $usage = 'usage: winsmux pipeline --workflow-action start --recipe-id <id> --workflow-id <id> --run-id <id> --task-file <path> --project-dir <path> --json | winsmux pipeline --workflow-action resume --run-id <id> --task-file <path> --project-dir <path> --json'
+    $tokens = @($CommandRest)
+    if ($tokens.Count -lt 1) {
+        Stop-WithError '--workflow-action requires start or resume.'
+    }
+    $action = [string]$tokens[0]
+    if ($action -cnotin @('start', 'resume')) {
+        Stop-WithError '--workflow-action requires start or resume.'
+    }
+
+    $values = [ordered]@{
+        recipe_id = ''
+        workflow_id = ''
+        run_id = ''
+        task_file = ''
+        project_dir = ''
+    }
+    $seenJson = $false
+    $index = 1
+    while ($index -lt $tokens.Count) {
+        $token = [string]$tokens[$index]
+        if ($token -ceq '--json') {
+            if ($seenJson) {
+                Stop-WithError $usage
+            }
+            $seenJson = $true
+            $index++
+            continue
+        }
+
+        $name = switch -CaseSensitive ($token) {
+            '--recipe-id' { 'recipe_id' }
+            '--workflow-id' { 'workflow_id' }
+            '--run-id' { 'run_id' }
+            '--task-file' { 'task_file' }
+            '--project-dir' { 'project_dir' }
+            default { '' }
+        }
+        if ([string]::IsNullOrWhiteSpace($name) -or
+            $index + 1 -ge $tokens.Count -or
+            -not [string]::IsNullOrWhiteSpace([string]$values[$name])) {
+            Stop-WithError $usage
+        }
+        $index++
+        $value = [string]$tokens[$index]
+        if ([string]::IsNullOrWhiteSpace($value) -or $value.StartsWith('--')) {
+            Stop-WithError $usage
+        }
+        $values[$name] = $value
+        $index++
+    }
+
+    foreach ($required in @('run_id', 'task_file', 'project_dir')) {
+        if ([string]::IsNullOrWhiteSpace([string]$values[$required])) {
+            Stop-WithError $usage
+        }
+    }
+    if (-not $seenJson) {
+        Stop-WithError $usage
+    }
+    if ($action -ceq 'start') {
+        if ([string]::IsNullOrWhiteSpace([string]$values.recipe_id) -or
+            [string]::IsNullOrWhiteSpace([string]$values.workflow_id)) {
+            Stop-WithError $usage
+        }
+    } elseif (-not [string]::IsNullOrWhiteSpace([string]$values.recipe_id) -or
+        -not [string]::IsNullOrWhiteSpace([string]$values.workflow_id)) {
+        Stop-WithError $usage
+    }
+
+    return [PSCustomObject][ordered]@{
+        workflow_action = $action
+        recipe_id = [string]$values.recipe_id
+        workflow_id = [string]$values.workflow_id
+        run_id = [string]$values.run_id
+        task_file = [string]$values.task_file
+        project_dir = [string]$values.project_dir
+        as_json = $seenJson
+    }
 }
 
 function Invoke-WinsmuxBuilderQueueCommand {

--- a/winsmux-core/scripts/declarative-workflow.ps1
+++ b/winsmux-core/scripts/declarative-workflow.ps1
@@ -311,29 +311,14 @@ function Invoke-DeclarativeWorkflowWorkspacePlan {
         [Parameter(Mandatory = $true)][string]$RecipeId,
         [Parameter(Mandatory = $true)][string]$WorkflowId,
         [Parameter(Mandatory = $true)][string]$RunId,
-        [Parameter(Mandatory = $true)][string]$ProjectDir
+        [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [Parameter(Mandatory = $true)][string]$WorkspacePlanCommand
     )
 
-    $command = ''
-    foreach ($candidate in @(
-        [string]$env:WINSMUX_RAW_EXE,
-        [string]$env:WINSMUX_BIN,
-        (Join-Path $ProjectDir 'target\release\winsmux.exe'),
-        (Join-Path $ProjectDir 'target\debug\winsmux.exe')
-    )) {
-        if (-not [string]::IsNullOrWhiteSpace($candidate) -and
-            (Test-Path -LiteralPath $candidate -PathType Leaf)) {
-            $command = [System.IO.Path]::GetFullPath($candidate)
-            break
-        }
+    if ([string]::IsNullOrWhiteSpace($WorkspacePlanCommand)) {
+        throw 'workflow_plan_unavailable: parent-resolved winsmux command is required.'
     }
-    if ([string]::IsNullOrWhiteSpace($command)) {
-        $resolved = Get-Command winsmux.exe -ErrorAction SilentlyContinue | Select-Object -First 1
-        if ($null -eq $resolved) {
-            throw 'workflow_plan_unavailable: winsmux executable was not found.'
-        }
-        $command = [string]$resolved.Path
-    }
+    $command = $WorkspacePlanCommand
 
     $output = @(
         & $command workspace-plan `
@@ -1064,6 +1049,7 @@ function Invoke-DeclarativeWorkflow {
         [Parameter(Mandatory = $true)][string]$RunId,
         [Parameter(Mandatory = $true)][string]$TaskFile,
         [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [string]$WorkspacePlanCommand = '',
         [scriptblock]$WorkspacePlanInvoker,
         [scriptblock]$ManifestIdentityReader,
         [scriptblock]$SourceHeadReader,
@@ -1077,12 +1063,17 @@ function Invoke-DeclarativeWorkflow {
     $resolvedProject = [System.IO.Path]::GetFullPath($ProjectDir)
     $task = Get-DeclarativeWorkflowTaskSnapshot -TaskFile $TaskFile
     if ($null -eq $WorkspacePlanInvoker) {
+        if ([string]::IsNullOrWhiteSpace($WorkspacePlanCommand)) {
+            throw 'workflow_plan_unavailable: parent-resolved winsmux command is required.'
+        }
+        $resolvedWorkspacePlanCommand = $WorkspacePlanCommand
         $WorkspacePlanInvoker = {
             param($SelectedRecipeId, $SelectedWorkflowId, $SelectedRunId, $SelectedProjectDir)
             Invoke-DeclarativeWorkflowWorkspacePlan `
                 -RecipeId $SelectedRecipeId -WorkflowId $SelectedWorkflowId `
-                -RunId $SelectedRunId -ProjectDir $SelectedProjectDir
-        }
+                -RunId $SelectedRunId -ProjectDir $SelectedProjectDir `
+                -WorkspacePlanCommand $resolvedWorkspacePlanCommand
+        }.GetNewClosure()
     }
     if ($null -eq $ManifestIdentityReader) {
         $ManifestIdentityReader = {

--- a/winsmux-core/scripts/declarative-workflow.ps1
+++ b/winsmux-core/scripts/declarative-workflow.ps1
@@ -389,6 +389,9 @@ function Assert-DeclarativeWorkflowPlan {
         [string](Get-DeclarativeWorkflowValue -InputObject $workflow -Name 'run_id' -Default '') -cne $RunId) {
         throw 'workflow_plan_invalid: normalized workflow identity mismatch.'
     }
+    if ([string](Get-DeclarativeWorkflowValue -InputObject $workflow -Name 'recipe_ref' -Default '') -cne $RecipeId) {
+        throw 'workflow_plan_invalid: normalized workflow recipe binding mismatch.'
+    }
 
     $nodes = @(Get-DeclarativeWorkflowValue -InputObject $workflow -Name 'nodes' -Default @())
     $order = @(Get-DeclarativeWorkflowValue -InputObject $workflow -Name 'topological_order' -Default @())
@@ -414,6 +417,67 @@ function Assert-DeclarativeWorkflowPlan {
     return $workflow
 }
 
+function ConvertTo-DeclarativeWorkflowPowerShellLiteral {
+    param([Parameter(Mandatory = $true)][string]$Value)
+
+    return "'" + $Value.Replace("'", "''") + "'"
+}
+
+function New-DeclarativeWorkflowDispatchPrompt {
+    param(
+        [Parameter(Mandatory = $true)][string]$TaskContent,
+        [Parameter(Mandatory = $true)]$Node,
+        [Parameter(Mandatory = $true)]$Run,
+        [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [Parameter(Mandatory = $true)][string]$ResultAdapterPath
+    )
+
+    $nodeId = [string](Get-DeclarativeWorkflowValue -InputObject $Node -Name 'node_id' -Default '')
+    Assert-DeclarativeWorkflowIdentifier -Value $nodeId -Name 'node_id'
+    $runId = [string](Get-DeclarativeWorkflowValue -InputObject $Run -Name 'run_id' -Default '')
+    Assert-DeclarativeWorkflowIdentifier -Value $runId -Name 'run_id'
+    $taskDigest = [string](Get-DeclarativeWorkflowValue -InputObject $Run -Name 'task_digest' -Default '')
+    $workflowFingerprint = [string](Get-DeclarativeWorkflowValue -InputObject $Run -Name 'workflow_fingerprint' -Default '')
+    if ($taskDigest -cnotmatch '^sha256:[0-9a-f]{64}$' -or
+        $workflowFingerprint -cnotmatch '^sha256:[0-9a-f]{64}$') {
+        throw 'workflow_dispatch_invalid: durable content identity is missing.'
+    }
+
+    $resolvedProject = [IO.Path]::GetFullPath($ProjectDir)
+    $resolvedAdapter = [IO.Path]::GetFullPath($ResultAdapterPath)
+    $callback = [ordered]@{
+        schema_version = 1
+        adapter_path = $resolvedAdapter
+        project_dir = $resolvedProject
+        run_id = $runId
+        node_id = $nodeId
+        task_digest = $taskDigest
+        workflow_fingerprint = $workflowFingerprint
+    }
+    $callbackJson = $callback | ConvertTo-Json -Depth 5 -Compress
+    $adapterLiteral = ConvertTo-DeclarativeWorkflowPowerShellLiteral -Value $resolvedAdapter
+    $projectLiteral = ConvertTo-DeclarativeWorkflowPowerShellLiteral -Value $resolvedProject
+    $runLiteral = ConvertTo-DeclarativeWorkflowPowerShellLiteral -Value $runId
+    $nodeLiteral = ConvertTo-DeclarativeWorkflowPowerShellLiteral -Value $nodeId
+    $commandPrefix = "pwsh -NoProfile -File $adapterLiteral -WorkflowResult -RunId $runLiteral " +
+        "-WorkflowResultNodeId $nodeLiteral -ProjectDir $projectLiteral"
+    $successCommand = "$commandPrefix -WorkflowResultOutcome succeeded " +
+        '-WorkflowResultExitCode 0 -AsJson'
+    $failureCommand = "$commandPrefix -WorkflowResultOutcome failed " +
+        '-WorkflowResultExitCode 1 -AsJson'
+    $lineBreak = "`n"
+    $contract = @(
+        '<winsmux-workflow-result-v1>',
+        $callbackJson,
+        'After completing this node, execute exactly one result command.',
+        "Success command: $successCommand",
+        "Failure command: $failureCommand",
+        '</winsmux-workflow-result-v1>'
+    ) -join $lineBreak
+
+    return $TaskContent + $lineBreak + $lineBreak + $contract
+}
+
 function Get-DeclarativeWorkflowNode {
     param(
         [Parameter(Mandatory = $true)]$Workflow,
@@ -436,12 +500,14 @@ function Update-DeclarativeWorkflowOverallState {
             [string]$State['nodes'][$nodeId]['state']
         }
     )
-    if ($nodeStates -contains 'failed') {
-        $State['state'] = 'failed'
-    } elseif ($nodeStates.Count -gt 0 -and @($nodeStates | Where-Object { $_ -cne 'succeeded' }).Count -eq 0) {
+    if ($nodeStates.Count -gt 0 -and @($nodeStates | Where-Object { $_ -cne 'succeeded' }).Count -eq 0) {
         $State['state'] = 'succeeded'
     } elseif (@($nodeStates | Where-Object { $_ -in @('running', 'dispatching') }).Count -gt 0) {
         $State['state'] = 'running'
+    } elseif ($nodeStates -contains 'blocked') {
+        $State['state'] = 'blocked'
+    } elseif ($nodeStates -contains 'failed') {
+        $State['state'] = 'failed'
     } else {
         $State['state'] = 'blocked'
     }
@@ -1031,14 +1097,23 @@ function Invoke-DeclarativeWorkflow {
         }
     }
     if ($null -eq $DispatchNode) {
+        $resultAdapterPath = [System.IO.Path]::GetFullPath(
+            (Join-Path $PSScriptRoot 'team-pipeline.ps1')
+        )
+        if (-not (Test-Path -LiteralPath $resultAdapterPath -PathType Leaf)) {
+            throw "workflow_dispatch_unavailable: result adapter was not found: $resultAdapterPath"
+        }
         $DispatchNode = {
             param($Node, $TaskContent, $Run)
             if (-not (Get-Command Invoke-TeamPipelineGuardedSend -CommandType Function -ErrorAction SilentlyContinue)) {
                 throw 'workflow_dispatch_unavailable: guarded send is not loaded.'
             }
             $target = [string](Get-DeclarativeWorkflowValue -InputObject $Node -Name 'pane_ref' -Default '')
+            $prompt = New-DeclarativeWorkflowDispatchPrompt `
+                -TaskContent $TaskContent -Node $Node -Run $Run `
+                -ProjectDir $resolvedProject -ResultAdapterPath $resultAdapterPath
             $blocked = Invoke-TeamPipelineGuardedSend `
-                -StageName 'WORKFLOW' -Target $target -Prompt $TaskContent `
+                -StageName 'WORKFLOW' -Target $target -Prompt $prompt `
                 -ProjectDir $resolvedProject -SessionName ([string]$Run['session']['session_name']) `
                 -ExpectedGenerationId ([string]$Run['session']['generation_id']) `
                 -ExpectedServerSessionId ([string]$Run['session']['server_session_id']) `

--- a/winsmux-core/scripts/declarative-workflow.ps1
+++ b/winsmux-core/scripts/declarative-workflow.ps1
@@ -1114,6 +1114,7 @@ function Invoke-DeclarativeWorkflow {
                 -ProjectDir $resolvedProject -ResultAdapterPath $resultAdapterPath
             $blocked = Invoke-TeamPipelineGuardedSend `
                 -StageName 'WORKFLOW' -Target $target -Prompt $prompt `
+                -WorkflowPromptStdin `
                 -ProjectDir $resolvedProject -SessionName ([string]$Run['session']['session_name']) `
                 -ExpectedGenerationId ([string]$Run['session']['generation_id']) `
                 -ExpectedServerSessionId ([string]$Run['session']['server_session_id']) `
@@ -1156,12 +1157,52 @@ function Invoke-DeclarativeWorkflow {
         }
 
         $state = Read-DeclarativeWorkflowRunState -ProjectDir $resolvedProject -RunId $RunId
-        if ([string]$state['state'] -in @('succeeded', 'failed', 'cancelled')) {
-            throw "workflow_terminal: $([string]$state['state'])"
-        }
+        $terminalState = [string]$state['state'] -in @('succeeded', 'failed', 'cancelled')
         $persistedFingerprint = Get-DeclarativeWorkflowContentDigest -Workflow $state['workflow']
         if ($persistedFingerprint -cne [string]$state['workflow_fingerprint']) {
             throw 'workflow fingerprint mismatch: persisted content changed.'
+        }
+        if ($terminalState) {
+            if ($task.digest -cne [string]$state['task_digest'] -or
+                [int64]$task.bytes.Length -ne [int64]$state['task_bytes']) {
+                throw 'workflow task identity changed.'
+            }
+            if ([string]$state['state'] -ceq 'cancelled') {
+                throw "workflow_terminal: $([string]$state['state'])"
+            }
+
+            $terminalMailbox = Get-DeclarativeWorkflowMailboxRecords `
+                -ProjectDir $resolvedProject -RunId $RunId -Run $state
+            $terminalPending = @(
+                $terminalMailbox.Values |
+                    Where-Object {
+                        -not [string]::IsNullOrWhiteSpace([string]($_['pending_path']))
+                    }
+            )
+            if ($terminalPending.Count -eq 0) {
+                throw "workflow_terminal: $([string]$state['state'])"
+            }
+
+            Assert-DeclarativeWorkflowStateProofConsistency `
+                -State $state -Mailbox $terminalMailbox
+            $terminalAdmitted = [System.Collections.Generic.HashSet[string]]::new(
+                [System.StringComparer]::Ordinal
+            )
+            foreach ($messageId in @($state['admitted_messages'])) {
+                $null = $terminalAdmitted.Add([string]$messageId)
+            }
+            foreach ($entry in @($terminalMailbox.Values)) {
+                $messageId = [string]$entry['record']['message_id']
+                if (-not $terminalAdmitted.Contains($messageId)) {
+                    throw 'workflow_mailbox_invalid: terminal run contains unadmitted proof.'
+                }
+            }
+            foreach ($entry in $terminalPending) {
+                Move-DeclarativeWorkflowMessageToConsumed `
+                    -ProjectDir $resolvedProject -RunId $RunId -MailboxEntry $entry
+            }
+            return Read-DeclarativeWorkflowRunState `
+                -ProjectDir $resolvedProject -RunId $RunId
         }
         $plan = & $WorkspacePlanInvoker `
             ([string]$state['recipe_id']) ([string]$state['workflow_id']) $RunId $resolvedProject

--- a/winsmux-core/scripts/declarative-workflow.ps1
+++ b/winsmux-core/scripts/declarative-workflow.ps1
@@ -1,0 +1,1189 @@
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+. (Join-Path $PSScriptRoot 'json-compat.ps1')
+
+function Get-DeclarativeWorkflowValue {
+    param(
+        [AllowNull()]$InputObject,
+        [Parameter(Mandatory = $true)][string]$Name,
+        $Default = $null
+    )
+
+    if ($null -eq $InputObject) {
+        return $Default
+    }
+    if ($InputObject -is [System.Collections.IDictionary] -and $InputObject.Contains($Name)) {
+        return $InputObject[$Name]
+    }
+    if ($null -ne $InputObject.PSObject -and $InputObject.PSObject.Properties.Name -contains $Name) {
+        return $InputObject.$Name
+    }
+    return $Default
+}
+
+function Assert-DeclarativeWorkflowIdentifier {
+    param(
+        [Parameter(Mandatory = $true)][string]$Value,
+        [Parameter(Mandatory = $true)][string]$Name
+    )
+
+    if ($Value -cnotmatch '^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$' -or $Value.Length -gt 128) {
+        throw "$Name is invalid."
+    }
+}
+
+function ConvertTo-DeclarativeWorkflowCanonicalObject {
+    param([AllowNull()]$Value)
+
+    if ($null -eq $Value) {
+        return $null
+    }
+    if ($Value -is [string] -or $Value -is [char] -or
+        $Value -is [bool] -or $Value -is [byte] -or
+        $Value -is [int16] -or $Value -is [int32] -or
+        $Value -is [int64] -or $Value -is [uint16] -or
+        $Value -is [uint32] -or $Value -is [uint64] -or
+        $Value -is [single] -or $Value -is [double] -or
+        $Value -is [decimal]) {
+        return $Value
+    }
+    if ($Value -is [System.DateTime]) {
+        return $Value.ToUniversalTime().ToString(
+            'o',
+            [System.Globalization.CultureInfo]::InvariantCulture
+        )
+    }
+    if ($Value -is [System.DateTimeOffset]) {
+        return $Value.UtcDateTime.ToString(
+            'o',
+            [System.Globalization.CultureInfo]::InvariantCulture
+        )
+    }
+
+    if ($Value -is [System.Collections.IDictionary]) {
+        $result = [ordered]@{}
+        foreach ($key in @($Value.Keys | ForEach-Object { [string]$_ } | Sort-Object -CaseSensitive)) {
+            $result[$key] = ConvertTo-DeclarativeWorkflowCanonicalObject -Value $Value[$key]
+        }
+        return $result
+    }
+
+    if ($Value -is [System.Collections.IEnumerable]) {
+        $items = @(
+            foreach ($item in $Value) {
+                ConvertTo-DeclarativeWorkflowCanonicalObject -Value $item
+            }
+        )
+        return ,$items
+    }
+
+    $properties = @($Value.PSObject.Properties.Name | Sort-Object -CaseSensitive)
+    if ($properties.Count -gt 0) {
+        $result = [ordered]@{}
+        foreach ($name in $properties) {
+            $result[$name] = ConvertTo-DeclarativeWorkflowCanonicalObject -Value $Value.$name
+        }
+        return $result
+    }
+
+    return [string]$Value
+}
+
+function ConvertTo-DeclarativeWorkflowCanonicalJson {
+    param([AllowNull()]$Value)
+
+    $canonical = ConvertTo-DeclarativeWorkflowCanonicalObject -Value $Value
+    return $canonical | ConvertTo-Json -Compress -Depth 50
+}
+
+function Get-DeclarativeWorkflowSha256 {
+    param([Parameter(Mandatory = $true)][byte[]]$Bytes)
+
+    $digest = [System.Security.Cryptography.SHA256]::Create().ComputeHash($Bytes)
+    return 'sha256:' + (($digest | ForEach-Object { $_.ToString('x2') }) -join '')
+}
+
+function Get-DeclarativeWorkflowContentDigest {
+    param([Parameter(Mandatory = $true)]$Workflow)
+
+    $json = ConvertTo-DeclarativeWorkflowCanonicalJson -Value $Workflow
+    return Get-DeclarativeWorkflowSha256 -Bytes ([System.Text.Encoding]::UTF8.GetBytes($json))
+}
+
+function ConvertTo-DeclarativeWorkflowUtcTimestamp {
+    param([Parameter(Mandatory = $true)]$Value)
+
+    if ($Value -is [DateTimeOffset]) {
+        return $Value.UtcDateTime.ToString(
+            'o',
+            [Globalization.CultureInfo]::InvariantCulture
+        )
+    }
+    if ($Value -is [DateTime]) {
+        return $Value.ToUniversalTime().ToString(
+            'o',
+            [Globalization.CultureInfo]::InvariantCulture
+        )
+    }
+
+    $parsed = [DateTimeOffset]::MinValue
+    if (-not [DateTimeOffset]::TryParse(
+            [string]$Value,
+            [Globalization.CultureInfo]::InvariantCulture,
+            [Globalization.DateTimeStyles]::RoundtripKind,
+            [ref]$parsed)) {
+        throw 'workflow_state_invalid: created_at is not an ISO timestamp.'
+    }
+    return $parsed.UtcDateTime.ToString(
+        'o',
+        [Globalization.CultureInfo]::InvariantCulture
+    )
+}
+
+function Get-DeclarativeWorkflowRunStatePath {
+    param(
+        [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [Parameter(Mandatory = $true)][string]$RunId
+    )
+
+    Assert-DeclarativeWorkflowIdentifier -Value $RunId -Name 'run_id'
+    $root = [System.IO.Path]::GetFullPath($ProjectDir)
+    return Join-Path (Join-Path (Join-Path $root '.winsmux') 'workflow-runs') "$RunId.json"
+}
+
+function Read-DeclarativeWorkflowRunState {
+    param(
+        [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [Parameter(Mandatory = $true)][string]$RunId
+    )
+
+    $path = Get-DeclarativeWorkflowRunStatePath -ProjectDir $ProjectDir -RunId $RunId
+    if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
+        throw "workflow_run_not_found: $RunId"
+    }
+    $bytes = [System.IO.File]::ReadAllBytes($path)
+    if ($bytes.Length -ge 3 -and
+        $bytes[0] -eq 0xEF -and $bytes[1] -eq 0xBB -and $bytes[2] -eq 0xBF) {
+        throw 'workflow_state_invalid: UTF-8 BOM is not allowed.'
+    }
+    try {
+        $text = [System.Text.UTF8Encoding]::new($false, $true).GetString($bytes)
+        $state = $text | ConvertFrom-WinsmuxJson -AsHashtable -Depth 50 -ErrorAction Stop
+    } catch {
+        throw "workflow_state_invalid: $($_.Exception.Message)"
+    }
+    if ([string](Get-DeclarativeWorkflowValue -InputObject $state -Name 'run_id' -Default '') -cne $RunId) {
+        throw 'workflow_state_invalid: run identity mismatch.'
+    }
+    return $state
+}
+
+function Set-DeclarativeWorkflowRunState {
+    param(
+        [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [Parameter(Mandatory = $true)][string]$RunId,
+        [Parameter(Mandatory = $true)]$State
+    )
+
+    Assert-DeclarativeWorkflowIdentifier -Value $RunId -Name 'run_id'
+    if ([string](Get-DeclarativeWorkflowValue -InputObject $State -Name 'run_id' -Default '') -cne $RunId) {
+        throw 'workflow_state_invalid: writer run identity mismatch.'
+    }
+    $path = Get-DeclarativeWorkflowRunStatePath -ProjectDir $ProjectDir -RunId $RunId
+    $directory = Split-Path -Parent $path
+    [System.IO.Directory]::CreateDirectory($directory) | Out-Null
+    $json = ConvertTo-DeclarativeWorkflowCanonicalJson -Value $State
+    $temporary = Join-Path $directory (".{0}.{1}.tmp" -f $RunId, [guid]::NewGuid().ToString('N'))
+    [System.IO.File]::WriteAllText(
+        $temporary,
+        $json,
+        [System.Text.UTF8Encoding]::new($false)
+    )
+    try {
+        [System.IO.File]::Move($temporary, $path, $true)
+    } finally {
+        if (Test-Path -LiteralPath $temporary -PathType Leaf) {
+            Remove-Item -LiteralPath $temporary -Force -ErrorAction SilentlyContinue
+        }
+    }
+    return $path
+}
+
+function Enter-DeclarativeWorkflowInvocationLease {
+    param(
+        [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [Parameter(Mandatory = $true)][string]$RunId
+    )
+
+    Assert-DeclarativeWorkflowIdentifier -Value $RunId -Name 'run_id'
+    $statePath = Get-DeclarativeWorkflowRunStatePath -ProjectDir $ProjectDir -RunId $RunId
+    $directory = Split-Path -Parent $statePath
+    [System.IO.Directory]::CreateDirectory($directory) | Out-Null
+    $leasePath = Join-Path $directory "$RunId.lease"
+    $stream = $null
+    try {
+        try {
+            $stream = [System.IO.FileStream]::new(
+                $leasePath,
+                [System.IO.FileMode]::OpenOrCreate,
+                [System.IO.FileAccess]::ReadWrite,
+                [System.IO.FileShare]::None
+            )
+        } catch [System.IO.IOException] {
+            throw 'workflow_run_busy'
+        }
+        $lease = [PSCustomObject]@{
+            Stream = $stream
+            Path = $leasePath
+            Released = $false
+        }
+        $lease | Add-Member -MemberType ScriptMethod -Name Dispose -Value {
+            if (-not $this.Released) {
+                $this.Stream.Dispose()
+                $this.Released = $true
+            }
+        } -Force
+        return $lease
+    } catch {
+        if ($null -ne $stream) {
+            $stream.Dispose()
+        }
+        throw
+    }
+}
+
+function Get-DeclarativeWorkflowTaskSnapshot {
+    param([Parameter(Mandatory = $true)][string]$TaskFile)
+
+    $path = [System.IO.Path]::GetFullPath($TaskFile)
+    if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
+        throw "workflow_task_not_found: $path"
+    }
+    $bytes = [System.IO.File]::ReadAllBytes($path)
+    try {
+        $text = [System.Text.UTF8Encoding]::new($false, $true).GetString($bytes)
+    } catch {
+        throw 'workflow_task_invalid: task file must be UTF-8.'
+    }
+    return [PSCustomObject]@{
+        path = $path
+        bytes = $bytes
+        text = $text
+        digest = Get-DeclarativeWorkflowSha256 -Bytes $bytes
+    }
+}
+
+function Get-DeclarativeWorkflowSourceHead {
+    param([Parameter(Mandatory = $true)][string]$ProjectDir)
+
+    $output = @(& git -C $ProjectDir rev-parse HEAD 2>&1)
+    if ($LASTEXITCODE -ne 0) {
+        throw "workflow_source_unavailable: $($output -join ' ')"
+    }
+    $head = ([string]($output | Select-Object -Last 1)).Trim().ToLowerInvariant()
+    if ($head -cnotmatch '^[0-9a-f]{40}$') {
+        throw 'workflow_source_invalid: expected an exact Git commit.'
+    }
+    return $head
+}
+
+function Get-DeclarativeWorkflowManifestIdentity {
+    param([Parameter(Mandatory = $true)][string]$ProjectDir)
+
+    if (-not (Get-Command Get-WinsmuxManifest -CommandType Function -ErrorAction SilentlyContinue) -or
+        -not (Get-Command Get-WinsmuxVerifiedManifestIdentity -CommandType Function -ErrorAction SilentlyContinue)) {
+        throw 'workflow_session_unavailable: verified manifest helpers are not loaded.'
+    }
+    $identity = Get-WinsmuxVerifiedManifestIdentity -Manifest (Get-WinsmuxManifest -ProjectDir $ProjectDir)
+    if ($null -eq $identity) {
+        throw 'workflow_session_invalid: current manifest identity is not verified.'
+    }
+    return [ordered]@{
+        session_name = [string]$identity.session_name
+        generation_id = [string]$identity.generation_id
+        server_session_id = [string]$identity.server_session_id
+    }
+}
+
+function Invoke-DeclarativeWorkflowWorkspacePlan {
+    param(
+        [Parameter(Mandatory = $true)][string]$RecipeId,
+        [Parameter(Mandatory = $true)][string]$WorkflowId,
+        [Parameter(Mandatory = $true)][string]$RunId,
+        [Parameter(Mandatory = $true)][string]$ProjectDir
+    )
+
+    $command = ''
+    foreach ($candidate in @(
+        [string]$env:WINSMUX_RAW_EXE,
+        [string]$env:WINSMUX_BIN,
+        (Join-Path $ProjectDir 'target\release\winsmux.exe'),
+        (Join-Path $ProjectDir 'target\debug\winsmux.exe')
+    )) {
+        if (-not [string]::IsNullOrWhiteSpace($candidate) -and
+            (Test-Path -LiteralPath $candidate -PathType Leaf)) {
+            $command = [System.IO.Path]::GetFullPath($candidate)
+            break
+        }
+    }
+    if ([string]::IsNullOrWhiteSpace($command)) {
+        $resolved = Get-Command winsmux.exe -ErrorAction SilentlyContinue | Select-Object -First 1
+        if ($null -eq $resolved) {
+            throw 'workflow_plan_unavailable: winsmux executable was not found.'
+        }
+        $command = [string]$resolved.Path
+    }
+
+    $output = @(
+        & $command workspace-plan `
+            --recipe-id $RecipeId `
+            --workflow-id $WorkflowId `
+            --run-id $RunId `
+            --project-dir $ProjectDir `
+            --json 2>&1
+    )
+    if ($LASTEXITCODE -ne 0) {
+        throw "workflow_plan_invalid: $($output -join ' ')"
+    }
+    try {
+        return ($output -join [Environment]::NewLine) |
+            ConvertFrom-WinsmuxJson -AsHashtable -Depth 50 -ErrorAction Stop
+    } catch {
+        throw "workflow_plan_invalid: $($_.Exception.Message)"
+    }
+}
+
+function Assert-DeclarativeWorkflowIdentity {
+    param(
+        [Parameter(Mandatory = $true)]$Identity,
+        [Parameter(Mandatory = $true)][string]$Context
+    )
+
+    foreach ($name in @('session_name', 'generation_id', 'server_session_id')) {
+        if ([string]::IsNullOrWhiteSpace([string](Get-DeclarativeWorkflowValue -InputObject $Identity -Name $name -Default ''))) {
+            throw "workflow_session_invalid: $Context is missing $name."
+        }
+    }
+}
+
+function Assert-DeclarativeWorkflowPlan {
+    param(
+        [Parameter(Mandatory = $true)]$Plan,
+        [Parameter(Mandatory = $true)][string]$RecipeId,
+        [Parameter(Mandatory = $true)][string]$WorkflowId,
+        [Parameter(Mandatory = $true)][string]$RunId
+    )
+
+    if ([string](Get-DeclarativeWorkflowValue -InputObject $Plan -Name 'recipe_id' -Default '') -cne $RecipeId -or
+        [string](Get-DeclarativeWorkflowValue -InputObject $Plan -Name 'workflow_id' -Default '') -cne $WorkflowId) {
+        throw 'workflow_plan_invalid: selected identity mismatch.'
+    }
+    $configFingerprint = [string](Get-DeclarativeWorkflowValue -InputObject $Plan -Name 'config_fingerprint' -Default '')
+    if ($configFingerprint -cnotmatch '^sha256:[0-9a-f]{64}$') {
+        throw 'workflow_plan_invalid: config fingerprint is invalid.'
+    }
+    $workflow = Get-DeclarativeWorkflowValue -InputObject $Plan -Name 'workflow'
+    if ($null -eq $workflow -or
+        [string](Get-DeclarativeWorkflowValue -InputObject $workflow -Name 'workflow_id' -Default '') -cne $WorkflowId -or
+        [string](Get-DeclarativeWorkflowValue -InputObject $workflow -Name 'run_id' -Default '') -cne $RunId) {
+        throw 'workflow_plan_invalid: normalized workflow identity mismatch.'
+    }
+
+    $nodes = @(Get-DeclarativeWorkflowValue -InputObject $workflow -Name 'nodes' -Default @())
+    $order = @(Get-DeclarativeWorkflowValue -InputObject $workflow -Name 'topological_order' -Default @())
+    if ($nodes.Count -eq 0 -or $order.Count -ne $nodes.Count) {
+        throw 'workflow_plan_invalid: normalized workflow is empty or unordered.'
+    }
+    $ids = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::Ordinal)
+    foreach ($node in $nodes) {
+        $nodeId = [string](Get-DeclarativeWorkflowValue -InputObject $node -Name 'node_id' -Default '')
+        $paneRef = [string](Get-DeclarativeWorkflowValue -InputObject $node -Name 'pane_ref' -Default '')
+        $action = [string](Get-DeclarativeWorkflowValue -InputObject $node -Name 'action' -Default '')
+        $idempotencyKey = [string](Get-DeclarativeWorkflowValue -InputObject $node -Name 'idempotency_key' -Default '')
+        Assert-DeclarativeWorkflowIdentifier -Value $nodeId -Name 'node_id'
+        if (-not $ids.Add($nodeId) -or [string]::IsNullOrWhiteSpace($paneRef) -or
+            $action -cne 'operator-dispatch' -or
+            $idempotencyKey -cne "$RunId`:$nodeId") {
+            throw 'workflow_plan_invalid: normalized node contract is invalid.'
+        }
+    }
+    if (@($order | Where-Object { -not $ids.Contains([string]$_) }).Count -gt 0) {
+        throw 'workflow_plan_invalid: topological order references an unknown node.'
+    }
+    return $workflow
+}
+
+function Get-DeclarativeWorkflowNode {
+    param(
+        [Parameter(Mandatory = $true)]$Workflow,
+        [Parameter(Mandatory = $true)][string]$NodeId
+    )
+
+    return @(
+        @(Get-DeclarativeWorkflowValue -InputObject $Workflow -Name 'nodes' -Default @())) |
+        Where-Object {
+            [string](Get-DeclarativeWorkflowValue -InputObject $_ -Name 'node_id' -Default '') -ceq $NodeId
+        } |
+        Select-Object -First 1
+}
+
+function Update-DeclarativeWorkflowOverallState {
+    param([Parameter(Mandatory = $true)]$State)
+
+    $nodeStates = @(
+        foreach ($nodeId in @($State['nodes'].Keys)) {
+            [string]$State['nodes'][$nodeId]['state']
+        }
+    )
+    if ($nodeStates -contains 'failed') {
+        $State['state'] = 'failed'
+    } elseif ($nodeStates.Count -gt 0 -and @($nodeStates | Where-Object { $_ -cne 'succeeded' }).Count -eq 0) {
+        $State['state'] = 'succeeded'
+    } elseif (@($nodeStates | Where-Object { $_ -in @('running', 'dispatching') }).Count -gt 0) {
+        $State['state'] = 'running'
+    } else {
+        $State['state'] = 'blocked'
+    }
+}
+
+function Invoke-DeclarativeWorkflowReadyNodes {
+    param(
+        [Parameter(Mandatory = $true)]$State,
+        [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [Parameter(Mandatory = $true)][string]$TaskContent,
+        [Parameter(Mandatory = $true)][scriptblock]$DispatchNode
+    )
+
+    $workflow = $State['workflow']
+    foreach ($nodeIdValue in @(Get-DeclarativeWorkflowValue -InputObject $workflow -Name 'topological_order' -Default @())) {
+        $nodeId = [string]$nodeIdValue
+        $nodeState = $State['nodes'][$nodeId]
+        if ([string]$nodeState['state'] -cne 'pending') {
+            continue
+        }
+        $node = Get-DeclarativeWorkflowNode -Workflow $workflow -NodeId $nodeId
+        $dependencies = @(Get-DeclarativeWorkflowValue -InputObject $node -Name 'depends_on' -Default @())
+        $ready = @($dependencies | Where-Object {
+                [string]$State['nodes'][[string]$_]['state'] -cne 'succeeded'
+            }).Count -eq 0
+        if (-not $ready) {
+            continue
+        }
+
+        $nodeState['state'] = 'dispatching'
+        Update-DeclarativeWorkflowOverallState -State $State
+        Set-DeclarativeWorkflowRunState -ProjectDir $ProjectDir -RunId ([string]$State['run_id']) -State $State | Out-Null
+        $receipt = & $DispatchNode $node $TaskContent $State
+        if ($null -eq $receipt -or
+            -not [bool](Get-DeclarativeWorkflowValue -InputObject $receipt -Name 'accepted' -Default $false)) {
+            throw "workflow_dispatch_rejected: $nodeId"
+        }
+        $nodeState['state'] = 'running'
+        Update-DeclarativeWorkflowOverallState -State $State
+        Set-DeclarativeWorkflowRunState -ProjectDir $ProjectDir -RunId ([string]$State['run_id']) -State $State | Out-Null
+    }
+}
+
+function New-DeclarativeWorkflowRunState {
+    param(
+        [Parameter(Mandatory = $true)]$Plan,
+        [Parameter(Mandatory = $true)]$Workflow,
+        [Parameter(Mandatory = $true)][string]$RunId,
+        [Parameter(Mandatory = $true)]$TaskSnapshot,
+        [Parameter(Mandatory = $true)][string]$SourceHead,
+        [Parameter(Mandatory = $true)]$Session
+    )
+
+    $nodes = [ordered]@{}
+    foreach ($node in @(Get-DeclarativeWorkflowValue -InputObject $Workflow -Name 'nodes' -Default @())) {
+        $nodeId = [string](Get-DeclarativeWorkflowValue -InputObject $node -Name 'node_id' -Default '')
+        $nodes[$nodeId] = [ordered]@{
+            state = 'pending'
+            pane_ref = [string](Get-DeclarativeWorkflowValue -InputObject $node -Name 'pane_ref' -Default '')
+            idempotency_key = [string](Get-DeclarativeWorkflowValue -InputObject $node -Name 'idempotency_key' -Default '')
+            message_id = $null
+            result_digest = $null
+            exit_code = $null
+        }
+    }
+
+    return [ordered]@{
+        schema_version = 1
+        run_id = $RunId
+        created_at = [System.DateTimeOffset]::UtcNow.ToString('o')
+        recipe_id = [string](Get-DeclarativeWorkflowValue -InputObject $Plan -Name 'recipe_id' -Default '')
+        workflow_id = [string](Get-DeclarativeWorkflowValue -InputObject $Plan -Name 'workflow_id' -Default '')
+        state = 'running'
+        config_fingerprint = [string](Get-DeclarativeWorkflowValue -InputObject $Plan -Name 'config_fingerprint' -Default '')
+        workflow = ConvertTo-DeclarativeWorkflowCanonicalObject -Value $Workflow
+        workflow_fingerprint = Get-DeclarativeWorkflowContentDigest -Workflow $Workflow
+        source_head = $SourceHead
+        task_digest = [string]$TaskSnapshot.digest
+        task_bytes = [int64]$TaskSnapshot.bytes.Length
+        session = ConvertTo-DeclarativeWorkflowCanonicalObject -Value $Session
+        nodes = $nodes
+        admitted_messages = @()
+    }
+}
+
+function Assert-DeclarativeWorkflowEnvelope {
+    param(
+        [Parameter(Mandatory = $true)]$Envelope,
+        [Parameter(Mandatory = $true)]$Run,
+        [Parameter(Mandatory = $true)][string]$RunId
+    )
+
+    $topLevel = @(
+        'mailbox_version', 'message_id', 'correlation_id', 'causation_id',
+        'idempotency_key', 'message_type', 'state', 'ttl_seconds',
+        'ack_required', 'from', 'to', 'content', 'timestamp'
+    )
+    $contentFields = @(
+        'run_id', 'node_id', 'node_idempotency_key', 'session_name',
+        'generation_id', 'server_session_id', 'workflow_fingerprint',
+        'task_digest', 'outcome', 'exit_code', 'result_digest'
+    )
+    if ($Envelope -isnot [System.Collections.IDictionary]) {
+        $Envelope = ConvertTo-DeclarativeWorkflowCanonicalObject -Value $Envelope
+    }
+    $unexpectedTop = @($Envelope.Keys | Where-Object { [string]$_ -notin $topLevel })
+    $missingTop = @($topLevel | Where-Object { -not $Envelope.Contains($_) })
+    if ($unexpectedTop.Count -gt 0 -or $missingTop.Count -gt 0) {
+        throw 'workflow_mailbox_invalid: envelope fields are not canonical.'
+    }
+
+    $messageId = [string]$Envelope['message_id']
+    Assert-DeclarativeWorkflowIdentifier -Value $messageId -Name 'message_id'
+    $content = $Envelope['content']
+    if ($content -isnot [System.Collections.IDictionary]) {
+        $content = ConvertTo-DeclarativeWorkflowCanonicalObject -Value $content
+    }
+    $unexpectedContent = @($content.Keys | Where-Object { [string]$_ -notin $contentFields })
+    $missingContent = @($contentFields | Where-Object { -not $content.Contains($_) })
+    if ($unexpectedContent.Count -gt 0 -or $missingContent.Count -gt 0) {
+        throw 'workflow_mailbox_invalid: result fields are not canonical.'
+    }
+
+    $nodeId = [string]$content['node_id']
+    Assert-DeclarativeWorkflowIdentifier -Value $nodeId -Name 'node_id'
+    if (-not $Run['nodes'].Contains($nodeId)) {
+        throw 'workflow_mailbox_invalid: node identity is unknown.'
+    }
+    $node = Get-DeclarativeWorkflowNode -Workflow $Run['workflow'] -NodeId $nodeId
+    $session = $Run['session']
+    $outcome = [string]$content['outcome']
+    $exitCode = [int]$content['exit_code']
+    $expectedResultDigest = Get-DeclarativeWorkflowSha256 -Bytes (
+        [System.Text.Encoding]::UTF8.GetBytes("$outcome`:$exitCode`:$nodeId")
+    )
+
+    if ([int]$Envelope['mailbox_version'] -ne 2 -or
+        [string]$Envelope['correlation_id'] -cne $messageId -or
+        [string]$Envelope['idempotency_key'] -cne "mailbox:v2:$RunId`:$nodeId" -or
+        [string]$Envelope['message_type'] -cne 'workflow_result' -or
+        [string]$Envelope['state'] -cne 'created' -or
+        [int]$Envelope['ttl_seconds'] -le 0 -or
+        -not [bool]$Envelope['ack_required'] -or
+        [string]$Envelope['to'] -cne 'Operator' -or
+        [string]$Envelope['from'] -cne [string](Get-DeclarativeWorkflowValue -InputObject $node -Name 'pane_ref' -Default '') -or
+        [string]$content['run_id'] -cne $RunId -or
+        [string]$content['node_idempotency_key'] -cne [string]$Run['nodes'][$nodeId]['idempotency_key'] -or
+        [string]$content['session_name'] -cne [string]$session['session_name'] -or
+        -not [string]::Equals([string]$content['generation_id'], [string]$session['generation_id'], [StringComparison]::Ordinal) -or
+        [string]$content['server_session_id'] -cne [string]$session['server_session_id'] -or
+        [string]$content['workflow_fingerprint'] -cne [string]$Run['workflow_fingerprint'] -or
+        [string]$content['task_digest'] -cne [string]$Run['task_digest'] -or
+        [string]$content['result_digest'] -cne $expectedResultDigest -or
+        ($outcome -ceq 'succeeded' -and $exitCode -ne 0) -or
+        ($outcome -ceq 'failed' -and $exitCode -eq 0) -or
+        $outcome -cnotin @('succeeded', 'failed')) {
+        throw 'workflow_mailbox_invalid: result identity or outcome is contradictory.'
+    }
+
+    return [ordered]@{
+        message_id = $messageId
+        node_id = $nodeId
+        outcome = $outcome
+        exit_code = $exitCode
+        result_digest = [string]$content['result_digest']
+        envelope = ConvertTo-DeclarativeWorkflowCanonicalObject -Value $Envelope
+    }
+}
+
+function Get-DeclarativeWorkflowMailboxDirectory {
+    param(
+        [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [Parameter(Mandatory = $true)][string]$RunId,
+        [Parameter(Mandatory = $true)][ValidateSet('pending', 'consumed')][string]$State
+    )
+
+    Assert-DeclarativeWorkflowIdentifier -Value $RunId -Name 'run_id'
+    return Join-Path (Join-Path (Join-Path (Join-Path ([System.IO.Path]::GetFullPath($ProjectDir)) '.winsmux') 'workflow-mailbox') $RunId) $State
+}
+
+function Read-DeclarativeWorkflowMailboxFile {
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    try {
+        $bytes = [System.IO.File]::ReadAllBytes($Path)
+        if ($bytes.Length -ge 3 -and
+            $bytes[0] -eq 0xEF -and $bytes[1] -eq 0xBB -and $bytes[2] -eq 0xBF) {
+            throw 'UTF-8 BOM is not allowed.'
+        }
+        $text = [System.Text.UTF8Encoding]::new($false, $true).GetString($bytes)
+        $value = $text | ConvertFrom-WinsmuxJson -AsHashtable -Depth 50 -ErrorAction Stop
+        return [PSCustomObject]@{
+            path = $Path
+            bytes = $bytes
+            value = $value
+        }
+    } catch {
+        throw "workflow_mailbox_invalid: $($_.Exception.Message)"
+    }
+}
+
+function Get-DeclarativeWorkflowMailboxPublication {
+    param(
+        [Parameter(Mandatory = $true)][string]$PendingPath,
+        [Parameter(Mandatory = $true)][string]$ConsumedPath,
+        [Parameter(Mandatory = $true)][byte[]]$ExpectedBytes
+    )
+
+    foreach ($candidate in @(
+            [PSCustomObject]@{ Path = $PendingPath; State = 'pending' },
+            [PSCustomObject]@{ Path = $ConsumedPath; State = 'consumed' }
+        )) {
+        $stream = $null
+        $memory = $null
+        try {
+            try {
+                $stream = [System.IO.FileStream]::new(
+                    $candidate.Path,
+                    [System.IO.FileMode]::Open,
+                    [System.IO.FileAccess]::Read,
+                    ([System.IO.FileShare]::ReadWrite -bor [System.IO.FileShare]::Delete)
+                )
+            } catch [System.IO.FileNotFoundException] {
+                continue
+            } catch [System.IO.DirectoryNotFoundException] {
+                continue
+            }
+            $memory = [System.IO.MemoryStream]::new()
+            $stream.CopyTo($memory)
+            $existing = $memory.ToArray()
+            if (-not [System.Linq.Enumerable]::SequenceEqual[byte]($existing, $ExpectedBytes)) {
+                throw 'workflow_mailbox_conflict: message_id already has different bytes.'
+            }
+            return [PSCustomObject]@{
+                accepted = $true
+                duplicate = $true
+                state = [string]$candidate.State
+            }
+        } finally {
+            if ($null -ne $memory) {
+                $memory.Dispose()
+            }
+            if ($null -ne $stream) {
+                $stream.Dispose()
+            }
+        }
+    }
+    return $null
+}
+
+function Write-DeclarativeWorkflowMailboxResultCore {
+    param(
+        [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [Parameter(Mandatory = $true)][string]$RunId,
+        [Parameter(Mandatory = $true)]$Run,
+        [Parameter(Mandatory = $true)]$Payload
+    )
+
+    try {
+        $envelope = if ($Payload -is [string]) {
+            $Payload | ConvertFrom-WinsmuxJson -AsHashtable -Depth 50 -ErrorAction Stop
+        } else {
+            ConvertTo-DeclarativeWorkflowCanonicalObject -Value $Payload
+        }
+    } catch {
+        throw "workflow_mailbox_invalid: $($_.Exception.Message)"
+    }
+    $record = Assert-DeclarativeWorkflowEnvelope -Envelope $envelope -Run $Run -RunId $RunId
+    $json = ConvertTo-DeclarativeWorkflowCanonicalJson -Value $record.envelope
+    $bytes = [System.Text.UTF8Encoding]::new($false).GetBytes($json)
+
+    $pendingDir = Get-DeclarativeWorkflowMailboxDirectory -ProjectDir $ProjectDir -RunId $RunId -State pending
+    $consumedDir = Get-DeclarativeWorkflowMailboxDirectory -ProjectDir $ProjectDir -RunId $RunId -State consumed
+    [System.IO.Directory]::CreateDirectory($pendingDir) | Out-Null
+    [System.IO.Directory]::CreateDirectory($consumedDir) | Out-Null
+    $pendingPath = Join-Path $pendingDir "$($record.message_id).json"
+    $consumedPath = Join-Path $consumedDir "$($record.message_id).json"
+
+    $existing = Get-DeclarativeWorkflowMailboxPublication `
+        -PendingPath $pendingPath -ConsumedPath $consumedPath -ExpectedBytes $bytes
+    if ($null -ne $existing) {
+        $existing | Add-Member -NotePropertyName message_id `
+            -NotePropertyValue $record.message_id
+        return $existing
+    }
+
+    $temporary = Join-Path $pendingDir (".{0}.{1}.tmp" -f $record.message_id, [guid]::NewGuid().ToString('N'))
+    [System.IO.File]::WriteAllBytes($temporary, $bytes)
+    try {
+        try {
+            [System.IO.File]::Move($temporary, $pendingPath)
+        } catch [System.IO.IOException] {
+            $collision = Get-DeclarativeWorkflowMailboxPublication `
+                -PendingPath $pendingPath -ConsumedPath $consumedPath -ExpectedBytes $bytes
+            if ($null -eq $collision) {
+                throw
+            }
+            $collision | Add-Member -NotePropertyName message_id `
+                -NotePropertyValue $record.message_id
+            return $collision
+        }
+    } finally {
+        if (Test-Path -LiteralPath $temporary -PathType Leaf) {
+            Remove-Item -LiteralPath $temporary -Force -ErrorAction SilentlyContinue
+        }
+    }
+    return [PSCustomObject]@{
+        accepted = $true
+        duplicate = $false
+        message_id = $record.message_id
+        state = 'pending'
+    }
+}
+
+function Write-DeclarativeWorkflowMailboxResult {
+    param(
+        [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [Parameter(Mandatory = $true)][string]$RunId,
+        [Parameter(Mandatory = $true)]$Payload
+    )
+
+    $lease = Enter-DeclarativeWorkflowInvocationLease -ProjectDir $ProjectDir -RunId $RunId
+    try {
+        $run = Read-DeclarativeWorkflowRunState -ProjectDir $ProjectDir -RunId $RunId
+        return Write-DeclarativeWorkflowMailboxResultCore `
+            -ProjectDir $ProjectDir -RunId $RunId -Run $run -Payload $Payload
+    } finally {
+        $lease.Dispose()
+    }
+}
+
+function Write-DeclarativeWorkflowNodeResult {
+    param(
+        [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [Parameter(Mandatory = $true)][string]$RunId,
+        [Parameter(Mandatory = $true)][string]$NodeId,
+        [Parameter(Mandatory = $true)][string]$Outcome,
+        [Parameter(Mandatory = $true)][int]$ExitCode
+    )
+
+    Assert-DeclarativeWorkflowIdentifier -Value $RunId -Name 'run_id'
+    Assert-DeclarativeWorkflowIdentifier -Value $NodeId -Name 'node_id'
+    if ($Outcome -cnotin @('succeeded', 'failed') -or
+        ($Outcome -ceq 'succeeded' -and $ExitCode -ne 0) -or
+        ($Outcome -ceq 'failed' -and $ExitCode -eq 0)) {
+        throw 'workflow_result_invalid: outcome and exit code are contradictory.'
+    }
+
+    $run = Read-DeclarativeWorkflowRunState -ProjectDir $ProjectDir -RunId $RunId
+    if (-not $run['nodes'].Contains($NodeId)) {
+        throw 'workflow_result_invalid: node identity is unknown.'
+    }
+    $nodeState = $run['nodes'][$NodeId]
+    $nodeOutcome = [string]$nodeState['state']
+    $isReplay = $nodeOutcome -cin @('succeeded', 'failed')
+    if (-not $isReplay -and
+        $nodeOutcome -cnotin @('dispatching', 'running', 'blocked')) {
+        throw "workflow_result_invalid: node '$NodeId' is not awaiting a result."
+    }
+    $node = Get-DeclarativeWorkflowNode -Workflow $run['workflow'] -NodeId $NodeId
+    $resultDigest = Get-DeclarativeWorkflowSha256 -Bytes (
+        [System.Text.Encoding]::UTF8.GetBytes("$Outcome`:$ExitCode`:$NodeId")
+    )
+    $messageIdentity = Get-DeclarativeWorkflowSha256 -Bytes (
+        [System.Text.Encoding]::UTF8.GetBytes(
+            "$RunId`0$NodeId`0$Outcome`0$ExitCode`0$resultDigest"
+        )
+    )
+    $messageId = 'result-' + $messageIdentity.Substring(7, 32)
+    if ($isReplay) {
+        if ($Outcome -cne $nodeOutcome -or
+            $ExitCode -ne [int]$nodeState['exit_code'] -or
+            $resultDigest -cne [string]$nodeState['result_digest'] -or
+            $messageId -cne [string]$nodeState['message_id'] -or
+            @($run['admitted_messages']) -cnotcontains $messageId) {
+            throw "workflow_result_conflict: terminal node '$NodeId' already owns a different result."
+        }
+        $mailbox = Get-DeclarativeWorkflowMailboxRecords `
+            -ProjectDir $ProjectDir -RunId $RunId -Run $run
+        Assert-DeclarativeWorkflowStateProofConsistency -State $run -Mailbox $mailbox
+    }
+    $createdAtValue = Get-DeclarativeWorkflowValue -InputObject $run -Name 'created_at' -Default ''
+    if ([string]::IsNullOrWhiteSpace([string]$createdAtValue)) {
+        throw 'workflow_state_invalid: created_at is missing.'
+    }
+    $createdAt = ConvertTo-DeclarativeWorkflowUtcTimestamp -Value $createdAtValue
+    $session = $run['session']
+    $envelope = [ordered]@{
+        mailbox_version = 2
+        message_id = $messageId
+        correlation_id = $messageId
+        causation_id = $null
+        idempotency_key = "mailbox:v2:$RunId`:$NodeId"
+        message_type = 'workflow_result'
+        state = 'created'
+        ttl_seconds = 300
+        ack_required = $true
+        from = [string](Get-DeclarativeWorkflowValue -InputObject $node -Name 'pane_ref' -Default '')
+        to = 'Operator'
+        content = [ordered]@{
+            run_id = $RunId
+            node_id = $NodeId
+            node_idempotency_key = [string]$nodeState['idempotency_key']
+            session_name = [string]$session['session_name']
+            generation_id = [string]$session['generation_id']
+            server_session_id = [string]$session['server_session_id']
+            workflow_fingerprint = [string]$run['workflow_fingerprint']
+            task_digest = [string]$run['task_digest']
+            outcome = $Outcome
+            exit_code = $ExitCode
+            result_digest = $resultDigest
+        }
+        timestamp = $createdAt
+    }
+    return Write-DeclarativeWorkflowMailboxResultCore `
+        -ProjectDir $ProjectDir -RunId $RunId -Run $run -Payload $envelope
+}
+
+function Get-DeclarativeWorkflowMailboxRecords {
+    param(
+        [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [Parameter(Mandatory = $true)][string]$RunId,
+        [Parameter(Mandatory = $true)]$Run
+    )
+
+    $byMessage = [ordered]@{}
+    foreach ($mailboxState in @('consumed', 'pending')) {
+        $directory = Get-DeclarativeWorkflowMailboxDirectory -ProjectDir $ProjectDir -RunId $RunId -State $mailboxState
+        if (-not (Test-Path -LiteralPath $directory -PathType Container)) {
+            continue
+        }
+        foreach ($file in @(Get-ChildItem -LiteralPath $directory -File -Filter '*.json' | Sort-Object Name)) {
+            $loaded = Read-DeclarativeWorkflowMailboxFile -Path $file.FullName
+            $record = Assert-DeclarativeWorkflowEnvelope -Envelope $loaded.value -Run $Run -RunId $RunId
+            if ($file.BaseName -cne [string]$record.message_id) {
+                throw 'workflow_mailbox_invalid: filename and message identity differ.'
+            }
+            $canonicalBytes = [System.Text.UTF8Encoding]::new($false).GetBytes(
+                (ConvertTo-DeclarativeWorkflowCanonicalJson -Value $record.envelope)
+            )
+            if ($byMessage.Contains([string]$record.message_id)) {
+                $existing = $byMessage[[string]$record.message_id]
+                if (-not [System.Linq.Enumerable]::SequenceEqual[byte]($existing.bytes, $canonicalBytes)) {
+                    throw 'workflow_mailbox_conflict: duplicate message bytes differ.'
+                }
+                if ($mailboxState -ceq 'pending') {
+                    $existing.pending_path = $file.FullName
+                }
+                continue
+            }
+            $byMessage[[string]$record.message_id] = [ordered]@{
+                record = $record
+                bytes = $canonicalBytes
+                pending_path = if ($mailboxState -ceq 'pending') { $file.FullName } else { $null }
+                consumed_path = if ($mailboxState -ceq 'consumed') { $file.FullName } else { $null }
+            }
+        }
+    }
+    return $byMessage
+}
+
+function Assert-DeclarativeWorkflowStateProofConsistency {
+    param(
+        [Parameter(Mandatory = $true)]$State,
+        [Parameter(Mandatory = $true)]$Mailbox
+    )
+
+    $admitted = @($State['admitted_messages'] | ForEach-Object { [string]$_ })
+    $admittedSet = [System.Collections.Generic.HashSet[string]]::new(
+        [System.StringComparer]::Ordinal
+    )
+    foreach ($messageId in $admitted) {
+        if ([string]::IsNullOrWhiteSpace($messageId) -or -not $admittedSet.Add($messageId)) {
+            throw 'workflow_state_proof_invalid: admitted message identities are not unique.'
+        }
+    }
+
+    $ownedProofs = [System.Collections.Generic.HashSet[string]]::new(
+        [System.StringComparer]::Ordinal
+    )
+    foreach ($nodeId in @($State['nodes'].Keys)) {
+        $nodeState = $State['nodes'][$nodeId]
+        $nodeOutcome = [string]$nodeState['state']
+        $messageId = [string]$nodeState['message_id']
+        $resultDigest = [string]$nodeState['result_digest']
+        $hasExitCode = $null -ne $nodeState['exit_code']
+        $terminal = $nodeOutcome -cin @('succeeded', 'failed')
+        if (-not $terminal) {
+            if (-not [string]::IsNullOrWhiteSpace($messageId) -or
+                -not [string]::IsNullOrWhiteSpace($resultDigest) -or
+                $hasExitCode) {
+                throw "workflow_state_proof_invalid: nonterminal node '$nodeId' claims result proof."
+            }
+            continue
+        }
+
+        if ([string]::IsNullOrWhiteSpace($messageId) -or
+            [string]::IsNullOrWhiteSpace($resultDigest) -or
+            -not $hasExitCode -or
+            -not $admittedSet.Contains($messageId) -or
+            -not $Mailbox.Contains($messageId) -or
+            -not $ownedProofs.Add($messageId)) {
+            throw "workflow_state_proof_invalid: terminal node '$nodeId' has no unique admitted proof."
+        }
+        $record = $Mailbox[$messageId]['record']
+        if ([string]$record['message_id'] -cne $messageId -or
+            [string]$record['node_id'] -cne [string]$nodeId -or
+            [string]$record['outcome'] -cne $nodeOutcome -or
+            [int]$record['exit_code'] -ne [int]$nodeState['exit_code'] -or
+            [string]$record['result_digest'] -cne $resultDigest) {
+            throw "workflow_state_proof_invalid: terminal node '$nodeId' proof does not match state."
+        }
+    }
+
+    foreach ($messageId in $admitted) {
+        if (-not $Mailbox.Contains($messageId) -or -not $ownedProofs.Contains($messageId)) {
+            throw 'workflow_state_proof_invalid: admitted proof is not owned by one terminal node.'
+        }
+    }
+}
+
+function Move-DeclarativeWorkflowMessageToConsumed {
+    param(
+        [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [Parameter(Mandatory = $true)][string]$RunId,
+        [Parameter(Mandatory = $true)]$MailboxEntry
+    )
+
+    $pendingPath = [string]$MailboxEntry['pending_path']
+    if ([string]::IsNullOrWhiteSpace($pendingPath) -or
+        -not (Test-Path -LiteralPath $pendingPath -PathType Leaf)) {
+        return
+    }
+    $consumedDir = Get-DeclarativeWorkflowMailboxDirectory -ProjectDir $ProjectDir -RunId $RunId -State consumed
+    [System.IO.Directory]::CreateDirectory($consumedDir) | Out-Null
+    $destination = Join-Path $consumedDir ([System.IO.Path]::GetFileName($pendingPath))
+    if (Test-Path -LiteralPath $destination -PathType Leaf) {
+        $existing = [System.IO.File]::ReadAllBytes($destination)
+        if (-not [System.Linq.Enumerable]::SequenceEqual[byte]($existing, [byte[]]$MailboxEntry['bytes'])) {
+            throw 'workflow_mailbox_conflict: consumed message bytes differ.'
+        }
+        Remove-Item -LiteralPath $pendingPath -Force
+        return
+    }
+    [System.IO.File]::Move($pendingPath, $destination)
+}
+
+function Invoke-DeclarativeWorkflow {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)][string]$Action,
+        [string]$RecipeId = '',
+        [string]$WorkflowId = '',
+        [Parameter(Mandatory = $true)][string]$RunId,
+        [Parameter(Mandatory = $true)][string]$TaskFile,
+        [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [scriptblock]$WorkspacePlanInvoker,
+        [scriptblock]$ManifestIdentityReader,
+        [scriptblock]$SourceHeadReader,
+        [scriptblock]$DispatchNode
+    )
+
+    if ($Action -cnotin @('start', 'resume')) {
+        throw 'workflow_action_invalid: expected start or resume.'
+    }
+    Assert-DeclarativeWorkflowIdentifier -Value $RunId -Name 'run_id'
+    $resolvedProject = [System.IO.Path]::GetFullPath($ProjectDir)
+    $task = Get-DeclarativeWorkflowTaskSnapshot -TaskFile $TaskFile
+    if ($null -eq $WorkspacePlanInvoker) {
+        $WorkspacePlanInvoker = {
+            param($SelectedRecipeId, $SelectedWorkflowId, $SelectedRunId, $SelectedProjectDir)
+            Invoke-DeclarativeWorkflowWorkspacePlan `
+                -RecipeId $SelectedRecipeId -WorkflowId $SelectedWorkflowId `
+                -RunId $SelectedRunId -ProjectDir $SelectedProjectDir
+        }
+    }
+    if ($null -eq $ManifestIdentityReader) {
+        $ManifestIdentityReader = {
+            param($SelectedProjectDir)
+            Get-DeclarativeWorkflowManifestIdentity -ProjectDir $SelectedProjectDir
+        }
+    }
+    if ($null -eq $SourceHeadReader) {
+        $SourceHeadReader = {
+            param($SelectedProjectDir)
+            Get-DeclarativeWorkflowSourceHead -ProjectDir $SelectedProjectDir
+        }
+    }
+    if ($null -eq $DispatchNode) {
+        $DispatchNode = {
+            param($Node, $TaskContent, $Run)
+            if (-not (Get-Command Invoke-TeamPipelineGuardedSend -CommandType Function -ErrorAction SilentlyContinue)) {
+                throw 'workflow_dispatch_unavailable: guarded send is not loaded.'
+            }
+            $target = [string](Get-DeclarativeWorkflowValue -InputObject $Node -Name 'pane_ref' -Default '')
+            $blocked = Invoke-TeamPipelineGuardedSend `
+                -StageName 'WORKFLOW' -Target $target -Prompt $TaskContent `
+                -ProjectDir $resolvedProject -SessionName ([string]$Run['session']['session_name']) `
+                -ExpectedGenerationId ([string]$Run['session']['generation_id']) `
+                -ExpectedServerSessionId ([string]$Run['session']['server_session_id']) `
+                -Role 'Worker' -Task $TaskContent
+            if ($null -ne $blocked) {
+                throw "workflow_dispatch_rejected: $target"
+            }
+            return [ordered]@{ accepted = $true }
+        }.GetNewClosure()
+    }
+
+    $lease = Enter-DeclarativeWorkflowInvocationLease -ProjectDir $resolvedProject -RunId $RunId
+    try {
+        if ($Action -ceq 'start') {
+            if ([string]::IsNullOrWhiteSpace($RecipeId) -or [string]::IsNullOrWhiteSpace($WorkflowId)) {
+                throw 'workflow_start_invalid: recipe_id and workflow_id are required.'
+            }
+            $statePath = Get-DeclarativeWorkflowRunStatePath -ProjectDir $resolvedProject -RunId $RunId
+            if (Test-Path -LiteralPath $statePath -PathType Leaf) {
+                throw 'workflow_run_exists'
+            }
+            $plan = & $WorkspacePlanInvoker $RecipeId $WorkflowId $RunId $resolvedProject
+            $workflow = Assert-DeclarativeWorkflowPlan `
+                -Plan $plan -RecipeId $RecipeId -WorkflowId $WorkflowId -RunId $RunId
+            $session = & $ManifestIdentityReader $resolvedProject
+            Assert-DeclarativeWorkflowIdentity -Identity $session -Context 'current manifest'
+            $sourceHead = [string](& $SourceHeadReader $resolvedProject)
+            if ($sourceHead -cnotmatch '^[0-9a-f]{40}$') {
+                throw 'workflow_source_invalid: expected an exact Git commit.'
+            }
+            $state = New-DeclarativeWorkflowRunState `
+                -Plan $plan -Workflow $workflow -RunId $RunId -TaskSnapshot $task `
+                -SourceHead $sourceHead -Session $session
+            Set-DeclarativeWorkflowRunState -ProjectDir $resolvedProject -RunId $RunId -State $state | Out-Null
+            Invoke-DeclarativeWorkflowReadyNodes `
+                -State $state -ProjectDir $resolvedProject -TaskContent $task.text -DispatchNode $DispatchNode
+            Update-DeclarativeWorkflowOverallState -State $state
+            Set-DeclarativeWorkflowRunState -ProjectDir $resolvedProject -RunId $RunId -State $state | Out-Null
+            return Read-DeclarativeWorkflowRunState -ProjectDir $resolvedProject -RunId $RunId
+        }
+
+        $state = Read-DeclarativeWorkflowRunState -ProjectDir $resolvedProject -RunId $RunId
+        if ([string]$state['state'] -in @('succeeded', 'failed', 'cancelled')) {
+            throw "workflow_terminal: $([string]$state['state'])"
+        }
+        $persistedFingerprint = Get-DeclarativeWorkflowContentDigest -Workflow $state['workflow']
+        if ($persistedFingerprint -cne [string]$state['workflow_fingerprint']) {
+            throw 'workflow fingerprint mismatch: persisted content changed.'
+        }
+        $plan = & $WorkspacePlanInvoker `
+            ([string]$state['recipe_id']) ([string]$state['workflow_id']) $RunId $resolvedProject
+        $currentWorkflow = Assert-DeclarativeWorkflowPlan `
+            -Plan $plan -RecipeId ([string]$state['recipe_id']) `
+            -WorkflowId ([string]$state['workflow_id']) -RunId $RunId
+        if ((Get-DeclarativeWorkflowContentDigest -Workflow $currentWorkflow) -cne $persistedFingerprint -or
+            [string](Get-DeclarativeWorkflowValue -InputObject $plan -Name 'config_fingerprint' -Default '') -cne
+                [string]$state['config_fingerprint']) {
+            throw 'workflow fingerprint mismatch: current content changed.'
+        }
+        if ($task.digest -cne [string]$state['task_digest'] -or
+            [int64]$task.bytes.Length -ne [int64]$state['task_bytes']) {
+            throw 'workflow task identity changed.'
+        }
+        $sourceHead = [string](& $SourceHeadReader $resolvedProject)
+        if ($sourceHead -cne [string]$state['source_head']) {
+            throw 'workflow source identity changed.'
+        }
+        $session = & $ManifestIdentityReader $resolvedProject
+        Assert-DeclarativeWorkflowIdentity -Identity $session -Context 'current manifest'
+        foreach ($name in @('session_name', 'generation_id', 'server_session_id')) {
+            if ([string](Get-DeclarativeWorkflowValue -InputObject $session -Name $name -Default '') -cne
+                [string]$state['session'][$name]) {
+                throw 'workflow session identity changed.'
+            }
+        }
+
+        $mailbox = Get-DeclarativeWorkflowMailboxRecords `
+            -ProjectDir $resolvedProject -RunId $RunId -Run $state
+        Assert-DeclarativeWorkflowStateProofConsistency -State $state -Mailbox $mailbox
+        $byNode = [ordered]@{}
+        foreach ($entry in @($mailbox.Values)) {
+            $nodeId = [string]$entry['record']['node_id']
+            if (-not $byNode.Contains($nodeId)) {
+                $byNode[$nodeId] = @()
+            }
+            $byNode[$nodeId] = @($byNode[$nodeId]) + @($entry)
+        }
+        foreach ($nodeId in @($byNode.Keys)) {
+            if (@($byNode[$nodeId]).Count -gt 1) {
+                throw "workflow_mailbox_ambiguous: $nodeId"
+            }
+        }
+
+        $moves = [System.Collections.Generic.List[object]]::new()
+        foreach ($nodeIdValue in @(Get-DeclarativeWorkflowValue -InputObject $state['workflow'] -Name 'topological_order' -Default @())) {
+            $nodeId = [string]$nodeIdValue
+            $nodeState = $state['nodes'][$nodeId]
+            $entries = @()
+            if ($byNode.Contains($nodeId)) {
+                $entries = @($byNode[$nodeId])
+            }
+            if ($entries.Count -eq 0) {
+                if ([string]$nodeState['state'] -in @('running', 'dispatching')) {
+                    $nodeState['state'] = 'blocked'
+                }
+                continue
+            }
+
+            $entry = $entries[0]
+            $record = $entry['record']
+            $messageId = [string]$record['message_id']
+            $alreadyAdmitted = @($state['admitted_messages']) -contains $messageId
+            if ($alreadyAdmitted) {
+                if ([string]$nodeState['message_id'] -cne $messageId) {
+                    throw 'workflow_mailbox_invalid: admitted message identity changed.'
+                }
+                $moves.Add($entry) | Out-Null
+                continue
+            }
+            if (-not [string]::IsNullOrWhiteSpace([string]$entry['consumed_path'])) {
+                throw 'workflow_mailbox_invalid: unadmitted result is already consumed.'
+            }
+
+            $nodeState['message_id'] = $messageId
+            $nodeState['result_digest'] = [string]$record['result_digest']
+            $nodeState['exit_code'] = [int]$record['exit_code']
+            $nodeState['state'] = [string]$record['outcome']
+            $state['admitted_messages'] = @($state['admitted_messages']) + @($messageId)
+            $moves.Add($entry) | Out-Null
+        }
+
+        Update-DeclarativeWorkflowOverallState -State $state
+        Set-DeclarativeWorkflowRunState -ProjectDir $resolvedProject -RunId $RunId -State $state | Out-Null
+        foreach ($entry in $moves) {
+            Move-DeclarativeWorkflowMessageToConsumed `
+                -ProjectDir $resolvedProject -RunId $RunId -MailboxEntry $entry
+        }
+        if ([string]$state['state'] -ne 'failed') {
+            Invoke-DeclarativeWorkflowReadyNodes `
+                -State $state -ProjectDir $resolvedProject -TaskContent $task.text -DispatchNode $DispatchNode
+        }
+        Update-DeclarativeWorkflowOverallState -State $state
+        Set-DeclarativeWorkflowRunState -ProjectDir $resolvedProject -RunId $RunId -State $state | Out-Null
+        return Read-DeclarativeWorkflowRunState -ProjectDir $resolvedProject -RunId $RunId
+    } finally {
+        $lease.Dispose()
+    }
+}

--- a/winsmux-core/scripts/team-pipeline.ps1
+++ b/winsmux-core/scripts/team-pipeline.ps1
@@ -12,6 +12,16 @@ param(
     [int]$MaxFixRounds = 2,
     [switch]$SkipPlan,
     [switch]$SkipVerify,
+    [string]$WorkflowAction = '',
+    [string]$RecipeId = '',
+    [string]$WorkflowId = '',
+    [string]$RunId = '',
+    [string]$TaskFile = '',
+    [string]$ProjectDir = '',
+    [switch]$WorkflowResult,
+    [string]$WorkflowResultNodeId = '',
+    [string]$WorkflowResultOutcome = '',
+    [int]$WorkflowResultExitCode = [int]::MinValue,
     [switch]$AsJson
 )
 
@@ -19,12 +29,18 @@ $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
 [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
 
+$script:TeamPipelineInvocationProjectDir = $ProjectDir
+$script:TeamPipelineInvocationAsJson = [bool]$AsJson
 $script:TeamPipelineBridgeScript = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\..\scripts\winsmux-core.ps1'))
 $script:TeamPipelineLoggerScript = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot 'logger.ps1'))
 $script:TeamPipelinePaneEnvScript = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot 'pane-env.ps1'))
 $script:TeamPipelineDangerousApprovalPattern = '(?im)(rm\s+-rf|Remove-Item\s+.+-Recurse.+-Force|git\s+push\s+--force|git\s+reset\s+--hard|DROP\s+TABLE|DELETE\s+FROM)'
 
 . (Join-Path $PSScriptRoot 'manifest.ps1')
+$script:DeclarativeWorkflowScript = Join-Path $PSScriptRoot 'declarative-workflow.ps1'
+if (Test-Path -LiteralPath $script:DeclarativeWorkflowScript -PathType Leaf) {
+    . $script:DeclarativeWorkflowScript
+}
 if (Test-Path $script:TeamPipelineLoggerScript -PathType Leaf) {
     . $script:TeamPipelineLoggerScript
 }
@@ -455,12 +471,67 @@ function Get-TeamPipelineConsultRole {
 function Invoke-TeamPipelineBridge {
     param(
         [Parameter(Mandatory = $true)][string[]]$Arguments,
-        [switch]$AllowFailure
+        [switch]$AllowFailure,
+        [string]$ProjectDir = '',
+        [string]$ExpectedSessionName = '',
+        [string]$ExpectedGenerationId = '',
+        [string]$ExpectedServerSessionId = ''
     )
 
-    $output = & pwsh -NoProfile -File $script:TeamPipelineBridgeScript @Arguments 2>&1
-    $exitCode = $LASTEXITCODE
-    $text = ($output | Out-String).TrimEnd()
+    $authorityValues = [ordered]@{
+        WINSMUX_INTERNAL_WORKFLOW_PROJECT_DIR = $ProjectDir
+        WINSMUX_INTERNAL_WORKFLOW_SESSION_NAME = $ExpectedSessionName
+        WINSMUX_INTERNAL_WORKFLOW_GENERATION_ID = $ExpectedGenerationId
+        WINSMUX_INTERNAL_WORKFLOW_SERVER_SESSION_ID = $ExpectedServerSessionId
+    }
+    $authorityPresent = @(
+        $authorityValues.Values |
+            Where-Object { -not [string]::IsNullOrWhiteSpace([string]$_) }
+    ).Count
+    if ($authorityPresent -notin @(0, $authorityValues.Count)) {
+        throw 'workflow_dispatch_authority_invalid: project and exact session tuple are required together.'
+    }
+    if ($authorityPresent -gt 0) {
+        $authorityValues['WINSMUX_INTERNAL_WORKFLOW_PROJECT_DIR'] =
+            [System.IO.Path]::GetFullPath($ProjectDir)
+    }
+
+    $originalEnvironment = [ordered]@{}
+    foreach ($name in $authorityValues.Keys) {
+        $originalEnvironment[$name] = [Environment]::GetEnvironmentVariable(
+            $name,
+            [EnvironmentVariableTarget]::Process
+        )
+    }
+    $pushed = $false
+    try {
+        if ($authorityPresent -gt 0) {
+            foreach ($name in $authorityValues.Keys) {
+                [Environment]::SetEnvironmentVariable(
+                    $name,
+                    [string]$authorityValues[$name],
+                    [EnvironmentVariableTarget]::Process
+                )
+            }
+            Push-Location ([string]$authorityValues['WINSMUX_INTERNAL_WORKFLOW_PROJECT_DIR'])
+            $pushed = $true
+        }
+
+        $output = & pwsh -NoProfile -File $script:TeamPipelineBridgeScript @Arguments 2>&1
+        $exitCode = $LASTEXITCODE
+        $text = ($output | Out-String).TrimEnd()
+    } finally {
+        if ($pushed) {
+            Pop-Location
+        }
+        foreach ($name in $originalEnvironment.Keys) {
+            [Environment]::SetEnvironmentVariable(
+                $name,
+                $originalEnvironment[$name],
+                [EnvironmentVariableTarget]::Process
+            )
+        }
+    }
 
     if ($exitCode -ne 0 -and -not $AllowFailure) {
         if ([string]::IsNullOrWhiteSpace($text)) {
@@ -910,6 +981,8 @@ function Invoke-TeamPipelineGuardedSend {
         [Parameter(Mandatory = $true)][string]$Prompt,
         [Parameter(Mandatory = $true)][string]$ProjectDir,
         [Parameter(Mandatory = $true)][string]$SessionName,
+        [string]$ExpectedGenerationId = '',
+        [string]$ExpectedServerSessionId = '',
         [string]$Role = '',
         [string]$Task = '',
         [int]$Attempt = 0
@@ -917,7 +990,17 @@ function Invoke-TeamPipelineGuardedSend {
 
     $violation = Find-TeamPipelineSecurityViolation -StageName $StageName -Text $Prompt
     if ($null -eq $violation) {
-        Invoke-TeamPipelineBridge -Arguments @('send', $Target, $Prompt) | Out-Null
+        $bridgeParameters = @{
+            Arguments = @('send', $Target, $Prompt)
+        }
+        if (-not [string]::IsNullOrWhiteSpace($ExpectedGenerationId) -or
+            -not [string]::IsNullOrWhiteSpace($ExpectedServerSessionId)) {
+            $bridgeParameters['ProjectDir'] = $ProjectDir
+            $bridgeParameters['ExpectedSessionName'] = $SessionName
+            $bridgeParameters['ExpectedGenerationId'] = $ExpectedGenerationId
+            $bridgeParameters['ExpectedServerSessionId'] = $ExpectedServerSessionId
+        }
+        Invoke-TeamPipelineBridge @bridgeParameters | Out-Null
         return $null
     }
 
@@ -1744,9 +1827,46 @@ function Invoke-TeamPipeline {
 }
 
 if ($MyInvocation.InvocationName -ne '.') {
-    $pipelineResult = Invoke-TeamPipeline -Task $Task -Builder $Builder -Researcher $Researcher -Reviewer $Reviewer -ManifestPath $ManifestPath -BuilderWorktreePath $BuilderWorktreePath -PollIntervalSeconds $PollIntervalSeconds -StageTimeoutSeconds $StageTimeoutSeconds -MaxFixRounds $MaxFixRounds -SkipPlan:$SkipPlan -SkipVerify:$SkipVerify
-    if ($AsJson) {
-        $pipelineResult | ConvertTo-Json -Depth 8
+    $workflowProjectDir = $script:TeamPipelineInvocationProjectDir
+    if ($WorkflowResult) {
+        if (-not [string]::IsNullOrWhiteSpace($WorkflowAction)) {
+            throw 'workflow_result_invalid: result production and workflow execution are mutually exclusive.'
+        }
+        if ([string]::IsNullOrWhiteSpace($workflowProjectDir) -or
+            [string]::IsNullOrWhiteSpace($RunId) -or
+            [string]::IsNullOrWhiteSpace($WorkflowResultNodeId) -or
+            $WorkflowResultOutcome -cnotin @('succeeded', 'failed') -or
+            $WorkflowResultExitCode -eq [int]::MinValue) {
+            throw 'workflow_result_invalid: project, run, node, ordinal outcome, and exit code are required.'
+        }
+        if (-not (Get-Command Write-DeclarativeWorkflowNodeResult -CommandType Function -ErrorAction SilentlyContinue)) {
+            throw "Declarative workflow result adapter not found: $script:DeclarativeWorkflowScript"
+        }
+        $pipelineResult = Write-DeclarativeWorkflowNodeResult `
+            -ProjectDir $workflowProjectDir `
+            -RunId $RunId `
+            -NodeId $WorkflowResultNodeId `
+            -Outcome $WorkflowResultOutcome `
+            -ExitCode $WorkflowResultExitCode
+    } elseif (-not [string]::IsNullOrWhiteSpace($WorkflowAction)) {
+        if (-not (Get-Command Invoke-DeclarativeWorkflow -CommandType Function -ErrorAction SilentlyContinue)) {
+            throw "Declarative workflow runtime not found: $script:DeclarativeWorkflowScript"
+        }
+        if ([string]::IsNullOrWhiteSpace($workflowProjectDir)) {
+            $workflowProjectDir = (Get-Location).Path
+        }
+        $pipelineResult = Invoke-DeclarativeWorkflow `
+            -Action $WorkflowAction `
+            -RecipeId $RecipeId `
+            -WorkflowId $WorkflowId `
+            -RunId $RunId `
+            -TaskFile $TaskFile `
+            -ProjectDir $workflowProjectDir
+    } else {
+        $pipelineResult = Invoke-TeamPipeline -Task $Task -Builder $Builder -Researcher $Researcher -Reviewer $Reviewer -ManifestPath $ManifestPath -BuilderWorktreePath $BuilderWorktreePath -PollIntervalSeconds $PollIntervalSeconds -StageTimeoutSeconds $StageTimeoutSeconds -MaxFixRounds $MaxFixRounds -SkipPlan:$SkipPlan -SkipVerify:$SkipVerify
+    }
+    if ($script:TeamPipelineInvocationAsJson) {
+        $pipelineResult | ConvertTo-Json -Depth 50
     } else {
         $pipelineResult
     }

--- a/winsmux-core/scripts/team-pipeline.ps1
+++ b/winsmux-core/scripts/team-pipeline.ps1
@@ -18,6 +18,7 @@ param(
     [string]$RunId = '',
     [string]$TaskFile = '',
     [string]$ProjectDir = '',
+    [string]$WorkflowPlanCommand = '',
     [switch]$WorkflowResult,
     [string]$WorkflowResultNodeId = '',
     [string]$WorkflowResultOutcome = '',
@@ -1929,7 +1930,8 @@ if ($MyInvocation.InvocationName -ne '.') {
             -WorkflowId $WorkflowId `
             -RunId $RunId `
             -TaskFile $TaskFile `
-            -ProjectDir $workflowProjectDir
+            -ProjectDir $workflowProjectDir `
+            -WorkspacePlanCommand $WorkflowPlanCommand
     } else {
         $pipelineResult = Invoke-TeamPipeline -Task $Task -Builder $Builder -Researcher $Researcher -Reviewer $Reviewer -ManifestPath $ManifestPath -BuilderWorktreePath $BuilderWorktreePath -PollIntervalSeconds $PollIntervalSeconds -StageTimeoutSeconds $StageTimeoutSeconds -MaxFixRounds $MaxFixRounds -SkipPlan:$SkipPlan -SkipVerify:$SkipVerify
     }

--- a/winsmux-core/scripts/team-pipeline.ps1
+++ b/winsmux-core/scripts/team-pipeline.ps1
@@ -471,6 +471,7 @@ function Get-TeamPipelineConsultRole {
 function Invoke-TeamPipelineBridge {
     param(
         [Parameter(Mandatory = $true)][string[]]$Arguments,
+        [AllowNull()][string]$InputText,
         [switch]$AllowFailure,
         [string]$ProjectDir = '',
         [string]$ExpectedSessionName = '',
@@ -478,6 +479,7 @@ function Invoke-TeamPipelineBridge {
         [string]$ExpectedServerSessionId = ''
     )
 
+    $hasInputText = $PSBoundParameters.ContainsKey('InputText')
     $authorityValues = [ordered]@{
         WINSMUX_INTERNAL_WORKFLOW_PROJECT_DIR = $ProjectDir
         WINSMUX_INTERNAL_WORKFLOW_SESSION_NAME = $ExpectedSessionName
@@ -490,6 +492,17 @@ function Invoke-TeamPipelineBridge {
     ).Count
     if ($authorityPresent -notin @(0, $authorityValues.Count)) {
         throw 'workflow_dispatch_authority_invalid: project and exact session tuple are required together.'
+    }
+    if ($hasInputText) {
+        if ($authorityPresent -ne $authorityValues.Count) {
+            throw 'workflow_dispatch_authority_invalid: workflow prompt stdin requires the complete authority tuple.'
+        }
+        if ($Arguments.Count -ne 3 -or
+            [string]$Arguments[0] -cne 'send' -or
+            [string]::IsNullOrWhiteSpace([string]$Arguments[1]) -or
+            [string]$Arguments[2] -cne '--workflow-prompt-stdin') {
+            throw 'workflow_dispatch_transport_invalid: stdin prompt requires send, target, and the internal marker only.'
+        }
     }
     if ($authorityPresent -gt 0) {
         $authorityValues['WINSMUX_INTERNAL_WORKFLOW_PROJECT_DIR'] =
@@ -517,9 +530,56 @@ function Invoke-TeamPipelineBridge {
             $pushed = $true
         }
 
-        $output = & pwsh -NoProfile -File $script:TeamPipelineBridgeScript @Arguments 2>&1
-        $exitCode = $LASTEXITCODE
-        $text = ($output | Out-String).TrimEnd()
+        if ($hasInputText) {
+            $pwshCommand = Get-Command pwsh -ErrorAction Stop
+            $pwshPath = if (-not [string]::IsNullOrWhiteSpace([string]$pwshCommand.Source)) {
+                [string]$pwshCommand.Source
+            } else {
+                [string]$pwshCommand.Path
+            }
+            $startInfo = [System.Diagnostics.ProcessStartInfo]::new()
+            $startInfo.FileName = $pwshPath
+            $startInfo.UseShellExecute = $false
+            $startInfo.CreateNoWindow = $true
+            $startInfo.WorkingDirectory =
+                [string]$authorityValues['WINSMUX_INTERNAL_WORKFLOW_PROJECT_DIR']
+            $startInfo.RedirectStandardInput = $true
+            $startInfo.RedirectStandardOutput = $true
+            $startInfo.RedirectStandardError = $true
+            $startInfo.StandardInputEncoding = [System.Text.UTF8Encoding]::new($false)
+            $startInfo.StandardOutputEncoding = [System.Text.UTF8Encoding]::new($false, $true)
+            $startInfo.StandardErrorEncoding = [System.Text.UTF8Encoding]::new($false, $true)
+            foreach ($argument in @('-NoProfile', '-File', $script:TeamPipelineBridgeScript) + @($Arguments)) {
+                $startInfo.ArgumentList.Add([string]$argument)
+            }
+
+            $process = [System.Diagnostics.Process]::new()
+            $process.StartInfo = $startInfo
+            try {
+                if (-not $process.Start()) {
+                    throw 'workflow_dispatch_transport_failed: child process did not start.'
+                }
+                $stdoutTask = $process.StandardOutput.ReadToEndAsync()
+                $stderrTask = $process.StandardError.ReadToEndAsync()
+                $process.StandardInput.Write($InputText)
+                $process.StandardInput.Close()
+                $process.WaitForExit()
+                $stdoutText = $stdoutTask.GetAwaiter().GetResult()
+                $stderrText = $stderrTask.GetAwaiter().GetResult()
+                $exitCode = $process.ExitCode
+                $text = @(
+                    ([string]$stdoutText).TrimEnd()
+                    ([string]$stderrText).TrimEnd()
+                ) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+                    Join-String -Separator ([Environment]::NewLine)
+            } finally {
+                $process.Dispose()
+            }
+        } else {
+            $output = & pwsh -NoProfile -File $script:TeamPipelineBridgeScript @Arguments 2>&1
+            $exitCode = $LASTEXITCODE
+            $text = ($output | Out-String).TrimEnd()
+        }
     } finally {
         if ($pushed) {
             Pop-Location
@@ -983,6 +1043,7 @@ function Invoke-TeamPipelineGuardedSend {
         [Parameter(Mandatory = $true)][string]$SessionName,
         [string]$ExpectedGenerationId = '',
         [string]$ExpectedServerSessionId = '',
+        [switch]$WorkflowPromptStdin,
         [string]$Role = '',
         [string]$Task = '',
         [int]$Attempt = 0
@@ -991,7 +1052,14 @@ function Invoke-TeamPipelineGuardedSend {
     $violation = Find-TeamPipelineSecurityViolation -StageName $StageName -Text $Prompt
     if ($null -eq $violation) {
         $bridgeParameters = @{
-            Arguments = @('send', $Target, $Prompt)
+            Arguments = if ($WorkflowPromptStdin) {
+                @('send', $Target, '--workflow-prompt-stdin')
+            } else {
+                @('send', $Target, $Prompt)
+            }
+        }
+        if ($WorkflowPromptStdin) {
+            $bridgeParameters['InputText'] = $Prompt
         }
         if (-not [string]::IsNullOrWhiteSpace($ExpectedGenerationId) -or
             -not [string]::IsNullOrWhiteSpace($ExpectedServerSessionId)) {


### PR DESCRIPTION
## Summary

- add `winsmux pipeline --workflow-action start|resume` as the only public declarative workflow actions
- normalize deterministic workflow DAGs in the Rust workflow domain and persist content-derived run identity
- separate the mutable start/resume state authority from the lease-independent immutable result-mailbox producer
- preserve legacy pipeline/task-run behavior and include the runtime dependency in installed/npm package validation

This replacement keeps public cancellation recovery, a separate proof store,
unrelated-run cleanup, and filesystem-sandbox claims out of scope.

## Verification

- TASK-659 production-path decision rows: 21/21 unfiltered and 21/21 row-level GREEN
- PowerShell 5.1 compatibility plus frozen module ownership: 22/22
- npm/installer package contract: 21/21
- official parallel Pester: 1,652/1,653, plus the one unchanged C93 selector 1/1 on the same tree after its fixture Node process exited once with Windows access violation `0xC0000005`; no full-suite rerun
- PowerShell parser: 8/8 paths, zero errors
- `cargo fmt --check`, desktop split static gate, public-surface audit, full `git-guard`, and gitleaks v8.30.0 history scan passed

Local Rust type execution remains owned by CI because the local MSVC
environment cannot locate `msvcrt.lib`; no product failure was observed before
that toolchain boundary.
