### PR TITLE
chore(deps): update postcss to 8.5.18

### DIFF
--- a/winsmux-app/package-lock.json
+++ b/winsmux-app/package-lock.json
@@ -1169,9 +1169,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "dev": true,
       "funding": [
         {
@@ -1255,9 +1255,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.10",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
-      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "version": "8.5.18",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.18.tgz",
+      "integrity": "sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==",
       "dev": true,
       "funding": [
         {
@@ -1275,7 +1275,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },


### PR DESCRIPTION
## Summary

- Resolve Dependabot alerts [#18](https://github.com/Sora-bluesky/winsmux/security/dependabot/18) and [#19](https://github.com/Sora-bluesky/winsmux/security/dependabot/19).
- Update the transitive development dependency `postcss` from `8.5.10` to the first version that fixes both alerts, `8.5.18`.
- Update its required dependency `nanoid` from `3.3.11` to `3.3.12`.
- Keep `vite` at `6.4.3` and leave `package.json` unchanged.

## Verification

- `npm ci --ignore-scripts` — passed; the lockfile hash remained unchanged.
- `npm ls postcss nanoid --all --json` — resolved `vite@6.4.3 -> postcss@8.5.18 -> nanoid@3.3.12`.
- `npm audit --json` — 0 vulnerabilities at every severity.
- `npm run build` — passed.
- `npm run test:common-contract-package` — passed.
- `npm run test:automation-driver-pool` — passed.
- `scripts/git-guard.ps1` in staged and full modes — passed.
- `scripts/audit-public-surface.ps1` — passed.
- Normal pre-commit and pre-push hooks — passed; gitleaks found 0 leaks.

## Rollback

Revert commit `d949acbbc535950cc4d77f54d670f82c6244b025` to restore the previous lockfile. That rollback would reintroduce both high-severity alerts, so it should only be used together with another patched `postcss` version. The alerts are not dismissed by this change.
