### PR TITLE
feat(workflow): add deterministic context packs

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -59,6 +59,10 @@ name = "workflow_contract"
 path = "tests-rs/workflow_contract.rs"
 
 [[test]]
+name = "context_pack_contract"
+path = "tests-rs/context_pack_contract.rs"
+
+[[test]]
 name = "search_ledger_contract"
 path = "tests-rs/search_ledger_contract.rs"
 

--- a/core/src/context_pack.rs
+++ b/core/src/context_pack.rs
@@ -553,20 +553,20 @@ fn is_stable_id(value: &str) -> bool {
 }
 
 fn is_stable_test_id(value: &str) -> bool {
-    if value.is_empty()
-        || value.len() > MAX_ID_BYTES
-        || !value.is_ascii()
-        || !value
-            .bytes()
-            .next()
-            .is_some_and(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit())
-    {
+    if value.is_empty() || value.len() > MAX_ID_BYTES || !value.is_ascii() {
         return false;
     }
-    value.bytes().all(|byte| {
-        byte.is_ascii_lowercase()
-            || byte.is_ascii_digit()
-            || matches!(byte, b'.' | b'_' | b'-' | b'/' | b':')
+    value.split("::").all(|segment| {
+        !segment.is_empty()
+            && segment
+                .bytes()
+                .next()
+                .is_some_and(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit())
+            && segment.bytes().all(|byte| {
+                byte.is_ascii_lowercase()
+                    || byte.is_ascii_digit()
+                    || matches!(byte, b'.' | b'_' | b'-')
+            })
     })
 }
 

--- a/core/src/context_pack.rs
+++ b/core/src/context_pack.rs
@@ -1,6 +1,6 @@
 use crate::manifest_contract::{
-    canonical_public_path_key, is_safe_public_path_identity, PUBLIC_REF_MAX_BYTES,
-    PUBLIC_REPO_PATH_MAX_BYTES,
+    canonical_public_path_key, is_context_pack_id, is_safe_public_path_identity,
+    PUBLIC_REF_MAX_BYTES, PUBLIC_REPO_PATH_MAX_BYTES,
 };
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -252,7 +252,7 @@ pub(crate) fn split_cli<T>(
     }
     let selection = match (pack_id, input) {
         (None, None) => None,
-        (Some(pack_id), Some(input)) if input == "-" && is_stable_id(&pack_id) => {
+        (Some(pack_id), Some(input)) if input == "-" && is_context_pack_id(&pack_id) => {
             Some(ContextPackCliSelection { pack_id })
         }
         _ => return Err(context_pack_rejected()),
@@ -298,7 +298,7 @@ pub(crate) fn build_context_pack(
     pack_id: &str,
     input_bytes: &[u8],
 ) -> ContextPackResult<ContextPackProjection> {
-    if !is_stable_id(pack_id) {
+    if !is_context_pack_id(pack_id) {
         return Err(ContextPackError);
     }
     let (include, limits, policy_fingerprint) = normalize_policy(root, pack_id)?;
@@ -525,33 +525,6 @@ fn remove_one_for_byte_limit(pack: &mut CanonicalContextPack) -> bool {
     }
     pack.omissions.omitted_by_bytes += 1;
     true
-}
-
-fn is_stable_id(value: &str) -> bool {
-    if value.is_empty() || value.len() > 64 || !value.is_ascii() {
-        return false;
-    }
-    let mut parts = value.split('-');
-    let Some(first) = parts.next() else {
-        return false;
-    };
-    if first.is_empty()
-        || !first
-            .bytes()
-            .next()
-            .is_some_and(|byte| byte.is_ascii_lowercase())
-        || !first
-            .bytes()
-            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit())
-    {
-        return false;
-    }
-    parts.all(|part| {
-        !part.is_empty()
-            && part
-                .bytes()
-                .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit())
-    })
 }
 
 fn is_stable_test_id(value: &str) -> bool {

--- a/core/src/context_pack.rs
+++ b/core/src/context_pack.rs
@@ -1,0 +1,669 @@
+use crate::manifest_contract::{
+    canonical_public_path_key, is_safe_public_path_identity, PUBLIC_REF_MAX_BYTES,
+    PUBLIC_REPO_PATH_MAX_BYTES,
+};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::{
+    collections::BTreeSet,
+    io::{self, Read},
+};
+
+const CONTEXT_PACK_SCHEMA_VERSION: u64 = 1;
+const DEFAULT_MAX_FILES: usize = 100;
+const DEFAULT_MAX_BYTES: usize = 262_144;
+const DEFAULT_MAX_EVIDENCE_REFS: usize = 50;
+const HARD_MAX_FILES: usize = 1_000;
+const HARD_MAX_BYTES: usize = 1_048_576;
+const HARD_MAX_EVIDENCE_REFS: usize = 500;
+const MAX_ID_BYTES: usize = 256;
+const MAX_CONTEXT_PACK_INPUT_BYTES: usize = 4 * 1024 * 1024;
+
+#[derive(Debug)]
+pub(crate) struct ContextPackError;
+
+type ContextPackResult<T> = Result<T, ContextPackError>;
+
+#[derive(Debug)]
+pub(crate) struct ContextPackCliSelection {
+    pack_id: String,
+}
+
+#[derive(Serialize)]
+#[serde(untagged)]
+pub(crate) enum WorkspacePlanOutput<T> {
+    Legacy(T),
+    WithContext(serde_json::Value),
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub(crate) struct ContextPackProjection {
+    canonical_json: String,
+    digest: String,
+    byte_count: usize,
+    manifest_projection: ContextPackManifestProjection,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct ContextPackManifestProjection {
+    pack_id: String,
+    schema_version: u64,
+    digest: String,
+    byte_count: usize,
+    source_head: String,
+    policy_fingerprint: String,
+    limits: ContextPackLimits,
+    omissions: ContextPackOmissions,
+    privacy_result: &'static str,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct CanonicalContextPack {
+    schema_version: u64,
+    pack_id: String,
+    source_head: String,
+    policy_fingerprint: String,
+    limits: ContextPackLimits,
+    groups: ContextPackGroups,
+    omissions: ContextPackOmissions,
+    privacy_result: &'static str,
+}
+
+#[derive(Clone, Debug, Default, Serialize)]
+struct ContextPackGroups {
+    code_map: Vec<CodeMapEntry>,
+    changed_files: Vec<ChangedFileEntry>,
+    tests: Vec<TestEntry>,
+    evidence_refs: Vec<String>,
+}
+
+#[derive(Clone, Debug, Default, Serialize)]
+struct ContextPackOmissions {
+    code_map: u64,
+    changed_files: u64,
+    tests: u64,
+    evidence_refs: u64,
+    omitted_by_bytes: u64,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct ContextPackLimits {
+    max_files: usize,
+    max_bytes: usize,
+    max_evidence_refs: usize,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(rename_all = "kebab-case")]
+enum IncludeGroup {
+    CodeMap,
+    ChangedFiles,
+    Tests,
+    EvidenceRefs,
+}
+
+impl IncludeGroup {
+    const ALL: [Self; 4] = [
+        Self::CodeMap,
+        Self::ChangedFiles,
+        Self::Tests,
+        Self::EvidenceRefs,
+    ];
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+struct ContextPackPolicy {
+    schema_version: u64,
+    include: Vec<IncludeGroup>,
+    #[serde(default)]
+    limits: ContextPackPolicyLimits,
+    #[serde(default)]
+    privacy: ContextPackPrivacy,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+struct ContextPackPolicyLimits {
+    #[serde(default = "default_max_files")]
+    max_files: usize,
+    #[serde(default = "default_max_bytes")]
+    max_bytes: usize,
+    #[serde(default = "default_max_evidence_refs")]
+    max_evidence_refs: usize,
+}
+
+impl Default for ContextPackPolicyLimits {
+    fn default() -> Self {
+        Self {
+            max_files: DEFAULT_MAX_FILES,
+            max_bytes: DEFAULT_MAX_BYTES,
+            max_evidence_refs: DEFAULT_MAX_EVIDENCE_REFS,
+        }
+    }
+}
+
+#[derive(Debug, Default, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+struct ContextPackPrivacy {
+    #[serde(default)]
+    raw_transcript: bool,
+    #[serde(default)]
+    prompt_bodies: bool,
+    #[serde(default)]
+    secrets: bool,
+    #[serde(default)]
+    private_local_paths: bool,
+}
+
+#[derive(Serialize)]
+struct NormalizedPolicyFingerprint {
+    schema_version: u64,
+    include: Vec<IncludeGroup>,
+    limits: ContextPackLimits,
+    privacy: ContextPackPrivacy,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ContextPackInput {
+    schema_version: u64,
+    source_head: String,
+    #[serde(default)]
+    code_map: Vec<CodeMapEntry>,
+    #[serde(default)]
+    changed_files: Vec<ChangedFileEntry>,
+    #[serde(default)]
+    tests: Vec<TestEntry>,
+    #[serde(default)]
+    evidence_refs: Vec<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct CodeMapEntry {
+    path: String,
+    content_sha256: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct ChangedFileEntry {
+    path: String,
+    status: ChangedFileStatus,
+    content_sha256: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum ChangedFileStatus {
+    Added,
+    Modified,
+    Deleted,
+    Renamed,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct TestEntry {
+    test_id: String,
+    outcome: TestOutcome,
+    evidence_ref: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum TestOutcome {
+    Passed,
+    Failed,
+    Blocked,
+    NotApplicable,
+}
+
+pub(crate) fn split_cli<T>(
+    args: &[&String],
+    parse_legacy: impl FnOnce(&[&String]) -> io::Result<T>,
+) -> io::Result<(Option<ContextPackCliSelection>, T)> {
+    let mut legacy_args = Vec::with_capacity(args.len());
+    let mut pack_id = None;
+    let mut input = None;
+    let mut index = 0;
+    while index < args.len() {
+        let slot = match args[index].as_str() {
+            "--context-pack-id" => Some(&mut pack_id),
+            "--context-pack-input" => Some(&mut input),
+            value if value.starts_with("--context-pack") => {
+                return Err(context_pack_rejected());
+            }
+            _ => None,
+        };
+        let Some(slot) = slot else {
+            legacy_args.push(args[index]);
+            index += 1;
+            continue;
+        };
+        let Some(value) = args.get(index + 1) else {
+            return Err(context_pack_rejected());
+        };
+        if slot.replace(value.to_string()).is_some() {
+            return Err(context_pack_rejected());
+        }
+        index += 2;
+    }
+    let selection = match (pack_id, input) {
+        (None, None) => None,
+        (Some(pack_id), Some(input)) if input == "-" => Some(ContextPackCliSelection { pack_id }),
+        _ => return Err(context_pack_rejected()),
+    };
+    Ok((selection, parse_legacy(&legacy_args)?))
+}
+
+pub(crate) fn apply_cli<T: Serialize>(
+    root: &serde_yaml::Value,
+    selection: Option<ContextPackCliSelection>,
+    payload: T,
+) -> io::Result<WorkspacePlanOutput<T>> {
+    let Some(selection) = selection else {
+        return Ok(WorkspacePlanOutput::Legacy(payload));
+    };
+    let mut input = Vec::new();
+    io::stdin()
+        .take((MAX_CONTEXT_PACK_INPUT_BYTES + 1) as u64)
+        .read_to_end(&mut input)
+        .map_err(|_| context_pack_rejected())?;
+    if input.len() > MAX_CONTEXT_PACK_INPUT_BYTES {
+        return Err(context_pack_rejected());
+    }
+    let context_pack = build_context_pack(root, &selection.pack_id, &input)
+        .map_err(|_| context_pack_rejected())?;
+    let mut output = serde_json::to_value(payload).map_err(|_| context_pack_rejected())?;
+    output
+        .as_object_mut()
+        .ok_or_else(context_pack_rejected)?
+        .insert(
+            "context_pack".to_string(),
+            serde_json::to_value(context_pack).map_err(|_| context_pack_rejected())?,
+        );
+    Ok(WorkspacePlanOutput::WithContext(output))
+}
+
+fn context_pack_rejected() -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, "context pack rejected.")
+}
+
+pub(crate) fn build_context_pack(
+    root: &serde_yaml::Value,
+    pack_id: &str,
+    input_bytes: &[u8],
+) -> ContextPackResult<ContextPackProjection> {
+    if !is_stable_id(pack_id) {
+        return Err(ContextPackError);
+    }
+    let (include, limits, policy_fingerprint) = normalize_policy(root, pack_id)?;
+    let mut input: ContextPackInput =
+        serde_json::from_slice(input_bytes).map_err(|_| ContextPackError)?;
+    validate_input(&input)?;
+
+    input.code_map.sort_by(|left, right| {
+        (&left.path, &left.content_sha256).cmp(&(&right.path, &right.content_sha256))
+    });
+    input.changed_files.sort_by(|left, right| {
+        (&left.path, &left.status, &left.content_sha256).cmp(&(
+            &right.path,
+            &right.status,
+            &right.content_sha256,
+        ))
+    });
+    input.tests.sort_by(|left, right| {
+        (&left.test_id, &left.outcome, &left.evidence_ref).cmp(&(
+            &right.test_id,
+            &right.outcome,
+            &right.evidence_ref,
+        ))
+    });
+    input.evidence_refs.sort();
+
+    let include = include.into_iter().collect::<BTreeSet<_>>();
+    let mut groups = ContextPackGroups::default();
+    let mut omissions = ContextPackOmissions::default();
+
+    let mut remaining_files = limits.max_files;
+    if include.contains(&IncludeGroup::CodeMap) {
+        let keep = remaining_files.min(input.code_map.len());
+        groups
+            .code_map
+            .extend(input.code_map.iter().take(keep).cloned());
+        omissions.code_map = (input.code_map.len() - keep) as u64;
+        remaining_files -= keep;
+    } else {
+        omissions.code_map = input.code_map.len() as u64;
+    }
+    if include.contains(&IncludeGroup::ChangedFiles) {
+        let keep = remaining_files.min(input.changed_files.len());
+        groups
+            .changed_files
+            .extend(input.changed_files.iter().take(keep).cloned());
+        omissions.changed_files = (input.changed_files.len() - keep) as u64;
+    } else {
+        omissions.changed_files = input.changed_files.len() as u64;
+    }
+
+    let mut remaining_refs = limits.max_evidence_refs;
+    if include.contains(&IncludeGroup::Tests) {
+        let keep = remaining_refs.min(input.tests.len());
+        groups.tests.extend(input.tests.iter().take(keep).cloned());
+        omissions.tests = (input.tests.len() - keep) as u64;
+        remaining_refs -= keep;
+    } else {
+        omissions.tests = input.tests.len() as u64;
+    }
+    if include.contains(&IncludeGroup::EvidenceRefs) {
+        let keep = remaining_refs.min(input.evidence_refs.len());
+        groups
+            .evidence_refs
+            .extend(input.evidence_refs.iter().take(keep).cloned());
+        omissions.evidence_refs = (input.evidence_refs.len() - keep) as u64;
+    } else {
+        omissions.evidence_refs = input.evidence_refs.len() as u64;
+    }
+
+    let mut canonical = CanonicalContextPack {
+        schema_version: CONTEXT_PACK_SCHEMA_VERSION,
+        pack_id: pack_id.to_string(),
+        source_head: input.source_head,
+        policy_fingerprint: policy_fingerprint.clone(),
+        limits: limits.clone(),
+        groups,
+        omissions,
+        privacy_result: "pass",
+    };
+    let canonical_bytes = loop {
+        let bytes = serde_json::to_vec(&canonical).map_err(|_| ContextPackError)?;
+        if bytes.len() <= limits.max_bytes {
+            break bytes;
+        }
+        if !remove_one_for_byte_limit(&mut canonical) {
+            return Err(ContextPackError);
+        }
+    };
+
+    let digest = sha256(&canonical_bytes);
+    let byte_count = canonical_bytes.len();
+    let canonical_json = String::from_utf8(canonical_bytes).map_err(|_| ContextPackError)?;
+    let manifest_projection = ContextPackManifestProjection {
+        pack_id: pack_id.to_string(),
+        schema_version: CONTEXT_PACK_SCHEMA_VERSION,
+        digest: digest.clone(),
+        byte_count,
+        source_head: canonical.source_head.clone(),
+        policy_fingerprint,
+        limits,
+        omissions: canonical.omissions,
+        privacy_result: "pass",
+    };
+    Ok(ContextPackProjection {
+        canonical_json,
+        digest,
+        byte_count,
+        manifest_projection,
+    })
+}
+
+fn normalize_policy(
+    root: &serde_yaml::Value,
+    pack_id: &str,
+) -> ContextPackResult<(Vec<IncludeGroup>, ContextPackLimits, String)> {
+    let root = root.as_mapping().ok_or(ContextPackError)?;
+    let policies = root
+        .get(serde_yaml::Value::String("context-packs".to_string()))
+        .and_then(serde_yaml::Value::as_mapping)
+        .ok_or(ContextPackError)?;
+    let raw = policies
+        .get(serde_yaml::Value::String(pack_id.to_string()))
+        .ok_or(ContextPackError)?;
+    let policy: ContextPackPolicy =
+        serde_yaml::from_value(raw.clone()).map_err(|_| ContextPackError)?;
+    if policy.schema_version != CONTEXT_PACK_SCHEMA_VERSION || policy.include.is_empty() {
+        return Err(ContextPackError);
+    }
+    let selected = policy.include.iter().copied().collect::<BTreeSet<_>>();
+    if selected.len() != policy.include.len() {
+        return Err(ContextPackError);
+    }
+    if policy.limits.max_files == 0
+        || policy.limits.max_files > HARD_MAX_FILES
+        || policy.limits.max_bytes == 0
+        || policy.limits.max_bytes > HARD_MAX_BYTES
+        || policy.limits.max_evidence_refs == 0
+        || policy.limits.max_evidence_refs > HARD_MAX_EVIDENCE_REFS
+        || policy.privacy.raw_transcript
+        || policy.privacy.prompt_bodies
+        || policy.privacy.secrets
+        || policy.privacy.private_local_paths
+    {
+        return Err(ContextPackError);
+    }
+    let include = IncludeGroup::ALL
+        .into_iter()
+        .filter(|group| selected.contains(group))
+        .collect::<Vec<_>>();
+    let limits = ContextPackLimits {
+        max_files: policy.limits.max_files,
+        max_bytes: policy.limits.max_bytes,
+        max_evidence_refs: policy.limits.max_evidence_refs,
+    };
+    let normalized = NormalizedPolicyFingerprint {
+        schema_version: CONTEXT_PACK_SCHEMA_VERSION,
+        include: include.clone(),
+        limits: limits.clone(),
+        privacy: policy.privacy,
+    };
+    let policy_bytes = serde_json::to_vec(&normalized).map_err(|_| ContextPackError)?;
+    Ok((include, limits, sha256(&policy_bytes)))
+}
+
+fn validate_input(input: &ContextPackInput) -> ContextPackResult<()> {
+    if input.schema_version != CONTEXT_PACK_SCHEMA_VERSION || !is_lower_hex(&input.source_head, 40)
+    {
+        return Err(ContextPackError);
+    }
+
+    let mut code_paths = BTreeSet::new();
+    for entry in &input.code_map {
+        if !is_safe_repo_path(&entry.path)
+            || !is_sha256(&entry.content_sha256)
+            || !code_paths.insert(canonical_public_path_key(&entry.path))
+        {
+            return Err(ContextPackError);
+        }
+    }
+
+    let mut changed_paths = BTreeSet::new();
+    for entry in &input.changed_files {
+        if !is_safe_repo_path(&entry.path)
+            || !is_sha256(&entry.content_sha256)
+            || !changed_paths.insert(canonical_public_path_key(&entry.path))
+        {
+            return Err(ContextPackError);
+        }
+    }
+
+    let mut test_ids = BTreeSet::new();
+    let mut evidence_refs = BTreeSet::new();
+    for entry in &input.tests {
+        if !is_stable_test_id(&entry.test_id)
+            || !is_safe_evidence_ref(&entry.evidence_ref)
+            || !test_ids.insert(entry.test_id.as_str())
+            || !evidence_refs.insert(canonical_public_path_key(&entry.evidence_ref))
+        {
+            return Err(ContextPackError);
+        }
+    }
+    for evidence_ref in &input.evidence_refs {
+        if !is_safe_evidence_ref(evidence_ref)
+            || !evidence_refs.insert(canonical_public_path_key(evidence_ref))
+        {
+            return Err(ContextPackError);
+        }
+    }
+    Ok(())
+}
+
+fn remove_one_for_byte_limit(pack: &mut CanonicalContextPack) -> bool {
+    if pack.groups.evidence_refs.pop().is_some() {
+        pack.omissions.evidence_refs += 1;
+    } else if pack.groups.tests.pop().is_some() {
+        pack.omissions.tests += 1;
+    } else if pack.groups.changed_files.pop().is_some() {
+        pack.omissions.changed_files += 1;
+    } else if pack.groups.code_map.pop().is_some() {
+        pack.omissions.code_map += 1;
+    } else {
+        return false;
+    }
+    pack.omissions.omitted_by_bytes += 1;
+    true
+}
+
+fn is_stable_id(value: &str) -> bool {
+    if value.is_empty() || value.len() > 64 || !value.is_ascii() {
+        return false;
+    }
+    let mut parts = value.split('-');
+    let Some(first) = parts.next() else {
+        return false;
+    };
+    if first.is_empty()
+        || !first
+            .bytes()
+            .next()
+            .is_some_and(|byte| byte.is_ascii_lowercase())
+        || !first
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit())
+    {
+        return false;
+    }
+    parts.all(|part| {
+        !part.is_empty()
+            && part
+                .bytes()
+                .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit())
+    })
+}
+
+fn is_stable_test_id(value: &str) -> bool {
+    if value.is_empty()
+        || value.len() > MAX_ID_BYTES
+        || !value.is_ascii()
+        || !value
+            .bytes()
+            .next()
+            .is_some_and(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit())
+    {
+        return false;
+    }
+    value.bytes().all(|byte| {
+        byte.is_ascii_lowercase()
+            || byte.is_ascii_digit()
+            || matches!(byte, b'.' | b'_' | b'-' | b'/' | b':')
+    })
+}
+
+fn is_safe_repo_path(value: &str) -> bool {
+    if value.is_empty()
+        || !value.is_ascii()
+        || value.starts_with('/')
+        || value.ends_with('/')
+        || value.contains('\\')
+        || value.contains(':')
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-' | b'/'))
+    {
+        return false;
+    }
+    is_safe_public_path_identity(value, value, PUBLIC_REPO_PATH_MAX_BYTES)
+}
+
+fn is_safe_evidence_ref(value: &str) -> bool {
+    if value.is_empty()
+        || !value.is_ascii()
+        || value.contains('\\')
+        || value.contains("..")
+        || value.contains("//")
+    {
+        return false;
+    }
+    let tail = value
+        .strip_prefix("evidence:")
+        .or_else(|| value.strip_prefix("context:"))
+        .or_else(|| value.strip_prefix("context-packs/"));
+    let Some(tail) = tail else {
+        return false;
+    };
+    if tail.is_empty()
+        || tail.starts_with('/')
+        || tail.ends_with('/')
+        || !tail
+            .bytes()
+            .next()
+            .is_some_and(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit())
+    {
+        return false;
+    }
+    tail.bytes().all(|byte| {
+        byte.is_ascii_lowercase()
+            || byte.is_ascii_digit()
+            || matches!(byte, b'.' | b'_' | b'-' | b'/')
+    }) && is_safe_public_path_identity(value, tail, PUBLIC_REF_MAX_BYTES)
+}
+
+fn is_sha256(value: &str) -> bool {
+    value
+        .strip_prefix("sha256:")
+        .is_some_and(|hex| is_lower_hex(hex, 64))
+}
+
+fn is_lower_hex(value: &str, expected_len: usize) -> bool {
+    value.len() == expected_len
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+}
+
+fn sha256(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    format!("sha256:{:x}", hasher.finalize())
+}
+
+const fn default_max_files() -> usize {
+    DEFAULT_MAX_FILES
+}
+
+const fn default_max_bytes() -> usize {
+    DEFAULT_MAX_BYTES
+}
+
+const fn default_max_evidence_refs() -> usize {
+    DEFAULT_MAX_EVIDENCE_REFS
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_safe_repo_path;
+
+    #[test]
+    fn private_runtime_namespaces_are_case_insensitive_on_windows() {
+        for path in [
+            ".GIT/config",
+            ".Winsmux/private.json",
+            "core/.git/config",
+            "core/.WINSMUX/private.json",
+        ] {
+            assert!(!is_safe_repo_path(path), "{path} must remain private");
+        }
+        assert!(is_safe_repo_path("core/src/context_pack.rs"));
+    }
+}

--- a/core/src/context_pack.rs
+++ b/core/src/context_pack.rs
@@ -252,7 +252,9 @@ pub(crate) fn split_cli<T>(
     }
     let selection = match (pack_id, input) {
         (None, None) => None,
-        (Some(pack_id), Some(input)) if input == "-" => Some(ContextPackCliSelection { pack_id }),
+        (Some(pack_id), Some(input)) if input == "-" && is_stable_id(&pack_id) => {
+            Some(ContextPackCliSelection { pack_id })
+        }
         _ => return Err(context_pack_rejected()),
     };
     Ok((selection, parse_legacy(&legacy_args)?))

--- a/core/src/context_pack.rs
+++ b/core/src/context_pack.rs
@@ -1,6 +1,6 @@
 use crate::manifest_contract::{
-    canonical_public_path_key, is_context_pack_id, is_safe_public_path_identity,
-    PUBLIC_REF_MAX_BYTES, PUBLIC_REPO_PATH_MAX_BYTES,
+    canonical_public_path_key, is_safe_public_path_identity, PUBLIC_REF_MAX_BYTES,
+    PUBLIC_REPO_PATH_MAX_BYTES,
 };
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -41,20 +41,6 @@ pub(crate) struct ContextPackProjection {
     canonical_json: String,
     digest: String,
     byte_count: usize,
-    manifest_projection: ContextPackManifestProjection,
-}
-
-#[derive(Clone, Debug, Serialize)]
-struct ContextPackManifestProjection {
-    pack_id: String,
-    schema_version: u64,
-    digest: String,
-    byte_count: usize,
-    source_head: String,
-    policy_fingerprint: String,
-    limits: ContextPackLimits,
-    omissions: ContextPackOmissions,
-    privacy_result: &'static str,
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -392,22 +378,37 @@ pub(crate) fn build_context_pack(
     let digest = sha256(&canonical_bytes);
     let byte_count = canonical_bytes.len();
     let canonical_json = String::from_utf8(canonical_bytes).map_err(|_| ContextPackError)?;
-    let manifest_projection = ContextPackManifestProjection {
-        pack_id: pack_id.to_string(),
-        schema_version: CONTEXT_PACK_SCHEMA_VERSION,
-        digest: digest.clone(),
-        byte_count,
-        source_head: canonical.source_head.clone(),
-        policy_fingerprint,
-        limits,
-        omissions: canonical.omissions,
-        privacy_result: "pass",
-    };
     Ok(ContextPackProjection {
         canonical_json,
         digest,
         byte_count,
-        manifest_projection,
+    })
+}
+
+fn is_context_pack_id(value: &str) -> bool {
+    if value.is_empty() || value.len() > 64 || !value.is_ascii() {
+        return false;
+    }
+    let mut parts = value.split('-');
+    let Some(first) = parts.next() else {
+        return false;
+    };
+    if first.is_empty()
+        || !first
+            .bytes()
+            .next()
+            .is_some_and(|byte| byte.is_ascii_lowercase())
+        || !first
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit())
+    {
+        return false;
+    }
+    parts.all(|part| {
+        !part.is_empty()
+            && part
+                .bytes()
+                .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit())
     })
 }
 

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -31,6 +31,7 @@ mod read_path;
 mod search_ledger;
 mod dogfood;
 mod machine_contract;
+mod context_pack;
 mod operator_cli;
 mod project_settings_render;
 mod client;

--- a/core/src/manifest_contract.rs
+++ b/core/src/manifest_contract.rs
@@ -536,7 +536,7 @@ fn validate_context_pack_manifest(
     pack_id: &str,
     context_pack: &ContextPackManifest,
 ) -> Result<(), String> {
-    if !is_declarative_workspace_id(pack_id)
+    if !is_context_pack_id(pack_id)
         || context_pack.schema_version.value() != Some(1)
         || !is_manifest_sha256(&context_pack.digest)
         || !is_manifest_sha256(&context_pack.policy_fingerprint)
@@ -603,6 +603,10 @@ fn is_declarative_workspace_id(value: &str) -> bool {
                 .bytes()
                 .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit())
     })
+}
+
+pub(crate) fn is_context_pack_id(value: &str) -> bool {
+    !value.is_empty() && value.len() <= 64 && value.is_ascii() && is_declarative_workspace_id(value)
 }
 
 fn is_safe_declarative_workspace_evidence_ref(value: &str) -> bool {

--- a/core/src/manifest_contract.rs
+++ b/core/src/manifest_contract.rs
@@ -16,6 +16,7 @@ pub struct WinsmuxManifest {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct DeclarativeWorkspaceManifest {
     pub schema_version: ManifestU32,
     pub config_fingerprint: String,
@@ -24,40 +25,6 @@ pub struct DeclarativeWorkspaceManifest {
     pub resolved_bindings: BTreeMap<String, String>,
     #[serde(default)]
     pub dry_run_plan_ref: String,
-    #[serde(default)]
-    pub context_packs: BTreeMap<String, ContextPackManifest>,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct ContextPackManifest {
-    pub schema_version: ManifestU32,
-    pub digest: String,
-    pub byte_count: ManifestU32,
-    pub source_head: String,
-    pub policy_fingerprint: String,
-    pub limits: ContextPackManifestLimits,
-    pub omissions: ContextPackManifestOmissions,
-    pub privacy_result: String,
-    pub durable_ref: String,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct ContextPackManifestLimits {
-    pub max_files: ManifestU32,
-    pub max_bytes: ManifestU32,
-    pub max_evidence_refs: ManifestU32,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct ContextPackManifestOmissions {
-    pub code_map: ManifestU32,
-    pub changed_files: ManifestU32,
-    pub tests: ManifestU32,
-    pub evidence_refs: ManifestU32,
-    pub omitted_by_bytes: ManifestU32,
 }
 
 #[derive(Debug, Deserialize)]
@@ -526,58 +493,6 @@ fn validate_declarative_workspace(projection: &DeclarativeWorkspaceManifest) -> 
             "declarative_workspace.dry_run_plan_ref must be a safe evidence reference".to_string(),
         );
     }
-    for (pack_id, context_pack) in &projection.context_packs {
-        validate_context_pack_manifest(pack_id, context_pack)?;
-    }
-    Ok(())
-}
-
-fn validate_context_pack_manifest(
-    pack_id: &str,
-    context_pack: &ContextPackManifest,
-) -> Result<(), String> {
-    if !is_context_pack_id(pack_id)
-        || context_pack.schema_version.value() != Some(1)
-        || !is_manifest_sha256(&context_pack.digest)
-        || !is_manifest_sha256(&context_pack.policy_fingerprint)
-        || !is_manifest_lower_hex(&context_pack.source_head, 40)
-        || context_pack.privacy_result != "pass"
-        || !is_safe_context_pack_ref(&context_pack.durable_ref)
-    {
-        return Err("declarative_workspace context-pack metadata is invalid".to_string());
-    }
-    let Some(byte_count) = context_pack.byte_count.value() else {
-        return Err("declarative_workspace context-pack metadata is invalid".to_string());
-    };
-    let Some(max_files) = context_pack.limits.max_files.value() else {
-        return Err("declarative_workspace context-pack metadata is invalid".to_string());
-    };
-    let Some(max_bytes) = context_pack.limits.max_bytes.value() else {
-        return Err("declarative_workspace context-pack metadata is invalid".to_string());
-    };
-    let Some(max_evidence_refs) = context_pack.limits.max_evidence_refs.value() else {
-        return Err("declarative_workspace context-pack metadata is invalid".to_string());
-    };
-    if byte_count == 0
-        || byte_count > max_bytes
-        || max_files == 0
-        || max_files > 1_000
-        || max_bytes == 0
-        || max_bytes > 1_048_576
-        || max_evidence_refs == 0
-        || max_evidence_refs > 500
-        || [
-            &context_pack.omissions.code_map,
-            &context_pack.omissions.changed_files,
-            &context_pack.omissions.tests,
-            &context_pack.omissions.evidence_refs,
-            &context_pack.omissions.omitted_by_bytes,
-        ]
-        .into_iter()
-        .any(|value| value.value().is_none())
-    {
-        return Err("declarative_workspace context-pack metadata is invalid".to_string());
-    }
     Ok(())
 }
 
@@ -605,10 +520,6 @@ fn is_declarative_workspace_id(value: &str) -> bool {
     })
 }
 
-pub(crate) fn is_context_pack_id(value: &str) -> bool {
-    !value.is_empty() && value.len() <= 64 && value.is_ascii() && is_declarative_workspace_id(value)
-}
-
 fn is_safe_declarative_workspace_evidence_ref(value: &str) -> bool {
     let Some(path) = value.strip_prefix("evidence:") else {
         return false;
@@ -626,19 +537,6 @@ fn is_safe_declarative_workspace_evidence_ref(value: &str) -> bool {
                 || matches!(byte, b'.' | b'_' | b'-' | b'/')
         })
         && is_safe_public_path_identity(value, path, PUBLIC_REF_MAX_BYTES)
-}
-
-fn is_manifest_sha256(value: &str) -> bool {
-    value
-        .strip_prefix("sha256:")
-        .is_some_and(|hex| is_manifest_lower_hex(hex, 64))
-}
-
-fn is_manifest_lower_hex(value: &str, expected_len: usize) -> bool {
-    value.len() == expected_len
-        && value
-            .bytes()
-            .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
 }
 
 pub(crate) const PUBLIC_REPO_PATH_MAX_BYTES: usize = 240;
@@ -693,27 +591,6 @@ fn is_safe_win32_public_segment(value: &str) -> bool {
         }
     }
     true
-}
-
-fn is_safe_context_pack_ref(value: &str) -> bool {
-    let Some(path) = value.strip_prefix("context-packs/") else {
-        return false;
-    };
-    let mut bytes = path.bytes();
-    let Some(first) = bytes.next() else {
-        return false;
-    };
-    (first.is_ascii_lowercase() || first.is_ascii_digit())
-        && !path.ends_with('/')
-        && !path.contains("..")
-        && !path.contains('\\')
-        && !path.contains("//")
-        && bytes.all(|byte| {
-            byte.is_ascii_lowercase()
-                || byte.is_ascii_digit()
-                || matches!(byte, b'.' | b'_' | b'-' | b'/')
-        })
-        && is_safe_public_path_identity(value, path, PUBLIC_REF_MAX_BYTES)
 }
 
 fn normalize_manifest_pane(

--- a/core/src/manifest_contract.rs
+++ b/core/src/manifest_contract.rs
@@ -24,6 +24,40 @@ pub struct DeclarativeWorkspaceManifest {
     pub resolved_bindings: BTreeMap<String, String>,
     #[serde(default)]
     pub dry_run_plan_ref: String,
+    #[serde(default)]
+    pub context_packs: BTreeMap<String, ContextPackManifest>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ContextPackManifest {
+    pub schema_version: ManifestU32,
+    pub digest: String,
+    pub byte_count: ManifestU32,
+    pub source_head: String,
+    pub policy_fingerprint: String,
+    pub limits: ContextPackManifestLimits,
+    pub omissions: ContextPackManifestOmissions,
+    pub privacy_result: String,
+    pub durable_ref: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ContextPackManifestLimits {
+    pub max_files: ManifestU32,
+    pub max_bytes: ManifestU32,
+    pub max_evidence_refs: ManifestU32,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ContextPackManifestOmissions {
+    pub code_map: ManifestU32,
+    pub changed_files: ManifestU32,
+    pub tests: ManifestU32,
+    pub evidence_refs: ManifestU32,
+    pub omitted_by_bytes: ManifestU32,
 }
 
 #[derive(Debug, Deserialize)]
@@ -492,6 +526,58 @@ fn validate_declarative_workspace(projection: &DeclarativeWorkspaceManifest) -> 
             "declarative_workspace.dry_run_plan_ref must be a safe evidence reference".to_string(),
         );
     }
+    for (pack_id, context_pack) in &projection.context_packs {
+        validate_context_pack_manifest(pack_id, context_pack)?;
+    }
+    Ok(())
+}
+
+fn validate_context_pack_manifest(
+    pack_id: &str,
+    context_pack: &ContextPackManifest,
+) -> Result<(), String> {
+    if !is_declarative_workspace_id(pack_id)
+        || context_pack.schema_version.value() != Some(1)
+        || !is_manifest_sha256(&context_pack.digest)
+        || !is_manifest_sha256(&context_pack.policy_fingerprint)
+        || !is_manifest_lower_hex(&context_pack.source_head, 40)
+        || context_pack.privacy_result != "pass"
+        || !is_safe_context_pack_ref(&context_pack.durable_ref)
+    {
+        return Err("declarative_workspace context-pack metadata is invalid".to_string());
+    }
+    let Some(byte_count) = context_pack.byte_count.value() else {
+        return Err("declarative_workspace context-pack metadata is invalid".to_string());
+    };
+    let Some(max_files) = context_pack.limits.max_files.value() else {
+        return Err("declarative_workspace context-pack metadata is invalid".to_string());
+    };
+    let Some(max_bytes) = context_pack.limits.max_bytes.value() else {
+        return Err("declarative_workspace context-pack metadata is invalid".to_string());
+    };
+    let Some(max_evidence_refs) = context_pack.limits.max_evidence_refs.value() else {
+        return Err("declarative_workspace context-pack metadata is invalid".to_string());
+    };
+    if byte_count == 0
+        || byte_count > max_bytes
+        || max_files == 0
+        || max_files > 1_000
+        || max_bytes == 0
+        || max_bytes > 1_048_576
+        || max_evidence_refs == 0
+        || max_evidence_refs > 500
+        || [
+            &context_pack.omissions.code_map,
+            &context_pack.omissions.changed_files,
+            &context_pack.omissions.tests,
+            &context_pack.omissions.evidence_refs,
+            &context_pack.omissions.omitted_by_bytes,
+        ]
+        .into_iter()
+        .any(|value| value.value().is_none())
+    {
+        return Err("declarative_workspace context-pack metadata is invalid".to_string());
+    }
     Ok(())
 }
 
@@ -535,6 +621,95 @@ fn is_safe_declarative_workspace_evidence_ref(value: &str) -> bool {
                 || byte.is_ascii_digit()
                 || matches!(byte, b'.' | b'_' | b'-' | b'/')
         })
+        && is_safe_public_path_identity(value, path, PUBLIC_REF_MAX_BYTES)
+}
+
+fn is_manifest_sha256(value: &str) -> bool {
+    value
+        .strip_prefix("sha256:")
+        .is_some_and(|hex| is_manifest_lower_hex(hex, 64))
+}
+
+fn is_manifest_lower_hex(value: &str, expected_len: usize) -> bool {
+    value.len() == expected_len
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+}
+
+pub(crate) const PUBLIC_REPO_PATH_MAX_BYTES: usize = 240;
+pub(crate) const PUBLIC_REF_MAX_BYTES: usize = 256;
+const PUBLIC_PATH_COMPONENT_MAX_BYTES: usize = 240;
+
+pub(crate) fn canonical_public_path_key(value: &str) -> String {
+    value.to_ascii_lowercase()
+}
+
+pub(crate) fn is_safe_public_path_identity(
+    full_value: &str,
+    path: &str,
+    total_max_bytes: usize,
+) -> bool {
+    !full_value.is_empty()
+        && full_value.len() <= total_max_bytes
+        && full_value.is_ascii()
+        && !path.is_empty()
+        && path.split('/').all(is_safe_win32_public_segment)
+}
+
+fn is_safe_win32_public_segment(value: &str) -> bool {
+    if value.is_empty()
+        || value.len() > PUBLIC_PATH_COMPONENT_MAX_BYTES
+        || value.ends_with('.')
+        || value.ends_with(' ')
+        || matches!(value, "." | "..")
+        || value.eq_ignore_ascii_case(".git")
+        || value.eq_ignore_ascii_case(".winsmux")
+    {
+        return false;
+    }
+
+    let basename = value.split('.').next().unwrap_or(value);
+    if basename.eq_ignore_ascii_case("con")
+        || basename.eq_ignore_ascii_case("prn")
+        || basename.eq_ignore_ascii_case("aux")
+        || basename.eq_ignore_ascii_case("nul")
+    {
+        return false;
+    }
+    let bytes = basename.as_bytes();
+    if bytes.len() == 4 && matches!(bytes[3], b'1'..=b'9') {
+        let prefix = [
+            bytes[0].to_ascii_lowercase(),
+            bytes[1].to_ascii_lowercase(),
+            bytes[2].to_ascii_lowercase(),
+        ];
+        if prefix == *b"com" || prefix == *b"lpt" {
+            return false;
+        }
+    }
+    true
+}
+
+fn is_safe_context_pack_ref(value: &str) -> bool {
+    let Some(path) = value.strip_prefix("context-packs/") else {
+        return false;
+    };
+    let mut bytes = path.bytes();
+    let Some(first) = bytes.next() else {
+        return false;
+    };
+    (first.is_ascii_lowercase() || first.is_ascii_digit())
+        && !path.ends_with('/')
+        && !path.contains("..")
+        && !path.contains('\\')
+        && !path.contains("//")
+        && bytes.all(|byte| {
+            byte.is_ascii_lowercase()
+                || byte.is_ascii_digit()
+                || matches!(byte, b'.' | b'_' | b'-' | b'/')
+        })
+        && is_safe_public_path_identity(value, path, PUBLIC_REF_MAX_BYTES)
 }
 
 fn normalize_manifest_pane(

--- a/core/src/operator_cli.rs
+++ b/core/src/operator_cli.rs
@@ -59,7 +59,6 @@ const WORKSPACE_PLAN_GLOBAL_OPTIONS: [&str; 13] = [
     "@bridge-external-commander",
     "@bridge-commanders",
 ];
-
 pub fn is_operator_status_invocation(args: &[&String]) -> bool {
     args.iter()
         .any(|arg| matches!(arg.as_str(), "--json" | "-h" | "--help"))
@@ -254,7 +253,8 @@ pub fn run_workspace_plan_command(args: &[&String]) -> io::Result<()> {
         return Ok(());
     }
 
-    let options = parse_workspace_plan_options(args)?;
+    let (context_pack, options) =
+        crate::context_pack::split_cli(args, parse_workspace_plan_options)?;
     let (_yaml, root, settings) = read_workspace_plan_snapshot(&options.project_dir)?;
     let mut slots = Vec::with_capacity(settings.agent_slots.len());
     for slot in &settings.agent_slots {
@@ -279,7 +279,11 @@ pub fn run_workspace_plan_command(args: &[&String]) -> io::Result<()> {
         options.run_id.as_deref(),
         &slots,
     )?;
-    write_json(&payload)
+    write_json(&crate::context_pack::apply_cli(
+        &root,
+        context_pack,
+        payload,
+    )?)
 }
 
 pub fn run_operator_jobs_command(args: &[&String]) -> io::Result<()> {
@@ -6980,7 +6984,7 @@ fn usage_for(command: &str) -> &'static str {
             "usage: winsmux meta-plan --task <text> [--roles <path>] [--review-rounds <1|2>] [--json] [--project-dir <path>] [--session <name>]"
         }
         "workspace-plan" => {
-            "usage: winsmux workspace-plan --recipe-id <id> [--workflow-id <id>] [--run-id <id>] --json [--project-dir <path>]"
+            "usage: winsmux workspace-plan --recipe-id <id> [--workflow-id <id>] [--run-id <id>] [--context-pack-id <id> --context-pack-input -] --json [--project-dir <path>]"
         }
         "provider-capabilities" => {
             "usage: winsmux provider-capabilities [provider] [--json] [--project-dir <path>]"

--- a/core/tests-rs/context_pack_contract.rs
+++ b/core/tests-rs/context_pack_contract.rs
@@ -17,10 +17,19 @@ fn base_yaml() -> String {
 }
 
 fn context_pack_policy(max_files: usize, max_bytes: usize, max_evidence_refs: usize) -> String {
+    context_pack_policy_for_id("review-pack", max_files, max_bytes, max_evidence_refs)
+}
+
+fn context_pack_policy_for_id(
+    pack_id: &str,
+    max_files: usize,
+    max_bytes: usize,
+    max_evidence_refs: usize,
+) -> String {
     format!(
         r#"
 context-packs:
-  review-pack:
+  {pack_id}:
     schema-version: 1
     include: [code-map, changed-files, tests, evidence-refs]
     limits:
@@ -96,6 +105,10 @@ fn permuted_input() -> serde_json::Value {
 }
 
 fn workspace_plan_args(project: &Path) -> Vec<String> {
+    workspace_plan_args_with_pack_id(project, "review-pack")
+}
+
+fn workspace_plan_args_with_pack_id(project: &Path, pack_id: &str) -> Vec<String> {
     vec![
         "workspace-plan".into(),
         "--recipe-id".into(),
@@ -103,7 +116,7 @@ fn workspace_plan_args(project: &Path) -> Vec<String> {
         "--workflow-id".into(),
         "bugfix".into(),
         "--context-pack-id".into(),
-        "review-pack".into(),
+        pack_id.into(),
         "--context-pack-input".into(),
         "-".into(),
         "--json".into(),
@@ -1623,6 +1636,260 @@ fn cp21_public_string_grammars_reject_path_shapes_before_output() {
     );
 }
 
+#[test]
+fn cp22_rust_manifest_pack_id_bound_matches_cli_authority() {
+    let pack_id_edge = "a".repeat(64);
+    let pack_id_over = "a".repeat(65);
+    let long_generic_recipe = "r".repeat(65);
+    assert_eq!(
+        pack_id_edge.as_bytes().len(),
+        64,
+        "exact 64-byte context-pack ID edge must be explicit"
+    );
+    assert_eq!(
+        pack_id_over.as_bytes().len(),
+        65,
+        "context-pack ID edge+1 must be explicit"
+    );
+
+    let producer = make_project(&context_pack_policy_for_id(&pack_id_edge, 100, 262_144, 50));
+    let project_runtime_bytes = snapshot_tree(producer.path());
+    let edge_input = serde_json::to_vec(&sample_input()).expect("serialize exact-edge input");
+    let accepted_producer = run_binary(
+        &workspace_plan_args_with_pack_id(producer.path(), &pack_id_edge),
+        &edge_input,
+    );
+    let accepted_payload = parse_success(&accepted_producer);
+    assert_eq!(
+        accepted_payload["context_pack"]["manifest_projection"]["pack_id"],
+        serde_json::json!(pack_id_edge),
+        "exact 64-byte context-pack ID must remain accepted by the producer"
+    );
+    assert_eq!(
+        snapshot_tree(producer.path()),
+        project_runtime_bytes,
+        "project_runtime_bytes must remain unchanged for the accepted ID edge"
+    );
+    assert_rejected(
+        &run_binary(
+            &workspace_plan_args_with_pack_id(producer.path(), &pack_id_over),
+            &edge_input,
+        ),
+        &project_runtime_bytes,
+        producer.path(),
+    );
+
+    let manifest_fixture = make_project("");
+    let manifest_path = manifest_fixture
+        .path()
+        .join(".winsmux")
+        .join("manifest.yaml");
+    let status_args = vec![
+        "status".into(),
+        "--json".into(),
+        "--project-dir".into(),
+        manifest_fixture.path().display().to_string(),
+    ];
+    let manifest_yaml = |pack_id: &str| {
+        format!(
+            r#"version: 1
+session:
+  name: test
+  project_dir: ''
+  started: ''
+  ended: ''
+panes: {{}}
+declarative_workspace:
+  schema_version: 1
+  config_fingerprint: {CONTENT_A}
+  recipe_id: {long_generic_recipe}
+  resolved_bindings: {{}}
+  context_packs:
+    {pack_id}:
+      schema_version: 1
+      digest: {CONTENT_B}
+      byte_count: 100
+      source_head: {SOURCE_HEAD}
+      policy_fingerprint: {CONTENT_C}
+      limits:
+        max_files: 100
+        max_bytes: 262144
+        max_evidence_refs: 50
+      omissions:
+        code_map: 0
+        changed_files: 0
+        tests: 0
+        evidence_refs: 0
+        omitted_by_bytes: 0
+      privacy_result: pass
+      durable_ref: context-packs/{pack_id}.json
+"#
+        )
+    };
+
+    let manifest_edge_yaml = manifest_yaml(&pack_id_edge);
+    fs::write(&manifest_path, &manifest_edge_yaml).expect("write exact-edge manifest");
+    let manifest_edge_before = fs::read(&manifest_path).expect("read exact-edge manifest");
+    let manifest_edge_output = run_binary(&status_args, b"");
+    assert!(
+        manifest_edge_output.status.success(),
+        "exact 64-byte manifest pack ID must remain accepted: {}",
+        String::from_utf8_lossy(&manifest_edge_output.stderr)
+    );
+    serde_json::from_slice::<serde_json::Value>(&manifest_edge_output.stdout)
+        .expect("accepted manifest read must emit one JSON payload");
+    assert_eq!(
+        fs::read(&manifest_path).unwrap(),
+        manifest_edge_before,
+        "manifest bytes must remain unchanged for the accepted ID edge"
+    );
+    assert!(
+        manifest_edge_yaml.contains(&format!("recipe_id: {long_generic_recipe}")),
+        "generic workspace identifiers must not inherit the context-pack 64-byte bound"
+    );
+
+    let manifest_over_yaml = manifest_yaml(&pack_id_over);
+    fs::write(&manifest_path, &manifest_over_yaml).expect("write edge+1 manifest");
+    let manifest_over_before = fs::read(&manifest_path).expect("read edge+1 manifest");
+    let manifest_over_output = run_binary(&status_args, b"");
+    let mut rust_boundary_violations = Vec::new();
+    if manifest_over_output.status.success()
+        || !manifest_over_output.stdout.is_empty()
+        || fs::read(&manifest_path).unwrap() != manifest_over_before
+    {
+        rust_boundary_violations.push(format!(
+            "65-byte context-pack ID reached public read output: status={:?}, stdout_bytes={}",
+            manifest_over_output.status,
+            manifest_over_output.stdout.len()
+        ));
+    }
+    if String::from_utf8_lossy(&manifest_over_output.stderr).contains(&pack_id_over) {
+        rust_boundary_violations
+            .push("65-byte context-pack ID was reflected by manifest rejection".to_string());
+    }
+    assert!(
+        rust_boundary_violations.is_empty(),
+        "Rust manifest and CLI context-pack ID boundaries must agree at 64 bytes; \
+         65-byte context-pack ID must reject before public read output; \
+         manifest bytes must remain unchanged; violations={rust_boundary_violations:?}"
+    );
+}
+
+#[test]
+#[cfg(windows)]
+fn cp23_powershell_projection_pack_id_bound_matches_cli_authority() {
+    let pack_id_edge = "a".repeat(64);
+    let pack_id_over = "a".repeat(65);
+    let long_generic_recipe = "r".repeat(65);
+    let producer = make_project(&context_pack_policy_for_id(&pack_id_edge, 100, 262_144, 50));
+    let producer_before = snapshot_tree(producer.path());
+    let input = serde_json::to_vec(&sample_input()).expect("serialize projection input");
+    parse_success(&run_binary(
+        &workspace_plan_args_with_pack_id(producer.path(), &pack_id_edge),
+        &input,
+    ));
+    assert_rejected(
+        &run_binary(
+            &workspace_plan_args_with_pack_id(producer.path(), &pack_id_over),
+            &input,
+        ),
+        &producer_before,
+        producer.path(),
+    );
+
+    let plan = |pack_id: &str| {
+        serde_json::json!({
+            "config_fingerprint": CONTENT_A,
+            "recipe_id": long_generic_recipe,
+            "resolved_bindings": {},
+            "context_pack": {
+                "manifest_projection": {
+                    "pack_id": pack_id,
+                    "schema_version": 1,
+                    "digest": CONTENT_B,
+                    "byte_count": 100,
+                    "source_head": SOURCE_HEAD,
+                    "policy_fingerprint": CONTENT_C,
+                    "limits": {
+                        "max_files": 100,
+                        "max_bytes": 262144,
+                        "max_evidence_refs": 50
+                    },
+                    "omissions": {
+                        "code_map": 0,
+                        "changed_files": 0,
+                        "tests": 0,
+                        "evidence_refs": 0,
+                        "omitted_by_bytes": 0
+                    },
+                    "privacy_result": "pass"
+                }
+            }
+        })
+    };
+
+    let edge_fixture = make_project("");
+    let edge_plan = plan(&pack_id_edge);
+    let (edge_output, edge_before, edge_after) = render_manifest_process_with_refs_and_state(
+        edge_fixture.path(),
+        &edge_plan,
+        "",
+        &format!("context-packs/{pack_id_edge}.json"),
+    );
+    assert!(
+        edge_output.status.success(),
+        "exact 64-byte external-plan pack ID must remain accepted: {}",
+        String::from_utf8_lossy(&edge_output.stderr)
+    );
+    let edge_yaml =
+        String::from_utf8(edge_output.stdout).expect("accepted projection YAML must be UTF-8");
+    assert!(
+        edge_yaml.contains(&pack_id_edge),
+        "accepted projection must preserve the exact authored 64-byte map key"
+    );
+    assert_eq!(
+        edge_before, edge_after,
+        "PowerShell projection must preserve runtime bytes after test setup"
+    );
+    assert_eq!(
+        edge_plan["recipe_id"],
+        serde_json::json!(long_generic_recipe),
+        "generic workspace identifiers must not inherit the context-pack 64-byte bound"
+    );
+
+    let over_fixture = make_project("");
+    let over_plan = plan(&pack_id_over);
+    let (over_output, over_before, over_after) = render_manifest_process_with_refs_and_state(
+        over_fixture.path(),
+        &over_plan,
+        "",
+        &format!("context-packs/{pack_id_over}.json"),
+    );
+    let mut powershell_boundary_violations = Vec::new();
+    if over_output.status.success() || !over_output.stdout.is_empty() {
+        powershell_boundary_violations.push(format!(
+            "65-byte external-plan pack ID reached projection YAML: status={:?}, stdout_bytes={}",
+            over_output.status,
+            over_output.stdout.len()
+        ));
+    }
+    if over_before != over_after {
+        powershell_boundary_violations
+            .push("PowerShell projection rejection must preserve runtime bytes".to_string());
+    }
+    if String::from_utf8_lossy(&over_output.stderr).contains(&pack_id_over) {
+        powershell_boundary_violations.push(
+            "65-byte external-plan pack ID was reflected by projection rejection".to_string(),
+        );
+    }
+    assert!(
+        powershell_boundary_violations.is_empty(),
+        "PowerShell projection and CLI context-pack ID boundaries must agree at 64 bytes; \
+         65-byte external-plan pack ID must reject before projection, YAML, or save; \
+         external-plan rejection must emit no YAML; violations={powershell_boundary_violations:?}"
+    );
+}
+
 #[cfg(windows)]
 fn render_manifest_with_powershell(
     project: &Path,
@@ -1650,6 +1917,16 @@ fn render_manifest_process_with_refs(
     dry_run_ref: &str,
     durable_ref: &str,
 ) -> Output {
+    render_manifest_process_with_refs_and_state(project, plan, dry_run_ref, durable_ref).0
+}
+
+#[cfg(windows)]
+fn render_manifest_process_with_refs_and_state(
+    project: &Path,
+    plan: &serde_json::Value,
+    dry_run_ref: &str,
+    durable_ref: &str,
+) -> (Output, Vec<(String, Vec<u8>)>, Vec<(String, Vec<u8>)>) {
     let plan_path = project.join("task660-plan.json");
     let script_path = project.join("task660-render.ps1");
     fs::write(
@@ -1685,11 +1962,14 @@ $manifest = [ordered]@{{
         durable_ref.replace('\'', "''"),
     );
     fs::write(&script_path, script).expect("write PowerShell fixture");
-    Command::new("pwsh")
+    let before = snapshot_tree(project);
+    let output = Command::new("pwsh")
         .args(["-NoProfile", "-NonInteractive", "-File"])
         .arg(&script_path)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .output()
-        .expect("run PowerShell manifest projection")
+        .expect("run PowerShell manifest projection");
+    let after = snapshot_tree(project);
+    (output, before, after)
 }

--- a/core/tests-rs/context_pack_contract.rs
+++ b/core/tests-rs/context_pack_contract.rs
@@ -372,42 +372,6 @@ fn cp03_byte_limit_uses_deterministic_reverse_group_reduction() {
 }
 
 #[test]
-#[cfg(windows)]
-fn cp04_metadata_only_manifest_round_trips_across_powershell_and_rust() {
-    let fixture = make_project(&context_pack_policy(100, 262_144, 50));
-    let payload = parse_success(&run_pack(fixture.path(), &sample_input()));
-    let yaml =
-        render_manifest_with_powershell(fixture.path(), &payload, "context-packs/review-pack.json");
-    assert!(
-        !yaml.contains("canonical_json")
-            && !yaml.contains("core/src/workflow.rs")
-            && !yaml.contains("prompt")
-            && !yaml.contains("transcript"),
-        "manifest protected sink must contain metadata only"
-    );
-    assert!(
-        yaml.contains("context_packs:") && yaml.contains("durable_ref:"),
-        "New-WinsmuxDeclarativeWorkspaceProjection must materialize bounded metadata"
-    );
-    fs::write(fixture.path().join(".winsmux").join("manifest.yaml"), yaml)
-        .expect("write generated manifest fixture");
-    let args = vec![
-        "status".into(),
-        "--json".into(),
-        "--project-dir".into(),
-        fixture.path().display().to_string(),
-    ];
-    let output = run_binary(&args, b"");
-    assert!(
-        output.status.success(),
-        "WinsmuxManifest::from_yaml and LedgerSnapshot must consume metadata: {}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-    serde_json::from_slice::<serde_json::Value>(&output.stdout)
-        .expect("Rust public status output must remain valid JSON");
-}
-
-#[test]
 fn cp05_unselected_or_absent_context_pack_preserves_legacy_bytes() {
     let legacy = make_project("");
     let configured = make_project(&context_pack_policy(100, 262_144, 50));
@@ -712,112 +676,6 @@ fn cp12_metadata_only_body_that_cannot_fit_rejects_without_partial_output() {
 }
 
 #[test]
-#[cfg(windows)]
-fn cp13_manifest_rejects_raw_fields_in_both_runtime_owners() {
-    let fixture = make_project(&context_pack_policy(100, 262_144, 50));
-    let mut plan = serde_json::json!({
-        "config_fingerprint": CONTENT_A,
-        "recipe_id": "bugfix-two-slot",
-        "resolved_bindings": {},
-        "context_pack": {
-            "manifest_projection": {
-                "pack_id": "review-pack",
-                "schema_version": 1,
-                "digest": CONTENT_B,
-                "byte_count": 100,
-                "source_head": SOURCE_HEAD,
-                "policy_fingerprint": CONTENT_C,
-                "limits": {"max_files": 100, "max_bytes": 262144, "max_evidence_refs": 50},
-                "omissions": {"code_map": 0, "changed_files": 0, "tests": 0, "evidence_refs": 0, "omitted_by_bytes": 0},
-                "privacy_result": "pass"
-            }
-        }
-    });
-    plan["context_pack"]["manifest_projection"]["canonical_json"] =
-        serde_json::json!("secret-marker-body");
-    let output = render_manifest_process(fixture.path(), &plan, "context-packs/review-pack.json");
-    assert!(
-        !output.status.success(),
-        "PowerShell authority must reject unknown raw metadata"
-    );
-    assert!(
-        output.stdout.is_empty(),
-        "Save-WinsmuxManifest must not run"
-    );
-    assert!(
-        !String::from_utf8_lossy(&output.stderr).contains("secret-marker"),
-        "PowerShell rejection must not reflect raw body"
-    );
-
-    let invalid_yaml = format!(
-        r#"version: 1
-session:
-  name: test
-  project_dir: ''
-  started: ''
-  ended: ''
-panes: {{}}
-declarative_workspace:
-  schema_version: 1
-  config_fingerprint: {CONTENT_A}
-  recipe_id: bugfix-two-slot
-  resolved_bindings: {{}}
-  context_packs:
-    review-pack:
-      schema_version: 1
-      digest: {CONTENT_B}
-      byte_count: 100
-      source_head: {SOURCE_HEAD}
-      policy_fingerprint: {CONTENT_C}
-      limits:
-        max_files: 100
-        max_bytes: 262144
-        max_evidence_refs: 50
-      omissions:
-        code_map: 0
-        changed_files: 0
-        tests: 0
-        evidence_refs: 0
-        omitted_by_bytes: 0
-      privacy_result: pass
-      durable_ref: context-packs/review-pack.json
-      raw_transcript: secret-marker-transcript
-"#
-    );
-    fs::write(
-        fixture.path().join(".winsmux").join("manifest.yaml"),
-        invalid_yaml,
-    )
-    .expect("write invalid manifest");
-    let before = fs::read(fixture.path().join(".winsmux").join("manifest.yaml"))
-        .expect("read invalid manifest");
-    let args = vec![
-        "status".into(),
-        "--json".into(),
-        "--project-dir".into(),
-        fixture.path().display().to_string(),
-    ];
-    let status = run_binary(&args, b"");
-    assert!(
-        !status.status.success(),
-        "Rust manifest consumer must reject"
-    );
-    assert!(
-        status.stdout.is_empty(),
-        "invalid manifest must not produce partial status"
-    );
-    assert!(
-        !String::from_utf8_lossy(&status.stderr).contains("secret-marker"),
-        "Rust manifest rejection must not reflect raw value"
-    );
-    assert_eq!(
-        fs::read(fixture.path().join(".winsmux").join("manifest.yaml")).unwrap(),
-        before,
-        "preexisting manifest bytes remain unchanged"
-    );
-}
-
-#[test]
 fn cp14_win32_repository_path_aliases_fail_closed() {
     let fixture = make_project(&context_pack_policy(100, 262_144, 50));
     let before = snapshot_tree(fixture.path());
@@ -865,223 +723,6 @@ fn cp15_win32_evidence_ref_aliases_fail_closed() {
         before,
         "Win32 evidence ref rejection must preserve project and runtime bytes"
     );
-}
-
-#[test]
-#[cfg(windows)]
-fn cp16_powershell_public_refs_share_one_segment_identity_authority() {
-    let fixture = make_project(&context_pack_policy(100, 262_144, 50));
-    let plan = serde_json::json!({
-        "config_fingerprint": CONTENT_A,
-        "recipe_id": "bugfix-two-slot",
-        "resolved_bindings": {},
-        "context_pack": {
-            "manifest_projection": {
-                "pack_id": "review-pack",
-                "schema_version": 1,
-                "digest": CONTENT_B,
-                "byte_count": 100,
-                "source_head": SOURCE_HEAD,
-                "policy_fingerprint": CONTENT_C,
-                "limits": {"max_files": 100, "max_bytes": 262144, "max_evidence_refs": 50},
-                "omissions": {"code_map": 0, "changed_files": 0, "tests": 0, "evidence_refs": 0, "omitted_by_bytes": 0},
-                "privacy_result": "pass"
-            }
-        }
-    });
-    let runtime = fixture.path().join(".winsmux");
-    let before = snapshot_tree(&runtime);
-    let cases = [
-        (
-            "PowerShell DryRunPlanRef private alias must reject",
-            "evidence:review/.winsmux./secret",
-            "context-packs/review-pack.json",
-        ),
-        (
-            "PowerShell DryRunPlanRef dot segment must reject",
-            "evidence:review/./plan.json",
-            "context-packs/review-pack.json",
-        ),
-        (
-            "PowerShell DryRunPlanRef empty segment must reject",
-            "evidence:review//plan.json",
-            "context-packs/review-pack.json",
-        ),
-        (
-            "PowerShell DryRunPlanRef reserved device must reject",
-            "evidence:review/nul.txt",
-            "context-packs/review-pack.json",
-        ),
-        (
-            "PowerShell DryRunPlanRef trailing period must reject",
-            "evidence:review/public.",
-            "context-packs/review-pack.json",
-        ),
-        (
-            "PowerShell ContextPackRef private alias must reject",
-            "evidence:workspace-plan.json",
-            "context-packs/review-pack/.winsmux./secret",
-        ),
-        (
-            "PowerShell ContextPackRef dot segment must reject",
-            "evidence:workspace-plan.json",
-            "context-packs/review-pack/./plan.json",
-        ),
-        (
-            "PowerShell ContextPackRef empty segment must reject",
-            "evidence:workspace-plan.json",
-            "context-packs/review-pack//plan.json",
-        ),
-        (
-            "PowerShell ContextPackRef reserved device must reject",
-            "evidence:workspace-plan.json",
-            "context-packs/review-pack/lpt1.log",
-        ),
-        (
-            "PowerShell ContextPackRef trailing period must reject",
-            "evidence:workspace-plan.json",
-            "context-packs/review-pack/public.",
-        ),
-    ];
-    for (segment_invariant, dry_run_ref, durable_ref) in cases {
-        let output =
-            render_manifest_process_with_refs(fixture.path(), &plan, dry_run_ref, durable_ref);
-        assert!(!output.status.success(), "{segment_invariant}");
-        assert!(
-            output.stdout.is_empty(),
-            "rejection must occur before projection or manifest serialization"
-        );
-        assert!(
-            !String::from_utf8_lossy(&output.stderr).contains(dry_run_ref)
-                && !String::from_utf8_lossy(&output.stderr).contains(durable_ref),
-            "PowerShell public reference rejection must not reflect an unsafe value"
-        );
-        assert_eq!(
-            snapshot_tree(&runtime),
-            before,
-            "PowerShell rejection must preserve runtime bytes"
-        );
-    }
-}
-
-#[test]
-#[cfg(windows)]
-fn cp17_rust_manifest_public_refs_share_one_segment_identity_authority() {
-    let fixture = make_project(&context_pack_policy(100, 262_144, 50));
-    let manifest_path = fixture.path().join(".winsmux").join("manifest.yaml");
-    let args = vec![
-        "status".into(),
-        "--json".into(),
-        "--project-dir".into(),
-        fixture.path().display().to_string(),
-    ];
-    let cases = [
-        (
-            "Rust dry_run_plan_ref private alias must reject",
-            "evidence:review/.winsmux./secret",
-            "context-packs/review-pack.json",
-        ),
-        (
-            "Rust dry_run_plan_ref dot segment must reject",
-            "evidence:review/./plan.json",
-            "context-packs/review-pack.json",
-        ),
-        (
-            "Rust dry_run_plan_ref empty segment must reject",
-            "evidence:review//plan.json",
-            "context-packs/review-pack.json",
-        ),
-        (
-            "Rust dry_run_plan_ref reserved device must reject",
-            "evidence:review/nul.txt",
-            "context-packs/review-pack.json",
-        ),
-        (
-            "Rust dry_run_plan_ref trailing period must reject",
-            "evidence:review/public.",
-            "context-packs/review-pack.json",
-        ),
-        (
-            "Rust durable_ref private alias must reject",
-            "evidence:workspace-plan.json",
-            "context-packs/review-pack/.winsmux./secret",
-        ),
-        (
-            "Rust durable_ref dot segment must reject",
-            "evidence:workspace-plan.json",
-            "context-packs/review-pack/./plan.json",
-        ),
-        (
-            "Rust durable_ref empty segment must reject",
-            "evidence:workspace-plan.json",
-            "context-packs/review-pack//plan.json",
-        ),
-        (
-            "Rust durable_ref reserved device must reject",
-            "evidence:workspace-plan.json",
-            "context-packs/review-pack/lpt1.log",
-        ),
-        (
-            "Rust durable_ref trailing period must reject",
-            "evidence:workspace-plan.json",
-            "context-packs/review-pack/public.",
-        ),
-    ];
-    for (segment_invariant, dry_run_ref, durable_ref) in cases {
-        let yaml = format!(
-            r#"version: 1
-session:
-  name: test
-  project_dir: ''
-  started: ''
-  ended: ''
-panes: {{}}
-declarative_workspace:
-  schema_version: 1
-  config_fingerprint: {CONTENT_A}
-  recipe_id: bugfix-two-slot
-  resolved_bindings: {{}}
-  dry_run_plan_ref: {dry_run_ref}
-  context_packs:
-    review-pack:
-      schema_version: 1
-      digest: {CONTENT_B}
-      byte_count: 100
-      source_head: {SOURCE_HEAD}
-      policy_fingerprint: {CONTENT_C}
-      limits:
-        max_files: 100
-        max_bytes: 262144
-        max_evidence_refs: 50
-      omissions:
-        code_map: 0
-        changed_files: 0
-        tests: 0
-        evidence_refs: 0
-        omitted_by_bytes: 0
-      privacy_result: pass
-      durable_ref: {durable_ref}
-"#
-        );
-        fs::write(&manifest_path, yaml).expect("write Win32 alias manifest");
-        let before = fs::read(&manifest_path).expect("read Win32 alias manifest");
-        let output = run_binary(&args, b"");
-        assert!(!output.status.success(), "{segment_invariant}");
-        assert!(
-            output.stdout.is_empty(),
-            "invalid durable ref must not produce a public read payload"
-        );
-        assert!(
-            !String::from_utf8_lossy(&output.stderr).contains(dry_run_ref)
-                && !String::from_utf8_lossy(&output.stderr).contains(durable_ref),
-            "Rust public reference rejection must not reflect an unsafe value"
-        );
-        assert_eq!(
-            fs::read(&manifest_path).unwrap(),
-            before,
-            "Rust manifest rejection must preserve durable bytes"
-        );
-    }
 }
 
 #[test]
@@ -1178,265 +819,6 @@ fn cp18_rust_context_pack_path_fields_enforce_exact_total_and_component_byte_edg
                 assert!(!output.status.success(), "{boundary_invariant}");
                 assert_rejected(&output, &before, fixture.path());
             }
-        }
-    }
-}
-
-#[test]
-#[cfg(windows)]
-fn cp19_powershell_public_refs_enforce_exact_total_and_component_byte_edges() {
-    let fixture = make_project(&context_pack_policy(100, 262_144, 50));
-    let evidence_component_edge = format!("evidence:{}", "a".repeat(240));
-    let evidence_component_over = format!("evidence:{}", "a".repeat(241));
-    let evidence_total_edge = format!("evidence:{}/{}", "a".repeat(240), "b".repeat(6));
-    let evidence_total_over = format!("evidence:{}/{}", "a".repeat(240), "b".repeat(7));
-    let plan = serde_json::json!({
-        "config_fingerprint": CONTENT_A,
-        "recipe_id": "bugfix-two-slot",
-        "resolved_bindings": {},
-        "context_pack": {
-            "manifest_projection": {
-                "pack_id": "review-pack",
-                "schema_version": 1,
-                "digest": CONTENT_B,
-                "byte_count": 100,
-                "source_head": SOURCE_HEAD,
-                "policy_fingerprint": CONTENT_C,
-                "limits": {"max_files": 100, "max_bytes": 262144, "max_evidence_refs": 50},
-                "omissions": {"code_map": 0, "changed_files": 0, "tests": 0, "evidence_refs": 0, "omitted_by_bytes": 0},
-                "privacy_result": "pass"
-            }
-        }
-    });
-    let context_component_edge = format!("context-packs/{}", "a".repeat(240));
-    let context_component_over = format!("context-packs/{}", "a".repeat(241));
-    let context_total_edge = format!("context-packs/{}/b", "a".repeat(240));
-    let context_total_over = format!("context-packs/{}/bb", "a".repeat(240));
-    assert_eq!(
-        context_total_edge.as_bytes().len(),
-        256,
-        "PF06 exact total byte edge must be 256"
-    );
-    assert_eq!(
-        context_component_edge
-            .strip_prefix("context-packs/")
-            .unwrap()
-            .split('/')
-            .map(str::len)
-            .max(),
-        Some(240),
-        "PF06 exact component byte edge must be 240"
-    );
-    let powershell_cases = [
-        (
-            evidence_component_edge.as_str(),
-            "context-packs/review-pack.json",
-            true,
-            "PF05 exact component byte edge must accept",
-        ),
-        (
-            evidence_component_over.as_str(),
-            "context-packs/review-pack.json",
-            false,
-            "PF05 component byte edge+1 must reject",
-        ),
-        (
-            evidence_total_edge.as_str(),
-            "context-packs/review-pack.json",
-            true,
-            "PF05 exact total byte edge must accept",
-        ),
-        (
-            evidence_total_over.as_str(),
-            "context-packs/review-pack.json",
-            false,
-            "PF05 total byte edge+1 must reject",
-        ),
-        (
-            "evidence:workspace-plan.json",
-            context_component_edge.as_str(),
-            true,
-            "PF06 exact component byte edge must accept",
-        ),
-        (
-            "evidence:workspace-plan.json",
-            context_component_over.as_str(),
-            false,
-            "PF06 component byte edge+1 must reject",
-        ),
-        (
-            "evidence:workspace-plan.json",
-            context_total_edge.as_str(),
-            true,
-            "PF06 exact total byte edge must accept",
-        ),
-        (
-            "evidence:workspace-plan.json",
-            context_total_over.as_str(),
-            false,
-            "PF06 total byte edge+1 must reject",
-        ),
-    ];
-    let runtime_before = snapshot_tree(&fixture.path().join(".winsmux"));
-    for (dry_run_ref, durable_ref, should_accept, boundary_invariant) in powershell_cases {
-        let output =
-            render_manifest_process_with_refs(fixture.path(), &plan, dry_run_ref, durable_ref);
-        assert_eq!(
-            snapshot_tree(&fixture.path().join(".winsmux")),
-            runtime_before,
-            "{boundary_invariant}: PowerShell boundary must preserve runtime bytes"
-        );
-        if should_accept {
-            assert!(output.status.success(), "{boundary_invariant}");
-            assert!(
-                !output.stdout.is_empty(),
-                "{boundary_invariant}: accepted projection must be complete"
-            );
-        } else {
-            assert!(!output.status.success(), "{boundary_invariant}");
-            assert!(
-                output.stdout.is_empty(),
-                "{boundary_invariant}: rejected projection must emit no YAML"
-            );
-        }
-    }
-}
-
-#[test]
-#[cfg(windows)]
-fn cp20_rust_manifest_public_refs_enforce_exact_total_and_component_byte_edges() {
-    let fixture = make_project(&context_pack_policy(100, 262_144, 50));
-    let evidence_component_edge = format!("evidence:{}", "a".repeat(240));
-    let evidence_component_over = format!("evidence:{}", "a".repeat(241));
-    let evidence_total_edge = format!("evidence:{}/{}", "a".repeat(240), "b".repeat(6));
-    let evidence_total_over = format!("evidence:{}/{}", "a".repeat(240), "b".repeat(7));
-    let context_component_edge = format!("context-packs/{}", "a".repeat(240));
-    let context_component_over = format!("context-packs/{}", "a".repeat(241));
-    let context_total_edge = format!("context-packs/{}/b", "a".repeat(240));
-    let context_total_over = format!("context-packs/{}/bb", "a".repeat(240));
-    assert_eq!(
-        evidence_total_edge.as_bytes().len(),
-        256,
-        "PF07 exact total byte edge must be 256"
-    );
-    assert_eq!(
-        context_total_edge.as_bytes().len(),
-        256,
-        "PF08 exact total byte edge must be 256"
-    );
-    let manifest_path = fixture.path().join(".winsmux").join("manifest.yaml");
-    let status_args = vec![
-        "status".into(),
-        "--json".into(),
-        "--project-dir".into(),
-        fixture.path().display().to_string(),
-    ];
-    let manifest_cases = [
-        (
-            evidence_component_edge.as_str(),
-            "context-packs/review-pack.json",
-            true,
-            "PF07 exact component byte edge must accept",
-        ),
-        (
-            evidence_component_over.as_str(),
-            "context-packs/review-pack.json",
-            false,
-            "PF07 component byte edge+1 must reject",
-        ),
-        (
-            evidence_total_edge.as_str(),
-            "context-packs/review-pack.json",
-            true,
-            "PF07 exact total byte edge must accept",
-        ),
-        (
-            evidence_total_over.as_str(),
-            "context-packs/review-pack.json",
-            false,
-            "PF07 total byte edge+1 must reject",
-        ),
-        (
-            "evidence:workspace-plan.json",
-            context_component_edge.as_str(),
-            true,
-            "PF08 exact component byte edge must accept",
-        ),
-        (
-            "evidence:workspace-plan.json",
-            context_component_over.as_str(),
-            false,
-            "PF08 component byte edge+1 must reject",
-        ),
-        (
-            "evidence:workspace-plan.json",
-            context_total_edge.as_str(),
-            true,
-            "PF08 exact total byte edge must accept",
-        ),
-        (
-            "evidence:workspace-plan.json",
-            context_total_over.as_str(),
-            false,
-            "PF08 total byte edge+1 must reject",
-        ),
-    ];
-    for (dry_run_ref, durable_ref, should_accept, boundary_invariant) in manifest_cases {
-        let yaml = format!(
-            r#"version: 1
-session:
-  name: test
-  project_dir: ''
-  started: ''
-  ended: ''
-panes: {{}}
-declarative_workspace:
-  schema_version: 1
-  config_fingerprint: {CONTENT_A}
-  recipe_id: bugfix-two-slot
-  resolved_bindings: {{}}
-  dry_run_plan_ref: {dry_run_ref}
-  context_packs:
-    review-pack:
-      schema_version: 1
-      digest: {CONTENT_B}
-      byte_count: 100
-      source_head: {SOURCE_HEAD}
-      policy_fingerprint: {CONTENT_C}
-      limits:
-        max_files: 100
-        max_bytes: 262144
-        max_evidence_refs: 50
-      omissions:
-        code_map: 0
-        changed_files: 0
-        tests: 0
-        evidence_refs: 0
-        omitted_by_bytes: 0
-      privacy_result: pass
-      durable_ref: {durable_ref}
-"#
-        );
-        fs::write(&manifest_path, yaml).expect("write boundary manifest");
-        let manifest_before = fs::read(&manifest_path).expect("read boundary manifest");
-        let output = run_binary(&status_args, b"");
-        assert_eq!(
-            fs::read(&manifest_path).unwrap(),
-            manifest_before,
-            "{boundary_invariant}: Rust manifest read must preserve durable bytes"
-        );
-        if should_accept {
-            assert!(output.status.success(), "{boundary_invariant}");
-            assert!(
-                !output.stdout.is_empty(),
-                "{boundary_invariant}: accepted manifest read must emit one payload"
-            );
-        } else {
-            assert!(!output.status.success(), "{boundary_invariant}");
-            assert!(
-                output.stdout.is_empty(),
-                "{boundary_invariant}: rejected manifest read must emit no payload"
-            );
         }
     }
 }
@@ -1637,48 +1019,7 @@ fn cp21_public_string_grammars_reject_path_shapes_before_output() {
 }
 
 #[test]
-fn cp22_rust_manifest_pack_id_bound_matches_cli_authority() {
-    let pack_id_edge = "a".repeat(64);
-    let pack_id_over = "a".repeat(65);
-    let long_generic_recipe = "r".repeat(65);
-    assert_eq!(
-        pack_id_edge.as_bytes().len(),
-        64,
-        "exact 64-byte context-pack ID edge must be explicit"
-    );
-    assert_eq!(
-        pack_id_over.as_bytes().len(),
-        65,
-        "context-pack ID edge+1 must be explicit"
-    );
-
-    let producer = make_project(&context_pack_policy_for_id(&pack_id_edge, 100, 262_144, 50));
-    let project_runtime_bytes = snapshot_tree(producer.path());
-    let edge_input = serde_json::to_vec(&sample_input()).expect("serialize exact-edge input");
-    let accepted_producer = run_binary(
-        &workspace_plan_args_with_pack_id(producer.path(), &pack_id_edge),
-        &edge_input,
-    );
-    let accepted_payload = parse_success(&accepted_producer);
-    assert_eq!(
-        accepted_payload["context_pack"]["manifest_projection"]["pack_id"],
-        serde_json::json!(pack_id_edge),
-        "exact 64-byte context-pack ID must remain accepted by the producer"
-    );
-    assert_eq!(
-        snapshot_tree(producer.path()),
-        project_runtime_bytes,
-        "project_runtime_bytes must remain unchanged for the accepted ID edge"
-    );
-    assert_rejected(
-        &run_binary(
-            &workspace_plan_args_with_pack_id(producer.path(), &pack_id_over),
-            &edge_input,
-        ),
-        &project_runtime_bytes,
-        producer.path(),
-    );
-
+fn cp22_rust_manifest_context_pack_persistence_is_unsupported() {
     let manifest_fixture = make_project("");
     let manifest_path = manifest_fixture
         .path()
@@ -1690,9 +1031,9 @@ fn cp22_rust_manifest_pack_id_bound_matches_cli_authority() {
         "--project-dir".into(),
         manifest_fixture.path().display().to_string(),
     ];
-    let manifest_yaml = |pack_id: &str| {
-        format!(
-            r#"version: 1
+    let removed_section = ["context_", "packs"].concat();
+    let manifest_yaml = format!(
+        r#"version: 1
 session:
   name: test
   project_dir: ''
@@ -1702,10 +1043,10 @@ panes: {{}}
 declarative_workspace:
   schema_version: 1
   config_fingerprint: {CONTENT_A}
-  recipe_id: {long_generic_recipe}
+  recipe_id: review-workspace
   resolved_bindings: {{}}
-  context_packs:
-    {pack_id}:
+  {removed_section}:
+    review-pack:
       schema_version: 1
       digest: {CONTENT_B}
       byte_count: 100
@@ -1722,202 +1063,133 @@ declarative_workspace:
         evidence_refs: 0
         omitted_by_bytes: 0
       privacy_result: pass
-      durable_ref: context-packs/{pack_id}.json
+      durable_ref: context-packs/review-pack.json
 "#
-        )
-    };
-
-    let manifest_edge_yaml = manifest_yaml(&pack_id_edge);
-    fs::write(&manifest_path, &manifest_edge_yaml).expect("write exact-edge manifest");
-    let manifest_edge_before = fs::read(&manifest_path).expect("read exact-edge manifest");
-    let manifest_edge_output = run_binary(&status_args, b"");
-    assert!(
-        manifest_edge_output.status.success(),
-        "exact 64-byte manifest pack ID must remain accepted: {}",
-        String::from_utf8_lossy(&manifest_edge_output.stderr)
     );
-    serde_json::from_slice::<serde_json::Value>(&manifest_edge_output.stdout)
-        .expect("accepted manifest read must emit one JSON payload");
-    assert_eq!(
-        fs::read(&manifest_path).unwrap(),
-        manifest_edge_before,
-        "manifest bytes must remain unchanged for the accepted ID edge"
-    );
-    assert!(
-        manifest_edge_yaml.contains(&format!("recipe_id: {long_generic_recipe}")),
-        "generic workspace identifiers must not inherit the context-pack 64-byte bound"
-    );
-
-    let manifest_over_yaml = manifest_yaml(&pack_id_over);
-    fs::write(&manifest_path, &manifest_over_yaml).expect("write edge+1 manifest");
-    let manifest_over_before = fs::read(&manifest_path).expect("read edge+1 manifest");
-    let manifest_over_output = run_binary(&status_args, b"");
-    let mut rust_boundary_violations = Vec::new();
-    if manifest_over_output.status.success()
-        || !manifest_over_output.stdout.is_empty()
-        || fs::read(&manifest_path).unwrap() != manifest_over_before
-    {
-        rust_boundary_violations.push(format!(
-            "65-byte context-pack ID reached public read output: status={:?}, stdout_bytes={}",
-            manifest_over_output.status,
-            manifest_over_output.stdout.len()
+    fs::write(&manifest_path, &manifest_yaml).expect("write removed-surface manifest");
+    let manifest_before = fs::read(&manifest_path).expect("read removed-surface manifest");
+    let output = run_binary(&status_args, b"");
+    let mut violations = Vec::new();
+    if output.status.success() {
+        violations.push("hand-authored context-pack persistence reached public read".to_string());
+    }
+    if !output.stdout.is_empty() {
+        violations.push(format!(
+            "removed manifest surface emitted {} stdout bytes",
+            output.stdout.len()
         ));
     }
-    if String::from_utf8_lossy(&manifest_over_output.stderr).contains(&pack_id_over) {
-        rust_boundary_violations
-            .push("65-byte context-pack ID was reflected by manifest rejection".to_string());
+    if fs::read(&manifest_path).unwrap() != manifest_before {
+        violations.push("manifest bytes changed during removed-surface rejection".to_string());
+    }
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    if stderr.contains(CONTENT_B) || stderr.contains("context-packs/review-pack.json") {
+        violations.push("removed manifest metadata was reflected by rejection".to_string());
     }
     assert!(
-        rust_boundary_violations.is_empty(),
-        "Rust manifest and CLI context-pack ID boundaries must agree at 64 bytes; \
-         65-byte context-pack ID must reject before public read output; \
-         manifest bytes must remain unchanged; violations={rust_boundary_violations:?}"
+        violations.is_empty(),
+        "hand-authored context-pack persistence must reject before public read output; \
+         manifest bytes must remain unchanged; violations={violations:?}"
     );
 }
 
 #[test]
 #[cfg(windows)]
-fn cp23_powershell_projection_pack_id_bound_matches_cli_authority() {
-    let pack_id_edge = "a".repeat(64);
-    let pack_id_over = "a".repeat(65);
-    let long_generic_recipe = "r".repeat(65);
-    let producer = make_project(&context_pack_policy_for_id(&pack_id_edge, 100, 262_144, 50));
+fn cp23_powershell_context_pack_persistence_is_unsupported() {
+    let producer = make_project(&context_pack_policy(100, 262_144, 50));
     let producer_before = snapshot_tree(producer.path());
-    let input = serde_json::to_vec(&sample_input()).expect("serialize projection input");
-    parse_success(&run_binary(
-        &workspace_plan_args_with_pack_id(producer.path(), &pack_id_edge),
-        &input,
-    ));
-    assert_rejected(
-        &run_binary(
-            &workspace_plan_args_with_pack_id(producer.path(), &pack_id_over),
-            &input,
-        ),
-        &producer_before,
-        producer.path(),
-    );
-
-    let plan = |pack_id: &str| {
-        serde_json::json!({
-            "config_fingerprint": CONTENT_A,
-            "recipe_id": long_generic_recipe,
-            "resolved_bindings": {},
-            "context_pack": {
-                "manifest_projection": {
-                    "pack_id": pack_id,
-                    "schema_version": 1,
-                    "digest": CONTENT_B,
-                    "byte_count": 100,
-                    "source_head": SOURCE_HEAD,
-                    "policy_fingerprint": CONTENT_C,
-                    "limits": {
-                        "max_files": 100,
-                        "max_bytes": 262144,
-                        "max_evidence_refs": 50
-                    },
-                    "omissions": {
-                        "code_map": 0,
-                        "changed_files": 0,
-                        "tests": 0,
-                        "evidence_refs": 0,
-                        "omitted_by_bytes": 0
-                    },
-                    "privacy_result": "pass"
-                }
-            }
-        })
-    };
-
-    let edge_fixture = make_project("");
-    let edge_plan = plan(&pack_id_edge);
-    let (edge_output, edge_before, edge_after) = render_manifest_process_with_refs_and_state(
-        edge_fixture.path(),
-        &edge_plan,
-        "",
-        &format!("context-packs/{pack_id_edge}.json"),
-    );
-    assert!(
-        edge_output.status.success(),
-        "exact 64-byte external-plan pack ID must remain accepted: {}",
-        String::from_utf8_lossy(&edge_output.stderr)
-    );
-    let edge_yaml =
-        String::from_utf8(edge_output.stdout).expect("accepted projection YAML must be UTF-8");
-    assert!(
-        edge_yaml.contains(&pack_id_edge),
-        "accepted projection must preserve the exact authored 64-byte map key"
-    );
+    let producer_plan = parse_success(&run_pack(producer.path(), &sample_input()));
     assert_eq!(
-        edge_before, edge_after,
-        "PowerShell projection must preserve runtime bytes after test setup"
+        snapshot_tree(producer.path()),
+        producer_before,
+        "public producer must preserve project and runtime bytes"
     );
-    assert_eq!(
-        edge_plan["recipe_id"],
-        serde_json::json!(long_generic_recipe),
-        "generic workspace identifiers must not inherit the context-pack 64-byte bound"
-    );
+    let mut fabricated_plan = producer_plan.clone();
+    fabricated_plan["context_pack"]
+        .as_object_mut()
+        .expect("context_pack object")
+        .remove("canonical_json");
+    fabricated_plan["context_pack"]
+        .as_object_mut()
+        .expect("context_pack object")
+        .remove("digest");
+    fabricated_plan["context_pack"]
+        .as_object_mut()
+        .expect("context_pack object")
+        .remove("byte_count");
 
-    let over_fixture = make_project("");
-    let over_plan = plan(&pack_id_over);
-    let (over_output, over_before, over_after) = render_manifest_process_with_refs_and_state(
-        over_fixture.path(),
-        &over_plan,
-        "",
-        &format!("context-packs/{pack_id_over}.json"),
+    let cases = [
+        ("producer-payload", producer_plan),
+        ("fabricated-projection-only", fabricated_plan),
+    ];
+    let mut violations = Vec::new();
+    for (case_name, plan) in cases {
+        let fixture = make_project("");
+        let (output, before, after) = render_manifest_process_with_refs_and_state(
+            fixture.path(),
+            &plan,
+            "",
+            "context-packs/review-pack.json",
+        );
+        if output.status.success() || !output.stdout.is_empty() {
+            violations.push(format!(
+                "{case_name} reached projection output: status={:?}, stdout_bytes={}",
+                output.status,
+                output.stdout.len()
+            ));
+        }
+        if before != after {
+            violations.push(format!(
+                "{case_name} changed runtime bytes before old-path rejection"
+            ));
+        }
+    }
+    assert!(
+        violations.is_empty(),
+        "old PowerShell context-pack persistence entry must reject before projection, YAML, or save; \
+         runtime bytes must remain unchanged; violations={violations:?}"
     );
-    let mut powershell_boundary_violations = Vec::new();
-    if over_output.status.success() || !over_output.stdout.is_empty() {
-        powershell_boundary_violations.push(format!(
-            "65-byte external-plan pack ID reached projection YAML: status={:?}, stdout_bytes={}",
-            over_output.status,
-            over_output.stdout.len()
+}
+
+#[test]
+fn cp24_public_context_pack_envelope_is_canonical_only() {
+    let fixture = make_project(&context_pack_policy(100, 262_144, 50));
+    let before = snapshot_tree(fixture.path());
+    let payload = parse_success(&run_pack(fixture.path(), &sample_input()));
+    let pack = payload["context_pack"]
+        .as_object()
+        .expect("public context_pack must be an object");
+    let mut actual_keys = pack.keys().cloned().collect::<Vec<_>>();
+    actual_keys.sort();
+    let expected_keys = vec![
+        "byte_count".to_string(),
+        "canonical_json".to_string(),
+        "digest".to_string(),
+    ];
+    let canonical = pack["canonical_json"]
+        .as_str()
+        .expect("canonical_json must be a UTF-8 string");
+    let mut violations = Vec::new();
+    if actual_keys != expected_keys {
+        violations.push(format!(
+            "public context-pack key set is {actual_keys:?}, expected {expected_keys:?}"
         ));
     }
-    if over_before != over_after {
-        powershell_boundary_violations
-            .push("PowerShell projection rejection must preserve runtime bytes".to_string());
+    if pack["digest"] != serde_json::json!(sha256(canonical.as_bytes())) {
+        violations.push("digest is not derived from exact canonical UTF-8 bytes".to_string());
     }
-    if String::from_utf8_lossy(&over_output.stderr).contains(&pack_id_over) {
-        powershell_boundary_violations.push(
-            "65-byte external-plan pack ID was reflected by projection rejection".to_string(),
-        );
+    if pack["byte_count"] != serde_json::json!(canonical.len()) {
+        violations.push("byte_count is not the exact canonical UTF-8 byte length".to_string());
+    }
+    if snapshot_tree(fixture.path()) != before {
+        violations.push("public preview changed project or runtime bytes".to_string());
     }
     assert!(
-        powershell_boundary_violations.is_empty(),
-        "PowerShell projection and CLI context-pack ID boundaries must agree at 64 bytes; \
-         65-byte external-plan pack ID must reject before projection, YAML, or save; \
-         external-plan rejection must emit no YAML; violations={powershell_boundary_violations:?}"
+        violations.is_empty(),
+        "public context-pack envelope must contain only canonical_json, digest, and byte_count; \
+         rejection emits no public output; rejection preserves durable state bytes; \
+         project and runtime bytes must remain unchanged; violations={violations:?}"
     );
-}
-
-#[cfg(windows)]
-fn render_manifest_with_powershell(
-    project: &Path,
-    plan: &serde_json::Value,
-    durable_ref: &str,
-) -> String {
-    let output = render_manifest_process(project, plan, durable_ref);
-    assert!(
-        output.status.success(),
-        "PowerShell manifest projection failed: {}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-    String::from_utf8(output.stdout).expect("manifest YAML must be UTF-8")
-}
-
-#[cfg(windows)]
-fn render_manifest_process(project: &Path, plan: &serde_json::Value, durable_ref: &str) -> Output {
-    render_manifest_process_with_refs(project, plan, "", durable_ref)
-}
-
-#[cfg(windows)]
-fn render_manifest_process_with_refs(
-    project: &Path,
-    plan: &serde_json::Value,
-    dry_run_ref: &str,
-    durable_ref: &str,
-) -> Output {
-    render_manifest_process_with_refs_and_state(project, plan, dry_run_ref, durable_ref).0
 }
 
 #[cfg(windows)]
@@ -1940,11 +1212,12 @@ fn render_manifest_process_with_refs_and_state(
         .join("winsmux-core")
         .join("scripts")
         .join("manifest.ps1");
+    let removed_parameter = ["-Context", "PackRef"].concat();
     let script = format!(
         r#"[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)
 . '{}'
 $plan = Get-Content -Raw -LiteralPath '{}' | ConvertFrom-Json
-$projection = New-WinsmuxDeclarativeWorkspaceProjection -Plan $plan -DryRunPlanRef '{}' -ContextPackRef '{}'
+$projection = New-WinsmuxDeclarativeWorkspaceProjection -Plan $plan -DryRunPlanRef '{}' {} '{}'
 $manifest = [ordered]@{{
   version = 1
   saved_at = '2026-07-26T00:00:00Z'
@@ -1959,6 +1232,7 @@ $manifest = [ordered]@{{
         manifest_script.display().to_string().replace('\'', "''"),
         plan_path.display().to_string().replace('\'', "''"),
         dry_run_ref.replace('\'', "''"),
+        removed_parameter,
         durable_ref.replace('\'', "''"),
     );
     fs::write(&script_path, script).expect("write PowerShell fixture");

--- a/core/tests-rs/context_pack_contract.rs
+++ b/core/tests-rs/context_pack_contract.rs
@@ -11,9 +11,44 @@ const CONTENT_A: &str = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 const CONTENT_B: &str = "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
 const CONTENT_C: &str = "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
 const CONTEXT_REJECTION: &str = "winsmux: context pack rejected.\n";
+const ARCHITECTURE_DOC: &str =
+    include_str!("../../docs/project/v03629-declarative-workspace-architecture.md");
+const RUNNABLE_CONTEXT_PACK_V1_START: &str = "<!-- TASK660-RUNNABLE-CONTEXT-PACK-V1:START -->";
+const RUNNABLE_CONTEXT_PACK_V1_END: &str = "<!-- TASK660-RUNNABLE-CONTEXT-PACK-V1:END -->";
 
 fn base_yaml() -> String {
     include_str!("../../tests/fixtures/workspace-recipes/valid-v1.yaml").to_string()
+}
+
+fn documented_context_pack_policy_v1() -> &'static str {
+    assert_eq!(
+        ARCHITECTURE_DOC
+            .matches(RUNNABLE_CONTEXT_PACK_V1_START)
+            .count(),
+        1,
+        "architecture doc must contain exactly one runnable context-pack v1 start marker"
+    );
+    assert_eq!(
+        ARCHITECTURE_DOC
+            .matches(RUNNABLE_CONTEXT_PACK_V1_END)
+            .count(),
+        1,
+        "architecture doc must contain exactly one runnable context-pack v1 end marker"
+    );
+    let (_, after_start) = ARCHITECTURE_DOC
+        .split_once(RUNNABLE_CONTEXT_PACK_V1_START)
+        .expect("architecture doc must contain the runnable context-pack v1 start marker");
+    let (marked_block, _) = after_start
+        .split_once(RUNNABLE_CONTEXT_PACK_V1_END)
+        .expect("architecture doc must contain the runnable context-pack v1 end marker");
+    let fenced_block = marked_block.trim();
+    let yaml = fenced_block
+        .strip_prefix("```yaml\r\n")
+        .or_else(|| fenced_block.strip_prefix("```yaml\n"))
+        .expect("runnable context-pack v1 must start with a YAML fence");
+    yaml.strip_suffix("\r\n```")
+        .or_else(|| yaml.strip_suffix("\n```"))
+        .expect("runnable context-pack v1 must end with a YAML fence")
 }
 
 fn context_pack_policy(max_files: usize, max_bytes: usize, max_evidence_refs: usize) -> String {
@@ -1189,6 +1224,104 @@ fn cp24_public_context_pack_envelope_is_canonical_only() {
         "public context-pack envelope must contain only canonical_json, digest, and byte_count; \
          rejection emits no public output; rejection preserves durable state bytes; \
          project and runtime bytes must remain unchanged; violations={violations:?}"
+    );
+}
+
+#[test]
+fn cp25_documented_task660_contract_matches_public_preview_and_excludes_persistence() {
+    let documented_policy = documented_context_pack_policy_v1();
+    let fixture = make_project(documented_policy);
+    let before = snapshot_tree(fixture.path());
+    let payload = parse_success(&run_pack(fixture.path(), &sample_input()));
+    let pack = payload["context_pack"]
+        .as_object()
+        .expect("documented public context_pack must be an object");
+    let mut actual_keys = pack.keys().cloned().collect::<Vec<_>>();
+    actual_keys.sort();
+    let expected_keys = vec![
+        "byte_count".to_string(),
+        "canonical_json".to_string(),
+        "digest".to_string(),
+    ];
+    let canonical = pack["canonical_json"]
+        .as_str()
+        .expect("documented canonical_json must be a UTF-8 string");
+    let stale_claims = [
+        "The manifest stores only pack ID",
+        "metadata-only PowerShell/Rust manifest projection",
+        "context-pack metadata round-trips",
+        "TASK-662 owns any future verified cross-runtime persistence contract",
+    ];
+    let workflow_context_ref_claim = ["context", "_pack_", "refs: [context-pack:...]"].concat();
+    let task660_section = ARCHITECTURE_DOC
+        .split_once("### 6.3 TASK-660: repository context package")
+        .expect("architecture doc must contain the TASK-660 section")
+        .1
+        .split_once("### 6.4 TASK-661: templates, gallery, and migration path")
+        .expect("TASK-660 section must end before TASK-661")
+        .0;
+    let task662_section = ARCHITECTURE_DOC
+        .split_once("### 6.5 TASK-662: workflow pre-release gate")
+        .expect("architecture doc must contain the TASK-662 section")
+        .1;
+
+    let mut violations = Vec::new();
+    if actual_keys != expected_keys {
+        violations.push(format!(
+            "documented public context-pack key set is {actual_keys:?}, expected {expected_keys:?}"
+        ));
+    }
+    if pack["digest"] != serde_json::json!(sha256(canonical.as_bytes())) {
+        violations
+            .push("documented digest is not derived from exact canonical UTF-8 bytes".to_string());
+    }
+    if pack["byte_count"] != serde_json::json!(canonical.len()) {
+        violations
+            .push("documented byte_count is not the exact canonical UTF-8 byte length".to_string());
+    }
+    for stale_claim in stale_claims {
+        if ARCHITECTURE_DOC.contains(stale_claim) {
+            violations.push(format!(
+                "architecture doc retains stale persistence claim: {stale_claim}"
+            ));
+        }
+    }
+    if ARCHITECTURE_DOC.contains(&workflow_context_ref_claim) {
+        violations.push("current workflow manifest example retains a context-pack ref".to_string());
+    }
+    for required_claim in [
+        "read-only context-pack preview",
+        "does not persist the context-pack result",
+        "canonical_json",
+        "byte_count",
+    ] {
+        if !task660_section.contains(required_claim) {
+            violations.push(format!(
+                "TASK-660 section is missing current contract claim: {required_claim}"
+            ));
+        }
+    }
+    if !task662_section.contains("does not implement context-pack persistence") {
+        violations.push(
+            "TASK-662 section does not exclude context-pack persistence implementation".to_string(),
+        );
+    }
+    if !ARCHITECTURE_DOC
+        .contains("Existing ledger context-pack references are a separate pre-existing mechanism")
+    {
+        violations.push(
+            "architecture doc does not distinguish the existing ledger reference mechanism"
+                .to_string(),
+        );
+    }
+    if snapshot_tree(fixture.path()) != before {
+        violations.push("documented preview changed project or runtime bytes".to_string());
+    }
+    assert!(
+        violations.is_empty(),
+        "documented TASK-660 contract must run through the public context-pack entry, \
+         expose only canonical_json, digest, and byte_count, exclude persistence ownership, \
+         and keep project and runtime bytes unchanged; violations={violations:?}"
     );
 }
 

--- a/core/tests-rs/context_pack_contract.rs
+++ b/core/tests-rs/context_pack_contract.rs
@@ -3,6 +3,8 @@ use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
 
 const SOURCE_HEAD: &str = "0123456789abcdef0123456789abcdef01234567";
 const CONTENT_A: &str = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
@@ -122,6 +124,41 @@ fn run_binary(args: &[String], stdin_bytes: &[u8]) -> Output {
         let _ = stdin.write_all(stdin_bytes);
     }
     child.wait_with_output().expect("collect winsmux output")
+}
+
+fn run_binary_holding_stdin(args: &[String]) -> (Output, bool) {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("run winsmux binary with held stdin");
+    let held_stdin = child.stdin.take().expect("hold child stdin open");
+    let deadline = Instant::now() + Duration::from_secs(2);
+    let exited_while_stdin_open = loop {
+        if child
+            .try_wait()
+            .expect("poll winsmux binary with held stdin")
+            .is_some()
+        {
+            break true;
+        }
+        if Instant::now() >= deadline {
+            break false;
+        }
+        thread::sleep(Duration::from_millis(20));
+    };
+    drop(held_stdin);
+    if !exited_while_stdin_open {
+        let _ = child.kill();
+    }
+    (
+        child
+            .wait_with_output()
+            .expect("collect winsmux output with held stdin"),
+        exited_while_stdin_open,
+    )
 }
 
 fn run_pack(project: &Path, input: &serde_json::Value) -> Output {
@@ -1443,6 +1480,79 @@ fn cp21_public_string_grammars_reject_path_shapes_before_output() {
             assert_rejected(&output, &before, fixture.path());
         }
     }
+
+    let mut pack_id_boundary_violations = Vec::new();
+    let bot_example_args = vec![
+        "workspace-plan".into(),
+        "--context-pack-id".into(),
+        "--json".into(),
+        "--context-pack-input".into(),
+        "-".into(),
+    ];
+    let bot_example = run_binary(&bot_example_args, b"");
+    if bot_example.status.success()
+        || !bot_example.stdout.is_empty()
+        || String::from_utf8_lossy(&bot_example.stderr) != CONTEXT_REJECTION
+        || snapshot_tree(fixture.path()) != before
+    {
+        pack_id_boundary_violations.push(format!(
+            "option-token pack ID reached legacy outcome: status={:?}, stderr={:?}",
+            bot_example.status,
+            String::from_utf8_lossy(&bot_example.stderr)
+        ));
+    }
+
+    let mut held_stdin_args = workspace_plan_args(fixture.path());
+    let held_pack_id_index = held_stdin_args
+        .iter()
+        .position(|arg| arg == "--context-pack-id")
+        .expect("public entry must carry the held-stdin pack ID")
+        + 1;
+    held_stdin_args[held_pack_id_index] = "--json".into();
+    let (held_stdin_output, exited_while_stdin_open) = run_binary_holding_stdin(&held_stdin_args);
+    if !exited_while_stdin_open
+        || held_stdin_output.status.success()
+        || !held_stdin_output.stdout.is_empty()
+        || String::from_utf8_lossy(&held_stdin_output.stderr) != CONTEXT_REJECTION
+        || snapshot_tree(fixture.path()) != before
+    {
+        pack_id_boundary_violations.push(format!(
+            "invalid pack ID reached snapshot or stdin: exited_while_stdin_open={exited_while_stdin_open}, status={:?}, stderr={:?}",
+            held_stdin_output.status,
+            String::from_utf8_lossy(&held_stdin_output.stderr)
+        ));
+    }
+
+    let poisoned_project = tempfile::tempdir().expect("create poisoned project boundary");
+    let poisoned_before = snapshot_tree(poisoned_project.path());
+    let mut poisoned_args = workspace_plan_args(poisoned_project.path());
+    let poisoned_pack_id_index = poisoned_args
+        .iter()
+        .position(|arg| arg == "--context-pack-id")
+        .expect("public entry must carry the poisoned-project pack ID")
+        + 1;
+    poisoned_args[poisoned_pack_id_index] = "review/pack".into();
+    let poisoned_output = run_binary(
+        &poisoned_args,
+        serde_json::to_vec(&sample_input())
+            .expect("serialize poisoned-project pack input")
+            .as_slice(),
+    );
+    if poisoned_output.status.success()
+        || !poisoned_output.stdout.is_empty()
+        || String::from_utf8_lossy(&poisoned_output.stderr) != CONTEXT_REJECTION
+        || snapshot_tree(poisoned_project.path()) != poisoned_before
+    {
+        pack_id_boundary_violations.push(format!(
+            "invalid pack ID reached poisoned project snapshot: status={:?}, stderr={:?}",
+            poisoned_output.status,
+            String::from_utf8_lossy(&poisoned_output.stderr)
+        ));
+    }
+    assert!(
+        pack_id_boundary_violations.is_empty(),
+        "pack ID grammar must reject before legacy parsing, project snapshot, stdin, and write_json; violations={pack_id_boundary_violations:?}"
+    );
 
     let mut invalid_pack_args = workspace_plan_args(fixture.path());
     let pack_id_index = invalid_pack_args

--- a/core/tests-rs/context_pack_contract.rs
+++ b/core/tests-rs/context_pack_contract.rs
@@ -1391,6 +1391,128 @@ declarative_workspace:
     }
 }
 
+#[test]
+fn cp21_public_string_grammars_reject_path_shapes_before_output() {
+    let fixture = make_project(&context_pack_policy(100, 262_144, 50));
+    let before = snapshot_tree(fixture.path());
+    let unsafe_test_ids = [
+        "c:/users/alice/private-test",
+        "c:users-private-test",
+        "suite/../../private-test",
+        "suite/.winsmux/private-test",
+        "module:case",
+        "module::::case",
+        "module::.winsmux",
+        "module::case/child",
+    ];
+    let mut admitted_path_shapes = Vec::new();
+
+    for test_id in unsafe_test_ids {
+        let mut input = sample_input();
+        input["tests"][0]["test_id"] = serde_json::json!(test_id);
+        let output = run_pack(fixture.path(), &input);
+        if output.status.success() {
+            assert!(
+                output.stderr.is_empty(),
+                "an admitted path-shaped test ID must not produce a mixed outcome"
+            );
+            let payload: serde_json::Value =
+                serde_json::from_slice(&output.stdout).expect("accepted output must be JSON");
+            let canonical_json = payload["context_pack"]["canonical_json"]
+                .as_str()
+                .expect("accepted output must include canonical_json");
+            let canonical: serde_json::Value =
+                serde_json::from_str(canonical_json).expect("canonical_json must parse");
+            assert_eq!(
+                canonical["groups"]["tests"][0]["test_id"],
+                serde_json::json!(test_id),
+                "an admitted path-shaped test ID must be observed at the protected output sink"
+            );
+            assert_eq!(
+                canonical["privacy_result"],
+                serde_json::json!("pass"),
+                "privacy_result must expose the false privacy claim for RED evidence"
+            );
+            assert_eq!(
+                snapshot_tree(fixture.path()),
+                before,
+                "project_runtime_bytes must remain unchanged while collecting RED cases"
+            );
+            admitted_path_shapes.push(test_id.to_string());
+        } else {
+            assert_rejected(&output, &before, fixture.path());
+        }
+    }
+
+    let mut invalid_pack_args = workspace_plan_args(fixture.path());
+    let pack_id_index = invalid_pack_args
+        .iter()
+        .position(|arg| arg == "--context-pack-id")
+        .expect("public entry must carry the pack ID")
+        + 1;
+    invalid_pack_args[pack_id_index] = "review/pack".into();
+    assert_rejected(
+        &run_binary(
+            &invalid_pack_args,
+            serde_json::to_vec(&sample_input())
+                .expect("serialize invalid pack input")
+                .as_slice(),
+        ),
+        &before,
+        fixture.path(),
+    );
+    assert!(
+        snapshot_tree(fixture.path()) == before,
+        "pack ID path shape must reject before write_json"
+    );
+
+    let mut invalid_changed_digest = sample_input();
+    invalid_changed_digest["changed_files"][0]["content_sha256"] = serde_json::json!("sha256:ABC");
+    assert_rejected(
+        &run_pack(fixture.path(), &invalid_changed_digest),
+        &before,
+        fixture.path(),
+    );
+    assert!(
+        snapshot_tree(fixture.path()) == before,
+        "changed-file content identity must reject before write_json"
+    );
+
+    let mut valid = sample_input();
+    valid["tests"][0]["test_id"] = serde_json::json!("module.name::case_1");
+    let first = parse_success(&run_pack(fixture.path(), &valid));
+    let second = parse_success(&run_pack(fixture.path(), &valid));
+    let first_canonical: serde_json::Value = serde_json::from_str(
+        first["context_pack"]["canonical_json"]
+            .as_str()
+            .expect("valid logical namespace must include canonical_json"),
+    )
+    .expect("valid logical namespace canonical_json must parse");
+    assert_eq!(
+        first_canonical["groups"]["tests"][0]["test_id"],
+        serde_json::json!("module.name::case_1"),
+        "valid logical namespace must remain accepted"
+    );
+    assert_eq!(
+        first["context_pack"]["canonical_json"], second["context_pack"]["canonical_json"],
+        "valid logical namespace must preserve deterministic bytes"
+    );
+    assert_eq!(
+        first["context_pack"]["digest"], second["context_pack"]["digest"],
+        "valid logical namespace must preserve deterministic digest"
+    );
+    assert_eq!(
+        snapshot_tree(fixture.path()),
+        before,
+        "project_runtime_bytes must remain unchanged for valid logical IDs"
+    );
+
+    assert!(
+        admitted_path_shapes.is_empty(),
+        "public string grammar must reject every path-shaped value before write_json; admitted={admitted_path_shapes:?}"
+    );
+}
+
 #[cfg(windows)]
 fn render_manifest_with_powershell(
     project: &Path,

--- a/core/tests-rs/context_pack_contract.rs
+++ b/core/tests-rs/context_pack_contract.rs
@@ -1,0 +1,1463 @@
+use sha2::{Digest, Sha256};
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output, Stdio};
+
+const SOURCE_HEAD: &str = "0123456789abcdef0123456789abcdef01234567";
+const CONTENT_A: &str = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const CONTENT_B: &str = "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+const CONTENT_C: &str = "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
+const CONTEXT_REJECTION: &str = "winsmux: context pack rejected.\n";
+
+fn base_yaml() -> String {
+    include_str!("../../tests/fixtures/workspace-recipes/valid-v1.yaml").to_string()
+}
+
+fn context_pack_policy(max_files: usize, max_bytes: usize, max_evidence_refs: usize) -> String {
+    format!(
+        r#"
+context-packs:
+  review-pack:
+    schema-version: 1
+    include: [code-map, changed-files, tests, evidence-refs]
+    limits:
+      max-files: {max_files}
+      max-bytes: {max_bytes}
+      max-evidence-refs: {max_evidence_refs}
+    privacy:
+      raw-transcript: false
+      prompt-bodies: false
+      secrets: false
+      private-local-paths: false
+"#
+    )
+}
+
+fn make_project(yaml_suffix: &str) -> tempfile::TempDir {
+    let fixture = tempfile::tempdir().expect("create context-pack fixture");
+    fs::write(
+        fixture.path().join(".winsmux.yaml"),
+        format!("{}{}", base_yaml(), yaml_suffix),
+    )
+    .expect("write workspace config");
+    let runtime = fixture.path().join(".winsmux");
+    fs::create_dir_all(&runtime).expect("create runtime fixture");
+    fs::write(
+        runtime.join("provider-capabilities.json"),
+        include_str!("../../tests/fixtures/workspace-recipes/valid-v1.provider-capabilities.json"),
+    )
+    .expect("write provider capabilities");
+    fixture
+}
+
+fn sample_input() -> serde_json::Value {
+    serde_json::json!({
+        "schema_version": 1,
+        "source_head": SOURCE_HEAD,
+        "code_map": [
+            {"path": "core/src/workflow.rs", "content_sha256": CONTENT_A},
+            {"path": "core/src/operator_cli.rs", "content_sha256": CONTENT_B}
+        ],
+        "changed_files": [
+            {"path": "core/src/context_pack.rs", "status": "added", "content_sha256": CONTENT_C}
+        ],
+        "tests": [
+            {"test_id": "context-pack-contract", "outcome": "passed", "evidence_ref": "evidence:task660/tests"}
+        ],
+        "evidence_refs": [
+            "evidence:task660/preedit",
+            "context:task660/source-map"
+        ]
+    })
+}
+
+fn permuted_input() -> serde_json::Value {
+    serde_json::json!({
+        "evidence_refs": [
+            "context:task660/source-map",
+            "evidence:task660/preedit"
+        ],
+        "tests": [
+            {"evidence_ref": "evidence:task660/tests", "outcome": "passed", "test_id": "context-pack-contract"}
+        ],
+        "changed_files": [
+            {"content_sha256": CONTENT_C, "status": "added", "path": "core/src/context_pack.rs"}
+        ],
+        "code_map": [
+            {"content_sha256": CONTENT_B, "path": "core/src/operator_cli.rs"},
+            {"content_sha256": CONTENT_A, "path": "core/src/workflow.rs"}
+        ],
+        "source_head": SOURCE_HEAD,
+        "schema_version": 1
+    })
+}
+
+fn workspace_plan_args(project: &Path) -> Vec<String> {
+    vec![
+        "workspace-plan".into(),
+        "--recipe-id".into(),
+        "bugfix-two-slot".into(),
+        "--workflow-id".into(),
+        "bugfix".into(),
+        "--context-pack-id".into(),
+        "review-pack".into(),
+        "--context-pack-input".into(),
+        "-".into(),
+        "--json".into(),
+        "--project-dir".into(),
+        project.display().to_string(),
+    ]
+}
+
+fn run_binary(args: &[String], stdin_bytes: &[u8]) -> Output {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_winsmux"))
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("run winsmux binary");
+    if let Some(mut stdin) = child.stdin.take() {
+        let _ = stdin.write_all(stdin_bytes);
+    }
+    child.wait_with_output().expect("collect winsmux output")
+}
+
+fn run_pack(project: &Path, input: &serde_json::Value) -> Output {
+    run_binary(
+        &workspace_plan_args(project),
+        serde_json::to_vec(input)
+            .expect("serialize context input")
+            .as_slice(),
+    )
+}
+
+fn parse_success(output: &Output) -> serde_json::Value {
+    assert!(
+        output.status.success(),
+        "workspace-plan public entry must succeed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        output.stderr.is_empty(),
+        "accepted outcome must have empty stderr"
+    );
+    serde_json::from_slice(&output.stdout).expect("write_json must emit one JSON document")
+}
+
+fn sha256(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    format!("sha256:{:x}", hasher.finalize())
+}
+
+fn snapshot_tree(root: &Path) -> Vec<(String, Vec<u8>)> {
+    fn collect(root: &Path, current: &Path, files: &mut Vec<(String, Vec<u8>)>) {
+        let mut entries = fs::read_dir(current)
+            .expect("read fixture tree")
+            .map(|entry| entry.expect("read fixture entry"))
+            .collect::<Vec<_>>();
+        entries.sort_by_key(|entry| entry.file_name());
+        for entry in entries {
+            let path = entry.path();
+            if path.is_dir() {
+                collect(root, &path, files);
+            } else {
+                let relative = path
+                    .strip_prefix(root)
+                    .expect("fixture path is beneath root")
+                    .to_string_lossy()
+                    .replace('\\', "/");
+                files.push((relative, fs::read(path).expect("read fixture file")));
+            }
+        }
+    }
+
+    let mut files = Vec::new();
+    collect(root, root, &mut files);
+    files
+}
+
+fn assert_rejected(output: &Output, before: &[(String, Vec<u8>)], project: &Path) {
+    assert!(!output.status.success(), "invalid context pack must reject");
+    assert!(
+        output.stdout.is_empty(),
+        "rejected outcome must not reach write_json"
+    );
+    assert_eq!(
+        String::from_utf8(output.stderr.clone()).expect("stderr must be UTF-8"),
+        CONTEXT_REJECTION,
+        "outcome_semantics must be one non-reflective typed rejection"
+    );
+    assert_eq!(
+        snapshot_tree(project),
+        before,
+        "protected_sinks and durable_source bytes must remain unchanged"
+    );
+}
+
+#[test]
+fn cp01_public_preview_is_deterministic_and_side_effect_free() {
+    let fixture = make_project(&context_pack_policy(100, 262_144, 50));
+    let before = snapshot_tree(fixture.path());
+    let first = parse_success(&run_pack(fixture.path(), &sample_input()));
+    let second = parse_success(&run_pack(fixture.path(), &permuted_input()));
+    let first_pack = &first["context_pack"];
+    let second_pack = &second["context_pack"];
+    assert_eq!(
+        first_pack["canonical_json"], second_pack["canonical_json"],
+        "content_identity must ignore input ordering"
+    );
+    assert_eq!(
+        first_pack["digest"], second_pack["digest"],
+        "authority_producer must derive one digest from canonical bytes"
+    );
+    let canonical = first_pack["canonical_json"]
+        .as_str()
+        .expect("canonical_json must be a string");
+    assert_eq!(
+        first_pack["byte_count"],
+        canonical.as_bytes().len(),
+        "consumer must report exact UTF-8 byte length"
+    );
+    assert_eq!(
+        first_pack["digest"],
+        sha256(canonical.as_bytes()),
+        "digest must bind exact canonical bytes"
+    );
+    assert_eq!(
+        snapshot_tree(fixture.path()),
+        before,
+        "transport_liveness preview must not mutate project or runtime state"
+    );
+}
+
+#[test]
+fn cp02_count_limits_report_exact_group_omissions() {
+    let fixture = make_project(&context_pack_policy(2, 262_144, 2));
+    let mut input = sample_input();
+    input["changed_files"] = serde_json::json!([
+        {"path": "core/src/a.rs", "status": "modified", "content_sha256": CONTENT_A},
+        {"path": "core/src/b.rs", "status": "modified", "content_sha256": CONTENT_B}
+    ]);
+    input["tests"] = serde_json::json!([
+        {"test_id": "alpha-test", "outcome": "passed", "evidence_ref": "evidence:task660/alpha"},
+        {"test_id": "beta-test", "outcome": "passed", "evidence_ref": "evidence:task660/beta"}
+    ]);
+    let before = snapshot_tree(fixture.path());
+    let payload = parse_success(&run_pack(fixture.path(), &input));
+    let canonical: serde_json::Value = serde_json::from_str(
+        payload["context_pack"]["canonical_json"]
+            .as_str()
+            .expect("canonical body"),
+    )
+    .expect("canonical body JSON");
+    assert_eq!(
+        canonical["groups"]["code_map"]
+            .as_array()
+            .expect("code_map group")
+            .len()
+            + canonical["groups"]["changed_files"]
+                .as_array()
+                .expect("changed_files group")
+                .len(),
+        2,
+        "max_files must count both path-bearing groups"
+    );
+    assert_eq!(
+        canonical["omissions"]["changed_files"], 2,
+        "postcondition must identify omitted changed files"
+    );
+    assert_eq!(
+        canonical["omissions"]["evidence_refs"], 2,
+        "postcondition must identify omitted top-level refs"
+    );
+    assert_eq!(
+        canonical["omissions"]["omitted_by_bytes"], 0,
+        "count-only overflow must not be attributed to byte pressure"
+    );
+    assert_eq!(
+        snapshot_tree(fixture.path()),
+        before,
+        "count bounding leaves unrelated_state unchanged"
+    );
+}
+
+#[test]
+fn cp03_byte_limit_uses_deterministic_reverse_group_reduction() {
+    let fixture = make_project(&context_pack_policy(100, 900, 50));
+    let mut input = sample_input();
+    input["evidence_refs"] = serde_json::json!([
+        "evidence:task660/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "evidence:task660/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "evidence:task660/cccccccccccccccccccccccccccccccccccccccc"
+    ]);
+    let first = parse_success(&run_pack(fixture.path(), &input));
+    let second = parse_success(&run_pack(fixture.path(), &input));
+    let pack = &first["context_pack"];
+    let canonical: serde_json::Value =
+        serde_json::from_str(pack["canonical_json"].as_str().expect("canonical body"))
+            .expect("canonical JSON");
+    assert!(
+        pack["byte_count"].as_u64().expect("byte count") <= 900,
+        "max_bytes must bound emitted canonical bytes"
+    );
+    assert!(
+        canonical["omissions"]["omitted_by_bytes"]
+            .as_u64()
+            .expect("byte omission count")
+            > 0,
+        "byte pressure must be explicit"
+    );
+    assert_eq!(
+        first["context_pack"], second["context_pack"],
+        "reverse group reduction must be deterministic"
+    );
+    assert_eq!(
+        pack["digest"],
+        sha256(pack["canonical_json"].as_str().unwrap().as_bytes()),
+        "protected sink digest must match reduced body"
+    );
+}
+
+#[test]
+#[cfg(windows)]
+fn cp04_metadata_only_manifest_round_trips_across_powershell_and_rust() {
+    let fixture = make_project(&context_pack_policy(100, 262_144, 50));
+    let payload = parse_success(&run_pack(fixture.path(), &sample_input()));
+    let yaml =
+        render_manifest_with_powershell(fixture.path(), &payload, "context-packs/review-pack.json");
+    assert!(
+        !yaml.contains("canonical_json")
+            && !yaml.contains("core/src/workflow.rs")
+            && !yaml.contains("prompt")
+            && !yaml.contains("transcript"),
+        "manifest protected sink must contain metadata only"
+    );
+    assert!(
+        yaml.contains("context_packs:") && yaml.contains("durable_ref:"),
+        "New-WinsmuxDeclarativeWorkspaceProjection must materialize bounded metadata"
+    );
+    fs::write(fixture.path().join(".winsmux").join("manifest.yaml"), yaml)
+        .expect("write generated manifest fixture");
+    let args = vec![
+        "status".into(),
+        "--json".into(),
+        "--project-dir".into(),
+        fixture.path().display().to_string(),
+    ];
+    let output = run_binary(&args, b"");
+    assert!(
+        output.status.success(),
+        "WinsmuxManifest::from_yaml and LedgerSnapshot must consume metadata: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_slice::<serde_json::Value>(&output.stdout)
+        .expect("Rust public status output must remain valid JSON");
+}
+
+#[test]
+fn cp05_unselected_or_absent_context_pack_preserves_legacy_bytes() {
+    let legacy = make_project("");
+    let configured = make_project(&context_pack_policy(100, 262_144, 50));
+    let legacy_args = |project: &Path| {
+        vec![
+            "workspace-plan".into(),
+            "--recipe-id".into(),
+            "bugfix-two-slot".into(),
+            "--workflow-id".into(),
+            "bugfix".into(),
+            "--json".into(),
+            "--project-dir".into(),
+            project.display().to_string(),
+        ]
+    };
+    let before = snapshot_tree(configured.path());
+    let baseline = run_binary(&legacy_args(legacy.path()), b"");
+    let unselected = run_binary(
+        &legacy_args(configured.path()),
+        br#"{"raw_transcript":"must-not-be-read"}"#,
+    );
+    assert!(baseline.status.success() && unselected.status.success());
+    assert_eq!(
+        baseline.stdout, unselected.stdout,
+        "no explicit selector must preserve legacy write_json bytes"
+    );
+    let payload: serde_json::Value =
+        serde_json::from_slice(&unselected.stdout).expect("legacy output JSON");
+    assert!(
+        payload.get("context_pack").is_none(),
+        "unselected policy must remain inert"
+    );
+    assert_eq!(
+        snapshot_tree(configured.path()),
+        before,
+        "legacy path must preserve all project/runtime bytes"
+    );
+    let help = run_binary(&["workspace-plan".into(), "--help".into()], b"");
+    let help_text = String::from_utf8(help.stdout).expect("workspace-plan help must be UTF-8");
+    assert!(
+        help.status.success()
+            && help_text.contains("--context-pack-id <id>")
+            && help_text.contains("--context-pack-input -"),
+        "new opt-in public flags must be discoverable without changing legacy JSON"
+    );
+}
+
+#[test]
+fn cp06_cli_envelope_rejects_unpaired_duplicate_nonstdin_and_oversized_input() {
+    let fixture = make_project(&context_pack_policy(100, 262_144, 50));
+    let before = snapshot_tree(fixture.path());
+    let project = fixture.path().display().to_string();
+    let cases = [
+        vec![
+            "workspace-plan".into(),
+            "--recipe-id".into(),
+            "bugfix-two-slot".into(),
+            "--context-pack-id".into(),
+            "review-pack".into(),
+            "--json".into(),
+            "--project-dir".into(),
+            project.clone(),
+        ],
+        vec![
+            "workspace-plan".into(),
+            "--recipe-id".into(),
+            "bugfix-two-slot".into(),
+            "--context-pack-input".into(),
+            "-".into(),
+            "--json".into(),
+            "--project-dir".into(),
+            project.clone(),
+        ],
+        vec![
+            "workspace-plan".into(),
+            "--recipe-id".into(),
+            "bugfix-two-slot".into(),
+            "--context-pack-id".into(),
+            "review-pack".into(),
+            "--context-pack-id".into(),
+            "review-pack".into(),
+            "--context-pack-input".into(),
+            "-".into(),
+            "--json".into(),
+            "--project-dir".into(),
+            project.clone(),
+        ],
+        vec![
+            "workspace-plan".into(),
+            "--recipe-id".into(),
+            "bugfix-two-slot".into(),
+            "--context-pack-id".into(),
+            "review-pack".into(),
+            "--context-pack-input".into(),
+            "input.json".into(),
+            "--json".into(),
+            "--project-dir".into(),
+            project,
+        ],
+    ];
+    for args in cases {
+        assert_rejected(&run_binary(&args, b"{}"), &before, fixture.path());
+    }
+    let oversized = vec![b'x'; 4 * 1024 * 1024 + 1];
+    assert_rejected(
+        &run_binary(&workspace_plan_args(fixture.path()), &oversized),
+        &before,
+        fixture.path(),
+    );
+}
+
+#[test]
+fn cp07_policy_schema_and_privacy_fail_closed_without_reflection() {
+    let cases = [
+        "    schema-version: 2\n    include: [code-map]\n",
+        "    schema-version: 1\n    include: [code-map, code-map]\n",
+        "    schema-version: 1\n    include: [code-map]\n    limits:\n      max-files: 0\n",
+        "    schema-version: 1\n    include: [code-map]\n    limits:\n      max-bytes: 1048577\n",
+        "    schema-version: 1\n    include: [code-map]\n    privacy:\n      secrets: true\n",
+        "    schema-version: 1\n    include: [code-map]\n    private-marker: secret-marker\n",
+        "    schema-version: 1\n    include: [code-map]\n    privacy:\n      secret-marker: false\n",
+    ];
+    for body in cases {
+        let suffix = format!("\ncontext-packs:\n  review-pack:\n{body}");
+        let fixture = make_project(&suffix);
+        let before = snapshot_tree(fixture.path());
+        let output = run_pack(fixture.path(), &sample_input());
+        assert_rejected(&output, &before, fixture.path());
+        assert!(
+            !String::from_utf8_lossy(&output.stderr).contains("secret-marker"),
+            "policy rejection must not reflect private input"
+        );
+    }
+}
+
+#[test]
+fn cp08_closed_input_schema_rejects_raw_or_oversized_fields() {
+    let fixture = make_project(&context_pack_policy(100, 262_144, 50));
+    let before = snapshot_tree(fixture.path());
+    let cases = [
+        (
+            "raw_transcript",
+            serde_json::json!("secret-marker-transcript"),
+        ),
+        ("prompt_body", serde_json::json!("secret-marker-prompt")),
+        ("secret", serde_json::json!("secret-marker-value")),
+        ("provider_metadata", serde_json::json!({"hidden": true})),
+        ("body", serde_json::json!("secret-marker-body")),
+    ];
+    for (key, value) in cases {
+        let mut input = sample_input();
+        input
+            .as_object_mut()
+            .expect("sample input object")
+            .insert(key.into(), value);
+        let output = run_pack(fixture.path(), &input);
+        assert_rejected(&output, &before, fixture.path());
+        assert!(
+            !String::from_utf8_lossy(&output.stderr).contains("secret-marker"),
+            "closed schema must not reflect rejected values"
+        );
+    }
+    let mut unsupported = sample_input();
+    unsupported["schema_version"] = serde_json::json!(2);
+    assert_rejected(
+        &run_pack(fixture.path(), &unsupported),
+        &before,
+        fixture.path(),
+    );
+    let mut oversized = sample_input();
+    oversized["tests"][0]["test_id"] = serde_json::json!("x".repeat(257));
+    assert_rejected(
+        &run_pack(fixture.path(), &oversized),
+        &before,
+        fixture.path(),
+    );
+}
+
+#[test]
+fn cp09_private_or_escaping_paths_never_reach_output() {
+    let fixture = make_project(&context_pack_policy(100, 262_144, 50));
+    let before = snapshot_tree(fixture.path());
+    let paths = [
+        "C:/Users/private/file.rs",
+        "C:\\Users\\private\\file.rs",
+        "/home/private/file.rs",
+        "../private/file.rs",
+        "core/../private/file.rs",
+        ".git/config",
+        ".winsmux/private.json",
+        "//server/share/file.rs",
+        "core/src/\nprivate.rs",
+    ];
+    for path in paths {
+        let mut input = sample_input();
+        input["code_map"][0]["path"] = serde_json::json!(path);
+        let output = run_pack(fixture.path(), &input);
+        assert_rejected(&output, &before, fixture.path());
+        assert!(
+            !String::from_utf8_lossy(&output.stderr).contains("private"),
+            "private path must not be reflected"
+        );
+    }
+}
+
+#[test]
+fn cp10_unattributed_or_invalid_identity_fields_fail_closed() {
+    let fixture = make_project(&context_pack_policy(100, 262_144, 50));
+    let before = snapshot_tree(fixture.path());
+    let mut cases = Vec::new();
+    let mut input = sample_input();
+    input["source_head"] = serde_json::json!("ABC");
+    cases.push(input);
+    let mut input = sample_input();
+    input["code_map"][0]["content_sha256"] = serde_json::json!("sha256:ABC");
+    cases.push(input);
+    let mut input = sample_input();
+    input["changed_files"][0]["status"] = serde_json::json!("copied");
+    cases.push(input);
+    let mut input = sample_input();
+    input["tests"][0]["outcome"] = serde_json::json!("success");
+    cases.push(input);
+    let mut input = sample_input();
+    input["tests"][0]["test_id"] = serde_json::json!("Invalid Test");
+    cases.push(input);
+    let mut input = sample_input();
+    input["evidence_refs"][0] = serde_json::json!("file:C:/private");
+    cases.push(input);
+    let mut input = sample_input();
+    input["tests"][0]
+        .as_object_mut()
+        .expect("test entry")
+        .remove("evidence_ref");
+    cases.push(input);
+    for input in cases {
+        assert_rejected(&run_pack(fixture.path(), &input), &before, fixture.path());
+    }
+}
+
+#[test]
+fn cp11_duplicate_canonical_identities_are_rejected_not_deduplicated() {
+    let fixture = make_project(&context_pack_policy(100, 262_144, 50));
+    let before = snapshot_tree(fixture.path());
+    let mut cases = Vec::new();
+    let mut input = sample_input();
+    let duplicate = input["code_map"][0].clone();
+    input["code_map"].as_array_mut().unwrap().push(duplicate);
+    cases.push(("exact code_map identity must reject", input));
+    let mut input = sample_input();
+    let duplicate = input["changed_files"][0].clone();
+    input["changed_files"]
+        .as_array_mut()
+        .unwrap()
+        .push(duplicate);
+    cases.push(("exact changed_files identity must reject", input));
+    let mut input = sample_input();
+    let duplicate = input["tests"][0].clone();
+    input["tests"].as_array_mut().unwrap().push(duplicate);
+    cases.push(("exact test identity must reject", input));
+    let mut input = sample_input();
+    let duplicate = input["evidence_refs"][0].clone();
+    input["evidence_refs"]
+        .as_array_mut()
+        .unwrap()
+        .push(duplicate);
+    cases.push(("exact evidence identity must reject", input));
+    let mut input = sample_input();
+    input["code_map"]
+        .as_array_mut()
+        .unwrap()
+        .push(serde_json::json!({
+            "path": "Core/src/workflow.rs",
+            "content_sha256": CONTENT_C
+        }));
+    cases.push(("case-folded code_map identity must reject", input));
+    let mut input = sample_input();
+    input["changed_files"]
+        .as_array_mut()
+        .unwrap()
+        .push(serde_json::json!({
+            "path": "Core/src/context_pack.rs",
+            "status": "deleted",
+            "content_sha256": CONTENT_B
+        }));
+    cases.push(("case-folded changed_files identity must reject", input));
+    for (identity_invariant, input) in cases {
+        let output = run_pack(fixture.path(), &input);
+        assert!(
+            !output.status.success(),
+            "{identity_invariant}: one Win32 identity cannot carry conflicting metadata"
+        );
+        assert_rejected(&output, &before, fixture.path());
+    }
+}
+
+#[test]
+fn cp12_metadata_only_body_that_cannot_fit_rejects_without_partial_output() {
+    let fixture = make_project(&context_pack_policy(100, 1, 50));
+    let before = snapshot_tree(fixture.path());
+    let output = run_pack(fixture.path(), &sample_input());
+    assert_rejected(&output, &before, fixture.path());
+}
+
+#[test]
+#[cfg(windows)]
+fn cp13_manifest_rejects_raw_fields_in_both_runtime_owners() {
+    let fixture = make_project(&context_pack_policy(100, 262_144, 50));
+    let mut plan = serde_json::json!({
+        "config_fingerprint": CONTENT_A,
+        "recipe_id": "bugfix-two-slot",
+        "resolved_bindings": {},
+        "context_pack": {
+            "manifest_projection": {
+                "pack_id": "review-pack",
+                "schema_version": 1,
+                "digest": CONTENT_B,
+                "byte_count": 100,
+                "source_head": SOURCE_HEAD,
+                "policy_fingerprint": CONTENT_C,
+                "limits": {"max_files": 100, "max_bytes": 262144, "max_evidence_refs": 50},
+                "omissions": {"code_map": 0, "changed_files": 0, "tests": 0, "evidence_refs": 0, "omitted_by_bytes": 0},
+                "privacy_result": "pass"
+            }
+        }
+    });
+    plan["context_pack"]["manifest_projection"]["canonical_json"] =
+        serde_json::json!("secret-marker-body");
+    let output = render_manifest_process(fixture.path(), &plan, "context-packs/review-pack.json");
+    assert!(
+        !output.status.success(),
+        "PowerShell authority must reject unknown raw metadata"
+    );
+    assert!(
+        output.stdout.is_empty(),
+        "Save-WinsmuxManifest must not run"
+    );
+    assert!(
+        !String::from_utf8_lossy(&output.stderr).contains("secret-marker"),
+        "PowerShell rejection must not reflect raw body"
+    );
+
+    let invalid_yaml = format!(
+        r#"version: 1
+session:
+  name: test
+  project_dir: ''
+  started: ''
+  ended: ''
+panes: {{}}
+declarative_workspace:
+  schema_version: 1
+  config_fingerprint: {CONTENT_A}
+  recipe_id: bugfix-two-slot
+  resolved_bindings: {{}}
+  context_packs:
+    review-pack:
+      schema_version: 1
+      digest: {CONTENT_B}
+      byte_count: 100
+      source_head: {SOURCE_HEAD}
+      policy_fingerprint: {CONTENT_C}
+      limits:
+        max_files: 100
+        max_bytes: 262144
+        max_evidence_refs: 50
+      omissions:
+        code_map: 0
+        changed_files: 0
+        tests: 0
+        evidence_refs: 0
+        omitted_by_bytes: 0
+      privacy_result: pass
+      durable_ref: context-packs/review-pack.json
+      raw_transcript: secret-marker-transcript
+"#
+    );
+    fs::write(
+        fixture.path().join(".winsmux").join("manifest.yaml"),
+        invalid_yaml,
+    )
+    .expect("write invalid manifest");
+    let before = fs::read(fixture.path().join(".winsmux").join("manifest.yaml"))
+        .expect("read invalid manifest");
+    let args = vec![
+        "status".into(),
+        "--json".into(),
+        "--project-dir".into(),
+        fixture.path().display().to_string(),
+    ];
+    let status = run_binary(&args, b"");
+    assert!(
+        !status.status.success(),
+        "Rust manifest consumer must reject"
+    );
+    assert!(
+        status.stdout.is_empty(),
+        "invalid manifest must not produce partial status"
+    );
+    assert!(
+        !String::from_utf8_lossy(&status.stderr).contains("secret-marker"),
+        "Rust manifest rejection must not reflect raw value"
+    );
+    assert_eq!(
+        fs::read(fixture.path().join(".winsmux").join("manifest.yaml")).unwrap(),
+        before,
+        "preexisting manifest bytes remain unchanged"
+    );
+}
+
+#[test]
+fn cp14_win32_repository_path_aliases_fail_closed() {
+    let fixture = make_project(&context_pack_policy(100, 262_144, 50));
+    let before = snapshot_tree(fixture.path());
+    let cases = [
+        ("code_map", "core/.git./config"),
+        ("changed_files", "core/.winsmux./secret"),
+        ("code_map", "core/NUL.txt"),
+        ("changed_files", "reports/COM1.log"),
+        ("code_map", "reports/public."),
+    ];
+    for (group, path) in cases {
+        let mut input = sample_input();
+        input[group][0]["path"] = serde_json::json!(path);
+        assert_rejected(&run_pack(fixture.path(), &input), &before, fixture.path());
+    }
+    assert_eq!(
+        snapshot_tree(fixture.path()),
+        before,
+        "Win32 repository path rejection must preserve project and runtime bytes"
+    );
+}
+
+#[test]
+fn cp15_win32_evidence_ref_aliases_fail_closed() {
+    let fixture = make_project(&context_pack_policy(100, 262_144, 50));
+    let before = snapshot_tree(fixture.path());
+    let cases = [
+        ("test", "evidence:core/.git./config"),
+        ("test", "context:core/.winsmux./secret"),
+        ("top", "context-packs/nul.txt"),
+        ("top", "evidence:reports/lpt1.log"),
+        ("top", "context:reports/public."),
+    ];
+    for (field, evidence_ref) in cases {
+        let mut input = sample_input();
+        if field == "test" {
+            input["tests"][0]["evidence_ref"] = serde_json::json!(evidence_ref);
+        } else {
+            input["evidence_refs"][0] = serde_json::json!(evidence_ref);
+        }
+        assert_rejected(&run_pack(fixture.path(), &input), &before, fixture.path());
+    }
+    assert_eq!(
+        snapshot_tree(fixture.path()),
+        before,
+        "Win32 evidence ref rejection must preserve project and runtime bytes"
+    );
+}
+
+#[test]
+#[cfg(windows)]
+fn cp16_powershell_public_refs_share_one_segment_identity_authority() {
+    let fixture = make_project(&context_pack_policy(100, 262_144, 50));
+    let plan = serde_json::json!({
+        "config_fingerprint": CONTENT_A,
+        "recipe_id": "bugfix-two-slot",
+        "resolved_bindings": {},
+        "context_pack": {
+            "manifest_projection": {
+                "pack_id": "review-pack",
+                "schema_version": 1,
+                "digest": CONTENT_B,
+                "byte_count": 100,
+                "source_head": SOURCE_HEAD,
+                "policy_fingerprint": CONTENT_C,
+                "limits": {"max_files": 100, "max_bytes": 262144, "max_evidence_refs": 50},
+                "omissions": {"code_map": 0, "changed_files": 0, "tests": 0, "evidence_refs": 0, "omitted_by_bytes": 0},
+                "privacy_result": "pass"
+            }
+        }
+    });
+    let runtime = fixture.path().join(".winsmux");
+    let before = snapshot_tree(&runtime);
+    let cases = [
+        (
+            "PowerShell DryRunPlanRef private alias must reject",
+            "evidence:review/.winsmux./secret",
+            "context-packs/review-pack.json",
+        ),
+        (
+            "PowerShell DryRunPlanRef dot segment must reject",
+            "evidence:review/./plan.json",
+            "context-packs/review-pack.json",
+        ),
+        (
+            "PowerShell DryRunPlanRef empty segment must reject",
+            "evidence:review//plan.json",
+            "context-packs/review-pack.json",
+        ),
+        (
+            "PowerShell DryRunPlanRef reserved device must reject",
+            "evidence:review/nul.txt",
+            "context-packs/review-pack.json",
+        ),
+        (
+            "PowerShell DryRunPlanRef trailing period must reject",
+            "evidence:review/public.",
+            "context-packs/review-pack.json",
+        ),
+        (
+            "PowerShell ContextPackRef private alias must reject",
+            "evidence:workspace-plan.json",
+            "context-packs/review-pack/.winsmux./secret",
+        ),
+        (
+            "PowerShell ContextPackRef dot segment must reject",
+            "evidence:workspace-plan.json",
+            "context-packs/review-pack/./plan.json",
+        ),
+        (
+            "PowerShell ContextPackRef empty segment must reject",
+            "evidence:workspace-plan.json",
+            "context-packs/review-pack//plan.json",
+        ),
+        (
+            "PowerShell ContextPackRef reserved device must reject",
+            "evidence:workspace-plan.json",
+            "context-packs/review-pack/lpt1.log",
+        ),
+        (
+            "PowerShell ContextPackRef trailing period must reject",
+            "evidence:workspace-plan.json",
+            "context-packs/review-pack/public.",
+        ),
+    ];
+    for (segment_invariant, dry_run_ref, durable_ref) in cases {
+        let output =
+            render_manifest_process_with_refs(fixture.path(), &plan, dry_run_ref, durable_ref);
+        assert!(!output.status.success(), "{segment_invariant}");
+        assert!(
+            output.stdout.is_empty(),
+            "rejection must occur before projection or manifest serialization"
+        );
+        assert!(
+            !String::from_utf8_lossy(&output.stderr).contains(dry_run_ref)
+                && !String::from_utf8_lossy(&output.stderr).contains(durable_ref),
+            "PowerShell public reference rejection must not reflect an unsafe value"
+        );
+        assert_eq!(
+            snapshot_tree(&runtime),
+            before,
+            "PowerShell rejection must preserve runtime bytes"
+        );
+    }
+}
+
+#[test]
+#[cfg(windows)]
+fn cp17_rust_manifest_public_refs_share_one_segment_identity_authority() {
+    let fixture = make_project(&context_pack_policy(100, 262_144, 50));
+    let manifest_path = fixture.path().join(".winsmux").join("manifest.yaml");
+    let args = vec![
+        "status".into(),
+        "--json".into(),
+        "--project-dir".into(),
+        fixture.path().display().to_string(),
+    ];
+    let cases = [
+        (
+            "Rust dry_run_plan_ref private alias must reject",
+            "evidence:review/.winsmux./secret",
+            "context-packs/review-pack.json",
+        ),
+        (
+            "Rust dry_run_plan_ref dot segment must reject",
+            "evidence:review/./plan.json",
+            "context-packs/review-pack.json",
+        ),
+        (
+            "Rust dry_run_plan_ref empty segment must reject",
+            "evidence:review//plan.json",
+            "context-packs/review-pack.json",
+        ),
+        (
+            "Rust dry_run_plan_ref reserved device must reject",
+            "evidence:review/nul.txt",
+            "context-packs/review-pack.json",
+        ),
+        (
+            "Rust dry_run_plan_ref trailing period must reject",
+            "evidence:review/public.",
+            "context-packs/review-pack.json",
+        ),
+        (
+            "Rust durable_ref private alias must reject",
+            "evidence:workspace-plan.json",
+            "context-packs/review-pack/.winsmux./secret",
+        ),
+        (
+            "Rust durable_ref dot segment must reject",
+            "evidence:workspace-plan.json",
+            "context-packs/review-pack/./plan.json",
+        ),
+        (
+            "Rust durable_ref empty segment must reject",
+            "evidence:workspace-plan.json",
+            "context-packs/review-pack//plan.json",
+        ),
+        (
+            "Rust durable_ref reserved device must reject",
+            "evidence:workspace-plan.json",
+            "context-packs/review-pack/lpt1.log",
+        ),
+        (
+            "Rust durable_ref trailing period must reject",
+            "evidence:workspace-plan.json",
+            "context-packs/review-pack/public.",
+        ),
+    ];
+    for (segment_invariant, dry_run_ref, durable_ref) in cases {
+        let yaml = format!(
+            r#"version: 1
+session:
+  name: test
+  project_dir: ''
+  started: ''
+  ended: ''
+panes: {{}}
+declarative_workspace:
+  schema_version: 1
+  config_fingerprint: {CONTENT_A}
+  recipe_id: bugfix-two-slot
+  resolved_bindings: {{}}
+  dry_run_plan_ref: {dry_run_ref}
+  context_packs:
+    review-pack:
+      schema_version: 1
+      digest: {CONTENT_B}
+      byte_count: 100
+      source_head: {SOURCE_HEAD}
+      policy_fingerprint: {CONTENT_C}
+      limits:
+        max_files: 100
+        max_bytes: 262144
+        max_evidence_refs: 50
+      omissions:
+        code_map: 0
+        changed_files: 0
+        tests: 0
+        evidence_refs: 0
+        omitted_by_bytes: 0
+      privacy_result: pass
+      durable_ref: {durable_ref}
+"#
+        );
+        fs::write(&manifest_path, yaml).expect("write Win32 alias manifest");
+        let before = fs::read(&manifest_path).expect("read Win32 alias manifest");
+        let output = run_binary(&args, b"");
+        assert!(!output.status.success(), "{segment_invariant}");
+        assert!(
+            output.stdout.is_empty(),
+            "invalid durable ref must not produce a public read payload"
+        );
+        assert!(
+            !String::from_utf8_lossy(&output.stderr).contains(dry_run_ref)
+                && !String::from_utf8_lossy(&output.stderr).contains(durable_ref),
+            "Rust public reference rejection must not reflect an unsafe value"
+        );
+        assert_eq!(
+            fs::read(&manifest_path).unwrap(),
+            before,
+            "Rust manifest rejection must preserve durable bytes"
+        );
+    }
+}
+
+#[test]
+#[cfg(windows)]
+fn cp18_rust_context_pack_path_fields_enforce_exact_total_and_component_byte_edges() {
+    let fixture = make_project(&context_pack_policy(100, 262_144, 50));
+    let before = snapshot_tree(fixture.path());
+
+    let repo_edge = "a".repeat(240);
+    let repo_over = "a".repeat(241);
+    assert_eq!(
+        repo_edge.as_bytes().len(),
+        240,
+        "PF01/PF02 exact total and component byte edge must be 240"
+    );
+    for field in ["code_map", "changed_files"] {
+        let mut input = sample_input();
+        input[field][0]["path"] = serde_json::json!(repo_edge);
+        parse_success(&run_pack(fixture.path(), &input));
+        assert_eq!(
+            snapshot_tree(fixture.path()),
+            before,
+            "PF01/PF02 exact path edge must preserve state"
+        );
+
+        let mut input = sample_input();
+        input[field][0]["path"] = serde_json::json!(repo_over);
+        let output = run_pack(fixture.path(), &input);
+        assert!(
+            !output.status.success(),
+            "PF01/PF02 total and component byte edge+1 must reject"
+        );
+        assert_rejected(&output, &before, fixture.path());
+    }
+
+    let evidence_component_edge = format!("evidence:{}", "a".repeat(240));
+    let evidence_component_over = format!("evidence:{}", "a".repeat(241));
+    let evidence_total_edge = format!("evidence:{}/{}", "a".repeat(240), "b".repeat(6));
+    let evidence_total_over = format!("evidence:{}/{}", "a".repeat(240), "b".repeat(7));
+    assert_eq!(
+        evidence_total_edge.as_bytes().len(),
+        256,
+        "PF03/PF04 exact total byte edge must be 256"
+    );
+    assert_eq!(
+        evidence_component_edge
+            .strip_prefix("evidence:")
+            .unwrap()
+            .split('/')
+            .map(str::len)
+            .max(),
+        Some(240),
+        "PF03/PF04 exact component byte edge must be 240"
+    );
+    let evidence_cases = [
+        (
+            &evidence_component_edge,
+            true,
+            "PF03/PF04 exact component byte edge must accept",
+        ),
+        (
+            &evidence_component_over,
+            false,
+            "PF03/PF04 component byte edge+1 must reject",
+        ),
+        (
+            &evidence_total_edge,
+            true,
+            "PF03/PF04 exact total byte edge must accept",
+        ),
+        (
+            &evidence_total_over,
+            false,
+            "PF03/PF04 total byte edge+1 must reject",
+        ),
+    ];
+    for field in ["test", "top"] {
+        for (evidence_ref, should_accept, boundary_invariant) in evidence_cases {
+            let mut input = sample_input();
+            if field == "test" {
+                input["tests"][0]["evidence_ref"] = serde_json::json!(evidence_ref);
+            } else {
+                input["evidence_refs"][0] = serde_json::json!(evidence_ref);
+            }
+            let output = run_pack(fixture.path(), &input);
+            if should_accept {
+                parse_success(&output);
+                assert_eq!(
+                    snapshot_tree(fixture.path()),
+                    before,
+                    "{boundary_invariant}: accepted preview must preserve state"
+                );
+            } else {
+                assert!(!output.status.success(), "{boundary_invariant}");
+                assert_rejected(&output, &before, fixture.path());
+            }
+        }
+    }
+}
+
+#[test]
+#[cfg(windows)]
+fn cp19_powershell_public_refs_enforce_exact_total_and_component_byte_edges() {
+    let fixture = make_project(&context_pack_policy(100, 262_144, 50));
+    let evidence_component_edge = format!("evidence:{}", "a".repeat(240));
+    let evidence_component_over = format!("evidence:{}", "a".repeat(241));
+    let evidence_total_edge = format!("evidence:{}/{}", "a".repeat(240), "b".repeat(6));
+    let evidence_total_over = format!("evidence:{}/{}", "a".repeat(240), "b".repeat(7));
+    let plan = serde_json::json!({
+        "config_fingerprint": CONTENT_A,
+        "recipe_id": "bugfix-two-slot",
+        "resolved_bindings": {},
+        "context_pack": {
+            "manifest_projection": {
+                "pack_id": "review-pack",
+                "schema_version": 1,
+                "digest": CONTENT_B,
+                "byte_count": 100,
+                "source_head": SOURCE_HEAD,
+                "policy_fingerprint": CONTENT_C,
+                "limits": {"max_files": 100, "max_bytes": 262144, "max_evidence_refs": 50},
+                "omissions": {"code_map": 0, "changed_files": 0, "tests": 0, "evidence_refs": 0, "omitted_by_bytes": 0},
+                "privacy_result": "pass"
+            }
+        }
+    });
+    let context_component_edge = format!("context-packs/{}", "a".repeat(240));
+    let context_component_over = format!("context-packs/{}", "a".repeat(241));
+    let context_total_edge = format!("context-packs/{}/b", "a".repeat(240));
+    let context_total_over = format!("context-packs/{}/bb", "a".repeat(240));
+    assert_eq!(
+        context_total_edge.as_bytes().len(),
+        256,
+        "PF06 exact total byte edge must be 256"
+    );
+    assert_eq!(
+        context_component_edge
+            .strip_prefix("context-packs/")
+            .unwrap()
+            .split('/')
+            .map(str::len)
+            .max(),
+        Some(240),
+        "PF06 exact component byte edge must be 240"
+    );
+    let powershell_cases = [
+        (
+            evidence_component_edge.as_str(),
+            "context-packs/review-pack.json",
+            true,
+            "PF05 exact component byte edge must accept",
+        ),
+        (
+            evidence_component_over.as_str(),
+            "context-packs/review-pack.json",
+            false,
+            "PF05 component byte edge+1 must reject",
+        ),
+        (
+            evidence_total_edge.as_str(),
+            "context-packs/review-pack.json",
+            true,
+            "PF05 exact total byte edge must accept",
+        ),
+        (
+            evidence_total_over.as_str(),
+            "context-packs/review-pack.json",
+            false,
+            "PF05 total byte edge+1 must reject",
+        ),
+        (
+            "evidence:workspace-plan.json",
+            context_component_edge.as_str(),
+            true,
+            "PF06 exact component byte edge must accept",
+        ),
+        (
+            "evidence:workspace-plan.json",
+            context_component_over.as_str(),
+            false,
+            "PF06 component byte edge+1 must reject",
+        ),
+        (
+            "evidence:workspace-plan.json",
+            context_total_edge.as_str(),
+            true,
+            "PF06 exact total byte edge must accept",
+        ),
+        (
+            "evidence:workspace-plan.json",
+            context_total_over.as_str(),
+            false,
+            "PF06 total byte edge+1 must reject",
+        ),
+    ];
+    let runtime_before = snapshot_tree(&fixture.path().join(".winsmux"));
+    for (dry_run_ref, durable_ref, should_accept, boundary_invariant) in powershell_cases {
+        let output =
+            render_manifest_process_with_refs(fixture.path(), &plan, dry_run_ref, durable_ref);
+        assert_eq!(
+            snapshot_tree(&fixture.path().join(".winsmux")),
+            runtime_before,
+            "{boundary_invariant}: PowerShell boundary must preserve runtime bytes"
+        );
+        if should_accept {
+            assert!(output.status.success(), "{boundary_invariant}");
+            assert!(
+                !output.stdout.is_empty(),
+                "{boundary_invariant}: accepted projection must be complete"
+            );
+        } else {
+            assert!(!output.status.success(), "{boundary_invariant}");
+            assert!(
+                output.stdout.is_empty(),
+                "{boundary_invariant}: rejected projection must emit no YAML"
+            );
+        }
+    }
+}
+
+#[test]
+#[cfg(windows)]
+fn cp20_rust_manifest_public_refs_enforce_exact_total_and_component_byte_edges() {
+    let fixture = make_project(&context_pack_policy(100, 262_144, 50));
+    let evidence_component_edge = format!("evidence:{}", "a".repeat(240));
+    let evidence_component_over = format!("evidence:{}", "a".repeat(241));
+    let evidence_total_edge = format!("evidence:{}/{}", "a".repeat(240), "b".repeat(6));
+    let evidence_total_over = format!("evidence:{}/{}", "a".repeat(240), "b".repeat(7));
+    let context_component_edge = format!("context-packs/{}", "a".repeat(240));
+    let context_component_over = format!("context-packs/{}", "a".repeat(241));
+    let context_total_edge = format!("context-packs/{}/b", "a".repeat(240));
+    let context_total_over = format!("context-packs/{}/bb", "a".repeat(240));
+    assert_eq!(
+        evidence_total_edge.as_bytes().len(),
+        256,
+        "PF07 exact total byte edge must be 256"
+    );
+    assert_eq!(
+        context_total_edge.as_bytes().len(),
+        256,
+        "PF08 exact total byte edge must be 256"
+    );
+    let manifest_path = fixture.path().join(".winsmux").join("manifest.yaml");
+    let status_args = vec![
+        "status".into(),
+        "--json".into(),
+        "--project-dir".into(),
+        fixture.path().display().to_string(),
+    ];
+    let manifest_cases = [
+        (
+            evidence_component_edge.as_str(),
+            "context-packs/review-pack.json",
+            true,
+            "PF07 exact component byte edge must accept",
+        ),
+        (
+            evidence_component_over.as_str(),
+            "context-packs/review-pack.json",
+            false,
+            "PF07 component byte edge+1 must reject",
+        ),
+        (
+            evidence_total_edge.as_str(),
+            "context-packs/review-pack.json",
+            true,
+            "PF07 exact total byte edge must accept",
+        ),
+        (
+            evidence_total_over.as_str(),
+            "context-packs/review-pack.json",
+            false,
+            "PF07 total byte edge+1 must reject",
+        ),
+        (
+            "evidence:workspace-plan.json",
+            context_component_edge.as_str(),
+            true,
+            "PF08 exact component byte edge must accept",
+        ),
+        (
+            "evidence:workspace-plan.json",
+            context_component_over.as_str(),
+            false,
+            "PF08 component byte edge+1 must reject",
+        ),
+        (
+            "evidence:workspace-plan.json",
+            context_total_edge.as_str(),
+            true,
+            "PF08 exact total byte edge must accept",
+        ),
+        (
+            "evidence:workspace-plan.json",
+            context_total_over.as_str(),
+            false,
+            "PF08 total byte edge+1 must reject",
+        ),
+    ];
+    for (dry_run_ref, durable_ref, should_accept, boundary_invariant) in manifest_cases {
+        let yaml = format!(
+            r#"version: 1
+session:
+  name: test
+  project_dir: ''
+  started: ''
+  ended: ''
+panes: {{}}
+declarative_workspace:
+  schema_version: 1
+  config_fingerprint: {CONTENT_A}
+  recipe_id: bugfix-two-slot
+  resolved_bindings: {{}}
+  dry_run_plan_ref: {dry_run_ref}
+  context_packs:
+    review-pack:
+      schema_version: 1
+      digest: {CONTENT_B}
+      byte_count: 100
+      source_head: {SOURCE_HEAD}
+      policy_fingerprint: {CONTENT_C}
+      limits:
+        max_files: 100
+        max_bytes: 262144
+        max_evidence_refs: 50
+      omissions:
+        code_map: 0
+        changed_files: 0
+        tests: 0
+        evidence_refs: 0
+        omitted_by_bytes: 0
+      privacy_result: pass
+      durable_ref: {durable_ref}
+"#
+        );
+        fs::write(&manifest_path, yaml).expect("write boundary manifest");
+        let manifest_before = fs::read(&manifest_path).expect("read boundary manifest");
+        let output = run_binary(&status_args, b"");
+        assert_eq!(
+            fs::read(&manifest_path).unwrap(),
+            manifest_before,
+            "{boundary_invariant}: Rust manifest read must preserve durable bytes"
+        );
+        if should_accept {
+            assert!(output.status.success(), "{boundary_invariant}");
+            assert!(
+                !output.stdout.is_empty(),
+                "{boundary_invariant}: accepted manifest read must emit one payload"
+            );
+        } else {
+            assert!(!output.status.success(), "{boundary_invariant}");
+            assert!(
+                output.stdout.is_empty(),
+                "{boundary_invariant}: rejected manifest read must emit no payload"
+            );
+        }
+    }
+}
+
+#[cfg(windows)]
+fn render_manifest_with_powershell(
+    project: &Path,
+    plan: &serde_json::Value,
+    durable_ref: &str,
+) -> String {
+    let output = render_manifest_process(project, plan, durable_ref);
+    assert!(
+        output.status.success(),
+        "PowerShell manifest projection failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout).expect("manifest YAML must be UTF-8")
+}
+
+#[cfg(windows)]
+fn render_manifest_process(project: &Path, plan: &serde_json::Value, durable_ref: &str) -> Output {
+    render_manifest_process_with_refs(project, plan, "", durable_ref)
+}
+
+#[cfg(windows)]
+fn render_manifest_process_with_refs(
+    project: &Path,
+    plan: &serde_json::Value,
+    dry_run_ref: &str,
+    durable_ref: &str,
+) -> Output {
+    let plan_path = project.join("task660-plan.json");
+    let script_path = project.join("task660-render.ps1");
+    fs::write(
+        &plan_path,
+        serde_json::to_vec(plan).expect("serialize plan fixture"),
+    )
+    .expect("write plan fixture");
+    let manifest_script = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("core has repository parent")
+        .join("winsmux-core")
+        .join("scripts")
+        .join("manifest.ps1");
+    let script = format!(
+        r#"[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)
+. '{}'
+$plan = Get-Content -Raw -LiteralPath '{}' | ConvertFrom-Json
+$projection = New-WinsmuxDeclarativeWorkspaceProjection -Plan $plan -DryRunPlanRef '{}' -ContextPackRef '{}'
+$manifest = [ordered]@{{
+  version = 1
+  saved_at = '2026-07-26T00:00:00Z'
+  session = [ordered]@{{ name = 'test'; project_dir = ''; started = ''; ended = '' }}
+  panes = [ordered]@{{}}
+  tasks = [ordered]@{{ queued = @(); in_progress = @(); completed = @() }}
+  worktrees = [ordered]@{{}}
+  declarative_workspace = $projection
+}}
+[Console]::Out.Write((ConvertTo-ManifestYaml -Manifest $manifest))
+"#,
+        manifest_script.display().to_string().replace('\'', "''"),
+        plan_path.display().to_string().replace('\'', "''"),
+        dry_run_ref.replace('\'', "''"),
+        durable_ref.replace('\'', "''"),
+    );
+    fs::write(&script_path, script).expect("write PowerShell fixture");
+    Command::new("pwsh")
+        .args(["-NoProfile", "-NonInteractive", "-File"])
+        .arg(&script_path)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("run PowerShell manifest projection")
+}

--- a/docs/project/v03629-declarative-workspace-architecture.md
+++ b/docs/project/v03629-declarative-workspace-architecture.md
@@ -203,10 +203,12 @@ Workflow-level `resume-policy` and `cleanup-policy`, and node-level
 later child tasks. They are not executable TASK-659 fields. TASK-660 does not
 add a workflow field or route/resume authority.
 
-The following context-pack policy is executable through the side-effect-free
-TASK-660 preview entry. It remains inert until explicitly selected and is not
-part of the workflow v1 schema:
+The following marker-delimited context-pack policy is executable byte-for-byte
+through the public, side-effect-free `winsmux workspace-plan` TASK-660 preview.
+It remains inert until explicitly selected and is not part of the workflow v1
+schema:
 
+<!-- TASK660-RUNNABLE-CONTEXT-PACK-V1:START -->
 ```yaml
 context-packs:
   review-pack:
@@ -222,6 +224,7 @@ context-packs:
       secrets: false
       private-local-paths: false
 ```
+<!-- TASK660-RUNNABLE-CONTEXT-PACK-V1:END -->
 
 Normative field rules:
 
@@ -254,10 +257,11 @@ Normative field rules:
 - TASK-660 context-pack `include` values are allowlisted projections. Omitted
   limits use conservative defaults; enabling any privacy escape is rejected.
   The closed input schema accepts only attributable repository-relative
-  identities and safe evidence refs, never free-form content. Every persisted
-  path segment also uses Win32 identity rules: trailing periods or spaces,
-  reserved device basenames (including extensions), and private `.git` or
-  `.winsmux` namespace aliases are rejected before projection.
+  identities and safe evidence refs, never free-form content. Every admitted
+  repository-relative path segment also uses Win32 identity rules: trailing
+  periods or spaces, reserved device basenames (including extensions), and
+  private `.git` or `.winsmux` namespace aliases are rejected before
+  projection.
 
 Recipe and context-pack selection are explicit. The preview entry point is
 `winsmux workspace-plan --recipe-id <id> [--workflow-id <id>]
@@ -304,7 +308,6 @@ workflow_runs:
         checkpoint_ref: checkpoint:...
     cleanup_journal: []
     rollback_state: not_requested
-    context_pack_refs: [context-pack:...]
 ```
 
 The PowerShell writer in `winsmux-core/scripts/manifest.ps1` emits this fixed
@@ -321,9 +324,8 @@ Runtime values are projections, not re-parsed intent:
 - ledger events receive state transitions and attributable evidence refs;
 - TASK-660 exposes a read-only context-pack preview, but schema version 1 does
   not persist that result or connect it to Context Capsule, Checkpoint package,
-  routing, or resume. TASK-662 owns any future verified cross-runtime
-  persistence contract and must bind one typed consumer to the exact canonical
-  bytes before adding a runnable manifest field.
+  routing, or resume. No current declarative-workspace or workflow-run manifest
+  field carries the preview result.
 
 ## 4. Resumable workflow state model
 
@@ -363,18 +365,15 @@ The repository context pack is a bounded projection layered on the context
 budget contract in `core/src/ledger.rs`. It is not a transcript summary and is
 not a replacement for Context Capsule v1 or Checkpoint package v1.
 
-Required projection groups are:
+The canonical package contains `schema_version`, `pack_id`, `source_head`,
+`policy_fingerprint`, applied `limits`, projection `groups`, `omissions`, and
+`privacy_result`. Its four projection groups are:
 
-- `code_map`: repository-relative modules or symbols selected by deterministic
-  rules, with source head and optional digests;
-- `changed_files`: public repository-relative paths and bounded diff summaries,
-  reusing the current `public_changed_files` privacy behavior;
-- `tests`: check identifiers, commands when public-safe, outcomes, timestamps,
-  and evidence refs rather than raw output;
-- `evidence_refs`: allowlisted durable refs already attributable through the
-  ledger; and
-- `freshness`: source head, config fingerprint, creation time, limits applied,
-  omissions, and redaction counts.
+- `code_map`: repository-relative path and content SHA-256 pairs;
+- `changed_files`: repository-relative paths, typed change status, and content
+  SHA-256;
+- `tests`: test ID, typed outcome, and one attributable evidence ref; and
+- `evidence_refs`: allowlisted refs already attributable through the ledger.
 
 Generation is deterministic for the same source head, policy, and evidence
 set. When a limit is reached, the pack reports truncation and omitted counts;
@@ -383,10 +382,13 @@ raw terminal transcript, prompt body, secret, credential material, provider
 hidden metadata, an absolute private path, or a reference outside the allowed
 project/evidence namespaces.
 
-The manifest stores only pack ID, schema version, digest, freshness, limits,
-and durable reference. The ledger's context contract carries the ref and the
-summary quality/privacy result. A stale, invalid, source-head-mismatched, or
-over-budget pack is not routable and cannot authorize resume.
+The public preview envelope contains exactly `canonical_json`, `digest`, and
+`byte_count`. The producer derives the digest and byte count from the exact
+canonical UTF-8 bytes. It writes no manifest, registry, artifact, reference, or
+other durable state. Existing ledger context-pack references are a separate pre-existing mechanism;
+TASK-660 neither produces nor consumes them. An invalid input is rejected
+without public output or durable mutation, and a preview result cannot
+authorize routing or resume.
 
 ## 6. Child task contracts
 
@@ -461,15 +463,17 @@ declared rollback, or a filesystem-sandbox guarantee.
 
 ### 6.3 TASK-660: repository context package
 
-**Owns:** the `context-packs` policy schema; explicit `workspace-plan`
-selection; deterministic `code_map`, changed-file, test, and evidence-ref
-projections; byte/item budgets; strict source-head and content-identity shapes;
-pack digests; and metadata-only PowerShell/Rust manifest projection.
+**Owns:** the `context-packs` policy schema; the read-only context-pack preview
+selected explicitly through `workspace-plan`; deterministic `code_map`,
+changed-file, test, and evidence-ref projections; byte/item budgets; strict
+source-head and content-identity shapes; and the producer-only public envelope
+of `canonical_json`, `digest`, and `byte_count`.
 
 **Does not own:** raw transcript capture, general-purpose repository indexing,
 prompt storage, provider memory, workflow state transitions, freshness
-admission, route/resume authority, ledger event generation, Context Capsule,
-Checkpoint package, or preset UX.
+admission, route/resume authority, ledger event generation, manifest/reference/
+registry/artifact persistence, Context Capsule, Checkpoint package, or preset
+UX.
 
 **Acceptance gate:**
 
@@ -480,10 +484,12 @@ Checkpoint package, or preset UX.
   fields, and refs outside allowlisted namespaces are rejected through one
   non-reflective outcome; accepted packs have `privacy_result: pass`;
 - changed files and tests remain attributable to source head and evidence refs;
-- pack output is inert data and cannot itself authorize routing or resume; and
-- context-pack metadata round-trips without persisting canonical JSON, source
-  entries, raw diff/tool output, prompt bodies, or transcripts in
-  `.winsmux/manifest.yaml`.
+- pack output is inert data and cannot itself authorize routing or resume;
+- the public envelope contains no fields other than `canonical_json`, `digest`,
+  and `byte_count`, with both derived values bound to the exact canonical UTF-8
+  bytes; and
+- `workspace-plan` does not persist the context-pack result and leaves project
+  and runtime bytes unchanged on both acceptance and rejection.
 
 ### 6.4 TASK-661: templates, gallery, and migration path
 
@@ -513,8 +519,9 @@ flow.
 
 **Owns:** the aggregate release gate for declarative workflows: dry-run purity,
 rollback/cleanup recovery, interruption/resume, docs/examples, public-surface
-audit, and desktop/CLI parity. It also verifies the combined Lane A/Lane B
-config after TASK-718.
+audit, and desktop/CLI parity. It verifies the combined read-only context-pack
+preview and privacy result, and the combined Lane A/Lane B config after
+TASK-718. It does not implement context-pack persistence.
 
 **Does not own:** feature implementation hidden inside gate code, weakening
 tests to obtain a pass, GitHub Release publication without the separate release
@@ -523,8 +530,9 @@ approval, or automatic merge/release authority.
 **Acceptance gate:**
 
 - CLI and desktop load the same config fixture and report the same normalized
-  recipe, workflow, resolved slots, context-pack metadata, run state, and
-  blocking reasons;
+  recipe, workflow, resolved slots, run state, and blocking reasons; the
+  TASK-660 sub-gate separately verifies the read-only context-pack preview and
+  privacy result without adding a persistent consumer;
 - dry-run proves no panes, worktrees, messages, workflow state, or cleanup
   actions were mutated;
 - restart tests cover interruption before dispatch, after dispatch/before ack,

--- a/docs/project/v03629-declarative-workspace-architecture.md
+++ b/docs/project/v03629-declarative-workspace-architecture.md
@@ -199,12 +199,13 @@ workflows:
 The current workflow v1 parser derives every node idempotency key as
 `<run-id>:<node-id>`; it does not accept an authored `idempotency-key`.
 Workflow-level `resume-policy` and `cleanup-policy`, and node-level
-`verification` actions or `context-pack-ref`, are target concepts owned by
-later child tasks. They are not executable TASK-659 fields and require a new
-implemented schema contract before they may appear in a runnable example.
+`verification` actions or `context-pack-ref`, remain target concepts owned by
+later child tasks. They are not executable TASK-659 fields. TASK-660 does not
+add a workflow field or route/resume authority.
 
-The following context-pack fragment is therefore an illustrative,
-non-executable TASK-660 target, not part of the current workflow v1 contract:
+The following context-pack policy is executable through the side-effect-free
+TASK-660 preview entry. It remains inert until explicitly selected and is not
+part of the workflow v1 schema:
 
 ```yaml
 context-packs:
@@ -250,18 +251,24 @@ Normative field rules:
   node's stable idempotency key from the public run and node identities;
   authored idempotency, compensation, and cleanup fields are not workflow v1
   inputs.
-- For the non-executable TASK-660 target, context-pack `include` values are
-  allowlisted projections. Omitted limits use conservative defaults;
-  disabling privacy exclusions is not supported.
+- TASK-660 context-pack `include` values are allowlisted projections. Omitted
+  limits use conservative defaults; enabling any privacy escape is rejected.
+  The closed input schema accepts only attributable repository-relative
+  identities and safe evidence refs, never free-form content. Every persisted
+  path segment also uses Win32 identity rules: trailing periods or spaces,
+  reserved device basenames (including extensions), and private `.git` or
+  `.winsmux` namespace aliases are rejected before projection.
 
-Recipe selection is explicit. The TASK-658 preview entry point is
-`winsmux workspace-plan --recipe-id <id> [--workflow-id <id>] --json
---project-dir <path>`. Merely adding `workspace-recipes` does not select a
-recipe or alter startup. A `{{workflow-id}}` template requires the explicit
+Recipe and context-pack selection are explicit. The preview entry point is
+`winsmux workspace-plan --recipe-id <id> [--workflow-id <id>]
+[--context-pack-id <id> --context-pack-input -] --json --project-dir <path>`.
+Merely adding `workspace-recipes` or `context-packs` does not select either
+contract or alter startup. A `{{workflow-id}}` template requires the explicit
 `--workflow-id` value; recipe IDs are never substituted for missing workflow
-identity. Preview normalizes and validates the complete selected recipe before
-returning deterministic JSON and does not create logs, evidence, temporary
-files, manifests, processes, panes, branches, directories, or worktrees.
+identity. Preview normalizes and validates the complete selected recipe and,
+when selected, a stdin object capped at 4 MiB before returning deterministic
+JSON. It does not create logs, evidence, temporary files, manifests, processes,
+panes, branches, directories, or worktrees.
 
 ### 3.3 Runtime manifest projection
 
@@ -278,6 +285,25 @@ declarative_workspace:
     implement: worker-1
     verify: worker-2
   dry_run_plan_ref: evidence:...
+  context_packs:
+    review-pack:
+      schema_version: 1
+      digest: sha256:...
+      byte_count: 1234
+      source_head: 0123456789abcdef0123456789abcdef01234567
+      policy_fingerprint: sha256:...
+      limits:
+        max_files: 100
+        max_bytes: 262144
+        max_evidence_refs: 50
+      omissions:
+        code_map: 0
+        changed_files: 0
+        tests: 0
+        evidence_refs: 0
+        omitted_by_bytes: 0
+      privacy_result: pass
+      durable_ref: context-packs/review-pack.json
 
 workflow_runs:
   run-123:
@@ -313,9 +339,12 @@ Runtime values are projections, not re-parsed intent:
 - workflow entries receive the normalized DAG, node states, attempts,
   idempotency records, checkpoint refs, and cleanup journal;
 - ledger events receive state transitions and attributable evidence refs;
-- context packs receive public repository-relative refs and digests only;
-- Context Capsule and Checkpoint package receive the context-pack ref and
-  freshness/config fingerprint needed to judge safe resume.
+- context-pack manifest entries receive bounded metadata and one safe durable
+  ref only; canonical JSON, source entries, prompt bodies, transcripts, and
+  secrets are not manifest fields;
+- TASK-660 does not connect the ref to Context Capsule, Checkpoint package,
+  routing, or resume. A later integration owner must compare the metadata with
+  current source/config state before consumption.
 
 ## 4. Resumable workflow state model
 
@@ -453,26 +482,28 @@ declared rollback, or a filesystem-sandbox guarantee.
 
 ### 6.3 TASK-660: repository context package
 
-**Owns:** the `context-packs` schema; deterministic `code_map`, changed-file,
-test, and evidence-ref projections; byte/item budgets; freshness and source-head
-checks; redaction; pack digests; and integration with the existing ledger
-context contract, Context Capsule, and Checkpoint package.
+**Owns:** the `context-packs` policy schema; explicit `workspace-plan`
+selection; deterministic `code_map`, changed-file, test, and evidence-ref
+projections; byte/item budgets; strict source-head and content-identity shapes;
+pack digests; and metadata-only PowerShell/Rust manifest projection.
 
 **Does not own:** raw transcript capture, general-purpose repository indexing,
-prompt storage, provider memory, workflow state transitions, or preset UX.
+prompt storage, provider memory, workflow state transitions, freshness
+admission, route/resume authority, ledger event generation, Context Capsule,
+Checkpoint package, or preset UX.
 
 **Acceptance gate:**
 
 - identical public inputs produce the same digest and bounded ordering;
 - every projection enforces file, byte, and reference limits and reports
   truncation/omissions;
-- synthetic secrets, absolute private paths, prompt bodies, raw transcripts,
-  and refs outside allowlisted namespaces are rejected or redacted with a
-  failing privacy result where required;
+- absolute/private paths, prompt bodies, raw transcripts, secret/provider/body
+  fields, and refs outside allowlisted namespaces are rejected through one
+  non-reflective outcome; accepted packs have `privacy_result: pass`;
 - changed files and tests remain attributable to source head and evidence refs;
-- stale/source-mismatched/invalid packs are not routable and cannot satisfy a
-  resume gate; and
-- context-pack metadata round-trips without persisting raw diff/tool output in
+- pack output is inert data and cannot itself authorize routing or resume; and
+- context-pack metadata round-trips without persisting canonical JSON, source
+  entries, raw diff/tool output, prompt bodies, or transcripts in
   `.winsmux/manifest.yaml`.
 
 ### 6.4 TASK-661: templates, gallery, and migration path

--- a/docs/project/v03629-declarative-workspace-architecture.md
+++ b/docs/project/v03629-declarative-workspace-architecture.md
@@ -285,25 +285,6 @@ declarative_workspace:
     implement: worker-1
     verify: worker-2
   dry_run_plan_ref: evidence:...
-  context_packs:
-    review-pack:
-      schema_version: 1
-      digest: sha256:...
-      byte_count: 1234
-      source_head: 0123456789abcdef0123456789abcdef01234567
-      policy_fingerprint: sha256:...
-      limits:
-        max_files: 100
-        max_bytes: 262144
-        max_evidence_refs: 50
-      omissions:
-        code_map: 0
-        changed_files: 0
-        tests: 0
-        evidence_refs: 0
-        omitted_by_bytes: 0
-      privacy_result: pass
-      durable_ref: context-packs/review-pack.json
 
 workflow_runs:
   run-123:
@@ -326,11 +307,10 @@ workflow_runs:
     context_pack_refs: [context-pack:...]
 ```
 
-The PowerShell writer in `winsmux-core/scripts/manifest.ps1` currently emits a
-fixed section set, so child implementation must preserve unknown additive
-sections on read/write and add focused round-trip tests. The Rust
-`WinsmuxManifest`/`NormalizedManifestPane` path must continue to accept a
-manifest containing these sections even before every consumer uses them.
+The PowerShell writer in `winsmux-core/scripts/manifest.ps1` emits this fixed
+declarative-workspace schema. The Rust
+`WinsmuxManifest`/`NormalizedManifestPane` path accepts the same fields and
+rejects unknown fields within this versioned section.
 
 Runtime values are projections, not re-parsed intent:
 
@@ -339,12 +319,11 @@ Runtime values are projections, not re-parsed intent:
 - workflow entries receive the normalized DAG, node states, attempts,
   idempotency records, checkpoint refs, and cleanup journal;
 - ledger events receive state transitions and attributable evidence refs;
-- context-pack manifest entries receive bounded metadata and one safe durable
-  ref only; canonical JSON, source entries, prompt bodies, transcripts, and
-  secrets are not manifest fields;
-- TASK-660 does not connect the ref to Context Capsule, Checkpoint package,
-  routing, or resume. A later integration owner must compare the metadata with
-  current source/config state before consumption.
+- TASK-660 exposes a read-only context-pack preview, but schema version 1 does
+  not persist that result or connect it to Context Capsule, Checkpoint package,
+  routing, or resume. TASK-662 owns any future verified cross-runtime
+  persistence contract and must bind one typed consumer to the exact canonical
+  bytes before adding a runnable manifest field.
 
 ## 4. Resumable workflow state model
 

--- a/winsmux-core/scripts/manifest.ps1
+++ b/winsmux-core/scripts/manifest.ps1
@@ -1878,22 +1878,10 @@ function Test-WinsmuxPublicReferenceIdentity {
     return $true
 }
 
-function Test-WinsmuxContextPackId {
-    param(
-        [Parameter(Mandatory = $true)][string]$Value
-    )
-
-    return (
-        [System.Text.Encoding]::UTF8.GetByteCount($Value) -le 64 -and
-        $Value -cmatch '^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$'
-    )
-}
-
 function New-WinsmuxDeclarativeWorkspaceProjection {
     param(
         [Parameter(Mandatory = $true)]$Plan,
-        [AllowEmptyString()][string]$DryRunPlanRef = '',
-        [AllowEmptyString()][string]$ContextPackRef = ''
+        [AllowEmptyString()][string]$DryRunPlanRef = ''
     )
 
     $configFingerprint = [string]$Plan.config_fingerprint
@@ -1927,119 +1915,6 @@ function New-WinsmuxDeclarativeWorkspaceProjection {
     }
     if (-not [string]::IsNullOrWhiteSpace($DryRunPlanRef)) {
         $projection['dry_run_plan_ref'] = $DryRunPlanRef
-    }
-    if (-not [string]::IsNullOrWhiteSpace($ContextPackRef)) {
-        if (-not (Test-WinsmuxPublicReferenceIdentity -Value $ContextPackRef -Prefix 'context-packs/')) {
-            throw 'Context-pack manifest projection rejected.'
-        }
-
-        $planMap = ConvertTo-ManifestPropertyMap -Value $Plan
-        if (-not (@($planMap.Keys) -ccontains 'context_pack')) {
-            throw 'Context-pack manifest projection rejected.'
-        }
-        $contextPackMap = ConvertTo-ManifestPropertyMap -Value $planMap['context_pack']
-        if (-not (@($contextPackMap.Keys) -ccontains 'manifest_projection')) {
-            throw 'Context-pack manifest projection rejected.'
-        }
-        $metadata = ConvertTo-ManifestPropertyMap -Value $contextPackMap['manifest_projection']
-        $metadataKeys = @(
-            'pack_id',
-            'schema_version',
-            'digest',
-            'byte_count',
-            'source_head',
-            'policy_fingerprint',
-            'limits',
-            'omissions',
-            'privacy_result'
-        )
-        if ($metadata.Count -ne $metadataKeys.Count) {
-            throw 'Context-pack manifest projection rejected.'
-        }
-        foreach ($key in $metadata.Keys) {
-            if ($metadataKeys -cnotcontains [string]$key) {
-                throw 'Context-pack manifest projection rejected.'
-            }
-        }
-
-        $packId = [string]$metadata['pack_id']
-        $schemaVersion = ConvertTo-WinsmuxRuntimeInteger -Value $metadata['schema_version']
-        $digest = [string]$metadata['digest']
-        $byteCount = ConvertTo-WinsmuxRuntimeInteger -Value $metadata['byte_count']
-        $sourceHead = [string]$metadata['source_head']
-        $policyFingerprint = [string]$metadata['policy_fingerprint']
-        $privacyResult = [string]$metadata['privacy_result']
-        if (-not (Test-WinsmuxContextPackId -Value $packId) -or $schemaVersion -ne 1 -or
-            $digest -cnotmatch '^sha256:[0-9a-f]{64}$' -or
-            $null -eq $byteCount -or $byteCount -le 0 -or
-            $sourceHead -cnotmatch '^[0-9a-f]{40}$' -or
-            $policyFingerprint -cnotmatch '^sha256:[0-9a-f]{64}$' -or
-            $privacyResult -cne 'pass') {
-            throw 'Context-pack manifest projection rejected.'
-        }
-
-        $limits = ConvertTo-ManifestPropertyMap -Value $metadata['limits']
-        $limitKeys = @('max_files', 'max_bytes', 'max_evidence_refs')
-        if ($limits.Count -ne $limitKeys.Count) {
-            throw 'Context-pack manifest projection rejected.'
-        }
-        foreach ($key in $limits.Keys) {
-            if ($limitKeys -cnotcontains [string]$key) {
-                throw 'Context-pack manifest projection rejected.'
-            }
-        }
-        $maxFiles = ConvertTo-WinsmuxRuntimeInteger -Value $limits['max_files']
-        $maxBytes = ConvertTo-WinsmuxRuntimeInteger -Value $limits['max_bytes']
-        $maxEvidenceRefs = ConvertTo-WinsmuxRuntimeInteger -Value $limits['max_evidence_refs']
-        if ($null -eq $maxFiles -or $maxFiles -le 0 -or $maxFiles -gt 1000 -or
-            $null -eq $maxBytes -or $maxBytes -le 0 -or $maxBytes -gt 1048576 -or
-            $null -eq $maxEvidenceRefs -or $maxEvidenceRefs -le 0 -or
-            $maxEvidenceRefs -gt 500 -or $byteCount -gt $maxBytes) {
-            throw 'Context-pack manifest projection rejected.'
-        }
-
-        $omissions = ConvertTo-ManifestPropertyMap -Value $metadata['omissions']
-        $omissionKeys = @(
-            'code_map',
-            'changed_files',
-            'tests',
-            'evidence_refs',
-            'omitted_by_bytes'
-        )
-        if ($omissions.Count -ne $omissionKeys.Count) {
-            throw 'Context-pack manifest projection rejected.'
-        }
-        $normalizedOmissions = [ordered]@{}
-        foreach ($key in $omissions.Keys) {
-            if ($omissionKeys -cnotcontains [string]$key) {
-                throw 'Context-pack manifest projection rejected.'
-            }
-        }
-        foreach ($key in $omissionKeys) {
-            $value = ConvertTo-WinsmuxRuntimeInteger -Value $omissions[$key]
-            if ($null -eq $value -or $value -lt 0) {
-                throw 'Context-pack manifest projection rejected.'
-            }
-            $normalizedOmissions[$key] = $value
-        }
-
-        $contextPacks = [ordered]@{}
-        $contextPacks[$packId] = [ordered]@{
-            schema_version    = $schemaVersion
-            digest            = $digest
-            byte_count        = $byteCount
-            source_head       = $sourceHead
-            policy_fingerprint = $policyFingerprint
-            limits            = [ordered]@{
-                max_files         = $maxFiles
-                max_bytes         = $maxBytes
-                max_evidence_refs = $maxEvidenceRefs
-            }
-            omissions         = $normalizedOmissions
-            privacy_result    = $privacyResult
-            durable_ref       = $ContextPackRef
-        }
-        $projection['context_packs'] = $contextPacks
     }
     return $projection
 }

--- a/winsmux-core/scripts/manifest.ps1
+++ b/winsmux-core/scripts/manifest.ps1
@@ -1845,10 +1845,44 @@ function ConvertFrom-ManifestYaml {
     return $manifest
 }
 
+function Test-WinsmuxPublicReferenceIdentity {
+    param(
+        [Parameter(Mandatory = $true)][string]$Value,
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('evidence:', 'context-packs/')][string]$Prefix
+    )
+
+    if ([System.Text.Encoding]::UTF8.GetByteCount($Value) -gt 256 -or
+        -not $Value.StartsWith($Prefix, [System.StringComparison]::Ordinal)) {
+        return $false
+    }
+    $path = $Value.Substring($Prefix.Length)
+    if ($path -cnotmatch '^[a-z0-9][a-z0-9._/-]*$' -or
+        $path.EndsWith('/') -or $path.Contains('..') -or
+        $path.Contains('\') -or $path.Contains('//')) {
+        return $false
+    }
+
+    foreach ($segment in $path.Split([char]'/', [System.StringSplitOptions]::None)) {
+        if ([System.Text.Encoding]::UTF8.GetByteCount($segment) -gt 240 -or
+            [string]::IsNullOrEmpty($segment) -or
+            $segment.EndsWith('.') -or $segment.EndsWith(' ') -or
+            $segment -ieq '.git' -or $segment -ieq '.winsmux') {
+            return $false
+        }
+        $baseName = ($segment -split '\.', 2)[0]
+        if ($baseName -imatch '^(?:con|prn|aux|nul|com[1-9]|lpt[1-9])$') {
+            return $false
+        }
+    }
+    return $true
+}
+
 function New-WinsmuxDeclarativeWorkspaceProjection {
     param(
         [Parameter(Mandatory = $true)]$Plan,
-        [AllowEmptyString()][string]$DryRunPlanRef = ''
+        [AllowEmptyString()][string]$DryRunPlanRef = '',
+        [AllowEmptyString()][string]$ContextPackRef = ''
     )
 
     $configFingerprint = [string]$Plan.config_fingerprint
@@ -1861,8 +1895,7 @@ function New-WinsmuxDeclarativeWorkspaceProjection {
         throw 'Workspace plan recipe_id must be a stable lowercase ASCII identifier.'
     }
     if (-not [string]::IsNullOrWhiteSpace($DryRunPlanRef) -and
-        ($DryRunPlanRef -cnotmatch '^evidence:[a-z0-9][a-z0-9._/-]*$' -or
-            $DryRunPlanRef.Contains('..') -or $DryRunPlanRef.Contains('\'))) {
+        -not (Test-WinsmuxPublicReferenceIdentity -Value $DryRunPlanRef -Prefix 'evidence:')) {
         throw 'Workspace dry_run_plan_ref must be a safe evidence reference.'
     }
 
@@ -1883,6 +1916,119 @@ function New-WinsmuxDeclarativeWorkspaceProjection {
     }
     if (-not [string]::IsNullOrWhiteSpace($DryRunPlanRef)) {
         $projection['dry_run_plan_ref'] = $DryRunPlanRef
+    }
+    if (-not [string]::IsNullOrWhiteSpace($ContextPackRef)) {
+        if (-not (Test-WinsmuxPublicReferenceIdentity -Value $ContextPackRef -Prefix 'context-packs/')) {
+            throw 'Context-pack manifest projection rejected.'
+        }
+
+        $planMap = ConvertTo-ManifestPropertyMap -Value $Plan
+        if (-not (@($planMap.Keys) -ccontains 'context_pack')) {
+            throw 'Context-pack manifest projection rejected.'
+        }
+        $contextPackMap = ConvertTo-ManifestPropertyMap -Value $planMap['context_pack']
+        if (-not (@($contextPackMap.Keys) -ccontains 'manifest_projection')) {
+            throw 'Context-pack manifest projection rejected.'
+        }
+        $metadata = ConvertTo-ManifestPropertyMap -Value $contextPackMap['manifest_projection']
+        $metadataKeys = @(
+            'pack_id',
+            'schema_version',
+            'digest',
+            'byte_count',
+            'source_head',
+            'policy_fingerprint',
+            'limits',
+            'omissions',
+            'privacy_result'
+        )
+        if ($metadata.Count -ne $metadataKeys.Count) {
+            throw 'Context-pack manifest projection rejected.'
+        }
+        foreach ($key in $metadata.Keys) {
+            if ($metadataKeys -cnotcontains [string]$key) {
+                throw 'Context-pack manifest projection rejected.'
+            }
+        }
+
+        $packId = [string]$metadata['pack_id']
+        $schemaVersion = ConvertTo-WinsmuxRuntimeInteger -Value $metadata['schema_version']
+        $digest = [string]$metadata['digest']
+        $byteCount = ConvertTo-WinsmuxRuntimeInteger -Value $metadata['byte_count']
+        $sourceHead = [string]$metadata['source_head']
+        $policyFingerprint = [string]$metadata['policy_fingerprint']
+        $privacyResult = [string]$metadata['privacy_result']
+        if ($packId -cnotmatch $idPattern -or $schemaVersion -ne 1 -or
+            $digest -cnotmatch '^sha256:[0-9a-f]{64}$' -or
+            $null -eq $byteCount -or $byteCount -le 0 -or
+            $sourceHead -cnotmatch '^[0-9a-f]{40}$' -or
+            $policyFingerprint -cnotmatch '^sha256:[0-9a-f]{64}$' -or
+            $privacyResult -cne 'pass') {
+            throw 'Context-pack manifest projection rejected.'
+        }
+
+        $limits = ConvertTo-ManifestPropertyMap -Value $metadata['limits']
+        $limitKeys = @('max_files', 'max_bytes', 'max_evidence_refs')
+        if ($limits.Count -ne $limitKeys.Count) {
+            throw 'Context-pack manifest projection rejected.'
+        }
+        foreach ($key in $limits.Keys) {
+            if ($limitKeys -cnotcontains [string]$key) {
+                throw 'Context-pack manifest projection rejected.'
+            }
+        }
+        $maxFiles = ConvertTo-WinsmuxRuntimeInteger -Value $limits['max_files']
+        $maxBytes = ConvertTo-WinsmuxRuntimeInteger -Value $limits['max_bytes']
+        $maxEvidenceRefs = ConvertTo-WinsmuxRuntimeInteger -Value $limits['max_evidence_refs']
+        if ($null -eq $maxFiles -or $maxFiles -le 0 -or $maxFiles -gt 1000 -or
+            $null -eq $maxBytes -or $maxBytes -le 0 -or $maxBytes -gt 1048576 -or
+            $null -eq $maxEvidenceRefs -or $maxEvidenceRefs -le 0 -or
+            $maxEvidenceRefs -gt 500 -or $byteCount -gt $maxBytes) {
+            throw 'Context-pack manifest projection rejected.'
+        }
+
+        $omissions = ConvertTo-ManifestPropertyMap -Value $metadata['omissions']
+        $omissionKeys = @(
+            'code_map',
+            'changed_files',
+            'tests',
+            'evidence_refs',
+            'omitted_by_bytes'
+        )
+        if ($omissions.Count -ne $omissionKeys.Count) {
+            throw 'Context-pack manifest projection rejected.'
+        }
+        $normalizedOmissions = [ordered]@{}
+        foreach ($key in $omissions.Keys) {
+            if ($omissionKeys -cnotcontains [string]$key) {
+                throw 'Context-pack manifest projection rejected.'
+            }
+        }
+        foreach ($key in $omissionKeys) {
+            $value = ConvertTo-WinsmuxRuntimeInteger -Value $omissions[$key]
+            if ($null -eq $value -or $value -lt 0) {
+                throw 'Context-pack manifest projection rejected.'
+            }
+            $normalizedOmissions[$key] = $value
+        }
+
+        $contextPacks = [ordered]@{}
+        $contextPacks[$packId] = [ordered]@{
+            schema_version    = $schemaVersion
+            digest            = $digest
+            byte_count        = $byteCount
+            source_head       = $sourceHead
+            policy_fingerprint = $policyFingerprint
+            limits            = [ordered]@{
+                max_files         = $maxFiles
+                max_bytes         = $maxBytes
+                max_evidence_refs = $maxEvidenceRefs
+            }
+            omissions         = $normalizedOmissions
+            privacy_result    = $privacyResult
+            durable_ref       = $ContextPackRef
+        }
+        $projection['context_packs'] = $contextPacks
     }
     return $projection
 }

--- a/winsmux-core/scripts/manifest.ps1
+++ b/winsmux-core/scripts/manifest.ps1
@@ -1878,6 +1878,17 @@ function Test-WinsmuxPublicReferenceIdentity {
     return $true
 }
 
+function Test-WinsmuxContextPackId {
+    param(
+        [Parameter(Mandatory = $true)][string]$Value
+    )
+
+    return (
+        [System.Text.Encoding]::UTF8.GetByteCount($Value) -le 64 -and
+        $Value -cmatch '^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$'
+    )
+}
+
 function New-WinsmuxDeclarativeWorkspaceProjection {
     param(
         [Parameter(Mandatory = $true)]$Plan,
@@ -1958,7 +1969,7 @@ function New-WinsmuxDeclarativeWorkspaceProjection {
         $sourceHead = [string]$metadata['source_head']
         $policyFingerprint = [string]$metadata['policy_fingerprint']
         $privacyResult = [string]$metadata['privacy_result']
-        if ($packId -cnotmatch $idPattern -or $schemaVersion -ne 1 -or
+        if (-not (Test-WinsmuxContextPackId -Value $packId) -or $schemaVersion -ne 1 -or
             $digest -cnotmatch '^sha256:[0-9a-f]{64}$' -or
             $null -eq $byteCount -or $byteCount -le 0 -or
             $sourceHead -cnotmatch '^[0-9a-f]{40}$' -or


### PR DESCRIPTION
## Summary

- Add a deterministic, byte-bounded context-pack projection to the explicitly selected, side-effect-free `winsmux workspace-plan` preview.
- Return a producer-only public envelope containing exactly `canonical_json`, `digest`, and `byte_count`; identical admitted input yields identical canonical UTF-8 bytes and SHA-256 digest.
- Report bounded omissions inside the canonical projection while excluding raw transcripts, prompt bodies, secrets, and private local paths. TASK-660 does not persist context packs to manifests, references, registries, or artifacts.

## Surface Classification

- [x] Public product surface
- [x] Runtime contract surface
- [x] Contributor/test surface
- [ ] Generated/runtime artifact not tracked
- [ ] Not sure; reviewer help requested

Reference: [Repository surface policy](../docs/repo-surface-policy.md)

## Responsibility And Cutover

- Replaced behavior, workflow, config path, or responsibility: no default behavior is replaced; context-pack parsing, validation, canonical projection, and the three-field preview envelope are added behind the opt-in workspace-plan flag pair.
- Expected outcome: identical admitted input yields identical bytes and digest, oversized input reports deterministic omission metadata, and rejected input emits no public output while leaving project and runtime bytes unchanged.
- Source of truth: the Rust context-pack authority reached through the public workspace-plan child-process entry, plus the marker-delimited executable policy in the architecture contract.
- Old paths preserved, redirected, deprecated, or removed: workspace-plan calls without context-pack flags remain unchanged; former context-pack manifest/persistence surfaces reject before public output or durable mutation. Existing ledger references are a separate pre-existing mechanism.
- Out of scope: workflow state transitions, routing/resume authority, manifest/reference/registry/artifact persistence, presets, UI, and release publication.

## Verification

- Decision-table/closure selectors: 19/19 GREEN, including every active reject/fail-closed row and expected invariant state.
- Rust owner suites: context-pack 19/19, manifest 22/22, fixture 31/31, ledger 84/84, operator CLI 189/189, workflow contract 5/5; PowerShell owners 22/22.
- CandidateFreeze, derived-envelope, public-surface audit, git-guard, gitleaks, format, parser, and diff checks passed on final tree `0bcd5ca062bf825aac8b37033f6da8edd945c080`.
- Official full suite: 1,657/1,657 passed with zero failed, skipped, not-run, or harness failures; discovery and execution identity matched.
- Final remote gates: CI 36/36 successful, exact-head Codex observation clean, and unresolved review threads 0.

## Security And Privacy

- [x] No secrets, credentials, private local paths, browser profile paths, account IDs, customer data, raw transcripts, prompt bodies, or private logs are included.
- [x] Accepted output is inert preview data and cannot authorize routing or resume.
- [x] Rejection occurs before public output or durable mutation, and accepted/rejected runs preserve project and runtime bytes.

Rollback is a revert of this PR. The feature is opt-in and introduces no persistent-state migration.