### PR TITLE
fix(planning): order roadmap by dependencies and priority

### DIFF
--- a/tests/HarnessContract.Tests.ps1
+++ b/tests/HarnessContract.Tests.ps1
@@ -1552,7 +1552,7 @@ tasks:
     It 'includes a four-component release in the focus detail section' {
         $script:SyncExitCode | Should -Be 0 -Because $script:SyncOutput
         $script:RoadmapLines | Should -Contain '### v0.36.28.1: 4要素の修正版'
-        $script:RoadmapLines | Should -Contain '| [ ] | TASK-FOUR-PATCH | 4要素の修正タスク | P0 最優先 | winsmux | todo |'
+        $script:RoadmapLines | Should -Contain '| 1 | TASK-FOUR-PATCH | 4要素の修正タスク | P0 最優先 | 未着手 |'
         $script:RoadmapLines | Should -Not -Contain '| v0.36.28.1 | TASK-FOUR-PATCH | 4要素の修正タスク | P0 最優先 | winsmux | todo |'
     }
 

--- a/tests/PublicSurfacePolicy.Tests.ps1
+++ b/tests/PublicSurfacePolicy.Tests.ps1
@@ -175,6 +175,152 @@ Describe 'Public surface policy' {
         }
     }
 
+    It 'renders roadmap tasks in dependency-safe priority order with Japanese five-column tables' {
+        $backlog = Join-Path $TestDrive 'roadmap-backlog.yaml'
+        $roadmap = Join-Path $TestDrive 'ROADMAP.md'
+        $titles = Join-Path $TestDrive 'roadmap-title-ja.psd1'
+        $fixtureScripts = Join-Path $TestDrive 'winsmux-core/scripts'
+        $null = New-Item -ItemType Directory -Path $fixtureScripts -Force
+        foreach ($scriptName in @('sync-roadmap.ps1', 'planning-paths.ps1')) {
+            Copy-Item -LiteralPath (Join-Path $repoRoot "winsmux-core/scripts/$scriptName") -Destination (Join-Path $fixtureScripts $scriptName)
+        }
+        # The fixture deliberately omits sync-internal-docs.ps1. The generator's
+        # existing Test-Path guard prevents repo-side effects without an opt-out.
+        $syncScript = Join-Path $fixtureScripts 'sync-roadmap.ps1'
+
+        Set-Content -LiteralPath $titles -Encoding UTF8 -Value @'
+@{
+    VersionTitles = @{
+        "v0.36.30" = "現在版"
+        "v0.36.31" = "次版"
+        "v1.2.0" = "長期版"
+    }
+    TaskTitles = @{
+        "TASK-100" = "依存先の後に実行"
+        "TASK-101" = "完了済みの前提"
+        "TASK-102" = "優先度中"
+        "TASK-103" = "優先度最優先"
+        "TASK-104" = "ブロック形式の依存"
+        "TASK-105" = "後続の依存"
+        "TASK-106" = "別版の依存"
+        "TASK-110" = "長期の作業"
+        "TASK-120" = "欠落参照"
+        "TASK-130" = "循環一"
+        "TASK-131" = "循環二"
+    }
+}
+'@
+
+        Set-Content -LiteralPath $backlog -Encoding UTF8 -Value @'
+# === v0.36.30: current ===
+# === v0.36.31: next ===
+# === v1.2.0: long ===
+tasks:
+  - id: TASK-100
+    title: consumer
+    status: todo
+    priority: P0
+    target_version: v0.36.30
+    depends_on: [TASK-101]
+  - id: TASK-101
+    title: prerequisite
+    status: done
+    priority: P3
+    target_version: v0.36.30
+  - id: TASK-102
+    title: medium
+    status: todo
+    priority: P1
+    target_version: v0.36.30
+  - id: TASK-103
+    title: highest
+    status: wip
+    priority: P0
+    target_version: v0.36.30
+  - id: TASK-104
+    title: block dependency
+    status: todo
+    priority: P0
+    target_version: v0.36.30
+    depends_on:
+      - TASK-103
+  - id: TASK-105
+    title: later dependency
+    status: todo
+    priority: P2
+    target_version: v0.36.30
+    depends_on: [TASK-104]
+  - id: TASK-106
+    title: cross release
+    status: todo
+    priority: P0
+    target_version: v0.36.31
+    depends_on: [TASK-100]
+  - id: TASK-110
+    title: long term
+    status: todo
+    priority: P0
+    target_version: v1.2.0
+'@
+
+        $output = @(& pwsh -NoProfile -File $syncScript -BacklogPath $backlog -RoadmapPath $roadmap -RoadmapTitleJaPath $titles 2>&1)
+        $LASTEXITCODE | Should -Be 0
+        $rendered = Get-Content -LiteralPath $roadmap -Raw
+
+        foreach ($taskId in @('TASK-103', 'TASK-102', 'TASK-101', 'TASK-100', 'TASK-104', 'TASK-105')) {
+            $rendered | Should -Match ([regex]::Escape($taskId))
+        }
+        $rendered.IndexOf('TASK-103') | Should -BeLessThan $rendered.IndexOf('TASK-104')
+        $rendered.IndexOf('TASK-104') | Should -BeLessThan $rendered.IndexOf('TASK-102')
+        $rendered.IndexOf('TASK-102') | Should -BeLessThan $rendered.IndexOf('TASK-105')
+        $rendered.IndexOf('TASK-105') | Should -BeLessThan $rendered.IndexOf('TASK-101')
+        $rendered.IndexOf('TASK-101') | Should -BeLessThan $rendered.IndexOf('TASK-100')
+        $rendered.IndexOf('TASK-104') | Should -BeLessThan $rendered.IndexOf('TASK-105')
+        $rendered | Should -Match '### v0\.36\.31: 次版'
+        $rendered | Should -Match '### v1\.2\.0: 長期版'
+        $rendered | Should -Match '\| 順 \| ID \| やること \| 優先度 \| 状態 \|'
+        $rendered | Should -Match '\| 1 \| TASK-103 \| 優先度最優先 \| P0 最優先 \| 作業中 \|'
+        $rendered | Should -Match '\| 5 \| TASK-101 \| 完了済みの前提 \| P3 低 \| 完了 \|'
+        $rendered | Should -Not -Match '\|\s*対象\s*\|'
+        $rendered | Should -Not -Match '一意な責任'
+        $rendered | Should -Not -Match '\b(todo|wip)\b'
+        $rendered | Should -Not -Match '\[x\]|\[-\]|\[R\]|\[ \]'
+
+        Set-Content -LiteralPath $backlog -Encoding UTF8 -Value @'
+# === v0.36.30: current ===
+tasks:
+  - id: TASK-120
+    title: missing
+    status: todo
+    priority: P0
+    target_version: v0.36.30
+    depends_on: [TASK-999]
+'@
+        $output = @(& pwsh -NoProfile -File $syncScript -BacklogPath $backlog -RoadmapPath $roadmap -RoadmapTitleJaPath $titles 2>&1)
+        $LASTEXITCODE | Should -Be 1
+        ($output -join "`n") | Should -Match 'task TASK-120 in v0\.36\.30 references missing dependency TASK-999'
+
+        Set-Content -LiteralPath $backlog -Encoding UTF8 -Value @'
+# === v0.36.30: current ===
+tasks:
+  - id: TASK-130
+    title: first cycle
+    status: todo
+    priority: P1
+    target_version: v0.36.30
+    depends_on: [TASK-131]
+  - id: TASK-131
+    title: second cycle
+    status: todo
+    priority: P0
+    target_version: v0.36.30
+    depends_on: [TASK-130]
+'@
+        $output = @(& pwsh -NoProfile -File $syncScript -BacklogPath $backlog -RoadmapPath $roadmap -RoadmapTitleJaPath $titles 2>&1)
+        $LASTEXITCODE | Should -Be 1
+        ($output -join "`n") | Should -Match 'same-version cycle in v0\.36\.30; unconsumed tasks: TASK-131, TASK-130'
+    }
+
     It 'keeps the tracked roadmap title example scrubbed of live planning data' {
         $example = Get-Content (Join-Path $repoRoot 'tasks/roadmap-title-ja.example.psd1') -Raw
 

--- a/winsmux-core/scripts/sync-roadmap.ps1
+++ b/winsmux-core/scripts/sync-roadmap.ps1
@@ -1062,6 +1062,10 @@ foreach ($versionGroup in $versionGroups) {
         continue
     }
 
+    if (-not (Test-RequiresJapaneseVersionTitle -Version $versionGroup.Name)) {
+        continue
+    }
+
     $visibleTasks = @($versionGroup.Group | Where-Object { $_.Status -ne 'done' -and $_.Status -ne 'cancelled' })
     if ($visibleTasks.Count -eq 0) {
         continue

--- a/winsmux-core/scripts/sync-roadmap.ps1
+++ b/winsmux-core/scripts/sync-roadmap.ps1
@@ -377,9 +377,10 @@ function ConvertFrom-TaskBlock {
         paths         = @()
         artifacts     = @()
         changed_files = @()
+        depends_on    = @()
     }
 
-    $listKeys = @('files', 'paths', 'artifacts', 'changed_files')
+    $listKeys = @('files', 'paths', 'artifacts', 'changed_files', 'depends_on')
     $currentListKey = $null
 
     for ($index = 1; $index -lt $Lines.Count; $index++) {
@@ -431,6 +432,7 @@ function ConvertFrom-TaskBlock {
         Paths         = @($values['paths'])
         Artifacts     = @($values['artifacts'])
         ChangedFiles  = @($values['changed_files'])
+        DependsOn     = @($values['depends_on'])
     }
 }
 
@@ -664,7 +666,9 @@ function Get-StatusLabel {
         'in_progress' { return '作業中' }
         'doing' { return '作業中' }
         'active' { return '作業中' }
+        'wip' { return '作業中' }
         'cancelled' { return '取りやめ' }
+        'todo' { return '未着手' }
         'pending' { return '保留' }
         'backlog' { return '未着手' }
         default {
@@ -675,6 +679,89 @@ function Get-StatusLabel {
             return $Status
         }
     }
+}
+
+function Get-RoadmapTaskOrder {
+    param(
+        [Parameter(Mandatory = $true)]
+        [object[]]$Tasks,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Version,
+
+        [Parameter(Mandatory = $true)]
+        [hashtable]$TaskVersionById
+    )
+
+    $activeTasks = @($Tasks | Where-Object { $_.Status -ne 'cancelled' })
+    $byId = @{}
+    $inDegree = @{}
+    $dependents = @{}
+    foreach ($task in $activeTasks) {
+        $byId[$task.Id] = $task
+        $inDegree[$task.Id] = 0
+        $dependents[$task.Id] = New-Object System.Collections.Generic.List[string]
+    }
+
+    foreach ($task in $activeTasks) {
+        foreach ($dependencyId in @($task.DependsOn)) {
+            # A task in another release is visible in its own release only; it does
+            # not constrain this release's execution order.
+            if (-not $byId.ContainsKey($dependencyId)) {
+                if (-not $TaskVersionById.ContainsKey($dependencyId)) {
+                    throw ('Roadmap dependency validation failed: task {0} in {1} references missing dependency {2}.' -f $task.Id, $Version, $dependencyId)
+                }
+                continue
+            }
+
+            $inDegree[$task.Id]++
+            $dependents[$dependencyId].Add($task.Id)
+        }
+    }
+
+    $remaining = New-Object System.Collections.Generic.HashSet[string]([System.StringComparer]::Ordinal)
+    foreach ($task in $activeTasks) {
+        $null = $remaining.Add($task.Id)
+    }
+
+    $ordered = New-Object System.Collections.Generic.List[object]
+    while ($remaining.Count -gt 0) {
+        $ready = @(
+            $remaining |
+                Where-Object { $inDegree[$_] -eq 0 } |
+                ForEach-Object { $byId[$_] } |
+                Sort-Object @{ Expression = { Get-PriorityRank -Priority $_.Priority } }, @{ Expression = { $_.IdNumber } }, @{ Expression = { $_.Id } }
+        )
+        if ($ready.Count -eq 0) {
+            $unresolved = @(
+                $remaining |
+                    ForEach-Object { $byId[$_] } |
+                    Sort-Object @{ Expression = { Get-PriorityRank -Priority $_.Priority } }, @{ Expression = { $_.IdNumber } }, @{ Expression = { $_.Id } }
+            )
+            throw ('Roadmap dependency validation failed: same-version cycle in {0}; unconsumed tasks: {1}.' -f $Version, (($unresolved | ForEach-Object { $_.Id }) -join ', '))
+        }
+
+        # Re-evaluate readiness after every selection. A newly unblocked P0 task
+        # must outrank a P1 task that was already ready.
+        $task = $ready[0]
+        $null = $remaining.Remove($task.Id)
+        $ordered.Add($task)
+        foreach ($dependentId in $dependents[$task.Id]) {
+            $inDegree[$dependentId]--
+        }
+    }
+
+    return @($ordered.ToArray())
+}
+
+function Test-RoadmapVersionFullyDone {
+    param(
+        [Parameter(Mandatory = $true)]
+        [object[]]$Tasks
+    )
+
+    $activeTasks = @($Tasks | Where-Object { $_.Status -ne 'cancelled' })
+    return $activeTasks.Count -eq 0 -or @($activeTasks | Where-Object { $_.Status -ne 'done' }).Count -eq 0
 }
 
 function Get-PriorityLabel {
@@ -811,6 +898,10 @@ foreach ($taskBlock in $taskBlocks) {
     }
 }
 )
+$taskVersionById = @{}
+foreach ($task in $tasks) {
+    $taskVersionById[$task.Id] = $task.TargetVersion
+}
 
 $downgradedTasks = New-Object System.Collections.Generic.List[object]
 $validationWarnings = New-Object System.Collections.Generic.List[string]
@@ -900,7 +991,7 @@ $builder = [System.Text.StringBuilder]::new()
 [void]$builder.AppendLine('## 読み方')
 [void]$builder.AppendLine()
 [void]$builder.AppendLine('- まず「バージョン概要」で、どの版が終わっているかを確認します。')
-[void]$builder.AppendLine('- 次に「これから進めるタスク」で、未完了の作業だけを確認します。')
+[void]$builder.AppendLine('- 次に「これから進めるタスク」で、依存関係を満たす実行順を確認します。')
 [void]$builder.AppendLine('- 完了済みの古い版は、詳細を畳んでいます。必要な時は GitHub Release を見ます。')
 [void]$builder.AppendLine()
 [void]$builder.AppendLine('## バージョン概要')
@@ -924,13 +1015,50 @@ foreach ($versionGroup in $versionGroups) {
 [void]$builder.AppendLine()
 [void]$builder.AppendLine('## これから進めるタスク')
 [void]$builder.AppendLine()
-[void]$builder.AppendLine('完了済みの版は、この一覧から外しています。')
+[void]$builder.AppendLine('各版では、依存先を先に置き、同時に着手できるタスクは優先度順に並べます。')
 [void]$builder.AppendLine('詳細表示は、現在の作業版から v1.0.0 までに絞っています。')
-[void]$builder.AppendLine('長期版の未完了タスクは、後ろの一覧で確認できます。')
+[void]$builder.AppendLine('長期版は、未完了のタスクだけを後ろの一覧で確認できます。')
 [void]$builder.AppendLine()
 
 foreach ($versionGroup in $versionGroups) {
     if (-not (Test-RoadmapVersionInFocusRange -Version $versionGroup.Name)) {
+        continue
+    }
+
+    if (Test-RoadmapVersionFullyDone -Tasks @($versionGroup.Group)) {
+        continue
+    }
+
+    $visibleTasks = @($versionGroup.Group | Where-Object { $_.Status -ne 'cancelled' })
+
+    $vName = $versionGroup.Name
+    $defaultVersionTitle = if ($versionTitles.Contains($vName)) { $versionTitles[$vName] } else { '' }
+    $localizedVersionTitle = Get-RoadmapVersionTitle -Version $vName -DefaultTitle $defaultVersionTitle -Localization $roadmapLocalization.VersionTitles
+    $titleSuffix = if (-not [string]::IsNullOrWhiteSpace($localizedVersionTitle)) { ': ' + $localizedVersionTitle } else { '' }
+    [void]$builder.AppendLine(('### {0}{1}' -f $vName, $titleSuffix))
+    [void]$builder.AppendLine()
+    [void]$builder.AppendLine('| 順 | ID | やること | 優先度 | 状態 |')
+    [void]$builder.AppendLine('|----|----|----------|--------|------|')
+
+    $sortedTasks = @(Get-RoadmapTaskOrder -Tasks $visibleTasks -Version $vName -TaskVersionById $taskVersionById)
+    $sequence = 0
+    foreach ($task in $sortedTasks) {
+        $sequence++
+        $localizedTaskTitle = Get-RoadmapTaskTitle -Task $task -Localization $roadmapLocalization.TaskTitles
+        [void]$builder.AppendLine(('| {0} | {1} | {2} | {3} | {4} |' -f $sequence, $task.Id, $localizedTaskTitle.Title, (Get-PriorityLabel -Priority $task.Priority), (Get-StatusLabel -Status $task.Status)))
+    }
+
+    [void]$builder.AppendLine()
+}
+
+[void]$builder.AppendLine('## 長期計画の未完了タスク')
+[void]$builder.AppendLine()
+[void]$builder.AppendLine('この表は、直近の詳細欄に出していない長期版の未完了タスクを確認するための一覧です。')
+[void]$builder.AppendLine('版ごとの見出しを保ち、依存順と優先度を同じ読み方で確認できます。')
+[void]$builder.AppendLine()
+
+foreach ($versionGroup in $versionGroups) {
+    if (Test-RoadmapVersionInFocusRange -Version $versionGroup.Name) {
         continue
     }
 
@@ -945,52 +1073,22 @@ foreach ($versionGroup in $versionGroups) {
     $titleSuffix = if (-not [string]::IsNullOrWhiteSpace($localizedVersionTitle)) { ': ' + $localizedVersionTitle } else { '' }
     [void]$builder.AppendLine(('### {0}{1}' -f $vName, $titleSuffix))
     [void]$builder.AppendLine()
-    [void]$builder.AppendLine('| | ID | やること | 優先度 | 対象 | 状態 |')
-    [void]$builder.AppendLine('|-|-----|-------|----------|------|--------|')
+    [void]$builder.AppendLine('| 順 | ID | やること | 優先度 | 状態 |')
+    [void]$builder.AppendLine('|----|----|----------|--------|------|')
 
-    $sortedTasks = @($visibleTasks | Sort-Object @{ Expression = { Get-PriorityRank -Priority $_.Priority } }, @{ Expression = { $_.IdNumber } }, @{ Expression = { $_.Id } })
+    $sortedTasks = @(Get-RoadmapTaskOrder -Tasks $visibleTasks -Version $vName -TaskVersionById $taskVersionById)
+    $sequence = 0
     foreach ($task in $sortedTasks) {
+        $sequence++
         $localizedTaskTitle = Get-RoadmapTaskTitle -Task $task -Localization $roadmapLocalization.TaskTitles
-        [void]$builder.AppendLine(('| {0} | {1} | {2} | {3} | {4} | {5} |' -f (Get-StatusSymbol -Status $task.Status), $task.Id, $localizedTaskTitle.Title, (Get-PriorityLabel -Priority $task.Priority), $task.Repo, (Get-StatusLabel -Status $task.Status)))
+        [void]$builder.AppendLine(('| {0} | {1} | {2} | {3} | {4} |' -f $sequence, $task.Id, $localizedTaskTitle.Title, (Get-PriorityLabel -Priority $task.Priority), (Get-StatusLabel -Status $task.Status)))
     }
 
     [void]$builder.AppendLine()
 }
 
-[void]$builder.AppendLine('## 長期計画の未完了タスク')
-[void]$builder.AppendLine()
-[void]$builder.AppendLine('この表は、直近の詳細欄に出していない長期版を確認するための一覧です。')
-[void]$builder.AppendLine('未完了タスクの題名、対象、状態を残し、後続版の見落としを防ぎます。')
-[void]$builder.AppendLine()
-[void]$builder.AppendLine('| バージョン | ID | やること | 優先度 | 対象 | 状態 |')
-[void]$builder.AppendLine('|-----------|----|----------|--------|------|------|')
-
-foreach ($versionGroup in $versionGroups) {
-    if (Test-RoadmapVersionInFocusRange -Version $versionGroup.Name) {
-        continue
-    }
-
-    $visibleTasks = @($versionGroup.Group | Where-Object { $_.Status -ne 'done' -and $_.Status -ne 'cancelled' })
-    if ($visibleTasks.Count -eq 0) {
-        continue
-    }
-
-    $sortedTasks = @($visibleTasks | Sort-Object @{ Expression = { Get-PriorityRank -Priority $_.Priority } }, @{ Expression = { $_.IdNumber } }, @{ Expression = { $_.Id } })
-    foreach ($task in $sortedTasks) {
-        $localizedTaskTitle = Get-RoadmapTaskTitle -Task $task -Localization $roadmapLocalization.TaskTitles
-        [void]$builder.AppendLine(('| {0} | {1} | {2} | {3} | {4} | {5} |' -f $versionGroup.Name, $task.Id, $localizedTaskTitle.Title, (Get-PriorityLabel -Priority $task.Priority), $task.Repo, (Get-StatusLabel -Status $task.Status)))
-    }
-}
-
 [void]$builder.AppendLine()
 [void]$builder.AppendLine('## 凡例')
-[void]$builder.AppendLine()
-[void]$builder.AppendLine('| 記号 | 意味 |')
-[void]$builder.AppendLine('|------|------|')
-[void]$builder.AppendLine('| [x] | 完了 |')
-[void]$builder.AppendLine('| [-] | 作業中 |')
-[void]$builder.AppendLine('| [R] | レビュー中 |')
-[void]$builder.AppendLine('| [ ] | 未着手 |')
 [void]$builder.AppendLine()
 [void]$builder.AppendLine('| 優先度 | 意味 |')
 [void]$builder.AppendLine('|--------|------|')


### PR DESCRIPTION
## Summary

- order each release roadmap by dependency readiness, then priority, then task ID
- re-evaluate the ready set after every selected task so newly unblocked P0 work precedes waiting P1 work
- simplify the table to `順 / ID / やること / 優先度 / 状態` and render task states in Japanese
- add regression coverage for ordering, omitted columns, translated states, missing dependencies, and cycles

## Validation

- `tests/PublicSurfacePolicy.Tests.ps1`: 29 passed, 0 failed
- generated v0.36.30 order: `659, 660, 804, 800, 796, 661, 714, 715, 716, 717, 785, 718, 662, 663, 664, 665, 786, 666, 667, 789, 798, 668`
- pre-push: git-guard passed, public-surface audit passed, gitleaks 540 commits / 0 leaks