### PR TITLE
fix(release): normalize bounded probe boolean output

### DIFF
--- a/scripts/test-public-release.ps1
+++ b/scripts/test-public-release.ps1
@@ -1264,16 +1264,20 @@ function Invoke-BoundedDiagnosisProbe {
         if ($runner.HadErrors) {
             return 'error:io'
         }
-        $value = $false
-        if ($output.Count -ge 1) {
-            $lastOutput = $output[$output.Count - 1]
-            if ($lastOutput -is [string] -and $lastOutput -cmatch '^(?:true|false|unknown|error:[a-z]+)$') {
-                return [string]$lastOutput
-            }
-            $value = [bool]$lastOutput
+        if ($output.Count -lt 1) {
+            return 'false'
         }
-        if ($value) { return 'true' }
-        return 'false'
+        $lastOutputText = [string]$output[$output.Count - 1]
+        if ($lastOutputText -ceq [bool]::TrueString) {
+            return 'true'
+        }
+        if ($lastOutputText -ceq [bool]::FalseString) {
+            return 'false'
+        }
+        if ($lastOutputText -cmatch '^(?:true|false|unknown|error:[a-z]+)$') {
+            return $lastOutputText
+        }
+        return 'error:io'
     } catch {
         return 'error:io'
     } finally {
@@ -3829,12 +3833,14 @@ try {
                 probe_false = @{ Script = { param($ProbeArgument) $false }; Argument = $null }
                 probe_error = @{ Script = { param($ProbeArgument) throw 'synthetic diagnosis failure' }; Argument = $null }
                 probe_timeout = @{ Script = { param($ProbeArgument) Start-Sleep -Milliseconds 400; $true }; Argument = $null }
+                probe_invalid_output = @{ Script = { param($ProbeArgument) 'unexpected' }; Argument = $null }
             }
             $syntheticDiagnosis = Get-DesktopTeardownDiagnosis -UserDataFolder $diagnosisRoot -ProbeTable $syntheticProbeTable -ProbeTimeoutMilliseconds 100 -TotalBudgetMilliseconds 5000
             Assert-Condition ([string]$syntheticDiagnosis.probe_true -ceq 'true') 'The immediate true teardown probe did not return true.'
             Assert-Condition ([string]$syntheticDiagnosis.probe_false -ceq 'false') 'The immediate false teardown probe did not return false.'
             Assert-Condition ([string]$syntheticDiagnosis.probe_error -ceq 'error:io') 'The throwing teardown probe did not return error:io.'
             Assert-Condition ([string]$syntheticDiagnosis.probe_timeout -ceq 'error:timeout') 'The sleeping teardown probe did not return error:timeout.'
+            Assert-Condition ([string]$syntheticDiagnosis.probe_invalid_output -ceq 'error:io') 'The teardown probe accepted output outside the closed value domain.'
 
             $missingDiagnosisUserData = Join-Path $diagnosisRoot 'missing-user-data'
             $realProbeTable = New-DesktopTeardownProbeTable -UserDataFolder $missingDiagnosisUserData -RootProcessId $PID -DebugPort 49161

--- a/scripts/test-public-release.ps1
+++ b/scripts/test-public-release.ps1
@@ -3832,15 +3832,19 @@ try {
                 probe_true = @{ Script = { param($ProbeArgument) $true }; Argument = $null }
                 probe_false = @{ Script = { param($ProbeArgument) $false }; Argument = $null }
                 probe_error = @{ Script = { param($ProbeArgument) throw 'synthetic diagnosis failure' }; Argument = $null }
-                probe_timeout = @{ Script = { param($ProbeArgument) Start-Sleep -Milliseconds 400; $true }; Argument = $null }
                 probe_invalid_output = @{ Script = { param($ProbeArgument) 'unexpected' }; Argument = $null }
             }
-            $syntheticDiagnosis = Get-DesktopTeardownDiagnosis -UserDataFolder $diagnosisRoot -ProbeTable $syntheticProbeTable -ProbeTimeoutMilliseconds 100 -TotalBudgetMilliseconds 5000
+            $syntheticDiagnosis = Get-DesktopTeardownDiagnosis -UserDataFolder $diagnosisRoot -ProbeTable $syntheticProbeTable
             Assert-Condition ([string]$syntheticDiagnosis.probe_true -ceq 'true') 'The immediate true teardown probe did not return true.'
             Assert-Condition ([string]$syntheticDiagnosis.probe_false -ceq 'false') 'The immediate false teardown probe did not return false.'
             Assert-Condition ([string]$syntheticDiagnosis.probe_error -ceq 'error:io') 'The throwing teardown probe did not return error:io.'
-            Assert-Condition ([string]$syntheticDiagnosis.probe_timeout -ceq 'error:timeout') 'The sleeping teardown probe did not return error:timeout.'
             Assert-Condition ([string]$syntheticDiagnosis.probe_invalid_output -ceq 'error:io') 'The teardown probe accepted output outside the closed value domain.'
+
+            $syntheticTimeoutProbeTable = [ordered]@{
+                probe_timeout = @{ Script = { param($ProbeArgument) Start-Sleep -Milliseconds 400; $true }; Argument = $null }
+            }
+            $syntheticTimeoutDiagnosis = Get-DesktopTeardownDiagnosis -UserDataFolder $diagnosisRoot -ProbeTable $syntheticTimeoutProbeTable -ProbeTimeoutMilliseconds 100 -TotalBudgetMilliseconds 500
+            Assert-Condition ([string]$syntheticTimeoutDiagnosis.probe_timeout -ceq 'error:timeout') 'The sleeping teardown probe did not return error:timeout.'
 
             $missingDiagnosisUserData = Join-Path $diagnosisRoot 'missing-user-data'
             $realProbeTable = New-DesktopTeardownProbeTable -UserDataFolder $missingDiagnosisUserData -RootProcessId $PID -DebugPort 49161


### PR DESCRIPTION
## Summary

The latest `main` CI run failed in the `release-public` Pester shard because the Desktop teardown self-test observed a PowerShell Boolean differently across runtimes. This change replaces truthiness casting with an explicit closed-domain conversion so public release smoke behavior is deterministic.

## Changes

- Normalize Boolean `True` and `False` to the public `true` and `false` diagnosis values.
- Preserve the existing `true|false|unknown|error:*` closed string domain.
- Reject unexpected probe output as `error:io`.
- Extend the existing Desktop self-test with an unexpected-output case.

## Verification

- Exact Pester 5.7.1 focused `T668-SMOKE-DESKTOP`: 1/1 passed.
- Desktop public-smoke self-test JSON: exit 0, valid result, all diagnosis values in the closed domain.
- Exact Pester 5.7.1 `release-public` shard: 136/136 passed.
- PowerShell parser: 0 errors.
- `git diff --check`: passed.
- `git-guard`, public-surface audit, and verified gitleaks push checks: passed.
- Independent frozen-candidate review: PASS.

## Scope

Only `scripts/test-public-release.ps1` changes. TASK-810 and release workflow topology are unchanged.
