### PR TITLE
TASK-798: separate TaskCompleted gate from Pester execution

### DIFF
--- a/.claude/hooks/sh-task-gate.js
+++ b/.claude/hooks/sh-task-gate.js
@@ -7,100 +7,218 @@
 "use strict";
 
 const fs = require("fs");
-const { execSync } = require("child_process");
+const path = require("path");
+const { execFileSync } = require("child_process");
 const {
   readHookInput,
   allow,
   deny,
-  appendEvidence,
+  failClosed,
 } = require("./lib/sh-utils");
 
 const HOOK_NAME = "sh-task-gate";
+const EVIDENCE_PATH = path.join(
+  "artifacts",
+  "test-results",
+  "summary.json",
+);
+const EVIDENCE_LABEL = "artifacts/test-results/summary.json";
+const FRESHNESS_LIMIT_MS = 30000;
+const TREE_ID_PATTERN = /^[0-9a-f]{40}$/;
+const FAILURE_MODES = new Set([
+  "unavailable",
+  "harness-error",
+  "harness-postflight-error",
+]);
+const REQUIRED_COUNT_KEYS = [
+  "failed",
+  "failedBlocks",
+  "failedContainers",
+  "total",
+  "boundedLineFilterCount",
+];
 
-/**
- * Check if Pester test files exist.
- * @returns {boolean}
- */
-function hasPesterTests() {
+function denyGate(reason, detail) {
+  deny(`[${HOOK_NAME}] ${reason}: ${detail}`);
+}
+
+function isNonNegativeInteger(value) {
+  return Number.isFinite(value) && Number.isInteger(value) && value >= 0;
+}
+
+function readEvidence() {
+  let stat;
   try {
-    const files = fs.readdirSync("tests").filter((f) => f.endsWith(".Tests.ps1"));
-    return files.length > 0;
+    stat = fs.statSync(EVIDENCE_PATH);
   } catch {
+    denyGate("C1 missing", `${EVIDENCE_LABEL} is missing or unreadable.`);
+    return null;
+  }
+
+  if (!stat.isFile()) {
+    denyGate("C1 missing", `${EVIDENCE_LABEL} is not a readable file.`);
+    return null;
+  }
+
+  let raw;
+  try {
+    raw = fs.readFileSync(EVIDENCE_PATH, "utf8");
+  } catch {
+    denyGate("C1 missing", `${EVIDENCE_LABEL} is missing or unreadable.`);
+    return null;
+  }
+
+  let summary;
+  try {
+    summary = JSON.parse(raw);
+  } catch {
+    denyGate("C2 malformed", `${EVIDENCE_LABEL} is not valid JSON.`);
+    return null;
+  }
+
+  if (!summary || typeof summary !== "object" || Array.isArray(summary)) {
+    denyGate("C2 malformed", `${EVIDENCE_LABEL} must contain a JSON object.`);
+    return null;
+  }
+
+  return { summary, mtimeMs: stat.mtimeMs };
+}
+
+function validateSchema(summary) {
+  if (
+    Object.prototype.hasOwnProperty.call(summary, "mode") &&
+    typeof summary.mode !== "string"
+  ) {
+    denyGate("C2 malformed", `${EVIDENCE_LABEL} has an invalid mode.`);
     return false;
   }
-}
 
-/**
- * Run Pester tests and return the result.
- * @returns {{ passed: boolean, output: string, total: number, failed: number }}
- */
-function runPesterTests() {
-  try {
-    const output = execSync(
-      'pwsh -NoProfile -Command "$env:NO_COLOR=1; Invoke-Pester tests/ -Output Minimal -PassThru | Select-Object -Property TotalCount,FailedCount | ConvertTo-Json"',
-      { encoding: "utf8", timeout: 120000, stdio: ["pipe", "pipe", "pipe"] },
+  if (FAILURE_MODES.has(summary.mode)) {
+    denyGate("C4 failing", `${EVIDENCE_LABEL} reports mode ${summary.mode}.`);
+    return false;
+  }
+
+  for (const key of REQUIRED_COUNT_KEYS) {
+    if (!isNonNegativeInteger(summary[key])) {
+      denyGate(
+        "C2 malformed",
+        `${EVIDENCE_LABEL} has an invalid or missing ${key}.`,
+      );
+      return false;
+    }
+  }
+
+  if (
+    typeof summary.candidateTreeId !== "string" ||
+    !TREE_ID_PATTERN.test(summary.candidateTreeId)
+  ) {
+    denyGate(
+      "C2 malformed",
+      `${EVIDENCE_LABEL} has an invalid or missing candidateTreeId.`,
     );
-    try {
-      const result = JSON.parse(output.trim());
-      return {
-        passed: (result.FailedCount || 0) === 0,
-        output: `Pester: ${result.TotalCount} tests, ${result.FailedCount} failed`,
-        total: result.TotalCount || 0,
-        failed: result.FailedCount || 0,
-      };
-    } catch {
-      return { passed: true, output: output.slice(-300), total: 0, failed: 0 };
-    }
-  } catch (err) {
-    const output = (err.stdout || "") + (err.stderr || "");
-    return { passed: false, output: output.slice(-300), total: 0, failed: -1 };
+    return false;
+  }
+
+  return true;
+}
+
+function validateFreshness(mtimeMs) {
+  const now = Date.now();
+  const ageMs = now - mtimeMs;
+  if (
+    !Number.isFinite(mtimeMs) ||
+    mtimeMs > now ||
+    ageMs >= FRESHNESS_LIMIT_MS
+  ) {
+    denyGate(
+      "C3 stale",
+      `${EVIDENCE_LABEL} is not fresh enough for TaskCompleted.`,
+    );
+    return false;
+  }
+
+  return true;
+}
+
+function validatePassingSummary(summary) {
+  if (
+    summary.failed !== 0 ||
+    summary.failedBlocks !== 0 ||
+    summary.failedContainers !== 0 ||
+    summary.total < 1
+  ) {
+    denyGate("C4 failing", `${EVIDENCE_LABEL} does not report a passing suite.`);
+    return false;
+  }
+
+  return true;
+}
+
+function readCurrentTreeId() {
+  const treeId = execFileSync("git", ["write-tree"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+
+  if (!TREE_ID_PATTERN.test(treeId)) {
+    throw new Error("git write-tree returned an invalid tree ID");
+  }
+
+  return treeId;
+}
+
+function validateCurrentTree(summary) {
+  if (summary.candidateTreeId !== readCurrentTreeId()) {
+    denyGate(
+      "C5 tree_mismatch",
+      `${EVIDENCE_LABEL} does not match the current candidate tree.`,
+    );
+    return false;
+  }
+
+  return true;
+}
+
+function validateFullSuite(summary) {
+  if (summary.boundedLineFilterCount !== 0) {
+    denyGate(
+      "C6 not_full",
+      `${EVIDENCE_LABEL} reports a bounded test selection.`,
+    );
+    return false;
+  }
+
+  return true;
+}
+
+function main() {
+  readHookInput();
+  const evidence = readEvidence();
+  if (!evidence) return;
+  if (!validateSchema(evidence.summary)) return;
+  if (!validateFreshness(evidence.mtimeMs)) return;
+  if (!validatePassingSummary(evidence.summary)) return;
+  if (!validateCurrentTree(evidence.summary)) return;
+  if (!validateFullSuite(evidence.summary)) return;
+
+  allow(`[${HOOK_NAME}] Existing full-suite evidence verified.`);
+}
+
+function failOnUnexpectedException() {
+  const reason = `[${HOOK_NAME}] C7 exception: unexpected evidence verification failure.`;
+  try {
+    deny(reason);
+  } catch {
+    failClosed(reason);
   }
 }
 
-// ---------------------------------------------------------------------------
-// Main
-// ---------------------------------------------------------------------------
-
-try {
-  const input = readHookInput();
-  const toolName = input.tool_name || input.toolName || "";
-  const toolInput = input.tool_input || input.toolInput || {};
-  const sessionId = input.session_id || input.sessionId || "";
-  void toolName;
-  void toolInput;
-
-  // Step 2: Run Pester tests if available (TASK-039)
-  if (hasPesterTests()) {
-    const pester = runPesterTests();
-    if (!pester.passed) {
-      try {
-        appendEvidence({
-          hook: HOOK_NAME,
-          event: "TaskCompleted",
-          decision: "deny",
-          reason: "pester_failed",
-          output: pester.output,
-          session_id: sessionId,
-        });
-      } catch {}
-      deny(`[${HOOK_NAME}] Pester テスト失敗。${pester.output}`);
-      return;
-    }
-    allow(`[${HOOK_NAME}] Pester 通過。`);
-    return;
+if (require.main === module) {
+  try {
+    main();
+  } catch {
+    failOnUnexpectedException();
   }
-
-  allow();
-} catch (err) {
-  // Test gate: if we can't run tests, don't block the task (fail-open)
-  allow();
 }
 
-// ---------------------------------------------------------------------------
-// Exports (for testing)
-// ---------------------------------------------------------------------------
-
-module.exports = {
-  hasPesterTests,
-  runPesterTests,
-};
+module.exports = { main };


### PR DESCRIPTION
## Summary
- TASK-798: Claude TaskCompleted gate を Pester 実行から分離する。gate は Pester を spawn しない。current-tree の既存全量証拠（`artifacts/test-results/summary.json`）だけを検証する。
- Forest: 独自 Invoke-Pester / 120s child / 独自 JSON / fail-open を廃止。壁時計 <30s（happy 111.7ms）。missing / malformed / stale / failing は fail-closed。`run-tests.ps1` 0-byte。
- 1 commit: `22a2400e` verify TaskCompleted against existing full-suite evidence。file: `.claude/hooks/sh-task-gate.js` only。
- Grok Build independent review **APPROVE** on tip `22a2400e`（grok-4.6 / `--reasoning-effort xhigh`）。Grok Bot は reviewer ではない。

## Out of scope（この PR に含めない）
- 800 leaf ResultsDirectory Mandatory、mtime copy、producer 非認証、write-tree unstaged、official full 未実行は residual。REQUEST_CHANGES ではない。別タスク。
- Official full suite は意図的に未実行（証明に未使用 / 別 GO）。

## Test plan
- [x] Gate does not spawn Pester / 120s child / unique JSON
- [x] Gate verifies existing full-suite evidence only
- [x] Wall-clock <30s (happy 111.7ms)
- [x] missing / malformed / stale / failing fail-closed
- [x] run-tests.ps1 untouched (0-byte)
- [x] Grok Build independent review APPROVE @ `22a2400e`
- [ ] CI on this PR
- [ ] Do not merge until explicit GO（merge は別 GO）
