### PR TITLE
fix(dispatch): tolerate pane wrap and inject read-before-interact

### DIFF
--- a/.githooks/pre-commit-whitelist.ps1
+++ b/.githooks/pre-commit-whitelist.ps1
@@ -187,6 +187,7 @@ $whitelistPatterns = @(
     'winsmux-app/src/modelCapabilities.ts',
     'winsmux-app/src/sourceGraph.ts',
     'winsmux-app/src/workerPaneRouting.ts',
+    'winsmux-app/src/workerPaneInput.ts',
     'winsmux-app/src/styles.css',
     'winsmux-app/src-tauri/Cargo.toml',
     'winsmux-app/src-tauri/Cargo.lock',

--- a/core/src/operator_cli.rs
+++ b/core/src/operator_cli.rs
@@ -18,6 +18,7 @@ use crate::event_contract::{parse_event_jsonl, EventRecord};
 use crate::ledger::{attach_evidence_chain_to_event, public_changed_files};
 use crate::machine_contract::machine_contract_catalog;
 use crate::read_path;
+use crate::shell_lifecycle::shell_prompt_ready;
 use crate::types::VERSION;
 use crate::workflow::normalize_workspace_plan_payload;
 use crate::workspace_project_settings::{self, WorkspacePlanProjectSettings};
@@ -8415,36 +8416,6 @@ fn readiness_agent_name(value: &str) -> String {
         }
     }
     String::new()
