### PR TITLE
fix(release): retarget public smoke recovery at the published hotfix

### DIFF
--- a/.github/workflows/public-smoke-recovery.yml
+++ b/.github/workflows/public-smoke-recovery.yml
@@ -6,12 +6,12 @@ on:
       release_tag:
         description: Immutable annotated release tag to verify.
         required: true
-        default: v0.36.30
+        default: v0.36.30.1
         type: string
       release_commit:
         description: Peeled commit of the immutable annotated release tag.
         required: true
-        default: 75dcae87538e96a4cf49dc844d8343842d3c3178
+        default: 8b9b6eb5a26aa490422e91286b647bca29adb8f5
         type: string
       native_version:
         description: Exact Core and Desktop product version.
@@ -21,7 +21,7 @@ on:
       npm_version:
         description: Exact public npm package version.
         required: true
-        default: 0.36.30
+        default: 0.36.30-pkgfix.1
         type: string
 
 permissions:
@@ -117,15 +117,15 @@ jobs:
           $version = if ($surface -ceq 'Npm') { $npmVersion } else { $nativeVersion }
 
           if (
-            $releaseTag -cne 'v0.36.30' -or
-            $releaseCommit -cne '75dcae87538e96a4cf49dc844d8343842d3c3178' -or
+            $releaseTag -cne 'v0.36.30.1' -or
+            $releaseCommit -cne '8b9b6eb5a26aa490422e91286b647bca29adb8f5' -or
             $nativeVersion -cne '0.36.30' -or
-            $npmVersion -cne '0.36.30' -or
+            $npmVersion -cne '0.36.30-pkgfix.1' -or
             $repository -cne 'Sora-bluesky/winsmux' -or
             $workflowRef -cne 'refs/heads/main' -or
             $surface -notin @('Core', 'Desktop', 'Npm')
           ) {
-            throw 'Recovery workflow accepts only the immutable v0.36.30 public coordinates from main.'
+            throw 'Recovery workflow accepts only the immutable v0.36.30.1 public coordinates from main.'
           }
 
           $helperSourceCommit = (& git rev-parse HEAD).Trim()
@@ -136,11 +136,11 @@ jobs:
 
           $tagBefore = Get-RemoteTagIdentity -Tag $releaseTag
           if (
-            $tagBefore.tag_object_sha -cne 'feaab01701ddd1f0930da2e8b72cab1e7b25edb0' -or
+            $tagBefore.tag_object_sha -cne '9f5585151703d8d1dd3fca373d687194f0b94933' -or
             $tagBefore.target_commit -cne $releaseCommit -or
             $tagBefore.tag_object_sha -ceq $tagBefore.target_commit
           ) {
-            throw 'Annotated tag identity did not bind the immutable v0.36.30 object and peeled target.'
+            throw 'Annotated tag identity did not bind the immutable v0.36.30.1 object and peeled target.'
           }
 
           $helperOutput = @(

--- a/.github/workflows/public-smoke-recovery.yml
+++ b/.github/workflows/public-smoke-recovery.yml
@@ -114,7 +114,6 @@ jobs:
           $workflowRef = [string]$env:RECOVERY_WORKFLOW_REF
           $workflowSha = [string]$env:RECOVERY_WORKFLOW_SHA
           $surface = [string]$env:RECOVERY_SURFACE
-          $version = if ($surface -ceq 'Npm') { $npmVersion } else { $nativeVersion }
 
           if (
             $releaseTag -cne 'v0.36.30.1' -or
@@ -127,6 +126,10 @@ jobs:
           ) {
             throw 'Recovery workflow accepts only the immutable v0.36.30.1 public coordinates from main.'
           }
+
+          $workflowVersion = $releaseTag.Substring(1)
+          $helperVersion = if ($surface -ceq 'Npm') { $npmVersion } else { $workflowVersion }
+          $expectedReceiptVersion = if ($surface -ceq 'Npm') { $npmVersion } else { $nativeVersion }
 
           $helperSourceCommit = (& git rev-parse HEAD).Trim()
           if ($LASTEXITCODE -ne 0 -or $helperSourceCommit -cne $workflowSha) {
@@ -144,7 +147,7 @@ jobs:
           }
 
           $helperOutput = @(
-            & ./scripts/test-public-release.ps1 -Surface $surface -Version $version -ReleaseTag $releaseTag -Repository $repository -Json
+            & ./scripts/test-public-release.ps1 -Surface $surface -Version $helperVersion -ReleaseTag $releaseTag -Repository $repository -Json
           )
           if ($helperOutput.Count -ne 1) {
             throw "$surface helper did not produce exactly one terminal JSON receipt."
@@ -164,7 +167,7 @@ jobs:
           if (
             $helperReceipt.ok -ne $true -or
             [string]$helperReceipt.surface -cne $surface -or
-            [string]$helperReceipt.version -cne $version -or
+            [string]$helperReceipt.version -cne $expectedReceiptVersion -or
             [string]$helperReceipt.release_tag -cne $releaseTag -or
             [string]$helperReceipt.repository -cne $repository -or
             [string]$helperReceipt.cleanup -cne 'clean'

--- a/tests/VersionSurface.Tests.ps1
+++ b/tests/VersionSurface.Tests.ps1
@@ -845,8 +845,8 @@ Describe 'winsmux version surface' {
         }
         foreach ($coordinate in @(
             'refs/heads/main',
-            'feaab01701ddd1f0930da2e8b72cab1e7b25edb0',
-            '75dcae87538e96a4cf49dc844d8343842d3c3178',
+            '9f5585151703d8d1dd3fca373d687194f0b94933',
+            '8b9b6eb5a26aa490422e91286b647bca29adb8f5',
             'refs/tags/$Tag^{}',
             'helperSourceCommit -cne $workflowSha',
             'tagBefore = Get-RemoteTagIdentity',


### PR DESCRIPTION
## Summary

The public smoke recovery workflow pins one immutable release and refuses to run against anything
else. v0.36.30.1 is now published, so those pins move to it.

Four values change. Three of them are dispatch inputs and move in two places each, in the default and
in the guard that rejects mismatched values: the release tag, the peeled release commit, and the npm
package version. The fourth is the annotated tag object that the identity check binds to; it has no
input default and exists only in that guard.

The native product version deliberately does not move. It stays at 0.36.30 because this release is a
packaging hotfix and the product version did not change. The published desktop assets are still named
for 0.36.30, and the workflow builds the expected asset name from that value, so changing it would
make the workflow look for files that do not exist.

## Why

The guard exists so the workflow cannot be pointed at arbitrary coordinates. That also means it
cannot follow a new release on its own: leaving it as it is would make every post-release run throw
before it verified anything.

## Verification

The defaults and the guard were checked against each other so that a dispatch with no overrides
passes rather than throws. No literal of the previous tag or previous release commit remains in the
file. The native version is unchanged in both the default and the guard. The file parses as YAML.

The coordinates themselves were taken from the published release rather than from the plan: the
annotated tag object and its peeled commit come from the pushed tag, and the npm version comes from
the registry entry that the release workflow published.

## Scope and rollback

One workflow file. Rollback is a single-commit revert, which restores the previous pins.
