### PR TITLE
TASK-796: isolate Pester Git fixtures from host config and hooks

### DIFF
--- a/.githooks/pre-commit-whitelist.ps1
+++ b/.githooks/pre-commit-whitelist.ps1
@@ -155,6 +155,8 @@ $whitelistPatterns = @(
     'tests/V03619RepoAudit.Tests.ps1',
     'tests/Task810PesterRunner.Tests.ps1',
     'tests/Task800OperatorShellBoundary.Tests.ps1',
+    'tests/PesterGitIsolation.Tests.ps1',
+    'tests/Integration.WorktreeHook.Tests.ps1',
     'tests/README.md',
     'tests/V03620CoordinatorFoundation.Tests.ps1',
     'tests/V03621LocalRouterShadow.Tests.ps1',

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -197,7 +197,7 @@ jobs:
           - name: integration
             result: integration
             timeout_minutes: 25
-            paths: tests/Integration.GateEnforcement.Tests.ps1;tests/Integration.MultiAgent.Tests.ps1;tests/Integration.PaneMonitorHook.Tests.ps1;tests/Integration.PluginHookLoader.Tests.ps1;tests/Integration.WorktreeHook.Tests.ps1;tests/Task839WorktreeReviewState.Tests.ps1;tests/V03630DesktopDebugGate.Tests.ps1;tests/DeclarativeWorkflow.Tests.ps1;tests/Task810PesterRunner.Tests.ps1;tests/Task800OperatorShellBoundary.Tests.ps1
+            paths: tests/Integration.GateEnforcement.Tests.ps1;tests/Integration.MultiAgent.Tests.ps1;tests/Integration.PaneMonitorHook.Tests.ps1;tests/Integration.PluginHookLoader.Tests.ps1;tests/Integration.WorktreeHook.Tests.ps1;tests/Task839WorktreeReviewState.Tests.ps1;tests/V03630DesktopDebugGate.Tests.ps1;tests/DeclarativeWorkflow.Tests.ps1;tests/Task810PesterRunner.Tests.ps1;tests/Task800OperatorShellBoundary.Tests.ps1;tests/PesterGitIsolation.Tests.ps1
           - name: worker-benchmark
             result: worker-benchmark
             timeout_minutes: 20

--- a/.gitignore
+++ b/.gitignore
@@ -115,6 +115,7 @@ tests/bridge/_helpers/*
 !tests/V03630DesktopDebugGateProcess.Tests.ps1
 !tests/Task810PesterRunner.Tests.ps1
 !tests/Task800OperatorShellBoundary.Tests.ps1
+!tests/PesterGitIsolation.Tests.ps1
 !tests/BuilderWorktree.Tests.ps1
 !tests/codex-subagent-worktree-guard.Tests.ps1
 !tests/PublicSurfacePolicy.Tests.ps1

--- a/scripts/run-tests.ps1
+++ b/scripts/run-tests.ps1
@@ -506,6 +506,36 @@ function New-RunnerCandidateContext {
     if ($sourceDiff.ExitCode -ne 0) {
         throw "Candidate/source comparison failed ($($sourceDiff.ExitCode)): $($sourceDiff.StdErr)"
     }
+    $headInventory = Invoke-RunnerGit -RepositoryRoot $repositoryRoot -Arguments @('ls-tree', '-r', '--name-only', '-z', 'HEAD') -Environment $gitEnvironment -AllowFailure
+    if ($headInventory.ExitCode -eq 128) {
+        # Unborn HEAD has no committed paths that a staged deletion could leave behind.
+    } elseif ($headInventory.ExitCode -ne 0) {
+        throw "Candidate/HEAD path inventory failed ($($headInventory.ExitCode)): $($headInventory.StdErr)"
+    } else {
+        $candidateInventory = Invoke-RunnerGit -RepositoryRoot $repositoryRoot -Arguments @('ls-tree', '-r', '--name-only', '-z', $candidateTreeId) -Environment $gitEnvironment
+        $candidatePaths = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::OrdinalIgnoreCase)
+        foreach ($relativePath in @($candidateInventory.StdOut -split "`0" | Where-Object { $_ })) {
+            [void]$candidatePaths.Add(([string]$relativePath).Replace('\', '/'))
+        }
+        $repositoryPrefix = $repositoryRoot.TrimEnd('\', '/') + [System.IO.Path]::DirectorySeparatorChar
+        $leftovers = [System.Collections.Generic.List[string]]::new()
+        foreach ($relativePath in @($headInventory.StdOut -split "`0" | Where-Object { $_ })) {
+            $normalized = ([string]$relativePath).Replace('\', '/')
+            if ($candidatePaths.Contains($normalized)) {
+                continue
+            }
+            $fullPath = [System.IO.Path]::GetFullPath((Join-Path $repositoryRoot $normalized))
+            if (-not $fullPath.StartsWith($repositoryPrefix, [StringComparison]::OrdinalIgnoreCase)) {
+                throw "Staged-deletion path escapes repository root: $normalized"
+            }
+            if (Test-Path -LiteralPath $fullPath -PathType Leaf) {
+                $leftovers.Add($normalized)
+            }
+        }
+        if ($leftovers.Count -gt 0) {
+            throw "Candidate index omits working-tree files that remain after staged deletion: $($leftovers -join ', ')"
+        }
+    }
     $objectPathText = (Invoke-RunnerGit -RepositoryRoot $repositoryRoot -Arguments @('rev-parse', '--git-path', 'objects') -Environment $gitEnvironment).StdOut
     $candidateEnvironment = [ordered]@{}
     foreach ($entry in $gitEnvironment.GetEnumerator()) {

--- a/scripts/run-tests.ps1
+++ b/scripts/run-tests.ps1
@@ -978,6 +978,180 @@ function Assert-PesterWorkerSpecCandidatePaths {
     }
 }
 
+function Test-PesterPathUnderRoot {
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $true)][string]$Root
+    )
+
+    $fullPath = [System.IO.Path]::GetFullPath($Path)
+    $rootPrefix = [System.IO.Path]::GetFullPath($Root).TrimEnd('\', '/') + [System.IO.Path]::DirectorySeparatorChar
+    return $fullPath.StartsWith($rootPrefix, [StringComparison]::OrdinalIgnoreCase)
+}
+
+function Invoke-SerialPesterSlice {
+    param(
+        [Parameter(Mandatory = $true)][string]$WorkingDirectory,
+        [Parameter(Mandatory = $true)][string[]]$Paths,
+        [Parameter(Mandatory = $true)]$PesterModule,
+        [Parameter(Mandatory = $true)][string]$TestResultPath,
+        [string[]]$LineFilters = @(),
+        [string[]]$CoverageTargets = @(),
+        [string]$CoverageReportPath = '',
+        [switch]$EnableCoverage
+    )
+
+    if ($Paths.Count -eq 0) {
+        throw 'Serial Pester slice received no test paths.'
+    }
+
+    $previousLocationPath = (Get-Location).Path
+    $result = $null
+    try {
+        Push-Location -LiteralPath $WorkingDirectory
+        if ($PesterModule.Version.Major -ge 5) {
+            Import-Module $PesterModule.Path -Force -ErrorAction Stop | Out-Null
+            $configuration = [PesterConfiguration]::Default
+            $configuration.Run.Path = @($Paths)
+            $configuration.Run.PassThru = $true
+            $configuration.Run.Exit = $false
+            $configuration.Output.Verbosity = 'None'
+            $configuration.TestResult.Enabled = $true
+            $configuration.TestResult.OutputFormat = 'NUnitXml'
+            $configuration.TestResult.OutputPath = $TestResultPath
+            if ($LineFilters.Count -gt 0) {
+                $configuration.Filter.Line = @($LineFilters)
+            }
+            $configuration.CodeCoverage.Enabled = [bool]$EnableCoverage
+            if ($EnableCoverage) {
+                $configuration.CodeCoverage.Path = @($CoverageTargets)
+                $configuration.CodeCoverage.OutputPath = $CoverageReportPath
+            }
+            $result = Invoke-PesterIsolated -Configuration $configuration
+        } else {
+            if ($LineFilters.Count -gt 0) {
+                throw 'Pester line filters require Pester 5 or newer.'
+            }
+            if ($EnableCoverage) {
+                $result = Invoke-Pester @($Paths) -PassThru -Quiet -CodeCoverage @($CoverageTargets) -OutputFormat NUnitXml -OutputFile $TestResultPath
+            } else {
+                $result = Invoke-Pester @($Paths) -PassThru -Quiet -OutputFormat NUnitXml -OutputFile $TestResultPath
+            }
+        }
+    } finally {
+        Set-Location -LiteralPath $previousLocationPath
+    }
+    return $result
+}
+
+function Merge-SerialPesterCodeCoverage {
+    param($First, $Second)
+
+    if ($null -eq $First) { return $Second }
+    if ($null -eq $Second) { return $First }
+
+    $firstCommands = @()
+    $secondCommands = @()
+    if ($First.PSObject.Properties.Name -contains 'Commands') {
+        $firstCommands = @($First.Commands)
+    }
+    if ($Second.PSObject.Properties.Name -contains 'Commands') {
+        $secondCommands = @($Second.Commands)
+    }
+    if ($firstCommands.Count -eq 0 -and $secondCommands.Count -eq 0) {
+        $analyzed = [int](Get-ObjectProperty -InputObject $First -Name 'NumberOfCommandsAnalyzed' -DefaultValue 0)
+        $executed = [int](Get-ObjectProperty -InputObject $First -Name 'NumberOfCommandsExecuted' -DefaultValue 0)
+        $analyzed2 = [int](Get-ObjectProperty -InputObject $Second -Name 'NumberOfCommandsAnalyzed' -DefaultValue 0)
+        $executed2 = [int](Get-ObjectProperty -InputObject $Second -Name 'NumberOfCommandsExecuted' -DefaultValue 0)
+        $mergedAnalyzed = [math]::Max($analyzed, $analyzed2)
+        $mergedExecuted = [math]::Max($executed, $executed2)
+        $percent = if ($mergedAnalyzed -le 0) { 0 } else { [math]::Round(($mergedExecuted / [double]$mergedAnalyzed) * 100, 2) }
+        return [PSCustomObject]@{
+            CoveragePercent = $percent
+            NumberOfCommandsAnalyzed = $mergedAnalyzed
+            NumberOfCommandsExecuted = $mergedExecuted
+        }
+    }
+
+    $hits = @{}
+    foreach ($command in @($firstCommands + $secondCommands)) {
+        $file = [string](Get-ObjectProperty -InputObject $command -Name 'File' -DefaultValue '')
+        $line = [int](Get-ObjectProperty -InputObject $command -Name 'Line' -DefaultValue 0)
+        $commandText = [string](Get-ObjectProperty -InputObject $command -Name 'Command' -DefaultValue '')
+        $key = '{0}|{1}|{2}' -f $file, $line, $commandText
+        $executed = [bool](Get-ObjectProperty -InputObject $command -Name 'Executed' -DefaultValue $false)
+        if (-not $hits.ContainsKey($key)) {
+            $hits[$key] = $executed
+        } elseif ($executed) {
+            $hits[$key] = $true
+        }
+    }
+    $analyzed = $hits.Count
+    $executedCount = @($hits.Values | Where-Object { $_ }).Count
+    $percent = if ($analyzed -le 0) { 0 } else { [math]::Round(($executedCount / [double]$analyzed) * 100, 2) }
+    return [PSCustomObject]@{
+        CoveragePercent = $percent
+        NumberOfCommandsAnalyzed = $analyzed
+        NumberOfCommandsExecuted = $executedCount
+    }
+}
+
+function Merge-SerialPesterSliceResults {
+    param([Parameter(Mandatory = $true)][object[]]$Results)
+
+    $results = @($Results | Where-Object { $null -ne $_ })
+    if ($results.Count -eq 0) {
+        throw 'Serial Pester produced no slice results.'
+    }
+    if ($results.Count -eq 1) {
+        return $results[0]
+    }
+
+    $passed = 0
+    $failed = 0
+    $total = 0
+    $skipped = 0
+    $notRun = 0
+    $failedBlocks = 0
+    $failedContainers = 0
+    $tests = [System.Collections.Generic.List[object]]::new()
+    $coverage = $null
+    foreach ($result in $results) {
+        $passed += [int](Get-ObjectProperty -InputObject $result -Name 'PassedCount' -DefaultValue 0)
+        $failed += [int](Get-ObjectProperty -InputObject $result -Name 'FailedCount' -DefaultValue 0)
+        $total += [int](Get-ObjectProperty -InputObject $result -Name 'TotalCount' -DefaultValue 0)
+        $skipped += [int](Get-ObjectProperty -InputObject $result -Name 'SkippedCount' -DefaultValue 0)
+        $notRun += [int](Get-ObjectProperty -InputObject $result -Name 'NotRunCount' -DefaultValue 0)
+        $failedBlocks += [int](Get-ObjectProperty -InputObject $result -Name 'FailedBlocksCount' -DefaultValue 0)
+        $failedContainers += [int](Get-ObjectProperty -InputObject $result -Name 'FailedContainersCount' -DefaultValue 0)
+        foreach ($test in @($result.Tests)) {
+            $tests.Add($test)
+        }
+        $sliceCoverage = $null
+        if ($result.PSObject.Properties.Name -contains 'CodeCoverage') {
+            $sliceCoverage = $result.CodeCoverage
+        }
+        $coverage = Merge-SerialPesterCodeCoverage -First $coverage -Second $sliceCoverage
+    }
+    $outcome = if (($failed -gt 0) -or ($failedBlocks -gt 0) -or ($failedContainers -gt 0)) {
+        'Failed'
+    } else {
+        'Passed'
+    }
+    return [PSCustomObject]@{
+        PassedCount = $passed
+        FailedCount = $failed
+        TotalCount = $total
+        SkippedCount = $skipped
+        NotRunCount = $notRun
+        FailedBlocksCount = $failedBlocks
+        FailedContainersCount = $failedContainers
+        Result = $outcome
+        Tests = $tests.ToArray()
+        CodeCoverage = $coverage
+    }
+}
+
 function Invoke-SerialSuite {
     param(
         [Parameter(Mandatory = $true)][string]$RepositoryRoot,
@@ -1004,38 +1178,95 @@ function Invoke-SerialSuite {
         -PrivateRepositoryRoot $PrivateRepositoryRoot `
         -CandidateTestPaths $CandidateTestPaths)
     $executionLineFilters = @()
-    if ($PesterModule.Version.Major -ge 5) {
-        Import-Module $PesterModule.Path -Force -ErrorAction Stop | Out-Null
-        $configuration = [PesterConfiguration]::Default
-        $configuration.Run.Path = $executionPaths
-        $configuration.Run.PassThru = $true
-        $configuration.Run.Exit = $false
-        $configuration.Output.Verbosity = 'None'
-        $configuration.TestResult.Enabled = $true
-        $configuration.TestResult.OutputFormat = 'NUnitXml'
-        $configuration.TestResult.OutputPath = $TestResultPath
-        if ($LineFilters.Count -gt 0) {
-            $executionLineFilters = @(Convert-PesterExecutionLineFilters `
-                -RepositoryRoot $RepositoryRoot `
-                -PrivateRepositoryRoot $PrivateRepositoryRoot `
-                -LineFilters $LineFilters)
-            $configuration.Filter.Line = $executionLineFilters
-        }
-        $configuration.CodeCoverage.Enabled = [bool]$EnableCoverage
-        if ($EnableCoverage) {
-            $configuration.CodeCoverage.Path = $coverageTargets
-            $configuration.CodeCoverage.OutputPath = $CoverageReportPath
-        }
-        $result = Invoke-PesterIsolated -Configuration $configuration
-    } else {
-        if ($LineFilters.Count -gt 0) {
-            throw 'Pester line filters require Pester 5 or newer.'
-        }
-        if ($EnableCoverage) {
-            $result = Invoke-Pester $executionPaths -PassThru -Quiet -CodeCoverage $coverageTargets -OutputFormat NUnitXml -OutputFile $TestResultPath
+    if ($LineFilters.Count -gt 0) {
+        $executionLineFilters = @(Convert-PesterExecutionLineFilters `
+            -RepositoryRoot $RepositoryRoot `
+            -PrivateRepositoryRoot $PrivateRepositoryRoot `
+            -LineFilters $LineFilters)
+    }
+
+    $mutablePaths = [System.Collections.Generic.List[string]]::new()
+    $immutablePaths = [System.Collections.Generic.List[string]]::new()
+    foreach ($path in $executionPaths) {
+        if (Test-PesterPathUnderRoot -Path $path -Root $PrivateRepositoryRoot) {
+            $mutablePaths.Add($path)
         } else {
-            $result = Invoke-Pester $executionPaths -PassThru -Quiet -OutputFormat NUnitXml -OutputFile $TestResultPath
+            $immutablePaths.Add($path)
         }
+    }
+    $mutableFilters = [System.Collections.Generic.List[string]]::new()
+    $immutableFilters = [System.Collections.Generic.List[string]]::new()
+    foreach ($line in $executionLineFilters) {
+        $separator = ([string]$line).LastIndexOf(':')
+        $filterPath = if ($separator -gt 0) { ([string]$line).Substring(0, $separator) } else { [string]$line }
+        if (Test-PesterPathUnderRoot -Path $filterPath -Root $PrivateRepositoryRoot) {
+            $mutableFilters.Add([string]$line)
+        } else {
+            $immutableFilters.Add([string]$line)
+        }
+    }
+    if ($executionLineFilters.Count -gt 0) {
+        if ($mutableFilters.Count -eq 0) { $mutablePaths.Clear() }
+        if ($immutableFilters.Count -eq 0) { $immutablePaths.Clear() }
+    }
+    if (($mutablePaths.Count -eq 0) -and ($immutablePaths.Count -eq 0)) {
+        throw 'Serial Pester inventory has no executable slices.'
+    }
+
+    $previousLocationPath = (Get-Location).Path
+    $sliceResults = [System.Collections.Generic.List[object]]::new()
+    $nunitPaths = [System.Collections.Generic.List[string]]::new()
+    $result = $null
+    try {
+        if ($mutablePaths.Count -gt 0) {
+            $mutableResultPath = if ($immutablePaths.Count -gt 0) { "$TestResultPath.mutable.xml" } else { $TestResultPath }
+            $mutableCoveragePath = if ($immutablePaths.Count -gt 0) { "$CoverageReportPath.mutable.xml" } else { $CoverageReportPath }
+            $sliceResults.Add((Invoke-SerialPesterSlice `
+                -WorkingDirectory $PrivateRepositoryRoot `
+                -Paths @($mutablePaths) `
+                -PesterModule $PesterModule `
+                -TestResultPath $mutableResultPath `
+                -LineFilters @($mutableFilters) `
+                -CoverageTargets $coverageTargets `
+                -CoverageReportPath $mutableCoveragePath `
+                -EnableCoverage:$EnableCoverage))
+            $nunitPaths.Add($mutableResultPath)
+        }
+        if ($immutablePaths.Count -gt 0) {
+            $immutableResultPath = if ($mutablePaths.Count -gt 0) { "$TestResultPath.immutable.xml" } else { $TestResultPath }
+            $immutableCoveragePath = if ($mutablePaths.Count -gt 0) { "$CoverageReportPath.immutable.xml" } else { $CoverageReportPath }
+            $sliceResults.Add((Invoke-SerialPesterSlice `
+                -WorkingDirectory $RepositoryRoot `
+                -Paths @($immutablePaths) `
+                -PesterModule $PesterModule `
+                -TestResultPath $immutableResultPath `
+                -LineFilters @($immutableFilters) `
+                -CoverageTargets $coverageTargets `
+                -CoverageReportPath $immutableCoveragePath `
+                -EnableCoverage:$EnableCoverage))
+            $nunitPaths.Add($immutableResultPath)
+        }
+        $result = Merge-SerialPesterSliceResults -Results @($sliceResults)
+        if ($nunitPaths.Count -gt 1) {
+            $mergedFailed = [int](Get-ObjectProperty -InputObject $result -Name 'FailedCount' -DefaultValue 0)
+            $mergedSkipped = [int](Get-ObjectProperty -InputObject $result -Name 'SkippedCount' -DefaultValue 0)
+            $mergedNotRun = [int](Get-ObjectProperty -InputObject $result -Name 'NotRunCount' -DefaultValue 0)
+            $mergedTotal = [int](Get-ObjectProperty -InputObject $result -Name 'TotalCount' -DefaultValue 0)
+            $mergedBlocks = [int](Get-ObjectProperty -InputObject $result -Name 'FailedBlocksCount' -DefaultValue 0)
+            $mergedContainers = [int](Get-ObjectProperty -InputObject $result -Name 'FailedContainersCount' -DefaultValue 0)
+            Merge-NUnitResults `
+                -Paths @($nunitPaths) `
+                -OutputPath $TestResultPath `
+                -TotalCount $mergedTotal `
+                -FailedCount $mergedFailed `
+                -ErrorsCount ($mergedBlocks + $mergedContainers) `
+                -SkippedCount $mergedSkipped `
+                -NotRunCount $mergedNotRun `
+                -InconclusiveCount 0 `
+                -DurationSeconds $stopwatch.Elapsed.TotalSeconds
+        }
+    } finally {
+        Set-Location -LiteralPath $previousLocationPath
     }
     $stopwatch.Stop()
     $selectedTests = if ($executionLineFilters.Count -gt 0) {

--- a/scripts/run-tests.ps1
+++ b/scripts/run-tests.ps1
@@ -92,14 +92,18 @@ function Get-CoveragePercent {
         return [double]$CodeCoverage.CoveragePercent
     }
 
-    if (($CodeCoverage.PSObject.Properties.Name -contains 'NumberOfCommandsAnalyzed') -and
-        ($CodeCoverage.PSObject.Properties.Name -contains 'NumberOfCommandsExecuted')) {
-        $analyzed = [double]$CodeCoverage.NumberOfCommandsAnalyzed
-        if ($analyzed -le 0) {
+    $analyzed = Get-PesterCoverageNumericCount -InputObject $CodeCoverage -Names @(
+        'NumberOfCommandsAnalyzed', 'CommandsAnalyzedCount', 'CommandsAnalyzed'
+    )
+    $executed = Get-PesterCoverageNumericCount -InputObject $CodeCoverage -Names @(
+        'NumberOfCommandsExecuted', 'CommandsExecutedCount'
+    )
+    if ($null -ne $analyzed -and $null -ne $executed) {
+        if ([double]$analyzed -le 0) {
             return 0
         }
 
-        return [math]::Round(([double]$CodeCoverage.NumberOfCommandsExecuted / $analyzed) * 100, 2)
+        return [math]::Round(([double]$executed / [double]$analyzed) * 100, 2)
     }
 
     return $null
@@ -1044,32 +1048,159 @@ function Invoke-SerialPesterSlice {
     return $result
 }
 
+function Get-PesterCoverageNumericCount {
+    param(
+        [Parameter(Mandatory = $true)]$InputObject,
+        [Parameter(Mandatory = $true)][string[]]$Names
+    )
+
+    foreach ($name in $Names) {
+        $value = Get-ObjectProperty -InputObject $InputObject -Name $name
+        if ($null -eq $value) {
+            continue
+        }
+        if ($value -is [byte] -or $value -is [int16] -or $value -is [uint16] -or
+            $value -is [int] -or $value -is [uint32] -or $value -is [long] -or
+            $value -is [uint64] -or $value -is [decimal] -or $value -is [double] -or
+            $value -is [single] -or $value -is [int64]) {
+            return [int]$value
+        }
+    }
+    return $null
+}
+
+function Get-PesterCoverageCommandRecords {
+    param($CodeCoverage)
+
+    if ($null -eq $CodeCoverage) {
+        return @()
+    }
+
+    $names = @($CodeCoverage.PSObject.Properties.Name)
+    if ($names -contains 'Commands') {
+        $commands = @($CodeCoverage.Commands)
+        if ($commands.Count -gt 0) {
+            return $commands
+        }
+    }
+
+    $hits = @()
+    $misses = @()
+    if ($names -contains 'CommandsExecuted') {
+        $hits = @($CodeCoverage.CommandsExecuted)
+    } elseif ($names -contains 'HitCommands') {
+        $hits = @($CodeCoverage.HitCommands)
+    }
+    if ($names -contains 'CommandsMissed') {
+        $misses = @($CodeCoverage.CommandsMissed)
+    } elseif ($names -contains 'MissedCommands') {
+        $misses = @($CodeCoverage.MissedCommands)
+    }
+
+    $records = [System.Collections.Generic.List[object]]::new()
+    foreach ($command in $hits) {
+        $records.Add([PSCustomObject]@{
+            File = [string](Get-ObjectProperty -InputObject $command -Name 'File' -DefaultValue '')
+            Line = [int](Get-ObjectProperty -InputObject $command -Name 'Line' -DefaultValue 0)
+            Command = [string](Get-ObjectProperty -InputObject $command -Name 'Command' -DefaultValue '')
+            Executed = $true
+            HitCount = [int](Get-ObjectProperty -InputObject $command -Name 'HitCount' -DefaultValue 1)
+        })
+    }
+    foreach ($command in $misses) {
+        $records.Add([PSCustomObject]@{
+            File = [string](Get-ObjectProperty -InputObject $command -Name 'File' -DefaultValue '')
+            Line = [int](Get-ObjectProperty -InputObject $command -Name 'Line' -DefaultValue 0)
+            Command = [string](Get-ObjectProperty -InputObject $command -Name 'Command' -DefaultValue '')
+            Executed = $false
+            HitCount = [int](Get-ObjectProperty -InputObject $command -Name 'HitCount' -DefaultValue 0)
+        })
+    }
+    return $records.ToArray()
+}
+
+function Get-JaCoCoCoveredInstructionCount {
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        return -1
+    }
+    try {
+        [xml]$document = Get-Content -LiteralPath $Path -Raw -Encoding UTF8
+        if ($document.DocumentElement.LocalName -ne 'report') {
+            return -1
+        }
+        $counter = $document.DocumentElement.SelectSingleNode('counter[@type="INSTRUCTION"]')
+        if ($null -eq $counter) {
+            return 0
+        }
+        return [int]$counter.GetAttribute('covered')
+    } catch {
+        return -1
+    }
+}
+
+function Publish-SerialPesterCoverageXml {
+    param(
+        [string[]]$Paths,
+        [Parameter(Mandatory = $true)][string]$OutputPath
+    )
+
+    if ([string]::IsNullOrWhiteSpace($OutputPath)) {
+        return
+    }
+    $existing = @(
+        $Paths |
+            Where-Object { -not [string]::IsNullOrWhiteSpace($_) -and (Test-Path -LiteralPath $_) }
+    )
+    if ($existing.Count -eq 0) {
+        return
+    }
+    $source = $existing[0]
+    if ($existing.Count -gt 1) {
+        $bestCovered = -1
+        foreach ($path in $existing) {
+            $covered = Get-JaCoCoCoveredInstructionCount -Path $path
+            if ($covered -gt $bestCovered) {
+                $bestCovered = $covered
+                $source = $path
+            }
+        }
+    }
+    $sourceFull = [System.IO.Path]::GetFullPath($source)
+    $outputFull = [System.IO.Path]::GetFullPath($OutputPath)
+    if ($sourceFull -eq $outputFull) {
+        return
+    }
+    Copy-Item -LiteralPath $source -Destination $OutputPath -Force
+}
+
 function Merge-SerialPesterCodeCoverage {
     param($First, $Second)
 
     if ($null -eq $First) { return $Second }
     if ($null -eq $Second) { return $First }
 
-    $firstCommands = @()
-    $secondCommands = @()
-    if ($First.PSObject.Properties.Name -contains 'Commands') {
-        $firstCommands = @($First.Commands)
-    }
-    if ($Second.PSObject.Properties.Name -contains 'Commands') {
-        $secondCommands = @($Second.Commands)
-    }
+    $firstCommands = @(Get-PesterCoverageCommandRecords -CodeCoverage $First)
+    $secondCommands = @(Get-PesterCoverageCommandRecords -CodeCoverage $Second)
     if ($firstCommands.Count -eq 0 -and $secondCommands.Count -eq 0) {
-        $analyzed = [int](Get-ObjectProperty -InputObject $First -Name 'NumberOfCommandsAnalyzed' -DefaultValue 0)
-        $executed = [int](Get-ObjectProperty -InputObject $First -Name 'NumberOfCommandsExecuted' -DefaultValue 0)
-        $analyzed2 = [int](Get-ObjectProperty -InputObject $Second -Name 'NumberOfCommandsAnalyzed' -DefaultValue 0)
-        $executed2 = [int](Get-ObjectProperty -InputObject $Second -Name 'NumberOfCommandsExecuted' -DefaultValue 0)
-        $mergedAnalyzed = [math]::Max($analyzed, $analyzed2)
-        $mergedExecuted = [math]::Max($executed, $executed2)
+        $analyzed = Get-PesterCoverageNumericCount -InputObject $First -Names @('CommandsAnalyzedCount', 'NumberOfCommandsAnalyzed', 'CommandsAnalyzed')
+        $executed = Get-PesterCoverageNumericCount -InputObject $First -Names @('CommandsExecutedCount', 'NumberOfCommandsExecuted')
+        $analyzed2 = Get-PesterCoverageNumericCount -InputObject $Second -Names @('CommandsAnalyzedCount', 'NumberOfCommandsAnalyzed', 'CommandsAnalyzed')
+        $executed2 = Get-PesterCoverageNumericCount -InputObject $Second -Names @('CommandsExecutedCount', 'NumberOfCommandsExecuted')
+        if ($null -eq $analyzed) { $analyzed = 0 }
+        if ($null -eq $executed) { $executed = 0 }
+        if ($null -eq $analyzed2) { $analyzed2 = 0 }
+        if ($null -eq $executed2) { $executed2 = 0 }
+        $mergedAnalyzed = [math]::Max([int]$analyzed, [int]$analyzed2)
+        $mergedExecuted = [math]::Max([int]$executed, [int]$executed2)
         $percent = if ($mergedAnalyzed -le 0) { 0 } else { [math]::Round(($mergedExecuted / [double]$mergedAnalyzed) * 100, 2) }
         return [PSCustomObject]@{
             CoveragePercent = $percent
             NumberOfCommandsAnalyzed = $mergedAnalyzed
             NumberOfCommandsExecuted = $mergedExecuted
+            CommandsAnalyzedCount = $mergedAnalyzed
+            CommandsExecutedCount = $mergedExecuted
         }
     }
 
@@ -1080,6 +1211,12 @@ function Merge-SerialPesterCodeCoverage {
         $commandText = [string](Get-ObjectProperty -InputObject $command -Name 'Command' -DefaultValue '')
         $key = '{0}|{1}|{2}' -f $file, $line, $commandText
         $executed = [bool](Get-ObjectProperty -InputObject $command -Name 'Executed' -DefaultValue $false)
+        if (-not $executed) {
+            $hitCount = Get-PesterCoverageNumericCount -InputObject $command -Names @('HitCount')
+            if ($null -ne $hitCount -and [int]$hitCount -gt 0) {
+                $executed = $true
+            }
+        }
         if (-not $hits.ContainsKey($key)) {
             $hits[$key] = $executed
         } elseif ($executed) {
@@ -1093,6 +1230,8 @@ function Merge-SerialPesterCodeCoverage {
         CoveragePercent = $percent
         NumberOfCommandsAnalyzed = $analyzed
         NumberOfCommandsExecuted = $executedCount
+        CommandsAnalyzedCount = $analyzed
+        CommandsExecutedCount = $executedCount
     }
 }
 
@@ -1216,6 +1355,7 @@ function Invoke-SerialSuite {
     $previousLocationPath = (Get-Location).Path
     $sliceResults = [System.Collections.Generic.List[object]]::new()
     $nunitPaths = [System.Collections.Generic.List[string]]::new()
+    $coverageXmlPaths = [System.Collections.Generic.List[string]]::new()
     $result = $null
     try {
         if ($mutablePaths.Count -gt 0) {
@@ -1231,6 +1371,9 @@ function Invoke-SerialSuite {
                 -CoverageReportPath $mutableCoveragePath `
                 -EnableCoverage:$EnableCoverage))
             $nunitPaths.Add($mutableResultPath)
+            if ($EnableCoverage) {
+                $coverageXmlPaths.Add($mutableCoveragePath)
+            }
         }
         if ($immutablePaths.Count -gt 0) {
             $immutableResultPath = if ($mutablePaths.Count -gt 0) { "$TestResultPath.immutable.xml" } else { $TestResultPath }
@@ -1245,6 +1388,9 @@ function Invoke-SerialSuite {
                 -CoverageReportPath $immutableCoveragePath `
                 -EnableCoverage:$EnableCoverage))
             $nunitPaths.Add($immutableResultPath)
+            if ($EnableCoverage) {
+                $coverageXmlPaths.Add($immutableCoveragePath)
+            }
         }
         $result = Merge-SerialPesterSliceResults -Results @($sliceResults)
         if ($nunitPaths.Count -gt 1) {
@@ -1264,6 +1410,9 @@ function Invoke-SerialSuite {
                 -NotRunCount $mergedNotRun `
                 -InconclusiveCount 0 `
                 -DurationSeconds $stopwatch.Elapsed.TotalSeconds
+        }
+        if ($EnableCoverage) {
+            Publish-SerialPesterCoverageXml -Paths @($coverageXmlPaths) -OutputPath $CoverageReportPath
         }
     } finally {
         Set-Location -LiteralPath $previousLocationPath

--- a/scripts/run-tests.ps1
+++ b/scripts/run-tests.ps1
@@ -14,6 +14,9 @@ param(
     [string]$ResultsDirectory,
 
     [Parameter(DontShow = $true)]
+    [string[]]$LineFilters = @(),
+
+    [Parameter(DontShow = $true)]
     [string]$WorkerSpecPath,
 
     [Parameter(DontShow = $true)]
@@ -33,13 +36,19 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
 function Get-CoverageTargets {
-    param([string]$RepositoryRoot)
+    param(
+        [Parameter(Mandatory = $true)][string]$RepositoryRoot,
+        [Parameter(Mandatory = $true)][string[]]$TestPaths
+    )
 
-    $testFiles = Get-ChildItem -Path (Join-Path $RepositoryRoot 'tests') -Filter '*.Tests.ps1' -File -Recurse -ErrorAction SilentlyContinue
     $targets = [System.Collections.Generic.List[string]]::new()
 
-    foreach ($testFile in $testFiles) {
-        $content = Get-Content -Path $testFile.FullName -Raw -ErrorAction SilentlyContinue
+    foreach ($testPath in $TestPaths) {
+        $testFile = Get-Item -LiteralPath $testPath -ErrorAction Stop
+        if ($testFile.PSIsContainer -or -not $testFile.Name.EndsWith('.Tests.ps1', [StringComparison]::OrdinalIgnoreCase)) {
+            throw "Coverage input is not a Pester test file: $($testFile.FullName)"
+        }
+        $content = Get-Content -LiteralPath $testFile.FullName -Raw -ErrorAction SilentlyContinue
         if (-not $content) {
             continue
         }
@@ -162,15 +171,8 @@ function Get-ObjectProperty {
     return $DefaultValue
 }
 
-function Get-IsolatedChildEnvironment {
-    param(
-        [Parameter(Mandatory = $true)][string]$TempDirectory,
-        [Parameter(Mandatory = $true)][string]$ProjectDirectory
-    )
-
-    # Pass only non-secret platform/runtime context that tests need. In particular,
-    # do not inherit credential carriers such as *_TOKEN, GIT_ASKPASS,
-    # SSH_AUTH_SOCK, DOCKER_AUTH_CONFIG, or CI_JOB_JWT.
+function Get-RunnerPlatformEnvironment {
+    # Keep local Git and worker processes on the same non-secret platform allowlist.
     $allowedNames = @(
         'APPDATA', 'CI', 'COMPUTERNAME', 'ComSpec', 'GITHUB_ACTIONS',
         'GITHUB_EVENT_NAME', 'GITHUB_WORKSPACE', 'HOME', 'HOMEDRIVE',
@@ -184,18 +186,455 @@ function Get-IsolatedChildEnvironment {
     )
     $environment = [ordered]@{}
     foreach ($name in $allowedNames) {
-        $value = [Environment]::GetEnvironmentVariable($name)
+        $value = [Environment]::GetEnvironmentVariable($name, 'Process')
         if (-not [string]::IsNullOrEmpty($value)) {
             $environment[$name] = $value
         }
     }
+    return $environment
+}
+
+function Get-RunnerGitEnvironment {
+    param(
+        [Parameter(Mandatory = $true)][string]$HooksPath,
+        [Parameter(Mandatory = $true)][string]$TemplatePath,
+        [Parameter(Mandatory = $true)][string]$CandidateTreeId
+    )
+
+    if ($CandidateTreeId -notmatch '\A[0-9a-f]{40}\z') {
+        throw "Candidate tree ID is invalid: $CandidateTreeId"
+    }
+    $nullDevice = if ([Environment]::OSVersion.Platform -eq [PlatformID]::Win32NT) { 'NUL' } else { '/dev/null' }
+    return [ordered]@{
+        GIT_CONFIG_GLOBAL = $nullDevice
+        GIT_CONFIG_SYSTEM = $nullDevice
+        GIT_CONFIG_NOSYSTEM = '1'
+        GIT_CONFIG_COUNT = '5'
+        GIT_CONFIG_KEY_0 = 'init.defaultBranch'
+        GIT_CONFIG_VALUE_0 = 'main'
+        GIT_CONFIG_KEY_1 = 'core.hooksPath'
+        GIT_CONFIG_VALUE_1 = [System.IO.Path]::GetFullPath($HooksPath)
+        GIT_CONFIG_KEY_2 = 'commit.gpgSign'
+        GIT_CONFIG_VALUE_2 = 'false'
+        GIT_CONFIG_KEY_3 = 'tag.gpgSign'
+        GIT_CONFIG_VALUE_3 = 'false'
+        GIT_CONFIG_KEY_4 = 'core.autocrlf'
+        GIT_CONFIG_VALUE_4 = 'false'
+        GIT_TEMPLATE_DIR = [System.IO.Path]::GetFullPath($TemplatePath)
+        GIT_ATTR_NOSYSTEM = '1'
+        GIT_OPTIONAL_LOCKS = '0'
+        GIT_TERMINAL_PROMPT = '0'
+        GCM_INTERACTIVE = 'Never'
+        WINSMUX_PESTER_CANDIDATE_TREE = $CandidateTreeId
+    }
+}
+
+function Invoke-WithRunnerGitEnvironment {
+    param(
+        [Parameter(Mandatory = $true)][System.Collections.IDictionary]$Environment,
+        [Parameter(Mandatory = $true)][scriptblock]$ScriptBlock
+    )
+
+    $callerEnvironment = [ordered]@{}
+    foreach ($entry in [Environment]::GetEnvironmentVariables('Process').GetEnumerator()) {
+        $name = [string]$entry.Key
+        if ($name -like 'GIT_*' -or $name -in @('GCM_INTERACTIVE', 'WINSMUX_PESTER_CANDIDATE_TREE')) {
+            $callerEnvironment[$name] = [string]$entry.Value
+        }
+    }
+
+    try {
+        foreach ($name in @($callerEnvironment.Keys)) {
+            Remove-Item -LiteralPath ('Env:' + [string]$name) -ErrorAction SilentlyContinue
+        }
+        foreach ($entry in $Environment.GetEnumerator()) {
+            $name = [string]$entry.Key
+            if ($name -notlike 'GIT_*' -and $name -notin @('GCM_INTERACTIVE', 'WINSMUX_PESTER_CANDIDATE_TREE')) {
+                throw "Runner Git environment contains an unsupported variable: $name"
+            }
+            [Environment]::SetEnvironmentVariable($name, [string]$entry.Value, 'Process')
+        }
+        & $ScriptBlock
+    } finally {
+        foreach ($entry in [Environment]::GetEnvironmentVariables('Process').GetEnumerator()) {
+            $name = [string]$entry.Key
+            if ($name -like 'GIT_*' -or $name -in @('GCM_INTERACTIVE', 'WINSMUX_PESTER_CANDIDATE_TREE')) {
+                Remove-Item -LiteralPath ('Env:' + $name) -ErrorAction SilentlyContinue
+            }
+        }
+        foreach ($entry in $callerEnvironment.GetEnumerator()) {
+            [Environment]::SetEnvironmentVariable([string]$entry.Key, [string]$entry.Value, 'Process')
+        }
+    }
+}
+
+function Invoke-RunnerGit {
+    param(
+        [Parameter(Mandatory = $true)][string]$RepositoryRoot,
+        [Parameter(Mandatory = $true)][string[]]$Arguments,
+        [Parameter(Mandatory = $true)][System.Collections.IDictionary]$Environment,
+        [System.Collections.IDictionary]$ExtraEnvironment = @{},
+        [switch]$AllowFailure
+    )
+
+    $gitCommand = Get-Command git -CommandType Application -ErrorAction Stop | Select-Object -First 1
+    $gitPath = if ($gitCommand.Path) { $gitCommand.Path } else { $gitCommand.Source }
+    if ([string]::IsNullOrWhiteSpace($gitPath) -or -not (Test-Path -LiteralPath $gitPath -PathType Leaf)) {
+        throw 'A concrete Git executable could not be resolved.'
+    }
+
+    $startInfo = [System.Diagnostics.ProcessStartInfo]::new()
+    $startInfo.FileName = $gitPath
+    foreach ($argument in $Arguments) { $startInfo.ArgumentList.Add($argument) }
+    $startInfo.WorkingDirectory = [System.IO.Path]::GetFullPath($RepositoryRoot)
+    $startInfo.UseShellExecute = $false
+    $startInfo.CreateNoWindow = $true
+    $startInfo.RedirectStandardInput = $true
+    $startInfo.RedirectStandardOutput = $true
+    $startInfo.RedirectStandardError = $true
+    $startInfo.Environment.Clear()
+    foreach ($entry in (Get-RunnerPlatformEnvironment).GetEnumerator()) {
+        $startInfo.Environment[[string]$entry.Key] = [string]$entry.Value
+    }
+    foreach ($entry in $Environment.GetEnumerator()) {
+        $startInfo.Environment[[string]$entry.Key] = [string]$entry.Value
+    }
+    foreach ($entry in $ExtraEnvironment.GetEnumerator()) {
+        $startInfo.Environment[[string]$entry.Key] = [string]$entry.Value
+    }
+
+    $process = [System.Diagnostics.Process]::new()
+    $process.StartInfo = $startInfo
+    try {
+        [void]$process.Start()
+        $process.StandardInput.Close()
+        $stdout = $process.StandardOutput.ReadToEnd()
+        $stderr = $process.StandardError.ReadToEnd()
+        $process.WaitForExit()
+        if (-not $AllowFailure -and $process.ExitCode -ne 0) {
+            throw "git $($Arguments -join ' ') failed ($($process.ExitCode)): $($stderr.Trim())"
+        }
+        return [PSCustomObject]@{
+            ExitCode = [int]$process.ExitCode
+            StdOut = $stdout.TrimEnd([char[]]"`r`n")
+            StdErr = $stderr.TrimEnd([char[]]"`r`n")
+        }
+    } finally {
+        $process.Dispose()
+    }
+}
+
+function Resolve-RunnerGitPath {
+    param(
+        [Parameter(Mandatory = $true)][string]$RepositoryRoot,
+        [Parameter(Mandatory = $true)][string]$GitPath
+    )
+
+    if ([System.IO.Path]::IsPathRooted($GitPath)) {
+        return [System.IO.Path]::GetFullPath($GitPath)
+    }
+    return [System.IO.Path]::GetFullPath((Join-Path $RepositoryRoot $GitPath))
+}
+
+function Get-RunnerCandidateTestPaths {
+    param(
+        [Parameter(Mandatory = $true)][string]$RepositoryRoot,
+        [Parameter(Mandatory = $true)][string]$CandidateTreeId,
+        [Parameter(Mandatory = $true)][System.Collections.IDictionary]$Environment
+    )
+
+    if ($CandidateTreeId -notmatch '\A[0-9a-f]{40}\z') {
+        throw "Candidate tree ID is invalid: $CandidateTreeId"
+    }
+    $repositoryRoot = [System.IO.Path]::GetFullPath($RepositoryRoot)
+    $repositoryPrefix = $repositoryRoot.TrimEnd('\', '/') + [System.IO.Path]::DirectorySeparatorChar
+    $listed = Invoke-RunnerGit `
+        -RepositoryRoot $repositoryRoot `
+        -Arguments @('ls-tree', '-r', '--name-only', '-z', $CandidateTreeId, '--', 'tests') `
+        -Environment $Environment
+    $seen = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::OrdinalIgnoreCase)
+    $paths = [System.Collections.Generic.List[string]]::new()
+    foreach ($relativePath in @($listed.StdOut -split "`0" | Where-Object { $_ })) {
+        $normalized = ([string]$relativePath).Replace('\', '/')
+        if ($normalized -notmatch '(?i)\Atests/(?:.+/)?[^/]+\.Tests\.ps1\z') {
+            continue
+        }
+        $fullPath = [System.IO.Path]::GetFullPath((Join-Path $repositoryRoot $normalized))
+        if (-not $fullPath.StartsWith($repositoryPrefix, [StringComparison]::OrdinalIgnoreCase)) {
+            throw "Candidate Pester path escapes the repository root: $normalized"
+        }
+        if (-not (Test-Path -LiteralPath $fullPath -PathType Leaf)) {
+            throw "Candidate Pester test is missing from the working tree: $normalized"
+        }
+        if (-not $seen.Add($normalized)) {
+            throw "Candidate Pester inventory contains a duplicate path: $normalized"
+        }
+        $paths.Add($fullPath)
+    }
+    return @($paths | Sort-Object)
+}
+
+function Get-RunnerFileState {
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    $fullPath = [System.IO.Path]::GetFullPath($Path)
+    if (-not (Test-Path -LiteralPath $fullPath -PathType Leaf)) {
+        return [PSCustomObject]@{ Path = $fullPath; Exists = $false; Length = 0L; Sha256 = '' }
+    }
+    $item = Get-Item -LiteralPath $fullPath
+    return [PSCustomObject]@{
+        Path = $fullPath
+        Exists = $true
+        Length = [long]$item.Length
+        Sha256 = (Get-FileHash -LiteralPath $fullPath -Algorithm SHA256).Hash.ToLowerInvariant()
+    }
+}
+
+function Get-RunnerTrackedBytesFingerprint {
+    param(
+        [Parameter(Mandatory = $true)][string]$RepositoryRoot,
+        [Parameter(Mandatory = $true)][System.Collections.IDictionary]$Environment
+    )
+
+    $listed = Invoke-RunnerGit -RepositoryRoot $RepositoryRoot -Arguments @('ls-files', '-z', '--cached') -Environment $Environment
+    $ledger = [System.Collections.Generic.List[string]]::new()
+    foreach ($relativePath in @($listed.StdOut -split "`0" | Where-Object { $_ })) {
+        $fullPath = [System.IO.Path]::GetFullPath((Join-Path $RepositoryRoot $relativePath))
+        $repoPrefix = [System.IO.Path]::GetFullPath($RepositoryRoot).TrimEnd('\', '/') + [System.IO.Path]::DirectorySeparatorChar
+        if (-not $fullPath.StartsWith($repoPrefix, [StringComparison]::OrdinalIgnoreCase)) {
+            throw "Tracked path escapes repository root: $relativePath"
+        }
+        if (Test-Path -LiteralPath $fullPath -PathType Leaf) {
+            $state = Get-RunnerFileState -Path $fullPath
+            $ledger.Add("$relativePath`0$($state.Length)`0$($state.Sha256)")
+        } else {
+            $ledger.Add("$relativePath`0<absent-or-nonfile>")
+        }
+    }
+    $diff = Invoke-RunnerGit -RepositoryRoot $RepositoryRoot -Arguments @('diff-files', '--raw', '--no-abbrev', '-z') -Environment $Environment -AllowFailure
+    $ledger.Add("<diff-files>`0$($diff.ExitCode)`0$($diff.StdOut)")
+    return Get-IdentityHash -Identities $ledger.ToArray()
+}
+
+function Get-RunnerRepositoryState {
+    param(
+        [Parameter(Mandatory = $true)][string]$RepositoryRoot,
+        [Parameter(Mandatory = $true)][System.Collections.IDictionary]$Environment
+    )
+
+    $indexText = (Invoke-RunnerGit -RepositoryRoot $RepositoryRoot -Arguments @('rev-parse', '--git-path', 'index') -Environment $Environment).StdOut
+    $indexPath = Resolve-RunnerGitPath -RepositoryRoot $RepositoryRoot -GitPath $indexText
+    $refResult = Invoke-RunnerGit -RepositoryRoot $RepositoryRoot -Arguments @('show-ref', '--head', '--dereference') -Environment $Environment -AllowFailure
+    if ($refResult.ExitCode -notin @(0, 1)) { throw "git show-ref failed ($($refResult.ExitCode)): $($refResult.StdErr)" }
+    $headResult = Invoke-RunnerGit -RepositoryRoot $RepositoryRoot -Arguments @('symbolic-ref', '-q', 'HEAD') -Environment $Environment -AllowFailure
+    if ($headResult.ExitCode -notin @(0, 1)) { throw "git symbolic-ref failed ($($headResult.ExitCode)): $($headResult.StdErr)" }
+    $configStates = [System.Collections.Generic.List[object]]::new()
+    foreach ($configName in @('config', 'config.worktree')) {
+        $pathText = (Invoke-RunnerGit -RepositoryRoot $RepositoryRoot -Arguments @('rev-parse', '--git-path', $configName) -Environment $Environment).StdOut
+        $configStates.Add((Get-RunnerFileState -Path (Resolve-RunnerGitPath -RepositoryRoot $RepositoryRoot -GitPath $pathText)))
+    }
+    return [PSCustomObject]@{
+        Index = Get-RunnerFileState -Path $indexPath
+        TrackedBytesFingerprint = Get-RunnerTrackedBytesFingerprint -RepositoryRoot $RepositoryRoot -Environment $Environment
+        RefsFingerprint = Get-IdentityHash -Identities @($refResult.StdOut, $headResult.StdOut)
+        LocalConfigs = $configStates.ToArray()
+    }
+}
+
+function Assert-RunnerFileStateEqual {
+    param(
+        [Parameter(Mandatory = $true)]$Expected,
+        [Parameter(Mandatory = $true)]$Actual,
+        [Parameter(Mandatory = $true)][string]$Label
+    )
+
+    if ([string]$Expected.Path -cne [string]$Actual.Path -or
+        [bool]$Expected.Exists -ne [bool]$Actual.Exists -or
+        [long]$Expected.Length -ne [long]$Actual.Length -or
+        [string]$Expected.Sha256 -cne [string]$Actual.Sha256) {
+        throw "$Label changed during the Pester run."
+    }
+}
+
+function New-RunnerCandidateContext {
+    param(
+        [Parameter(Mandatory = $true)][string]$RepositoryRoot,
+        [Parameter(Mandatory = $true)][string]$ExecutionRoot,
+        [string]$ProspectiveIndexPath
+    )
+
+    $repositoryRoot = [System.IO.Path]::GetFullPath($RepositoryRoot)
+    $executionRoot = [System.IO.Path]::GetFullPath($ExecutionRoot)
+    New-Item -ItemType Directory -Path $executionRoot -Force | Out-Null
+    $hooksPath = Join-Path $executionRoot 'empty-hooks'
+    $templatePath = Join-Path $executionRoot 'empty-template'
+    New-Item -ItemType Directory -Path $hooksPath, $templatePath -Force | Out-Null
+
+    $bootstrapEnvironment = Get-RunnerGitEnvironment -HooksPath $hooksPath -TemplatePath $templatePath -CandidateTreeId ('0' * 40)
+    $sourceState = Get-RunnerRepositoryState -RepositoryRoot $repositoryRoot -Environment $bootstrapEnvironment
+    $sourceIndexPath = if ([string]::IsNullOrWhiteSpace($ProspectiveIndexPath)) {
+        [string]$sourceState.Index.Path
+    } elseif ([System.IO.Path]::IsPathRooted($ProspectiveIndexPath)) {
+        [System.IO.Path]::GetFullPath($ProspectiveIndexPath)
+    } else {
+        [System.IO.Path]::GetFullPath((Join-Path (Get-Location).Path $ProspectiveIndexPath))
+    }
+    if (-not (Test-Path -LiteralPath $sourceIndexPath -PathType Leaf)) {
+        throw "Candidate index does not exist: $sourceIndexPath"
+    }
+    $sourceIndexState = Get-RunnerFileState -Path $sourceIndexPath
+    $candidateIndexPath = Join-Path $executionRoot 'candidate.index'
+    if (Test-Path -LiteralPath $candidateIndexPath) {
+        throw "Candidate index destination already exists: $candidateIndexPath"
+    }
+    Copy-Item -LiteralPath $sourceIndexPath -Destination $candidateIndexPath -ErrorAction Stop
+
+    $candidateOverride = [ordered]@{ GIT_INDEX_FILE = $candidateIndexPath }
+    $candidateTreeId = (Invoke-RunnerGit -RepositoryRoot $repositoryRoot -Arguments @('write-tree') -Environment $bootstrapEnvironment -ExtraEnvironment $candidateOverride).StdOut
+    if ($candidateTreeId -notmatch '\A[0-9a-f]{40}\z') {
+        throw "git write-tree returned an invalid candidate tree ID: $candidateTreeId"
+    }
+    $gitEnvironment = Get-RunnerGitEnvironment -HooksPath $hooksPath -TemplatePath $templatePath -CandidateTreeId $candidateTreeId
+    $sourceDiff = Invoke-RunnerGit -RepositoryRoot $repositoryRoot -Arguments @('diff-files', '--quiet', '--no-ext-diff', '--ignore-submodules') -Environment $gitEnvironment -ExtraEnvironment $candidateOverride -AllowFailure
+    if ($sourceDiff.ExitCode -eq 1) {
+        throw 'Source tracked bytes do not match the candidate index.'
+    }
+    if ($sourceDiff.ExitCode -ne 0) {
+        throw "Candidate/source comparison failed ($($sourceDiff.ExitCode)): $($sourceDiff.StdErr)"
+    }
+    $objectPathText = (Invoke-RunnerGit -RepositoryRoot $repositoryRoot -Arguments @('rev-parse', '--git-path', 'objects') -Environment $gitEnvironment).StdOut
+    $candidateEnvironment = [ordered]@{}
+    foreach ($entry in $gitEnvironment.GetEnumerator()) {
+        $candidateEnvironment[[string]$entry.Key] = [string]$entry.Value
+    }
+    $candidateEnvironment['GIT_INDEX_FILE'] = $candidateIndexPath
+
+    $context = [PSCustomObject]@{
+        RepositoryRoot = $repositoryRoot
+        ExecutionRoot = $executionRoot
+        HooksPath = $hooksPath
+        TemplatePath = $templatePath
+        CandidateTreeId = $candidateTreeId
+        CandidateIndexPath = $candidateIndexPath
+        CandidateSourceIndex = $sourceIndexState
+        CandidateTrackedBytesFingerprint = Get-RunnerTrackedBytesFingerprint -RepositoryRoot $repositoryRoot -Environment $candidateEnvironment
+        SourceObjectDirectory = Resolve-RunnerGitPath -RepositoryRoot $repositoryRoot -GitPath $objectPathText
+        SourceState = $sourceState
+        GitEnvironment = $gitEnvironment
+        CandidateTestPaths = @(Get-RunnerCandidateTestPaths -RepositoryRoot $repositoryRoot -CandidateTreeId $candidateTreeId -Environment $gitEnvironment)
+    }
+    Assert-RunnerSourceState -Context $context
+    return $context
+}
+
+function Assert-RunnerSourceState {
+    param([Parameter(Mandatory = $true)]$Context)
+
+    $actual = Get-RunnerRepositoryState -RepositoryRoot ([string]$Context.RepositoryRoot) -Environment $Context.GitEnvironment
+    if ([string]$actual.TrackedBytesFingerprint -cne [string]$Context.SourceState.TrackedBytesFingerprint) {
+        throw 'Runner source tracked bytes changed during the Pester run.'
+    }
+    Assert-RunnerFileStateEqual -Expected $Context.SourceState.Index -Actual $actual.Index -Label 'Runner source index'
+    $candidateSourceNow = Get-RunnerFileState -Path ([string]$Context.CandidateSourceIndex.Path)
+    Assert-RunnerFileStateEqual -Expected $Context.CandidateSourceIndex -Actual $candidateSourceNow -Label 'Runner candidate source index'
+    $candidateEnvironment = [ordered]@{}
+    foreach ($entry in $Context.GitEnvironment.GetEnumerator()) {
+        $candidateEnvironment[[string]$entry.Key] = [string]$entry.Value
+    }
+    $candidateEnvironment['GIT_INDEX_FILE'] = [string]$Context.CandidateIndexPath
+    $candidateTrackedBytesNow = Get-RunnerTrackedBytesFingerprint -RepositoryRoot ([string]$Context.RepositoryRoot) -Environment $candidateEnvironment
+    if ([string]$candidateTrackedBytesNow -cne [string]$Context.CandidateTrackedBytesFingerprint) {
+        throw 'Runner candidate tracked bytes changed during the Pester run.'
+    }
+    if ([string]$actual.RefsFingerprint -cne [string]$Context.SourceState.RefsFingerprint) {
+        throw 'Runner source refs changed during the Pester run.'
+    }
+    if (@($actual.LocalConfigs).Count -ne @($Context.SourceState.LocalConfigs).Count) {
+        throw 'Runner source local config set changed during the Pester run.'
+    }
+    for ($index = 0; $index -lt @($actual.LocalConfigs).Count; $index++) {
+        Assert-RunnerFileStateEqual -Expected @($Context.SourceState.LocalConfigs)[$index] -Actual @($actual.LocalConfigs)[$index] -Label 'Runner source local config'
+    }
+}
+
+function New-RunnerPrivateRepository {
+    param(
+        [Parameter(Mandatory = $true)]$Context,
+        [Parameter(Mandatory = $true)][string]$DestinationPath
+    )
+
+    $destinationPath = [System.IO.Path]::GetFullPath($DestinationPath)
+    if ($destinationPath -eq [System.IO.Path]::GetFullPath([string]$Context.RepositoryRoot)) {
+        throw 'Private Pester repository must not be the source repository.'
+    }
+    if (Test-Path -LiteralPath $destinationPath) {
+        if (@(Get-ChildItem -LiteralPath $destinationPath -Force).Count -gt 0) {
+            throw "Private Pester repository destination is not empty: $destinationPath"
+        }
+    } else {
+        New-Item -ItemType Directory -Path $destinationPath -Force | Out-Null
+    }
+
+    [void](Invoke-RunnerGit -RepositoryRoot ([string]$Context.RepositoryRoot) -Arguments @('init', '--quiet', $destinationPath) -Environment $Context.GitEnvironment)
+    $privateObjectsText = (Invoke-RunnerGit -RepositoryRoot $destinationPath -Arguments @('rev-parse', '--git-path', 'objects') -Environment $Context.GitEnvironment).StdOut
+    $privateObjects = Resolve-RunnerGitPath -RepositoryRoot $destinationPath -GitPath $privateObjectsText
+    $alternatesDirectory = Join-Path $privateObjects 'info'
+    New-Item -ItemType Directory -Path $alternatesDirectory -Force | Out-Null
+    $alternate = [System.IO.Path]::GetFullPath([string]$Context.SourceObjectDirectory).Replace('\', '/') + "`n"
+    [System.IO.File]::WriteAllText((Join-Path $alternatesDirectory 'alternates'), $alternate, [System.Text.UTF8Encoding]::new($false))
+
+    [void](Invoke-RunnerGit -RepositoryRoot $destinationPath -Arguments @('read-tree', [string]$Context.CandidateTreeId) -Environment $Context.GitEnvironment)
+    [void](Invoke-RunnerGit -RepositoryRoot $destinationPath -Arguments @('checkout-index', '--all', '--force', '--index', '--ignore-skip-worktree-bits') -Environment $Context.GitEnvironment)
+    $identityEnvironment = [ordered]@{
+        GIT_AUTHOR_NAME = 'winsmux Pester fixture'
+        GIT_AUTHOR_EMAIL = 'pester-fixture@example.invalid'
+        GIT_AUTHOR_DATE = '2000-01-01T00:00:00Z'
+        GIT_COMMITTER_NAME = 'winsmux Pester fixture'
+        GIT_COMMITTER_EMAIL = 'pester-fixture@example.invalid'
+        GIT_COMMITTER_DATE = '2000-01-01T00:00:00Z'
+    }
+    $commitId = (Invoke-RunnerGit -RepositoryRoot $destinationPath -Arguments @('commit-tree', [string]$Context.CandidateTreeId, '-m', 'winsmux Pester candidate') -Environment $Context.GitEnvironment -ExtraEnvironment $identityEnvironment).StdOut
+    if ($commitId -notmatch '\A[0-9a-f]{40}\z') {
+        throw "git commit-tree returned an invalid commit ID: $commitId"
+    }
+    [void](Invoke-RunnerGit -RepositoryRoot $destinationPath -Arguments @('update-ref', 'refs/heads/candidate', $commitId) -Environment $Context.GitEnvironment)
+    [void](Invoke-RunnerGit -RepositoryRoot $destinationPath -Arguments @('symbolic-ref', 'HEAD', 'refs/heads/candidate') -Environment $Context.GitEnvironment)
+
+    $privateIndexTree = (Invoke-RunnerGit -RepositoryRoot $destinationPath -Arguments @('write-tree') -Environment $Context.GitEnvironment).StdOut
+    $privateHeadTree = (Invoke-RunnerGit -RepositoryRoot $destinationPath -Arguments @('rev-parse', 'HEAD^{tree}') -Environment $Context.GitEnvironment).StdOut
+    if ($privateIndexTree -cne [string]$Context.CandidateTreeId -or $privateHeadTree -cne [string]$Context.CandidateTreeId) {
+        throw 'Private Pester repository tree identity does not match the candidate tree.'
+    }
+    $privateDiff = Invoke-RunnerGit -RepositoryRoot $destinationPath -Arguments @('diff-files', '--quiet', '--no-ext-diff', '--ignore-submodules') -Environment $Context.GitEnvironment -AllowFailure
+    if ($privateDiff.ExitCode -ne 0) {
+        throw "Private Pester repository tracked bytes differ from its index ($($privateDiff.ExitCode))."
+    }
+    Assert-RunnerSourceState -Context $Context
+    return $destinationPath
+}
+
+function Get-IsolatedChildEnvironment {
+    param(
+        [Parameter(Mandatory = $true)][string]$TempDirectory,
+        [Parameter(Mandatory = $true)][string]$ProjectDirectory,
+        [Parameter(Mandatory = $true)][string]$HooksPath,
+        [Parameter(Mandatory = $true)][string]$TemplatePath,
+        [Parameter(Mandatory = $true)][string]$CandidateTreeId
+    )
+
+    # Pass only non-secret platform/runtime context that tests need. In particular,
+    # do not inherit credential carriers such as *_TOKEN, GIT_ASKPASS,
+    # SSH_AUTH_SOCK, DOCKER_AUTH_CONFIG, or CI_JOB_JWT.
+    $environment = Get-RunnerPlatformEnvironment
     $environment['TEMP'] = $TempDirectory
     $environment['TMP'] = $TempDirectory
     $environment['WINSMUX_ORCHESTRA_PROJECT_DIR'] = $ProjectDirectory
     $environment['WINSMUX_TEST_PROJECT_DIR'] = $ProjectDirectory
     $environment['NO_COLOR'] = '1'
-    $environment['GIT_TERMINAL_PROMPT'] = '0'
-    $environment['GCM_INTERACTIVE'] = 'Never'
+    $gitEnvironment = Get-RunnerGitEnvironment -HooksPath $HooksPath -TemplatePath $TemplatePath -CandidateTreeId $CandidateTreeId
+    foreach ($entry in $gitEnvironment.GetEnumerator()) {
+        $environment[[string]$entry.Key] = [string]$entry.Value
+    }
     return $environment
 }
 
@@ -234,12 +673,17 @@ function Invoke-IsolatedPwshWorkers {
                     )) {
                         $startInfo.ArgumentList.Add($argument)
                     }
-                    $startInfo.WorkingDirectory = $RepositoryRoot
+                    $startInfo.WorkingDirectory = [System.IO.Path]::GetFullPath([string]$spec.WorkingDirectory)
                     $startInfo.UseShellExecute = $false
                     $startInfo.CreateNoWindow = $true
                     $startInfo.RedirectStandardInput = $true
                     $startInfo.Environment.Clear()
-                    $childEnvironment = Get-IsolatedChildEnvironment -TempDirectory ([string]$spec.TempDirectory) -ProjectDirectory ([string]$spec.ProjectDirectory)
+                    $childEnvironment = Get-IsolatedChildEnvironment `
+                        -TempDirectory ([string]$spec.TempDirectory) `
+                        -ProjectDirectory ([string]$spec.ProjectDirectory) `
+                        -HooksPath ([string]$spec.HooksPath) `
+                        -TemplatePath ([string]$spec.TemplatePath) `
+                        -CandidateTreeId ([string]$spec.CandidateTreeId)
                     foreach ($entry in $childEnvironment.GetEnumerator()) {
                         $startInfo.Environment[[string]$entry.Key] = [string]$entry.Value
                     }
@@ -345,34 +789,238 @@ function Get-PesterModule {
     }
 }
 
+function Get-PrivatePesterFixtureRelativePaths {
+    return @(
+        'tests/HarnessContract.Tests.ps1'
+        'tests/PublicSurfacePolicy.Tests.ps1'
+    )
+}
+
+function Get-PesterExecutionPaths {
+    param(
+        [Parameter(Mandatory = $true)][string]$RepositoryRoot,
+        [Parameter(Mandatory = $true)][string]$PrivateRepositoryRoot,
+        [Parameter(Mandatory = $true)][string[]]$CandidateTestPaths
+    )
+
+    $owners = @(Get-PrivatePesterFixtureRelativePaths)
+    $paths = [System.Collections.Generic.List[string]]::new()
+    $candidateRelativePaths = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::OrdinalIgnoreCase)
+    foreach ($candidatePath in $CandidateTestPaths) {
+        $fullPath = [System.IO.Path]::GetFullPath($candidatePath)
+        $relative = [System.IO.Path]::GetRelativePath($RepositoryRoot, $fullPath).Replace('\', '/')
+        if ($relative.StartsWith('../', [StringComparison]::Ordinal) -or [System.IO.Path]::IsPathRooted($relative)) {
+            throw "Candidate Pester path escapes the source repository: $fullPath"
+        }
+        if (-not $candidateRelativePaths.Add($relative)) {
+            throw "Candidate Pester execution path is duplicated: $relative"
+        }
+        if ($relative -in $owners) {
+            $privatePath = Join-Path $PrivateRepositoryRoot $relative
+            if (-not (Test-Path -LiteralPath $privatePath -PathType Leaf)) {
+                throw "Private Pester owner path is missing: $relative"
+            }
+            $paths.Add([System.IO.Path]::GetFullPath($privatePath))
+        } else {
+            $paths.Add($fullPath)
+        }
+    }
+    $missingOwners = @($owners | Where-Object { -not $candidateRelativePaths.Contains($_) })
+    if ($missingOwners.Count -gt 0) {
+        throw "Candidate Pester inventory is missing private fixture owners: $($missingOwners -join ', ')"
+    }
+    if ($paths.Count -eq 0) {
+        throw 'Candidate Pester inventory is empty.'
+    }
+    return $paths.ToArray()
+}
+
+function Resolve-PesterLineFilter {
+    param(
+        [Parameter(Mandatory = $true)][string]$RepositoryRoot,
+        [Parameter(Mandatory = $true)][string]$LineFilter
+    )
+
+    $separator = $LineFilter.LastIndexOf(':')
+    if ($separator -le 0 -or $separator -eq ($LineFilter.Length - 1)) {
+        throw "Invalid Pester line filter: $LineFilter"
+    }
+    $lineNumber = 0
+    if (-not [int]::TryParse($LineFilter.Substring($separator + 1), [ref]$lineNumber) -or $lineNumber -le 0) {
+        throw "Invalid Pester line number: $LineFilter"
+    }
+    $pathText = $LineFilter.Substring(0, $separator)
+    $fullPath = if ([System.IO.Path]::IsPathRooted($pathText)) {
+        [System.IO.Path]::GetFullPath($pathText)
+    } else {
+        [System.IO.Path]::GetFullPath((Join-Path $RepositoryRoot $pathText))
+    }
+    $repositoryRoot = [System.IO.Path]::GetFullPath($RepositoryRoot)
+    $repositoryPrefix = $repositoryRoot.TrimEnd('\', '/') + [System.IO.Path]::DirectorySeparatorChar
+    if (-not $fullPath.StartsWith($repositoryPrefix, [StringComparison]::OrdinalIgnoreCase)) {
+        throw "Pester line filter escapes the repository root: $LineFilter"
+    }
+    return [PSCustomObject]@{
+        Path = $fullPath
+        Line = $lineNumber
+        Identity = '{0}:{1}' -f $fullPath.Replace('\', '/'), $lineNumber
+        Filter = '{0}:{1}' -f $fullPath, $lineNumber
+    }
+}
+
+function Convert-PesterExecutionLineFilters {
+    param(
+        [Parameter(Mandatory = $true)][string]$RepositoryRoot,
+        [Parameter(Mandatory = $true)][string]$PrivateRepositoryRoot,
+        [string[]]$LineFilters = @()
+    )
+
+    $owners = @(Get-PrivatePesterFixtureRelativePaths)
+    $seen = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::OrdinalIgnoreCase)
+    return @($LineFilters | ForEach-Object {
+        $resolved = Resolve-PesterLineFilter -RepositoryRoot $RepositoryRoot -LineFilter ([string]$_)
+        if (-not $seen.Add([string]$resolved.Identity)) {
+            throw "Duplicate Pester line filter: $_"
+        }
+        $relative = [System.IO.Path]::GetRelativePath($RepositoryRoot, [string]$resolved.Path).Replace('\', '/')
+        $executionPath = if ($relative -in $owners) {
+            [System.IO.Path]::GetFullPath((Join-Path $PrivateRepositoryRoot $relative))
+        } else {
+            [string]$resolved.Path
+        }
+        '{0}:{1}' -f $executionPath, [int]$resolved.Line
+    })
+}
+
+function Assert-PesterWorkerSpecCandidatePaths {
+    param(
+        [Parameter(Mandatory = $true)]$Spec,
+        [Parameter(Mandatory = $true)][System.Collections.IDictionary]$Environment
+    )
+
+    $repositoryRoot = [System.IO.Path]::GetFullPath([string]$Spec.RepositoryRoot)
+    $repositoryPrefix = $repositoryRoot.TrimEnd('\', '/') + [System.IO.Path]::DirectorySeparatorChar
+    $candidateTreeId = [string]$Spec.CandidateTreeId
+    $candidatePaths = @(Get-RunnerCandidateTestPaths `
+        -RepositoryRoot $repositoryRoot `
+        -CandidateTreeId $candidateTreeId `
+        -Environment $Environment)
+    if ($candidatePaths.Count -eq 0) {
+        throw 'Pester worker candidate test inventory is empty.'
+    }
+    $candidateSet = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::OrdinalIgnoreCase)
+    foreach ($candidatePath in $candidatePaths) { [void]$candidateSet.Add([System.IO.Path]::GetFullPath($candidatePath)) }
+
+    $specPaths = @($Spec.Paths | Where-Object { $null -ne $_ })
+    if ($specPaths.Count -eq 0) {
+        throw 'Pester worker spec has no test paths.'
+    }
+    $selectedPaths = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::OrdinalIgnoreCase)
+    foreach ($specPath in $specPaths) {
+        $pathText = [string]$specPath
+        if ([string]::IsNullOrWhiteSpace($pathText)) {
+            throw 'Pester worker spec contains an empty test path.'
+        }
+        $fullPath = if ([System.IO.Path]::IsPathRooted($pathText)) {
+            [System.IO.Path]::GetFullPath($pathText)
+        } else {
+            [System.IO.Path]::GetFullPath((Join-Path $repositoryRoot $pathText))
+        }
+        if (-not $fullPath.StartsWith($repositoryPrefix, [StringComparison]::OrdinalIgnoreCase)) {
+            throw "Pester worker path escapes its repository: $pathText"
+        }
+        if (-not $candidateSet.Contains($fullPath)) {
+            throw "Pester worker path is not in the candidate Pester test inventory: $pathText"
+        }
+        if (-not $selectedPaths.Add($fullPath)) {
+            throw "Pester worker spec contains a duplicate path: $pathText"
+        }
+    }
+
+    $lineFilters = @($Spec.LineFilters | Where-Object { $null -ne $_ })
+    $seenFilters = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::OrdinalIgnoreCase)
+    foreach ($lineFilter in $lineFilters) {
+        $resolved = Resolve-PesterLineFilter -RepositoryRoot $repositoryRoot -LineFilter ([string]$lineFilter)
+        if (-not $candidateSet.Contains([string]$resolved.Path)) {
+            throw "Pester worker line filter is not in the candidate Pester test inventory: $lineFilter"
+        }
+        if (-not $selectedPaths.Contains([string]$resolved.Path)) {
+            throw "Pester worker line filter is outside its declared paths: $lineFilter"
+        }
+        if (-not $seenFilters.Add([string]$resolved.Identity)) {
+            throw "Duplicate Pester line filter: $lineFilter"
+        }
+    }
+
+    $mode = [string]$Spec.Mode
+    $requiresPrivateRepository = [bool](Get-ObjectProperty -InputObject $Spec -Name 'RequiresPrivateRepository' -DefaultValue $false)
+    if ($mode -eq 'Discovery') {
+        if ($requiresPrivateRepository -or $lineFilters.Count -gt 0 -or $selectedPaths.Count -ne $candidateSet.Count) {
+            throw 'Pester discovery spec must contain the complete candidate inventory without line filters or private ownership.'
+        }
+        return
+    }
+    if ($mode -ne 'Test') {
+        throw "Unsupported Pester worker mode: $mode"
+    }
+
+    $ownerSet = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::OrdinalIgnoreCase)
+    foreach ($owner in Get-PrivatePesterFixtureRelativePaths) {
+        [void]$ownerSet.Add([System.IO.Path]::GetFullPath((Join-Path $repositoryRoot $owner)))
+    }
+    $selectedOwners = @($selectedPaths | Where-Object { $ownerSet.Contains([string]$_) })
+    if ($requiresPrivateRepository) {
+        if ($selectedPaths.Count -ne $ownerSet.Count -or $selectedOwners.Count -ne $ownerSet.Count) {
+            throw 'Private Pester worker must own exactly both mutable fixture suites.'
+        }
+    } elseif ($selectedOwners.Count -gt 0) {
+        throw 'Mutable Pester fixture suites cannot execute in the source repository.'
+    }
+}
+
 function Invoke-SerialSuite {
     param(
         [Parameter(Mandatory = $true)][string]$RepositoryRoot,
+        [Parameter(Mandatory = $true)][string]$PrivateRepositoryRoot,
         [Parameter(Mandatory = $true)][string]$TestResultPath,
         [Parameter(Mandatory = $true)][string]$CoverageReportPath,
         [Parameter(Mandatory = $true)]$PesterModule,
+        [Parameter(Mandatory = $true)][string[]]$CandidateTestPaths,
+        [string[]]$LineFilters = @(),
         [switch]$EnableCoverage
     )
 
     $coverageTargets = @()
     if ($EnableCoverage) {
-        $coverageTargets = @(Get-CoverageTargets -RepositoryRoot $RepositoryRoot)
+        $coverageTargets = @(Get-CoverageTargets -RepositoryRoot $RepositoryRoot -TestPaths $CandidateTestPaths)
         if ($coverageTargets.Count -eq 0) {
             throw 'Pester coverage was requested, but no coverage targets were found.'
         }
     }
 
     $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+    $executionPaths = @(Get-PesterExecutionPaths `
+        -RepositoryRoot $RepositoryRoot `
+        -PrivateRepositoryRoot $PrivateRepositoryRoot `
+        -CandidateTestPaths $CandidateTestPaths)
+    $executionLineFilters = @()
     if ($PesterModule.Version.Major -ge 5) {
         Import-Module $PesterModule.Path -Force -ErrorAction Stop | Out-Null
         $configuration = [PesterConfiguration]::Default
-        $configuration.Run.Path = @((Join-Path $RepositoryRoot 'tests'))
+        $configuration.Run.Path = $executionPaths
         $configuration.Run.PassThru = $true
         $configuration.Run.Exit = $false
         $configuration.Output.Verbosity = 'None'
         $configuration.TestResult.Enabled = $true
         $configuration.TestResult.OutputFormat = 'NUnitXml'
         $configuration.TestResult.OutputPath = $TestResultPath
+        if ($LineFilters.Count -gt 0) {
+            $executionLineFilters = @(Convert-PesterExecutionLineFilters `
+                -RepositoryRoot $RepositoryRoot `
+                -PrivateRepositoryRoot $PrivateRepositoryRoot `
+                -LineFilters $LineFilters)
+            $configuration.Filter.Line = $executionLineFilters
+        }
         $configuration.CodeCoverage.Enabled = [bool]$EnableCoverage
         if ($EnableCoverage) {
             $configuration.CodeCoverage.Path = $coverageTargets
@@ -380,16 +1028,45 @@ function Invoke-SerialSuite {
         }
         $result = Invoke-PesterIsolated -Configuration $configuration
     } else {
+        if ($LineFilters.Count -gt 0) {
+            throw 'Pester line filters require Pester 5 or newer.'
+        }
         if ($EnableCoverage) {
-            $result = Invoke-Pester (Join-Path $RepositoryRoot 'tests') -PassThru -Quiet -CodeCoverage $coverageTargets -OutputFormat NUnitXml -OutputFile $TestResultPath
+            $result = Invoke-Pester $executionPaths -PassThru -Quiet -CodeCoverage $coverageTargets -OutputFormat NUnitXml -OutputFile $TestResultPath
         } else {
-            $result = Invoke-Pester (Join-Path $RepositoryRoot 'tests') -PassThru -Quiet -OutputFormat NUnitXml -OutputFile $TestResultPath
+            $result = Invoke-Pester $executionPaths -PassThru -Quiet -OutputFormat NUnitXml -OutputFile $TestResultPath
         }
     }
     $stopwatch.Stop()
+    $selectedTests = if ($executionLineFilters.Count -gt 0) {
+        $selectedLines = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::OrdinalIgnoreCase)
+        foreach ($line in $executionLineFilters) {
+            [void]$selectedLines.Add(([string]$line).Replace('\', '/'))
+        }
+        @($result.Tests | Where-Object {
+            $lineIdentity = '{0}:{1}' -f ([string]$_.ScriptBlock.File).Replace('\', '/'), [int]$_.StartLine
+            $selectedLines.Contains($lineIdentity)
+        })
+    } else {
+        @($result.Tests)
+    }
+    if ($executionLineFilters.Count -gt 0) {
+        $matchedLines = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::OrdinalIgnoreCase)
+        foreach ($test in @($selectedTests)) {
+            $lineIdentity = '{0}:{1}' -f ([string]$test.ScriptBlock.File).Replace('\', '/'), [int]$test.StartLine
+            [void]$matchedLines.Add($lineIdentity)
+        }
+        $unmatched = @($executionLineFilters | Where-Object {
+            -not $matchedLines.Contains(([string]$_).Replace('\', '/'))
+        })
+        if ($unmatched.Count -gt 0) {
+            throw "Pester line filters matched no executed test: $($unmatched -join ', ')"
+        }
+    }
 
     return [PSCustomObject]@{
         Result = $result
+        SelectedTests = @($selectedTests)
         DurationSeconds = [math]::Round($stopwatch.Elapsed.TotalSeconds, 3)
     }
 }
@@ -398,13 +1075,33 @@ function Invoke-PesterWorker {
     param([Parameter(Mandatory = $true)][string]$SpecPath)
 
     $spec = Get-Content -LiteralPath $SpecPath -Raw -Encoding UTF8 | ConvertFrom-Json -ErrorAction Stop
+    $candidateTreeId = [string](Get-ObjectProperty -InputObject $spec -Name 'CandidateTreeId' -DefaultValue '')
+    if ($candidateTreeId -notmatch '\A[0-9a-f]{40}\z') {
+        throw 'Pester worker spec has no valid candidate tree ID.'
+    }
+    if ([Environment]::GetEnvironmentVariable('WINSMUX_PESTER_CANDIDATE_TREE', 'Process') -cne $candidateTreeId) {
+        throw 'Pester worker candidate tree ID does not match its controlled environment.'
+    }
+    $expectedCount = [int](Get-ObjectProperty -InputObject $spec -Name 'ExpectedCount' -DefaultValue -1)
+    if ($expectedCount -lt 0) {
+        throw 'Pester worker spec has no valid expected test count.'
+    }
+    $requiresPrivateRepository = [bool](Get-ObjectProperty -InputObject $spec -Name 'RequiresPrivateRepository' -DefaultValue $false)
+    $workerGitEnvironment = Get-RunnerGitEnvironment -HooksPath ([string]$spec.HooksPath) -TemplatePath ([string]$spec.TemplatePath) -CandidateTreeId $candidateTreeId
     New-Item -ItemType Directory -Path $spec.TempDirectory -Force | Out-Null
     New-Item -ItemType Directory -Path $spec.ProjectDirectory -Force | Out-Null
     New-Item -ItemType Directory -Path (Split-Path -Parent $spec.ResultPath) -Force | Out-Null
 
     try {
+        Assert-PesterWorkerSpecCandidatePaths -Spec $spec -Environment $workerGitEnvironment
+        if ($requiresPrivateRepository) {
+            $workerTreeId = (Invoke-RunnerGit -RepositoryRoot ([string]$spec.RepositoryRoot) -Arguments @('rev-parse', 'HEAD^{tree}') -Environment $workerGitEnvironment).StdOut
+            if ($workerTreeId -cne $candidateTreeId) {
+                throw 'Private Pester worker repository does not match the candidate tree ID.'
+            }
+        }
         if ([string]$spec.Mode -eq 'Discovery') {
-            $discovery = Invoke-TestDiscovery -TestsPath ([string]$spec.TestsPath) -PesterModulePath ([string]$spec.PesterModulePath)
+            $discovery = Invoke-TestDiscovery -Paths @($spec.Paths) -PesterModulePath ([string]$spec.PesterModulePath)
             $tests = @($discovery.Tests | ForEach-Object {
                 $pathParts = @($_.Path | ForEach-Object { [string]$_ })
                 $expandedName = if ($_.PSObject.Properties.Name -contains 'ExpandedName') { [string]$_.ExpandedName } else { [string]$_.Name }
@@ -428,6 +1125,7 @@ function Invoke-PesterWorker {
             $payload = [ordered]@{
                 mode = 'discovery'
                 workerId = [string]$spec.WorkerId
+                candidateTreeId = $candidateTreeId
                 total = [int]$discovery.TotalCount
                 failedBlocks = [int]$discovery.FailedBlocksCount
                 failedContainers = [int]$discovery.FailedContainersCount
@@ -475,7 +1173,9 @@ function Invoke-PesterWorker {
         $inconclusive = @($selectedTests | Where-Object { [string]$_.Result -eq 'Inconclusive' }).Count
         $payload = [ordered]@{
             workerId = [string]$spec.WorkerId
-            expectedCount = [int]$spec.ExpectedCount
+            candidateTreeId = $candidateTreeId
+            requiresPrivateRepository = $requiresPrivateRepository
+            expectedCount = $expectedCount
             total = [int]$selectedTests.Count
             passed = [int]$passed
             failed = [int]$failed
@@ -493,8 +1193,15 @@ function Invoke-PesterWorker {
             identityHash = Get-IdentityHash -Identities $identities
             identities = $identities
         }
+        $countMismatch = $payload.total -ne $expectedCount
+        if ($countMismatch) {
+            $payload['harnessError'] = "Pester worker expected $expectedCount tests, got $($payload.total)."
+        }
         $payload | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $spec.ResultPath -Encoding UTF8
 
+        if ($countMismatch) {
+            return 2
+        }
         if (($payload.failed -eq 0) -and ($payload.failedBlocks -eq 0) -and ($payload.failedContainers -eq 0)) {
             return 0
         }
@@ -502,7 +1209,9 @@ function Invoke-PesterWorker {
     } catch {
         $failure = [ordered]@{
             workerId = [string]$spec.WorkerId
-            expectedCount = [int]$spec.ExpectedCount
+            candidateTreeId = $candidateTreeId
+            requiresPrivateRepository = $requiresPrivateRepository
+            expectedCount = $expectedCount
             total = 0
             passed = 0
             failed = 0
@@ -529,13 +1238,16 @@ function Invoke-PesterWorker {
 
 function Invoke-TestDiscovery {
     param(
-        [Parameter(Mandatory = $true)][string]$TestsPath,
+        [Parameter(Mandatory = $true)][string[]]$Paths,
         [Parameter(Mandatory = $true)][string]$PesterModulePath
     )
 
+    if ($Paths.Count -eq 0) {
+        throw 'Pester discovery received an empty candidate test inventory.'
+    }
     Import-Module $PesterModulePath -Force -ErrorAction Stop | Out-Null
     $configuration = [PesterConfiguration]::Default
-    $configuration.Run.Path = @($TestsPath)
+    $configuration.Run.Path = @($Paths)
     $configuration.Run.PassThru = $true
     $configuration.Run.Exit = $false
     $configuration.Run.SkipRun = $true
@@ -609,18 +1321,27 @@ function Get-BridgeShards {
 function New-PesterWorkUnits {
     param(
         [Parameter(Mandatory = $true)][string]$RepositoryRoot,
+        [Parameter(Mandatory = $true)][string]$CandidateRepositoryRoot,
+        [Parameter(Mandatory = $true)][string[]]$CandidateTestPaths,
         [Parameter(Mandatory = $true)]$DiscoveryResult
     )
 
-    $testsPath = Join-Path $RepositoryRoot 'tests'
-    $testFiles = @(Get-ChildItem -LiteralPath $testsPath -Filter '*.Tests.ps1' -File -Recurse | Sort-Object FullName)
+    $testFiles = @($CandidateTestPaths | ForEach-Object { [System.IO.Path]::GetFullPath($_) } | Sort-Object -Unique)
     if ($testFiles.Count -eq 0) {
-        throw 'No Pester test files were found.'
+        throw 'Candidate Pester inventory is empty.'
+    }
+    if ($testFiles.Count -ne $CandidateTestPaths.Count) {
+        throw 'Candidate Pester inventory contains duplicate paths.'
     }
 
+    $candidateFiles = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::OrdinalIgnoreCase)
+    foreach ($testFile in $testFiles) { [void]$candidateFiles.Add($testFile) }
     $testsByFile = @{}
     foreach ($test in $DiscoveryResult.tests) {
         $file = [System.IO.Path]::GetFullPath([string]$test.file)
+        if (-not $candidateFiles.Contains($file)) {
+            throw "Pester discovery returned a test outside the candidate inventory: $file"
+        }
         if (-not $testsByFile.ContainsKey($file)) {
             $testsByFile[$file] = [System.Collections.Generic.List[object]]::new()
         }
@@ -628,20 +1349,63 @@ function New-PesterWorkUnits {
     }
 
     $units = [System.Collections.Generic.List[object]]::new()
-    $shards = @(Get-BridgeShards -RepositoryRoot $RepositoryRoot)
+    $shards = @(Get-BridgeShards -RepositoryRoot $CandidateRepositoryRoot | ForEach-Object {
+        $candidateShard = $_
+        $sourcePaths = @($candidateShard.Paths | ForEach-Object {
+            $relative = [System.IO.Path]::GetRelativePath($CandidateRepositoryRoot, [string]$_)
+            if ($relative.StartsWith("..$([System.IO.Path]::DirectorySeparatorChar)", [StringComparison]::Ordinal) -or
+                [System.IO.Path]::IsPathRooted($relative)) {
+                throw "Candidate bridge shard path escapes its repository: $_"
+            }
+            $sourcePath = [System.IO.Path]::GetFullPath((Join-Path $RepositoryRoot $relative))
+            if (-not $candidateFiles.Contains($sourcePath)) {
+                throw "Candidate bridge shard path is absent from the candidate test inventory: $relative"
+            }
+            $sourcePath
+        })
+        [PSCustomObject]@{ Name = [string]$candidateShard.Name; Paths = $sourcePaths }
+    })
     $bridgePaths = @($shards.Paths | ForEach-Object { [System.IO.Path]::GetFullPath([string]$_) } | Sort-Object -Unique)
-    foreach ($file in $testFiles | Where-Object { [System.IO.Path]::GetFullPath($_.FullName) -notin $bridgePaths }) {
-        $fullPath = [System.IO.Path]::GetFullPath($file.FullName)
+    $privatePaths = @(Get-PrivatePesterFixtureRelativePaths | ForEach-Object {
+        [System.IO.Path]::GetFullPath((Join-Path $RepositoryRoot $_))
+    })
+    if (@($privatePaths | Where-Object { $_ -in $bridgePaths }).Count -gt 0) {
+        throw 'A private Pester fixture owner is also assigned to a bridge shard.'
+    }
+    foreach ($file in $testFiles | Where-Object {
+        $candidate = [System.IO.Path]::GetFullPath($_)
+        $candidate -notin $bridgePaths -and $candidate -notin $privatePaths
+    }) {
+        $fullPath = [System.IO.Path]::GetFullPath($file)
         if (-not $testsByFile.ContainsKey($fullPath)) {
             throw "Pester discovery did not return tests for $fullPath"
         }
         $units.Add([PSCustomObject]@{
-            WorkerId = 'file-' + [System.IO.Path]::GetFileNameWithoutExtension($file.Name).ToLowerInvariant().Replace('.', '-')
+            WorkerId = 'file-' + [System.IO.Path]::GetFileNameWithoutExtension($fullPath).ToLowerInvariant().Replace('.', '-')
             Paths = @($fullPath)
             LineFilters = @()
             ExpectedCount = [int]$testsByFile[$fullPath].Count
+            RequiresPrivateRepository = $false
         })
     }
+
+    $privateCount = 0
+    foreach ($privatePath in $privatePaths) {
+        if (-not $testsByFile.ContainsKey($privatePath)) {
+            throw "Pester discovery did not return private fixture tests for $privatePath"
+        }
+        $privateCount += [int]$testsByFile[$privatePath].Count
+    }
+    if ($privateCount -eq 0) {
+        throw 'Private Pester fixture resolved to zero tests.'
+    }
+    $units.Add([PSCustomObject]@{
+        WorkerId = 'private-git-fixture'
+        Paths = $privatePaths
+        LineFilters = @()
+        ExpectedCount = $privateCount
+        RequiresPrivateRepository = $true
+    })
 
     foreach ($shard in $shards) {
         $count = 0
@@ -660,6 +1424,7 @@ function New-PesterWorkUnits {
             Paths = @($shard.Paths)
             LineFilters = @()
             ExpectedCount = $count
+            RequiresPrivateRepository = $false
         })
     }
 
@@ -668,6 +1433,79 @@ function New-PesterWorkUnits {
         throw "Pester work-unit coverage mismatch: units=$expected discovery=$($DiscoveryResult.total)"
     }
     return $units.ToArray()
+}
+
+function Select-PesterWorkUnitsByLineFilter {
+    param(
+        [Parameter(Mandatory = $true)][string]$RepositoryRoot,
+        [Parameter(Mandatory = $true)][object[]]$Units,
+        [Parameter(Mandatory = $true)]$DiscoveryResult,
+        [string[]]$LineFilters = @()
+    )
+
+    if ($LineFilters.Count -eq 0) {
+        return [PSCustomObject]@{
+            Units = $Units
+            Tests = @($DiscoveryResult.tests)
+            Total = [int]$DiscoveryResult.total
+        }
+    }
+
+    $requested = [System.Collections.Generic.Dictionary[string, object]]::new([StringComparer]::OrdinalIgnoreCase)
+    foreach ($lineFilter in $LineFilters) {
+        $resolved = Resolve-PesterLineFilter -RepositoryRoot $RepositoryRoot -LineFilter ([string]$lineFilter)
+        if ($requested.ContainsKey([string]$resolved.Identity)) {
+            throw "Duplicate Pester line filter: $lineFilter"
+        }
+        $requested[[string]$resolved.Identity] = $resolved
+    }
+
+    $selectedTests = [System.Collections.Generic.List[object]]::new()
+    $matched = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::OrdinalIgnoreCase)
+    foreach ($test in @($DiscoveryResult.tests)) {
+        $identity = '{0}:{1}' -f ([System.IO.Path]::GetFullPath([string]$test.file)).Replace('\', '/'), [int]$test.startLine
+        if ($requested.ContainsKey($identity)) {
+            $selectedTests.Add($test)
+            [void]$matched.Add($identity)
+        }
+    }
+    $unmatched = @($requested.Keys | Where-Object { -not $matched.Contains([string]$_) })
+    if ($unmatched.Count -gt 0) {
+        throw "Pester line filters matched no discovered test: $($unmatched -join ', ')"
+    }
+
+    $boundedUnits = [System.Collections.Generic.List[object]]::new()
+    foreach ($unit in $Units) {
+        $unitPaths = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::OrdinalIgnoreCase)
+        foreach ($path in @($unit.Paths)) {
+            [void]$unitPaths.Add([System.IO.Path]::GetFullPath([string]$path))
+        }
+        $unitTests = @($selectedTests | Where-Object {
+            $unitPaths.Contains([System.IO.Path]::GetFullPath([string]$_.file))
+        })
+        if ($unitTests.Count -eq 0) {
+            continue
+        }
+        $unitLineFilters = @($unitTests | ForEach-Object {
+            '{0}:{1}' -f [System.IO.Path]::GetFullPath([string]$_.file), [int]$_.startLine
+        } | Sort-Object -Unique)
+        $boundedUnits.Add([PSCustomObject]@{
+            WorkerId = [string]$unit.WorkerId
+            Paths = @($unit.Paths)
+            LineFilters = $unitLineFilters
+            ExpectedCount = [int]$unitTests.Count
+            RequiresPrivateRepository = [bool]$unit.RequiresPrivateRepository
+        })
+    }
+    $covered = [int](($boundedUnits | Measure-Object ExpectedCount -Sum).Sum)
+    if ($covered -ne $selectedTests.Count) {
+        throw "Bounded Pester work-unit coverage mismatch: units=$covered selected=$($selectedTests.Count)"
+    }
+    return [PSCustomObject]@{
+        Units = $boundedUnits.ToArray()
+        Tests = $selectedTests.ToArray()
+        Total = $selectedTests.Count
+    }
 }
 
 function Merge-NUnitResults {
@@ -760,11 +1598,14 @@ function Merge-NUnitResults {
 function Invoke-ParallelSuite {
     param(
         [Parameter(Mandatory = $true)][string]$RepositoryRoot,
+        [Parameter(Mandatory = $true)][string]$PrivateRepositoryRoot,
+        [Parameter(Mandatory = $true)]$CandidateContext,
         [Parameter(Mandatory = $true)][string]$ResultsRoot,
         [Parameter(Mandatory = $true)][string]$TestResultPath,
         [Parameter(Mandatory = $true)]$PesterModule,
         [Parameter(Mandatory = $true)][int]$ThrottleLimit,
-        [Parameter(Mandatory = $true)][int]$TimeoutSeconds
+        [Parameter(Mandatory = $true)][int]$TimeoutSeconds,
+        [string[]]$LineFilters = @()
     )
 
     $runId = (Get-Date).ToUniversalTime().ToString('yyyyMMddTHHmmssfffZ') + '-' + [guid]::NewGuid().ToString('N').Substring(0, 8)
@@ -789,13 +1630,21 @@ function Invoke-ParallelSuite {
         $discoverySpec = [ordered]@{
             Mode = 'Discovery'
             WorkerId = 'discovery'
-            TestsPath = Join-Path $RepositoryRoot 'tests'
+            RepositoryRoot = $RepositoryRoot
+            WorkingDirectory = $RepositoryRoot
+            Paths = @($CandidateContext.CandidateTestPaths)
+            LineFilters = @()
+            ExpectedCount = 0
             ResultPath = Join-Path $discoveryRoot 'result.json'
             StdOutPath = Join-Path $discoveryRoot 'stdout.log'
             StdErrPath = Join-Path $discoveryRoot 'stderr.log'
             TempDirectory = $discoveryTemp
             ProjectDirectory = $discoveryProject
             PesterModulePath = [string]$PesterModule.Path
+            CandidateTreeId = [string]$CandidateContext.CandidateTreeId
+            HooksPath = [string]$CandidateContext.HooksPath
+            TemplatePath = [string]$CandidateContext.TemplatePath
+            RequiresPrivateRepository = $false
         }
         $discoverySpecPath = Join-Path $discoveryRoot 'spec.json'
         $discoverySpec | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $discoverySpecPath -Encoding UTF8
@@ -811,8 +1660,18 @@ function Invoke-ParallelSuite {
         if (([string]$discovery.mode -ne 'discovery') -or ([int]$discovery.total -le 0)) {
             throw 'Isolated Pester discovery returned an invalid payload.'
         }
-        $expectedIdentities = @($discovery.tests.identity | ForEach-Object { [string]$_ } | Sort-Object)
-        $units = @(New-PesterWorkUnits -RepositoryRoot $RepositoryRoot -DiscoveryResult $discovery)
+        if ([string]$discovery.candidateTreeId -cne [string]$CandidateContext.CandidateTreeId) {
+            throw 'Isolated Pester discovery candidate tree ID mismatch.'
+        }
+        $allUnits = @(New-PesterWorkUnits `
+            -RepositoryRoot $RepositoryRoot `
+            -CandidateRepositoryRoot $PrivateRepositoryRoot `
+            -CandidateTestPaths @($CandidateContext.CandidateTestPaths) `
+            -DiscoveryResult $discovery)
+        $selection = Select-PesterWorkUnitsByLineFilter -RepositoryRoot $RepositoryRoot -Units $allUnits -DiscoveryResult $discovery -LineFilters $LineFilters
+        $units = @($selection.Units)
+        $expectedTotal = [int]$selection.Total
+        $expectedIdentities = @($selection.Tests.identity | ForEach-Object { [string]$_ } | Sort-Object)
         $specs = [System.Collections.Generic.List[object]]::new()
         $specPaths = [System.Collections.Generic.List[string]]::new()
         $index = 0
@@ -823,12 +1682,28 @@ function Invoke-ParallelSuite {
             $projectDirectory = Join-Path $workerTemp 'project'
             New-Item -ItemType Directory -Path $workerRoot -Force | Out-Null
             New-Item -ItemType Directory -Path $projectDirectory -Force | Out-Null
+            $requiresPrivateRepository = [bool]$unit.RequiresPrivateRepository
+            $workerRepositoryRoot = if ($requiresPrivateRepository) { $PrivateRepositoryRoot } else { $RepositoryRoot }
+            $workerPaths = if ($requiresPrivateRepository) {
+                @($unit.Paths | ForEach-Object {
+                    $relative = [System.IO.Path]::GetRelativePath($RepositoryRoot, [string]$_)
+                    $mapped = [System.IO.Path]::GetFullPath((Join-Path $PrivateRepositoryRoot $relative))
+                    if (-not (Test-Path -LiteralPath $mapped -PathType Leaf)) {
+                        throw "Private Pester worker path is missing: $relative"
+                    }
+                    $mapped
+                })
+            } else {
+                @($unit.Paths)
+            }
+            $workerLineFilters = @(Convert-PesterExecutionLineFilters -RepositoryRoot $RepositoryRoot -PrivateRepositoryRoot $PrivateRepositoryRoot -LineFilters @($unit.LineFilters))
             $spec = [ordered]@{
                 Mode = 'Test'
                 WorkerId = [string]$unit.WorkerId
-                RepositoryRoot = $RepositoryRoot
-                Paths = @($unit.Paths)
-                LineFilters = @($unit.LineFilters)
+                RepositoryRoot = $workerRepositoryRoot
+                WorkingDirectory = $workerRepositoryRoot
+                Paths = $workerPaths
+                LineFilters = $workerLineFilters
                 ExpectedCount = [int]$unit.ExpectedCount
                 ResultPath = Join-Path $workerRoot 'result.json'
                 NUnitPath = Join-Path $workerRoot 'result.xml'
@@ -837,6 +1712,10 @@ function Invoke-ParallelSuite {
                 TempDirectory = $workerTemp
                 ProjectDirectory = $projectDirectory
                 PesterModulePath = [string]$PesterModule.Path
+                CandidateTreeId = [string]$CandidateContext.CandidateTreeId
+                HooksPath = [string]$CandidateContext.HooksPath
+                TemplatePath = [string]$CandidateContext.TemplatePath
+                RequiresPrivateRepository = $requiresPrivateRepository
             }
             $specPath = Join-Path $workerRoot 'spec.json'
             $spec | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $specPath -Encoding UTF8
@@ -873,6 +1752,12 @@ function Invoke-ParallelSuite {
             if ([string]$payload.workerId -ne [string]$launch.WorkerId) {
                 $harnessFailures.Add("$($launch.WorkerId): result worker identity mismatch")
             }
+            if ([string]$payload.candidateTreeId -cne [string]$CandidateContext.CandidateTreeId) {
+                $harnessFailures.Add("$($launch.WorkerId): result candidate tree identity mismatch")
+            }
+            if ([bool]$payload.requiresPrivateRepository -ne [bool]$spec.RequiresPrivateRepository) {
+                $harnessFailures.Add("$($launch.WorkerId): result private fixture ownership mismatch")
+            }
             if ([int]$payload.total -ne [int]$spec.ExpectedCount) {
                 $harnessFailures.Add("$($launch.WorkerId): expected $($spec.ExpectedCount) tests, got $($payload.total)")
             }
@@ -901,8 +1786,8 @@ function Invoke-ParallelSuite {
         $failedBlocks = [int](($workerPayloads | Measure-Object failedBlocks -Sum).Sum)
         $failedContainers = [int](($workerPayloads | Measure-Object failedContainers -Sum).Sum)
         $actualIdentities = @($workerPayloads.identities | ForEach-Object { [string]$_ } | Sort-Object)
-        if ($totalCount -ne [int]$discovery.total) {
-            $harnessFailures.Add("aggregate total $totalCount does not match discovery total $($discovery.total)")
+        if ($totalCount -ne $expectedTotal) {
+            $harnessFailures.Add("aggregate total $totalCount does not match selected discovery total $expectedTotal")
         }
         if ($actualIdentities.Count -ne $expectedIdentities.Count) {
             $harnessFailures.Add("identity count $($actualIdentities.Count) does not match discovery $($expectedIdentities.Count)")
@@ -934,6 +1819,7 @@ function Invoke-ParallelSuite {
             FailedContainersCount = $failedContainers
             IdentityHash = Get-IdentityHash -Identities $actualIdentities
             DiscoveryIdentityHash = Get-IdentityHash -Identities $expectedIdentities
+            CandidateTreeId = [string]$CandidateContext.CandidateTreeId
             HarnessFailures = $harnessFailures
         }
     } finally {
@@ -952,16 +1838,42 @@ function Invoke-ParallelSuite {
 
 if (-not [string]::IsNullOrWhiteSpace($WorkerSpecPath)) {
     $workerExitCode = 2
-    if (-not [string]::IsNullOrWhiteSpace($WorkerStdOutPath) -and -not [string]::IsNullOrWhiteSpace($WorkerStdErrPath)) {
-        $WorkerStdOutPath = [System.IO.Path]::GetFullPath($WorkerStdOutPath)
-        $WorkerStdErrPath = [System.IO.Path]::GetFullPath($WorkerStdErrPath)
-        New-Item -ItemType Directory -Path (Split-Path -Parent $WorkerStdOutPath) -Force | Out-Null
-        New-Item -ItemType Directory -Path (Split-Path -Parent $WorkerStdErrPath) -Force | Out-Null
-        & {
-            $script:workerExitCode = Invoke-PesterWorker -SpecPath ([System.IO.Path]::GetFullPath($WorkerSpecPath))
-        } 1> $WorkerStdOutPath 2> $WorkerStdErrPath
-    } else {
-        $workerExitCode = Invoke-PesterWorker -SpecPath ([System.IO.Path]::GetFullPath($WorkerSpecPath))
+    try {
+        $workerSpecFullPath = [System.IO.Path]::GetFullPath($WorkerSpecPath)
+        $workerSpec = Get-Content -LiteralPath $workerSpecFullPath -Raw -Encoding UTF8 | ConvertFrom-Json -ErrorAction Stop
+        $workerRepositoryRoot = [System.IO.Path]::GetFullPath([string]$workerSpec.RepositoryRoot)
+        $workerWorkingDirectory = [System.IO.Path]::GetFullPath([string]$workerSpec.WorkingDirectory)
+        if (-not [StringComparer]::OrdinalIgnoreCase.Equals($workerRepositoryRoot, $workerWorkingDirectory)) {
+            throw 'Pester worker working directory must equal its repository root.'
+        }
+        $workerGitEnvironment = Get-RunnerGitEnvironment `
+            -HooksPath ([string]$workerSpec.HooksPath) `
+            -TemplatePath ([string]$workerSpec.TemplatePath) `
+            -CandidateTreeId ([string]$workerSpec.CandidateTreeId)
+        $workerAction = {
+            Push-Location -LiteralPath $workerRepositoryRoot
+            try {
+                Invoke-WithRunnerGitEnvironment -Environment $workerGitEnvironment -ScriptBlock {
+                    Invoke-PesterWorker -SpecPath $workerSpecFullPath
+                }
+            } finally {
+                Pop-Location
+            }
+        }
+        if (-not [string]::IsNullOrWhiteSpace($WorkerStdOutPath) -and -not [string]::IsNullOrWhiteSpace($WorkerStdErrPath)) {
+            $WorkerStdOutPath = [System.IO.Path]::GetFullPath($WorkerStdOutPath)
+            $WorkerStdErrPath = [System.IO.Path]::GetFullPath($WorkerStdErrPath)
+            New-Item -ItemType Directory -Path (Split-Path -Parent $WorkerStdOutPath) -Force | Out-Null
+            New-Item -ItemType Directory -Path (Split-Path -Parent $WorkerStdErrPath) -Force | Out-Null
+            & {
+                $script:workerExitCode = & $workerAction
+            } 1> $WorkerStdOutPath 2> $WorkerStdErrPath
+        } else {
+            $workerExitCode = & $workerAction
+        }
+    } catch {
+        [Console]::Error.WriteLine("Pester worker setup failed: $($_.Exception.Message)")
+        $workerExitCode = 2
     }
     exit $workerExitCode
 }
@@ -982,110 +1894,193 @@ foreach ($stalePath in @($testResultPath, $coverageReportPath, $summaryPath)) {
     }
 }
 
-$pesterModule = Get-PesterModule
-if (-not $pesterModule) {
-    Write-TestSummary -Path $summaryPath -PassedCount 0 -FailedCount 1 -TotalCount 0 -CoveragePercent $null -CoverageThreshold $CoverageThreshold -Additional @{ mode = 'unavailable' }
-    Write-Output 'Pester: module not found'
-    Write-Output 'Coverage: unavailable'
-    exit 1
-}
-
-$useParallel = [bool]$Parallel -and -not [bool]$Coverage -and ($pesterModule.Version.Major -ge 5)
-if ($env:WINSMUX_UPDATE_GOLDEN -eq '1') {
-    $useParallel = $false
-    Write-Output 'Pester: parallel execution disabled because WINSMUX_UPDATE_GOLDEN=1'
-}
+$prospectiveIndexPath = [Environment]::GetEnvironmentVariable('GIT_INDEX_FILE', 'Process')
+$controllerId = (Get-Date).ToUniversalTime().ToString('yyyyMMddTHHmmssfffZ') + '-' + [guid]::NewGuid().ToString('N').Substring(0, 8)
+$runnerControlRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('winsmux-pester-controller-' + $controllerId)
+$candidateContext = $null
+$privateRepositoryRoot = $null
+$runnerExitCode = 1
+$postflightFailure = ''
 
 try {
-    if ($useParallel) {
-        Import-Module $pesterModule.Path -Force -ErrorAction Stop | Out-Null
-        $probe = [PesterConfiguration]::Default
-        $requiredRunProperties = @('Path', 'PassThru', 'Exit', 'SkipRun')
-        if (@($requiredRunProperties | Where-Object { $probe.Run.PSObject.Properties.Name -notcontains $_ }).Count -gt 0 -or
-            $probe.Filter.PSObject.Properties.Name -notcontains 'Line') {
-            $useParallel = $false
-            Write-Output 'Pester: parallel features unavailable; using serial execution'
-        }
+    $contextParameters = @{
+        RepositoryRoot = $repositoryRoot
+        ExecutionRoot = $runnerControlRoot
     }
+    if (-not [string]::IsNullOrWhiteSpace($prospectiveIndexPath)) {
+        $contextParameters['ProspectiveIndexPath'] = $prospectiveIndexPath
+    }
+    $candidateContext = New-RunnerCandidateContext @contextParameters
+    $privateRepositoryRoot = New-RunnerPrivateRepository -Context $candidateContext -DestinationPath (Join-Path $runnerControlRoot 'private-repository')
 
-    if ($useParallel) {
-        $parallelResult = Invoke-ParallelSuite -RepositoryRoot $repositoryRoot -ResultsRoot $ResultsDirectory -TestResultPath $testResultPath -PesterModule $pesterModule -ThrottleLimit $MaxParallel -TimeoutSeconds $WorkerTimeoutSeconds
-        $additional = [ordered]@{
-            skipped = $parallelResult.SkippedCount
-            notRun = $parallelResult.NotRunCount
-            failedBlocks = $parallelResult.FailedBlocksCount
-            failedContainers = $parallelResult.FailedContainersCount
-            parallel = $true
-            durationSeconds = $parallelResult.DurationSeconds
-            workerCount = $parallelResult.WorkerCount
-            runId = $parallelResult.RunId
-            identityHash = $parallelResult.IdentityHash
-            discoveryIdentityHash = $parallelResult.DiscoveryIdentityHash
-            harnessFailures = @($parallelResult.HarnessFailures)
-        }
-        Write-TestSummary -Path $summaryPath -PassedCount $parallelResult.PassedCount -FailedCount $parallelResult.FailedCount -TotalCount $parallelResult.TotalCount -CoveragePercent $null -CoverageThreshold $CoverageThreshold -Additional $additional
-        Write-Output ('Pester: Passed={0} Failed={1} Total={2}' -f $parallelResult.PassedCount, $parallelResult.FailedCount, $parallelResult.TotalCount)
-        Write-Output 'Coverage: disabled'
-        Write-Output ('Parallel: Workers={0} Duration={1:N3}s MaxParallel={2}' -f $parallelResult.WorkerCount, $parallelResult.DurationSeconds, $MaxParallel)
-        foreach ($failure in @($parallelResult.HarnessFailures)) {
-            Write-Warning $failure
-        }
-        if (($parallelResult.FailedCount -eq 0) -and
-            ($parallelResult.FailedBlocksCount -eq 0) -and
-            ($parallelResult.FailedContainersCount -eq 0) -and
-            (@($parallelResult.HarnessFailures).Count -eq 0)) {
-            exit 0
-        }
-        exit 1
-    }
-
-    $serial = Invoke-SerialSuite -RepositoryRoot $repositoryRoot -TestResultPath $testResultPath -CoverageReportPath $coverageReportPath -PesterModule $pesterModule -EnableCoverage:$Coverage
-    $result = $serial.Result
-    $passedCount = [int](Get-ObjectProperty -InputObject $result -Name 'PassedCount' -DefaultValue 0)
-    $failedCount = [int](Get-ObjectProperty -InputObject $result -Name 'FailedCount' -DefaultValue 0)
-    $totalCount = [int](Get-ObjectProperty -InputObject $result -Name 'TotalCount' -DefaultValue ($passedCount + $failedCount))
-    $skippedCount = [int](Get-ObjectProperty -InputObject $result -Name 'SkippedCount' -DefaultValue 0)
-    $notRunCount = [int](Get-ObjectProperty -InputObject $result -Name 'NotRunCount' -DefaultValue 0)
-    $failedBlocksCount = [int](Get-ObjectProperty -InputObject $result -Name 'FailedBlocksCount' -DefaultValue 0)
-    $failedContainersCount = [int](Get-ObjectProperty -InputObject $result -Name 'FailedContainersCount' -DefaultValue 0)
-    $resultTests = @(Get-ObjectProperty -InputObject $result -Name 'Tests' -DefaultValue @())
-    $coveragePercent = Get-CoveragePercent -CodeCoverage (Get-ObjectProperty -InputObject $result -Name 'CodeCoverage')
-    $thresholdMet = (-not $Coverage) -or (($null -ne $coveragePercent) -and ($coveragePercent -ge $CoverageThreshold))
-    $identities = @($resultTests | ForEach-Object { Get-TestIdentity -Test $_ })
-    $additional = [ordered]@{
-        skipped = $skippedCount
-        notRun = $notRunCount
-        failedBlocks = $failedBlocksCount
-        failedContainers = $failedContainersCount
-        parallel = $false
-        durationSeconds = $serial.DurationSeconds
-        workerCount = 1
-        identityHash = Get-IdentityHash -Identities $identities
-    }
-    Write-TestSummary -Path $summaryPath -PassedCount $passedCount -FailedCount $failedCount -TotalCount $totalCount -CoveragePercent $coveragePercent -CoverageThreshold $CoverageThreshold -Additional $additional
-    Write-Output ('Pester: Passed={0} Failed={1} Total={2}' -f $passedCount, $failedCount, $totalCount)
-    if ($Coverage) {
-        if ($null -ne $coveragePercent) {
-            Write-Output ('Coverage: {0:N2}% (threshold: {1}%)' -f $coveragePercent, $CoverageThreshold)
+    Invoke-WithRunnerGitEnvironment -Environment $candidateContext.GitEnvironment -ScriptBlock {
+        $pesterModule = Get-PesterModule
+        if (-not $pesterModule) {
+            Write-TestSummary -Path $summaryPath -PassedCount 0 -FailedCount 1 -TotalCount 0 -CoveragePercent $null -CoverageThreshold $CoverageThreshold -Additional @{
+                mode = 'unavailable'
+                candidateTreeId = [string]$candidateContext.CandidateTreeId
+            }
+            Write-Output 'Pester: module not found'
+            Write-Output 'Coverage: unavailable'
+            $script:runnerExitCode = 1
         } else {
-            Write-Output ('Coverage: unavailable (threshold: {0}%)' -f $CoverageThreshold)
-        }
-    } else {
-        Write-Output 'Coverage: disabled'
-    }
-    Write-Output ('Parallel: disabled Duration={0:N3}s' -f $serial.DurationSeconds)
+            $useParallel = [bool]$Parallel -and -not [bool]$Coverage -and ($pesterModule.Version.Major -ge 5)
+            if ($env:WINSMUX_UPDATE_GOLDEN -eq '1') {
+                $useParallel = $false
+                Write-Output 'Pester: parallel execution disabled because WINSMUX_UPDATE_GOLDEN=1'
+            }
 
-    if (($failedCount -eq 0) -and
-        ($failedBlocksCount -eq 0) -and
-        ($failedContainersCount -eq 0) -and
-        $thresholdMet) {
-        exit 0
+            if ($useParallel) {
+                Import-Module $pesterModule.Path -Force -ErrorAction Stop | Out-Null
+                $probe = [PesterConfiguration]::Default
+                $requiredRunProperties = @('Path', 'PassThru', 'Exit', 'SkipRun')
+                if (@($requiredRunProperties | Where-Object { $probe.Run.PSObject.Properties.Name -notcontains $_ }).Count -gt 0 -or
+                    $probe.Filter.PSObject.Properties.Name -notcontains 'Line') {
+                    $useParallel = $false
+                    Write-Output 'Pester: parallel features unavailable; using serial execution'
+                }
+            }
+
+            if ($useParallel) {
+                $parallelResult = Invoke-ParallelSuite `
+                    -RepositoryRoot $repositoryRoot `
+                    -PrivateRepositoryRoot $privateRepositoryRoot `
+                    -CandidateContext $candidateContext `
+                    -ResultsRoot $ResultsDirectory `
+                    -TestResultPath $testResultPath `
+                    -PesterModule $pesterModule `
+                    -ThrottleLimit $MaxParallel `
+                    -TimeoutSeconds $WorkerTimeoutSeconds `
+                    -LineFilters $LineFilters
+                $additional = [ordered]@{
+                    skipped = $parallelResult.SkippedCount
+                    notRun = $parallelResult.NotRunCount
+                    failedBlocks = $parallelResult.FailedBlocksCount
+                    failedContainers = $parallelResult.FailedContainersCount
+                    parallel = $true
+                    durationSeconds = $parallelResult.DurationSeconds
+                    workerCount = $parallelResult.WorkerCount
+                    runId = $parallelResult.RunId
+                    identityHash = $parallelResult.IdentityHash
+                    discoveryIdentityHash = $parallelResult.DiscoveryIdentityHash
+                    candidateTreeId = $parallelResult.CandidateTreeId
+                    privateFixtureOwnerCount = 2
+                    boundedLineFilterCount = $LineFilters.Count
+                    harnessFailures = @($parallelResult.HarnessFailures)
+                }
+                Write-TestSummary -Path $summaryPath -PassedCount $parallelResult.PassedCount -FailedCount $parallelResult.FailedCount -TotalCount $parallelResult.TotalCount -CoveragePercent $null -CoverageThreshold $CoverageThreshold -Additional $additional
+                Write-Output ('Pester: Passed={0} Failed={1} Total={2}' -f $parallelResult.PassedCount, $parallelResult.FailedCount, $parallelResult.TotalCount)
+                Write-Output 'Coverage: disabled'
+                Write-Output ('Parallel: Workers={0} Duration={1:N3}s MaxParallel={2}' -f $parallelResult.WorkerCount, $parallelResult.DurationSeconds, $MaxParallel)
+                foreach ($failure in @($parallelResult.HarnessFailures)) {
+                    Write-Warning $failure
+                }
+                $script:runnerExitCode = if (($parallelResult.FailedCount -eq 0) -and
+                    ($parallelResult.FailedBlocksCount -eq 0) -and
+                    ($parallelResult.FailedContainersCount -eq 0) -and
+                    (@($parallelResult.HarnessFailures).Count -eq 0)) { 0 } else { 1 }
+            } else {
+                $serial = Invoke-SerialSuite `
+                    -RepositoryRoot $repositoryRoot `
+                    -PrivateRepositoryRoot $privateRepositoryRoot `
+                    -TestResultPath $testResultPath `
+                    -CoverageReportPath $coverageReportPath `
+                    -PesterModule $pesterModule `
+                    -CandidateTestPaths @($candidateContext.CandidateTestPaths) `
+                    -LineFilters $LineFilters `
+                    -EnableCoverage:$Coverage
+                $result = $serial.Result
+                $resultTests = @($serial.SelectedTests)
+                if ($LineFilters.Count -gt 0) {
+                    $passedCount = @($resultTests | Where-Object { [string]$_.Result -eq 'Passed' }).Count
+                    $failedCount = @($resultTests | Where-Object { [string]$_.Result -eq 'Failed' }).Count
+                    $skippedCount = @($resultTests | Where-Object { [string]$_.Result -eq 'Skipped' }).Count
+                    $notRunCount = @($resultTests | Where-Object { [string]$_.Result -eq 'NotRun' }).Count
+                    $totalCount = $resultTests.Count
+                } else {
+                    $passedCount = [int](Get-ObjectProperty -InputObject $result -Name 'PassedCount' -DefaultValue 0)
+                    $failedCount = [int](Get-ObjectProperty -InputObject $result -Name 'FailedCount' -DefaultValue 0)
+                    $totalCount = [int](Get-ObjectProperty -InputObject $result -Name 'TotalCount' -DefaultValue ($passedCount + $failedCount))
+                    $skippedCount = [int](Get-ObjectProperty -InputObject $result -Name 'SkippedCount' -DefaultValue 0)
+                    $notRunCount = [int](Get-ObjectProperty -InputObject $result -Name 'NotRunCount' -DefaultValue 0)
+                }
+                $failedBlocksCount = [int](Get-ObjectProperty -InputObject $result -Name 'FailedBlocksCount' -DefaultValue 0)
+                $failedContainersCount = [int](Get-ObjectProperty -InputObject $result -Name 'FailedContainersCount' -DefaultValue 0)
+                $coveragePercent = Get-CoveragePercent -CodeCoverage (Get-ObjectProperty -InputObject $result -Name 'CodeCoverage')
+                $thresholdMet = (-not $Coverage) -or (($null -ne $coveragePercent) -and ($coveragePercent -ge $CoverageThreshold))
+                $identities = @($resultTests | ForEach-Object { Get-TestIdentity -Test $_ })
+                $additional = [ordered]@{
+                    skipped = $skippedCount
+                    notRun = $notRunCount
+                    failedBlocks = $failedBlocksCount
+                    failedContainers = $failedContainersCount
+                    parallel = $false
+                    durationSeconds = $serial.DurationSeconds
+                    workerCount = 1
+                    identityHash = Get-IdentityHash -Identities $identities
+                    candidateTreeId = [string]$candidateContext.CandidateTreeId
+                    privateFixtureOwnerCount = 2
+                    boundedLineFilterCount = $LineFilters.Count
+                }
+                Write-TestSummary -Path $summaryPath -PassedCount $passedCount -FailedCount $failedCount -TotalCount $totalCount -CoveragePercent $coveragePercent -CoverageThreshold $CoverageThreshold -Additional $additional
+                Write-Output ('Pester: Passed={0} Failed={1} Total={2}' -f $passedCount, $failedCount, $totalCount)
+                if ($Coverage) {
+                    if ($null -ne $coveragePercent) {
+                        Write-Output ('Coverage: {0:N2}% (threshold: {1}%)' -f $coveragePercent, $CoverageThreshold)
+                    } else {
+                        Write-Output ('Coverage: unavailable (threshold: {0}%)' -f $CoverageThreshold)
+                    }
+                } else {
+                    Write-Output 'Coverage: disabled'
+                }
+                Write-Output ('Parallel: disabled Duration={0:N3}s' -f $serial.DurationSeconds)
+                $script:runnerExitCode = if (($failedCount -eq 0) -and
+                    ($failedBlocksCount -eq 0) -and
+                    ($failedContainersCount -eq 0) -and
+                    $thresholdMet) { 0 } else { 1 }
+            }
+        }
     }
-    exit 1
 } catch {
-    Write-TestSummary -Path $summaryPath -PassedCount 0 -FailedCount 1 -TotalCount 0 -CoveragePercent $null -CoverageThreshold $CoverageThreshold -Additional @{ mode = 'harness-error'; error = $_.Exception.Message }
+    $runnerExitCode = 1
+    Write-TestSummary -Path $summaryPath -PassedCount 0 -FailedCount 1 -TotalCount 0 -CoveragePercent $null -CoverageThreshold $CoverageThreshold -Additional @{
+        mode = 'harness-error'
+        error = $_.Exception.Message
+        candidateTreeId = $(if ($null -ne $candidateContext) { [string]$candidateContext.CandidateTreeId } else { '' })
+    }
     Write-Output 'Pester: Passed=0 Failed=1 Total=0'
     Write-Output $(if ($Coverage) { 'Coverage: unavailable' } else { 'Coverage: disabled' })
-    Write-Error $_
-    exit 1
+    [Console]::Error.WriteLine($_.Exception.Message)
+} finally {
+    if ($null -ne $candidateContext) {
+        try {
+            Assert-RunnerSourceState -Context $candidateContext
+        } catch {
+            $postflightFailure = $_.Exception.Message
+        }
+    }
+    if (Test-Path -LiteralPath $runnerControlRoot) {
+        $tempPrefix = [System.IO.Path]::GetFullPath([System.IO.Path]::GetTempPath()).TrimEnd('\', '/') + [System.IO.Path]::DirectorySeparatorChar
+        $resolvedControlRoot = [System.IO.Path]::GetFullPath($runnerControlRoot)
+        if (-not $resolvedControlRoot.StartsWith($tempPrefix, [StringComparison]::OrdinalIgnoreCase)) {
+            $postflightFailure = 'Runner controller cleanup target escaped the system TEMP directory.'
+        } else {
+            try {
+                Remove-Item -LiteralPath $resolvedControlRoot -Recurse -Force -ErrorAction Stop
+            } catch {
+                $postflightFailure = "Runner private fixture cleanup failed: $($_.Exception.Message)"
+            }
+        }
+    }
+    if (-not [string]::IsNullOrWhiteSpace($postflightFailure)) {
+        $runnerExitCode = 1
+        Write-TestSummary -Path $summaryPath -PassedCount 0 -FailedCount 1 -TotalCount 0 -CoveragePercent $null -CoverageThreshold $CoverageThreshold -Additional @{
+            mode = 'harness-postflight-error'
+            error = $postflightFailure
+            candidateTreeId = $(if ($null -ne $candidateContext) { [string]$candidateContext.CandidateTreeId } else { '' })
+        }
+        [Console]::Error.WriteLine($postflightFailure)
+    }
 }
+
+exit $runnerExitCode

--- a/scripts/winsmux-pester.psm1
+++ b/scripts/winsmux-pester.psm1
@@ -117,6 +117,7 @@ function Get-WinsmuxPesterShardRegistry {
             'tests/DeclarativeWorkflow.Tests.ps1'
             'tests/Task810PesterRunner.Tests.ps1'
             'tests/Task800OperatorShellBoundary.Tests.ps1'
+            'tests/PesterGitIsolation.Tests.ps1'
         ) -ResultFile 'test-results-integration.xml')
         (New-WinsmuxPesterMatrixRow -Ordinal 15 -ShardId 'worker-benchmark' -TimeoutMinutes 20 -TestPaths @(
             'tests/CliBakeoff.Tests.ps1'

--- a/tests/Integration.WorktreeHook.Tests.ps1
+++ b/tests/Integration.WorktreeHook.Tests.ps1
@@ -5,55 +5,298 @@ Describe 'sh-worktree integration' {
         $script:FixtureBaseRoot = Join-Path ([System.IO.Path]::GetTempPath()) 'winsmux-tests\worktree-hook'
         $script:RepoRoot = Split-Path -Parent $PSScriptRoot
         $script:SourceHookRoot = Join-Path $script:RepoRoot '.claude\hooks'
+        $script:Utf8NoBom = [System.Text.UTF8Encoding]::new($false)
         $nodeCommand = Get-Command node -ErrorAction SilentlyContinue | Select-Object -First 1
         if ($null -eq $nodeCommand) {
             throw 'node was not found in PATH.'
         }
 
         $script:NodePath = if ($nodeCommand.Path) { $nodeCommand.Path } else { $nodeCommand.Name }
+        $gitCommand = Get-Command git -CommandType Application -ErrorAction Stop | Select-Object -First 1
+        $script:GitPath = if ($gitCommand.Path) { $gitCommand.Path } else { $gitCommand.Source }
+        if ([string]::IsNullOrWhiteSpace($script:GitPath) -or -not (Test-Path -LiteralPath $script:GitPath -PathType Leaf)) {
+            throw 'A concrete Git executable could not be resolved.'
+        }
 
-        function Invoke-WorktreeHook {
+        function Get-WorktreeFixtureGitEnvironment {
+            param([Parameter(Mandatory = $true)][string]$FixtureRoot)
+
+            $emptyHooks = Join-Path $FixtureRoot 'empty-hooks'
+            $emptyTemplate = Join-Path $FixtureRoot 'empty-template'
+            New-Item -ItemType Directory -Path $emptyHooks, $emptyTemplate -Force | Out-Null
+            $nullDevice = if ($IsWindows) { 'NUL' } else { '/dev/null' }
+            return [ordered]@{
+                GIT_CONFIG_GLOBAL = $nullDevice
+                GIT_CONFIG_SYSTEM = $nullDevice
+                GIT_CONFIG_NOSYSTEM = '1'
+                GIT_CONFIG_COUNT = '5'
+                GIT_CONFIG_KEY_0 = 'init.defaultBranch'
+                GIT_CONFIG_VALUE_0 = 'main'
+                GIT_CONFIG_KEY_1 = 'core.hooksPath'
+                GIT_CONFIG_VALUE_1 = $emptyHooks
+                GIT_CONFIG_KEY_2 = 'commit.gpgSign'
+                GIT_CONFIG_VALUE_2 = 'false'
+                GIT_CONFIG_KEY_3 = 'tag.gpgSign'
+                GIT_CONFIG_VALUE_3 = 'false'
+                GIT_CONFIG_KEY_4 = 'core.autocrlf'
+                GIT_CONFIG_VALUE_4 = 'false'
+                GIT_TEMPLATE_DIR = $emptyTemplate
+                GIT_ATTR_NOSYSTEM = '1'
+                GIT_OPTIONAL_LOCKS = '0'
+                GIT_TERMINAL_PROMPT = '0'
+                GCM_INTERACTIVE = 'Never'
+            }
+        }
+
+        function Get-WorktreeFixtureProcessEnvironment {
             param(
-                [Parameter(Mandatory = $true)][string]$RepoRoot,
-                [Parameter(Mandatory = $true)][hashtable]$Payload
+                [Parameter(Mandatory = $true)][System.Collections.IDictionary]$GitEnvironment,
+                [System.Collections.IDictionary]$ExtraEnvironment = @{}
             )
 
-            $hookPath = Join-Path $RepoRoot '.claude\hooks\sh-worktree.js'
-            $json = $Payload | ConvertTo-Json -Compress -Depth 10
+            $environment = [ordered]@{}
+            foreach ($name in @(
+                'APPDATA', 'ComSpec', 'HOME', 'LOCALAPPDATA', 'OS', 'Path', 'PATHEXT',
+                'ProgramData', 'ProgramFiles', 'ProgramFiles(x86)', 'ProgramW6432',
+                'PSModulePath', 'SystemDrive', 'SystemRoot', 'TEMP', 'TMP', 'USERPROFILE', 'windir'
+            )) {
+                $value = [Environment]::GetEnvironmentVariable($name, 'Process')
+                if (-not [string]::IsNullOrEmpty($value)) { $environment[$name] = $value }
+            }
+            foreach ($entry in $GitEnvironment.GetEnumerator()) {
+                $environment[[string]$entry.Key] = [string]$entry.Value
+            }
+            foreach ($entry in $ExtraEnvironment.GetEnumerator()) {
+                $environment[[string]$entry.Key] = [string]$entry.Value
+            }
+            return $environment
+        }
+
+        function Invoke-WorktreeFixtureProcess {
+            param(
+                [Parameter(Mandatory = $true)][string]$FilePath,
+                [Parameter(Mandatory = $true)][string]$WorkingDirectory,
+                [Parameter(Mandatory = $true)][string[]]$Arguments,
+                [Parameter(Mandatory = $true)][System.Collections.IDictionary]$GitEnvironment,
+                [System.Collections.IDictionary]$ExtraEnvironment = @{},
+                [string]$StandardInput
+            )
 
             $startInfo = [System.Diagnostics.ProcessStartInfo]::new()
-            $startInfo.FileName = $script:NodePath
-            $startInfo.ArgumentList.Add($hookPath)
-            $startInfo.WorkingDirectory = $RepoRoot
+            $startInfo.FileName = $FilePath
+            foreach ($argument in $Arguments) { $startInfo.ArgumentList.Add($argument) }
+            $startInfo.WorkingDirectory = $WorkingDirectory
             $startInfo.UseShellExecute = $false
             $startInfo.CreateNoWindow = $true
             $startInfo.RedirectStandardInput = $true
             $startInfo.RedirectStandardOutput = $true
             $startInfo.RedirectStandardError = $true
+            $startInfo.Environment.Clear()
+            $processEnvironment = Get-WorktreeFixtureProcessEnvironment -GitEnvironment $GitEnvironment -ExtraEnvironment $ExtraEnvironment
+            foreach ($entry in $processEnvironment.GetEnumerator()) {
+                $startInfo.Environment[[string]$entry.Key] = [string]$entry.Value
+            }
 
             $process = [System.Diagnostics.Process]::Start($startInfo)
             try {
-                $process.StandardInput.Write($json)
+                if ($null -ne $StandardInput) { $process.StandardInput.Write($StandardInput) }
                 $process.StandardInput.Close()
-
                 $stdout = $process.StandardOutput.ReadToEnd()
                 $stderr = $process.StandardError.ReadToEnd()
                 $process.WaitForExit()
-
                 return [PSCustomObject]@{
-                    ExitCode = $process.ExitCode
-                    StdOut   = $stdout.Trim()
-                    StdErr   = $stderr.Trim()
+                    ExitCode = [int]$process.ExitCode
+                    StdOut = $stdout.Trim()
+                    StdErr = $stderr.Trim()
                 }
             } finally {
                 $process.Dispose()
             }
         }
 
+        function Invoke-WorktreeFixtureGit {
+            param(
+                [Parameter(Mandatory = $true)][string]$RepoRoot,
+                [Parameter(Mandatory = $true)][string[]]$Arguments,
+                [Parameter(Mandatory = $true)][System.Collections.IDictionary]$Environment,
+                [System.Collections.IDictionary]$ExtraEnvironment = @{}
+            )
+
+            $result = Invoke-WorktreeFixtureProcess -FilePath $script:GitPath -WorkingDirectory $RepoRoot -Arguments $Arguments -GitEnvironment $Environment -ExtraEnvironment $ExtraEnvironment
+            if ($result.ExitCode -ne 0) {
+                throw "git $($Arguments -join ' ') failed ($($result.ExitCode)): $($result.StdErr)"
+            }
+            return $result
+        }
+
+        function Resolve-WorktreeFixtureGitPath {
+            param(
+                [Parameter(Mandatory = $true)][string]$RepoRoot,
+                [Parameter(Mandatory = $true)][string]$GitPath
+            )
+
+            if ([System.IO.Path]::IsPathRooted($GitPath)) {
+                return [System.IO.Path]::GetFullPath($GitPath)
+            }
+            return [System.IO.Path]::GetFullPath((Join-Path $RepoRoot $GitPath))
+        }
+
+        function Get-WorktreeFixtureFileState {
+            param([Parameter(Mandatory = $true)][string]$Path)
+
+            $fullPath = [System.IO.Path]::GetFullPath($Path)
+            if (-not (Test-Path -LiteralPath $fullPath -PathType Leaf)) {
+                return [PSCustomObject]@{ Path = $fullPath; Exists = $false; Length = 0L; Sha256 = '' }
+            }
+            $item = Get-Item -LiteralPath $fullPath
+            return [PSCustomObject]@{
+                Path = $fullPath
+                Exists = $true
+                Length = [long]$item.Length
+                Sha256 = (Get-FileHash -LiteralPath $fullPath -Algorithm SHA256).Hash.ToLowerInvariant()
+            }
+        }
+
+        function Get-WorktreeFixtureRepositoryState {
+            param(
+                [Parameter(Mandatory = $true)][string]$RepoRoot,
+                [Parameter(Mandatory = $true)][System.Collections.IDictionary]$Environment
+            )
+
+            $tracked = (Invoke-WorktreeFixtureGit -RepoRoot $RepoRoot -Environment $Environment -Arguments @('ls-files', '-z', '--cached')).StdOut
+            $ledger = [System.Collections.Generic.List[string]]::new()
+            $repoPrefix = [System.IO.Path]::GetFullPath($RepoRoot).TrimEnd('\', '/') + [System.IO.Path]::DirectorySeparatorChar
+            foreach ($relativePath in @($tracked -split "`0" | Where-Object { $_ })) {
+                $fullPath = [System.IO.Path]::GetFullPath((Join-Path $RepoRoot $relativePath))
+                if (-not $fullPath.StartsWith($repoPrefix, [StringComparison]::OrdinalIgnoreCase)) {
+                    throw "Tracked path escapes repository root: $relativePath"
+                }
+                $state = Get-WorktreeFixtureFileState -Path $fullPath
+                if ($state.Exists) {
+                    $ledger.Add("$relativePath`0$($state.Length)`0$($state.Sha256)")
+                } else {
+                    $ledger.Add("$relativePath`0<absent-or-nonfile>")
+                }
+            }
+            $diff = (Invoke-WorktreeFixtureGit -RepoRoot $RepoRoot -Environment $Environment -Arguments @('diff-files', '--raw', '--no-abbrev', '-z')).StdOut
+            $ledger.Add("<diff-files>`0$diff")
+            $sha = [System.Security.Cryptography.SHA256]::Create()
+            try {
+                $trackedBytes = ([Convert]::ToHexString($sha.ComputeHash(
+                    [System.Text.Encoding]::UTF8.GetBytes((@($ledger | Sort-Object) -join "`n"))
+                ))).ToLowerInvariant()
+            } finally {
+                $sha.Dispose()
+            }
+
+            $indexText = (Invoke-WorktreeFixtureGit -RepoRoot $RepoRoot -Environment $Environment -Arguments @('rev-parse', '--git-path', 'index')).StdOut
+            $configs = [System.Collections.Generic.List[object]]::new()
+            foreach ($configName in @('config', 'config.worktree')) {
+                $configText = (Invoke-WorktreeFixtureGit -RepoRoot $RepoRoot -Environment $Environment -Arguments @('rev-parse', '--git-path', $configName)).StdOut
+                $configs.Add((Get-WorktreeFixtureFileState -Path (Resolve-WorktreeFixtureGitPath -RepoRoot $RepoRoot -GitPath $configText)))
+            }
+            return [PSCustomObject]@{
+                TrackedBytes = $trackedBytes
+                Index = Get-WorktreeFixtureFileState -Path (Resolve-WorktreeFixtureGitPath -RepoRoot $RepoRoot -GitPath $indexText)
+                Refs = (Invoke-WorktreeFixtureGit -RepoRoot $RepoRoot -Environment $Environment -Arguments @('show-ref', '--head', '--dereference')).StdOut
+                LocalConfigs = $configs.ToArray()
+            }
+        }
+
+        function Assert-WorktreeFixtureFileState {
+            param(
+                [Parameter(Mandatory = $true)]$Expected,
+                [Parameter(Mandatory = $true)]$Actual
+            )
+
+            $Actual.Path | Should -BeExactly $Expected.Path
+            $Actual.Exists | Should -Be $Expected.Exists
+            $Actual.Length | Should -Be $Expected.Length
+            $Actual.Sha256 | Should -BeExactly $Expected.Sha256
+        }
+
+        function Assert-WorktreeFixtureRepositoryState {
+            param(
+                [Parameter(Mandatory = $true)]$Expected,
+                [Parameter(Mandatory = $true)]$Actual
+            )
+
+            $Actual.TrackedBytes | Should -BeExactly $Expected.TrackedBytes
+            Assert-WorktreeFixtureFileState -Expected $Expected.Index -Actual $Actual.Index
+            $Actual.Refs | Should -BeExactly $Expected.Refs
+            @($Actual.LocalConfigs).Count | Should -Be @($Expected.LocalConfigs).Count
+            for ($index = 0; $index -lt @($Expected.LocalConfigs).Count; $index++) {
+                Assert-WorktreeFixtureFileState -Expected @($Expected.LocalConfigs)[$index] -Actual @($Actual.LocalConfigs)[$index]
+            }
+        }
+
+        function Invoke-WorktreeHook {
+            param(
+                [Parameter(Mandatory = $true)][string]$RepoRoot,
+                [Parameter(Mandatory = $true)][hashtable]$Payload,
+                [Parameter(Mandatory = $true)][System.Collections.IDictionary]$Environment
+            )
+
+            $hookPath = Join-Path $RepoRoot '.claude\hooks\sh-worktree.js'
+            $json = $Payload | ConvertTo-Json -Compress -Depth 10
+
+            return Invoke-WorktreeFixtureProcess `
+                -FilePath $script:NodePath `
+                -WorkingDirectory $RepoRoot `
+                -Arguments @($hookPath) `
+                -GitEnvironment $Environment `
+                -StandardInput $json
+        }
+
+        function Get-CallerGitEnvironment {
+            $snapshot = [ordered]@{}
+            foreach ($entry in Get-ChildItem Env:) {
+                if ($entry.Name -like 'GIT_*' -or $entry.Name -eq 'GCM_INTERACTIVE') {
+                    $snapshot[$entry.Name] = [string]$entry.Value
+                }
+            }
+            return $snapshot
+        }
+
+        function Restore-CallerGitEnvironment {
+            param([Parameter(Mandatory = $true)][System.Collections.IDictionary]$Snapshot)
+
+            foreach ($entry in @(Get-ChildItem Env:)) {
+                if ($entry.Name -like 'GIT_*' -or $entry.Name -eq 'GCM_INTERACTIVE') {
+                    Remove-Item -LiteralPath ('Env:' + $entry.Name) -ErrorAction SilentlyContinue
+                }
+            }
+            foreach ($entry in $Snapshot.GetEnumerator()) {
+                [Environment]::SetEnvironmentVariable([string]$entry.Key, [string]$entry.Value, 'Process')
+            }
+        }
+
+        function Write-WorktreeFixtureHook {
+            param(
+                [Parameter(Mandatory = $true)][string]$Path,
+                [Parameter(Mandatory = $true)][string]$MarkerVariable
+            )
+
+            $content = "#!/bin/sh`n" + ('printf ''%s\n'' hook >> "$' + $MarkerVariable + '"') + "`n"
+            [System.IO.File]::WriteAllText($Path, $content, $script:Utf8NoBom)
+            if (-not $IsWindows) {
+                [System.IO.File]::SetUnixFileMode(
+                    $Path,
+                    [System.IO.UnixFileMode]::UserRead -bor
+                        [System.IO.UnixFileMode]::UserWrite -bor
+                        [System.IO.UnixFileMode]::UserExecute
+                )
+            }
+        }
+
         function New-WorktreeHookFixture {
+            param([System.Collections.IDictionary]$ExtraEnvironment = @{})
+
             $fixtureRoot = Join-Path $script:FixtureBaseRoot ([guid]::NewGuid().ToString('N'))
+            $script:FixtureRoot = $fixtureRoot
             $repoRoot = Join-Path $fixtureRoot 'repo'
             $worktreeTarget = Join-Path $repoRoot '.worktrees\feature-auth'
+            $gitEnvironment = Get-WorktreeFixtureGitEnvironment -FixtureRoot $fixtureRoot
 
             New-Item -ItemType Directory -Path (Join-Path $repoRoot '.claude\hooks\lib') -Force | Out-Null
             New-Item -ItemType Directory -Path (Join-Path $repoRoot '.claude\patterns') -Force | Out-Null
@@ -68,14 +311,18 @@ Describe 'sh-worktree integration' {
             Set-Content -Path (Join-Path $repoRoot '.claude\hooks\sh-extra.js') -Value 'console.log("extra");' -Encoding UTF8
             Set-Content -Path (Join-Path $repoRoot 'README.md') -Value 'fixture' -Encoding UTF8
 
-            & git -C $repoRoot init | Out-Null
-            & git -C $repoRoot add .
-            & git -C $repoRoot -c user.name='Test User' -c user.email='test@example.com' commit -m 'init' | Out-Null
+            [void](Invoke-WorktreeFixtureGit -RepoRoot $repoRoot -Environment $gitEnvironment -ExtraEnvironment $ExtraEnvironment -Arguments @('init'))
+            [void](Invoke-WorktreeFixtureGit -RepoRoot $repoRoot -Environment $gitEnvironment -ExtraEnvironment $ExtraEnvironment -Arguments @('add', '--', '.'))
+            [void](Invoke-WorktreeFixtureGit -RepoRoot $repoRoot -Environment $gitEnvironment -ExtraEnvironment $ExtraEnvironment -Arguments @(
+                '-c', 'user.name=Test User', '-c', 'user.email=test@example.invalid',
+                'commit', '-m', 'init'
+            ))
 
             return [PSCustomObject]@{
                 Root           = $fixtureRoot
                 RepoRoot       = $repoRoot
                 WorktreeTarget = $worktreeTarget
+                GitEnvironment = $gitEnvironment
             }
         }
     }
@@ -91,7 +338,7 @@ Describe 'sh-worktree integration' {
         $fixture = New-WorktreeHookFixture
         $script:FixtureRoot = $fixture.Root
 
-        $result = Invoke-WorktreeHook -RepoRoot $fixture.RepoRoot -Payload @{
+        $result = Invoke-WorktreeHook -RepoRoot $fixture.RepoRoot -Environment $fixture.GitEnvironment -Payload @{
             hook_event_name = 'WorktreeCreate'
             session_id      = 'session-1'
             cwd             = $fixture.RepoRoot
@@ -109,7 +356,7 @@ Describe 'sh-worktree integration' {
         $fixture = New-WorktreeHookFixture
         $script:FixtureRoot = $fixture.Root
 
-        $createResult = Invoke-WorktreeHook -RepoRoot $fixture.RepoRoot -Payload @{
+        $createResult = Invoke-WorktreeHook -RepoRoot $fixture.RepoRoot -Environment $fixture.GitEnvironment -Payload @{
             hook_event_name = 'WorktreeCreate'
             session_id      = 'session-2'
             cwd             = $fixture.RepoRoot
@@ -122,7 +369,7 @@ Describe 'sh-worktree integration' {
         New-Item -ItemType Directory -Path $ledgerDir -Force | Out-Null
         Set-Content -Path (Join-Path $ledgerDir 'evidence-ledger.jsonl') -Value '{"event":"child-entry"}' -Encoding UTF8
 
-        $removeResult = Invoke-WorktreeHook -RepoRoot $fixture.RepoRoot -Payload @{
+        $removeResult = Invoke-WorktreeHook -RepoRoot $fixture.RepoRoot -Environment $fixture.GitEnvironment -Payload @{
             hook_event_name = 'WorktreeRemove'
             session_id      = 'session-2'
             cwd             = $fixture.RepoRoot
@@ -143,5 +390,71 @@ Describe 'sh-worktree integration' {
         $mergedEntry | Should -Not -BeNullOrEmpty
         $mergedEntry.event | Should -Be 'child-entry'
         $mergedEntry.source_worktree | Should -Be $fixture.WorktreeTarget
+    }
+
+    It 'isolates direct Git calls from external hooks and permits one explicit fixture-local hook' {
+        $callerBefore = Get-CallerGitEnvironment
+        $sourceStateEnvironment = Get-WorktreeFixtureGitEnvironment -FixtureRoot (Join-Path $TestDrive 'source-state')
+        $sourceBefore = Get-WorktreeFixtureRepositoryState -RepoRoot $script:RepoRoot -Environment $sourceStateEnvironment
+        $externalHooks = Join-Path $TestDrive 'external-hooks'
+        $hostileTemplate = Join-Path $TestDrive 'hostile-template'
+        New-Item -ItemType Directory -Path $externalHooks, (Join-Path $hostileTemplate 'hooks') -Force | Out-Null
+        $externalMarker = Join-Path $TestDrive 'external.marker'
+        $localMarker = Join-Path $TestDrive 'local.marker'
+        Write-WorktreeFixtureHook -Path (Join-Path $externalHooks 'pre-commit') -MarkerVariable 'WINSMUX_EXTERNAL_HOOK_MARKER'
+        Write-WorktreeFixtureHook -Path (Join-Path $hostileTemplate 'hooks\pre-commit') -MarkerVariable 'WINSMUX_EXTERNAL_HOOK_MARKER'
+        $hostileConfig = Join-Path $TestDrive 'hostile.gitconfig'
+        $externalUnix = $externalHooks.Replace('\', '/')
+        [System.IO.File]::WriteAllText($hostileConfig, "[core]`n`thooksPath = $externalUnix`n", $script:Utf8NoBom)
+        $markerEnvironment = [ordered]@{
+            WINSMUX_EXTERNAL_HOOK_MARKER = $externalMarker
+            WINSMUX_LOCAL_HOOK_MARKER = $localMarker
+        }
+
+        try {
+            [Environment]::SetEnvironmentVariable('GCM_INTERACTIVE', 'caller-direct', 'Process')
+            [Environment]::SetEnvironmentVariable('GIT_CONFIG_GLOBAL', $hostileConfig, 'Process')
+            [Environment]::SetEnvironmentVariable('GIT_CONFIG_PARAMETERS', "'core.hooksPath'='$externalUnix'", 'Process')
+            [Environment]::SetEnvironmentVariable('GIT_CONFIG_COUNT', '1', 'Process')
+            [Environment]::SetEnvironmentVariable('GIT_CONFIG_KEY_0', 'core.hooksPath', 'Process')
+            [Environment]::SetEnvironmentVariable('GIT_CONFIG_VALUE_0', $externalHooks, 'Process')
+            [Environment]::SetEnvironmentVariable('GIT_TEMPLATE_DIR', $hostileTemplate, 'Process')
+            [Environment]::SetEnvironmentVariable('GIT_DIR', (Join-Path $TestDrive 'hostile.git'), 'Process')
+            [Environment]::SetEnvironmentVariable('GIT_WORK_TREE', (Join-Path $TestDrive 'hostile-worktree'), 'Process')
+
+            $fixture = New-WorktreeHookFixture -ExtraEnvironment $markerEnvironment
+            $script:FixtureRoot = $fixture.Root
+            $createResult = Invoke-WorktreeHook -RepoRoot $fixture.RepoRoot -Environment $fixture.GitEnvironment -Payload @{
+                hook_event_name = 'WorktreeCreate'
+                session_id = 'session-isolated'
+                cwd = $fixture.RepoRoot
+                name = 'feature-auth'
+            }
+            $createResult.ExitCode | Should -Be 0
+            Test-Path -LiteralPath $externalMarker | Should -BeFalse
+            Test-Path -LiteralPath (Join-Path $fixture.RepoRoot '.git\hooks\pre-commit') | Should -BeFalse
+
+            $localHooks = Join-Path $fixture.RepoRoot '.fixture-hooks'
+            New-Item -ItemType Directory -Path $localHooks -Force | Out-Null
+            Write-WorktreeFixtureHook -Path (Join-Path $localHooks 'pre-commit') -MarkerVariable 'WINSMUX_LOCAL_HOOK_MARKER'
+            [void](Invoke-WorktreeFixtureGit -RepoRoot $fixture.RepoRoot -Environment $fixture.GitEnvironment -ExtraEnvironment $markerEnvironment -Arguments @(
+                '-c', 'user.name=Test User', '-c', 'user.email=test@example.invalid',
+                '-c', "core.hooksPath=$($localHooks.Replace('\', '/'))",
+                'commit', '--allow-empty', '-m', 'explicit fixture hook'
+            ))
+            Test-Path -LiteralPath $externalMarker | Should -BeFalse
+            @(Get-Content -LiteralPath $localMarker).Count | Should -Be 1
+        } finally {
+            Restore-CallerGitEnvironment -Snapshot $callerBefore
+        }
+
+        $callerAfter = Get-CallerGitEnvironment
+        $callerAfter.Count | Should -Be $callerBefore.Count
+        foreach ($name in $callerBefore.Keys) {
+            $callerAfter.Contains($name) | Should -BeTrue
+            $callerAfter[$name] | Should -BeExactly $callerBefore[$name]
+        }
+        $sourceAfter = Get-WorktreeFixtureRepositoryState -RepoRoot $script:RepoRoot -Environment $sourceStateEnvironment
+        Assert-WorktreeFixtureRepositoryState -Expected $sourceBefore -Actual $sourceAfter
     }
 }

--- a/tests/PesterGitIsolation.Tests.ps1
+++ b/tests/PesterGitIsolation.Tests.ps1
@@ -1,0 +1,648 @@
+#Requires -Version 7.0
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+Describe 'TASK-796 Pester Git isolation' -Tag 'integration' {
+    BeforeAll {
+        $script:RepoRoot = Split-Path -Parent $PSScriptRoot
+        $script:RunnerPath = Join-Path $script:RepoRoot 'scripts\run-tests.ps1'
+        $script:Utf8NoBom = [System.Text.UTF8Encoding]::new($false)
+        $gitCommand = Get-Command git -CommandType Application -ErrorAction Stop | Select-Object -First 1
+        $script:GitPath = if ($gitCommand.Path) { $gitCommand.Path } else { $gitCommand.Source }
+        $pwshCommand = Get-Command pwsh -CommandType Application -ErrorAction Stop | Select-Object -First 1
+        $script:PwshPath = if ($pwshCommand.Path) { $pwshCommand.Path } else { $pwshCommand.Source }
+        foreach ($applicationPath in @($script:GitPath, $script:PwshPath)) {
+            if (-not (Test-Path -LiteralPath $applicationPath -PathType Leaf)) {
+                throw "Required application is not a file: $applicationPath"
+            }
+        }
+
+        $tokens = $null
+        $parseErrors = $null
+        $runnerAst = [System.Management.Automation.Language.Parser]::ParseFile(
+            $script:RunnerPath,
+            [ref]$tokens,
+            [ref]$parseErrors
+        )
+        if ($parseErrors.Count -gt 0) {
+            throw "run-tests.ps1 parse failed: $($parseErrors[0].Message)"
+        }
+        $runnerFunctions = $runnerAst.FindAll({
+            param($node)
+            $node -is [System.Management.Automation.Language.FunctionDefinitionAst]
+        }, $false)
+        foreach ($runnerFunction in $runnerFunctions) {
+            Invoke-Expression $runnerFunction.Extent.Text
+        }
+
+        function Assert-Task796RunnerFunction {
+            param([Parameter(Mandatory)][string]$Name)
+
+            Get-Command $Name -CommandType Function -ErrorAction SilentlyContinue |
+                Should -Not -BeNullOrEmpty -Because "$Name is a TASK-796 runner responsibility"
+        }
+
+        function Get-TestPlatformEnvironment {
+            $environment = [ordered]@{}
+            foreach ($name in @(
+                'APPDATA', 'ComSpec', 'HOME', 'LOCALAPPDATA', 'Path', 'PATHEXT',
+                'ProgramData', 'ProgramFiles', 'ProgramFiles(x86)', 'ProgramW6432',
+                'PSModulePath', 'SystemDrive', 'SystemRoot', 'TEMP', 'TMP',
+                'USERNAME', 'USERPROFILE', 'windir'
+            )) {
+                $value = [Environment]::GetEnvironmentVariable($name)
+                if ($null -ne $value) { $environment[$name] = $value }
+            }
+            $nullDevice = if ($IsWindows) { 'NUL' } else { '/dev/null' }
+            $emptyHooks = Join-Path $TestDrive 'bootstrap-hooks'
+            $emptyTemplate = Join-Path $TestDrive 'bootstrap-template'
+            New-Item -ItemType Directory -Path $emptyHooks, $emptyTemplate -Force | Out-Null
+            $environment['GIT_CONFIG_GLOBAL'] = $nullDevice
+            $environment['GIT_CONFIG_SYSTEM'] = $nullDevice
+            $environment['GIT_CONFIG_NOSYSTEM'] = '1'
+            $environment['GIT_CONFIG_COUNT'] = '2'
+            $environment['GIT_CONFIG_KEY_0'] = 'core.hooksPath'
+            $environment['GIT_CONFIG_VALUE_0'] = $emptyHooks
+            $environment['GIT_CONFIG_KEY_1'] = 'init.defaultBranch'
+            $environment['GIT_CONFIG_VALUE_1'] = 'main'
+            $environment['GIT_TEMPLATE_DIR'] = $emptyTemplate
+            $environment['GIT_TERMINAL_PROMPT'] = '0'
+            return $environment
+        }
+
+        function Invoke-TestGit {
+            param(
+                [Parameter(Mandatory)][string]$RepositoryRoot,
+                [Parameter(Mandatory)][string[]]$Arguments,
+                [System.Collections.IDictionary]$Environment = (Get-TestPlatformEnvironment),
+                [System.Collections.IDictionary]$ExtraEnvironment = @{},
+                [switch]$AllowFailure
+            )
+
+            $startInfo = [System.Diagnostics.ProcessStartInfo]::new()
+            $startInfo.FileName = $script:GitPath
+            foreach ($argument in $Arguments) { $startInfo.ArgumentList.Add($argument) }
+            $startInfo.WorkingDirectory = $RepositoryRoot
+            $startInfo.UseShellExecute = $false
+            $startInfo.CreateNoWindow = $true
+            $startInfo.RedirectStandardOutput = $true
+            $startInfo.RedirectStandardError = $true
+            $startInfo.Environment.Clear()
+            foreach ($entry in $Environment.GetEnumerator()) {
+                $startInfo.Environment[[string]$entry.Key] = [string]$entry.Value
+            }
+            foreach ($entry in $ExtraEnvironment.GetEnumerator()) {
+                $startInfo.Environment[[string]$entry.Key] = [string]$entry.Value
+            }
+
+            $process = [System.Diagnostics.Process]::Start($startInfo)
+            try {
+                $stdout = $process.StandardOutput.ReadToEnd()
+                $stderr = $process.StandardError.ReadToEnd()
+                $process.WaitForExit()
+                if (-not $AllowFailure -and $process.ExitCode -ne 0) {
+                    throw "git $($Arguments -join ' ') failed ($($process.ExitCode)): $stderr"
+                }
+                return [PSCustomObject]@{
+                    ExitCode = [int]$process.ExitCode
+                    StdOut = $stdout.Trim()
+                    StdErr = $stderr.Trim()
+                }
+            } finally {
+                $process.Dispose()
+            }
+        }
+
+        function Invoke-TestPowerShell {
+            param(
+                [Parameter(Mandatory)][string]$WorkingDirectory,
+                [Parameter(Mandatory)][string[]]$Arguments,
+                [System.Collections.IDictionary]$Environment = (Get-TestPlatformEnvironment),
+                [System.Collections.IDictionary]$ExtraEnvironment = @{},
+                [switch]$AllowFailure
+            )
+
+            $startInfo = [System.Diagnostics.ProcessStartInfo]::new()
+            $startInfo.FileName = $script:PwshPath
+            foreach ($argument in $Arguments) { $startInfo.ArgumentList.Add($argument) }
+            $startInfo.WorkingDirectory = $WorkingDirectory
+            $startInfo.UseShellExecute = $false
+            $startInfo.CreateNoWindow = $true
+            $startInfo.RedirectStandardOutput = $true
+            $startInfo.RedirectStandardError = $true
+            $startInfo.Environment.Clear()
+            foreach ($entry in $Environment.GetEnumerator()) {
+                $startInfo.Environment[[string]$entry.Key] = [string]$entry.Value
+            }
+            foreach ($entry in $ExtraEnvironment.GetEnumerator()) {
+                $startInfo.Environment[[string]$entry.Key] = [string]$entry.Value
+            }
+
+            $process = [System.Diagnostics.Process]::Start($startInfo)
+            try {
+                $stdout = $process.StandardOutput.ReadToEnd()
+                $stderr = $process.StandardError.ReadToEnd()
+                $process.WaitForExit()
+                if (-not $AllowFailure -and $process.ExitCode -ne 0) {
+                    throw "pwsh $($Arguments -join ' ') failed ($($process.ExitCode)): $stderr"
+                }
+                return [PSCustomObject]@{
+                    ExitCode = [int]$process.ExitCode
+                    StdOut = $stdout.Trim()
+                    StdErr = $stderr.Trim()
+                }
+            } finally {
+                $process.Dispose()
+            }
+        }
+
+        function New-TestRepository {
+            param([Parameter(Mandatory)][string]$Name)
+
+            $root = Join-Path $TestDrive $Name
+            New-Item -ItemType Directory -Path $root -Force | Out-Null
+            [void](Invoke-TestGit -RepositoryRoot $root -Arguments @('init'))
+            [System.IO.File]::WriteAllText((Join-Path $root 'tracked.txt'), "base`n", $script:Utf8NoBom)
+            [void](Invoke-TestGit -RepositoryRoot $root -Arguments @('add', '--', 'tracked.txt'))
+            [void](Invoke-TestGit -RepositoryRoot $root -Arguments @(
+                '-c', 'user.name=TASK-796 Fixture', '-c', 'user.email=task796@example.invalid',
+                'commit', '-m', 'fixture base'
+            ))
+            return $root
+        }
+
+        function Get-FileSha256 {
+            param([Parameter(Mandatory)][string]$Path)
+
+            if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) { return '<absent>' }
+            return (Get-FileHash -LiteralPath $Path -Algorithm SHA256).Hash.ToLowerInvariant()
+        }
+
+        function Get-EnvironmentEvidence {
+            param([Parameter(Mandatory)][string[]]$Names)
+
+            $evidence = [ordered]@{}
+            foreach ($name in $Names) {
+                $value = [Environment]::GetEnvironmentVariable($name, 'Process')
+                $evidence[$name] = [PSCustomObject]@{
+                    Exists = $null -ne $value
+                    Value = $value
+                }
+            }
+            return $evidence
+        }
+
+        function Assert-EnvironmentEvidence {
+            param(
+                [Parameter(Mandatory)][System.Collections.IDictionary]$Expected,
+                [Parameter(Mandatory)][System.Collections.IDictionary]$Actual
+            )
+
+            foreach ($name in $Expected.Keys) {
+                $Actual[$name].Exists | Should -Be $Expected[$name].Exists
+                $Actual[$name].Value | Should -BeExactly $Expected[$name].Value
+            }
+        }
+
+        function Write-HookScript {
+            param(
+                [Parameter(Mandatory)][string]$Path,
+                [Parameter(Mandatory)][string]$MarkerVariable
+            )
+
+            $content = "#!/bin/sh`n" + ('printf ''%s\n'' hook >> "$' + $MarkerVariable + '"') + "`n"
+            [System.IO.File]::WriteAllText($Path, $content, $script:Utf8NoBom)
+        }
+    }
+
+    BeforeEach {
+        $script:CallerGitEnvironment = [ordered]@{}
+        foreach ($entry in Get-ChildItem Env:) {
+            if ($entry.Name -like 'GIT_*' -or $entry.Name -eq 'WINSMUX_PESTER_CANDIDATE_TREE') {
+                $script:CallerGitEnvironment[$entry.Name] = [string]$entry.Value
+            }
+        }
+    }
+
+    AfterEach {
+        foreach ($entry in @(Get-ChildItem Env:)) {
+            if ($entry.Name -like 'GIT_*' -or $entry.Name -eq 'WINSMUX_PESTER_CANDIDATE_TREE') {
+                Remove-Item -LiteralPath ('Env:' + $entry.Name) -ErrorAction SilentlyContinue
+            }
+        }
+        foreach ($entry in $script:CallerGitEnvironment.GetEnumerator()) {
+            [Environment]::SetEnvironmentVariable([string]$entry.Key, [string]$entry.Value, 'Process')
+        }
+    }
+
+    It 'T796-CONTROL extracts current runner functions without executing its entry' {
+        (Get-IdentityHash -Identities @('b', 'a')) |
+            Should -BeExactly (Get-IdentityHash -Identities @('a', 'b'))
+    }
+
+    It 'T796-E01 creates a controlled Git environment for every child worker' {
+        Assert-Task796RunnerFunction -Name 'Get-RunnerGitEnvironment'
+        $hooksPath = Join-Path $TestDrive 'managed-hooks'
+        $templatePath = Join-Path $TestDrive 'managed-template'
+        $tree = '1234567890123456789012345678901234567890'
+        $gitEnvironment = Get-RunnerGitEnvironment -HooksPath $hooksPath -TemplatePath $templatePath -CandidateTreeId $tree
+
+        $gitEnvironment['GIT_CONFIG_GLOBAL'] | Should -Be $(if ($IsWindows) { 'NUL' } else { '/dev/null' })
+        $gitEnvironment['GIT_CONFIG_SYSTEM'] | Should -Be $(if ($IsWindows) { 'NUL' } else { '/dev/null' })
+        $gitEnvironment['GIT_CONFIG_NOSYSTEM'] | Should -Be '1'
+        $gitEnvironment['GIT_CONFIG_PARAMETERS'] | Should -BeNullOrEmpty
+        $gitEnvironment['GIT_TEMPLATE_DIR'] | Should -BeExactly $templatePath
+        $gitEnvironment['WINSMUX_PESTER_CANDIDATE_TREE'] | Should -BeExactly $tree
+        @($gitEnvironment.Keys | Where-Object { $_ -like 'GIT_CONFIG_KEY_*' } | ForEach-Object { $gitEnvironment[$_] }) |
+            Should -Contain 'core.hooksPath'
+
+        $child = Get-IsolatedChildEnvironment -TempDirectory $TestDrive -ProjectDirectory $TestDrive -HooksPath $hooksPath -TemplatePath $templatePath -CandidateTreeId $tree
+        foreach ($entry in $gitEnvironment.GetEnumerator()) {
+            $child[[string]$entry.Key] | Should -BeExactly ([string]$entry.Value)
+        }
+        $child.Contains('GIT_DIR') | Should -BeFalse
+        $child.Contains('GIT_INDEX_FILE') | Should -BeFalse
+        $child.Contains('GIT_WORK_TREE') | Should -BeFalse
+    }
+
+    It 'T796-E02 restores caller Git variables after success, including absence' {
+        Assert-Task796RunnerFunction -Name 'Invoke-WithRunnerGitEnvironment'
+        $names = @('GCM_INTERACTIVE', 'GIT_CONFIG_GLOBAL', 'GIT_CONFIG_PARAMETERS', 'GIT_DIR', 'GIT_TASK796_CREATED', 'WINSMUX_PESTER_CANDIDATE_TREE')
+        [Environment]::SetEnvironmentVariable('GCM_INTERACTIVE', 'caller-interactive', 'Process')
+        [Environment]::SetEnvironmentVariable('GIT_CONFIG_GLOBAL', 'caller-global', 'Process')
+        [Environment]::SetEnvironmentVariable('GIT_CONFIG_PARAMETERS', "'caller.key'='caller value'", 'Process')
+        Remove-Item -LiteralPath 'Env:GIT_DIR' -ErrorAction SilentlyContinue
+        Remove-Item -LiteralPath 'Env:GIT_TASK796_CREATED' -ErrorAction SilentlyContinue
+        [Environment]::SetEnvironmentVariable('WINSMUX_PESTER_CANDIDATE_TREE', 'caller-tree', 'Process')
+        $before = Get-EnvironmentEvidence -Names $names
+        $managed = [ordered]@{
+            GCM_INTERACTIVE = 'Never'
+            GIT_CONFIG_GLOBAL = 'managed-global'
+            WINSMUX_PESTER_CANDIDATE_TREE = 'managed-tree'
+        }
+
+        $observed = Invoke-WithRunnerGitEnvironment -Environment $managed -ScriptBlock {
+            [Environment]::SetEnvironmentVariable('GIT_TASK796_CREATED', 'created', 'Process')
+            return Get-EnvironmentEvidence -Names $names
+        }
+
+        $observed['GIT_CONFIG_GLOBAL'].Value | Should -BeExactly 'managed-global'
+        $observed['GCM_INTERACTIVE'].Value | Should -BeExactly 'Never'
+        $observed['GIT_CONFIG_PARAMETERS'].Exists | Should -BeFalse
+        $observed['GIT_DIR'].Exists | Should -BeFalse
+        $observed['WINSMUX_PESTER_CANDIDATE_TREE'].Value | Should -BeExactly 'managed-tree'
+        Assert-EnvironmentEvidence -Expected $before -Actual (Get-EnvironmentEvidence -Names $names)
+    }
+
+    It 'T796-E03 restores caller Git variables after assertion and setup failures' {
+        Assert-Task796RunnerFunction -Name 'Invoke-WithRunnerGitEnvironment'
+        $names = @('GCM_INTERACTIVE', 'GIT_CONFIG_GLOBAL', 'GIT_CONFIG_COUNT', 'GIT_TASK796_CREATED', 'WINSMUX_PESTER_CANDIDATE_TREE')
+        [Environment]::SetEnvironmentVariable('GCM_INTERACTIVE', 'caller-before-failure', 'Process')
+        [Environment]::SetEnvironmentVariable('GIT_CONFIG_GLOBAL', 'caller-before-failure', 'Process')
+        Remove-Item -LiteralPath 'Env:GIT_CONFIG_COUNT' -ErrorAction SilentlyContinue
+        Remove-Item -LiteralPath 'Env:GIT_TASK796_CREATED' -ErrorAction SilentlyContinue
+        [Environment]::SetEnvironmentVariable('WINSMUX_PESTER_CANDIDATE_TREE', 'caller-tree', 'Process')
+        $before = Get-EnvironmentEvidence -Names $names
+        $managed = [ordered]@{ GCM_INTERACTIVE = 'Never'; GIT_CONFIG_GLOBAL = 'managed'; GIT_CONFIG_COUNT = '0'; WINSMUX_PESTER_CANDIDATE_TREE = 'managed-tree' }
+
+        try {
+            Invoke-WithRunnerGitEnvironment -Environment $managed -ScriptBlock {
+                [Environment]::SetEnvironmentVariable('GIT_TASK796_CREATED', 'assertion', 'Process')
+                1 | Should -Be 2
+            }
+        } catch {}
+        Assert-EnvironmentEvidence -Expected $before -Actual (Get-EnvironmentEvidence -Names $names)
+
+        try {
+            Invoke-WithRunnerGitEnvironment -Environment $managed -ScriptBlock {
+                [Environment]::SetEnvironmentVariable('GIT_TASK796_CREATED', 'setup', 'Process')
+                throw 'synthetic setup failure'
+            }
+        } catch {}
+        Assert-EnvironmentEvidence -Expected $before -Actual (Get-EnvironmentEvidence -Names $names)
+    }
+
+    It 'T796-C01 materializes the prospective index as an exact private checkout-index tree' {
+        Assert-Task796RunnerFunction -Name 'New-RunnerCandidateContext'
+        Assert-Task796RunnerFunction -Name 'New-RunnerPrivateRepository'
+        Assert-Task796RunnerFunction -Name 'Assert-RunnerSourceState'
+        $source = New-TestRepository -Name 'prospective-source'
+        $actualIndex = (Invoke-TestGit -RepositoryRoot $source -Arguments @('rev-parse', '--git-path', 'index')).StdOut
+        if (-not [System.IO.Path]::IsPathRooted($actualIndex)) { $actualIndex = Join-Path $source $actualIndex }
+        $prospectiveIndex = Join-Path $TestDrive 'prospective.index'
+        Copy-Item -LiteralPath $actualIndex -Destination $prospectiveIndex
+        [System.IO.File]::WriteAllText((Join-Path $source 'tracked.txt'), "candidate`n", $script:Utf8NoBom)
+        [System.IO.File]::WriteAllText((Join-Path $source 'added.txt'), "added`n", $script:Utf8NoBom)
+        $prospectiveEnvironment = Get-TestPlatformEnvironment
+        $prospectiveEnvironment['GIT_INDEX_FILE'] = $prospectiveIndex
+        [void](Invoke-TestGit -RepositoryRoot $source -Arguments @('add', '--', 'tracked.txt', 'added.txt') -Environment $prospectiveEnvironment)
+        $expectedTree = (Invoke-TestGit -RepositoryRoot $source -Arguments @('write-tree') -Environment $prospectiveEnvironment).StdOut
+        $indexBefore = Get-FileSha256 -Path $actualIndex
+        $prospectiveBefore = Get-FileSha256 -Path $prospectiveIndex
+        $refsBefore = (Invoke-TestGit -RepositoryRoot $source -Arguments @('show-ref', '--head')).StdOut
+        $configBefore = Get-FileSha256 -Path (Join-Path $source '.git\config')
+
+        $context = New-RunnerCandidateContext -RepositoryRoot $source -ExecutionRoot (Join-Path $TestDrive 'controller') -ProspectiveIndexPath $prospectiveIndex
+        $privateRoot = New-RunnerPrivateRepository -Context $context -DestinationPath (Join-Path $TestDrive 'private')
+
+        $context.CandidateTreeId | Should -BeExactly $expectedTree
+        (Invoke-TestGit -RepositoryRoot $privateRoot -Arguments @('write-tree') -Environment $context.GitEnvironment).StdOut | Should -BeExactly $expectedTree
+        (Invoke-TestGit -RepositoryRoot $privateRoot -Arguments @('rev-parse', 'HEAD^{tree}') -Environment $context.GitEnvironment).StdOut | Should -BeExactly $expectedTree
+        [System.IO.File]::ReadAllText((Join-Path $privateRoot 'tracked.txt')) | Should -BeExactly "candidate`n"
+        [System.IO.File]::ReadAllText((Join-Path $privateRoot 'added.txt')) | Should -BeExactly "added`n"
+        Assert-RunnerSourceState -Context $context
+        (Get-FileSha256 -Path $actualIndex) | Should -BeExactly $indexBefore
+        (Get-FileSha256 -Path $prospectiveIndex) | Should -BeExactly $prospectiveBefore
+        (Invoke-TestGit -RepositoryRoot $source -Arguments @('show-ref', '--head')).StdOut | Should -BeExactly $refsBefore
+        (Get-FileSha256 -Path (Join-Path $source '.git\config')) | Should -BeExactly $configBefore
+    }
+
+    It 'T796-C02 detects source tracked-byte drift without repairing caller Git state' {
+        Assert-Task796RunnerFunction -Name 'New-RunnerCandidateContext'
+        Assert-Task796RunnerFunction -Name 'Assert-RunnerSourceState'
+        $source = New-TestRepository -Name 'drift-source'
+        $actualIndex = (Invoke-TestGit -RepositoryRoot $source -Arguments @('rev-parse', '--git-path', 'index')).StdOut
+        if (-not [System.IO.Path]::IsPathRooted($actualIndex)) { $actualIndex = Join-Path $source $actualIndex }
+        $indexBefore = Get-FileSha256 -Path $actualIndex
+        $refsBefore = (Invoke-TestGit -RepositoryRoot $source -Arguments @('show-ref', '--head')).StdOut
+        $configBefore = Get-FileSha256 -Path (Join-Path $source '.git\config')
+        $context = New-RunnerCandidateContext -RepositoryRoot $source -ExecutionRoot (Join-Path $TestDrive 'drift-controller')
+
+        [System.IO.File]::WriteAllText((Join-Path $source 'tracked.txt'), "drift`n", $script:Utf8NoBom)
+        { Assert-RunnerSourceState -Context $context } | Should -Throw '*source tracked bytes changed*'
+        (Get-FileSha256 -Path $actualIndex) | Should -BeExactly $indexBefore
+        (Invoke-TestGit -RepositoryRoot $source -Arguments @('show-ref', '--head')).StdOut | Should -BeExactly $refsBefore
+        (Get-FileSha256 -Path (Join-Path $source '.git\config')) | Should -BeExactly $configBefore
+    }
+
+    It 'T796-C03 detects drift in a path tracked only by the prospective index' {
+        Assert-Task796RunnerFunction -Name 'New-RunnerCandidateContext'
+        Assert-Task796RunnerFunction -Name 'Assert-RunnerSourceState'
+        $source = New-TestRepository -Name 'candidate-only-drift-source'
+        $actualIndex = (Invoke-TestGit -RepositoryRoot $source -Arguments @('rev-parse', '--git-path', 'index')).StdOut
+        if (-not [System.IO.Path]::IsPathRooted($actualIndex)) { $actualIndex = Join-Path $source $actualIndex }
+        $prospectiveIndex = Join-Path $TestDrive 'candidate-only.index'
+        Copy-Item -LiteralPath $actualIndex -Destination $prospectiveIndex
+        [System.IO.File]::WriteAllText((Join-Path $source 'candidate-only.txt'), "candidate`n", $script:Utf8NoBom)
+        $prospectiveEnvironment = Get-TestPlatformEnvironment
+        $prospectiveEnvironment['GIT_INDEX_FILE'] = $prospectiveIndex
+        [void](Invoke-TestGit -RepositoryRoot $source -Arguments @('add', '--', 'candidate-only.txt') -Environment $prospectiveEnvironment)
+        $prospectiveBefore = Get-FileSha256 -Path $prospectiveIndex
+        $context = New-RunnerCandidateContext -RepositoryRoot $source -ExecutionRoot (Join-Path $TestDrive 'candidate-only-controller') -ProspectiveIndexPath $prospectiveIndex
+
+        [System.IO.File]::WriteAllText((Join-Path $source 'candidate-only.txt'), "drift`n", $script:Utf8NoBom)
+
+        { Assert-RunnerSourceState -Context $context } | Should -Throw '*candidate tracked bytes changed*'
+        (Get-FileSha256 -Path $prospectiveIndex) | Should -BeExactly $prospectiveBefore
+    }
+
+    It 'T796-L01 rejects unmatched line filters in serial and direct worker entry points' {
+        Assert-Task796RunnerFunction -Name 'Get-RunnerCandidateTestPaths'
+        Assert-Task796RunnerFunction -Name 'Assert-PesterWorkerSpecCandidatePaths'
+        $allowlist = @(
+            '.githooks/pre-commit-whitelist.ps1'
+            '.gitignore'
+            'scripts/run-tests.ps1'
+            'tests/Integration.WorktreeHook.Tests.ps1'
+            'tests/PesterGitIsolation.Tests.ps1'
+        )
+        $actualIndex = (Invoke-TestGit -RepositoryRoot $script:RepoRoot -Arguments @('rev-parse', '--git-path', 'index')).StdOut
+        if (-not [System.IO.Path]::IsPathRooted($actualIndex)) {
+            $actualIndex = Join-Path $script:RepoRoot $actualIndex
+        }
+        $prospectiveIndex = Join-Path $TestDrive 'selector-candidate.index'
+        Copy-Item -LiteralPath $actualIndex -Destination $prospectiveIndex
+        $candidateEnvironment = Get-TestPlatformEnvironment
+        $candidateEnvironment['GIT_INDEX_FILE'] = $prospectiveIndex
+        [void](Invoke-TestGit -RepositoryRoot $script:RepoRoot -Arguments (@('add', '--') + $allowlist) -Environment $candidateEnvironment)
+        $candidateTreeId = (Invoke-TestGit -RepositoryRoot $script:RepoRoot -Arguments @('write-tree') -Environment $candidateEnvironment).StdOut
+        $actualIndexBefore = Get-FileSha256 -Path $actualIndex
+        $prospectiveIndexBefore = Get-FileSha256 -Path $prospectiveIndex
+        $candidateTestPaths = @(Get-RunnerCandidateTestPaths `
+            -RepositoryRoot $script:RepoRoot `
+            -CandidateTreeId $candidateTreeId `
+            -Environment $candidateEnvironment)
+        $candidateTestPaths | Should -Contain (Join-Path $script:RepoRoot 'tests\PesterGitIsolation.Tests.ps1')
+
+        $removedIndex = Join-Path $TestDrive 'selector-removed.index'
+        Copy-Item -LiteralPath $prospectiveIndex -Destination $removedIndex
+        $removedEnvironment = Get-TestPlatformEnvironment
+        $removedEnvironment['GIT_INDEX_FILE'] = $removedIndex
+        [void](Invoke-TestGit -RepositoryRoot $script:RepoRoot -Environment $removedEnvironment -Arguments @(
+            'update-index', '--force-remove', '--', 'tests/Integration.WorktreeHook.Tests.ps1'
+        ))
+        $removedTreeId = (Invoke-TestGit -RepositoryRoot $script:RepoRoot -Environment $removedEnvironment -Arguments @('write-tree')).StdOut
+        @(Get-RunnerCandidateTestPaths `
+            -RepositoryRoot $script:RepoRoot `
+            -CandidateTreeId $removedTreeId `
+            -Environment $removedEnvironment) |
+            Should -Not -Contain (Join-Path $script:RepoRoot 'tests\Integration.WorktreeHook.Tests.ps1')
+
+        $resolverModule = Join-Path $script:RepoRoot 'scripts\winsmux-pester.psm1'
+        Import-Module $resolverModule -Force -ErrorAction Stop | Out-Null
+        $pesterResolution = Resolve-WinsmuxPester571
+        $pesterResolution.resolution_status | Should -BeExactly 'resolved'
+        $invalidLineFilter = '{0}:999999' -f (Join-Path $script:RepoRoot 'tests\PesterGitIsolation.Tests.ps1')
+        $hooksPath = Join-Path $TestDrive 'selector-hooks'
+        $templatePath = Join-Path $TestDrive 'selector-template'
+        New-Item -ItemType Directory -Path $hooksPath, $templatePath -Force | Out-Null
+
+        $workerRoot = Join-Path $TestDrive 'selector-worker'
+        $workerSpec = [ordered]@{
+            Mode = 'Test'
+            WorkerId = 'selector-negative'
+            RepositoryRoot = $script:RepoRoot
+            WorkingDirectory = $script:RepoRoot
+            Paths = @((Join-Path $script:RepoRoot 'tests\PesterGitIsolation.Tests.ps1'))
+            LineFilters = @($invalidLineFilter)
+            ExpectedCount = 1
+            ResultPath = Join-Path $workerRoot 'result.json'
+            NUnitPath = Join-Path $workerRoot 'result.xml'
+            StdOutPath = Join-Path $workerRoot 'stdout.log'
+            StdErrPath = Join-Path $workerRoot 'stderr.log'
+            TempDirectory = Join-Path $workerRoot 'temp'
+            ProjectDirectory = Join-Path $workerRoot 'project'
+            PesterModulePath = [string]$pesterResolution.manifest_path
+            CandidateTreeId = $candidateTreeId
+            HooksPath = $hooksPath
+            TemplatePath = $templatePath
+            RequiresPrivateRepository = $false
+        }
+        New-Item -ItemType Directory -Path $workerRoot -Force | Out-Null
+        $workerSpecPath = Join-Path $workerRoot 'spec.json'
+        [System.IO.File]::WriteAllText($workerSpecPath, ($workerSpec | ConvertTo-Json -Depth 8), $script:Utf8NoBom)
+        $workerRun = Invoke-TestPowerShell -WorkingDirectory $script:RepoRoot -AllowFailure -Arguments @(
+            '-NoLogo', '-NoProfile', '-NonInteractive', '-File', $script:RunnerPath,
+            '-WorkerSpecPath', $workerSpecPath
+        )
+        $workerRun.ExitCode | Should -Be 2
+        Test-Path -LiteralPath $workerSpec.ResultPath -PathType Leaf | Should -BeTrue
+        $workerPayload = Get-Content -LiteralPath $workerSpec.ResultPath -Raw -Encoding UTF8 | ConvertFrom-Json
+        $workerPayload.total | Should -Be 0
+        $workerPayload.expectedCount | Should -Be 1
+        $workerPayload.harnessError | Should -Match 'expected 1 tests, got 0'
+
+        $injectedRelativePath = 'tests/task796-candidate-exclusion-{0}.Tests.ps1' -f [guid]::NewGuid().ToString('N')
+        $injectedPath = Join-Path $script:RepoRoot $injectedRelativePath
+        $createdInjectedPath = $false
+        try {
+            if (Test-Path -LiteralPath $injectedPath) {
+                throw "Candidate exclusion probe already exists: $injectedPath"
+            }
+            [System.IO.File]::WriteAllText($injectedPath, "Describe 'candidate-external' { It 'must not run' { 1 | Should -Be 2 } }`n", $script:Utf8NoBom)
+            $createdInjectedPath = $true
+            (Invoke-TestGit -RepositoryRoot $script:RepoRoot -Arguments @('check-ignore', '--quiet', '--', $injectedRelativePath) -AllowFailure).ExitCode |
+                Should -Be 0
+            @(Get-RunnerCandidateTestPaths `
+                -RepositoryRoot $script:RepoRoot `
+                -CandidateTreeId $candidateTreeId `
+                -Environment $candidateEnvironment) |
+                Should -Not -Contain $injectedPath
+
+            $membershipRoot = Join-Path $TestDrive 'membership-worker'
+            New-Item -ItemType Directory -Path $membershipRoot -Force | Out-Null
+            $membershipSpec = [ordered]@{
+                Mode = 'Test'
+                WorkerId = 'membership-negative'
+                RepositoryRoot = $script:RepoRoot
+                WorkingDirectory = $script:RepoRoot
+                Paths = @($injectedPath)
+                LineFilters = @()
+                ExpectedCount = 1
+                ResultPath = Join-Path $membershipRoot 'result.json'
+                NUnitPath = Join-Path $membershipRoot 'result.xml'
+                StdOutPath = Join-Path $membershipRoot 'stdout.log'
+                StdErrPath = Join-Path $membershipRoot 'stderr.log'
+                TempDirectory = Join-Path $membershipRoot 'temp'
+                ProjectDirectory = Join-Path $membershipRoot 'project'
+                PesterModulePath = [string]$pesterResolution.manifest_path
+                CandidateTreeId = $candidateTreeId
+                HooksPath = $hooksPath
+                TemplatePath = $templatePath
+                RequiresPrivateRepository = $false
+            }
+            $membershipSpecPath = Join-Path $membershipRoot 'spec.json'
+            [System.IO.File]::WriteAllText($membershipSpecPath, ($membershipSpec | ConvertTo-Json -Depth 8), $script:Utf8NoBom)
+            $membershipRun = Invoke-TestPowerShell -WorkingDirectory $script:RepoRoot -AllowFailure -Arguments @(
+                '-NoLogo', '-NoProfile', '-NonInteractive', '-File', $script:RunnerPath,
+                '-WorkerSpecPath', $membershipSpecPath
+            )
+            $membershipRun.ExitCode | Should -Be 2
+            Test-Path -LiteralPath $membershipSpec.ResultPath -PathType Leaf | Should -BeTrue
+            $membershipPayload = Get-Content -LiteralPath $membershipSpec.ResultPath -Raw -Encoding UTF8 | ConvertFrom-Json
+            $membershipPayload.harnessError | Should -Match 'not in the candidate Pester test inventory'
+        } finally {
+            if ($createdInjectedPath -and (Test-Path -LiteralPath $injectedPath -PathType Leaf)) {
+                Remove-Item -LiteralPath $injectedPath -Force
+            }
+        }
+
+        $serialRoot = Join-Path $TestDrive 'selector-serial'
+        $wrapperPath = Join-Path $TestDrive 'invoke-selector-serial.ps1'
+        $wrapper = @'
+param(
+    [Parameter(Mandatory)][string]$RunnerPath,
+    [Parameter(Mandatory)][string]$LineFilter,
+    [Parameter(Mandatory)][string]$ResultsDirectory
+)
+& $RunnerPath -Parallel:$false -LineFilters @($LineFilter) -ResultsDirectory $ResultsDirectory
+exit $LASTEXITCODE
+'@
+        [System.IO.File]::WriteAllText($wrapperPath, $wrapper, $script:Utf8NoBom)
+        $serialRun = Invoke-TestPowerShell -WorkingDirectory $script:RepoRoot -AllowFailure `
+            -ExtraEnvironment ([ordered]@{ GIT_INDEX_FILE = $prospectiveIndex }) `
+            -Arguments @(
+                '-NoLogo', '-NoProfile', '-NonInteractive', '-File', $wrapperPath,
+                '-RunnerPath', $script:RunnerPath,
+                '-LineFilter', $invalidLineFilter,
+                '-ResultsDirectory', $serialRoot
+            )
+        $serialRun.ExitCode | Should -Be 1
+        $serialSummaryPath = Join-Path $serialRoot 'summary.json'
+        Test-Path -LiteralPath $serialSummaryPath -PathType Leaf | Should -BeTrue
+        $serialSummary = Get-Content -LiteralPath $serialSummaryPath -Raw -Encoding UTF8 | ConvertFrom-Json
+        $serialSummary.mode | Should -BeExactly 'harness-error'
+        $serialSummary.error | Should -Match 'matched no executed test'
+        $serialSummary.total | Should -Be 0
+
+        (Get-FileSha256 -Path $actualIndex) | Should -BeExactly $actualIndexBefore
+        (Get-FileSha256 -Path $prospectiveIndex) | Should -BeExactly $prospectiveIndexBefore
+    }
+
+    It 'T796-F01 suppresses external hooks and permits one explicit fixture-local hook' {
+        Assert-Task796RunnerFunction -Name 'New-RunnerCandidateContext'
+        Assert-Task796RunnerFunction -Name 'New-RunnerPrivateRepository'
+        $source = New-TestRepository -Name 'hook-source'
+        $context = New-RunnerCandidateContext -RepositoryRoot $source -ExecutionRoot (Join-Path $TestDrive 'hook-controller')
+        $privateRoot = New-RunnerPrivateRepository -Context $context -DestinationPath (Join-Path $TestDrive 'hook-private')
+        $externalHooks = Join-Path $TestDrive 'external-hooks'
+        $localHooks = Join-Path $TestDrive 'local-hooks'
+        New-Item -ItemType Directory -Path $externalHooks, $localHooks -Force | Out-Null
+        $externalMarker = Join-Path $TestDrive 'external.marker'
+        $localMarker = Join-Path $TestDrive 'local.marker'
+        Write-HookScript -Path (Join-Path $externalHooks 'pre-commit') -MarkerVariable 'WINSMUX_EXTERNAL_HOOK_MARKER'
+        Write-HookScript -Path (Join-Path $localHooks 'pre-commit') -MarkerVariable 'WINSMUX_LOCAL_HOOK_MARKER'
+        $globalConfig = Join-Path $TestDrive 'hostile.gitconfig'
+        $externalUnix = $externalHooks.Replace('\', '/')
+        [System.IO.File]::WriteAllText($globalConfig, "[core]`n`thooksPath = $externalUnix`n", $script:Utf8NoBom)
+        [Environment]::SetEnvironmentVariable('GIT_CONFIG_GLOBAL', $globalConfig, 'Process')
+        $markers = [ordered]@{
+            WINSMUX_EXTERNAL_HOOK_MARKER = $externalMarker
+            WINSMUX_LOCAL_HOOK_MARKER = $localMarker
+        }
+
+        [void](Invoke-TestGit -RepositoryRoot $privateRoot -Environment $context.GitEnvironment -ExtraEnvironment $markers -Arguments @(
+            '-c', 'user.name=TASK-796 Fixture', '-c', 'user.email=task796@example.invalid',
+            'commit', '--allow-empty', '-m', 'managed hook boundary'
+        ))
+        Test-Path -LiteralPath $externalMarker | Should -BeFalse
+
+        [void](Invoke-TestGit -RepositoryRoot $privateRoot -Environment $context.GitEnvironment -ExtraEnvironment $markers -Arguments @(
+            '-c', 'user.name=TASK-796 Fixture', '-c', 'user.email=task796@example.invalid',
+            '-c', "core.hooksPath=$($localHooks.Replace('\', '/'))",
+            'commit', '--allow-empty', '-m', 'explicit local hook'
+        ))
+        Test-Path -LiteralPath $externalMarker | Should -BeFalse
+        @(Get-Content -LiteralPath $localMarker).Count | Should -Be 1
+    }
+
+    It 'T796-F02 assigns only both mutable suites to one private fixture worker' {
+        Assert-Task796RunnerFunction -Name 'Select-PesterWorkUnitsByLineFilter'
+        $testFiles = @(Get-ChildItem -LiteralPath (Join-Path $script:RepoRoot 'tests') -Filter '*.Tests.ps1' -File -Recurse)
+        $discoveryTests = @($testFiles | ForEach-Object {
+            [PSCustomObject]@{ file = $_.FullName; startLine = 1; identity = "tests/$($_.Name):1|fixture" }
+        })
+        $discovery = [PSCustomObject]@{ total = $discoveryTests.Count; tests = $discoveryTests }
+        $units = @(New-PesterWorkUnits `
+            -RepositoryRoot $script:RepoRoot `
+            -CandidateRepositoryRoot $script:RepoRoot `
+            -CandidateTestPaths @($testFiles.FullName) `
+            -DiscoveryResult $discovery)
+
+        @($units | Where-Object { $_.PSObject.Properties.Name -notcontains 'RequiresPrivateRepository' }).Count | Should -Be 0
+        $privateUnits = @($units | Where-Object { [bool]$_.RequiresPrivateRepository })
+        $privateUnits.Count | Should -Be 1
+        $privateUnits[0].WorkerId | Should -BeExactly 'private-git-fixture'
+        @($privateUnits[0].Paths | ForEach-Object { [System.IO.Path]::GetFileName($_) } | Sort-Object) |
+            Should -Be @('HarnessContract.Tests.ps1', 'PublicSurfacePolicy.Tests.ps1')
+        @($units | Where-Object { -not [bool]$_.RequiresPrivateRepository } | ForEach-Object { $_.Paths } |
+            ForEach-Object { [System.IO.Path]::GetFileName($_) }) |
+            Should -Not -Contain 'HarnessContract.Tests.ps1'
+        @($units | Where-Object { -not [bool]$_.RequiresPrivateRepository } | ForEach-Object { $_.Paths } |
+            ForEach-Object { [System.IO.Path]::GetFileName($_) }) |
+            Should -Not -Contain 'PublicSurfacePolicy.Tests.ps1'
+
+        $boundedFilters = @(
+            '{0}:1' -f (Join-Path $script:RepoRoot 'tests\PesterGitIsolation.Tests.ps1')
+            '{0}:1' -f (Join-Path $script:RepoRoot 'tests\Integration.WorktreeHook.Tests.ps1')
+        )
+        $bounded = Select-PesterWorkUnitsByLineFilter -RepositoryRoot $script:RepoRoot -Units $units -DiscoveryResult $discovery -LineFilters $boundedFilters
+        $bounded.Total | Should -Be 2
+        @($bounded.Units).Count | Should -Be 2
+        @($bounded.Units | Where-Object { [bool]$_.RequiresPrivateRepository }).Count | Should -Be 0
+        @($bounded.Units | ForEach-Object { [System.IO.Path]::GetFileName($_.Paths[0]) } | Sort-Object) |
+            Should -Be @('Integration.WorktreeHook.Tests.ps1', 'PesterGitIsolation.Tests.ps1')
+        @($bounded.Units | ForEach-Object { @($_.LineFilters).Count }) | Should -Be @(1, 1)
+    }
+}

--- a/tests/PesterGitIsolation.Tests.ps1
+++ b/tests/PesterGitIsolation.Tests.ps1
@@ -482,6 +482,43 @@ Describe 'TASK-796 Pester Git isolation' -Tag 'integration' {
         (Get-FileSha256 -Path $prospectiveIndex) | Should -BeExactly $prospectiveBefore
     }
 
+    It 'T796-C04 rejects a candidate when a staged delete leaves a working-tree file' {
+        Assert-Task796RunnerFunction -Name 'New-RunnerCandidateContext'
+        $source = New-TestRepository -Name 'staged-delete-leftover-source'
+        [System.IO.File]::WriteAllText((Join-Path $source 'doomed.txt'), "doomed-bytes`n", $script:Utf8NoBom)
+        [void](Invoke-TestGit -RepositoryRoot $source -Arguments @('add', '--', 'doomed.txt'))
+        [void](Invoke-TestGit -RepositoryRoot $source -Arguments @(
+            '-c', 'user.name=TASK-796 Fixture', '-c', 'user.email=task796@example.invalid',
+            'commit', '-m', 'add doomed'
+        ))
+        $actualIndex = (Invoke-TestGit -RepositoryRoot $source -Arguments @('rev-parse', '--git-path', 'index')).StdOut
+        if (-not [System.IO.Path]::IsPathRooted($actualIndex)) { $actualIndex = Join-Path $source $actualIndex }
+        $prospectiveIndex = Join-Path $TestDrive 'staged-delete-leftover.index'
+        Copy-Item -LiteralPath $actualIndex -Destination $prospectiveIndex
+        $prospectiveEnvironment = Get-TestPlatformEnvironment
+        $prospectiveEnvironment['GIT_INDEX_FILE'] = $prospectiveIndex
+        [void](Invoke-TestGit -RepositoryRoot $source -Environment $prospectiveEnvironment -Arguments @(
+            'update-index', '--force-remove', '--', 'doomed.txt'
+        ))
+        $indexBefore = Get-FileSha256 -Path $actualIndex
+        $prospectiveBefore = Get-FileSha256 -Path $prospectiveIndex
+        $refsBefore = (Invoke-TestGit -RepositoryRoot $source -Arguments @('show-ref', '--head')).StdOut
+        $configBefore = Get-FileSha256 -Path (Join-Path $source '.git\config')
+        $leftoverPath = Join-Path $source 'doomed.txt'
+        Test-Path -LiteralPath $leftoverPath -PathType Leaf | Should -BeTrue
+        [System.IO.File]::ReadAllText($leftoverPath) | Should -BeExactly "doomed-bytes`n"
+
+        { New-RunnerCandidateContext -RepositoryRoot $source -ExecutionRoot (Join-Path $TestDrive 'staged-delete-leftover-controller') -ProspectiveIndexPath $prospectiveIndex } |
+            Should -Throw '*staged deletion*'
+
+        Test-Path -LiteralPath $leftoverPath -PathType Leaf | Should -BeTrue
+        [System.IO.File]::ReadAllText($leftoverPath) | Should -BeExactly "doomed-bytes`n"
+        (Get-FileSha256 -Path $actualIndex) | Should -BeExactly $indexBefore
+        (Get-FileSha256 -Path $prospectiveIndex) | Should -BeExactly $prospectiveBefore
+        (Invoke-TestGit -RepositoryRoot $source -Arguments @('show-ref', '--head')).StdOut | Should -BeExactly $refsBefore
+        (Get-FileSha256 -Path (Join-Path $source '.git\config')) | Should -BeExactly $configBefore
+    }
+
     It 'T796-L01 rejects unmatched line filters in serial and direct worker entry points' {
         Assert-Task796RunnerFunction -Name 'Get-RunnerCandidateTestPaths'
         Assert-Task796RunnerFunction -Name 'Assert-PesterWorkerSpecCandidatePaths'

--- a/tests/PesterGitIsolation.Tests.ps1
+++ b/tests/PesterGitIsolation.Tests.ps1
@@ -55,8 +55,12 @@ Describe 'TASK-796 Pester Git isolation' -Tag 'integration' {
                 if ($null -ne $value) { $environment[$name] = $value }
             }
             $nullDevice = if ($IsWindows) { 'NUL' } else { '/dev/null' }
-            $emptyHooks = Join-Path $TestDrive 'bootstrap-hooks'
-            $emptyTemplate = Join-Path $TestDrive 'bootstrap-template'
+            $bootstrapRoot = $TestDrive
+            if ([string]::IsNullOrWhiteSpace([string]$bootstrapRoot)) {
+                $bootstrapRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('t796-bootstrap-' + [guid]::NewGuid().ToString('N'))
+            }
+            $emptyHooks = Join-Path $bootstrapRoot 'bootstrap-hooks'
+            $emptyTemplate = Join-Path $bootstrapRoot 'bootstrap-template'
             New-Item -ItemType Directory -Path $emptyHooks, $emptyTemplate -Force | Out-Null
             $environment['GIT_CONFIG_GLOBAL'] = $nullDevice
             $environment['GIT_CONFIG_SYSTEM'] = $nullDevice
@@ -214,6 +218,87 @@ Describe 'TASK-796 Pester Git isolation' -Tag 'integration' {
             $content = "#!/bin/sh`n" + ('printf ''%s\n'' hook >> "$' + $MarkerVariable + '"') + "`n"
             [System.IO.File]::WriteAllText($Path, $content, $script:Utf8NoBom)
         }
+
+        function New-T796SerialCwdFixture {
+            param([Parameter(Mandatory)][string]$Name)
+
+            $root = Join-Path ([System.IO.Path]::GetTempPath()) ('t796-' + $Name + '-' + [guid]::NewGuid().ToString('N'))
+            $source = Join-Path $root 'source'
+            New-Item -ItemType Directory -Path (Join-Path $source 'tests'), (Join-Path $source 'scripts') -Force | Out-Null
+            [void](Invoke-TestGit -RepositoryRoot $source -Arguments @('init'))
+            $probeLines = @(
+                "Describe 'T796 serial CWD probe' {"
+                "    It 'records unqualified git toplevel' {"
+                '        $toplevel = (& git rev-parse --show-toplevel 2>$null | Out-String).Trim()'
+                '        $cwd = (Get-Location).Path'
+                '        [ordered]@{ toplevel = $toplevel; cwd = $cwd } | ConvertTo-Json | Set-Content -LiteralPath $env:T796_SERIAL_CWD_EVIDENCE -Encoding utf8'
+                '        $realSource = [string]$env:T796_REAL_SOURCE_ROOT'
+                '        if (-not [string]::IsNullOrWhiteSpace($toplevel) -and -not [string]::IsNullOrWhiteSpace($realSource)) {'
+                '            $realFull = [System.IO.Path]::GetFullPath($realSource)'
+                '            $topFull = [System.IO.Path]::GetFullPath($toplevel)'
+                '            if (-not [StringComparer]::OrdinalIgnoreCase.Equals($topFull, $realFull)) {'
+                '                & git config core.hooksPath .githooks'
+                '            }'
+                '        }'
+                '        $true | Should -BeTrue'
+                '    }'
+                '}'
+            )
+            $harnessLines = @(
+                "Describe 'T796 harness stub' {"
+                "    It 'stays quiet' { `$true | Should -BeTrue }"
+                '}'
+            )
+            $immutableLines = @(
+                "Describe 'T796 serial immutable CWD probe' {"
+                "    It 'records unqualified git toplevel from source CWD' {"
+                '        $toplevel = (& git rev-parse --show-toplevel 2>$null | Out-String).Trim()'
+                '        $cwd = (Get-Location).Path'
+                '        [ordered]@{ toplevel = $toplevel; cwd = $cwd } | ConvertTo-Json | Set-Content -LiteralPath $env:T796_SERIAL_IMMUTABLE_CWD_EVIDENCE -Encoding utf8'
+                '        $true | Should -BeTrue'
+                '    }'
+                '}'
+            )
+            [System.IO.File]::WriteAllText((Join-Path $source 'tests\PublicSurfacePolicy.Tests.ps1'), ($probeLines -join "`n") + "`n", $script:Utf8NoBom)
+            [System.IO.File]::WriteAllText((Join-Path $source 'tests\HarnessContract.Tests.ps1'), ($harnessLines -join "`n") + "`n", $script:Utf8NoBom)
+            [System.IO.File]::WriteAllText((Join-Path $source 'tests\VersionSurface.Tests.ps1'), ($immutableLines -join "`n") + "`n", $script:Utf8NoBom)
+            [System.IO.File]::WriteAllText((Join-Path $source 'scripts\dummy.ps1'), "function Get-T796Dummy { 'ok' }`n", $script:Utf8NoBom)
+            [System.IO.File]::WriteAllText((Join-Path $source 'tracked.txt'), "base`n", $script:Utf8NoBom)
+            [void](Invoke-TestGit -RepositoryRoot $source -Arguments @('add', '--', 'tests/PublicSurfacePolicy.Tests.ps1', 'tests/HarnessContract.Tests.ps1', 'tests/VersionSurface.Tests.ps1', 'scripts/dummy.ps1', 'tracked.txt'))
+            [void](Invoke-TestGit -RepositoryRoot $source -Arguments @(
+                '-c', 'user.name=TASK-796 Fixture', '-c', 'user.email=task796@example.invalid',
+                'commit', '-m', 'serial cwd fixture'
+            ))
+            return [PSCustomObject]@{ Root = $root; Source = $source }
+        }
+
+        function Invoke-T796SerialCwdSuite {
+            param(
+                [Parameter(Mandatory)][string]$Source,
+                [Parameter(Mandatory)][string]$PrivateRoot,
+                [Parameter(Mandatory)]$GitEnvironment,
+                [Parameter(Mandatory)]$PesterModule,
+                [Parameter(Mandatory)][string]$ResultsRoot,
+                [switch]$EnableCoverage
+            )
+
+            $candidatePaths = @(
+                (Join-Path $Source 'tests\HarnessContract.Tests.ps1')
+                (Join-Path $Source 'tests\PublicSurfacePolicy.Tests.ps1')
+                (Join-Path $Source 'tests\VersionSurface.Tests.ps1')
+            )
+            Invoke-WithRunnerGitEnvironment -Environment $GitEnvironment -ScriptBlock {
+                Invoke-SerialSuite `
+                    -RepositoryRoot $Source `
+                    -PrivateRepositoryRoot $PrivateRoot `
+                    -TestResultPath (Join-Path $ResultsRoot 'pester-results.xml') `
+                    -CoverageReportPath (Join-Path $ResultsRoot 'coverage.xml') `
+                    -PesterModule $PesterModule `
+                    -CandidateTestPaths $candidatePaths `
+                    -EnableCoverage:$EnableCoverage
+            }
+        }
+
     }
 
     BeforeEach {
@@ -645,4 +730,152 @@ exit $LASTEXITCODE
             Should -Be @('Integration.WorktreeHook.Tests.ps1', 'PesterGitIsolation.Tests.ps1')
         @($bounded.Units | ForEach-Object { @($_.LineFilters).Count }) | Should -Be @(1, 1)
     }
+
+    It 'T796-F03 runs serial mutable suites from the private Git fixture' {
+        Assert-Task796RunnerFunction -Name 'Invoke-SerialSuite'
+        Assert-Task796RunnerFunction -Name 'Get-PesterExecutionPaths'
+        Assert-Task796RunnerFunction -Name 'New-RunnerCandidateContext'
+        Assert-Task796RunnerFunction -Name 'New-RunnerPrivateRepository'
+        Assert-Task796RunnerFunction -Name 'Invoke-WithRunnerGitEnvironment'
+        $fixture = New-T796SerialCwdFixture -Name 'serial-cwd'
+        $source = [string]$fixture.Source
+        $sourceConfig = Join-Path $source '.git\config'
+        $realConfig = Join-Path $script:RepoRoot '.git\config'
+        $sourceConfigBefore = Get-FileSha256 -Path $sourceConfig
+        $realConfigBefore = Get-FileSha256 -Path $realConfig
+        $realHooksBefore = (Invoke-TestGit -RepositoryRoot $script:RepoRoot -Arguments @('config', '--local', '--get', 'core.hooksPath') -AllowFailure).StdOut
+        $context = New-RunnerCandidateContext -RepositoryRoot $source -ExecutionRoot (Join-Path $fixture.Root 'controller')
+        $privateRoot = New-RunnerPrivateRepository -Context $context -DestinationPath (Join-Path $fixture.Root 'private')
+        $evidencePath = Join-Path $fixture.Root 'serial-cwd-evidence.json'
+        $immutableEvidencePath = Join-Path $fixture.Root 'serial-immutable-cwd-evidence.json'
+        $resultsRoot = Join-Path $fixture.Root 'results'
+        New-Item -ItemType Directory -Path $resultsRoot -Force | Out-Null
+        $resolverModule = Join-Path $script:RepoRoot 'scripts\winsmux-pester.psm1'
+        Import-Module $resolverModule -Force -ErrorAction Stop | Out-Null
+        $pesterResolution = Resolve-WinsmuxPester571
+        $pesterResolution.resolution_status | Should -BeExactly 'resolved'
+        $pesterModule = [pscustomobject]@{
+            Name = 'Pester'
+            Version = [version]'5.7.1'
+            Path = [string]$pesterResolution.manifest_path
+            ModuleBase = [string]$pesterResolution.module_base
+        }
+        $locationBefore = (Get-Location).Path
+        $env:T796_SERIAL_CWD_EVIDENCE = $evidencePath
+        $env:T796_SERIAL_IMMUTABLE_CWD_EVIDENCE = $immutableEvidencePath
+        $env:T796_REAL_SOURCE_ROOT = $script:RepoRoot
+        try {
+            Set-Location -LiteralPath $source
+            try {
+                $null = Invoke-T796SerialCwdSuite `
+                    -Source $source `
+                    -PrivateRoot $privateRoot `
+                    -GitEnvironment $context.GitEnvironment `
+                    -PesterModule $pesterModule `
+                    -ResultsRoot $resultsRoot
+                [System.IO.Path]::GetFullPath((Get-Location).Path) | Should -BeExactly ([System.IO.Path]::GetFullPath($source))
+            } finally {
+                Set-Location -LiteralPath $locationBefore
+            }
+        } finally {
+            Remove-Item -LiteralPath 'Env:T796_SERIAL_CWD_EVIDENCE' -ErrorAction SilentlyContinue
+            Remove-Item -LiteralPath 'Env:T796_SERIAL_IMMUTABLE_CWD_EVIDENCE' -ErrorAction SilentlyContinue
+            Remove-Item -LiteralPath 'Env:T796_REAL_SOURCE_ROOT' -ErrorAction SilentlyContinue
+        }
+        try {
+        Test-Path -LiteralPath $evidencePath -PathType Leaf | Should -BeTrue
+        Test-Path -LiteralPath $immutableEvidencePath -PathType Leaf | Should -BeTrue
+        $evidence = Get-Content -LiteralPath $evidencePath -Raw -Encoding UTF8 | ConvertFrom-Json
+        $immutableEvidence = Get-Content -LiteralPath $immutableEvidencePath -Raw -Encoding UTF8 | ConvertFrom-Json
+        $privateFull = [System.IO.Path]::GetFullPath($privateRoot)
+        $sourceFull = [System.IO.Path]::GetFullPath($source)
+        [System.IO.Path]::GetFullPath([string]$evidence.toplevel) | Should -BeExactly $privateFull
+        [System.IO.Path]::GetFullPath([string]$evidence.cwd) | Should -BeExactly $privateFull
+        [System.IO.Path]::GetFullPath([string]$immutableEvidence.toplevel) | Should -BeExactly $sourceFull
+        [System.IO.Path]::GetFullPath([string]$immutableEvidence.cwd) | Should -BeExactly $sourceFull
+        [System.IO.Path]::GetFullPath((Get-Location).Path) | Should -BeExactly ([System.IO.Path]::GetFullPath($locationBefore))
+        (Get-FileSha256 -Path $sourceConfig) | Should -BeExactly $sourceConfigBefore
+        (Get-FileSha256 -Path $realConfig) | Should -BeExactly $realConfigBefore
+        $realHooksAfter = (Invoke-TestGit -RepositoryRoot $script:RepoRoot -Arguments @('config', '--local', '--get', 'core.hooksPath') -AllowFailure).StdOut
+        $realHooksAfter | Should -BeExactly $realHooksBefore
+        $privateHooks = (Invoke-TestGit -RepositoryRoot $privateRoot -Environment $context.GitEnvironment -Arguments @('config', '--local', '--get', 'core.hooksPath') -AllowFailure).StdOut
+        $privateHooks | Should -BeExactly '.githooks'
+        } finally {
+            if (Test-Path -LiteralPath $fixture.Root) {
+                Remove-Item -LiteralPath $fixture.Root -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+    }
+
+    It 'T796-F04 runs coverage-serial mutable suites from the private Git fixture' {
+        Assert-Task796RunnerFunction -Name 'Invoke-SerialSuite'
+        $fixture = New-T796SerialCwdFixture -Name 'coverage-cwd'
+        $source = [string]$fixture.Source
+        $sourceConfig = Join-Path $source '.git\config'
+        $realConfig = Join-Path $script:RepoRoot '.git\config'
+        $sourceConfigBefore = Get-FileSha256 -Path $sourceConfig
+        $realConfigBefore = Get-FileSha256 -Path $realConfig
+        $context = New-RunnerCandidateContext -RepositoryRoot $source -ExecutionRoot (Join-Path $fixture.Root 'controller')
+        $privateRoot = New-RunnerPrivateRepository -Context $context -DestinationPath (Join-Path $fixture.Root 'private')
+        $evidencePath = Join-Path $fixture.Root 'coverage-cwd-evidence.json'
+        $immutableEvidencePath = Join-Path $fixture.Root 'coverage-immutable-cwd-evidence.json'
+        $resultsRoot = Join-Path $fixture.Root 'results'
+        New-Item -ItemType Directory -Path $resultsRoot -Force | Out-Null
+        $resolverModule = Join-Path $script:RepoRoot 'scripts\winsmux-pester.psm1'
+        Import-Module $resolverModule -Force -ErrorAction Stop | Out-Null
+        $pesterResolution = Resolve-WinsmuxPester571
+        $pesterResolution.resolution_status | Should -BeExactly 'resolved'
+        $pesterModule = [pscustomobject]@{
+            Name = 'Pester'
+            Version = [version]'5.7.1'
+            Path = [string]$pesterResolution.manifest_path
+            ModuleBase = [string]$pesterResolution.module_base
+        }
+        $locationBefore = (Get-Location).Path
+        $env:T796_SERIAL_CWD_EVIDENCE = $evidencePath
+        $env:T796_SERIAL_IMMUTABLE_CWD_EVIDENCE = $immutableEvidencePath
+        $env:T796_REAL_SOURCE_ROOT = $script:RepoRoot
+        try {
+            Set-Location -LiteralPath $source
+            try {
+                $serial = Invoke-T796SerialCwdSuite `
+                    -Source $source `
+                    -PrivateRoot $privateRoot `
+                    -GitEnvironment $context.GitEnvironment `
+                    -PesterModule $pesterModule `
+                    -ResultsRoot $resultsRoot `
+                    -EnableCoverage
+                [System.IO.Path]::GetFullPath((Get-Location).Path) | Should -BeExactly ([System.IO.Path]::GetFullPath($source))
+            } finally {
+                Set-Location -LiteralPath $locationBefore
+            }
+        } finally {
+            Remove-Item -LiteralPath 'Env:T796_SERIAL_CWD_EVIDENCE' -ErrorAction SilentlyContinue
+            Remove-Item -LiteralPath 'Env:T796_SERIAL_IMMUTABLE_CWD_EVIDENCE' -ErrorAction SilentlyContinue
+            Remove-Item -LiteralPath 'Env:T796_REAL_SOURCE_ROOT' -ErrorAction SilentlyContinue
+        }
+        try {
+        $serial | Should -Not -BeNullOrEmpty
+        Test-Path -LiteralPath $evidencePath -PathType Leaf | Should -BeTrue
+        Test-Path -LiteralPath $immutableEvidencePath -PathType Leaf | Should -BeTrue
+        $evidence = Get-Content -LiteralPath $evidencePath -Raw -Encoding UTF8 | ConvertFrom-Json
+        $immutableEvidence = Get-Content -LiteralPath $immutableEvidencePath -Raw -Encoding UTF8 | ConvertFrom-Json
+        $privateFull = [System.IO.Path]::GetFullPath($privateRoot)
+        $sourceFull = [System.IO.Path]::GetFullPath($source)
+        [System.IO.Path]::GetFullPath([string]$evidence.toplevel) | Should -BeExactly $privateFull
+        [System.IO.Path]::GetFullPath([string]$evidence.cwd) | Should -BeExactly $privateFull
+        [System.IO.Path]::GetFullPath([string]$immutableEvidence.toplevel) | Should -BeExactly $sourceFull
+        [System.IO.Path]::GetFullPath([string]$immutableEvidence.cwd) | Should -BeExactly $sourceFull
+        [System.IO.Path]::GetFullPath((Get-Location).Path) | Should -BeExactly ([System.IO.Path]::GetFullPath($locationBefore))
+        (Get-FileSha256 -Path $sourceConfig) | Should -BeExactly $sourceConfigBefore
+        (Get-FileSha256 -Path $realConfig) | Should -BeExactly $realConfigBefore
+        $privateHooks = (Invoke-TestGit -RepositoryRoot $privateRoot -Environment $context.GitEnvironment -Arguments @('config', '--local', '--get', 'core.hooksPath') -AllowFailure).StdOut
+        $privateHooks | Should -BeExactly '.githooks'
+        } finally {
+            if (Test-Path -LiteralPath $fixture.Root) {
+                Remove-Item -LiteralPath $fixture.Root -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+    }
 }
+


### PR DESCRIPTION
## Summary
- TASK-796: official Pester fixture の Git を host config / external hooks から隔離する。controlled runner Git env + candidate tree ID で、harness 所有の private `checkout-index` fixture を使う。
- Forest: source tracked bytes / index / refs / local config は entry 前後で不変。external hook 0、fixture-local hook 1。caller Git env は restore。
- 製品 focused: TASK-810 80/80、TASK-800 7/7 非回帰。
- 1 commit: `22419b41` isolate official Pester fixture Git config and external hooks。
- Grok Build independent review **APPROVE** on tip `22419b41`。

## Out of scope（この PR に含めない）
- leftover-close、observe types、v7 ideas、stale freeze `workingFileSha256` は residual。REQUEST_CHANGES ではない。別タスク。
- Official full suite は意図的に未実行（CandidateFreeze 後 / 別 GO）。

## Test plan
- [x] Pester Git isolation: controlled runner Git env + candidate tree ID
- [x] Private checkout-index fixture owned by harness
- [x] Source tracked bytes / index / refs / local config unchanged across entries
- [x] External hook 0 / fixture-local hook 1
- [x] Caller Git env restored
- [x] TASK-810 80/80 非回帰
- [x] TASK-800 7/7 非回帰
- [x] Grok Build independent review APPROVE @ `22419b41`
- [ ] Official full suite（CandidateFreeze later / 別 GO）
- [ ] CI on this PR
- [ ] Do not merge until explicit GO（merge は別 GO）