-}
-
-fn shell_prompt_ready(text: &str) -> bool {
-    let lines: Vec<&str> = text
-        .lines()
-        .map(str::trim)
-        .filter(|line| !line.is_empty())
-        .collect();
-    if lines.is_empty() {
-        return false;
-    }
-    if lines[lines.len() - 1].starts_with("PS ") {
-        return true;
-    }
-
-    let start = lines.len().saturating_sub(6);
-    let collapsed: String = lines[start..]
-        .join("")
-        .chars()
-        .filter(|ch| !ch.is_whitespace())
-        .collect();
-    if collapsed.is_empty() || !collapsed.ends_with('>') {
-        return false;
-    }
-
-    let lower = collapsed.to_ascii_lowercase();
-    match lower.find("ps") {
-        Some(idx) => collapsed[idx + 2..].chars().count() >= 2,
-        None => false,
-    }
 }
 
 fn wait_for_shell_prompt(pane_id: &str) -> io::Result<()> {

--- a/core/src/operator_cli.rs
+++ b/core/src/operator_cli.rs
@@ -8417,11 +8417,41 @@ fn readiness_agent_name(value: &str) -> String {
     String::new()
 }
 
+fn shell_prompt_ready(text: &str) -> bool {
+    let lines: Vec<&str> = text
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .collect();
+    if lines.is_empty() {
+        return false;
+    }
+    if lines[lines.len() - 1].starts_with("PS ") {
+        return true;
+    }
+
+    let start = lines.len().saturating_sub(6);
+    let collapsed: String = lines[start..]
+        .join("")
+        .chars()
+        .filter(|ch| !ch.is_whitespace())
+        .collect();
+    if collapsed.is_empty() || !collapsed.ends_with('>') {
+        return false;
+    }
+
+    let lower = collapsed.to_ascii_lowercase();
+    match lower.find("ps") {
+        Some(idx) => collapsed[idx + 2..].chars().count() >= 2,
+        None => false,
+    }
+}
+
 fn wait_for_shell_prompt(pane_id: &str) -> io::Result<()> {
     let deadline = Instant::now() + Duration::from_secs(15);
     while Instant::now() < deadline {
         let text = capture_pane_tail(pane_id)?;
-        if text.lines().any(|line| line.trim().starts_with("PS ")) {
+        if shell_prompt_ready(&text) {
             return Ok(());
         }
         thread::sleep(Duration::from_millis(500));

--- a/core/src/shell_lifecycle.rs
+++ b/core/src/shell_lifecycle.rs
@@ -75,6 +75,36 @@ pub fn should_reset_warm_pane_after_default_shell_change(old_shell: &str, new_sh
     old_shell != new_shell
 }
 
+pub fn shell_prompt_ready(text: &str) -> bool {
+    let lines: Vec<&str> = text
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .collect();
+    if lines.is_empty() {
+        return false;
+    }
+    if lines[lines.len() - 1].starts_with("PS ") {
+        return true;
+    }
+
+    let start = lines.len().saturating_sub(6);
+    let collapsed: String = lines[start..]
+        .join("")
+        .chars()
+        .filter(|ch| !ch.is_whitespace())
+        .collect();
+    if collapsed.is_empty() || !collapsed.ends_with('>') {
+        return false;
+    }
+
+    let lower = collapsed.to_ascii_lowercase();
+    match lower.find("ps") {
+        Some(idx) => collapsed[idx + 2..].chars().count() >= 2,
+        None => false,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/core/tests-rs/operator_cli_unit.rs
+++ b/core/tests-rs/operator_cli_unit.rs
@@ -1425,3 +1425,30 @@ fn operator_cli_review_reset_removes_empty_review_state_file() {
     assert!(!project_dir.join(".winsmux").join("review-state.json").exists());
     let _ = std::fs::remove_dir_all(project_dir);
 }
+
+#[test]
+fn shell_prompt_ready_accepts_unwrapped_powershell_prompt() {
+    assert!(shell_prompt_ready("PS C:\\repo>"));
+    assert!(shell_prompt_ready("PS /home/user>"));
+}
+
+#[test]
+fn shell_prompt_ready_accepts_wrapped_powershell_prompt() {
+    let wrapped = "PS C:\\Users\\Administrator\\Documents\\winsmux-o\nrchestra>";
+    assert!(shell_prompt_ready(wrapped));
+    let wrapped_gt = "PS C:\\very\\long\\path\\winsmux-orchestra\n>";
+    assert!(shell_prompt_ready(wrapped_gt));
+}
+
+#[test]
+fn shell_prompt_ready_rejects_copyright_banner_and_busy_output() {
+    let banner = concat!(
+        "PowerShell 7.5.4\n",
+        "Copyright (c) Microsoft Corporation.\n",
+        "https://aka.ms/powershell\n",
+        "Type 'help' to get help."
+    );
+    assert!(!shell_prompt_ready(banner));
+    let busy = "PS C:\\repo> pwsh -NoProfile -File launch.ps1\nrunning bootstrap";
+    assert!(!shell_prompt_ready(busy));
+}

--- a/install.ps1
+++ b/install.ps1
@@ -242,6 +242,9 @@ function Write-InstallProfileManifest {
 
 function Install-CoreSupportScripts {
     Download-File "winsmux-core/scripts/json-compat.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "json-compat.ps1")
+    # winsmux-core.ps1 calls Test-PaneContainsCommandFragment / Test-ShellPromptText
+    # on every profile, including core and security.
+    Download-File "winsmux-core/scripts/pane-dispatch-detect.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "pane-dispatch-detect.ps1")
     Download-OptionalFile "winsmux-core/scripts/control-plane-workers.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "control-plane-workers.ps1")
     Download-OptionalFile "winsmux-core/scripts/control-plane-ledger.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "control-plane-ledger.ps1")
 }
@@ -280,7 +283,6 @@ function Install-OrchestraSupportScripts {
     Download-File "winsmux-core/scripts/orchestra-layout.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "orchestra-layout.ps1")
     Download-File "winsmux-core/scripts/orchestra-ui-attach.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "orchestra-ui-attach.ps1")
     Download-File "winsmux-core/scripts/pane-control.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "pane-control.ps1")
-    Download-File "winsmux-core/scripts/pane-dispatch-detect.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "pane-dispatch-detect.ps1")
     Download-File "winsmux-core/scripts/pane-env.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "pane-env.ps1")
     Download-File "winsmux-core/scripts/pane-border.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "pane-border.ps1")
     Download-File "winsmux-core/scripts/pane-status.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "pane-status.ps1")
@@ -342,7 +344,6 @@ function Remove-ProfileExcludedSupportScripts {
                 "orchestra-layout.ps1",
                 "orchestra-ui-attach.ps1",
                 "pane-control.ps1",
-                "pane-dispatch-detect.ps1",
                 "pane-env.ps1",
                 "pane-border.ps1",
                 "pane-status.ps1",

--- a/install.ps1
+++ b/install.ps1
@@ -280,6 +280,7 @@ function Install-OrchestraSupportScripts {
     Download-File "winsmux-core/scripts/orchestra-layout.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "orchestra-layout.ps1")
     Download-File "winsmux-core/scripts/orchestra-ui-attach.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "orchestra-ui-attach.ps1")
     Download-File "winsmux-core/scripts/pane-control.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "pane-control.ps1")
+    Download-File "winsmux-core/scripts/pane-dispatch-detect.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "pane-dispatch-detect.ps1")
     Download-File "winsmux-core/scripts/pane-env.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "pane-env.ps1")
     Download-File "winsmux-core/scripts/pane-border.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "pane-border.ps1")
     Download-File "winsmux-core/scripts/pane-status.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "pane-status.ps1")
@@ -341,6 +342,7 @@ function Remove-ProfileExcludedSupportScripts {
                 "orchestra-layout.ps1",
                 "orchestra-ui-attach.ps1",
                 "pane-control.ps1",
+                "pane-dispatch-detect.ps1",
                 "pane-env.ps1",
                 "pane-border.ps1",
                 "pane-status.ps1",

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -79,6 +79,7 @@ $SubmissionContractScript = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRo
 $ControlPlaneCommandsScript = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\winsmux-core\scripts\control-plane-commands.ps1'))
 $ControlPlaneWorkersScript = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\winsmux-core\scripts\control-plane-workers.ps1'))
 $ControlPlaneLedgerScript = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\winsmux-core\scripts\control-plane-ledger.ps1'))
+$PaneDispatchDetectScript = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\winsmux-core\scripts\pane-dispatch-detect.ps1'))
 
 # Adapter module owns external script calls: github-write-preflight.ps1, dispatch-router.ps1,
 # task-splitter.ps1, team-pipeline.ps1, builder-queue.ps1, orchestra-smoke.ps1,
@@ -147,6 +148,10 @@ if (Test-Path $ControlPlaneWorkersScript -PathType Leaf) {
 
 if (Test-Path $ControlPlaneLedgerScript -PathType Leaf) {
     . $ControlPlaneLedgerScript
+}
+
+if (Test-Path $PaneDispatchDetectScript -PathType Leaf) {
+    . $PaneDispatchDetectScript
 }
 
 # --- Windows Credential Manager P/Invoke ---
@@ -3392,28 +3397,6 @@ function Split-SendKeysLiteralChunks {
     return @($chunks)
 }
 
-function Test-PaneContainsCommandFragment {
-    param(
-        [AllowEmptyString()][string]$PaneText,
-        [AllowEmptyString()][string]$CommandText,
-        [ValidateRange(8, 256)][int]$FragmentLength = 64
-    )
-
-    if ([string]::IsNullOrWhiteSpace($PaneText) -or [string]::IsNullOrWhiteSpace($CommandText)) {
-        return $false
-    }
-
-    $normalizedPaneText = (($PaneText -replace '\s+', '')).ToLowerInvariant()
-    $normalizedCommandText = (($CommandText -replace '\s+', '')).ToLowerInvariant()
-    if ([string]::IsNullOrWhiteSpace($normalizedPaneText) -or [string]::IsNullOrWhiteSpace($normalizedCommandText)) {
-        return $false
-    }
-
-    $effectiveLength = [Math]::Min($FragmentLength, $normalizedCommandText.Length)
-    $fragment = $normalizedCommandText.Substring([Math]::Max(0, $normalizedCommandText.Length - $effectiveLength))
-    return $normalizedPaneText.Contains($fragment)
-}
-
 function Assert-SendPaneRuntimeLease {
     param(
         [Parameter(Mandatory = $true)][string]$PaneId,
@@ -3458,6 +3441,13 @@ function Send-TextToPane {
 
     foreach ($sendTarget in $targetCandidates) {
         $preSendText = Get-PaneSnapshotText -PaneId $PaneId -Lines 200
+        if ($null -eq $preSendText) {
+            $attemptFailures.Add("target ${sendTarget}: pre-send capture failed") | Out-Null
+            continue
+        }
+        # Capture is the read. Inject the read-before-interact mark before any mutation
+        # so send cannot type into an unread pane and drop as a silent no-op.
+        Set-ReadMark $PaneId
         if ($resolvedPromptTransport -eq 'stdin') {
             Assert-SendPaneRuntimeLease -PaneId $PaneId -RuntimeProjectDir $RuntimeProjectDir `
                 -RuntimeOperation $RuntimeOperation -ExpectedGenerationId $ExpectedGenerationId
@@ -3910,8 +3900,7 @@ function Wait-PaneShellReady {
     $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
     while ((Get-Date) -lt $deadline) {
         $snapshot = (Invoke-WinsmuxRaw -Arguments @('capture-pane', '-t', $PaneId, '-p', '-J', '-S', '-50') 2>$null | Out-String).TrimEnd()
-        $lastLine = Get-LastNonEmptyLine $snapshot
-        if ($lastLine -and $lastLine.Trim() -match '^PS ') {
+        if (Test-ShellPromptText -Text $snapshot) {
             return
         }
 
@@ -5680,16 +5669,14 @@ function Invoke-Role {
         # Respawn pane (kills current process + restarts shell in one step, #174)
         Invoke-WinsmuxRaw -Arguments @('respawn-pane', '-k', '-t', $paneId, '-c', $launchDir)
 
-        # Wait for shell ready (poll for PS prompt)
-        $deadline = (Get-Date).AddSeconds(15)
-        while ((Get-Date) -lt $deadline) {
-            $snapshot = (Invoke-WinsmuxRaw -Arguments @('capture-pane', '-t', $paneId, '-p') 2>$null | Out-String).TrimEnd()
-            $lastLine = ($snapshot -split "`n" | Where-Object { $_.Trim() } | Select-Object -Last 1)
-            if ($lastLine -and $lastLine.Trim() -match '^PS ') { break }
-            Start-Sleep -Milliseconds 500
-        }
+        Wait-PaneShellReady -PaneId $paneId
 
         Invoke-WinsmuxRaw -Arguments @('send-keys', '-t', $paneId, '-l', $launchCmd)
+        Start-Sleep -Milliseconds 300
+        $typedText = Get-PaneSnapshotText -PaneId $paneId -Lines 200
+        if (-not (Test-PaneContainsCommandFragment -PaneText $typedText -CommandText $launchCmd)) {
+            Stop-WithError "failed to send launch command to ${paneId}: typed command fragment was not observed"
+        }
         Invoke-WinsmuxRaw -Arguments @('send-keys', '-t', $paneId, 'Enter')
     } finally {
         if (-not [string]::IsNullOrWhiteSpace($sessionName)) {

--- a/tests/AgentReadiness.Tests.ps1
+++ b/tests/AgentReadiness.Tests.ps1
@@ -222,12 +222,14 @@ Describe 'dispatch pane echo and shell prompt detection' {
 
     It 'matches long task text when wrap decorations split the suffix' {
         $task = 'Implement TASK-833 operator dispatch path reliability for wrap-tolerant echo matching and shell prompt detection across startup commands and task text.'
-        $suffix = $task.Substring($task.Length - 70)
-        $pane = @(
-            '> Implement TASK-833 operator dispatch path reliability'
-            "> $($suffix.Substring(0, 20))"
-            "> $($suffix.Substring(20))"
-        ) -join "`n"
+        $raw = '> ' + $task
+        $lines = [System.Collections.Generic.List[string]]::new()
+        while ($raw.Length -gt 42) {
+            $lines.Add($raw.Substring(0, 42)) | Out-Null
+            $raw = '> ' + $raw.Substring(42)
+        }
+        $lines.Add($raw) | Out-Null
+        $pane = $lines -join "`n"
         Test-PaneContainsCommandFragment -PaneText $pane -CommandText $task | Should -BeTrue
     }
 }

--- a/tests/AgentReadiness.Tests.ps1
+++ b/tests/AgentReadiness.Tests.ps1
@@ -160,3 +160,74 @@ Describe 'agent readiness prompt detection' {
         }
     }
 }
+
+Describe 'dispatch pane echo and shell prompt detection' {
+    BeforeAll {
+        . (Join-Path (Split-Path -Parent $PSScriptRoot) 'winsmux-core\scripts\pane-dispatch-detect.ps1')
+    }
+
+    It 'accepts an unwrapped PowerShell prompt' {
+        Test-ShellPromptText -Text 'PS C:\repo>' | Should -BeTrue
+        Test-ShellPromptText -Text 'PS /home/user>' | Should -BeTrue
+    }
+
+    It 'accepts a ConPTY-wrapped PowerShell prompt split across lines' {
+        $wrapped = @(
+            'PS C:\Users\Administrator\Documents\winsmux-o'
+            'rchestra>'
+        ) -join "`n"
+        Test-ShellPromptText -Text $wrapped | Should -BeTrue
+    }
+
+    It 'accepts a wrapped prompt whose last visible line is only >' {
+        $wrapped = @(
+            'PS C:\very\long\path\winsmux-orchestra'
+            '>'
+        ) -join "`n"
+        Test-ShellPromptText -Text $wrapped | Should -BeTrue
+    }
+
+    It 'rejects a copyright banner before the shell prompt exists' {
+        $banner = @(
+            'PowerShell 7.5.4'
+            'Copyright (c) Microsoft Corporation.'
+            'https://aka.ms/powershell'
+            "Type 'help' to get help."
+        ) -join "`n"
+        Test-ShellPromptText -Text $banner | Should -BeFalse
+    }
+
+    It 'rejects a busy pane whose last line is not a prompt' {
+        $busy = @(
+            'PS C:\repo> pwsh -NoProfile -File C:\repo\winsmux-core\scripts\orchestra-pane-bootstrap.ps1'
+            'running bootstrap'
+        ) -join "`n"
+        Test-ShellPromptText -Text $busy | Should -BeFalse
+    }
+
+    It 'matches a wrapped long startup command with line-leading prompt decorations' {
+        $command = 'pwsh -NoProfile -File C:\Users\Administrator\Documents\winsmux-orchestra\winsmux-core\scripts\orchestra-pane-bootstrap.ps1 -PlanFile C:\Users\Administrator\Documents\winsmux-orchestra\.winsmux\orchestra-bootstrap\%2.json'
+        $pane = @(
+            'PS C:\Users\Administrator\Documents\winsmux-orchestra> pwsh -NoProfile -File C:\Users\Administrator\Documents\winsmux-o'
+            '> rchestra\winsmux-core\scripts\orchestra-pane-bootstrap.ps1 -PlanFile C:\Users\Administrator\Documents\winsmux-orchestra\.winsmux\orchestra-bootstrap\%2.json'
+        ) -join "`n"
+        Test-PaneContainsCommandFragment -PaneText $pane -CommandText $command | Should -BeTrue
+    }
+
+    It 'matches long task text when only the prefix is visible in the TUI' {
+        $task = 'Implement TASK-833 operator dispatch path reliability for wrap-tolerant echo matching and shell prompt detection across startup commands and task text.'
+        $pane = '> ' + $task.Substring(0, 72)
+        Test-PaneContainsCommandFragment -PaneText $pane -CommandText $task | Should -BeTrue
+    }
+
+    It 'matches long task text when wrap decorations split the suffix' {
+        $task = 'Implement TASK-833 operator dispatch path reliability for wrap-tolerant echo matching and shell prompt detection across startup commands and task text.'
+        $suffix = $task.Substring($task.Length - 70)
+        $pane = @(
+            '> Implement TASK-833 operator dispatch path reliability'
+            "> $($suffix.Substring(0, 20))"
+            "> $($suffix.Substring(20))"
+        ) -join "`n"
+        Test-PaneContainsCommandFragment -PaneText $pane -CommandText $task | Should -BeTrue
+    }
+}

--- a/tests/PublicSurfacePolicy.Tests.ps1
+++ b/tests/PublicSurfacePolicy.Tests.ps1
@@ -213,6 +213,7 @@ Describe 'Public surface policy' {
         $coreSupportFiles.Groups['files'].Value | Should -Match 'Download-OptionalFile'
         $coreSupportFiles.Groups['files'].Value | Should -Not -Match 'Download-File "winsmux-core/scripts/control-plane-workers\.ps1"'
         $coreSupportFiles.Groups['files'].Value | Should -Not -Match 'Download-File "winsmux-core/scripts/control-plane-ledger\.ps1"'
+        $coreSupportFiles.Groups['files'].Value | Should -Match 'Download-File "winsmux-core/scripts/pane-dispatch-detect\.ps1"'
         $installer | Should -Match 'winsmux-core/scripts/orchestra-smoke\.ps1'
         $installer | Should -Match 'winsmux-core/scripts/doctor\.ps1'
         $installer | Should -Match 'winsmux-core/scripts/orchestra-attach-confirm\.ps1'
@@ -232,6 +233,7 @@ Describe 'Public surface policy' {
         $orchestrationRemovalFiles.Success | Should -BeTrue
         $orchestrationRemovalFiles.Groups['files'].Value | Should -Not -Match '"control-plane-workers\.ps1"'
         $orchestrationRemovalFiles.Groups['files'].Value | Should -Not -Match '"control-plane-ledger\.ps1"'
+        $orchestrationRemovalFiles.Groups['files'].Value | Should -Not -Match '"pane-dispatch-detect\.ps1"'
     }
 
     It 'keeps public install and OAuth wording aligned with the current policy' {

--- a/tests/PublicSurfacePolicy.Tests.ps1
+++ b/tests/PublicSurfacePolicy.Tests.ps1
@@ -219,6 +219,7 @@ Describe 'Public surface policy' {
         $installer | Should -Match 'winsmux-core/scripts/orchestra-pane-bootstrap\.ps1'
         $installer | Should -Match 'winsmux-core/scripts/operator-poll\.ps1'
         $installer | Should -Match 'winsmux-core/scripts/pane-control\.ps1'
+        $installer | Should -Match 'winsmux-core/scripts/pane-dispatch-detect\.ps1'
         $installer | Should -Match 'winsmux-core/scripts/agent-monitor\.ps1'
         $installer | Should -Match 'winsmux-core/scripts/agent-watchdog\.ps1'
         $installer | Should -Match 'winsmux-core/scripts/orchestra-state\.ps1'

--- a/tests/bridge/AgentOrchestra.Tests.ps1
+++ b/tests/bridge/AgentOrchestra.Tests.ps1
@@ -2852,8 +2852,18 @@ Describe 'orchestra-start rollback helpers' {
     }
 
     It 'delivers launch commands in-process without public bridge argv' {
-        Mock Invoke-Winsmux { }
+        $script:launchCaptureCount = 0
+        Mock Invoke-Winsmux {
+            if ($Arguments[0] -eq 'capture-pane') {
+                $script:launchCaptureCount += 1
+                if ($script:launchCaptureCount -eq 1) {
+                    return 'PS C:\repo>'
+                }
+                return 'PS C:\repo> pwsh -NoProfile -File bootstrap.ps1'
+            }
+        }
         Mock Invoke-Bridge { throw 'launch delivery must not use public bridge argv' }
+        Mock Start-Sleep { }
 
         Send-OrchestraBridgeCommand `
             -Target '%2' `
@@ -2862,6 +2872,12 @@ Describe 'orchestra-start rollback helpers' {
             -SessionName 'winsmux-orchestra'
 
         Should -Invoke Invoke-Bridge -Times 0 -Exactly
+        Should -Invoke Invoke-Winsmux -Times 2 -Exactly -ParameterFilter {
+            $Arguments[0] -eq 'capture-pane' -and
+            $Arguments[1] -eq '-t' -and
+            $Arguments[2] -eq '%2' -and
+            $TargetSessionName -eq 'winsmux-orchestra'
+        }
         Should -Invoke Invoke-Winsmux -Times 1 -Exactly -ParameterFilter {
             @($Arguments) -join '|' -eq 'send-keys|-t|%2|-l|--|pwsh -NoProfile -File bootstrap.ps1' -and
             $TargetSessionName -eq 'winsmux-orchestra'
@@ -2869,6 +2885,28 @@ Describe 'orchestra-start rollback helpers' {
         Should -Invoke Invoke-Winsmux -Times 1 -Exactly -ParameterFilter {
             @($Arguments) -join '|' -eq 'send-keys|-t|%2|Enter' -and
             $TargetSessionName -eq 'winsmux-orchestra'
+        }
+    }
+
+    It 'fails closed when launch echo fragment is not observed' {
+        Mock Invoke-Winsmux {
+            if ($Arguments[0] -eq 'capture-pane') {
+                return 'PS C:\repo>'
+            }
+        }
+        Mock Invoke-Bridge { throw 'launch delivery must not use public bridge argv' }
+        Mock Start-Sleep { }
+
+        {
+            Send-OrchestraBridgeCommand `
+                -Target '%2' `
+                -Text 'pwsh -NoProfile -File bootstrap.ps1' `
+                -DeliveryClass 'launch' `
+                -SessionName 'winsmux-orchestra'
+        } | Should -Throw '*launch command fragment was not observed*'
+
+        Should -Invoke Invoke-Winsmux -Times 0 -Exactly -ParameterFilter {
+            @($Arguments) -join '|' -eq 'send-keys|-t|%2|Enter'
         }
     }
 

--- a/tests/bridge/ArtifactsRuntime.Tests.ps1
+++ b/tests/bridge/ArtifactsRuntime.Tests.ps1
@@ -3157,6 +3157,96 @@ Describe 'winsmux send fallback' {
         $script:sendAttempts | Should -Be @('%7 paste', 'default:0.3 paste', 'default:0.3 Enter')
     }
 
+    It 'TASK833 injects the read-before-interact mark before the first send-keys' {
+        $script:protocolTrace = [System.Collections.Generic.List[string]]::new()
+        $script:snapshotCount = 0
+        Mock Resolve-TerminalBackend { 'tauri' }
+        Mock Split-SendKeysLiteralChunks { @('echo test') }
+        Mock Get-PaneSnapshotText {
+            $script:snapshotCount++
+            switch ($script:snapshotCount) {
+                1 { return 'PS C:\repo> ' }
+                2 { return 'PS C:\repo> echo test' }
+                default { return "PS C:\repo> echo test`nresult" }
+            }
+        }
+        Mock Assert-SendPaneRuntimeLease { }
+        Mock Set-ReadMark { $script:protocolTrace.Add('read-mark') | Out-Null }
+        Mock Invoke-WinsmuxSendKeys {
+            $script:protocolTrace.Add('send-keys') | Out-Null
+            [PSCustomObject]@{ ExitCode = 0; Output = '' }
+        }
+        Mock Save-Watermark { }
+
+        $result = Send-TextToPane -PaneId '%7' -CommandText 'echo test'
+        $result | Should -Be 'sent to %7 via %7'
+        $script:protocolTrace[0] | Should -Be 'read-mark'
+        ($script:protocolTrace.IndexOf('read-mark')) | Should -BeLessThan ($script:protocolTrace.IndexOf('send-keys'))
+    }
+
+    It 'TASK833 fails closed when pre-send capture returns null' {
+        Mock Resolve-TerminalBackend { 'tauri' }
+        Mock Get-PaneSnapshotText { $null }
+        Mock Stop-WithError { param([string]$Message) throw $Message }
+        Mock Set-ReadMark { throw 'read mark must not be set after failed capture' }
+        Mock Invoke-WinsmuxSendKeys { throw 'send-keys must not run after failed capture' }
+
+        { Send-TextToPane -PaneId '%7' -CommandText 'echo test' } |
+            Should -Throw '*pre-send capture failed*'
+    }
+
+    It 'TASK833 observes a wrapped startup command echo before Enter' {
+        $launch = 'pwsh -NoProfile -File C:\Users\Administrator\Documents\winsmux-orchestra\winsmux-core\scripts\orchestra-pane-bootstrap.ps1 -PlanFile C:\Users\Administrator\Documents\winsmux-orchestra\.winsmux\orchestra-bootstrap\%2.json'
+        $wrapped = @(
+            'PS C:\Users\Administrator\Documents\winsmux-orchestra> pwsh -NoProfile -File C:\Users\Administrator\Documents\winsmux-o'
+            '> rchestra\winsmux-core\scripts\orchestra-pane-bootstrap.ps1 -PlanFile C:\Users\Administrator\Documents\winsmux-orchestra\.winsmux\orchestra-bootstrap\%2.json'
+        ) -join "`n"
+        $script:snapshotCount = 0
+        Mock Resolve-TerminalBackend { 'tauri' }
+        Mock Split-SendKeysLiteralChunks { @($launch) }
+        Mock Get-PaneSnapshotText {
+            $script:snapshotCount++
+            switch ($script:snapshotCount) {
+                1 { return 'PS C:\Users\Administrator\Documents\winsmux-orchestra>' }
+                2 { return $wrapped }
+                default { return "$wrapped`nstarting" }
+            }
+        }
+        Mock Assert-SendPaneRuntimeLease { }
+        Mock Invoke-WinsmuxSendKeys { [PSCustomObject]@{ ExitCode = 0; Output = '' } }
+        Mock Save-Watermark { }
+        Mock Set-ReadMark { }
+
+        Send-TextToPane -PaneId '%7' -CommandText $launch | Should -Be 'sent to %7 via %7'
+        Should -Invoke Invoke-WinsmuxSendKeys -Times 1 -Exactly -ParameterFilter {
+            -not $Literal -and [string]$Keys[0] -ceq 'Enter'
+        }
+    }
+
+    It 'TASK833 observes wrapped task text when only the prefix is captured' {
+        $task = 'Implement TASK-833 operator dispatch path reliability for wrap-tolerant echo matching and shell prompt detection across startup commands and task text.'
+        $script:snapshotCount = 0
+        Mock Resolve-TerminalBackend { 'tauri' }
+        Mock Split-SendKeysLiteralChunks { @($task) }
+        Mock Get-PaneSnapshotText {
+            $script:snapshotCount++
+            switch ($script:snapshotCount) {
+                1 { return '> ' }
+                2 { return ('> ' + $task.Substring(0, 72)) }
+                default { return ('> ' + $task.Substring(0, 72) + "`nsubmitted") }
+            }
+        }
+        Mock Assert-SendPaneRuntimeLease { }
+        Mock Invoke-WinsmuxSendKeys { [PSCustomObject]@{ ExitCode = 0; Output = '' } }
+        Mock Save-Watermark { }
+        Mock Set-ReadMark { }
+
+        Send-TextToPane -PaneId '%7' -CommandText $task | Should -Be 'sent to %7 via %7'
+        Should -Invoke Invoke-WinsmuxSendKeys -Times 1 -Exactly -ParameterFilter {
+            -not $Literal -and [string]$Keys[0] -ceq 'Enter'
+        }
+    }
+
 }
 
 Describe 'watermark helpers' {

--- a/winsmux-app/index.html
+++ b/winsmux-app/index.html
@@ -547,6 +547,14 @@
                       <span id="voice-draft-storage-toggle-label">Save long voice drafts locally</span>
                     </label>
                   </div>
+                  <div class="settings-field settings-field-wide context-label-sub">
+                    <label class="settings-field-label" id="direct-worker-pane-input-label" for="direct-worker-pane-input">Direct Worker Pane Input</label>
+                    <div class="settings-field-description" id="direct-worker-pane-input-description">Worker panes stay read-only by default. When on, typing and paste reach the focused worker pane. Operator dispatch is unchanged.</div>
+                    <label class="settings-checkbox-control">
+                      <input id="direct-worker-pane-input" type="checkbox" />
+                      <span id="direct-worker-pane-input-toggle-label">Allow typing and paste into worker panes</span>
+                    </label>
+                  </div>
                 </section>
               </div>
             </div>

--- a/winsmux-app/package.json
+++ b/winsmux-app/package.json
@@ -32,6 +32,7 @@
     "test:project-explorer-tree": "node ./scripts/project-explorer-tree-check.mjs",
     "test:settings-preference-options": "node --experimental-strip-types ./scripts/settings-preference-options-check.mjs",
     "test:worker-pane-routing": "node ./scripts/worker-pane-routing-check.mjs",
+    "test:worker-pane-input": "node ./scripts/worker-pane-input-check.mjs",
     "test:worker-readiness-prompt": "node ./scripts/worker-readiness-prompt-check.mjs",
     "generate:common-contract-bindings": "node ./scripts/generate-common-contract-bindings.mjs",
     "test:common-contract-package": "node ./scripts/generate-common-contract-bindings.mjs --check && node ./scripts/common-contract-package-check.mjs",

--- a/winsmux-app/scripts/clickable-coverage-harness.mjs
+++ b/winsmux-app/scripts/clickable-coverage-harness.mjs
@@ -811,6 +811,11 @@ async function testSettings(page) {
   recordClick("settings voice draft checkbox on");
   await page.locator("#voice-draft-storage-input").uncheck();
   recordClick("settings voice draft checkbox off");
+  await page.locator("#direct-worker-pane-input").scrollIntoViewIfNeeded();
+  await page.locator("#direct-worker-pane-input").check();
+  recordClick("settings direct worker pane input checkbox on");
+  await page.locator("#direct-worker-pane-input").uncheck();
+  recordClick("settings direct worker pane input checkbox off");
   await clickSelector(page, "#apply-settings-btn", "settings apply");
   await clickSelector(page, "#close-settings-btn", "settings close");
 }

--- a/winsmux-app/scripts/desktop-pane-e2e.mjs
+++ b/winsmux-app/scripts/desktop-pane-e2e.mjs
@@ -1040,6 +1040,25 @@ async function startPaneFromUiAndWaitForPrompt(page, paneId, selector) {
   await waitForPtyPrompt(page, paneId);
 }
 
+async function enableDirectWorkerPaneInputFromSettings(page) {
+  await page.click("#activity-settings-btn");
+  await page.locator("#settings-sheet").waitFor({ state: "visible", timeout: 60_000 });
+  const userTab = page.locator("#settings-tab-user");
+  if (await userTab.isVisible().catch(() => false)) {
+    await userTab.click();
+  }
+  const inputNav = page.locator("#settings-nav-security");
+  if (await inputNav.isVisible().catch(() => false)) {
+    await inputNav.click();
+  }
+  const checkbox = page.locator("#direct-worker-pane-input");
+  await checkbox.scrollIntoViewIfNeeded();
+  await checkbox.check();
+  await page.click("#apply-settings-btn");
+  await page.click("#close-settings-btn");
+  await page.locator("#settings-sheet").waitFor({ state: "hidden", timeout: 60_000 });
+}
+
 function escapePwshSingleQuoted(value) {
   return value.replace(/'/g, "''");
 }
@@ -3027,6 +3046,7 @@ async function main() {
 
     await runStep("worker pane starts from real UI typing", async () => {
       await setWorkbenchLayout(page, "3x2");
+      await enableDirectWorkerPaneInputFromSettings(page);
       await startPaneFromUiAndWaitForPrompt(page, "worker-1", "#pane-worker-1 .pane-terminal");
       await typeIntoTerminal(page, "#pane-worker-1 .pane-terminal", `Write-Output '${WORKER_UI_MARKER}'`);
       const output = await waitForPtyOutputLine(page, "worker-1", WORKER_UI_MARKER);
@@ -3190,6 +3210,7 @@ async function main() {
     });
 
     await runStep("worker terminal keeps shortcuts, arrows, and paste in the PTY", async () => {
+      await enableDirectWorkerPaneInputFromSettings(page);
       const terminalSelector = "#pane-worker-1 .pane-terminal";
       await page.click(terminalSelector, { timeout: 10_000 });
       await page.keyboard.press("Control+K");

--- a/winsmux-app/scripts/worker-pane-input-check.mjs
+++ b/winsmux-app/scripts/worker-pane-input-check.mjs
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import ts from "typescript";
+
+async function loadWorkerPaneInputModule() {
+  const sourcePath = path.resolve("src/workerPaneInput.ts");
+  const source = await readFile(sourcePath, "utf8");
+  const transpiled = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.ESNext,
+      target: ts.ScriptTarget.ES2020,
+    },
+    fileName: sourcePath,
+  });
+
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "winsmux-worker-pane-input-"));
+  const modulePath = path.join(tempDir, "workerPaneInput.mjs");
+  await writeFile(modulePath, transpiled.outputText, "utf8");
+
+  try {
+    return await import(pathToFileURL(modulePath).href);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+const {
+  isDirectWorkerPaneInputEnabled,
+  shouldForwardWorkerPaneInput,
+} = await loadWorkerPaneInputModule();
+
+assert.equal(isDirectWorkerPaneInputEnabled(undefined), false);
+assert.equal(isDirectWorkerPaneInputEnabled(null), false);
+assert.equal(isDirectWorkerPaneInputEnabled(false), false);
+assert.equal(isDirectWorkerPaneInputEnabled("true"), false);
+assert.equal(isDirectWorkerPaneInputEnabled(true), true);
+
+assert.equal(shouldForwardWorkerPaneInput("user", undefined), false);
+assert.equal(shouldForwardWorkerPaneInput("user", false), false);
+assert.equal(shouldForwardWorkerPaneInput("user", true), true);
+assert.equal(shouldForwardWorkerPaneInput("dispatch", undefined), true);
+assert.equal(shouldForwardWorkerPaneInput("dispatch", false), true);
+assert.equal(shouldForwardWorkerPaneInput("dispatch", true), true);
+
+console.log("worker-pane-input-check: ok");

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -89,6 +89,7 @@ import {
   selectConfiguredWorkerStartRoster,
 } from "./workerStartPlanning";
 import { hasWorkerReadyPromptInAnySource } from "./workerReadinessPrompt";
+import { isDirectWorkerPaneInputEnabled, shouldForwardWorkerPaneInput } from "./workerPaneInput";
 import {
   DesktopSummaryRefreshScheduler,
   type DesktopSummaryRefreshContext,
@@ -408,6 +409,7 @@ interface ThemeState {
   editorFontSize: number;
   voiceShortcut: string;
   persistVoiceDraftLocally: boolean;
+  directWorkerPaneInput: boolean;
   focusMode: FocusMode;
   language: LanguageMode;
 }
@@ -891,6 +893,7 @@ const themeState: ThemeState = {
   editorFontSize: DEFAULT_EDITOR_FONT_SIZE,
   voiceShortcut: DEFAULT_VOICE_SHORTCUT,
   persistVoiceDraftLocally: false,
+  directWorkerPaneInput: false,
   focusMode: "standard",
   language: "en",
 };
@@ -1918,6 +1921,10 @@ function createPane(paneId?: string, options?: { deferWorkbenchUpdate?: boolean 
   meta.className = "pane-meta";
   meta.textContent = getLanguageText("No branch · waiting for summary", "ブランチなし・要約待ち");
 
+  const directInputBadge = document.createElement("span");
+  directInputBadge.className = "pane-direct-input-badge";
+  directInputBadge.hidden = true;
+
   const closeBtn = document.createElement("button");
   closeBtn.className = "pane-close";
   closeBtn.textContent = "×";
@@ -1925,6 +1932,7 @@ function createPane(paneId?: string, options?: { deferWorkbenchUpdate?: boolean 
 
   labelGroup.appendChild(label);
   labelGroup.appendChild(meta);
+  labelGroup.appendChild(directInputBadge);
   header.appendChild(labelGroup);
   header.appendChild(closeBtn);
 
@@ -1943,7 +1951,12 @@ function createPane(paneId?: string, options?: { deferWorkbenchUpdate?: boolean 
   terminal.open(termDiv);
 
   terminal.onData((data: string) => {
-    void ensurePanePtyStarted(id).then(() => writePtyData(id, data)).catch((error) => {
+    void ensurePanePtyStarted(id).then(() => {
+      if (!shouldForwardWorkerPaneInput("user", themeState.directWorkerPaneInput)) {
+        return;
+      }
+      return writePtyData(id, data);
+    }).catch((error) => {
       console.warn("Failed to write PTY data", error);
     });
   });
@@ -1978,6 +1991,8 @@ function createPane(paneId?: string, options?: { deferWorkbenchUpdate?: boolean 
     updateWorkbenchControls();
     scheduleWorkbenchPaneFit();
   }
+
+  applyWorkerPaneDirectInputState();
 
   if (shouldAutoStartPane(id)) {
     void ensurePanePtyStarted(id);
@@ -9707,6 +9722,7 @@ function cloneThemeState(state: ThemeState): ThemeState {
     editorFontSize: state.editorFontSize,
     voiceShortcut: state.voiceShortcut,
     persistVoiceDraftLocally: state.persistVoiceDraftLocally,
+    directWorkerPaneInput: state.directWorkerPaneInput === true,
     focusMode: state.focusMode,
     language: state.language,
   };
@@ -9721,6 +9737,7 @@ function themeStatesEqual(left: ThemeState, right: ThemeState) {
     && left.editorFontSize === right.editorFontSize
     && left.voiceShortcut === right.voiceShortcut
     && left.persistVoiceDraftLocally === right.persistVoiceDraftLocally
+    && left.directWorkerPaneInput === right.directWorkerPaneInput
     && left.focusMode === right.focusMode
     && left.language === right.language;
 }
@@ -9983,6 +10000,7 @@ function readStoredShellPreferences(): ShellPreferenceState | null {
     const editorFontSize = clampEditorFontSize(parsedEditorFontSize);
     const voiceShortcut = normalizeVoiceShortcut(parsed.voiceShortcut);
     const persistVoiceDraftLocally = parsed.persistVoiceDraftLocally === true;
+    const directWorkerPaneInput = parsed.directWorkerPaneInput === true;
     const focusMode = focusModeOptions.find((item) => item.value === parsed.focusMode)?.value ?? "standard";
     const language = languageOptions.find((item) => item.value === parsed.language)?.value ?? "en";
     if (!theme || !density || !wrapMode) {
@@ -10017,6 +10035,7 @@ function readStoredShellPreferences(): ShellPreferenceState | null {
       editorFontSize,
       voiceShortcut,
       persistVoiceDraftLocally,
+      directWorkerPaneInput,
       focusMode,
       language,
       sidebarWidth: Math.max(MIN_SIDEBAR_WIDTH, Math.min(MAX_SIDEBAR_WIDTH, Math.round(normalizedSidebarWidth))),
@@ -10046,6 +10065,7 @@ function persistThemeState() {
       editorFontSize: themeState.editorFontSize,
       voiceShortcut: normalizeVoiceShortcut(themeState.voiceShortcut),
       persistVoiceDraftLocally: themeState.persistVoiceDraftLocally,
+      directWorkerPaneInput: themeState.directWorkerPaneInput === true,
       focusMode: themeState.focusMode,
       language: themeState.language,
       sidebarWidth,
@@ -10326,6 +10346,14 @@ function applyLanguageChrome() {
       : "Keeps a text-only recovery copy for long voice drafts on this device. Raw audio is never stored.",
   );
   setElementText("voice-draft-storage-toggle-label", japanese ? "長時間の音声下書きをローカルに保存" : "Save long voice drafts locally");
+  setElementText("direct-worker-pane-input-label", japanese ? "ワーカーペインへの直接入力" : "Direct Worker Pane Input");
+  setElementText(
+    "direct-worker-pane-input-description",
+    japanese
+      ? "既定ではワーカーペインは表示専用です。オンにすると、フォーカス中のワーカーペインへ直接入力・貼り付けできます。オペレーターからの dispatch には影響しません。"
+      : "Worker panes stay read-only by default. When on, typing and paste reach the focused worker pane. Operator dispatch is unchanged.",
+  );
+  setElementText("direct-worker-pane-input-toggle-label", japanese ? "ワーカーペインへ直接入力する" : "Allow typing and paste into worker panes");
   setSelectorText(".brand-block .sidebar-caption", japanese ? "オペレーターシェル" : "Operator shell");
   setSelectorText('[data-i18n="sessions-title"]', japanese ? "セッション" : "Sessions");
   setSelectorText('[data-i18n="files-title"]', japanese ? "ファイル" : "Files");
@@ -10402,6 +10430,7 @@ function applyLanguageChrome() {
   if (sourceControlMessage) {
     sourceControlMessage.placeholder = japanese ? "コミットメッセージ" : "Commit message";
   }
+  applyWorkerPaneDirectInputState();
 }
 
 function applyThemeState(nextState: ThemeState) {
@@ -10416,6 +10445,7 @@ function applyThemeState(nextState: ThemeState) {
   if (!themeState.persistVoiceDraftLocally) {
     clearVoiceDraftRecoveryStorage();
   }
+  themeState.directWorkerPaneInput = nextState.directWorkerPaneInput === true;
   themeState.focusMode = nextState.focusMode;
   themeState.language = nextState.language;
   applyShellPreferences();
@@ -10442,6 +10472,22 @@ function applyThemeState(nextState: ThemeState) {
   renderCommandBar();
   renderSettingsControls();
   renderFooterLane();
+  applyWorkerPaneDirectInputState();
+}
+
+function applyWorkerPaneDirectInputState(state: ThemeState = themeState) {
+  const enabled = isDirectWorkerPaneInputEnabled(state.directWorkerPaneInput);
+  const badgeText = state.language === "ja" ? "直接入力" : "Direct input";
+  panes.forEach((pane) => {
+    pane.terminal.options.disableStdin = !enabled;
+    pane.container.classList.toggle("pane-direct-input", enabled);
+    pane.container.dataset.directInput = enabled ? "on" : "off";
+    const badge = pane.container.querySelector(".pane-direct-input-badge");
+    if (badge instanceof HTMLElement) {
+      badge.hidden = !enabled;
+      badge.textContent = badgeText;
+    }
+  });
 }
 
 function applyCodeFontToPanes(state: ThemeState = themeState) {
@@ -10651,6 +10697,20 @@ function updateVoiceDraftStorageControl(activeState: ThemeState) {
   input.onchange = () => {
     const draft = getSettingsDraftState();
     draft.persistVoiceDraftLocally = input.checked;
+    updateSettingsApplyButton();
+    renderFooterLane();
+  };
+}
+
+function updateDirectWorkerPaneInputControl(activeState: ThemeState) {
+  const input = document.getElementById("direct-worker-pane-input") as HTMLInputElement | null;
+  if (!input) {
+    return;
+  }
+  input.checked = isDirectWorkerPaneInputEnabled(activeState.directWorkerPaneInput);
+  input.onchange = () => {
+    const draft = getSettingsDraftState();
+    draft.directWorkerPaneInput = input.checked;
     updateSettingsApplyButton();
     renderFooterLane();
   };
@@ -12207,6 +12267,7 @@ function renderSettingsControls() {
   updateFontFamilyControl(activeState);
   updateVoiceShortcutControl(activeState);
   updateVoiceDraftStorageControl(activeState);
+  updateDirectWorkerPaneInputControl(activeState);
   renderSettingsFontFamilyMenu(activeState);
 
   renderPreferenceOptions("theme-options", themeOptions, activeState.theme, (value) => {

--- a/winsmux-app/src/styles.css
+++ b/winsmux-app/src/styles.css
@@ -5519,6 +5519,29 @@ body.is-resizing-workbench {
   text-overflow: ellipsis;
 }
 
+.pane-direct-input-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0 6px;
+  height: 16px;
+  border-radius: 999px;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  color: var(--ws-chrome-bg);
+  background: #d97706;
+  text-transform: uppercase;
+  flex-shrink: 0;
+}
+
+.pane-direct-input-badge[hidden] {
+  display: none;
+}
+
+.pane[data-direct-input="on"] {
+  box-shadow: inset 0 0 0 1px rgba(217, 119, 6, 0.55);
+}
+
 .pane-close {
   background: none;
   border: none;

--- a/winsmux-app/src/workerPaneInput.ts
+++ b/winsmux-app/src/workerPaneInput.ts
@@ -1,0 +1,13 @@
+export function isDirectWorkerPaneInputEnabled(value: unknown): boolean {
+  return value === true;
+}
+
+export function shouldForwardWorkerPaneInput(
+  source: "user" | "dispatch",
+  enabled: unknown,
+): boolean {
+  if (source === "dispatch") {
+    return true;
+  }
+  return isDirectWorkerPaneInputEnabled(enabled);
+}

--- a/winsmux-core/scripts/agent-monitor.ps1
+++ b/winsmux-core/scripts/agent-monitor.ps1
@@ -30,6 +30,7 @@ Set-StrictMode -Version Latest
 $scriptDir = $PSScriptRoot
 . "$scriptDir/settings.ps1"
 . "$scriptDir/agent-readiness.ps1"
+. "$scriptDir/pane-dispatch-detect.ps1"
 . "$scriptDir/pane-control.ps1"
 . "$scriptDir/orchestra-state.ps1"
 . "$scriptDir/clm-safe-io.ps1"
@@ -473,16 +474,7 @@ function Get-MonitorContextRemainingPercent {
 function Test-PowerShellPromptText {
     param([AllowNull()][string]$Text)
 
-    if ([string]::IsNullOrWhiteSpace($Text)) {
-        return $false
-    }
-
-    $lastLine = Get-LastNonEmptyLine -Text $Text
-    if ($null -eq $lastLine) {
-        return $false
-    }
-
-    return $lastLine.TrimStart() -match '^PS [A-Z]:\\'
+    return (Test-ShellPromptText -Text $Text)
 }
 
 function Wait-MonitorPaneShellReady {
@@ -496,7 +488,7 @@ function Wait-MonitorPaneShellReady {
         try {
             $snapshot = Invoke-MonitorWinsmux -Arguments @('capture-pane', '-t', $PaneId, '-p', '-J', '-S', '-80') -CaptureOutput
             $text = ($snapshot | Out-String).TrimEnd()
-            if ($null -ne (Get-LastNonEmptyLine -Text $text)) {
+            if (Test-ShellPromptText -Text $text) {
                 return
             }
         } catch {

--- a/winsmux-core/scripts/orchestra-start.ps1
+++ b/winsmux-core/scripts/orchestra-start.ps1
@@ -12,6 +12,7 @@ $scriptDir = $PSScriptRoot
 . "$scriptDir/builder-worktree.ps1"
 . "$scriptDir/logger.ps1"
 . "$scriptDir/agent-readiness.ps1"
+. "$scriptDir/pane-dispatch-detect.ps1"
 . "$scriptDir/orchestra-preflight.ps1"
 . "$scriptDir/manifest.ps1"
 . "$scriptDir/pane-env.ps1"
@@ -1062,10 +1063,32 @@ function Send-OrchestraBridgeCommand {
     )
 
     if ($DeliveryClass -eq 'launch') {
+        $preSendText = $null
+        try {
+            $preSendSnapshot = Invoke-Winsmux `
+                -Arguments @('capture-pane', '-t', $Target, '-p', '-J', '-S', '-80') `
+                -CaptureOutput `
+                -TargetSessionName $SessionName
+            $preSendText = ($preSendSnapshot | Out-String)
+        } catch {
+            throw "pre-send capture failed for pane $Target"
+        }
+        if ($null -eq $preSendText) {
+            throw "pre-send capture failed for pane $Target"
+        }
         foreach ($chunk in @(Split-OrchestraBridgeLiteralChunks -Text $Text)) {
             Invoke-Winsmux `
                 -Arguments @('send-keys', '-t', $Target, '-l', '--', $chunk) `
                 -TargetSessionName $SessionName
+        }
+        Start-Sleep -Milliseconds 300
+        $typedSnapshot = Invoke-Winsmux `
+            -Arguments @('capture-pane', '-t', $Target, '-p', '-J', '-S', '-80') `
+            -CaptureOutput `
+            -TargetSessionName $SessionName
+        $typedText = ($typedSnapshot | Out-String)
+        if ($typedText -eq $preSendText -or -not (Test-PaneContainsCommandFragment -PaneText $typedText -CommandText $Text)) {
+            throw "launch command fragment was not observed in pane $Target"
         }
         Invoke-Winsmux `
             -Arguments @('send-keys', '-t', $Target, 'Enter') `
@@ -1549,7 +1572,7 @@ function Wait-PaneShellReady {
         try {
             $snapshot = Invoke-Winsmux -Arguments @('capture-pane', '-t', $PaneId, '-p', '-J', '-S', '-80') -CaptureOutput -TargetSessionName $SessionName
             $text = ($snapshot | Out-String).TrimEnd()
-            if ($null -ne (Get-LastNonEmptyLine -Text $text)) {
+            if (Test-ShellPromptText -Text $text) {
                 return
             }
         } catch {

--- a/winsmux-core/scripts/pane-dispatch-detect.ps1
+++ b/winsmux-core/scripts/pane-dispatch-detect.ps1
@@ -1,0 +1,102 @@
+<#
+.SYNOPSIS
+Wrap-tolerant pane echo matching and shell-prompt detection for dispatch.
+
+.DESCRIPTION
+Narrow worker panes wrap long startup commands, task text, and the PowerShell
+prompt itself. Capture-pane -J does not join ConPTY hard wraps, so last-line
+`^PS ` checks and suffix-only echo contains checks become silent misses.
+These helpers collapse wrap seams (newlines and line-leading prompt/box
+decorations) before matching. Dot-source from the send/wait/startup paths;
+do not treat this file as a public command surface.
+#>
+
+Set-StrictMode -Version Latest
+
+function ConvertTo-DispatchEchoFingerprint {
+    param(
+        [AllowNull()][AllowEmptyString()][string]$Text,
+        [switch]$StripWrapDecorations
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Text)) {
+        return ''
+    }
+
+    $parts = [System.Collections.Generic.List[string]]::new()
+    foreach ($rawLine in @($Text -split "\r?\n")) {
+        $line = [string]$rawLine
+        if ($StripWrapDecorations) {
+            $line = $line.Trim()
+            $line = $line -replace '^[\u2500-\u259F]+', ''
+            $line = $line -replace '^[>›❯]{1,2}\s*', ''
+            $line = $line -replace '^PS\s+\S*>\s*', ''
+        }
+        $parts.Add($line) | Out-Null
+    }
+
+    return (($parts -join '') -replace '\s+', '').ToLowerInvariant()
+}
+
+function Test-PaneContainsCommandFragment {
+    param(
+        [AllowEmptyString()][string]$PaneText,
+        [AllowEmptyString()][string]$CommandText,
+        [ValidateRange(8, 256)][int]$FragmentLength = 64
+    )
+
+    if ([string]::IsNullOrWhiteSpace($PaneText) -or [string]::IsNullOrWhiteSpace($CommandText)) {
+        return $false
+    }
+
+    $normalizedPaneText = ConvertTo-DispatchEchoFingerprint -Text $PaneText -StripWrapDecorations
+    $normalizedCommandText = ConvertTo-DispatchEchoFingerprint -Text $CommandText
+    if ([string]::IsNullOrWhiteSpace($normalizedPaneText) -or [string]::IsNullOrWhiteSpace($normalizedCommandText)) {
+        return $false
+    }
+
+    if ($normalizedPaneText.Contains($normalizedCommandText)) {
+        return $true
+    }
+
+    $effectiveLength = [Math]::Min($FragmentLength, $normalizedCommandText.Length)
+    $prefix = $normalizedCommandText.Substring(0, $effectiveLength)
+    $suffix = $normalizedCommandText.Substring($normalizedCommandText.Length - $effectiveLength)
+    return $normalizedPaneText.Contains($prefix) -or $normalizedPaneText.Contains($suffix)
+}
+
+function Test-ShellPromptText {
+    param([AllowNull()][AllowEmptyString()][string]$Text)
+
+    if ([string]::IsNullOrWhiteSpace($Text)) {
+        return $false
+    }
+
+    $lines = [System.Collections.Generic.List[string]]::new()
+    foreach ($rawLine in @($Text -split "\r?\n")) {
+        $trimmed = ([string]$rawLine).Trim()
+        if (-not [string]::IsNullOrWhiteSpace($trimmed)) {
+            $lines.Add($trimmed) | Out-Null
+        }
+    }
+
+    if ($lines.Count -eq 0) {
+        return $false
+    }
+
+    if ($lines[$lines.Count - 1] -match '^PS\s+') {
+        return $true
+    }
+
+    $tailStart = [Math]::Max(0, $lines.Count - 6)
+    $collapsed = ''
+    for ($index = $tailStart; $index -lt $lines.Count; $index++) {
+        $collapsed += $lines[$index]
+    }
+    $collapsed = $collapsed -replace '\s+', ''
+    if ([string]::IsNullOrWhiteSpace($collapsed)) {
+        return $false
+    }
+
+    return [bool]($collapsed -match '(?i)PS.{2,}>$')
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

TASK-833: make the operator dispatch send/detect path fail closed instead of silently dropping startup commands and task text.

Three root causes, one change-set (same mechanism as #1104 #1108 #1118 #1122 #1127 #1135):

1. Read-before-interact inject was a silent no-op. `Send-TextToPane` now captures first, sets the read mark before any `send-keys`, and skips the target when capture returns `$null`. Orchestra/monitor waits no longer treat a copyright banner or any non-empty line as a ready prompt.
2. Long send echo matching broke on narrow-pane wrap. Shared `Test-PaneContainsCommandFragment` strips wrap decorations and matches prefix or suffix, covering both startup commands and task text.
3. Shell prompt wrap broke prompt detection. Shared `Test-ShellPromptText` (and Rust `shell_prompt_ready`) reconstruct a wrapped `PS ...>` tail instead of requiring the last line to start with `PS `.

#1127 is the same pane input path: Settings toggle for direct user input into worker panes, default OFF, with a visible badge. Operator dispatch (`pty.write` / `winsmux send`) is unchanged.

## Correction on this PR (not a new 833 PR)

Commit `17853fd` addresses the two red Pester jobs on `f48b433` and the confirmed install-helper P1. **Not merged.** No VERSION bump. No tag / Release / npm.

### Forest P1 (confirmed at file:line)

`scripts/winsmux-core.ps1` calls `Test-PaneContainsCommandFragment` / `Test-ShellPromptText` at 3482 / 3903 / 5677 after sourcing `pane-dispatch-detect.ps1` at 153-155. The helper was only downloaded in `Install-OrchestraSupportScripts` (`install.ps1:283` on `f48b433`) and listed in the `orchestration_scripts` removal set (`install.ps1:345` on `f48b433`). `core` / `security` omit `orchestration_scripts` (`install.ps1:208-210`), so `Remove-ProfileExcludedSupportScripts` deleted the helper those profiles still call.

Fix: install the helper from `Install-CoreSupportScripts` and keep it out of the orchestra removal list. Default profile remains `full` (helper present). `core` / `security` are supported.

P2 loose prompt regex was **not** the CI send-fragment miss (empty mock capture made `typedText -eq $preSendText` at `orchestra-start.ps1:1091`). Left unchanged.

## Surface Classification

- [x] Public product surface
- [x] Runtime contract surface
- [x] Contributor/test surface
- [ ] Generated/runtime artifact not tracked
- [ ] Not sure; reviewer help requested

Reference: [Repository surface policy](../docs/repo-surface-policy.md)

## Responsibility And Cutover

- Replaced behavior, workflow, config path, or responsibility: pane send echo matching, shell-prompt wait, read-mark inject, worker-pane stdin forwarding, and core-profile install of the shared detect helper.
- Expected outcome: dispatch types only after a real PS prompt and a successful read; wrapped echo still counts as delivered; worker panes are read-only unless the toggle is on; core/security installs keep `pane-dispatch-detect.ps1`.
- Source of truth: `winsmux-core/scripts/pane-dispatch-detect.ps1` for send/detect helpers; `core/src/shell_lifecycle.rs` `shell_prompt_ready` for the Rust wait; `winsmux-app/src/workerPaneInput.ts` for the direct-input gate.
- Old paths preserved, redirected, deprecated, or removed: old suffix-only `Test-PaneContainsCommandFragment` in `scripts/winsmux-core.ps1` is replaced by the shared helper. Installer ships the helper from core support, not only orchestra.

## Verification

Linux cloud agent (pwsh 7.5.2, Pester 5.7.1). **Not Windows Pester GREEN. Not merged.**

| Command | Exit |
|---|---|
| `python3` physical_lines replica (`operator_cli.rs` 11656 / 11657, others under baseline) | 0 |
| `pwsh -NoProfile -File scripts/test-v03626-desktop-split-gate.ps1 -Json` (`all_pass=true`, `failed_count=0`, `check_count=40`) | 0 |
| `Invoke-Pester tests/V03626DesktopSplitGate.Tests.ps1` (5 passed) | 0 |
| `Invoke-Pester tests/bridge/AgentOrchestra.Tests.ps1` FullName `*delivers launch commands in-process without public bridge argv*` and `*fails closed when launch echo fragment is not observed*` (2 passed) | 0 |
| `Invoke-Pester tests/PublicSurfacePolicy.Tests.ps1` FullName `*keeps installer next steps aligned with public first-run commands*` (1 passed; helper in core support, not in orchestra removal) | 0 |
| `Invoke-Pester tests/AgentReadiness.Tests.ps1` FullName `*dispatch pane echo and shell prompt detection*` (8 passed) | 0 |
| `pwsh -NoProfile -File scripts/assert-install-downloads-exist.ps1` (`pane-dispatch-detect.ps1` in downloads and runtime deps) | 0 |
| `cargo test --manifest-path core/Cargo.toml shell_prompt_ready` | 101 (skipped: cargo 1.83 `edition2024` / `ratatui-termwiz`) |

Skipped / still required on Windows:

- Full `Invoke-Pester -Path tests` / canonical `scripts/run-tests.ps1`
- Full CI shards `Pester Tests (bridge-agent-orchestra)` and `Pester Tests (desktop-split-v03626)` on this head
- `cargo test --manifest-path core/Cargo.toml shell_prompt_ready` on a toolchain that can resolve the lockfile
- `npm --prefix winsmux-app run test:desktop-pane-e2e`
- `npm --prefix winsmux-app run test:clickable-coverage`
- Live ConPTY wrap on a narrow worker pane (startup command + long task text)

## Security And Privacy

- [x] No secrets, credentials, private local paths, browser profile paths, account IDs, customer data, or raw private logs are included.
- [x] Security issues are reported through `SECURITY.md`, not this public pull request.
- [x] Rollback is clear for any configuration, automation, release, or routing change.

Rollback: revert this PR. No VERSION bump, no merge, no tag.

Related: #1104 #1108 #1118 #1122 #1127 #1135. This PR does not close the broader product issues; it fixes the shared send/detect mechanism. #1127 is implemented in this change-set.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-db073e2c-0a1f-4802-a6f3-dd30096f659f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-db073e2c-0a1f-4802-a6f3-dd30096f659f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

