### PR TITLE
fix(deps): update postcss past GHSA-fxqj-rqcc-2cmp

### DIFF
--- a/winsmux-app/package-lock.json
+++ b/winsmux-app/package-lock.json
@@ -1169,9 +1169,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -1255,9 +1255,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.18",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.18.tgz",
-      "integrity": "sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -1275,7 +1275,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },


### PR DESCRIPTION
## Summary

- update the transitive development dependency `postcss` from 8.5.18 to 8.5.26
- update `nanoid` from 3.3.12 to 3.3.18 as required by the patched PostCSS release
- resolve Dependabot alert #20 / GHSA-fxqj-rqcc-2cmp (CVE-2026-69153)

## Security context

Dependabot reports PostCSS versions through 8.5.22 as vulnerable to attacker-controlled `sourceMappingURL` reads when `from` is unset. The first patched release is 8.5.23; this lockfile resolves 8.5.26.

## Verification

- `npm audit --package-lock-only --ignore-scripts --json`: 0 vulnerabilities
- `npm ci --ignore-scripts --no-audit --no-fund`: passed
- `npm run build`: passed
- `scripts/git-guard.ps1 -Mode staged`: passed
- `scripts/git-guard.ps1 -Mode full`: passed
- `scripts/audit-public-surface.ps1`: passed
- pre-push gitleaks: 553 commits, no leaks

Alert: https://github.com/Sora-bluesky/winsmux/security/dependabot/20
